### PR TITLE
Issue 688 branching

### DIFF
--- a/app/scripts/modules/core/help/helpContents.js
+++ b/app/scripts/modules/core/help/helpContents.js
@@ -157,12 +157,13 @@ module.exports = angular.module('spinnaker.core.help.contents', [])
     'pipeline.config.bake.amiSuffix': '<p>(Optional) String of date in format YYYYMMDDHHmm, default is calculated from timestamp,</p>',
     'pipeline.config.bake.enhancedNetworking': '<p>(Optional) Enable enhanced networking (sr-iov) support for image (requires hvm and trusty base_os).</p>',
     'pipeline.config.bake.amiName': '<p>(Optional) Default = $package-$arch-$ami_suffix-$store_type</p>',
-    'pipeline.config.bake.templateFileName': '<p>(Optional) The explicit packer template to use, instead of resolving one from rosco\'s configuration.</p>',
     'pipeline.config.gce.bake.baseImage': '<p>(Optional) A GCE image name. For example: ubuntu-1204-precise-v20150910.</p>',
     'pipeline.config.manualJudgment.instructions': '<p>(Optional) Instructions are shown to the user when making a manual judgment.</p><p>May contain HTML.</p>',
     'pipeline.config.manualJudgment.failPipeline': '' +
       '<p><strong>Checked</strong> - the overall pipeline will fail whenever the manual judgment is negative.</p>' +
       '<p><strong>Unchecked</strong> - the overall pipeline will continue executing but this particular branch will stop.</p>',
+    'pipeline.config.manualJudgment.judgmentInputs': '<p>(Optional) Entries populate input dropdown when making manual judgment.</p>' +
+      '<p>Selected value can be used in precondition to determine branching.  e.g. execution.stages[n].context.judgmentInput==value</p>',
     'pipeline.config.failPipeline': '' +
     '<p><strong>Checked</strong> - the overall pipeline will fail whenever the stage fails.</p>' +
     '<p><strong>Unchecked</strong> - the overall pipeline will continue executing but this particular branch will stop.</p>',

--- a/app/scripts/modules/core/help/helpContents.js
+++ b/app/scripts/modules/core/help/helpContents.js
@@ -157,6 +157,7 @@ module.exports = angular.module('spinnaker.core.help.contents', [])
     'pipeline.config.bake.amiSuffix': '<p>(Optional) String of date in format YYYYMMDDHHmm, default is calculated from timestamp,</p>',
     'pipeline.config.bake.enhancedNetworking': '<p>(Optional) Enable enhanced networking (sr-iov) support for image (requires hvm and trusty base_os).</p>',
     'pipeline.config.bake.amiName': '<p>(Optional) Default = $package-$arch-$ami_suffix-$store_type</p>',
+    'pipeline.config.bake.templateFileName': '<p>(Optional) The explicit packer template to use, instead of resolving one from rosco\'s configuration.</p>',
     'pipeline.config.gce.bake.baseImage': '<p>(Optional) A GCE image name. For example: ubuntu-1204-precise-v20150910.</p>',
     'pipeline.config.manualJudgment.instructions': '<p>(Optional) Instructions are shown to the user when making a manual judgment.</p><p>May contain HTML.</p>',
     'pipeline.config.manualJudgment.failPipeline': '' +

--- a/app/scripts/modules/core/pipeline/config/stages/manualJudgment/manualJudgment.service.js
+++ b/app/scripts/modules/core/pipeline/config/stages/manualJudgment/manualJudgment.service.js
@@ -20,16 +20,15 @@ module.exports = angular
       };
     };
 
