### PR TITLE
provide "Starting" indicator when no metrics available

### DIFF
--- a/app/scripts/modules/instance/details/aws/instanceDetails.html
+++ b/app/scripts/modules/instance/details/aws/instanceDetails.html
@@ -71,6 +71,10 @@
       </dl>
     </collapsible-section>
     <collapsible-section heading="Status" expanded="true">
+      <p ng-if="instance.healthState === 'Starting' && !healthMetrics.length">
+        <span class="glyphicon glyphicon-Starting-triangle"></span> <strong>Starting</strong>
+      </p>
+
       <dl>
         <dt ng-repeat-start="metric in healthMetrics | orderBy: 'type'">{{metric.type | robotToHuman}}</dt>
         <dd ng-repeat-end>


### PR DESCRIPTION
If the healthState of the instance is "Starting" and we have no metrics, provide a placeholder to indicate that it's starting up
