### PR TITLE
allow scroll trigger to fire on elements

### DIFF
--- a/app/scripts/directives/instances.js
+++ b/app/scripts/directives/instances.js
@@ -10,7 +10,8 @@ angular.module('deckApp')
       scope: {
         instances: '=',
         renderInstancesOnScroll: '=',
-        highlight: '='
+        highlight: '=',
+        scrollTarget: '@',
       },
       link: function (scope, elem) {
         scope.$state = scope.$parent.$state;
@@ -25,7 +26,7 @@ angular.module('deckApp')
 
         if (scope.renderInstancesOnScroll) {
           scope.displayedInstances = [];
-          scrollTriggerService.register(scope, elem, showAllInstances);
+          scrollTriggerService.register(scope, elem, scope.scrollTarget, showAllInstances);
         } else {
           showAllInstances();
         }

--- a/app/scripts/modules/clusterFilter/clusterFilterService.js
+++ b/app/scripts/modules/clusterFilter/clusterFilterService.js
@@ -228,7 +228,7 @@ angular
 
     function setDisplayOptions(totalInstancesDisplayed) {
       var newOptions =  {
-        renderInstancesOnScroll: totalInstancesDisplayed > 2000, // TODO: move to config
+        renderInstancesOnScroll: totalInstancesDisplayed > 1000, // TODO: move to config
         totalInstancesDisplayed: totalInstancesDisplayed,
         showInstances: ClusterFilterModel.sortFilter.showAllInstances,
         hideHealthy: ClusterFilterModel.sortFilter.hideHealthy,

--- a/app/views/application/cluster/serverGroup.html
+++ b/app/views/application/cluster/serverGroup.html
@@ -38,7 +38,7 @@
       <span ng-if="serverGroup.isDisabled" class="badge badge-disabled">disabled</span>
     </div>
     <div ng-if="displayOptions.showInstances">
-      <instances highlight="displayOptions.filter" instances="serverGroup.instances" render-instances-on-scroll="displayOptions.renderInstancesOnScroll"></instances>
+      <instances highlight="displayOptions.filter" scroll-target="nav-content" instances="serverGroup.instances" render-instances-on-scroll="displayOptions.renderInstancesOnScroll"></instances>
     </div>
   </div>
 </div>

--- a/app/views/insight.html
+++ b/app/views/insight.html
@@ -7,7 +7,7 @@
       </div>
 
       <div class="col-md-9">
-        <div ui-view="master" class="nav-content"></div>
+        <div ui-view="master" class="nav-content" data-scroll-id="nav-content"></div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
The changes introduced by make columns independently scrollable means the window shouldn't ever receive scroll events, so we have to fire them on a node instead.

I tried to write tests for this but it was a mess and I don't want to spend all day trying to do so.
