### PR TITLE
suspend application refresh for large apps, inactive windows

### DIFF
--- a/app/scripts/directives/serverGroup.js
+++ b/app/scripts/directives/serverGroup.js
@@ -21,33 +21,9 @@ angular.module('deckApp')
         scope.$state = $rootScope.$state;
         var filteredInstances = scope.serverGroup.instances.filter(clusterFilterService.shouldShowInstance);
 
-        function loadView() {
-          scope.$evalAsync(function() {
-            scope.viewModel.loaded = true;
-            scope.viewModel.placeholderStyle = '';
-          });
-        }
-
-        function calculatePlaceholderHeight() {
-          if (scope.displayOptions.showInstances) {
-            var instances = filteredInstances;
-            if (scope.displayOptions.listInstances) {
-              var extraLoadBalancers = instances.reduce(function(acc, instance) {
-                var loadBalancerHealths = _.find(instance.health, { type: 'LoadBalancer' });
-                return loadBalancerHealths ? loadBalancerHealths.loadBalancers.length - 1 : 0 + acc;
-              }, 0);
-              return instances.length * 29 + extraLoadBalancers * 18 + 34; //34 = header (29) + original padding (5)
-            } else {
-              var rows = Math.ceil(instances.length / 60);
-              return rows * 20 + 5;
-            }
-          }
-        }
-
         var serverGroup = scope.serverGroup;
 
         scope.viewModel = {
-          loaded: true,
           waypoint: [serverGroup.account,serverGroup.region,serverGroup.name].join(':'),
           serverGroup: serverGroup,
           serverGroupSequence: $filter('serverGroupSequence')(serverGroup.name),
@@ -61,14 +37,6 @@ angular.module('deckApp')
             href: [jenkins.host + 'job', jenkins.name, jenkins.number, ''].join('/'),
             number: jenkins.number,
           };
-        }
-
-        var wasInLastWindow = waypointService.getLastWindow(scope.application.name).indexOf(scope.viewModel.waypoint) !== -1;
-
-        if (scope.displayOptions.renderInstancesOnScroll && !wasInLastWindow) {
-          scope.viewModel.loaded = false;
-          scope.viewModel.placeholderStyle = { 'padding-bottom': calculatePlaceholderHeight() + 'px'};
-          scrollTriggerService.register(scope, el, 'clusters-content', loadView);
         }
 
         scope.loadDetails = function(e) {

--- a/app/scripts/filters/timeFormatters.js
+++ b/app/scripts/filters/timeFormatters.js
@@ -8,6 +8,12 @@ angular.module('deckApp')
       return moment.isValid() ? moment.format('YYYY-MM-DD HH:mm:ss') : 'n/a';
     };
   })
