### PR TITLE
do not register provider unless a providers block is configured in se…

### DIFF
--- a/app/scripts/modules/core/cloudProvider/cloudProvider.registry.js
+++ b/app/scripts/modules/core/cloudProvider/cloudProvider.registry.js
@@ -4,13 +4,16 @@ let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.cloudProvider.registry', [
   require('../../utils/lodash.js'),
+  require('../../config/settings.js'),
 ])
-  .provider('cloudProviderRegistry', function(_) {
+  .provider('cloudProviderRegistry', function(_, settings) {
 
     const providers = Object.create(null);
 
     this.registerProvider = (cloudProvider, config) => {
-      providers[cloudProvider] = config;
+      if (settings.providers && settings.providers[cloudProvider]) {
+        providers[cloudProvider] = config;
+      }
     };
 
     function getProvider(provider) {


### PR DESCRIPTION
…ttings

Not sure if this code is going to stick around, but it probably will, if nothing else to ensure some defaults are configured for each provider.

Right now, by simply adding a dependency on the provider module, caches get initialized for all providers, even if they're not configured. This addresses that without breaking developer workflow ATM
