### PR TITLE
only attach security groups when they have been indexed

### DIFF
--- a/app/scripts/modules/core/securityGroup/securityGroup.read.service.js
+++ b/app/scripts/modules/core/securityGroup/securityGroup.read.service.js
@@ -123,6 +123,10 @@ module.exports = angular.module('spinnaker.core.securityGroup.read.service', [
     }
 
     function attachSecurityGroups(application, nameBasedSecurityGroups, retryIfNotFound) {
+      if (!application.securityGroupsIndex) {
+        // security groups have not yet been indexed; bail
+        return $q.when(null);
+      }
       let notFoundCaught = false;
       if (nameBasedSecurityGroups) {
         // reset everything

--- a/app/scripts/modules/core/securityGroup/securityGroup.read.service.spec.js
+++ b/app/scripts/modules/core/securityGroup/securityGroup.read.service.spec.js
@@ -31,6 +31,28 @@ describe('Service: securityGroupReader', function () {
     })
   );
 
+  it('does nothing when index not in place', function () {
+    var application = {
+      accounts: [ 'test' ],
+      securityGroups: { data: [] },
+      serverGroups: {data: []},
+      loadBalancers: {data: [
+        {
+          name: 'my-elb',
+          account: 'test',
+          region: 'us-east-1',
+          securityGroups: [
+            'not-cached',
+          ]
+        }
+      ]}
+    };
+
+    securityGroupReader.attachSecurityGroups(application);
+    $scope.$digest();
+    expect(application.securityGroups.data.length).toBe(0);
+  });
+
   it('attaches load balancer to security group usages', function() {
     var application = {
       accounts: [ 'test' ],
@@ -61,6 +83,7 @@ describe('Service: securityGroupReader', function () {
       accounts: [ 'test' ],
       securityGroups: { data: [] },
       serverGroups: {data: []},
+      securityGroupsIndex: {},
       loadBalancers: {data: [
         {
           name: 'my-elb',


### PR DESCRIPTION
prevents eager reloading of security groups when they are in the process of loading