### PR TITLE
manage URL, expanded sections based on filters, deep links

### DIFF
--- a/app/scripts/modules/core/delivery/executionGroup/execution/execution.directive.html
+++ b/app/scripts/modules/core/delivery/executionGroup/execution/execution.directive.html
@@ -1,0 +1,68 @@
+<div class="execution" id="execution-{{vm.execution.id}}">
+  <execution-status execution="vm.execution" filter="vm.filter">
+  </execution-status>
+  <div class="execution-bar">
+    <div class="stages">
+      <div ng-repeat="stage in vm.execution.stageSummaries"
+           class="clickable stage execution-status execution-status-{{stage.status.toLowerCase()}}"
+           ng-class="{active: vm.isActive($index), glowing: stage.isRunning}"
+           ng-style="{width: 100/vm.execution.stageSummaries.length + '%', 'background-color': stage.color}"
+           uib-tooltip-template="stage.labelTemplateUrl"
+           tooltip-title="(Click for details)"
+           tooltip-placement="bottom"
+           ng-click="vm.toggleDetails({executionId: vm.execution.id, index: $index})"></div>
+      <div ng-if="!vm.execution.stageSummaries.length" class="text-center">
+        No stages found.
+        <a target="_blank" ng-href="{{vm.pipelinesUrl + vm.execution.id}}">Source</a>
+      </div>
+    </div>
+    <div class="execution-summary">
+      Status: <span class="status execution-status execution-status-{{vm.execution.status.toLowerCase()}}">{{vm.execution.status}}</span>
+      <span class="pull-right">Duration: {{vm.execution.runningTimeInMs | duration}}</span>
+    </div>
+  </div>
+  <div class="execution-actions">
+    <a href
+       ng-if="!vm.execution.isActive"
+       ng-click="vm.deleteExecution(); $event.stopPropagation();"
+       uib-tooltip="Delete execution">
+      <span class="glyphicon glyphicon-trash"></span>
+    </a>
+    <a href
+       ng-if="vm.execution.isActive"
+       ng-click="vm.cancelExecution(); $event.stopPropagation();"
+       uib-tooltip="Cancel execution">
+      <span class="glyphicon glyphicon-remove-circle"></span>
+    </a>
+  </div>
+
+  <div ng-if="vm.showDetails()" class="execution-graph">
+    <a href
+       class="pull-right hide-details-link"
+       ng-if="vm.execution.parallel"
+       ui-sref=".">
+      Hide Details <span class="glyphicon glyphicon-remove"></span>
+    </a>
+    <pipeline-graph ng-if="vm.execution.parallel"
+                    execution="vm.execution"
+                    on-node-click="vm.toggleDetails"
+                    view-state="vm.viewState">
+
+    </pipeline-graph>
+  </div>
+
+  <div ng-if="vm.showDetails()" class="execution-details">
+    <div class="row">
+      <execution-details execution="vm.execution">
+      </execution-details>
+    </div>
+    <div class="row permalinks text-right">
+      <div class="col-md-12">
+        <a target="_blank" ng-href="{{vm.pipelinesUrl + vm.execution.id}}">Source</a>
+        |
+        <a target="_blank" ng-href="{{vm.getUrl()}}">Permalink</a>
+        <copy-to-clipboard text="{{vm.getUrl()}}" tool-tip="Copy permalink to clipboard"></copy-to-clipboard>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/scripts/modules/core/delivery/executionGroup/execution/execution.directive.js
+++ b/app/scripts/modules/core/delivery/executionGroup/execution/execution.directive.js
@@ -1,0 +1,94 @@
+'use strict';
+
+let angular = require('angular');
+
+require('./execution.less');
+
+module.exports = angular
+  .module('spinnaker.core.delivery.group.executionGroup.execution.directive', [
+    require('../../filter/executionFilter.service.js'),
+    require('../../filter/executionFilter.model.js'),
+    require('../../../confirmationModal/confirmationModal.service.js'),
+  ])
+  .directive('execution', function() {
+    return {
+      restrict: 'E',
+      templateUrl: require('./execution.directive.html'),
+      scope: {},
+      bindToController: {
+        application: '=',
+        execution: '=',
+      },
+      controller: 'ExecutionCtrl',
+      controllerAs: 'vm',
+    };
+  })
+  .controller('ExecutionCtrl', function ($scope, $location, $stateParams, $state,
+                                         settings, ExecutionFilterModel, executionService, confirmationModalService) {
+
+    this.pipelinesUrl = [settings.gateUrl, 'pipelines/'].join('/');
+
+    this.showDetails = () => {
+      return this.execution.id === $stateParams.executionId &&
+        $state.includes('**.execution.**');
+    };
+
+    this.isActive = (stageIndex) => {
+      return this.showDetails(this.execution.id) && Number($stateParams.stage) === stageIndex;
+    };
+
+    this.toggleDetails = (node) => {
+      const params = { executionId: node.executionId, stage: node.index};
+      if ($state.includes('**.execution', params)) {
+        $state.go('^');
+      } else {
+        if ($state.current.name.indexOf('.executions.execution') !== -1) {
+          $state.go('.', params);
+        } else {
+          $state.go('.execution', params);
+        }
+      }
+    };
+
+    this.getUrl = () => $location.absUrl();
+
+    let updateViewStateDetails = () => {
+      this.viewState.activeStageId = Number($stateParams.stage);
+      this.viewState.executionId = $stateParams.executionId;
+    };
+
+    $scope.$on('$stateChangeSuccess', updateViewStateDetails);
+
+    this.viewState = {
+      activeStageId: Number($stateParams.stage),
+      executionId: this.execution.id,
+      canTriggerPipelineManually: this.pipelineConfig,
+      canConfigure: this.pipelineConfig,
+      showPipelineName: ExecutionFilterModel.sortFilter.groupBy !== 'name',
+    };
+
+    this.deleteExecution = () => {
+      confirmationModalService.confirm({
+        header: 'Really delete execution?',
+        buttonText: 'Delete',
+        body: '<p>This will permanently delete the execution history.</p>',
+        submitMethod: () => executionService.deleteExecution(this.application, this.execution.id)
+      });
+    };
+
+    this.cancelExecution = () => {
+      confirmationModalService.confirm({
+        header: 'Really stop execution of ' + this.execution.name + '?',
+        buttonText: 'Stop running ' + this.execution.name,
+        destructive: false,
+        submitMethod: () => executionService.cancelExecution(this.execution.id)
+      });
+    };
+
+    $scope.$on('$destroy', () => {
+      if (this.isActive()) {
+        this.hideDetails();
+      }
+    });
+
+  }).name;

