### PR TITLE
avoid NPE when ami lookup fails

### DIFF
--- a/app/scripts/services/ServerGroupConfigurationService.js
+++ b/app/scripts/services/ServerGroupConfigurationService.js
@@ -41,6 +41,9 @@ angular.module('deckApp')
     function loadImagesFromAmi(command) {
       return imageService.getAmi(command.selectedProvider, command.viewState.imageId, command.region, command.credentials).then(
         function (namedImage) {
+          if (!namedImage) {
+            return [];
+          }
           command.amiName = namedImage.imageName;
 
           var packageRegex = /((nf(lx)?-)?\w+)-?\w+/;


### PR DESCRIPTION
I'm not sure we can confidently say the user cannot create a server group just because we can't find the AMI specified on the existing server group they're cloning. So... just return an empty array.

fixes https://github.com/spinnaker/deck/issues/498
