### PR TITLE
handle async loading of tasks on tasks page

### DIFF
--- a/app/scripts/modules/tasks/taskDetails.controller.js
+++ b/app/scripts/modules/tasks/taskDetails.controller.js
@@ -2,22 +2,26 @@
 
 
 angular.module('deckApp.tasks.detail.controller', [])
-  .controller('TaskDetailsCtrl', function($scope, $log, taskId, application, $state, notificationsService, tasksWriter) {
+  .controller('TaskDetailsCtrl', function($scope, $log, $state,
+                                          tasksReader, tasksWriter,
+                                          taskId, application) {
 
     var vm = this;
 
     function extractTaskDetails() {
-      var filtered = application.tasks.filter(function(task) {
+      var tasks = application.tasks || [];
+      var filtered = tasks.filter(function(task) {
         return task.id === taskId;
       });
       if (!filtered.length) {
-        notificationsService.create({
-          message: 'No task with id "' + taskId + '" was found.',
-          autoDismiss: true,
-          hideTimestamp: true,
-          strong: true
-        });
-        $state.go('^');
+        tasksReader.getOneTaskForApplication(application.name, taskId).then(
+          function(result) {
+            vm.task = result;
+          },
+          function () {
+            $state.go('^');
+          }
+        );
       } else {
         vm.task = filtered[0];
       }

--- a/app/scripts/modules/tasks/tasks.controller.js
+++ b/app/scripts/modules/tasks/tasks.controller.js
@@ -8,16 +8,18 @@ angular.module('deckApp.tasks.main', ['deckApp.utils.lodash'])
     self.application = application;
 
     self.sortedTasks = [];
+    self.tasksLoaded = false;
 
     self.sortTasks = function() {
+      if (application.tasks) {
+        self.tasksLoaded = true;
+      }
       var joinedLists = filterRunningTasks().concat(filterNonRunningTasks());
       self.sortedTasks = joinedLists;
       return joinedLists;
     };
 
-    self.sortTasks();
-
-    application.registerAutoRefreshHandler(self.sortTasks, $scope);
+    $scope.$watch('application.tasks', self.sortTasks);
 
     function filterRunningTasks() {
       var running = _.chain(application.tasks)
@@ -26,9 +28,7 @@ angular.module('deckApp.tasks.main', ['deckApp.utils.lodash'])
         })
         .value();
 
-
-      var ordered = running.sort(taskStartTimeComparitor);
-      return ordered;
+      return running.sort(taskStartTimeComparator);
     }
 
     function filterNonRunningTasks() {
@@ -38,11 +38,10 @@ angular.module('deckApp.tasks.main', ['deckApp.utils.lodash'])
         })
         .value();
 
-      var ordered = notRunning.sort(taskStartTimeComparitor);
-      return ordered;
+      return notRunning.sort(taskStartTimeComparator);
     }
 
-    function taskStartTimeComparitor(taskA, taskB) {
+    function taskStartTimeComparator(taskA, taskB) {
       return taskB.startTime > taskA.startTime ? 1 : taskB.startTime < taskA.startTime ? -1 : 0;
     }
 

--- a/app/scripts/modules/tasks/tasks.controller.spec.js
+++ b/app/scripts/modules/tasks/tasks.controller.spec.js
@@ -3,11 +3,13 @@
 describe('Controller: tasks', function () {
   var controller;
   var controllerInjector;
+  var scope;
 
   controllerInjector = function (appData) {
     appData.registerAutoRefreshHandler = angular.noop;
     return function ($controller, $rootScope) {
-      controller = $controller('TasksCtrl', { application: appData, $scope: $rootScope.$new() });
+      scope = $rootScope.$new();
+      controller = $controller('TasksCtrl', { application: appData, $scope: scope });
     };
   };
 
@@ -19,8 +21,17 @@ describe('Controller: tasks', function () {
     )
   );
 
-  it('should have an injected controller', function () {
-    expect(controller).toBeDefined();
+  describe('initialization', function() {
+    it('tasksLoaded flag should be false', function() {
+      scope.$digest();
+      expect(controller.tasksLoaded).toBe(false);
+    });
+
+    it('tasksLoaded flag should be true if tasks object is present on application', function() {
+      inject(controllerInjector({tasks: [] }));
+      scope.$digest();
+      expect(controller.tasksLoaded).toBe(true);
+    });
   });
 
   describe('Filtering Task list with one running task', function () {
@@ -82,7 +93,7 @@ describe('Controller: tasks', function () {
       )
     );
 
-    it('should sort the tasks in decending order by startTime', function () {
+    it('should sort the tasks in descending order by startTime', function () {
       var sortedList = controller.sortTasks();
       expect(sortedList.length).toBe(2);
       expect(sortedList[0].startTime).toBe(100);

--- a/app/scripts/modules/tasks/tasks.html
+++ b/app/scripts/modules/tasks/tasks.html
@@ -1,5 +1,8 @@
 <div class="row">
-  <div class="col-md-7 tasks">
+  <div class="col-md-7" ng-if="!tasks.tasksLoaded" style="position: relative; height: 300px">
+    <h1 us-spinner="{radius:30, width:8, length: 16}"></h1>
+  </div>
+  <div class="col-md-7 tasks" ng-if="tasks.tasksLoaded">
     <div class="row">
       <div class="col-md-9">
         <div class="btn-group">


### PR DESCRIPTION
Tasks are no longer part of the application auto-refresh cycle, so they may not be loaded when the user tries to access the /tasks page. If they are coming from a deep link to a task details page, an exception is thrown and the page breaks.

This fixes all that by loading the task details if it's not found in the application's tasks, and adding a spinner to the main section if the tasks aren't yet loaded into the application.
