### PR TITLE
do not try to set current page if it does not exist

### DIFF
--- a/app/scripts/modules/core/modal/wizard/v2modalWizard.directive.js
+++ b/app/scripts/modules/core/modal/wizard/v2modalWizard.directive.js
@@ -23,7 +23,9 @@ module.exports = angular.module('spinnaker.core.modalWizard.wizard.v2', [
 ).controller('v2ModalWizardCtrl', function($scope, v2modalWizardService) {
     $scope.wizard = v2modalWizardService;
     $scope.$on('waypoints-changed', (event, snapshot) => {
-      let ids = snapshot.lastWindow.map((entry) => entry.elem);
+      let ids = snapshot.lastWindow
+        .map((entry) => entry.elem)
+        .filter($scope.wizard.getPage);
       ids.reverse().forEach((id) => v2modalWizardService.setCurrentPage($scope.wizard.getPage(id), true));
     });
 


### PR DESCRIPTION
Not sure how this happens exactly, but sometimes a waypoint gets snapshotted on a page that's either been removed or doesn't exist. This simply guards against that scenario causing an NPE by ensuring the page exists and is registered before trying to mark it as the current page.