### PR TITLE
fix width for execution details; consistent exception messages

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -48,7 +48,7 @@
 </div>
 
 <div class="container" ng-if="!authenticating">
-  <div class="container-liquid" ui-view="main"></div>
+  <div ui-view="main"></div>
 </div>
 
 <!-- inject:js -->

--- a/app/scripts/modules/delivery/delivery.module.js
+++ b/app/scripts/modules/delivery/delivery.module.js
@@ -20,6 +20,7 @@ angular.module('deckApp.delivery', [
   'deckApp.delivery.executionGroup.directive',
   'deckApp.delivery.executionGroupHeading.directive',
   'deckApp.delivery.executionStatus.directive',
+  'deckApp.delivery.executionDetails.stageFailureMessage.directive',
 
   'deckApp.executionDetails.controller',
   'deckApp.settings',

--- a/app/scripts/modules/delivery/executionDetails.html
+++ b/app/scripts/modules/delivery/executionDetails.html
@@ -61,7 +61,7 @@
             </a>
           </div>
         </div>
-        <ng-include src="ctrl.getDetailsSourceUrl()"></ng-include>
+        <div ng-include="ctrl.getDetailsSourceUrl()"></ng-include>
       </div>
     </div>
   </div>

--- a/app/scripts/modules/delivery/stageFailureMessage/stageFailureMessage.directive.js
+++ b/app/scripts/modules/delivery/stageFailureMessage/stageFailureMessage.directive.js
@@ -1,0 +1,13 @@
+'use strict';
+
+angular.module('deckApp.delivery.executionDetails.stageFailureMessage.directive', [])
+  .directive('stageFailureMessage', function () {
+    return {
+      restrict: 'E',
+      templateUrl: 'scripts/modules/delivery/stageFailureMessage/stageFailureMessage.html',
+      scope: {
+        isFailed: '=',
+        message: '=',
+      },
+    };
+  });

--- a/app/scripts/modules/delivery/stageFailureMessage/stageFailureMessage.html
+++ b/app/scripts/modules/delivery/stageFailureMessage/stageFailureMessage.html
@@ -1,0 +1,10 @@
+<div class="row" ng-if="isFailed">
+  <div class="col-md-12">
+    <div class="alert alert-danger">
+      <h5>Exception:</h5>
+      <p>
+        {{message || 'No Reason provided.'}}
+      </p>
+    </div>
+  </div>
+</div>

--- a/app/scripts/modules/pipelines/config/stages/bake/bakeExecutionDetails.html
+++ b/app/scripts/modules/pipelines/config/stages/bake/bakeExecutionDetails.html
@@ -23,19 +23,7 @@
     <execution-step-details item="stage"></execution-step-details>
   </div>
 
-  <div class="row" ng-if="stage.isFailed">
-    <div class="col-md-12">
-      <div class="alert alert-danger">
-        <h5>Exception:</h5>
-        <p ng-if="ctrl.getException(stage)">
-          {{ctrl.getException(stage)}}
-        </p>
-        <p ng-if="!ctrl.getException(stage)">
-          No reason provided.
-        </p>
-      </div>
-    </div>
-  </div>
+  <stage-failure-message is-failed="stage.isFailed" message="ctrl.getException(stage)"></stage-failure-message>
 
   <div class="row" ng-if="stage.context.package && stage.context.region && stage.context.status.resourceId">
     <div class="col-md-12">

--- a/app/scripts/modules/pipelines/config/stages/deploy/deployExecutionDetails.html
+++ b/app/scripts/modules/pipelines/config/stages/deploy/deployExecutionDetails.html
@@ -4,7 +4,7 @@
       <h5>Deployment Configuration</h5>
       <dl class="dl-narrow dl-horizontal">
         <dt>Account</dt>
-        <dd>{{stage.context.account}}</dd>
+        <dd><account-tag account="stage.context.account"></account-tag></dd>
         <dt>Region</dt>
         <dd ng-repeat="(region, zones) in stage.context.availabilityZones">{{region}}<br/>({{zones.join(', ')}})</dd>
         <dt>Cluster</dt>
@@ -27,19 +27,7 @@
 
   </div>
 
-  <div class="row" ng-if="stage.isFailed">
-    <div class="col-md-12">
-      <div class="alert alert-danger">
-        <h5>Exception:</h5>
-        <p ng-if="ctrl.getException(stage)">
-          {{ctrl.getException(stage)}}
-        </p>
-        <p ng-if="!ctrl.getException(stage)">
-          No reason provided.
-        </p>
-      </div>
-    </div>
-  </div>
+  <stage-failure-message is-failed="stage.isFailed" message="ctrl.getException(stage)"></stage-failure-message>
 
   <div class="row" ng-if="stage.isCompleted && stage.context['kato.tasks'][0].resultObjects">
     <div class="col-md-12">

--- a/app/scripts/modules/pipelines/config/stages/destroyAsg/destroyAsgExecutionDetails.html
+++ b/app/scripts/modules/pipelines/config/stages/destroyAsg/destroyAsgExecutionDetails.html
@@ -3,14 +3,12 @@
     <div class="col-md-6">
       <h5>Destroy ASG Stage Configuration</h5>
       <dl class="dl-narrow dl-horizontal">
-        <dt>ASG Name</dt>
-        <dd>{{stage.context.asgName}}</dd>
         <dt>Account</dt>
         <dd><account-tag account="stage.context.credentials"></account-tag></dd>
-      </dl>
-      <dl class="dl-narrow dl-horizontal">
-        <dt>Regions</dt>
+        <dt>Region</dt>
         <dd>{{stage.context.regions.join(', ')}}</dd>
+        <dt>ASG Name</dt>
+        <dd>{{stage.context.asgName}}</dd>
       </dl>
     </div>
 
@@ -18,19 +16,7 @@
 
   </div>
 
-  <div class="row" ng-if="stage.isFailed">
-    <div class="col-md-12">
-      <div class="alert alert-danger">
-        <h5>Exception:</h5>
-        <p ng-if="ctrl.getException(stage)">
-          {{ctrl.getException(stage)}}
-        </p>
-        <p ng-if="!ctrl.getException(stage)">
-          No reason provided.
-        </p>
-      </div>
-    </div>
-  </div>
+  <stage-failure-message is-failed="stage.isFailed" message="ctrl.getException(stage)"></stage-failure-message>
 
   <div class="row" ng-if="stage.context.execution.logs">
     <div class="col-md-12">

--- a/app/scripts/modules/pipelines/config/stages/disableAsg/disableAsgExecutionDetails.html
+++ b/app/scripts/modules/pipelines/config/stages/disableAsg/disableAsgExecutionDetails.html
@@ -3,14 +3,12 @@
     <div class="col-md-6">
       <h5>Disable ASG Stage Configuration</h5>
       <dl class="dl-narrow dl-horizontal">
-        <dt>ASG Name</dt>
-        <dd>{{stage.context.asgName}}</dd>
         <dt>Account</dt>
         <dd><account-tag account="stage.context.credentials"></account-tag></dd>
-      </dl>
-      <dl class="dl-narrow dl-horizontal">
-        <dt>Regions</dt>
+        <dt>Region</dt>
         <dd>{{stage.context.regions.join(', ')}}</dd>
+        <dt>ASG Name</dt>
+        <dd>{{stage.context.asgName}}</dd>
       </dl>
     </div>
 
@@ -18,19 +16,7 @@
 
   </div>
 
-  <div class="row" ng-if="stage.isFailed">
-    <div class="col-md-12">
-      <div class="alert alert-danger">
-        <h5>Exception:</h5>
-        <p ng-if="ctrl.getException(stage)">
-          {{ctrl.getException(stage)}}
-        </p>
-        <p ng-if="!ctrl.getException(stage)">
-          No reason provided.
-        </p>
-      </div>
-    </div>
-  </div>
+  <stage-failure-message is-failed="stage.isFailed" message="ctrl.getException(stage)"></stage-failure-message>
 
   <div class="row" ng-if="stage.context.execution.logs">
     <div class="col-md-12">

--- a/app/scripts/modules/pipelines/config/stages/enableAsg/enableAsgExecutionDetails.html
+++ b/app/scripts/modules/pipelines/config/stages/enableAsg/enableAsgExecutionDetails.html
@@ -3,14 +3,12 @@
     <div class="col-md-6">
       <h5>Enable ASG Stage Configuration</h5>
       <dl class="dl-narrow dl-horizontal">
-        <dt>ASG Name</dt>
-        <dd>{{stage.context.asgName}}</dd>
         <dt>Account</dt>
         <dd><account-tag account="stage.context.credentials"></account-tag></dd>
-      </dl>
-      <dl class="dl-narrow dl-horizontal">
-        <dt>Regions</dt>
+        <dt>Region</dt>
         <dd>{{stage.context.regions.join(', ')}}</dd>
+        <dt>ASG Name</dt>
+        <dd>{{stage.context.asgName}}</dd>
       </dl>
     </div>
 
@@ -18,19 +16,7 @@
 
   </div>
 
-  <div class="row" ng-if="stage.isFailed">
-    <div class="col-md-12">
-      <div class="alert alert-danger">
-        <h5>Exception:</h5>
-        <p ng-if="ctrl.getException(stage)">
-          {{ctrl.getException(stage)}}
-        </p>
-        <p ng-if="!ctrl.getException(stage)">
-          No reason provided.
-        </p>
-      </div>
-    </div>
-  </div>
+  <stage-failure-message is-failed="stage.isFailed" message="ctrl.getException(stage)"></stage-failure-message>
 
   <div class="row" ng-if="stage.context.execution.logs">
     <div class="col-md-12">

--- a/app/scripts/modules/pipelines/config/stages/jenkins/jenkinsExecutionDetails.html
+++ b/app/scripts/modules/pipelines/config/stages/jenkins/jenkinsExecutionDetails.html
@@ -19,19 +19,7 @@
 
   </div>
 
-  <div class="row" ng-if="stage.isFailed">
-    <div class="col-md-12">
-      <div class="alert alert-danger">
-        <h5>Exception:</h5>
-        <p ng-if="ctrl.getException(stage)">
-          {{ctrl.getException(stage)}}
-        </p>
-        <p ng-if="!ctrl.getException(stage)">
-          No reason provided.
-        </p>
-      </div>
-    </div>
-  </div>
+  <stage-failure-message is-failed="stage.isFailed" message="ctrl.getException(stage)"></stage-failure-message>
 
   <div class="row" ng-if="stage.context.execution.logs">
     <div class="col-md-12">

--- a/app/scripts/modules/pipelines/config/stages/modifyScalingProcess/modifyScalingProcessExecutionDetails.html
+++ b/app/scripts/modules/pipelines/config/stages/modifyScalingProcess/modifyScalingProcessExecutionDetails.html
@@ -3,18 +3,14 @@
     <div class="col-md-6">
       <h5>Modify Scaling Processes Stage Configuration</h5>
       <dl class="dl-narrow dl-horizontal">
+        <dt>Account</dt>
+        <dd><account-tag account="stage.context.credentials"></account-tag></dd>
+        <dt>Region</dt>
+        <dd>{{stage.context.regions.join(', ')}}</dd>
         <dt>ASG Name</dt>
         <dd>{{stage.context.asgName}}</dd>
-      </dl>
-      <dl class="dl-narrow dl-horizontal">
-        <dt>Regions</dt>
-        <dd>{{stage.context.regions}}</dd>
-      </dl>
-      <dl class="dl-narrow dl-horizontal">
         <dt>Action</dt>
         <dd>{{stage.context.action}}</dd>
-      </dl>
-      <dl class="dl-narrow dl-horizontal">
         <dt>Processes</dt>
         <dd>{{stage.context.processes}}</dd>
       </dl>
@@ -24,19 +20,7 @@
 
   </div>
 
-  <div class="row" ng-if="stage.isFailed">
-    <div class="col-md-12">
-      <div class="alert alert-danger">
-        <h5>Exception:</h5>
-        <p ng-if="ctrl.getException(stage)">
-          {{ctrl.getException(stage)}}
-        </p>
-        <p ng-if="!ctrl.getException(stage)">
-          No reason provided.
-        </p>
-      </div>
-    </div>
-  </div>
+  <stage-failure-message is-failed="stage.isFailed" message="ctrl.getException(stage)"></stage-failure-message>
 
   <div class="row" ng-if="stage.context.execution.logs">
     <div class="col-md-12">

--- a/app/scripts/modules/pipelines/config/stages/resizeAsg/resizeAsgExecutionDetails.html
+++ b/app/scripts/modules/pipelines/config/stages/resizeAsg/resizeAsgExecutionDetails.html
@@ -3,22 +3,12 @@
     <div class="col-md-6">
       <h5>Resize ASG Stage Configuration</h5>
       <dl class="dl-narrow dl-horizontal">
-        <dt>Cluster</dt>
-        <dd>{{stage.context.cluster}}</dd>
-      </dl>
-      <dl class="dl-narrow dl-horizontal">
+        <dt>Account</dt>
+        <dd><account-tag account="stage.context.credentials"></account-tag></dd>
+        <dt>Region</dt>
+        <dd>{{stage.context.regions.join(',')}}</dd>
         <dt>ASG Name</dt>
         <dd>{{stage.context.asgName}}</dd>
-      </dl>
-      <dl class="dl-narrow dl-horizontal">
-        <dt>Scaling Action</dt>
-        <dd>{{stage.context.action}}</dd>
-      </dl>
-      <dl class="dl-narrow dl-horizontal">
-        <dt>Regions</dt>
-        <dd>{{stage.context.regions}}</dd>
-      </dl>
-      <dl class="dl-narrow dl-horizontal">
         <dt>Capacity</dt>
         <dd>{{stage.context.capacity.min}} / {{stage.context.capacity.desired}} / {{stage.context.capacity.max}}</dd>
       </dl>
@@ -28,19 +18,7 @@
 
   </div>
 
-  <div class="row" ng-if="stage.isFailed">
-    <div class="col-md-12">
-      <div class="alert alert-danger">
-        <h5>Exception:</h5>
-        <p ng-if="ctrl.getException(stage)">
-          {{ctrl.getException(stage)}}
-        </p>
-        <p ng-if="!ctrl.getException(stage)">
-          No reason provided.
-        </p>
-      </div>
-    </div>
-  </div>
+  <stage-failure-message is-failed="stage.isFailed" message="ctrl.getException(stage)"></stage-failure-message>
 
   <div class="row" ng-if="stage.context.execution.logs">
     <div class="col-md-12">

--- a/app/scripts/modules/pipelines/config/stages/script/scriptExecutionDetails.html
+++ b/app/scripts/modules/pipelines/config/stages/script/scriptExecutionDetails.html
@@ -16,19 +16,7 @@
 
   </div>
 
-  <div class="row" ng-if="stage.isFailed">
-    <div class="col-md-12">
-      <div class="alert alert-danger">
-        <h5>Exception:</h5>
-        <p ng-if="ctrl.getException(stage)">
-          {{ctrl.getException(stage)}}
-        </p>
-        <p ng-if="!ctrl.getException(stage)">
-          No reason provided.
-        </p>
-      </div>
-    </div>
-  </div>
+  <stage-failure-message is-failed="stage.isFailed" message="ctrl.getException(stage)"></stage-failure-message>
 
   <div class="row" ng-if="stage.context.execution.logs">
     <div class="col-md-12">

--- a/app/scripts/modules/pipelines/config/stages/wait/waitExecutionDetails.html
+++ b/app/scripts/modules/pipelines/config/stages/wait/waitExecutionDetails.html
@@ -12,19 +12,7 @@
 
   </div>
 
-  <div class="row" ng-if="stage.isFailed">
-    <div class="col-md-12">
-      <div class="alert alert-danger">
-        <h5>Exception:</h5>
-        <p ng-if="ctrl.getException(stage)">
-          {{ctrl.getException(stage)}}
-        </p>
-        <p ng-if="!ctrl.getException(stage)">
-          No reason provided.
-        </p>
-      </div>
-    </div>
-  </div>
+  <stage-failure-message is-failed="stage.isFailed" message="ctrl.getException(stage)"></stage-failure-message>
 
   <div class="row" ng-if="stage.context.execution.logs">
     <div class="col-md-12">

--- a/app/styles/pipelines.less
+++ b/app/styles/pipelines.less
@@ -9,6 +9,20 @@
   display: flex;
   flex-direction: column;
 
+  @media(min-width: 768px) and (max-width: 992px) {
+    width: 768px;
+  }
+
+  @media(min-width: 992px) {
+    width: 992px;
+  }
+  @media(min-width: 1200px) {
+    width: 1200px;
+  }
+  @media(min-width: 1400px) {
+    width: 1400px;
+  }
+
   > .header {
     flex: none
   }


### PR DESCRIPTION
Consistency is nice:
- Always should account, then region, the cluster/ASG name in that order
- Fix width on execution details so it doesn't blow out to the edge of the page
- Refactor exception message to a directive
