### PR TITLE
Incremental improvement to test:ci task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -50,11 +50,17 @@ gulp.task('test:karma', function(done) {
 });
 
 gulp.task('test:ci', function(done) {
-  karma.server.start({
-    configFile: __dirname+'/karma.conf.js',
-    browsers: ['Chrome'],
-    singleRun: false,
-  }, done);
+  run(
+    'clean',
+    'build:prepare',
+    function() {
+      karma.server.start({
+        configFile: __dirname+'/karma.conf.js',
+        browsers: ['Chrome'],
+        singleRun: false,
+      }, done)
+    }
+  );
 });
 
 gulp.task('test', ['test:karma']);


### PR DESCRIPTION
Running the task (`gulp test:ci`) should also handle clean and build steps.

Really, it should include watches, too, so if we change application code, we rebuild. That can happen later, though.
