### PR TITLE
access global search via "/" key

### DIFF
--- a/app/scripts/modules/search/global/globalSearch.directive.js
+++ b/app/scripts/modules/search/global/globalSearch.directive.js
@@ -22,6 +22,14 @@ angular.module('deckApp.search.global')
           });
         });
 
+        window.bind('keyup.globalsearch', function(event) {
+          var $target = $(event.target);
+          if ($target.is('input, textarea') || event.which !== 191) {
+            return;
+          }
+          element.find('input').focus();
+        });
+
         scope.$on('$destroy', function() {
           window.unbind('.globalsearch');
         });

--- a/app/scripts/modules/search/global/globalSearch.less
+++ b/app/scripts/modules/search/global/globalSearch.less
@@ -47,3 +47,9 @@
   }
 }
 
+.keyboard-key {
+  color: @code-yellow;
+  font-family: monospace;
+  font-weight: bold;
+}
+

--- a/app/styles/imports/colors.less
+++ b/app/styles/imports/colors.less
@@ -43,3 +43,5 @@
 
 @glow-init: rgba(137, 195, 231, .7);
 @glow-mid: rgba(137, 195, 231, .3);
+
+@code-yellow: #dddd00;

--- a/app/views/globalsearch.html
+++ b/app/views/globalsearch.html
@@ -8,7 +8,7 @@
           ng-model="query"
           ng-focus="ctrl.displayResults()"
           ng-keyup="ctrl.dispatchQueryInput($event)"/>
-        <span class="glyphicon glyphicon-search form-control-feedback"></span>
+        <span class="glyphicon glyphicon-search form-control-feedback" tooltip-html-unsafe="Keyboard shortcut: <span class='keyboard-key'>/</span>" tooltip-placement="right"></span>
       </div>
     </div>
   </form>


### PR DESCRIPTION
The search results are already fully navigable via keyboard (up, down, tab, escape); this would mean you can get to it (as long as the focus is not in an input or textarea) by typing "/".

Discoverability is not _great_, but it's there in a popover on the magnifying glass:
![screen shot 2015-01-23 at 1 46 10 pm](https://cloud.githubusercontent.com/assets/73450/5883391/ade4df1c-a306-11e4-9c71-44dfe0636d8a.png)

Are we into this? I think people would be into this.