--- a/app/scripts/modules/core/delivery/executionGroup/execution/execution.less
+++ b/app/scripts/modules/core/delivery/executionGroup/execution/execution.less
@@ -1,0 +1,47 @@
+@import "../../../presentation/less/imports/commonImports.less";
+
+.execution-actions {
+  display: inline-block;
+  width: 20px;
+  vertical-align: top;
+  padding-top: 20px;
+  margin-left: 6px;
+  .glyphicon-remove-circle {
+    color: @unhealthy_red;
+  }
+}
+.execution-summary {
+  padding: 0 5px 5px;
+  font-size: 90%;
+}
+
+execution-details-section-nav {
+  margin-left: 15px;
+  display: block;
+}
+
+execution-status {
+  display: inline-block;
+  width: 180px;
+}
+.execution-bar {
+  display: inline-block;
+  width: calc(~"100% - 215px");
+  vertical-align: top;
+  padding-top: 20px;
+  .stage {
+    margin-top: 0;
+    display: inline-block;
+    height: 20px;
+    opacity: 0.65;
+    &:hover, &.active {
+      opacity: 1;
+    }
+    &.active {
+      border: 1px solid @dark_grey;
+    }
+    &.glowing {
+      .glowing(2.5);
+    }
+  }
+}

--- a/app/scripts/modules/core/delivery/executionGroup/executionGroup.directive.html
+++ b/app/scripts/modules/core/delivery/executionGroup/executionGroup.directive.html
@@ -50,72 +50,7 @@
       <div class="execution"
            ng-repeat="execution in vm.group.executions track by $index"
            id="execution-{{execution.id}}">
