### PR TITLE
hold all non-authentication requests until authentication completes

### DIFF
--- a/app/scripts/modules/authentication/authentication.initializer.service.js
+++ b/app/scripts/modules/authentication/authentication.initializer.service.js
@@ -1,0 +1,48 @@
+'use strict';
+
+angular.module('spinnaker.authentication.initializer.service', [
+  'spinnaker.settings',
+  'spinnaker.authentication.service',
+  'ui.bootstrap',
+])
+  .factory('authenticationInitializer', function ($http, $rootScope, $modal, redirectService, authenticationService, settings, $location) {
+
+    function authenticateUser() {
+      $rootScope.authenticating = true;
+      $http.get(settings.authEndpoint)
+        .success(function (data) {
+          if (data.email) {
+            authenticationService.setAuthenticatedUser(data.email);
+          }
+          $rootScope.authenticating = false;
+        })
+        .error(function (data, status, headers) {
+          var redirect = headers('X-AUTH-REDIRECT-URL');
+          if (status === 401 && redirect) {
+            $modal.open({
+              templateUrl: 'scripts/modules/authentication/authenticating.html',
+              windowClass: 'modal no-animate',
+              backdropClass: 'modal-backdrop-no-animate',
+              backdrop: 'static',
+              keyboard: false
+            });
+            var callback = encodeURIComponent($location.absUrl());
+            redirectService.redirect(settings.gateUrl + redirect + '?callback=' + callback);
+          } else {
+            $rootScope.authenticating = false;
+          }
+        });
+    }
+
+    return {
+      authenticateUser: authenticateUser
+    };
+  })
+  .factory('redirectService', function($window) {
+    // this exists so we can spy on the location without actually changing the window location in tests
+    return {
+      redirect: function(url) {
+        $window.location.href = url;
+      }
+    };
+  });

--- a/app/scripts/modules/authentication/authentication.interceptor.service.js
+++ b/app/scripts/modules/authentication/authentication.interceptor.service.js
@@ -1,0 +1,32 @@
+'use strict';
+
+angular.module('spinnaker.authentication.interceptor.service', [
+  'spinnaker.settings',
+  'spinnaker.authentication.service',
+])
+  .factory('authenticationInterceptor', function ($q, settings, authenticationService) {
+
+    return {
+      request: function (config) {
+        var deferred = $q.defer();
+        // pass through to authentication endpoint and non-http resources
+        if (config.url === settings.authEndpoint || config.url.indexOf('http') !== 0) {
+          deferred.resolve(config);
+        } else {
+          if (authenticationService.getAuthenticatedUser().authenticated) {
+            deferred.resolve(config);
+          } else {
+            authenticationService.onAuthentication(function () {
+              deferred.resolve(config);
+            });
+          }
+        }
+        return deferred.promise;
+      }
+    };
+  })
+  .config(function ($httpProvider, settings) {
+    if (settings.authEnabled) {
+      $httpProvider.interceptors.push('authenticationInterceptor');
+    }
+  });

--- a/app/scripts/modules/authentication/authentication.interceptor.spec.js
+++ b/app/scripts/modules/authentication/authentication.interceptor.spec.js
@@ -1,0 +1,77 @@
+'use strict';
+
+describe('authenticationInterceptor', function() {
+
+  var interceptor, $q, settings, authenticationService, $rootScope;
+
+  beforeEach(module('spinnaker.authentication.interceptor.service'));
+
+  beforeEach(inject(function(authenticationInterceptor, _$q_, _settings_, _authenticationService_, _$rootScope_) {
+    interceptor = authenticationInterceptor;
+    $q = _$q_;
+    settings = _settings_;
+    authenticationService = _authenticationService_;
+    $rootScope = _$rootScope_;
+  }));
+
+  describe('non-intercepted requests', function() {
+    it('resolves immediately for auth endpoint', function() {
+      var resolved = null;
+      var request = { url: settings.authEndpoint };
+      interceptor.request(request).then(function(result) { resolved = result; });
+      $rootScope.$digest();
+      expect(resolved).toBe(request);
+    });
+
+    it('resolves immediately for relative and non-http requests', function() {
+      var resolved = null;
+      var request = { url: '/something/relative' };
+      interceptor.request(request).then(function(result) { resolved = result; });
+      $rootScope.$digest();
+      expect(resolved.url).toBe(request.url);
+
+      request.url = 'tcp://what.are.you.doing.here';
+      interceptor.request(request).then(function(result) { resolved = result; });
+      $rootScope.$digest();
+      expect(resolved.url).toBe(request.url);
+    });
+  });
+
+  describe('intercepted requests', function () {
+
+    it('registers event with authentication service and does not resolve when not authenticated', function () {
+      var resolved = null;
+      var request = { url: 'http://some-server.spinnaker.org' };
+
+      var pendingRequests = [];
+
+      spyOn(authenticationService, 'getAuthenticatedUser').and.returnValue({ authenticated: false });
+      spyOn(authenticationService, 'onAuthentication').and.callFake(function(pendingRequest) {
+        pendingRequests.push(pendingRequest);
+      });
+
+      interceptor.request(request).then(function(result) { resolved = result; });
+      $rootScope.$digest();
+      expect(resolved).toBe(null);
+      expect(pendingRequests.length).toBe(1);
+
+      // simulate authentication event
+      pendingRequests[0]();
+      $rootScope.$digest();
+      expect(resolved).toBe(request);
+    });
+
+    it('resolves immediately when authenticated', function () {
+      var resolved = null;
+      var request = { url: 'http://some-server.spinnaker.org' };
+
+      spyOn(authenticationService, 'getAuthenticatedUser').and.returnValue({ authenticated: true });
+
+      interceptor.request(request).then(function(result) { resolved = result; });
+      $rootScope.$digest();
+      expect(resolved.url).toBe(request.url);
+
+    });
+  });
+
+});

