### PR TITLE
remove selected state when selecting instance in same ASG

### DIFF
--- a/app/scripts/directives/instanceList.directive.js
+++ b/app/scripts/directives/instanceList.directive.js
@@ -144,6 +144,9 @@ angular.module('deckApp')
               if (!$targetRow.length) {
                 return;
               }
+              if (scope.activeInstance) {
+                $('tr[data-instance-id="' + scope.activeInstance.instanceId+'"]', elem).removeClass('active');
+              }
               var targetRow = $targetRow.get(0);
               var params = {
                 instanceId: targetRow.getAttribute('data-instance-id'),
@@ -158,15 +161,17 @@ angular.module('deckApp')
           });
         });
 
-        scope.$on('$locationChangeSuccess', function() {
+        function clearActiveState() {
           if (scope.activeInstance && !$state.includes('**.instanceDetails', scope.activeInstance)) {
             $('tr[data-instance-id="' + scope.activeInstance.instanceId+'"]', elem).removeClass('active');
             scope.activeInstance = null;
           }
-        });
+        }
+
+        scope.$on('$locationChangeSuccess', clearActiveState);
 
         scope.$on('$destroy', function() {
-          $('[data-toggle="tooltip"]', elem).removeData().tooltip('destroy');
+          $('[data-toggle="tooltip"]', elem).tooltip('destroy').removeData();
           elem.unbind('click');
         });
 

--- a/app/scripts/directives/instances.js
+++ b/app/scripts/directives/instances.js
@@ -39,6 +39,9 @@ angular.module('deckApp')
               if (event.isDefaultPrevented() || (event.originalEvent && (event.originalEvent.defaultPrevented || event.originalEvent.target.href))) {
                 return;
               }
+              if (scope.activeInstance) {
+                $('a[data-instance-id="' + scope.activeInstance.instanceId+'"]', elem).removeClass('active');
+              }
               var params = {
                 instanceId: event.target.getAttribute('data-instance-id'),
                 provider: event.target.getAttribute('data-provider')
@@ -52,15 +55,17 @@ angular.module('deckApp')
           });
         });
 
-        scope.$on('$locationChangeSuccess', function() {
+        function clearActiveState() {
           if (scope.activeInstance && !$state.includes('**.instanceDetails', scope.activeInstance)) {
             $('a[data-instance-id="' + scope.activeInstance.instanceId+'"]', elem).removeClass('active');
             scope.activeInstance = null;
           }
-        });
+        }
+
+        scope.$on('$locationChangeSuccess', clearActiveState);
 
         scope.$on('$destroy', function() {
-          $('[data-toggle="tooltip"]', elem).removeData().tooltip('destroy');
+          $('[data-toggle="tooltip"]', elem).tooltip('destroy').removeData();
           elem.unbind('click');
         });
       }


### PR DESCRIPTION
Currently, if you select an instance in an ASG, then select another instance in the same ASG, the highlighting is not removed until the application refreshes. This fixes that.
