### PR TITLE
record project applications on dashboard load only

### DIFF
--- a/app/scripts/modules/core/projects/dashboard/dashboard.controller.js
+++ b/app/scripts/modules/core/projects/dashboard/dashboard.controller.js
@@ -9,13 +9,22 @@ module.exports = angular.module('spinnaker.core.projects.dashboard.controller', 
   require('./pipeline/projectPipeline.directive.js'),
   require('../../delivery/execution.service.js'),
   require('../../scheduler/scheduler.service.js'),
+  require('../../history/recentHistory.service.js'),
 ])
-  .controller('ProjectDashboardCtrl', function ($scope, projectConfiguration, executionService, scheduler) {
+  .controller('ProjectDashboardCtrl', function ($scope, projectConfiguration, executionService, scheduler, recentHistoryService) {
 
     $scope.project = projectConfiguration;
 
     if (projectConfiguration.notFound) {
+      recentHistoryService.removeLastItem('projects');
       return;
+    } else {
+      recentHistoryService.addExtraDataToLatest('projects',
+        {
+          config: {
+            applications: projectConfiguration.config.applications
+          }
+        });
     }
 
     this.state = {

--- a/app/scripts/modules/core/projects/project.controller.js
+++ b/app/scripts/modules/core/projects/project.controller.js
@@ -6,25 +6,11 @@ require('./project.less');
 
 module.exports = angular.module('spinnaker.core.projects.project.controller', [
   require('./configure/configureProject.modal.controller.js'),
-  require('./service/project.read.service.js'),
-  require('../history/recentHistory.service.js'),
   require('../utils/lodash.js'),
 ])
-  .controller('ProjectCtrl', function ($scope, $modal, $timeout, projectReader, $state, projectConfiguration, recentHistoryService, _) {
+  .controller('ProjectCtrl', function ($scope, $modal, $timeout, $state, projectConfiguration, _) {
 
     $scope.project = projectConfiguration;
-
-    if (projectConfiguration.notFound) {
-      recentHistoryService.removeLastItem('projects');
-      return;
-    } else {
-      recentHistoryService.addExtraDataToLatest('projects',
-        {
-          config: {
-            applications: projectConfiguration.config.applications
-          }
-        });
-    }
 
     projectConfiguration.config.applications = projectConfiguration.config.applications || [];
 


### PR DESCRIPTION
Fixes an issue when navigating directly to an application in a project and then to the project dashboard, which leaves an empty list of applications in the "Recently Viewed" project.
