### PR TITLE
allow provider selection in bakes

### DIFF
--- a/app/scripts/modules/pipelines/config/stages/bake/bakeStage.html
+++ b/app/scripts/modules/pipelines/config/stages/bake/bakeStage.html
@@ -4,125 +4,139 @@
   </h4>
 </div>
 <form class="form-horizontal" ng-if="!viewState.loading">
-  <div class="form-group">
-    <label class="col-md-2 col-md-offset-1 sm-label-left">Region</label>
+  <div class="form-group" if-multiple-providers>
+    <label class="col-md-2 col-md-offset-1 sm-label-left">Provider</label>
+
     <div class="col-md-6">
-      <select class="form-control input-sm" ng-model="stage.region" ng-options="region for region in regions">
-        <option value="">Select a region...</option>
-      </select>
+      <provider-selector ng-if="viewState.providerSelectionRequired" component="stage" field="cloudProviderType" read-only="!stage.isNew"></provider-selector>
     </div>
   </div>
-  <div class="form-group">
-    <div class="col-md-2 col-md-offset-1 sm-label-left">
-      <b>Package</b>
-      <help-field key="pipeline.config.bake.package"></help-field>
+  <div ng-if="viewState.providerSelected">
+    <div class="form-group">
+      <label class="col-md-2 col-md-offset-1 sm-label-left">Region</label>
+
+      <div class="col-md-6">
+        <select class="form-control input-sm" ng-model="stage.region" ng-options="region for region in regions">
+          <option value="">Select a region...</option>
+        </select>
+      </div>
     </div>
-    <div class="col-md-6">
-      <input type="text" class="form-control input-sm"
-             ng-model="stage.package"/>
+    <div class="form-group">
+      <div class="col-md-2 col-md-offset-1 sm-label-left">
+        <b>Package</b>
+        <help-field key="pipeline.config.bake.package"></help-field>
+      </div>
+      <div class="col-md-6">
+        <input type="text" class="form-control input-sm"
+               ng-model="stage.package"/>
+      </div>
     </div>
-  </div>
-  <div class="form-group">
-    <label class="col-md-2 col-md-offset-1 sm-label-left">Base OS</label>
-    <div class="col-md-6">
-      <label class="radio-inline" ng-repeat="baseOsOption in baseOsOptions">
-        <input type="radio"
-               ng-model="stage.baseOs"
-               ng-value="baseOsOption"/>
-        {{baseOsOption}}
-      </label>
-    </div>
-  </div>
-  <div class="form-group">
-    <label class="col-md-2 col-md-offset-1 sm-label-left">VM Type</label>
-    <div class="col-md-6">
-      <label class="radio-inline" ng-repeat="vmType in vmTypes">
-        <input type="radio"
-               ng-model="stage.vmType"
-               ng-value="vmType"/>
-        {{vmType | uppercase}}
-      </label>
-    </div>
-  </div>
-  <div class="form-group">
-    <label class="col-md-2 col-md-offset-1 sm-label-left">Store Type</label>
-    <div class="col-md-6">
-      <label class="radio-inline" ng-repeat="storeType in storeTypes">
-        <input type="radio"
-               ng-model="stage.storeType"
-               ng-value="storeType"/>
-        {{storeType | uppercase}}
-      </label>
-    </div>
-  </div>
-  <div class="form-group">
-    <label class="col-md-2 col-md-offset-1 sm-label-left">Base Label</label>
-    <div class="col-md-6">
-      <label class="radio-inline" ng-repeat="baseLabel in baseLabelOptions">
-        <input type="radio"
-               ng-model="stage.baseLabel"
-               ng-value="baseLabel"/>
-        {{baseLabel}}
-      </label>
-    </div>
-  </div>
-  <div class="form-group">
-    <div class="col-md-9 col-md-offset-1">
-      <div class="checkbox">
-        <label>
-          <input type="checkbox" ng-model="stage.showAdvancedOptions">
-          <strong>Show Advanced Options</strong>
+    <div class="form-group">
+      <label class="col-md-2 col-md-offset-1 sm-label-left">Base OS</label>
+
+      <div class="col-md-6">
+        <label class="radio-inline" ng-repeat="baseOsOption in baseOsOptions">
+          <input type="radio"
+                 ng-model="stage.baseOs"
+                 ng-value="baseOsOption"/>
+          {{baseOsOption}}
         </label>
       </div>
     </div>
-  </div>
-  <div ng-class="{collapse: stage.showAdvancedOptions !== true, collapse.in: stage.showAdvancedOptions === true}">
-    <div class="form-group">
-      <label class="col-md-2 col-md-offset-1 sm-label-left">Base Name</label>
+    <div class="form-group" ng-if="stage.cloudProviderType === 'aws'">
+      <label class="col-md-2 col-md-offset-1 sm-label-left">VM Type</label>
 
       <div class="col-md-6">
