### PR TITLE
validate jenkins stage exists before bake

### DIFF
--- a/app/scripts/modules/core/pipeline/config/stages/bake/aws/awsBakeStage.js
+++ b/app/scripts/modules/core/pipeline/config/stages/bake/aws/awsBakeStage.js
@@ -19,7 +19,11 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.aws.bakeStage', [
       defaultTimeoutMs: 60 * 60 * 1000, // 60 minutes
       validators: [
         { type: 'requiredField', fieldName: 'package', },
-        { type: 'requiredField', fieldName: 'regions', }
+        { type: 'requiredField', fieldName: 'regions', },
+        { type: 'stageOrTriggerBeforeType',
+          stageType: 'jenkins',
+          message: 'Bake stages should always have a Jenkins stage or trigger preceding them.<br> Otherwise, ' +
+        'Spinnaker will bake and deploy the most-recently built package.'}
       ],
     });
   })


### PR DESCRIPTION
This might be a little too opinionated, but until we get integration with other CI services, I'm going with it. It won't actually prevent a pipeline from being saved - or executed. It just warns the user that maybe this is not a great idea.