### PR TITLE
Adds a (Generic) ACA Task Stage.

### DIFF
--- a/app/scripts/modules/netflix/netflix.module.js
+++ b/app/scripts/modules/netflix/netflix.module.js
@@ -17,6 +17,7 @@ module.exports = angular
     require('./feedback/feedback.module.js'),
     require('./instance/aws/netflixAwsInstanceDetails.controller.js'),
     require('./pipeline/stage/canary/canaryStage.module.js'),
+    require('./pipeline/stage/acaTask/acaTaskStage.module'),
     require('./pipeline/stage/properties'),
     require('./pipeline/stage/quickPatchAsg/quickPatchAsgStage.module.js'),
     require('./pipeline/stage/quickPatchAsg/bulkQuickPatchStage/bulkQuickPatchStage.module.js'),

--- a/app/scripts/modules/netflix/pipeline/stage/acaTask/acaTaskExecutionDetails.html
+++ b/app/scripts/modules/netflix/pipeline/stage/acaTask/acaTaskExecutionDetails.html
@@ -1,0 +1,207 @@
+<div class="canary-details" ng-controller="CanaryExecutionDetailsCtrl as canaryDetailsCtrl">
+  <execution-details-section-nav sections="configSections"></execution-details-section-nav>
+
+  <div class="step-section-details" ng-if="detailsSection === 'canarySummary'">
+    <div class="row">
+      <div class="col-md-2 canary-summary">
+        <div class="score score-large">
+          <canary-score health="canary.health.health"
+                        result="canary.canaryResult.overallResult"
+                        score="canary.canaryResult.overallScore"></canary-score>
+        </div>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-md-12">
+        <table class="table">
+          <tbody>
+          <tr>
+            <td style="border-top: none !important;"><strong>Canary Result</strong></td>
+            <td style="border-top: none !important;"><strong>Duration</strong></td>
+            <td style="border-top: none !important;"><strong>Report</strong></td>
+            <td style="border-top: none !important;"><strong>Last Updated</strong></td>
+          </tr>
+          <tr ng-repeat="canaryDeployment in canaryDeployments">
+            <td>
+              <canary-score result="canaryDeployment.canaryAnalysisResult.result"
+                            score="canaryDeployment.canaryAnalysisResult.score"
+                            health="canaryDeployment.health.health"></canary-score>
+            </td>
+            <td>
+              <span ng-if="canaryDeployment.canaryAnalysisResult.timeDuration.durationString">
+                {{ canaryDeployment.canaryAnalysisResult.timeDuration.durationString }}
+              </span>
+              <span ng-if="!canaryDeployment.canaryAnalysisResult.timeDuration.durationString">
+                -
+              </span>
+            </td>
+            <td>
+              <a ng-if="canaryDeployment.canaryAnalysisResult.canaryReportURL"
+                 target="_blank" ng-href="{{canaryDeployment.canaryAnalysisResult.canaryReportURL}}">
+                Canary Report
+              </a>
+            </td>
+            <td>
+              <span ng-if="canaryDeployment.canaryAnalysisResult.lastUpdated">
+                {{ canaryDeployment.canaryAnalysisResult.lastUpdated | timestamp}}
+              </span>
+              <span ng-if="!canaryDeployment.canaryAnalysisResult.lastUpdated">
+                -
+              </span>
+            </td>
+          </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-md-12">
+        <div class="well alert alert-info">
+          <div class="row" ng-if="canary.launchedDate">
+            <div class="col-md-2">
+              <strong>Launched</strong>
+            </div>
+            <div class="col-md-9">
+              <span>{{ canary.launchedDate | timestamp }}</span>
+            </div>
+          </div>
+          <div class="row" ng-if="canary.endDate" style="margin-top: 6px;">
+            <div class="col-md-2">
+              <strong>Ended</strong>
+            </div>
+            <div class="col-md-9">
+              <span>{{ canary.endDate | timestamp }}</span>
+            </div>
+          </div>
+          <div class="row" style="margin-top: 6px;">
+            <div class="col-md-2">
+              <strong>Status</strong>
+            </div>
+            <div class="col-md-9">
+              <h5><canary-status status="canary.status.status"></canary-status></h5>
+            </div>
+          </div>
+          <div class="row" ng-if="canary.status.reason">
+            <div class="col-md-2">
+              <strong>Message</strong>
+            </div>
+            <div class="col-md-9">
+              <span>{{ canary.status.reason }}</span>
+            </div>
+          </div>
+          <div class="row" ng-if="canary.canaryResult.manual" style="margin-top: 6px;">
+            <div class="col-md-2">
+              <strong>Result</strong>
+            </div>
+            <div class="col-md-6">
+              <div class="alert canary-summary-alert alert-danger"><strong>Canary result has been manually set</strong></div>
+            </div>
+          </div>
+          <div class="row"
+               ng-if="!canary.canaryResult.manual
+                      && canary.status.complete
+                      && canary.canaryResult.overallResult === 'failure'
+                      && canary.canaryResult.message"
+               style="margin-top: 6px;">
+            <div class="col-md-2">
+              <strong>Result</strong>
+            </div>
+            <div class="col-md-10">
+              <div class="alert canary-summary-alert alert-danger"><strong>{{ canary.canaryResult.message }}</strong></div>
+            </div>
+          </div>
+        </div>
+        <stage-failure-message is-failed="stage.exceptions.length > 0" messages="stage.exceptions"></stage-failure-message>
+      </div>
+    </div>
+  </div>
+
+  <div class="step-section-details" ng-if="detailsSection === 'canaryConfig'">
+    <div class="row">
+      <div class="col-md-12">
+        <div class="row">
+          <div class="col-md-4"><h5>Name</h5></div>
+          <div class="col-md-6"><h5 ng-bind="canaryConfig.name"></h5></div>
+        </div>
+        <div class="horizontal-rule"></div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-md-12 canary-config-section">
+        <div class="row" ng-if="canary.canaryDeployments.length > 0">
+          <div class="col-md-4 sm-label-right compact">Account</div>
+          <div class="col-md-6"><account-tag account="canary.canaryDeployments[0].accountName" pad="right"></account-tag></div>
+        </div>
+        <div class="row">
+          <div class="col-md-4 sm-label-right compact">Duration</div>
+          <div class="col-md-6">{{canaryConfig.lifetimeHours}} hours</div>
+        </div>
+        <div class="row">
+          <div class="col-md-4 sm-label-right compact">Success Criteria</div>
+          <div class="col-md-6">{{canaryConfig.canarySuccessCriteria.canaryResultScore}}</div>
+        </div>
+        <div class="row">
+          <div class="col-md-4 sm-label-right compact">Result Strategy</div>
+          <div class="col-md-6">{{canaryConfig.combinedCanaryResultStrategy | lowercase}}</div>
+        </div>
+        <div class="row" ng-if="canary.canaryDeployments.length > 0">
+          <div class="col-md-4 sm-label-right compact">Scope Type</div>
+          <div class="col-md-6">{{canary.canaryDeployments[0].type}}</div>
+        </div>
+        <div class="row" ng-if="canary.canaryDeployments.length > 0">
+          <div class="col-md-4 sm-label-right compact">Baseline</div>
+          <div class="col-md-6">{{canary.canaryDeployments[0].baseline}}</div>
+        </div>
+        <div class="row" ng-if="canary.canaryDeployments.length > 0">
+          <div class="col-md-4 sm-label-right compact">Canary</div>
+          <div class="col-md-6">{{canary.canaryDeployments[0].canary}}</div>
+        </div>
+      </div>
+      <div class="col-md-12 canary-config-section">
+        <h5>Analysis Config</h5>
+        <div class="horizontal-rule"></div>
+        <div class="row">
+          <div class="col-md-4 sm-label-right compact">Config Name</div>
+          <div class="col-md-6">
+            <a href="http://canary.prod.netflix.net/ui/canaryTasks/{{baseline.account}}/{{canaryConfig.canaryAnalysisConfig.name}}" target="_blank">
+              {{canaryConfig.canaryAnalysisConfig.name}}
+            </a>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col-md-4 sm-label-right compact">Warmup Period</div>
+          <div class="col-md-6">{{canaryConfig.canaryAnalysisConfig.beginCanaryAnalysisAfterMins}} minutes</div>
+        </div>
+        <div class="row">
+          <div class="col-md-4 sm-label-right compact">Interval</div>
+          <div class="col-md-6">{{canaryConfig.canaryAnalysisConfig.canaryAnalysisIntervalMins}} minutes</div>
+        </div>
+        <div class="row">
+          <div class="col-md-4 sm-label-right compact">Notification Hours</div>
+          <div class="col-md-6">{{canaryConfig.canaryAnalysisConfig.notificationHours.join(', ')}}</div>
+        </div>
+        <div class="row">
+          <div class="col-md-4 sm-label-right compact">Canary Report Recipients</div>
+          <div class="col-md-6">{{canary.recipients.join(', ')}}</div>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-md-12 canary-config-section">
+        <h5>Health Check</h5>
+        <div class="horizontal-rule"></div>
+        <div class="row">
+          <div class="col-md-4 sm-label-right compact">Minimum Canary Score</div>
+          <div class="col-md-6">{{canaryConfig.canaryHealthCheckHandler.minimumCanaryResultScore}}</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="step-section-details" ng-if="detailsSection === 'taskStatus'">
+    <div class="row">
+      <execution-step-details item="stage"></execution-step-details>
+    </div>
+  </div>
+</div>

