### PR TITLE
provider/aws: show cooldown on simple policies; allow selection of no…

### DIFF
--- a/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/scalingPolicySummary.component.html
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/scalingPolicySummary.component.html
@@ -5,7 +5,8 @@
        popover-trigger="mouseenter">
     <div>
       <strong>Whenever</strong>
-      {{alarm.statistic}} of {{alarm.metricName}} is <span ng-bind-html="alarm.comparator"></span> {{alarm.threshold}}
+      {{alarm.statistic}} of <span class="alarm-name">{{alarm.metricName}}</span>
+      is <span ng-bind-html="alarm.comparator"></span> {{alarm.threshold}}
     </div>
     <div>
       <strong>for at least</strong>

--- a/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/scalingPolicySummary.component.less
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/scalingPolicySummary.component.less
@@ -1,4 +1,7 @@
 scaling-policy-summary {
+  .alarm-name {
+    word-break: break-all;
+  }
   .actions {
     font-size: 85%;
     margin: 0 0 15px 0;

--- a/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/alarm/alarmConfigurer.component.html
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/alarm/alarmConfigurer.component.html
@@ -27,6 +27,9 @@
             ng-options="stat for stat in $ctrl.statistics">
     </select>
     <span class="input-label" style="vertical-align: top; margin-top: 7px"> of </span>
+    <div class="text-center" style="display: inline-block; width: 100px; margin-top: 7px" ng-if="!$ctrl.viewState.metricsLoaded">
+      <span class="glyphicon glyphicon-spinning glyphicon-asterisk"></span>
+    </div>
     <div style="display: inline-block; width: 500px" ng-if="$ctrl.viewState.metricsLoaded">
       <select class="form-control input-sm"
               required
@@ -42,24 +45,32 @@
               ng-if="$ctrl.viewState.advancedMode"
               ng-options="namespace for namespace in $ctrl.namespaces">
       </select>
-      <select class="form-control input-sm"
-              required
-              ng-model="$ctrl.viewState.selectedMetric"
-              ng-change="$ctrl.metricChanged()"
-              ng-if="$ctrl.viewState.advancedMode"
-              ng-options="metric as metric.advancedLabel for metric in $ctrl.metrics">
-      </select>
+      <div style="display: inline-block; width: 300px; position: relative; top: -3px"
+           ng-if="$ctrl.viewState.advancedMode">
+        <input type="text" class="form-control input-sm" style="width: 100%"
+               required
+               uib-typeahead="option.name as option.name for option in $ctrl.metrics | filter: $viewValue"
+               typeahead-show-hint="true"
+               typeahead-min-length="0"
+               typeahead-editable="true"
+               typeahead-on-select="$ctrl.metricChanged()"
+               ng-change="$ctrl.metricChanged()"
+               ng-model-options="{ updateOn: 'default blur', debounce: { 'default': 300, 'blur': 0 } }"
+               ng-model="$ctrl.alarm.metricName"
+               placeholder="name"/>
+      </div>
       <a href class="small"
          ng-if="!$ctrl.viewState.advancedMode"
          ng-click="$ctrl.advancedMode()">
         Search all metrics <help-field key="aws.scalingPolicy.search.all"></help-field>
       </a>
-      <span class="input-label" ng-if="$ctrl.viewState.advancedMode && $ctrl.metrics.length === 0">
-        No metrics found for selected namespace + dimensions
+      <span class="input-label" style="margin-left: 5px"
+            ng-if="$ctrl.viewState.advancedMode && $ctrl.metrics.length === 0">
+        <strong>Note:</strong> no metrics found for selected namespace + dimensions
       </span>
       <div style="padding-left: 5px;">
         <a href class="small"
-           ng-if="$ctrl.viewState.advancedMode"
+           ng-if="$ctrl.viewState.advancedMode && !$ctrl.viewState.noDefaultMetrics"
            ng-click="$ctrl.simpleMode()">
           Only show metrics for this auto scaling group <help-field key="aws.scalingPolicy.search.restricted"></help-field>
         </a>

--- a/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/alarm/dimensionsEditor.component.html
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/alarm/dimensionsEditor.component.html
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="col-md-12 small">
-    <div>Enter dimensions to filter the available metrics above.</div>
+    <h5>Dimensions</h5>
   </div>
 </div>
 <div ng-repeat="dimension in $ctrl.alarm.dimensions" class="row dimensions-row">

--- a/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/alarm/dimensionsEditor.component.less
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/alarm/dimensionsEditor.component.less
@@ -1,4 +1,7 @@
 dimensions-editor {
+  h5 {
+    margin-bottom: 0;
+  }
   display: block;
   padding-left: 5px;
 

--- a/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/upsertScalingPolicy.modal.html
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/upsertScalingPolicy.modal.html
@@ -64,7 +64,7 @@
             </span>
           </div>
         </div>
-        <div class="row" ng-if="ctrl.command.simple && ctrl.viewState.operator !== 'Remove'">
+        <div class="row" ng-if="ctrl.command.simple">
           <div class="col-md-2 sm-label-right">Cooldown</div>
           <div class="col-md-10 content-fields">
             <span class="form-control-static select-placeholder">


### PR DESCRIPTION
…n-existent metrics

Simple scaling policies should always show a cooldown period, even if they scaling an ASG down.

Also, users might want to set up or tweak scaling policies for metrics that don't yet exist. We do this when cloning an ASG - there are no metrics yet, but we create alarms against them, assuming metrics will start being collected once the ASG has instances. This changes the dropdown to a typeahead when in the advanced/search-all mode.