### PR TITLE
do not wait for force refresh message on enable asg

### DIFF
--- a/app/scripts/modules/serverGroups/details/aws/serverGroupDetails.aws.controller.js
+++ b/app/scripts/modules/serverGroups/details/aws/serverGroupDetails.aws.controller.js
@@ -192,8 +192,6 @@ angular.module('deckApp.serverGroup.details.aws.controller', [
       var taskMonitor = {
         application: application,
         title: 'Enabling ' + serverGroup.name,
-        forceRefreshMessage: 'Refreshing application...',
-        forceRefreshEnabled: true
       };
 
       var submitMethod = function () {


### PR DESCRIPTION
Enable ASG does not have a forceRefresh step, so the task shows an error message because it never sees the forceRefresh happening.
