### PR TITLE
refresh instance types if selection is not found

### DIFF
--- a/app/scripts/modules/amazon/serverGroup/configure/serverGroupConfiguration.service.js
+++ b/app/scripts/modules/amazon/serverGroup/configure/serverGroupConfiguration.service.js
@@ -50,6 +50,7 @@ module.exports = angular.module('spinnaker.aws.serverGroup.configure.service', [
       }).then(function(backingData) {
         var loadBalancerReloader = $q.when(null);
         var securityGroupReloader = $q.when(null);
+        var instanceTypeReloader = $q.when(null);
         backingData.accounts = _.keys(backingData.regionsKeyedByAccount);
         backingData.filtered = {};
         command.backingData = backingData;
@@ -68,8 +69,11 @@ module.exports = angular.module('spinnaker.aws.serverGroup.configure.service', [
             securityGroupReloader = refreshSecurityGroups(command, true);
           }
         }
+        if (command.instanceType) {
+          instanceTypeReloader = refreshInstanceTypes(command, true);
+        }
 
-        return $q.all([loadBalancerReloader, securityGroupReloader]).then(function() {
+        return $q.all([loadBalancerReloader, securityGroupReloader, instanceTypeReloader]).then(function() {
           attachEventHandlers(command);
         });
       });
@@ -248,11 +252,13 @@ module.exports = angular.module('spinnaker.aws.serverGroup.configure.service', [
       });
     }
 
-    function refreshInstanceTypes(command) {
+    function refreshInstanceTypes(command, skipCommandReconfiguration) {
       return cacheInitializer.refreshCache('instanceTypes').then(function() {
         return awsInstanceTypeService.getAllTypesByRegion().then(function(instanceTypes) {
           command.backingData.instanceTypes = instanceTypes;
-          configureInstanceTypes(command);
+          if (!skipCommandReconfiguration) {
+            configureInstanceTypes(command);
+          }
         });
       });
     }


### PR DESCRIPTION
When cloning an existing ASG, if the instance type is not found, clear the cache and attempt to reload the instance types.

@cfieber we are already doing this on load balancers and security groups (if selections are not found, clear the cache and try again). It sounds like you saw an issue today with this behavior - was it a problem with the instance type?
