### PR TITLE
fix styling on whats-new directive when unread updates present

### DIFF
--- a/app/scripts/modules/core/presentation/main.less
+++ b/app/scripts/modules/core/presentation/main.less
@@ -945,19 +945,6 @@ textarea.code {
   }
 }
 
-feedback {
-  margin-right: 20px;
-  margin-left: 10px;
-  float: right;
-  display: inline-block;
-}
-
-whats-new {
-  margin-right: 20px;
-  float: right;
-  display: inline-block;
-}
-
 .modal {
   &.no-animate {
     transition: none;
@@ -999,26 +986,6 @@ whats-new {
 select.input-sm {
   padding-left: 5px;
   padding-right: 0;
-}
-
-whats-new {
-  .navbar-nav > li > a {
-    &.unread {
-      padding: 4px 12px;
-      @media (min-width: 768px) and (max-width: 992px) {
-        padding: 15px 0;
-        line-height: 20px;
-      }
-      font-weight: 400;
-      .timestamp {
-        color: @code-yellow;
-        font-size: 80%;
-        font-weight: 200;
-        display: block;
-      }
-
-    }
-  }
 }
 
 html {

--- a/app/scripts/modules/netflix/whatsNew/whatsNew.directive.html
+++ b/app/scripts/modules/netflix/whatsNew/whatsNew.directive.html
@@ -1,5 +1,5 @@
 <li class="whats-new" ng-if="fileLastUpdated">
-  <a href class="remove-border-top" ng-click="showWhatsNew()">
+  <a href class="remove-border-top" ng-click="showWhatsNew()" ng-class="{unread: updatesUnread()}">
     <span class="glyphicon glyphicon-info-sign"></span>
     <span class="hidden-xs hidden-sm">What's New</span>
     <span ng-if="updatesUnread()" class="timestamp hidden-sm">({{lastUpdatedDate | timestamp}})</span>

--- a/app/scripts/modules/netflix/whatsNew/whatsNew.less
+++ b/app/scripts/modules/netflix/whatsNew/whatsNew.less
@@ -1,13 +1,19 @@
 @import "../../core/presentation/less/imports/commonImports.less";
 
-.whats-new {
-  font-weight: 400;
-
-  .timestamp {
-    color: @code-yellow;
-    font-size: 80%;
-    font-weight: 200;
-    display: block;
-    position: fixed;
+.navbar-inverse .navbar-nav > li.whats-new > a {
+  &.unread {
+    padding: 5px 12px;
+    @media (min-width: 768px) and (max-width: 992px) {
+      padding: 15px 0;
+      line-height: 20px;
+      color: @code-yellow;
+    }
+    font-weight: 400;
+    .timestamp {
+      color: @code-yellow;
+      font-size: 80%;
+      font-weight: 200;
+      display: block;
+    }
   }
 }


### PR DESCRIPTION
We lost some style attributes on a recent refactor of the `whatsNew` directive. This PR:
* fixes padding and an overflow issue with the "last updated" label
(current)
<img width="237" alt="screen shot 2015-12-15 at 9 23 09 am" src="https://cloud.githubusercontent.com/assets/73450/11818212/e715baec-a30d-11e5-9c4f-7f819baacb1d.png">
(this pr)
<img width="249" alt="screen shot 2015-12-15 at 9 23 55 am" src="https://cloud.githubusercontent.com/assets/73450/11818210/e7137606-a30d-11e5-9d10-3f9916881b14.png">

* sets the icon color to yellow on smaller screens when there are unread messages
<img width="108" alt="screen shot 2015-12-15 at 9 24 26 am" src="https://cloud.githubusercontent.com/assets/73450/11818211/e714c128-a30d-11e5-9f05-6de8b49adbee.png">

cc @riltsken 


