### PR TITLE
store recently viewed items, surface in infrastructure page

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -146,8 +146,9 @@ module.exports = angular.module('spinnaker', [
     require('./modules/netflix/blesk/blesk.module.js'),
     require('./modules/fastProperties/fastProperties.module.js'),
     require('./modules/account/accountLabelColor.directive.js'),
+    require('./modules/core/history/recentHistory.service.js'),
 ])
-  .run(function($state, $rootScope, $log, $exceptionHandler, cacheInitializer, $modalStack, pageTitleService, settings) {
+  .run(function($state, $rootScope, $log, $exceptionHandler, cacheInitializer, $modalStack, pageTitleService, settings, recentHistoryService) {
     // This can go away when the next version of ui-router is available (0.2.11+)
     // for now, it's needed because ui-sref-active does not work on parent states
     // and we have to use ng-class. It's gross.
@@ -200,6 +201,9 @@ module.exports = angular.module('spinnaker', [
         fromParams: fromParams
       });
       pageTitleService.handleRoutingSuccess(toState.data);
+      if (toState.data && toState.data.history) {
+        recentHistoryService.addItem(toState.data.history.type, toState.name, toParams);
+      }
     });
 
     $rootScope.feature = settings.feature;
@@ -293,7 +297,7 @@ module.exports = angular.module('spinnaker', [
           $analytics.eventTrack(action, {category: 'JavaScript Error', label: label, noninteraction: true});
           $delegate(exception, cause);
         } catch(e) {
-          // eat it to permit a endless exception loop from happening
+          // eat it to prevent an endless exception loop from happening
         }
       };
     });

