### PR TITLE
use built-in support for HTML popover contents

### DIFF
--- a/app/scripts/modules/core/core.module.js
+++ b/app/scripts/modules/core/core.module.js
@@ -161,18 +161,6 @@ module.exports = angular
       });
     });
   })
-  .run(function($templateCache) {
-    $templateCache.put('template/popover/popover.html',
-      '<div tooltip-animation-class="fade"' +
-      '  uib-tooltip-classes' +
-      '  ng-class="{ in: isOpen() }">' +
-      '  <div class="arrow"></div>' +
-      '  <div class="popover-inner">' +
-      '      <h3 class="popover-title" ng-bind="title" ng-if="title"></h3>' +
-      '      <div class="popover-content" ng-bind-html="content"></div>' +
-      '  </div>' +
-      '  </div>');
-  })
   .config(function ($logProvider, statesProvider) {
     statesProvider.setStates();
     $logProvider.debugEnabled(true);

--- a/app/scripts/modules/core/help/helpField.directive.html
+++ b/app/scripts/modules/core/help/helpField.directive.html
@@ -2,7 +2,7 @@
      class="help-contents small"
      ng-bind-html="contents.content"></div>
 <a href class="help-field" ng-if="!expand && contents.content"
-        uib-popover="{{contents.content}}"
+        uib-popover-html="contents.content"
         popover-placement="{{contents.placement}}"
         popover-trigger="mouseenter focus">
   <span class="small glyphicon glyphicon-question-sign"></span>

--- a/app/scripts/modules/core/help/helpField.directive.spec.js
+++ b/app/scripts/modules/core/help/helpField.directive.spec.js
@@ -1,19 +1,3 @@
-/*
- * Copyright 2014 Netflix, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 'use strict';
 
 describe('Directives: helpField', function () {
@@ -32,38 +16,44 @@ describe('Directives: helpField', function () {
 
   beforeEach(window.inject(function ($rootScope, $compile, _helpContentsRegistry_) {
     helpContentsRegistry = _helpContentsRegistry_;
-    this.executeTest = function executeTest(htmlString, expected, attr = 'uib-popover') {
+    this.executeTest = function executeTest(htmlString, expected, attr = 'uib-popover-html') {
       var $scope = $rootScope.$new();
       var helpField = $compile(htmlString)($scope);
       $scope.$digest();
       expect(helpField.find('a').attr(attr)).toBe(expected);
     };
+    this.testContent = function(htmlString, expected) {
+      var $scope = $rootScope.$new();
+      var helpField = $compile(htmlString)($scope);
+      $scope.$digest();
+      expect(angular.element(helpField.find('a')).scope().contents.content).toBe(expected);
+    };
   }));
 
   it('uses provided content if supplied', function() {
-    this.executeTest('<help-field content="some content"></help-field>', 'some content');
+    this.testContent('<help-field content="some content"></help-field>', 'some content');
   });
 
   it('uses key to look up content if supplied', function() {
-    this.executeTest('<help-field key="aws.serverGroup.stack"></help-field>', 'expected stack help');
+    this.testContent('<help-field key="aws.serverGroup.stack"></help-field>', 'expected stack help');
   });
 
   it('prefers overrides', function() {
     spyOn(helpContentsRegistry, 'getHelpField').and.returnValue('override content');
-    this.executeTest('<help-field key="aws.serverGroup.stack"></help-field>', 'override content');
+    this.testContent('<help-field key="aws.serverGroup.stack"></help-field>', 'override content');
   });
 
 
   it('uses fallback if key not present', function() {
-    this.executeTest('<help-field key="nonexistent.key" fallback="the fallback"></help-field>', 'the fallback');
+    this.testContent('<help-field key="nonexistent.key" fallback="the fallback"></help-field>', 'the fallback');
   });
 
   it('ignores key if content is defined', function() {
-    this.executeTest('<help-field key="aws.serverGroup.stack" content="overridden!"></help-field>', 'overridden!');
+    this.testContent('<help-field key="aws.serverGroup.stack" content="overridden!"></help-field>', 'overridden!');
   });
 
   it('ignores key and fallback if content is defined', function() {
-    this.executeTest('<help-field key="aws.serverGroup.stack" fallback="will be ignored" content="overridden!"></help-field>', 'overridden!');
+    this.testContent('<help-field key="aws.serverGroup.stack" fallback="will be ignored" content="overridden!"></help-field>', 'overridden!');
   });
 
   it('defaults position to "top"', function() {


### PR DESCRIPTION
`popover` now supports HTML, so we can get rid of the template override