### PR TITLE
Identify 'Clone Server Group' dialog based on provider type, just like '...

### DIFF
--- a/app/scripts/controllers/ServerGroupDetailsCtrl.js
+++ b/app/scripts/controllers/ServerGroupDetailsCtrl.js
@@ -145,8 +145,8 @@ angular.module('deckApp')
 
     this.cloneServerGroup = function cloneServerGroup(serverGroup) {
       $modal.open({
-        templateUrl: 'views/application/modal/serverGroup/aws/serverGroupWizard.html',
-        controller: 'awsCloneServerGroupCtrl as ctrl',
+        templateUrl: 'views/application/modal/serverGroup/' + serverGroup.type + '/serverGroupWizard.html',
+        controller: serverGroup.type + 'CloneServerGroupCtrl as ctrl',
         resolve: {
           title: function() { return 'Clone ' + serverGroup.name; },
           application: function() { return application; },

--- a/app/scripts/controllers/modal/gceCloneServerGroupCtrl.js
+++ b/app/scripts/controllers/modal/gceCloneServerGroupCtrl.js
@@ -278,22 +278,14 @@ angular.module('deckApp.gce')
           'keyPair': serverGroup.launchConfig.keyName,
           'associatePublicIpAddress': serverGroup.launchConfig.associatePublicIpAddress,
           'ramdiskId': serverGroup.launchConfig.ramdiskId,
-          'instanceMonitoring': serverGroup.launchConfig.instanceMonitoring.enabled,
+          'instanceMonitoring': serverGroup.launchConfig.instanceMonitoring && serverGroup.launchConfig.instanceMonitoring.enabled,
           'ebsOptimized': serverGroup.launchConfig.ebsOptimized,
           'amiName': amiName
         });
       }
-      var vpcZoneIdentifier = serverGroup.asg.vpczoneIdentifier;
-      if (vpcZoneIdentifier !== '') {
-        var subnetId = vpcZoneIdentifier.split(',')[0];
-        var subnet = _($scope.subnets).find({'id': subnetId});
-        command.subnetType = subnet.purpose;
-        command.vpcId = subnet.vpcId;
-      } else {
-        command.subnetType = '';
-        command.vpcId = null;
-      }
-      if (serverGroup.launchConfig && serverGroup.launchConfig.securityGroups.length) {
+      command.subnetType = '';
+      command.vpcId = null;
+      if (serverGroup.launchConfig && serverGroup.launchConfig.securityGroups && serverGroup.launchConfig.securityGroups.length) {
         command.securityGroups = serverGroup.launchConfig.securityGroups;
       }
       return command;
@@ -377,8 +369,9 @@ angular.module('deckApp.gce')
       var command = angular.copy($scope.command);
       var description;
       if (serverGroup) {
-        description = 'Create Cloned Server Group from ' + serverGroup.asg.autoScalingGroupName;
+        description = 'Create Cloned Server Group from ' + serverGroup.name;
         command.type = 'copyLastAsg';
+        command.providerType = 'gce';
         command.source = {
           'account': serverGroup.account,
           'region': serverGroup.region,


### PR DESCRIPTION
...Create Server Group' dialog.

Tweak gce-specific dialog to avoid whatever the javascript-equivalent of NPEs is.
Dialog is now shown (for the first time; sweet), and properly progagates the request to gate.
Gate forwards the request to orca, and then orca responds (correctly) that it can't find 'copyLastAsg_gce'.
Working on that next.
Doing this one top down: deck->gate->orca->kato
