### PR TITLE
allow users to configure scaling processes when creating new ASG

### DIFF
--- a/app/scripts/modules/amazon/serverGroup/configure/serverGroupConfiguration.service.js
+++ b/app/scripts/modules/amazon/serverGroup/configure/serverGroupConfiguration.service.js
@@ -14,11 +14,12 @@ module.exports = angular.module('spinnaker.aws.serverGroup.configure.service', [
   require('../../../core/cache/cacheInitializer.js'),
   require('../../../core/utils/lodash.js'),
   require('../../../core/serverGroup/configure/common/serverGroupCommand.registry.js'),
+  require('../details/scalingProcesses/autoScalingProcess.service.js'),
 ])
   .factory('awsServerGroupConfigurationService', function($q, awsImageReader, accountService, securityGroupReader,
                                                           awsInstanceTypeService, cacheInitializer, namingService,
                                                           subnetReader, keyPairsReader, loadBalancerReader, _,
-                                                          serverGroupCommandRegistry) {
+                                                          serverGroupCommandRegistry, autoScalingProcessService) {
 
 
     var healthCheckTypes = ['EC2', 'ELB'],
@@ -70,6 +71,7 @@ module.exports = angular.module('spinnaker.aws.serverGroup.configure.service', [
         var instanceTypeReloader = $q.when(null);
         backingData.accounts = _.keys(backingData.regionsKeyedByAccount);
         backingData.filtered = {};
+        backingData.scalingProcesses = autoScalingProcessService.listProcesses();
         command.backingData = backingData;
         configureVpcId(command);
 

--- a/app/scripts/modules/amazon/serverGroup/configure/wizard/advancedSettings.html
+++ b/app/scripts/modules/amazon/serverGroup/configure/wizard/advancedSettings.html
@@ -97,13 +97,17 @@
       </div>
     </div>
     <div class="form-group">
-      <div class="col-md-5 sm-label-left"><b>Enable Traffic</b></div>
+      <div class="col-md-5 sm-label-left"><b>Scaling Processes</b></div>
       <div class="col-md-6 checkbox">
-        <label><input type="checkbox"
-                      ng-click="command.toggleSuspendedProcess('AddToLoadBalancer')"
-                      ng-checked="!command.processIsSuspended('AddToLoadBalancer')"/>
-          Send client requests to new instances
-        </label>
+        <div ng-repeat="process in command.backingData.scalingProcesses">
+          <label>
+            <input type="checkbox"
+                   ng-click="command.toggleSuspendedProcess(process.name)"
+                   ng-checked="!command.processIsSuspended(process.name)"/>
+            {{process.name}}
+            <help-field content="{{process.description}}"></help-field>
+          </label>
+        </div>
       </div>
     </div>
     <div class="form-group" ng-if="application.attributes.platformHealthOnlyShowOverride">

--- a/app/scripts/modules/amazon/serverGroup/details/scalingProcesses/autoScalingProcess.service.js
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingProcesses/autoScalingProcess.service.js
@@ -76,6 +76,7 @@ module.exports = angular.module('spinnaker.serverGroup.details.aws.autoscaling.p
     }
 
     return {
+      listProcesses: listProcesses,
       normalizeScalingProcesses: normalizeScalingProcesses,
       getDisabledDate: getDisabledDate,
     };


### PR DESCRIPTION
It's the *advanced* settings screen, where users would expect to have this level of control over their ASG configuration.

<img width="534" alt="screen shot 2016-01-19 at 9 33 26 am" src="https://cloud.githubusercontent.com/assets/73450/12426680/bff0e836-be8f-11e5-9042-45ed5e39eda8.png">


@zanthrash please review