### PR TITLE
refactor platformHealthOverride directive; place consistently in modals

### DIFF
--- a/app/scripts/modules/amazon/serverGroup/configure/wizard/advancedSettings.html
+++ b/app/scripts/modules/amazon/serverGroup/configure/wizard/advancedSettings.html
@@ -106,14 +106,14 @@
         </label>
       </div>
     </div>
-
-
-    <platform-health-override ng-if="application.attributes.platformHealthOnlyShowOverride"
-                              command="command"
-                              platform-health-type="'Amazon'"
-                              label-text="Task Completion"
-                              label-columns="5">
-    </platform-health-override>
+    <div class="form-group" ng-if="application.attributes.platformHealthOnlyShowOverride">
+      <div class="col-md-5 sm-label-left"><b>Task Completion</b></div>
+      <div class="col-md-6">
+        <platform-health-override command="command"
+                                  platform-health-type="'Amazon'">
+        </platform-health-override>
+      </div>
+    </div>
   </div>
 
   <div class="modal-footer">

--- a/app/scripts/modules/amazon/serverGroup/details/resize/resizeServerGroup.html
+++ b/app/scripts/modules/amazon/serverGroup/details/resize/resizeServerGroup.html
@@ -11,8 +11,7 @@
         <div class="col-sm-10 col-sm-offset-1">
           <platform-health-override command="command"
                                     platform-health-type="'Amazon'"
-                                    show-help-details="true"
-                                    field-columns="12">
+                                    show-help-details="true">
           </platform-health-override>
         </div>
       </div>

--- a/app/scripts/modules/cloudfoundry/serverGroup/details/resize/resizeServerGroup.html
+++ b/app/scripts/modules/cloudfoundry/serverGroup/details/resize/resizeServerGroup.html
@@ -6,89 +6,97 @@
       <h3>Resize {{serverGroup.name}}</h3>
     </div>
     <div class="modal-body container-fluid form-horizontal">
-        <div ng-if="command.advancedMode">
-          <div class="form-group">
-            <div class="col-md-12">
-              <p>Sets up auto-scaling for this server group.</p>
-              <p>To disable auto-scaling, use the <a href ng-click="command.advancedMode = false">Simple Mode</a>.</p>
-            </div>
+      <div ng-if="command.advancedMode">
+        <div class="form-group">
+          <div class="col-md-12">
+            <p>Sets up auto-scaling for this server group.</p>
+            <p>To disable auto-scaling, use the <a href ng-click="command.advancedMode = false">Simple Mode</a>.</p>
           </div>
-          <div class="form-group">
-            <div class="col-md-2 col-md-offset-3"><b>Min</b></div>
-            <div class="col-md-2"><b>Max</b></div>
-            <div class="col-md-2"><b>Desired</b></div>
-          </div>
-          <div class="form-group">
-            <div class="col-md-3 text-right"><b>Current</b></div>
-            <div class="col-md-2"><b>{{currentSize.min}}</b></div>
-            <div class="col-md-2"><b>{{currentSize.max}}</b></div>
-            <div class="col-md-2"><b>{{currentSize.desired}}</b></div>
-          </div>
-          <div class="form-group">
-            <div class="col-md-3 text-right"><b>New</b></div>
-            <div class="col-md-2"><input type="number"
-                                         class="form-control input-sm"
-                                         ng-model="command.min"
-                                         min="0"
-                                         required
-                                         max="{{command.max}}"/></div>
-            <div class="col-md-2"><input type="number"
-                                         class="form-control input-sm"
-                                         ng-model="command.max"
-                                         required
-                                         min="{{command.min}}"/></div>
-            <div class="col-md-2"><input type="number"
-                                         class="form-control input-sm"
-                                         ng-model="command.desired"
-                                         required
-                                         min="{{command.min}}"
-                                         max="{{command.max}}"/></div>
-          </div>
+        </div>
+        <div class="form-group">
+          <div class="col-md-2 col-md-offset-3"><b>Min</b></div>
+          <div class="col-md-2"><b>Max</b></div>
+          <div class="col-md-2"><b>Desired</b></div>
+        </div>
+        <div class="form-group">
+          <div class="col-md-3 text-right"><b>Current</b></div>
+          <div class="col-md-2"><b>{{currentSize.min}}</b></div>
+          <div class="col-md-2"><b>{{currentSize.max}}</b></div>
+          <div class="col-md-2"><b>{{currentSize.desired}}</b></div>
+        </div>
+        <div class="form-group">
+          <div class="col-md-3 text-right"><b>New</b></div>
+          <div class="col-md-2"><input type="number"
+                                       class="form-control input-sm"
+                                       ng-model="command.min"
+                                       min="0"
+                                       required
+                                       max="{{command.max}}"/></div>
+          <div class="col-md-2"><input type="number"
+                                       class="form-control input-sm"
+                                       ng-model="command.max"
+                                       required
+                                       min="{{command.min}}"/></div>
+          <div class="col-md-2"><input type="number"
+                                       class="form-control input-sm"
+                                       ng-model="command.desired"
+                                       required
+                                       min="{{command.min}}"
+                                       max="{{command.max}}"/></div>
+        </div>
 
