### PR TITLE
include url message in HipChat link

### DIFF
--- a/app/scripts/config.js
+++ b/app/scripts/config.js
@@ -35,6 +35,9 @@ angular.module('spinnaker')
       'Content-Type': 'application/json;charset=utf-8'
     };
   })
+  .config(function($compileProvider) {
+    $compileProvider.aHrefSanitizationWhitelist(/^\s*(https?|mailto|hipchat):/);
+  })
   .config(function($provide) {
     $provide.decorator('$exceptionHandler', function ($delegate, $analytics) {
       return function (exception, cause) {

--- a/app/scripts/modules/feedback/feedback.directive.js
+++ b/app/scripts/modules/feedback/feedback.directive.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('spinnaker.feedback.directive', [])
-  .directive('feedback', function() {
+  .directive('feedback', function($location) {
     return {
       restrict: 'E',
       templateUrl: 'scripts/modules/feedback/feedback.html',
@@ -14,6 +14,10 @@ angular.module('spinnaker.feedback.directive', [])
 
         $scope.toggleMenu = function() {
           $scope.state.showMenu = !$scope.state.showMenu;
+        };
+
+        $scope.getCurrentUrlMessage = function() {
+          return encodeURIComponent('(via ' + $location.absUrl() + ')\n');
         };
 
         $scope.openFeedback = function() {

--- a/app/scripts/modules/feedback/feedback.html
+++ b/app/scripts/modules/feedback/feedback.html
@@ -14,7 +14,7 @@
         </a>
       </li>
       <li>
-        <a href="hipchat://www.hipchat.com/room/Spinnaker%20Help" ng-click="toggleMenu()">
+        <a href="hipchat://www.hipchat.com/room/Spinnaker%20Help?message={{getCurrentUrlMessage()}}" ng-click="toggleMenu()">
           <span class="icon"><span class="glyphicon icon-bubbles"></span></span>
           Talk to us on HipChat
         </a>


### PR DESCRIPTION
The config changes are needed to keep Angular from prefixing the link with "unsafe:" and preventing it from actually doing anything.
