### PR TITLE
override config defaults on creation if app is only present in one ac…

### DIFF
--- a/app/scripts/modules/applications/applications.read.service.js
+++ b/app/scripts/modules/applications/applications.read.service.js
@@ -155,6 +155,30 @@ angular
       return gateEndpoint.one('applications', application);
     }
 
+    function addDefaultRegion(application) {
+      var fromServerGroups = _.pluck(application.serverGroups, 'region'),
+        fromLoadBalancers = _.pluck(application.loadBalancers, 'region'),
+        fromSecurityGroups = _.pluck(application.securityGroups, 'region');
+
+      var allRegions = _.union(fromServerGroups, fromLoadBalancers, fromSecurityGroups);
+
+      if (allRegions.length === 1) {
+        application.defaultRegion = allRegions[0];
+      }
+    }
+
+    function addDefaultCredentials(application) {
+      var fromServerGroups = _.pluck(application.serverGroups, 'account'),
+        fromLoadBalancers = _.pluck(application.loadBalancers, 'account'),
+        fromSecurityGroups = _.pluck(application.securityGroups, 'accountName');
+
+      var allCredentials = _.union(fromServerGroups, fromLoadBalancers, fromSecurityGroups);
+
+      if (allCredentials.length === 1) {
+        application.defaultCredentials = allCredentials[0];
+      }
+    }
+
     function addTasksToApplication(application, tasks) {
       application.tasks = angular.isArray(tasks) ? tasks : [];
       clusterService.addTasksToServerGroups(application);
@@ -174,6 +198,9 @@ angular
       original.securityGroups = newApplication.securityGroups;
       original.lastRefresh = newApplication.lastRefresh;
       original.securityGroupsIndex = newApplication.securityGroupsIndex;
+      original.defaultRegion = newApplication.defaultRegion;
+      original.defaultCredentials = newApplication.defaultCredentials;
+
       clusterService.addTasksToServerGroups(original);
       clusterService.addExecutionsToServerGroups(original);
 
@@ -240,6 +267,8 @@ angular
                     application.serverGroups.forEach(function(sg) {
                       sg.stringVal = JSON.stringify(sg, jsonReplacer);
                     });
+                    addDefaultRegion(application);
+                    addDefaultCredentials(application);
                     return application;
                   },
                   function(err) {

--- a/app/scripts/modules/loadBalancers/configure/aws/CreateLoadBalancerCtrl.js
+++ b/app/scripts/modules/loadBalancers/configure/aws/CreateLoadBalancerCtrl.js
@@ -78,7 +78,7 @@ angular.module('spinnaker.loadBalancer.aws.create.controller', [
           delete $scope.loadBalancer.name;
         }
       } else {
-        $scope.loadBalancer = awsLoadBalancerTransformer.constructNewLoadBalancerTemplate();
+        $scope.loadBalancer = awsLoadBalancerTransformer.constructNewLoadBalancerTemplate(application);
       }
       if (isNew) {
         initializeLoadBalancerNames();

--- a/app/scripts/modules/loadBalancers/configure/aws/loadBalancer.transformer.service.js
+++ b/app/scripts/modules/loadBalancers/configure/aws/loadBalancer.transformer.service.js
@@ -121,12 +121,14 @@ angular.module('spinnaker.aws.loadBalancer.transformer.service', [
       return toEdit;
     }
 
-    function constructNewLoadBalancerTemplate() {
+    function constructNewLoadBalancerTemplate(application) {
+      var defaultCredentials = application.defaultCredentials || settings.providers.aws.defaults.account,
+          defaultRegion = application.defaultRegion || settings.providers.aws.defaults.region;
       return {
         stack: '',
         detail: 'frontend',
-        credentials: settings.providers.aws.defaults.account,
-        region: settings.providers.aws.defaults.region,
+        credentials: defaultCredentials,
+        region: defaultRegion,
         vpcId: null,
         healthCheckProtocol: 'HTTP',
         healthCheckPort: 7001,

--- a/app/scripts/modules/pipelines/config/stages/bake/bakeStage.js
+++ b/app/scripts/modules/pipelines/config/stages/bake/bakeStage.js
@@ -76,6 +76,9 @@ angular.module('spinnaker.pipelines.stage.bake')
         } else if ($scope.regions.indexOf($scope.stage.region) === -1) {
           delete $scope.stage.region;
         }
+        if (!$scope.stage.regions.length && $scope.application.defaultRegion) {
+          $scope.stage.regions.push($scope.application.defaultRegion);
+        }
         $scope.baseOsOptions = results.baseOsOptions;
         $scope.vmTypes = results.vmTypes;
         $scope.baseLabelOptions = results.baseLabelOptions;

--- a/app/scripts/modules/pipelines/config/stages/destroyAsg/destroyAsgStage.js
+++ b/app/scripts/modules/pipelines/config/stages/destroyAsg/destroyAsgStage.js
@@ -36,7 +36,7 @@ angular.module('spinnaker.pipelines.stage.destroyAsg')
     $scope.regions = ['us-east-1', 'us-west-1', 'eu-west-1', 'us-west-2'];
 
     ctrl.accountUpdated = function() {
-      accountService.getRegionsForAccount($scope.stage.credentials).then(function(regions) {
+      accountService.getRegionsForAccount(stage.credentials).then(function(regions) {
         $scope.regions = _.map(regions, function(v) { return v.name; });
         $scope.state.regionsLoaded = true;
       });
@@ -44,14 +44,21 @@ angular.module('spinnaker.pipelines.stage.destroyAsg')
 
     $scope.targets = stageConstants.targetList;
 
-    (function() {
-      if ($scope.stage.credentials) {
-        ctrl.accountUpdated();
-      }
-      if (!$scope.stage.target) {
-        $scope.stage.target = $scope.targets[0].val;
-      }
-    })();
+    stage.regions = stage.regions || [];
+    
+    if (!stage.credentials && $scope.application.defaultCredentials) {
+      stage.credentials = $scope.application.defaultCredentials;
+    }
+    if (!stage.regions.length && $scope.application.defaultRegion) {
+      stage.regions.push($scope.application.defaultRegion);
+    }
+    
+    if (stage.credentials) {
+      ctrl.accountUpdated();
+    }
+    if (!stage.target) {
+      stage.target = $scope.targets[0].val;
+    }
 
   });
 

--- a/app/scripts/modules/pipelines/config/stages/disableAsg/disableAsgStage.js
+++ b/app/scripts/modules/pipelines/config/stages/disableAsg/disableAsgStage.js
@@ -22,7 +22,7 @@ angular.module('spinnaker.pipelines.stage.disableAsg')
     var ctrl = this;
 
     $scope.stage = stage;
-
+    
     $scope.state = {
       accounts: false,
       regionsLoaded: false
@@ -36,7 +36,7 @@ angular.module('spinnaker.pipelines.stage.disableAsg')
     $scope.regions = ['us-east-1', 'us-west-1', 'eu-west-1', 'us-west-2'];
 
     ctrl.accountUpdated = function() {
-      accountService.getRegionsForAccount($scope.stage.credentials).then(function(regions) {
+      accountService.getRegionsForAccount(stage.credentials).then(function(regions) {
         $scope.regions = _.map(regions, function(v) { return v.name; });
         $scope.state.regionsLoaded = true;
       });
@@ -44,14 +44,21 @@ angular.module('spinnaker.pipelines.stage.disableAsg')
 
     $scope.targets = stageConstants.targetList;
 
-    (function() {
-      if ($scope.stage.credentials) {
-        ctrl.accountUpdated();
-      }
-      if (!$scope.stage.target) {
-        $scope.stage.target = $scope.targets[0].val;
-      }
-    })();
+    stage.regions = stage.regions || [];
+
+    if (!stage.credentials && $scope.application.defaultCredentials) {
+      stage.credentials = $scope.application.defaultCredentials;
+    }
+    if (!stage.regions.length && $scope.application.defaultRegion) {
+      stage.regions.push($scope.application.defaultRegion);
+    }
+
+    if (stage.credentials) {
+      ctrl.accountUpdated();
+    }
+    if (!stage.target) {
+      stage.target = $scope.targets[0].val;
+    }
 
   });
 

--- a/app/scripts/modules/pipelines/config/stages/enableAsg/enableAsgStage.js
+++ b/app/scripts/modules/pipelines/config/stages/enableAsg/enableAsgStage.js
@@ -35,14 +35,21 @@ angular.module('spinnaker.pipelines.stage.enableAsg')
 
     $scope.targets = stageConstants.targetList;
 
-    (function() {
-      if ($scope.stage.credentials) {
-        $scope.accountUpdated();
-      }
-      if (!$scope.stage.target) {
-        $scope.stage.target = $scope.targets[0].val;
-      }
-    })();
+    stage.regions = stage.regions || [];
+
+    if (!stage.credentials && $scope.application.defaultCredentials) {
+      stage.credentials = $scope.application.defaultCredentials;
+    }
+    if (!stage.regions.length && $scope.application.defaultRegion) {
+      stage.regions.push($scope.application.defaultRegion);
+    }
+
+    if (stage.credentials) {
+      $scope.accountUpdated();
+    }
+    if (!stage.target) {
+      stage.target = $scope.targets[0].val;
+    }
 
     $scope.$watch('stage.credentials', $scope.accountUpdated);
   });

--- a/app/scripts/modules/pipelines/config/stages/findAmi/findAmiStage.js
+++ b/app/scripts/modules/pipelines/config/stages/findAmi/findAmiStage.js
@@ -27,21 +27,21 @@ angular.module('spinnaker.pipelines.stage.findAmi')
     $scope.regions = ['us-east-1', 'us-west-1', 'eu-west-1', 'us-west-2'];
 
     $scope.accountUpdated = function() {
-      accountService.getRegionsForAccount($scope.stage.account).then(function(regions) {
+      accountService.getRegionsForAccount(stage.account).then(function(regions) {
         $scope.regions = _.map(regions, function(v) { return v.name; });
         $scope.regionsLoaded = true;
       });
     };
 
     $scope.toggleRegion = function(region) {
-      if (!$scope.stage.regions) {
-        $scope.stage.regions = [];
+      if (!stage.regions) {
+        stage.regions = [];
       }
-      var idx = $scope.stage.regions.indexOf(region);
+      var idx = stage.regions.indexOf(region);
       if (idx > -1) {
-        $scope.stage.regions.splice(idx,1);
+        stage.regions.splice(idx,1);
       } else {
-        $scope.stage.regions.push(region);
+        stage.regions.push(region);
       }
     };
 
@@ -63,17 +63,25 @@ angular.module('spinnaker.pipelines.stage.findAmi')
       description: 'When multiple server groups exist, fail'
     }];
 
-    (function() {
-      if ($scope.stage.account) {
-        $scope.accountUpdated();
-      }
-      if (!$scope.stage.selectionStrategy) {
-        $scope.stage.selectionStrategy = $scope.selectionStrategies[0].val;
-      }
-      if (angular.isUndefined($scope.stage.onlyEnabled)) {
-        $scope.stage.onlyEnabled = true;
-      }
-    })();
+    stage.regions = stage.regions || [];
+    stage.selectionStrategy = stage.selectionStrategy || $scope.selectionStrategies[0].val;
+
+    if (angular.isUndefined(stage.onlyEnabled)) {
+      stage.onlyEnabled = true;
+    }
+
+    if (!stage.account && $scope.application.defaultCredentials) {
+      stage.account = $scope.application.defaultCredentials;
+    }
+    if (!stage.regions.length && $scope.application.defaultRegion) {
+      stage.regions.push($scope.application.defaultRegion);
+    }
+
+    if (stage.account) {
+      $scope.accountUpdated();
+    }
+
+    
 
     $scope.$watch('stage.account', $scope.accountUpdated);
   });

--- a/app/scripts/modules/pipelines/config/stages/modifyScalingProcess/modifyScalingProcessStage.js
+++ b/app/scripts/modules/pipelines/config/stages/modifyScalingProcess/modifyScalingProcessStage.js
@@ -27,7 +27,7 @@ angular.module('spinnaker.pipelines.stage.modifyScalingProcess')
     $scope.regions = ['us-east-1', 'us-west-1', 'eu-west-1', 'us-west-2'];
 
     $scope.accountUpdated = function() {
-      accountService.getRegionsForAccount($scope.stage.credentials).then(function(regions) {
+      accountService.getRegionsForAccount(stage.credentials).then(function(regions) {
         $scope.regions = _.map(regions, function(v) { return v.name; });
         $scope.regionsLoaded = true;
       });
@@ -49,30 +49,31 @@ angular.module('spinnaker.pipelines.stage.modifyScalingProcess')
       'Launch', 'Terminate', 'AddToLoadBalancer', 'AlarmNotification', 'AZRebalance', 'HealthCheck', 'ReplaceUnhealthy', 'ScheduledActions'
     ];
 
-    (function() {
-      if (!$scope.stage.processes) {
-        $scope.stage.processes = [];
-      }
-      if ($scope.stage.credentials) {
-        $scope.accountUpdated();
-      }
-      if (!$scope.stage.action) {
-        $scope.stage.action = $scope.actions[0].val;
-      }
-      if (!$scope.stage.target) {
-        $scope.stage.target = $scope.targets[0].val;
-      }
-    })();
+    stage.processes = stage.processes || [];
+    stage.regions = stage.regions || [];
+    stage.action = stage.action || $scope.actions[0].val;
+    stage.target = stage.target || $scope.targets[0].val;
+
+    if (!stage.credentials && $scope.application.defaultCredentials) {
+      stage.credentials = $scope.application.defaultCredentials;
+    }
+    if (!stage.regions.length && $scope.application.defaultRegion) {
+      stage.regions.push($scope.application.defaultRegion);
+    }
+    
+    if (stage.credentials) {
+      $scope.accountUpdated();
+    }
 
     $scope.toggleProcess = function(process) {
-      if (!$scope.stage.processes) {
-        $scope.stage.processes = [];
+      if (!stage.processes) {
+        stage.processes = [];
       }
-      var idx = $scope.stage.processes.indexOf(process);
+      var idx = stage.processes.indexOf(process);
       if (idx > -1) {
-        $scope.stage.processes.splice(idx,1);
+        stage.processes.splice(idx,1);
       } else {
-        $scope.stage.processes.push(process);
+        stage.processes.push(process);
       }
     };
 

--- a/app/scripts/modules/pipelines/config/stages/overrideTimeout/overrideTimeout.directive.js
+++ b/app/scripts/modules/pipelines/config/stages/overrideTimeout/overrideTimeout.directive.js
@@ -31,7 +31,7 @@ angular.module('spinnaker.pipelines.stage.overrideTimeout', [
     this.setOverrideValues = function() {
       var stage = $scope.stage,
           stageConfig = pipelineConfig.getStageConfig(stage.type),
-          stageDefaults = stageConfig.defaultTimeoutMs;
+          stageDefaults = stageConfig ? stageConfig.defaultTimeoutMs : null;
 
       $scope.vm = {
         configurable: !!stageDefaults

--- a/app/scripts/modules/pipelines/config/stages/resizeAsg/resizeAsgStage.js
+++ b/app/scripts/modules/pipelines/config/stages/resizeAsg/resizeAsgStage.js
@@ -37,7 +37,7 @@ angular.module('spinnaker.pipelines.stage.resizeAsg')
     $scope.regionsLoaded = false;
 
     ctrl.accountUpdated = function() {
-      accountService.getRegionsForAccount($scope.stage.credentials).then(function(regions) {
+      accountService.getRegionsForAccount(stage.credentials).then(function(regions) {
         $scope.regions = _.map(regions, function(v) { return v.name; });
         $scope.regionsLoaded = true;
       });
@@ -71,36 +71,31 @@ angular.module('spinnaker.pipelines.stage.resizeAsg')
       }
     ];
 
-    (function() {
-      if (!$scope.stage.capacity) {
-        $scope.stage.capacity = {};
-      }
-      if (!$scope.stage.regions) {
-        $scope.stage.regions = [];
-      }
-      if ($scope.stage.credentials) {
-        ctrl.accountUpdated();
-      }
-      if (!$scope.stage.target) {
-        $scope.stage.target = $scope.resizeTargets[0].val;
-      }
-      if (!$scope.stage.action) {
-        $scope.stage.action = $scope.scaleActions[0].val;
-      }
-      if (!$scope.stage.resizeType) {
-        $scope.stage.resizeType = $scope.resizeTypes[0].val;
-      }
-    })();
+    stage.capacity = stage.capacity || {};
+    stage.regions = stage.regions || [];
+    stage.target = stage.target || $scope.resizeTargets[0].val;
+    stage.action = stage.action || $scope.scaleActions[0].val;
+    stage.resizeType = stage.resizeType || $scope.resizeTypes[0].val;
 
+    if (!stage.credentials && $scope.application.defaultCredentials) {
+      stage.credentials = $scope.application.defaultCredentials;
+    }
+    if (!stage.regions.length && $scope.application.defaultRegion) {
+      stage.regions.push($scope.application.defaultRegion);
+    }
+
+    if (stage.credentials) {
+      ctrl.accountUpdated();
+    }
 
     ctrl.updateCapacity = function() {
-      $scope.stage.capacity.desired = $scope.stage.capacity.max;
+      stage.capacity.desired = stage.capacity.max;
     };
 
     ctrl.updateResizeType = function() {
-      $scope.stage.capacity = {};
-      delete $scope.stage.scalePct;
-      delete $scope.stage.scaleNum;
+      stage.capacity = {};
+      delete stage.scalePct;
+      delete stage.scaleNum;
     };
 
   });

--- a/app/scripts/modules/securityGroups/AllSecurityGroupsCtrl.js
+++ b/app/scripts/modules/securityGroups/AllSecurityGroupsCtrl.js
@@ -5,8 +5,9 @@ angular.module('spinnaker.securityGroup.all.controller', [
   'ui.bootstrap',
   'spinnaker.utils.lodash',
   'spinnaker.providerSelection.service',
+  'spinnaker.settings',
 ])
-  .controller('AllSecurityGroupsCtrl', function($scope, $modal, _, providerSelectionService, application) {
+  .controller('AllSecurityGroupsCtrl', function($scope, $modal, _, providerSelectionService, application, settings) {
     $scope.application = application;
 
     $scope.sortFilter = {
@@ -53,15 +54,17 @@ angular.module('spinnaker.securityGroup.all.controller', [
 
     this.createSecurityGroup = function createSecurityGroup() {
       providerSelectionService.selectProvider().then(function(provider) {
+        var defaultCredentials = application.defaultCredentials || settings.providers.aws.defaults.account,
+            defaultRegion = application.defaultRegion || settings.providers.aws.defaults.region;
         $modal.open({
           templateUrl: 'scripts/modules/securityGroups/configure/' + provider + '/createSecurityGroup.html',
           controller: 'CreateSecurityGroupCtrl as ctrl',
           resolve: {
             securityGroup: function () {
               return {
-                credentials: 'test',
+                credentials: defaultCredentials,
                 subnet: 'none',
-                regions: [],
+                regions: [defaultRegion],
                 vpcId: null,
                 securityGroupIngress: []
               };

--- a/app/scripts/modules/serverGroups/configure/aws/serverGroupCommandBuilder.service.js
+++ b/app/scripts/modules/serverGroups/configure/aws/serverGroupCommandBuilder.service.js
@@ -14,8 +14,8 @@ angular.module('spinnaker.aws.serverGroupCommandBuilder.service', [
       defaults = defaults || {};
       var regionsKeyedByAccountLoader = accountService.getRegionsKeyedByAccount('aws');
 
-      var defaultCredentials = defaults.account || settings.providers.aws.defaults.account;
-      var defaultRegion = defaults.region || settings.providers.aws.defaults.region;
+      var defaultCredentials = defaults.account || application.defaultCredentials || settings.providers.aws.defaults.account;
+      var defaultRegion = defaults.region || application.defaultRegion || settings.providers.aws.defaults.region;
 
       var preferredZonesLoader = accountService.getAvailabilityZonesForAccountAndRegion('aws', defaultCredentials, defaultRegion);
 


### PR DESCRIPTION
…count or region

This applies to stages, server groups, load balancers, and security groups: if it's a new component, and your app is only deployed in one account or region, we should pre-select that instead of the ones in the settings.js file.
