### PR TITLE
limit to last five runs, fixed filters, sticky headers

### DIFF
--- a/app/scripts/modules/delivery/executionGroup.html
+++ b/app/scripts/modules/delivery/executionGroup.html
@@ -8,7 +8,7 @@
         Status
       </div>
     </div>
-    <div class="row" ng-repeat="execution in executionGroup = (executions | executions:filter:grouping)">
+    <div class="row" ng-repeat="execution in executionGroup = (executions | executions:filter:grouping | limitTo: filter.count )">
       <div class="col-md-12">
         <execution execution="execution"
                    executions="executions"

--- a/app/scripts/modules/delivery/executionGroupHeading.html
+++ b/app/scripts/modules/delivery/executionGroupHeading.html
@@ -1,6 +1,6 @@
 <div class="col-md-12">
   <div class="row">
-    <div class="col-md-12 execution-group-heading">
+    <div class="col-md-12 execution-group-heading" sticky-header>
       <div class="row">
         <div class="col-md-10" ng-click="ctrl.toggle()">
           <h4>

--- a/app/scripts/modules/delivery/executionStatus.html
+++ b/app/scripts/modules/delivery/executionStatus.html
@@ -78,6 +78,11 @@
         <h5 class="status status-completed">
           COMPLETED
         </h5>
+        <ul>
+          <li>
+            {{execution.runningTime}}
+          </li>
+        </ul>
       </span>
       <span ng-switch-default>
         Unknown

