### PR TITLE
SPIN-1418: Add Cluster selector to pipeline stages that require selecting a cluster.

### DIFF
--- a/app/scripts/modules/core/application/listExtractor/listExtractor.service.js
+++ b/app/scripts/modules/core/application/listExtractor/listExtractor.service.js
@@ -37,6 +37,20 @@ module.exports = angular
 
     let defaultClusterFilter = (/*cluster*/) => true;
 
+    let clusterFilterForCredentialsAndRegion = (credentials, region) => {
+      return (cluster) => {
+        let acctFilter = credentials ? cluster.account === credentials : true;
+
+        let regionFilter = Array.isArray(region) && region.length
+          ? _.some( cluster.serverGroups, (sg) => _.some(region, (region) => region === sg.region))
+          : _.isString(region) //region is just a string not an array
+          ? _.any(cluster.serverGroups, (sg) => sg.region === region)
+          : true;
+
+        return acctFilter && regionFilter;
+      };
+    };
+
     let getClusters = (appList, clusterFilter = defaultClusterFilter) => {
       return _(appList)
         .map('clusters').flatten()
@@ -47,6 +61,7 @@ module.exports = angular
         .value()
         .sort();
     };
+
 
     let getAsgs = (appList, clusterFilter = defaultClusterFilter) => {
       return _(appList)
@@ -96,6 +111,7 @@ module.exports = angular
       getRegions: getRegions,
       getStacks: getStacks,
       getClusters: getClusters,
+      clusterFilterForCredentialsAndRegion: clusterFilterForCredentialsAndRegion,
       getAsgs: getAsgs,
       getZones: getZones,
       getInstances: getInstances,

--- a/app/scripts/modules/core/pipeline/config/stages/destroyAsg/aws/awsDestroyAsgStage.js
+++ b/app/scripts/modules/core/pipeline/config/stages/destroyAsg/aws/awsDestroyAsgStage.js
@@ -5,7 +5,7 @@ let angular = require('angular');
 //BEN_TODO: where is this defined?
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.aws.destroyAsgStage', [
-  require('../../../../../utils/lodash.js'),
+  require('../../../../../../core/application/listExtractor/listExtractor.service'),
   require('../../stageConstants.js'),
   require('./destroyAsgExecutionDetails.controller.js')
 ])
@@ -28,7 +28,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.aws.destroyAsgSta
         { type: 'requiredField', fieldName: 'credentials', fieldLabel: 'account'},
       ],
     });
