### PR TITLE
executionUser filter: do not throw NPE if no parent execution

### DIFF
--- a/app/scripts/modules/core/delivery/status/executionUser.filter.js
+++ b/app/scripts/modules/core/delivery/status/executionUser.filter.js
@@ -2,15 +2,17 @@
 
 let angular = require('angular');
 
-module.exports = angular.module('spinnaker.core.delivery.executionUser.filter', [])
-  .filter('executionUser', function () {
+module.exports = angular.module('spinnaker.core.delivery.executionUser.filter', [
+  require('../../utils/lodash.js'),
+])
+  .filter('executionUser', function (_) {
     return function (input) {
       if (!input.trigger.user) {
         return 'unknown user';
       }
       var user = input.trigger.user;
-      if (user === '[anonymous]') {
-        user = input.trigger.parentExecution.trigger.user || user;
+      if (user === '[anonymous]' && _.has(input, 'trigger.parentExecution.trigger.user')) {
+        user = input.trigger.parentExecution.trigger.user;
       }
       return user;
     };


### PR DESCRIPTION
If authentication is disabled, the user will be `[anonymous]`, even if not triggered by a parent pipeline.

cc @tomaslin 