--- a/app/scripts/modules/delivery/pipelineExecutions.controller.js
+++ b/app/scripts/modules/delivery/pipelineExecutions.controller.js
@@ -14,6 +14,7 @@ angular.module('deckApp.delivery.pipelineExecutions.controller', [
     };
 
     $scope.filter = {
+      count: 5,
       execution: {
         status: {
           running: true,
@@ -120,7 +121,7 @@ angular.module('deckApp.delivery.pipelineExecutions.controller', [
       });
       // if we detected the loading of a details section, scroll it into view
       if ($scope.detailsTarget) {
-        scrollToService.scrollTo('execution-' + $scope.detailsTarget, 250);
+        scrollToService.scrollTo('execution-' + $scope.detailsTarget, '.execution-groups', 415);
       }
       var noExecutions = !results.executions || !results.executions.length;
       var noConfigurations = !results.configurations.length;

--- a/app/scripts/modules/delivery/pipelineExecutions.executionFilter.html
+++ b/app/scripts/modules/delivery/pipelineExecutions.executionFilter.html
@@ -50,25 +50,38 @@
     </div>
   </div>
   <div class="form-group">
-    <label>Scaling</label>
-    <div class="btn-group">
-      <label class="btn btn-default btn"
-             ng-model="filter.stage.scale"
-             btn-radio="'absolute'">
-        <span class="glyphicon glyphicon-align-left" title="Absolute" aria-hidden="true"></span>
-      </label>
-      <label class="btn btn-default btn"
-             ng-model="filter.stage.scale"
-             btn-radio="'fixed'">
-        <span class="glyphicon glyphicon-align-justify" title="Fixed" aria-hidden="true"></span>
-      </label>
-      <label class="btn btn-default btn"
-             ng-model="filter.stage.scale"
-             btn-radio="'relative'">
-        <span class="glyphicon glyphicon-tasks" title="Relative" aria-hidden="true"></span>
-      </label>
-    </div>
+    <label>Show</label>
+    <select class="input input-sm" ng-model="filter.count" style="width: 50px">
+      <option value="1">1</option>
+      <option value="2">2</option>
+      <option value="5">5</option>
+      <option value="10">10</option>
+      <option value="25">25</option>
+      <option value="50">50</option>
+      <option value="100">100</option>
+    </select>
+    per group
   </div>
+  <!--<div class="form-group">-->
+    <!--<label>Scaling</label>-->
+    <!--<div class="btn-group">-->
+      <!--<label class="btn btn-default btn"-->
+             <!--ng-model="filter.stage.scale"-->
+             <!--btn-radio="'absolute'">-->
+        <!--<span class="glyphicon glyphicon-align-left" title="Absolute" aria-hidden="true"></span>-->
+      <!--</label>-->
+      <!--<label class="btn btn-default btn"-->
+             <!--ng-model="filter.stage.scale"-->
+             <!--btn-radio="'fixed'">-->
+        <!--<span class="glyphicon glyphicon-align-justify" title="Fixed" aria-hidden="true"></span>-->
+      <!--</label>-->
+      <!--<label class="btn btn-default btn"-->
+             <!--ng-model="filter.stage.scale"-->
+             <!--btn-radio="'relative'">-->
+        <!--<span class="glyphicon glyphicon-tasks" title="Relative" aria-hidden="true"></span>-->
+      <!--</label>-->
+    <!--</div>-->
+  <!--</div>-->
   <div class="form-group pull-right">
     <a ui-sref="^.pipelineConfig" class="configure-pipelines-btn btn"><span class="glyphicon glyphicon-cog"></span> Configure Pipelines</a>
   </div>

--- a/app/scripts/modules/delivery/pipelineExecutions.html
+++ b/app/scripts/modules/delivery/pipelineExecutions.html
@@ -1,20 +1,22 @@
-<div class="row pipelines executions" ng-if="executions.length || configurations.length">
-  <div class="col-md-12">
-    <div class="row">
-      <div class="col-md-12 filter-controls">
-        <ng-include src="'scripts/modules/delivery/pipelineExecutions.executionFilter.html'">
-        </ng-include>
-      </div>
+<div class="row pipelines executions" ng-if="!viewState.loading && (executions.length || configurations.length)">
+  <div class="row header">
+    <div class="col-md-12 filter-controls">
+      <ng-include src="'scripts/modules/delivery/pipelineExecutions.executionFilter.html'">
+      </ng-include>
     </div>
+  </div>
+  <div class="execution-groups" sticky-headers>
     <div class="row"
          ng-if="filter.execution.groupBy"
          ng-repeat="executionGrouping in executions | executionGroups:filter:configurations">
-      <execution-group-heading value="executionGrouping"
-                               scale="scale"
-                               filter="filter"
-                               executions="executions"
-                               configurations="configurations">
-      </execution-group-heading>
+      <div class="col-md-12">
+        <execution-group-heading value="executionGrouping"
+                                 scale="scale"
+                                 filter="filter"
+                                 executions="executions"
+                                 configurations="configurations">
+        </execution-group-heading>
+      </div>
     </div>
     <div class="row"
          ng-if="!filter.execution.groupBy">
@@ -27,13 +29,15 @@
     </div>
   </div>
 </div>
-<div class="row pipelines executions" ng-if="!executions.length && !configurations.length && !viewState.loading && !viewState.initializationError">
+<div class="row pipelines executions"
+     ng-if="!executions.length && !configurations.length && !viewState.loading && !viewState.initializationError">
   <div class="col-md-8 text-center">
     <h4>We couldn't find any pipelines execution history for {{application.name}}.</h4>
-    <a ui-sref="^.pipelineConfig" class="btn btn-default"><span class="glyphicon glyphicon-cog"></span> Configure Pipelines</a>
+    <a ui-sref="^.pipelineConfig" class="btn btn-default">
+        <span class="glyphicon glyphicon-cog"></span> Configure Pipelines</a>
   </div>
 </div>
-<div class="row pipelines executions" ng-if="viewState.loading">
+<div class="row" ng-if="viewState.loading">
   <div class="col-md-12">
     <h2 class="text-center" style="margin-bottom: 250px">
       <span class="glyphicon glyphicon-asterisk glyphicon-spinning"></span>

--- a/app/scripts/modules/utils/scrollTo/scrollTo.service.js
+++ b/app/scripts/modules/utils/scrollTo/scrollTo.service.js
@@ -19,13 +19,15 @@
 angular.module('deckApp.utils.scrollTo', ['deckApp.utils.jQuery'])
   .factory('scrollToService', function($timeout, $) {
 
-    function scrollTo(elementId, offset) {
+    function scrollTo(elementId, scrollableContainer, offset) {
       $timeout(function() {
         var elem = $('#' + elementId);
         if (elem.length) {
-          var content = $('html,body');
-          var top = elem.offset().top - offset;
-          content.animate({scrollTop: top + 'px'}, 200);
+          var content = elem.closest(scrollableContainer);
+          if (content.length) {
+            var top = elem.offset().top - offset;
+            content.animate({scrollTop: top + 'px'}, 200);
+          }
         }
       });
     }

--- a/app/scripts/modules/utils/scrollTriggerService.js
+++ b/app/scripts/modules/utils/scrollTriggerService.js
@@ -57,7 +57,7 @@ angular.module('deckApp.utils.scrollTrigger', ['deckApp.utils.jQuery'])
       return registeredEvent && elementTop < scrollBottom;
     }
 
-    var fireEvents = _.debounce(function fireEvents(scrollTarget) {
+    var fireEvents = _.throttle(function fireEvents(scrollTarget) {
       var scrollBottom = $$window.scrollTop() + $window.innerHeight,
           executed = [];
 

--- a/app/scripts/modules/utils/stickyHeader/stickyHeader.directive.js
+++ b/app/scripts/modules/utils/stickyHeader/stickyHeader.directive.js
@@ -1,0 +1,63 @@
+'use strict';
+
+/**
+ * Based on https://github.com/polarblau/stickySectionHeaders
+ */
+
+angular.module('deckApp.utils.stickyHeader', [
+  'deckApp.utils.jQuery',
+])
+  .directive('stickyHeader', function ($log, _) {
+    return {
+      restrict: 'A',
+      link: {
+        post: function (scope, elem) {
+          var $heading = elem,
+            $section = $heading.parent(),
+            $scrollableContainer = $heading.closest('[sticky-headers]'),
+            id = parseInt(Math.random() * new Date().getTime());
+
+          if (!$scrollableContainer.length) {
+            $log.warn('No parent container with attribute "sticky-header"; headers will not stick.');
+            return;
+          }
+
+          $scrollableContainer.css({position: 'relative'});
+
+          var positionHeader = _.throttle(function () {
+            var containerTop = $scrollableContainer.offset().top,
+              containerWidth = $scrollableContainer.width(),
+              sectionOffset = $section.offset(),
+              top = sectionOffset.top - containerTop;
+
+            if (top < 0) {
+              $section.css({
+                paddingTop: $heading.height(),
+              });
+              $heading.addClass('heading-sticky').css({
+                top: containerTop,
+                width: containerWidth,
+              });
+            } else {
+              $section.css({
+                paddingTop: 0,
+              });
+              $heading.removeClass('heading-sticky').css({
+                top: '',
+                width: '',
+                zIndex: 3,
+              });
+            }
+
+          }, 100);
+
+          $scrollableContainer.bind('scroll.stickyHeader-' + id, positionHeader);
+          $scrollableContainer.bind('resize.stickyHeader-' + id, positionHeader);
+
+          scope.$on('$destroy', function () {
+            $scrollableContainer.unbind('.stickyHeader-' + id);
+          });
+        },
+      }
+    };
+  });

--- a/app/scripts/modules/utils/stickyHeader/stickyHeader.less
+++ b/app/scripts/modules/utils/stickyHeader/stickyHeader.less
@@ -1,0 +1,5 @@
+[sticky-headers] .heading-sticky {
+  position: fixed;
+  z-index: 2;
+  margin: 0;
+}

--- a/app/scripts/modules/utils/utils.module.js
+++ b/app/scripts/modules/utils/utils.module.js
@@ -9,4 +9,5 @@ angular.module('deckApp.utils', [
   'deckApp.utils.moment',
   'deckApp.utils.scrollTrigger',
   'deckApp.utils.rx',
+  'deckApp.utils.stickyHeader',
 ]);

--- a/app/styles/delivery.less
+++ b/app/styles/delivery.less
@@ -101,8 +101,9 @@ body, html {
     margin-top: 5px;
     background-color: @mid_grey;
     color: rgb(248, 248, 248);
-    border: 1px solid @mid_grey;
+    border: 2px solid @lightest_grey;
     border-radius: 3px;
+    box-shadow: 0 8px 6px -6px @lightest_grey;
     h4 {
       cursor: pointer;
       .glyphicon {
@@ -135,7 +136,7 @@ body, html {
     padding-bottom: 5px;
     border-bottom: 1px solid @mid_light_grey;
     .form-group {
-      margin: 0 30px 20px 0;
+      margin: 0 30px 10px 0;
       &:last-child {
         margin-right: 0;
       }

--- a/app/styles/pipelines.less
+++ b/app/styles/pipelines.less
@@ -1,6 +1,24 @@
 @import "app/styles/imports/commonImports.less";
 
 .pipelines {
+  position: fixed;
+  top: 130px;
+  bottom: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+  display: flex;
+  flex-direction: column;
+
+  > .header {
+    flex: none
+  }
+
+  > .execution-groups {
+    padding: 0 15px;
+    flex: 1 0 100px;
+    overflow-y: auto;
+  }
+
   .stage-filters {
     label {
       font-size: 12px;


### PR DESCRIPTION
- cleaned up header a bit, removed scale controls, which were no longer working, anyway
- added limit control to number of executions shown per group (default: 5)
- pipeline headers now stick as user scrolls
- added duration to status on completed pipelines - this may need some work, we'll see what kind of feedback we get

![screen shot 2015-02-12 at 11 50 04 pm](https://cloud.githubusercontent.com/assets/73450/6184057/e9ad608a-b311-11e4-81b0-f631b407c621.png)

fixes #603 
