### PR TITLE
pass load balancer names to register/deregister method

### DIFF
--- a/app/scripts/modules/instance/details/gce/instance.details.controller.js
+++ b/app/scripts/modules/instance/details/gce/instance.details.controller.js
@@ -230,7 +230,7 @@ angular.module('deckApp.instance.detail.gce.controller', [
 
     this.registerInstanceWithLoadBalancer = function registerInstanceWithLoadBalancer() {
       var instance = $scope.instance;
-      var loadBalancerNames = _.pluck(instance.loadBalancers, 'name').join(' and ');
+      var loadBalancerNames = instance.loadBalancers.join(' and ');
 
       var taskMonitor = {
         application: application,
@@ -253,7 +253,7 @@ angular.module('deckApp.instance.detail.gce.controller', [
 
     this.deregisterInstanceFromLoadBalancer = function deregisterInstanceFromLoadBalancer() {
       var instance = $scope.instance;
-      var loadBalancerNames = _.pluck(instance.loadBalancers, 'name').join(' and ');
+      var loadBalancerNames = instance.loadBalancers.join(' and ');
 
       var taskMonitor = {
         application: application,

--- a/app/scripts/modules/instance/instance.write.service.js
+++ b/app/scripts/modules/instance/instance.write.service.js
@@ -4,7 +4,7 @@ angular
   .module('deckApp.instance.write.service', [
     'deckApp.taskExecutor.service'
   ])
-  .factory('instanceWriter', function (taskExecutor, _) {
+  .factory('instanceWriter', function (taskExecutor) {
 
     function terminateInstance(instance, application) {
       return taskExecutor.executeTask({
@@ -48,7 +48,7 @@ angular
           {
             type: 'deregisterInstancesFromLoadBalancer',
             instanceIds: [instance.instanceId],
-            loadBalancers: _.pluck(instance.loadBalancers, 'name'),
+            loadBalancers: instance.loadBalancers,
             region: instance.region,
             credentials: instance.account,
             providerType: instance.providerType
@@ -65,7 +65,7 @@ angular
           {
             type: 'registerInstancesWithLoadBalancer',
             instanceIds: [instance.instanceId],
-            loadBalancers: _.pluck(instance.loadBalancers, 'name'),
+            loadBalancers: instance.loadBalancers,
             region: instance.region,
             credentials: instance.account,
             providerType: instance.providerType


### PR DESCRIPTION
cc @duftler 

This fixes the issue you're seeing where load balancer names are not being passed in to the `register` and `deregister` tasks.
