### PR TITLE
Fix license and repo warning for "npm install"

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,11 @@
   "main": "./dist/bundle.js",
   "name": "deck",
   "version": "0.0.0",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/spinnaker/deck.git"
+  },
   "publishConfig": {
     "registry": "http://artifacts.netflix.com/api/npm/npm-local"
   },


### PR DESCRIPTION
This is to fix the following warnings that appear when you run "npm install"

npm WARN package.json deck@0.0.0 No repository field.
npm WARN package.json deck@0.0.0 No license field.