### PR TITLE
make user data copying on clone configurable

### DIFF
--- a/app/scripts/modules/amazon/serverGroup/configure/serverGroupCommandBuilder.service.js
+++ b/app/scripts/modules/amazon/serverGroup/configure/serverGroupCommandBuilder.service.js
@@ -244,7 +244,7 @@ module.exports = angular.module('spinnaker.aws.serverGroupCommandBuilder.service
             instanceMonitoring: serverGroup.launchConfig.instanceMonitoring.enabled,
             ebsOptimized: serverGroup.launchConfig.ebsOptimized,
           });
-          if (serverGroup.launchConfig.userData) {
+          if (serverGroup.launchConfig.userData && _.get(settings, 'providers.aws.copyUserDataOnClone')) {
             command.base64UserData = serverGroup.launchConfig.userData;
           }
           command.viewState.imageId = serverGroup.launchConfig.imageId;

--- a/settings.js
+++ b/settings.js
@@ -26,6 +26,7 @@ window.spinnakerSettings = {
         region: 'us-east-1'
       },
       defaultSecurityGroups: ['nf-datacenter-vpc', 'nf-infrastructure-vpc', 'nf-datacenter', 'nf-infrastructure'],
+      copyUserDataOnClone: true,
     },
     gce: {
       defaults: {


### PR DESCRIPTION
Unfortunately, Netflix does not want to copy over user data from the ancestor ASG, so we need a way to disable this behavior.

@duftler please review