### PR TITLE
get notification type from first stage, if present

### DIFF
--- a/app/scripts/modules/cluster/clusterService.js
+++ b/app/scripts/modules/cluster/clusterService.js
@@ -122,9 +122,13 @@ module.exports = angular.module('spinnaker.cluster.service', [
       'terminateinstances': instanceIdsTaskMatcher,
       'rebootinstances': instanceIdsTaskMatcher,
       'resizeasg': baseTaskMatcher,
+      'resizeservergroup': baseTaskMatcher,
       'disableasg': baseTaskMatcher,
+      'disableservergroup': baseTaskMatcher,
       'destroyasg': baseTaskMatcher,
+      'destroyservergroup': baseTaskMatcher,
       'enableasg': baseTaskMatcher,
+      'enableservergroup': baseTaskMatcher,
       'destroygooglereplicapool': baseTaskMatcher,
       'enablegoogleservergroup': baseTaskMatcher,
       'disablegoogleservergroup': baseTaskMatcher,
@@ -132,7 +136,10 @@ module.exports = angular.module('spinnaker.cluster.service', [
     };
 
     function taskMatches(task, serverGroup) {
-      var matcher = taskMatchers[task.getValueFor('notification.type')];
+      let notificationType = _.has(task, 'execution.stages') ?
+        task.execution.stages[0].context['notification.type'] :
+        task.getValueFor('notification.type');
+      var matcher = taskMatchers[notificationType];
       return matcher ? matcher(task, serverGroup) : false;
     }
 


### PR DESCRIPTION
We should not rely on the task's variables to determine the notification type, since that's going to be the most recent stage that ran, it seems.

This is all brittle and we'll surely need to revisit in the future.
