### PR TITLE
Update default chaos monkey config options

### DIFF
--- a/app/scripts/modules/netflix/application/netflixCreateApplicationModal.controller.js
+++ b/app/scripts/modules/netflix/application/netflixCreateApplicationModal.controller.js
@@ -32,7 +32,7 @@ module.exports = angular
     if (this.chaosEnabled) {
       this.application.chaosMonkey = {
         enabled: true,
-        meanTimeBetweenKillsInWorkDays: 5,
+        meanTimeBetweenKillsInWorkDays: 2,
         minTimeBetweenKillsInWorkDays: 1,
         grouping: 'cluster',
         regionsAreIndependent: true,

--- a/app/scripts/modules/netflix/chaosMonkey/chaosMonkeyConfig.directive.js
+++ b/app/scripts/modules/netflix/chaosMonkey/chaosMonkeyConfig.directive.js
@@ -30,7 +30,7 @@ module.exports = angular
     }
     let config = this.application.attributes.chaosMonkey || {
         enabled: false,
-        meanTimeBetweenKillsInWorkDays: 5,
+        meanTimeBetweenKillsInWorkDays: 2,
         minTimeBetweenKillsInWorkDays: 1,
         grouping: 'cluster',
         regionsAreIndependent: true,


### PR DESCRIPTION
Change default Chaos Monkey meanTimeBetweenKillsInWorkDays from 5 days to 2
days, for consistency with existing Chaos Monkey behavior.