### PR TITLE
provider/kubernetes: Find image stage

### DIFF
--- a/app/scripts/modules/amazon/serverGroup/configure/serverGroupCommandBuilder.aws.service.spec.js
+++ b/app/scripts/modules/amazon/serverGroup/configure/serverGroupCommandBuilder.aws.service.spec.js
@@ -77,7 +77,7 @@ describe('Service: awsServerGroup', function () {
         this.$q.when(['d', 'g'])
       );
 
-      spyOn(this.accountService, 'getRegionsKeyedByAccount').and.returnValue(
+      spyOn(this.accountService, 'getCredentialsKeyedByAccount').and.returnValue(
         this.$q.when({
           test: ['us-east-1', 'us-west-1'],
           prod: ['us-west-1', 'eu-west-1']

--- a/app/scripts/modules/amazon/serverGroup/configure/serverGroupCommandBuilder.service.js
+++ b/app/scripts/modules/amazon/serverGroup/configure/serverGroupCommandBuilder.service.js
@@ -17,7 +17,7 @@ module.exports = angular.module('spinnaker.aws.serverGroupCommandBuilder.service
 
     function buildNewServerGroupCommand (application, defaults) {
       defaults = defaults || {};
-      var regionsKeyedByAccountLoader = accountService.getRegionsKeyedByAccount('aws');
+      var credentialsLoader = accountService.getCredentialsKeyedByAccount('aws');
 
       var defaultCredentials = defaults.account || application.defaultCredentials.aws || settings.providers.aws.defaults.account;
       var defaultRegion = defaults.region || application.defaultRegions.aws || settings.providers.aws.defaults.region;
@@ -26,13 +26,13 @@ module.exports = angular.module('spinnaker.aws.serverGroupCommandBuilder.service
 
       return $q.all({
         preferredZones: preferredZonesLoader,
-        regionsKeyedByAccount: regionsKeyedByAccountLoader,
+        credentialsKeyedByAccount: credentialsLoader,
       })
         .then(function (asyncData) {
           var availabilityZones = asyncData.preferredZones;
 
-          var regions = asyncData.regionsKeyedByAccount[defaultCredentials];
-          var keyPair = regions ? regions.defaultKeyPair : null;
+          var credentials = asyncData.credentialsKeyedByAccount[defaultCredentials];
+          var keyPair = credentials ? credentials.defaultKeyPair : null;
 
           var command = {
             application: application.name,

--- a/app/scripts/modules/amazon/serverGroup/configure/serverGroupCommandBuilder.spec.js
+++ b/app/scripts/modules/amazon/serverGroup/configure/serverGroupCommandBuilder.spec.js
@@ -15,7 +15,7 @@ describe('awsServerGroupCommandBuilder', function() {
     this.instanceTypeService = instanceTypeService;
     this.$q = $q;
     spyOn(accountService, 'getPreferredZonesByAccount').and.returnValue($q.when(AccountServiceFixture.preferredZonesByAccount));
-    spyOn(accountService, 'getRegionsKeyedByAccount').and.returnValue($q.when(AccountServiceFixture.regionsKeyedByAccount));
+    spyOn(accountService, 'getCredentialsKeyedByAccount').and.returnValue($q.when(AccountServiceFixture.credentialsKeyedByAccount));
     spyOn(subnetReader, 'listSubnets').and.returnValue($q.when([]));
     spyOn(accountService, 'getAvailabilityZonesForAccountAndRegion').and.returnValue(
       this.$q.when(['a', 'b', 'c'])

--- a/app/scripts/modules/amazon/serverGroup/configure/serverGroupConfiguration.service.js
+++ b/app/scripts/modules/amazon/serverGroup/configure/serverGroupConfiguration.service.js
@@ -60,7 +60,7 @@ module.exports = angular.module('spinnaker.aws.serverGroup.configure.service', [
       };
 
       return $q.all({
-        regionsKeyedByAccount: accountService.getRegionsKeyedByAccount('aws'),
+        credentialsKeyedByAccount: accountService.getCredentialsKeyedByAccount('aws'),
         securityGroups: securityGroupReader.getAllSecurityGroups(),
         loadBalancers: loadBalancerReader.listLoadBalancers('aws'),
         subnets: subnetReader.listSubnets(),
@@ -74,7 +74,7 @@ module.exports = angular.module('spinnaker.aws.serverGroup.configure.service', [
         var loadBalancerReloader = $q.when(null);
         var securityGroupReloader = $q.when(null);
         var instanceTypeReloader = $q.when(null);
-        backingData.accounts = _.keys(backingData.regionsKeyedByAccount);
+        backingData.accounts = _.keys(backingData.credentialsKeyedByAccount);
         backingData.filtered = {};
         backingData.scalingProcesses = autoScalingProcessService.listProcesses();
         command.backingData = backingData;
@@ -149,7 +149,7 @@ module.exports = angular.module('spinnaker.aws.serverGroup.configure.service', [
           .pluck('keyName')
           .valueOf();
         if (command.keyPair && filtered.indexOf(command.keyPair) === -1) {
-          var acct = command.backingData.regionsKeyedByAccount[command.credentials] || {regions: [], defaultKeyPair: null};
+          var acct = command.backingData.credentialsKeyedByAccount[command.credentials] || {regions: [], defaultKeyPair: null};
           command.keyPair = acct.defaultKeyPair;
           // Note: this will generally be ignored, so we probably won't flag it in the UI
           result.dirty.keyPair = true;
@@ -220,7 +220,7 @@ module.exports = angular.module('spinnaker.aws.serverGroup.configure.service', [
 
     function configureAvailabilityZones(command) {
       command.backingData.filtered.availabilityZones =
-        _.find(command.backingData.regionsKeyedByAccount[command.credentials].regions, {name: command.region}).availabilityZones;
+        _.find(command.backingData.credentialsKeyedByAccount[command.credentials].regions, {name: command.region}).availabilityZones;
     }
 
     function configureSubnetPurposes(command) {
@@ -414,7 +414,7 @@ module.exports = angular.module('spinnaker.aws.serverGroup.configure.service', [
         var result = { dirty: {} };
         var backingData = command.backingData;
         if (command.credentials) {
-          var regionsForAccount = backingData.regionsKeyedByAccount[command.credentials] || {regions: [], defaultKeyPair: null};
+          var regionsForAccount = backingData.credentialsKeyedByAccount[command.credentials] || {regions: [], defaultKeyPair: null};
           backingData.filtered.regions = regionsForAccount.regions;
           if (!_(backingData.filtered.regions).some({name: command.region})) {
             command.region = null;

--- a/app/scripts/modules/amazon/serverGroup/configure/serverGroupConfiguration.service.spec.js
+++ b/app/scripts/modules/amazon/serverGroup/configure/serverGroupConfiguration.service.spec.js
@@ -73,7 +73,7 @@ describe('Service: awsServerGroupConfiguration', function () {
 
   describe('configureCommand', function () {
     it ('attempts to reload load balancers if some are not found on initialization, but does not set dirty flag', function () {
-      spyOn(accountService, 'getRegionsKeyedByAccount').and.returnValue($q.when([]));
+      spyOn(accountService, 'getCredentialsKeyedByAccount').and.returnValue($q.when([]));
       spyOn(securityGroupReader, 'getAllSecurityGroups').and.returnValue($q.when([]));
       spyOn(loadBalancerReader, 'listLoadBalancers').and.returnValue($q.when(this.allLoadBalancers));
       spyOn(subnetReader, 'listSubnets').and.returnValue($q.when([]));
@@ -104,7 +104,7 @@ describe('Service: awsServerGroupConfiguration', function () {
     });
 
     it ('attempts to reload security groups if some are not found on initialization, but does not set dirty flag', function () {
-      spyOn(accountService, 'getRegionsKeyedByAccount').and.returnValue($q.when([]));
+      spyOn(accountService, 'getCredentialsKeyedByAccount').and.returnValue($q.when([]));
       spyOn(securityGroupReader, 'getAllSecurityGroups').and.returnValue($q.when([]));
       spyOn(loadBalancerReader, 'listLoadBalancers').and.returnValue($q.when(this.allLoadBalancers));
       spyOn(subnetReader, 'listSubnets').and.returnValue($q.when([]));
@@ -136,7 +136,7 @@ describe('Service: awsServerGroupConfiguration', function () {
     });
 
     it ('attempts to reload instance types if already selected on initialization, but does not set dirty flag', function () {
-      spyOn(accountService, 'getRegionsKeyedByAccount').and.returnValue($q.when([]));
+      spyOn(accountService, 'getCredentialsKeyedByAccount').and.returnValue($q.when([]));
       spyOn(securityGroupReader, 'getAllSecurityGroups').and.returnValue($q.when([]));
       spyOn(loadBalancerReader, 'listLoadBalancers').and.returnValue($q.when([]));
       spyOn(subnetReader, 'listSubnets').and.returnValue($q.when([]));
@@ -348,7 +348,7 @@ describe('Service: awsServerGroupConfiguration', function () {
       this.command = {
         backingData: {
           filtered: {},
-          regionsKeyedByAccount: {
+          credentialsKeyedByAccount: {
             test: {
               defaultKeyPair: 'test-pair'
             },
@@ -407,7 +407,7 @@ describe('Service: awsServerGroupConfiguration', function () {
         viewState: {},
         backingData: {
           filtered: {},
-          regionsKeyedByAccount: {
+          credentialsKeyedByAccount: {
             test: {
               defaultKeyPair: 'test-pair'
             },

--- a/app/scripts/modules/amazon/serverGroup/configure/wizard/CloneServerGroup.aws.controller.spec.js
+++ b/app/scripts/modules/amazon/serverGroup/configure/wizard/CloneServerGroup.aws.controller.spec.js
@@ -75,7 +75,7 @@ describe('Controller: awsCloneServerGroup', function () {
       return {
         credentials: 'test',
         region: 'us-east-1',
-        availabilityZones: AccountServiceFixture.regionsKeyedByAccount.test.regions[0].availabilityZones,
+        availabilityZones: AccountServiceFixture.credentialsKeyedByAccount.test.regions[0].availabilityZones,
         securityGroups: [],
         selectedProvider: 'aws',
         instanceMonitoring: true,
@@ -114,7 +114,7 @@ describe('Controller: awsCloneServerGroup', function () {
       var resolve = this.resolve;
 
       spyOn(this.accountService, 'getPreferredZonesByAccount').and.callFake(resolve(AccountServiceFixture.preferredZonesByAccount));
-      spyOn(this.accountService, 'getRegionsKeyedByAccount').and.callFake(resolve(AccountServiceFixture.regionsKeyedByAccount));
+      spyOn(this.accountService, 'getCredentialsKeyedByAccount').and.callFake(resolve(AccountServiceFixture.credentialsKeyedByAccount));
       spyOn(this.subnetReader, 'listSubnets').and.callFake(resolve([]));
       spyOn(this.keyPairsReader, 'listKeyPairs').and.callFake(resolve([]));
       spyOn(this.securityGroupReader, 'getAllSecurityGroups').and.callFake(resolve(securityGroupReaderFixture.allSecurityGroups));
@@ -229,7 +229,7 @@ describe('Controller: awsCloneServerGroup', function () {
 
       this.wizard = jasmine.createSpyObj('wizard', ['markDirty', 'markComplete', 'includePage']);
       spyOn(this.accountService, 'getPreferredZonesByAccount').and.callFake(resolve(AccountServiceFixture.preferredZonesByAccount));
-      spyOn(this.accountService, 'getRegionsKeyedByAccount').and.callFake(resolve(AccountServiceFixture.regionsKeyedByAccount));
+      spyOn(this.accountService, 'getCredentialsKeyedByAccount').and.callFake(resolve(AccountServiceFixture.credentialsKeyedByAccount));
       spyOn(this.subnetReader, 'listSubnets').and.callFake(resolve([]));
       spyOn(this.keyPairsReader, 'listKeyPairs').and.callFake(resolve([]));
       spyOn(this.securityGroupReader, 'getAllSecurityGroups').and.callFake(resolve(securityGroupReaderFixture.allSecurityGroups));
@@ -384,7 +384,7 @@ describe('Controller: awsCloneServerGroup', function () {
           spec = this;
 
       spyOn(this.accountService, 'getPreferredZonesByAccount').and.callFake(resolve(AccountServiceFixture.preferredZonesByAccount));
-      spyOn(this.accountService, 'getRegionsKeyedByAccount').and.callFake(resolve(AccountServiceFixture.regionsKeyedByAccount));
+      spyOn(this.accountService, 'getCredentialsKeyedByAccount').and.callFake(resolve(AccountServiceFixture.credentialsKeyedByAccount));
       spyOn(this.subnetReader, 'listSubnets').and.callFake(resolve([]));
       spyOn(this.keyPairsReader, 'listKeyPairs').and.callFake(resolve([]));
       spyOn(this.securityGroupReader, 'getAllSecurityGroups').and.callFake(resolve(securityGroupReaderFixture.allSecurityGroups));

--- a/app/scripts/modules/azure/cache/cacheConfigurer.service.js
+++ b/app/scripts/modules/azure/cache/cacheConfigurer.service.js
@@ -17,7 +17,7 @@ module.exports = angular.module('spinnaker.azure.cache.initializer', [
     let config = Object.create(null);
 
     config.credentials = {
-      initializers: [ () => accountService.getRegionsKeyedByAccount('azure') ],
+      initializers: [ () => accountService.getCredentialsKeyedByAccount('azure') ],
     };
 
     config.instanceTypes = {

--- a/app/scripts/modules/azure/serverGroup/configure/serverGroupCommandBuilder.azure.service.spec.js
+++ b/app/scripts/modules/azure/serverGroup/configure/serverGroupCommandBuilder.azure.service.spec.js
@@ -75,7 +75,7 @@
          this.$q.when(['d', 'g'])
        );
 
-       spyOn(this.accountService, 'getRegionsKeyedByAccount').and.returnValue(
+       spyOn(this.accountService, 'getCredentialsKeyedByAccount').and.returnValue(
          this.$q.when({
            test: ['us-east-1', 'us-west-1'],
            prod: ['us-west-1', 'eu-west-1']

--- a/app/scripts/modules/azure/serverGroup/configure/serverGroupCommandBuilder.spec.js
+++ b/app/scripts/modules/azure/serverGroup/configure/serverGroupCommandBuilder.spec.js
@@ -15,7 +15,7 @@
      this.instanceTypeService = instanceTypeService;
      this.$q = $q;
      spyOn(accountService, 'getPreferredZonesByAccount').and.returnValue($q.when(AccountServiceFixture.preferredZonesByAccount));
-     spyOn(accountService, 'getRegionsKeyedByAccount').and.returnValue($q.when(AccountServiceFixture.regionsKeyedByAccount));
+     spyOn(accountService, 'getCredentialsKeyedByAccount').and.returnValue($q.when(AccountServiceFixture.credentialsKeyedByAccount));
      spyOn(subnetReader, 'listSubnets').and.returnValue($q.when([]));
      spyOn(accountService, 'getAvailabilityZonesForAccountAndRegion').and.returnValue(
        this.$q.when(['a', 'b', 'c'])

--- a/app/scripts/modules/azure/serverGroup/configure/serverGroupConfiguration.service.js
+++ b/app/scripts/modules/azure/serverGroup/configure/serverGroupConfiguration.service.js
@@ -40,7 +40,7 @@ module.exports = angular.module('spinnaker.azure.serverGroup.configure.service',
       }
 
       return $q.all({
-        regionsKeyedByAccount: accountService.getRegionsKeyedByAccount('azure'),
+        credentialsKeyedByAccount: accountService.getCredentialsKeyedByAccount('azure'),
         securityGroups: securityGroupReader.getAllSecurityGroups(),
         loadBalancers: loadBalancerReader.loadLoadBalancers(application.name),
         subnets: subnetReader.listSubnets(),
@@ -54,7 +54,7 @@ module.exports = angular.module('spinnaker.azure.serverGroup.configure.service',
         var loadBalancerReloader = $q.when(null);
         var securityGroupReloader = $q.when(null);
         var instanceTypeReloader = $q.when(null);
-        backingData.accounts = _.keys(backingData.regionsKeyedByAccount);
+        backingData.accounts = _.keys(backingData.credentialsKeyedByAccount);
         backingData.filtered = {};
         command.backingData = backingData;
         configureVpcId(command);
@@ -125,7 +125,7 @@ module.exports = angular.module('spinnaker.azure.serverGroup.configure.service',
           .pluck('keyName')
           .valueOf();
         if (command.keyPair && filtered.indexOf(command.keyPair) === -1) {
-          var acct = command.backingData.regionsKeyedByAccount[command.credentials] || {regions: [], defaultKeyPair: null};
+          var acct = command.backingData.credentialsKeyedByAccount[command.credentials] || {regions: [], defaultKeyPair: null};
           command.keyPair = acct.defaultKeyPair;
           // Note: this will generally be ignored, so we probably won't flag it in the UI
           result.dirty.keyPair = true;
@@ -181,7 +181,7 @@ module.exports = angular.module('spinnaker.azure.serverGroup.configure.service',
 
     function configureAvailabilityZones(command) {
       command.backingData.filtered.availabilityZones =
-        _.find(command.backingData.regionsKeyedByAccount[command.credentials].regions, {name: command.region}).availabilityZones;
+        _.find(command.backingData.credentialsKeyedByAccount[command.credentials].regions, {name: command.region}).availabilityZones;
     }
 
     function configureSubnetPurposes(command) {
@@ -389,7 +389,7 @@ module.exports = angular.module('spinnaker.azure.serverGroup.configure.service',
         var result = { dirty: {} };
         var backingData = command.backingData;
         if (command.credentials) {
-          var regionsForAccount = backingData.regionsKeyedByAccount[command.credentials] || {regions: [], defaultKeyPair: null};
+          var regionsForAccount = backingData.credentialsKeyedByAccount[command.credentials] || {regions: [], defaultKeyPair: null};
           backingData.filtered.regions = regionsForAccount.regions;
           if (!_(backingData.filtered.regions).some({name: command.region})) {
             command.region = null;

--- a/app/scripts/modules/azure/serverGroup/configure/serverGroupConfiguration.service.spec.js
+++ b/app/scripts/modules/azure/serverGroup/configure/serverGroupConfiguration.service.spec.js
@@ -89,7 +89,7 @@
 
    describe('configureCommand', function () {
      it ('attempts to reload load balancers if some are not found on initialization, but does not set dirty flag', function () {
-       spyOn(accountService, 'getRegionsKeyedByAccount').and.returnValue($q.when([]));
+       spyOn(accountService, 'getCredentialsKeyedByAccount').and.returnValue($q.when([]));
        spyOn(securityGroupReader, 'getAllSecurityGroups').and.returnValue($q.when([]));
        spyOn(loadBalancerReader, 'listLoadBalancers').and.returnValue($q.when(this.allLoadBalancers));
        spyOn(subnetReader, 'listSubnets').and.returnValue($q.when([]));
@@ -120,7 +120,7 @@
      });
 
      it ('attempts to reload security groups if some are not found on initialization, but does not set dirty flag', function () {
-       spyOn(accountService, 'getRegionsKeyedByAccount').and.returnValue($q.when([]));
+       spyOn(accountService, 'getCredentialsKeyedByAccount').and.returnValue($q.when([]));
        spyOn(securityGroupReader, 'getAllSecurityGroups').and.returnValue($q.when([]));
        spyOn(loadBalancerReader, 'listLoadBalancers').and.returnValue($q.when(this.allLoadBalancers));
        spyOn(subnetReader, 'listSubnets').and.returnValue($q.when([]));
@@ -151,7 +151,7 @@
      });
 
      it ('attempts to reload instance types if previous selection is not found on initialization, but does not set dirty flag', function () {
-       spyOn(accountService, 'getRegionsKeyedByAccount').and.returnValue($q.when([]));
+       spyOn(accountService, 'getCredentialsKeyedByAccount').and.returnValue($q.when([]));
        spyOn(securityGroupReader, 'getAllSecurityGroups').and.returnValue($q.when([]));
        spyOn(loadBalancerReader, 'listLoadBalancers').and.returnValue($q.when([]));
        spyOn(subnetReader, 'listSubnets').and.returnValue($q.when([]));
@@ -359,7 +359,7 @@
        this.command = {
          backingData: {
            filtered: {},
-           regionsKeyedByAccount: {
+           credentialsKeyedByAccount: {
              test: {
                defaultKeyPair: 'test-pair'
              },

--- a/app/scripts/modules/azure/serverGroup/configure/wizard/CloneServerGroup.azure.controller.spec.js
+++ b/app/scripts/modules/azure/serverGroup/configure/wizard/CloneServerGroup.azure.controller.spec.js
@@ -75,7 +75,7 @@
        return {
          credentials: 'test',
          region: 'us-east-1',
-         availabilityZones: AccountServiceFixture.regionsKeyedByAccount.test.regions[0].availabilityZones,
+         availabilityZones: AccountServiceFixture.credentialsKeyedByAccount.test.regions[0].availabilityZones,
          securityGroups: [],
          selectedProvider: 'azure',
          instanceMonitoring: true,
@@ -115,7 +115,7 @@
 
        this.wizard = jasmine.createSpyObj('wizard', ['markDirty', 'markComplete', 'includePage']);
        spyOn(this.accountService, 'getPreferredZonesByAccount').and.callFake(resolve(AccountServiceFixture.preferredZonesByAccount));
-       spyOn(this.accountService, 'getRegionsKeyedByAccount').and.callFake(resolve(AccountServiceFixture.regionsKeyedByAccount));
+       spyOn(this.accountService, 'getCredentialsKeyedByAccount').and.callFake(resolve(AccountServiceFixture.credentialsKeyedByAccount));
        spyOn(this.subnetReader, 'listSubnets').and.callFake(resolve([]));
        spyOn(this.keyPairsReader, 'listKeyPairs').and.callFake(resolve([]));
        spyOn(this.securityGroupReader, 'getAllSecurityGroups').and.callFake(resolve(securityGroupReaderFixture.allSecurityGroups));
@@ -229,7 +229,7 @@
 
        this.wizard = jasmine.createSpyObj('wizard', ['markDirty', 'markComplete', 'includePage']);
        spyOn(this.accountService, 'getPreferredZonesByAccount').and.callFake(resolve(AccountServiceFixture.preferredZonesByAccount));
-       spyOn(this.accountService, 'getRegionsKeyedByAccount').and.callFake(resolve(AccountServiceFixture.regionsKeyedByAccount));
+       spyOn(this.accountService, 'getCredentialsKeyedByAccount').and.callFake(resolve(AccountServiceFixture.credentialsKeyedByAccount));
        spyOn(this.subnetReader, 'listSubnets').and.callFake(resolve([]));
        spyOn(this.keyPairsReader, 'listKeyPairs').and.callFake(resolve([]));
        spyOn(this.securityGroupReader, 'getAllSecurityGroups').and.callFake(resolve(securityGroupReaderFixture.allSecurityGroups));
@@ -385,7 +385,7 @@
 
        this.wizard = jasmine.createSpyObj('wizard', ['markDirty', 'markComplete', 'includePage']);
        spyOn(this.accountService, 'getPreferredZonesByAccount').and.callFake(resolve(AccountServiceFixture.preferredZonesByAccount));
-       spyOn(this.accountService, 'getRegionsKeyedByAccount').and.callFake(resolve(AccountServiceFixture.regionsKeyedByAccount));
+       spyOn(this.accountService, 'getCredentialsKeyedByAccount').and.callFake(resolve(AccountServiceFixture.credentialsKeyedByAccount));
        spyOn(this.subnetReader, 'listSubnets').and.callFake(resolve([]));
        spyOn(this.keyPairsReader, 'listKeyPairs').and.callFake(resolve([]));
        spyOn(this.securityGroupReader, 'getAllSecurityGroups').and.callFake(resolve(securityGroupReaderFixture.allSecurityGroups));

--- a/app/scripts/modules/cloudfoundry/cache/cacheConfigurer.service.js
+++ b/app/scripts/modules/cloudfoundry/cache/cacheConfigurer.service.js
@@ -13,7 +13,7 @@ module.exports = angular.module('spinnaker.cf.cache.initializer', [
     let config = Object.create(null);
 
     config.credentials = {
-      initializers: [ () => accountService.getRegionsKeyedByAccount('cf') ],
+      initializers: [ () => accountService.getCredentialsKeyedByAccount('cf') ],
     };
 
     config.instanceTypes = {

--- a/app/scripts/modules/cloudfoundry/loadBalancer/details/LoadBalancerDetailsCtrl.js
+++ b/app/scripts/modules/cloudfoundry/loadBalancer/details/LoadBalancerDetailsCtrl.js
@@ -41,8 +41,8 @@ module.exports = angular.module('spinnaker.loadBalancer.cf.details.controller', 
             $scope.loadBalancer.elb = filtered[0];
             $scope.loadBalancer.account = loadBalancer.accountId;
 
-            accountService.getRegionsKeyedByAccount('cf').then(function(regionsKeyedByAccount) {
-              $scope.loadBalancer.elb.availabilityZones = regionsKeyedByAccount[loadBalancer.accountId].regions[loadBalancer.region].sort();
+            accountService.getCredentialsKeyedByAccount('cf').then(function(credentialsKeyedByAccount) {
+              $scope.loadBalancer.elb.availabilityZones = credentialsKeyedByAccount[loadBalancer.accountId].regions[loadBalancer.region].sort();
             });
           }
           accountService.getAccountDetails(loadBalancer.accountId).then(function() {

--- a/app/scripts/modules/cloudfoundry/serverGroup/configure/serverGroupConfiguration.service.js
+++ b/app/scripts/modules/cloudfoundry/serverGroup/configure/serverGroupConfiguration.service.js
@@ -16,12 +16,12 @@ module.exports = angular.module('spinnaker.serverGroup.configure.cf.configuratio
 
     function configureCommand(command) {
       return $q.all({
-        regionsKeyedByAccount: accountService.getRegionsKeyedByAccount('cf'),
+        credentialsKeyedByAccount: accountService.getCredentialsKeyedByAccount('cf'),
         securityGroups: securityGroupReader.getAllSecurityGroups(),
         instanceTypes: cfInstanceTypeService.getAllTypesByRegion()
       }).then(function(backingData) {
         var securityGroupReloader = $q.when(null);
-        backingData.accounts = _.keys(backingData.regionsKeyedByAccount);
+        backingData.accounts = _.keys(backingData.credentialsKeyedByAccount);
         backingData.filtered = {};
         command.backingData = backingData;
         configureImages(command);
@@ -61,7 +61,7 @@ module.exports = angular.module('spinnaker.serverGroup.configure.cf.configuratio
 
     function configureZones(command) {
       command.backingData.filtered.zones =
-        command.backingData.regionsKeyedByAccount[command.credentials].regions[command.region];
+        command.backingData.credentialsKeyedByAccount[command.credentials].regions[command.region];
     }
 
     function getSecurityGroups(command) {
@@ -164,7 +164,7 @@ module.exports = angular.module('spinnaker.serverGroup.configure.cf.configuratio
         var result = { dirty: {} };
         var backingData = command.backingData;
         if (command.credentials) {
-          backingData.filtered.regions = Object.keys(backingData.regionsKeyedByAccount[command.credentials].regions);
+          backingData.filtered.regions = Object.keys(backingData.credentialsKeyedByAccount[command.credentials].regions);
           if (backingData.filtered.regions.indexOf(command.region) === -1) {
             command.region = null;
             result.dirty.region = true;

--- a/app/scripts/modules/core/account/account.service.js
+++ b/app/scripts/modules/core/account/account.service.js
@@ -77,7 +77,7 @@ module.exports = angular.module('spinnaker.core.account.service', [
       });
     };
 
-    let getRegionsKeyedByAccount = _.memoize((provider) => {
+    let getCredentialsKeyedByAccount = _.memoize((provider) => {
       var deferred = $q.defer();
       listAccounts(provider).then(function(accounts) {
         $q.all(accounts.reduce(function(acc, account) {
@@ -94,23 +94,25 @@ module.exports = angular.module('spinnaker.core.account.service', [
       return deferred.promise;
     });
 
-    let getUniqueRegionsForAllAccounts = _.memoize((provider) => {
-      return getRegionsKeyedByAccount(provider)
-        .then(function(regionsByAccount) {
-          let regions = _.chain(regionsByAccount)
-            .values()
-            .map(acct => acct.regions)
-            .flatten()
-            .map(reg => reg.name)
-            .uniq()
-            .value();
+    let getUniqueAttributeForAllAccounts = (attribute) => {
+      return _.memoize((provider) => {
+        return getCredentialsKeyedByAccount(provider)
+          .then(function(credentialsByAccount) {
+            let attributes = _.chain(credentialsByAccount)
+              .values()
+              .map(acct => acct[attribute])
+              .flatten()
+              .map(reg => reg.name)
+              .uniq()
+              .value();
 
-          return regions;
-        });
-    });
+            return attributes;
+          });
+       });
+    };
 
     let getUniqueGceZonesForAllAccounts = _.memoize((provider) => {
-      return getRegionsKeyedByAccount(provider)
+      return getCredentialsKeyedByAccount(provider)
         .then(function(regionsByAccount) {
           return _.chain(regionsByAccount)
             .values()
@@ -160,9 +162,9 @@ module.exports = angular.module('spinnaker.core.account.service', [
       getAccountDetails: getAccountDetails,
       getAllAccountDetailsForProvider: getAllAccountDetailsForProvider,
       getRegionsForAccount: getRegionsForAccount,
-      getRegionsKeyedByAccount: getRegionsKeyedByAccount,
+      getCredentialsKeyedByAccount: getCredentialsKeyedByAccount,
       getPreferredZonesByAccount: getPreferredZonesByAccount,
-      getUniqueRegionsForAllAccounts: getUniqueRegionsForAllAccounts,
+      getUniqueAttributeForAllAccounts: getUniqueAttributeForAllAccounts,
       getUniqueGceZonesForAllAccounts: getUniqueGceZonesForAllAccounts,
       getAvailabilityZonesForAccountAndRegion: getAvailabilityZonesForAccountAndRegion
     };

--- a/app/scripts/modules/core/help/helpContents.js
+++ b/app/scripts/modules/core/help/helpContents.js
@@ -211,6 +211,7 @@ module.exports = angular.module('spinnaker.core.help.contents', [])
 
     'cluster.description': '<p>A cluster is a collection of server groups with the same name (stack + detail) in the same account.</p>',
     'pipeline.config.findAmi.cluster': 'The cluster to look at when selecting the image to use in this pipeline.',
+    'pipeline.config.findAmi.imageNamePattern': 'A regex used to match the name of the image. Must result in exactly one match to succeed. Empty is treated as match any.',
     'pipeline.config.dependsOn': 'Declares which stages must be run <em>before</em> this stage begins.',
     'pipeline.config.parallel.execution': '<p>Enabling parallel stage execution allows you to run stages only after dependent ' +
       'stages have completed.</p><p>By configuring a pipeline this way, you can reduce the time it takes to run.</p>',

--- a/app/scripts/modules/core/pipeline/config/stages/findAmi/kubernetes/findAmiExecutionDetails.controller.js
+++ b/app/scripts/modules/core/pipeline/config/stages/findAmi/kubernetes/findAmiExecutionDetails.controller.js
@@ -1,0 +1,23 @@
+'use strict';
+
+let angular = require('angular');
+
+module.exports = angular.module('spinnaker.core.pipeline.stage.findAmi.kubernetes.executionDetails.controller', [
+  require('angular-ui-router'),
+  require('../../../../../delivery/details/executionDetailsSection.service.js'),
+  require('../../../../../delivery/details/executionDetailsSectionNav.directive.js'),
+])
+  .controller('kubernetesFindAmiExecutionDetailsController', function ($scope, $stateParams, executionDetailsSectionService) {
+
+    $scope.configSections = ['findImageConfig', 'taskStatus'];
+
+    function initialize() {
+      executionDetailsSectionService.synchronizeSection($scope.configSections);
+      $scope.detailsSection = $stateParams.details;
+    }
+
+    initialize();
+
+    $scope.$on('$stateChangeSuccess', initialize, true);
+
+  });

--- a/app/scripts/modules/core/pipeline/config/stages/findAmi/kubernetes/findAmiExecutionDetails.html
+++ b/app/scripts/modules/core/pipeline/config/stages/findAmi/kubernetes/findAmiExecutionDetails.html
@@ -1,0 +1,42 @@
+<div ng-controller="kubernetesFindAmiExecutionDetailsController">
+  <execution-details-section-nav sections="configSections"></execution-details-section-nav>
+  <div class="step-section-details" ng-if="detailsSection === 'findImageConfig'">
+    <div class="row">
+      <div class="col-md-6">
+        <dl class="dl-narrow dl-horizontal">
+          <dt>Account</dt>
+          <dd>
+            <account-tag account="stage.context.credentials"></account-tag>
+          </dd>
+          <dt ng-if="stage.context.zones">Zones</dt>
+          <dd ng-if="stage.context.zones">{{stage.context.zones.join(', ')}}</dd>
+          <dt>Cluster</dt>
+          <dd>{{stage.context.cluster}}</dd>
+        </dl>
+      </div>
+    </div>
+    <stage-failure-message is-failed="stage.isFailed" message="stage.failureMessage"></stage-failure-message>
+
+    <div class="row" ng-if="stage.context.amiDetails">
+      <div class="col-md-12">
+        <div class="well alert alert-info">
+          <h4>Results</h4>
+          <dl ng-repeat="image in stage.context.amiDetails" class="dl-narrow dl-horizontal">
+            <dt>Zone</dt>
+            <dd>{{image.zone}}</dd>
+            <dt>Image ID</dt>
+            <dd>{{image.imageId}}</dd>
+            <dt>Name</dt>
+            <dd>{{image.imageName}}</dd>
+          </dl>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="step-section-details" ng-if="detailsSection === 'taskStatus'">
+    <div class="row">
+      <execution-step-details item="stage"></execution-step-details>
+    </div>
+  </div>
+</div>

--- a/app/scripts/modules/core/pipeline/config/stages/findAmi/kubernetes/findAmiStage.html
+++ b/app/scripts/modules/core/pipeline/config/stages/findAmi/kubernetes/findAmiStage.html
@@ -1,0 +1,30 @@
+<div ng-controller="kubernetesFindAmiStageController as findAmiController" class="form-horizontal">
+
+  <account-namespace-cluster-selector
+    application="application"
+    provider="kubernetes"
+    component="stage"
+    accounts="accounts">
+  </account-namespace-cluster-selector>
+
+  <stage-config-field label="Server Group Selection">
+    <ui-select ng-model="stage.selectionStrategy" class="form-control input-sm">
+      <ui-select-match placeholder="None">{{$select.selected.label}}</ui-select-match>
+      <ui-select-choices repeat="strategy.val as strategy in selectionStrategies | filter: $select.search">
+        <strong ng-bind-html="strategy.label | highlight: $select.search"></strong>
+        <div ng-bind-html="strategy.description"></div>
+      </ui-select-choices>
+    </ui-select>
+  </stage-config-field>
+  <stage-config-field label="Server Group Filters">
+    <label class="checkbox-inline">
+      <input type="checkbox"
+             ng-model="stage.onlyEnabled"/>
+      Only consider enabled Server Groups
+    </label>
+  </stage-config-field>
+  <stage-config-field help-key="pipeline.config.findAmi.imageNamePattern" label="Image Name Pattern">
+    <input type="text" class="form-control input-sm"
+           ng-model="stage.imageNamePattern"/>
+  </stage-config-field>
+</div>

--- a/app/scripts/modules/core/pipeline/config/stages/findAmi/kubernetes/kubernetesFindAmiStage.js
+++ b/app/scripts/modules/core/pipeline/config/stages/findAmi/kubernetes/kubernetesFindAmiStage.js
@@ -1,0 +1,70 @@
+'use strict';
+
+let angular = require('angular');
+
+module.exports = angular.module('spinnaker.core.pipeline.stage.kubernetes.findAmiStage', [
+  require('../../../../../../core/application/listExtractor/listExtractor.service'),
+  require('./findAmiExecutionDetails.controller.js'),
+  require('../../../../../account/account.service.js'),
+])
+  .config(function(pipelineConfigProvider) {
+    pipelineConfigProvider.registerStage({
+      provides: 'findImage',
+      cloudProvider: 'kubernetes',
+      templateUrl: require('./findAmiStage.html'),
+      executionDetailsUrl: require('./findAmiExecutionDetails.html'),
+      validators: [
+        { type: 'requiredField', fieldName: 'cluster' },
+        { type: 'requiredField', fieldName: 'selectionStrategy', fieldLabel: 'Server Group Selection'},
+        { type: 'requiredField', fieldName: 'namespace' },
+        { type: 'requiredField', fieldName: 'imageNamePattern' },
+        { type: 'requiredField', fieldName: 'credentials' }
+      ]
+    });
+  }).controller('kubernetesFindAmiStageController', function($scope, accountService) {
+
+    let stage = $scope.stage;
+
+    $scope.state = {
+      accounts: false,
+      zonesLoaded: false
+    };
+
+    accountService.listAccounts('kubernetes').then(function (accounts) {
+      $scope.accounts = accounts;
+      $scope.state.accounts = true;
+    });
+
+    $scope.selectionStrategies = [{
+      label: 'Largest',
+      val: 'LARGEST',
+      description: 'When multiple server groups exist, prefer the server group with the most instances'
+    }, {
+      label: 'Newest',
+      val: 'NEWEST',
+      description: 'When multiple server groups exist, prefer the newest'
+    }, {
+      label: 'Oldest',
+      val: 'OLDEST',
+      description: 'When multiple server groups exist, prefer the oldest'
+    }, {
+      label: 'Fail',
+      val: 'FAIL',
+      description: 'When multiple server groups exist, fail'
+    }];
+
+    stage.namespace = stage.namespace || [];
+    stage.cloudProvider = 'kubernetes';
+    stage.selectionStrategy = stage.selectionStrategy || $scope.selectionStrategies[0].val;
+
+    if (angular.isUndefined(stage.onlyEnabled)) {
+      stage.onlyEnabled = true;
+    }
+
+    if (!stage.credentials && $scope.application.defaultCredentials.kubernetes) {
+      stage.credentials = $scope.application.defaultCredentials.kubernetes;
+    }
+
+    $scope.$watch('stage.credentials', $scope.accountUpdated);
+  });
+

--- a/app/scripts/modules/core/widgets/accountNamespaceClusterSelector.component.html
+++ b/app/scripts/modules/core/widgets/accountNamespaceClusterSelector.component.html
@@ -1,0 +1,28 @@
+<stage-config-field label="Account">
+  <account-select-field
+    component="vm.component"
+    field="credentials"
+    accounts="vm.accounts"
+    provider="vm.provider"
+    on-change="vm.accountUpdated()"
+    required>
+  </account-select-field>
+</stage-config-field>
+<stage-config-field label="Namespace">
+  <p ng-if="!vm.component.credentials" class="form-control-static">(Select an Account)</p>
+  <checklist
+    ng-if="vm.component.credentials"
+    items="vm.namespaces"
+    model="vm.component.namespaces"
+    inline="true"
+    on-change="vm.namespaceChanged()"
+    include-select-all-button="true">
+  </checklist>
+</stage-config-field>
+<stage-config-field label="Cluster" help-key="pipeline.config.findAmi.cluster">
+  <cluster-selector
+    clusters="vm.clusterList"
+    model="vm.component[vm.clusterField]"
+    toggled="vm.clusterSelectInputToggled(isToggled)">
+  </cluster-selector>
+</stage-config-field>

--- a/app/scripts/modules/core/widgets/accountNamespaceClusterSelector.component.js
+++ b/app/scripts/modules/core/widgets/accountNamespaceClusterSelector.component.js
@@ -3,12 +3,12 @@
 let angular = require('angular');
 
 module.exports = angular
-  .module('spinnaker.core.accountRegionClusterSelector.directive', [
+  .module('spinnaker.core.accountNamespaceClusterSelector.directive', [
     require('../../core/application/listExtractor/listExtractor.service'),
     require('../../core/account/account.service'),
     require('../../core/utils/lodash')
   ])
-  .directive('accountRegionClusterSelector', function() {
+  .directive('accountNamespaceClusterSelector', function() {
     return {
       restrict: 'E',
       scope: {},
@@ -17,9 +17,9 @@ module.exports = angular
         component: '=',
         accounts: '=',
         clusterField: '@',
-        singleRegion: '=',
+        provider: '=',
       },
-      templateUrl: require('./accountRegionClusterSelector.component.html'),
+      templateUrl: require('./accountNamespaceClusterSelector.component.html'),
       controllerAs: 'vm',
       controller: function controller(appListExtractorService, accountService, _) {
 
@@ -28,22 +28,24 @@ module.exports = angular
         let vm = this;
         let isTextInputForClusterFiled;
 
-        let regions;
+        let namespaces;
 
-        let setRegionList = () => {
+        let setNamespaceList = () => {
           let accountFilter = (cluster) => cluster.account === vm.component.credentials;
-          let regionList = appListExtractorService.getRegions([vm.application], accountFilter);
-          vm.regions = regionList.length ? regionList : regions;
+          // TODO(lwander): Move away from regions to namespaces here.
+          let namespaceList = appListExtractorService.getRegions([vm.application], accountFilter);
+          vm.namespaces = namespaceList.length ? namespaceList : namespaces;
         };
 
 
         let setClusterList = () => {
-          let regionField = this.singleRegion ? vm.component.region : vm.component.regions;
-          let clusterFilter = appListExtractorService.clusterFilterForCredentialsAndRegion(vm.component.credentials, regionField);
+          let namespaceField = vm.component.namespaces;
+          // TODO(lwander): Move away from regions to namespaces here.
+          let clusterFilter = appListExtractorService.clusterFilterForCredentialsAndRegion(vm.component.credentials, namespaceField);
           vm.clusterList = appListExtractorService.getClusters([vm.application], clusterFilter);
         };
 
-        vm.regionChanged = () => {
+        vm.namespaceChanged = () => {
           setClusterList();
           if (!isTextInputForClusterFiled && ! _.includes(vm.clusterList, vm.component[this.clusterField])) {
             vm.component[this.clusterField] = undefined;
@@ -51,14 +53,14 @@ module.exports = angular
         };
 
         let setToggledState = () => {
-          vm.regions = regions;
+          vm.namespaces = namespaces;
           isTextInputForClusterFiled = true;
         };
 
         let setUnToggledState = () => {
           vm.component[this.clusterField] = undefined;
           isTextInputForClusterFiled = false;
-          setRegionList();
+          setNamespaceList();
         };
 
         vm.clusterSelectInputToggled = (isToggled) => {
@@ -67,19 +69,19 @@ module.exports = angular
 
         vm.accountUpdated = () => {
           vm.component[this.clusterField] = undefined;
-          setRegionList();
+          setNamespaceList();
           setClusterList();
         };
 
         let init = () => {
-          accountService.getUniqueAttributeForAllAccounts('regions')(vm.component.cloudProviderType).then((allRegions) => {
-            regions = allRegions;
-            return allRegions;
+          accountService.getUniqueAttributeForAllAccounts('namespaces')(vm.component.cloudProviderType).then((allNamespaces) => {
+            namespaces = allNamespaces;
+            return allNamespaces;
           })
-          .then((allRegions) => {
-            setRegionList();
+          .then((allNamespaces) => {
+            setNamespaceList();
             setClusterList();
-            vm.regions = _.includes(vm.clusterList, vm.component[this.clusterField]) ? vm.regions : allRegions;
+            vm.namespaces = _.includes(vm.clusterList, vm.component[this.clusterField]) ? vm.namespaces : allNamespaces;
           });
         };
 

--- a/app/scripts/modules/core/widgets/index.js
+++ b/app/scripts/modules/core/widgets/index.js
@@ -4,7 +4,8 @@ let angular = require('angular');
 
 module.exports = angular
   .module('spinnaker.core.widgets', [
-    require('./scopeClusterSelector.directive'),
+    require('./accountNamespaceClusterSelector.component'),
     require('./accountRegionClusterSelector.component'),
     require('./accountZoneClusterSelector.component'),
+    require('./scopeClusterSelector.directive'),
   ]);

--- a/app/scripts/modules/google/cache/cacheConfigurer.service.js
+++ b/app/scripts/modules/google/cache/cacheConfigurer.service.js
@@ -16,7 +16,7 @@ module.exports = angular.module('spinnaker.gce.cache.initializer', [
     let config = Object.create(null);
 
     config.credentials = {
-      initializers: [ () => accountService.getRegionsKeyedByAccount('gce') ],
+      initializers: [ () => accountService.getCredentialsKeyedByAccount('gce') ],
     };
 
     config.instanceTypes = {

--- a/app/scripts/modules/google/loadBalancer/details/LoadBalancerDetailsCtrl.js
+++ b/app/scripts/modules/google/loadBalancer/details/LoadBalancerDetailsCtrl.js
@@ -41,8 +41,8 @@ module.exports = angular.module('spinnaker.loadBalancer.gce.details.controller',
             $scope.loadBalancer.elb = filtered[0];
             $scope.loadBalancer.account = loadBalancer.accountId;
 
-            accountService.getRegionsKeyedByAccount('gce').then(function(regionsKeyedByAccount) {
-              $scope.loadBalancer.elb.availabilityZones = regionsKeyedByAccount[loadBalancer.accountId].regions[loadBalancer.region].sort();
+            accountService.getCredentialsKeyedByAccount('gce').then(function(credentialsKeyedByAccount) {
+              $scope.loadBalancer.elb.availabilityZones = credentialsKeyedByAccount[loadBalancer.accountId].regions[loadBalancer.region].sort();
             });
           }
           accountService.getAccountDetails(loadBalancer.accountId).then(function(accountDetails) {

--- a/app/scripts/modules/google/serverGroup/configure/serverGroupConfiguration.service.js
+++ b/app/scripts/modules/google/serverGroup/configure/serverGroupConfiguration.service.js
@@ -55,7 +55,7 @@ module.exports = angular.module('spinnaker.serverGroup.configure.gce.configurati
       }
 
       return $q.all({
-        regionsKeyedByAccount: accountService.getRegionsKeyedByAccount('gce'),
+        credentialsKeyedByAccount: accountService.getCredentialsKeyedByAccount('gce'),
         securityGroups: securityGroupReader.getAllSecurityGroups(),
         networks: networkReader.listNetworksByProvider('gce'),
         subnets: subnetReader.listSubnetsByProvider('gce'),
@@ -68,7 +68,7 @@ module.exports = angular.module('spinnaker.serverGroup.configure.gce.configurati
         var loadBalancerReloader = $q.when(null);
         var securityGroupReloader = $q.when(null);
         var networkReloader = $q.when(null);
-        backingData.accounts = _.keys(backingData.regionsKeyedByAccount);
+        backingData.accounts = _.keys(backingData.credentialsKeyedByAccount);
         backingData.filtered = {};
         command.backingData = backingData;
         configureImages(command);
@@ -185,7 +185,7 @@ module.exports = angular.module('spinnaker.serverGroup.configure.gce.configurati
         return result;
       }
       filteredData.zones =
-        command.backingData.regionsKeyedByAccount[command.credentials].regions[command.region];
+        command.backingData.credentialsKeyedByAccount[command.credentials].regions[command.region];
       if (!_(filteredData.zones).contains(command.zone)) {
         command.zone = '';
         result.dirty.zone = true;
@@ -370,7 +370,7 @@ module.exports = angular.module('spinnaker.serverGroup.configure.gce.configurati
         var result = { dirty: {} };
         var backingData = command.backingData;
         if (command.credentials) {
-          backingData.filtered.regions = Object.keys(backingData.regionsKeyedByAccount[command.credentials].regions);
+          backingData.filtered.regions = Object.keys(backingData.credentialsKeyedByAccount[command.credentials].regions);
           if (backingData.filtered.regions.indexOf(command.region) === -1) {
             command.region = null;
             result.dirty.region = true;

--- a/app/scripts/modules/kubernetes/cache/configurer.service.js
+++ b/app/scripts/modules/kubernetes/cache/configurer.service.js
@@ -13,11 +13,7 @@ module.exports = angular.module('spinnaker.kubernetes.cache.initializer', [
     let config = Object.create(null);
 
     config.account = {
-      initializers: [ () => accountService.getRegionsKeyedByAccount('kubernetes') ],
-    };
-
-    config.instanceTypes = {
-      initializers: [ () => instanceTypeService.getAllTypesByRegion('kubernetes') ],
+      initializers: [ () => accountService.getCredentialsKeyedByAccount('kubernetes') ],
     };
 
     config.loadBalancers = {

--- a/app/scripts/modules/kubernetes/kubernetes.module.js
+++ b/app/scripts/modules/kubernetes/kubernetes.module.js
@@ -11,17 +11,19 @@ templates.keys().forEach(function(key) {
 });
 
 module.exports = angular.module('spinnaker.kubernetes', [
+  require('../core/pipeline/config/stages/findAmi/kubernetes/kubernetesFindAmiStage.js'),
   require('./cache/configurer.service.js'),
+  require('./container/configurer.directive.js'),
+  require('./instance/details/details.kubernetes.module.js'),
+  require('./loadBalancer/configure/configure.kubernetes.module.js'),
+  require('./loadBalancer/details/details.kubernetes.module.js'),
+  require('./loadBalancer/transformer.js'),
+  require('./namespace/multiSelectField.component.js'),
+  require('./namespace/selectField.directive.js'),
   require('./serverGroup/configure/CommandBuilder.js'),
   require('./serverGroup/configure/configure.kubernetes.module.js'),
   require('./serverGroup/details/details.kubernetes.module.js'),
   require('./serverGroup/transformer.js'),
-  require('./loadBalancer/transformer.js'),
-  require('./loadBalancer/details/details.kubernetes.module.js'),
-  require('./loadBalancer/configure/configure.kubernetes.module.js'),
-  require('./instance/details/details.kubernetes.module.js'),
-  require('./namespace/selectField.directive.js'),
-  require('./container/configurer.directive.js'),
 ])
   .config(function(cloudProviderRegistryProvider) {
     cloudProviderRegistryProvider.registerProvider('kubernetes', {

--- a/app/scripts/modules/kubernetes/namespace/multiSelectField.component.html
+++ b/app/scripts/modules/kubernetes/namespace/multiSelectField.component.html
@@ -1,0 +1,18 @@
+<stage-config-field label="Namespaces">
+  <p ng-if="!vm.component.credentials" class="form-control-static">(Select an Account)</p>
+  <select class="form-control input-sm"
+          ng-if="vm.component.credentials"
+          ng-model="vm.component.region"
+          ng-change="vm.regionChanged()"
+          ng-options="namespace for namespace in vm.namespaces"
+          required>
+  </select>
+  <checklist
+    ng-if="vm.component.credentials && !vm.singleRegion"
+    items="vm.namespaces"
+    model="vm.component.regions"
+    inline="true"
+    on-change="vm.namespaceChanged()"
+    include-select-all-button="true">
+  </checklist>
+</stage-config-field>

--- a/app/scripts/modules/kubernetes/namespace/multiSelectField.component.js
+++ b/app/scripts/modules/kubernetes/namespace/multiSelectField.component.js
@@ -3,12 +3,12 @@
 let angular = require('angular');
 
 module.exports = angular
-  .module('spinnaker.core.accountRegionClusterSelector.directive', [
+  .module('kubernetes.namespace.multiSelectField.component', [
     require('../../core/application/listExtractor/listExtractor.service'),
     require('../../core/account/account.service'),
     require('../../core/utils/lodash')
   ])
-  .directive('accountRegionClusterSelector', function() {
+  .directive('namespaceMultiSelectField', function() {
     return {
       restrict: 'E',
       scope: {},
@@ -17,9 +17,8 @@ module.exports = angular
         component: '=',
         accounts: '=',
         clusterField: '@',
-        singleRegion: '=',
       },
-      templateUrl: require('./accountRegionClusterSelector.component.html'),
+      templateUrl: require('./multiSelectField.component.html'),
       controllerAs: 'vm',
       controller: function controller(appListExtractorService, accountService, _) {
 
@@ -28,22 +27,22 @@ module.exports = angular
         let vm = this;
         let isTextInputForClusterFiled;
 
-        let regions;
+        let namespaces;
 
-        let setRegionList = () => {
+        let setNamespaceList = () => {
           let accountFilter = (cluster) => cluster.account === vm.component.credentials;
-          let regionList = appListExtractorService.getRegions([vm.application], accountFilter);
-          vm.regions = regionList.length ? regionList : regions;
+          let namespaceList = appListExtractorService.getRegions([vm.application], accountFilter);
+          vm.namespaces = namespaceList.length ? namespaceList : namespaces;
         };
 
 
         let setClusterList = () => {
-          let regionField = this.singleRegion ? vm.component.region : vm.component.regions;
-          let clusterFilter = appListExtractorService.clusterFilterForCredentialsAndRegion(vm.component.credentials, regionField);
+          let namespaceField = vm.component.regionss;
+          let clusterFilter = appListExtractorService.clusterFilterForCredentialsAndRegion(vm.component.credentials, namespaceField);
           vm.clusterList = appListExtractorService.getClusters([vm.application], clusterFilter);
         };
 
-        vm.regionChanged = () => {
+        vm.namespaceChanged = () => {
           setClusterList();
           if (!isTextInputForClusterFiled && ! _.includes(vm.clusterList, vm.component[this.clusterField])) {
             vm.component[this.clusterField] = undefined;
@@ -51,14 +50,14 @@ module.exports = angular
         };
 
         let setToggledState = () => {
-          vm.regions = regions;
+          vm.namespaces = namespaces;
           isTextInputForClusterFiled = true;
         };
 
         let setUnToggledState = () => {
           vm.component[this.clusterField] = undefined;
           isTextInputForClusterFiled = false;
-          setRegionList();
+          setNamespaceList();
         };
 
         vm.clusterSelectInputToggled = (isToggled) => {
@@ -67,19 +66,19 @@ module.exports = angular
 
         vm.accountUpdated = () => {
           vm.component[this.clusterField] = undefined;
-          setRegionList();
+          setNamespaceList();
           setClusterList();
         };
 
         let init = () => {
-          accountService.getUniqueAttributeForAllAccounts('regions')(vm.component.cloudProviderType).then((allRegions) => {
-            regions = allRegions;
-            return allRegions;
+          accountService.getUniqueRegionsForAllAccounts(vm.component.cloudProviderType).then((allNamespaces) => {
+            namespaces = allNamespaces;
+            return allNamespaces;
           })
-          .then((allRegions) => {
-            setRegionList();
+          .then((allNamespaces) => {
+            setNamespaceList();
             setClusterList();
-            vm.regions = _.includes(vm.clusterList, vm.component[this.clusterField]) ? vm.regions : allRegions;
+            vm.namespaces = _.includes(vm.clusterList, vm.component[this.clusterField]) ? vm.namespaces : allNamespaces;
           });
         };
 

--- a/app/scripts/modules/kubernetes/namespace/multiSelectField.directive.html
+++ b/app/scripts/modules/kubernetes/namespace/multiSelectField.directive.html
@@ -1,0 +1,18 @@
+<stage-config-field label="Namespaces">
+  <p ng-if="!vm.component.credentials" class="form-control-static">(Select an Account)</p>
+  <select class="form-control input-sm"
+          ng-if="vm.component.credentials"
+          ng-model="vm.component.regions"
+          ng-change="vm.regionChanged()"
+          ng-options="namespace for namespace in vm.namespaces"
+          required>
+  </select>
+  <checklist
+    ng-if="vm.component.credentials && !vm.singleRegion"
+    items="vm.regions"
+    model="vm.component.regions"
+    inline="true"
+    on-change="vm.regionChanged()"
+    include-select-all-button="true">
+  </checklist>
+</stage-config-field>

--- a/app/scripts/modules/kubernetes/serverGroup/configure/wizard/Clone.controller.js
+++ b/app/scripts/modules/kubernetes/serverGroup/configure/wizard/Clone.controller.js
@@ -51,7 +51,7 @@ module.exports = angular.module('spinnaker.serverGroup.configure.kubernetes.clon
     }
 
     function initializeWatches() {
-      $scope.$watch('command.credentials', $scope.command.credentialsChanged);
+      $scope.$watch('command.account', $scope.command.accountChanged);
       $scope.$watch('command.namespace', $scope.command.namespaceChanged);
     }
 
@@ -67,7 +67,7 @@ module.exports = angular.module('spinnaker.serverGroup.configure.kubernetes.clon
 
     this.isValid = function () {
       return $scope.command && $scope.command.containers.length > 0 &&
-        $scope.command.credentials !== null &&
+        $scope.command.account !== null &&
         v2modalWizardService.isComplete();
     };
 

--- a/app/scripts/modules/titan/serverGroup/configure/serverGroupConfiguration.service.js
+++ b/app/scripts/modules/titan/serverGroup/configure/serverGroupConfiguration.service.js
@@ -11,12 +11,12 @@ module.exports = angular.module('spinnaker.serverGroup.configure.titan.configura
     function configureCommand(command) {
       command.image = command.viewState.imageId;
       return $q.all({
-        regionsKeyedByAccount: accountService.getRegionsKeyedByAccount('titan'),
+        credentialsKeyedByAccount: accountService.getCredentialsKeyedByAccount('titan'),
         images: [],
       }).then(function(backingData) {
-        backingData.accounts = _.keys(backingData.regionsKeyedByAccount);
+        backingData.accounts = _.keys(backingData.credentialsKeyedByAccount);
         backingData.filtered = {};
-        backingData.filtered.regions = backingData.regionsKeyedByAccount[command.credentials].regions;
+        backingData.filtered.regions = backingData.credentialsKeyedByAccount[command.credentials].regions;
         command.backingData = backingData;
 
         return $q.all([]).then(function() {
@@ -26,7 +26,7 @@ module.exports = angular.module('spinnaker.serverGroup.configure.titan.configura
     }
 
     function configureZones(command) {
-      command.backingData.filtered.regions = Object.keys(command.backingData.regionsKeyedByAccount[command.credentials].regions);
+      command.backingData.filtered.regions = Object.keys(command.backingData.credentialsKeyedByAccount[command.credentials].regions);
     }
 
     function attachEventHandlers(command) {
@@ -36,7 +36,7 @@ module.exports = angular.module('spinnaker.serverGroup.configure.titan.configura
         var backingData = command.backingData;
         configureZones(command);
         if (command.credentials) {
-          backingData.filtered.regions = backingData.regionsKeyedByAccount[command.credentials].regions;
+          backingData.filtered.regions = backingData.credentialsKeyedByAccount[command.credentials].regions;
           if (backingData.filtered.regions.indexOf(command.region) === -1) {
             command.region = null;
             result.dirty.region = true;

--- a/test/fixture/AccountServiceFixtures.js
+++ b/test/fixture/AccountServiceFixtures.js
@@ -1,5 +1,5 @@
 var AccountServiceFixture = {};
-AccountServiceFixture.regionsKeyedByAccount = {
+AccountServiceFixture.credentialsKeyedByAccount = {
   'test': {
     regions: [
       {


### PR DESCRIPTION
Added `FindImage` stage to the Kubernetes Provider.

@duftler 

In the process, I renamed `getRegionsKeyedByAccount` to `getCredentialsKeyedByAccount`, since this function was already returning a map of `account name -> credentials data`. I used this to change `getUniqueRegionsForAllAccounts` to `getUniqueAttributeForAllAccounts(attribute)` (where `getUniqueRegionsForAllAccounts ~= getUniqueAttributeForAllAccounts('regions')`). Because of those changes, could you PTAL @anotherchrisberry.