-        </div>
-        <div ng-if="!command.advancedMode">
-          <div class="form-group">
-            <div class="col-md-12">
-              <p>Sets min, max, and desired instance counts to the same value.</p>
-              <p> To allow true auto-scaling, use the <a href ng-click="command.advancedMode = true">Advanced Mode</a>.</p>
-            </div>
-          </div>
-          <div class="form-group">
-            <div class="col-md-12">
-              <h4>Current size:</h4>
-            </div>
-          </div>
-          <div class="form-group form-inline">
-            <div class="col-md-11 col-md-offset-1">
-              <label>
-                <input type="number"
-                       class="form-control input-sm"
-                       ng-model="currentSize.desired"
-                       style="width: 60px"
-                       readonly/>
-                instance<span ng-if="currentSize.desired > 1">s</span>
-              </label>
-            </div>
-          </div>
-          <div class="form-group">
-            <div class="col-md-12">
-              <h4>Resize to:</h4>
-            </div>
-          </div>
-          <div class="form-group form-inline">
-            <div class="col-md-11 col-md-offset-1">
-              <label>
-                <input type="number"
-                       class="form-control input-sm highlight-pristine"
-                       ng-model="command.newSize"
-                       min="0"
-                       required
-                       style="width: 60px"/>
-                instances
-              </label>
-            </div>
+      </div>
+      <div ng-if="!command.advancedMode">
+        <div class="form-group">
+          <div class="col-md-12">
+            <p>Sets min, max, and desired instance counts to the same value.</p>
+            <p> To allow true auto-scaling, use the <a href ng-click="command.advancedMode = true">Advanced Mode</a>.</p>
           </div>
         </div>
+        <div class="form-group">
+          <div class="col-md-12">
+            <h4>Current size:</h4>
+          </div>
+        </div>
+        <div class="form-group form-inline">
+          <div class="col-md-11 col-md-offset-1">
+            <label>
+              <input type="number"
+                     class="form-control input-sm"
+                     ng-model="currentSize.desired"
+                     style="width: 60px"
+                     readonly/>
+              instance<span ng-if="currentSize.desired > 1">s</span>
+            </label>
+          </div>
+        </div>
+        <div class="form-group">
+          <div class="col-md-12">
+            <h4>Resize to:</h4>
+          </div>
+        </div>
+        <div class="form-group form-inline">
+          <div class="col-md-11 col-md-offset-1">
+            <label>
+              <input type="number"
+                     class="form-control input-sm highlight-pristine"
+                     ng-model="command.newSize"
+                     min="0"
+                     required
+                     style="width: 60px"/>
+              instances
+            </label>
+          </div>
+        </div>
+      </div>
+      <div class="row" ng-if="command.platformHealthOnlyShowOverride">
+        <div class="col-sm-10 col-sm-offset-1">
+          <platform-health-override command="command"
+                                    platform-health-type="'Cloud Foundry'"
+                                    show-help-details="true">
+          </platform-health-override>
+        </div>
+      </div>
       <div class="row" ng-if="verification.required">
         <div class="col-sm-12">
           <hr/>
@@ -100,15 +108,6 @@
               <input type="text" ng-model="verification.verifyAccount" class="form-control input-sm highlight-pristine" ng-class="{'ng-invalid': verification.verifyAccount !== serverGroup.account.toUpperCase()}"/>
             </div>
           </div>
