### PR TITLE
refactor provider settings to get data from credentials endpoint

### DIFF
--- a/app/scripts/modules/amazon/instance/details/instanceDetails.html
+++ b/app/scripts/modules/amazon/instance/details/instanceDetails.html
@@ -61,7 +61,7 @@
         <dd ng-if="!instance.launchTime">(Unknown)</dd>
         <dt>In:</dt>
         <dd>
-          <account-tag account="instance.account" provider="instance.provider" pad="right"></account-tag>
+          <account-tag account="instance.account" pad="right"></account-tag>
           {{instance.placement.availabilityZone || '(Unknown)'}}
         </dd>
         <dt>Type:</dt>

--- a/app/scripts/modules/amazon/loadBalancer/details/loadBalancerDetail.html
+++ b/app/scripts/modules/amazon/loadBalancer/details/loadBalancerDetail.html
@@ -49,7 +49,7 @@
         <dt>Created:</dt>
         <dd>{{loadBalancer.elb.createdTime | timestamp}}</dd>
         <dt>In:</dt>
-        <dd><account-tag account="loadBalancer.account" pad="right" provider="loadBalancer.type"></account-tag> {{loadBalancer.region}}</dd>
+        <dd><account-tag account="loadBalancer.account" pad="right"></account-tag> {{loadBalancer.region}}</dd>
         <dt>VPC:</dt>
         <dd><vpc-tag vpc-id="loadBalancer.elb.vpcid"></vpc-tag></dd>
       </dl>

--- a/app/scripts/modules/amazon/securityGroup/details/securityGroupDetail.html
+++ b/app/scripts/modules/amazon/securityGroup/details/securityGroupDetail.html
@@ -36,7 +36,7 @@
         <dt>ID:</dt>
         <dd>{{securityGroup.id}}</dd>
         <dt>Account:</dt>
-        <dd><account-tag account="securityGroup.accountName" provider="'aws'"></account-tag></dd>
+        <dd><account-tag account="securityGroup.accountName"></account-tag></dd>
         <dt>Region:</dt>
         <dd>{{securityGroup.region}}</dd>
         <dt>VPC:</dt>

--- a/app/scripts/modules/amazon/serverGroup/configure/serverGroupCommandBuilder.service.js
+++ b/app/scripts/modules/amazon/serverGroup/configure/serverGroupCommandBuilder.service.js
@@ -142,7 +142,7 @@ module.exports = angular.module('spinnaker.aws.serverGroupCommandBuilder.service
     function buildServerGroupCommandFromExisting(application, serverGroup, mode) {
       mode = mode || 'clone';
 
-      var preferredZonesLoader = accountService.getPreferredZonesByAccount();
+      var preferredZonesLoader = accountService.getPreferredZonesByAccount('aws');
       var subnetsLoader = subnetReader.listSubnets();
 
       var serverGroupName = namingService.parseServerGroupName(serverGroup.asg.autoScalingGroupName);

--- a/app/scripts/modules/amazon/serverGroup/configure/serverGroupConfiguration.service.js
+++ b/app/scripts/modules/amazon/serverGroup/configure/serverGroupConfiguration.service.js
@@ -58,7 +58,7 @@ module.exports = angular.module('spinnaker.aws.serverGroup.configure.service', [
         securityGroups: securityGroupReader.getAllSecurityGroups(),
         loadBalancers: loadBalancerReader.listLoadBalancers('aws'),
         subnets: subnetReader.listSubnets(),
-        preferredZones: accountService.getPreferredZonesByAccount(),
+        preferredZones: accountService.getPreferredZonesByAccount('aws'),
         keyPairs: keyPairsReader.listKeyPairs(),
         packageImages: imageLoader,
         instanceTypes: awsInstanceTypeService.getAllTypesByRegion(),

--- a/app/scripts/modules/amazon/serverGroup/configure/wizard/templateSelection.html
+++ b/app/scripts/modules/amazon/serverGroup/configure/wizard/templateSelection.html
@@ -17,7 +17,7 @@
                        class="form-control input-sm">
               <ui-select-match placeholder="Select...">
               <span ng-if="!$select.selected.label">
-                <account-tag account="$select.selected.account" provider="'aws'"></account-tag>
+                <account-tag account="$select.selected.account"></account-tag>
                 <span ng-if="$select.selected.serverGroup">{{$select.selected.serverGroupName}}</span>
                 ({{$select.selected.region}})
               </span>

--- a/app/scripts/modules/amazon/serverGroup/details/resize/resizeServerGroup.controller.js
+++ b/app/scripts/modules/amazon/serverGroup/details/resize/resizeServerGroup.controller.js
@@ -23,8 +23,13 @@ module.exports = angular.module('spinnaker.amazon.serverGroup.details.resize.con
     };
 
     $scope.verification = {
-      required: accountService.challengeDestructiveActions('aws', serverGroup.account)
+      required: false,
+      verifyAccount: ''
     };
+
+    accountService.challengeDestructiveActions(serverGroup.account).then((challenge) => {
+      $scope.verification.required = challenge;
+    });
 
     $scope.command = angular.copy($scope.currentSize);
     $scope.command.advancedMode = serverGroup.asg.minSize !== serverGroup.asg.maxSize;

--- a/app/scripts/modules/amazon/serverGroup/details/resize/verification.directive.html
+++ b/app/scripts/modules/amazon/serverGroup/details/resize/verification.directive.html
@@ -1,7 +1,7 @@
 <div class="row" ng-if="vm.verification.required">
   <div class="col-sm-12">
     <hr/>
-    <h4 class="confirmation-modal">Type the name of the account ( <account-tag account="vm.account" provider="'aws'"></account-tag> ) below to continue.</h4>
+    <h4 class="confirmation-modal">Type the name of the account ( <account-tag account="vm.account"></account-tag> ) below to continue.</h4>
   </div>
   <div class="col-sm-offset-1 col-sm-10">
     <div class="form-inline">

--- a/app/scripts/modules/amazon/serverGroup/details/serverGroupDetails.html
+++ b/app/scripts/modules/amazon/serverGroup/details/serverGroupDetails.html
@@ -100,7 +100,7 @@
         <dd>{{serverGroup.createdTime | timestamp}}</dd>
         <dt>In:</dt>
         <dd>
-          <account-tag account="serverGroup.account" provider="serverGroup.type" pad="right"></account-tag>
+          <account-tag account="serverGroup.account" pad="right"></account-tag>
 
           {{serverGroup.region}}
         </dd>

--- a/app/scripts/modules/cloudfoundry/instance/details/instanceDetails.html
+++ b/app/scripts/modules/cloudfoundry/instance/details/instanceDetails.html
@@ -60,7 +60,7 @@
         <dd ng-if="!instance.launchTime">(Unknown)</dd>
         <dt>In:</dt>
         <dd>
-          <account-tag account="instance.account" provider="instance.provider" pad="right"></account-tag>
+          <account-tag account="instance.account" pad="right"></account-tag>
           {{instance.placement.availabilityZone || '(Unknown)'}}
         </dd>
         <dt>Type:</dt>

--- a/app/scripts/modules/cloudfoundry/loadBalancer/details/loadBalancerDetails.html
+++ b/app/scripts/modules/cloudfoundry/loadBalancer/details/loadBalancerDetails.html
@@ -47,7 +47,7 @@
         <dt>Created:</dt>
         <dd>{{loadBalancer.elb.createdTime | timestamp}}</dd>
         <dt>In:</dt>
-        <dd><account-tag account="loadBalancer.account" pad="right" provider="loadBalancer.type"></account-tag> {{loadBalancer.region}}</dd>
+        <dd><account-tag account="loadBalancer.account" pad="right"></account-tag> {{loadBalancer.region}}</dd>
       </dl>
       <dl ng-class="InsightFilterStateModel.filtersExpanded ? '' : 'dl-horizontal dl-wide'">
         <dt>Zones:</dt>

--- a/app/scripts/modules/cloudfoundry/securityGroup/details/securityGroupDetails.html
+++ b/app/scripts/modules/cloudfoundry/securityGroup/details/securityGroupDetails.html
@@ -24,7 +24,7 @@
         <dt>ID:</dt>
         <dd>{{securityGroup.id}}</dd>
         <dt>Account:</dt>
-        <dd><account-tag account="securityGroup.accountName" provider="'cf'"></account-tag></dd>
+        <dd><account-tag account="securityGroup.accountName"></account-tag></dd>
         <dt>Region:</dt>
         <dd>{{securityGroup.region}}</dd>
         <dt>Target Tags:</dt>

--- a/app/scripts/modules/cloudfoundry/serverGroup/configure/wizard/templateSelection.html
+++ b/app/scripts/modules/cloudfoundry/serverGroup/configure/wizard/templateSelection.html
@@ -20,14 +20,14 @@
                        class="form-control input-sm">
               <ui-select-match placeholder="Select...">
               <span ng-if="!$select.selected.label">
-                <account-tag account="$select.selected.account" provider="'cf'"></account-tag>
+                <account-tag account="$select.selected.account"></account-tag>
                 <span ng-if="$select.selected.serverGroup">{{$select.selected.serverGroupName}}</span>
                 ({{$select.selected.region}})
               </span>
                 <span ng-if="$select.selected.label">{{$select.selected.label}}</span>
               </ui-select-match>
               <ui-select-choices repeat="template in templates | anyFieldFilter: {label: $select.search, serverGroupName: $select.search}">
-                <h5 ng-if="!template.label"><account-tag account="template.account" provider="'cf'"></account-tag> {{template.cluster}} ({{template.region}})</h5>
+                <h5 ng-if="!template.label"><account-tag account="template.account"></account-tag> {{template.cluster}} ({{template.region}})</h5>
                 <h5 ng-if="template.label">{{template.label}}</h5>
                 <div ng-if="template.serverGroup">
                   <b>Most recent server group: </b> {{template.serverGroupName}}

--- a/app/scripts/modules/cloudfoundry/serverGroup/details/resize/resizeServerGroup.controller.js
+++ b/app/scripts/modules/cloudfoundry/serverGroup/details/resize/resizeServerGroup.controller.js
@@ -21,8 +21,13 @@ module.exports = angular.module('spinnaker.cf.serverGroup.details.resize.control
     };
 
     $scope.verification = {
-      required: accountService.challengeDestructiveActions(serverGroup.account)
+      required: false,
+      verifyAccount: '',
     };
+
+    accountService.challengeDestructiveActions(serverGroup.account).then((challenge) => {
+      $scope.verification.required = challenge;
+    });
 
     $scope.command = angular.copy($scope.currentSize);
     $scope.command.advancedMode = serverGroup.asg.minSize !== serverGroup.asg.maxSize;

--- a/app/scripts/modules/cloudfoundry/serverGroup/details/resize/resizeServerGroup.html
+++ b/app/scripts/modules/cloudfoundry/serverGroup/details/resize/resizeServerGroup.html
@@ -100,7 +100,7 @@
       <div class="row" ng-if="verification.required">
         <div class="col-sm-12">
           <hr/>
-          <h4 class="confirmation-modal">Type the name of the account ( <account-tag account="serverGroup.account" provider="'cf'"></account-tag> ) below to continue.</h4>
+          <h4 class="confirmation-modal">Type the name of the account ( <account-tag account="serverGroup.account"></account-tag> ) below to continue.</h4>
         </div>
         <div class="col-sm-offset-1 col-sm-10">
           <div class="form-inline">

--- a/app/scripts/modules/cloudfoundry/serverGroup/details/serverGroupDetails.html
+++ b/app/scripts/modules/cloudfoundry/serverGroup/details/serverGroupDetails.html
@@ -99,7 +99,7 @@
         <dd>{{serverGroup.launchConfig.createdTime | timestamp}}</dd>
         <dt>In:</dt>
         <dd>
-          <account-tag account="serverGroup.account" provider="serverGroup.type" pad="right"></account-tag>
+          <account-tag account="serverGroup.account" pad="right"></account-tag>
           {{serverGroup.region}}
         </dd>
         <dt>Zone:</dt>

--- a/app/scripts/modules/core/account/accountLabelColor.directive.js
+++ b/app/scripts/modules/core/account/accountLabelColor.directive.js
@@ -12,11 +12,11 @@ module.exports = angular
       template: '<span class="account-tag account-tag-{{accountType}}">{{account}}</span>',
       scope: {
         account: '@',
-        provider: '@'
       },
       controller: function ($scope, accountService) {
-        const isProdAccount = accountService.challengeDestructiveActions($scope.provider, $scope.account);
-        $scope.accountType = isProdAccount ? 'prod' : $scope.account;
+        accountService.challengeDestructiveActions($scope.account).then((isProdAccount) => {
+          $scope.accountType = isProdAccount ? 'prod' : $scope.account;
+        });
       }
     };
   })

--- a/app/scripts/modules/core/account/accountSelectField.directive.js
+++ b/app/scripts/modules/core/account/accountSelectField.directive.js
@@ -3,9 +3,9 @@
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.account.accountSelectField.directive', [
-  require('../config/settings.js')
+  require('./account.service.js'),
 ])
