### PR TITLE
handle cut/paste/blur events on global search

### DIFF
--- a/app/scripts/modules/core/search/global/globalSearch.controller.js
+++ b/app/scripts/modules/core/search/global/globalSearch.controller.js
@@ -27,6 +27,13 @@ module.exports = angular.module('spinnaker.core.search.global.controller', [
       $element.find('input').focus();
     }
 
+    this.searchFieldBlurred = ($blurEvent) => {
+      // if the target is outside the global search (e.g. shift+tab), hide the results
+      if (!$.contains($element.get(0), $blurEvent.relatedTarget)) {
+        this.hideResults();
+      }
+    };
+
     this.displayResults = () => {
       if ($scope.query) {
         $scope.showSearchResults = true;
@@ -137,6 +144,12 @@ module.exports = angular.module('spinnaker.core.search.global.controller', [
       var $target = $(event.target);
       if (event.which === 27) { // escape
         reset();
+      }
+      if (event.which === 9) { // tab - let it navigate automatically, but close menu if on the last result
+        if ($element.find('ul.dropdown-menu').find('a').last().is(':focus')) {
+          ctrl.hideResults();
+          return;
+        }
       }
       if (event.which === 40) { // down
         ctrl.focussedResult = null;

--- a/app/scripts/modules/core/search/global/globalSearch.directive.html
+++ b/app/scripts/modules/core/search/global/globalSearch.directive.html
@@ -3,11 +3,14 @@
     <div class="form-group has-feedback">
       <div class="input-group">
         <input type="search"
-          class="form-control flat"
-          placeholder="Search"
-          ng-model="query"
-          ng-focus="ctrl.displayResults()"
-          ng-keyup="ctrl.dispatchQueryInput($event)"
+               class="form-control flat"
+               placeholder="Search"
+               ng-model="query"
+               ng-focus="ctrl.displayResults()"
+               ng-keyup="ctrl.dispatchQueryInput($event)"
+               ng-blur="ctrl.searchFieldBlurred($event)"
+               ng-paste="ctrl.dispatchQueryInput($event)"
+               ng-cut="ctrl.dispatchQueryInput($event)"
           />
         <span class="glyphicon glyphicon-search form-control-feedback"></span>
       </div>


### PR DESCRIPTION
Right now, if you click in the search box and paste some text, nothing happens. If you select the text and cut it, first of all, why are you doing that, second, fine, we should handle that gracefully. Also, if you are using the tab key to navigate the results, we should hide them if you navigate away from the menu altogether.

@zanthrash or @duftler please review if you have a minute.