### PR TITLE
remove kato section, add failure message to task details

### DIFF
--- a/app/scripts/modules/tasks/taskdetails.html
+++ b/app/scripts/modules/tasks/taskdetails.html
@@ -51,19 +51,12 @@
         <dt>Running time</dt>
         <dd>{{ step.runningTime }}</dd>
       </dl>
-    </collapsible-section>
-    <collapsible-section heading="Kato Log" expanded="true">
-      <h5 ng-repeat-start="step in taskDetail.task.katoTasks">
-        {{ step.status }}
-      </h5>
-      <dl class="well" style="padding: 10px;" ng-repeat-end>
-        <dt>Started</dt>
-        <dd>{{ step.startTime | relativeTime }}</dd>
-        <dt>Completed</dt>
-        <dd>{{ step.endTime | relativeTime }}</dd>
-        <!--<dt>Running time</dt> // TODO: include running time
-          <dd>{{ step.runningTime }}</dd>-->
-      </dl>
+      <div class="alert alert-danger" ng-if="taskDetail.task.failureMessage">
+        <h4>Exception Details:</h4>
+        <p>
+          {{taskDetail.task.failureMessage}}
+        </p>
+      </div>
     </collapsible-section>
   </div>
 </div>


### PR DESCRIPTION
The Kato phases don't really tell people much - they just want to know if their task failed or succeeded, and if it failed, why.

At the least, we need to remove the start/end dates, since we no longer get that data from Kato. If we want to leave in the phases, it'll end up being a list of status messages and nothing more.

@danveloper feel free to push back if you disagree with this assessment.

Example of new view (for failed tasks):
![screen shot 2015-01-09 at 5 27 30 pm](https://cloud.githubusercontent.com/assets/73450/5689900/e16f1010-9824-11e4-9894-ae2997b6ee5b.png)
