### PR TITLE
do not instantiate instance details until application is loaded

### DIFF
--- a/app/scripts/modules/amazon/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/amazon/instance/details/instance.details.controller.js
@@ -362,7 +362,11 @@ module.exports = angular.module('spinnaker.instance.detail.aws.controller', [
       );
     };
 
-    retrieveInstance().then(() => {
+    let initialize = app.isStandalone ?
+      retrieveInstance() :
+      $q.all([app.serverGroups.ready(), app.loadBalancers.ready()]).then(retrieveInstance);
+
+    initialize.then(() => {
       // Two things to look out for here:
       //  1. If the retrieveInstance call completes *after* the user has navigated away from the view, there
       //     is no point in subscribing to the refresh

--- a/app/scripts/modules/amazon/instance/details/instance.details.controller.spec.js
+++ b/app/scripts/modules/amazon/instance/details/instance.details.controller.spec.js
@@ -60,6 +60,11 @@ describe('Controller: awsInstanceDetailsCtrl', function () {
         })
       );
       var application = {};
+
+      applicationReader.addSectionToApplication({key: 'loadBalancers', lazy: true}, application);
+      application.loadBalancers.data = [];
+      application.loadBalancers.loaded = true;
+
       applicationReader.addSectionToApplication({key: 'serverGroups', lazy: true}, application);
       application.serverGroups.data = [
         {
@@ -75,6 +80,7 @@ describe('Controller: awsInstanceDetailsCtrl', function () {
           ]
         }
       ];
+      application.serverGroups.loaded = true;
 
       this.createController(application, params);
       scope.$digest();
@@ -102,6 +108,11 @@ describe('Controller: awsInstanceDetailsCtrl', function () {
       );
 
       var application = {};
+
+      applicationReader.addSectionToApplication({key: 'loadBalancers', lazy: true}, application);
+      application.loadBalancers.data = [];
+      application.loadBalancers.loaded = true;
+
       applicationReader.addSectionToApplication({key: 'serverGroups', lazy: true}, application);
       application.serverGroups.data = [
         {
@@ -117,6 +128,7 @@ describe('Controller: awsInstanceDetailsCtrl', function () {
           ]
         }
       ];
+      application.serverGroups.loaded = true;
 
       this.createController(application, params);
       scope.$digest();

--- a/app/scripts/modules/azure/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/azure/instance/details/instance.details.controller.js
@@ -361,7 +361,11 @@ module.exports = angular.module('spinnaker.azure.instance.detail.controller', [
       );
     };
 
-    retrieveInstance().then(() => {
+    let initialize = app.isStandalone ?
+      retrieveInstance() :
+      $q.all([app.serverGroups.ready(), app.loadBalancers.ready()]).then(retrieveInstance);
+
+    initialize.then(() => {
       // Two things to look out for here:
       //  1. If the retrieveInstance call completes *after* the user has navigated away from the view, there
       //     is no point in subscribing to the refresh

--- a/app/scripts/modules/azure/instance/details/instance.details.controller.spec.js
+++ b/app/scripts/modules/azure/instance/details/instance.details.controller.spec.js
@@ -55,6 +55,11 @@ describe('Controller: azureInstanceDetailsCtrl', function () {
         })
       );
       var application = {};
+
+      applicationReader.addSectionToApplication({key: 'loadBalancers', lazy: true}, application);
+      application.loadBalancers.data = [];
+      application.loadBalancers.loaded = true;
+
       applicationReader.addSectionToApplication({key: 'serverGroups', lazy: true}, application);
       application.serverGroups.data = [
         {
@@ -70,6 +75,7 @@ describe('Controller: azureInstanceDetailsCtrl', function () {
           ]
         }
       ];
+      application.serverGroups.loaded = true;
 
       this.createController(application, params);
       scope.$digest();
@@ -97,6 +103,11 @@ describe('Controller: azureInstanceDetailsCtrl', function () {
       );
 
       var application = {};
+
+      applicationReader.addSectionToApplication({key: 'loadBalancers', lazy: true}, application);
+      application.loadBalancers.data = [];
+      application.loadBalancers.loaded = true;
+
       applicationReader.addSectionToApplication({key: 'serverGroups', lazy: true}, application);
       application.serverGroups.data = [
         {
@@ -112,6 +123,7 @@ describe('Controller: azureInstanceDetailsCtrl', function () {
           ]
         }
       ];
+      application.serverGroups.loaded = true;
 
       this.createController(application, params);
       scope.$digest();

--- a/app/scripts/modules/cloudfoundry/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/cloudfoundry/instance/details/instance.details.controller.js
@@ -343,7 +343,11 @@ module.exports = angular.module('spinnaker.instance.detail.cf.controller', [
       );
     };
 
-    retrieveInstance().then(() => {
+    let initialize = app.isStandalone ?
+      retrieveInstance() :
+      $q.all([app.serverGroups.ready(), app.loadBalancers.ready()]).then(retrieveInstance);
+
+    initialize.then(() => {
       // Two things to look out for here:
       //  1. If the retrieveInstance call completes *after* the user has navigated away from the view, there
       //     is no point in subscribing to the refresh

--- a/app/scripts/modules/cloudfoundry/instance/details/instance.details.controller.spec.js
+++ b/app/scripts/modules/cloudfoundry/instance/details/instance.details.controller.spec.js
@@ -2,9 +2,7 @@
 
 describe('Controller: cfInstanceDetailsCtrl', function () {
 
-  const angular = require('angular');
   //NOTE: This is only testing the controllers dependencies. Please add more tests.
-
   var controller;
   var scope;
 
@@ -20,7 +18,7 @@ describe('Controller: cfInstanceDetailsCtrl', function () {
       controller = $controller('cfInstanceDetailsCtrl', {
         $scope: scope,
         instance: {},
-        app: {}
+        app: { isStandalone: true},
       });
     })
   );

--- a/app/scripts/modules/core/orchestratedItem/orchestratedItem.transformer.spec.js
+++ b/app/scripts/modules/core/orchestratedItem/orchestratedItem.transformer.spec.js
@@ -2,23 +2,23 @@
 
 describe('orchestratedItem transformer', function () {
   var transformer;
-  
+
   beforeEach(window.module(
     require('./orchestratedItem.transformer')
   ));
-  
+
   beforeEach(window.inject(function(orchestratedItemTransformer) {
     transformer = orchestratedItemTransformer;
   }));
-  
+
   describe('failure message extraction', function () {
 
     let getMessage = (obj) => {
       transformer.defineProperties(obj);
       return obj.failureMessage;
     };
-    
-    
+
+
     it('returns null when no stage context', function() {
       expect(getMessage({})).toBe(null);
     });

--- a/app/scripts/modules/google/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/google/instance/details/instance.details.controller.js
@@ -418,7 +418,11 @@ module.exports = angular.module('spinnaker.instance.detail.gce.controller', [
       );
     };
 
-    retrieveInstance().then(() => {
+    let initialize = app.isStandalone ?
+      retrieveInstance() :
+      $q.all([app.serverGroups.ready(), app.loadBalancers.ready()]).then(retrieveInstance);
+
+    initialize.then(() => {
       // Two things to look out for here:
       //  1. If the retrieveInstance call completes *after* the user has navigated away from the view, there
       //     is no point in subscribing to the refresh

--- a/app/scripts/modules/google/instance/details/instance.details.controller.spec.js
+++ b/app/scripts/modules/google/instance/details/instance.details.controller.spec.js
@@ -1,8 +1,6 @@
 'use strict';
 
 describe('Controller: gceInstanceDetailsCtrl', function () {
-
-  const angular = require('angular');
   //NOTE: This is only testing the controllers dependencies. Please add more tests.
 
   var controller;
@@ -20,7 +18,7 @@ describe('Controller: gceInstanceDetailsCtrl', function () {
       controller = $controller('gceInstanceDetailsCtrl', {
         $scope: scope,
         instance: {},
-        app: {}
+        app: { isStandalone: true},
       });
     })
   );

--- a/app/scripts/modules/titan/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/titan/instance/details/instance.details.controller.js
@@ -212,7 +212,11 @@ module.exports = angular.module('spinnaker.instance.detail.titan.controller', [
       );
     };
 
-    retrieveInstance().then(() => {
+    let initialize = app.isStandalone ?
+      retrieveInstance() :
+      app.serverGroups.ready().then(retrieveInstance);
+
+    initialize.then(() => {
       // Two things to look out for here:
       //  1. If the retrieveInstance call completes *after* the user has navigated away from the view, there
       //     is no point in subscribing to the refresh


### PR DESCRIPTION
Deep linking to an instance almost never works right now, because we expect the server groups and load balancers to be there. If they're not (and, again, they almost always not), the details panel closes, assuming the instance is gone.

This changes that behavior by waiting for any supporting data sources (server groups, load balancers) to be ready before trying to initialize the instance details.

@robfletcher this fixes what we were seeing earlier this afternoon with deep links not working to instances.