### PR TITLE
provider/aws: add feature to lock out EC2 Classic deployments

### DIFF
--- a/app/scripts/modules/amazon/loadBalancer/configure/createLoadBalancer.controller.js
+++ b/app/scripts/modules/amazon/loadBalancer/configure/createLoadBalancer.controller.js
@@ -39,6 +39,7 @@ module.exports = angular.module('spinnaker.loadBalancer.aws.create.controller', 
     };
 
     $scope.isNew = isNew;
+    $scope.application = application;
     // if this controller is used in the context of "Create Load Balancer" stage,
     // then forPipelineConfig flag will be true. In that case, the Load Balancer
     // modal dialog will just return the Load Balancer object.

--- a/app/scripts/modules/amazon/loadBalancer/configure/createLoadBalancerProperties.html
+++ b/app/scripts/modules/amazon/loadBalancer/configure/createLoadBalancerProperties.html
@@ -69,7 +69,14 @@
       provider="'aws'" >
     </load-balancer-availability-zone-selector>
 
-    <subnet-select-field label-columns="3" help-key="aws.loadBalancer.subnet" component="loadBalancer" field="subnetType" region="loadBalancer.region" subnets="subnets" on-change="ctrl.subnetUpdated()"></subnet-select-field>
+    <subnet-select-field label-columns="3"
+                         help-key="aws.loadBalancer.subnet"
+                         component="loadBalancer"
+                         field="subnetType"
+                         region="loadBalancer.region"
+                         subnets="subnets"
+                         application="application"
+                         on-change="ctrl.subnetUpdated()"></subnet-select-field>
     <!--Adding support for public facing elb. Display only for vpc-->
     <div class="form-group" ng-if="loadBalancer.vpcId && !state.hideInternalFlag">
       <div class="col-md-3 sm-label-right"><b>Internal</b></div>

