### PR TITLE
avoids error where securityGroups is undefined on create server group…

### DIFF
--- a/app/scripts/modules/amazon/serverGroup/configure/serverGroupCommandBuilder.service.js
+++ b/app/scripts/modules/amazon/serverGroup/configure/serverGroupCommandBuilder.service.js
@@ -65,6 +65,7 @@ module.exports = angular.module('spinnaker.aws.serverGroupCommandBuilder.service
             availabilityZones: availabilityZones,
             keyPair: keyPair,
             suspendedProcesses: [],
+            securityGroups: [],
             viewState: {
               instanceProfile: 'custom',
               allImageSelection: null,


### PR DESCRIPTION
… modal

and the diff has nothing to compare with. Seems like the right thing to initialize with anyway.
