### PR TITLE
include region in *AsgStage label

### DIFF
--- a/app/scripts/modules/core/pipeline/config/stages/destroyAsg/aws/destroyAsgExecutionDetails.html
+++ b/app/scripts/modules/core/pipeline/config/stages/destroyAsg/aws/destroyAsgExecutionDetails.html
@@ -27,17 +27,17 @@
           <dt>Region</dt>
           <dd>{{stage.context.regions.join(', ')}}</dd>
           <dt>Server Group</dt>
-          <dd>{{stage.context.asgName}}</dd>
+          <dd>{{stage.context.serverGroupName}}</dd>
         </dl>
       </div>
     </div>
     <stage-failure-message is-failed="stage.isFailed" message="stage.failureMessage"></stage-failure-message>
 
-    <div class="row" ng-if="stage.isCompleted && stage.context.asgName">
+    <div class="row" ng-if="stage.isCompleted && stage.context.serverGroupName">
       <div class="col-md-12">
         <div class="well alert alert-info">
           <strong>Destroyed:</strong>
-          {{stage.context.asgName}}
+          {{stage.context.serverGroupName}}
         </div>
       </div>
     </div>

--- a/app/scripts/modules/core/pipeline/config/stages/destroyAsg/aws/destroyAsgStepLabel.html
+++ b/app/scripts/modules/core/pipeline/config/stages/destroyAsg/aws/destroyAsgStepLabel.html
@@ -1,1 +1,5 @@
-<span class="task-label">Destroy Server Group: {{step.context.serverGroupName}}</span>
+<span class="task-label">
+  Destroy Server Group:
+  {{step.context.serverGroupName}}
+  ({{step.context.regions[0]}})
+</span>

--- a/app/scripts/modules/core/pipeline/config/stages/destroyAsg/cf/destroyAsgExecutionDetails.html
+++ b/app/scripts/modules/core/pipeline/config/stages/destroyAsg/cf/destroyAsgExecutionDetails.html
@@ -17,7 +17,7 @@
     </div>
     <stage-failure-message is-failed="stage.isFailed" message="stage.failureMessage"></stage-failure-message>
 
-    <div class="row" ng-if="stage.isCompleted && stage.context.asgName">
+    <div class="row" ng-if="stage.isCompleted && stage.context.serverGroupName">
       <div class="col-md-12">
         <div class="well alert alert-info">
           <strong>Destroyed:</strong>

--- a/app/scripts/modules/core/pipeline/config/stages/destroyAsg/cf/destroyAsgStepLabel.html
+++ b/app/scripts/modules/core/pipeline/config/stages/destroyAsg/cf/destroyAsgStepLabel.html
@@ -1,1 +1,5 @@
-<span class="task-label">Destroy Server Group: {{step.context.serverGroupName}}</span>
+<span class="task-label">
+  Destroy Server Group:
+  {{step.context.serverGroupName}}
+  ({{step.context.zones[0]}})
+</span>

--- a/app/scripts/modules/core/pipeline/config/stages/destroyAsg/gce/destroyAsgExecutionDetails.html
+++ b/app/scripts/modules/core/pipeline/config/stages/destroyAsg/gce/destroyAsgExecutionDetails.html
@@ -17,7 +17,7 @@
     </div>
     <stage-failure-message is-failed="stage.isFailed" message="stage.failureMessage"></stage-failure-message>
 
-    <div class="row" ng-if="stage.isCompleted && stage.context.asgName">
+    <div class="row" ng-if="stage.isCompleted && stage.context.serverGroupName">
       <div class="col-md-12">
         <div class="well alert alert-info">
           <strong>Destroyed:</strong>

--- a/app/scripts/modules/core/pipeline/config/stages/destroyAsg/gce/destroyAsgStepLabel.html
+++ b/app/scripts/modules/core/pipeline/config/stages/destroyAsg/gce/destroyAsgStepLabel.html
@@ -1,1 +1,5 @@
-<span class="task-label">Destroy Server Group: {{step.context.serverGroupName}}</span>
+<span class="task-label">
+  Destroy Server Group:
+  {{step.context.serverGroupName}}
+  ({{step.context.zones[0]}})
+</span>

--- a/app/scripts/modules/core/pipeline/config/stages/determineTargetReference/determineTargetReferenceDetails.html
+++ b/app/scripts/modules/core/pipeline/config/stages/determineTargetReference/determineTargetReferenceDetails.html
@@ -1,7 +1,7 @@
 <div>
   <div class="step-section-details">
     <div class="row">
-      <div class="col-md-6">
+      <div class="col-md-12">
         <dl class="dl-narrow dl-horizontal">
           <dt>Account</dt>
           <dd>
