### PR TITLE
change refresh icon color based on last refresh time

### DIFF
--- a/app/scripts/modules/core/application/application.controller.js
+++ b/app/scripts/modules/core/application/application.controller.js
@@ -20,6 +20,16 @@ module.exports = angular.module('spinnaker.application.controller', [
       return;
     }
 
+    $scope.getAgeColor = () => {
+      const yellowAge = 2 * 60 * 1000; // 2 minutes
+      const redAge = 5 * 60 * 1000; // 5 minutes
+      let lastRefresh = app.lastRefresh || 0;
+      let age = new Date().getTime() - lastRefresh;
+
+      return age < yellowAge ? 'young' :
+             age < redAge ? 'old' : 'ancient';
+    };
+
     var hotkeyBind = hotkeys.bindTo($scope);
     var applicationHotkeys = [
       {

--- a/app/scripts/modules/core/application/application.html
+++ b/app/scripts/modules/core/application/application.html
@@ -2,7 +2,7 @@
     <h2>
       <span class="application-name">{{application.name}}</span>
       <a href ng-click="application.refreshImmediately(true)">
-        <span class="small glyphicon glyphicon-refresh refresh-enabled"
+        <span class="small glyphicon glyphicon-refresh refresh-enabled refresh-{{getAgeColor()}}"
               uib-tooltip-template="refreshTooltipTemplate"
               tooltip-placement="{{$window.innerWidth < 1100 ? 'right' : 'bottom'}}"
               ng-class="{'glyphicon-spinning': application.refreshing}"></span>

--- a/app/scripts/modules/core/application/application.less
+++ b/app/scripts/modules/core/application/application.less
@@ -200,10 +200,16 @@
 }
 
 .glyphicon-refresh {
-  &.refresh-enabled {
-    color: @healthy_green_icon;
-  }
   &.refresh-disabled {
     opacity: 0.5;
+  }
+  &.refresh-young {
+    color: @healthy_green_icon;
+  }
+  &.refresh-old {
+    color: #CEB717;
+  }
+  &.refresh-ancient {
+    color: @unhealthy_red;
   }
 }


### PR DESCRIPTION
If the application has not refreshed in the past 2 minutes, the refresh icon will be yellow; if it's older than 5 minutes, it'll be red. This should help make it more clear when re-activating a tab that the data is not as fresh as the user might expect.
