### PR TITLE
allow lookup of ami by id

### DIFF
--- a/app/scripts/controllers/modal/awsCloneServerGroupCtrl.js
+++ b/app/scripts/controllers/modal/awsCloneServerGroupCtrl.js
@@ -5,6 +5,7 @@ angular.module('deckApp.aws')
   .controller('awsCloneServerGroupCtrl', function($scope, $modalInstance, _, $q, $exceptionHandler, $state, settings,
                                                accountService, orcaService, mortService, oortService, searchService, serverGroupService,
                                                instanceTypeService, modalWizardService, securityGroupService, taskMonitorService,
+                                               imageService,
                                                serverGroup, application, title) {
     $scope.title = title;
     $scope.healthCheckTypes = ['EC2', 'ELB'];
@@ -115,17 +116,17 @@ angular.module('deckApp.aws')
       $scope.command.selectedProvider = 'aws';
     }
 
-    var imageLoader = oortService.findImages(application.name, $scope.command.region, $scope.command.credentials).then(function(images) {
+    var imageLoader = imageService.findImages(application.name, $scope.command.region, $scope.command.credentials).then(function(images) {
       $scope.packageImages = images;
       if (images.length === 0) {
         if (serverGroup) {
-          oortService.getAmi(serverGroup.launchConfig.imageId, serverGroup.region, serverGroup.account).then(function (namedImage) {
+          imageService.getAmi(serverGroup.launchConfig.imageId, serverGroup.region, serverGroup.account).then(function (namedImage) {
             if (namedImage) {
               var packageRegex = /(\w+)-?\w+/;
               $scope.command.amiName = namedImage.imageName;
               var match = packageRegex.exec(namedImage.imageName);
               $scope.packageBase = match[1];
-              oortService.findImages($scope.packageBase, $scope.command.region, $scope.command.credentials).then(function(searchResults) {
+              imageService.findImages($scope.packageBase, $scope.command.region, $scope.command.credentials).then(function(searchResults) {
                 $scope.packageImages = searchResults;
                 $scope.state.imagesLoaded = true;
                 configureImages();

--- a/app/scripts/services/imageService.js
+++ b/app/scripts/services/imageService.js
@@ -1,0 +1,36 @@
+'use strict';
+
+
+angular.module('deckApp')
+  .factory('imageService', function (settings, $q, Restangular) {
+
+    var oortEndpoint = Restangular.withConfig(function(RestangularConfigurer) {
+      RestangularConfigurer.setBaseUrl(settings.oortUrl);
+    });
+
+    function findImages(query, region, account) {
+      if (query.length < 3) {
+        return $q.when([{message: 'Please enter at least 3 characters...'}]);
+      }
+      return oortEndpoint.all('aws/images/find').getList({q: query, region: region, account: account}, {}).then(function(results) {
+          return results;
+        },
+        function() {
+          return [];
+        });
+    }
+
+    function getAmi(amiName, region, credentials) {
+      return oortEndpoint.all('aws/images').one(credentials).one(region).all(amiName).getList().then(function(results) {
+          return results && results.length ? results[0] : null;
+        },
+        function() {
+          return null;
+        });
+    }
+
+    return {
+      findImages: findImages,
+      getAmi: getAmi,
+    };
+  });

--- a/app/scripts/services/oortService.js
+++ b/app/scripts/services/oortService.js
@@ -156,27 +156,6 @@ angular.module('deckApp')
         });
     }
 
-    function findImages(query, region, credentials) {
-      if (query.length < 3) {
-        return $q.when([{message: 'Please enter at least 3 characters...'}]);
-      }
-      return oortEndpoint.all('aws/images/find').getList({imageName: query, region: region, credentials: credentials}, {}).then(function(results) {
-        return results;
-      },
-      function() {
-        return [];
-      });
-    }
-
-    function getAmi(amiName, region, credentials) {
-      return oortEndpoint.all('aws/images').one(credentials).one(region).all(amiName).getList().then(function(results) {
-        return results && results.length ? results[0] : null;
-      },
-      function() {
-        return null;
-      });
-    }
-
     function listLoadBalancers() {
       return oortEndpoint
         .all('aws/loadBalancers')
@@ -191,8 +170,6 @@ angular.module('deckApp')
     return {
       listApplications: listApplications,
       getApplication: getApplication,
-      findImages: findImages,
-      getAmi: getAmi,
       getInstanceDetails: getInstanceDetails,
       listLoadBalancers: listLoadBalancers,
       getApplicationWithoutAppendages: getApplicationEndpoint,

--- a/app/views/application/modal/serverGroup/aws/basicSettings.html
+++ b/app/views/application/modal/serverGroup/aws/basicSettings.html
@@ -44,6 +44,7 @@
                              refresh-delay="0">
             <span ng-bind-html="result.message"></span>
             <span ng-bind-html="result.imageName | highlight: $select.search"></span>
+            <span ng-if="result.amis[command.region][0]">(<span ng-bind-html="result.amis[command.region][0] | highlight: $select.search"></span>)</span>
           </ui-select-choices>
         </ui-select>
         <span ng-if="regionalImages.length > 0">
@@ -56,6 +57,7 @@
           <ui-select-match placeholder="Pick an image">{{$select.selected.imageName}}</ui-select-match>
           <ui-select-choices repeat="image.imageName as image in regionalImages | filter: $select.search | orderBy: '-imageName'">
             <span ng-bind-html="image.imageName | highlight: $select.search"></span>
+            (<span ng-bind-html="image.amis[command.region][0] | highlight: $select.search"></span>)
           </ui-select-choices>
         </ui-select>
         <a href ng-click="state.queryAllImages = true">Search All Images</a><help-field key="aws.serverGroup.allImages"></help-field>

--- a/test/spec/controllers/awsCloneServerGroupCtrl.js
+++ b/test/spec/controllers/awsCloneServerGroupCtrl.js
@@ -5,7 +5,7 @@ describe('Controller: awsCloneServerGroup', function () {
   beforeEach(loadDeckWithoutCacheInitializer);
 
   beforeEach(function() {
-    inject(function ($controller, $rootScope, accountService, orcaService, mortService, oortService, settings,
+    inject(function ($controller, $rootScope, accountService, orcaService, mortService, oortService, imageService, settings,
                      searchService, instanceTypeService, modalWizardService, securityGroupService, taskMonitorService, $q) {
 
       this.$scope = $rootScope.$new();
@@ -13,6 +13,7 @@ describe('Controller: awsCloneServerGroup', function () {
       this.orcaService = orcaService;
       this.mortService = mortService;
       this.oortService = oortService;
+      this.imageService = imageService;
       this.searchService = searchService;
       this.instanceTypeService = instanceTypeService;
       this.modalWizardService = modalWizardService;
@@ -64,6 +65,7 @@ describe('Controller: awsCloneServerGroup', function () {
           orcaService: this.orcaService,
           mortService: this.mortService,
           oortService: this.oortService,
+          imageService: this.imageService,
           searchService: this.searchService,
           instanceTypeService: this.instanceTypeService,
           modalWizardService: this.modalWizardService,
@@ -86,7 +88,7 @@ describe('Controller: awsCloneServerGroup', function () {
       spyOn(this.mortService, 'listKeyPairs').and.callFake(resolve([]));
       spyOn(this.securityGroupService, 'getAllSecurityGroups').and.callFake(resolve(SecurityGroupServiceFixture.allSecurityGroups));
       spyOn(this.oortService, 'listLoadBalancers').and.callFake(resolve([]));
-      spyOn(this.oortService, 'findImages').and.callFake(resolve([{amis: {'us-east-1': []}}]));
+      spyOn(this.imageService, 'findImages').and.callFake(resolve([{amis: {'us-east-1': []}}]));
 
       spyOn(this.searchService, 'search').and.callFake(resolve({results: []}));
       spyOn(this.modalWizardService, 'getWizard').and.returnValue(this.wizard);
@@ -216,6 +218,7 @@ describe('Controller: awsCloneServerGroup', function () {
           orcaService: this.orcaService,
           mortService: this.mortService,
           oortService: this.oortService,
+          imageService: this.imageService,
           searchService: this.searchService,
           instanceTypeService: this.instanceTypeService,
           modalWizardService: this.modalWizardService,
@@ -249,7 +252,7 @@ describe('Controller: awsCloneServerGroup', function () {
       var $scope = this.$scope;
       setupMocks.bind(this).call();
 
-      spyOn(this.oortService, 'findImages').and.callFake(this.resolve([]));
+      spyOn(this.imageService, 'findImages').and.callFake(this.resolve([]));
 
       initController();
 
@@ -264,7 +267,7 @@ describe('Controller: awsCloneServerGroup', function () {
           regionalImages = [{amis: {'us-east-1': []}}];
       setupMocks.bind(this).call();
 
-      spyOn(this.oortService, 'findImages').and.callFake(this.resolve(regionalImages));
+      spyOn(this.imageService, 'findImages').and.callFake(this.resolve(regionalImages));
 
       initController();
 
@@ -295,7 +298,7 @@ describe('Controller: awsCloneServerGroup', function () {
           };
       setupMocks.bind(this).call();
 
-      spyOn(this.oortService, 'findImages').and.callFake(function(query) {
+      spyOn(this.imageService, 'findImages').and.callFake(function(query) {
         if (query === 'something') {
           return context.resolve(packageBasedImages).call();
         } else {
@@ -303,7 +306,7 @@ describe('Controller: awsCloneServerGroup', function () {
         }
       });
 
-      spyOn(this.oortService, 'getAmi').and.callFake(this.resolve(amiBasedImage));
+      spyOn(this.imageService, 'getAmi').and.callFake(this.resolve(amiBasedImage));
 
       initController(serverGroup);
 
@@ -311,9 +314,9 @@ describe('Controller: awsCloneServerGroup', function () {
 
       expect($scope.state.imagesLoaded).toBe(true);
       expect($scope.state.queryAllImages).toBe(false);
-      expect(this.oortService.getAmi).toHaveBeenCalledWith(serverGroup.launchConfig.imageId, serverGroup.region, serverGroup.account);
-      expect(this.oortService.findImages).toHaveBeenCalledWith($scope.applicationName, serverGroup.region, serverGroup.account);
-      expect(this.oortService.findImages).toHaveBeenCalledWith('something', serverGroup.region, serverGroup.account);
+      expect(this.imageService.getAmi).toHaveBeenCalledWith(serverGroup.launchConfig.imageId, serverGroup.region, serverGroup.account);
+      expect(this.imageService.findImages).toHaveBeenCalledWith($scope.applicationName, serverGroup.region, serverGroup.account);
+      expect(this.imageService.findImages).toHaveBeenCalledWith('something', serverGroup.region, serverGroup.account);
       expect($scope.regionalImages).toEqual(packageBasedImages);
     });
 
@@ -322,8 +325,8 @@ describe('Controller: awsCloneServerGroup', function () {
           serverGroup = this.buildBaseClone();
       setupMocks.bind(this).call();
 
-      spyOn(this.oortService, 'findImages').and.callFake(this.resolve([]));
-      spyOn(this.oortService, 'getAmi').and.callFake(this.resolve(null));
+      spyOn(this.imageService, 'findImages').and.callFake(this.resolve([]));
+      spyOn(this.imageService, 'getAmi').and.callFake(this.resolve(null));
 
       initController(serverGroup);
 
@@ -331,8 +334,8 @@ describe('Controller: awsCloneServerGroup', function () {
 
       expect($scope.state.imagesLoaded).toBe(true);
       expect($scope.state.queryAllImages).toBe(true);
-      expect(this.oortService.getAmi).toHaveBeenCalledWith(serverGroup.launchConfig.imageId, serverGroup.region, serverGroup.account);
-      expect(this.oortService.findImages).toHaveBeenCalledWith($scope.applicationName, serverGroup.region, serverGroup.account);
+      expect(this.imageService.getAmi).toHaveBeenCalledWith(serverGroup.launchConfig.imageId, serverGroup.region, serverGroup.account);
+      expect(this.imageService.findImages).toHaveBeenCalledWith($scope.applicationName, serverGroup.region, serverGroup.account);
       expect($scope.regionalImages).toEqual([]);
     });
 
@@ -341,8 +344,8 @@ describe('Controller: awsCloneServerGroup', function () {
 
       setupMocks.bind(this).call();
 
-      spyOn(this.oortService, 'findImages').and.callFake(this.resolve([]));
-      spyOn(this.oortService, 'getAmi').and.callFake(this.resolve(null));
+      spyOn(this.imageService, 'findImages').and.callFake(this.resolve([]));
+      spyOn(this.imageService, 'getAmi').and.callFake(this.resolve(null));
 
       initController();
 
@@ -357,8 +360,8 @@ describe('Controller: awsCloneServerGroup', function () {
 
       setupMocks.bind(this).call();
 
-      spyOn(this.oortService, 'findImages').and.callFake(this.resolve([{imageName: 'something-packagebase', amis: {'us-east-1': ['ami-1234']}}]));
-      spyOn(this.oortService, 'getAmi').and.callFake(this.resolve(null));
+      spyOn(this.imageService, 'findImages').and.callFake(this.resolve([{imageName: 'something-packagebase', amis: {'us-east-1': ['ami-1234']}}]));
+      spyOn(this.imageService, 'getAmi').and.callFake(this.resolve(null));
 
       initController();
 
@@ -388,6 +391,7 @@ describe('Controller: awsCloneServerGroup', function () {
           orcaService: this.orcaService,
           mortService: this.mortService,
           oortService: this.oortService,
+          imageService: this.imageService,
           searchService: this.searchService,
           instanceTypeService: this.instanceTypeService,
           modalWizardService: this.modalWizardService,
@@ -416,8 +420,8 @@ describe('Controller: awsCloneServerGroup', function () {
       spyOn(this.modalWizardService, 'getWizard').and.returnValue(this.wizard);
 
       spyOn(this.instanceTypeService, 'getAvailableTypesForRegions').and.callFake(resolve([]));
-      spyOn(this.oortService, 'findImages').and.callFake(this.resolve([]));
-      spyOn(this.oortService, 'getAmi').and.callFake(this.resolve(null));
+      spyOn(this.imageService, 'findImages').and.callFake(this.resolve([]));
+      spyOn(this.imageService, 'getAmi').and.callFake(this.resolve(null));
 
       spyOn(this.orcaService, 'cloneServerGroup').and.callFake(function(command, applicationName, description) {
         spec.submitted = {

--- a/test/spec/services/imageService.spec.js
+++ b/test/spec/services/imageService.spec.js
@@ -16,15 +16,15 @@
 
 'use strict';
 
-describe('Service: Oort', function() {
+describe('Service: NamedImage', function() {
 
   var service, $http, config, scope, timeout;
 
   beforeEach(loadDeckWithoutCacheInitializer);
 
-  beforeEach(inject(function (settings, oortService, $httpBackend, $rootScope, $timeout) {
+  beforeEach(inject(function (settings, imageService, $httpBackend, $rootScope, $timeout) {
 
-    service = oortService;
+    service = imageService;
     config = settings;
     $http = $httpBackend;
     timeout = $timeout;
@@ -41,7 +41,7 @@ describe('Service: Oort', function() {
     var query = 'abc', region = 'us-west-1', credentials = 'test';
 
     function buildQueryString() {
-      return config.oortUrl + '/aws/images/find?credentials='+ credentials + '&imageName='+query + '&region=' + region;
+      return config.oortUrl + '/aws/images/find?account='+ credentials + '&q='+query + '&region=' + region;
     }
 
     it('queries oort when 3 or more characters are supplied', function() {


### PR DESCRIPTION
refactoring image stuff to imageService; this is definitely going to conflict with the other PR I have open to refactor the awsCloneServerGroupCtrl so I'll deal with it whenever one of them gets merged in.

**Dependent on changes in https://github.com/spinnaker/oort/pull/100 getting to main!!!**

will fix #269 and spinnaker/spinnaker#208
