### PR TITLE
reflect view state in page title; closes spinnaker/spinnaker#160

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -2,7 +2,7 @@
 <html class="no-js" ng-app="deckApp">
 <head>
   <meta charset="utf-8">
-  <title>Spinnaker: Deck</title>
+  <title ng-bind="pageTitle">Spinnaker</title>
   <meta name="description" content="">
   <meta name="viewport" content="width=device-width">
   <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -22,7 +22,7 @@ angular.module('deckApp', [
     'deckApp.aws',
     'deckApp.gce'
   ])
-  .run(function($state, $rootScope, $log, $exceptionHandler, cacheInitializer, $modalStack) {
+  .run(function($state, $rootScope, $log, $exceptionHandler, cacheInitializer, $modalStack, pageTitleService) {
     // This can go away when the next version of ui-router is available (0.2.11+)
     // for now, it's needed because ui-sref-active does not work on parent states
     // and we have to use ng-class. It's gross.
@@ -50,7 +50,7 @@ angular.module('deckApp', [
         fromState: fromState,
         fromParams: fromParams
       });
-      $rootScope.routing = true;
+      pageTitleService.handleRoutingStart();
     });
 
     $rootScope.$on('$stateChangeError', function(event, toState, toParams, fromState, fromParams, error) {
@@ -63,7 +63,7 @@ angular.module('deckApp', [
         error: error
       });
       $state.go('home.404');
-      $rootScope.routing = false;
+      pageTitleService.handleRoutingError();
     });
 
     $rootScope.$on('$stateChangeSuccess', function(event, toState, toParams, fromState, fromParams) {
@@ -74,6 +74,6 @@ angular.module('deckApp', [
         fromState: fromState,
         fromParams: fromParams
       });
-      $rootScope.routing = false;
+      pageTitleService.handleRoutingSuccess(toState.data);
     });
   });

--- a/app/scripts/providers/states.js
+++ b/app/scripts/providers/states.js
@@ -24,6 +24,12 @@ angular.module('deckApp')
               instanceId: $stateParams.instanceId
             };
           }]
+        },
+        data: {
+          pageTitleDetails: {
+            title: 'Instance Details',
+            nameParam: 'instanceId'
+          }
         }
       };
 
@@ -44,6 +50,14 @@ angular.module('deckApp')
               region: $stateParams.region
             };
           }]
+        },
+        data: {
+          pageTitleDetails: {
+            title: 'Server Group Details',
+            nameParam: 'serverGroup',
+            accountParam: 'accountId',
+            regionParam: 'region'
+          }
         }
       };
 
@@ -64,6 +78,14 @@ angular.module('deckApp')
               region: $stateParams.region
             };
           }]
+        },
+        data: {
+          pageTitleDetails: {
+            title: 'Load Balancer Details',
+            nameParam: 'name',
+            accountParam: 'accountId',
+            regionParam: 'region'
+          }
         }
       };
 
@@ -84,6 +106,14 @@ angular.module('deckApp')
               region: $stateParams.region
             };
           }]
+        },
+        data: {
+          pageTitleDetails: {
+            title: 'Security Group Details',
+            nameParam: 'name',
+            accountParam: 'accountId',
+            regionParam: 'region'
+          }
         }
       };
 
@@ -143,6 +173,11 @@ angular.module('deckApp')
               controller: 'AllClustersCtrl as ctrl'
             }
           },
+          data: {
+            pageTitleSection: {
+              title: 'Clusters'
+            }
+          },
           children: [
             loadBalancerDetails,
             serverGroupDetails,
@@ -162,6 +197,13 @@ angular.module('deckApp')
                   return {account: $stateParams.account, clusterName: $stateParams.cluster};
                 }]
               },
+              data: {
+                pageTitleSection: {
+                  title: 'Cluster',
+                  nameParam: 'cluster',
+                  accountParam: 'account'
+                }
+              },
               children: [loadBalancerDetails, serverGroupDetails, instanceDetails],
             }
           ],
@@ -177,6 +219,11 @@ angular.module('deckApp')
             'master': {
               templateUrl: 'views/application/loadBalancer/all.html',
               controller: 'AllLoadBalancersCtrl as ctrl'
+            }
+          },
+          data: {
+            pageTitleSection: {
+              title: 'Load Balancers'
             }
           },
           children: [
@@ -202,6 +249,14 @@ angular.module('deckApp')
                   };
                 }]
               },
