### PR TITLE
preserve details on health in instance details

### DIFF
--- a/app/scripts/modules/instance/details/aws/instance.details.controller.spec.js
+++ b/app/scripts/modules/instance/details/aws/instance.details.controller.spec.js
@@ -6,14 +6,19 @@ describe('Controller: awsInstanceDetailsCtrl', function () {
 
   var controller;
   var scope;
+  var instanceReader;
+  var $q;
 
   beforeEach(
     module('deckApp.instance.detail.aws.controller')
   );
 
   beforeEach(
-    inject(function ($rootScope, $controller) {
+    inject(function ($rootScope, $controller, _instanceReader_, _$q_) {
       scope = $rootScope.$new();
+      instanceReader = _instanceReader_;
+      $q = _$q_;
+
       controller = $controller('awsInstanceDetailsCtrl', {
         $scope: scope,
         instance: {},
@@ -21,10 +26,62 @@ describe('Controller: awsInstanceDetailsCtrl', function () {
           registerAutoRefreshHandler: angular.noop
         }
       });
+
+      this.createController = function(application, instance) {
+        application.registerAutoRefreshHandler = application.registerAutoRefreshHandler || angular.noop;
+        controller = $controller('awsInstanceDetailsCtrl', {
+          $scope: scope,
+          instance: instance,
+          application: application,
+        });
+      };
     })
   );
 
-  it('should instantiate the controller', function () {
-    expect(controller).toBeDefined();
+  describe('health metrics', function () {
+    it('overrides new health with health from application, adding new fields', function() {
+      var details = {
+        health: [
+          { type: 'Discovery', status: 'Up', extra: 'details field', reason: 'mutated'}
+        ]
+      };
+      var params = {
+        instanceId: 'i-123', region: 'us-west-1', account: 'test'
+      };
+
+      spyOn(instanceReader, 'getInstanceDetails').and.returnValue(
+        $q.when({
+          plain: function() {
+            return details;
+          }
+        })
+      );
+      var application = {
+        clusters: [ {
+          serverGroups: [
+            {
+              account: 'test',
+              region: 'us-west-1',
+              instances: [
+                {
+                  id: 'i-123',
+                  health: [
+                    { type: 'Discovery', status: 'Down', reason: 'original reason'}
+                  ]
+                }
+              ]
+            }
+          ]
+        }]
+      };
+
+      this.createController(application, params);
+      scope.$digest();
+
+      expect(scope.healthMetrics.length).toBe(1);
+      expect(scope.healthMetrics[0].reason).toBe('original reason');
+      expect(scope.healthMetrics[0].status).toBe('Down');
+      expect(scope.healthMetrics[0].extra).toBe('details field');
+    });
   });
 });


### PR DESCRIPTION
Add in any health details not present in summary health. Fixes a regression where status and health URLs stopped appearing on the page.
