### PR TITLE
component to allow editing of objects as key-value pairs

### DIFF
--- a/app/scripts/modules/core/forms/forms.module.js
+++ b/app/scripts/modules/core/forms/forms.module.js
@@ -8,4 +8,5 @@ module.exports = angular.module('spinnaker.core.forms', [
   require('./checkmap/checkmap.directive.js'),
   require('./ignoreEmptyDelete.directive.js'),
   require('./buttonBusyIndicator/buttonBusyIndicator.directive.js'),
+  require('./mapEditor/mapEditor.component.js'),
 ]);

--- a/app/scripts/modules/core/forms/mapEditor/mapEditor.component.html
+++ b/app/scripts/modules/core/forms/mapEditor/mapEditor.component.html
@@ -1,0 +1,41 @@
+<form name="mapEditor">
+  <table class="table table-condensed">
+    <thead>
+    <tr>
+      <th ng-bind="$ctrl.keyLabel"></th>
+      <th ng-bind="$ctrl.valueLabel"></th>
+      <th></th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr ng-repeat="pair in $ctrl.backingModel">
+      <td><input class="form-control input input-sm" type="text"
+                 name="{{$index}}"
+                 ng-model="pair.key"
+                 validate-unique="pair.checkUnique">
+        <div class="error-message" ng-if="mapEditor[$index].$error.validateUnique">Duplicate key</div>
+      </td>
+      <td><input class="form-control input input-sm" type="text"
+                 ng-model="pair.value"></td>
+      <td>
+        <div class="form-control-static">
+          <a href ng-click="$ctrl.removeField($index)">
+            <span class="glyphicon glyphicon-trash"></span>
+            <span class="sr-only">Remove field</span>
+          </a>
+        </div>
+      </td>
+    </tr>
+    </tbody>
+    <tfoot>
+    <tr>
+      <td colspan="3">
+        <button class="btn btn-block btn-sm add-new" ng-click="$ctrl.addField()">
+          <span class="glyphicon glyphicon-plus-sign"></span>
+          Add Field
+        </button>
+      </td>
+    </tr>
+    </tfoot>
+  </table>
+</form>

--- a/app/scripts/modules/core/forms/mapEditor/mapEditor.component.js
+++ b/app/scripts/modules/core/forms/mapEditor/mapEditor.component.js
@@ -1,0 +1,68 @@
+'use strict';
+
+const angular = require('angular');
+
+module.exports = angular
+  .module('spinnaker.core.forms.mapEditor.component', [
+    require('../../validation/validateUnique.directive')
+  ])
+  .component('mapEditor', {
+    bindings: {
+      model: '=',
+      keyLabel: '@',
+      valueLabel: '@',
+      allowEmpty: '=',
+      onChange: '&',
+    },
+    controller: function($scope) {
+      this.backingModel = [];
+
+      // Set default values for optional fields
+      this.onChange = this.onChange || angular.noop;
+      this.keyLabel = this.keyLabel || 'Key';
+      this.valueLabel = this.valueLabel || 'Value';
+
+      let modelKeys = () => Object.keys(this.model);
+
+      this.addField = () => {
+        this.backingModel.push({ key: '', value: '', checkUnique: modelKeys() });
+        // do not fire the onChange event, since no values have been committed to the object
+      };
+
+      this.removeField = (index) => {
+        this.backingModel.splice(index, 1);
+        this.synchronize();
+        this.onChange();
+      };
+
+      // Clears existing values from model, then replaces them
+      this.synchronize = () => {
+        let modelStart = JSON.stringify(this.model);
+        let allKeys = this.backingModel.map((pair) => pair.key);
+        modelKeys().forEach((key) => delete this.model[key]);
+        this.backingModel.forEach((pair) => {
+          if (pair.key && (this.allowEmpty || pair.value)) {
+            this.model[pair.key] = pair.value;
+          }
+          // include other keys to verify no duplicates
+          pair.checkUnique = allKeys.filter((key) => pair.key !== key);
+        });
+        if (modelStart !== JSON.stringify(this.model)) {
+          this.onChange();
+        }
+      };
+
+      // if defined, the $onInit method will automatically be called when components are initialized
+      this.$onInit = () => {
+        if (this.model) {
+          modelKeys().forEach((key) => {
+            this.backingModel.push({key: key, value: this.model[key]});
+          });
+        }
+      };
+
+      $scope.$watch(() => JSON.stringify(this.backingModel), this.synchronize);
+    },
+    templateUrl: require('./mapEditor.component.html'),
+  }
+);

