### PR TITLE
Adding show-all-regions flag on accountRegionClusterSelector component.

### DIFF
--- a/app/scripts/modules/core/pipeline/config/stages/findAmi/aws/findAmiStage.html
+++ b/app/scripts/modules/core/pipeline/config/stages/findAmi/aws/findAmiStage.html
@@ -2,7 +2,8 @@
   <account-region-cluster-selector
     application="application"
     component="stage"
-    accounts="accounts" >
+    accounts="accounts"
+    show-all-regions="true">
   </account-region-cluster-selector>
   <stage-config-field label="Server Group Selection">
     <ui-select ng-model="stage.selectionStrategy" class="form-control input-sm">

--- a/app/scripts/modules/core/widgets/accountRegionClusterSelector.component.js
+++ b/app/scripts/modules/core/widgets/accountRegionClusterSelector.component.js
@@ -18,6 +18,7 @@ module.exports = angular
         accounts: '=',
         clusterField: '@',
         singleRegion: '=',
+        showAllRegions: '=?'
       },
       templateUrl: require('./accountRegionClusterSelector.component.html'),
       controllerAs: 'vm',
@@ -26,6 +27,8 @@ module.exports = angular
         this.clusterField = this.clusterField || 'cluster';
 
         let vm = this;
+        let showAllRegions = vm.showAllRegions || false;
+
         let isTextInputForClusterFiled;
 
         let regions;
@@ -33,7 +36,7 @@ module.exports = angular
         let setRegionList = () => {
           let accountFilter = (cluster) => cluster.account === vm.component.credentials;
           let regionList = appListExtractorService.getRegions([vm.application], accountFilter);
-          vm.regions = regionList.length ? regionList : regions;
+          vm.regions = showAllRegions ? regions : regionList.length ? regionList : regions;
         };
 
 


### PR DESCRIPTION
This is need for the findAmi stage to show all the regions, not just the ones that have a cluster deployed in them.
The default is "false" for this flag.

@anotherchrisberry PTAL