### PR TITLE
change the description of deploy stage

### DIFF
--- a/app/scripts/modules/pipelines/config/stages/deploy/deployStage.js
+++ b/app/scripts/modules/pipelines/config/stages/deploy/deployStage.js
@@ -4,7 +4,7 @@ angular.module('deckApp.pipelines.stage.deploy')
   .config(function (pipelineConfigProvider) {
     pipelineConfigProvider.registerStage({
       label: 'Deploy',
-      description: 'Deploys the previously baked AMI',
+      description: 'Deploys the previously baked or found AMI',
       key: 'deploy',
       templateUrl: 'scripts/modules/pipelines/config/stages/deploy/deployStage.html',
       executionDetailsUrl: 'scripts/modules/pipelines/config/stages/deploy/deployExecutionDetails.html',


### PR DESCRIPTION
reflects the fact that you can also find an AMI instead of just baking it.

@anotherchrisberry 
