### PR TITLE
remove hover effect on cluster pods

### DIFF
--- a/app/styles/rollups.less
+++ b/app/styles/rollups.less
@@ -385,9 +385,15 @@ load-balancers-tag {
 
 .row {
   cluster-pod {
+    .rollup-summary {
+      &:hover {
+        box-shadow: none;
+      }
+    }
     .rollup-entry {
       &:hover {
         box-shadow: none;
+        border-color: #c4c4c4;
       }
     }
     .server-group-sequence {


### PR DESCRIPTION
As @tomaslin pointed out, you cannot click on a cluster pod, so there's no sense adding any hover effect to it.
