### PR TITLE
Added the ability to specify certificate name instead of ARN

### DIFF
--- a/app/scripts/modules/amazon/loadBalancer/configure/createLoadBalancer.controller.js
+++ b/app/scripts/modules/amazon/loadBalancer/configure/createLoadBalancer.controller.js
@@ -238,7 +238,7 @@ module.exports = angular.module('spinnaker.loadBalancer.aws.create.controller', 
     function certificateIdAsARN(accountId, certificateId) {
       if (certificateId) {
         // If they really want to enter the ARN...
-        if (!certificateId.indexOf('arn') > -1) {
+        if (!certificateId.indexOf('arn:aws:iam::"') === 0) {
           return "arn:aws:iam::" + accountId + ":server-certificate/" + certificateId;
         }
       }

--- a/app/scripts/modules/amazon/loadBalancer/configure/createLoadBalancer.controller.js
+++ b/app/scripts/modules/amazon/loadBalancer/configure/createLoadBalancer.controller.js
@@ -235,6 +235,24 @@ module.exports = angular.module('spinnaker.loadBalancer.aws.create.controller', 
       $scope.existingSecurityGroupNames = [];
     }
 
+    function certificateIdAsARN(accountId, certificateId) {
+      if (certificateId) {
+        // If they really want to enter the ARN...
+        if (!certificateId.indexOf('arn') > -1) {
+          return "arn:aws:iam::" + accountId + ":server-certificate/" + certificateId;
+        }
+      }
+    }
+
+    function formatListeners() {
+      return accountService.getAccountDetails($scope.loadBalancer.credentials).then(function (account) {
+        $scope.loadBalancer.listeners.forEach(function (listener, idx) {
+          var arn = certificateIdAsARN(account.accountId, listener.sslCertificateId);
+          $scope.loadBalancer.listeners[idx].sslCertificateId = arn;
+        });
+      });
+    }
+
     initializeController();
 
     // Controller API
@@ -337,7 +355,9 @@ module.exports = angular.module('spinnaker.loadBalancer.aws.create.controller', 
 
       $scope.taskMonitor.submit(
         function() {
-          return loadBalancerWriter.upsertLoadBalancer($scope.loadBalancer, application, descriptor);
+          return formatListeners().then(function () {
+            return loadBalancerWriter.upsertLoadBalancer($scope.loadBalancer, application, descriptor);
+          });
         }
       );
     };

--- a/app/scripts/modules/amazon/loadBalancer/configure/createLoadBalancer.controller.js
+++ b/app/scripts/modules/amazon/loadBalancer/configure/createLoadBalancer.controller.js
@@ -238,8 +238,8 @@ module.exports = angular.module('spinnaker.loadBalancer.aws.create.controller', 
     function certificateIdAsARN(accountId, certificateId) {
       if (certificateId) {
         // If they really want to enter the ARN...
-        if (!certificateId.indexOf('arn:aws:iam::"') === 0) {
-          return "arn:aws:iam::" + accountId + ":server-certificate/" + certificateId;
+        if (!certificateId.indexOf('arn:aws:iam::') === 0) {
+          return 'arn:aws:iam::' + accodtId + ':server-certificate/' + certificateId;
         }
       }
     }

--- a/app/scripts/modules/amazon/loadBalancer/configure/listeners.html
+++ b/app/scripts/modules/amazon/loadBalancer/configure/listeners.html
@@ -10,7 +10,7 @@
             <th></th>
             <th>Internal Protocol</th>
             <th>Internal Port</th>
-            <th ng-if="ctrl.showSslCertificateIdField()" width="30%">SSL Certificate ARN</th>
+            <th ng-if="ctrl.showSslCertificateIdField()" width="30%">SSL Certificate Name</th>
             <th></th>
           </tr>
           </thead>

--- a/app/scripts/modules/amazon/loadBalancer/loadBalancer.transformer.js
+++ b/app/scripts/modules/amazon/loadBalancer/loadBalancer.transformer.js
@@ -101,6 +101,9 @@ module.exports = angular.module('spinnaker.aws.loadBalancer.transformer', [
         if (elb.listenerDescriptions) {
           toEdit.listeners = elb.listenerDescriptions.map(function (description) {
             var listener = description.listener;
+            if (listener.sslcertificateId) {
+              listener.sslcertificateId = listener.sslcertificateId.split("/")[1];
+            }
             return {
               internalProtocol: listener.instanceProtocol,
               internalPort: listener.instancePort,


### PR DESCRIPTION
We get a lot of people asking how to format ARNs for their SSL certificates coming from Lemur. This change allows them to simply specify the SSL certificate name and formats it correctly as an ARN.