### PR TITLE
update stage counter when editing pipeline as JSON

### DIFF
--- a/app/scripts/modules/pipelines/config/actions/json/editPipelineJson.module.js
+++ b/app/scripts/modules/pipelines/config/actions/json/editPipelineJson.module.js
@@ -17,6 +17,13 @@ module.exports = angular.module('spinnaker.pipelines.config.actions.editJson', [
       delete obj.stageCounter;
     }
 
+    function updateStageCounter() {
+      if (pipeline.parallel) {
+        let stageIds = pipeline.stages.map((stage) => Number(stage.refId));
+        stageIds.forEach((stageId) => pipeline.stageCounter = Math.max(pipeline.stageCounter, stageId + 1));
+      }
+    }
+
     this.initialize = function() {
       var toCopy = pipeline.hasOwnProperty('plain') ? pipeline.plain() : pipeline;
       var pipelineCopy = _.cloneDeep(toCopy, function (value) {
@@ -38,6 +45,7 @@ module.exports = angular.module('spinnaker.pipelines.config.actions.editJson', [
 
         removeImmutableFields(parsed);
         angular.extend(pipeline, parsed);
+        updateStageCounter();
 
         $modalInstance.close();
       } catch (e) {

--- a/app/scripts/modules/pipelines/config/actions/json/editPipelineJsonModal.controller.spec.js
+++ b/app/scripts/modules/pipelines/config/actions/json/editPipelineJsonModal.controller.spec.js
@@ -109,4 +109,22 @@ describe('Controller: renamePipelineModal', function() {
     expect(this.$scope.command.errorMessage).not.toBe(null);
   });
 
+  it ('updateApplicationFromJson sets the stage counter based on max value of refIds', function () {
+    var pipeline = {
+      application: 'myApp',
+      name: 'foo',
+      stageCounter: 4,
+      parallel: true,
+      stages: [
+        {refId: '3'},
+        {refId: '13'}
+      ]
+    };
+    this.initializeController(pipeline);
+    this.$scope.command = {pipelineJSON: JSON.stringify(pipeline)};
+    this.controller.updatePipeline();
+
+    expect(pipeline.stageCounter).toBe(14);
+  });
+
 });


### PR DESCRIPTION
This should prevent a number of errors we see when users modify the number of stages present via the Edit as JSON feature of pipelines
