### PR TITLE
re-attach server groups on application refresh; fixes #287

### DIFF
--- a/app/scripts/directives/healthCounts.js
+++ b/app/scripts/directives/healthCounts.js
@@ -11,14 +11,19 @@ angular.module('deckApp')
         container: '='
       },
       link: function(scope) {
-        var container = scope.container,
+
+        function calculateHealthPercent() {
+          var container = scope.container,
             up = container.upCount,
             down = container.downCount,
             unknown = container.unknownCount,
             total = up + down + unknown;
 
-        scope.healthPercent = total ? parseInt(up*100/total) : 'n/a';
-        scope.healthPercentLabel = total ? '%' : '';
+          scope.healthPercent = total ? parseInt(up*100/total) : 'n/a';
+          scope.healthPercentLabel = total ? '%' : '';
+        }
+
+        scope.$watch('container', calculateHealthPercent);
       }
     };
   }

--- a/app/scripts/services/oortService.js
+++ b/app/scripts/services/oortService.js
@@ -93,6 +93,7 @@ angular.module('deckApp')
     function deepCopyApplication(original, newApplication) {
       original.accounts = newApplication.accounts;
       original.clusters = newApplication.clusters;
+      original.serverGroups = newApplication.serverGroups;
       original.loadBalancers = newApplication.loadBalancers;
       original.tasks = newApplication.tasks;
       original.securityGroups = newApplication.securityGroups;


### PR DESCRIPTION
Two things:
1. We were not re-attaching the server groups to the application on refresh, so we're doing that now, which solves most of the UI synchronization issues.
2. We were not updating the health percentage when it changed in the details, so we're doing that now.

I started to write tests for the health counts directive, but the `replace: true` makes it really hard to check DOM content, or at least made it hard enough that I gave up after 15 minutes.
