### PR TITLE
Strip off all trailing dashes as both Amazon and Google throw errors …

### DIFF
--- a/app/scripts/modules/amazon/loadBalancer/configure/createLoadBalancer.controller.js
+++ b/app/scripts/modules/amazon/loadBalancer/configure/createLoadBalancer.controller.js
@@ -260,7 +260,8 @@ module.exports = angular.module('spinnaker.loadBalancer.aws.create.controller', 
 
     this.getName = function() {
       var elb = $scope.loadBalancer;
-      return [application.name, (elb.stack || ''), (elb.detail || '')].join('-');
+      var elbName = [application.name, (elb.stack || ''), (elb.detail || '')].join('-');
+      return _.trimRight(elbName, "-");
     };
 
     this.accountUpdated = function() {

--- a/app/scripts/modules/google/loadBalancer/configure/CreateLoadBalancerCtrl.js
+++ b/app/scripts/modules/google/loadBalancer/configure/CreateLoadBalancerCtrl.js
@@ -112,8 +112,9 @@ module.exports = angular.module('spinnaker.loadBalancer.gce.create.controller', 
     };
 
     this.getName = function() {
-      var elb = $scope.loadBalancer;
-      return [application.name, (elb.stack || ''), (elb.detail || '')].join('-');
+      var loadBalancer = $scope.loadBalancer;
+      var loadBalancerName = [application.name, (loadBalancer.stack || ''), (loadBalancer.detail || '')].join('-');
+      return _.trimRight(loadBalancerName, "-");
     };
 
     this.accountUpdated = function() {


### PR DESCRIPTION
…when load balancer names end with a dash.
