### PR TITLE
validate destroyAsg stage operates against a deployed cluster

### DIFF
--- a/app/scripts/modules/naming/naming.service.js
+++ b/app/scripts/modules/naming/naming.service.js
@@ -31,12 +31,12 @@ angular.module('spinnaker.naming', [])
       return result;
     }
 
-    function getClusterName(app, cluster, detail) {
+    function getClusterName(app, stack, detail) {
       var clusterName = app;
-      if (cluster) {
-        clusterName += '-' + cluster;
+      if (stack) {
+        clusterName += '-' + stack;
       }
-      if (!cluster && detail) {
+      if (!stack && detail) {
         clusterName += '-';
       }
       if (detail) {

--- a/app/scripts/modules/pipelines/config/stages/destroyAsg/destroyAsgStage.js
+++ b/app/scripts/modules/pipelines/config/stages/destroyAsg/destroyAsgStage.js
@@ -11,6 +11,12 @@ angular.module('spinnaker.pipelines.stage.destroyAsg')
       templateUrl: 'scripts/modules/pipelines/config/stages/destroyAsg/destroyAsgStage.html',
       executionDetailsUrl: 'scripts/modules/pipelines/config/stages/destroyAsg/destroyAsgExecutionDetails.html',
       executionStepLabelUrl: 'scripts/modules/pipelines/config/stages/destroyAsg/destroyAsgStepLabel.html',
+      validators: [
+        {
+          type: 'targetImpedance',
+          message: 'This pipeline will attempt to destroy a server group without deploying a new version into the same cluster.'
+        },
+      ],
     });
   }).controller('DestroyAsgStageCtrl', function($scope, stage, accountService) {
     var ctrl = this;


### PR DESCRIPTION
Adds a validation to `destroyAsg` stages, warning the user if the destroy stage operates on a cluster that is not being deployed to earlier in the pipeline.

This may be too tightly coupled to the structure of the `(destroy | disable | enable)Asg` stages; if that turns out to be true, we can refactor.
