### PR TITLE
fix label for resize-percentage

### DIFF
--- a/app/scripts/modules/core/pipeline/config/stages/resizeAsg/aws/resizeAsgStage.html
+++ b/app/scripts/modules/core/pipeline/config/stages/resizeAsg/aws/resizeAsgStage.html
@@ -41,8 +41,8 @@
       </stage-config-field>
       <div class="form-group" ng-if="stage.resizeType === 'pct'">
         <div class="col-md-9 col-md-offset-3">
-          <label class="col-md-2 sm-label-left" style="font-size:12px;line-height:13px;margin-left:0;padding-left:0">Resize Percentage</label>
-          <div class="col-md-2">
+          <label class="col-md-2 sm-label-left" style="margin-left:0;padding-left:0">Resize Percentage</label>
+              <div class="col-md-2">
             <input type="number" min="0" ng-model="stage.scalePct" class="form-control input-sm" />
           </div>
         </div>


### PR DESCRIPTION
Before:
<img width="558" alt="screen shot 2015-12-01 at 1 04 22 pm" src="https://cloud.githubusercontent.com/assets/74310/11514257/575e1aca-982c-11e5-9a65-c1a69547465b.png">

After:
<img width="341" alt="screen shot 2015-12-01 at 1 05 23 pm" src="https://cloud.githubusercontent.com/assets/74310/11514256/575d7a2a-982c-11e5-955c-720004983dca.png">

Aligns with the way the incremental label looks like:

<img width="539" alt="screen shot 2015-12-01 at 1 07 11 pm" src="https://cloud.githubusercontent.com/assets/74310/11514279/7acc7d9e-982c-11e5-9acd-227768797b4a.png">
