### PR TITLE
improve usability in v2 modal wizards on small screens

### DIFF
--- a/app/scripts/modules/core/modal/modals.less
+++ b/app/scripts/modules/core/modal/modals.less
@@ -15,10 +15,18 @@
   h2, h3, h4, h5 {
     font-weight: 600;
   }
+  modal-close {
+    display: block;
+    position: relative;
+    z-index: 6;
+  }
 }
 
 .modal-header {
   background-color: #f5f5f5;
+  h3 {
+    margin: 0;
+  }
 }
 
 modal-wizard {

--- a/app/scripts/modules/core/modal/wizard/modalWizard.less
+++ b/app/scripts/modules/core/modal/wizard/modalWizard.less
@@ -13,6 +13,10 @@ v2-modal-wizard {
     margin: 0;
     padding: 0;
     list-style-type: none;
+    height: auto;
+    position: relative;
+    background-color: #ffffff;
+    z-index: 5;
     .clearfix();
     li {
       display: block;
@@ -32,13 +36,9 @@ v2-modal-wizard {
         width: @indicator-size;
         height: @indicator-size;
         border-radius: 100%;
-        background-color: #e6e6e6;
+        background-color: transparent;
         content: '';
         transition: 0.25s;
-      }
-
-      a:before {
-        background-color: transparent;
         font-size: 135%;
         font-family: 'Glyphicons Halflings';
       }
@@ -78,9 +78,10 @@ v2-modal-wizard {
   }
 
   .steps {
-    overflow: auto;
+    overflow-y: auto;
+    overflow-x: hidden;
     clear: both;
-    max-height: calc(~"100vh - 250px");
+    max-height: calc(~"100vh - 215px");
     .wizard-subheading {
       padding: 0;
       h4 {
@@ -89,6 +90,33 @@ v2-modal-wizard {
         color: @lightest_grey;
         background-color: @dark_blue_background;
         font-weight: 300;
+        @media(max-width: 992px) {
+          padding-left: 0;
+          &:before {
+            display: inline-block;
+            margin: 0 10px;
+            width: @indicator-size;
+            height: @indicator-size;
+            border-radius: 100%;
+            background-color: #808080;
+            content: '';
+            transition: 0.25s;
+          }
+          &.done {
+            &:before {
+              background-color: @healthy_green_icon;
+            }
+          }
+          &.dirty {
+            &:before {
+              color: @state-danger-text;
+              background-color: transparent;
+              content: "\e088";
+              top: 11px;
+            }
+          }
+
+        }
       }
       margin-bottom: 10px;
     }

--- a/app/scripts/modules/core/modal/wizard/v2modalWizard.directive.html
+++ b/app/scripts/modules/core/modal/wizard/v2modalWizard.directive.html
@@ -6,7 +6,7 @@
   </div>
   <div class="modal-body">
     <div class="row">
-      <div class="col-md-3">
+      <div class="col-md-3 hidden-sm hidden-xs">
         <ul class="steps-indicator wizard-navigation">
           <li ng-repeat="page in wizard.renderedPages"
               class="animated"
@@ -20,7 +20,7 @@
           </li>
         </ul>
       </div>
-      <div class="col-md-9">
+      <div class="col-md-9 col-sm-12">
         <div class="steps"
              ng-transclude
              sticky-headers

--- a/app/scripts/modules/core/modal/wizard/v2wizardPage.directive.html
+++ b/app/scripts/modules/core/modal/wizard/v2wizardPage.directive.html
@@ -5,7 +5,7 @@
        sticky-header
        added-offset-height="-30"
       >
-    <h4>{{label}}</h4>
+    <h4 ng-class="{ default: !state.done, current: state.current, done: state.done, dirty: state.dirty }">{{label}}</h4>
   </div>
   <div class="wizard-page-body" ng-transclude></div>
 </div>


### PR DESCRIPTION
Providing a nominally better modal wizard experience on smaller screens by removing the steps on the side and including the state indicator in the header.

Also removing some padding from the header across modals and restoring the rendering of the close button on v2 wizards.