### PR TITLE
Remove CF load balancer editing

### DIFF
--- a/app/scripts/modules/cloudfoundry/loadBalancer/configure/editLoadBalancer.html
+++ b/app/scripts/modules/cloudfoundry/loadBalancer/configure/editLoadBalancer.html
@@ -1,2 +1,0 @@
-<modal-wizard heading="Edit {{loadBalancer.name}}: {{loadBalancer.region}}: {{loadBalancer.credentials}}">
-</modal-wizard>

--- a/app/scripts/modules/cloudfoundry/loadBalancer/details/LoadBalancerDetailsCtrl.js
+++ b/app/scripts/modules/cloudfoundry/loadBalancer/details/LoadBalancerDetailsCtrl.js
@@ -67,18 +67,6 @@ module.exports = angular.module('spinnaker.loadBalancer.cf.details.controller', 
 
     extractLoadBalancer().then(() => application.registerAutoRefreshHandler(extractLoadBalancer, $scope));
 
-    this.editLoadBalancer = function editLoadBalancer() {
-      $uibModal.open({
-        templateUrl: require('../configure/editLoadBalancer.html'),
-        controller: 'cfCreateLoadBalancerCtrl as ctrl',
-        resolve: {
-          application: function() { return application; },
-          loadBalancer: function() { return angular.copy($scope.loadBalancer); },
-          isNew: function() { return false; }
-        }
-      });
-    };
-
     this.deleteLoadBalancer = function deleteLoadBalancer() {
       if ($scope.loadBalancer.instances && $scope.loadBalancer.instances.length) {
         return;

--- a/app/scripts/modules/cloudfoundry/loadBalancer/details/loadBalancerDetails.html
+++ b/app/scripts/modules/cloudfoundry/loadBalancer/details/loadBalancerDetails.html
@@ -32,7 +32,6 @@
             Load Balancer Actions <span class="caret"></span>
           </button>
           <ul class="dropdown-menu" role="menu">
-            <li><a href ng-click="ctrl.editLoadBalancer()">Edit Load Balancer</a></li>
             <li ng-if="!loadBalancer.instances.length"><a href ng-click="ctrl.deleteLoadBalancer()">Delete Load Balancer</a></li>
             <li ng-if="loadBalancer.instances.length" class="disabled" uib-tooltip="You must detach all instances before you can delete this load balancer.">
               <a href ng-click="ctrl.deleteLoadBalancer()">Delete Load Balancer</a>

--- a/app/scripts/modules/cloudfoundry/loadBalancer/loadBalancer.transformer.js
+++ b/app/scripts/modules/cloudfoundry/loadBalancer/loadBalancer.transformer.js
@@ -83,8 +83,15 @@ module.exports = angular.module('spinnaker.cf.loadBalancer.transformer', [
     }
 
     function convertLoadBalancerForEditing(loadBalancer) {
-      // TODO: fill in
-      return {};
+      return {
+        provider: 'cf',
+        stack: loadBalancer.stack,
+        detail: loadBalancer.detail,
+        credentials: loadBalancer.credentials,
+        region: loadBalancer.region,
+        healthCheckProtocol: loadBalancer.healthCheckProtocol,
+        healthCheckPort: loadBalancer.healthCheckPort
+      };
     }
 
     return {


### PR DESCRIPTION
Cloud Foundry load balancers are simple routes applied to multiple apps, so there is nothing to edit. You create, delete, and map them.