-  .directive('accountSelectField', function(settings, _) {
+  .directive('accountSelectField', function($q, _, accountService) {
   return {
     restrict: 'E',
     templateUrl: require('./accountSelectField.directive.html'),
@@ -22,21 +22,31 @@ module.exports = angular.module('spinnaker.core.account.accountSelectField.direc
       multiselect: '='
     },
     link: function(scope) {
-      function groupAccounts(accounts) {
-        if (accounts && accounts[0] && accounts[0].name) {
-          accounts = _.pluck(accounts, 'name');
-        }
-        if (accounts) {
-          scope.primaryAccounts = accounts.sort();
-        }
-        if (accounts && accounts.length && settings.providers[scope.provider] && settings.providers[scope.provider].primaryAccounts) {
-          scope.primaryAccounts = accounts.filter(function(account) {
-              return settings.providers[scope.provider].primaryAccounts.indexOf(account) !== -1;
-          }).sort();
-          scope.secondaryAccounts = _.xor(accounts, scope.primaryAccounts).sort();
-          scope.mergedAccounts = _.flatten([scope.primaryAccounts, scope.secondaryAccounts]);
-        }
+      scope.mergedAccounts = [];
 
+      function groupAccounts(accounts) {
+        let getAccountDetails = scope.provider ?
+          accountService.getAllAccountDetailsForProvider(scope.provider) :
+          $q.when([]);
+
+        getAccountDetails.then((details) => {
+          let accountNames = accounts;
+
+          if (accounts && accounts[0] && accounts[0].name) {
+            accountNames = _.pluck(accounts, 'name');
+          }
+          scope.mergedAccounts = accountNames;
+          if (accountNames) {
+            scope.primaryAccounts = accountNames.sort();
+          }
+          if (accountNames && accountNames.length && details.length) {
+            scope.primaryAccounts = accountNames.filter(function(account) {
+              return details.some((detail) => detail.name === account && detail.primaryAccount);
+            }).sort();
+            scope.secondaryAccounts = _.xor(accountNames, scope.primaryAccounts).sort();
+            scope.mergedAccounts = _.flatten([scope.primaryAccounts, scope.secondaryAccounts]);
+          }
+        });
       }
 
       scope.groupBy = function(account) {

--- a/app/scripts/modules/core/account/accountTag.directive.js
+++ b/app/scripts/modules/core/account/accountTag.directive.js
@@ -2,28 +2,25 @@
 
 let angular = require('angular');
 
-module.exports = angular.module('spinnaker.core.account.accountTag.directive', [
-])
+module.exports = angular
+  .module('spinnaker.core.account.accountTag.directive', [
+    require('./account.service.js'),
+  ])
   .directive('accountTag', function () {
     return {
       restrict: 'E',
-      template: '<span class="label label-default account-label account-label-{{getAccountType()}} {{pad}}">{{account}}</span>',
+      template: '<span class="label label-default account-label account-label-{{accountType}} {{pad}}">{{account}}</span>',
       scope: {
         account: '=',
-        provider: '=?',
         pad: '@?'
       },
-      controller: function($scope, settings ) {
-
-        $scope.getAccountType = function() {
-          if($scope.provider && settings.providers[$scope.provider]) {
-            var prodAccounts = settings.providers[$scope.provider].challengeDestructiveActions || [];
-            return prodAccounts.indexOf($scope.account) > -1 ? 'prod' : $scope.account;
-          } else {
-            return $scope.account;
-          }
-        };
-
+      controller: function($scope, accountService) {
+        function getAccountType() {
+          accountService.challengeDestructiveActions($scope.account).then((challenge) => {
+            $scope.accountType = challenge ? 'prod' : $scope.account;
+          });
+        }
+        $scope.$watch('account', getAccountType);
       },
     };
 }).name;

--- a/app/scripts/modules/core/account/collapsibleAccountTag.directive.html
+++ b/app/scripts/modules/core/account/collapsibleAccountTag.directive.html
@@ -1,4 +1,4 @@
-<span class="account-tag account-tag-{{accountType}}">
-  <span class="small glyphicon glyphicon-chevron-{{getIcon()}}"></span>
-  {{account}}
+<span class="account-tag account-tag-{{vm.accountType}}">
+  <span class="small glyphicon glyphicon-chevron-{{vm.getIcon()}}"></span>
+  {{vm.account}}
 </span>

--- a/app/scripts/modules/core/account/collapsibleAccountTag.directive.js
+++ b/app/scripts/modules/core/account/collapsibleAccountTag.directive.js
@@ -10,16 +10,23 @@ module.exports = angular
     return {
       restrict: 'E',
       templateUrl: require('./collapsibleAccountTag.directive.html'),
-      scope: {
+      scope: {},
+      bindToController: {
         account: '@',
-        provider: '@',
         state: '=',
       },
+      controllerAs: 'vm',
       controller: function ($scope, accountService) {
-        const isProdAccount = accountService.challengeDestructiveActions($scope.provider, $scope.account);
-        $scope.accountType = isProdAccount ? 'prod' : $scope.account;
+        this.getIcon = () => this.state.expanded ? 'down' : 'up';
 
-        $scope.getIcon = () => $scope.state.expanded ? 'down' : 'up';
+        let getAccountType = () => {
+          accountService.challengeDestructiveActions(this.account).then((challenge) => {
+            this.accountType = challenge ? 'prod' : $scope.account;
+          });
+        };
+
+        $scope.$watch(() => this.account, getAccountType);
+
       }
     };
   })

--- a/app/scripts/modules/core/cluster/clusterPod.html
+++ b/app/scripts/modules/core/cluster/clusterPod.html
@@ -5,7 +5,7 @@
         <div class="col-md-12">
           <div class="rollup-title-cell">
             <h5>
-              <account-label-color account="{{parentHeading}}" provider="{{grouping.cluster.serverGroups[0].type}}"></account-label-color>
+              <account-label-color account="{{parentHeading}}"></account-label-color>
               <span class="glyphicon glyphicon-th"></span>
               {{grouping.heading}}
               <health-counts container="grouping.cluster"></health-counts>

--- a/app/scripts/modules/core/confirmationModal/confirm.html
+++ b/app/scripts/modules/core/confirmationModal/confirm.html
@@ -18,7 +18,7 @@
       </div>
       <div class="row" ng-if="verification.requireAccountEntry">
         <div class="col-sm-offset-1 col-sm-10">
-          <p>Type the name of the account ( <account-tag account="params.account" provider="params.provider"></account-tag> ) below to continue.</p>
+          <p>Type the name of the account ( <account-tag account="params.account"></account-tag> ) below to continue.</p>
           <div class="form-inline">
             <div class="form-group">
               <input type="text" auto-focus ng-model="verification.verifyAccount" class="form-control input-sm highlight-pristine" ng-class="{'ng-invalid': verification.verifyAccount !== params.account.toUpperCase()}"/>

--- a/app/scripts/modules/core/confirmationModal/confirmationModal.service.js
+++ b/app/scripts/modules/core/confirmationModal/confirmationModal.service.js
@@ -59,9 +59,13 @@ module.exports = angular.module('spinnaker.core.confirmationModal.service', [
     }
 
     $scope.verification = {
-      requireAccountEntry: accountService.challengeDestructiveActions(params.provider, params.account),
+      requireAccountEntry: false,
       verifyAccount: ''
     };
+
+    accountService.challengeDestructiveActions(params.account).then((challenge) => {
+      $scope.verification.requireAccountEntry = challenge;
+    });
 
     this.formDisabled = function () {
       return $scope.verification.requireAccountEntry && $scope.verification.verifyAccount !== params.account.toUpperCase();

--- a/app/scripts/modules/core/loadBalancer/loadBalancer/loadBalancerPod.html
+++ b/app/scripts/modules/core/loadBalancer/loadBalancer/loadBalancerPod.html
@@ -5,7 +5,7 @@
         <div class="col-md-12">
           <div class="rollup-title-cell">
             <h5>
-              <account-label-color account="{{parentHeading}}" provider="{{grouping.subgroups[0].loadBalancer.type}}"></account-label-color>
+              <account-label-color account="{{parentHeading}}"></account-label-color>
               <span class="icon icon-elb"></span>
               {{grouping.heading}}
             </h5>

--- a/app/scripts/modules/core/pipeline/config/stages/deploy/cf/deployStage.html
+++ b/app/scripts/modules/core/pipeline/config/stages/deploy/cf/deployStage.html
@@ -26,7 +26,7 @@
             {{cluster.providerType || 'cf'}}
           </td>
           <td>
-            <account-tag account="cluster.account" provider="'cf'"></account-tag>
+            <account-tag account="cluster.account"></account-tag>
           </td>
           <td>
             {{ deployCloudFoundryStageCtrl.getClusterName(cluster) }}

--- a/app/scripts/modules/core/pipeline/config/stages/deploy/deployExecutionDetails.html
+++ b/app/scripts/modules/core/pipeline/config/stages/deploy/deployExecutionDetails.html
@@ -6,7 +6,7 @@
         <dl class="dl-narrow dl-horizontal">
           <dt>Account</dt>
           <dd>
-            <account-tag account="stage.context.account" provider="provider"></account-tag>
+            <account-tag account="stage.context.account"></account-tag>
           </dd>
           <dt>Region</dt>
           <dd ng-repeat="(region, zones) in stage.context.availabilityZones">{{region}}<br/>({{zones.join(', ')}})</dd>

--- a/app/scripts/modules/core/pipeline/config/stages/deploy/deployStage.html
+++ b/app/scripts/modules/core/pipeline/config/stages/deploy/deployStage.html
@@ -27,7 +27,7 @@
             <cloud-provider-label provider="cluster.cloudProvider || cluster.provider || cluster.providerType || 'aws'"></cloud-provider-label>
           </td>
           <td>
-            <account-tag account="cluster.account" provider="cluster.cloudProvider || cluster.provider || cluster.providerType || 'aws'"></account-tag>
+            <account-tag account="cluster.account"></account-tag>
           </td>
           <td>
             {{ deployStageCtrl.getClusterName(cluster) }}

--- a/app/scripts/modules/core/pipeline/config/stages/destroyAsg/aws/destroyAsgExecutionDetails.html
+++ b/app/scripts/modules/core/pipeline/config/stages/destroyAsg/aws/destroyAsgExecutionDetails.html
@@ -22,7 +22,7 @@
         <dl class="dl-narrow dl-horizontal">
           <dt>Account</dt>
           <dd>
-            <account-tag account="stage.context.credentials" provider="'aws'"></account-tag>
+            <account-tag account="stage.context.credentials"></account-tag>
           </dd>
           <dt>Region</dt>
           <dd>{{stage.context.regions.join(', ')}}</dd>

--- a/app/scripts/modules/core/pipeline/config/stages/destroyAsg/gce/destroyAsgExecutionDetails.html
+++ b/app/scripts/modules/core/pipeline/config/stages/destroyAsg/gce/destroyAsgExecutionDetails.html
@@ -6,7 +6,7 @@
         <dl class="dl-narrow dl-horizontal">
           <dt>Account</dt>
           <dd>
-            <account-tag account="stage.context.credentials" provider="'gce'"></account-tag>
+            <account-tag account="stage.context.credentials"></account-tag>
           </dd>
           <dt>Zone</dt>
           <dd>{{stage.context.zones.join(', ')}}</dd>

--- a/app/scripts/modules/core/pipeline/config/stages/determineTargetReference/determineTargetReferenceDetails.html
+++ b/app/scripts/modules/core/pipeline/config/stages/determineTargetReference/determineTargetReferenceDetails.html
@@ -5,7 +5,7 @@
         <dl class="dl-narrow dl-horizontal">
           <dt>Account</dt>
           <dd>
-            <account-tag account="stage.context.credentials" provider="stage.providerType || stage.cloudProvider || 'aws'"></account-tag>
+            <account-tag account="stage.context.credentials"></account-tag>
           </dd>
           <dt ng-if="stage.context.regions">Region</dt>
           <dd ng-if="stage.context.regions">{{stage.context.regions.join(', ')}}</dd>

--- a/app/scripts/modules/core/pipeline/config/stages/disableAsg/aws/disableAsgExecutionDetails.html
+++ b/app/scripts/modules/core/pipeline/config/stages/disableAsg/aws/disableAsgExecutionDetails.html
@@ -6,7 +6,7 @@
         <dl class="dl-narrow dl-horizontal">
           <dt>Account</dt>
           <dd>
-            <account-tag account="stage.context.credentials" provider="'aws'"></account-tag>
+            <account-tag account="stage.context.credentials"></account-tag>
           </dd>
           <dt>Region</dt>
           <dd>{{stage.context.regions.join(', ')}}</dd>

--- a/app/scripts/modules/core/pipeline/config/stages/disableAsg/gce/disableAsgExecutionDetails.html
+++ b/app/scripts/modules/core/pipeline/config/stages/disableAsg/gce/disableAsgExecutionDetails.html
@@ -6,7 +6,7 @@
         <dl class="dl-narrow dl-horizontal">
           <dt>Account</dt>
           <dd>
-            <account-tag account="stage.context.credentials" provider="'gce'"></account-tag>
+            <account-tag account="stage.context.credentials"></account-tag>
           </dd>
           <dt>Zone</dt>
           <dd>{{stage.context.zones.join(', ')}}</dd>

--- a/app/scripts/modules/core/pipeline/config/stages/disableCluster/aws/disableClusterExecutionDetails.html
+++ b/app/scripts/modules/core/pipeline/config/stages/disableCluster/aws/disableClusterExecutionDetails.html
@@ -6,7 +6,7 @@
                 <dl class="dl-narrow dl-horizontal">
                     <dt>Account</dt>
                     <dd>
-                        <account-tag account="stage.context.credentials" provider="stage.context.cloudProvider"></account-tag>
+                        <account-tag account="stage.context.credentials"></account-tag>
                     </dd>
                     <dt>Regions</dt>
                     <dd>{{stage.context.regions.join(', ')}}</dd>

--- a/app/scripts/modules/core/pipeline/config/stages/disableCluster/aws/disableClusterStage.html
+++ b/app/scripts/modules/core/pipeline/config/stages/disableCluster/aws/disableClusterStage.html
@@ -4,7 +4,7 @@
            class="form-control input-sm" />
   </stage-config-field>
   <stage-config-field label="Account">
-      <account-select-field component="stage" field="credentials" accounts="accounts" on-change="disableClusterStageCtrl.accountUpdated()" required></account-select-field>
+      <account-select-field component="stage" field="credentials" accounts="accounts" provider="'aws'" on-change="disableClusterStageCtrl.accountUpdated()" required></account-select-field>
   </stage-config-field>
   <stage-config-field label="Regions">
     <p ng-if="!stage.credentials" class="form-control-static">(Select an Account)</p>

--- a/app/scripts/modules/core/pipeline/config/stages/disableCluster/gce/disableClusterExecutionDetails.html
+++ b/app/scripts/modules/core/pipeline/config/stages/disableCluster/gce/disableClusterExecutionDetails.html
@@ -6,7 +6,7 @@
                 <dl class="dl-narrow dl-horizontal">
                     <dt>Account</dt>
                     <dd>
-                        <account-tag account="stage.context.credentials" provider="stage.context.cloudProvider"></account-tag>
+                        <account-tag account="stage.context.credentials"></account-tag>
                     </dd>
                     <dt>Zones</dt>
                     <dd>{{stage.context.zones.join(', ')}}</dd>

--- a/app/scripts/modules/core/pipeline/config/stages/disableCluster/gce/disableClusterStage.html
+++ b/app/scripts/modules/core/pipeline/config/stages/disableCluster/gce/disableClusterStage.html
@@ -4,7 +4,7 @@
       class="form-control input-sm" />
   </stage-config-field>
   <stage-config-field label="Account">
-    <account-select-field component="stage" field="credentials" accounts="accounts" on-change="disableClusterStageCtrl.accountUpdated()" required></account-select-field>
+    <account-select-field component="stage" field="credentials" accounts="accounts" provider="'gce'" on-change="disableClusterStageCtrl.accountUpdated()" required></account-select-field>
   </stage-config-field>
   <stage-config-field label="Zones">
     <p ng-if="!stage.credentials" class="form-control-static">(Select an Account)</p>

--- a/app/scripts/modules/core/pipeline/config/stages/enableAsg/aws/enableAsgExecutionDetails.html
+++ b/app/scripts/modules/core/pipeline/config/stages/enableAsg/aws/enableAsgExecutionDetails.html
@@ -6,7 +6,7 @@
         <dl class="dl-narrow dl-horizontal">
           <dt>Account</dt>
           <dd>
-            <account-tag account="stage.context.credentials" provider="'aws'"></account-tag>
+            <account-tag account="stage.context.credentials"></account-tag>
           </dd>
           <dt>Region</dt>
           <dd>{{stage.context.regions.join(', ')}}</dd>

--- a/app/scripts/modules/core/pipeline/config/stages/enableAsg/gce/enableAsgExecutionDetails.html
+++ b/app/scripts/modules/core/pipeline/config/stages/enableAsg/gce/enableAsgExecutionDetails.html
@@ -6,7 +6,7 @@
         <dl class="dl-narrow dl-horizontal">
           <dt>Account</dt>
           <dd>
-            <account-tag account="stage.context.credentials" provider="'gce'"></account-tag>
+            <account-tag account="stage.context.credentials"></account-tag>
           </dd>
           <dt>Zone</dt>
           <dd>{{stage.context.zones.join(', ')}}</dd>

--- a/app/scripts/modules/core/pipeline/config/stages/findAmi/aws/findAmiExecutionDetails.html
+++ b/app/scripts/modules/core/pipeline/config/stages/findAmi/aws/findAmiExecutionDetails.html
@@ -6,7 +6,7 @@
         <dl class="dl-narrow dl-horizontal">
           <dt>Account</dt>
           <dd>
-            <account-tag account="stage.context.credentials" provider="'aws'"></account-tag>
+            <account-tag account="stage.context.credentials"></account-tag>
           </dd>
           <dt ng-if="stage.context.regions">Regions</dt>
           <dd ng-if="stage.context.regions">{{stage.context.regions.join(', ')}}</dd>

--- a/app/scripts/modules/core/pipeline/config/stages/findAmi/aws/findAmiStage.html
+++ b/app/scripts/modules/core/pipeline/config/stages/findAmi/aws/findAmiStage.html
@@ -4,7 +4,7 @@
       class="form-control input-sm" />
   </stage-config-field>
   <stage-config-field label="Account">
-    <account-select-field component="stage" field="credentials" accounts="accounts" on-change="findAmiCtrl.accountUpdated()" required></account-select-field>
+    <account-select-field component="stage" field="credentials" accounts="accounts" provider="'aws'" on-change="findAmiCtrl.accountUpdated()" required></account-select-field>
   </stage-config-field>
   <stage-config-field label="Server Group Selection">
     <ui-select ng-model="stage.selectionStrategy" class="form-control input-sm">

--- a/app/scripts/modules/core/pipeline/config/stages/findAmi/gce/findAmiExecutionDetails.html
+++ b/app/scripts/modules/core/pipeline/config/stages/findAmi/gce/findAmiExecutionDetails.html
@@ -6,7 +6,7 @@
         <dl class="dl-narrow dl-horizontal">
           <dt>Account</dt>
           <dd>
-            <account-tag account="stage.context.credentials" provider="'gce'"></account-tag>
+            <account-tag account="stage.context.credentials"></account-tag>
           </dd>
           <dt ng-if="stage.context.zones">Zones</dt>
           <dd ng-if="stage.context.zones">{{stage.context.zones.join(', ')}}</dd>

--- a/app/scripts/modules/core/pipeline/config/stages/findAmi/gce/findAmiStage.html
+++ b/app/scripts/modules/core/pipeline/config/stages/findAmi/gce/findAmiStage.html
@@ -4,7 +4,7 @@
       class="form-control input-sm" />
   </stage-config-field>
   <stage-config-field label="Account">
-    <account-select-field component="stage" field="credentials" accounts="accounts" on-change="findAmiCtrl.accountUpdated()" required></account-select-field>
+    <account-select-field component="stage" field="credentials" accounts="accounts" provider="'gce'" on-change="findAmiCtrl.accountUpdated()" required></account-select-field>
   </stage-config-field>
   <stage-config-field label="Server Group Selection">
     <ui-select ng-model="stage.selectionStrategy" class="form-control input-sm">

--- a/app/scripts/modules/core/pipeline/config/stages/modifyScalingProcess/modifyScalingProcessExecutionDetails.html
+++ b/app/scripts/modules/core/pipeline/config/stages/modifyScalingProcess/modifyScalingProcessExecutionDetails.html
@@ -5,7 +5,7 @@
       <div class="col-md-9">
         <dl class="dl-narrow dl-horizontal">
           <dt>Account</dt>
-          <dd><account-tag account="stage.context.credentials" provider="'aws'"></account-tag></dd>
+          <dd><account-tag account="stage.context.credentials"></account-tag></dd>
           <dt>Region</dt>
           <dd>{{stage.context.regions.join(', ')}}</dd>
           <dt>ASG Name</dt>

--- a/app/scripts/modules/core/pipeline/config/stages/resizeAsg/aws/resizeAsgExecutionDetails.html
+++ b/app/scripts/modules/core/pipeline/config/stages/resizeAsg/aws/resizeAsgExecutionDetails.html
@@ -5,7 +5,7 @@
       <div class="col-md-9">
         <dl class="dl-narrow dl-horizontal">
           <dt>Account</dt>
-          <dd><account-tag account="stage.context.credentials" provider="'aws'"></account-tag></dd>
+          <dd><account-tag account="stage.context.credentials"></account-tag></dd>
           <dt>Region</dt>
           <dd>{{stage.context.regions.join(',')}}</dd>
           <dt>Server Group</dt>

--- a/app/scripts/modules/core/pipeline/config/stages/resizeAsg/cf/resizeAsgExecutionDetails.html
+++ b/app/scripts/modules/core/pipeline/config/stages/resizeAsg/cf/resizeAsgExecutionDetails.html
@@ -5,7 +5,7 @@
       <div class="col-md-9">
         <dl class="dl-narrow dl-horizontal">
           <dt>Account</dt>
-          <dd><account-tag account="stage.context.credentials" provider="'cf'"></account-tag></dd>
+          <dd><account-tag account="stage.context.credentials"></account-tag></dd>
           <dt>Region</dt>
           <dd>{{stage.context.regions.join(',')}}</dd>
           <dt>Server Group</dt>

--- a/app/scripts/modules/core/pipeline/config/stages/resizeAsg/gce/resizeAsgExecutionDetails.html
+++ b/app/scripts/modules/core/pipeline/config/stages/resizeAsg/gce/resizeAsgExecutionDetails.html
@@ -5,7 +5,7 @@
       <div class="col-md-9">
         <dl class="dl-narrow dl-horizontal">
           <dt>Account</dt>
-          <dd><account-tag account="stage.context.credentials" provider="'gce'"></account-tag></dd>
+          <dd><account-tag account="stage.context.credentials"></account-tag></dd>
           <dt>Zones</dt>
           <dd>{{stage.context.zones.join(',')}}</dd>
           <dt>Server Group</dt>

--- a/app/scripts/modules/core/pipeline/config/stages/scaleDownCluster/aws/scaleDownClusterExecutionDetails.html
+++ b/app/scripts/modules/core/pipeline/config/stages/scaleDownCluster/aws/scaleDownClusterExecutionDetails.html
@@ -6,7 +6,7 @@
                 <dl class="dl-narrow dl-horizontal">
                     <dt>Account</dt>
                     <dd>
-                        <account-tag account="stage.context.credentials" provider="stage.context.cloudProvider"></account-tag>
+                        <account-tag account="stage.context.credentials"></account-tag>
                     </dd>
                     <dt>Region</dt>
                     <dd>{{stage.context.regions.join(', ')}}</dd>

--- a/app/scripts/modules/core/pipeline/config/stages/scaleDownCluster/gce/scaleDownClusterExecutionDetails.html
+++ b/app/scripts/modules/core/pipeline/config/stages/scaleDownCluster/gce/scaleDownClusterExecutionDetails.html
@@ -6,7 +6,7 @@
                 <dl class="dl-narrow dl-horizontal">
                     <dt>Account</dt>
                     <dd>
-                        <account-tag account="stage.context.credentials" provider="stage.context.cloudProvider"></account-tag>
+                        <account-tag account="stage.context.credentials"></account-tag>
                     </dd>
                     <dt>Zone</dt>
                     <dd>{{stage.context.zones.join(', ')}}</dd>

--- a/app/scripts/modules/core/pipeline/config/stages/shrinkCluster/aws/shrinkClusterExecutionDetails.html
+++ b/app/scripts/modules/core/pipeline/config/stages/shrinkCluster/aws/shrinkClusterExecutionDetails.html
@@ -6,7 +6,7 @@
                 <dl class="dl-narrow dl-horizontal">
                     <dt>Account</dt>
                     <dd>
-                        <account-tag account="stage.context.credentials" provider="stage.context.cloudProvider"></account-tag>
+                        <account-tag account="stage.context.credentials"></account-tag>
                     </dd>
                     <dt>Region</dt>
                     <dd>{{stage.context.regions.join(', ')}}</dd>

--- a/app/scripts/modules/core/pipeline/config/stages/shrinkCluster/gce/shrinkClusterExecutionDetails.html
+++ b/app/scripts/modules/core/pipeline/config/stages/shrinkCluster/gce/shrinkClusterExecutionDetails.html
@@ -6,7 +6,7 @@
                 <dl class="dl-narrow dl-horizontal">
                     <dt>Account</dt>
                     <dd>
-                        <account-tag account="stage.context.credentials" provider="stage.context.cloudProvider"></account-tag>
+                        <account-tag account="stage.context.credentials"></account-tag>
                     </dd>
                     <dt>Zone</dt>
                     <dd>{{stage.context.zones.join(', ')}}</dd>

--- a/app/scripts/modules/core/region/regionSelectField.directive.html
+++ b/app/scripts/modules/core/region/regionSelectField.directive.html
@@ -7,9 +7,7 @@
             ng-model="component[field]"
             ng-change="onChange()"
             required>
-      <option ng-repeat="region in primaryRegions" value="{{region}}" ng-selected="component[field] === region">{{region}}</option>
-      <option ng-if="primaryRegions.length && secondaryRegions.length" value="{{dividerText}}" disabled>{{dividerText}}</option>
-      <option ng-repeat="region in secondaryRegions" value="{{region}}" ng-selected="component[field] === region">{{region}}</option>
+      <option ng-repeat="region in regions" value="{{region.name}}" ng-selected="component[field] === region">{{region.name}}</option>
     </select>
     <p ng-if="readOnly" class="form-control-static">{{component[field]}}</p>
   </div>

--- a/app/scripts/modules/core/region/regionSelectField.directive.js
+++ b/app/scripts/modules/core/region/regionSelectField.directive.js
@@ -2,11 +2,10 @@
 
 let angular = require('angular');
 
-module.exports = angular.module('spinnaker.core.region.regionSelectField.directive', [
-  require('../config/settings.js'),
-  require('../utils/lodash.js'),
-])
-  .directive('regionSelectField', function (settings, _) {
+module.exports = angular
+  .module('spinnaker.core.region.regionSelectField.directive', [
+  ])
+  .directive('regionSelectField', function () {
     return {
       restrict: 'E',
       templateUrl: require('./regionSelectField.directive.html'),
@@ -21,21 +20,5 @@ module.exports = angular.module('spinnaker.core.region.regionSelectField.directi
         fieldColumns: '@',
         readOnly: '=',
       },
-      link: function(scope) {
-        function groupRegions(regions) {
-          var regionNames = _.pluck(regions, 'name');
-          if (regionNames) {
-            scope.primaryRegions = regionNames.sort();
-          }
-          if (regionNames && regionNames.length) {
-            scope.primaryRegions = regionNames.filter(function(region) {
-              return settings.providers[scope.provider].primaryRegions.indexOf(region) !== -1;
-            }).sort();
-            scope.secondaryRegions = _.xor(regionNames, scope.primaryRegions).sort();
-          }
-        }
-        scope.dividerText = '---------------';
-        scope.$watch('regions', groupRegions);
-      }
     };
-}).name;
+  }).name;

--- a/app/scripts/modules/core/region/regionSelectField.directive.spec.js
+++ b/app/scripts/modules/core/region/regionSelectField.directive.spec.js
@@ -32,63 +32,14 @@ describe('Directives: regionSelectField', function () {
             initialize: angular.noop
           };
         });
-        $provide.constant('settings', {
-          providers: { aws: { primaryRegions: ['us-east-1', 'us-east-2', 'us-west-1'] } }
-      });
-    });
+      }
+    );
   });
-
-
 
   beforeEach(window.inject(function ($rootScope, $compile) {
     this.scope = $rootScope.$new();
     this.compile = $compile;
-    this.divider = '---------------';
   }));
-
-  it('groups regions into primary, secondary buckets', function() {
-    var scope = this.scope;
-
-    scope.regions = [{name: 'us-east-1'}, {name: 'eu-west-1'}, {name: 'sa-east-1'}];
-
-    scope.model = { regionField: 'sa-east-1', accountField: 'a'};
-
-    var html = '<region-select-field regions="regions" component="model" field="regionField" account="model.accountField" provider="\'aws\'" label-columns="2"></region-select-field>';
-
-    var elem = this.compile(html)(scope);
-    scope.$digest();
-
-    var options = elem.find('option');
-    var expected = ['us-east-1', this.divider, 'eu-west-1', 'sa-east-1'];
-
-    expect(options.length).toBe(4);
-    options.each(function(idx, option) {
-      expect(option.value).toBe(expected[idx]);
-    });
-    expect(elem.find('option[disabled]')[0].value).toBe(this.divider);
-    expect(elem.find('option[selected]')[0].value).toBe('sa-east-1');
-  });
-
-  it('does not group if only primary or secondary regions are available', function() {
-    var scope = this.scope;
-
-    scope.regions = [{name: 'us-east-1'}, {name: 'us-east-2'}];
-
-    scope.model = { regionField: 'us-east-1', accountField: 'a'};
-
-    var html = '<region-select-field regions="regions" component="model" field="regionField" account="model.accountField" provider="\'aws\'" label-columns="2"></region-select-field>';
-
-    var elem = this.compile(html)(scope);
-    scope.$digest();
-
-    var options = elem.find('option');
-    var expected = ['us-east-1', 'us-east-2'];
-
-    expect(options.length).toBe(2);
-    options.each(function(idx, option) {
-      expect(option.value).toBe(expected[idx]);
-    });
-  });
 
   it('updates values when regions change', function() {
     var scope = this.scope;
@@ -115,6 +66,4 @@ describe('Directives: regionSelectField', function () {
       expect(option.value).toBe(expected[idx]);
     });
   });
-
-
 });

--- a/app/scripts/modules/core/search/searchResult/searchResult.directive.html
+++ b/app/scripts/modules/core/search/searchResult/searchResult.directive.html
@@ -1,6 +1,5 @@
 <span class="search-result">
   <account-tag
-      account="item.account || item.params.account || item.params.accountId || item.params.accountName"
-      provider="item.provider || item.params.provider || item.params.type"></account-tag>
+      account="item.account || item.params.account || item.params.accountId || item.params.accountName"></account-tag>
   {{ item.displayName }}
 </span>

--- a/app/scripts/modules/core/securityGroup/securityGroupPod.html
+++ b/app/scripts/modules/core/securityGroup/securityGroupPod.html
@@ -5,7 +5,7 @@
         <div class="col-md-12">
           <div class="rollup-title-cell">
             <h5>
-              <account-label-color account="{{parentHeading}}" provider="{{grouping.subgroups[0].securityGroup.provider || 'aws'}}"></account-label-color>
+              <account-label-color account="{{parentHeading}}"></account-label-color>
               <span class="glyphicon glyphicon-transfer"></span>
               {{grouping.heading}}
             </h5>

--- a/app/scripts/modules/google/instance/details/instanceDetails.html
+++ b/app/scripts/modules/google/instance/details/instanceDetails.html
@@ -67,7 +67,7 @@
         <dd ng-if="!instance.launchTime">(Unknown)</dd>
         <dt>In:</dt>
         <dd>
-          <account-tag account="instance.account" provider="instance.provider" pad="right"></account-tag>
+          <account-tag account="instance.account" pad="right"></account-tag>
           {{instance.placement.availabilityZone || '(Unknown)'}}
         </dd>
         <dt>Type:</dt>

--- a/app/scripts/modules/google/loadBalancer/details/loadBalancerDetails.html
+++ b/app/scripts/modules/google/loadBalancer/details/loadBalancerDetails.html
@@ -48,7 +48,7 @@
         <dt>Created:</dt>
         <dd>{{loadBalancer.elb.createdTime | timestamp}}</dd>
         <dt>In:</dt>
-        <dd><account-tag account="loadBalancer.account" pad="right" provider="loadBalancer.type"></account-tag> {{loadBalancer.region}}</dd>
+        <dd><account-tag account="loadBalancer.account" pad="right"></account-tag> {{loadBalancer.region}}</dd>
       </dl>
       <dl ng-class="InsightFilterStateModel.filtersExpanded ? '' : 'dl-horizontal dl-wide'">
         <dt>Zones:</dt>

--- a/app/scripts/modules/google/securityGroup/details/securityGroupDetails.html
+++ b/app/scripts/modules/google/securityGroup/details/securityGroupDetails.html
@@ -36,7 +36,7 @@
         <dt>ID:</dt>
         <dd>{{securityGroup.id}}</dd>
         <dt>Account:</dt>
-        <dd><account-tag account="securityGroup.accountName" provider="'gce'"></account-tag></dd>
+        <dd><account-tag account="securityGroup.accountName"></account-tag></dd>
         <dt>Region:</dt>
         <dd>{{securityGroup.region}}</dd>
         <dt>Network:</dt>

--- a/app/scripts/modules/google/serverGroup/configure/wizard/templateSelection.html
+++ b/app/scripts/modules/google/serverGroup/configure/wizard/templateSelection.html
@@ -20,14 +20,14 @@
                        class="form-control input-sm">
               <ui-select-match placeholder="Select...">
               <span ng-if="!$select.selected.label">
-                <account-tag account="$select.selected.account" provider="'gce'"></account-tag>
+                <account-tag account="$select.selected.account"></account-tag>
                 <span ng-if="$select.selected.serverGroup">{{$select.selected.serverGroupName}}</span>
                 ({{$select.selected.region}})
               </span>
                 <span ng-if="$select.selected.label">{{$select.selected.label}}</span>
               </ui-select-match>
               <ui-select-choices repeat="template in templates | anyFieldFilter: {label: $select.search, serverGroupName: $select.search}">
-                <h5 ng-if="!template.label"><account-tag account="template.account" provider="'gce'"></account-tag> {{template.cluster}} ({{template.region}})</h5>
+                <h5 ng-if="!template.label"><account-tag account="template.account"></account-tag> {{template.cluster}} ({{template.region}})</h5>
                 <h5 ng-if="template.label">{{template.label}}</h5>
                 <div ng-if="template.serverGroup">
                   <b>Most recent server group: </b> {{template.serverGroupName}}

--- a/app/scripts/modules/google/serverGroup/details/resize/resizeServerGroup.controller.js
+++ b/app/scripts/modules/google/serverGroup/details/resize/resizeServerGroup.controller.js
@@ -19,8 +19,13 @@ module.exports = angular.module('spinnaker.google.serverGroup.details.resize.con
     };
 
     $scope.verification = {
-      required: accountService.challengeDestructiveActions(serverGroup.account)
+      required: false,
+      verifyAccount: '',
     };
+
+    accountService.challengeDestructiveActions(serverGroup.account).then((challenge) => {
+      $scope.verification.required = challenge;
+    });
 
     $scope.command = angular.copy($scope.currentSize);
     $scope.command.advancedMode = serverGroup.asg.minSize !== serverGroup.asg.maxSize;

--- a/app/scripts/modules/google/serverGroup/details/resize/resizeServerGroup.html
+++ b/app/scripts/modules/google/serverGroup/details/resize/resizeServerGroup.html
@@ -100,7 +100,7 @@
       <div class="row" ng-if="verification.required">
         <div class="col-sm-12">
           <hr/>
-          <h4 class="confirmation-modal">Type the name of the account ( <account-tag account="serverGroup.account" provider="'gce'"></account-tag> ) below to continue.</h4>
+          <h4 class="confirmation-modal">Type the name of the account ( <account-tag account="serverGroup.account"></account-tag> ) below to continue.</h4>
         </div>
         <div class="col-sm-offset-1 col-sm-10">
           <div class="form-inline">

--- a/app/scripts/modules/google/serverGroup/details/serverGroupDetails.html
+++ b/app/scripts/modules/google/serverGroup/details/serverGroupDetails.html
@@ -99,7 +99,7 @@
         <dd>{{serverGroup.launchConfig.createdTime | timestamp}}</dd>
         <dt>In:</dt>
         <dd>
-          <account-tag account="serverGroup.account" provider="serverGroup.type" pad="right"></account-tag>
+          <account-tag account="serverGroup.account" pad="right"></account-tag>
           {{serverGroup.region}}
         </dd>
         <dt>Zone:</dt>

--- a/app/scripts/modules/netflix/fastProperties/modal/deleteFastProperty.controller.js
+++ b/app/scripts/modules/netflix/fastProperties/modal/deleteFastProperty.controller.js
@@ -15,9 +15,13 @@ module.exports = angular
     vm.fastProperty = fastProperty;
 
     vm.verification = {
-      requireAccountEntry: accountService.challengeDestructiveActions('aws', vm.fastProperty.env),
+      requireAccountEntry: false,
       verifyAccount: ''
     };
+
+    accountService.challengeDestructiveActions(vm.fastProperty.env).then((challenge) => {
+      vm.verification.requireAccountEntry = challenge;
+    });
 
     vm.cancel = function() {
       $modalInstance.dismiss();

--- a/app/scripts/modules/netflix/fastProperties/modal/deleteFastProperty.html
+++ b/app/scripts/modules/netflix/fastProperties/modal/deleteFastProperty.html
@@ -9,7 +9,7 @@
 
       <div class="row" ng-if="delete.fastProperty.env == 'prod'">
         <div class="col-sm-offset-1 col-sm-10">
-          <p>Type the name of the account ( <account-tag account="delete.fastProperty.env" provider="'aws'"></account-tag> ) below to continue.</p>
+          <p>Type the name of the account ( <account-tag account="delete.fastProperty.env"></account-tag> ) below to continue.</p>
           <div class="form-inline">
             <div class="form-group">
               <input type="text" auto-focus ng-model="delete.verification.verifyAccount" class="form-control input-sm highlight-pristine" ng-class="{'ng-invalid': delete.verification.verifyAccount !== delete.fastProperty.env.toUpperCase()}"/>

--- a/app/scripts/modules/netflix/instance/aws/instanceDetails.html
+++ b/app/scripts/modules/netflix/instance/aws/instanceDetails.html
@@ -25,9 +25,8 @@
       </h3>
 
       <copy-to-clipboard
-          ng-if="instance.provider === 'aws'"
           class="copy-to-clipboard"
-          text="ssh -t {{ctrl.getBastionAddressForAccount(instance.account)}} 'oq-ssh --region {{instance.region}} {{instance.instanceId}}'"
+          text="ssh -t {{ctrl.bastionHost}} 'oq-ssh --region {{instance.region}} {{instance.instanceId}}'"
           tool-tip="Copy SSH command to clipboard">
       </copy-to-clipboard>
 
@@ -69,7 +68,7 @@
         <dd ng-if="!instance.launchTime">(Unknown)</dd>
         <dt>In:</dt>
         <dd>
-          <account-tag account="instance.account" provider="instance.provider" pad="right"></account-tag>
+          <account-tag account="instance.account" pad="right"></account-tag>
           {{instance.placement.availabilityZone || '(Unknown)'}}
         </dd>
         <dt>Type:</dt>

--- a/app/scripts/modules/netflix/instance/aws/netflixAwsInstanceDetails.controller.js
+++ b/app/scripts/modules/netflix/instance/aws/netflixAwsInstanceDetails.controller.js
@@ -6,6 +6,7 @@ module.exports = angular.module('spinnaker.netflix.instance.aws.controller', [
   require('angular-ui-router'),
   require('angular-ui-bootstrap'),
   require('../../../core/utils/lodash.js'),
+  require('../../../core/account/account.service.js'),
   require('../../../core/instance/instance.write.service.js'),
   require('../../../core/instance/instance.read.service.js'),
   require('../../../core/confirmationModal/confirmationModal.service.js'),
@@ -16,10 +17,12 @@ module.exports = angular.module('spinnaker.netflix.instance.aws.controller', [
   require('../../../amazon/instance/details/instance.details.controller.js'),
 ])
   .controller('netflixAwsInstanceDetailsCtrl', function ($scope, $state, $uibModal, InsightFilterStateModel, settings,
-                                                  instanceWriter, confirmationModalService, recentHistoryService,
-                                                  instanceReader, _, instance, app, $q, $controller) {
+                                                         instanceWriter, confirmationModalService, recentHistoryService,
+                                                         accountService,
+                                                         instanceReader, _, instance, app, $q, $controller) {
 
     this.instanceDetailsLoaded = () => {
+      this.getBastionAddressForAccount($scope.instance.account);
       var discoveryMetric = _.find($scope.healthMetrics, function(metric) { return metric.type === 'Discovery'; });
       if (discoveryMetric && discoveryMetric.vipAddress) {
         var vipList = discoveryMetric.vipAddress;
@@ -52,9 +55,10 @@ module.exports = angular.module('spinnaker.netflix.instance.aws.controller', [
       }
     }));
 
-    this.getBastionAddressForAccount = function(account) {
-      let accountBastions = settings.providers.aws.accountBastions || {};
-      return accountBastions[account] || 'unknown';
+    this.getBastionAddressForAccount = (account) => {
+      return accountService.getAccountDetails(account).then((details) => {
+        this.bastionHost = details.bastionHost || 'unknown';
+      });
     };
 
   }

--- a/app/scripts/modules/netflix/migrator/serverGroup/serverGroup.migrator.modal.html
+++ b/app/scripts/modules/netflix/migrator/serverGroup/serverGroup.migrator.modal.html
@@ -19,7 +19,7 @@
       <div class="row preview" ng-if="preview && !viewState.computing && !viewState.executing && !viewState.error">
         <div class="col-md-10 col-md-offset-1">
           <div ng-if="!viewState.migrationComplete">
-            <p>This will migrate <strong>{{source.asgName}}</strong> in {{source.region}} <account-tag account="source.account" provider="'aws'"></account-tag> to VPC0.</p>
+            <p>This will migrate <strong>{{source.asgName}}</strong> in {{source.region}} <account-tag account="source.account"></account-tag> to VPC0.</p>
             <p>As part of this migration, the following items will be created:</p>
           </div>
           <div ng-if="viewState.migrationComplete">

--- a/app/scripts/modules/netflix/pipeline/stage/canary/canaryExecutionDetails.html
+++ b/app/scripts/modules/netflix/pipeline/stage/canary/canaryExecutionDetails.html
@@ -134,7 +134,7 @@
       <div class="col-md-12 canary-config-section">
         <div class="row">
           <div class="col-md-4 sm-label-left compact">Baseline</div>
-          <div class="col-md-6"><account-tag account="baseline.account" provider="'aws'" pad="right"></account-tag> {{baseline.cluster}}</div>
+          <div class="col-md-6"><account-tag account="baseline.account" pad="right"></account-tag> {{baseline.cluster}}</div>
         </div>
         <div class="row">
           <div class="col-md-4 sm-label-left compact">Duration</div>

--- a/app/scripts/modules/netflix/pipeline/stage/canary/canaryStage.html
+++ b/app/scripts/modules/netflix/pipeline/stage/canary/canaryStage.html
@@ -116,7 +116,7 @@
           <tbody>
           <tr ng-repeat="clusterPair in stage.clusterPairs">
             <td>
-              <account-tag account="clusterPair.baseline.account" provider="'aws'"></account-tag>
+              <account-tag account="clusterPair.baseline.account"></account-tag>
               {{canaryStageCtrl.getRegion(clusterPair.baseline)}}
             </td>
             <td>

--- a/app/scripts/modules/netflix/pipeline/stage/quickPatchAsg/bulkQuickPatchStage/bulkQuickPatchStageExecutionDetails.html
+++ b/app/scripts/modules/netflix/pipeline/stage/quickPatchAsg/bulkQuickPatchStage/bulkQuickPatchStageExecutionDetails.html
@@ -6,7 +6,7 @@
         <dl class="dl-horizontal">
           <dt>Account</dt>
           <dd>
-            <account-tag account="stage.context.credentials" provider="'aws'"></account-tag>
+            <account-tag account="stage.context.credentials"></account-tag>
           </dd>
           <dt>Region</dt>
           <dd>{{stage.context.region}}</dd>

--- a/app/scripts/modules/netflix/pipeline/stage/quickPatchAsg/quickPatchAsgExecutionDetails.html
+++ b/app/scripts/modules/netflix/pipeline/stage/quickPatchAsg/quickPatchAsgExecutionDetails.html
@@ -6,7 +6,7 @@
         <dl class="dl-horizontal">
           <dt>Account</dt>
           <dd>
-            <account-tag account="stage.context.credentials" provider="'aws'"></account-tag>
+            <account-tag account="stage.context.credentials"></account-tag>
           </dd>
           <dt>Region</dt>
           <dd>{{stage.context.region}}</dd>

--- a/app/scripts/modules/netflix/report/reservationReport.directive.html
+++ b/app/scripts/modules/netflix/report/reservationReport.directive.html
@@ -2,7 +2,7 @@
 <!-- TODO: Remove error switch when feature flagging is available to toggle this directive on and off -->
 <div class="small reservation-report" ng-if="!vm.viewState.loading && !vm.viewState.error">
   <div ng-if="!vm.viewState.error">
-    <h4>Reservations for {{vm.instanceType}} in <account-tag account="vm.account" provider="'aws'"></account-tag></h4>
+    <h4>Reservations for {{vm.instanceType}} in <account-tag account="vm.account"></account-tag></h4>
     <table class="table table-condensed">
       <thead>
       <tr>

--- a/app/scripts/modules/netflix/serverGroup/awsServerGroupDetails.html
+++ b/app/scripts/modules/netflix/serverGroup/awsServerGroupDetails.html
@@ -100,7 +100,7 @@
         <dd>{{serverGroup.createdTime | timestamp}}</dd>
         <dt>In:</dt>
         <dd>
-          <account-tag account="serverGroup.account" provider="serverGroup.type" pad="right"></account-tag>
+          <account-tag account="serverGroup.account" pad="right"></account-tag>
 
           {{serverGroup.region}}
         </dd>

--- a/app/scripts/modules/netflix/serverGroup/networking/details/disassociateElasticIp.html
+++ b/app/scripts/modules/netflix/serverGroup/networking/details/disassociateElasticIp.html
@@ -22,7 +22,7 @@
       </div>
       <div class="form-group" ng-if="verification.requireAccountEntry">
         <div class="col-sm-offset-1 col-sm-10">
-          <p class="confirmation-modal">Type the name of the account ( <account-tag account="serverGroup.account" provider="'aws'"></account-tag> ) below to continue.</p>
+          <p class="confirmation-modal">Type the name of the account ( <account-tag account="serverGroup.account"></account-tag> ) below to continue.</p>
           <div class="form-inline">
             <div class="form-group">
               <input type="text" auto-focus ng-model="verification.verifyAccount" class="form-control input-sm highlight-pristine" ng-class="{'ng-invalid': verification.verifyAccount !== serverGroup.account.toUpperCase()}"/>

--- a/app/scripts/modules/netflix/serverGroup/networking/elasticIp.controller.js
+++ b/app/scripts/modules/netflix/serverGroup/networking/elasticIp.controller.js
@@ -8,13 +8,17 @@ module.exports = angular.module('spinnaker.aws.serverGroup.details.elasticIp.con
   require('../../../core/task/monitor/taskMonitorService.js')
 ])
   .controller('ElasticIpCtrl', function($scope, $modalInstance, accountService, elasticIpWriter, taskMonitorService,
-                                                application, serverGroup, elasticIp, onTaskComplete) {
+                                        application, serverGroup, elasticIp, onTaskComplete) {
     $scope.serverGroup = serverGroup;
     $scope.elasticIp = elasticIp;
 
     $scope.verification = {
-      requireAccountEntry: accountService.challengeDestructiveActions(serverGroup.account)
+      requireAccountEntry: false
     };
+
+    accountService.challengeDestructiveActions(serverGroup.account).then((challenge) => {
+      $scope.verification.requireAccountEntry = challenge;
+    });
 
     this.isValid = function () {
       if ($scope.verification.requireAccountEntry && $scope.verification.verifyAccount !== serverGroup.account.toUpperCase()) {

--- a/app/scripts/modules/titan/instance/details/instanceDetails.html
+++ b/app/scripts/modules/titan/instance/details/instanceDetails.html
@@ -66,7 +66,7 @@
     <collapsible-section heading="Task Placement" expanded="true">
       <dl class="dl-horizontal" ng-class="InsightFilterStateModel.filtersExpanded ? 'dl-narrow' : 'dl-wide'">
         <dt>Account:</dt>
-        <dd><account-tag account="instance.account" provider="instance.provider" pad="right"></account-tag></dd>
+        <dd><account-tag account="instance.account" pad="right"></account-tag></dd>
         <dt>Region:</dt>
         <dd>{{instance.placement.region}}</dd>
         <dt>Host:</dt>

--- a/app/scripts/modules/titan/serverGroup/configure/wizard/templateSelection.html
+++ b/app/scripts/modules/titan/serverGroup/configure/wizard/templateSelection.html
@@ -27,7 +27,7 @@
                 <span ng-if="$select.selected.label">{{$select.selected.label}}</span>
               </ui-select-match>
               <ui-select-choices repeat="template in templates | anyFieldFilter: {label: $select.search, serverGroupName: $select.search}">
-                <h5 ng-if="!template.label"><account-tag account="template.account" provider="'titan'"></account-tag> {{template.cluster}} ({{template.region}})</h5>
+                <h5 ng-if="!template.label"><account-tag account="template.account"></account-tag> {{template.cluster}} ({{template.region}})</h5>
                 <h5 ng-if="template.label">{{template.label}}</h5>
                 <div ng-if="template.serverGroup">
                   <b>Most recent server group: </b> {{template.serverGroupName}}

--- a/app/scripts/modules/titan/serverGroup/details/resize/resizeServerGroup.controller.js
+++ b/app/scripts/modules/titan/serverGroup/details/resize/resizeServerGroup.controller.js
@@ -18,8 +18,14 @@ module.exports = angular.module('spinnaker.titan.serverGroup.details.resize.cont
     };
 
     $scope.verification = {
-      required: accountService.challengeDestructiveActions(serverGroup.account)
+      required: false,
+      verifyAccount: '',
     };
+
+    accountService.challengeDestructiveActions(serverGroup.account).then((challenge) => {
+      $scope.verification.required = challenge;
+    });
+
 
     $scope.command = angular.copy($scope.currentSize);
     $scope.command.advancedMode = serverGroup.capacity.min !== serverGroup.capacity.max;

--- a/app/scripts/modules/titan/serverGroup/details/resize/resizeServerGroup.html
+++ b/app/scripts/modules/titan/serverGroup/details/resize/resizeServerGroup.html
@@ -92,7 +92,7 @@
       <div class="row" ng-if="verification.required">
         <div class="col-sm-12">
           <hr/>
-          <h4 class="confirmation-modal">Type the name of the account ( <account-tag account="serverGroup.account" provider="'titan'"></account-tag> ) below to continue.</h4>
+          <h4 class="confirmation-modal">Type the name of the account ( <account-tag account="serverGroup.account"></account-tag> ) below to continue.</h4>
         </div>
         <div class="col-sm-offset-1 col-sm-10">
           <div class="form-inline">

--- a/app/scripts/modules/titan/serverGroup/details/serverGroupDetails.html
+++ b/app/scripts/modules/titan/serverGroup/details/serverGroupDetails.html
@@ -103,7 +103,7 @@
     <collapsible-section heading="Placement Constraints" expanded="true">
       <dl class="dl-horizontal" ng-class="InsightFilterStateModel.filtersExpanded ? 'dl-narrow' : 'dl-wide'">
         <dt>Account:</dt>
-        <dd><account-tag account="serverGroup.account" provider="serverGroup.type" pad="right"></account-tag></dd>
+        <dd><account-tag account="serverGroup.account" pad="right"></account-tag></dd>
         <dt>Region:</dt>
         <dd>{{serverGroup.region}}</dd>
         <dt ng-if="serverGroup.placement.zones">Zones:</dt>

--- a/settings.js
+++ b/settings.js
@@ -43,107 +43,20 @@ window.spinnakerSettings = {
         account: 'test',
         region: 'us-east-1'
       },
-      primaryAccounts: ['prod', 'test'],
-      primaryRegions: ['eu-west-1', 'us-east-1', 'us-west-1', 'us-west-2'],
-      challengeDestructiveActions: ['mgmt', 'prod', 'mceprod', 'cpl'],
       defaultSecurityGroups: ['nf-datacenter-vpc', 'nf-infrastructure-vpc', 'nf-datacenter', 'nf-infrastructure'],
-      accountBastions : {
-        'prod': 'aws.prod.netflix.net',
-        'test': 'aws.test.netflix.net',
-        'mgmt': 'aws.mgmt.netflix.net',
-        'mcetest': 'awsmce.test.netflix.net',
-        'mceprod': 'awsmce.prod.netflix.net',
-        'cpl': 'awscpl.prod.netflix.net',
-      },
-      preferredZonesByAccount: {
-        prod: {
-          'us-east-1': ['us-east-1c', 'us-east-1d', 'us-east-1e'],
-          'us-west-1': ['us-west-1a', 'us-west-1c'],
-          'us-west-2': ['us-west-2a', 'us-west-2b', 'us-west-2c'],
-          'eu-west-1': ['eu-west-1a', 'eu-west-1b', 'eu-west-1c'],
-          'ap-northeast-1': ['ap-northeast-1a', 'ap-northeast-1b', 'ap-northeast-1c'],
-          'ap-southeast-1': ['ap-southeast-1a', 'ap-southeast-1b'],
-          'ap-southeast-2': ['ap-southeast-2a', 'ap-southeast-2b'],
-          'sa-east-1': ['sa-east-1a', 'sa-east-1b']
-        },
-        test: {
-          'us-east-1': ['us-east-1c', 'us-east-1d', 'us-east-1e'],
-          'us-west-1': ['us-west-1a', 'us-west-1c'],
-          'us-west-2': ['us-west-2a', 'us-west-2b', 'us-west-2c'],
-          'eu-west-1': ['eu-west-1a', 'eu-west-1b', 'eu-west-1c'],
-          'ap-northeast-1': ['ap-northeast-1a', 'ap-northeast-1b', 'ap-northeast-1c'],
-          'ap-southeast-1': ['ap-southeast-1a', 'ap-southeast-1b'],
-          'ap-southeast-2': ['ap-southeast-2a', 'ap-southeast-2b'],
-          'sa-east-1': ['sa-east-1a', 'sa-east-1b']
-        },
-        mgmt: {
-          'us-east-1': ['us-east-1c', 'us-east-1d', 'us-east-1e'],
-          'us-west-1': ['us-west-1a', 'us-west-1c'],
-          'us-west-2': ['us-west-2a', 'us-west-2b', 'us-west-2c'],
-          'eu-west-1': ['eu-west-1a', 'eu-west-1b', 'eu-west-1c'],
-          'ap-northeast-1': ['ap-northeast-1a', 'ap-northeast-1b', 'ap-northeast-1c'],
-          'ap-southeast-1': ['ap-southeast-1a', 'ap-southeast-1b'],
-          'ap-southeast-2': ['ap-southeast-2a', 'ap-southeast-2b'],
-          'sa-east-1': ['sa-east-1a', 'sa-east-1b']
-        },
-        mgmttest: {
-          'us-east-1': ['us-east-1c', 'us-east-1d', 'us-east-1e'],
-          'us-west-1': ['us-west-1a', 'us-west-1c'],
-          'us-west-2': ['us-west-2a', 'us-west-2b', 'us-west-2c'],
-          'eu-west-1': ['eu-west-1a', 'eu-west-1b', 'eu-west-1c'],
-          'ap-northeast-1': ['ap-northeast-1a', 'ap-northeast-1b', 'ap-northeast-1c'],
-          'ap-southeast-1': ['ap-southeast-1a', 'ap-southeast-1b'],
-          'ap-southeast-2': ['ap-southeast-2a', 'ap-southeast-2b'],
-          'sa-east-1': ['sa-east-1a', 'sa-east-1b']
-        },
-        mceprod: {
-          'us-east-1': ['us-east-1a', 'us-east-1b', 'us-east-1c', 'us-east-1d', 'us-east-1e'],
-          'us-west-1': ['us-west-1a', 'us-west-1b', 'us-west-1c'],
-          'us-west-2': ['us-west-2a', 'us-west-2b', 'us-west-2c'],
-          'eu-west-1': ['eu-west-1a', 'eu-west-1b', 'eu-west-1c'],
-          'ap-northeast-1': ['ap-northeast-1a', 'ap-northeast-1b', 'ap-northeast-1c'],
-          'ap-southeast-1': ['ap-southeast-1a', 'ap-southeast-1b'],
-          'ap-southeast-2': ['ap-southeast-2a', 'ap-southeast-2b'],
-          'sa-east-1': ['sa-east-1a', 'sa-east-1b']
-        },
-        mcetest: {
-          'us-east-1': ['us-east-1a', 'us-east-1b', 'us-east-1c', 'us-east-1d'],
-          'us-west-1': ['us-west-1b', 'us-west-1c'],
-          'us-west-2': ['us-west-2a', 'us-west-2b', 'us-west-2c'],
-          'eu-west-1': ['eu-west-1a', 'eu-west-1b', 'eu-west-1c'],
-          'ap-northeast-1': ['ap-northeast-1a', 'ap-northeast-1b', 'ap-northeast-1c'],
-          'ap-southeast-1': ['ap-southeast-1a', 'ap-southeast-1b'],
-          'ap-southeast-2': ['ap-southeast-2a', 'ap-southeast-2b'],
-          'sa-east-1': ['sa-east-1a', 'sa-east-1b']
-        },
-        default: {
-          'us-east-1': ['us-east-1a', 'us-east-1b', 'us-east-1c', 'us-east-1d', 'us-east-1e'],
-          'us-west-1': ['us-west-1a', 'us-west-1b', 'us-west-1c'],
-          'us-west-2': ['us-west-2a', 'us-west-2b', 'us-west-2c'],
-          'eu-west-1': ['eu-west-1a', 'eu-west-1b', 'eu-west-1c'],
-          'ap-northeast-1': ['ap-northeast-1a', 'ap-northeast-1b', 'ap-northeast-1c'],
-          'ap-southeast-1': ['ap-southeast-1a', 'ap-southeast-1b'],
-          'ap-southeast-2': ['ap-southeast-2a', 'ap-southeast-2b'],
-          'sa-east-1': ['sa-east-1a', 'sa-east-1b']
-        }
-      }
     },
-   gce: {
+    gce: {
       defaults: {
         account: 'my-google-account',
         region: 'us-central1',
         zone: 'us-central1-f',
       },
-      primaryAccounts: ['my-google-account'],
-      challengeDestructiveActions: ['my-google-account'],
     },
     titan: {
       defaults: {
         account: 'titantest',
         region: 'us-east-1'
       },
-      primaryAccounts: ['test'],
-      primaryRegions: ['us-east-1'],
     }
   },
   whatsNew: {


### PR DESCRIPTION
Still need to determine what's required on the installation script side of things (if anything). As written, everything should should "work" without changing the scripts:
 * if there are no configured preferred zones in cloud driver, all zones will be used, which is a sensible default
 * primary accounts won't exist (unless that work has made it into the scripts), so all account tags would appear gray.

@zanthrash please review