### PR TITLE
prefix slash in capacity/zones heading with whitespace

### DIFF
--- a/app/scripts/modules/amazon/serverGroup/configure/wizard/serverGroupWizard.html
+++ b/app/scripts/modules/amazon/serverGroup/configure/wizard/serverGroupWizard.html
@@ -21,7 +21,7 @@
       <wizard-page key="instance-type" label="Instance Type" render="command.viewState.instanceProfile && command.viewState.instanceProfile !== 'custom'">
         <ng-include src="pages.instanceType"></ng-include>
       </wizard-page>
-      <wizard-page key="capacity" label="Capacity/ Zones">
+      <wizard-page key="capacity" label="Capacity / Zones">
         <ng-include src="pages.capacity"></ng-include>
       </wizard-page>
       <wizard-page key="advanced" label="Advanced Settings" mandatory="false">


### PR DESCRIPTION
<img width="570" alt="screen shot 2016-01-26 at 2 11 10 pm" src="https://cloud.githubusercontent.com/assets/73450/12596828/c1ce6a3c-c436-11e5-8ab6-1cb1f87d5c1b.png">

@zanthrash plz review