### PR TITLE
poll executions before completing cancel/delete operation

### DIFF
--- a/app/scripts/modules/core/delivery/executionGroup/execution/execution.directive.js
+++ b/app/scripts/modules/core/delivery/executionGroup/execution/execution.directive.js
@@ -90,7 +90,7 @@ module.exports = angular
         header: 'Really stop execution of ' + this.execution.name + '?',
         buttonText: 'Stop running ' + this.execution.name,
         destructive: false,
-        submitMethod: () => executionService.cancelExecution(this.execution.id)
+        submitMethod: () => executionService.cancelExecution(this.application, this.execution.id)
       });
     };
 

--- a/app/scripts/modules/core/delivery/service/execution.service.spec.js
+++ b/app/scripts/modules/core/delivery/service/execution.service.spec.js
@@ -2,11 +2,11 @@
 
 describe('Service: executionService', function () {
 
-  //NOTE: This is only testing the service dependencies. Please add more tests.
-
   var executionService;
   var $httpBackend;
   var settings;
+  var timeout;
+  var $q;
 
   beforeEach(
     window.module(
@@ -15,10 +15,12 @@ describe('Service: executionService', function () {
   );
 
   beforeEach(
-    window.inject(function (_executionService_, _$httpBackend_, _settings_) {
+    window.inject(function (_executionService_, _$httpBackend_, _settings_, _$timeout_, _$q_) {
       executionService = _executionService_;
       $httpBackend = _$httpBackend_;
       settings = _settings_;
+      timeout = _$timeout_;
+      $q = _$q_;
     })
   );
 
@@ -27,8 +29,75 @@ describe('Service: executionService', function () {
     $httpBackend.verifyNoOutstandingRequest();
   });
 
-  it('should instantiate the controller', function () {
-    expect(executionService).toBeDefined();
+  describe('cancelling pipeline', function () {
+    it('should wait until pipeline is not running, then resolve', function () {
+      let completed = false;
+      let executionId = 'abc';
+      let cancelUrl = [ settings.gateUrl, 'applications', 'deck', 'pipelines', executionId, 'cancel' ].join('/');
+      let checkUrl = [ settings.gateUrl, 'applications', 'deck', 'pipelines' ].join('/')
+        .concat('?statuses=RUNNING,SUSPENDED,NOT_STARTED');
+      let application = { name: 'deck', reloadExecutions: () => $q.when(null) };
+
+      $httpBackend.expectPUT(cancelUrl).respond(200, []);
+      $httpBackend.expectGET(checkUrl).respond(200, [{id: executionId}]);
+
+      executionService.cancelExecution(application, executionId).then(() => completed = true);
+      $httpBackend.flush();
+      expect(completed).toBe(false);
+
+      $httpBackend.expectGET(checkUrl).respond(200, [{id: 'some-other-execution'}]);
+      timeout.flush();
+      $httpBackend.flush();
+      expect(completed).toBe(true);
+    });
+
+    it('should propagate rejection from failed cancel', function () {
+      let failed = false;
+      let executionId = 'abc';
+      let cancelUrl = [ settings.gateUrl, 'applications', 'deck', 'pipelines', executionId, 'cancel' ].join('/');
+      let application = { name: 'deck', reloadExecutions: () => $q.when(null) };
+
+      $httpBackend.expectPUT(cancelUrl).respond(500, []);
+
+      executionService.cancelExecution(application, executionId).then(angular.noop, () => failed = true);
+      $httpBackend.flush();
+      expect(failed).toBe(true);
+    });
+  });
+
+  describe('deleting pipeline', function () {
+    it('should wait until pipeline is missing, then resolve', function () {
+      let completed = false;
+      let executionId = 'abc';
+      let deleteUrl = [ settings.gateUrl, 'pipelines', executionId ].join('/');
+      let checkUrl = [ settings.gateUrl, 'applications', 'deck', 'pipelines' ].join('/');
+      let application = { name: 'deck', reloadExecutions: () => $q.when(null) };
+
+      $httpBackend.expectDELETE(deleteUrl).respond(200, []);
+      $httpBackend.expectGET(checkUrl).respond(200, [{id: executionId}]);
+
+      executionService.deleteExecution(application, executionId).then(() => completed = true);
+      $httpBackend.flush();
+      expect(completed).toBe(false);
+
+      $httpBackend.expectGET(checkUrl).respond(200, [{id: 'some-other-execution'}]);
+      timeout.flush();
+      $httpBackend.flush();
+      expect(completed).toBe(true);
+    });
+
+    it('should propagate rejection from failed delete', function () {
+      let failed = false;
+      let executionId = 'abc';
+      let deleteUrl = [ settings.gateUrl, 'pipelines', executionId ].join('/');
+      let application = { name: 'deck', reloadExecutions: () => $q.when(null) };
+
+      $httpBackend.expectDELETE(deleteUrl).respond(500, []);
+
+      executionService.deleteExecution(application, executionId).then(angular.noop, () => failed = true);
+      $httpBackend.flush();
+      expect(failed).toBe(true);
+    });
   });
 
   describe('when fetching pipelines', function () {


### PR DESCRIPTION
We're seeing a race condition, where Orca acknowledges the cancel/delete operation, but the new status is not always reflected when we immediately grab the executions.

This mimics the behavior of the `startPipeline` action by polling the appropriate endpoint until the expected state is reached, then reloading the application's executions to update the view.