### PR TITLE
allow deregistrations from load balancer regardless of health

### DIFF
--- a/app/scripts/modules/instance/details/aws/instanceDetails.html
+++ b/app/scripts/modules/instance/details/aws/instanceDetails.html
@@ -34,7 +34,7 @@
             <li><a href ng-click="ctrl.enableInstanceInDiscovery()" ng-if="ctrl.canRegisterWithDiscovery()">Enable in Discovery</a></li>
             <li><a href ng-click="ctrl.disableInstanceInDiscovery()" ng-if="ctrl.hasHealthState('Discovery', 'Up')">Disable in Discovery</a></li>
             <li><a href ng-click="ctrl.registerInstanceWithLoadBalancer()" ng-if="ctrl.canRegisterWithLoadBalancer()">Register with Load Balancer</a></li>
-            <li><a href ng-click="ctrl.deregisterInstanceFromLoadBalancer()" ng-if="instance.loadBalancers.length > 0 && ctrl.hasHealthState('LoadBalancer', 'Up')">Deregister from Load Balancer</a></li>
+            <li><a href ng-click="ctrl.deregisterInstanceFromLoadBalancer()" ng-if="instance.loadBalancers.length > 0">Deregister from Load Balancer</a></li>
             <li role="presentation" class="divider" ng-if="instance.health.length > 0"></li>
             <li><a href ng-click="ctrl.rebootInstance()">Reboot Instance</a></li>
             <li><a href ng-click="ctrl.terminateInstance()">Terminate Instance</a></li>

--- a/app/scripts/modules/instance/details/gce/instanceDetails.html
+++ b/app/scripts/modules/instance/details/gce/instanceDetails.html
@@ -35,7 +35,7 @@
             <li><a href ng-click="ctrl.enableInstanceInDiscovery()" ng-if="ctrl.canRegisterWithDiscovery()">Enable in Discovery</a></li>
             <li><a href ng-click="ctrl.disableInstanceInDiscovery()" ng-if="ctrl.hasHealthState('Discovery', 'Up')">Disable in Discovery</a></li>
             <li><a href ng-click="ctrl.registerInstanceWithLoadBalancer()" ng-if="ctrl.canRegisterWithLoadBalancer()">Register with Load Balancer</a></li>
-            <li><a href ng-click="ctrl.deregisterInstanceFromLoadBalancer()" ng-if="instance.loadBalancers.length > 0 && ctrl.hasHealthState('LoadBalancer', 'Up')">Deregister from Load Balancer</a></li>
+            <li><a href ng-click="ctrl.deregisterInstanceFromLoadBalancer()" ng-if="instance.loadBalancers.length > 0">Deregister from Load Balancer</a></li>
             <li role="presentation" class="divider" ng-if="instance.health.length > 0"></li>
             <li><a href ng-click="ctrl.rebootInstance()">Reboot Instance</a></li>
             <li><a href ng-click="ctrl.terminateInstance()">Terminate Instance</a></li>


### PR DESCRIPTION
If an instance has _any_ load balancer health, it's attached and we should allow users to de-register it.
