### PR TITLE
fix initial selection on regionSelectField

### DIFF
--- a/app/scripts/modules/core/region/regionSelectField.directive.html
+++ b/app/scripts/modules/core/region/regionSelectField.directive.html
@@ -7,7 +7,7 @@
             ng-model="component[field]"
             ng-change="onChange()"
             required>
-      <option ng-repeat="region in regions" value="{{region.name}}" ng-selected="component[field] === region">{{region.name}}</option>
+      <option ng-repeat="region in regions" value="{{region.name}}" ng-selected="component[field] === region.name">{{region.name}}</option>
     </select>
     <p ng-if="readOnly" class="form-control-static">{{component[field]}}</p>
   </div>

--- a/app/scripts/modules/core/region/regionSelectField.directive.spec.js
+++ b/app/scripts/modules/core/region/regionSelectField.directive.spec.js
@@ -66,4 +66,21 @@ describe('Directives: regionSelectField', function () {
       expect(option.value).toBe(expected[idx]);
     });
   });
+
+  it('selects correct initial value', function () {
+    var scope = this.scope;
+
+    scope.regions = [{name: 'us-east-1'}, {name: 'us-west-1'}];
+
+    scope.model = { regionField: 'us-west-1', accountField: 'a'};
+
+    var html = '<region-select-field regions="regions" component="model" field="regionField" account="model.accountField" provider="\'aws\'" label-columns="2"></region-select-field>';
+
+    var elem = this.compile(html)(scope);
+    scope.$digest();
+
+    var options = elem.find('option');
+    expect(options[1].selected).toBe(true);
+
+  });
 });


### PR DESCRIPTION
How this bug has been in the wild for at least three weeks without anyone seeing it is a mystery. I guess maybe folks just don't notice it, since it doesn't seem to affect the actual model values.

Basically, what's happening now is that the displayed value in the select box is always the first option, even if the second or third option were selected. That's not really true: I am seeing the third option being surface, just not the fourth option, which makes even less sense. For example: with options [`us-east-1`, `us-west-1`, `us-west-2`, `eu-west-1`], if `eu-west-1` is pre-populated, the select box shows `us-east-1`; if `us-west-2` is pre-populated, the select box shows `us-west-2`. Why? What kind of world do we live in?

Whatever. This fixes it. 

@zanthrash can you review?