### PR TITLE
core: Surface job objects among clusters

### DIFF
--- a/app/scripts/modules/core/cluster/cluster.service.js
+++ b/app/scripts/modules/core/cluster/cluster.service.js
@@ -9,19 +9,38 @@ module.exports = angular.module('spinnaker.core.cluster.service', [
   require('exports?"restangular"!imports?_=lodash!restangular'),
   require('../utils/lodash.js'),
   require('../serverGroup/serverGroup.transformer.js'),
+  require('../job/job.transformer.js'),
 ])
-  .factory('clusterService', function ($q, Restangular, _, serverGroupTransformer, namingService) {
+  .factory('clusterService', function ($q, Restangular, _, serverGroupTransformer,
+                                       jobTransformer, namingService) {
 
     function loadServerGroups(applicationName) {
-      var serverGroupLoader = Restangular.one('applications', applicationName).all('serverGroups').getList();
+      var serverGroupLoader = $q.all({
+        serverGroups: Restangular.one('applications', applicationName).all('serverGroups').getList(),
+        jobs: Restangular.one('applications', applicationName).all('jobs').getList(),
+      });
       return serverGroupLoader.then(function(results) {
-        results.forEach(addHealthStatusCheck);
-        results.forEach(addStackToServerGroup);
-        return $q.all(results.map(serverGroupTransformer.normalizeServerGroup));
+        results.serverGroups = results.serverGroups || [];
+        results.jobs = results.jobs || [];
+
+        results.serverGroups.forEach(addHealthStatusCheck);
+        results.serverGroups.forEach(parseName);
+        results.serverGroups.forEach((serverGroup) =>
+            serverGroup.category = 'serverGroup'
+          );
+
+        results.jobs.forEach(addHealthStatusCheck);
+        results.jobs.forEach(parseName);
+        results.jobs.forEach((job) =>
+            job.category = 'job'
+          );
+
+        return $q.all(results.serverGroups.map(serverGroupTransformer.normalizeServerGroup)
+            .concat(results.jobs.map(jobTransformer.normalizeJob)));
       });
     }
 
-    function addStackToServerGroup(serverGroup) {
+    function parseName(serverGroup) {
       var nameParts = namingService.parseServerGroupName(serverGroup.name);
       serverGroup.stack = nameParts.stack;
       serverGroup.detail = nameParts.freeFormDetails;
@@ -51,6 +70,9 @@ module.exports = angular.module('spinnaker.core.cluster.service', [
         return;
       }
       cluster.serverGroups.forEach(function(serverGroup) {
+        if (!serverGroup.instanceCounts) {
+          return;
+        }
         cluster.instanceCounts.total += serverGroup.instanceCounts.total || 0;
         cluster.instanceCounts.up += serverGroup.instanceCounts.up || 0;
         cluster.instanceCounts.down += serverGroup.instanceCounts.down || 0;
@@ -161,7 +183,6 @@ module.exports = angular.module('spinnaker.core.cluster.service', [
       });
     }
 
-
     function findStagesWithServerGroupInfo(stages) {
       var stagesWithServerGroups = _.filter(stages, function (stage) {
          return ( _.includes(['deploy', 'destroyAsg', 'resizeAsg'], stage.type) && _.has(stage.context, 'deploy.server.groups') ) ||
@@ -215,7 +236,7 @@ module.exports = angular.module('spinnaker.core.cluster.service', [
     function addProvidersAndServerGroupsToInstances(serverGroups) {
       serverGroups.forEach(function(serverGroup) {
         serverGroup.instances.forEach(function(instance) {
-          instance.provider = serverGroup.type;
+          instance.provider = serverGroup.type || serverGroup.provider;
           instance.serverGroup = instance.serverGroup || serverGroup.name;
           instance.vpcId = serverGroup.vpcId;
         });
@@ -226,11 +247,14 @@ module.exports = angular.module('spinnaker.core.cluster.service', [
       var clusters = [];
       var groupedByAccount = _.groupBy(serverGroups, 'account');
       _.forOwn(groupedByAccount, function(accountServerGroups, account) {
-        var groupedByCluster = _.groupBy(accountServerGroups, 'cluster');
-        _.forOwn(groupedByCluster, function(clusterServerGroups, clusterName) {
-          var cluster = {account: account, name: clusterName, serverGroups: clusterServerGroups};
-          addHealthCountsToCluster(cluster);
-          clusters.push(cluster);
+        var groupedByCategory = _.groupBy(accountServerGroups, 'category');
+        _.forOwn(groupedByCategory, function(categoryServerGroups, category) {
+          var groupedByCluster = _.groupBy(categoryServerGroups, 'cluster');
+          _.forOwn(groupedByCluster, function(clusterServerGroups, clusterName) {
+            var cluster = {account: account, category: category, name: clusterName, serverGroups: clusterServerGroups};
+            addHealthCountsToCluster(cluster);
+            clusters.push(cluster);
+          });
         });
       });
       addProvidersAndServerGroupsToInstances(serverGroups);
@@ -267,7 +291,10 @@ module.exports = angular.module('spinnaker.core.cluster.service', [
         let toRemove = [];
         application.serverGroups.data.forEach((serverGroup, idx) => {
           let matches = serverGroups.filter((test) =>
-            test.name === serverGroup.name && test.account === serverGroup.account && test.region === serverGroup.region
+            test.name === serverGroup.name &&
+            test.account === serverGroup.account &&
+            test.region === serverGroup.region &&
+            test.category === serverGroup.category
           );
           if (!matches.length) {
             toRemove.push(idx);
@@ -283,7 +310,10 @@ module.exports = angular.module('spinnaker.core.cluster.service', [
         // add any new ones
         serverGroups.forEach((serverGroup) => {
           if (!application.serverGroups.data.filter((test) =>
-              test.name === serverGroup.name && test.account === serverGroup.account && test.region === serverGroup.region
+              test.name === serverGroup.name &&
+              test.account === serverGroup.account &&
+              test.region === serverGroup.region &&
+              test.category === serverGroup.category
             ).length) {
             application.serverGroups.data.push(serverGroup);
           }

--- a/app/scripts/modules/core/cluster/clusterPod.html
+++ b/app/scripts/modules/core/cluster/clusterPod.html
@@ -5,10 +5,12 @@
         <div class="col-md-12">
           <div class="rollup-title-cell">
             <h5>
-              <account-label-color account="{{parentHeading}}"></account-label-color>
-              <span class="glyphicon glyphicon-th"></span>
-              {{grouping.heading}}
-              <health-counts container="grouping.cluster.instanceCounts"></health-counts>
+              <div class="{{grouping.cluster.category}}">
+                <account-label-color account="{{parentHeading}}"></account-label-color>
+                <span class="glyphicon glyphicon-th"></span>
+                {{grouping.heading}}
+                <health-counts container="grouping.cluster.instanceCounts"></health-counts>
+              </div>
             </h5>
           </div>
         </div>

--- a/app/scripts/modules/core/cluster/filter/clusterFilter.model.js
+++ b/app/scripts/modules/core/cluster/filter/clusterFilter.model.js
@@ -19,6 +19,7 @@ module.exports = angular
       { model: 'account', param: 'acct', type: 'object', },
       { model: 'region', param: 'reg', type: 'object', },
       { model: 'stack', param: 'stack', type: 'object', },
+      { model: 'category', param: 'category', type: 'object', },
       { model: 'status', type: 'object', filterTranslator: {Up: 'Healthy', Down: 'Unhealthy', OutOfService: 'Out of Service'}},
       { model: 'availabilityZone', param: 'zone', type: 'object', filterLabel: 'availability zone' },
       { model: 'instanceType', type: 'object', filterLabel: 'instance type'},

--- a/app/scripts/modules/core/cluster/filter/clusterFilter.service.spec.js
+++ b/app/scripts/modules/core/cluster/filter/clusterFilter.service.spec.js
@@ -563,8 +563,10 @@ describe('Service: clusterFilterService', function () {
 
   describe('group diffing', function() {
     beforeEach(function() {
-      this.serverGroup001 = { cluster: 'cluster-a', name: 'cluster-a-v001', account: 'prod', region: 'us-east-1', stringVal: 'original' };
-      this.serverGroup000 = { cluster: 'cluster-a', name: 'cluster-a-v000', account: 'prod', region: 'us-east-1', stringVal: 'should be deleted' };
+      this.clusterA = { account: 'prod', category: 'serverGroup', name: 'cluster-a' };
+      this.clusterB = { account: 'prod', category: 'serverGroup', name: 'cluster-b' };
+      this.serverGroup001 = { cluster: 'cluster-a', name: 'cluster-a-v001', account: 'prod', region: 'us-east-1', stringVal: 'original', category: 'serverGroup' };
+      this.serverGroup000 = { cluster: 'cluster-a', name: 'cluster-a-v000', account: 'prod', region: 'us-east-1', stringVal: 'should be deleted', category: 'serverGroup' };
       ClusterFilterModel.groups = [
         {
           heading: 'prod',
@@ -575,6 +577,7 @@ describe('Service: clusterFilterService', function () {
               subgroups: [
                 {
                   heading: 'us-east-1',
+                  category: 'serverGroup',
                   serverGroups: [
                     this.serverGroup000,
                     this.serverGroup001,
@@ -592,8 +595,12 @@ describe('Service: clusterFilterService', function () {
         serverGroups: { data: [
           this.serverGroup000,
           this.serverGroup001,
-          { cluster: 'cluster-a', name: 'cluster-a-v003', account: 'test', region: 'us-east-1', stringVal: 'new' },
-        ]}
+          { cluster: 'cluster-a', name: 'cluster-a-v003', account: 'test', region: 'us-east-1', stringVal: 'new', category: 'serverGroup' },
+        ]},
+        clusters: [
+          this.clusterA,
+          { name: 'cluster-a', account: 'test', category: 'serverGroup' },
+        ]
       };
       service.updateClusterGroups(application);
       $timeout.flush();
@@ -612,8 +619,12 @@ describe('Service: clusterFilterService', function () {
         serverGroups: { data: [
           this.serverGroup000,
           this.serverGroup001,
-          { cluster: 'cluster-b', name: 'cluster-a-v003', account: 'prod', region: 'us-east-1', stringVal: 'new' },
+          { cluster: 'cluster-b', name: 'cluster-a-v003', account: 'prod', region: 'us-east-1', stringVal: 'new', category: 'serverGroup' },
         ]}
+        clusters: [
+          this.clusterA,
+          this.clusterB,
+        ]
       };
       service.updateClusterGroups(application);
       $timeout.flush();
@@ -631,7 +642,7 @@ describe('Service: clusterFilterService', function () {
         serverGroups: { data: [
           this.serverGroup000,
           this.serverGroup001,
-          { cluster: 'cluster-a', name: 'cluster-a-v003', account: 'prod', region: 'us-west-1', stringVal: 'new' },
+          { cluster: 'cluster-a', name: 'cluster-a-v003', account: 'prod', region: 'us-west-1', stringVal: 'new', category: 'serverGroup' },
         ]}
       };
       service.updateClusterGroups(application);
@@ -649,7 +660,7 @@ describe('Service: clusterFilterService', function () {
         serverGroups: { data: [
           this.serverGroup000,
           this.serverGroup001,
-          { cluster: 'cluster-a', name: 'cluster-a-v003', account: 'prod', region: 'us-east-1', stringVal: 'new' },
+          { cluster: 'cluster-a', name: 'cluster-a-v003', account: 'prod', region: 'us-east-1', stringVal: 'new', category: 'serverGroup' },
         ]}
       };
       service.updateClusterGroups(application);
@@ -666,7 +677,7 @@ describe('Service: clusterFilterService', function () {
         serverGroups: { data: [
           this.serverGroup000,
           this.serverGroup001,
-          { cluster: 'cluster-a', name: 'cluster-a-v003', account: 'test', region: 'us-east-1', stringVal: 'new' },
+          { cluster: 'cluster-a', name: 'cluster-a-v003', account: 'test', region: 'us-east-1', stringVal: 'new', category: 'serverGroup' },
         ]}
       };
       service.updateClusterGroups(application);
@@ -685,7 +696,7 @@ describe('Service: clusterFilterService', function () {
         serverGroups: { data: [
           this.serverGroup000,
           this.serverGroup001,
-          { cluster: 'cluster-b', name: 'cluster-a-v003', account: 'prod', region: 'us-east-1', stringVal: 'new' },
+          { cluster: 'cluster-b', name: 'cluster-a-v003', account: 'prod', region: 'us-east-1', stringVal: 'new', category: 'serverGroup' },
         ]}
       };
       service.updateClusterGroups(application);
@@ -706,7 +717,7 @@ describe('Service: clusterFilterService', function () {
         serverGroups: { data: [
           this.serverGroup000,
           this.serverGroup001,
-          { cluster: 'cluster-a', name: 'cluster-a-v003', account: 'prod', region: 'us-west-1', stringVal: 'new' },
+          { cluster: 'cluster-a', name: 'cluster-a-v003', account: 'prod', region: 'us-west-1', stringVal: 'new', category: 'serverGroup' },
         ]}
       };
       service.updateClusterGroups(application);
@@ -742,8 +753,8 @@ describe('Service: clusterFilterService', function () {
     it('leaves server groups alone when stringVal does not change', function() {
       var application = {
         serverGroups: { data: [
-          { cluster: 'cluster-a', name: 'cluster-a-v000', account: 'prod', region: 'us-east-1', stringVal: 'should be deleted' },
-          { cluster: 'cluster-a', name: 'cluster-a-v001', account: 'prod', region: 'us-east-1', stringVal: 'original' },
+          { cluster: 'cluster-a', name: 'cluster-a-v000', account: 'prod', region: 'us-east-1', stringVal: 'should be deleted', category: 'serverGroup' },
+          { cluster: 'cluster-a', name: 'cluster-a-v001', account: 'prod', region: 'us-east-1', stringVal: 'original', category: 'serverGroup' },
         ]}
       };
       service.updateClusterGroups(application);
@@ -755,8 +766,8 @@ describe('Service: clusterFilterService', function () {
     it('replaces server group when stringVal changes', function() {
       var application = {
         serverGroups: { data: [
-          { cluster: 'cluster-a', name: 'cluster-a-v000', account: 'prod', region: 'us-east-1', stringVal: 'mutated' },
-          { cluster: 'cluster-a', name: 'cluster-a-v001', account: 'prod', region: 'us-east-1', stringVal: 'original' },
+          { cluster: 'cluster-a', name: 'cluster-a-v000', account: 'prod', region: 'us-east-1', stringVal: 'mutated', category: 'serverGroup' },
+          { cluster: 'cluster-a', name: 'cluster-a-v001', account: 'prod', region: 'us-east-1', stringVal: 'original', category: 'serverGroup' },
         ]}
       };
       service.updateClusterGroups(application);
@@ -772,7 +783,7 @@ describe('Service: clusterFilterService', function () {
       var application = {
         serverGroups: { data: [
           { cluster: 'cluster-a', name: 'cluster-a-v001', account: 'prod', region: 'us-east-1', stringVal: 'original',
-            runningTasks: runningTasks, executions: executions,
+            runningTasks: runningTasks, executions: executions, category: 'serverGroup',
           },
         ]}
       };

--- a/app/scripts/modules/core/cluster/filter/filterNav.html
+++ b/app/scripts/modules/core/cluster/filter/filterNav.html
@@ -33,6 +33,14 @@
     </div>
   </filter-section>
 
+  <filter-section heading="Category" expanded="true">
+    <div class="checkbox" ng-repeat="category in clustersFilters.categoryHeadings | orderBy: 'toString()' ">
+      <label>
+        <input type="checkbox" ng-model="sortFilter.category[heading]" ng-change="clustersFilters.updateClusterGroups()"/>{{heading}}
+      </label>
+    </div>
+  </filter-section>
+
   <filter-section heading="Stack" expanded="true">
     <div class="checkbox" ng-repeat="heading in clustersFilters.stackHeadings | orderBy: 'toString()' ">
       <label>

--- a/app/scripts/modules/core/cluster/rollups.less
+++ b/app/scripts/modules/core/cluster/rollups.less
@@ -186,6 +186,9 @@ server-group {
     margin: 0;
     font-size: 110%;
     font-weight: 300;
+    .job {
+      background: repeating-linear-gradient(45deg, @dark_blue_background, @dark_blue_background 5px, @dark_grey 5px, @dark_grey 10px);
+    }
   }
   .account-tag {
     .small {

--- a/app/scripts/modules/core/core.module.js
+++ b/app/scripts/modules/core/core.module.js
@@ -118,6 +118,7 @@ module.exports = angular
     require('./search/search.module.js'),
     require('./securityGroup/securityGroup.module.js'),
     require('./serverGroup/serverGroup.module.js'),
+    require('./job/job.module.js'),
 
     require('./task/task.module.js'),
 

--- a/app/scripts/modules/core/job/job.module.js
+++ b/app/scripts/modules/core/job/job.module.js
@@ -1,0 +1,8 @@
+'use strict';
+
+let angular = require('angular');
+
+module.exports = angular
+  .module('spinnaker.core.job', [
+    require('./job.transformer.js'),
+  ]);

--- a/app/scripts/modules/core/job/job.transformer.js
+++ b/app/scripts/modules/core/job/job.transformer.js
@@ -1,0 +1,43 @@
+'use strict';
+
+let angular = require('angular');
+
+module.exports = angular.module('spinnaker.core.job.transformer', [
+  require('../cloudProvider/serviceDelegate.service.js'),
+])
+  .factory('jobTransformer', function (serviceDelegate) {
+
+    function normalizeJob(job) {
+      job.region = job.region || job.location;
+      job.type = job.type || job.provider;
+      return serviceDelegate.getDelegate(job.provider || job.type, 'job.transformer').
+        normalizeJob(job);
+    }
+
+    function convertJobCommandToDeployConfiguration(base) {
+      var service = serviceDelegate.getDelegate(base.selectedProvider, 'job.transformer');
+      return service ? service.convertJobCommandToDeployConfiguration(base) : null;
+    }
+
+    // strips out Angular bits (see angular.js#toJsonReplacer), as well as executions and running tasks
+    function jsonReplacer(key, value) {
+      var val = value;
+
+      if (typeof key === 'string' && key.charAt(0) === '$' && key.charAt(1) === '$') {
+        val = undefined;
+      }
+
+      if (key === 'executions' || key === 'runningTasks') {
+        val = undefined;
+      }
+
+      return val;
+    }
+
+    return {
+      normalizeJob: normalizeJob,
+      convertJobCommandToDeployConfiguration: convertJobCommandToDeployConfiguration,
+      jsonReplacer: jsonReplacer,
+    };
+
+  });

--- a/app/scripts/modules/kubernetes/job/job.module.js
+++ b/app/scripts/modules/kubernetes/job/job.module.js
@@ -1,0 +1,7 @@
+'use strict';
+
+let angular = require('angular');
+
+module.exports = angular.module('spinnaker.job.kubernetes', [
+  require('./transformer.js'),
+]);

--- a/app/scripts/modules/kubernetes/job/transformer.js
+++ b/app/scripts/modules/kubernetes/job/transformer.js
@@ -1,0 +1,16 @@
+'use strict';
+
+let angular = require('angular');
+
+module.exports = angular
+  .module('spinnaker.kubernetes.job.transformer', [ ])
+  .factory('kubernetesJobTransformer', function ($q) {
+
+    function normalizeJob(job) {
+      return $q.when(job); // no-op
+    }
+
+    return {
+      normalizeJob: normalizeJob,
+    };
+  });

--- a/app/scripts/modules/kubernetes/kubernetes.module.js
+++ b/app/scripts/modules/kubernetes/kubernetes.module.js
@@ -20,6 +20,7 @@ module.exports = angular.module('spinnaker.kubernetes', [
   require('./container/configurer.directive.js'),
   require('./container/probe.directive.js'),
   require('./instance/details/details.kubernetes.module.js'),
+  require('./job/job.module.js'),
   require('./loadBalancer/configure/configure.kubernetes.module.js'),
   require('./loadBalancer/details/details.kubernetes.module.js'),
   require('./loadBalancer/transformer.js'),
@@ -79,6 +80,9 @@ module.exports = angular.module('spinnaker.kubernetes', [
         cloneServerGroupTemplateUrl: require('./serverGroup/configure/wizard/wizard.html'),
         commandBuilder: 'kubernetesServerGroupCommandBuilder',
         configurationService: 'kubernetesServerGroupConfigurationService',
+      },
+      job: {
+        transformer: 'kubernetesJobTransformer',
       },
     });
   });

--- a/test/mock/mockApplicationData.js
+++ b/test/mock/mockApplicationData.js
@@ -4,16 +4,16 @@ module.exports = angular
   .module('cluster.test.data', [])
   .value('applicationJSON', {
       clusters: [
-        { name: 'in-eu-east-2-only', account: 'prod', region: 'eu-east-2'},
-        { name: 'in-us-west-1-only', account: 'test', region: 'us-west-1'},
+        { name: 'in-eu-east-2-only', account: 'prod', region: 'eu-east-2', category: 'serverGroup' },
+        { name: 'in-us-west-1-only', account: 'test', region: 'us-west-1', category: 'serverGroup' },
       ],
       serverGroups: { data: [
         {cluster: 'in-eu-east-2-only', 'account': 'prod', region: 'eu-east-2', instances: [], name: 'in-eu-east-2-only',
           instanceCounts: {total: 0, up: 0, down: 0, unknown: 0, starting: 0, outOfService: 0 },
-          isDisabled: true, type:'gce', instanceType: 'm3.medium', vpcName: ''},
+          isDisabled: true, type:'gce', instanceType: 'm3.medium', vpcName: '', category: 'serverGroup' },
         {cluster: 'in-us-west-1-only', 'account': 'test', region: 'us-west-1', instances: [ {} ], name: 'in-us-west-1-only',
           instanceCounts: {total: 1, up: 0, down: 1, unknown: 0, starting: 0, outOfService: 0},
-          isDisabled: false, type: 'aws', instanceType: 'm3.large', vpcName: 'Main'},
+          isDisabled: false, type: 'aws', instanceType: 'm3.large', vpcName: 'Main', category: 'serverGroup' },
       ]}
     }
   )
@@ -26,8 +26,10 @@ module.exports = angular
         hasLoadBalancers: false,
         subgroups : [ {
           heading : 'eu-east-2',
+          category: 'serverGroup',
           serverGroups : [ {
             cluster: 'in-eu-east-2-only',
+            category: 'serverGroup',
             account : 'prod',
             region : 'eu-east-2',
             instances : [ ],
@@ -43,7 +45,7 @@ module.exports = angular
             isDisabled: true,
             type: 'gce',
             instanceType: 'm3.medium',
-            vpcName: ''
+            vpcName: '',
           } ]
         } ]
       } ] },
@@ -55,8 +57,10 @@ module.exports = angular
           hasLoadBalancers: false,
           subgroups : [ {
             heading : 'us-west-1',
+            category: 'serverGroup',
             serverGroups : [ {
               cluster: 'in-us-west-1-only',
+              category: 'serverGroup',
               account : 'test',
               region : 'us-west-1',
               instances : [ {} ],


### PR DESCRIPTION
This is the first of a few PRs to surface jobs among clusters. It looks like this:

![job-show](https://cloud.githubusercontent.com/assets/4874941/14770462/2683da76-0a40-11e6-92c4-fe357a04c185.png)

(The job has the diagonal lines). 

I still need to report health states correctly (for both the Job and the instances it's made of), as well as allow the user to use filters to select only Jobs or Server groups.

@duftler @anotherchrisberry PTAL