### PR TITLE
Use 'Std' instead of 'EBS'.

### DIFF
--- a/app/scripts/services/gceInstanceTypeService.js
+++ b/app/scripts/services/gceInstanceTypeService.js
@@ -9,6 +9,7 @@ angular.module('deckApp')
     var n1standard = {
       type: 'n1-standard',
       description: 'This family provides a balance of compute, memory, and network resources, and it is a good choice for general purpose applications.',
+      storageType: 'SSD',
       instanceTypes: [
         {
           name: 'n1-standard-1',
@@ -16,7 +17,6 @@ angular.module('deckApp')
           cpu: 1,
           memory: 3.75,
           storage: {
-            type: 'SSD',
             size: 20,
             count: 1
           },
@@ -28,7 +28,6 @@ angular.module('deckApp')
           cpu: 2,
           memory: 7.5,
           storage: {
-            type: 'SSD',
             size: 40,
             count: 1
           },
@@ -40,7 +39,6 @@ angular.module('deckApp')
           cpu: 4,
           memory: 15,
           storage: {
-            type: 'SSD',
             size: 40,
             count: 2
           },
@@ -52,7 +50,6 @@ angular.module('deckApp')
           cpu: 8,
           memory: 30,
           storage: {
-            type: 'SSD',
             size: 80,
             count: 2
           },
@@ -64,7 +61,6 @@ angular.module('deckApp')
           cpu: 16,
           memory: 60,
           storage: {
-            type: 'SSD',
             size: 160,
             count: 2
           },
@@ -76,6 +72,7 @@ angular.module('deckApp')
     var f1micro = {
       type: 'f1-micro bursting',
       description: 'This family of machine types is a good choice for small, non-resource intensive workloads that don’t use the full CPU often or consistently, but occasionally need to burst (e.g. web servers, developer environments and small databases).',
+      storageType: 'Std',
       instanceTypes: [
         {
           name: 'f1-micro',
@@ -83,7 +80,6 @@ angular.module('deckApp')
           cpu: 1,
           memory: 0.60,
           storage: {
-            type: 'Standard',
             size: 10,
             count: 1
           },
@@ -95,7 +91,6 @@ angular.module('deckApp')
           cpu: 1,
           memory: 1.70,
           storage: {
-            type: 'Standard',
             size: 10,
             count: 1
           },
@@ -107,6 +102,7 @@ angular.module('deckApp')
     var n1highmem = {
       type: 'n1-highmem',
       description: 'High memory machine types are ideal for tasks that require more memory relative to virtual cores. High memory machine types have 6.50GB of RAM per virtual core.',
+      storageType: 'SSD',
       instanceTypes: [
         {
           name: 'n1-highmem-2',
@@ -114,7 +110,6 @@ angular.module('deckApp')
           cpu: 2,
           memory: 13,
           storage: {
-            type: 'SSD',
             size: 40,
             count: 1
           },
@@ -126,7 +121,6 @@ angular.module('deckApp')
           cpu: 4,
           memory: 26,
           storage: {
-            type: 'SSD',
             size: 80,
             count: 1
           },
@@ -138,7 +132,6 @@ angular.module('deckApp')
           cpu: 8,
           memory: 52,
           storage: {
-            type: 'SSD',
             size: 160,
             count: 1
           },
@@ -150,7 +143,6 @@ angular.module('deckApp')
           cpu: 16,
           memory: 104,
           storage: {
-            type: 'SSD',
             size: 320,
             count: 1
           },
@@ -162,6 +154,7 @@ angular.module('deckApp')
     var n1highcpu = {
       type: 'n1-highcpu',
       description: 'High CPU machine types are ideal for tasks that require more virtual cores relative to memory. High CPU machine types have one virtual core for every 0.90GB of RAM.',
+      storageType: 'SSD',
       instanceTypes: [
         {
           name: 'n1-highcpu-2',
@@ -169,7 +162,6 @@ angular.module('deckApp')
           cpu: 2,
           memory: 1.80,
           storage: {
-            type: 'SSD',
             size: 20,
             count: 2
           },
@@ -181,7 +173,6 @@ angular.module('deckApp')
           cpu: 4,
           memory: 3.60,
           storage: {
-            type: 'SSD',
             size: 40,
             count: 2
           },
@@ -193,7 +184,6 @@ angular.module('deckApp')
           cpu: 8,
           memory: 7.20,
           storage: {
-            type: 'SSD',
             size: 80,
             count: 2
           },
@@ -205,7 +195,6 @@ angular.module('deckApp')
           cpu: 16,
           memory: 14.4,
           storage: {
-            type: 'SSD',
             size: 160,
             count: 2
           },

--- a/app/views/application/modal/serverGroup/gce/instanceType.html
+++ b/app/views/application/modal/serverGroup/gce/instanceType.html
@@ -13,7 +13,7 @@
             <th>Size</th>
             <th>vCPU</th>
             <th>Mem (GiB)</th>
-            <th>SSD Storage (GB)</th>
+            <th>{{family.storageType}} Storage (GB)</th>
             <th>Cost</th>
           </tr>
           </thead>
@@ -26,8 +26,7 @@
               <td>{{instanceType.label}}</td>
               <td>{{instanceType.cpu}}</td>
               <td>{{instanceType.memory}}</td>
-              <td ng-if="instanceType.storage.type === 'EBS'">EBS Only</td>
-              <td ng-if="instanceType.storage.type === 'SSD'">{{instanceType.storage.count}}&times;{{instanceType.storage.size}}</td>
+              <td>{{instanceType.storage.count}}&times;{{instanceType.storage.size}}</td>
               <td><span class="label-cost label-cost-{{instanceType.costFactor}}"></span><span class="sr-only">{{instanceType.costFactor}}&times;</span></td>
             </tr>
           </tbody>


### PR DESCRIPTION
Promote storageType to Family.
Make instanceType view set storage heading based on family.storageType.
@rbuskens please have a look to verify your edits are displayed properly.
![image](https://cloud.githubusercontent.com/assets/8437718/5321138/6fed9236-7c86-11e4-856c-53eb4ad0d1f4.png)
![image](https://cloud.githubusercontent.com/assets/8437718/5321168/c569e5e8-7c86-11e4-828c-efed0867c58a.png)
![image](https://cloud.githubusercontent.com/assets/8437718/5321169/c999697c-7c86-11e4-98ad-275d2188f921.png)
![image](https://cloud.githubusercontent.com/assets/8437718/5321171/d20be4b8-7c86-11e4-9a7b-cde841e111a8.png)