+  .filter('relativeTime', function(momentService) {
+    return function(input) {
+      var moment = momentService(isNaN(parseInt(input)) ? input : parseInt(input));
+      return moment.isValid() ? moment.fromNow() : 'n/a';
+    };
+  })
   .filter('duration', function(momentService) {
     return function(input) {
       var moment = momentService.utc(isNaN(parseInt(input)) ? input : parseInt(input));

--- a/app/scripts/modules/applications/application.controller.js
+++ b/app/scripts/modules/applications/application.controller.js
@@ -12,7 +12,17 @@ angular.module('deckApp.application.controller', [
       return;
     }
 
-    application.enableAutoRefresh($scope);
+    function countInstances() {
+      var serverGroups = application.serverGroups || [];
+      return serverGroups
+        .reduce(function(total, serverGroup) {
+          return serverGroup.instances.length + total;
+        }, 0);
+    }
+
+    if (countInstances() < 500) {
+      application.enableAutoRefresh($scope);
+    }
 
     executionsService.getAll().then(function(oldExecutions) {
       $scope.executions = oldExecutions;

--- a/app/scripts/modules/applications/application.html
+++ b/app/scripts/modules/applications/application.html
@@ -2,6 +2,21 @@
   <div class="container">
     <h2 style="min-width: 200px">
       {{application.name}}
+      <a href ng-click="application.refreshImmediately(true)">
+        <span class="small glyphicon glyphicon-refresh"
+              tooltip-html-unsafe="
+                <p>Auto refresh is <strong>{{application.refreshing ? 'in progress' : application.autoRefreshEnabled ? 'enabled' : 'disabled'}}</strong>.
+                   <br>(click <span class='small glyphicon glyphicon-refresh'></span> to refresh)</p>
+                <p>Last refresh: {{application.lastRefresh | timestamp }} <br> ({{application.lastRefresh | relativeTime }})</p>
+                <p class='small'><strong>Note:</strong> Due to caching, data may be delayed up to 2 minutes</p>
+                {{!application.autoRefreshEnabled ? '<p class=small>For page performance reasons, we disable auto refresh whenever an application has more than 500 instances.</p>': ''}}"
+              tooltip-placement="bottom"
+              ng-class="{
+              'refresh-enabled': application.autoRefreshEnabled,
+              'refresh-disabled': !application.autoRefreshEnabled,
+              'glyphicon-spinning': application.refreshing,
+              }"></span>
+      </a>
     </h2>
     <div ng-if="application.notFound">
       <h1 class="text-center">&lt;404&gt;</h1>

--- a/app/scripts/modules/cluster/serverGroup.html
+++ b/app/scripts/modules/cluster/serverGroup.html
@@ -7,7 +7,6 @@
      }">
   <div class="cluster-container">
     <div class="server-group-title" sticky-header added-offset-height="69" added-offset-width="-4"
-         ng-style="viewModel.placeholderStyle"
          sticky-if="headerIsSticky()">
       <div class="container-fluid no-padding">
         <div class="row">
@@ -34,13 +33,13 @@
         </div>
       </div>
     </div>
-    <div class="instance-list" ng-if="displayOptions.showInstances && viewModel.loaded">
+    <div class="instance-list" ng-if="displayOptions.showInstances">
       <div ng-if="!displayOptions.listInstances">
         <instances highlight="displayOptions.filter" scroll-target="clusters-content" instances="viewModel.instances"
                    render-instances-on-scroll="false"></instances>
       </div>
       <div ng-if="displayOptions.listInstances">
-        <instance-list instances="viewModel.instances" sort-filter="sortFilter" render-instances-on-scroll="displayOptions.renderInstancesOnScroll"></instance-list>
+        <instance-list instances="viewModel.instances" sort-filter="sortFilter"></instance-list>
       </div>
     </div>
   </div>

--- a/app/scripts/modules/tasks/monitor/taskMonitorService.js
+++ b/app/scripts/modules/tasks/monitor/taskMonitorService.js
@@ -96,7 +96,7 @@ angular.module('deckApp.tasks.monitor.service', [])
 
       function handleForceRefreshComplete() {
         monitor.startForceRefresh();
-        monitor.application.refreshImmediately().then(handleApplicationRefreshComplete);
+        monitor.application.refreshImmediately(true).then(handleApplicationRefreshComplete);
       }
 
       function handleApplicationRefreshComplete() {

--- a/app/scripts/services/clusterService.js
+++ b/app/scripts/services/clusterService.js
@@ -139,6 +139,14 @@ angular.module('deckApp.cluster.service', [
       });
     }
 
+    function setInstancesDisabled(serverGroups) {
+      _.filter(serverGroups, 'isDisabled').forEach(function(serverGroup) {
+        serverGroup.instances.forEach(function(instance) {
+          instance.healthStatus = 'Disabled';
+        });
+      });
+    }
+
     function collateServerGroupsIntoClusters(serverGroups) {
       var clusters = [];
       var groupedByAccount = _.groupBy(serverGroups, 'account');
@@ -151,6 +159,7 @@ angular.module('deckApp.cluster.service', [
         });
       });
       addProvidersToInstances(serverGroups);
+      setInstancesDisabled(serverGroups);
       return clusters;
     }
 

--- a/app/styles/application.less
+++ b/app/styles/application.less
@@ -27,6 +27,14 @@
     }
     font-weight: 700;
     display: inline-block;
+    .glyphicon-refresh {
+      &.refresh-enabled {
+        color: @healthy_green_icon;
+      }
+      &.refresh-disabled {
+        opacity: 0.5;
+      }
+    }
   }
   ul {
     display: inline-block;

--- a/app/styles/imports/animations.less
+++ b/app/styles/imports/animations.less
@@ -76,7 +76,7 @@
 
 .spinning(@duration: 4) {
   transform: translateZ(0);
-  -webkit-animation:spin ~"@{duration}s" steps(45) infinite;
-  -moz-animation:spin ~"@{duration}s" steps(45) infinite;
-  animation:spin ~"@{duration}s" steps(45) infinite;
+  -webkit-animation:spin ~"@{duration}s" steps(60) infinite;
+  -moz-animation:spin ~"@{duration}s" steps(60) infinite;
+  animation:spin ~"@{duration}s" steps(60) infinite;
 }

--- a/app/styles/main.less
+++ b/app/styles/main.less
@@ -719,11 +719,11 @@ tfoot .add-new {
 
 .glyphicon-spinning {
   display: inline-block;
-  height: 1em;
-  line-height: 1;
+  height: 0 !important;
+  line-height: 0 !important;
+  padding-top: 0.5px;
   margin: 0;
   opacity: 0.7;
-  text-shadow: 0 0 .25em rgba(255,255,255, .3);
   .spinning();
 }
 

--- a/app/styles/rollups.less
+++ b/app/styles/rollups.less
@@ -440,6 +440,7 @@ load-balancers-tag {
         box-shadow: 0 0 3px 0px @mid_grey;
       }
       .instance-list {
+        clear: both;
         padding: 0 10px 0 23px;
 
       }


### PR DESCRIPTION
In conjunction with #751, we should get very noticeable performance improvements here.
- disabling application auto-refresh for applications with more than 500 instances
- suspending auto-refresh when the window loses focus (user goes to another application on their computer)
- suspending auto-refresh when the user navigates to a different tab
- suspending auto-refresh when the user loses internet connectivity

Also adding a refresh button next to the application name with a tooltip.

While the application is refreshing, the button spins. Hovering over the button provides the following:
![screen shot 2015-03-08 at 7 08 54 pm](https://cloud.githubusercontent.com/assets/73450/6549158/8eb21f6e-c5cb-11e4-8a64-b3cbf9641558.png)

When auto-refresh is enabled, the icon is green:
![screen shot 2015-03-08 at 7 08 37 pm](https://cloud.githubusercontent.com/assets/73450/6549160/8eb3a884-c5cb-11e4-80cd-8e95ceabc828.png)

When auto-refresh is disabled, the icon is gray and provides an explanation:
![screen shot 2015-03-08 at 7 08 21 pm](https://cloud.githubusercontent.com/assets/73450/6549159/8eb39ba0-c5cb-11e4-9255-1e449358af03.png)
