### PR TITLE
remove code to disable cache while authenticating

### DIFF
--- a/app/scripts/modules/caches/infrastructureCacheConfig.js
+++ b/app/scripts/modules/caches/infrastructureCacheConfig.js
@@ -4,7 +4,6 @@ angular.module('spinnaker.caches.infrastructure.config', [])
   .constant('infrastructureCacheConfig', {
     credentials: {
       version: 2,
-      authEnabled: true,
     },
     vpcs: {
       version: 2,

--- a/app/scripts/modules/caches/infrastructureCaches.js
+++ b/app/scripts/modules/caches/infrastructureCaches.js
@@ -3,10 +3,8 @@
 /* jshint newcap: false */
 angular.module('spinnaker.caches.infrastructure', [
   'spinnaker.caches.core',
-  'spinnaker.authentication.service',
-  'spinnaker.settings',
 ])
-  .factory('infrastructureCaches', function(deckCacheFactory, authenticationService, settings) {
+  .factory('infrastructureCaches', function(deckCacheFactory) {
 
     var caches = Object.create(null);
 
@@ -23,19 +21,8 @@ angular.module('spinnaker.caches.infrastructure', [
     }
 
     function createCache(key, cacheConfig) {
-      var shouldDisable = false;
-      if (settings.authEnabled && cacheConfig.authEnabled && !authenticationService.getAuthenticatedUser().authenticated) {
-        shouldDisable = true;
-      }
-      cacheConfig.disabled = shouldDisable;
       deckCacheFactory.createCache(namespace, key, cacheConfig);
-      var cache = deckCacheFactory.getCache(namespace, key);
-      if (shouldDisable) {
-        authenticationService.onAuthentication(function() {
-          cache.enable();
-        });
-      }
-      caches[key] = cache;
+      caches[key] = deckCacheFactory.getCache(namespace, key);
     }
 
     caches.clearCaches = clearCaches;

--- a/app/scripts/modules/caches/infrastructureCaches.spec.js
+++ b/app/scripts/modules/caches/infrastructureCaches.spec.js
@@ -2,14 +2,12 @@
 
 describe('spinnaker.caches.infrastructure', function() {
 
-  var infrastructureCaches, deckCacheFactory, authenticationService, settings;
+  var infrastructureCaches, deckCacheFactory;
 
   beforeEach(module('spinnaker.caches.infrastructure'));
-  beforeEach(inject(function(_infrastructureCaches_, _deckCacheFactory_, _authenticationService_, _settings_) {
+  beforeEach(inject(function(_infrastructureCaches_, _deckCacheFactory_) {
     infrastructureCaches = _infrastructureCaches_;
     deckCacheFactory = _deckCacheFactory_;
-    authenticationService = _authenticationService_;
-    settings = _settings_;
   }));
 
   describe('cache initialization', function() {
@@ -83,32 +81,5 @@ describe('spinnaker.caches.infrastructure', function() {
       expect(this.removalCalls.length).toBe(removalCallsAfterInitialization + 1);
     });
 
-    it('should set disabled flag and register event when authEnabled', function () {
-      var originalAuthEnabled = settings.authEnabled;
-      settings.authEnabled = true;
-      spyOn(authenticationService, 'getAuthenticatedUser').and.returnValue({authenticated: false});
-      spyOn(authenticationService, 'onAuthentication');
-      infrastructureCaches.createCache('authCache', {
-        cacheFactory: this.cacheFactory,
-        authEnabled: true,
-      });
-      expect(this.cacheInstantiations[3].config.disabled).toBe(true);
-      expect(authenticationService.onAuthentication.calls.count()).toBe(1);
-      settings.authEnabled = originalAuthEnabled;
-    });
-
-    it('should ignore authEnabled flag when settings disable auth', function () {
-      var originalAuthEnabled = settings.authEnabled;
-      settings.authEnabled = false;
-      spyOn(authenticationService, 'getAuthenticatedUser').and.returnValue({authenticated: false});
-      spyOn(authenticationService, 'onAuthentication');
-      infrastructureCaches.createCache('authCache', {
-        cacheFactory: this.cacheFactory,
-        authEnabled: true,
-      });
-      expect(this.cacheInstantiations[3].config.disabled).toBe(false);
-      expect(authenticationService.onAuthentication.calls.count()).toBe(0);
-      settings.authEnabled = originalAuthEnabled;
-    });
   });
 });

--- a/app/scripts/modules/subnet/subnet.read.service.spec.js
+++ b/app/scripts/modules/subnet/subnet.read.service.spec.js
@@ -2,16 +2,15 @@
 
 describe('subnetReader', function() {
 
-  var service, $http, $scope, settings;
+  var service, $http, $scope;
 
   beforeEach(
     module('spinnaker.subnet.read.service')
   );
 
-  beforeEach(inject(function (_settings_, $httpBackend, $rootScope, _subnetReader_) {
+  beforeEach(inject(function ($httpBackend, $rootScope, _subnetReader_) {
     service = _subnetReader_;
     $http = $httpBackend;
-    settings = _settings_;
     $scope = $rootScope.$new();
   }));
 

--- a/app/scripts/modules/vpc/vpc.read.service.spec.js
+++ b/app/scripts/modules/vpc/vpc.read.service.spec.js
@@ -2,16 +2,15 @@
 
 describe('vpcReader', function() {
 
-  var service, $http, $scope, settings;
+  var service, $http, $scope;
 
   beforeEach(
     module('spinnaker.vpc.read.service')
   );
 
-  beforeEach(inject(function (_settings_, $httpBackend, $rootScope, _vpcReader_) {
+  beforeEach(inject(function ($httpBackend, $rootScope, _vpcReader_) {
     service = _vpcReader_;
     $http = $httpBackend;
-    settings = _settings_;
     $scope = $rootScope.$new();
   }));
 


### PR DESCRIPTION
Since all HTTP calls are now deferred until authentication completes, this feature is no longer necessary.
