### PR TITLE
there's more than one way to find a task exception

### DIFF
--- a/app/scripts/modules/tasks/tasks.api.config.js
+++ b/app/scripts/modules/tasks/tasks.api.config.js
@@ -202,13 +202,24 @@ angular.module('deckApp.tasks.api', [
           get: function() {
             var generalException = task.getValueFor('exception');
             if (generalException) {
-              return generalException.details.errors ? generalException.details.errors.join(', ') : 'No reason provided';
+              if (generalException.details && generalException.details.errors && generalException.details.errors.length) {
+                return generalException.details.errors.join(', ');
+              }
+              if (generalException.details && generalException.details.error) {
+                return generalException.details.error;
+              }
+              return 'No reason provided';
             }
 
             if ((task.isFailed || task.isStopped) && getKatoTasks(task)) {
               var katoTasks = getKatoTasks(task);
               var katoException = katoTasks[katoTasks.length -1].exception;
-              return katoException ? katoException.message : 'No reason provided';
+              if (katoException) {
+                return katoException ? katoException.message : 'No reason provided.';
+              } else {
+                return this.lastKatoMessage;
+              }
+
             }
 
             return false;


### PR DESCRIPTION
If the `errors` field on the general task exception is empty, try the `error` field.

If the `exception` field on the last known kato task is falsy, use the last status message in the kato history.
