### PR TITLE
add action to edit pipeline as json

### DIFF
--- a/app/scripts/modules/pipelines/config/actions/json/editPipelineJson.module.js
+++ b/app/scripts/modules/pipelines/config/actions/json/editPipelineJson.module.js
@@ -1,0 +1,3 @@
+'use strict';
+
+angular.module('deckApp.pipelines.editJson', ['deckApp.pipelines', 'deckApp.settings', 'deckApp.utils.lodash']);

--- a/app/scripts/modules/pipelines/config/actions/json/editPipelineJsonModal.controller.js
+++ b/app/scripts/modules/pipelines/config/actions/json/editPipelineJsonModal.controller.js
@@ -1,0 +1,53 @@
+'use strict';
+
+angular.module('deckApp.pipelines.rename')
+  .controller('EditPipelineJsonModalCtrl', function($scope, pipeline, _, $modalInstance) {
+
+    this.cancel = $modalInstance.dismiss;
+
+    function removeImmutableFields(obj) {
+      if (obj.name) {
+        console.warn('NAME!', obj.name);
+        delete obj.name;
+      }
+      if (obj.application) {
+        console.warn('APP!', obj.application);
+        delete obj.application;
+      }
+      if (obj.appConfig) {
+        console.warn('AC!', obj.appConfig);
+        delete obj.appConfig;
+      }
+    }
+
+    this.initialize = function() {
+      var toCopy = pipeline.hasOwnProperty('plain') ? pipeline.plain() : pipeline;
+      var pipelineCopy = _.cloneDeep(toCopy, function (value) {
+        if (value && value.$$hashKey) {
+          delete value.$$hashKey;
+        }
+      });
+      removeImmutableFields(pipelineCopy);
+
+      $scope.command = {
+        pipelineJSON: JSON.stringify(pipelineCopy, null, 2)
+      };
+    };
+
+    this.updatePipeline = function() {
+      try {
+        var parsed = JSON.parse($scope.command.pipelineJSON);
+
+        removeImmutableFields(parsed);
+        angular.extend(pipeline, parsed);
+
+        $modalInstance.close();
+      } catch (e) {
+        $scope.command.invalid = true;
+        $scope.command.errorMessage = e.message;
+      }
+    };
+
+    this.initialize();
+
+  });

--- a/app/scripts/modules/pipelines/config/actions/json/editPipelineJsonModal.controller.spec.js
+++ b/app/scripts/modules/pipelines/config/actions/json/editPipelineJsonModal.controller.spec.js
@@ -1,0 +1,104 @@
+'use strict';
+
+describe('Controller: renamePipelineModal', function() {
+
+  beforeEach(module('deckApp.pipelines.editJson'));
+
+  beforeEach(inject(function ($controller, $rootScope, _) {
+    this.initializeController = function (pipeline) {
+      this.$scope = $rootScope.$new();
+      this.$modalInstance = { close: angular.noop };
+      this.controller = $controller('EditPipelineJsonModalCtrl', {
+        $scope: this.$scope,
+        pipeline: pipeline,
+        $modalInstance: this.$modalInstance,
+        _: _,
+      });
+    };
+  }));
+
+  it ('controller removes name, all Restangular fields and hash keys', function() {
+
+    var pipeline = {
+      name: 'foo',
+      application: 'myApp',
+      stage: {
+        foo: [
+          {}
+        ],
+        bar: {},
+        baz: '',
+        bat: 4
+      }
+    };
+
+    this.initializeController(pipeline);
+
+    // sprinkle some hash keys into the pipeline
+    pipeline.stage.$$hashKey = '01D';
+    pipeline.stage.foo[0].$$hashKey = '01F';
+    pipeline.stage.bar.$$hashKey = '01G';
+    pipeline.plain = function() { return pipeline; };
+    spyOn(pipeline, 'plain').and.callThrough();
+
+    this.controller.initialize();
+
+    var converted = JSON.parse(this.$scope.command.pipelineJSON);
+
+    // restangular fields
+    expect(pipeline.plain).toHaveBeenCalled();
+
+    // name
+    expect(converted.name).toBeUndefined();
+    expect(converted.application).toBeUndefined();
+
+    // hash keys
+    expect(converted.stage.$$hashKey).toBeUndefined();
+    expect(converted.stage.foo[0].$$hashKey).toBeUndefined();
+    expect(converted.stage.bar.$$hashKey).toBeUndefined();
+  });
+
+  it ('updatePipeline updates fields, removing name if added', function() {
+    var pipeline = {
+      application: 'myApp',
+      name: 'foo',
+      stage: {
+        foo: [
+          {}
+        ],
+        bar: {},
+        baz: '',
+        bat: 4
+      }
+    };
+
+    this.initializeController(pipeline);
+    spyOn(this.$modalInstance, 'close');
+
+    var converted = JSON.parse(this.$scope.command.pipelineJSON);
+    converted.application = 'someOtherApp';
+    converted.name = 'replacedName';
+    converted.bar = { updated: true };
+    this.$scope.command.pipelineJSON = JSON.stringify(converted);
+
+    this.controller.updatePipeline();
+
+    expect(pipeline.application).toBe('myApp');
+    expect(pipeline.bar.updated).toBe(true);
+
+    expect(this.$modalInstance.close).toHaveBeenCalled();
+  });
+
+  it ('updateApplicationFromJson displays an error message when malformed JSON provided', function() {
+    var pipeline = {};
+
+    this.initializeController(pipeline);
+
+    this.$scope.command = {pipelineJSON: 'This is not very good JSON'};
+    this.controller.updatePipeline();
+
+    expect(this.$scope.command.invalid).toBe(true);
+    expect(this.$scope.command.errorMessage).not.toBe(null);
+  });
+
+});

