### PR TITLE
Added a checkbox in the config stage to handle pipleines in queue

### DIFF
--- a/app/scripts/modules/core/delivery/create/createPipelineModal.controller.js
+++ b/app/scripts/modules/core/delivery/create/createPipelineModal.controller.js
@@ -14,7 +14,8 @@ module.exports = angular.module('spinnaker.core.pipeline.create.controller', [
       stages: [],
       triggers: [],
       application: application.name,
-      limitConcurrent: true
+      limitConcurrent: true,
+      limitWaiting: true
     };
 
     $scope.viewState = {};

--- a/app/scripts/modules/core/delivery/create/createPipelineModal.controller.js
+++ b/app/scripts/modules/core/delivery/create/createPipelineModal.controller.js
@@ -15,7 +15,7 @@ module.exports = angular.module('spinnaker.core.pipeline.create.controller', [
       triggers: [],
       application: application.name,
       limitConcurrent: true,
-      limitWaiting: true
+      keepWaitingPipelines: false
     };
 
     $scope.viewState = {};

--- a/app/scripts/modules/core/help/helpContents.js
+++ b/app/scripts/modules/core/help/helpContents.js
@@ -216,6 +216,7 @@ module.exports = angular.module('spinnaker.core.help.contents', [])
     'pipeline.config.fastProperty.rollback': 'Enables the Fast Property to be rolled back to it previous state when the pipeline completes.',
     'pipeline.config.parallel.execution': '<p>Enabling parallel stage execution allows you to run stages only after dependent ' +
       'stages have completed.</p><p>By configuring a pipeline this way, you can reduce the time it takes to run.</p>',
+    'pipeline.config.parallel.cancel.queue': '<p>If concurrent pipeline execution is disabled, then the pipelines that are in the waiting queue will get canceled by default. <br><br>Check this box if you want to keep them in the queue.</p>',
     'pipeline.config.timeout': '<p>Allows you to override the amount of time the stage can run before failing.</p> ' +
     '<p><b>Note:</b> this is not the overall time the stage has, but rather the time for specific tasks.</p>',
     'pipeline.config.timeout.bake': '<p>For the Bake stage, the timeout will apply to both the "Create Bake" and "Monitor Bake" tasks.</p>',

--- a/app/scripts/modules/core/pipeline/config/pipelineConfigurer.js
+++ b/app/scripts/modules/core/pipeline/config/pipelineConfigurer.js
@@ -272,7 +272,7 @@ module.exports = angular.module('spinnaker.core.pipeline.config.pipelineConfigur
         parallel: copy.parallel,
         appConfig: copy.appConfig || {},
         limitConcurrent: copy.limitConcurrent,
-        limitWaiting: copy.limitWaiting,
+        keepWaitingPipelines: copy.keepWaitingPipelines,
         stageCounter: copy.stageCounter,
         parameterConfig: copy.parameterConfig,
         notifications: copy.notifications,

--- a/app/scripts/modules/core/pipeline/config/pipelineConfigurer.js
+++ b/app/scripts/modules/core/pipeline/config/pipelineConfigurer.js
@@ -272,6 +272,7 @@ module.exports = angular.module('spinnaker.core.pipeline.config.pipelineConfigur
         parallel: copy.parallel,
         appConfig: copy.appConfig || {},
         limitConcurrent: copy.limitConcurrent,
+        limitWaiting: copy.limitWaiting,
         stageCounter: copy.stageCounter,
         parameterConfig: copy.parameterConfig,
         notifications: copy.notifications,

--- a/app/scripts/modules/core/pipeline/config/triggers/triggers.html
+++ b/app/scripts/modules/core/pipeline/config/triggers/triggers.html
@@ -11,7 +11,7 @@
       </div>
       <div ng-if="pipeline.limitConcurrent"class="checkbox">
         <label>
-          <input type="checkbox" ng-model="pipeline.limitWaiting" ng-true-value="false" ng-false-value="true">
+          <input type="checkbox" ng-model="pipeline.keepWaitingPipelines">
           <strong>Do not automatically cancel pipelines waiting in queue. </strong>
           <help-field key="pipeline.config.parallel.cancel.queue"/>
         </label>

--- a/app/scripts/modules/core/pipeline/config/triggers/triggers.html
+++ b/app/scripts/modules/core/pipeline/config/triggers/triggers.html
@@ -9,6 +9,13 @@
          <strong>Disable concurrent pipeline executions (only run one at a time). </strong>
         </label>
       </div>
+      <div ng-if="pipeline.limitConcurrent"class="checkbox">
+        <label>
+          <input type="checkbox" ng-model="pipeline.limitWaiting" ng-true-value="false" ng-false-value="true">
+          <strong>Do not automatically cancel pipelines waiting in queue. </strong>
+          <help-field key="pipeline.config.parallel.cancel.queue"/>
+        </label>
+      </div>
     </div>
   </div>
 


### PR DESCRIPTION
Added a checkbox in the configuration stage to ask users if pipelines in queue need to be cancelled. This is related to the issue https://github.com/spinnaker/spinnaker/issues/805 and orca PR https://github.com/spinnaker/orca/pull/767

This checkbox is shown only if the concurrent execution is enabled by checking the first check box.
Also added tooltip help.
