### PR TITLE
allow providers to specify cache config

### DIFF
--- a/app/scripts/modules/amazon/aws.module.js
+++ b/app/scripts/modules/amazon/aws.module.js
@@ -23,11 +23,15 @@ module.exports = angular.module('spinnaker.aws', [
   require('./subnet/subnet.module.js'),
   require('./vpc/vpc.module.js'),
   require('./image/image.reader.js'),
+  require('./cache/cacheConfigurer.service.js'),
 ])
   .config(function(cloudProviderRegistryProvider) {
     cloudProviderRegistryProvider.registerProvider('aws', {
       logo: {
         path: require('./logo_aws.png'),
+      },
+      cache: {
+        configurer: 'awsCacheConfigurer',
       },
       image: {
         reader: 'awsImageReader',

--- a/app/scripts/modules/amazon/cache/cacheConfigurer.service.js
+++ b/app/scripts/modules/amazon/cache/cacheConfigurer.service.js
@@ -1,0 +1,48 @@
+'use strict';
+
+let angular = require('angular');
+
+module.exports = angular.module('spinnaker.aws.cache.initializer', [
+  require('../../account/accountService.js'),
+  require('../../loadBalancers/loadBalancer.read.service.js'),
+  require('../../instance/instanceTypeService.js'),
+  require('../../securityGroups/securityGroup.read.service.js'),
+  require('../subnet/subnet.read.service.js'),
+  require('../vpc/vpc.read.service.js'),
+  require('../keyPairs/keyPairs.read.service.js'),
+])
+  .factory('awsCacheConfigurer', function ($q,
+                                         accountService, instanceTypeService, securityGroupReader,
+                                         subnetReader, vpcReader, keyPairsReader, loadBalancerReader) {
+
+    let config = Object.create(null);
+
+    config.credentials = {
+      initializers: [ () => accountService.getRegionsKeyedByAccount('aws') ],
+    };
+
+    config.instanceTypes = {
+      initializers: [ () => instanceTypeService.getAllTypesByRegion('aws') ],
+    };
+
+    config.loadBalancers = {
+      initializers: [ () => loadBalancerReader.listLoadBalancers('aws') ],
+    };
+
+    config.subnets = {
+      version: 2,
+      initializers: [subnetReader.listSubnets],
+    };
+
+    config.vpcs = {
+      version: 2,
+      initializers: [vpcReader.listVpcs],
+    };
+
+    config.keyPairs = {
+      initializers: [keyPairsReader.listKeyPairs]
+    };
+
+    return config;
+  })
+  .name;

--- a/app/scripts/modules/caches/cacheInitializer.js
+++ b/app/scripts/modules/caches/cacheInitializer.js
@@ -3,48 +3,68 @@
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.caches.initializer', [
-  require('../loadBalancers/loadBalancer.read.service.js'),
   require('../account/accountService.js'),
-  require('../instance/instanceTypeService.js'),
   require('../securityGroups/securityGroup.read.service.js'),
-  require('../amazon/subnet/subnet.read.service.js'),
-  require('../amazon/vpc/vpc.read.service.js'),
-  require('../amazon/keyPairs/keyPairs.read.service.js'),
-  require('../loadBalancers/loadBalancer.read.service.js'),
   require('../applications/applications.read.service.js'),
   require('../jenkins/index.js'),
   require('./infrastructureCaches.js'),
   require('./infrastructureCacheConfig.js'),
+  require('../utils/lodash.js'),
+  require('../core/cloudProvider/cloudProvider.registry.js'),
 ])
   .factory('cacheInitializer', function ($q, applicationReader, infrastructureCaches,
-                                         accountService, instanceTypeService, securityGroupReader,
-                                         subnetReader, vpcReader, keyPairsReader, loadBalancerReader,
-                                         igorService, infrastructureCacheConfig) {
+                                         accountService, securityGroupReader, cloudProviderRegistry,
+                                         igorService, infrastructureCacheConfig, serviceDelegate, _) {
 
     var initializers = {
-      credentials: [accountService.getRegionsKeyedByAccount, accountService.listAccounts],
-      instanceTypes: [ function() { return instanceTypeService.getAllTypesByRegion('aws'); }],
-      loadBalancers: [ function() { return loadBalancerReader.listLoadBalancers('aws'); }],
+      credentials: [accountService.listAccounts],
       securityGroups: [securityGroupReader.getAllSecurityGroups],
-      subnets: [subnetReader.listSubnets],
-      vpcs: [vpcReader.listVpcs],
-      keyPairs: [keyPairsReader.listKeyPairs],
       applications: [applicationReader.listApplications],
       buildMasters: [igorService.listMasters],
     };
 
+    var cacheConfig = _.cloneDeep(infrastructureCacheConfig);
+
+    function setConfigDefaults(key, config) {
+      config.version = config.version || 1;
+      config.maxAge = config.maxAge || 2 * 24 * 60 * 60 * 1000;
+      config.initializers = config.initializers || initializers[key] || [];
+    }
+
+    function extendConfig() {
+      Object.keys(cacheConfig).forEach((key) => {
+        setConfigDefaults(key, cacheConfig[key]);
+      });
+      cloudProviderRegistry.listRegisteredProviders().forEach((provider) => {
+        let providerConfig = serviceDelegate.getDelegate(provider, 'cache.configurer');
+        if (providerConfig) {
+          Object.keys(providerConfig).forEach(function(key) {
+            setConfigDefaults(key, providerConfig[key]);
+            if (!cacheConfig[key]) {
+              cacheConfig[key] = providerConfig[key];
+            }
+            cacheConfig[key].initializers = _.uniq((cacheConfig[key].initializers).concat(providerConfig[key].initializers));
+            cacheConfig[key].version = Math.max(cacheConfig[key].version, providerConfig[key].version);
+            cacheConfig[key].maxAge = Math.min(cacheConfig[key].maxAge, providerConfig[key].maxAge);
+
+          });
+        }
+      });
+    }
+
     function initialize() {
+      extendConfig();
       var all = [];
-      Object.keys(infrastructureCacheConfig).forEach(function(key) {
+      Object.keys(cacheConfig).forEach(function(key) {
         all.push(initializeCache(key));
       });
       return $q.all(all);
     }
 
     function initializeCache(key) {
-      infrastructureCaches.createCache(key, infrastructureCacheConfig[key]);
-      if (initializers[key]) {
-        var initializer = initializers[key];
+      infrastructureCaches.createCache(key, cacheConfig[key]);
+      if (cacheConfig[key].initializers) {
+        var initializer = cacheConfig[key].initializers;
         var all = [];
         initializer.forEach(function(method) {
           all.push(method());
@@ -60,7 +80,7 @@ module.exports = angular.module('spinnaker.caches.initializer', [
 
     function refreshCaches() {
       var all = [];
-      Object.keys(initializers).forEach(function(key) {
+      Object.keys(cacheConfig).forEach(function(key) {
         all.push(refreshCache(key));
       });
       return $q.all(all);

--- a/app/scripts/modules/caches/deckCacheFactory.js
+++ b/app/scripts/modules/caches/deckCacheFactory.js
@@ -102,22 +102,8 @@ module.exports = angular.module('spinnaker.caches.core', [
     function clearPreviousVersions(namespace, cacheId, currentVersion, cacheFactory) {
       if (currentVersion) {
 
-        // clear non-versioned cache (TODO: remove after 5/15/15)
-        cacheFactory.createCache(cacheId, { storageMode: 'localStorage', });
-        cacheFactory.get(cacheId).removeAll();
-        cacheFactory.get(cacheId).destroy();
-
         // clear previous versions
         for (var i = 0; i < currentVersion; i++) {
-          // non-namespaced (TODO: remove after 5/15/15)
-          cacheFactory.createCache(cacheId, {
-            storageMode: 'localStorage',
-            storagePrefix: getStoragePrefix(cacheId, i+1),
-          });
-          cacheFactory.get(cacheId).removeAll();
-          cacheFactory.get(cacheId).destroy();
-
-          // namespaced
           var key = buildCacheKey(namespace, cacheId);
           if (cacheFactory.get(key)) {
             cacheFactory.get(key).destroy();

--- a/app/scripts/modules/caches/infrastructureCaches.spec.js
+++ b/app/scripts/modules/caches/infrastructureCaches.spec.js
@@ -60,15 +60,12 @@ describe('spinnaker.caches.infrastructure', function() {
 
       infrastructureCaches.createCache('myCache', config);
 
-      expect(this.cacheInstantiations.length).toBe(6);
-      expect(this.cacheInstantiations[0].config.storagePrefix).toBeUndefined();
-      expect(this.cacheInstantiations[1].config.storagePrefix).toBe(deckCacheFactory.getStoragePrefix('myCache', 1));
-      expect(this.cacheInstantiations[2].config.storagePrefix).toBe(deckCacheFactory.getStoragePrefix('infrastructure:myCache', 0));
-      expect(this.cacheInstantiations[3].config.storagePrefix).toBe(deckCacheFactory.getStoragePrefix('myCache', 2));
-      expect(this.cacheInstantiations[4].config.storagePrefix).toBe(deckCacheFactory.getStoragePrefix('infrastructure:myCache', 1));
-      expect(this.cacheInstantiations[5].config.storagePrefix).toBe(deckCacheFactory.getStoragePrefix('infrastructure:myCache', 2));
-      expect(this.removalCalls.length).toBe(5);
-      expect(this.removalCalls).toEqual(['myCache', 'myCache', 'infrastructure:myCache', 'myCache', 'infrastructure:myCache']);
+      expect(this.cacheInstantiations.length).toBe(3);
+      expect(this.cacheInstantiations[0].config.storagePrefix).toBe(deckCacheFactory.getStoragePrefix('infrastructure:myCache', 0));
+      expect(this.cacheInstantiations[1].config.storagePrefix).toBe(deckCacheFactory.getStoragePrefix('infrastructure:myCache', 1));
+      expect(this.cacheInstantiations[2].config.storagePrefix).toBe(deckCacheFactory.getStoragePrefix('infrastructure:myCache', 2));
+      expect(this.removalCalls.length).toBe(2);
+      expect(this.removalCalls).toEqual(['infrastructure:myCache', 'infrastructure:myCache']);
 
     });
 
@@ -77,13 +74,11 @@ describe('spinnaker.caches.infrastructure', function() {
         cacheFactory: this.cacheFactory,
       });
 
-      expect(this.cacheInstantiations.length).toBe(4);
-      expect(this.cacheInstantiations[0].config.storagePrefix).toBeUndefined();
-      expect(this.cacheInstantiations[1].config.storagePrefix).toBe(deckCacheFactory.getStoragePrefix('myCache', 1));
-      expect(this.cacheInstantiations[2].config.storagePrefix).toBe(deckCacheFactory.getStoragePrefix('infrastructure:myCache', 0));
-      expect(this.cacheInstantiations[3].config.storagePrefix).toBe(deckCacheFactory.getStoragePrefix('infrastructure:myCache', 1));
-      expect(this.removalCalls.length).toBe(3);
-      expect(this.removalCalls).toEqual(['myCache', 'myCache', 'infrastructure:myCache']);
+      expect(this.cacheInstantiations.length).toBe(2);
+      expect(this.cacheInstantiations[0].config.storagePrefix).toBe(deckCacheFactory.getStoragePrefix('infrastructure:myCache', 0));
+      expect(this.cacheInstantiations[1].config.storagePrefix).toBe(deckCacheFactory.getStoragePrefix('infrastructure:myCache', 1));
+      expect(this.removalCalls.length).toBe(1);
+      expect(this.removalCalls).toEqual(['infrastructure:myCache']);
     });
 
     it('should remove all keys when clearCache called', function() {

--- a/app/scripts/modules/core/cloudProvider/cloudProvider.registry.js
+++ b/app/scripts/modules/core/cloudProvider/cloudProvider.registry.js
@@ -7,7 +7,7 @@ module.exports = angular.module('spinnaker.core.cloudProvider.registry', [
 ])
   .provider('cloudProviderRegistry', function(_) {
 
-    const providers = {};
+    const providers = Object.create(null);
 
     this.registerProvider = (cloudProvider, config) => {
       providers[cloudProvider] = config;
@@ -15,6 +15,10 @@ module.exports = angular.module('spinnaker.core.cloudProvider.registry', [
 
     function getProvider(provider) {
       return _.cloneDeep(providers[provider]);
+    }
+
+    function listRegisteredProviders() {
+      return Object.keys(providers);
     }
 
     function getValue(provider, key) {
@@ -50,6 +54,7 @@ module.exports = angular.module('spinnaker.core.cloudProvider.registry', [
       return {
         getProvider: getProvider,
         getValue: getValue,
+        listRegisteredProviders: listRegisteredProviders,
       };
     };
 

--- a/app/scripts/modules/google/cache/cacheConfigurer.service.js
+++ b/app/scripts/modules/google/cache/cacheConfigurer.service.js
@@ -1,0 +1,31 @@
+'use strict';
+
+let angular = require('angular');
+
+module.exports = angular.module('spinnaker.gce.cache.initializer', [
+  require('../../account/accountService.js'),
+  require('../../loadBalancers/loadBalancer.read.service.js'),
+  require('../../instance/instanceTypeService.js'),
+  require('../../securityGroups/securityGroup.read.service.js'),
+])
+  .factory('gceCacheConfigurer', function ($q,
+                                         accountService, instanceTypeService, securityGroupReader,
+                                         subnetReader, vpcReader, keyPairsReader, loadBalancerReader) {
+
+    let config = Object.create(null);
+
+    config.credentials = {
+      initializers: [ () => accountService.getRegionsKeyedByAccount('gce') ],
+    };
+
+    config.instanceTypes = {
+      initializers: [ () => instanceTypeService.getAllTypesByRegion('gce') ],
+    };
+
+    config.loadBalancers = {
+      initializers: [ () => loadBalancerReader.listLoadBalancers('gce') ],
+    };
+
+    return config;
+  })
+  .name;

--- a/app/scripts/modules/google/gce.module.js
+++ b/app/scripts/modules/google/gce.module.js
@@ -21,11 +21,15 @@ module.exports = angular.module('spinnaker.gce', [
   require('./securityGroup/configure/EditSecurityGroupCtrl.js'),
   require('./securityGroup/securityGroup.transformer.js'),
   require('./image/image.reader.js'),
+  require('./cache/cacheConfigurer.service.js'),
 ])
   .config(function(cloudProviderRegistryProvider) {
     cloudProviderRegistryProvider.registerProvider('gce', {
       logo: {
         path: require('./logo_gce.png'),
+      },
+      cache: {
+        configurer: 'gceCacheConfigurer',
       },
       image: {
         reader: 'gceImageReader',


### PR DESCRIPTION
Providers can now override TTL, version on infrastructure caches, specify initializers, or create brand new infrastructure cache entries.
