### PR TITLE
filter search images by region

### DIFF
--- a/app/scripts/modules/amazon/serverGroup/configure/serverGroupCommandBuilder.service.js
+++ b/app/scripts/modules/amazon/serverGroup/configure/serverGroupCommandBuilder.service.js
@@ -61,7 +61,6 @@ module.exports = angular.module('spinnaker.aws.serverGroupCommandBuilder.service
             securityGroups: [],
             viewState: {
               instanceProfile: 'custom',
-              allImageSelection: null,
               useAllImageSelection: false,
               useSimpleCapacity: true,
               usePreferredZones: true,
@@ -195,7 +194,6 @@ module.exports = angular.module('spinnaker.aws.serverGroupCommandBuilder.service
           suspendedProcesses: (serverGroup.asg.suspendedProcesses || []).map((process) => process.processName),
           viewState: {
             instanceProfile: asyncData.instanceProfile,
-            allImageSelection: null,
             useAllImageSelection: false,
             useSimpleCapacity: serverGroup.asg.minSize === serverGroup.asg.maxSize,
             usePreferredZones: usePreferredZones,

--- a/app/scripts/modules/amazon/serverGroup/configure/wizard/CloneServerGroup.aws.controller.js
+++ b/app/scripts/modules/amazon/serverGroup/configure/wizard/CloneServerGroup.aws.controller.js
@@ -164,7 +164,7 @@ module.exports = angular.module('spinnaker.aws.cloneServerGroup.controller', [
 
     this.isValid = function () {
       return $scope.command &&
-        ($scope.command.viewState.useAllImageSelection ? $scope.command.viewState.allImageSelection !== null : $scope.command.amiName !== null) &&
+        ($scope.command.amiName !== null) &&
         ($scope.command.application !== null) &&
         ($scope.command.credentials !== null) && ($scope.command.instanceType !== null) &&
         ($scope.command.region !== null) && ($scope.command.availabilityZones !== null) &&

--- a/app/scripts/modules/amazon/serverGroup/configure/wizard/basicSettings.html
+++ b/app/scripts/modules/amazon/serverGroup/configure/wizard/basicSettings.html
@@ -50,24 +50,20 @@
           <help-field key="aws.serverGroup.imageName"></help-field>
         </div>
         <div class="col-md-9" ng-if="command.viewState.useAllImageSelection">
-          <ui-select ng-model="command.viewState.allImageSelection"
+          <ui-select ng-model="command.amiName"
                      class="form-control input-sm"
                      on-select="basicSettingsCtrl.imageChanged($item)"
                      required>
             <ui-select-match placeholder="Search for an image...">{{$select.selected.imageName || $select.selected}}</ui-select-match>
-            <ui-select-choices repeat="result.imageName as result in allImageSearchResults track by $index"
+            <ui-select-choices repeat="result.imageName as result in command.backingData.filtered.images track by $index"
                                refresh="basicSettingsCtrl.searchImages($select.search)"
                                ui-disable-choice="result.message"
-                               reset-search-input="false"
-                               refresh-delay="0">
+                               reset-search-input="false">
               <span ng-bind-html="result.message"></span>
               <span ng-bind-html="result.imageName | highlight: $select.search"></span>
               <span ng-if="result.ami">(<span ng-bind-html="result.ami | highlight: $select.search"></span>)</span>
             </ui-select-choices>
           </ui-select>
-          <span ng-if="command.backingData.filtered.images.length > 0">
-            <help-field key="aws.serverGroup.filterImages"></help-field>
-          </span>
         </div>
         <div class="col-md-9" ng-if="!command.viewState.useAllImageSelection">
           <ui-select class="form-control input-sm" required
@@ -79,7 +75,7 @@
               (<span ng-bind-html="image.ami | highlight: $select.search"></span>)
             </ui-select-choices>
           </ui-select>
-          <a href ng-click="command.viewState.useAllImageSelection = true">Search All Images</a><help-field key="aws.serverGroup.allImages"></help-field>
+          <a href ng-click="basicSettingsCtrl.enableAllImageSearch()">Search All Images</a><help-field key="aws.serverGroup.allImages"></help-field>
         </div>
       </div>
       <deployment-strategy-selector label-columns="3" field-columns="9" ng-if="!command.viewState.disableStrategySelection && command.selectedProvider" command="command"></deployment-strategy-selector>

--- a/app/scripts/modules/amazon/serverGroup/serverGroup.transformer.js
+++ b/app/scripts/modules/amazon/serverGroup/serverGroup.transformer.js
@@ -29,9 +29,6 @@ module.exports = angular.module('spinnaker.aws.serverGroup.transformer', [
       if (base.viewState.mode !== 'clone') {
         delete command.source;
       }
-      if (base.viewState.useAllImageSelection) {
-        command.amiName = base.viewState.allImageSelection;
-      }
       command.cloudProvider = 'aws';
       command.availabilityZones = {};
       command.availabilityZones[command.region] = base.availabilityZones;

--- a/app/scripts/modules/amazon/serverGroup/serverGroup.transformer.spec.js
+++ b/app/scripts/modules/amazon/serverGroup/serverGroup.transformer.spec.js
@@ -53,22 +53,6 @@ describe('awsServerGroupTransformer', function () {
 
   describe('command transforms', function () {
 
-    it('sets amiName from allImageSelection', function () {
-      var command = {
-        viewState: {
-          mode: 'create',
-          useAllImageSelection: true,
-          allImageSelection: 'something-packagebase',
-        },
-        application: { name: 'theApp'}
-      };
-
-      var transformed = transformer.convertServerGroupCommandToDeployConfiguration(command);
-
-      expect(transformed.amiName).toBe('something-packagebase');
-
-    });
-
     it('removes subnetType property when null', function () {
       var command = {
         viewState: {

--- a/app/scripts/modules/core/serverGroup/configure/common/basicSettingsMixin.controller.js
+++ b/app/scripts/modules/core/serverGroup/configure/common/basicSettingsMixin.controller.js
@@ -12,42 +12,6 @@ module.exports = angular
     require('../../../image/image.reader.js')
   ])
   .controller('BasicSettingsMixin', function ($scope, RxService, imageReader, namingService, $uibModalStack, $state, _) {
-    function searchImages(q) {
-      $scope.allImageSearchResults = [
-        {
-          message: '<span class="glyphicon glyphicon-spinning glyphicon-asterisk"></span> Finding results matching "' + q + '"...'
-        }
-      ];
-      return RxService.Observable.fromPromise(
-        imageReader.findImages({
-          provider: $scope.command.selectedProvider,
-          q: q,
-          region: $scope.command.region
-        })
-      );
-    }
-
-    var imageSearchResultsStream = new RxService.Subject();
-
-    imageSearchResultsStream
-      .throttle(250)
-      .flatMapLatest(searchImages)
-      .subscribe(function (data) {
-        $scope.allImageSearchResults = data.map(function(image) {
-          if (image.message && !image.imageName) {
-            return image;
-          }
-          return {
-            imageName: image.imageName,
-            ami: image.amis && image.amis[$scope.command.region] ? image.amis[$scope.command.region][0] : null,
-            virtualizationType: image.attributes ? image.attributes.virtualizationType : null,
-          };
-        });
-      });
-
-    this.searchImages = function(q) {
-      imageSearchResultsStream.onNext(q);
-    };
 
     this.createsNewCluster = function() {
       var name = this.getNamePreview();


### PR DESCRIPTION
Move image search functionality out of mixin, since it is only used by Amazon.

This fixes an issue where changing the region after selecting an image via search might not remove the selection if it's not available in the newly-selected region.
