### PR TITLE
consider all relevant fields when memoizing stage config lookup

### DIFF
--- a/app/scripts/modules/core/pipeline/config/pipelineConfigProvider.js
+++ b/app/scripts/modules/core/pipeline/config/pipelineConfigProvider.js
@@ -86,7 +86,7 @@ module.exports = angular.module('spinnaker.core.pipeline.config.configProvider',
         });
       }
       return matches.length ? matches[0] : null;
-    }, (stage) => stage ? stage.type : '');
+    }, (stage) => [stage ? stage.type : '', stage.cloudProvider || stage.cloudProviderType || 'aws'].join(':'));
 
     function getTriggerConfig(type) {
       var matches = getTriggerTypes().filter(function(triggerType) { return triggerType.key === type; });


### PR DESCRIPTION
Since `cloudProvider`/`cloudProviderType` are used in the lookup operation, we need to include that in the key that lodash uses when performing the memoization.

@duftler this should fix what you're seeing - PTAL