### PR TITLE
Control rendering of "implicit" security groups with a checkbox.

### DIFF
--- a/app/scripts/modules/core/help/helpContents.js
+++ b/app/scripts/modules/core/help/helpContents.js
@@ -86,6 +86,7 @@ module.exports = angular.module('spinnaker.core.help.contents', [])
     'gce.loadBalancer.healthCheck': '(Optional) <b>Health Checks</b> use HTTP requests to determine if a VM instance is healthy.',
     'gce.loadBalancer.portRange': '(Optional) Only packets addressed to ports in the specified <b>Port Range</b> will be forwarded. If left empty, all ports are forwarded. Must be a single port number or two port numbers separated by a dash. Each port number must be between 1 and 65535, inclusive. For example: 5000-5999.',
     'gce.serverGroup.capacity': 'The number of instances that the instance group manager will attempt to maintain. Deleting or abandoning instances will affect this number, as will resizing the group.',
+    'gce.serverGroup.securityGroups.implicit': 'Firewall rules with no target tags defined will permit incoming connections that match the ingress rules to all instances in the network.',
     'pipeline.config.deploy.template': '<p>Select an existing cluster to use as a template for this deployment, and we\'ll pre-fill ' +
       'the configuration based on the newest server group in the cluster.</p>' +
       '<p>If you want to start from scratch, select "None".</p>' +

--- a/app/scripts/modules/google/serverGroup/configure/ServerGroupCommandBuilder.js
+++ b/app/scripts/modules/google/serverGroup/configure/ServerGroupCommandBuilder.js
@@ -123,6 +123,7 @@ module.exports = angular.module('spinnaker.gce.serverGroupCommandBuilder.service
           useAllImageSelection: false,
           useSimpleCapacity: true,
           usePreferredZones: true,
+          listImplicitSecurityGroups: false,
           mode: defaults.mode || 'create',
         }
       };
@@ -180,6 +181,7 @@ module.exports = angular.module('spinnaker.gce.serverGroupCommandBuilder.service
           useAllImageSelection: false,
           useSimpleCapacity: true,
           usePreferredZones: false,
+          listImplicitSecurityGroups: false,
           mode: mode,
         },
       };

--- a/app/scripts/modules/google/serverGroup/configure/serverGroupConfiguration.service.js
+++ b/app/scripts/modules/google/serverGroup/configure/serverGroupConfiguration.service.js
@@ -189,14 +189,19 @@ module.exports = angular.module('spinnaker.serverGroup.configure.gce.configurati
           results.dirty.securityGroups = removed;
         }
       }
-      command.backingData.filtered.securityGroups = newSecurityGroups;
 
-      var implicitSecurityGroups = _.filter(newSecurityGroups, function(securityGroup) {
+      // Only include explicit security group options in the pulldown list.
+      command.backingData.filtered.securityGroups = _.filter(newSecurityGroups, function(securityGroup) {
+        return !_.isEmpty(securityGroup.targetTags);
+      });
+
+      // Identify implicit security groups so they can be optionally listed in a read-only state.
+      command.implicitSecurityGroups = _.filter(newSecurityGroups, function(securityGroup) {
         return _.isEmpty(securityGroup.targetTags);
       });
-      var implicitSecurityGroupIds = _.pluck(implicitSecurityGroups, 'id');
 
-      command.securityGroups = _.union(command.securityGroups, implicitSecurityGroupIds).sort();
+      // Only include explicitly-selected security groups in the body of the command.
+      command.securityGroups = _.difference(command.securityGroups, _.pluck(command.implicitSecurityGroups, 'id'));
 
       return results;
     }

--- a/app/scripts/modules/google/serverGroup/configure/serverGroupSecurityGroupsDirective.html
+++ b/app/scripts/modules/google/serverGroup/configure/serverGroupSecurityGroupsDirective.html
@@ -1,5 +1,5 @@
-<div class="col-md-12" ng-if="command.viewState.dirty.securityGroups">
-  <div class="alert alert-warning">
+<div class="col-md-12" ng-if="command.viewState.dirty.securityGroups" style="max-height: 200px">
+  <div class="alert alert-warning" style="max-height: 175px; overflow: auto">
     <p><span class="glyphicon glyphicon-warning-sign"></span>
       The following security groups could not be found in the selected account/network and were removed:
     </p>
@@ -16,12 +16,33 @@
   <div class="col-md-3 sm-label-left"><b>Security Groups</b></div>
   <div class="col-md-9">
     <ui-select multiple ng-model="command.securityGroups" class="form-control input-sm">
-      <ui-select-match>{{$item.name}} ({{$item.id}})</ui-select-match>
+      <ui-select-match>{{$item.name}}</ui-select-match>
       <ui-select-choices repeat="securityGroup.id as securityGroup in command.backingData.filtered.securityGroups | anyFieldFilter: {name: $select.search, id: $select.search}">
         <span ng-bind-html="securityGroup.name | highlight: $select.search"></span>
         (<span ng-bind-html="securityGroup.id  | highlight: $select.search"></span>)
       </ui-select-choices>
     </ui-select>
+  </div>
+</div>
+
+<div class="form-group" ng-if="command.viewState.listImplicitSecurityGroups">
+  <div class="col-md-3 sm-label-left"><b>Implicit Security Groups</b></div>
+  <div class="col-md-9">
+    <ul ng-if="command.implicitSecurityGroups.length" style="margin-top: 10px; list-style-type: none">
+      <li ng-repeat="securityGroup in command.implicitSecurityGroups">{{securityGroup.name}}</li>
+    </ul>
+    <ul ng-if="!command.implicitSecurityGroups.length" style="margin-top: 10px; list-style-type: none">
+      <li>None</li>
+    </ul>
+  </div>
+</div>
+
+<div class="form-group small" style="margin-top: 20px">
+  <div class="col-md-9 col-md-offset-3 checkbox">
+    <p>
+      <label><input type="checkbox" ng-model="command.viewState.listImplicitSecurityGroups"/> Show Implicit Security Groups </label>
+      <help-field key="gce.serverGroup.securityGroups.implicit"></help-field>
+    </p>
   </div>
 </div>
 


### PR DESCRIPTION
Implicit security group list will be read-only.
Don't include implicit security groups in list of choices for explicitly adding to new server group.
Don't include implicit security groups in warning message for missing/removed security groups.
Limit height of warning message for missing/removed security groups.
