### PR TITLE
allow instances to be launched in disabled state

### DIFF
--- a/app/scripts/controllers/modal/ServerGroupAdvancedSettingsCtrl.js
+++ b/app/scripts/controllers/modal/ServerGroupAdvancedSettingsCtrl.js
@@ -14,4 +14,18 @@ angular.module('deckApp')
       }
     });
 
+    this.toggleSuspendedProcess = function(process) {
+      $scope.command.suspendedProcesses = $scope.command.suspendedProcesses || [];
+      var processIndex = $scope.command.suspendedProcesses.indexOf(process);
+      if (processIndex === -1) {
+        $scope.command.suspendedProcesses.push(process);
+      } else {
+        $scope.command.suspendedProcesses.splice(processIndex, 1);
+      }
+    };
+
+    this.processIsSuspended = function(process) {
+      return $scope.command.suspendedProcesses.indexOf(process) !== -1;
+    }
+
   });

--- a/app/scripts/services/awsServerGroupService.js
+++ b/app/scripts/services/awsServerGroupService.js
@@ -37,6 +37,7 @@ angular.module('deckApp')
           vpcId: null,
           availabilityZones: availabilityZones,
           keyPair: keyPair,
+          suspendedProcesses: [],
           viewState: {
             instanceProfile: null,
             allImageSelection: null,
@@ -85,6 +86,7 @@ angular.module('deckApp')
             region: serverGroup.region,
             asgName: serverGroup.asg.autoScalingGroupName,
           },
+          suspendedProcesses: _.pluck(serverGroup.asg.suspendedProcesses, 'processName'),
           viewState: {
             instanceProfile: 'custom',
             allImageSelection: null,

--- a/app/views/application/modal/serverGroup/aws/advancedSettings.html
+++ b/app/views/application/modal/serverGroup/aws/advancedSettings.html
@@ -101,6 +101,16 @@
         </label>
       </div>
     </div>
+    <div class="form-group">
+      <div class="col-md-5 sm-label-left"><b>Enable Traffic</b></div>
+      <div class="col-md-6 checkbox">
+        <label><input type="checkbox"
+                      ng-click="settingsCtrl.toggleSuspendedProcess('AddToLoadBalancer')"
+                      ng-checked="!settingsCtrl.processIsSuspended('AddToLoadBalancer')"/>
+          Send client requests to new instances
+        </label>
+      </div>
+    </div>
   </div>
 
   <div class="modal-footer">

--- a/test/spec/controllers/ServerGroupAdvancedSettingsCtrl.spec.js
+++ b/test/spec/controllers/ServerGroupAdvancedSettingsCtrl.spec.js
@@ -1,0 +1,65 @@
+'use strict';
+
+describe('Controller: ServerGroupAdvancedSettings', function () {
+
+  beforeEach(loadDeckWithoutCacheInitializer);
+
+  beforeEach(module('deckApp'));
+
+  beforeEach(inject(function ($controller, $rootScope, modalWizardService) {
+    this.scope = $rootScope.$new();
+
+    this.scope.command = {
+      suspendedProcesses: [],
+    };
+
+    this.wizard = jasmine.createSpyObj('wizard', ['markComplete', 'markClean', 'markDirty']);
+
+    spyOn(modalWizardService, 'getWizard').and.returnValue(this.wizard);
+
+    this.ctrl = $controller('ServerGroupAdvancedSettingsCtrl', {
+      $scope: this.scope,
+      modalWizardService: modalWizardService
+    });
+  }));
+
+
+  it('toggleSuspendedProcess adds suspended processes to command if absent, removes if present', function() {
+    var scope = this.scope,
+      command = scope.command;
+
+    expect(command.suspendedProcesses).toEqual([]);
+
+    this.ctrl.toggleSuspendedProcess('foo');
+    expect(command.suspendedProcesses).toEqual(['foo']);
+
+    this.ctrl.toggleSuspendedProcess('bar');
+    expect(command.suspendedProcesses).toEqual(['foo', 'bar']);
+
+    this.ctrl.toggleSuspendedProcess('baz');
+    expect(command.suspendedProcesses).toEqual(['foo', 'bar', 'baz']);
+
+    this.ctrl.toggleSuspendedProcess('bar');
+    expect(command.suspendedProcesses).toEqual(['foo', 'baz']);
+
+    this.ctrl.toggleSuspendedProcess('foo');
+    expect(command.suspendedProcesses).toEqual(['baz']);
+
+    this.ctrl.toggleSuspendedProcess('baz');
+    expect(command.suspendedProcesses).toEqual([]);
+  });
+
+  it('processIsSuspended returns true if process is in suspendedProcesses array, false otherwise', function() {
+    var scope = this.scope,
+      command = scope.command;
+
+    expect(command.suspendedProcesses).toEqual([]);
+    expect(this.ctrl.processIsSuspended('foo')).toBe(false);
+
+    command.suspendedProcesses = ['foo'];
+    expect(this.ctrl.processIsSuspended('foo')).toBe(true);
+    expect(this.ctrl.processIsSuspended('bar')).toBe(false);
+  });
+
+
+});


### PR DESCRIPTION
**Depends on https://github.com/spinnaker/oort/pull/107**

Adds a feature similar to Asgard, allowing users to create/clone a server group with instances disabled: not attached to load balancers, not enabled in Discovery.