-  }).controller('awsDestroyAsgStageCtrl', function($scope, accountService, stageConstants, _) {
+  }).controller('awsDestroyAsgStageCtrl', function($scope, accountService, stageConstants, appListExtractorService) {
     var ctrl = this;
 
     let stage = $scope.stage;
@@ -38,18 +38,33 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.aws.destroyAsgSta
       regionsLoaded: false
     };
 
+    let setClusterList = () => {
+      let clusterFilter = appListExtractorService.clusterFilterForCredentialsAndRegion($scope.stage.credentials, $scope.stage.regions);
+      $scope.clusterList = appListExtractorService.getClusters([$scope.application], clusterFilter);
+    };
+
+    $scope.resetSelectedCluster = () => {
+      $scope.stage.cluster = undefined;
+      setClusterList();
+    };
+
     accountService.listAccounts('aws').then(function (accounts) {
       $scope.accounts = accounts;
       $scope.state.accounts = true;
+      setClusterList();
     });
 
     $scope.regions = ['us-east-1', 'us-west-1', 'eu-west-1', 'us-west-2'];
 
+    ctrl.reset = () => {
+      ctrl.accountUpdated();
+      $scope.resetSelectedCluster();
+    };
+
     ctrl.accountUpdated = function() {
-      accountService.getRegionsForAccount(stage.credentials).then(function(regions) {
-        $scope.regions = _.map(regions, function(v) { return v.name; });
-        $scope.state.regionsLoaded = true;
-      });
+      let accountFilter = (cluster) => cluster.account === $scope.stage.credentials;
+      $scope.regions = appListExtractorService.getRegions([$scope.application], accountFilter);
+      $scope.state.regionsLoaded = true;
     };
 
     $scope.targets = stageConstants.targetList;

--- a/app/scripts/modules/core/pipeline/config/stages/destroyAsg/aws/destroyAsgStage.html
+++ b/app/scripts/modules/core/pipeline/config/stages/destroyAsg/aws/destroyAsgStage.html
@@ -1,14 +1,24 @@
 <div ng-controller="awsDestroyAsgStageCtrl as destroyAsgStageCtrl" class="form-horizontal">
   <div ng-if="!pipeline.strategy">
     <stage-config-field label="Account">
-      <account-select-field component="stage" field="credentials" accounts="accounts" provider="'aws'" on-change="destroyAsgStageCtrl.accountUpdated()" required></account-select-field>
+      <account-select-field component="stage" field="credentials" accounts="accounts" provider="'aws'" on-change="destroyAsgStageCtrl.reset()" required></account-select-field>
     </stage-config-field>
     <stage-config-field label="Regions">
       <p ng-if="!stage.credentials" class="form-control-static">(Select an Account)</p>
-      <checklist ng-if="stage.credentials" items="regions" model="stage.regions" inline="true" include-select-all-button="true"></checklist>
+      <checklist
+        ng-if="stage.credentials"
+        items="regions"
+        model="stage.regions"
+        inline="true"
+        on-change="resetSelectedCluster()"
+        include-select-all-button="true">
+      </checklist>
     </stage-config-field>
     <stage-config-field label="Cluster" help-key="pipeline.config.destroyAsg.cluster">
-      <input type="text" required ng-model="stage.cluster" class="form-control input-sm" />
+      <cluster-selector
+        clusters="clusterList"
+        model="stage.cluster">
+      </cluster-selector>
     </stage-config-field>
   </div>
   <stage-config-field label="target">

--- a/app/scripts/modules/core/pipeline/config/stages/disableAsg/aws/disableAsgStage.html
+++ b/app/scripts/modules/core/pipeline/config/stages/disableAsg/aws/disableAsgStage.html
@@ -1,14 +1,24 @@
 <div ng-controller="awsDisableAsgStageCtrl as disableAsgStageCtrl"class="form-horizontal">
   <div ng-if="!pipeline.strategy">
     <stage-config-field label="Account">
-      <account-select-field component="stage" field="credentials" accounts="accounts" provider="'aws'" on-change="disableAsgStageCtrl.accountUpdated()" required></account-select-field>
+      <account-select-field component="stage" field="credentials" accounts="accounts" provider="'aws'" on-change="disableAsgStageCtrl.reset()" required></account-select-field>
     </stage-config-field>
     <stage-config-field label="Regions">
       <p ng-if="!stage.credentials" class="form-control-static">(Select an Account)</p>
-      <checklist ng-if="stage.credentials" items="regions" model="stage.regions" inline="true" include-select-all-button="true"></checklist>
+      <checklist
+        ng-if="stage.credentials"
+        items="regions"
+        model="stage.regions"
+        inline="true"
+        include-select-all-button="true"
+        on-change="disableAsgStageCtrl.resetSelectedCluster()">
+      </checklist>
     </stage-config-field>
     <stage-config-field label="Cluster" help-key="pipeline.config.disableAsg.cluster">
-      <input type="text" required ng-model="stage.cluster" class="form-control input-sm" />
+      <cluster-selector
+        clusters="clusterList"
+        model="stage.cluster">
+      </cluster-selector>
     </stage-config-field>
   </div>
   <stage-config-field label="Target">

--- a/app/scripts/modules/core/pipeline/config/stages/disableCluster/aws/awsDisableClusterStage.js
+++ b/app/scripts/modules/core/pipeline/config/stages/disableCluster/aws/awsDisableClusterStage.js
@@ -3,7 +3,7 @@
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.aws.disableClusterStage', [
-  require('../../../../../utils/lodash.js'),
+  require('../../../../../../core/application/listExtractor/listExtractor.service'),
   require('../../stageConstants.js'),
   require('./disableClusterExecutionDetails.controller.js')
 ])
