### PR TITLE
attach tooltips to instances div, not body

### DIFF
--- a/app/scripts/directives/instances.js
+++ b/app/scripts/directives/instances.js
@@ -30,7 +30,7 @@ angular.module('spinnaker')
                   '" data-toggle="tooltip" data-instance-id="' + id +
                   '" class="instance health-status-' + instance.healthState + activeClass + '"></a>';
         }).join('') + '</div>';
-        $('[data-toggle="tooltip"]', elem).tooltip({placement: 'top', container: 'body'});
+        elem.tooltip({selector: 'a.instance', placement: 'top', container: elem});
 
         elem.click(function(event) {
           $timeout(function() {
@@ -65,7 +65,6 @@ angular.module('spinnaker')
         scope.$on('$locationChangeSuccess', clearActiveState);
 
         scope.$on('$destroy', function() {
-          $('[data-toggle="tooltip"]', elem).tooltip('destroy').removeData();
           elem.unbind('click');
         });
       }


### PR DESCRIPTION
for whatever reason, the `$destroy` event triggered by Angular kills the bootstrap tooltip plugin without removing the tooltip if it's present and attached to the body. Attaching the tooltips to the wrapper div solves this.
