### PR TITLE
allow clicking anywhere in server group pod to load details; fixes #308

### DIFF
--- a/app/scripts/directives/serverGroup.js
+++ b/app/scripts/directives/serverGroup.js
@@ -2,7 +2,7 @@
 
 
 angular.module('deckApp')
-  .directive('serverGroup', function ($rootScope) {
+  .directive('serverGroup', function ($rootScope, $timeout) {
     return {
       restrict: 'E',
       replace: true,
@@ -12,8 +12,29 @@ angular.module('deckApp')
         serverGroup: '=',
         displayOptions: '='
       },
-      link: function (scope) {
+      link: function (scope, el) {
+        // stolen from uiSref directive
+        var base = el.parent().inheritedData('$uiView').state;
+
         scope.$state = $rootScope.$state;
+
+        scope.loadDetails = function(e) {
+          $timeout(function() {
+            var serverGroup = scope.serverGroup;
+            // anything handled by ui-sref or actual links should be ignored
+            if (e.isDefaultPrevented() || (e.originalEvent && e.originalEvent.target.href)) {
+              return;
+            }
+            var params = {
+              region: serverGroup.region,
+              accountId: serverGroup.account,
+              serverGroup: serverGroup.name
+            };
+            // also stolen from uiSref directive
+            scope.$state.go('.serverGroup', params, {relative: base, inherit: true});
+          });
+        };
+
         if (scope.serverGroup.isDisabled) {
           scope.serverGroup.instances.forEach(function(instance) {
             instance.healthStatus = 'Disabled';

--- a/app/views/application/cluster/serverGroup.html
+++ b/app/views/application/cluster/serverGroup.html
@@ -1,4 +1,5 @@
 <div class="row rollup-entry sub-group"
+     ng-click="loadDetails($event)"
      ng-class="{
         active: $state.includes('**.serverGroup', {region: serverGroup.region, accountId: serverGroup.account, serverGroup: serverGroup.name}),
         disabled: serverGroup.isDisabled


### PR DESCRIPTION
Allows users to click anywhere in the server group pod to load the details.

We sadly can't just attach the `ui-sref` directive to the container because of the way ui-sref works: it attaches a click handler to the element that bubbles up. So the last element that receives the click always wins, meaning you can't click on anything inside the pod.

This works around that by stealing a bunch of code (two lines) from the `ui-sref` directive itself and ignoring clicks on child links and elements that have a `ui-sref` attached to them (by seeing if the original target had called `preventDefault`).
