### PR TITLE
SPIN-346: Fixing missing VM attributes from bakeStage

### DIFF
--- a/app/scripts/modules/pipelines/config/stages/bake/bakeStage.js
+++ b/app/scripts/modules/pipelines/config/stages/bake/bakeStage.js
@@ -40,6 +40,7 @@ angular.module('deckApp.pipelines.stage.bake')
         $scope.viewState.loading = false;
       } else {
         $scope.viewState.providerSelectionRequired = false;
+        $scope.stage.cloudProviderType = $scope.stage.cloudProviderType || _.first(providers);
       }
       ctrl.providerSelected();
     });


### PR DESCRIPTION
The VM options in the bake stage where missing b/c the cloudProviderType was not being set on the stage object.
It is possible that this is a bug in orca. However this fix address the issue now and will be ok if orca ever returns this value.
