### PR TITLE
provider/kuberenetes: Added missing security group reader

### DIFF
--- a/app/scripts/modules/kubernetes/kubernetes.module.js
+++ b/app/scripts/modules/kubernetes/kubernetes.module.js
@@ -27,6 +27,7 @@ module.exports = angular.module('spinnaker.kubernetes', [
   require('./namespace/selectField.directive.js'),
   require('./search/resultFormatter.js'),
   require('./securityGroup/configure/configure.kubernetes.module.js'),
+  require('./securityGroup/reader.js'),
   require('./securityGroup/transformer.js'),
   require('./serverGroup/configure/CommandBuilder.js'),
   require('./serverGroup/configure/configure.kubernetes.module.js'),
@@ -62,6 +63,7 @@ module.exports = angular.module('spinnaker.kubernetes', [
         createLoadBalancerController: 'kubernetesUpsertLoadBalancerController',
       },
       securityGroup: {
+        reader: 'kubernetesSecurityGroupReader',
         transformer: 'kubernetesSecurityGroupTransformer',
         createSecurityGroupTemplateUrl: require('./securityGroup/configure/wizard/wizard.html'),
         createSecurityGroupController: 'kubernetesUpsertSecurityGroupController',

--- a/app/scripts/modules/kubernetes/securityGroup/reader.js
+++ b/app/scripts/modules/kubernetes/securityGroup/reader.js
@@ -1,0 +1,16 @@
+'use strict';
+
+let angular = require('angular');
+
+module.exports = angular.module('spinnaker.kubernetes.securityGroup.reader', [
+])
+  .factory('kubernetesSecurityGroupReader', function () {
+
+    function resolveIndexedSecurityGroup(indexedSecurityGroups, container, securityGroupId) {
+      return indexedSecurityGroups[container.account][container.region][securityGroupId];
+    }
+
+    return {
+      resolveIndexedSecurityGroup: resolveIndexedSecurityGroup,
+    };
+  });


### PR DESCRIPTION
Turns out it's needed to render security groups in the UI

@duftler 