### PR TITLE
allow closing details by clicking on stage bar

### DIFF
--- a/app/scripts/modules/delivery/executionBar.controller.js
+++ b/app/scripts/modules/delivery/executionBar.controller.js
@@ -4,7 +4,7 @@ angular.module('deckApp.delivery.executionBar.controller', [
   'deckApp.pipelines.config',
   'ui.router',
 ])
-  .controller('executionBar', function($scope, $filter, $stateParams, pipelineConfig) {
+  .controller('executionBar', function($scope, $filter, $stateParams, pipelineConfig, $state) {
     var controller = this;
 
     controller.getStageWidth = function() {
@@ -37,6 +37,18 @@ angular.module('deckApp.delivery.executionBar.controller', [
         'background-color': controller.getStageColor(stage),
         opacity: controller.getStageOpacity(stage),
       };
+    };
+
+    controller.toggleDetails = function(executionId, stageIndex) {
+      if ($state.includes('**.execution', {executionId: executionId, stage: stageIndex})) {
+        $state.go('^');
+      } else {
+        if ($state.includes('**.execution')) {
+          $state.go('^.execution', {executionId: executionId, stage: stageIndex, step: 0});
+        } else {
+          $state.go('.execution', {executionId: executionId, stage: stageIndex, step: 0});
+        }
+      }
     };
 
     controller.getLabelTemplate = function(stage) {

--- a/app/scripts/modules/delivery/executionBar.html
+++ b/app/scripts/modules/delivery/executionBar.html
@@ -2,7 +2,7 @@
   <div class="col-md-12">
     <div ng-repeat="stage in execution.stageSummaries"
          class="execution-stage"
-         ui-sref=".execution({executionId: execution.id, stage: $index, step: 0})"
+         ng-click="ctrl.toggleDetails(execution.id, $index); $event.stopPropagation()"
          style="width: {{ctrl.getStageWidth()}}">
       <div class="execution-stage-bar"
            ng-class="{glowing: stage.isRunning }"


### PR DESCRIPTION
If the stage is already open, let users close the details by clicking on the stage bar or label again instead of making them click the (x), which is on the far right side of the execution details.
