### PR TITLE
additional guards on ordering, add to bottom, scroll to added

### DIFF
--- a/app/scripts/modules/pipelines/config/actions/create/createPipelineButton.html
+++ b/app/scripts/modules/pipelines/config/actions/create/createPipelineButton.html
@@ -1,3 +1,3 @@
-<button class="btn btn-sm btn-default"
+<button class="btn btn-block add-new"
         ng-click="buttonCtrl.createPipeline()">
   <span class="glyphicon glyphicon-plus-sign"></span> Create New Pipeline</button>

--- a/app/scripts/modules/pipelines/config/actions/create/createPipelineModal.controller.js
+++ b/app/scripts/modules/pipelines/config/actions/create/createPipelineModal.controller.js
@@ -3,8 +3,9 @@
 angular.module('deckApp.pipelines.create.controller', [
   'deckApp.utils.lodash',
   'deckApp.pipelines.config.service',
+  'deckApp.utils.scrollTo',
 ])
-  .controller('CreatePipelineModalCtrl', function($scope, application, _, pipelineConfigService, $modalInstance, $log) {
+  .controller('CreatePipelineModalCtrl', function($scope, application, _, pipelineConfigService, $modalInstance, $log, scrollToService, $timeout) {
 
     var noTemplate = {name: 'None', stages: [], triggers: [], application: application.name};
 
@@ -31,7 +32,13 @@ angular.module('deckApp.pipelines.create.controller', [
       return pipelineConfigService.savePipeline(template).then(
         function() {
           template.isNew = true;
-          application.pipelines.splice(0, 0, template);
+          template.tempId = new Date().getTime();
+          template.index = application.pipelines.length;
+          application.pipelines.push(template);
+          scrollToService.scrollTo(template.tempId, null, 100);
+          $timeout(function() {
+            delete template.tempId;
+          });
 
           $modalInstance.close();
         },

--- a/app/scripts/modules/pipelines/config/pipelineConfig.html
+++ b/app/scripts/modules/pipelines/config/pipelineConfig.html
@@ -1,17 +1,12 @@
 <div class="row" ng-if="application.pipelines.length">
-  <div class="col-md-4">
+  <div class="col-md-3">
     <a class="btn btn-link" ui-sref="^.executions">
       <span class="small glyphicon glyphicon glyphicon-circle-arrow-left"></span>
       Pipeline Executions
     </a>
   </div>
-  <div class="col-md-4 text-right">
-    <create-pipeline-button application="application"></create-pipeline-button>
-  </div>
-</div>
-<div class="row">
-  <div class="col-md-12">
-    <p style="margin-top: 10px">
+  <div class="col-md-5 text-right">
+    <p class="form-control-static">
       <strong>Tip:</strong>
       Pipelines and stages are sortable - just drag them into the desired position.
     </p>
@@ -28,7 +23,14 @@
     </div>
   </div>
 </div>
-  <div class="row" ng-if="!state.pipelinesLoaded" style="min-height: 300px">
+<div class="row">
+  <div class="row">
+    <div class="col-md-8">
+      <create-pipeline-button application="application"></create-pipeline-button>
+    </div>
+  </div>
+</div>
+<div class="row" ng-if="!state.pipelinesLoaded" style="min-height: 300px">
     <h4 class="text-center">
       <span us-spinner="{radius:20, width:6, length: 12}"></span>
     </h4>

--- a/app/scripts/modules/pipelines/config/pipelineConfig.less
+++ b/app/scripts/modules/pipelines/config/pipelineConfig.less
@@ -40,12 +40,6 @@
   }
 }
 
-.pipeline-configurer {
-  &:last-child {
-    margin-bottom: 100px;
-  }
-}
-
 pipeline-configurer {
   margin-top: 15px;
   display: block;

--- a/app/scripts/modules/pipelines/config/pipelineConfigurer.html
+++ b/app/scripts/modules/pipelines/config/pipelineConfigurer.html
@@ -1,7 +1,7 @@
 <accordion>
   <accordion-group is-open="viewState.expanded">
     <accordion-heading>
-      <h4 class="heading-pipeline-config">
+      <h4 class="heading-pipeline-config" ng-attr-id="{{pipeline.tempId}}">
         <span class="glyphicon glyphicon-chevron-{{viewState.expanded ? 'down' : 'right'}}"></span> {{pipeline.name || '[Unnamed]'}} <span ng-if="pipeline.disabled" class="badge badge-disabled">disabled</span>
         <pipeline-config-errors pipeline="pipeline"></pipeline-config-errors>
       </h4>

--- a/app/scripts/modules/utils/scrollTo/scrollTo.service.js
+++ b/app/scripts/modules/utils/scrollTo/scrollTo.service.js
@@ -23,7 +23,7 @@ angular.module('deckApp.utils.scrollTo', ['deckApp.utils.jQuery'])
       $timeout(function() {
         var elem = $('#' + elementId);
         if (elem.length) {
-          var content = elem.closest(scrollableContainer);
+          var content = scrollableContainer ? elem.closest(scrollableContainer) : $('body');
           if (content.length) {
             var top = elem.offset().top - offset;
             content.animate({scrollTop: top + 'px'}, 200);


### PR DESCRIPTION
Fixes #734 by alway adding pipelines at the end of the list, then scrolling to them.

Also moving the "create" button to the bottom to be a little more consistent with other areas of the app, and to clean up the header area. We'll see how that goes.
