### PR TITLE
do not kill the cache when clearing it - just remove keys

### DIFF
--- a/app/scripts/modules/caches/infrastructureCaches.js
+++ b/app/scripts/modules/caches/infrastructureCaches.js
@@ -11,9 +11,8 @@ angular.module('spinnaker.caches.infrastructure', [
     var namespace = 'infrastructure';
 
     function clearCache(key) {
-      if (caches[key] && caches[key].destroy) {
-        caches[key].destroy();
-        createCache(key, caches[key].config);
+      if (caches[key] && caches[key].removeAll) {
+        caches[key].removeAll();
       }
     }
 

--- a/app/scripts/modules/caches/infrastructureCaches.spec.js
+++ b/app/scripts/modules/caches/infrastructureCaches.spec.js
@@ -15,7 +15,6 @@ describe('spinnaker.caches.infrastructure', function() {
     beforeEach(function() {
       var cacheInstantiations = [];
       var removalCalls = [];
-      var destroyCalls = [];
 
       var cacheFactory = function(cacheId, config) {
         cacheInstantiations.push({cacheId: cacheId, config: config});
@@ -26,16 +25,13 @@ describe('spinnaker.caches.infrastructure', function() {
           removeAll: function() {
             removalCalls.push(cacheId);
           },
-          destroy: function() {
-            destroyCalls.push(cacheId);
-          }
+          destroy: angular.noop,
         };
       };
 
       this.cacheFactory = cacheFactory;
       this.cacheInstantiations = cacheInstantiations;
       this.removalCalls = removalCalls;
-      this.destroyCalls = destroyCalls;
 
     });
 
@@ -72,6 +68,17 @@ describe('spinnaker.caches.infrastructure', function() {
       expect(this.cacheInstantiations[3].config.storagePrefix).toBe(deckCacheFactory.getStoragePrefix('infrastructure:myCache', 1));
       expect(this.removalCalls.length).toBe(3);
       expect(this.removalCalls).toEqual(['myCache', 'myCache', 'infrastructure:myCache']);
+    });
+
+    it('should remove all keys when clearCache called', function() {
+      infrastructureCaches.createCache('someBadCache', {
+        cacheFactory: this.cacheFactory,
+        version: 0,
+      });
+
+      var removalCallsAfterInitialization = this.removalCalls.length;
+      infrastructureCaches.clearCache('someBadCache');
+      expect(this.removalCalls.length).toBe(removalCallsAfterInitialization + 1);
     });
 
   });


### PR DESCRIPTION
Otherwise, any references to the cache object are no longer valid and subsequent attempts by Angular to put items (i.e. ajax responses) into the cache throw NPEs.
