### PR TITLE
do not fade running tasks; show/hide running tasks on hover

### DIFF
--- a/app/scripts/modules/cluster/rollups.less
+++ b/app/scripts/modules/cluster/rollups.less
@@ -183,19 +183,25 @@
 
 running-tasks-tag {
   position: relative;
+  top: 2px;
+  right: 5px;
+  .icon-spinner {
+    color: @link-color;
+  }
 }
 
 .menu-running-tasks {
   text-align: left;
   position: absolute;
   z-index: 3;
-  right: -10px;
+  top: 20px;
+  right: -12px;
   background-color: #ffffff;
   margin-top: 12px;
   border: 1px solid #777777;
   padding: 5px 10px;
   border-radius: 3px;
-  box-shadow: 0px 0px 5px 2px #eeeeee;
+  box-shadow: 0 0 2px 1px #eeeeee;
   text-transform: none;
   color: @text-color;
   font-weight: 400;
@@ -364,11 +370,6 @@ load-balancers-tag {
           background-color: @active_pod_blue;
         }
       }
-      &.disabled {
-        &:hover, &.active {
-          opacity: 0.7;
-        }
-      }
     }
     .table {
       margin-top: -5px;
@@ -408,9 +409,17 @@ load-balancers-tag {
   }
 
   .disabled {
-    opacity: 0.4;
-    .glyphicon-th {
+    opacity: 1;
+    .section-title, health-counts, load-balancers-tag, instances {
+      opacity: 0.4;
+    }
+    .icon-server-group {
       color: @mid_grey;
+    }
+    &:hover {
+      .section-title, health-counts, load-balancers-tag, instances {
+        opacity: 0.7;
+      }
     }
   }
 
@@ -437,6 +446,10 @@ load-balancers-tag {
     text-align: center;
     color: @mid_grey;
   }
+}
+
+instances {
+  display: block;
 }
 
 .row {

--- a/app/scripts/modules/serverGroups/pod/runningTasksTag.html
+++ b/app/scripts/modules/serverGroups/pod/runningTasksTag.html
@@ -1,9 +1,7 @@
 <span ng-if="tasks.length || runningExecutions().length">
-  <button class="btn btn-link no-padding"
-          ng-click="popover.show = !popover.show; $event.stopPropagation();"
-          tooltip="{{popover.show ? 'Hide' : 'Show'}} running task{{tasks.length > 1 ? 's' : ''}}">
+  <span ng-mouseenter="popover.show = true" ng-mouseleave="popover.show = false">
     <span class="icon"><span class="glyphicon icon-spinner glyphicon-spinning"></span></span>
-  </button>
+  </span>
   <div class="menu-running-tasks" ng-if="popover.show">
     <div class="container-fluid" ng-repeat="task in tasks | orderBy:'-startTime'">
       <div class="row">

--- a/app/scripts/modules/serverGroups/serverGroup.directive.html
+++ b/app/scripts/modules/serverGroups/serverGroup.directive.html
@@ -10,7 +10,7 @@
          sticky-if="headerIsSticky()">
       <div class="container-fluid no-padding">
         <div class="row">
-          <div class="col-md-8">
+          <div class="col-md-8 section-title">
             <span class="icon icon-server-group icon-{{viewModel.serverGroup.type}} small"></span>
             <span class="server-group-sequence">{{ viewModel.serverGroupSequence }}</span><span ng-if="viewModel.jenkins">:</span>
             <a ng-if="viewModel.jenkins"


### PR DESCRIPTION
Someone finally noticed that the running tasks have an opacity problem when the server group is disabled. This fixes that, and also changes the toggle behavior to show/hide on mouseenter/mouseleave instead of clicking. I think this is better, we'll see if that's not a universally held belief.
