### PR TITLE
filter internal steps from display on execution details

### DIFF
--- a/app/scripts/modules/pipelines/config/stages/core/displayableTasks.filter.js
+++ b/app/scripts/modules/pipelines/config/stages/core/displayableTasks.filter.js
@@ -1,0 +1,15 @@
+'use strict';
+
+angular.module('deckApp.pipelines.stages.core.displayableTasks.filter', [])
+  .filter('displayableTasks', function() {
+    var blacklist = [
+      'forceCacheRefresh',
+    ];
+    return function(input) {
+      if (input) {
+        return input.filter(function(test) {
+          return blacklist.indexOf(test.name) === -1 ? input : null;
+        });
+      }
+    };
+  });

--- a/app/scripts/modules/pipelines/config/stages/core/executionStepDetails.html
+++ b/app/scripts/modules/pipelines/config/stages/core/executionStepDetails.html
@@ -14,7 +14,7 @@
         <span ng-include="executionStepDetailsCtrl.getTaskLabel(stage.type)"></span>
       </div>
     </div>
-    <div class="row" ng-repeat="task in stage.tasks">
+    <div class="row" ng-repeat="task in stage.tasks | displayableTasks">
       <div class="col-md-8">
         <span class="small"><status-glyph item="task"></status-glyph></span> {{task.name | robotToHuman }}
       </div>

--- a/app/scripts/modules/pipelines/config/stages/core/stage.core.module.js
+++ b/app/scripts/modules/pipelines/config/stages/core/stage.core.module.js
@@ -1,5 +1,6 @@
 'use strict';
 
 angular.module('deckApp.pipelines.stage.core', [
-  'deckApp.pipelines.stages.core.executionStepDetails'
+  'deckApp.pipelines.stages.core.executionStepDetails',
+  'deckApp.pipelines.stages.core.displayableTasks.filter',
 ]);

--- a/app/scripts/modules/tasks/tasks.controller.js
+++ b/app/scripts/modules/tasks/tasks.controller.js
@@ -7,6 +7,7 @@ angular.module('deckApp.tasks.main', [
   'deckApp.caches.viewStateCache',
   'deckApp.tasks.write.service',
   'deckApp.confirmationModal.service',
+  'deckApp.pipelines.stages.core.displayableTasks.filter',
   'ui.router',
   'deckApp.settings',
 ])

--- a/app/scripts/modules/tasks/tasks.html
+++ b/app/scripts/modules/tasks/tasks.html
@@ -112,7 +112,7 @@
                 </a>
               </td>
             </tr>
-            <tr ng-repeat="step in task.steps"
+            <tr ng-repeat="step in task.steps | displayableTasks"
                 ng-if="tasks.isExpanded(task.id)"
                 class="task-step">
               <td colspan="2">


### PR DESCRIPTION
I am pretty sure nobody cares about the `forceCacheRefresh` step. We can add others to the list.
