### PR TITLE
do not memoize listProviders method

### DIFF
--- a/app/scripts/modules/core/account/account.service.js
+++ b/app/scripts/modules/core/account/account.service.js
@@ -61,7 +61,7 @@ module.exports = angular.module('spinnaker.core.account.service', [
         .getList();
     }
 
-    let listProviders = _.memoize((application) => {
+    let listProviders = (application) => {
       return listAccounts().then(function(accounts) {
         let allProviders = _.uniq(_.pluck(accounts, 'type'));
         let availableRegisteredProviders = _.intersection(allProviders, cloudProviderRegistry.listRegisteredProviders());
@@ -75,7 +75,7 @@ module.exports = angular.module('spinnaker.core.account.service', [
         }
         return availableRegisteredProviders;
       });
-    });
+    };
 
     let getRegionsKeyedByAccount = _.memoize((provider) => {
       var deferred = $q.defer();


### PR DESCRIPTION
Two reasons this should never have been memoized in the first place:
* there's no key resolver (second argument to `_.memoize`), so the application will just be `toString()`ed to get the key, so it'll always be `[object Object]`, regardless of which application is passed in
* the result of the function could change if the application's `cloudProviders` attribute changed, so it's really just a bad idea to memoize it in the first place.

@JargoonPard please review - thanks for catching this