### PR TITLE
select no strategy/template by default, no preview without template

### DIFF
--- a/app/scripts/modules/pipelines/config/stages/deploy/deployInitializer.directive.js
+++ b/app/scripts/modules/pipelines/config/stages/deploy/deployInitializer.directive.js
@@ -16,14 +16,13 @@ angular.module('deckApp.pipelines.stage.deploy')
   .controller('DeployInitializerCtrl', function($scope, serverGroupService, securityGroupService, deploymentStrategiesService, _) {
     var controller = this;
 
+    var noTemplate = { label: 'None', serverGroup: null, cluster: null };
     $scope.command = {
-      strategy: null,
-      template: null
+      strategy: '',
+      template: noTemplate,
     };
 
-    $scope.templates = [
-      { label: 'None', serverGroup: null, cluster: null }
-    ];
+    $scope.templates = [ noTemplate ];
 
     var allClusters = _.groupBy($scope.application.serverGroups, function(serverGroup) {
       return [serverGroup.cluster, serverGroup.account, serverGroup.region].join(':');

--- a/app/scripts/modules/pipelines/config/stages/deploy/deployInitializer.html
+++ b/app/scripts/modules/pipelines/config/stages/deploy/deployInitializer.html
@@ -36,13 +36,20 @@
     </div>
   </div>
 
-  <div class="form-group" ng-if="command.template">
+  <div class="form-group" ng-if="command.template.serverGroup">
     <div class="col-md-12">
       <deploy-preview stage="stage"></deploy-preview>
     </div>
     <div class="col-md-12 text-right">
       <button class="btn btn-primary" ng-click="deployInitializerCtrl.useTemplate()">
         Use this template
+      </button>
+    </div>
+  </div>
+  <div class="form-group" ng-if="!command.template.serverGroup">
+    <div class="col-md-9 text-right">
+      <button class="btn btn-primary" ng-click="deployInitializerCtrl.useTemplate()">
+        Continue without a template
       </button>
     </div>
   </div>


### PR DESCRIPTION
We've gotten feedback that the preview is confusing when selecting no template.

This changeset selects "None" for both deployment strategy and template by default, and only shows the preview when a template is selected.