+              data: {
+                pageTitleMain: {
+                  title: 'Load Balancer',
+                  nameParam: 'loadBalancer',
+                  accountParam: 'loadBalancerAccount',
+                  regionParam: 'loadBalancerRegion'
+                }
+              },
               children: [loadBalancerDetails, serverGroupDetails, instanceDetails],
             }
           ],
@@ -216,6 +271,11 @@ angular.module('deckApp')
             'master': {
               templateUrl: 'views/application/connection/all.html',
               controller: 'AllSecurityGroupsCtrl as ctrl'
+            }
+          },
+          data: {
+            pageTitleSection: {
+              title: 'Security Groups'
             }
           },
           children: [
@@ -240,6 +300,14 @@ angular.module('deckApp')
                   };
                 }]
               },
+              data: {
+                pageTitleSection: {
+                  title: 'Security Group',
+                  nameParam: 'securityGroup',
+                  accountParam: 'securityGroupAccount',
+                  regionParam: 'securityGroupRegion'
+                }
+              },
               children: [loadBalancerDetails, serverGroupDetails, securityGroupDetails]
             }
           ]
@@ -255,6 +323,11 @@ angular.module('deckApp')
             templateUrl: 'views/tasks.html',
             controller: 'TasksCtrl',
           },
+        },
+        data: {
+          pageTitleSection: {
+            title: 'Tasks'
+          }
         },
         children: [taskDetails],
       };
@@ -273,6 +346,11 @@ angular.module('deckApp')
             return oortService.getApplication($stateParams.application);
           }]
         },
+        data: {
+          pageTitleMain: {
+            field: 'application'
+          }
+        },
         children: [
           insight,
           tasks,
@@ -286,6 +364,11 @@ angular.module('deckApp')
           'main@': {
             templateUrl: 'views/applications.html',
             controller: 'ApplicationsCtrl as ctrl'
+          }
+        },
+        data: {
+          pageTitleMain: {
+            label: 'Applications'
           }
         },
         children: [
@@ -303,6 +386,11 @@ angular.module('deckApp')
             controller: 'InfrastructureCtrl as ctrl',
           }
         },
