### PR TITLE
Parse build details by build number

### DIFF
--- a/app/scripts/modules/delivery/buildDisplayName.filter.js
+++ b/app/scripts/modules/delivery/buildDisplayName.filter.js
@@ -4,8 +4,8 @@ angular.module('deckApp.delivery.buildDisplayName.filter', [])
   .filter('buildDisplayName', function() {
     return function(input) {
       var formattedInput = '';
-      if( input.contains(':') ){
-        formattedInput = input.split(':').pop();
+      if( input.fullDisplayName !== undefined ){
+        formattedInput = input.fullDisplayName.split('#' + input.number).pop();
       }
       return formattedInput;
     };

--- a/app/scripts/modules/delivery/manualPipelineExecution.html
+++ b/app/scripts/modules/delivery/manualPipelineExecution.html
@@ -72,7 +72,7 @@
               <ui-select-match placeholder="Select...">
                 <span>
                   <strong>Build {{$select.selected.number}}</strong>
-                  {{$select.selected.fullDisplayName | buildDisplayName}}
+                  {{$select.selected | buildDisplayName}}
                   ({{$select.selected.timestamp | timestamp}} -
                   {{$select.selected.result}})
                 </span>
@@ -80,7 +80,7 @@
               <ui-select-choices repeat="build in builds | anyFieldFilter: {number: $select.search, status: $select.search}">
               <span>
                   <strong>Build {{build.number}}</strong>
-                  {{build.fullDisplayName | buildDisplayName}}
+                  {{build | buildDisplayName}}
                   ({{build.timestamp | timestamp}} -
                   {{build.result}})
                 </span>


### PR DESCRIPTION
the previous implementation of build details naively assumed that build names in jenkins were split via ':'. Found a few projects that don't follow this convention, so instead we split build details by the build number. 
