### PR TITLE
show spinner while all*Ctrl is initializing

### DIFF
--- a/app/scripts/modules/core/cluster/allClusters.controller.js
+++ b/app/scripts/modules/core/cluster/allClusters.controller.js
@@ -17,10 +17,11 @@ module.exports = angular.module('spinnaker.core.cluster.allClusters.controller',
   require('angular-ui-bootstrap'),
   require('../cloudProvider/cloudProvider.registry.js'),
 ])
-  .controller('AllClustersCtrl', function($scope, app, $uibModal, providerSelectionService, _, clusterFilterService,
+  .controller('AllClustersCtrl', function($scope, app, $uibModal, $timeout, providerSelectionService, _, clusterFilterService,
                                           ClusterFilterModel, serverGroupCommandBuilder, cloudProviderRegistry) {
 
     ClusterFilterModel.activate();
+    this.initialized = false;
 
     $scope.sortFilter = ClusterFilterModel.sortFilter;
 
@@ -48,16 +49,17 @@ module.exports = angular.module('spinnaker.core.cluster.allClusters.controller',
       });
     }
 
-    function updateClusterGroups() {
+    let updateClusterGroups = () => {
       ClusterFilterModel.applyParamsToUrl();
-      $scope.$evalAsync(function() {
+      $scope.$evalAsync(() => {
           clusterFilterService.updateClusterGroups(app);
+          $scope.groups = ClusterFilterModel.groups;
+          $scope.tags = ClusterFilterModel.tags;
+          // Timeout because the updateClusterGroups method is debounced by 25ms
+          $timeout(() => { this.initialized = true; }, 50);
         }
       );
-
-      $scope.groups = ClusterFilterModel.groups;
-      $scope.tags = ClusterFilterModel.tags;
-    }
+    };
 
     this.clearFilters = function() {
       clusterFilterService.clearFilters();

--- a/app/scripts/modules/core/cluster/groupings.html
+++ b/app/scripts/modules/core/cluster/groupings.html
@@ -1,4 +1,4 @@
-<div>
+<div ng-if="allClusters.initialized">
   <div ng-repeat="group in groups" class="rollup">
     <cluster-pod ng-repeat="subgroup in group.subgroups"
                  grouping="subgroup"
@@ -10,4 +10,7 @@
   <div ng-if="groups.length === 0">
     <h4 class="text-center">No server groups match the filters you've selected.</h4>
   </div>
+</div>
+<div ng-if="!allClusters.initialized">
+  <h3 us-spinner="{radius:30, width:8, length: 16}"></h3>
 </div>

--- a/app/scripts/modules/core/loadBalancer/AllLoadBalancersCtrl.js
+++ b/app/scripts/modules/core/loadBalancer/AllLoadBalancersCtrl.js
@@ -12,10 +12,12 @@ module.exports = angular.module('spinnaker.core.loadBalancer.controller', [
   require('../filterModel/filter.tags.directive.js'),
   require('../cloudProvider/cloudProvider.registry.js'),
 ])
-  .controller('AllLoadBalancersCtrl', function($scope, $uibModal, _, providerSelectionService, cloudProviderRegistry,
+  .controller('AllLoadBalancersCtrl', function($scope, $uibModal, _, $timeout,
+                                               providerSelectionService, cloudProviderRegistry,
                                                LoadBalancerFilterModel, loadBalancerFilterService, app ) {
 
     LoadBalancerFilterModel.activate();
+    this.initialized = false;
 
     $scope.application = app;
 
@@ -42,14 +44,16 @@ module.exports = angular.module('spinnaker.core.loadBalancer.controller', [
       updateLoadBalancerGroups();
     };
 
-    function updateLoadBalancerGroups() {
+    let updateLoadBalancerGroups = () => {
       LoadBalancerFilterModel.applyParamsToUrl();
-      $scope.$evalAsync(function() {
+      $scope.$evalAsync(() => {
         loadBalancerFilterService.updateLoadBalancerGroups(app);
         $scope.groups = LoadBalancerFilterModel.groups;
         $scope.tags = LoadBalancerFilterModel.tags;
+        // Timeout because the updateLoadBalancerGroups method is debounced by 25ms
+        $timeout(() => { this.initialized = true; }, 50);
       });
-    }
+    };
 
     this.createLoadBalancer = function createLoadBalancer() {
       providerSelectionService.selectProvider(app).then(function(selectedProvider) {

--- a/app/scripts/modules/core/loadBalancer/groupings.html
+++ b/app/scripts/modules/core/loadBalancer/groupings.html
@@ -1,4 +1,4 @@
-<div>
+<div ng-if="ctrl.initialized">
   <div ng-repeat="group in groups" class="rollup">
     <load-balancer-pod ng-repeat="subgroup in group.subgroups"
                        grouping="subgroup"
@@ -8,4 +8,7 @@
   <div ng-if="groups.length === 0">
     <h4 class="text-center">No load balancers match the filters you've selected.</h4>
   </div>
+</div>
+<div ng-if="!ctrl.initialized">
+  <h3 us-spinner="{radius:30, width:8, length: 16}"></h3>
 </div>

--- a/app/scripts/modules/core/securityGroup/AllSecurityGroupsCtrl.js
+++ b/app/scripts/modules/core/securityGroup/AllSecurityGroupsCtrl.js
@@ -11,11 +11,12 @@ module.exports = angular.module('spinnaker.core.securityGroup.all.controller', [
   require('angular-ui-bootstrap'),
   require('../cloudProvider/cloudProvider.registry.js'),
 ])
-  .controller('AllSecurityGroupsCtrl', function($scope, app, $uibModal, _, providerSelectionService, settings,
-                                                cloudProviderRegistry,
+  .controller('AllSecurityGroupsCtrl', function($scope, app, $uibModal, _, $timeout,
+                                                providerSelectionService, settings, cloudProviderRegistry,
                                                 SecurityGroupFilterModel, securityGroupFilterService) {
 
     SecurityGroupFilterModel.activate();
+    this.initialized = false;
 
     $scope.application = app;
 
@@ -43,14 +44,16 @@ module.exports = angular.module('spinnaker.core.securityGroup.all.controller', [
       updateSecurityGroups();
     };
 
-    function updateSecurityGroups() {
+    let updateSecurityGroups = () => {
       SecurityGroupFilterModel.applyParamsToUrl();
-      $scope.$evalAsync(function () {
+      $scope.$evalAsync(() => {
         securityGroupFilterService.updateSecurityGroups(app);
         $scope.groups = SecurityGroupFilterModel.groups;
         $scope.tags = SecurityGroupFilterModel.tags;
+        // Timeout because the updateSecurityGroups method is debounced by 25ms
+        $timeout(() => { this.initialized = true; }, 50);
       });
-    }
+    };
 
     this.createSecurityGroup = function createSecurityGroup() {
       providerSelectionService.selectProvider(app).then(function(selectedProvider) {

--- a/app/scripts/modules/core/securityGroup/groupings.html
+++ b/app/scripts/modules/core/securityGroup/groupings.html
@@ -1,4 +1,4 @@
-<div>
+<div ng-if="ctrl.initialized">
   <div ng-repeat="group in groups" class="rollup">
     <security-group-pod ng-repeat="subgroup in group.subgroups"
                         grouping="subgroup"
@@ -8,4 +8,7 @@
   <div ng-if="groups.length === 0">
     <h4 class="text-center">No security groups match the filters you've selected.</h4>
   </div>
+</div>
+<div ng-if="!ctrl.initialized">
+  <h3 us-spinner="{radius:30, width:8, length: 16}"></h3>
 </div>


### PR DESCRIPTION
This gets rid of the "No ***\* matches the selected filters" message that flashes while the view is initializing.