--- a/app/scripts/modules/pipelines/config/actions/json/editPipelineJsonModal.html
+++ b/app/scripts/modules/pipelines/config/actions/json/editPipelineJsonModal.html
@@ -1,0 +1,42 @@
+<div modal-page>
+  <modal-close></modal-close>
+  <div class="modal-header">
+    <h3>Edit Pipeline JSON</h3>
+  </div>
+  <div class="modal-body">
+    <div class="row">
+      <div class="col-md-12">
+        <p>
+          The JSON below represents the pipeline configuration in its persisted state.
+          You can change it here or use this to quickly copy a pipeline.
+        </p>
+      </div>
+    </div>
+    <form role="form" name="form" class="form-horizontal">
+      <div class="form-group">
+        <textarea class="code form-control" rows=20 ng-model="command.pipelineJSON"></textarea>
+      </div>
+    </form>
+    <div class="row">
+      <div class="col-md-12">
+        <p>
+          <strong>Note:</strong> Clicking "Update Pipeline" below will not save your changes to the server - it only
+          updates the configuration within the browser, so you'll want to verify your changes and click "Save Changes"
+          when you're ready.
+        </p>
+      </div>
+    </div>
+    <div class="form-group row slide-in" ng-if="command.invalid">
+      <div class="col-sm-9 col-sm-offset-3 error-message">
+        Error: {{command.errorMessage}}
+      </div>
+    </div>
+  </div>
+  <div class="modal-footer">
+    <button class="btn btn-default" ng-click="editPipelineJsonModalCtrl.cancel()">Cancel</button>
+    <button class="btn btn-primary"
+            ng-click="editPipelineJsonModalCtrl.updatePipeline()">
+      <span class="glyphicon glyphicon-ok-circle"></span> Update Pipeline
+    </button>
+  </div>
+</div>

--- a/app/scripts/modules/pipelines/config/pipelineConfigurer.html
+++ b/app/scripts/modules/pipelines/config/pipelineConfigurer.html
@@ -14,6 +14,7 @@
         <ul class="dropdown-menu" role="menu">
           <li><a href ng-click="pipelineConfigurerCtrl.renamePipeline()">Rename</a></li>
           <li><a href ng-click="pipelineConfigurerCtrl.deletePipeline()">Delete</a></li>
+          <li><a href ng-click="pipelineConfigurerCtrl.editPipelineJson()">Edit as JSON</a></li>
         </ul>
       </div>
     </div>

--- a/app/scripts/modules/pipelines/config/pipelineConfigurer.js
+++ b/app/scripts/modules/pipelines/config/pipelineConfigurer.js
@@ -88,6 +88,17 @@ angular.module('deckApp.pipelines')
         });
     };
 
+    this.editPipelineJson = function() {
+      $modal.open({
+        templateUrl: 'scripts/modules/pipelines/config/actions/json/editPipelineJsonModal.html',
+        controller: 'EditPipelineJsonModalCtrl',
+        controllerAs: 'editPipelineJsonModalCtrl',
+        resolve: {
+          pipeline: function() { return $scope.pipeline; },
+        }
+      });
+    };
+
     this.navigateToStage = function(index, event) {
       $scope.viewState.section = 'stage';
       $scope.viewState.stageIndex = index;

--- a/app/scripts/modules/pipelines/pipelines.module.js
+++ b/app/scripts/modules/pipelines/pipelines.module.js
@@ -13,6 +13,7 @@ angular.module('deckApp.pipelines', [
   'deckApp.pipelines.create',
   'deckApp.pipelines.delete',
   'deckApp.pipelines.rename',
+  'deckApp.pipelines.editJson',
   'deckApp.authentication',
   'deckApp.utils.lodash',
   'ui.sortable',


### PR DESCRIPTION
This will hopefully help us debug some of the issues we're seeing in pipeline configurations.

Adds an "Edit as JSON" action in the pipeline config view, which is very similar (and largely extracted) from previous work on configuration UI.