-        <input type="text" class="form-control input-sm"
-               ng-model="stage.baseName"/>
+        <label class="radio-inline" ng-repeat="vmType in vmTypes">
+          <input type="radio"
+                 ng-model="stage.vmType"
+                 ng-value="vmType"/>
+          {{vmType | uppercase}}
+        </label>
+      </div>
+    </div>
+    <div class="form-group" ng-if="stage.cloudProviderType === 'aws'">
+      <label class="col-md-2 col-md-offset-1 sm-label-left">Store Type</label>
+
+      <div class="col-md-6">
+        <label class="radio-inline" ng-repeat="storeType in storeTypes">
+          <input type="radio"
+                 ng-model="stage.storeType"
+                 ng-value="storeType"/>
+          {{storeType | uppercase}}
+        </label>
       </div>
     </div>
     <div class="form-group">
-      <div class="col-md-2 col-md-offset-1 sm-label-left">
-        <b>Base AMI</b>
-        <help-field key="pipeline.config.bake.baseAmi"></help-field>
-      </div>
+      <label class="col-md-2 col-md-offset-1 sm-label-left">Base Label</label>
+
       <div class="col-md-6">
-        <input type="text" class="form-control input-sm"
-               ng-model="stage.baseAmi"/>
+        <label class="radio-inline" ng-repeat="baseLabel in baseLabelOptions">
+          <input type="radio"
+                 ng-model="stage.baseLabel"
+                 ng-value="baseLabel"/>
+          {{baseLabel}}
+        </label>
       </div>
     </div>
-    <div class="form-group">
-      <div class="col-md-2 col-md-offset-1 sm-label-left">
-        <b>AMI Name</b>
-        <help-field key="pipeline.config.bake.amiName"></help-field>
-      </div>
-      <div class="col-md-6">
-        <input type="text" class="form-control input-sm"
-               ng-model="stage.amiName"/>
-      </div>
-    </div>
-    <div class="form-group">
-      <div class="col-md-2 col-md-offset-1 sm-label-left">
-        <b>AMI Suffix</b>
-        <help-field key="pipeline.config.bake.amiSuffix"></help-field>
-      </div>
-      <div class="col-md-6">
-        <input type="text" class="form-control input-sm"
-               ng-model="stage.amiSuffix"/>
+    <div class="form-group" ng-if="stage.cloudProviderType === 'aws'">
+      <div class="col-md-9 col-md-offset-1">
+        <div class="checkbox">
+          <label>
+            <input type="checkbox" ng-model="stage.showAdvancedOptions">
+            <strong>Show Advanced Options</strong>
+          </label>
+        </div>
       </div>
     </div>
-    <div class="form-group">
-      <div class="col-md-2 col-md-offset-1 sm-label-left">
-        <b>Use Enhanced Networking</b>
-        <help-field key="pipeline.config.bake.enhancedNetworking"></help-field>
+    <div ng-class="{collapse: stage.showAdvancedOptions !== true, collapse.in: stage.showAdvancedOptions === true}">
+      <div class="form-group">
+        <label class="col-md-2 col-md-offset-1 sm-label-left">Base Name</label>
+
+        <div class="col-md-6">
+          <input type="text" class="form-control input-sm"
+                 ng-model="stage.baseName"/>
+        </div>
       </div>
-      <div class="col-md-6">
-        <input type="checkbox"
-               ng-model="stage.enhancedNetworking"/>
+      <div class="form-group">
+        <div class="col-md-2 col-md-offset-1 sm-label-left">
+          <b>Base AMI</b>
+          <help-field key="pipeline.config.bake.baseAmi"></help-field>
+        </div>
+        <div class="col-md-6">
+          <input type="text" class="form-control input-sm"
+                 ng-model="stage.baseAmi"/>
+        </div>
+      </div>
+      <div class="form-group">
+        <div class="col-md-2 col-md-offset-1 sm-label-left">
+          <b>AMI Name</b>
+          <help-field key="pipeline.config.bake.amiName"></help-field>
+        </div>
+        <div class="col-md-6">
+          <input type="text" class="form-control input-sm"
+                 ng-model="stage.amiName"/>
+        </div>
+      </div>
+      <div class="form-group">
+        <div class="col-md-2 col-md-offset-1 sm-label-left">
+          <b>AMI Suffix</b>
+          <help-field key="pipeline.config.bake.amiSuffix"></help-field>
+        </div>
+        <div class="col-md-6">
+          <input type="text" class="form-control input-sm"
+                 ng-model="stage.amiSuffix"/>
+        </div>
+      </div>
+      <div class="form-group">
+        <div class="col-md-2 col-md-offset-1 sm-label-left">
+          <b>Use Enhanced Networking</b>
+          <help-field key="pipeline.config.bake.enhancedNetworking"></help-field>
+        </div>
+        <div class="col-md-6">
+          <input type="checkbox"
+                 ng-model="stage.enhancedNetworking"/>
+        </div>
       </div>
     </div>
   </div>

