### PR TITLE
allow rendering of up to 50 executions per pipeline

### DIFF
--- a/app/scripts/modules/core/application/service/applications.read.service.spec.js
+++ b/app/scripts/modules/core/application/service/applications.read.service.spec.js
@@ -56,7 +56,7 @@ describe('Service: applicationReader', function () {
 
     describe('loading executions', function () {
       it('loads executions and sets appropriate flags', function () {
-        spyOn(executionService, 'getRunningExecutions').and.returnValue($q.when([{status: 'COMPLETED', stages: []}]));
+        spyOn(executionService, 'getRunningExecutions').and.returnValue($q.when([{status: 'SUCCEEDED', stages: []}]));
         var result = null;
         loadApplication([], [], [], {executions: true}).then((app) => {
           result = app;
@@ -84,7 +84,7 @@ describe('Service: applicationReader', function () {
 
     describe('reload executions', function () {
       it('reloads executions and sets appropriate flags', function () {
-        spyOn(executionService, 'getRunningExecutions').and.returnValue($q.when([{status: 'COMPLETED', stages: []}]));
+        spyOn(executionService, 'getRunningExecutions').and.returnValue($q.when([{status: 'SUCCEEDED', stages: []}]));
         var result = null,
             nextCalls = 0;
         loadApplication([], [], [], {executions: true}).then((app) => {
@@ -138,7 +138,7 @@ describe('Service: applicationReader', function () {
 
     describe('loading tasks', function () {
       it('loads tasks and sets appropriate flags', function () {
-        spyOn(taskReader, 'getRunningTasks').and.returnValue($q.when([{status: 'COMPLETED'}]));
+        spyOn(taskReader, 'getRunningTasks').and.returnValue($q.when([{status: 'SUCCEEDED'}]));
         var result = null;
         loadApplication([], [], [], {tasks: true}).then((app) => {
           result = app;
@@ -166,7 +166,7 @@ describe('Service: applicationReader', function () {
 
     describe('reload tasks', function () {
       it('reloads tasks and sets appropriate flags', function () {
-        spyOn(taskReader, 'getRunningTasks').and.returnValue($q.when([{status: 'COMPLETED'}]));
+        spyOn(taskReader, 'getRunningTasks').and.returnValue($q.when([{status: 'SUCCEEDED'}]));
         var result = null,
             nextCalls = 0;
         loadApplication([], [], [], {tasks: true}).then((app) => {

--- a/app/scripts/modules/core/cluster/cluster.service.spec.js
+++ b/app/scripts/modules/core/cluster/cluster.service.spec.js
@@ -253,7 +253,7 @@ describe('Service: InstanceType', function () {
       it('ignores non-running tasks', function() {
         var app = this.application;
         this.buildCommonTask('resizeasg');
-        app.tasks[0].status = 'COMPLETED';
+        app.tasks[0].status = 'SUCCEEDED';
         clusterService.addTasksToServerGroups(app);
         app.serverGroups.forEach(function(serverGroup) {
           expect(serverGroup.runningTasks.length).toBe(0);

--- a/app/scripts/modules/core/delivery/executions/executions.controller.js
+++ b/app/scripts/modules/core/delivery/executions/executions.controller.js
@@ -41,13 +41,18 @@ module.exports = angular.module('spinnaker.core.delivery.executions.controller',
       this.updateExecutionGroups();
     };
 
-    this.updateExecutionGroups = () => {
+    this.updateExecutionGroups = (reload) => {
       normalizeExecutionNames();
       ExecutionFilterModel.applyParamsToUrl();
-      executionFilterService.updateExecutionGroups(this.application);
-      this.tags = ExecutionFilterModel.tags;
-      // updateExecutionGroups is debounced by 25ms, so we need to delay setting the loading flag a bit
-      $timeout(() => { this.viewState.loading = false; }, 50);
+      if (reload) {
+        this.application.reloadingExecutionsForFilters = true;
+        this.application.reloadExecutions();
+      } else {
+        executionFilterService.updateExecutionGroups(this.application);
+        this.tags = ExecutionFilterModel.tags;
+        // updateExecutionGroups is debounced by 25ms, so we need to delay setting the loading flag a bit
+        $timeout(() => { this.viewState.loading = false; }, 50);
+      }
     };
 
     this.viewState = {
@@ -72,7 +77,7 @@ module.exports = angular.module('spinnaker.core.delivery.executions.controller',
       }
     });
 
-    $scope.filterCountOptions = [1, 2, 5, 10, 20];
+    $scope.filterCountOptions = [1, 2, 5, 10, 20, 30, 40, 50];
 
     let dataInitializationFailure = () => {
       this.viewState.loading = false;

--- a/app/scripts/modules/core/delivery/executions/executions.html
+++ b/app/scripts/modules/core/delivery/executions/executions.html
@@ -37,7 +37,7 @@
         </div>
         <div class="form-group">
           <label>Show</label>
-          <select class="form-control input-sm" ng-model="vm.filter.count" ng-change="vm.updateExecutionGroups()"
+          <select class="form-control input-sm" ng-model="vm.filter.count" ng-change="vm.updateExecutionGroups(true)"
                   ng-options="count for count in filterCountOptions">
           </select>
           executions per pipeline
@@ -66,6 +66,8 @@
     </div>
     <div class="text-center" ng-if="vm.viewState.loading">
       <h3 us-spinner="{radius:30, width:8, length: 16}"></h3>
+    </div>
+    <div class="text-center transition-overlay" ng-if="vm.application.reloadingExecutionsForFilters" style="margin-left: -25px">
     </div>
     <div class="text-center" ng-if="!vm.viewState.loading && !vm.application.executions.length && !vm.application.pipelineConfigs.length">
       <h4>No pipelines configured for this application.</h4>

--- a/app/scripts/modules/core/delivery/executions/executions.less
+++ b/app/scripts/modules/core/delivery/executions/executions.less
@@ -52,7 +52,7 @@ executions {
 .execution-status-failed {
   color: @unhealthy_red;
 }
-.execution-status-completed {
+.execution-status-succeeded {
   color: @healthy_green_border;
 }
 
@@ -63,9 +63,9 @@ executions {
     fill: @stage-failed;
     background-color: @stage-failed;
   }
-  &.execution-marker-completed {
-    fill: @stage-completed;
-    background-color: @stage-completed;
+  &.execution-marker-succeeded {
+    fill: @stage-succeeded;
+    background-color: @stage-succeeded;
   }
   &.execution-marker-running {
     fill: @stage-running;

--- a/app/scripts/modules/core/delivery/filter/executionFilter.controller.js
+++ b/app/scripts/modules/core/delivery/filter/executionFilter.controller.js
@@ -26,9 +26,14 @@ module.exports = angular.module('spinnaker.core.delivery.filter.executionFilter.
       this.pipelineSortOptions.disabled = true;
     };
 
-    this.updateExecutionGroups = () => {
+    this.updateExecutionGroups = (reload) => {
       ExecutionFilterModel.applyParamsToUrl();
-      executionFilterService.updateExecutionGroups(this.application);
+      if (reload) {
+        this.application.reloadingExecutionsForFilters = true;
+        this.application.reloadExecutions();
+      } else {
+        executionFilterService.updateExecutionGroups(this.application);
+      }
     };
 
     this.clearFilters = () => {
@@ -46,6 +51,7 @@ module.exports = angular.module('spinnaker.core.delivery.filter.executionFilter.
         .map((option) => option.name);
       this.pipelineNames = _.uniq(allOptions);
       this.updateExecutionGroups();
+      this.application.reloadingExecutionsForFilters = false;
     };
 
     var executionWatcher = this.application.executionRefreshStream.subscribe(this.initialize);

--- a/app/scripts/modules/core/delivery/filter/filterNav.html
+++ b/app/scripts/modules/core/delivery/filter/filterNav.html
@@ -53,7 +53,7 @@
           <label>
             <input type="checkbox"
                    ng-model="sortFilter.status.RUNNING"
-                   ng-change="vm.updateExecutionGroups()"/>
+                   ng-change="vm.updateExecutionGroups(true)"/>
             Running
           </label>
         </div>
@@ -61,23 +61,23 @@
           <label>
             <input type="checkbox"
                    ng-model="sortFilter.status.FAILED"
-                   ng-change="vm.updateExecutionGroups()"/>
+                   ng-change="vm.updateExecutionGroups(true)"/>
             Failed
           </label>
         </div>
         <div class="checkbox">
           <label>
             <input type="checkbox"
-                   ng-model="sortFilter.status.COMPLETED"
-                   ng-change="vm.updateExecutionGroups()"/>
-            Completed
+                   ng-model="sortFilter.status.SUCCEEDED"
+                   ng-change="vm.updateExecutionGroups(true)"/>
+            Succeeded
           </label>
         </div>
         <div class="checkbox">
           <label>
             <input type="checkbox"
                    ng-model="sortFilter.status.NOT_STARTED"
-                   ng-change="vm.updateExecutionGroups()"/>
+                   ng-change="vm.updateExecutionGroups(true)"/>
             Not Started
           </label>
         </div>
@@ -85,7 +85,7 @@
           <label>
             <input type="checkbox"
                    ng-model="sortFilter.status.CANCELED"
-                   ng-change="vm.updateExecutionGroups()"/>
+                   ng-change="vm.updateExecutionGroups(true)"/>
             Canceled
           </label>
         </div>
@@ -93,7 +93,7 @@
           <label>
             <input type="checkbox"
                    ng-model="sortFilter.status.STOPPED"
-                   ng-change="vm.updateExecutionGroups()"/>
+                   ng-change="vm.updateExecutionGroups(true)"/>
             Stopped
           </label>
         </div>

--- a/app/scripts/modules/core/delivery/service/execution.service.js
+++ b/app/scripts/modules/core/delivery/service/execution.service.js
@@ -5,21 +5,23 @@ module.exports = angular.module('spinnaker.core.delivery.executions.service', [
   require('../../cache/deckCacheFactory.js'),
   require('../../utils/appendTransform.js'),
   require('../../config/settings.js'),
+  require('../filter/executionFilter.model.js'),
   require('./executions.transformer.service.js')
 ])
-  .factory('executionService', function($http, $timeout, $q, $log,
+  .factory('executionService', function($http, $timeout, $q, $log, ExecutionFilterModel,
                                          settings, appendTransform, executionsTransformer) {
 
     const activeStatuses = ['RUNNING', 'SUSPENDED', 'PAUSED', 'NOT_STARTED'];
+    const runningLimit = 30;
 
     function getRunningExecutions(applicationName) {
-      return getExecutions(applicationName, activeStatuses);
+      return getExecutions(applicationName, {statuses: activeStatuses, limit: runningLimit});
     }
 
-    function getExecutions(applicationName, statuses = []) {
-      let url = [ settings.gateUrl, 'applications', applicationName, 'pipelines'].join('/');
+    function getExecutions(applicationName, {statuses = Object.keys(ExecutionFilterModel.sortFilter.status), limit = ExecutionFilterModel.sortFilter.count} = {}) {
+      let url = [ settings.gateUrl, 'applications', applicationName, `pipelines?limit=${limit}`].join('/');
       if (statuses.length) {
-        url += '?statuses=' + statuses.map((status) => status.toUpperCase()).join(',');
+        url += '&statuses=' + statuses.map((status) => status.toUpperCase()).join(',');
       }
       return $http({
         method: 'GET',

--- a/app/scripts/modules/core/delivery/service/execution.service.spec.js
+++ b/app/scripts/modules/core/delivery/service/execution.service.spec.js
@@ -15,12 +15,13 @@ describe('Service: executionService', function () {
   );
 
   beforeEach(
-    window.inject(function (_executionService_, _$httpBackend_, _settings_, _$timeout_, _$q_) {
+    window.inject(function (_executionService_, _$httpBackend_, _settings_, _$timeout_, _$q_, ExecutionFilterModel) {
       executionService = _executionService_;
       $httpBackend = _$httpBackend_;
       settings = _settings_;
       timeout = _$timeout_;
       $q = _$q_;
+      ExecutionFilterModel.sortFilter.count = 3;
     })
   );
 
@@ -35,7 +36,7 @@ describe('Service: executionService', function () {
       let executionId = 'abc';
       let cancelUrl = [ settings.gateUrl, 'applications', 'deck', 'pipelines', executionId, 'cancel' ].join('/');
       let checkUrl = [ settings.gateUrl, 'applications', 'deck', 'pipelines' ].join('/')
-        .concat('?statuses=RUNNING,SUSPENDED,PAUSED,NOT_STARTED');
+        .concat('?limit=30&statuses=RUNNING,SUSPENDED,PAUSED,NOT_STARTED');
       let application = { name: 'deck', reloadExecutions: () => $q.when(null) };
 
       $httpBackend.expectPUT(cancelUrl).respond(200, []);
@@ -70,7 +71,7 @@ describe('Service: executionService', function () {
       let completed = false;
       let executionId = 'abc';
       let deleteUrl = [ settings.gateUrl, 'pipelines', executionId ].join('/');
-      let checkUrl = [ settings.gateUrl, 'applications', 'deck', 'pipelines' ].join('/');
+      let checkUrl = [ settings.gateUrl, 'applications', 'deck', 'pipelines?limit=3' ].join('/');
       let application = { name: 'deck', reloadExecutions: () => $q.when(null) };
 
       $httpBackend.expectDELETE(deleteUrl).respond(200, []);
@@ -153,7 +154,7 @@ describe('Service: executionService', function () {
           settings.gateUrl,
           'applications',
           'deck',
-          'pipelines',
+          'pipelines?limit=3',
         ].join('/');
 
       $httpBackend.expectGET(url).respond(200, []);
@@ -177,7 +178,7 @@ describe('Service: executionService', function () {
         settings.gateUrl,
         'applications',
         'deck',
-        'pipelines',
+        'pipelines?limit=3',
       ].join('/');
 
       $httpBackend.expectGET(url).respond(429, []);

--- a/app/scripts/modules/core/delivery/service/executions.transformer.service.spec.js
+++ b/app/scripts/modules/core/delivery/service/executions.transformer.service.spec.js
@@ -108,11 +108,11 @@ describe('executionTransformerService', function() {
     it('should set summary status and start/end times based on child stages', function() {
       var execution = {
         stages: [
-          { id: '1', name: 'bake', status: 'COMPLETED', startTime: 7, endTime: 8 },
+          { id: '1', name: 'bake', status: 'SUCCEEDED', startTime: 7, endTime: 8 },
           { id: '2', name: 'deploy', status: 'RUNNING', startTime: 7 },
           { id: '3', name: 'wait', status: 'NOT_STARTED' },
-          { id: '4', parentStageId: '2', syntheticStageOwner: 'STAGE_BEFORE', status: 'COMPLETED', startTime: 4, endTime: 6},
-          { id: '5', parentStageId: '1', syntheticStageOwner: 'STAGE_BEFORE', status: 'COMPLETED', startTime: 5, endTime: 6},
+          { id: '4', parentStageId: '2', syntheticStageOwner: 'STAGE_BEFORE', status: 'SUCCEEDED', startTime: 4, endTime: 6},
+          { id: '5', parentStageId: '1', syntheticStageOwner: 'STAGE_BEFORE', status: 'SUCCEEDED', startTime: 5, endTime: 6},
           { id: '6', parentStageId: '2', syntheticStageOwner: 'STAGE_BEFORE', status: 'NOT_STARTED' },
           { id: '7', parentStageId: '3', syntheticStageOwner: 'STAGE_BEFORE', status: 'NOT_STARTED' },
           { id: '8', parentStageId: '3', syntheticStageOwner: 'STAGE_AFTER', status: 'NOT_STARTED' },
@@ -120,7 +120,7 @@ describe('executionTransformerService', function() {
       };
       this.transformer.transformExecution({}, execution);
 
-      expect(execution.stageSummaries[0].status).toBe('COMPLETED');
+      expect(execution.stageSummaries[0].status).toBe('SUCCEEDED');
       expect(execution.stageSummaries[0].startTime).toBe(5);
       expect(execution.stageSummaries[0].endTime).toBe(8);
 
@@ -136,8 +136,8 @@ describe('executionTransformerService', function() {
     it('should remove stage summary end time if current stage is still running', function () {
       var execution = {
         stages: [
-          { id: '2', name: 'deploy', status: 'COMPLETED', startTime: 7, endTime: 8 },
-          { id: '4', parentStageId: '2', syntheticStageOwner: 'STAGE_BEFORE', status: 'COMPLETED', startTime: 4, endTime: 6},
+          { id: '2', name: 'deploy', status: 'SUCCEEDED', startTime: 7, endTime: 8 },
+          { id: '4', parentStageId: '2', syntheticStageOwner: 'STAGE_BEFORE', status: 'SUCCEEDED', startTime: 4, endTime: 6},
           { id: '6', parentStageId: '2', syntheticStageOwner: 'STAGE_BEFORE', status: 'RUNNING', startTime: 6 },
         ]
       };
@@ -148,10 +148,10 @@ describe('executionTransformerService', function() {
     it('should set stage summary end time to the maximum value of all stage end times', function () {
       var execution = {
         stages: [
-          { id: '2', name: 'deploy', status: 'COMPLETED', startTime: 7, endTime: 8 },
-          { id: '4', parentStageId: '2', syntheticStageOwner: 'STAGE_BEFORE', status: 'COMPLETED', startTime: 4, endTime: 6},
-          { id: '5', parentStageId: '2', syntheticStageOwner: 'STAGE_BEFORE', status: 'COMPLETED', startTime: 4, endTime: 9},
-          { id: '6', parentStageId: '2', syntheticStageOwner: 'STAGE_AFTER', status: 'COMPLETED', startTime: 6, endTime: 11 },
+          { id: '2', name: 'deploy', status: 'SUCCEEDED', startTime: 7, endTime: 8 },
+          { id: '4', parentStageId: '2', syntheticStageOwner: 'STAGE_BEFORE', status: 'SUCCEEDED', startTime: 4, endTime: 6},
+          { id: '5', parentStageId: '2', syntheticStageOwner: 'STAGE_BEFORE', status: 'SUCCEEDED', startTime: 4, endTime: 9},
+          { id: '6', parentStageId: '2', syntheticStageOwner: 'STAGE_AFTER', status: 'SUCCEEDED', startTime: 6, endTime: 11 },
         ]
       };
       this.transformer.transformExecution({}, execution);
@@ -161,9 +161,9 @@ describe('executionTransformerService', function() {
     it('should not set stage status, start/end times based on child stages on non-summary stages', function() {
       var execution = {
         stages: [
-          { id: '1', name: 'bake', status: 'COMPLETED', startTime: 7, endTime: 8 },
-          { id: '2', parentStageId: '1', syntheticStageOwner: 'STAGE_AFTER', status: 'COMPLETED', startTime: 8, endTime: 9},
-          { id: '3', parentStageId: '2', syntheticStageOwner: 'STAGE_BEFORE', status: 'COMPLETED', startTime: 7, endTime: 8},
+          { id: '1', name: 'bake', status: 'SUCCEEDED', startTime: 7, endTime: 8 },
+          { id: '2', parentStageId: '1', syntheticStageOwner: 'STAGE_AFTER', status: 'SUCCEEDED', startTime: 8, endTime: 9},
+          { id: '3', parentStageId: '2', syntheticStageOwner: 'STAGE_BEFORE', status: 'SUCCEEDED', startTime: 7, endTime: 8},
           { id: '4', parentStageId: '2', syntheticStageOwner: 'STAGE_AFTER', status: 'RUNNING', startTime: 11 },
           { id: '5', parentStageId: '2', syntheticStageOwner: 'STAGE_AFTER', status: 'NOT_STARTED' },
         ]
@@ -184,7 +184,7 @@ describe('executionTransformerService', function() {
 
       expect(_.pluck(summary.stages, 'id')).toEqual(['1', '3', '2', '4', '5']);
       expect(nested.id).toBe('2');
-      expect(nested.status).toBe('COMPLETED');
+      expect(nested.status).toBe('SUCCEEDED');
       expect(nested.startTime).toBe(8);
       expect(nested.endTime).toBe(9);
     });
@@ -192,10 +192,10 @@ describe('executionTransformerService', function() {
     it('should add startTime to stage summary based on min of child stage start times if first stage has no start time', function () {
       var execution = {
         stages: [
-          { id: '2', name: 'deploy', status: 'COMPLETED', startTime: null, endTime: 8 },
-          { id: '4', parentStageId: '2', syntheticStageOwner: 'STAGE_BEFORE', status: 'COMPLETED', startTime: null, endTime: 6},
-          { id: '5', parentStageId: '2', syntheticStageOwner: 'STAGE_BEFORE', status: 'COMPLETED', startTime: 11, endTime: 9},
-          { id: '6', parentStageId: '2', syntheticStageOwner: 'STAGE_AFTER', status: 'COMPLETED', startTime: 4, endTime: 11 },
+          { id: '2', name: 'deploy', status: 'SUCCEEDED', startTime: null, endTime: 8 },
+          { id: '4', parentStageId: '2', syntheticStageOwner: 'STAGE_BEFORE', status: 'SUCCEEDED', startTime: null, endTime: 6},
+          { id: '5', parentStageId: '2', syntheticStageOwner: 'STAGE_BEFORE', status: 'SUCCEEDED', startTime: 11, endTime: 9},
+          { id: '6', parentStageId: '2', syntheticStageOwner: 'STAGE_AFTER', status: 'SUCCEEDED', startTime: 4, endTime: 11 },
         ]
       };
       this.transformer.transformExecution({}, execution);

--- a/app/scripts/modules/core/orchestratedItem/orchestratedItem.transformer.js
+++ b/app/scripts/modules/core/orchestratedItem/orchestratedItem.transformer.js
@@ -72,7 +72,7 @@ module.exports = angular.module('spinnaker.core.orchestratedItem.transformer', [
         },
         isCompleted: {
           get: function() {
-            return item.status === 'COMPLETED';
+            return item.status === 'SUCCEEDED';
           },
         },
         isRunning: {
@@ -111,7 +111,7 @@ module.exports = angular.module('spinnaker.core.orchestratedItem.transformer', [
           }
         },
         status: {
-          // Returns either COMPLETED, RUNNING, FAILED, CANCELED, or NOT_STARTED
+          // Returns either SUCCEEDED, RUNNING, FAILED, CANCELED, or NOT_STARTED
           get: function() { return normalizeStatus(item); },
           set: function(status) {
             item.originalStatus = status;
@@ -138,7 +138,7 @@ module.exports = angular.module('spinnaker.core.orchestratedItem.transformer', [
       switch(item.originalStatus) {
         case 'COMPLETED':
         case 'SUCCEEDED':
-          return 'COMPLETED';
+          return 'SUCCEEDED';
         case 'STARTED':
         case 'EXECUTING':
         case 'RUNNING':

--- a/app/scripts/modules/core/orchestratedItem/orchestratedItem.transformer.spec.js
+++ b/app/scripts/modules/core/orchestratedItem/orchestratedItem.transformer.spec.js
@@ -241,7 +241,7 @@ describe('orchestratedItem transformer', function () {
     });
 
     it('returns null if no failure message is present', function () {
-      expect(getMessage({ status: 'COMPLETED' })).toBe(null);
+      expect(getMessage({ status: 'SUCCEEDED' })).toBe(null);
     });
 
     it('returns null if tide task succeeded', function () {

--- a/app/scripts/modules/core/pipeline/config/graph/pipelineGraph.less
+++ b/app/scripts/modules/core/pipeline/config/graph/pipelineGraph.less
@@ -44,7 +44,7 @@ pipeline-graph {
         stroke: @unhealthy_red;
       }
       &.completed {
-        stroke: @stage-completed;
+        stroke: @stage-succeeded;
       }
       &.not_started, &.suspended, &.canceled, &.unknown {
         stroke: @mid_light_grey;

--- a/app/scripts/modules/core/pipeline/config/triggers/pipeline/pipelineTriggerOptions.directive.js
+++ b/app/scripts/modules/core/pipeline/config/triggers/pipeline/pipelineTriggerOptions.directive.js
@@ -51,7 +51,7 @@ module.exports = angular
         return;
       }
       this.viewState.executionsLoading = true;
-      executionService.getExecutions(command.trigger.application)
+      executionService.getExecutions(command.trigger.application, {statuses: []})
         .then(executionLoadSuccess, executionLoadFailure);
     };
 

--- a/app/scripts/modules/core/pipeline/pipelines.less
+++ b/app/scripts/modules/core/pipeline/pipelines.less
@@ -71,7 +71,7 @@
       }
 
     }
-    .label-completed {
+    .label-succeeded {
       background-color: @healthy_green_border;
     }
     .label-failed, .label-terminated {

--- a/app/scripts/modules/core/presentation/less/imports/colors.less
+++ b/app/scripts/modules/core/presentation/less/imports/colors.less
@@ -57,7 +57,7 @@
 
 @bootstrap_info: #d9edf7;
 
-@stage-completed: #769D3E;
+@stage-succeeded: #769D3E;
 @stage-failed: #b82525;
 @stage-running: #2275b8;
 @stage-default: #cccccc;

--- a/app/scripts/modules/core/presentation/main.less
+++ b/app/scripts/modules/core/presentation/main.less
@@ -773,7 +773,7 @@ tfoot .add-new {
   position:fixed;
   top: 58px;
   width:100%;
-  height:100%
+  height:100%;
 }
 
 .transition-overlay {
@@ -782,7 +782,8 @@ tfoot .add-new {
   opacity:.7;
   position:fixed;
   width:100%;
-  height:100%
+  height:100%;
+  transition: opacity 0.2s;
 }
 
 .panel {

--- a/app/scripts/modules/core/task/monitor/taskMonitorService.spec.js
+++ b/app/scripts/modules/core/task/monitor/taskMonitorService.spec.js
@@ -49,7 +49,7 @@ describe('Service: taskMonitorService', function () {
       $http.flush();
       expect(monitor.task.isCompleted).toBe(false);
 
-      $http.expectGET(['/applications', 'deck', 'tasks', 'a'].join('/')).respond(200, { status: 'COMPLETED' });
+      $http.expectGET(['/applications', 'deck', 'tasks', 'a'].join('/')).respond(200, { status: 'SUCCEEDED' });
       $timeout.flush(); // complete second time
       $http.flush();
 

--- a/app/scripts/modules/core/task/task.read.service.spec.js
+++ b/app/scripts/modules/core/task/task.read.service.spec.js
@@ -39,7 +39,7 @@ describe('Service: taskReader', function () {
       $http.whenGET('/applications/deck/tasks/1').respond(200, {
         id: 1,
         foo: 3,
-        status: 'COMPLETED'
+        status: 'SUCCEEDED'
       });
 
       var completed = false;
@@ -58,7 +58,7 @@ describe('Service: taskReader', function () {
       $http.whenGET('/applications/deck/tasks/1').respond(200, {
         id: 1,
         foo: 3,
-        status: 'COMPLETED'
+        status: 'SUCCEEDED'
       });
 
       var completed = false,
@@ -105,7 +105,7 @@ describe('Service: taskReader', function () {
       expect(failed).toBe(false);
 
       // succeeds
-      $http.expectGET('/applications/deck/tasks/1').respond(200, { id: 1, status: 'COMPLETED' });
+      $http.expectGET('/applications/deck/tasks/1').respond(200, { id: 1, status: 'SUCCEEDED' });
       cycle();
       expect(completed).toBe(true);
       expect(failed).toBe(false);
@@ -179,7 +179,7 @@ describe('Service: taskReader', function () {
     it('uses start time to calculate running time if endTime is zero', function () {
       $http.whenGET('/applications/deck/tasks/1').respond(200, {
         id: 2,
-        status: 'COMPLETED',
+        status: 'SUCCEEDED',
         startTime: new Date(),
         endTime: 0
       });
@@ -192,7 +192,7 @@ describe('Service: taskReader', function () {
     it('uses start time to calculate running time if endTime is not present', function () {
       $http.whenGET('/applications/deck/tasks/1').respond(200, {
         id: 2,
-        status: 'COMPLETED',
+        status: 'SUCCEEDED',
         startTime: new Date()
       });
 
@@ -206,7 +206,7 @@ describe('Service: taskReader', function () {
           end = start + 120 * 1000;
       $http.whenGET('/applications/deck/tasks/1').respond(200, {
         id: 2,
-        status: 'COMPLETED',
+        status: 'SUCCEEDED',
         startTime: start,
         endTime: end
       });
@@ -221,7 +221,7 @@ describe('Service: taskReader', function () {
           offset = 200000;
       $http.whenGET('/applications/deck/tasks/1').respond(200, {
         id: 2,
-        status: 'COMPLETED',
+        status: 'SUCCEEDED',
         startTime: now + offset
       });
 

--- a/app/scripts/modules/core/task/tasks.controller.spec.js
+++ b/app/scripts/modules/core/task/tasks.controller.spec.js
@@ -125,7 +125,7 @@ describe('Controller: tasks', function () {
   describe('Filtering Task list with one running task', function () {
     var application = {
       tasks: [
-        {status: 'COMPLETED', name: 'a'},
+        {status: 'SUCCEEDED', name: 'a'},
         {status: 'RUNNING', name: 'a'},
       ]
     };
@@ -161,8 +161,8 @@ describe('Controller: tasks', function () {
   describe('Filtering Task list with zero running task', function () {
     var application = {
       tasks: [
-        {status: 'COMPLETED', startTime: 22, name: 'a'},
-        {status: 'COMPLETED', startTime: 100, name: 'a'},
+        {status: 'SUCCEEDED', startTime: 22, name: 'a'},
+        {status: 'SUCCEEDED', startTime: 100, name: 'a'},
       ]
     };
 
@@ -173,7 +173,7 @@ describe('Controller: tasks', function () {
       expect(sortedList.length).toBe(2);
       expect(sortedList[0].startTime).toBe(100);
       sortedList.forEach(function(task) {
-        expect(task.status).toEqual('COMPLETED');
+        expect(task.status).toEqual('SUCCEEDED');
       });
     });
   });

--- a/app/scripts/modules/core/task/tasks.fixture.js
+++ b/app/scripts/modules/core/task/tasks.fixture.js
@@ -17,7 +17,7 @@ TasksFixture.initialSnapshot = [
   },
   {
     id: 2,
-    status: 'COMPLETED',
+    status: 'SUCCEEDED',
     variables: [
       {
         key: 'description',
@@ -50,7 +50,7 @@ TasksFixture.initialSnapshot = [
 TasksFixture.secondSnapshot = [
   {
     id: 1,
-    status: 'COMPLETED',
+    status: 'SUCCEEDED',
     variables: [
       {
         key: 'description',
@@ -65,7 +65,7 @@ TasksFixture.secondSnapshot = [
   },
   {
     id: 2,
-    status: 'COMPLETED',
+    status: 'SUCCEEDED',
     variables: [
       {
         key: 'description',
@@ -110,7 +110,7 @@ TasksFixture.secondSnapshot = [
   },
   {
     id: 5,
-    status: 'COMPLETED',
+    status: 'SUCCEEDED',
     variables: [
       {
         key: 'description',

--- a/app/scripts/modules/core/task/tasks.html
+++ b/app/scripts/modules/core/task/tasks.html
@@ -21,8 +21,8 @@
           <label class="btn btn-sm btn-default" ng-model="viewState.taskStateFilter" uib-btn-radio="'RUNNING'">
             <a href><status-glyph item="{isRunning: true}"></status-glyph> Running</a>
           </label>
-          <label class="btn btn-sm btn-default" ng-model="viewState.taskStateFilter" uib-btn-radio="'COMPLETED'">
-            <a href><status-glyph item="{isCompleted: true}"></status-glyph> Completed</a>
+          <label class="btn btn-sm btn-default" ng-model="viewState.taskStateFilter" uib-btn-radio="'SUCCEEDED'">
+            <a href><status-glyph item="{isCompleted: true}"></status-glyph> Succeeded</a>
           </label>
           <label class="btn btn-sm btn-default" ng-model="viewState.taskStateFilter" uib-btn-radio="'FAILED'">
             <a href><status-glyph item="{isFailed: true}"></status-glyph> Failed</a>

--- a/app/scripts/modules/netflix/pipeline/stage/canary/canaryStage.transformer.js
+++ b/app/scripts/modules/netflix/pipeline/stage/canary/canaryStage.transformer.js
@@ -160,7 +160,7 @@ module.exports = angular.module('spinnaker.netflix.pipeline.stage.canary.transfo
               status = 'RUNNING';
             }
             if (canaryStatus.complete) {
-              status = 'COMPLETED';
+              status = 'SUCCEEDED';
             }
             if (canaryStatus.status === 'DISABLED') {
               status = 'DISABLED';

--- a/app/scripts/modules/netflix/pipeline/stage/canary/canaryStatus.directive.js
+++ b/app/scripts/modules/netflix/pipeline/stage/canary/canaryStatus.directive.js
@@ -14,7 +14,7 @@ module.exports = angular.module('spinnaker.netflix.pipeline.stages.canary.status
         function applyLabel() {
           scope.statusLabel = scope.status === 'LAUNCHED' ? 'launched'
             : scope.status === 'RUNNING' ? 'running'
-            : scope.status === 'COMPLETED' ? 'completed'
+            : scope.status === 'SUCCEEDED' ? 'completed'
             : scope.status === 'FAILED' ? 'failed'
             : scope.status === 'TERMINATED' ? 'terminated'
             : scope.status === 'CANCELED' ? 'canceled'


### PR DESCRIPTION
@spinnaker/netflix-reviewers this change means we'll always be retrieving 50 executions per pipeline (but still potentially rendering a subset of those, based on user filters).

@ajordens yea or nay