### PR TITLE
Updated the help message for the "Package" field of Bake stage

### DIFF
--- a/app/scripts/modules/core/help/helpContents.js
+++ b/app/scripts/modules/core/help/helpContents.js
@@ -157,8 +157,11 @@ module.exports = angular.module('spinnaker.core.help.contents', [])
     'pipeline.config.quickPatchAsg.rollingPatch': '<p>Patch one instance at a time vs. all at once.</p>',
     'pipeline.config.quickPatchAsg.skipUpToDate': '<p>Skip instances which already have the requested version.</p>',
     'pipeline.config.jenkins.propertyFile': '<p>(Optional) Configures the name to the Jenkins artifact file used to pass in properties to later stages in the Spinnaker pipeline.</p>',
+<<<<<<< HEAD
+=======
     'pipeline.config.bake.package': '<p>The name of the package you want installed (without any version identifiers).</p>' +
       '<p>If your build produces a deb file named "myapp_1.27-h343", you would want to enter "myapp" here.</p>',
+>>>>>>> parent of a35f5a8... Updated the help message for the "Package" field of the Bake stage
     'pipeline.config.bake.baseAmi': '<p>(Optional) ami-????????</p>',
     'pipeline.config.bake.amiSuffix': '<p>(Optional) String of date in format YYYYMMDDHHmm, default is calculated from timestamp,</p>',
     'pipeline.config.bake.enhancedNetworking': '<p>(Optional) Enable enhanced networking (sr-iov) support for image (requires hvm and trusty base_os).</p>',

--- a/app/scripts/modules/core/help/helpContents.js
+++ b/app/scripts/modules/core/help/helpContents.js
@@ -157,11 +157,6 @@ module.exports = angular.module('spinnaker.core.help.contents', [])
     'pipeline.config.quickPatchAsg.rollingPatch': '<p>Patch one instance at a time vs. all at once.</p>',
     'pipeline.config.quickPatchAsg.skipUpToDate': '<p>Skip instances which already have the requested version.</p>',
     'pipeline.config.jenkins.propertyFile': '<p>(Optional) Configures the name to the Jenkins artifact file used to pass in properties to later stages in the Spinnaker pipeline.</p>',
-<<<<<<< HEAD
-=======
-    'pipeline.config.bake.package': '<p>The name of the package you want installed (without any version identifiers).</p>' +
-      '<p>If your build produces a deb file named "myapp_1.27-h343", you would want to enter "myapp" here.</p>',
->>>>>>> parent of a35f5a8... Updated the help message for the "Package" field of the Bake stage
     'pipeline.config.bake.baseAmi': '<p>(Optional) ami-????????</p>',
     'pipeline.config.bake.amiSuffix': '<p>(Optional) String of date in format YYYYMMDDHHmm, default is calculated from timestamp,</p>',
     'pipeline.config.bake.enhancedNetworking': '<p>(Optional) Enable enhanced networking (sr-iov) support for image (requires hvm and trusty base_os).</p>',

--- a/app/scripts/modules/netflix/help/netflixHelpContents.registry.js
+++ b/app/scripts/modules/netflix/help/netflixHelpContents.registry.js
@@ -52,6 +52,12 @@ module.exports = angular
         key: 'chaos.exceptions',
         contents: '<p>When Chaos Monkey is enabled, exceptions tell Chaos Monkey to leave certain clusters alone. ' +
         'You can use wildcards (*) to include all matching fields.</p>'
+      },
+      {
+        key: 'pipeline.config.bake.package',
+        contents: '<p>The name of the package you want installed (without any version identifiers).</p>' +
+        '<p>If your build produces a deb file named "myapp_1.27-h343", you would want to enter "myapp" here.</p>' +
+        '<p>If there are multiple packages (space separated), then they will be installed in the order they are entered.</p>'
       }
     ];
     helpContents.forEach((entry) => helpContentsRegistry.register(entry.key, entry.contents));


### PR DESCRIPTION
Made the changes suggested by @anotherchrisberry and @duftler  in the PR #1992 .
Moved the "pipeline.config.bake.package" message from helpContents.js to netflixHelpContents.registry.js. 

![packagebakehelp](https://cloud.githubusercontent.com/assets/16142228/13237568/d08ece3a-d981-11e5-9078-908a548b911a.png)


