### PR TITLE
skip upstream check on kubernetes deployment clusters

### DIFF
--- a/app/scripts/modules/kubernetes/kubernetes.module.js
+++ b/app/scripts/modules/kubernetes/kubernetes.module.js
@@ -71,6 +71,7 @@ module.exports = angular.module('spinnaker.kubernetes', [
         createSecurityGroupController: 'kubernetesUpsertSecurityGroupController',
       },
       serverGroup: {
+        skipUpstreamStageCheck: true,
         transformer: 'kubernetesServerGroupTransformer',
         detailsTemplateUrl: require('./serverGroup/details/details.html'),
         detailsController: 'kubernetesServerGroupDetailsController',


### PR DESCRIPTION
Prevents the warning message when adding a deploy stage to a pipeline when the user is only deploying to Kubernetes and there is no bake or find image stage before it.

@lwander PTAL