### PR TITLE
better surface inconsistent builds in project clusters

### DIFF
--- a/app/scripts/modules/core/projects/dashboard/cluster/inconsistentBuilds.tooltip.html
+++ b/app/scripts/modules/core/projects/dashboard/cluster/inconsistentBuilds.tooltip.html
@@ -1,0 +1,3 @@
+<span ng-repeat="build in application.regions[region].inconsistentBuilds">
+  Build #{{build.number}}: deployed {{build.deployed | relativeTime }}
+</span>

--- a/app/scripts/modules/core/projects/dashboard/cluster/projectCluster.directive.html
+++ b/app/scripts/modules/core/projects/dashboard/cluster/projectCluster.directive.html
@@ -49,15 +49,15 @@
       <tbody>
       <tr ng-repeat="application in vm.clusterData.applications | orderBy: 'name'">
         <td>
-          <a class="heavy" ng-click="vm.clearFilters(application.metadata)" ng-href="{{application.metadata.href}}" ng-class="application.inconsistentBuilds ? 'text-warning' : ''">
+          <a class="heavy" ng-click="vm.clearFilters(application.metadata)" ng-href="{{application.metadata.href}}" ng-class="application.hasInconsistentBuilds ? 'text-warning' : ''">
             {{application.name | uppercase}}
           </a>
         </td>
         <td>
-          <a class="heavy" ng-if="application.build.number > -1" href="{{application.build.url}}" target="_blank">
+          <a class="heavy" ng-if="application.build.number" href="{{application.build.url}}" target="_blank">
             <span ng-if="vm.state.loaded">#</span>{{application.build.number}}
           </a>
-          <span ng-if="application.inconsistentBuilds"
+          <span ng-if="application.hasInconsistentBuilds"
                 class="glyphicon glyphicon-warning-sign text-warning"
                 uib-tooltip="Some server groups are deployed with an older build."></span>
         </td>
@@ -76,20 +76,16 @@
         </td>
         <td ng-repeat="region in vm.clusterData.regions">
           <span ng-if="application.regions[region]">
-            <a  ng-click="vm.clearFilters(application.regions[region].metadata)" ng-href="{{application.regions[region].metadata.href}}">
+            <a ng-click="vm.clearFilters(application.regions[region].metadata)" ng-href="{{application.regions[region].metadata.href}}">
               <health-counts container="application.regions[region].instanceCounts"
                              additional-legend-text="(Click to view cluster in this region)"
                              legend-placement="right"></health-counts>
             </a>
