### PR TITLE
remove v2wizard flag

### DIFF
--- a/app/scripts/modules/amazon/aws.module.js
+++ b/app/scripts/modules/amazon/aws.module.js
@@ -47,7 +47,6 @@ module.exports = angular.module('spinnaker.aws', [
 ])
   .config(function(cloudProviderRegistryProvider) {
     cloudProviderRegistryProvider.registerProvider('aws', {
-      v2wizard: true,
       name: 'Amazon',
       logo: {
         path: require('./logo/amazon.logo.svg'),

--- a/app/scripts/modules/amazon/serverGroup/serverGroup.transformer.js
+++ b/app/scripts/modules/amazon/serverGroup/serverGroup.transformer.js
@@ -32,7 +32,7 @@ module.exports = angular.module('spinnaker.aws.serverGroup.transformer', [
       adjuster.operator = adjuster.scalingAdjustment < 0 ? 'decrease' : 'increase';
       adjuster.absAdjustment = Math.abs(adjuster.scalingAdjustment);
     }
-    
+
     let upperBoundSorter = (a, b) => b.metricIntervalUpperBound - a.metricIntervalUpperBound,
         lowerBoundSorter = (a, b) => a.metricIntervalLowerBound - b.metricIntervalLowerBound;
 

--- a/app/scripts/modules/azure/azure.module.js
+++ b/app/scripts/modules/azure/azure.module.js
@@ -33,7 +33,6 @@ module.exports = angular.module('spinnaker.azure', [
 ])
   .config(function(cloudProviderRegistryProvider) {
     cloudProviderRegistryProvider.registerProvider('azure', {
-      v2wizard: true,
       name: 'Azure',
       logo: {
         path: require('./logo_azure.png'),

--- a/app/scripts/modules/cloudfoundry/cf.module.js
+++ b/app/scripts/modules/cloudfoundry/cf.module.js
@@ -36,7 +36,6 @@ module.exports = angular.module('spinnaker.cf', [
 ])
     .config(function(cloudProviderRegistryProvider) {
         cloudProviderRegistryProvider.registerProvider('cf', {
-            v2wizard: true,
             name: 'Cloud Foundry',
             logo: {
                 path: require('./logo/logo_cf.png'),

--- a/app/scripts/modules/core/cluster/allClusters.controller.js
+++ b/app/scripts/modules/core/cluster/allClusters.controller.js
@@ -57,7 +57,7 @@ module.exports = angular.module('spinnaker.core.cluster.allClusters.controller',
         $uibModal.open({
           templateUrl: provider.cloneServerGroupTemplateUrl,
           controller: `${provider.cloneServerGroupController} as ctrl`,
-          size: cloudProviderRegistry.getValue(selectedProvider, 'v2wizard') ? 'lg' : 'md',
+          size: 'lg',
           resolve: {
             title: function() { return 'Create New Server Group'; },
             application: function() { return app; },

--- a/app/scripts/modules/core/loadBalancer/AllLoadBalancersCtrl.js
+++ b/app/scripts/modules/core/loadBalancer/AllLoadBalancersCtrl.js
@@ -47,7 +47,7 @@ module.exports = angular.module('spinnaker.core.loadBalancer.controller', [
         $uibModal.open({
           templateUrl: provider.createLoadBalancerTemplateUrl,
           controller: `${provider.createLoadBalancerController} as ctrl`,
-          size: cloudProviderRegistry.getValue(selectedProvider, 'v2wizard') ? 'lg' : 'md',
+          size: 'lg',
           resolve: {
             application: function() { return app; },
             loadBalancer: function() { return null; },

--- a/app/scripts/modules/core/pipeline/config/stages/createLoadBalancer/createLoadBalancerStage.js
+++ b/app/scripts/modules/core/pipeline/config/stages/createLoadBalancer/createLoadBalancerStage.js
@@ -38,7 +38,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.createLoadBalance
         $uibModal.open({
           templateUrl: config.createLoadBalancerTemplateUrl,
           controller: `${config.createLoadBalancerController} as ctrl`,
-          size: cloudProviderRegistry.getValue(selectedProvider, 'v2wizard') ? 'lg' : 'md',
+          size: 'lg',
           resolve: {
             application: () => $scope.application,
             loadBalancer: () => null,
@@ -59,7 +59,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.createLoadBalance
         $uibModal.open({
           templateUrl: config.editLoadBalancerTemplateUrl,
           controller: `${config.createLoadBalancerController} as ctrl`,
-          size: cloudProviderRegistry.getValue(selectedProvider, 'v2wizard') ? 'lg' : 'md',
+          size: 'lg',
           resolve: {
             application: () => $scope.application,
             loadBalancer: () => angular.copy(loadBalancer),

--- a/app/scripts/modules/core/securityGroup/AllSecurityGroupsCtrl.js
+++ b/app/scripts/modules/core/securityGroup/AllSecurityGroupsCtrl.js
@@ -48,7 +48,7 @@ module.exports = angular.module('spinnaker.core.securityGroup.all.controller', [
         $uibModal.open({
           templateUrl: provider.createSecurityGroupTemplateUrl,
           controller: `${provider.createSecurityGroupController} as ctrl`,
-          size: cloudProviderRegistry.getValue(selectedProvider, 'v2wizard') ? 'lg' : 'md',
+          size: 'lg',
           resolve: {
             securityGroup: function () {
               return {

--- a/app/scripts/modules/google/gce.module.js
+++ b/app/scripts/modules/google/gce.module.js
@@ -46,7 +46,6 @@ module.exports = angular.module('spinnaker.gce', [
 ])
   .config(function(cloudProviderRegistryProvider) {
     cloudProviderRegistryProvider.registerProvider('gce', {
-      v2wizard: true,
       name: 'Google',
       logo: {
         path: require('./logo/gce.logo.png'),

--- a/app/scripts/modules/kubernetes/kubernetes.module.js
+++ b/app/scripts/modules/kubernetes/kubernetes.module.js
@@ -38,7 +38,6 @@ module.exports = angular.module('spinnaker.kubernetes', [
 ])
   .config(function(cloudProviderRegistryProvider) {
     cloudProviderRegistryProvider.registerProvider('kubernetes', {
-      v2wizard: true,
       name: 'Kubernetes',
       cache: {
         configurer: 'kubernetesCacheConfigurer',

--- a/app/scripts/modules/titan/titan.module.js
+++ b/app/scripts/modules/titan/titan.module.js
@@ -22,7 +22,6 @@ module.exports = angular.module('spinnaker.titan', [
 ])
   .config(function(cloudProviderRegistryProvider) {
     cloudProviderRegistryProvider.registerProvider('titan', {
-      v2wizard: true,
       name: 'Titan',
       logo: {
         path: require('./logo/titan.logo.png')


### PR DESCRIPTION
All providers have migrated to the v2 wizards, so this is no longer needed - nice job, everyone!