### PR TITLE
memoize computationally expensive calls

### DIFF
--- a/app/scripts/modules/account/accountService.js
+++ b/app/scripts/modules/account/accountService.js
@@ -79,7 +79,7 @@ angular.module('deckApp.account.service', [
       });
     }
 
-    function getRegionsKeyedByAccount() {
+    var getRegionsKeyedByAccount = _.memoize(function() {
       var deferred = $q.defer();
       listAccounts().then(function(accounts) {
         $q.all(accounts.reduce(function(acc, account) {
@@ -94,7 +94,7 @@ angular.module('deckApp.account.service', [
         });
       });
       return deferred.promise;
-    }
+    });
 
     function getAccountDetails(accountName) {
       return Restangular.one('credentials', accountName)

--- a/app/scripts/services/awsInstanceTypeService.js
+++ b/app/scripts/services/awsInstanceTypeService.js
@@ -252,7 +252,7 @@ angular.module('deckApp.aws.instanceType.service', [
       return $q.when(categories);
     }
 
-    function getAllTypesByRegion() {
+    var getAllTypesByRegion = _.memoize(function getAllTypesByRegion() {
 
       var instanceTypesEndpoint = Restangular.withConfig(function (RestangularConfigurer) {
         RestangularConfigurer.setDefaultHttpFields({cache: true});
@@ -261,7 +261,7 @@ angular.module('deckApp.aws.instanceType.service', [
       return instanceTypesEndpoint.all('instanceTypes').getList().then(function (types) {
         return _.groupBy(types, 'region');
       });
-    }
+    });
 
     function getAvailableTypesForRegions(availableRegions, selectedRegions) {
       selectedRegions = selectedRegions || [];


### PR DESCRIPTION
These calls each typically take between 400 and 1200 ms, but the data never changes once loaded.

This should speed up switching to the deploy tab, as well as create/clone ASG modal rendering significantly.
