### PR TITLE
minor refactor of clone server group ctrl to various services

### DIFF
--- a/app/scripts/controllers/AllClustersCtrl.js
+++ b/app/scripts/controllers/AllClustersCtrl.js
@@ -3,7 +3,7 @@
 
 angular.module('deckApp')
   .controller('AllClustersCtrl', function($scope, application, $modal, mortService,
-                                          securityGroupService, accountService, oortService,
+                                          securityGroupService, accountService, oortService, serverGroupService,
                                           _, $stateParams, $location, settings, $q, $window) {
     var defPrimary = 'account', defSecondary = 'region';
     $scope.sortFilter.allowSorting = true;
@@ -174,6 +174,7 @@ angular.module('deckApp')
             title: function() { return 'Create New Server Group'; },
             application: function() { return application; },
             serverGroup: function() { return null; },
+            serverGroupCommand: function() { return serverGroupService.buildNewServerGroupCommand(application, selectedProvider); },
             provider: function() { return selectedProvider; }
           }
         });

--- a/app/scripts/controllers/ServerGroupDetailsCtrl.js
+++ b/app/scripts/controllers/ServerGroupDetailsCtrl.js
@@ -4,7 +4,6 @@
 
 angular.module('deckApp')
   .controller('ServerGroupDetailsCtrl', function ($scope, $state, application, serverGroup, orcaService, notifications,
-                                                  mortService, oortService, accountService, securityGroupService,
                                                   serverGroupService, $modal, confirmationModalService, _) {
 
 
@@ -150,7 +149,8 @@ angular.module('deckApp')
         resolve: {
           title: function() { return 'Clone ' + serverGroup.name; },
           application: function() { return application; },
-          serverGroup: function() { return serverGroup; }
+          serverGroup: function() { return serverGroup; },
+          serverGroupCommand: function() { return serverGroupService.buildServerGroupCommandFromExisting(application, serverGroup); },
         }
       });
     };

--- a/app/scripts/controllers/modal/InstanceArchetypeCtrl.js
+++ b/app/scripts/controllers/modal/InstanceArchetypeCtrl.js
@@ -10,16 +10,16 @@ angular.module('deckApp')
       $scope.instanceProfiles = categories;
     });
 
