### PR TITLE
style tweaks to judgment inputs

### DIFF
--- a/app/scripts/modules/core/help/helpContents.js
+++ b/app/scripts/modules/core/help/helpContents.js
@@ -163,8 +163,12 @@ module.exports = angular.module('spinnaker.core.help.contents', [])
     'pipeline.config.manualJudgment.failPipeline': '' +
       '<p><strong>Checked</strong> - the overall pipeline will fail whenever the manual judgment is negative.</p>' +
       '<p><strong>Unchecked</strong> - the overall pipeline will continue executing but this particular branch will stop.</p>',
-    'pipeline.config.manualJudgment.judgmentInputs': '<p>(Optional) Entries populate input dropdown when making manual judgment.</p>' +
-      '<p>Selected value can be used in precondition to determine branching.  e.g. execution.stages[n].context.judgmentInput==value</p>',
+    'pipeline.config.manualJudgment.judgmentInputs': '<p>(Optional) Entries populate a dropdown displayed when ' +
+      'performing a manual judgment.</p>' +
+      '<p>The selected value can be used in a subsequent <strong>Check Preconditions</strong> stage to determine branching.</p>' +
+      '<p>For example, if the user selects "rollback" from this list of options, that branch can be activated by using the ' +
+      'expression: ' +
+      '<samp class="small">execution.stages[n].context.judgmentInput=="rollback"</samp></p>',
     'pipeline.config.failPipeline': '' +
     '<p><strong>Checked</strong> - the overall pipeline will fail whenever the stage fails.</p>' +
     '<p><strong>Unchecked</strong> - the overall pipeline will continue executing but this particular branch will stop.</p>',

--- a/app/scripts/modules/core/modal/modals.less
+++ b/app/scripts/modules/core/modal/modals.less
@@ -237,6 +237,10 @@ select.select2 {
   background: #ffffff;
 }
 
+abbr.select2-search-choice-close {
+  margin-top: 0;
+}
+
 .select2-container-multi {
   &.select2-container-active {
     .select2-choices {

--- a/app/scripts/modules/core/pipeline/config/stages/manualJudgment/manualJudgmentExecutionDetails.html
+++ b/app/scripts/modules/core/pipeline/config/stages/manualJudgment/manualJudgmentExecutionDetails.html
@@ -12,12 +12,12 @@
           </dd>
           <dt ng-if="stage.context.judgmentInput">Input</dt>
           <dd ng-if="stage.context.judgmentInput">{{ stage.context.judgmentInput | robotToHuman}}</dd>
-          <dt>Instructions</dt>
+          <dt ng-if="stage.context.instructions">Instructions</dt>
           <dd ng-bind-html="stage.context.instructions"></dd>
         </dl>
       </div>
       <div class="col-md-9" ng-if="!stage.context.judgmentStatus && stage.status === 'RUNNING'">
-        <div ng-if="!!stage.context.judgmentInputs.length">
+        <div class="form-group" ng-if="!!stage.context.judgmentInputs.length">
           <p><b>Judgment Input</b></p>
           <ui-select ng-model="viewState.judgmentInput" class="form-control input-sm">
             <ui-select-match allow-clear="true" placeholder="Select...">{{$select.selected.value}}</ui-select-match>

--- a/app/scripts/modules/core/pipeline/config/stages/manualJudgment/manualJudgmentStage.html
+++ b/app/scripts/modules/core/pipeline/config/stages/manualJudgment/manualJudgmentStage.html
@@ -13,25 +13,22 @@
       </label>
     </div>
   </stage-config-field>
-  <stage-config-field label="Judgment Input Values" help-key="pipeline.config.manualJudgment.judgmentInputs">
+  <stage-config-field label="Judgment Inputs" help-key="pipeline.config.manualJudgment.judgmentInputs">
     <table class="table table-condensed packed">
       <thead>
       <tr>
-        <th>Input Value</th>
-        <th>Actions</th>
+        <th style="width:30%">Option</th>
+        <th class="text-right">Actions</th>
       </tr>
       </thead>
       <tbody>
       <tr ng-repeat="judgmentInput in stage.judgmentInputs track by $index">
         <td>
-        <div class="col-md-6">
           <input type="text" required ng-model="judgmentInput.value" value="{{judgmentInput.value}}"
                  class="form-control input-sm"/>
-        </div>
         </td>
-        <td>
-          <a class="btn btn-xs btn-link pad-left" href
-             ng-click="manualJudgmentStageCtrl.removeJudgmentInput($index)">Remove</a>
+        <td class="text-right">
+          <a class="small" href ng-click="manualJudgmentStageCtrl.removeJudgmentInput($index)">Remove</a>
         </td>
       </tr>
       </tbody>
@@ -52,7 +49,7 @@
       <tr>
         <th>Type</th>
         <th>Details</th>
-        <th>Actions</th>
+        <th class="text-right">Actions</th>
       </tr>
       </thead>
       <tbody>
@@ -63,8 +60,8 @@
         <td>
           {{notification.address}}
         </td>
-        <td>
-          <a class="btn btn-xs btn-link pad-left" href
+        <td class="text-right">
+          <a class="small" href
              ng-click="manualJudgmentStageCtrl.removeNotification($index)">Remove</a>
         </td>
       </tr>


### PR DESCRIPTION
Minor style and wording changes to supplement https://github.com/spinnaker/deck/pull/1929

Configuration view
 * Do not show "Instructions" heading if no instructions present
 * Expanded help text to provide more context
 * Tweak alignment of table elements
<img width="785" alt="screen shot 2016-02-01 at 10 27 17 pm" src="https://cloud.githubusercontent.com/assets/73450/12741711/cc9195c8-c933-11e5-812a-0e63086dd6a8.png">

Execution view
 * Add some padding between ui-select and Stop/Continue buttons
 * Fixed position of clearing `x` in ui-select
<img width="403" alt="screen shot 2016-02-01 at 10 34 59 pm" src="https://cloud.githubusercontent.com/assets/73450/12741744/10a74a00-c934-11e5-9403-f9b8eb470973.png">

@bfarrell I figured this would be easier than asking you to make all these little changes in your PR.

