### PR TITLE
wait until task state is recorded, then refresh the view

### DIFF
--- a/app/scripts/modules/core/task/task.write.service.js
+++ b/app/scripts/modules/core/task/task.write.service.js
@@ -5,8 +5,9 @@ let angular = require('angular');
 module.exports = angular
   .module('spinnaker.core.task.write.service', [
     require('exports?"restangular"!imports?_=lodash!restangular'),
+    require('./task.read.service.js'),
   ])
-  .factory('taskWriter', function(Restangular) {
+  .factory('taskWriter', function(Restangular, taskReader, $q, $timeout) {
 
     var endpoint = Restangular.all('applications');
 
@@ -19,11 +20,46 @@ module.exports = angular
     }
 
     function cancelTask(application, taskId) {
-      return getEndpoint(application).one(taskId).one('cancel').put();
+      return getEndpoint(application).one(taskId).one('cancel').put().then(() =>
+        waitUntilTaskMatches(application, taskId, (task) => task.status === 'CANCELED')
+      );
+    }
+
+    function waitUntilTaskMatches(application, taskId, closure) {
+      return taskReader.getOneTaskForApplication(application, taskId).then((task) => {
+        if (closure(task)) {
+          return task;
+        }
+        return $timeout(() => waitUntilTaskMatches(application, taskId, closure), 1000);
+      });
+    }
+
+    function waitUntilTaskIsDeleted(taskId) {
+      // wait until the task is gone, i.e. the promise from the get() is rejected, before succeeding
+      var deferred = $q.defer();
+      Restangular.one('tasks', taskId).get().then(
+        () => {
+          $timeout(() => {
+            // task is still present, try again
+            waitUntilTaskIsDeleted(taskId).then(deferred.resolve);
+          }, 1000, false);
+        },
+        (resp) => {
+          if (resp.status === 404) {
+            // task is no longer present
+            deferred.resolve();
+          } else {
+            $timeout(() => {
+              // task is maybe still present, try again
+              waitUntilTaskIsDeleted(taskId).then(deferred.resolve);
+            }, 1000, false);
+          }
+        });
+      return deferred.promise;
     }
 
     function deleteTask(taskId) {
-      return Restangular.all('tasks').one(taskId).remove();
+      return Restangular.one('tasks', taskId).remove().then(() => waitUntilTaskIsDeleted(taskId));
     }
 
     return {

--- a/app/scripts/modules/core/task/task.write.service.spec.js
+++ b/app/scripts/modules/core/task/task.write.service.spec.js
@@ -1,0 +1,81 @@
+'use strict';
+
+describe('Service: taskWriter', function () {
+
+  var taskWriter;
+  var $httpBackend;
+  var timeout;
+  var $q;
+
+  beforeEach(
+    window.module(
+      require('./task.write.service')
+    )
+  );
+
+  beforeEach(
+    window.inject(function (_taskWriter_, _$httpBackend_, _$timeout_, _$q_) {
+      taskWriter = _taskWriter_;
+      $httpBackend = _$httpBackend_;
+      timeout = _$timeout_;
+      $q = _$q_;
+    })
+  );
+
+  afterEach(function () {
+    $httpBackend.verifyNoOutstandingExpectation();
+    $httpBackend.verifyNoOutstandingRequest();
+  });
+
+  describe('cancelling task', function () {
+    it('should wait until task is canceled, then resolve', function () {
+      let completed = false;
+      let taskId = 'abc';
+      let cancelUrl = ['', 'applications', 'deck', 'tasks', taskId, 'cancel'].join('/');
+      let checkUrl = ['', 'applications', 'deck', 'tasks', taskId].join('/');
+      let application = 'deck';
+
+      $httpBackend.expectPUT(cancelUrl).respond(200, []);
+      $httpBackend.expectGET(checkUrl).respond(200, [{id: taskId}]);
+
+      taskWriter.cancelTask(application, taskId).then(() => completed = true);
+      $httpBackend.flush();
+      expect(completed).toBe(false);
+
+      $httpBackend.expectGET(checkUrl).respond(200, {status: 'CANCELED' });
+      timeout.flush();
+      $httpBackend.flush();
+      expect(completed).toBe(true);
+    });
+  });
+
+  describe('deleting task', function () {
+    it('should wait until task is gone, then resolve', function () {
+      let completed = false;
+      let taskId = 'abc';
+      let deleteUrl = ['', 'tasks', taskId].join('/');
+      let checkUrl = ['', 'tasks', taskId].join('/');
+
+      $httpBackend.expectDELETE(deleteUrl).respond(200, []);
+
+      taskWriter.deleteTask(taskId).then(() => completed = true);
+
+      // first check: task is still present
+      $httpBackend.expectGET(checkUrl).respond(200, [{id: taskId}]);
+      $httpBackend.flush();
+      expect(completed).toBe(false);
+
+      // second check: task retrieval returns some error, try again
+      $httpBackend.expectGET(checkUrl).respond(500, null);
+      timeout.flush();
+      $httpBackend.flush();
+      expect(completed).toBe(false);
+
+      // third check: task is not present, should complete
+      $httpBackend.expectGET(checkUrl).respond(404, null);
+      timeout.flush();
+      $httpBackend.flush();
+      expect(completed).toBe(true);
+    });
+  });
+});

--- a/app/scripts/modules/core/task/tasks.controller.js
+++ b/app/scripts/modules/core/task/tasks.controller.js
@@ -17,15 +17,17 @@ module.exports = angular.module('spinnaker.core.task.controller', [
     const application = app;
 
     application.loadAllTasks = true;
-    application.reloadTasks(true).then(
-      () => {
-        $scope.viewState.loading = false;
-        $scope.viewState.loadError = app.tasksLoadFailure;
-        if (!app.tasksLoadFailure) {
-          this.sortTasks();
-        }
-      });
-    $scope.$on('$destroy', () => application.loadAllTasks = false);
+    let taskReloadWatcher = application.taskRefreshStream.subscribe(() => {
+      $scope.viewState.loading = false;
+      $scope.viewState.loadError = app.tasksLoadFailure;
+      if (!app.tasksLoadFailure) {
+        this.sortTasks();
+      }
+    });
+    $scope.$on('$destroy', () => {
+      application.loadAllTasks = false;
+      taskReloadWatcher.dispose();
+    });
 
     var tasksViewStateCache = viewStateCache.tasks || viewStateCache.createCache('tasks', { version: 1 });
 
@@ -256,6 +258,7 @@ module.exports = angular.module('spinnaker.core.task.controller', [
     });
 
     initializeViewState();
+    application.reloadTasks(true);
 
   }
 ).name;


### PR DESCRIPTION
We currently do not refresh the list of tasks on the tasks view after deleting or canceling a task.

With this PR, we poll the task, waiting for the expected state:
 * for canceled tasks, wait until the status is CANCELED
 * for deleted tasks, wait until we get a 404 when querying the task

then reload the tasks.

@zanthrash please review