@@ -15,7 +15,10 @@
           <dd>{{stage.context.cluster}}</dd>
           <dt>Server Groups</dt>
           <dd ng-if="stage.context.targetReferences.length">
-            <div data-ng-repeat="tr in stage.context.targetReferences">{{tr.name}}</div>
+            <div data-ng-repeat="tr in stage.context.targetReferences">
+              {{tr.name}}
+              <span ng-if="tr.region || tr.zone">({{tr.region || tr.zone}})</span>
+            </div>
           </dd>
           <dd ng-if="!stage.context.targetReferences.length">[n/a]</dd>
         </dl>

--- a/app/scripts/modules/core/pipeline/config/stages/disableAsg/aws/disableAsgExecutionDetails.html
+++ b/app/scripts/modules/core/pipeline/config/stages/disableAsg/aws/disableAsgExecutionDetails.html
@@ -11,17 +11,17 @@
           <dt>Region</dt>
           <dd>{{stage.context.regions.join(', ')}}</dd>
           <dt>Server Group</dt>
-          <dd>{{stage.context.asgName}}</dd>
+          <dd>{{stage.context.serverGroupName}}</dd>
         </dl>
       </div>
     </div>
     <stage-failure-message is-failed="stage.isFailed" message="stage.failureMessage"></stage-failure-message>
 
-    <div class="row" ng-if="stage.isCompleted && stage.context.asgName">
+    <div class="row" ng-if="stage.isCompleted && stage.context.serverGroupName">
       <div class="col-md-12">
         <div class="well alert alert-info">
           <strong>Disabled:</strong>
-          {{stage.context.asgName}}
+          {{stage.context.serverGroupName}}
         </div>
       </div>
     </div>

--- a/app/scripts/modules/core/pipeline/config/stages/disableAsg/aws/disableAsgStepLabel.html
+++ b/app/scripts/modules/core/pipeline/config/stages/disableAsg/aws/disableAsgStepLabel.html
@@ -1,1 +1,5 @@
-<span class="task-label">Disable Server Group: {{step.context.serverGroupName}}</span>
+<span class="task-label">
+  Disable Server Group:
+  {{step.context.serverGroupName}}
+  ({{step.context.regions[0]}})
+</span>

--- a/app/scripts/modules/core/pipeline/config/stages/disableAsg/cf/disableAsgStepLabel.html
+++ b/app/scripts/modules/core/pipeline/config/stages/disableAsg/cf/disableAsgStepLabel.html
@@ -1,1 +1,5 @@
-<span class="task-label">Disable Server Group: {{step.context.serverGroupName}}</span>
+<span class="task-label">
+  Disable Server Group:
+  {{step.context.serverGroupName}}
+  ({{step.context.zones[0]}})
+</span>

--- a/app/scripts/modules/core/pipeline/config/stages/disableAsg/gce/disableAsgStepLabel.html
+++ b/app/scripts/modules/core/pipeline/config/stages/disableAsg/gce/disableAsgStepLabel.html
@@ -1,1 +1,5 @@
-<span class="task-label">Disable Server Group: {{step.context.serverGroupName}}</span>
+<span class="task-label">
+  Disable Server Group:
+  {{step.context.serverGroupName}}
+  ({{step.context.zones[0]}})
+</span>

--- a/app/scripts/modules/core/pipeline/config/stages/enableAsg/aws/enableAsgExecutionDetails.html
+++ b/app/scripts/modules/core/pipeline/config/stages/enableAsg/aws/enableAsgExecutionDetails.html
@@ -11,7 +11,7 @@
           <dt>Region</dt>
           <dd>{{stage.context.regions.join(', ')}}</dd>
           <dt>Server Group</dt>
-          <dd>{{stage.context.asgName}}</dd>
+          <dd>{{stage.context.serverGroupName}}</dd>
         </dl>
       </div>
     </div>

--- a/app/scripts/modules/core/pipeline/config/stages/enableAsg/aws/enableAsgStepLabel.html
+++ b/app/scripts/modules/core/pipeline/config/stages/enableAsg/aws/enableAsgStepLabel.html
@@ -1,1 +1,5 @@
-<span class="task-label">Enable Server Group: {{step.context.serverGroupName}}</span>
+<span class="task-label">
+  Enable Server Group:
+  {{step.context.serverGroupName}}
+  ({{step.context.regions[0]}})
+</span>

--- a/app/scripts/modules/core/pipeline/config/stages/enableAsg/cf/enableAsgStepLabel.html
+++ b/app/scripts/modules/core/pipeline/config/stages/enableAsg/cf/enableAsgStepLabel.html
@@ -1,1 +1,5 @@
-<span class="task-label">Enable Server Group: {{step.context.serverGroupName}}</span>
+<span class="task-label">
+  Enable Server Group:
+  {{step.context.serverGroupName}}
+  ({{step.context.zones[0]}})
+</span>

