### PR TITLE
explicitly state that no metrics found for an instance

### DIFF
--- a/app/scripts/modules/instance/details/aws/instanceDetails.html
+++ b/app/scripts/modules/instance/details/aws/instanceDetails.html
@@ -70,6 +70,9 @@
       </dl>
     </collapsible-section>
     <collapsible-section heading="Status" expanded="true">
+      <p ng-if="instance.healthState !== 'Starting' && !healthMetrics.length">
+        No health metrics found for this instance
+      </p>
       <p ng-if="instance.healthState === 'Starting' && !healthMetrics.length">
         <span class="glyphicon glyphicon-Starting-triangle"></span> <strong>Starting</strong>
       </p>

--- a/app/scripts/modules/instance/details/gce/instanceDetails.html
+++ b/app/scripts/modules/instance/details/gce/instanceDetails.html
@@ -70,6 +70,9 @@
       </dl>
     </collapsible-section>
     <collapsible-section heading="Status" expanded="true">
+      <p ng-if="instance.healthState !== 'Starting' && !healthMetrics.length">
+        No health metrics found for this instance
+      </p>
       <p ng-if="instance.healthState === 'Starting' && !healthMetrics.length">
         <span class="glyphicon glyphicon-Starting-triangle"></span> <strong>Starting</strong>
       </p>


### PR DESCRIPTION
We've heard complaints from a few folks that the empty status section is confusing.
