### PR TITLE
 Fixing the issue with the cluster filter on applicaiton autoreload, and...

### DIFF
--- a/app/scripts/modules/clusterFilter/clusterFilterModel.spec.js
+++ b/app/scripts/modules/clusterFilter/clusterFilterModel.spec.js
@@ -1,0 +1,62 @@
+'use strict';
+
+
+describe('Cluster Filter Model', function () {
+
+  var ClusterFilterModel;
+
+  beforeEach(module(
+    'cluster.filter.model'
+  ));
+
+  beforeEach(
+    inject(function(_ClusterFilterModel_){
+      ClusterFilterModel = _ClusterFilterModel_;
+    })
+  );
+
+  describe('convert sortFilter object to a string for the query param', function () {
+
+    it('should convert an object with all true values to string', function () {
+      var obj = {
+        foo: true,
+        bar: true
+      };
+
+      var result = ClusterFilterModel.convertObjectToParam(obj);
+
+      expect(result).toEqual('foo,bar');
+    });
+
+
+    it('should convert an object with mixed true and false values to string', function () {
+
+      var obj = {
+        foo: true,
+        bar: false
+      };
+
+      var result = ClusterFilterModel.convertObjectToParam(obj);
+      expect(result).toEqual('foo');
+    });
+
+
+    it('should convert an object with mixed all false values to empty string', function () {
+      var obj = {
+        foo: false,
+        bar: false
+      };
+
+      var result = ClusterFilterModel.convertObjectToParam(obj);
+      expect(result).toEqual('');
+    });
+
+
+    it('should convert an empty object with mixed all false values to empty string', function () {
+      var obj = {};
+
+      var result = ClusterFilterModel.convertObjectToParam(obj);
+      expect(result).toEqual('');
+    });
+  });
+});

--- a/app/scripts/providers/states.js
+++ b/app/scripts/providers/states.js
@@ -167,6 +167,7 @@ angular.module('deckApp')
         children: [
           {
           name: 'clusters',
+          reloadOnSearch: false,
           url: '/clusters?q&primary&secondary&hideInstances&hideHealthy&hideDisabled&acct&reg&status&providerType&instanceType',
           views: {
             'nav': {


### PR DESCRIPTION
... ui-router state change within the 'cluster' parent route.
- Also the filters will now be 'sticky' across non-cluster state changes. e.g. LoadBalancers, SecurityGroups, Tasks, etc
