### PR TITLE
prevent repeated submits when user presses enter on confirm dialog

### DIFF
--- a/app/scripts/modules/core/confirmationModal/confirmationModal.controller.js
+++ b/app/scripts/modules/core/confirmationModal/confirmationModal.controller.js
@@ -26,7 +26,9 @@ module.exports = angular
       toVerify: params.textToVerify,
     };
 
-    this.formDisabled = () => $scope.verification.required && !$scope.verification.verified;
+    this.formDisabled = () => {
+      return $scope.state.submitting || ($scope.verification.required && !$scope.verification.verified);
+    };
 
     function showError(exception) {
       $scope.state.error = true;


### PR DESCRIPTION
Yet another followup to the earlier pull request, which made it easier to submit a confirmation modal without clicking on anything, which also made it really easy to submit the same task multiple times. This really fixes that last part.