### PR TITLE
Get regions and zones from gate/kato /credentials/{account} endpoint.

### DIFF
--- a/app/views/directives/gce/regionSelectField.html
+++ b/app/views/directives/gce/regionSelectField.html
@@ -8,7 +8,7 @@
             ng-model="component.region"
             ng-change="onChange()"
             required>
-      <option ng-repeat="region in ['us-central1', 'europe-west1', 'asia-east1']"
+      <option ng-repeat="region in regions"
               value="{{region}}"
               ng-selected="component[field] === region">{{region}}</option>
     </select>

--- a/app/views/directives/gce/zoneSelectField.html
+++ b/app/views/directives/gce/zoneSelectField.html
@@ -8,10 +8,7 @@
             ng-model="component.zone"
             ng-change="onChange()"
             required>
-      <option ng-repeat="zone in ['us-central1-a', 'us-central1-b', 'us-central1-f',
-                                  'europe-west1-a', 'europe-west1-b', 'europe-west1-c',
-                                  'asia-east1-a', 'asia-east1-b', 'asia-east1-c']
-                                 | filter:component.region"
+      <option ng-repeat="zone in zones"
               value="{{zone}}"
               ng-selected="component[field] === zone">{{zone}}</option>
     </select>


### PR DESCRIPTION
If regions are not returned with /credentials call, fallback behavior is to use same default regions/zones as before.
Once PR https://github.com/spinnaker/kato/pull/148 is merged, Regions and Zones will be dynamically-populated in the Create/Clone Server Group dialog (and the lists will reflect the permissions of the GCP Project associated with the selected Account).
