### PR TITLE
Cache Networks.

### DIFF
--- a/app/scripts/modules/caches/cacheInitializer.js
+++ b/app/scripts/modules/caches/cacheInitializer.js
@@ -4,6 +4,7 @@ let angular = require('angular');
 
 module.exports = angular.module('spinnaker.caches.initializer', [
   require('../account/account.service.js'),
+  require('../network/network.read.service.js'),
   require('../securityGroups/securityGroup.read.service.js'),
   require('../applications/applications.read.service.js'),
   require('../jenkins/igor.service.js'),
@@ -14,10 +15,11 @@ module.exports = angular.module('spinnaker.caches.initializer', [
 ])
   .factory('cacheInitializer', function ($q, applicationReader, infrastructureCaches,
                                          accountService, securityGroupReader, cloudProviderRegistry,
-                                         igorService, infrastructureCacheConfig, serviceDelegate, _) {
+                                         igorService, infrastructureCacheConfig, serviceDelegate, networkReader, _) {
 
     var initializers = {
       credentials: [accountService.listAccounts],
+      networks: [networkReader.listNetworks],
       securityGroups: [securityGroupReader.getAllSecurityGroups],
       applications: [applicationReader.listApplications],
       buildMasters: [igorService.listMasters],

--- a/app/scripts/modules/caches/infrastructureCacheConfig.js
+++ b/app/scripts/modules/caches/infrastructureCacheConfig.js
@@ -7,6 +7,9 @@ module.exports = angular.module('spinnaker.caches.infrastructure.config', [])
     credentials: {
       version: 2,
     },
+    networks: {
+      version: 2,
+    },
     vpcs: {
       version: 2,
     },

--- a/app/scripts/modules/config/applicationConfig.view.html
+++ b/app/scripts/modules/config/applicationConfig.view.html
@@ -131,6 +131,16 @@
             </div>
           </div>
           <div class="row">
+            <div class="col-md-3 col-md-offset-1">Networks</div>
+            <div class="col-md-3">{{config.getCacheInfo('networks').ageMax | timestamp}}</div>
+            <div class="col-md-1 text-center">
+              <a href ng-click="config.refreshCache('networks')">
+              <span ng-class="{'glyphicon-spinning':config.clearingCache['networks']}"
+                    class="glyphicon glyphicon-refresh"></span>
+              </a>
+            </div>
+          </div>
+          <div class="row">
             <div class="col-md-3 col-md-offset-1">VPCs</div>
             <div class="col-md-3">{{config.getCacheInfo('vpcs').ageMax | timestamp}}</div>
             <div class="col-md-1 text-center">

--- a/app/scripts/modules/google/gce.module.js
+++ b/app/scripts/modules/google/gce.module.js
@@ -9,6 +9,7 @@ module.exports = angular.module('spinnaker.gce', [
   require('./serverGroup/configure/wizard/CloneServerGroupCtrl.js'),
   require('./serverGroup/configure/serverGroup.configure.gce.module.js'),
   require('./serverGroup/serverGroup.transformer.js'),
+  require('../network/network.module.js'),
   require('../pipelines/config/stages/bake/docker/dockerBakeStage.js'),
   require('../pipelines/config/stages/bake/gce/gceBakeStage.js'),
   require('../pipelines/config/stages/resizeAsg/gce/gceResizeAsgStage.js'),

--- a/app/scripts/modules/google/gceNetworkSelectField.directive.js
+++ b/app/scripts/modules/google/gceNetworkSelectField.directive.js
@@ -1,0 +1,20 @@
+'use strict';
+
+let angular = require('angular');
+
+module.exports = angular.module('spinnaker.google.networkSelectField.directive', [])
+  .directive('gceNetworkSelectField', function () {
+    return {
+      restrict: 'E',
+      templateUrl: require('./networkSelectField.directive.html'),
+      scope: {
+        networks: '=',
+        component: '=',
+        field: '@',
+        account: '=',
+        onChange: '&',
+        labelColumns: '@',
+        fieldColumns: '@',
+      }
+    };
+  }).name;

--- a/app/scripts/modules/google/networkSelectField.directive.html
+++ b/app/scripts/modules/google/networkSelectField.directive.html
@@ -1,0 +1,16 @@
+<div class="form-group">
+  <div class="col-md-{{labelColumns}} sm-label-left">Network</div>
+  <div class="col-md-{{fieldColumns || 7}}" ng-if="!account">(Select an account)</div>
+  <div class="col-md-{{fieldColumns || 7}}">
+    <select class="form-control input-sm"
+            ng-if="account"
+            ng-model="component.network"
+            ng-change="onChange()"
+            required>
+      <option ng-repeat="network in networks"
+              value="{{network}}"
+              ng-selected="component[field] === network">{{network}}</option>
+    </select>
+    <p ng-if="readOnly" class="form-control-static">{{component[field]}}</p>
+  </div>
+</div>

--- a/app/scripts/modules/google/securityGroup/clone/cloneSecurityGroup.controller.js
+++ b/app/scripts/modules/google/securityGroup/clone/cloneSecurityGroup.controller.js
@@ -54,6 +54,8 @@ module.exports = angular
       .flatten()
       .value();
 
+    securityGroup.backingData = {};
+
     delete securityGroup.targetTags;
 
     vm.upsert = function () {

--- a/app/scripts/modules/google/securityGroup/configure/ConfigSecurityGroupMixin.controller.js
+++ b/app/scripts/modules/google/securityGroup/configure/ConfigSecurityGroupMixin.controller.js
@@ -9,6 +9,7 @@ module.exports = angular
     require('../../../securityGroups/securityGroup.write.service.js'),
     require('../../../account/account.service.js'),
     require('../../../modal/wizard/modalWizard.directive.js'),
+    require('../../../network/network.read.service.js'),
     require('../../../utils/lodash.js'),
   ])
   .controller('gceConfigSecurityGroupMixin', function ($scope,
@@ -22,6 +23,7 @@ module.exports = angular
                                                        accountService,
                                                        modalWizardService,
                                                        cacheInitializer,
+                                                       networkReader,
                                                        _ ) {
 
 
@@ -99,6 +101,7 @@ module.exports = angular
             sourceRanges: _.uniq(_.pluck($scope.securityGroup.sourceRanges, 'value')),
             allowed: allowed,
             region: "global",
+            network: $scope.securityGroup.network,
           });
         }
       );
@@ -106,6 +109,7 @@ module.exports = angular
 
     ctrl.accountUpdated = function() {
       ctrl.initializeSecurityGroups();
+      ctrl.updateNetworks();
       ctrl.updateName();
     };
 
@@ -136,8 +140,15 @@ module.exports = angular
       });
     };
 
-    ctrl.cancel = function () {
+    ctrl.cancel = function() {
       $modalInstance.dismiss();
+    };
+
+    ctrl.updateNetworks = function() {
+      networkReader.listNetworksByProvider('gce').then(function(gceNetworks) {
+        var account = $scope.securityGroup.credentials || $scope.securityGroup.accountName;
+        $scope.securityGroup.backingData.networks = _.pluck(_.filter(gceNetworks, { account: account }), 'name');
+      });
     };
 
     ctrl.getCurrentNamePattern = function() {

--- a/app/scripts/modules/google/securityGroup/configure/CreateSecurityGroupCtrl.js
+++ b/app/scripts/modules/google/securityGroup/configure/CreateSecurityGroupCtrl.js
@@ -22,6 +22,8 @@ module.exports = angular.module('spinnaker.gce.securityGroup.create.controller',
 
     var ctrl = this;
 
+    securityGroup.backingData = {};
+    securityGroup.network = 'default';
     securityGroup.sourceRanges = [];
     securityGroup.ipIngress = [];
 

--- a/app/scripts/modules/google/securityGroup/configure/createSecurityGroupProperties.html
+++ b/app/scripts/modules/google/securityGroup/configure/createSecurityGroupProperties.html
@@ -36,6 +36,8 @@
           <account-select-field component="securityGroup" field="credentials" accounts="accounts" provider="'gce'" on-change="ctrl.accountUpdated()"></account-select-field>
         </div>
       </div>
+      <gce-network-select-field label-columns="4" field-columns="8" component="securityGroup" field="network" account="securityGroup.credentials" networks="securityGroup.backingData.networks"></gce-network-select-field>
+    </div>
     <div class="modal-footer">
       <button class="btn btn-default pull-left"
               ng-click="ctrl.cancel()">Cancel

--- a/app/scripts/modules/google/serverGroup/configure/ServerGroupCommandBuilder.js
+++ b/app/scripts/modules/google/serverGroup/configure/ServerGroupCommandBuilder.js
@@ -30,6 +30,17 @@ module.exports = angular.module('spinnaker.gce.serverGroupCommandBuilder.service
       });
     }
 
+    function extractNetworkName(serverGroup) {
+      if (_.has(serverGroup, 'launchConfig.instanceTemplate.properties.networkInterfaces')) {
+        var networkInterfaces = serverGroup.launchConfig.instanceTemplate.properties.networkInterfaces;
+        if (networkInterfaces.length === 1) {
+          var networkUrl = networkInterfaces[0].network;
+          return _.last(networkUrl.split('/'));
+        }
+      }
+      return null;
+    }
+
     function populateCustomMetadata(metadataItems, command) {
       if (metadataItems) {
         if (angular.isArray(metadataItems)) {
@@ -93,6 +104,7 @@ module.exports = angular.module('spinnaker.gce.serverGroupCommandBuilder.service
         credentials: defaultCredentials,
         region: defaultRegion,
         zone: defaultZone,
+        network: 'default',
         strategy: '',
         capacity: {
           min: 0,
@@ -149,6 +161,7 @@ module.exports = angular.module('spinnaker.gce.serverGroupCommandBuilder.service
           desired: serverGroup.asg.desiredCapacity
         },
         zone: serverGroup.zones[0],
+        network: extractNetworkName(serverGroup),
         instanceMetadata: [],
         tags: [],
         availabilityZones: [],

--- a/app/scripts/modules/google/serverGroup/configure/serverGroupBasicSettingsDirective.html
+++ b/app/scripts/modules/google/serverGroup/configure/serverGroupBasicSettingsDirective.html
@@ -9,6 +9,7 @@
   </div>
   <gce-region-select-field label-columns="2" component="command" field="region" account="command.credentials" regions="command.backingData.filtered.regions"></gce-region-select-field>
   <gce-zone-select-field label-columns="2" component="command" field="zone" account="command.credentials" zones="command.backingData.filtered.zones"></gce-zone-select-field>
+  <gce-network-select-field label-columns="2" component="command" field="network" account="command.credentials" networks="command.backingData.filtered.networks"></gce-network-select-field>
   <div class="form-group">
     <div class="col-md-2 sm-label-left">
       <b>Stack</b>

--- a/app/scripts/modules/google/serverGroup/configure/serverGroupBasicSettingsSelector.directive.js
+++ b/app/scripts/modules/google/serverGroup/configure/serverGroupBasicSettingsSelector.directive.js
@@ -5,6 +5,7 @@ let angular = require('angular');
 module.exports = angular.module('spinnaker.serverGroup.configure.gce.basicSettingsSelector', [
   require('../../gceRegionSelectField.directive.js'),
   require('../../gceZoneSelectField.directive.js'),
+  require('../../gceNetworkSelectField.directive.js'),
 ])
   .directive('gceServerGroupBasicSettingsSelector', function() {
     return {

--- a/app/scripts/modules/google/serverGroup/configure/serverGroupSecurityGroupsDirective.html
+++ b/app/scripts/modules/google/serverGroup/configure/serverGroupSecurityGroupsDirective.html
@@ -1,7 +1,7 @@
 <div class="col-md-12" ng-if="command.viewState.dirty.securityGroups">
   <div class="alert alert-warning">
     <p><span class="glyphicon glyphicon-warning-sign"></span>
-      The following security groups could not be found in the selected account and were removed:
+      The following security groups could not be found in the selected account/network and were removed:
     </p>
     <ul>
       <li ng-repeat="securityGroup in command.viewState.dirty.securityGroups">{{securityGroup}}</li>

--- a/app/scripts/modules/google/serverGroup/configure/wizard/CloneServerGroupCtrl.js
+++ b/app/scripts/modules/google/serverGroup/configure/wizard/CloneServerGroupCtrl.js
@@ -70,11 +70,13 @@ module.exports = angular.module('spinnaker.serverGroup.configure.gce.cloneServer
     function initializeWatches() {
       $scope.$watch('command.credentials', createResultProcessor($scope.command.credentialsChanged));
       $scope.$watch('command.region', createResultProcessor($scope.command.regionChanged));
+      $scope.$watch('command.network', createResultProcessor($scope.command.networkChanged));
     }
 
     function initializeSelectOptions() {
       processCommandUpdateResult($scope.command.credentialsChanged());
       processCommandUpdateResult($scope.command.regionChanged());
+      processCommandUpdateResult($scope.command.networkChanged());
     }
 
     function createResultProcessor(method) {

--- a/app/scripts/modules/network/network.module.js
+++ b/app/scripts/modules/network/network.module.js
@@ -1,0 +1,8 @@
+'use strict';
+
+let angular = require('angular');
+
+module.exports = angular
+  .module('spinnaker.network', [
+    require('./network.read.service.js')
+  ]).name;

--- a/app/scripts/modules/network/network.read.service.js
+++ b/app/scripts/modules/network/network.read.service.js
@@ -1,0 +1,30 @@
+'use strict';
+
+let angular = require('angular');
+
+module.exports = angular
+  .module('spinnaker.network.read.service', [
+    require('exports?"restangular"!imports?_=lodash!restangular'),
+    require('../utils/lodash.js'),
+    require('../caches/infrastructureCaches.js')
+  ])
+  .factory('networkReader', function (Restangular, infrastructureCaches ) {
+
+    function listNetworks() {
+      return Restangular.one('networks')
+        .withHttpConfig({cache: infrastructureCaches.networks})
+        .get();
+    }
+
+    function listNetworksByProvider(cloudProvider) {
+      return listNetworks().then(function(networks) {
+        return networks[cloudProvider];
+      });
+    }
+
+    return {
+      listNetworks: listNetworks,
+      listNetworksByProvider: listNetworksByProvider,
+    };
+
+  }).name;


### PR DESCRIPTION
Surface Google Networks when Deploying/Cloning Server Groups and Security Groups.
This uses the new `/networks` entry-point exposed via gate/clouddriver.
Note: `/networks/aws` can now be used in place of `/vpcs` (although I didn't touch any vpc-related bits here).
There is a new "Networks" item listed in the Config->Cache Management section. If we decide to just cache Networks instead of VPCs (since we deprecated the `/vpcs` endpoint on gate/clouddriver when we generalized it to `/networks`), maybe we can have one item in that section labeled "Networks/VPCs"?
@anotherchrisberry please review.
