### PR TITLE
prompt user before leaving page with pending changes

### DIFF
--- a/app/scripts/modules/pipelines/config/actions/delete/deletePipeline.module.js
+++ b/app/scripts/modules/pipelines/config/actions/delete/deletePipeline.module.js
@@ -1,3 +1,7 @@
 'use strict';
 
-angular.module('deckApp.pipelines.delete', ['deckApp.pipelines', 'deckApp.settings']);
+angular.module('deckApp.pipelines.delete', [
+  'deckApp.pipelines',
+  'deckApp.settings',
+  'deckApp.pipelines.dirtyTracker.service',
+]);

--- a/app/scripts/modules/pipelines/config/actions/delete/deletePipelineModal.controller.js
+++ b/app/scripts/modules/pipelines/config/actions/delete/deletePipelineModal.controller.js
@@ -1,7 +1,9 @@
 'use strict';
 
 angular.module('deckApp.pipelines.delete')
-  .controller('DeletePipelineModalCtrl', function($scope, application, pipeline, pipelineConfigService, $modalInstance, $log) {
+  .controller('DeletePipelineModalCtrl', function($scope, $modalInstance, $log,
+                                                  dirtyPipelineTracker, pipelineConfigService,
+                                                  application, pipeline) {
 
     this.cancel = $modalInstance.dismiss;
 
@@ -19,7 +21,7 @@ angular.module('deckApp.pipelines.delete')
               pipelineConfigService.savePipeline(pipeline);
             }
           });
-
+          dirtyPipelineTracker.remove(pipeline.name);
           $modalInstance.close();
         },
         function(response) {

--- a/app/scripts/modules/pipelines/config/actions/rename/renamePipeline.module.js
+++ b/app/scripts/modules/pipelines/config/actions/rename/renamePipeline.module.js
@@ -1,3 +1,8 @@
 'use strict';
 
-angular.module('deckApp.pipelines.rename', ['deckApp.pipelines', 'deckApp.settings', 'deckApp.utils.lodash']);
+angular.module('deckApp.pipelines.rename', [
+  'deckApp.pipelines',
+  'deckApp.settings',
+  'deckApp.utils.lodash',
+  'deckApp.pipelines.dirtyTracker.service',
+]);

--- a/app/scripts/modules/pipelines/config/actions/rename/renamePipelineModal.controller.js
+++ b/app/scripts/modules/pipelines/config/actions/rename/renamePipelineModal.controller.js
@@ -1,7 +1,8 @@
 'use strict';
 
 angular.module('deckApp.pipelines.rename')
-  .controller('RenamePipelineModalCtrl', function($scope, application, pipeline, _, pipelineConfigService, $modalInstance, $log) {
+  .controller('RenamePipelineModalCtrl', function($scope, application, pipeline, _, $modalInstance, $log,
+                                                  dirtyPipelineTracker, pipelineConfigService) {
 
     this.cancel = $modalInstance.dismiss;
 
@@ -20,6 +21,7 @@ angular.module('deckApp.pipelines.rename')
       return pipelineConfigService.renamePipeline(application.name, currentName, $scope.command.newName).then(
         function() {
           $scope.pipeline.name = $scope.command.newName;
+          dirtyPipelineTracker.remove(currentName);
           $modalInstance.close();
         },
         function(response) {

--- a/app/scripts/modules/pipelines/config/actions/rename/renamePipelineModal.html
+++ b/app/scripts/modules/pipelines/config/actions/rename/renamePipelineModal.html
@@ -18,6 +18,11 @@
                  validate-unique="existingNames"/>
         </div>
       </div>
+      <div class="form-group">
+        <div class="col-md-12">
+          <p class="form-control-static"><strong>Note:</strong> by renaming the pipeline, you will save any pending changes.</p>
+        </div>
+      </div>
       <div class="form-group row slide-in animated" ng-if="form.name.$error.pattern">
         <div class="col-sm-9 col-sm-offset-3 error-message">
           <div>

--- a/app/scripts/modules/pipelines/config/pipelineConfigurer.js
+++ b/app/scripts/modules/pipelines/config/pipelineConfigurer.js
@@ -12,7 +12,8 @@ angular.module('deckApp.pipelines')
       templateUrl: 'scripts/modules/pipelines/config/pipelineConfigurer.html'
     };
   })
-  .controller('PipelineConfigurerCtrl', function($scope, pipelineConfigService, $modal, $timeout, _) {
+  .controller('PipelineConfigurerCtrl', function($scope, $modal, $timeout, _,
+                                                 dirtyPipelineTracker, pipelineConfigService) {
 
     $scope.viewState = {
       expanded: true,
@@ -178,14 +179,26 @@ angular.module('deckApp.pipelines')
       return base;
     }
 
+    function pipelineUpdated(newVal, oldVal) {
+      if (newVal && oldVal && newVal.name !== oldVal.name) {
+        $scope.viewState.original = null;
+      }
+      markDirty();
+    }
+
     var markDirty = function markDirty() {
       if (!$scope.viewState.original) {
         $scope.viewState.original = angular.toJson(getPlain($scope.pipeline));
       }
       $scope.viewState.isDirty = $scope.viewState.original !== angular.toJson(getPlain($scope.pipeline));
+      if ($scope.viewState.isDirty) {
+        dirtyPipelineTracker.add($scope.pipeline.name);
+      } else {
+        dirtyPipelineTracker.remove($scope.pipeline.name);
+      }
     };
 
-    $scope.$watch('pipeline', markDirty, true);
+    $scope.$watch('pipeline', pipelineUpdated, true);
     $scope.$watch('viewState.original', markDirty, true);
 
   });

--- a/app/scripts/modules/pipelines/config/services/dirtyPipelineTracker.service.js
+++ b/app/scripts/modules/pipelines/config/services/dirtyPipelineTracker.service.js
@@ -1,0 +1,39 @@
+'use strict';
+
+/**
+ * Simple registry to track pipelines that have been changed without being saved
+ */
+angular.module('deckApp.pipelines.dirtyTracker.service', [])
+  .factory('dirtyPipelineTracker', function() {
+
+    var dirtyPipelines = [];
+
+    function add(name) {
+      if (dirtyPipelines.indexOf(name) === -1) {
+        dirtyPipelines.push(name);
+      }
+    }
+
+    function remove(name) {
+      var index = dirtyPipelines.indexOf(name);
+      if (index !== -1) {
+        dirtyPipelines.splice(index, 1);
+      }
+    }
+
+    function list() {
+      return angular.copy(dirtyPipelines);
+    }
+
+    function hasDirtyPipelines() {
+      return dirtyPipelines.length > 0;
+    }
+
+    return {
+      add: add,
+      remove: remove,
+      list: list,
+      hasDirtyPipelines: hasDirtyPipelines,
+    };
+  }
+);

--- a/app/scripts/modules/pipelines/pipelines.module.js
+++ b/app/scripts/modules/pipelines/pipelines.module.js
@@ -5,7 +5,7 @@ angular.module('deckApp.pipelines', [
   'deckApp.pipelines.config.controller',
   'deckApp.pipelines.create.controller',
   'deckApp.pipelines.config.validator.directive',
-
+  'deckApp.pipelines.dirtyTracker.service',
 
   'restangular',
   'deckApp.pipelines.stage',


### PR DESCRIPTION
If any pipelines are dirty, prompt the user before navigating or closing the browser.

Nothing fancy, just relatively consistent.

_Navigation within app_
![screen shot 2015-03-19 at 9 18 45 pm](https://cloud.githubusercontent.com/assets/73450/6745982/9bf68f2e-ce7d-11e4-9839-9ea89108d02b.png)

_Attempting to reload the page_
![screen shot 2015-03-19 at 9 18 36 pm](https://cloud.githubusercontent.com/assets/73450/6745983/9bf87a64-ce7d-11e4-8726-341eb79ecadd.png)

_Attempting to close the browser window or tab_
![screen shot 2015-03-19 at 9 18 21 pm](https://cloud.githubusercontent.com/assets/73450/6745984/9c0b4d88-ce7d-11e4-9f13-9a745719bcba.png)
