### PR TITLE
Use stage type as name if no name or name is "null"

### DIFF
--- a/app/scripts/modules/delivery/pipelineExecutions.controller.js
+++ b/app/scripts/modules/delivery/pipelineExecutions.controller.js
@@ -81,6 +81,13 @@ angular.module('deckApp.delivery')
     };
 
     executionsService.getAll().then(function(e) {
+      e.forEach(function(execution) {
+        execution.stages.forEach(function(stage) {
+          if (!stage.name || stage.name === 'null') {
+            stage.name = stage.type;
+          }
+        });
+      });
       $scope.filter.stage.max = e.reduce(function(acc, execution) {
         return execution.stages.length > acc ? execution.stages.length : acc;
       }, 0);


### PR DESCRIPTION
Stage `name` is optional in the configuration screens, so default to the `type` field if `name` is not present.

If it is present and has a value of "null", also use the type.
