### PR TITLE
Expose detail field for load balancer creation

### DIFF
--- a/app/scripts/modules/loadBalancers/CreateLoadBalancerCtrl.js
+++ b/app/scripts/modules/loadBalancers/CreateLoadBalancerCtrl.js
@@ -38,7 +38,6 @@ angular.module('deckApp')
     }
 
     function initializeCreateMode() {
-      $scope.state.maxStackLength = 32 - application.name.length - '-frontend'.length - 1;
       preloadSecurityGroups();
       accountService.listAccounts().then(function (accounts) {
         $scope.accounts = accounts;
@@ -76,6 +75,7 @@ angular.module('deckApp')
           }
           allLoadBalancerNames[result.account][result.region].push(result.loadBalancer.toLowerCase());
           $scope.state.loadBalancerNamesLoaded = true;
+          updateLoadBalancerNames();
         });
       });
     }
@@ -174,10 +174,8 @@ angular.module('deckApp')
     };
 
     this.updateName = function() {
-      var elb = $scope.loadBalancer,
-          name = application.name + '-' + (elb.stack || '');
-      elb.clusterName = name;
-      $scope.namePreview = name + '-frontend';
+      var elb = $scope.loadBalancer;
+      elb.name = [application.name, (elb.stack || ''), (elb.detail || '')].join('-');
     };
 
     this.accountUpdated = function() {
@@ -218,7 +216,7 @@ angular.module('deckApp')
     $scope.taskMonitor.onApplicationRefresh = function handleApplicationRefreshComplete() {
       $modalInstance.close();
       var newStateParams = {
-        name: $scope.loadBalancer.name || $scope.loadBalancer.clusterName + '-frontend',
+        name: $scope.loadBalancer.name,
         accountId: $scope.loadBalancer.credentials,
         region: $scope.loadBalancer.region
       };

--- a/app/scripts/modules/loadBalancers/CreateLoadBalancerCtrl.spec.js
+++ b/app/scripts/modules/loadBalancers/CreateLoadBalancerCtrl.spec.js
@@ -37,8 +37,4 @@ describe('Controller: CreateLoadBalancerCtrl', function () {
 
   });
 
-  it('sets maximum length of stack based on application name', function() {
-    // 19 === 32 - 3 (application name length) - 9 ("-frontend" length) - 1 (dash separator)
-    expect(this.$scope.state.maxStackLength).toEqual(19);
-  });
 });

--- a/app/scripts/modules/loadBalancers/createLoadBalancerProperties.html
+++ b/app/scripts/modules/loadBalancers/createLoadBalancerProperties.html
@@ -6,10 +6,13 @@
     <div class="form-group">
       <div class="col-md-12 well" ng-class="{'alert-danger': form.loadBalancerName.$error.validateUnique, 'alert-info': !form.loadBalancerName.$error.validateUnique}">
         <strong>Your load balancer will be named:</strong>
-        <span>{{namePreview}}</span>
-        <input type="hidden"
+        <span>{{loadBalancer.name}}</span>
+          <!-- Angular does not seem to run length validation on hidden inputs, hence the text + display:none -->
+        <input type="text"
+               style="display: none"
+               ng-maxlength="32"
                class="form-control input-sm"
-               ng-model="namePreview"
+               ng-model="loadBalancer.name"
                validate-unique="usedLoadBalancerNames"
                validate-ignore-case="true"
                name="loadBalancerName"/>
@@ -25,21 +28,36 @@
     </div>
     <region-select-field label-columns="3" component="loadBalancer" field="region" account="loadBalancer.credentials" on-change="ctrl.regionUpdated()" regions="regions"></region-select-field>
     <div class="form-group">
-      <div class="col-md-3 sm-label-left">Stack <help-field content="Maximum length: {{state.maxStackLength}} characters"></help-field> </div>
+      <div class="col-md-3 sm-label-left">Stack <help-field key="aws.loadBalancer.stack"></help-field></div>
       <div class="col-md-3">
         <input type="text"
                class="form-control input-sm"
                ng-model="loadBalancer.stack"
                name="stackName"
