### PR TITLE
fix defaultRegions usage

### DIFF
--- a/app/scripts/modules/amazon/serverGroup/configure/serverGroupCommandBuilder.service.js
+++ b/app/scripts/modules/amazon/serverGroup/configure/serverGroupCommandBuilder.service.js
@@ -20,7 +20,7 @@ module.exports = angular.module('spinnaker.aws.serverGroupCommandBuilder.service
       var regionsKeyedByAccountLoader = accountService.getRegionsKeyedByAccount('aws');
 
       var defaultCredentials = defaults.account || application.defaultCredentials.aws || settings.providers.aws.defaults.account;
-      var defaultRegion = defaults.region || application.defaultRegion || settings.providers.aws.defaults.region;
+      var defaultRegion = defaults.region || application.defaultRegions.aws || settings.providers.aws.defaults.region;
 
       var preferredZonesLoader = accountService.getAvailabilityZonesForAccountAndRegion('aws', defaultCredentials, defaultRegion);
 

--- a/app/scripts/modules/core/application/service/applications.read.service.js
+++ b/app/scripts/modules/core/application/service/applications.read.service.js
@@ -271,7 +271,7 @@ module.exports = angular
       original.securityGroups = newApplication.securityGroups;
       original.lastRefresh = newApplication.lastRefresh;
       original.securityGroupsIndex = newApplication.securityGroupsIndex;
-      original.defaultRegion = newApplication.defaultRegion;
+      original.defaultRegions = newApplication.defaultRegions;
       original.defaultCredentials = newApplication.defaultCredentials;
 
       clusterService.addTasksToServerGroups(original);

--- a/app/scripts/modules/core/application/service/applications.read.service.spec.js
+++ b/app/scripts/modules/core/application/service/applications.read.service.spec.js
@@ -2,10 +2,14 @@
 
 describe('Service: applicationReader', function () {
 
-  //NOTE: This is only testing the service dependencies. Please add more tests.
-
   var applicationReader;
   var application;
+  var securityGroupReader;
+  var loadBalancerReader;
+  var clusterService;
+  var $http;
+  var $q;
+  var $scope;
 
   beforeEach(
     window.module(
@@ -14,14 +18,164 @@ describe('Service: applicationReader', function () {
   );
 
   beforeEach(
-    window.inject(function (_applicationReader_) {
+    window.inject(function (_applicationReader_, _securityGroupReader_, _clusterService_, $httpBackend, _$q_, _loadBalancerReader_, $rootScope) {
       applicationReader = _applicationReader_;
+      securityGroupReader = _securityGroupReader_;
+      clusterService = _clusterService_;
+      loadBalancerReader = _loadBalancerReader_;
+      $http = $httpBackend;
+      $q = _$q_;
       application = {};
+      $scope = $rootScope.$new();
     })
   );
 
-  it('should instantiate the controller', function () {
-    expect(applicationReader).toBeDefined();
+  describe('load application', function () {
+
+    function loadApplication(serverGroups, loadBalancers, securityGroupsByApplicationName) {
+      $http.expectGET('/applications/deck').respond(200, {name: 'deck', attributes: {}});
+      spyOn(securityGroupReader, 'loadSecurityGroupsByApplicationName').and.returnValue($q.when(securityGroupsByApplicationName));
+      spyOn(loadBalancerReader, 'loadLoadBalancers').and.returnValue($q.when(loadBalancers));
+      spyOn(clusterService, 'loadServerGroups').and.returnValue($q.when(serverGroups));
+      spyOn(securityGroupReader, 'loadSecurityGroups').and.returnValue($q.when([]));
+      spyOn(securityGroupReader, 'attachSecurityGroups').and.callFake(function(app, derivedGroups, groupsByName) {
+        app.securityGroups = derivedGroups.concat(groupsByName);
+        return $q.when(app);
+      });
+
+      return applicationReader.getApplication('deck');
+    }
+
+    describe('setting default credentials and regions', function () {
+      it('sets default credentials and region from server group when only one account/region found', function () {
+        var serverGroups = [{
+              name: 'deck-test-v001',
+              cluster: 'deck-test',
+              account: 'test',
+              region: 'us-west-2',
+              provider: 'aws',
+              instances: []
+            }],
+            loadBalancers = [],
+            securityGroupsByApplicationName = [],
+            result = null;
+
+        loadApplication(serverGroups, loadBalancers, securityGroupsByApplicationName).then((app) => {
+          result = app;
+        });
+        $scope.$digest();
+        $http.flush();
+        expect(result.defaultCredentials.aws).toBe('test');
+        expect(result.defaultRegions.aws).toBe('us-west-2');
+      });
+
+      it('sets default credentials and region from load balancer when only one account/region found', function () {
+        var serverGroups = [],
+            loadBalancers = [{name: 'deck-frontend', account: 'prod', type: 'gce', region: 'us-central-1', serverGroups: []}],
+            securityGroupsByApplicationName = [],
+            result = null;
+
+        loadApplication(serverGroups, loadBalancers, securityGroupsByApplicationName).then((app) => {
+          result = app;
+        });
+        $scope.$digest();
+        $http.flush();
+        expect(result.defaultCredentials.gce).toBe('prod');
+        expect(result.defaultRegions.gce).toBe('us-central-1');
+      });
+
+      it('sets default credentials and region from security group', function () {
+        var serverGroups = [],
+            loadBalancers = [],
+            securityGroupsByApplicationName = [{name: 'deck-test', type: 'cf', accountName: 'test', region: 'us-south-7'}],
+            result = null;
+
+        loadApplication(serverGroups, loadBalancers, securityGroupsByApplicationName).then((app) => {
+          result = app;
+        });
+        $scope.$digest();
+        $http.flush();
+        expect(result.defaultCredentials.cf).toBe('test');
+        expect(result.defaultRegions.cf).toBe('us-south-7');
+      });
+
+      it('does not set defaults when multiple values found for the same provider', function () {
+        var serverGroups = [],
+            loadBalancers = [{name: 'deck-frontend', account: 'prod', type: 'aws', region: 'us-west-1', serverGroups: []}],
+            securityGroupsByApplicationName = [{name: 'deck-test', type: 'aws', accountName: 'test', region: 'us-east-1'}],
+            result = null;
+
+        loadApplication(serverGroups, loadBalancers, securityGroupsByApplicationName).then((app) => {
+          result = app;
+        });
+        $scope.$digest();
+        $http.flush();
+        expect(result.defaultCredentials.aws).toBeUndefined();
+        expect(result.defaultRegions.aws).toBeUndefined();
+      });
+
+      it('sets default region or default credentials if possible', function () {
+        var serverGroups = [],
+            loadBalancers = [{name: 'deck-frontend', account: 'prod', type: 'aws', region: 'us-east-1', serverGroups: []}],
+            securityGroupsByApplicationName = [{name: 'deck-test', type: 'aws', accountName: 'test', region: 'us-east-1'}],
+            result = null;
+
+        loadApplication(serverGroups, loadBalancers, securityGroupsByApplicationName).then((app) => {
+          result = app;
+        });
+        $scope.$digest();
+        $http.flush();
+        expect(result.defaultCredentials.aws).toBeUndefined();
+        expect(result.defaultRegions.aws).toBe('us-east-1');
+      });
+
+      it('sets default credentials, even if region cannot be set', function () {
+        var serverGroups = [],
+            loadBalancers = [{name: 'deck-frontend', account: 'test', type: 'aws', region: 'us-east-1', serverGroups: []}],
+            securityGroupsByApplicationName = [{name: 'deck-test', type: 'aws', accountName: 'test', region: 'us-west-1'}],
+            result = null;
+
+        loadApplication(serverGroups, loadBalancers, securityGroupsByApplicationName).then((app) => {
+          result = app;
+        });
+        $scope.$digest();
+        $http.flush();
+        expect(result.defaultCredentials.aws).toBe('test');
+        expect(result.defaultRegions.aws).toBeUndefined();
+      });
+
+      it('should set defaults for multiple providers', function () {
+        var serverGroups = [
+              {
+                name: 'deck-test-v001',
+                account: 'test',
+                region: 'us-west-2',
+                provider: 'aws',
+                instances: []
+              },
+              {
+                name: 'deck-gce-v001',
+                account: 'gce-test',
+                region: 'us-central-1',
+                provider: 'gce',
+                instances: [],
+              }
+            ],
+            loadBalancers = [{name: 'deck-frontend', account: 'gce-test', type: 'gce', region: 'us-central-1', serverGroups: []}],
+            securityGroupsByApplicationName = [{name: 'deck-test', type: 'aws', accountName: 'test', region: 'us-west-2'}],
+            result = null;
+
+        loadApplication(serverGroups, loadBalancers, securityGroupsByApplicationName).then((app) => {
+          result = app;
+        });
+        $scope.$digest();
+        $http.flush();
+        expect(result.defaultCredentials.aws).toBe('test');
+        expect(result.defaultRegions.aws).toBe('us-west-2');
+        expect(result.defaultCredentials.gce).toBe('gce-test');
+        expect(result.defaultRegions.gce).toBe('us-central-1');
+      });
+    });
   });
 
   describe('adding executions to applications', function () {

--- a/app/scripts/modules/core/pipeline/config/stages/bake/aws/awsBakeStage.js
+++ b/app/scripts/modules/core/pipeline/config/stages/bake/aws/awsBakeStage.js
@@ -63,11 +63,11 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.aws.bakeStage', [
         } else if ($scope.regions.indexOf($scope.stage.region) === -1) {
           delete $scope.stage.region;
         }
-        if (!$scope.stage.regions.length && $scope.application.defaultRegion) {
-          $scope.stage.regions.push($scope.application.defaultRegion);
+        if (!$scope.stage.regions.length && $scope.application.defaultRegions.aws) {
+          $scope.stage.regions.push($scope.application.defaultRegions.aws);
         }
-        if (!$scope.stage.regions.length && $scope.application.defaultRegion) {
-          $scope.stage.regions.push($scope.application.defaultRegion);
+        if (!$scope.stage.regions.length && $scope.application.defaultRegions.aws) {
+          $scope.stage.regions.push($scope.application.defaultRegions.aws);
         }
         $scope.baseOsOptions = results.baseOsOptions;
         $scope.baseLabelOptions = results.baseLabelOptions;

--- a/app/scripts/modules/core/pipeline/config/stages/disableAsg/aws/awsDisableAsgStage.js
+++ b/app/scripts/modules/core/pipeline/config/stages/disableAsg/aws/awsDisableAsgStage.js
@@ -64,7 +64,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.aws.disableAsgSta
       stage.credentials = $scope.application.defaultCredentials.aws;
     }
     if (!stage.regions.length && $scope.application.defaultRegions.aws) {
-      stage.regions.push($scope.application.defaultRegion.aws);
+      stage.regions.push($scope.application.defaultRegions.aws);
     }
 
     if (stage.credentials) {

--- a/app/scripts/modules/core/pipeline/config/stages/resizeAsg/cf/cfResizeAsgStage.js
+++ b/app/scripts/modules/core/pipeline/config/stages/resizeAsg/cf/cfResizeAsgStage.js
@@ -92,8 +92,8 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.cf.resizeAsgStage
     if (!stage.credentials && $scope.application.defaultCredentials) {
       stage.credentials = $scope.application.defaultCredentials;
     }
-    if (!stage.regions.length && $scope.application.defaultRegion) {
-      stage.regions.push($scope.application.defaultRegion);
+    if (!stage.regions.length && $scope.application.defaultRegions.cf) {
+      stage.regions.push($scope.application.defaultRegions.cf);
     }
 
     if (stage.credentials) {


### PR DESCRIPTION
Missed these in a prior refactoring.

Also adding some tests around setting default regions/credentials, since we have next to no test coverage on the applicationReader. There should be a lot more tests, considering the complexity of that operation, but I think we want to refactor it quite a bit, which would be a good opportunity to add some test coverage.

@duftler please review