### PR TITLE
vpc migrator implementation

### DIFF
--- a/app/scripts/modules/migrator/migrator.directive.html
+++ b/app/scripts/modules/migrator/migrator.directive.html
@@ -1,0 +1,1 @@
+<a ng-hide="!showAction" href ng-click="migratorActionCtrl.previewMigration()">Migrate to VPC0</a>

--- a/app/scripts/modules/migrator/migrator.directive.js
+++ b/app/scripts/modules/migrator/migrator.directive.js
@@ -1,0 +1,120 @@
+'use strict';
+
+angular.module('spinnaker.migrator.directive', [
+  'ui.bootstrap',
+  'spinnaker.vpc.read.service',
+  'spinnaker.settings',
+  'spinnaker.migrator.service',
+])
+  .directive('migrator', function () {
+    return {
+      restrict: 'E',
+      replace: true,
+      scope: {
+        application: '=',
+        component: '=',
+        type: '@',
+      },
+      templateUrl: 'scripts/modules/migrator/migrator.directive.html',
+      controller: 'MigratorActionCtrl',
+      controllerAs: 'migratorActionCtrl'
+    };
+  })
+  .controller('MigratorActionCtrl', function ($scope, $modal, vpcReader, settings) {
+
+    vpcReader.getVpcName($scope.component.vpcId).then(function (name) {
+      $scope.showAction = name === 'Main' && settings.feature.vpcMigrator;
+    });
+
+    this.previewMigration = function () {
+      $modal.open({
+        templateUrl: 'scripts/modules/migrator/migrator.modal.html',
+        controller: 'MigratorCtrl as ctrl',
+        resolve: {
+          component: function () {
+            return $scope.component;
+          },
+          application: function () {
+            return $scope.application;
+          },
+          type: function() {
+            return $scope.type;
+          }
+        }
+      });
+    };
+  })
+  .controller('MigratorCtrl', function ($scope, component, application, type, $modalInstance, migratorService) {
+
+    var typeToField = {
+      serverGroup: 'asgName',
+      pipeline: 'pipelineId',
+    };
+
+    $scope.application = application;
+    $scope.component = component;
+
+    $scope.viewState = {
+      computing: true,
+    };
+
+    $scope.source = {
+      region: component.region,
+      account: component.account
+    };
+
+    $scope.source[typeToField[type]] = component.name;
+
+    var target = {
+      region: component.region,
+      account: component.account,
+      vpcName: 'vpc0'
+    };
+
+    var dryRun = migratorService.executeMigration({
+      source: $scope.source,
+      target: target,
+      dryRun: true,
+      application: application
+    });
+
+    dryRun.deferred.promise.then(
+      function () {
+        $scope.viewState.computing = false;
+        $scope.preview = dryRun.executionPlan;
+      },
+      function (error) {
+        $scope.viewState.error = error;
+      }
+    );
+
+    this.cancel = function () {
+      dryRun.deferred.promise.cancelled = true;
+      if ($scope.executor) {
+        $scope.executor.deferred.promise.cancelled = true;
+      }
+      $modalInstance.dismiss();
+    };
+
+    this.submit = function () {
+      $scope.viewState.executing = true;
+      var executor = migratorService.executeMigration({
+        source: $scope.source,
+        target: target,
+        dryRun: false,
+        application: application
+      });
+      executor.deferred.promise.then(
+        function () {
+          $scope.viewState.executing = false;
+          $scope.viewState.migrationComplete = true;
+        },
+        function (error) {
+          $scope.viewState.executing = false;
+          $scope.viewState.error = error;
+        }
+      );
+      $scope.executor = executor;
+    };
+
+  });

--- a/app/scripts/modules/migrator/migrator.less
+++ b/app/scripts/modules/migrator/migrator.less
@@ -1,0 +1,20 @@
+@import "app/styles/imports/commonImports.less";
+
+.migrator-modal {
+  .preview {
+    h4 {
+      margin: 20px 0 8px 0;
+      .glyphicon, .icon {
+        color: @healthy_green;
+      }
+    }
+    .preview-entry {
+      margin-left:18px;
+      font-weight:600;
+    }
+    .note {
+      margin-left:18px;
+      margin-top:5px;
+    }
+  }
+}

