### PR TITLE
Minor tweaks to validation of server group creation

### DIFF
--- a/app/scripts/modules/azure/serverGroup/configure/wizard/securityGroup/ServerGroupSecurityGroups.controller.js
+++ b/app/scripts/modules/azure/serverGroup/configure/wizard/securityGroup/ServerGroupSecurityGroups.controller.js
@@ -8,4 +8,8 @@ module.exports = angular.module('spinnaker.azure.serverGroup.configure.securityG
   .controller('azureServerGroupSecurityGroupsCtrl', function(v2modalWizardService) {
     v2modalWizardService.markClean('security-groups');
     v2modalWizardService.markComplete('security-groups');
+
+    this.securityGroupChanged = () => {
+      v2modalWizardService.markComplete('security-groups');
+    };
   });

--- a/app/scripts/modules/azure/serverGroup/configure/wizard/securityGroup/serverGroupSecurityGroupsSelector.directive.html
+++ b/app/scripts/modules/azure/serverGroup/configure/wizard/securityGroup/serverGroupSecurityGroupsSelector.directive.html
@@ -1,9 +1,9 @@
 <h5 class="text-center" ng-if="!command.viewState.securityGroupsConfigured">Please select an account and region.</h5>
-<div ng-if="command.viewState.securityGroupsConfigured">
+<div ng-if="command.viewState.securityGroupsConfigured"  ng-controller="azureServerGroupSecurityGroupsCtrl as securityGroupCtrl">
   <div class="form-group">
     <div class="col-md-3 sm-label-right"><b>Security Groups</b></div>
     <div class="col-md-9">
-      <ui-select ng-model="command.selectedSecurityGroup" class="form-control input-sm">
+      <ui-select ng-model="command.selectedSecurityGroup" class="form-control input-sm" on-select="securityGroupCtrl.securityGroupChanged()">
         <ui-select-match placeholder="select a security group">{{$select.selected.id}}</ui-select-match>
         <ui-select-choices repeat="securityGroup as securityGroup in command.backingData.filtered.securityGroups | anyFieldFilter: {name: $select.search, id: $select.search}">
           <span ng-bind-html="securityGroup.id | highlight: $select.search"></span>

--- a/app/scripts/modules/azure/serverGroup/configure/wizard/serverGroupWizard.html
+++ b/app/scripts/modules/azure/serverGroup/configure/wizard/serverGroupWizard.html
@@ -10,10 +10,10 @@
       <v2-wizard-page key="basic-settings" label="Basic Settings" hide-subheading="true">
         <ng-include src="pages.basicSettings"></ng-include>
       </v2-wizard-page>
-      <v2-wizard-page key="load-balancers" label="Load Balancers">
+      <v2-wizard-page key="load-balancers" label="Load Balancers" mark-complete-on-view="false">
         <ng-include src="pages.loadBalancers"></ng-include>
       </v2-wizard-page>
-      <v2-wizard-page key="security-groups" label="Security Groups">
+      <v2-wizard-page key="security-groups" label="Security Groups" mark-complete-on-view="false">
         <ng-include src="pages.securityGroups"></ng-include>
       </v2-wizard-page>
       <v2-wizard-page key="capacity" label="Capacity">

--- a/app/scripts/modules/azure/serverGroup/configure/wizard/serverGroupWizard.html
+++ b/app/scripts/modules/azure/serverGroup/configure/wizard/serverGroupWizard.html
@@ -10,17 +10,10 @@
       <v2-wizard-page key="basic-settings" label="Basic Settings" hide-subheading="true">
         <ng-include src="pages.basicSettings"></ng-include>
       </v2-wizard-page>
-<<<<<<< HEAD
       <v2-wizard-page key="load-balancers" label="Load Balancers" mark-complete-on-view="false">
         <ng-include src="pages.loadBalancers"></ng-include>
       </v2-wizard-page>
       <v2-wizard-page key="security-groups" label="Security Groups" mark-complete-on-view="false">
-=======
-      <v2-wizard-page key="load-balancers" label="Load Balancers" markCompleteOnView="false">
-        <ng-include src="pages.loadBalancers"></ng-include>
-      </v2-wizard-page>
-      <v2-wizard-page key="security-groups" label="Security Groups" markCompleteOnView="false">
->>>>>>> 4600efc... Minor tweaks to validation of server group creation
         <ng-include src="pages.securityGroups"></ng-include>
       </v2-wizard-page>
       <v2-wizard-page key="capacity" label="Capacity">

--- a/app/scripts/modules/azure/serverGroup/configure/wizard/serverGroupWizard.html
+++ b/app/scripts/modules/azure/serverGroup/configure/wizard/serverGroupWizard.html
@@ -10,10 +10,17 @@
       <v2-wizard-page key="basic-settings" label="Basic Settings" hide-subheading="true">
         <ng-include src="pages.basicSettings"></ng-include>
       </v2-wizard-page>
+<<<<<<< HEAD
       <v2-wizard-page key="load-balancers" label="Load Balancers" mark-complete-on-view="false">
         <ng-include src="pages.loadBalancers"></ng-include>
       </v2-wizard-page>
       <v2-wizard-page key="security-groups" label="Security Groups" mark-complete-on-view="false">
+=======
+      <v2-wizard-page key="load-balancers" label="Load Balancers" markCompleteOnView="false">
+        <ng-include src="pages.loadBalancers"></ng-include>
+      </v2-wizard-page>
+      <v2-wizard-page key="security-groups" label="Security Groups" markCompleteOnView="false">
+>>>>>>> 4600efc... Minor tweaks to validation of server group creation
         <ng-include src="pages.securityGroups"></ng-include>
       </v2-wizard-page>
       <v2-wizard-page key="capacity" label="Capacity">


### PR DESCRIPTION
A few minor tweaks for validation of the server group creation
Changed the casing of markcompleteonview in v2wizardPage.directive.js as angular is normalizing the attribute names in methods on link: in directives. This resulted in the test markCompleteOnReview !== 'false' always returning true.

**_Note that there are other instances of mixed casing for attributes on other directives that should be reviewed for subtle bugs like this one._**

@anotherchrisberry @duftler PTAL