### PR TITLE
override execution status based on restrict window; show active execu…

### DIFF
--- a/app/scripts/modules/applications/application.html
+++ b/app/scripts/modules/applications/application.html
@@ -28,8 +28,8 @@
            analytics-on="click" analytics-category="Application View" analytics-label="Pipelines tab selected"
            ng-class="{active: $state.includes('**.executions.**') || $state.includes('**.pipelineConfig')}">
           Pipelines <span class="badge"
-                         ng-if="( application.executions | filter:{isRunning:'true'}).length > 0">
-            {{ (application.executions | filter:{isRunning:'true'}).length }}
+                         ng-if="( application.executions | filter:{isActive:true}).length > 0">
+            {{ (application.executions | filter:{isActive:true}).length }}
           </span>
         </a>
       </li>

--- a/app/scripts/modules/delivery/executionGroupHeading.controller.js
+++ b/app/scripts/modules/delivery/executionGroupHeading.controller.js
@@ -64,7 +64,7 @@ module.exports = angular.module('spinnaker.delivery.executionGroupHeading.contro
         if (execution.name !== $scope.value) {
           return false;
         }
-        return execution.status === 'RUNNING' || execution.status === 'NOT_STARTED';
+        return execution.isActive;
       });
     }
 

--- a/app/scripts/modules/pipelines/config/stages/executionWindows/executionWindows.transformer.js
+++ b/app/scripts/modules/pipelines/config/stages/executionWindows/executionWindows.transformer.js
@@ -5,14 +5,26 @@ module.exports =  angular.module('spinnaker.pipelines.stage.executionWindows.tra
 
     //Overrides "running" status, setting it to "suspended"
     function transformRunningExecutionWindows(execution) {
+      var hasRunningStage = false,
+          inRestrictedWindow = false;
       execution.stages
         .filter(function (stage) {
           return stage.type === 'restrictExecutionDuringTimeWindow' && stage.status === 'RUNNING';
         })
         .forEach(function (stage) {
+          inRestrictedWindow = true;
           stage.status = 'SUSPENDED';
           stage.tasks.forEach(function(task) { task.status = 'SUSPENDED'; });
         });
+
+      if (inRestrictedWindow && execution.status === 'RUNNING') {
+        hasRunningStage = execution.stages.some(function (stage) {
+          return stage.status === 'RUNNING';
+        });
+      }
+      if (inRestrictedWindow && !hasRunningStage) {
+        execution.status = 'SUSPENDED';
+      }
     }
     this.transform = function(application, execution) {
       transformRunningExecutionWindows(execution);

--- a/app/scripts/services/orchestratedItem.js
+++ b/app/scripts/services/orchestratedItem.js
@@ -32,6 +32,11 @@ module.exports = angular.module('spinnaker.orchestratedItem.service', [
             return item.status === 'FAILED';
           },
         },
+        isActive: {
+          get: function() {
+            return item.status === 'RUNNING' || item.status === 'SUSPENDED' || item.status === 'NOT_STARTED';
+          }
+        },
         hasNotStarted: {
           get: function() {
             return item.status === 'NOT_STARTED';


### PR DESCRIPTION
…tions in bubbles
- if a pipeline is "RUNNING", but the only thing running is the restrict execution window stage, override the status to "SUSPENDED"
- change the bubbles next to pipeline names and the pipelines tab to show running, not started, and suspended pipelines
