### PR TITLE
remove deploy stages from canary, rely on synthetically constructed

### DIFF
--- a/app/scripts/modules/core/pipeline/config/stages/canary/canaryStage.transformer.js
+++ b/app/scripts/modules/core/pipeline/config/stages/canary/canaryStage.transformer.js
@@ -135,6 +135,9 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.canary.transforme
           if (_.some(deployStages, { status: 'RUNNING' })) {
             status = 'RUNNING';
           }
+          if (_.some(deployStages, { status: 'TERMINAL' })) {
+            status = 'TERMINAL';
+          }
           var canaryStatus = stage.context.canary.status;
           if (canaryStatus && status !== 'CANCELED') {
             if (canaryStatus.status === 'LAUNCHED' || monitorStage.status === 'RUNNING') {
@@ -247,6 +250,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.canary.transforme
             var canaryDeploymentId = deployment.canaryAnalysisResult ? deployment.canaryAnalysisResult.canaryDeploymentId : null;
             syntheticStagesToAdd.push(createSyntheticCanaryDeploymentStage(stage, deployment, status, deployParent, deploymentEndTime, canaryDeploymentId, execution));
           });
+          execution.stages = execution.stages.filter((stage) => deployStages.indexOf(stage) === -1);
         }
       });
       execution.stages = execution.stages.concat(syntheticStagesToAdd);


### PR DESCRIPTION
We don't surface the deploy stages for a canary, but they do take up slots in the execution, which can break things when a canary deployment fails. So just remove them and rely on the synthetically generated ones.
