### PR TITLE
add tags to Server Groups heading

### DIFF
--- a/app/scripts/modules/cluster/all.html
+++ b/app/scripts/modules/cluster/all.html
@@ -34,6 +34,13 @@
       </button>
     </div>
   </div>
+  <div class="col-md-12 filter-tags" ng-if="tags.length">
+    Filtered by: <span class="filter-tag" ng-repeat="tag in tags">
+      <strong>{{tag.label}}</strong>: {{tag.value}}
+      <a href ng-click="tag.clear()"><span class="glyphicon glyphicon-remove-sign"></span></a>
+    </span>
+    <a href class="clear-filters" ng-click="allClusters.clearFilters()" ng-if="tags.length > 1">Clear All</a>
+  </div>
 </div>
 <div class="content"
      data-scroll-id="clusters-content"

--- a/app/scripts/modules/cluster/allClusters.controller.js
+++ b/app/scripts/modules/cluster/allClusters.controller.js
@@ -45,16 +45,22 @@ angular.module('clusters.all', [
       });
     }
 
-
     function updateClusterGroups() {
       clusterFilterService.updateQueryParams();
-      $scope.$evalAsync(
-        clusterFilterService.updateClusterGroups(application)
+      $scope.$evalAsync(function() {
+          clusterFilterService.updateClusterGroups(application);
+        }
       );
 
       $scope.groups = ClusterFilterModel.groups;
       $scope.displayOptions = ClusterFilterModel.displayOptions;
+      $scope.tags = ClusterFilterModel.sortFilter.tags;
     }
+
+    this.clearFilters = function() {
+      clusterFilterService.clearFilters();
+      updateClusterGroups();
+    };
 
     this.createServerGroup = function createServerGroup() {
       providerSelectionService.selectProvider().then(function(selectedProvider) {

--- a/app/scripts/modules/clusterFilter/clusterFilterModel.js
+++ b/app/scripts/modules/clusterFilter/clusterFilterModel.js
@@ -5,7 +5,8 @@ angular
   .factory('ClusterFilterModel', function($rootScope, $state, $stateParams, $location, _) {
 
     var sortFilter = {
-      instanceSort: { key: 'launchTime' }
+      instanceSort: { key: 'launchTime' },
+      tags: [],
     };
 
     var savedClusterState = {};

--- a/app/scripts/modules/clusterFilter/clusterFilterService.js
+++ b/app/scripts/modules/clusterFilter/clusterFilterService.js
@@ -205,6 +205,7 @@ angular
         sortGroupsByHeading(groups);
         setDisplayOptions(totalInstancesDisplayed);
         waypointService.restoreToWaypoint(application.name);
+        addTags();
         lastApplication = application;
         return groups;
     }
@@ -219,7 +220,7 @@ angular
 
     function setDisplayOptions(totalInstancesDisplayed) {
       var newOptions =  {
-        renderInstancesOnScroll: totalInstancesDisplayed > 1000, // TODO: move to config
+        renderInstancesOnScroll: totalInstancesDisplayed > 1000, // TODO: remove
         totalInstancesDisplayed: totalInstancesDisplayed,
         showInstances: ClusterFilterModel.sortFilter.showAllInstances,
         listInstances: ClusterFilterModel.sortFilter.listInstances,
@@ -232,6 +233,55 @@ angular
     function clearFilters() {
       ClusterFilterModel.clearFilters();
       updateQueryParams();
+    }
+
+    function addTagsForSection(key, label, translator) {
+      translator = translator || {};
+      var tags = ClusterFilterModel.sortFilter.tags;
+      if (ClusterFilterModel.sortFilter[key]) {
+        _.forOwn(ClusterFilterModel.sortFilter[key], function(isActive, value) {
+          if (isActive) {
+            tags.push({
+              key: key,
+              label: label,
+              value: translator[value] || value,
+              clear: function() {
+                delete ClusterFilterModel.sortFilter[key][value];
+                updateQueryParams();
+                updateClusterGroups();
+              }
+            });
+          }
+        });
+      }
+      return tags;
+    }
+
+    function addFilterTag() {
+      if (ClusterFilterModel.sortFilter.filter) {
+        ClusterFilterModel.sortFilter.tags.push({
+          key: 'filter',
+          label: 'search',
+          value: ClusterFilterModel.sortFilter.filter,
+          clear: function() {
+            ClusterFilterModel.sortFilter.filter = '';
+            updateQueryParams();
+            updateClusterGroups();
+          }
+        });
+      }
+    }
+
+    function addTags() {
+      var tags = ClusterFilterModel.sortFilter.tags;
+      tags.length = 0;
+      addFilterTag();
+      addTagsForSection('account', 'account');
+      addTagsForSection('region', 'region');
+      addTagsForSection('status', 'status', {Up: 'Healthy', Down: 'Unhealthy', OutOfService: 'Out of Service'});
+      addTagsForSection('availabilityZone', 'zone');
+      addTagsForSection('instanceType', 'instance type');
+      addTagsForSection('providerType', 'provider');
     }
 
     return {

--- a/app/scripts/modules/clusterFilter/clusterFilterService.spec.js
+++ b/app/scripts/modules/clusterFilter/clusterFilterService.spec.js
@@ -28,6 +28,18 @@ describe('Service: clusterFilterService', function () {
     )
   );
 
+  beforeEach(function() {
+    this.verifyTags = function(expectedTags) {
+      var actual = ClusterFilterModel.sortFilter.tags;
+      expect(actual.length).toBe(expectedTags.length);
+      expectedTags.forEach(function(expected) {
+        expect(actual.some(function(test) {
+          return test.key === expected.key && test.label === expected.label && test.value === expected.value;
+        })).toBe(true);
+      });
+    };
+  });
+
   it('should have the service injected in the test', function () {
     expect(service).toBeDefined();
     expect($location).toBeDefined();
@@ -177,11 +189,18 @@ describe('Service: clusterFilterService', function () {
         ClusterFilterModel.sortFilter.account = {prod: true};
         var expectedProd = _.filter(groupedJSON, {heading:'prod'});
         expect(service.updateClusterGroups(applicationJSON)).toEqual(expectedProd);
+        this.verifyTags([
+          { key: 'account', label: 'account', value: 'prod' }
+        ]);
       });
 
       it('All account filters: should show all accounts', function () {
         ClusterFilterModel.sortFilter.account = {prod: true, test: true};
         expect(service.updateClusterGroups(applicationJSON)).toEqual(groupedJSON);
+        this.verifyTags([
+          { key: 'account', label: 'account', value: 'prod' },
+          { key: 'account', label: 'account', value: 'test' },
+        ]);
       });
     });
   });
@@ -191,6 +210,9 @@ describe('Service: clusterFilterService', function () {
       ClusterFilterModel.sortFilter.region = {'us-west-1' : true};
       var expected = _.filter(groupedJSON, {subgroups: [{heading: 'in-us-west-1-only' }]});
       expect(service.updateClusterGroups(applicationJSON)).toEqual(expected);
+      this.verifyTags([
+        { key: 'region', label: 'region', value: 'us-west-1' },
+      ]);
     });
   });
 
@@ -210,11 +232,15 @@ describe('Service: clusterFilterService', function () {
       );
 
       expect(service.updateClusterGroups(applicationJSON)).toEqual(expected);
+      this.verifyTags([
+        { key: 'status', label: 'status', value: 'healthy' },
+      ]);
     });
 
     it('should not filter by healthy if unchecked', function () {
       ClusterFilterModel.sortFilter.status = {healthy : false};
       expect(service.updateClusterGroups(applicationJSON)).toEqual(groupedJSON);
+      this.verifyTags([]);
     });
   });
 
@@ -234,11 +260,15 @@ describe('Service: clusterFilterService', function () {
       );
 
       expect(service.updateClusterGroups(applicationJSON)).toEqual(expected);
+      this.verifyTags([
+        { key: 'status', label: 'status', value: 'unhealthy' },
+      ]);
     });
 
     it('should not filter by unhealthy if unchecked', function () {
       ClusterFilterModel.sortFilter.status = {unhealthy : false};
       expect(service.updateClusterGroups(applicationJSON)).toEqual(groupedJSON);
+      this.verifyTags([]);
     });
 
   });
