### PR TITLE
fix linter warnings in cf module

### DIFF
--- a/app/scripts/modules/cloudfoundry/serverGroup/configure/wizard/ServerGroupAdvanced.controller.js
+++ b/app/scripts/modules/cloudfoundry/serverGroup/configure/wizard/ServerGroupAdvanced.controller.js
@@ -5,7 +5,7 @@ let angular = require('angular');
 module.exports = angular.module('spinnaker.serverGroup.configure.cf.advanced.controller', [
         require('../../../../core/modal/wizard/v2modalWizard.service.js'),
     ])
-    .controller('cfServerGroupAdvancedCtrl', function($scope, v2modalWizardService) {
+    .controller('cfServerGroupAdvancedCtrl', function(/*$scope, v2modalWizardService*/) {
 
         // TODO(GLT): Fix roles after Find/Bake updates are rolled in.
 

--- a/app/scripts/modules/cloudfoundry/serverGroup/configure/wizard/ServerGroupArtifactSettings.controller.js
+++ b/app/scripts/modules/cloudfoundry/serverGroup/configure/wizard/ServerGroupArtifactSettings.controller.js
@@ -5,7 +5,7 @@ let angular = require('angular');
 module.exports = angular.module('spinnaker.serverGroup.configure.cf.artifactSettings.controller', [
   require('../../../../core/modal/wizard/v2modalWizard.service.js'),
 ])
-  .controller('cfServerGroupArtifactSettingsCtrl', function($scope, v2modalWizardService) {
+  .controller('cfServerGroupArtifactSettingsCtrl', function(/*$scope, v2modalWizardService*/) {
 
     // TODO(GLT): Fix roles after Find/Bake updates are rolled in.
 

--- a/app/scripts/modules/cloudfoundry/serverGroup/configure/wizard/ServerGroupBasicSettings.controller.js
+++ b/app/scripts/modules/cloudfoundry/serverGroup/configure/wizard/ServerGroupBasicSettings.controller.js
@@ -3,7 +3,7 @@
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.serverGroup.configure.cf.basicSettings.controller', [])
-  .controller('cfServerGroupBasicSettingsCtrl', function($scope, v2modalWizardService) {
+  .controller('cfServerGroupBasicSettingsCtrl', function(/*$scope, v2modalWizardService*/) {
 
     // TODO(GLT): Fix roles after Find/Bake updates are rolled in.
 

--- a/app/scripts/modules/cloudfoundry/serverGroup/configure/wizard/ServerGroupEnvs.controller.js
+++ b/app/scripts/modules/cloudfoundry/serverGroup/configure/wizard/ServerGroupEnvs.controller.js
@@ -5,7 +5,7 @@ let angular = require('angular');
 module.exports = angular.module('spinnaker.serverGroup.configure.cf.envs.controller', [
         require('../../../../core/modal/wizard/v2modalWizard.service.js'),
     ])
-    .controller('cfServerGroupEnvsCtrl', function($scope, v2modalWizardService) {
+    .controller('cfServerGroupEnvsCtrl', function(/*$scope, v2modalWizardService*/) {
 
         // TODO(GLT): Fix roles after Find/Bake updates are rolled in.
 

--- a/app/scripts/modules/cloudfoundry/serverGroup/configure/wizard/ServerGroupLoadBalancers.controller.js
+++ b/app/scripts/modules/cloudfoundry/serverGroup/configure/wizard/ServerGroupLoadBalancers.controller.js
@@ -5,7 +5,7 @@ let angular = require('angular');
 module.exports = angular.module('spinnaker.serverGroup.configure.cf.loadBalancers.controller', [
         require('../../../../core/modal/wizard/v2modalWizard.service.js'),
     ])
-    .controller('cfServerGroupLoadBalancersCtrl', function($scope, v2modalWizardService) {
+    .controller('cfServerGroupLoadBalancersCtrl', function(/*$scope, v2modalWizardService*/) {
 
         // TODO(GLT): Fix roles after Find/Bake updates are rolled in.
 

--- a/app/scripts/modules/cloudfoundry/serverGroup/configure/wizard/ServerGroupServices.controller.js
+++ b/app/scripts/modules/cloudfoundry/serverGroup/configure/wizard/ServerGroupServices.controller.js
@@ -5,7 +5,7 @@ let angular = require('angular');
 module.exports = angular.module('spinnaker.serverGroup.configure.cf.services.controller', [
         require('../../../../core/modal/wizard/v2modalWizard.service.js'),
     ])
-    .controller('cfServerGroupServicesCtrl', function($scope, v2modalWizardService) {
+    .controller('cfServerGroupServicesCtrl', function(/*$scope, v2modalWizardService*/) {
 
         // TODO(GLT): Fix roles after Find/Bake updates are rolled in.
 


### PR DESCRIPTION
heads up @gregturn - getting a bunch of linter warnings about unused arguments - just commenting these out for now to keep the command line output cleaner