### PR TITLE
include vpcId parameter for security groups

### DIFF
--- a/app/scripts/controllers/InstanceDetailsCtrl.js
+++ b/app/scripts/controllers/InstanceDetailsCtrl.js
@@ -22,7 +22,7 @@ angular.module('deckApp')
     }
 
     function retrieveInstance() {
-      var instanceSummary, loadBalancers, account, region;
+      var instanceSummary, loadBalancers, account, region, vpcId;
       if (!application.clusters) {
         // standalone instance
         instanceSummary = {};
@@ -38,6 +38,7 @@ angular.module('deckApp')
                 loadBalancers = serverGroup.loadBalancers;
                 account = serverGroup.account;
                 region = serverGroup.region;
+                vpcId = serverGroup.vpcId;
                 return true;
               }
             });
@@ -52,6 +53,7 @@ angular.module('deckApp')
           extractHealthMetrics(details);
           $scope.instance.account = account;
           $scope.instance.region = region;
+          $scope.instance.vpcId = vpcId;
           $scope.instance.loadBalancers = loadBalancers;
           $scope.baseIpAddress = details.publicDnsName || details.privateIpAddress;
         },

--- a/app/scripts/controllers/SecurityGroupDetailsCtrl.js
+++ b/app/scripts/controllers/SecurityGroupDetailsCtrl.js
@@ -11,7 +11,7 @@ angular.module('deckApp')
     };
 
     function extractSecurityGroup() {
-      securityGroupService.getSecurityGroupDetails(application, securityGroup.accountId, securityGroup.region, securityGroup.name).then(function (details) {
+      securityGroupService.getSecurityGroupDetails(application, securityGroup.accountId, securityGroup.region, securityGroup.vpcId, securityGroup.name).then(function (details) {
         $scope.state.loading = false;
         $scope.securityGroup = details;
 

--- a/app/scripts/directives/securityGroup.js
+++ b/app/scripts/directives/securityGroup.js
@@ -27,6 +27,7 @@ angular.module('deckApp')
               region: securityGroup.region,
               accountId: securityGroup.accountName,
               name: securityGroup.name,
+              vpcId: securityGroup.vpcId,
             };
             // also stolen from uiSref directive
             scope.$state.go('.securityGroupDetails', params, {relative: base, inherit: true});

--- a/app/scripts/directives/securityGroupCounts.js
+++ b/app/scripts/directives/securityGroupCounts.js
@@ -6,7 +6,6 @@ angular.module('deckApp')
     return {
       templateUrl: 'views/application/securityGroupCounts.html',
       restrict: 'E',
-      replace: true,
       scope: {
         container: '='
       },

--- a/app/scripts/modules/loadBalancers/loadBalancerDetails.html
+++ b/app/scripts/modules/loadBalancers/loadBalancerDetails.html
@@ -87,7 +87,7 @@
     <collapsible-section heading="Security Groups">
       <ul>
         <li ng-repeat="securityGroup in securityGroups">
-          <a ui-sref="^.securityGroupDetails({name:securityGroup.name, accountId: loadBalancer.account, region: loadBalancer.region})">
+          <a ui-sref="^.securityGroupDetails({name:securityGroup.name, accountId: loadBalancer.account, region: loadBalancer.region, vpcId: loadBalancer.vpcId})">
             {{securityGroup.name}} ({{securityGroup.id}})
           </a>
         </li>

--- a/app/scripts/modules/serverGroups/details/aws/serverGroupDetails.html
+++ b/app/scripts/modules/serverGroups/details/aws/serverGroupDetails.html
@@ -150,7 +150,7 @@
     <collapsible-section heading="Security Groups">
       <ul>
         <li ng-repeat="securityGroup in securityGroups">
-          <a ui-sref="^.securityGroupDetails({name: securityGroup.name, accountId: securityGroup.accountName, region: serverGroup.region})">
+          <a ui-sref="^.securityGroupDetails({name: securityGroup.name, accountId: securityGroup.accountName, region: serverGroup.region, vpcId: serverGroup.vpcId})">
             {{securityGroup.name}} ({{securityGroup.id}})
           </a>
         </li>

--- a/app/scripts/modules/serverGroups/details/gce/serverGroupDetails.html
+++ b/app/scripts/modules/serverGroups/details/gce/serverGroupDetails.html
@@ -138,7 +138,7 @@
     <collapsible-section heading="Security Groups">
       <ul>
         <li ng-repeat="securityGroup in securityGroups">
-          <a ui-sref="^.securityGroupDetails({name: securityGroup.name, accountId: securityGroup.accountName, region: serverGroup.region})">
+          <a ui-sref="^.securityGroupDetails({name: securityGroup.name, accountId: securityGroup.accountName, region: serverGroup.region, vpcId: serverGroup.vpcId})">
             {{securityGroup.name}} ({{securityGroup.id}})
           </a>
         </li>

--- a/app/scripts/providers/states.js
+++ b/app/scripts/providers/states.js
@@ -108,7 +108,7 @@ angular.module('deckApp')
 
       var securityGroupDetails = {
         name: 'securityGroupDetails',
-        url: '/securityGroupDetails?name&accountId&region',
+        url: '/securityGroupDetails?name&accountId&region&vpcId',
         views: {
           'detail@home.applications.application.insight': {
             templateUrl: 'views/application/connection/securityGroupDetails.html',
@@ -121,7 +121,8 @@ angular.module('deckApp')
             return {
               name: $stateParams.name,
               accountId: $stateParams.accountId,
-              region: $stateParams.region
+              region: $stateParams.region,
+              vpcId: $stateParams.vpcId,
             };
           }]
         },

--- a/app/scripts/services/securityGroupService.js
+++ b/app/scripts/services/securityGroupService.js
@@ -118,8 +118,8 @@ angular.module('deckApp')
       return securityGroupIndex;
     }
 
-    function getSecurityGroupDetails(application, account, region, id) {
-      return Restangular.one('securityGroups', account).one(id).get({region: region}).then(function(details) {
+    function getSecurityGroupDetails(application, account, region, vpcId, id) {
+      return Restangular.one('securityGroups', account).one(id).get({region: region, vpcId: vpcId}).then(function(details) {
         if (details && details.inboundRules) {
           details.ipRangeRules = details.inboundRules.filter(function(rule) {
             return rule.range;

--- a/app/views/application/connection/navigation.html
+++ b/app/views/application/connection/navigation.html
@@ -22,7 +22,7 @@
   <div class="sub-nav-item">
     <h4>{{heading}}</h4>
     <a ng-repeat="securityGroup in ctrl.getSecurityGroupsFor(heading) | orderBy:'name'"
-       ui-sref=".connection.securityGroupDetails({securityGroup: securityGroup.name, securityGroupRegion: securityGroup.region, securityGroupAccount: securityGroup.accountName, name: securityGroup.name, region: securityGroup.region, accountId: securityGroup.accountName})"
+       ui-sref=".connection.securityGroupDetails({securityGroup: securityGroup.name, securityGroupRegion: securityGroup.region, securityGroupAccount: securityGroup.accountName, name: securityGroup.name, region: securityGroup.region, accountId: securityGroup.accountName, vpcId: securityGroup.vpcId})"
        ng-class="{active: $state.includes('**.connection.**', {securityGroup: securityGroup.name, securityGroupRegion: securityGroup.region, securityGroupAccount: securityGroup.accountName} )}">
       {{ctrl.getSecurityGroupLabel(securityGroup)}}
       <security-group-counts container="securityGroup.usages"></security-group-counts>

--- a/app/views/application/connection/securityGroup.html
+++ b/app/views/application/connection/securityGroup.html
@@ -1,13 +1,13 @@
 <div class="rollup-entry"
-     ng-class="{active: $state.includes('**.securityGroupDetails', {region: securityGroup.region, accountId: securityGroup.accountName, name: securityGroup.name})}">
+     ng-class="{active: $state.includes('**.securityGroupDetails', {region: securityGroup.region, accountId: securityGroup.accountName, name: securityGroup.name, vpcId: securityGroup.vpcId})}">
   <div class="container-fluid"
        ng-click="loadDetails($event)">
     <div class="row">
       <div class="rollup-summary col-sm-12">
       <a class="rollup-title-cell"
-         ui-sref=".securityGroupDetails({region: securityGroup.region, accountId: securityGroup.accountName, name: securityGroup.name})">
+         ui-sref=".securityGroupDetails({region: securityGroup.region, accountId: securityGroup.accountName, name: securityGroup.name, vpcId: securityGroup.vpcId})">
         <span class="glyphicon glyphicon-transfer"></span> {{securityGroup.name}}
-        <account-tag account="securityGroup.account" pad="left"></account-tag>
+        <account-tag account="securityGroup.accountName" pad="left"></account-tag>
       </a>
       </div>
     </div>

--- a/app/views/application/instanceDetails.html
+++ b/app/views/application/instanceDetails.html
@@ -99,7 +99,7 @@
     <collapsible-section ng-if="!instance.notFound" heading="Security Groups">
         <ul>
           <li ng-repeat="securityGroup in instance.securityGroups | orderBy:'groupName'">
-            <a ui-sref="^.securityGroupDetails({name:securityGroup.groupName, accountId: instance.account, region: instance.region})">
+            <a ui-sref="^.securityGroupDetails({name:securityGroup.groupName, accountId: instance.account, region: instance.region, vpcId: instance.vpcId})">
               {{securityGroup.groupName}} ({{securityGroup.groupId}})
             </a>
           </li>


### PR DESCRIPTION
Fixes https://github.com/spinnaker/deck/issues/613

Can be merged in any time - does not need to wait for Mort/Gate updates, which will ignore the `vpcId` field until that parameter is read and accepted by them.
