### PR TITLE
SPIN-346: Fixing missing VM attributes from bakeStage

### DIFF
--- a/app/scripts/modules/pipelines/config/stages/bake/bakeStage.html
+++ b/app/scripts/modules/pipelines/config/stages/bake/bakeStage.html
@@ -43,7 +43,7 @@
         </label>
       </div>
     </div>
-    <div class="form-group" ng-if="stage.cloudProviderType === 'aws'">
+    <div class="form-group" ng-if="stage.cloudProviderType === 'aws' || stage.cloudProviderType === undefined">
       <label class="col-md-2 col-md-offset-1 sm-label-left">VM Type</label>
 
       <div class="col-md-6">

--- a/app/scripts/modules/pipelines/config/stages/bake/bakeStage.js
+++ b/app/scripts/modules/pipelines/config/stages/bake/bakeStage.js
@@ -40,13 +40,18 @@ angular.module('deckApp.pipelines.stage.bake')
         $scope.viewState.loading = false;
       } else {
         $scope.viewState.providerSelectionRequired = false;
-        $scope.stage.cloudProviderType = $scope.stage.cloudProviderType || _.first(providers);
       }
       ctrl.providerSelected();
     });
 
     this.providerSelected = function() {
       if (!$scope.stage.cloudProviderType && $scope.viewState.providerSelectionRequired) {
+        bakeryService.getVmTypes().then( function(vmTypes) {
+          $scope.vmTypes = vmTypes;
+        } );
+        if (!$scope.stage.vmType && $scope.vmTypes && $scope.vmTypes.length) {
+          $scope.stage.vmType = $scope.vmTypes[0];
+        }
         return;
       }
       $scope.viewState.providerSelected = true;


### PR DESCRIPTION
First implemetation was passing the cloudProviderType and causing the Bakery barf.  This fix just shows the vm types if there cloudProviderType is 'undefined' or 'aws'
