### PR TITLE
do not call onError from an Observable

### DIFF
--- a/app/scripts/modules/core/delivery/executions/executions.controller.js
+++ b/app/scripts/modules/core/delivery/executions/executions.controller.js
@@ -78,7 +78,15 @@ module.exports = angular.module('spinnaker.core.delivery.executions.controller',
 
     });
 
+    let dataInitializationFailure = () => {
+      this.viewState.loading = false;
+      this.viewState.initializationError = true;
+    };
+
     function normalizeExecutionNames() {
+      if (application.executionsLoadFailure) {
+        dataInitializationFailure();
+      }
       let executions = application.executions || [];
       var configurations = application.pipelineConfigs || [];
       executions.forEach(function(execution) {
@@ -92,11 +100,6 @@ module.exports = angular.module('spinnaker.core.delivery.executions.controller',
         }
       });
     }
-
-    let dataInitializationFailure = () => {
-      this.viewState.loading = false;
-      this.viewState.initializationError = true;
-    };
 
     let executionWatcher = this.application.executionRefreshStream.subscribe(normalizeExecutionNames, dataInitializationFailure);
     $scope.$on('$destroy', () => executionWatcher.dispose());

--- a/app/scripts/modules/core/delivery/filter/executionFilter.controller.js
+++ b/app/scripts/modules/core/delivery/filter/executionFilter.controller.js
@@ -37,6 +37,9 @@ module.exports = angular.module('spinnaker.core.delivery.filter.executionFilter.
     };
 
     this.initialize = () => {
+      if (this.application.pipelineConfigsLoadFailure) {
+        return;
+      }
       let allOptions = _.sortBy(this.application.pipelineConfigs, 'index')
         .concat(this.application.executions)
         .filter((option) => option && option.name)

--- a/app/scripts/modules/netflix/alert/alertHandler.js
+++ b/app/scripts/modules/netflix/alert/alertHandler.js
@@ -14,6 +14,14 @@ module.exports = angular
         if (!settings.alert) {
           return;
         }
+        let message = exception.message;
+        if (!message) {
+          try {
+            message = JSON.stringify(exception);
+          } catch (e) {
+            message = '[No message available - could not convert exception to JSON string]';
+          }
+        }
         let payload = {
           alertName: 'Spinnaker',
           details: {
@@ -21,9 +29,9 @@ module.exports = angular
             user: authenticationService.getAuthenticatedUser().name,
           },
           exception: {
-            classes: [exception.name],
-            messages: [exception.message],
-            stackTraces: [exception.stack],
+            classes: [exception.name || '[no name on exception]'],
+            messages: [message],
+            stackTraces: [exception.stack || '[no stacktrace available]'],
             callerClass: 'Spinnaker',
             callerMethod: '[see stack trace]',
           },


### PR DESCRIPTION
Turns out `onError` terminates any subscriptions, so that's not what we want to do on load failures.