### PR TITLE
Fix for "The deck debian package does not install apache2 in the right order" Issue#723

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,8 @@ ospackage {
   packageName = "spinnaker-deck"
   version = toVers(project.version.toString())
   release '3'
-  into "/var/www/html"
+  into "/opt/deck/html"
   requires "apache2"
   from "build/webpack"
 }
+


### PR DESCRIPTION
Previously apache2 was added as "Depends" in the control file (through build.gradle). Because of this, the actual deployment of apache2 was happening only after the deck files are laid out. This resulted in the index.html file being overwritten by the one from apache2.
Fix was to add apache2 as Pre-Depends instead of Depends in the debian control file thereby making sure that apache2 is installed and configured fully before deck is installed.