### PR TITLE
Updates aws ResizeAsgStage config to support Scale To Cluster option.

### DIFF
--- a/app/scripts/modules/core/help/helpContents.js
+++ b/app/scripts/modules/core/help/helpContents.js
@@ -113,6 +113,12 @@ module.exports = angular.module('spinnaker.core.help.contents', [])
     'loadBalancer.advancedSettings.healthInterval': '<p>Configures the interval, in seconds, between ELB health checks.</p><p>Default: <b>10</b></p>',
     'loadBalancer.advancedSettings.healthyThreshold': '<p>Configures the number of healthy observations before reinstituting an instance into the ELB’s traffic rotation.</p><p>Default: <b>10</b></p>',
     'loadBalancer.advancedSettings.unhealthyThreshold': '<p>Configures the number of unhealthy observations before deservicing an instance from the ELB.</p><p>Default: <b>2</b></p>',
+    'pipeline.config.resizeAsg.action': '<p>Configures the resize action for the target server group.<ul>' +
+      '<li><b>Scale Up</b> increases the size of the target server group by an incremental or percentage amount</li>' +
+      '<li><b>Scale Down</b> decreases the size of the target server group by an incremental or percentage amount</li>' +
+      '<li><b>Scale to Cluster Size</b> increases the size of the target server group to match the largest server group in the cluster, optionally with an incremental or percentage additional capacity. Additional capacity will not exceed the existing maximum size.</li>' +
+      '<li><b>Scale to Exact Size</b> adjusts the size of the target server group to match the provided capacity</li>' +
+      '</ul></p>',
     'pipeline.config.resizeAsg.cluster': '<p>Configures the cluster upon which this resize operation will act. The <em>target</em> specifies what server group to resolve for the operation.</p>',
     'pipeline.config.modifyScalingProcess.cluster': '<p>Configures the cluster upon which this modify scaling process operation will act. The <em>target</em> specifies what server group to resolve for the operation.</p>',
     'pipeline.config.enableAsg.cluster': '<p>Configures the cluster upon which this enable operation will act. The <em>target</em> specifies what server group to resolve for the operation.</p>',

--- a/app/scripts/modules/core/pipeline/config/stages/resizeAsg/aws/awsResizeAsgStage.js
+++ b/app/scripts/modules/core/pipeline/config/stages/resizeAsg/aws/awsResizeAsgStage.js
@@ -62,7 +62,15 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.aws.resizeAsgStag
       {
         label: 'Scale Down',
         val: 'scale_down'
-      }
+      },
+      {
+        label: 'Scale to Cluster Size',
+        val: 'scale_to_cluster'
+      },
+      {
+        label: 'Scale to Exact Size',
+        val: 'scale_exact'
+      },
     ];
 
     $scope.resizeTypes = [
@@ -74,10 +82,6 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.aws.resizeAsgStag
         label: 'Incremental',
         val: 'incr'
       },
-      {
-        label: 'Exact',
-        val: 'exact'
-      }
     ];
 
     stage.capacity = stage.capacity || {};
@@ -85,6 +89,9 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.aws.resizeAsgStag
     stage.target = stage.target || $scope.resizeTargets[0].val;
     stage.action = stage.action || $scope.scaleActions[0].val;
     stage.resizeType = stage.resizeType || $scope.resizeTypes[0].val;
+    if (stage.resizeType === 'exact') {
+      stage.action = 'scale_exact';
+    }
     stage.cloudProvider = 'aws';
 
     if (stage.isNew && $scope.application.attributes.platformHealthOnly) {
@@ -103,9 +110,18 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.aws.resizeAsgStag
     }
 
     ctrl.updateResizeType = function() {
-      stage.capacity = {};
-      delete stage.scalePct;
-      delete stage.scaleNum;
+      if (stage.action === 'scale_exact') {
+        stage.resizeType = 'exact';
+        delete stage.scalePct;
+        delete stage.scaleNum;
+      } else {
+        stage.capacity = {};
+        if (stage.resizeType === 'pct') {
+          delete stage.scaleNum;
+        } else if (stage.resizeType === 'incr') {
+          delete stage.scalePct;
+        }
+      }
     };
 
   })

--- a/app/scripts/modules/core/pipeline/config/stages/resizeAsg/aws/resizeAsgStage.html
+++ b/app/scripts/modules/core/pipeline/config/stages/resizeAsg/aws/resizeAsgStage.html
@@ -39,18 +39,23 @@
       </div>
     </div>
     <div class="form-group">
