### PR TITLE
include tooltip on anchor, not spinning icon

### DIFF
--- a/app/scripts/modules/core/presentation/refresher/componentRefresher.directive.html
+++ b/app/scripts/modules/core/presentation/refresher/componentRefresher.directive.html
@@ -1,6 +1,7 @@
-<a href ng-click="vm.refresh()">
-        <span class="small glyphicon glyphicon-refresh refresh-enabled refresh-{{vm.getAgeColor()}}"
-              uib-tooltip-template="vm.templateUrl"
-              tooltip-placement="{{vm.$window.innerWidth < 1100 ? 'right' : 'bottom'}}"
-              ng-class="{'glyphicon-spinning': vm.state.loading}"></span>
+<a href
+   ng-click="vm.refresh()"
+   uib-tooltip-template="vm.templateUrl"
+   tooltip-placement="{{vm.$window.innerWidth < 1100 ? 'right' : 'bottom'}}">
+  <span class="small glyphicon glyphicon-refresh refresh-enabled refresh-{{vm.getAgeColor()}}"
+        ng-class="{'glyphicon-spinning': vm.state.loading}"></span>
 </a>


### PR DESCRIPTION
In its current state, the tooltip shifts up and down as the refresh icon spins. We can avoid this horrible behavior by attaching the tooltip to the parent anchor tag.