### PR TITLE
override restricted windows to suspended status when running

### DIFF
--- a/app/scripts/modules/delivery/executionStatus.directive.js
+++ b/app/scripts/modules/delivery/executionStatus.directive.js
@@ -13,16 +13,16 @@ angular.module('spinnaker.delivery.executionStatus.directive', [])
       link: function(scope) {
 
         function findDeployStageList() {
-          return _(scope.execution.stages)
+          var deploymentDetails = _(scope.execution.stages)
             .chain()
             .find(function(stage) {
               return stage.type === 'deploy';
             })
             .get('context')
             .get('deploymentDetails')
-            .first()
-            .get('jenkins')
             .value();
+
+          return deploymentDetails && deploymentDetails.length ? deploymentDetails[0].jenkins : null;
         }
 
         scope.execution.buildInfo = findDeployStageList();

--- a/app/scripts/modules/pipelines/config/stages/executionWindows/executionWIndows.transformer.js
+++ b/app/scripts/modules/pipelines/config/stages/executionWindows/executionWIndows.transformer.js
@@ -1,0 +1,23 @@
+'use strict';
+
+angular.module('spinnaker.pipelines.stage.executionWindows.transformer', [])
+  .service('executionWindowsTransformer', function() {
+
+    /**
+     * Overrides "running" status, setting it to "suspended"
+     */
+    function transformRunningExecutionWindows(execution) {
+      execution.stages
+        .filter(function (stage) {
+          return stage.type === 'restrictExecutionDuringTimeWindow' && stage.status === 'RUNNING';
+        })
+        .forEach(function (stage) {
+          stage.status = 'SUSPENDED';
+          stage.tasks.forEach(function(task) { task.status = 'SUSPENDED'; });
+        });
+    }
+
+    this.transform = function(application, execution) {
+      transformRunningExecutionWindows(execution);
+    };
+  });

--- a/app/scripts/modules/pipelines/config/stages/executionWindows/executionWindowsStage.js
+++ b/app/scripts/modules/pipelines/config/stages/executionWindows/executionWindowsStage.js
@@ -9,4 +9,7 @@ angular.module('spinnaker.pipelines.stage.executionWindows')
       key: 'restrictExecutionDuringTimeWindow',
       executionDetailsUrl: 'scripts/modules/pipelines/config/stages/executionWindows/executionWindowsDetails.html',
     });
+  })
+  .run(function(pipelineConfig, executionWindowsTransformer) {
+    pipelineConfig.registerTransformer(executionWindowsTransformer);
   });

--- a/app/scripts/modules/pipelines/config/stages/executionWindows/executionWindowsStage.module.js
+++ b/app/scripts/modules/pipelines/config/stages/executionWindows/executionWindowsStage.module.js
@@ -4,4 +4,5 @@ angular.module('spinnaker.pipelines.stage.executionWindows', [
   'spinnaker.pipelines.stage',
   'spinnaker.pipelines.stage.core',
   'spinnaker.pipelines.stage.executionWindows.directive',
+  'spinnaker.pipelines.stage.executionWindows.transformer',
 ]);

--- a/app/scripts/modules/pipelines/config/stages/stage.html
+++ b/app/scripts/modules/pipelines/config/stages/stage.html
@@ -22,7 +22,7 @@
             </div>
             <div class="col-md-6" ng-if="!stage.isNew">
               <p class="form-control-static" ng-if="!stage.isNew">
-                {{stage.type}}
+                {{stage.type | robotToHuman}}
                 <help-field content="{{description}}"></help-field>
               </p>
             </div>


### PR DESCRIPTION
- also fixing a bug in `executionStatus` that would throw NPEs when there were no deployment details
- also applying robotToHuman filter on stage type in pipeline editing view
