### PR TITLE
infrastructure level caches

### DIFF
--- a/app/scripts/services/accountService.js
+++ b/app/scripts/services/accountService.js
@@ -2,7 +2,7 @@
 
 
 angular.module('deckApp')
-  .factory('accountService', function(settings, Restangular, $q, scheduledCache) {
+  .factory('accountService', function(settings, Restangular, $q, scheduledCache, infrastructureCaches) {
 
     var credentialsEndpoint = Restangular.withConfig(function(RestangularConfigurer) {
       RestangularConfigurer.setBaseUrl(settings.gateUrl);
@@ -68,7 +68,7 @@ angular.module('deckApp')
     function listAccounts() {
       return credentialsEndpoint
         .all('credentials')
-        .withHttpConfig({cache: scheduledCache})
+        .withHttpConfig({cache: infrastructureCaches.credentials})
         .getList();
     }
 
@@ -79,7 +79,7 @@ angular.module('deckApp')
           acc[account] = credentialsEndpoint
             .all('credentials')
             .one(account)
-            .withHttpConfig({cache: scheduledCache})
+            .withHttpConfig({cache: infrastructureCaches.credentials})
             .get();
           return acc;
         }, {})).then(function(result) {
@@ -90,7 +90,9 @@ angular.module('deckApp')
     }
 
     function getAccountDetails(accountName) {
-      return credentialsEndpoint.one('credentials', accountName).get();
+      return credentialsEndpoint.one('credentials', accountName)
+        .withHttpConfig({cache: infrastructureCaches.credentials})
+        .get();
     }
 
     function getRegionsForAccount(accountName) {

--- a/app/scripts/services/cacheInitializer.js
+++ b/app/scripts/services/cacheInitializer.js
@@ -1,11 +1,17 @@
 'use strict';
 
 angular.module('deckApp')
-  .factory('cacheInitializer', function(accountService, instanceTypeService) {
+  .factory('cacheInitializer', function(accountService, instanceTypeService, oortService, securityGroupService, mortService) {
     return {
       initialize: function() {
         accountService.getRegionsKeyedByAccount();
+        accountService.listAccounts();
         instanceTypeService.getAllTypesByRegion('aws');
+        oortService.listAWSLoadBalancers();
+        securityGroupService.getAllSecurityGroups();
+        mortService.listSubnets();
+        mortService.listVpcs();
+        mortService.listKeyPairs();
       }
     };
   });

--- a/app/scripts/services/infrastructureCaches.js
+++ b/app/scripts/services/infrastructureCaches.js
@@ -1,0 +1,20 @@
+'use strict';
+
+angular.module('deckApp')
+  .factory('infrastructureCaches', function($cacheFactory) {
+
+    var caches = {};
+
+    function addCache(cacheId) {
+      $cacheFactory(cacheId);
+      caches[cacheId] = $cacheFactory.get(cacheId);
+    }
+
+    addCache('credentials');
+    addCache('vpcs');
+    addCache('subnets');
+    addCache('loadBalancers');
+    addCache('securityGroups');
+
+    return caches;
+  });

--- a/app/scripts/services/mortService.js
+++ b/app/scripts/services/mortService.js
@@ -2,7 +2,7 @@
 
 
 angular.module('deckApp')
-  .factory('mortService', function (settings, $q, Restangular) {
+  .factory('mortService', function (settings, $q, Restangular, infrastructureCaches) {
 
     var subnetsCache = [],
         vpcsCache = [],
@@ -17,7 +17,9 @@ angular.module('deckApp')
         return $q.when(subnetsCache);
       } else {
         var deferred = $q.defer();
-        endpoint.all('subnets').getList().then(function(list) {
+        endpoint.all('subnets')
+          .withHttpConfig({cache: infrastructureCaches.subnets})
+          .getList().then(function(list) {
           subnetsCache = list;
           deferred.resolve(list);
         });
@@ -30,7 +32,9 @@ angular.module('deckApp')
         return $q.when(vpcsCache);
       } else {
         var deferred = $q.defer();
-        endpoint.all('vpcs').getList().then(function(list) {
+        endpoint.all('vpcs')
+          .withHttpConfig({cache: infrastructureCaches.vpcs})
+          .getList().then(function(list) {
           vpcsCache = list;
           deferred.resolve(list);
         });
@@ -43,7 +47,9 @@ angular.module('deckApp')
         return $q.when(keyPairsCache);
       } else {
         var deferred = $q.defer();
-        endpoint.all('keyPairs').getList().then(function(list) {
+        endpoint.all('keyPairs')
+          .withHttpConfig({cache: infrastructureCaches.keyPairs})
+          .getList().then(function(list) {
           keyPairsCache = list;
           deferred.resolve(list);
         });

--- a/app/scripts/services/oortService.js
+++ b/app/scripts/services/oortService.js
@@ -4,7 +4,7 @@
 angular.module('deckApp')
   .factory('oortService', function (searchService, settings, $q, Restangular, _, $timeout,
                                     clusterService, loadBalancerService, pond, securityGroupService,
-                                    scheduler, taskTracker, $exceptionHandler, scheduledCache) {
+                                    scheduler, taskTracker, $exceptionHandler, infrastructureCaches) {
 
     var gateEndpoint = Restangular.withConfig(function(RestangularConfigurer) {
       RestangularConfigurer.setBaseUrl(settings.gateUrl);
@@ -154,7 +154,7 @@ angular.module('deckApp')
     function listAWSLoadBalancers() {
       return gateEndpoint
         .all('loadBalancers')
-        .withHttpConfig({cache: scheduledCache })
+        .withHttpConfig({cache: infrastructureCaches.loadBalancers})
         .getList({provider: 'aws'});
     }
 

--- a/app/scripts/services/orcaService.js
+++ b/app/scripts/services/orcaService.js
@@ -2,7 +2,7 @@
 
 
 angular.module('deckApp')
-  .factory('orcaService', function(settings, Restangular, scheduler, notifications, urlBuilder, pond, $q, authenticationService, scheduledCache) {
+  .factory('orcaService', function(settings, Restangular, scheduler, notifications, urlBuilder, pond, $q, authenticationService, scheduledCache, infrastructureCaches) {
 
     var endpoint = Restangular.withConfig(function(RestangularConfigurer) {
       RestangularConfigurer.setBaseUrl(settings.gateUrl);
@@ -149,7 +149,7 @@ angular.module('deckApp')
 
     function upsertSecurityGroup(securityGroup, applicationName, descriptor) {
       securityGroup.type = 'upsertSecurityGroup';
-      scheduledCache.removeAll();
+      infrastructureCaches.securityGroups.removeAll();
       return executeTask({
         job: [
           securityGroup
@@ -183,7 +183,7 @@ angular.module('deckApp')
     }
 
     function deleteLoadBalancer(loadBalancer, applicationName) {
-      scheduledCache.removeAll();
+      infrastructureCaches.loadBalancers.removeAll();
       return executeTask({
         job: [
           {

--- a/app/scripts/services/securityGroupService.js
+++ b/app/scripts/services/securityGroupService.js
@@ -2,7 +2,7 @@
 
 
 angular.module('deckApp')
-  .factory('securityGroupService', function (searchService, settings, $q, Restangular, _, $exceptionHandler, scheduledCache, notifications) {
+  .factory('securityGroupService', function (searchService, settings, $q, Restangular, _, $exceptionHandler, scheduledCache, infrastructureCaches, notifications) {
 
     var mortEndpoint = Restangular.withConfig(function (RestangularConfigurer) {
       RestangularConfigurer.setBaseUrl(settings.gateUrl);
@@ -16,7 +16,7 @@ angular.module('deckApp')
         securityGroupPromises.push(
           mortEndpoint.all('securityGroups')
             .one(account)
-            .withHttpConfig({cache: scheduledCache})
+            .withHttpConfig({cache: infrastructureCaches.securityGroups})
             .get()
             .then(
               function(groups) {
@@ -142,7 +142,9 @@ angular.module('deckApp')
     }
 
     function getAllSecurityGroups() {
-      return mortEndpoint.one('securityGroups').withHttpConfig({cache: scheduledCache}).get();
+      return mortEndpoint.one('securityGroups')
+        .withHttpConfig({cache: infrastructureCaches.securityGroups})
+        .get();
     }
 
     function getApplicationSecurityGroup(application, account, region, id) {


### PR DESCRIPTION
Provide separate caches for the common components that don't change often, and initialize them asynchronously on application startup.

It would be nice to put these into local storage down the road, with a TTL of an hour or something, but that gets messy when things need to be invalidated. For now, this should be an improvement.
