### PR TITLE
hack for broken start times; normalized status

### DIFF
--- a/app/scripts/modules/delivery/executionDetails.html
+++ b/app/scripts/modules/delivery/executionDetails.html
@@ -28,8 +28,8 @@
               ng-class="{ current: ctrl.isStageCurrent(stage) }">
             <td>{{ stage.name }}</td>
             <td>
-              <span class="label label-default label-{{ stage.status | lowercase }}">
-                {{ stage.status }}
+              <span class="label label-default label-{{ stage.normalizedStatus | lowercase }}">
+                {{ stage.normalizedStatus }}
               </span>
             </td>
             <td>{{ stage.startTime | relativeTime }}</td>

--- a/app/scripts/modules/delivery/executionStatus.html
+++ b/app/scripts/modules/delivery/executionStatus.html
@@ -18,20 +18,8 @@
     </ul>
   </div>
   <div class="col-md-5">
-    <span ng-switch="execution.status.toLowerCase()">
+    <span ng-switch="execution.normalizedStatus.toLowerCase()">
       <span ng-switch-when="failed">
-        <span>
-          <h5 class="status status-failed">
-            FAILED
-          </h5>
-          <ul>
-            <li>
-              {{ ctrl.getFailedStage(execution) }}
-            </li>
-          </ul>
-        </span>
-      </span>
-      <span ng-switch-when="terminal">
         <span>
           <h5 class="status status-failed">
             FAILED

--- a/app/scripts/modules/delivery/executions.filter.js
+++ b/app/scripts/modules/delivery/executions.filter.js
@@ -7,8 +7,7 @@ angular.module('deckApp.delivery')
         .filter(function(execution) {
           return [
             // execution status is not filtered
-            filter.execution.status[execution.status.toLowerCase()] ||
-              filter.execution.status.failed && execution.status.toLowerCase() === 'terminal',
+            filter.execution.status[execution.normalizedStatus.toLowerCase()],
 
             // not grouped
             !filter.execution.groupBy ||

--- a/app/scripts/modules/delivery/executionsService.js
+++ b/app/scripts/modules/delivery/executionsService.js
@@ -27,6 +27,18 @@ angular.module('deckApp.delivery')
       return deferred.promise;
     }
 
+    function fixStageTime(stage) {
+      if (stage.tasks && stage.tasks.length) {
+        stage.startTime = stage.tasks[0].startTime;
+      }
+    }
+
+    function fixExecutionTime(execution) {
+      if (execution.stages && execution.stages.length) {
+        execution.startTime = execution.stages[0].startTime;
+      }
+    }
+
     function getExecutions() {
       var deferred = $q.defer();
       $http({
@@ -36,6 +48,12 @@ angular.module('deckApp.delivery')
           executions.forEach(function(execution) {
             orchestratedItem.defineProperties(execution);
             execution.stages.forEach(orchestratedItem.defineProperties);
+
+            // TODO: Remove when https://github.com/spinnaker/orca/issues/167 is resolved
+            execution.stages.forEach(fixStageTime);
+            fixExecutionTime(execution);
+            // end TODO
+
             Object.defineProperty(execution, 'currentStage', {
               get: function() {
                 if (execution.isCompleted) {

--- a/app/scripts/modules/delivery/pipelineExecutions.controller.js
+++ b/app/scripts/modules/delivery/pipelineExecutions.controller.js
@@ -36,7 +36,6 @@ angular.module('deckApp.delivery')
 
     $scope.statusDisplayNames = {
       'failed': 'Failed',
-      'terminal': 'Failed',
       //'not_started': 'Not Started',
       'running': 'Running',
       'completed': 'Completed',
@@ -49,8 +48,8 @@ angular.module('deckApp.delivery')
       status: d3Service
         .scale
         .ordinal()
-        .domain(['succeeded', 'failed', 'terminal', 'running', 'not_started'])
-        .range(['#c0d89d', '#b82525', '#b82525', '#2275b8', '#ffffff']),
+        .domain(['completed', 'failed', 'running', 'not_started'])
+        .range(['#c0d89d', '#b82525','#2275b8', '#ffffff']),
     };
 
     controller.solo = function(facet, value) {

--- a/app/scripts/modules/delivery/stages.filter.js
+++ b/app/scripts/modules/delivery/stages.filter.js
@@ -5,9 +5,9 @@ angular.module('deckApp.delivery')
     return function(stages, filter) {
       return stages.filter(function(stage) {
         return filter.stage.name[stage.name] &&
-          filter.stage.status[stage.status.toLowerCase()] ||
+          filter.stage.status[stage.normalizedStatus.toLowerCase()] ||
           (filter.stage.scale === 'fixed' &&
-             stage.status.toLowerCase() === 'not_started' &&
+             stage.normalizedStatus.toLowerCase() === 'not_started' &&
              filter.stage.name[stage.name]);
       });
     };

--- a/app/scripts/services/orchestratedItem.js
+++ b/app/scripts/services/orchestratedItem.js
@@ -29,6 +29,24 @@ angular.module('deckApp')
             return item.status === 'NOT_STARTED';
           }
         },
+        normalizedStatus: {
+          get: function() {
+            switch(item.status) {
+              case 'COMPLETED':
+              case 'SUCCEEDED':
+                return 'COMPLETED';
+              case 'STARTED':
+              case 'EXECUTING':
+              case 'RUNNING':
+                return 'RUNNING';
+              case 'FAILED':
+              case 'TERMINAL':
+                return 'FAILED';
+              default:
+                return item.status;
+            }
+          }
+        },
         runningTime: {
           get: function() {
             return momentService

--- a/app/styles/pipelines.less
+++ b/app/styles/pipelines.less
@@ -63,13 +63,13 @@
       }
 
     }
-    .label-succeeded, .label-completed {
+    .label-completed {
       background-color: @healthy_green_border;
     }
     .label-failed {
       background-color: @unhealthy_red;
     }
-    .label-started, .label-running, .label-executing {
+    .label-running {
       background-color: @spinnaker-blue;
     }
   }


### PR DESCRIPTION
Two things:
1. Start times are incorrect in Orca (https://github.com/spinnaker/orca/issues/167) and I'm not sure if they'll be fixed before tomorrow's CloudU. This is a temporary isolated hack to use the start time of the first task for stages and executions as the start time of the execution.
2. We are not consistently dealing with the eight or nine different status options and I think there are really just three (possibly four when we get to "not started") we want to deal with: running, completed, failed.
