### PR TITLE
create/edit/delete AWS scaling policy feature

### DIFF
--- a/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/addScalingPolicyButton.component.js
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/addScalingPolicyButton.component.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const angular = require('angular');
+
+module.exports = angular
+  .module('spinnaker.amazon.serverGroup.details.scalingPolicy.addButton', [
+    require('angular-ui-bootstrap'),
+    require('../../../../core/utils/uuid.service.js'),
+  ])
+  .component('addScalingPolicyButton', {
+    bindings: {
+      serverGroup: '=',
+      application: '=',
+    },
+    template: '<a href ng-click="$ctrl.addScalingPolicy()">Create new scaling policy</a>',
+    controller: function($uibModal) {
+
+      let policy = {
+        alarms: [{
+          statistic: 'Average',
+          comparisonOperator: 'GreaterThanThreshold',
+          evaluationPeriods: 1,
+          dimensions: [{ name: 'AutoScalingGroupName', value: this.serverGroup.name}],
+          period: 60,
+        }],
+        adjustmentType: 'ChangeInCapacity',
+        stepAdjustments: [{
+          scalingAdjustment: 1,
+        }],
+        estimatedInstanceWarmup: 600,
+      };
+
+      this.addScalingPolicy = () => {
+        $uibModal.open({
+          templateUrl: require('./upsert/upsertScalingPolicy.modal.html'),
+          controller: 'awsUpsertScalingPolicyCtrl',
+          controllerAs: 'ctrl',
+          size: 'lg',
+          resolve: {
+            policy: () => policy,
+            serverGroup: () => this.serverGroup,
+            application: () => this.application,
+          }
+        });
+      };
+    }
+  });

