### PR TITLE
Execution tweaks

### DIFF
--- a/app/scripts/modules/core/delivery/details/executionDetails.less
+++ b/app/scripts/modules/core/delivery/details/executionDetails.less
@@ -38,9 +38,16 @@ execution {
       padding: 15px;
     }
 
+    .execution-details-summary {
+      h6.duration {
+        margin-top: 0;
+      }
+    }
     .execution-details-title {
       text-transform: uppercase;
       font-weight: 600;
+      margin-bottom: 0;
+      padding-bottom: 5px;
       .btn-group {
         margin-left: 20px;
         text-transform: none;

--- a/app/scripts/modules/core/pipeline/config/graph/pipelineGraph.directive.html
+++ b/app/scripts/modules/core/pipeline/config/graph/pipelineGraph.directive.html
@@ -12,22 +12,6 @@
           ng-attr-stroke="{{link.color}}"
           ng-attr-transform="translate({{0-stage.x}}, {{0-stage.y}})"></path>
 
-
-    <foreignobject ng-attr-width="{{maxLabelWidth}}" height="100"
-                   ng-attr-transform="translate({{labelOffsetX}}, {{stage.leaf && !stage.executionStage ? -8 : labelOffsetY*-1}})">
-      <div class="execution-stage-label clickable {{stage.status.toLowerCase()}}"
-           ng-if="stage.labelTemplateUrl"
-           ng-mouseenter="highlight(stage)" ng-mouseleave="removeHighlight(stage)"
-           ng-style="{height: stage.height + 'px'}"
-           ng-click="nodeClicked(stage)">
-        <div ng-include="stage.labelTemplateUrl"></div>
-      </div>
-      <div class="label-body node"
-           ng-if="!stage.labelTemplateUrl"
-           ng-mouseenter="highlight(stage)" ng-mouseleave="removeHighlight(stage)"
-           ng-click="nodeClicked(stage)"><a href>{{stage.name}}</a></div>
-    </foreignobject>
-
     <circle ng-attr-r="{{nodeRadius}}"
             class="clickable stage-type-{{stage.masterStage.type.toLowerCase()}} execution-marker execution-marker-{{stage.status.toLowerCase()}}"
             ng-class="{active: stage.isActive}"
@@ -53,5 +37,22 @@
           ng-mouseenter="highlight(stage)" ng-mouseleave="removeHighlight(stage)"
           ng-click="nodeClicked(stage)"></rect>
 
+  </g>
+
+  <g ng-repeat="stage in allNodes" ng-class="{'has-status': stage.status, active: stage.isActive, highlighted: stage.isHighlighted}" ng-attr-transform="translate({{stage.x}},{{stage.y}})">
+    <foreignobject ng-attr-width="{{maxLabelWidth}}" height="100"
+                   ng-attr-transform="translate({{labelOffsetX}}, {{stage.leaf && !stage.executionStage ? -8 : labelOffsetY*-1}})">
+      <div class="execution-stage-label clickable {{stage.status.toLowerCase()}}"
+           ng-if="stage.labelTemplateUrl"
+           ng-mouseenter="highlight(stage)" ng-mouseleave="removeHighlight(stage)"
+           ng-style="{height: stage.height + 'px'}"
+           ng-click="nodeClicked(stage)">
+        <div ng-include="stage.labelTemplateUrl"></div>
+      </div>
+      <div class="label-body node"
+           ng-if="!stage.labelTemplateUrl"
+           ng-mouseenter="highlight(stage)" ng-mouseleave="removeHighlight(stage)"
+           ng-click="nodeClicked(stage)"><a href>{{stage.name}}</a></div>
+    </foreignobject>
   </g>
 </svg>

--- a/app/scripts/modules/core/pipeline/config/stages/core/executionSummary.html
+++ b/app/scripts/modules/core/pipeline/config/stages/core/executionSummary.html
@@ -1,4 +1,4 @@
-<div>
+<div class="execution-details-summary">
   <h5 class="execution-details-title">
     {{stageSummary.name || stageSummary.type }} Details
 
@@ -12,6 +12,7 @@
       </ul>
     </div>
   </h5>
+  <h6 class="duration">Duration: {{stageSummary.runningTimeInMs | duration}}</h6>
 
   <table class="table">
     <thead>

--- a/app/scripts/modules/netflix/pipeline/stage/canary/canaryExecutionSummary.html
+++ b/app/scripts/modules/netflix/pipeline/stage/canary/canaryExecutionSummary.html
@@ -2,10 +2,6 @@
   <h5 class="execution-details-title">
     {{stageSummary.name || stageSummary.type }} Details
 
-    <!--<span style="margin-left: 50px" class="label label-default label-{{ stageSummary.masterStage.context.canary.status.status | lowercase }}">-->
-      <!--{{ stageSummary.masterStage.context.canary.status.status | lowercase | robotToHuman }}-->
-    <!--</span>-->
-
     <div ng-if="stageSummary.masterStage.context.canary.status.status === 'LAUNCHED' ||
                 stageSummary.masterStage.context.canary.status.status === 'RUNNING' ||
                 stageSummary.masterStage.context.canary.status.status === 'DISABLED'" uib-dropdown class="btn-group pull-right">
@@ -19,6 +15,7 @@
       </ul>
     </div>
   </h5>
+  <h6 class="duration">Duration: {{stageSummary.runningTimeInMs | duration}}</h6>
   <table class="table canary-summary">
     <thead>
     <tr>


### PR DESCRIPTION
Two things:

1. Include the duration of the overall stage in the summary view
<img width="534" alt="screen shot 2016-01-05 at 9 05 06 pm" src="https://cloud.githubusercontent.com/assets/73450/12135403/10881c06-b3f0-11e5-9887-1bff8962bb99.png">

2. Render the graph labels _after_ all the links have been drawn to make sure the links never overlap the labels
_Current_
<img width="721" alt="screen shot 2016-01-05 at 9 06 13 pm" src="https://cloud.githubusercontent.com/assets/73450/12135424/35ca03e4-b3f0-11e5-9d67-fd8ec6e44f66.png">
_With this PR_
<img width="755" alt="screen shot 2016-01-05 at 9 06 24 pm" src="https://cloud.githubusercontent.com/assets/73450/12135427/3d1318c0-b3f0-11e5-8ced-738055d3ac44.png">

@dzapata does this look reasonable?