### PR TITLE
poll manual judgment stage on decisions

### DIFF
--- a/app/scripts/modules/core/application/modal/editApplication.html
+++ b/app/scripts/modules/core/application/modal/editApplication.html
@@ -156,9 +156,7 @@
               ng-disabled="!editApplicationForm.$valid || editApp.submitting"
               ng-click="editApp.submit()">
         <span class="glyphicon glyphicon-ok-circle" ng-if="!editApp.submitting"></span>
-        <span ng-if="editApp.submitting" style="display: inline-block; position: relative; width: 16px; height: 15px">
-          <span us-spinner="{color: '#ffffff', left: '3px', top: '10px', radius:3, width: 2, length: 3}"></span>
-        </span>
+        <button-busy-indicator ng-if="editApp.submitting"></button-busy-indicator>
         Update
       </button>
     </div>

--- a/app/scripts/modules/core/application/modal/newapplication.html
+++ b/app/scripts/modules/core/application/modal/newapplication.html
@@ -188,9 +188,7 @@
               ng-disabled="newApplicationForm.$invalid || !newAppModal.application.hasOwnProperty('account') || (newAppModal.application.hasOwnProperty('account') && newAppModal.application.account.length < 1)|| newAppModal.state.submitting"
               ng-click="newAppModal.submit()">
         <span class="glyphicon glyphicon-ok-circle" ng-if="!newAppModal.state.submitting"></span>
-        <span ng-if="newAppModal.state.submitting" style="display: inline-block; position: relative; width: 16px; height: 15px">
-          <span us-spinner="{color: '#ffffff', left: '3px', top: '10px', radius:3, width: 2, length: 3}"></span>
-        </span>
+        <button-busy-indicator ng-if="newAppModal.state.submitting"></button-busy-indicator>
         Create
       </button>
     </div>

--- a/app/scripts/modules/core/confirmationModal/confirm.html
+++ b/app/scripts/modules/core/confirmationModal/confirm.html
@@ -42,9 +42,7 @@
             ng-disabled="ctrl.formDisabled()"
             ng-click="ctrl.confirm()">
       <span ng-if="params.glyphicon" class="glyphicon glyphicon-{{params.glyphicon}}"></span>
-        <span ng-if="state.submitting" style="display: inline-block; position: relative; width: 16px; height: 15px">
-          <span us-spinner="{color: '#ffffff', left: '3px', top: '10px', radius:3, width: 2, length: 3}"></span>
-        </span>
+      <button-busy-indicator ng-if="state.submitting"></button-busy-indicator>
       {{params.buttonText}}
     </button>
   </div>

--- a/app/scripts/modules/core/delivery/details/executionDetails.directive.js
+++ b/app/scripts/modules/core/delivery/details/executionDetails.directive.js
@@ -11,6 +11,7 @@ module.exports = angular.module('spinnaker.core.delivery.executionDetails.direct
       restrict: 'E',
       scope: {
         execution: '=',
+        application: '=',
       },
       templateUrl: require('./executionDetails.html'),
       controller: 'executionDetails as ctrl',

--- a/app/scripts/modules/core/delivery/executionGroup/execution/execution.directive.html
+++ b/app/scripts/modules/core/delivery/executionGroup/execution/execution.directive.html
@@ -4,7 +4,7 @@
   <div class="execution-bar">
     <div class="stages">
       <div ng-repeat="stage in vm.execution.stageSummaries"
-           class="clickable stage execution-status execution-status-{{stage.status.toLowerCase()}}"
+           class="clickable stage stage-type-{{stage.type.toLowerCase()}} execution-marker execution-marker-{{stage.status.toLowerCase()}}"
            ng-class="{active: vm.isActive($index), glowing: stage.isRunning}"
            ng-style="{width: 100/vm.execution.stageSummaries.length + '%', 'background-color': stage.color}"
            uib-tooltip-template="stage.labelTemplateUrl"
@@ -53,7 +53,7 @@
 
   <div ng-if="vm.showDetails()" class="execution-details">
     <div class="row">
-      <execution-details execution="vm.execution">
+      <execution-details execution="vm.execution" application="vm.application">
       </execution-details>
     </div>
     <div class="row permalinks text-right">

--- a/app/scripts/modules/core/delivery/executions/executions.less
+++ b/app/scripts/modules/core/delivery/executions/executions.less
@@ -56,3 +56,23 @@ executions {
   color: @healthy_green_border;
 }
 
+.execution-marker {
+  fill: @stage-default;
+  background-color: @stage-default;
+  &.execution-marker-failed {
+    fill: @stage-failed;
+    background-color: @stage-failed;
+  }
+  &.execution-marker-completed {
+    fill: @stage-completed;
+    background-color: @stage-completed;
+  }
+  &.execution-marker-running {
+    fill: @stage-running;
+    background-color: @stage-running;
+  }
+  &.execution-marker-stopped {
+    fill: @stage-stopped;
+    background-color: @stage-stopped;
+  }
+}

--- a/app/scripts/modules/core/delivery/service/executions.transformer.service.js
+++ b/app/scripts/modules/core/delivery/service/executions.transformer.service.js
@@ -211,29 +211,13 @@ module.exports = angular.module('spinnaker.core.delivery.executionTransformer.se
       }
     }
 