--- a/app/scripts/modules/amazon/securityGroup/configure/CreateSecurityGroupCtrl.js
+++ b/app/scripts/modules/amazon/securityGroup/configure/CreateSecurityGroupCtrl.js
@@ -9,11 +9,12 @@ module.exports = angular.module('spinnaker.amazon.securityGroup.create.controlle
   require('../../../core/cache/cacheInitializer.js'),
   require('../../../core/task/monitor/taskMonitorService.js'),
   require('../../../core/securityGroup/securityGroup.read.service.js'),
+  require('../../../core/config/settings.js'),
 ])
   .controller('awsCreateSecurityGroupCtrl', function($scope, $modalInstance, $state, $controller,
                                                   accountService, securityGroupReader,
                                                   taskMonitorService, cacheInitializer, infrastructureCaches,
-                                                  _, application, securityGroup ) {
+                                                  _, application, securityGroup, settings ) {
 
     $scope.pages = {
       location: require('./createSecurityGroupProperties.html'),
@@ -27,6 +28,7 @@ module.exports = angular.module('spinnaker.amazon.securityGroup.create.controlle
       $modalInstance: $modalInstance,
       application: application,
       securityGroup: securityGroup,
+      settings: settings,
     }));
 
 

--- a/app/scripts/modules/amazon/securityGroup/configure/createSecurityGroupProperties.html
+++ b/app/scripts/modules/amazon/securityGroup/configure/createSecurityGroupProperties.html
@@ -50,7 +50,7 @@
           <select class="form-control input-sm" ng-model="securityGroup.vpcId"
                   ng-change="ctrl.vpcUpdated()"
                   ng-if="securityGroup.regions.length">
-            <option value="">None (EC2 Classic)</option>
+            <option value="" ng-if="!hideClassic">None (EC2 Classic)</option>
             <option ng-repeat="vpc in activeVpcs | orderBy: 'label'" value="{{vpc.ids[0]}}" ng-selected="securityGroup.vpcId === vpc.ids[0]">{{vpc.label}}</option>
             <option ng-if="activeVpcs.length && deprecatedVpcs.length" disabled>---------------</option>
             <option ng-repeat="vpc in deprecatedVpcs | orderBy: 'label'" value="{{vpc.ids[0]}}" ng-selected="securityGroup.vpcId === vpc.ids[0]">{{vpc.label}}</option>

--- a/app/scripts/modules/amazon/serverGroup/configure/wizard/location/basicSettings.html
+++ b/app/scripts/modules/amazon/serverGroup/configure/wizard/location/basicSettings.html
@@ -14,7 +14,14 @@
         </div>
       </div>
       <region-select-field read-only="command.viewState.readOnlyFields.region" label-columns="3" component="command" field="region" account="command.credentials" provider="'aws'" regions="command.backingData.filtered.regions"></region-select-field>
-      <subnet-select-field read-only="command.viewState.readOnlyFields.subnet" label-columns="3" help-key="aws.serverGroup.subnet" component="command" field="subnetType" region="command.region" subnets="command.backingData.filtered.subnetPurposes"></subnet-select-field>
+      <subnet-select-field read-only="command.viewState.readOnlyFields.subnet"
+                           label-columns="3"
+                           help-key="aws.serverGroup.subnet"
+                           component="command"
+                           field="subnetType"
+                           region="command.region"
+                           application="application"
+                           subnets="command.backingData.filtered.subnetPurposes"></subnet-select-field>
       <div class="form-group">
         <div class="col-md-3 sm-label-right">
           Stack

--- a/app/scripts/modules/amazon/subnet/subnetSelectField.directive.html
+++ b/app/scripts/modules/amazon/subnet/subnetSelectField.directive.html
@@ -8,7 +8,7 @@
     <select class="form-control input-sm" ng-model="component[field]"
             ng-change="onChange()"
             ng-if="!readOnly">
-      <option value="">None (EC2 Classic)</option>
+      <option ng-if="!hideClassic" value="">None (EC2 Classic)</option>
       <option ng-repeat="subnet in activeSubnets | orderBy: 'label'" value="{{subnet.purpose}}" ng-selected="component[field] === subnet.purpose">{{subnet.label}}</option>
       <option ng-if="activeSubnets.length && deprecatedSubnets.length" disabled>---------------</option>
       <option ng-repeat="subnet in deprecatedSubnets | orderBy: 'label'" value="{{subnet.purpose}}" ng-selected="component[field] === subnet.purpose">{{subnet.label}}</option>

--- a/app/scripts/modules/amazon/subnet/subnetSelectField.directive.js
+++ b/app/scripts/modules/amazon/subnet/subnetSelectField.directive.js
@@ -3,9 +3,10 @@
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.subnet.subnetSelectField.directive', [
-
+  require('../../core/config/settings'),
+  require('../../core/utils/lodash'),
 ])
-  .directive('subnetSelectField', function () {
+  .directive('subnetSelectField', function (settings, _) {
     return {
       restrict: 'E',
       templateUrl: require('./subnetSelectField.directive.html'),
@@ -18,13 +19,31 @@ module.exports = angular.module('spinnaker.subnet.subnetSelectField.directive', 
         labelColumns: '@',
         helpKey: '@',
         readOnly: '=',
+        application: '='
       },
       link: function(scope) {
 
+        scope.hideClassic = false;
+        let lockoutDate = _.get(settings, 'providers.aws.classicLaunchLockout');
+        if (lockoutDate) {
+          let application = scope.application,
+              createTs = Number(_.get(application, 'attributes.createTs', 0));
+          if (createTs >= lockoutDate) {
+            scope.hideClassic = true;
+            if (!scope.component[scope.field] && scope.subnets && scope.subnets.length) {
+              scope.component[scope.field] = scope.subnets[0].purpose;
+            }
+          }
+        }
         function setSubnets() {
           var subnets = scope.subnets || [];
           scope.activeSubnets = subnets.filter(function(subnet) { return !subnet.deprecated; });
           scope.deprecatedSubnets = subnets.filter(function(subnet) { return subnet.deprecated; });
+          if (scope.hideClassic && subnets.length) {
+            if (!scope.component[scope.field] && subnets.length) {
+              scope.component[scope.field] = subnets[0].purpose;
+            }
+          }
         }
 
         scope.$watch('subnets', setSubnets);


### PR DESCRIPTION
Adds the ability to restrict deployments to EC2 Classic for applications based on their creation date via Front50.

The locking functionality *only* kicks in when it's configured _and_ the application's `createTs` attributes is equal to or after the configured timestamp.

@zanthrash PTAL