### PR TITLE
Adds 'checkmap' directive to make zone layout prettier

### DIFF
--- a/app/scripts/modules/core/forms/checkmap/checkmap.directive.html
+++ b/app/scripts/modules/core/forms/checkmap/checkmap.directive.html
@@ -1,0 +1,13 @@
+<ul class="checkmap">
+  <li ng-repeat="(key, valList) in itemMap" class="checkmap-group">
+    <ul class="checkmap">
+      <li class="checkmap-header">{{key}}</li>
+      <li ng-repeat="item in valList">
+        <label>
+          <input type="checkbox" ng-checked="!!modelHolder[key][item]" ng-model="modelHolder[key][item]" ng-change="updateSelectedItems()">
+          {{item}}
+        </label>
+      </li>
+    </ul>
+  </li>
+</ul>

--- a/app/scripts/modules/core/forms/checkmap/checkmap.directive.js
+++ b/app/scripts/modules/core/forms/checkmap/checkmap.directive.js
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2015 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+let angular = require('angular');
+
+module.exports = angular.module('spinnaker.core.forms.checkmap.checkmap.directive', [
+  require('../../utils/lodash.js'),
+])
+  .directive('checkmap', function(_) {
+    return {
+      restrict: 'E',
+      templateUrl: require('./checkmap.directive.html'),
+      scope: {
+        // The map to display, key --> list of displayable items.
+        itemMap: '=',
+        // Array of selected items from the itemMap, regardless of key.
+        selectedItems: '=',
+        onChange: '&'
+      },
+      link: function(scope) {
+        function initializeModelHolder() {
+          scope.selectedItems = scope.selectedItems || [];
+          // modelHolder is a map of key --> val --> "checked" boolean.
+          scope.modelHolder = {};
+          _.forEach(scope.itemMap, function(itemList, key) {
+            scope.modelHolder[key] = {};
+            _.forEach(itemList, function(item) {
+              scope.modelHolder[key][item] = _.includes(scope.selectedItems, item);
+            });
+          });
+
+          _.forEach(scope.selectedItems, function(selectedItem) {
+            _.forEach(scope.modelHolder, function(itemList, key) {
+              if (_.includes(itemList, selectedItem)) {
+                scope.modelHolder[key][selectedItem] = true;
+              }
+            });
+          });
+        }
+
+        function updateSelectedItems() {
+          var newSelectedItems = [];
+          _.forEach(scope.modelHolder, function(valMap) {
+            _.forEach(valMap, function(selected, item) {
+              if (selected) {
+                newSelectedItems.push(item);
+              }
+            });
+          });
+
+
+          angular.copy(newSelectedItems, scope.selectedItems);
+
+          if (scope.onChange) {
+            scope.$evalAsync(scope.onChange);
+          }
+        }
+
+        scope.updateSelectedItems = updateSelectedItems;
+
+        scope.$watch('selectedItems', initializeModelHolder);
+      }
+    };
+  }).name;

--- a/app/scripts/modules/core/forms/checkmap/checkmap.directive.spec.js
+++ b/app/scripts/modules/core/forms/checkmap/checkmap.directive.spec.js
@@ -1,0 +1,50 @@
+'use strict';
+
+describe('Directives: checkmap', function () {
+  require('./checkmap.directive.html');
+
+  beforeEach(
+    window.module(
+      require('./checkmap.directive.js')
+    )
+  );
+
+  beforeEach(window.inject(function ($rootScope, $compile) {
+    this.scope = $rootScope.$new();
+    this.compile = $compile;
+  }));
+
+  it('updates selections when changed', function() {
+    var scope = this.scope,
+      compile = this.compile;
+
+    scope.itemMap = {
+      alphabet : ['a', 'b', 'c', 'd']
+    };
+
+    scope.selectedItems = ['a', 'b', 'c'];
+
+    var checkmap = compile('<checkmap item-map="itemMap" selected-items="selectedItems"></checkmap>')(scope);
+
+    scope.$apply();
+
+    // Initial state check.
+    expect(checkmap.find('li.checkmap-header').size()).toBe(1);
+    expect(checkmap.find('input').size()).toBe(4);
+    expect(checkmap.find('input:checked').size()).toBe(3);
+
+    scope.selectedItems = ['b', 'd'];
+
+    scope.$digest();
+
+    expect(checkmap.find('input').size()).toBe(4);
+    expect(checkmap.find('input:checked').size()).toBe(2);
+
+    checkmap.find('input:checked')[0].click();
+    scope.$digest();
+
+    expect(checkmap.find('input:checked').size()).toBe(1);
+    expect(scope.selectedItems).toEqual(['d'])
+
+  });
+});

--- a/app/scripts/modules/core/forms/forms.module.js
+++ b/app/scripts/modules/core/forms/forms.module.js
@@ -5,4 +5,5 @@ let angular = require('angular');
 module.exports = angular.module('spinnaker.core.forms', [
   require('./autofocus/autofocus.directive.js'),
   require('./checklist/checklist.directive.js'),
+  require('./checkmap/checkmap.directive.js'),
 ]).name;

--- a/app/scripts/modules/core/pipeline/config/stages/resizeAsg/gce/gceResizeAsgStage.js
+++ b/app/scripts/modules/core/pipeline/config/stages/resizeAsg/gce/gceResizeAsgStage.js
@@ -41,11 +41,11 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.gce.resizeAsgStag
       $scope.viewState.accountsLoaded = true;
     });
 
-    $scope.zones = ['us-central1-a', 'us-central1-b', 'us-central1-c'];
+    $scope.zones = {"us-central1": ['us-central1-a', 'us-central1-b', 'us-central1-c']};
 
     ctrl.accountUpdated = function () {
       accountService.getRegionsForAccount(stage.credentials).then(function(regions) {
-        $scope.zones = _.flatten(_.map(regions, (zones) => { return zones; } ));
+        $scope.zones = regions;
         $scope.zonesLoaded = true;
       });
     };

--- a/app/scripts/modules/core/pipeline/config/stages/resizeAsg/gce/resizeAsgStage.html
+++ b/app/scripts/modules/core/pipeline/config/stages/resizeAsg/gce/resizeAsgStage.html
@@ -27,7 +27,7 @@
         <p class="form-control-static">(Select an Account)</p>
       </div>
       <div class="col-md-6" ng-if="stage.credentials">
-        <checklist items="zones" model="stage.zones" inline="true" include-select-all-button="false"></checklist>
+        <checkmap item-map="zones" selected-items="stage.zones"></checkmap>
       </div>
     </div>
     <div class="form-group">

--- a/app/scripts/modules/core/presentation/main.less
+++ b/app/scripts/modules/core/presentation/main.less
@@ -1152,6 +1152,31 @@ body > .select2-container.open {
   }
 }
 
+ul.checkmap {
+  padding-left: 0;
+  li {
+    list-style-type: none;
+    label {
+      font-weight: normal;
+    }
+  }
+  ul {
+    padding-left: 0;
+    margin-bottom: 0;
+  }
+}
+
+.checkmap-group {
+  display: inline-table;
+  min-width: 120px;
+}
+
+.checkmap-header {
+  font-weight: bold;
+  text-decoration: underline;
+  padding-left: 16px;
+}
+
 .break-word {
   word-break: break-all;
 }


### PR DESCRIPTION
@duftler @anotherchrisberry PTAL.

'checkmap' is an expansion of a 'checklist'. It takes a map of key --> lists. It makes the key a header, and enumerates the list as a checklist. 

![nk5k9zhhwko](https://cloud.githubusercontent.com/assets/13141550/11075876/987cb768-87c5-11e5-9965-d9719e8c4acd.png)
