### PR TITLE
tweak styling on server group and instance highlighting

### DIFF
--- a/app/scripts/modules/cluster/serverGroup.html
+++ b/app/scripts/modules/cluster/serverGroup.html
@@ -1,14 +1,12 @@
-<div class="cluster-pod-server-group"
+<div class="cluster-pod-server-group clickable"
      waypoint="{{viewModel.waypoint}}"
+     ng-click="loadDetails($event)"
      ng-class="{
-        disabled: viewModel.serverGroup.isDisabled
+        disabled: viewModel.serverGroup.isDisabled,
+        active: $state.includes('**.serverGroup', {region: viewModel.serverGroup.region, accountId: viewModel.serverGroup.account, serverGroup: viewModel.serverGroup.name, provider: viewModel.serverGroup.type})
      }">
   <div class="cluster-container">
-    <div class="server-group-title clickable" sticky-header added-offset-height="69" added-offset-width="-4"
-         ng-click="loadDetails($event)"
-         ng-class="{
-            active: $state.includes('**.serverGroup', {region: viewModel.serverGroup.region, accountId: viewModel.serverGroup.account, serverGroup: viewModel.serverGroup.name, provider: viewModel.serverGroup.type})
-          }"
+    <div class="server-group-title" sticky-header added-offset-height="69" added-offset-width="-4"
          ng-style="viewModel.placeholderStyle"
          sticky-if="headerIsSticky()">
       <div class="container-fluid no-padding">

