### PR TITLE
selectively apply netflix module, init cache on configured providers

### DIFF
--- a/app/scripts/modules/core/cache/cacheInitializer.js
+++ b/app/scripts/modules/core/cache/cacheInitializer.js
@@ -37,20 +37,25 @@ module.exports = angular.module('spinnaker.core.cache.initializer', [
       Object.keys(cacheConfig).forEach((key) => {
         setConfigDefaults(key, cacheConfig[key]);
       });
-      cloudProviderRegistry.listRegisteredProviders().forEach((provider) => {
-        if (serviceDelegate.hasDelegate(provider, 'cache.configurer')) {
-          let providerConfig = serviceDelegate.getDelegate(provider, 'cache.configurer');
-          Object.keys(providerConfig).forEach(function(key) {
-            setConfigDefaults(key, providerConfig[key]);
-            if (!cacheConfig[key]) {
-              cacheConfig[key] = providerConfig[key];
-            }
-            cacheConfig[key].initializers = _.uniq((cacheConfig[key].initializers).concat(providerConfig[key].initializers));
-            cacheConfig[key].onReset = _.uniq((cacheConfig[key].onReset).concat(providerConfig[key].onReset));
-            cacheConfig[key].version = Math.max(cacheConfig[key].version, providerConfig[key].version);
-            cacheConfig[key].maxAge = Math.min(cacheConfig[key].maxAge, providerConfig[key].maxAge);
-          });
-        }
+      accountService.listProviders().then((availableProviders) => {
+        cloudProviderRegistry.listRegisteredProviders().forEach((provider) => {
+          if (availableProviders.indexOf(provider) < 0) {
+            return;
+          }
+          if (serviceDelegate.hasDelegate(provider, 'cache.configurer')) {
+            let providerConfig = serviceDelegate.getDelegate(provider, 'cache.configurer');
+            Object.keys(providerConfig).forEach(function(key) {
+              setConfigDefaults(key, providerConfig[key]);
+              if (!cacheConfig[key]) {
+                cacheConfig[key] = providerConfig[key];
+              }
+              cacheConfig[key].initializers = _.uniq((cacheConfig[key].initializers).concat(providerConfig[key].initializers));
+              cacheConfig[key].onReset = _.uniq((cacheConfig[key].onReset).concat(providerConfig[key].onReset));
+              cacheConfig[key].version = Math.max(cacheConfig[key].version, providerConfig[key].version);
+              cacheConfig[key].maxAge = Math.min(cacheConfig[key].maxAge, providerConfig[key].maxAge);
+            });
+          }
+        });
       });
     }
 

--- a/app/scripts/modules/core/templateOverride/templateOverride.registry.js
+++ b/app/scripts/modules/core/templateOverride/templateOverride.registry.js
@@ -2,24 +2,23 @@
 
 let angular = require('angular');
 
-module.exports = angular.module('spinnaker.core.templateOverride.registry', [
-])
-  .provider('templateOverrideRegistry', function() {
+module.exports = angular
+  .module('spinnaker.core.templateOverride.registry', [])
+  .factory('templateOverrideRegistry', function() {
 
     const overrides = Object.create(null);
 
-    this.override = (key, val) => {
+    function override (key, val) {
       overrides[key] = val;
-    };
+    }
 
     function getTemplate(key, defaultVal) {
       return overrides[key] || defaultVal;
     }
 
-    this.$get = function() {
-      return {
-        getTemplate: getTemplate,
-      };
+    return {
+      getTemplate: getTemplate,
+      override: override,
     };
 
   }).name;

--- a/app/scripts/modules/google/cache/cacheConfigurer.service.js
+++ b/app/scripts/modules/google/cache/cacheConfigurer.service.js
@@ -4,10 +4,11 @@ let angular = require('angular');
 
 module.exports = angular.module('spinnaker.gce.cache.initializer', [
   require('../../core/account/account.service.js'),
+  require('../../core/loadBalancer/loadBalancer.read.service.js'),
   require('../../core/instance/instanceTypeService.js'),
   require('../../core/securityGroup/securityGroup.read.service.js'),
 ])
-  .factory('gceCacheConfigurer', function (accountService, instanceTypeService) {
+  .factory('gceCacheConfigurer', function (accountService, instanceTypeService, loadBalancerReader) {
 
     let config = Object.create(null);
 
@@ -17,6 +18,10 @@ module.exports = angular.module('spinnaker.gce.cache.initializer', [
 
     config.instanceTypes = {
       initializers: [ () => instanceTypeService.getAllTypesByRegion('gce') ],
+    };
+
+    config.loadBalancers = {
+      initializers: [ () => loadBalancerReader.listLoadBalancers('gce') ],
     };
 
     return config;

--- a/app/scripts/modules/netflix/netflix.module.js
+++ b/app/scripts/modules/netflix/netflix.module.js
@@ -27,21 +27,25 @@ module.exports = angular
     require('./serverGroup/diff/securityGroupDiff.directive.js'),
     require('./serverGroup/networking/networking.module.js'),
     require('./report/reservationReport.directive.js'),
+
+    require('../core/config/settings.js'),
   ])
-  .run(function(cloudProviderRegistry) {
-    cloudProviderRegistry.overrideValue(
-      'aws',
-      'instance.detailsTemplateUrl',
-      require('./instance/aws/instanceDetails.html')
-    );
-    cloudProviderRegistry.overrideValue(
-      'aws',
-      'instance.detailsController',
-      'netflixAwsInstanceDetailsCtrl'
-    );
-    cloudProviderRegistry.overrideValue(
-      'aws',
-      'serverGroup.detailsTemplateUrl',
-      require('./serverGroup/awsServerGroupDetails.html')
-    );
+  .run(function(cloudProviderRegistry, settings) {
+    if (settings.feature && settings.feature.netflixMode) {
+      cloudProviderRegistry.overrideValue(
+        'aws',
+        'instance.detailsTemplateUrl',
+        require('./instance/aws/instanceDetails.html')
+      );
+      cloudProviderRegistry.overrideValue(
+        'aws',
+        'instance.detailsController',
+        'netflixAwsInstanceDetailsCtrl'
+      );
+      cloudProviderRegistry.overrideValue(
+        'aws',
+        'serverGroup.detailsTemplateUrl',
+        require('./serverGroup/awsServerGroupDetails.html')
+      );
+    }
   }).name;

--- a/app/scripts/modules/netflix/templateOverride/templateOverrides.module.js
+++ b/app/scripts/modules/netflix/templateOverride/templateOverrides.module.js
@@ -5,12 +5,15 @@ const angular = require('angular');
 module.exports = angular
   .module('spinnaker.netflix.templateOverride.templateOverrides', [
     require('../../core/templateOverride/templateOverride.registry.js'),
+    require('../../core/config/settings.js'),
   ])
-  .config(function(templateOverrideRegistryProvider) {
-    templateOverrideRegistryProvider.override('applicationNavHeader', require('./applicationNav.html'));
-    templateOverrideRegistryProvider.override('pipelineConfigActions', require('./pipelineConfigActions.html'));
-    templateOverrideRegistryProvider.override('spinnakerHeader', require('./spinnakerHeader.html'));
-    templateOverrideRegistryProvider.override('aws.serverGroup.securityGroups', require('../serverGroup/awsServerGroupSecurityGroups.html'));
-    templateOverrideRegistryProvider.override('aws.serverGroup.capacity', require('../serverGroup/capacity/awsServerGroupCapacity.html'));
-    templateOverrideRegistryProvider.override('aws.resize.modal', require('../serverGroup/resize/awsResizeServerGroup.html'));
+  .run(function(templateOverrideRegistry, settings) {
+    if (settings.feature && settings.feature.netflixMode) {
+      templateOverrideRegistry.override('applicationNavHeader', require('./applicationNav.html'));
+      templateOverrideRegistry.override('pipelineConfigActions', require('./pipelineConfigActions.html'));
+      templateOverrideRegistry.override('spinnakerHeader', require('./spinnakerHeader.html'));
+      templateOverrideRegistry.override('aws.serverGroup.securityGroups', require('../serverGroup/awsServerGroupSecurityGroups.html'));
+      templateOverrideRegistry.override('aws.serverGroup.capacity', require('../serverGroup/capacity/awsServerGroupCapacity.html'));
+      templateOverrideRegistry.override('aws.resize.modal', require('../serverGroup/resize/awsResizeServerGroup.html'));
+    }
   }).name;

--- a/settings.js
+++ b/settings.js
@@ -134,5 +134,6 @@ window.spinnakerSettings = {
     vpcMigrator: true,
     clusterDiff: true,
     rebakeControlEnabled: false,
+    netflixMode: false,
   },
 };


### PR DESCRIPTION
@ajordens your idea of initializing caches only if the provider is actually configured on the backend is a good one.

Also adding a feature flag to enable the netflix module overrides (cc @zanthrash). Ideally, we'd be dealing with both these issues by changing app.js, but I don't see that happening any time soon and this won't be hard to unwind when we get to that point.