### PR TITLE
do not inherit parameters for stage/step on downstream link

### DIFF
--- a/app/scripts/modules/pipelines/config/stages/pipeline/pipelineExecutionDetails.html
+++ b/app/scripts/modules/pipelines/config/stages/pipeline/pipelineExecutionDetails.html
@@ -18,6 +18,7 @@
         <div class="well alert alert-info">
           <a ng-if="stage.context.executionId"
              ui-sref="home.applications.application.executions.execution({ application: stage.context.application, executionId: stage.context.executionId })"
+             ui-sref-opts="{inherit: false}"
              target="_blank">View Pipeline Execution</a>
         </div>
       </div>


### PR DESCRIPTION
Currently, clicking on the link to the downstream execution will render it using the same state parameters as the current view. This resets those parameters.

(the other way to do this is to set stage and step explicitly to "0")
