### PR TITLE
make form top-level node in AWS clone server group modal

### DIFF
--- a/app/scripts/modules/amazon/serverGroup/configure/wizard/serverGroupWizard.html
+++ b/app/scripts/modules/amazon/serverGroup/configure/wizard/serverGroupWizard.html
@@ -1,4 +1,4 @@
-<div>
+<form name="form" class="form-horizontal" novalidate>
   <div ng-if="state.requiresTemplateSelection">
     <ng-include src="pages.templateSelection"></ng-include>
   </div>
@@ -6,35 +6,33 @@
     <h3 us-spinner="{radius:30, width:8, length: 16}"></h3>
   </div>
   <div ng-if="!state.requiresTemplateSelection">
-    <form name="form" class="form-horizontal" novalidate>
-      <v2-modal-wizard ng-show="state.loaded" heading="{{title}}">
-        <v2-wizard-page key="location" label="Basic Settings" mark-complete-on-view="false">
-          <ng-include src="pages.basicSettings"></ng-include>
-        </v2-wizard-page>
-        <v2-wizard-page key="load-balancers" label="Load Balancers" done="true">
-          <ng-include src="pages.loadBalancers"></ng-include>
-        </v2-wizard-page>
-        <v2-wizard-page key="security-groups" label="Security Groups" done="true">
-          <ng-include src="pages.securityGroups"></ng-include>
-        </v2-wizard-page>
-        <v2-wizard-page key="instance-type" label="Instance Type" mark-complete-on-view="false">
-          <ng-include src="pages.instanceType"></ng-include>
-        </v2-wizard-page>
-        <v2-wizard-page key="capacity" label="Capacity" done="true">
-          <ng-include src="pages.capacity"></ng-include>
-        </v2-wizard-page>
-        <v2-wizard-page key="zones" label="Availability Zones" done="true">
-          <ng-include src="pages.zones"></ng-include>
-        </v2-wizard-page>
-        <v2-wizard-page key="advanced" label="Advanced Settings" done="true">
-          <ng-include src="pages.advancedSettings"></ng-include>
-        </v2-wizard-page>
-      </v2-modal-wizard>
-      <div class="modal-footer" ng-if="state.loaded">
-        <button ng-disabled="taskMonitor.submitting" class="btn btn-default btn-cancel" ng-click="ctrl.cancel()">Cancel</button>
-        <submit-button ng-if="ctrl.showSubmitButton()" is-disabled="!ctrl.isValid() || taskMonitor.submitting" label="command.viewState.submitButtonLabel"
-        submitting="taskMonitor.submitting" on-click="ctrl.submit()" is-new="true"></submit-button>
-      </div>
-    </form>
+    <v2-modal-wizard ng-show="state.loaded" heading="{{title}}">
+      <v2-wizard-page key="location" label="Basic Settings" mark-complete-on-view="false">
+        <ng-include src="pages.basicSettings"></ng-include>
+      </v2-wizard-page>
+      <v2-wizard-page key="load-balancers" label="Load Balancers" done="true">
+        <ng-include src="pages.loadBalancers"></ng-include>
+      </v2-wizard-page>
+      <v2-wizard-page key="security-groups" label="Security Groups" done="true">
+        <ng-include src="pages.securityGroups"></ng-include>
+      </v2-wizard-page>
+      <v2-wizard-page key="instance-type" label="Instance Type" mark-complete-on-view="false">
+        <ng-include src="pages.instanceType"></ng-include>
+      </v2-wizard-page>
+      <v2-wizard-page key="capacity" label="Capacity" done="true">
+        <ng-include src="pages.capacity"></ng-include>
+      </v2-wizard-page>
+      <v2-wizard-page key="zones" label="Availability Zones" done="true">
+        <ng-include src="pages.zones"></ng-include>
+      </v2-wizard-page>
+      <v2-wizard-page key="advanced" label="Advanced Settings" done="true">
+        <ng-include src="pages.advancedSettings"></ng-include>
+      </v2-wizard-page>
+    </v2-modal-wizard>
+    <div class="modal-footer" ng-if="state.loaded">
+      <button ng-disabled="taskMonitor.submitting" class="btn btn-default btn-cancel" ng-click="ctrl.cancel()">Cancel</button>
+      <submit-button ng-if="ctrl.showSubmitButton()" is-disabled="!ctrl.isValid() || taskMonitor.submitting" label="command.viewState.submitButtonLabel"
+      submitting="taskMonitor.submitting" on-click="ctrl.submit()" is-new="true"></submit-button>
+    </div>
   </div>
-</div>
+</form>


### PR DESCRIPTION
need this to keep Angular from blowing up, since the controller has a reference to the form, which is currently nested in an `ng-if`'d element which seems to cause grief on instantiation of the modal.