--- a/app/scripts/modules/amazon/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/amazon/instance/details/instance.details.controller.js
@@ -11,9 +11,10 @@ module.exports = angular.module('spinnaker.instance.detail.aws.controller', [
   require('../../vpc/vpcTag.directive.js'),
   require('../../../confirmationModal/confirmationModal.service.js'),
   require('../../../insight/insightFilterState.model.js'),
+  require('../../../core/history/recentHistory.service.js'),
 ])
   .controller('awsInstanceDetailsCtrl', function ($scope, $state, $modal, InsightFilterStateModel,
-                                               instanceWriter, confirmationModalService,
+                                               instanceWriter, confirmationModalService, recentHistoryService,
                                                instanceReader, _, instance, app) {
 
     // needed for standalone instances
@@ -53,6 +54,7 @@ module.exports = angular.module('spinnaker.instance.detail.aws.controller', [
     }
 
     function retrieveInstance() {
+      var extraData = {};
       var instanceSummary, loadBalancers, account, region, vpcId;
       if (!app.serverGroups) {
         // standalone instance
@@ -69,6 +71,8 @@ module.exports = angular.module('spinnaker.instance.detail.aws.controller', [
               account = serverGroup.account;
               region = serverGroup.region;
               vpcId = serverGroup.vpcId;
+              extraData.serverGroup = serverGroup.name;
+              extraData.vpcId = serverGroup.vpcId;
               return true;
             }
           });
@@ -111,6 +115,9 @@ module.exports = angular.module('spinnaker.instance.detail.aws.controller', [
       }
 
       if (instanceSummary && account && region) {
+        extraData.account = account;
+        extraData.region = region;
+        recentHistoryService.addExtraDataToLatest('instances', extraData);
         instanceReader.getInstanceDetails(account, region, instance.instanceId).then(function(details) {
           details = details.plain();
           $scope.state.loading = false;

--- a/app/scripts/modules/amazon/instance/details/instance.details.controller.spec.js
+++ b/app/scripts/modules/amazon/instance/details/instance.details.controller.spec.js
@@ -36,6 +36,9 @@ describe('Controller: awsInstanceDetailsCtrl', function () {
           $scope: scope,
           instance: instance,
           app: application,
+          recentHistoryService: {
+            addExtraDataToLatest: angular.noop,
+          },
         });
       };
     })

--- a/app/scripts/modules/core/cloudProvider/cloudProvider.registry.spec.js
+++ b/app/scripts/modules/core/cloudProvider/cloudProvider.registry.spec.js
@@ -18,9 +18,6 @@ describe('cloudProviderRegistry: API', function() {
       var config = { key: 'a' };
       configurer.registerProvider('aws', config);
       expect(configurer.$get().getProvider('aws')).toEqual(config);
-
-      configurer.registerProvider('gce', {key: 'b'});
-      expect(configurer.$get().getProvider('gce')).toEqual({key: 'b'});
     }));
   });
 

--- a/app/scripts/modules/core/history/recentHistory.service.js
+++ b/app/scripts/modules/core/history/recentHistory.service.js
@@ -1,0 +1,63 @@
+'use strict';
+
+let angular = require('angular');
+
+module.exports = angular.module('spinnaker.core.history.service', [
+  require('../../caches/deckCacheFactory.js'),
+  require('../../utils/lodash.js'),
+])
+  .factory('recentHistoryService', function (_, deckCacheFactory) {
+
+    const maxItems = 15;
+
+    deckCacheFactory.createCache('history', 'user', {
+      maxAge: 90 * 24 * 60 * 60 * 1000 // 90 days,
+    });
+
+    let cache = deckCacheFactory.getCache('history', 'user');
+
+    function addItem(type, state, params) {
+      var items = _.sortBy(getItems(type), 'accessTime').slice(0, maxItems),
+          existing = _.find(items, { state: state, params: params }),
+          entry = {
+            params: params,
+            state: state,
+            accessTime: new Date().getTime(),
+            extraData: {}
+          };
+      if (existing) {
+        items[items.indexOf(existing)] = entry;
+      } else {
+        if (items.length === maxItems) {
+          items[maxItems - 1] = entry;
+        } else {
+          items.push(entry);
+        }
+      }
+      cache.put(type, items.reverse());
+    }
+
+    function getItems(type) {
+      return cache.get(type) || [];
+    }
+
+    /**
+     * Used to include additional fields needed by display formatters that might not be present in $stateParams,
+     * but is resolved in a controller when the view loads
+     * See instanceDetails.controller.js for an example
+     * @param type
+     * @param extraData
+     */
+    function addExtraDataToLatest(type, extraData) {
+      var items = _.sortBy(getItems(type), 'accessTime').reverse();
+      items[0].extraData = extraData;
+      cache.put(type, items);
+    }
+
+
+    return {
+      addItem: addItem,
+      getItems: getItems,
+      addExtraDataToLatest: addExtraDataToLatest,
+    };
+  }).name;

--- a/app/scripts/modules/google/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/google/instance/details/instance.details.controller.js
@@ -10,9 +10,10 @@ module.exports = angular.module('spinnaker.instance.detail.gce.controller', [
   require('../../../confirmationModal/confirmationModal.service.js'),
   require('../../../utils/lodash.js'),
   require('../../../insight/insightFilterState.model.js'),
+  require('../../../core/history/recentHistory.service.js'),
 ])
   .controller('gceInstanceDetailsCtrl', function ($scope, $state, $modal, InsightFilterStateModel,
-                                               instanceWriter, confirmationModalService,
+                                               instanceWriter, confirmationModalService, recentHistoryService,
                                                instanceReader, _, instance, app) {
 
     // needed for standalone instances
@@ -52,6 +53,7 @@ module.exports = angular.module('spinnaker.instance.detail.gce.controller', [
     }
 
     function retrieveInstance() {
+      var extraData = {};
       var instanceSummary, loadBalancers, account, region, vpcId;
       if (!app.serverGroups) {
         // standalone instance
@@ -67,7 +69,7 @@ module.exports = angular.module('spinnaker.instance.detail.gce.controller', [
               loadBalancers = serverGroup.loadBalancers;
               account = serverGroup.account;
               region = serverGroup.region;
-              vpcId = serverGroup.vpcId;
+              extraData.serverGroup = serverGroup.name;
               return true;
             }
           });
@@ -110,6 +112,9 @@ module.exports = angular.module('spinnaker.instance.detail.gce.controller', [
       }
 
       if (instanceSummary && account && region) {
+        extraData.account = account;
+        extraData.region = region;
+        recentHistoryService.addExtraDataToLatest('instances', extraData);
         instanceReader.getInstanceDetails(account, region, instance.instanceId).then(function(details) {
           details = details.plain();
           $scope.state.loading = false;

--- a/app/scripts/modules/navigation/states.provider.js
+++ b/app/scripts/modules/navigation/states.provider.js
@@ -48,7 +48,10 @@ module.exports = angular.module('spinnaker.states', [
           pageTitleDetails: {
             title: 'Instance Details',
             nameParam: 'instanceId'
-          }
+          },
+          history: {
+            type: 'instances',
+          },
         }
       };
 
@@ -80,7 +83,10 @@ module.exports = angular.module('spinnaker.states', [
             nameParam: 'serverGroup',
             accountParam: 'accountId',
             regionParam: 'region'
-          }
+          },
+          history: {
+            type: 'serverGroups',
+          },
         }
       };
 
@@ -119,7 +125,10 @@ module.exports = angular.module('spinnaker.states', [
             nameParam: 'name',
             accountParam: 'accountId',
             regionParam: 'region'
-          }
+          },
+          history: {
+            type: 'loadBalancers',
+          },
         }
       };
 
@@ -363,7 +372,10 @@ module.exports = angular.module('spinnaker.states', [
         data: {
           pageTitleMain: {
             field: 'application'
-          }
+          },
+          history: {
+            type: 'applications',
+          },
         },
         children: [
           insight,
@@ -482,7 +494,10 @@ module.exports = angular.module('spinnaker.states', [
           pageTitleDetails: {
             title: 'Instance Details',
             nameParam: 'instanceId'
-          }
+          },
+          history: {
+            type: 'instances',
+          },
         }
       };
 

--- a/app/scripts/modules/search/infrastructure/infrastructure.html
+++ b/app/scripts/modules/search/infrastructure/infrastructure.html
@@ -1,16 +1,25 @@
 <div class="container infrastructure global-search-header">
   <div class="row">
-    <div class="col-md-3 col-sm-12">
-      <h2>Infrastructure</h2>
+    <div class="col-md-12">
+      <h2>Infrastructure Search</h2>
     </div>
+  </div>
+  <div class="row">
+    <div class="col-md-12">
+      <h4>You may search for Applications, Clusters, Load Balancers, and Server Groups.</h4>
+    </div>
+  </div>
+  <div class="row">
     <div class="col-md-4 col-sm-12">
       <form class="form form-horizontal">
         <div class="form-group">
           <div class="col-md-12">
             <input type="search"
-                   class="form-control input-md"
+                   class="form-control input-lg"
+                   style="margin-bottom: 10px"
                    placeholder="Search infrastructure"
-                   focus
+                   autofocus
+                   ng-model-options="{ updateOn: 'default blur', debounce: { 'default': 300, 'blur': 0 } }"
                    ng-model="query">
           </div>
         </div>
@@ -18,31 +27,51 @@
     </div>
   </div>
 </div>
-<span ng-if="ctrl.hasResults()">
+<div ng-if="ctrl.hasResults()">
   <div class="row" ng-if="moreResults">
     <div class="col-md-12">
       <p style="margin: 10px 20px 0">Only showing the first {{pageSize}} results found.</p>
     </div>
   </div>
   <div class="row infrastructure">
-    <div class="col-md-4" ng-repeat="category in categories | orderBy:'category'">
+    <div class="col-md-4 animated category-container" ng-repeat="category in categories | orderBy:'category'">
       <div class="panel category row">
         <div class="summary">{{ category.category }} ({{category.results.length}})</div>
-        <div class="col-md-12 details-container">
-          <div class="details row padding">
-            <div class="col-md-12" ng-repeat="result in category.results">
-              <a href="{{ result.href }}">{{ result.name }}</a>
-            </div>
-          </div>
+        <div class="details-container list-group">
+          <a class="list-group-item"
+             ng-repeat="result in category.results"
+             href="{{ result.href }}"><span bind-html-unsafe="result.name | typeaheadHighlight:query"></span></a>
         </div>
       </div>
     </div>
   </div>
-</span>
-<span ng-if="ctrl.noMatches()">
+</div>
+<h2 ng-if="viewState.searching" class="text-center" style="margin-bottom: 25px">
+  <span class="glyphicon glyphicon-asterisk glyphicon-spinning"></span>
+</h2>
+<div ng-if="ctrl.noMatches() && !viewState.searching">
   <div class="row">
     <div class="col-md-12">
       <h4 class="text-center">No results matching {{ query }}.</h4>
     </div>
   </div>
-</span>
+</div>
+<div ng-if="ctrl.hasRecentItems && !viewState.searching">
+  <div class="row infrastructure recently-viewed-items">
+    <div class="col-md-12">
+      <h3>Recently viewed</h3>
+    </div>
+  </div>
+  <div class="row infrastructure">
+    <div class="col-md-4 animated category-container" ng-repeat="category in recentItems | orderBy:'category'">
+      <div class="panel category row">
+        <div class="summary">{{ category.category | robotToHuman }} ({{category.results.length}})</div>
+        <div class="details-container list-group">
+          <a class="list-group-item"
+             ng-repeat="result in category.results"
+             ui-sref="{{ result.state }}(result.params)">{{ result.name }}</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/scripts/modules/search/infrastructure/infrastructure.less
+++ b/app/scripts/modules/search/infrastructure/infrastructure.less
@@ -17,18 +17,32 @@
 @import "../../core/presentation/less/imports/commonImports.less";
 
 .infrastructure {
+  h3 {
+    font-weight: 600;
+    margin-left: 15px;
+  }
+  &.recently-viewed-items {
+    border-top: 1px solid @mid_grey;
+  }
   .panel {
-    background-color: #f1f1f1;
+    border: 0;
     .summary {
-      padding: 15px;
+      background-color: @mid_grey;
+      color: @lightest_grey;
+      text-transform: uppercase;
+      padding: 8px 12px;
+      font-weight: 600;
     }
     .details-container {
-      background-color: #FFF;
+      background-color: @lightest_grey;
       height: 200px;
       overflow-y: scroll;
-      .details {
-        padding-top: 15px;
-
+      border-bottom: 2px solid @mid_grey;
+      a {
+        background-color: @lightest_grey;
+        &:hover, &:focus {
+          background-color: #ffffff;
+        }
       }
     }
 


### PR DESCRIPTION
Incremental step to make Infrastructure a little nicer.
- remembers recently visited items and displays them after search results
- cleaned up style to be more consistent with the rest of the app

This is a small step towards projects views and getting rid of the applications list that everyone loves so much.
