### PR TITLE
refactor project cluster loading to use new endpoint

### DIFF
--- a/app/scripts/modules/core/projects/dashboard/cluster/inconsistentBuilds.tooltip.html
+++ b/app/scripts/modules/core/projects/dashboard/cluster/inconsistentBuilds.tooltip.html
@@ -1,3 +1,3 @@
 <span ng-repeat="build in application.regions[region].inconsistentBuilds">
-  Build #{{build.number}}: deployed {{build.deployed | relativeTime }}
+  Build #{{build.buildNumber}}: deployed {{build.deployed | relativeTime }}
 </span>

--- a/app/scripts/modules/core/projects/dashboard/cluster/projectCluster.controller.spec.js
+++ b/app/scripts/modules/core/projects/dashboard/cluster/projectCluster.controller.spec.js
@@ -1,0 +1,128 @@
+'use strict';
+
+describe('Controller: projectCluster directive', function () {
+
+  var $controller, vm, $scope, project, cluster, urlBuilder;
+
+  beforeEach(window.module(
+    require('./projectCluster.directive.js')
+  ));
+
+  beforeEach(
+    window.inject(function ($rootScope, _$controller_, _urlBuilderService_) {
+      $scope = $rootScope.$new();
+      $controller = _$controller_;
+      urlBuilder = _urlBuilderService_;
+    })
+  );
+
+  describe('model construction', function () {
+    beforeEach(function () {
+      spyOn(urlBuilder, 'buildFromMetadata').and.returnValue('url');
+
+      cluster = {
+        account: 'prod'
+      };
+      project = {
+        name: 'test-app',
+        config: {
+          applications: ['app1'],
+          clusters: [cluster],
+        },
+      };
+
+      this.initialize = () => {
+        vm = $controller('ProjectClusterCtrl', {
+          $scope: $scope,
+        }, {project: project, cluster: cluster});
+      };
+    });
+
+    it('derives regions for cluster from application clusters', function () {
+      cluster = {
+        applications: [
+          {
+            clusters: [
+              {region: 'us-east-1'}
+            ]
+          },
+          {
+            clusters: [
+              {region: 'us-west-1'},
+              {region: 'us-east-1'}
+            ]
+          }
+        ]
+      };
+
+      this.initialize();
+      expect(cluster.regions).toEqual(['us-east-1', 'us-west-1']);
+      cluster.applications.push({clusters: [{region: 'eu-west-1'}]});
+
+      this.initialize();
+      expect(cluster.regions).toEqual(['eu-west-1', 'us-east-1', 'us-west-1']);
+    });
+
+    it('puts application clusters into regions map', function () {
+      let cluster1 = {region: 'us-east-1'},
+          cluster2 = {region: 'us-west-1'},
+          cluster3 = {region: 'us-east-1'};
+
+      cluster = {
+        applications: [
+          {clusters: [cluster1]},
+          {clusters: [cluster2, cluster3]}
+        ]
+      };
+
+      this.initialize();
+      expect(cluster.applications[0].regions['us-east-1']).toBe(cluster1);
+      expect(cluster.applications[0].regions['us-west-1']).toBeUndefined();
+      expect(cluster.applications[1].regions['us-west-1']).toBe(cluster2);
+      expect(cluster.applications[1].regions['us-east-1']).toBe(cluster3);
+    });
+
+    it('adds application build if any present', function () {
+      let cluster1 = {region: 'us-east-1', builds: []},
+          cluster2 = {region: 'us-west-1', builds: [{buildNumber: 1}]},
+          cluster3 = {region: 'us-east-1', builds: [{buildNumber: 1}]};
+
+      cluster = {
+        applications: [
+          {clusters: [cluster1]},
+          {clusters: [cluster2, cluster3]}
+        ]
+      };
+
+      this.initialize();
+      expect(cluster.applications[0].build).toBeUndefined();
+      expect(cluster.applications[1].build).not.toBeUndefined();
+      expect(cluster.applications[1].build.buildNumber).toBe(1);
+    });
+
+    it('adds inconsistentBuilds flag to cluster and application clusters', function () {
+      let cluster1 = {region: 'us-east-1', builds: []},
+          cluster2 = {region: 'us-west-1', builds: [{buildNumber: 1}]},
+          cluster3 = {region: 'us-east-1', builds: [{buildNumber: 1}, {buildNumber: 3}]},
+          cluster4 = {region: 'us-east-1', builds: [{buildNumber: 2}]};
+
+      cluster = {
+        applications: [
+          {clusters: [cluster1]},
+          {clusters: [cluster2, cluster3]},
+          {clusters: [cluster4]}
+        ]
+      };
+
+      this.initialize();
+      expect(cluster.applications[0].build).toBeUndefined();
+      expect(cluster.applications[0].hasInconsistentBuilds).toBeUndefined();
+      expect(cluster.applications[1].build).not.toBeUndefined();
+      expect(cluster.applications[1].build.buildNumber).toBe(3);
+      expect(cluster.applications[1].hasInconsistentBuilds).toBe(true);
+      expect(cluster.applications[2].build).not.toBeUndefined();
+      expect(cluster.applications[2].build.buildNumber).toBe(2);
+      expect(cluster.applications[2].hasInconsistentBuilds).toBe(false);
+    });
+  });
+});

