### PR TITLE
Makes  use newly exposed endpoing on Gate to get base OS options.

### DIFF
--- a/app/scripts/modules/core/pipeline/config/stages/bake/aws/awsBakeStage.js
+++ b/app/scripts/modules/core/pipeline/config/stages/bake/aws/awsBakeStage.js
@@ -45,7 +45,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.aws.bakeStage', [
     function initialize() {
       $q.all({
         regions: bakeryService.getRegions('aws'),
-        baseOsOptions: bakeryService.getBaseOsOptions(),
+        baseOsOptions: bakeryService.getBaseOsOptions('aws'),
         baseLabelOptions: bakeryService.getBaseLabelOptions(),
         vmTypes: bakeryService.getVmTypes(),
         storeTypes: bakeryService.getStoreTypes(),
@@ -70,11 +70,11 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.aws.bakeStage', [
         if (!$scope.stage.regions.length && $scope.application.defaultRegions.aws) {
           $scope.stage.regions.push($scope.application.defaultRegions.aws);
         }
-        $scope.baseOsOptions = results.baseOsOptions;
+        $scope.baseOsOptions = results.baseOsOptions.baseImages;
         $scope.baseLabelOptions = results.baseLabelOptions;
 
         if (!$scope.stage.baseOs && $scope.baseOsOptions && $scope.baseOsOptions.length) {
-          $scope.stage.baseOs = $scope.baseOsOptions[0];
+          $scope.stage.baseOs = $scope.baseOsOptions[0].id;
         }
         if (!$scope.stage.baseLabel && $scope.baseLabelOptions && $scope.baseLabelOptions.length) {
           $scope.stage.baseLabel = $scope.baseLabelOptions[0];

--- a/app/scripts/modules/core/pipeline/config/stages/bake/aws/bakeStage.html
+++ b/app/scripts/modules/core/pipeline/config/stages/bake/aws/bakeStage.html
@@ -16,8 +16,8 @@
       <label class="radio-inline" ng-repeat="baseOsOption in baseOsOptions">
         <input type="radio"
                ng-model="stage.baseOs"
-               ng-value="baseOsOption"/>
-        {{baseOsOption}}
+               ng-value="baseOsOption.id"/>
+        {{baseOsOption.id}} ({{baseOsOption.shortDescription}}) <help-field content="{{baseOsOption.detailedDescription}}" />
       </label>
     </stage-config-field>
     <stage-config-field label="VM Type" ng-if="stage.cloudProviderType === 'aws' || stage.cloudProviderType === undefined">

--- a/app/scripts/modules/core/pipeline/config/stages/bake/bakery.service.js
+++ b/app/scripts/modules/core/pipeline/config/stages/bake/bakery.service.js
@@ -2,9 +2,10 @@
 
 let angular = require('angular');
 
-// TODO: Move everything in here to config
-module.exports = angular.module('spinnaker.core.pipeline.stage.bake.service', [])
-  .factory('bakeryService', function($q) {
+module.exports = angular.module('spinnaker.core.pipeline.stage.bake.service', [
+  require('exports?"restangular"!imports?_=lodash!restangular'),
+])
+  .factory('bakeryService', function($q, _, Restangular) {
 
     function getRegions(provider) {
       if (!provider || provider === 'aws') {
@@ -15,8 +16,16 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.bake.service', []
       }
     }
 
-    function getBaseOsOptions() {
-      return $q.when(['trusty', 'ubuntu', 'centos']);
+    function getBaseOsOptions(provider) {
+      if (provider) {
+        return getBaseOsOptions().then(function(options) {
+          return _.find(options, { cloudProvider: provider });
+        });
+      }
+      return Restangular
+        .all('bakery/options')
+        .withHttpConfig({cache: true})
+        .getList();
     }
 
     function getBaseLabelOptions() {

--- a/app/scripts/modules/core/pipeline/config/stages/bake/docker/bakeStage.html
+++ b/app/scripts/modules/core/pipeline/config/stages/bake/docker/bakeStage.html
@@ -7,8 +7,8 @@
     <label class="radio-inline" ng-repeat="baseOsOption in baseOsOptions">
       <input type="radio"
              ng-model="stage.baseOs"
-             ng-value="baseOsOption"/>
-      {{baseOsOption}}
+             ng-value="baseOsOption.id"/>
+      {{baseOsOption.id}} ({{baseOsOption.shortDescription}}) <help-field content="{{baseOsOption.detailedDescription}}" />
     </label>
   </stage-config-field>
 

--- a/app/scripts/modules/core/pipeline/config/stages/bake/docker/dockerBakeStage.js
+++ b/app/scripts/modules/core/pipeline/config/stages/bake/docker/dockerBakeStage.js
@@ -45,14 +45,14 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.docker.bakeStage'
     function initialize() {
       $scope.viewState.providerSelected = true;
       $q.all({
-        baseOsOptions: bakeryService.getBaseOsOptions(),
+        baseOsOptions: bakeryService.getBaseOsOptions('docker'),
         baseLabelOptions: bakeryService.getBaseLabelOptions(),
       }).then(function(results) {
-        $scope.baseOsOptions = results.baseOsOptions;
+        $scope.baseOsOptions = results.baseOsOptions.baseImages;
         $scope.baseLabelOptions = results.baseLabelOptions;
 
         if (!$scope.stage.baseOs && $scope.baseOsOptions && $scope.baseOsOptions.length) {
-          $scope.stage.baseOs = $scope.baseOsOptions[0];
+          $scope.stage.baseOs = $scope.baseOsOptions[0].id;
         }
         if (!$scope.stage.baseLabel && $scope.baseLabelOptions && $scope.baseLabelOptions.length) {
           $scope.stage.baseLabel = $scope.baseLabelOptions[0];

--- a/app/scripts/modules/core/pipeline/config/stages/bake/gce/bakeStage.html
+++ b/app/scripts/modules/core/pipeline/config/stages/bake/gce/bakeStage.html
@@ -7,8 +7,8 @@
     <label class="radio-inline" ng-repeat="baseOsOption in baseOsOptions">
       <input type="radio"
              ng-model="stage.baseOs"
-             ng-value="baseOsOption"/>
-      {{baseOsOption}}
+             ng-value="baseOsOption.id"/>
+      {{baseOsOption.id}} ({{baseOsOption.shortDescription}}) <help-field content="{{baseOsOption.detailedDescription}}" />
     </label>
   </stage-config-field>
 

--- a/app/scripts/modules/core/pipeline/config/stages/bake/gce/gceBakeStage.js
+++ b/app/scripts/modules/core/pipeline/config/stages/bake/gce/gceBakeStage.js
@@ -40,14 +40,14 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.gce.bakeStage', [
     function initialize() {
       $scope.viewState.providerSelected = true;
       $q.all({
-        baseOsOptions: bakeryService.getBaseOsOptions(),
+        baseOsOptions: bakeryService.getBaseOsOptions('gce'),
         baseLabelOptions: bakeryService.getBaseLabelOptions(),
       }).then(function(results) {
-        $scope.baseOsOptions = results.baseOsOptions;
+        $scope.baseOsOptions = results.baseOsOptions.baseImages;
         $scope.baseLabelOptions = results.baseLabelOptions;
 
         if (!$scope.stage.baseOs && $scope.baseOsOptions && $scope.baseOsOptions.length) {
-          $scope.stage.baseOs = $scope.baseOsOptions[0];
+          $scope.stage.baseOs = $scope.baseOsOptions[0].id;
         }
         if (!$scope.stage.baseLabel && $scope.baseLabelOptions && $scope.baseLabelOptions.length) {
           $scope.stage.baseLabel = $scope.baseLabelOptions[0];


### PR DESCRIPTION
This PR needs to be merged after https://github.com/spinnaker/gate/pull/166 and https://github.com/spinnaker/orca/pull/687

Google/AWS base OS options:
![base-os](https://cloud.githubusercontent.com/assets/13141550/11819710/50fa0852-a32f-11e5-9d20-803b87f98428.png)

Rosco disabled (Netflix-only) base OS options:
![base-os-rosco-disabled](https://cloud.githubusercontent.com/assets/13141550/11819826/f65f88d0-a32f-11e5-9f15-e96bcebdc473.png)

Error screenshot if specified base OS is not found:
![base-os-error](https://cloud.githubusercontent.com/assets/13141550/11819705/4c7f8450-a32f-11e5-8a8b-fa657df5f762.png)

@anotherchrisberry 
@spinnaker/reviewers

Tag: https://github.com/spinnaker/spinnaker/issues/597 