--- a/app/scripts/modules/authentication/authentication.module.js
+++ b/app/scripts/modules/authentication/authentication.module.js
@@ -3,15 +3,17 @@
 angular.module('spinnaker.authentication', [
   'ui.bootstrap',
   'spinnaker.authentication.service',
+  'spinnaker.authentication.interceptor.service',
+  'spinnaker.authentication.initializer.service',
   'spinnaker.authentication.directive',
   'spinnaker.settings',
 ])
   .config(function ($httpProvider) {
     $httpProvider.interceptors.push('gateRequestInterceptor');
   })
-  .run(function (authenticationService, settings) {
+  .run(function (authenticationInitializer, settings) {
     if(settings.authEnabled) {
-      authenticationService.authenticateUser();
+      authenticationInitializer.authenticateUser();
     }
   })
   .factory('gateRequestInterceptor', function (settings) {

--- a/app/scripts/modules/authentication/authenticationProvider.spec.js
+++ b/app/scripts/modules/authentication/authenticationProvider.spec.js
@@ -32,7 +32,7 @@ describe('authenticationProvider: application startup', function() {
   describe('authenticateUser', function() {
     it('requests authentication from gate, then sets authentication name field', function() {
       if(!this.settings.authEnabled) { pending(); } //prevents the test from running if authentication is not enabled
-      this.$http.whenGET(this.settings.gateUrl + '/auth/info').respond(200, {email: 'joe!'});
+      this.$http.whenGET(this.settings.authEndpoint).respond(200, {email: 'joe!'});
       this.$timeout.flush();
       this.$http.flush();
 
@@ -48,7 +48,7 @@ describe('authenticationProvider: application startup', function() {
       spyOn(this.redirectService, 'redirect').and.callFake(function(url) {
         redirectUrl = url;
       });
-      this.$http.whenGET(this.settings.gateUrl + '/auth/info').respond(401, null, {'X-AUTH-REDIRECT-URL': '/authUp'});
+      this.$http.whenGET(this.settings.authEndpoint).respond(401, null, {'X-AUTH-REDIRECT-URL': '/authUp'});
       this.$timeout.flush();
       this.$http.flush();
 

--- a/app/scripts/modules/authentication/authenticationService.spec.js
+++ b/app/scripts/modules/authentication/authenticationService.spec.js
@@ -52,7 +52,6 @@ describe('authenticationService', function() {
   describe('authentication', function () {
 
     it('fires events and sets user', function () {
-      $http.expectGET(settings.gateUrl + '/auth/info').respond(200, {email: 'foo@bar.com'});
       var firedEvents = 0;
       this.authenticationService.onAuthentication(function() {
         firedEvents++;
@@ -60,10 +59,7 @@ describe('authenticationService', function() {
       this.authenticationService.onAuthentication(function() {
         firedEvents++;
       });
-      this.authenticationService.authenticateUser();
-
-
-      $http.flush();
+      this.authenticationService.setAuthenticatedUser('foo@bar.com');
       expect(this.authenticationService.getAuthenticatedUser().name).toBe('foo@bar.com');
       expect(firedEvents).toBe(2);
     });

--- a/app/scripts/settings/settings.js
+++ b/app/scripts/settings/settings.js
@@ -5,6 +5,7 @@ angular.module('spinnaker.settings', [])
   .constant('settings', {
     feedbackUrl: 'http://hootch.test.netflix.net/submit',
     gateUrl: 'https://spinnaker-api-prestaging.prod.netflix.net',
+    authEndpoint: 'https://spinnaker-api-prestaging.prod.netflix.net/auth/info',
     pollSchedule: 30000,
     providers: {
       aws: {


### PR DESCRIPTION
Some deck chair shuffling to get around circular dependencies, but the basic gist is: if the user is not authenticated, hold any http requests until authentication completes, then make those ajax calls.

This should set us up for success when we actually start rejecting calls to gate when not authenticated.

I am hoping this resolves the issues with the "Logging you in..." message appearing repeatedly. My speculation is that, since a bunch of requests come in at the same time, we end up receiving multiple session ids, but I have no proof that this is the case. Fingers crossed.

Will need to update the internal build to include the authUrl setting. There is redundancy there but I can live with it for now.
