### PR TITLE
allow users to specify enable/disable parallel execution

### DIFF
--- a/app/scripts/modules/pipelines/config/actions/create/createPipelineModal.controller.js
+++ b/app/scripts/modules/pipelines/config/actions/create/createPipelineModal.controller.js
@@ -18,7 +18,8 @@ angular.module('deckApp.pipelines.create.controller', [
     $scope.existingNames = _.pluck($scope.templates, 'name');
 
     $scope.command = {
-      template: noTemplate
+      template: noTemplate,
+      parallel: true,
     };
 
     this.cancel = $modalInstance.dismiss;
@@ -27,6 +28,9 @@ angular.module('deckApp.pipelines.create.controller', [
       var template = $scope.command.template;
       if (template.fromServer) {
         template = angular.copy(template.plain());
+      }
+      if (template === noTemplate && $scope.command.parallel) {
+        pipelineConfigService.enableParallelExecution(template);
       }
       template.name = $scope.command.name;
       if (target === 'top') {

--- a/app/scripts/modules/pipelines/config/actions/create/createPipelineModal.html
+++ b/app/scripts/modules/pipelines/config/actions/create/createPipelineModal.html
@@ -58,6 +58,14 @@
           </ui-select>
         </div>
       </div>
+      <div class="checkbox col-md-offset-3" ng-if="!command.template.id">
+        <label>
+          <input type="checkbox" ng-model="command.parallel"/>
+          Enable parallel stage execution
+          <help-field key="pipeline.config.parallel.execution"></help-field>
+        </label>
+      </div>
+
     </form>
   </div>
   <div class="modal-footer">

--- a/app/scripts/modules/pipelines/config/actions/disableParallel/disableParallel.controller.js
+++ b/app/scripts/modules/pipelines/config/actions/disableParallel/disableParallel.controller.js
@@ -1,0 +1,17 @@
+'use strict';
+
+angular.module('deckApp.pipelines.disableParallel', [
+  'deckApp.pipelines.config.service',
+])
+  .controller('DisableParallelModalCtrl', function($scope, pipeline, _, $modalInstance, pipelineConfigService) {
+
+    this.cancel = $modalInstance.dismiss;
+
+    $scope.pipeline = pipeline;
+
+    this.disableParallel = function() {
+      pipelineConfigService.disableParallelExecution(pipeline);
+      $modalInstance.close();
+    };
+
+  });

--- a/app/scripts/modules/pipelines/config/actions/disableParallel/disableParallel.html
+++ b/app/scripts/modules/pipelines/config/actions/disableParallel/disableParallel.html
@@ -1,0 +1,23 @@
+<div modal-page>
+  <modal-close></modal-close>
+  <div class="modal-header">
+    <h3>Enable Parallel Execution</h3>
+  </div>
+  <div class="modal-body">
+    <form role="form" name="form" class="form-horizontal">
+      <div class="form-group">
+        <div class="col-md-12">
+          <p>Disabling parallel execution will force each stage to run sequentially.</p>
+          <p>Are you sure you want to disable parallel execution for the pipeline: {{pipeline.name}}?</p>
+        </div>
+      </div>
+    </form>
+  </div>
+  <div class="modal-footer">
+    <button class="btn btn-default" ng-click="disableParallelModalCtrl.cancel()">Cancel</button>
+    <button class="btn btn-primary"
+            ng-click="disableParallelModalCtrl.disableParallel()">
+      <span class="glyphicon glyphicon-ok-circle"></span> Disable Parallel Execution
+    </button>
+  </div>
+</div>

--- a/app/scripts/modules/pipelines/config/actions/enableParallel/enableParallel.controller.js
+++ b/app/scripts/modules/pipelines/config/actions/enableParallel/enableParallel.controller.js
@@ -1,0 +1,17 @@
+'use strict';
+
+angular.module('deckApp.pipelines.enableParallel', [
+  'deckApp.pipelines.config.service',
+])
+  .controller('EnableParallelModalCtrl', function($scope, pipeline, _, $modalInstance, pipelineConfigService) {
+
+    this.cancel = $modalInstance.dismiss;
+
+    $scope.pipeline = pipeline;
+
+    this.makeParallel = function() {
+      pipelineConfigService.enableParallelExecution(pipeline);
+      $modalInstance.close();
+    };
+
+  });

--- a/app/scripts/modules/pipelines/config/actions/enableParallel/enableParallel.html
+++ b/app/scripts/modules/pipelines/config/actions/enableParallel/enableParallel.html
@@ -1,0 +1,23 @@
+<div modal-page>
+  <modal-close></modal-close>
+  <div class="modal-header">
+    <h3>Enable Parallel Execution</h3>
+  </div>
+  <div class="modal-body">
+    <form role="form" name="form" class="form-horizontal">
+      <div class="form-group">
+        <div class="col-md-12">
+          <p>Enabling parallel execution allows you to run some stages concurrently.</p>
+          <p>Are you sure you want to enable parallel execution for the pipeline: {{pipeline.name}}?</p>
+        </div>
+      </div>
+    </form>
+  </div>
+  <div class="modal-footer">
+    <button class="btn btn-default" ng-click="enableParallelModalCtrl.cancel()">Cancel</button>
+    <button class="btn btn-primary"
+            ng-click="enableParallelModalCtrl.makeParallel()">
+      <span class="glyphicon glyphicon-ok-circle"></span> Enable Parallel Execution
+    </button>
+  </div>
+</div>

--- a/app/scripts/modules/pipelines/config/pipelineConfigurer.html
+++ b/app/scripts/modules/pipelines/config/pipelineConfigurer.html
@@ -15,10 +15,12 @@
           <li><a href ng-click="pipelineConfigurerCtrl.renamePipeline()">Rename</a></li>
           <li><a href ng-click="pipelineConfigurerCtrl.deletePipeline()">Delete</a></li>
           <li><a href ng-click="pipelineConfigurerCtrl.editPipelineJson()">Edit as JSON</a></li>
+          <li ng-if="pipeline.parallel"><a href ng-click="pipelineConfigurerCtrl.disableParallel()">Disable parallel execution</a></li>
+          <li ng-if="!pipeline.parallel"><a href ng-click="pipelineConfigurerCtrl.enableParallel()">Enable parallel execution</a></li>
         </ul>
       </div>
     </div>
-    <div class="row pipeline-config" ng-if="!viewState.parallelPipelinesEnabled">
+    <div class="row pipeline-config" ng-if="!pipeline.parallel">
       <div class="col-md-12">
         <ul class="nav-pipeline-config">
           <li class="config-section">
@@ -46,7 +48,7 @@
         </ul>
       </div>
     </div>
-    <div ng-if="viewState.parallelPipelinesEnabled && viewState.expanded">
+    <div ng-if="pipeline.parallel && viewState.expanded">
       <pipeline-graph view-state="viewState" pipeline="pipeline" on-node-click="pipelineConfigurerCtrl.navigateTo"></pipeline-graph>
       <div class="row">
         <div class="col-md-12">

--- a/app/scripts/modules/pipelines/config/services/pipelineConfigService.js
+++ b/app/scripts/modules/pipelines/config/services/pipelineConfigService.js
@@ -107,6 +107,30 @@ angular.module('deckApp.pipelines.config.service', [
       return _.uniq(upstreamStages);
     }
 
+    function enableParallelExecution(pipeline) {
+      pipeline.stageCounter = 0;
+      pipeline.stages.forEach(function(stage) {
+        pipeline.stageCounter++;
+        stage.refId = pipeline.stageCounter + '';
+        if (pipeline.stageCounter > 1) {
+          stage.requisiteStageRefIds = [(pipeline.stageCounter - 1) + ''];
+        } else {
+          stage.requisiteStageRefIds = [];
+        }
+      });
+      pipeline.parallel = true;
+      pipeline.stageCounter = pipeline.stages.length;
+    }
+
+    function disableParallelExecution(pipeline) {
+      delete pipeline.stageCounter;
+      pipeline.stages.forEach(function(stage) {
+        delete stage.refId;
+        delete stage.requisiteStageRefIds;
+      });
+      delete pipeline.parallel;
+    }
+
     return {
       getPipelinesForApplication: getPipelinesForApplication,
       savePipeline: savePipeline,
@@ -116,6 +140,8 @@ angular.module('deckApp.pipelines.config.service', [
       buildViewStateCacheKey: buildViewStateCacheKey,
       getDependencyCandidateStages: getDependencyCandidateStages,
       getAllUpstreamDependencies: getAllUpstreamDependencies,
+      enableParallelExecution: enableParallelExecution,
+      disableParallelExecution: disableParallelExecution,
     };
 
   });

--- a/app/scripts/modules/pipelines/config/stages/stage.html
+++ b/app/scripts/modules/pipelines/config/stages/stage.html
@@ -35,7 +35,7 @@
           <input type="text" class="form-control input-sm" required ng-model="stage.name"/>
         </div>
       </div>
-      <div class="form-group" ng-if="viewState.parallelPipelinesEnabled">
+      <div class="form-group" ng-if="pipeline.parallel">
         <label class="col-md-2 col-md-offset-1 sm-label-left">
           Depends On
           <help-field key="pipeline.config.dependsOn"></help-field>

--- a/app/scripts/modules/pipelines/config/stages/stage.js
+++ b/app/scripts/modules/pipelines/config/stages/stage.js
@@ -39,7 +39,7 @@ angular.module('deckApp.pipelines.stageConfig', [
     };
 
     $scope.updateAvailableDependencyStages = function() {
-      if (!$scope.viewState.parallelPipelinesEnabled) {
+      if (!$scope.pipeline.parallel) {
         return;
       }
       var availableDependencyStages = pipelineConfigService.getDependencyCandidateStages($scope.pipeline, $scope.stage);
@@ -126,6 +126,7 @@ angular.module('deckApp.pipelines.stageConfig', [
 
     $scope.$on('pipeline-reverted', this.selectStage);
     $scope.$on('pipeline-json-edited', this.selectStage);
+    $scope.$on('pipeline-parallel-changed', this.selectStage);
     $scope.$watch('stage.type', this.selectStage);
     $scope.$watch('viewState.stageIndex', this.selectStage);
   });

--- a/app/scripts/modules/pipelines/config/validation/pipelineConfigValidation.service.js
+++ b/app/scripts/modules/pipelines/config/validation/pipelineConfigValidation.service.js
@@ -4,15 +4,14 @@ angular.module('deckApp.pipelines.config.validator.service', [
   'deckApp.pipelines.config',
   'deckApp.pipelines.config.service',
   'deckApp.utils.lodash',
-  'deckApp.settings',
 ])
-  .factory('pipelineConfigValidator', function($log, _, pipelineConfig, pipelineConfigService, settings) {
+  .factory('pipelineConfigValidator', function($log, _, pipelineConfig, pipelineConfigService) {
 
     var validators = {
       stageBeforeType: function(pipeline, index, validationConfig, messages) {
         var stageTypes = validationConfig.stageTypes || [validationConfig.stageType];
         var stagesToTest = pipeline.stages.slice(0, index+1);
-        if (settings.feature.parallelPipelines) {
+        if (pipeline.parallel) {
           stagesToTest = pipelineConfigService.getAllUpstreamDependencies(pipeline, pipeline.stages[index]);
         }
         for (var i = 0; i < stagesToTest.length; i++) {
@@ -35,7 +34,7 @@ angular.module('deckApp.pipelines.config.validator.service', [
           field = field[part];
         });
 
-        
+
         if (fieldNotFound ||
           (!field && field !== 0) ||
           (field && field instanceof Array && field.length === 0)

--- a/app/scripts/modules/pipelines/pipelines.module.js
+++ b/app/scripts/modules/pipelines/pipelines.module.js
@@ -13,6 +13,8 @@ angular.module('deckApp.pipelines', [
   'deckApp.pipelines.trigger',
   'deckApp.pipelines.create',
   'deckApp.pipelines.delete',
+  'deckApp.pipelines.enableParallel',
+  'deckApp.pipelines.disableParallel',
   'deckApp.pipelines.rename',
   'deckApp.pipelines.editJson',
   'deckApp.authentication',

--- a/app/scripts/settings/helpContents.js
+++ b/app/scripts/settings/helpContents.js
@@ -117,6 +117,8 @@ angular.module('deckApp.help')
 
     'pipeline.config.findAmi.cluster': 'The cluster to look at when selecting the AMI to use in this pipeline.',
     'pipeline.config.dependsOn': 'Declares which stages must be run <em>before</em> this stage begins.',
+    'pipeline.config.parallel.execution': '<p>Enabling parallel stage execution allows you to run stages only after dependent ' +
+      'stages have completed.</p><p>By configuring a pipeline this way, you can reduce the time it takes to run.</p>',
 
 
     'strategy.redblack.scaleDown': '<p>Resizes the target server group to zero instances before disabling it.</p>' +

--- a/app/scripts/settings/settings.js
+++ b/app/scripts/settings/settings.js
@@ -76,7 +76,6 @@ angular.module('deckApp.settings', [])
     feature: {
       notifications: false,
       canary: true,
-      parallelPipelines: true,
     },
 
 


### PR DESCRIPTION
Gives us a soft rollout of parallel pipeline configuration.

When creating a new pipeline, a checkbox, selected by default, determines if the pipeline should be parallel.

Toggling parallel execution is done via the "Actions" menu on existing pipelines.
