### PR TITLE
set preferred zones correctly on pipeline config

### DIFF
--- a/app/scripts/services/ServerGroupConfigurationService.js
+++ b/app/scripts/services/ServerGroupConfigurationService.js
@@ -221,7 +221,7 @@ angular.module('deckApp')
         var currentZoneCount = command.availabilityZones ? command.availabilityZones.length : 0;
         var result = { dirty: {} };
         if (command.viewState.usePreferredZones) {
-          command.availabilityZones = command.backingData.preferredZones[command.credentials][command.region].sort();
+          command.availabilityZones = angular.copy(command.backingData.preferredZones[command.credentials][command.region].sort());
         }
         if (!command.viewState.usePreferredZones) {
           command.availabilityZones = _.intersection(command.availabilityZones, command.backingData.filtered.availabilityZones);

--- a/test/spec/services/awsServerGroupService.spec.js
+++ b/test/spec/services/awsServerGroupService.spec.js
@@ -54,6 +54,7 @@ describe('Service: awsServerGroup', function () {
             'us-east-1': ['d', 'e'],
           },
           prod: {
+            'us-west-1': ['d','g'],
             'us-east-1': ['d','e'],
             'eu-west-1': ['a','m']
           }
@@ -79,6 +80,25 @@ describe('Service: awsServerGroup', function () {
 
       expect(command.credentials).toBe('prod');
       expect(command.region).toBe('us-west-1');
+    });
+
+    it('sets usePreferredZones', function() {
+      var command = null;
+      this.service.buildServerGroupCommandFromPipeline({}, this.cluster, 'prod').then(function(result) {
+        command = result;
+      });
+
+      this.$scope.$digest();
+      expect(command.viewState.usePreferredZones).toBe(true);
+
+      // remove an availability zone, should be false
+      this.cluster.availabilityZones['us-west-1'].pop();
+      this.service.buildServerGroupCommandFromPipeline({}, this.cluster, 'prod').then(function(result) {
+        command = result;
+      });
+
+      this.$scope.$digest();
+      expect(command.viewState.usePreferredZones).toBe(false);
     });
 
   });


### PR DESCRIPTION
The current code only correctly sets the preferred zones flag if the pipeline is being deployed to us-east-1, which isn't great.

Fixes https://github.com/spinnaker/deck/issues/494
