### PR TITLE
wait for all executions to load before initializing controller

### DIFF
--- a/app/scripts/modules/core/delivery/executionGroup/executionGroups.directive.html
+++ b/app/scripts/modules/core/delivery/executionGroup/executionGroups.directive.html
@@ -2,6 +2,9 @@
   <div class="row" ng-if="vm.viewState.initializationError">
     <h4 class="text-center">There was a server error loading pipelines. Please try again later.</h4>
   </div>
+  <div ng-if="!vm.groups.length" class="text-center">
+    <h4>No executions match the filters you've selected.</h4>
+  </div>
   <div class="execution-groups all-execution-groups" sticky-headers>
     <div ng-repeat="group in vm.groups">
       <execution-group group="group"
@@ -9,9 +12,4 @@
       </execution-group>
     </div>
   </div>
-</div>
-<div class="row" ng-if="vm.viewState.loading" style="min-height: 300px">
-  <h4 class="text-center">
-    <span us-spinner="{radius:20, width:6, length: 12}"></span>
-  </h4>
 </div>

--- a/app/scripts/modules/core/delivery/executions/executions.controller.js
+++ b/app/scripts/modules/core/delivery/executions/executions.controller.js
@@ -55,12 +55,8 @@ module.exports = angular.module('spinnaker.core.delivery.executions.controller',
       triggeringExecution: false,
     };
 
-    let executionLoader = $q.when(null);
-    if (!application.executionsLoaded) {
-      let deferred = $q.defer();
-      executionLoader = deferred.promise;
-      $scope.$on('executions-loaded', deferred.resolve);
-    }
+    let executionLoader = $q.defer();
+    $scope.$on('executions-reloaded', executionLoader.resolve);
 
     let configLoader = $q.when(null);
     if (application.pipelineConfigsLoading) {
@@ -69,7 +65,7 @@ module.exports = angular.module('spinnaker.core.delivery.executions.controller',
       $scope.$on('pipelineConfigs-loaded', deferred.resolve);
     }
 
-    $q.all([executionLoader, configLoader]).then(() => {
+    $q.all([executionLoader.promise, configLoader]).then(() => {
       this.updateExecutionGroups();
       this.viewState.loading = false;
       if ($stateParams.executionId) {

--- a/app/scripts/modules/core/delivery/executions/executions.html
+++ b/app/scripts/modules/core/delivery/executions/executions.html
@@ -17,7 +17,7 @@
     <execution-filters ng-if="!vm.viewState.loading" application="vm.application"></execution-filters>
   </div>
   <div class="full-content" data-scroll-id="nav-content" ng-class="{'filters-expanded': vm.InsightFilterStateModel.filtersExpanded}">
-    <div class="execution-groups-header">
+    <div class="execution-groups-header" ng-if="!vm.viewState.loading">
       <form class="form-inline execution-filters">
         <div class="form-group" ng-if="vm.filter.groupBy" style="margin-right: 20px">
           <a class="btn btn-xs btn-default" href ng-click="vm.toggleExpansion(true)" uib-tooltip="expand all">
@@ -66,6 +66,9 @@
     </div>
     <div class="text-center" ng-if="vm.viewState.loading">
       <h3 us-spinner="{radius:30, width:8, length: 16}"></h3>
+    </div>
+    <div class="text-center" ng-if="!vm.viewState.loading && !vm.application.executions.length && !vm.application.pipelineConfigs.length">
+      <h4>No pipelines configured for this application.</h4>
     </div>
     <execution-groups
         application="vm.application"

--- a/app/scripts/modules/core/delivery/filter/filterNav.html
+++ b/app/scripts/modules/core/delivery/filter/filterNav.html
@@ -36,7 +36,7 @@
             </label>
           </div>
         </div>
-        <div>
+        <div ng-if="vm.pipelineNames.length">
           <a class="btn btn-xs btn-default" href
              ng-if="vm.viewState.pipelineReorderDisabled"
              ng-click="vm.enablePipelineReorder()">Reorder Pipelines</a>


### PR DESCRIPTION
With the recent changes to load only active executions on application initialization, we usually break when coming to a specific execution from a deep link. This fixes that.

Also adding some sugar around applications without pipelines, or filters that filter out everything.
