### PR TITLE
SPIN-247:  Add cluster selector with some smarts.

### DIFF
--- a/app/scripts/modules/core/application/listExtractor/listExtractor.service.js
+++ b/app/scripts/modules/core/application/listExtractor/listExtractor.service.js
@@ -8,9 +8,12 @@ module.exports = angular
   ])
   .factory('appListExtractorService', function(_) {
 
-    let getRegions = (appList) => {
+    let defaultAccountFilter = (/*cluster*/) => true;
+
+    let getRegions = (appList, accountFilter = defaultAccountFilter) => {
       return _(appList)
         .map('clusters').flatten()
+        .filter(accountFilter)
         .map('serverGroups').flatten()
         .map('region')
         .compact()

--- a/app/scripts/modules/core/task/verification/userVerification.directive.spec.js
+++ b/app/scripts/modules/core/task/verification/userVerification.directive.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-fdescribe('Controller: UserVerification', function () {
+describe('Controller: UserVerification', function () {
   var controller, accountService, $scope, $q;
 
   beforeEach(

--- a/app/scripts/modules/core/widgets/index.js
+++ b/app/scripts/modules/core/widgets/index.js
@@ -1,0 +1,8 @@
+'use strict';
+
+let angular = require('angular');
+
+module.exports = angular
+  .module('spinnaker.core.widgets', [
+    require('./scopeClusterSelector.directive')
+  ]);

--- a/app/scripts/modules/core/widgets/scopeClusterSelector.directive.html
+++ b/app/scripts/modules/core/widgets/scopeClusterSelector.directive.html
@@ -8,13 +8,6 @@
         ng-if="!vm.freeFormClusterField"
         >
 
-      <option value=""></option>
-      <option
-          ng-if="vm.allowNone"
-          value="none"
-          ng-selected="!vm.model">
-        none
-      </option>
       <option
           ng-repeat="cluster in vm.clusters"
           value="{{cluster}}"
@@ -26,7 +19,6 @@
 
     <input
         type="text"
-        ng-blur="vm.clusterChanged()"
         class="form-control input-sm"
         ng-if="vm.freeFormClusterField"
         ng-model="vm.model" />
@@ -35,6 +27,6 @@
 
   <div class="pull-right">
     <a href ng-click="vm.toggleFreeFormClusterField($event)" ng-if="!vm.freeFormClusterField">Toggle for text input</a>
-    <a href ng-click="vm.toggleFreeFormClusterField($event)" ng-if="vm.freeFormClusterField">Toggle for list of exiting clusters </a>
+    <a href ng-click="vm.toggleFreeFormClusterField($event)" ng-if="vm.freeFormClusterField">Toggle for list of existing clusters </a>
   </div>
 </div>

--- a/app/scripts/modules/core/widgets/scopeClusterSelector.directive.html
+++ b/app/scripts/modules/core/widgets/scopeClusterSelector.directive.html
@@ -1,0 +1,40 @@
+<div>
+  <div>
+    <select
+        name="stacks"
+        class="form-control input-sm"
+        ng-model="vm.model"
+        ng-change="vm.clusterChanged()"
+        ng-if="!vm.freeFormClusterField"
+        >
+
+      <option value=""></option>
+      <option
+          ng-if="vm.allowNone"
+          value="none"
+          ng-selected="!vm.model">
+        none
+      </option>
+      <option
+          ng-repeat="cluster in vm.clusters"
+          value="{{cluster}}"
+          ng-selected="vm.model === cluster"
+          >
+        {{cluster}}
+      </option>
+    </select>
+
+    <input
+        type="text"
+        ng-blur="vm.clusterChanged()"
+        class="form-control input-sm"
+        ng-if="vm.freeFormClusterField"
+        ng-model="vm.model" />
+
+  </div>
+
+  <div class="pull-right">
+    <a href ng-click="vm.toggleFreeFormClusterField($event)" ng-if="!vm.freeFormClusterField">Toggle for text input</a>
+    <a href ng-click="vm.toggleFreeFormClusterField($event)" ng-if="vm.freeFormClusterField">Toggle for list of exiting clusters </a>
+  </div>
+</div>

--- a/app/scripts/modules/core/widgets/scopeClusterSelector.directive.js
+++ b/app/scripts/modules/core/widgets/scopeClusterSelector.directive.js
@@ -1,0 +1,37 @@
+'use strict';
+
+
+let angular = require('angular');
+
+module.exports = angular
+  .module('spinnaker.fastProperties.scope.clusterSelector.directive', [])
+  .directive('clusterSelector', function() {
+    return {
+      restrict: 'E',
+      bindToController: {
+        model: '=?',
+        clusters: '=?',
+        onChange: '&?',
+      },
+      controllerAs: 'vm',
+      controller: function controller() {
+        var vm = this;
+        vm.freeFormClusterField = false;
+
+        vm.clusterChanged = () => {
+          vm.onChange ? vm.onChange({cluster: vm.model}) : angular.noop();
+        };
+
+        vm.toggleFreeFormClusterField = function(event) {
+          event.preventDefault();
+          vm.freeFormClusterField = !vm.freeFormClusterField;
+        };
+
+        vm.getClusterList = () => {
+          return vm.getClusters();
+        };
+
+      },
+      templateUrl: require('./scopeClusterSelector.directive.html')
+    };
+  });

--- a/app/scripts/modules/core/widgets/scopeClusterSelector.directive.js
+++ b/app/scripts/modules/core/widgets/scopeClusterSelector.directive.js
@@ -8,27 +8,19 @@ module.exports = angular
   .directive('clusterSelector', function() {
     return {
       restrict: 'E',
+      scope: {},
       bindToController: {
-        model: '=?',
-        clusters: '=?',
-        onChange: '&?',
+        model: '=',
+        clusters: '=',
       },
       controllerAs: 'vm',
       controller: function controller() {
         var vm = this;
         vm.freeFormClusterField = false;
 
-        vm.clusterChanged = () => {
-          vm.onChange ? vm.onChange({cluster: vm.model}) : angular.noop();
-        };
-
         vm.toggleFreeFormClusterField = function(event) {
           event.preventDefault();
           vm.freeFormClusterField = !vm.freeFormClusterField;
-        };
-
-        vm.getClusterList = () => {
-          return vm.getClusters();
         };
 
       },

--- a/app/scripts/modules/netflix/pipeline/stage/quickPatchAsg/quickPatchAsgStage.html
+++ b/app/scripts/modules/netflix/pipeline/stage/quickPatchAsg/quickPatchAsgStage.html
@@ -8,10 +8,13 @@
                        provider="'aws'"
                        regions="regions"
                        label-columns="2 col-md-offset-1"
+                       on-change="resetSelectedCluster()"
                        field-columns="6"></region-select-field>
   <stage-config-field label="Cluster" help-key="pipeline.config.quickPatchAsg.cluster">
-    <input type="text" required ng-model="stage.clusterName"
-      class="form-control input-sm" />
+    <cluster-selector
+      clusters="clusterList"
+      model="stage.clusterName">
+    </cluster-selector>
   </stage-config-field>
   <stage-config-field label="Package" help-key="pipeline.config.quickPatchAsg.package">
     <input type="text" required ng-model="stage.package"


### PR DESCRIPTION
Both the region list and cluster list are derived from the what account is
selected. The cluster list starts off with all clusters available.  Once an
account is selected the region and cluster list are filter to show only
those regions and clusters in the account. Once the region is selected the cluster list will filter down to show only clusters in that region.

Changing either the account or region selections will remove the selected
cluster item if there was one.

Also removed the focus on a test that accidentally got checked in.

@anotherchrisberry cleaned up, plz review