### PR TITLE
Netflix help registry

### DIFF
--- a/app/scripts/modules/netflix/help/netflixHelpContents.registry.js
+++ b/app/scripts/modules/netflix/help/netflixHelpContents.registry.js
@@ -5,8 +5,9 @@ const angular = require('angular');
 module.exports = angular
   .module('spinnaker.netflix.help.registry', [
     require('../../core/help/helpContents.registry.js'),
+    require('../../core/config/settings.js'),
   ])
-  .run(function(helpContentsRegistry) {
+  .run(function(helpContentsRegistry, settings) {
     let helpContents = [
       {
         key: 'application.chaos.enabled',
@@ -54,5 +55,7 @@ module.exports = angular
         'You can use wildcards (*) to include all matching fields.</p>'
       }
     ];
-    helpContents.forEach((entry) => helpContentsRegistry.register(entry.key, entry.contents));
+    if (settings.feature && settings.feature.netflixMode) {
+      helpContents.forEach((entry) => helpContentsRegistry.register(entry.key, entry.contents));
+    }
   });


### PR DESCRIPTION
Surprise, we were adding the Netflix-specific help contents to every build. This allows it to operate as an optional override.

@vjames-bmc Sorry! This is why you're seeing what you're seeing in https://github.com/spinnaker/deck/pull/2008. Once I get this merged, go ahead and rebase, then update that PR as I was suggesting.