### PR TITLE
Refactor imageService as we did instanceService and serverGroupService.

### DIFF
--- a/app/scripts/controllers/modal/ServerGroupBasicSettingsCtrl.js
+++ b/app/scripts/controllers/modal/ServerGroupBasicSettingsCtrl.js
@@ -19,7 +19,7 @@ angular.module('deckApp')
         }
       ];
       return new RxService.Observable.fromPromise(
-        imageService.findImages(q, $scope.command.region, $scope.command.credentials)
+        imageService.findImages($scope.command.selectedProvider, q, $scope.command.region, $scope.command.credentials)
       );
     }
 

--- a/app/scripts/controllers/modal/awsCloneServerGroupCtrl.js
+++ b/app/scripts/controllers/modal/awsCloneServerGroupCtrl.js
@@ -53,17 +53,17 @@ angular.module('deckApp.aws')
 
     $scope.command = serverGroupCommand;
 
-    var imageLoader = imageService.findImages(application.name, serverGroupCommand.region, serverGroupCommand.credentials).then(function(images) {
+    var imageLoader = imageService.findImages($scope.command.selectedProvider, application.name, serverGroupCommand.region, serverGroupCommand.credentials).then(function(images) {
       $scope.packageImages = images;
       if (images.length === 0) {
         if (serverGroupCommand.viewState.mode === 'clone') {
-          imageService.getAmi(serverGroupCommand.viewState.imageId, serverGroupCommand.region, serverGroupCommand.credentials).then(function (namedImage) {
+          imageService.getAmi($scope.command.selectedProvider, serverGroupCommand.viewState.imageId, serverGroupCommand.region, serverGroupCommand.credentials).then(function (namedImage) {
             if (namedImage) {
               var packageRegex = /(\w+)-?\w+/;
               $scope.command.amiName = namedImage.imageName;
               var match = packageRegex.exec(namedImage.imageName);
               $scope.packageBase = match[1];
-              imageService.findImages($scope.packageBase, serverGroupCommand.region, serverGroupCommand.credentials).then(function(searchResults) {
+              imageService.findImages($scope.command.selectedProvider, $scope.packageBase, serverGroupCommand.region, serverGroupCommand.credentials).then(function(searchResults) {
                 $scope.packageImages = searchResults;
                 $scope.state.imagesLoaded = true;
                 configureImages();

--- a/app/scripts/services/awsImageService.js
+++ b/app/scripts/services/awsImageService.js
@@ -1,0 +1,36 @@
+'use strict';
+
+
+angular.module('deckApp')
+  .factory('awsImageService', function (settings, $q, Restangular) {
+
+    var oortEndpoint = Restangular.withConfig(function(RestangularConfigurer) {
+      RestangularConfigurer.setBaseUrl(settings.oortUrl);
+    });
+
+    function findImages(query, region, account) {
+      if (query.length < 3) {
+        return $q.when([{message: 'Please enter at least 3 characters...'}]);
+      }
+      return oortEndpoint.all('aws/images/find').getList({q: query, region: region, account: account}, {}).then(function(results) {
+          return results;
+        },
+        function() {
+          return [];
+        });
+    }
+
+    function getAmi(amiName, region, credentials) {
+      return oortEndpoint.all('aws/images').one(credentials).one(region).all(amiName).getList().then(function(results) {
+          return results && results.length ? results[0] : null;
+        },
+        function() {
+          return null;
+        });
+    }
+
+    return {
+      findImages: findImages,
+      getAmi: getAmi,
+    };
+  });

--- a/app/scripts/services/gceImageService.js
+++ b/app/scripts/services/gceImageService.js
@@ -1,0 +1,22 @@
+'use strict';
+
+
+angular.module('deckApp')
+  .factory('gceImageService', function ($q) {
+
+    // TODO(duftler): Call oort once oort can return GCE images.
+    function findImages(query, region, account) {
+      return $q.when(['debian-7-wheezy-v20141108', 'centos-7-v20141108']);
+    }
+
+    // TODO(duftler): Call oort once oort can return GCE images.
+    // TODO(duftler): Rename getAmi() to getImage()?
+    function getAmi(amiName, region, credentials) {
+      return null;
+    }
+
+    return {
+      findImages: findImages,
+      getAmi: getAmi,
+    };
+  });

--- a/app/scripts/services/imageService.js
+++ b/app/scripts/services/imageService.js
@@ -2,31 +2,18 @@
 
 
 angular.module('deckApp')
-  .factory('imageService', function (settings, $q, Restangular) {
+  .factory('imageService', function (awsImageService, gceImageService) {
 
-    var oortEndpoint = Restangular.withConfig(function(RestangularConfigurer) {
-      RestangularConfigurer.setBaseUrl(settings.oortUrl);
-    });
-
-    function findImages(query, region, account) {
-      if (query.length < 3) {
-        return $q.when([{message: 'Please enter at least 3 characters...'}]);
-      }
-      return oortEndpoint.all('aws/images/find').getList({q: query, region: region, account: account}, {}).then(function(results) {
-          return results;
-        },
-        function() {
-          return [];
-        });
+    function getDelegate(provider) {
+      return (!provider || provider === 'aws') ? awsImageService : gceImageService;
     }
 
-    function getAmi(amiName, region, credentials) {
-      return oortEndpoint.all('aws/images').one(credentials).one(region).all(amiName).getList().then(function(results) {
-          return results && results.length ? results[0] : null;
-        },
-        function() {
-          return null;
-        });
+    function findImages(selectedProvider, query, region, account) {
+      return getDelegate(selectedProvider).findImages(query, region, account);
+    }
+
+    function getAmi(selectedProvider, amiName, region, credentials) {
+      return getDelegate(selectedProvider).getAmi(amiName, region, credentials);
     }
 
     return {

--- a/app/views/application/modal/serverGroup/gce/basicSettings.html
+++ b/app/views/application/modal/serverGroup/gce/basicSettings.html
@@ -40,7 +40,7 @@
                 ng-model="command.image"
                 ng-change="onChange()"
                 required>
-          <option ng-repeat="image in ['debian-7-wheezy-v20141108', 'centos-7-v20141108']"
+          <option ng-repeat="image in gceImages"
                   value="{{image}}"
                   ng-selected="command.image === image">{{image}}</option>
         </select>

--- a/test/spec/controllers/awsCloneServerGroupCtrl.js
+++ b/test/spec/controllers/awsCloneServerGroupCtrl.js
@@ -5,7 +5,7 @@ describe('Controller: awsCloneServerGroup', function () {
   beforeEach(loadDeckWithoutCacheInitializer);
 
   beforeEach(function() {
-    inject(function ($controller, $rootScope, accountService, orcaService, mortService, oortService, imageService, settings,
+    inject(function ($controller, $rootScope, accountService, orcaService, mortService, oortService, awsImageService, imageService, settings,
                      searchService, instanceTypeService, modalWizardService, securityGroupService, taskMonitorService, serverGroupService, $q) {
 
       this.$scope = $rootScope.$new();
@@ -13,6 +13,7 @@ describe('Controller: awsCloneServerGroup', function () {
       this.orcaService = orcaService;
       this.mortService = mortService;
       this.oortService = oortService;
+      this.awsImageService = awsImageService;
       this.imageService = imageService;
       this.searchService = searchService;
       this.instanceTypeService = instanceTypeService;
@@ -103,7 +104,7 @@ describe('Controller: awsCloneServerGroup', function () {
       spyOn(this.mortService, 'listKeyPairs').and.callFake(resolve([]));
       spyOn(this.securityGroupService, 'getAllSecurityGroups').and.callFake(resolve(SecurityGroupServiceFixture.allSecurityGroups));
       spyOn(this.oortService, 'listLoadBalancers').and.callFake(resolve([]));
-      spyOn(this.imageService, 'findImages').and.callFake(resolve([{amis: {'us-east-1': []}}]));
+      spyOn(this.awsImageService, 'findImages').and.callFake(resolve([{amis: {'us-east-1': []}}]));
 
       spyOn(this.searchService, 'search').and.callFake(resolve({results: []}));
       spyOn(this.modalWizardService, 'getWizard').and.returnValue(this.wizard);
@@ -232,7 +233,7 @@ describe('Controller: awsCloneServerGroup', function () {
       var $scope = this.$scope;
       setupMocks.bind(this).call();
 
-      spyOn(this.imageService, 'findImages').and.callFake(this.resolve([]));
+      spyOn(this.awsImageService, 'findImages').and.callFake(this.resolve([]));
 
       initController(this.buildBaseNew());
 
@@ -249,7 +250,7 @@ describe('Controller: awsCloneServerGroup', function () {
         ];
       setupMocks.bind(this).call();
 
-      spyOn(this.imageService, 'findImages').and.callFake(this.resolve(regionalImages));
+      spyOn(this.awsImageService, 'findImages').and.callFake(this.resolve(regionalImages));
 
       initController(this.buildBaseNew());
 
@@ -271,7 +272,7 @@ describe('Controller: awsCloneServerGroup', function () {
 
       serverGroup.region = 'us-east-1';
 
-      spyOn(this.imageService, 'findImages').and.callFake(function (query) {
+      spyOn(this.awsImageService, 'findImages').and.callFake(function (query) {
         if (query === 'something') {
           return context.resolve(packageBasedImages).call();
         } else {
@@ -279,7 +280,7 @@ describe('Controller: awsCloneServerGroup', function () {
         }
       });
 
-      spyOn(this.imageService, 'getAmi').and.callFake(this.resolve(amiBasedImage));
+      spyOn(this.awsImageService, 'getAmi').and.callFake(this.resolve(amiBasedImage));
 
       initController(serverGroup);
 
@@ -287,9 +288,9 @@ describe('Controller: awsCloneServerGroup', function () {
 
       expect($scope.state.imagesLoaded).toBe(true);
       expect($scope.command.viewState.useAllImageSelection).toBeFalsy();
-      expect(this.imageService.getAmi).toHaveBeenCalledWith(serverGroup.viewState.imageId, serverGroup.region, serverGroup.credentials);
-      expect(this.imageService.findImages).toHaveBeenCalledWith($scope.applicationName, serverGroup.region, serverGroup.credentials);
-      expect(this.imageService.findImages).toHaveBeenCalledWith('something', serverGroup.region, serverGroup.credentials);
+      expect(this.awsImageService.getAmi).toHaveBeenCalledWith(serverGroup.viewState.imageId, serverGroup.region, serverGroup.credentials);
+      expect(this.awsImageService.findImages).toHaveBeenCalledWith($scope.applicationName, serverGroup.region, serverGroup.credentials);
+      expect(this.awsImageService.findImages).toHaveBeenCalledWith('something', serverGroup.region, serverGroup.credentials);
       expect($scope.regionalImages.length).toBe(1);
       expect($scope.regionalImages[0]).toEqual({imageName: 'something-packagebase', ami: 'ami-1234'});
     });
@@ -299,8 +300,8 @@ describe('Controller: awsCloneServerGroup', function () {
         serverGroup = this.buildBaseClone();
       setupMocks.bind(this).call();
 
-      spyOn(this.imageService, 'findImages').and.callFake(this.resolve([]));
-      spyOn(this.imageService, 'getAmi').and.callFake(this.resolve(null));
+      spyOn(this.awsImageService, 'findImages').and.callFake(this.resolve([]));
+      spyOn(this.awsImageService, 'getAmi').and.callFake(this.resolve(null));
 
       initController(serverGroup);
 
@@ -308,8 +309,8 @@ describe('Controller: awsCloneServerGroup', function () {
 
       expect($scope.state.imagesLoaded).toBe(true);
       expect($scope.command.viewState.useAllImageSelection).toBe(true);
-      expect(this.imageService.getAmi).toHaveBeenCalledWith(serverGroup.viewState.imageId, serverGroup.region, serverGroup.credentials);
-      expect(this.imageService.findImages).toHaveBeenCalledWith($scope.applicationName, serverGroup.region, serverGroup.credentials);
+      expect(this.awsImageService.getAmi).toHaveBeenCalledWith(serverGroup.viewState.imageId, serverGroup.region, serverGroup.credentials);
+      expect(this.awsImageService.findImages).toHaveBeenCalledWith($scope.applicationName, serverGroup.region, serverGroup.credentials);
       expect($scope.regionalImages).toEqual([]);
     });
 
@@ -318,8 +319,8 @@ describe('Controller: awsCloneServerGroup', function () {
 
       setupMocks.bind(this).call();
 
-      spyOn(this.imageService, 'findImages').and.callFake(this.resolve([]));
-      spyOn(this.imageService, 'getAmi').and.callFake(this.resolve(null));
+      spyOn(this.awsImageService, 'findImages').and.callFake(this.resolve([]));
+      spyOn(this.awsImageService, 'getAmi').and.callFake(this.resolve(null));
 
       initController(this.buildBaseNew());
 

--- a/test/spec/services/imageService.spec.js
+++ b/test/spec/services/imageService.spec.js
@@ -51,7 +51,7 @@ describe('Service: NamedImage', function() {
         {success: true}
       ]);
 
-      service.findImages(query, region, credentials).then(function(results) {
+      service.findImages('aws', query, region, credentials).then(function(results) {
         result = results;
       });
 
@@ -66,7 +66,7 @@ describe('Service: NamedImage', function() {
         {success: true}
       ]);
 
-      service.findImages(query, region, credentials).then(function(results) {
+      service.findImages('aws', query, region, credentials).then(function(results) {
         result = results;
       });
 
@@ -81,7 +81,7 @@ describe('Service: NamedImage', function() {
 
       var result = null;
 
-      service.findImages(query, region, credentials).then(function(results) {
+      service.findImages('aws', query, region, credentials).then(function(results) {
         result = results;
       });
 
@@ -97,7 +97,7 @@ describe('Service: NamedImage', function() {
 
       $http.when('GET', buildQueryString()).respond(404, {});
 
-      service.findImages(query, region, credentials).then(function(results) {
+      service.findImages('aws', query, region, credentials).then(function(results) {
         result = results;
       });
 
@@ -119,7 +119,7 @@ describe('Service: NamedImage', function() {
 
       $http.when('GET', buildQueryString()).respond(404, {});
 
-      service.getAmi(imageName, region, credentials).then(function(results) {
+      service.getAmi('aws', imageName, region, credentials).then(function(results) {
         result = results;
       });
 
@@ -131,7 +131,7 @@ describe('Service: NamedImage', function() {
 
       $http.when('GET', buildQueryString()).respond(200, []);
 
-      service.getAmi(imageName, region, credentials).then(function(results) {
+      service.getAmi('aws', imageName, region, credentials).then(function(results) {
         result = results;
       });
 


### PR DESCRIPTION
Implement GCE-specific imageService delegate with hard-coded list.
Verify image id of cloned server group exists in retrieved list of images prior to marking BasicSettings 'Complete'.
Update unit tests to reflect imageService changes.
