### PR TITLE
color provider icons via CSS filters, not mask

### DIFF
--- a/app/scripts/modules/amazon/logo/aws.logo.less
+++ b/app/scripts/modules/amazon/logo/aws.logo.less
@@ -1,8 +1,6 @@
 cloud-provider-logo {
   .icon-aws {
-    mask: url('aws.icon.svg') no-repeat 50% 50%;
-    -webkit-mask: url('aws.icon.svg') no-repeat 50% 0%;
-    mask-size: cover;
-    -webkit-mask-size: cover;
+    background: url('aws.icon.svg') no-repeat 50% 50%;
+    background-size: cover;
   }
 }

--- a/app/scripts/modules/cloudfoundry/logo/cf.logo.less
+++ b/app/scripts/modules/cloudfoundry/logo/cf.logo.less
@@ -1,8 +1,6 @@
 cloud-provider-logo {
   .icon-cf {
-    mask: url('cf.logo.svg') no-repeat 50% 50%;
-    -webkit-mask: url('cf.logo.svg') no-repeat 50% 0%;
-    mask-size: cover;
-    -webkit-mask-size: cover;
+    background: url('cf.logo.svg') no-repeat 50% 50%;
+    background-size: cover;
   }
 }

--- a/app/scripts/modules/core/cloudProvider/cloudProviderLogo.less
+++ b/app/scripts/modules/core/cloudProvider/cloudProviderLogo.less
@@ -6,14 +6,16 @@ cloud-provider-logo {
   .icon {
     display: inline-block;
     vertical-align: sub;
-    background-color: @healthy_green_icon;
+    -webkit-filter: invert(53%) sepia(100%) hue-rotate(50deg);
+    filter: invert(53%) sepia(100%) hue-rotate(50deg);
   }
 }
 
 .disabled {
   cloud-provider-logo {
     .icon {
-      background-color: @mid_grey;
+      -webkit-filter: opacity(64%);
+      filter: opacity(64%);
     }
   }
 }

--- a/app/scripts/modules/google/logo/gce.logo.less
+++ b/app/scripts/modules/google/logo/gce.logo.less
@@ -1,8 +1,6 @@
 cloud-provider-logo {
   .icon-gce {
-    mask: url('gce.logo.svg') no-repeat 50% 50%;
-    -webkit-mask: url('gce.logo.svg') no-repeat 50% 0%;
-    mask-size: cover;
-    -webkit-mask-size: cover;
+    background: url('gce.logo.svg') no-repeat 50% 50%;
+    background-size: cover;
   }
 }

--- a/app/scripts/modules/kubernetes/logo/kubernetes.logo.less
+++ b/app/scripts/modules/kubernetes/logo/kubernetes.logo.less
@@ -1,8 +1,6 @@
 cloud-provider-logo {
   .icon-kubernetes {
-    mask: url('kubernetes.icon.svg') no-repeat 50% 50%;
-    -webkit-mask: url('kubernetes.icon.svg') no-repeat 50% 0%;
-    mask-size: cover;
-    -webkit-mask-size: cover;
+    background: url('kubernetes.icon.svg') no-repeat 50% 50%;
+    background-size: cover;
   }
 }

--- a/app/scripts/modules/titan/logo/titan.logo.less
+++ b/app/scripts/modules/titan/logo/titan.logo.less
@@ -1,8 +1,6 @@
 cloud-provider-logo {
   .icon-titan {
-    mask: url('titan.logo.svg') no-repeat 50% 50%;
-    -webkit-mask: url('titan.logo.svg') no-repeat 50% 0%;
-    mask-size: cover;
-    -webkit-mask-size: cover;
+    background: url('titan.logo.svg') no-repeat 50% 50%;
+    background-size: cover;
   }
 }


### PR DESCRIPTION
Turns out the CSS `mask` property is not supported yet in Firefox, IE, or Edge. Instead of seeing this nice provider icons like this:
<img width="203" alt="screen shot 2016-04-09 at 7 02 11 pm" src="https://cloud.githubusercontent.com/assets/73450/14407622/ac1eeaf2-fe85-11e5-8a6f-752328477c0f.png">
<img width="322" alt="screen shot 2016-04-09 at 7 02 18 pm" src="https://cloud.githubusercontent.com/assets/73450/14407623/ac1f8d90-fe85-11e5-90c2-5d3b26ac35b2.png">

users of those browsers see:
<img width="223" alt="screen shot 2016-04-09 at 6 58 04 pm" src="https://cloud.githubusercontent.com/assets/73450/14407618/8357026c-fe85-11e5-8921-d0e4d07dad31.png">
<img width="330" alt="screen shot 2016-04-09 at 6 58 17 pm" src="https://cloud.githubusercontent.com/assets/73450/14407619/83591da4-fe85-11e5-94b5-351662df065c.png">

This changes that, so all users see the actual icon, not just the block of color.

Some would argue the approach to making this happen (inverting the color, adding a sepia filter to get it into the color spectrum, then rotating the hue of the resulting color) is a huge hack. That is obviously true, and if there's a better way to accomplish the same thing, I'm all for it - with the constraint being that providers only need to supply a black SVG icon.

@zanthrash PTAL