@@ -20,7 +20,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.aws.disableCluste
         { type: 'requiredField', fieldName: 'credentials', fieldLabel: 'account'},
       ],
     });
-  }).controller('awsDisableClusterStageCtrl', function($scope, accountService, stageConstants, _) {
+  }).controller('awsDisableClusterStageCtrl', function($scope, accountService, stageConstants, appListExtractorService) {
     var ctrl = this;
 
     let stage = $scope.stage;
@@ -30,18 +30,37 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.aws.disableCluste
       regionsLoaded: false
     };
 
+    let setClusterList = () => {
+      let clusterFilter = appListExtractorService.clusterFilterForCredentialsAndRegion($scope.stage.credentials, $scope.stage.regions);
+      $scope.clusterList = appListExtractorService.getClusters([$scope.application], clusterFilter);
+    };
+
+    ctrl.resetSelectedCluster = () => {
+      $scope.stage.cluster = undefined;
+      setClusterList();
+    };
+
     accountService.listAccounts('aws').then(function (accounts) {
       $scope.accounts = accounts;
       $scope.state.accounts = true;
+      setClusterList();
     });
 
-    $scope.regions = ['us-east-1', 'us-west-1', 'eu-west-1', 'us-west-2'];
+    accountService.listAccounts('aws').then(function (accounts) {
+      $scope.accounts = accounts;
+      $scope.state.accounts = true;
+      setClusterList();
+    });
 
     ctrl.accountUpdated = function() {
-      accountService.getRegionsForAccount(stage.credentials).then(function(regions) {
-        $scope.regions = _.map(regions, function(v) { return v.name; });
-        $scope.state.regionsLoaded = true;
-      });
+      let accountFilter = (cluster) => cluster.account === $scope.stage.credentials;
+      $scope.regions = appListExtractorService.getRegions([$scope.application], accountFilter);
+      $scope.state.regionsLoaded = true;
+    };
+
+    ctrl.reset = () => {
+      ctrl.accountUpdated();
+      ctrl.resetSelectedCluster();
     };
 
     stage.regions = stage.regions || [];

--- a/app/scripts/modules/core/pipeline/config/stages/disableCluster/aws/disableClusterStage.html
+++ b/app/scripts/modules/core/pipeline/config/stages/disableCluster/aws/disableClusterStage.html
@@ -1,15 +1,24 @@
 <div ng-controller="awsDisableClusterStageCtrl as disableClusterStageCtrl" class="form-horizontal">
   <div ng-if="!pipeline.strategy">
   <stage-config-field label="Account">
-    <account-select-field component="stage" field="credentials" accounts="accounts" provider="'aws'" on-change="disableClusterStageCtrl.accountUpdated()" required></account-select-field>
+    <account-select-field component="stage" field="credentials" accounts="accounts" provider="'aws'" on-change="disableClusterStageCtrl.reset()" required></account-select-field>
   </stage-config-field>
   <stage-config-field label="Regions">
     <p ng-if="!stage.credentials" class="form-control-static">(Select an Account)</p>
-    <checklist ng-if="stage.credentials" items="regions" model="stage.regions" inline="true" include-select-all-button="true"></checklist>
+    <checklist
+      ng-if="stage.credentials"
+      items="regions"
+      model="stage.regions"
+      inline="true"
+      on-change="disableClusterStageCtrl.resetSelectedCluster()"
+      include-select-all-button="true">
+    </checklist>
   </stage-config-field>
   <stage-config-field label="Cluster" help-key="pipeline.config.disableCluster.cluster">
-    <input type="text" required ng-model="stage.cluster"
-           class="form-control input-sm" />
+    <cluster-selector
+      clusters="clusterList"
+      model="stage.cluster">
+    </cluster-selector>
   </stage-config-field>
   </div>
   <stage-config-field label="Disable Options">

--- a/app/scripts/modules/core/pipeline/config/stages/enableAsg/aws/enableAsgStage.html
+++ b/app/scripts/modules/core/pipeline/config/stages/enableAsg/aws/enableAsgStage.html
@@ -1,14 +1,23 @@
 <div ng-controller="awsEnableAsgStageCtrl as enableAsgStageCtrl" class="form-horizontal">
   <div ng-if="!pipeline.strategy">
     <stage-config-field label="Account">
-      <account-select-field component="stage" field="credentials" accounts="accounts" provider="'aws'" on-change="enableAsgStageCtrl.accountUpdated()" required></account-select-field>
+      <account-select-field component="stage" field="credentials" accounts="accounts" provider="'aws'" on-change="enableAsgStageCtrl.reset()" required></account-select-field>
     </stage-config-field>
     <stage-config-field label="Regions">
       <p ng-if="!stage.credentials" class="form-control-static">(Select an Account)</p>
-      <checklist ng-if="stage.credentials" items="regions" model="stage.regions" inline="true" include-select-all-button="true"></checklist>
+      <checklist
+        ng-if="stage.credentials"
+        items="regions"
+        model="stage.regions"
+        inline="true"
+        on-change="enableAsgStageCtrl.resetSelectedCluster()"
+        include-select-all-button="true"></checklist>
     </stage-config-field>
     <stage-config-field label="Cluster" help-key="pipeline.config.enableAsg.cluster">
-      <input type="text" required ng-model="stage.cluster" class="form-control input-sm" />
+      <cluster-selector
+        clusters="clusterList"
+        model="stage.cluster">
+      </cluster-selector>
     </stage-config-field>
   </div>
   <stage-config-field label="Target">

--- a/app/scripts/modules/core/pipeline/config/stages/modifyScalingProcess/modifyScalingProcessStage.html
+++ b/app/scripts/modules/core/pipeline/config/stages/modifyScalingProcess/modifyScalingProcessStage.html
@@ -1,14 +1,22 @@
 <div class="form-horizontal">
   <div ng-if="!pipeline.strategy">
     <stage-config-field label="Account">
-      <account-select-field component="stage" field="credentials" accounts="accounts" provider="'aws'" on-change="accountUpdated" required></account-select-field>
+      <account-select-field component="stage" field="credentials" accounts="accounts" provider="'aws'" on-change="reset()" required></account-select-field>
     </stage-config-field>
     <stage-config-field label="Regions" field-columns="8" ng-if="stage.credentials">
-      <checklist items="regions" model="stage.regions" inline="true" include-select-all-button="true"></checklist>
+      <checklist
+        items="regions"
+        model="stage.regions"
+        inline="true"
+        on-change="resetSelectedCluster()"
+        include-select-all-button="true">
+      </checklist>
     </stage-config-field>
     <stage-config-field label="Cluster" help-key="pipeline.config.modifyScalingProcess.cluster">
-      <input type="text" required ng-model="stage.cluster"
-        class="form-control input-sm" />
+      <cluster-selector
+        clusters="clusterList"
+        model="stage.cluster">
+      </cluster-selector>
     </stage-config-field>
   </div>
   <stage-config-field label="Target">

--- a/app/scripts/modules/core/pipeline/config/stages/resizeAsg/aws/resizeAsgStage.html
+++ b/app/scripts/modules/core/pipeline/config/stages/resizeAsg/aws/resizeAsgStage.html
@@ -8,15 +8,24 @@
     <div ng-if="viewState.accountsLoaded">
       <stage-config-field label="Account">
         <account-select-field component="stage" field="credentials" accounts="accounts" provider="'aws'"
-                              on-change="resizeAsgStageCtrl.accountUpdated()" required></account-select-field>
+                              on-change="resizeAsgStageCtrl.reset()" required></account-select-field>
       </stage-config-field>
       <stage-config-field label="Regions">
         <p ng-if="!stage.credentials" class="form-control-static">(Select an Account)</p>
-        <checklist ng-if="stage.credentials" items="regions" model="stage.regions" inline="true"
-                   include-select-all-button="true"></checklist>
+        <checklist
+          ng-if="stage.credentials"
+          items="regions"
+          model="stage.regions"
+          inline="true"
+          on-change="resizeAsgStageCtrl.resetSelectedCluster()"
+          include-select-all-button="true">
+        </checklist>
       </stage-config-field>
       <stage-config-field label="Cluster" help-key="pipeline.config.resizeAsg.cluster">
-        <input type="text" required ng-model="stage.cluster" class="form-control input-sm"/>
+        <cluster-selector
+          clusters="clusterList"
+          model="stage.cluster">
+        </cluster-selector>
       </stage-config-field>
     </div>
   </div>

--- a/app/scripts/modules/core/pipeline/config/stages/scaleDownCluster/aws/scaleDownClusterStage.html
+++ b/app/scripts/modules/core/pipeline/config/stages/scaleDownCluster/aws/scaleDownClusterStage.html
@@ -1,15 +1,24 @@
 <div ng-controller="awsScaleDownClusterStageCtrl as scaleDownClusterStageCtrl" class="form-horizontal">
   <div ng-if="!pipeline.strategy">
     <stage-config-field label="Account">
-      <account-select-field component="stage" field="credentials" accounts="accounts" provider="'aws'" on-change="scaleDownClusterStageCtrl.accountUpdated()" required></account-select-field>
+      <account-select-field component="stage" field="credentials" accounts="accounts" provider="'aws'" on-change="scaleDownClusterStageCtrl.reset()" required></account-select-field>
     </stage-config-field>
     <stage-config-field label="Regions">
       <p ng-if="!stage.credentials" class="form-control-static">(Select an Account)</p>
-      <checklist ng-if="stage.credentials" items="regions" model="stage.regions" inline="true" include-select-all-button="true"></checklist>
+      <checklist
+        ng-if="stage.credentials"
+        items="regions"
+        model="stage.regions"
+        inline="true"
+        on-change="scaleDownClusterStageCtrl.resetSelectedCluster()"
+        include-select-all-button="true">
+      </checklist>
     </stage-config-field>
     <stage-config-field label="Cluster" help-key="pipeline.config.scaleDownCluster.cluster">
-      <input type="text" required ng-model="stage.cluster"
-        class="form-control input-sm" />
+      <cluster-selector
+        clusters="clusterList"
+        model="stage.cluster">
+      </cluster-selector>
     </stage-config-field>
   </div>
   <stage-config-field label="Scale Down Options">

--- a/app/scripts/modules/core/pipeline/config/stages/shrinkCluster/aws/awsShrinkClusterStage.js
+++ b/app/scripts/modules/core/pipeline/config/stages/shrinkCluster/aws/awsShrinkClusterStage.js
@@ -3,7 +3,7 @@
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.aws.shrinkClusterStage', [
-  require('../../../../../utils/lodash.js'),
+  require('../../../../../../core/application/listExtractor/listExtractor.service'),
   require('../../stageConstants.js'),
   require('./shrinkClusterExecutionDetails.controller.js')
 ])
