### PR TITLE
make notification options configurable

### DIFF
--- a/app/scripts/modules/core/notification/notificationTypeConfig.provider.js
+++ b/app/scripts/modules/core/notification/notificationTypeConfig.provider.js
@@ -2,17 +2,21 @@
 
 let angular = require('angular');
 
-module.exports = angular.module('spinnaker.core.notification.type.config', [])
-  .provider('notificationTypeConfig', function() {
+module.exports = angular
+  .module('spinnaker.core.notification.type.config', [
+    require('../config/settings')
+  ])
+  .provider('notificationTypeConfig', function(settings) {
 
     var notificationTypes = [];
 
     function registerNotificationType(config) {
+      config.config = settings.notifications[config.key] || { enabled: true };
       notificationTypes.push(config);
     }
 
     function listNotificationTypes() {
-      return angular.copy(notificationTypes);
+      return angular.copy(notificationTypes).filter(n => n.config.enabled);
     }
 
     this.registerNotificationType = registerNotificationType;

--- a/app/scripts/modules/core/notification/selector/notificationSelector.directive.js
+++ b/app/scripts/modules/core/notification/selector/notificationSelector.directive.js
@@ -7,30 +7,31 @@ module.exports = angular.module('spinnaker.core.notification.selector.directive'
   .directive('notificationSelector', function() {
     return {
       restrict: 'E',
-      scope: {
+      bindToController: {
         notification: '=',
         level: '='
       },
       templateUrl: require('./notificationSelector.html'),
       controller: 'NotificationSelectorCtrl',
-      controllerAs: 'notificationCtrl'
+      controllerAs: 'vm'
     };
   })
-  .controller('NotificationSelectorCtrl', function($scope, notificationTypeService) {
+  .controller('NotificationSelectorCtrl', function(notificationTypeService) {
 
-    $scope.notificationTypes = notificationTypeService.listNotificationTypes();
+    this.notificationTypes = notificationTypeService.listNotificationTypes();
 
-    if (!$scope.notification.type && $scope.notificationTypes && $scope.notificationTypes.length) {
-      $scope.notification.type = $scope.notificationTypes[0].key;
+    this.updateNotificationType = function () {
+      this.notification.address = null;
+      let notificationConfig = notificationTypeService.getNotificationType(this.notification.type);
+      this.notificationConfig = notificationConfig ? notificationConfig.config : {};
+      this.addressTemplateUrl = notificationConfig ? notificationConfig.addressTemplateUrl : '';
+    };
+
+    if (!this.notification.type && this.notificationTypes && this.notificationTypes.length) {
+      this.notification.type = this.notificationTypes[0].key;
+      this.notificationConfig = this.notificationTypes[0].config;
     }
 
-    this.clearAddress = function () {
-      $scope.notification.address = null;
-    };
-
-    this.getNotificationAddressTemplateUrl = function () {
-      var notificationConfig = notificationTypeService.getNotificationType($scope.notification.type);
-      return notificationConfig ? notificationConfig.addressTemplateUrl : '';
-    };
+    this.updateNotificationType();
 
   });

--- a/app/scripts/modules/core/notification/selector/notificationSelector.html
+++ b/app/scripts/modules/core/notification/selector/notificationSelector.html
@@ -2,10 +2,10 @@
   <div class="col-sm-3 sm-label-right" id="type">Notify via</div>
   <div class="col-sm-9">
     <select class="input-sm"
-            ng-options="t.key as t.label for t in notificationTypes"
-            ng-model="notification.type"
-            ng-change="notificationCtrl.clearAddress()">
+            ng-options="t.key as t.label for t in vm.notificationTypes"
+            ng-model="vm.notification.type"
+            ng-change="vm.updateNotificationType()">
     </select>
   </div>
 </div>
-<div ng-include="notificationCtrl.getNotificationAddressTemplateUrl()"></div>
+<div ng-include="vm.addressTemplateUrl"></div>

--- a/app/scripts/modules/core/notification/types/email/additionalFields.html
+++ b/app/scripts/modules/core/notification/types/email/additionalFields.html
@@ -5,7 +5,7 @@
       <input type="email"
              name="address"
              class="form-control input-sm "
-             ng-model="notification.address"
+             ng-model="vm.notification.address"
              placeholder="enter an email address"
              required>
       </input>

--- a/app/scripts/modules/core/notification/types/hipchat/additionalFields.html
+++ b/app/scripts/modules/core/notification/types/hipchat/additionalFields.html
@@ -1,12 +1,14 @@
 <div class="form-group row">
-  <div class="col-sm-9 col-sm-offset-3"><strong>Please Note:</strong> You need to invite the Skynet T-800 bot to <strong>private</strong> rooms to
-    receive HipChat notifications<br/>
+  <div class="col-sm-9 col-sm-offset-3"
+       ng-if="vm.notificationConfig.botName">
+    <strong>Please note:</strong> You need to invite the <strong select-on-dbl-click>{{vm.notificationConfig.botName}}</strong> bot to
+    <strong>private</strong> rooms to receive HipChat notifications<br/>
   </div>
   <div class="col-sm-3 sm-label-right">HipChat Room</div>
   <div class="col-sm-9">
     <input name="hipchat"
            class="form-control input-sm "
-           ng-model="notification.address"
+           ng-model="vm.notification.address"
            placeholder="enter a HipChat room"
            required />
   </div>

--- a/app/scripts/modules/core/notification/types/slack/additionalFields.html
+++ b/app/scripts/modules/core/notification/types/slack/additionalFields.html
@@ -3,8 +3,14 @@
   <div class="col-sm-9">
     <input name="Slack"
            class="form-control input-sm "
-           ng-model="notification.address"
+           ng-model="vm.notification.address"
            placeholder="enter a Slack channel"
            required />
+  </div>
+  <div class="col-sm-9 col-sm-offset-3"
+       ng-if="vm.notificationConfig.botName">
+    <strong>Note:</strong> You will need to invite the
+    <strong select-on-dbl-click>{{vm.notificationConfig.botName}}</strong>
+    bot to this channel to receive Slack notifications<br/>
   </div>
 </div>

--- a/app/scripts/modules/core/notification/types/sms/additionalFields.html
+++ b/app/scripts/modules/core/notification/types/sms/additionalFields.html
@@ -7,7 +7,7 @@
              ng-minlength="10"
              ng-maxlength="10"
              class="form-control input-sm "
-             ng-model="notification.address"
+             ng-model="vm.notification.address"
              placeholder="enter a phone number"
              required />
     </div>

--- a/settings.js
+++ b/settings.js
@@ -56,6 +56,22 @@ window.spinnakerSettings = {
     gistId: '32526cd608db3d811b38',
     fileName: 'news.md',
   },
+  notifications: {
+    email: {
+      enabled: true,
+    },
+    hipchat: {
+      enabled: true,
+      botName: 'Skynet T-800'
+    },
+    sms: {
+      enabled: true,
+    },
+    slack: {
+      enabled: true,
+      botName: 'spinnakerbot'
+    }
+  },
   authEnabled: process.env.AUTH === 'enabled',
   gitSources: ['stash', 'github'],
   triggerTypes: ['git', 'pipeline', 'docker', 'cron', 'jenkins'],


### PR DESCRIPTION
Allow configuration of which notifications are available, and let users configure the name of the bot for HipChat and Slack that will send notifications, so they know who to invite into private rooms.

Also updating the notification directive to be a little more modern (replacing `$scope` with `vm`, using `bindToController`).

Corresponding PRs:
* echo: https://github.com/spinnaker/echo/pull/83
* spinnaker: https://github.com/spinnaker/spinnaker/pull/850