### PR TITLE
set provider on bake execution details

### DIFF
--- a/app/scripts/modules/pipelines/config/stages/bake/bakeExecutionDetails.controller.js
+++ b/app/scripts/modules/pipelines/config/stages/bake/bakeExecutionDetails.controller.js
@@ -1,0 +1,6 @@
+'use strict';
+
+angular.module('deckApp.pipelines.stage.bake.executionDetails.controller', [])
+  .controller('BakeExecutionDetailsCtrl', function ($scope) {
+    $scope.provider = $scope.stage.context.cloudProviderType || 'aws';
+  });

--- a/app/scripts/modules/pipelines/config/stages/bake/bakeExecutionDetails.html
+++ b/app/scripts/modules/pipelines/config/stages/bake/bakeExecutionDetails.html
@@ -1,18 +1,18 @@
-<div>
+<div ng-controller="BakeExecutionDetailsCtrl">
   <div class="row">
     <div class="col-md-6">
       <h5>Bake Configuration</h5>
       <dl class="dl-narrow dl-horizontal">
         <dt if-multiple-providers>Provider</dt>
-        <dd if-multiple-providers>{{stage.context.cloudProviderType ? stage.context.cloudProviderType : 'aws'}}</dd>
+        <dd if-multiple-providers>{{provider}}</dd>
         <dt>Image</dt>
         <dd>{{stage.context.ami}}</dd>
         <dt>Region</dt>
         <dd>{{stage.context.region}}</dd>
         <dt>Base OS</dt>
         <dd>{{stage.context.baseOs}}</dd>
-        <dt>Store Type</dt>
-        <dd>{{stage.context.storeType}}</dd>
+        <dt ng-if="provider === 'aws'">Store Type</dt>
+        <dd ng-if="provider === 'aws'">{{stage.context.storeType}}</dd>
         <dt>Label</dt>
         <dd>{{stage.context.baseLabel}}</dd>
         <dt>Package</dt>

--- a/app/scripts/modules/pipelines/config/stages/bake/bakeStage.module.js
+++ b/app/scripts/modules/pipelines/config/stages/bake/bakeStage.module.js
@@ -1,3 +1,7 @@
 'use strict';
 
-angular.module('deckApp.pipelines.stage.bake', ['deckApp.pipelines.stage', 'deckApp.pipelines.stage.core']);
+angular.module('deckApp.pipelines.stage.bake', [
+  'deckApp.pipelines.stage',
+  'deckApp.pipelines.stage.core',
+  'deckApp.pipelines.stage.bake.executionDetails.controller',
+]);


### PR DESCRIPTION
Set a separate field on the execution details scope to supply a `provider` field, which can be used to toggle fields that are specific to various providers.

We may want to split this out into separate files per provider, but this is a reasonable short-term fix for @duftler 
