### PR TITLE
route to pipeline config if no executions or configurations

### DIFF
--- a/app/scripts/modules/delivery/pipelineExecutions.controller.js
+++ b/app/scripts/modules/delivery/pipelineExecutions.controller.js
@@ -6,7 +6,7 @@ angular.module('deckApp.delivery.pipelineExecutions.controller', [
   'deckApp.pipelines.config.service',
   'deckApp.utils.scrollTo'
 ])
-  .controller('pipelineExecutions', function($scope, $q, executionsService, d3Service, pipelineConfigService, scrollToService) {
+  .controller('pipelineExecutions', function($scope, $q, $state, executionsService, d3Service, pipelineConfigService, scrollToService) {
     var controller = this;
 
     $scope.viewState = {
@@ -121,6 +121,11 @@ angular.module('deckApp.delivery.pipelineExecutions.controller', [
       // if we detected the loading of a details section, scroll it into view
       if ($scope.detailsTarget) {
         scrollToService.scrollTo('execution-' + $scope.detailsTarget, 250);
+      }
+      var noExecutions = !results.executions || !results.executions.length;
+      var noConfigurations = !results.configurations.length;
+      if(noExecutions && noConfigurations) {
+        $state.go('^.pipelineConfig');
       }
     }
 

--- a/app/scripts/modules/delivery/pipelineExecutions.controller.spec.js
+++ b/app/scripts/modules/delivery/pipelineExecutions.controller.spec.js
@@ -6,23 +6,43 @@ describe('Controller: pipelineExecutions', function () {
 
   var controller;
   var scope;
+  var $state;
+  var pipelineConfigService;
+  var executionsService;
+  var $q;
 
   beforeEach(
     module('deckApp.delivery.pipelineExecutions.controller')
   );
 
   beforeEach(
-    inject(function ($rootScope, $controller) {
+    inject(function ($rootScope, $controller, _$state_, _pipelineConfigService_, _executionsService_, _$q_) {
       scope = $rootScope.$new();
+      $state = { go: angular.noop };
+      pipelineConfigService = _pipelineConfigService_;
+      executionsService = _executionsService_;
+      $q = _$q_;
       scope.application = {name: 'foo'};
-      controller = $controller('pipelineExecutions', {
-        $scope: scope
-      });
+
+      this.initializeController = function() {
+        controller = $controller('pipelineExecutions', {
+          $scope: scope,
+          $state: $state,
+          pipelineConfigService: pipelineConfigService,
+          executionsService: executionsService,
+        });
+      };
     })
   );
 
-  it('should instantiate the controller', function () {
-    expect(controller).toBeDefined();
+  it('should reroute to pipeline config when no execution history or configurations', function () {
+    spyOn($state, 'go');
+    spyOn(pipelineConfigService, 'getPipelinesForApplication').and.returnValue($q.when({ plain: angular.noop, length: 0 }));
+    spyOn(executionsService, 'getAll').and.returnValue($q.when([]));
+    this.initializeController();
+    scope.$digest();
+
+    expect($state.go).toHaveBeenCalledWith('^.pipelineConfig');
   });
 });
 

--- a/app/scripts/modules/pipelines/config/pipelineConfig.html
+++ b/app/scripts/modules/pipelines/config/pipelineConfig.html
@@ -1,8 +1,8 @@
 <div class="row" ng-if="application.pipelines.length">
   <div class="col-md-4">
     <a class="btn btn-link" ui-sref="^.executions">
-      <span class="glyphicon glyphicon-arrow-left"></span>
-      Back to Executions
+      <span class="small glyphicon glyphicon glyphicon-circle-arrow-left"></span>
+      Pipeline Executions
     </a>
   </div>
   <div class="col-md-4 text-right">


### PR DESCRIPTION
If there are no pipelines configured and no execution history, reroute the `/executions` endpoint to `/pipelines`

fixes https://github.com/spinnaker/deck/issues/652
