### PR TITLE
surface nested failures when creating an application

### DIFF
--- a/app/scripts/modules/core/application/modal/newapplication.html
+++ b/app/scripts/modules/core/application/modal/newapplication.html
@@ -191,9 +191,13 @@
       </div>
     </div>
 
-    <div class="form-group row slide-in animated" ng-if="newAppModal.errorMsgs">
-      <div class="col-sm-9 col-sm-offset-3 error-message" ng-repeat="errorMsg in newAppModal.errorMsgs">
-        {{errorMsg}}
+    <div class="form-group row slide-in animated" ng-if="newAppModal.errorMsgs.length">
+      <div class="col-md-12">
+        <div class="alert alert-danger">
+          <div ng-repeat="errorMsg in newAppModal.errorMsgs">
+            <status-glyph item="{isFailed: true}"></status-glyph> {{errorMsg}}
+          </div>
+        </div>
       </div>
     </div>
 

--- a/app/scripts/modules/core/application/service/applications.write.service.js
+++ b/app/scripts/modules/core/application/service/applications.write.service.js
@@ -11,7 +11,6 @@ module.exports = angular
 
     function createApplication(app, account) {
       return taskExecutor.executeTask({
-        suppressNotification: true,
         job: [
           {
             type: 'createApplication',
@@ -48,7 +47,6 @@ module.exports = angular
 
       accounts.forEach(function(account) {
         taskList.push(taskExecutor.executeTask({
-          suppressNotification: true,
           job: [
             {
               type: 'updateApplication',
@@ -91,7 +89,6 @@ module.exports = angular
       accounts.forEach(function(account) {
         taskList.push(
           {
-            suppressNotification: true,
             job: [
               {
                 type: 'deleteApplication',


### PR DESCRIPTION
If the task itself fails, we should surface those exceptions. Also, we should rely on the tasks.api.js method to get the failure message.
