### PR TITLE
use correct controller for aws find image details

### DIFF
--- a/app/scripts/modules/core/pipeline/config/stages/findAmi/aws/findAmiExecutionDetails.html
+++ b/app/scripts/modules/core/pipeline/config/stages/findAmi/aws/findAmiExecutionDetails.html
@@ -1,4 +1,4 @@
-<div ng-controller="gceFindAmiExecutionDetailsCtrl">
+<div ng-controller="awsFindAmiExecutionDetailsCtrl">
   <execution-details-section-nav sections="configSections"></execution-details-section-nav>
   <div class="step-section-details" ng-if="detailsSection === 'findImageConfig'">
     <div class="row">


### PR DESCRIPTION
The controllers are identical, which is why this has been working without issue.