### PR TITLE
require az selector directive

### DIFF
--- a/app/scripts/modules/amazon/serverGroup/configure/wizard/capacity/ServerGroupCapacity.controller.js
+++ b/app/scripts/modules/amazon/serverGroup/configure/wizard/capacity/ServerGroupCapacity.controller.js
@@ -8,6 +8,7 @@ module.exports = angular.module('spinnaker.serverGroup.configure.aws.serverGroup
   require('./capacityFooter.directive.js'),
   require('./targetHealthyPercentageSelector.directive.js'),
   require('./azRebalanceSelector.directive.js'),
+  require('../availabilityZoneSelector.directive.js'),
 ])
   .controller('awsServerGroupCapacityCtrl', function($scope, modalWizardService) {
 


### PR DESCRIPTION
Well, this is missing in prod right now. Not sure how frequently used it is, since we haven't heard about it from users, but we should probably restore it so users can select AZs when creating a new ASG.
