### PR TITLE
Shorten field name so it fits on one line

### DIFF
--- a/app/scripts/modules/core/pipeline/config/stages/bake/aws/bakeStage.html
+++ b/app/scripts/modules/core/pipeline/config/stages/bake/aws/bakeStage.html
@@ -133,7 +133,7 @@
       </div>
       <div class="form-group">
         <div class="col-md-2 col-md-offset-1 sm-label-left">
-          <b>Use Enhanced Networking</b>
+          <b>Enhanced Networking</b>
           <help-field key="pipeline.config.bake.enhancedNetworking"></help-field>
         </div>
         <div class="col-md-6">

--- a/app/scripts/modules/core/pipeline/config/stages/bake/aws/bakeStage.html
+++ b/app/scripts/modules/core/pipeline/config/stages/bake/aws/bakeStage.html
@@ -137,8 +137,12 @@
           <help-field key="pipeline.config.bake.enhancedNetworking"></help-field>
         </div>
         <div class="col-md-6">
-          <input type="checkbox"
-                 ng-model="stage.enhancedNetworking"/>
+          <div class="checkbox">
+            <label>
+              <input type="checkbox"
+                     ng-model="stage.enhancedNetworking"/>
+            </label>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
The "Use Enhanced Networking" label expanded to two lines because of its length. Shortening it to "Enhanced Networking" puts it one line.

**Before**
![image](https://cloud.githubusercontent.com/assets/192336/11282528/fed12a64-8ebc-11e5-99a0-60a4a350b7bd.png)
---
**After**
![image](https://cloud.githubusercontent.com/assets/192336/11282546/1c872216-8ebd-11e5-9d34-b203fd988cc2.png)
---
**With proper bootstrap class**
![image](https://cloud.githubusercontent.com/assets/192336/11307090/298d8ed0-8f73-11e5-9ebc-0af3b8d38541.png)

