### PR TITLE
Change 'Select All' button to 'Deselect All' when all items are selected

### DIFF
--- a/app/scripts/modules/core/forms/checklist/checklist.directive.html
+++ b/app/scripts/modules/core/forms/checklist/checklist.directive.html
@@ -20,7 +20,7 @@
     </label>
   </li>
   <li ng-if="includeSelectAllButton && items.length > 1">
-    <a href class="btn btn-default btn-xs push-left" type="button" ng-click="selectAll()">Select All</a>
+    <a href class="btn btn-default btn-xs push-left" type="button" ng-click="selectAllOrNone()">{{selectButtonText()}}</a>
   </li>
 </ul>
 <label ng-if="inline" class="checkbox-inline" ng-repeat="item in items">
@@ -35,4 +35,4 @@
    class="btn btn-default btn-xs"
    style="margin: 8px 0 0 10px"
    ng-if="inline && includeSelectAllButton && items.length > 1"
-   ng-click="selectAll()">Select All</a>
+   ng-click="selectAllOrNone()">{{selectButtonText()}}</a>

--- a/app/scripts/modules/core/forms/checklist/checklist.directive.js
+++ b/app/scripts/modules/core/forms/checklist/checklist.directive.js
@@ -54,13 +54,37 @@ module.exports = angular.module('spinnaker.core.forms.checklist.checklist.direct
           }
         }
 
-        scope.selectAll = function () {
+        function allItemsSelected() {
+          var allSelected = true;
           scope.items.forEach(function (key) {
-            scope.modelHolder[key] = true;
+            if (!scope.modelHolder[key]) {
+              allSelected = false;
+            }
           });
+          return allSelected;
+        }
+
+        scope.selectAllOrNone = function () {
+          if (allItemsSelected()) {
+            scope.items.forEach(function (key) {
+              scope.modelHolder[key] = false;
+            });
+          } else {
+            scope.items.forEach(function (key) {
+              scope.modelHolder[key] = true;
+            });
+          }
           updateModel();
         };
 
+        scope.selectButtonText = function () {
+          if (allItemsSelected()) {
+            return 'Deselect All';
+          }
+          return 'Select All';
+        };
+
+        scope.allItemsSelected = allItemsSelected;
         scope.updateModel = updateModel;
 
         scope.$watch('model', initializeModelHolder);

--- a/app/scripts/modules/core/forms/checklist/checklist.directive.spec.js
+++ b/app/scripts/modules/core/forms/checklist/checklist.directive.spec.js
@@ -83,4 +83,64 @@ describe('Directives: checklist', function () {
     expect(scope.model.selections).toEqual(['b']);
   });
 
+  it('selects all items when clicking "Select All"', function() {
+    var scope = this.scope,
+        compile = this.compile;
+
+    scope.model = {
+      selections: ['a', 'b', 'c']
+    };
+
+    scope.items = ['a', 'b', 'c', 'd'];
+
+    var html = '<checklist model="model.selections" items="items" include-select-all-button="true"></checklist>';
+    var checklist = compile(html)(scope);
+    scope.$digest();
+
+    expect(checklist.find('input:checked').size()).toBe(3);
+    $(checklist.find('a')[0]).click();
+    expect(checklist.find('input:checked').size()).toBe(4);
+  });
+
+  it('deselects all items when clicking "Deselect All"', function() {
+    var scope = this.scope,
+        compile = this.compile;
+
+    scope.model = {
+      selections: ['a', 'b', 'c', 'd']
+    };
+
+    scope.items = ['a', 'b', 'c', 'd'];
+
+    var html = '<checklist model="model.selections" items="items" inline="true" include-select-all-button="true"></checklist>';
+    var checklist = compile(html)(scope);
+    scope.$digest();
+
+    expect(checklist.find('input:checked').size()).toBe(4);
+    $(checklist.find('a')[0]).click();
+    expect(checklist.find('input:checked').size()).toBe(0);
+  });
+
+  it('shows correct text for "Deselect" or "Select" based on current selection', function() {
+    var scope = this.scope,
+        compile = this.compile;
+
+    scope.model = {
+      selections: ['a', 'b', 'c']
+    };
+
+    scope.items = ['a', 'b', 'c', 'd'];
+
+    var html = '<checklist model="model.selections" items="items" include-select-all-button="true"></checklist>';
+    var checklist = compile(html)(scope);
+    scope.$digest();
+
+    var selectButton = checklist.find('a')[0]
+
+    expect(selectButton.text).toBe('Select All'); // Some items selected
+    $(selectButton).click();
+    expect(selectButton.text).toBe('Deselect All'); // All items selected
+    $(selectButton).click();
+    expect(selectButton.text).toBe('Select All'); // No items selected
+  });
 });


### PR DESCRIPTION
If all items in a list are selected, we're left with an unhelpful "Select All" button. This changes that button to a "Deselect All" if every item is already selected. If only some of the items are selected, it remains "Select All".

![image](https://cloud.githubusercontent.com/assets/192336/11285946/64bf3070-8ecf-11e5-9805-e880381f78a3.png)
![image](https://cloud.githubusercontent.com/assets/192336/11286009/b381576a-8ecf-11e5-94ad-ebf11ce27383.png)
![image](https://cloud.githubusercontent.com/assets/192336/11285925/595ae4f4-8ecf-11e5-9054-57115bc31565.png)
