### PR TITLE
allowing pipeline sorting by drag/drop

### DIFF
--- a/app/scripts/modules/delivery/executionGroups.filter.js
+++ b/app/scripts/modules/delivery/executionGroups.filter.js
@@ -9,6 +9,9 @@ angular.module('deckApp.delivery.executionGroups.filter', [
       switch (filter.execution.groupBy) {
         case 'timeBoundary':
           return Object.keys(timeBoundaries.groupByTimeBoundary(executions));
+        case 'name':
+          configurations = configurations || [];
+          return _.unique(_.pluck(_.sortBy(executions, 'index').concat(configurations), filter.execution.groupBy));
         default:
           configurations = configurations || [];
           return _.unique(_.pluck(executions.concat(configurations), filter.execution.groupBy)).sort();

--- a/app/scripts/modules/pipelines/config/actions/json/editPipelineJsonModal.controller.js
+++ b/app/scripts/modules/pipelines/config/actions/json/editPipelineJsonModal.controller.js
@@ -15,6 +15,9 @@ angular.module('deckApp.pipelines.rename')
       if (obj.hasOwnProperty('appConfig')) {
         delete obj.appConfig;
       }
+      if (obj.hasOwnProperty('index')) {
+        delete obj.index;
+      }
     }
 
     this.initialize = function() {

--- a/app/scripts/modules/pipelines/config/pipelineConfig.controller.js
+++ b/app/scripts/modules/pipelines/config/pipelineConfig.controller.js
@@ -2,17 +2,53 @@
 
 angular.module('deckApp.pipelines.config.controller', [
   'ui.router',
-  'deckApp.pipelines.config.service'
+  'deckApp.pipelines.config.service',
+  'deckApp.utils.lodash',
 ])
-  .controller('PipelineConfigCtrl', function($scope, $stateParams, pipelineConfigService) {
+  .controller('PipelineConfigCtrl', function($scope, $timeout, $stateParams, pipelineConfigService, _, $q) {
 
     $scope.state = {
       pipelinesLoaded: false
     };
 
+    var ctrl = this;
+
+    ctrl.updatePipelines = function(pipelines) {
+      $q.all(pipelines.map(function(pipeline) {
+        return pipelineConfigService.savePipeline(pipeline, true);
+      }));
+    };
+
     pipelineConfigService.getPipelinesForApplication($stateParams.application).then(function(pipelines) {
-      $scope.application.pipelines = pipelines;
+      // if there are pipelines without an index, fix that
+      if (pipelines && pipelines.length && pipelines[0].index === undefined) {
+        pipelines.forEach(function(pipeline, index) {
+          pipeline.index = index;
+        });
+        ctrl.updatePipelines(pipelines);
+      }
+      $scope.application.pipelines = _.sortBy(pipelines, 'index');
       $scope.state.pipelinesLoaded = true;
     });
+
+    $scope.pipelineSortOptions = {
+      axis: 'y',
+      delay: 150,
+      placeholder: 'drop-placeholder',
+      'ui-floating': false,
+      start: function(e, ui) {
+        ui.placeholder.width(ui.helper.width()).height(ui.helper.height());
+      },
+      stop: function() {
+        var dirty = [];
+        $scope.application.pipelines.forEach(function(pipeline, index) {
+          if (pipeline.index !== index) {
+            pipeline.index = index;
+            dirty.push(pipeline);
+          }
+        });
+        ctrl.updatePipelines(dirty);
+      }
+    };
 
   });

--- a/app/scripts/modules/pipelines/config/pipelineConfig.html
+++ b/app/scripts/modules/pipelines/config/pipelineConfig.html
@@ -9,9 +9,23 @@
     <create-pipeline-button application="application"></create-pipeline-button>
   </div>
 </div>
-<div class="row pipeline-configurer" ng-repeat="pipeline in application.pipelines" ng-class="{'new-pipeline': pipeline.isNew}">
-  <div class="col-md-8">
-    <pipeline-configurer pipeline="pipeline" application="application"></pipeline-configurer>
+<div class="row">
+  <div class="col-md-12">
+    <p style="margin-top: 10px">
+      <strong>Tip:</strong>
+      Pipelines and stages are sortable - just drag them into the desired position.
+    </p>
+  </div>
+</div>
+<div class="row"
+       ui-sortable="pipelineSortOptions"
+       ng-model="application.pipelines">
+  <div class="row pipeline-configurer"
+       ng-repeat="pipeline in application.pipelines"
+       ng-class="{'new-pipeline': pipeline.isNew}">
+    <div class="col-md-8">
+      <pipeline-configurer pipeline="pipeline" application="application"></pipeline-configurer>
+    </div>
   </div>
 </div>
   <div class="row" ng-if="!state.pipelinesLoaded" style="min-height: 300px">

--- a/app/scripts/modules/pipelines/config/pipelineConfigurer.js
+++ b/app/scripts/modules/pipelines/config/pipelineConfigurer.js
@@ -171,7 +171,9 @@ angular.module('deckApp.pipelines')
     };
 
     function getPlain(pipeline) {
-      return pipeline.fromServer ? pipeline.plain() : pipeline;
+      var base = pipeline.fromServer ? pipeline.plain() : angular.copy(pipeline);
+      base.index = null;
+      return base;
     }
 
     var markDirty = function markDirty() {

--- a/app/scripts/modules/pipelines/config/services/pipelineConfigService.js
+++ b/app/scripts/modules/pipelines/config/services/pipelineConfigService.js
@@ -16,9 +16,11 @@ angular.module('deckApp.pipelines.config.service', [
       return Restangular.all('pipelines').one(applicationName, pipelineName).remove();
     }
 
-    function savePipeline(pipeline) {
+    function savePipeline(pipeline, retainIsNewFlags) {
       pipeline.stages.forEach(function(stage) {
-        delete stage.isNew;
+        if (!retainIsNewFlags) {
+          delete stage.isNew;
+        }
         if (!stage.name) {
           delete stage.name;
         }


### PR DESCRIPTION
Sets an `index` field on each pipeline and uses it to sort them in the executions view and in the configuration view.
