### PR TITLE
bind and show instance tooltips on mouseover

### DIFF
--- a/app/scripts/modules/core/instance/instances.directive.js
+++ b/app/scripts/modules/core/instance/instances.directive.js
@@ -15,7 +15,8 @@ module.exports = angular.module('spinnaker.core.instance.instances.directive', [
       },
       link: function (scope, elem) {
         var $state = scope.$parent.$state;
-        let lastRender = '';
+        let lastRender = '',
+            tooltipsApplied = false;
 
         var base = elem.parent().inheritedData('$uiView').state;
 
@@ -41,9 +42,11 @@ module.exports = angular.module('spinnaker.core.instance.instances.directive', [
             }).join('') + '</div>';
 
           if (innerHtml !== lastRender) {
-            $('[data-toggle="tooltip"]', elem).tooltip('destroy');
+            if (tooltipsApplied) {
+              $('[data-toggle="tooltip"]', elem).tooltip('destroy');
+              tooltipsApplied = false;
+            }
             elem.get(0).innerHTML = innerHtml;
-            $('[data-toggle="tooltip"]', elem).tooltip({placement: 'top', container: 'body', animation: false});
             lastRender = innerHtml;
           }
         }
@@ -71,6 +74,11 @@ module.exports = angular.module('spinnaker.core.instance.instances.directive', [
           });
         });
 
+        elem.mouseover((event) => {
+          $(event.target, elem).tooltip({placement: 'top', container: 'body', animation: false}).tooltip('show');
+          tooltipsApplied = true;
+        });
+
         function clearActiveState() {
           if (scope.activeInstance && !$state.includes('**.instanceDetails', scope.activeInstance)) {
             $('a[data-instance-id="' + scope.activeInstance.instanceId+'"]', elem).removeClass('active');
@@ -81,8 +89,13 @@ module.exports = angular.module('spinnaker.core.instance.instances.directive', [
         scope.$on('$locationChangeSuccess', clearActiveState);
 
         scope.$on('$destroy', function() {
-          $('[data-toggle="tooltip"]', elem).tooltip('destroy');
+          if (tooltipsApplied) {
+            $('[data-toggle="tooltip"]', elem).tooltip('destroy');
+            tooltipsApplied = false;
+          }
+          elem.unbind('mouseover');
           elem.unbind('click');
+          lastRender = null;
         });
 
         scope.$watch('instances', renderInstances);

--- a/app/scripts/modules/core/instance/instances.html
+++ b/app/scripts/modules/core/instance/instances.html
@@ -1,9 +1,0 @@
-<div class="instances">
-  <a class="instance health-status-{{instance.healthState}}"
-     ng-class="{highlighted: highlight && highlight.length > 1 && instance.id.indexOf(highlight) !== -1}"
-     ng-repeat="instance in displayedInstances | instanceSearch:highlight track by instance.id | orderBy:'launchTime'"
-     uib-tooltip="{{instance.id}}"
-     ui-sref=".instanceDetails({instanceId: instance.id, provider: instance.provider })"
-     ui-sref-active="active">
-    <span class="sr-only">{{instance.id}}</span></a>
-</div>

--- a/app/scripts/modules/core/serverGroup/serverGroup.directive.html
+++ b/app/scripts/modules/core/serverGroup/serverGroup.directive.html
@@ -24,8 +24,12 @@
           </div>
           <div class="col-md-4 col-sm-6 text-right">
             <health-counts container="viewModel.serverGroup"></health-counts>
-            <running-tasks-tag application="application" tasks="viewModel.serverGroup.runningTasks" executions="viewModel.serverGroup.executions"></running-tasks-tag>
-            <load-balancers-tag server-group="viewModel.serverGroup" max-display="1"></load-balancers-tag>
+            <running-tasks-tag
+                ng-if="viewModel.serverGroup.runningTasks.length || viewModel.serverGroup.executions.length"
+                application="application" tasks="viewModel.serverGroup.runningTasks" executions="viewModel.serverGroup.executions"></running-tasks-tag>
+            <load-balancers-tag
+                ng-if="viewModel.serverGroup.loadBalancers.length"
+                server-group="viewModel.serverGroup" max-display="1"></load-balancers-tag>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Continuing down the path of sacrificing simplicity for performance...

Don't bind tooltips to every instance chiclet, since they are rarely utilized. Instead, bind them when the instances are moused over.

Performance improvement is around a second in the best case, which isn't a _lot_ but is _some_ - brings the view render down to ~3s from ~4s for an application with several thousand instances.
