### PR TITLE
use largest id as counter on edit

### DIFF
--- a/app/scripts/modules/pipelines/config/actions/json/editPipelineJson.module.js
+++ b/app/scripts/modules/pipelines/config/actions/json/editPipelineJson.module.js
@@ -20,7 +20,7 @@ module.exports = angular.module('spinnaker.pipelines.config.actions.editJson', [
     function updateStageCounter() {
       if (pipeline.parallel) {
         let stageIds = pipeline.stages.map((stage) => Number(stage.refId));
-        stageIds.forEach((stageId) => pipeline.stageCounter = Math.max(pipeline.stageCounter, stageId + 1));
+        stageIds.forEach((stageId) => pipeline.stageCounter = Math.max(pipeline.stageCounter, stageId));
       }
     }
 

--- a/app/scripts/modules/pipelines/config/actions/json/editPipelineJsonModal.controller.spec.js
+++ b/app/scripts/modules/pipelines/config/actions/json/editPipelineJsonModal.controller.spec.js
@@ -124,7 +124,7 @@ describe('Controller: renamePipelineModal', function() {
     this.$scope.command = {pipelineJSON: JSON.stringify(pipeline)};
     this.controller.updatePipeline();
 
-    expect(pipeline.stageCounter).toBe(14);
+    expect(pipeline.stageCounter).toBe(13);
   });
 
 });


### PR DESCRIPTION
To be consistent with the add stage functionality, we should use the highest stage id, not "id + 1"
