### PR TITLE
fix hover color on security groups, load balancers

### DIFF
--- a/app/scripts/directives/loadBalancer.js
+++ b/app/scripts/directives/loadBalancer.js
@@ -2,26 +2,43 @@
 
 
 angular.module('deckApp')
-  .directive('loadBalancer', function () {
+  .directive('loadBalancer', function ($rootScope, $timeout) {
     return {
       restrict: 'E',
       templateUrl: 'views/application/loadBalancer/loadBalancer.html',
-      controller: 'LoadBalancerDirectiveCtrl as ctrl',
       scope: {
         loadBalancer: '=',
         displayOptions: '='
+      },
+      link: function(scope, el) {
+        var base = el.parent().inheritedData('$uiView').state;
+
+        scope.$state = $rootScope.$state;
+
+        scope.loadDetails = function(e) {
+          $timeout(function() {
+            var loadBalancer = scope.loadBalancer;
+            // anything handled by ui-sref or actual links should be ignored
+            if (e.isDefaultPrevented() || (e.originalEvent && e.originalEvent.target.href)) {
+              return;
+            }
+            var params = {
+              region: loadBalancer.region,
+              accountId: loadBalancer.account,
+              name: loadBalancer.name,
+              vpcId: loadBalancer.vpcId
+            };
+            // also stolen from uiSref directive
+            scope.$state.go('.loadBalancerDetails', params, {relative: base, inherit: true});
+          });
+        };
+
+        scope.displayServerGroup = function (serverGroup) {
+          if (scope.displayOptions.hideHealthy) {
+            return serverGroup.downCount > 0;
+          }
+          return scope.displayOptions.showServerGroups;
+        };
       }
     };
-  })
-  .controller('LoadBalancerDirectiveCtrl', function($scope, $rootScope) {
-
-    $scope.$state = $rootScope.$state;
-
-    this.displayServerGroup = function (serverGroup) {
-      if ($scope.displayOptions.hideHealthy) {
-        return serverGroup.downCount > 0;
-      }
-      return $scope.displayOptions.showServerGroups;
-    };
-
   });

--- a/app/scripts/directives/securityGroup.js
+++ b/app/scripts/directives/securityGroup.js
@@ -2,7 +2,7 @@
 
 
 angular.module('deckApp')
-  .directive('securityGroup', function ($rootScope) {
+  .directive('securityGroup', function ($rootScope, $timeout) {
     return {
       restrict: 'E',
       replace: true,
@@ -11,8 +11,28 @@ angular.module('deckApp')
         securityGroup: '=',
         displayOptions: '='
       },
-      link: function (scope) {
+      link: function (scope, el) {
+        var base = el.parent().inheritedData('$uiView').state;
+
         scope.$state = $rootScope.$state;
+
+        scope.loadDetails = function(e) {
+          $timeout(function() {
+            var securityGroup = scope.securityGroup;
+            // anything handled by ui-sref or actual links should be ignored
+            if (e.isDefaultPrevented() || (e.originalEvent && e.originalEvent.target.href)) {
+              return;
+            }
+            var params = {
+              region: securityGroup.region,
+              accountId: securityGroup.accountName,
+              name: securityGroup.name,
+            };
+            // also stolen from uiSref directive
+            scope.$state.go('.securityGroupDetails', params, {relative: base, inherit: true});
+          });
+        };
+
       }
     };
   }

--- a/app/styles/rollups.less
+++ b/app/styles/rollups.less
@@ -123,7 +123,7 @@
   display: table-cell;
   width: auto;
   color: @lightest_grey;
-  &:active, &:hover {
+  &:active, &:hover, &:focus {
     color: @lighter_grey;
     text-decoration: none;
     font-weight: 600;

--- a/app/views/application/connection/securityGroup.html
+++ b/app/views/application/connection/securityGroup.html
@@ -1,6 +1,7 @@
-<div class="rollup-entry">
+<div class="rollup-entry"
+     ng-class="{active: $state.includes('**.securityGroupDetails', {region: securityGroup.region, accountId: securityGroup.accountName, name: securityGroup.name})}">
   <div class="container-fluid"
-       ng-class="{active: $state.includes('**.connections.**', {region: securityGroup.region, account: securityGroup.account, securityGroup: securityGroup.name})}">
+       ng-click="loadDetails($event)">
     <div class="row">
       <div class="rollup-summary col-sm-12">
       <a class="rollup-title-cell"

--- a/app/views/application/loadBalancer/loadBalancer.html
+++ b/app/views/application/loadBalancer/loadBalancer.html
@@ -1,19 +1,20 @@
 <div class="row rollup-entry"
-     ng-class="{active: $state.includes('**.loadBalancer.**', {region: loadBalancer.region, account: loadBalancer.account, loadBalancer: loadBalancer.name})}">
+     ng-class="{active: $state.includes('**.loadBalancerDetails', {region: loadBalancer.region, accountId: loadBalancer.account, name: loadBalancer.name, vpcId: loadBalancer.vpcId})}"
+     ng-click="loadDetails($event)">
   <div class="rollup-summary">
     <a class="rollup-title-cell"
        ui-sref=".loadBalancerDetails({region: loadBalancer.region, accountId: loadBalancer.account, name: loadBalancer.name, vpcId: loadBalancer.vpcId})">
       <span class="icon icon-elb"></span> {{loadBalancer.name}}
       <account-tag account="loadBalancer.account" pad="left"></account-tag>
       <span ng-if="!displayOptions.showServerGroups">
-        <health-counts container="loadBalancer.health"></health-counts>
+        <health-counts container="loadBalancer.healthCounts"></health-counts>
       </span>
     </a>
   </div>
   <div class="rollup-details">
     <div ng-if="displayOptions.showServerGroups">
       <load-balancer-server-group
-        ng-if="ctrl.displayServerGroup(serverGroup)"
+        ng-if="displayServerGroup(serverGroup)"
         ng-repeat="serverGroup in loadBalancer.serverGroups | orderBy:'-name'"
         display-options="displayOptions"
         server-group="serverGroup"></load-balancer-server-group>


### PR DESCRIPTION
Also making load balancer and security group pods behave the same way server group pods behave: click anywhere to load them, highlight the pod when it's selected.

Also fixed health counts issue on the load balancer pod.

These pages have been neglected for some time. They don't get much use, so we don't get a lot of feedback when they break. This at least refreshes them to the same appearance and behavior of the server groups page.
