### PR TITLE
squash vpc params if not present

### DIFF
--- a/app/scripts/providers/states.js
+++ b/app/scripts/providers/states.js
@@ -99,7 +99,7 @@ angular.module('deckApp.states', [
         params: {
           vpcId: {
             value: null,
-            squash: 'ec2-classic',
+            squash: true,
           },
         },
         views: {
@@ -140,7 +140,7 @@ angular.module('deckApp.states', [
         params: {
           vpcId: {
             value: null,
-            squash: 'ec2-classic',
+            squash: true,
           },
         },
         views: {


### PR DESCRIPTION
For some reason, this wasn't working when I tried it previously but now seems to be working as expected.

Instead of filling the "vpcId" path variable with "ec2-classic" when no VPC is specified for a load balancer or security group, angular-ui will "squash" it, removing it from the URL altogether.

Example:
/applications/myApp/connections/securityGroupDetails/aws/prod/eu-west-1/ec2-classic/my-group
becomes
/applications/myApp/connections/securityGroupDetails/aws/prod/eu-west-1/my-group
