### PR TITLE
Enable edit of security group with cross account ingress.

### DIFF
--- a/app/scripts/modules/amazon/securityGroup/configure/EditSecurityGroupCtrl.js
+++ b/app/scripts/modules/amazon/securityGroup/configure/EditSecurityGroupCtrl.js
@@ -45,6 +45,8 @@ module.exports = angular.module('spinnaker.securityGroup.aws.edit.controller', [
       }).map(function(rule) {
         return rule.portRanges.map(function(portRange) {
           return {
+            accountName: rule.securityGroup.accountName || rule.securityGroup.accountId,
+            id: rule.securityGroup.id,
             name: rule.securityGroup.name,
             type: rule.protocol,
             startPort: portRange.startPort,

--- a/app/scripts/modules/amazon/securityGroup/configure/createSecurityGroupIngress.html
+++ b/app/scripts/modules/amazon/securityGroup/configure/createSecurityGroupIngress.html
@@ -37,7 +37,10 @@
             <tbody>
             <tr ng-repeat="rule in securityGroup.securityGroupIngress">
               <td>
-                <span class="form-control-static" ng-if="rule.existing">{{rule.name}}</span>
+                <span class="form-control-static" ng-if="rule.existing">
+                  <account-tag account="rule.accountName" ng-if="rule.accountName !== securityGroup.accountName"></account-tag>
+                  {{rule.name}}
+                </span>
                 <ui-select ng-if="!rule.existing" ng-model="rule.name" class="form-control input-sm" style="width: 244px">
                   <ui-select-match>{{$select.selected}}</ui-select-match>
                   <ui-select-choices repeat="securityGroup as securityGroup in availableSecurityGroups | filter: $select.search | limitTo: state.infiniteScroll.currentItems"

--- a/app/scripts/modules/amazon/securityGroup/details/securityGroupDetail.html
+++ b/app/scripts/modules/amazon/securityGroup/details/securityGroupDetail.html
@@ -66,6 +66,7 @@
         <dt>Security Group</dt>
         <dd ng-if="rule.securityGroup.name">
           <a ui-sref="^.securityGroupDetails({name: rule.securityGroup.name, accountId: rule.securityGroup.accountName, region: rule.securityGroup.region, vpcId: securityGroup.vpcId, provider: 'aws'})">
+            <account-tag account="rule.securityGroup.accountName || rule.securityGroup.accountId" ng-if="rule.securityGroup.accountName !== securityGroup.accountName"></account-tag>
             {{rule.securityGroup.name}} ({{rule.securityGroup.id}})
           </a>
         </dd>


### PR DESCRIPTION
Populate accountName and id for ingress so that CloudDriver understands exactly which security group is specified.
Fix links to cross account security group details.
Display account on cross account security groups in detail and edit views.