### PR TITLE
graceful failure if pipeline is running and no steps are running

### DIFF
--- a/app/scripts/modules/delivery/executionStatus.controller.js
+++ b/app/scripts/modules/delivery/executionStatus.controller.js
@@ -5,14 +5,22 @@ angular.module('deckApp.delivery')
     var controller = this;
 
     controller.getFailedStage = function(execution) {
-      return execution.stages.filter(function(stage) {
+      var failed = execution.stages.filter(function(stage) {
         return stage.isFailed;
-      })[0].name;
+      });
+      if (failed && failed.length) {
+        return failed[0].name;
+      }
+      return 'Unknown';
     };
 
     controller.getRunningStage = function(execution) {
-      return execution.stages.filter(function(stage) {
-        return stage.isRunning;
-      })[0].name;
+      var runningOrNext = execution.stages.filter(function(stage) {
+        return stage.isRunning || stage.hasNotStarted;
+      });
+      if (runningOrNext && runningOrNext.length) {
+        return runningOrNext[0].name;
+      }
+      return 'Unknown';
     };
   });


### PR DESCRIPTION
Not sure if this should ever happen, but it's happening now, and it's conceivable that it'll happen in the future.

A pipeline can have a status of running, but the next stage may be paused. And it might fail inexplicably, i.e. there are no failing stages, but the pipeline gets marked as failed. These changes protect against those cases.
