### PR TITLE
edit copy of application properties, fix tests

### DIFF
--- a/app/scripts/modules/config/config.controller.js
+++ b/app/scripts/modules/config/config.controller.js
@@ -7,6 +7,7 @@ angular
     'spinnaker.confirmationModal.service',
     'spinnaker.caches.initializer',
     'spinnaker.caches.infrastructure',
+    'spinnaker.config.notification.service',
   ])
   .controller('ConfigController', function ($modal, $state, $log, applicationWriter, confirmationModalService,
                                             cacheInitializer, infrastructureCaches, application, notificationService) {
@@ -26,7 +27,9 @@ angular
             return application;
           }
         }
-      });
+      }).result.then(function(newAttributes) {
+          application.attributes = newAttributes;
+        });
     };
 
     vm.deleteApplication = function () {

--- a/app/scripts/modules/config/config.controller.spec.js
+++ b/app/scripts/modules/config/config.controller.spec.js
@@ -1,67 +1,59 @@
 'use strict';
 
-xdescribe('Controller: Config', function () {
+describe('Controller: Config', function () {
 
   var $controller;
   var configController;
-  var applicationWriter;
-  var $state;
+  var notificationService;
   var $rootScope;
-  var $q;
+  var $modal;
+  var application;
 
   beforeEach(module(
     'spinnaker.config.controller'
   ));
 
   beforeEach(
-    inject(function (_$rootScope_, _$controller_, _$q_, _applicationWriter_, _$state_) {
+    inject(function (_$rootScope_, _$controller_, _$modal_, _notificationService_) {
       $rootScope = _$rootScope_;
       $controller = _$controller_;
-      applicationWriter = _applicationWriter_;
-      $state = _$state_;
-      $q = _$q_;
+      $modal = _$modal_;
+      notificationService = _notificationService_;
     })
   );
 
+  beforeEach(function() {
+    spyOn(notificationService, 'getNotificationsForApplication').and.returnValue({then: angular.noop});
+  });
 
-  describe('delete an application ', function () {
+  describe('edit application ', function () {
     beforeEach( function() {
+        application = {
+          serverGroups:[],
+          name: 'test-app',
+          accounts: 'test'
+        };
+
         configController = $controller('ConfigController', {
-          applicationWriter: applicationWriter,
-          application: {
-            serverGroups:[],
-            name: 'test-app',
-            accounts: 'test'
-          }
+          application: application,
+          $modal: $modal,
+          notificationService: notificationService,
         });
       }
     );
 
-    it('should delete the app and route to the applications list page', function () {
-      var deferred = $q.defer();
+    it('should copy attributes when edit application is successful', function() {
+      var newAttributes = { foo: 'bar' };
+      spyOn($modal, 'open').and.returnValue({
+        result: {
+          then: function(method) {
+            method(newAttributes);
+          }
+        }
+      });
 
-      spyOn(applicationWriter, 'deleteApplication').and.returnValue(deferred.promise);
-      spyOn($state, 'go');
-
-      configController.deleteApplication();
-      deferred.resolve('all good');
-      $rootScope.$apply();
-
-      expect(applicationWriter.deleteApplication).toHaveBeenCalled();
-      expect($state.go).toHaveBeenCalledWith('home.applications');
-    });
-
-    it('should show an error if the delete fails', function () {
-      var deferred = $q.defer();
-
-      spyOn(applicationWriter, 'deleteApplication').and.returnValue(deferred.promise);
-      configController.deleteApplication();
-
-      deferred.reject(new Error('failed'));
-      $rootScope.$apply();
-
-      expect(applicationWriter.deleteApplication).toHaveBeenCalled();
-      expect(configController.error).toBe('failed');
+      configController.editApplication();
+      expect(application.attributes).toBe(newAttributes);
     });
   });
 

--- a/app/scripts/modules/config/modal/editApplication.controller.modal.js
+++ b/app/scripts/modules/config/modal/editApplication.controller.modal.js
@@ -2,21 +2,19 @@
 
 angular
   .module('spinnaker.editApplication.modal.controller',[
-    'spinnaker.applications.write.service'
+    'spinnaker.applications.write.service',
+    'ui.router',
+    'spinnaker.utils.lodash',
   ])
-  .controller('EditApplicationController', function ($window, $state, application, applicationWriter) {
+  .controller('EditApplicationController', function ($window, $state, application, $modalInstance, applicationWriter, _) {
     var vm = this;
     vm.submitting = false;
     vm.errorMsgs = [];
     vm.application = application;
-    vm.applicationAttributes = application.attributes;
+    vm.applicationAttributes = _.cloneDeep(application.attributes);
 
-    function routeToApplication() {
-      $state.go(
-        'home.applications.application', {
-          application: vm.application.name,
-        }
-      );
+    function closeModal() {
+      $modalInstance.close(vm.applicationAttributes);
     }
 
     function extractErrorMsg(error) {
@@ -45,15 +43,9 @@ angular
       vm.submitting = false;
     }
 
-
-
     function submitting() {
       vm.submitting = true;
     }
-
-
-
-
 
     vm.clearEmailMsg = function() {
       vm.emailErrorMsg = '';
@@ -62,13 +54,13 @@ angular
     vm.submit = function () {
       submitting();
 
-      applicationWriter.updateApplication(application.attributes)
+      applicationWriter.updateApplication(vm.applicationAttributes)
         .then(
           function(taskResponseList) {
             _.first(taskResponseList)
               .watchForTaskComplete()
               .then(
-                routeToApplication,
+                closeModal,
                 extractErrorMsg
               );
           },


### PR DESCRIPTION
Right now, we are editing the actual application, meaning that canceling the action leaves the attributes on the page changed.

Instead, we make a copy of the `attributes` object, edit that, then set those attributes on the application once the application is successfully saved.
