### PR TITLE
attach filter params to instance, server group searches

### DIFF
--- a/app/scripts/modules/search/global/globalSearch.controller.js
+++ b/app/scripts/modules/search/global/globalSearch.controller.js
@@ -74,6 +74,11 @@ angular.module('deckApp.search.global')
           acct[result.account] = true;
           ClusterFilterModel.sortFilter.account = acct;
         }
+        if (result.region) {
+          var reg = {};
+          reg[result.region] = true;
+          ClusterFilterModel.sortFilter.region = reg;
+        }
         if ($stateParams.application === result.application) {
           clusterFilterService.updateClusterGroups();
         }

--- a/app/scripts/services/urlbuilder.js
+++ b/app/scripts/services/urlbuilder.js
@@ -10,8 +10,6 @@ angular.module('deckApp.urlBuilder', ['ui.router'])
           'home.applications.application.insight.clusters.serverGroup',
           {
             application: input.application,
-            cluster: input.cluster,
-            account: input.account,
             accountId: input.account,
             region: input.region,
             serverGroup: input.serverGroup,
@@ -19,7 +17,7 @@ angular.module('deckApp.urlBuilder', ['ui.router'])
           },
           { inherit: false }
         );
-        return buildUrl(href, {q: input.serverGroup});
+        return buildUrl(href, {q: input.serverGroup, acct: input.account, reg: input.region});
       },
       // url for a single instance
       'instances': function(input) {
@@ -34,18 +32,16 @@ angular.module('deckApp.urlBuilder', ['ui.router'])
             }
           );
         }
-        return $state.href(
+        var href = $state.href(
           'home.applications.application.insight.clusters.instanceDetails',
           {
             application: input.application,
-            cluster: input.cluster,
-            accountId: input.account,
             instanceId: input.instanceId,
-            account: input.account,
             provider: input.provider,
           },
           { inherit: false }
         );
+        return buildUrl(href, {q: input.serverGroup, acct: input.account, reg: input.region});
       },
       // url for a single cluster
       'clusters': function(input) {


### PR DESCRIPTION
Fixing a month-old regression where we are not filtering clusters correctly when deep-linking to instances and server groups via global search.
