### PR TITLE
provider/kubernetes: Fix namespace validation

### DIFF
--- a/app/scripts/modules/core/pipeline/config/stages/disableAsg/kubernetes/kubernetesDisableAsgStage.js
+++ b/app/scripts/modules/core/pipeline/config/stages/disableAsg/kubernetes/kubernetesDisableAsgStage.js
@@ -22,7 +22,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.kubernetes.disabl
         },
         { type: 'requiredField', fieldName: 'cluster' },
         { type: 'requiredField', fieldName: 'target', },
-        { type: 'requiredField', fieldName: 'namespace', },
+        { type: 'requiredField', fieldName: 'namespaces', },
         { type: 'requiredField', fieldName: 'credentials', fieldLabel: 'account'},
       ],
     });


### PR DESCRIPTION
_someone_ misspelled 'namespaces'.