-        </div>
-      </div>
-      <div class="row" ng-if="command.platformHealthOnlyShowOverride">
-        <div class="col-sm-10 col-sm-offset-1">
-          <platform-health-override command="command"
-                                    platform-health-type="'Cloud Foundry'"
-                                    show-help-details="true"
-                                    field-columns="12">
-          </platform-health-override>
         </div>
       </div>
     </div>

--- a/app/scripts/modules/core/application/modal/platformHealthOverrideCheckbox.directive.html
+++ b/app/scripts/modules/core/application/modal/platformHealthOverrideCheckbox.directive.html
@@ -1,12 +1,9 @@
-<div class="form-group">
-  <label ng-if="labelText" class="col-md-{{labelColumns}} {{labelOffset}} sm-label-left">{{labelText}}</label>
-  <div class="col-md-{{fieldColumns || 6}} checkbox">
-    <label>
-      <input type="checkbox"
-             init-platform-health
-             ng-click="clicked($event)"/>
-      Consider only {{platformHealthType}} health
-    </label>
-    <help-field key="application.platformHealthOnly" expand="showHelpDetails"></help-field>
-  </div>
+<div class="checkbox">
+  <label>
+    <input type="checkbox"
+           init-platform-health
+           ng-click="clicked($event)"/>
+    Consider only {{platformHealthType}} health
+  </label>
+  <help-field key="application.platformHealthOnly" expand="showHelpDetails"></help-field>
 </div>

--- a/app/scripts/modules/core/confirmationModal/confirm.html
+++ b/app/scripts/modules/core/confirmationModal/confirm.html
@@ -8,6 +8,14 @@
     <form role="form" class="container-fluid" ng-submit="ctrl.confirm()">
       <div ng-if="params.body" ng-bind-html="params.body">
       </div>
+      <div class="row" ng-if="params.platformHealthOnlyShowOverride">
+        <div class="col-sm-offset-1 col-sm-10">
+          <platform-health-override command="params"
+                                    platform-health-type="params.platformHealthType"
+                                    show-help-details="true">
+          </platform-health-override>
+        </div>
+      </div>
       <div class="row" ng-if="verification.requireAccountEntry">
         <div class="col-sm-offset-1 col-sm-10">
           <p>Type the name of the account ( <account-tag account="params.account" provider="params.provider"></account-tag> ) below to continue.</p>
@@ -16,16 +24,6 @@
               <input type="text" auto-focus ng-model="verification.verifyAccount" class="form-control input-sm highlight-pristine" ng-class="{'ng-invalid': verification.verifyAccount !== params.account.toUpperCase()}"/>
             </div>
           </div>
-        </div>
-      </div>
-      <div class="row" ng-if="params.platformHealthOnlyShowOverride">
-        <div class="col-sm-offset-1 col-sm-10">
-          <platform-health-override command="params"
-                                    platform-health-type="params.platformHealthType"
-                                    field-columns="12"
-                                    show-help-details="true"
-                                    label-offset="col-sm-offset-1">
-          </platform-health-override>
         </div>
       </div>
     </form>

--- a/app/scripts/modules/core/pipeline/config/health/stagePlatformHealthOverride.directive.js
+++ b/app/scripts/modules/core/pipeline/config/health/stagePlatformHealthOverride.directive.js
@@ -1,0 +1,21 @@
+'use strict';
+
+let angular = require('angular');
+
+module.exports = angular
+  .module('spinnaker.core.pipeline.config.health.stagePlatformHealthOverride.directive', [
+  ])
+  .directive('stagePlatformHealthOverride', function() {
+    return {
+      restrict: 'E',
+      templateUrl: require('./stagePlatformHealthOverrideCheckbox.directive.html'),
+      scope: {},
+      controller: angular.noop,
+      controllerAs: 'vm',
+      bindToController: {
+        stage: '=',
+        application: '=',
+        platformHealthType: '=',
+      },
+    };
+  }).name;