--- a/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/chart/metricAlarmChart.component.spec.js
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/chart/metricAlarmChart.component.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-fdescribe('Component: metricAlarmChart', function () {
+describe('Component: metricAlarmChart', function () {
 
   var $ctrl, $scope, cloudMetricsReader, rx, $q;
 

--- a/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/scalingPolicy.write.service.js
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/scalingPolicy.write.service.js
@@ -1,0 +1,41 @@
+'use strict';
+
+let angular = require('angular');
+
+module.exports = angular
+  .module('spinnaker.aws.serverGroup.details.scalingPolicy.write.service', [
+    require('../../../../core/task/taskExecutor.js')
+  ])
+  .factory('scalingPolicyWriter', function (taskExecutor) {
+
+    function upsertScalingPolicy(application, command) {
+      command.type = 'upsertScalingPolicy';
+      return taskExecutor.executeTask({
+        application: application,
+        description: 'Upsert scaling policy ' + command.name,
+        job: [command]
+      });
+    }
+
+    function deleteScalingPolicy(application, serverGroup, scalingPolicy) {
+      return taskExecutor.executeTask({
+        application: application,
+        description: 'Delete scaling policy ' + scalingPolicy.name,
+        job: [
+          {
+            type: 'deleteScalingPolicy',
+            provider: serverGroup.type,
+            credentials: serverGroup.account,
+            region: serverGroup.region,
+            policyName: scalingPolicy.policyName,
+            serverGroupName: serverGroup.name,
+          }
+        ]
+      });
+    }
+
+    return {
+      upsertScalingPolicy: upsertScalingPolicy,
+      deleteScalingPolicy: deleteScalingPolicy,
+    };
+  });

--- a/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/scalingPolicySummary.component.html
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/scalingPolicySummary.component.html
@@ -1,19 +1,25 @@
 <div ng-repeat="alarm in $ctrl.policy.alarms track by $index">
-  <div>
-    <strong>Whenever</strong>
-    {{alarm.statistic}} of {{alarm.metricName}} is <span ng-bind-html="alarm.comparator"></span> {{alarm.threshold}}
-  </div>
-  <div>
-    <strong>for at least</strong>
-    {{alarm.evaluationPeriods}} consecutive periods of {{alarm.period}} seconds
-  </div>
-  <div class="actions">
-    <button class="btn btn-xs btn-link btn-left"
-       uib-popover-template="$ctrl.popoverTemplate"
+  <div uib-popover-template="$ctrl.popoverTemplate"
        popover-placement="left"
        popover-title="{{$ctrl.policy.policyName}}"
-       popover-trigger="mouseenter focus click">
-      Details
+       popover-trigger="mouseenter">
+    <div>
+      <strong>Whenever</strong>
+      {{alarm.statistic}} of {{alarm.metricName}} is <span ng-bind-html="alarm.comparator"></span> {{alarm.threshold}}
+    </div>
+    <div>
+      <strong>for at least</strong>
+      {{alarm.evaluationPeriods}} consecutive periods of {{alarm.period}} seconds
+    </div>
+  </div>
+  <div class="actions text-right">
+    <button class="btn btn-xs btn-link" ng-click="$ctrl.editPolicy()">
+      <span class="glyphicon glyphicon-cog" uib-tooltip="Edit policy"></span>
+      <span class="sr-only">Edit policy</span>
+    </button>
+    <button class="btn btn-xs btn-link" ng-click="$ctrl.deletePolicy()">
+      <span class="glyphicon glyphicon-trash" uib-tooltip="Delete policy"></span>
+      <span class="sr-only">Delete policy</span>
     </button>
   </div>
 </div>

--- a/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/alarm/alarmConfigurer.component.html
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/alarm/alarmConfigurer.component.html
@@ -1,0 +1,113 @@
+<div class="row" ng-if="$ctrl.modalViewState.multipleAlarms">
+  <div class="col-md-12">
+    <div class="alert alert-warning">
+      <p><span class="glyphicon glyphicon-warning-sign"></span>
+        This scaling policy is configured with multiple alarms. You are only editing the first alarm.</p>
+      <p>To edit or remove the additional alarms, you will need to use the AWS console.</p>
+    </div>
+  </div>
+</div>
+<div class="row" ng-if="$ctrl.alarm.alarmActionArns.length > 1">
+  <div class="col-md-12">
+    <div class="alert alert-warning">
+      <p><span class="glyphicon glyphicon-warning-sign"></span>
+        This alarm is used in multiple scaling policies. Any changes here will affect those other scaling policies.</p>
+    </div>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md-2 sm-label-right">Whenever </div>
+  <div class="col-md-10 content-fields">
+    <select class="form-control input-sm"
+            style="vertical-align: top;"
+            required
+            ng-model="$ctrl.alarm.statistic"
+            ng-change="$ctrl.metricChanged()"
+            ng-options="stat for stat in $ctrl.statistics">
+    </select>
+    <span class="input-label"> of </span>
+    <div style="display: inline-block; width: 500px" ng-if="$ctrl.viewState.metricsLoaded">
+      <select class="form-control input-sm"
+              required
+              ng-model="$ctrl.viewState.selectedMetric"
+              ng-change="$ctrl.metricChanged()"
+              ng-if="!$ctrl.viewState.advancedMode"
+              ng-options="metric as metric.label for metric in $ctrl.metrics">
+      </select>
+      <select class="form-control input-sm"
+              required
+              ng-model="$ctrl.alarm.namespace"
+              ng-change="$ctrl.namespaceChanged()"
+              ng-if="$ctrl.viewState.advancedMode"
+              ng-options="namespace for namespace in $ctrl.namespaces">
+      </select>
+      <select class="form-control input-sm"
+              required
+              ng-model="$ctrl.viewState.selectedMetric"
+              ng-change="$ctrl.metricChanged()"
+              ng-if="$ctrl.viewState.advancedMode"
+              ng-options="metric as metric.advancedLabel for metric in $ctrl.metrics">
+      </select>
+      <a href class="small"
+         ng-if="!$ctrl.viewState.advancedMode"
+         ng-click="$ctrl.advancedMode()">
+        Search all metrics
+      </a>
+      <div ng-if="$ctrl.viewState.advancedMode">
+        <dimensions-editor alarm="$ctrl.alarm"
+                           server-group="$ctrl.serverGroup"
+                           namespace-updated="$ctrl.namespaceUpdated"
+                           update-available-metrics="$ctrl.updateAvailableMetrics()"></dimensions-editor>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md-2 sm-label-right">is </div>
+  <div class="col-md-10 content-fields">
+    <select class="form-control input-sm"
+            style="width: 50px"
+            ng-model="$ctrl.alarm.comparisonOperator"
+            ng-change="$ctrl.alarmComparatorChanged()"
+            ng-options="comparator.value as comparator.label for comparator in $ctrl.comparators">
+    </select>
+    <input type="number"
+           class="form-control input-sm"
+           style="width: 100px"
+           ng-change="$ctrl.thresholdChanged()"
+           ng-model="$ctrl.alarm.threshold" />
+    <span class="input-label" ng-bind="$ctrl.viewState.unit"></span>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md-2 sm-label-right">for at least </div>
+  <div class="col-md-10 content-fields">
+    <input type="number"
+           class="form-control input-sm"
+           style="width: 50px"
+           ng-model="$ctrl.alarm.evaluationPeriods" />
+    <span class="input-label"> consecutive period(s) of </span>
+    <select class="form-control input-sm"
+            ng-change="$ctrl.periodChanged()"
+            ng-model="$ctrl.alarm.period"
+            ng-options="period.value as period.label for period in $ctrl.periods"></select>
+  </div>
+</div>
+
+<div class="row" ng-if="$ctrl.alarm.metricName">
+  <div class="col-md-10 col-md-offset-1">
+    <div style="height: 150px">
+      <metric-alarm-chart alarm="$ctrl.alarm"
+                          ng-if="$ctrl.alarm"
+                          style="height: 150px;"
+                          alarm-updated="$ctrl.alarmUpdated"
+                          ticks="{x: 12, y: 5}"
+                          margins="{top: 10, left: 50}"
+                          stats="$ctrl.viewState"
+                          server-group="$ctrl.serverGroup"></metric-alarm-chart>
+    </div>
+  </div>
+</div>

--- a/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/alarm/alarmConfigurer.component.js
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/alarm/alarmConfigurer.component.js
@@ -1,0 +1,209 @@
+'use strict';
+
+const angular = require('angular');
+
+module.exports = angular
+  .module('spinnaker.aws.serverGroup.details.scalingPolicy.alarm.configurer', [
+    require('../../../../../../core/utils/lodash.js'),
+    require('../../../../../../core/utils/rx.js'),
+    require('../../../../../../core/config/settings.js'),
+    require('../../../../../../core/serverGroup/metrics/cloudMetrics.read.service.js'),
+    require('./dimensionsEditor.component.js'),
+  ])
+  .component('awsAlarmConfigurer', {
+    bindings: {
+      command: '=',
+      modalViewState: '=',
+      serverGroup: '<',
+      boundsChanged: '&',
+    },
+    templateUrl: require('./alarmConfigurer.component.html'),
+    controller: function (cloudMetricsReader, _, rx, settings) {
+
+      // AWS does not provide an API to get this, so we're baking it in. If you use custom namespaces, add them to
+      // the settings.js block for aws as an array, e.g. aws { metrics: { customNamespaces: ['myns1', 'other'] } }
+      this.namespaces =
+        _.get(settings, 'providers.aws.metrics.customNamespaces', []).concat([
+          'AWS/AutoScaling',
+          'AWS/Billing',
+          'AWS/CloudFront',
+          'AWS/CloudSearch',
+          'AWS/Events',
+          'AWS/DynamoDB',
+          'AWS/ECS',
+          'AWS/ElastiCache',
+          'AWS/EBS',
+          'AWS/EC2',
+          'AWS/ELB',
+          'AWS/ElasticMapReduce',
+          'AWS/ES',
+          'AWS/Kinesis',
+          'AWS/Lambda',
+          'AWS/ML',
+          'AWS/OpsWorks',
+          'AWS/Redshift',
+          'AWS/RDS',
+          'AWS/Route53',
+          'AWS/SNS',
+          'AWS/SQS',
+          'AWS/S3',
+          'AWS/SWF',
+          'AWS/StorageGateway',
+          'AWS/WAF',
+          'AWS/WorkSpaces',
+        ]);
+
+      this.statistics = [ 'Average', 'Maximum', 'Minimum', 'SampleCount', 'Sum' ];
+
+      this.comparators = [
+        { label: '>=', value: 'GreaterThanOrEqualToThreshold' },
+        { label: '>', value: 'GreaterThanThreshold' },
+        { label: '<=', value: 'LessThanOrEqualToThreshold' },
+        { label: '<', value: 'LessThanThreshold' },
+      ];
+
+      this.periods = [
+        { label: '1 minute', value: 60 },
+        { label: '5 minutes', value: 60 * 5 },
+        { label: '15 minutes', value: 60 * 15 },
+        { label: '1 hour', value: 60 * 60 },
+        { label: '4 hours', value: 60 * 60 * 4},
+        { label: '1 day', value: 60 * 60 * 24 },
+      ];
+
+      this.viewState = {
+        advancedMode: false,
+        metricsLoaded: false,
+        selectedMetric: null,
+      };
+
+      this.alarmUpdated = new rx.Subject();
+      this.namespaceUpdated = new rx.Subject();
+
+      this.thresholdChanged = () => {
+        let source = this.modalViewState.comparatorBound === 'max' ? 'metricIntervalLowerBound' : 'metricIntervalUpperBound';
+        if (this.command.step) {
+          // always set the first step at the alarm threshold
+          this.command.step.stepAdjustments[0][source] = this.command.alarm.threshold;
+        }
+        this.boundsChanged();
+        this.alarmUpdated.onNext();
+      };
+
+      let convertDimensionsToObject = () => {
+        return this.alarm.dimensions.reduce((acc, dimension) => {
+          acc[dimension.name] = dimension.value;
+          return acc;
+        }, {});
+      };
+
+      // used to determine if dimensions have changed when selecting a metric
+      function dimensionsToString(metric) {
+        let dimensions = metric.dimensions || [];
+        return dimensions.map(d => [d.name, d.value].join(':')).join(',');
+      }
+
+      this.metricChanged = () => {
+        if (!this.viewState.metricsLoaded) {
+          return;
+        }
+        let alarm = this.alarm;
+        if (this.viewState.selectedMetric) {
+          let selected = this.viewState.selectedMetric,
+              dimensionsChanged = selected && dimensionsToString(alarm) !== dimensionsToString(selected),
+              alarmUpdated = alarm.metricName !== selected.name || alarm.namespace !== selected.namespace ||
+                             dimensionsChanged;
+          alarm.metricName = selected.name;
+          alarm.namespace = selected.namespace;
+          if (dimensionsChanged) {
+            alarm.dimensions = selected.dimensions;
+            this.updateAvailableMetrics();
+          }
+          if (alarmUpdated) {
+            this.alarmUpdated.onNext();
+          }
+        } else {
+          if (!this.viewState.advancedMode) {
+            alarm.namespace = null;
+          }
+          alarm.metricName = null;
+          this.alarmUpdated.onNext();
+        }
+      };
+
+      this.periodChanged = () => this.alarmUpdated.onNext();
+
+      this.namespaceChanged = () => {
+        this.namespaceUpdated.onNext();
+        this.updateAvailableMetrics();
+      };
+
+      this.advancedMode = () => {
+        this.viewState.advancedMode = true;
+      };
+
+      function dimensionSorter(a, b) {
+        return a.name.localeCompare(b.name);
+      }
+
+      function transformAvailableMetric(metric) {
+        metric.label = `(${metric.namespace}) ${metric.name}`;
+        metric.dimensions = metric.dimensions || [];
+        metric.dimensionValues = metric.dimensions.sort(dimensionSorter).map(d => d.value).join(', ');
+        if (metric.dimensions.length) {
+          metric.advancedLabel = `${metric.name} (${metric.dimensionValues})`;
+        } else {
+          metric.advancedLabel = metric.name;
+        }
+      }
+
+      this.updateAvailableMetrics = () => {
+        let alarm = this.alarm;
+        let dimensions = convertDimensionsToObject();
+        if (this.viewState.advancedMode) {
+          dimensions.namespace = alarm.namespace;
+        }
+
+        cloudMetricsReader.listMetrics('aws', this.serverGroup.account, this.serverGroup.region, dimensions).then(
+          (results) => {
+            results = results || [];
+            this.viewState.metricsLoaded = true;
+            results.forEach(transformAvailableMetric);
+            this.metrics = results.sort((a, b) => a.label.localeCompare(b.label));
+            let currentDimensions = this.alarm.dimensions.sort(dimensionSorter).map(d => d.value).join(', ');
+            let [selected] = this.metrics.filter(metric =>
+              metric.name === alarm.metricName && metric.namespace === alarm.namespace &&
+              metric.dimensionValues === currentDimensions
+            );
+            this.viewState.selectedMetric = selected;
+            this.metricChanged();
+          })
+        .catch(() => {
+            this.viewState.metricsLoaded = true;
+            this.advancedMode();
+          });
+      };
+
+      this.alarmComparatorChanged = () => {
+        this.modalViewState.comparatorBound = this.alarm.comparisonOperator.indexOf('Greater') === 0 ? 'max' : 'min';
+        this.metricChanged();
+      };
+
+      let initializeMode = () => {
+        let dimensions = this.alarm.dimensions;
+        if (!dimensions || !dimensions.length || dimensions.length > 1 ||
+          dimensions[0].name !== 'AutoScalingGroupName' || dimensions[0].value !== this.serverGroup.name) {
+          this.advancedMode();
+        }
+      };
+
+      this.$onInit = () => {
+        this.alarm = this.command.alarm;
+        initializeMode();
+        this.updateAvailableMetrics();
+        this.alarmComparatorChanged();
+        this.alarmUpdated.onNext();
+      };
+
+    }
+  });

--- a/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/alarm/alarmConfigurer.component.spec.js
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/alarm/alarmConfigurer.component.spec.js
@@ -1,0 +1,257 @@
+'use strict';
+
+describe('Component: alarmConfigurer', function () {
+
+  var $ctrl, $scope, cloudMetricsReader, rx, $q, alarm;
+
+  beforeEach(
+    window.module(
+      require('./alarmConfigurer.component')
+    )
+  );
+
+  beforeEach(
+    window.inject( function($componentController, $rootScope, _cloudMetricsReader_, _rx_, _, _$q_) {
+      $scope = $rootScope.$new();
+      cloudMetricsReader = _cloudMetricsReader_;
+      rx = _rx_;
+      $q = _$q_;
+
+      this.initialize = (bindings) => {
+        $ctrl = $componentController('awsAlarmConfigurer', {
+          $scope: $scope,
+          cloudMetricsReader: cloudMetricsReader,
+          rx: rx,
+          _: _,
+        }, bindings);
+      };
+    })
+  );
+
+
+  describe('initialization', function () {
+    beforeEach(function () {
+      alarm = {
+        comparisonOperator: 'GreaterThanThreshold',
+        dimensions: [ { name: 'AutoScalingGroupName', value: 'asg-v000' }],
+        metricName: 'CPUUtilization',
+        namespace: 'AWS/EC2',
+      };
+    });
+
+    it('sets advanced mode when dimensions are non-standard', function () {
+      this.initialize({ command: {alarm: alarm}, serverGroup: { name: 'asg-v000'}, modalViewState: {} });
+      $ctrl.$onInit();
+      expect($ctrl.viewState.advancedMode).toBe(false);
+
+      this.initialize({ command: {alarm: alarm}, serverGroup: { name: 'other-v001'}, modalViewState: {} });
+      $ctrl.$onInit();
+      expect($ctrl.viewState.advancedMode).toBe(true);
+    });
+
+    it('sets comparatorBound on modalViewState', function () {
+      this.initialize({ command: {alarm: alarm}, serverGroup: { name: 'asg-v000'}, modalViewState: {} });
+      $ctrl.$onInit();
+      expect($ctrl.modalViewState.comparatorBound).toBe('max');
+    });
+
+    it('updates available metrics on initialization, triggers alarmUpdated once', function () {
+      spyOn(cloudMetricsReader, 'listMetrics').and.returnValue($q.when([
+        {
+          namespace: 'AWS/EC2',
+          name: 'CPUUtilization',
+          dimensions: [ { name: 'AutoScalingGroupName', value: 'asg-v000' } ]
+        },
+        {
+          namespace: 'AWS/EC2',
+          name: 'NetworkIn',
+          dimensions: [ { name: 'AutoScalingGroupName', value: 'asg-v000' } ]
+        }
+      ]));
+      this.initialize({ command: {alarm: alarm}, serverGroup: { name: 'asg-v000'}, modalViewState: {} });
+      spyOn($ctrl.alarmUpdated, 'onNext');
+      $ctrl.$onInit();
+      $scope.$digest();
+
+      expect($ctrl.metrics.length).toBe(2);
+      expect($ctrl.metrics.map(m => m.name)).toEqual(['CPUUtilization', 'NetworkIn']);
+      expect($ctrl.viewState.selectedMetric).toBe($ctrl.metrics[0]);
+      expect($ctrl.viewState.metricsLoaded).toBe(true);
+      expect($ctrl.alarmUpdated.onNext.calls.count()).toBe(1);
+    });
+  });
+
+  describe('thresholdChanged', function () {
+    it ('updates first step when comparatorBound is max to new threshold, calls boundsChanged', function () {
+      var bcCalled = false;
+      let command = {
+        alarm: {
+          comparisonOperator: 'GreaterThanThreshold',
+          threshold: 6,
+        },
+        step: {
+          stepAdjustments: [
+            {
+              metricIntervalLowerBound: 1,
+              metricIntervalUpperBound: 2
+            },
+            {
+              metricIntervalLowerBound: 3,
+              metricIntervalUpperBound: 4
+            }
+          ]
+        }
+      };
+      let boundsChanged = () => bcCalled = true;
+
+      this.initialize({
+        command: command,
+        serverGroup: { name: 'asg-v000'},
+        modalViewState: { comparatorBound: 'max' },
+        boundsChanged: boundsChanged });
+
+      spyOn($ctrl.alarmUpdated, 'onNext');
+      $ctrl.thresholdChanged();
+
+      expect(command.step.stepAdjustments[0].metricIntervalLowerBound).toBe(6);
+      expect(bcCalled).toBe(true);
+      expect($ctrl.alarmUpdated.onNext.calls.count()).toBe(1);
+    });
+  });
+
+  describe('metricChanged', function () {
+    beforeEach(function () {
+      alarm = {
+        namespace: 'AWS/EC2',
+        metricName: 'CPUUtilization',
+        comparisonOperator: 'GreaterThanThreshold',
+        dimensions: [ { name: 'AutoScalingGroupName', value: 'asg-v000' } ]
+      };
+
+      this.initialize({ command: {alarm: alarm}, serverGroup: { name: 'asg-v000'}, modalViewState: {} });
+      spyOn(cloudMetricsReader, 'listMetrics').and.returnValue($q.when([
+        {
+          namespace: 'AWS/EC2',
+          name: 'CPUUtilization',
+          dimensions: [ { name: 'AutoScalingGroupName', value: 'asg-v000' } ]
+        },
+        {
+          namespace: 'AWS/EC2',
+          name: 'NetworkIn',
+          dimensions: [ { name: 'AutoScalingGroupName', value: 'asg-v000' }, { name: 'sr', value: '71'} ]
+        }
+      ]));
+
+      $ctrl.$onInit();
+      $scope.$digest();
+    });
+
+    it('triggers alarmUpdated, updates alarm fields when new metric selected', function () {
+      spyOn($ctrl.alarmUpdated, 'onNext');
+
+      $ctrl.viewState.selectedMetric = $ctrl.metrics[1];
+      $ctrl.metricChanged();
+      expect(alarm.metricName).toBe('NetworkIn');
+      expect($ctrl.alarmUpdated.onNext.calls.count()).toBe(1);
+    });
+
+    it('updates dimensions, available metrics when dimensions on selected metric are different', function () {
+      spyOn($ctrl, 'updateAvailableMetrics');
+
+      $ctrl.viewState.selectedMetric = $ctrl.metrics[1];
+      $ctrl.metricChanged();
+
+      expect(alarm.dimensions.length).toBe(2);
+      expect($ctrl.updateAvailableMetrics.calls.count()).toBe(1);
+    });
+
+    it('clears namespace when not in advanced mode and selected metric is removed', function () {
+      spyOn($ctrl.alarmUpdated, 'onNext');
+      $ctrl.viewState.selectedMetric = null;
+      $ctrl.metricChanged();
+      expect(alarm.namespace).toBe(null);
+      expect($ctrl.alarmUpdated.onNext.calls.count()).toBe(1);
+    });
+
+    it('does not clear namespace when in advanced mode and selected metric is removed', function () {
+      spyOn($ctrl.alarmUpdated, 'onNext');
+      $ctrl.viewState.advancedMode = true;
+      $ctrl.viewState.selectedMetric = null;
+      $ctrl.metricChanged();
+      expect(alarm.namespace).toBe('AWS/EC2');
+      expect($ctrl.alarmUpdated.onNext.calls.count()).toBe(1);
+    });
+  });
+
+  describe('metric transformations', function () {
+    beforeEach(function () {
+      alarm = {
+        namespace: 'AWS/EC2',
+        metricName: 'CPUUtilization',
+        comparisonOperator: 'GreaterThanThreshold',
+        dimensions: [ { name: 'AutoScalingGroupName', value: 'asg-v000' } ]
+      };
+
+      this.initialize({ command: {alarm: alarm}, serverGroup: { name: 'asg-v000'}, modalViewState: {} });
+      spyOn(cloudMetricsReader, 'listMetrics').and.returnValue($q.when([
+        {
+          namespace: 'AWS/EC2',
+          name: 'CPUUtilization',
+          dimensions: [ { name: 'AutoScalingGroupName', value: 'asg-v000' } ]
+        },
+        {
+          namespace: 'AWS/EC2',
+          name: 'NetworkIn',
+          dimensions: [ { name: 'AutoScalingGroupName', value: 'asg-v000' }, { name: 'sr', value: '71'} ]
+        },
+        {
+          namespace: 'AWS/EBS',
+          name: 'somethingElse'
+        }
+      ]));
+
+      $ctrl.$onInit();
+      $scope.$digest();
+    });
+
+    it('adds label to each metric, sorts by label', function () {
+      expect($ctrl.metrics.map(m => m.label)).toEqual([
+        '(AWS/EBS) somethingElse', '(AWS/EC2) CPUUtilization', '(AWS/EC2) NetworkIn']);
+    });
+
+    it('adds default dimensions if not present', function () {
+      expect($ctrl.metrics[0].dimensions).toEqual([]);
+    });
+
+    it('adds dimensionValues to each dimension', function () {
+      expect($ctrl.metrics.map(m => m.dimensionValues)).toEqual(['', 'asg-v000', 'asg-v000, 71']);
+    });
+
+    it('adds advancedLabel based on presence of dimensions', function () {
+      expect($ctrl.metrics.map(m => m.advancedLabel)).toEqual([
+        'somethingElse', 'CPUUtilization (asg-v000)', 'NetworkIn (asg-v000, 71)'
+      ]);
+    });
+  });
+
+  describe('update available metrics', function () {
+    it ('sets advanced mode when metrics fail to load', function () {
+      alarm = {
+        namespace: 'AWS/EC2',
+        metricName: 'CPUUtilization',
+        comparisonOperator: 'GreaterThanThreshold',
+        dimensions: [ { name: 'AutoScalingGroupName', value: 'asg-v000' } ]
+      };
+
+      this.initialize({ command: {alarm: alarm}, serverGroup: { name: 'asg-v000'}, modalViewState: {} });
+      spyOn(cloudMetricsReader, 'listMetrics').and.returnValue($q.reject(null));
+
+      $ctrl.$onInit();
+      $scope.$digest();
+
+      expect($ctrl.viewState.metricsLoaded).toBe(true);
+      expect($ctrl.viewState.advancedMode).toBe(true);
+    });
+  });
+
+});

--- a/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/alarm/dimensionsEditor.component.html
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/alarm/dimensionsEditor.component.html
@@ -1,0 +1,41 @@
+<div class="row">
+  <div class="col-md-12" style="padding-left: 20px;">
+    <span class="sm-label sm-label-left">Dimensions</span>
+  </div>
+</div>
+<div ng-repeat="dimension in $ctrl.alarm.dimensions" class="row">
+  <div class="col-md-4" style="padding-right: 0">
+    <input type="text" class="form-control input-sm" style="width: 100%"
+           required
+           uib-typeahead="option for option in $ctrl.dimensionOptions | filter: $viewValue"
+           typeahead-show-hint="true"
+           typeahead-min-length="0"
+           typeahead-editable="true"
+           typeahead-on-select="$ctrl.updateAvailableMetrics()"
+           ng-change="$ctrl.updateAvailableMetrics()"
+           ng-model-options="{ updateOn: 'default blur', debounce: { 'default': 300, 'blur': 0 } }"
+           ng-model="dimension.name" placeholder="name"/>
+  </div>
+  <div class="col-md-6" style="padding-left: 10px">
+    <input type="text" class="form-control input-sm" style="width: 100%"
+           required
+           ng-model-options="{ updateOn: 'default blur', debounce: { 'default': 300, 'blur': 0 } }"
+           ng-change="$ctrl.updateAvailableMetrics()"
+           ng-model="dimension.value" placeholder="value"/>
+  </div>
+  <div class="col-md-2">
+    <a class="form-control-static" href ng-click="$ctrl.removeDimension($index)">
+      <span class="glyphicon glyphicon-trash" uib-tooltip="Remove dimension"></span>
+    </a>
+  </div>
+</div>
+<div class="row">
+  <div class="col-md-10">
+    <button class="btn btn-block btn-xs add-new"
+            style="width: 100%; margin-left: 5px; padding: 4px"
+            ng-click="$ctrl.alarm.dimensions.push({})">
+      <span class="glyphicon glyphicon-plus-sign"></span>
+      Add dimension
+    </button>
+  </div>
+</div>

--- a/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/alarm/dimensionsEditor.component.js
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/alarm/dimensionsEditor.component.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const angular = require('angular');
+
+module.exports = angular
+  .module('spinnaker.aws.serverGroup.details.scalingPolicy.dimensionEditor', [
+    require('../../../../../../core/utils/lodash.js'),
+    require('../../../../../../core/serverGroup/metrics/cloudMetrics.read.service.js'),
+  ])
+  .component('dimensionsEditor', {
+    bindings: {
+      alarm: '=',
+      serverGroup: '=',
+      updateAvailableMetrics: '&',
+      namespaceUpdated: '=',
+    },
+    templateUrl: require('./dimensionsEditor.component.html'),
+    controller: function (cloudMetricsReader, _, rx) {
+
+      this.viewState = {
+        loadingDimensions: false
+      };
+
+      this.fetchDimensionOptions = () => {
+        this.viewState.loadingDimensions = true;
+        let filters = { namespace: this.alarm.namespace };
+        return rx.Observable
+          .fromPromise(
+          cloudMetricsReader.listMetrics('aws', this.serverGroup.account, this.serverGroup.region, filters)
+        );
+      };
+
+      let dimensionSubject = new rx.Subject();
+
+      dimensionSubject
+        .flatMapLatest(this.fetchDimensionOptions)
+        .subscribe((results) => {
+          this.viewState.loadingDimensions = false;
+          results = results || [];
+          results.forEach(r => r.dimensions = r.dimensions || []);
+          this.dimensionOptions = _.uniq(_.flatten(results.map(r => r.dimensions.map(d => d.name)))).sort();
+        });
+
+      this.updateDimensionOptions = () => {
+        dimensionSubject.onNext();
+      };
+
+      this.removeDimension = (index) => {
+        this.alarm.dimensions.splice(index, 1);
+        this.updateAvailableMetrics();
+      };
+
+      this.$onInit = () => {
+        this.updateDimensionOptions();
+        this.namespaceUpdated.subscribe(() => {
+          this.updateDimensionOptions();
+        });
+      };
+
+    }
+  });

--- a/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/simple/simplePolicyAction.component.html
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/simple/simplePolicyAction.component.html
@@ -1,0 +1,22 @@
+<div class="row">
+  <div class="col-md-10 col-md-offset-1">
+    <select class="form-control input-sm"
+            style="width: 65px"
+            required
+            ng-model="$ctrl.viewState.operator"
+            ng-change="$ctrl.operatorChanged()"
+            ng-options="adjustment for adjustment in $ctrl.availableActions"></select>
+    <input type="number" min="0"
+           class="form-control input-sm"
+           style="width: 65px"
+           required
+           ng-model="$ctrl.policy.scalingAdjustment"/>
+
+    <select class="form-control input-sm"
+            style="width: 110px"
+            required
+            ng-model="$ctrl.viewState.adjustmentType"
+            ng-change="$ctrl.adjustmentTypeChanged()"
+            ng-options="option for option in $ctrl.adjustmentTypeOptions"></select>
+  </div>
+</div>

--- a/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/simple/simplePolicyAction.component.js
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/simple/simplePolicyAction.component.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const angular = require('angular');
+
+module.exports = angular
+  .module('spinnaker.aws.serverGroup.details.scalingPolicy.upsert.actions.simplePolicy', [
+  ])
+  .component('awsSimplePolicyAction', {
+    bindings: {
+      policy: '<',
+      viewState: '=',
+    },
+    templateUrl: require('./simplePolicyAction.component.html'),
+    controller: function () {
+      this.operatorChanged = () => {
+        this.adjustmentTypeOptions = this.viewState.operator === 'Set to' ?
+          ['instances'] :
+          ['instances', 'percent of group'];
+      };
+
+      this.availableActions = ['Add', 'Remove', 'Set to'];
+
+      this.adjustmentTypeChanged = () => {
+        if (this.viewState.adjustmentType === 'instances') {
+          this.command.adjustmentType = this.viewState.operator === 'Set to' ? 'ExactCapacity' : 'ChangeInCapacity';
+        } else {
+          this.command.adjustmentType = 'PercentChangeInCapacity';
+        }
+      };
+
+      this.$onInit = () => {
+        this.operatorChanged();
+      };
+    }
+  });

--- a/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/step/stepPolicyAction.component.html
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/step/stepPolicyAction.component.html
@@ -1,0 +1,84 @@
+<div class="row" ng-repeat="step in $ctrl.command.step.stepAdjustments">
+  <div class="col-md-10 col-md-offset-1 step-policy-row">
+    <select ng-if="$first"
+            class="form-control input-sm"
+            style="width: 65px"
+            required
+            ng-model="$ctrl.viewState.operator"
+            ng-change="$ctrl.operatorChanged()"
+            ng-options="adjustment for adjustment in $ctrl.availableActions"></select>
+              <span style="width: 75px; text-transform: capitalize"
+                    class="form-control-static select-placeholder"
+                    ng-bind="$ctrl.viewState.operator"
+                    ng-if="!$first"></span>
+
+    <input type="number" min="0"
+           class="form-control input-sm"
+           required
+           style="width: 65px"
+           ng-model="step.scalingAdjustment"/>
+
+    <select ng-if="$first"
+            class="form-control input-sm"
+            style="width: 110px"
+            required
+            ng-model="$ctrl.viewState.adjustmentType"
+            ng-change="$ctrl.adjustmentTypeChanged()"
+            ng-options="option for option in $ctrl.adjustmentTypeOptions"></select>
+    <span style="width: 120px" class="form-control-static select-placeholder"
+          ng-if="!$first" ng-bind="$ctrl.viewState.adjustmentType"></span>
+    <span class="input-label">
+    when
+    </span>
+    <span ng-if="$ctrl.viewState.comparatorBound === 'max'">
+
+      <span class="input-label text-right"
+            ng-bind="step.metricIntervalLowerBound"
+            style="width: 65px"></span>
+      <span class="input-label">&le;</span>
+      <span class="input-label" ng-bind="$ctrl.command.alarm.metricName"></span>
+      <span is-visible="!$last" class="input-label">&lt;</span>
+      <input type="number"
+             ng-if="!$last"
+             class="form-control input-sm"
+             ng-model="step.metricIntervalUpperBound"
+             ng-change="$ctrl.boundsChanged()"
+             required
+             ng-min="step.metricIntervalLowerBound"
+             style="width: 85px"/>
+      <span style="width: 65px"
+            class="select-placeholder"
+            ng-if="$last"></span>
+    </span>
+
+    <span ng-if="$ctrl.viewState.comparatorBound === 'min'">
+      <span class="input-label text-right"
+            ng-bind="step.metricIntervalUpperBound"
+            style="width: 65px"></span>
+      <span class="input-label">&ge;</span>
+      <span class="input-label" ng-bind="$ctrl.command.alarm.metricName"></span>
+      <span is-visible="!$last" class="input-label">&gt;</span>
+      <input type="number"
+             ng-if="!$last"
+             class="form-control input-sm"
+             ng-model="step.metricIntervalLowerBound"
+             required
+             ng-max="step.metricIntervalUpperBound"
+             ng-change="$ctrl.boundsChanged()"
+             style="width: 85px"/>
+    </span>
+    <span ng-if="!$first" class="pull-right" style="padding: 5px 0;">
+      <a href ng-click="$ctrl.removeStep($index)">
+        <span class="glyphicon glyphicon-trash"></span>
+      </a>
+    </span>
+  </div>
+</div>
+<div class="row" style="margin-top: 10px">
+  <div class="col-md-10 col-md-offset-1">
+    <button class="btn btn-block btn-sm add-new" ng-click="$ctrl.addStep(step)">
+      <span class="glyphicon glyphicon-plus-sign"></span>
+      Add action
+    </button>
+  </div>
+</div>

--- a/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/step/stepPolicyAction.component.js
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/step/stepPolicyAction.component.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const angular = require('angular');
+
+require('./stepPolicyAction.component.less');
+
+module.exports = angular
+  .module('spinnaker.aws.serverGroup.details.scalingPolicy.upsert.actions.stePolicy', [
+  ])
+  .component('awsStepPolicyAction', {
+    bindings: {
+      command: '<',
+      viewState: '=',
+      boundsChanged: '&',
+    },
+    templateUrl: require('./stepPolicyAction.component.html'),
+    controller: function () {
+      this.operatorChanged = () => {
+        this.adjustmentTypeOptions = this.viewState.operator === 'Set to' ?
+          ['instances'] :
+          ['instances', 'percent of group'];
+      };
+
+      this.availableActions = ['Add', 'Remove', 'Set to'];
+
+      this.adjustmentTypeChanged = () => {
+        if (this.viewState.adjustmentType === 'instances') {
+          this.command.adjustmentType = this.viewState.operator === 'Set to' ? 'ExactCapacity' : 'ChangeInCapacity';
+        } else {
+          this.command.adjustmentType = 'PercentChangeInCapacity';
+        }
+      };
+
+      this.addStep = () => {
+        this.command.step.stepAdjustments.push({});
+      };
+
+      this.removeStep = (index) => {
+        this.command.step.stepAdjustments.splice(index, 1);
+        this.boundsChanged();
+      };
+
+      this.$onInit = () => {
+        this.operatorChanged();
+      };
+    }
+  });

--- a/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/step/stepPolicyAction.component.less
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/step/stepPolicyAction.component.less
@@ -1,0 +1,4 @@
+.step-policy-row {
+  padding: 5px 0;
+  border-bottom: 1px solid #dedede;
+}

--- a/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/upsertScalingPolicy.controller.js
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/upsertScalingPolicy.controller.js
@@ -1,0 +1,194 @@
+'use strict';
+
+const angular = require('angular');
+
+require('./upsertScalingPolicy.modal.less');
+
+module.exports = angular
+  .module('spinnaker.aws.serverGroup.details.scalingPolicy.upsertScalingPolicy.controller', [
+    require('../scalingPolicy.write.service.js'),
+    require('exports?"n3-line-chart"!n3-charts/build/LineChart.js'),
+    require('../../../../../core/serverGroup/serverGroup.read.service.js'),
+    require('./simple/simplePolicyAction.component.js'),
+    require('./step/stepPolicyAction.component.js'),
+    require('./alarm/alarmConfigurer.component.js'),
+  ])
+  .controller('awsUpsertScalingPolicyCtrl', function ($modalInstance, _, scalingPolicyWriter,
+                                                      taskMonitorService,
+                                                      serverGroupReader, serverGroup, application, policy) {
+
+    this.serverGroup = serverGroup;
+
+    this.viewState = {
+      isNew: !policy.policyARN,
+      multipleAlarms: policy.alarms.length > 1,
+      metricsLoaded: false,
+      namespacesLoaded: false,
+    };
+
+    function createCommand() {
+      return {
+        name: policy.policyName,
+        serverGroupName: serverGroup.name,
+        credentials: serverGroup.account,
+        region: serverGroup.region,
+        provider: serverGroup.type,
+        adjustmentType: policy.adjustmentType,
+        minAdjustmentMagnitude: policy.minAdjustmentMagnitude,
+      };
+    }
+
+    function initializeAlarm(command, policy) {
+      let alarm = policy.alarms[0];
+      command.alarm = {
+        name: alarm.alarmName,
+        region: serverGroup.region,
+        actionsEnabled: true,
+        alarmDescription: alarm.alarmDescription,
+        comparisonOperator: alarm.comparisonOperator,
+        dimensions: alarm.dimensions,
+        evaluationPeriods: alarm.evaluationPeriods,
+        period: alarm.period,
+        threshold: alarm.threshold,
+        namespace: alarm.namespace,
+        metricName: alarm.metricName,
+        statistic: alarm.statistic,
+        unit: alarm.unit,
+        alarmActionArns: alarm.alarmActions,
+        insufficientDataActionArns: alarm.insufficientDataActions,
+        okActionArns: alarm.okActions
+      };
+    }
+
+    this.initialize = () => {
+      var command = createCommand();
+
+      initializeAlarm(command, policy);
+
+      if (command.adjustmentType === 'ExactCapacity') {
+        this.viewState.operator = 'Set to';
+        this.viewState.adjustmentType = 'instances';
+      } else {
+        let adjustmentBasis = policy.scalingAdjustment;
+        if (policy.stepAdjustments && policy.stepAdjustments.length) {
+          adjustmentBasis = policy.stepAdjustments[0].scalingAdjustment;
+        }
+        this.viewState.operator = adjustmentBasis > 0 ? 'Add' : 'Remove';
+        this.viewState.adjustmentType = policy.adjustmentType === 'ChangeInCapacity' ? 'instances' : 'percent of group';
+      }
+
+      if (policy.stepAdjustments && policy.stepAdjustments.length) {
+        initializeStepPolicy(command, policy);
+      } else {
+        initializeSimplePolicy(command, policy);
+      }
+
+      this.command = command;
+
+    };
+
+    function initializeStepPolicy(command, policy) {
+      let threshold = command.alarm.threshold;
+      command.step = {
+        estimatedInstanceWarmup: policy.estimatedInstanceWarmup || command.cooldown || 600,
+        metricAggregationType: command.alarm.statistic,
+      };
+      command.step.stepAdjustments = policy.stepAdjustments.map((adjustment) => {
+        let step = {
+          scalingAdjustment: Math.abs(adjustment.scalingAdjustment),
+        };
+        if (adjustment.metricIntervalUpperBound !== undefined) {
+          step.metricIntervalUpperBound = adjustment.metricIntervalUpperBound + threshold;
+        }
+        if (adjustment.metricIntervalLowerBound !== undefined) {
+          step.metricIntervalLowerBound = adjustment.metricIntervalLowerBound + threshold;
+        }
+        return step;
+      });
+    }
+
+    function initializeSimplePolicy(command, policy) {
+      command.simple = {
+        cooldown: policy.cooldown || 600,
+        scalingAdjustment: Math.abs(policy.scalingAdjustment) || 1,
+      };
+    }
+
+    this.boundsChanged = () => {
+      let source = this.viewState.comparatorBound === 'min' ? 'metricIntervalLowerBound' : 'metricIntervalUpperBound',
+          target = source === 'metricIntervalLowerBound' ? 'metricIntervalUpperBound' : 'metricIntervalLowerBound';
+
+      if (this.command.step) {
+        let steps = this.command.step.stepAdjustments;
+        steps.forEach((step, index) => {
+          if (steps.length > index + 1) {
+            steps[index + 1][target] = step[source];
+          }
+        });
+        // remove the source boundary from the last step
+        delete steps[steps.length - 1][source];
+      }
+    };
+
+    this.switchMode = () => {
+      let command = this.command;
+      if (command.step) {
+        let policy = { cooldown: command.step.estimatedInstanceWarmup };
+        delete command.step;
+        initializeSimplePolicy(command, policy);
+      } else {
+        let stepAdjustments = [{
+          scalingAdjustment: command.simple.scalingAdjustment
+        }];
+        if (this.viewState.comparatorBound === 'min') {
+          stepAdjustments[0].metricIntervalUpperBound = 0;
+        } else {
+          stepAdjustments[0].metricIntervalLowerBound = 0;
+        }
+        delete command.simple;
+        initializeStepPolicy(command, { stepAdjustments: stepAdjustments });
+        this.boundsChanged();
+      }
+    };
+
+    this.action = this.viewState.isNew ? 'Create' : 'Edit';
+
+    let prepareCommandForSubmit = () => {
+      let command = _.cloneDeep(this.command);
+
+      if (command.step) {
+        // adjust metricIntervalLowerBound/UpperBound for each step based on alarm threshold
+        command.step.stepAdjustments.forEach((step) => {
+          if (this.viewState.operator === 'Remove') {
+            step.scalingAdjustment = 0 - step.scalingAdjustment;
+          }
+          if (step.metricIntervalLowerBound !== undefined) {
+            step.metricIntervalLowerBound -= command.alarm.threshold;
+          }
+          if (step.metricIntervalUpperBound !== undefined) {
+            step.metricIntervalUpperBound -= command.alarm.threshold;
+          }
+        });
+      }
+      return command;
+    };
+
+    this.save = () => {
+      let command = prepareCommandForSubmit();
+      var submitMethod = () => scalingPolicyWriter.upsertScalingPolicy(application, command);
+
+      var taskMonitorConfig = {
+        modalInstance: $modalInstance,
+        application: application,
+        title: this.action + ' scaling policy for ' + serverGroup.name,
+      };
+
+      this.taskMonitor = taskMonitorService.buildTaskMonitor(taskMonitorConfig);
+
+      this.taskMonitor.submit(submitMethod);
+    };
+
+    this.cancel = $modalInstance.dismiss;
+
+    this.initialize();
+  });

--- a/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/upsertScalingPolicy.modal.html
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/upsertScalingPolicy.modal.html
@@ -1,0 +1,105 @@
+<div modal-page class="scaling-policy-modal form-inline">
+  <task-monitor monitor="ctrl.taskMonitor"></task-monitor>
+  <modal-close></modal-close>
+  <div class="modal-header">
+    <h3>{{ctrl.action}} scaling policy</h3>
+  </div>
+  <div class="modal-body">
+    <form name="form" novalidate>
+      <h4 class="section-heading">Conditions</h4>
+      <div class="section-body">
+        <aws-alarm-configurer command="ctrl.command"
+                              modal-view-state="ctrl.viewState"
+                              server-group="ctrl.serverGroup"
+                              bounds-changed="ctrl.boundsChanged()"></aws-alarm-configurer>
+      </div>
+      <h4 class="section-heading">Actions</h4>
+      <div class="section-body" ng-if="!ctrl.command.alarm.metricName">
+        <h4 class="text-center">Select a metric</h4>
+      </div>
+      <div class="section-body" ng-if="ctrl.command.alarm.metricName">
+
+        <div ng-if="ctrl.command.simple">
+          <div class="row">
+            <div class="col-md-10 col-md-offset-1">
+              <p>This is a simple scaling policy. To declare different actions based on the magnitude of the alarm,
+                convert it to a <a href ng-click="ctrl.switchMode()">step policy</a>.</p>
+            </div>
+          </div>
+
+          <aws-simple-policy-action policy="ctrl.command.simple"
+                                    view-state="ctrl.viewState"></aws-simple-policy-action>
+        </div>
+        <div ng-if="ctrl.command.step">
+          <aws-step-policy-action command="ctrl.command"
+                                  view-state="ctrl.viewState"
+                                  bounds-changed="ctrl.boundsChanged()"></aws-step-policy-action>
+        </div>
+      </div>
+      <h4 class="section-heading">Additional Settings</h4>
+      <div class="section-body section-additional-settings">
+        <div class="row" ng-if="!ctrl.viewState.isNew">
+          <div class="col-md-2 sm-label-right">Policy Name</div>
+          <div class="col-md-10 content-fields">
+            <span class="form-control-static select-placeholder" ng-if="!ctrl.viewState.isNew" ng-bind="ctrl.command.name"></span>
+          </div>
+        </div>
+
+        <div class="row" ng-if="ctrl.viewState.adjustmentType !== 'instances'">
+          <div class="col-md-2 sm-label-right">Adjustment Step</div>
+          <div class="col-md-10 content-fields">
+            <span class="form-control-static select-placeholder">
+              Add instances in increments of at least
+            </span>
+            <input type="number"
+                   style="width: 60px"
+                   class="form-control input-sm"
+                   required
+                   ng-model="ctrl.command.minAdjustmentMagnitude"/>
+            <span class="input-label">
+              instance(s)
+            </span>
+          </div>
+        </div>
+        <div class="row" ng-if="ctrl.command.simple">
+          <div class="col-md-2 sm-label-right">Cooldown</div>
+          <div class="col-md-10 content-fields">
+            <span class="form-control-static select-placeholder">
+              Wait at least
+            </span>
+            <input type="number"
+                   style="width: 60px"
+                   class="form-control input-sm"
+                   required
+                   ng-model="ctrl.command.simple.cooldown"/>
+            <span class="input-label">
+              seconds before another scaling event
+            </span>
+          </div>
+        </div>
+        <div class="row" ng-if="ctrl.command.step">
+          <div class="col-md-2 sm-label-right">Warmup</div>
+          <div class="col-md-10 content-fields">
+            <span class="form-control-static select-placeholder">Instances need</span>
+            <input type="number"
+                   style="width: 60px"
+                   class="form-control input-sm"
+                   required
+                   ng-model="ctrl.command.step.estimatedInstanceWarmup"/>
+            <span class="input-label">
+              seconds to warm up after each step
+            </span>
+          </div>
+        </div>
+      </div>
+    </form>
+  </div>
+
+  <div class="modal-footer">
+    <button class="btn btn-default" ng-click="ctrl.cancel()">Cancel</button>
+    <submit-button is-disabled="!form.$valid"
+                   submitting="taskMonitor.submitting"
+                   on-click="ctrl.save()"
+                   is-new="ctrl.viewState.isNew"></submit-button>
+  </div>
+</div>

--- a/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/upsertScalingPolicy.modal.less
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/upsertScalingPolicy.modal.less
@@ -1,0 +1,35 @@
+.scaling-policy-modal {
+  input, select {
+    margin: 0 5px;
+  }
+  span.input-label, .select-placeholder {
+    display: inline-block;
+    font-size: 12px;
+  }
+  .chart {
+    .line-series {
+      path {
+        stroke-width: 2px;
+      }
+    }
+    .axis {
+      font-family: 'Source Sans Pro', sans-serif;
+    }
+  }
+  .section-additional-settings {
+    .row {
+      margin-bottom: 10px;
+    }
+  }
+
+  aws-alarm-configurer > .row {
+    margin-bottom: 10px;
+  }
+
+  .sm-label-right {
+    padding-right: 5px;
+  }
+  .content-fields {
+    padding-left: 0;
+  }
+}

--- a/app/scripts/modules/amazon/serverGroup/details/serverGroupDetails.aws.controller.js
+++ b/app/scripts/modules/amazon/serverGroup/details/serverGroupDetails.aws.controller.js
@@ -27,6 +27,7 @@ module.exports = angular.module('spinnaker.serverGroup.details.aws.controller', 
   require('./rollback/rollbackServerGroup.controller'),
   require('../../../core/utils/selectOnDblClick.directive.js'),
   require('../serverGroup.transformer.js'),
+  require('./scalingPolicy/addScalingPolicyButton.component.js'),
 ])
   .controller('awsServerGroupDetailsCtrl', function ($scope, $state, app, serverGroup, InsightFilterStateModel,
                                                      serverGroupReader, awsServerGroupCommandBuilder, $uibModal,

--- a/app/scripts/modules/amazon/serverGroup/details/serverGroupDetails.html
+++ b/app/scripts/modules/amazon/serverGroup/details/serverGroupDetails.html
@@ -219,11 +219,12 @@
       </ul>
     </collapsible-section>
     <collapsible-section heading="Scaling Policies">
-      <p>Scaling Policies can be modified via the AWS Console.</p>
       <scaling-policy-summary ng-repeat="policy in ctrl.scalingPolicies track by policy.policyARN"
                       policy="policy"
                       server-group="ctrl.serverGroup"
                       application="ctrl.application"></scaling-policy-summary>
+      <add-scaling-policy-button server-group="ctrl.serverGroup"
+                                 application="ctrl.application"></add-scaling-policy-button>
     </collapsible-section>
     <collapsible-section heading="Scheduled Actions">
       <scheduled-action ng-repeat="action in ctrl.serverGroup.scheduledActions" action="action"></scheduled-action>

--- a/app/scripts/modules/core/modal/modals.less
+++ b/app/scripts/modules/core/modal/modals.less
@@ -137,6 +137,16 @@ modal-wizard {
   h3, h4 {
     margin-top: 0;
   }
+  .section-heading {
+    color: @lightest_grey;
+    background-color: @dark_blue_background;
+    padding: 10px;
+    margin-bottom: 0;
+    font-weight: 300;
+  }
+  .section-body {
+    padding: 10px 0 20px 0;
+  }
 }
 
 .forward {

--- a/app/scripts/modules/core/presentation/main.less
+++ b/app/scripts/modules/core/presentation/main.less
@@ -1002,6 +1002,11 @@ select.input-sm {
   padding-right: 0;
 }
 
+.select-placeholder {
+  display: inline-block;
+  padding-left: 14px;
+}
+
 html {
   overflow: hidden;
 }

--- a/app/scripts/modules/core/task/monitor/taskMonitor.directive.js
+++ b/app/scripts/modules/core/task/monitor/taskMonitor.directive.js
@@ -12,7 +12,6 @@ module.exports = angular.module('spinnaker.tasks.monitor.directive', [
   .directive('taskMonitor', function () {
     return {
       restrict: 'E',
-      replace: true,
       templateUrl: require('./taskMonitor.html'),
       scope: {
         taskMonitor: '=monitor'

--- a/app/scripts/modules/core/task/monitor/taskMonitor.directive.less
+++ b/app/scripts/modules/core/task/monitor/taskMonitor.directive.less
@@ -1,5 +1,8 @@
 @import "../../presentation/less/imports/commonImports.less";
 
+task-monitor {
+  display: block;
+}
 .not-started {
   color: @mid_lighter_grey;
 }

--- a/app/scripts/modules/netflix/serverGroup/awsServerGroupDetails.html
+++ b/app/scripts/modules/netflix/serverGroup/awsServerGroupDetails.html
@@ -222,10 +222,12 @@
       <nflx-server-group-networking server-group="ctrl.serverGroup" application="ctrl.application"></nflx-server-group-networking>
     </collapsible-section>
     <collapsible-section heading="Scaling Policies">
-      <scaling-policy ng-repeat="policy in ctrl.serverGroup.scalingPolicies"
+      <scaling-policy-summary ng-repeat="policy in ctrl.scalingPolicies track by policy.policyARN"
                       policy="policy"
                       server-group="ctrl.serverGroup"
-                      application="ctrl.application"></scaling-policy>
+                      application="ctrl.application"></scaling-policy-summary>
+      <add-scaling-policy-button server-group="ctrl.serverGroup"
+                                 application="ctrl.application"></add-scaling-policy-button>
     </collapsible-section>
     <collapsible-section heading="Scheduled Actions">
       <scheduled-action ng-repeat="action in ctrl.serverGroup.scheduledActions" action="action"></scheduled-action>


### PR DESCRIPTION
Initial cut of create/edit/delete operations for AWS scaling policies.

As long as you're not reusing alarms across policies, and not attaching multiple alarms to a policy, you are probably going to like this. Still need to add warnings for those scenarios.

If you're mostly using metrics that are scoped to an ASG, this is also going to be in your wheelhouse.

I will add more comments to this PR tomorrow. My laptop is shutting itself down every couple of minutes, so I am just going to get this PR started.

@zanthrash PTAL. I know it's too big to be legitimately reviewed.

