### PR TITLE
better resolution of images on clone

### DIFF
--- a/app/scripts/services/awsImageService.js
+++ b/app/scripts/services/awsImageService.js
@@ -9,10 +9,17 @@ angular.module('deckApp')
     });
 
     function findImages(query, region, account) {
+      var params = {q: query};
+      if (region) {
+        params.region = region;
+      }
+      if (account) {
+        params.account = account;
+      }
       if (query.length < 3) {
         return $q.when([{message: 'Please enter at least 3 characters...'}]);
       }
-      return oortEndpoint.all('aws/images/find').getList({q: query, region: region}, {}).then(function(results) {
+      return oortEndpoint.all('aws/images/find').getList(params, {}).then(function(results) {
           return results;
         },
         function() {


### PR DESCRIPTION
Right now, we're basically doing it wrong when looking up images - both during create and clone operations.

On clone, we only get images based on the **application name** and **region**. We should be getting images based on **package name** only. Otherwise, if the user switches from region _A_ to region _B_, we'll only show them images that happen to be in both _A_ and _B_ - definitely not good. 

Also, if some images match the application name, but the ASG they're cloning is using an AMI with a different package name, that AMI will not be provided and they'll have to do a lot more forensic work to find the correct AMI. It's been noted correctly as a regression from Asgard.

I've added an optional `nflx-` prefix to the package matcher. This is against Frigga conventions but that's how a number of apps (e.g. evcache, api) are rolling right now. In the current state, we'll match against `nflx`, which returns about 1400 images.