--- a/app/scripts/modules/core/pipeline/config/health/stagePlatformHealthOverrideCheckbox.directive.html
+++ b/app/scripts/modules/core/pipeline/config/health/stagePlatformHealthOverrideCheckbox.directive.html
@@ -1,0 +1,10 @@
+<div class="form-group" ng-if="vm.application.attributes.platformHealthOnlyShowOverride">
+  <div class="col-md-2 col-md-offset-1 sm-label-left">
+    <b>Task Completion</b>
+  </div>
+  <div class="col-md-6">
+    <platform-health-override command="vm.stage"
+                              platform-health-type="vm.platformHealthType">
+    </platform-health-override>
+  </div>
+</div>

--- a/app/scripts/modules/core/pipeline/config/pipelineConfig.module.js
+++ b/app/scripts/modules/core/pipeline/config/pipelineConfig.module.js
@@ -18,4 +18,5 @@ module.exports = angular.module('spinnaker.core.pipeline.config', [
   require('./validation/pipelineConfigValidator.directive.js'),
   require('./targetSelect.directive.js'),
   require('./createNew.directive.js'),
+  require('./health/stagePlatformHealthOverride.directive.js'),
 ]).name;

--- a/app/scripts/modules/core/pipeline/config/stages/disableAsg/aws/disableAsgStage.html
+++ b/app/scripts/modules/core/pipeline/config/stages/disableAsg/aws/disableAsgStage.html
@@ -33,11 +33,8 @@
       <target-select model="stage" options="targets"></target-select>
     </div>
   </div>
-  <platform-health-override ng-if="application.attributes.platformHealthOnlyShowOverride"
-                            command="stage"
-                            platform-health-type="'Amazon'"
-                            label-text="Task Completion"
-                            label-columns="2"
-                            label-offset="col-md-offset-1">
-  </platform-health-override>
+  <stage-platform-health-override application="application"
+                                  stage="stage"
+                                  platform-health-type="'Amazon'">
+  </stage-platform-health-override>
 </div>

--- a/app/scripts/modules/core/pipeline/config/stages/disableAsg/gce/disableAsgStage.html
+++ b/app/scripts/modules/core/pipeline/config/stages/disableAsg/gce/disableAsgStage.html
@@ -33,12 +33,8 @@
       <target-select model="stage" options="targets"></target-select>
     </div>
   </div>
-
-  <platform-health-override ng-if="application.attributes.platformHealthOnlyShowOverride"
-                            command="stage"
-                            platform-health-type="'Google'"
-                            label-text="Task Completion"
-                            label-columns="2"
-                            label-offset="col-md-offset-1">
-  </platform-health-override>
+  <stage-platform-health-override application="application"
+                                  stage="stage"
+                                  platform-health-type="'Google'">
+  </stage-platform-health-override>
 </div>

--- a/app/scripts/modules/core/pipeline/config/stages/disableCluster/aws/disableClusterStage.html
+++ b/app/scripts/modules/core/pipeline/config/stages/disableCluster/aws/disableClusterStage.html
@@ -42,11 +42,8 @@
       </div>
     </div>
   </div>
-  <platform-health-override ng-if="application.attributes.platformHealthOnlyShowOverride"
-                            command="stage"
-                            platform-health-type="'Amazon'"
-                            label-text="Task Completion"
-                            label-columns="2"
-                            label-offset="col-md-offset-1">
-  </platform-health-override>
+  <stage-platform-health-override application="application"
+                                  stage="stage"
+                                  platform-health-type="'Amazon'">
+  </stage-platform-health-override>
 </div>

--- a/app/scripts/modules/core/pipeline/config/stages/disableCluster/gce/disableClusterStage.html
+++ b/app/scripts/modules/core/pipeline/config/stages/disableCluster/gce/disableClusterStage.html
@@ -42,11 +42,8 @@
       </div>
     </div>
   </div>
-  <platform-health-override ng-if="application.attributes.platformHealthOnlyShowOverride"
-                            command="stage"
-                            platform-health-type="'Google'"
-                            label-text="Task Completion"
-                            label-columns="2"
-                            label-offset="col-md-offset-1">
-  </platform-health-override>
+  <stage-platform-health-override application="application"
+                                  stage="stage"
+                                  platform-health-type="'Google'">
+  </stage-platform-health-override>
 </div>

--- a/app/scripts/modules/core/pipeline/config/stages/enableAsg/aws/enableAsgStage.html
+++ b/app/scripts/modules/core/pipeline/config/stages/enableAsg/aws/enableAsgStage.html
@@ -33,11 +33,8 @@
       <target-select model="stage" options="targets"></target-select>
     </div>
   </div>
