### PR TITLE
Fix for Issue#768 - Project pipeline status is incorrect

### DIFF
--- a/app/scripts/modules/core/projects/dashboard/pipeline/projectPipeline.directive.html
+++ b/app/scripts/modules/core/projects/dashboard/pipeline/projectPipeline.directive.html
@@ -7,7 +7,8 @@
   (<execution-build-number execution="vm.execution"></execution-build-number><span ng-if="vm.hasBuildInfo">, </span>started {{vm.execution.startTime | timestamp }})
   <div class="execution-bar">
     <div ng-repeat="stage in vm.execution.stageSummaries"
-         class="clickable stage execution-marker execution-marker-{{stage.status.toLowerCase()}}"
+         class="clickable stage stage-type-{{stage.type.toLowerCase()}}
+         execution-marker execution-marker-{{stage.status.toLowerCase()}}"
          ng-style="{width: vm.stageWidth, 'background-color': stage.color}"
          uib-tooltip-template="stage.labelTemplateUrl"
          tooltip-title="(Click for details)"


### PR DESCRIPTION
Fix for Issue#768. Pipelines displayed under Project don't show Judgement stage in yellow color. It shows correctly when opened in the application context. So a user wouldn't know that something needs attention by just looking at the project dashboard.
cc @anotherchrisberry 