### PR TITLE
minute field of scheduled executions in the pipelines view incorrect

### DIFF
--- a/app/scripts/modules/pipelines/config/stages/executionWindows/executionWindowsDetails.html
+++ b/app/scripts/modules/pipelines/config/stages/executionWindows/executionWindowsDetails.html
@@ -7,7 +7,7 @@
         <div ng-repeat="window in stage.context.restrictedExecutionWindow.whitelist">
           <dt>From</dt>
           <dd>
-            {{window.startHour}}:{{window.startHour}}
+            {{window.startHour}}:{{window.startMin}}
             <strong>&nbsp;to&nbsp;</strong>
             {{window.endHour}}:{{window.endMin}}
             <strong>&nbsp;PST</strong>


### PR DESCRIPTION
was showing hh:hh instead of hh:mm for start time
