### PR TITLE
Use fancy new map-editor instead of hand-rolling GCE Instance Metadata.

### DIFF
--- a/app/scripts/modules/core/forms/mapEditor/mapEditor.component.html
+++ b/app/scripts/modules/core/forms/mapEditor/mapEditor.component.html
@@ -32,7 +32,7 @@
       <td colspan="3">
         <button class="btn btn-block btn-sm add-new" ng-click="$ctrl.addField()">
           <span class="glyphicon glyphicon-plus-sign"></span>
-          Add Field
+          {{ $ctrl.addButtonLabel }}
         </button>
       </td>
     </tr>

--- a/app/scripts/modules/core/forms/mapEditor/mapEditor.component.js
+++ b/app/scripts/modules/core/forms/mapEditor/mapEditor.component.js
@@ -11,6 +11,7 @@ module.exports = angular
       model: '=',
       keyLabel: '@',
       valueLabel: '@',
+      addButtonLabel: '@',
       allowEmpty: '=?',
       onChange: '&',
     },
@@ -21,6 +22,7 @@ module.exports = angular
       this.onChange = this.onChange || angular.noop;
       this.keyLabel = this.keyLabel || 'Key';
       this.valueLabel = this.valueLabel || 'Value';
+      this.addButtonLabel = this.addButtonLabel || 'Add Field';
       this.allowEmpty = this.allowEmpty || false;
 
       let modelKeys = () => Object.keys(this.model);

--- a/app/scripts/modules/core/help/helpContents.js
+++ b/app/scripts/modules/core/help/helpContents.js
@@ -109,6 +109,7 @@ module.exports = angular.module('spinnaker.core.help.contents', [])
     'gce.loadBalancer.portRange': '(Optional) Only packets addressed to ports in the specified <b>Port Range</b> will be forwarded. If left empty, all ports are forwarded. Must be a single port number or two port numbers separated by a dash. Each port number must be between 1 and 65535, inclusive. For example: 5000-5999.',
     'gce.serverGroup.imageName': '(Required) <b>Image</b> is the Google Compute Engine image. Images are restricted to the account selected.',
     'gce.serverGroup.capacity': 'The number of instances that the instance group manager will attempt to maintain. Deleting or abandoning instances will affect this number, as will resizing the group.',
+    'gce.serverGroup.customMetadata': '<b>Custom Metadata</b> will be propagated to the instances in this server group. This is useful for passing in arbitrary values that can be queried by your code on the instance.',
     'gce.serverGroup.customMetadata.load-balancer-names': 'This field is used to "remember" what load balancers this server group is associated with, even if the instances are deregistered.',
     'gce.serverGroup.customMetadata.startup-script': 'This script will run automatically on every boot.',
     'gce.serverGroup.preemptibility': 'A preemptible VM costs much less, but lasts only 24 hours. It can be terminated sooner due to system demands.',

--- a/app/scripts/modules/google/serverGroup/configure/ServerGroupCommandBuilder.js
+++ b/app/scripts/modules/google/serverGroup/configure/ServerGroupCommandBuilder.js
@@ -126,19 +126,14 @@ module.exports = angular.module('spinnaker.gce.serverGroupCommandBuilder.service
           metadataItems.forEach(function (metadataItem) {
             // Don't show 'load-balancer-names' key/value pair in the wizard.
             if (metadataItem.key !== 'load-balancer-names') {
-              // The 'key' and 'value' attributes are used to enable the Add/Remove behavior in the wizard.
-              command.instanceMetadata.push(metadataItem);
+              command.instanceMetadata[metadataItem.key] = metadataItem.value;
             }
           });
         } else {
           for (var property in metadataItems) {
             // Don't show 'load-balancer-names' key/value pair in the wizard.
             if (property !== 'load-balancer-names') {
-              // The 'key' and 'value' attributes are used to enable the Add/Remove behavior in the wizard.
-              command.instanceMetadata.push({
-                key: property,
-                value: metadataItems[property],
-              });
+              command.instanceMetadata[property] = metadataItems[property];
             }
           }
         }
