### PR TITLE
Enable display of OutOfService chicklets on Load Balancers tab when S…

### DIFF
--- a/app/scripts/modules/loadBalancers/loadBalancer.directive.js
+++ b/app/scripts/modules/loadBalancers/loadBalancer.directive.js
@@ -3,8 +3,9 @@
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.loadBalancer.directive', [
+  require('../utils/lodash.js'),
 ])
-  .directive('loadBalancer', function ($rootScope, $timeout, LoadBalancerFilterModel) {
+  .directive('loadBalancer', function ($rootScope, $timeout, _, LoadBalancerFilterModel) {
     return {
       restrict: 'E',
       templateUrl: require('./loadBalancer/loadBalancer.html'),
@@ -20,6 +21,10 @@ module.exports = angular.module('spinnaker.loadBalancer.directive', [
         scope.$state = $rootScope.$state;
 
         scope.waypoint = [loadBalancer.account, loadBalancer.region, loadBalancer.name].join(':');
+
+        scope.viewModel = {
+          instances: loadBalancer.instances.concat(_.flatten(_.pluck(loadBalancer.serverGroups, 'detachedInstances')))
+        };
 
         scope.loadDetails = function(event) {
           $timeout(function() {

--- a/app/scripts/modules/loadBalancers/loadBalancer/loadBalancer.html
+++ b/app/scripts/modules/loadBalancers/loadBalancer/loadBalancer.html
@@ -18,7 +18,7 @@
         server-group="serverGroup"></load-balancer-server-group>
     </div>
     <div class="instance-list" ng-if="!sortFilter.showServerGroups && sortFilter.showInstances">
-      <instances instances="loadBalancer.instances"></instances>
+      <instances instances="viewModel.instances"></instances>
     </div>
   </div>
 </div>


### PR DESCRIPTION
…erver Groups are hidden.

In the screen-grabs below, the top load balancer is AWS, the second from the top is GCE.

Before:
![image](https://cloud.githubusercontent.com/assets/8437718/9690530/e5ae1ff8-530a-11e5-98a3-88628a41ee67.png)

After:
![image](https://cloud.githubusercontent.com/assets/8437718/9690538/ee779718-530a-11e5-9b5c-3232ca7fa8cc.png)
