### PR TITLE
revert overzealous dropdown menu styling

### DIFF
--- a/app/scripts/modules/core/presentation/details.less
+++ b/app/scripts/modules/core/presentation/details.less
@@ -136,7 +136,7 @@
         }
       }
 
-      .dropdown-menu {
+      .uib-dropdown-menu {
         min-width: 80px;
       }
     }

--- a/app/scripts/modules/core/search/global/globalSearch.directive.html
+++ b/app/scripts/modules/core/search/global/globalSearch.directive.html
@@ -13,12 +13,12 @@
       </div>
     </div>
   </form>
-  <ul class="uib-dropdown-menu"
+  <ul class="dropdown-menu"
       role="menu"
       ng-if="querying">
     <li class="loader">searching..</li>
   </ul>
-  <ul class="uib-dropdown-menu"
+  <ul class="dropdown-menu"
       role="menu"
       ng-if="!querying && showRecentItems">
     <li ng-repeat-start="category in recentItems" class="category-heading">
@@ -36,7 +36,7 @@
       </a>
     </li>
   </ul>
-  <ul class="uib-dropdown-menu"
+  <ul class="dropdown-menu"
       role="menu"
       ng-if="!querying && showSearchResults">
     <li ng-repeat-start="category in categories | orderBy: 'order'" class="category-heading">

--- a/app/scripts/modules/netflix/feedback/feedback.html
+++ b/app/scripts/modules/netflix/feedback/feedback.html
@@ -6,7 +6,7 @@
     <a href class="dropdown-toggle" ng-click="toggleMenu()">
       <span class="glyphicon glyphicon-comment"></span> <span class="hidden-xs hidden-sm">Feedback</span>
     </a>
-    <ul class="uib-dropdown-menu">
+    <ul class="dropdown-menu">
       <li>
         <a href ng-click="openFeedback(); toggleMenu();">
           <span class="glyphicon glyphicon-envelope"></span>


### PR DESCRIPTION
Top-level menu items don't use the ui-bootstrap dropdowns, so maybe we shouldn't wreck their rendering.