### PR TITLE
extend model instead of deep copying

### DIFF
--- a/app/scripts/modules/clusterFilter/clusterFilterService.js
+++ b/app/scripts/modules/clusterFilter/clusterFilterService.js
@@ -214,7 +214,7 @@ angular
 
     function sortGroupsByHeading(groups) {
       var sortedGroups = _.sortBy(groups, 'heading');
-      angular.copy(sortedGroups,ClusterFilterModel.groups) ;
+      angular.extend(ClusterFilterModel.groups, sortedGroups) ;
     }
 
     function setDisplayOptions(totalInstancesDisplayed) {


### PR DESCRIPTION
That `copy` call does a deep copy and often takes 6 to 7 seconds.

Seems like we don't need to deep copy, just assign the `sortedGroups` to the model's `groups`