--- a/app/scripts/modules/migrator/migrator.modal.html
+++ b/app/scripts/modules/migrator/migrator.modal.html
@@ -1,0 +1,76 @@
+<div modal-page class="migrator-modal">
+  <div ng-include="'scripts/modules/migrator/migrator.modal.submitting.html'"></div>
+  <form role="form" name="form">
+    <modal-close></modal-close>
+    <div class="modal-header">
+      <h3>Migrate {{component.name}} to VPC0</h3>
+    </div>
+    <div class="modal-body">
+
+      <div class="row" ng-if="viewState.computing">
+        <div class="col-md-10 col-md-offset-1">
+          <h3 class="text-center">
+            <span class="small glyphicon glyphicon-asterisk glyphicon-spinning"></span>
+            Calculating execution plan...
+          </h3>
+        </div>
+      </div>
+
+      <div class="row preview" ng-if="!viewState.computing && preview && !viewState.executing && !viewState.migrationComplete">
+        <div class="col-md-10 col-md-offset-1">
+          <p>This will migrate <strong>{{source.asgName}}</strong> in {{source.region}} <account-tag account="source.account"></account-tag> to VPC0.</p>
+          <p>As part of this migration, the following items will be created:</p>
+          <div ng-if="preview.securityGroups.length">
+            <h4><span class="glyphicon glyphicon-transfer small"></span> Security Groups</h4>
+            <div ng-repeat="securityGroup in preview.securityGroups" class="preview-entry">{{securityGroup.awsReference.identity.groupName}}</div>
+          </div>
+          <div ng-if="preview.loadBalancers.length">
+            <h4><span class="small icon icon-elb"></span> Load Balancers</h4>
+            <div ng-repeat="loadBalancer in preview.loadBalancers" class="preview-entry">{{loadBalancer.awsReference.identity.loadBalancerName}}</div>
+            <p class="note">Note: if Route53 or sticky session policies are configured for the current load balancer,
+              you will need to set that up in the AWS console.
+            </p>
+          </div>
+          <div ng-if="preview.serverGroups.length">
+            <h4><span class="small glyphicon glyphicon-th"></span> Server Groups</h4>
+            <div ng-repeat="serverGroup in preview.serverGroups" class="preview-entry">{{serverGroup.awsReference.identity.autoScalingGroupName}}</div>
+            <p class="note">Note: server groups will be started in a disabled state with zero instances.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="row" ng-if="viewState.error">
+      <div class="col-md-10 col-md-offset-1">
+        We could not calculate an execution plan for {{component.name}} at this time.
+        <p>Reason: {{viewState.error}}</p>
+      </div>
+    </div>
+
+    <div class="row task-progress" ng-if="viewState.migrationComplete">
+      <div class="col-md-10 col-md-offset-1">
+        <p>The following operations have been successfully completed:</p>
+
+        <ul class="task task-progress">
+          <li ng-repeat="mutation in preview.mutations | orderBy: 'objectName'">
+            <span class="glyphicon glyphicon-ok-circle"></span> {{mutation.message}} <strong>{{mutation.objectName}}</strong>
+          </li>
+        </ul>
+
+      </div>
+    </div>
+    <div class="modal-footer" ng-if="viewState.error">
+      <button class="btn btn-default" ng-click="ctrl.cancel()">Close</button>
+    </div>
+
+    <div class="modal-footer" ng-if="!viewState.error && !viewState.executing">
+      <button class="btn btn-default" ng-click="ctrl.cancel()">{{viewState.migrationComplete ? 'Close' : 'Cancel'}}</button>
+      <button class="btn btn-primary"
+              ng-if="!viewState.executing && !viewState.computing && !viewState.migrationComplete"
+              ng-click="ctrl.submit()">
+        Migrate {{component.name}} to VPC0
+      </button>
+    </div>
+
+  </form>
+</div>

