### PR TITLE
reset interval when scheduleImmediate called

### DIFF
--- a/app/scripts/modules/core/application/service/applications.read.service.js
+++ b/app/scripts/modules/core/application/service/applications.read.service.js
@@ -93,7 +93,7 @@ module.exports = angular
 
         application.registerAutoRefreshHandler = registerAutoRefreshHandler;
         application.autoRefreshHandlers = [];
-        application.refreshImmediately = refreshApplication;
+        application.refreshImmediately = scheduler.scheduleImmediate;
         application.enableAutoRefresh = enableAutoRefresh;
         application.reloadTasks = reloadTasks;
         application.reloadExecutions = reloadExecutions;

--- a/app/scripts/modules/core/projects/dashboard/cluster/projectCluster.directive.js
+++ b/app/scripts/modules/core/projects/dashboard/cluster/projectCluster.directive.js
@@ -233,7 +233,7 @@ module.exports = angular.module('spinnaker.core.projects.dashboard.clusters.proj
 
     $scope.$on('$destroy', () => dataLoader.dispose());
 
-    this.refreshImmediately = () => scheduler.scheduleImmediate(loadData);
+    this.refreshImmediately = scheduler.scheduleImmediate;
 
     loadData();
 

--- a/app/scripts/modules/core/projects/dashboard/dashboard.controller.js
+++ b/app/scripts/modules/core/projects/dashboard/dashboard.controller.js
@@ -36,7 +36,7 @@ module.exports = angular.module('spinnaker.core.projects.dashboard.controller', 
 
     $scope.$on('$destroy', () => dataLoader.dispose());
 
-    this.refreshImmediately = () => scheduler.scheduleImmediate(getExecutions);
+    this.refreshImmediately = scheduler.scheduleImmediate;
 
     this.refreshImmediately();
 

--- a/app/scripts/modules/scheduler/scheduler.service.js
+++ b/app/scripts/modules/scheduler/scheduler.service.js
@@ -48,6 +48,12 @@ module.exports = angular.module('spinnaker.scheduler', [
       }
     };
 
+    let scheduleImmediate = () => {
+      runner();
+      source.pause();
+      $timeout(runner, settings.pollSchedule);
+    };
+
     document.addEventListener('visibilitychange', watchDocumentVisibility);
     $window.addEventListener('offline', suspendScheduler);
     $window.addEventListener('online', resumeScheduler);
@@ -56,7 +62,7 @@ module.exports = angular.module('spinnaker.scheduler', [
     return {
       get: function() { return scheduler; },
       subscribe: scheduler.subscribe.bind(scheduler),
-      scheduleImmediate: scheduler.onNext.bind(scheduler),
+      scheduleImmediate: scheduleImmediate,
       scheduleOnCompletion: function(promise) {
         var deferred = $q.defer();
         promise.then(


### PR DESCRIPTION
Otherwise, clicking the refresh button next to the application just inserts a refresh, which will then rerun on its regular 30 second schedule, which can be...bad.