--- a/app/scripts/modules/netflix/pipeline/stage/acaTask/acaTaskExecutionSummary.html
+++ b/app/scripts/modules/netflix/pipeline/stage/acaTask/acaTaskExecutionSummary.html
@@ -1,0 +1,51 @@
+<div ng-controller="CanaryExecutionSummaryCtrl as canaryExecutionSummaryCtrl">
+  <h5 class="execution-details-title">
+    {{stageSummary.name || stageSummary.type }} Details
+
+    <div ng-if="stageSummary.masterStage.context.canary.status.status === 'LAUNCHED' ||
+                stageSummary.masterStage.context.canary.status.status === 'RUNNING' ||
+                stageSummary.masterStage.context.canary.status.status === 'DISABLED'" uib-dropdown class="btn-group pull-right">
+      <button type="button" class="btn btn-default btn-sm dropdown-toggle" aria-expanded="false" uib-dropdown-toggle>
+        Actions
+        <span class="caret"></span>
+      </button>
+      <ul class="dropdown-menu" uib-dropdown-menu role="menu">
+        <li><a href ng-click="canaryExecutionSummaryCtrl.generateCanaryScore()">Generate Canary Result</a></li>
+        <li><a href ng-click="canaryExecutionSummaryCtrl.endCanary()">End Canary</a></li>
+      </ul>
+    </div>
+  </h5>
+  <h6 class="duration">Duration: {{stageSummary.runningTimeInMs | duration}}</h6>
+  <table class="table canary-summary">
+    <thead>
+    <tr>
+      <th width="60%">Deployment</th>
+      <th width="40%">Running Time</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr class="clickable"
+        ng-class="{ info: ctrl.isStepCurrent(stageSummary.masterStageIndex) }"
+        ng-click="ctrl.toggleDetails(stageSummary.masterStageIndex)">
+      <td>
+        <status-glyph item="{isFailed: true}" ng-if="stageSummary.masterStage.exceptions.length"></status-glyph>
+        <strong>Canary Summary</strong>
+      </td>
+      <td>{{stageSummary.runningTimeInMs | duration}}</td>
+    </tr>
+    <tr class="clickable canary-deployment-row"
+        ng-repeat="stage in stageSummary.stages"
+        ng-class="{ info: ctrl.isStepCurrent($index) }"
+        ng-if="stage.type === 'monitorAcaTask'"
+        ng-click="ctrl.toggleDetails($index)">
+
+      <td>{{ stage.name }}</td>
+      <td>{{stage.runningTimeInMs | duration}}</td>
+    </tr>
+    </tbody>
+  </table>
+  <div ng-if="stageSummary.comments">
+    <strong>Comments</strong>
+    <p ng-bind-html="stageSummary.comments"></p>
+  </div>
+</div>

