### PR TITLE
implement delete security group

### DIFF
--- a/app/scripts/controllers/SecurityGroupDetailsCtrl.js
+++ b/app/scripts/controllers/SecurityGroupDetailsCtrl.js
@@ -2,7 +2,9 @@
 
 
 angular.module('deckApp')
-  .controller('SecurityGroupDetailsCtrl', function ($scope, $state, notificationsService, securityGroup, application, securityGroupService, $modal) {
+  .controller('SecurityGroupDetailsCtrl', function ($scope, $state, notificationsService, securityGroup, application,
+                                                    confirmationModalService, securityGroupWriter, securityGroupService,
+                                                    $modal) {
 
     $scope.state = {
       loading: true
@@ -13,8 +15,8 @@ angular.module('deckApp')
         $scope.state.loading = false;
         $scope.securityGroup = details;
 
-        var restanularlessDetails = details.plain();
-        if (_.isEmpty(restanularlessDetails)) {
+        var restangularlessDetails = details.plain();
+        if (_.isEmpty(restangularlessDetails)) {
           fourOhFour();
         }
       },
@@ -49,5 +51,30 @@ angular.module('deckApp')
         }
       });
     };
+
+    this.deleteSecurityGroup = function deleteSecurityGroup() {
+      var taskMonitor = {
+        application: application,
+        title: 'Deleting ' + securityGroup.name,
+        forceRefreshMessage: 'Refreshing application...',
+        forceRefreshEnabled: true
+      };
+
+      var submitMethod = function () {
+        securityGroup.providerType = $scope.securityGroup.type;
+        return securityGroupWriter.deleteSecurityGroup($scope.securityGroup, application);
+      };
+
+      confirmationModalService.confirm({
+        header: 'Really delete ' + securityGroup.name + '?',
+        buttonText: 'Delete ' + securityGroup.name,
+        destructive: true,
+        account: securityGroup.accountId,
+        applicationName: application.name,
+        taskMonitorConfig: taskMonitor,
+        submitMethod: submitMethod
+      });
+    };
+
   }
 );

--- a/app/scripts/modules/securityGroups/securityGroup.write.service.js
+++ b/app/scripts/modules/securityGroups/securityGroup.write.service.js
@@ -23,9 +23,31 @@ angular
       return operation;
     }
 
+    function deleteSecurityGroup(securityGroup, application) {
+      var operation = taskExecutor.executeTask({
+        job: [
+          {
+            type: 'deleteSecurityGroup',
+            securityGroupName: securityGroup.name,
+            regions: [securityGroup.region],
+            credentials: securityGroup.accountId,
+            providerType: securityGroup.providerType,
+            vpcId: securityGroup.vpcId
+          }
+        ],
+        application: application,
+        description: 'Delete security group: ' + securityGroup.name + ' in ' + securityGroup.accountId + ':' + securityGroup.region
+      });
+
+      operation.then(infrastructureCaches.securityGroups.removeAll);
+
+      return operation;
+    }
+
 
     return {
-      upsertSecurityGroup: upsertSecurityGroup
+      upsertSecurityGroup: upsertSecurityGroup,
+      deleteSecurityGroup: deleteSecurityGroup,
     };
 
   });

--- a/app/views/application/connection/securityGroupDetails.html
+++ b/app/views/application/connection/securityGroupDetails.html
@@ -22,6 +22,7 @@
         </button>
         <ul class="dropdown-menu" role="menu">
           <li><a href ng-click="ctrl.editInboundRules()">Edit Inbound Rules</a></li>
+          <li><a href ng-click="ctrl.deleteSecurityGroup()">Delete Security Group</a></li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
Depends on https://github.com/spinnaker/mort/pull/29 - without this, there's not really any point deleting security groups, since we won't know they've been deleted until we restart Mort.

Closes https://github.com/spinnaker/deck/issues/74