--- a/app/scripts/modules/clusterFilter/instanceList.filter.js
+++ b/app/scripts/modules/clusterFilter/instanceList.filter.js
@@ -4,6 +4,9 @@ angular
   .module('deckApp.instanceList.filter', [])
   .filter('instanceSearch', function () {
     return function (instanceList, query) {
+      if (!query) {
+        return instanceList;
+      }
       if (instanceList && instanceList.length) {
         return instanceList.filter(function (instance) {
           if (query.match('^i-')) {

--- a/app/scripts/modules/instance/instanceList.html
+++ b/app/scripts/modules/instance/instanceList.html
@@ -15,7 +15,7 @@
     <tr ng-repeat="instance in viewModel.instances | instanceSearch:sortFilter.filter | orderBy: sortFilter.instanceSort.key track by instance.id"
         ng-click="loadInstanceDetails($event, instance.id, instance.provider)"
         class="clickable"
-        ng-class="{ active: $state.includes('**.instanceDetails', {instanceId: instance.id}) }">
+        ng-class="{ info: $state.includes('**.instanceDetails', {instanceId: instance.id}) }">
       <!-- use this when multi-select is a thing -->
       <!--<td><input type="checkbox"></td>-->
       <td>

--- a/app/styles/imports/animations.less
+++ b/app/styles/imports/animations.less
@@ -32,3 +32,51 @@
      50% { -webkit-box-shadow: 0 30px 30px @glow-mid inset, 0 -30px 30px @glow-mid inset;}
      100% { -webkit-box-shadow: 0 30px 30px @glow-init inset, 0 -30px 30px @glow-init inset;}
 }
+
+.pulsing {
+  -webkit-animation: pulse linear 1.5s infinite;
+  animation: pulse linear 1.5s infinite;
+}
+
+@-webkit-keyframes pulse {
+  0% { opacity: 1; }
+  50% { opacity: .25; }
+  100% { opacity: 1; }
+}
+@keyframes pulse {
+  0% { opacity: 1; }
+  50% { opacity: .25; }
+  100% { opacity: 1; }
+}
+
+@-moz-keyframes spin {
+  from {
+    -moz-transform: rotate(0deg);
+  }
+  to {
+    -moz-transform: rotate(360deg);
+  }
+}
+@-webkit-keyframes spin {
+  from {
+    -webkit-transform: rotate(0deg);
+  }
+  to {
+    -webkit-transform: rotate(360deg);
+  }
+}
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.spinning(@duration: 4) {
+  transform: translateZ(0);
+  -webkit-animation:spin ~"@{duration}s" steps(45) infinite;
+  -moz-animation:spin ~"@{duration}s" steps(45) infinite;
+  animation:spin ~"@{duration}s" steps(45) infinite;
+}

--- a/app/styles/imports/colors.less
+++ b/app/styles/imports/colors.less
@@ -45,3 +45,5 @@
 @glow-mid: rgba(137, 195, 231, .3);
 
 @code-yellow: #dddd00;
+
+@bootstrap_info: #d9edf7;

--- a/app/styles/imports/commonImports.less
+++ b/app/styles/imports/commonImports.less
@@ -1,4 +1,5 @@
 @import "app/styles/imports/colors.less";
+@import "app/styles/imports/animations.less";
 @import "app/styles/imports/mixins.less";
 @import "bower_components/bootstrap/less/mixins.less";
 @import "bower_components/bootstrap/less/variables.less";

--- a/app/styles/main.less
+++ b/app/styles/main.less
@@ -717,14 +717,6 @@ tfoot .add-new {
   cursor: pointer;
 }
 
-@-moz-keyframes spin { 100% { -moz-transform: rotate(360deg); } }
-@-webkit-keyframes spin { 100% { -webkit-transform: rotate(360deg); } }
-@keyframes spin {
-  100% {
-    transform: rotate(360deg);
-  }
-}
-
 .glyphicon-spinning {
   display: inline-block;
   height: 1em;
@@ -732,10 +724,7 @@ tfoot .add-new {
   margin: 0;
   opacity: 0.7;
   text-shadow: 0 0 .25em rgba(255,255,255, .3);
-  transform: translateZ(0);
-  -webkit-animation:spin 4s linear infinite;
-  -moz-animation:spin 4s linear infinite;
-  animation:spin 4s linear infinite;
+  .spinning();
 }
 
 a.help-field {

--- a/app/styles/modals.less
+++ b/app/styles/modals.less
@@ -86,22 +86,6 @@
   }
 }
 
-.pulsing {
-  -webkit-animation: pulse linear 1.5s infinite;
-  animation: pulse linear 1.5s infinite;
-}
-
-@-webkit-keyframes pulse {
-  0% { opacity: 1; }
-  50% { opacity: .25; }
-  100% { opacity: 1; }
-}
-@keyframes pulse {
-  0% { opacity: 1; }
-  50% { opacity: .25; }
-  100% { opacity: 1; }
-}
-
 .modal-body {
   h3, h4 {
     margin-top: 0;

--- a/app/styles/rollups.less
+++ b/app/styles/rollups.less
@@ -62,7 +62,6 @@
 }
 
 .instances {
-  background-color: #ffffff;
   a.instance {
     border: 1px solid @healthy_green_border;
     border-radius: 2px;
@@ -93,7 +92,7 @@
     &.active {
       border-color: @dark_grey;
       background-color: @healthy_green_border;
-      box-shadow: 0 0 3px 0px #999999;
+      box-shadow: 0 0 4px 2px #999999;
       &.health-status-Unhealthy {
         background-color: @unhealthy_red_border;
       }
@@ -320,9 +319,9 @@ load-balancers-tag {
 
 
 .rollup-details {
+  background-color: #ffffff;
   padding: 0;
   border-top: 1px solid #c4c4c4;
-  background-color: #ffffff;
   border-bottom-left-radius: 2px;
   border-bottom-right-radius: 2px;
 
@@ -400,9 +399,11 @@ load-balancers-tag {
       text-transform: uppercase;
       font-weight: 600;
     }
+    .subgroup-title {
+      background-color: #ffffff;
+    }
     .server-group-title, .subgroup-title {
-      padding: 5px 10px;
-      background-color: #fff;
+      padding: 5px 10px 2px;
       border-bottom-width: 0;
       &.clickable {
         &:hover, &.active {
@@ -425,8 +426,22 @@ load-balancers-tag {
     }
     border-bottom: 1px solid @mid_light_grey;
     .cluster-pod-server-group {
+      background-color: #ffffff;
+      .server-group-title {
+        background-color: #ffffff;
+      }
+      &.active {
+        background-color: @bootstrap_info;
+        .server-group-title {
+          background-color: @bootstrap_info;
+        }
+      }
+      &:hover {
+        box-shadow: 0 0 3px 0px @mid_grey;
+      }
       .instance-list {
-        padding: 0 10px;
+        padding: 0 10px 0 23px;
+
       }
       &.disabled {
         &:hover, &.active {
@@ -435,7 +450,8 @@ load-balancers-tag {
       }
     }
     .table {
-      margin-bottom: 5px;
+      margin-top: -5px;
+      margin-bottom: 10px;
       font-size: 90%;
     }
   }


### PR DESCRIPTION
- make the entire server group section clickable, not just the title
- change gray highlight on title bar hover to a box shadow on entire server group
- change selected color for instance rows and server groups to light blue
- heavier box shadow on selected chiclet
- bump alignment of instances to put them directly underneath (and a little closer up to) ASG name

Also tweaking the spinning animation to run at 45fps, which cuts CPU usage from ~30% to ~15% when that stupid animation is going.

Also fixing a bug preventing instances from being displayed on the load balancers view, not that anyone noticed because nobody has ever clicked on that checkbox to show instances on the load balancer view.
