### PR TITLE
refactor application reader; rx replacing $broadcast

### DIFF
--- a/app/scripts/modules/amazon/instance/details/instance.details.controller.spec.js
+++ b/app/scripts/modules/amazon/instance/details/instance.details.controller.spec.js
@@ -3,12 +3,12 @@
 
 describe('Controller: awsInstanceDetailsCtrl', function () {
 
-  //NOTE: This is only testing the controllers dependencies. Please add more tests.
-
   var controller;
   var scope;
   var instanceReader;
   var $q;
+  var rx;
+  var refreshStream;
 
   beforeEach(
     window.module(
@@ -17,22 +17,24 @@ describe('Controller: awsInstanceDetailsCtrl', function () {
   );
 
   beforeEach(
-    window.inject(function ($rootScope, $controller, _instanceReader_, _$q_) {
+    window.inject(function ($rootScope, $controller, _instanceReader_, _$q_, _rx_) {
       scope = $rootScope.$new();
       instanceReader = _instanceReader_;
       $q = _$q_;
+      rx = _rx_;
+      refreshStream = new rx.Subject();
 
       controller = $controller('awsInstanceDetailsCtrl', {
         $scope: scope,
         instance: {},
         app: {
-          registerAutoRefreshHandler: angular.noop
+          autoRefreshStream: refreshStream
         },
         overrides: {},
       });
 
       this.createController = function(application, instance) {
-        application.registerAutoRefreshHandler = application.registerAutoRefreshHandler || angular.noop;
+        application.autoRefreshStream = application.autoRefreshStream || refreshStream;
         controller = $controller('awsInstanceDetailsCtrl', {
           $scope: scope,
           instance: instance,

--- a/app/scripts/modules/amazon/serverGroup/configure/wizard/ServerGroupBasicSettings.controller.js
+++ b/app/scripts/modules/amazon/serverGroup/configure/wizard/ServerGroupBasicSettings.controller.js
@@ -12,7 +12,7 @@ module.exports = angular.module('spinnaker.serverGroup.configure.aws.basicSettin
   require('../../../../core/naming/naming.service.js'),
 ])
   .controller('awsServerGroupBasicSettingsCtrl', function($scope, $controller, $uibModalStack, $state,
-                                                          modalWizardService, RxService, imageReader, namingService) {
+                                                          modalWizardService, rx, imageReader, namingService) {
 
     function searchImages(q) {
       $scope.command.backingData.filtered.images = [
@@ -20,7 +20,7 @@ module.exports = angular.module('spinnaker.serverGroup.configure.aws.basicSettin
           message: '<span class="glyphicon glyphicon-spinning glyphicon-asterisk"></span> Finding results matching "' + q + '"...'
         }
       ];
-      return RxService.Observable.fromPromise(
+      return rx.Observable.fromPromise(
         imageReader.findImages({
           provider: $scope.command.selectedProvider,
           q: q,
@@ -29,7 +29,7 @@ module.exports = angular.module('spinnaker.serverGroup.configure.aws.basicSettin
       );
     }
 
-    var imageSearchResultsStream = new RxService.Subject();
+    var imageSearchResultsStream = new rx.Subject();
 
     imageSearchResultsStream
       .throttle(250)
@@ -63,7 +63,6 @@ module.exports = angular.module('spinnaker.serverGroup.configure.aws.basicSettin
 
     angular.extend(this, $controller('BasicSettingsMixin', {
       $scope: $scope,
-      RxService: RxService,
       imageReader: imageReader,
       namingService: namingService,
       $uibModalStack: $uibModalStack,

--- a/app/scripts/modules/azure/serverGroup/configure/serverGroupBasicSettingsSelector.directive.js
+++ b/app/scripts/modules/azure/serverGroup/configure/serverGroupBasicSettingsSelector.directive.js
@@ -21,11 +21,10 @@ module.exports = angular
       controller: 'ServerGroupBasicSettingsSelectorCtrl as basicSettingsCtrl',
     };
   })
-  .controller('azureServerGroupBasicSettingsSelectorCtrl', function($scope, $controller, RxService, imageReader, namingService, $modalStack, $state) {
+  .controller('azureServerGroupBasicSettingsSelectorCtrl', function($scope, $controller, imageReader, namingService, $modalStack, $state) {
 
     angular.extend(this, $controller('BasicSettingsMixin', {
       $scope: $scope,
-      RxService: RxService,
       imageReader: imageReader,
       namingService: namingService,
       $modalStack: $modalStack,

--- a/app/scripts/modules/cloudfoundry/serverGroup/configure/serverGroupBasicSettingsSelector.directive.js
+++ b/app/scripts/modules/cloudfoundry/serverGroup/configure/serverGroupBasicSettingsSelector.directive.js
@@ -16,10 +16,9 @@ module.exports = angular.module('spinnaker.serverGroup.configure.cf.basicSetting
       controller: 'cfServerGroupBasicSettingsSelectorCtrl as basicSettingsCtrl',
     };
   })
-  .controller('cfServerGroupBasicSettingsSelectorCtrl', function($scope, $controller, RxService, imageReader, namingService, $uibModalStack, $state) {
+  .controller('cfServerGroupBasicSettingsSelectorCtrl', function($scope, $controller, imageReader, namingService, $uibModalStack, $state) {
     angular.extend(this, $controller('BasicSettingsMixin', {
       $scope: $scope,
-      RxService: RxService,
       imageReader: imageReader,
       namingService: namingService,
       $uibModalStack: $uibModalStack,

--- a/app/scripts/modules/core/delivery/filter/executionFilter.controller.js
+++ b/app/scripts/modules/core/delivery/filter/executionFilter.controller.js
@@ -45,8 +45,14 @@ module.exports = angular.module('spinnaker.core.delivery.filter.executionFilter.
       this.updateExecutionGroups();
     };
 
-    $scope.$on('executions-reloaded', this.initialize);
-    $scope.$on('pipelineConfigs-reloaded', this.initialize);
+    var executionWatcher = this.application.executionRefreshStream.subscribe(this.initialize);
+    var pipelineConfigWatcher = this.application.pipelineConfigRefreshStream.subscribe(this.initialize);
+
+    $scope.$on('$destroy', () => {
+      executionWatcher.dispose();
+      pipelineConfigWatcher.dispose();
+    });
+
     this.initialize();
 
     $scope.$on('$destroy', $rootScope.$on('$locationChangeSuccess', () => {

--- a/app/scripts/modules/core/pipeline/config/pipelineConfig.controller.spec.js
+++ b/app/scripts/modules/core/pipeline/config/pipelineConfig.controller.spec.js
@@ -4,27 +4,55 @@ describe('Controller: PipelineConfigCtrl', function () {
 
   var controller;
   var scope;
+  var rx;
 
   beforeEach(
     window.module(
-      require('./pipelineConfig.controller.js')
+      require('./pipelineConfig.controller.js'),
+      require('../../utils/rx.js')
     )
   );
 
   beforeEach(
-    window.inject(function ($rootScope, $controller) {
+    window.inject(function ($rootScope, $controller, _rx_) {
       scope = $rootScope.$new();
       controller = $controller;
+      rx = _rx_;
     })
   );
 
-  it('should reload pipeline configs if not present on application', function () {
-    scope.application = { reloadPipelineConfigs: angular.noop };
-    spyOn(scope.application, 'reloadPipelineConfigs');
-    controller('PipelineConfigCtrl', {
-      $scope: scope
+  it('should initialize immediately if pipeline configs are already present', function () {
+    scope.application = {
+      pipelineConfigs: [
+        { id: 'a'}
+      ]
+    };
+    let vm = controller('PipelineConfigCtrl', {
+      $scope: scope,
+      $stateParams: {
+        pipelineId: 'a'
+      }
     });
-    expect(scope.application.reloadPipelineConfigs.calls.count()).toBe(1);
+    expect(vm.state.pipelinesLoaded).toBe(true);
+  });
+
+  it('should wait until pipeline configs are loaded before initializing', function () {
+    var pipelineConfigRefreshStream = new rx.Subject();
+    scope.application = {
+      pipelineConfigRefreshStream: pipelineConfigRefreshStream,
+    };
+    pipelineConfigRefreshStream.onNext();
+    let vm = controller('PipelineConfigCtrl', {
+      $scope: scope,
+      $stateParams: {
+        pipelineId: 'a'
+      }
+    });
+
+    scope.application.pipelineConfigs = [ {id: 'a'} ];
+    pipelineConfigRefreshStream.onNext();
+
+    expect(vm.state.pipelinesLoaded).toBe(true);
   });
 });
 

--- a/app/scripts/modules/core/scheduler/scheduler.service.js
+++ b/app/scripts/modules/core/scheduler/scheduler.service.js
@@ -6,12 +6,12 @@ module.exports = angular.module('spinnaker.core.scheduler', [
   require('../utils/rx.js'),
   require('../config/settings.js')
 ])
-  .factory('scheduler', function(RxService, settings, $q, $log, $window, $timeout) {
-    var scheduler = new RxService.Subject();
+  .factory('scheduler', function(rx, settings, $q, $log, $window, $timeout) {
+    var scheduler = new rx.Subject();
 
     let lastRun = new Date().getTime();
 
-    let source = RxService.Observable
+    let source = rx.Observable
       .timer(0, settings.pollSchedule)
       .pausable(scheduler);
 

--- a/app/scripts/modules/core/search/infrastructure/infrastructureSearch.service.js
+++ b/app/scripts/modules/core/search/infrastructure/infrastructureSearch.service.js
@@ -8,7 +8,7 @@ module.exports = angular.module('spinnaker.infrastructure.search.service', [
   require('../../application/service/applications.read.service.js'),
   require('../../cloudProvider/serviceDelegate.service.js'),
 ])
-  .factory('infrastructureSearchService', function(RxService, $q, searchService, urlBuilderService, applicationReader, serviceDelegate) {
+  .factory('infrastructureSearchService', function(rx, $q, searchService, urlBuilderService, applicationReader, serviceDelegate) {
     return function() {
       var deferred;
 
@@ -77,7 +77,7 @@ module.exports = angular.module('spinnaker.infrastructure.search.service', [
         };
       }
 
-      var querySubject = new RxService.Subject();
+      var querySubject = new rx.Subject();
 
       let initializeCategories = () => {
         let categories = {};
@@ -103,10 +103,10 @@ module.exports = angular.module('spinnaker.infrastructure.search.service', [
       querySubject
         .flatMapLatest(function(query) {
           if (!query || !angular.isDefined(query) || query.length < 1) {
-            return RxService.Observable.just(searchService.getFallbackResults());
+            return rx.Observable.just(searchService.getFallbackResults());
           }
 
-          return RxService.Observable.fromPromise(searchService.search({
+          return rx.Observable.fromPromise(searchService.search({
            q: query,
            type: Object.keys(searchConfig),
           }));

--- a/app/scripts/modules/core/serverGroup/configure/common/basicSettingsMixin.controller.js
+++ b/app/scripts/modules/core/serverGroup/configure/common/basicSettingsMixin.controller.js
@@ -6,12 +6,11 @@ module.exports = angular
   .module('spinnaker.core.serverGroup.basicSettings.controller', [
     require('angular-ui-bootstrap'),
     require('angular-ui-router'),
-    require('../../../utils/rx.js'),
     require('../../../utils/lodash.js'),
     require('../../../naming/naming.service.js'),
     require('../../../image/image.reader.js')
   ])
-  .controller('BasicSettingsMixin', function ($scope, RxService, imageReader, namingService, $uibModalStack, $state, _) {
+  .controller('BasicSettingsMixin', function ($scope, imageReader, namingService, $uibModalStack, $state, _) {
 
     this.createsNewCluster = function() {
       var name = this.getNamePreview();

--- a/app/scripts/modules/core/serverGroup/configure/common/basicSettingsMixin.controller.spec.js
+++ b/app/scripts/modules/core/serverGroup/configure/common/basicSettingsMixin.controller.spec.js
@@ -9,13 +9,12 @@ describe('Basic Settings Mixin Controller:', function () {
     )
   );
 
-  beforeEach(window.inject(function($controller, $rootScope, RxService, namingService) {
+  beforeEach(window.inject(function($controller, $rootScope, namingService) {
     $scope = $rootScope.$new();
     $scope.application = { name: 'app', serverGroups: [] };
     $scope.command = { viewState: { }};
     controller = $controller('BasicSettingsMixin',{
       $scope: $scope,
-      RxService: RxService,
       namingService: namingService,
       $uibModalStack: { dismissAll: angular.noop },
     });

--- a/app/scripts/modules/core/utils/jQuery.js
+++ b/app/scripts/modules/core/utils/jQuery.js
@@ -3,7 +3,7 @@
 let angular = require('angular');
 let $ = require('jquery');
 
-module.exports = angular.module('spinnaker.core.utils.jQuery', [])
-  .factory('$', function() {
-    return $;
-  }).name;
+module.exports = angular
+  .module('spinnaker.core.utils.jQuery', [])
+  .constant('$', $)
+  .name;

--- a/app/scripts/modules/core/utils/lodash.js
+++ b/app/scripts/modules/core/utils/lodash.js
@@ -3,6 +3,7 @@ const _ = require('lodash');
 
 let angular = require('angular');
 
-module.exports = angular.module('spinnaker.core.utils.lodash', [])
+module.exports = angular
+  .module('spinnaker.core.utils.lodash', [])
   .constant('_', _ )
   .name;

--- a/app/scripts/modules/core/utils/rx.js
+++ b/app/scripts/modules/core/utils/rx.js
@@ -3,8 +3,7 @@
 let rx = require('rx');
 let angular = require('angular');
 
-module.exports = angular.module('spinnaker.core.utils.rx', [])
-  .factory('RxService', function () {
-    return rx;
-  }
-).name;
+module.exports = angular
+  .module('spinnaker.core.utils.rx', [])
+  .constant('rx', rx)
+  .name;

--- a/app/scripts/modules/google/serverGroup/configure/serverGroupBasicSettingsSelector.directive.js
+++ b/app/scripts/modules/google/serverGroup/configure/serverGroupBasicSettingsSelector.directive.js
@@ -20,10 +20,9 @@ module.exports = angular.module('spinnaker.serverGroup.configure.gce.basicSettin
       controller: 'gceServerGroupBasicSettingsSelectorCtrl as basicSettingsCtrl',
     };
   })
-  .controller('gceServerGroupBasicSettingsSelectorCtrl', function($scope, $controller, RxService, imageReader, namingService, $uibModalStack, $state) {
+  .controller('gceServerGroupBasicSettingsSelectorCtrl', function($scope, $controller, imageReader, namingService, $uibModalStack, $state) {
     angular.extend(this, $controller('BasicSettingsMixin', {
       $scope: $scope,
-      RxService: RxService,
       imageReader: imageReader,
       namingService: namingService,
       $uibModalStack: $uibModalStack,

--- a/app/scripts/modules/titan/serverGroup/configure/serverGroupBasicSettingsSelector.directive.js
+++ b/app/scripts/modules/titan/serverGroup/configure/serverGroupBasicSettingsSelector.directive.js
@@ -16,10 +16,9 @@ module.exports = angular.module('spinnaker.serverGroup.configure.titan.basicSett
       controller: 'titanServerGroupBasicSettingsSelectorCtrl as basicSettingsCtrl',
     };
   })
-  .controller('titanServerGroupBasicSettingsSelectorCtrl', function($scope, $controller, RxService, namingService, $uibModalStack, $state) {
+  .controller('titanServerGroupBasicSettingsSelectorCtrl', function($scope, $controller, namingService, $uibModalStack, $state) {
     angular.extend(this, $controller('BasicSettingsMixin', {
       $scope: $scope,
-      RxService: RxService,
       namingService: namingService,
       $uibModalStack: $uibModalStack,
       $state: $state,


### PR DESCRIPTION
Trying to get away from passing scope objects into the application object by providing `Observable`s that controllers can subscribe to in order to react to application refresh events.

The code feels a little more verbose (we have to remember to dispose of the subscription when the controller $scope is destroyed), but seems more correct than having the application manage the events when it refreshes. It also feels a lot cleaner than using `$rootScope.$broadcast` everywhere.

Also starting to refactor the `applicationReader` service into more manageable (i.e. non-200-line) methods.

I am not very familiar with RxJS, so any feedback is welcome here.