--- a/app/scripts/modules/core/projects/dashboard/cluster/projectCluster.directive.html
+++ b/app/scripts/modules/core/projects/dashboard/cluster/projectCluster.directive.html
@@ -7,22 +7,14 @@
             <h5>
               <collapsible-account-tag account="{{vm.cluster.account}}" state="vm.state"></collapsible-account-tag>
               <span class="cluster-name">{{vm.clusterLabel}}</span>
-
-              <a href ng-click="vm.refreshImmediately(); $event.stopPropagation()">
-                <span class="small glyphicon glyphicon-refresh refresh-enabled"
-                      tooltip-placement="bottom"
-                      uib-tooltip-template="vm.refreshTooltipTemplate"
-                      ng-class="{'glyphicon-spinning': vm.state.refreshing}"></span>
-              </a>
-
-              <span class="pull-right" ng-if="vm.state.loaded">
+              <span class="pull-right">
                 <span class="cluster-health">
-                  {{vm.clusterData.applications.length}} Application<span ng-if="vm.clusterData.applications.length !== 1">s</span>
+                  {{vm.cluster.applications.length}} Application<span ng-if="vm.cluster.applications.length !== 1">s</span>
                 </span>
                 <span class="cluster-health">
-                  {{vm.clusterData.instanceCounts.totalCount}} Instances
+                  {{vm.cluster.instanceCounts.total}} Instances
                 </span>
-                <health-counts container="vm.clusterData.instanceCounts"></health-counts>
+                <health-counts container="vm.cluster.instanceCounts"></health-counts>
               </span>
             </h5>
           </div>
@@ -31,50 +23,44 @@
     </div>
   </div>
   <div class="rollup-details" ng-if="vm.state.expanded">
-    <div ng-if="!vm.state.refreshing && !vm.clusterData.regions.length" class="text-center">
+    <div ng-if="!vm.cluster.applications.length" class="text-center">
       <p>No clusters found for any applications.</p>
     </div>
-    <table class="table table-condensed" ng-if="vm.clusterData.applications.length">
+    <table class="table table-condensed" ng-if="vm.cluster.applications.length">
       <thead>
         <tr>
           <th width="18%"></th>
           <th width="9%"></th>
-          <th ng-if="vm.state.loaded" width="15%">Last Push</th>
-          <th width="58%" ng-if="!vm.state.loaded">(loading clusters...)</th>
-          <th ng-repeat="region in vm.clusterData.regions" width="{{57/vm.clusterData.regions.length}}%">
+          <th width="15%">Last Push</th>
+          <th ng-repeat="region in vm.cluster.regions" width="{{57/vm.cluster.regions.length}}%">
             {{region}}
           </th>
         </tr>
       </thead>
       <tbody>
-      <tr ng-repeat="application in vm.clusterData.applications | orderBy: 'name'">
+      <tr ng-repeat="application in vm.cluster.applications | orderBy: 'name'">
         <td>
           <a class="heavy" ng-click="vm.clearFilters(application.metadata)" ng-href="{{application.metadata.href}}" ng-class="application.hasInconsistentBuilds ? 'text-warning' : ''">
-            {{application.name | uppercase}}
+            {{application.application | uppercase}}
           </a>
         </td>
         <td>
-          <a class="heavy" ng-if="application.build.number" href="{{application.build.url}}" target="_blank">
-            <span ng-if="vm.state.loaded">#</span>{{application.build.number}}
+          <a class="heavy" ng-if="application.build.buildNumber" href="{{application.build.url}}" target="_blank">
+            <span>#</span>{{application.build.buildNumber}}
           </a>
           <span ng-if="application.hasInconsistentBuilds"
                 class="glyphicon glyphicon-warning-sign text-warning"
                 uib-tooltip="Some server groups are deployed with an older build."></span>
         </td>
-        <td ng-if="!vm.state.loaded">
-          <div class="text-center">
-            <span class="glyphicon glyphicon-asterisk glyphicon-spinning"></span>
-          </div>
-        </td>
-        <td ng-if="vm.state.loaded">
-          <span ng-if="!application.lastCreatedTime">
+        <td>
+          <span ng-if="!application.lastPush">
             -
           </span>
-          <span class="small" ng-if="application.lastCreatedTime">
-            {{application.lastCreatedTime | relativeTime }}
+          <span class="small" ng-if="application.lastPush">
+            {{application.lastPush | relativeTime }}
           </span>
         </td>
-        <td ng-repeat="region in vm.clusterData.regions">
+        <td ng-repeat="region in vm.cluster.regions">
           <span ng-if="application.regions[region]">
             <a ng-click="vm.clearFilters(application.regions[region].metadata)" ng-href="{{application.regions[region].metadata.href}}">
               <health-counts container="application.regions[region].instanceCounts"

