### PR TITLE
add help contents, multiple stage type validator

### DIFF
--- a/app/scripts/modules/pipelines/config/stages/deploy/deployStage.js
+++ b/app/scripts/modules/pipelines/config/stages/deploy/deployStage.js
@@ -13,8 +13,8 @@ angular.module('deckApp.pipelines.stage.deploy')
       validators: [
         {
           type: 'stageBeforeType',
-          stageType: 'bake',
-          message: 'You must have a bake stage immediately before any deploy stage.'
+          stageTypes: ['bake', 'findAmi'],
+          message: 'You must have a Bake or Find AMI stage before any deploy stage.'
         },
       ],
     });

--- a/app/scripts/modules/pipelines/config/stages/findAmi/findAmiStage.html
+++ b/app/scripts/modules/pipelines/config/stages/findAmi/findAmiStage.html
@@ -16,7 +16,7 @@
     </div>
   </div>
   <div class="form-group">
-    <label class="col-md-2 col-md-offset-1 sm-label-left">ASG Selection Strategy</label>
+    <label class="col-md-2 col-md-offset-1 sm-label-left">ASG Selection</label>
     <div class="col-md-6">
       <ui-select ng-model="stage.selectionStrategy" class="form-control input-sm">
         <ui-select-match placeholder="None">{{$select.selected.label}}</ui-select-match>

--- a/app/scripts/modules/pipelines/config/validation/pipelineConfigValidation.service.js
+++ b/app/scripts/modules/pipelines/config/validation/pipelineConfigValidation.service.js
@@ -8,8 +8,9 @@ angular.module('deckApp.pipelines.config.validator.service', [
 
     var validators = {
       stageBeforeType: function(pipeline, index, validationConfig, messages) {
+        var stageTypes = validationConfig.stageTypes || [validationConfig.stageType];
         for (var i = 0; i < index; i++) {
-          if (pipeline.stages[i].type === validationConfig.stageType) {
+          if (stageTypes.indexOf(pipeline.stages[i].type) !== -1) {
             return;
           }
         }

--- a/app/scripts/modules/pipelines/config/validation/pipelineConfigValidation.service.spec.js
+++ b/app/scripts/modules/pipelines/config/validation/pipelineConfigValidation.service.spec.js
@@ -136,6 +136,48 @@ describe('pipelineConfigValidator', function() {
         messages = this.validator.validatePipeline(pipeline);
         expect(messages.length).toBe(0);
       });
+
+      it('validates against multiple types if present', function() {
+        spyOn(this.pipelineConfig, 'getStageConfig').and.callFake(function(type) {
+          if (type === 'withValidation') {
+            return {
+              validators: [
+                {
+                  type: 'stageBeforeType',
+                  stageTypes: ['one', 'two'],
+                  message: 'need a prereq',
+                },
+              ]
+            };
+          } else {
+            return {};
+          }
+        });
+
+        var pipeline = {
+          stages: [
+            {type: 'three'},
+            {type: 'withValidation'}
+          ]
+        };
+
+        var messages = this.validator.validatePipeline(pipeline);
+        expect(messages.length).toBe(1);
+        expect(messages[0]).toBe('need a prereq');
+
+        pipeline.stages[0].type = 'one';
+        messages = this.validator.validatePipeline(pipeline);
+        expect(messages.length).toBe(0);
+
+        pipeline.stages = [
+          {type: 'two'},
+          {type: 'somethingElse'},
+          {type: 'withValidation'}
+        ];
+
+        messages = this.validator.validatePipeline(pipeline);
+        expect(messages.length).toBe(0);
+      });
     });
 
     describe('checkRequiredField', function() {

--- a/app/scripts/settings/helpContents.js
+++ b/app/scripts/settings/helpContents.js
@@ -74,5 +74,7 @@ angular.module('deckApp.help')
       '<li>For <b>GCE</b>, a server group is an <b>Instance Group</b>.</li>' +
       '</ul>',
 
+    'pipeline.config.findAmi.cluster': 'The cluster to look at when selecting the AMI to use in this pipeline.'
+
 
   });


### PR DESCRIPTION
Allowing a stage to declare an array of types that must be before it.

Also adding help contents for the cluster field in the Find AMI stage.
