### PR TITLE
Add firewallRuleName to deleteSecurityGroup job.

### DIFF
--- a/app/scripts/modules/amazon/securityGroup/details/SecurityGroupDetailsCtrl.js
+++ b/app/scripts/modules/amazon/securityGroup/details/SecurityGroupDetailsCtrl.js
@@ -87,8 +87,10 @@ module.exports = angular.module('spinnaker.securityGroup.aws.details.controller'
       };
 
       var submitMethod = function () {
-        securityGroup.providerType = $scope.securityGroup.type;
-        return securityGroupWriter.deleteSecurityGroup($scope.securityGroup, application, {vpcId: $scope.securityGroup.vpcId});
+        return securityGroupWriter.deleteSecurityGroup(securityGroup, application, {
+          cloudProvider: $scope.securityGroup.type,
+          vpcId: $scope.securityGroup.vpcId,
+        });
       };
 
       confirmationModalService.confirm({

--- a/app/scripts/modules/google/securityGroup/details/SecurityGroupDetailsCtrl.js
+++ b/app/scripts/modules/google/securityGroup/details/SecurityGroupDetailsCtrl.js
@@ -114,7 +114,10 @@ module.exports = angular.module('spinnaker.securityGroup.gce.details.controller'
 
       var submitMethod = function () {
         securityGroup.providerType = $scope.securityGroup.type;
-        return securityGroupWriter.deleteSecurityGroup($scope.securityGroup, application);
+        return securityGroupWriter.deleteSecurityGroup(securityGroup, application, {
+          cloudProvider: $scope.securityGroup.type,
+          firewallRuleName: securityGroup.name,
+        });
       };
 
       confirmationModalService.confirm({

--- a/app/scripts/modules/securityGroups/securityGroup.write.service.js
+++ b/app/scripts/modules/securityGroups/securityGroup.write.service.js
@@ -30,13 +30,13 @@ module.exports = angular
       params.type = 'deleteSecurityGroup';
       params.securityGroupName = securityGroup.name;
       params.regions = [securityGroup.region];
-      params.credentials = securityGroup.accountName;
+      params.credentials = securityGroup.accountId;
       params.providerType = securityGroup.providerType;
 
       var operation = taskExecutor.executeTask({
         job: [params],
         application: application,
-        description: 'Delete security group: ' + securityGroup.name + ' in ' + securityGroup.accountName + ':' + securityGroup.region
+        description: 'Delete security group: ' + securityGroup.name + ' in ' + securityGroup.accountId + ':' + securityGroup.region
       });
 
       infrastructureCaches.clearCache('securityGroups');


### PR DESCRIPTION
Also add cloudProvider to both Amazon and Google Security Group deletions. It is used by the delete security group force cache refresh task.
