### PR TITLE
Allow columns to scroll independently; fix round corners on search

### DIFF
--- a/app/styles/details.less
+++ b/app/styles/details.less
@@ -28,30 +28,8 @@
 }
 
 .details-panel {
-  position: fixed;
-  top: 150px;
-  bottom: 0;
-  overflow-y: hidden;
-  width: 240px;
-
-  @media (max-width:768px) {
-    top: 130px;
-    margin-left: -25px;
-    width: 95%;
-  }
-
-  @media(min-width: 768px) and (max-width: 992px) {
-    top: 190px;
-    width: 210px;
-  }
-
-  @media(min-width: 992px) {
-    width: 220px;
-  }
-  @media(min-width: 1200px) {
-    width: 240px;
-  }
-
+  display: flex;
+  flex-direction: column;
   border: 1px solid #aaaaaa;
   border-bottom-width: 0;
   border-top-left-radius: 5px;
@@ -75,13 +53,12 @@
   }
 
   .content {
+    flex: 1 0 100px;
     overflow-y: auto;
-    padding-bottom: 135px;
-    height: 100%;
-
   }
 
   .header {
+    flex: none;
     padding: 20px 15px 0 15px;
     margin-bottom: 10px;
     .header-text {

--- a/app/styles/main.less
+++ b/app/styles/main.less
@@ -65,8 +65,84 @@ body {
   border-top: 1px solid @mid_grey;
 }
 
+.insight {
+  .nav, .nav-content, .details-panel {
+    position: fixed;
+    top: 150px;
+    bottom: 0;
+    overflow-y: auto;
+    overflow-x: hidden;
+  }
+  .nav {
+    margin-left: -15px;
+    @media(min-width: 768px) and (max-width: 992px) {
+      width: 180px;
+    }
+
+    @media(min-width: 992px) {
+      width: 200px;
+    }
+    @media(min-width: 1200px) {
+      width: 230px;
+    }
+    @media(min-width: 1400px) {
+      width: 260px;
+    }
+  }
+  .nav-content {
+    margin-left: 15px;
+    @media (max-width:768px) {
+      width: 70%;
+    }
+
+    @media(min-width: 768px) and (max-width: 992px) {
+      width: 500px;
+    }
+
+    @media(min-width: 992px) {
+      width: 540px;
+    }
+    @media(min-width: 1200px) {
+      width: 630px;
+    }
+    @media(min-width: 1400px) {
+      width: 750px;
+    }
+  }
+  .details-panel {
+    overflow-y: hidden;
+    @media (max-width:768px) {
+      top: 170px;
+      margin-left: -25px;
+      width: 95%;
+    }
+
+    @media(min-width: 768px) and (max-width: 992px) {
+      top: 190px;
+      width: 210px;
+    }
+
+    @media(min-width: 992px) {
+      width: 220px;
+    }
+    @media(min-width: 1200px) {
+      width: 240px;
+    }
+    @media(min-width: 1400px) {
+      width: 310px;
+    }
+  }
+}
+
 .no-padding {
   padding: 0;
+}
+
+.flat {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
 }
 
 .inactive-sort-key {

--- a/app/styles/navigation.less
+++ b/app/styles/navigation.less
@@ -17,14 +17,14 @@
 @import "app/styles/imports/commonImports.less";
 
 .secondary-panel {
-  .nav, .nav-content {
-    min-height: 300px;
-  }
   .nav {
     padding: 0 0 0 10px;
     background-color: @secondary_panel_grey;
     border: 1px solid @mid_light_grey;
     border-radius: 5px;
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+    border-bottom-width: 0;
 
     h3 {
       margin-right: 10px;

--- a/app/styles/tasks.less
+++ b/app/styles/tasks.less
@@ -60,6 +60,11 @@
   @media(min-width: 992px) {
     .details-panel {
       width: 34% !important;
+      position: fixed;
+      top: 150px;
+      bottom: 0;
+      overflow-y: auto;
+      overflow-x: hidden;
     }
   }
   @media(max-width: 992px) {

--- a/app/views/globalsearch.html
+++ b/app/views/globalsearch.html
@@ -3,7 +3,7 @@
     <div class="form-group has-feedback">
       <div class="input-group">
         <input type="search"
-          class="form-control"
+          class="form-control flat"
           placeholder="Search"
           ng-model="query"
           ng-focus="ctrl.displayResults()"

--- a/app/views/insight.html
+++ b/app/views/insight.html
@@ -1,13 +1,13 @@
-<div class="row">
+<div class="row insight">
   <div class="col-md-9 col-sm-8">
     <div class="row">
 
-      <div class="col-md-3 nav hidden-sm hidden-xs" ng-hide="insight.isSideNavHideable">
-        <div ui-view="nav"></div>
+      <div class="col-md-3 hidden-sm hidden-xs" ng-hide="insight.isSideNavHideable">
+        <div ui-view="nav" class="nav"></div>
       </div>
 
-      <div class="col-md-9 nav-content">
-        <div ui-view="master"></div>
+      <div class="col-md-9">
+        <div ui-view="master" class="nav-content"></div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
We've heard from several people that they didn't realize that the details column is scrollable and thought the content was just stuck offscreen.

This change makes all three columns independently scrollable, which feels a lot more intuitive. Scrolling on the far right side of the screen won't do anything now - you actually need to scroll within the section you want to scroll.

The header of the details panel is still static, but the headers for the other panels are not (they will scroll away), which I don't _think_ is a big deal, but we'll see.

The CSS is about as messy or a tiny bit less messy than it was before. There's surely a cleaner way to handle this but I'm not going to spend two days trying to figure it out. If anyone has bandwidth and wants to take a crack at it, you won't hurt my feelings one bit.

Also squaring the other two corners on the global search just because.
![screen shot 2015-01-08 at 8 28 56 pm](https://cloud.githubusercontent.com/assets/73450/5675527/0db7fcfa-9775-11e4-9687-17151608b83c.png)