--- a/app/scripts/modules/netflix/pipeline/stage/acaTask/acaTaskMonitor/acaTaskExecutionDetails.controller.js
+++ b/app/scripts/modules/netflix/pipeline/stage/acaTask/acaTaskMonitor/acaTaskExecutionDetails.controller.js
@@ -1,0 +1,71 @@
+'use strict';
+
+let angular = require('angular');
+
+module.exports = angular.module('spinnaker.netflix.pipeline.stage.canary.acaTaskExecution.details.controller', [
+  require('angular-ui-router'),
+  require('../../../../../core/utils/lodash.js'),
+  require('../../../../../core/delivery/details/executionDetailsSection.service.js'),
+  require('../../../../../core/delivery/details/executionDetailsSectionNav.directive.js'),
+  require('../../../../../core/navigation/urlBuilder.service.js'),
+  require('../../canary/canaryDeployment/canaryDeploymentHistory.service.js')
+])
+  .controller('AcaTaskExecutionDetailsCtrl', function ($scope, _, $stateParams, $timeout,
+                                                                executionDetailsSectionService,
+                                                                canaryDeploymentHistoryService, urlBuilderService,
+                                                                clusterFilterService) {
+
+    function initialize() {
+
+      $scope.configSections = ['canaryDeployment', 'canaryAnalysisHistory'];
+
+      $scope.deployment = $scope.stage.context;
+
+      $scope.viewState = {
+        loadingHistory: true,
+        loadingHistoryError: false,
+      };
+
+      executionDetailsSectionService.synchronizeSection($scope.configSections);
+      $scope.detailsSection = $stateParams.details;
+
+
+      $scope.loadHistory();
+    }
+
+    $scope.loadHistory = function () {
+
+      if ($scope.deployment.canary.canaryDeployments.length > 0) {
+        $scope.viewState.loadingHistory = true;
+        $scope.viewState.loadingHistoryError = false;
+
+        var canaryDeploymentId = $scope.deployment.canary.canaryDeployments[0].id;
+        canaryDeploymentHistoryService.getAnalysisHistory(canaryDeploymentId).then(
+          function (results) {
+            $scope.analysisHistory = results;
+            $scope.viewState.loadingHistory = false;
+          },
+          function () {
+            $scope.viewState.loadingHistory = false;
+            $scope.viewState.loadingHistoryError = true;
+          }
+        );
+      } else {
+        $scope.analysisHistory = [];
+        $scope.viewState.loadingHistory = false;
+      }
+    };
+
+    this.overrideFiltersForUrl = clusterFilterService.overrideFiltersForUrl;
+
+    this.overrideFiltersForUrl = clusterFilterService.overrideFiltersForUrl;
+
+    initialize();
+
+    $scope.$on('$stateChangeSuccess',
+      function () {
+        $timeout(initialize);
+      },
+      true);
+
+  });