@@ -258,6 +288,10 @@ describe('Service: clusterFilterService', function () {
         }
       );
       expect(service.updateClusterGroups(applicationJSON)).toEqual(expected);
+      this.verifyTags([
+        { key: 'status', label: 'status', value: 'healthy' },
+        { key: 'status', label: 'status', value: 'unhealthy' },
+      ]);
     });
   });
 
@@ -276,11 +310,15 @@ describe('Service: clusterFilterService', function () {
         }
       );
       expect(service.updateClusterGroups(applicationJSON)).toEqual(expected);
+      this.verifyTags([
+        { key: 'status', label: 'status', value: 'Disabled' },
+      ]);
     });
 
     it('should not filter if the status is unchecked', function () {
       ClusterFilterModel.sortFilter.status = { Disabled: false };
       expect(service.updateClusterGroups(applicationJSON)).toEqual(groupedJSON);
+      this.verifyTags([]);
     });
   });
 
@@ -297,6 +335,9 @@ describe('Service: clusterFilterService', function () {
       starting.healthState = 'Starting';
       serverGroup.startingCount = 1;
       expect(service.updateClusterGroups(appCopy).length).toBe(1);
+      this.verifyTags([
+        { key: 'status', label: 'status', value: 'Starting' },
+      ]);
     });
   });
 
