### PR TITLE
Copy placeholder option fix for two remaining fields with static choices.

### DIFF
--- a/app/views/application/modal/serverGroup/gce/basicSettings.html
+++ b/app/views/application/modal/serverGroup/gce/basicSettings.html
@@ -37,10 +37,9 @@
     <!-- TODO(duftler): Dynamically populate this field with the correct set of images based on region/zone/project. -->
     <select class="form-control input-sm"
             ng-model="command.image"
-            ng-options="option as option for option in ['debian-7-wheezy-v20141017', 'centos-7-v20141016']"
             ng-change="onChange()"
             required>
-      <option value=""></option>
+      <option ng-repeat="option in ['debian-7-wheezy-v20141108', 'centos-7-v20141108']" value="{{option}}">{{option}}</option>
     </select>
   </div>
 <!--

--- a/app/views/directives/gce/zoneSelectField.html
+++ b/app/views/directives/gce/zoneSelectField.html
@@ -6,10 +6,9 @@
     <select class="form-control input-sm"
             ng-if="account"
             ng-model="component.zone"
-            ng-options="option as option for option in ['us-central1-a', 'us-central1-b']"
             ng-change="onChange()"
             required>
-      <option value=""></option>
+      <option ng-repeat="option in ['us-central1-a', 'us-central1-b']" value="{{option}}">{{option}}</option>
     </select>
   </div>
 </div>

--- a/app/views/modal/providerSelection.html
+++ b/app/views/modal/providerSelection.html
@@ -6,9 +6,8 @@
     <div class="modal-body">
       <select
         class="form-control input"
-        ng-model="command.provider"
-        ng-options="provider as provider for provider in providerOptions">
-        <option value="">Select...</option>
+        ng-model="command.provider">
+        <option ng-repeat="provider in providerOptions" value="{{provider}}">{{provider}}</option>
       </select>
     </div>
     <div class="modal-footer">


### PR DESCRIPTION
Some more details:
- The behavior only shows up when trying to select the final item in a list.
- The issue affected both selecting an item with the mouse, and with the keyboard (by typing the first letter of the item label).
- The behavior was not there when the providerSelect (and GCE Create/Clone Server Group modal) dialogs were first made to work.
- In the GCE Create/Clone Server Group dialog, the choices for the Account pulldown are populated dynamically. The choices for the Zone and Image are statically populated. The behavior shows up only for Zone and Image. This change copies Chris's fix from the provider pulldown.
- Even after removing the 'fix' line in the plunker Zan posted, I don't see the issue.
