### PR TITLE
add deployment strategy to clone operation

### DIFF
--- a/app/scripts/controllers/modal/ServerGroupBasicSettingsCtrl.js
+++ b/app/scripts/controllers/modal/ServerGroupBasicSettingsCtrl.js
@@ -2,7 +2,7 @@
 
 
 angular.module('deckApp')
-  .controller('ServerGroupBasicSettingsCtrl', function($scope, modalWizardService, settings, serverGroupService, imageService, RxService) {
+  .controller('ServerGroupBasicSettingsCtrl', function($scope, modalWizardService, settings, serverGroupService, imageService, RxService, deploymentStrategiesService) {
 
     $scope.$watch('form.$valid', function(newVal) {
       if (newVal) {
@@ -48,5 +48,16 @@ angular.module('deckApp')
       }
       return serverGroupService.getClusterName($scope.applicationName, command.stack, command.freeFormDetails);
     };
+
+    // Use undefined to check for the presence of the 'strategy' field, which is added to the command
+    // on "clone" operations, but not "create new" operations, where it doesn't seem valid to have a strategy
+    // (assuming "create new" is used to create a brand new cluster).
+    //
+    // The field is hidden on the form if no deployment strategies are present on the scope.
+    if ($scope.command.strategy !== undefined) {
+      deploymentStrategiesService.listAvailableStrategies().then(function (strategies) {
+        $scope.deploymentStrategies = strategies;
+      });
+    }
 
   });

--- a/app/scripts/services/awsServerGroupService.js
+++ b/app/scripts/services/awsServerGroupService.js
@@ -64,6 +64,7 @@ angular.module('deckApp')
 
         var command = {
           application: application.name,
+          strategy: '',
           stack: serverGroupName.stack,
           freeFormDetails: serverGroupName.freeFormDetails,
           credentials: serverGroup.account,

--- a/app/scripts/services/deploymentStrategiesService.js
+++ b/app/scripts/services/deploymentStrategiesService.js
@@ -1,0 +1,21 @@
+'use strict';
+
+
+angular.module('deckApp')
+  .factory('deploymentStrategiesService', function ($q) {
+
+    var strategies = [
+      {label: 'Highlander', key: 'highlander', description: 'Destroys previous server group as soon as new server group passes health checks'},
+      {label: 'Red/Black', key: 'redblack', description: 'Disables previous server group as soon as new server group passes health checks'},
+      {label: 'None', key: '', description: 'Creates the next server group with no impact on existing server groups'},
+    ];
+
+    function listAvailableStrategies() {
+      return $q.when(strategies);
+    }
+
+    return {
+      listAvailableStrategies: listAvailableStrategies
+    };
+
+  });

--- a/app/scripts/settings/helpContents.js
+++ b/app/scripts/settings/helpContents.js
@@ -20,5 +20,6 @@ angular.module('deckApp')
     'aws.serverGroup.detail': '(Optional) <b>Detail</b> is a string of free-form alphanumeric characters and hyphens to describe any other variables',
     'aws.serverGroup.imageName': '(Required) <b>Image</b> is the deployable Amazon Machine Image. Images are restricted to the account and region selected.',
     'aws.serverGroup.allImages': 'Search for an image that does not match the name of your application.',
-    'aws.serverGroup.filterImages': 'Select from a pre-filtered list of images matching the name of your application.'
+    'aws.serverGroup.filterImages': 'Select from a pre-filtered list of images matching the name of your application.',
+    'aws.serverGroup.strategy': 'The deployment strategy tells Spinnaker what to do with the previous version of the server group.',
   });

--- a/app/views/application/modal/serverGroup/aws/basicSettings.html
+++ b/app/views/application/modal/serverGroup/aws/basicSettings.html
@@ -63,6 +63,21 @@
         <a href ng-click="command.viewState.useAllImageSelection = true">Search All Images</a><help-field key="aws.serverGroup.allImages"></help-field>
       </div>
     </div>
+    <div class="form-group" ng-if="deploymentStrategies.length">
+      <div class="col-md-2 sm-label-left">
+        <b>Strategy</b>
+        <help-field key="aws.serverGroup.strategy"></help-field>
+      </div>
+      <div class="col-md-10">
+        <ui-select ng-model="command.strategy" class="form-control input-sm" required>
+          <ui-select-match placeholder="None">{{$select.selected.label}}</ui-select-match>
+          <ui-select-choices repeat="strategy.key as strategy in deploymentStrategies | filter: $select.search">
+            <strong ng-bind-html="strategy.label | highlight: $select.search"></strong>
+            <div ng-bind-html="strategy.description"></div>
+          </ui-select-choices>
+        </ui-select>
+      </div>
+    </div>
   </div>
 
   <div class="modal-footer">


### PR DESCRIPTION
Eventually, the metadata for the available strategies will come from gate; for now, it's hard-coded in the deploymentStrategiesService.

It's pretty simple stuff:
![screen shot 2014-11-21 at 5 06 35 pm](https://cloud.githubusercontent.com/assets/73450/5152184/d2dd6006-71a0-11e4-8689-d6adcf3d05bf.png)
