### PR TITLE
defer diff calculation until modal is initialized

### DIFF
--- a/app/scripts/modules/amazon/serverGroup/configure/serverGroupCommandBuilder.service.js
+++ b/app/scripts/modules/amazon/serverGroup/configure/serverGroupCommandBuilder.service.js
@@ -5,14 +5,13 @@ let angular = require('angular');
 module.exports = angular.module('spinnaker.aws.serverGroupCommandBuilder.service', [
   require('exports?"restangular"!imports?_=lodash!restangular'),
   require('../../../core/account/account.service.js'),
-  require('../../../core/diff/diff.service.js'),
   require('../../subnet/subnet.read.service.js'),
   require('../../../core/instance/instanceTypeService.js'),
   require('../../../core/naming/naming.service.js'),
   require('./serverGroupConfiguration.service.js'),
   require('../../../core/utils/lodash.js'),
 ])
-  .factory('awsServerGroupCommandBuilder', function (settings, Restangular, $exceptionHandler, $q, diffService,
+  .factory('awsServerGroupCommandBuilder', function (settings, Restangular, $exceptionHandler, $q,
                                                      accountService, subnetReader, namingService, instanceTypeService,
                                                      awsServerGroupConfigurationService, _) {
 
@@ -25,15 +24,9 @@ module.exports = angular.module('spinnaker.aws.serverGroupCommandBuilder.service
 
       var preferredZonesLoader = accountService.getAvailabilityZonesForAccountAndRegion('aws', defaultCredentials, defaultRegion);
 
-      var clusterDiffLoader = function() { return []; };
-      if (application.name) {
-        clusterDiffLoader = diffService.getClusterDiffForAccount(defaultCredentials, application.name);
-      }
-
       return $q.all({
         preferredZones: preferredZonesLoader,
         regionsKeyedByAccount: regionsKeyedByAccountLoader,
-        clusterDiff: clusterDiffLoader,
       })
         .then(function (asyncData) {
           var availabilityZones = asyncData.preferredZones;
@@ -74,7 +67,6 @@ module.exports = angular.module('spinnaker.aws.serverGroupCommandBuilder.service
               usePreferredZones: true,
               mode: defaults.mode || 'create',
               disableStrategySelection: true,
-              clusterDiff: asyncData.clusterDiff,
             },
           };
         });
@@ -149,8 +141,6 @@ module.exports = angular.module('spinnaker.aws.serverGroupCommandBuilder.service
       var subnetsLoader = subnetReader.listSubnets();
 
       var serverGroupName = namingService.parseServerGroupName(serverGroup.asg.autoScalingGroupName);
-      var clusterName = namingService.getClusterName(application.name, serverGroupName.stack, serverGroupName.freeFormDetails);
-      var clusterDiffLoader = diffService.getClusterDiffForAccount(serverGroup.account, clusterName);
 
       var instanceType = serverGroup.launchConfig ? serverGroup.launchConfig.instanceType : null;
       var instanceTypeCategoryLoader = instanceTypeService.getCategoryForInstanceType('aws', instanceType);
@@ -159,7 +149,6 @@ module.exports = angular.module('spinnaker.aws.serverGroupCommandBuilder.service
         preferredZones: preferredZonesLoader,
         subnets: subnetsLoader,
         instanceProfile: instanceTypeCategoryLoader,
-        clusterDiff: clusterDiffLoader,
       });
 
       return asyncLoader.then(function(asyncData) {
@@ -206,7 +195,6 @@ module.exports = angular.module('spinnaker.aws.serverGroupCommandBuilder.service
             usePreferredZones: usePreferredZones,
             mode: mode,
             isNew: false,
-            clusterDiff: asyncData.clusterDiff,
           },
         };
 

--- a/app/scripts/modules/core/pipeline/config/actions/create/createPipelineModal.controller.spec.js
+++ b/app/scripts/modules/core/pipeline/config/actions/create/createPipelineModal.controller.spec.js
@@ -179,7 +179,7 @@ describe('Controller: createPipelineModal', function() {
       expect(this.$scope.viewState.errorMessage).toBe('No message provided');
     });
 
-    fit('replaces trigger ids if found', function() {
+    it('replaces trigger ids if found', function() {
       var submitted = null,
           $q = this.$q;
 


### PR DESCRIPTION
All the other async methods when creating a serverGroupCommand are cached and happen pretty much immediately, so the command is ready on the next cycle. The diff can take a few seconds, and since the command promise needs to be resolved before the modal opens, it can cause a delay between clicking the button to create/clone a server group and the modal actually appearing. Once the modal opens, the diff is immediately calculated, so it's unnecessary here.

Technically, there is still the potential for the modal to be delayed, but that's outside the scope of this pull request.

(Also fixing an unrelated and unintentional test isolation change)
