### PR TITLE
debian default doc root is moved from /var/www to /var/www/html in th…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ ospackage {
   packageName = "spinnaker-deck"
   version = toVers(project.version.toString())
   release '3'
-  into "/var/www"
+  into "/var/www/html"
   requires "apache2"
   from "build/webpack"
 }


### PR DESCRIPTION
debian default doc root is moved from /var/www to /var/www/html in the apache2 package, install deck in /var/www/html

This change installs deck into /var/www/html so it is ready to use straight after the installation of the deb package.

http://stackoverflow.com/questions/21660621/why-has-the-apache2-www-dir-been-moved-to-var-www-html