### PR TITLE
style tweaks, avoid state exception when toggling details

### DIFF
--- a/app/scripts/modules/core/delivery/executionGroup/execution/execution.directive.html
+++ b/app/scripts/modules/core/delivery/executionGroup/execution/execution.directive.html
@@ -7,8 +7,9 @@
   <div class="execution-bar">
     <div class="stages">
       <div ng-repeat="stage in vm.execution.stageSummaries"
-           class="clickable stage stage-type-{{stage.type.toLowerCase()}} execution-marker execution-marker-{{stage.status.toLowerCase()}}"
-           ng-class="{active: vm.isActive($index), glowing: stage.isRunning}"
+           class="clickable stage stage-type-{{stage.type.toLowerCase()}}
+                  execution-marker execution-marker-{{stage.status.toLowerCase()}}
+                  {{vm.isActive($index) ? 'active' : ''}} {{stage.isRunning ? 'glowing' : ''}}"
            ng-style="{width: 100/vm.execution.stageSummaries.length + '%', 'background-color': stage.color}"
            uib-tooltip-template="stage.labelTemplateUrl"
            tooltip-title="(Click for details)"

--- a/app/scripts/modules/core/delivery/executionGroup/execution/execution.directive.js
+++ b/app/scripts/modules/core/delivery/executionGroup/execution/execution.directive.js
@@ -36,15 +36,17 @@ module.exports = angular
     };
 
     this.isActive = (stageIndex) => {
-      return this.showDetails(this.execution.id) && Number($stateParams.stage) === stageIndex;
+      return this.showDetails() && Number($stateParams.stage) === stageIndex;
     };
 
     this.toggleDetails = (node) => {
       const params = { executionId: node.executionId, stage: node.index};
       if ($state.includes('**.execution', params)) {
-        $state.go('^');
+        if (!this.standalone) {
+          $state.go('^');
+        }
       } else {
-        if ($state.current.name.indexOf('.executions.execution') !== -1 || $state.current.name.indexOf('.executionDetails.execution') !== -1) {
+        if ($state.current.name.indexOf('.executions.execution') !== -1 || this.standalone) {
           $state.go('.', params);
         } else {
           $state.go('.execution', params);

--- a/app/scripts/modules/core/delivery/executionGroup/execution/execution.less
+++ b/app/scripts/modules/core/delivery/executionGroup/execution/execution.less
@@ -1,5 +1,52 @@
 @import "../../../presentation/less/imports/commonImports.less";
 
+execution {
+  .label-succeeded {
+    background-color: @healthy_green_border;
+  }
+  .label-terminal, .label-terminated {
+    background-color: @unhealthy_red;
+  }
+  .label-running, .label-launched {
+    background-color: @spinnaker-blue;
+  }
+  .label {
+    text-transform: uppercase;
+    border-radius: 0;
+    color: #fff;
+    font-weight: 600;
+    .glyphicon {
+      color: #ffffff;
+    }
+  }
+  .timestamp {
+    color: @mid_grey;
+    font-size: .8em;
+    padding-top: 22px;
+  }
+  .panel {
+    .summary {
+      background-color: @mid_light_grey;
+      cursor: pointer;
+      padding-bottom: 0px;
+      h5 {
+        font-weight: bold;
+        display: inline-block;
+      }
+    }
+    .summary.current {
+      background-color: #FFF;
+    }
+
+    .details {
+      .tr {
+        background-color: lighten(@spinnaker-blue, 20%);
+      }
+    }
+
+  }
+}
+
 .execution-actions {
   display: inline-block;
   width: 40px;
@@ -43,6 +90,7 @@ execution-status {
     display: inline-block;
     height: 20px;
     opacity: 0.65;
+    transition: 0.2s all;
     &:hover, &.active {
       opacity: 1;
     }

--- a/app/scripts/modules/core/delivery/executions/executions.less
+++ b/app/scripts/modules/core/delivery/executions/executions.less
@@ -75,6 +75,10 @@ executions {
     fill: @stage-stopped;
     background-color: @stage-stopped;
   }
+  &.execution-marker-not_started, &.execution-marker-canceled {
+    fill: @stage-default;
+    background-color: @stage-default;
+  }
   &.execution-marker-paused {
     fill: @stage-running;
     background-color: @stage-running;

--- a/app/scripts/modules/core/pipeline/config/graph/pipelineGraph.directive.html
+++ b/app/scripts/modules/core/pipeline/config/graph/pipelineGraph.directive.html
@@ -49,10 +49,10 @@
            ng-click="nodeClicked(stage)">
         <div ng-include="stage.labelTemplateUrl"></div>
       </div>
-      <div class="label-body node"
+      <div class="label-body node clickable"
            ng-if="!stage.labelTemplateUrl"
            ng-mouseenter="highlight(stage)" ng-mouseleave="removeHighlight(stage)"
-           ng-click="nodeClicked(stage)"><a href>{{stage.name}}</a></div>
+           ng-click="nodeClicked(stage)"><a>{{stage.name}}</a></div>
     </foreignobject>
   </g>
 </svg>

--- a/app/scripts/modules/core/pipeline/config/graph/pipelineGraph.less
+++ b/app/scripts/modules/core/pipeline/config/graph/pipelineGraph.less
@@ -103,6 +103,7 @@ pipeline-graph {
             background-color: @dark_blue_background;
             border-radius: 4px;
             text-shadow: none;
+            transition: 0.10s all;
           }
           font-weight: 600;
           margin-left: -12px;

--- a/app/scripts/modules/core/pipeline/pipelines.less
+++ b/app/scripts/modules/core/pipeline/pipelines.less
@@ -44,52 +44,6 @@
   .faded {
     color: @mid_lighter_grey;
   }
-  .execution {
-    .timestamp {
-      color: @mid_grey;
-      font-size: .8em;
-      padding-top: 22px;
-    }
-    .panel {
-      .summary {
-        background-color: @mid_light_grey;
-        cursor: pointer;
-        padding-bottom: 0px;
-        h5 {
-          font-weight: bold;
-          display: inline-block;
-        }
-      }
-      .summary.current {
-        background-color: #FFF;
-      }
-
-      .details {
-        .tr {
-          background-color: lighten(@spinnaker-blue, 20%);
-        }
-      }
-
-    }
-    .label-succeeded {
-      background-color: @healthy_green_border;
-    }
-    .label-terminal, .label-terminated {
-      background-color: @unhealthy_red;
-    }
-    .label-running, .label-launched {
-      background-color: @spinnaker-blue;
-    }
-    .label {
-      text-transform: uppercase;
-      border-radius: 0;
-      color: #fff;
-      font-weight: 600;
-      .glyphicon {
-        color: #ffffff;
-      }
-    }
-  }
 }
 
 .canary-config-view {


### PR DESCRIPTION
Dealing with a handful of little things:
 * Angular keeps fixing, then regressing, on this weird scenario where using `ng-class` and `class` on the same node with more than one interpolation (i.e. using `{{}}`) in the `class` causes the `ng-class` to stop working after the first application. So we're dropping it here and sticking with `class` for everything in this particular case.
 * Fixing a navigation error where clicking on the active stage would throw an exception trying to navigate to a parent state in standalone mode
 * Fixing styles for labels in the execution summary view in standalone mode
 * Adding a little transition to stage labels and bar segments in the graphs. I think it looks nice but it may be annoying, in which case we can always remove it.