### PR TITLE
provider/kubernetes: Start work on deploy pipelines

### DIFF
--- a/app/scripts/modules/core/pipeline/config/stages/deploy/deployStage.js
+++ b/app/scripts/modules/core/pipeline/config/stages/deploy/deployStage.js
@@ -91,7 +91,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.deployStage', [
               return $scope.application;
             },
             serverGroupCommand: function () {
-              return serverGroupCommandBuilder.buildNewServerGroupCommandForPipeline(selectedProvider);
+              return serverGroupCommandBuilder.buildNewServerGroupCommandForPipeline(selectedProvider, $scope.stage, $scope.$parent.pipeline.stages);
             },
           }
         }).result.then(function(command) {

--- a/app/scripts/modules/core/serverGroup/configure/common/serverGroupCommandBuilder.js
+++ b/app/scripts/modules/core/serverGroup/configure/common/serverGroupCommandBuilder.js
@@ -26,8 +26,8 @@ module.exports = angular.module('spinnaker.core.serverGroup.configure.common.ser
       return getDelegate(serverGroup.type).buildServerGroupCommandFromExisting(application, serverGroup, mode);
     }
 
-    function buildNewServerGroupCommandForPipeline(provider) {
-      return getDelegate(provider).buildNewServerGroupCommandForPipeline();
+    function buildNewServerGroupCommandForPipeline(provider, currentStage, allStages) {
+      return getDelegate(provider).buildNewServerGroupCommandForPipeline(currentStage, allStages);
     }
 
     function buildServerGroupCommandFromPipeline(application, cluster) {

--- a/app/scripts/modules/kubernetes/cache/configurer.service.js
+++ b/app/scripts/modules/kubernetes/cache/configurer.service.js
@@ -12,7 +12,7 @@ module.exports = angular.module('spinnaker.kubernetes.cache.initializer', [
 
     let config = Object.create(null);
 
-    config.credentials = {
+    config.account = {
       initializers: [ () => accountService.getRegionsKeyedByAccount('kubernetes') ],
     };
 

--- a/app/scripts/modules/kubernetes/container/configurer.directive.html
+++ b/app/scripts/modules/kubernetes/container/configurer.directive.html
@@ -4,8 +4,13 @@
       Image
       <help-field key="kubernetes.containers.image"></help-field>
     </div>
-    <div class="col-md-6">
-      <p class="form-control-static">{{container.image}}</p>
+    <div class="col-md-9">
+      <ui-select ng-model="container.image" class="form-control input-sm">
+        <ui-select-match>{{$select.selected.image}}</ui-select-match>
+        <ui-select-choices repeat="container.image as container in command.backingData.filtered.containers | filter: { image: $select.search }">
+          <span ng-bind-html="'(' + container.registry + ') ' + container.image | highlight: $select.search"></span>
+        </ui-select-choices>
+      </ui-select>
     </div>
   </div>
   <div class="form-group">

--- a/app/scripts/modules/kubernetes/container/configurer.directive.js
+++ b/app/scripts/modules/kubernetes/container/configurer.directive.js
@@ -10,6 +10,7 @@ module.exports = angular.module('spinnaker.kubernetes.container.configurer.direc
       scope: {
         container: '=',
         index: '=',
+        command: '=',
       }
     };
   })

--- a/app/scripts/modules/kubernetes/image/image.reader.js
+++ b/app/scripts/modules/kubernetes/image/image.reader.js
@@ -13,7 +13,7 @@ module.exports = angular.module('spinnaker.kubernetes.image.reader', [])
         });
     }
 
-    function getImage(/*amiName, region, credentials*/) {
+    function getImage(/*amiName, region, account*/) {
       // kubernetes images are not regional so we don't need to retrieve ids scoped to regions.
       return null;
     }

--- a/app/scripts/modules/kubernetes/loadBalancer/configure/wizard/basicSettings.html
+++ b/app/scripts/modules/kubernetes/loadBalancer/configure/wizard/basicSettings.html
@@ -16,16 +16,16 @@
                validate-unique="existingLoadBalancerNames"
                validate-ignore-case="true"
                name="loadBalancerName"/>
-        <validation-error ng-if="form.loadBalancerName.$error.validateUnique" message="There is already a load balancer in {{loadBalancer.credentials}} with that name."></validation-error>
+        <validation-error ng-if="form.loadBalancerName.$error.validateUnique" message="There is already a load balancer in {{loadBalancer.account}} with that name."></validation-error>
       </div>
     </div>
     <div class="form-group">
       <div class="col-md-3 sm-label-right">Account</div>
       <div class="col-md-7">
-        <account-select-field component="loadBalancer" field="credentials" accounts="accounts" provider="'kubernetes'" on-change="ctrl.accountUpdated()"></account-select-field>
+        <account-select-field component="loadBalancer" field="account" accounts="accounts" provider="'kubernetes'" on-change="ctrl.accountUpdated()"></account-select-field>
       </div>
     </div>
-      <namespace-select-field component="loadBalancer" field="namespace" account="loadBalancer.credentials" namespaces="namespaces" on-change="ctrl.namespaceUpdated()"></namespace-select-field>
+      <namespace-select-field component="loadBalancer" field="namespace" account="loadBalancer.account" namespaces="namespaces" on-change="ctrl.namespaceUpdated()"></namespace-select-field>
     <div class="form-group">
       <div class="col-md-3 sm-label-right">Stack <help-field key="kubernetes.loadBalancer.stack"></help-field></div>
       <div class="col-md-3">

--- a/app/scripts/modules/kubernetes/loadBalancer/configure/wizard/upsert.controller.js
+++ b/app/scripts/modules/kubernetes/loadBalancer/configure/wizard/upsert.controller.js
@@ -41,7 +41,7 @@ module.exports = angular.module('spinnaker.loadBalancer.kubernetes.create.contro
       $modalInstance.close();
       var newStateParams = {
         name: $scope.loadBalancer.name,
-        accountId: $scope.loadBalancer.credentials,
+        accountId: $scope.loadBalancer.account,
         region: $scope.loadBalancer.region,
         provider: 'kubernetes',
       };
@@ -75,8 +75,8 @@ module.exports = angular.module('spinnaker.loadBalancer.kubernetes.create.contro
         $scope.state.accountsLoaded = true;
 
         var accountNames = _.pluck($scope.accounts, 'name');
-        if (accountNames.length && accountNames.indexOf($scope.loadBalancer.credentials) === -1) {
-          $scope.loadBalancer.credentials = accountNames[0];
+        if (accountNames.length && accountNames.indexOf($scope.loadBalancer.account) === -1) {
+          $scope.loadBalancer.account = accountNames[0];
         }
 
         ctrl.accountUpdated();
@@ -103,7 +103,7 @@ module.exports = angular.module('spinnaker.loadBalancer.kubernetes.create.contro
     }
 
     function updateLoadBalancerNames() {
-      var account = $scope.loadBalancer.credentials;
+      var account = $scope.loadBalancer.account;
 
       if (allLoadBalancerNames[account]) {
         $scope.existingLoadBalancerNames = _.flatten(_.map(allLoadBalancerNames[account]));
@@ -134,7 +134,7 @@ module.exports = angular.module('spinnaker.loadBalancer.kubernetes.create.contro
     };
 
     this.accountUpdated = function() {
-      accountService.getAccountDetails($scope.loadBalancer.credentials).then(function(details) {
+      accountService.getAccountDetails($scope.loadBalancer.account).then(function(details) {
         $scope.namespaces = details.namespaces;
         ctrl.namespaceUpdated();
       });

--- a/app/scripts/modules/kubernetes/loadBalancer/transformer.js
+++ b/app/scripts/modules/kubernetes/loadBalancer/transformer.js
@@ -24,7 +24,7 @@ module.exports = angular.module('spinnaker.kubernetes.loadBalancer.transformer',
         stack: '',
         detail: '',
         type: 'ClusterIP',
-        credentials: settings.providers.kubernetes ? settings.providers.kubernetes.defaults.account : null,
+        account: settings.providers.kubernetes ? settings.providers.kubernetes.defaults.account : null,
         namespace: settings.providers.kubernetes ? settings.providers.kubernetes.defaults.namespace : null,
         ports: [
           {

--- a/app/scripts/modules/kubernetes/serverGroup/configure/configuration.service.js
+++ b/app/scripts/modules/kubernetes/serverGroup/configure/configuration.service.js
@@ -61,7 +61,7 @@ module.exports = angular.module('spinnaker.serverGroup.configure.kubernetes.conf
 
     function getLoadBalancerNames(command) {
       return _(command.backingData.loadBalancers)
-        .filter({ account: command.credentials })
+        .filter({ account: command.account })
         .filter({ namespace: command.namespace })
         .pluck('name')
         .flatten(true)
@@ -95,7 +95,8 @@ module.exports = angular.module('spinnaker.serverGroup.configure.kubernetes.conf
         if (_.find(command.backingData.filtered.containers, { image: container.image })) {
           validContainers.push(container);
         } else {
-          result.dirty.containers = true;
+          result.dirty.containers = result.dirty.containers || [];
+          result.dirty.containers.push(container.image);
         }
       });
       command.containers = validContainers;
@@ -110,13 +111,13 @@ module.exports = angular.module('spinnaker.serverGroup.configure.kubernetes.conf
 
     /* TODO(lwander) To be incorporated later.
     function refreshNamespaces(command) {
-      return accountService.getAccountDetails(command.credentials).then(function(details) {
+      return accountService.getAccountDetails(command.account).then(function(details) {
         command.backingData.filtered.namespaces = details.namespaces;
       });
     }
 
     function refreshDockerRegistries(command) {
-      return accountService.getAccountDetails(command.credentials).then(function(details) {
+      return accountService.getAccountDetails(command.account).then(function(details) {
         command.backingData.filtered.dockerRegistries = details.dockerRegistries;
       });
     }
@@ -153,7 +154,7 @@ module.exports = angular.module('spinnaker.serverGroup.configure.kubernetes.conf
 
     function configureAccount(command) {
       var result = { dirty: {} };
-      command.backingData.account = command.backingData.accountMap[command.credentials];
+      command.backingData.account = command.backingData.accountMap[command.account];
       angular.extend(result.dirty, configureDockerRegistries(command).dirty);
       angular.extend(result.dirty, configureNamespaces(command).dirty);
       angular.extend(result.dirty, configureSecurityGroups(command).dirty);
@@ -186,7 +187,7 @@ module.exports = angular.module('spinnaker.serverGroup.configure.kubernetes.conf
         return result;
       };
 
-      command.credentialsChanged = function credentialsChanged() {
+      command.accountChanged = function accountChanged() {
         var result = { dirty: {} };
         angular.extend(result.dirty, configureAccount(command).dirty);
         command.viewState.dirty = command.viewState.dirty || {};

--- a/app/scripts/modules/kubernetes/serverGroup/configure/configure.kubernetes.module.js
+++ b/app/scripts/modules/kubernetes/serverGroup/configure/configure.kubernetes.module.js
@@ -9,4 +9,5 @@ module.exports = angular.module('spinnaker.serverGroup.configure.kubernetes', [
   require('./wizard/BasicSettings.controller.js'),
   require('./wizard/Clone.controller.js'),
   require('./wizard/loadBalancers.controller.js'),
+  require('./wizard/templateSelection.controller.js'),
 ]);

--- a/app/scripts/modules/kubernetes/serverGroup/configure/wizard/Clone.controller.js
+++ b/app/scripts/modules/kubernetes/serverGroup/configure/wizard/Clone.controller.js
@@ -15,6 +15,7 @@ module.exports = angular.module('spinnaker.serverGroup.configure.kubernetes.clon
                                                          kubernetesServerGroupConfigurationService,
                                                          serverGroupCommand, application, title) {
     $scope.pages = {
+      templateSelection: require('./templateSelection.html'),
       basicSettings: require('./basicSettings.html'),
       loadBalancers: require('./loadBalancers.html'),
       securityGroups: require('./securityGroups.html'),

--- a/app/scripts/modules/kubernetes/serverGroup/configure/wizard/basicSettings.html
+++ b/app/scripts/modules/kubernetes/serverGroup/configure/wizard/basicSettings.html
@@ -5,10 +5,10 @@
         <b>Account</b>
       </div>
       <div class="col-md-7">
-        <account-select-field component="command" field="credentials" accounts="command.backingData.accounts" provider="'kubernetes'"></account-select-field>
+        <account-select-field component="command" field="account" accounts="command.backingData.accounts" provider="'kubernetes'"></account-select-field>
       </div>
     </div>
-      <namespace-select-field component="command" field="namespace" account="command.credentials" namespaces="command.backingData.filtered.namespaces"></namespace-select-field>
+      <namespace-select-field component="command" field="namespace" account="command.account" namespaces="command.backingData.filtered.namespaces"></namespace-select-field>
     <div class="form-group">
       <div class="col-md-3 sm-label-right">
         Stack
@@ -41,15 +41,29 @@
       </div>
     </div>
 
+    <div class="col-md-12" ng-if="command.viewState.dirty.containers">
+      <div class="alert alert-warning">
+        <p><span class="glyphicon glyphicon-warning-sign"></span>
+          The following containers are not registered in the above namespace/account and were removed:
+        </p>
+        <ul>
+          <li ng-repeat="removed in command.viewState.dirty.containers">{{removed}}</li>
+        </ul>
+        <p class="text-right">
+          <a class="btn btn-sm btn-default dirty-flag-dismiss" href ng-click="command.viewState.dirty.containers = null">Okay</a>
+        </p>
+      </div>
+    </div>
+
     <div class="form-group">
       <div class="col-md-3 sm-label-right"><b>Containers</b>
       <help-field key="kubernetes.serverGroup.containers"></help-field>
       </div>
       <div class="col-md-9">
         <ui-select multiple ng-model="command.containers" class="form-control input-sm">
-          <ui-select-match>{{$item.registry}}/{{$item.image}}</ui-select-match>
+          <ui-select-match>{{$item.image}}</ui-select-match>
           <ui-select-choices repeat="container in command.backingData.filtered.containers | filter: { image: $select.search }">
-            <span ng-bind-html="container.registry + '/' + container.image | highlight: $select.search"></span>
+            <span ng-bind-html="'(' + container.registry + ') ' + container.image | highlight: $select.search"></span>
           </ui-select-choices>
         </ui-select>
       </div>

--- a/app/scripts/modules/kubernetes/serverGroup/configure/wizard/templateSelection.controller.js
+++ b/app/scripts/modules/kubernetes/serverGroup/configure/wizard/templateSelection.controller.js
@@ -1,0 +1,70 @@
+'use strict';
+
+let angular = require('angular');
+
+module.exports = angular.module('spinnaker.serverGroup.configure.kubernetes.templateSelection.controller', [
+  require('../../../../core/serverGroup/serverGroup.read.service.js'),
+  require('../../../../core/utils/lodash.js'),
+  require('../CommandBuilder.js'),
+])
+  .controller('kubernetesTemplateSelectionController', function($scope, kubernetesServerGroupCommandBuilder, serverGroupReader, _) {
+    var controller = this;
+
+    var noTemplate = { label: 'None', serverGroup: null, cluster: null };
+
+    $scope.command.viewState.template = noTemplate;
+
+    $scope.templates = [ noTemplate ];
+
+    var allClusters = _.groupBy(_.filter($scope.application.serverGroups.data, { type: 'kubernetes' }), function(serverGroup) {
+      return [serverGroup.cluster, serverGroup.account, serverGroup.region].join(':');
+    });
+
+    _.forEach(allClusters, function(cluster) {
+      var latest = _.sortBy(cluster, 'name').pop();
+      $scope.templates.push({
+        cluster: latest.cluster,
+        account: latest.account,
+        region: latest.region,
+        serverGroupName: latest.name,
+        serverGroup: latest
+      });
+    });
+
+    function applyCommandToScope(command) {
+      command.viewState.disableImageSelection = true;
+      command.viewState.disableStrategySelection = $scope.command.viewState.disableStrategySelection || false;
+      command.viewState.submitButtonLabel = 'Add';
+      angular.copy(command, $scope.command);
+    }
+
+    function buildEmptyCommand() {
+      return kubernetesServerGroupCommandBuilder.buildNewServerGroupCommand($scope.application, {mode: 'createPipeline'}).then(function(command) {
+        applyCommandToScope(command);
+      });
+    }
+
+    function buildCommandFromTemplate(serverGroup) {
+      return serverGroupReader.getServerGroup($scope.application.name, serverGroup.account, serverGroup.region, serverGroup.name).then(function (details) {
+        return kubernetesServerGroupCommandBuilder.buildServerGroupCommandFromExisting($scope.application, details, 'editPipeline').then(function (command) {
+          applyCommandToScope(command);
+        });
+      });
+    }
+
+    controller.selectTemplate = function () {
+      var selection = $scope.command.viewState.template;
+      if (selection && selection.cluster && selection.serverGroup) {
+        return buildCommandFromTemplate(selection.serverGroup);
+      } else {
+        return buildEmptyCommand();
+      }
+    };
+
+    controller.useTemplate = function() {
+      $scope.state.loaded = false;
+      controller.selectTemplate().then(function() {
+        $scope.$emit('template-selected');
+      });
+    };
+  });

--- a/app/scripts/modules/kubernetes/serverGroup/configure/wizard/templateSelection.html
+++ b/app/scripts/modules/kubernetes/serverGroup/configure/wizard/templateSelection.html
@@ -1,0 +1,65 @@
+<div modal-page ng-controller="kubernetesTemplateSelectionController as templateSelection">
+  <modal-close></modal-close>
+  <div ng-if="state.loaded">
+    <div class="modal-header">
+      <h3>Template Selection</h3>
+    </div>
+    <div class="modal-body">
+      <form class="form-horizontal">
+        <div class="form-group">
+          <div class="col-md-4 col-md-offset-1 sm-label-left">
+            <b>Copy configuration from</b>
+          </div>
+        </div>
+        <div class="form-group">
+          <div class="col-md-6 col-md-offset-1">
+            <ui-select ng-model="command.viewState.template"
+                       class="form-control input-sm">
+              <ui-select-match placeholder="Select...">
+              <span ng-if="!$select.selected.label">
+                <account-tag account="$select.selected.account"></account-tag>
+                <span ng-if="$select.selected.serverGroup">{{$select.selected.serverGroupName}}</span>
+                ({{$select.selected.region}})
+              </span>
+                <span ng-if="$select.selected.label">{{$select.selected.label}}</span>
+              </ui-select-match>
+              <ui-select-choices repeat="template in templates | anyFieldFilter: {label: $select.search, serverGroupName: $select.search}">
+                <h5 ng-if="!template.label"><account-tag account="template.account"></account-tag> {{template.cluster}} ({{template.region}})</h5>
+                <h5 ng-if="template.label">{{template.label}}</h5>
+                <div ng-if="template.serverGroup">
+                  <b>Most recent server group: </b> {{template.serverGroupName}}
+                </div>
+              </ui-select-choices>
+            </ui-select>
+          </div>
+        </div>
+        <div class="form-group" ng-if="command.viewState.customTemplateMessage">
+          <p class="col-md-10 col-md-offset-1" ng-bind-html="command.viewState.customTemplateMessage"></p>
+        </div>
+        <div class="form-group" ng-if="command.viewState.template.serverGroup" style="margin-top: 20px">
+          <div class="col-md-10 col-md-offset-1 well">
+            These fields <strong>will be</strong> copied over from the most recent server group:
+            <ul>
+              <li>account, namespace, cluster name (stack, details)</li>
+              <li>load balancers</li>
+              <li>security groups</li>
+              <li>container configuration</li>
+            </ul>
+            These fields <strong>will NOT</strong> be copied over, and will be reset to defaults:
+            <ul>
+              <li ng-if="!command.viewState.disableStrategySelection">the deployment strategy (if any) used to deploy the most recent server group</li>
+            </ul>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="modal-footer">
+      <button class="btn btn-primary"
+              ng-click="templateSelection.useTemplate()">
+        <span ng-if="command.viewState.template.serverGroup">Use this template</span>
+        <span ng-if="!command.viewState.template.serverGroup">Continue without a template</span>
+        <span class="glyphicon glyphicon-chevron-right"></span>
+      </button>
+    </div>
+  </div>
+</div>

--- a/app/scripts/modules/kubernetes/serverGroup/configure/wizard/wizard.html
+++ b/app/scripts/modules/kubernetes/serverGroup/configure/wizard/wizard.html
@@ -20,7 +20,7 @@
     </v2-wizard-page>
     <div ng-repeat="container in command.containers">
       <v2-wizard-page key="container-{{$index}}" label="Container {{container.image}}" done="true">
-        <kubernetes-container-configurer index="$index" container="container"></kubernetes-container-configurer>
+        <kubernetes-container-configurer command="command" index="$index" container="container"></kubernetes-container-configurer>
       </v2-wizard-page>
     </div>
   </v2-modal-wizard>


### PR DESCRIPTION
This enables template selection in the pipeline deploy view, and starts the work needed to be able to select an image from among multiple "Find Image" stages. The reason why I allow multiple find image stages is because a single instance (pod) can house multiple containers. In order to disambiguate the "Find Image" stages, the current pipeline details are now passed into `serverGroupCommandBuilder.buildNewServerGroupCommandForPipeline` to discover all upstream "Find Image" stages. Presenting these stages to the user in the Server Group configuration, and sending the details to Orca will come in a later PR, namely, after I've generalized deploymentDetails.

@duftler 

@anotherchrisberry since I'm touching some of the `core` module, could you PTAL?