### PR TITLE
handle SPEL in jenkins master name

### DIFF
--- a/app/scripts/modules/core/pipeline/config/stages/jenkins/jenkinsStage.html
+++ b/app/scripts/modules/core/pipeline/config/stages/jenkins/jenkinsStage.html
@@ -2,7 +2,10 @@
   <div class="form-group">
     <label class="col-md-2 col-md-offset-1 sm-label-left">Master</label>
     <div class="col-md-6">
+      <p class="form-control-static"
+         ng-if="viewState.masterIsParameterized">{{stage.master}}</p>
       <ui-select class="form-control input-sm"
+                 ng-if="!viewState.masterIsParameterized"
                  ng-model="stage.master">
         <ui-select-match placeholder="Select a master...">{{$select.selected}}</ui-select-match>
         <ui-select-choices repeat="master in masters | filter: $select.search">
@@ -10,7 +13,7 @@
         </ui-select-choices>
       </ui-select>
     </div>
-    <div class="col-md-1 text-center">
+    <div class="col-md-1 text-center" ng-if="!viewState.masterIsParameterized">
       <a href
          ng-click="jenkinsStageCtrl.refreshMasters()"
          tooltip-placement="right"
@@ -25,18 +28,22 @@
     <label class="col-md-2 col-md-offset-1 sm-label-left">Job</label>
     <div class="col-md-6">
       <p class="form-control-static" ng-if="!stage.master">(Select a master)</p>
+      <p class="form-control-static" ng-if="viewState.masterIsParameterized">
+        <input type="text" ng-model="stage.job" class="form-control input-sm"/>
+      </p>
       <div ng-if="stage.master && viewState.jobsLoaded">
         <ui-select class="form-control input-sm"
+                   ng-if="!viewState.masterIsParameterized"
                    ng-model="stage.job">
           <ui-select-match placeholder="Select a job...">{{$select.selected}}</ui-select-match>
           <ui-select-choices repeat="job in jobs | filter: $select.search"><span ng-bind-html="job | highlight: $select.search"></span></ui-select-choices>
         </ui-select>
       </div>
-      <div class="text-center" ng-if="stage.master && !viewState.jobsLoaded">
+      <div class="text-center" ng-if="stage.master && !viewState.jobsLoaded && !viewState.masterIsParameterized">
         <span class="glyphicon glyphicon-asterisk glyphicon-spinning"></span>
       </div>
     </div>
-    <div class="col-md-1 text-center">
+    <div class="col-md-1 text-center" ng-if="!viewState.masterIsParameterized">
       <a href
          ng-click="jenkinsStageCtrl.refreshJobs()"
          tooltip-placement="right"

--- a/app/scripts/modules/core/pipeline/config/stages/jenkins/jenkinsStage.js
+++ b/app/scripts/modules/core/pipeline/config/stages/jenkins/jenkinsStage.js
@@ -51,6 +51,10 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.jenkinsStage', []
 
     function updateJobsList() {
       if ($scope.stage && $scope.stage.master) {
+        $scope.viewState.masterIsParameterized = $scope.stage.master.indexOf('${') > -1;
+        if ($scope.viewState.masterIsParameterized) {
+          return;
+        }
         $scope.viewState.jobsLoaded = false;
         $scope.jobs = [];
         igorService.listJobsForMaster($scope.stage.master).then(function(jobs) {
@@ -68,7 +72,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.jenkinsStage', []
     }
 
     function updateJobConfig() {
-      if ($scope.stage && $scope.stage.master && $scope.stage.job) {
+      if ($scope.stage && $scope.stage.master && $scope.stage.job && !$scope.viewState.masterIsParameterized) {
         igorService.getJobConfig($scope.stage.master, $scope.stage.job).then(function(config){
         if(!$scope.stage.parameters) {
           $scope.stage.parameters = {};


### PR DESCRIPTION
If the user has entered a SPEL expression in the `master` field, we should not render a ui-select field for the master or job, since it will clear out _at least_ the job value.

This leaves the master in a read-only state via the form-based UI. To update the master, the user will have to go in via "Edit as JSON" and change the value - which is how it got in that state in the first place.

Not sure where else we're affected by SPEL in the stages, but will have a look around...
