### PR TITLE
add ready() method to application and sections

### DIFF
--- a/app/scripts/modules/core/delivery/executions/executions.controller.js
+++ b/app/scripts/modules/core/delivery/executions/executions.controller.js
@@ -60,21 +60,7 @@ module.exports = angular.module('spinnaker.core.delivery.executions.controller',
       triggeringExecution: false,
     };
 
-    let executionLoader = $q.defer();
-    if (application.executions.loaded) {
-      executionLoader.resolve();
-    } else {
-      application.executions.onNextRefresh($scope, executionLoader.resolve);
-    }
-
-    let configLoader = $q.defer();
-    if (application.pipelineConfigs.loaded) {
-      configLoader.resolve();
-    } else {
-      application.pipelineConfigs.onNextRefresh($scope, configLoader.resolve);
-    }
-
-    $q.all([executionLoader.promise, configLoader.promise]).then(() => {
+    $q.all([application.executions.ready(), application.pipelineConfigs.ready()]).then(() => {
       this.updateExecutionGroups();
       if ($stateParams.executionId) {
         scrollIntoView();

--- a/app/scripts/modules/core/delivery/executions/executions.controller.spec.js
+++ b/app/scripts/modules/core/delivery/executions/executions.controller.spec.js
@@ -9,33 +9,35 @@ describe('Controller: pipelineExecutions', function () {
   var $state;
   var $stateParams;
   var $timeout;
-  var rx;
   var scrollToService;
 
   beforeEach(
     window.module(
       require('./executions.controller'),
-      require('../../utils/rx')
+      require('../../application/service/applications.read.service.js')
     )
   );
 
   beforeEach(
-    window.inject(function ($rootScope, $controller, _$timeout_, _rx_, _scrollToService_) {
+    window.inject(function ($rootScope, $controller, _$timeout_, _scrollToService_, applicationReader) {
       scope = $rootScope.$new();
-      $state = { go: angular.noop };
+      $state = {go: angular.noop};
       $stateParams = {};
       $timeout = _$timeout_;
-      rx = _rx_;
       scrollToService = _scrollToService_;
 
-      this.initializeController = function (application) {
+      this.initializeController = function (application, data) {
         scope.application = application;
-        application.executions.refreshStream = new rx.Subject();
-        application.executions.onRefresh = function($scope, method) { return application.executions.refreshStream.subscribe(method); };
-        application.executions.onNextRefresh = function($scope, method) { return application.executions.refreshStream.take(1).subscribe(method); };
-        application.pipelineConfigs.refreshStream = new rx.Subject();
-        application.pipelineConfigs.onRefresh = function($scope, method) { return application.pipelineConfigs.refreshStream.subscribe(method); };
-        application.pipelineConfigs.onNextRefresh = function($scope, method) { return application.pipelineConfigs.refreshStream.take(1).subscribe(method); };
+        applicationReader.addSectionToApplication({key: 'executions', lazy: true}, application);
+        applicationReader.addSectionToApplication({key: 'pipelineConfigs', lazy: true}, application);
+        if (data && data.executions) {
+          application.executions.data = data.executions;
+          application.executions.loaded = true;
+        }
+        if (data && data.pipelineConfigs) {
+          application.pipelineConfigs.data = data.pipelineConfigs;
+          application.pipelineConfigs.loaded = true;
+        }
 
         controller = $controller('ExecutionsCtrl', {
           $scope: scope,
@@ -50,11 +52,8 @@ describe('Controller: pipelineExecutions', function () {
   it('should not set loading flag to false until executions and pipeline configs have been loaded', function () {
     var application = {
       name: 'foo',
-      executions: { refresh: angular.noop, },
-      pipelineConfigs: { refresh: angular.noop, },
     };
     this.initializeController(application);
-    scope.$digest();
 
     expect(controller.viewState.loading).toBe(true);
 
@@ -62,42 +61,43 @@ describe('Controller: pipelineExecutions', function () {
     application.pipelineConfigs.refreshStream.onNext();
     scope.$digest();
     $timeout.flush();
-
     expect(controller.viewState.loading).toBe(false);
   });
 
   it('should update execution name when pipelineConfigId is present and name differs in config', function () {
     var application = {
-      name: 'foo',
-      pipelineConfigs: { data: [
-        {
-          id: 'a1',
-          name: 'updated name',
-        },
-        {
-          id: 'a2',
-          name: 'unchanged',
-        },
-      ], loaded: true},
-      executions: { data: [
-        {
-          pipelineConfigId: 'a1',
-          name: 'oldName',
-          stageSummaries: [],
-        },
-        {
-          pipelineConfigId: 'a2',
-          name: 'unchanged',
-          stageSummaries: [],
-        },
-        {
-          pipelineConfigId: 'a3',
-          name: 'no longer configured',
-          stageSummaries: [],
-        }
-      ], loaded: true},
+      name: 'foo'
     };
-    this.initializeController(application);
+    var pipelineConfigs = [
+      {
+        id: 'a1',
+        name: 'updated name',
+      },
+      {
+        id: 'a2',
+        name: 'unchanged',
+      },
+    ];
+    var executions = [
+      {
+        pipelineConfigId: 'a1',
+        name: 'oldName',
+        stageSummaries: [],
+      },
+      {
+        pipelineConfigId: 'a2',
+        name: 'unchanged',
+        stageSummaries: [],
+      },
+      {
+        pipelineConfigId: 'a3',
+        name: 'no longer configured',
+        stageSummaries: [],
+      }
+    ];
+
+    this.initializeController(application, {pipelineConfigs: pipelineConfigs, executions: executions});
+    scope.$digest();
     $timeout.flush();
 
     expect(application.executions.data[0].name).toBe('updated name');
@@ -113,15 +113,13 @@ describe('Controller: pipelineExecutions', function () {
       spyOn(scrollToService, 'scrollTo');
       application = {
         name: 'foo',
-        executions: { data: [], loaded: true },
-        pipelineConfigs: { data: [], loaded: true },
       };
     });
 
     it('should scroll execution into view on initialization if an execution is present in state params', function () {
       $stateParams.executionId = 'a';
 
-      this.initializeController(application);
+      this.initializeController(application, { pipelineConfigs: [], executions: []});
       scope.$digest();
 
       expect(scrollToService.scrollTo.calls.count()).toBe(1);
@@ -140,7 +138,7 @@ describe('Controller: pipelineExecutions', function () {
 
       expect(scrollToService.scrollTo.calls.count()).toBe(0);
 
-      scope.$broadcast('$stateChangeSuccess', { name: 'executions.execution' }, { executionId: 'a' }, { name: 'executions' }, {});
+      scope.$broadcast('$stateChangeSuccess', {name: 'executions.execution'}, {executionId: 'a'}, {name: 'executions'}, {});
       expect(scrollToService.scrollTo.calls.count()).toBe(1);
     });
 
@@ -150,49 +148,49 @@ describe('Controller: pipelineExecutions', function () {
 
       expect(scrollToService.scrollTo.calls.count()).toBe(0);
 
-      scope.$broadcast('$stateChangeSuccess', { name: 'executions.execution' }, { executionId: 'a' }, { name: 'executions.execution' }, { executionId: 'b' });
+      scope.$broadcast('$stateChangeSuccess', {name: 'executions.execution'}, {executionId: 'a'}, {name: 'executions.execution'}, {executionId: 'b'});
       expect(scrollToService.scrollTo.calls.count()).toBe(1);
     });
 
     it('should scroll into view if no params change, because the user clicked on a link somewhere else in the page', function () {
-      let params = { executionId: 'a', step: 'b', stage: 'c', details: 'd' };
+      let params = {executionId: 'a', step: 'b', stage: 'c', details: 'd'};
 
       this.initializeController(application);
       scope.$digest();
 
       expect(scrollToService.scrollTo.calls.count()).toBe(0);
 
-      scope.$broadcast('$stateChangeSuccess', { name: 'executions.execution' }, params, { name: 'executions.execution' }, params);
+      scope.$broadcast('$stateChangeSuccess', {name: 'executions.execution'}, params, {name: 'executions.execution'}, params);
       expect(scrollToService.scrollTo.calls.count()).toBe(1);
     });
 
     it('should NOT scroll into view if step changes', function () {
-      let toParams = { executionId: 'a', step: 'b', stage: 'c', details: 'd' },
-          fromParams = { executionId: 'a', step: 'c', stage: 'c', details: 'd' };
+      let toParams = {executionId: 'a', step: 'b', stage: 'c', details: 'd'},
+          fromParams = {executionId: 'a', step: 'c', stage: 'c', details: 'd'};
 
       this.initializeController(application);
       scope.$digest();
-      scope.$broadcast('$stateChangeSuccess', { name: 'executions' }, toParams, { name: 'executions' }, fromParams);
+      scope.$broadcast('$stateChangeSuccess', {name: 'executions'}, toParams, {name: 'executions'}, fromParams);
       expect(scrollToService.scrollTo.calls.count()).toBe(0);
     });
 
     it('should NOT scroll into view if stage changes', function () {
-      let toParams = { executionId: 'a', step: 'b', stage: 'c', details: 'd' },
-          fromParams = { executionId: 'a', step: 'b', stage: 'e', details: 'd' };
+      let toParams = {executionId: 'a', step: 'b', stage: 'c', details: 'd'},
+          fromParams = {executionId: 'a', step: 'b', stage: 'e', details: 'd'};
 
       this.initializeController(application);
       scope.$digest();
-      scope.$broadcast('$stateChangeSuccess', { name: 'executions' }, toParams, { name: 'executions' }, fromParams);
+      scope.$broadcast('$stateChangeSuccess', {name: 'executions'}, toParams, {name: 'executions'}, fromParams);
       expect(scrollToService.scrollTo.calls.count()).toBe(0);
     });
 
     it('should NOT scroll into view if detail changes', function () {
-      let toParams = { executionId: 'a', step: 'b', stage: 'c', details: 'd' },
-          fromParams = { executionId: 'a', step: 'b', stage: 'c', details: 'e' };
+      let toParams = {executionId: 'a', step: 'b', stage: 'c', details: 'd'},
+          fromParams = {executionId: 'a', step: 'b', stage: 'c', details: 'e'};
 
       this.initializeController(application);
       scope.$digest();
-      scope.$broadcast('$stateChangeSuccess', { name: 'executions' }, toParams, { name: 'executions' }, fromParams);
+      scope.$broadcast('$stateChangeSuccess', {name: 'executions'}, toParams, {name: 'executions'}, fromParams);
       expect(scrollToService.scrollTo.calls.count()).toBe(0);
     });
 

--- a/app/scripts/modules/core/pipeline/config/pipelineConfig.controller.js
+++ b/app/scripts/modules/core/pipeline/config/pipelineConfig.controller.js
@@ -30,11 +30,7 @@ module.exports = angular.module('spinnaker.core.pipeline.config.controller', [
     };
 
     if (!application.notFound) {
-      if (!application.pipelineConfigs.loaded) {
-        application.pipelineConfigs.onNextRefresh($scope, this.initialize);
-      } else {
-        this.initialize();
-      }
+      application.pipelineConfigs.ready().then(this.initialize);
     }
 
     function getWarningMessage() {

--- a/app/scripts/modules/core/pipeline/config/pipelineConfig.controller.spec.js
+++ b/app/scripts/modules/core/pipeline/config/pipelineConfig.controller.spec.js
@@ -4,41 +4,36 @@ describe('Controller: PipelineConfigCtrl', function () {
 
   var controller;
   var scope;
-  var rx;
   var applicationReader;
 
   beforeEach(
     window.module(
       require('./pipelineConfig.controller.js'),
-      require('../../utils/rx.js'),
       require('../../application/service/applications.read.service.js')
     )
   );
 
   beforeEach(
-    window.inject(function ($rootScope, $controller, _rx_, _applicationReader_) {
+    window.inject(function ($rootScope, $controller, _applicationReader_) {
       scope = $rootScope.$new();
       controller = $controller;
-      rx = _rx_;
       applicationReader = _applicationReader_;
     })
   );
 
   it('should initialize immediately if pipeline configs are already present', function () {
-    scope.application = {
-      pipelineConfigs: {
-        loaded: true,
-        data: [
-          { id: 'a'}
-        ]
-      }
-    };
+    scope.application = {};
+    applicationReader.addSectionToApplication({key: 'pipelineConfigs', lazy: true}, scope.application);
+    scope.application.pipelineConfigs.data = [ { id: 'a' } ];
+    scope.application.pipelineConfigs.loaded = true;
+
     let vm = controller('PipelineConfigCtrl', {
       $scope: scope,
       $stateParams: {
         pipelineId: 'a'
       }
     });
+    scope.$digest();
     expect(vm.state.pipelinesLoaded).toBe(true);
   });
 
@@ -54,6 +49,7 @@ describe('Controller: PipelineConfigCtrl', function () {
 
     scope.application.pipelineConfigs.data.push({id: 'a'});
     scope.application.pipelineConfigs.refreshStream.onNext();
+    scope.$digest();
 
     expect(vm.state.pipelinesLoaded).toBe(true);
   });

--- a/app/scripts/modules/core/task/tasks.controller.js
+++ b/app/scripts/modules/core/task/tasks.controller.js
@@ -252,14 +252,7 @@ module.exports = angular.module('spinnaker.core.task.controller', [
 
     initializeViewState();
 
-    let taskLoader = $q.defer();
-    if (application.tasks.loading) {
-      application.tasks.onNextRefresh($scope, taskLoader.resolve);
-    } else {
-      taskLoader.resolve();
-    }
-
-    taskLoader.promise.then(() => {
+    application.tasks.ready().then(() => {
       $scope.viewState.loading = false;
       $scope.viewState.loadError = app.tasks.loadFailure;
       if (!app.tasks.loadFailure) {

--- a/app/scripts/modules/core/task/tasks.controller.spec.js
+++ b/app/scripts/modules/core/task/tasks.controller.spec.js
@@ -25,6 +25,8 @@ describe('Controller: tasks', function () {
         let application = {};
         applicationReader.addSectionToApplication({key: 'tasks', lazy: true}, application);
         application.tasks.data = tasks || [];
+        application.tasks.loaded = true;
+        application.tasks.refreshStream.onNext();
 
         let confirmationModalService = {
           confirm: function(params) {
@@ -52,7 +54,6 @@ describe('Controller: tasks', function () {
     });
 
     it('loading flag should be false when tasks reloaded', function() {
-      this.initializeController();
       scope.$digest();
       expect(scope.viewState.loading).toBe(false);
     });

--- a/app/scripts/modules/netflix/fastProperties/modal/fastPropertyScopeBuilder.service.js
+++ b/app/scripts/modules/netflix/fastProperties/modal/fastPropertyScopeBuilder.service.js
@@ -76,8 +76,8 @@ module.exports = angular
         applicationReader
           .getApplication(appName)
           .then( (application) => {
-            return application.refresh(true)  // This is a hack. Due to a race condition in the applicationReader. The clusters don't get bound to the application before tha app returns from the function. TODO: Revisit applicationReader design.
-              .then((application) => {
+            return application.ready()
+              .then(() => {
                 ctrl.chosenApps[appName] = application;
                 return ctrl.chosenApps;
               });


### PR DESCRIPTION
Removes some boilerplate and provides a simple promise that resolves when a section's content is loaded, or resolves immediately if it's already loaded. At the application level, it will resolve when all content is loaded.

@zanthrash this might be cleaner for the fast property scope builder - can you give it a shot?