### PR TITLE
enable multiselect actions on instances

### DIFF
--- a/app/scripts/modules/core/cluster/filter/clusterFilter.model.spec.js
+++ b/app/scripts/modules/core/cluster/filter/clusterFilter.model.spec.js
@@ -3,15 +3,208 @@
 
 describe('Cluster Filter Model', function () {
 
-  var ClusterFilterModel;
+  var ClusterFilterModel, $state;
 
   beforeEach(window.module(
     require('./clusterFilter.model')
   ));
 
   beforeEach(
-    window.inject(function(_ClusterFilterModel_){
+    window.inject(function(_ClusterFilterModel_, _$state_){
       ClusterFilterModel = _ClusterFilterModel_;
+      $state = _$state_;
     })
   );
+
+  describe('multiple instance management', function () {
+    beforeEach(function() {
+      this.result = null;
+      this.currentStates = [];
+      spyOn($state, 'includes').and.callFake((substate) => this.currentStates.indexOf(substate) > -1);
+      spyOn($state, 'go').and.callFake((newState) => this.result = newState);
+    });
+
+    describe('syncNavigation', function () {
+      beforeEach(function() {
+        this.instanceGroup = ClusterFilterModel.getOrCreateMultiselectInstanceGroup(
+          {name: 'a', account: 'prod', region: 'us-east-1', type: 'aws'});
+      });
+
+      it('navigates to multipleInstances child view when not already there and instances are selected', function () {
+        this.instanceGroup.instanceIds.push('i-123');
+        this.currentStates = ['**.clusters.*'];
+        ClusterFilterModel.syncNavigation();
+        expect(this.result).toBe('^.multipleInstances');
+      });
+
+      it('navigates to multipleInstances sibling view when not already there and instances are selected', function () {
+        this.instanceGroup.instanceIds.push('i-123');
+        this.currentStates = ['**.clusters.instanceDetails'];
+        ClusterFilterModel.syncNavigation();
+        expect(this.result).toBe('.multipleInstances');
+      });
+
+      it('does not navigate when already in multipleInstances view', function () {
+        this.instanceGroup.instanceIds.push('i-123');
+        this.currentStates = ['**.multipleInstances'];
+        ClusterFilterModel.syncNavigation();
+        expect(this.result).toBe(null);
+      });
+
+      it('navigates away from multipleInstances view when no instances are selected', function () {
+        this.currentStates = ['**.multipleInstances'];
+        ClusterFilterModel.syncNavigation();
+        expect(this.result).toBe('^');
+      });
+    });
+
+    describe('getOrCreateMultiselectInstanceGroup', function () {
+      beforeEach(function () {
+        this.serverGroup = {
+          name: 'asg-v001',
+          account: 'prod',
+          region: 'us-east-1',
+          type: 'aws'
+        };
+        this.original = ClusterFilterModel.getOrCreateMultiselectInstanceGroup(this.serverGroup);
+      });
+
+      it('reuses existing instance group', function () {
+        let test = ClusterFilterModel.getOrCreateMultiselectInstanceGroup(this.serverGroup);
+        expect(test).toBe(this.original);
+      });
+
+      it('creates new instance group if name does not match', function () {
+        this.serverGroup.name += 'a';
+        let test = ClusterFilterModel.getOrCreateMultiselectInstanceGroup(this.serverGroup);
+        expect(test).not.toBe(this.original);
+      });
+
+      it('creates new instance group if region does not match', function () {
+        this.serverGroup.region += 'a';
+        let test = ClusterFilterModel.getOrCreateMultiselectInstanceGroup(this.serverGroup);
+        expect(test).not.toBe(this.original);
+      });
+
+      it('creates new instance group if account does not match', function () {
+        this.serverGroup.account += 'a';
+        let test = ClusterFilterModel.getOrCreateMultiselectInstanceGroup(this.serverGroup);
+        expect(test).not.toBe(this.original);
+      });
+
+      it('creates new instance group if type does not match', function () {
+        this.serverGroup.type += 'a';
+        let test = ClusterFilterModel.getOrCreateMultiselectInstanceGroup(this.serverGroup);
+        expect(test).not.toBe(this.original);
+      });
+    });
+
+    describe('toggleMultiselectInstance', function () {
+      beforeEach(function () {
+        this.serverGroup = {
+          name: 'asg-v001',
+          account: 'prod',
+          region: 'us-east-1',
+          type: 'aws'
+        };
+
+        this.instanceGroup = ClusterFilterModel.getOrCreateMultiselectInstanceGroup(this.serverGroup);
+
+        spyOn(ClusterFilterModel, 'syncNavigation');
+      });
+
+      it('adds instance id if not present', function () {
+        ClusterFilterModel.toggleMultiselectInstance(this.serverGroup, 'i-1234');
+
+        expect(this.instanceGroup.instanceIds).toEqual(['i-1234']);
+        expect(ClusterFilterModel.syncNavigation.calls.count()).toBe(1);
+      });
+
+      it('removes instance id if present and sets selectAll flag to false', function () {
+        this.instanceGroup.instanceIds.push('i-1234');
+        this.instanceGroup.selectAll = true;
+
+        ClusterFilterModel.toggleMultiselectInstance(this.serverGroup, 'i-1234');
+
+        expect(this.instanceGroup.instanceIds).toEqual([]);
+        expect(this.instanceGroup.selectAll).toBe(false);
+        expect(ClusterFilterModel.syncNavigation.calls.count()).toBe(1);
+      });
+    });
+
+    describe('toggleSelectAll', function () {
+      beforeEach(function () {
+        this.serverGroup = {
+          name: 'asg-v001',
+          account: 'prod',
+          region: 'us-east-1',
+          type: 'aws'
+        };
+
+        this.instanceGroup = ClusterFilterModel.getOrCreateMultiselectInstanceGroup(this.serverGroup);
+
+        spyOn(ClusterFilterModel, 'syncNavigation');
+      });
+
+      it('sets selectAll flag to true and adds supplied instanceIds when selectAll is false', function () {
+        let instanceIds = ['i-1234', 'i-2345'];
+        ClusterFilterModel.toggleSelectAll(this.serverGroup, instanceIds);
+
+        expect(this.instanceGroup.selectAll).toBe(true);
+        expect(this.instanceGroup.instanceIds).toBe(instanceIds);
+        expect(ClusterFilterModel.syncNavigation.calls.count()).toBe(1);
+      });
+
+      it('sets selectAll flag to false and clears supplied instanceIds when selectAll is true', function () {
+        let instanceIds = ['i-1234', 'i-2345'];
+        this.instanceGroup.selectAll = true;
+        this.instanceGroup.instanceIds = instanceIds;
+        ClusterFilterModel.toggleSelectAll(this.serverGroup, instanceIds);
+
+        expect(this.instanceGroup.selectAll).toBe(false);
+        expect(this.instanceGroup.instanceIds).toEqual([]);
+        expect(ClusterFilterModel.syncNavigation.calls.count()).toBe(1);
+      });
+    });
+
+    describe('instanceIsMultiselected', function () {
+      it('returns true if instance is selected, false otherwise', function () {
+        let serverGroup = {
+          name: 'asg-v001',
+          account: 'prod',
+          region: 'us-east-1',
+          type: 'aws'
+        };
+
+        let instanceId = 'i-1234';
+
+        let instanceGroup = ClusterFilterModel.getOrCreateMultiselectInstanceGroup(serverGroup);
+        instanceGroup.instanceIds.push(instanceId);
+
+        expect(ClusterFilterModel.instanceIsMultiselected(serverGroup, instanceId)).toBe(true);
+        expect(ClusterFilterModel.instanceIsMultiselected(serverGroup, instanceId + 'a')).toBe(false);
+      });
+    });
+
+    describe('state change start event', function () {
+      it('clears multiselectInstanceGroups when navigating away from multipleInstances', function () {
+        let newState = { name: '.clusters' },
+            oldState = { name: '.multipleInstances' };
+        ClusterFilterModel.multiselectInstanceGroups = [ 'it does not matter, we are just verifying the array is cleared'];
+
+        ClusterFilterModel.handleStateChangeStart(null, newState, null, oldState, null);
+        expect(ClusterFilterModel.multiselectInstanceGroups).toEqual([]);
+      });
+
+      it('preserves multiselectInstanceGroups when navigating to multipleInstances', function () {
+        let oldState = { name: '.clusters' },
+            newState = { name: '.multipleInstances' },
+            oldGroups = [ 'a', 'b', 'c', 'just testing it does not get cleared'];
+        ClusterFilterModel.multiselectInstanceGroups = oldGroups;
+
+        ClusterFilterModel.handleStateChangeStart(null, newState, null, oldState, null);
+        expect(ClusterFilterModel.multiselectInstanceGroups.length).toBe(4);
+      });
+    });
+  });
 });

--- a/app/scripts/modules/core/cluster/rollups.less
+++ b/app/scripts/modules/core/cluster/rollups.less
@@ -72,6 +72,10 @@
   line-height: 10px;
   border-radius: 2px;
   padding-bottom: 5px;
+  tr.instance-row:hover > td.no-hover {
+    background-color: #ffffff;
+    cursor: default;
+  }
   a.instance {
     margin: 0;
     display: inline-block;

--- a/app/scripts/modules/core/instance/details/multipleInstanceServerGroup.directive.html
+++ b/app/scripts/modules/core/instance/details/multipleInstanceServerGroup.directive.html
@@ -1,0 +1,19 @@
+<h5>
+  <div class="server-group-name">
+    <cloud-provider-logo provider="vm.instanceGroup.cloudProvider" height="16px" width="16px"></cloud-provider-logo>
+    {{vm.instanceGroup.serverGroup}}
+  </div>
+</h5>
+<div class="server-group-details">
+  <account-tag account="vm.instanceGroup.account"></account-tag>
+  {{vm.instanceGroup.region}}
+</div>
+<div class="multiple-instance-list">
+  {{vm.instanceGroup.instances.length}} instance<span ng-if="vm.instanceGroup.instances.length !== 1">s</span>
+  <ul>
+    <li ng-repeat="instance in vm.instanceGroup.instances">
+      <span class="glyphicon glyphicon-{{instance.healthState}}-triangle"></span>
+      {{instance.id}}
+    </li>
+  </ul>
+</div>

--- a/app/scripts/modules/core/instance/details/multipleInstanceServerGroup.directive.js
+++ b/app/scripts/modules/core/instance/details/multipleInstanceServerGroup.directive.js
@@ -1,0 +1,22 @@
+'use strict';
+
+let angular = require('angular');
+
+require('./multipleInstanceServerGroup.directive.less');
+
+module.exports = angular
+  .module('spinnaker.core.instance.details.multipleInstanceServerGroup.directive', [
+
+  ])
+  .directive('multipleInstanceServerGroup', function () {
+    return {
+      restrict: 'E',
+      scope: {},
+      bindToController: {
+        instanceGroup: '='
+      },
+      controller: angular.noop,
+      controllerAs: 'vm',
+      templateUrl: require('./multipleInstanceServerGroup.directive.html')
+    };
+  });

--- a/app/scripts/modules/core/instance/details/multipleInstanceServerGroup.directive.less
+++ b/app/scripts/modules/core/instance/details/multipleInstanceServerGroup.directive.less
@@ -1,0 +1,22 @@
+multiple-instance-server-group {
+  display: block;
+  margin-bottom: 20px;
+  h5 {
+    font-size: 110%;
+    margin-bottom: 5px;
+    padding-bottom: 0;
+  }
+  .server-group-name {
+    font-weight: 600;
+  }
+  .server-group-details {
+    margin-left: 24px;
+    margin-bottom: 5px;
+  }
+  .multiple-instance-list {
+    margin-left: 24px;
+    ul {
+      font-size: 80%;
+    }
+  }
+}

--- a/app/scripts/modules/core/instance/details/multipleInstances.controller.js
+++ b/app/scripts/modules/core/instance/details/multipleInstances.controller.js
@@ -1,0 +1,226 @@
+'use strict';
+
+let angular = require('angular');
+
+module.exports = angular.module('spinnaker.core.instance.details.multipleInstances.controller', [
+  require('angular-ui-router'),
+  require('../instance.write.service.js'),
+  require('../../confirmationModal/confirmationModal.service.js'),
+  require('../../insight/insightFilterState.model.js'),
+  require('../../cluster/filter/clusterFilter.model.js'),
+  require('./multipleInstanceServerGroup.directive.js'),
+])
+  .controller('MultipleInstancesCtrl', function ($scope, $state, InsightFilterStateModel,
+                                                 confirmationModalService, ClusterFilterModel,
+                                                 instanceWriter, app) {
+
+    this.InsightFilterStateModel = InsightFilterStateModel;
+    this.selectedGroups = [];
+
+    /**
+     * Actions
+     */
+
+    let getDescriptor = () => {
+      let descriptor = this.instancesCount + ' instance';
+      if (this.instancesCount > 1) {
+        descriptor += 's';
+      }
+      return descriptor;
+    };
+
+    let confirm = (submitMethod, verbs, body) => {
+      let descriptor = getDescriptor();
+      var taskMonitor = {
+        application: app,
+        title: verbs.presentContinuous + ' ' + descriptor,
+      };
+
+      confirmationModalService.confirm({
+        header: 'Really ' + verbs.simplePresent.toLowerCase() + ' ' + descriptor + '?',
+        buttonText: verbs.simplePresent + ' ' + descriptor,
+        verificationLabel: 'Verify the number of instances (<strong>'+ this.instancesCount + '</strong>) to be ' + verbs.futurePerfect.toLowerCase(),
+        textToVerify: this.instancesCount + '',
+        taskMonitorConfig: taskMonitor,
+        body: body,
+        submitMethod: submitMethod
+      });
+    };
+
+    this.terminateInstances = () => {
+      let submitMethod = () => instanceWriter.terminateInstances(this.selectedGroups, app);
+      confirm(submitMethod, {
+        presentContinuous: 'Terminating',
+        simplePresent: 'Terminate',
+        futurePerfect: 'Terminated'
+      });
+    };
+
+    this.rebootInstances = () => {
+      let submitMethod = () => instanceWriter.rebootInstances(this.selectedGroups, app);
+      confirm(submitMethod, {
+        presentContinuous: 'Rebooting',
+        simplePresent: 'Reboot',
+        futurePerfect: 'Rebooted'
+      });
+    };
+
+    let allDiscoveryHealthsMatch = (state) => {
+      return this.selectedGroups.every((group) => {
+        return group.instances.every((instance) => {
+          var discoveryHealth = instance.health.filter(function(health) {
+            return health.type === 'Discovery';
+          });
+          return discoveryHealth.length ? discoveryHealth[0].state === state : false;
+        });
+      });
+    };
+
+    this.canRegisterWithDiscovery = () => allDiscoveryHealthsMatch('OutOfService');
+
+    this.canDeregisterWithDiscovery = () => allDiscoveryHealthsMatch('Up');
+
+    this.registerWithDiscovery = () => {
+      let submitMethod = () => instanceWriter.enableInstancesInDiscovery(this.selectedGroups, app);
+      confirm(submitMethod, {
+        presentContinuous: 'Registering',
+        simplePresent: 'Register',
+        futurePerfect: 'Registered'
+      });
+    };
+
+    this.deregisterWithDiscovery = () => {
+      let submitMethod = () => instanceWriter.disableInstancesInDiscovery(this.selectedGroups, app);
+      confirm(submitMethod, {
+        presentContinuous: 'Deregistering',
+        simplePresent: 'Deregister',
+        futurePerfect: 'Deregistered'
+      });
+    };
+
+    let getAllLoadBalancers = () => {
+      if (!this.selectedGroups.length) {
+        return [];
+      }
+      let base = this.selectedGroups[0].loadBalancers.sort().join(' ');
+      if (this.selectedGroups.every((group) => group.loadBalancers.sort().join(' ') === base)) {
+        return this.selectedGroups[0].loadBalancers;
+      }
+      return [];
+    };
+
+    this.canRegisterWithLoadBalancers = () => {
+      return getAllLoadBalancers().length !== 0 && // !== 0 so we always return a boolean
+        this.selectedGroups.every((group) =>
+          group.instances.every((instance) =>
+            instance.health.every((health) =>
+            health.type !== 'LoadBalancer')));
+    };
+
+    this.canDeregisterFromLoadBalancers = () => {
+      let allLoadBalancers = getAllLoadBalancers().sort().join(' ');
+      return this.selectedGroups.every((group) => {
+        return group.instances.every((instance) => {
+          return instance.health.some((health) => {
+            return health.type === 'LoadBalancer' &&
+              allLoadBalancers === health.loadBalancers.map((lb) => lb.name).sort().join(' ');
+          });
+        });
+      });
+    };
+
+    this.registerWithLoadBalancers = () => {
+      let allLoadBalancers = getAllLoadBalancers().sort();
+      let submitMethod = () => instanceWriter.registerInstancesWithLoadBalancer(this.selectedGroups, app, allLoadBalancers);
+      confirm(submitMethod, {
+        presentContinuous: 'Registering',
+        simplePresent: 'Register',
+        futurePerfect: 'Registered'
+      },
+        `<p>Instances will be registered with the following load balancers: <b>${allLoadBalancers.join(', ')}</b></p>`
+      );
+    };
+
+    this.deregisterFromLoadBalancers = () => {
+      let allLoadBalancers = getAllLoadBalancers().sort();
+      let submitMethod = () => instanceWriter.deregisterInstancesFromLoadBalancer(this.selectedGroups, app, allLoadBalancers);
+      confirm(submitMethod, {
+        presentContinuous: 'Deregistering',
+        simplePresent: 'Deregister',
+        futurePerfect: 'Deregistered'
+      },
+        `<p>Instances will be deregistered from the following load balancers: <b>${allLoadBalancers.join(', ')}</b></p>`
+      );
+    };
+
+    /***
+     * View instantiation/synchronization
+     */
+
+    function getServerGroup(group) {
+      let [serverGroup] = app.serverGroups.filter((serverGroup) => serverGroup.name === group.serverGroup &&
+          serverGroup.account === group.account && serverGroup.region === group.region);
+
+      return serverGroup;
+    }
+
+    function getInstanceDetails(group, instanceId) {
+      let serverGroup = getServerGroup(group);
+
+      if (!serverGroup) {
+        return null;
+      }
+
+      let [instance] = serverGroup.instances.filter((instance) => instance.id === instanceId);
+      return instance || {};
+    }
+
+    let makeInstanceModel = (group, instanceId) => {
+      let instance = getInstanceDetails(group, instanceId);
+      return {
+        id: instanceId,
+        health: instance.health,
+        healthState: instance.healthState,
+      };
+    };
+
+    let makeServerGroupModel = (group) => {
+      let parentServerGroup = getServerGroup(group),
+          loadBalancers = parentServerGroup ? parentServerGroup.loadBalancers : [];
+
+      return {
+        cloudProvider: group.cloudProvider,
+        serverGroup: group.serverGroup,
+        loadBalancers: loadBalancers,
+        account: group.account,
+        region: group.region,
+        instanceIds: group.instanceIds,
+        instances: group.instanceIds.map((instanceId) => makeInstanceModel(group, instanceId))
+      };
+    };
+
+
+
+    let retrieveInstances = () => {
+      this.instancesCount = 0;
+      this.selectedGroups = ClusterFilterModel.multiselectInstanceGroups
+        .filter((group) => group.instanceIds.length)
+        .map(makeServerGroupModel);
+
+      this.selectedGroups.forEach((group) => {
+        this.instancesCount += group.instances.length;
+      });
+    };
+
+    let multiselectWatcher = ClusterFilterModel.multiselectInstancesStream.subscribe(retrieveInstances);
+    let refreshWatcher = app.autoRefreshStream.subscribe(retrieveInstances);
+
+    retrieveInstances();
+
+    $scope.$on('$destroy', () => {
+      refreshWatcher.dispose();
+      multiselectWatcher.dispose();
+    });
+
+  }
+);

--- a/app/scripts/modules/core/instance/details/multipleInstances.controller.spec.js
+++ b/app/scripts/modules/core/instance/details/multipleInstances.controller.spec.js
@@ -1,0 +1,269 @@
+'use strict';
+
+
+describe('Controller: MultipleInstances', function () {
+
+  var controller;
+  var scope;
+  var rx;
+  var refreshStream;
+  var ClusterFilterModel;
+
+  beforeEach(
+    window.module(
+      require('./multipleInstances.controller')
+    )
+  );
+
+  beforeEach(
+    window.inject(function ($rootScope, $controller, _$q_, _rx_, _ClusterFilterModel_) {
+      scope = $rootScope.$new();
+      ClusterFilterModel = _ClusterFilterModel_;
+      rx = _rx_;
+      refreshStream = new rx.Subject();
+
+      this.createController = function (application) {
+        application.autoRefreshStream = application.autoRefreshStream || refreshStream;
+        controller = $controller('MultipleInstancesCtrl', {
+          $scope: scope,
+          app: application,
+        });
+      };
+    })
+  );
+
+  beforeEach(function () {
+    this.serverGroupA = { type: 'aws', name: 'asg-v001', account: 'prod', region: 'us-east-1', instances: [
+      { id: 'i-123', availabilityZone: 'c', launchTime: 1, healthState: 'Up', health: []},
+      { id: 'i-234', availabilityZone: 'd', launchTime: 2, healthState: 'Up', health: []}
+    ]
+    };
+    this.serverGroupB = { type: 'gce', name: 'asg-v002', account: 'test', region: 'us-west-1', instances: [
+      { id: 'g-234', availabilityZone: 'e', launchTime: 2, healthState: 'Up', health: []}
+    ]};
+    this.serverGroupC = { type: 'gce', name: 'asg-v003', account: 'test', region: 'us-west-1', instances: [
+      { id: 'g-234', availabilityZone: 'f', launchTime: 2, healthState: 'Up', health: []}
+    ]};
+
+    this.getInstanceGroup = (serverGroup) => {
+      return ClusterFilterModel.getOrCreateMultiselectInstanceGroup(serverGroup);
+    };
+
+    this.addInstance = (serverGroup, instanceId) => {
+      let instanceGroup = this.getInstanceGroup(serverGroup);
+      instanceGroup.instanceIds.push(instanceId);
+    };
+  });
+
+  describe('instance retrieval', function () {
+
+    it('gets details for each selected instance and maps it to instanceGroup', function () {
+      this.addInstance(this.serverGroupA, 'i-234');
+      this.addInstance(this.serverGroupB, 'g-234');
+      // no instances
+      this.getInstanceGroup(this.serverGroupC);
+      this.createController({ serverGroups: [this.serverGroupA, this.serverGroupB, this.serverGroupC]});
+
+      expect(ClusterFilterModel.multiselectInstanceGroups.length).toBe(3);
+      expect(controller.selectedGroups.length).toBe(2);
+
+      let groupA = controller.selectedGroups[0],
+          groupB = controller.selectedGroups[1];
+
+      expect(groupA.instances.length).toBe(1);
+      expect(groupA.serverGroup).toBe('asg-v001');
+
+      expect(groupB.instances.length).toBe(1);
+      expect(groupB.serverGroup).toBe('asg-v002');
+
+      expect(controller.instancesCount).toBe(2);
+    });
+
+    it('re-retrieves instances when application refreshes', function () {
+      let application = { serverGroups: [this.serverGroupA, this.serverGroupB, this.serverGroupC]};
+      this.addInstance(this.serverGroupA, 'i-234');
+      this.createController(application);
+
+      expect(controller.selectedGroups.length).toBe(1);
+      expect(controller.selectedGroups[0].instances[0].healthState).toBe('Up');
+
+      this.serverGroupA.instances[1].healthState = 'Down';
+      application.autoRefreshStream.onNext();
+
+      expect(controller.selectedGroups[0].instances[0].healthState).toBe('Down');
+    });
+
+    it('re-retrieves instances when multiselectInstancesStream refreshes', function () {
+      let application = { serverGroups: [this.serverGroupA, this.serverGroupB, this.serverGroupC]};
+      this.addInstance(this.serverGroupA, 'i-234');
+      this.createController(application);
+
+      expect(controller.selectedGroups.length).toBe(1);
+      expect(controller.selectedGroups[0].instances.length).toBe(1);
+
+      this.addInstance(this.serverGroupA, 'i-123');
+      // unchanged as stream hasn't emitted new value yet
+      expect(controller.selectedGroups[0].instances.length).toBe(1);
+
+      ClusterFilterModel.multiselectInstancesStream.onNext();
+
+      expect(controller.selectedGroups[0].instances.length).toBe(2);
+    });
+  });
+
+  describe('discovery actions', function () {
+    beforeEach(function () {
+      this.application = { serverGroups: [this.serverGroupA, this.serverGroupB, this.serverGroupC]};
+    });
+
+    it('can register with discovery when discovery is out of service for all selected instances', function () {
+      this.serverGroupA.instances.forEach((instance) => {
+        instance.health.push({type: 'Discovery', state: 'OutOfService'});
+        this.addInstance(this.serverGroupA, instance.id);
+      });
+      this.serverGroupB.instances.forEach((instance) => {
+        instance.health.push({type: 'Discovery', state: 'OutOfService'});
+        this.addInstance(this.serverGroupB, instance.id);
+      });
+      this.createController(this.application);
+      expect(controller.canRegisterWithDiscovery()).toBe(true);
+      expect(controller.canDeregisterWithDiscovery()).toBe(false);
+    });
+
+    it('can deregister with discovery when discovery is up for all selected instances', function () {
+      this.serverGroupA.instances.forEach((instance) => {
+        instance.health.push({type: 'Discovery', state: 'Up'});
+        this.addInstance(this.serverGroupA, instance.id);
+      });
+      this.serverGroupB.instances.forEach((instance) => {
+        instance.health.push({type: 'Discovery', state: 'Up'});
+        this.addInstance(this.serverGroupB, instance.id);
+      });
+      this.createController(this.application);
+      expect(controller.canDeregisterWithDiscovery()).toBe(true);
+      expect(controller.canRegisterWithDiscovery()).toBe(false);
+    });
+
+    it('has no discovery actions when some instance is not reporting discovery health', function () {
+      this.serverGroupA.instances.forEach((instance) => {
+        instance.health.push({type: 'Discovery', state: 'OutOfService'});
+        this.addInstance(this.serverGroupA, instance.id);
+      });
+      this.serverGroupB.instances.forEach((instance) => {
+        this.addInstance(this.serverGroupB, instance.id);
+      });
+      this.createController(this.application);
+      expect(controller.canRegisterWithDiscovery()).toBe(false);
+      expect(controller.canDeregisterWithDiscovery()).toBe(false);
+    });
+
+    it('has no discovery actions when instances have different discovery health states', function () {
+      this.serverGroupA.instances.forEach((instance) => {
+        instance.health.push({type: 'Discovery', state: 'Up'});
+        this.addInstance(this.serverGroupA, instance.id);
+      });
+      this.serverGroupB.instances.forEach((instance) => {
+        instance.health.push({type: 'Discovery', state: 'OutOfService'});
+        this.addInstance(this.serverGroupB, instance.id);
+      });
+      this.createController(this.application);
+      expect(controller.canDeregisterWithDiscovery()).toBe(false);
+      expect(controller.canRegisterWithDiscovery()).toBe(false);
+    });
+  });
+
+  describe('load balancer actions', function () {
+    beforeEach(function () {
+      this.application = { serverGroups: [this.serverGroupA, this.serverGroupB, this.serverGroupC]};
+      this.makeLoadBalancerHealth = () => {
+        return {type: 'LoadBalancer', loadBalancers: [{name: 'lb-1'}, {name: 'lb-2'}]};
+      };
+      this.serverGroupA.loadBalancers = [ 'lb-1', 'lb-2' ];
+      this.serverGroupB.loadBalancers = [ 'lb-2', 'lb-1' ];
+    });
+
+    it('can register with load balancers when server groups have the same load balancers and no instances have lb health', function () {
+      this.serverGroupA.instances.forEach((instance) => this.addInstance(this.serverGroupA, instance.id));
+      this.serverGroupB.instances.forEach((instance) => this.addInstance(this.serverGroupB, instance.id));
+      this.createController(this.application);
+      expect(controller.canRegisterWithLoadBalancers()).toBe(true);
+    });
+
+    it('cannot register with load balancers when server groups have the same load balancers but any instance has lb health', function () {
+      this.serverGroupA.instances.forEach((instance) => this.addInstance(this.serverGroupA, instance.id));
+      this.serverGroupB.instances.forEach((instance) => this.addInstance(this.serverGroupB, instance.id));
+      this.serverGroupB.instances[0].health.push({type: 'LoadBalancer'});
+      this.createController(this.application);
+      expect(controller.canRegisterWithLoadBalancers()).toBe(false);
+    });
+
+    it('cannot register with load balancers when server groups have different load balancers', function () {
+      this.serverGroupA.instances.forEach((instance) => this.addInstance(this.serverGroupA, instance.id));
+      this.serverGroupB.instances.forEach((instance) => this.addInstance(this.serverGroupB, instance.id));
+      this.serverGroupB.loadBalancers = [ 'lb-1', 'lb-3' ];
+      this.createController(this.application);
+      expect(controller.canRegisterWithLoadBalancers()).toBe(false);
+    });
+
+    it('cannot register with load balancers when server groups have no load balancers', function () {
+      this.serverGroupA.instances.forEach((instance) => this.addInstance(this.serverGroupA, instance.id));
+      this.serverGroupB.instances.forEach((instance) => this.addInstance(this.serverGroupB, instance.id));
+      this.serverGroupA.loadBalancers = [];
+      this.serverGroupB.loadBalancers = [];
+      this.createController(this.application);
+      expect(controller.canRegisterWithLoadBalancers()).toBe(false);
+    });
+
+    it('can deregister from load balancers when instances are registered with the all load balancers, which are the same', function () {
+      this.serverGroupA.instances.forEach((instance) => {
+        instance.health.push(this.makeLoadBalancerHealth());
+        this.addInstance(this.serverGroupA, instance.id);
+      });
+      this.serverGroupB.instances.forEach((instance) => {
+        instance.health.push(this.makeLoadBalancerHealth());
+        this.addInstance(this.serverGroupB, instance.id);
+      });
+      this.createController(this.application);
+      expect(controller.canDeregisterFromLoadBalancers()).toBe(true);
+    });
+
+    it('cannot deregister from load balancers when some instance is not registered', function () {
+      this.serverGroupA.instances.forEach((instance) => {
+        instance.health.push(this.makeLoadBalancerHealth());
+        this.addInstance(this.serverGroupA, instance.id);
+      });
+      this.serverGroupB.instances.forEach((instance) => this.addInstance(this.serverGroupB, instance.id));
+      this.createController(this.application);
+      expect(controller.canDeregisterFromLoadBalancers()).toBe(false);
+    });
+
+    it('cannot deregister from load balancers when some instance is registered with different load balancers', function () {
+      this.serverGroupA.instances.forEach((instance) => {
+        instance.health.push(this.makeLoadBalancerHealth());
+        this.addInstance(this.serverGroupA, instance.id);
+      });
+      this.serverGroupB.instances.forEach((instance) => {
+        let health = this.makeLoadBalancerHealth();
+        health.loadBalancers.push({name: 'lb-3'});
+        instance.health.push(health);
+        this.addInstance(this.serverGroupB, instance.id);
+      });
+      this.createController(this.application);
+      expect(controller.canDeregisterFromLoadBalancers()).toBe(false);
+    });
+
+    it('cannot deregister from load balancers when some server group has different load balancers', function () {
+      this.serverGroupA.instances.forEach((instance) => {
+        instance.health.push(this.makeLoadBalancerHealth());
+        this.addInstance(this.serverGroupA, instance.id);
+      });
+      this.serverGroupB.instances.forEach((instance) => {
+        instance.health.push(this.makeLoadBalancerHealth());
+        this.addInstance(this.serverGroupB, instance.id);
+      });
+      this.serverGroupB.loadBalancers = [ 'lb-2', 'lb-1', 'lb-3' ];
+      this.createController(this.application);
+      expect(controller.canDeregisterFromLoadBalancers()).toBe(false);
+    });
+  });
+});

--- a/app/scripts/modules/core/instance/details/multipleInstances.view.html
+++ b/app/scripts/modules/core/instance/details/multipleInstances.view.html
@@ -1,0 +1,42 @@
+<div class="details-panel">
+  <div class="header">
+    <div class="close-button">
+      <a class="btn btn-link"
+         ui-sref="^">
+        <span class="glyphicon glyphicon-remove"></span>
+      </a>
+    </div>
+    <div class="header-text">
+      <span class="glyphicon glyphicon-hdd {{vm.healthState}}"></span>
+      <h3>
+        {{vm.instancesCount}} Instance<span ng-if="vm.instancesCount !== 1">s</span>
+      </h3>
+    </div>
+    <div>
+      <div class="actions">
+        <div class="dropdown" uib-dropdown dropdown-append-to-body>
+          <button type="button" class="btn btn-sm btn-primary dropdown-toggle" ng-disabled="disabled" uib-dropdown-toggle>
+            Actions <span class="caret"></span>
+          </button>
+          <ul class="uib-dropdown-menu" role="menu">
+            <li><a href ng-click="vm.registerWithDiscovery()" ng-if="vm.canRegisterWithDiscovery()">Enable in Discovery</a></li>
+            <li><a href ng-click="vm.deregisterWithDiscovery()" ng-if="vm.canDeregisterWithDiscovery()">Disable in Discovery</a></li>
+            <li><a href ng-click="vm.registerWithLoadBalancers()" ng-if="vm.canRegisterWithLoadBalancers()">Register with Load Balancer</a></li>
+            <li><a href ng-click="vm.deregisterFromLoadBalancers()" ng-if="vm.canDeregisterFromLoadBalancers()">Deregister from Load Balancer</a></li>
+            <li role="presentation" class="divider"></li>
+            <li><a href ng-click="vm.rebootInstances()">Reboot</a></li>
+            <li><a href ng-click="vm.terminateInstances()">Terminate</a></li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="content">
+    <collapsible-section heading="Server Groups" expanded="true">
+      <multiple-instance-server-group ng-repeat="instanceGroup in vm.selectedGroups"
+                                      instance-group="instanceGroup">
+
+      </multiple-instance-server-group>
+    </collapsible-section>
+  </div>
+</div>

--- a/app/scripts/modules/core/instance/instance.module.js
+++ b/app/scripts/modules/core/instance/instance.module.js
@@ -8,4 +8,5 @@ module.exports = angular
   .module('spinnaker.core.instance', [
     require('./details/console/consoleOutputLink.directive.js'),
     require('./loadBalancer/instanceLoadBalancerHealth.directive.js'),
+    require('./details/multipleInstances.controller.js'),
   ]);

--- a/app/scripts/modules/core/instance/instance.write.service.spec.js
+++ b/app/scripts/modules/core/instance/instance.write.service.spec.js
@@ -1,21 +1,23 @@
 'use strict';
 
 describe('Service: instance writer', function () {
-  var service, serverGroupReader, taskExecutor, $q, $scope;
+  var service, serverGroupReader, taskExecutor, $q, $scope, ClusterFilterModel;
 
   beforeEach(
     window.module(
-      require('./instance.write.service')
+      require('./instance.write.service'),
+      require('../cluster/filter/clusterFilter.model')
     )
   );
 
   beforeEach(
-    window.inject(function(instanceWriter, _taskExecutor_, _serverGroupReader_, _$q_, $rootScope) {
+    window.inject(function(instanceWriter, _taskExecutor_, _serverGroupReader_, _$q_, $rootScope, _ClusterFilterModel_) {
       service = instanceWriter;
       taskExecutor = _taskExecutor_;
       serverGroupReader = _serverGroupReader_;
       $q = _$q_;
       $scope = $rootScope.$new();
+      ClusterFilterModel = _ClusterFilterModel_;
     })
   );
 
@@ -51,6 +53,94 @@ describe('Service: instance writer', function () {
       expect(executedTask.setMaxToNewDesired).toBe(true);
     });
 
+  });
+
+  describe('multi-instance operations', function () {
+    beforeEach(function () {
+      this.task = null;
+      this.serverGroupA = { type: 'aws', name: 'asg-v001', account: 'prod', region: 'us-east-1' };
+      this.serverGroupB = { type: 'gce', name: 'asg-v002', account: 'test', region: 'us-west-1' };
+
+      this.getInstanceGroup = (serverGroup) => {
+        return ClusterFilterModel.getOrCreateMultiselectInstanceGroup(serverGroup);
+      };
+
+      this.addInstance = (serverGroup, instance) => {
+        let instanceGroup = this.getInstanceGroup(serverGroup);
+        instanceGroup.instanceIds.push(instance.id);
+        instanceGroup.instances.push(instance);
+      };
+
+      spyOn(taskExecutor, 'executeTask').and.callFake((task) => this.task = task);
+    });
+
+    it('only sends jobs for groups with instances', function () {
+      let application = {};
+      this.addInstance(this.serverGroupB, {id: 'i-234'});
+      this.addInstance(this.serverGroupB, {id: 'i-345'});
+      service.terminateInstances(
+        [this.getInstanceGroup(this.serverGroupA), this.getInstanceGroup(this.serverGroupB)],
+        application);
+
+      expect(this.task.job.length).toBe(1);
+
+      let job = this.task.job[0];
+
+      expect(job.type).toBe('terminateInstances');
+      expect(job.instanceIds).toEqual(['i-234', 'i-345']);
+      expect(job.region).toBe('us-west-1');
+      expect(job.cloudProvider).toBe('gce');
+      expect(job.credentials).toBe('test');
+      expect(job.serverGroupName).toBe('asg-v002');
+    });
+
+    it('includes a useful descriptor on terminate instances', function () {
+      let application = {};
+      this.addInstance(this.serverGroupA, {id: 'i-123', zone: 'a', launchTime: 2});
+
+      service.terminateInstances([this.getInstanceGroup(this.serverGroupA)], application);
+      expect(this.task.description).toBe('Terminate 1 instance');
+
+      this.addInstance(this.serverGroupA, {id: 'i-1234', zone: 'a', launchTime: 1});
+      service.terminateInstances([this.getInstanceGroup(this.serverGroupA)], application);
+      expect(this.task.description).toBe('Terminate 2 instances');
+    });
+
+    it('includes a useful descriptor on reboot instances', function () {
+      let application = {};
+      this.addInstance(this.serverGroupA, {id: 'i-123', zone: 'a', launchTime: 2});
+
+      service.rebootInstances([this.getInstanceGroup(this.serverGroupA)], application);
+      expect(this.task.description).toBe('Reboot 1 instance');
+
+      this.addInstance(this.serverGroupA, {id: 'i-1234', zone: 'a', launchTime: 1});
+      service.rebootInstances([this.getInstanceGroup(this.serverGroupA)], application);
+      expect(this.task.description).toBe('Reboot 2 instances');
+    });
+
+    it('includes a useful descriptor on disable in discovery', function () {
+      let application = {};
+      this.addInstance(this.serverGroupA, {id: 'i-123', zone: 'a', launchTime: 2});
+
+      service.disableInstancesInDiscovery([this.getInstanceGroup(this.serverGroupA)], application);
+      expect(this.task.description).toBe('Disable 1 instance in discovery');
+
+      this.addInstance(this.serverGroupA, {id: 'i-1234', zone: 'a', launchTime: 1});
+      service.disableInstancesInDiscovery([this.getInstanceGroup(this.serverGroupA)], application);
+      expect(this.task.description).toBe('Disable 2 instances in discovery');
+    });
+
+    it('includes a useful descriptor on enable in discovery', function () {
+      let application = {};
+      this.addInstance(this.serverGroupA, {id: 'i-123', zone: 'a', launchTime: 2});
+
+      service.enableInstancesInDiscovery([this.getInstanceGroup(this.serverGroupA)], application);
+      expect(this.task.description).toBe('Enable 1 instance in discovery');
+
+      this.addInstance(this.serverGroupA, {id: 'i-1234', zone: 'a', launchTime: 1});
+      service.enableInstancesInDiscovery([this.getInstanceGroup(this.serverGroupA)], application);
+      expect(this.task.description).toBe('Enable 2 instances in discovery');
+    });
   });
 
 });

--- a/app/scripts/modules/core/instance/instanceList.directive.html
+++ b/app/scripts/modules/core/instance/instanceList.directive.html
@@ -1,8 +1,7 @@
 <table ng-if="instances.length" class="table table-hover table-condensed instances">
   <thead>
   <tr>
-    <!-- use this when multi-select is a thing -->
-    <!--<th width="4%"><input type="checkbox"></th>-->
+    <th width="4%"><input type="checkbox" ng-checked="instanceGroup.selectAll" ng-click="selectAllClicked($event)"/></th>
     <th width="{{::columnWidth.id}}%" sort-toggle key="id" label="Instance" sort-model="sortFilter.instanceSort" on-change="applyParamsToUrl()"></th>
     <th width="{{::columnWidth.launchTime}}%" sort-toggle key="launchTime" label="Launch Time" default="true" sort-model="sortFilter.instanceSort" on-change="applyParamsToUrl()"></th>
     <th width="{{::columnWidth.zone}}%" sort-toggle key="availabilityZone" label="Zone" sort-model="sortFilter.instanceSort" on-change="applyParamsToUrl()"></th>
@@ -14,6 +13,7 @@
   </thead>
   <tbody class="instance-list-body"
          instances="instances"
+         server-group="serverGroup"
          has-load-balancers="hasLoadBalancers"
          has-discovery="hasDiscovery"
          show-provider-health="showProviderHealth"

--- a/app/scripts/modules/core/navigation/states.provider.js
+++ b/app/scripts/modules/core/navigation/states.provider.js
@@ -74,6 +74,23 @@ module.exports = angular.module('spinnaker.core.navigation.states.provider', [
         }
       };
 
+      var multipleInstances = {
+        name: 'multipleInstances',
+        url: '/multipleInstances',
+        views: {
+          'detail@../insight': {
+            templateUrl: require('../instance/details/multipleInstances.view.html'),
+            controller: 'MultipleInstancesCtrl',
+            controllerAs: 'vm'
+          }
+        },
+        data: {
+          pageTitleDetails: {
+            title: 'Multiple Instances',
+          },
+        }
+      };
+
       var serverGroupDetails = {
         name: 'serverGroup',
         url: '/serverGroupDetails/:provider/:accountId/:region/:serverGroup',
@@ -242,6 +259,7 @@ module.exports = angular.module('spinnaker.core.navigation.states.provider', [
             serverGroupDetails,
             instanceDetails,
             securityGroupDetails,
+            multipleInstances,
           ],
         },
         {

--- a/app/scripts/modules/core/serverGroup/serverGroup.directive.html
+++ b/app/scripts/modules/core/serverGroup/serverGroup.directive.html
@@ -42,6 +42,7 @@
         <instance-list instances="viewModel.instances"
                        sort-filter="sortFilter"
                        has-discovery="hasDiscovery"
+                       server-group="viewModel.serverGroup"
                        has-load-balancers="hasLoadBalancers"></instance-list>
       </div>
     </div>

--- a/test/mock/mockApplicationData.js
+++ b/test/mock/mockApplicationData.js
@@ -8,10 +8,10 @@ module.exports = angular
         { name: 'in-us-west-1-only', account: 'test', region: 'us-west-1'},
       ],
       serverGroups: [
-        {cluster: 'in-eu-east-2-only', 'account': 'prod', region: 'eu-east-2', instances: [],
+        {cluster: 'in-eu-east-2-only', 'account': 'prod', region: 'eu-east-2', instances: [], name: 'in-eu-east-2-only',
           instanceCounts: {total: 0, up: 0, down: 0, unknown: 0, starting: 0, outOfService: 0 },
           isDisabled: true, type:'gce', instanceType: 'm3.medium', vpcName: ''},
-        {cluster: 'in-us-west-1-only', 'account': 'test', region: 'us-west-1', instances: [ {} ],
+        {cluster: 'in-us-west-1-only', 'account': 'test', region: 'us-west-1', instances: [ {} ], name: 'in-us-west-1-only',
           instanceCounts: {total: 1, up: 0, down: 1, unknown: 0, starting: 0, outOfService: 0},
           isDisabled: false, type: 'aws', instanceType: 'm3.large', vpcName: 'Main'},
       ]
@@ -31,6 +31,7 @@ module.exports = angular
             account : 'prod',
             region : 'eu-east-2',
             instances : [  ],
+            name: 'in-eu-east-2-only',
             instanceCounts: {
               total: 0,
               up: 0,
@@ -59,6 +60,7 @@ module.exports = angular
               account : 'test',
               region : 'us-west-1',
               instances : [ {} ],
+              name: 'in-us-west-1-only',
               instanceCounts: {
                 total: 1,
                 up: 0,


### PR DESCRIPTION
Note: this is for review only right now. I'd like to get @ttomsu 's https://github.com/spinnaker/deck/pull/1809 in first, then rebase against it and clean up the write operations (remove launch time, maybe more?).

This PR adds the ability to perform a handful of actions against multiple instances at the same time. To enable this behavior, the "with details" checkbox must be selected in the clusters view, then the user must click the individual checkboxes next to each instance (or click the "select all" checkbox in the table header for a given server group).

There are five components responsible for managing the state of selection:
* `clusterFilterService`: removes selected instances when the user changes filters, causing an instance to no longer be present on the screen, or instances disappear (due to a server group being deleted, instances being terminated, etc.); also adds instances when `selectAll` is enabled for a given server group and either: a) it reappears after having been removed by some filter or b) a new instance appears
* `ClusterFilterModel`: tracks the state of selected instances, provides the API other components use to toggle instance selection; synchronizes navigation state (hiding details when no instances are selected, showing details when some instance is selected)
* `multipleInstancesController`: determines which actions are available for the selected instances
* `instanceList` directive: handles select-all dispatch to `ClusterFilterModel`
* `instanceListBody` directive: handles individual instance toggling

@zanthrash feel free to review this if you see this in the next day or two; otherwise, don't worry, it's (almost) the same code we reviewed last week that I promised would be done five days ago.