-      <label class="col-md-2 col-md-offset-1 sm-label-left">Action</label>
+      <label class="col-md-2 col-md-offset-1 sm-label-left">Action
+      <help-field key="pipeline.config.resizeAsg.action"></help-field>
+      </label>
       <div class="col-md-6">
         <select class="form-control input-sm"
                 required
                 ng-model="stage.action"
+                ng-change="resizeAsgStageCtrl.updateResizeType()"
                 ng-options="a.val as a.label for a in scaleActions">
           <option>Select an action...</option>
         </select>
       </div>
     </div>
+    <div ng-if="stage.action !== 'scale_exact'">
     <div class="form-group">
-      <label class="col-md-2 col-md-offset-1 sm-label-left">Type</label>
+      <label ng-if="stage.action !== 'scale_to_cluster'" class="col-md-2 col-md-offset-1 sm-label-left">Type</label>
+      <label ng-if="stage.action === 'scale_to_cluster'" class="col-md-2 col-md-offset-1 sm-label-left">Additional Capacity</label>
       <div class="col-md-6">
         <select class="form-control input-sm"
                 required
@@ -65,7 +70,7 @@
       <div class="col-md-9 col-md-offset-3">
         <label class="col-md-2 sm-label-left" style="font-size:12px;line-height:13px;margin-left:0;padding-left:0">Resize Percentage</label>
         <div class="col-md-2">
-          <input type="number" ng-model="stage.scalePct"
+          <input type="number" min="0" ng-model="stage.scalePct"
             class="form-control input-sm" />
         </div>
       </div>
@@ -78,7 +83,7 @@
       <div class="col-md-9 col-md-offset-3">
         <label class="col-md-2 sm-label-left" style="margin-left:0;padding-left:0">Resize-by Amount</label>
         <div class="col-md-2">
-          <input type="number" ng-model="stage.scaleNum"
+          <input type="number" min="0" ng-model="stage.scaleNum"
             class="form-control input-sm" />
         </div>
       </div>
@@ -87,7 +92,8 @@
         <em class="subinput-note">This is the exact amount by which the target server group's capacity will be increased</em>
       </div>
     </div>
-    <div class="form-group" ng-if="stage.resizeType === 'exact'">
+    </div>
+    <div class="form-group" ng-if="stage.action === 'scale_exact'">
       <div class="col-md-9 col-md-offset-3 small">
         <div class="col-md-9">
           <div class="col-md-2 col-md-offset-3">Min</div>

--- a/app/scripts/modules/core/pipeline/config/stages/resizeAsg/cf/cfResizeAsgStage.js
+++ b/app/scripts/modules/core/pipeline/config/stages/resizeAsg/cf/cfResizeAsgStage.js
@@ -57,7 +57,15 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.cf.resizeAsgStage
       {
         label: 'Scale Down',
         val: 'scale_down'
-      }
+      },
+      {
+        label: 'Scale to Cluster Size',
+        val: 'scale_to_cluster'
+      },
+      {
+        label: 'Scale to Exact Size',
+        val: 'scale_exact'
+      },
     ];
 
     $scope.resizeTypes = [
@@ -68,10 +76,6 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.cf.resizeAsgStage
       {
         label: 'Incremental',
         val: 'incr'
-      },
-      {
-        label: 'Exact',
-        val: 'exact'
       }
     ];
 
@@ -80,6 +84,9 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.cf.resizeAsgStage
     stage.target = stage.target || $scope.resizeTargets[0].val;
     stage.action = stage.action || $scope.scaleActions[0].val;
     stage.resizeType = stage.resizeType || $scope.resizeTypes[0].val;
+    if (stage.resizeType === 'exact') {
+      stage.action = 'scale_exact';
+    }
     stage.cloudProvider = 'cf';
 
     if (!stage.credentials && $scope.application.defaultCredentials) {
@@ -94,11 +101,19 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.cf.resizeAsgStage
     }
 
     ctrl.updateResizeType = function() {
-      stage.capacity = {};
-      delete stage.scalePct;
-      delete stage.scaleNum;
+      if (stage.action === 'scale_exact') {
+        stage.resizeType = 'exact';
+        delete stage.scalePct;
+        delete stage.scaleNum;
+      } else {
+        stage.capacity = {};
+        if (stage.resizeType === 'pct') {
+          delete stage.scaleNum;
+        } else if (stage.resizeType === 'incr') {
+          delete stage.scalePct;
+        }
+      }
     };
