### PR TITLE
(netflix) allow users to select subnets when migrating to VPC

### DIFF
--- a/app/scripts/modules/netflix/migrator/migrator.less
+++ b/app/scripts/modules/netflix/migrator/migrator.less
@@ -1,6 +1,14 @@
 @import "../../core/presentation/less/imports/commonImports.less";
 
 .migrator-modal {
+  .migration-options {
+    padding: 10px 15px;
+    border-top: 1px solid @light_grey;
+
+    h4 {
+      margin-bottom: 0;
+    }
+  }
   .preview {
     h4 {
       margin: 20px 0 8px 0;

--- a/app/scripts/modules/netflix/migrator/pipeline/pipeline.migrator.directive.js
+++ b/app/scripts/modules/netflix/migrator/pipeline/pipeline.migrator.directive.js
@@ -160,7 +160,8 @@ module.exports = angular
         target = { vpcName: 'vpc0', };
 
     this.migrationOptions = {
-      allowIngressFromClassic: true
+      allowIngressFromClassic: true,
+      subnetType: 'internal',
     };
 
     var migrationConfig = {
@@ -187,6 +188,7 @@ module.exports = angular
       this.viewState.executing = true;
       migrationConfig.dryRun = false;
       migrationConfig.allowIngressFromClassic = this.migrationOptions.allowIngressFromClassic;
+      migrationConfig.target.subnetType = this.migrationOptions.subnetType;
       let executor = migratorService.executeMigration(migrationConfig);
       executor.then(migrationStarted, errorMode);
     };

--- a/app/scripts/modules/netflix/migrator/pipeline/pipeline.migrator.modal.html
+++ b/app/scripts/modules/netflix/migrator/pipeline/pipeline.migrator.modal.html
@@ -17,11 +17,6 @@
       </div>
 
       <div class="row preview" ng-if="vm.preview && !vm.viewState.computing && !vm.viewState.executing && !vm.viewState.error">
-        <div class="form-group">
-          <div class="col-md-6 col-md-offset-1 checkbox">
-            <label><input type="checkbox" ng-model="vm.migrationOptions.allowIngressFromClassic"/> Allow Access From EC2 Classic </label>
-          </div>
-        </div>
         <div class="col-md-10 col-md-offset-1">
           <div ng-if="!vm.viewState.migrationComplete">
             <p>This will create new pipeline named
@@ -78,6 +73,30 @@
       <div class="col-md-10 col-md-offset-1">
         <h4>We could not calculate an execution plan for {{vm.component.name}} at this time.</h4>
         <p>Reason: {{vm.viewState.error}}</p>
+      </div>
+    </div>
+
+    <div ng-if="!vm.viewState.migrationComplete" class="migration-options">
+      <div class="row">
+        <div class="col-md-10 col-md-offset-1">
+          <h4>Migration Options</h4>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-md-10 col-md-offset-1 checkbox">
+          <label><input type="checkbox" ng-model="vm.migrationOptions.allowIngressFromClassic"/> Allow Access From EC2 Classic </label>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-md-10 col-md-offset-1">
+          Place the new ASG in the
+          <select class="form-control input-sm"
+                  style="display: inline; width: auto"
+                  ng-model="vm.migrationOptions.subnetType"
+                  ng-options="type for type in ['internal', 'external']"></select>
+          subnet
+        </div>
       </div>
     </div>
 

--- a/app/scripts/modules/netflix/migrator/serverGroup/serverGroup.migrator.directive.js
+++ b/app/scripts/modules/netflix/migrator/serverGroup/serverGroup.migrator.directive.js
@@ -97,7 +97,8 @@ module.exports = angular
     };
 
     this.migrationOptions = {
-      allowIngressFromClassic: true
+      allowIngressFromClassic: true,
+      subnetType: 'internal',
     };
 
     this.source = {
@@ -134,6 +135,7 @@ module.exports = angular
       this.viewState.executing = true;
       migrationConfig.dryRun = false;
       migrationConfig.allowIngressFromClassic = this.migrationOptions.allowIngressFromClassic;
+      migrationConfig.target.subnetType = this.migrationOptions.subnetType;
       let executor = migratorService.executeMigration(migrationConfig);
       executor.then(migrationStarted, errorMode);
     };

--- a/app/scripts/modules/netflix/migrator/serverGroup/serverGroup.migrator.modal.html
+++ b/app/scripts/modules/netflix/migrator/serverGroup/serverGroup.migrator.modal.html
@@ -17,11 +17,6 @@
       </div>
 
       <div class="row preview" ng-if="vm.preview && !vm.viewState.computing && !vm.viewState.executing && !vm.viewState.error">
-        <div class="form-group">
-          <div class="col-md-6 col-md-offset-1 checkbox">
-            <label><input type="checkbox" ng-model="vm.migrationOptions.allowIngressFromClassic"/> Allow Access From EC2 Classic </label>
-          </div>
-        </div>
         <div class="col-md-10 col-md-offset-1">
           <div ng-if="!vm.viewState.migrationComplete">
             <p>This will migrate
@@ -67,6 +62,30 @@
         <h4 ng-if="!vm.preview">We could not calculate an execution plan for {{vm.component.name}} at this time.</h4>
         <h4 ng-if="vm.preview">We could not perform the migration of {{vm.component.name}} at this time.</h4>
         <p><strong>Reason:</strong> {{vm.viewState.error}}</p>
+      </div>
+    </div>
+
+    <div ng-if="!vm.viewState.migrationComplete" class="migration-options">
+      <div class="row">
+        <div class="col-md-10 col-md-offset-1">
+          <h4>Migration Options</h4>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-md-10 col-md-offset-1 checkbox">
+          <label><input type="checkbox" ng-model="vm.migrationOptions.allowIngressFromClassic"/> Allow Access From EC2 Classic </label>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-md-10 col-md-offset-1">
+          Place the new ASG in the
+          <select class="form-control input-sm"
+                  style="display: inline; width: auto"
+                  ng-model="vm.migrationOptions.subnetType"
+                  ng-options="type for type in ['internal', 'external']"></select>
+          subnet
+        </div>
       </div>
     </div>
 


### PR DESCRIPTION
Give the people their subnet type selection (but in a hard-coded, super opinionated, only going to work at Netflix or if your two subnets are "internal" and "external" way).