### PR TITLE
surface rebake option on manual execution, include details in pipeline

### DIFF
--- a/app/scripts/modules/core/delivery/executionGroup/executionGroup.directive.js
+++ b/app/scripts/modules/core/delivery/executionGroup/executionGroup.directive.js
@@ -95,7 +95,7 @@ module.exports = angular
     this.triggerPipeline = () => {
       $uibModal.open({
         templateUrl: require('../manualExecution/manualPipelineExecution.html'),
-        controller: 'ManualPipelineExecutionCtrl as ctrl',
+        controller: 'ManualPipelineExecutionCtrl as vm',
         resolve: {
           pipeline: () => this.pipelineConfig,
           application: () => this.application,

--- a/app/scripts/modules/core/delivery/executions/executions.controller.js
+++ b/app/scripts/modules/core/delivery/executions/executions.controller.js
@@ -128,7 +128,7 @@ module.exports = angular.module('spinnaker.core.delivery.executions.controller',
     this.triggerPipeline = () => {
       $uibModal.open({
         templateUrl: require('../manualExecution/manualPipelineExecution.html'),
-        controller: 'ManualPipelineExecutionCtrl as ctrl',
+        controller: 'ManualPipelineExecutionCtrl as vm',
         resolve: {
           pipeline: () => null,
           application: () => this.application,

--- a/app/scripts/modules/core/delivery/manualExecution/manualPipelineExecution.controller.spec.js
+++ b/app/scripts/modules/core/delivery/manualExecution/manualPipelineExecution.controller.spec.js
@@ -1,0 +1,249 @@
+'use strict';
+
+
+describe('Controller: ManualPipelineExecution', function () {
+
+  beforeEach(
+    window.module(
+      require('./manualPipelineExecution.controller')
+    )
+  );
+
+  beforeEach(window.inject(function ($controller, $rootScope, igorService, _, $q) {
+    this.scope = $rootScope.$new();
+    this.igorService = igorService;
+    this.$q = $q;
+
+    this.initializeController = function(application, pipeline, modalInstance) {
+      this.ctrl = $controller('ManualPipelineExecutionCtrl', {
+        $scope: this.scope,
+        application: application,
+        pipeline: pipeline,
+        igorService: igorService,
+        _: _,
+        $modalInstance: modalInstance || {}
+      });
+    };
+  }));
+
+  describe('Initialization', function () {
+    describe('No pipeline provided', function () {
+      it('sets pipeline options on controller from application', function () {
+        let application = {
+          pipelineConfigs: [
+            { id: 'a' },
+            { id: 'b' }
+          ]
+        };
+        this.initializeController(application);
+
+        expect(this.ctrl.pipelineOptions).toBe(application.pipelineConfigs);
+      });
+    });
+
+    describe('Pipeline provided', function () {
+      it ('sets running executions on ctrl', function () {
+        let application = {
+          pipelineConfigs: [
+            { id: 'a', triggers: [], stages: [] },
+            { id: 'b' }
+          ],
+          executions: [
+            { pipelineConfigId: 'a', isActive: false },
+            { pipelineConfigId: 'a', isActive: true },
+            { pipelineConfigId: 'b', isActive: true },
+          ]
+        };
+
+        this.initializeController(application, application.pipelineConfigs[0]);
+        expect(this.ctrl.currentlyRunningExecutions).toEqual([application.executions[1]]);
+      });
+
+      it('adds jenkins trigger options to ctrl, setting description, overriding type, preferring enabled', function () {
+        let application = {
+          pipelineConfigs: [
+            {
+              id: 'a',
+              triggers: [
+                { type: 'jenkins', enabled: false, master: 'spinnaker', job: 'package'},
+                { type: 'jenkins', enabled: true, master: 'spinnaker', job: 'test'},
+                { type: 'other'}
+              ],
+              stages: []
+            },
+          ],
+          executions: []
+        };
+        let expected = [
+          { type: 'manual', master: 'spinnaker', job: 'test', description: 'spinnaker: test', buildNumber: null, enabled: true },
+          { type: 'manual', master: 'spinnaker', job: 'package', description: 'spinnaker: package', buildNumber: null, enabled: false }
+        ];
+
+        this.initializeController(application, application.pipelineConfigs[0]);
+        expect(this.ctrl.triggers).toEqual(expected);
+        expect(this.ctrl.command.trigger).toEqual(expected[0]);
+      });
+
+      it('includes completed, successful jobs for selected trigger', function () {
+        let builds = [
+          { building: true, number: 5 },
+          { building: false, result: 'FAILURE', number: 4 },
+          { building: false, result: 'SUCCESS', number: 3 },
+          { building: false, result: 'SUCCESS', number: 2 },
+        ];
+        spyOn(this.igorService, 'listBuildsForJob').and.returnValue(this.$q.when(builds));
+
+        let application = {
+          pipelineConfigs: [
+            {
+              id: 'a',
+              triggers: [ { type: 'jenkins', enabled: true, master: 'spinnaker', job: 'test'} ],
+              stages: []
+            },
+          ],
+          executions: []
+        };
+
+        this.initializeController(application, application.pipelineConfigs[0]);
+        expect(this.igorService.listBuildsForJob.calls.count()).toBe(1);
+        expect(this.ctrl.viewState.buildsLoading).toBe(true);
+
+        this.scope.$digest();
+        expect(this.ctrl.builds).toEqual([builds[2], builds[3]]);
+        expect(this.ctrl.command.selectedBuild).toEqual(builds[2]);
+        expect(this.ctrl.viewState.buildsLoading).toBe(false);
+      });
+
+      it('clears builds when trigger is unselected', function () {
+        spyOn(this.igorService, 'listBuildsForJob').and.returnValue(this.$q.when([
+          { building: false, result: 'SUCCESS', number: 3 }
+        ]));
+        let application = {
+          pipelineConfigs: [
+            {
+              id: 'a',
+              triggers: [ { type: 'jenkins', enabled: true, master: 'spinnaker', job: 'test'} ],
+              stages: []
+            },
+          ],
+          executions: []
+        };
+
+        this.initializeController(application, application.pipelineConfigs[0]);
+        this.scope.$digest();
+        expect(this.ctrl.builds.length).toBe(1);
+        this.ctrl.triggerUpdated(null);
+        expect(this.ctrl.builds.length).toBe(0);
+      });
+
+      it('sets showRebakeOption if any stage is a bake stage', function () {
+        let application = {
+          pipelineConfigs: [
+            {
+              id: 'a',
+              triggers: [],
+              stages: [ {type: 'not-a-bake'}, {type: 'also-not-a-bake'}]
+            },
+            {
+              id: 'b',
+              triggers: [],
+              stages: [ {type: 'not-a-bake'}, {type: 'bake'}]
+            },
+          ],
+          executions: []
+        };
+
+        this.initializeController(application, application.pipelineConfigs[0]);
+        expect(this.ctrl.showRebakeOption).toBe(false);
+        this.initializeController(application, application.pipelineConfigs[1]);
+        expect(this.ctrl.showRebakeOption).toBe(true);
+      });
+
+      it('sets parameters if present', function () {
+        let application = {
+          pipelineConfigs: [
+            {
+              id: 'a',
+              triggers: [],
+              stages: [],
+              parameterConfig: [
+                { name: 'foo' },
+                { name: 'bar', 'default': 'mr. peanutbutter' },
+                { name: 'baz', 'default': '' },
+                { name: 'bojack', 'default': null }
+              ]
+            },
+          ],
+          executions: []
+        };
+
+        this.initializeController(application, application.pipelineConfigs[0]);
+        expect(this.ctrl.parameters).toEqual({foo: undefined, bar: 'mr. peanutbutter', baz: '', bojack: null});
+      });
+    });
+  });
+
+  describe('execution', function () {
+    beforeEach(function () {
+      this.command = null;
+      this.modalInstance = {
+        close: (cmd) => {
+          this.command = cmd;
+        }
+      };
+    });
+    it('adds a placeholder trigger if none present', function () {
+      let application = {
+        pipelineConfigs: [
+          { id: 'a', name: 'aa', triggers: [], stages: []},
+        ],
+        executions: []
+      };
+      this.initializeController(application, application.pipelineConfigs[0], this.modalInstance);
+
+      this.ctrl.execute();
+      expect(this.command.trigger).toEqual({});
+    });
+
+    it('adds parameters if configured', function () {
+      let application = {
+        pipelineConfigs: [
+          {
+            id: 'a',
+            triggers: [],
+            stages: [],
+            parameterConfig: [
+              { name: 'bar', 'default': 'mr. peanutbutter' },
+            ]
+          },
+        ],
+        executions: []
+      };
+
+      this.initializeController(application, application.pipelineConfigs[0], this.modalInstance);
+      this.ctrl.execute();
+      expect(this.command.trigger.parameters).toEqual({bar: 'mr. peanutbutter'});
+    });
+
+    it('adds build number if selected', function () {
+      spyOn(this.igorService, 'listBuildsForJob').and.returnValue(this.$q.when([
+        { building: false, result: 'SUCCESS', number: 3 }
+      ]));
+      let application = {
+        pipelineConfigs: [
+          {
+            id: 'a',
+            triggers: [ { type: 'jenkins', enabled: true, master: 'spinnaker', job: 'test'} ],
+            stages: []
+          },
+        ],
+        executions: []
+      };
+
+      this.initializeController(application, application.pipelineConfigs[0], this.modalInstance);
+      this.scope.$digest();
+      this.ctrl.execute();
+      expect(this.command.trigger.buildNumber).toBe(3);
+    });
+  });
+});

--- a/app/scripts/modules/core/delivery/manualExecution/manualPipelineExecution.html
+++ b/app/scripts/modules/core/delivery/manualExecution/manualPipelineExecution.html
@@ -2,40 +2,40 @@
   <task-monitor monitor="taskMonitor"></task-monitor>
   <modal-close></modal-close>
   <div class="modal-header">
-    <h3 ng-if="command.pipeline && triggers.length">Select Execution Parameters</h3>
-    <h3 ng-if="command.pipeline && !triggers.length">Confirm Execution</h3>
-    <h3 ng-if="!command.pipeline">Select Pipeline</h3>
+    <h3 ng-if="vm.command.pipeline && vm.triggers.length">Select Execution Parameters</h3>
+    <h3 ng-if="vm.command.pipeline && !vm.triggers.length">Confirm Execution</h3>
+    <h3 ng-if="!vm.command.pipeline">Select Pipeline</h3>
   </div>
   <form role="form">
     <div class="modal-body container-fluid form-horizontal">
-      <div class="form-group" ng-if="pipelineOptions">
+      <div class="form-group" ng-if="vm.pipelineOptions">
         <label class="col-md-2 col-md-offset-1 sm-label-left">Pipeline</label>
         <div class="col-md-7">
-          <ui-select ng-model="command.pipeline"
+          <ui-select ng-model="vm.command.pipeline"
                      style="width: 250px"
                      class="form-control input-sm"
-                     on-select="pipelineSelected()">
+                     on-select="vm.pipelineSelected()">
             <ui-select-match>
               <strong>{{$select.selected.name}}</strong>
             </ui-select-match>
-            <ui-select-choices repeat="pipeline as pipeline in application.pipelineConfigs | anyFieldFilter: {name: $select.search }">
+            <ui-select-choices repeat="pipeline as pipeline in vm.pipelineOptions | anyFieldFilter: {name: $select.search }">
               <div><strong>{{pipeline.name}}</strong></div>
             </ui-select-choices>
           </ui-select>
         </div>
       </div>
-      <div class="form-group" ng-if="command.pipeline">
+      <div class="form-group" ng-if="vm.command.pipeline">
         <div class="col-md-10">
-          <p>This will start a new run of <strong>{{command.pipeline.name}}</strong>.</p>
+          <p>This will start a new run of <strong>{{vm.command.pipeline.name}}</strong>.</p>
         </div>
       </div>
       <div class="alert alert-warning"
-           ng-if="currentlyRunningExecutions.length">
+           ng-if="vm.currentlyRunningExecutions.length">
         <p><strong>
           <span class="glyphicon glyphicon-warning-sign"></span>
           This pipeline is currently executing!
         </strong></p>
-        <div ng-repeat="execution in currentlyRunningExecutions" class="pad-left">
+        <div ng-repeat="execution in vm.currentlyRunningExecutions" class="pad-left">
           <strong>Execution started: </strong>{{execution.startTime | timestamp }}
           <div>
             <strong>Current stage:</strong>
@@ -46,31 +46,31 @@
         </div>
       </div>
 
-      <div class="form-group" ng-if="triggers.length">
+      <div ng-if="vm.triggers.length">
         <div class="form-group">
           <label class="col-md-2 col-md-offset-1 sm-label-left">Trigger</label>
           <div class="col-md-6">
             <p class="form-control-static"
-               ng-if="triggers.length === 1">{{command.trigger.description}}</p>
+               ng-if="vm.triggers.length === 1">{{vm.command.trigger.description}}</p>
             <select class="form-control input-sm"
-                    ng-if="triggers.length > 1"
-                    ng-model="command.trigger"
-                    ng-options="trigger as trigger.description for trigger in triggers"
-                    ng-change="triggerUpdated(trigger)">
+                    ng-if="vm.triggers.length > 1"
+                    ng-model="vm.command.trigger"
+                    ng-options="trigger as trigger.description for trigger in vm.triggers"
+                    ng-change="vm.triggerUpdated(trigger)">
             </select>
           </div>
         </div>
         <div class="form-group">
           <label class="col-md-2 col-md-offset-1 sm-label-left">Build</label>
-          <div class="col-md-6" ng-if="viewState.buildsLoading">
+          <div class="col-md-6" ng-if="vm.viewState.buildsLoading">
             <p class="form-control-static text-center" >
               <span class="glyphicon glyphicon-asterisk glyphicon-spinning"></span>
             </p>
           </div>
-          <div class="col-md-9" ng-if="!viewState.buildsLoading">
+          <div class="col-md-9" ng-if="!vm.viewState.buildsLoading">
             <ui-select class="form-control input-sm"
-                       ng-model="command.selectedBuild"
-                       on-select="updateSelectedBuild($item)">
+                       ng-model="vm.command.selectedBuild"
+                       on-select="vm.updateSelectedBuild($item)">
               <ui-select-match placeholder="Select...">
                 <span>
                   <strong>Build {{$select.selected.number}}</strong>
@@ -78,7 +78,7 @@
                   ({{$select.selected.timestamp | timestamp}})
                 </span>
               </ui-select-match>
-              <ui-select-choices repeat="build in builds | anyFieldFilter: {number: $select.search, fullDisplayName: $select.search, status: $select.search}">
+              <ui-select-choices repeat="build in vm.builds | anyFieldFilter: {number: $select.search, fullDisplayName: $select.search, status: $select.search}">
               <span>
                   <strong>Build {{build.number}}</strong>
                   {{build | buildDisplayName}}
@@ -90,27 +90,38 @@
         </div>
       </div>
 
-      <div class="form-group" ng-if="command.pipeline.parameterConfig !== undefined && command.pipeline.parameterConfig.length">
+      <div class="form-group" ng-if="vm.command.pipeline.parameterConfig !== undefined && vm.command.pipeline.parameterConfig.length">
         <div class="col-md-10">
           <h4>Parameters</h4>
         </div>
-        <div class="form-group" ng-repeat="parameter in command.pipeline.parameterConfig | orderBy:'name' ">
+        <div class="form-group" ng-repeat="parameter in vm.command.pipeline.parameterConfig | orderBy:'name' ">
           <div class="col-md-offset-1 col-md-4 sm-label-left break-word">
             <b>{{parameter.name}}</b>
             <help-field content="{{parameter.description}}" ng-if="parameter.description"></help-field>
           </div>
           <div class="col-md-6">
-            <input type="text" class="form-control input-sm" ng-model="parameters[parameter.name]"/>
+            <input type="text" class="form-control input-sm" ng-model="vm.parameters[parameter.name]"/>
           </div>
+        </div>
+      </div>
+
+      <div class="form-group" ng-if="vm.showRebakeOption">
+        <label class="col-md-2 col-md-offset-1 sm-label-left">Rebake</label>
+        <div class="col-md-6 checkbox">
+          <label>
+            <input type="checkbox" ng-model="vm.command.trigger.rebake"/>
+            Force Rebake
+            <help-field key="execution.forceRebake"></help-field>
+          </label>
         </div>
       </div>
 
     </div>
     <div class="modal-footer">
-      <button class="btn btn-default" ng-click="ctrl.cancel()">Cancel</button>
+      <button class="btn btn-default" ng-click="vm.cancel()">Cancel</button>
       <button type="submit"
               class="btn btn-primary"
-              ng-click="ctrl.execute()">
+              ng-click="vm.execute()">
         <span class="glyphicon glyphicon-play"></span> Run
       </button>
     </div>

--- a/app/scripts/modules/core/help/helpContents.js
+++ b/app/scripts/modules/core/help/helpContents.js
@@ -222,4 +222,7 @@ module.exports = angular.module('spinnaker.core.help.contents', [])
     'project.cluster.detail': '<p>(Optional field)</p><p>Filters displayed clusters by detail.</p><p>Enter <samp>*</samp> to include all details; leave blank to omit any clusters with a detail.</p>',
     'instanceType.unavailable': '<p>This instance type is not available for the selected configuration.</p>',
     'fastProperty.canary.strategy.rolloutList': '<p>A comma separated list of numbers or percentages of instance canary against.</p>',
+    'execution.forceRebake': '<p>By default, the bakery will <b>not</b> create a new image if the contents of the package have not changed; ' +
+      'instead, it will return the previously baked image.</p>' +
+      '<p>Select this option to force the bakery to create a new image, regardless of whether or not the selected package exists.</p>',
   }).name;

--- a/app/scripts/modules/core/pipeline/config/stages/bake/aws/awsBakeStage.js
+++ b/app/scripts/modules/core/pipeline/config/stages/bake/aws/awsBakeStage.js
@@ -16,6 +16,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.aws.bakeStage', [
       description: 'Bakes an image in the specified region',
       templateUrl: require('./bakeStage.html'),
       executionDetailsUrl: require('./bakeExecutionDetails.html'),
+      executionLabelTemplateUrl: require('../bakeExecutionLabel.html'),
       defaultTimeoutMs: 60 * 60 * 1000, // 60 minutes
       validators: [
         { type: 'requiredField', fieldName: 'package', },

--- a/app/scripts/modules/core/pipeline/config/stages/bake/aws/bakeExecutionDetails.html
+++ b/app/scripts/modules/core/pipeline/config/stages/bake/aws/bakeExecutionDetails.html
@@ -34,6 +34,7 @@
     <div class="row" ng-if="stage.context.region && stage.context.status.resourceId">
       <div class="col-md-12">
         <div class="well alert alert-info">
+          <div ng-if="stage.context.previouslyBaked">No changes detected; reused existing bake</div>
           <a target="_blank" href="{{ bakeryDetailUrl(stage) }}">
             View Bakery Details
           </a>

--- a/app/scripts/modules/core/pipeline/config/stages/bake/bakeExecutionLabel.html
+++ b/app/scripts/modules/core/pipeline/config/stages/bake/bakeExecutionLabel.html
@@ -1,0 +1,12 @@
+<span class="stage-label">
+  {{ stage.name }}
+  {{ stage.context | json}}
+  <span class="small" ng-if="stage.masterStage.context.allPreviouslyBaked">
+    <br/>
+    (previously baked)
+  </span>
+  <span class="small" ng-if="stage.masterStage.context.somePreviouslyBaked">
+    <br/>
+    (some previously baked)
+  </span>
+</span>

--- a/app/scripts/modules/core/pipeline/config/stages/bake/bakeStage.js
+++ b/app/scripts/modules/core/pipeline/config/stages/bake/bakeStage.js
@@ -2,9 +2,11 @@
 
 let angular = require('angular');
 
-module.exports = angular.module('spinnaker.core.pipeline.stage.bakeStage', [
-  require('../../pipelineConfigProvider.js'),
-])
+module.exports = angular
+  .module('spinnaker.core.pipeline.stage.bakeStage', [
+    require('../../pipelineConfigProvider.js'),
+    require('./bakeStage.transformer.js'),
+  ])
   .config(function(pipelineConfigProvider) {
     pipelineConfigProvider.registerStage({
       useBaseProvider: true,
@@ -12,4 +14,8 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.bakeStage', [
       description: 'Bakes an image in the specified region',
       key: 'bake',
     });
-  }).name;
+  })
+  .run(function(pipelineConfig, bakeStageTransformer) {
+    pipelineConfig.registerTransformer(bakeStageTransformer);
+  })
+  .name;

--- a/app/scripts/modules/core/pipeline/config/stages/bake/bakeStage.transformer.js
+++ b/app/scripts/modules/core/pipeline/config/stages/bake/bakeStage.transformer.js
@@ -1,0 +1,29 @@
+'use strict';
+
+let angular = require('angular');
+
+module.exports = angular
+  .module('spinnaker.core.pipeline.stage.bake.transformer', [
+  ])
+  .service('bakeStageTransformer', function() {
+
+    /**
+     * Bubbles "previouslyBaked" flag up to parallel bake stage
+     */
+    function propagatePreviouslyBakedFlag(execution) {
+      execution.stages.forEach(function(stage) {
+        if (stage.type === 'bake' && stage.context) {
+          let childBakeStages = execution.stages.filter((test) => test.type === 'bake' && test.parentStageId === stage.id);
+          if (childBakeStages.length) {
+            stage.context.allPreviouslyBaked = childBakeStages.every((child) => child.context.previouslyBaked);
+            stage.context.somePreviouslyBaked = !stage.context.allPreviouslyBaked &&
+              childBakeStages.some((child) => child.context.previouslyBaked);
+          }
+        }
+      });
+    }
+
+    this.transform = function(application, execution) {
+      propagatePreviouslyBakedFlag(execution);
+    };
+  }).name;

--- a/app/scripts/modules/core/pipeline/config/stages/bake/bakeStage.transformer.spec.js
+++ b/app/scripts/modules/core/pipeline/config/stages/bake/bakeStage.transformer.spec.js
@@ -1,0 +1,48 @@
+'use strict';
+
+describe('bakeStageTransformer', function() {
+
+  beforeEach(
+    window.module(
+      require('./bakeStage.transformer')
+    )
+  );
+
+  beforeEach(window.inject(function (bakeStageTransformer) {
+    this.transformer = bakeStageTransformer;
+  }));
+
+  describe('transform', function () {
+    it('should add allPreviouslyBaked/somePreviouslyBaked flags when all/some child bake stages are marked previouslyBaked', function () {
+      var execution = {
+        stages: [
+          {id: 'a', name: 'a', context: {}},
+          {id: 'b', name: 'b', parentStageId: 'a', context: {previouslyBaked: true}},
+          {id: 'c', name: 'c', parentStageId: 'a', context: {previouslyBaked: true}},
+          {id: 'e', name: 'e', context: {}},
+          {id: 'f', name: 'f', parentStageId: 'e', context: {previouslyBaked: true}},
+          {id: 'g', name: 'g', parentStageId: 'e', context: {previouslyBaked: false}},
+          {id: 'h', name: 'h', context: {}},
+          {id: 'i', name: 'i', parentStageId: 'h', context: {previouslyBaked: false}},
+          {id: 'j', name: 'j', context: {}},
+        ]
+      };
+
+      execution.stages.forEach((stage) => stage.type = 'bake');
+
+      this.transformer.transform({}, execution);
+
+      expect(execution.stages[0].context.allPreviouslyBaked).toBe(true);
+      expect(execution.stages[0].context.somePreviouslyBaked).toBe(false);
+
+      expect(execution.stages[3].context.allPreviouslyBaked).toBe(false);
+      expect(execution.stages[3].context.somePreviouslyBaked).toBe(true);
+
+      expect(execution.stages[6].context.allPreviouslyBaked).toBe(false);
+      expect(execution.stages[6].context.somePreviouslyBaked).toBe(false);
+
+      expect(execution.stages[8].context.allPreviouslyBaked).toBe(undefined);
+      expect(execution.stages[8].context.somePreviouslyBaked).toBe(undefined);
+    });
+  });
+});

--- a/app/scripts/modules/core/pipeline/config/stages/bake/docker/dockerBakeStage.js
+++ b/app/scripts/modules/core/pipeline/config/stages/bake/docker/dockerBakeStage.js
@@ -21,6 +21,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.docker.bakeStage'
       description: 'Bakes an image in the specified region',
       templateUrl: require('./bakeStage.html'),
       executionDetailsUrl: require('./bakeExecutionDetails.html'),
+      executionLabelTemplateUrl: require('../bakeExecutionLabel.html'),
       defaultTimeoutMs: 60 * 60 * 1000, // 60 minutes
       validators: [
         { type: 'requiredField', fieldName: 'package', },

--- a/app/scripts/modules/core/pipeline/config/stages/bake/gce/gceBakeStage.js
+++ b/app/scripts/modules/core/pipeline/config/stages/bake/gce/gceBakeStage.js
@@ -16,6 +16,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.gce.bakeStage', [
       description: 'Bakes an image in the specified region',
       templateUrl: require('./bakeStage.html'),
       executionDetailsUrl: require('./bakeExecutionDetails.html'),
+      executionLabelTemplateUrl: require('../bakeExecutionLabel.html'),
       defaultTimeoutMs: 60 * 60 * 1000, // 60 minutes
       validators: [
         { type: 'requiredField', fieldName: 'package', },


### PR DESCRIPTION
* provide visual clues that a previous bake was returned on a bake operation
* allow users to request a rebake when triggering a pipeline with a bake stage
* refactored the ManualPipelineExecutionCtrl to use the `vm` pattern
* added a pile of tests

dependent on https://github.com/spinnaker/orca/pull/678

@zanthrash @duftler please review when you have time

<img width="603" alt="screen shot 2015-12-10 at 2 53 26 pm" src="https://cloud.githubusercontent.com/assets/73450/11731127/11f97ea6-9f4e-11e5-9c4b-45a311cfe44a.png">
<img width="976" alt="screen shot 2015-12-10 at 2 49 00 pm" src="https://cloud.githubusercontent.com/assets/73450/11731126/11f61108-9f4e-11e5-994c-7cb2febd3f21.png">
