### PR TITLE
stringify before transform; reduce footprint of security group index

### DIFF
--- a/app/scripts/modules/delivery/executionsService.js
+++ b/app/scripts/modules/delivery/executionsService.js
@@ -21,12 +21,12 @@ module.exports = angular.module('spinnaker.delivery.executions.service', [
             return [];
           }
           executions.forEach(function(execution) {
-            executionsTransformer.transformExecution(application, execution);
             try {
               execution.stringVal = JSON.stringify(execution);
             } catch (e) {
               $log.warn('Could not stringify execution:', execution.id);
             }
+            executionsTransformer.transformExecution(application, execution);
           });
           return executions;
         }),

--- a/app/scripts/modules/securityGroups/securityGroup.html
+++ b/app/scripts/modules/securityGroups/securityGroup.html
@@ -15,9 +15,9 @@
       <div ng-repeat="serverGroup in securityGroup.usages.serverGroups | orderBy:'-name'"
            class="rollup-row" ng-class="{disabled: serverGroup.isDisabled}">
         <a
-            ui-sref=".serverGroup({region: serverGroup.region, accountId: serverGroup.account, serverGroup: serverGroup.name, provider: serverGroup.type})"
+            ui-sref=".serverGroup({region: securityGroup.region, accountId: securityGroup.account, serverGroup: serverGroup.name, provider: securityGroup.provider})"
             ui-sref-active="active">
-          <span class="icon icon-server-group icon-{{serverGroup.type}} small"></span> {{serverGroup.name}}
+          <span class="icon icon-server-group icon-{{securityGroup.provider}} small"></span> {{serverGroup.name}}
         </a>
       </div>
     </div>
@@ -28,7 +28,7 @@
       <div ng-repeat="loadBalancer in securityGroup.usages.loadBalancers | orderBy:'-name'"
            class="rollup-row">
         <a
-            ui-sref=".loadBalancerDetails({region: loadBalancer.region, accountId: loadBalancer.account, name: loadBalancer.name, vpcId: loadBalancer.vpcId, provider: loadBalancer.provider})"
+            ui-sref=".loadBalancerDetails({region: securityGroup.region, accountId: securityGroup.account, name: loadBalancer.name, vpcId: securityGroup.vpcId, provider: securityGroup.provider})"
             ui-sref-active="active">
           <span class="icon icon-elb"></span> {{loadBalancer.name}}
         </a>

--- a/app/scripts/modules/securityGroups/securityGroup.read.service.js
+++ b/app/scripts/modules/securityGroups/securityGroup.read.service.js
@@ -91,7 +91,7 @@ module.exports = angular.module('spinnaker.securityGroup.read.service', [
             try {
               var securityGroup = resolve(indexedSecurityGroups, loadBalancer, securityGroupId);
               attachUsageFields(securityGroup);
-              securityGroup.usages.loadBalancers.push(loadBalancer);
+              securityGroup.usages.loadBalancers.push({name: loadBalancer.name});
               applicationSecurityGroups.push(securityGroup);
             } catch (e) {
               $log.warn('could not attach security group to load balancer:', loadBalancer.name, securityGroupId, e);
@@ -106,7 +106,7 @@ module.exports = angular.module('spinnaker.securityGroup.read.service', [
             try {
               var securityGroup = resolve(indexedSecurityGroups, serverGroup, securityGroupId);
               attachUsageFields(securityGroup);
-              securityGroup.usages.serverGroups.push(serverGroup);
+              securityGroup.usages.serverGroups.push({name: serverGroup.name, isDisabled: serverGroup.isDisabled});
               applicationSecurityGroups.push(securityGroup);
             } catch (e) {
               $log.warn('could not attach security group to server group:', serverGroup.name, securityGroupId);


### PR DESCRIPTION
Retain the minimum required info on load balancers and server groups in security group index to make it a little easier on garbage collection.

Also stringify execution pre-transform, since nothing in the transform should alter the diff. I'll probably regret this.
