### PR TITLE
allow filtering by email; restore sort by header functionality

### DIFF
--- a/app/scripts/controllers/applications.js
+++ b/app/scripts/controllers/applications.js
@@ -2,11 +2,13 @@
 
 
 angular.module('deckApp')
-  .controller('ApplicationsCtrl', function($scope, $exceptionHandler, $modal, $log, $filter, RxService, accountService, front50, notifications, oortService, orcaService, searchService, urlBuilder, $state, $timeout) {
+  .controller('ApplicationsCtrl', function($scope, $exceptionHandler, $modal, $log, $filter, accountService,
+                                           notifications, oortService, orcaService, urlBuilder, $state,
+                                           $timeout) {
 
     $scope.applicationsLoaded = false;
 
-    $scope.sorting = {
+    $scope.sortModel = {
       sortKey: 'name',
       reverse: false
     };
@@ -62,20 +64,9 @@ angular.module('deckApp')
       }
     ];
 
-    searchService.search('oort', {q:'', type: 'applications', pageSize:100000}).then(function(searchResults) {
-      if (!$scope.applications) {
-        $scope.applications = searchResults.results.map(function (app) {
-          return {name: app.application};
-        });
-        ctrl.filterApplications();
-        $scope.partiallyLoaded = true;
-        $scope.applicationsLoaded = true;
-      }
-    });
-
     this.filterApplications = function filterApplications() {
-      var filtered = $filter('filter')($scope.applications, {name: $scope.applicationFilter}),
-        sorted = $filter('orderBy')(filtered, $scope.sorting.sortKey, $scope.sorting.reverse);
+      var filtered = $filter('anyFieldFilter')($scope.applications, {name: $scope.applicationFilter, email: $scope.applicationFilter}),
+        sorted = $filter('orderBy')(filtered, $scope.sortModel.sortKey, $scope.sortModel.reverse);
       $scope.filteredApplications = sorted;
       this.resetPaginator();
     };
@@ -111,8 +102,6 @@ angular.module('deckApp')
       $scope.applications = applications;
       ctrl.filterApplications();
       $scope.applicationsLoaded = true;
-      $scope.partiallyLoaded = false;
-      $scope.fullyLoaded = true;
     });
 
   }

