### PR TITLE
set virtualizationType on aws command based on image match

### DIFF
--- a/app/scripts/modules/amazon/serverGroup/configure/serverGroupConfiguration.service.js
+++ b/app/scripts/modules/amazon/serverGroup/configure/serverGroupConfiguration.service.js
@@ -196,15 +196,18 @@ module.exports = angular.module('spinnaker.aws.serverGroup.configure.service', [
               ami: image.amis ? image.amis[command.region][0] : null
             };
           });
-        var regionalImageMatches = regionalImages.filter((image) => image.imageName === command.amiName);
-        if (command.amiName && !regionalImageMatches.length) {
+        var [match] = regionalImages.filter((image) => image.imageName === command.amiName);
+        if (command.amiName && !match) {
           result.dirty.amiName = true;
           command.amiName = null;
         } else {
-          command.virtualizationType = regionalImages.length ? regionalImages[0].virtualizationType : null;
+          command.virtualizationType = match ? match.virtualizationType : null;
         }
       } else {
-        command.amiName = null;
+        if (command.amiName) {
+          result.dirty.amiName = true;
+          command.amiName = null;
+        }
       }
       command.backingData.filtered.images = regionalImages;
       return result;


### PR DESCRIPTION
The code currently looks at all the regional images to pick the virtualization type, which, while usually correct (for some reason - this code is three months old), it is not always correct, and is definitely unintentional. This picks up the virtualizationType value from the matching image.

@zanthrash please review