### PR TITLE
Fix duplicate form elements causing naming failure

### DIFF
--- a/app/scripts/modules/amazon/serverGroup/configure/wizard/advancedSettings/advancedSettings.html
+++ b/app/scripts/modules/amazon/serverGroup/configure/wizard/advancedSettings/advancedSettings.html
@@ -1,4 +1,4 @@
-<form name="form" class="container-fluid form-horizontal" novalidate>
+<div class="container-fluid form-horizontal">
   <div class="form-group">
     <div class="col-md-5 sm-label-right"><b>Cooldown</b></div>
     <div class="col-md-2"><input type="text" required
@@ -138,4 +138,4 @@
     </div>
     <map-editor model="command.tags" allow-empty="true"></map-editor>
   </div>
-</form>
+</div>

--- a/app/scripts/modules/amazon/serverGroup/configure/wizard/capacity/zones.html
+++ b/app/scripts/modules/amazon/serverGroup/configure/wizard/capacity/zones.html
@@ -1,4 +1,4 @@
-<form class="container-fluid form-horizontal" name="form" novalidate>
+<div class="container-fluid form-horizontal">
   <availability-zone-selector command="command"></availability-zone-selector>
   <az-rebalance-selector command="command"></az-rebalance-selector>
-</form>
+</div>

--- a/app/scripts/modules/amazon/serverGroup/configure/wizard/location/basicSettings.html
+++ b/app/scripts/modules/amazon/serverGroup/configure/wizard/location/basicSettings.html
@@ -1,4 +1,4 @@
-<form name="form" class="container-fluid form-horizontal" ng-controller="awsServerGroupBasicSettingsCtrl as basicSettingsCtrl" novalidate>
+<div class="container-fluid form-horizontal" ng-controller="awsServerGroupBasicSettingsCtrl as basicSettingsCtrl">
     <ng-form name="basicSettings">
       <div class="form-group row" ng-if="command.regionIsDeprecated()">
         <div class="col-md-12 error-message">
@@ -130,4 +130,4 @@
       </div>
     </ng-form>
     <task-reason command="command"></task-reason>
-</form>
+</div>

--- a/app/scripts/modules/amazon/serverGroup/configure/wizard/serverGroupWizard.html
+++ b/app/scripts/modules/amazon/serverGroup/configure/wizard/serverGroupWizard.html
@@ -6,7 +6,7 @@
     <h3 us-spinner="{radius:30, width:8, length: 16}"></h3>
   </div>
   <div ng-if="!state.requiresTemplateSelection">
-    <form name="form" class="form-horizontal">
+    <form name="form" class="form-horizontal" novalidate>
       <v2-modal-wizard ng-show="state.loaded" heading="{{title}}">
         <v2-wizard-page key="location" label="Basic Settings" mark-complete-on-view="false">
           <ng-include src="pages.basicSettings"></ng-include>

--- a/app/scripts/modules/azure/serverGroup/configure/wizard/basicSettings/basicSettings.html
+++ b/app/scripts/modules/azure/serverGroup/configure/wizard/basicSettings/basicSettings.html
@@ -1,5 +1,4 @@
-<form name="form" class="container-fluid form-horizontal" ng-controller="azureServerGroupBasicSettingsCtrl as basicSettingsCtrl"
-novalidate>
+<div class="container-fluid form-horizontal" ng-controller="azureServerGroupBasicSettingsCtrl as basicSettingsCtrl">
   <div class="modal-body">
     <ng-form name="basicSettings">
       <div class="form-group">
@@ -94,4 +93,4 @@ novalidate>
       </div>
     </ng-form>
   </div>
-</form>
+</div>

--- a/app/scripts/modules/azure/serverGroup/configure/wizard/serverGroupWizard.html
+++ b/app/scripts/modules/azure/serverGroup/configure/wizard/serverGroupWizard.html
@@ -6,7 +6,7 @@
     <h3 us-spinner="{radius:30, width:8, length: 16}"></h3>
   </div>
   <div>
-    <form name="serverGroupWizardForm" class="form-horizontal">
+    <form name="serverGroupWizardForm" class="form-horizontal" novalidate>
       <v2-modal-wizard ng-show="state.loaded && !state.requiresTemplateSelection" heading="{{title}}">
         <v2-wizard-page key="basic-settings" label="Basic Settings" hide-subheading="true">
           <ng-include src="pages.basicSettings"></ng-include>

--- a/app/scripts/modules/google/serverGroup/configure/wizard/basicSettings.html
+++ b/app/scripts/modules/google/serverGroup/configure/wizard/basicSettings.html
@@ -1,4 +1,4 @@
-<form name="form" class="container-fluid form-horizontal" ng-controller="gceServerGroupBasicSettingsCtrl as basicSettingsCtrl" novalidate>
+<div class="container-fluid form-horizontal" ng-controller="gceServerGroupBasicSettingsCtrl as basicSettingsCtrl">
   <ng-form name="basicSettings">
     <div class="form-group">
       <div class="col-md-3 sm-label-right">
@@ -120,4 +120,4 @@
     </div>
   </ng-form>
   <task-reason command="command"></task-reason>
-</form>
+</div>

--- a/app/scripts/modules/google/serverGroup/configure/wizard/serverGroupWizard.html
+++ b/app/scripts/modules/google/serverGroup/configure/wizard/serverGroupWizard.html
@@ -6,7 +6,7 @@
     <h3 us-spinner="{radius:30, width:8, length: 16}"></h3>
   </div>
   <div ng-if="!state.requiresTemplateSelection">
-    <form name="form" class="form-horizontal">
+    <form name="form" class="form-horizontal" novalidate>
       <v2-modal-wizard ng-show="state.loaded" heading="{{title}}">
         <v2-wizard-page key="location" label="Basic Settings" mark-complete-on-view="false">
           <ng-include src="pages.basicSettings"></ng-include>


### PR DESCRIPTION
Having a form element in the basicSettings.html is causing a conflict with the newly added form tag in the ServerGroupWizard.html file which resulted in the call into the naming service not being executed.

This changes the form in basic settings to a div and adds a novalidate attribute to the form element on ServerGroupWizard.html.

@anotherchrisberry @duftler PTAL I have validated the Azure and AWS fix but I don't have a GCE account.  I also noticed that several of the other child pages in Google also have form elements but the remaining AWS pages do not (nor do the Azure). So there may yet be some side affects, particularly in Google.