### PR TITLE
validate pipeline name via regex, show warnings

### DIFF
--- a/app/scripts/modules/pipelines/config/actions/create/createPipelineModal.html
+++ b/app/scripts/modules/pipelines/config/actions/create/createPipelineModal.html
@@ -17,7 +17,20 @@
         <div class="col-md-7">
           <input type="text" class="form-control input-sm"
                  ng-model="command.name"
+                 name="name"
+                 required
+                 ng-pattern="/^[a-zA-z_0-9-\s]*$/"
                  validate-unique="existingNames"/>
+        </div>
+      </div>
+      <div class="form-group row slide-in" ng-if="form.name.$error.pattern">
+        <div class="col-sm-9 col-sm-offset-3 error-message">
+          <span>Pipeline name can only contain letters, numbers, spaces, dashes, and underscores.</span>
+        </div>
+      </div>
+      <div class="form-group row slide-in" ng-if="form.name.$error.validateUnique">
+        <div class="col-sm-9 col-sm-offset-3 error-message">
+          <span>There is already a pipeline with that name.</span>
         </div>
       </div>
       <div class="form-group" ng-if="templates.length > 1">

--- a/app/scripts/modules/pipelines/config/actions/rename/renamePipelineModal.controller.js
+++ b/app/scripts/modules/pipelines/config/actions/rename/renamePipelineModal.controller.js
@@ -11,13 +11,15 @@ angular.module('deckApp.pipelines.rename')
 
     $scope.pipeline = pipeline;
     $scope.existingNames = _.without(_.pluck(application.pipelines, 'name'), currentName);
-    $scope.newName = currentName;
+    $scope.command = {
+      newName: currentName
+    };
 
     this.renamePipeline = function() {
       pipeline.name = $scope.newName;
-      return pipelineConfigService.renamePipeline(application.name, currentName, $scope.newName).then(
+      return pipelineConfigService.renamePipeline(application.name, currentName, $scope.command.newName).then(
         function() {
-          $scope.pipeline.name = $scope.newName;
+          $scope.pipeline.name = $scope.command.newName;
           $modalInstance.close();
         },
         function(response) {

--- a/app/scripts/modules/pipelines/config/actions/rename/renamePipelineModal.controller.spec.js
+++ b/app/scripts/modules/pipelines/config/actions/rename/renamePipelineModal.controller.spec.js
@@ -48,7 +48,9 @@ describe('Controller: renamePipelineModal', function() {
           submittedCurrentName = null,
           submittedApplication = null;
 
-      this.$scope.newName = 'd';
+      this.$scope.command = {
+        newName: 'd'
+      };
 
       spyOn(this.pipelineConfigService, 'renamePipeline').and.callFake(function (applicationName, currentName, newName) {
         submittedNewName = newName;

--- a/app/scripts/modules/pipelines/config/actions/rename/renamePipelineModal.html
+++ b/app/scripts/modules/pipelines/config/actions/rename/renamePipelineModal.html
@@ -11,8 +11,21 @@
         </div>
         <div class="col-md-7">
           <input type="text" class="form-control input-sm"
-                 ng-model="newName"
+                 ng-model="command.newName"
+                 name="name"
+                 required
+                 ng-pattern="/^[a-zA-z_0-9-\s]*$/"
                  validate-unique="existingNames"/>
+        </div>
+      </div>
+      <div class="form-group row slide-in" ng-if="form.name.$error.pattern">
+        <div class="col-sm-9 col-sm-offset-3 error-message">
+          <span>Pipeline name can only contain letters, numbers, spaces, dashes, and underscores.</span>
+        </div>
+      </div>
+      <div class="form-group row slide-in" ng-if="form.name.$error.validateUnique">
+        <div class="col-sm-9 col-sm-offset-3 error-message">
+          <span>There is already a pipeline with that name.</span>
         </div>
       </div>
     </form>


### PR DESCRIPTION
We're going to say this fixes https://github.com/spinnaker/deck/issues/598

Don't allow anything but letters, numbers, spaces, dashes, and underscores in pipeline names.
