### PR TITLE
add skipValidation, custom validator functions to pipeline config

### DIFF
--- a/app/scripts/modules/core/pipeline/config/validation/pipelineConfigValidation.service.js
+++ b/app/scripts/modules/core/pipeline/config/validation/pipelineConfigValidation.service.js
@@ -121,6 +121,9 @@ module.exports = angular.module('spinnaker.core.pipeline.config.validator.servic
         let config = pipelineConfig.getStageConfig(stage);
         if (config && config.validators) {
           config.validators.forEach(function(validator) {
+            if (validator.skipValidation && validator.skipValidation(pipeline, stage)) {
+              return;
+            }
             switch(validator.type) {
               case 'stageOrTriggerBeforeType':
                 validators.stageOrTriggerBeforeType(pipeline, index, validator, messages);
@@ -133,6 +136,9 @@ module.exports = angular.module('spinnaker.core.pipeline.config.validator.servic
                 break;
               case 'requiredField':
                 validators.checkRequiredField(pipeline, stage, validator, config, messages);
+                break;
+              case 'custom':
+                validator.validator(pipeline, stage, validator, config, messages);
                 break;
               default:
                 $log.warn('No validator of type "' + validator.type + '" found, ignoring validation on stage "' + stage.name + '" (' + stage.type + ')');


### PR DESCRIPTION
* adds a custom validator type for pipeline stages
* adds a `skipValidation` option for validator configurations, allowing a particular validator to not run if the function returns `true`

Utilizing the `skipValidation` method for Cloud Foundry server groups, so they don't throw warnings without a `findImage` or `bake` stage preceding them. If there are multiple clusters in the deploy stage and one of them is _not_ CF, it'll still show the warning.

Should fix https://github.com/spinnaker/spinnaker/issues/639