### PR TITLE
rendering instances in clusters view via raw JS

### DIFF
--- a/app/scripts/directives/instanceList.directive.js
+++ b/app/scripts/directives/instanceList.directive.js
@@ -2,99 +2,171 @@
 
 
 angular.module('deckApp')
-  .directive('instanceList', function (scrollTriggerService, clusterFilterService, $rootScope) {
+  .directive('instanceList', function(clusterFilterService) {
     return {
       restrict: 'E',
       templateUrl: 'scripts/modules/instance/instanceList.html',
       scope: {
         instances: '=',
-        renderInstancesOnScroll: '=',
-        scrollTarget: '@',
         sortFilter: '=',
       },
+      link: function(scope) {
+        scope.updateQueryParams = clusterFilterService.updateQueryParams;
+      }
+    };
+  })
+  .directive('instanceListBody', function ($timeout, $filter, $rootScope, $state, scrollTriggerService, clusterFilterService) {
+    return {
+      restrict: 'C',
+      scope: {
+        instances: '=',
+        sortFilter: '=',
+        renderInstancesOnScroll: '=',
+      },
       link: function (scope, elem) {
-        scope.$state = scope.$parent.$state;
         scope.rendered = false;
 
-        scope.viewModel = {
-          instances: [],
-          hasDiscovery: true,
-          hasLoadBalancers: true,
-        };
+        var base = elem.parent().inheritedData('$uiView').state;
 
-        function showAllInstances() {
-          scope.$evalAsync(function() {
-            buildViewModel();
-            scope.rendered = true;
+        function buildTableRowOpenTag(instance) {
+          var activeClass = $state.includes('**.instanceDetails', {instanceId: instance.id, provider: instance.provider }) ? ' info' : ' ';
+          return '<tr class="clickable instance-row ' + activeClass + '"' +
+            ' data-provider="' + instance.provider + '"' +
+            ' data-instance-id="' + instance.id + '">';
+        }
+
+        function buildInstanceIdCell(row, instance) {
+          var status = instance.isHealthy ? 'up' : instance.hasHealthStatus ? 'down' : 'unknown';
+          row += '<td><span class="glyphicon glyphicon-' + status + '-triangle"></span>' +
+            instance.id + '</td>';
+          return row;
+        }
+
+        function buildLaunchTimeCell(row, instance) {
+          row += '<td>' + $filter('simpleTime')(instance.launchTime) + '</td>';
+          return row;
+        }
+
+        function buildZoneCell(row, instance) {
+          row += '<td>' + instance.availabilityZone + '</td>';
+          return row;
+        }
+
+        function buildDiscoveryCell(row, discoveryStatus) {
+          row += '<td class="text-center small">' + discoveryStatus + '</td>';
+          return row;
+        }
+
+        function buildLoadBalancersCell(row, loadBalancers) {
+          row += '<td>';
+          loadBalancers.forEach(function (loadBalancer) {
+            var tooltip = loadBalancer.state === 'OutOfService' ? loadBalancer.description.replace(/"/g, '&quot;') : null;
+            var icon = loadBalancer.state === 'InService' ? 'up' : 'down';
+            if (tooltip) {
+              row += '<div data-toggle="tooltip" title="' + tooltip + '">';
+            } else {
+              row += '<div>';
+            }
+            row += '<span class="glyphicon glyphicon-' + icon + '-triangle"></span> ';
+            row += loadBalancer.name;
+            row += '</div>';
+          });
+          if (!loadBalancers.length) {
+            row += '-';
+          }
+          row += '</td>';
+          return row;
+        }
+
+        function renderInstances() {
+          $('[data-toggle="tooltip"]', elem).tooltip('destroy');
+          var instances = scope.instances || [],
+            filtered = instances.filter(clusterFilterService.shouldShowInstance),
+            sorted = $filter('orderBy')(filtered, scope.sortFilter.instanceSort.key);
+
+          elem.get(0).innerHTML = sorted.map(function (instance) {
+            var loadBalancers = [],
+              discoveryState = '',
+              discoveryStatus = '-',
+              loadBalancerSort = '';
+
+            instance.health.forEach(function (health) {
+              if (health.type === 'LoadBalancer') {
+                loadBalancers = health.loadBalancers;
+                loadBalancerSort = _(health.loadBalancers)
+                  .sortByAll(['name', 'state'])
+                  .map(function (lbh) {
+                    return lbh.name + ':' + lbh.state;
+                  })
+                  .join(',');
+              }
+              if (health.type === 'Discovery') {
+                discoveryState = health.state.toLowerCase();
+                discoveryStatus = $filter('robotToHuman')(health.status.toLowerCase());
+              }
+            });
+
+            var row = buildTableRowOpenTag(instance);
+            row = buildInstanceIdCell(row, instance);
+            row = buildLaunchTimeCell(row, instance);
+            row = buildZoneCell(row, instance);
+            row = buildDiscoveryCell(row, discoveryStatus);
+            row = buildLoadBalancersCell(row, loadBalancers);
+            row += '</tr>';
+
+            return row;
+
+          }).join('');
+
+          $('[data-toggle="tooltip"]', elem).tooltip({placement: 'left', container: 'body'});
+
+          scope.$watch('sortFilter.instanceSort.key', function(newVal, oldVal) {
+            if (newVal && oldVal && newVal !== oldVal) {
+              renderInstances();
+            }
           });
         }
 
         if (scope.renderInstancesOnScroll) {
-          scrollTriggerService.register(scope, elem, scope.scrollTarget, showAllInstances);
+          scrollTriggerService.register(scope, elem, scope.scrollTarget, renderInstances);
         } else {
-          showAllInstances();
+          renderInstances();
         }
 
-        function buildViewModel() {
-          var instances = [],
-            hasDiscovery = false, hasLoadBalancers = false;
+        scope.$on('$destroy', function() {
+          $('[data-toggle="tooltip"]', elem).tooltip('destroy');
+          elem.unbind('click');
+        });
 
-          scope.instances.forEach(function(instance) {
-            if (!clusterFilterService.shouldShowInstance(instance)) {
-              return;
+        elem.click(function(event) {
+          $timeout(function() {
+            if (event.target) {
+              // anything handled by ui-sref or actual links should be ignored
+              if (event.isDefaultPrevented() || (event.originalEvent && (event.originalEvent.defaultPrevented || event.originalEvent.target.href))) {
+                return;
+              }
+              var $targetRow =  $(event.target).closest('tr');
+              if (!$targetRow.length) {
+                return;
+              }
+              var targetRow = $targetRow.get(0);
+              var params = {
+                instanceId: targetRow.getAttribute('data-instance-id'),
+                provider: targetRow.getAttribute('data-provider')
+              };
+              // also stolen from uiSref directive
+              $state.go('.instanceDetails', params, {relative: base, inherit: true});
+              $('tr.instance-row').removeClass('info');
+              targetRow.className += ' info';
+              event.preventDefault();
             }
-            var instanceView = {
-              id: instance.id,
-              launchTime: instance.launchTime,
-              availabilityZone: instance.availabilityZone,
-              status: instance.isHealthy ? 'up' : instance.hasHealthStatus ? 'down' : 'unknown',
-              provider: instance.provider,
-            };
-            instances.push(instanceView);
-            instance.health.forEach(function(health) {
-              if (health.type === 'LoadBalancer') {
-                hasLoadBalancers = true;
-                instanceView.loadBalancers = health.loadBalancers;
-                instanceView.loadBalancerSort =  _(health.loadBalancers)
-                  .sortByAll(['name', 'state'])
-                  .map(function(lbh) { return lbh.name + ':' + lbh.state; })
-                  .join(',');
-              }
-              if (health.type === 'Discovery') {
-                hasDiscovery = true;
-                instanceView.discoveryState = health.state.toLowerCase();
-                instanceView.discoveryStatus = health.status.toLowerCase();
-              }
-            });
           });
+        });
 
-          scope.viewModel = {
-            instances: instances,
-            hasDiscovery: hasDiscovery,
-            hasLoadBalancers: hasLoadBalancers
-          };
-        }
-
-        // stolen from uiSref directive
-        var base = elem.parent().inheritedData('$uiView').state;
-
-        scope.$state = $rootScope.$state;
-
-        scope.loadInstanceDetails = function(event, id, provider) {
-          // anything handled by ui-sref or actual links should be ignored
-          if (event.isDefaultPrevented() || (event.originalEvent && event.originalEvent.target.href)) {
-            return;
-          }
-          event.preventDefault();
-          var params = {
-            instanceId: id,
-            provider: provider,
-          };
-          // also stolen from uiSref directive
-          scope.$state.go('.instanceDetails', params, {relative: base, inherit: true});
-        };
-
-        scope.updateQueryParams = clusterFilterService.updateQueryParams;
+        scope.$on('$destroy', function() {
+          $('[data-toggle="tooltip"]', elem).tooltip('destroy');
+          elem.unbind('click');
+        });
 
       }
     };

--- a/app/scripts/directives/instances.js
+++ b/app/scripts/directives/instances.js
@@ -2,10 +2,9 @@
 
 
 angular.module('deckApp')
-  .directive('instances', function (scrollTriggerService) {
+  .directive('instances', function ($timeout, $) {
     return {
       restrict: 'E',
-      templateUrl: 'scripts/modules/instance/instances.html',
       scope: {
         instances: '=',
         renderInstancesOnScroll: '=',
@@ -13,22 +12,48 @@ angular.module('deckApp')
         scrollTarget: '@',
       },
       link: function (scope, elem) {
-        scope.$state = scope.$parent.$state;
-        scope.rendered = false;
+        var $state = scope.$parent.$state;
+        scope.rendered = true;
 
-        function showAllInstances() {
-          scope.$evalAsync(function() {
-            scope.displayedInstances = scope.instances;
-            scope.rendered = true;
+        var base = elem.parent().inheritedData('$uiView').state;
+
+        var instances = _.sortBy(scope.instances, 'launchTime');
+        elem.get(0).innerHTML = '<div class="instances">' + instances.map(function(instance) {
+          var healthStatus = instance.isHealthy ? 'Healthy' : instance.hasHealthStatus ? 'Unhealthy' : 'UnknownStatus',
+              disabledClass = instance.healthStatus === 'Disabled' ? ' health-status-Unknown' : ' ',
+              activeClass = $state.includes('**.instanceDetails', {instanceId: instance.id, provider: instance.provider }) ? ' active' : ' ',
+              id = instance.id;
+          return '<a title="' + id +
+                  '" data-provider="' + instance.provider +
+                  '" data-toggle="tooltip" data-instance-id="' + id +
+                  '" class="instance health-status-' + healthStatus + disabledClass + activeClass + '"></a>';
+        }).join('') + '</div>';
+        $('[data-toggle="tooltip"]', elem).tooltip({placement: 'top', container: 'body'});
+
+        elem.click(function(event) {
+          $timeout(function() {
+            if (event.target && event.target.getAttribute('data-instance-id')) {
+              // anything handled by ui-sref or actual links should be ignored
+              if (event.isDefaultPrevented() || (event.originalEvent && (event.originalEvent.defaultPrevented || event.originalEvent.target.href))) {
+                return;
+              }
+              var params = {
+                instanceId: event.target.getAttribute('data-instance-id'),
+                provider: event.target.getAttribute('data-provider')
+              };
+              // also stolen from uiSref directive
+              $state.go('.instanceDetails', params, {relative: base, inherit: true});
+              $('a.instance').removeClass('active');
+              event.target.className += ' active';
+              event.preventDefault();
+            }
           });
-        }
+        });
 
-        if (scope.renderInstancesOnScroll) {
-          scope.displayedInstances = [];
-          scrollTriggerService.register(scope, elem, scope.scrollTarget, showAllInstances);
-        } else {
-          showAllInstances();
-        }
+        scope.$on('$destroy', function() {
+          $('[data-toggle="tooltip"]', elem).tooltip('destroy');
+          elem.unbind('click');
+        });
       }
     };
   }

--- a/app/scripts/modules/cluster/serverGroup.html
+++ b/app/scripts/modules/cluster/serverGroup.html
@@ -40,9 +40,7 @@
                    render-instances-on-scroll="false"></instances>
       </div>
       <div ng-if="displayOptions.listInstances">
-        <instance-list scroll-target="clusters-content" instances="viewModel.instances"
-                       sort-filter="sortFilter"
-                       render-instances-on-scroll="false"></instance-list>
+        <instance-list instances="viewModel.instances" sort-filter="sortFilter" render-instances-on-scroll="displayOptions.renderInstancesOnScroll"></instance-list>
       </div>
     </div>
   </div>

--- a/app/scripts/modules/instance/instanceList.html
+++ b/app/scripts/modules/instance/instanceList.html
@@ -1,42 +1,16 @@
-<table ng-if="viewModel.instances.length" class="table table-hover table-condensed instances">
+<table ng-if="instances.length" class="table table-hover table-condensed instances">
   <thead>
-    <tr>
-      <!-- use this when multi-select is a thing -->
-      <!--<th width="4%"><input type="checkbox"></th>-->
-      <th width="15%" sort-toggle key="id" label="Instance" sort-model="sortFilter.instanceSort" on-change="updateQueryParams()"></th>
-      <th width="23%" sort-toggle key="launchTime" label="Launch Time" default="true" sort-model="sortFilter.instanceSort" on-change="updateQueryParams()"></th>
-      <th width="13%" sort-toggle key="availabilityZone" label="Zone" sort-model="sortFilter.instanceSort" on-change="updateQueryParams()"></th>
-      <th width="15%" class="text-center" sort-toggle key="discoveryState" label="Discovery" sort-model="sortFilter.instanceSort" on-change="updateQueryParams()"></th>
-      <th width="34%" sort-toggle key="loadBalancerSort" label="Load Balancers" sort-model="sortFilter.instanceSort" on-change="updateQueryParams()"></th>
+  <tr>
+    <!-- use this when multi-select is a thing -->
+    <!--<th width="4%"><input type="checkbox"></th>-->
+    <th width="15%" sort-toggle key="id" label="Instance" sort-model="sortFilter.instanceSort" on-change="updateQueryParams()"></th>
+    <th width="23%" sort-toggle key="launchTime" label="Launch Time" default="true" sort-model="sortFilter.instanceSort" on-change="updateQueryParams()"></th>
+    <th width="13%" sort-toggle key="availabilityZone" label="Zone" sort-model="sortFilter.instanceSort" on-change="updateQueryParams()"></th>
+    <th width="15%" class="text-center" sort-toggle key="discoveryState" label="Discovery" sort-model="sortFilter.instanceSort" on-change="updateQueryParams()"></th>
+    <th width="34%" sort-toggle key="loadBalancerSort" label="Load Balancers" sort-model="sortFilter.instanceSort" on-change="updateQueryParams()"></th>
 
-    </tr>
+  </tr>
   </thead>
-  <tbody>
-    <tr ng-repeat="instance in viewModel.instances | instanceSearch:sortFilter.filter | orderBy: sortFilter.instanceSort.key track by instance.id"
-        ng-click="loadInstanceDetails($event, instance.id, instance.provider)"
-        class="clickable"
-        ng-class="{ info: $state.includes('**.instanceDetails', {instanceId: instance.id}) }">
-      <!-- use this when multi-select is a thing -->
-      <!--<td><input type="checkbox"></td>-->
-      <td>
-        <span class="glyphicon glyphicon-{{instance.status.toLowerCase()}}-triangle"></span>
-        {{instance.id}}
-      </td>
-      <td>{{instance.launchTime | simpleTime }}</td>
-      <td>{{instance.availabilityZone}}</td>
-      <td class="text-center">
-        <span ng-if="instance.discoveryState" class="small discovery-{{instance.discoveryState}}">
-          {{ instance.discoveryStatus | robotToHuman }}
-        </span>
-        <span ng-if="!instance.discoveryState">-</span>
-      </td>
-      <td>
-        <div ng-repeat="loadBalancer in instance.loadBalancers">
-          <instance-load-balancer-health load-balancer="loadBalancer"></instance-load-balancer-health>
-        </div>
-        <div ng-if="!instance.loadBalancers.length">-</div>
-      </td>
-    </tr>
+  <tbody class="instance-list-body" instances="instances" sort-filter="sortFilter">
   </tbody>
 </table>
-<span class="rollup-placeholder" ng-if="!rendered">(Rendering instances...)</span>

--- a/app/scripts/modules/utils/stickyHeader/stickyHeader.directive.js
+++ b/app/scripts/modules/utils/stickyHeader/stickyHeader.directive.js
@@ -16,7 +16,8 @@ angular.module('deckApp.utils.stickyHeader', [
           var $heading = elem,
             $section = $heading.parent(),
             $scrollableContainer = $heading.closest('[sticky-headers]'),
-            id = parseInt(Math.random() * new Date().getTime());
+            id = parseInt(Math.random() * new Date().getTime()),
+            isSticky = false;
 
           if (!$scrollableContainer.length) {
             $log.warn('No parent container with attribute "sticky-header"; headers will not stick.');
@@ -60,6 +61,7 @@ angular.module('deckApp.utils.stickyHeader', [
                 width: containerWidth + addedOffsetWidth,
                 zIndex: zIndex
               });
+              isSticky = true;
             } else {
               clearStickiness($section, $heading);
             }
@@ -74,12 +76,15 @@ angular.module('deckApp.utils.stickyHeader', [
           }
 
           function clearStickiness($section, $heading) {
-            $section.css({
-              paddingTop: 0,
-            });
-            if ($heading.get(0).className.indexOf('heading-sticky') !== -1) {
-              $heading.removeClass('heading-sticky').addClass('not-sticky');
+            if (isSticky) {
+              $section.css({
+                paddingTop: 0,
+              });
+              if ($heading.get(0).className.indexOf('heading-sticky') !== -1) {
+                $heading.removeClass('heading-sticky').addClass('not-sticky');
+              }
             }
+            isSticky = false;
           }
 
           function toggleSticky(enabled) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -211,7 +211,12 @@ gulp.task('scripts:application', ['jshint', 'clean:scripts:application'], functi
   ]), 'application.js');
 });
 gulp.task('scripts:vendor', ['clean:scripts:vendor'], function() {
-  return prepareJs(gulp.src(['bower_components/jquery/dist/jquery.js'].concat(bowerFiles({filter: /.*\.js/i}))), 'vendor.js');
+  return prepareJs(
+    gulp.src([
+      'bower_components/jquery/dist/jquery.js',
+    ]
+    .concat(bowerFiles({filter: /.*\.js/i}))
+    .concat('bower_components/bootstrap/js/tooltip.js')), 'vendor.js');
 });
 
 gulp.task('scripts:templates', ['clean:scripts:templates'], function() {


### PR DESCRIPTION
Minor performance improvements on smaller applications, huge performance improvements on huge applications with thousands of instances.

Still rendering on scroll, but setting `innerHTML` of the element instead of letting Angular render it.

Basically doubling down on the ugliness of stepping outside Angular, which will make maintenance a continuing nightmare, but from a user experience it's actually very good.

Seems to be free of memory leaks; I ran a huge application with a 1000+ instance ASG in view and memory consumption stayed consistent.
