### PR TITLE
check for destroyed scope before trying to refresh/navigate

### DIFF
--- a/app/scripts/modules/amazon/loadBalancer/configure/createLoadBalancer.controller.js
+++ b/app/scripts/modules/amazon/loadBalancer/configure/createLoadBalancer.controller.js
@@ -311,6 +311,10 @@ module.exports = angular.module('spinnaker.loadBalancer.aws.create.controller', 
     };
 
     $scope.taskMonitor.onApplicationRefresh = function handleApplicationRefreshComplete() {
+      // If the user has already closed the modal, do not navigate to the new details view
+      if ($scope.$$destroyed) {
+        return;
+      }
       $modalInstance.close();
       var newStateParams = {
         name: $scope.loadBalancer.name,

--- a/app/scripts/modules/amazon/loadBalancer/details/loadBalancerDetail.controller.js
+++ b/app/scripts/modules/amazon/loadBalancer/details/loadBalancerDetail.controller.js
@@ -74,9 +74,14 @@ module.exports = angular.module('spinnaker.loadBalancer.aws.details.controller',
       $state.go('^', null, {location: 'replace'});
     }
 
-    extractLoadBalancer();
-
-    app.registerAutoRefreshHandler(extractLoadBalancer, $scope);
+    extractLoadBalancer().then(() => {
+      // If the user navigates away from the view before the initial extractLoadBalancer call completes,
+      // do not bother subscribing to the autoRefreshStream
+      if (!$scope.$$destroyed) {
+        let refreshWatcher = app.autoRefreshStream.subscribe(extractLoadBalancer);
+        $scope.$on('$destroy', () => refreshWatcher.dispose());
+      }
+    });
 
     this.editLoadBalancer = function editLoadBalancer() {
       $uibModal.open({

--- a/app/scripts/modules/amazon/securityGroup/configure/configSecurityGroup.mixin.controller.js
+++ b/app/scripts/modules/amazon/securityGroup/configure/configSecurityGroup.mixin.controller.js
@@ -57,6 +57,10 @@ module.exports = angular
     $scope.securityGroup = securityGroup;
 
     $scope.taskMonitor.onApplicationRefresh = function handleApplicationRefreshComplete() {
+      // If the user has already closed the modal, do not navigate to the new details view
+      if ($scope.$$destroyed) {
+        return;
+      }
       $modalInstance.close();
       var newStateParams = {
         name: $scope.securityGroup.name,

--- a/app/scripts/modules/amazon/securityGroup/details/securityGroupDetail.controller.js
+++ b/app/scripts/modules/amazon/securityGroup/details/securityGroupDetail.controller.js
@@ -47,7 +47,14 @@ module.exports = angular.module('spinnaker.securityGroup.aws.details.controller'
       $state.go('^', null, {location: 'replace'});
     }
 
-    extractSecurityGroup().then(() => application.registerAutoRefreshHandler(extractSecurityGroup, $scope));
+    extractSecurityGroup().then(() => {
+      // If the user navigates away from the view before the initial extractSecurityGroup call completes,
+      // do not bother subscribing to the autoRefreshStream
+      if (!$scope.$$destroyed) {
+        let refreshWatcher = app.autoRefreshStream.subscribe(extractSecurityGroup);
+        $scope.$on('$destroy', () => refreshWatcher.dispose());
+      }
+    });
 
     this.editInboundRules = function editInboundRules() {
       $uibModal.open({

--- a/app/scripts/modules/amazon/serverGroup/configure/wizard/CloneServerGroup.aws.controller.js
+++ b/app/scripts/modules/amazon/serverGroup/configure/wizard/CloneServerGroup.aws.controller.js
@@ -146,6 +146,10 @@ module.exports = angular.module('spinnaker.aws.cloneServerGroup.controller', [
     }
 
     $scope.taskMonitor.onApplicationRefresh = function handleApplicationRefreshComplete() {
+      // If the user has already closed the modal, do not navigate to the new details view
+      if ($scope.$$destroyed) {
+        return;
+      }
       $scope.taskMonitor.task.getCompletedKatoTask().then(function(katoTask) {
         if (katoTask.resultObjects && katoTask.resultObjects.length && katoTask.resultObjects[0].serverGroupNames) {
           var newStateParams = {

--- a/app/scripts/modules/amazon/serverGroup/details/serverGroupDetails.aws.controller.js
+++ b/app/scripts/modules/amazon/serverGroup/details/serverGroupDetails.aws.controller.js
@@ -144,7 +144,14 @@ module.exports = angular.module('spinnaker.serverGroup.details.aws.controller', 
       $scope.state.loading = false;
     }
 
-    retrieveServerGroup().then(() => app.registerAutoRefreshHandler(retrieveServerGroup, $scope));
+    retrieveServerGroup().then(() => {
+      // If the user navigates away from the view before the initial retrieveServerGroup call completes,
+      // do not bother subscribing to the autoRefreshStream
+      if (!$scope.$$destroyed) {
+        let refreshWatcher = app.autoRefreshStream.subscribe(retrieveServerGroup);
+        $scope.$on('$destroy', () => refreshWatcher.dispose());
+      }
+    });
 
     this.destroyServerGroup = function destroyServerGroup() {
       var serverGroup = $scope.serverGroup;

--- a/app/scripts/modules/azure/instance/details/instance.details.controller.spec.js
+++ b/app/scripts/modules/azure/instance/details/instance.details.controller.spec.js
@@ -9,6 +9,8 @@ describe('Controller: azureInstanceDetailsCtrl', function () {
   var scope;
   var instanceReader;
   var $q;
+  var rx;
+  var refreshStream;
 
   beforeEach(
     window.module(
@@ -17,21 +19,23 @@ describe('Controller: azureInstanceDetailsCtrl', function () {
   );
 
   beforeEach(
-    window.inject(function ($rootScope, $controller, _instanceReader_, _$q_) {
+    window.inject(function ($rootScope, $controller, _instanceReader_, _$q_, _rx_) {
       scope = $rootScope.$new();
       instanceReader = _instanceReader_;
       $q = _$q_;
+      rx = _rx_;
+      refreshStream = new rx.Subject();
 
       controller = $controller('azureInstanceDetailsCtrl', {
         $scope: scope,
         instance: {},
         app: {
-          registerAutoRefreshHandler: angular.noop
+          autoRefreshStream: refreshStream
         }
       });
 
       this.createController = function(application, instance) {
-        application.registerAutoRefreshHandler = application.registerAutoRefreshHandler || angular.noop;
+        application.autoRefreshStream = application.autoRefreshStream || refreshStream;
         controller = $controller('azureInstanceDetailsCtrl', {
           $scope: scope,
           instance: instance,

--- a/app/scripts/modules/azure/loadBalancer/configure/createLoadBalancer.controller.js
+++ b/app/scripts/modules/azure/loadBalancer/configure/createLoadBalancer.controller.js
@@ -288,6 +288,10 @@ module.exports = angular.module('spinnaker.azure.loadBalancer.create.controller'
     };
 
     $scope.taskMonitor.onApplicationRefresh = function handleApplicationRefreshComplete() {
+      // If the user has already closed the modal, do not navigate to the new details view
+      if ($scope.$$destroyed) {
+        return;
+      }
       $modalInstance.close();
       var newStateParams = {
         name: $scope.loadBalancer.name,

--- a/app/scripts/modules/azure/loadBalancer/details/loadBalancerDetail.controller.js
+++ b/app/scripts/modules/azure/loadBalancer/details/loadBalancerDetail.controller.js
@@ -63,9 +63,14 @@ module.exports = angular.module('spinnaker.azure.loadBalancer.details.controller
       return $q.when(null);
     }
 
-    extractLoadBalancer();
-
-    app.registerAutoRefreshHandler(extractLoadBalancer, $scope);
+    extractLoadBalancer().then(() => {
+      // If the user navigates away from the view before the initial extractLoadBalancer call completes,
+      // do not bother subscribing to the autoRefreshStream
+      if (!$scope.$$destroyed) {
+        let refreshWatcher = app.autoRefreshStream.subscribe(extractLoadBalancer);
+        $scope.$on('$destroy', () => refreshWatcher.dispose());
+      }
+    });
 
     this.editLoadBalancer = function editLoadBalancer() {
       $modal.open({

--- a/app/scripts/modules/azure/securityGroup/configure/configSecurityGroup.mixin.controller.js
+++ b/app/scripts/modules/azure/securityGroup/configure/configSecurityGroup.mixin.controller.js
@@ -57,6 +57,10 @@ module.exports = angular
     $scope.securityGroup = securityGroup;
 
     $scope.taskMonitor.onApplicationRefresh = function handleApplicationRefreshComplete() {
+      // If the user has already closed the modal, do not navigate to the new details view
+      if ($scope.$$destroyed) {
+        return;
+      }
       $modalInstance.close();
       var newStateParams = {
         name: $scope.securityGroup.name,

--- a/app/scripts/modules/azure/securityGroup/details/securityGroupDetail.controller.js
+++ b/app/scripts/modules/azure/securityGroup/details/securityGroupDetail.controller.js
@@ -44,7 +44,14 @@ module.exports = angular.module('spinnaker.azure.securityGroup.azure.details.con
       $state.go('^');
     }
 
-    extractSecurityGroup().then(() => application.registerAutoRefreshHandler(extractSecurityGroup, $scope));
+    extractSecurityGroup().then(() => {
+      // If the user navigates away from the view before the initial extractSecurityGroup call completes,
+      // do not bother subscribing to the autoRefreshStream
+      if (!$scope.$$destroyed) {
+        let refreshWatcher = app.autoRefreshStream.subscribe(extractSecurityGroup);
+        $scope.$on('$destroy', () => refreshWatcher.dispose());
+      }
+    });
 
     this.editInboundRules = function editInboundRules() {
       $modal.open({

--- a/app/scripts/modules/azure/serverGroup/configure/wizard/CloneServerGroup.azure.controller.js
+++ b/app/scripts/modules/azure/serverGroup/configure/wizard/CloneServerGroup.azure.controller.js
@@ -130,6 +130,10 @@ module.exports = angular.module('spinnaker.azure.cloneServerGroup.controller', [
     }
 
     $scope.taskMonitor.onApplicationRefresh = function handleApplicationRefreshComplete() {
+      // If the user has already closed the modal, do not navigate to the new details view
+      if ($scope.$$destroyed) {
+        return;
+      }
       $scope.taskMonitor.task.getCompletedKatoTask().then(function(katoTask) {
         if (katoTask.resultObjects && katoTask.resultObjects.length && katoTask.resultObjects[0].serverGroupNames) {
           var newStateParams = {

--- a/app/scripts/modules/azure/serverGroup/details/serverGroupDetails.azure.controller.js
+++ b/app/scripts/modules/azure/serverGroup/details/serverGroupDetails.azure.controller.js
@@ -124,7 +124,14 @@ module.exports = angular.module('spinnaker.azure.serverGroup.details.controller'
       $scope.state.loading = false;
     }
 
-    retrieveServerGroup().then(() => app.registerAutoRefreshHandler(retrieveServerGroup, $scope));
+    retrieveServerGroup().then(() => {
+      // If the user navigates away from the view before the initial retrieveServerGroup call completes,
+      // do not bother subscribing to the autoRefreshStream
+      if (!$scope.$$destroyed) {
+        let refreshWatcher = app.autoRefreshStream.subscribe(retrieveServerGroup);
+        $scope.$on('$destroy', () => refreshWatcher.dispose());
+      }
+    });
 
     this.destroyServerGroup = function destroyServerGroup() {
       var serverGroup = $scope.serverGroup;

--- a/app/scripts/modules/cloudfoundry/loadBalancer/configure/CreateLoadBalancerCtrl.js
+++ b/app/scripts/modules/cloudfoundry/loadBalancer/configure/CreateLoadBalancerCtrl.js
@@ -123,6 +123,10 @@ module.exports = angular.module('spinnaker.loadBalancer.cf.create.controller', [
     };
 
     $scope.taskMonitor.onApplicationRefresh = function handleApplicationRefreshComplete() {
+      // If the user has already closed the modal, do not navigate to the new details view
+      if ($scope.$$destroyed) {
+        return;
+      }
       $modalInstance.close();
       var newStateParams = {
         name: $scope.loadBalancer.name,

--- a/app/scripts/modules/cloudfoundry/loadBalancer/details/LoadBalancerDetailsCtrl.js
+++ b/app/scripts/modules/cloudfoundry/loadBalancer/details/LoadBalancerDetailsCtrl.js
@@ -65,7 +65,14 @@ module.exports = angular.module('spinnaker.loadBalancer.cf.details.controller', 
       $state.go('^', null, {location: 'replace'});
     }
 
-    extractLoadBalancer().then(() => application.registerAutoRefreshHandler(extractLoadBalancer, $scope));
+    extractLoadBalancer().then(() => {
+      // If the user navigates away from the view before the initial extractLoadBalancer call completes,
+      // do not bother subscribing to the autoRefreshStream
+      if (!$scope.$$destroyed) {
+        let refreshWatcher = app.autoRefreshStream.subscribe(extractLoadBalancer);
+        $scope.$on('$destroy', () => refreshWatcher.dispose());
+      }
+    });
 
     this.deleteLoadBalancer = function deleteLoadBalancer() {
       if ($scope.loadBalancer.instances && $scope.loadBalancer.instances.length) {

--- a/app/scripts/modules/cloudfoundry/securityGroup/details/SecurityGroupDetailsCtrl.js
+++ b/app/scripts/modules/cloudfoundry/securityGroup/details/SecurityGroupDetailsCtrl.js
@@ -63,9 +63,14 @@ module.exports = angular.module('spinnaker.securityGroup.cf.details.controller',
       $state.go('^', null, {location: 'replace'});
     }
 
-    extractSecurityGroup();
-
-    application.registerAutoRefreshHandler(extractSecurityGroup, $scope);
+    extractSecurityGroup().then(() => {
+      // If the user navigates away from the view before the initial extractSecurityGroup call completes,
+      // do not bother subscribing to the autoRefreshStream
+      if (!$scope.$$destroyed) {
+        let refreshWatcher = app.autoRefreshStream.subscribe(extractSecurityGroup);
+        $scope.$on('$destroy', () => refreshWatcher.dispose());
+      }
+    });
 
   }
 ).name;

--- a/app/scripts/modules/cloudfoundry/serverGroup/configure/wizard/CloneServerGroupCtrl.js
+++ b/app/scripts/modules/cloudfoundry/serverGroup/configure/wizard/CloneServerGroupCtrl.js
@@ -86,6 +86,10 @@ module.exports = angular.module('spinnaker.serverGroup.configure.cf.cloneServerG
     };
 
     $scope.taskMonitor.onApplicationRefresh = function handleApplicationRefreshComplete() {
+      // If the user has already closed the modal, do not navigate to the new details view
+      if ($scope.$$destroyed) {
+        return;
+      }
       $scope.taskMonitor.task.getCompletedKatoTask().then(function(katoTask) {
         if (katoTask.resultObjects && katoTask.resultObjects.length && katoTask.resultObjects[0].serverGroupNames) {
           var newStateParams = {

--- a/app/scripts/modules/core/delivery/manualExecution/manualPipelineExecution.controller.js
+++ b/app/scripts/modules/core/delivery/manualExecution/manualPipelineExecution.controller.js
@@ -73,8 +73,9 @@ module.exports = angular.module('spinnaker.core.delivery.manualPipelineExecution
     };
 
     $scope.pipelineSelected = () => {
-      let pipeline = $scope.command.pipeline;
-      $scope.currentlyRunningExecutions = application.executions
+      let pipeline = $scope.command.pipeline,
+          executions = application.executions || [];
+      $scope.currentlyRunningExecutions = executions
         .filter((execution) => execution.pipelineConfigId === pipeline.id && execution.isActive);
       addTriggers();
       $scope.triggerUpdated();

--- a/app/scripts/modules/core/navigation/states.provider.js
+++ b/app/scripts/modules/core/navigation/states.provider.js
@@ -493,10 +493,10 @@ module.exports = angular.module('spinnaker.core.navigation.states.provider', [
           app: function() {
             return {
               name: '(standalone instance)',
-              registerAutoRefreshHandler: angular.noop,
               isStandalone: true,
             };
-          }
+          },
+          overrides: () => { return {}; },
         },
         data: {
           pageTitleDetails: {

--- a/app/scripts/modules/google/loadBalancer/configure/CreateLoadBalancerCtrl.js
+++ b/app/scripts/modules/google/loadBalancer/configure/CreateLoadBalancerCtrl.js
@@ -143,6 +143,10 @@ module.exports = angular.module('spinnaker.loadBalancer.gce.create.controller', 
     };
 
     $scope.taskMonitor.onApplicationRefresh = function handleApplicationRefreshComplete() {
+      // If the user has already closed the modal, do not navigate to the new details view
+      if ($scope.$$destroyed) {
+        return;
+      }
       $modalInstance.close();
       var newStateParams = {
         name: $scope.loadBalancer.name,

--- a/app/scripts/modules/google/loadBalancer/details/LoadBalancerDetailsCtrl.js
+++ b/app/scripts/modules/google/loadBalancer/details/LoadBalancerDetailsCtrl.js
@@ -66,7 +66,14 @@ module.exports = angular.module('spinnaker.loadBalancer.gce.details.controller',
       $state.go('^', null, {location: 'replace'});
     }
 
-    extractLoadBalancer().then(() => application.registerAutoRefreshHandler(extractLoadBalancer, $scope));
+    extractLoadBalancer().then(() => {
+      // If the user navigates away from the view before the initial extractLoadBalancer call completes,
+      // do not bother subscribing to the autoRefreshStream
+      if (!$scope.$$destroyed) {
+        let refreshWatcher = app.autoRefreshStream.subscribe(extractLoadBalancer);
+        $scope.$on('$destroy', () => refreshWatcher.dispose());
+      }
+    });
 
     this.editLoadBalancer = function editLoadBalancer() {
       $uibModal.open({

--- a/app/scripts/modules/google/securityGroup/configure/ConfigSecurityGroupMixin.controller.js
+++ b/app/scripts/modules/google/securityGroup/configure/ConfigSecurityGroupMixin.controller.js
@@ -57,6 +57,10 @@ module.exports = angular
     $scope.securityGroup = securityGroup;
 
     $scope.taskMonitor.onApplicationRefresh = function handleApplicationRefreshComplete() {
+      // If the user has already closed the modal, do not navigate to the new details view
+      if ($scope.$$destroyed) {
+        return;
+      }
       $modalInstance.close();
       var newStateParams = {
         name: $scope.securityGroup.name,

--- a/app/scripts/modules/google/securityGroup/details/SecurityGroupDetailsCtrl.js
+++ b/app/scripts/modules/google/securityGroup/details/SecurityGroupDetailsCtrl.js
@@ -111,7 +111,14 @@ module.exports = angular.module('spinnaker.securityGroup.gce.details.controller'
       $state.go('^', null, {location: 'replace'});
     }
 
-    extractSecurityGroup().then(() => application.registerAutoRefreshHandler(extractSecurityGroup, $scope));
+    extractSecurityGroup().then(() => {
+      // If the user navigates away from the view before the initial extractSecurityGroup call completes,
+      // do not bother subscribing to the autoRefreshStream
+      if (!$scope.$$destroyed) {
+        let refreshWatcher = app.autoRefreshStream.subscribe(extractSecurityGroup);
+        $scope.$on('$destroy', () => refreshWatcher.dispose());
+      }
+    });
 
     this.editInboundRules = function editInboundRules() {
       $uibModal.open({

--- a/app/scripts/modules/google/serverGroup/configure/wizard/CloneServerGroupCtrl.js
+++ b/app/scripts/modules/google/serverGroup/configure/wizard/CloneServerGroupCtrl.js
@@ -128,6 +128,10 @@ module.exports = angular.module('spinnaker.serverGroup.configure.gce.cloneServer
     };
 
     $scope.taskMonitor.onApplicationRefresh = function handleApplicationRefreshComplete() {
+      // If the user has already closed the modal, do not navigate to the new details view
+      if ($scope.$$destroyed) {
+        return;
+      }
       $scope.taskMonitor.task.getCompletedKatoTask().then(function(katoTask) {
         if (katoTask.resultObjects && katoTask.resultObjects.length && katoTask.resultObjects[0].serverGroupNames) {
           var newStateParams = {

--- a/app/scripts/modules/google/serverGroup/details/serverGroupDetails.gce.controller.js
+++ b/app/scripts/modules/google/serverGroup/details/serverGroupDetails.gce.controller.js
@@ -196,7 +196,14 @@ module.exports = angular.module('spinnaker.serverGroup.details.gce.controller', 
       }
     }
 
-    retrieveServerGroup().then(() => application.registerAutoRefreshHandler(retrieveServerGroup, $scope));
+    retrieveServerGroup().then(() => {
+      // If the user navigates away from the view before the initial retrieveServerGroup call completes,
+      // do not bother subscribing to the autoRefreshStream
+      if (!$scope.$$destroyed) {
+        let refreshWatcher = app.autoRefreshStream.subscribe(retrieveServerGroup);
+        $scope.$on('$destroy', () => refreshWatcher.dispose());
+      }
+    });
 
     this.destroyServerGroup = function destroyServerGroup() {
       var serverGroup = $scope.serverGroup;

--- a/app/scripts/modules/titan/serverGroup/configure/wizard/CloneServerGroup.titan.controller.js
+++ b/app/scripts/modules/titan/serverGroup/configure/wizard/CloneServerGroup.titan.controller.js
@@ -66,6 +66,10 @@ module.exports = angular.module('spinnaker.serverGroup.configure.titan.cloneServ
     };
 
     $scope.taskMonitor.onApplicationRefresh = function handleApplicationRefreshComplete() {
+      // If the user has already closed the modal, do not navigate to the new details view
+      if ($scope.$$destroyed) {
+        return;
+      }
       $scope.taskMonitor.task.getCompletedKatoTask().then(function(katoTask) {
         if (katoTask.resultObjects && katoTask.resultObjects.length && katoTask.resultObjects[0].serverGroupNames) {
           var newStateParams = {


### PR DESCRIPTION
We sometimes get errors (and memory leaks) when an async task or method is registered and tries to run when a scope (either of a modal or a details panel) is closed - or the user navigates away from the application - while an application refresh is happening.

Users almost certainly don't notice these errors because they don't get an email literally every time one of these errors happen.

@zanthrash please review