### PR TITLE
SPIN-1447: multiselect UX improvements

### DIFF
--- a/app/scripts/modules/core/cluster/rollups.less
+++ b/app/scripts/modules/core/cluster/rollups.less
@@ -76,10 +76,6 @@
     font-size: 200%;
     margin: 0;
   }
-  tr.instance-row:hover > td.no-hover {
-    background-color: #ffffff;
-    cursor: default;
-  }
   a.instance {
     margin: 0;
     display: inline-block;

--- a/app/scripts/modules/core/instance/details/multipleInstances.controller.js
+++ b/app/scripts/modules/core/instance/details/multipleInstances.controller.js
@@ -200,17 +200,15 @@ module.exports = angular.module('spinnaker.core.instance.details.multipleInstanc
       };
     };
 
-
+    let countInstances = () => {
+      return ClusterFilterModel.multiselectInstanceGroups.reduce((acc, group) => acc + group.instanceIds.length, 0);
+    };
 
     let retrieveInstances = () => {
-      this.instancesCount = 0;
+      this.instancesCount = countInstances();
       this.selectedGroups = ClusterFilterModel.multiselectInstanceGroups
         .filter((group) => group.instanceIds.length)
         .map(makeServerGroupModel);
-
-      this.selectedGroups.forEach((group) => {
-        this.instancesCount += group.instances.length;
-      });
     };
 
     let multiselectWatcher = ClusterFilterModel.multiselectInstancesStream.subscribe(retrieveInstances);
@@ -219,6 +217,11 @@ module.exports = angular.module('spinnaker.core.instance.details.multipleInstanc
     retrieveInstances();
 
     $scope.$on('$destroy', () => {
+      // if there's just one instance selected, this is being destroyed because we're moving to the instanceDetails
+      // view; otherwise, deselect any instances because the user is closing the panel explicitly
+      if (countInstances() !== 1) {
+        ClusterFilterModel.clearAllMultiselectGroups();
+      }
       refreshWatcher.dispose();
       multiselectWatcher.dispose();
     });

--- a/app/scripts/modules/core/instance/instanceListBody.directive.js
+++ b/app/scripts/modules/core/instance/instanceListBody.directive.js
@@ -23,8 +23,6 @@ module.exports = angular.module('spinnaker.core.instance.instanceListBody.direct
             instanceGroup = ClusterFilterModel.getOrCreateMultiselectInstanceGroup(scope.serverGroup),
             activeInstance = null;
 
-        var base = elem.parent().inheritedData('$uiView').state;
-
         function toggleSelection(instanceId) {
           ClusterFilterModel.toggleMultiselectInstance(scope.serverGroup, instanceId);
         }
@@ -35,7 +33,7 @@ module.exports = angular.module('spinnaker.core.instance.instanceListBody.direct
 
         function buildInstanceCheckboxCell(instance) {
           let isChecked = ClusterFilterModel.instanceIsMultiselected(scope.serverGroup, instance.id);
-          return `<td class="no-hover"><input type="checkbox" data-instance-id="${instance.id}" ${isChecked ? 'checked' : ''}/></td>`;
+          return `<td class="no-hover"><input type="checkbox" ${isChecked ? 'checked' : ''}/></td>`;
         }
 
         function buildInstanceIdCell(instance) {
@@ -208,12 +206,6 @@ module.exports = angular.module('spinnaker.core.instance.instanceListBody.direct
         elem.click(function(event) {
           $timeout(function() {
             if (event.target) {
-              let $target = $(event.target);
-              if ($target.is(':checkbox')) {
-                toggleSelection(event.target.getAttribute('data-instance-id'));
-                event.preventDefault();
-                return;
-              }
               // anything handled by ui-sref or actual links should be ignored
               if (event.isDefaultPrevented() || (event.originalEvent && (event.originalEvent.defaultPrevented || event.originalEvent.target.href))) {
                 return;
@@ -225,15 +217,7 @@ module.exports = angular.module('spinnaker.core.instance.instanceListBody.direct
               if (activeInstance) {
                 $('tr[data-instance-id="' + activeInstance.instanceId + '"]', elem).removeClass('active');
               }
-              var targetRow = $targetRow.get(0);
-              var params = {
-                instanceId: targetRow.getAttribute('data-instance-id'),
-                provider: targetRow.getAttribute('data-provider')
-              };
-              activeInstance = params;
-              // also stolen from uiSref directive
-              $state.go('.instanceDetails', params, {relative: base, inherit: true});
-              $targetRow.addClass('active');
+              toggleSelection($targetRow.attr('data-instance-id'));
               event.preventDefault();
             }
           });


### PR DESCRIPTION
The current behavior around multiselect is really confusing: users have to click the checkbox next to an instance to enable multiselect, but a lot of users assume they should click on that checkbox to see details for a single instance, so they're confused when they just see "1 Instance" in the heading and a very limited view of that instance's details.

Also, trying to close the details panel in multiselect mode doesn't do anything - it just pops right back up.

Finally, it's really unintuitive that clicking the checkbox and clicking elsewhere in the row result in totally different details view.

This PR addresses most of these concerns. The row and the checkbox behave the same way: they select the instance in multiselect mode. However, if just one instance is selected, we show the instance's details, not the "1 instance" multiselect details.

I believe I've accounted for every scenario except one:
 * loading the page (from a deep link) in multiselect mode with an instance details view showing
 * toggling between 0-1 instances, 0-2 instances, 2-0, 1-0, with or without either details view present
 * closing the instance details panel
 * closing the multiselect panel
 * toggling the "with details" checkbox, with or without an instance selected

The one scenario I can't do cleanly is toggling the "with details" checkbox when multiple instances are selected. Because that checkbox doesn't fire a `$stateChangeStart` event, we'd have to listen to the `$rootScope`'s `$locationChangeStart` event and parse the parameters to make the decision, which seems really nasty. So toggling "with details" off will leave the multiselect details view open.

@zanthrash please review and never make me touch routing again outside Angular UI in this application.
