### PR TITLE
consistent details, fix security group details loading issue

### DIFF
--- a/app/scripts/modules/instance/instanceDetails.html
+++ b/app/scripts/modules/instance/instanceDetails.html
@@ -55,7 +55,7 @@
   </div>
   <div class="content" ng-if="!state.loading">
     <collapsible-section heading="Instance Information" expanded="true">
-      <dl>
+      <dl class="dl-horizontal dl-narrow">
         <dt>Launched:</dt>
         <dd ng-if="instance.launchTime">{{instance.launchTime | timestamp}}</dd>
         <dd ng-if="!instance.launchTime">(Unknown)</dd>
@@ -64,7 +64,7 @@
           <account-tag account="instance.account" pad="right"></account-tag>
           {{instance.placement.availabilityZone || '(Unknown)'}}
         </dd>
-        <dt>Instance Type:</dt>
+        <dt>Type:</dt>
         <dd>{{instance.instanceType || '(Unknown)'}}</dd>
         <dt ng-if="instance.serverGroup">Server Group:</dt>
         <dd ng-if="instance.serverGroup">{{instance.serverGroup}}</dd>

--- a/app/scripts/modules/loadBalancers/details/aws/loadBalancerDetails.html
+++ b/app/scripts/modules/loadBalancers/details/aws/loadBalancerDetails.html
@@ -44,32 +44,34 @@
   </div>
   <div ng-if="!state.loading" class="content">
     <collapsible-section heading="Load Balancer Details" expanded="true">
-        <dl class="dl-horizontal dl-narrow">
-          <dt>Created:</dt>
-          <dd>{{loadBalancer.elb.createdTime | timestamp}}</dd>
-          <dt>Region:</dt>
-          <dd>{{loadBalancer.region}}</dd>
-          <dt>Account:</dt>
-          <dd><account-tag account="loadBalancer.account"></account-tag></dd>
-        </dl>
-        <dl>
-          <dt>Availability Zones:</dt>
-          <dd>
-            <ul>
-              <li ng-repeat="availabilityZone in loadBalancer.elb.availabilityZones">{{availabilityZone}}</li>
-            </ul>
-          </dd>
-          <dt ng-if="loadBalancer.serverGroupNames">Server Groups:</dt>
-          <dd ng-if="loadBalancer.serverGroupNames">
-            <ul>
-              <li ng-repeat="serverGroup in loadBalancer.serverGroupNames">{{serverGroup}}</li>
-            </ul>
-          </dd>
-          <dt ng-if="loadBalancer.elb.dnsname">DNS Name</dt>
-          <dd><a target=_blank href="http://{{loadBalancer.elb.dnsname}}">{{loadBalancer.elb.dnsname}}</a></dd>
-          <dt ng-if="loadBalancer.elb.vpcid">VPC ID</dt>
-          <dd>{{loadBalancer.elb.vpcid}}</dd>
-        </dl>
+      <dl class="dl-horizontal dl-narrow">
+        <dt>Created:</dt>
+        <dd>{{loadBalancer.elb.createdTime | timestamp}}</dd>
+        <dt>In:</dt>
+        <dd><account-tag account="loadBalancer.account" pad="right"></account-tag> {{loadBalancer.region}}</dd>
+        <dt>VPC:</dt>
+        <dd>{{loadBalancer.elb.vpcid || 'None (EC2 Classic)'}}</dd>
+      </dl>
+      <dl>
+        <dt>Availability Zones:</dt>
+        <dd>
+          <ul style="margin-left: 30px">
+            <li ng-repeat="availabilityZone in loadBalancer.elb.availabilityZones">{{availabilityZone}}</li>
+          </ul>
+        </dd>
+      </dl>
+      <dl>
+        <dt ng-if="loadBalancer.serverGroups">Server Groups:</dt>
+        <dd ng-if="loadBalancer.serverGroups">
+          <ul style="margin-left: 30px">
+            <li ng-repeat="serverGroup in loadBalancer.serverGroups">{{serverGroup.name}}</li>
+          </ul>
+        </dd>
+      </dl>
+      <dl>
+        <dt ng-if="loadBalancer.elb.dnsname">DNS Name</dt>
+        <dd><a target=_blank href="http://{{loadBalancer.elb.dnsname}}">{{loadBalancer.elb.dnsname}}</a></dd>
+      </dl>
     </collapsible-section>
     <collapsible-section heading="Status" expanded="true">
       <health-counts class="pull-left" container="loadBalancer.healthCounts"></health-counts>

--- a/app/scripts/modules/securityGroups/details/aws/securityGroupDetails.html
+++ b/app/scripts/modules/securityGroups/details/aws/securityGroupDetails.html
@@ -32,12 +32,12 @@
       <dl class="dl-horizontal dl-narrow">
         <dt>ID:</dt>
         <dd>{{securityGroup.id}}</dd>
+        <dt>Account:</dt>
+        <dd><account-tag account="securityGroup.accountName"></account-tag></dd>
         <dt>Region:</dt>
         <dd>{{securityGroup.region}}</dd>
         <dt>VPC:</dt>
-        <dd>{{securityGroup.vpcId}}</dd>
-        <dt>Account:</dt>
-        <dd><account-tag account="securityGroup.accountName"></account-tag></dd>
+        <dd>{{securityGroup.vpcId || 'None (EC2 Classic)'}}</dd>
         <dt>Description:</dt>
         <dd>{{securityGroup.description}}</dd>
       </dl>

--- a/app/scripts/modules/securityGroups/securityGroup.directive.js
+++ b/app/scripts/modules/securityGroups/securityGroup.directive.js
@@ -28,7 +28,7 @@ angular.module('deckApp.securityGroup.rollup', [])
               accountId: securityGroup.accountName,
               name: securityGroup.name,
               vpcId: securityGroup.vpcId,
-              provider: securityGroup.provider,
+              provider: securityGroup.provider || 'aws',
             };
             // also stolen from uiSref directive
             scope.$state.go('.securityGroupDetails', params, {relative: base, inherit: true});

--- a/app/scripts/modules/serverGroups/details/aws/serverGroupDetails.html
+++ b/app/scripts/modules/serverGroups/details/aws/serverGroupDetails.html
@@ -80,8 +80,8 @@
         <dd>{{serverGroup.launchConfig.createdTime | timestamp}}</dd>
         <dt>In:</dt>
         <dd>
-          {{serverGroup.cluster}}:{{serverGroup.region}}
-          <account-tag account="serverGroup.account" pad="left"></account-tag>
+          <account-tag account="serverGroup.account" pad="right"></account-tag>
+          {{serverGroup.region}}
         </dd>
         <dt>Subnet:</dt>
         <dd>{{serverGroup.subnetType || 'None (EC2 Classic)'}}</dd>


### PR DESCRIPTION
Clean up header sections to be consistent with account/region placement across instances, server groups, load balancers, and security groups. Also fixed a bug that's at least a week old preventing access to security group details from the security groups tab