-
   })
   .name;
 

--- a/app/scripts/modules/core/pipeline/config/stages/resizeAsg/cf/resizeAsgStage.html
+++ b/app/scripts/modules/core/pipeline/config/stages/resizeAsg/cf/resizeAsgStage.html
@@ -39,55 +39,61 @@
       </div>
     </div>
     <div class="form-group">
-      <label class="col-md-2 col-md-offset-1 sm-label-left">Action</label>
+      <label class="col-md-2 col-md-offset-1 sm-label-left">Action
+        <help-field key="pipeline.config.resizeAsg.action"></help-field>
+      </label>
       <div class="col-md-6">
         <select class="form-control input-sm"
                 required
                 ng-model="stage.action"
+                ng-change="resizeAsgStageCtrl.updateResizeType()"
                 ng-options="a.val as a.label for a in scaleActions">
           <option>Select an action...</option>
         </select>
       </div>
     </div>
-    <div class="form-group">
-      <label class="col-md-2 col-md-offset-1 sm-label-left">Type</label>
-      <div class="col-md-6">
-        <select class="form-control input-sm"
-                required
-                ng-model="stage.resizeType"
-                ng-change="resizeAsgStageCtrl.updateResizeType()"
-                ng-options="t.val as t.label for t in resizeTypes">
-          <option>Select an action...</option>
-        </select>
-      </div>
-    </div>
-    <div class="form-group" ng-if="stage.resizeType === 'pct'">
-      <div class="col-md-9 col-md-offset-3">
-        <label class="col-md-2 sm-label-left" style="font-size:12px;line-height:13px;margin-left:0;padding-left:0">Resize Percentage</label>
-        <div class="col-md-2">
-          <input type="number" ng-model="stage.scalePct"
-            class="form-control input-sm" />
+    <div ng-if="stage.action !== 'scale_exact'">
+      <div class="form-group">
+        <label ng-if="stage.action !== 'scale_to_cluster'" class="col-md-2 col-md-offset-1 sm-label-left">Type</label>
+        <label ng-if="stage.action === 'scale_to_cluster'" class="col-md-2 col-md-offset-1 sm-label-left">Additional Capacity</label>
+        <div class="col-md-6">
+          <select class="form-control input-sm"
+                  required
+                  ng-model="stage.resizeType"
+                  ng-change="resizeAsgStageCtrl.updateResizeType()"
+                  ng-options="t.val as t.label for t in resizeTypes">
+            <option>Select an action...</option>
+          </select>
         </div>
       </div>
-      <div class="col-md-9 col-md-offset-3">
-        <em class="subinput-note">This is the percentage by which the target server group's capacity will be increased</em>
-      </div>
+      <div class="form-group" ng-if="stage.resizeType === 'pct'">
+        <div class="col-md-9 col-md-offset-3">
+          <label class="col-md-2 sm-label-left" style="font-size:12px;line-height:13px;margin-left:0;padding-left:0">Resize Percentage</label>
+          <div class="col-md-2">
+            <input type="number" min="0" ng-model="stage.scalePct"
+                   class="form-control input-sm" />
+          </div>
+        </div>
+        <div class="col-md-9 col-md-offset-3">
+          <em class="subinput-note">This is the percentage by which the target server group's capacity will be increased</em>
+        </div>
 
-    </div>
-    <div class="form-group" ng-if="stage.resizeType === 'incr'">
-      <div class="col-md-9 col-md-offset-3">
-        <label class="col-md-2 sm-label-left" style="margin-left:0;padding-left:0">Resize-by Amount</label>
-        <div class="col-md-2">
-          <input type="number" ng-model="stage.scaleNum"
-            class="form-control input-sm" />
+      </div>
+      <div class="form-group" ng-if="stage.resizeType === 'incr'">
+        <div class="col-md-9 col-md-offset-3">
+          <label class="col-md-2 sm-label-left" style="margin-left:0;padding-left:0">Resize-by Amount</label>
+          <div class="col-md-2">
+            <input type="number" min="0" ng-model="stage.scaleNum"
+                   class="form-control input-sm" />
+          </div>
+        </div>
+
+        <div class="col-md-9 col-md-offset-3">
+          <em class="subinput-note">This is the exact amount by which the target server group's capacity will be increased</em>
         </div>
       </div>
