### PR TITLE
remove extraneous settings fields from azure block

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -19,24 +19,6 @@ window.spinnakerSettings = {
         account: 'azure-test',
         region: 'West US'
       },
-      primaryAccounts: ['azure-test'],
-      primaryRegions: ['West US', 'East US', 'Central US', 'North Central US', 'South Central US'],
-      preferredZonesByAccount: {
-	test: {
-           'West US': ['West US'],
-           'East US': ['East US'],
-           'Central US': ['Central US'],
-           'North Central US': ['North Central US'],
-           'South Central US': ['South Central US']
-        },
-	default: {
-           'West US': ['West US'],
-           'East US': ['East US'],
-           'Central US': ['Central US'],
-           'North Central US': ['North Central US'],
-           'South Central US': ['South Central US']
-	}
-     }
     },
     aws: {
       defaults: {


### PR DESCRIPTION
These settings have been moved to Clouddriver, so are no longer needed in settings.js

cc @JargoonPard - can you review this and verify everything is still working as expected?