### PR TITLE
remove default "frontend" detail from load balancer

### DIFF
--- a/app/scripts/modules/amazon/loadBalancer/loadBalancer.transformer.js
+++ b/app/scripts/modules/amazon/loadBalancer/loadBalancer.transformer.js
@@ -143,7 +143,7 @@ module.exports = angular.module('spinnaker.aws.loadBalancer.transformer', [
           defaultRegion = application.defaultRegion || settings.providers.aws.defaults.region;
       return {
         stack: '',
-        detail: 'frontend',
+        detail: '',
         credentials: defaultCredentials,
         region: defaultRegion,
         vpcId: null,


### PR DESCRIPTION
I know the dream is to use the VPC name, since that is our new default, but that, it turns out, is a lot less trivial to code.