-
-      <div class="col-md-9 col-md-offset-3">
-        <em class="subinput-note">This is the exact amount by which the target server group's capacity will be increased</em>
-      </div>
     </div>
-    <div class="form-group" ng-if="stage.resizeType === 'exact'">
+    <div class="form-group" ng-if="stage.action === 'scale_exact'">
       <div class="col-md-9 col-md-offset-3 small">
         <div class="col-md-9">
           <div class="col-md-2 col-md-offset-3">Min</div>
@@ -100,7 +106,7 @@
         <div class="col-md-9">
           <div class="col-md-2">
             <input type="number" ng-model="stage.capacity.min"
-              class="form-control input-sm" />
+                   class="form-control input-sm" />
           </div>
           <div class="col-md-2">
             <input type="number" ng-model="stage.capacity.max"

--- a/app/scripts/modules/core/pipeline/config/stages/resizeAsg/gce/gceResizeAsgStage.js
+++ b/app/scripts/modules/core/pipeline/config/stages/resizeAsg/gce/gceResizeAsgStage.js
@@ -60,7 +60,15 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.gce.resizeAsgStag
       {
         label: 'Scale Down',
         val: 'scale_down'
-      }
+      },
+      {
+        label: 'Scale to Cluster Size',
+        val: 'scale_to_cluster'
+      },
+      {
+        label: 'Scale to Exact Size',
+        val: 'scale_exact'
+      },
     ];
 
     $scope.resizeTypes = [
@@ -71,10 +79,6 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.gce.resizeAsgStag
       {
         label: 'Incremental',
         val: 'incr'
-      },
-      {
-        label: 'Exact',
-        val: 'exact'
       }
     ];
 
@@ -83,6 +87,9 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.gce.resizeAsgStag
     stage.target = stage.target || $scope.resizeTargets[0].val;
     stage.action = stage.action || $scope.scaleActions[0].val;
     stage.resizeType = stage.resizeType || $scope.resizeTypes[0].val;
+    if (stage.resizeType === 'exact') {
+      stage.action = 'scale_exact';
+    }
     stage.cloudProvider = 'gce';
     stage.cloudProviderType = 'gce';
 
@@ -99,11 +106,19 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.gce.resizeAsgStag
     }
 
     ctrl.updateResizeType = function() {
-      stage.capacity = {};
-      delete stage.scalePct;
-      delete stage.scaleNum;
+      if (stage.action === 'scale_exact') {
+        stage.resizeType = 'exact';
+        delete stage.scalePct;
+        delete stage.scaleNum;
+      } else {
+        stage.capacity = {};
+        if (stage.resizeType === 'pct') {
+          delete stage.scaleNum;
+        } else if (stage.resizeType === 'incr') {
+          delete stage.scalePct;
+        }
+      }
     };
-
   })
   .name;
 

--- a/app/scripts/modules/core/pipeline/config/stages/resizeAsg/gce/resizeAsgStage.html
+++ b/app/scripts/modules/core/pipeline/config/stages/resizeAsg/gce/resizeAsgStage.html
@@ -39,55 +39,61 @@
       </div>
     </div>
     <div class="form-group">
-      <label class="col-md-2 col-md-offset-1 sm-label-left">Action</label>
+      <label class="col-md-2 col-md-offset-1 sm-label-left">Action
+        <help-field key="pipeline.config.resizeAsg.action"></help-field>
+      </label>
       <div class="col-md-6">
         <select class="form-control input-sm"
                 required
                 ng-model="stage.action"
+                ng-change="resizeAsgStageCtrl.updateResizeType()"
                 ng-options="a.val as a.label for a in scaleActions">
           <option>Select an action...</option>
         </select>
       </div>
     </div>
