### PR TITLE
do not initialize gce load balancers on app start

### DIFF
--- a/app/scripts/modules/google/cache/cacheConfigurer.service.js
+++ b/app/scripts/modules/google/cache/cacheConfigurer.service.js
@@ -4,11 +4,10 @@ let angular = require('angular');
 
 module.exports = angular.module('spinnaker.gce.cache.initializer', [
   require('../../core/account/account.service.js'),
-  require('../../core/loadBalancer/loadBalancer.read.service.js'),
   require('../../core/instance/instanceTypeService.js'),
   require('../../core/securityGroup/securityGroup.read.service.js'),
 ])
-  .factory('gceCacheConfigurer', function (accountService, instanceTypeService, loadBalancerReader) {
+  .factory('gceCacheConfigurer', function (accountService, instanceTypeService) {
 
     let config = Object.create(null);
 
@@ -18,10 +17,6 @@ module.exports = angular.module('spinnaker.gce.cache.initializer', [
 
     config.instanceTypes = {
       initializers: [ () => instanceTypeService.getAllTypesByRegion('gce') ],
-    };
-
-    config.loadBalancers = {
-      initializers: [ () => loadBalancerReader.listLoadBalancers('gce') ],
     };
 
     return config;


### PR DESCRIPTION
@duftler I'm going to merge this in - the only side effect is the list of load balancers for GCE will be lazy-loaded the first time it's needed, but that should get rid of the 429s folks are seeing when the app starts up without GCE enabled.