### PR TITLE
Add params={} to rebootInstances.

### DIFF
--- a/app/scripts/modules/google/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/google/instance/details/instance.details.controller.js
@@ -300,7 +300,9 @@ module.exports = angular.module('spinnaker.instance.detail.gce.controller', [
       };
 
       var submitMethod = function () {
-        return instanceWriter.rebootInstance(instance, app);
+        return instanceWriter.rebootInstance(instance, app, {
+          interestingHealthProviderNames: [],
+        });
       };
 
       confirmationModalService.confirm({

--- a/app/scripts/modules/instance/instance.write.service.js
+++ b/app/scripts/modules/instance/instance.write.service.js
@@ -46,19 +46,16 @@ module.exports = angular
         });
     }
 
-    function rebootInstance(instance, application) {
+    function rebootInstance(instance, application, params={}) {
+      params.type = 'rebootInstances';
+      params.instanceIds = [instance.instanceId];
+      params.region = instance.region;
+      params.zone = instance.placement.availabilityZone;
+      params.credentials = instance.account;
+      params.cloudProvider = instance.providerType;
+
       return taskExecutor.executeTask({
-        job: [
-          {
-            type: 'rebootInstances',
-            instanceIds: [instance.instanceId],
-            region: instance.region,
-            zone: instance.placement.availabilityZone,
-            credentials: instance.account,
-            cloudProvider: instance.providerType,
-            providerType: instance.providerType
-          }
-        ],
+        job: [params],
         application: application,
         description: 'Reboot instance: ' + instance.instanceId
       });


### PR DESCRIPTION
Drop providerType from rebootInstances.
Pass interestingHealthProviderNames=[] when rebooting Google instances.
https://github.com/spinnaker/clouddriver/pull/117 and https://github.com/spinnaker/orca/pull/572 must be merged/deployed first.
