### PR TITLE
Fixup auto-select behavior when there are no providers specified, or the...

### DIFF
--- a/app/scripts/controllers/AllClustersCtrl.js
+++ b/app/scripts/controllers/AllClustersCtrl.js
@@ -155,11 +155,15 @@ angular.module('deckApp')
     this.createServerGroup = function createServerGroup() {
       var provider = $q.when('aws');
 
-      if (settings.providers && settings.providers.length && settings.providers.length > 1) {
-        provider = $modal.open({
-          templateUrl: 'views/modal/providerSelection.html',
-          controller: 'ProviderSelectCtrl as ctrl'
-        }).result;
+      if (settings.providers && settings.providers.length) {
+        if (settings.providers.length > 1) {
+          provider = $modal.open({
+            templateUrl: 'views/modal/providerSelection.html',
+            controller: 'ProviderSelectCtrl as ctrl'
+          }).result;
+        } else {
+          provider = $q.when(settings.providers[0]);
+        }
       }
 
       provider.then(function(selectedProvider) {


### PR DESCRIPTION
...re is exactly one specified.

I tested this with:
- No providers specified (that is, the providers attribute wasn't present at all).
- Just 'aws' specified (the default config in settings.js).
- Both 'aws' and 'gce specified.
- Just 'gce' specified.

Without this fix, if just 'gce' was specified, 'aws' would still be auto-selected (with no mechanism for selecting 'gce').

I think these lines: https://github.com/spinnaker/deck/blob/master/app/scripts/controllers/modal/ProviderSelectCtrl.js#L13-L15 can now go away, but @anotherchrisberry should probably make that call.
