### PR TITLE
various tweaks to scaling policies per user feedback

### DIFF
--- a/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/chart/metricAlarmChart.component.js
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/chart/metricAlarmChart.component.js
@@ -43,7 +43,7 @@ module.exports = angular
         let start = new Date(new Date().getTime() - 24 * 60 * 60 * 1000),
             end = new Date(),
             threshold = this.alarm.threshold || 0,
-            topline = this.alarm.comparisonOperator.indexOf('Less') === 0 ? threshold * 3 : 0;
+            topline = this.alarm.comparisonOperator.indexOf('Less') === 0 ? threshold * 3 : threshold * 1.02;
 
         /**
          * Draw four lines:
@@ -137,7 +137,7 @@ module.exports = angular
               axis: 'y',
               dataset: 'threshold',
               key: 'val',
-              label: 'alarm threshold',
+              label: `alarm threshold (${this.alarm.threshold})`,
               color: 'hsl(343, 79%, 32%)',
               type: ['line'],
               id: 'threshold',
@@ -146,7 +146,7 @@ module.exports = angular
               axis: 'y',
               dataset: 'baseline',
               key: 'val',
-              label: '',
+              label: ' ',
               color: 'transparent',
               type: ['line'],
               id: 'baseline'
@@ -155,7 +155,7 @@ module.exports = angular
               axis: 'y',
               dataset: 'topline',
               key: 'val',
-              label: '',
+              label: ' ',
               color: 'transparent',
               type: ['line'],
               id: 'topline'

--- a/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/chart/metricAlarmChart.component.less
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/chart/metricAlarmChart.component.less
@@ -1,13 +1,7 @@
 metric-alarm-chart {
   position: relative;
   display: block;
-  &.no-y-axis {
-    .y-axis {
-      .tick {
-        display: none;
-      }
-    }
-  }
+  margin-bottom: 50px;
   .chart {
     .line-series {
       path {
@@ -19,7 +13,12 @@ metric-alarm-chart {
     }
   }
   .chart-legend {
-    display: none;
+    margin-top: -10px;
+    margin-left: 48px;
+    .item > .icon {
+      width: 14px;
+      height: 14px;
+    }
   }
   .no-data-overlay {
     position: absolute;

--- a/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/chart/metricAlarmChart.component.spec.js
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/chart/metricAlarmChart.component.spec.js
@@ -182,20 +182,20 @@ describe('Component: metricAlarmChart', function () {
       expect($ctrl.chartData.threshold.map(d => d.val)).toEqual([3.1, 3.1]);
     });
 
-    it('sets topline to 0 when alarm comparator is >=', function () {
-      alarm.threshold = 3.1;
+    it('sets topline to 1.02x threshold when alarm comparator is >=', function () {
+      alarm.threshold = 10;
       alarm.comparisonOperator = 'GreaterThanOrEqualToThreshold';
       this.initialize({ alarm: alarm, serverGroup: {}});
       $ctrl.$onInit();
-      expect($ctrl.chartData.topline.map(d => d.val)).toEqual([0, 0]);
+      expect($ctrl.chartData.topline.map(d => d.val)).toEqual([10.2, 10.2]);
     });
 
-    it('sets topline to 0 when alarm comparator is >', function () {
-      alarm.threshold = 3.1;
+    it('sets topline to 1.02x threshold when alarm comparator is >', function () {
+      alarm.threshold = 100;
       alarm.comparisonOperator = 'GreaterThanThreshold';
       this.initialize({ alarm: alarm, serverGroup: {}});
       $ctrl.$onInit();
-      expect($ctrl.chartData.topline.map(d => d.val)).toEqual([0, 0]);
+      expect($ctrl.chartData.topline.map(d => d.val)).toEqual([102, 102]);
     });
 
     it('sets topline to 3 * threshold when alarm comparator is <', function () {

--- a/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/popover/scalingPolicyPopover.component.html
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/popover/scalingPolicyPopover.component.html
@@ -86,7 +86,6 @@
   </dl>
   <metric-alarm-chart style="height: 100px;"
                       alarm="$ctrl.policy.alarms[0]"
-                      class="no-y-axis"
-                      margins="{top: 5, left: 30}"
+                      margins="{top: 5, left: 50}"
                       server-group="$ctrl.serverGroup"></metric-alarm-chart>
 </div>

--- a/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/alarm/alarmConfigurer.component.html
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/alarm/alarmConfigurer.component.html
@@ -23,10 +23,10 @@
             style="vertical-align: top;"
             required
             ng-model="$ctrl.alarm.statistic"
-            ng-change="$ctrl.metricChanged()"
+            ng-change="$ctrl.metricChanged(true)"
             ng-options="stat for stat in $ctrl.statistics">
     </select>
-    <span class="input-label"> of </span>
+    <span class="input-label" style="vertical-align: top; margin-top: 7px"> of </span>
     <div style="display: inline-block; width: 500px" ng-if="$ctrl.viewState.metricsLoaded">
       <select class="form-control input-sm"
               required
@@ -52,8 +52,18 @@
       <a href class="small"
          ng-if="!$ctrl.viewState.advancedMode"
          ng-click="$ctrl.advancedMode()">
-        Search all metrics
+        Search all metrics <help-field key="aws.scalingPolicy.search.all"></help-field>
       </a>
+      <span class="input-label" ng-if="$ctrl.viewState.advancedMode && $ctrl.metrics.length === 0">
+        No metrics found for selected namespace + dimensions
+      </span>
+      <div style="padding-left: 5px;">
+        <a href class="small"
+           ng-if="$ctrl.viewState.advancedMode"
+           ng-click="$ctrl.simpleMode()">
+          Only show metrics for this auto scaling group <help-field key="aws.scalingPolicy.search.restricted"></help-field>
+        </a>
+      </div>
       <div ng-if="$ctrl.viewState.advancedMode">
         <dimensions-editor alarm="$ctrl.alarm"
                            server-group="$ctrl.serverGroup"

--- a/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/alarm/dimensionsEditor.component.html
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/alarm/dimensionsEditor.component.html
@@ -1,9 +1,9 @@
 <div class="row">
-  <div class="col-md-12" style="padding-left: 20px;">
-    <span class="sm-label sm-label-left">Dimensions</span>
+  <div class="col-md-12 small">
+    <div>Enter dimensions to filter the available metrics above.</div>
   </div>
 </div>
-<div ng-repeat="dimension in $ctrl.alarm.dimensions" class="row">
+<div ng-repeat="dimension in $ctrl.alarm.dimensions" class="row dimensions-row">
   <div class="col-md-4" style="padding-right: 0">
     <input type="text" class="form-control input-sm" style="width: 100%"
            required
@@ -32,7 +32,6 @@
 <div class="row">
   <div class="col-md-10">
     <button class="btn btn-block btn-xs add-new"
-            style="width: 100%; margin-left: 5px; padding: 4px"
             ng-click="$ctrl.alarm.dimensions.push({})">
       <span class="glyphicon glyphicon-plus-sign"></span>
       Add dimension

--- a/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/alarm/dimensionsEditor.component.js
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/alarm/dimensionsEditor.component.js
@@ -2,6 +2,8 @@
 
 const angular = require('angular');
 
+require('./dimensionsEditor.component.less');
+
 module.exports = angular
   .module('spinnaker.aws.serverGroup.details.scalingPolicy.dimensionEditor', [
     require('../../../../../../core/utils/lodash.js'),

--- a/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/alarm/dimensionsEditor.component.less
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/alarm/dimensionsEditor.component.less
@@ -1,0 +1,15 @@
+dimensions-editor {
+  display: block;
+  padding-left: 5px;
+
+  .dimensions-row {
+    margin-top: 5px;
+    margin-left: -20px;
+  }
+
+  .add-new {
+    margin-left: 0;
+    padding: 4px;
+    width: 100%;
+  }
+}

--- a/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/simple/simplePolicyAction.component.html
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/simple/simplePolicyAction.component.html
@@ -10,7 +10,7 @@
            class="form-control input-sm"
            style="width: 65px"
            required
-           ng-model="$ctrl.policy.scalingAdjustment"/>
+           ng-model="$ctrl.command.simple.scalingAdjustment"/>
 
     <select class="form-control input-sm"
             style="width: 110px"

--- a/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/simple/simplePolicyAction.component.js
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/simple/simplePolicyAction.component.js
@@ -7,7 +7,7 @@ module.exports = angular
   ])
   .component('awsSimplePolicyAction', {
     bindings: {
-      policy: '<',
+      command: '<',
       viewState: '=',
     },
     templateUrl: require('./simplePolicyAction.component.html'),

--- a/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/step/stepPolicyAction.component.html
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/step/stepPolicyAction.component.html
@@ -7,12 +7,12 @@
             ng-model="$ctrl.viewState.operator"
             ng-change="$ctrl.operatorChanged()"
             ng-options="adjustment for adjustment in $ctrl.availableActions"></select>
-              <span style="width: 75px; text-transform: capitalize"
-                    class="form-control-static select-placeholder"
-                    ng-bind="$ctrl.viewState.operator"
-                    ng-if="!$first"></span>
+    <span style="width: 75px; text-transform: capitalize"
+          class="form-control-static select-placeholder"
+          ng-bind="$ctrl.viewState.operator"
+          ng-if="!$first"></span>
 
-    <input type="number" min="0"
+    <input type="number" min="1"
            class="form-control input-sm"
            required
            style="width: 65px"
@@ -28,16 +28,19 @@
     <span style="width: 120px" class="form-control-static select-placeholder"
           ng-if="!$first" ng-bind="$ctrl.viewState.adjustmentType"></span>
     <span class="input-label">
-    when
+      when <strong ng-bind="$ctrl.command.alarm.metricName"></strong>
     </span>
-    <span ng-if="$ctrl.viewState.comparatorBound === 'max'">
 
-      <span class="input-label text-right"
-            ng-bind="step.metricIntervalLowerBound"
-            style="width: 65px"></span>
-      <span class="input-label">&le;</span>
-      <span class="input-label" ng-bind="$ctrl.command.alarm.metricName"></span>
-      <span is-visible="!$last" class="input-label">&lt;</span>
+    <span ng-if="$ctrl.viewState.comparatorBound === 'max'">
+      <span class="input-label" ng-if="!$last">
+        is between
+      </span>
+      <span class="input-label" ng-bind="step.metricIntervalLowerBound"></span>
+      <span class="input-label" ng-if="!$last">and</span>
+      <span class="input-label" ng-if="$last">
+        is greater than
+      </span>
+
       <input type="number"
              ng-if="!$last"
              class="form-control input-sm"
@@ -46,18 +49,12 @@
              required
              ng-min="step.metricIntervalLowerBound"
              style="width: 85px"/>
-      <span style="width: 65px"
-            class="select-placeholder"
-            ng-if="$last"></span>
     </span>
 
     <span ng-if="$ctrl.viewState.comparatorBound === 'min'">
-      <span class="input-label text-right"
-            ng-bind="step.metricIntervalUpperBound"
-            style="width: 65px"></span>
-      <span class="input-label">&ge;</span>
-      <span class="input-label" ng-bind="$ctrl.command.alarm.metricName"></span>
-      <span is-visible="!$last" class="input-label">&gt;</span>
+      <span class="input-label" ng-if="!$last">
+        is between
+      </span>
       <input type="number"
              ng-if="!$last"
              class="form-control input-sm"
@@ -66,7 +63,14 @@
              ng-max="step.metricIntervalUpperBound"
              ng-change="$ctrl.boundsChanged()"
              style="width: 85px"/>
+      <span class="input-label" ng-if="!$last">and</span>
+      <span class="input-label" ng-if="$last">
+        is less than
+      </span>
+
+      <span class="input-label text-right" ng-bind="step.metricIntervalUpperBound"></span>
     </span>
+
     <span ng-if="!$first" class="pull-right" style="padding: 5px 0;">
       <a href ng-click="$ctrl.removeStep($index)">
         <span class="glyphicon glyphicon-trash"></span>
@@ -78,7 +82,7 @@
   <div class="col-md-10 col-md-offset-1">
     <button class="btn btn-block btn-sm add-new" ng-click="$ctrl.addStep(step)">
       <span class="glyphicon glyphicon-plus-sign"></span>
-      Add action
+      Add step
     </button>
   </div>
 </div>

--- a/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/step/stepPolicyAction.component.js
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/step/stepPolicyAction.component.js
@@ -32,7 +32,7 @@ module.exports = angular
       };
 
       this.addStep = () => {
-        this.command.step.stepAdjustments.push({});
+        this.command.step.stepAdjustments.push({ scalingAdjustment: 1 });
       };
 
       this.removeStep = (index) => {

--- a/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/upsertScalingPolicy.modal.html
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/upsertScalingPolicy.modal.html
@@ -22,12 +22,14 @@
         <div ng-if="ctrl.command.simple">
           <div class="row">
             <div class="col-md-10 col-md-offset-1">
-              <p>This is a simple scaling policy. To declare different actions based on the magnitude of the alarm,
-                convert it to a <a href ng-click="ctrl.switchMode()">step policy</a>.</p>
+              <p>
+                This is a simple scaling policy. To declare different actions based on the magnitude of the alarm,
+                <strong>switch to a <a href ng-click="ctrl.switchMode()">step policy</a>.</strong>
+              </p>
             </div>
           </div>
 
-          <aws-simple-policy-action policy="ctrl.command.simple"
+          <aws-simple-policy-action command="ctrl.command"
                                     view-state="ctrl.viewState"></aws-simple-policy-action>
         </div>
         <div ng-if="ctrl.command.step">

--- a/app/scripts/modules/core/help/helpContents.js
+++ b/app/scripts/modules/core/help/helpContents.js
@@ -46,6 +46,10 @@ module.exports = angular.module('spinnaker.core.help.contents', [])
     'aws.securityGroup.vpc': '<p>The VPC to which this security group will apply.</p>' +
       '<p>If you wish to use VPC but are unsure which VPC to use, the most common one is "Main".</p>' +
       '<p>If you do not wish to use VPC, select "None".</p>',
+    'aws.scalingPolicy.search.restricted': '<p>Resets dimensions to "AutoScalingGroupName: {name of the ASG}" and provides' +
+    ' a simpler, combined input for the namespace and metric name fields.</p>',
+    'aws.scalingPolicy.search.all': '<p>Allows you to edit the dimensions and namespace to find a specific metric for' +
+    ' this alarm.</p>',
     'cf.artifact.repository.options': '<p>You may include {job} and {buildNumber} to dynamically build a path to your artifact.</p>',
     'cluster.search': 'Quickly filter the displayed server groups by the following fields:' +
       '<ul>' +


### PR DESCRIPTION
- adding legend to graph to provide more context about what the lines are
- including y-scale in popover graph
- changed text on "convert to step policy" action to clarify it does not persist the change immediately
- "Add action" is now "Add step"
- switching direction of threshold, e.g. `<` to `>`, clears existing steps
- step markers are presented in a more human readable format
- graph updates when statistic changes
- added help text and inline text to clarify dimensions and metrics/namespaces in advanced search view
- default adjustment step to "1"