### PR TITLE
only include group name once when warning about removed security grou…

### DIFF
--- a/app/scripts/modules/amazon/securityGroup/configure/configSecurityGroup.mixin.controller.js
+++ b/app/scripts/modules/amazon/securityGroup/configure/configSecurityGroup.mixin.controller.js
@@ -201,7 +201,7 @@ module.exports = angular
     function clearInvalidSecurityGroups() {
       var removed = $scope.state.removedRules;
       $scope.securityGroup.securityGroupIngress = $scope.securityGroup.securityGroupIngress.filter(function(rule) {
-        if (rule.name && $scope.availableSecurityGroups.indexOf(rule.name) === -1) {
+        if (rule.name && $scope.availableSecurityGroups.indexOf(rule.name) === -1 && removed.indexOf(rule.name) === -1) {
           removed.push(rule.name);
           return false;
         }

--- a/app/scripts/modules/azure/securityGroup/configure/configSecurityGroup.mixin.controller.js
+++ b/app/scripts/modules/azure/securityGroup/configure/configSecurityGroup.mixin.controller.js
@@ -166,7 +166,7 @@ module.exports = angular
     function clearInvalidSecurityGroups() {
       var removed = $scope.state.removedRules;
       $scope.securityGroup.securityGroupIngress = $scope.securityGroup.securityGroupIngress.filter(function(rule) {
-        if (rule.name && $scope.availableSecurityGroups.indexOf(rule.name) === -1) {
+        if (rule.name && $scope.availableSecurityGroups.indexOf(rule.name) === -1 && removed.indexOf(rule.name) === -1) {
           removed.push(rule.name);
           return false;
         }


### PR DESCRIPTION
…p rules

When the user switches account, region, or vpcId (or when they clone an existing security group, which has a rule that's not valid because the other security group has been deleted, I guess that can happen), we remove any rules that can't be mapped because there isn't a security group in the new location with the same name.

The warning in the modal just shows the removed group's name, which it does via `ng-repeat`. If there are multiple rules, e.g. HTTP and HTTPS, that get removed, we currently include the same removed name multiple times, which blows up Angular. This small change prevents that from happening.