### PR TITLE
Add support for Rollback operation on Google server groups.

### DIFF
--- a/app/scripts/modules/google/serverGroup/details/rollback/rollbackServerGroup.controller.js
+++ b/app/scripts/modules/google/serverGroup/details/rollback/rollbackServerGroup.controller.js
@@ -1,0 +1,65 @@
+'use strict';
+
+let angular = require('angular');
+
+module.exports = angular.module('spinnaker.google.serverGroup.details.rollback.controller', [
+      require('../../../../core/account/account.service.js'),
+      require('../../../../core/application/modal/platformHealthOverride.directive.js'),
+      require('../../../../core/serverGroup/serverGroup.write.service.js'),
+      require('../../../../core/task/monitor/taskMonitorService.js'),
+    ])
+    .controller('gceRollbackServerGroupCtrl', function ($scope, $modalInstance, accountService, serverGroupWriter,
+                                                        taskMonitorService,
+                                                        application, serverGroup, disabledServerGroups) {
+      $scope.serverGroup = serverGroup;
+      $scope.disabledServerGroups = disabledServerGroups.sort((a, b) => b.name.localeCompare(a.name));
+      $scope.verification = {
+        required: accountService.challengeDestructiveActions('gce', serverGroup.account)
+      };
+
+      $scope.command = {
+        rollbackType: 'EXPLICIT',
+        rollbackContext: {
+          rollbackServerGroupName: serverGroup.name
+        },
+        zone: serverGroup.zones[0],
+      };
+
+      if (application && application.attributes) {
+        $scope.command.platformHealthOnlyShowOverride = application.attributes.platformHealthOnlyShowOverride;
+      }
+
+      this.isValid = function () {
+        var command = $scope.command;
+        if ($scope.verification.required && $scope.verification.verifyAccount !== serverGroup.account.toUpperCase()) {
+          return false;
+        }
+
+        return command.rollbackContext.restoreServerGroupName !== undefined;
+      };
+
+      this.rollback = function () {
+        if (!this.isValid()) {
+          return;
+        }
+
+        var submitMethod = function () {
+          return serverGroupWriter.rollbackServerGroup(serverGroup, application, $scope.command);
+        };
+
+        var taskMonitorConfig = {
+          modalInstance: $modalInstance,
+          application: application,
+          title: 'Rollback ' + serverGroup.name,
+          submitMethod: submitMethod
+        };
+
+        $scope.taskMonitor = taskMonitorService.buildTaskMonitor(taskMonitorConfig);
+
+        $scope.taskMonitor.submit(submitMethod);
+      };
+
+      this.cancel = function () {
+        $modalInstance.dismiss();
+      };
+    }).name;

--- a/app/scripts/modules/google/serverGroup/details/rollback/rollbackServerGroup.html
+++ b/app/scripts/modules/google/serverGroup/details/rollback/rollbackServerGroup.html
@@ -1,0 +1,54 @@
+<div modal-page class="confirmation-modal">
+  <task-monitor monitor="taskMonitor"></task-monitor>
+  <form role="form">
+    <modal-close></modal-close>
+    <div class="modal-header">
+      <h3>Rollback {{serverGroup.name}}</h3>
+    </div>
+    <div class="modal-body confirmation-modal">
+      <div class="row">
+        <div class="col-sm-4 col-sm-offset-1">
+          <strong>Restore Server Group</strong>
+        </div>
+        <div class="col-sm-6">
+          <ui-select ng-model="command.rollbackContext.restoreServerGroupName" class="form-control input-sm">
+            <ui-select-match placeholder="Select...">{{$select.selected.name}}</ui-select-match>
+            <ui-select-choices repeat="serverGroup.name as serverGroup in disabledServerGroups">
+              <span ng-bind-html="serverGroup.name"></span>
+            </ui-select-choices>
+          </ui-select>
+        </div>
+      </div>
+      <div class="row" ng-if="command.platformHealthOnlyShowOverride">
+        <div class="col-sm-10 col-sm-offset-1">
+          <platform-health-override command="command"
+                                    platform-health-type="'Google'"
+                                    show-help-details="true"
+                                    field-columns="12">
+          </platform-health-override>
+        </div>
+      </div>
+      <div class="row verification" ng-if="verification.required" style="margin-top: 10px">
+        <div class="col-sm-offset-1 col-sm-10">
+          <p>Type the name of the account ( <account-tag account="serverGroup.account"></account-tag> ) below to continue.</p>
+          <div class="form-inline">
+            <div class="form-group">
+              <input type="text" ng-model="verification.verifyAccount" class="form-control input-sm highlight-pristine"
+                     ng-class="{'ng-invalid': verification.verifyAccount !== serverGroup.account.toUpperCase()}"/>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="modal-footer">
+      <button type="submit" ng-click="ctrl.rollback()" style="display:none"></button> <!-- Allows form submission via enter keypress-->
+      <button class="btn btn-default" ng-click="ctrl.cancel()">Cancel</button>
+      <button type="submit"
+              class="btn btn-primary"
+              ng-click="ctrl.rollback()"
+              ng-disabled="!ctrl.isValid()">
+        Submit
+      </button>
+    </div>
+  </form>
+</div>

