### PR TITLE
normalize status everywhere

### DIFF
--- a/app/scripts/filters/pipelineExecutionStatus.js
+++ b/app/scripts/filters/pipelineExecutionStatus.js
@@ -15,10 +15,7 @@ angular.module('deckApp')
         case 'COMPLETED':
           return 'COMPLETED';
         case 'FAILED':
-        case 'STOPPED':
           return getStageMatching(execution, 'FAILED')[0];
-        case 'STARTED':
-          return getStageMatching(execution, 'RUNNING')[0];
         case 'RUNNING':
           return getStageMatching(execution, 'RUNNING')[0];
       }

--- a/app/scripts/filters/tasks.js
+++ b/app/scripts/filters/tasks.js
@@ -13,11 +13,11 @@ angular.module('deckApp')
           });
         case 'Completed':
           return tasks.filter(function(task) {
-            return task.status === 'SUCCEEDED';
+            return task.status === 'COMPLETED';
           });
         case 'Errored':
           return tasks.filter(function(task) {
-            return task.status === 'FAILED' || task.status === 'TERMINAL' || task.status === 'SUSPENDED';
+            return task.status === 'FAILED';
           });
         default:
           return tasks;

--- a/app/scripts/modules/delivery/executions.filter.js
+++ b/app/scripts/modules/delivery/executions.filter.js
@@ -7,7 +7,7 @@ angular.module('deckApp.delivery')
         .filter(function(execution) {
           return [
             // execution status is not filtered
-            filter.execution.status[execution.normalizedStatus.toLowerCase()],
+            filter.execution.status[execution.status.toLowerCase()],
 
             // not grouped
             !filter.execution.groupBy ||

--- a/app/scripts/modules/delivery/stages.filter.js
+++ b/app/scripts/modules/delivery/stages.filter.js
@@ -5,9 +5,9 @@ angular.module('deckApp.delivery')
     return function(stages, filter) {
       return stages.filter(function(stage) {
         return filter.stage.name[stage.name] &&
-          filter.stage.status[stage.normalizedStatus.toLowerCase()] ||
+          filter.stage.status[stage.status.toLowerCase()] ||
           (filter.stage.scale === 'fixed' &&
-             stage.normalizedStatus.toLowerCase() === 'not_started' &&
+             stage.status.toLowerCase() === 'not_started' &&
              filter.stage.name[stage.name]);
       });
     };

--- a/app/scripts/services/orchestratedItem.js
+++ b/app/scripts/services/orchestratedItem.js
@@ -1,50 +1,41 @@
 'use strict';
 
 angular.module('deckApp')
-  .factory('orchestratedItem', function(momentService) {
+  .factory('orchestratedItem', function(momentService, $log) {
     function defineProperties(item) {
+      var testDescriptor = Object.getOwnPropertyDescriptor(item, 'runningTime');
+      if (testDescriptor && !testDescriptor.enumerable) {
+        return;
+      }
+
+      item.originalStatus = item.status;
       Object.defineProperties(item, {
         isCompleted: {
           get: function() {
-            return item.status === 'COMPLETED' || item.status === 'SUCCEEDED';
+            return item.status === 'COMPLETED';
           },
         },
         isRunning: {
           get: function() {
-            return item.status === 'STARTED' || item.status === 'EXECUTING' || item.status === 'RUNNING';
+            return item.status === 'RUNNING';
           },
         },
         isFailed: {
           get: function() {
-            return item.status === 'FAILED' || item.status === 'STOPPED' || item.status === 'TERMINAL';
+            return item.status === 'FAILED';
           },
-        },
-        isStopped: {
-          get: function() {
-            return item.status === 'STOPPED';
-          }
         },
         hasNotStarted: {
           get: function() {
             return item.status === 'NOT_STARTED';
           }
         },
-        normalizedStatus: {
-          get: function() {
-            switch(item.status) {
-              case 'COMPLETED':
-              case 'SUCCEEDED':
-                return 'COMPLETED';
-              case 'STARTED':
-              case 'EXECUTING':
-              case 'RUNNING':
-                return 'RUNNING';
-              case 'FAILED':
-              case 'TERMINAL':
-                return 'FAILED';
-              default:
-                return item.status;
-            }
+        status: {
+          // Returns either COMPLETED, RUNNING, FAILED, or NOT_STARTED
+          get: function() { return normalizeStatus(item); },
+          set: function(status) {
+            item.originalStatus = status;
+            normalizeStatus(item);
           }
         },
         runningTime: {
@@ -55,6 +46,28 @@ angular.module('deckApp')
           }
         }
       });
+    }
+
+    function normalizeStatus(item) {
+      switch(item.originalStatus) {
+        case 'COMPLETED':
+        case 'SUCCEEDED':
+          return 'COMPLETED';
+        case 'STARTED':
+        case 'EXECUTING':
+        case 'RUNNING':
+          return 'RUNNING';
+        case 'FAILED':
+        case 'TERMINAL':
+        case 'STOPPED':
+        case 'SUSPENDED':
+          return 'FAILED';
+        case 'NOT_STARTED':
+          return 'NOT_STARTED';
+        default:
+          $log.warn('Unrecognized status:', item.originalStatus);
+          return item.originalStatus;
+      }
     }
 
     return {

--- a/app/scripts/services/pond.js
+++ b/app/scripts/services/pond.js
@@ -2,44 +2,7 @@
 
 
 angular.module('deckApp')
-  .factory('pond', function(settings, Restangular, momentService, urlBuilder, $timeout, $q, kato, $exceptionHandler) {
-    function setStatusProperties(item) {
-      Object.defineProperties(item, {
-        isEnqueued: {
-          get: function() {
-            return item.status === 'NOT_STARTED' || item.status === 'STARTED';
-          }
-        },
-        isCompleted: {
-          get: function() {
-            return item.status === 'COMPLETED' || item.status === 'SUCCEEDED';
-          },
-        },
-        isRunning: {
-          get: function() {
-            return item.status === 'RUNNING';
-          },
-        },
-        isFailed: {
-          get: function() {
-            return item.status === 'FAILED' || item.status === 'STOPPED' || item.status === 'TERMINAL';
-          },
-        },
-        isStopped: {
-          get: function() {
-            return item.status === 'STOPPED';
-          }
-        },
-        runningTime: {
-          get: function() {
-            var endTime = item.status === 'STARTED' ? new Date() : parseInt(item.endTime) || parseInt(item.startTime);
-            return momentService
-              .duration(endTime - parseInt(item.startTime))
-              .humanize();
-          }
-        }
-      });
-    }
+  .factory('pond', function(settings, Restangular, momentService, urlBuilder, $timeout, $q, kato, $exceptionHandler, orchestratedItem) {
 
     function getKatoTasks(task) {
       return task.getValueFor('kato.tasks');
@@ -167,7 +130,7 @@ angular.module('deckApp')
         if (task.isCompleted) {
           deferred.resolve(task);
         }
-        if ((task.isRunning || task.isEnqueued) && !deferred.promise.cancelled) {
+        if (task.isRunning && !deferred.promise.cancelled) {
           $timeout(function () {
             task.get().then(function (updatedTask) {
               updateTask(task, updatedTask);

--- a/app/scripts/services/taskTracker.js
+++ b/app/scripts/services/taskTracker.js
@@ -18,7 +18,7 @@ angular.module('deckApp')
             return oldTask.id !== task.id;
           });
           var hasBeenSeenIncomplete = oldTasks.some(function(oldTask) {
-            return oldTask.id === task.id && oldTask.status === 'STARTED';
+            return oldTask.id === task.id && oldTask.status === 'RUNNING';
           });
           return hasNotBeenSeen || hasBeenSeenIncomplete;
         });
@@ -32,14 +32,14 @@ angular.module('deckApp')
 
     that.getFailed = function getFailed(oldTasks, newTasks) {
       return that.getTasksMatchingPred(oldTasks, newTasks, function(task) {
-        return task.status === 'FAILED' || task.status === 'STOPPED';
+        return task.status === 'FAILED';
       });
     };
 
     that.forceRefreshFromTasks = function forceRefreshFromTasks(tasks) {
       if (tasks.some(function(task) {
         return task.steps.some(function(step) {
-          return step.name === 'ForceCacheRefreshStep';
+          return step.name === 'forceCacheRefresh';
         });
       })) {
         scheduler.scheduleImmediate();

--- a/test/fixture/tasks.js
+++ b/test/fixture/tasks.js
@@ -123,7 +123,7 @@ TasksFixture.secondSnapshot = [
     ],
     steps: [
       {
-        name: 'ForceCacheRefreshStep',
+        name: 'forceCacheRefresh',
       }
     ],
   },
@@ -142,7 +142,7 @@ TasksFixture.secondSnapshot = [
     ],
     steps: [
       {
-        name: 'ForceCacheRefreshStep',
+        name: 'forceCacheRefresh',
       }
     ],
   },
@@ -161,7 +161,7 @@ TasksFixture.secondSnapshot = [
     ],
     steps: [
       {
-        name: 'ForceCacheRefreshStep',
+        name: 'forceCacheRefresh',
       }
     ],
   },
@@ -180,7 +180,7 @@ TasksFixture.secondSnapshot = [
     ],
     steps: [
       {
-        name: 'ForceCacheRefreshStep',
+        name: 'forceCacheRefresh',
       }
     ],
   },
@@ -199,7 +199,7 @@ TasksFixture.secondSnapshot = [
     ],
     steps: [
       {
-        name: 'ForceCacheRefreshStep',
+        name: 'forceCacheRefresh',
       }
     ],
   }

--- a/test/spec/filters/tasks.js
+++ b/test/spec/filters/tasks.js
@@ -4,12 +4,14 @@
 
 describe('Filter: taskFilter', function() {
   beforeEach(function() {
-    this.tasks = TasksFixture.secondSnapshot;
     module('deckApp');
   });
 
-  beforeEach(inject(function(taskFilterFilter) {
+  beforeEach(inject(function(taskFilterFilter, orchestratedItem) {
     this.taskFilter = taskFilterFilter;
+    this.tasks = TasksFixture.secondSnapshot;
+    this.tasks.forEach(orchestratedItem.defineProperties);
+
   }));
 
 
@@ -19,22 +21,22 @@ describe('Filter: taskFilter', function() {
     });
 
     it('should return only "RUNNING" task if "Running" selected', function() {
-      var filteredList = (this.taskFilter(this.tasks, 'Running'))
+      var filteredList = (this.taskFilter(this.tasks, 'Running'));
       expect(filteredList.length).toBe(1);
       expect(filteredList[0].status).toEqual('RUNNING');
     });
 
-    it('should return SUCCEEDED tasks if "Completed" selected', function () {
+    it('should return COMPLETED tasks if "Completed" selected', function () {
       var filteredList = (this.taskFilter(this.tasks, 'Completed'));
-      expect(filteredList.length).toBe(1);
-      expect(filteredList[0].status).toEqual('SUCCEEDED');
+      expect(filteredList.length).toBe(4);
+      expect(filteredList[0].status).toEqual('COMPLETED');
     });
 
-    it('should return FAILED and TERMINAL tasks if "Errored" selected', function () {
+    it('should return FAILED tasks if "Errored" selected', function () {
       var filteredList = (this.taskFilter(this.tasks, 'Errored'));
-      expect(filteredList.length).toBe(3);
+      expect(filteredList.length).toBe(4);
       filteredList.forEach(function(task) {
-        expect(['FAILED', 'TERMINAL', 'SUSPENDED']).toContain(task.status);
+        expect(['FAILED']).toContain(task.status);
       });
     });
 
@@ -42,29 +44,29 @@ describe('Filter: taskFilter', function() {
 
     it('treats SUSPENDED tests like FAILED ones', function() {
       expect(this.tasks.some(function(task) {
-        return task.status === 'FAILED';
+        return task.originalStatus === 'FAILED';
       })).toBe(true);
 
       expect(this.tasks.some(function(task) {
-        return task.status === 'SUSPENDED';
+        return task.originalStatus === 'SUSPENDED';
       })).toBe(true);
 
       expect(this.tasks.some(function(task) {
-        return task.status !== 'SUSPENDED' || task.status !== 'FAILED';
+        return task.originalStatus !== 'SUSPENDED' || task.originalStatus !== 'FAILED';
       })).toBe(true);
 
       var filtered = this.taskFilter(this.tasks, 'Errored');
 
       expect(filtered.some(function(task) {
-        return task.status === 'FAILED';
+        return task.originalStatus === 'FAILED';
       })).toBe(true);
 
       expect(filtered.some(function(task) {
-        return task.status === 'SUSPENDED';
+        return task.originalStatus === 'SUSPENDED';
       })).toBe(true);
 
       expect(filtered.every(function(task) {
-        return task.status === 'SUSPENDED' || task.status === 'FAILED' || task.status === 'TERMINAL';
+        return task.originalStatus === 'SUSPENDED' || task.originalStatus === 'FAILED' || task.originalStatus === 'TERMINAL' || task.originalStatus === 'STOPPED';
       })).toBe(true);
     });
   });

--- a/test/spec/services/pond.js
+++ b/test/spec/services/pond.js
@@ -125,7 +125,7 @@ describe('Service: Pond - task complete, task force refresh', function() {
       requestHandler.respond(200, { id: 1, status: 'STOPPED' });
       cycle();
       expect(result.id).toBe(1);
-      expect(result.status).toBe('STOPPED');
+      expect(result.status).toBe('FAILED');
     });
 
 
@@ -147,7 +147,7 @@ describe('Service: Pond - task complete, task force refresh', function() {
         id: 1,
         status: 'RUNNING',
         steps: [{
-          name: 'ForceCacheRefreshStep',
+          name: 'forceCacheRefresh',
           status: 'STARTED'
         }]
       });
@@ -159,7 +159,7 @@ describe('Service: Pond - task complete, task force refresh', function() {
         id: 1,
         status: 'RUNNING',
         steps: [{
-          name: 'ForceCacheRefreshStep',
+          name: 'forceCacheRefresh',
           status: 'COMPLETED'
         }]
       });
@@ -187,7 +187,7 @@ describe('Service: Pond - task complete, task force refresh', function() {
         id: 1,
         status: 'RUNNING',
         steps: [{
-          name: 'ForceCacheRefreshStep',
+          name: 'forceCacheRefresh',
           status: 'STARTED'
         }]
       });
@@ -199,7 +199,7 @@ describe('Service: Pond - task complete, task force refresh', function() {
         id: 1,
         status: 'RUNNING',
         steps: [{
-          name: 'ForceCacheRefreshStep',
+          name: 'forceCacheRefresh',
           status: 'FAILED'
         }]
       });
@@ -240,7 +240,7 @@ describe('Service: Pond - task complete, task force refresh', function() {
         id: 1,
         status: 'RUNNING',
         steps: [{
-          name: 'ForceCacheRefreshStep',
+          name: 'forceCacheRefresh',
           status: 'STARTED'
         }]
       });

--- a/test/spec/services/taskTracker.js
+++ b/test/spec/services/taskTracker.js
@@ -11,9 +11,6 @@ describe('Service: taskTracker', function() {
       scheduleImmediate: angular.noop,
     };
 
-    this.initialSnapshot = TasksFixture.initialSnapshot;
-    this.secondSnapshot = TasksFixture.secondSnapshot;
-
     spyOn(notifications, 'create');
     spyOn(scheduler, 'scheduleImmediate');
 
@@ -28,8 +25,14 @@ describe('Service: taskTracker', function() {
     this.scheduler = scheduler;
   });
 
-  beforeEach(inject(function(taskTracker) {
+  beforeEach(inject(function(taskTracker, orchestratedItem) {
     this.taskTracker = taskTracker;
+
+    this.initialSnapshot = TasksFixture.initialSnapshot;
+    this.secondSnapshot = TasksFixture.secondSnapshot;
+    this.initialSnapshot.forEach(orchestratedItem.defineProperties);
+    this.secondSnapshot.forEach(orchestratedItem.defineProperties);
+
   }));
 
   describe('getCompleted(old, new)', function() {
@@ -56,11 +59,11 @@ describe('Service: taskTracker', function() {
   });
 
   describe('forceRefreshFromTasks(tasks)', function() {
-    it('checks for a task that has a ForceCacheRefreshStep', function() {
+    it('checks for a task that has a forceCacheRefresh Step', function() {
       function checkForForceCacheRefresh(tasks) {
         return tasks.some(function(task) {
           return task.steps.some(function(step) {
-            return step.name === 'ForceCacheRefreshStep';
+            return step.name === 'forceCacheRefresh';
           });
         });
       }
@@ -72,7 +75,7 @@ describe('Service: taskTracker', function() {
 
     });
 
-    it('calls scheduler.scheduleImmediate when a ForceCacheRefreshStep is found', function() {
+    it('calls scheduler.scheduleImmediate when a forceCacheRefresh Step is found', function() {
       this.taskTracker.forceRefreshFromTasks(this.initialSnapshot);
       expect(this.scheduler.scheduleImmediate).not.toHaveBeenCalled();
 


### PR DESCRIPTION
I started down this road yesterday but this is wrapping it up and making the `status` field the one to use - it's confusing the have `normalizedStatus` everywhere and know to use it.

Instead, we're assigning the `status` to an `originalStatus` field.

Also updating `ForceCacheRefreshStep` to `forceCacheRefresh`, which isn't working right now on Oort, anyway, but will someday. I'll disable the checks for that step in a separate PR.

This resolves https://github.com/spinnaker/deck/issues/405
