### PR TITLE
allow timeout override on specific stages

### DIFF
--- a/app/scripts/modules/pipelines/config/stages/bake/bakeStage.js
+++ b/app/scripts/modules/pipelines/config/stages/bake/bakeStage.js
@@ -10,6 +10,7 @@ angular.module('spinnaker.pipelines.stage.bake')
       controllerAs: 'bakeStageCtrl',
       templateUrl: 'scripts/modules/pipelines/config/stages/bake/bakeStage.html',
       executionDetailsUrl: 'scripts/modules/pipelines/config/stages/bake/bakeExecutionDetails.html',
+      defaultTimeoutMs: 60 * 60 * 1000, // 60 minutes
       validators: [
         {
           type: 'requiredField',

--- a/app/scripts/modules/pipelines/config/stages/deploy/deployStage.js
+++ b/app/scripts/modules/pipelines/config/stages/deploy/deployStage.js
@@ -10,6 +10,7 @@ angular.module('spinnaker.pipelines.stage.deploy')
       executionDetailsUrl: 'scripts/modules/pipelines/config/stages/deploy/deployExecutionDetails.html',
       controller: 'DeployStageCtrl',
       controllerAs: 'deployStageCtrl',
+      defaultTimeoutMs: 60 * 60 * 1000, // 60 minutes
       validators: [
         {
           type: 'stageBeforeType',

--- a/app/scripts/modules/pipelines/config/stages/jenkins/jenkinsStage.js
+++ b/app/scripts/modules/pipelines/config/stages/jenkins/jenkinsStage.js
@@ -11,6 +11,7 @@ angular.module('spinnaker.pipelines.stage.jenkins')
       templateUrl: 'scripts/modules/pipelines/config/stages/jenkins/jenkinsStage.html',
       executionDetailsUrl: 'scripts/modules/pipelines/config/stages/jenkins/jenkinsExecutionDetails.html',
       executionLabelTemplateUrl: 'scripts/modules/pipelines/config/stages/jenkins/jenkinsExecutionLabel.html',
+      defaultTimeoutMs: 2 * 60 * 60 * 1000, // 2 hours
       validators: [
         {
           type: 'requiredField',

--- a/app/scripts/modules/pipelines/config/stages/overrideTimeout/overrideTimeout.directive.html
+++ b/app/scripts/modules/pipelines/config/stages/overrideTimeout/overrideTimeout.directive.html
@@ -1,0 +1,41 @@
+<div ng-if="vm.configurable">
+    <div class="form-group">
+        <div class="col-md-9 col-md-offset-1">
+            <div class="checkbox">
+                <label>
+                    <input type="checkbox" ng-model="stage.overrideTimeout"
+                           ng-change="overrideTimeoutCtrl.setOverrideValues()"/>
+                    <strong> Override default timeout</strong>
+                    (
+                    <span class="default-timeout">
+                        <span ng-if="vm.defaults.hours">{{vm.defaults.hours}} hour<span
+                                ng-if="vm.defaults.hours > 1">s</span></span>
+                        <span ng-if="vm.defaults.minutes">{{vm.defaults.minutes}} minute<span
+                                ng-if="vm.defaults.minutes > 1">s</span></span>
+                    </span>
+                    )
+                    <help-field content="{{vm.helpContent}}"></help-field>
+                </label>
+            </div>
+        </div>
+    </div>
+    <div ng-if="stage.overrideTimeout">
+        <div class="form-group form-inline">
+            <div class="col-md-9 col-md-offset-1 checkbox-padding">
+                Fail this stage if it takes longer than
+                <input type="number"
+                       ng-min="0"
+                       class="form-control input-sm inline-number with-space-before"
+                       ng-model="vm.hours"
+                       ng-change="overrideTimeoutCtrl.synchronizeTimeout()"/>
+                hours
+                <input type="number"
+                       ng-min="0"
+                       class="form-control input-sm inline-number with-space-before"
+                       ng-model="vm.minutes"
+                       ng-change="overrideTimeoutCtrl.synchronizeTimeout()"/>
+                minutes to complete
+            </div>
+        </div>
+    </div>
+</div>

--- a/app/scripts/modules/pipelines/config/stages/overrideTimeout/overrideTimeout.directive.js
+++ b/app/scripts/modules/pipelines/config/stages/overrideTimeout/overrideTimeout.directive.js
@@ -1,0 +1,70 @@
+'use strict';
+
+angular.module('spinnaker.pipelines.stage.overrideTimeout', [
+  'spinnaker.pipelines.config',
+  'spinnaker.help',
+])
+  .directive('overrideTimeout', function() {
+    return {
+      restrict: 'E',
+      scope: {
+        stage: '=',
+      },
+      templateUrl: 'scripts/modules/pipelines/config/stages/overrideTimeout/overrideTimeout.directive.html',
+      controller: 'OverrideTimeoutCtrl',
+      controllerAs: 'overrideTimeoutCtrl',
+    };
+  })
+  .controller('OverrideTimeoutCtrl', function($scope, pipelineConfig, helpContents) {
+    function toHoursAndMinutes(ms) {
+      if (!ms) {
+        return { hours: 0, minutes: 0 };
+      } else {
+        var seconds = ms / 1000;
+        return {
+          hours: Math.floor(seconds / 3600),
+          minutes: Math.floor(seconds / 60) % 60,
+        };
+      }
+    }
+
+    this.setOverrideValues = function() {
+      var stage = $scope.stage,
+          stageConfig = pipelineConfig.getStageConfig(stage.type),
+          stageDefaults = stageConfig.defaultTimeoutMs;
+
+      if (stage.overrideTimeout === undefined) {
+        stage.overrideTimeout = !!stage.stageTimeoutMs;
+      }
+
+      $scope.vm = {
+        configurable: !!stageDefaults
+      };
+
+      $scope.vm.helpContent = helpContents['pipeline.config.timeout'] + helpContents['pipeline.config.timeout.' + stage.type];
+      $scope.vm.defaults = toHoursAndMinutes(stageDefaults);
+
+      if (stage.overrideTimeout) {
+        var overrideValue = stage.stageTimeoutMs || stageDefaults;
+        $scope.vm.hours = toHoursAndMinutes(overrideValue).hours;
+        $scope.vm.minutes = toHoursAndMinutes(overrideValue).minutes;
+      } else {
+        delete stage.stageTimeoutMs;
+      }
+    };
+
+    this.synchronizeTimeout = function() {
+      var timeout = 0,
+        vm = $scope.vm;
+      if (!isNaN(vm.minutes)) {
+        timeout += 60 * 1000 * parseInt(vm.minutes);
+      }
+      if (!isNaN(vm.hours)) {
+        timeout += 60 * 60 * 1000 * parseInt(vm.hours);
+      }
+      $scope.stage.stageTimeoutMs = timeout;
+    };
+
+    $scope.$watch('stage', this.setOverrideValues, true);
+
+  });

--- a/app/scripts/modules/pipelines/config/stages/overrideTimeout/overrideTimeout.directive.spec.js
+++ b/app/scripts/modules/pipelines/config/stages/overrideTimeout/overrideTimeout.directive.spec.js
@@ -1,0 +1,95 @@
+'use strict';
+
+describe('Directives: overrideTimeout', function () {
+
+  var stageConfig = {};
+
+  beforeEach(module('spinnaker.pipelines.stage.overrideTimeout', function ($provide) {
+    $provide.service('pipelineConfig', function () {
+      return {
+        getStageConfig: function () { return stageConfig; }
+      };
+    });
+  }));
+
+  beforeEach(module('spinnaker.templates'));
+
+  beforeEach(inject(function ($rootScope, $compile, $controller, pipelineConfig, helpContents) {
+    this.scope = $rootScope.$new();
+    this.scope.stage = {};
+    this.compile = $compile;
+    this.$controller = $controller;
+    this.pipelineConfig = pipelineConfig;
+    this.helpContents = helpContents;
+    stageConfig = {defaultTimeoutMs: 90 * 60 * 1000};
+  }));
+
+  describe('checkbox toggle control', function () {
+
+    it('displays nothing when stage is not supported', function () {
+      stageConfig = {};
+      var domNode = this.compile('<override-timeout stage="stage"></override-timeout>')(this.scope);
+      this.scope.$digest();
+
+      expect(domNode.find('div').size()).toBe(0);
+    });
+
+    it('shows the default value when stage is supported', function () {
+      var domNode = this.compile('<override-timeout stage="stage"></override-timeout>')(this.scope);
+      this.scope.$digest();
+      expect(domNode.find('.default-timeout').text().indexOf('1 hour')).not.toBe(-1);
+      expect(domNode.find('.default-timeout').text().indexOf('30 minutes')).not.toBe(-1);
+    });
+
+    it('shows the contents when stageTimeoutMs is set', function () {
+      this.scope.stage.stageTimeoutMs = 30000;
+      var domNode = this.compile('<override-timeout stage="stage"></override-timeout>')(this.scope);
+      this.scope.$digest();
+      expect(domNode.find('input[type="number"]').size()).toBe(2);
+    });
+
+    it('unsets timeout, removes contents when overrideTimeout is set to false', function () {
+      this.scope.stage.stageTimeoutMs = 30000;
+      var domNode = this.compile('<override-timeout stage="stage"></override-timeout>')(this.scope);
+      this.scope.$digest();
+      expect(domNode.find('input[type="number"]').size()).toBe(2);
+      this.scope.stage.overrideTimeout = false;
+      this.scope.$digest();
+      expect(domNode.find('input[type="number"]').size()).toBe(0);
+      expect(this.scope.stage.stageTimeoutMs).toBeUndefined();
+    });
+  });
+  
+  describe('time conversion', function () {
+    it('rounds down', function() {
+      this.scope.stage.stageTimeoutMs = 30 * 60 * 1000 + 499;
+      this.$controller('OverrideTimeoutCtrl', {
+        $scope: this.scope,
+        pipelineConfig: this.pipelineConfig,
+        helpContents: this.helpContents,
+      });
+      this.scope.$digest();
+      expect(this.scope.vm.minutes).toBe(30);
+    });
+
+    it('rolls minutes over to hours', function() {
+      this.scope.stage.stageTimeoutMs = 95 * 60 * 1000;
+      var ctrl = this.$controller('OverrideTimeoutCtrl', {
+        $scope: this.scope,
+        pipelineConfig: this.pipelineConfig,
+        helpContents: this.helpContents,
+      });
+      this.scope.$digest();
+      expect(this.scope.vm.minutes).toBe(35);
+      expect(this.scope.vm.hours).toBe(1);
+
+      this.scope.vm.hours = 0;
+      this.scope.vm.minutes = 99;
+      ctrl.synchronizeTimeout();
+      this.scope.$digest();
+      expect(this.scope.vm.hours).toBe(1);
+      expect(this.scope.vm.minutes).toBe(39);
+    });
+  });
+
+});

--- a/app/scripts/modules/pipelines/config/stages/stage.html
+++ b/app/scripts/modules/pipelines/config/stages/stage.html
@@ -66,6 +66,7 @@
         </div>
       </div>
       <execution-windows stage="stage"></execution-windows>
+      <override-timeout stage="stage"></override-timeout>
     </div>
   </div>
 </div>

--- a/app/scripts/modules/pipelines/config/stages/stage.module.js
+++ b/app/scripts/modules/pipelines/config/stages/stage.module.js
@@ -3,5 +3,6 @@
 angular.module('spinnaker.pipelines.stage', [
   'spinnaker.pipelines',
   'spinnaker.pipelines.stageConfig',
-  'spinnaker.stage.constants'
+  'spinnaker.stage.constants',
+  'spinnaker.pipelines.stage.overrideTimeout',
 ]);

--- a/app/scripts/settings/helpContents.js
+++ b/app/scripts/settings/helpContents.js
@@ -119,6 +119,11 @@ angular.module('spinnaker.help')
     'pipeline.config.dependsOn': 'Declares which stages must be run <em>before</em> this stage begins.',
     'pipeline.config.parallel.execution': '<p>Enabling parallel stage execution allows you to run stages only after dependent ' +
       'stages have completed.</p><p>By configuring a pipeline this way, you can reduce the time it takes to run.</p>',
+    'pipeline.config.timeout': '<p>Allows you to override the amount of time the stage can run before failing.</p> ' +
+    '<p><b>Note:</b> this is not the overall time the stage has, but rather the time for specific tasks.</p>',
+    'pipeline.config.timeout.bake': '<p>For the Bake stage, the timeout will apply to both the "Create Bake" and "Monitor Bake" tasks.</p>',
+    'pipeline.config.timeout.deploy': '<p>For the Deploy stage, the timeout will apply to both the "Monitor Deploy" and "Wait For Up Instances" tasks.</p>',
+    'pipeline.config.timeout.jenkins': '<p>For the Jenkins stage, the timeout will apply to both the "Wait For Jenkins Job Start" and "Monitor Jenkins Job" tasks.</p>',
     'serverGroupCapacity.useSourceCapacityTrue':  '<p>Spinnaker will use the current capacity of the existing server group when deploying a new server group.</p>' +
       '<p>This setting is intended to support a server group with auto-scaling enabled, where the bounds and desired capacity are controlled by an external process.</p>' +
       '<p>In the event that there is no existing server group, the deploy will fail.</p>',

--- a/app/styles/main.less
+++ b/app/styles/main.less
@@ -389,6 +389,10 @@ body > .container {
   }
 }
 
+.checkbox-padding {
+  padding-left: 35px;
+}
+
 .modal-content {
   overflow-x: hidden;
   overflow-y: hidden;


### PR DESCRIPTION
For a handful of stages, it's become necessary to allow users to configure the timeout of the tasks in each one.

Since we don't have a clean separation of the task timeout and the stage timeout, we're relying on help text to clarify what the timeouts are for. This may cause confusion and support headaches but that's the boat we're out to sea in.