-    var colorMapping = {
-      completed: '#769D3E',
-      failed: '#b82525',
-      running: '#2275b8',
-      'not_started': '#cccccc',
-      canceled: '#cccccc',
-      suspended: '#cccccc',
-      unknown: '#cccccc',
-      stopped: '#777777',
-    };
-
     function addStageWidths(execution) {
       execution.stageWidth = 100 / execution.stageSummaries.length + '%';
     }
 
     function styleStage(stage) {
       var stageConfig = pipelineConfig.getStageConfig(stage);
-      var status = stage.status || 'UNKNOWN';
-      stage.color = colorMapping[status.toLowerCase()] || '#cccccc';
       if (stageConfig) {
-        if (stageConfig.executionBarColorProvider && stageConfig.executionBarColorProvider(stage)) {
-          stage.color = stageConfig.executionBarColorProvider(stage);
-        }
         stage.labelTemplateUrl = stageConfig.executionLabelTemplateUrl || executionBarLabelTemplate;
       }
     }

--- a/app/scripts/modules/core/forms/buttonBusyIndicator/buttonBusyIndicator.directive.html
+++ b/app/scripts/modules/core/forms/buttonBusyIndicator/buttonBusyIndicator.directive.html
@@ -1,0 +1,1 @@
+<span us-spinner="{color: '#ffffff', left: '3px', top: '10px', radius:3, width: 2, length: 3}"></span>

--- a/app/scripts/modules/core/forms/buttonBusyIndicator/buttonBusyIndicator.directive.js
+++ b/app/scripts/modules/core/forms/buttonBusyIndicator/buttonBusyIndicator.directive.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const angular = require('angular');
+
+require('./buttonBusyIndicator.directive.less');
+
+module.exports = angular
+  .module('spinnaker.core.forms.buttonBusyIndicator.directive', [])
+  .directive('buttonBusyIndicator', function () {
+    return {
+      restrict: 'E',
+      templateUrl: require('./buttonBusyIndicator.directive.html')
+    };
+  }).name;

--- a/app/scripts/modules/core/forms/buttonBusyIndicator/buttonBusyIndicator.directive.less
+++ b/app/scripts/modules/core/forms/buttonBusyIndicator/buttonBusyIndicator.directive.less
@@ -1,0 +1,6 @@
+button-busy-indicator {
+  display: inline-block;
+  position: relative;
+  width: 16px;
+  height: 15px
+}

--- a/app/scripts/modules/core/forms/forms.module.js
+++ b/app/scripts/modules/core/forms/forms.module.js
@@ -7,4 +7,5 @@ module.exports = angular.module('spinnaker.core.forms', [
   require('./checklist/checklist.directive.js'),
   require('./checkmap/checkmap.directive.js'),
   require('./ignoreEmptyDelete.directive.js'),
+  require('./buttonBusyIndicator/buttonBusyIndicator.directive.js'),
 ]).name;

