### PR TITLE
core/account: properly handle generic behavior in `getUniqueAttributeForAllAccounts`

### DIFF
--- a/app/scripts/modules/core/account/account.service.js
+++ b/app/scripts/modules/core/account/account.service.js
@@ -102,7 +102,7 @@ module.exports = angular.module('spinnaker.core.account.service', [
               .values()
               .map(acct => acct[attribute])
               .flatten()
-              .map(reg => reg.name)
+              .map(reg => reg.name || reg)
               .uniq()
               .value();
 


### PR DESCRIPTION
I realized the above function won't extract an attribute that doesn't have a `.name` field.