--- a/app/scripts/modules/pipelines/config/stages/bake/bakeStage.module.js
+++ b/app/scripts/modules/pipelines/config/stages/bake/bakeStage.module.js
@@ -4,4 +4,6 @@ angular.module('deckApp.pipelines.stage.bake', [
   'deckApp.pipelines.stage',
   'deckApp.pipelines.stage.core',
   'deckApp.pipelines.stage.bake.executionDetails.controller',
+  'deckApp.providerSelection.directive',
+  'deckApp.account.service',
 ]);

--- a/app/scripts/modules/pipelines/config/stages/bake/bakery.service.js
+++ b/app/scripts/modules/pipelines/config/stages/bake/bakery.service.js
@@ -1,10 +1,16 @@
 'use strict';
 
+// TODO: Move everything in here to config
 angular.module('deckApp.pipelines.stage.bake')
   .factory('bakeryService', function($q) {
 
-    function getRegions() {
-      return $q.when(['us-east-1', 'us-west-1', 'us-west-2', 'eu-west-1']);
+    function getRegions(provider) {
+      if (!provider || provider === 'aws') {
+        return $q.when(['us-east-1', 'us-west-1', 'us-west-2', 'eu-west-1']);
+      }
+      if (provider === 'gce') {
+        return $q.when(['asia-east1', 'us-central1', 'europe-west1']);
+      }
     }
 
     function getBaseOsOptions() {

--- a/app/scripts/modules/providerSelection/providerSelector.directive.js
+++ b/app/scripts/modules/providerSelection/providerSelector.directive.js
@@ -1,0 +1,32 @@
+'use strict';
+
+angular.module('deckApp.providerSelection.directive', [
+  'deckApp.account.service',
+])
+  .directive('providerSelector', function(accountService) {
+    return {
+      restrict: 'E',
+      scope: {
+        component: '=',
+        field: '@',
+        readOnly: '=',
+      },
+      templateUrl: 'scripts/modules/providerSelection/providerSelector.html',
+      link: function(scope) {
+        scope.initialized = false;
+        accountService.listProviders().then(function(providers) {
+          scope.initialized = true;
+          if (!providers.length) {
+            scope.component[scope.field] = 'aws';
+          }
+          if (providers.length === 1) {
+            scope.component[scope.field] = providers[0];
+          }
+          if (providers.length > 1) {
+            scope.providers = providers;
+            scope.showSelector = true;
+          }
+        });
+      },
+    };
+  });

--- a/app/scripts/modules/providerSelection/providerSelector.html
+++ b/app/scripts/modules/providerSelection/providerSelector.html
@@ -1,0 +1,15 @@
+<ui-select ng-model="component[field]"
+           ng-if="initialized && showSelector && !readOnly"
+           class="form-control input-sm">
+  <ui-select-match placeholder="Select a provider">
+    <span class="icon icon-server-group icon-{{$select.selected}} small"></span>
+    {{$select.selected}}
+  </ui-select-match>
+  <ui-select-choices repeat="provider in providers | filter: $select.search">
+    <h5><span class="icon icon-server-group icon-{{provider}} small"></span> {{provider}}</h5>
+  </ui-select-choices>
+</ui-select>
+<p class="form-control-static" ng-if="readOnly">
+  <span class="icon icon-server-group icon-{{component[field]}} small"></span>
+  {{component[field]}}
+</p>

--- a/app/styles/application.less
+++ b/app/styles/application.less
@@ -111,3 +111,9 @@
     font-size: 90%;
   }
 }
+
+.select2-highlighted {
+  .icon {
+    color: inherit;
+  }
+}


### PR DESCRIPTION
@duftler If you're good with this, go ahead and merge. I've tested it a bit on roscoapp and it seems to behave as expected: only showing the AWS fields when AWS is selected, requiring provider selection before surfacing additional fields, defaulting to nothing.

![screen shot 2015-04-13 at 11 01 45 pm](https://cloud.githubusercontent.com/assets/73450/7131491/e4242b7e-e234-11e4-9427-e535c3d07094.png)
![screen shot 2015-04-13 at 11 01 32 pm](https://cloud.githubusercontent.com/assets/73450/7131492/e427e5d4-e234-11e4-8e14-e74aec1721b6.png)