@@ -313,6 +354,9 @@ describe('Service: clusterFilterService', function () {
       starting.healthState = 'OutOfService';
       serverGroup.outOfServiceCount = 1;
       expect(service.updateClusterGroups(appCopy).length).toBe(1);
+      this.verifyTags([
+        { key: 'status', label: 'status', value: 'Out of Service' },
+      ]);
     });
   });
 
@@ -331,16 +375,24 @@ describe('Service: clusterFilterService', function () {
         }
       );
       expect(service.updateClusterGroups(applicationJSON)).toEqual(expected);
+      this.verifyTags([
+        { key: 'providerType', label: 'provider', value: 'aws' },
+      ]);
     });
 
     it('should not filter if no provider type is selected', function () {
       ClusterFilterModel.sortFilter.providerType = undefined;
       expect(service.updateClusterGroups(applicationJSON)).toEqual(groupedJSON);
+      this.verifyTags([]);
     });
 
     it('should not filter if all provider are selected', function () {
       ClusterFilterModel.sortFilter.providerType = {aws: true, gce: true};
       expect(service.updateClusterGroups(applicationJSON)).toEqual(groupedJSON);
+      this.verifyTags([
+        { key: 'providerType', label: 'provider', value: 'aws' },
+        { key: 'providerType', label: 'provider', value: 'gce' },
+      ]);
     });
   });
 
@@ -359,16 +411,21 @@ describe('Service: clusterFilterService', function () {
         }
       );
       expect(service.updateClusterGroups(applicationJSON)).toEqual(expected);
+      this.verifyTags([
+        { key: 'instanceType', label: 'instance type', value: 'm3.large' },
+      ]);
     });
 
     it('should not filter if no instance type selected', function () {
       ClusterFilterModel.sortFilter.instanceType = undefined;
       expect(service.updateClusterGroups(applicationJSON)).toEqual(groupedJSON);
+      this.verifyTags([]);
     });
 
     it('should not filter if the instance type is unchecked', function () {
       ClusterFilterModel.sortFilter.instanceType = {'m3.large' : false};
       expect(service.updateClusterGroups(applicationJSON)).toEqual(groupedJSON);
+      this.verifyTags([]);
     });
   });
 
@@ -384,6 +441,7 @@ describe('Service: clusterFilterService', function () {
       expect(ClusterFilterModel.sortFilter.providerType).toBeDefined();
       service.clearFilters();
       expect(ClusterFilterModel.sortFilter.providerType).toBeUndefined();
+      this.verifyTags([]);
     });
 
   });

--- a/app/styles/application.less
+++ b/app/styles/application.less
@@ -83,3 +83,31 @@
     text-decoration: none;
   }
 }
+
+.filter-tags {
+  border-top: 1px solid @mid_light_grey;
+  padding: 5px 15px 0;
+  .filter-tag {
+    strong {
+      font-weight: 600;
+      text-transform: uppercase;
+    }
+    border-radius: 2px;
+    display: inline-block;
+    padding: 3px 5px;
+    margin-right: 10px;
+    margin-bottom: 5px;
+    background-color: @light_grey;
+    font-size: 90%;
+    a {
+      font-size: 90%;
+      color: @mid_grey;
+    }
+  }
+  .clear-filters {
+    display: inline-block;
+    margin-left: 5px;
+    color: @text-color;
+    font-size: 90%;
+  }
+}


### PR DESCRIPTION
People have been having trouble realizing that filters are applied when they come in from deep links - Permalinks, global search, etc. - when they haven't applied the filters themselves.

This adds eBay-style tags to the top to make it more clear that filters have been applied, and lets users clear filters more easily:

![screen shot 2015-04-06 at 6 24 31 pm](https://cloud.githubusercontent.com/assets/73450/7015603/1c4c39b0-dc8b-11e4-9323-a7e2bf0ad0fe.png)
