### PR TITLE
account service calls differentiate by provider

### DIFF
--- a/app/scripts/modules/account/accountService.js
+++ b/app/scripts/modules/account/accountService.js
@@ -66,7 +66,12 @@ angular.module('deckApp.account.service', [
       return $q.when(preferredZonesByAccount);
     }
 
-    function listAccounts() {
+    function listAccounts(provider) {
+      if (provider) {
+        return listAccounts().then(function(accounts) {
+          return _.filter(accounts, { type: provider });
+        });
+      }
       return Restangular
         .all('credentials')
         .withHttpConfig({cache: infrastructureCaches.credentials})
@@ -79,9 +84,9 @@ angular.module('deckApp.account.service', [
       });
     }
 
-    var getRegionsKeyedByAccount = _.memoize(function() {
+    var getRegionsKeyedByAccount = _.memoize(function(provider) {
       var deferred = $q.defer();
-      listAccounts().then(function(accounts) {
+      listAccounts(provider).then(function(accounts) {
         $q.all(accounts.reduce(function(acc, account) {
           acc[account.name] = Restangular
             .all('credentials')

--- a/app/scripts/modules/account/accountService.spec.js
+++ b/app/scripts/modules/account/accountService.spec.js
@@ -4,20 +4,37 @@ describe('Service: accountService ', function () {
 
   //NOTE: This is only testing the service dependencies. Please add more tests.
 
-  var accountService;
+  var accountService, $http, settings;
 
   beforeEach(
     module('deckApp.account.service')
   );
 
   beforeEach(
-    inject(function (_accountService_) {
+    inject(function (_accountService_, $httpBackend) {
       accountService = _accountService_;
+      $http = $httpBackend;
     })
   );
 
-  it('should instantiate the controller', function () {
-    expect(accountService).toBeDefined();
+  it('should filter the list of accounts by provider when supplied', function () {
+    $http.expectGET('/credentials').respond(200, [
+      { name: 'test', type: 'aws' },
+      { name: 'prod', type: 'aws' },
+      { name: 'prod', type: 'gce' },
+      { name: 'gce-test', type: 'gce' },
+    ]);
+
+    var accounts = null;
+    accountService.listAccounts('aws').then(function(results) {
+      accounts = results;
+    });
+
+    $http.flush();
+
+    expect(accounts.length).toBe(2);
+    expect(_.pluck(accounts, 'name')).toEqual(['test', 'prod']);
+
   });
 });
 

--- a/app/scripts/modules/loadBalancers/configure/aws/CreateLoadBalancerCtrl.js
+++ b/app/scripts/modules/loadBalancers/configure/aws/CreateLoadBalancerCtrl.js
@@ -47,7 +47,7 @@ angular.module('deckApp.loadBalancer.aws.create.controller', [
 
     function initializeCreateMode() {
       preloadSecurityGroups();
-      accountService.listAccounts().then(function (accounts) {
+      accountService.listAccounts('aws').then(function (accounts) {
         $scope.accounts = accounts;
         $scope.state.accountsLoaded = true;
         ctrl.accountUpdated();

--- a/app/scripts/modules/securityGroups/configure/aws/CreateSecurityGroupCtrl.js
+++ b/app/scripts/modules/securityGroups/configure/aws/CreateSecurityGroupCtrl.js
@@ -37,7 +37,7 @@ angular.module('deckApp.securityGroup.aws.create.controller', [
       allSecurityGroups = securityGroups;
     });
 
-    accountService.listAccounts().then(function(accounts) {
+    accountService.listAccounts('aws').then(function(accounts) {
       $scope.accounts = accounts;
       ctrl.accountUpdated();
     });

--- a/app/scripts/modules/serverGroups/configure/aws/ServerGroupCommandBuilder.js
+++ b/app/scripts/modules/serverGroups/configure/aws/ServerGroupCommandBuilder.js
@@ -10,7 +10,7 @@ angular.module('deckApp.aws.serverGroupCommandBuilder.service', [
   .factory('awsServerGroupCommandBuilder', function (settings, Restangular, $exceptionHandler, $q, accountService, subnetReader, namingService) {
     function buildNewServerGroupCommand(application, account, region) {
       var preferredZonesLoader = accountService.getPreferredZonesByAccount();
-      var regionsKeyedByAccountLoader = accountService.getRegionsKeyedByAccount();
+      var regionsKeyedByAccountLoader = accountService.getRegionsKeyedByAccount('aws');
       var asyncLoader = $q.all({preferredZones: preferredZonesLoader, regionsKeyedByAccount: regionsKeyedByAccountLoader});
 
       return asyncLoader.then(function(asyncData) {

--- a/app/scripts/modules/serverGroups/configure/aws/ServerGroupConfigurationService.js
+++ b/app/scripts/modules/serverGroups/configure/aws/ServerGroupConfigurationService.js
@@ -15,7 +15,7 @@ angular.module('deckApp.serverGroup.configure.aws')
       }
 
       return $q.all({
-        regionsKeyedByAccount: accountService.getRegionsKeyedByAccount(),
+        regionsKeyedByAccount: accountService.getRegionsKeyedByAccount('aws'),
         securityGroups: securityGroupReader.getAllSecurityGroups(),
         loadBalancers: loadBalancerReader.listAWSLoadBalancers(),
         subnets: subnetReader.listSubnets(),

--- a/app/scripts/modules/serverGroups/configure/gce/ServerGroupConfigurationService.js
+++ b/app/scripts/modules/serverGroups/configure/gce/ServerGroupConfigurationService.js
@@ -9,7 +9,7 @@ angular.module('deckApp.serverGroup.configure.gce')
     function configureCommand(command) {
       command.image = command.viewState.imageId;
       return $q.all({
-        regionsKeyedByAccount: accountService.getRegionsKeyedByAccount(),
+        regionsKeyedByAccount: accountService.getRegionsKeyedByAccount('gce'),
         loadBalancers: loadBalancerReader.listGCELoadBalancers(),
         instanceTypes: instanceTypeService.getAllTypesByRegion('gce'),
         images: imageService.findImages({provider: 'gce'})


### PR DESCRIPTION
`provider` is now an optional parameter to `listAccounts` and `getRegionsKeyedByAccount`

fixes https://github.com/spinnaker/deck/issues/670
