### PR TITLE
SPIN-1353: Make hitting <enter> key will run the execution.

### DIFF
--- a/app/scripts/modules/core/delivery/manualExecution/manualPipelineExecution.html
+++ b/app/scripts/modules/core/delivery/manualExecution/manualPipelineExecution.html
@@ -101,7 +101,7 @@
       </div>
     </div>
     <div class="modal-footer">
-      <button class="btn btn-default" ng-click="vm.cancel()">Cancel</button>
+      <button type="button" class="btn btn-default" ng-click="vm.cancel()">Cancel</button>
       <button type="submit"
               class="btn btn-primary"
               ng-click="vm.execute()">


### PR DESCRIPTION
Previously when the <enter> key was hit the close button was 'clicked'
because it was the first in the DOM, unless the 'Run' key had focus.

I added a type="button" to the cancel button which Chrome, FF, Safari (only
ones tested) will ignore it and use the type="submit" for the <enter> key
event.

@anotherchrisberry plz review