### PR TITLE
transform executions including rolling pushes

### DIFF
--- a/app/scripts/modules/pipelines/config/stages/deploy/deployStage.module.js
+++ b/app/scripts/modules/pipelines/config/stages/deploy/deployStage.module.js
@@ -8,4 +8,8 @@ angular.module('spinnaker.pipelines.stage.deploy', [
   'spinnaker.utils.lodash',
   'spinnaker.serverGroup.read.service',
   'spinnaker.aws.serverGroupCommandBuilder.service',
-]);
+  'spinnaker.pipelines.stage.deploy.transformer',
+])
+  .run(function(pipelineConfig, deployStageTransformer) {
+    pipelineConfig.registerTransformer(deployStageTransformer);
+  });

--- a/app/scripts/modules/pipelines/config/stages/deploy/deployStage.transformer.js
+++ b/app/scripts/modules/pipelines/config/stages/deploy/deployStage.transformer.js
@@ -1,0 +1,54 @@
+'use strict';
+
+angular.module('spinnaker.pipelines.stage.deploy.transformer', [])
+  .service('deployStageTransformer', function() {
+
+    /**
+     * Removes rollingPush, modifyAsgLaunchConfiguration stages, adding them as tasks to the parent deploy stage,
+     * then overriding the status and endTime fields for the deploy stage
+     */
+    function transformRollingPushes(execution) {
+      var stagesToRemove = [];
+      execution.stages.forEach(function(stage) {
+        if (stage.type === 'deploy' && stage.context && stage.context.strategy === 'rollingpush' && stage.context.source) {
+          var modifyLaunchConfigurationStage = _.find(execution.stages, {
+            type: 'modifyAsgLaunchConfiguration',
+            parentStageId: stage.id,
+          });
+          var rollingPushStage = _.find(execution.stages, {
+            type: 'rollingPush',
+            parentStageId: stage.id,
+          });
+          if (modifyLaunchConfigurationStage) {
+            stagesToRemove.push(modifyLaunchConfigurationStage);
+            stage.tasks.push({
+              name: modifyLaunchConfigurationStage.name,
+              startTime: modifyLaunchConfigurationStage.startTime,
+              endTime: modifyLaunchConfigurationStage.endTime,
+              status: modifyLaunchConfigurationStage.status,
+            });
+            stage.endTime = modifyLaunchConfigurationStage.endTime;
+            stage.status = modifyLaunchConfigurationStage.status;
+          }
+          if (rollingPushStage) {
+            stagesToRemove.push(rollingPushStage);
+            stage.tasks.push({
+              name: rollingPushStage.name,
+              startTime: rollingPushStage.startTime,
+              endTime: rollingPushStage.endTime,
+              status: rollingPushStage.status,
+            });
+            stage.endTime = rollingPushStage.endTime;
+            stage.status = rollingPushStage.status;
+          }
+        }
+      });
+      execution.stages = execution.stages.filter(function(stage) {
+        return stagesToRemove.indexOf(stage) === -1;
+      });
+    }
+
+    this.transform = function(application, execution) {
+      transformRollingPushes(execution);
+    };
+  });


### PR DESCRIPTION
for @cfieber 

Looks like we can just match on the parent stage - will want to test this against a deploy stage with multiple rolling pushes, but it seems like it should work.
