### PR TITLE
refactor task monitoring - always update the first task retrieved

### DIFF
--- a/app/scripts/services/kato.js
+++ b/app/scripts/services/kato.js
@@ -4,7 +4,7 @@ require('../app');
 var angular = require('angular');
 
 angular.module('deckApp')
-  .factory('kato', function(settings, Restangular, $timeout, $q) {
+  .factory('kato', function(settings, Restangular, $timeout, $q, _) {
 
     function setTaskProperties(task) {
       task.waitUntilComplete = function waitUntilComplete() {
@@ -26,6 +26,20 @@ angular.module('deckApp')
           deferred.reject(task);
         }
         return deferred.promise;
+      };
+
+      task.asPondKatoTask = function asPondKatoTask() {
+        var pondTask = {
+          history: task.history,
+          status: task.status,
+          resultObjects: task.resultObjects
+        };
+
+        var exception = _.find(task.resultObjects, {type: 'EXCEPTION'});
+        if (exception) {
+          pondTask.exception = exception;
+        }
+        return pondTask;
       };
 
       Object.defineProperties(task, {

--- a/app/views/taskMonitor.html
+++ b/app/views/taskMonitor.html
@@ -31,7 +31,7 @@
         <alert type="danger">
           <h4><span class="glyphicon glyphicon-warning-sign"></span> Error:</h4>
 
-          <p>{{taskMonitor.task.status.status}}</p>
+          <p>{{taskMonitor.errorMessage}}</p>
         </alert>
         <p ng-if="taskMonitor.task.id">
           <a


### PR DESCRIPTION
Handling this in a similar way as application refresh: copy properties onto an existing object instead of replacing it entirely.

Ideally, we wouldn't have to do most of this. We'd just poll the task from pond and it would have the kato execution history once it had the kato task id. But deck has to work with the systems we have here in the real world.
