### PR TITLE
not caching builds endpoint

### DIFF
--- a/app/scripts/modules/core/application/applicationConfig.view.html
+++ b/app/scripts/modules/core/application/applicationConfig.view.html
@@ -112,26 +112,6 @@
               </a>
             </div>
           </div>
-          <div class="row">
-            <div class="col-md-3 col-md-offset-1">Build Masters</div>
-            <div class="col-md-3">{{config.getCacheInfo('buildMasters').ageMax | timestamp}}</div>
-            <div class="col-md-1 text-center">
-              <a href ng-click="config.refreshCache('buildMasters')">
-              <span ng-class="{'glyphicon-spinning':config.clearingCache['buildMasters']}"
-                    class="glyphicon glyphicon-refresh"></span>
-              </a>
-            </div>
-          </div>
-          <div class="row">
-            <div class="col-md-3 col-md-offset-1">Build Jobs</div>
-            <div class="col-md-3">{{config.getCacheInfo('buildJobs').ageMax | timestamp}}</div>
-            <div class="col-md-1 text-center">
-              <a href ng-click="config.refreshCache('buildJobs')">
-              <span ng-class="{'glyphicon-spinning':config.clearingCache['buildJobs']}"
-                    class="glyphicon glyphicon-refresh"></span>
-              </a>
-            </div>
-          </div>
           <div class="row" style="margin-top:20px">
             <div class="col-md-10">
               <button class="btn btn-link" ng-if="!config.clearingCaches" ng-click="config.refreshCaches()"><span

--- a/app/scripts/modules/core/cache/infrastructureCacheConfig.js
+++ b/app/scripts/modules/core/cache/infrastructureCacheConfig.js
@@ -4,9 +4,6 @@ let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.cache.infrastructure.config', [])
   .constant('infrastructureCacheConfig', {
-    credentials: {
-      version: 2,
-    },
     networks: {
       version: 2,
     },
@@ -29,12 +26,5 @@ module.exports = angular.module('spinnaker.core.cache.infrastructure.config', []
       maxAge: 7 * 24 * 60 * 60 * 1000,
       version: 2
     },
-    keyPairs: {},
-    buildMasters: {
-      maxAge: 7 * 24 * 60 * 60 * 1000
-    },
-    buildJobs: {
-      maxAge: 7 * 24 * 60 * 60 * 1000
-    }
   })
   .name;

--- a/app/scripts/modules/core/pipeline/config/stages/jenkins/jenkinsStage.html
+++ b/app/scripts/modules/core/pipeline/config/stages/jenkins/jenkinsStage.html
@@ -14,8 +14,7 @@
       <a href
          ng-click="jenkinsStageCtrl.refreshMasters()"
          tooltip-placement="right"
-         tooltip-html-unsafe="Masters {{viewState.mastersRefreshing ? 'refreshing.<br>' : 'last refreshed ' }}{{viewState.mastersLastRefreshed}}
-                              <br>(click <span class='small glyphicon glyphicon-refresh'></span> to refresh)</p>"
+         uib-tooltip="{{viewState.mastersRefreshing ? 'Masters refreshing.' : 'Refresh masters list' }}"
         >
               <span ng-class="{'glyphicon-spinning':viewState.mastersRefreshing}"
                     class="glyphicon glyphicon-refresh"></span>
@@ -41,8 +40,7 @@
       <a href
          ng-click="jenkinsStageCtrl.refreshJobs()"
          tooltip-placement="right"
-         tooltip-html-unsafe="Jobs {{viewState.jobsRefreshing ? 'refreshing.<br>' : 'last refreshed ' }}{{viewState.jobsLastRefreshed}}
-                              <br>(click <span class='small glyphicon glyphicon-refresh'></span> to refresh)</p>"
+         uib-tooltip="{{viewState.jobsRefreshing ? 'Jobs refreshing.' : 'Refresh job list' }}"
         >
               <span ng-class="{'glyphicon-spinning':viewState.jobsRefreshing}"
                     class="glyphicon glyphicon-refresh"></span>

--- a/app/scripts/modules/core/pipeline/config/stages/jenkins/jenkinsStage.js
+++ b/app/scripts/modules/core/pipeline/config/stages/jenkins/jenkinsStage.js
@@ -20,17 +20,15 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.jenkinsStage', []
         { type: 'requiredField', fieldName: 'job', },
       ],
     });
-  }).controller('JenkinsStageCtrl', function($scope, stage, igorService, $filter, infrastructureCaches, _) {
+  }).controller('JenkinsStageCtrl', function($scope, stage, igorService, _) {
 
     $scope.stage = stage;
 
     $scope.viewState = {
       mastersLoaded: false,
       mastersRefreshing: false,
-      mastersLastRefreshed: null,
       jobsLoaded: false,
       jobsRefreshing: false,
-      jobsLastRefreshed: null,
     };
 
     function initializeMasters() {
@@ -38,21 +36,16 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.jenkinsStage', []
         $scope.masters = masters;
         $scope.viewState.mastersLoaded = true;
         $scope.viewState.mastersRefreshing = false;
-        $scope.viewState.mastersLastRefreshed = $filter('timestamp')(infrastructureCaches.buildMasters.getStats().ageMax);
       });
     }
 
     this.refreshMasters = function() {
       $scope.viewState.mastersRefreshing = true;
-      $scope.viewState.mastersLastRefreshed = null;
-      infrastructureCaches.clearCache('buildMasters');
       initializeMasters();
     };
 
     this.refreshJobs = function() {
       $scope.viewState.jobsRefreshing = true;
-      $scope.viewState.jobsLastRefreshed = null;
-      infrastructureCaches.clearCache('buildJobs');
       updateJobsList();
     };
 
