### PR TITLE
remove circular references on transformed executions; ng-show->ng-if

### DIFF
--- a/app/scripts/modules/delivery/executionGroupHeading.html
+++ b/app/scripts/modules/delivery/executionGroupHeading.html
@@ -35,7 +35,7 @@
       </div>
     </div>
   </div>
-  <div class="row" ng-show="viewState.open">
+  <div class="row" ng-if="viewState.open">
     <div class="col-md-12 execution-group-container">
       <execution-group grouping="value"
                        filter="filter"

--- a/app/scripts/modules/delivery/executions.transformer.service.js
+++ b/app/scripts/modules/delivery/executions.transformer.service.js
@@ -253,6 +253,7 @@ module.exports = angular.module('spinnaker.delivery.executionTransformer.service
     function transformStageSummary(summary) {
       summary.stages = flattenAndFilter(summary);
       summary.stages.forEach(transformStage);
+      summary.stages.forEach((stage) => delete stage.stages);
       summary.masterStageIndex = summary.stages.indexOf(summary.masterStage) === -1 ? 0 : summary.stages.indexOf(summary.masterStage);
       transformStage(summary);
       styleStage(summary);


### PR DESCRIPTION
`ng-show` renders the dom nodes, which is not awesome when there are > 100 executions on the page.

Circular references being removed because I might do some awful diffing this weekend to try to improve performance. I will go to jail for this.
