### PR TITLE
provide placeholder option for provider select modal

### DIFF
--- a/app/views/modal/providerSelection.html
+++ b/app/views/modal/providerSelection.html
@@ -8,6 +8,7 @@
         class="form-control input"
         ng-model="command.provider"
         ng-options="provider as provider for provider in providerOptions">
+        <option value="">Select...</option>
       </select>
     </div>
     <div class="modal-footer">


### PR DESCRIPTION
I neither know nor care why Angular is doing this but it's probably because we're not using Ember.

When there are multiple providers configured (in settings.js), or at least when you have `aws` and `gce` configured, and you try to select the provider via the keyboard like a grown-up, you have to type the letter 'g' twice.

Inspecting the HTML for the select reveals this, which I mean what is that first option even:

``` html
<select class="form-control input ng-valid ng-dirty" ng-model="command.provider" ng-options="provider as provider for provider in providerOptions">
  <option value="? string:gce ?"></option>
  <option value="0" selected="selected">aws</option>
  <option value="1">gce</option>
</select>
```

For whatever reason, adding a default empty option resolves this.
