### PR TITLE
do not bind auto-refresh until component is loaded

### DIFF
--- a/app/scripts/modules/amazon/loadBalancer/details/loadBalancerDetail.controller.js
+++ b/app/scripts/modules/amazon/loadBalancer/details/loadBalancerDetail.controller.js
@@ -14,7 +14,7 @@ module.exports = angular.module('spinnaker.loadBalancer.aws.details.controller',
   require('../../../utils/selectOnDblClick.directive.js'),
 ])
   .controller('awsLoadBalancerDetailsCtrl', function ($scope, $state, $exceptionHandler, $modal, loadBalancer, app, InsightFilterStateModel,
-                                                   securityGroupReader, _, confirmationModalService, loadBalancerWriter, loadBalancerReader) {
+                                                   securityGroupReader, _, confirmationModalService, loadBalancerWriter, loadBalancerReader, $q) {
 
     $scope.state = {
       loading: true
@@ -33,7 +33,7 @@ module.exports = angular.module('spinnaker.loadBalancer.aws.details.controller',
 
       if ($scope.loadBalancer) {
         var detailsLoader = loadBalancerReader.getLoadBalancerDetails($scope.loadBalancer.provider, loadBalancer.accountId, loadBalancer.region, loadBalancer.name);
-        detailsLoader.then(function(details) {
+        return detailsLoader.then(function(details) {
           $scope.state.loading = false;
           var securityGroups = [];
           var filtered = details.filter(function(test) {
@@ -60,6 +60,8 @@ module.exports = angular.module('spinnaker.loadBalancer.aws.details.controller',
       if (!$scope.loadBalancer) {
         $state.go('^');
       }
+
+      return $q.when(null);
     }
 
     extractLoadBalancer();

--- a/app/scripts/modules/amazon/securityGroup/details/securityGroupDetail.controller.js
+++ b/app/scripts/modules/amazon/securityGroup/details/securityGroupDetail.controller.js
@@ -26,7 +26,7 @@ module.exports = angular.module('spinnaker.securityGroup.aws.details.controller'
     $scope.InsightFilterStateModel = InsightFilterStateModel;
 
     function extractSecurityGroup() {
-      securityGroupReader.getSecurityGroupDetails(application, securityGroup.accountId, securityGroup.provider, securityGroup.region, securityGroup.vpcId, securityGroup.name).then(function (details) {
+      return securityGroupReader.getSecurityGroupDetails(application, securityGroup.accountId, securityGroup.provider, securityGroup.region, securityGroup.vpcId, securityGroup.name).then(function (details) {
         $scope.state.loading = false;
 
         if (!details || _.isEmpty( details.plain())) {
@@ -44,9 +44,7 @@ module.exports = angular.module('spinnaker.securityGroup.aws.details.controller'
       $state.go('^');
     }
 
-    extractSecurityGroup();
-
-    application.registerAutoRefreshHandler(extractSecurityGroup, $scope);
+    extractSecurityGroup().then(() => application.registerAutoRefreshHandler(extractSecurityGroup, $scope));
 
     this.editInboundRules = function editInboundRules() {
       $modal.open({

--- a/app/scripts/modules/amazon/serverGroup/details/serverGroupDetails.aws.controller.js
+++ b/app/scripts/modules/amazon/serverGroup/details/serverGroupDetails.aws.controller.js
@@ -70,7 +70,7 @@ module.exports = angular.module('spinnaker.serverGroup.details.aws.controller', 
 
     function retrieveServerGroup() {
       var summary = extractServerGroupSummary();
-      serverGroupReader.getServerGroup(app.name, serverGroup.accountId, serverGroup.region, serverGroup.name).then(function(details) {
+      return serverGroupReader.getServerGroup(app.name, serverGroup.accountId, serverGroup.region, serverGroup.name).then(function(details) {
         cancelLoader();
 
         var restangularlessDetails = details.plain();
@@ -124,9 +124,7 @@ module.exports = angular.module('spinnaker.serverGroup.details.aws.controller', 
       $scope.state.loading = false;
     }
 
-    retrieveServerGroup();
-
-    app.registerAutoRefreshHandler(retrieveServerGroup, $scope);
+    retrieveServerGroup().then(() => app.registerAutoRefreshHandler(retrieveServerGroup, $scope));
 
     this.destroyServerGroup = function destroyServerGroup() {
       var serverGroup = $scope.serverGroup;

--- a/app/scripts/modules/core/application/service/applications.read.service.js
+++ b/app/scripts/modules/core/application/service/applications.read.service.js
@@ -52,6 +52,9 @@ module.exports = angular
 
 
         function registerAutoRefreshHandler(method, scope) {
+          if (scope.$$destroyed) {
+            return;
+          }
           application.autoRefreshHandlers.push(method);
           scope.$on('$destroy', function () {
             application.autoRefreshHandlers = application.autoRefreshHandlers.filter((handler) => handler !== method);

--- a/app/scripts/modules/google/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/google/instance/details/instance.details.controller.js
@@ -15,7 +15,7 @@ module.exports = angular.module('spinnaker.instance.detail.gce.controller', [
 ])
   .controller('gceInstanceDetailsCtrl', function ($scope, $state, $modal, InsightFilterStateModel,
                                                instanceWriter, confirmationModalService, recentHistoryService,
-                                               instanceReader, _, instance, app) {
+                                               instanceReader, _, instance, app, $q) {
 
     // needed for standalone instances
     $scope.detailsTemplateUrl = require('./instanceDetails.html');
@@ -116,7 +116,7 @@ module.exports = angular.module('spinnaker.instance.detail.gce.controller', [
         extraData.account = account;
         extraData.region = region;
         recentHistoryService.addExtraDataToLatest('instances', extraData);
-        instanceReader.getInstanceDetails(account, region, instance.instanceId).then(function(details) {
+        return instanceReader.getInstanceDetails(account, region, instance.instanceId).then(function(details) {
           details = details.plain();
           $scope.state.loading = false;
           extractHealthMetrics(instanceSummary, details);
@@ -150,6 +150,8 @@ module.exports = angular.module('spinnaker.instance.detail.gce.controller', [
       if (!instanceSummary) {
         $state.go('^');
       }
+
+      return $q.when(null);
     }
 
     function getNetwork() {
@@ -370,9 +372,7 @@ module.exports = angular.module('spinnaker.instance.detail.gce.controller', [
       );
     };
 
-    retrieveInstance();
-
-    app.registerAutoRefreshHandler(retrieveInstance, $scope);
+    retrieveInstance().then(() => app.registerAutoRefreshHandler(retrieveInstance, $scope));
 
     $scope.account = instance.account;
 

--- a/app/scripts/modules/google/securityGroup/details/SecurityGroupDetailsCtrl.js
+++ b/app/scripts/modules/google/securityGroup/details/SecurityGroupDetailsCtrl.js
@@ -43,7 +43,7 @@ module.exports = angular.module('spinnaker.securityGroup.gce.details.controller'
     $scope.InsightFilterStateModel = InsightFilterStateModel;
 
     function extractSecurityGroup() {
-      securityGroupReader.getSecurityGroupDetails(application, securityGroup.accountId, securityGroup.provider, securityGroup.region, securityGroup.vpcId, securityGroup.name).then(function (details) {
+      return securityGroupReader.getSecurityGroupDetails(application, securityGroup.accountId, securityGroup.provider, securityGroup.region, securityGroup.vpcId, securityGroup.name).then(function (details) {
         $scope.state.loading = false;
 
         if (!details || _.isEmpty( details.plain())) {
@@ -108,9 +108,7 @@ module.exports = angular.module('spinnaker.securityGroup.gce.details.controller'
       $state.go('^');
     }
 
-    extractSecurityGroup();
-
-    application.registerAutoRefreshHandler(extractSecurityGroup, $scope);
+    extractSecurityGroup().then(() => application.registerAutoRefreshHandler(extractSecurityGroup, $scope));
 
     this.editInboundRules = function editInboundRules() {
       $modal.open({

--- a/app/scripts/modules/google/serverGroup/details/serverGroupDetails.gce.controller.js
+++ b/app/scripts/modules/google/serverGroup/details/serverGroupDetails.gce.controller.js
@@ -48,7 +48,7 @@ module.exports = angular.module('spinnaker.serverGroup.details.gce.controller', 
 
     function retrieveServerGroup() {
       var summary = extractServerGroupSummary();
-      serverGroupReader.getServerGroup(application.name, serverGroup.accountId, serverGroup.region, serverGroup.name).then(function(details) {
+      return serverGroupReader.getServerGroup(application.name, serverGroup.accountId, serverGroup.region, serverGroup.name).then(function(details) {
         cancelLoader();
 
         var restangularlessDetails = details.plain();
@@ -81,9 +81,7 @@ module.exports = angular.module('spinnaker.serverGroup.details.gce.controller', 
       $scope.state.loading = false;
     }
 
-    retrieveServerGroup();
-
-    application.registerAutoRefreshHandler(retrieveServerGroup, $scope);
+    retrieveServerGroup().then(() => application.registerAutoRefreshHandler(retrieveServerGroup, $scope));
 
     this.destroyServerGroup = function destroyServerGroup() {
       var serverGroup = $scope.serverGroup;


### PR DESCRIPTION
If a detail view is loaded just before an application refresh event, the detail view will be immediately refreshed once the application refreshes, which is not great, especially if the detail view loads a 2000-instance server group. So let's not do that.
