### PR TITLE
bigger checkboxes, less horrid performance on instance list with > 2k…

### DIFF
--- a/app/scripts/modules/core/cluster/filter/clusterFilter.model.js
+++ b/app/scripts/modules/core/cluster/filter/clusterFilter.model.js
@@ -132,6 +132,10 @@ module.exports = angular
       return filterModel.hasSavedState(toParams) && !isClusterStateOrChild(fromState.name);
     }
 
+    function changingApplications(toParams, fromParams) {
+      return toParams.application !== fromParams.application;
+    }
+
     // WHY??? Because, when the stateChangeStart event fires, the $location.search() will return whatever the query
     // params are on the route we are going to, so if the user is using the back button, for example, to go to the
     // Infrastructure page with a search already entered, we'll pick up whatever search was entered there, and if we
@@ -148,7 +152,7 @@ module.exports = angular
     });
 
     this.handleStateChangeStart = (event, toState, toParams, fromState, fromParams) => {
-      if (toState.name.indexOf('multipleInstances') < 0) {
+      if (movingFromClusterState(toState, fromState) || changingApplications(toParams, fromParams)) {
         this.multiselectInstanceGroups.length = 0;
         this.multiselectInstancesStream.onNext();
       }

--- a/app/scripts/modules/core/cluster/filter/clusterFilter.model.spec.js
+++ b/app/scripts/modules/core/cluster/filter/clusterFilter.model.spec.js
@@ -187,22 +187,38 @@ describe('Cluster Filter Model', function () {
     });
 
     describe('state change start event', function () {
-      it('clears multiselectInstanceGroups when navigating away from multipleInstances', function () {
-        let newState = { name: '.clusters' },
-            oldState = { name: '.multipleInstances' };
+      it('clears multiselectInstanceGroups when navigating away from clusters view', function () {
+        let oldState = { name: 'home.applications.application.insight.clusters' },
+            newState = { name: 'home.applications.application.insight.loadBalancers' },
+            oldParams = { application: 'a' },
+            newParams = { application: 'a' };
         ClusterFilterModel.multiselectInstanceGroups = [ 'it does not matter, we are just verifying the array is cleared'];
 
-        ClusterFilterModel.handleStateChangeStart(null, newState, null, oldState, null);
+        ClusterFilterModel.handleStateChangeStart(null, newState, newParams, oldState, oldParams);
+        expect(ClusterFilterModel.multiselectInstanceGroups).toEqual([]);
+      });
+
+      it('clears multiselectInstanceGroups when navigating to a different application', function () {
+        let oldState = { name: 'home.applications.application.insight.clusters' },
+            newState = { name: 'home.applications.application.insight.clusters' },
+            oldParams = { application: 'a' },
+            newParams = { application: 'b' };
+        ClusterFilterModel.multiselectInstanceGroups = [ 'it does not matter, we are just verifying the array is cleared'];
+
+        ClusterFilterModel.handleStateChangeStart(null, newState, newParams, oldState, oldParams);
         expect(ClusterFilterModel.multiselectInstanceGroups).toEqual([]);
       });
 
       it('preserves multiselectInstanceGroups when navigating to multipleInstances', function () {
-        let oldState = { name: '.clusters' },
-            newState = { name: '.multipleInstances' },
+        let oldState = { name: 'home.applications.application.insight.clusters' },
+            newState = { name: 'clusters.multipleInstances' },
+            oldParams = { application: 'a' },
+            newParams = { application: 'a' },
             oldGroups = [ 'a', 'b', 'c', 'just testing it does not get cleared'];
+
         ClusterFilterModel.multiselectInstanceGroups = oldGroups;
 
-        ClusterFilterModel.handleStateChangeStart(null, newState, null, oldState, null);
+        ClusterFilterModel.handleStateChangeStart(null, newState, newParams, oldState, oldParams);
         expect(ClusterFilterModel.multiselectInstanceGroups.length).toBe(4);
       });
     });

--- a/app/scripts/modules/core/cluster/rollups.less
+++ b/app/scripts/modules/core/cluster/rollups.less
@@ -72,6 +72,11 @@
   line-height: 10px;
   border-radius: 2px;
   padding-bottom: 5px;
+  input[type="checkbox"] {
+    transform: scale(1.25);
+    -webkit-transform: scale(1.25);
+    margin: 0;
+  }
   tr.instance-row:hover > td.no-hover {
     background-color: #ffffff;
     cursor: default;

--- a/app/scripts/modules/core/instance/instances.directive.js
+++ b/app/scripts/modules/core/instance/instances.directive.js
@@ -15,8 +15,7 @@ module.exports = angular.module('spinnaker.core.instance.instances.directive', [
       },
       link: function (scope, elem) {
         var $state = scope.$parent.$state;
-        let lastRender = '',
-            tooltipsApplied = false;
+        let tooltipsApplied = false;
 
         var base = elem.parent().inheritedData('$uiView').state;
 
@@ -41,13 +40,12 @@ module.exports = angular.module('spinnaker.core.instance.instances.directive', [
                 '" class="instance health-status-' + instance.healthState + activeClass + '"></a>';
             }).join('') + '</div>';
 
-          if (innerHtml !== lastRender) {
+          if (innerHtml !== elem.get(0).innerHTML) {
             if (tooltipsApplied) {
               $('[data-toggle="tooltip"]', elem).tooltip('destroy');
               tooltipsApplied = false;
             }
             elem.get(0).innerHTML = innerHtml;
-            lastRender = innerHtml;
           }
         }
 
@@ -95,7 +93,6 @@ module.exports = angular.module('spinnaker.core.instance.instances.directive', [
           }
           elem.unbind('mouseover');
           elem.unbind('click');
-          lastRender = null;
         });
 
         scope.$watch('instances', renderInstances);


### PR DESCRIPTION
… instances

With no labels, the checkboxes are really too small to consistently click in the instance list view to enable multi-select, so we are bumping them out to be 25% bigger.

Also reducing the number of re-renders we perform instead of blindly always re-rendering every instance list on the page whenever any checkbox is clicked.

Finally, not re-rendering if the `innerHTML` is unchanged, which means we don't have to store the previous render, which cuts memory usage by an embarrassingly large amount (50-75MB on very big applications).

@zanthrash please review