### PR TITLE
use consistent readable time for all timestamps

### DIFF
--- a/app/scripts/directives/instanceList.directive.js
+++ b/app/scripts/directives/instanceList.directive.js
@@ -43,7 +43,7 @@ angular.module('deckApp')
         }
 
         function buildLaunchTimeCell(row, instance) {
-          row += '<td>' + $filter('simpleTime')(instance.launchTime) + '</td>';
+          row += '<td>' + $filter('timestamp')(instance.launchTime) + '</td>';
           return row;
         }
 

--- a/app/scripts/filters/timeFormatters.js
+++ b/app/scripts/filters/timeFormatters.js
@@ -2,26 +2,13 @@
 
 
 angular.module('deckApp')
-  .filter('relativeTime', function(momentService) {
+  .filter('timestamp', function(momentService) {
     return function(input) {
-      input = input || '';
       var moment = momentService(isNaN(parseInt(input)) ? input : parseInt(input));
-      return moment.isValid()? moment.calendar() : 'n/a';
+      return moment.isValid() ? moment.format('YYYY-MM-DD HH:mm:ss') : 'n/a';
     };
   })
   .filter('duration', function(momentService) {
-    return function(input) {
-      var moment = momentService(isNaN(parseInt(input)) ? input : parseInt(input));
-      return moment.isValid()? moment.fromNow() : 'n/a';
-    };
-  })
-  .filter('simpleTime', function(momentService) {
-    return function(input) {
-      var moment = momentService(isNaN(parseInt(input)) ? input : parseInt(input));
-      return moment.isValid() ? moment.format('MM/DD/YY, h:mm:ss a') : 'n/a';
-    };
-  })
-  .filter('numericDuration', function(momentService) {
     return function(input) {
       var moment = momentService.utc(isNaN(parseInt(input)) ? input : parseInt(input));
       var format = moment.hours() ? 'HH:mm:ss' : 'mm:ss';

--- a/app/scripts/modules/applications/applications.html
+++ b/app/scripts/modules/applications/applications.html
@@ -47,10 +47,10 @@
             </a>
           </td>
           <td>
-            {{ application.createTs | relativeTime }}
+            {{ application.createTs | timestamp }}
           </td>
           <td>
-            {{ application.updateTs | relativeTime }}
+            {{ application.updateTs | timestamp }}
           </td>
           <td>
             {{ application.email }}

--- a/app/scripts/modules/delivery/executionDetails.html
+++ b/app/scripts/modules/delivery/executionDetails.html
@@ -25,8 +25,8 @@
         <tbody>
           <tr ng-repeat-start="stageSummary in execution.stageSummaries" class="stage-summary">
             <td>{{ stageSummary.name }}</td>
-            <td>{{ stageSummary.startTime | simpleTime }}</td>
-            <td>{{ stageSummary.endTime | simpleTime }}</td>
+            <td>{{ stageSummary.startTime | timestamp }}</td>
+            <td>{{ stageSummary.endTime | timestamp }}</td>
             <td>
               <span class="label label-default label-{{ stageSummary.status | lowercase }}">
                 <status-glyph item="stageSummary"></status-glyph>{{ stageSummary.status | lowercase | robotToHuman }}
@@ -38,8 +38,8 @@
               ng-class="{ info: ctrl.isStageCurrent(stage.index) }"
               ng-click="ctrl.toggleDetails(stage.index)">
             <td>{{ (stage.name && stage.name != stage.type) ? stage.name : (stage.type | robotToHuman) }}</td>
-            <td>{{ stage.startTime | simpleTime }}</td>
-            <td>{{ stage.endTime | simpleTime }}</td>
+            <td>{{ stage.startTime | timestamp }}</td>
+            <td>{{ stage.endTime | timestamp }}</td>
             <td>
               <span class="label label-default label-{{ stage.status | lowercase }}">
                 {{ stage.status | lowercase | robotToHuman }}

--- a/app/scripts/modules/delivery/executionStatus.html
+++ b/app/scripts/modules/delivery/executionStatus.html
@@ -26,7 +26,7 @@
           {{ execution.trigger.user || 'unknown user'}}
         </li>
         <li>
-          {{ execution.startTime | relativeTime }}
+          {{ execution.startTime | timestamp }}
         </li>
       </span>
     </ul>

--- a/app/scripts/modules/instance/instanceDetails.html
+++ b/app/scripts/modules/instance/instanceDetails.html
@@ -57,12 +57,12 @@
     <collapsible-section heading="Instance Information" expanded="true">
       <dl>
         <dt>Launched:</dt>
-        <dd ng-if="instance.launchTime">{{instance.launchTime | relativeTime}}</dd>
+        <dd ng-if="instance.launchTime">{{instance.launchTime | timestamp}}</dd>
         <dd ng-if="!instance.launchTime">(Unknown)</dd>
         <dt>In:</dt>
         <dd>
+          <account-tag account="instance.account" pad="right"></account-tag>
           {{instance.placement.availabilityZone || '(Unknown)'}}
-          <account-tag account="instance.account" pad="left"></account-tag>
         </dd>
         <dt>Instance Type:</dt>
         <dd>{{instance.instanceType || '(Unknown)'}}</dd>

--- a/app/scripts/modules/loadBalancers/details/aws/loadBalancerDetails.html
+++ b/app/scripts/modules/loadBalancers/details/aws/loadBalancerDetails.html
@@ -46,7 +46,7 @@
     <collapsible-section heading="Load Balancer Details" expanded="true">
         <dl class="dl-horizontal dl-narrow">
           <dt>Created:</dt>
-          <dd>{{loadBalancer.elb.createdTime | relativeTime}}</dd>
+          <dd>{{loadBalancer.elb.createdTime | timestamp}}</dd>
           <dt>Region:</dt>
           <dd>{{loadBalancer.region}}</dd>
           <dt>Account:</dt>

--- a/app/scripts/modules/loadBalancers/details/gce/loadBalancerDetails.html
+++ b/app/scripts/modules/loadBalancers/details/gce/loadBalancerDetails.html
@@ -46,7 +46,7 @@
     <collapsible-section heading="Load Balancer Details" expanded="true">
         <dl class="dl-horizontal dl-narrow">
           <dt>Created:</dt>
-          <dd>{{loadBalancer.elb.createdTime | relativeTime}}</dd>
+          <dd>{{loadBalancer.elb.createdTime | timestamp}}</dd>
           <dt>Region:</dt>
           <dd>{{loadBalancer.region}}</dd>
           <dt>Account:</dt>

--- a/app/scripts/modules/pipelines/config/stages/core/executionStepDetails.html
+++ b/app/scripts/modules/pipelines/config/stages/core/executionStepDetails.html
@@ -13,7 +13,7 @@
       <span class="small"><status-glyph item="item"></status-glyph></span> {{item.name | robotToHuman }}
     </div>
     <div class="col-md-4 text-right">
-      {{item.runningTimeInMs | numericDuration }}
+      {{item.runningTimeInMs | duration }}
     </div>
   </div>
 </div>

--- a/app/scripts/modules/serverGroups/details/aws/serverGroupDetails.html
+++ b/app/scripts/modules/serverGroups/details/aws/serverGroupDetails.html
@@ -69,7 +69,7 @@
             <span class="small"><status-glyph item="step"></status-glyph></span> {{step.name | robotToHuman }}
           </div>
           <div class="col-md-4 text-right">
-            {{step.runningTimeInMs | numericDuration }}
+            {{step.runningTimeInMs | duration }}
           </div>
         </div>
       </div>
@@ -77,7 +77,7 @@
     <collapsible-section heading="Server Group Information" expanded="true">
       <dl class="dl-horizontal dl-narrow">
         <dt>Created:</dt>
-        <dd>{{serverGroup.launchConfig.createdTime | relativeTime}}</dd>
+        <dd>{{serverGroup.launchConfig.createdTime | timestamp}}</dd>
         <dt>In:</dt>
         <dd>
           {{serverGroup.cluster}}:{{serverGroup.region}}

--- a/app/scripts/modules/serverGroups/details/gce/serverGroupDetails.html
+++ b/app/scripts/modules/serverGroups/details/gce/serverGroupDetails.html
@@ -69,7 +69,7 @@
             <span class="small"><status-glyph item="step"></status-glyph></span> {{step.name | robotToHuman }}
           </div>
           <div class="col-md-4 text-right">
-            {{step.runningTimeInMs | numericDuration }}
+            {{step.runningTimeInMs | duration }}
           </div>
         </div>
       </div>
@@ -77,7 +77,7 @@
     <collapsible-section heading="Server Group Information" expanded="true">
       <dl>
         <dt>Created:</dt>
-        <dd>{{serverGroup.launchConfig.createdTime | relativeTime}}</dd>
+        <dd>{{serverGroup.launchConfig.createdTime | timestamp}}</dd>
         <dt>In:</dt>
         <dd>
           {{serverGroup.cluster}}:{{serverGroup.region}}

--- a/app/scripts/modules/serverGroups/details/scalingActivities.html
+++ b/app/scripts/modules/serverGroups/details/scalingActivities.html
@@ -10,7 +10,7 @@
     <div ng-repeat="activity in activities" ng-if="activities.length">
         <p class="clearfix">
           <span class="label label-{{ctrl.isSuccessful(activity) ? 'success' : 'danger'}} pull-left">{{activity.statusCode}}</span>
-          <span class="label label-default pull-right">{{activity.startTime | relativeTime}}</span>
+          <span class="label label-default pull-right">{{activity.startTime | timestamp}}</span>
         </p>
         <p>{{activity.cause}}</p>
         <p>Summary of activities:

--- a/app/scripts/modules/serverGroups/pod/runningTasksTag.html
+++ b/app/scripts/modules/serverGroups/pod/runningTasksTag.html
@@ -18,7 +18,7 @@
           <span class="small"><status-glyph item="step"></status-glyph></span> {{step.name | robotToHuman }}
         </div>
         <div class="col-md-4 text-right">
-          {{step.runningTimeInMs | numericDuration }}
+          {{step.runningTimeInMs | duration }}
         </div>
       </div>
     </div>

--- a/app/scripts/modules/tasks/taskdetails.html
+++ b/app/scripts/modules/tasks/taskdetails.html
@@ -32,10 +32,10 @@
       {{ taskDetail.task.status}}
       <dl>
         <dt>Started</dt>
-        <dd>{{ taskDetail.task.startTime | relativeTime }}</dd>
+        <dd>{{ taskDetail.task.startTime | timestamp }}</dd>
         <span ng-if="taskDetail.task.isCompleted">
           <dt>Completed</dt>
-          <dd>{{ taskDetail.task.endTime | relativeTime }}</dd>
+          <dd>{{ taskDetail.task.endTime | timestamp }}</dd>
         </span>
         <dt>Running time</dt>
         <dd>{{ taskDetail.task.runningTime }}</dd>
@@ -48,9 +48,9 @@
       </h5>
       <dl class="well" style="padding: 10px;" ng-repeat-end>
         <dt>Started</dt>
-        <dd>{{ step.startTime | relativeTime }}</dd>
+        <dd>{{ step.startTime | timestamp }}</dd>
         <dt>Completed</dt>
-        <dd>{{ step.endTime | relativeTime }}</dd>
+        <dd>{{ step.endTime | timestamp }}</dd>
         <dt>Running time</dt>
         <dd>{{ step.runningTime }}</dd>
       </dl>

--- a/app/scripts/modules/tasks/taskview.html
+++ b/app/scripts/modules/tasks/taskview.html
@@ -32,9 +32,9 @@
                 Not started
               </div>
               <dl ng-if="!task.hasNotStarted">
-                <dt>Started</dt> <dd>{{ task.startTime | relativeTime }}</dd>
+                <dt>Started</dt> <dd>{{ task.startTime | timestamp }}</dd>
                 <dt ng-if="task.isCompleted && task.endTime">Completed</dt>
-                <dd ng-if="task.isCompleted && task.endTime">{{ task.endTime | relativeTime }}</dd>
+                <dd ng-if="task.isCompleted && task.endTime">{{ task.endTime | timestamp }}</dd>
                 <dt>Running time<dt> <dd>{{ task.runningTime }}</dd>
               </dl>
             </div>


### PR DESCRIPTION
This make all timestamps consistent throughout the application:
`YYYY-MM-DD HH:mm:ss`, e.g. 2015-03-06 13:01:44

Times will still always be in local time - I'm not willing to bite off UTC or append the timezone offset to each timestamp, but if people insist on it, we can certainly have that conversation.
