### PR TITLE
make internal flag for load balancers configurable

### DIFF
--- a/app/scripts/modules/amazon/loadBalancer/configure/createLoadBalancer.controller.js
+++ b/app/scripts/modules/amazon/loadBalancer/configure/createLoadBalancer.controller.js
@@ -103,6 +103,12 @@ module.exports = angular.module('spinnaker.loadBalancer.aws.create.controller', 
       if (_.has(settings, 'providers.aws.defaultSecurityGroups')) {
         defaultSecurityGroups = settings.providers.aws.defaultSecurityGroups;
       }
+      if (_.has(settings, 'providers.aws.loadBalancers.inferInternalFlagFromSubnet')) {
+        if (settings.providers.aws.loadBalancers.inferInternalFlagFromSubnet) {
+          delete $scope.loadBalancer.isInternal;
+          $scope.state.hideInternalFlag = true;
+        }
+      }
       accountService.listAccounts('aws').then(function (accounts) {
         $scope.accounts = accounts;
         $scope.state.accountsLoaded = true;

--- a/app/scripts/modules/amazon/loadBalancer/configure/createLoadBalancerProperties.html
+++ b/app/scripts/modules/amazon/loadBalancer/configure/createLoadBalancerProperties.html
@@ -55,17 +55,6 @@
       </div>
     </div>
 
-    <!--Adding support for public facing elb. Display only for vpc-->
-    <div class="form-group" ng-if="loadBalancer.vpcId">
-      <div class="col-md-3 sm-label-right"><b>Internal</b></div>
-      <div class="col-md-7 checkbox">
-        <label><input type="checkbox"
-                      ng-model="loadBalancer.isInternal"/>
-          Create an internal load balancer
-        </label>
-      </div>
-    </div>
-
     <div class="form-group">
       <div class="col-md-9 col-md-offset-3" ng-if="form.loadBalancerName.$error.maxlength">
         <validation-error message="Load Balancer name can only be 32 characters."></validation-error>
@@ -81,5 +70,16 @@
     </load-balancer-availability-zone-selector>
 
     <subnet-select-field label-columns="3" help-key="aws.loadBalancer.subnet" component="loadBalancer" field="subnetType" region="loadBalancer.region" subnets="subnets" on-change="ctrl.subnetUpdated()"></subnet-select-field>
+    <!--Adding support for public facing elb. Display only for vpc-->
+    <div class="form-group" ng-if="loadBalancer.vpcId && !state.hideInternalFlag">
+      <div class="col-md-3 sm-label-right"><b>Internal</b></div>
+      <div class="col-md-7 checkbox">
+        <label><input type="checkbox"
+                      ng-model="loadBalancer.isInternal"/>
+          Create an internal load balancer
+        </label>
+      </div>
+    </div>
+
   </div>
 </form>

--- a/settings.js
+++ b/settings.js
@@ -26,6 +26,11 @@ window.spinnakerSettings = {
         region: 'us-east-1'
       },
       defaultSecurityGroups: ['nf-datacenter-vpc', 'nf-infrastructure-vpc', 'nf-datacenter', 'nf-infrastructure'],
+      loadBalancers: {
+        // if true, VPC load balancers will be created as internal load balancers iff the selected subnet has a purpose
+        // tag that starts with "internal"
+        inferInternalFlagFromSubnet: false,
+      },
     },
     gce: {
       defaults: {


### PR DESCRIPTION
A couple of changes:
 1. Move the checkbox for "Internal" below the VPC/Subnet select field. Since the checkbox only appears after the user selects a subnet, the checkbox should not be above the select field.
 2. Make the checkbox optional via a configuration setting. This is a feature needed at Netflix, since we've traditionally assigned the `internal` flag value based on the purpose or name of the subnet.