### PR TITLE
decouple task loading from application load

### DIFF
--- a/app/scripts/controllers/InstanceDetailsCtrl.js
+++ b/app/scripts/controllers/InstanceDetailsCtrl.js
@@ -78,7 +78,7 @@ angular.module('deckApp')
       };
 
       var submitMethod = function () {
-        return instanceWriter.terminateInstance(instance, $scope.application.name);
+        return instanceWriter.terminateInstance(instance, $scope.application);
       };
 
       confirmationModalService.confirm({

--- a/app/scripts/controllers/ServerGroupDetailsCtrl.js
+++ b/app/scripts/controllers/ServerGroupDetailsCtrl.js
@@ -65,7 +65,7 @@ angular.module('deckApp')
       };
 
       var submitMethod = function () {
-        return serverGroupWriter.destroyServerGroup(serverGroup, application.name);
+        return serverGroupWriter.destroyServerGroup(serverGroup, application);
       };
 
       var stateParams = {
@@ -103,7 +103,7 @@ angular.module('deckApp')
       };
 
       var submitMethod = function () {
-        return serverGroupWriter.disableServerGroup(serverGroup, application.name);
+        return serverGroupWriter.disableServerGroup(serverGroup, application);
       };
 
       confirmationModalService.confirm({
@@ -128,7 +128,7 @@ angular.module('deckApp')
       };
 
       var submitMethod = function () {
-        return serverGroupWriter.enableServerGroup(serverGroup, application.name);
+        return serverGroupWriter.enableServerGroup(serverGroup, application);
       };
 
       confirmationModalService.confirm({

--- a/app/scripts/controllers/modal/CreateSecurityGroupCtrl.js
+++ b/app/scripts/controllers/modal/CreateSecurityGroupCtrl.js
@@ -131,7 +131,7 @@ angular.module('deckApp')
     this.upsert = function () {
       $scope.taskMonitor.submit(
         function() {
-          return securityGroupWriter.upsertSecurityGroup($scope.securityGroup, application.name, 'Create');
+          return securityGroupWriter.upsertSecurityGroup($scope.securityGroup, application, 'Create');
         }
       );
     };

--- a/app/scripts/controllers/modal/ResizeServerGroupCtrl.js
+++ b/app/scripts/controllers/modal/ResizeServerGroupCtrl.js
@@ -39,7 +39,7 @@ angular.module('deckApp')
       }
 
       var submitMethod = function() {
-        return serverGroupWriter.resizeServerGroup(serverGroup, capacity, application.name);
+        return serverGroupWriter.resizeServerGroup(serverGroup, capacity, application);
       };
 
       var taskMonitorConfig = {

--- a/app/scripts/controllers/modal/awsCloneServerGroupCtrl.js
+++ b/app/scripts/controllers/modal/awsCloneServerGroupCtrl.js
@@ -134,7 +134,7 @@ angular.module('deckApp.aws')
       } else {
         $scope.taskMonitor.submit(
           function() {
-            return serverGroupWriter.cloneServerGroup($scope.command, application.name);
+            return serverGroupWriter.cloneServerGroup($scope.command, application);
           }
         );
       }

--- a/app/scripts/controllers/modal/gceCloneServerGroupCtrl.js
+++ b/app/scripts/controllers/modal/gceCloneServerGroupCtrl.js
@@ -310,7 +310,7 @@ angular.module('deckApp.gce')
         function() {
           transformInstanceMetadata();
 
-          return serverGroupWriter.cloneServerGroup($scope.command, application.name);
+          return serverGroupWriter.cloneServerGroup($scope.command, application);
         }
       );
     };

--- a/app/scripts/modules/instance/instance.write.service.js
+++ b/app/scripts/modules/instance/instance.write.service.js
@@ -4,7 +4,7 @@ angular
   .module('deckApp.instance.write.service', [])
   .factory('instanceWriter', function (taskExecutor) {
 
-    function terminateInstance(instance, applicationName) {
+    function terminateInstance(instance, application) {
       return taskExecutor.executeTask({
         job: [
           {
@@ -17,7 +17,7 @@ angular
             providerType: instance.providerType
           }
         ],
-        application: applicationName,
+        application: application,
         description: 'Terminate instance: ' + instance.instanceId
       });
     }

--- a/app/scripts/modules/loadBalancers/CreateLoadBalancerCtrl.js
+++ b/app/scripts/modules/loadBalancers/CreateLoadBalancerCtrl.js
@@ -235,7 +235,7 @@ angular.module('deckApp')
 
       $scope.taskMonitor.submit(
         function() {
-          return loadBalancerWriter.upsertLoadBalancer($scope.loadBalancer, application.name, descriptor);
+          return loadBalancerWriter.upsertLoadBalancer($scope.loadBalancer, application, descriptor);
         }
       );
     };

--- a/app/scripts/modules/loadBalancers/LoadBalancerDetailsCtrl.js
+++ b/app/scripts/modules/loadBalancers/LoadBalancerDetailsCtrl.js
@@ -76,7 +76,7 @@ angular.module('deckApp')
 
       var submitMethod = function () {
         loadBalancer.providerType = $scope.loadBalancer.type;
-        return loadBalancerWriter.deleteLoadBalancer(loadBalancer, application.name);
+        return loadBalancerWriter.deleteLoadBalancer(loadBalancer, application);
       };
 
       confirmationModalService.confirm({

--- a/app/scripts/modules/loadBalancers/loadBalancer.write.service.js
+++ b/app/scripts/modules/loadBalancers/loadBalancer.write.service.js
@@ -4,7 +4,7 @@ angular
   .module('deckApp.loadBalancer.write.service', [])
   .factory('loadBalancerWriter', function(infrastructureCaches, scheduledCache, taskExecutor) {
 
-    function deleteLoadBalancer(loadBalancer, applicationName) {
+    function deleteLoadBalancer(loadBalancer, application) {
       var operation = taskExecutor.executeTask({
         job: [
           {
@@ -15,7 +15,7 @@ angular
             providerType: loadBalancer.providerType
           }
         ],
-        application: applicationName,
+        application: application,
         description: 'Delete load balancer: ' + loadBalancer.name + ' in ' + loadBalancer.accountId + ':' + loadBalancer.region
       });
 
@@ -25,7 +25,7 @@ angular
     }
 
 
-    function upsertLoadBalancer(loadBalancer, applicationName, descriptor) {
+    function upsertLoadBalancer(loadBalancer, application, descriptor) {
       var name = loadBalancer.clusterName || loadBalancer.name;
       if (loadBalancer.healthCheckProtocol.indexOf('HTTP') === 0) {
         loadBalancer.healthCheck = loadBalancer.healthCheckProtocol + ':' + loadBalancer.healthCheckPort + loadBalancer.healthCheckPath;
@@ -42,7 +42,7 @@ angular
         job: [
           loadBalancer
         ],
-        application: applicationName,
+        application: application,
         description: descriptor + ' Load Balancer: ' + name
       });
 

--- a/app/scripts/modules/securityGroups/securityGroup.write.service.js
+++ b/app/scripts/modules/securityGroups/securityGroup.write.service.js
@@ -4,14 +4,14 @@ angular
   .module('deckApp.securityGroup.write.service', ['deckApp.caches.infrastructure'])
   .factory('securityGroupWriter' ,function (taskExecutor, infrastructureCaches) {
 
-    function upsertSecurityGroup(command, applicationName, descriptor) {
+    function upsertSecurityGroup(command, application, descriptor) {
       command.type = 'upsertSecurityGroup';
 
       var operation = taskExecutor.executeTask({
         job: [
           command
         ],
-        application: applicationName,
+        application: application,
         description: descriptor + ' Security Group: ' + command.name
       });
 

--- a/app/scripts/modules/serverGroups/serverGroup.write.service.js
+++ b/app/scripts/modules/serverGroups/serverGroup.write.service.js
@@ -4,7 +4,7 @@ angular
   .module('deckApp.serverGroup.write.service', ['deckApp.serverGroup.transformer.service'])
   .factory('serverGroupWriter', function (taskExecutor, serverGroupTransformer) {
 
-    function destroyServerGroup(serverGroup, applicationName) {
+    function destroyServerGroup(serverGroup, application) {
       return taskExecutor.executeTask({
         job: [
           {
@@ -16,7 +16,7 @@ angular
             providerType: serverGroup.type
           }
         ],
-        application: applicationName,
+        application: application,
         description: 'Destroy Server Group: ' + serverGroup.name
       });
     }
@@ -38,7 +38,7 @@ angular
       });
     }
 
-    function enableServerGroup(serverGroup, applicationName) {
+    function enableServerGroup(serverGroup, application) {
       return taskExecutor.executeTask({
         job: [
           {
@@ -50,12 +50,12 @@ angular
             providerType: serverGroup.type
           }
         ],
-        application: applicationName,
+        application: application,
         description: 'Enable Server Group: ' + serverGroup.name
       });
     }
 
-    function resizeServerGroup(serverGroup, capacity, applicationName) {
+    function resizeServerGroup(serverGroup, capacity, application) {
       return taskExecutor.executeTask({
         job: [
           {
@@ -68,12 +68,12 @@ angular
             providerType: serverGroup.type
           }
         ],
-        application: applicationName,
+        application: application,
         description: 'Resize Server Group: ' + serverGroup.name + ' to ' + capacity.min + '/' + capacity.desired + '/' + capacity.max
       });
     }
 
-    function cloneServerGroup(command, applicationName) {
+    function cloneServerGroup(command, application) {
 
       var description;
       if (command.viewState.mode === 'clone') {
@@ -81,7 +81,7 @@ angular
         command.type = 'copyLastAsg';
       } else {
         command.type = 'deploy';
-        var asgName = applicationName;
+        var asgName = application.name;
         if (command.stack) {
           asgName += '-' + command.stack;
         }
@@ -98,7 +98,7 @@ angular
         job: [
           serverGroupTransformer.convertServerGroupCommandToDeployConfiguration(command)
         ],
-        application: applicationName,
+        application: application,
         description: description
       });
     }

--- a/app/scripts/modules/serverGroups/serverGroup.write.service.spec.js
+++ b/app/scripts/modules/serverGroups/serverGroup.write.service.spec.js
@@ -26,7 +26,7 @@ describe('serverGroupWriter', function () {
 
       $httpBackend.expectGET(settings.gateUrl + '/applications/appName/tasks/1').respond({});
 
-      serverGroupWriter.cloneServerGroup(command, 'appName');
+      serverGroupWriter.cloneServerGroup(command, { name: 'appName', reloadTasks: angular.noop });
       $httpBackend.flush();
 
       return submitted;
@@ -38,7 +38,8 @@ describe('serverGroupWriter', function () {
             mode: 'create',
             useAllImageSelection: true,
             allImageSelection: 'something-packagebase',
-          }
+          },
+          application: { name: 'theApp'}
         };
 
       var submitted = postTask(command);
@@ -55,6 +56,7 @@ describe('serverGroupWriter', function () {
             allImageSelection: 'something-packagebase',
           },
           subnetType: null,
+          application: { name: 'theApp'}
         };
 
       var submitted = postTask(command);
@@ -70,6 +72,7 @@ describe('serverGroupWriter', function () {
           viewState: {
             mode: 'create',
           },
+          application: { name: 'theApp'}
         };
 
       var submitted = postTask(command);
@@ -96,7 +99,8 @@ describe('serverGroupWriter', function () {
           },
           source: {
             asgName: 'appName-v002',
-          }
+          },
+          application: { name: 'theApp'}
         };
 
       var submitted = postTask(command);

--- a/app/scripts/providers/states.js
+++ b/app/scripts/providers/states.js
@@ -330,7 +330,7 @@ angular.module('deckApp')
         },
         resolve: {
           application: ['$stateParams', 'applicationReader', function($stateParams, applicationReader) {
-            return applicationReader.getApplication($stateParams.application);
+            return applicationReader.getApplication($stateParams.application, {tasks: true});
           }]
         },
         data: {

--- a/app/scripts/services/taskExecutor.js
+++ b/app/scripts/services/taskExecutor.js
@@ -6,6 +6,9 @@ angular.module('deckApp')
 
 
     function executeTask(taskCommand) {
+      var application = taskCommand.application;
+      taskCommand.application = application.name;
+
       if (taskCommand.job[0].providerType === 'aws') {
         delete taskCommand.job[0].providerType;
       }
@@ -20,16 +23,17 @@ angular.module('deckApp')
 
           if(!taskCommand.supressNotification) {
             notificationsService.create({
-              title: taskCommand.application,
+              title: application.name,
               message: taskCommand.description,
               href: urlBuilder.buildFromMetadata({
                 type: 'task',
-                application: taskCommand.application,
+                application: application.name,
                 taskId: taskId
               })
             });
           }
-          return tasksReader.getOneTaskForApplication(taskCommand.application, taskId);
+          application.reloadTasks();
+          return tasksReader.getOneTaskForApplication(application.name, taskId);
         },
         function(response) {
           var error = {


### PR DESCRIPTION
This is required for #479 - just want to get it in separately.

Still loading tasks with the application, but allowing it to occur asynchronously from the rest of the application loading, since tasks are not really tied to any other component of the application.

This lets us immediately surface the existence of running tasks upon execution.
