### PR TITLE
Show AWS instance tags on instance details.

### DIFF
--- a/app/scripts/modules/amazon/instance/details/instanceDetails.html
+++ b/app/scripts/modules/amazon/instance/details/instanceDetails.html
@@ -159,6 +159,13 @@
           </li>
         </ul>
     </collapsible-section>
+    <collapsible-section ng-if="!instance.notFound" heading="Tags">
+      <div ng-if=" !instance.tags.length">No tags associated with this server</div>
+      <dl ng-if="instance.tags.length">
+        <dt ng-repeat-start="tag in instance.tags | orderBy: 'key.toLowerCase()'">{{tag.key}}</dt>
+        <dd ng-repeat-end>{{tag.value}}</dd>
+      </dl>
+    </collapsible-section>
     <collapsible-section heading="Logs" ng-if="baseIpAddress">
       <ul>
         <li>


### PR DESCRIPTION
This adds a `TAGS` section to the instance details UI for AWS instances. This is similar to how the cluster tags are currently displayed for AWS ASGs. This is using data that was already available from the API; it just wasn't being exposed.

![image](https://cloud.githubusercontent.com/assets/192336/13830585/48c4fa32-eb93-11e5-801d-cf2abe808af0.png)