### PR TITLE
handle server group details with dash in name

### DIFF
--- a/app/scripts/services/serverGroupService.js
+++ b/app/scripts/services/serverGroupService.js
@@ -27,13 +27,31 @@ angular.module('deckApp')
     }
 
     function parseServerGroupName(serverGroupName) {
-      var asgNameRegex = /(\w+)(-v\d{3})?(-(\w+)?(-v\d{3})?(-(\w+))?)?(-v\d{3})?/;
-      var match = asgNameRegex.exec(serverGroupName);
-      return {
-        application: match[1],
-        stack: match[4] || '',
-        freeFormDetails: match[7] || ''
-      };
+      var versionPattern = /(v\d{3})/;
+      if (!serverGroupName) {
+        return {};
+      }
+      var split = serverGroupName.split('-'),
+          isVersioned = versionPattern.test(split[split.length - 1]),
+          result = {
+            application: split[0],
+            stack: '',
+            freeFormDetails: ''
+          };
+
+      // get rid of version, since we are not returning it
+      if (isVersioned) {
+        split.pop();
+      }
+
+      if (split.length > 1) {
+        result.stack = split[1];
+      }
+      if (split.length > 2) {
+        result.freeFormDetails = split.slice(2, split.length).join('-');
+      }
+
+      return result;
     }
 
     function getClusterName(app, cluster, detail) {

--- a/test/spec/services/serverGroupService.js
+++ b/test/spec/services/serverGroupService.js
@@ -1,6 +1,6 @@
 'use strict';
 
-describe('scheduledCache', function() {
+describe('serverGroupService', function() {
   beforeEach(function() {
     module('deckApp');
   });
@@ -9,28 +9,38 @@ describe('scheduledCache', function() {
     this.serverGroupService = serverGroupService;
   }));
 
-  it('parses server group name', function() {
-    expect(this.serverGroupService.parseServerGroupName('app-v000'))
-      .toEqual({application: 'app', stack: '', freeFormDetails: ''});
+  describe('parseServerGroupName', function() {
+    it('parses server group name with no stack or details', function() {
+      expect(this.serverGroupService.parseServerGroupName('app-v001'))
+        .toEqual({application: 'app', stack: '', freeFormDetails: ''});
+      expect(this.serverGroupService.parseServerGroupName('app-test-v001'))
+        .toEqual({application: 'app', stack: 'test', freeFormDetails: ''});
+      expect(this.serverGroupService.parseServerGroupName('app--detail-v001'))
+        .toEqual({application: 'app', stack: '', freeFormDetails: 'detail'});
+      expect(this.serverGroupService.parseServerGroupName('app--detail-withdashes-v001'))
+        .toEqual({application: 'app', stack: '', freeFormDetails: 'detail-withdashes'});
+    });
 
-    expect(this.serverGroupService.parseServerGroupName('app-test-v000'))
-      .toEqual({application: 'app', stack: 'test', freeFormDetails: ''});
-
-    expect(this.serverGroupService.parseServerGroupName('app-test-detail-v000'))
-      .toEqual({application: 'app', stack: 'test', freeFormDetails: 'detail'});
-
-    expect(this.serverGroupService.parseServerGroupName('app--detail-v000'))
-      .toEqual({application: 'app', stack: '', freeFormDetails: 'detail'});
+    it('parses server group name with no version', function() {
+      expect(this.serverGroupService.parseServerGroupName('app'))
+        .toEqual({application: 'app', stack: '', freeFormDetails: ''});
+      expect(this.serverGroupService.parseServerGroupName('app-test'))
+        .toEqual({application: 'app', stack: 'test', freeFormDetails: ''});
+      expect(this.serverGroupService.parseServerGroupName('app--detail'))
+        .toEqual({application: 'app', stack: '', freeFormDetails: 'detail'});
+      expect(this.serverGroupService.parseServerGroupName('app--detail-withdashes'))
+        .toEqual({application: 'app', stack: '', freeFormDetails: 'detail-withdashes'});
+    });
 
   });
 
   it('creates cluster name', function() {
-
-    expect(this.serverGroupService.getClusterName('app', 'cluster', 'details')).toBe('app-cluster-details');
-    expect(this.serverGroupService.getClusterName('app', null, 'details')).toBe('app--details');
     expect(this.serverGroupService.getClusterName('app', null, null)).toBe('app');
     expect(this.serverGroupService.getClusterName('app', 'cluster', null)).toBe('app-cluster');
-
+    expect(this.serverGroupService.getClusterName('app', null, 'details')).toBe('app--details');
+    expect(this.serverGroupService.getClusterName('app', null, 'details-withdash')).toBe('app--details-withdash');
+    expect(this.serverGroupService.getClusterName('app', 'cluster', 'details')).toBe('app-cluster-details');
+    expect(this.serverGroupService.getClusterName('app', 'cluster', 'details-withdash')).toBe('app-cluster-details-withdash');
 
   });
 });


### PR DESCRIPTION
Per https://jira.netflix.com/browse/SPIN-13, it seems legitimate to have dashes in the details part of a server group name.

I almost died while trying to work with the existing regex so I rewrote the whole thing like a fourth grader, splitting the name on hyphens.
