### PR TITLE
default ELB listener protocol to HTTP

### DIFF
--- a/app/scripts/modules/loadBalancers/CreateLoadBalancerCtrl.js
+++ b/app/scripts/modules/loadBalancers/CreateLoadBalancerCtrl.js
@@ -211,7 +211,7 @@ angular.module('deckApp')
     };
 
     this.addListener = function() {
-      $scope.loadBalancer.listeners.push({});
+      $scope.loadBalancer.listeners.push({internalProtocol: 'HTTP', externalProtocol: 'HTTP'});
     };
 
     $scope.taskMonitor.onApplicationRefresh = function handleApplicationRefreshComplete() {


### PR DESCRIPTION
Since we don't provide an empty option in the `ng-options` for listener protocols, we need to set a default value.

Fixes #467 
