### PR TITLE
update scaling activities modal

### DIFF
--- a/app/scripts/controllers/ServerGroupDetailsCtrl.js
+++ b/app/scripts/controllers/ServerGroupDetailsCtrl.js
@@ -155,15 +155,15 @@ angular.module('deckApp')
 
     this.showScalingActivities = function showScalingActivities() {
       $scope.activities = [];
-      var modal = $modal.open({
+      $modal.open({
         templateUrl: 'views/application/modal/serverGroup/scalingActivities.html',
         controller: 'ScalingActivitiesCtrl as ctrl',
-        scope: $scope
-      });
-      modal.opened.then(function() {
-        serverGroupService.getScalingActivities(application.name, $scope.account, $scope.cluster.name, $scope.serverGroup.name, $scope.serverGroup.region).then(function(response) {
-          $scope.activities = response;
-        });
+        resolve: {
+          applicationName: function() { return application.name; },
+          account: function() { return $scope.account; },
+          clusterName: function() { return $scope.cluster.name; },
+          serverGroup: function() { return $scope.serverGroup; }
+        }
       });
     };
 
@@ -171,7 +171,7 @@ angular.module('deckApp')
       $scope.userData = window.atob($scope.launchConfig.userData);
       $modal.open({
         templateUrl: 'views/application/modal/serverGroup/userData.html',
-        controller: 'UserDataCtrl',
+        controller: 'CloseableModalCtrl',
         scope: $scope
       });
     };
@@ -184,11 +184,4 @@ angular.module('deckApp')
       return null;
     };
   }
-).controller('ScalingActivitiesCtrl', function($scope, $modalInstance) {
-  $scope.isSuccessful = function(activity) {
-    return activity.statusCode === 'Successful';
-  };
-  $scope.close = $modalInstance.dismiss;
-}).controller('UserDataCtrl', function($scope, $modalInstance) {
-    $scope.close = $modalInstance.dismiss;
-});
+);

--- a/app/scripts/controllers/modal/CloseableModalCtrl.js
+++ b/app/scripts/controllers/modal/CloseableModalCtrl.js
@@ -1,0 +1,7 @@
+'use strict';
+
+angular.module('deckApp')
+  .controller('CloseableModalCtrl', function($scope, $modalInstance) {
+    $scope.close = $modalInstance.dismiss;
+  }
+);

--- a/app/scripts/controllers/modal/ScalingActivitiesCtrl.js
+++ b/app/scripts/controllers/modal/ScalingActivitiesCtrl.js
@@ -1,0 +1,42 @@
+'use strict';
+
+angular.module('deckApp')
+  .controller('ScalingActivitiesCtrl', function($scope, $modalInstance, applicationName, account, clusterName, serverGroup, serverGroupService) {
+    var ctrl = this;
+    serverGroupService.getScalingActivities(applicationName, account, clusterName, serverGroup.name, serverGroup.region).then(function(response) {
+      $scope.activities = ctrl.groupScalingActivities(response);
+    });
+
+    this.groupScalingActivities = function(activities) {
+      var grouped = _.groupBy(activities, 'cause'),
+        results = [];
+      _.forOwn(grouped, function(group) {
+        if (group.length) {
+          var events = [];
+          group.forEach(function(entry) {
+            var availabilityZone = 'unknown';
+            try {
+              availabilityZone = JSON.parse(entry.details)['Availability Zone'] || availabilityZone;
+            } catch (e) {
+              // I don't imagine this would happen but let's not blow up the world if it does.
+            }
+            events.push({description: entry.description, availabilityZone: availabilityZone});
+          });
+          results.push({
+            cause: group[0].cause,
+            events: events,
+            startTime: group[0].startTime,
+            statusCode: group[0].statusCode
+          });
+        }
+      });
+      return _.sortBy(results, 'startTime').reverse();
+    };
+
+    $scope.serverGroup = serverGroup;
+
+    this.isSuccessful = function(activity) {
+      return activity.statusCode === 'Successful';
+    };
+    $scope.close = $modalInstance.dismiss;
+  });

--- a/app/views/application/modal/serverGroup/scalingActivities.html
+++ b/app/views/application/modal/serverGroup/scalingActivities.html
@@ -8,11 +8,19 @@
     </div>
     <div ng-repeat="activity in activities" ng-if="activities.length">
         <p class="clearfix">
-          <span class="label label-{{isSuccessful(activity) ? 'success' : 'danger'}} pull-left">{{activity.statusCode}}</span>
+          <span class="label label-{{ctrl.isSuccessful(activity) ? 'success' : 'danger'}} pull-left">{{activity.statusCode}}</span>
           <span class="label label-default pull-right">{{activity.startTime | relativeTime}}</span>
         </p>
         <p>{{activity.cause}}</p>
