### PR TITLE
move rebake control above parameters in manual pipeline execution modal

### DIFF
--- a/app/scripts/modules/core/delivery/manualExecution/manualPipelineExecution.html
+++ b/app/scripts/modules/core/delivery/manualExecution/manualPipelineExecution.html
@@ -88,6 +88,17 @@
             </ui-select>
           </div>
         </div>
+        <div class="form-group" ng-if="vm.showRebakeOption">
+          <label class="col-md-2 col-md-offset-1 sm-label-left">Rebake</label>
+          <div class="col-md-6 checkbox">
+            <label>
+              <input type="checkbox" ng-model="vm.command.trigger.rebake"/>
+              Force Rebake
+              <help-field key="execution.forceRebake"></help-field>
+            </label>
+          </div>
+        </div>
+
       </div>
 
       <div class="form-group" ng-if="vm.command.pipeline.parameterConfig !== undefined && vm.command.pipeline.parameterConfig.length">
@@ -104,18 +115,6 @@
           </div>
         </div>
       </div>
-
-      <div class="form-group" ng-if="vm.showRebakeOption">
-        <label class="col-md-2 col-md-offset-1 sm-label-left">Rebake</label>
-        <div class="col-md-6 checkbox">
-          <label>
-            <input type="checkbox" ng-model="vm.command.trigger.rebake"/>
-            Force Rebake
-            <help-field key="execution.forceRebake"></help-field>
-          </label>
-        </div>
-      </div>
-
     </div>
     <div class="modal-footer">
       <button class="btn btn-default" ng-click="vm.cancel()">Cancel</button>


### PR DESCRIPTION
Current:
![screen shot 2015-12-14 at 9 21 32 am](https://cloud.githubusercontent.com/assets/73450/11788106/1e189318-a244-11e5-9805-9d1f8b4a5063.png)


PR:
![screen shot 2015-12-14 at 9 21 16 am](https://cloud.githubusercontent.com/assets/73450/11788109/22f44472-a244-11e5-8994-79259c046609.png)


Parameters are still ugly because the names tend to be longer; this makes the modal layout a little less ugly.