### PR TITLE
graph perf fix; correct netflix override template

### DIFF
--- a/app/scripts/modules/core/pipeline/config/graph/pipeline.graph.directive.js
+++ b/app/scripts/modules/core/pipeline/config/graph/pipeline.graph.directive.js
@@ -156,6 +156,8 @@ module.exports = angular.module('spinnaker.core.pipeline.config.graph.directive'
               node.children = _.uniq(node.children);
               node.parents = _.uniq(node.parents);
               node.leaf = node.children.length === 0;
+            });
+            nodes.forEach((node) => {
               node.lastPhase = getLastPhase(node);
             });
 

--- a/app/scripts/modules/netflix/templateOverride/templateOverrides.module.js
+++ b/app/scripts/modules/netflix/templateOverride/templateOverrides.module.js
@@ -18,7 +18,7 @@ module.exports = angular
         { key: 'pipelineConfigActions', value: require('./pipelineConfigActions.html') },
         { key: 'spinnakerHeader', value: require('./spinnakerHeader.html') },
         { key: 'aws.serverGroup.securityGroups', value: require('../serverGroup/awsServerGroupSecurityGroups.html') },
-        { key: 'aws.serverGroup.capacity', value: require('../serverGroup/awsServerGroupSecurityGroups.html') },
+        { key: 'aws.serverGroup.capacity', value: require('../serverGroup/capacity/awsServerGroupCapacity.html') },
         { key: 'aws.resize.modal', value: require('../serverGroup/resize/awsResizeServerGroup.html') },
       ];
       templates.forEach((template) => overrideRegistry.overrideTemplate(template.key, template.value));


### PR DESCRIPTION
fixes netflix template override for server group capacity; calculate last phase after uniq-ing child nodes for pipeline graph