### PR TITLE
show health columns based on overall cluster shape

### DIFF
--- a/app/scripts/modules/core/cluster/clusterPod.html
+++ b/app/scripts/modules/core/cluster/clusterPod.html
@@ -24,6 +24,8 @@
         server-group="serverGroup"
         cluster="serverGroup.cluster"
         application="application"
+        has-discovery="grouping.hasDiscovery"
+        has-load-balancers="grouping.hasLoadBalancers"
         parent-heading="subgroup.heading"></server-group>
     </div>
     <div class="permalinks text-right">

--- a/app/scripts/modules/core/cluster/filter/clusterFilter.service.js
+++ b/app/scripts/modules/core/cluster/filter/clusterFilter.service.js
@@ -116,6 +116,30 @@ module.exports = angular
       return true;
     }
 
+    function hasDiscovery(group) {
+      return group.serverGroups.some((serverGroup) =>
+          (serverGroup.instances || []).some((instance) =>
+              (instance.health || []).some((health) => health.type === 'Discovery')
+          )
+      );
+    }
+
+    function hasLoadBalancers(group) {
+      return group.serverGroups.some((serverGroup) =>
+          (serverGroup.instances || []).some((instance) =>
+              (instance.health || []).some((health) => health.type === 'LoadBalancer')
+          )
+      );
+    }
+
+    function addHealthFlags() {
+      ClusterFilterModel.groups.forEach((group) => {
+        group.subgroups.forEach((subgroup) => {
+          subgroup.hasDiscovery = subgroup.subgroups.some(hasDiscovery);
+          subgroup.hasLoadBalancers = subgroup.subgroups.some(hasLoadBalancers);
+        });
+      });
+    }
 
     /**
      * Grouping logic
@@ -158,6 +182,7 @@ module.exports = angular
       waypointService.restoreToWaypoint(application.name);
       ClusterFilterModel.addTags();
       lastApplication = application;
+      addHealthFlags();
       return groups;
     }, 25);
 

--- a/app/scripts/modules/core/instance/instanceList.directive.html
+++ b/app/scripts/modules/core/instance/instanceList.directive.html
@@ -3,14 +3,20 @@
   <tr>
     <!-- use this when multi-select is a thing -->
     <!--<th width="4%"><input type="checkbox"></th>-->
-    <th width="15%" sort-toggle key="id" label="Instance" sort-model="sortFilter.instanceSort" on-change="applyParamsToUrl()"></th>
-    <th width="23%" sort-toggle key="launchTime" label="Launch Time" default="true" sort-model="sortFilter.instanceSort" on-change="applyParamsToUrl()"></th>
-    <th width="13%" sort-toggle key="availabilityZone" label="Zone" sort-model="sortFilter.instanceSort" on-change="applyParamsToUrl()"></th>
-    <th width="15%" class="text-center" sort-toggle key="discoveryState" label="Discovery" sort-model="sortFilter.instanceSort" on-change="applyParamsToUrl()"></th>
-    <th width="34%" sort-toggle key="loadBalancerSort" label="Load Balancers" sort-model="sortFilter.instanceSort" on-change="applyParamsToUrl()"></th>
+    <th width="{{::columnWidth.id}}%" sort-toggle key="id" label="Instance" sort-model="sortFilter.instanceSort" on-change="applyParamsToUrl()"></th>
+    <th width="{{::columnWidth.launchTime}}%" sort-toggle key="launchTime" label="Launch Time" default="true" sort-model="sortFilter.instanceSort" on-change="applyParamsToUrl()"></th>
+    <th width="{{::columnWidth.zone}}%" sort-toggle key="availabilityZone" label="Zone" sort-model="sortFilter.instanceSort" on-change="applyParamsToUrl()"></th>
+    <th ng-if="hasDiscovery" width="{{::columnWidth.discovery}}%" class="text-center" sort-toggle key="discoveryState" label="Discovery" sort-model="sortFilter.instanceSort" on-change="applyParamsToUrl()"></th>
+    <th ng-if="hasLoadBalancers" width="{{::columnWidth.loadBalancers}}%" sort-toggle key="loadBalancerSort" label="Load Balancers" sort-model="sortFilter.instanceSort" on-change="applyParamsToUrl()"></th>
+    <th ng-if="showProviderHealth" width="{{::columnWidth.cloudProvider}}%" class="text-center" sort-toggle key="providerHealth" label="Cloud Provider" sort-model="sortFilter.instanceSort" on-change="applyParamsToUrl()"></th>
 
   </tr>
   </thead>
-  <tbody class="instance-list-body" instances="instances" sort-filter="sortFilter">
+  <tbody class="instance-list-body"
+         instances="instances"
+         has-load-balancers="hasLoadBalancers"
+         has-discovery="hasDiscovery"
+         show-provider-health="showProviderHealth"
+         sort-filter="sortFilter">
   </tbody>
 </table>

--- a/app/scripts/modules/core/instance/instanceList.directive.js
+++ b/app/scripts/modules/core/instance/instanceList.directive.js
@@ -11,11 +11,30 @@ module.exports = angular.module('spinnaker.core.instance.instanceList.directive'
       restrict: 'E',
       templateUrl: require('./instanceList.directive.html'),
       scope: {
+        hasDiscovery: '=',
+        hasLoadBalancers: '=',
         instances: '=',
         sortFilter: '=',
       },
       link: function (scope) {
         scope.applyParamsToUrl = ClusterFilterModel.applyParamsToUrl;
+        scope.showProviderHealth = !scope.hasDiscovery && !scope.hasLoadBalancers;
+
+        scope.columnWidth = {
+          id: 14,
+          launchTime: 23,
+          zone: 13,
+          discovery: 16,
+          loadBalancers: 34,
+          cloudProvider: 34,
+        };
+
+        if (!scope.hasDiscovery) {
+          scope.columnWidth.id += 4;
+          scope.columnWidth.launchTime += 4;
+          scope.columnWidth.zone += 4;
+          scope.columnWidth.loadBalancers += 4;
+        }
       }
     };
   }).name;

--- a/app/scripts/modules/core/serverGroup/serverGroup.directive.html
+++ b/app/scripts/modules/core/serverGroup/serverGroup.directive.html
@@ -35,7 +35,10 @@
         <instances highlight="sortFilter.filter" instances="viewModel.instances"></instances>
       </div>
       <div ng-if="sortFilter.listInstances">
-        <instance-list instances="viewModel.instances" sort-filter="sortFilter"></instance-list>
+        <instance-list instances="viewModel.instances"
+                       sort-filter="sortFilter"
+                       has-discovery="hasDiscovery"
+                       has-load-balancers="hasLoadBalancers"></instance-list>
       </div>
     </div>
   </div>

--- a/app/scripts/modules/core/serverGroup/serverGroup.directive.js
+++ b/app/scripts/modules/core/serverGroup/serverGroup.directive.js
@@ -18,6 +18,8 @@ module.exports = angular.module('spinnaker.core.serverGroup.serverGroup.directiv
         serverGroup: '=',
         application: '=',
         parentHeading: '=',
+        hasLoadBalancers: '=',
+        hasDiscovery: '=',
       },
       link: function (scope, el) {
 

--- a/test/mock/mockApplicationData.js
+++ b/test/mock/mockApplicationData.js
@@ -22,6 +22,8 @@ module.exports = angular
       heading : 'prod',
       subgroups : [ {
         heading : 'in-eu-east-2-only',
+        hasDiscovery: false,
+        hasLoadBalancers: false,
         subgroups : [ {
           heading : 'eu-east-2',
           serverGroups : [ {
@@ -46,6 +48,8 @@ module.exports = angular
         heading : 'test',
         subgroups : [ {
           heading : 'in-us-west-1-only',
+          hasDiscovery: false,
+          hasLoadBalancers: false,
           subgroups : [ {
             heading : 'us-west-1',
             serverGroups : [ {


### PR DESCRIPTION
It doesn't make sense to show "Load Balancer" and "Discovery" when an application (or cloud provider) doesn't support it, so conditionally show those columns based on the overall shape of the cluster, i.e. if _some_ instance in one of the server groups in the cluster is using Discovery, show Discovery; if _some_ instance is using a load balancer, show Load Balancer; otherwise, show the cloud provider health.

We'll want to abstract this further, probably, to support generic health provider types, but this makes things a little more sensible in the UI for now.