+        data: {
+          pageTitleMain: {
+            label: 'Infrastructure'
+          }
+        }
       };
 
       var home = {

--- a/app/scripts/services/pageTitleService.js
+++ b/app/scripts/services/pageTitleService.js
@@ -1,0 +1,87 @@
+'use strict';
+
+angular.module('deckApp')
+  .factory('pageTitleService', function($rootScope, $stateParams) {
+
+    function handleRoutingStart() {
+      $rootScope.routing = true;
+      $rootScope.pageTitle = 'Spinnaker: Loading...';
+    }
+
+    function handleRoutingError() {
+      $rootScope.routing = false;
+      $rootScope.pageTitle = 'Spinnaker: Error';
+    }
+
+    function handleRoutingSuccess(config) {
+      var parts = configurePageTitle(config);
+      var title = parts.main || 'Spinnaker';
+      if (parts.section) {
+        title += ' - ' + parts.section;
+      }
+      if (parts.details) {
+        title += ' - ' + parts.details;
+      }
+      $rootScope.routing = false;
+      $rootScope.pageTitle = title;
+    }
+
+
+    function resolveStateParams(config) {
+      if (!config) {
+        return null;
+      }
+      var result = config.title;
+      if (config.nameParam) {
+        result += ': ' + $stateParams[config.nameParam];
+      }
+      if (config.accountParam || config.regionParam) {
+        result += ' (';
+        if (config.accountParam && config.regionParam) {
+          result += $stateParams[config.accountParam] + ':' + $stateParams[config.regionParam];
+        } else {
+          result += $stateParams[config.accountParam] || $stateParams[config.regionParam];
+        }
+        result += ')';
+      }
+      return result;
+    }
+
+    function configureSection(sectionConfig) {
+      return resolveStateParams(sectionConfig);
+    }
+
+    function configureDetails(detailsConfig) {
+      return resolveStateParams(detailsConfig);
+    }
+
+    function configureMain(mainConfig) {
+      var main = null;
+      if (!mainConfig) {
+        return main;
+      }
+      if (mainConfig.field) {
+        main = $stateParams[mainConfig.field];
+      }
+      if (mainConfig.label) {
+        main = mainConfig.label;
+      }
+      return main;
+    }
+
+    function configurePageTitle(data) {
+      data = data || {};
+      return {
+        main: configureMain(data.pageTitleMain),
+        section: configureSection(data.pageTitleSection),
+        details: configureDetails(data.pageTitleDetails)
+      };
+    }
+
+    return {
+      handleRoutingStart: handleRoutingStart,
+      handleRoutingSuccess: handleRoutingSuccess,
+      handleRoutingError: handleRoutingError
+    };
+
+  });

--- a/test/spec/services/pageTitleService.js
+++ b/test/spec/services/pageTitleService.js
@@ -1,0 +1,178 @@
+'use strict';
+
+describe('Service: pageTitleService', function() {
+
+  beforeEach(loadDeckWithoutCacheInitializer);
+
+  beforeEach(inject(function (pageTitleService, $stateParams, $rootScope) {
+    this.pageTitleService = pageTitleService;
+    this.$stateParams = $stateParams;
+    this.$rootScope = $rootScope;
+  }));
+
+  describe('handleRoutingStart', function() {
+    it('sets page title, routing flag on root scope', function() {
+      var scope = this.$rootScope;
+
+      expect(scope.routing).toBeFalsy();
+      expect(scope.pageTitle).toBeUndefined();
+
+      this.pageTitleService.handleRoutingStart();
+      expect(scope.routing).toBe(true);
+      expect(scope.pageTitle).toBe('Spinnaker: Loading...');
+    });
+  });
+
+  describe('handleRoutingError', function() {
+    it('sets page title, clears routing flag on root scope', function() {
+      var scope = this.$rootScope;
+
+      this.pageTitleService.handleRoutingStart();
+      expect(scope.routing).toBe(true);
+      expect(scope.pageTitle).toBe('Spinnaker: Loading...');
+
+      this.pageTitleService.handleRoutingError();
+      expect(scope.routing).toBe(false);
+      expect(scope.pageTitle).toBe('Spinnaker: Error');
+
+    });
+  });
+
+  describe('handleRoutingSuccess', function() {
+
+    afterEach(function() {
+      expect(this.$rootScope.routing).toBe(false);
+    });
+
+    it('falls back to "Spinnaker" when nothing configured', function() {
+      this.pageTitleService.handleRoutingSuccess();
+      expect(this.$rootScope.pageTitle).toBe('Spinnaker');
+    });
+
+    it('sets page title when only main is configured with a label', function() {
+      this.pageTitleService.handleRoutingSuccess({pageTitleMain: {label: 'expected result'}});
+      expect(this.$rootScope.pageTitle).toBe('expected result');
+    });
+
+    it('sets page title from state params when main is configured with a field', function() {
+      this.$stateParams.someParam = 'expected result from field';
+      this.pageTitleService.handleRoutingSuccess({pageTitleMain: {field: 'someParam'}});
+      expect(this.$rootScope.pageTitle).toBe('expected result from field');
+    });
+
+    it('ignores field value when label provided in main configuration', function() {
+      this.$stateParams.someParam = 'expected result from field';
+      this.pageTitleService.handleRoutingSuccess({pageTitleMain: {field: 'someParam', label: 'Overruled!'}});
+      expect(this.$rootScope.pageTitle).toBe('Overruled!');
+    });
+
+    it('handles section config - title only', function() {
+      this.pageTitleService.handleRoutingSuccess({pageTitleSection: {title: 'The Section'}});
+      expect(this.$rootScope.pageTitle).toBe('Spinnaker - The Section');
+    });
+
+    it('appends name if provided in section config', function() {
+      this.$stateParams.sectionNameParam = 'Some thing';
+      this.pageTitleService.handleRoutingSuccess({pageTitleSection: {title: 'The Section', nameParam: 'sectionNameParam'}});
+      expect(this.$rootScope.pageTitle).toBe('Spinnaker - The Section: Some thing');
+    });
+
+    it('appends account and region in section config, separated by colon if both provided', function() {
+      this.$stateParams.sectionNameParam = 'Some thing';
+      this.$stateParams.sectionAccountParam = 'test';
+      this.$stateParams.sectionRegionParam = 'us-east-1';
+
+      this.pageTitleService.handleRoutingSuccess({pageTitleSection: {
+        title: 'The Section',
+        nameParam: 'sectionNameParam',
+        accountParam: 'sectionAccountParam'
+      }});
+      expect(this.$rootScope.pageTitle).toBe('Spinnaker - The Section: Some thing (test)');
+
+      this.pageTitleService.handleRoutingSuccess({pageTitleSection: {
+        title: 'The Section',
+        nameParam: 'sectionNameParam',
+        regionParam: 'sectionRegionParam'
+      }});
+      expect(this.$rootScope.pageTitle).toBe('Spinnaker - The Section: Some thing (us-east-1)');
+
+      this.pageTitleService.handleRoutingSuccess({pageTitleSection: {
+        title: 'The Section',
+        nameParam: 'sectionNameParam',
+        accountParam: 'sectionAccountParam',
+        regionParam: 'sectionRegionParam'
+      }});
+      expect(this.$rootScope.pageTitle).toBe('Spinnaker - The Section: Some thing (test:us-east-1)');
+    });
+
+    it('handles details config the same way it handles section config', function() {
+      this.$stateParams.sectionNameParam = 'Some thing';
+      this.$stateParams.sectionAccountParam = 'test';
+      this.$stateParams.sectionRegionParam = 'us-east-1';
+      this.$stateParams.detailsNameParam = 'Some specific thing';
+      this.$stateParams.detailsAccountParam = 'prod';
+      this.$stateParams.detailsRegionParam = 'us-east-1';
+
+      this.pageTitleService.handleRoutingSuccess({
+        pageTitleSection: {
+          title: 'The Section',
+          nameParam: 'sectionNameParam',
+          accountParam: 'sectionAccountParam'
+        },
+        pageTitleDetails: {
+          title: 'The Details',
+          nameParam: 'detailsNameParam',
+          accountParam: 'detailsAccountParam'
+        }
+      });
+      expect(this.$rootScope.pageTitle).toBe('Spinnaker - The Section: Some thing (test) - The Details: Some specific thing (prod)');
+
+      this.pageTitleService.handleRoutingSuccess({
+        pageTitleSection: {
+          title: 'The Section'
+        },
+        pageTitleDetails: {
+          title: 'The Details',
+          nameParam: 'detailsNameParam',
+          accountParam: 'detailsAccountParam',
+          regionParam: 'detailsRegionParam'
+        }
+      });
+      expect(this.$rootScope.pageTitle).toBe('Spinnaker - The Section - The Details: Some specific thing (prod:us-east-1)');
+
+      this.pageTitleService.handleRoutingSuccess({
+        pageTitleSection: {
+          title: 'The Section'
+        },
+        pageTitleDetails: {
+          title: 'The Details',
+          nameParam: 'detailsNameParam',
+          regionParam: 'detailsRegionParam'
+        }
+      });
+      expect(this.$rootScope.pageTitle).toBe('Spinnaker - The Section - The Details: Some specific thing (us-east-1)');
+
+      this.pageTitleService.handleRoutingSuccess({
+        pageTitleSection: {
+          title: 'The Section'
+        },
+        pageTitleDetails: {
+          title: 'The Details',
+          nameParam: 'detailsNameParam'
+        }
+      });
+      expect(this.$rootScope.pageTitle).toBe('Spinnaker - The Section - The Details: Some specific thing');
+
+      this.pageTitleService.handleRoutingSuccess({
+        pageTitleSection: {
+          title: 'The Section'
+        },
+        pageTitleDetails: {
+          title: 'The Details'
+        }
+      });
+      expect(this.$rootScope.pageTitle).toBe('Spinnaker - The Section - The Details');
+    })
+  });
+
+});


### PR DESCRIPTION
The tests should reflect what the page title will be, but basically it's this:

{Main} - {Section} - {Details}

Section and Details have a title, optionally followed by a colon and a name that is derived from $stateParams (i.e. the URL), then optionally account/region derived from $stateParams.

Examples:

Deck - Load Balancers
Deck - Load Balancer: deck-main-frontend (prod:us-east-1)
Deck - Load Balancer: deck-main-frontend (prod:us-east-1) - Server Group Details: deck-main-v008 (prod:us-east-1)
Deck - Load Balancers - Server Group Details: deck-main-v008 (prod:us-east-1)

It has the potential to get redundant with the account/region, but it would frankly be a huge pain to figure out the edge cases and logic to decide whether or not to show it in both places. This is simple and a lot better than the static title we have now.
