### PR TITLE
get executions from application

### DIFF
--- a/app/scripts/modules/applications/application.controller.js
+++ b/app/scripts/modules/applications/application.controller.js
@@ -1,11 +1,8 @@
 'use strict';
 
 
-angular.module('deckApp.application.controller', [
-  'deckApp.delivery.executions.service',
-  'deckApp.tasks.tracker'
-])
-  .controller('ApplicationCtrl', function($scope, application, executionsService, taskTracker) {
+angular.module('deckApp.application.controller', [])
+  .controller('ApplicationCtrl', function($scope, application) {
     $scope.application = application;
     $scope.insightTarget = application;
     if (application.notFound) {
@@ -23,19 +20,6 @@ angular.module('deckApp.application.controller', [
     if (countInstances() < 500) {
       application.enableAutoRefresh($scope);
     }
-
-    executionsService.getAll(application.name).then(function(oldExecutions) {
-      $scope.executions = oldExecutions;
-      var subscription = executionsService.subscribeAll(function(newExecutions) {
-        taskTracker.handleTaskUpdates(oldExecutions, newExecutions);
-        $scope.executions = newExecutions;
-        oldExecutions = newExecutions;
-      });
-      $scope.$on('$destroy', function() {
-        subscription.dispose();
-      });
-    });
-
   }
 );
 

--- a/app/scripts/modules/applications/application.html
+++ b/app/scripts/modules/applications/application.html
@@ -29,7 +29,7 @@
            ng-class="{active: $state.includes('**.executions.**') || $state.includes('**.pipelineConfig')}">
           Delivery <span class="badge"
                          ng-if="( application.executions | filter:{isRunning:'true'}).length > 0">
-            {{ (executions | filter:{isRunning:'true'}).length }}
+            {{ (application.executions | filter:{isRunning:'true'}).length }}
           </span>
         </a>
       </li>

--- a/app/scripts/modules/delivery/executionGroupHeading.controller.js
+++ b/app/scripts/modules/delivery/executionGroupHeading.controller.js
@@ -5,7 +5,7 @@ angular.module('deckApp.delivery.executionGroupHeading.controller', [
   'deckApp.pipelines.config.service',
   'deckApp.delivery.executions.service'
 ])
-  .controller('executionGroupHeading', function($scope, $stateParams, $timeout, pipelineConfigService, executionsService, _ ) {
+  .controller('executionGroupHeading', function($scope, $timeout, pipelineConfigService, executionsService, _) {
     var controller = this;
 
     $scope.viewState = {
@@ -34,11 +34,10 @@ angular.module('deckApp.delivery.executionGroupHeading.controller', [
         return execution.status === 'RUNNING' || execution.status === 'NOT_STARTED';
       });
       var ignoreList = _.pluck(toIgnore, 'id');
-      pipelineConfigService.triggerPipeline($stateParams.application, $scope.value).then(
+      pipelineConfigService.triggerPipeline($scope.application.name, $scope.value).then(
         function() {
-          var monitor = executionsService.waitUntilNewTriggeredPipelineAppears($scope.value, ignoreList);
+          var monitor = executionsService.waitUntilNewTriggeredPipelineAppears($scope.application, $scope.value, ignoreList);
           monitor.then(function() {
-            executionsService.forceRefresh();
             $scope.viewState.triggeringExecution = false;
           });
           $scope.viewState.poll = monitor;

--- a/app/scripts/modules/delivery/executionGroupHeading.controller.spec.js
+++ b/app/scripts/modules/delivery/executionGroupHeading.controller.spec.js
@@ -13,9 +13,8 @@ describe('Controller: ExecutionGroupHeading', function () {
   describe('triggerPipeline', function() {
     beforeEach(function() {
       var $q = this.$q;
-      this.$stateParams = {
-        application: 'app'
-      };
+
+      this.$scope.application = {};
 
       this.initializeController = function() {
         this.pipelineConfigService = {
@@ -32,7 +31,7 @@ describe('Controller: ExecutionGroupHeading', function () {
           $scope: this.$scope,
           pipelineConfigService: this.pipelineConfigService,
           executionsService: this.executionsService,
-          $stateParams: this.$stateParams
+          application: this.$scope.application,
         });
       };
     });
@@ -49,15 +48,13 @@ describe('Controller: ExecutionGroupHeading', function () {
       this.initializeController();
 
       spyOn(this.executionsService, 'waitUntilNewTriggeredPipelineAppears').and.returnValue(this.$q.when(null));
-      spyOn(this.executionsService, 'forceRefresh');
 
       this.controller.triggerPipeline();
       expect(this.$scope.viewState.triggeringExecution).toBe(true);
 
       this.$scope.$digest();
 
-      expect(this.executionsService.waitUntilNewTriggeredPipelineAppears).toHaveBeenCalledWith('pipeline name a', ['exec-1', 'exec-2']);
-      expect(this.executionsService.forceRefresh).toHaveBeenCalled();
+      expect(this.executionsService.waitUntilNewTriggeredPipelineAppears).toHaveBeenCalledWith(this.$scope.application, 'pipeline name a', ['exec-1', 'exec-2']);
       expect(this.$scope.viewState.triggeringExecution).toBe(false);
 
     });

--- a/app/scripts/modules/delivery/executionGroupHeading.directive.js
+++ b/app/scripts/modules/delivery/executionGroupHeading.directive.js
@@ -11,6 +11,7 @@ angular.module('deckApp.delivery.executionGroupHeading.directive', [])
         filter: '=',
         executions: '=',
         configurations: '=',
+        application: '=',
       },
       templateUrl: 'scripts/modules/delivery/executionGroupHeading.html',
       controller: 'executionGroupHeading as ctrl',

--- a/app/scripts/modules/delivery/executions.transformer.service.js
+++ b/app/scripts/modules/delivery/executions.transformer.service.js
@@ -14,6 +14,9 @@ angular.module('deckApp.delivery.executionTransformer.service', [
         stage.after = stage.after || [];
         stage.index = index;
         orchestratedItem.defineProperties(stage);
+        if (stage.tasks && stage.tasks.length) {
+          stage.tasks.forEach(orchestratedItem.defineProperties);
+        }
       });
 
       execution.stages.forEach(function(stage) {
@@ -41,6 +44,8 @@ angular.module('deckApp.delivery.executionTransformer.service', [
           });
         }
       });
+
+      orchestratedItem.defineProperties(execution);
 
       stageSummaries.forEach(transformStageSummary);
       execution.stageSummaries = stageSummaries;

--- a/app/scripts/modules/delivery/executionsService.js
+++ b/app/scripts/modules/delivery/executionsService.js
@@ -19,16 +19,7 @@ angular.module('deckApp.delivery.executions.service', [
           if (!executions || !executions.length) {
             return [];
           }
-          executions.forEach(function(execution) {
-            orchestratedItem.defineProperties(execution);
-            execution.stages.forEach(function(stage) {
-              orchestratedItem.defineProperties(stage);
-              if (stage.tasks && stage.tasks.length) {
-                stage.tasks.forEach(orchestratedItem.defineProperties);
-              }
-            });
-            executionsTransformer.transformExecution(execution);
-          });
+          executions.forEach(executionsTransformer.transformExecution);
           return executions;
         }),
         url: [
@@ -48,10 +39,10 @@ angular.module('deckApp.delivery.executions.service', [
       return deferred.promise;
     }
 
-    function waitUntilNewTriggeredPipelineAppears(pipelineName, ignoreList) {
+    function waitUntilNewTriggeredPipelineAppears(application, pipelineName, ignoreList) {
 
-      var appName = $stateParams.application;
-      return getExecutions(appName).then(function(executions) {
+      return application.reloadExecutions().then(function() {
+        var executions = application.executions;
         var match = executions.filter(function(execution) {
           return (execution.status === 'RUNNING' || execution.status === 'NOT_STARTED') &&
             execution.name === pipelineName &&
@@ -63,7 +54,7 @@ angular.module('deckApp.delivery.executions.service', [
           return deferred.promise;
         } else {
           return $timeout(function() {
-            return waitUntilNewTriggeredPipelineAppears(pipelineName, ignoreList);
+            return waitUntilNewTriggeredPipelineAppears(application, pipelineName, ignoreList);
           }, 1000);
         }
       });

--- a/app/scripts/modules/delivery/pipelineExecutions.html
+++ b/app/scripts/modules/delivery/pipelineExecutions.html
@@ -14,7 +14,8 @@
                                  scale="scale"
                                  filter="filter"
                                  executions="executions"
-                                 configurations="configurations">
+                                 configurations="configurations"
+                                 application="application">
         </execution-group-heading>
       </div>
     </div>

--- a/app/scripts/modules/tasks/taskTracker.js
+++ b/app/scripts/modules/tasks/taskTracker.js
@@ -18,6 +18,8 @@ angular.module('deckApp.tasks.tracker', [
     };
 
     that.getTasksMatchingPred = function getTasksMatchingPred(oldTasks, newTasks, pred) {
+      oldTasks = oldTasks || [];
+      newTasks = newTasks || [];
       return newTasks.filter(pred)
         .filter(function(task) {
           var hasNotBeenSeen = oldTasks.every(function(oldTask) {


### PR DESCRIPTION
- Tie pipeline execution loading into application
- Use `$broadcast` events to notify controllers when tasks, executions have been loaded/reloaded

This fixes an issue where we end up loading the executions at least twice when deep linking to the delivery tab, and (hopefully) cleans up the code a bit.
