### PR TITLE
refactor test config, add autoscroll directive

### DIFF
--- a/app/scripts/directives/autoScroll.js
+++ b/app/scripts/directives/autoScroll.js
@@ -1,0 +1,20 @@
+'use strict';
+
+require('../app');
+var angular = require('angular');
+
+angular.module('deckApp')
+  .directive('autoScroll', function ($, $timeout) {
+    return {
+      restrict: 'A',
+      link: function(scope, elem, attrs) {
+        var $elem = $(elem);
+        scope.$watch(attrs.autoScroll, function() {
+          $timeout(function() {
+            $elem.parent().scrollTop($elem.height());
+          });
+        }, true);
+      }
+    };
+  }
+);

--- a/app/scripts/services/cacheInitializer.js
+++ b/app/scripts/services/cacheInitializer.js
@@ -1,11 +1,13 @@
 'use strict';
 
 angular.module('deckApp')
-  .factory('cacheInitializer', function(accountService, instanceTypeService) {
+  .factory('cacheInitializer', function(accountService, instanceTypeService, settings) {
     return {
       initialize: function() {
-        accountService.getRegionsKeyedByAccount();
-        instanceTypeService.getAllTypesByRegion();
+        if (!settings.cacheInitializerDisabled) {
+          accountService.getRegionsKeyedByAccount();
+          instanceTypeService.getAllTypesByRegion();
+        }
       }
     };
   });

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -18,7 +18,7 @@ module.exports = function(config) {
     files: [
       '.tmp/scripts/application.js',
       '.tmp/scripts/templates.js',
-      'dist/scripts/settings/settings.js',
+      'test/settings.js',
       'node_modules/angular-mocks/angular-mocks.js',
       'node_modules/rx/dist/rx.all.js',
       'test/poly/**/*.js',

--- a/test/settings.js
+++ b/test/settings.js
@@ -1,0 +1,19 @@
+'use strict';
+
+angular.module('deckApp')
+  .constant('settings', {
+    front50Url: 'http://front50-staging.prod.netflix.net',
+    oortUrl: 'http://oort-prestaging.prod.netflix.net',
+    mortUrl: 'http://mort-prestaging.prod.netflix.net',
+    pondUrl: 'http://pond-prestaging.prod.netflix.net',
+    katoUrl: 'http://kato-prestaging.prod.netflix.net',
+    awsMetadataUrl: 'http://spinnaker.test.netflix.net/aws',
+    credentialsUrl: 'http://kato-prestaging.prod.netflix.net/',
+    accounts: {
+      prod: {
+        challengeDestructiveActions: true
+      }
+    },
+    cacheInitializerDisabled: true,
+    pollSchedule: 30000
+  });

--- a/test/spec/directive/autoScroll.js
+++ b/test/spec/directive/autoScroll.js
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+describe('Directives: auto-scroll', function () {
+
+  beforeEach(module('deckApp'));
+
+  function buildContainer(height) {
+    return '<div style="overflow:auto; height: ' + height + 'px"></div>';
+  }
+  function buildAutoScroller(watchers) {
+    return '<div auto-scroll="' + watchers + '"></div>';
+  }
+  function buildChild(height) {
+    return '<div style="height: ' + height + 'px"></div>';
+  }
+
+  function buildWatchableContainer(watch, context) {
+    var $ = context.$,
+        compile = context.compile,
+        scope = context.scope;
+
+    var container = $(buildContainer(15)),
+      autoScroller = $(buildAutoScroller(watch)),
+      child = $(buildChild(50));
+
+    autoScroller.append(child);
+    container.append(autoScroller);
+    container.appendTo('body');
+
+    compile(container)(scope);
+    scope.$digest();
+
+    return container;
+  }
+
+  beforeEach(inject(function ($rootScope, $compile, $, $timeout) {
+    this.scope = $rootScope.$new();
+    this.compile = $compile;
+    this.timeout = $timeout;
+    this.$ = $;
+  }));
+
+  it ('should scroll when a watched property is changed', function() {
+    var scope = this.scope;
+    scope.watched = 1;
+    var container = buildWatchableContainer('watched', this);
+    expect(container.scrollTop()).toBe(0);
+
+    scope.watched = 2;
+    scope.$digest();
+    this.timeout.flush();
+
+    expect(container.scrollTop()).toBe(35);
+  });
+
+  it ('should scroll on deep changes', function() {
+    var scope = this.scope;
+
+    scope.watched = {
+      field: 1
+    };
+    var container = buildWatchableContainer('watched.field', this);
+
+    scope.watched.field = 2;
+    scope.$digest();
+    this.timeout.flush();
+
+    expect(container.scrollTop()).toBe(35);
+  });
+
+  it ('should scroll on multiple changes', function() {
+    var scope = this.scope;
+
+    scope.watched = {
+      field: 1
+    };
+    scope.other = 'a';
+
+    var container = buildWatchableContainer('[watched.field, other]', this);
+
+    scope.watched.field = 2;
+    scope.$digest();
+    this.timeout.flush();
+
+    expect(container.scrollTop()).toBe(35);
+
+    container.scrollTop(0);
+
+    scope.other = 'b';
+    scope.$digest();
+    this.timeout.flush();
+    expect(container.scrollTop()).toBe(35);
+  });
+
+  it ('should scroll after dom changes applied', function() {
+    var $ = this.$,
+      compile = this.compile,
+      scope = this.scope;
+
+    scope.a = 0;
+    scope.b = 0;
+
+    var container = $(buildContainer(25)),
+      autoScroller = $('<div auto-scroll="[a,b]"></div>'),
+      childA = $('<div ng-if="a === 1" style="height: 100px"></div>'),
+      childB = $('<div ng-if="b === 1" style="height: 60px"></div>');
+
+    autoScroller.append(childA).append(childB);
+    container.append(autoScroller);
+    container.appendTo('body');
+
+    compile(container)(scope);
+    scope.$digest();
+    expect(container.scrollTop()).toBe(0);
+
+    scope.a = 1;
+    scope.$digest();
+    this.timeout.flush();
+    expect(container.scrollTop()).toBe(75);
+
+    scope.b = 1;
+    scope.$digest();
+    this.timeout.flush();
+    expect(container.scrollTop()).toBe(135);
+
+    scope.a = 2;
+    scope.$digest();
+    this.timeout.flush();
+    expect(container.scrollTop()).toBe(35);
+
+    container.height(170);
+    scope.a = 1;
+    scope.$digest();
+    this.timeout.flush();
+    expect(container.scrollTop()).toBe(0);
+  });
+
+});

--- a/test/spec/services/taskTracker.js
+++ b/test/spec/services/taskTracker.js
@@ -9,7 +9,7 @@ describe('Service: taskTracker', function() {
     this.initialTasks = [
       {
         id: 1,
-        status: 'RUNNING',
+        status: 'STARTED',
         variables: [
           {
             key: 'description',
@@ -90,10 +90,4 @@ describe('Service: taskTracker', function() {
     });
   });
 
-  describe('generateNotifications(tasks)', function() {
-    it('generates one notification for each task passed in', function() {
-      this.taskTracker.generateNotifications(this.newTasks);
-      expect(this.notifications.create.callCount).toEqual(this.newTasks.length);
-    });
-  });
 });


### PR DESCRIPTION
- Provide a mechanism to watch properties and adjust the vertical scroll of a container when those properties change. This allows the container to always show the bottom-most content, so when things are added to, for example, a list of tasks, the most recent ones can stay in the view.
- Also using a separate settings.js file for karma tests.