--- a/app/scripts/controllers/sorttoggle.js
+++ b/app/scripts/controllers/sorttoggle.js
@@ -21,6 +21,9 @@ angular.module('deckApp')
     ctrl.setSortKey = function (key) {
       $scope.model.sortKey = key;
       $scope.model.reverse = ctrl.isSortKey(key) ? !$scope.model.reverse : false;
+      if ($scope.onChange) {
+        $scope.onChange();
+      }
     };
 
     ctrl.isSortKey = function (key) {

--- a/app/views/applications.html
+++ b/app/views/applications.html
@@ -29,30 +29,15 @@
       <span class="glyphicon glyphicon-asterisk glyphicon-spinning"></span>
     </h2>
     <table ng-if="applicationsLoaded" class="table table-striped">
-      <thead ng-if="partiallyLoaded">
+      <thead>
         <tr>
-          <th sort-toggle key="name" label="Name" default="true"></th>
-          <th class="loading-header"><span class="glyphicon glyphicon-asterisk glyphicon-spinning"></span> Loading: Created, Updated, Owner</th>
+          <th sort-toggle key="name" label="Name" default="true" on-change="ctrl.filterApplications()"></th>
+          <th sort-toggle key="createTs" label="Created" on-change="ctrl.filterApplications()"></th>
+          <th sort-toggle key="updateTs" label="Updated" on-change="ctrl.filterApplications()"></th>
+          <th sort-toggle key="email" label="Owner" on-change="ctrl.filterApplications()"></th>
         </tr>
       </thead>
-      <tbody ng-if="partiallyLoaded">
-        <tr ng-repeat="application in ctrl.resultPage()">
-          <td>
-            <a ui-sref=".application({ application: application.name })">
-              {{ application.name }}
-            </a>
-          </td>
-        </tr>
-      </tbody>
-      <thead ng-if="fullyLoaded">
-        <tr>
-          <th sort-toggle key="name" label="Name" default="true"></th>
-          <th sort-toggle key="attributes.createTs" label="Created"></th>
-          <th sort-toggle key="attributes.updateTs" label="Updated"></th>
-          <th sort-toggle key="attributes.email" label="Owner"></th>
-        </tr>
-      </thead>
-      <tbody ng-if="fullyLoaded">
+      <tbody>
         <tr ng-repeat="application in ctrl.resultPage()">
           <td>
             <a ui-sref=".application({ application: application.name.toLowerCase() })">

--- a/test/spec/controllers/applications.controller.spec.js
+++ b/test/spec/controllers/applications.controller.spec.js
@@ -1,0 +1,101 @@
+'use strict';
+
+describe('Controller: Applications', function () {
+
+  beforeEach(loadDeckWithoutCacheInitializer);
+
+  beforeEach(module('deckApp'));
+
+  describe('filtering', function() {
+
+    var deck = { name: 'deck', email: 'a@netflix.com', createTs: new Date(2) },
+        oort = { name: 'oort', email: 'b@netflix.com', createTs: new Date(3) },
+        mort = { name: 'mort', email: 'c@netflix.com', createTs: new Date(1) },
+        applicationList = [ deck, oort, mort ];
+
+    // Initialize the controller and a mock scope
+    beforeEach(inject(function ($controller, $rootScope, $window, $q, $modal, $log, $filter, accountService, notifications,
+                                oortService, orcaService, urlBuilder, $state, $timeout, settings) {
+
+      this.$scope = $rootScope.$new();
+      this.oortService = oortService;
+      this.settings = settings;
+      this.$q = $q;
+      this.accountService = accountService;
+
+      spyOn(this.oortService, 'listApplications').and.callFake(function () {
+        return $q.when(applicationList);
+      });
+
+      spyOn(this.accountService, 'listAccounts').and.callFake(function() {
+        return $q.when([]);
+      });
+
+      this.ctrl = $controller('ApplicationsCtrl', {
+        $scope: this.$scope,
+        $modal: $modal,
+        $log: $log,
+        $filter: $filter,
+        accountService: accountService,
+        notifications: notifications,
+        oortService: oortService,
+        orcaService: orcaService,
+        urlBuilder: orcaService,
+        $state: $state,
+        $timeout: $timeout
+      });
+
+    }));
+
+    it('sets applicationsLoaded flag when applications retrieved and added to scope', function () {
+      var $scope = this.$scope;
+
+      expect($scope.applicationsLoaded).toBe(false);
+      expect($scope.applications).toBeUndefined();
+
+      $scope.$digest();
+
+      expect($scope.applicationsLoaded).toBe(true);
+      expect($scope.applications).toBe(applicationList);
+      expect($scope.filteredApplications).toEqual([deck, mort, oort]);
+
+    });
+
+    it('filters applications by name or email', function () {
+      var $scope = this.$scope,
+          ctrl = this.ctrl;
+
+      $scope.applicationFilter = 'a@netflix.com';
+      $scope.$digest();
+      expect($scope.applications).toBe(applicationList);
+      expect($scope.filteredApplications).toEqual([deck]);
+
+      $scope.applicationFilter = 'ort';
+      ctrl.filterApplications();
+      expect($scope.filteredApplications).toEqual([mort, oort]);
+    });
+
+    it('sorts and filters applications', function() {
+      var $scope = this.$scope,
+          ctrl = this.ctrl;
+
+      $scope.sortModel.reverse = true;
+      $scope.$digest();
+      expect($scope.filteredApplications).toEqual([oort, mort, deck]);
+
+      $scope.sortModel.sortKey = 'createTs';
+      ctrl.filterApplications();
+      expect($scope.filteredApplications).toEqual([oort, deck, mort]);
+
+      $scope.sortModel.reverse = false;
+      ctrl.filterApplications();
+      expect($scope.filteredApplications).toEqual([mort, deck, oort]);
+
+      $scope.applicationFilter = 'ort';
+      ctrl.filterApplications();
+      expect($scope.filteredApplications).toEqual([mort, oort]);
+    });
+
+
+  });
+});


### PR DESCRIPTION
Fixes spinnaker/spinnaker#256

Also removing the intermediate application list load from oort's search. Gate's /applications endpoint is very fast now; we don't really need to do this now.