-    let provideJudgment = (execution, stage, judgment) => {
+    let provideJudgment = (execution, stage, judgment, input) => {
       var targetUrl = [settings.gateUrl, 'pipelines', execution.id, 'stages', stage.id].join('/');
       var deferred = $q.defer();
       var request = {
         method: 'PATCH',
         url: targetUrl,
-        data: {judgmentStatus: judgment},
+        data: {judgmentStatus: judgment, judgmentInput: input},
         timeout: settings.pollSchedule * 2 + 5000, // TODO: replace with apiHost call
       };
-
       $http(request)
         .success(() => {
           executionService.waitUntilExecutionMatches(execution.id, buildMatcher(stage, judgment, deferred))

--- a/app/scripts/modules/core/pipeline/config/stages/manualJudgment/manualJudgmentExecutionDetails.controller.js
+++ b/app/scripts/modules/core/pipeline/config/stages/manualJudgment/manualJudgmentExecutionDetails.controller.js
@@ -16,6 +16,7 @@ module.exports = angular
     $scope.viewState = {
       submitting: false,
       judgmentDecision: null,
+      judgmentInput: null,
       error: false,
     };
 
@@ -38,12 +39,12 @@ module.exports = angular
       $scope.viewState.error = true;
     }
 
-    this.provideJudgment = (judgmentDecision) => {
+    this.provideJudgment = (judgmentDecision, judgmentInput) => {
       $scope.viewState.submitting = true;
       $scope.viewState.error = false;
       $scope.viewState.judgmentDecision = judgmentDecision;
-      return manualJudgmentService.provideJudgment($scope.execution, $scope.stage, judgmentDecision)
+      $scope.viewState.judgmentInput = judgmentInput;
+      return manualJudgmentService.provideJudgment($scope.execution, $scope.stage, judgmentDecision, judgmentInput)
         .then(judgmentMade, judgmentFailure);
     };
-
   });

--- a/app/scripts/modules/core/pipeline/config/stages/manualJudgment/manualJudgmentExecutionDetails.html
+++ b/app/scripts/modules/core/pipeline/config/stages/manualJudgment/manualJudgmentExecutionDetails.html
@@ -10,12 +10,23 @@
           <dd ng-if="stage.context.lastModifiedBy">
             <span ng-bind="stage.context.lastModifiedBy"></span> <br/> {{ stage.endTime | timestamp }}
           </dd>
+          <dt ng-if="stage.context.judgmentInput">Input</dt>
+          <dd ng-if="stage.context.judgmentInput">{{ stage.context.judgmentInput | robotToHuman}}</dd>
           <dt>Instructions</dt>
           <dd ng-bind-html="stage.context.instructions"></dd>
         </dl>
       </div>
       <div class="col-md-9" ng-if="!stage.context.judgmentStatus && stage.status === 'RUNNING'">
-        <button class="btn btn-primary" ng-click="manualCtrl.provideJudgment('continue')" ng-disabled="viewState.submitting">
+        <div ng-if="!!stage.context.judgmentInputs.length">
+          <p><b>Judgment Input</b></p>
+          <ui-select ng-model="viewState.judgmentInput" class="form-control input-sm">
+            <ui-select-match allow-clear="true" placeholder="Select...">{{$select.selected.value}}</ui-select-match>
+            <ui-select-choices repeat="judgmentInput in stage.context.judgmentInputs | filter: $select.search">
+              <span ng-bind-html="judgmentInput.value | highlight: $select.search"></span>
+            </ui-select-choices>
+          </ui-select>
+        </div>
+        <button class="btn btn-primary" ng-click="manualCtrl.provideJudgment('continue', viewState.judgmentInput.value)" ng-disabled="viewState.submitting">
           <button-busy-indicator ng-if="viewState.submitting && viewState.judgmentDecision === 'continue'"></button-busy-indicator>
           Continue
         </button>

--- a/app/scripts/modules/core/pipeline/config/stages/manualJudgment/manualJudgmentStage.html
+++ b/app/scripts/modules/core/pipeline/config/stages/manualJudgment/manualJudgmentStage.html
@@ -13,6 +13,39 @@
       </label>
     </div>
   </stage-config-field>
+  <stage-config-field label="Judgment Input Values" help-key="pipeline.config.manualJudgment.judgmentInputs">
+    <table class="table table-condensed packed">
+      <thead>
+      <tr>
+        <th>Input Value</th>
+        <th>Actions</th>
+      </tr>
+      </thead>
+      <tbody>
+      <tr ng-repeat="judgmentInput in stage.judgmentInputs track by $index">
+        <td>
+        <div class="col-md-6">
+          <input type="text" required ng-model="judgmentInput.value" value="{{judgmentInput.value}}"
+                 class="form-control input-sm"/>
+        </div>
+        </td>
+        <td>
+          <a class="btn btn-xs btn-link pad-left" href
+             ng-click="manualJudgmentStageCtrl.removeJudgmentInput($index)">Remove</a>
+        </td>
+      </tr>
+      </tbody>
+      <tfoot>
+      <tr>
+        <td colspan="7">
+          <button class="btn btn-block btn-sm add-new" ng-click="manualJudgmentStageCtrl.addJudgmentInput()">
+            <span class="glyphicon glyphicon-plus-sign"></span> Add judgment input
+          </button>
+        </td>
+      </tr>
+      </tfoot>
+    </table>
+  </stage-config-field>
   <stage-config-field label="Notifications">
     <table class="table table-condensed">
       <thead>

--- a/app/scripts/modules/core/pipeline/config/stages/manualJudgment/manualJudgmentStage.js
+++ b/app/scripts/modules/core/pipeline/config/stages/manualJudgment/manualJudgmentStage.js
@@ -19,6 +19,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.manualJudgmentSta
   .controller('ManualJudgmentStageCtrl', function($scope, $uibModal) {
 
     $scope.stage.notifications = $scope.stage.notifications || [];
+    $scope.stage.judgmentInputs = $scope.stage.judgmentInputs || [];
     $scope.stage.failPipeline = ($scope.stage.failPipeline === undefined ? true : $scope.stage.failPipeline);
 
     this.addNotification = function() {
@@ -40,4 +41,15 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.manualJudgmentSta
       $scope.stage.notifications.splice(idx, 1);
     };
 
+    this.addJudgmentInput = function() {
+      if (!$scope.stage.judgmentInputs) {
+        $scope.stage.judgmentInputs = [];
+      }
+      var judgmentInput = {};
+      $scope.stage.judgmentInputs.push(judgmentInput);
+    };
+
+    this.removeJudgmentInput = function (idx) {
+      $scope.stage.judgmentInputs.splice(idx, 1);
+    };
   });


### PR DESCRIPTION
Add support for branching after a manual judgment stage as discussed in issue [#688.](https://github.com/spinnaker/spinnaker/issues/688)  At design time, a user may add a series of inputs values to manual judgment stage.
![image](https://cloud.githubusercontent.com/assets/3035661/12734835/98fc5e3a-c908-11e5-8672-906caaf3271c.png)

Those values will then populate a searchable drop down in the manual judgment at runtime.  If no values were entered at design, this will not appear.
![image](https://cloud.githubusercontent.com/assets/3035661/12734847/b67633aa-c908-11e5-94c0-d8ae9ce00445.png)

By doing this, several parallel pipeline paths can be branched after a manual judgment.  Each of those paths would then start with a Check Precondition Stage.  That stage would look for the input value selected in the manual judgment.  

![image](https://cloud.githubusercontent.com/assets/3035661/12734914/3d3796f4-c909-11e5-86de-31dd4d81e293.png)