-        <hr/>
+        <p>Summary of activities:
+          <ul>
+            <li ng-repeat="event in activity.events | orderBy: ['availabilityZone', 'description']">
+              {{event.description}}
+              <span ng-if="event.availabilityZone"> ({{event.availabilityZone}})</span>
+            </li>
+          </ul>
+        </p>
+        <hr ng-if="!$last"/>
     </div>
   </div>
   <div class="modal-footer">

--- a/test/spec/controllers/ScalingActivitiesCtrl.js
+++ b/test/spec/controllers/ScalingActivitiesCtrl.js
@@ -1,0 +1,86 @@
+'use strict';
+
+describe('Controller: ScalingActivitiesCtrl', function () {
+
+  beforeEach(loadDeckWithoutCacheInitializer);
+
+  beforeEach(function () {
+    inject(function ($controller, $rootScope, serverGroupService, $q) {
+      var spec = this;
+
+      this.$scope = $rootScope.$new();
+      this.$q = $q;
+      this.serverGroupService = serverGroupService;
+      this.activities = [];
+
+      spyOn(this.serverGroupService, 'getScalingActivities').andCallFake(function () {
+        return $q.when(spec.activities);
+      });
+
+      this.ctrl = $controller('ScalingActivitiesCtrl', {
+        $scope: this.$scope,
+        serverGroupService: serverGroupService,
+        applicationName: 'app',
+        account: 'test',
+        clusterName: 'cluster',
+        serverGroup: {
+          name: 'asg-v001',
+          region: 'us-east-1'
+        },
+        $modalInstance: jasmine.createSpyObj('$modalInstance', ['dismiss'])
+      });
+    });
+  });
+
+  describe('Activity grouping', function () {
+
+    it('groups activities by cause, parsing availability zone from details, sorted by start date, newest first', function () {
+      var spec = this;
+      var activities = [
+        {
+          description: "Launching a new EC2 instance: i-05c487e8",
+          details: '{"Availability Zone":"us-east-1d"}'
+        },
+        {
+          description: "Launching a new EC2 instance: i-abcdefgh",
+          details: '{"Availability Zone":"us-east-1e"}'
+        }
+      ];
+
+      activities.forEach(function(activity) {
+        spec.activities.push({ description: activity.description, cause: 'common cause', details: activity.details, startTime: 3});
+      });
+
+      spec.activities.push({ description: 'some other thing', cause: 'some other cause', startTime: 2});
+
+      this.$scope.$digest();
+
+      var result = this.$scope.activities;
+      expect(result.length).toEqual(2);
+      expect(result[0].cause).toBe('common cause');
+      expect(result[1].cause).toBe('some other cause');
+      expect(result[0].events[0].description).toEqual(activities[0].description);
+      expect(result[0].events[1].description).toEqual(activities[1].description);
+      expect(result[0].events[0].availabilityZone).toBe('us-east-1d');
+      expect(result[0].events[1].availabilityZone).toBe('us-east-1e');
+    });
+
+    it('returns "unknown" for availability zone if details field not present, cannot be parsed, or does not contain key "Availability Zone"', function() {
+      this.activities.push({ description: 'a', cause: 'some cause', details: 'not JSON so cannot be parsed'});
+      this.activities.push({ description: 'b', cause: 'some cause'});
+      this.activities.push({ description: 'c', cause: 'some cause', details: '{"Not Availability Zone":"us-east-1c"}'});
+      this.activities.push({ description: 'd', cause: 'some cause', details: '{"Availability Zone":"us-east-1c"}'});
+
+      this.$scope.$digest();
+
+      var result = this.$scope.activities;
+      expect(result.length).toEqual(1);
+      expect(result[0].cause).toBe('some cause');
+      expect(result[0].events[0].availabilityZone).toBe('unknown');
+      expect(result[0].events[1].availabilityZone).toBe('unknown');
+      expect(result[0].events[2].availabilityZone).toBe('unknown');
+      expect(result[0].events[3].availabilityZone).toBe('us-east-1c');
+    });
+
+  });
+});


### PR DESCRIPTION
Right now, the activities appear to be duplicated because the cause is the same when multiple instances are created or terminated in a single activity. These updates group scaling activities by cause, then summarize them, providing description of the actual event, as well as availability zone if present in the activity details.

Current on the left, revision on the right:
![scaling_update](https://cloud.githubusercontent.com/assets/73450/4845652/291f5e0e-6046-11e4-85c1-316537287506.png)
