### PR TITLE
track executions by $id, not $index

### DIFF
--- a/app/scripts/modules/core/delivery/executionGroup/executionGroup.directive.html
+++ b/app/scripts/modules/core/delivery/executionGroup/executionGroup.directive.html
@@ -47,7 +47,7 @@
       <div ng-if="!vm.group.executions.length" style="padding-bottom: 10px">
         <em>No executions found matching the selected filters.</em>
       </div>
-      <execution ng-repeat="execution in vm.group.executions track by $index"
+      <execution ng-repeat="execution in vm.group.executions"
                  execution="execution" application="vm.application"></execution>
     </div>
   </div>

--- a/app/scripts/modules/core/pipeline/config/graph/pipeline.graph.directive.js
+++ b/app/scripts/modules/core/pipeline/config/graph/pipeline.graph.directive.js
@@ -330,7 +330,6 @@ module.exports = angular.module('spinnaker.core.pipeline.config.graph.directive'
 
         updateGraph();
 
-        scope.$watch('execution', updateGraph);
         scope.$watch('pipeline', updateGraph, true);
         scope.$watch('viewState', updateGraph, true);
         $($window).bind('resize.pipelineGraph-' + graphId, handleWindowResize);


### PR DESCRIPTION
Also run all the tests.

Tracking by `$index` causes grief because we need to add `$watch`es all over the place to make sure we don't bork the view when new items enter the execution group.

@zanthrash please review