-               ng-maxlength="{{state.maxStackLength}}"
                ng-change="ctrl.updateName()"
                ng-pattern="/^[a-zA-Z0-9]*$/"/>
       </div>
-      <div class="col-md-7 col-md-offset-3" ng-if="form.stackName.$error.maxlength">
-        <validation-error message="Maximum length is {{state.maxStackLength}} characters."></validation-error>
+      <div class="col-md-6 form-inline">
+        <label class="sm-label-left">
+          Detail <help-field key="aws.loadBalancer.detail"></help-field>
+        </label>
+        <input type="text"
+               class="form-control input-sm"
+               ng-model="loadBalancer.detail"
+               name="detailName"
+               ng-change="ctrl.updateName()"
+               ng-pattern="/^[a-zA-Z0-9]*$/"/>
       </div>
       <div class="col-md-7 col-md-offset-3" ng-if="form.stackName.$error.pattern">
         <validation-error message="Stack can only contain letters and numbers."></validation-error>
+      </div>
+      <div class="col-md-7 col-md-offset-3" ng-if="form.detailName.$error.pattern">
+        <validation-error message="Detail can only contain letters and numbers."></validation-error>
+      </div>
+    </div>
+    <div class="form-group">
+      <div class="col-md-9 col-md-offset-3" ng-if="form.loadBalancerName.$error.maxlength">
+        <validation-error message="Load Balancer name can only be 32 characters."></validation-error>
       </div>
     </div>
     <div class="form-group">

--- a/app/scripts/modules/loadBalancers/loadBalancerService.js
+++ b/app/scripts/modules/loadBalancers/loadBalancerService.js
@@ -88,6 +88,8 @@ angular.module('deckApp')
 
     function constructNewLoadBalancerTemplate() {
       return {
+        stack: '',
+        detail: 'frontend',
         credentials: settings.defaults.account,
         region: settings.defaults.region,
         vpcId: null,

--- a/app/scripts/modules/validation/validateUnique.js
+++ b/app/scripts/modules/validation/validateUnique.js
@@ -24,7 +24,7 @@ angular.module('deckApp.validation')
         };
 
         ctrl.$parsers.push(uniqueValidator);
-        ctrl.$formatters.unshift(uniqueValidator);
+        ctrl.$formatters.push(uniqueValidator);
       }
     };
   }

--- a/app/scripts/settings/helpContents.js
+++ b/app/scripts/settings/helpContents.js
@@ -16,6 +16,9 @@ angular.module('deckApp.help')
       '<li><b>internal</b> access to the load balancer will be restricted to internal clients (i.e. require VPN access)</li>' +
       '<li><b>external</b> the load balancer will be publicly accessible and running in VPC</li>' +
       '</ul>',
+    'aws.loadBalancer.detail': '<p>(Optional) <b>Detail</b> is a string of free-form alphanumeric characters; by convention, we recommend using "frontend".</p><p>' +
+      'However, if your stack name needs to be longer (load balancer names are limited to 32 characters), consider changing it to "elb", or omit it altogether.</p>',
+    'aws.loadBalancer.stack': '(Optional) <b>Stack</b> is one of the core naming components of a cluster, used to create vertical stacks of dependent services for integration testing.',
     'aws.serverGroup.stack': '(Optional) <b>Stack</b> is one of the core naming components of a cluster, used to create vertical stacks of dependent services for integration testing.',
     'aws.serverGroup.detail': '(Optional) <b>Detail</b> is a string of free-form alphanumeric characters and hyphens to describe any other variables',
     'aws.serverGroup.imageName': '(Required) <b>Image</b> is the deployable Amazon Machine Image. Images are restricted to the account and region selected.',


### PR DESCRIPTION
Removing most of the validation done last week around name length and constructing the load balancer name explicitly before sending it along.

Also fixing an issue where name uniqueness was not being validated if the user never changed account or region.

fixes #528 
