### PR TITLE
edit copy of deploy configuration instead of original

### DIFF
--- a/app/scripts/modules/serverGroups/configure/aws/serverGroupCommandBuilder.service.js
+++ b/app/scripts/modules/serverGroups/configure/aws/serverGroupCommandBuilder.service.js
@@ -66,8 +66,9 @@ angular.module('spinnaker.aws.serverGroupCommandBuilder.service', [
         });
     }
 
-    function buildServerGroupCommandFromPipeline(application, pipelineCluster) {
+    function buildServerGroupCommandFromPipeline(application, originalCluster) {
 
+      var pipelineCluster = _.cloneDeep(originalCluster);
       var region = Object.keys(pipelineCluster.availabilityZones)[0];
       var instanceTypeCategoryLoader = instanceTypeService.getCategoryForInstanceType('aws', pipelineCluster.instanceType);
       var commandOptions = { account: pipelineCluster.account, region: region };

--- a/app/scripts/modules/serverGroups/configure/gce/ServerGroupCommandBuilder.js
+++ b/app/scripts/modules/serverGroups/configure/gce/ServerGroupCommandBuilder.js
@@ -190,8 +190,9 @@ angular.module('spinnaker.gce.serverGroupCommandBuilder.service', [
       return $q.when(command);
     }
 
-    function buildServerGroupCommandFromPipeline(application, pipelineCluster) {
+    function buildServerGroupCommandFromPipeline(application, originalCluster) {
 
+      var pipelineCluster = _.cloneDeep(originalCluster);
       var region = Object.keys(pipelineCluster.availabilityZones)[0];
       var instanceTypeCategoryLoader = instanceTypeService.getCategoryForInstanceType('gce', pipelineCluster.instanceType);
       var commandOptions = { account: pipelineCluster.account, region: region };


### PR DESCRIPTION
Without this change, modifying certain properties of a deploy configuration (e.g. capacity) modify the actual configuration, so canceling the edit leaves the deploy configuration partially changed.
