### PR TITLE
Friday fixes

### DIFF
--- a/app/scripts/modules/amazon/securityGroup/details/securityGroupDetail.controller.js
+++ b/app/scripts/modules/amazon/securityGroup/details/securityGroupDetail.controller.js
@@ -119,5 +119,10 @@ module.exports = angular.module('spinnaker.securityGroup.aws.details.controller'
       });
     };
 
+    if (app.isStandalone) {
+      app.securityGroups = {
+        refresh: extractSecurityGroup
+      };
+    }
   }
 );

--- a/app/scripts/modules/amazon/securityGroup/details/securityGroupDetail.controller.js
+++ b/app/scripts/modules/amazon/securityGroup/details/securityGroupDetail.controller.js
@@ -120,6 +120,7 @@ module.exports = angular.module('spinnaker.securityGroup.aws.details.controller'
     };
 
     if (app.isStandalone) {
+      // we still want the edit to refresh the security group details when the modal closes
       app.securityGroups = {
         refresh: extractSecurityGroup
       };

--- a/app/scripts/modules/azure/securityGroup/details/securityGroupDetail.controller.js
+++ b/app/scripts/modules/azure/securityGroup/details/securityGroupDetail.controller.js
@@ -110,5 +110,12 @@ module.exports = angular.module('spinnaker.azure.securityGroup.azure.details.con
       });
     };
 
+    if (app.isStandalone) {
+      // we still want the edit to refresh the security group details when the modal closes
+      app.securityGroups = {
+        refresh: extractSecurityGroup
+      };
+    }
+
   }
 );

--- a/app/scripts/modules/cloudfoundry/securityGroup/details/SecurityGroupDetailsCtrl.js
+++ b/app/scripts/modules/cloudfoundry/securityGroup/details/SecurityGroupDetailsCtrl.js
@@ -71,5 +71,11 @@ module.exports = angular.module('spinnaker.securityGroup.cf.details.controller',
       }
     });
 
+    if (app.isStandalone) {
+      // we still want the edit to refresh the security group details when the modal closes
+      app.securityGroups = {
+        refresh: extractSecurityGroup
+      };
+    }
   }
 );

--- a/app/scripts/modules/core/account/accountSelectField.directive.html
+++ b/app/scripts/modules/core/account/accountSelectField.directive.html
@@ -9,7 +9,7 @@
   <option ng-repeat="account in vm.secondaryAccounts" value="{{account}}" ng-selected="vm.component[vm.field] === account">{{account}}</option>
 </select>
 
-  <p class="form-control-static" ng-if="readOnly">{{vm.component[vm.field]}}</p>
+  <p class="form-control-static" ng-if="vm.readOnly">{{vm.component[vm.field]}}</p>
 </div>
 
 <div ng-if="vm.multiselect">

--- a/app/scripts/modules/google/securityGroup/details/SecurityGroupDetailsCtrl.js
+++ b/app/scripts/modules/google/securityGroup/details/SecurityGroupDetailsCtrl.js
@@ -183,5 +183,11 @@ module.exports = angular.module('spinnaker.securityGroup.gce.details.controller'
       });
     };
 
+    if (app.isStandalone) {
+      // we still want the edit to refresh the security group details when the modal closes
+      app.securityGroups = {
+        refresh: extractSecurityGroup
+      };
+    }
   }
 );

--- a/app/scripts/modules/netflix/pipeline/stage/canary/canaryStage.js
+++ b/app/scripts/modules/netflix/pipeline/stage/canary/canaryStage.js
@@ -158,6 +158,7 @@ module.exports = angular.module('spinnaker.netflix.pipeline.stage.canaryStage', 
         $uibModal.open({
           templateUrl: config.cloneServerGroupTemplateUrl,
           controller: `${config.cloneServerGroupController} as ctrl`,
+          size: 'lg',
           resolve: {
             title: function () {
               return 'Add Cluster Pair';
@@ -198,6 +199,7 @@ module.exports = angular.module('spinnaker.netflix.pipeline.stage.canaryStage', 
       $uibModal.open({
         templateUrl: config.cloneServerGroupTemplateUrl,
         controller: `${config.cloneServerGroupController} as ctrl`,
+        size: 'lg',
         resolve: {
           title: function () {
             return 'Configure ' + type + ' Cluster';


### PR DESCRIPTION
Three small things:
 1. Use the larger modal size when editing canary clusters, since they are using the v2 modals
 2. Allow editing and refresh of standalone security groups
 3. Fixed a very old bug where account is not displayed in read-only mode when using `account-select-field directive`