### PR TITLE
auto-focus on task monitor close button

### DIFF
--- a/app/scripts/modules/tasks/monitor/taskMonitor.html
+++ b/app/scripts/modules/tasks/monitor/taskMonitor.html
@@ -48,7 +48,7 @@
     </div>
   </div>
   <div class="modal-footer" ng-if="!taskMonitor.error">
-    <button class="btn btn-primary" ng-click="taskMonitor.closeModal()">Close</button>
+    <button class="btn btn-primary" ng-click="taskMonitor.closeModal()" auto-focus>Close</button>
   </div>
   <div class="modal-footer" ng-if="taskMonitor.error">
     <button class="btn btn-primary" ng-if="taskMonitor.error" ng-click="taskMonitor.error = null">Go back and try to fix


### PR DESCRIPTION
Resolves a super annoying issue where you submit a modal form by pressing enter, then press enter again, not knowing the focus is on the form behind the monitor, which then resubmits the form, which probably doesn't work out well.