--- a/app/scripts/modules/netflix/pipeline/stage/acaTask/acaTaskMonitor/acaTaskMonitor.module.js
+++ b/app/scripts/modules/netflix/pipeline/stage/acaTask/acaTaskMonitor/acaTaskMonitor.module.js
@@ -1,0 +1,8 @@
+'use strict';
+
+let angular = require('angular');
+
+module.exports = angular.module('spinnaker.netflix.pipeline.stage.canary.acaTaskMonitor', [
+  require('./acaTaskMonitorStage'),
+  require('./acaTaskExecutionDetails.controller'),
+]);

--- a/app/scripts/modules/netflix/pipeline/stage/acaTask/acaTaskMonitor/acaTaskMonitorExecutionDetails.html
+++ b/app/scripts/modules/netflix/pipeline/stage/acaTask/acaTaskMonitor/acaTaskMonitorExecutionDetails.html
@@ -1,0 +1,80 @@
+<div class="canary-details" ng-controller="AcaTaskExecutionDetailsCtrl as canaryDeploymentDetailsCtrl">
+  <execution-details-section-nav sections="configSections"></execution-details-section-nav>
+
+  <div class="step-section-details" ng-if="detailsSection === 'canaryDeployment'">
+    <div class="row">
+      <div class="col-md-12 canary-summary">
+        <div class="score score-large">
+          <canary-score health="stage.context.canary.health.health"
+                        result="stage.context.canary.canaryResult.overallResult"
+                        score="stage.context.canary.canaryResult.overallScore"></canary-score>
+        </div>
+        <div class="canary-summary-section">
+          <span ng-if="stage.context.canary.canaryResult.lastUpdated">
+            <strong>Last updated&nbsp;:&nbsp;&nbsp;</strong>
+            {{ stage.context.canary.canaryResult.lastUpdated | timestamp}}
+          </span>
+          <span ng-if="!stage.context.canary.canaryResult.lastUpdated">No canary result available</span>
+          <br/>
+          <span ng-if="stage.context.canary.canaryResult.lastUpdated">
+            <strong>Score duration&nbsp;:&nbsp;&nbsp;</strong>
+            {{ stage.context.canary.canaryResult.lastCanaryAnalysisResults[0].timeDuration.durationString }}
+          </span>
+        </div>
+        <div class="canary-summary-section">
+          <a ng-if="stage.context.canary.canaryResult.lastCanaryAnalysisResults[0].canaryReportURL" target="_blank" ng-href="{{stage.context.canary.canaryResult.lastCanaryAnalysisResults[0].canaryReportURL}}">Canary Report</a>
+          <br/>
+          <span style="visibility: hidden;">Diff Report</span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="step-section-details" ng-if="detailsSection === 'canaryAnalysisHistory'">
+    <div class="row">
+      <div class="col-md-12">
+        <p class="text-center" ng-if="viewState.loadingHistory">Loading...</p>
+        <p class="text-center" ng-if="!viewState.loadingHistory && viewState.loadingHistoryError">
+          Canary analysis history could not be loaded. <br/>
+          <a href ng-click="loadHistory()">Reload score history</a>
+        </p>
+        <table class="table" ng-if="!viewState.loadingHistory && !viewState.loadingHistoryError">
+          <thead>
+          <tr>
+            <th>Score</th>
+            <th>Score Duration</th>
+            <th>Generated On</th>
+            <th>Report</th>
+          </tr>
+          </thead>
+          <tbody>
+            <tr ng-repeat="scoreReport in analysisHistory | orderBy: '-lastUpdated'">
+              <td>
+                <canary-score result="scoreReport.result"
+                              score="scoreReport.score"
+                              health="scoreReport.health"></canary-score>
+              </td>
+              <td>{{ scoreReport.timeDuration.durationString }}</td>
+              <td>{{ scoreReport.lastUpdated | timestamp }}</td>
+              <td><a target="_blank" ng-href="{{scoreReport.canaryReportURL}}">Canary Report</a></td>
+            </tr>
+          </tbody>
+        </table>
+        <p class="text-center" ng-if="!viewState.loadingHistory && !analysisHistory.length">No canary analysis history available</p>
+
+      </div>
+    </div>
+  </div>
+  <div class="step-section-details" ng-if="detailsSection === 'codeChanges' && commits">
+    <table>
+      <tr><th>#</th><th>Date</th><th>Commit</th><th>Message</th><th>Author</th></tr>
+      <tr ng-repeat="commit in commits">
+        <td><b>{{$index+1}}</b>&nbsp;&nbsp;</td>
+        <td>{{commit.timestamp | date:'MM/dd'}}&nbsp;&nbsp;</td>
+        <td><a target="_blank" href="{{commit.commitUrl}}">{{commit.displayId}}</a>&nbsp;&nbsp;</td>
+        <td>{{commit.message | limitTo: 50}}&nbsp;&nbsp;</td>
+        <td>{{commit.authorDisplayName}}</td>
+      </tr>
+    </table>
+  </div>
+</div>

