### PR TITLE
Fix for #712: Deploy Stage of Pipeline would reset to default state.

### DIFF
--- a/app/scripts/modules/serverGroups/configure/aws/serverGroupCapacity.controller.spec.js
+++ b/app/scripts/modules/serverGroups/configure/aws/serverGroupCapacity.controller.spec.js
@@ -30,14 +30,14 @@ describe('Controller: ServerGroupCapacitySelector', function () {
 
     command.viewState.useSimpleCapacity = true;
     command.capacity.desired = 2;
-    scope.$digest();
+    scope.setMinMax(command.capacity.desired);
 
     expect(command.capacity.min).toBe(2);
     expect(command.capacity.max).toBe(2);
 
     command.viewState.useSimpleCapacity = false;
     command.capacity.desired = 1;
-    scope.$digest();
+    scope.setMinMax(command.capacity.desired);
 
     expect(command.capacity.min).toBe(2);
     expect(command.capacity.max).toBe(2);

--- a/app/scripts/modules/serverGroups/configure/aws/serverGroupCapacityDirective.html
+++ b/app/scripts/modules/serverGroups/configure/aws/serverGroupCapacityDirective.html
@@ -45,7 +45,7 @@
     </div>
     <div class="form-group">
       <div class="col-md-4 sm-label-left"><b>Number of Instances</b></div>
-      <div class="col-md-2"><input type="number"
+      <div class="col-md-2"><input type="number" ng-change="setMinMax(command.capacity.desired)"
                                    class="form-control input-sm"
                                    ng-model="command.capacity.desired"
                                    min="0"

--- a/app/scripts/modules/serverGroups/configure/aws/serverGroupCapacitySelector.directive.js
+++ b/app/scripts/modules/serverGroups/configure/aws/serverGroupCapacitySelector.directive.js
@@ -12,11 +12,10 @@ angular.module('deckApp.serverGroup.configure.aws')
     };
   })
   .controller('ServerGroupCapacitySelectorCtrl', function($scope) {
-    $scope.$watch('command.capacity.desired', function(newVal) {
+    $scope.setMinMax = function(newVal) {
       if ($scope.command.viewState.useSimpleCapacity) {
         $scope.command.capacity.min = newVal;
         $scope.command.capacity.max = newVal;
       }
-    });
-
+    };
   });


### PR DESCRIPTION
This issue was caused by the multiple watchers on command.capacity.desired causing other watchers to fire in the deployStage.js
that are meant to synchronize the state between the pipeline stage object and the command object.  This watcher-chain-of-death was
causing the entire stage object to be reset whenever the capacity was changed.

To fix this I replaced the watchers on the directive controller with an function call that just updates the state on an ng-change.
