### PR TITLE
Values for 'Storage' column were missing for Google server groups. Th…

### DIFF
--- a/app/scripts/modules/serverGroups/configure/common/instanceTypeDirective.html
+++ b/app/scripts/modules/serverGroups/configure/common/instanceTypeDirective.html
@@ -9,7 +9,7 @@
         <th>Size</th>
         <th>vCPU</th>
         <th>Mem (GiB)</th>
-        <th>SSD Storage (GB)</th>
+        <th>{{family.storageType || 'SSD'}} Storage (GB)</th>
         <th>Cost</th>
       </tr>
       </thead>
@@ -23,7 +23,7 @@
         <td>{{instanceType.cpu}}</td>
         <td>{{instanceType.memory}}</td>
         <td ng-if="instanceType.storage.type === 'EBS'">EBS Only</td>
-        <td ng-if="instanceType.storage.type === 'SSD'">{{instanceType.storage.count}}&times;{{instanceType.storage.size}}</td>
+        <td ng-if="instanceType.storage.type === 'SSD' || family.storageType">{{instanceType.storage.count}}&times;{{instanceType.storage.size}}</td>
         <td><cost-factor factor="instanceType.costFactor"></cost-factor></td>
       </tr>
       </tbody>


### PR DESCRIPTION
…is commit re-enables the logic from this PR: https://github.com/spinnaker/deck/commit/8c753808188fd0ccdce102685a12245cf30092fc

It looks like the provider-specific instance type directives were deprecated in favor of a common directive, so I had to put this logic in the common one.

Tested with AWS server group, and it looks the same. With GCE server group the entries in the storage column are restored.
