### PR TITLE
surface scaling processes, provide edit capabilities

### DIFF
--- a/app/scripts/modules/serverGroups/details/aws/autoScalingProcess.service.js
+++ b/app/scripts/modules/serverGroups/details/aws/autoScalingProcess.service.js
@@ -1,0 +1,47 @@
+'use strict';
+
+angular.module('deckApp.serverGroup.details.aws.autoscaling.process', [])
+  .factory('autoScalingProcessService', function() {
+    function listProcesses() {
+      return [
+        {
+          name: 'Launch',
+          description: 'Controls if new instances should be launched into the ASG. If this is disabled, scale-up ' +
+            'events will not produce new instances.',
+        },
+        {
+          name: 'Terminate',
+          description: 'Controls if instances should be terminated during a scale-down event.',
+        },
+        {
+          name: 'AddToLoadBalancer',
+          description: 'Controls if new instances should be added to the ASG’s ELB.',
+        },
+        {
+          name: 'AlarmNotification',
+          description: 'This disables autoscaling.',
+        },
+        {
+          name: 'AZRebalance',
+          description: 'Controls whether instances in an Availability Zone should be rebalanced to another zone when ' +
+            'the AZ becomes unhealthy.',
+        },
+        {
+          name: 'HealthCheck',
+          description: 'If disabled, the instance’s health will no longer be reported to the autoscaling processor.',
+        },
+        {
+          name: 'ReplaceUnhealthy',
+          description: 'Controls whether instances should be replaced if they failed the health check.',
+        },
+        {
+          name: 'ScheduledActions',
+          description: 'Controls whether scheduled actions should be executed.',
+        },
+      ];
+    }
+
+    return {
+      listProcesses: listProcesses,
+    };
+  });

--- a/app/scripts/modules/serverGroups/details/aws/modifyScalingProcesses.controller.js
+++ b/app/scripts/modules/serverGroups/details/aws/modifyScalingProcesses.controller.js
@@ -1,0 +1,74 @@
+'use strict';
+
+angular.module('deckApp.serverGroup.details.aws.autoscaling.process.controller', [
+  'deckApp.utils.lodash',
+  'deckApp.tasks.monitor',
+  'deckApp.taskExecutor.service',
+])
+  .controller('ModifyScalingProcessesCtrl', function($scope, $modalInstance, taskMonitorService, taskExecutor, application, serverGroup, processes, _) {
+    $scope.command = angular.copy(processes);
+    $scope.serverGroup = serverGroup;
+
+    var currentlyEnabled = _($scope.command).filter({enabled: true}).pluck('name').valueOf(),
+        currentlySuspended = _($scope.command).filter({enabled: false}).pluck('name').valueOf();
+
+    this.isDirty = function () {
+      var enabledSelections = _($scope.command).filter({enabled: true}).pluck('name').valueOf(),
+        suspendedSelections = _($scope.command).filter({enabled: false}).pluck('name').valueOf(),
+        toEnable = _.intersection(currentlySuspended, enabledSelections),
+        toSuspend = _.intersection(currentlyEnabled, suspendedSelections);
+
+      return !!(toEnable.length || toSuspend.length);
+    };
+
+    this.submit = function () {
+      var enabledSelections = _($scope.command).filter({enabled: true}).pluck('name').valueOf(),
+          suspendedSelections = _($scope.command).filter({enabled: false}).pluck('name').valueOf(),
+          toEnable = _.intersection(currentlySuspended, enabledSelections),
+          toSuspend = _.intersection(currentlyEnabled, suspendedSelections);
+
+      var job = [];
+      if (toEnable.length) {
+        job.push({
+          type: 'modifyScalingProcess',
+          action: 'resume',
+          processes: toEnable,
+          asgName: serverGroup.name,
+          regions: [serverGroup.region],
+          credentials: serverGroup.account,
+        });
+      }
+      if (toSuspend.length) {
+        job.push({
+          type: 'modifyScalingProcess',
+          action: 'suspend',
+          processes: toSuspend,
+          asgName: serverGroup.name,
+          regions: [serverGroup.region],
+          credentials: serverGroup.account,
+        });
+      }
+
+      var submitMethod = function() {
+        return taskExecutor.executeTask({
+          job: job,
+          application: application,
+          description: 'Update Auto Scaling Processes for ' + serverGroup.name
+        });
+      };
+
+      var taskMonitorConfig = {
+        modalInstance: $modalInstance,
+        application: application,
+        title: 'Update Auto Scaling Processes for ' + serverGroup.name,
+        submitMethod: submitMethod,
+        forceRefreshEnabled: true,
+      };
+
+      $scope.taskMonitor = taskMonitorService.buildTaskMonitor(taskMonitorConfig);
+
+      $scope.taskMonitor.submit(submitMethod);
+    };
+
+    this.cancel = $modalInstance.dismiss;
+  });

