### PR TITLE
favor _.debounce over debounce

### DIFF
--- a/app/scripts/modules/core/cluster/filter/clusterFilter.service.js
+++ b/app/scripts/modules/core/cluster/filter/clusterFilter.service.js
@@ -5,7 +5,6 @@ let angular = require('angular');
 module.exports = angular
   .module('cluster.filter.service', [
     require('angular-ui-router'),
-    require('exports?"debounce"!angular-debounce'),
     require('./clusterFilter.model'),
     require('./multiselect.model'),
     require('../../utils/lodash'),
@@ -13,7 +12,7 @@ module.exports = angular
     require('../../filterModel/filter.model.service'),
   ])
   .factory('clusterFilterService', function (ClusterFilterModel, MultiselectModel, _, waypointService, $log, $stateParams, $state,
-                                             filterModelService, debounce) {
+                                             filterModelService) {
 
     var lastApplication = null;
 
@@ -229,7 +228,7 @@ module.exports = angular
      * Grouping logic
      */
     // this gets called every time the URL changes, so we debounce it a tiny bit
-    var updateClusterGroups = debounce((application) => {
+    var updateClusterGroups = _.debounce((application) => {
       if (!application) {
         application = lastApplication;
         if (!lastApplication) {

--- a/app/scripts/modules/core/cluster/filter/clusterFilter.service.spec.js
+++ b/app/scripts/modules/core/cluster/filter/clusterFilter.service.spec.js
@@ -9,40 +9,30 @@ describe('Service: clusterFilterService', function () {
   var MultiselectModel;
   var applicationJSON;
   var groupedJSON;
-  var _;
   var $timeout;
 
-  beforeEach(
+  beforeEach(function() {
+    spyOn(_, 'debounce').and.callFake(fn => (app) => $timeout(fn(app)));
     window.module(
       require('./clusterFilter.service.js'),
       require('./clusterFilter.model.js'),
       require('../../../../../../test/mock/mockApplicationData.js')
-    )
-  );
-
-  beforeEach(
+    );
     window.inject(
-      function (clusterFilterService, _ClusterFilterModel_, _MultiselectModel_, ___, _$timeout_) {
-        _ = ___;
+      function (clusterFilterService, _ClusterFilterModel_, _MultiselectModel_, _$timeout_, _applicationJSON_, _groupedJSON_) {
         service = clusterFilterService;
         ClusterFilterModel = _ClusterFilterModel_;
         MultiselectModel = _MultiselectModel_;
         $timeout = _$timeout_;
         ClusterFilterModel.groups = [];
-      }
-    )
-  );
 
-  beforeEach(
-    window.inject(
-      function (_applicationJSON_, _groupedJSON_) {
         applicationJSON = _applicationJSON_;
         groupedJSON = _groupedJSON_;
         groupedJSON[0].subgroups[0].cluster = applicationJSON.clusters[0];
         groupedJSON[1].subgroups[0].cluster = applicationJSON.clusters[1];
       }
-    )
-  );
+    );
+  });
 
   beforeEach(function() {
     this.verifyTags = function(expectedTags) {

--- a/app/scripts/modules/core/delivery/filter/executionFilter.service.js
+++ b/app/scripts/modules/core/delivery/filter/executionFilter.service.js
@@ -5,7 +5,6 @@ let angular = require('angular');
 module.exports = angular
   .module('spinnaker.core.delivery.filter.executionFilter.service', [
     require('angular-ui-router'),
-    require('exports?"debounce"!angular-debounce'),
     require('./executionFilter.model.js'),
     require('../../utils/lodash.js'),
     require('../../utils/waypoints/waypoint.service.js'),
@@ -13,7 +12,7 @@ module.exports = angular
     require('../../orchestratedItem/timeBoundaries.service.js'),
   ])
   .factory('executionFilterService', function (ExecutionFilterModel, _, timeBoundaries, waypointService, $log,
-                                               filterModelService, debounce) {
+                                               filterModelService) {
 
     var lastApplication = null;
 
@@ -163,7 +162,7 @@ module.exports = angular
     }
 
     // this gets called every time the URL changes, so we debounce it a tiny bit
-    var updateExecutionGroups = debounce((application) => {
+    var updateExecutionGroups = _.debounce((application) => {
       if (!application) {
         application = lastApplication;
         if (!lastApplication) {

--- a/app/scripts/modules/core/delivery/filter/executionFilter.service.spec.js
+++ b/app/scripts/modules/core/delivery/filter/executionFilter.service.spec.js
@@ -7,14 +7,12 @@ describe('Service: executionFilterService', function () {
   var ExecutionFilterModel;
   var $timeout;
 
-  beforeEach(
+  beforeEach(function() {
+    spyOn(_, 'debounce').and.callFake(fn => (app) => $timeout(fn(app)));
     window.module(
       require('./executionFilter.service.js'),
       require('./executionFilter.model.js')
-    )
-  );
-
-  beforeEach(
+    );
     window.inject(
       function (_$location_, executionFilterService, _ExecutionFilterModel_, _$timeout_) {
         service = executionFilterService;
@@ -22,8 +20,8 @@ describe('Service: executionFilterService', function () {
         $timeout = _$timeout_;
         ExecutionFilterModel.groups = [];
       }
-    )
-  );
+    );
+  });
 
   describe('Updating execution groups', function () {
 

--- a/app/scripts/modules/core/loadBalancer/filter/loadBalancer.filter.service.js
+++ b/app/scripts/modules/core/loadBalancer/filter/loadBalancer.filter.service.js
@@ -6,12 +6,11 @@ module.exports = angular
   .module('spinnaker.core.loadBalancer.filter.service', [
     require('./loadBalancer.filter.model.js'),
     require('../../utils/lodash.js'),
-    require('exports?"debounce"!angular-debounce'),
     require('../../utils/waypoints/waypoint.service.js'),
     require('../../filterModel/filter.model.service.js'),
   ])
   .factory('loadBalancerFilterService', function (LoadBalancerFilterModel, _, waypointService, filterModelService,
-                                                  $log, debounce) {
+                                                  $log) {
 
     var isFilterable = filterModelService.isFilterable,
         getCheckValues = filterModelService.getCheckValues;
@@ -100,7 +99,7 @@ module.exports = angular
      * @param application
      * @returns {*}
      */
-    var updateLoadBalancerGroups = debounce((application) => {
+    var updateLoadBalancerGroups = _.debounce((application) => {
       if (!application) {
         application = lastApplication;
         if (!lastApplication) {

--- a/app/scripts/modules/core/loadBalancer/filter/loadBalancer.filter.service.spec.js
+++ b/app/scripts/modules/core/loadBalancer/filter/loadBalancer.filter.service.spec.js
@@ -10,15 +10,12 @@ describe('Service: loadBalancerFilterService', function () {
   var resultJson;
   var $timeout;
 
-  beforeEach(
+  beforeEach(function() {
+    spyOn(_, 'debounce').and.callFake(fn => (app) => $timeout(fn(app)));
     window.module(
-      require('../../utils/lodash.js'),
       require('./loadBalancer.filter.service.js'),
       require('./loadBalancer.filter.model.js')
-    )
-  );
-
-  beforeEach(
+    );
     window.inject(
       function (loadBalancerFilterService, _LoadBalancerFilterModel_, _$timeout_) {
         service = loadBalancerFilterService;
@@ -26,8 +23,8 @@ describe('Service: loadBalancerFilterService', function () {
         $timeout = _$timeout_;
         LoadBalancerFilterModel.groups = [];
       }
-    )
-  );
+    );
+  });
 
   beforeEach(function () {
     app = {
@@ -94,7 +91,6 @@ describe('Service: loadBalancerFilterService', function () {
       it('should not match on partial vpc name', function () {
         LoadBalancerFilterModel.sortFilter.filter = 'vpc:main-old';
         service.updateLoadBalancerGroups(app);
-        $timeout.flush();
         expect(LoadBalancerFilterModel.groups).toEqual([]);
       });
     });

--- a/app/scripts/modules/core/securityGroup/filter/securityGroup.filter.service.js
+++ b/app/scripts/modules/core/securityGroup/filter/securityGroup.filter.service.js
@@ -6,12 +6,11 @@ module.exports = angular
   .module('securityGroup.filter.service', [
     require('./securityGroup.filter.model.js'),
     require('../../utils/lodash.js'),
-    require('exports?"debounce"!angular-debounce'),
     require('../../utils/waypoints/waypoint.service.js'),
     require('../../filterModel/filter.model.service.js'),
   ])
   .factory('securityGroupFilterService', function (SecurityGroupFilterModel, _, waypointService, filterModelService,
-                                                  $log, debounce) {
+                                                  $log) {
 
     var lastApplication = null;
 
@@ -60,7 +59,7 @@ module.exports = angular
      * @param application
      * @returns {*}
      */
-    var updateSecurityGroups = debounce((application) => {
+    var updateSecurityGroups = _.debounce((application) => {
       if (!application) {
         application = lastApplication;
         if (!lastApplication) {

--- a/app/scripts/modules/core/securityGroup/filter/securityGroup.filter.service.spec.js
+++ b/app/scripts/modules/core/securityGroup/filter/securityGroup.filter.service.spec.js
@@ -10,23 +10,21 @@ describe('Service: securityGroupFilterService', function () {
   var resultJson;
   var $timeout;
 
-  beforeEach(
+  beforeEach(function() {
+    spyOn(_, 'debounce').and.callFake(fn => (app) => $timeout(fn(app)));
     window.module(
       require('../../utils/lodash.js'),
       require('./securityGroup.filter.service.js'),
       require('./securityGroup.filter.model.js')
-    )
-  );
-
-  beforeEach(
+    );
     window.inject(
       function (securityGroupFilterService, _SecurityGroupFilterModel_, _$timeout_) {
         service = securityGroupFilterService;
         SecurityGroupFilterModel = _SecurityGroupFilterModel_;
         $timeout = _$timeout_;
       }
-    )
-  );
+    );
+  });
 
   beforeEach(function () {
     app = {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "angular": "~1.5.0",
     "angular-animate": "~1.5.0",
     "angular-cache": "^4.2.2",
-    "angular-debounce": "git://github.com/shahata/angular-debounce.git#0.1.7",
     "angular-filter": "^0.5.4",
     "angular-hotkeys": "^1.5.0",
     "angular-marked": "0.0.17",


### PR DESCRIPTION
Sadly, the update I made to angular-ui-bootstrap this morning uses a `debounce` attribute, which collides with a directive that the `debounce` module also includes.

So goodbye, debounce module. All hail lodash.

@zanthrash PTAL