### PR TITLE
more restrictive globbing on image search

### DIFF
--- a/app/scripts/modules/serverGroups/configure/aws/serverGroupConfiguration.service.js
+++ b/app/scripts/modules/serverGroups/configure/aws/serverGroupConfiguration.service.js
@@ -43,7 +43,7 @@ angular.module('deckApp.aws.serverGroup.configure.service', [
     function loadImagesFromApplicationName(application, provider) {
       return imageService.findImages({
         provider: provider,
-        q: application.name
+        q: application.name.replace(/_/g, '[_\\-]') + '*',
       });
     }
 
@@ -64,7 +64,7 @@ angular.module('deckApp.aws.serverGroup.configure.service', [
 
           return imageService.findImages({
             provider: command.selectedProvider,
-            q: packageBase
+            q: packageBase + '-*',
           });
         },
         function() {

--- a/app/scripts/modules/serverGroups/configure/aws/wizard/CloneServerGroup.aws.controller.spec.js
+++ b/app/scripts/modules/serverGroups/configure/aws/wizard/CloneServerGroup.aws.controller.spec.js
@@ -279,7 +279,7 @@ describe('Controller: awsCloneServerGroup', function () {
       serverGroup.region = 'us-east-1';
 
       spyOn(this.imageService, 'findImages').and.callFake(function (params) {
-        if (params.q === 'something') {
+        if (params.q === 'something-*') {
           return context.resolve(packageBasedImages).call();
         } else {
           return context.resolve([]).call();
@@ -294,7 +294,7 @@ describe('Controller: awsCloneServerGroup', function () {
 
       expect($scope.command.viewState.useAllImageSelection).toBeFalsy();
       expect(this.imageService.getAmi).toHaveBeenCalledWith('aws', serverGroup.viewState.imageId, serverGroup.region, serverGroup.credentials);
-      expect(this.imageService.findImages).toHaveBeenCalledWith({provider: 'aws', q: 'something'});
+      expect(this.imageService.findImages).toHaveBeenCalledWith({provider: 'aws', q: 'something-*'});
 
       expect($scope.command.backingData.filtered.images.length).toBe(1);
       expect($scope.command.backingData.filtered.images[0]).toEqual({imageName: 'something-packagebase', ami: 'ami-1234'});


### PR DESCRIPTION
I'm sure this will be wrong and irritate some people and we'll hear about it.

Oort now lets us explicitly declare a globbing pattern when searching images, so this takes advantage of that and appends the `*` to the end of the query.
