### PR TITLE
This is to prevent some JS errors that can happen on the cluster filters

### DIFF
--- a/app/scripts/modules/core/application/listExtractor/listExtractor.service.js
+++ b/app/scripts/modules/core/application/listExtractor/listExtractor.service.js
@@ -18,6 +18,7 @@ module.exports = angular
         .map('region')
         .compact()
         .unique()
+        .sort()
         .value();
     };
 
@@ -46,9 +47,9 @@ module.exports = angular
 
     let clusterFilterForCredentialsAndRegion = (credentials, region) => {
       return (cluster) => {
-        let acctFilter = credentials ? cluster.account === credentials : true;
+        let acctFilter = cluster && credentials ? cluster.account === credentials : true;
 
-        let regionFilter = Array.isArray(region) && region.length
+        let regionFilter = cluster && Array.isArray(region) && region.length
           ? _.some( cluster.serverGroups, (sg) => _.some(region, (region) => region === sg.region))
           : _.isString(region) //region is just a string not an array
           ? _.any(cluster.serverGroups, (sg) => sg.region === region)

--- a/app/scripts/modules/core/application/listExtractor/listExtractor.service.spec.js
+++ b/app/scripts/modules/core/application/listExtractor/listExtractor.service.spec.js
@@ -114,7 +114,7 @@ describe('appListExtractorService', function () {
 
       let result = service.getRegions(appList);
       expect(result.length).toEqual(3);
-      expect(result).toEqual(['us-west-1', 'us-west-2', 'eu-east-1']);
+      expect(result).toEqual(['eu-east-1', 'us-west-1', 'us-west-2']);
     });
 
   });

--- a/app/scripts/modules/core/widgets/accountRegionClusterSelector.component.js
+++ b/app/scripts/modules/core/widgets/accountRegionClusterSelector.component.js
@@ -34,7 +34,9 @@ module.exports = angular
         let regions;
 
         let setRegionList = () => {
-          let accountFilter = (cluster) => cluster.account === vm.component.credentials;
+          let accountFilter = (cluster) => {
+            return cluster ? cluster.account === vm.component.credentials : true;
+          };
           let regionList = appListExtractorService.getRegions([vm.application], accountFilter);
           vm.regions = showAllRegions ? regions : regionList.length ? regionList : regions;
         };


### PR DESCRIPTION
Occasionally a undefined cluster get passed into the filter throwing an error whenever the filter inspects it.
 This is mainly for the for the account-region-cluster-selector component on the findAmi stage.

- also added a sort call on the get regions so they come back in a consistant order.