### PR TITLE
ignore subnets without purpose

### DIFF
--- a/app/scripts/controllers/modal/awsCloneServerGroupCtrl.js
+++ b/app/scripts/controllers/modal/awsCloneServerGroupCtrl.js
@@ -221,9 +221,13 @@ angular.module('deckApp.aws')
     }
 
     function subnetChanged() {
-      var subnet = _($scope.subnets)
-        .find({'purpose': $scope.command.subnetType, 'account': $scope.command.credentials, 'region': $scope.command.region});
-      $scope.command.vpcId = subnet ? subnet.vpcId : null;
+      if (!$scope.command.subnetType) {
+        $scope.command.vpcId = null;
+      } else {
+        var subnet = _($scope.subnets)
+          .find({'purpose': $scope.command.subnetType, 'account': $scope.command.credentials, 'region': $scope.command.region});
+        $scope.command.vpcId = subnet ? subnet.vpcId : null;
+      }
       configureSecurityGroupOptions();
       configureLoadBalancerOptions();
     }

--- a/app/scripts/services/oortService.js
+++ b/app/scripts/services/oortService.js
@@ -71,7 +71,7 @@ angular.module('deckApp')
           return matches.length ? matches[0] : null;
         };
 
-        if (application.fromServer) {
+        if (application.fromServer && application.clusters) {
           application.accounts = Object.keys(application.clusters);
         }
         return application;

--- a/test/spec/controllers/awsCloneServerGroupCtrl.js
+++ b/test/spec/controllers/awsCloneServerGroupCtrl.js
@@ -530,6 +530,33 @@ describe('Controller: awsCloneServerGroup', function () {
       expect(this.submitted.command.type).toBe('copyLastAsg');
       expect(this.submitted.description).toBe('Create Cloned Server Group from testasg-v002');
     });
+
+    it('updates vpcId when subnetType changes, ignoring subnets without a purpose', function() {
+      var $scope = this.$scope,
+        serverGroup = this.buildBaseClone();
+
+      setupMocks.bind(this).call();
+
+      initController(serverGroup);
+
+      $scope.$digest();
+
+      $scope.subnets = [
+        { vpcId: 'vpc-1', account: 'prod', region: 'us-west-1' },
+        { vpcId: 'vpc-2', account: 'prod', region: 'us-west-1', purpose: 'magic' }
+      ];
+
+      expect($scope.command.vpcId).toBe(null);
+
+      $scope.command.subnetType = 'magic';
+      $scope.$digest();
+      expect($scope.command.vpcId).toBe('vpc-2');
+
+      $scope.command.subnetType = '';
+      $scope.$digest();
+      expect($scope.command.vpcId).toBe(null);
+
+    });
   });
 
 });


### PR DESCRIPTION
We have a subnet without a purpose tag, which is going to happen moving forward. Sadly, we match those subnets in the create/clone server group controller and act like we're in VPC, which just makes everyone miserable, especially if they're trying to deploy into test/us-west-2 right now in EC2 (Classic) mode.

I also threw in a bonus guard for applications without clusters because it's Friday and I saw that error pop up in my console at some point while I was debugging the issue mentioned above.
