### PR TITLE
(core) lazy load tasks, executions

### DIFF
--- a/app/scripts/modules/core/application/applicationNav.html
+++ b/app/scripts/modules/core/application/applicationNav.html
@@ -5,8 +5,8 @@
        ng-class="{active: $state.includes('**.executions.**') || $state.includes('**.pipelineConfig')}">
       Pipelines
       <span class="badge"
-            ng-if="( application.executions.data | filter:{isActive:true}).length > 0">
-        {{ (application.executions.data | filter:{isActive:true}).length }}
+            ng-if="application.runningExecutions.data.length">
+        {{ (application.runningExecutions.data.length }}
       </span>
     </a>
     <a ng-if="application.executions.loadFailure">
@@ -39,8 +39,8 @@
        ng-class="{active: $state.includes('**.tasks.**')}">
       Tasks
       <span class="badge"
-            ng-if="( application.tasks.data | filter:{isActive:true}).length > 0">
-        {{ (application.tasks.data | filter:{isActive:true}).length }}
+            ng-if="application.runningTasks.data.length">
+        {{ (application.runningTasks.data.length }}
       </span>
     </a>
     <a ng-if="application.tasks.loadFailure">

--- a/app/scripts/modules/core/application/service/applications.read.service.js
+++ b/app/scripts/modules/core/application/service/applications.read.service.js
@@ -123,11 +123,13 @@ module.exports = angular
         key: 'tasks',
         loader: loadTasks,
         onLoad: addTasks,
+        lazy: true,
       },
       {
         key: 'executions',
         loader: loadExecutions,
         onLoad: addExecutions,
+        lazy: true,
       },
       {
         key: 'loadBalancers',
@@ -138,6 +140,7 @@ module.exports = angular
         key: 'pipelineConfigs',
         loader: loadPipelineConfigs,
         onLoad: addPipelineConfigs,
+        lazy: true,
       },
       {
         key: 'securityGroups',
@@ -196,7 +199,25 @@ module.exports = angular
         return deferred.promise;
       };
 
+      section.activate = () => {
+        if (!section.active) {
+          section.active = true;
+          if (!section.loaded) {
+            section.refresh();
+          }
+        }
+      };
+
+      section.deactivate = () => {
+        section.active = false;
+      };
+
       section.refresh = (forceRefresh) => {
+        if (sectionConfig.lazy && !section.active) {
+          section.data.length = 0;
+          section.loaded = false;
+          return $q.when(null);
+        }
         if (section.loading && !forceRefresh) {
           $log.warn(`${key} still loading, skipping refresh`);
           return $q.when(null);

--- a/app/scripts/modules/core/delivery/executions/executions.controller.js
+++ b/app/scripts/modules/core/delivery/executions/executions.controller.js
@@ -30,7 +30,11 @@ module.exports = angular.module('spinnaker.core.delivery.executions.controller',
     }
 
     application.activeState = application.executions;
-    $scope.$on('$destroy', () => application.activeState = application);
+    $scope.$on('$destroy', () => {
+      application.activeState = application;
+      application.executions.deactivate();
+      application.pipelineConfigs.deactivate();
+    });
 
     this.InsightFilterStateModel = InsightFilterStateModel;
 
@@ -59,6 +63,9 @@ module.exports = angular.module('spinnaker.core.delivery.executions.controller',
       loading: true,
       triggeringExecution: false,
     };
+
+    application.executions.activate();
+    application.pipelineConfigs.activate();
 
     $q.all([application.executions.ready(), application.pipelineConfigs.ready()]).then(() => {
       this.updateExecutionGroups();

--- a/app/scripts/modules/core/delivery/executions/executions.controller.spec.js
+++ b/app/scripts/modules/core/delivery/executions/executions.controller.spec.js
@@ -2,8 +2,6 @@
 
 describe('Controller: pipelineExecutions', function () {
 
-  const angular = require('angular');
-
   var controller;
   var scope;
   var $state;
@@ -30,6 +28,8 @@ describe('Controller: pipelineExecutions', function () {
         scope.application = application;
         applicationReader.addSectionToApplication({key: 'executions', lazy: true}, application);
         applicationReader.addSectionToApplication({key: 'pipelineConfigs', lazy: true}, application);
+        application.executions.activate = angular.noop;
+        application.pipelineConfigs.activate = angular.noop;
         if (data && data.executions) {
           application.executions.data = data.executions;
           application.executions.loaded = true;

--- a/app/scripts/modules/core/pipeline/config/actions/delete/deletePipelineModal.controller.spec.js
+++ b/app/scripts/modules/core/pipeline/config/actions/delete/deletePipelineModal.controller.spec.js
@@ -46,6 +46,7 @@ describe('Controller: deletePipelineModal', function() {
         loader: () => this.$q.when(null),
         onLoad: () => this.$q.when(null),
       }, this.application);
+      this.application.pipelineConfigs.activate();
       this.application.pipelineConfigs.data = [this.pipelines[0], this.pipelines[1], this.pipelines[2]];
       this.initializeController(this.application, this.pipelines[1]);
 

--- a/app/scripts/modules/core/pipeline/config/actions/rename/renamePipelineModal.controller.spec.js
+++ b/app/scripts/modules/core/pipeline/config/actions/rename/renamePipelineModal.controller.spec.js
@@ -43,6 +43,7 @@ describe('Controller: renamePipelineModal', function() {
       loader: () => this.$q.when(null),
       onLoad: () => this.$q.when(null),
     }, this.application);
+    this.application.pipelineConfigs.activate();
     this.application.pipelineConfigs.data = [this.pipelines[0], this.pipelines[1], this.pipelines[2]];
     this.initializeController(this.application, this.pipelines[1]);
 

--- a/app/scripts/modules/core/task/tasks.controller.js
+++ b/app/scripts/modules/core/task/tasks.controller.js
@@ -260,8 +260,12 @@ module.exports = angular.module('spinnaker.core.task.controller', [
       }
     });
 
+    application.tasks.activate();
     application.activeState = application.tasks;
-    $scope.$on('$destroy', () => application.activeState = application);
+    $scope.$on('$destroy', () => {
+      application.activeState = application;
+      application.tasks.deactivate();
+    });
 
     this.application.tasks.onRefresh($scope, this.sortTasks);
   }

--- a/app/scripts/modules/core/task/tasks.controller.spec.js
+++ b/app/scripts/modules/core/task/tasks.controller.spec.js
@@ -1,8 +1,6 @@
 'use strict';
 
 describe('Controller: tasks', function () {
-  const angular = require('angular');
-
   var controller;
   var taskWriter;
   var scope;
@@ -23,6 +21,7 @@ describe('Controller: tasks', function () {
       this.initializeController = (tasks) => {
         let application = {};
         applicationReader.addSectionToApplication({key: 'tasks', lazy: true}, application);
+        application.tasks.activate = angular.noop;
         application.tasks.data = tasks || [];
         application.tasks.loaded = true;
         application.tasks.refreshStream.onNext();

--- a/app/scripts/modules/netflix/application/applicationNav.html
+++ b/app/scripts/modules/netflix/application/applicationNav.html
@@ -5,8 +5,8 @@
        ng-class="{active: $state.includes('**.executions.**') || $state.includes('**.pipelineConfig')}">
       Pipelines
       <span class="badge"
-            ng-if="( application.executions.data | filter:{isActive:true}).length > 0">
-        {{ (application.executions.data | filter:{isActive:true}).length }}
+            ng-if="application.runningExecutions.data.length">
+        {{application.runningExecutions.data.length}}
       </span>
     </a>
     <a ng-if="application.executions.loadFailure">
@@ -46,8 +46,8 @@
        ng-class="{active: $state.includes('**.tasks.**')}">
       Tasks
       <span class="badge"
-            ng-if="( application.tasks.data | filter:{isActive:true}).length > 0">
-        {{ (application.tasks.data | filter:{isActive:true}).length }}
+            ng-if="application.runningTasks.data.length">
+        {{application.runningTasks.data.length}}
       </span>
     </a>
     <a ng-if="application.tasks.loadFailure">

--- a/app/scripts/modules/titan/serverGroup/serverGroup.transformer.js
+++ b/app/scripts/modules/titan/serverGroup/serverGroup.transformer.js
@@ -27,7 +27,7 @@ module.exports = angular
         var securityGroups = '' + command.securityGroups;
         command.securityGroups = securityGroups.split(/\s*,\s*/);
       }
-      if (command.resources.allocateIpAddress === true ) {
+      if (command.resources.allocateIpAddress === true) {
         delete command.resources.ports;
       }
       delete command.viewState;


### PR DESCRIPTION
When an application has a lot of pipelines and a lot of executions of those pipelines, it gets expensive to eagerly load them when the user is not actively looking at the pipelines view.

This change shifts the initialization of those views to their respective controllers (pipelines, tasks). When the user exits those views, the data will be cleared on the next application refresh.

Running against larger applications at Netflix, I am seeing a pretty big drop in memory consumption from the browser. This should also help take some of the load off Orca, since we're not constantly bombing it with data requests.

The downside: when a user navigates to the pipelines or tasks view the first time, the data needs to be fetched before it can be rendered. We'll have to watch this and see if users complain or notice. My hope is that, by reducing the overall load, responses from Orca will be fast enough to offset the delay.