### PR TITLE
ignore end time on running items when calculating durations

### DIFF
--- a/app/scripts/modules/core/orchestratedItem/orchestratedItem.transformer.js
+++ b/app/scripts/modules/core/orchestratedItem/orchestratedItem.transformer.js
@@ -69,7 +69,10 @@ module.exports = angular.module('spinnaker.core.orchestratedItem.transformer', [
         },
         runningTimeInMs: {
           get: function() {
-            return (parseInt(item.endTime) || new Date().getTime()) - parseInt(item.startTime);
+            let endTime = item.isRunning || !item.endTime ? new Date().getTime() : item.endTime;
+            return parseInt(endTime) - parseInt(item.startTime);
+            // TODO: remove the lines above once we stop incorrectly setting the end time on running items
+            //return (parseInt(item.endTime) || new Date().getTime()) - parseInt(item.startTime);
           }
         }
       });


### PR DESCRIPTION
temporary until we can figure out why we are setting an end time on running stages in Orca...
