### PR TITLE
truncate ClusterFilterModelGroups and add new ones

### DIFF
--- a/app/scripts/modules/clusterFilter/clusterFilterService.js
+++ b/app/scripts/modules/clusterFilter/clusterFilterService.js
@@ -214,7 +214,10 @@ angular
 
     function sortGroupsByHeading(groups) {
       var sortedGroups = _.sortBy(groups, 'heading');
-      angular.extend(ClusterFilterModel.groups, sortedGroups) ;
+      ClusterFilterModel.groups.length = 0;
+      sortedGroups.forEach(function(group) {
+        ClusterFilterModel.groups.push(group);
+      });
     }
 
     function setDisplayOptions(totalInstancesDisplayed) {


### PR DESCRIPTION
Fixes https://github.com/spinnaker/deck/issues/396

`angular.extend` is wrong. `ClusterFilterModel.groups` is an array; we just need to clear it out and add the new sorted groups, which is what this does in 0-1ms.
