### PR TITLE
expose maxRemainingAsgs in deck for red/back

### DIFF
--- a/app/scripts/modules/deploymentStrategy/strategies/redblack/additionalFields.html
+++ b/app/scripts/modules/deploymentStrategy/strategies/redblack/additionalFields.html
@@ -4,4 +4,9 @@
       Scale down replaced server group to zero instances
     </label>
   </div>
+  <div class="col-md-12">
+    <label><input style="width:2em" type="number" ng-model="command.maxRemainingAsgs">
+      Maximum number of server groups to leave
+    </label>
+  </div>
 </div>

--- a/app/scripts/modules/deploymentStrategy/strategies/redblack/redblack.strategy.module.js
+++ b/app/scripts/modules/deploymentStrategy/strategies/redblack/redblack.strategy.module.js
@@ -6,7 +6,7 @@ angular.module('deckApp.deploymentStrategy.redblack', [])
       label: 'Red/Black',
       description: 'Disables previous server group as soon as new server group passes health checks',
       key: 'redblack',
-      additionalFields: ['scaleDown'],
+      additionalFields: ['scaleDown', 'maxRemainingAsgs'],
       additionalFieldsTemplateUrl: 'scripts/modules/deploymentStrategy/strategies/redblack/additionalFields.html',
     });
   });


### PR DESCRIPTION
I added a maxRemainingAsgs in orca for cleaning up old asgs after a red/black push.  This change exposes it in deck.  Tested locally.

@anotherchrisberry can you please take a look at the styling?  I hardcoded the field width, but I'm sure there's a better way.