-        <execution-status execution="execution" filter="filter">
-        </execution-status>
-        <div class="execution-bar">
-          <div class="stages">
-            <div ng-repeat="stage in execution.stageSummaries"
-                 class="clickable stage execution-status execution-status-{{stage.status.toLowerCase()}}"
-                 ng-class="{active: vm.isActive(execution.id, $index), glowing: stage.isRunning}"
-                 ng-style="{width: 100/execution.stageSummaries.length + '%', 'background-color': stage.color}"
-                 uib-tooltip-template="stage.labelTemplateUrl"
-                 tooltip-title="(Click for details)"
-                 tooltip-placement="bottom"
-                 ng-click="vm.toggleDetails({executionId: execution.id, index: $index})"></div>
-            <div ng-if="!execution.stageSummaries.length" class="text-center">
-              No stages found.
-              <a target="_blank" ng-href="{{vm.pipelinesUrl + execution.id}}">Source</a>
-            </div>
-          </div>
-          <div class="execution-summary">
-            Status: <span class="status execution-status execution-status-{{execution.status.toLowerCase()}}">{{execution.status}}</span>
-            <span class="pull-right">Duration: {{execution.runningTimeInMs | duration}}</span>
-          </div>
-        </div>
-        <div class="execution-actions">
-          <a href
-             ng-if="!execution.isActive"
-             ng-click="vm.deleteExecution(execution); $event.stopPropagation();"
-             uib-tooltip="Delete execution">
-            <span class="glyphicon glyphicon-trash"></span>
-          </a>
-          <a href
-             ng-if="execution.isActive"
-             ng-click="vm.cancelExecution(execution); $event.stopPropagation();"
-             uib-tooltip="Cancel execution">
-            <span class="glyphicon glyphicon-remove-circle"></span>
-          </a>
-        </div>
-
-        <div ng-if="vm.showDetails(execution.id)" class="execution-graph">
-          <a href
-             class="pull-right hide-details-link"
-             ng-if="execution.parallel"
-             ui-sref=".">
-            Hide Details <span class="glyphicon glyphicon-remove"></span>
-          </a>
-          <pipeline-graph ng-if="execution.parallel"
-                          execution="execution"
-                          on-node-click="vm.toggleDetails"
-                          view-state="vm.viewState">
-
-          </pipeline-graph>
-        </div>
-
-        <div ng-if="vm.showDetails(execution.id)" class="execution-details">
-          <div class="row">
-            <execution-details execution="execution">
-            </execution-details>
-          </div>
-          <div class="row permalinks text-right">
-            <div class="col-md-12">
-              <a target="_blank" ng-href="{{vm.pipelinesUrl + execution.id}}">Source</a>
-              |
-              <a target="_blank" ng-href="{{vm.getUrl()}}">Permalink</a>
-              <copy-to-clipboard text="{{vm.getUrl()}}" tool-tip="Copy permalink to clipboard"></copy-to-clipboard>
-            </div>
-          </div>
-        </div>
+        <execution execution="execution" application="vm.application"></execution>
 
       </div>
     </div>

--- a/app/scripts/modules/core/delivery/executionGroup/executionGroup.less
+++ b/app/scripts/modules/core/delivery/executionGroup/executionGroup.less
@@ -1,50 +1,5 @@
 @import "../../presentation/less/imports/commonImports.less";
 
