### PR TITLE
Add implementation for Azure Destroy Server Group pipeline stage

### DIFF
--- a/app/scripts/modules/azure/azure.module.js
+++ b/app/scripts/modules/azure/azure.module.js
@@ -9,6 +9,7 @@ templates.keys().forEach(function(key) {
 });
 
 module.exports = angular.module('spinnaker.azure', [
+  require('../core/pipeline/config/stages/destroyAsg/azure/azureDestroyAsgStage.js'),
   require('../core/cloudProvider/cloudProvider.registry.js'),
   require('./serverGroup/details/serverGroup.details.module.js'),
   require('./serverGroup/serverGroup.transformer.js'),

--- a/app/scripts/modules/core/pipeline/config/stages/destroyAsg/azure/azureDestroyAsgStage.js
+++ b/app/scripts/modules/core/pipeline/config/stages/destroyAsg/azure/azureDestroyAsgStage.js
@@ -1,0 +1,70 @@
+'use strict';
+
+let angular = require('angular');
+
+module.exports = angular.module('spinnaker.core.pipeline.stage.azure.destroyAsgStage', [
+  require('../../../../../account/account.service.js'),
+  require('../../stageConstants.js'),
+  require('./destroyAsgExecutionDetails.controller.js')
+])
+  .config(function(pipelineConfigProvider) {
+    pipelineConfigProvider.registerStage({
+      provides: 'destroyServerGroup',
+      cloudProvider: 'azure',
+      templateUrl: require('./destroyAsgStage.html'),
+      executionDetailsUrl: require('./destroyAsgExecutionDetails.html'),
+      executionStepLabelUrl: require('./destroyAsgStepLabel.html'),
+      validators: [
+        {
+          type: 'targetImpedance',
+          message: 'This pipeline will attempt to destroy a server group without deploying a new version into the same cluster.'
+        },
+        { type: 'requiredField', fieldName: 'cluster' },
+        { type: 'requiredField', fieldName: 'target', },
+        { type: 'requiredField', fieldName: 'regions', },
+        { type: 'requiredField', fieldName: 'credentials', fieldLabel: 'account'},
+      ],
+    });
+  }).controller('azureDestroyAsgStageCtrl', function($scope, accountService, stageConstants) {
+    var ctrl = this;
+
+    let stage = $scope.stage;
+
+    $scope.state = {
+      accounts: false,
+      regionsLoaded: false
+    };
+
+
+    accountService.listAccounts('azure').then(function (accounts) {
+      $scope.accounts = accounts;
+      $scope.state.accounts = true;
+    });
+
+    ctrl.accountUpdated = function() {
+      accountService.getAccountDetails(stage.credentials).then(function(details) {
+        stage.regions = [details.org];
+//        stage.regions = ['eastus', 'westus'];
+      });
+    };
+
+    $scope.targets = stageConstants.targetList;
+
+    stage.regions = stage.regions || [];
+    stage.cloudProvider = 'azure';
+
+    stage.interestingHealthProviderNames = ['azureService'];
+
+    if (!stage.credentials && $scope.application.defaultCredentials.azure) {
+      stage.credentials = $scope.application.defaultCredentials.azure;
+    }
+
+    if (stage.credentials) {
+      ctrl.accountUpdated();
+    }
+    if (!stage.target) {
+      stage.target = $scope.targets[0].val;
+    }
+
+  });
+

--- a/app/scripts/modules/core/pipeline/config/stages/destroyAsg/azure/destroyAsgExecutionDetails.controller.js
+++ b/app/scripts/modules/core/pipeline/config/stages/destroyAsg/azure/destroyAsgExecutionDetails.controller.js
@@ -1,0 +1,23 @@
+'use strict';
+
+let angular = require('angular');
+
+module.exports = angular.module('spinnaker.core.pipeline.stage.destroyAsg.azure.executionDetails.controller', [
+  require('angular-ui-router'),
+  require('../../../../../delivery/details/executionDetailsSection.service.js'),
+  require('../../../../../delivery/details/executionDetailsSectionNav.directive.js'),
+])
+  .controller('azureDestroyAsgExecutionDetailsCtrl', function ($scope, $stateParams, executionDetailsSectionService) {
+
+    $scope.configSections = ['destroyServerGroupConfig', 'taskStatus'];
+
+    function initialize() {
+      executionDetailsSectionService.synchronizeSection($scope.configSections);
+      $scope.detailsSection = $stateParams.details;
+    }
+
+    initialize();
+
+    $scope.$on('$stateChangeSuccess', initialize, true);
+
+  });

--- a/app/scripts/modules/core/pipeline/config/stages/destroyAsg/azure/destroyAsgExecutionDetails.html
+++ b/app/scripts/modules/core/pipeline/config/stages/destroyAsg/azure/destroyAsgExecutionDetails.html
@@ -1,0 +1,46 @@
+<div ng-controller="azureDestroyAsgExecutionDetailsCtrl">
+  <execution-details-section-nav sections="configSections"></execution-details-section-nav>
+  <div class="step-section-details" ng-if="detailsSection === 'destroyServerGroupConfig'">
+    <div class="row">
+      <div class="col-md-9">
+        <dl class="dl-narrow dl-horizontal">
+          <dt>Account</dt>
+          <dd>
+            <account-tag account="stage.context.credentials"></account-tag>
+          </dd>
+          <dt>Region</dt>
+          <dd>{{stage.context.regions.join(', ')}}</dd>
+          <dt>Server Group</dt>
+          <dd>{{stage.context.serverGroupName}}</dd>
+        </dl>
+      </div>
+    </div>
+    <stage-failure-message is-failed="stage.isFailed" message="stage.failureMessage"></stage-failure-message>
+
+    <div class="row" ng-if="stage.isCompleted && stage.context.serverGroupName">
+      <div class="col-md-12">
+        <div class="well alert alert-info">
+          <strong>Destroyed:</strong>
+          {{stage.context.serverGroupName}}
+        </div>
+      </div>
+    </div>
+
+    <div class="row" ng-if="stage.context.execution.logs">
+      <div class="col-md-12">
+        <div class="well alert alert-info">
+          <!-- TODO: Move this to config -->
+          <a target="_blank" href="{{stage.context.execution.logs}}">
+            View Execution Logs
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="step-section-details" ng-if="detailsSection === 'taskStatus'">
+    <div class="row">
+      <execution-step-details item="stage"></execution-step-details>
+    </div>
+  </div>
+</div>

--- a/app/scripts/modules/core/pipeline/config/stages/destroyAsg/azure/destroyAsgStage.html
+++ b/app/scripts/modules/core/pipeline/config/stages/destroyAsg/azure/destroyAsgStage.html
@@ -1,0 +1,13 @@
+<div ng-controller="azureDestroyAsgStageCtrl as destroyAsgStageCtrl" class="form-horizontal">
+  <div ng-if="!pipeline.strategy">
+    <account-region-cluster-selector
+      application="application"
+      component="stage"
+      accounts="accounts">
+    </account-region-cluster-selector>
+  </div>
+  <stage-config-field label="Target">
+    <target-select model="stage" options="targets"></target-select>
+  </stage-config-field>
+</div>
+

--- a/app/scripts/modules/core/pipeline/config/stages/destroyAsg/azure/destroyAsgStepLabel.html
+++ b/app/scripts/modules/core/pipeline/config/stages/destroyAsg/azure/destroyAsgStepLabel.html
@@ -1,0 +1,5 @@
+<span class="task-label">
+  Destroy Server Group:
+  {{step.context.serverGroupName}}
+  ({{step.context.regions[0]}})
+</span>

--- a/app/scripts/modules/core/pipeline/config/validation/pipelineConfigValidation.service.js
+++ b/app/scripts/modules/core/pipeline/config/validation/pipelineConfigValidation.service.js
@@ -82,7 +82,7 @@ module.exports = angular.module('spinnaker.core.pipeline.config.validator.servic
             if (toTest.type === 'deploy' && toTest.clusters && toTest.clusters.length) {
               toTest.clusters.forEach(function(cluster) {
                 var clusterName = namingService.getClusterName(cluster.application, cluster.stack, cluster.freeFormDetails);
-                if (clusterName === stage.cluster && cluster.account === stage.credentials && cluster.availabilityZones.hasOwnProperty(region)) {
+                if (clusterName === stage.cluster && cluster.account === stage.credentials && cluster.availabilityZones && cluster.availabilityZones.hasOwnProperty(region)) {
                   regionFound = true;
                 }
               });


### PR DESCRIPTION
This change enables the destroy server group operation for Azure through a pipeline. For that I followed mostly the AWS current implementation with some additional small tweaks. 

@anotherchrisberry can you please take a look?