### PR TITLE
extract regions for AWS bake stage from credentials

### DIFF
--- a/app/scripts/modules/core/account/account.service.js
+++ b/app/scripts/modules/core/account/account.service.js
@@ -98,9 +98,8 @@ module.exports = angular.module('spinnaker.core.account.service', [
       return _.memoize((provider) => {
         return getCredentialsKeyedByAccount(provider)
           .then(function(credentialsByAccount) {
-            let attributes = _.chain(credentialsByAccount)
-              .values()
-              .map(acct => acct[attribute])
+            let attributes = _(credentialsByAccount)
+              .pluck(attribute)
               .flatten()
               .map(reg => reg.name || reg)
               .uniq()
@@ -114,9 +113,8 @@ module.exports = angular.module('spinnaker.core.account.service', [
     let getUniqueGceZonesForAllAccounts = _.memoize((provider) => {
       return getCredentialsKeyedByAccount(provider)
         .then(function(regionsByAccount) {
-          return _.chain(regionsByAccount)
-            .values()
-            .map(acct => acct.regions)
+          return _(regionsByAccount)
+            .pluck('regions')
             .flatten()
             .reduce((acc, obj) => {
               Object.keys(obj).forEach((key) => {

--- a/app/scripts/modules/core/pipeline/config/stages/bake/bakery.service.js
+++ b/app/scripts/modules/core/pipeline/config/stages/bake/bakery.service.js
@@ -4,16 +4,16 @@ let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.bake.service', [
   require('exports?"restangular"!imports?_=lodash!restangular'),
+  require('../../../../account/account.service.js'),
+  require('../../../../config/settings.js'),
 ])
-  .factory('bakeryService', function($q, _, Restangular) {
+  .factory('bakeryService', function($q, _, Restangular, accountService, settings) {
 
     function getRegions(provider) {
-      if (!provider || provider === 'aws') {
-        return $q.when(['us-east-1', 'us-west-1', 'us-west-2', 'eu-west-1']);
+      if (_.has(settings, `providers.${provider}.bakeryRegions`)) {
+        return $q.when(_.get(settings, `providers.${provider}.bakeryRegions`));
       }
-      if (provider === 'gce') {
-        return $q.when(['asia-east1', 'us-central1', 'europe-west1']);
-      }
+      return accountService.getUniqueAttributeForAllAccounts('regions')(provider).then(regions => regions.sort());
     }
 
     function getBaseOsOptions(provider) {


### PR DESCRIPTION
Someone asked earlier today why the regions in the AWS bake stage are always `us-east-1`, `us-west-1`, `us-west-2`, and `eu-west-1`. I couldn't bring myself to say "look at L12 of bakery.service.js, and you'll see that we hard-coded it that way, but we return a promise to make you think we're getting them from some external data source", even if that is true. I didn't even respond at all. I made Tomás do it.

In a perfect world, where we never had users, this PR would be basically one line: replacing the `getRegions` method in the bakery service with:
```javascript
accountService.getUniqueAttributeForAllAccounts('regions')(provider).then(regions => regions.sort());
```

But in our world, we have users who have seen those four regions in that order for over a year, so they've probably gotten used to them, and they'll probably yell at us if we change the order. So I've added an escape hatch via the settings.

Other approaches I considered:
 * create an Angular filter to sort an arbitrary list of strings based on some configuration value - I actually started down this route and had it working, but it seemed overkill, since we haven't needed it yet and it was getting messy when I tried to apply it to the regions in the regionSelectField directive, which has objects instead of strings for the regions
* providing the override via the netflix module - we may end up doing it this way later, but settings.js is the path of least resistance for this change

(The changes to account.service.js are totally unrelated, just wanted to clean some things up while I was looking at them)

@zanthrash please review