### PR TITLE
use provided application instead of inherited scope

### DIFF
--- a/app/scripts/modules/instance/details/aws/instance.details.controller.js
+++ b/app/scripts/modules/instance/details/aws/instance.details.controller.js
@@ -142,7 +142,7 @@ angular.module('deckApp.instance.detail.aws.controller', [
       };
 
       var submitMethod = function () {
-        return instanceWriter.terminateInstance(instance, $scope.application);
+        return instanceWriter.terminateInstance(instance, application);
       };
 
       confirmationModalService.confirm({
@@ -165,7 +165,7 @@ angular.module('deckApp.instance.detail.aws.controller', [
       };
 
       var submitMethod = function () {
-        return instanceWriter.rebootInstance(instance, $scope.application);
+        return instanceWriter.rebootInstance(instance, application);
       };
 
       confirmationModalService.confirm({
@@ -189,7 +189,7 @@ angular.module('deckApp.instance.detail.aws.controller', [
       };
 
       var submitMethod = function () {
-        return instanceWriter.registerInstanceWithLoadBalancer(instance, $scope.application);
+        return instanceWriter.registerInstanceWithLoadBalancer(instance, application);
       };
 
       confirmationModalService.confirm({
@@ -212,7 +212,7 @@ angular.module('deckApp.instance.detail.aws.controller', [
       };
 
       var submitMethod = function () {
-        return instanceWriter.deregisterInstanceFromLoadBalancer(instance, $scope.application);
+        return instanceWriter.deregisterInstanceFromLoadBalancer(instance, application);
       };
 
       confirmationModalService.confirm({
@@ -235,7 +235,7 @@ angular.module('deckApp.instance.detail.aws.controller', [
       };
 
       var submitMethod = function () {
-        return instanceWriter.enableInstanceInDiscovery(instance, $scope.application);
+        return instanceWriter.enableInstanceInDiscovery(instance, application);
       };
 
       confirmationModalService.confirm({
@@ -257,7 +257,7 @@ angular.module('deckApp.instance.detail.aws.controller', [
       };
 
       var submitMethod = function () {
-        return instanceWriter.disableInstanceInDiscovery(instance, $scope.application);
+        return instanceWriter.disableInstanceInDiscovery(instance, application);
       };
 
       confirmationModalService.confirm({

--- a/app/scripts/modules/instance/details/gce/instance.details.controller.js
+++ b/app/scripts/modules/instance/details/gce/instance.details.controller.js
@@ -127,7 +127,7 @@ angular.module('deckApp.instance.detail.gce.controller', [
       };
 
       var submitMethod = function () {
-        return instanceWriter.terminateInstance(instance, $scope.application);
+        return instanceWriter.terminateInstance(instance, application);
       };
 
       confirmationModalService.confirm({
@@ -150,7 +150,7 @@ angular.module('deckApp.instance.detail.gce.controller', [
       };
 
       var submitMethod = function () {
-        return instanceWriter.rebootInstance(instance, $scope.application);
+        return instanceWriter.rebootInstance(instance, application);
       };
 
       confirmationModalService.confirm({
@@ -174,7 +174,7 @@ angular.module('deckApp.instance.detail.gce.controller', [
       };
 
       var submitMethod = function () {
-        return instanceWriter.registerInstanceWithLoadBalancer(instance, $scope.application);
+        return instanceWriter.registerInstanceWithLoadBalancer(instance, application);
       };
 
       confirmationModalService.confirm({
@@ -197,7 +197,7 @@ angular.module('deckApp.instance.detail.gce.controller', [
       };
 
       var submitMethod = function () {
-        return instanceWriter.deregisterInstanceFromLoadBalancer(instance, $scope.application);
+        return instanceWriter.deregisterInstanceFromLoadBalancer(instance, application);
       };
 
       confirmationModalService.confirm({
@@ -220,7 +220,7 @@ angular.module('deckApp.instance.detail.gce.controller', [
       };
 
       var submitMethod = function () {
-        return instanceWriter.enableInstanceInDiscovery(instance, $scope.application);
+        return instanceWriter.enableInstanceInDiscovery(instance, application);
       };
 
       confirmationModalService.confirm({
@@ -242,7 +242,7 @@ angular.module('deckApp.instance.detail.gce.controller', [
       };
 
       var submitMethod = function () {
-        return instanceWriter.disableInstanceInDiscovery(instance, $scope.application);
+        return instanceWriter.disableInstanceInDiscovery(instance, application);
       };
 
       confirmationModalService.confirm({


### PR DESCRIPTION
Fixing some code that was working in spite of itself.

The only reason we were able to get the `application` off the scope is because of the parent controller, I suppose. But that does not work for standalone instances. This resolves that.

cc @duftler 