--- a/app/scripts/modules/core/modal/buttons/submitButton.directive.html
+++ b/app/scripts/modules/core/modal/buttons/submitButton.directive.html
@@ -2,8 +2,6 @@
         ng-disabled="isDisabled"
         ng-click="onClick()">
   <span ng-if="!submitting" class="glyphicon glyphicon-ok-circle"></span>
-  <span ng-if="submitting" style="display: inline-block; position: relative; width: 16px; height: 15px">
-    <span us-spinner="{color: '#ffffff', left: '3px', top: '10px', radius:3, width: 2, length: 3}"></span>
-  </span>
+  <button-busy-indicator ng-if="submitting"></button-busy-indicator>
   {{label || (isNew ? 'Create' : 'Update')}}
 </button>

--- a/app/scripts/modules/core/pipeline/config/graph/pipelineGraph.directive.html
+++ b/app/scripts/modules/core/pipeline/config/graph/pipelineGraph.directive.html
@@ -29,9 +29,8 @@
     </foreignobject>
 
     <circle ng-attr-r="{{nodeRadius}}"
-            class="clickable"
+            class="clickable stage-type-{{stage.masterStage.type.toLowerCase()}} execution-marker execution-marker-{{stage.status.toLowerCase()}}"
             ng-class="{active: stage.isActive}"
-            ng-style="{fill: stage.color}"
             ng-attr-fill-opacity="{{!stage.isActive && stage.executionStage ? 0.4: 1}}"
             ng-mouseenter="highlight(stage)" ng-mouseleave="removeHighlight(stage)"
             ng-click="nodeClicked(stage)"></circle>