-  <platform-health-override ng-if="application.attributes.platformHealthOnlyShowOverride"
-                            command="stage"
-                            platform-health-type="'Amazon'"
-                            label-text="Task Completion"
-                            label-columns="2"
-                            label-offset="col-md-offset-1">
-  </platform-health-override>
+  <stage-platform-health-override application="application"
+                                  stage="stage"
+                                  platform-health-type="'Amazon'">
+  </stage-platform-health-override>
 </div>

--- a/app/scripts/modules/core/pipeline/config/stages/enableAsg/gce/enableAsgStage.html
+++ b/app/scripts/modules/core/pipeline/config/stages/enableAsg/gce/enableAsgStage.html
@@ -33,11 +33,8 @@
       <target-select model="stage" options="targets"></target-select>
     </div>
   </div>
-  <platform-health-override ng-if="application.attributes.platformHealthOnlyShowOverride"
-                            command="stage"
-                            platform-health-type="'Google'"
-                            label-text="Task Completion"
-                            label-columns="2"
-                            label-offset="col-md-offset-1">
-  </platform-health-override>
+  <stage-platform-health-override application="application"
+                                  stage="stage"
+                                  platform-health-type="'Google'">
+  </stage-platform-health-override>
 </div>

--- a/app/scripts/modules/core/pipeline/config/stages/resizeAsg/aws/resizeAsgStage.html
+++ b/app/scripts/modules/core/pipeline/config/stages/resizeAsg/aws/resizeAsgStage.html
@@ -118,12 +118,9 @@
         <em class="subinput-note">This is the exact amount to which the target server group will be scaled</em>
       </div>
     </div>
-    <platform-health-override ng-if="application.attributes.platformHealthOnlyShowOverride"
-                              command="stage"
-                              platform-health-type="'Amazon'"
-                              label-text="Task Completion"
-                              label-columns="2"
-                              label-offset="col-md-offset-1">
-    </platform-health-override>
+    <stage-platform-health-override application="application"
+                                    stage="stage"
+                                    platform-health-type="'Amazon'">
+    </stage-platform-health-override>
   </div>
 </div>

--- a/app/scripts/modules/core/pipeline/config/stages/resizeAsg/gce/resizeAsgStage.html
+++ b/app/scripts/modules/core/pipeline/config/stages/resizeAsg/gce/resizeAsgStage.html
@@ -118,12 +118,9 @@
         <em class="subinput-note">This is the exact amount to which the target server group will be scaled</em>
       </div>
     </div>
-    <platform-health-override ng-if="application.attributes.platformHealthOnlyShowOverride"
-                              command="stage"
-                              platform-health-type="'Google'"
-                              label-text="Task Completion"
-                              label-columns="2"
-                              label-offset="col-md-offset-1">
-    </platform-health-override>
+    <stage-platform-health-override application="application"
+                                    stage="stage"
+                                    platform-health-type="'Google'">
+    </stage-platform-health-override>
   </div>
 </div>

--- a/app/scripts/modules/google/serverGroup/configure/wizard/advancedSettings.html
+++ b/app/scripts/modules/google/serverGroup/configure/wizard/advancedSettings.html
@@ -1,13 +1,14 @@
 <form name="form" class="container-fluid form-horizontal" ng-controller="gceServerGroupAdvancedSettingsCtrl as settingsCtrl" novalidate>
   <div class="modal-body">
     <gce-server-group-advanced-settings-selector command="command"></gce-server-group-advanced-settings-selector>
-    <div>
-      <platform-health-override ng-if="application.attributes.platformHealthOnlyShowOverride"
-                                command="command"
-                                platform-health-type="'Google'"
-                                label-text="Task Completion"
-                                label-columns="5">
-      </platform-health-override>
+    <div class="form-group">
+      <div class="col-md-5 sm-label-left"><b>Task Completion</b></div>
+      <div class="col-md-6">
+        <platform-health-override ng-if="application.attributes.platformHealthOnlyShowOverride"
+                                  command="command"
+                                  platform-health-type="'Google'">
+        </platform-health-override>
+      </div>
     </div>
   </div>
 

