### PR TITLE
limit options to 100 on potentially huge dropdowns

### DIFF
--- a/app/scripts/modules/amazon/serverGroup/configure/serverGroupLoadBalancersSelector.directive.html
+++ b/app/scripts/modules/amazon/serverGroup/configure/serverGroupLoadBalancersSelector.directive.html
@@ -17,7 +17,7 @@
   <div class="col-md-9">
     <ui-select multiple ng-model="command.loadBalancers" class="form-control input-sm">
       <ui-select-match>{{$item}}</ui-select-match>
-      <ui-select-choices repeat="loadBalancer in command.backingData.filtered.loadBalancers | filter: $select.search">
+      <ui-select-choices repeat="loadBalancer in command.backingData.filtered.loadBalancers | filter: $select.search | limitTo: 100">
         <span ng-bind-html="loadBalancer | highlight: $select.search"></span>
       </ui-select-choices>
     </ui-select>

--- a/app/scripts/modules/amazon/serverGroup/configure/serverGroupSecurityGroupsSelector.directive.html
+++ b/app/scripts/modules/amazon/serverGroup/configure/serverGroupSecurityGroupsSelector.directive.html
@@ -46,7 +46,7 @@
   <div class="col-md-9">
     <ui-select multiple ng-model="command.securityGroups" class="form-control input-sm">
       <ui-select-match>{{$item.name}} ({{$item.id}})</ui-select-match>
-      <ui-select-choices repeat="securityGroup.id as securityGroup in command.backingData.filtered.securityGroups | anyFieldFilter: {name: $select.search, id: $select.search}">
+      <ui-select-choices repeat="securityGroup.id as securityGroup in command.backingData.filtered.securityGroups | anyFieldFilter: {name: $select.search, id: $select.search} | limitTo: 100">
         <span ng-bind-html="securityGroup.name | highlight: $select.search"></span>
         (<span ng-bind-html="securityGroup.id  | highlight: $select.search"></span>)
       </ui-select-choices>


### PR DESCRIPTION
Not happy about this, but performance is brutal on these select fields when there are 1000+ options.

I tried to make this work with ng-infinite-scroll, but that requires a container attribute, and, ui-select's multiselect seems to instantiate the options list node multiple times, so the infinite scroll gets attached to a node that is later detached and removed from the tree instead of the one that is rendered at the end.

We'll see if folks complain. I am guessing they won't, as people expect this to behave as an auto-complete.
