### PR TITLE
redirect old links to single cluster to new single cluster view

### DIFF
--- a/app/scripts/providers/states.js
+++ b/app/scripts/providers/states.js
@@ -6,6 +6,12 @@ angular.module('deckApp')
       $urlRouterProvider.otherwise('/');
       $urlRouterProvider.when('/applications/{application}', '/applications/{application}/clusters');
       $urlRouterProvider.when('/', '/applications');
+      $urlRouterProvider.when(
+        '/applications/{application}/clusters/{acct}/{q}?reg',
+        ['$match', function ($match) {
+          return '/applications/' + $match.application + '/clusters?q=cluster:' + $match.q + '&acct=' + $match.acct + '&reg=' + $match.reg;
+        }]
+      );
 
       var instanceDetails = {
         name: 'instanceDetails',


### PR DESCRIPTION
The monkeys have links pointing to the old single cluster view pages, which are no longer accessible. This redirects to the new view.

cc @zanthrash 
