### PR TITLE
provide jump links for applications in global search

### DIFF
--- a/app/scripts/modules/search/global/globalSearch.controller.js
+++ b/app/scripts/modules/search/global/globalSearch.controller.js
@@ -13,6 +13,7 @@ angular.module('spinnaker.search.global')
       $scope.query = null;
       $scope.categories = null;
       $scope.showSearchResults = false;
+      ctrl.focussedResult = null;
       $element.find('input').focus();
     }
 
@@ -92,6 +93,7 @@ angular.module('spinnaker.search.global')
         reset();
       }
       if (event.which === 40) { // down
+        ctrl.focussedResult = null;
         try {
           $target
             .parent()
@@ -104,6 +106,7 @@ angular.module('spinnaker.search.global')
         event.preventDefault();
       }
       if (event.which === 38) { // up
+        ctrl.focussedResult = null;
         try {
           $target
             .parent()
@@ -114,6 +117,27 @@ angular.module('spinnaker.search.global')
           ctrl.focusLastSearchResult(event);
         }
         event.preventDefault();
+      }
+      if (event.which === 39) { // right
+        if ($target.is('.sublinked') || $target.is('.sublink')) {
+          if ($target.nextAll('.sublink').size()) {
+            $target.nextAll('.sublink')[0].focus();
+          } else {
+            $target.prevAll('.sublinked')[0].focus();
+          }
+        }
+      }
+      if (event.which === 37) { // left
+        if ($target.is('.sublinked')) {
+          $target.nextAll('.sublink').last().focus();
+        }
+        if ($target.is('.sublink')) {
+          try {
+            $target.prevAll('.sublink')[0].focus();
+          } catch (e) {
+            $target.prevAll('.sublinked')[0].focus();
+          }
+        }
       }
     };
   });

--- a/app/scripts/modules/search/global/globalSearch.less
+++ b/app/scripts/modules/search/global/globalSearch.less
@@ -18,8 +18,16 @@
       a {
         font-variant: normal;
         color: #000;
+        transition: background-color 0.2s, outline-width 0.2s;
         .expand-results {
           font-weight: bold;
+        }
+        &.sublinked, &.sublink {
+          display: inline-block;
+          padding-right: 5px;
+        }
+        &.sublink {
+          padding: 3px 6px;
         }
       }
       &.category-heading {

--- a/app/scripts/modules/search/infrastructure/infrastructureSearch.service.js
+++ b/app/scripts/modules/search/infrastructure/infrastructureSearch.service.js
@@ -19,6 +19,21 @@ angular.module('spinnaker.search')
         };
       }
 
+      var sublinks = {
+        applications: [
+          { name: 'clusters', href: '/clusters' },
+          { name: 'pipelines', href: '/../executions' },
+          { name: 'tasks', href: '/../tasks' }
+        ]
+      };
+
+      function applySublinks(entry) {
+        if (sublinks[entry.type]) {
+          entry.sublinks = sublinks[entry.type];
+          entry.href += entry.sublinks[0].href;
+        }
+      }
+
       var displayNameFormatter = {
         serverGroups: function(entry) {
           return entry.serverGroup + ' (' + entry.account + ': ' + entry.region + ')';
@@ -52,6 +67,7 @@ angular.module('spinnaker.search')
             var cat = entry.type;
             entry.name = displayNameFormatter[entry.type](entry);
             entry.href = urlBuilder.buildFromMetadata(entry);
+            applySublinks(entry);
             if (angular.isDefined(categories[cat])) {
               categories[cat].push(entry);
             } else {

--- a/app/scripts/services/urlbuilder.js
+++ b/app/scripts/services/urlbuilder.js
@@ -57,7 +57,7 @@ angular.module('spinnaker.urlBuilder', ['ui.router'])
       // url for a single application
       'applications': function(input) {
         return $state.href(
-          'home.applications.application.insight.clusters',
+          'home.applications.application',
           {
             application: input.application,
           },

--- a/app/views/globalsearch.html
+++ b/app/views/globalsearch.html
@@ -27,10 +27,25 @@
     </li>
     <li ng-repeat="result in category.results.slice(0,5)"
         ng-repeat-end
+        ng-mouseover="ctrl.focussedResult = result"
         class="result">
       <a ng-keydown="ctrl.navigateResults($event)" ng-click="ctrl.clearFilters(result)" href="{{ result.href }}" analytics-on="click"
          analytics-category="Global Search"
-         analytics-label="{{result.name}}"><span bind-html-unsafe="result.name | typeaheadHighlight:query"></span></a>
+         ng-class="{sublinked: result.sublinks}"
+         ng-focus="ctrl.focussedResult = result"
+         analytics-label="{{result.name}}"><span bind-html-unsafe="result.name | typeaheadHighlight:query"></span>
+      </a>
+      <span class="small" ng-if="result.sublinks && ctrl.focussedResult === result">jump to: </span>
+      <span ng-repeat-start="sublink in result.sublinks.slice(1)"
+            ng-show="ctrl.focussedResult === result && $index > 0">|</span>
+      <a class="sublink small" analytics-on="click"
+         ng-show="ctrl.focussedResult === result"
+         ng-repeat-end
+         analytics-category="Global Search - sublink"
+         ng-keydown="ctrl.navigateResults($event)" ng-click="ctrl.clearFilters(result)"
+         href="{{ result.href + sublink.href }}">
+        {{sublink.name}}
+      </a>
     </li>
     <li class="divider"></li>
     <li class="result" ng-if="categories.length">


### PR DESCRIPTION
Allow users to quickly navigate to pipeline executions or tasks from the global search menu. 

It's been driving me a little nuts when I want to see an application's executions that I have to pick it from the menu, then click "pipelines". Never again!
