### PR TITLE
Add userdata field to the UI

### DIFF
--- a/app/scripts/modules/amazon/serverGroup/configure/wizard/advancedSettings.html
+++ b/app/scripts/modules/amazon/serverGroup/configure/wizard/advancedSettings.html
@@ -64,6 +64,15 @@
                                    ng-model="command.iamRole"/></div>
     </div>
     <div class="form-group">
+      <div class="col-md-5 sm-label-left">
+        <b>UserData (optional)</b>
+        <help-field key="aws.serverGroup.base64UserData"></help-field>
+      </div>
+      <div class="col-md-6"><input type="text"
+                                   class="form-control input-sm"
+                                   ng-model="command.base64UserData"/></div>
+    </div>
+    <div class="form-group">
       <div class="col-md-5 sm-label-left"><b>Instance Monitoring</b></div>
       <div class="col-md-6 checkbox">
         <label><input type="checkbox" ng-model="command.instanceMonitoring"/> Enable Instance Monitoring </label>

--- a/app/scripts/modules/core/help/helpContents.js
+++ b/app/scripts/modules/core/help/helpContents.js
@@ -36,6 +36,7 @@ module.exports = angular.module('spinnaker.core.help.contents', [])
     'aws.serverGroup.stack': '(Optional) <b>Stack</b> is one of the core naming components of a cluster, used to create vertical stacks of dependent services for integration testing.',
     'aws.serverGroup.detail': '(Optional) <b>Detail</b> is a string of free-form alphanumeric characters and hyphens to describe any other variables.',
     'aws.serverGroup.imageName': '(Required) <b>Image</b> is the deployable Amazon Machine Image. Images are restricted to the account and region selected.',
+    'aws.serverGroup.base64UserData': '(Optional) <b>UserData</b> is a base64 encoded string.',
     'aws.serverGroup.allImages': 'Search for an image that does not match the name of your application.',
     'aws.serverGroup.filterImages': 'Select from a pre-filtered list of images matching the name of your application.',
     'aws.serverGroup.strategy': 'The deployment strategy tells Spinnaker what to do with the previous version of the server group.',


### PR DESCRIPTION
The AWS deploy accepts an optional field "base64UserData" in the pipeline's JSON. This just adds that field to the UI so that users don't need to edit the JSON manually. The "Advanced Settings" tab seemed appropriate for this. The help text informs the users that the string must be base64 encoded.

![image](https://cloud.githubusercontent.com/assets/192336/12497004/731bdf7a-c056-11e5-967c-d88b2b83c7a7.png)