-    if ($scope.command.region && $scope.command.instanceType && !$scope.command.instanceProfile) {
-      $scope.command.instanceProfile = 'custom';
+    if ($scope.command.region && $scope.command.instanceType && !$scope.command.viewState.instanceProfile) {
+      $scope.command.viewState.instanceProfile = 'custom';
     }
 
     this.selectInstanceType = function (type) {
-      if ($scope.command.instanceProfile === type) {
+      if ($scope.command.viewState.instanceProfile === type) {
         type = null;
       }
-      $scope.command.instanceProfile = type;
-      if ($scope.command.instanceProfile === 'custom') {
+      $scope.command.viewState.instanceProfile = type;
+      if ($scope.command.viewState.instanceProfile === 'custom') {
         wizard.excludePage('instance-type');
       } else {
         wizard.includePage('instance-type');
@@ -34,7 +34,7 @@ angular.module('deckApp')
     };
 
     this.instanceTypeSelected = function() {
-      if ($scope.command.instanceType) {
+      if ($scope.command.viewState.instanceType) {
         wizard.markClean('instance-profile');
         wizard.markComplete('instance-profile');
       }

--- a/app/scripts/controllers/modal/awsCloneServerGroupCtrl.js
+++ b/app/scripts/controllers/modal/awsCloneServerGroupCtrl.js
@@ -3,10 +3,10 @@
 
 angular.module('deckApp.aws')
   .controller('awsCloneServerGroupCtrl', function($scope, $modalInstance, _, $q, $exceptionHandler, $state, settings,
-                                               accountService, orcaService, mortService, oortService, searchService, serverGroupService,
+                                               accountService, orcaService, mortService, oortService,
                                                instanceTypeService, modalWizardService, securityGroupService, taskMonitorService,
                                                imageService,
-                                               serverGroup, application, title) {
+                                               serverGroupCommand, application, title) {
     $scope.title = title;
     $scope.healthCheckTypes = ['EC2', 'ELB'];
     $scope.terminationPolicies = ['OldestInstance', 'NewestInstance', 'OldestLaunchConfiguration', 'ClosestToNextInstanceHour', 'Default'];
@@ -16,8 +16,6 @@ angular.module('deckApp.aws')
     $scope.state = {
       loaded: false,
       imagesLoaded: false,
-      queryAllImages: false,
-      useSimpleCapacity: true
     };
 
     $scope.taskMonitor = taskMonitorService.buildTaskMonitor({
@@ -53,92 +51,31 @@ angular.module('deckApp.aws')
       $scope.keyPairs = keyPairs;
     });
 
+    $scope.command = serverGroupCommand;
 
-    function buildCommandFromExisting(serverGroup) {
-      var command = {
-        'credentials': serverGroup.account,
-        'cooldown': serverGroup.asg.defaultCooldown,
-        'healthCheckGracePeriod': serverGroup.asg.healthCheckGracePeriod,
-        'healthCheckType': serverGroup.asg.healthCheckType,
-        'terminationPolicies': serverGroup.asg.terminationPolicies,
-        'loadBalancers': serverGroup.asg.loadBalancerNames,
-        'region': serverGroup.region,
-        'capacity': {
-          'min': serverGroup.asg.minSize,
-          'max': serverGroup.asg.maxSize,
-          'desired': serverGroup.asg.desiredCapacity
-        },
-        'allImageSelection': null,
-        'instanceProfile': 'custom'
-      };
-      if (serverGroup.launchConfig && serverGroup.launchConfig.securityGroups.length) {
-        command.securityGroups = serverGroup.launchConfig.securityGroups;
-      }
-      return command;
-    }
-
-    function createCommandTemplate() {
-      var defaultCredentials = settings.defaults.account;
-      var defaultRegion = settings.defaults.region;
-      return {
-        'application': application.name,
-        'credentials': defaultCredentials,
-        'region': defaultRegion,
-        'usePreferredZones': true,
-        'capacity': {
-          'min': 1,
-          'max': 1,
-          'desired': 1
-        },
-        'cooldown': 10,
-        'healthCheckType': 'EC2',
-        'healthCheckGracePeriod': 600,
-        'instanceMonitoring': false,
-        'ebsOptimized': false,
-
-        'iamRole': 'BaseIAMRole', // should not be hard coded here
-
-        'terminationPolicies': ['Default'],
-        'vpcId': null,
-        allImageSelection: null
-      };
-    }
-
-
-    if (serverGroup) {
-      $scope.command = buildCommandFromExisting(serverGroup);
-    } else {
-      $scope.command = createCommandTemplate();
-
-      // If we used the attribute name 'providerType' it would trigger the stage-decorating logic in orca.
-      // Would be cleaner to change that logic in orca to expect providerType and always identify stages using that
-      // parameter. Then we could change this to providerType.
-      $scope.command.selectedProvider = 'aws';
-    }
-
-    var imageLoader = imageService.findImages(application.name, $scope.command.region, $scope.command.credentials).then(function(images) {
+    var imageLoader = imageService.findImages(application.name, serverGroupCommand.region, serverGroupCommand.credentials).then(function(images) {
       $scope.packageImages = images;
       if (images.length === 0) {
-        if (serverGroup) {
-          imageService.getAmi(serverGroup.launchConfig.imageId, serverGroup.region, serverGroup.account).then(function (namedImage) {
+        if (serverGroupCommand.viewState.mode === 'clone') {
+          imageService.getAmi(serverGroupCommand.viewState.imageId, serverGroupCommand.region, serverGroupCommand.credentials).then(function (namedImage) {
             if (namedImage) {
               var packageRegex = /(\w+)-?\w+/;
               $scope.command.amiName = namedImage.imageName;
               var match = packageRegex.exec(namedImage.imageName);
               $scope.packageBase = match[1];
-              imageService.findImages($scope.packageBase, $scope.command.region, $scope.command.credentials).then(function(searchResults) {
+              imageService.findImages($scope.packageBase, serverGroupCommand.region, serverGroupCommand.credentials).then(function(searchResults) {
                 $scope.packageImages = searchResults;
                 $scope.state.imagesLoaded = true;
                 configureImages();
               });
             } else {
-              $scope.state.queryAllImages = true;
+              $scope.command.viewState.useAllImageSelection = true;
               $scope.state.imagesLoaded = true;
             }
           });
         } else {
           $scope.state.imagesLoaded = true;
-          $scope.state.queryAllImages = true;
+          $scope.command.viewState.useAllImageSelection = true;
         }
       } else {
         $scope.state.imagesLoaded = true;
@@ -154,7 +91,7 @@ angular.module('deckApp.aws')
     });
 
     function initializeWizardState() {
-      if (serverGroup) {
+      if (serverGroupCommand.viewState.mode === 'clone') {
         modalWizardService.getWizard().markComplete('location');
         modalWizardService.getWizard().markComplete('load-balancers');
         modalWizardService.getWizard().markComplete('security-groups');
@@ -168,7 +105,7 @@ angular.module('deckApp.aws')
       $scope.$watch('command.credentials', credentialsChanged);
       $scope.$watch('command.region', regionChanged);
       $scope.$watch('command.subnetType', subnetChanged);
-      $scope.$watch('command.usePreferredZones', usePreferredZonesToggled);
+      $scope.$watch('command.viewState.usePreferredZones', usePreferredZonesToggled);
     }
 
     function initializeSelectOptions() {
@@ -210,7 +147,7 @@ angular.module('deckApp.aws')
       }
 
       usePreferredZonesToggled();
-      if (!command.usePreferredZones) {
+      if (!command.viewState.usePreferredZones) {
         command.availabilityZones = _.intersection(command.availabilityZones, $scope.regionalAvailabilityZones);
         var newZoneCount = command.availabilityZones ? command.availabilityZones.length : 0;
         if (currentZoneCount !== newZoneCount) {
@@ -221,7 +158,7 @@ angular.module('deckApp.aws')
 
     function usePreferredZonesToggled() {
       var command = $scope.command;
-      if (command.usePreferredZones) {
+      if (command.viewState.usePreferredZones) {
         command.availabilityZones = $scope.preferredZones[command.credentials][command.region].sort();
       }
     }
@@ -231,7 +168,7 @@ angular.module('deckApp.aws')
         $scope.command.vpcId = null;
       } else {
         var subnet = _($scope.subnets)
-          .find({'purpose': $scope.command.subnetType, 'account': $scope.command.credentials, 'region': $scope.command.region});
+          .find({purpose: $scope.command.subnetType, account: $scope.command.credentials, region: $scope.command.region});
         $scope.command.vpcId = subnet ? subnet.vpcId : null;
       }
       configureSecurityGroupOptions();
@@ -240,7 +177,7 @@ angular.module('deckApp.aws')
 
     function configureAvailabilityZones() {
       $scope.regionalAvailabilityZones = _.find($scope.regionsKeyedByAccount[$scope.command.credentials].regions,
-        {'name': $scope.command.region}).availabilityZones;
+        {name: $scope.command.region}).availabilityZones;
     }
 
     function configureSubnetPurposes() {
@@ -248,9 +185,9 @@ angular.module('deckApp.aws')
         $scope.regionSubnetPurposes = null;
       }
       $scope.regionSubnetPurposes = _($scope.subnets)
-        .filter({'account': $scope.command.credentials, 'region': $scope.command.region})
-        .reject({'target': 'elb'})
-        .reject({'purpose': null})
+        .filter({account: $scope.command.credentials, region: $scope.command.region})
+        .reject({target: 'elb'})
+        .reject({purpose: null})
         .pluck('purpose')
         .uniq()
         .map(function(purpose) { return { purpose: purpose, label: purpose };})
@@ -259,7 +196,7 @@ angular.module('deckApp.aws')
 
     function configureSecurityGroupOptions() {
       var newRegionalSecurityGroups = _($scope.securityGroups[$scope.command.credentials].aws[$scope.command.region])
-        .filter({'vpcId': $scope.command.vpcId || null})
+        .filter({vpcId: $scope.command.vpcId || null})
         .valueOf();
       if ($scope.regionalSecurityGroups && $scope.command.securityGroups) {
         var previousCount = $scope.command.securityGroups.length;
@@ -289,13 +226,13 @@ angular.module('deckApp.aws')
       var newLoadBalancers = _($scope.loadBalancers)
         .pluck('accounts')
         .flatten(true)
-        .filter({'name': $scope.command.credentials})
+        .filter({name: $scope.command.credentials})
         .pluck('regions')
         .flatten(true)
-        .filter({'name': $scope.command.region})
+        .filter({name: $scope.command.region})
         .pluck('loadBalancers')
         .flatten(true)
-        .filter({'vpcId': $scope.command.vpcId})
+        .filter({vpcId: $scope.command.vpcId})
         .pluck('name')
         .unique()
         .valueOf();
@@ -343,67 +280,19 @@ angular.module('deckApp.aws')
     }
 
     function initializeCommand() {
-      var command = $scope.command;
-      if (serverGroup) {
-        var asg = serverGroup.asg;
-        $scope.state.useSimpleCapacity = asg.minSize === asg.maxSize;
-        var serverGroupName = serverGroupService.parseServerGroupName(serverGroup.asg.autoScalingGroupName);
-        var zones = serverGroup.asg.availabilityZones.sort();
-        var preferredZones = $scope.preferredZones[serverGroup.account][serverGroup.region].sort();
-        var usePreferredZones = zones.join(',') === preferredZones.join(',');
-
-        command.application = serverGroupName.application;
-        command.stack = serverGroupName.stack;
-        command.freeFormDetails = serverGroupName.freeFormDetails;
-        command.availabilityZones = zones;
-        command.usePreferredZones = usePreferredZones;
-
-        var vpcZoneIdentifier = serverGroup.asg.vpczoneIdentifier;
-        if (vpcZoneIdentifier !== '') {
-          var subnetId = vpcZoneIdentifier.split(',')[0];
-          var subnet = _($scope.subnets).find({'id': subnetId});
-          command.subnetType = subnet.purpose;
-          command.vpcId = subnet.vpcId;
-        } else {
-          command.subnetType = '';
-          command.vpcId = null;
+      if (serverGroupCommand.viewState.imageId) {
+        var foundImage = $scope.packageImages.filter(function(image) {
+          return image.amis[serverGroupCommand.region] && image.amis[serverGroupCommand.region].indexOf(serverGroupCommand.viewState.imageId) !== -1;
+        });
+        if (foundImage.length) {
+          serverGroupCommand.amiName = foundImage[0].imageName;
         }
-
-        if (serverGroup.launchConfig) {
-          var amiName = null;
-          if (serverGroup.launchConfig.imageId) {
-            var foundImage = $scope.packageImages.filter(function(image) {
-              return image.amis[serverGroup.region] && image.amis[serverGroup.region].indexOf(serverGroup.launchConfig.imageId) !== -1;
-            });
-            if (foundImage.length) {
-              amiName = foundImage[0].imageName;
-            }
-          }
-          angular.extend(command, {
-            'instanceType': serverGroup.launchConfig.instanceType,
-            'iamRole': serverGroup.launchConfig.iamInstanceProfile,
-            'keyPair': serverGroup.launchConfig.keyName,
-            'associatePublicIpAddress': serverGroup.launchConfig.associatePublicIpAddress,
-            'ramdiskId': serverGroup.launchConfig.ramdiskId,
-            'instanceMonitoring': serverGroup.launchConfig.instanceMonitoring.enabled,
-            'ebsOptimized': serverGroup.launchConfig.ebsOptimized,
-            'amiName': amiName
-          });
-        }
-      } else {
-        command.availabilityZones = $scope.preferredZones[command.credentials][command.region];
-        command.keyPair = $scope.regionsKeyedByAccount[command.credentials].defaultKeyPair;
       }
-
     }
-
-    this.useAllImageSelection = function() {
-      return $scope.state.queryAllImages || !$scope.regionalImages || $scope.regionalImages.length === 0;
-    };
 
     this.isValid = function () {
       return $scope.command &&
-        (this.useAllImageSelection () ? $scope.command.allImageSelection !== null : $scope.command.amiName !== null) &&
+        ($scope.command.viewState.useAllImageSelection ? $scope.command.viewState.allImageSelection !== null : $scope.command.amiName !== null) &&
         ($scope.command.application !== null) &&
         ($scope.command.credentials !== null) && ($scope.command.instanceType !== null) &&
         ($scope.command.region !== null) && ($scope.command.availabilityZones !== null) &&
@@ -440,50 +329,9 @@ angular.module('deckApp.aws')
     };
 
     this.clone = function () {
-
-      var command = angular.copy($scope.command);
-      var description;
-      if (serverGroup) {
-        description = 'Create Cloned Server Group from ' + serverGroup.asg.autoScalingGroupName;
-        command.type = 'copyLastAsg';
-        command.source = {
-          'account': serverGroup.account,
-          'region': serverGroup.region,
-          'asgName': serverGroup.asg.autoScalingGroupName
-        };
-      } else {
-        command.type = 'deploy';
-        var asgName = application.name;
-        if (command.stack) {
-          asgName += '-' + command.stack;
-        }
-        if (!command.stack && command.freeFormDetails) {
-          asgName += '-';
-        }
-        if (command.freeFormDetails) {
-          asgName += '-' + command.freeFormDetails;
-        }
-        description = 'Create New Server Group in cluster ' + asgName;
-      }
-      if (this.useAllImageSelection()) {
-        command.amiName = command.allImageSelection;
-      }
-      command.availabilityZones = {};
-      command.availabilityZones[command.region] = $scope.command.availabilityZones;
-      delete command.region;
-      delete command.allImageSelection;
-      delete command.selectedProvider;
-      delete command.instanceProfile;
-      delete command.vpcId;
-      delete command.usePreferredZones;
-
-      if (!command.subnetType) {
-        delete command.subnetType;
-      }
-
       $scope.taskMonitor.submit(
         function() {
-          return orcaService.cloneServerGroup(command, application.name, description);
+          return orcaService.cloneServerGroup($scope.command, application.name);
         }
       );
     };

--- a/app/scripts/services/serverGroupService.js
+++ b/app/scripts/services/serverGroupService.js
@@ -2,7 +2,7 @@
 
 
 angular.module('deckApp')
-  .factory('serverGroupService', function (settings, Restangular, $exceptionHandler) {
+  .factory('serverGroupService', function (settings, Restangular, $exceptionHandler, $q, accountService, mortService) {
 
     var oortEndpoint = Restangular.withConfig(function (RestangularConfigurer) {
       RestangularConfigurer.setBaseUrl(settings.oortUrl);
@@ -68,11 +68,137 @@ angular.module('deckApp')
       return clusterName;
     }
 
+    function buildNewServerGroupCommand(application, provider) {
+      var preferredZonesLoader = accountService.getPreferredZonesByAccount();
+      var regionsKeyedByAccountLoader = accountService.getRegionsKeyedByAccount();
+      var asyncLoader = $q.all({preferredZones: preferredZonesLoader, regionsKeyedByAccount: regionsKeyedByAccountLoader});
+
+      return asyncLoader.then(function(asyncData) {
+        var defaultCredentials = settings.defaults.account;
+        var defaultRegion = settings.defaults.region;
+
+        var availabilityZones = asyncData.preferredZones[defaultCredentials][defaultRegion];
+        var keyPair = asyncData.regionsKeyedByAccount[defaultCredentials].defaultKeyPair;
+
+        return {
+          application: application.name,
+          credentials: defaultCredentials,
+          region: defaultRegion,
+          capacity: {
+            min: 1,
+            max: 1,
+            desired: 1
+          },
+          cooldown: 10,
+          healthCheckType: 'EC2',
+          healthCheckGracePeriod: 600,
+          instanceMonitoring: false,
+          ebsOptimized: false,
+          selectedProvider: provider,
+          iamRole: 'BaseIAMRole', // should not be hard coded here
+
+          terminationPolicies: ['Default'],
+          vpcId: null,
+          availabilityZones: availabilityZones,
+          keyPair: keyPair,
+          viewState: {
+            instanceProfile: null,
+            allImageSelection: null,
+            useAllImageSelection: false,
+            useSimpleCapacity: true,
+            usePreferredZones: true,
+            mode: 'create',
+          },
+        };
+      });
+    }
+
+    function buildServerGroupCommandFromExisting(application, serverGroup, mode) {
+      mode = mode || 'clone';
+      var preferredZonesLoader = accountService.getPreferredZonesByAccount();
+      var subnetsLoader = mortService.listSubnets();
+      var asyncLoader = $q.all({preferredZones: preferredZonesLoader, subnets: subnetsLoader});
+
+      return asyncLoader.then(function(asyncData) {
+        var serverGroupName = parseServerGroupName(serverGroup.asg.autoScalingGroupName);
+
+        var zones = serverGroup.asg.availabilityZones.sort();
+        var preferredZones = asyncData.preferredZones[serverGroup.account][serverGroup.region].sort();
+        var usePreferredZones = zones.join(',') === preferredZones.join(',');
+
+        var command = {
+          application: application.name,
+          stack: serverGroupName.stack,
+          freeFormDetails: serverGroupName.freeFormDetails,
+          credentials: serverGroup.account,
+          cooldown: serverGroup.asg.defaultCooldown,
+          healthCheckGracePeriod: serverGroup.asg.healthCheckGracePeriod,
+          healthCheckType: serverGroup.asg.healthCheckType,
+          terminationPolicies: serverGroup.asg.terminationPolicies,
+          loadBalancers: serverGroup.asg.loadBalancerNames,
+          region: serverGroup.region,
+          capacity: {
+            'min': serverGroup.asg.minSize,
+            'max': serverGroup.asg.maxSize,
+            'desired': serverGroup.asg.desiredCapacity
+          },
+          availabilityZones: zones,
+          selectedProvider: 'aws',
+          source: {
+            account: serverGroup.account,
+            region: serverGroup.region,
+            asgName: serverGroup.asg.autoScalingGroupName,
+          },
+          viewState: {
+            instanceProfile: 'custom',
+            allImageSelection: null,
+            useAllImageSelection: false,
+            useSimpleCapacity: serverGroup.asg.minSize === serverGroup.asg.maxSize,
+            usePreferredZones: usePreferredZones,
+            mode: mode,
+          },
+        };
+
+        var vpcZoneIdentifier = serverGroup.asg.vpczoneIdentifier;
+        if (vpcZoneIdentifier !== '') {
+          var subnetId = vpcZoneIdentifier.split(',')[0];
+          var subnet = _(asyncData.subnets).find({'id': subnetId});
+          command.subnetType = subnet.purpose;
+          command.vpcId = subnet.vpcId;
+        } else {
+          command.subnetType = '';
+          command.vpcId = null;
+        }
+
+        if (serverGroup.launchConfig) {
+          angular.extend(command, {
+            instanceType: serverGroup.launchConfig.instanceType,
+            iamRole: serverGroup.launchConfig.iamInstanceProfile,
+            keyPair: serverGroup.launchConfig.keyName,
+            associatePublicIpAddress: serverGroup.launchConfig.associatePublicIpAddress,
+            ramdiskId: serverGroup.launchConfig.ramdiskId,
+            instanceMonitoring: serverGroup.launchConfig.instanceMonitoring.enabled,
+            ebsOptimized: serverGroup.launchConfig.ebsOptimized,
+          });
+          command.viewState.imageId = serverGroup.launchConfig.imageId;
+        }
+
+        if (serverGroup.launchConfig && serverGroup.launchConfig.securityGroups.length) {
+          command.securityGroups = serverGroup.launchConfig.securityGroups;
+        }
+        return command;
+      });
+    }
+
+
+
     return {
       getScalingActivities: getScalingActivities,
       parseServerGroupName: parseServerGroupName,
       getClusterName: getClusterName,
-      getServerGroup: getServerGroup
+      getServerGroup: getServerGroup,
+      buildNewServerGroupCommand: buildNewServerGroupCommand,
+      buildServerGroupCommandFromExisting: buildServerGroupCommandFromExisting
     };
 });
 

--- a/app/views/application/modal/serverGroup/aws/basicSettings.html
+++ b/app/views/application/modal/serverGroup/aws/basicSettings.html
@@ -32,8 +32,8 @@
         <help-field key="aws.serverGroup.imageName"></help-field>
       </div>
       <div class="col-md-7" ng-if="!state.imagesLoaded"><h5 class="loader"> finding images...</h5></div>
-      <div class="col-md-10" ng-if="state.imagesLoaded && ctrl.useAllImageSelection()">
-        <ui-select ng-model="command.allImageSelection"
+      <div class="col-md-10" ng-if="state.imagesLoaded && command.viewState.useAllImageSelection">
+        <ui-select ng-model="command.viewState.allImageSelection"
                    class="form-control input-sm"
                    required>
           <ui-select-match placeholder="Search for an image...">{{$select.selected.imageName || $select.selected}}</ui-select-match>
@@ -48,11 +48,11 @@
           </ui-select-choices>
         </ui-select>
         <span ng-if="regionalImages.length > 0">
-          <a href ng-click="state.queryAllImages = false">Only show images matching "{{packageBase || applicationName}}"</a>
+          <a href ng-click="command.viewState.useAllImageSelection = false">Only show images matching "{{packageBase || applicationName}}"</a>
           <help-field key="aws.serverGroup.filterImages"></help-field>
         </span>
       </div>
-      <div class="col-md-10" ng-if="state.imagesLoaded && !ctrl.useAllImageSelection()">
+      <div class="col-md-10" ng-if="state.imagesLoaded && !command.viewState.useAllImageSelection">
         <ui-select ng-model="command.amiName" class="form-control input-sm" required>
           <ui-select-match placeholder="Pick an image">{{$select.selected.imageName}}</ui-select-match>
           <ui-select-choices repeat="image.imageName as image in regionalImages | filter: $select.search | orderBy: '-imageName'">
@@ -60,7 +60,7 @@
             (<span ng-bind-html="image.amis[command.region][0] | highlight: $select.search"></span>)
           </ui-select-choices>
         </ui-select>
-        <a href ng-click="state.queryAllImages = true">Search All Images</a><help-field key="aws.serverGroup.allImages"></help-field>
+        <a href ng-click="command.viewState.useAllImageSelection = true">Search All Images</a><help-field key="aws.serverGroup.allImages"></help-field>
       </div>
     </div>
   </div>

--- a/app/views/application/modal/serverGroup/aws/capacity.html
+++ b/app/views/application/modal/serverGroup/aws/capacity.html
@@ -1,9 +1,9 @@
 <form ng-controller="ServerGroupCapacityCtrl" class="container-fluid form-horizontal" name="form" novalidate>
   <div class="modal-body">
-    <div ng-if="!state.useSimpleCapacity">
+    <div ng-if="!command.viewState.useSimpleCapacity">
       <div class="form-group col-md-12">
         <p>Sets up auto-scaling for this server group.</p>
-        <p>To disable auto-scaling, use the <a href ng-click="state.useSimpleCapacity = true">Simple Mode</a>.</p>
+        <p>To disable auto-scaling, use the <a href ng-click="command.viewState.useSimpleCapacity = true">Simple Mode</a>.</p>
       </div>
 
       <div class="form-group">
@@ -35,10 +35,10 @@
       </div>
     </div>
 
-    <div ng-if="state.useSimpleCapacity">
+    <div ng-if="command.viewState.useSimpleCapacity">
       <div class="form-group col-md-12">
         <p>Sets min, max, and desired instance counts to the same value.</p>
-        <p> To allow true auto-scaling, use the <a href ng-click="state.useSimpleCapacity = false">Advanced Mode</a>.</p>
+        <p> To allow true auto-scaling, use the <a href ng-click="command.viewState.useSimpleCapacity = false">Advanced Mode</a>.</p>
       </div>
       <div class="form-group">
         <div class="col-md-4 sm-label-left"><b>Number of Instances</b></div>
@@ -55,16 +55,16 @@
     <input type="hidden" ng-model="command.availabilityZones[0]" required/>
     <div class="form-group">
       <div class="col-md-4 sm-label-left">Availability Zones</div>
-      <div class="col-md-7" ng-if="!command.usePreferredZones && !command.region">(Select a region)</div>
+      <div class="col-md-7" ng-if="!command.viewState.usePreferredZones && !command.region">(Select a region)</div>
       <div class="col-md-7" ng-if="command.region">
         <p>Automatic Availability Zone Balancing:</p>
         <select class="form-control input-sm"
-                ng-model="command.usePreferredZones"
+                ng-model="command.viewState.usePreferredZones"
                 ng-options="option.value as option.label for option in autoBalancingOptions">
 
         </select>
         <br/>
-        <div ng-if="command.usePreferredZones">
+        <div ng-if="command.viewState.usePreferredZones">
           <p>
             Server group will be available in:
             <ul>
@@ -74,7 +74,7 @@
             </ul>
           </p>
         </div>
-        <div ng-if="command.region && !command.usePreferredZones">
+        <div ng-if="command.region && !command.viewState.usePreferredZones">
           Restrict server group instances to:
           <checklist items="regionalAvailabilityZones"
                      model="command.availabilityZones"></checklist>

--- a/app/views/application/modal/serverGroup/aws/instanceArchetype.html
+++ b/app/views/application/modal/serverGroup/aws/instanceArchetype.html
@@ -6,9 +6,9 @@
     <div class="row">
       <div class="col-md-3 col-narrow" ng-repeat="instanceProfile in instanceProfiles">
         <button class="panel panel-default instance-profile"
-                ng-class="{active: command.instanceProfile === instanceProfile.type}"
+                ng-class="{active: command.viewState.instanceProfile === instanceProfile.type}"
                 ng-click="instanceArchetypeCtrl.selectInstanceType(instanceProfile.type, $event)">
-          <span is-visible="command.instanceProfile === instanceProfile.type"
+          <span is-visible="command.viewState.instanceProfile === instanceProfile.type"
                 class="glyphicon glyphicon-ok-circle selected-indicator"></span>
           <div class="panel-heading">
             <h4><span class="glyphicon glyphicon-hdd"></span><br/> {{instanceProfile.label}}</h4>
@@ -17,9 +17,9 @@
       </div>
       <div class="col-md-3 col-narrow">
         <button class="panel panel-default instance-profile"
-                ng-class="{active: command.instanceProfile === 'custom'}"
+                ng-class="{active: command.viewState.instanceProfile === 'custom'}"
                 ng-click="instanceArchetypeCtrl.selectInstanceType('custom', $event)">
-          <span is-visible="command.instanceProfile === 'custom'"
+          <span is-visible="command.viewState.instanceProfile === 'custom'"
                 class="glyphicon glyphicon-ok-circle selected-indicator custom"></span>
           <div class="panel-heading">
             <h4><span class="glyphicon glyphicon-asterisk"></span><br/> Custom Type</h4>
@@ -27,12 +27,12 @@
         </button>
       </div>
     </div>
-    <div class="row fade-in" ng-if="command.instanceProfile === 'custom'">
+    <div class="row fade-in" ng-if="command.viewState.instanceProfile === 'custom'">
       <div class="col-md-12">
         <select class="form-control input-sm"
                 ng-model="command.instanceType"
                 ng-options="customType for customType in regionalInstanceTypes"
-                ng-required="command.instanceProfile === 'custom'"
+                ng-required="command.viewState.instanceProfile === 'custom'"
                 ng-change="instanceArchetypeCtrl.instanceTypeSelected()">
           <option value="">Select an instance type...</option>
         </select>
@@ -48,7 +48,7 @@
     <submit-button ng-if="ctrl.showSubmitButton()" is-disabled="form.$invalid || !ctrl.isValid() || taskMonitor.submitting"
                    submitting="taskMonitor.submitting" on-click="ctrl.clone()" is-new="true"></submit-button>
     <button class="btn btn-primary"
-            ng-disabled="!command.instanceProfile || form.$invalid"
+            ng-disabled="!command.viewState.instanceProfile || form.$invalid"
             ng-click="wizard.nextPage(form.$valid)">
       Next <span class="glyphicon glyphicon-chevron-right"></span>
     </button>

--- a/test/spec/controllers/awsCloneServerGroupCtrl.js
+++ b/test/spec/controllers/awsCloneServerGroupCtrl.js
@@ -6,7 +6,7 @@ describe('Controller: awsCloneServerGroup', function () {
 
   beforeEach(function() {
     inject(function ($controller, $rootScope, accountService, orcaService, mortService, oortService, imageService, settings,
-                     searchService, instanceTypeService, modalWizardService, securityGroupService, taskMonitorService, $q) {
+                     searchService, instanceTypeService, modalWizardService, securityGroupService, taskMonitorService, serverGroupService, $q) {
 
       this.$scope = $rootScope.$new();
       this.accountService = accountService;
@@ -18,6 +18,7 @@ describe('Controller: awsCloneServerGroup', function () {
       this.instanceTypeService = instanceTypeService;
       this.modalWizardService = modalWizardService;
       this.securityGroupService = securityGroupService;
+      this.serverGroupService = serverGroupService;
       this.taskMonitorService = taskMonitorService;
       this.settings = settings;
       this.$q = $q;
@@ -36,26 +37,39 @@ describe('Controller: awsCloneServerGroup', function () {
 
     this.buildBaseClone = function() {
       return {
-        account: 'prod',
+        credentials: 'prod',
         region: 'us-west-1',
-        asg: {
-          availabilityZones: ['g','h','i'],
-          autoScalingGroupName: 'testasg-v002',
-          vpczoneIdentifier: ''
+        availabilityZones: ['g','h','i'],
+        instanceMonitoring: true,
+        securityGroups: [],
+        source: {
+          asgName: 'testasg-v002'
         },
-        launchConfig: {
+        viewState: {
+          mode: 'clone',
           imageId: 'ami-123',
-          instanceMonitoring: {
-            enabled: true
-          },
-          securityGroups: []
+          usePreferredZones: true,
         }
       };
-    }
+    };
+
+    this.buildBaseNew = function() {
+      return {
+        credentials: 'test',
+        region: 'us-east-1',
+        availabilityZones: AccountServiceFixture.regionsKeyedByAccount['test'].regions[0].availabilityZones,
+        securityGroups: [],
+        instanceMonitoring: true,
+        viewState: {
+          mode: 'create',
+          usePreferredZones: true,
+        }
+      };
+    };
   });
 
   describe('preferred zone handling', function() {
-    function initController(serverGroup) {
+    function initController(serverGroupCommand) {
       inject(function ($controller) {
         this.ctrl = $controller('awsCloneServerGroupCtrl', {
           $scope: this.$scope,
@@ -70,8 +84,9 @@ describe('Controller: awsCloneServerGroup', function () {
           instanceTypeService: this.instanceTypeService,
           modalWizardService: this.modalWizardService,
           securityGroupService: this.securityGroupService,
+          serverGroupService: this.serverGroupService,
           taskMonitorService: this.taskMonitorService,
-          serverGroup: serverGroup,
+          serverGroupCommand: serverGroupCommand,
           application: {name: 'x'},
           title: 'n/a'
         });
@@ -96,46 +111,11 @@ describe('Controller: awsCloneServerGroup', function () {
       spyOn(this.instanceTypeService, 'getAvailableTypesForRegions').and.callFake(resolve([]));
     }
 
-    it('initializes to default values, setting usePreferredZone flag to true', function () {
-      var $scope = this.$scope;
-      setupMocks.bind(this).call();
-
-      initController();
-
-      $scope.$digest();
-
-      expect($scope.command.usePreferredZones).toBe(true);
-      expect($scope.command.availabilityZones).toEqual(['a', 'b', 'c']);
-    });
-
-    it('sets usePreferredZones flag based on initial value', function() {
-      var $scope = this.$scope;
-      setupMocks.bind(this).call();
-
-      var serverGroup = this.buildBaseClone();
-
-      initController(serverGroup);
-
-      $scope.$digest();
-
-      expect($scope.command.usePreferredZones).toBe(true);
-      expect($scope.command.availabilityZones).toEqual(['g', 'h', 'i']);
-
-      serverGroup.asg.availabilityZones = ['g'];
-      initController(serverGroup);
-
-      $scope.$digest();
-
-      expect($scope.command.usePreferredZones).toBe(false);
-      expect($scope.command.availabilityZones).toEqual(['g']);
-
-    });
-
     it('updates to default values when credentials changed', function() {
       var $scope = this.$scope;
       setupMocks.bind(this).call();
 
-      initController();
+      initController(this.buildBaseNew());
 
       $scope.$digest();
 
@@ -149,14 +129,14 @@ describe('Controller: awsCloneServerGroup', function () {
       var $scope = this.$scope;
       setupMocks.bind(this).call();
 
-      initController();
+      initController(this.buildBaseNew());
 
       $scope.$digest();
 
       $scope.command.region = 'us-west-1';
       $scope.$digest();
 
-      expect($scope.command.usePreferredZones).toBe(true);
+      expect($scope.command.viewState.usePreferredZones).toBe(true);
       expect($scope.command.availabilityZones).toEqual(['c', 'd']);
       expect(this.wizard.markDirty.calls.count()).toBe(0);
     });
@@ -165,17 +145,17 @@ describe('Controller: awsCloneServerGroup', function () {
       var $scope = this.$scope;
       setupMocks.bind(this).call();
 
-      initController();
+      initController(this.buildBaseNew());
 
       $scope.$digest();
 
       expect($scope.command.availabilityZones).toEqual(['a','b','c']);
 
       $scope.command.region = 'us-west-1';
-      $scope.command.usePreferredZones = false;
+      $scope.command.viewState.usePreferredZones = false;
       $scope.$digest();
 
-      expect($scope.command.usePreferredZones).toBe(false);
+      expect($scope.command.viewState.usePreferredZones).toBe(false);
       expect($scope.command.availabilityZones).toEqual(['b','c']);
       expect(this.wizard.markDirty.calls.count()).toBe(1);
     });
@@ -184,31 +164,31 @@ describe('Controller: awsCloneServerGroup', function () {
       var $scope = this.$scope;
       setupMocks.bind(this).call();
 
-      initController();
+      initController(this.buildBaseNew());
 
       $scope.$digest();
 
       expect($scope.command.availabilityZones).toEqual(['a','b','c']);
-      expect($scope.command.usePreferredZones).toBe(true);
+      expect($scope.command.viewState.usePreferredZones).toBe(true);
 
-      $scope.command.usePreferredZones = false;
+      $scope.command.viewState.usePreferredZones = false;
       $scope.$digest();
 
       expect($scope.command.availabilityZones).toEqual(['a','b','c']);
-      expect($scope.command.usePreferredZones).toBe(false);
+      expect($scope.command.viewState.usePreferredZones).toBe(false);
 
       $scope.command.availabilityZones = [];
-      $scope.command.usePreferredZones = true;
+      $scope.command.viewState.usePreferredZones = true;
 
       $scope.$digest();
 
       expect($scope.command.availabilityZones).toEqual(['a','b','c']);
-      expect($scope.command.usePreferredZones).toBe(true);
+      expect($scope.command.viewState.usePreferredZones).toBe(true);
     });
   });
 
   describe('image loading', function() {
-    function initController(serverGroup) {
+    function initController(serverGroupCommand) {
       inject(function ($controller) {
         this.ctrl = $controller('awsCloneServerGroupCtrl', {
           $scope: this.$scope,
@@ -224,7 +204,7 @@ describe('Controller: awsCloneServerGroup', function () {
           modalWizardService: this.modalWizardService,
           securityGroupService: this.securityGroupService,
           taskMonitorService: this.taskMonitorService,
-          serverGroup: serverGroup,
+          serverGroupCommand: serverGroupCommand,
           application: {name: 'x'},
           title: 'n/a'
         });
@@ -248,57 +228,49 @@ describe('Controller: awsCloneServerGroup', function () {
       spyOn(this.instanceTypeService, 'getAvailableTypesForRegions').and.callFake(resolve([]));
     }
 
-    it('sets state flags for imagesLoaded and queryAllImages when none found and no server group provided', function() {
+    it('sets state flags for imagesLoaded and useAllImageSelection when none found and no server group provided', function () {
       var $scope = this.$scope;
       setupMocks.bind(this).call();
 
       spyOn(this.imageService, 'findImages').and.callFake(this.resolve([]));
 
-      initController();
+      initController(this.buildBaseNew());
 
       $scope.$digest();
 
       expect($scope.state.imagesLoaded).toBe(true);
-      expect($scope.state.queryAllImages).toBe(true);
+      expect($scope.command.viewState.useAllImageSelection).toBe(true);
     });
 
-    it('sets state flag for imagesLoaded and puts found images on scope when found', function() {
+    it('sets state flag for imagesLoaded and puts found images on scope when found', function () {
       var $scope = this.$scope,
-          regionalImages = [{amis: {'us-east-1': []}}];
+        regionalImages = [
+          {amis: {'us-east-1': []}}
+        ];
       setupMocks.bind(this).call();
 
       spyOn(this.imageService, 'findImages').and.callFake(this.resolve(regionalImages));
 
-      initController();
+      initController(this.buildBaseNew());
 
       $scope.$digest();
 
       expect($scope.state.imagesLoaded).toBe(true);
-      expect($scope.state.queryAllImages).toBe(false);
+      expect($scope.command.viewState.useAllImageSelection).toBeFalsy();
       expect($scope.regionalImages).toEqual(regionalImages);
     });
 
-    it('queries based on existing ami when none found for the application', function() {
+    it('queries based on existing ami when none found for the application', function () {
       var context = this,
-          $scope = this.$scope,
-          amiBasedImage = {imageName: 'something-packagebase', amis: {'us-east-1': ['ami-1234']}},
-          packageBasedImages = [{imageName: 'something-packagebase', amis: {'us-east-1': ['ami-1234']}}],
-          serverGroup = {
-            launchConfig: {
-              imageId: 'ami-1234',
-              securityGroups: [],
-              instanceMonitoring: {}
-            },
-            region: 'us-east-1',
-            account: 'test',
-            asg: {
-              availabilityZones: [],
-              vpczoneIdentifier: ''
-            }
-          };
+        $scope = this.$scope,
+        amiBasedImage = {imageName: 'something-packagebase', amis: {'us-east-1': ['ami-1234']}},
+        packageBasedImages = [amiBasedImage],
+        serverGroup = this.buildBaseClone();
       setupMocks.bind(this).call();
 
-      spyOn(this.imageService, 'findImages').and.callFake(function(query) {
+      serverGroup.region = 'us-east-1';
+
+      spyOn(this.imageService, 'findImages').and.callFake(function (query) {
         if (query === 'something') {
           return context.resolve(packageBasedImages).call();
         } else {
@@ -313,16 +285,16 @@ describe('Controller: awsCloneServerGroup', function () {
       $scope.$digest();
 
       expect($scope.state.imagesLoaded).toBe(true);
-      expect($scope.state.queryAllImages).toBe(false);
-      expect(this.imageService.getAmi).toHaveBeenCalledWith(serverGroup.launchConfig.imageId, serverGroup.region, serverGroup.account);
-      expect(this.imageService.findImages).toHaveBeenCalledWith($scope.applicationName, serverGroup.region, serverGroup.account);
-      expect(this.imageService.findImages).toHaveBeenCalledWith('something', serverGroup.region, serverGroup.account);
+      expect($scope.command.viewState.useAllImageSelection).toBeFalsy();
+      expect(this.imageService.getAmi).toHaveBeenCalledWith(serverGroup.viewState.imageId, serverGroup.region, serverGroup.credentials);
+      expect(this.imageService.findImages).toHaveBeenCalledWith($scope.applicationName, serverGroup.region, serverGroup.credentials);
+      expect(this.imageService.findImages).toHaveBeenCalledWith('something', serverGroup.region, serverGroup.credentials);
       expect($scope.regionalImages).toEqual(packageBasedImages);
     });
 
-    it('adds no regional images to the scope when the one provided does not match any results', function() {
+    it('adds no regional images to the scope when the one provided does not match any results', function () {
       var $scope = this.$scope,
-          serverGroup = this.buildBaseClone();
+        serverGroup = this.buildBaseClone();
       setupMocks.bind(this).call();
 
       spyOn(this.imageService, 'findImages').and.callFake(this.resolve([]));
@@ -333,13 +305,13 @@ describe('Controller: awsCloneServerGroup', function () {
       $scope.$digest();
 
       expect($scope.state.imagesLoaded).toBe(true);
-      expect($scope.state.queryAllImages).toBe(true);
-      expect(this.imageService.getAmi).toHaveBeenCalledWith(serverGroup.launchConfig.imageId, serverGroup.region, serverGroup.account);
-      expect(this.imageService.findImages).toHaveBeenCalledWith($scope.applicationName, serverGroup.region, serverGroup.account);
+      expect($scope.command.viewState.useAllImageSelection).toBe(true);
+      expect(this.imageService.getAmi).toHaveBeenCalledWith(serverGroup.viewState.imageId, serverGroup.region, serverGroup.credentials);
+      expect(this.imageService.findImages).toHaveBeenCalledWith($scope.applicationName, serverGroup.region, serverGroup.credentials);
       expect($scope.regionalImages).toEqual([]);
     });
 
-    it('queries all images for ami when no regional images present', function() {
+    it('queries all images for ami when no regional images present', function () {
       var $scope = this.$scope;
 
       setupMocks.bind(this).call();
@@ -347,36 +319,12 @@ describe('Controller: awsCloneServerGroup', function () {
       spyOn(this.imageService, 'findImages').and.callFake(this.resolve([]));
       spyOn(this.imageService, 'getAmi').and.callFake(this.resolve(null));
 
-      initController();
+      initController(this.buildBaseNew());
 
       $scope.$digest();
 
       expect($scope.state.imagesLoaded).toBe(true);
-      expect(this.ctrl.useAllImageSelection()).toBe(true);
-    });
-
-    it('queries all images for ami when specified by user', function() {
-      var $scope = this.$scope;
-
-      setupMocks.bind(this).call();
-
-      spyOn(this.imageService, 'findImages').and.callFake(this.resolve([{imageName: 'something-packagebase', amis: {'us-east-1': ['ami-1234']}}]));
-      spyOn(this.imageService, 'getAmi').and.callFake(this.resolve(null));
-
-      initController();
-
-      $scope.$digest();
-      expect($scope.state.imagesLoaded).toBe(true);
-      expect(this.ctrl.useAllImageSelection()).toBe(false);
-
-      $scope.state.queryAllImages = true;
-      $scope.$digest();
-      expect(this.ctrl.useAllImageSelection()).toBe(true);
-
-      $scope.state.queryAllImages = false;
-      $scope.$digest();
-      expect(this.ctrl.useAllImageSelection()).toBe(false);
-
+      expect($scope.command.viewState.useAllImageSelection).toBe(true);
     });
   });
 
@@ -397,7 +345,7 @@ describe('Controller: awsCloneServerGroup', function () {
           modalWizardService: this.modalWizardService,
           securityGroupService: this.securityGroupService,
           taskMonitorService: this.taskMonitorService,
-          serverGroup: serverGroup,
+          serverGroupCommand: serverGroup,
           application: {name: 'x'},
           title: 'n/a'
         });
@@ -432,108 +380,6 @@ describe('Controller: awsCloneServerGroup', function () {
       });
 
     }
-
-    it('sets amiName from allImageSelection', function() {
-      var $scope = this.$scope;
-
-      setupMocks.bind(this).call();
-
-      initController();
-
-      spyOn(this.$scope.taskMonitor, 'submit').and.callFake(function(method) {
-        method.call();
-      });
-
-      $scope.command.allImageSelection = 'something-packagebase';
-
-      this.ctrl.clone();
-      $scope.$digest();
-
-      var command = this.submitted.command;
-
-      expect(command.amiName).toBe('something-packagebase');
-
-    });
-
-    it('removes subnetType property when null', function() {
-      var $scope = this.$scope;
-
-      setupMocks.bind(this).call();
-
-      initController();
-
-      spyOn(this.$scope.taskMonitor, 'submit').and.callFake(function(method) {
-        method.call();
-      });
-
-      this.ctrl.clone();
-      $scope.$digest();
-
-      expect(this.submitted.command.subnetType).toBe(undefined);
-
-      $scope.command.subnetType = 'internal';
-
-      this.ctrl.clone();
-      $scope.$digest();
-
-      expect(this.submitted.command.subnetType).toBe('internal');
-    });
-
-    it('sets action type and description appropriately when creating new', function() {
-      var $scope = this.$scope,
-          command = $scope.command;
-
-      setupMocks.bind(this).call();
-
-      initController();
-
-      spyOn(this.$scope.taskMonitor, 'submit').and.callFake(function(method) {
-        method.call();
-      });
-
-      this.ctrl.clone();
-      $scope.$digest();
-
-      expect(this.submitted.command.type).toBe('deploy');
-      expect(this.submitted.description).toBe('Create New Server Group in cluster x');
-
-      $scope.command.stack = 'main';
-      this.ctrl.clone();
-      $scope.$digest();
-
-      expect(this.submitted.description).toBe('Create New Server Group in cluster x-main');
-
-      $scope.command.freeFormDetails = 'details';
-      this.ctrl.clone();
-      $scope.$digest();
-
-      expect(this.submitted.description).toBe('Create New Server Group in cluster x-main-details');
-
-      delete $scope.command.stack;
-      this.ctrl.clone();
-      $scope.$digest();
-
-      expect(this.submitted.description).toBe('Create New Server Group in cluster x--details');
-    });
-
-    it('sets action type and description appropriately when cloning', function() {
-      var $scope = this.$scope,
-          serverGroup = this.buildBaseClone();
-
-      setupMocks.bind(this).call();
-
-      initController(serverGroup);
-
-      spyOn(this.$scope.taskMonitor, 'submit').and.callFake(function(method) {
-        method.call();
-      });
-
-      this.ctrl.clone();
-      $scope.$digest();
-
-      expect(this.submitted.command.type).toBe('copyLastAsg');
-      expect(this.submitted.description).toBe('Create Cloned Server Group from testasg-v002');
-    });
 
     it('updates vpcId when subnetType changes, ignoring subnets without a purpose', function() {
       var $scope = this.$scope,

--- a/test/spec/services/orcaService.spec.js
+++ b/test/spec/services/orcaService.spec.js
@@ -1,0 +1,107 @@
+'use strict';
+
+describe('orcaService', function () {
+
+  var orcaService,
+    $httpBackend,
+    settings;
+
+  beforeEach(function () {
+    loadDeckWithoutCacheInitializer();
+    inject(function (_orcaService_, _$httpBackend_, _settings_) {
+      orcaService = _orcaService_;
+      $httpBackend = _$httpBackend_;
+      settings = _settings_;
+    });
+  });
+
+  describe('clone server group submit', function () {
+
+    function postTask(command) {
+      var submitted = null;
+      $httpBackend.expectPOST(settings.gateUrl + '/applications/appName/tasks', function (bodyString) {
+        submitted = angular.fromJson(bodyString);
+        return true;
+      }).respond(200, {ref: '/1'});
+
+      $httpBackend.expectGET(settings.gateUrl + '/applications/appName/tasks/1').respond({});
+
+      orcaService.cloneServerGroup(command, 'appName');
+      $httpBackend.flush();
+
+      return submitted;
+    }
+
+    it('sets amiName from allImageSelection', function () {
+      var command = {
+          viewState: {
+            mode: 'create',
+            useAllImageSelection: true,
+            allImageSelection: 'something-packagebase',
+          }
+        };
+
+      var submitted = postTask(command);
+
+      expect(submitted.job[0].amiName).toBe('something-packagebase');
+
+    });
+
+    it('removes subnetType property when null', function () {
+      var command = {
+          viewState: {
+            mode: 'create',
+            useAllImageSelection: true,
+            allImageSelection: 'something-packagebase',
+          },
+          subnetType: null,
+        };
+
+      var submitted = postTask(command);
+      expect(submitted.job[0].subnetType).toBe(undefined);
+
+      command.subnetType = 'internal';
+      submitted = postTask(command);
+      expect(submitted.job[0].subnetType).toBe('internal');
+    });
+
+    it('sets action type and description appropriately when creating new', function () {
+      var command = {
+          viewState: {
+            mode: 'create',
+          },
+        };
+
+      var submitted = postTask(command);
+      expect(submitted.job[0].type).toBe('deploy');
+      expect(submitted.description).toBe('Create New Server Group in cluster appName');
+
+      command.stack = 'main';
+      submitted = postTask(command);
+      expect(submitted.description).toBe('Create New Server Group in cluster appName-main');
+
+      command.freeFormDetails = 'details';
+      submitted = postTask(command);
+      expect(submitted.description).toBe('Create New Server Group in cluster appName-main-details');
+
+      delete command.stack;
+      submitted = postTask(command);
+      expect(submitted.description).toBe('Create New Server Group in cluster appName--details');
+    });
+
+    it('sets action type and description appropriately when cloning', function () {
+      var command = {
+          viewState: {
+            mode: 'clone',
+          },
+          source: {
+            asgName: 'appName-v002',
+          }
+        };
+
+      var submitted = postTask(command);
+      expect(submitted.job[0].type).toBe('copyLastAsg');
+      expect(submitted.description).toBe('Create Cloned Server Group from appName-v002');
+    });
+  });
+});


### PR DESCRIPTION
This doesn't structurally change the behavior of the create/clone server group modal. It moves responsibility for constructing the command to the callers, and moves the process of instantiating the commands into the serverGroupService.

I am going to need this behavior for pipeline configuration in order to reuse that modal. There will be more - albeit smaller - changes to the modal and controllers and everything else, but that will come later. This is an incremental step I wanted to get in to hopefully limit the size of the pipeline config PR.
