### PR TITLE
Fix CAP error that caused namespace collision between Kubernetes and …

### DIFF
--- a/app/scripts/modules/kubernetes/serverGroup/details/resize/resize.controller.js
+++ b/app/scripts/modules/kubernetes/serverGroup/details/resize/resize.controller.js
@@ -2,7 +2,7 @@
 
 let angular = require('angular');
 
-module.exports = angular.module('spinnaker.google.serverGroup.details.resize.controller', [
+module.exports = angular.module('spinnaker.kubernetes.serverGroup.details.resize.controller', [
   require('../../../../core/application/modal/platformHealthOverride.directive.js'),
   require('../../../../core/task/modal/reason.directive.js'),
   require('../../../../core/serverGroup/serverGroup.write.service.js'),


### PR DESCRIPTION
…Google resize server group controllers.