### PR TITLE
do not transform unstarted canary stages; accept TERMINATED status

### DIFF
--- a/app/scripts/modules/pipelines/config/stages/canary/canaryStage.transformer.js
+++ b/app/scripts/modules/pipelines/config/stages/canary/canaryStage.transformer.js
@@ -2,7 +2,7 @@
 
 // TODO: Clean this up on the backend - this is a mess
 angular.module('spinnaker.pipelines.stage.canary.transformer', [])
-  .service('canaryStageTransformer', function() {
+  .service('canaryStageTransformer', function($log) {
 
     // adds "canary" or "baseline" to the deploy stage name when converting it to a task
     function getDeployTaskName(stage) {
@@ -107,6 +107,10 @@ angular.module('spinnaker.pipelines.stage.canary.transformer', [])
               canaryStageId: stage.id,
             }
           });
+          if (!deployParent) {
+            $log.warn('No deployment parent found for canary stage in execution:', execution.id);
+            return;
+          }
           var monitorStage = _.find(execution.stages, {
             type: 'monitorCanary',
             context: {

--- a/app/scripts/services/orchestratedItem.js
+++ b/app/scripts/services/orchestratedItem.js
@@ -90,6 +90,8 @@ angular.module('spinnaker.orchestratedItem.service', [
           return 'CANCELED';
         case 'UNKNOWN':
           return 'UNKNOWN';
+        case 'TERMINATED':
+          return 'TERMINATED';
         default:
           if (item.originalStatus) {
             $log.warn('Unrecognized status:', item.originalStatus);


### PR DESCRIPTION
Logs the execution id to the console but otherwise does not try to transform the canary stage if it can't be transformed.

Also just passing through the TERMINATED status, since we see that intermittently and it's just noise in the console at this point.
