### PR TITLE
Improve behavior of Region control on bake stage.

### DIFF
--- a/app/scripts/modules/pipelines/config/stages/bake/bakeExecutionDetails.html
+++ b/app/scripts/modules/pipelines/config/stages/bake/bakeExecutionDetails.html
@@ -8,8 +8,8 @@
           <dd if-multiple-providers>{{provider}}</dd>
           <dt>Image</dt>
           <dd>{{stage.context.ami}}</dd>
-          <dt ng-if="provider !== 'docker'">Region</dt>
-          <dd ng-if="provider !== 'docker'">{{stage.context.region}}</dd>
+          <dt>Region</dt>
+          <dd>{{stage.context.region}}</dd>
           <dt>Package</dt>
           <dd>{{stage.context.package}}</dd>
         </dl>

--- a/app/scripts/modules/pipelines/config/stages/bake/bakeStage.html
+++ b/app/scripts/modules/pipelines/config/stages/bake/bakeStage.html
@@ -12,7 +12,7 @@
     </div>
   </div>
   <div ng-if="viewState.providerSelected">
-    <div class="form-group" ng-if="!stage.cloudProviderType || stage.cloudProviderType === 'aws'">
+    <div class="form-group">
       <label class="col-md-2 col-md-offset-1 sm-label-left">Region</label>
 
       <div class="col-md-6">

--- a/app/scripts/modules/pipelines/config/stages/bake/bakeStage.js
+++ b/app/scripts/modules/pipelines/config/stages/bake/bakeStage.js
@@ -56,7 +56,16 @@ angular.module('deckApp.pipelines.stage.bake')
         vmTypes: bakeryService.getVmTypes(),
         storeTypes: bakeryService.getStoreTypes(),
       }).then(function(results) {
-        $scope.regions = results.regions;
+        if (!$scope.stage.cloudProviderType || $scope.stage.cloudProviderType === 'aws') {
+          $scope.regions = results.regions;
+        } else {
+          $scope.regions  = ["global"];
+        }
+        if ($scope.regions.length === 1) {
+          $scope.stage.region = $scope.regions[0];
+        } else if ($scope.regions.indexOf($scope.stage.region) === -1) {
+          delete $scope.stage.region;
+        }
         $scope.baseOsOptions = results.baseOsOptions;
         $scope.vmTypes = results.vmTypes;
         $scope.baseLabelOptions = results.baseLabelOptions;


### PR DESCRIPTION
Always show Region control on Bake stage ui and on execution ui.
Populate choices with provider-specific choices if AWS, with exactly ['global'] if not.
When switching between providers, select the first region if there is exactly one choice.
If not, check if the region is in the new list of choices. If it is, leave it alone. If not, clear it.
This change was motivated primarily by orca-bakery being unhappy when receiving a bake request with 0 regions.
So, decided to explicitly specify 'global' as the region when not on AWS.
