### PR TITLE
provider/kubernetes: Render basic server group information on "cluster" screen

### DIFF
--- a/app/scripts/modules/kubernetes/kubernetes.module.js
+++ b/app/scripts/modules/kubernetes/kubernetes.module.js
@@ -11,6 +11,7 @@ templates.keys().forEach(function(key) {
 module.exports = angular.module('spinnaker.kubernetes', [
   require('./serverGroup/configure/CommandBuilder.js'),
   require('./serverGroup/configure/configure.kubernetes.module.js'),
+  require('./serverGroup/details/details.kubernetes.module.js'),
   require('./serverGroup/transformer.js'),
 ])
   .config(function(cloudProviderRegistryProvider) {
@@ -21,6 +22,8 @@ module.exports = angular.module('spinnaker.kubernetes', [
       },
       serverGroup: {
         transformer: 'kubernetesServerGroupTransformer',
+        detailsTemplateUrl: require('./serverGroup/details/details.html'),
+        detailsController: 'kubernetesDetailsController',
         cloneServerGroupController: 'kubernetesCloneServerGroupController',
         cloneServerGroupTemplateUrl: require('./serverGroup/configure/wizard/wizard.html'),
         commandBuilder: 'kubernetesServerGroupCommandBuilder',

--- a/app/scripts/modules/kubernetes/serverGroup/details/details.controller.js
+++ b/app/scripts/modules/kubernetes/serverGroup/details/details.controller.js
@@ -1,0 +1,118 @@
+'use strict';
+/* jshint camelcase:false */
+
+let angular = require('angular');
+
+module.exports = angular.module('spinnaker.serverGroup.details.kubernetes.controller', [
+  require('angular-ui-router'),
+  require('../../../core/serverGroup/serverGroup.read.service.js'),
+  require('../../../core/serverGroup/details/serverGroupWarningMessage.service.js'),
+  require('../../../core/serverGroup/serverGroup.write.service.js'),
+  require('../../../core/serverGroup/configure/common/runningExecutions.service.js'),
+  require('../../../core/utils/lodash.js'),
+  require('../../../core/insight/insightFilterState.model.js'),
+  require('../../../core/utils/selectOnDblClick.directive.js'),
+])
+  .controller('kubernetesDetailsController', function ($scope, $state, app, serverGroup, InsightFilterStateModel,
+                                                       serverGroupReader, $uibModal, serverGroupWriter,
+                                                       runningExecutionsService, serverGroupWarningMessageService) {
+
+    let application = app;
+
+    $scope.state = {
+      loading: true
+    };
+
+    $scope.InsightFilterStateModel = InsightFilterStateModel;
+
+    function extractServerGroupSummary() {
+      var summary = _.find(application.serverGroups, function (toCheck) {
+        return toCheck.name === serverGroup.name && toCheck.account === serverGroup.accountId && toCheck.region === serverGroup.region;
+      });
+      if (!summary) {
+        application.loadBalancers.some(function (loadBalancer) {
+          if (loadBalancer.account === serverGroup.accountId && loadBalancer.region === serverGroup.region) {
+            return loadBalancer.serverGroups.some(function (possibleServerGroup) {
+              if (possibleServerGroup.name === serverGroup.name) {
+                summary = possibleServerGroup;
+                return true;
+              }
+            });
+          }
+        });
+      }
+      return summary;
+    }
+
+    function retrieveServerGroup() {
+      var summary = extractServerGroupSummary();
+      return serverGroupReader.getServerGroup(application.name, serverGroup.accountId, serverGroup.region, serverGroup.name).then(function(details) {
+        cancelLoader();
+
+        var restangularlessDetails = details.plain();
+        angular.extend(restangularlessDetails, summary);
+
+        $scope.serverGroup = restangularlessDetails;
+        $scope.runningExecutions = function() {
+          return runningExecutionsService.filterRunningExecutions($scope.serverGroup.executions);
+        };
+      },
+        autoClose
+      );
+    }
+
+    function autoClose() {
+      if ($scope.$$destroyed) {
+        return;
+      }
+      $state.params.allowModalToStayOpen = true;
+      $state.go('^', null, {location: 'replace'});
+    }
+
+    function cancelLoader() {
+      $scope.state.loading = false;
+    }
+
+    retrieveServerGroup().then(() => {
+      // If the user navigates away from the view before the initial retrieveServerGroup call completes,
+      // do not bother subscribing to the autoRefreshStream
+      if (!$scope.$$destroyed) {
+        let refreshWatcher = app.autoRefreshStream.subscribe(retrieveServerGroup);
+        $scope.$on('$destroy', () => refreshWatcher.dispose());
+      }
+    });
+
+    this.destroyServerGroup = () => {
+    };
+
+    this.getBodyTemplate = (serverGroup, application) => {
+      if (this.isLastServerGroupInRegion(serverGroup, application)) {
+        return serverGroupWarningMessageService.getMessage(serverGroup);
+      }
+    };
+
+    this.isLastServerGroupInRegion = function (serverGroup, application ) {
+      try {
+        var cluster = _.find(application.clusters, {name: serverGroup.cluster, account:serverGroup.account});
+        return _.filter(cluster.serverGroups, {region: serverGroup.region}).length === 1;
+      } catch (error) {
+        return false;
+      }
+    };
+
+    this.disableServerGroup = function disableServerGroup() {
+    };
+
+    this.enableServerGroup = function enableServerGroup() {
+    };
+
+    this.rollbackServerGroup = function rollbackServerGroup() {
+    };
+
+    this.resizeServerGroup = function resizeServerGroup() {
+    };
+
+    this.cloneServerGroup = function cloneServerGroup() {
+    };
+  }
+);

--- a/app/scripts/modules/kubernetes/serverGroup/details/details.html
+++ b/app/scripts/modules/kubernetes/serverGroup/details/details.html
@@ -1,0 +1,172 @@
+<div class="details-panel"
+     ng-class="{ disabled: serverGroup.isDisabled }">
+
+  <div class="header" ng-if="state.loading">
+      <div class="close-button">
+          <a class="btn btn-link"
+             ui-sref="^">
+              <span class="glyphicon glyphicon-remove"></span>
+          </a>
+      </div>
+      <h4 class="text-center">
+          <span us-spinner="{radius:20, width:6, length: 12}"></span>
+      </h4>
+  </div>
+
+
+  <div class="header" ng-if="!state.loading">
+    <div class="close-button">
+      <a class="btn btn-link"
+          ui-sref="^">
+        <span class="glyphicon glyphicon-remove"></span>
+      </a>
+    </div>
+    <div class="header-text">
+      <cloud-provider-logo provider="serverGroup.type" height="36px" width="36px" style="margin-right: 10px"></cloud-provider-logo>
+      <h3 select-on-dbl-click>
+        {{serverGroup.name}}
+      </h3>
+    </div>
+    <div>
+      <div class="actions" ng-class="{ insights: serverGroup.insightActions.length > 0 }">
+        <div class="dropdown" uib-dropdown dropdown-append-to-body>
+          <button type="button" class="btn btn-sm btn-primary dropdown-toggle" uib-dropdown-toggle>
+            Server Group Actions <span class="caret"></span>
+          </button>
+          <ul class="uib-dropdown-menu" role="menu">
+            <li><a href ng-click="warn(\"what did you think would happen?\")">Coming Soon...</a></li>
+          </ul>
+        </div>
+        <div class="dropdown" ng-if="serverGroup.insightActions.length > 0" uib-dropdown dropdown-append-to-body>
+          <button type="button" class="btn btn-sm btn-default dropdown-toggle" uib-dropdown-toggle>
+            Insight <span class="caret"></span>
+          </button>
+          <ul class="uib-dropdown-menu" role="menu">
+            <li ng-repeat="action in serverGroup.insightActions"><a target=_blank href="{{action.url}}">{{action.label}}</a></li>
+          </ul>
+        </div>
+        <div class="clearfix"></div>
+      </div>
+    </div>
+  </div>
+  <div class="content" ng-if="!state.loading">
+    <h4 class="text-center" ng-if="serverGroup.isDisabled">[SERVER GROUP IS DISABLED]</h4>
+    <collapsible-section heading="Running Tasks" expanded="true" body-class="details-running-tasks" ng-if="serverGroup.runningTasks.length > 0 || runningExecutions().length > 0">
+      <div class="container-fluid no-padding" ng-repeat="task in serverGroup.runningTasks | orderBy:'-startTime'">
+        <div class="row">
+          <div class="col-md-12">
+            <strong>
+              {{task.name}}
+            </strong>
+          </div>
+        </div>
+        <div class="row" ng-repeat="step in task.steps | displayableTasks">
+          <div class="col-md-7 col-md-offset-0">
+            <span class="small"><status-glyph item="step"></status-glyph></span> {{step.name | robotToHuman }}
+          </div>
+          <div class="col-md-4 text-right">
+            {{step.runningTimeInMs | duration }}
+          </div>
+        </div>
+      </div>
+
+      <div class="container-fluid no-padding" ng-repeat="execution in runningExecutions()">
+        <div class="row">
+          <div class="col-md-12">
+            <strong>
+              Pipeline: {{execution.name}}
+            </strong>
+          </div>
+        </div>
+        <div class="row" ng-repeat="stage in execution.stages">
+          <div class="col-md-7 col-md-offset-0">
+            <span class="small"><status-glyph item="stage"></status-glyph></span> {{stage.name | robotToHuman }}
+          </div>
+          <div class="col-md-4 text-right">
+            {{stage.runningTimeInMs | duration }}
+          </div>
+        </div>
+      </div>
+
+    </collapsible-section>
+    <collapsible-section heading="Server Group Information" expanded="true">
+      <dl class="dl-horizontal" ng-class="InsightFilterStateModel.filtersExpanded ? 'dl-narrow' : 'dl-wide'">
+        <dt>Created</dt>
+        <dd>{{serverGroup.createdTime | timestamp }}</dd>
+        <dt>In</dt>
+        <dd><account-tag account="serverGroup.account" pad="right"></account-tag><dd>
+        <dt>Namespace<dt>
+        <dd>{{serverGroup.region}}</dd>
+      </dl>
+    </collapsible-section>
+    <collapsible-section heading="Size" expanded="true">
+      <dl class="dl-horizontal"
+          ng-class="InsightFilterStateModel.filtersExpanded ? 'dl-narrow' : 'dl-wide'" >
+        <dt>Min/Max</dt>
+        <dd>{{serverGroup.capacity.desired}}</dd>
+        <dt>Current</dt>
+        <dd>{{serverGroup.instances.length}}</dd>
+      </dl>
+    </collapsible-section>
+    <collapsible-section heading="Health" expanded="true">
+      <dl class="dl-horizontal"
+          ng-class="InsightFilterStateModel.filtersExpanded ? 'dl-narrow' : 'dl-wide'"
+          ng-if="serverGroup">
+        <dt>Instances</dt>
+        <dd>
+          <health-counts container="serverGroup.instanceCounts" class="pull-left"></health-counts>
+        </dd>
+      </dl>
+    </collapsible-section>
+    <collapsible-section heading="Launch Configuration">
+      <dl ng-repeat="container in serverGroup.containers" class="dl-horizontal"
+          ng-class="InsightFilterStateModel.filtersExpanded ? 'dl-narrow' : 'dl-wide'" >
+        <dt>Name</dt> 
+        <dd>{{container.name}}</dd>
+        <dt>Image</dt>
+        <dd>{{container.image}}</dd>
+        <div ng-if="container.resources">
+          <div ng-if="container.resources.limits">
+            <div ng-if="container.resources.limits.cpu">
+              <dt>CPU Limit</dt>
+              <dd>{{container.resources.limits.cpu}}</dd>
+            </div>
+            <div ng-if="container.resources.limits.memory">
+              <dt>Memory Limit</dt>
+              <dd>{{container.resources.limits.memory}}</dd>
+            </div>
+          </div>
+          <div ng-if="container.resources.requests">
+            <div ng-if="container.resources.requests.cpu">
+              <dt>CPU Request</dt>
+              <dd>{{container.resources.requests.cpu}}</dd>
+            </div>
+            <div ng-if="container.resources.requests.memory">
+              <dt>Memory Request</dt>
+              <dd>{{container.resources.requests.memory}}</dd>
+            </div>
+          </div>
+        </div>
+      </dl>
+    </collapsible-section>
+    <collapsible-section heading="Labels">
+      <div ng-if="!serverGroup.labels">No labels associated with this replication controller</div>
+      <dl ng-repeat="(key, value) in serverGroup.labels" class="dl-horizontal"
+          ng-class="InsightFilterStateModel.filtersExpanded ? 'dl-narrow' : 'dl-wide'" >
+        {{key}}: {{value}}
+      </dl>
+    </collapsible-section>
+    <collapsible-section heading="Logs">
+      <ul>
+        <li ng-if="serverGroup.logsLink">
+          <a href="{{serverGroup.logsLink}}" target="_blank">Developers Console Logs</a>
+          <copy-to-clipboard
+              class="copy-to-clipboard copy-to-clipboard-sm"
+              text="{{serverGroup.logsLink}}"
+              tool-tip="Copy to clipboard">
+          </copy-to-clipboard>
+        </li>
+      </ul>
+    </collapsible-section>
+  </div>
+</div>

--- a/app/scripts/modules/kubernetes/serverGroup/details/details.kubernetes.module.js
+++ b/app/scripts/modules/kubernetes/serverGroup/details/details.kubernetes.module.js
@@ -1,0 +1,8 @@
+'use strict';
+
+let angular = require('angular');
+
+module.exports = angular.module('spinnaker.serverGroup.details.kubernetes', [
+  require('../../../core/account/account.module.js'),
+  require('./details.controller.js'),
+]);


### PR DESCRIPTION
Only basic information is currently displayed (name, creation time, health, resource requests, image names), but more will be added as I make the server group more customizable.