### PR TITLE
scheduled cache tests and improvements

### DIFF
--- a/app/scripts/services/scheduledCache.js
+++ b/app/scripts/services/scheduledCache.js
@@ -11,32 +11,31 @@ angular.module('deckApp')
         that.schedules[k].dispose();
       });
     }
-    
-    that.schedules = {}; 
+
+    that.schedules = {};
 
     that.cycles =  10;
 
     that.cache = $cacheFactory('scheduledHttp');
 
-    that.info = that.cache.info;
+    that.info = function() {
+      return that.cache.info();
+    };
 
     that.put = function(k, v) {
       if (that.schedules[k]) {
         that.schedules[k].dispose();
       }
-      that.schedules[k] = scheduler.get()
-        .skip(that.cycles)
-        .subscribe(function() {
-          $http({
-            url: k,
-            method: 'GET',
-            cache: that.cache,
-          }).success(angular.noop);
-        });
+      that.schedules[k] = scheduler.subscribeEveryN(that.cycles, function() {
+        $http.get(k, { cache: that.cache })
+          .success(angular.noop);
+      });
       return that.cache.put(k,v);
     };
 
-    that.get = that.cache.get;
+    that.get = function(k) {
+      return that.cache.get(k);
+    };
 
     that.remove = function(k) {
       that.cache.remove(k);

--- a/app/scripts/services/scheduler.js
+++ b/app/scripts/services/scheduler.js
@@ -17,6 +17,11 @@ angular.module('deckApp')
       get: function() { return scheduler; },
       subscribe: scheduler.subscribe.bind(scheduler),
       scheduleImmediate: scheduler.onNext.bind(scheduler),
+      subscribeEveryN: function(n, fn) {
+        return scheduler
+          .skip(n)
+          .subscribe(fn);
+      },
       scheduleOnCompletion: function(promise) {
         var deferred = $q.defer();
         promise.then(

--- a/test/spec/services/scheduledCache.js
+++ b/test/spec/services/scheduledCache.js
@@ -1,0 +1,80 @@
+'use strict';
+
+describe('scheduledCache', function() {
+  beforeEach(function() {
+    module('deckApp');
+  });
+
+  beforeEach(inject(function(scheduledCache, $http, $cacheFactory, scheduler) {
+    this.scheduledCache = scheduledCache;
+    this.$http = $http;
+    this.$cacheFactory = $cacheFactory;
+    this.scheduler = scheduler;
+  }));
+
+  describe('#info', function() {
+    it('passes through to the underlying cache', function() {
+      spyOn(this.scheduledCache.cache, 'info');
+      this.scheduledCache.info(null);
+      expect(this.scheduledCache.cache.info).toHaveBeenCalled();
+    });
+  });
+
+  describe('#get', function() {
+    it('passes through to the underlying cache', function() {
+      spyOn(this.scheduledCache.cache, 'get');
+      this.scheduledCache.get('a value');
+      expect(this.scheduledCache.cache.get).toHaveBeenCalledWith('a value');
+    });
+  });
+
+
+  describe('#remove', function() {
+    it('passes through to the underlying cache', function() {
+      spyOn(this.scheduledCache.cache, 'remove');
+      this.scheduledCache.remove('a value');
+      expect(this.scheduledCache.cache.remove).toHaveBeenCalledWith('a value');
+    });
+  });
+
+  describe('#put', function() {
+    it('removes any active schedule for k by calling dispose', function() {
+      var disposable = {
+        dispose: angular.noop,
+      };
+      spyOn(disposable, 'dispose');
+      this.scheduledCache.schedules['a key'] = disposable;
+      this.scheduledCache.put('a key', 'a value');
+      expect(disposable.dispose).toHaveBeenCalled();
+    });
+
+    it('subscribes to the scheduler via subscribeEveryN', function() {
+      spyOn(this.scheduler, 'subscribeEveryN');
+      this.scheduledCache.put('a key', 'a value');
+      expect(this.scheduler.subscribeEveryN)
+        .toHaveBeenCalledWith(this.scheduledCache.cycles, jasmine.any(Function));
+    });
+
+    describe('the update', function() {
+      beforeEach(function() {
+        spyOn(this.scheduler, 'subscribeEveryN').andCallFake(function(cycles, fn) {
+          fn();
+        });
+      });
+
+      it('makes a get request to the cache key (a url)', function() {
+        spyOn(this.$http, 'get').andCallThrough();
+        this.scheduledCache.put('a key', 'a value');
+        expect(this.$http.get).toHaveBeenCalledWith('a key', jasmine.any(Object));
+      });
+
+      it('supplies the underlying cache for use in the $http request', function() {
+        spyOn(this.$http, 'get').andCallFake(function(url, config) {
+          expect(config.cache).toEqual(this.scheduledCache.cache);
+          return { success: angular.noop };
+        }.bind(this));
+        this.scheduledCache.put('a key', 'a value');
+      });
+    });
+  });
+});


### PR DESCRIPTION
### changes
- adds some tests for the `scheduledCache` service.
- makes a few changes to the `scheduler` service and `scheduledCache` service, mostly to reduce coupling and make testing a bit easier.
