### PR TITLE
refresh cache if declared security groups are missing

### DIFF
--- a/app/scripts/modules/applications/applications.read.service.js
+++ b/app/scripts/modules/applications/applications.read.service.js
@@ -245,9 +245,15 @@ angular
               if (application.tasks) {
                 clusterService.addTasksToServerGroups(application);
               }
-              securityGroupReader.attachSecurityGroups(application, results.securityGroups, applicationLoader.securityGroups);
-
-              return application;
+              return securityGroupReader.attachSecurityGroups(application, results.securityGroups, applicationLoader.securityGroups, true)
+                .then(
+                  function() {
+                    return application;
+                  },
+                  function(err) {
+                    $exceptionHandler(err, 'Failed to load application');
+                  }
+                );
             }, function(err) {
               $exceptionHandler(err, 'Failed to load application');
             });

--- a/app/scripts/modules/securityGroups/securityGroup.read.service.spec.js
+++ b/app/scripts/modules/securityGroups/securityGroup.read.service.spec.js
@@ -2,22 +2,89 @@
 
 describe('Service: securityGroupReader', function () {
 
-  //NOTE: This is only testing the service dependencies. Please add more tests.
-
-  var securityGroupReader;
+  var securityGroupReader,
+    infrastructureCaches,
+    $http,
+    settings,
+    $exceptionHandler,
+    $scope;
 
   beforeEach(
     module('deckApp.securityGroup.read.service')
   );
 
   beforeEach(
-    inject(function (_securityGroupReader_) {
+    inject(function (_securityGroupReader_, _infrastructureCaches_, $httpBackend, _settings_, _$exceptionHandler_, $rootScope) {
       securityGroupReader = _securityGroupReader_;
+      infrastructureCaches = _infrastructureCaches_;
+      $http = $httpBackend;
+      settings = _settings_;
+      $exceptionHandler = _$exceptionHandler_;
+      $scope = $rootScope.$new();
     })
   );
 
-  it('should instantiate the controller', function () {
-    expect(securityGroupReader).toBeDefined();
+  it('attaches load balancer to security group usages', function() {
+    var application = {
+      accounts: [ 'test' ],
+      serverGroups: [],
+      loadBalancers: [
+        {
+          name: 'my-elb',
+          account: 'test',
+          region: 'us-east-1',
+          securityGroups: [
+            'not-cached',
+          ]
+        }
+      ]
+    };
+
+    var securityGroups = [
+      { account: 'test',
+        securityGroups: {
+          'us-east-1': [
+            { name: 'not-cached', id: 'not-cached-id', vpcId: null }
+          ]
+        }
+      }
+    ];
+
+    securityGroupReader.attachSecurityGroups(application, securityGroups, [], true);
+    $scope.$digest();
+    var group = application.securityGroups[0];
+    expect(group.name).toBe('not-cached');
+    expect(group.usages.loadBalancers[0]).toBe(application.loadBalancers[0]);
+  });
+
+  it('should clear cache, then reload security groups and try again if a security group is not found', function () {
+    var application = {
+      accounts: [ 'test' ],
+      serverGroups: [],
+      loadBalancers: [
+        {
+          name: 'my-elb',
+          account: 'test',
+          region: 'us-east-1',
+          securityGroups: [
+            'not-cached',
+          ]
+        }
+      ]
+    };
+
+    $http.expectGET('/securityGroups/test').respond(200, {
+      'us-east-1': [
+        { name: 'not-cached', id: 'not-cached-id', vpcId: null }
+      ]
+    });
+
+    securityGroupReader.attachSecurityGroups(application, [], [], true);
+    $http.flush();
+    var group = application.securityGroups[0];
+    expect(group.name).toBe('not-cached');
+    expect(group.usages.loadBalancers[0]).toBe(application.loadBalancers[0]);
+
   });
 });
 


### PR DESCRIPTION
If a security group is declared on a load balancer or server group, or one of the security groups found via search, clear the cache, then try to attach again.

This should fix caching issues caused by another user creating the security group, or by the security group being created outside Deck.

Cache invalidation is hard.
