### PR TITLE
fixes population of default values when swapping between exact and incremental resize types

### DIFF
--- a/app/scripts/modules/core/pipeline/config/stages/resizeAsg/aws/awsResizeAsgStage.js
+++ b/app/scripts/modules/core/pipeline/config/stages/resizeAsg/aws/awsResizeAsgStage.js
@@ -79,7 +79,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.aws.resizeAsgStag
     stage.target = stage.target || $scope.resizeTargets[0].val;
     stage.action = stage.action || $scope.scaleActions[0].val;
     stage.resizeType = stage.resizeType || $scope.resizeTypes[0].val;
-    if (stage.resizeType === 'exact') {
+    if (!stage.action && stage.resizeType === 'exact') {
       stage.action = 'scale_exact';
     }
     stage.cloudProvider = 'aws';
@@ -104,8 +104,10 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.aws.resizeAsgStag
         stage.capacity = {};
         if (stage.resizeType === 'pct') {
           delete stage.scaleNum;
-        } else if (stage.resizeType === 'incr') {
+        } else {
+          stage.resizeType = 'incr';
           delete stage.scalePct;
+          stage.scaleNum = stage.scaleNum || 0;
         }
       }
     };


### PR DESCRIPTION
currently switching the control to 'scale to exact size' then back to 'scale up/down/to cluster size' leaves the resizeType as exact (unless the user goes and specifically changes that). This changes two things:

1) only figure out that we are in 'exact' mode if the action is unspecified. That change was in to handle the case of a pre-November 2015 created pipeline where exact was not an action

2) when selecting one of the other resize actions, ensure we always specify a resizeType (it falls through to increment by 0 as a default)

@spinnaker/netflix-reviewers PTAL