@@ -61,7 +54,6 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.jenkinsStage', []
         $scope.viewState.jobsLoaded = false;
         $scope.jobs = [];
         igorService.listJobsForMaster($scope.stage.master).then(function(jobs) {
-          $scope.viewState.jobsLastRefreshed = $filter('timestamp')(infrastructureCaches.buildJobs.getStats().ageMax);
           $scope.viewState.jobsLoaded = true;
           $scope.viewState.jobsRefreshing = false;
           $scope.jobs = jobs;

--- a/app/scripts/modules/core/pipeline/config/triggers/jenkins/jenkinsTrigger.html
+++ b/app/scripts/modules/core/pipeline/config/triggers/jenkins/jenkinsTrigger.html
@@ -13,8 +13,7 @@
       <a href
          ng-click="jenkinsTriggerCtrl.refreshMasters()"
          tooltip-placement="right"
-         uib-tooltip-html-unsafe="Masters {{viewState.mastersRefreshing ? 'refreshing.<br>' : 'last refreshed ' }}{{viewState.mastersLastRefreshed}}
-                              <br>(click <span class='small glyphicon glyphicon-refresh'></span> to refresh)</p>"
+         uib-tooltip="{{viewState.mastersRefreshing ? 'Masters refreshing.' : 'Refresh masters list' }}"
         >
               <span ng-class="{'glyphicon-spinning':viewState.mastersRefreshing}"
                     class="glyphicon glyphicon-refresh"></span>
@@ -40,8 +39,7 @@
       <a href
          ng-click="jenkinsTriggerCtrl.refreshJobs()"
          tooltip-placement="right"
-         uib-tooltip-html-unsafe="Jobs {{viewState.jobsRefreshing ? 'refreshing.<br>' : 'last refreshed ' }}{{viewState.jobsLastRefreshed}}
-                              <br>(click <span class='small glyphicon glyphicon-refresh'></span> to refresh)</p>"
+         uib-tooltip="{{viewState.jobsRefreshing ? 'Jobs refreshing.' : 'Refresh job list' }}"
         >
               <span ng-class="{'glyphicon-spinning':viewState.jobsRefreshing}"
                     class="glyphicon glyphicon-refresh"></span>

--- a/app/scripts/modules/core/pipeline/config/triggers/jenkins/jenkinsTrigger.module.js
+++ b/app/scripts/modules/core/pipeline/config/triggers/jenkins/jenkinsTrigger.module.js
@@ -5,10 +5,7 @@ let angular = require('angular');
 module.exports = angular.module('spinnaker.core.pipeline.config.trigger.jenkins', [
   require('../trigger.directive.js'),
   require('../../../../ci/jenkins/igor.service.js'),
-  require('../../../../cache/cacheInitializer.js'),
-  require('../../../../cache/infrastructureCaches.js'),
   require('../../pipelineConfigProvider.js'),
-  require('../../../../utils/timeFormatters.js')
 ])
   .config(function(pipelineConfigProvider) {
     pipelineConfigProvider.registerTrigger({
@@ -28,17 +25,15 @@ module.exports = angular.module('spinnaker.core.pipeline.config.trigger.jenkins'
       ],
     });
   })
-  .controller('JenkinsTriggerCtrl', function($scope, trigger, igorService, cacheInitializer, infrastructureCaches, $filter) {
+  .controller('JenkinsTriggerCtrl', function($scope, trigger, igorService) {
 
     $scope.trigger = trigger;
 
     $scope.viewState = {
       mastersLoaded: false,
       mastersRefreshing: false,
-      mastersLastRefreshed: null,
       jobsLoaded: false,
       jobsRefreshing: false,
-      jobsLastRefreshed: null,
     };
 
     function initializeMasters() {
@@ -46,21 +41,16 @@ module.exports = angular.module('spinnaker.core.pipeline.config.trigger.jenkins'
         $scope.masters = masters;
         $scope.viewState.mastersLoaded = true;
         $scope.viewState.mastersRefreshing = false;
-        $scope.viewState.mastersLastRefreshed = $filter('timestamp')(infrastructureCaches.buildMasters.getStats().ageMax);
       });
     }
 
     this.refreshMasters = function() {
       $scope.viewState.mastersRefreshing = true;
-      $scope.viewState.mastersLastRefreshed = null;
-      infrastructureCaches.clearCache('buildMasters');
       initializeMasters();
     };
 
     this.refreshJobs = function() {
       $scope.viewState.jobsRefreshing = true;
-      $scope.viewState.jobsLastRefreshed = null;
-      infrastructureCaches.clearCache('buildJobs');
       updateJobsList();
     };
 
@@ -69,7 +59,6 @@ module.exports = angular.module('spinnaker.core.pipeline.config.trigger.jenkins'
         $scope.viewState.jobsLoaded = false;
         $scope.jobs = [];
         igorService.listJobsForMaster($scope.trigger.master).then(function(jobs) {
-          $scope.viewState.jobsLastRefreshed = $filter('timestamp')(infrastructureCaches.buildJobs.getStats().ageMax);
           $scope.viewState.jobsLoaded = true;
           $scope.viewState.jobsRefreshing = false;
           $scope.jobs = jobs;


### PR DESCRIPTION
As far as I can tell, we only ever cached the masters/jobs calls for a few days in March before the caching was rolled back accidentally.

Cleaning up other caches that have been removed, too...
