### PR TITLE
provider/aws: allow creation of cross-account ingress sg rules

### DIFF
--- a/app/scripts/modules/amazon/securityGroup/configure/CreateSecurityGroup.controller.spec.js
+++ b/app/scripts/modules/amazon/securityGroup/configure/CreateSecurityGroup.controller.spec.js
@@ -154,7 +154,7 @@ describe('Controller: CreateSecurityGroup', function () {
 
     describe('security group removal', function () {
       beforeEach(function () {
-        spyOn(this.v2modalWizardService, 'markDirty').and.callFake(angular.noop);
+        spyOn(this.v2modalWizardService, 'markDirty').and.returnValue(null);
         this.initializeCtrl();
         let securityGroup = this.$scope.securityGroup;
         securityGroup.credentials = 'prod';

--- a/app/scripts/modules/amazon/securityGroup/configure/CreateSecurityGroupCtrl.js
+++ b/app/scripts/modules/amazon/securityGroup/configure/CreateSecurityGroupCtrl.js
@@ -4,7 +4,6 @@ let angular = require('angular');
 
 module.exports = angular.module('spinnaker.amazon.securityGroup.create.controller', [
   require('angular-ui-router'),
-  require('../../../core/account/account.service.js'),
   require('../../../core/cache/infrastructureCaches.js'),
   require('../../../core/cache/cacheInitializer.js'),
   require('../../../core/task/monitor/taskMonitorService.js'),
@@ -12,7 +11,7 @@ module.exports = angular.module('spinnaker.amazon.securityGroup.create.controlle
   require('../../../core/config/settings.js'),
 ])
   .controller('awsCreateSecurityGroupCtrl', function($scope, $uibModalInstance, $state, $controller,
-                                                  accountService, securityGroupReader,
+                                                  securityGroupReader,
                                                   taskMonitorService, cacheInitializer, infrastructureCaches,
                                                   _, application, securityGroup, settings ) {
 
@@ -31,21 +30,10 @@ module.exports = angular.module('spinnaker.amazon.securityGroup.create.controlle
       settings: settings,
     }));
 
+    $scope.state.isNew = true;
 
-    accountService.listAccounts('aws').then(function(accounts) {
-      $scope.accounts = accounts;
-      ctrl.accountUpdated();
-    });
+    ctrl.upsert = () => ctrl.mixinUpsert('Create');
 
-    this.getSecurityGroupRefreshTime = function() {
-      return infrastructureCaches.securityGroups.getStats().ageMax;
-    };
-
-
-    ctrl.upsert = function () {
-      ctrl.mixinUpsert('Create');
-    };
-
-    ctrl.initializeSecurityGroups();
+    ctrl.initializeSecurityGroups().then(ctrl.initializeAccounts);
 
   });

--- a/app/scripts/modules/amazon/securityGroup/configure/createSecurityGroup.html
+++ b/app/scripts/modules/amazon/securityGroup/configure/createSecurityGroup.html
@@ -12,6 +12,6 @@
             ng-click="ctrl.cancel()">Cancel
     </button>
     <submit-button is-disabled="form.$invalid || !wizard.isComplete() || state.submitting"
-                   submitting="state.submitting" on-click="ctrl.upsert()" is-new="isNew"></submit-button>
+                   submitting="state.submitting" on-click="ctrl.upsert()" is-new="state.isNew"></submit-button>
   </div>
 </ng-form>

--- a/app/scripts/modules/amazon/securityGroup/configure/createSecurityGroupIngress.html
+++ b/app/scripts/modules/amazon/securityGroup/configure/createSecurityGroupIngress.html
@@ -37,26 +37,23 @@
             <tbody>
             <tr ng-repeat="rule in securityGroup.securityGroupIngress">
               <td>
-                <span class="form-control-static" ng-if="rule.existing">
-                  <account-tag account="rule.accountName" ng-if="rule.accountName !== securityGroup.accountName"></account-tag>
-                  {{rule.name}}
-                </span>
-                <ui-select ng-if="!rule.existing" ng-model="rule.name" class="form-control input-sm" required style="width: 244px">
-                  <ui-select-match>{{$select.selected}}</ui-select-match>
-                  <ui-select-choices repeat="securityGroup as securityGroup in availableSecurityGroups | filter: $select.search | limitTo: state.infiniteScroll.currentItems"
-                                     infinite-scroll="ctrl.addMoreItems()"
-                                     infinite-scroll-distance="2">
-                    <span ng-bind-html="securityGroup | highlight: $select.search"></span>
-                  </ui-select-choices>
-                </ui-select>
+                <ingress-rule-group-selector rule="rule"
+                                             ng-if="state.securityGroupsLoaded"
+                                             security-group="securityGroup"
+                                             vpcs="allVpcs"
+                                             accounts="accounts"
+                                             all-security-groups="allSecurityGroups"
+                                             coordinates-changed="coordinatesChanged"
+                                             all-security-groups-updated="allSecurityGroupsUpdated"></ingress-rule-group-selector>
               </td>
               <td><select class="form-control input-sm" ng-model="rule.type"
                           ng-options="protocol as protocol.toUpperCase() for protocol in ['tcp', 'udp', 'icmp']" required></select></td>
               <td><input class="form-control input-sm" type="number" min="0" ng-model="rule.startPort" required/></td>
               <td><input class="form-control input-sm" type="number" min="0" ng-model="rule.endPort" required/></td>
-              <td><a class="btn btn-link sm-label"
-                     ng-click="ctrl.removeRule(securityGroup.securityGroupIngress, $index)"><span
-                class="glyphicon glyphicon-trash"></span></a></td>
+              <td><a class="sm-label"
+                     ng-click="ctrl.removeRule(securityGroup.securityGroupIngress, $index)">
+                <span class="glyphicon glyphicon-trash"></span></a>
+              </td>
             </tr>
             </tbody>
             <tfoot>

--- a/app/scripts/modules/amazon/securityGroup/configure/editSecurityGroup.html
+++ b/app/scripts/modules/amazon/securityGroup/configure/editSecurityGroup.html
@@ -8,6 +8,6 @@
           ng-click="ctrl.cancel()">Cancel
   </button>
   <submit-button is-disabled="form.$invalid || !wizard.isComplete() || state.submitting"
-                 submitting="state.submitting" on-click="ctrl.upsert()" is-new="isNew"></submit-button>
+                 submitting="state.submitting" on-click="ctrl.upsert()" is-new="state.isNew"></submit-button>
 </div>
 

--- a/app/scripts/modules/amazon/securityGroup/configure/ingressRuleGroupSelector.component.html
+++ b/app/scripts/modules/amazon/securityGroup/configure/ingressRuleGroupSelector.component.html
@@ -1,0 +1,49 @@
+<span class="form-control-static" ng-if="$ctrl.rule.existing">
+  <account-tag account="$ctrl.rule.accountName" ng-if="$ctrl.rule.accountName !== $ctrl.securityGroup.accountName"></account-tag>
+  {{$ctrl.rule.name}}
+</span>
+
+<div ng-if="$ctrl.rule.crossAccountEnabled && $ctrl.securityGroup.regions.length === 1" class="cross-account-select">
+  <div class="row">
+    <div class="col-md-3"><span class="small">Account</span></div>
+    <div class="col-md-9">
+      <account-select-field component="$ctrl.rule" field="accountName" accounts="$ctrl.accounts" provider="'aws'" on-change="$ctrl.setAvailableSecurityGroups()"></account-select-field>
+    </div>
+  </div>
+  <div class="row" ng-if="$ctrl.securityGroup.vpcId">
+    <div class="col-md-3"><span class="small">VPC</span></div>
+    <div class="col-md-9">
+      <select class="form-control input-sm" ng-model="$ctrl.rule.vpcId"
+             ng-change="$ctrl.setAvailableSecurityGroups()">
+        <option ng-repeat="vpc in $ctrl.regionalVpcs[$ctrl.rule.accountName]" value="{{vpc.id}}" ng-selected="$ctrl.rule.vpcId === vpc.id">{{vpc.label}}</option>
+      </select>
+    </div>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md-3">
+    <span class="small" ng-if="$ctrl.rule.crossAccountEnabled">Group</span>
+  </div>
+  <div class="col-md-{{$ctrl.rule.crossAccountEnabled ? 9 : 12}}">
+    <ui-select ng-if="!$ctrl.rule.existing" ng-model="$ctrl.rule.name" class="form-control input-sm" required style="width: 100%">
+      <ui-select-match>{{$select.selected}}</ui-select-match>
+      <ui-select-choices repeat="securityGroup as securityGroup in $ctrl.availableSecurityGroups | filter: $select.search | limitTo: $ctrl.infiniteScroll.currentItems"
+                         infinite-scroll="$ctrl.addMoreItems()"
+                         infinite-scroll-distance="2">
+        <span ng-bind-html="securityGroup | highlight: $select.search"></span>
+      </ui-select-choices>
+    </ui-select>
+  </div>
+</div>
+
+<a href
+   class="small"
+   ng-if="!$ctrl.rule.existing && $ctrl.securityGroup.regions.length === 1 && !$ctrl.rule.crossAccountEnabled"
+   ng-click="$ctrl.enableCrossAccount($index)">
+  Select from a different account <span ng-if="$ctrl.securityGroup.vpcId">or VPC</span>
+</a>
+
+<span ng-if="$ctrl.securityGroup.regions.length > 1" class="small">
+  Cross-account rules disabled when 2+ regions selected
+</span>

--- a/app/scripts/modules/amazon/securityGroup/configure/ingressRuleGroupSelector.component.js
+++ b/app/scripts/modules/amazon/securityGroup/configure/ingressRuleGroupSelector.component.js
@@ -1,0 +1,134 @@
+'use strict';
+
+const angular = require('angular');
+
+require('./ingressRuleGroupSelector.component.less');
+
+module.exports = angular
+  .module('spinnaker.amazon.securityGroup.configure.ingressRuleGroupSelector', [
+    require('../../../core/utils/lodash'),
+  ])
+  .component('ingressRuleGroupSelector', {
+    bindings: {
+      rule: '=',
+      securityGroup: '=',
+      accounts: '=',
+      vpcs: '=',
+      allSecurityGroups: '=',
+      coordinatesChanged: '=',
+      allSecurityGroupsUpdated: '=',
+    },
+    templateUrl: require('./ingressRuleGroupSelector.component.html'),
+    controller: function(_) {
+
+      this.infiniteScroll = {
+        currentItems: 20,
+      };
+
+      this.addMoreItems = () => this.infiniteScroll.currentItems += 20;
+
+      this.setAvailableSecurityGroups = () => {
+        var account = this.rule.accountName || this.securityGroup.credentials;
+        var regions = this.securityGroup.regions;
+        var vpcId = this.rule.vpcId || this.securityGroup.vpcId || null;
+
+        var existingSecurityGroupNames = [];
+        var availableSecurityGroups = [];
+
+        if (regions.length > 1) {
+          this.disableCrossAccount();
+        }
+
+        regions.forEach(region => {
+          var regionalVpcId = null;
+          if (vpcId) {
+            var [baseVpc] = this.vpcs.filter(vpc => vpc.id === vpcId),
+                [regionalVpc] = this.vpcs.filter(vpc => vpc.account === account && vpc.region === region && vpc.name === baseVpc.name);
+            regionalVpcId = regionalVpc ? regionalVpc.id : undefined;
+          }
+
+          var regionalGroupNames = this.allSecurityGroups[account].aws[region]
+            .filter(group => group.vpcId === regionalVpcId)
+            .map(group => group.name);
+
+          existingSecurityGroupNames = _.uniq(existingSecurityGroupNames.concat(regionalGroupNames));
+
+          if (!availableSecurityGroups.length) {
+            availableSecurityGroups = existingSecurityGroupNames;
+          } else {
+            availableSecurityGroups = _.intersection(availableSecurityGroups, regionalGroupNames);
+          }
+        });
+        if (regions.length === 1) {
+          this.configureAvailableVpcs();
+        }
+        this.availableSecurityGroups = availableSecurityGroups;
+        if (availableSecurityGroups.indexOf(this.rule.name) === -1) {
+          this.rule.name = null;
+        }
+      };
+
+      let addRegionalVpc = (vpc) => {
+        let account = vpc.account;
+        if (!this.regionalVpcs[account]) {
+          this.regionalVpcs[account] = [];
+        }
+        this.regionalVpcs[account].push({
+          id: vpc.id,
+          label: vpc.label,
+          deprecated: vpc.deprecated,
+        });
+      };
+      
+      let reconcileRuleVpc = (filtered) => {
+        if (this.rule.vpcId) {
+          if (!this.securityGroup.vpcId) {
+            this.rule.vpcId = null;
+            this.rule.name = null;
+            return;
+          }
+          let [baseVpc] = filtered.filter(vpc => vpc.id === this.rule.vpcId),
+              [regionalVpc] = filtered.filter(vpc => vpc.account === this.rule.accountName && vpc.name === baseVpc.name);
+          if (regionalVpc) {
+            this.rule.vpcId = regionalVpc.id;
+          } else {
+            this.rule.vpcId = null;
+            this.rule.name = null;
+          }
+        }
+      };
+
+      this.configureAvailableVpcs = () => {
+        let region = this.securityGroup.regions[0];
+        let filtered = this.vpcs.filter(vpc => vpc.region === region);
+        this.regionalVpcs = {};
+        filtered.forEach(addRegionalVpc);
+        reconcileRuleVpc(filtered);
+      };
+
+      this.subscriptions = [
+        this.allSecurityGroupsUpdated.subscribe(this.setAvailableSecurityGroups),
+        this.coordinatesChanged.subscribe(this.setAvailableSecurityGroups)
+      ];
+
+      this.enableCrossAccount = () => {
+        this.rule.crossAccountEnabled = true;
+        this.rule.accountName = this.securityGroup.credentials;
+        this.rule.vpcId = this.securityGroup.vpcId;
+      };
+
+      this.disableCrossAccount = () => {
+        this.rule.crossAccountEnabled = false;
+        this.rule.accountName = undefined;
+        this.rule.vpcId = undefined;
+      };
+
+      this.$onInit = this.setAvailableSecurityGroups;
+
+      // HACK: This won't do anything until a fix for https://github.com/angular/angular.js/issues/14020 is released.
+      // It will probably lead to some very small memory leaks, and possibly some exceptions that the user will not see.
+      this.$onDestroy = () => {
+        this.subscriptions.forEach(subscription => subscription.dispose());
+      };
+    }
+  });

--- a/app/scripts/modules/amazon/securityGroup/configure/ingressRuleGroupSelector.component.less
+++ b/app/scripts/modules/amazon/securityGroup/configure/ingressRuleGroupSelector.component.less
@@ -1,0 +1,6 @@
+ingress-rule-group-selector {
+  .col-md-3 {
+    padding-right: 0;
+    font-weight: 600;
+  }
+}


### PR DESCRIPTION
Cross-account security group rules are a thing. We (mostly) support it in Orca/Clouddriver; this adds support to add cross-account ingress rules when creating or editing a security group.

One caveat: we are not supporting the creation of cross-account rules when creating multiple security groups at a time (by selecting multiple regions). There's a fair amount of work that needs to be done in Clouddriver to support this, and it can wait until someone asks for it.

I had bigger intentions of refactoring this code, but there are three functionally separate modals that use a lot of this code - create, edit, clone - and it's a mess. I got around 1500 LOC changed and wasn't close to having anything working, so I abandoned it and ended up with this.