### PR TITLE
encode and simplify callback param passing for auth

### DIFF
--- a/app/scripts/modules/authentication/authenticationProvider.spec.js
+++ b/app/scripts/modules/authentication/authenticationProvider.spec.js
@@ -52,10 +52,12 @@ describe('authenticationProvider: application startup', function() {
       this.$timeout.flush();
       this.$http.flush();
 
+      var callback = encodeURIComponent(this.$location.absUrl());
+
       expect(this.$rootScope.authenticating).toBe(true);
       expect(this.authenticationService.getAuthenticatedUser().name).toBe('[anonymous]');
       expect(this.authenticationService.getAuthenticatedUser().authenticated).toBe(false);
-      expect(redirectUrl).toBe(this.settings.gateUrl + '/authUp?callback=' + this.$window.location.origin + '&path=' + this.$location.path());
+      expect(redirectUrl).toBe(this.settings.gateUrl + '/authUp?callback=' + callback);
       expect(this.$modal.open.calls.count()).toBe(1);
       expect(this.modal.dismiss.calls.count()).toBe(0);
     });

--- a/app/scripts/modules/authentication/authenticationService.js
+++ b/app/scripts/modules/authentication/authenticationService.js
@@ -40,7 +40,8 @@ angular.module('deckApp.authentication.service', [
               backdrop: 'static',
               keyboard: false
             });
-            redirectService.redirect(settings.gateUrl + redirect + '?callback=' + $window.location.origin + '&path=' + $location.path());
+            var callback = encodeURIComponent($location.absUrl());
+            redirectService.redirect(settings.gateUrl + redirect + '?callback=' + callback);
           } else {
             $rootScope.authenticating = false;
           }


### PR DESCRIPTION
Avoids having to make changes to gate while preserving query params...