--- a/app/scripts/modules/core/pipeline/config/stages/enableAsg/gce/enableAsgStepLabel.html
+++ b/app/scripts/modules/core/pipeline/config/stages/enableAsg/gce/enableAsgStepLabel.html
@@ -1,1 +1,5 @@
-<span class="task-label">Enable Server Group: {{step.context.serverGroupName}}</span>
+<span class="task-label">
+  Enable Server Group:
+  {{step.context.serverGroupName}}
+  ({{step.context.zones[0]}})
+</span>

--- a/app/scripts/modules/core/pipeline/config/stages/resizeAsg/aws/resizeAsgExecutionDetails.html
+++ b/app/scripts/modules/core/pipeline/config/stages/resizeAsg/aws/resizeAsgExecutionDetails.html
@@ -9,7 +9,7 @@
           <dt>Region</dt>
           <dd>{{stage.context.regions.join(',')}}</dd>
           <dt>Server Group</dt>
-          <dd>{{stage.context.asgName}}</dd>
+          <dd>{{stage.context.serverGroupName}}</dd>
           <dt>Capacity</dt>
           <dd>{{stage.context.capacity.min}} / {{stage.context.capacity.desired}} / {{stage.context.capacity.max}}</dd>
         </dl>

--- a/app/scripts/modules/core/pipeline/config/stages/resizeAsg/aws/resizeAsgStepLabel.html
+++ b/app/scripts/modules/core/pipeline/config/stages/resizeAsg/aws/resizeAsgStepLabel.html
@@ -1,1 +1,5 @@
-<span class="task-label">Resize Server Group: {{step.context.asgName}}</span>
+<span class="task-label">
+  Resize Server Group:
+  {{step.context.serverGroupName}}
+  ({{step.context.regions[0]}})
+</span>

--- a/app/scripts/modules/core/pipeline/config/stages/resizeAsg/cf/resizeAsgExecutionDetails.html
+++ b/app/scripts/modules/core/pipeline/config/stages/resizeAsg/cf/resizeAsgExecutionDetails.html
@@ -9,7 +9,7 @@
           <dt>Region</dt>
           <dd>{{stage.context.regions.join(',')}}</dd>
           <dt>Server Group</dt>
-          <dd>{{stage.context.asgName}}</dd>
+          <dd>{{stage.context.serverGroupName}}</dd>
           <dt>Capacity</dt>
           <dd>{{stage.context.capacity.min}} / {{stage.context.capacity.desired}} / {{stage.context.capacity.max}}</dd>
         </dl>

--- a/app/scripts/modules/core/pipeline/config/stages/resizeAsg/cf/resizeAsgStepLabel.html
+++ b/app/scripts/modules/core/pipeline/config/stages/resizeAsg/cf/resizeAsgStepLabel.html
@@ -1,1 +1,5 @@
-<span class="task-label">Resize Server Group: {{step.context.asgName}}</span>
+<span class="task-label">
+  Resize Server Group:
+  {{step.context.serverGroupName}}
+  ({{step.context.zones[0]}})
+</span>

--- a/app/scripts/modules/core/pipeline/config/stages/resizeAsg/gce/resizeAsgExecutionDetails.html
+++ b/app/scripts/modules/core/pipeline/config/stages/resizeAsg/gce/resizeAsgExecutionDetails.html
@@ -9,7 +9,7 @@
           <dt>Zones</dt>
           <dd>{{stage.context.zones.join(',')}}</dd>
           <dt>Server Group</dt>
-          <dd>{{stage.context.asgName}}</dd>
+          <dd>{{stage.context.serverGroupName}}</dd>
           <dt>Target Size</dt>
           <dd>{{stage.context.capacity.desired}}</dd>
         </dl>

--- a/app/scripts/modules/core/pipeline/config/stages/resizeAsg/gce/resizeAsgStepLabel.html
+++ b/app/scripts/modules/core/pipeline/config/stages/resizeAsg/gce/resizeAsgStepLabel.html
@@ -1,1 +1,5 @@
-<span class="task-label">Resize Server Group: {{step.context.asgName}}</span>
+<span class="task-label">
+  Resize Server Group:
+  {{step.context.serverGroupName}}
+  ({{step.context.zones[0]}})
+</span>


### PR DESCRIPTION
Since we allow these operations to act on multiple regions, it would be nice to include the region in the step labels in the execution details so users don't have to click on each step to figure out where it was operating.

Also cleaning up some references to `asgName`, which should be `serverGroupName` now.

@duftler can you verify this works on GCE when you have a minute?