### PR TITLE
pod scroll behavior tweaks

### DIFF
--- a/app/scripts/directives/instanceList.directive.js
+++ b/app/scripts/directives/instanceList.directive.js
@@ -2,7 +2,7 @@
 
 
 angular.module('deckApp')
-  .directive('instanceList', function (scrollTriggerService, clusterFilterService, $rootScope, $timeout) {
+  .directive('instanceList', function (scrollTriggerService, clusterFilterService, $rootScope) {
     return {
       restrict: 'E',
       templateUrl: 'scripts/modules/instance/instanceList.html',
@@ -80,18 +80,16 @@ angular.module('deckApp')
         scope.$state = $rootScope.$state;
 
         scope.loadInstanceDetails = function(event, id) {
-          $timeout(function() {
-            // anything handled by ui-sref or actual links should be ignored
-            if (event.isDefaultPrevented() || (event.originalEvent && event.originalEvent.target.href)) {
-              return;
-            }
-            event.preventDefault();
-            var params = {
-              instanceId: id
-            };
-            // also stolen from uiSref directive
-            scope.$state.go('.instanceDetails', params, {relative: base, inherit: true});
-          });
+          // anything handled by ui-sref or actual links should be ignored
+          if (event.isDefaultPrevented() || (event.originalEvent && event.originalEvent.target.href)) {
+            return;
+          }
+          event.preventDefault();
+          var params = {
+            instanceId: id
+          };
+          // also stolen from uiSref directive
+          scope.$state.go('.instanceDetails', params, {relative: base, inherit: true});
         };
 
         scope.updateQueryParams = clusterFilterService.updateQueryParams;

--- a/app/scripts/modules/clusterFilter/clusterFilterService.js
+++ b/app/scripts/modules/clusterFilter/clusterFilterService.js
@@ -13,24 +13,23 @@ angular
 
       var defPrimary = 'account';
       var defSecondary = 'cluster';
-      var instanceSortDefault = 'launchTime';
 
       var filter = ClusterFilterModel.sortFilter.filter.length ? ClusterFilterModel.sortFilter.filter : null,
           locationQ = $location.search().q || null;
       if (filter !== locationQ) {
         $location.search('q',
-            ClusterFilterModel.sortFilter.filter.length > 0 ? ClusterFilterModel.sortFilter.filter : undefined);
+            ClusterFilterModel.sortFilter.filter.length > 0 ? ClusterFilterModel.sortFilter.filter : '');
       }
       $location.search('hideHealth', ClusterFilterModel.sortFilter.hideHealthy ? true : null);
       $location.search('hideInstances', ClusterFilterModel.sortFilter.showAllInstances ? null : true);
-      $location.search('listInstances', ClusterFilterModel.sortFilter.listInstances ? true : null);
+      $location.search('listInstances', ClusterFilterModel.sortFilter.listInstances ? 'true' : null);
       $location.search('hideDisabled', ClusterFilterModel.sortFilter.hideDisabled ? true : null);
       $location.search('primary',
         ClusterFilterModel.sortFilter.sortPrimary === defPrimary ? null : ClusterFilterModel.sortFilter.sortPrimary);
       $location.search('secondary',
           ClusterFilterModel.sortFilter.sortSecondary === defSecondary ? null : ClusterFilterModel.sortFilter.sortSecondary);
       $location.search('instanceSort',
-          ClusterFilterModel.sortFilter.instanceSort.key === instanceSortDefault ? null : ClusterFilterModel.sortFilter.instanceSort.key);
+          ClusterFilterModel.sortFilter.instanceSort.key);
 
       updateAccountParams();
       updateRegionParams();

--- a/app/scripts/modules/utils/scrollTriggerService.js
+++ b/app/scripts/modules/utils/scrollTriggerService.js
@@ -4,7 +4,6 @@
 angular.module('deckApp.utils.scrollTrigger', ['deckApp.utils.jQuery'])
   .factory('scrollTriggerService', function($window, $timeout, $) {
     var eventRegistry = Object.create(null),// creates {} with no prototype; ES6 Maps would be preferable (available in Chrome 38?),
-        waypointRegistry = Object.create(null),
         registryCounter = 0,
         scrollEventActive = Object.create(null),
         $$window = $($window);
@@ -40,73 +39,6 @@ angular.module('deckApp.utils.scrollTrigger', ['deckApp.utils.jQuery'])
       activateScrollEvent(scrollTarget);
     }
 
-    function registerWaypointContainer(elementScope, element, key, offset) {
-      waypointRegistry[key] = waypointRegistry[key] || Object.create(null);
-      waypointRegistry[key].container = element;
-      waypointRegistry[key].offset = offset;
-      enableWaypointEvent(element, key);
-      elementScope.$on('$destroy', function() {
-        waypointRegistry[key] = null;
-        disableWaypointEvent(key);
-      });
-    }
-
-    function enableWaypointEvent(element, key) {
-      var registryEntry = waypointRegistry[key];
-      if (!registryEntry.scrollEnabled) {
-        // because they do not affect rendering directly, we can debounce this pretty liberally
-        element.bind('scroll.waypointEvents resize.waypointEvents', _.debounce(function() {
-          var containerRect = element.get(0).getBoundingClientRect(),
-              topThreshold = containerRect.top + registryEntry.offset,
-              waypoints = element.find('[waypoint]'),
-              inView = [];
-          waypoints.each(function(idx, waypoint) {
-            var waypointRect = waypoint.getBoundingClientRect();
-            if (waypointRect.bottom >= topThreshold && waypointRect.top <= containerRect.bottom) {
-              inView.push({ top: waypointRect.top, elem: waypoint.getAttribute('waypoint') });
-            }
-          });
-
-          waypointRegistry[key].lastWindow = _(inView).sortBy('top').pluck('elem').valueOf();
-
-        }, 300));
-        registryEntry.scrollEnabled = true;
-      }
-    }
-
-    function disableWaypointEvent(key) {
-      var registry = waypointRegistry[key];
-      if (registry) {
-        registry.container.unbind('scroll.waypointEvents resize.waypointEvents');
-        registry.scrollEnabled = false;
-      }
-    }
-
-    function restoreToWaypoint(key) {
-      $timeout(function() {
-        var registry = waypointRegistry[key];
-        if (!registry) {
-          return;
-        }
-
-        var candidates = registry.lastWindow || [],
-            container = registry.container,
-            containerScrollTop = container.scrollTop(),
-            containerTop = container.offset().top;
-
-        candidates.every(function(candidate) {
-          var elem = $('[waypoint="' + candidate + '"]', container);
-          if (elem.length) {
-            container.scrollTop(containerScrollTop + elem.offset().top - containerTop - registry.offset);
-            container.trigger('scroll');
-            return false;
-          }
-          return true;
-
-        });
-      }, 50);
-    }
-
     function deregister(scrollTarget, registeredEventId) {
       if (eventRegistry[scrollTarget] && eventRegistry[scrollTarget][registeredEventId]) {
         delete eventRegistry[scrollTarget][registeredEventId];
@@ -117,8 +49,7 @@ angular.module('deckApp.utils.scrollTrigger', ['deckApp.utils.jQuery'])
     }
 
     function eventIsInView(registeredEvent, scrollBottom) {
-      var elementRect = registeredEvent.element.get(0).getBoundingClientRect(),
-          elementTop = elementRect.bottom - elementRect.height;
+      var elementTop = registeredEvent.element.get(0).getBoundingClientRect().top;
       if (elementTop < 0) {
         return false;
       }
@@ -156,10 +87,6 @@ angular.module('deckApp.utils.scrollTrigger', ['deckApp.utils.jQuery'])
 
     return {
       register: register,
-      registerWaypointContainer: registerWaypointContainer,
-      enableWaypointEvent: enableWaypointEvent,
-      disableWaypointEvent: disableWaypointEvent,
-      restoreToWaypoint: restoreToWaypoint,
     };
   }
 );

--- a/app/scripts/modules/utils/waypoints/waypoint.service.js
+++ b/app/scripts/modules/utils/waypoints/waypoint.service.js
@@ -34,7 +34,7 @@ angular.module('deckApp.utils.waypoints.service', [
             }
           });
 
-          waypointRegistry[key].lastWindow = _(inView).sortBy('top').pluck('elem').valueOf();
+          waypointRegistry[key].lastWindow = _.sortBy(inView, 'top');
 
         }, 300));
         registryEntry.scrollEnabled = true;
@@ -58,13 +58,12 @@ angular.module('deckApp.utils.waypoints.service', [
 
         var candidates = registry.lastWindow || [],
           container = registry.container,
-          containerScrollTop = container.scrollTop(),
-          containerTop = container.offset().top;
+          containerScrollTop = container.scrollTop();
 
         candidates.every(function(candidate) {
-          var elem = $('[waypoint="' + candidate + '"]', container);
+          var elem = $('[waypoint="' + candidate.elem + '"]', container);
           if (elem.length) {
-            container.scrollTop(containerScrollTop + elem.offset().top - containerTop - registry.offset);
+            container.scrollTop(containerScrollTop + elem.offset().top - candidate.top);
             container.trigger('scroll');
             return false;
           }


### PR DESCRIPTION
setting default filter values to avoid page reload, which loses the scroll position when getting different details.
