### PR TITLE
SPIN-1453: Adding new ACA Config selector to FP ACA screen.

### DIFF
--- a/app/scripts/modules/netflix/canary/canary.read.service.js
+++ b/app/scripts/modules/netflix/canary/canary.read.service.js
@@ -9,12 +9,17 @@ module.exports = angular
   ])
   .factory('canaryReadService', function(Restangular) {
 
-    function getCanaryById(canaryId) {
+    let getCanaryById = (canaryId) => {
       return Restangular.one('canaries').one(canaryId).get();
-    }
+    };
+
+    let getCanaryConfigsByApplication = (applicationName) => {
+      return Restangular.one('canaryConfigs').one(applicationName).getList();
+    };
 
     return {
       getCanaryById: getCanaryById,
+      getCanaryConfigsByApplication: getCanaryConfigsByApplication
     };
 
   });

--- a/app/scripts/modules/netflix/canary/canaryConfigSelector.directive.html
+++ b/app/scripts/modules/netflix/canary/canaryConfigSelector.directive.html
@@ -1,0 +1,19 @@
+<div>
+  <div>
+    <ui-select
+      ng-model="vm.model"
+      class="form-control input-sm"
+      on-select="vm.selectorChanged($item)" >
+
+      <ui-select-match>
+        <span ng-if="vm.isNameInConfigList($select.selected.name)">{{$select.selected.name}}</span>
+      </ui-select-match>
+
+      <ui-select-choices
+        repeat="option in (vm.canaryConfigs | filter: $select.search) track by option.id" >
+        {{option.name}}
+      </ui-select-choices>
+    </ui-select>
+
+  </div>
+</div>

--- a/app/scripts/modules/netflix/canary/canaryConfigSelector.directive.js
+++ b/app/scripts/modules/netflix/canary/canaryConfigSelector.directive.js
@@ -1,0 +1,57 @@
+'use strict';
+
+let angular = require('angular');
+
+module.exports = angular
+  .module('spinnaker.netfilx.widgits.canaryConfigSelector.directive', [
+    require('./canary.read.service'),
+    require('../../core/utils/lodash')
+  ])
+  .directive('canaryConfigSelector', () => {
+    return {
+      scope: {},
+      bindToController: {
+        model: '=' ,
+        applicationName: '='
+      },
+      templateUrl: require('./canaryConfigSelector.directive.html'),
+      controllerAs: 'vm',
+      controller: function($scope, canaryReadService, _) {
+        let vm = this;
+
+        vm.selectorChanged = (model) => {
+          if (model) {
+            vm.model = model;
+            vm.model.successfulScore = model.canarySuccessCriteria.canaryResultScore;
+            vm.model.unhealthyScore = model.canaryHealthCheckHandler.minimumCanaryResultScore;
+            vm.model.resultStrategy = model.combinedCanaryResultStrategy;
+          }
+        };
+
+        vm.isNameInConfigList = (selectedName) => {
+          return getSelected(vm.canaryConfigs, selectedName).length ? true : false;
+        };
+
+        let setOptions = (results) => {
+          vm.canaryConfigs = results;
+          return vm.canaryConfigs;
+        };
+
+        let getSelected = _.curry((canaryConfigs = [], canaryName) => {
+          return canaryConfigs.filter((config) => config.name === canaryName);
+        });
+
+        let findConfigAndSet = _.flowRight(vm.selectorChanged, _.first, getSelected);
+
+        $scope.$watch('vm.model.name', function(newVal) {
+          if(newVal !== undefined) {
+            findConfigAndSet(vm.canaryConfigs, newVal);
+          }
+        });
+
+        canaryReadService.getCanaryConfigsByApplication(vm.applicationName)
+          .then(setOptions);
+
+      }
+    };
+  });

--- a/app/scripts/modules/netflix/canary/index.js
+++ b/app/scripts/modules/netflix/canary/index.js
@@ -4,5 +4,6 @@ let angular = require('angular');
 
 module.exports = angular
   .module('spinnaker.core.canary', [
-    require('./canaryAnalysisNameSelector.directive.js')
+    require('./canaryAnalysisNameSelector.directive.js'),
+    require('./canaryConfigSelector.directive')
   ]);

--- a/app/scripts/modules/netflix/fastProperties/modal/wizard/fastPropertyAcaConfigForm.directive.html
+++ b/app/scripts/modules/netflix/fastProperties/modal/wizard/fastPropertyAcaConfigForm.directive.html
@@ -23,6 +23,18 @@
 
               <div class="form-group">
                 <div class="indent col-md-4  sm-label-right">
+                  <b>Configs</b>
+                </div>
+                <div class="col-md-8">
+                  <canary-config-selector
+                    application-name="newFP.appName"
+                    model="newFP.property.canary">
+                  </canary-config-selector>
+                </div>
+              </div>
+
+              <div class="form-group">
+                <div class="indent col-md-4  sm-label-right">
                   <b>Name</b>
                 </div>
                 <div class="col-md-8">
@@ -65,8 +77,8 @@
                       class="form-control input-sm"
                       ng-model="newFP.property.canary.resultStrategy"
                       >
-                    <option value="LOWEST">lowest</option>
-                    <option value="AGGREGATE">aggregate</option>
+                    <option value="LOWEST" ng-selected="newFP.property.canary.resultStrategy === 'LOWEST'">lowest</option>
+                    <option value="AGGREGATE" ng-selected="newFP.property.canary.resultStrategy === 'AGGREGATE'">aggregate</option>
                   </select>
                 </div>
               </div>
@@ -198,5 +210,4 @@
     </button>
   </div>
 
-  {{newFP.startScope}}
 </form>


### PR DESCRIPTION
This selector gets a list of all previous Canary Configs for a given app.   When the user selects a previous confg it populates the Canary Config form with the values.

This can eventually go into the ACA pipeline stage I just want to get it out there and get some feedback from users.