### PR TITLE
fix canary CSS, Failed->Terminal, fix sub-stage ordering

### DIFF
--- a/app/scripts/modules/core/delivery/details/executionDetails.less
+++ b/app/scripts/modules/core/delivery/details/executionDetails.less
@@ -54,64 +54,6 @@ execution {
       }
     }
 
-    .canary-summary {
-      .canary-deployment-row {
-        td:first-child {
-          padding-left: 20px;
-          font-weight: 600;
-        }
-      }
-    }
-
-    .canary-details {
-      .section-title {
-        border-bottom: 1px solid @mid_lighter_grey;
-        margin-bottom: 20px;
-        h4 {
-          border-bottom: 0;
-        }
-      }
-      h4 {
-        margin-bottom: 10px;
-        border-bottom: 1px solid @mid_lighter_grey;
-      }
-      .canary-config-section {
-        margin-bottom: 20px;
-      }
-
-      .canary-summary {
-        margin-bottom: 5px;
-        padding-bottom: 5px;
-        align-items: center;
-        display: flex;
-
-        & > div {
-          display: flex;
-          flex: 4 0 20px;
-          margin-right: 15px;
-          &.canary-summary-section {
-            display: block;
-          }
-          &.score-large {
-            flex: 0 0 auto;
-            height: 48px;
-            .score {
-              line-height: 38px;
-              height: 48px;
-              padding-left: 10px;
-              padding-right: 10px;
-              font-size: 175%;
-            }
-            margin-right: 10px;
-          }
-        }
-      }
-
-      h5 {
-        margin: 0;
-      }
-    }
-
     tbody {
       tr.stage-summary {
         font-weight: 600;

--- a/app/scripts/modules/core/delivery/executions/executions.controller.js
+++ b/app/scripts/modules/core/delivery/executions/executions.controller.js
@@ -38,7 +38,7 @@ module.exports = angular.module('spinnaker.core.delivery.executions.controller',
 
     this.clearFilters = () => {
       executionFilterService.clearFilters();
-      this.updateExecutionGroups();
+      this.updateExecutionGroups(true);
     };
 
     this.updateExecutionGroups = (reload) => {

--- a/app/scripts/modules/core/delivery/executions/executions.html
+++ b/app/scripts/modules/core/delivery/executions/executions.html
@@ -62,7 +62,7 @@
           <create-new application="application"></create-new>
         </div>
       </form>
-      <filter-tags tags="vm.tags" tag-cleared="vm.updateClusterGroups()" clear-filters="vm.clearFilters()"></filter-tags>
+      <filter-tags tags="vm.tags" tag-cleared="vm.updateExecutionGroups(true)" clear-filters="vm.clearFilters()"></filter-tags>
     </div>
     <div class="text-center" ng-if="vm.viewState.loading">
       <h3 us-spinner="{radius:30, width:8, length: 16}"></h3>

--- a/app/scripts/modules/core/delivery/executions/executions.less
+++ b/app/scripts/modules/core/delivery/executions/executions.less
@@ -49,7 +49,7 @@ executions {
 .execution-status-executing, .execution-status-running {
   color: @spinnaker-blue;
 }
-.execution-status-failed {
+.execution-status-terminal {
   color: @unhealthy_red;
 }
 .execution-status-succeeded {
@@ -59,9 +59,9 @@ executions {
 .execution-marker {
   fill: @stage-default;
   background-color: @stage-default;
-  &.execution-marker-failed {
-    fill: @stage-failed;
-    background-color: @stage-failed;
+  &.execution-marker-terminal {
+    fill: @stage-terminal;
+    background-color: @stage-terminal;
   }
   &.execution-marker-succeeded {
     fill: @stage-succeeded;

--- a/app/scripts/modules/core/delivery/filter/filterNav.html
+++ b/app/scripts/modules/core/delivery/filter/filterNav.html
@@ -60,9 +60,9 @@
         <div class="checkbox">
           <label>
             <input type="checkbox"
-                   ng-model="sortFilter.status.FAILED"
+                   ng-model="sortFilter.status.TERMINAL"
                    ng-change="vm.updateExecutionGroups(true)"/>
-            Failed
+            Terminal
           </label>
         </div>
         <div class="checkbox">

--- a/app/scripts/modules/core/delivery/service/executions.transformer.service.spec.js
+++ b/app/scripts/modules/core/delivery/service/executions.transformer.service.spec.js
@@ -49,25 +49,7 @@ describe('executionTransformerService', function() {
       };
 
       this.transformer.transformExecution({}, execution);
-      expect(_.pluck(execution.stageSummaries[0].stages, 'id')).toEqual(['f', 'e', 'c', 'b', 'a', 'g', 'd', 'h']);
-    });
-
-    it('should sort sibling before stages by start time if available', function() {
-      var execution = {
-        stages: [
-          { id: 'a', name: 'a' },
-          { id: 'b', name: 'b', parentStageId: 'a', syntheticStageOwner: 'STAGE_BEFORE', startTime: 2 },
-          { id: 'c', name: 'c', parentStageId: 'a', syntheticStageOwner: 'STAGE_BEFORE', startTime: 1 },
-          { id: 'd', name: 'd', parentStageId: 'a', syntheticStageOwner: 'STAGE_AFTER' },
-          { id: 'e', name: 'e', parentStageId: 'b', syntheticStageOwner: 'STAGE_BEFORE' },
-          { id: 'f', name: 'f', parentStageId: 'b', syntheticStageOwner: 'STAGE_BEFORE', startTime: 1 },
-          { id: 'g', name: 'g', parentStageId: 'd', syntheticStageOwner: 'STAGE_BEFORE' },
-          { id: 'h', name: 'h', parentStageId: 'd', syntheticStageOwner: 'STAGE_AFTER' },
-        ]
-      };
-
-      this.transformer.transformExecution({}, execution);
-      expect(_.pluck(execution.stageSummaries[0].stages, 'id')).toEqual(['f', 'e', 'c', 'b', 'a', 'g', 'd', 'h']);
+      expect(_.pluck(execution.stageSummaries[0].stages, 'id')).toEqual(['c', 'f', 'e', 'b', 'a', 'g', 'd', 'h']);
     });
 
     it('should group stages into summaries when no synthetic stages added', function() {

--- a/app/scripts/modules/core/orchestratedItem/orchestratedItem.transformer.js
+++ b/app/scripts/modules/core/orchestratedItem/orchestratedItem.transformer.js
@@ -82,7 +82,7 @@ module.exports = angular.module('spinnaker.core.orchestratedItem.transformer', [
         },
         isFailed: {
           get: function() {
-            return item.status === 'FAILED';
+            return item.status === 'TERMINAL';
           },
         },
         isActive: {
@@ -145,7 +145,7 @@ module.exports = angular.module('spinnaker.core.orchestratedItem.transformer', [
           return 'RUNNING';
         case 'FAILED':
         case 'TERMINAL':
-          return 'FAILED';
+          return 'TERMINAL';
         case 'STOPPED':
           return 'STOPPED';
         case 'SUSPENDED':

--- a/app/scripts/modules/core/pipeline/pipelines.less
+++ b/app/scripts/modules/core/pipeline/pipelines.less
@@ -74,7 +74,7 @@
     .label-succeeded {
       background-color: @healthy_green_border;
     }
-    .label-failed, .label-terminated {
+    .label-terminal, .label-terminated {
       background-color: @unhealthy_red;
     }
     .label-running, .label-launched {

--- a/app/scripts/modules/core/presentation/less/imports/colors.less
+++ b/app/scripts/modules/core/presentation/less/imports/colors.less
@@ -58,7 +58,7 @@
 @bootstrap_info: #d9edf7;
 
 @stage-succeeded: #769D3E;
-@stage-failed: #b82525;
+@stage-terminal: #b82525;
 @stage-running: #2275b8;
 @stage-default: #cccccc;
 @stage-stopped: #777777;

--- a/app/scripts/modules/core/task/task.read.service.spec.js
+++ b/app/scripts/modules/core/task/task.read.service.spec.js
@@ -139,7 +139,7 @@ describe('Service: taskReader', function () {
       expect(failed).toBe(false);
 
       // succeeds
-      $http.expectGET('/applications/deck/tasks/1').respond(200, { id: 1, status: 'FAILED' });
+      $http.expectGET('/applications/deck/tasks/1').respond(200, { id: 1, status: 'TERMINAL' });
       cycle();
       expect(completed).toBe(false);
       expect(failed).toBe(true);

--- a/app/scripts/modules/core/task/tasks.html
+++ b/app/scripts/modules/core/task/tasks.html
@@ -24,8 +24,8 @@
           <label class="btn btn-sm btn-default" ng-model="viewState.taskStateFilter" uib-btn-radio="'SUCCEEDED'">
             <a href><status-glyph item="{isCompleted: true}"></status-glyph> Succeeded</a>
           </label>
-          <label class="btn btn-sm btn-default" ng-model="viewState.taskStateFilter" uib-btn-radio="'FAILED'">
-            <a href><status-glyph item="{isFailed: true}"></status-glyph> Failed</a>
+          <label class="btn btn-sm btn-default" ng-model="viewState.taskStateFilter" uib-btn-radio="'TERMINAL'">
+            <a href><status-glyph item="{isFailed: true}"></status-glyph> Terminal</a>
           </label>
           <label class="btn btn-sm btn-default" ng-model="viewState.taskStateFilter" uib-btn-radio="'CANCELED'">
             <a href><status-glyph item="{isCanceled: true}"></status-glyph> Canceled</a>

--- a/app/scripts/modules/netflix/canary/canary.less
+++ b/app/scripts/modules/netflix/canary/canary.less
@@ -1,3 +1,54 @@
+@import "../../core/presentation/less/imports/commonImports.less";
+
+.canary-summary {
+  .canary-deployment-row {
+    td:first-child {
+      padding-left: 20px;
+      font-weight: 600;
+    }
+  }
+}
+
+.canary-details {
+  .section-title {
+    border-bottom: 1px solid @mid_lighter_grey;
+    margin-bottom: 20px;
+    h4 {
+      border-bottom: 0;
+    }
+  }
+  h4 {
+    margin-bottom: 10px;
+    border-bottom: 1px solid @mid_lighter_grey;
+  }
+  .canary-config-section {
+    margin-bottom: 20px;
+  }
+
+  .canary-summary {
+    margin-bottom: 5px;
+    padding-bottom: 5px;
+    align-items: center;
+    display: flex;
+
+    & > div {
+      display: flex;
+      flex: 4 0 20px;
+      margin-right: 15px;
+      &.canary-summary-section {
+        display: block;
+      }
+      &.score-large {
+        flex: 0 0 auto;
+        margin-right: 10px;
+      }
+    }
+  }
+
+  h5 {
+    margin: 0;
+  }
+}
 
 .canary-container {
   padding-bottom: 10px;
@@ -7,11 +58,11 @@
 
 .score-large .score {
   height: 48px;
-  line-height: 38px;
+  line-height: 48px;
   padding: 0 10px 0 10px;
-  font-size: 175%;
-  border-radius: 0px;
-  margin: 10px 0 5px 10px;
+  font-size: 200%;
+  border-radius: 0;
+  margin: 0 0 5px 10px;
   min-width: 48px;
 }
 


### PR DESCRIPTION
A minor CSS fix, a minor data ordering fix, and a couple of bigger functionality fixes:
 * (bigger) "Failed" is now "Terminal" to better align with Orca's status values
 * (bigger) Removing a filter tag will reload executions
 * (minor) Much more sensible ordering of synthetic child stages (for @ajordens )
 * (minor) Fixed the CSS on the canary score box so the number is centered and the box is positioned more cleanly (@zanthrash - you'll want to check this on the fast property rollouts to make sure it looks fine there)

@zanthrash or @ajordens please review when you have a minute