### PR TITLE
Add help text for GCE Server Group capacity directive.

### DIFF
--- a/app/scripts/modules/serverGroups/configure/gce/serverGroupCapacityDirective.html
+++ b/app/scripts/modules/serverGroups/configure/gce/serverGroupCapacityDirective.html
@@ -1,5 +1,8 @@
 <div class="form-group">
-  <div class="col-md-4 sm-label-left"><b>Capacity</b></div>
+  <div class="col-md-4 sm-label-left">
+      <b>Number of Instances</b>
+      <help-field key="gce.serverGroup.capacity"></help-field>
+  </div>
   <div class="col-md-2"><input type="number" ng-change="setMinMax(command.capacity.desired)"
                                class="form-control input-sm"
                                ng-model="command.capacity.desired"

--- a/app/scripts/settings/helpContents.js
+++ b/app/scripts/settings/helpContents.js
@@ -84,6 +84,7 @@ module.exports = angular.module('spinnaker.help.contents', [])
     'gce.loadBalancer.advancedSettings.unhealthyThreshold': '<p>Configures the number of unhealthy observations before deservicing an instance from the load balancer.</p><p>Default: <b>2</b></p>',
     'gce.loadBalancer.healthCheck': '(Optional) <b>Health Checks</b> use HTTP requests to determine if a VM instance is healthy.',
     'gce.loadBalancer.portRange': '(Optional) Only packets addressed to ports in the specified <b>Port Range</b> will be forwarded. If left empty, all ports are forwarded. Must be a single port number or two port numbers separated by a dash. Each port number must be between 1 and 65535, inclusive. For example: 5000-5999.',
+    'gce.serverGroup.capacity': 'The number of instances that the instance group manager will attempt to maintain. Deleting or abandoning instances will affect this number, as will resizing the group.',
     'pipeline.config.deploy.template': '<p>Select an existing cluster to use as a template for this deployment, and we\'ll pre-fill ' +
       'the configuration based on the newest server group in the cluster.</p>' +
       '<p>If you want to start from scratch, select "None".</p>' +


### PR DESCRIPTION
Change field label from 'Capacity' to 'Number of Instances'.
