### PR TITLE
- Preventing the creation of an application via the UI unless at least 1 account is selected.

### DIFF
--- a/app/scripts/modules/applications/modal/newapplication.html
+++ b/app/scripts/modules/applications/modal/newapplication.html
@@ -150,7 +150,7 @@
       <button type="submit"
               class="btn btn-primary"
               data-purpose="submit"
-              ng-disabled="!newApplicationForm.$valid || newAppModal.submitting"
+              ng-disabled="newApplicationForm.$invalid || !newAppModal.application.hasOwnProperty('account') || (newAppModal.application.hasOwnProperty('account') && newAppModal.application.account.length < 1)|| newAppModal.submitting"
               ng-click="newAppModal.submit()" analytics-on="click" analytics-category="New Application" analytics-label="Create">
         <span class="glyphicon glyphicon-ok-circle"></span> Create
       </button>

--- a/app/views/directives/accountSelectField.html
+++ b/app/views/directives/accountSelectField.html
@@ -13,8 +13,8 @@
 </div>
 
 <div ng-if="multiselect">
-  <ui-select multiple ng-model="component[field]" class="form-control input-sm" style="width:200px" >
-    <ui-select-match>
+  <ui-select multiple required name="accounts" ng-model="component[field]" class="form-control input-sm" style="width:200px" >
+    <ui-select-match >
       {{$item}}
     </ui-select-match>
     <ui-select-choices group-by="groupBy" repeat="account in mergedAccounts | filter: $select.search">


### PR DESCRIPTION
Had to do it this way because the validation on ui-select is busted. Would have liked to use a custom validator directive but that is a 1.3 feature.
