### PR TITLE
add server group name to instance if not already attached

### DIFF
--- a/app/scripts/services/clusterService.js
+++ b/app/scripts/services/clusterService.js
@@ -174,10 +174,11 @@ angular.module('deckApp.cluster.service', [
 
 
 
-    function addProvidersToInstances(serverGroups) {
+    function addProvidersAndServerGroupsToInstances(serverGroups) {
       serverGroups.forEach(function(serverGroup) {
         serverGroup.instances.forEach(function(instance) {
           instance.provider = serverGroup.type;
+          instance.serverGroup = instance.serverGroup || serverGroup.name;
         });
       });
     }
@@ -193,7 +194,7 @@ angular.module('deckApp.cluster.service', [
           clusters.push(cluster);
         });
       });
-      addProvidersToInstances(serverGroups);
+      addProvidersAndServerGroupsToInstances(serverGroups);
       return clusters;
     }
 

--- a/app/styles/main.less
+++ b/app/styles/main.less
@@ -222,7 +222,7 @@ dl {
   }
   &.dl-narrow {
     dt {
-      width: 80px;
+      width: 90px;
     }
     dd {
       margin-left: 100px;


### PR DESCRIPTION
@duftler this should handle the case where it's explicitly passed in from the server (https://github.com/spinnaker/oort/pull/176); otherwise, it will add it based on its parent container.

Also fixing the ellipsis on "Server Groups:"
