### PR TITLE
provider/kubernetes: Populate deploy images with triggers

### DIFF
--- a/app/scripts/modules/core/pipeline/config/triggers/docker/dockerTrigger.module.js
+++ b/app/scripts/modules/core/pipeline/config/triggers/docker/dockerTrigger.module.js
@@ -62,6 +62,9 @@ module.exports = angular.module('spinnaker.core.pipeline.trigger.docker', [
         $scope.images = images;
         $scope.registryMap = images.reduce((map, image) => {
           let key = image.registry;
+          if (!key) {
+            return map;
+          }
           let all = map[key] || [];
           if (all.indexOf(image.repository) < 0) {
             map[key] = all.concat(image.repository);

--- a/app/scripts/modules/kubernetes/serverGroup/configure/configuration.service.js
+++ b/app/scripts/modules/kubernetes/serverGroup/configure/configuration.service.js
@@ -48,6 +48,7 @@ module.exports = angular.module('spinnaker.serverGroup.configure.kubernetes.conf
             imageId: command.buildImageId(image),
             registry: image.registry,
             fromContext: image.fromContext,
+            fromTrigger: image.fromTrigger,
             cluster: image.cluster,
             pattern: image.pattern,
             stageId: image.stageId,
@@ -109,7 +110,9 @@ module.exports = angular.module('spinnaker.serverGroup.configure.kubernetes.conf
       command.backingData.filtered.containers = _.map(command.backingData.filtered.images, mapImageToContainer(command));
       var validContainers = [];
       command.containers.forEach(function(container) {
-        if (container.imageDescription.fromContext || _.find(command.backingData.filtered.containers, { imageDescription: { imageId: container.imageDescription.imageId } })) {
+        if (container.imageDescription.fromContext
+            || container.imageDescription.fromTrigger
+            || _.find(command.backingData.filtered.containers, { imageDescription: { imageId: container.imageDescription.imageId } })) {
           validContainers.push(container);
         } else {
           result.dirty.containers = result.dirty.containers || [];
@@ -189,7 +192,7 @@ module.exports = angular.module('spinnaker.serverGroup.configure.kubernetes.conf
           return registry.accountName;
         });
         command.backingData.filtered.images = _.filter(command.backingData.allImages, function(image) {
-          return image.fromContext || _.contains(accounts, image.account);
+          return image.fromContext || image.fromTrigger || _.contains(accounts, image.account);
         });
       }
       return result;


### PR DESCRIPTION
The user can now specify which trigger corresponds to which image in Deck.
![trigger](https://cloud.githubusercontent.com/assets/4874941/13794856/7bb5a10e-ead4-11e5-8152-fb828987fe44.jpg)
@duftler 