### PR TITLE
auto-refresh instance types if none present; provide option to refres…

### DIFF
--- a/app/scripts/modules/caches/cacheInitializer.js
+++ b/app/scripts/modules/caches/cacheInitializer.js
@@ -23,7 +23,7 @@ angular.module('spinnaker.caches.initializer', [
 
     var initializers = {
       credentials: [accountService.getRegionsKeyedByAccount, accountService.listAccounts],
-      instanceTypes: [ function() { instanceTypeService.getAllTypesByRegion('aws'); }],
+      instanceTypes: [ function() { return instanceTypeService.getAllTypesByRegion('aws'); }],
       loadBalancers: [loadBalancerReader.listAWSLoadBalancers],
       securityGroups: [securityGroupReader.getAllSecurityGroups],
       subnets: [subnetReader.listSubnets],

--- a/app/scripts/modules/serverGroups/configure/aws/serverGroupConfiguration.service.js
+++ b/app/scripts/modules/serverGroups/configure/aws/serverGroupConfiguration.service.js
@@ -209,6 +209,15 @@ angular.module('spinnaker.aws.serverGroup.configure.service', [
       });
     }
 
+    function refreshInstanceTypes(command) {
+      return cacheInitializer.refreshCache('instanceTypes').then(function() {
+        return instanceTypeService.getAllTypesByRegion('aws').then(function(instanceTypes) {
+          command.backingData.instanceTypes = instanceTypes;
+          configureInstanceTypes(command);
+        });
+      });
+    }
+
     function configureLoadBalancerOptions(command) {
       var results = { dirty: {} };
       var current = command.loadBalancers;
@@ -339,6 +348,7 @@ angular.module('spinnaker.aws.serverGroup.configure.service', [
       configureVpcId: configureVpcId,
       refreshLoadBalancers: refreshLoadBalancers,
       refreshSecurityGroups: refreshSecurityGroups,
+      refreshInstanceTypes: refreshInstanceTypes,
     };
 
 

--- a/app/scripts/modules/serverGroups/configure/common/instanceArchetypeDirective.html
+++ b/app/scripts/modules/serverGroups/configure/common/instanceArchetypeDirective.html
@@ -41,4 +41,17 @@
       <option value="">Select an instance type...</option>
     </select>
   </div>
+  <div class="form-group small" style="margin-top: 20px">
+    <div class="col-md-9 col-md-offset-1">
+      <p>
+        <span ng-if="instanceArchetypeCtrl.refreshing"><span class="small glyphicon glyphicon-refresh glyphicon-spinning"></span></span>
+        Instance types
+        <span ng-if="!instanceArchetypeCtrl.refreshing">last refreshed {{ instanceArchetypeCtrl.getInstanceTypeRefreshTime() | timestamp }}</span>
+        <span ng-if="instanceArchetypeCtrl.refreshing"> refreshing...</span>
+      </p>
+      <p>If you're not seeing an instance type you expect,
+        <a href ng-click="instanceArchetypeCtrl.refreshInstanceTypes()">click here</a> to refresh the list.
+      </p>
+    </div>
+  </div>
 </div>

--- a/app/scripts/modules/serverGroups/configure/common/serverGroup.configure.common.module.js
+++ b/app/scripts/modules/serverGroups/configure/common/serverGroup.configure.common.module.js
@@ -1,3 +1,5 @@
 'use strict';
 
-angular.module('spinnaker.serverGroup.configure.common', []);
+angular.module('spinnaker.serverGroup.configure.common', [
+  'spinnaker.serverGroup.configure.common.configure.service',
+]);

--- a/app/scripts/modules/serverGroups/configure/common/serverGroupConfiguration.service.js
+++ b/app/scripts/modules/serverGroups/configure/common/serverGroupConfiguration.service.js
@@ -1,0 +1,20 @@
+'use strict';
+
+angular.module('spinnaker.serverGroup.configure.common.configure.service', [
+  'spinnaker.aws.serverGroup.configure.service',
+  'spinnaker.gce.serverGroup.configure.service',
+])
+.factory('serverGroupConfigurationService', function(awsServerGroupConfigurationService, gceServerGroupConfigurationService) {
+
+  function getDelegate(provider) {
+    return (!provider || provider === 'aws') ? awsServerGroupConfigurationService : gceServerGroupConfigurationService;
+  }
+
+  function refreshInstanceTypes(provider, command) {
+    return getDelegate(provider).refreshInstanceTypes(command);
+  }
+
+  return {
+    refreshInstanceTypes: refreshInstanceTypes,
+  };
+});

--- a/app/scripts/modules/serverGroups/configure/gce/serverGroup.configure.gce.module.js
+++ b/app/scripts/modules/serverGroups/configure/gce/serverGroup.configure.gce.module.js
@@ -4,4 +4,5 @@ angular.module('spinnaker.serverGroup.configure.gce', [
   'spinnaker.account',
   'spinnaker.serverGroup.configure.gce.deployInitialization.controller',
   'spinnaker.serverGroups.basicSettings.controller',
+  'spinnaker.gce.serverGroup.configure.service',
 ]);

--- a/app/scripts/modules/serverGroups/configure/gce/serverGroupConfiguration.service.js
+++ b/app/scripts/modules/serverGroups/configure/gce/serverGroupConfiguration.service.js
@@ -1,7 +1,13 @@
 'use strict';
 
-angular.module('spinnaker.serverGroup.configure.gce')
-  .factory('gceServerGroupConfigurationService', function(imageService, accountService, securityGroupReader,
+angular.module('spinnaker.gce.serverGroup.configure.service', [
+  'spinnaker.image.service',
+  'spinnaker.account.service',
+  'spinnaker.instanceType.service',
+  'spinnaker.caches.initializer',
+  'spinnaker.loadBalancer.read.service',
+])
+  .factory('gceServerGroupConfigurationService', function(imageService, accountService,
                                                           instanceTypeService, cacheInitializer,
                                                           $q, loadBalancerReader) {
 
@@ -106,6 +112,15 @@ angular.module('spinnaker.serverGroup.configure.gce')
       });
     }
 
+    function refreshInstanceTypes(command) {
+      return cacheInitializer.refreshCache('instanceTypes').then(function() {
+        return instanceTypeService.getAllTypesByRegion('aws').then(function(instanceTypes) {
+          command.backingData.instanceTypes = instanceTypes;
+          configureInstanceTypes(command);
+        });
+      });
+    }
+
     function attachEventHandlers(command) {
 
       command.regionChanged = function regionChanged() {
@@ -150,6 +165,7 @@ angular.module('spinnaker.serverGroup.configure.gce')
       configureZones: configureZones,
       configureLoadBalancerOptions: configureLoadBalancerOptions,
       refreshLoadBalancers: refreshLoadBalancers,
+      refreshInstanceTypes: refreshInstanceTypes,
     };
 
 


### PR DESCRIPTION
Oh, this will be quick, I thought.

I'll just copy what's in the other directives, I thought.

Nope, just had to create another delegate service, tweak a handful of other things, etc. But now the instance types will try to self-heal if none are found, which is nice.
