### PR TITLE
generate start time of stage summary from child stages

### DIFF
--- a/app/scripts/modules/core/delivery/service/executions.transformer.service.js
+++ b/app/scripts/modules/core/delivery/service/executions.transformer.service.js
@@ -138,6 +138,16 @@ module.exports = angular.module('spinnaker.core.delivery.executionTransformer.se
       return currentStages;
     }
 
+    // TODO: remove if we ever figure out why quickPatchAsgStage never has a startTime
+    function setMasterStageStartTime(stages, stage) {
+      let allStartTimes = stages
+        .filter((child) => child.startTime)
+        .map((child) => child.startTime);
+      if (allStartTimes.length) {
+        stage.startTime = Math.min(...allStartTimes);
+      }
+    }
+
     function transformStage(stage) {
       var stages = flattenAndFilter(stage);
 
@@ -145,10 +155,9 @@ module.exports = angular.module('spinnaker.core.delivery.executionTransformer.se
         return;
       }
 
-
       if (stage.masterStage) {
         var lastStage = stages[stages.length - 1];
-        stage.startTime = stages[0].startTime;
+        setMasterStageStartTime(stages, stage);
         var lastNotStartedStage = _(stages).findLast(
           function (childStage) {
             return !childStage.hasNotStarted;

--- a/app/scripts/modules/core/delivery/service/executions.transformer.service.spec.js
+++ b/app/scripts/modules/core/delivery/service/executions.transformer.service.spec.js
@@ -188,5 +188,18 @@ describe('executionTransformerService', function() {
       expect(nested.startTime).toBe(8);
       expect(nested.endTime).toBe(9);
     });
+
+    it('should add startTime to stage summary based on min of child stage start times if first stage has no start time', function () {
+      var execution = {
+        stages: [
+          { id: '2', name: 'deploy', status: 'COMPLETED', startTime: null, endTime: 8 },
+          { id: '4', parentStageId: '2', syntheticStageOwner: 'STAGE_BEFORE', status: 'COMPLETED', startTime: null, endTime: 6},
+          { id: '5', parentStageId: '2', syntheticStageOwner: 'STAGE_BEFORE', status: 'COMPLETED', startTime: 11, endTime: 9},
+          { id: '6', parentStageId: '2', syntheticStageOwner: 'STAGE_AFTER', status: 'COMPLETED', startTime: 4, endTime: 11 },
+        ]
+      };
+      this.transformer.transformExecution({}, execution);
+      expect(execution.stageSummaries[0].startTime).toBe(4);
+    });
   });
 });


### PR DESCRIPTION
Somehow, the quick patch stage always has a `null` start time, which messes up duration calculations. Until we can figure out _why_ that is the case, this will set its start time (and the start time of other stage summaries) to the min value of any child stage.

@zanthrash @ajordens please review