### PR TITLE
tweak graph collision algorithm

### DIFF
--- a/app/scripts/modules/core/pipeline/config/graph/pipeline.graph.directive.js
+++ b/app/scripts/modules/core/pipeline/config/graph/pipeline.graph.directive.js
@@ -172,7 +172,15 @@ module.exports = angular.module('spinnaker.core.pipeline.config.graph.directive'
                   }
                   return 0;
                 },
-                // same highest parent, so sort by number of children (more first)
+                // same highest parent, prefer fewer terminal children if any
+                function(node) {
+                  return node.children.filter((child) => !child.children.length).length || 100;
+                },
+                // same highest parent, same number of terminal children, prefer fewer parents
+                function(node) {
+                  return node.parents.length;
+                },
+                // same highest parent, same number of terminal children and parents
                 function(node) {
                   return 1 - node.children.length;
                 },


### PR DESCRIPTION
A handful of changes to reduce the number of collisions when arranging graph nodes:
- always push terminal stages that are not at the end of the graph to the bottom row
- bubble nodes with fewer parents to the top
- oh who cares this only barely makes sense to me just trust me it's probably better