@@ -20,7 +20,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.aws.shrinkCluster
         { type: 'requiredField', fieldName: 'credentials', fieldLabel: 'account'},
       ],
     });
-  }).controller('awsShrinkClusterStageCtrl', function($scope, accountService, stageConstants, _) {
+  }).controller('awsShrinkClusterStageCtrl', function($scope, accountService, stageConstants, appListExtractorService) {
     var ctrl = this;
 
     let stage = $scope.stage;
@@ -30,18 +30,31 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.aws.shrinkCluster
       regionsLoaded: false
     };
 
+    let setClusterList = () => {
+      let clusterFilter = appListExtractorService.clusterFilterForCredentialsAndRegion($scope.stage.credentials, $scope.stage.regions);
+      $scope.clusterList = appListExtractorService.getClusters([$scope.application], clusterFilter);
+    };
+
+    ctrl.resetSelectedCluster = () => {
+      $scope.stage.cluster = undefined;
+      setClusterList();
+    };
+
     accountService.listAccounts('aws').then(function (accounts) {
       $scope.accounts = accounts;
       $scope.state.accounts = true;
+      setClusterList();
     });
 
-    $scope.regions = ['us-east-1', 'us-west-1', 'eu-west-1', 'us-west-2'];
-
     ctrl.accountUpdated = function() {
-      accountService.getRegionsForAccount(stage.credentials).then(function(regions) {
-        $scope.regions = _.map(regions, function(v) { return v.name; });
-        $scope.state.regionsLoaded = true;
-      });
+      let accountFilter = (cluster) => cluster.account === $scope.stage.credentials;
+      $scope.regions = appListExtractorService.getRegions([$scope.application], accountFilter);
+      $scope.viewState.regionsLoaded = true;
+    };
+
+    ctrl.reset = () => {
+      ctrl.accountUpdated();
+      ctrl.resetSelectedCluster();
     };
 
     stage.regions = stage.regions || [];

--- a/app/scripts/modules/core/pipeline/config/stages/shrinkCluster/aws/shrinkClusterStage.html
+++ b/app/scripts/modules/core/pipeline/config/stages/shrinkCluster/aws/shrinkClusterStage.html
@@ -1,15 +1,24 @@
 <div ng-controller="awsShrinkClusterStageCtrl as shrinkClusterStageCtrl" class="form-horizontal">
   <div ng-if="!pipeline.strategy">
   <stage-config-field label="Account">
-    <account-select-field component="stage" field="credentials" accounts="accounts" provider="'aws'" on-change="shrinkClusterStageCtrl.accountUpdated()" required></account-select-field>
+    <account-select-field component="stage" field="credentials" accounts="accounts" provider="'aws'" on-change="shrinkClusterStageCtrl.reset()" required></account-select-field>
   </stage-config-field>
   <stage-config-field label="Regions">
     <p ng-if="!stage.credentials" class="form-control-static">(Select an Account)</p>
-    <checklist ng-if="stage.credentials" items="regions" model="stage.regions" inline="true" include-select-all-button="true"></checklist>
+    <checklist
+      ng-if="stage.credentials"
+      items="regions"
+      model="stage.regions"
+      inline="true"
+      on-change="shrinkClusterStageCtrl.resetSelectedCluster()"
+      include-select-all-button="true">
+    </checklist>
   </stage-config-field>
   <stage-config-field label="Cluster" help-key="pipeline.config.shrinkCluster.cluster">
-    <input type="text" required ng-model="stage.cluster"
-           class="form-control input-sm" />
+    <cluster-selector
+      clusters="clusterList"
+      model="stage.cluster">
+    </cluster-selector>
   </stage-config-field>
   </div>
   <stage-config-field label="Shrink Options">

--- a/app/scripts/modules/core/widgets/scopeClusterSelector.directive.js
+++ b/app/scripts/modules/core/widgets/scopeClusterSelector.directive.js
@@ -16,7 +16,7 @@ module.exports = angular
       controllerAs: 'vm',
       controller: function controller() {
         var vm = this;
-        vm.freeFormClusterField = false;
+        vm.freeFormClusterField = vm.model === undefined ? false : !vm.clusters.some(cluster => cluster === vm.model);
 
         vm.toggleFreeFormClusterField = function(event) {
           event.preventDefault();

--- a/app/scripts/modules/netflix/pipeline/stage/canary/canaryStage.html
+++ b/app/scripts/modules/netflix/pipeline/stage/canary/canaryStage.html
@@ -110,11 +110,20 @@
   <h5>Baseline Version <help-field key="pipeline.config.canary.baselineVersion"></help-field></h5>
   <div class="horizontal-rule"></div>
   <stage-config-field label="Account">
-    <account-select-field component="stage.baseline" field="account" accounts="accounts" provider="'aws'" on-change="angular.noop()"required ></account-select-field>
+    <account-select-field
+      component="stage.baseline"
+      field="account"
+      accounts="accounts"
+      provider="'aws'"
+      on-change="resetSelectedCluster()"
+      required >
+    </account-select-field>
   </stage-config-field>
   <stage-config-field label="Cluster">
-    <input type="text" required ng-model="stage.baseline.cluster"
-           class="form-control input-sm" />
+    <cluster-selector
+      clusters="clusterList"
+      model="stage.baseline.cluster">
+    </cluster-selector>
   </stage-config-field>
   <h5>Canary / Baseline Cluster Pairs <help-field key="pipeline.config.canary.clusterPairs"></help-field></h5>
   <div class="horizontal-rule"></div>

--- a/app/scripts/modules/netflix/pipeline/stage/quickPatchAsg/quickPatchAsgStage.html
+++ b/app/scripts/modules/netflix/pipeline/stage/quickPatchAsg/quickPatchAsgStage.html
@@ -1,6 +1,6 @@
 <div class="form-horizontal">
   <stage-config-field label="Account">
-    <account-select-field component="stage" field="credentials" accounts="accounts" provider="'aws'" on-change="quickPatchAsgStageCtrl.accountUpdated()" required></account-select-field>
+    <account-select-field component="stage" field="credentials" accounts="accounts" provider="'aws'" on-change="reset()" required></account-select-field>
   </stage-config-field>
   <region-select-field component="stage"
                        field="region"

--- a/app/scripts/modules/netflix/pipeline/stage/quickPatchAsg/quickPatchAsgStage.js
+++ b/app/scripts/modules/netflix/pipeline/stage/quickPatchAsg/quickPatchAsgStage.js
@@ -6,7 +6,6 @@ module.exports = angular.module('spinnaker.netflix.pipeline.stage.quickPatchAsgS
   require('../../../../core/pipeline/config/pipelineConfigProvider.js'),
   require('../../../../core/application/listExtractor/listExtractor.service'),
   require('../../../../core/config/settings.js'),
-  require('../../../../core/utils/lodash'),
   require('../../../../core/widgets')
 ])
   .config(function(pipelineConfigProvider, settings) {
@@ -28,19 +27,14 @@ module.exports = angular.module('spinnaker.netflix.pipeline.stage.quickPatchAsgS
         ],
       });
     }
-  }).controller('QuickPatchAsgStageCtrl', function($scope, stage, bakeryService, accountService, appListExtractorService, _) {
+  }).controller('QuickPatchAsgStageCtrl', function($scope, stage, bakeryService, accountService, appListExtractorService) {
     $scope.stage = stage;
     $scope.baseOsOptions = ['ubuntu', 'centos'];
     $scope.stage.application = $scope.application.name;
     $scope.stage.healthProviders = ['Discovery'];
 
-    let clusterFilter = (cluster) => {
-      let acctFilter = $scope.stage.account ? cluster.account === $scope.stage.account : true;
-      let regionFilter = $scope.stage.region ? _.any(cluster.serverGroups, (sg) => sg.region === $scope.stage.region) : true;
-      return acctFilter && regionFilter;
-    };
-
     let setClusterList = () => {
+      let clusterFilter = appListExtractorService.clusterFilterForCredentialsAndRegion($scope.stage.account, $scope.stage.region);
       $scope.clusterList = appListExtractorService.getClusters([$scope.application], clusterFilter);
     };
 
@@ -60,6 +54,11 @@ module.exports = angular.module('spinnaker.netflix.pipeline.stage.quickPatchAsgS
       setClusterList();
     };
 
+    $scope.reset = () => {
+      $scope.accountUpdated();
+      $scope.resetSelectedCluster();
+    };
+
     $scope.accountUpdated = function() {
       let accountFilter = (cluster) => cluster.account === $scope.stage.credentials;
 
@@ -68,7 +67,6 @@ module.exports = angular.module('spinnaker.netflix.pipeline.stage.quickPatchAsgS
 
       $scope.regionsLoaded = true;
       $scope.stage.account = $scope.stage.credentials;
-      $scope.resetSelectedCluster();
     };
 
     (function() {


### PR DESCRIPTION
Also fixing a bug that surfaced in the deployed quick patch stage where a saved cluster name was getting marked undefined upon stage load.
This fixes the QIP stage and all the other stages that use the cluster selector.

The cluster filter was also extracted into a factory function that can be used across all stages.

@anotherchrisberry please review.