### PR TITLE
differentiate between vpc and classic reservations in report

### DIFF
--- a/app/scripts/modules/netflix/report/reservationReport.directive.html
+++ b/app/scripts/modules/netflix/report/reservationReport.directive.html
@@ -2,7 +2,11 @@
 <!-- TODO: Remove error switch when feature flagging is available to toggle this directive on and off -->
 <div class="small reservation-report" ng-if="!vm.viewState.loading && !vm.viewState.error">
   <div ng-if="!vm.viewState.error">
-    <h4>Reservations for {{vm.instanceType}} in <account-tag account="vm.account"></account-tag></h4>
+    <h4>
+      <span ng-if="vm.isVpc">VPC</span>
+      Reservations for {{vm.instanceType}} in
+      <account-tag account="vm.account"></account-tag>
+    </h4>
     <table class="table table-condensed">
       <thead>
       <tr>
@@ -14,12 +18,12 @@
       </tr>
       </thead>
       <tbody>
-        <tr ng-repeat="row in vm.report">
+        <tr ng-repeat="row in vm.reportData">
           <td>{{row.availabilityZone}}</td>
           <td>{{row.os}}</td>
-          <td>{{row.reservations.reserved}}</td>
-          <td>{{row.reservations.used}}</td>
-          <td><strong>{{row.reservations.surplus}}</strong></td>
+          <td>{{row.display.reserved}}</td>
+          <td>{{row.display.used}}</td>
+          <td><strong ng-class="row.display.surplus < 1 ? 'warning-text' : ''">{{row.display.surplus}}</strong></td>
         </tr>
       </tbody>
     </table>

--- a/app/scripts/modules/netflix/report/reservationReport.directive.spec.js
+++ b/app/scripts/modules/netflix/report/reservationReport.directive.spec.js
@@ -1,0 +1,128 @@
+'use strict';
+
+describe('Directives: reservation report', function () {
+
+  require('./reservationReport.directive.html');
+
+  beforeEach(window.module(require('./reservationReport.directive')));
+  beforeEach(function() {
+    jasmine.addMatchers(require('../../../../../test/helpers/customMatchers'));
+  });
+
+  beforeEach(window.inject(function ($rootScope, $compile, reservationReportReader, $httpBackend, settings, accountService, $q) {
+    this.scope = $rootScope.$new();
+    this.compile = $compile;
+    this.reservationReportReader = reservationReportReader;
+    this.$http = $httpBackend;
+    this.settings = settings;
+
+    spyOn(accountService, 'challengeDestructiveActions').and.returnValue($q.when(false));
+
+    this.$http.expectGET([this.settings.gateUrl, 'reports', 'reservation', 'v2'].join('/')).respond(200, {
+      reservations: [
+        { availabilityZone: 'us-east-1a', instanceType: 'm3.medium', os: 'LINUX', region: 'us-east-1',
+          accounts: {
+            prod: {reserved: 3, used: 1, surplus: 2, reservedVpc: 5, usedVpc: 1, surplusVpc: 4 },
+            test: {reserved: 3, used: 0, surplus: 3, reservedVpc: 1, usedVpc: 1, surplusVpc: 0 }
+          },
+        },
+        { availabilityZone: 'us-east-1a', instanceType: 'm3.large', os: 'LINUX', region: 'us-east-1',
+          accounts: {
+            prod: {reserved: 1, used: 1, surplus: 0, reservedVpc: 1, usedVpc: 1, surplusVpc: 0 },
+            test: {reserved: 3, used: 1, surplus: 2, reservedVpc: 2, usedVpc: 1, surplusVpc: 1 }
+          },
+        },
+        { availabilityZone: 'us-east-1b', instanceType: 'm3.medium', os: 'LINUX', region: 'us-east-1',
+          accounts: {
+            prod: {reserved: 13, used: 11, surplus: 2, reservedVpc: 15, usedVpc: 11, surplusVpc: 4 },
+            test: {reserved: 13, used: 10, surplus: 3, reservedVpc: 11, usedVpc: 11, surplusVpc: 0 }
+          },
+        },
+        { availabilityZone: 'us-east-1b', instanceType: 'm3.large', os: 'LINUX', region: 'us-east-1',
+          accounts: {
+            prod: {reserved: 1, used: 2, surplus: -1, reservedVpc: 11, usedVpc: 11, surplusVpc: 0 },
+            test: {reserved: 13, used: 1, surplus: 12, reservedVpc: 12, usedVpc: 11, surplusVpc: 1 }
+          },
+        },
+        { availabilityZone: 'us-east-1c', instanceType: 'm3.medium', os: 'LINUX', region: 'us-east-1',
+          accounts: {
+            prod: {reserved: 23, used: 1, surplus: 22, reservedVpc: 25, usedVpc: 21, surplusVpc: 4 },
+            test: {reserved: 23, used: 33, surplus: -10, reservedVpc: 21, usedVpc: 21, surplusVpc: 0 }
+          },
+        },
+        { availabilityZone: 'us-east-1c', instanceType: 'm3.large', os: 'LINUX', region: 'us-east-1',
+          accounts: {
+            prod: {reserved: 31, used: 1, surplus: 30, reservedVpc: 31, usedVpc: 31, surplusVpc: 0 },
+            test: {reserved: 33, used: 1, surplus: 32, reservedVpc: 2, usedVpc: 31, surplusVpc: -29 }
+          },
+        },
+      ]
+    });
+
+  }));
+
+  it('displays two rows for report', function () {
+    var scope = this.scope,
+        compile = this.compile;
+
+    scope.account = 'prod';
+    scope.region = 'us-east-1';
+    scope.instanceType = 'm3.medium';
+    scope.zones = ['us-east-1a', 'us-east-1c'];
+    scope.isVpc = true;
+
+    var report = compile('<reservation-report account="account" region="region" instance-type="instanceType" zones="zones" is-vpc="isVpc"></reservation-report>')(scope);
+
+    scope.$digest();
+    this.$http.flush();
+
+    expect(report.find('h4')).textMatch('VPC Reservations for m3.medium in prod');
+    expect(report.find('tbody tr').size()).toBe(2);
+  });
+
+  it('updates report title, rows when account, region, instanceType, zones, vpc flag change', function () {
+    var scope = this.scope,
+        compile = this.compile;
+
+    scope.account = 'prod';
+    scope.region = 'us-east-1';
+    scope.instanceType = 'm3.medium';
+    scope.zones = ['us-east-1a', 'us-east-1c'];
+    scope.isVpc = false;
+
+    var report = compile('<reservation-report account="account" region="region" instance-type="instanceType" zones="zones" is-vpc="isVpc"></reservation-report>')(scope);
+
+    scope.$digest();
+    this.$http.flush();
+
+    expect(report.find('h4')).textMatch('Reservations for m3.medium in prod');
+    expect(report.find('tbody tr td:eq(2)')).textMatch('3');
+
+    scope.isVpc = true;
+    scope.$digest();
+    expect(report.find('h4')).textMatch('VPC Reservations for m3.medium in prod');
+    expect(report.find('tbody tr td:eq(2)')).textMatch('5');
+
+    scope.instanceType = 'm3.large';
+    scope.$digest();
+    expect(report.find('h4')).textMatch('VPC Reservations for m3.large in prod');
+    expect(report.find('tbody tr td:eq(2)')).textMatch('1');
+
+    scope.account = 'test';
+    scope.$digest();
+    expect(report.find('h4')).textMatch('VPC Reservations for m3.large in test');
+    expect(report.find('tbody tr td:eq(2)')).textMatch('2');
+
+    scope.region = 'us-west-2';
+    scope.$digest();
+    expect(report.find('h4')).textMatch('VPC Reservations for m3.large in test');
+    expect(report.find('tbody tr').size()).toBe(0);
+
+    scope.region = 'us-east-1';
+    scope.zones = ['us-east-1a'];
+    scope.$digest();
+    expect(report.find('h4')).textMatch('VPC Reservations for m3.large in test');
+    expect(report.find('tbody tr').size()).toBe(1);
+    expect(report.find('tbody tr td:eq(2)')).textMatch('2');
+  });
+});