--- a/app/scripts/modules/google/serverGroup/details/resize/resizeServerGroup.html
+++ b/app/scripts/modules/google/serverGroup/details/resize/resizeServerGroup.html
@@ -6,89 +6,97 @@
       <h3>Resize {{serverGroup.name}}</h3>
     </div>
     <div class="modal-body container-fluid form-horizontal">
-        <div ng-if="command.advancedMode">
-          <div class="form-group">
-            <div class="col-md-12">
-              <p>Sets up auto-scaling for this server group.</p>
-              <p>To disable auto-scaling, use the <a href ng-click="command.advancedMode = false">Simple Mode</a>.</p>
-            </div>
+      <div ng-if="command.advancedMode">
+        <div class="form-group">
+          <div class="col-md-12">
+            <p>Sets up auto-scaling for this server group.</p>
+            <p>To disable auto-scaling, use the <a href ng-click="command.advancedMode = false">Simple Mode</a>.</p>
           </div>
-          <div class="form-group">
-            <div class="col-md-2 col-md-offset-3"><b>Min</b></div>
-            <div class="col-md-2"><b>Max</b></div>
-            <div class="col-md-2"><b>Desired</b></div>
-          </div>
-          <div class="form-group">
-            <div class="col-md-3 text-right"><b>Current</b></div>
-            <div class="col-md-2"><b>{{currentSize.min}}</b></div>
-            <div class="col-md-2"><b>{{currentSize.max}}</b></div>
-            <div class="col-md-2"><b>{{currentSize.desired}}</b></div>
-          </div>
-          <div class="form-group">
-            <div class="col-md-3 text-right"><b>New</b></div>
-            <div class="col-md-2"><input type="number"
-                                         class="form-control input-sm"
-                                         ng-model="command.min"
-                                         min="0"
-                                         required
-                                         max="{{command.max}}"/></div>
-            <div class="col-md-2"><input type="number"
-                                         class="form-control input-sm"
-                                         ng-model="command.max"
-                                         required
-                                         min="{{command.min}}"/></div>
-            <div class="col-md-2"><input type="number"
-                                         class="form-control input-sm"
-                                         ng-model="command.desired"
-                                         required
-                                         min="{{command.min}}"
-                                         max="{{command.max}}"/></div>
-          </div>
+        </div>
+        <div class="form-group">
+          <div class="col-md-2 col-md-offset-3"><b>Min</b></div>
+          <div class="col-md-2"><b>Max</b></div>
+          <div class="col-md-2"><b>Desired</b></div>
+        </div>
+        <div class="form-group">
+          <div class="col-md-3 text-right"><b>Current</b></div>
+          <div class="col-md-2"><b>{{currentSize.min}}</b></div>
+          <div class="col-md-2"><b>{{currentSize.max}}</b></div>
+          <div class="col-md-2"><b>{{currentSize.desired}}</b></div>
+        </div>
+        <div class="form-group">
+          <div class="col-md-3 text-right"><b>New</b></div>
+          <div class="col-md-2"><input type="number"
+                                       class="form-control input-sm"
+                                       ng-model="command.min"
+                                       min="0"
+                                       required
+                                       max="{{command.max}}"/></div>
+          <div class="col-md-2"><input type="number"
+                                       class="form-control input-sm"
+                                       ng-model="command.max"
+                                       required
+                                       min="{{command.min}}"/></div>
+          <div class="col-md-2"><input type="number"
+                                       class="form-control input-sm"
+                                       ng-model="command.desired"
+                                       required
+                                       min="{{command.min}}"
+                                       max="{{command.max}}"/></div>
+        </div>
 
