### PR TITLE
allow providers to implement their own search result formatters

### DIFF
--- a/app/scripts/modules/amazon/aws.module.js
+++ b/app/scripts/modules/amazon/aws.module.js
@@ -30,6 +30,7 @@ module.exports = angular.module('spinnaker.aws', [
   require('./vpc/vpc.module.js'),
   require('./image/image.reader.js'),
   require('./cache/cacheConfigurer.service.js'),
+  require('./search/searchResultFormatter.js'),
 ])
   .config(function(cloudProviderRegistryProvider) {
     cloudProviderRegistryProvider.registerProvider('aws', {
@@ -70,6 +71,9 @@ module.exports = angular.module('spinnaker.aws', [
         detailsController: 'awsSecurityGroupDetailsCtrl',
         createSecurityGroupTemplateUrl: require('./securityGroup/configure/createSecurityGroup.html'),
         createSecurityGroupController: 'awsCreateSecurityGroupCtrl',
+      },
+      search: {
+        resultFormatter: 'awsSearchResultFormatter',
       }
     });
   }).name;

--- a/app/scripts/modules/amazon/search/searchResultFormatter.js
+++ b/app/scripts/modules/amazon/search/searchResultFormatter.js
@@ -1,0 +1,18 @@
+'use strict';
+
+let angular = require('angular');
+
+module.exports = angular
+  .module('spinnaker.amazon.search.searchResultFormatter', [
+    require('../vpc/vpc.read.service.js'),
+  ])
+  .factory('awsSearchResultFormatter', function(vpcReader) {
+    return {
+      securityGroups: function(entry) {
+        return vpcReader.getVpcName(entry.vpcId).then(function (vpcName) {
+          let region = vpcName ? entry.region + ' - ' + vpcName.toLowerCase() : entry.region;
+          return entry.name + ' (' + region + ')';
+        });
+      }
+    };
+  }).name;


### PR DESCRIPTION
I believe this is the last of the provider-specific code in the core module, aside from pipeline stages, which is a whole other mess.
