### PR TITLE
remove animations on auth modal, do not dismiss when redirecting

### DIFF
--- a/app/scripts/modules/authentication/authenticatedUser.html
+++ b/app/scripts/modules/authentication/authenticatedUser.html
@@ -1,4 +1,4 @@
-<ul class="nav navbar-nav navbar-right feedback-nav" ng-if="user.authenticated">
+<ul class="nav navbar-nav navbar-right feedback-nav" is-visible="user.authenticated">
   <li>
   <a popover="Logged in as <b>{{user.name}}</b>"
      popover-append-to-body="true"

--- a/app/scripts/modules/authentication/authenticationProvider.spec.js
+++ b/app/scripts/modules/authentication/authenticationProvider.spec.js
@@ -46,7 +46,7 @@ describe('authenticationProvider: application startup', function() {
       this.$timeout.flush();
       this.$http.flush();
 
-      expect(this.$rootScope.authenticating).toBe(false);
+      expect(this.$rootScope.authenticating).toBe(true);
       expect(this.authenticationService.getAuthenticatedUser().name).toBe('[anonymous]');
       expect(this.authenticationService.getAuthenticatedUser().authenticated).toBe(false);
       expect(redirectUrl).toBe(this.settings.gateUrl + '/authUp?callback=' + this.$window.location.origin + '&path=' + this.$location.path());

--- a/app/scripts/modules/authentication/authenticationService.js
+++ b/app/scripts/modules/authentication/authenticationService.js
@@ -22,7 +22,7 @@ angular.module('deckApp.authentication')
       $rootScope.authenticating = true;
       var modal = $modal.open({
         templateUrl: 'scripts/modules/authentication/authenticating.html',
-        windowClass: 'modal fade in',
+        windowClass: 'modal no-animate',
         backdropClass: 'modal-backdrop-no-animate',
         backdrop: 'static',
         keyboard: false
@@ -32,17 +32,17 @@ angular.module('deckApp.authentication')
           if (data.email) {
             setAuthenticatedUser(data.email);
           }
+          $rootScope.authenticating = false;
           modal.dismiss();
         })
         .error(function (data, status, headers) {
           var redirect = headers('X-AUTH-REDIRECT-URL');
           if (status === 401 && redirect) {
             redirectService.redirect(settings.gateUrl + redirect + '?callback=' + $window.location.origin + '&path=' + $location.path());
+          } else {
+            $rootScope.authenticating = false;
           }
           modal.dismiss();
-        })
-        .finally(function() {
-          $rootScope.authenticating = false;
         });
     }
 

--- a/app/styles/main.less
+++ b/app/styles/main.less
@@ -835,45 +835,22 @@ feedback {
   display: inline-block;
 }
 
-.modal-backdrop {
-  &.modal-backdrop-no-animate {
+.modal {
+  &.no-animate {
     transition: none;
+    .modal-dialog {
+      transition: none;
+    }
   }
 }
 
-feedback {
-  margin-right: 20px;
-  float: right;
-  display: inline-block;
-}
-
 .modal-backdrop {
   &.modal-backdrop-no-animate {
+    background-color: @lightest_grey;
     transition: none;
-  }
-}
-
-feedback {
-  margin-right: 20px;
-  float: right;
-  display: inline-block;
-}
-
-.modal-backdrop {
-  &.modal-backdrop-no-animate {
-    transition: none;
-  }
-}
-
-feedback {
-  margin-right: 20px;
-  float: right;
-  display: inline-block;
-}
-
-.modal-backdrop {
-  &.modal-backdrop-no-animate {
-    transition: none;
+    &.fade .modal-dialog {
+      transition: none;
+    }
   }
 }
 


### PR DESCRIPTION
I haven't tracked down the issue where users get logged in a hundred times, but at least it's a little less jarring:
- switch the `ng-if` on the authenticated user icon in the header to `is-visible` so it takes up the same space, whether it's displayed or not, keeping the items in the header from shifting left once authentication completes
- removed all animations from the modal
- keeping the modal open when redirecting to SSO provider