--- a/app/scripts/modules/core/pipeline/config/graph/pipelineGraph.less
+++ b/app/scripts/modules/core/pipeline/config/graph/pipelineGraph.less
@@ -44,7 +44,7 @@ pipeline-graph {
         stroke: @unhealthy_red;
       }
       &.completed {
-        stroke: @stage_complete;
+        stroke: @stage-completed;
       }
       &.not_started, &.suspended, &.canceled, &.unknown {
         stroke: @mid_light_grey;
@@ -52,13 +52,8 @@ pipeline-graph {
     }
 
     g {
-      circle, rect {
-        fill: @mid_light_grey;
-      }
-      &.connected {
-        circle, rect {
-          fill: @mid_lighter_grey;
-        }
+      rect {
+        fill: @stage-default;
       }
       &.active, &.highlighted {
         circle, rect {
@@ -67,7 +62,6 @@ pipeline-graph {
         }
         &.has-status {
           circle {
-            fill: #ffffff;
             fill-opacity: 1;
             stroke: @mid_grey;
             stroke-width: 2px;

--- a/app/scripts/modules/core/pipeline/config/graph/pipelineGraph.service.js
+++ b/app/scripts/modules/core/pipeline/config/graph/pipelineGraph.service.js
@@ -23,8 +23,6 @@ module.exports = angular
           children: [],
           parentLinks: [],
           childLinks: [],
-          color: stage.color,
-          strokeColor: stage.color,
           isActive: viewState.activeStageId === stage.index && viewState.executionId === execution.id,
           isHighlighted: false,
           status: stage.status,
@@ -32,9 +30,6 @@ module.exports = angular
           hasNotStarted: stage.hasNotStarted,
           executionId: execution.id,
         };
-        if (node.isActive) {
-          node.strokeColor = '#ffffff';
-        }
         if (!node.parentIds.length) {
           node.root = true;
         }

--- a/app/scripts/modules/core/pipeline/config/stages/manualJudgment/manualJudgment.service.js
+++ b/app/scripts/modules/core/pipeline/config/stages/manualJudgment/manualJudgment.service.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const angular = require('angular');
+
+module.exports = angular
+  .module('spinnaker.core.pipeline.stage.manualJudgment.service', [
+    require('../../../../config/settings.js'),
+    require('../../../../delivery/service/execution.service.js'),
+  ])
+  .factory('manualJudgmentService', function($http, $q, settings, executionService) {
+
+    let buildMatcher = (stage, judgment, deferred) => {
+      return (execution) => {
+        let matches = execution.stages.filter((test) => test.id === stage.id);
+        if (!matches.length) {
+          deferred.reject();
+          return true;
+        }
+        return matches[0].status !== 'RUNNING';
+      };
+    };
+
+    let provideJudgment = (execution, stage, judgment) => {
+      var targetUrl = [settings.gateUrl, 'pipelines', execution.id, 'stages', stage.id].join('/');
+      var deferred = $q.defer();
+      var request = {
+        method: 'PATCH',
+        url: targetUrl,
+        data: {judgmentStatus: judgment},
+        timeout: settings.pollSchedule * 2 + 5000, // TODO: replace with apiHost call
+      };
+
+      $http(request)
+        .success(() => {
+          executionService.waitUntilExecutionMatches(execution.id, buildMatcher(stage, judgment, deferred))
+            .then(deferred.resolve, deferred.reject);
+          }
+        )
+        .error(deferred.reject);
+
+      return deferred.promise;
+    };
+
+    return {
+      provideJudgment: provideJudgment
+    };
+  }).name;

--- a/app/scripts/modules/core/pipeline/config/stages/manualJudgment/manualJudgment.service.spec.js
+++ b/app/scripts/modules/core/pipeline/config/stages/manualJudgment/manualJudgment.service.spec.js
@@ -1,0 +1,87 @@
+'use strict';
+
+describe('Service: manualJudgment', function () {
+
+  var $scope, service, $http, $q, settings, executionService;
+
+  beforeEach(
+    window.module(
+      require('./manualJudgment.service')
+    )
+  );
+
+  beforeEach(
+    window.inject(function ($rootScope, manualJudgmentService, $httpBackend, _$q_, _settings_,
+                            _executionService_) {
+      $scope = $rootScope.$new();
+      service = manualJudgmentService;
+      $http = $httpBackend;
+      $q = _$q_;
+      settings = _settings_;
+      executionService = _executionService_;
+    })
+  );
+
+  describe('provideJudgment', function () {
+    beforeEach(function() {
+      this.execution = { id: 'ex-id' };
+      this.stage = { id: 'stage-id' };
+      this.requestUrl = [settings.gateUrl, 'pipelines', this.execution.id, 'stages', this.stage.id].join('/');
+    });
+
+    it('should resolve when execution status matches request', function () {
+      let deferred = $q.defer(),
+          succeeded = false;
+
+      $http.expectPATCH(this.requestUrl).respond(200, '');
+      spyOn(executionService, 'waitUntilExecutionMatches').and.returnValue(deferred.promise);
+
+      service.provideJudgment(this.execution, this.stage, 'continue').then(() => succeeded = true);
+
+      $http.flush();
+      expect(succeeded).toBe(false);
+
+      // waitForExecutionMatches...
+      deferred.resolve();
+      $scope.$digest();
+
+      expect(succeeded).toBe(true);
+    });
+
+    it('should fail when waitUntilExecutionMatches fails', function () {
+      let deferred = $q.defer(),
+          succeeded = false,
+          failed = false;
+
+      $http.expectPATCH(this.requestUrl).respond(200, '');
+      spyOn(executionService, 'waitUntilExecutionMatches').and.returnValue(deferred.promise);
+
+      service.provideJudgment(this.execution, this.stage, 'continue').then(() => succeeded = true, () => failed = true);
+
+      $http.flush();
+      expect(succeeded).toBe(false);
+      expect(failed).toBe(false);
+
+      // waitForExecutionMatches...
+      deferred.reject();
+      $scope.$digest();
+
+      expect(succeeded).toBe(false);
+      expect(failed).toBe(true);
+    });
+
+    it('should fail when patch call fails', function () {
+      let succeeded = false,
+          failed = false;
+
+      $http.expectPATCH(this.requestUrl).respond(503, '');
+
+      service.provideJudgment(this.execution, this.stage, 'continue').then(() => succeeded = true, () => failed = true);
+
+      $http.flush();
+      expect(succeeded).toBe(false);
+      expect(failed).toBe(true);
+    });
+
+  });
+});

--- a/app/scripts/modules/core/pipeline/config/stages/manualJudgment/manualJudgmentExecutionDetails.controller.js
+++ b/app/scripts/modules/core/pipeline/config/stages/manualJudgment/manualJudgmentExecutionDetails.controller.js
@@ -2,13 +2,22 @@
 
 let angular = require('angular');
 
-module.exports = angular.module('spinnaker.core.pipeline.stage.manualJudgment.executionDetails.controller', [
-  require('angular-ui-router'),
-  require('../../../../delivery/details/executionDetailsSection.service.js'),
-  require('../../../../delivery/details/executionDetailsSectionNav.directive.js'),
-])
-  .controller('ManualJudgmentExecutionDetailsCtrl', function ($scope, $stateParams, $http, settings, executionDetailsSectionService, _) {
+module.exports = angular
+    .module('spinnaker.core.pipeline.stage.manualJudgment.executionDetails.controller', [
+    require('angular-ui-router'),
+    require('./manualJudgment.service.js'),
+    require('../../../../delivery/details/executionDetailsSection.service.js'),
+    require('../../../../delivery/details/executionDetailsSectionNav.directive.js'),
+  ])
+  .controller('ManualJudgmentExecutionDetailsCtrl', function ($scope, $stateParams, manualJudgmentService,
+                                                              executionDetailsSectionService) {
+
     $scope.configSections = ['manualJudgment', 'taskStatus'];
+    $scope.viewState = {
+      submitting: false,
+      judgmentDecision: null,
+      error: false,
+    };
 
     function initialize() {
       executionDetailsSectionService.synchronizeSection($scope.configSections);
@@ -18,31 +27,23 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.manualJudgment.ex
     initialize();
     $scope.$on('$stateChangeSuccess', initialize, true);
 
-    function provideJudgment(judgmentStatus, executionStatus) {
-      var targetUrl = [settings.gateUrl, 'pipelines', $stateParams.executionId, 'stages', $scope.stage.id].join('/');
-      $http({
-        method: 'PATCH',
-        url: targetUrl,
-        data: angular.toJson({judgmentStatus: judgmentStatus}),
-        timeout: settings.pollSchedule * 2 + 5000, // TODO: replace with apiHost call
-      }).success(function() {
-        $scope.stage.context.judgmentStatus = judgmentStatus;
-        $scope.stage.status = executionStatus;
-
-        var stageSummary = _.find($scope.execution.stageSummaries, function (stageSummary) {
-          return stageSummary.id === $scope.stage.id;
-        });
-        if (stageSummary) {
-          stageSummary.status = $scope.stage.status;
-        }
-      });
+    function judgmentMade() {
+      // do not update the submitting state - the reload of the executions will clear it out; otherwise,
+      // there is a flash on the screen when we go from submitting to not submitting to the buttons not being there.
+      $scope.application.reloadExecutions();
     }
 
-    this.continue = function () {
-      provideJudgment('continue', 'SUCCEEDED');
+    function judgmentFailure() {
+      $scope.viewState.submitting = false;
+      $scope.viewState.error = true;
+    }
+
+    this.provideJudgment = (judgmentDecision) => {
+      $scope.viewState.submitting = true;
+      $scope.viewState.error = false;
+      $scope.viewState.judgmentDecision = judgmentDecision;
+      return manualJudgmentService.provideJudgment($scope.execution, $scope.stage, judgmentDecision)
+        .then(judgmentMade, judgmentFailure);
     };
 
-    this.stop = function () {
-      provideJudgment('stop', 'TERMINAL');
-    };
   }).name;

--- a/app/scripts/modules/core/pipeline/config/stages/manualJudgment/manualJudgmentExecutionDetails.controller.spec.js
+++ b/app/scripts/modules/core/pipeline/config/stages/manualJudgment/manualJudgmentExecutionDetails.controller.spec.js
@@ -1,0 +1,76 @@
+'use strict';
+
+describe('Controller: manualJudgmentExecutionDetails', function () {
+
+  var $scope, controller, $q, manualJudgmentService;
+
+  beforeEach(window.module(require('./manualJudgmentExecutionDetails.controller')));
+
+  beforeEach(window.inject(function ($controller, $rootScope, _manualJudgmentService_, _executionDetailsSectionService_, _$q_) {
+    $scope = $rootScope.$new();
+    $q = _$q_;
+
+    manualJudgmentService = _manualJudgmentService_;
+
+    spyOn(_executionDetailsSectionService_, 'synchronizeSection').and.callFake(angular.noop);
+
+    controller = $controller('ManualJudgmentExecutionDetailsCtrl', {
+        $scope: $scope,
+        manualJudgmentService: manualJudgmentService,
+        executionDetailsSectionService: _executionDetailsSectionService_,
+        $stateParams: { details: ''},
+      });
+    }));
+
+    describe('provideJudgment', function () {
+
+      it('sets view state flags on successful judgment, then reloads application executions', function () {
+        let reloadCalled = false,
+            viewState = $scope.viewState;
+        $scope.application = {
+          reloadExecutions: () => reloadCalled = true
+        };
+
+        spyOn(manualJudgmentService, 'provideJudgment').and.returnValue($q.when(null));
+
+        controller.provideJudgment('continue');
+
+        expect(viewState.submitting).toBe(true);
+        expect(viewState.error).toBe(false);
+        expect(viewState.judgmentDecision).toBe('continue');
+        expect(reloadCalled).toBe(false);
+
+        $scope.$digest();
+
+        // submitting is left alone - application execution reload will clear it up
+        expect(viewState.submitting).toBe(true);
+        expect(viewState.error).toBe(false);
+        expect(viewState.judgmentDecision).toBe('continue');
+        expect(reloadCalled).toBe(true);
+      });
+
+      it('sets view state flags of failure, does not reload application executions', function () {
+        let reloadCalled = false,
+            viewState = $scope.viewState;
+        $scope.application = {
+          reloadExecutions: () => reloadCalled = true
+        };
+
+        spyOn(manualJudgmentService, 'provideJudgment').and.returnValue($q.reject(null));
+
+        controller.provideJudgment('continue');
+
+        expect(viewState.submitting).toBe(true);
+        expect(viewState.error).toBe(false);
+        expect(viewState.judgmentDecision).toBe('continue');
+        expect(reloadCalled).toBe(false);
+
+        $scope.$digest();
+
+        expect(viewState.submitting).toBe(false);
+        expect(viewState.error).toBe(true);
+        expect(viewState.judgmentDecision).toBe('continue');
+        expect(reloadCalled).toBe(false);
+      });
+    });
+});

--- a/app/scripts/modules/core/pipeline/config/stages/manualJudgment/manualJudgmentExecutionDetails.html
+++ b/app/scripts/modules/core/pipeline/config/stages/manualJudgment/manualJudgmentExecutionDetails.html
@@ -15,8 +15,17 @@
         </dl>
       </div>
       <div class="col-md-9" ng-if="!stage.context.judgmentStatus && stage.status === 'RUNNING'">
-        <button class="btn btn-primary" ng-click="manualCtrl.continue()">Continue</button>
-        <button class="btn btn-danger" ng-click="manualCtrl.stop()">Stop</button>
+        <button class="btn btn-primary" ng-click="manualCtrl.provideJudgment('continue')" ng-disabled="viewState.submitting">
+          <button-busy-indicator ng-if="viewState.submitting && viewState.judgmentDecision === 'continue'"></button-busy-indicator>
+          Continue
+        </button>
+        <button class="btn btn-danger" ng-click="manualCtrl.provideJudgment('stop')" ng-disabled="viewState.submitting">
+          <button-busy-indicator ng-if="viewState.submitting && viewState.judgmentDecision === 'stop'"></button-busy-indicator>
+          Stop
+        </button>
+      </div>
+      <div class="col-md-12 error-message" ng-if="viewState.error">
+        There was an error recording your decision. Please try again.
       </div>
     </div>
 
@@ -29,4 +38,3 @@
     </div>
   </div>
 </div>
-

--- a/app/scripts/modules/core/pipeline/config/stages/manualJudgment/manualJudgmentExecutionDetails.less
+++ b/app/scripts/modules/core/pipeline/config/stages/manualJudgment/manualJudgmentExecutionDetails.less
@@ -1,0 +1,8 @@
+.execution-marker {
+  &.execution-marker-running {
+    &.stage-type-manualjudgment {
+      background-color: #F0AD4E;
+      fill: #F0AD4E;
+    }
+  }
+}

--- a/app/scripts/modules/core/pipeline/config/stages/manualJudgment/manualJudgmentStage.js
+++ b/app/scripts/modules/core/pipeline/config/stages/manualJudgment/manualJudgmentStage.js
@@ -14,13 +14,6 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.manualJudgmentSta
       templateUrl: require('./manualJudgmentStage.html'),
       executionDetailsUrl: require('./manualJudgmentExecutionDetails.html'),
       strategy: true,
-      executionBarColorProvider: function (stageSummary) {
-        if (stageSummary.status === 'RUNNING') {
-          return '#F0AD4E';
-        }
-
-        return undefined;
-      }
     });
   })
   .controller('ManualJudgmentStageCtrl', function($scope, $uibModal) {

--- a/app/scripts/modules/core/pipeline/config/stages/manualJudgment/manualJudgmentStage.module.js
+++ b/app/scripts/modules/core/pipeline/config/stages/manualJudgment/manualJudgmentStage.module.js
@@ -2,6 +2,8 @@
 
 let angular = require('angular');
 
+require('./manualJudgmentExecutionDetails.less');
+
 module.exports = angular.module('spinnaker.core.pipeline.stage.manualJudgment', [
   require('../stage.module.js'),
   require('../core/stage.core.module.js'),

--- a/app/scripts/modules/core/presentation/less/imports/colors.less
+++ b/app/scripts/modules/core/presentation/less/imports/colors.less
@@ -44,8 +44,6 @@
 
 @unhealthy_orange: #F0AD4E;
 
-@stage_complete: #769D3E;
-
 @spinnaker-link-color: #229cb3;
 @spinnaker-link-hover: #1d8499;
 @missing_health: #b9d4ed;
@@ -58,3 +56,9 @@
 @code-yellow: #dddd00;
 
 @bootstrap_info: #d9edf7;
+
+@stage-completed: #769D3E;
+@stage-failed: #b82525;
+@stage-running: #2275b8;
+@stage-default: #cccccc;
+@stage-stopped: #777777;

--- a/app/scripts/modules/core/projects/dashboard/pipeline/projectPipeline.directive.html
+++ b/app/scripts/modules/core/projects/dashboard/pipeline/projectPipeline.directive.html
@@ -7,7 +7,7 @@
   (<execution-build-number execution="vm.execution"></execution-build-number><span ng-if="vm.hasBuildInfo">, </span>started {{vm.execution.startTime | timestamp }})
   <div class="execution-bar">
     <div ng-repeat="stage in vm.execution.stageSummaries"
-         class="clickable stage execution-status execution-status-{{stage.status.toLowerCase()}}"
+         class="clickable stage execution-marker execution-marker-{{stage.status.toLowerCase()}}"
          ng-style="{width: vm.stageWidth, 'background-color': stage.color}"
          uib-tooltip-template="stage.labelTemplateUrl"
          tooltip-title="(Click for details)"

--- a/app/scripts/modules/netflix/application/createApplication.modal.html
+++ b/app/scripts/modules/netflix/application/createApplication.modal.html
@@ -213,9 +213,7 @@
               ng-disabled="newApplicationForm.$invalid || !newAppModal.application.hasOwnProperty('account') || (newAppModal.application.hasOwnProperty('account') && newAppModal.application.account.length < 1)|| newAppModal.state.submitting"
               ng-click="newAppModal.submit()">
         <span class="glyphicon glyphicon-ok-circle" ng-if="!newAppModal.state.submitting"></span>
-        <span ng-if="newAppModal.state.submitting" style="display: inline-block; position: relative; width: 16px; height: 15px">
-          <span us-spinner="{color: '#ffffff', left: '3px', top: '10px', radius:3, width: 2, length: 3}"></span>
-        </span>
+        <button-busy-indicator ng-if="newAppModal.state.submitting"></button-busy-indicator>
         Create
       </button>
     </div>

--- a/app/scripts/modules/netflix/application/editApplication.modal.html
+++ b/app/scripts/modules/netflix/application/editApplication.modal.html
@@ -171,7 +171,7 @@
               ng-disabled="!editApplicationForm.$valid || editApp.submitting"
               ng-click="editApp.submit()">
         <span class="glyphicon glyphicon-ok-circle" ng-if="!editApp.submitting"></span>
-        <span ng-if="editApp.submitting" style="display: inline-block; position: relative; width: 16px; height: 15px">
+        <span ng-if="editApp.submitting" class="button-busy-indicator">
           <span us-spinner="{color: '#ffffff', left: '3px', top: '10px', radius:3, width: 2, length: 3}"></span>
         </span>
         Update

--- a/app/scripts/modules/netflix/fastProperties/modal/deleteFastProperty.html
+++ b/app/scripts/modules/netflix/fastProperties/modal/deleteFastProperty.html
@@ -49,9 +49,7 @@
             ng-disabled="delete.formDisabled()"
             ng-click="delete.confirm()">
       <span ng-if="params.glyphicon" class="glyphicon glyphicon-{{params.glyphicon}}"></span>
-        <span ng-if="state.submitting" style="display: inline-block; position: relative; width: 16px; height: 15px">
-          <span us-spinner="{color: '#ffffff', left: '3px', top: '10px', radius:3, width: 2, length: 3}"></span>
-        </span>
+      <button-busy-indicator ng-if="state.submitting"></button-busy-indicator>
       Delete
     </button>
   </div>

--- a/app/scripts/modules/netflix/pipeline/stage/canary/actions/endCanary.modal.html
+++ b/app/scripts/modules/netflix/pipeline/stage/canary/actions/endCanary.modal.html
@@ -42,9 +42,7 @@
               ng-if="state !== 'success'"
               ng-click="ctrl.endCanary()"
               ng-disabled="state === 'submitting' || !command.reason">
-        <span ng-if="state === 'submitting'" style="display: inline-block; position: relative; width: 16px; height: 15px">
-          <span us-spinner="{color: '#ffffff', left: '3px', top: '10px', radius:3, width: 2, length: 3}"></span>
-        </span>
+        <button-busy-indicator ng-if="state === 'submitting'"></button-busy-indicator>
         Submit
       </button>
     </div>

--- a/app/scripts/modules/netflix/pipeline/stage/canary/actions/generateScore.modal.html
+++ b/app/scripts/modules/netflix/pipeline/stage/canary/actions/generateScore.modal.html
@@ -43,9 +43,7 @@
               ng-if="state !== 'success'"
               ng-click="ctrl.generateCanaryScore()"
               ng-disabled="state === 'submitting' || !command.duration || command.duration < 1">
-        <span ng-if="state === 'submitting'" style="display: inline-block; position: relative; width: 16px; height: 15px">
-          <span us-spinner="{color: '#ffffff', left: '3px', top: '10px', radius:3, width: 2, length: 3}"></span>
-        </span>
+        <button-busy-indicator ng-if="state === 'submitting'"></button-busy-indicator>
         Submit
       </button>
     </div>


### PR DESCRIPTION
What started as a three-line quick fix has devolved into this 526-line refactoring.

There are a couple of things wrapped up here:
* refactor a bunch (~10) of copy/pastes of a span to show that a button is busy into a directive
* refactor the underlying code around manual judgment decisions

The judgment code refactor addresses the following:
* removes the inlined colors for stages and pushes it back into CSS so users can override it
* handles failures (not that we've seen any...yet)
* provides feedback to the user that the action is being processed
* waits until the stage is no longer running, then reloads the executions for the application

@ajordens this is for you
@zanthrash can you review this when you have a minute?