--- a/app/scripts/modules/netflix/pipeline/stage/acaTask/acaTaskMonitor/acaTaskMonitorStage.js
+++ b/app/scripts/modules/netflix/pipeline/stage/acaTask/acaTaskMonitor/acaTaskMonitorStage.js
@@ -1,0 +1,12 @@
+'use strict';
+
+let angular = require('angular');
+
+module.exports = angular.module('spinnaker.netflix.pipeline.stage.canary.acaTaskMonitorStage', [])
+  .config(function(pipelineConfigProvider) {
+    pipelineConfigProvider.registerStage({
+      synthetic: true,
+      key: 'monitorAcaTask',
+      executionDetailsUrl: require('./acaTaskMonitorExecutionDetails.html'),
+    });
+  });

--- a/app/scripts/modules/netflix/pipeline/stage/acaTask/acaTaskStage.html
+++ b/app/scripts/modules/netflix/pipeline/stage/acaTask/acaTaskStage.html
@@ -1,0 +1,176 @@
+<div class="form-horizontal canary-config-view">
+  <h4>Canary Config</h4>
+  <stage-config-field label="Name" field-columns="3">
+    <input type="text" required ng-model="stage.canary.canaryConfig.name"
+           class="form-control input-sm" />
+  </stage-config-field>
+  <stage-config-field label="Canary Lifetime" field-columns="3">
+    <input type="text" required ng-model="stage.canary.canaryConfig.lifetimeHours"
+           class="form-control input-sm" style="display: inline-block; width: 33%" />
+    <span class="form-control-static">hours</span>
+  </stage-config-field>
+
+  {{stage.canary.canaryConfig.combinedCanaryResultStrategy}}
+  <stage-config-field label="Result Strategy" help-key="pipeline.config.canary.resultStrategy" field-columns="3">
+    <select class="form-control input-sm"
+            ng-model="stage.canary.canaryConfig.combinedCanaryResultStrategy">
+      <option value="LOWEST">lowest</option>
+      <option value="AGGREGATE">average</option>
+    </select>
+  </stage-config-field>
+
+  <div class="form-group">
+    <div class="col-md-2 col-md-offset-1 sm-label-right">
+      <label>Successful Score</label>
+      <help-field key="pipeline.config.canary.successfulScore"></help-field>
+    </div>
+    <div class="col-md-1">
+      <input type="text" required ng-model="stage.canary.canaryConfig.canarySuccessCriteria.canaryResultScore"
+             class="form-control input-sm" />
+    </div>
+    <div class="col-md-2 col-md-offset-1 sm-label-right">
+      <label>Unhealthy Score</label>
+      <help-field key="pipeline.config.canary.unhealthyScore"></help-field>
+    </div>
+    <div class="col-md-1">
+      <input type="text" required ng-model="stage.canary.canaryConfig.canaryHealthCheckHandler.minimumCanaryResultScore"
+             class="form-control input-sm" />
+    </div>
+  </div>
+
+
+  <h5>Analysis Config</h5>
+
+  <div class="horizontal-rule"></div>
+  <stage-config-field label="Name" help-key="pipeline.config.canary.canaryConfigurationName" field-columns="3">
+    <canary-analysis-name-selector
+        model="stage.canary.canaryConfig.canaryAnalysisConfig.name"
+        class-name="form-control input-sm">
+    </canary-analysis-name-selector>
+  </stage-config-field>
+  <stage-config-field label="Delay">
+    <input type="text" required ng-model="stage.canary.canaryConfig.canaryAnalysisConfig.beginCanaryAnalysisAfterMins"
+           class="form-control input-sm" style="display: inline-block; width: 20%"/>
+    <span class="form-control-static">
+      minutes before starting analysis <help-field key="pipeline.config.canary.delayBeforeAnalysis"></help-field>
+    </span>
+  </stage-config-field>
+  <stage-config-field label="Notification Hours" help-key="pipeline.config.canary.notificationHours" field-columns="3">
+    <input type="text" ng-model="acaTaskStageCtrl.notificationHours"
+           class="form-control input-sm" ng-change="acaTaskStageCtrl.splitNotificationHours()" />
+  </stage-config-field>
+  <stage-config-field label="Frequency" help-key="pipeline.config.canary.canaryInterval" field-columns="3">
+    <input type="text" required ng-model="stage.canary.canaryConfig.canaryAnalysisConfig.canaryAnalysisIntervalMins"
+           class="form-control input-sm" style="width: 33%; display: inline-block"/>
+    <span class="form-control-static"> minutes</span>
+  </stage-config-field>
+
+  <div class="checkbox col-md-offset-1">
+    <label>
+      <input type="checkbox" ng-model="stage.canary.canaryConfig.canaryAnalysisConfig.useLookback"/>
+      <b>Use Look-back</b>
+      <help-field key="pipeline.config.canary.lookback"></help-field>
+    </label>
+  </div>
+  <div class="form-group" ng-if="stage.canary.canaryConfig.canaryAnalysisConfig.useLookback" style="margin-top: 10px;">
+    <div class="col-md-2 col-md-offset-1 sm-label-right">
+      <label>Look-back Duration</label>
+    </div>
+    <div class="col-md-2">
+      <input
+        type="number"
+        required
+        ng-model="stage.canary.canaryConfig.canaryAnalysisConfig.lookbackMins"
+        class="form-control input-sm" style="display: inline-block; width: 40%"/>
+      <span class="form-control-static"> minutes</span>
+    </div>
+    <div
+      class="error-message col-md-6"
+      ng-if="stage.canary.canaryConfig.canaryAnalysisConfig.lookbackMins > 0 && stage.canary.canaryConfig.canaryAnalysisConfig.lookbackMins < 30" >
+      <b>NOTE:</b> To provide enough data points for the Canary Analysis it is recommended to set the look-back time to at least 30 minutes.
+    </div>
+  </div>
+
+
+  <h5>Owner</h5>
+  <div class="horizontal-rule"></div>
+  <stage-config-field label="Email">
+    <input type="email" required ng-model="stage.canary.owner"
+           class="form-control input-sm" />
+  </stage-config-field>
+
+
+  <h5>Metric Scope<help-field key="pipeline.config.canary.baselineVersion"></help-field></h5>
+  <div class="horizontal-rule"></div>
+
+  <stage-config-field label="Account">
+    <account-select-field
+      component="canaryDeployment"
+      field="accountName"
+      accounts="accounts"
+      provider="'aws'"
+      required >
+    </account-select-field>
+  </stage-config-field>
+
+  <stage-config-field label="Region">
+    <label class="checkbox-inline" ng-repeat="region in regions">
+      <input
+        type="radio"
+        ng-value="region"
+        ng-model="canaryDeployment.region"
+      >
+      {{region}}
+    </label>
+  </stage-config-field>
+
+  <stage-config-field label="Scope Type">
+    <select
+      name="scopeType"
+      class="form-control input-sm"
+      ng-model="canaryDeployment.type">
+      <option value="query">Query</option>
+      <option value="cluster">Cluster</option>
+      <option value="asg">ASG</option>
+    </select>
+  </stage-config-field>
+
+  <stage-config-field label="Baseline">
+    <textarea
+      class="form-control input-sm"
+      ng-if="canaryDeployment.type === 'query'"
+      ng-model="canaryDeployment.baseline">
+    </textarea>
+
+    <input
+      class="form-control input-sm"
+      ng-if="canaryDeployment.type !== 'query'"
+      ng-model="canaryDeployment.baseline"
+      required
+      type="text" >
+
+  </stage-config-field>
+
+
+
+  <stage-config-field label="Canary">
+    <textarea
+      class="form-control input-sm"
+      ng-if="canaryDeployment.type === 'query'"
+      ng-model="canaryDeployment.canary">
+    </textarea>
+
+    <input
+      class="form-control input-sm"
+      ng-if="canaryDeployment.type !== 'query'"
+      ng-model="canaryDeployment.canary"
+      required
+      type="text" >
+
+
+  </stage-config-field>
+
+  {{stage.canary}}<br><br>
+  {{canaryDeployment}}
+  {{application.name}}
+</div>

