### PR TITLE
Determine instance category (e.g. General, High Memory, Micro) by search...

### DIFF
--- a/app/scripts/controllers/modal/gceCloneServerGroupCtrl.js
+++ b/app/scripts/controllers/modal/gceCloneServerGroupCtrl.js
@@ -265,7 +265,6 @@ angular.module('deckApp.gce')
           'desired': serverGroup.asg.desiredCapacity
         },
         'allImageSelection': null,
-        'instanceProfile': 'custom'
       };
       if (serverGroup.launchConfig) {
         var amiName = null;
@@ -285,6 +284,7 @@ angular.module('deckApp.gce')
           'ebsOptimized': serverGroup.launchConfig.ebsOptimized,
           'amiName': amiName
         });
+        determineInstanceCategoryFromInstanceType(command);
       }
       command.subnetType = '';
       command.vpcId = null;
@@ -332,6 +332,23 @@ angular.module('deckApp.gce')
       // Would be cleaner to change that logic in orca to expect providerType and always identify stages using that
       // parameter. Then we could change this to providerType.
       $scope.command.selectedProvider = 'gce';
+    }
+
+    // Two assumptions here:
+    //   1) All GCE machine types are represented in the tree of choices.
+    //   2) Each machine type appears in exactly one category.
+    function determineInstanceCategoryFromInstanceType(command) {
+      instanceTypeService.getCategories('gce').then(function(categories) {
+        categories.forEach(function(category) {
+          category.families.forEach(function(family) {
+            family.instanceTypes.forEach(function(instanceType) {
+              if (instanceType.name === command.instanceType) {
+                command.instanceProfile = category.type;
+              }
+            });
+          });
+        });
+      });
     }
 
     this.isValid = function () {

--- a/app/views/application/modal/serverGroup/gce/instanceArchetype.html
+++ b/app/views/application/modal/serverGroup/gce/instanceArchetype.html
@@ -6,7 +6,7 @@
       <h4 class="col-md-12">My application is:</h4>
     </div>
     <div class="row">
-      <div class="col-md-4 col-narrow" ng-repeat="instanceProfile in instanceProfiles">
+      <div class="col-md-3 col-narrow" ng-repeat="instanceProfile in instanceProfiles">
         <button class="panel panel-default instance-profile"
                 ng-class="{active: command.instanceProfile === instanceProfile.type}"
                 ng-click="instanceArchetypeCtrl.selectInstanceType(instanceProfile.type, $event)">
@@ -17,7 +17,8 @@
           </div>
         </button>
       </div>
-      <div class="col-md-4 col-narrow">
+<!--
+      <div class="col-md-3 col-narrow">
         <button class="panel panel-default instance-profile"
                 ng-class="{active: command.instanceProfile === 'custom'}"
                 ng-click="instanceArchetypeCtrl.selectInstanceType('custom', $event)">
@@ -40,6 +41,7 @@
         </select>
       </div>
     </div>
+-->
   </div>
   <div class="modal-footer">
     <button class="btn btn-default pull-left"


### PR DESCRIPTION
...ing known categories for instance type of server group being cloned.

Remove Custom Type as a category.
Shrink size of category choices back down so they look pretty again.