--- a/app/scripts/modules/migrator/migrator.modal.submitting.html
+++ b/app/scripts/modules/migrator/migrator.modal.submitting.html
@@ -1,0 +1,26 @@
+<div class="overlay overlay-modal" modal-page modal-overlay ng-if="viewState.executing || viewState.error">
+  <div class="modal-header">
+    <h3>Migrating {{component.name}} to VPC0</h3>
+  </div>
+  <div class="modal-body clearfix">
+    <div class="col-md-10 col-md-offset-1">
+      <ul class="task task-progress">
+        <li ng-repeat="entry in executor.lastResult.eventLog">
+          <span class="glyphicon glyphicon-ok-circle"></span> {{entry}}
+        </li>
+      </ul>
+      <ul class="task task-progress task-progress-running">
+        <li><span class="glyphicon glyphicon-spinning glyphicon-asterisk"></span></li>
+      </ul>
+    </div>
+  </div>
+  <div class="modal-footer">
+    <button class="btn btn-primary"
+            ng-if="!viewState.error"
+            ng-click="ctrl.cancel()" auto-focus>Close</button>
+    <button class="btn btn-primary"
+            ng-if="viewState.error"
+            ng-click="viewState.error = null">Go back and try again
+    </button>
+  </div>
+</div>

--- a/app/scripts/modules/migrator/migrator.service.js
+++ b/app/scripts/modules/migrator/migrator.service.js
@@ -1,0 +1,92 @@
+'use strict';
+
+angular.module('spinnaker.migrator.service', [
+  'spinnaker.utils.lodash',
+  'spinnaker.taskExecutor.service',
+  ])
+  .factory('migratorService', function($timeout, $q, _, taskExecutor) {
+
+    function executeMigration(config) {
+      var deferred = $q.defer();
+      var task = { id: null, deferred: deferred, dryRun: config.dryRun };
+      var taskStarter = taskExecutor.executeTask({
+        application: config.application,
+        description: 'Migrate ' + config.source.asgName + ' to VPC0',
+        job: [{
+          source: config.source,
+          type: 'deepCopyServerGroup',
+          target: config.target,
+          dryRun: config.dryRun,
+        }]
+      });
+
+      taskStarter.then(function(execution) {
+        task.id = execution.id;
+        task.execution = execution;
+        monitorTask(task);
+      });
+
+      return task;
+    }
+
+    function monitorTask(task) {
+
+      if (task.execution.isFailed) {
+        var exception = task.execution.getValueFor('exception') || { message: 'No reason provided.'};
+        task.deferred.reject(exception.message);
+        return;
+      }
+      if (task.execution.isCompleted && task.execution.getValueFor('tide.task')) {
+        if (task.dryRun) {
+          task.executionPlan = buildPreview(task);
+        }
+        task.deferred.resolve();
+      } else {
+        if (!task.deferred.promise.cancelled) {
+          task.lastResult = extractLastResult(task);
+          $timeout(function() {
+            task.execution.get().then(function(reloaded) {
+              task.execution = reloaded;
+              monitorTask(task);
+            });
+          }, 1000);
+        }
+      }
+
+    }
+
+    function getTideTask(task) {
+      if (task.execution.getValueFor('tide.task')) {
+        return task.execution.getValueFor('tide.task');
+      }
+      return {};
+    }
+
+    function extractLastResult(taskResult) {
+      var tideTask = getTideTask(taskResult);
+      taskResult.eventLog = _(tideTask.history).sortBy('timeStamp')
+        .pluck('message')
+        .valueOf();
+      return taskResult;
+    }
+
+    function buildPreview(plan) {
+      var tideTask = getTideTask(plan);
+      tideTask.mutations = tideTask.mutations || [];
+      return {
+        securityGroups: tideTask.mutations.filter(function(mutation) { return mutationIs(mutation, 'groupName'); }),
+        loadBalancers: tideTask.mutations.filter(function(mutation) { return mutationIs(mutation, 'loadBalancerName'); }),
+        serverGroups: tideTask.mutations.filter(function(mutation) { return mutationIs(mutation, 'autoScalingGroupName'); }),
+      };
+    }
+
+    function mutationIs(mutation, field) {
+      return mutation.awsReference && mutation.awsReference.identity && mutation.awsReference.identity[field];
+    }
+
+    return {
+      executeMigration: executeMigration,
+    };
+
+  })
+;

