### PR TITLE
do not copy core processes when using disabled ASG; make maxRemaining…

### DIFF
--- a/app/scripts/modules/amazon/serverGroup/configure/serverGroupCommandBuilder.service.js
+++ b/app/scripts/modules/amazon/serverGroup/configure/serverGroupCommandBuilder.service.js
@@ -163,6 +163,9 @@ module.exports = angular.module('spinnaker.aws.serverGroupCommandBuilder.service
           usePreferredZones = zones.join(',') === preferredZones.join(',');
         }
 
+        // These processes should never be copied over, as the affect launching instances and enabling traffic
+        let enabledProcesses = ['Launch', 'Terminate', 'AddToLoadBalancer'];
+
         var command = {
           application: application.name,
           strategy: '',
@@ -189,7 +192,9 @@ module.exports = angular.module('spinnaker.aws.serverGroupCommandBuilder.service
             region: serverGroup.region,
             asgName: serverGroup.asg.autoScalingGroupName,
           },
-          suspendedProcesses: (serverGroup.asg.suspendedProcesses || []).map((process) => process.processName),
+          suspendedProcesses: (serverGroup.asg.suspendedProcesses || [])
+            .map((process) => process.processName)
+            .filter((name) => enabledProcesses.indexOf(name) < 0),
           viewState: {
             instanceProfile: asyncData.instanceProfile,
             useAllImageSelection: false,

--- a/app/scripts/modules/amazon/serverGroup/configure/wizard/basicSettings.html
+++ b/app/scripts/modules/amazon/serverGroup/configure/wizard/basicSettings.html
@@ -78,6 +78,19 @@
           <a href ng-click="basicSettingsCtrl.enableAllImageSearch()">Search All Images</a><help-field key="aws.serverGroup.allImages"></help-field>
         </div>
       </div>
+      <div class="form-group">
+        <div class="col-md-3 sm-label-right">
+          Traffic <help-field key="aws.serverGroup.traffic"></help-field>
+        </div>
+        <div class="col-md-9 checkbox">
+          <label>
+            <input type="checkbox"
+                   ng-click="command.toggleSuspendedProcess('AddToLoadBalancer')"
+                   ng-checked="!command.processIsSuspended('AddToLoadBalancer')"/>
+            Send client requests to new instances
+          </label>
+        </div>
+      </div>
       <deployment-strategy-selector label-columns="3" field-columns="9" ng-if="!command.viewState.disableStrategySelection && command.selectedProvider" command="command"></deployment-strategy-selector>
       <div class="form-group" ng-if="!command.viewState.hideClusterNamePreview">
         <div class="col-md-12">

--- a/app/scripts/modules/amazon/serverGroup/configure/wizard/templateSelection.html
+++ b/app/scripts/modules/amazon/serverGroup/configure/wizard/templateSelection.html
@@ -48,7 +48,7 @@
             </ul>
             These fields <strong>will NOT</strong> be copied over, and will be reset to defaults:
             <ul>
-              <li>suspended processes</li>
+              <li>the following suspended scaling processes: Launch, Terminate, AddToLoadBalancer</li>
               <li ng-if="!command.viewState.disableStrategySelection">the deployment strategy (if any) used to deploy the most recent server group</li>
             </ul>
             If a server group exists in this cluster at the time of deployment, its scaling policies will be copied over to the new server group.

--- a/app/scripts/modules/core/deploymentStrategy/strategies/redblack/redblack.strategy.module.js
+++ b/app/scripts/modules/core/deploymentStrategy/strategies/redblack/redblack.strategy.module.js
@@ -11,8 +11,5 @@ module.exports = angular.module('spinnaker.core.deploymentStrategy.redblack', []
       providers: ['aws', 'gce', 'cf'],
       additionalFields: ['scaleDown', 'maxRemainingAsgs'],
       additionalFieldsTemplateUrl: require('./additionalFields.html'),
-      initializationMethod: function(command) {
-        command.maxRemainingAsgs = command.maxRemainingAsgs || 2;
-      },
     });
   });

