### PR TITLE
use timeout to set execution details

### DIFF
--- a/app/scripts/modules/pipelines/config/stages/canary/canaryExecutionDetails.controller.js
+++ b/app/scripts/modules/pipelines/config/stages/canary/canaryExecutionDetails.controller.js
@@ -6,17 +6,25 @@ angular.module('spinnaker.pipelines.stage.canary.details.controller', [
   'spinnaker.executionDetails.section.service',
   'spinnaker.executionDetails.section.nav.directive'
 ])
-  .controller('CanaryExecutionDetailsCtrl', function ($scope, _, $stateParams, executionDetailsSectionService) {
+  .controller('CanaryExecutionDetailsCtrl', function ($scope, _, $stateParams, $timeout, executionDetailsSectionService) {
+
+    $scope.configSections = ['canarySummary', 'canaryConfig', 'taskStatus'];
 
     function initialize() {
-      $scope.configSections = ['canarySummary', 'canaryConfig', 'taskStatus'];
-      $scope.canary = $scope.stage.context.canary;
-      $scope.canaryConfig = $scope.stage.context.canary.canaryConfig;
-      $scope.baseline = $scope.stage.context.baseline;
-      $scope.canaryDeployments = $scope.stage.context.canary.canaryDeployments;
 
-      executionDetailsSectionService.synchronizeSection($scope.configSections);
-      $scope.detailsSection = $stateParams.details;
+      // When this is called from a stateChangeSuccess event, the stage in the scope is not updated in this digest cycle
+      // so we need to wait until the next cycle to update any scope values based on the stage
+      $timeout(function() {
+        executionDetailsSectionService.synchronizeSection($scope.configSections);
+        $scope.detailsSection = $stateParams.details;
+
+        $scope.canary = $scope.stage.context.canary;
+        if ($scope.canary) {
+          $scope.canaryConfig = $scope.canary.canaryConfig;
+          $scope.baseline = $scope.stage.context.baseline;
+          $scope.canaryDeployments = $scope.canary.canaryDeployments;
+        }
+      });
     }
 
     initialize();

--- a/app/scripts/modules/pipelines/config/stages/canary/canaryScore.directive.js
+++ b/app/scripts/modules/pipelines/config/stages/canary/canaryScore.directive.js
@@ -24,7 +24,8 @@ angular.module('spinnaker.pipelines.stages.canary.score.directive', [])
             : 'unknown';
         }
 
-        scope.$watch('health', applyLabel);
+        scope.$watch('health', applyLabel, true);
+        scope.$watch('result', applyLabel, true);
       }
     };
   });

--- a/app/scripts/modules/pipelines/config/stages/jenkins/jenkinsExecutionDetails.controller.js
+++ b/app/scripts/modules/pipelines/config/stages/jenkins/jenkinsExecutionDetails.controller.js
@@ -5,14 +5,14 @@ angular.module('spinnaker.pipelines.stage.jenkins.executionDetails.controller', 
   'spinnaker.executionDetails.section.service',
   'spinnaker.executionDetails.section.nav.directive',
 ])
-  .controller('JenkinsExecutionDetailsCtrl', function ($scope, $stateParams, executionDetailsSectionService) {
+  .controller('JenkinsExecutionDetailsCtrl', function ($scope, $stateParams, $timeout, executionDetailsSectionService) {
 
     $scope.configSections = ['jenkinsConfig', 'taskStatus'];
 
     function initialize() {
       executionDetailsSectionService.synchronizeSection($scope.configSections);
       $scope.detailsSection = $stateParams.details;
-      getFailureMessage();
+      $timeout(getFailureMessage);
     }
 
     function getFailureMessage() {

--- a/app/scripts/modules/pipelines/config/stages/jenkins/jenkinsExecutionDetails.controller.spec.js
+++ b/app/scripts/modules/pipelines/config/stages/jenkins/jenkinsExecutionDetails.controller.spec.js
@@ -5,7 +5,7 @@ describe('Jenkins Execution Details Controller:', function () {
 
   beforeEach(module('spinnaker.pipelines.stage.jenkins.executionDetails.controller'));
 
-  beforeEach(inject(function($controller, $rootScope) {
+  beforeEach(inject(function($controller, $rootScope, $timeout) {
     this.initializeController = function(stage) {
       var scope = $rootScope.$new();
       scope.stage = stage;
@@ -14,6 +14,7 @@ describe('Jenkins Execution Details Controller:', function () {
         executionDetailsSectionService: { synchronizeSection: angular.noop, },
       });
       $scope = scope;
+      $timeout.flush();
     };
   }));
 


### PR DESCRIPTION
More `$watch`es and more `$timeout`s to deal with `stateChangeSuccess` events firing in the `$digest` cycle before the `$scope` is actually updated.

We do this in every other stage where we do something meaningful with the controller, just never got into these two.