--- a/app/scripts/modules/netflix/pipeline/stage/acaTask/acaTaskStage.js
+++ b/app/scripts/modules/netflix/pipeline/stage/acaTask/acaTaskStage.js
@@ -1,0 +1,113 @@
+'use strict';
+
+let angular = require('angular');
+
+module.exports = angular.module('spinnaker.netflix.pipeline.stage.genericCanaryStage', [
+  require('../../../../core/application/listExtractor/listExtractor.service'),
+  require('../../../../core/serverGroup/configure/common/serverGroupCommandBuilder.js'),
+  require('../../../../core/cloudProvider/cloudProvider.registry.js'),
+  require('../../../../core/config/settings.js'),
+  require('../../../../core/account/account.service.js'),
+])
+  .config(function (pipelineConfigProvider, settings) {
+    if (settings.feature && settings.feature.netflixMode) {
+      pipelineConfigProvider.registerStage({
+        label: 'ACA Task',
+        description: 'Canary T that run against an existing cluster, asg, or query',
+        key: 'acaTask',
+        templateUrl: require('./acaTaskStage.html'),
+        executionDetailsUrl: require('./acaTaskExecutionDetails.html'),
+        executionSummaryUrl: require('./acaTaskExecutionSummary.html'),
+        executionLabelTemplateUrl: require('../canary/canaryExecutionLabel.html'),
+        controller: 'AcaTaskStageCtrl',
+        controllerAs: 'acaTaskStageCtrl',
+        validators: [
+          {
+            type: 'stageBeforeType',
+            stageTypes: ['bake', 'findAmi', 'findImage'],
+            message: 'You must have a Bake or Find AMI stage before a canary stage.'
+          },
+        ],
+      });
+    }
+  })
+  .controller('AcaTaskStageCtrl', function ($scope, $uibModal, stage, _,
+                                           namingService, providerSelectionService,
+                                           authenticationService, cloudProviderRegistry,
+                                           serverGroupCommandBuilder, awsServerGroupTransformer, accountService, appListExtractorService) {
+
+    var user = authenticationService.getAuthenticatedUser();
+    $scope.stage = stage;
+    $scope.stage.baseline = $scope.stage.baseline || {};
+    $scope.stage.canary = $scope.stage.canary || {};
+    $scope.stage.canary.application = $scope.stage.canary.application || $scope.application.name;
+    $scope.stage.canary.owner = $scope.stage.canary.owner || (user.authenticated ? user.name : null);
+    $scope.stage.canary.watchers = $scope.stage.canary.watchers || [];
+    $scope.stage.canary.canaryConfig = $scope.stage.canary.canaryConfig || { name: [$scope.pipeline.name, 'Canary'].join(' - ') };
+    $scope.stage.canary.canaryConfig.canaryHealthCheckHandler = Object.assign($scope.stage.canary.canaryConfig.canaryHealthCheckHandler || {}, {'@class':'com.netflix.spinnaker.mine.CanaryResultHealthCheckHandler'});
+    $scope.stage.canary.canaryConfig.canaryAnalysisConfig = $scope.stage.canary.canaryConfig.canaryAnalysisConfig || {};
+    $scope.stage.canary.canaryConfig.canaryAnalysisConfig.notificationHours = $scope.stage.canary.canaryConfig.canaryAnalysisConfig.notificationHours || [];
+    $scope.stage.canary.canaryConfig.canaryAnalysisConfig.useLookback = $scope.stage.canary.canaryConfig.canaryAnalysisConfig.useLookback || false;
+    $scope.stage.canary.canaryConfig.canaryAnalysisConfig.lookbackMins = $scope.stage.canary.canaryConfig.canaryAnalysisConfig.lookbackMins || 0;
+
+    $scope.stage.canary.canaryDeployments = $scope.stage.canary.canaryDeployments || [{type: 'query', '@class':'.CanaryTaskDeployment'}];
+
+    $scope.canaryDeployment = $scope.stage.canary.canaryDeployments[0];
+
+    accountService.getUniqueAttributeForAllAccounts('regions')('aws')
+      .then( (regions) => {
+        $scope.regions = regions.sort();
+      });
+
+
+    accountService.listAccounts('aws').then(function(accounts) {
+      $scope.accounts = accounts;
+      setClusterList();
+    });
+
+
+    this.notificationHours = $scope.stage.canary.canaryConfig.canaryAnalysisConfig.notificationHours.join(',');
+
+    this.splitNotificationHours = () => {
+      var hoursField = this.notificationHours || '';
+      $scope.stage.canary.canaryConfig.canaryAnalysisConfig.notificationHours = _.map(hoursField.split(','), function(str) {
+        if (!parseInt(str.trim()).isNaN) {
+          return parseInt(str.trim());
+        }
+        return 0;
+      });
+    };
+
+    this.getRegion = function(cluster) {
+      var availabilityZones = cluster.availabilityZones;
+      if (availabilityZones) {
+        var regions = Object.keys(availabilityZones);
+        if (regions && regions.length) {
+          return regions[0];
+        }
+      }
+      return 'n/a';
+    };
+
+    let clusterFilter = (cluster) => {
+      return $scope.stage.baseline.account ? cluster.account === $scope.stage.baseline.account : true;
+    };
+
+    let setClusterList = () => {
+      $scope.clusterList = appListExtractorService.getClusters([$scope.application], clusterFilter);
+    };
+
+    $scope.resetSelectedCluster = () => {
+      $scope.stage.baseline.cluster = undefined;
+      setClusterList();
+    };
+
+
+
+    function getClusterName(cluster) {
+      return namingService.getClusterName(cluster.application, cluster.stack, cluster.freeFormDetails);
+    }
+
+    this.getClusterName = getClusterName;
+
+  });

