### PR TITLE
backfill serverGroup account from parameters

### DIFF
--- a/app/scripts/modules/amazon/serverGroup/details/serverGroupDetails.aws.controller.js
+++ b/app/scripts/modules/amazon/serverGroup/details/serverGroupDetails.aws.controller.js
@@ -78,6 +78,8 @@ module.exports = angular.module('spinnaker.serverGroup.details.aws.controller', 
 
         var plainDetails = details.plain();
         angular.extend(plainDetails, summary);
+        // it's possible the summary was not found because the clusters are still loading
+        plainDetails.account = serverGroup.accountId;
 
         this.serverGroup = plainDetails;
           this.runningExecutions = () => {

--- a/app/scripts/modules/azure/serverGroup/details/serverGroupDetails.azure.controller.js
+++ b/app/scripts/modules/azure/serverGroup/details/serverGroupDetails.azure.controller.js
@@ -74,6 +74,7 @@ module.exports = angular.module('spinnaker.azure.serverGroup.details.controller'
 
         var restangularlessDetails = details.plain();
         angular.extend(restangularlessDetails, summary);
+        restangularlessDetails.account = serverGroup.accountId; // it's possible the summary was not found because the clusters are still loading
 
         $scope.serverGroup = restangularlessDetails;
         $scope.runningExecutions = function() {

--- a/app/scripts/modules/cloudfoundry/serverGroup/details/serverGroupDetails.cf.controller.js
+++ b/app/scripts/modules/cloudfoundry/serverGroup/details/serverGroupDetails.cf.controller.js
@@ -55,6 +55,8 @@ module.exports = angular.module('spinnaker.serverGroup.details.cf.controller', [
           cancelLoader();
 
           var restangularlessDetails = details.plain();
+          // it's possible the summary was not found because the clusters are still loading
+          restangularlessDetails.account = serverGroup.accountId;
           angular.extend(restangularlessDetails, summary);
 
           $scope.serverGroup = restangularlessDetails;

--- a/app/scripts/modules/google/serverGroup/details/serverGroupDetails.gce.controller.js
+++ b/app/scripts/modules/google/serverGroup/details/serverGroupDetails.gce.controller.js
@@ -57,6 +57,8 @@ module.exports = angular.module('spinnaker.serverGroup.details.gce.controller', 
         cancelLoader();
 
         var restangularlessDetails = details.plain();
+        // it's possible the summary was not found because the clusters are still loading
+        restangularlessDetails.account = serverGroup.accountId;
         angular.extend(restangularlessDetails, summary);
 
         $scope.serverGroup = restangularlessDetails;

--- a/app/scripts/modules/titan/serverGroup/details/serverGroupDetails.titan.controller.js
+++ b/app/scripts/modules/titan/serverGroup/details/serverGroupDetails.titan.controller.js
@@ -42,6 +42,8 @@ module.exports = angular.module('spinnaker.serverGroup.details.titan.controller'
         cancelLoader();
 
         var restangularlessDetails = details.plain();
+        // it's possible the summary was not found because the clusters are still loading
+        restangularlessDetails.account = serverGroup.accountId;
         angular.extend(restangularlessDetails, summary);
 
         $scope.serverGroup = restangularlessDetails;


### PR DESCRIPTION
If a user follows a deep link to a server group, it's possible the details load before the server groups for the application, leaving the `account` field unpopulated on the server group object, which can cause problems in any modal actions because we've (possibly unwisely) chosen to expect the `account` field (which comes from the summary object found in either the application's `serverGroups` or `loadBalancers`) instead of the `credentials` field, which comes from the details endpoint.

There are three ways to fix this problem:
 1. Set the `account` field based on the URL path parameter (`accountId`)
 2. Do not try to retrieve the server group details until the application's server groups are loaded
 3. Change the `account` references to `credentials` everywhere

(1) is the easiest, which is why it's what I did here.
(2) would provide a better guarantee that all data would be available before anything is displayed, but it would also mean a potentially slower overall experience if it takes 10-15 seconds for the server groups to load (unfortunately, this is not unheard of)
(3) is a more pure solution, but I am nervous I'm going to miss a reference or two somewhere

I'm tempted to go with (3) but wanted to verify with @lwander that kubernetes server groups have a `credentials` field (I recall some changes earlier today suggesting maybe they do not).