--- a/app/scripts/modules/core/help/helpContents.js
+++ b/app/scripts/modules/core/help/helpContents.js
@@ -40,6 +40,8 @@ module.exports = angular.module('spinnaker.core.help.contents', [])
     'aws.serverGroup.allImages': 'Search for an image that does not match the name of your application.',
     'aws.serverGroup.filterImages': 'Select from a pre-filtered list of images matching the name of your application.',
     'aws.serverGroup.strategy': 'The deployment strategy tells Spinnaker what to do with the previous version of the server group.',
+    'aws.serverGroup.traffic': 'Enables the "AddToLoadBalancer" scaling process, which is used by Spinnaker and ' +
+    ' discovery services to determine if the server group is enabled.',
     'aws.securityGroup.vpc': '<p>The VPC to which this security group will apply.</p>' +
       '<p>If you wish to use VPC but are unsure which VPC to use, the most common one is "Main".</p>' +
       '<p>If you do not wish to use VPC, select "None".</p>',
@@ -211,7 +213,7 @@ module.exports = angular.module('spinnaker.core.help.contents', [])
     'serverGroupCapacity.useSourceCapacityFalse': '<p>The specified capacity is used regardless of the presence or size of an existing server group.</p>',
     'strategy.redblack.scaleDown': '<p>Resizes the target server group to zero instances before disabling it.</p>' +
       '<p>Select this if you wish to retain the launch configuration for the old server group without running any instances.</p>',
-    'strategy.redblack.maxRemainingAsgs': '<p>Indicates the maximum number of server groups that will remain in this cluster - including the newly created one.</p>' +
+    'strategy.redblack.maxRemainingAsgs': '<p><b>Optional</b>: indicates the maximum number of server groups that will remain in this cluster - including the newly created one.</p>' +
       '<p>If you wish to destroy all server groups except the newly created one, select "Highlander" as the strategy.</p>' +
       '<p><strong>Minimum value:</strong> 2</p>',
     'strategy.rollingPush.relaunchAll': '<p>Incrementally terminates each instance in the server group, waiting for a new one to come up before terminating the next one.</p>',


### PR DESCRIPTION
…Asgs optional on red/black; surface Enable Traffic in basic settings

This PR attempts to remedy a series of recent bad decisions (all by me) that have been made:

_Original (bad) change:_ All suspended scaling processes are copied over when cloning an ASG or using an ASG as a template in a pipeline. This was done because, about four months ago, someone was having trouble when cloning an ASG which had the `AZRebalance` process suspended. At the time, we did not copy _any_ suspended processes, intentionally leaving them out, which was correct _most of the time_, because most of the time, only `Launch`, `Terminate`, and `AddToLoadBalancer` would ever be suspended, and those processes are key to scaling the ASG up and sending traffic to new instances. In reality, we should only be enabling those three processes by default, which we're now doing here.
_Fix:_ Copy over suspended processes _except_ `Launch`, `Terminate`, and `AddToLoadBalancer`

_Original (bad) change:_ A couple of weeks ago, in an effort to address the problems caused by the changes described above, I moved all the scaling processes to the Advanced Settings page of the wizard. We had an "Enable Traffic" checkbox on the Capacity/Zones page, which I removed. Removing that was a mistake, as a number of users were used to it and confused by it going away. For the most part, I don't think users knew that checkbox just toggled the `AddToLoadBalancer` process, and it's not intuitive that we use that to manage discovery status. 
_Fix:_ Restore that checkbox, but put it on the Basic Settings page so that users don't have to navigate through the entire wizard when performing a clone operation just to set that flag. I believe this is where that checkbox should have always been. Frankly, I wouldn't be moving it yet again if I hadn't made the mistake of removing it, but since I have, I think it makes sense to put it here.

_Original (bad) change:_ About a month ago, I changed the default setting for `maxRemainingAsgs` when selecting the red/black deployment strategy from nothing to "2". I'm reverting that change, as it's proven to be confusing on a number of counts:
  * It's not a required field, but including a default value implies that it is.
  * There was no migration done on existing pipelines (which was correct, I suppose - there should not have been any migration), and the implementation has led to some very confused users, who would go into their existing configurations, see that "2", and assume that was the value all along. If they left it blank, then came back to the configuration, they'd see that "2".
_Fix:_ Remove that default value, leaving the field blank, and adding text in the help bubble to explain that the field is optional.

@ajordens @cfieber @tomaslin @claymccoy @zanthrash @robfletcher would appreciate feedback on these changes, especially since I made the original changes that caused these problems without asking for feedback.