### PR TITLE
warn user if using create ASG dialog when clone is a better option

### DIFF
--- a/app/scripts/modules/serverGroups/configure/aws/serverGroup.configure.aws.module.js
+++ b/app/scripts/modules/serverGroups/configure/aws/serverGroup.configure.aws.module.js
@@ -4,4 +4,5 @@ angular.module('spinnaker.serverGroup.configure.aws', [
   'spinnaker.account',
   'spinnaker.serverGroup.configure.aws.deployInitialization.controller',
   'spinnaker.caches.infrastructure',
+  'ui.router',
 ]);

--- a/app/scripts/modules/serverGroups/configure/aws/serverGroupBasicSettingsDirective.html
+++ b/app/scripts/modules/serverGroups/configure/aws/serverGroupBasicSettingsDirective.html
@@ -63,13 +63,33 @@
 <deployment-strategy-selector ng-if="!command.viewState.disableStrategySelection && command.selectedProvider" command="command"></deployment-strategy-selector>
 <div class="form-group" ng-if="!command.viewState.hideClusterNamePreview">
   <div class="col-md-9 col-md-offset-2">
-    <div class="well-compact" ng-class="basicSettingsCtrl.createsNewCluster() ? 'alert alert-warning' : 'well'">
+    <div class="well-compact" ng-class="basicSettingsCtrl.showPreviewAsWarning() ? 'alert alert-warning' : 'well'">
       <h5 class="text-center">
         <p>Your server group will be in the cluster:</p>
-        <strong>
-          {{basicSettingsCtrl.getNamePreview()}}
-          <span ng-if="basicSettingsCtrl.createsNewCluster()"> (new cluster)</span>
-        </strong>
+        <p>
+          <strong>
+            {{basicSettingsCtrl.getNamePreview()}}
+            <span ng-if="basicSettingsCtrl.createsNewCluster()"> (new cluster)</span>
+          </strong>
+        </p>
+        <div ng-if="!basicSettingsCtrl.createsNewCluster() && command.viewState.mode === 'create' && latestServerGroup">
+          <p>
+            There is already a server group in this cluster. Do you want to clone it?
+          </p>
+          <p>
+            Cloning copies the entire configuration from the selected server group, allowing you
+            modify whichever fields (e.g. image) you need to change in the new server group.
+          </p>
+          <p>
+            To clone a server group, select "Clone" from the "Server Group Actions" menu in the details view of the
+            server group.
+          </p>
+          <p>
+            <a href ng-click="basicSettingsCtrl.navigateToLatestServerGroup()">
+              Go to details for {{latestServerGroup.name}}
+            </a>
+          </p>
+        </div>
       </h5>
     </div>
   </div>


### PR DESCRIPTION
We've had some confusion where newer users click the "Create New Server Group" button to create the next server group in a cluster, then have to enter all the data manually, which is error-prone.

If the user selects a target cluster that already exists, we provide an explanation that they might want to use the "Clone" action instead, with a link to the details of what we think they should be cloning. The idea of giving them the link is to train them to use the "Clone" operation instead of clicking the "Create New Server Group" button.

@duftler might want to port this same logic over to the Google side.
