### PR TITLE
Sort security groups in AWS load balancer details.

### DIFF
--- a/app/scripts/modules/amazon/loadBalancer/details/loadBalancerDetails.html
+++ b/app/scripts/modules/amazon/loadBalancer/details/loadBalancerDetails.html
@@ -96,7 +96,7 @@
     </collapsible-section>
     <collapsible-section heading="Security Groups">
       <ul>
-        <li ng-repeat="securityGroup in securityGroups">
+        <li ng-repeat="securityGroup in securityGroups | orderBy:'name'">
           <a ui-sref="^.securityGroupDetails({name:securityGroup.name, accountId: loadBalancer.account, region: loadBalancer.region, vpcId: loadBalancer.vpcId, provider: loadBalancer.provider})">
             {{securityGroup.name}} ({{securityGroup.id}})
           </a>

--- a/app/scripts/modules/google/loadBalancer/details/loadBalancerDetails.html
+++ b/app/scripts/modules/google/loadBalancer/details/loadBalancerDetails.html
@@ -84,15 +84,6 @@
         </dd>
       </dl>
     </collapsible-section>
-    <collapsible-section heading="Security Groups">
-      <ul>
-        <li ng-repeat="securityGroup in securityGroups">
-          <a ui-sref="^.securityGroupDetails({name:securityGroup.name, accountId: loadBalancer.account, region: loadBalancer.region, vpcId: loadBalancer.vpcId, provider: loadBalancer.provider})">
-            {{securityGroup.name}} ({{securityGroup.id}})
-          </a>
-        </li>
-      </ul>
-    </collapsible-section>
     <collapsible-section heading="Health Checks">
       <dl ng-class="InsightFilterStateModel.filtersExpanded ? '' : 'dl-horizontal dl-wide'">
         <dt>Target</dt>


### PR DESCRIPTION
Remove Security Groups section from Google load balancer details.
