### PR TITLE
Add 'Show Advanced Options' to Google bake stage configuration, with …

### DIFF
--- a/app/scripts/modules/core/help/helpContents.js
+++ b/app/scripts/modules/core/help/helpContents.js
@@ -154,6 +154,7 @@ module.exports = angular.module('spinnaker.core.help.contents', [])
     'pipeline.config.bake.amiSuffix': '<p>(Optional) String of date in format YYYYMMDDHHmm, default is calculated from timestamp,</p>',
     'pipeline.config.bake.enhancedNetworking': '<p>(Optional) Enable enhanced networking (sr-iov) support for image (requires hvm and trusty base_os).</p>',
     'pipeline.config.bake.amiName': '<p>(Optional) Default = $package-$arch-$ami_suffix-$store_type</p>',
+    'pipeline.config.gce.bake.baseImage': '<p>(Optional) A GCE image name. For example: ubuntu-1204-precise-v20150910.</p>',
     'pipeline.config.manualJudgment.instructions': '<p>(Optional) Instructions are shown to the user when making a manual judgment.</p><p>May contain HTML.</p>',
     'pipeline.config.manualJudgment.failPipeline': '' +
       '<p><strong>Checked</strong> - the overall pipeline will fail whenever the manual judgment is negative.</p>' +

--- a/app/scripts/modules/core/pipeline/config/stages/bake/gce/bakeExecutionDetails.html
+++ b/app/scripts/modules/core/pipeline/config/stages/bake/gce/bakeExecutionDetails.html
@@ -32,6 +32,7 @@
     <div class="row" ng-if="stage.context.region && stage.context.status.resourceId">
       <div class="col-md-12">
         <div class="alert alert-{{stage.isFailed ? 'danger' : 'info'}}">
+          <div ng-if="stage.context.previouslyBaked">No changes detected; reused existing bake</div>
           <a target="_blank" href="{{ bakeryDetailUrl(stage) }}">
             View Bakery Details
           </a>

--- a/app/scripts/modules/core/pipeline/config/stages/bake/gce/bakeStage.html
+++ b/app/scripts/modules/core/pipeline/config/stages/bake/gce/bakeStage.html
@@ -32,4 +32,20 @@
       </label>
     </div>
   </stage-config-field>
+  <div class="form-group">
+    <div class="col-md-9 col-md-offset-1">
+      <div class="checkbox">
+        <label>
+          <input type="checkbox" ng-model="stage.showAdvancedOptions">
+          <strong>Show Advanced Options</strong>
+        </label>
+      </div>
+    </div>
+  </div>
+  <div ng-class="{collapse: stage.showAdvancedOptions !== true, 'collapse.in': stage.showAdvancedOptions === true}">
+    <stage-config-field label="Base Image" help-key="pipeline.config.gce.bake.baseImage">
+      <input type="text" class="form-control input-sm"
+             ng-model="stage.baseAmi"/>
+    </stage-config-field>
+  </div>
 </div>


### PR DESCRIPTION
…a child 'Base Image' control.
Add support for 'No changes detected; reused existing bake' message on Google bake execution details.

Related to https://github.com/spinnaker/rosco/pull/63, but does not need to wait for that one to be merged.