### PR TITLE
hide overflow on html node, will never regret this

### DIFF
--- a/app/scripts/modules/core/presentation/main.less
+++ b/app/scripts/modules/core/presentation/main.less
@@ -925,6 +925,10 @@ whats-new {
   }
 }
 
+html {
+  overflow: hidden;
+}
+
 body, html {
   width: 100%;
   height: 100%;


### PR DESCRIPTION
If scrollbars are enabled, showing a tooltip results in the entire page shifting abruptly and momentarily, which I think is happening because it's getting positioned offscreen somewhere to calculate size, which triggers scrollbar rendering, then immediately removed or repositioned into the right place.
