### PR TITLE
fix submit button on AWS resize modal

### DIFF
--- a/app/scripts/modules/amazon/serverGroup/details/resize/resizeServerGroup.html
+++ b/app/scripts/modules/amazon/serverGroup/details/resize/resizeServerGroup.html
@@ -20,6 +20,6 @@
       <aws-verification account="serverGroup.account" verification="verification"></aws-verification>
 
     </div>
-    <aws-footer resize="ctrl.resize()" cancel="ctrl.cancel()" is-valid="ctrl.isValid()"></aws-footer>
+    <aws-footer action="ctrl.resize()" cancel="ctrl.cancel()" is-valid="ctrl.isValid()"></aws-footer>
   </form>
 </div>


### PR DESCRIPTION
Missed this on a previous PR - the footer directive's API changed, renaming "resize" to a generic "action".