### PR TITLE
core & kubernetes: Collapsible subheadings

### DIFF
--- a/app/scripts/modules/core/presentation/collapsibleSection/collapsibleSection.directive.html
+++ b/app/scripts/modules/core/presentation/collapsibleSection/collapsibleSection.directive.html
@@ -1,10 +1,10 @@
-<div class="collapsible-section">
-    <a href class="section-heading" ng-click="toggle()">
-      <h4 class="collapsible-heading">
-        <span class="glyphicon glyphicon-chevron-{{getIcon()}}"></span>
-        {{heading}}
-        <help-field ng-if="helpKey" key="{{helpKey}}" placement="right"></help-field>
-      </h4>
-    </a>
+<div class="collapsible-{{getClassType()}}section">
+  <a href class="section-{{getClassType()}}heading" ng-click="toggle()">
+    <h4 class="collapsible-{{getClassType()}}heading">
+      <span class="glyphicon glyphicon-chevron-{{getIcon()}}"></span>
+      {{heading}}
+      <help-field ng-if="helpKey" key="{{helpKey}}" placement="right"></help-field>
+    </h4>
+  </a>
   <div class="content-body" ng-class="bodyClass" ng-if="state.expanded" ng-transclude></div>
 </div>

--- a/app/scripts/modules/core/presentation/collapsibleSection/collapsibleSection.directive.js
+++ b/app/scripts/modules/core/presentation/collapsibleSection/collapsibleSection.directive.js
@@ -14,7 +14,8 @@ module.exports = angular.module('spinnaker.core.presentation.collapsibleSection.
         heading: '@',
         expanded: '@?',
         bodyClass: '@?',
-        helpKey: '@'
+        helpKey: '@',
+        subsection: '=',
       },
       templateUrl: require('./collapsibleSection.directive.html'),
       link: function(scope) {
@@ -24,6 +25,10 @@ module.exports = angular.module('spinnaker.core.presentation.collapsibleSection.
         scope.state = {expanded: expanded};
         scope.getIcon = function() {
           return scope.state.expanded ? 'down' : 'up';
+        };
+
+        scope.getClassType = function() {
+          return scope.subsection ? 'sub' : '';
         };
 
         scope.toggle = function() {

--- a/app/scripts/modules/core/presentation/main.less
+++ b/app/scripts/modules/core/presentation/main.less
@@ -812,6 +812,44 @@ tfoot .add-new {
   }
 }
 
+.collapsible-subsection {
+  a.section-subheading {
+    color: #000000;
+  }
+  h4.collapsible-subheading {
+    padding: 10px 15px;
+    background-color: @lightest_grey;
+    margin: 0;
+    .glyphicon {
+      font-size: 70%;
+      opacity: 0.7;
+      margin-right: 4px;
+      font-weight: 200;
+    }
+    font-size: 115%;
+    font-weight: 200;
+  }
+  .content-body {
+    .fade-in(0.15);
+    .clearfix;
+    padding-left: 17px;
+    margin: 10px 0 20px 0;
+    ul {
+      list-style-type: none;
+      padding-left: 0;
+    }
+  }
+  padding: 0;
+
+  &:last-child {
+    border-bottom-width: 0;
+  }
+
+  &:first-child {
+    padding-top: 0;
+  }
+}
+
 .collapsible-section {
   a.section-heading {
     color: #000000;

--- a/app/scripts/modules/kubernetes/container/configurer.directive.html
+++ b/app/scripts/modules/kubernetes/container/configurer.directive.html
@@ -32,7 +32,7 @@
     </div>
   </div>
 
-  <collapsible-section heading="Basic Settings" expanded="false">
+  <collapsible-section heading="Basic Settings" expanded="false" subsection="true">
     <div class="form-group">
       <div class="sm-label-left">
         <b>Commands</b>
@@ -121,7 +121,7 @@
     </div>
   </collapsible-section>
 
-  <collapsible-section heading="Resources" expanded="false">
+  <collapsible-section heading="Resources" expanded="false" subsection="true">
     <div class="form-group">
       <div class="col-md-3">
       </div>
@@ -166,7 +166,7 @@
     </div>
   </collapsible-section>
 
-  <collapsible-section heading="Ports" expanded="false">
+  <collapsible-section heading="Ports" expanded="false" subsection="true">
     <div ng-repeat="port in container.ports">
       <hr ng-if="$index > 0">
       <div class="form-group">
@@ -226,7 +226,7 @@
       class="glyphicon glyphicon-plus-sign"></span> Add New Port
     </button>
   </collapsible-section>
-  <collapsible-section heading="Volume Mounts" expanded="false">
+  <collapsible-section heading="Volume Mounts" expanded="false" subsection="true">
     <div ng-repeat="mount in container.volumeMounts">
       <div class="form-group">
         <div class="col-md-3 sm-label-right">
@@ -269,7 +269,7 @@
       class="glyphicon glyphicon-plus-sign"></span> Add New Volume Mount
     </button>
   </collapsible-section>
-  <collapsible-section heading="Probes" expanded="false">
+  <collapsible-section heading="Probes" expanded="false" subsection="true">
     <kubernetes-container-probe container="container" command="command" probetype="'readinessProbe'" heading="'Readiness'"></kubernetes-container-probe>
     <hr>
     <kubernetes-container-probe container="container" command="command" probetype="'livenessProbe'" heading="'Liveness'"></kubernetes-container-probe>


### PR DESCRIPTION
Recently, a change broke the collapsible sections I was using in the create server group dialog. I've been meaning to make the collapsible sections used inside the dialogs looks different (less bold than the modal wizard subheadings), so I used this time to both fix the collapsible sections to create a separate collapsible "subsection".

Before:
![old-headings](https://cloud.githubusercontent.com/assets/4874941/14256192/f19fc656-fa65-11e5-9fd7-4c0f7ad5a4a2.png)


After:
![new-headings](https://cloud.githubusercontent.com/assets/4874941/14256195/f545b216-fa65-11e5-8825-17bea6cb3bc6.png)

@duftler @anotherchrisberry 