### PR TITLE
gracefully recover from pipeline retrieval failures

### DIFF
--- a/app/scripts/modules/delivery/executionsService.js
+++ b/app/scripts/modules/delivery/executionsService.js
@@ -8,6 +8,9 @@ angular.module('deckApp.delivery')
       $http({
         method: 'GET',
         transformResponse: appendTransform(function(executions) {
+          if (!executions || !executions.length) {
+            return [];
+          }
           executions.forEach(function(execution) {
             orchestratedItem.defineProperties(execution);
             execution.stages.forEach(function(stage) {
@@ -49,9 +52,14 @@ angular.module('deckApp.delivery')
           $stateParams.application,
           'pipelines',
         ].join('/'),
-      }).then(function(resp) {
-        deferred.resolve(resp.data);
-      });
+      }).then(
+        function(resp) {
+          deferred.resolve(resp.data);
+        },
+        function(resp) {
+          deferred.reject(resp);
+        }
+      );
       return deferred.promise;
     }
 

--- a/app/scripts/modules/delivery/pipelineExecutions.controller.js
+++ b/app/scripts/modules/delivery/pipelineExecutions.controller.js
@@ -100,10 +100,7 @@ angular.module('deckApp.delivery')
       $scope.detailsTarget = toParams.executionId;
     });
 
-    $q.all({
-      configurations: pipelineConfigService.getPipelinesForApplication($scope.application.name),
-      executions: executionsService.getAll()
-    }).then(function(results) {
+    function dataInitializationSuccess(results) {
       $scope.viewState.loading = false;
       $scope.configurations = results.configurations.plain();
       updateExecutions(results.executions);
@@ -115,5 +112,15 @@ angular.module('deckApp.delivery')
       if ($scope.detailsTarget) {
         scrollToService.scrollTo('execution-' + $scope.detailsTarget, 250);
       }
-    });
+    }
+
+    function dataInitializationFailure() {
+      $scope.viewState.loading = false;
+      $scope.viewState.initializationError = true;
+    }
+
+    $q.all({
+      configurations: pipelineConfigService.getPipelinesForApplication($scope.application.name),
+      executions: executionsService.getAll()
+    }).then(dataInitializationSuccess, dataInitializationFailure);
   });

--- a/app/scripts/modules/delivery/pipelineExecutions.html
+++ b/app/scripts/modules/delivery/pipelineExecutions.html
@@ -27,7 +27,7 @@
     </div>
   </div>
 </div>
-<div class="row pipelines executions" ng-if="!executions.length && !configurations.length && !viewState.loading">
+<div class="row pipelines executions" ng-if="!executions.length && !configurations.length && !viewState.loading && !viewState.initializationError">
   <div class="col-md-8 text-center">
     <h4>We couldn't find any pipelines execution history for {{application.name}}.</h4>
     <a ui-sref="^.pipelineConfig" class="btn btn-default"><span class="glyphicon glyphicon-cog"></span> Configure Pipelines</a>
@@ -39,4 +39,7 @@
       <span class="glyphicon glyphicon-asterisk glyphicon-spinning"></span>
     </h2>
   </div>
+</div>
+<div class="row" ng-if="viewState.initializationError">
+  <h4 class="text-center">There was a server error loading pipelines. Please try again later.</h4>
 </div>


### PR DESCRIPTION
If the /pipelines or /pipelineConfigs endpoint is down, show an error message to the user instead of the forever spinner.
