### PR TITLE
Adding support for internet-elb v2.

### DIFF
--- a/app/scripts/modules/amazon/loadBalancer/configure/createLoadBalancerProperties.html
+++ b/app/scripts/modules/amazon/loadBalancer/configure/createLoadBalancerProperties.html
@@ -54,6 +54,18 @@
         <validation-error message="Detail can only contain letters, numbers, and dashes."></validation-error>
       </div>
     </div>
+
+    <!--Adding support for public facing elb. Display only for vpc-->
+    <div class="form-group" ng-if="loadBalancer.vpcId">
+      <div class="col-md-3 sm-label-right"><b>Internal</b></div>
+      <div class="col-md-7 checkbox">
+        <label><input type="checkbox"
+                      ng-model="loadBalancer.isInternal"/>
+          Create an internal load balancer
+        </label>
+      </div>
+    </div>
+
     <div class="form-group">
       <div class="col-md-9 col-md-offset-3" ng-if="form.loadBalancerName.$error.maxlength">
         <validation-error message="Load Balancer name can only be 32 characters."></validation-error>

--- a/app/scripts/modules/amazon/loadBalancer/loadBalancer.transformer.js
+++ b/app/scripts/modules/amazon/loadBalancer/loadBalancer.transformer.js
@@ -146,6 +146,7 @@ module.exports = angular.module('spinnaker.aws.loadBalancer.transformer', [
       return {
         stack: '',
         detail: '',
+        isInternal: false,
         credentials: defaultCredentials,
         region: defaultRegion,
         vpcId: null,


### PR DESCRIPTION
1. The checkbox for isInternal appears only for vpc.
2. Updated loadBalancer.transformer.js to have isInternal flag.