### PR TITLE
SPIN-1415:  Evict Local Storage if there is an exception on setItem

### DIFF
--- a/app/scripts/modules/core/cache/collapsibleSectionStateCache.js
+++ b/app/scripts/modules/core/cache/collapsibleSectionStateCache.js
@@ -12,7 +12,7 @@ module.exports = angular.module('spinnaker.core.cache.collapsibleSectionState', 
 
     try {
       CacheFactory.createCache(cacheId, {
-        maxAge: 30 * 24 * 60 * 60 * 1000, // 30 days
+        maxAge: 7 * 24 * 60 * 60 * 1000, // 7 days
         deleteOnExpire: 'aggressive',
         storageMode: 'localStorage',
       });

--- a/app/scripts/modules/core/cache/deckCacheFactory.js
+++ b/app/scripts/modules/core/cache/deckCacheFactory.js
@@ -60,16 +60,7 @@ module.exports = angular.module('spinnaker.core.cache.deckCacheFactory', [
           window.localStorage.setItem(k, v);
         } catch (e) {
           $log.warn('Local Storage Error! Clearing caches and trying again.\nException:', e);
-          for (var key in window.localStorage) {
-            // invalidate keystore for any angular caches
-            if (key.match(/angular-cache\.caches\.infrastructure:.*.\.keys/)) {
-              window.localStorage.setItem(key, '[]');
-            }
-            // clear the data itself
-            if (key.match(/angular-cache\.caches\.infrastructure:.*.\.data\./)) {
-              window.localStorage.removeItem(key);
-            }
-          }
+          window.localStorage.clear();
           window.localStorage.setItem(k, v);
         }
       },


### PR DESCRIPTION
Our current strategy to only clear out the infrastructureCaches if there is an exception thrown on insert.
As the app has grown we have added more and more to Local Storage resulting in the possibility of exhausting the 5MB of space given in most browsers.

This change simply evicts the entire local storage (restricted to the namespace of the url), when there is an insert exception.

This change also reduces the TTL of the 'collapsible section cache' from 30 days to 7 days.

@anotherchrisberry Please review.