### PR TITLE
remove unneeded wizard state init code from titan

### DIFF
--- a/app/scripts/modules/titan/serverGroup/configure/wizard/CloneServerGroup.titan.controller.js
+++ b/app/scripts/modules/titan/serverGroup/configure/wizard/CloneServerGroup.titan.controller.js
@@ -71,20 +71,7 @@ module.exports = angular.module('spinnaker.serverGroup.configure.titan.cloneServ
     function configureCommand() {
       titanServerGroupConfigurationService.configureCommand(serverGroupCommand).then(function () {
         $scope.state.loaded = true;
-        initializeWizardState();
       });
-    }
-
-    function initializeWizardState() {
-      var mode = serverGroupCommand.viewState.mode;
-      if (mode === 'clone' || mode === 'editPipeline') {
-        if ($scope.command.image || $scope.command.viewState.disableImageSelection) {
-          v2modalWizardService.markComplete('location');
-        }
-        v2modalWizardService.markComplete('resources');
-        v2modalWizardService.markComplete('capacity');
-        v2modalWizardService.markComplete('parameters');
-      }
     }
 
     this.isValid = function () {

--- a/app/scripts/modules/titan/serverGroup/configure/wizard/serverGroupWizard.html
+++ b/app/scripts/modules/titan/serverGroup/configure/wizard/serverGroupWizard.html
@@ -7,20 +7,18 @@
       <h3 us-spinner="{radius:30, width:8, length: 16}"></h3>
     </div>
     <v2-modal-wizard ng-show="state.loaded" heading="{{title}}">
-      <v2-wizard ng-show="state.loaded && !state.requiresTemplateSelection" heading="{{title}}">
-        <v2-wizard-page key="location" label="Basic Settings">
-          <ng-include src="pages.basicSettings"></ng-include>
-        </v2-wizard-page>
-        <v2-wizard-page key="resources" label="Resources">
-          <ng-include src="pages.resources"></ng-include>
-        </v2-wizard-page>
-        <v2-wizard-page key="capacity" label="Capacity">
-          <ng-include src="pages.capacity"></ng-include>
-        </v2-wizard-page>
-        <v2-wizard-page key="parameters" label="Environment" mandatory="false">
-          <ng-include src="pages.parameters"></ng-include>
-        </v2-wizard-page>
-      </v2-wizard>
+      <v2-wizard-page key="location" label="Basic Settings">
+        <ng-include src="pages.basicSettings"></ng-include>
+      </v2-wizard-page>
+      <v2-wizard-page key="resources" label="Resources">
+        <ng-include src="pages.resources"></ng-include>
+      </v2-wizard-page>
+      <v2-wizard-page key="capacity" label="Capacity">
+        <ng-include src="pages.capacity"></ng-include>
+      </v2-wizard-page>
+      <v2-wizard-page key="parameters" label="Environment" mandatory="false">
+        <ng-include src="pages.parameters"></ng-include>
+      </v2-wizard-page>
     </v2-modal-wizard>
     <div class="modal-footer">
       <button ng-disabled="taskMonitor.submitting" class="btn btn-default btn-cancel" ng-click="ctrl.cancel()">Cancel


### PR DESCRIPTION
We have a race condition the _second_ time a pipeline deployment command for titan is initialized: the command is ready immediately, which is before the wizard is initialized, so we get NPEs. This "fixes" that scenario by avoiding it altogether - the pages will automatically be marked as complete on render, so there's no need for the initialization block.