### PR TITLE
do not reload current details section

### DIFF
--- a/app/scripts/modules/core/loadBalancer/loadBalancer.directive.js
+++ b/app/scripts/modules/core/loadBalancer/loadBalancer.directive.js
@@ -10,6 +10,7 @@ module.exports = angular.module('spinnaker.core.loadBalancer.directive', [
       restrict: 'E',
       templateUrl: require('./loadBalancer/loadBalancer.html'),
       scope: {
+        application: '=',
         loadBalancer: '=',
         serverGroups: '=',
       },
@@ -34,12 +35,18 @@ module.exports = angular.module('spinnaker.core.loadBalancer.directive', [
               return;
             }
             var params = {
+              application: scope.application.name,
               region: loadBalancer.region,
               accountId: loadBalancer.account,
               name: loadBalancer.name,
               vpcId: loadBalancer.vpcId,
               provider: loadBalancer.provider,
             };
+
+            if (angular.equals(scope.$state.params, params)) {
+              // already there
+              return;
+            }
             // also stolen from uiSref directive
             scope.$state.go('.loadBalancerDetails', params, {relative: base, inherit: true});
           });

--- a/app/scripts/modules/core/loadBalancer/loadBalancer/loadBalancerPod.html
+++ b/app/scripts/modules/core/loadBalancer/loadBalancer/loadBalancerPod.html
@@ -17,6 +17,7 @@
   <div class="rollup-details">
     <div class="pod-subgroup" ng-repeat="subgroup in grouping.subgroups">
       <load-balancer
+          application="application"
           load-balancer="subgroup.loadBalancer"
           server-groups="subgroup.serverGroups"></load-balancer>
     </div>

--- a/app/scripts/modules/core/securityGroup/securityGroup.directive.js
+++ b/app/scripts/modules/core/securityGroup/securityGroup.directive.js
@@ -9,6 +9,7 @@ module.exports = angular.module('spinnaker.core.securityGroup.directive', [])
       replace: true,
       templateUrl: require('./securityGroup.html'),
       scope: {
+        application: '=',
         securityGroup: '=',
         sortFilter: '='
       },
@@ -29,12 +30,18 @@ module.exports = angular.module('spinnaker.core.securityGroup.directive', [])
               return;
             }
             var params = {
+              application: scope.application.name,
               region: securityGroup.region,
               accountId: securityGroup.accountName,
               name: securityGroup.name,
               vpcId: securityGroup.vpcId,
               provider: securityGroup.provider,
             };
+
+            if (angular.equals(scope.$state.params, params)) {
+              // already there
+              return;
+            }
             // also stolen from uiSref directive
             scope.$state.go('.securityGroupDetails', params, {relative: base, inherit: true});
           });

--- a/app/scripts/modules/core/securityGroup/securityGroupPod.html
+++ b/app/scripts/modules/core/securityGroup/securityGroupPod.html
@@ -17,6 +17,7 @@
   <div class="rollup-details">
     <div class="pod-subgroup" ng-repeat="subgroup in grouping.subgroups">
       <security-group
+          application="application"
           security-group="subgroup.securityGroup"
           sort-filter="sortFilter"></security-group>
     </div>

--- a/app/scripts/modules/core/serverGroup/serverGroup.directive.js
+++ b/app/scripts/modules/core/serverGroup/serverGroup.directive.js
@@ -72,11 +72,16 @@ module.exports = angular.module('spinnaker.core.serverGroup.serverGroup.directiv
               return;
             }
             var params = {
+              application: scope.application.name,
               region: serverGroup.region,
               accountId: serverGroup.account,
               serverGroup: serverGroup.name,
               provider: serverGroup.type,
             };
+            if (angular.equals(scope.$state.params, params)) {
+              // already there
+              return;
+            }
             // also stolen from uiSref directive
             scope.$state.go('.serverGroup', params, {relative: base, inherit: true});
           });


### PR DESCRIPTION
If you have filters set, then click on an item to load the details, then change the filters, then click on the same item, it will reload the details and kill the most recently changed filters. This prevents that.
