### PR TITLE
modal enhancements; fixes #136

### DIFF
--- a/app/scripts/controllers/ServerGroupDetailsCtrl.js
+++ b/app/scripts/controllers/ServerGroupDetailsCtrl.js
@@ -49,8 +49,9 @@ angular.module('deckApp')
       var taskMonitor = {
         application: application,
         title: 'Destroying ' + serverGroup.name,
-//        forceRefreshMessage: 'Refreshing application...',
-        forceRefreshEnabled: false
+        forceRefreshMessage: 'Refreshing application...',
+        forceRefreshEnabled: true,
+        katoPhaseToMonitor: 'DESTROY_ASG'
       };
 
       var submitMethod = function () {
@@ -89,18 +90,12 @@ angular.module('deckApp')
       var taskMonitor = {
         application: application,
         title: 'Disabling ' + serverGroup.name,
-//        forceRefreshMessage: 'Refreshing application...',
-        forceRefreshEnabled: false
+        forceRefreshMessage: 'Refreshing application...',
+        forceRefreshEnabled: true
       };
 
       var submitMethod = function () {
         return orcaService.disableServerGroup(serverGroup, application.name);
-      };
-
-      var stateParams = {
-        name: serverGroup.name,
-        accountId: serverGroup.account,
-        region: serverGroup.region
       };
 
       confirmationModalService.confirm({
@@ -109,17 +104,7 @@ angular.module('deckApp')
         destructive: true,
         account: serverGroup.account,
         taskMonitorConfig: taskMonitor,
-        submitMethod: submitMethod,
-        onTaskComplete: function() {
-          if ($state.includes('**.serverGroup', stateParams)) {
-            $state.go('^');
-          }
-        },
-        onApplicationRefresh: function() {
-          if ($state.includes('**.serverGroup', stateParams)) {
-            $state.go('^');
-          }
-        }
+        submitMethod: submitMethod
       });
 
     };

--- a/app/scripts/controllers/modal/awsCloneServerGroupCtrl.js
+++ b/app/scripts/controllers/modal/awsCloneServerGroupCtrl.js
@@ -345,19 +345,17 @@ angular.module('deckApp.aws')
             accountId: $scope.command.credentials,
             region: $scope.command.region
           };
-          if (!$state.includes('**.clusters.**')) {
-            $state.go('^.^.^.clusters.serverGroup', newStateParams);
-          } else {
-            if ($state.includes('**.serverGroup')) {
-              $state.go('^.^.serverGroup', newStateParams);
-            } else {
-              if ($state.includes('**.clusters.*')) {
-                $state.go('^.serverGroup', newStateParams);
-              } else {
-                $state.go('.serverGroup', newStateParams);
-              }
-            }
+          var transitionTo = '^.^.^.clusters.serverGroup';
+          if ($state.includes('**.clusters.serverGroup')) {  // clone via details, all view
+            transitionTo = '^.serverGroup';
           }
+          if ($state.includes('**.clusters.cluster.serverGroup')) { // clone or create with details open
+            transitionTo = '^.^.serverGroup';
+          }
+          if ($state.includes('**.clusters')) { // create new, no details open
+            transitionTo = '.serverGroup';
+          }
+          $state.go(transitionTo, newStateParams);
         }
       });
     };

--- a/app/scripts/directives/dynamicOverlay.js
+++ b/app/scripts/directives/dynamicOverlay.js
@@ -11,8 +11,8 @@ angular.module('deckApp')
               $modal = $elem.closest('.modal-content'),
               modalHeight = $modal.height();
 
-          if (modalHeight < 350) {
-            modalHeight = 350;
+          if (modalHeight < 450) {
+            modalHeight = 450;
           }
 
           $modal.height(modalHeight);

--- a/app/scripts/services/taskMonitorService.js
+++ b/app/scripts/services/taskMonitorService.js
@@ -21,7 +21,8 @@ angular.module('deckApp')
         application: params.application,
         onApplicationRefresh: params.onApplicationRefresh || params.modalInstance.dismiss,
         onTaskComplete: params.onTaskComplete || params.modalInstance.dismiss,
-        modalInstance: params.modalInstance
+        modalInstance: params.modalInstance,
+        katoPhaseToMonitor: params.katoPhaseToMonitor || null
       };
 
       monitor.closeModal = function () {
@@ -56,7 +57,7 @@ angular.module('deckApp')
 
       monitor.handleTaskSuccess = function(task) {
         monitor.task = task;
-        task.getCompletedKatoTask().then(
+        task.getCompletedKatoTask(monitor.katoPhaseToMonitor).then(
           function() {
             handleKatoRefreshSuccess(task);
           },

--- a/app/styles/details.less
+++ b/app/styles/details.less
@@ -73,7 +73,7 @@
   }
 
   .content {
-    overflow-y: scroll;
+    overflow-y: auto;
     padding-bottom: 120px;
     height: 100%;
 

--- a/app/views/taskMonitor.html
+++ b/app/views/taskMonitor.html
@@ -26,6 +26,9 @@
         <ul class="task task-progress task-progress-running" ng-if="!taskMonitor.forceRefreshComplete && !taskMonitor.forceRefreshing && !taskMonitor.error">
           <li><span class="glyphicon glyphicon-spinning glyphicon-asterisk"></span></li>
         </ul>
+        <p>
+            You can monitor this task from the Tasks view. You'll also receive updates on its progress through the Notifications.
+        </p>
       </div>
       <div class="col-md-12 overlay-modal-error" ng-if="taskMonitor.error">
         <alert type="danger">
@@ -42,7 +45,10 @@
       </div>
     </div>
   </div>
-  <div class="modal-footer">
+  <div class="modal-footer" ng-if="!taskMonitor.error">
+    <button class="btn btn-primary" ng-click="taskMonitor.closeModal()">Close</button>
+  </div>
+  <div class="modal-footer" ng-if="taskMonitor.error">
     <button class="btn btn-primary" ng-if="taskMonitor.error" ng-click="taskMonitor.error = null">Go back and try to fix
       this
     </button>

--- a/test/fixture/tasks.js
+++ b/test/fixture/tasks.js
@@ -144,7 +144,8 @@ TasksFixture.failedKatoTask = {
 TasksFixture.successfulKatoTask = {
   id: 3,
   status: {
-    completed: true
+    completed: true,
+    failed: false
   },
   history: [{
     phase: "ORCHESTRATION",


### PR DESCRIPTION
- adds an escape hatch while task is executing (close button, explanatory text)
- provides more vertical space for task status
- allows user to specify key in kato task history to watch for so we can handle orchestration tasks with multiple kato steps
- does not navigate away from a server group details after disabling it
