### PR TITLE
remove -webkit prefix for flexbox

### DIFF
--- a/app/scripts/modules/core/application/application.less
+++ b/app/scripts/modules/core/application/application.less
@@ -5,7 +5,6 @@
   margin-bottom: 0;
   background-color: #f8f8f8;
   flex: 0 0 auto;
-  -webkit-flex: 0 0 auto;
   .application-name {
     display: inline-block;
   }

--- a/app/scripts/modules/core/delivery/executions/executions.less
+++ b/app/scripts/modules/core/delivery/executions/executions.less
@@ -2,9 +2,7 @@
 
 executions {
   display: flex;
-  display: -webkit-flex;
   flex: 1 1 auto;
-  -webkit-flex: 1 1 auto;
   .execution-groups-header {
     margin-left: -8px;
     position: relative;

--- a/app/scripts/modules/core/navigation/navigation.less
+++ b/app/scripts/modules/core/navigation/navigation.less
@@ -25,7 +25,6 @@
 .secondary-panel {
   > div {
     flex: 1 1 auto;
-    -webkit-flex: 1 1 auto;
     overflow-y: auto;
     overflow-x: hidden;
     padding-top: 20px;

--- a/app/scripts/modules/core/pipeline/pipelines.less
+++ b/app/scripts/modules/core/pipeline/pipelines.less
@@ -3,20 +3,16 @@
 .pipelines {
   overflow-x: hidden;
   display: flex;
-  display: -webkit-flex;
   flex-direction: column;
-  -webkit-flex-direction: column;
   width: 100%;
 
   > .header {
     flex: none;
-    -webkit-flex: none;
   }
 
   > .execution-groups {
     padding: 0 0 0 10px;
     flex: 1 0 100px;
-    -webkit-flex: 1 0 100px;
     overflow-y: auto;
   }
 

--- a/app/scripts/modules/core/presentation/details.less
+++ b/app/scripts/modules/core/presentation/details.less
@@ -40,9 +40,7 @@
 
 .details-panel {
   display: flex;
-  display: -webkit-flex;
   flex-direction: column;
-  -webkit-flex-direction: column;
   border: 1px solid #aaaaaa;
   border-bottom-width: 0;
   background-color: #ffffff;
@@ -69,13 +67,11 @@
 
   .content {
     flex: 1 0 100px;
-    -webkit-flex: 1 0 100px;
     overflow-y: auto;
   }
 
   .header {
     flex: none;
-    -webkit-flex: none;
     padding: 20px 15px 0 15px;
     margin-bottom: 10px;
     .header-text {

--- a/app/scripts/modules/core/presentation/main.less
+++ b/app/scripts/modules/core/presentation/main.less
@@ -104,18 +104,14 @@ html {
     overflow-x: hidden;
 
     display: flex;
-    display: -webkit-flex;
     flex-direction: column;
-    -webkit-flex-direction: column;
 
     > .header {
       flex: 0 0 auto;
-      -webkit-flex: 0 0 auto;
     }
 
     > .content {
       flex: 1 1 100px;
-      -webkit-flex: 1 1 100px;
       overflow-y: auto;
     }
   }
@@ -1071,28 +1067,21 @@ body, html {
 
 .spinnaker-container {
   display: flex;
-  display: -webkit-flex;
   flex-direction: column;
-  -webkit-flex-direction: column;
   width: 100%;
   height: 100%;
   .spinnaker-header {
     flex: 0 0 auto;
-    -webkit-flex: 0 0 auto;
     border-radius: 0;
     margin-bottom: 0;
   }
   .spinnaker-content {
     display: flex;
-    display: -webkit-flex;
     flex: 1 1 auto;
-    -webkit-flex: 1 1 auto;
     overflow-y: auto;
     > .container {
       display: flex;
-      display: -webkit-flex;
       flex-direction: column;
-      -webkit-flex-direction: column;
       padding: 0;
       @media (min-width: 768px) and (max-width: 992px) {
         margin: 0;
@@ -1101,24 +1090,17 @@ body, html {
     }
     .scrollable-columns {
       flex: 1 1 auto;
-      -webkit-flex: 1 1 auto;
       display: flex;
-      display: -webkit-flex;
       >div {
         display: flex;
-        display: -webkit-flex;
         flex: 1 1 auto;
-        -webkit-flex: 1 1 auto;
       }
       .insight {
         display: flex;
-        display: -webkit-flex;
         flex: 0 0 auto;
-        -webkit-flex: 0 0 auto;
         padding: 20px 30px 0;
         >div {
           display: flex;
-          display: -webkit-flex;
         }
       }
     }

--- a/app/scripts/modules/core/projects/project.less
+++ b/app/scripts/modules/core/projects/project.less
@@ -21,7 +21,6 @@
   margin-bottom: 0;
   padding-bottom: 0;
   flex: 0 0 auto;
-  -webkit-flex: 0 0 auto;
 
   .nav-popover-menu {
     z-index: 25;
@@ -58,7 +57,5 @@
 .flex-fill {
   display: flex;
   flex: 1 1 auto;
-  -webkit-flex: 1 1 auto;
   flex-direction: column;
-  -webkit-flex-direction: column;
 }

--- a/app/scripts/modules/core/task/tasks.less
+++ b/app/scripts/modules/core/task/tasks.less
@@ -2,16 +2,13 @@
 
 .tasks-wrapper {
   display: flex;
-  display: -webkit-flex;
 }
 
 .tasks {
   overflow-y: auto;
   overflow-x: hidden;
   display: flex;
-  display: -webkit-flex;
   flex-direction: column;
-  -webkit-flex-direction: column;
 
   @media (min-width: 768px) and (max-width: 992px) {
     width: 768px;
@@ -33,7 +30,6 @@
       font-weight: 600;
     }
     flex: 0 0 auto;
-    -webkit-flex: 0 0 auto;
     z-index: 4;
     box-shadow: 0 20px 10px -10px @lightest_grey;
     padding-bottom: 0;
@@ -51,7 +47,6 @@
   > .tasks-content {
     padding: 10px 15px;
     flex: 1 1 auto;
-    -webkit-flex: 1 1 auto;
     overflow-y: auto;
   }
 

--- a/app/scripts/modules/netflix/fastProperties/fastProperties.less
+++ b/app/scripts/modules/netflix/fastProperties/fastProperties.less
@@ -2,16 +2,13 @@
 
 .fastProperty-wrapper {
   display: flex;
-  display: -webkit-flex;
 }
 
 .fastProperty {
   overflow-y: auto;
   overflow-x: hidden;
   display: flex;
-  display: -webkit-flex;
   flex-direction: column;
-  -webkit-flex-direction: column;
 
   @media (min-width: 768px) and (max-width: 992px) {
     width: 768px;
@@ -32,7 +29,6 @@
 
 .fastProperty .fp-header {
   flex: 0 0 auto;
-  -webkit-flex: 0 0 auto;
   z-index: 4;
   box-shadow: 0 20px 10px -10px @lightest_grey;
   padding-bottom: 0;
@@ -46,7 +42,6 @@
 .fastProperty .content {
   padding: 10px 15px;
   flex: 1 1 auto;
-  -webkit-flex: 1 1 auto;
   overflow-y: auto;
 
 }


### PR DESCRIPTION
Chrome has supported unprefixed flexbox properties since at least v47 (v50 is current); Safari 9 also does not need the prefix.

@zanthrash PTAL