--- a/app/scripts/modules/serverGroups/details/aws/modifyScalingProcesses.controller.spec.js
+++ b/app/scripts/modules/serverGroups/details/aws/modifyScalingProcesses.controller.spec.js
@@ -1,0 +1,112 @@
+'use strict';
+
+describe('Controller: modifyScalingProcesses', function() {
+
+  beforeEach(module('deckApp.serverGroup.details.aws.autoscaling.process.controller'));
+
+  beforeEach(inject(function($controller, $rootScope, _) {
+    this.$modalInstance = { close: angular.noop };
+    this.taskMonitorService = { buildTaskMonitor: angular.noop };
+    this.taskExecutor = { executeTask: angular.noop };
+    this.$scope = $rootScope.$new();
+
+    this.initializeController = function(serverGroup, processes) {
+      this.processes = processes;
+
+      this.controller = $controller('ModifyScalingProcessesCtrl', {
+        $scope: this.$scope,
+        serverGroup: serverGroup,
+        processes: this.processes,
+        application: {},
+        taskMonitorService: this.taskMonitorService,
+        taskExecutor: this.taskExecutor,
+        $modalInstance: this.$modalInstance,
+        _: _,
+      });
+    };
+  }));
+
+  describe('isDirty', function() {
+
+    beforeEach(function() {
+      this.serverGroup = {name: 'the-asg'};
+      this.processes = [
+        { name: 'Launch', enabled: true },
+        { name: 'Terminate', enabled: true }
+      ];
+    });
+    it('starts as not dirty',function() {
+      this.initializeController(this.serverGroup, this.processes);
+      expect(this.controller.isDirty()).toBe(false);
+    });
+
+    it('becomes dirty when a process is changed, becomes clean when the process is changed back', function() {
+      this.initializeController(this.serverGroup, this.processes);
+      expect(this.controller.isDirty()).toBe(false);
+
+      this.$scope.command[0].enabled = false;
+      expect(this.controller.isDirty()).toBe(true);
+
+      this.$scope.command[1].enabled = false;
+      expect(this.controller.isDirty()).toBe(true);
+
+      this.$scope.command[0].enabled = true;
+      expect(this.controller.isDirty()).toBe(true);
+
+      this.$scope.command[1].enabled = true;
+      expect(this.controller.isDirty()).toBe(false);
+    });
+  });
+
+  describe('form submission', function() {
+    beforeEach(function() {
+      this.serverGroup = {name: 'the-asg', region: 'us-east-1', account: 'test'};
+      this.processes = [
+        { name: 'Launch', enabled: true },
+        { name: 'Terminate', enabled: true },
+        { name: 'AddToLoadBalancer', enabled: false }
+      ];
+      this.taskMonitor = { submit: angular.noop };
+      spyOn(this.taskMonitorService, 'buildTaskMonitor').and.returnValue(this.taskMonitor);
+      spyOn(this.taskMonitor, 'submit').and.callFake(function(method) { method(); });
+      spyOn(this.taskExecutor, 'executeTask');
+    });
+
+    it('sends a resume job when processes are enabled', function() {
+      this.initializeController(this.serverGroup, this.processes);
+      this.$scope.command[2].enabled = true;
+      this.controller.submit();
+      var job = this.taskExecutor.executeTask.calls.mostRecent().args[0].job;
+
+      expect(job.length).toBe(1);
+      expect(job[0].action).toBe('resume');
+      expect(job[0].processes).toEqual(['AddToLoadBalancer']);
+    });
+
+    it('sends a suspend job when processes are enabled', function() {
+      this.initializeController(this.serverGroup, this.processes);
+      this.$scope.command[1].enabled = false;
+      this.controller.submit();
+      var job = this.taskExecutor.executeTask.calls.mostRecent().args[0].job;
+
+      expect(job.length).toBe(1);
+      expect(job[0].action).toBe('suspend');
+      expect(job[0].processes).toEqual(['Terminate']);
+    });
+
+    it('sends both a resume and suspend job when processes are enabled', function() {
+      this.initializeController(this.serverGroup, this.processes);
+      this.$scope.command[0].enabled = false;
+      this.$scope.command[2].enabled = true;
+      this.controller.submit();
+      var job = this.taskExecutor.executeTask.calls.mostRecent().args[0].job;
+
+      expect(job.length).toBe(2);
+      expect(job[0].action).toBe('resume');
+      expect(job[0].processes).toEqual(['AddToLoadBalancer']);
+      expect(job[1].action).toBe('suspend');
+      expect(job[1].processes).toEqual(['Launch']);
+    });
+  });
+
+});

