### PR TITLE
(aws) only apply vpcId to new security groups when classic lock enabled

### DIFF
--- a/app/scripts/modules/amazon/securityGroup/configure/configSecurityGroup.mixin.controller.js
+++ b/app/scripts/modules/amazon/securityGroup/configure/configSecurityGroup.mixin.controller.js
@@ -143,7 +143,7 @@ module.exports = angular
         $scope.vpcs = available;
 
         let lockoutDate = _.get(settings, 'providers.aws.classicLaunchLockout');
-        if (lockoutDate) {
+        if (!securityGroup.id && lockoutDate) {
           let createTs = Number(_.get(application, 'attributes.createTs', 0));
           if (createTs >= lockoutDate) {
             $scope.hideClassic = true;


### PR DESCRIPTION
Otherwise, a EC2 Classic security group in a newer application gets a vpcId, which is never correct when editing a security group.