### PR TITLE
gceImageService now does a call to /images/find with {provider: 'gce', a...

### DIFF
--- a/app/scripts/services/ServerGroupConfigurationService.js
+++ b/app/scripts/services/ServerGroupConfigurationService.js
@@ -11,7 +11,7 @@ angular.module('deckApp')
       if (command.viewState.disableImageSelection) {
         imageLoader = $q.when(null);
       } else {
-        imageLoader = command.viewState.imageId ? loadImagesFromAmi(command) : loadImagesFromApplicationName(application, command.selectedProvider);
+        imageLoader = command.viewState.imageId ? loadImagesFromAmi(command) : loadImagesFromApplicationName(application, command.selectedProvider, command.region, command.credentials);
       }
 
       return $q.all({
@@ -31,8 +31,8 @@ angular.module('deckApp')
       });
     }
 
-    function loadImagesFromApplicationName(application, provider) {
-      return imageService.findImages(provider, application.name);
+    function loadImagesFromApplicationName(application, provider, region, account) {
+      return imageService.findImages(provider, application.name, region, account);
     }
 
     function loadImagesFromAmi(command) {
@@ -44,7 +44,7 @@ angular.module('deckApp')
           var match = packageRegex.exec(namedImage.imageName);
           var packageBase = match[1];
 
-          return imageService.findImages(command.selectedProvider, packageBase);
+          return imageService.findImages(command.selectedProvider, packageBase, command.region, command.credentials);
         },
         function() {
           return [];

--- a/app/scripts/services/awsImageService.js
+++ b/app/scripts/services/awsImageService.js
@@ -20,6 +20,7 @@ angular.module('deckApp')
       if (query.length < 3) {
         return $q.when([{message: 'Please enter at least 3 characters...'}]);
       }
+
       return gateEndpoint.all('images/find').withHttpConfig({cache: scheduledCache}).getList(params, {}).then(function(results) {
           return results;
         },

--- a/app/scripts/services/gceImageService.js
+++ b/app/scripts/services/gceImageService.js
@@ -9,7 +9,7 @@ angular.module('deckApp')
     });
 
     function findImages(query, region, account) {
-      return gateEndpoint.all('images/' + account).getList({provider: 'gce'}, {}).then(function(results) {
+      return gateEndpoint.all('images/find').getList({account: account, provider: 'gce'}, {}).then(function(results) {
           return results;
         },
         function() {

--- a/test/spec/controllers/awsCloneServerGroupCtrl.js
+++ b/test/spec/controllers/awsCloneServerGroupCtrl.js
@@ -291,7 +291,7 @@ describe('Controller: awsCloneServerGroup', function () {
 
       expect($scope.command.viewState.useAllImageSelection).toBeFalsy();
       expect(this.imageService.getAmi).toHaveBeenCalledWith('aws', serverGroup.viewState.imageId, serverGroup.region, serverGroup.credentials);
-      expect(this.imageService.findImages).toHaveBeenCalledWith('aws', 'something');
+      expect(this.imageService.findImages).toHaveBeenCalledWith('aws', 'something', 'us-east-1', 'prod');
 
       expect($scope.command.backingData.filtered.images.length).toBe(1);
       expect($scope.command.backingData.filtered.images[0]).toEqual({imageName: 'something-packagebase', ami: 'ami-1234'});


### PR DESCRIPTION
...ccount: account}.
- Had to make a couple minor changes to get region and account passed to findImages.

https://github.com/spinnaker/gate/issues/34