--- a/app/scripts/modules/netflix/pipeline/stage/acaTask/acaTaskStage.module.js
+++ b/app/scripts/modules/netflix/pipeline/stage/acaTask/acaTaskStage.module.js
@@ -1,0 +1,18 @@
+'use strict';
+
+let angular = require('angular');
+
+module.exports = angular.module('spinnaker.netflix.pipeline.stage.genericCanary', [
+  require('./acaTaskStage'),
+  require('../../../../core/utils/lodash.js'),
+  require('../../../../core/serverGroup/serverGroup.read.service.js'),
+  require('./acaTaskStage.transformer'),
+  require('../canary/canaryScore.directive.js'),
+  require('../canary/canaryStatus.directive.js'),
+  require('../../../../core/account/account.service.js'),
+  require('../../../../core/naming/naming.service.js'),
+  require('./acaTaskMonitor/acaTaskMonitor.module')
+])
+  .run(function(pipelineConfig, acaTaskTransformer) {
+    pipelineConfig.registerTransformer(acaTaskTransformer);
+  });

--- a/app/scripts/modules/netflix/pipeline/stage/acaTask/acaTaskStage.transformer.js
+++ b/app/scripts/modules/netflix/pipeline/stage/acaTask/acaTaskStage.transformer.js
@@ -1,0 +1,80 @@
+'use strict';
+
+let angular = require('angular');
+
+module.exports = angular.module('spinnaker.netflix.pipeline.stage.acaTask.transformer', [
+  require('../../../../core/utils/lodash.js'),
+  require('../../../../core/orchestratedItem/orchestratedItem.transformer.js'),
+])
+  .service('acaTaskTransformer', function($log, _, orchestratedItemTransformer) {
+
+    function getException (stage) {
+      orchestratedItemTransformer.defineProperties(stage);
+      return stage && stage.isFailed ? stage.failureMessage : null;
+    }
+
+
+    this.transform = function(application, execution) {
+      execution.stages.forEach(function(stage) {
+        if (stage.type === 'acaTask') {
+          orchestratedItemTransformer.defineProperties(stage);
+          stage.exceptions = [];
+
+          var monitorStage = _.find(execution.stages, {
+            type: 'monitorAcaTask',
+            context: {
+              canaryStageId: stage.id,
+            }
+          });
+
+
+          if (getException(monitorStage)) {
+            stage.exceptions.push('Monitor Canary failure: ' + getException(monitorStage));
+          }
+
+          stage.exceptions = _.uniq(stage.exceptions);
+
+          stage.context.canary = (monitorStage && monitorStage.context.canary) || stage.context.canary;
+
+          var status = monitorStage && monitorStage.status === 'CANCELED' ? 'CANCELED' : 'UNKNOWN';
+
+          var canaryStatus = stage.context.canary.status;
+          if (canaryStatus && status !== 'CANCELED') {
+            if (canaryStatus.status === 'LAUNCHED' || monitorStage.status === 'RUNNING') {
+              status = 'RUNNING';
+            }
+            if (canaryStatus.complete) {
+              status = 'SUCCEEDED';
+            }
+            if (canaryStatus.status === 'DISABLED') {
+              status = 'DISABLED';
+            }
+            if (canaryStatus.status === 'FAILED') {
+              status = 'FAILED';
+            }
+            if (canaryStatus.status === 'TERMINATED') {
+              status = 'TERMINATED';
+            }
+            canaryStatus.status = status;
+          } else {
+            stage.context.canary.status = { status: status };
+          }
+          stage.status = status;
+
+          var tasks = [];
+
+          if(monitorStage) {
+            tasks.push({
+              id: monitorStage.id,
+              name: monitorStage.name,
+              startTime: monitorStage.startTime,
+              endTime: monitorStage.endTime,
+              status: monitorStage.status,
+            });
+          }
+
+          stage.tasks = tasks;
+        }
+      });
+    };
+  });


### PR DESCRIPTION
Allows a pipeline run an ACA task that does not require a newly deployed baseline or canary cluster.
An ACA Task can be run with a scope type of either query, cluster, and asg.

@anotherchrisberry PTAL

NOTE: Please don't merge until all the downstream bits are in place (ORCA, MINE)