### PR TITLE
adapt acct-reg-cluster-selector to work with quick patch stage

### DIFF
--- a/app/scripts/modules/core/application/service/applications.read.service.js
+++ b/app/scripts/modules/core/application/service/applications.read.service.js
@@ -247,6 +247,7 @@ module.exports = angular
 
       return $http.get([settings.gateUrl, 'applications', applicationName].join('/'))
         .then((response) => {
+          delete response.data.clusters; // do not overwrite the clusters we constructed!
           angular.extend(application, response.data);
           applicationLoadSuccess(application);
           return application;

--- a/app/scripts/modules/core/widgets/accountRegionClusterSelector.component.html
+++ b/app/scripts/modules/core/widgets/accountRegionClusterSelector.component.html
@@ -8,10 +8,17 @@
     required>
   </account-select-field>
 </stage-config-field>
-<stage-config-field label="Regions">
+<stage-config-field label="{{vm.singleRegion ? 'Region' : 'Regions'}}">
   <p ng-if="!vm.component.credentials" class="form-control-static">(Select an Account)</p>
+  <select class="form-control input-sm"
+          ng-if="vm.component.credentials && vm.singleRegion"
+          ng-model="vm.component.region"
+          ng-change="vm.regionChanged()"
+          ng-options="region for region in vm.regions"
+          required>
+  </select>
   <checklist
-    ng-if="vm.component.credentials"
+    ng-if="vm.component.credentials && !vm.singleRegion"
     items="vm.regions"
     model="vm.component.regions"
     inline="true"
@@ -22,7 +29,7 @@
 <stage-config-field label="Cluster" help-key="pipeline.config.findAmi.cluster">
   <cluster-selector
     clusters="vm.clusterList"
-    model="vm.component.cluster"
+    model="vm.component[vm.clusterField]"
     toggled="vm.clusterSelectInputToggled(isToggled)">
   </cluster-selector>
 </stage-config-field>

--- a/app/scripts/modules/core/widgets/accountRegionClusterSelector.component.js
+++ b/app/scripts/modules/core/widgets/accountRegionClusterSelector.component.js
@@ -16,10 +16,15 @@ module.exports = angular
         application: '=',
         component: '=',
         accounts: '=',
+        clusterField: '@',
+        singleRegion: '=',
       },
       templateUrl: require('./accountRegionClusterSelector.component.html'),
       controllerAs: 'vm',
       controller: function controller(appListExtractorService, accountService, _) {
+
+        this.clusterField = this.clusterField || 'cluster';
+
         let vm = this;
         let isTextInputForClusterFiled;
 
@@ -33,14 +38,15 @@ module.exports = angular
 
 
         let setClusterList = () => {
-          let clusterFilter = appListExtractorService.clusterFilterForCredentialsAndRegion(vm.component.credentials, vm.component.regions);
+          let regionField = this.singleRegion ? vm.component.region : vm.component.regions;
+          let clusterFilter = appListExtractorService.clusterFilterForCredentialsAndRegion(vm.component.credentials, regionField);
           vm.clusterList = appListExtractorService.getClusters([vm.application], clusterFilter);
         };
 
         vm.regionChanged = () => {
           setClusterList();
-          if (!isTextInputForClusterFiled && ! _.includes(vm.clusterList, vm.component.cluster)) {
-            vm.component.cluster = undefined;
+          if (!isTextInputForClusterFiled && ! _.includes(vm.clusterList, vm.component[this.clusterField])) {
+            vm.component[this.clusterField] = undefined;
           }
         };
 
@@ -50,7 +56,7 @@ module.exports = angular
         };
 
         let setUnToggledState = () => {
-          vm.component.cluster = undefined;
+          vm.component[this.clusterField] = undefined;
           isTextInputForClusterFiled = false;
           setRegionList();
         };
@@ -59,8 +65,8 @@ module.exports = angular
           isToggled ? setToggledState() : setUnToggledState();
         };
 
-        vm.accountUpdated = function() {
-          vm.component.cluster = undefined;
+        vm.accountUpdated = () => {
+          vm.component[this.clusterField] = undefined;
           setRegionList();
           setClusterList();
         };
@@ -73,7 +79,7 @@ module.exports = angular
           .then((allRegions) => {
             setRegionList();
             setClusterList();
-            vm.regions = _.includes(vm.clusterList, vm.component.cluster) ? vm.regions : allRegions;
+            vm.regions = _.includes(vm.clusterList, vm.component[this.clusterField]) ? vm.regions : allRegions;
           });
         };
 

--- a/app/scripts/modules/netflix/pipeline/stage/quickPatchAsg/quickPatchAsgStage.html
+++ b/app/scripts/modules/netflix/pipeline/stage/quickPatchAsg/quickPatchAsgStage.html
@@ -3,7 +3,9 @@
   <account-region-cluster-selector
     application="application"
     component="stage"
-    accounts="accounts" >
+    accounts="accounts"
+    cluster-field="clusterName"
+    single-region="true">
   </account-region-cluster-selector>
 
   <stage-config-field label="Package" help-key="pipeline.config.quickPatchAsg.package">


### PR DESCRIPTION
The Quick Patch stage uses `clusterName` instead of `cluster`, and a single `region` instead of `regions`. To maintain backwards compatibility with scripts and existing stages, I am leaving the quick patch stage as-is, although we may want to update the `clusterName` field at some point to be consistent with other stages.