### PR TITLE
display suspended stage as gray, show suspended stage in status

### DIFF
--- a/app/scripts/modules/delivery/executionStatus.controller.js
+++ b/app/scripts/modules/delivery/executionStatus.controller.js
@@ -36,6 +36,16 @@ angular.module('deckApp.delivery.executionStatus.controller', [
       return 'Unknown';
     };
 
+    controller.getSuspendedStage = function(execution) {
+      var suspended = execution.stageSummaries.filter(function(stage) {
+        return stage.isSuspended;
+      });
+      if (suspended && suspended.length) {
+        return suspended[0].name;
+      }
+      return 'Unknown';
+    };
+
     controller.cancelExecution = function(execution) {
       confirmationModalService.confirm({
         header: 'Really stop execution of ' + execution.name + '?',

--- a/app/scripts/modules/delivery/executionStatus.controller.spec.js
+++ b/app/scripts/modules/delivery/executionStatus.controller.spec.js
@@ -20,7 +20,38 @@ describe('Controller: executionStatus', function () {
     })
   );
 
-  it('should instantiate the controller', function () {
-    expect(controller).toBeDefined();
+  describe('getSuspendedStage', function() {
+    it('returns first suspended stage summary', function() {
+      var execution = {
+        stageSummaries: [
+          { isSuspended: false, name: 'not-suspended' },
+          { isSuspended: true, name: 'is-suspended' },
+          { isSuspended: true, name: 'is-also-suspended' },
+        ]
+      };
+      expect(controller.getSuspendedStage(execution)).toBe('is-suspended');
+    });
+
+    it('returns "Unknown" when no stage is suspended', function() {
+      var execution = {
+        stageSummaries: [
+          { isSuspended: false, name: 'not-suspended' },
+          { isSuspended: false, name: 'also-not-suspended' },
+        ]
+      };
+      expect(controller.getSuspendedStage(execution)).toBe('Unknown');
+    });
+
+    it('returns "Unknown" when no stage is suspended', function() {
+      var execution = {
+        stageSummaries: [
+          { isSuspended: false, name: 'not-suspended' },
+          { isSuspended: true, name: 'is-suspended' },
+          { isSuspended: false, name: 'also-not-suspended' },
+        ]
+      };
+      expect(controller.getSuspendedStage(execution)).toBe('is-suspended');
+    });
   });
+
 });

--- a/app/scripts/modules/delivery/executionStatus.html
+++ b/app/scripts/modules/delivery/executionStatus.html
@@ -69,7 +69,7 @@
           </h5>
           <ul>
             <li>
-              Next Stage: {{ ctrl.getRunningStage(execution) }}
+              On: {{ ctrl.getSuspendedStage(execution) }}
             </li>
           </ul>
         </span>

--- a/app/scripts/modules/delivery/pipelineExecutions.controller.js
+++ b/app/scripts/modules/delivery/pipelineExecutions.controller.js
@@ -54,6 +54,7 @@ angular.module('deckApp.delivery.pipelineExecutions.controller', [
       running: 'Running',
       completed: 'Completed',
       canceled: 'Canceled',
+      suspended: 'Suspended',
     };
 
     $scope.scale = {
@@ -63,8 +64,8 @@ angular.module('deckApp.delivery.pipelineExecutions.controller', [
       status: d3Service
         .scale
         .ordinal()
-        .domain(['completed', 'failed', 'running', 'not_started', 'canceled'])
-        .range(['#769D3E', '#b82525','#2275b8', '#cccccc']),
+        .domain(['completed', 'failed', 'running', 'not_started', 'canceled', 'suspended'])
+        .range(['#769D3E', '#b82525','#2275b8', '#cccccc', '#cccccc', '#cccccc']),
     };
 
     controller.solo = function(facet, value) {


### PR DESCRIPTION
@sthadeshwar This will do the following:
- show the bar as gray when a stage is suspended
- show "On: {{suspended stage name}}" instead of "Next: Unknown" under the "Suspended" label to the left of the execution bar.
