### PR TITLE
disable cache when user not authenticated

### DIFF
--- a/app/scripts/modules/account/accountService.js
+++ b/app/scripts/modules/account/accountService.js
@@ -54,7 +54,7 @@ angular.module('spinnaker.account.service', [
       });
     }
 
-    var getRegionsKeyedByAccount = _.memoize(function(provider) {
+    function getRegionsKeyedByAccount(provider) {
       var deferred = $q.defer();
       listAccounts(provider).then(function(accounts) {
         $q.all(accounts.reduce(function(acc, account) {
@@ -69,7 +69,7 @@ angular.module('spinnaker.account.service', [
         });
       });
       return deferred.promise;
-    });
+    }
 
     function getAccountDetails(accountName) {
       return Restangular.one('credentials', accountName)

--- a/app/scripts/modules/authentication/authenticationService.js
+++ b/app/scripts/modules/authentication/authenticationService.js
@@ -10,6 +10,8 @@ angular.module('spinnaker.authentication.service', [
       authenticated: false
     };
 
+    var onAuthenticationEvents = [];
+
     function setAuthenticatedUser(authenticatedUser) {
       if (authenticatedUser) {
         user.name = authenticatedUser;
@@ -21,10 +23,17 @@ angular.module('spinnaker.authentication.service', [
       return user;
     }
 
+    function onAuthentication(event) {
+      onAuthenticationEvents.push(event);
+    }
+
     function authenticateUser() {
       $rootScope.authenticating = true;
       $http.get(settings.gateUrl + '/auth/info')
         .success(function (data) {
+          onAuthenticationEvents.forEach(function(event) {
+            event();
+          });
           if (data.email) {
             setAuthenticatedUser(data.email);
           }
@@ -52,6 +61,7 @@ angular.module('spinnaker.authentication.service', [
       setAuthenticatedUser: setAuthenticatedUser,
       getAuthenticatedUser: getAuthenticatedUser,
       authenticateUser: authenticateUser,
+      onAuthentication: onAuthentication,
     };
   })
   .factory('redirectService', function($window) {

--- a/app/scripts/modules/authentication/authenticationService.spec.js
+++ b/app/scripts/modules/authentication/authenticationService.spec.js
@@ -2,15 +2,19 @@
 
 describe('authenticationService', function() {
 
+  var $http, settings;
+
   beforeEach(function() {
     loadDeck({
       initializeCache: false,
-      generateUrls: true
-    })
+      generateUrls: true,
+    });
   });
 
-  beforeEach(inject(function(authenticationService) {
+  beforeEach(inject(function(authenticationService, $httpBackend, _settings_) {
     this.authenticationService = authenticationService;
+    $http = $httpBackend;
+    settings = _settings_;
   }));
 
   describe('setAuthenticatedUser', function() {
@@ -42,6 +46,26 @@ describe('authenticationService', function() {
       this.authenticationService.setAuthenticatedUser('');
       expect(user.name).toBe('[anonymous]');
       expect(user.authenticated).toBe(false);
+    });
+  });
+
+  describe('authentication', function () {
+
+    it('fires events and sets user', function () {
+      $http.expectGET(settings.gateUrl + '/auth/info').respond(200, {email: 'foo@bar.com'});
+      var firedEvents = 0;
+      this.authenticationService.onAuthentication(function() {
+        firedEvents++;
+      });
+      this.authenticationService.onAuthentication(function() {
+        firedEvents++;
+      });
+      this.authenticationService.authenticateUser();
+
+
+      $http.flush();
+      expect(this.authenticationService.getAuthenticatedUser().name).toBe('foo@bar.com');
+      expect(firedEvents).toBe(2);
     });
   });
 

--- a/app/scripts/modules/caches/deckCacheFactory.js
+++ b/app/scripts/modules/caches/deckCacheFactory.js
@@ -90,6 +90,7 @@ angular.module('spinnaker.caches.core', [
         storagePrefix: getStoragePrefix(key, currentVersion),
         recycleFreq: 5000, // ms,
         storageImpl: selfClearingLocalStorage,
+        disabled: cacheConfig.disabled,
       });
       caches[key] = cacheFactory.get(key);
       caches[key].getStats = getStats.bind(null, caches[key]);

--- a/app/scripts/modules/caches/infrastructureCacheConfig.js
+++ b/app/scripts/modules/caches/infrastructureCacheConfig.js
@@ -2,7 +2,10 @@
 
 angular.module('spinnaker.caches.infrastructure.config', [])
   .constant('infrastructureCacheConfig', {
-    credentials: {},
+    credentials: {
+      version: 2,
+      authEnabled: true,
+    },
     vpcs: {},
     subnets: {},
     applications: {

--- a/app/scripts/modules/caches/infrastructureCaches.js
+++ b/app/scripts/modules/caches/infrastructureCaches.js
@@ -3,8 +3,10 @@
 /* jshint newcap: false */
 angular.module('spinnaker.caches.infrastructure', [
   'spinnaker.caches.core',
+  'spinnaker.authentication.service',
+  'spinnaker.settings',
 ])
-  .factory('infrastructureCaches', function(deckCacheFactory) {
+  .factory('infrastructureCaches', function(deckCacheFactory, authenticationService, settings) {
 
     var caches = Object.create(null);
 
@@ -20,9 +22,20 @@ angular.module('spinnaker.caches.infrastructure', [
       Object.keys(caches).forEach(clearCache);
     }
 
-    function createCache(key, config) {
-      deckCacheFactory.createCache(namespace, key, config);
-      caches[key] = deckCacheFactory.getCache(namespace, key);
+    function createCache(key, cacheConfig) {
+      var shouldDisable = false;
+      if (settings.authEnabled && cacheConfig.authEnabled && !authenticationService.getAuthenticatedUser().authenticated) {
+        shouldDisable = true;
+      }
+      cacheConfig.disabled = shouldDisable;
+      deckCacheFactory.createCache(namespace, key, cacheConfig);
+      var cache = deckCacheFactory.getCache(namespace, key);
+      if (shouldDisable) {
+        authenticationService.onAuthentication(function() {
+          cache.enable();
+        });
+      }
+      caches[key] = cache;
     }
 
     caches.clearCaches = clearCaches;


### PR DESCRIPTION
Because Gate filters some data (just credentials right now), we need to _not_ cache that data when the first calls come through, since we assume the user is authenticated.

Rather that halt all execution until authentication completes, we simply disable caches that are configured with the `authEnabled` flag, then enable them when authentication completes. This is skipped if authentication is not enabled in the settings.

As a side effect, we have a hook into the completion of the authentication event.
