### PR TITLE
Add 'Prefer AMI Block Device Mappings' control to Advanced Settings t…

### DIFF
--- a/app/scripts/modules/amazon/serverGroup/configure/wizard/advancedSettings/advancedSettings.html
+++ b/app/scripts/modules/amazon/serverGroup/configure/wizard/advancedSettings/advancedSettings.html
@@ -83,6 +83,12 @@
     </div>
   </div>
   <div class="form-group">
+    <div class="col-md-5 sm-label-right"><b>AMI Block Device Mappings</b></div>
+    <div class="col-md-6 checkbox">
+      <label><input type="checkbox" ng-model="command.useAmiBlockDeviceMappings"/> Prefer AMI Block Device Mappings</label>
+    </div>
+  </div>
+  <div class="form-group">
     <div class="col-md-5 sm-label-right"><b>Associate Public IP Address</b></div>
     <div class="col-md-2 radio">
       <label>


### PR DESCRIPTION
…ab of AWS wizard.

If set, the AMI block device mappings are used for the newly-provisioned server group.

Relates to https://github.com/spinnaker/clouddriver/pull/364.