### PR TITLE
remove animation from authentication modal

### DIFF
--- a/app/scripts/modules/authentication/authenticationService.js
+++ b/app/scripts/modules/authentication/authenticationService.js
@@ -20,7 +20,11 @@ angular.module('deckApp.authentication')
 
     function authenticateUser() {
       var modal = $modal.open({
-        templateUrl: 'scripts/modules/authentication/authenticating.html'
+        templateUrl: 'scripts/modules/authentication/authenticating.html',
+        windowClass: 'modal fade in',
+        backdropClass: 'modal-backdrop-no-animate',
+        backdrop: 'static',
+        keyboard: false
       });
       $http.get(settings.gateUrl + '/auth/info')
         .success(function (data) {

--- a/app/styles/main.less
+++ b/app/styles/main.less
@@ -687,3 +687,9 @@ feedback {
   float: right;
   display: inline-block;
 }
+
+.modal-backdrop {
+  &.modal-backdrop-no-animate {
+    transition: none;
+  }
+}

--- a/app/views/applications.html
+++ b/app/views/applications.html
@@ -26,13 +26,13 @@
 <div class="row">
   <div class="col-md-12">
     <h2 ng-if="!applicationsLoaded" class="text-center" style="margin-bottom: 250px">
-      <span us-spinner="{radius:30, width:8, length: 16}"></span>
+      <span class="glyphicon glyphicon-asterisk glyphicon-spinning"></span>
     </h2>
     <table ng-if="applicationsLoaded" class="table table-striped">
       <thead ng-if="partiallyLoaded">
         <tr>
           <th sort-toggle key="name" label="Name" default="true"></th>
-          <th class="loading-header"><div us-spinner="{left: '-4px', radius:4, width:2, length: 3}"></div> Loading: Created, Updated, Owner</th>
+          <th class="loading-header"><span class="glyphicon glyphicon-asterisk glyphicon-spinning"></span> Loading: Created, Updated, Owner</th>
         </tr>
       </thead>
       <tbody ng-if="partiallyLoaded">


### PR DESCRIPTION
This makes the authentication modal more modal-y: you cannot click outside it or press escape to make it go away.

Also, it takes away the fade-in-the-background-slide-down-the-modal effect, which is a little jarring when the authentication happens quickly.

I got rid of the `us-spinner`s on this page, which bleed through modals, which is nice; replaced them with the dumb spinning asterisk.