--- a/app/scripts/modules/serverGroups/details/aws/modifyScalingProcesses.html
+++ b/app/scripts/modules/serverGroups/details/aws/modifyScalingProcesses.html
@@ -1,0 +1,31 @@
+<div modal-page>
+  <task-monitor monitor="taskMonitor"></task-monitor>
+  <form role="form">
+    <modal-close></modal-close>
+    <div class="modal-header">
+      <h3>Modify Scaling Processes for {{serverGroup.name}}</h3>
+    </div>
+    <div class="modal-body container-fluid form-horizontal">
+      <div class="form-group">
+        <div class="col-sm-offset-2 col-sm-10">
+          <div class="checkbox" ng-repeat="process in command">
+            <label>
+              <input type="checkbox" ng-model="process.enabled">
+              {{process.name}}
+            </label>
+            <help-field content="{{process.description}}" placement="right"></help-field>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="modal-footer">
+      <button class="btn btn-default" ng-click="ctrl.cancel()">Cancel</button>
+      <button type="submit"
+              class="btn btn-primary"
+              ng-disabled="!ctrl.isDirty()"
+              ng-click="ctrl.submit()">
+        Submit
+      </button>
+    </div>
+  </form>
+</div>

--- a/app/scripts/modules/serverGroups/details/aws/serverGroup.details.module.js
+++ b/app/scripts/modules/serverGroups/details/aws/serverGroup.details.module.js
@@ -1,5 +1,8 @@
 'use strict';
 
 angular.module('deckApp.serverGroup.details.aws', [
-  'deckApp.notifications'
+  'deckApp.notifications',
+  'deckApp.serverGroup.details.aws.controller',
+  'deckApp.serverGroup.details.aws.autoscaling.process',
+  'deckApp.serverGroup.details.aws.autoscaling.process.controller',
 ]);

--- a/app/scripts/modules/serverGroups/details/aws/serverGroupDetails.html
+++ b/app/scripts/modules/serverGroups/details/aws/serverGroupDetails.html
@@ -137,6 +137,16 @@
         <dd ng-if="!serverGroup.launchConfig.userData">[none]</dd>
       </dl>
     </collapsible-section>
+    <collapsible-section heading="Scaling Processes">
+      <ul class="scaling-processes">
+        <li ng-repeat="process in autoScalingProcesses">
+          <span is-visible="process.enabled" class="glyphicon glyphicon-ok small"></span>
+          <span ng-class="{'text-disabled': !process.enabled}">{{process.name}}</span>
+          <help-field content="{{process.description}}" placement="right"></help-field>
+        </li>
+      </ul>
+      <a href ng-click="ctrl.toggleScalingProcesses()">Edit Scaling Processes</a>
+    </collapsible-section>
     <collapsible-section heading="Security Groups">
       <ul>
         <li ng-repeat="securityGroup in securityGroups">

--- a/app/scripts/modules/serverGroups/serverGroup.module.js
+++ b/app/scripts/modules/serverGroups/serverGroup.module.js
@@ -8,5 +8,5 @@ angular
     'deckApp.serverGroup.configure.gce',
     'deckApp.serverGroup.configure.common',
     'deckApp.serverGroup.display.tasks.tag',
-    'deckApp.serverGroup.details.aws.controller',
+    'deckApp.serverGroup.details.aws',
   ]);

--- a/app/scripts/services/urlbuilder.js
+++ b/app/scripts/services/urlbuilder.js
@@ -109,7 +109,7 @@ angular.module('deckApp.urlBuilder', ['ui.router'])
     function createCloneTask(task) {
       var regionAndName = task.getValueFor('deploy.server.groups');
       var account = task.getValueFor('deploy.account.name');
-      if (!regionAndName) {
+      if (!regionAndName || !Object.keys(regionAndName)[0]) {
         return false;
       }
 

--- a/app/styles/details.less
+++ b/app/styles/details.less
@@ -175,5 +175,10 @@
       border-top: 1px solid #c4c4c4;
     }
   }
+  .scaling-processes {
+    .glyphicon-ok {
+      color: @healthy_green_icon;
+    }
+  }
 }
 

--- a/app/styles/main.less
+++ b/app/styles/main.less
@@ -864,3 +864,7 @@ feedback {
   padding-bottom: 0;
   margin-bottom: 0;
 }
+
+.text-disabled {
+  color: @mid_lighter_grey;
+}


### PR DESCRIPTION
Displays scaling processes in the server group details, with a check mark next to enabled ones and a help bubble that appears to the right:

![screen shot 2015-01-27 at 4 45 28 pm](https://cloud.githubusercontent.com/assets/73450/5930424/5214569a-a644-11e4-8d80-7bd79923451c.png)

Help content is taken directly from Gate's documentation.

Edit screen allows users to enable or suspend processes.

![screen shot 2015-01-27 at 4 49 54 pm](https://cloud.githubusercontent.com/assets/73450/5930441/8d88fafa-a644-11e4-8ca7-842d7d0e308e.png)
