### PR TITLE
nicer failures

### DIFF
--- a/app/scripts/controllers/ApplicationCtrl.js
+++ b/app/scripts/controllers/ApplicationCtrl.js
@@ -4,6 +4,11 @@
 angular.module('deckApp')
   .controller('ApplicationCtrl', function($scope, application, executionsService, taskTracker) {
     $scope.application = application;
+    $scope.insightTarget = application;
+    if (application.notFound) {
+      return;
+    }
+
     application.enableAutoRefresh($scope);
 
     executionsService.getAll().then(function(oldExecutions) {

--- a/app/scripts/controllers/InsightCtrl.js
+++ b/app/scripts/controllers/InsightCtrl.js
@@ -6,7 +6,9 @@ angular.module('deckApp')
     $scope.sortFilter = {};
 
     function isSideNavHideable() {
-      return  $state.is('home.applications.application.insight.clusters') && $scope.application.serverGroups.length === 0;
+      return  $state.is('home.applications.application.insight.clusters') &&
+        $scope.application.serverGroups &&
+        $scope.application.serverGroups.length === 0;
     }
 
     $scope.$on('$stateChangeSuccess', function() {

--- a/app/scripts/providers/states.js
+++ b/app/scripts/providers/states.js
@@ -4,6 +4,10 @@ angular.module('deckApp')
   .provider('states', function($stateProvider, $urlRouterProvider, stateHelperProvider, deliveryStates) {
     this.setStates = function() {
       $urlRouterProvider.otherwise('/');
+      // Don't crash on trailing slashes
+      $urlRouterProvider.when('/{path:.*}/', ['$match', function($match) {
+        return '/' + $match.path;
+      }]);
       $urlRouterProvider.when('/applications/{application}', '/applications/{application}/clusters');
       $urlRouterProvider.when('/', '/applications');
       $urlRouterProvider.when(
@@ -358,7 +362,11 @@ angular.module('deckApp')
         },
         resolve: {
           application: ['$stateParams', 'applicationReader', function($stateParams, applicationReader) {
-            return applicationReader.getApplication($stateParams.application, {tasks: true});
+            return applicationReader.getApplication($stateParams.application, {tasks: true})
+              .then(
+              function(app) { return app; },
+              function() { return {notFound: true, name: $stateParams.application}; }
+            );
           }]
         },
         data: {

--- a/app/views/application.html
+++ b/app/views/application.html
@@ -7,7 +7,11 @@
       </a>
       {{application.name}}
     </h2>
-    <ul class="nav nav-pills">
+    <div ng-if="application.notFound">
+      <h1 class="text-center">&lt;404&gt;</h1>
+      <p class="text-center">Please check your URL - we can't find any data for <em>{{application.name}}</em>.</p>
+    </div>
+    <ul class="nav nav-pills" ng-if="!application.notFound">
       <li>
         <a ui-sref=".executions"
            analytics-on="click" analytics-category="Application View" analytics-label="Delivery tab selected"

--- a/app/views/insight.html
+++ b/app/views/insight.html
@@ -1,4 +1,4 @@
-<div class="row insight">
+<div class="row insight" ng-if="!insightTarget.notFound">
   <div class="col-md-9 col-sm-8">
     <div class="row">
 


### PR DESCRIPTION
- Don't redirect to the 404 page when an application is not found. Change the view, but let the user refresh the page to try again.
- Strip trailing slashes off URLs - otherwise, we 404 on valid URLs.
