### PR TITLE
default strategy to none for create new/no-template deploys

### DIFF
--- a/app/scripts/modules/serverGroups/configure/aws/serverGroupCommandBuilder.service.js
+++ b/app/scripts/modules/serverGroups/configure/aws/serverGroupCommandBuilder.service.js
@@ -35,7 +35,7 @@ module.exports = angular.module('spinnaker.aws.serverGroupCommandBuilder.service
             application: application.name,
             credentials: defaultCredentials,
             region: defaultRegion,
-            strategy: 'redblack',
+            strategy: '',
             capacity: {
               min: 1,
               max: 1,

--- a/app/scripts/modules/serverGroups/configure/aws/wizard/deployInitializer.controller.js
+++ b/app/scripts/modules/serverGroups/configure/aws/wizard/deployInitializer.controller.js
@@ -61,6 +61,7 @@ module.exports = angular.module('spinnaker.serverGroup.configure.aws.deployIniti
         angular.extend(details, serverGroup);
         return awsServerGroupCommandBuilder.buildServerGroupCommandFromExisting($scope.application, details, 'editPipeline').then(function (command) {
           applyCommandToScope(command);
+          $scope.command.strategy = 'redblack';
         });
       });
     }


### PR DESCRIPTION
right now, we send 'redblack' on new deployments, which means we try to find the old ASG and disable it, which is never what we want to do on a "Create New Server Group" action.
