### PR TITLE
autofocus account confirm box, allow enter to submit confirm modal

### DIFF
--- a/app/scripts/modules/core/confirmationModal/confirm.html
+++ b/app/scripts/modules/core/confirmationModal/confirm.html
@@ -1,13 +1,12 @@
 <div modal-page class="confirmation-modal">
-  <task-monitor monitor="taskMonitor"></task-monitor>
-  <modal-close></modal-close>
-  <div class="modal-header">
-    <h3>{{params.header}}</h3>
-  </div>
-  <div class="modal-body confirmation-modal" ng-if="params.body || state.error || params.platformHealthOnlyShowOverride || params.askForReason">
-    <form role="form" class="container-fluid" ng-submit="ctrl.confirm()">
-      <div ng-if="params.body" ng-bind-html="params.body">
-      </div>
+  <form role="form" class="container-fluid" ng-submit="ctrl.confirm()">
+    <task-monitor monitor="taskMonitor"></task-monitor>
+    <modal-close></modal-close>
+    <div class="modal-header">
+      <h3>{{params.header}}</h3>
+    </div>
+    <div class="modal-body confirmation-modal" ng-if="params.body || state.error || params.platformHealthOnlyShowOverride || params.askForReason">
+      <div ng-if="params.body" ng-bind-html="params.body"></div>
       <div class="row" ng-if="params.platformHealthOnlyShowOverride">
         <div class="col-sm-offset-1 col-sm-10">
           <platform-health-override command="params"
@@ -16,26 +15,29 @@
           </platform-health-override>
         </div>
       </div>
-    </form>
-    <div ng-if="state.error">
-      <div class="alert alert-danger">
-        <h4>An exception occurred:</h4>
-        <p>
-          {{errorMessage || 'No details provided.'}}
-        </p>
+      <div ng-if="state.error">
+        <div class="alert alert-danger">
+          <h4>An exception occurred:</h4>
+          <p>
+            {{errorMessage || 'No details provided.'}}
+          </p>
+        </div>
       </div>
+      <task-reason ng-if="taskMonitor && params.askForReason" command="params"></task-reason>
     </div>
-    <task-reason ng-if="taskMonitor && params.askForReason" command="params"></task-reason>
-  </div>
-  <div class="modal-footer">
-    <user-verification verification="verification" account="params.account" label="params.verificationLabel"></user-verification>
-    <button class="btn btn-default" ng-click="ctrl.cancel()">{{params.cancelButtonText}}</button>
-    <button class="btn btn-primary"
-            ng-disabled="ctrl.formDisabled()"
-            ng-click="ctrl.confirm()">
-      <span ng-if="params.glyphicon" class="glyphicon glyphicon-{{params.glyphicon}}"></span>
-      <button-busy-indicator ng-if="state.submitting"></button-busy-indicator>
-      {{params.buttonText}}
-    </button>
-  </div>
+    <div class="modal-footer">
+      <user-verification verification="verification" account="params.account" label="params.verificationLabel" autofocus="true"></user-verification>
+      <button class="btn btn-default"
+              type="button"
+              ng-click="ctrl.cancel()">{{params.cancelButtonText}}</button>
+      <button class="btn btn-primary"
+              type="submit"
+              ng-disabled="ctrl.formDisabled()"
+              ng-click="ctrl.confirm()">
+        <span ng-if="params.glyphicon" class="glyphicon glyphicon-{{params.glyphicon}}"></span>
+        <button-busy-indicator ng-if="state.submitting"></button-busy-indicator>
+        {{params.buttonText}}
+      </button>
+    </div>
+  </form>
 </div>

--- a/app/scripts/modules/core/forms/autofocus/autofocus.directive.js
+++ b/app/scripts/modules/core/forms/autofocus/autofocus.directive.js
@@ -2,12 +2,22 @@
 
 let angular = require('angular');
 
-module.exports = angular.module('spinnaker.account.accountSelectField.directive', [])
-  .directive('autofocus', function($timeout) {
+/***
+ * Directive to allow optionally setting autofocus behavior of form elements
+ *   <input auto-focus/> will not focus
+ *   <input auto-focus="somethingThatIsTrue"/> will focus
+ *   <input auto-focus="somethingThatIsFalse"/> will not focus
+ *   <input autofocus/> will focus in the vast majority of browsers (not Angular - this is just HTML)
+ *
+ */
+module.exports = angular.module('spinnaker.core.forms.autoFocus.directive', [])
+  .directive('autoFocus', function($timeout) {
     return {
       restrict: 'A',
-      link: function(scope, elem) {
-        $timeout(function() { elem.focus(); });
+      link: function(scope, elem, attrs) {
+        if (scope.$eval(attrs.autoFocus)) {
+          $timeout(() => elem.focus());
+        }
       }
     };
 });

--- a/app/scripts/modules/core/task/verification/userVerification.directive.html
+++ b/app/scripts/modules/core/task/verification/userVerification.directive.html
@@ -8,6 +8,7 @@
                class="form-control input-sm highlight-pristine"
                ng-model="vm.userVerification"
                ng-change="vm.verify()"
+               auto-focus="vm.autofocus"
                ng-class="{'ng-invalid': !vm.verification.verified}" />
       </div>
     </div>

--- a/app/scripts/modules/core/task/verification/userVerification.directive.js
+++ b/app/scripts/modules/core/task/verification/userVerification.directive.js
@@ -19,7 +19,8 @@ module.exports = angular
       bindToController: {
         verification: '=',
         account: '=',
-        label: '=?'
+        label: '=?',
+        autofocus: '=?',
       },
       controllerAs: 'vm',
       controller: 'UserVerificationCtrl',


### PR DESCRIPTION
I had to change the `autofocus` directive, since it collides with the `autofocus` attribute, which is just part of the HTML spec.

This is one of those PRs that's best viewed with the ignore whitespace flag (i.e. `?w=1`) set in your URL.