### PR TITLE
fix step policy rendering inconsistency between popover and edit modal

### DIFF
--- a/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/popover/scalingPolicyPopover.component.html
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/popover/scalingPolicyPopover.component.html
@@ -12,36 +12,32 @@
     <dt>then</dt>
     <dd ng-if="$ctrl.policy.stepAdjustments.length">
       <div ng-repeat="stepAdjustment in $ctrl.policy.stepAdjustments">
-        if
-        <span ng-if="$ctrl.alarm.comparisonOperator.indexOf('Greater') === 0">
-          <span ng-if="stepAdjustment.metricIntervalUpperBound">
-            {{$ctrl.alarm.threshold + stepAdjustment.metricIntervalUpperBound}}
-            &gt;
+        <span ng-if="$ctrl.policy.stepAdjustments.length > 1">
+          if {{$ctrl.alarm.metricName}}
+          <span ng-if="$ctrl.alarm.comparisonOperator.indexOf('Greater') === 0">
+            <span ng-if="stepAdjustment.metricIntervalUpperBound !== undefined && stepAdjustment.metricIntervalLowerBound !== undefined">
+              is between
+              {{$ctrl.alarm.threshold + stepAdjustment.metricIntervalLowerBound}}
+              and
+              {{$ctrl.alarm.threshold + stepAdjustment.metricIntervalUpperBound}}
+            </span>
+            <span ng-if="stepAdjustment.metricIntervalUpperBound === undefined">
+              is greater than {{$ctrl.alarm.threshold + stepAdjustment.metricIntervalLowerBound}}
+            </span>
           </span>
-          {{$ctrl.alarm.metricName}}
-          <span ng-if="stepAdjustment.metricIntervalLowerBound">
-            &ge; {{$ctrl.alarm.threshold + stepAdjustment.metricIntervalLowerBound}}
-          </span>
-          <span ng-if="!stepAdjustment.metricIntervalLowerBound">
-            <span ng-bind-html="$ctrl.alarm.comparator"></span>
-            {{$ctrl.alarm.threshold}}
-          </span>
-        </span>
 
-        <span ng-if="$ctrl.alarm.comparisonOperator.indexOf('Less') === 0">
-          <span ng-if="stepAdjustment.metricIntervalLowerBound">
-            {{$ctrl.alarm.threshold + stepAdjustment.metricIntervalLowerBound}}
-            &lt;
-          </span>
-          {{$ctrl.alarm.metricName}}
-          <span ng-if="stepAdjustment.metricIntervalUpperBound">
-             &le; {{$ctrl.alarm.threshold + stepAdjustment.metricIntervalUpperBound}}
-          </span>
-          <span ng-if="!stepAdjustment.metricIntervalUpperBound">
-            <span ng-bind-html="$ctrl.alarm.comparator"></span>
-            {{$ctrl.alarm.threshold}}
-          </span>
-        </span>,
+          <span ng-if="$ctrl.alarm.comparisonOperator.indexOf('Less') === 0">
+            <span ng-if="stepAdjustment.metricIntervalUpperBound !== undefined && stepAdjustment.metricIntervalLowerBound !== undefined">
+              is between
+              {{$ctrl.alarm.threshold + stepAdjustment.metricIntervalLowerBound}}
+              and
+              {{$ctrl.alarm.threshold + stepAdjustment.metricIntervalUpperBound}}
+            </span>
+            <span ng-if="stepAdjustment.metricIntervalLowerBound === undefined">
+              is less than {{$ctrl.alarm.threshold + stepAdjustment.metricIntervalUpperBound}}
+            </span>
+          </span>,
+        </span>
         <span ng-if="$ctrl.policy.adjustmentType === 'ExactCapacity'">
           set capacity
           to {{stepAdjustment.scalingAdjustment}} instance<span ng-if="stepAdjustment.scalingAdjustment > 1">s</span>

--- a/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/step/stepPolicyAction.component.html
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/step/stepPolicyAction.component.html
@@ -34,11 +34,12 @@
     <span ng-if="$ctrl.viewState.comparatorBound === 'max'">
       <span class="input-label" ng-if="!$last">
         is between
+        <span class="input-label" ng-bind="step.metricIntervalLowerBound"></span>
+        <span class="input-label">and</span>
       </span>
-      <span class="input-label" ng-bind="step.metricIntervalLowerBound"></span>
-      <span class="input-label" ng-if="!$last">and</span>
       <span class="input-label" ng-if="$last">
         is greater than
+        <span class="input-label" ng-bind="step.metricIntervalLowerBound"></span>
       </span>
 
       <input type="number"
@@ -67,7 +68,6 @@
       <span class="input-label" ng-if="$last">
         is less than
       </span>
-
       <span class="input-label text-right" ng-bind="step.metricIntervalUpperBound"></span>
     </span>
 

--- a/app/scripts/modules/amazon/serverGroup/serverGroup.transformer.js
+++ b/app/scripts/modules/amazon/serverGroup/serverGroup.transformer.js
@@ -32,6 +32,9 @@ module.exports = angular.module('spinnaker.aws.serverGroup.transformer', [
       adjuster.operator = adjuster.scalingAdjustment < 0 ? 'decrease' : 'increase';
       adjuster.absAdjustment = Math.abs(adjuster.scalingAdjustment);
     }
+    
+    let upperBoundSorter = (a, b) => b.metricIntervalUpperBound - a.metricIntervalUpperBound,
+        lowerBoundSorter = (a, b) => a.metricIntervalLowerBound - b.metricIntervalLowerBound;
 
     let transformScalingPolicy = (policy) => {
       policy.alarms = policy.alarms || [];
@@ -39,6 +42,9 @@ module.exports = angular.module('spinnaker.aws.serverGroup.transformer', [
       addAdjustmentAttributes(policy); // simple policies
       if (policy.stepAdjustments && policy.stepAdjustments.length) {
         policy.stepAdjustments.forEach(addAdjustmentAttributes); // step policies
+        let sorter = policy.stepAdjustments.every(a => a.metricIntervalUpperBound !== undefined) ?
+          upperBoundSorter : lowerBoundSorter;
+        policy.stepAdjustments.sort(sorter);
       }
     };
 


### PR DESCRIPTION
Couple of things:

1. The popovers are getting the same, more human-readable treatment the edit modal got.
2. The steps are not guaranteed to return in a sensible order, so we need to sort them up front to avoid having what was configured as the last step potentially show up in the middle or beginning of the list of steps.

Current (edit modal, steps out of order, not showing threshold on last step):
<img width="874" alt="screen shot 2016-04-12 at 3 48 24 pm" src="https://cloud.githubusercontent.com/assets/73450/14478002/ba073c6c-00c6-11e6-941c-b9a207f98545.png">

Fixed:
<img width="876" alt="screen shot 2016-04-12 at 3 48 33 pm" src="https://cloud.githubusercontent.com/assets/73450/14477960/7369324c-00c6-11e6-8f0f-a4730e548c3f.png">

Current (popover, less readable, unsorted):
<img width="412" alt="screen shot 2016-04-12 at 3 52 25 pm" src="https://cloud.githubusercontent.com/assets/73450/14478030/dc3bd7e8-00c6-11e6-9aec-4c769ac287f1.png">


Fixed:
<img width="415" alt="screen shot 2016-04-12 at 3 52 40 pm" src="https://cloud.githubusercontent.com/assets/73450/14477985/a76a579c-00c6-11e6-9697-e7a577462e6e.png">

