### PR TITLE
task modal improvements; fixes #190

### DIFF
--- a/app/scripts/services/kato.js
+++ b/app/scripts/services/kato.js
@@ -37,7 +37,8 @@ angular.module('deckApp')
         var pondTask = {
           history: task.history,
           status: task.status,
-          resultObjects: task.resultObjects
+          resultObjects: task.resultObjects,
+          id: task.id
         };
 
         var exception = _.find(task.resultObjects, {type: 'EXCEPTION'});

--- a/app/scripts/services/pond.js
+++ b/app/scripts/services/pond.js
@@ -55,7 +55,7 @@ angular.module('deckApp')
       task.pendingPolls = [];
 
       task.updateKatoTask = function(katoTask) {
-        var katoTasks = getKatoTasks(task);
+        var katoTasks = task.getValueFor('kato.tasks');
         if (katoTasks && katoTasks.length && katoTasks[katoTasks.length - 1].id === katoTask.id) {
           var lastTask = katoTasks[katoTasks.length - 1];
           angular.copy(katoTask.asPondKatoTask(), lastTask);

--- a/app/views/taskMonitor.html
+++ b/app/views/taskMonitor.html
@@ -3,10 +3,10 @@
     <h3>{{taskMonitor.title}}</h3>
   </div>
   <div class="modal-body clearfix">
-    <div class="clearfix" auto-scroll="[taskMonitor.task.history, taskMonitor.task.error, taskMonitor.task.forceRefreshing]">
+    <div class="clearfix" auto-scroll="[taskMonitor.task.getValueFor('kato.tasks'), taskMonitor.task.error, taskMonitor.task.forceRefreshing]">
       <div class="col-md-12 overlay-modal-status" ng-if="taskMonitor.task">
-        <ul class="task task-progress">
-          <li ng-repeat="step in taskMonitor.task.history">
+        <ul class="task task-progress" ng-repeat="katoTask in taskMonitor.task.getValueFor('kato.tasks')">
+          <li ng-repeat="step in katoTask.history">
             <span class="glyphicon glyphicon-{{step.status.indexOf('Orchestration failed') === 0 ? 'warning-sign' : 'ok-circle'}}"></span>
             {{step.status}}
           </li>
@@ -26,8 +26,11 @@
         <ul class="task task-progress task-progress-running" ng-if="!taskMonitor.forceRefreshComplete && !taskMonitor.forceRefreshing && !taskMonitor.error">
           <li><span class="glyphicon glyphicon-spinning glyphicon-asterisk"></span></li>
         </ul>
-        <p>
-            You can monitor this task from the Tasks view. You'll also receive updates on its progress through the Notifications.
+        <p ng-if="taskMonitor.task.id && !taskMonitor.error">
+            You can
+            <a ui-sref="home.applications.application.tasks.taskDetails({application: taskMonitor.application.name, taskId: taskMonitor.task.id})">monitor
+              this task from the Tasks view</a>.
+          You'll also receive updates on its progress through the Notifications.
         </p>
       </div>
       <div class="col-md-12 overlay-modal-error" ng-if="taskMonitor.error">

--- a/test/spec/services/pond.js
+++ b/test/spec/services/pond.js
@@ -247,6 +247,47 @@ describe('Service: Pond - task complete, task force refresh', function() {
     $http.verifyNoOutstandingRequest();
   });
 
+  it('appends kato task if not found, updates when found', function() {
+
+    var katoTask = {
+      id: 3,
+      asPondKatoTask: function() {
+        return { id: 3, updateable: 'a'};
+      }
+    };
+
+    $http.whenGET(config.pondUrl + '/tasks/1').respond(200, {
+      id: 1,
+      status: 'STARTED',
+      steps: [],
+      variables: []
+    });
+    $http.flush();
+
+    task.updateKatoTask(katoTask);
+
+    expect(task.getValueFor('kato.tasks').length).toBe(1);
+    expect(task.getValueFor('kato.tasks')[0].id).toBe(3);
+    expect(task.getValueFor('kato.tasks')[0].updateable).toBe('a');
+
+    task.getValueFor('kato.tasks')[0].updateable = 'b';
+    task.updateKatoTask(katoTask);
+    expect(task.getValueFor('kato.tasks').length).toBe(1);
+    expect(task.getValueFor('kato.tasks')[0].updateable).toBe('a');
+
+    var katoTask2 = {
+      id: 4,
+      asPondKatoTask: function() {
+        return {id: 4, history: []}
+      }
+    };
+
+    task.updateKatoTask(katoTask2);
+    expect(task.getValueFor('kato.tasks').length).toBe(2);
+    expect(task.getValueFor('kato.tasks')[1].id).toBe(4);
+
+  });
+
 
   function cycle() {
     timeout.flush();

--- a/test/spec/services/pondKato.js
+++ b/test/spec/services/pondKato.js
@@ -140,7 +140,7 @@ describe('Service: Pond - task complete, task force refresh', function() {
 
   });
 
-  it('waits until matching kato phase found before resolving', function() {
+  it('waits until matching kato phase found before resolving, appending pending task to kato.tasks', function() {
 
     var result = null,
       pondRequestHandler = $http.whenGET(config.pondUrl + '/tasks/1'),
@@ -168,7 +168,10 @@ describe('Service: Pond - task complete, task force refresh', function() {
     // When refetching pond task, a new task is the most recent
     pondRequestHandler.respond(200, {
       id: 1,
-      variables: [ { key: 'kato.last.task.id', value: { id: 4 } }],
+      variables: [
+        { key: 'kato.last.task.id', value: { id: 4 } },
+        { key: 'kato.tasks', value: [ {id: 3, history: []}]}
+      ],
       status: 'STARTED'
     });
 
@@ -187,6 +190,8 @@ describe('Service: Pond - task complete, task force refresh', function() {
     katoRequestHandler.respond(200, desiredKatoTask);
 
     cycle();
+
+    expect(task.getValueFor('kato.tasks').length).toBe(2);
     expect(result.id).toBe(4);
     expect(result.history).toEqual(desiredKatoTask.history);
 


### PR DESCRIPTION
- correctly update existing kato tasks
- show all kato tasks in status window, not just most recent one
- include link to monitor task in tasks view
