### PR TITLE
fix packaging issues around moment-timezone

### DIFF
--- a/app/scripts/modules/config/config.controller.spec.js
+++ b/app/scripts/modules/config/config.controller.spec.js
@@ -11,7 +11,7 @@ describe('Controller: Config', function () {
 
   beforeEach(window.module(
     require('./config.controller.js'),
-    require('./notification.service.js')
+    require('../notifications/notification.service.js')
   ));
 
   beforeEach(

--- a/app/scripts/modules/whatsNew/whatsNew.directive.js
+++ b/app/scripts/modules/whatsNew/whatsNew.directive.js
@@ -2,9 +2,6 @@
 
 let angular = require('angular');
 
-require('./whatsNew.directive.html');
-require('./whatsNew.directive.modal.html');
-
 module.exports = angular
   .module('spinnaker.whatsNew.directive', [
     require('angular-marked'),

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "jquery": "2.1.4",
     "jquery-ui": "^1.10.5",
     "loader-utils": "^0.2.11",
+    "moment-timezone": "^0.4.0",
     "ng-infinite-scroll": "^1.2.0",
     "restangular": "~1.4.0",
     "select2-bootstrap-css": "git://github.com/t0m/select2-bootstrap-css.git#v1.3.1",

--- a/utils/moment.js
+++ b/utils/moment.js
@@ -1,6 +1,6 @@
 'use strict';
 
-let moment = require('moment');
+let moment = require('moment-timezone');
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.utils.moment', [])

--- a/utils/timeFormatters.js
+++ b/utils/timeFormatters.js
@@ -5,11 +5,10 @@ let angular = require('angular');
 
 module.exports = angular.module('spinnaker.utils.timeFormatters', [
   require('./moment.js'),
-  require('../settings/settings.js'),
 ])
-  .filter('timestamp', function(momentService, settings) {
+  .filter('timestamp', function(momentService) {
     return function(input) {
-      var tz = settings.defaultTimeZone || 'America/Los_Angeles';
+      var tz = 'America/Los_Angeles'; // TODO: clean up utils and read this from settings
       var moment = momentService.tz(isNaN(parseInt(input)) ? input : parseInt(input), tz);
       return moment.isValid() ? moment.format('YYYY-MM-DD HH:mm:ss z') : '-';
     };


### PR DESCRIPTION
For the sake of getting a build out, removing the dependency on settings.js from the momentService, which ends up getting pushed into node_modules/utils, where it can't find the settings.js file.
