### PR TITLE
do not initialize project if no config found

### DIFF
--- a/app/scripts/modules/core/projects/project.controller.js
+++ b/app/scripts/modules/core/projects/project.controller.js
@@ -56,7 +56,7 @@ module.exports = angular.module('spinnaker.core.projects.project.controller', [
       this.viewState.dashboard = !selectedApplication;
     };
 
-    if (!projectConfiguration.notFound) {
+    if (projectConfiguration.config) {
       initialize();
     }
 


### PR DESCRIPTION
This is a better guard for an invalid project, or if Front50 or Gate is failing.