### PR TITLE
get provider, vpcId from configured security group

### DIFF
--- a/app/scripts/modules/amazon/securityGroup/details/securityGroupDetail.controller.js
+++ b/app/scripts/modules/amazon/securityGroup/details/securityGroupDetail.controller.js
@@ -102,8 +102,8 @@ module.exports = angular.module('spinnaker.securityGroup.aws.details.controller'
 
       var submitMethod = function () {
         return securityGroupWriter.deleteSecurityGroup(securityGroup, application, {
-          cloudProvider: $scope.securityGroup.type,
-          vpcId: $scope.securityGroup.vpcId,
+          cloudProvider: securityGroup.provider,
+          vpcId: securityGroup.vpcId,
         });
       };
 


### PR DESCRIPTION
It is hard for me to imagine a scenario where `$scope.securityGroup` would be `undefined` at this point in the code, but apparently there is one, so let's not throw an NPE if we get there.