### PR TITLE
fix size on modal wizard step indicator

### DIFF
--- a/app/styles/modals.less
+++ b/app/styles/modals.less
@@ -49,7 +49,7 @@
         width: @indicator-size;
         height: @indicator-size;
         background-color: transparent;
-        font-size: 120%;
+        font-size: 175%;
         font-family: 'Glyphicons Halflings';
         left: ~'calc(50% - @{indicator-radius})';
       }
@@ -64,6 +64,7 @@
             color: @state-danger-text;
             background-color: transparent;
             content: "\e088";
+            top: -7px;
           }
         }
       }


### PR DESCRIPTION
I made the indicators a lot bigger a while ago but forgot to increase the size on the dirty step indicator. That is what this does.
