### PR TITLE
Fix for selecting a build number when manually running a pipeline.

### DIFF
--- a/app/scripts/modules/delivery/manualPipelineExecution.controller.js
+++ b/app/scripts/modules/delivery/manualPipelineExecution.controller.js
@@ -45,6 +45,10 @@ angular.module('deckApp.delivery.manualPipelineExecution.controller', [
       }
     };
 
+    $scope.updateSelectedBuild = function(item) {
+      $scope.selectedBuild = item;
+    };
+
     this.cancel = function() {
       $modalInstance.dismiss();
     };

--- a/app/scripts/modules/delivery/manualPipelineExecution.html
+++ b/app/scripts/modules/delivery/manualPipelineExecution.html
@@ -67,7 +67,8 @@
           </div>
           <div class="col-md-7" ng-if="!viewState.buildsLoading">
             <ui-select class="form-control input-sm"
-                       ng-model="selectedBuild">
+                       ng-model="selectedBuild"
+                       on-select="updateSelectedBuild($item)">
               <ui-select-match placeholder="Select...">
                 <span>
                   <strong>Build {{$select.selected.number}}</strong>


### PR DESCRIPTION
The selected build was not updating the scope and in turn not being sent down the wire when manually starting a pipeline.
