### PR TITLE
It turns out that Kato actually expects and imageID to be supplied for a...

### DIFF
--- a/app/scripts/controllers/modal/CloneServerGroupCtrl.js
+++ b/app/scripts/controllers/modal/CloneServerGroupCtrl.js
@@ -88,7 +88,6 @@ angular.module('deckApp')
     var populateRegionalImages = function() {
       $scope.images = _(packageImages)
         .filter({'region': $scope.command.region})
-        .pluck('imageName')
         .valueOf();
     };
     populateRegionalImages();
@@ -149,6 +148,7 @@ angular.module('deckApp')
       var availabilityZones = _.intersection(command.availabilityZones, $scope.regionalAvailabilityZones);
       var loadBalancers = _.intersection(command.loadBalancers, $scope.regionalLoadBalancers);
       var securityGroupNames = _.intersection(command.securityGroups, _.pluck($scope.regionalSecurityGroups, 'name'));
+      command.amiName = _($scope.images).find({'imageName': command.amiName}).imageId;
       command.availabilityZones = {};
       command.availabilityZones[command.region] = availabilityZones;
       command.loadBalancers = loadBalancers;

--- a/app/views/application/modal/clone/imageSelection.html
+++ b/app/views/application/modal/clone/imageSelection.html
@@ -51,7 +51,7 @@
         <div class="col-md-4 text-right"><b>Image</b></div>
         <div class="col-md-6">
           <select ui-select2 class="form-control input-sm" ng-model="command.amiName" data-placeholder="Pick an instance type">
-            <option ng-repeat="image in images" value="{{image}}">{{image}}</option>
+            <option ng-repeat="image in images" value="{{image.imageName}}">{{image.imageName}}</option>
           </select>
         </div>
       </div>


### PR DESCRIPTION
...miName.