-execution-status {
-  display: inline-block;
-  width: 180px;
-}
-.execution-bar {
-  display: inline-block;
-  width: calc(~"100% - 215px");
-  vertical-align: top;
-  padding-top: 20px;
-  .stage {
-    margin-top: 0;
-    display: inline-block;
-    height: 20px;
-    opacity: 0.65;
-    &:hover, &.active {
-      opacity: 1;
-    }
-    &.active {
-      border: 1px solid @dark_grey;
-    }
-    &.glowing {
-      .glowing(2.5);
-    }
-  }
-}
-.execution-actions {
-  display: inline-block;
-  width: 20px;
-  vertical-align: top;
-  padding-top: 20px;
-  margin-left: 6px;
-  .glyphicon-remove-circle {
-    color: @unhealthy_red;
-  }
-}
-.execution-summary {
-  padding: 0 5px 5px;
-  font-size: 90%;
-}
-
-execution-details-section-nav {
-  margin-left: 15px;
-  display: block;
-}
-
 .execution-group-container {
   padding: 10px 30px 0;
 }

--- a/app/scripts/modules/core/delivery/executions/executions.controller.js
+++ b/app/scripts/modules/core/delivery/executions/executions.controller.js
@@ -6,8 +6,6 @@ module.exports = angular.module('spinnaker.core.delivery.executions.controller',
   require('../service/execution.service.js'),
   require('../../pipeline/config/services/pipelineConfigService.js'),
   require('../../utils/scrollTo/scrollTo.service.js'),
-  require('../../cache/collapsibleSectionStateCache.js'),
-  require('../../cache/viewStateCache.js'),
   require('../../insight/insightFilterState.model.js'),
   require('../filter/executionFilter.model.js'),
   require('../filter/executionFilter.service.js'),
@@ -16,7 +14,7 @@ module.exports = angular.module('spinnaker.core.delivery.executions.controller',
   .controller('ExecutionsCtrl', function($scope, $state, $q, $uibModal, $stateParams,
                                          pipelineConfigService, scrollToService,
                                          executionService, ExecutionFilterModel, executionFilterService,
-                                         viewStateCache, collapsibleSectionStateCache, InsightFilterStateModel) {
+                                         InsightFilterStateModel) {
 
     if (ExecutionFilterModel.mostRecentApplication !== $scope.application.name) {
       ExecutionFilterModel.groups = [];
@@ -72,16 +70,11 @@ module.exports = angular.module('spinnaker.core.delivery.executions.controller',
       }
     });
 
-    var executionsViewStateCache = viewStateCache.executions || viewStateCache.createCache('executions', {
-        version: 1,
-        maxAge: 180 * 24 * 60 * 60 * 1000, // 180 days
-      });
-
-    function cacheViewState() {
-      executionsViewStateCache.put($scope.application.name, $scope.filter);
-    }
-
     $scope.filterCountOptions = [1, 2, 5];
+
+    $scope.$watch(() => ExecutionFilterModel.groups, () => {
+
+    });
 
     function normalizeExecutionNames() {
       let executions = application.executions || [];
@@ -105,7 +98,6 @@ module.exports = angular.module('spinnaker.core.delivery.executions.controller',
 
     $scope.$on('executions-load-failure', dataInitializationFailure);
     $scope.$on('executions-reloaded', normalizeExecutionNames);
-    $scope.$watch('filter', cacheViewState, true);
 
     this.toggleExpansion = (expand) => {
       $scope.$broadcast('toggle-expansion', expand);

--- a/app/scripts/modules/core/pipeline/config/graph/pipelineGraph.less
+++ b/app/scripts/modules/core/pipeline/config/graph/pipelineGraph.less
@@ -2,8 +2,8 @@
 
 pipeline-graph {
   display: block;
-  position: relative;
-  overflow-x: auto;
+  //position: relative;
+  //overflow-x: auto;
   svg {
     path.link {
       fill: none;


### PR DESCRIPTION
If an execution is hidden by changing the filters or by collapsing the heading, fix the URL so that it's no longer in that state.

Similarly, when the view loads without filters, as is the case in a deep link, ensure the execution group is expanded.