--- a/app/scripts/modules/core/projects/dashboard/cluster/projectCluster.directive.js
+++ b/app/scripts/modules/core/projects/dashboard/cluster/projectCluster.directive.js
@@ -7,12 +7,12 @@ require('./projectCluster.less');
 module.exports = angular.module('spinnaker.core.projects.dashboard.clusters.projectCluster.directive', [
   require('../../../account/collapsibleAccountTag.directive.js'),
   require('../../../navigation/urlBuilder.service.js'),
-  require('../../../cluster/cluster.service.js'),
   require('../../../utils/lodash.js'),
   require('../../../cache/collapsibleSectionStateCache.js'),
   require('../../../scheduler/scheduler.service.js'),
-  require('../../../naming/naming.service.js'),
   require('../../../cluster/filter/clusterFilter.service.js'),
+  require('../../../utils/timeFormatters.js'),
+  require('../../../healthCounts/healthCounts.directive.js'),
 ])
   .directive('projectCluster', function () {
     return {
@@ -22,18 +22,13 @@ module.exports = angular.module('spinnaker.core.projects.dashboard.clusters.proj
       bindToController: {
         project: '=',
         cluster: '=',
-        parentViewState: '=',
       },
       controller: 'ProjectClusterCtrl',
       controllerAs: 'vm',
     };
   })
-  .controller('ProjectClusterCtrl', function($scope, urlBuilderService, clusterService, $q, _,
-                                             collapsibleSectionStateCache, namingService, scheduler,
+  .controller('ProjectClusterCtrl', function($scope, urlBuilderService, _, collapsibleSectionStateCache, scheduler,
                                              clusterFilterService) {
-
-    let getApplications = () => this.cluster.applications && this.cluster.applications.length ?
-      this.cluster.applications : this.project.config.applications;
 
     let stateCache = collapsibleSectionStateCache;
 
@@ -45,11 +40,7 @@ module.exports = angular.module('spinnaker.core.projects.dashboard.clusters.proj
     this.inconsistentBuildsTemplate = require('./inconsistentBuilds.tooltip.html');
 
     this.state = {
-      loaded: false,
       expanded: stateCache.isSet(getCacheKey()) ? stateCache.isExpanded(getCacheKey()) : true,
-      lastRefresh: null,
-      refreshing: false,
-      autoRefreshEnabled: true,
     };
 
     this.toggle = () => {
@@ -64,212 +55,81 @@ module.exports = angular.module('spinnaker.core.projects.dashboard.clusters.proj
           stackParam = stack && stack !== '*' ? stack : null,
           detailParam = detail && detail !== '*' ? detail : null;
 
-      let metadata = {
+      return {
         type: 'clusters',
         project: this.project.name,
-        application: application.name,
+        application: application.application,
         cluster: clusterParam,
         stack: stackParam,
         detail: detailParam,
         account: this.cluster.account,
       };
-      return metadata;
     };
 
-    let addMetadata = () => {
-      this.clusterData.applications.forEach((application) => {
-        let baseMetadata = getMetadata(application);
-        Object.keys(application.regions).forEach((region) => {
-          baseMetadata.region = region;
-          baseMetadata.href = urlBuilderService.buildFromMetadata(baseMetadata);
-          application.regions[region].metadata = baseMetadata;
-        });
+    let addMetadata = (application) => {
+      let baseMetadata = getMetadata(application);
+      application.metadata = baseMetadata;
+      application.metadata.href = urlBuilderService.buildFromMetadata(baseMetadata);
+      application.clusters.forEach((cluster) => {
+        let clusterMetadata = getMetadata(application);
+        clusterMetadata.region = cluster.region;
+        clusterMetadata.href = urlBuilderService.buildFromMetadata(clusterMetadata);
+        cluster.metadata = clusterMetadata;
       });
     };
 
-    let clusterLoaders = {};
+    let getBuildUrl = (build) => [build.host + 'job', build.job, build.buildNumber, ''].join('/');
 
-    let addInstanceCounts = (container) => {
-      container.instanceCounts = {
-          totalCount: 0,
-          upCount: 0,
-          downCount: 0,
-          outOfServiceCount: 0,
-          startingCount: 0,
-          unknownCount: 0,
-      };
-    };
-
-    let incrementInstanceCounts = (parent, container) => {
-      let parentCounts = parent.instanceCounts;
-      parentCounts.totalCount += container.instanceCounts.total;
-      parentCounts.upCount += container.instanceCounts.up;
-      parentCounts.downCount += container.instanceCounts.down;
-      parentCounts.outOfServiceCount += container.instanceCounts.outOfService;
-      parentCounts.startingCount += container.instanceCounts.starting;
-      parentCounts.unknownCount += container.instanceCounts.unknown;
-    };
-
-    let makeBuildModel = (serverGroup) => {
-      let buildModel = { number: 0 };
-      if (serverGroup && serverGroup.buildInfo && serverGroup.buildInfo.jenkins) {
-        let jenkins = serverGroup.buildInfo.jenkins;
-        buildModel.number = Number(jenkins.number);
-        buildModel.url = [jenkins.host + 'job', jenkins.name, jenkins.number, ''].join('/');
-        buildModel.deployed = serverGroup.createdTime;
+    let addApplicationBuild = (application) => {
+      let allBuilds = _((application.clusters || []).map((cluster) => cluster.builds))
+        .flatten()
+        .compact()
+        .uniq((build) => build.buildNumber)
+        .value();
+      if (allBuilds.length) {
+        application.build = _.max(allBuilds, (build) => Number(build.buildNumber));
+        application.build.url = getBuildUrl(application.build);
+        application.hasInconsistentBuilds = allBuilds.length > 1;
       }
-      return buildModel;
-    };
-
-    let initializeClusterData = () => {
-      this.clusterData = {
-        regions: [],
-        instanceCounts: {
-          totalCount: 0,
-          upCount: 0,
-          downCount: 0,
-          outOfServiceCount: 0,
-          startingCount: 0,
-          unknownCount: 0,
-        }
-      };
-      this.clusterData.applications = getApplications().map((application) => {
-        let metadata = getMetadata({name: application});
-        metadata.href = urlBuilderService.buildFromMetadata(metadata);
-        return {
-          name: application,
-          regions: {},
-          metadata: metadata,
-        };
-      });
-    };
-
-    let applyRegionsAndInstanceCounts = (clusters, application) => {
-      let clusterData = clusters[application];
-      let serverGroups = clusterData.serverGroups || [];
-      clusterData.serverGroups = serverGroups.filter((serverGroup) =>
-        serverGroup && !serverGroup.disabled && serverGroup.instances.length > 0
-      );
-      let applicationData = _.find(this.clusterData.applications, (appData) => appData.name === application);
-      applicationData.build = makeBuildModel();
-      let serverGroupsByRegion = _.groupBy(clusterData.serverGroups, 'region');
-      if (clusterData.serverGroups.length) {
-        applicationData.lastCreatedTime = _.sortBy(clusterData.serverGroups, 'createdTime').pop().createdTime;
-      }
-      Object.keys(serverGroupsByRegion).forEach((region) => {
-        this.clusterData.regions.push(region);
-        let serverGroups = serverGroupsByRegion[region];
-        let regionInfo = {
-          build: makeBuildModel(),
-          otherBuilds: [],
-        };
-        if (serverGroups && serverGroups.length) {
-          regionInfo.lastCreatedTime = _.sortBy(serverGroups, 'createdTime').pop().createdTime;
-        }
-        addInstanceCounts(regionInfo);
-        applicationData.regions[region] = regionInfo;
-        applicationData.lastCreatedTime = _.sortBy(serverGroups, 'createdTime').pop().createdTime;
-        serverGroups.forEach((serverGroup) => {
-          serverGroup.build = makeBuildModel(serverGroup);
-          if (!regionInfo.build.number) {
-            regionInfo.build = serverGroup.build;
-          } else {
-            if (serverGroup.build.number > regionInfo.build.number) {
-              regionInfo.otherBuilds.push(regionInfo.build);
-              regionInfo.build = serverGroup.build;
-            }
-            if (serverGroup.build.number < regionInfo.build.number) {
-              if (regionInfo.otherBuilds.every((build) => build.number !== serverGroup.build.number)) {
-                regionInfo.otherBuilds.push(serverGroup.build);
-              }
-            }
-          }
-          incrementInstanceCounts(regionInfo, serverGroup);
-          incrementInstanceCounts(this.clusterData, serverGroup);
-        });
-        if (applicationData.build.number <= regionInfo.build.number) {
-          applicationData.build = regionInfo.build;
-        }
-      });
     };
 
     let applyInconsistentBuildFlag = (application) => {
-      application.hasInconsistentBuilds = false;
-      Object.keys(application.regions).forEach((regionName) => {
-        let region = application.regions[regionName];
-        if (region.build.number !== application.build.number || region.otherBuilds.length) {
+      application.clusters.forEach((cluster) => {
+        let builds = cluster.builds || [];
+        if (builds.length && (builds.length > 1 || builds[0].buildNumber !== application.build.buildNumber)) {
           application.hasInconsistentBuilds = true;
-          region.inconsistentBuilds = region.otherBuilds.length ? region.otherBuilds : [region.build];
+          cluster.inconsistentBuilds = cluster.builds.filter(
+            (build) => build.buildNumber !== application.build.buildNumber);
         }
       });
     };
 
-
-    let getClusterMatches = (clusters) => {
-      let stack = this.cluster.stack,
-        detail = this.cluster.detail,
-        targetClusters = clusters[this.cluster.account] || [];
-      return targetClusters.filter((cluster) => {
-        let clusterParts = namingService.parseServerGroupName(cluster);
-        if (stack !== '*' && clusterParts.stack !== stack) {
-          return false;
-        }
-        if (detail !== '*' && clusterParts.freeFormDetails !== detail) {
-          return false;
-        }
-        return true;
+    let mapClustersToRegions = (cluster, application) => {
+      application.regions = {};
+      cluster.regions.forEach((region) => {
+        application.regions[region] = _.find(application.clusters, (regionCluster) => regionCluster.region === region);
       });
     };
 
-    let buildDataLoader = (application) => {
-      if (this.cluster.stack === '*' || this.cluster.detail === '*') {
-        return clusterService.getClusters(application).then((clusters) => {
-          let clustersToLoad = getClusterMatches(clusters);
-          return $q.all(clustersToLoad.map((cluster) => {
-            return clusterService.getCluster(application, this.cluster.account, cluster);
-          })).then((clusterResults) => {
-            let megaCluster = { serverGroups: [] };
-            clusterResults.forEach((clusterResult => {
-              megaCluster.serverGroups = megaCluster.serverGroups.concat(clusterResult.serverGroups);
-            }));
-            return megaCluster;
-          });
-        });
-      } else {
-        let clusterName = namingService.getClusterName(application, this.cluster.stack, this.cluster.detail);
-        return clusterService.getCluster(application, this.cluster.account, clusterName);
-      }
+    let addRegions = (cluster) => {
+      cluster.regions = _.uniq(_.flatten(
+        cluster.applications.map((application) =>
+         application.clusters.map((regionCluster) => regionCluster.region)
+        )
+      )).sort();
     };
 
-    let loadData = () => {
-      this.state.refreshing = true;
-
-      getApplications().map((application) => {
-        clusterLoaders[application] = buildDataLoader(application);
-      });
-      $q.all(clusterLoaders).then((clusters) => {
-        addInstanceCounts(this.clusterData);
-        Object.keys(clusters).forEach((application) => {
-          applyRegionsAndInstanceCounts(clusters, application);
-        });
-        this.clusterData.applications.forEach(applyInconsistentBuildFlag);
-        this.clusterData.regions = _.uniq(this.clusterData.regions).sort();
-        this.state.loaded = true;
-        this.state.refreshing = false;
-        this.state.lastRefresh = new Date().getTime();
-        addMetadata();
+    let initialize = () => {
+      addRegions(this.cluster);
+      this.cluster.applications.forEach((application) => {
+        mapClustersToRegions(this.cluster, application);
+        addApplicationBuild(application);
+        applyInconsistentBuildFlag(application);
+        addMetadata(application);
       });
     };
 
-    initializeClusterData();
-
-    let dataLoader = scheduler.subscribe(loadData);
-
-    $scope.$on('$destroy', () => dataLoader.dispose());
-
-    this.refreshImmediately = scheduler.scheduleImmediate;
-
-    loadData();
+    initialize();
 
     this.clusterLabel = this.cluster.detail ? [this.cluster.stack, this.cluster.detail].join('-') : this.cluster.stack;
 

--- a/app/scripts/modules/core/projects/dashboard/cluster/projectCluster.directive.spec.js
+++ b/app/scripts/modules/core/projects/dashboard/cluster/projectCluster.directive.spec.js
@@ -1,226 +1,134 @@
 'use strict';
 
-describe('Controller: projectCluster directive', function () {
+describe('Directives: projectCluster', function () {
 
-  var $controller, vm, $scope, project, cluster, clusterService, $q, urlBuilder;
-
-  beforeEach(window.module(
-    require('./projectCluster.directive.js')
-  ));
+  require('./projectCluster.directive.html');
+  require('../../../account/collapsibleAccountTag.directive.html');
 
   beforeEach(
-    window.inject(function ($rootScope, _$controller_, _$q_, _clusterService_, _urlBuilderService_) {
+    window.module(
+      require('./projectCluster.directive')
+    )
+  );
+
+  var $compile, $scope, $q, urlBuilder;
+
+  beforeEach(
+    window.inject(function ($rootScope, _$compile_, _$q_, _urlBuilderService_, accountService) {
       $scope = $rootScope.$new();
-      $controller = _$controller_;
+      $compile = _$compile_;
       $q = _$q_;
-      clusterService = _clusterService_;
       urlBuilder = _urlBuilderService_;
+
+      spyOn(urlBuilder, 'buildFromMetadata').and.returnValue('url');
+      // needed for collapsibleAccountTag
+      spyOn(accountService, 'challengeDestructiveActions').and.returnValue($q.when(true));
     })
   );
 
-  describe('model construction', function () {
-    beforeEach( function() {
-      spyOn(urlBuilder, 'buildFromMetadata').and.returnValue('url');
-
-      cluster = {
-        account: 'prod'
-      };
-      project = {
-        name: 'test-app',
-        config: {
-          applications: [ 'app1' ],
-          clusters: [cluster],
-        },
-      };
-
-      this.initialize = () => {
-        vm = $controller('ProjectClusterCtrl', {
-          $scope: $scope,
-          $q: $q,
-          clusterService: clusterService,
-        }, {project: project, cluster: cluster});
-      };
-    });
-
-    it('should add instance counts, last created time, and build data to model', function () {
-      spyOn(clusterService, 'getCluster').and.returnValue($q.when({
-        serverGroups: [
-          {
-            name: 'app1-v000',
-            region: 'us-east-1',
-            createdTime: 1,
-            buildInfo: {
-              jenkins: { number: 3 }
-            },
-            instanceCounts: {
-              up: 3, down: 1, unknown: 1, outOfService: 1, starting: 2, total: 8,
-            },
-            instances: [ { } ],
-          },
-          {
-            name: 'app1-v001',
-            region: 'us-east-1',
-            createdTime: 2,
-            buildInfo: {
-              jenkins: { number: 3 }
-            },
-            instanceCounts: {
-              up: 1, down: 0, unknown: 1, outOfService: 2, starting: 1, total: 5,
-            },
-            instances: [ { } ],
-          },
-          {
-            name: 'app1-v003',
-            region: 'us-west-1',
-            createdTime: 24,
-            buildInfo: {
-              jenkins: { number: 3 }
-            },
-            instanceCounts: {
-              up: 1, down: 0, unknown: 0, outOfService: 0, starting: 1, total: 2,
-            },
-            instances: [ { } ],
-          }
-        ]
-      }));
-
-      this.initialize();
-      $scope.$digest();
-      let clusterData = vm.clusterData,
-          usEast = clusterData.applications[0].regions['us-east-1'],
-          usWest = clusterData.applications[0].regions['us-west-1'];
-
-      expect(clusterData.instanceCounts).toEqual({totalCount: 15, upCount: 5, downCount: 1, unknownCount: 2, outOfServiceCount: 3, startingCount: 4});
-      expect(usEast.instanceCounts).toEqual({totalCount: 13, upCount: 4, downCount: 1, unknownCount: 2, outOfServiceCount: 3, startingCount: 3});
-      expect(usWest.instanceCounts).toEqual({totalCount: 2, upCount: 1, downCount: 0, unknownCount: 0, outOfServiceCount: 0, startingCount: 1});
-
-      expect(clusterData.applications[0].lastCreatedTime).toBe(24);
-      expect(usEast.lastCreatedTime).toBe(2);
-      expect(usWest.lastCreatedTime).toBe(24);
-      expect(vm.clusterData.applications[0].build.number).toBe(3);
-    });
-
-    it('should add inconsistent builds to model', function() {
-      spyOn(clusterService, 'getCluster').and.returnValue($q.when({
-        serverGroups: [
-          {
-            name: 'app1-v000',
-            region: 'us-east-1',
-            createdTime: 1,
-            buildInfo: {
-              jenkins: { number: 3 }
-            },
-            instanceCounts: {
-              up: 1, down: 0, unknown: 0, outOfService: 0, starting: 0, total: 1,
-            },
-            instances: [ { } ],
-          },
-          {
-            name: 'app1-v001',
-            region: 'us-east-1',
-            createdTime: 2,
-            buildInfo: {
-              jenkins: { number: 4 }
-            },
-            instanceCounts: {
-              up: 1, down: 0, unknown: 0, outOfService: 0, starting: 0, total: 1,
-            },
-            instances: [ { } ],
-          }
-        ]
-      }));
-
-      this.initialize();
-      $scope.$digest();
-      expect(vm.clusterData.applications[0].hasInconsistentBuilds).toBe(true);
-      expect(vm.clusterData.applications[0].regions['us-east-1'].inconsistentBuilds[0].number).toBe(3);
-
-    });
-
-    it('should only add inconsistent build to model once', function () {
-      spyOn(clusterService, 'getCluster').and.returnValue($q.when({
-        serverGroups: [
-          {
-            name: 'app1-v000',
-            region: 'us-east-1',
-            createdTime: 1,
-            buildInfo: {
-              jenkins: { number: 3 }
-            },
-            instanceCounts: {
-              up: 1, down: 0, unknown: 0, outOfService: 0, starting: 0, total: 1,
-            },
-            instances: [ { } ],
-          },
-          {
-            name: 'app1-v001',
-            region: 'us-east-1',
-            createdTime: 2,
-            buildInfo: {
-              jenkins: { number: 3 }
-            },
-            instanceCounts: {
-              up: 1, down: 0, unknown: 0, outOfService: 0, starting: 0, total: 1,
-            },
-            instances: [ { } ],
-          },
-          {
-            name: 'app1-v002',
-            region: 'us-east-1',
-            createdTime: 3,
-            buildInfo: {
-              jenkins: { number: 4 }
-            },
-            instanceCounts: {
-              up: 1, down: 0, unknown: 0, outOfService: 0, starting: 0, total: 1,
-            },
-            instances: [ { } ],
-          }
-        ]
-      }));
-
-      this.initialize();
-      $scope.$digest();
-      expect(vm.clusterData.applications[0].hasInconsistentBuilds).toBe(true);
-      expect(vm.clusterData.applications[0].regions['us-east-1'].inconsistentBuilds.length).toBe(1);
-      expect(vm.clusterData.applications[0].regions['us-east-1'].inconsistentBuilds[0].number).toBe(3);
-    });
-
-    it('should add inconsistent build, even if it is in a more recent deployment', function () {
-      spyOn(clusterService, 'getCluster').and.returnValue($q.when({
-        serverGroups: [
-          {
-            name: 'app1-v000',
-            region: 'us-east-1',
-            createdTime: 1,
-            buildInfo: {
-              jenkins: { number: 4 }
-            },
-            instanceCounts: {
-              up: 1, down: 0, unknown: 0, outOfService: 0, starting: 0, total: 1,
-            },
-            instances: [ { } ],
-          },
-          {
-            name: 'app1-v002',
-            region: 'us-east-1',
-            createdTime: 3,
-            buildInfo: {
-              jenkins: { number: 2 }
-            },
-            instanceCounts: {
-              up: 1, down: 0, unknown: 0, outOfService: 0, starting: 0, total: 1,
-            },
-            instances: [ { } ],
-          }
-        ]
-      }));
-
-      this.initialize();
-      $scope.$digest();
-      expect(vm.clusterData.applications[0].hasInconsistentBuilds).toBe(true);
-      expect(vm.clusterData.applications[0].regions['us-east-1'].inconsistentBuilds.length).toBe(1);
-      expect(vm.clusterData.applications[0].regions['us-east-1'].inconsistentBuilds[0].number).toBe(2);
-    });
+  beforeEach(function () {
+    $scope.project = {
+      name: 'foo',
+    };
   });
+
+  it('includes a column for each region and a row for each application, with build number for application', function () {
+    let cluster1 = {region: 'us-east-1', builds: []},
+        cluster2 = {region: 'us-west-1', builds: [{buildNumber: 1}]},
+        cluster3 = {region: 'us-east-1', builds: [{buildNumber: 1}]};
+
+    $scope.cluster = {
+      account: 'prod',
+      stack: '',
+      detail: '',
+      applications: [
+        {application: 'app1', clusters: [cluster1]},
+        {application: 'app2', clusters: [cluster2, cluster3]}
+      ]
+    };
+
+    var html = '<project-cluster cluster="cluster" project="project"></project-cluster>';
+
+    var elem = $compile(html)($scope);
+    $scope.$digest();
+
+    // columns for each region
+    expect(elem.find('.rollup-details').size()).toBe(1);
+    expect(elem.find('th').size()).toBe(5);
+    expect(elem.find('th:eq(3)').html().trim()).toBe('us-east-1');
+    expect(elem.find('th:eq(4)').html().trim()).toBe('us-west-1');
+
+    // application rows
+    let app1Row = elem.find('tbody tr:eq(0)');
+    let app2Row = elem.find('tbody tr:eq(1)');
+    expect(elem.find('tbody tr').size()).toBe(2);
+    expect(app1Row.find('td:eq(0)').text().trim()).toBe('APP1');
+    expect(app2Row.find('td:eq(0)').text().trim()).toBe('APP2');
+    expect(app1Row.find('td:eq(1)').text().trim()).toBe('');
+    expect(app2Row.find('td:eq(1)').text().trim()).toBe('#1');
+  });
+
+  it('omits last push entry if none found for an application', function () {
+    let cluster1 = {region: 'us-east-1', builds: []},
+        cluster2 = {region: 'us-west-1', builds: [{buildNumber: 1}]};
+
+    $scope.cluster = {
+      account: 'prod',
+      stack: '',
+      detail: '',
+      applications: [
+        {application: 'app1', clusters: [cluster1]},
+        {application: 'app2', lastPush: 3, clusters: [cluster2]}
+      ]
+    };
+
+    var html = '<project-cluster cluster="cluster" project="project"></project-cluster>';
+
+    var elem = $compile(html)($scope);
+    $scope.$digest();
+
+    // application rows
+    let app1Row = elem.find('tbody tr:eq(0)');
+    let app2Row = elem.find('tbody tr:eq(1)');
+    expect(app1Row.find('td:eq(2)').text().trim()).toBe('-');
+    // dates are fun to test - let's just verify it's not "-"
+    expect(app2Row.find('td:eq(2)').text().trim()).not.toBe('-');
+  });
+
+  it('includes application count in header, instance counts in header and each region', function () {
+    let cluster1 = {region: 'us-east-1', builds: [], instanceCounts: { total: 3, up: 3, down: 0 }},
+        cluster2 = {region: 'us-west-1', builds: [{buildNumber: 1}], instanceCounts: { total: 3, up: 1, down: 2, starting: 1}};
+
+    $scope.cluster = {
+      account: 'prod',
+      stack: 'foo',
+      detail: '*',
+      instanceCounts: { up: 4, down: 2, unknown: 1 },
+      applications: [
+        {application: 'app1', clusters: [cluster1]},
+        {application: 'app2', lastPush: 3, clusters: [cluster2]}
+      ]
+    };
+
+    var html = '<project-cluster cluster="cluster" project="project"></project-cluster>';
+
+    var elem = $compile(html)($scope);
+    $scope.$digest();
+
+    let upSelector = ' span[ng-if="container.up"]:eq(0)';
+
+    expect(elem.find('.cluster-name').text().trim()).toBe('foo-*');
+    expect(elem.find('.cluster-health:eq(0)').text().trim()).toBe('2 Applications');
+    expect(elem.find('.rollup-summary health-counts' + upSelector).text().trim()).toBe('4');
+
+    // first app: dash in us-west-1, 3 up in us-east-1
+    expect(elem.find('tbody tr:eq(0) td:eq(3) health-counts' + upSelector).text().trim()).toBe('3');
+    expect(elem.find('tbody tr:eq(0) td:eq(4)').text().trim()).toBe('-');
+
+    // second app: dash in us-east-1, 1 up in us-west-1
+    expect(elem.find('tbody tr:eq(1) td:eq(3)').text().trim()).toBe('-');
+    expect(elem.find('tbody tr:eq(1) td:eq(4) health-counts' + upSelector).text().trim()).toBe('1');
+
+  });
+
 });

--- a/app/scripts/modules/core/projects/dashboard/dashboard.html
+++ b/app/scripts/modules/core/projects/dashboard/dashboard.html
@@ -1,12 +1,22 @@
 <div ng-if="!project.notFound" class="project-dashboard">
   <div class="row">
     <div class="col-md-7">
-      <h3>Application Status</h3>
+      <h3>Application Status
+        <a href ng-click="dashboardCtrl.refreshImmediately()">
+          <span class="small glyphicon glyphicon-refresh refresh-enabled"
+                tooltip-placement="bottom"
+                uib-tooltip-template="dashboardCtrl.refreshTooltipTemplate"
+                ng-class="{'glyphicon-spinning': dashboardCtrl.state.refreshing}"></span>
+        </a>
+      </h3>
       <project-cluster
-          ng-repeat="cluster in project.config.clusters"
+          ng-repeat="cluster in dashboardCtrl.clusters"
           project="project"
           cluster="cluster"
           ></project-cluster>
+      <div class="text-center" ng-if="!dashboardCtrl.state.clustersLoaded">
+        <span class="glyphicon glyphicon-asterisk glyphicon-spinning"></span>
+      </div>
       <h4 ng-if="!project.config.clusters.length">No clusters configured</h4>
     </div>
     <div class="col-md-5">
@@ -18,6 +28,9 @@
                 ng-class="{'glyphicon-spinning': dashboardCtrl.state.refreshing}"></span>
         </a>
       </h3>
+      <div class="text-center" ng-if="!dashboardCtrl.state.executionsLoaded">
+        <span class="glyphicon glyphicon-asterisk glyphicon-spinning"></span>
+      </div>
       <project-pipeline
         ng-repeat="execution in executions"
         execution="execution"></project-pipeline>

--- a/app/scripts/modules/core/projects/service/project.read.service.js
+++ b/app/scripts/modules/core/projects/service/project.read.service.js
@@ -4,29 +4,40 @@ let angular = require('angular');
 
 module.exports = angular
   .module('spinnaker.core.projects.read.service', [
-    require('exports?"restangular"!imports?_=lodash!restangular'),
-    require('../../utils/lodash.js'),
   ])
-  .factory('projectReader', function ($q, Restangular, _) {
+  .factory('projectReader', function ($http, settings) {
 
     function listProjects() {
-      return Restangular.all('projects').getList();
+      let url = [settings.gateUrl, 'projects'].join('/');
+      return $http({
+        method: 'GET',
+        url: url,
+        timeout: settings.pollSchedule * 2 + 5000, // TODO: replace with apiHost call
+      }).then((resp) => resp.data);
     }
 
     function getProjectConfig(projectName) {
-      return listProjects().then((projects) => {
-        let project = _.find(projects, (test) => test.name.toLowerCase() === projectName.toLowerCase());
-        if (project) {
-          return Restangular.one('projects', project.id).get();
-        } else {
-          return $q.reject(projectName);
-        }
-      });
+      let url = [settings.gateUrl, 'projects', projectName].join('/');
+      return $http({
+        method: 'GET',
+        url: url,
+        timeout: settings.pollSchedule * 2 + 5000, // TODO: replace with apiHost call
+      }).then((resp) => resp.data);
+    }
+
+    function getProjectClusters(projectName) {
+      let url = [settings.gateUrl, 'projects', projectName, 'clusters'].join('/');
+      return $http({
+        method: 'GET',
+        url: url,
+        timeout: settings.pollSchedule * 2 + 5000, // TODO: replace with apiHost call
+      }).then((resp) => resp.data);
     }
 
     return {
       listProjects: listProjects,
       getProjectConfig: getProjectConfig,
+      getProjectClusters: getProjectClusters,
     };
 
   });


### PR DESCRIPTION
We have a shiny new endpoint to retrieve all project cluster info in one call, instead of coordinating dozens (or hundreds) of async calls, which cleans up a lot of logic that was previously in this controller.

This depends on https://github.com/spinnaker/gate/pull/167 getting pushed to prod, which I'll do shortly.

@zanthrash for your reviewing pleasure