### PR TITLE
do not initialize strategy selector until provider selected

### DIFF
--- a/app/scripts/modules/serverGroups/configure/aws/serverGroupBasicSettingsDirective.html
+++ b/app/scripts/modules/serverGroups/configure/aws/serverGroupBasicSettingsDirective.html
@@ -60,7 +60,7 @@
     <a href ng-click="command.viewState.useAllImageSelection = true">Search All Images</a><help-field key="aws.serverGroup.allImages"></help-field>
   </div>
 </div>
-<deployment-strategy-selector ng-if="!command.viewState.disableStrategySelection" command="command"></deployment-strategy-selector>
+<deployment-strategy-selector ng-if="!command.viewState.disableStrategySelection && command.selectedProvider" command="command"></deployment-strategy-selector>
 <div class="form-group" ng-if="!command.viewState.hideClusterNamePreview">
   <div class="col-md-9 col-md-offset-2">
     <div class="well-compact" ng-class="basicSettingsCtrl.createsNewCluster() ? 'alert alert-warning' : 'well'">

--- a/app/scripts/modules/serverGroups/configure/gce/serverGroupBasicSettingsDirective.html
+++ b/app/scripts/modules/serverGroups/configure/gce/serverGroupBasicSettingsDirective.html
@@ -39,7 +39,7 @@
     </select>
   </div>
 </div>
-<deployment-strategy-selector command="command"></deployment-strategy-selector>
+<deployment-strategy-selector ng-if="!command.viewState.disableStrategySelection && command.selectedProvider" command="command"></deployment-strategy-selector>
 <div class="form-group" ng-if="!command.viewState.hideClusterNamePreview">
   <div class="col-md-9 col-md-offset-2">
     <div class="well-compact" ng-class="basicSettingsCtrl.createsNewCluster() ? 'alert alert-warning' : 'well'">


### PR DESCRIPTION
When adding a new cluster via pipeline config, the basic settings screen (which includes the deployment strategy selection) is pre-rendered via the modal wizard - but it has no provider selected, so rolling push is not available until navigating to a different screen, or adding the cluster and then editing it.

This just prevents rendering of the strategy until a provider has been selected.
