### PR TITLE
tweak behavior of auto-refresh button on application

### DIFF
--- a/app/scripts/modules/applications/application.controller.js
+++ b/app/scripts/modules/applications/application.controller.js
@@ -9,6 +9,15 @@ angular.module('deckApp.application.controller', [])
       return;
     }
 
+    this.toggleRefresh = function() {
+      if (application.autoRefreshEnabled) {
+        application.disableAutoRefresh();
+      } else {
+        application.resumeAutoRefresh();
+        application.refreshImmediately();
+      }
+    };
+
     function countInstances() {
       var serverGroups = application.serverGroups || [];
       return serverGroups
@@ -17,8 +26,9 @@ angular.module('deckApp.application.controller', [])
         }, 0);
     }
 
-    if (countInstances() < 500) {
-      application.enableAutoRefresh($scope);
+    application.enableAutoRefresh($scope);
+    if (countInstances() > 500) {
+      application.disableAutoRefresh();
     }
   }
 );

--- a/app/scripts/modules/applications/application.controller.spec.js
+++ b/app/scripts/modules/applications/application.controller.spec.js
@@ -1,0 +1,56 @@
+'use strict';
+
+describe('Controller: Application', function () {
+
+  beforeEach(module('deckApp.application.controller'));
+
+  beforeEach(inject(function ($controller, $rootScope) {
+    this.scope = $rootScope.$new();
+
+    this.application = {
+      enableAutoRefresh: angular.noop,
+      disableAutoRefresh: angular.noop,
+      serverGroups: [
+        { instances: {}}
+      ]
+    };
+
+    this.initializeController = function() {
+      this.ctrl = $controller('ApplicationCtrl', {
+        $scope: this.scope,
+        application: this.application,
+      });
+    };
+  }));
+
+  it('enables auto refresh when there are 500 or fewer instances in the application', function() {
+    this.application.serverGroups[0].instances.length = 500;
+    spyOn(this.application, 'enableAutoRefresh');
+    spyOn(this.application, 'disableAutoRefresh');
+    this.initializeController();
+
+    expect(this.application.enableAutoRefresh).toHaveBeenCalled();
+    expect(this.application.disableAutoRefresh).not.toHaveBeenCalled();
+
+    this.application.serverGroups[0].instances.length = 1;
+    this.initializeController();
+    expect(this.application.disableAutoRefresh).not.toHaveBeenCalled();
+  });
+
+  it('disables auto refresh when there are more than 500 instances in the application', function() {
+    this.application.serverGroups[0].instances.length = 0;
+    spyOn(this.application, 'enableAutoRefresh');
+    spyOn(this.application, 'disableAutoRefresh');
+    this.initializeController();
+
+    expect(this.application.enableAutoRefresh).toHaveBeenCalled();
+    expect(this.application.disableAutoRefresh).not.toHaveBeenCalled();
+
+    this.application.serverGroups[0].instances.length = 501;
+    this.initializeController();
+    expect(this.application.disableAutoRefresh).toHaveBeenCalled();
+  });
+
+
+
+});

--- a/app/scripts/modules/applications/application.html
+++ b/app/scripts/modules/applications/application.html
@@ -2,14 +2,14 @@
   <div class="container">
     <h2 style="min-width: 200px">
       {{application.name}}
-      <a href ng-click="application.refreshImmediately(true)">
+      <a href ng-click="ctrl.toggleRefresh()">
         <span class="small glyphicon glyphicon-refresh"
               tooltip-html-unsafe="
                 <p>Auto refresh is <strong>{{application.refreshing ? 'in progress' : application.autoRefreshEnabled ? 'enabled' : 'disabled'}}</strong>.
-                   <br>(click <span class='small glyphicon glyphicon-refresh'></span> to refresh)</p>
+                   <br>(click <span class='small glyphicon glyphicon-refresh'></span> to {{application.autoRefreshEnabled ? 'disable' : 'enable'}})</p>
                 <p>Last refresh: {{application.lastRefresh | timestamp }} <br> ({{application.lastRefresh | relativeTime }})</p>
                 <p class='small'><strong>Note:</strong> Due to caching, data may be delayed up to 2 minutes</p>
-                {{!application.autoRefreshEnabled ? '<p class=small>For page performance reasons, we disable auto refresh whenever an application has more than 500 instances.</p>': ''}}"
+                {{!application.autoRefreshEnabled ? '<p class=small>To minimize performance issues in the browser, we disable auto refresh automatically whenever an application has more than 500 instances.</p>': ''}}"
               tooltip-placement="bottom"
               ng-class="{
               'refresh-enabled': application.autoRefreshEnabled,

--- a/app/scripts/modules/applications/applications.read.service.js
+++ b/app/scripts/modules/applications/applications.read.service.js
@@ -149,6 +149,7 @@ angular
         application.refreshImmediately = refreshApplication;
         application.disableAutoRefresh = disableAutoRefresh;
         application.enableAutoRefresh = enableAutoRefresh;
+        application.resumeAutoRefresh = resumeAutoRefresh;
         application.getCluster = getCluster;
         application.reloadTasks = reloadTasks;
         application.reloadExecutions = reloadExecutions;


### PR DESCRIPTION
Clicking the button now toggles auto-refresh: if it's on, it will disable it; if it's off, it will enable it and refresh the application immediately.