--- a/app/scripts/modules/google/serverGroup/details/serverGroupDetails.gce.controller.js
+++ b/app/scripts/modules/google/serverGroup/details/serverGroupDetails.gce.controller.js
@@ -15,6 +15,7 @@ module.exports = angular.module('spinnaker.serverGroup.details.gce.controller', 
   require('../../../core/utils/lodash.js'),
   require('../../../core/insight/insightFilterState.model.js'),
   require('./resize/resizeServerGroup.controller'),
+  require('./rollback/rollbackServerGroup.controller'),
   require('../../../core/utils/selectOnDblClick.directive.js'),
 ])
   .controller('gceServerGroupDetailsCtrl', function ($scope, $state, $templateCache, $interpolate, app, serverGroup, InsightFilterStateModel,
@@ -319,6 +320,21 @@ module.exports = angular.module('spinnaker.serverGroup.details.gce.controller', 
       }
 
       confirmationModalService.confirm(confirmationModalParams);
+    };
+
+    this.rollbackServerGroup = function rollbackServerGroup() {
+      $uibModal.open({
+        templateUrl: require('./rollback/rollbackServerGroup.html'),
+        controller: 'gceRollbackServerGroupCtrl as ctrl',
+        resolve: {
+          serverGroup: function() { return $scope.serverGroup; },
+          disabledServerGroups: function() {
+            var cluster = _.find(app.clusters, {name: $scope.serverGroup.cluster, account: $scope.serverGroup.account});
+            return _.filter(cluster.serverGroups, {isDisabled: true, region: $scope.serverGroup.region});
+          },
+          application: function() { return app; }
+        }
+      });
     };
 
     this.resizeServerGroup = function resizeServerGroup() {

--- a/app/scripts/modules/google/serverGroup/details/serverGroupDetails.html
+++ b/app/scripts/modules/google/serverGroup/details/serverGroupDetails.html
@@ -34,6 +34,8 @@
             Server Group Actions <span class="caret"></span>
           </button>
           <ul class="dropdown-menu" role="menu">
+            <li><a href ng-if="!serverGroup.isDisabled" ng-click="ctrl.rollbackServerGroup()">Rollback</a></li>
+            <li role="presentation" class="divider" ng-if="!serverGroup.isDisabled"></li>
             <li><a href ng-click="ctrl.resizeServerGroup()">Resize</a></li>
             <li><a href ng-if="!serverGroup.isDisabled" ng-click="ctrl.disableServerGroup()">Disable</a></li>
             <li><a href ng-if="serverGroup.isDisabled && serverGroup.loadBalancers.length" ng-click="ctrl.enableServerGroup()">Enable</a></li>


### PR DESCRIPTION
@ttomsu: This will fail with `enableDisableGoogleServerGroupDescription.zone.empty` until (I think) `orca/AbstractServerGroupTask.convert()` properly sets `zone` on GCE server group operations.
@ajordens fyi