### PR TITLE
hack around faulty task status reporting in orca

### DIFF
--- a/app/scripts/modules/tasks/tasks.api.config.js
+++ b/app/scripts/modules/tasks/tasks.api.config.js
@@ -155,7 +155,7 @@ angular.module('spinnaker.tasks.api', [
         }
         if (task.isCompleted || task.isRunning) {
           var forceRefreshStep = task.steps.filter(function(step) { return step.name === 'forceCacheRefresh'; });
-          if (forceRefreshStep.length && forceRefreshStep[0].status !== 'RUNNING' && forceRefreshStep[0].status !== 'NOT_STARTED') {
+          if (forceRefreshStep.length && (forceRefreshStep[0].status === 'COMPLETED' || forceRefreshStep[0].status === 'FAILED')) {
             var forceRefreshStatus = forceRefreshStep[0].status;
             if (forceRefreshStatus === 'COMPLETED') {
               deferred.resolve(task);
@@ -164,7 +164,9 @@ angular.module('spinnaker.tasks.api', [
               deferred.reject(task);
             }
           } else {
-            if (task.isCompleted) {
+            // HACK: If the task is completed, the steps should be completed, but sometimes Orca does not return the latest
+            // status of the steps. So we'll just band-aid over that.
+            if (task.isCompleted && forceRefreshStep.length && forceRefreshStep[0].status !== 'NOT_STARTED' && forceRefreshStep[0].status !== 'RUNNING') {
               deferred.reject(task);
             } else {
               if (!deferred.promise.cancelled) {


### PR DESCRIPTION
Somehow, Orca is sometimes returning a status of SUCCEEDED, even though some of the steps are NOT_STARTED. While this is very very bad, tracking down the root cause is beyond the scope of this PR. This PR is adding another band aid to deal with a buggy status reporting. 

Eventually - probably within 500ms, as far as I can tell - Orca shows the correct status for all tasks. So just keep polling until the expected status is returned.
