### PR TITLE
use font-size instead of scale to size checkboxes

### DIFF
--- a/app/scripts/modules/core/cluster/rollups.less
+++ b/app/scripts/modules/core/cluster/rollups.less
@@ -73,8 +73,7 @@
   border-radius: 2px;
   padding-bottom: 5px;
   input[type="checkbox"] {
-    transform: scale(1.25);
-    -webkit-transform: scale(1.25);
+    font-size: 200%;
     margin: 0;
   }
   tr.instance-row:hover > td.no-hover {


### PR DESCRIPTION
instead of pixelated garbage like this:
![screen shot 2016-01-14 at 12 01 44 pm](https://cloud.githubusercontent.com/assets/73450/12335992/c8e4fafe-bab6-11e5-8eda-23c8d96c9569.png)

get normal looking checkboxes like this:
![screen shot 2016-01-14 at 12 03 45 pm](https://cloud.githubusercontent.com/assets/73450/12336013/e5fc0cb8-bab6-11e5-8321-fab20c7e6b37.png)


cc @cfieber 