-        </div>
-        <div ng-if="!command.advancedMode">
-          <div class="form-group">
-            <div class="col-md-12">
-              <p>Sets min, max, and desired instance counts to the same value.</p>
-              <p> To allow true auto-scaling, use the <a href ng-click="command.advancedMode = true">Advanced Mode</a>.</p>
-            </div>
-          </div>
-          <div class="form-group">
-            <div class="col-md-12">
-              <h4>Current size:</h4>
-            </div>
-          </div>
-          <div class="form-group form-inline">
-            <div class="col-md-11 col-md-offset-1">
-              <label>
-                <input type="number"
-                       class="form-control input-sm"
-                       ng-model="currentSize.desired"
-                       style="width: 60px"
-                       readonly/>
-                instance<span ng-if="currentSize.desired > 1">s</span>
-              </label>
-            </div>
-          </div>
-          <div class="form-group">
-            <div class="col-md-12">
-              <h4>Resize to:</h4>
-            </div>
-          </div>
-          <div class="form-group form-inline">
-            <div class="col-md-11 col-md-offset-1">
-              <label>
-                <input type="number"
-                       class="form-control input-sm highlight-pristine"
-                       ng-model="command.newSize"
-                       min="0"
-                       required
-                       style="width: 60px"/>
-                instances
-              </label>
-            </div>
+      </div>
+      <div ng-if="!command.advancedMode">
+        <div class="form-group">
+          <div class="col-md-12">
+            <p>Sets min, max, and desired instance counts to the same value.</p>
+            <p> To allow true auto-scaling, use the <a href ng-click="command.advancedMode = true">Advanced Mode</a>.</p>
           </div>
         </div>
+        <div class="form-group">
+          <div class="col-md-12">
+            <h4>Current size:</h4>
+          </div>
+        </div>
+        <div class="form-group form-inline">
+          <div class="col-md-11 col-md-offset-1">
+            <label>
+              <input type="number"
+                     class="form-control input-sm"
+                     ng-model="currentSize.desired"
+                     style="width: 60px"
+                     readonly/>
+              instance<span ng-if="currentSize.desired > 1">s</span>
+            </label>
+          </div>
+        </div>
+        <div class="form-group">
+          <div class="col-md-12">
+            <h4>Resize to:</h4>
+          </div>
+        </div>
+        <div class="form-group form-inline">
+          <div class="col-md-11 col-md-offset-1">
+            <label>
+              <input type="number"
+                     class="form-control input-sm highlight-pristine"
+                     ng-model="command.newSize"
+                     min="0"
+                     required
+                     style="width: 60px"/>
+              instances
+            </label>
+          </div>
+        </div>
+      </div>
+      <div class="form-group" ng-if="command.platformHealthOnlyShowOverride">
+        <div class="col-sm-10 col-md-offset-1">
+          <platform-health-override command="command"
+                                    platform-health-type="'Google'"
+                                    show-help-details="true">
+          </platform-health-override>
+        </div>
+      </div>
       <div class="row" ng-if="verification.required">
         <div class="col-sm-12">
           <hr/>
@@ -100,15 +108,6 @@
               <input type="text" ng-model="verification.verifyAccount" class="form-control input-sm highlight-pristine" ng-class="{'ng-invalid': verification.verifyAccount !== serverGroup.account.toUpperCase()}"/>
             </div>
           </div>
-        </div>
-      </div>
-      <div class="row" ng-if="command.platformHealthOnlyShowOverride">
-        <div class="col-sm-10 col-sm-offset-1">
-          <platform-health-override command="command"
-                                    platform-health-type="'Google'"
-                                    show-help-details="true"
-                                    field-columns="12">
-          </platform-health-override>
         </div>
       </div>
     </div>

--- a/app/scripts/modules/netflix/serverGroup/resize/awsResizeServerGroup.html
+++ b/app/scripts/modules/netflix/serverGroup/resize/awsResizeServerGroup.html
@@ -20,8 +20,7 @@
         <div class="col-sm-10 col-sm-offset-1">
           <platform-health-override command="command"
                                     platform-health-type="'Amazon'"
-                                    show-help-details="true"
-                                    field-columns="12">
+                                    show-help-details="true">
           </platform-health-override>
         </div>
       </div>


### PR DESCRIPTION
Not as much going on here as the 500+ line changeset implies.

Two main things re: the directive itself:
1. Split the `<platform-health-override>` directive into two separate directives: one that is used generically to render the checkbox and label, and a second, `<stage-platform-health-override>`, to generically apply the directive in stage config.
2. Remove the left-side label from the `<platform-health-override>` directive. The whole column management thing is a mess carried over from some other directives (i.e., don't blame the person who wrote this directive, blame the person who wrote the original directives the pattern was copied from).

The other thing (and the original reason I went into this code) is to put the platform health override before the account verification, which should always be the last item in any modal (if present).