### PR TITLE
implement provider-specific validation mechanism for application name

### DIFF
--- a/app/scripts/modules/amazon/aws.module.js
+++ b/app/scripts/modules/amazon/aws.module.js
@@ -38,6 +38,7 @@ module.exports = angular.module('spinnaker.aws', [
   require('./securityGroup/securityGroup.transformer.js'),
   require('./securityGroup/securityGroup.reader.js'),
   require('./subnet/subnet.module.js'),
+  require('./validation/applicationName.validator.js'),
   require('./vpc/vpc.module.js'),
   require('./image/image.reader.js'),
   require('./cache/cacheConfigurer.service.js'),

--- a/app/scripts/modules/amazon/validation/applicationName.validator.js
+++ b/app/scripts/modules/amazon/validation/applicationName.validator.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const angular = require('angular');
+
+module.exports = angular
+  .module('spinnaker.aws.validation.applicationName', [
+    require('../../core/application/modal/validation/applicationName.validator.js'),
+  ])
+  .factory('awsApplicationNameValidator', function () {
+
+    function validate(name) {
+      let warnings = [],
+          errors = [];
+      name = name || '';
+      if (name.indexOf('.') > -1 || name.indexOf('_') > -1) {
+        warnings.push(`If the application's name contains an underscore(_) or dot(.),
+          you will not be able to create a load balancer,
+          preventing it from being used as a front end service.`);
+      }
+
+      if (name.length > 20) {
+        if (name.length > 32) {
+          warnings.push(`You will not be able to create an Amazon load balancer for this application if the
+          application's name is longer than 32 characters (currently: ${name.length} characters)`);
+        } else {
+          if (name.length >= 30) {
+            warnings.push(`If you plan to create load balancers for this application, be aware that the character limit
+            for load balancer names is 32 (currently: ${name.length} characters). With separators ("-"), you will not
+            be able to add a stack and detail field to any load balancer.`);
+          } else {
+            let remaining = 30 - name.length;
+            warnings.push(`If you plan to create load balancers for this application, be aware that the character limit
+            for load balancer names is 32. You will only have ~${remaining} characters to add a stack or detail
+            field to any load balancer.`);
+          }
+        }
+      }
+
+      return {
+        warnings: warnings,
+        errors: errors,
+      };
+    }
+
+    return {
+      validate: validate
+    };
+  })
+  .run(function(applicationNameValidator, awsApplicationNameValidator) {
+    applicationNameValidator.registerValidator('aws', awsApplicationNameValidator);
+  });

--- a/app/scripts/modules/core/application/modal/createApplication.modal.controller.js
+++ b/app/scripts/modules/core/application/modal/createApplication.modal.controller.js
@@ -9,6 +9,8 @@ module.exports = angular
     require('../service/applications.read.service.js'),
     require('../../utils/lodash.js'),
     require('../../account/account.service.js'),
+    require('./validation/applicationNameValidationMessages.directive.js'),
+    require('./validation/validateApplicationName.directive.js'),
   ])
   .controller('CreateApplicationModalCtrl', function($scope, $q, $log, $state, $modalInstance, accountService, applicationWriter, applicationReader, _) {
     var vm = this;

--- a/app/scripts/modules/core/application/modal/newapplication.html
+++ b/app/scripts/modules/core/application/modal/newapplication.html
@@ -14,12 +14,15 @@
           <input type="text"
                  autofocus
                  name="name"
-                 ng-pattern="/^[a-zA-z_0-9.]*$/"
                  class="form-control input-sm"
                  data-purpose="application-name"
                  ng-model="newAppModal.application.name"
                  placeholder="Enter an application name"
                  validate-unique="newAppModal.data.appNameList"
+                 ng-pattern="/^[a-zA-Z_0-9.]*$/"
+                 ng-model-options="{allowInvalid: true}"
+                 validate-application-name
+                 cloud-providers="newAppModal.application.cloudProviders"
                  required/>
         </div>
       </div>
@@ -30,16 +33,11 @@
         </div>
       </div>
 
+      <application-name-validation-messages application="newAppModal.application"></application-name-validation-messages>
+
       <div class="form-group row slide-in animated" ng-if="newApplicationForm.name.$error.validateUnique">
         <div class="col-sm-9 col-sm-offset-3 error-message">
           <span>Application name must be unique.</span>
-        </div>
-      </div>
-
-      <div class="form-group row slide-in animated" ng-if="newAppModal.application.name.indexOf('_') > -1 || newAppModal.application.name.indexOf('.') > -1">
-        <div class="col-sm-9 col-sm-offset-3 warn-message">
-          <span>If the application's name contains an underscore(_) or dot(.), you will not be able to create a load balancer,
-            preventing it from being used as a front end service.</span>
         </div>
       </div>
 
@@ -142,7 +140,7 @@
 
       <div class="form-group row">
         <div class="col-sm-3 sm-label-left">Instance Health</div>
-        <div class="col-sm-9 checkbox" style="margin-bottom: 0">
+        <div class="col-sm-9 checkbox" style="margin-bottom: 0; margin-top: 5px">
           <label>
             <input type="checkbox"
                    ng-model="newAppModal.application.platformHealthOnly"/>

--- a/app/scripts/modules/core/application/modal/validation/applicationName.validator.js
+++ b/app/scripts/modules/core/application/modal/validation/applicationName.validator.js
@@ -1,0 +1,71 @@
+'use strict';
+
+let angular = require('angular');
+
+/**
+ * Responsible for registering validators around the application name, then running them
+ * when creating a new application.
+ */
+module.exports = angular.module('spinnaker.core.application.applicationName.validator', [
+  require('../../../cloudProvider/cloudProvider.registry.js'),
+])
+  .factory('applicationNameValidator', function(cloudProviderRegistry, $log) {
+
+    const providers = Object.create(null);
+
+    /**
+     * Registers a validator for a cloud provider.
+     * @param cloudProvider the key of the cloud provider, e.g. "aws", "gce"
+     * @param validator the actual validator
+     */
+    let registerValidator = (cloudProvider, validator) => {
+      if (cloudProviderRegistry.getProvider(cloudProvider)) {
+        if (!providers[cloudProvider]) {
+          providers[cloudProvider] = [];
+        }
+        providers[cloudProvider].push(validator);
+      } else {
+        $log.warn('Tried to register an applicationNameValidator for a provider that does not exist: ' + cloudProvider);
+      }
+    };
+
+    /**
+     * Performs the actual validation. If there are no providers supplied, all configured validators will fire
+     * and add their messages to the result.
+     * @param applicationName the name of the application
+     * @param providersToTest the configured cloud providers; if empty, validators for all providers will fire
+     * @returns {{errors: Array, warnings: Array}}
+     */
+    let validate = (applicationName, providersToTest) => {
+      let toCheck = providersToTest && providersToTest.length ?
+        providersToTest :
+        cloudProviderRegistry.listRegisteredProviders();
+
+      let errors = [],
+          warnings = [];
+
+      toCheck.forEach((provider) => {
+        if (providers[provider]) {
+          providers[provider].forEach((validator) => {
+            let results = validator.validate(applicationName);
+            results.warnings.forEach((message) => {
+              warnings.push({ cloudProvider: provider, message: message});
+            });
+            results.errors.forEach((message) => {
+              errors.push({ cloudProvider: provider, message: message});
+            });
+          });
+        }
+      });
+
+      return {
+        errors: errors,
+        warnings: warnings,
+      };
+    };
+
+    return {
+      registerValidator: registerValidator,
+      validate: validate,
+    };
+  });

--- a/app/scripts/modules/core/application/modal/validation/applicationName.validator.spec.js
+++ b/app/scripts/modules/core/application/modal/validation/applicationName.validator.spec.js
@@ -1,0 +1,73 @@
+'use strict';
+
+describe('Validator: applicationName', function () {
+
+  var validator, validator1, validator2;
+
+  beforeEach(
+    window.module(
+      require('./applicationName.validator.js'),
+      require('./exampleApplicationName.validator.js')
+    )
+  );
+
+  beforeEach(window.inject(function (applicationNameValidator, exampleApplicationNameValidator, exampleApplicationNameValidator2) {
+    validator = applicationNameValidator;
+    validator1 = exampleApplicationNameValidator;
+    validator2 = exampleApplicationNameValidator2;
+  }));
+
+  describe('warning messages', function () {
+    it('aggregates warning messages when multiple or no providers are specified', function () {
+      var result = validator.validate(validator1.COMMON_WARNING_CONDITION, []);
+      expect(result.warnings.length).toBe(2);
+      expect(result.warnings[0].cloudProvider).toEqual(validator1.provider);
+      expect(result.warnings[0].message).toEqual(validator1.COMMON_WARNING_MESSAGE);
+      expect(result.warnings[1].cloudProvider).toEqual(validator2.provider);
+      expect(result.warnings[1].message).toEqual(validator2.COMMON_WARNING_MESSAGE);
+
+      result = validator.validate(validator1.COMMON_WARNING_CONDITION, [validator1.provider, validator2.provider]);
+      expect(result.warnings[0].message).toEqual(validator1.COMMON_WARNING_MESSAGE);
+      expect(result.warnings[0].cloudProvider).toEqual(validator1.provider);
+      expect(result.warnings[1].cloudProvider).toEqual(validator2.provider);
+      expect(result.warnings[1].message).toEqual(validator2.COMMON_WARNING_MESSAGE);
+    });
+
+    it('provides warnings only from provider when specified', function () {
+      var result = validator.validate(validator1.WARNING_CONDITION, [validator2.provider]);
+      expect(result.warnings.length).toBe(0);
+
+      result = validator.validate(validator1.WARNING_CONDITION, [validator1.provider]);
+      expect(result.warnings.length).toBe(1);
+      expect(result.warnings[0].cloudProvider).toEqual(validator1.provider);
+      expect(result.warnings[0].message).toEqual(validator1.WARNING_MESSAGE);
+    });
+  });
+
+  describe('error messages', function () {
+    it('aggregates error messages when multiple or no providers are specified', function () {
+      var result = validator.validate(validator1.COMMON_ERROR_CONDITION, []);
+      expect(result.errors.length).toBe(2);
+      expect(result.errors[0].cloudProvider).toEqual(validator1.provider);
+      expect(result.errors[0].message).toEqual(validator1.COMMON_ERROR_MESSAGE);
+      expect(result.errors[1].cloudProvider).toEqual(validator2.provider);
+      expect(result.errors[1].message).toEqual(validator2.COMMON_ERROR_MESSAGE);
+
+      result = validator.validate(validator1.COMMON_ERROR_CONDITION, [validator1.provider, validator2.provider]);
+      expect(result.errors[0].message).toEqual(validator1.COMMON_ERROR_MESSAGE);
+      expect(result.errors[0].cloudProvider).toEqual(validator1.provider);
+      expect(result.errors[1].cloudProvider).toEqual(validator2.provider);
+      expect(result.errors[1].message).toEqual(validator2.COMMON_ERROR_MESSAGE);
+    });
+
+    it('provides errors only from provider when specified', function () {
+      var result = validator.validate(validator1.ERROR_CONDITION, [validator2.provider]);
+      expect(result.errors.length).toBe(0);
+
+      result = validator.validate(validator1.ERROR_CONDITION, [validator1.provider]);
+      expect(result.errors.length).toBe(1);
+      expect(result.errors[0].cloudProvider).toEqual(validator1.provider);
+      expect(result.errors[0].message).toEqual(validator1.ERROR_MESSAGE);
+    });
+  });
+});

--- a/app/scripts/modules/core/application/modal/validation/applicationNameValidationMessages.directive.html
+++ b/app/scripts/modules/core/application/modal/validation/applicationNameValidationMessages.directive.html
@@ -1,0 +1,12 @@
+<div class="form-group row slide-in animated" ng-if="vm.warnings.length">
+  <div class="col-sm-9 col-sm-offset-3 warn-message" ng-repeat="warning in vm.warnings">
+    <cloud-provider-logo provider="warning.cloudProvider" height="16px" width="16px"></cloud-provider-logo>
+    {{warning.message}}
+  </div>
+</div>
+<div class="form-group row slide-in animated" ng-if="vm.errors.length">
+  <div class="col-sm-9 col-sm-offset-3 error-message" ng-repeat="error in vm.errors">
+    <cloud-provider-logo provider="error.cloudProvider" height="16px" width="16px"></cloud-provider-logo>
+    {{error.message}}
+  </div>
+</div>

--- a/app/scripts/modules/core/application/modal/validation/applicationNameValidationMessages.directive.js
+++ b/app/scripts/modules/core/application/modal/validation/applicationNameValidationMessages.directive.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const angular = require('angular');
+
+/**
+ * This directive is responsible for rendering error and warning messages to the screen when creating a new application.
+ * It does NOT set the validity of the form field - that is handled by the validateApplicationName directive.
+ */
+module.exports = angular
+  .module('spinnaker.core.application.config.applicationNameValidationMessages.directive', [
+    require('./applicationName.validator.js'),
+  ])
+  .directive('applicationNameValidationMessages', function () {
+    return {
+      restrict: 'E',
+      templateUrl: require('./applicationNameValidationMessages.directive.html'),
+      scope: {},
+      bindToController: {
+        application: '=',
+      },
+      controller: 'ApplicationNameValidationMessagesCtrl',
+      controllerAs: 'vm',
+    };
+  })
+  .controller('ApplicationNameValidationMessagesCtrl', function ($scope, applicationNameValidator) {
+
+    let validate = () => {
+      let validation = applicationNameValidator.validate(this.application.name, this.application.cloudProviders);
+      this.warnings = validation.warnings;
+      this.errors = validation.errors;
+    };
+
+    $scope.$watch(() => this.application.name, validate);
+    $scope.$watch(() => this.application.cloudProviders, validate);
+
+  });

--- a/app/scripts/modules/core/application/modal/validation/exampleApplicationName.validator.js
+++ b/app/scripts/modules/core/application/modal/validation/exampleApplicationName.validator.js
@@ -1,0 +1,116 @@
+'use strict';
+
+const angular = require('angular');
+
+module.exports = angular
+  .module('spinnaker.core.application.modal.validation.example.applicationName', [
+    require('./applicationName.validator.js'),
+    require('../../../cloudProvider/cloudProvider.registry.js'),
+    require('../../../config/settings.js'),
+  ])
+  .factory('exampleApplicationNameValidator', function () {
+
+    const warningMessage = 'WARNING!!!!',
+          warningCondition = 'application.warning',
+          errorMessage = 'ERRORRRRRR!!!',
+          errorCondition = 'application.error',
+          commonWarningCondition = 'common.warning',
+          commonWarningMessage = '2COMMON WARNING',
+          commonErrorCondition = 'common.error',
+          commonErrorMessage = 'COMMON ERROR!';
+
+    function validate(name) {
+      let warnings = [],
+          errors = [];
+      name = name || '';
+      if (name === warningCondition) {
+        warnings.push(warningMessage);
+      }
+      if (name === errorCondition) {
+        errors.push(errorMessage);
+      }
+      if (name === commonWarningCondition) {
+        warnings.push(commonWarningMessage);
+      }
+      if (name === commonErrorCondition) {
+        errors.push(commonErrorMessage);
+      }
+
+      return {
+        warnings: warnings,
+        errors: errors,
+      };
+    }
+
+    return {
+      provider: 'example',
+      validate: validate,
+      WARNING_MESSAGE: warningMessage,
+      WARNING_CONDITION: warningCondition,
+      ERROR_MESSAGE: errorMessage,
+      ERROR_CONDITION: errorCondition,
+      COMMON_WARNING_MESSAGE: commonWarningMessage,
+      COMMON_WARNING_CONDITION: commonWarningCondition,
+      COMMON_ERROR_MESSAGE: commonErrorMessage,
+      COMMON_ERROR_CONDITION: commonErrorCondition,
+    };
+  })
+  .factory('exampleApplicationNameValidator2', function () {
+
+    const warningMessage = '2WARNING!!!!',
+          warningCondition = 'application.warning2',
+          errorMessage = '2ERRORRRRRR!!!',
+          errorCondition = 'application.error2',
+          commonWarningCondition = 'common.warning',
+          commonWarningMessage = '2COMMON WARNING',
+          commonErrorCondition = 'common.error',
+          commonErrorMessage = '2COMMON ERROR!';
+
+    function validate(name) {
+      let warnings = [],
+          errors = [];
+      name = name || '';
+
+      if (name === warningCondition) {
+        warnings.push(warningMessage);
+      }
+      if (name === commonWarningCondition) {
+        warnings.push(commonWarningMessage);
+      }
+      if (name === errorCondition) {
+        errors.push(errorMessage);
+      }
+      if (name === commonErrorCondition) {
+        errors.push(commonErrorMessage);
+      }
+
+      return {
+        warnings: warnings,
+        errors: errors,
+      };
+    }
+
+    return {
+      provider: 'example2',
+      validate: validate,
+      WARNING_MESSAGE: warningMessage,
+      WARNING_CONDITION: warningCondition,
+      ERROR_MESSAGE: errorMessage,
+      ERROR_CONDITION: errorCondition,
+      COMMON_WARNING_MESSAGE: commonWarningMessage,
+      COMMON_WARNING_CONDITION: commonWarningCondition,
+      COMMON_ERROR_MESSAGE: commonErrorMessage,
+      COMMON_ERROR_CONDITION: commonErrorCondition,
+
+    };
+  })
+  .run(function(applicationNameValidator, exampleApplicationNameValidator, exampleApplicationNameValidator2) {
+    applicationNameValidator.registerValidator('example', exampleApplicationNameValidator);
+    applicationNameValidator.registerValidator('example2', exampleApplicationNameValidator2);
+  })
+  .config(function(cloudProviderRegistryProvider, settings) {
+    settings.providers.example = {};
+    settings.providers.example2 = {};
+    cloudProviderRegistryProvider.registerProvider('example', {});
+    cloudProviderRegistryProvider.registerProvider('example2', {});
+  });

--- a/app/scripts/modules/core/application/modal/validation/validateApplicationName.directive.js
+++ b/app/scripts/modules/core/application/modal/validation/validateApplicationName.directive.js
@@ -1,0 +1,32 @@
+'use strict';
+
+let angular = require('angular');
+
+/**
+ * This directive is responsible for setting the validity of the name field when creating a new application.
+ * It does NOT render the error/warning messages to the screen - that is handled by the
+ * applicationNameValidationMessages directive.
+ */
+module.exports = angular
+  .module('spinnaker.core.application.modal.validateApplicationName.directive', [
+    require('./applicationName.validator.js'),
+  ])
+  .directive('validateApplicationName', function (applicationNameValidator) {
+    return {
+      restrict: 'A',
+      require: 'ngModel',
+      link: function (scope, elem, attr, ctrl) {
+        scope.$watch(attr.cloudProviders, function (newVal, oldVal) {
+          if (newVal !== oldVal && (ctrl.$viewValue || ctrl.$dirty)) {
+            ctrl.$validate();
+          }
+        }, true);
+
+        ctrl.$validators.validateApplicationName = (value) => {
+          var cloudProviders = scope.$eval(attr.cloudProviders) || [];
+          return applicationNameValidator.validate(value, cloudProviders).errors.length === 0;
+        };
+      }
+    };
+  }
+);

--- a/app/scripts/modules/core/application/modal/validation/validateApplicationName.directive.spec.js
+++ b/app/scripts/modules/core/application/modal/validation/validateApplicationName.directive.spec.js
@@ -1,0 +1,126 @@
+'use strict';
+
+describe('Validator: validateApplicationName', function () {
+
+  var validator1, validator2;
+
+  beforeEach(
+    window.module(
+      require('./exampleApplicationName.validator.js'),
+      require('./validateApplicationName.directive.js')
+    )
+  );
+
+  beforeEach(window.inject(function ($rootScope, $compile, exampleApplicationNameValidator, exampleApplicationNameValidator2) {
+    this.$rootScope = $rootScope;
+    this.compile = $compile;
+    validator1 = exampleApplicationNameValidator;
+    validator2 = exampleApplicationNameValidator2;
+  }));
+
+  beforeEach(function() {
+    var compile = this.compile;
+
+    this.initialize = function(val, cloudProviders) {
+      this.scope = this.$rootScope.$new();
+      this.scope.app = { name: val };
+      this.scope.cp = cloudProviders;
+
+      var input = '<input type="text" name="appName" ng-model="app.name" validate-application-name cloud-providers="cp"/>';
+
+      var dom = '<form name="form">' + input + '</form>';
+
+      compile(dom)(this.scope);
+      this.scope.$digest();
+    };
+
+    this.isValid = function() {
+      return this.scope.form.appName.$valid;
+    };
+  });
+
+  describe('valid cases', function () {
+
+    it('should be valid when no provider selected and name does not match warning or error condition', function () {
+      this.initialize('zz' + validator1.WARNING_CONDITION, []);
+      expect(this.isValid()).toBe(true);
+
+      this.initialize('zz' + validator1.ERROR_CONDITION, []);
+      expect(this.isValid()).toBe(true);
+
+      this.initialize('zz' + validator2.WARNING_CONDITION, []);
+      expect(this.isValid()).toBe(true);
+
+      this.initialize('zz' + validator2.ERROR_CONDITION, []);
+      expect(this.isValid()).toBe(true);
+    });
+
+    it('should be valid when a cloudProvider is selected and name does not match warning or error of other provider', function () {
+      this.initialize(validator1.WARNING_CONDITION, [validator2.provider]);
+      expect(this.isValid()).toBe(true);
+
+      this.initialize(validator1.ERROR_CONDITION, [validator2.provider]);
+      expect(this.isValid()).toBe(true);
+
+      this.initialize(validator2.WARNING_CONDITION, [validator1.provider]);
+      expect(this.isValid()).toBe(true);
+
+      this.initialize(validator2.ERROR_CONDITION, [validator1.provider]);
+      expect(this.isValid()).toBe(true);
+    });
+
+    it('should be valid when a name matches warnings', function () {
+      this.initialize(validator1.WARNING_CONDITION, []);
+      expect(this.isValid()).toBe(true);
+
+      this.initialize(validator2.WARNING_CONDITION, []);
+      expect(this.isValid()).toBe(true);
+
+    });
+  });
+
+  describe ('invalid cases', function () {
+
+    it('should be invalid if name is invalid for any provider and none specified', function () {
+      this.initialize(validator1.ERROR_CONDITION, []);
+      expect(this.isValid()).toBe(false);
+
+      this.initialize(validator2.ERROR_CONDITION, []);
+      expect(this.isValid()).toBe(false);
+    });
+
+    it('should be invalid if name is invalid for specified provider', function () {
+      this.initialize(validator1.ERROR_CONDITION, [validator2.provider]);
+      expect(this.isValid()).toBe(true);
+
+      this.initialize(validator1.ERROR_CONDITION, [validator1.provider]);
+      expect(this.isValid()).toBe(false);
+    });
+
+  });
+
+  describe ('value/option changes', function () {
+    it ('should flip when providers change', function () {
+      this.initialize(validator2.ERROR_CONDITION, [validator1.provider]);
+      expect(this.isValid()).toBe(true);
+
+      this.scope.cp = [validator2.provider];
+      this.scope.$digest();
+      expect(this.isValid()).toBe(false);
+
+      this.scope.cp = [validator1.provider];
+      this.scope.$digest();
+      expect(this.isValid()).toBe(true);
+    });
+
+    it ('should flip when name changes', function () {
+      this.initialize(validator1.ERROR_CONDITION + 'zz', [validator1.provider]);
+      expect(this.isValid()).toBe(true);
+
+      this.scope.app.name = validator1.ERROR_CONDITION;
+      this.scope.$digest();
+      expect(this.isValid()).toBe(false);
+    });
+
+  });
+});

--- a/app/scripts/modules/core/serverGroup/configure/common/basicSettingsMixin.controller.js
+++ b/app/scripts/modules/core/serverGroup/configure/common/basicSettingsMixin.controller.js
@@ -64,8 +64,8 @@ module.exports = angular
     this.stackPattern = {
       test: function(stack) {
         var pattern = $scope.command.viewState.templatingEnabled ?
-          /^([a-zA-z_0-9._]*(\${.+})*)*$/ :
-          /^[a-zA-z_0-9._]*$/;
+          /^([a-zA-Z_0-9._]*(\${.+})*)*$/ :
+          /^[a-zA-Z_0-9._]*$/;
         return pattern.test(stack);
       }
     };
@@ -73,8 +73,8 @@ module.exports = angular
     this.detailPattern = {
       test: function(stack) {
         var pattern = $scope.command.viewState.templatingEnabled ?
-          /^([a-zA-z_0-9._-]*(\${.+})*)*$/ :
-          /^[a-zA-z_0-9._-]*$/;
+          /^([a-zA-Z_0-9._-]*(\${.+})*)*$/ :
+          /^[a-zA-Z_0-9._-]*$/;
         return pattern.test(stack);
       }
     };

--- a/app/scripts/modules/netflix/application/createApplication.modal.html
+++ b/app/scripts/modules/netflix/application/createApplication.modal.html
@@ -14,12 +14,15 @@
           <input type="text"
                  autofocus
                  name="name"
-                 ng-pattern="/^[a-zA-z_0-9.]*$/"
                  class="form-control input-sm"
                  data-purpose="application-name"
                  ng-model="newAppModal.application.name"
                  placeholder="Enter an application name"
                  validate-unique="newAppModal.data.appNameList"
+                 ng-pattern="/^[a-zA-Z_0-9.]*$/"
+                 ng-model-options="{allowInvalid: true}"
+                 validate-application-name
+                 cloud-providers="newAppModal.application.cloudProviders"
                  required/>
         </div>
       </div>
@@ -30,16 +33,11 @@
         </div>
       </div>
 
+      <application-name-validation-messages application="newAppModal.application"></application-name-validation-messages>
+
       <div class="form-group row slide-in animated" ng-if="newApplicationForm.name.$error.validateUnique">
         <div class="col-sm-9 col-sm-offset-3 error-message">
           <span>Application name must be unique.</span>
-        </div>
-      </div>
-
-      <div class="form-group row slide-in animated" ng-if="newAppModal.application.name.indexOf('_') > -1 || newAppModal.application.name.indexOf('.') > -1">
-        <div class="col-sm-9 col-sm-offset-3 warn-message">
-          <span>If the application's name contains an underscore(_) or dot(.), you will not be able to create a load balancer,
-            preventing it from being used as a front end service.</span>
         </div>
       </div>
 

--- a/app/scripts/modules/netflix/fastProperties/modal/wizard/fastPropertyForm.directive.html
+++ b/app/scripts/modules/netflix/fastProperties/modal/wizard/fastPropertyForm.directive.html
@@ -30,7 +30,7 @@
                name="name"
                required
                ng-disabled="newFP.isEditing"
-               ng-pattern="/^[a-zA-z_0-9.]*$/"
+               ng-pattern="/^[a-zA-Z_0-9.]*$/"
                class="form-control input-sm"
                data-purpose="fastProperty-key"
                ng-model="newFP.property.key"


### PR DESCRIPTION
Provides a mechanism for any provider to specify warning and error conditions for application names.

For example: due to AWS's kinda severe restrictions on load balancer names, we warn users about very long names. That should not be a concern for users who are not using AWS.

I've left the character restrictions in place (`ng-pattern` - alphanumeric + dot + underscore) because we use the application name everywhere and don't want to have to URL-encode the names of components.

@zanthrash @duftler please review when you have time