--- a/app/scripts/modules/serverGroups/details/aws/serverGroupDetails.aws.controller.js
+++ b/app/scripts/modules/serverGroups/details/aws/serverGroupDetails.aws.controller.js
@@ -12,6 +12,7 @@ angular.module('spinnaker.serverGroup.details.aws.controller', [
   'spinnaker.aws.serverGroupCommandBuilder.service',
   'spinnaker.executionFilter.service',
   'spinnaker.vpc.tag.directive',
+  'spinnaker.migrator.directive',
 ])
   .controller('awsServerGroupDetailsCtrl', function ($scope, $state, $templateCache, $compile, application, serverGroup,
                                                      serverGroupReader, awsServerGroupCommandBuilder, $modal, confirmationModalService, _, serverGroupWriter,

--- a/app/scripts/modules/serverGroups/details/aws/serverGroupDetails.html
+++ b/app/scripts/modules/serverGroups/details/aws/serverGroupDetails.html
@@ -39,6 +39,7 @@
             <li><a href ng-if="serverGroup.isDisabled" ng-click="ctrl.enableServerGroup()">Enable</a></li>
             <li><a href ng-click="ctrl.destroyServerGroup()">Destroy</a></li>
             <li><a href ng-click="ctrl.cloneServerGroup(serverGroup)">Clone</a></li>
+            <li><migrator application="application" component="serverGroup" type="serverGroup"></migrator></li>
           </ul>
         </div>
         <div class="dropdown" ng-if="serverGroup.insightActions.length > 0" dropdown>

--- a/app/scripts/modules/tasks/tasks.read.service.js
+++ b/app/scripts/modules/tasks/tasks.read.service.js
@@ -5,7 +5,12 @@ angular
   .factory('tasksReader', function(tasksApi) {
 
     function listAllTasksForApplication(applicationName) {
-      return tasksApi.one('applications', applicationName).all('tasks').getList();
+      return tasksApi.one('applications', applicationName).all('tasks').getList()
+        .then(function(tasks) {
+          return tasks.filter(function(task) {
+            return !task.getValueFor('dryRun');
+          });
+        });
     }
 
 

--- a/app/scripts/modules/vpc/vpc.read.service.js
+++ b/app/scripts/modules/vpc/vpc.read.service.js
@@ -11,8 +11,18 @@ angular
         .getList();
     }
 
+    function getVpcName(id) {
+      return listVpcs().then(function(vpcs) {
+        var matches = vpcs.filter(function(test) {
+          return test.id === id;
+        });
+        return matches.length ? matches[0].name : null;
+      });
+    }
+
     return {
-      listVpcs: listVpcs
+      listVpcs: listVpcs,
+      getVpcName: getVpcName,
     };
 
   });

--- a/app/scripts/modules/vpc/vpcTag.directive.js
+++ b/app/scripts/modules/vpc/vpcTag.directive.js
@@ -15,12 +15,11 @@ angular.module('spinnaker.vpc.tag.directive', [
           if (!scope.vpcId) {
             scope.vpcLabel = 'None (EC2 Classic)';
           } else {
-            vpcReader.listVpcs().then(function (vpcs) {
-              var vpc = _.find(vpcs, {id: scope.vpcId});
+            vpcReader.getVpcName(scope.vpcId).then(function (name) {
               scope.vpcLabel = '(' + scope.vpcId + ')';
 
-              if (vpc) {
-                scope.vpcLabel = vpc.name + ' ' + scope.vpcLabel;
+              if (name) {
+                scope.vpcLabel = name + ' ' + scope.vpcLabel;
               }
             });
           }

--- a/app/scripts/modules/vpc/vpcTag.directive.spec.js
+++ b/app/scripts/modules/vpc/vpcTag.directive.spec.js
@@ -2,33 +2,34 @@
 
 describe('Directives: healthCounts', function () {
 
+  var $q, vpcReader;
+
   beforeEach(module('spinnaker.vpc.tag.directive'));
 
-  beforeEach(inject(function ($rootScope, $compile, $q, vpcReader) {
+  beforeEach(inject(function ($rootScope, $compile, _$q_, _vpcReader_) {
     this.scope = $rootScope.$new();
     this.compile = $compile;
-    spyOn(vpcReader, 'listVpcs').and.callFake(function() {
-      return $q.when([{id: 'vpc-1', name: 'Main VPC'}]);
-    });
+    $q = _$q_;
+    vpcReader = _vpcReader_;
   }));
 
   describe('vpc tag rendering - no VPC provided', function () {
 
     it('displays default message when no vpcId supplied', function () {
-      var domNode = this.compile('<vpc-tag></health-counts>')(this.scope);
+      var domNode = this.compile('<vpc-tag></vpc-tag>')(this.scope);
       this.scope.$digest();
       expect(domNode.find('span').text()).toBe('None (EC2 Classic)');
     });
 
     it('displays default message when undefined vpcId supplied', function () {
-      var domNode = this.compile('<vpc-tag vpc-id="notDefined"></health-counts>')(this.scope);
+      var domNode = this.compile('<vpc-tag vpc-id="notDefined"></vpc-tag>')(this.scope);
       this.scope.$digest();
       expect(domNode.find('span').text()).toBe('None (EC2 Classic)');
     });
 
     it('displays default message when null vpcId supplied', function () {
       this.scope.vpcId = null;
-      var domNode = this.compile('<vpc-tag vpc-id="vpcId"></health-counts>')(this.scope);
+      var domNode = this.compile('<vpc-tag vpc-id="vpcId"></vpc-tag>')(this.scope);
       this.scope.$digest();
       expect(domNode.find('span').text()).toBe('None (EC2 Classic)');
     });
@@ -37,15 +38,21 @@ describe('Directives: healthCounts', function () {
   describe('vpc tag rendering - VPC provided', function () {
 
     it('displays vpc name when found', function() {
+      spyOn(vpcReader, 'getVpcName').and.callFake(function() {
+        return $q.when('Main VPC');
+      });
       this.scope.vpcId = 'vpc-1';
-      var domNode = this.compile('<vpc-tag vpc-id="vpcId"></health-counts>')(this.scope);
+      var domNode = this.compile('<vpc-tag vpc-id="vpcId"></vpc-tag>')(this.scope);
       this.scope.$digest();
       expect(domNode.find('span').text()).toBe('Main VPC (vpc-1)');
     });
 
     it('displays vpc id when not found', function() {
+      spyOn(vpcReader, 'getVpcName').and.callFake(function() {
+        return $q.when(null);
+      });
       this.scope.vpcId = 'vpc-2';
-      var domNode = this.compile('<vpc-tag vpc-id="vpcId"></health-counts>')(this.scope);
+      var domNode = this.compile('<vpc-tag vpc-id="vpcId"></vpc-tag>')(this.scope);
       this.scope.$digest();
       expect(domNode.find('span').text()).toBe('(vpc-2)');
     });

--- a/app/scripts/settings/settings.js
+++ b/app/scripts/settings/settings.js
@@ -79,6 +79,7 @@ angular.module('spinnaker.settings', [])
       canary: true,
       parallelPipelines: true,
       fastProperty: true,
+      vpcMigrator: true,
     },
 
 

--- a/app/styles/modals.less
+++ b/app/styles/modals.less
@@ -5,6 +5,9 @@
 }
 .modal {
   z-index: 10002;
+  h2, h3, h4, h5 {
+    font-weight: 600;
+  }
 }
 
 .modal-header {


### PR DESCRIPTION
Feature flagged; for now, performs a very specific migration of a server group in "Main" to "vpc0". 

Eventually, the goal is to make this general purpose, as it integrates with Tide to perform a deep copy of load balancers and security groups into an arbitrary set of coordinates, i.e. it can migrate a server group to a new region, new account, new VPC, or any combination of the three.

The plan is to add this to pipelines next week, which will involve a refactor (the API is not complete for pipeline migrations, so it's unclear what the data structures will need to look like). This just gets it out the door and into production, since we've tagged our "Main" VPC as deprecated and are now surfacing that in the UI.
