### PR TITLE
show server group creation time in pod; fixes #225

### DIFF
--- a/app/scripts/filters/timeFormatters.js
+++ b/app/scripts/filters/timeFormatters.js
@@ -7,4 +7,10 @@ angular.module('deckApp')
       var moment = momentService(isNaN(parseInt(input)) ? input : parseInt(input));
       return moment.isValid()? moment.calendar() : 'n/a';
     };
+  })
+  .filter('duration', function(momentService) {
+    return function(input) {
+      var moment = momentService(isNaN(parseInt(input)) ? input : parseInt(input));
+      return moment.isValid()? moment.fromNow() : 'n/a';
+    };
   });

--- a/app/views/application/cluster/serverGroup.html
+++ b/app/views/application/cluster/serverGroup.html
@@ -15,10 +15,13 @@
   </div>
   <div class="rollup-details">
     <div class="build-title">
+      <span ng-if="serverGroup.asg.createdTime">
+        Created: {{serverGroup.asg.createdTime | date : 'MM/dd/yy @ HH:mm'}},
+      </span>
       <a ng-if="serverGroup.buildInfo.jenkins.host"
          href="{{ serverGroup.buildInfo.jenkins.host }}job/{{ serverGroup.buildInfo.jenkins.name }}/{{ serverGroup.buildInfo.jenkins.number }}/"
          target="_blank">
-          Build #{{ serverGroup.buildInfo.jenkins.number }}
+          Build: #{{ serverGroup.buildInfo.jenkins.number }}
       </a>
       <span ng-if="!serverGroup.buildInfo.jenkins.host">
           (No build info)


### PR DESCRIPTION
Updated view, now with simple create time stamp:
![screen shot 2014-10-28 at 6 21 42 pm](https://cloud.githubusercontent.com/assets/73450/4819784/073d257e-5f0a-11e4-9ed8-daa95141b470.png)
