### PR TITLE
falsy check on q param to avoid state change

### DIFF
--- a/app/scripts/modules/clusterFilter/clusterFilterService.js
+++ b/app/scripts/modules/clusterFilter/clusterFilterService.js
@@ -10,8 +10,12 @@ angular
       var defPrimary = 'account';
       var defSecondary = 'region';
 
-      $location.search('q',
-          ClusterFilterModel.sortFilter.filter.length > 0 ? ClusterFilterModel.sortFilter.filter : null);
+      var filter = ClusterFilterModel.sortFilter.filter.length ? ClusterFilterModel.sortFilter.filter : null,
+          locationQ = $location.search().q || null;
+      if (filter !== locationQ) {
+        $location.search('q',
+            ClusterFilterModel.sortFilter.filter.length > 0 ? ClusterFilterModel.sortFilter.filter : undefined);
+      }
       $location.search('hideHealth', ClusterFilterModel.sortFilter.hideHealthy ? true : null);
       $location.search('hideInstances', ClusterFilterModel.sortFilter.showAllInstances ? null : true);
       $location.search('hideDisabled', ClusterFilterModel.sortFilter.hideDisabled ? true : null);


### PR DESCRIPTION
When navigating to a details state from a clean, non-filtered clusters view, we end up triggering a state change event, which closes all modals. Like all things associated with keeping the state values of a parent state in the URL (aka the cluster filtering), this gets nasty quickly.

By default, the `q` (filter) parameter is `undefined`. When we synchronize the filters, we should not set the value to `null` if it doesn't exist, because we all know `null !== undefined` in javascript.

Unfortunately, we also know that `undefined !== undefined` in javascript because sure why not.

So, we are left to do a falsy check on the model, where the value might be `''` or `null`, but to perform the falsy check without blowing up or suppressing our jshint rules (by using `!=` because what kind of monster would do that), we'll just coerce our checked values to null.

This is gross, I hate it, but we hate almost everything about the cluster filter state management, so what's one more thing to hate about it. Happy Friday.

Fixes https://github.com/spinnaker/deck/issues/601
