### PR TITLE
do not delete providerType from tasks

### DIFF
--- a/app/scripts/modules/tasks/taskExecutor.js
+++ b/app/scripts/modules/tasks/taskExecutor.js
@@ -20,10 +20,6 @@ module.exports = angular.module('spinnaker.taskExecutor.service', [
       var application = taskCommand.application;
       taskCommand.application = application.name;
 
-      if (taskCommand.job[0].providerType === 'aws') {
-        delete taskCommand.job[0].providerType;
-      }
-
       taskCommand.job.forEach(function(job) {
         job.user = authenticationService.getAuthenticatedUser().name;
       });


### PR DESCRIPTION
I assume this was in place for a reason at some point, but everything _seems_ to work with it in place now - and if it doesn't, we should dig in and find out why
