### PR TITLE
remove empty fields on bake stage

### DIFF
--- a/app/scripts/modules/pipelines/config/stages/bake/bakeStage.js
+++ b/app/scripts/modules/pipelines/config/stages/bake/bakeStage.js
@@ -19,7 +19,7 @@ angular.module('deckApp.pipelines.stage.bake')
       ],
     });
   })
-  .controller('BakeStageCtrl', function($scope, stage, bakeryService, $q, authenticationService, accountService) {
+  .controller('BakeStageCtrl', function($scope, stage, bakeryService, $q, _, authenticationService, accountService) {
     var ctrl = this;
 
     $scope.stage = stage;
@@ -84,6 +84,14 @@ angular.module('deckApp.pipelines.stage.bake')
       });
     };
 
-    $scope.$watch('stage.cloudProviderType', this.providerSelected);
+    function deleteEmptyProperties() {
+      _.forOwn($scope.stage, function(val, key) {
+        if (val === '') {
+          delete $scope.stage[key];
+        }
+      });
+    }
 
+    $scope.$watch('stage.cloudProviderType', this.providerSelected);
+    $scope.$watch('stage', deleteEmptyProperties, true);
   });

--- a/app/scripts/modules/pipelines/config/stages/bake/bakeStage.module.js
+++ b/app/scripts/modules/pipelines/config/stages/bake/bakeStage.module.js
@@ -6,4 +6,5 @@ angular.module('deckApp.pipelines.stage.bake', [
   'deckApp.pipelines.stage.bake.executionDetails.controller',
   'deckApp.providerSelection.directive',
   'deckApp.account.service',
+  'deckApp.utils.lodash',
 ]);


### PR DESCRIPTION
The bakery barfs on invalid or empty fields (at least it does on `baseAmi`), so clear them out if they're empty.
