### PR TITLE
In Bake Stage Controller, if there is exactly only provider, and no p…

### DIFF
--- a/app/scripts/modules/pipelines/config/stages/bake/bakeStage.js
+++ b/app/scripts/modules/pipelines/config/stages/bake/bakeStage.js
@@ -46,6 +46,11 @@ angular.module('spinnaker.pipelines.stage.bake')
         $scope.viewState.providerSelectionRequired = true;
         $scope.viewState.loading = false;
       } else {
+        // If there is exactly one provider, and there is not already a provider selected, select the only choice.
+        if (providers.length === 1 && !$scope.stage.cloudProviderType) {
+          $scope.stage.cloudProviderType = providers[0];
+        }
+
         $scope.viewState.providerSelectionRequired = false;
       }
       ctrl.providerSelected();


### PR DESCRIPTION
…rovider is yet selected, select the only choice.

Without this change, a Spinnaker instance configured with only Google credentials does not present any mechanism for a user to select GCE when configuring a bake stage.
