### PR TITLE
always reattach running tasks, executions to server groups

### DIFF
--- a/app/scripts/modules/clusterFilter/clusterFilterService.js
+++ b/app/scripts/modules/clusterFilter/clusterFilterService.js
@@ -201,6 +201,8 @@ module.exports = angular
             $log.debug('change detected, updating server group:', serverGroup.name, serverGroup.account, serverGroup.region);
             oldGroup.serverGroups[idx] = newServerGroup;
           }
+          serverGroup.executions = newServerGroup.executions;
+          serverGroup.runningTasks = newServerGroup.runningTasks;
         }
       });
       toRemove.reverse().forEach(function(idx) {

--- a/app/scripts/modules/clusterFilter/clusterFilterService.spec.js
+++ b/app/scripts/modules/clusterFilter/clusterFilterService.spec.js
@@ -609,5 +609,21 @@ describe('Service: clusterFilterService', function () {
       expect(ClusterFilterModel.groups[0].subgroups[0].subgroups[0].serverGroups[0]).toBe(application.serverGroups[0]);
       expect(ClusterFilterModel.groups[0].subgroups[0].subgroups[0].serverGroups[1]).toBe(this.serverGroup001);
     });
+
+    it('adds executions and running tasks, even when stringVal does not change', function () {
+      var runningTasks = [ { name: 'a' } ],
+          executions = [ { name: 'b' } ];
+      var application = {
+        serverGroups: [
+          { cluster: 'cluster-a', name: 'cluster-a-v001', account: 'prod', region: 'us-east-1', stringVal: 'original',
+            runningTasks: runningTasks, executions: executions,
+          },
+        ]
+      };
+      service.updateClusterGroups(application);
+      expect(ClusterFilterModel.groups[0].subgroups[0].subgroups[0].serverGroups[0]).toBe(this.serverGroup001);
+      expect(ClusterFilterModel.groups[0].subgroups[0].subgroups[0].serverGroups[0].runningTasks).toBe(runningTasks);
+      expect(ClusterFilterModel.groups[0].subgroups[0].subgroups[0].serverGroups[0].executions).toBe(executions);
+    });
   });
 });


### PR DESCRIPTION
Because the "diff" does not inspect running tasks or executions, always update them on the model.