--- a/app/scripts/modules/netflix/report/reservationReport.read.service.js
+++ b/app/scripts/modules/netflix/report/reservationReport.read.service.js
@@ -4,16 +4,14 @@ let angular = require('angular');
 
 module.exports = angular
   .module('spinnaker.amazon.instance.report.reservation.read.service', [
-    require('exports?"restangular"!imports?_=lodash!restangular'),
     require('../../core/utils/lodash.js'),
+    require('../../core/config/settings.js'),
   ])
-  .factory('reservationReportReader', function (Restangular) {
-    function getReservationsFor(account, region, instanceType) {
-      return Restangular.one('reports', 'reservation')
-        .get()
-        .then((result) => {
-          return extractReservations(result.reservations, account, region, instanceType);
-        });
+  .factory('reservationReportReader', function ($http, settings) {
+
+    function getReservations() {
+      return $http.get([settings.gateUrl, 'reports', 'reservation', 'v2'].join('/'))
+          .then((response) => response.data);
     }
 
     function extractReservations(reservations, account, region, instanceType) {
@@ -31,6 +29,7 @@ module.exports = angular
     }
 
     return {
-      getReservationsFor: getReservationsFor
+      getReservations: getReservations,
+      extractReservations: extractReservations,
     };
   });

--- a/app/scripts/modules/netflix/serverGroup/resize/awsResizeServerGroup.html
+++ b/app/scripts/modules/netflix/serverGroup/resize/awsResizeServerGroup.html
@@ -11,6 +11,7 @@
           <reservation-report account="serverGroup.account"
                               region="serverGroup.region"
                               zones="serverGroup.asg.availabilityZones"
+                              is-vpc="!!serverGroup.vpcId"
                               instance-type="serverGroup.launchConfig.instanceType"></reservation-report>
         </div>
       </div>

--- a/app/scripts/modules/netflix/serverGroup/wizard/capacity/awsServerGroupCapacity.html
+++ b/app/scripts/modules/netflix/serverGroup/wizard/capacity/awsServerGroupCapacity.html
@@ -5,6 +5,7 @@
                           account="command.credentials"
                           region="command.region"
                           zones="command.availabilityZones"
+                          is-vpc="!!command.subnetType"
                           instance-type="command.instanceType"></reservation-report>
     </div>
   </div>

--- a/test/helpers/customMatchers.js
+++ b/test/helpers/customMatchers.js
@@ -1,0 +1,25 @@
+'use strict';
+var matchers = {
+  textMatch: function() {
+    return {
+      compare: function(actual, expected) {
+        if (expected === undefined) {
+          expected = '';
+        }
+        if (actual !== undefined) {
+          actual = actual.text().trim().replace(/\s+/g, ' ');
+        }
+        var result = {};
+        result.pass = expected === actual;
+        if (result.pass) {
+          result.message = 'Expected ' + expected;
+        } else {
+          result.message = 'Expected ' + expected + ' but was ' + actual;
+        }
+        return result;
+      }
+    };
+  }
+};
+
+module.exports = matchers;


### PR DESCRIPTION
* Use v2 reservation report endpoint
* Differentiate between classic and VPC reservations
* Update report when account, region, zones, instance type, or VPC flag changes
* Avoid over-fetching reservation report when above values change

@ajordens for your review