### PR TITLE
used hacked up infinite scroller

### DIFF
--- a/app/scripts/modules/amazon/securityGroup/configure/EditSecurityGroupCtrl.js
+++ b/app/scripts/modules/amazon/securityGroup/configure/EditSecurityGroupCtrl.js
@@ -13,7 +13,7 @@ module.exports = angular.module('spinnaker.securityGroup.aws.edit.controller', [
   .controller('awsEditSecurityGroupCtrl', function($scope, $modalInstance, $state,
                                                 accountService, securityGroupReader,
                                                 taskMonitorService, cacheInitializer, infrastructureCaches,
-                                                _, application, securityGroup, securityGroupWriter) {
+                                                _, application, securityGroup, securityGroupWriter, $controller) {
 
     $scope.pages = {
       ingress: require('./createSecurityGroupIngress.html'),
@@ -24,6 +24,13 @@ module.exports = angular.module('spinnaker.securityGroup.aws.edit.controller', [
     $scope.state = {
       refreshingSecurityGroups: false,
     };
+
+    angular.extend(this, $controller('awsConfigSecurityGroupMixin', {
+      $scope: $scope,
+      $modalInstance: $modalInstance,
+      application: application,
+      securityGroup: securityGroup,
+    }));
 
     $scope.taskMonitor = taskMonitorService.buildTaskMonitor({
       application: application,
@@ -41,7 +48,8 @@ module.exports = angular.module('spinnaker.securityGroup.aws.edit.controller', [
             name: rule.securityGroup.name,
             type: rule.protocol,
             startPort: portRange.startPort,
-            endPort: portRange.endPort
+            endPort: portRange.endPort,
+            existing: true,
           };
         });
       })

--- a/app/scripts/modules/amazon/securityGroup/configure/createSecurityGroupIngress.html
+++ b/app/scripts/modules/amazon/securityGroup/configure/createSecurityGroupIngress.html
@@ -37,11 +37,11 @@
             <tbody>
             <tr ng-repeat="rule in securityGroup.securityGroupIngress">
               <td>
-                <ui-select ng-model="rule.name" class="form-control input-sm" style="width: 244px">
+                <span class="form-control-static" ng-if="rule.existing">{{rule.name}}</span>
+                <ui-select ng-if="!rule.existing" ng-model="rule.name" class="form-control input-sm" style="width: 244px">
                   <ui-select-match>{{$select.selected}}</ui-select-match>
                   <ui-select-choices repeat="securityGroup as securityGroup in availableSecurityGroups | filter: $select.search | limitTo: state.infiniteScroll.currentItems"
                                      infinite-scroll="ctrl.addMoreItems()"
-                                     infinite-scroll-container="'.ui-select-choices-content'"
                                      infinite-scroll-distance="2">
                     <span ng-bind-html="securityGroup | highlight: $select.search"></span>
                   </ui-select-choices>

--- a/app/scripts/modules/azure/securityGroup/configure/createSecurityGroupIngress.html
+++ b/app/scripts/modules/azure/securityGroup/configure/createSecurityGroupIngress.html
@@ -41,7 +41,6 @@
                   <ui-select-match>{{$select.selected}}</ui-select-match>
                   <ui-select-choices repeat="securityGroup as securityGroup in availableSecurityGroups | filter: $select.search | limitTo: state.infiniteScroll.currentItems"
                                      infinite-scroll="ctrl.addMoreItems()"
-                                     infinite-scroll-container="'.ui-select-choices-content'"
                                      infinite-scroll-distance="2">
                     <span ng-bind-html="securityGroup | highlight: $select.search"></span>
                   </ui-select-choices>

--- a/app/scripts/modules/core/core.module.js
+++ b/app/scripts/modules/core/core.module.js
@@ -35,7 +35,6 @@ module.exports = angular
     require('angular-ui-router'),
     require('angular-ui-bootstrap'),
     require('exports?"angular.filter"!angular-filter'),
-    require('exports?"infinite-scroll"!ng-infinite-scroll/build/ng-infinite-scroll.js'),
     require('exports?"restangular"!imports?_=lodash!restangular'),
     require('exports?"ui.select"!ui-select'),
     require('imports?define=>false!exports?"angularSpinner"!angular-spinner'),

--- a/app/scripts/modules/core/deploymentStrategy/strategies/custom/customStrategySelector.directive.html
+++ b/app/scripts/modules/core/deploymentStrategy/strategies/custom/customStrategySelector.directive.html
@@ -8,7 +8,7 @@
           <ui-select-match placeholder="None">{{$select.selected}}</ui-select-match>
           <ui-select-choices
               repeat="application in applications | filter: $select.search | limitTo: viewState.infiniteScroll.currentItems"
-              infinite-scroll="pipelinecommandCtrl.addMoreItems()"
+              infinite-scroll="customStrategySelectorController.addMoreItems()"
               infinite-scroll-distance="2">
             <div ng-bind-html="application | highlight: $select.search"></div>
           </ui-select-choices>

--- a/app/scripts/modules/core/projects/configure/configureProject.modal.controller.js
+++ b/app/scripts/modules/core/projects/configure/configureProject.modal.controller.js
@@ -7,7 +7,6 @@ module.exports = angular.module('spinnaker.core.projects.configure.modal.control
   require('../service/project.read.service.js'),
   require('../../account/account.service.js'),
   require('../../pipeline/config/services/pipelineConfigService.js'),
-  require('exports?"infinite-scroll"!ng-infinite-scroll/build/ng-infinite-scroll.js'),
 ])
   .controller('ConfigureProjectModalCtrl', function ($scope, projectConfig, $modalInstance, $q,
                                                      pipelineConfigService, applicationReader, projectWriter,

--- a/app/scripts/modules/core/projects/configure/projectApplications.modal.html
+++ b/app/scripts/modules/core/projects/configure/projectApplications.modal.html
@@ -11,7 +11,6 @@
           </ui-select-match>
           <ui-select-choices repeat="application in applications | filter: $select.search | limitTo: viewState.infiniteScroll.currentItems"
                              infinite-scroll="ctrl.addMoreItems()"
-                             infinite-scroll-container="'.ui-select-choices-content'"
                              infinite-scroll-distance="2">
             {{application}}
           </ui-select-choices>

--- a/app/scripts/modules/core/utils/infiniteScroll.directive.js
+++ b/app/scripts/modules/core/utils/infiniteScroll.directive.js
@@ -1,0 +1,76 @@
+'use strict';
+
+/*
+  This is a hacked version of https://github.com/sroze/ngInfiniteScroll
+  extracted entirely from this Plunkr: http://plnkr.co/edit/OwhFCyHz0mO1yZMj5UW5?p=preview
+  based on this comment https://github.com/angular-ui/ui-select/issues/389#issuecomment-95295234
+
+  This is what using ui-select has done to us.
+ */
+
+const angular = require('angular');
+
+module.exports = angular
+  .module('spinnaker.core.utils.infiniteScroll.directive', [])
+  .directive('infiniteScroll', function($rootScope, $window, $timeout) {
+    return {
+      link: function(scope, elem, attrs) {
+        var checkWhenEnabled, handler, scrollDistance, scrollEnabled;
+        $window = angular.element($window);
+        elem.css('overflow-y', 'auto');
+        elem.css('overflow-x', 'hidden');
+        elem.css('height', 'inherit');
+        scrollDistance = 0;
+        if (attrs.infiniteScrollDistance != null) {
+          scope.$watch(attrs.infiniteScrollDistance, function(value) {
+            return (scrollDistance = parseInt(value, 10));
+          });
+        }
+        scrollEnabled = true;
+        checkWhenEnabled = false;
+        if (attrs.infiniteScrollDisabled != null) {
+          scope.$watch(attrs.infiniteScrollDisabled, function(value) {
+            scrollEnabled = !value;
+            if (scrollEnabled && checkWhenEnabled) {
+              checkWhenEnabled = false;
+              return handler();
+            }
+          });
+        }
+        $rootScope.$on('refreshStart', function () {
+          elem.animate({ scrollTop: '0' });
+        });
+        handler = function() {
+          var container, elementBottom, remaining, shouldScroll, containerBottom;
+          container = $(elem.children()[0]);
+          elementBottom = elem.offset().top + elem.height();
+          containerBottom = container.offset().top + container.height();
+          remaining = containerBottom - elementBottom;
+          shouldScroll = remaining <= elem.height() * scrollDistance;
+          if (shouldScroll && scrollEnabled) {
+            if ($rootScope.$$phase) {
+              return scope.$eval(attrs.infiniteScroll);
+            } else {
+              return scope.$apply(attrs.infiniteScroll);
+            }
+          } else if (shouldScroll) {
+            return (checkWhenEnabled = true);
+          }
+        };
+        elem.on('scroll', handler);
+        scope.$on('$destroy', function() {
+          return $window.off('scroll', handler);
+        });
+        return $timeout((function() {
+          if (attrs.infiniteScrollImmediateCheck) {
+            if (scope.$eval(attrs.infiniteScrollImmediateCheck)) {
+              return handler();
+            }
+          } else {
+            return handler();
+          }
+        }), 0);
+      }
+    };
+  }
+);

--- a/app/scripts/modules/core/utils/utils.module.js
+++ b/app/scripts/modules/core/utils/utils.module.js
@@ -12,4 +12,5 @@ module.exports = angular.module('spinnaker.utils', [
   require('./appendTransform.js'),
   require('./clipboard/copyToClipboard.directive.js'),
   require('./timeFormatters.js'),
+  require('./infiniteScroll.directive.js'),
 ]);

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "loader-utils": "^0.2.11",
     "lodash": "^3.10.1",
     "moment-timezone": "^0.4.0",
-    "ng-infinite-scroll": "^1.2.0",
     "restangular": "~1.4.0",
     "rx": "^2.5.3",
     "select2-bootstrap-css": "git://github.com/t0m/select2-bootstrap-css.git#v1.3.1",


### PR DESCRIPTION
So...it turns out the angular-infinite-scroll-with-ui-select trick doesn't _really_ work with ng-infinite-scroll OOB. The demonstrated working version is hacked together.

This PR brings that hacked-together version into Deck and fixes our uses of it throughout the codebase. I've tested all locations we're currently using it, and it now works as expected.

Also changing the way editing ingress rules works when editing a security group. There's rarely ever a case when it makes sense to change the name of security group, while retaining ports. So we just show the name as a read-only value.

@zanthrash please review...