-    <div class="form-group">
-      <label class="col-md-2 col-md-offset-1 sm-label-left">Type</label>
-      <div class="col-md-6">
-        <select class="form-control input-sm"
-                required
-                ng-model="stage.resizeType"
-                ng-change="resizeAsgStageCtrl.updateResizeType()"
-                ng-options="t.val as t.label for t in resizeTypes">
-          <option>Select an action...</option>
-        </select>
-      </div>
-    </div>
-    <div class="form-group" ng-if="stage.resizeType === 'pct'">
-      <div class="col-md-9 col-md-offset-3">
-        <label class="col-md-2 sm-label-left" style="font-size:12px;line-height:13px;margin-left:0;padding-left:0">Resize Percentage</label>
-        <div class="col-md-2">
-          <input type="number" ng-model="stage.scalePct"
-            class="form-control input-sm" />
+    <div ng-if="stage.action !== 'scale_exact'">
+      <div class="form-group">
+        <label ng-if="stage.action !== 'scale_to_cluster'" class="col-md-2 col-md-offset-1 sm-label-left">Type</label>
+        <label ng-if="stage.action === 'scale_to_cluster'" class="col-md-2 col-md-offset-1 sm-label-left">Additional Capacity</label>
+        <div class="col-md-6">
+          <select class="form-control input-sm"
+                  required
+                  ng-model="stage.resizeType"
+                  ng-change="resizeAsgStageCtrl.updateResizeType()"
+                  ng-options="t.val as t.label for t in resizeTypes">
+            <option>Select an action...</option>
+          </select>
         </div>
       </div>
-      <div class="col-md-9 col-md-offset-3">
-        <em class="subinput-note">This is the percentage by which the target server group's capacity will be increased</em>
-      </div>
+      <div class="form-group" ng-if="stage.resizeType === 'pct'">
+        <div class="col-md-9 col-md-offset-3">
+          <label class="col-md-2 sm-label-left" style="font-size:12px;line-height:13px;margin-left:0;padding-left:0">Resize Percentage</label>
+          <div class="col-md-2">
+            <input type="number" min="0" ng-model="stage.scalePct"
+                   class="form-control input-sm" />
+          </div>
+        </div>
+        <div class="col-md-9 col-md-offset-3">
+          <em class="subinput-note">This is the percentage by which the target server group's capacity will be increased</em>
+        </div>
 
-    </div>
-    <div class="form-group" ng-if="stage.resizeType === 'incr'">
-      <div class="col-md-9 col-md-offset-3">
-        <label class="col-md-2 sm-label-left" style="margin-left:0;padding-left:0">Resize-by Amount</label>
-        <div class="col-md-2">
-          <input type="number" ng-model="stage.scaleNum"
-            class="form-control input-sm" />
+      </div>
+      <div class="form-group" ng-if="stage.resizeType === 'incr'">
+        <div class="col-md-9 col-md-offset-3">
+          <label class="col-md-2 sm-label-left" style="margin-left:0;padding-left:0">Resize-by Amount</label>
+          <div class="col-md-2">
+            <input type="number" min="0" ng-model="stage.scaleNum"
+                   class="form-control input-sm" />
+          </div>
+        </div>
+
+        <div class="col-md-9 col-md-offset-3">
+          <em class="subinput-note">This is the exact amount by which the target server group's capacity will be increased</em>
         </div>
       </div>
-
-      <div class="col-md-9 col-md-offset-3">
-        <em class="subinput-note">This is the exact amount by which the target server group's capacity will be increased</em>
-      </div>
     </div>
-    <div class="form-group" ng-if="stage.resizeType === 'exact'">
+    <div class="form-group" ng-if="stage.action === 'scale_exact'">
       <div class="col-md-9 col-md-offset-3 small">
         <div class="col-md-9">
           <div class="col-md-2 col-md-offset-3">Min</div>
@@ -100,7 +106,7 @@
         <div class="col-md-9">
           <div class="col-md-2">
             <input type="number" ng-model="stage.capacity.min"
-              class="form-control input-sm" />
+                   class="form-control input-sm" />
           </div>
           <div class="col-md-2">
             <input type="number" ng-model="stage.capacity.max"


### PR DESCRIPTION
Also makes scale to exact size an action instead of a type of scale up or scale down

Requires https://github.com/spinnaker/orca/pull/610 for scale to cluster

@anotherchrisberry I only changed the AWS implementation so far - looking at what is there on CF and GCE they are mostly identical with some very minor differences. Is there something we can do better here where changes like this don't mean re-implementing the same thing in each provider? (Not suggesting we solve that as part of this PR, mainly just asking)

@duftler @gregturn I will apply the equivalent change to the GCE / CF resize stages once @anotherchrisberry tells me all the JavaScript and HTML fouls I committed in here..
