### PR TITLE
use flexbox to center container

### DIFF
--- a/app/scripts/modules/core/presentation/main.less
+++ b/app/scripts/modules/core/presentation/main.less
@@ -1077,12 +1077,14 @@ body, html {
   }
   .spinnaker-content {
     display: flex;
+    justify-content: center;
     flex: 1 1 auto;
     overflow-y: auto;
     > .container {
       display: flex;
       flex-direction: column;
       padding: 0;
+      margin: 0;
       @media (min-width: 768px) and (max-width: 992px) {
         margin: 0;
         width: 100%;


### PR DESCRIPTION
Starting with Chrome 50, we're seeing this really annoying behavior where the entire screen shifts to the left sometimes, removing any margin present. This fixes that.