### PR TITLE
only short-circuit filter application when navigating to child states

### DIFF
--- a/app/scripts/modules/core/cluster/filter/clusterFilter.model.js
+++ b/app/scripts/modules/core/cluster/filter/clusterFilter.model.js
@@ -81,7 +81,7 @@ module.exports = angular
     });
 
     $rootScope.$on('$stateChangeSuccess', function(event, toState, toParams, fromState) {
-      if (isClusterStateOrChild(toState.name)) {
+      if (movingToClusterState(toState) && isClusterStateOrChild(fromState.name)) {
         filterModel.applyParamsToUrl();
         return;
       }

--- a/app/scripts/modules/core/delivery/filter/executionFilter.model.js
+++ b/app/scripts/modules/core/delivery/filter/executionFilter.model.js
@@ -114,7 +114,7 @@ module.exports = angular
     });
 
     $rootScope.$on('$stateChangeSuccess', function(event, toState, toParams, fromState) {
-      if (isExecutionStateOrChild(toState.name)) {
+      if (movingToExecutionsState(toState) && isExecutionStateOrChild(fromState.name)) {
         filterModel.applyParamsToUrl();
         return;
       }

--- a/app/scripts/modules/core/loadBalancer/filter/loadBalancer.filter.model.js
+++ b/app/scripts/modules/core/loadBalancer/filter/loadBalancer.filter.model.js
@@ -77,7 +77,7 @@ module.exports = angular
     });
 
     $rootScope.$on('$stateChangeSuccess', function(event, toState, toParams, fromState) {
-      if (isLoadBalancerStateOrChild(toState.name)) {
+      if (isLoadBalancerStateOrChild(toState.name) && isLoadBalancerStateOrChild(fromState.name)) {
         filterModel.applyParamsToUrl();
         return;
       }

--- a/app/scripts/modules/core/securityGroup/filter/securityGroup.filter.model.js
+++ b/app/scripts/modules/core/securityGroup/filter/securityGroup.filter.model.js
@@ -75,7 +75,7 @@ module.exports = angular
     });
 
     $rootScope.$on('$stateChangeSuccess', function(event, toState, toParams, fromState) {
-      if (isSecurityGroupStateOrChild(toState.name)) {
+      if (isSecurityGroupStateOrChild(toState.name) && isSecurityGroupStateOrChild(fromState.name)) {
         filterModel.applyParamsToUrl();
         return;
       }
@@ -83,7 +83,6 @@ module.exports = angular
         if (shouldRouteToSavedState(toParams, fromState)) {
           filterModel.restoreState(toParams);
         }
-
         if (fromSecurityGroupsState(fromState) && !filterModel.hasSavedState(toParams)) {
           filterModel.clearFilters();
         }


### PR DESCRIPTION
otherwise, filters with shared names (e.g. search) get copied into sibling states when navigating the applications via top-level navigation.
