### PR TITLE
do not cache image search results

### DIFF
--- a/app/scripts/modules/account/accountService.js
+++ b/app/scripts/modules/account/accountService.js
@@ -4,10 +4,10 @@
 angular.module('spinnaker.account.service', [
   'restangular',
   'spinnaker.utils.lodash',
-  'spinnaker.caches.scheduled',
+  'spinnaker.settings',
   'spinnaker.caches.infrastructure'
 ])
-  .factory('accountService', function(settings, _, Restangular, $q, scheduledCache, infrastructureCaches) {
+  .factory('accountService', function(settings, _, Restangular, $q, infrastructureCaches) {
 
     function getPreferredZonesByAccount(providerName) {
       var _providerName = providerName || 'aws';

--- a/app/scripts/modules/loadBalancers/loadBalancer.write.service.js
+++ b/app/scripts/modules/loadBalancers/loadBalancer.write.service.js
@@ -4,9 +4,8 @@ angular
   .module('spinnaker.loadBalancer.write.service', [
     'spinnaker.taskExecutor.service',
     'spinnaker.caches.infrastructure',
-    'spinnaker.caches.scheduled'
   ])
-  .factory('loadBalancerWriter', function(infrastructureCaches, scheduledCache, taskExecutor) {
+  .factory('loadBalancerWriter', function(infrastructureCaches, taskExecutor) {
 
     function deleteLoadBalancer(loadBalancer, application) {
       var operation = taskExecutor.executeTask({

--- a/app/scripts/modules/securityGroups/securityGroup.read.service.js
+++ b/app/scripts/modules/securityGroups/securityGroup.read.service.js
@@ -6,10 +6,9 @@ angular.module('spinnaker.securityGroup.read.service', [
   'spinnaker.settings',
   'spinnaker.search.service',
   'spinnaker.utils.lodash',
-  'spinnaker.caches.scheduled',
   'spinnaker.caches.infrastructure',
 ])
-  .factory('securityGroupReader', function ($q, $exceptionHandler, $log, Restangular, searchService, settings, _, scheduledCache, infrastructureCaches) {
+  .factory('securityGroupReader', function ($q, $exceptionHandler, $log, Restangular, searchService, _, infrastructureCaches) {
 
     function loadSecurityGroups(application) {
 

--- a/app/scripts/services/awsImageService.js
+++ b/app/scripts/services/awsImageService.js
@@ -3,16 +3,14 @@
 
 angular.module('spinnaker.aws.image.service', [
   'restangular',
-  'spinnaker.settings',
-  'spinnaker.caches.scheduled',
 ])
-  .factory('awsImageService', function ($q, Restangular,  settings, scheduledCache) {
+  .factory('awsImageService', function ($q, Restangular) {
 
     function findImages(params) {
       if (!params.q || params.q.length < 3) {
         return $q.when([{message: 'Please enter at least 3 characters...'}]);
       }
-      return Restangular.all('images/find').withHttpConfig({cache: scheduledCache}).getList(params, {})
+      return Restangular.all('images/find').getList(params, {})
         .then(function(results) {
           return results;
         },

--- a/app/scripts/services/gceImageService.js
+++ b/app/scripts/services/gceImageService.js
@@ -1,11 +1,13 @@
 'use strict';
 
 
-angular.module('spinnaker.gce.image.service', [])
-  .factory('gceImageService', function (settings, $q, Restangular, scheduledCache) {
+angular.module('spinnaker.gce.image.service', [
+  'restangular',
+])
+  .factory('gceImageService', function ($q, Restangular) {
 
     function findImages(params) {
-      return Restangular.all('images/find').withHttpConfig({cache: scheduledCache}).getList(params, {}).then(function(results) {
+      return Restangular.all('images/find').getList(params, {}).then(function(results) {
           return results;
         },
         function() {

--- a/app/scripts/services/imageService.spec.js
+++ b/app/scripts/services/imageService.spec.js
@@ -18,17 +18,16 @@
 
 describe('Service: ImageService', function() {
 
-  var service, $http, config, scope, timeout;
+  var service, $http, scope, timeout;
 
   beforeEach(
     module('spinnaker.image.service')
   );
 
 
-  beforeEach(inject(function (settings, imageService, $httpBackend, $rootScope, $timeout) {
+  beforeEach(inject(function (imageService, $httpBackend, $rootScope, $timeout) {
 
     service = imageService;
-    config = settings;
     $http = $httpBackend;
     timeout = $timeout;
     scope = $rootScope.$new();

--- a/app/scripts/services/taskExecutor.js
+++ b/app/scripts/services/taskExecutor.js
@@ -3,17 +3,14 @@
 
 angular.module('spinnaker.taskExecutor.service', [
   'restangular',
-  'spinnaker.settings',
   'spinnaker.scheduler',
   'spinnaker.urlBuilder',
   'spinnaker.authentication',
   'spinnaker.authentication.service',
-  'spinnaker.caches.scheduled',
-  'spinnaker.caches.infrastructure',
   'spinnaker.tasks.read.service',
   'spinnaker.tasks.write.service',
 ])
-  .factory('taskExecutor', function(settings, Restangular, scheduler, urlBuilder, $q, authenticationService, scheduledCache, infrastructureCaches, tasksReader, tasksWriter) {
+  .factory('taskExecutor', function(Restangular, scheduler, urlBuilder, $q, authenticationService, tasksReader, tasksWriter) {
 
 
     function executeTask(taskCommand) {


### PR DESCRIPTION
`scheduledCache` does not work as expected (it returns the cached result the first 10 cycles, but then returns nothing at all), so just removing it here, which stinks because the image search is really slow, but it's better than getting no images until the page is refreshed.
