### PR TITLE
Sort security groups in server group details for both AWS and Google.

### DIFF
--- a/app/scripts/modules/amazon/serverGroup/details/serverGroupDetails.html
+++ b/app/scripts/modules/amazon/serverGroup/details/serverGroupDetails.html
@@ -204,7 +204,7 @@
     </collapsible-section>
     <collapsible-section heading="Security Groups">
       <ul>
-        <li ng-repeat="securityGroup in securityGroups">
+        <li ng-repeat="securityGroup in securityGroups | orderBy:'name'">
           <a ui-sref="^.securityGroupDetails({name: securityGroup.name, accountId: securityGroup.accountName, region: serverGroup.region, vpcId: serverGroup.vpcId, provider: serverGroup.type})">
             {{securityGroup.name}} ({{securityGroup.id}})
           </a>

--- a/app/scripts/modules/google/serverGroup/details/serverGroupDetails.html
+++ b/app/scripts/modules/google/serverGroup/details/serverGroupDetails.html
@@ -166,7 +166,7 @@
     </collapsible-section>
     <collapsible-section heading="Security Groups">
       <ul>
-        <li ng-repeat="securityGroup in securityGroups">
+        <li ng-repeat="securityGroup in securityGroups | orderBy:'name'">
           <a ui-sref="^.securityGroupDetails({name: securityGroup.name, accountId: securityGroup.accountName, region: 'global', provider: serverGroup.type})">
             {{securityGroup.name}}
           </a>


### PR DESCRIPTION
Can't see any reason to sort them in instance details but not in server group details.
