### PR TITLE
provider/kubernetes: Fix fields missing from pipeline details

### DIFF
--- a/app/scripts/modules/core/pipeline/config/stages/deploy/deployExecutionDetails.html
+++ b/app/scripts/modules/core/pipeline/config/stages/deploy/deployExecutionDetails.html
@@ -9,7 +9,12 @@
             <account-tag account="stage.context.account"></account-tag>
           </dd>
           <dt>Region</dt>
-          <dd ng-repeat="(region, zones) in stage.context.availabilityZones">{{region}}<br/>({{zones.join(', ')}})</dd>
+          <div ng-if="stage.context.availabilityZones">
+            <dd ng-repeat="(region, zones) in stage.context.availabilityZones">{{region}}<br/>({{zones.join(', ')}})</dd>
+          </div>
+          <div ng-if="stage.context.namespace">
+            <dd>{{stage.context.namespace}}</dd>
+          </div>
           <dt>Cluster</dt>
           <dd>{{stage.context | clusterName }}</dd>
         </dl>
@@ -21,6 +26,9 @@
           <dt>Strategy</dt>
           <dd>{{stage.context.strategy || '[none]'}}</dd>
           <dt>Capacity</dt>
+          <dd ng-if="!stage.context.capacity">
+            {{stage.context.targetSize}}
+          </dd>
           <dd ng-if="stage.context.useSourceCapacity">Current Server Group</dd>
           <dd ng-if="!stage.context.useSourceCapacity && stage.context.capacity.min === stage.context.capacity.max">{{stage.context.capacity.max}}</dd>
           <dd ng-if="stage.context.useSourceCapacity && stage.context.capacity.min !== stage.context.capacity.max">

--- a/app/scripts/modules/core/pipeline/config/stages/resizeAsg/kubernetes/resizeExecutionDetails.html
+++ b/app/scripts/modules/core/pipeline/config/stages/resizeAsg/kubernetes/resizeExecutionDetails.html
@@ -1,4 +1,4 @@
-<div ng-controller="kubernetesResizeAsgExecutionDetailsCtrl">
+<div ng-controller="kubernetesResizeExecutionDetailsController">
   <execution-details-section-nav sections="configSections"></execution-details-section-nav>
   <div class="step-section-details" ng-if="detailsSection === 'resizeServerGroupConfig'">
     <div class="row">

--- a/app/scripts/modules/core/pipeline/config/stages/resizeAsg/kubernetes/resizeStage.js
+++ b/app/scripts/modules/core/pipeline/config/stages/resizeAsg/kubernetes/resizeStage.js
@@ -86,7 +86,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.kubernetes.resize
     stage.cloudProviderType = 'kubernetes';
 
     if (stage.isNew && $scope.application.attributes.platformHealthOnly) {
-      stage.interestingHealthProviderNames = ['Kubernetes'];
+      stage.interestingHealthProviderNames = ['KubernetesPod'];
     }
 
     if (!stage.credentials && $scope.application.defaultCredentials.kubernetes) {

--- a/app/scripts/modules/kubernetes/serverGroup/configure/wizard/volumes.controller.js
+++ b/app/scripts/modules/kubernetes/serverGroup/configure/wizard/volumes.controller.js
@@ -47,6 +47,7 @@ module.exports = angular.module('spinnaker.serverGroup.configure.kubernetes.volu
     };
 
     this.prepVolumes = function() {
+      $scope.command.volumeSources = $scope.command.volumeSources || [];
       $scope.command.volumeSources.map((source) => {
         if (!source.hostPath) {
           source.hostPath = this.defaultHostPath();


### PR DESCRIPTION
Cluster size and region were missing the deploy details, and the entire resize details pane were missing in Kubernetes pipelines. 

@duftler 