### PR TITLE
filter in-page on global search results

### DIFF
--- a/app/scripts/modules/clusterFilter/clusterFilterService.js
+++ b/app/scripts/modules/clusterFilter/clusterFilterService.js
@@ -8,6 +8,8 @@ angular
   ])
   .factory('clusterFilterService', function ($location, $stateParams, ClusterFilterModel, _, waypointService) {
 
+    var lastApplication = null;
+
     function updateQueryParams() {
 
       var filter = ClusterFilterModel.sortFilter.filter.length ? ClusterFilterModel.sortFilter.filter : null,
@@ -200,6 +202,13 @@ angular
     }
 
     function updateClusterGroups(application) {
+        if (!application) {
+          application = lastApplication;
+          if (!lastApplication) {
+            return null;
+          }
+        }
+
         var groups = [],
           totalInstancesDisplayed = 0,
           primarySort = ClusterFilterModel.sortFilter.sortPrimary,
@@ -233,6 +242,7 @@ angular
         sortGroupsByHeading(groups);
         setDisplayOptions(totalInstancesDisplayed);
         waypointService.restoreToWaypoint(application.name);
+        lastApplication = application;
         return groups;
     }
 

--- a/app/scripts/modules/search/global/globalSearch.controller.js
+++ b/app/scripts/modules/search/global/globalSearch.controller.js
@@ -2,7 +2,7 @@
 
 
 angular.module('deckApp.search.global')
-  .controller('GlobalSearchCtrl', function($scope, $element, infrastructureSearchService, _) {
+  .controller('GlobalSearchCtrl', function($scope, $element, $window, infrastructureSearchService, ClusterFilterModel, $stateParams, _, clusterFilterService) {
     var ctrl = this;
     var search = infrastructureSearchService();
 
@@ -64,6 +64,16 @@ angular.module('deckApp.search.global')
       });
     }, 200);
 
+    ctrl.clearFilters = function(result) {
+      if (result.href.indexOf('/clusters') !== -1) {
+        ClusterFilterModel.clearFilters();
+        ClusterFilterModel.sortFilter.filter = result.serverGroup ? result.serverGroup :
+          result.cluster ? 'cluster:' + result.cluster : '';
+        if ($stateParams.application === result.application) {
+          clusterFilterService.updateClusterGroups();
+        }
+      }
+    };
 
     this.focusFirstSearchResult = function focusFirstSearchResult(event) {
       try {

--- a/app/scripts/modules/search/global/globalSearch.module.js
+++ b/app/scripts/modules/search/global/globalSearch.module.js
@@ -3,4 +3,6 @@
 angular.module('deckApp.search.global', [
   'deckApp.utils.jQuery',
   'deckApp.utils.lodash',
+  'cluster.filter.model',
+  'cluster.filter.service',
 ]);

--- a/app/scripts/modules/search/globalSearch.spec.js
+++ b/app/scripts/modules/search/globalSearch.spec.js
@@ -7,7 +7,7 @@ describe('Controller: GlobalSearch', function () {
 
   describe('keyboard navigation', function() {
     // Initialize the controller and a mock scope
-    beforeEach(inject(function ($controller, $rootScope, $window, $q, _) {
+    beforeEach(inject(function ($controller, $rootScope, $window, $q, _, ClusterFilterModel, clusterFilterService) {
       var inputSpy = jasmine.createSpyObj('input', ['focus']),
           infrastructureSearchService = jasmine.createSpy('infrastructureSearchService');
       this.$scope = $rootScope.$new();
@@ -25,7 +25,9 @@ describe('Controller: GlobalSearch', function () {
         $scope: this.$scope,
         $element: this.$element,
         _ : _,
-        infrastructureSearchService: function() { return infrastructureSearchService; }
+        infrastructureSearchService: function() { return infrastructureSearchService; },
+        ClusterFilterModel: ClusterFilterModel,
+        clusterFilterService: clusterFilterService,
       });
 
       this.$scope.showSearchResults = true;

--- a/app/views/globalsearch.html
+++ b/app/views/globalsearch.html
@@ -28,7 +28,7 @@
     <li ng-repeat="result in category.results.slice(0,5)"
         ng-repeat-end
         class="result">
-      <a ng-keydown="ctrl.navigateResults($event)" href="{{ result.href }}" analytics-on="click"
+      <a ng-keydown="ctrl.navigateResults($event)" ng-click="ctrl.clearFilters(result)" href="{{ result.href }}" analytics-on="click"
          analytics-category="Global Search"
          analytics-label="{{result.name}}"><span bind-html-unsafe="result.name | typeaheadHighlight:query"></span></a>
     </li>


### PR DESCRIPTION
When navigating through global search, we lose the `q` parameter because of the insane way we try to manage query parameters.

This updates the cluster filter when navigating between clusters within the same application, maintaining the value in the ClusterFilterModel and the URL. It also gracefully handles switching between another tab in an application and the clusters tab, both in the same application and to a different application.

We still lose the `q` value when navigating from the Infrastructure page, or when moving from the clusters view in one application to the clusters view in another application. It's incrementally less buggy.

I honestly can't bring myself to dig into this any more to try to capture that last use case. If someone complains about it, I'll dig into it again.
