### PR TITLE
only show provider selection modal if providers support it

### DIFF
--- a/app/scripts/modules/core/cloudProvider/cloudProvider.registry.js
+++ b/app/scripts/modules/core/cloudProvider/cloudProvider.registry.js
@@ -43,6 +43,10 @@ module.exports = angular.module('spinnaker.core.cloudProvider.registry', [
       current[lastKey] = val;
     }
 
+    function hasValue(provider, key) {
+      return !!getProvider(provider) && getValue(provider, key) !== null;
+    }
+
     function getValue(provider, key) {
       if (!key) {
         return null;
@@ -76,6 +80,7 @@ module.exports = angular.module('spinnaker.core.cloudProvider.registry', [
       return {
         getProvider: getProvider,
         getValue: getValue,
+        hasValue: hasValue,
         overrideValue: overrideValue,
         listRegisteredProviders: listRegisteredProviders,
       };

--- a/app/scripts/modules/core/cloudProvider/cloudProvider.registry.spec.js
+++ b/app/scripts/modules/core/cloudProvider/cloudProvider.registry.spec.js
@@ -69,5 +69,37 @@ describe('cloudProviderRegistry: API', function() {
     }));
   });
 
+  describe('hasValue', function () {
+    beforeEach(function() {
+      this.config = {
+        key: 'a',
+        nested: {
+          good: 'nice',
+          falsy: false,
+          nully: null,
+          zero: 0,
+        }
+      };
+    });
+
+    it('returns true on simple or nested properties', function() {
+      configurer.registerProvider('aws', this.config);
+      expect(configurer.$get().hasValue('aws', 'key')).toBe(true);
+      expect(configurer.$get().hasValue('aws', 'nested')).toBe(true);
+      expect(configurer.$get().hasValue('aws', 'nested.good')).toBe(true);
+      expect(configurer.$get().hasValue('aws', 'nested.falsy')).toBe(true);
+      expect(configurer.$get().hasValue('aws', 'nested.zero')).toBe(true);
+    });
+
+    it('returns false on null properties, non-existent properties or non-existent providers', function () {
+      configurer.registerProvider('aws', this.config);
+      expect(configurer.$get().hasValue('aws', 'nested.nully')).toBe(false);
+      expect(configurer.$get().hasValue('aws', 'nonexistent')).toBe(false);
+      expect(configurer.$get().hasValue('aws', 'definitely.nonexistent')).toBe(false);
+      expect(configurer.$get().hasValue('boo', 'bar')).toBe(false);
+      expect(configurer.$get().hasValue('boo', 'bar.baz')).toBe(false);
+    });
+  });
+
 
 });

--- a/app/scripts/modules/core/cloudProvider/providerSelection/providerSelection.service.js
+++ b/app/scripts/modules/core/cloudProvider/providerSelection/providerSelection.service.js
@@ -6,11 +6,16 @@ module.exports = angular.module('spinnaker.providerSelection.service', [
   require('../../account/account.service.js'),
   require('../../config/settings.js'),
   require('../../utils/lodash.js'),
+  require('../cloudProvider.registry.js'),
 ])
-  .factory('providerSelectionService', function($uibModal, $q, _, accountService, settings) {
-    function selectProvider(application) {
+  .factory('providerSelectionService', function($uibModal, $q, _, accountService, settings, cloudProviderRegistry) {
+    function selectProvider(application, feature) {
       return accountService.listProviders(application).then((providers) => {
         var provider;
+
+        if (feature) {
+          providers = providers.filter((provider) => cloudProviderRegistry.hasValue(provider, feature));
+        }
 
         if (providers.length > 1) {
           provider = $uibModal.open({

--- a/app/scripts/modules/core/cluster/allClusters.controller.js
+++ b/app/scripts/modules/core/cluster/allClusters.controller.js
@@ -67,7 +67,7 @@ module.exports = angular.module('spinnaker.core.cluster.allClusters.controller',
     };
 
     this.createServerGroup = function createServerGroup() {
-      providerSelectionService.selectProvider(app).then(function(selectedProvider) {
+      providerSelectionService.selectProvider(app, 'serverGroup').then(function(selectedProvider) {
         let provider = cloudProviderRegistry.getValue(selectedProvider, 'serverGroup');
         $uibModal.open({
           templateUrl: provider.cloneServerGroupTemplateUrl,

--- a/app/scripts/modules/core/loadBalancer/AllLoadBalancersCtrl.js
+++ b/app/scripts/modules/core/loadBalancer/AllLoadBalancersCtrl.js
@@ -56,7 +56,7 @@ module.exports = angular.module('spinnaker.core.loadBalancer.controller', [
     };
 
     this.createLoadBalancer = function createLoadBalancer() {
-      providerSelectionService.selectProvider(app).then(function(selectedProvider) {
+      providerSelectionService.selectProvider(app, 'loadBalancer').then(function(selectedProvider) {
         let provider = cloudProviderRegistry.getValue(selectedProvider, 'loadBalancer');
         $uibModal.open({
           templateUrl: provider.createLoadBalancerTemplateUrl,

--- a/app/scripts/modules/core/securityGroup/AllSecurityGroupsCtrl.js
+++ b/app/scripts/modules/core/securityGroup/AllSecurityGroupsCtrl.js
@@ -56,7 +56,7 @@ module.exports = angular.module('spinnaker.core.securityGroup.all.controller', [
     };
 
     this.createSecurityGroup = function createSecurityGroup() {
-      providerSelectionService.selectProvider(app).then(function(selectedProvider) {
+      providerSelectionService.selectProvider(app, 'securityGroup').then(function(selectedProvider) {
         let provider = cloudProviderRegistry.getValue(selectedProvider, 'securityGroup');
         var defaultCredentials = app.defaultCredentials || settings.providers[selectedProvider].defaults.account,
             defaultRegion = app.defaultRegion || settings.providers[selectedProvider].defaults.region;


### PR DESCRIPTION
God help me, it includes tests.

This will prevent the interstitial modal from appearing in a multi-provider configuration unless multiple providers support the feature, e.g. Titan does not support load balancers or security groups, so we will not present the modal if Titan and AWS are the configured providers.

Should be helpful for CF, since it sounds like it won't support one or both of those features...
