### PR TITLE
guard against missing property when filtering groups

### DIFF
--- a/app/scripts/modules/core/cluster/filter/clusterFilter.service.js
+++ b/app/scripts/modules/core/cluster/filter/clusterFilter.service.js
@@ -296,7 +296,8 @@ module.exports = angular
       var groupsToRemove = [];
 
       oldGroups.forEach(function(oldGroup, idx) {
-        var newGroup = _.find(newGroups, { heading: oldGroup.heading, category: oldGroup.category });
+        var [newGroup] = (newGroups || []).filter(group => group.heading === oldGroup.heading &&
+          group.category === oldGroup.category);
         if (!newGroup) {
           groupsToRemove.push(idx);
         } else {


### PR DESCRIPTION
Turns out lodash's `_.find` method will omit items without a supplied property, even if the matcher on that property is `undefined` - which means we are currently recreating every node in the clusters view every time the data refreshes or the user clicks on a deep link within the view, since it thinks every cluster group is new.