--- a/app/scripts/modules/core/forms/mapEditor/mapEditor.component.spec.js
+++ b/app/scripts/modules/core/forms/mapEditor/mapEditor.component.spec.js
@@ -1,0 +1,186 @@
+'use strict';
+
+describe('Component: mapEditor', function () {
+
+  var scope;
+
+  beforeEach(
+    window.module(
+      require('./mapEditor.component.js')
+    )
+  );
+
+  beforeEach(window.inject(function ($rootScope, $compile) {
+    scope = $rootScope.$new();
+    this.compile = $compile;
+  }));
+
+  it('initializes with provided values', function() {
+    scope.model = {foo: 'bar', bah: 11};
+    let dom = this.compile('<map-editor model="model"></map-editor>')(scope);
+    scope.$digest();
+
+    expect(dom.find('input').size()).toBe(4);
+    expect(dom.find('input').get(0).value).toBe('foo');
+    expect(dom.find('input').get(1).value).toBe('bar');
+    expect(dom.find('input').get(2).value).toBe('bah');
+    expect(dom.find('input').get(3).value).toBe('11');
+  });
+
+  describe('empty value handling', function () {
+    it('ignores empty values when synchronizing to the model', function () {
+      scope.model = {foo: 'bar', bah: 11};
+      let dom = this.compile('<map-editor model="model"></map-editor>')(scope);
+      scope.$digest();
+      $(dom.find('input')[3]).val('').change();
+      scope.$digest();
+      expect(scope.model.foo).toBe('bar');
+      expect(scope.model.bah).toBeUndefined();
+    });
+
+    it('writes empty values when allowEmpty flag is set', function () {
+      scope.model = {foo: 'bar', bah: 11};
+      let dom = this.compile('<map-editor model="model" allow-empty="true"></map-editor>')(scope);
+      scope.$digest();
+      $(dom.find('input')[3]).val('').change();
+      scope.$digest();
+      expect(scope.model.foo).toBe('bar');
+      expect(scope.model.bah).toBe('');
+    });
+  });
+
+  describe('overriding table headings', function () {
+    it ('defaults to "Key" and "Value"', function () {
+      scope.model = {};
+      let dom = this.compile('<map-editor model="model"></map-editor>')(scope);
+      scope.$digest();
+      expect(dom.find('th')[0].innerText).toBe('Key');
+      expect(dom.find('th')[1].innerText).toBe('Value');
+    });
+
+    it ('can override "Key" and "Value"', function () {
+      scope.model = {};
+      let dom = this.compile('<map-editor model="model" key-label="some key" value-label="the value"></map-editor>')(scope);
+      scope.$digest();
+      expect(dom.find('th')[0].innerText).toBe('some key');
+      expect(dom.find('th')[1].innerText).toBe('the value');
+    });
+  });
+
+  describe('adding new entries', function () {
+    it('creates a new row in the table, but does not synchronize to model', function () {
+      scope.model = {};
+      let dom = this.compile('<map-editor model="model"></map-editor>')(scope);
+      scope.$digest();
+      dom.find('button').click();
+      expect(dom.find('tbody tr').length).toBe(1);
+      expect(dom.find('input').length).toBe(2);
+    });
+
+    it('does not flag multiple new rows without keys as having duplicate keys', function () {
+      scope.model = {};
+      let dom = this.compile('<map-editor model="model"></map-editor>')(scope);
+      scope.$digest();
+      dom.find('button').click();
+      dom.find('button').click();
+      expect(dom.find('tbody tr').length).toBe(2);
+      expect(dom.find('input').length).toBe(4);
+      expect(dom.find('.error-message').length).toBe(0);
+    });
+
+    it('if provided, calls the onChange event when key/value are both entered', function () {
+      let changeDetected = false;
+      scope.onChange = () => changeDetected = true;
+      scope.model = {foo: 'bar'};
+      let dom = this.compile('<map-editor model="model" on-change="onChange()"></map-editor>')(scope);
+      scope.$digest();
+      expect(dom.find('input').length).toBe(2);
+      dom.find('button').click();
+      scope.$digest();
+      expect(dom.find('input').length).toBe(4);
+      expect(changeDetected).toBe(false);
+
+      $(dom.find('input')[2]).val('bah').change();
+      scope.$digest();
+      expect(changeDetected).toBe(false);
+      $(dom.find('input')[3]).val('aah').change();
+      scope.$digest();
+      expect(changeDetected).toBe(true);
+    });
+  });
+
+  describe('removing entries', function () {
+    it('removes the entry when the trash can is clicked', function () {
+      scope.model = {foo: '1'};
+      let dom = this.compile('<map-editor model="model"></map-editor>')(scope);
+      scope.$digest();
+      expect(dom.find('input').length).toBe(2);
+      dom.find('a').click();
+      expect(dom.find('tbody tr').length).toBe(0);
+      expect(dom.find('input').length).toBe(0);
+      expect(scope.model.foo).toBeUndefined();
+    });
+
+    it('calls the onChange event if provided', function () {
+      let changeDetected = false;
+      scope.onChange = () => changeDetected = true;
+      scope.model = {foo: '1'};
+      let dom = this.compile('<map-editor model="model" on-change="onChange()"></map-editor>')(scope);
+      scope.$digest();
+      dom.find('a').click();
+      expect(dom.find('tbody tr').length).toBe(0);
+      expect(dom.find('input').length).toBe(0);
+      expect(scope.model.foo).toBeUndefined();
+      expect(changeDetected).toBe(true);
+    });
+  });
+
+  describe('duplicate key handling', function () {
+    it('provides a warning when a duplicate key is entered', function () {
+      scope.model = { a: '1', b: '2'};
+      let dom = this.compile('<map-editor model="model"></map-editor>')(scope);
+      scope.$digest();
+      $(dom.find('input')[2]).val('a').trigger('input');
+      scope.$digest();
+      expect(dom.find('.error-message').length).toBe(1);
+    });
+
+    it('removes the warning when the duplicate key is removed', function () {
+      scope.model = { a: '1', b: '2'};
+      let dom = this.compile('<map-editor model="model"></map-editor>')(scope);
+      scope.$digest();
+      $(dom.find('input')[2]).val('a').trigger('input');
+      scope.$digest();
+      expect(dom.find('input').length).toBe(4);
+      expect(dom.find('.error-message').length).toBe(1);
+      $(dom.find('a')[1]).click();
+      scope.$digest();
+      expect(dom.find('.error-message').length).toBe(0);
+      expect(dom.find('input').length).toBe(2);
+    });
+
+    it('only flags the changed entry, regardless of order relative to duplicated key', function () {
+      scope.model = { a: '1', b: '2'};
+      let dom = this.compile('<map-editor model="model"></map-editor>')(scope);
+      scope.$digest();
+      $(dom.find('input')[0]).val('b').trigger('input');
+      scope.$digest();
+      expect(dom.find('tbody tr:first-child .error-message').length).toBe(1);
+      expect(dom.find('tbody tr:nth-child(2) .error-message').length).toBe(0);
+
+      $(dom.find('input')[2]).val('a').trigger('input');
+      scope.$digest();
+      expect(dom.find('tbody tr:first-child .error-message').length).toBe(0);
+      expect(dom.find('tbody tr:nth-child(2) .error-message').length).toBe(0);
+
+      $(dom.find('input')[2]).val('b').trigger('input');
+      scope.$digest();
+      expect(dom.find('tbody tr:first-child .error-message').length).toBe(0);
+      expect(dom.find('tbody tr:nth-child(2) .error-message').length).toBe(1);
+
+    });
+  });
+
+
+
+});


### PR DESCRIPTION
Pretty simple Angular 1.5 component to allow editing of a map as simple key-value pairs. Provides options for `onChange` events, customizing labels for table, and allowing empty values.

<img width="677" alt="screen shot 2016-02-19 at 1 03 06 pm" src="https://cloud.githubusercontent.com/assets/73450/13188925/38225fa6-d709-11e5-96c2-66e020c2f15d.png">


Usage:
```html
<map-editor model="stage.extendedAttributes"></map-editor>
```
@tonyrzhang give this a shot - I think it will handle what you need for the extended attributes work...