@@ -205,7 +200,7 @@ module.exports = angular.module('spinnaker.gce.serverGroupCommandBuilder.service
         persistentDiskType: 'pd-ssd',
         persistentDiskSizeGb: 10,
         localSSDCount: 1,
-        instanceMetadata: [],
+        instanceMetadata: {},
         tags: [],
         preemptible: false,
         automaticRestart: true,
@@ -271,7 +266,7 @@ module.exports = angular.module('spinnaker.gce.serverGroupCommandBuilder.service
         zone: serverGroup.zones[0],
         network: extractNetworkName(serverGroup),
         subnet: extractSubnetName(serverGroup),
-        instanceMetadata: [],
+        instanceMetadata: {},
         tags: [],
         availabilityZones: [],
         cloudProvider: 'gce',
@@ -349,7 +344,7 @@ module.exports = angular.module('spinnaker.gce.serverGroupCommandBuilder.service
 
         return populateDisksFromPipeline(extendedCommand.disks, extendedCommand).then(function() {
           var instanceMetadata = extendedCommand.instanceMetadata;
-          extendedCommand.instanceMetadata = [];
+          extendedCommand.instanceMetadata = {};
           populateCustomMetadata(instanceMetadata, extendedCommand);
 
           var instanceTemplateTags = {items: extendedCommand.tags};

--- a/app/scripts/modules/google/serverGroup/configure/serverGroupAdvancedSettingsDirective.html
+++ b/app/scripts/modules/google/serverGroup/configure/serverGroupAdvancedSettingsDirective.html
@@ -33,38 +33,14 @@
                                ng-disabled="!command.viewState.instanceTypeDetails.storage.localSSDSupported"/></div>
 </div>
 <div class="form-group">
-  <div class="col-md-12">
-    <table class="table table-condensed packed metadata">
-      <b>Custom Metadata</b>
-      <thead>
-      <tr>
-        <th style="width: 25%">Key</th>
-        <th style="width: 75%">Value</th>
-      </tr>
-      </thead>
-      <tbody>
-      <tr ng-repeat="instanceMetadataPair in command.instanceMetadata">
-        <td><input class="form-control input-sm" type="text" ng-model="instanceMetadataPair.key" required/></td>
-        <td><input class="form-control input-sm" type="text" ng-model="instanceMetadataPair.value" required/></td>
-        <td><a class="btn btn-link sm-label"
-               ng-click="advancedSettingsCtrl.removeInstanceMetadata($index)"><span
-          class="glyphicon glyphicon-trash"></span></a></td>
-      </tr>
-      </tbody>
-      <tfoot>
-      <tr>
-        <td colspan="2">
-          <button class="add-new col-md-12" ng-click="advancedSettingsCtrl.addInstanceMetadata()"><span
-            class="glyphicon glyphicon-plus-sign"></span> Add New Metadata
-          </button>
-        </td>
-      </tr>
-      </tfoot>
-    </table>
+  <div class="sm-label-left">
+    <b>Custom Metadata</b>
+    <help-field key="gce.serverGroup.customMetadata"></help-field>
   </div>
+  <map-editor model="command.instanceMetadata" add-button-label="Add New Metadata" allow-empty="true"></map-editor>
 </div>
 <div class="form-group">
-  <div class="col-md-12">
+  <div class="sm-label-left">
     <table class="table table-condensed packed tags">
       <b>Tags</b>
       <tbody>
@@ -78,7 +54,7 @@
       <tfoot>
       <tr>
         <td colspan="1">
-          <button class="add-new col-md-12" ng-click="advancedSettingsCtrl.addTag()"><span
+          <button class="btn btn-block btn-sm add-new" ng-click="advancedSettingsCtrl.addTag()"><span
             class="glyphicon glyphicon-plus-sign"></span> Add New Tag
           </button>
         </td>

--- a/app/scripts/modules/google/serverGroup/configure/serverGroupAdvancedSettingsSelector.directive.js
+++ b/app/scripts/modules/google/serverGroup/configure/serverGroupAdvancedSettingsSelector.directive.js
@@ -17,14 +17,6 @@ module.exports = angular
     };
   })
   .controller('gceServerGroupAdvancedSettingsSelectorCtrl', function($scope) {
-    this.addInstanceMetadata = function() {
-      $scope.command.instanceMetadata.push({});
-    };
-
-    this.removeInstanceMetadata = function(index) {
-      $scope.command.instanceMetadata.splice(index, 1);
-    };
-
     this.addTag = function() {
       $scope.command.tags.push({});
     };

--- a/app/scripts/modules/google/serverGroup/configure/serverGroupAdvancedSettingsSelector.directive.spec.js
+++ b/app/scripts/modules/google/serverGroup/configure/serverGroupAdvancedSettingsSelector.directive.spec.js
@@ -20,40 +20,6 @@ describe('Directive: GCE Group Advanced Settings Selector', function() {
     this.scope.$digest();
   }));
 
-  it('should correctly add a metadata key/value to the command', function() {
-    expect(this.scope.command.instanceMetadata.length).toEqual(0);
-
-    this.elem.find('table.metadata button').trigger('click');
-    this.scope.$apply();
-    expect(this.scope.command.instanceMetadata.length).toEqual(1);
-
-    var inputs = this.elem.find('table.metadata input');
-    expect(inputs.length).toEqual(2);
-    $(inputs[0]).val('myKey').trigger('input');
-    $(inputs[1]).val('myVal').trigger('input');
-    this.scope.$apply();
-
-    expect(this.scope.command.instanceMetadata.length).toEqual(1);
-    expect(this.scope.command.instanceMetadata[0].key).toEqual('myKey');
-    expect(this.scope.command.instanceMetadata[0].value).toEqual('myVal');
-  });
-
-  it('should correctly remove a metadata key/value from the command', function() {
-    this.scope.command.instanceMetadata.push({'key': 'myKey1', 'value': 'myVal1'},
-      {'key': 'myKey2', 'value': 'myVal2'});
-    this.scope.$apply();
-
-    var removeLinks = this.elem.find('table.metadata a');
-    expect(removeLinks.length).toEqual(2);
-
-    $(removeLinks[0]).trigger('click');
-    this.scope.$apply();
-
-    expect(this.scope.command.instanceMetadata.length).toEqual(1);
-    expect(this.scope.command.instanceMetadata[0].key).toEqual('myKey2');
-    expect(this.scope.command.instanceMetadata[0].value).toEqual('myVal2');
-  });
-
   it('should correctly add tags to the command', function() {
     expect(this.scope.command.tags.length).toEqual(0);
 

--- a/app/scripts/modules/google/serverGroup/configure/wizard/CloneServerGroupCtrl.js
+++ b/app/scripts/modules/google/serverGroup/configure/wizard/CloneServerGroupCtrl.js
@@ -169,18 +169,10 @@ module.exports = angular.module('spinnaker.serverGroup.configure.gce.cloneServer
     this.clone = function () {
       generateDiskDescriptors();
 
-      var origInstanceMetadata = $scope.command.instanceMetadata;
-      var transformedInstanceMetadata = {};
-      // The instanceMetadata is stored using 'key' and 'value' attributes to enable the Add/Remove behavior in the wizard.
-      $scope.command.instanceMetadata.forEach(function(metadataPair) {
-        transformedInstanceMetadata[metadataPair.key] = metadataPair.value;
-      });
-
       // We use this list of load balancer names when 'Enabling' a server group.
       if ($scope.command.loadBalancers && $scope.command.loadBalancers.length > 0) {
-        transformedInstanceMetadata['load-balancer-names'] = $scope.command.loadBalancers.toString();
+        $scope.command.instanceMetadata['load-balancer-names'] = $scope.command.loadBalancers.toString();
       }
-      $scope.command.instanceMetadata = transformedInstanceMetadata;
 
       var origTags = $scope.command.tags;
       var transformedTags = [];
@@ -204,7 +196,7 @@ module.exports = angular.module('spinnaker.serverGroup.configure.gce.cloneServer
           var promise = serverGroupWriter.cloneServerGroup(angular.copy($scope.command), application);
 
           // Copy back the original objects so the wizard can still be used if the command needs to be resubmitted.
-          $scope.command.instanceMetadata = origInstanceMetadata;
+          delete $scope.command.instanceMetadata['load-balancer-names'];
           $scope.command.tags = origTags;
 
           return promise;


### PR DESCRIPTION
Define addButtonLabel on map-editor to override default 'Add Field' text.