### PR TITLE
bundle most vendor files into separate chunk

### DIFF
--- a/app/scripts/modules/core/core.module.js
+++ b/app/scripts/modules/core/core.module.js
@@ -16,8 +16,6 @@ require('select2-bootstrap-css/select2-bootstrap.css');
 require('Select2/select2.css');
 require('ui-select/dist/select.css');
 
-require('angular-wizard/dist/angular-wizard.css');
-
 require('source-sans-pro');
 
 // load all templates into the $templateCache

--- a/app/scripts/modules/core/modal/wizard/modalWizard.less
+++ b/app/scripts/modules/core/modal/wizard/modalWizard.less
@@ -17,14 +17,21 @@ v2-modal-wizard {
     position: relative;
     background-color: #ffffff;
     z-index: 5;
+
     .clearfix();
     li {
       display: block;
       width: 100%;
       text-align: left;
       padding: 0;
+      position: relative;
       a {
+        color: #808080;
         display: block;
+        line-height: 15px;
+        text-decoration: none;
+        text-transform: uppercase;
+        transition: 0.25s;
         width: 100%;
         font-weight: normal;
         padding: 10px 5px 10px 32px;
@@ -39,7 +46,7 @@ v2-modal-wizard {
         background-color: transparent;
         content: '';
         transition: 0.25s;
-        font-size: 135%;
+        font-size: 110%;
         font-family: 'Glyphicons Halflings';
       }
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "angular-ui-router": "=0.2.13",
     "angular-ui-select2": "0.0.5",
     "angular-ui-sortable": "^0.13.4",
-    "angular-wizard": "^0.5.3",
     "bootstrap": "3.3.5",
     "clipboard": "git://github.com/zenorocha/clipboard.js.git#v1.3.1",
     "d3": "^3.5.6",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,6 +14,10 @@ module.exports = {
   entry: {
     settings: './settings.js',
     app: './app/scripts/app.js',
+    vendor: ['jquery', 'angular', 'angular-animate', 'angular-ui-bootstrap', 'angular-ui-router', 'restangular',
+      'source-sans-pro', 'angular-cache', 'angular-debounce', 'angular-marked', 'angular-messages', 'angular-sanitize',
+      'bootstrap', 'clipboard', 'd3', 'jquery-ui', 'moment-timezone', 'rx'
+    ]
   },
   output: {
     path: path.join(__dirname, 'build', 'webpack', process.env.SPINNAKER_ENV || ''),
@@ -69,9 +73,8 @@ module.exports = {
     root: nodeModulePath
   },
   plugins: [
-    new CommonsChunkPlugin(
-      /* filename= */'init.js'
-    ),
+    new CommonsChunkPlugin('vendor', 'vendor.bundle.js'),
+    new CommonsChunkPlugin('init.js'),
     new HtmlWebpackPlugin({
       title: 'Spinnaker',
       template: './app/index.html',


### PR DESCRIPTION
Splitting into separate bundles to reduce the bundles from one huge (~9MB) file to two very large (~4 and ~5MB) files.

Also bringing over the remaining styles needed from `angular-wizard` to remove that dependency.