### PR TITLE
Adding some right hand room to the multiselect ui-select box

### DIFF
--- a/app/scripts/modules/core/modal/modals.less
+++ b/app/scripts/modules/core/modal/modals.less
@@ -282,7 +282,7 @@ abbr.select2-search-choice-close {
     box-shadow: none;
     background-image: none;
     .select2-search-field {
-      width: calc(~"100% - 30px");
+      width: calc(~"100% - 40px");
       float: none;
       border: 1px dashed #a5a5a5;
       color: #a5a5a5;
@@ -316,7 +316,7 @@ abbr.select2-search-choice-close {
       box-shadow: none;
       div, span span {
         padding: 5px;
-        width: calc(~"100% - 30px");
+        width: calc(~"100% - 40px");
         display: inline-block;
         border: 1px solid #cccccc;
         border-radius: 4px;

--- a/app/scripts/modules/core/presentation/main.less
+++ b/app/scripts/modules/core/presentation/main.less
@@ -561,7 +561,20 @@ body > .container {
   overflow-x: hidden;
   overflow-y: hidden;
   border-radius: 3px;
+  ::-webkit-scrollbar {
+    background: transparent;
+    width: 8px;
+  }
+  ::-webkit-scrollbar-thumb {
+    background: transparent;
+  }
+  :hover {
+    ::-webkit-scrollbar-thumb {
+      background: #bdbdbd;
+    }
+  }
 }
+
 
 .modal-pages {
   width:1200px;
@@ -1076,7 +1089,7 @@ body, html {
 
 .ui-select-multiple {
   .select2-drop {
-    width: calc(~"100% - 30px");
+    width: calc(~"100% - 40px");
     margin-left: 1px;
   }
 }


### PR DESCRIPTION
The issue was that the scroll bar in the modal cluster view (clone, create, edit in pipeline) was covering the delete icon for the load balancer and security group multiselect box.

I trimed the width down by 10px and styled the scrollbar in the modals to be thinner and not expand on hover.

@anotherchrisberry PTAL