### PR TITLE
short-term visualization for synthetic stages

### DIFF
--- a/app/scripts/modules/delivery/executionBar.html
+++ b/app/scripts/modules/delivery/executionBar.html
@@ -1,6 +1,6 @@
 <div class="row execution-bar">
   <div class="col-md-12">
-    <div ng-repeat="stage in execution.stages | stages:filter"
+    <div ng-repeat="stage in execution.stageSummaries | stages:filter"
          class="execution-stage"
          ng-class="{glowing: stage.isRunning }"
          ng-style="ctrl.styleStage(stage)">

--- a/app/scripts/modules/delivery/executionDetails.controller.js
+++ b/app/scripts/modules/delivery/executionDetails.controller.js
@@ -38,7 +38,7 @@ angular.module('deckApp.delivery')
     };
 
     controller.getDetailsSourceUrl = function() {
-      if ($stateParams.stage) {
+      if ($stateParams.stage !== undefined) {
         var stage = $scope.execution.stages[getCurrentStage()];
         if (stage) {
           $scope.stage = stage;

--- a/app/scripts/modules/delivery/executionDetails.html
+++ b/app/scripts/modules/delivery/executionDetails.html
@@ -13,7 +13,7 @@
   </div>
   <div class="row">
     <div class="col-md-6">
-      <table class="table table-hover">
+      <table class="table">
         <thead>
           <tr>
             <th>Stage</th>
@@ -23,11 +23,21 @@
           </tr>
         </thead>
         <tbody>
-          <tr ng-repeat="stage in execution.stages"
-              ng-class="{ info: ctrl.isStageCurrent($index) }"
-              ng-click="ctrl.toggleDetails($index)"
-            >
-            <td>{{ stage.name != "null" ? stage.name : stage.type }}</td>
+          <tr ng-repeat-start="stageSummary in execution.stageSummaries" class="stage-summary">
+            <td>{{ stageSummary.name }}</td>
+            <td>{{ stageSummary.startTime | simpleTime }}</td>
+            <td>{{ stageSummary.endTime | simpleTime }}</td>
+            <td>
+              <span class="label label-default label-{{ stageSummary.status | lowercase }}">
+                <status-glyph item="stageSummary"></status-glyph>{{ stageSummary.status | lowercase | robotToHuman }}
+              </span>
+            </td>
+          </tr>
+          <tr class="clickable"
+              ng-repeat="stage in stageSummary.stages" ng-repeat-end
+              ng-class="{ info: ctrl.isStageCurrent(stage.index) }"
+              ng-click="ctrl.toggleDetails(stage.index)">
+            <td>{{ stage.type | robotToHuman }}</td>
             <td>{{ stage.startTime | simpleTime }}</td>
             <td>{{ stage.endTime | simpleTime }}</td>
             <td>
@@ -43,7 +53,7 @@
       <div class="stage-details well">
         <div class="row stage-details-heading">
           <div class="col-md-11">
-            <h4><span class="small"><status-glyph item="stage"></status-glyph></span> {{stage.name}}</h4>
+            <h4><span class="small"><status-glyph item="stage"></status-glyph></span> {{stage.type | robotToHuman }}</h4>
           </div>
           <div class="col-md-1 text-right">
             <a href ng-click="ctrl.closeDetails(); $event.stopPropagation();">

--- a/app/scripts/modules/delivery/executionStatus.html
+++ b/app/scripts/modules/delivery/executionStatus.html
@@ -17,7 +17,7 @@
           {{ execution.trigger.buildInfo.name }}
         </li>
         <li ng-switch-when="manual">
-          {{ execution.trigger.user }}
+          {{ execution.trigger.user || 'unknown user'}}
         </li>
         <li>
           {{ execution.startTime | relativeTime }}

--- a/app/scripts/modules/delivery/pipelineExecutions.controller.js
+++ b/app/scripts/modules/delivery/pipelineExecutions.controller.js
@@ -15,6 +15,7 @@ angular.module('deckApp.delivery')
           completed: true,
           failed: true,
           'not_started': true,
+          canceled: false,
         },
         triggers: {
           jenkins: true,
@@ -45,6 +46,7 @@ angular.module('deckApp.delivery')
       'not_started': 'Not Started',
       running: 'Running',
       completed: 'Completed',
+      canceled: 'Canceled',
     };
 
     $scope.scale = {
@@ -54,7 +56,7 @@ angular.module('deckApp.delivery')
       status: d3Service
         .scale
         .ordinal()
-        .domain(['completed', 'failed', 'running', 'not_started'])
+        .domain(['completed', 'failed', 'running', 'not_started', 'canceled'])
         .range(['#769D3E', '#b82525','#2275b8', '#cccccc']),
     };
 
@@ -70,7 +72,7 @@ angular.module('deckApp.delivery')
 
     controller.updateLegend = function() {
       var stageNames = Object.keys($scope.executions.reduce(function(acc, cur) {
-        cur.stages.forEach(function(stage) {
+        cur.stageSummaries.forEach(function(stage) {
           acc[stage.name] = true;
         });
         return acc;
@@ -87,7 +89,7 @@ angular.module('deckApp.delivery')
 
     function updateExecutions(executions) {
       $scope.filter.stage.max = executions.reduce(function(acc, execution) {
-        return execution.stages.length > acc ? execution.stages.length : acc;
+        return execution.stageSummaries.length > acc ? execution.stageSummaries.length : acc;
       }, 0);
       $scope.executions = executions;
       controller.updateLegend();

--- a/app/scripts/modules/delivery/pipelineExecutions.executionFilter.html
+++ b/app/scripts/modules/delivery/pipelineExecutions.executionFilter.html
@@ -36,6 +36,12 @@
              btn-checkbox>
         <status-glyph item="{isFailed: true}"></status-glyph> Failed
       </label>
+      <label class="btn btn-default btn"
+             ng-model="filter.execution.status.canceled"
+             btn-checkbox>
+        <status-glyph item="{isCanceled: true}"></status-glyph> Canceled
+      </label>
+
     </div>
   </div>
   <div class="pull-right">

--- a/app/scripts/modules/pipelines/config/stages/deploy/deployExecutionDetails.html
+++ b/app/scripts/modules/pipelines/config/stages/deploy/deployExecutionDetails.html
@@ -6,19 +6,19 @@
         <dt>Account</dt>
         <dd>{{stage.context.account}}</dd>
         <dt>Region</dt>
-        <dd ng-repeat="(region, zones) in stage.context.cluster.availabilityZones">{{region}}<br/>({{zones.join(', ')}})</dd>
+        <dd ng-repeat="(region, zones) in stage.context.availabilityZones">{{region}}<br/>({{zones.join(', ')}})</dd>
         <dt>Cluster</dt>
-        <dd>{{stage.context.cluster | clusterName }}</dd>
+        <dd>{{stage.context | clusterName }}</dd>
         <dt>VPC</dt>
-        <dd>{{stage.context.cluster.subnetType || '[none]'}}</dd>
+        <dd>{{stage.context.subnetType || '[none]'}}</dd>
         <dt>Strategy</dt>
-        <dd>{{stage.context.cluster.strategy || '[none]'}}</dd>
+        <dd>{{stage.context.strategy || '[none]'}}</dd>
         <dt>Capacity</dt>
-        <dd ng-if="stage.context.cluster.capacity.min === stage.context.cluster.capacity.max">{{stage.context.cluster.capacity.max}}</dd>
-        <dd ng-if="stage.context.cluster.capacity.min !== stage.context.cluster.capacity.max">
-          Min: {{stage.context.cluster.capacity.min}},
-          Max: {{stage.context.cluster.capacity.max}},
-          Desired: {{stage.context.cluster.capacity.desired}}
+        <dd ng-if="stage.context.capacity.min === stage.context.capacity.max">{{stage.context.capacity.max}}</dd>
+        <dd ng-if="stage.context.capacity.min !== stage.context.capacity.max">
+          Min: {{stage.context.capacity.min}},
+          Max: {{stage.context.capacity.max}},
+          Desired: {{stage.context.capacity.desired}}
         </dd>
       </dl>
     </div>

--- a/app/scripts/modules/pipelines/config/stages/disableAsg/disableAsgExecutionDetails.html
+++ b/app/scripts/modules/pipelines/config/stages/disableAsg/disableAsgExecutionDetails.html
@@ -5,10 +5,12 @@
       <dl class="dl-narrow dl-horizontal">
         <dt>ASG Name</dt>
         <dd>{{stage.context.asgName}}</dd>
+        <dt>Account</dt>
+        <dd><account-tag account="stage.context.credentials"></account-tag></dd>
       </dl>
       <dl class="dl-narrow dl-horizontal">
         <dt>Regions</dt>
-        <dd>{{stage.context.regions}}</dd>
+        <dd>{{stage.context.regions.join(', ')}}</dd>
       </dl>
     </div>
 

--- a/app/scripts/modules/pipelines/config/stages/enableAsg/enableAsgExecutionDetails.html
+++ b/app/scripts/modules/pipelines/config/stages/enableAsg/enableAsgExecutionDetails.html
@@ -5,10 +5,12 @@
       <dl class="dl-narrow dl-horizontal">
         <dt>ASG Name</dt>
         <dd>{{stage.context.asgName}}</dd>
+        <dt>Account</dt>
+        <dd><account-tag account="stage.context.credentials"></account-tag></dd>
       </dl>
       <dl class="dl-narrow dl-horizontal">
         <dt>Regions</dt>
-        <dd>{{stage.context.regions}}</dd>
+        <dd>{{stage.context.regions.join(', ')}}</dd>
       </dl>
     </div>
 

--- a/app/scripts/services/orchestratedItem.js
+++ b/app/scripts/services/orchestratedItem.js
@@ -38,7 +38,7 @@ angular.module('deckApp.orchestratedItem.service', [
           }
         },
         status: {
-          // Returns either COMPLETED, RUNNING, FAILED, or NOT_STARTED
+          // Returns either COMPLETED, RUNNING, FAILED, CANCELED, or NOT_STARTED
           get: function() { return normalizeStatus(item); },
           set: function(status) {
             item.originalStatus = status;

--- a/app/styles/delivery.less
+++ b/app/styles/delivery.less
@@ -28,8 +28,19 @@ body, html {
   }
   .execution-details {
     tbody {
-      tr {
+      tr.stage-summary {
+        font-weight: 600;
+      }
+      tr.clickable {
         cursor: pointer;
+        &:hover {
+          background-color: @table-bg-hover;
+        }
+        td{
+          &:first-child, &:last-child {
+            padding-left: 20px;
+          }
+        }
       }
     }
     background-color: @light_grey;

--- a/app/styles/tasks.less
+++ b/app/styles/tasks.less
@@ -50,6 +50,14 @@
   }
 }
 
+.label {
+  &.label-default {
+    .status-glyph {
+      color: #ffffff;
+    }
+  }
+}
+
 .status-glyph {
   &.glyphicon-ok {
     color: @healthy_green_icon;


### PR DESCRIPTION
This is a short-term fix to roll up synthetic stages into the configured stage. It's short-term in the sense that we need to redo most of this to handle parallel executions, which will probably look quite a bit different than what we have now.

Example: user configures two stages: bake and deploy, with highlander strategy.
Before:
![screen shot 2015-01-23 at 12 19 55 pm](https://cloud.githubusercontent.com/assets/73450/5881961/36696dc4-a2fa-11e4-8122-d7d65acf10b2.png)

After:
![screen shot 2015-01-23 at 12 19 32 pm](https://cloud.githubusercontent.com/assets/73450/5881966/3b86a880-a2fa-11e4-9016-b4cd4e895860.png)
