### PR TITLE
Allowing for authentication to be turned off.

### DIFF
--- a/app/scripts/modules/authentication/authentication.module.js
+++ b/app/scripts/modules/authentication/authentication.module.js
@@ -4,15 +4,17 @@ angular.module('deckApp.authentication', [
   'ui.bootstrap',
   'deckApp.authentication.service',
   'deckApp.authentication.directive',
-
+  'deckApp.settings',
 ])
   .config(function ($httpProvider) {
     $httpProvider.interceptors.push('gateRequestInterceptor');
   })
-  .run(function (authenticationService, $timeout) {
+  .run(function ($timeout, authenticationService, settings) {
     // timeout allows initial rerouting to occur; otherwise, we potentially immediately redirect on page load,
     // which closes the "Authenticating..." modal
-    $timeout(authenticationService.authenticateUser);
+    if(settings.authEnabled) {
+      $timeout(authenticationService.authenticateUser);
+    }
   })
   .factory('gateRequestInterceptor', function (settings) {
     return {

--- a/app/scripts/modules/authentication/authenticationProvider.spec.js
+++ b/app/scripts/modules/authentication/authenticationProvider.spec.js
@@ -26,6 +26,7 @@ describe('authenticationProvider: application startup', function() {
 
   describe('authenticateUser', function() {
     it('requests authentication from gate, then sets authentication name field', function() {
+      if(!this.settings.authEnabled) { pending(); } //prevents the test from running if authentication is not enabled
       this.$http.whenGET(this.settings.gateUrl + '/auth/info').respond(200, {email: 'joe!'});
       this.$timeout.flush();
       this.$http.flush();
@@ -37,6 +38,7 @@ describe('authenticationProvider: application startup', function() {
     });
 
     it('requests authentication from gate, then opens modal and redirects on 401', function() {
+      if(!this.settings.authEnabled) { pending(); } //prevents the test from running if authentication is not enabled
       var redirectUrl = 'abc';
       spyOn(this.redirectService, 'redirect').and.callFake(function(url) {
         redirectUrl = url;

--- a/app/scripts/settings/settings.js
+++ b/app/scripts/settings/settings.js
@@ -15,7 +15,8 @@ angular.module('deckApp.settings', [])
     defaults: {
       account: 'test',
       region: 'us-east-1'
-    }
+    },
+    authEnabled: true
   });
 
 window.tracking = {


### PR DESCRIPTION
-  Needed for UI End-to-end testing
-  Useful for when OneLogin goes down again.
