### PR TITLE
fix cache clearing; trim recent items to fit in container

### DIFF
--- a/app/scripts/modules/core/cache/infrastructureCaches.js
+++ b/app/scripts/modules/core/cache/infrastructureCaches.js
@@ -13,9 +13,10 @@ module.exports = angular.module('spinnaker.core.cache.infrastructure', [
     var namespace = 'infrastructure';
 
     function clearCache(key) {
-      if (caches[key] && caches[key].removeAll) {
-        caches[key].onReset.forEach((method) => method() );
-        caches[key].removeAll();
+      let cache = caches[key];
+      if (cache && cache.removeAll) {
+        cache.keys().forEach((k) => cache.remove(k));
+        cache.onReset.forEach((method) => method() );
       }
     }
 

--- a/app/scripts/modules/core/cache/infrastructureCaches.spec.js
+++ b/app/scripts/modules/core/cache/infrastructureCaches.spec.js
@@ -25,8 +25,11 @@ describe('spinnaker.core.cache.infrastructure', function() {
   describe('cache initialization', function() {
 
     beforeEach(function() {
+      let keys = [];
       var cacheInstantiations = [];
       var removalCalls = [];
+      var removeCalls = [];
+      this.keys = keys;
 
       var cacheFactory = function(cacheId, config) {
         cacheInstantiations.push({cacheId: cacheId, config: config});
@@ -41,6 +44,12 @@ describe('spinnaker.core.cache.infrastructure', function() {
           removeAll: function() {
             removalCalls.push(cacheId);
           },
+          remove: function(key) {
+            removeCalls.push(key);
+          },
+          keys: function() {
+            return keys;
+          },
           destroy: angular.noop,
         };
       };
@@ -48,6 +57,7 @@ describe('spinnaker.core.cache.infrastructure', function() {
       this.cacheFactory = cacheFactory;
       this.cacheInstantiations = cacheInstantiations;
       this.removalCalls = removalCalls;
+      this.removeCalls = removeCalls;
 
     });
 
@@ -81,16 +91,19 @@ describe('spinnaker.core.cache.infrastructure', function() {
       expect(this.removalCalls).toEqual(['infrastructure:myCache']);
     });
 
-    it('should remove all keys when clearCache called', function() {
+    it('should remove each key when clearCache called', function() {
       infrastructureCaches.createCache('someBadCache', {
         cacheFactory: this.cacheFactory,
         version: 0,
         onReset: [],
       });
 
+      this.keys.push('a');
+      this.keys.push('b');
       var removalCallsAfterInitialization = this.removalCalls.length;
       infrastructureCaches.clearCache('someBadCache');
-      expect(this.removalCalls.length).toBe(removalCallsAfterInitialization + 1);
+      expect(this.removalCalls.length).toBe(removalCallsAfterInitialization);
+      expect(this.removeCalls).toEqual(['a', 'b']);
     });
 
   });

--- a/app/scripts/modules/core/history/recentHistory.service.js
+++ b/app/scripts/modules/core/history/recentHistory.service.js
@@ -8,7 +8,7 @@ module.exports = angular.module('spinnaker.core.history.service', [
   require('../utils/uuid.service.js'),
 ])
   .factory('recentHistoryService', function (_, deckCacheFactory, uuidService) {
-    const maxItems = 15;
+    const maxItems = 5;
 
     deckCacheFactory.createCache('history', 'user', {
       version: 3,

--- a/app/scripts/modules/core/history/recentHistory.service.spec.js
+++ b/app/scripts/modules/core/history/recentHistory.service.spec.js
@@ -51,7 +51,7 @@ describe('recent history service', function() {
       initializeCache(15);
       service.addItem('whatever', 'state', {id: 'new item'});
       let ids = service.getItems('whatever').map((item) => { return item.params.id; });
-      expect(ids).toEqual(['new item', 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]);
+      expect(ids).toEqual(['new item', 0, 1, 2, 3]);
     });
 
     it('removes previous entry and adds replacement if params match', () => {

--- a/app/scripts/modules/core/search/infrastructure/infrastructure.less
+++ b/app/scripts/modules/core/search/infrastructure/infrastructure.less
@@ -81,6 +81,7 @@
         width: calc(~"100% - 20px");
       }
       a {
+        line-height: 18px;
         padding-right: 0;
         background-color: @lightest_grey;
         &:hover, &:focus {

--- a/app/scripts/modules/core/search/infrastructure/project/infrastructureProject.directive.less
+++ b/app/scripts/modules/core/search/infrastructure/project/infrastructureProject.directive.less
@@ -22,7 +22,11 @@ infrastructure-project {
   background-color: #ffffff;
   margin-bottom: 15px;
   a {
-    color: @text-color
+    color: @text-color;
+    display: block;
+    &:active, &:hover {
+      font-weight: 600;
+    }
   }
 
   .project-summary {


### PR DESCRIPTION
Who would have guessed that mucking with the cache internals might cause problems?

As it turns out, the angular cache factory's `removeAll` method does not call `remove` against each key in the underlying cache. So the intermediate cache I put in ten days ago (which keeps a cache of local storage items in memory to avoid the disk read penalty) never actually gets cleared when the cache is supposed to get cleared - so the old item just gets put right back into the local storage cache.

Also cleaning up the recent items on the infrastructure page to only show the most recent five items. Anything more involves scrolling, which is probably a non-starter for most users. We don't actually have metrics around this right now, so it's based on a guess and not actual data.