### PR TITLE
show reservation counts when performing AWS resize

### DIFF
--- a/app/scripts/modules/amazon/serverGroup/details/resize/resizeServerGroup.controller.js
+++ b/app/scripts/modules/amazon/serverGroup/details/resize/resizeServerGroup.controller.js
@@ -7,8 +7,10 @@ module.exports = angular.module('spinnaker.amazon.serverGroup.details.resize.con
   require('../../../../core/application/modal/platformHealthOverride.directive.js'),
   require('../../../../core/serverGroup/serverGroup.write.service.js'),
   require('../../../../core/task/monitor/taskMonitorService.js'),
+  require('../../report/reservationReport.directive.js'),
 ])
-  .controller('awsResizeServerGroupCtrl', function($scope, $modalInstance, accountService, serverGroupWriter, taskMonitorService,
+  .controller('awsResizeServerGroupCtrl', function($scope, $modalInstance, accountService, serverGroupWriter,
+                                                   taskMonitorService, reservationReportReader,
                                                    application, serverGroup) {
     $scope.serverGroup = serverGroup;
     $scope.currentSize = {

--- a/app/scripts/modules/amazon/serverGroup/details/resize/resizeServerGroup.html
+++ b/app/scripts/modules/amazon/serverGroup/details/resize/resizeServerGroup.html
@@ -6,89 +6,98 @@
       <h3>Resize {{serverGroup.name}}</h3>
     </div>
     <div class="modal-body container-fluid form-horizontal">
-        <div ng-if="command.advancedMode">
-          <div class="form-group">
-            <div class="col-md-12">
-              <p>Sets up auto-scaling for this server group.</p>
-              <p>To disable auto-scaling, use the <a href ng-click="command.advancedMode = false">Simple Mode</a>.</p>
-            </div>
-          </div>
-          <div class="form-group">
-            <div class="col-md-2 col-md-offset-3"><b>Min</b></div>
-            <div class="col-md-2"><b>Max</b></div>
-            <div class="col-md-2"><b>Desired</b></div>
-          </div>
-          <div class="form-group">
-            <div class="col-md-3 text-right"><b>Current</b></div>
-            <div class="col-md-2"><b>{{currentSize.min}}</b></div>
-            <div class="col-md-2"><b>{{currentSize.max}}</b></div>
-            <div class="col-md-2"><b>{{currentSize.desired}}</b></div>
-          </div>
-          <div class="form-group">
-            <div class="col-md-3 text-right"><b>New</b></div>
-            <div class="col-md-2"><input type="number"
-                                         class="form-control input-sm"
-                                         ng-model="command.min"
-                                         min="0"
-                                         required
-                                         max="{{command.max}}"/></div>
-            <div class="col-md-2"><input type="number"
-                                         class="form-control input-sm"
-                                         ng-model="command.max"
-                                         required
-                                         min="{{command.min}}"/></div>
-            <div class="col-md-2"><input type="number"
-                                         class="form-control input-sm"
-                                         ng-model="command.desired"
-                                         required
-                                         min="{{command.min}}"
-                                         max="{{command.max}}"/></div>
-          </div>
+      <div class="row">
+        <div class="col-md-12">
+          <reservation-report account="serverGroup.account"
+                              region="serverGroup.region"
+                              zones="serverGroup.asg.availabilityZones"
+                              instance-type="serverGroup.launchConfig.instanceType"></reservation-report>
+        </div>
+      </div>
 
-        </div>
-        <div ng-if="!command.advancedMode">
-          <div class="form-group">
-            <div class="col-md-12">
-              <p>Sets min, max, and desired instance counts to the same value.</p>
-              <p> To allow true auto-scaling, use the <a href ng-click="command.advancedMode = true">Advanced Mode</a>.</p>
-            </div>
-          </div>
-          <div class="form-group">
-            <div class="col-md-12">
-              <h4>Current size:</h4>
-            </div>
-          </div>
-          <div class="form-group form-inline">
-            <div class="col-md-11 col-md-offset-1">
-              <label>
-                <input type="number"
-                       class="form-control input-sm"
-                       ng-model="currentSize.desired"
-                       style="width: 60px"
-                       readonly/>
-                instance<span ng-if="currentSize.desired > 1">s</span>
-              </label>
-            </div>
-          </div>
-          <div class="form-group">
-            <div class="col-md-12">
-              <h4>Resize to:</h4>
-            </div>
-          </div>
-          <div class="form-group form-inline">
-            <div class="col-md-11 col-md-offset-1">
-              <label>
-                <input type="number"
-                       class="form-control input-sm highlight-pristine"
-                       ng-model="command.newSize"
-                       min="0"
-                       required
-                       style="width: 60px"/>
-                instances
-              </label>
-            </div>
+      <div ng-if="command.advancedMode">
+        <div class="form-group">
+          <div class="col-md-12">
+            <p>Sets up auto-scaling for this server group.</p>
+            <p>To disable auto-scaling, use the <a href ng-click="command.advancedMode = false">Simple Mode</a>.</p>
           </div>
         </div>
+        <div class="form-group">
+          <div class="col-md-2 col-md-offset-3"><b>Min</b></div>
+          <div class="col-md-2"><b>Max</b></div>
+          <div class="col-md-2"><b>Desired</b></div>
+        </div>
+        <div class="form-group">
+          <div class="col-md-3 text-right"><b>Current</b></div>
+          <div class="col-md-2"><b>{{currentSize.min}}</b></div>
+          <div class="col-md-2"><b>{{currentSize.max}}</b></div>
+          <div class="col-md-2"><b>{{currentSize.desired}}</b></div>
+        </div>
+        <div class="form-group">
+          <div class="col-md-3 text-right"><b>New</b></div>
+          <div class="col-md-2"><input type="number"
+                                       class="form-control input-sm"
+                                       ng-model="command.min"
+                                       min="0"
+                                       required
+                                       max="{{command.max}}"/></div>
+          <div class="col-md-2"><input type="number"
+                                       class="form-control input-sm"
+                                       ng-model="command.max"
+                                       required
+                                       min="{{command.min}}"/></div>
+          <div class="col-md-2"><input type="number"
+                                       class="form-control input-sm"
+                                       ng-model="command.desired"
+                                       required
+                                       min="{{command.min}}"
+                                       max="{{command.max}}"/></div>
+        </div>
+
+      </div>
+      <div ng-if="!command.advancedMode">
+        <div class="form-group">
+          <div class="col-md-12">
+            <p>Sets min, max, and desired instance counts to the same value.</p>
+            <p> To allow true auto-scaling, use the <a href ng-click="command.advancedMode = true">Advanced Mode</a>.</p>
+          </div>
+        </div>
+        <div class="form-group">
+          <div class="col-md-12">
+            <h4>Current size:</h4>
+          </div>
+        </div>
+        <div class="form-group form-inline">
+          <div class="col-md-11 col-md-offset-1">
+            <label>
+              <input type="number"
+                     class="form-control input-sm"
+                     ng-model="currentSize.desired"
+                     style="width: 60px"
+                     readonly/>
+              instance<span ng-if="currentSize.desired > 1">s</span>
+            </label>
+          </div>
+        </div>
+        <div class="form-group">
+          <div class="col-md-12">
+            <h4>Resize to:</h4>
+          </div>
+        </div>
+        <div class="form-group form-inline">
+          <div class="col-md-11 col-md-offset-1">
+            <label>
+              <input type="number"
+                     class="form-control input-sm highlight-pristine"
+                     ng-model="command.newSize"
+                     min="0"
+                     required
+                     style="width: 60px"/>
+              instances
+            </label>
+          </div>
+        </div>
+      </div>
       <div class="row" ng-if="verification.required">
         <div class="col-sm-12">
           <hr/>

--- a/app/scripts/modules/amazon/serverGroup/report/reservationReport.directive.html
+++ b/app/scripts/modules/amazon/serverGroup/report/reservationReport.directive.html
@@ -1,0 +1,30 @@
+<h4 ng-if="vm.viewState.loading"><span us-spinner="{radius:5, width:2, length: 3}"></span></h4>
+<!-- TODO: Remove error switch when feature flagging is available to toggle this directive on and off -->
+<div class="small reservation-report" ng-if="!vm.viewState.loading && !vm.viewState.error">
+  <div ng-if="!vm.viewState.error">
+    <h4>Reservations for {{vm.instanceType}} in <account-tag account="vm.account" provider="'aws'"></account-tag></h4>
+    <table class="table table-condensed">
+      <thead>
+      <tr>
+        <th>Zone</th>
+        <th>OS</th>
+        <th>Reserved</th>
+        <th>Used</th>
+        <th>Available</th>
+      </tr>
+      </thead>
+      <tbody>
+        <tr ng-repeat="row in vm.report">
+          <td>{{row.availabilityZone}}</td>
+          <td>{{row.os}}</td>
+          <td>{{row.reservations.reserved}}</td>
+          <td>{{row.reservations.used}}</td>
+          <td><strong>{{row.reservations.surplus}}</strong></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h5 ng-if="vm.viewState.error" class="text-center">
+    There was an error loading the reservation counts for {{vm.instanceType}}
+  </h5>
+</div>

--- a/app/scripts/modules/amazon/serverGroup/report/reservationReport.directive.js
+++ b/app/scripts/modules/amazon/serverGroup/report/reservationReport.directive.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const angular = require('angular');
+
+require('./reservationReport.directive.less');
+
+module.exports = angular
+  .module('spinnaker.amazon.serverGroup.report.reservationReport.directive', [
+    require('./reservationReport.read.service.js'),
+  ])
+  .directive('reservationReport', function() {
+    return {
+      restrict: 'E',
+      templateUrl: require('./reservationReport.directive.html'),
+      scope: {},
+      bindToController: {
+        account: '=',
+        region: '=',
+        instanceType: '=',
+        zones: '=',
+      },
+      controller: 'ReservationReportCtrl',
+      controllerAs: 'vm',
+    };
+  })
+  .controller('ReservationReportCtrl', function (reservationReportReader) {
+    this.viewState = {
+      loading: true,
+      error: false,
+    };
+
+    reservationReportReader.getReservationsFor(this.account, this.region, this.instanceType)
+      .then(
+      (report) => {
+        this.report = report.filter((row) => this.zones.indexOf(row.availabilityZone) > -1);
+        this.viewState.loading = false;
+      },
+      () => {
+        this.viewState.loading = false;
+        this.viewState.error = true;
+      }
+    );
+  })
+  .name;

--- a/app/scripts/modules/amazon/serverGroup/report/reservationReport.directive.less
+++ b/app/scripts/modules/amazon/serverGroup/report/reservationReport.directive.less
@@ -1,0 +1,13 @@
+@import "../../../core/presentation/less/imports/commonImports.less";
+reservation-report {
+  display: block;
+  margin-bottom: 20px;
+  .reservation-report {
+    border: 1px solid @light_grey;
+    background-color: @lightest_grey;
+    padding: 10px;
+    .table {
+      margin-bottom: 0;
+    }
+  }
+}

--- a/app/scripts/modules/amazon/serverGroup/report/reservationReport.read.service.js
+++ b/app/scripts/modules/amazon/serverGroup/report/reservationReport.read.service.js
@@ -1,0 +1,36 @@
+'use strict';
+
+let angular = require('angular');
+
+module.exports = angular
+  .module('spinnaker.amazon.instance.report.reservation.read.service', [
+    require('exports?"restangular"!imports?_=lodash!restangular'),
+    require('../../../core/utils/lodash.js'),
+  ])
+  .factory('reservationReportReader', function (Restangular) {
+    function getReservationsFor(account, region, instanceType) {
+      return Restangular.one('reports', 'reservation')
+        .get()
+        .then((result) => {
+          return extractReservations(result.reservations, account, region, instanceType);
+        });
+    }
+
+    function extractReservations(reservations, account, region, instanceType) {
+      return reservations
+        .filter((reservation) => reservation.region === region &&
+          reservation.instanceType === instanceType &&
+          reservation.accounts[account])
+        .map((reservation) => {
+          return {
+            availabilityZone: reservation.availabilityZone,
+            os: reservation.os,
+            reservations: reservation.accounts[account],
+          };
+        });
+    }
+
+    return {
+      getReservationsFor: getReservationsFor
+    };
+  }).name;

--- a/app/scripts/modules/core/delivery/executionGroup/executionGroup.directive.js
+++ b/app/scripts/modules/core/delivery/executionGroup/executionGroup.directive.js
@@ -8,7 +8,6 @@ module.exports = angular
   .module('spinnaker.core.delivery.group.executionGroup.directive', [
     require('../filter/executionFilter.service.js'),
     require('../filter/executionFilter.model.js'),
-    require('../../confirmationModal/confirmationModal.service.js'),
     require('../triggers/triggersTag.directive.js'),
     require('./execution/execution.directive.js'),
   ])
@@ -26,7 +25,7 @@ module.exports = angular
     };
   })
   .controller('executionGroupCtrl', function($scope, $timeout, _, $state, settings, $stateParams, $uibModal, executionService, collapsibleSectionStateCache,
-                                               ExecutionFilterModel, pipelineConfigService, confirmationModalService, $location) {
+                                               ExecutionFilterModel, pipelineConfigService) {
     this.showDetails = function(executionId) {
       return executionId === $stateParams.executionId &&
         $state.includes('**.execution.**');


### PR DESCRIPTION
For now, if the call fails to the /report/reservation endpoint in Gate, the directive will disappear. Once we have the feature flagging build stuff sorted out, we'll throw an `ng-if` on the directive.