-            <span class="text-warning"
-                  ng-if="application.inconsistentBuilds && application.regions[region].build.number !== application.build.number"
-                  uib-tooltip="Build {{application.regions[region].build.number > -1 ?
-                  '#' + application.regions[region].build.number
-                  : ''}} last deployed {{application.regions[region].lastCreatedTime | relativeTime }}">
-              <span ng-if="application.regions[region].build.number > -1">(#{{application.regions[region].build.number}})</span>
-              <span ng-if="application.regions[region].build.number === -1">(N/A)</span>
+            <span ng-if="application.regions[region].inconsistentBuilds.length">
+              <span class="glyphicon glyphicon-warning-sign text-warning"
+                    uib-tooltip-template="vm.inconsistentBuildsTemplate">
+              </span>
             </span>
-
           </span>
           <span ng-if="!application.regions[region]">
             -

--- a/app/scripts/modules/core/projects/dashboard/cluster/projectCluster.directive.spec.js
+++ b/app/scripts/modules/core/projects/dashboard/cluster/projectCluster.directive.spec.js
@@ -1,0 +1,226 @@
+'use strict';
+
+describe('Controller: projectCluster directive', function () {
+
+  var $controller, vm, $scope, project, cluster, clusterService, $q, urlBuilder;
+
+  beforeEach(window.module(
+    require('./projectCluster.directive.js')
+  ));
+
+  beforeEach(
+    window.inject(function ($rootScope, _$controller_, _$q_, _clusterService_, _urlBuilderService_) {
+      $scope = $rootScope.$new();
+      $controller = _$controller_;
+      $q = _$q_;
+      clusterService = _clusterService_;
+      urlBuilder = _urlBuilderService_;
+    })
+  );
+
+  describe('model construction', function () {
+    beforeEach( function() {
+      spyOn(urlBuilder, 'buildFromMetadata').and.returnValue('url');
+
+      cluster = {
+        account: 'prod'
+      };
+      project = {
+        name: 'test-app',
+        config: {
+          applications: [ 'app1' ],
+          clusters: [cluster],
+        },
+      };
+
+      this.initialize = () => {
+        vm = $controller('ProjectClusterCtrl', {
+          $scope: $scope,
+          $q: $q,
+          clusterService: clusterService,
+        }, {project: project, cluster: cluster});
+      };
+    });
+
+    it('should add instance counts, last created time, and build data to model', function () {
+      spyOn(clusterService, 'getCluster').and.returnValue($q.when({
+        serverGroups: [
+          {
+            name: 'app1-v000',
+            region: 'us-east-1',
+            createdTime: 1,
+            buildInfo: {
+              jenkins: { number: 3 }
+            },
+            instanceCounts: {
+              up: 3, down: 1, unknown: 1, outOfService: 1, starting: 2, total: 8,
+            },
+            instances: [ { } ],
+          },
+          {
+            name: 'app1-v001',
+            region: 'us-east-1',
+            createdTime: 2,
+            buildInfo: {
+              jenkins: { number: 3 }
+            },
+            instanceCounts: {
+              up: 1, down: 0, unknown: 1, outOfService: 2, starting: 1, total: 5,
+            },
+            instances: [ { } ],
+          },
+          {
+            name: 'app1-v003',
+            region: 'us-west-1',
+            createdTime: 24,
+            buildInfo: {
+              jenkins: { number: 3 }
+            },
+            instanceCounts: {
+              up: 1, down: 0, unknown: 0, outOfService: 0, starting: 1, total: 2,
+            },
+            instances: [ { } ],
+          }
+        ]
+      }));
+
+      this.initialize();
+      $scope.$digest();
+      let clusterData = vm.clusterData,
+          usEast = clusterData.applications[0].regions['us-east-1'],
+          usWest = clusterData.applications[0].regions['us-west-1'];
+
+      expect(clusterData.instanceCounts).toEqual({totalCount: 15, upCount: 5, downCount: 1, unknownCount: 2, outOfServiceCount: 3, startingCount: 4});
+      expect(usEast.instanceCounts).toEqual({totalCount: 13, upCount: 4, downCount: 1, unknownCount: 2, outOfServiceCount: 3, startingCount: 3});
+      expect(usWest.instanceCounts).toEqual({totalCount: 2, upCount: 1, downCount: 0, unknownCount: 0, outOfServiceCount: 0, startingCount: 1});
+
+      expect(clusterData.applications[0].lastCreatedTime).toBe(24);
+      expect(usEast.lastCreatedTime).toBe(2);
+      expect(usWest.lastCreatedTime).toBe(24);
+      expect(vm.clusterData.applications[0].build.number).toBe(3);
+    });
+
+    it('should add inconsistent builds to model', function() {
+      spyOn(clusterService, 'getCluster').and.returnValue($q.when({
+        serverGroups: [
+          {
+            name: 'app1-v000',
+            region: 'us-east-1',
+            createdTime: 1,
+            buildInfo: {
+              jenkins: { number: 3 }
+            },
+            instanceCounts: {
+              up: 1, down: 0, unknown: 0, outOfService: 0, starting: 0, total: 1,
+            },
+            instances: [ { } ],
+          },
+          {
+            name: 'app1-v001',
+            region: 'us-east-1',
+            createdTime: 2,
+            buildInfo: {
+              jenkins: { number: 4 }
+            },
+            instanceCounts: {
+              up: 1, down: 0, unknown: 0, outOfService: 0, starting: 0, total: 1,
+            },
+            instances: [ { } ],
+          }
+        ]
+      }));
+
+      this.initialize();
+      $scope.$digest();
+      expect(vm.clusterData.applications[0].hasInconsistentBuilds).toBe(true);
+      expect(vm.clusterData.applications[0].regions['us-east-1'].inconsistentBuilds[0].number).toBe(3);
+
+    });
+
+    it('should only add inconsistent build to model once', function () {
+      spyOn(clusterService, 'getCluster').and.returnValue($q.when({
+        serverGroups: [
+          {
+            name: 'app1-v000',
+            region: 'us-east-1',
+            createdTime: 1,
+            buildInfo: {
+              jenkins: { number: 3 }
+            },
+            instanceCounts: {
+              up: 1, down: 0, unknown: 0, outOfService: 0, starting: 0, total: 1,
+            },
+            instances: [ { } ],
+          },
+          {
+            name: 'app1-v001',
+            region: 'us-east-1',
+            createdTime: 2,
+            buildInfo: {
+              jenkins: { number: 3 }
+            },
+            instanceCounts: {
+              up: 1, down: 0, unknown: 0, outOfService: 0, starting: 0, total: 1,
+            },
+            instances: [ { } ],
+          },
+          {
+            name: 'app1-v002',
+            region: 'us-east-1',
+            createdTime: 3,
+            buildInfo: {
+              jenkins: { number: 4 }
+            },
+            instanceCounts: {
+              up: 1, down: 0, unknown: 0, outOfService: 0, starting: 0, total: 1,
+            },
+            instances: [ { } ],
+          }
+        ]
+      }));
+
+      this.initialize();
+      $scope.$digest();
+      expect(vm.clusterData.applications[0].hasInconsistentBuilds).toBe(true);
+      expect(vm.clusterData.applications[0].regions['us-east-1'].inconsistentBuilds.length).toBe(1);
+      expect(vm.clusterData.applications[0].regions['us-east-1'].inconsistentBuilds[0].number).toBe(3);
+    });
+
+    it('should add inconsistent build, even if it is in a more recent deployment', function () {
+      spyOn(clusterService, 'getCluster').and.returnValue($q.when({
+        serverGroups: [
+          {
+            name: 'app1-v000',
+            region: 'us-east-1',
+            createdTime: 1,
+            buildInfo: {
+              jenkins: { number: 4 }
+            },
+            instanceCounts: {
+              up: 1, down: 0, unknown: 0, outOfService: 0, starting: 0, total: 1,
+            },
+            instances: [ { } ],
+          },
+          {
+            name: 'app1-v002',
+            region: 'us-east-1',
+            createdTime: 3,
+            buildInfo: {
+              jenkins: { number: 2 }
+            },
+            instanceCounts: {
+              up: 1, down: 0, unknown: 0, outOfService: 0, starting: 0, total: 1,
+            },
+            instances: [ { } ],
+          }
+        ]
+      }));
+
+      this.initialize();
+      $scope.$digest();
+      expect(vm.clusterData.applications[0].hasInconsistentBuilds).toBe(true);
+      expect(vm.clusterData.applications[0].regions['us-east-1'].inconsistentBuilds.length).toBe(1);
+      expect(vm.clusterData.applications[0].regions['us-east-1'].inconsistentBuilds[0].number).toBe(2);
+    });
+  });
+});

--- a/app/scripts/modules/core/projects/service/project.read.service.js
+++ b/app/scripts/modules/core/projects/service/project.read.service.js
@@ -10,23 +10,18 @@ module.exports = angular
   .factory('projectReader', function ($q, Restangular, _) {
 
     function listProjects() {
-      if (!arguments.length) {
-        return Restangular.all('projects').getList();
-      }
-      return $q.when([{ name: 'API' }]);
+      return Restangular.all('projects').getList();
     }
 
     function getProjectConfig(projectName) {
-      if (arguments.length === 1) {
-        return listProjects().then((projects) => {
-          let project = _.find(projects, (test) => test.name.toLowerCase() === projectName.toLowerCase());
-          if (project) {
-            return Restangular.one('projects', project.id).get();
-          } else {
-            return $q.reject(projectName);
-          }
-        });
-      }
+      return listProjects().then((projects) => {
+        let project = _.find(projects, (test) => test.name.toLowerCase() === projectName.toLowerCase());
+        if (project) {
+          return Restangular.one('projects', project.id).get();
+        } else {
+          return $q.reject(projectName);
+        }
+      });
     }
 
     return {


### PR DESCRIPTION
The current implementation always takes the latest build in any region, which misses the scenario where multiple builds are deployed in the same region, which turns out to be a valid scenario.

@duftler or @zanthrash please review when you have a minute