### PR TITLE
filter links in execution details to single cluster view

### DIFF
--- a/app/scripts/modules/clusterFilter/clusterFilterService.js
+++ b/app/scripts/modules/clusterFilter/clusterFilterService.js
@@ -2,11 +2,12 @@
 
 angular
   .module('cluster.filter.service', [
+    'ui.router',
     'cluster.filter.model',
     'spinnaker.utils.lodash',
     'spinnaker.utils.waypoints.service',
   ])
-  .factory('clusterFilterService', function ($location, ClusterFilterModel, _, waypointService, $log) {
+  .factory('clusterFilterService', function ($location, ClusterFilterModel, _, waypointService, $log, $stateParams) {
 
     var lastApplication = null;
 
@@ -305,6 +306,27 @@ angular
       angular.copy(newOptions, ClusterFilterModel.displayOptions);
     }
 
+    function overrideFiltersForUrl(result) {
+      if (result.href.indexOf('/clusters') !== -1) {
+        ClusterFilterModel.clearFilters();
+        ClusterFilterModel.sortFilter.filter = result.serverGroup ? result.serverGroup :
+          result.cluster ? 'cluster:' + result.cluster : '';
+        if (result.account) {
+          var acct = {};
+          acct[result.account] = true;
+          ClusterFilterModel.sortFilter.account = acct;
+        }
+        if (result.region) {
+          var reg = {};
+          reg[result.region] = true;
+          ClusterFilterModel.sortFilter.region = reg;
+        }
+        if ($stateParams.application === result.application) {
+          updateClusterGroups();
+        }
+      }
+    }
+
     function clearFilters() {
       ClusterFilterModel.clearFilters();
       updateQueryParams();
@@ -396,6 +418,7 @@ angular
       sortGroupsByHeading: sortGroupsByHeading,
       clearFilters: clearFilters,
       shouldShowInstance: shouldShowInstance,
+      overrideFiltersForUrl: overrideFiltersForUrl,
     };
   }
 );

--- a/app/scripts/modules/pipelines/config/stages/canary/canaryDeployment/canaryDeploymentExecutionDetails.controller.js
+++ b/app/scripts/modules/pipelines/config/stages/canary/canaryDeployment/canaryDeploymentExecutionDetails.controller.js
@@ -6,11 +6,13 @@ angular.module('spinnaker.pipelines.stage.canary.canaryDeployment.details.contro
   'spinnaker.executionDetails.section.service',
   'spinnaker.executionDetails.section.nav.directive',
   'spinnaker.urlBuilder',
+  'cluster.filter.service',
   'spinnaker.pipelines.stages.canary.deployment.history.service'
 ])
   .controller('CanaryDeploymentExecutionDetailsCtrl', function ($scope, _, $stateParams, $timeout,
                                                                 executionDetailsSectionService,
-                                                                canaryDeploymentHistoryService, urlBuilder) {
+                                                                canaryDeploymentHistoryService, urlBuilder,
+                                                                clusterFilterService) {
 
     function initialize() {
       $scope.configSections = ['canaryDeployment', 'canaryAnalysisHistory', 'codeChanges'];
@@ -27,19 +29,23 @@ angular.module('spinnaker.pipelines.stage.canary.canaryDeployment.details.contro
       $scope.commits = $scope.stage.context.commits;
 
       if ($scope.deployment.baselineCluster) {
-        $scope.baselineClusterUrl = urlBuilder.buildFromMetadata({
+        var baselineMetadata = {
           type: 'clusters',
           application: $scope.stage.context.application,
           cluster: $scope.deployment.baselineCluster.name,
           account: $scope.deployment.baselineCluster.accountName,
-        });
+        };
+        baselineMetadata.href = urlBuilder.buildFromMetadata(baselineMetadata);
+        $scope.baselineClusterUrl = baselineMetadata;
 
-        $scope.canaryClusterUrl = urlBuilder.buildFromMetadata({
+        var canaryMetadata = {
           type: 'clusters',
           application: $scope.stage.context.application,
           cluster: $scope.deployment.canaryCluster.name,
           account: $scope.deployment.canaryCluster.accountName,
-        });
+        };
+        canaryMetadata.href = urlBuilder.buildFromMetadata(canaryMetadata);
+        $scope.canaryClusterUrl = canaryMetadata;
 
         $scope.loadHistory();
       }
@@ -65,6 +71,8 @@ angular.module('spinnaker.pipelines.stage.canary.canaryDeployment.details.contro
         $scope.viewState.loadingHistory = false;
       }
     };
+
+    this.overrideFiltersForUrl = clusterFilterService.overrideFiltersForUrl;
 
     initialize();
 

--- a/app/scripts/modules/pipelines/config/stages/canary/canaryDeployment/canaryDeploymentExecutionDetails.html
+++ b/app/scripts/modules/pipelines/config/stages/canary/canaryDeployment/canaryDeploymentExecutionDetails.html
@@ -37,7 +37,9 @@
         <div class="horizontal-rule"></div>
         <div class="row">
           <div class="col-md-3"><strong>Cluster</strong></div>
-          <div class="col-md-9"><a ng-href="{{baselineClusterUrl}}">{{deployment.baselineCluster.name}}</a></div>
+          <div class="col-md-9">
+            <a ng-click="$event.stopPropagation(); canaryDeploymentDetailsCtrl.overrideFiltersForUrl(baselineClusterUrl);"
+               ng-href="{{baselineClusterUrl.href}}">{{deployment.baselineCluster.name}}</a></div>
         </div>
         <div class="row">
           <div class="col-md-3"><strong>Image</strong></div>
@@ -59,7 +61,9 @@
         <div class="horizontal-rule"></div>
         <div class="row">
           <div class="col-md-3"><strong>Cluster</strong></div>
-          <div class="col-md-9"><a ng-href="{{canaryClusterUrl}}">{{deployment.canaryCluster.name}}</a></div>
+          <div class="col-md-9">
+            <a ng-click="$event.stopPropagation(); canaryDeploymentDetailsCtrl.overrideFiltersForUrl(canaryClusterUrl);"
+               ng-href="{{canaryClusterUrl.href}}">{{deployment.canaryCluster.name}}</a></div>
         </div>
         <div class="row">
           <div class="col-md-3"><strong>Image</strong></div>

--- a/app/scripts/modules/pipelines/config/stages/deploy/deployExecutionDetails.controller.js
+++ b/app/scripts/modules/pipelines/config/stages/deploy/deployExecutionDetails.controller.js
@@ -5,8 +5,10 @@ angular.module('spinnaker.pipelines.stage.deploy.details.controller', [
   'ui.router',
   'spinnaker.executionDetails.section.service',
   'spinnaker.executionDetails.section.nav.directive',
+  'spinnaker.urlBuilder',
+  'cluster.filter.service',
 ])
-  .controller('DeployExecutionDetailsCtrl', function ($scope, _, $stateParams, executionDetailsSectionService, $timeout) {
+  .controller('DeployExecutionDetailsCtrl', function ($scope, _, $stateParams, executionDetailsSectionService, $timeout, urlBuilder, clusterFilterService) {
 
     $scope.configSections = ['deploymentConfig', 'taskStatus', 'codeChanges'];
 
@@ -26,11 +28,16 @@ angular.module('spinnaker.pipelines.stage.deploy.details.controller', [
           var deployedArtifacts = _.find(resultObjects, key);
           if (deployedArtifacts) {
             _.forEach(deployedArtifacts[key], function (serverGroupName, region) {
-              results.push({
+              var result = {
+                type: 'serverGroups',
+                application: $scope.stage.context.application,
+                serverGroup: serverGroupName,
+                account: $scope.stage.context.account,
                 region: region,
-                name: serverGroupName,
-                provider: context.provider || 'aws',
-              });
+                provider: context.provider || 'aws'
+              };
+              result.href = urlBuilder.buildFromMetadata(result);
+              results.push(result);
             });
           }
         }
@@ -46,6 +53,8 @@ angular.module('spinnaker.pipelines.stage.deploy.details.controller', [
         $scope.deployed = results;
       });
     }
+
+    this.overrideFiltersForUrl = clusterFilterService.overrideFiltersForUrl;
 
     initialize();
 

--- a/app/scripts/modules/pipelines/config/stages/deploy/deployExecutionDetails.controller.spec.js
+++ b/app/scripts/modules/pipelines/config/stages/deploy/deployExecutionDetails.controller.spec.js
@@ -9,6 +9,7 @@ describe('DeployExecutionDetailsCtrl', function() {
     this._ = _;
     this.$timeout = $timeout;
     this.$scope = $rootScope.$new();
+    this.urlBuilder = { buildFromMetadata: function() { return '#'; }};
 
   }));
 
@@ -23,6 +24,7 @@ describe('DeployExecutionDetailsCtrl', function() {
           _: _,
           $stateParams: { details: 'deploymentConfig' },
           executionDetailsSectionService: jasmine.createSpyObj('executionDetailsSectionService', ['synchronizeSection']),
+          urlBuilder: this.urlBuilder,
         });
         this.$timeout.flush();
       };
@@ -73,8 +75,7 @@ describe('DeployExecutionDetailsCtrl', function() {
       };
       this.initializeController();
       expect(this.$scope.deployed.length).toBe(1);
-      expect(this.$scope.deployed[0].region).toBe('us-west-1');
-      expect(this.$scope.deployed[0].name).toBe('deployedAsg');
+      expect(this.$scope.deployed[0].serverGroup).toBe('deployedAsg');
 
     });
 
@@ -109,8 +110,7 @@ describe('DeployExecutionDetailsCtrl', function() {
       };
       this.initializeController();
       expect(this.$scope.deployed.length).toBe(1);
-      expect(this.$scope.deployed[0].region).toBe('us-west-1');
-      expect(this.$scope.deployed[0].name).toBe('deployedAsg');
+      expect(this.$scope.deployed[0].serverGroup).toBe('deployedAsg');
 
     });
 

--- a/app/scripts/modules/pipelines/config/stages/deploy/deployExecutionDetails.html
+++ b/app/scripts/modules/pipelines/config/stages/deploy/deployExecutionDetails.html
@@ -38,9 +38,9 @@
         <div class="well alert alert-info">
           <strong>Deployed:</strong>
           <a ng-repeat="serverGroup in deployed"
-             ng-click="$event.stopPropagation()"
-             ui-sref="home.applications.application.insight.clusters.serverGroup({application: stage.context.application, serverGroup: serverGroup.name, accountId: stage.context.account, region: serverGroup.region, provider: serverGroup.provider})">
-            {{serverGroup.name}}
+             ng-click="$event.stopPropagation(); deployDetailsCtrl.overrideFiltersForUrl(serverGroup);"
+             ng-href="{{serverGroup.href}}">
+            {{serverGroup.serverGroup}}
           </a>
         </div>
       </div>

--- a/app/scripts/modules/search/global/globalSearch.controller.js
+++ b/app/scripts/modules/search/global/globalSearch.controller.js
@@ -64,26 +64,7 @@ angular.module('spinnaker.search.global')
       });
     }, 200);
 
-    ctrl.clearFilters = function(result) {
-      if (result.href.indexOf('/clusters') !== -1) {
-        ClusterFilterModel.clearFilters();
-        ClusterFilterModel.sortFilter.filter = result.serverGroup ? result.serverGroup :
-            result.cluster ? 'cluster:' + result.cluster : '';
-        if (result.account) {
-          var acct = {};
-          acct[result.account] = true;
-          ClusterFilterModel.sortFilter.account = acct;
-        }
-        if (result.region) {
-          var reg = {};
-          reg[result.region] = true;
-          ClusterFilterModel.sortFilter.region = reg;
-        }
-        if ($stateParams.application === result.application) {
-          clusterFilterService.updateClusterGroups();
-        }
-      }
-    };
+    ctrl.clearFilters = clusterFilterService.overrideFiltersForUrl;
 
     this.focusFirstSearchResult = function focusFirstSearchResult(event) {
       try {


### PR DESCRIPTION
Moving the logic from global search that resets cluster filter model into clusterFilterService, then reusing in canary and deploy stage details.
