### PR TITLE
fallback to security group id when ingress rule not matched

### DIFF
--- a/app/scripts/modules/core/securityGroup/securityGroup.read.service.js
+++ b/app/scripts/modules/core/securityGroup/securityGroup.read.service.js
@@ -189,8 +189,10 @@ module.exports = angular.module('spinnaker.core.securityGroup.read.service', [
             return rule.securityGroup;
           });
           details.securityGroupRules.forEach(function(inboundRule) {
-            if (!inboundRule.securityGroup.name) {
-              inboundRule.securityGroup.name = getApplicationSecurityGroup(application, details.accountName, details.region, inboundRule.securityGroup.id).name;
+            let inboundGroup = inboundRule.securityGroup;
+            if (!inboundGroup.name) {
+              let applicationSecurityGroup = getApplicationSecurityGroup(application, inboundGroup.accountName, details.region, inboundGroup.id);
+              inboundGroup.name = applicationSecurityGroup ? applicationSecurityGroup.name : inboundGroup.id;
             }
           });
         }


### PR DESCRIPTION
In theory, this shouldn't happen, but if security group caches are out of sync, or we're not caching an account, or we don't know about a security group, we shouldn't throw exceptions when trying to attach inbound rules, so fallback to using the security group ID.