### PR TITLE
common ls cache; infrastructure and viewState as unique cache providers

### DIFF
--- a/app/scripts/modules/caches/caches.module.js
+++ b/app/scripts/modules/caches/caches.module.js
@@ -2,6 +2,7 @@
 
 angular
   .module('deckApp.caches', [
+    'deckApp.caches.core',
     'deckApp.caches.initializer',
     'deckApp.caches.applicationLevelScheduled',
     'deckApp.caches.collapsibleSectionState',

--- a/app/scripts/modules/caches/deckCacheFactory.js
+++ b/app/scripts/modules/caches/deckCacheFactory.js
@@ -1,0 +1,119 @@
+'use strict';
+
+angular.module('deckApp.caches.core', [
+  'angular-data.DSCacheFactory',
+])
+.factory('deckCacheFactory', function(DSCacheFactory) {
+
+    var caches = Object.create(null);
+
+    function buildCacheKey(namespace, cacheId) {
+      if (!namespace || !cacheId) {
+        return namespace || cacheId;
+      }
+      return [namespace, cacheId].join(':');
+    }
+
+    function clearCache(namespace, key) {
+      if (caches[key] && caches[key].destroy) {
+        caches[key].destroy();
+        createCache(namespace, key, caches[key].config);
+      }
+    }
+
+    function clearCaches() {
+      Object.keys(caches).forEach(clearCache);
+    }
+
+    function createCache(namespace, key, config) {
+      addLocalStorageCache(namespace, key, config);
+    }
+
+    // Provides number of keys and min/max age of all keys in the cache
+    function getStats(cache) {
+      var keys = cache.keys(),
+        ageMin = new Date().getTime(),
+        ageMax = 0;
+
+      keys.forEach(function (key) {
+        var info = cache.info(key);
+        ageMin = Math.min(ageMin, info.created);
+        ageMax = Math.max(ageMax, info.created);
+      });
+
+      return {
+        keys: keys.length,
+        ageMin: ageMin || null,
+        ageMax: ageMax || null
+      };
+    }
+
+    function getStoragePrefix(key, version) {
+      return 'angular-cache.caches.' + key + ':' + version + '.';
+    }
+
+    function addLocalStorageCache(namespace, cacheId, cacheConfig) {
+      var key = buildCacheKey(namespace, cacheId);
+      var cacheFactory = cacheConfig.cacheFactory || DSCacheFactory;
+      var maxAge = cacheConfig.maxAge || 2 * 24 * 60 * 60 * 1000,
+        currentVersion = cacheConfig.version || 1;
+
+      clearPreviousVersions(namespace, cacheId, currentVersion, cacheFactory);
+
+      cacheFactory(key, {
+        maxAge: maxAge,
+        deleteOnExpire: 'aggressive',
+        storageMode: 'localStorage',
+        storagePrefix: getStoragePrefix(key, currentVersion),
+        recycleFreq: 5000, // ms
+      });
+      caches[key] = cacheFactory.get(key);
+      caches[key].getStats = getStats.bind(null, caches[key]);
+      caches[key].config = cacheConfig;
+    }
+
+    function clearPreviousVersions(namespace, cacheId, currentVersion, cacheFactory) {
+      if (currentVersion) {
+
+        // clear non-versioned cache (TODO: remove after 5/15/15)
+        cacheFactory(cacheId, { storageMode: 'localStorage', });
+        cacheFactory.get(cacheId).removeAll();
+        cacheFactory.get(cacheId).destroy();
+
+        // clear previous versions
+        for (var i = 0; i < currentVersion; i++) {
+          // non-namespaced (TODO: remove after 5/15/15)
+          cacheFactory(cacheId, {
+            storageMode: 'localStorage',
+            storagePrefix: getStoragePrefix(cacheId, i+1),
+          });
+          cacheFactory.get(cacheId).removeAll();
+          cacheFactory.get(cacheId).destroy();
+
+          // namespaced
+          var key = buildCacheKey(namespace, cacheId);
+          cacheFactory(key, {
+            storageMode: 'localStorage',
+            storagePrefix: getStoragePrefix(key, i),
+          });
+          cacheFactory.get(key).removeAll();
+          cacheFactory.get(key).destroy();
+        }
+      }
+
+    }
+
+    function getCache(namespace, cacheId) {
+      return caches[buildCacheKey(namespace, cacheId)];
+    }
+
+    caches.getCache = getCache;
+    caches.clearCaches = clearCaches;
+    caches.clearCache = clearCache;
+    caches.createCache = createCache;
+    caches.getStoragePrefix = getStoragePrefix;
+
+
+    return caches;
+
+  });

--- a/app/scripts/modules/caches/infrastructureCaches.spec.js
+++ b/app/scripts/modules/caches/infrastructureCaches.spec.js
@@ -2,11 +2,12 @@
 
 describe('deckApp.caches.infrastructure', function() {
 
-  var infrastructureCaches;
+  var infrastructureCaches, deckCacheFactory;
 
   beforeEach(module('deckApp.caches.infrastructure'));
-  beforeEach(inject(function(_infrastructureCaches_) {
+  beforeEach(inject(function(_infrastructureCaches_, _deckCacheFactory_) {
     infrastructureCaches = _infrastructureCaches_;
+    deckCacheFactory = _deckCacheFactory_;
   }));
 
   describe('cache initialization', function() {
@@ -47,13 +48,16 @@ describe('deckApp.caches.infrastructure', function() {
 
       infrastructureCaches.createCache('myCache', config);
 
-      expect(this.cacheInstantiations.length).toBe(3);
+      expect(this.cacheInstantiations.length).toBe(6);
       expect(this.cacheInstantiations[0].config.storagePrefix).toBeUndefined();
-      expect(this.cacheInstantiations[1].config.storagePrefix).toBe(infrastructureCaches.getStoragePrefix('myCache', 1));
-      expect(this.cacheInstantiations[2].config.storagePrefix).toBe(infrastructureCaches.getStoragePrefix('myCache', 2));
-      expect(this.removalCalls.length).toBe(2);
-      expect(this.removalCalls).toEqual(['myCache', 'myCache']);
-      expect(this.destroyCalls).toEqual(['myCache', 'myCache']);
+      expect(this.cacheInstantiations[1].config.storagePrefix).toBe(deckCacheFactory.getStoragePrefix('myCache', 1));
+      expect(this.cacheInstantiations[2].config.storagePrefix).toBe(deckCacheFactory.getStoragePrefix('infrastructure:myCache', 0));
+      expect(this.cacheInstantiations[3].config.storagePrefix).toBe(deckCacheFactory.getStoragePrefix('myCache', 2));
+      expect(this.cacheInstantiations[4].config.storagePrefix).toBe(deckCacheFactory.getStoragePrefix('infrastructure:myCache', 1));
+      expect(this.cacheInstantiations[5].config.storagePrefix).toBe(deckCacheFactory.getStoragePrefix('infrastructure:myCache', 2));
+      expect(this.removalCalls.length).toBe(5);
+      expect(this.removalCalls).toEqual(['myCache', 'myCache', 'infrastructure:myCache', 'myCache', 'infrastructure:myCache']);
+      expect(this.destroyCalls).toEqual(['myCache', 'myCache', 'infrastructure:myCache', 'myCache', 'infrastructure:myCache']);
 
     });
 
@@ -62,11 +66,13 @@ describe('deckApp.caches.infrastructure', function() {
         cacheFactory: this.cacheFactory,
       });
 
-      expect(this.cacheInstantiations.length).toBe(2);
+      expect(this.cacheInstantiations.length).toBe(4);
       expect(this.cacheInstantiations[0].config.storagePrefix).toBeUndefined();
-      expect(this.cacheInstantiations[1].config.storagePrefix).toBe(infrastructureCaches.getStoragePrefix('myCache', 1));
-      expect(this.removalCalls.length).toBe(1);
-      expect(this.removalCalls).toEqual(['myCache']);
+      expect(this.cacheInstantiations[1].config.storagePrefix).toBe(deckCacheFactory.getStoragePrefix('myCache', 1));
+      expect(this.cacheInstantiations[2].config.storagePrefix).toBe(deckCacheFactory.getStoragePrefix('infrastructure:myCache', 0));
+      expect(this.cacheInstantiations[3].config.storagePrefix).toBe(deckCacheFactory.getStoragePrefix('infrastructure:myCache', 1));
+      expect(this.removalCalls.length).toBe(3);
+      expect(this.removalCalls).toEqual(['myCache', 'myCache', 'infrastructure:myCache']);
     });
 
   });

--- a/app/scripts/modules/delivery/pipelineExecutions.controller.js
+++ b/app/scripts/modules/delivery/pipelineExecutions.controller.js
@@ -14,17 +14,17 @@ angular.module('deckApp.delivery.pipelineExecutions.controller', [
 
     var controller = this;
 
-    var viewStateCacheKey = 'executions';
+    var executionsViewStateCache = viewStateCache.createCache('executions', { version: 1 });
 
     function cacheViewState() {
-      viewStateCache.cacheViewState($scope.application.name, viewStateCacheKey, $scope.filter);
+      executionsViewStateCache.put($scope.application.name, $scope.filter);
     }
 
     $scope.viewState = {
       loading: true
     };
 
-    $scope.filter = viewStateCache.getCachedViewState($scope.application.name, viewStateCacheKey) || {
+    $scope.filter = executionsViewStateCache.get($scope.application.name) || {
       count: 5,
       execution: {
         status: {

--- a/app/scripts/modules/delivery/pipelineExecutions.controller.spec.js
+++ b/app/scripts/modules/delivery/pipelineExecutions.controller.spec.js
@@ -2,14 +2,11 @@
 
 describe('Controller: pipelineExecutions', function () {
 
-  //NOTE: This is only testing the controllers dependencies. Please add more tests.
-
   var controller;
   var scope;
   var rootScope;
   var $state;
   var pipelineConfigService;
-  var executionsService;
   var $q;
 
   beforeEach(

--- a/app/scripts/modules/pipelines/config/pipelineConfigurer.js
+++ b/app/scripts/modules/pipelines/config/pipelineConfigurer.js
@@ -15,11 +15,13 @@ angular.module('deckApp.pipelines')
   .controller('PipelineConfigurerCtrl', function($scope, $modal, $timeout, _,
                                                  dirtyPipelineTracker, pipelineConfigService, viewStateCache) {
 
+    var configViewStateCache = viewStateCache.pipelineConfig;
+
     function buildCacheKey() {
-      return pipelineConfigService.buildViewStateCacheKey($scope.pipeline.name);
+      return pipelineConfigService.buildViewStateCacheKey($scope.application.name, $scope.pipeline.name);
     }
 
-    $scope.viewState = viewStateCache.getCachedViewState($scope.application.name, buildCacheKey()) || {
+    $scope.viewState = configViewStateCache.get(buildCacheKey()) || {
       expanded: true,
       section: 'triggers',
       stageIndex: 0,
@@ -208,7 +210,7 @@ angular.module('deckApp.pipelines')
     function cacheViewState() {
       var toCache = angular.copy($scope.viewState);
       delete toCache.original;
-      viewStateCache.cacheViewState($scope.application.name, buildCacheKey(), toCache);
+      configViewStateCache.put(buildCacheKey(), toCache);
     }
 
     $scope.$watch('pipeline', pipelineUpdated, true);

--- a/app/scripts/modules/pipelines/config/services/pipelineConfigService.js
+++ b/app/scripts/modules/pipelines/config/services/pipelineConfigService.js
@@ -9,8 +9,10 @@ angular.module('deckApp.pipelines.config.service', [
 ])
   .factory('pipelineConfigService', function (settings, Restangular, authenticationService, viewStateCache) {
 
-    function buildViewStateCacheKey(pipelineName) {
-      return ['pipelineConfig', pipelineName].join(':');
+    var configViewStateCache = viewStateCache.createCache('pipelineConfig', { version: 1 });
+
+    function buildViewStateCacheKey(applicationName, pipelineName) {
+      return [applicationName, pipelineName].join(':');
     }
 
     function getPipelinesForApplication(applicationName) {
@@ -34,7 +36,7 @@ angular.module('deckApp.pipelines.config.service', [
     }
 
     function renamePipeline(applicationName, currentName, newName) {
-      viewStateCache.clearViewState(applicationName, buildViewStateCacheKey(currentName));
+      configViewStateCache.remove(buildViewStateCacheKey(applicationName, currentName));
       return Restangular.all('pipelines').all('move').post({
         application: applicationName,
         from: currentName,


### PR DESCRIPTION
Changing viewStateCache to behave the same way infrastructureCache does, so we can cleanly version individual view states instead of all of them at once, as they are likely to change.

A fair amount of code is there to clean up previous versions; I believe this is now solid and we can remove large blocks of that code in a couple months.
