### PR TITLE
move stringify out of transformer

### DIFF
--- a/app/scripts/modules/delivery/executions.transformer.service.js
+++ b/app/scripts/modules/delivery/executions.transformer.service.js
@@ -9,7 +9,7 @@ module.exports = angular.module('spinnaker.delivery.executionTransformer.service
   require('../utils/lodash.js'),
   require('../pipelines/config/pipelineConfigProvider.js'),
 ])
-  .factory('executionsTransformer', function(orchestratedItemTransformer, _, pipelineConfig, $log) {
+  .factory('executionsTransformer', function(orchestratedItemTransformer, _, pipelineConfig) {
 
     var hiddenStageTypes = ['pipelineInitialization', 'waitForRequisiteCompletion'];
 
@@ -69,11 +69,6 @@ module.exports = angular.module('spinnaker.delivery.executionTransformer.service
       execution.currentStages = getCurrentStages(execution);
       addStageWidths(execution);
       addBuildInfo(execution);
-      try {
-        execution.stringVal = JSON.stringify(execution);
-      } catch (e) {
-        $log.warn('Could not stringify execution:', execution.id);
-      }
     }
 
     function flattenStages(stages, stage) {

--- a/app/scripts/modules/delivery/executionsService.js
+++ b/app/scripts/modules/delivery/executionsService.js
@@ -8,7 +8,8 @@ module.exports = angular.module('spinnaker.delivery.executions.service', [
   require('../utils/appendTransform.js'),
   require('./executions.transformer.service.js')
 ])
-  .factory('executionsService', function($stateParams, $http, $timeout, $q, scheduler, settings, appendTransform, executionsTransformer) {
+  .factory('executionsService', function($stateParams, $http, $timeout, $q, $log,
+                                         scheduler, settings, appendTransform, executionsTransformer) {
 
     function getExecutions(application) {
 
@@ -21,6 +22,11 @@ module.exports = angular.module('spinnaker.delivery.executions.service', [
           }
           executions.forEach(function(execution) {
             executionsTransformer.transformExecution(application, execution);
+            try {
+              execution.stringVal = JSON.stringify(execution);
+            } catch (e) {
+              $log.warn('Could not stringify execution:', execution.id);
+            }
           });
           return executions;
         }),


### PR DESCRIPTION
This one weird trick lets V8 optimize the transform, so it runs a lot faster, which is nice.

Note: if you're doing something expensive in JS, avoid try/catches, or keep them outside the expensive function.
