### PR TITLE
Cleanup VPC references in server group and instances details

### DIFF
--- a/app/scripts/modules/azure/instance/details/instanceDetails.html
+++ b/app/scripts/modules/azure/instance/details/instanceDetails.html
@@ -81,8 +81,6 @@
               serverGroup: instance.serverGroup,
               provider: instance.provider})">{{instance.serverGroup}}</a>
         </dd>
-        <dt ng-if="instance.serverGroup">VPC</dt>
-        <dd ng-if="instance.serverGroup"><vpc-tag vpc-id="instance.vpcId"></vpc-tag></dd>
       </dl>
     </collapsible-section>
     <collapsible-section heading="Status" expanded="true">

--- a/app/scripts/modules/azure/serverGroup/details/serverGroupDetails.html
+++ b/app/scripts/modules/azure/serverGroup/details/serverGroupDetails.html
@@ -104,17 +104,6 @@
 
           {{serverGroup.region}}
         </dd>
-        <dt>VPC</dt>
-        <dd><vpc-tag vpc-id="serverGroup.vpcId"></vpc-tag></dd>
-        <dt ng-if="serverGroup.vpcId">Subnet</dt>
-        <dd ng-if="serverGroup.vpcId">{{serverGroup.subnetType || 'None (EC2 Classic)'}}</dd>
-        <dt>Availability Zones</dt>
-        <dd>
-          <ul>
-            <li ng-repeat="zone in serverGroup.asg.availabilityZones">{{zone}}</li>
-          </ul>
-        </dd>
-
       </dl>
     </collapsible-section>
     <collapsible-section heading="Size" expanded="true">


### PR DESCRIPTION
Cleanup VPC references in server group and instances details since these are not relevant when displaying Azure resource details