### PR TITLE
provider/kubernetes: Create job details dialog

### DIFF
--- a/app/scripts/modules/core/cluster/cluster.service.js
+++ b/app/scripts/modules/core/cluster/cluster.service.js
@@ -66,10 +66,8 @@ module.exports = angular.module('spinnaker.core.cluster.service', [
         outOfService: 0,
         total: 0,
       };
-      if (!cluster.serverGroups) {
-        return;
-      }
-      cluster.serverGroups.forEach(function(serverGroup) {
+      var operand = cluster.serverGroups || cluster.jobs || [];
+      operand.forEach(function(serverGroup) {
         if (!serverGroup.instanceCounts) {
           return;
         }

--- a/app/scripts/modules/core/cluster/clusterPod.html
+++ b/app/scripts/modules/core/cluster/clusterPod.html
@@ -23,12 +23,22 @@
           sticky-header added-offset-height="39">{{subgroup.heading}}</h6>
       <server-group
         ng-repeat="serverGroup in subgroup.serverGroups | orderBy:'-name'"
+        ng-if="grouping.cluster.category === 'serverGroup'"
         server-group="serverGroup"
         cluster="serverGroup.cluster"
         application="application"
         has-discovery="grouping.hasDiscovery"
         has-load-balancers="grouping.hasLoadBalancers"
         parent-heading="subgroup.heading"></server-group>
+      <job
+        ng-repeat="serverGroup in subgroup.serverGroups | orderBy:'-name'"
+        ng-if="grouping.cluster.category === 'job'"
+        job="serverGroup"
+        cluster="serverGroup.cluster"
+        application="application"
+        has-discovery="grouping.hasDiscovery"
+        has-load-balancers="grouping.hasLoadBalancers"
+        parent-heading="subgroup.heading"></job>
     </div>
     <div class="permalinks text-right">
       <a ng-href="{{permalink}}" target="_blank">Permalink</a>

--- a/app/scripts/modules/core/cluster/filter/clusterFilter.service.js
+++ b/app/scripts/modules/core/cluster/filter/clusterFilter.service.js
@@ -266,6 +266,7 @@ module.exports = angular
             if (cluster) {
               clusterGroups.push( {
                 heading: clusterKey,
+                category: categoryKey,
                 subgroups: _.sortBy(regionGroups, 'heading'),
                 cluster: cluster
               } );
@@ -276,7 +277,7 @@ module.exports = angular
 
         groups.push( {
           heading: accountKey,
-          subgroups: _.sortBy(clusterGroups, 'heading')
+          subgroups: _.sortBy(clusterGroups, ['heading', 'category']),
         } );
       });
 
@@ -295,10 +296,10 @@ module.exports = angular
 
     function diffSubgroups(oldGroups, newGroups) {
       var groupsToRemove = [];
-
       oldGroups.forEach(function(oldGroup, idx) {
-        var [newGroup] = (newGroups || []).filter(group => group.heading === oldGroup.heading &&
-          group.category === oldGroup.category);
+        var [newGroup] = (newGroups || []).filter(group =>
+            group.heading === oldGroup.heading &&
+            group.category === oldGroup.category);
         if (!newGroup) {
           groupsToRemove.push(idx);
         } else {

--- a/app/scripts/modules/core/cluster/filter/clusterFilter.service.spec.js
+++ b/app/scripts/modules/core/cluster/filter/clusterFilter.service.spec.js
@@ -576,6 +576,7 @@ describe('Service: clusterFilterService', function () {
           subgroups: [
             {
               heading: 'cluster-a',
+              category: 'serverGroup',
               cluster: { name: 'cluster-a' },
               subgroups: [
                 {

--- a/app/scripts/modules/core/cluster/filter/multiselect.model.js
+++ b/app/scripts/modules/core/cluster/filter/multiselect.model.js
@@ -110,7 +110,7 @@ module.exports = angular
     };
 
     this.makeServerGroupKey = (serverGroup) =>
-      [serverGroup.type, serverGroup.account, serverGroup.region, serverGroup.name].join(':');
+      [serverGroup.type, serverGroup.account, serverGroup.region, serverGroup.name, serverGroup.category].join(':');
 
     this.serverGroupIsSelected = (serverGroup) => {
       if (!this.serverGroups.length) {
@@ -122,11 +122,17 @@ module.exports = angular
 
     this.toggleServerGroup = (serverGroup) => {
       if (!ClusterFilterModel.sortFilter.multiselect) {
-        let params = {provider: serverGroup.type, accountId: serverGroup.account, region: serverGroup.region, serverGroup: serverGroup.name};
+        let params = {
+          provider: serverGroup.type,
+          accountId: serverGroup.account,
+          region: serverGroup.region,
+          serverGroup: serverGroup.name,
+          job: serverGroup.name,
+        };
         if ($state.includes('**.clusters.*')) {
-          $state.go('^.serverGroup', params);
+          $state.go('^.' + serverGroup.category, params);
         } else {
-          $state.go('.serverGroup', params);
+          $state.go('.' + serverGroup.category, params);
         }
         return;
       }

--- a/app/scripts/modules/core/cluster/filter/multiselect.model.spec.js
+++ b/app/scripts/modules/core/cluster/filter/multiselect.model.spec.js
@@ -74,7 +74,7 @@ describe('Multiselect Model', function () {
 
       describe('server group selection', function () {
         beforeEach(function() {
-          this.serverGroup = {name: 'a', account: 'prod', region: 'us-east-1', type: 'aws'};
+          this.serverGroup = {name: 'a', account: 'prod', region: 'us-east-1', type: 'aws', category: 'serverGroup'};
         });
 
         it('navigates to multipleServerGroups child view when not already there and group is selected', function () {
@@ -109,7 +109,8 @@ describe('Multiselect Model', function () {
           name: 'asg-v001',
           account: 'prod',
           region: 'us-east-1',
-          type: 'aws'
+          type: 'aws',
+          category: 'serverGroup'
         };
       });
 

--- a/app/scripts/modules/core/filterModel/filter.model.service.js
+++ b/app/scripts/modules/core/filterModel/filter.model.service.js
@@ -72,6 +72,17 @@ module.exports = angular
       };
     }
 
+    function checkCategoryFilters(model) {
+      return function(target) {
+        if (isFilterable(model.sortFilter.category)) {
+          var checkedCategories = getCheckValues(model.sortFilter.category);
+          return _.contains(checkedCategories, target.type) || _.contains(checkedCategories, target.category);
+        } else {
+          return true;
+        }
+      };
+    }
+
     function checkProviderFilters(model) {
       return function(target) {
         if (isFilterable(model.sortFilter.providerType)) {
@@ -298,7 +309,8 @@ module.exports = angular
       checkRegionFilters: checkRegionFilters,
       checkStackFilters: checkStackFilters,
       checkStatusFilters: checkStatusFilters,
-      checkProviderFilters: checkProviderFilters
+      checkProviderFilters: checkProviderFilters,
+      checkCategoryFilters: checkCategoryFilters,
     };
 
   });

--- a/app/scripts/modules/core/job/job.directive.html
+++ b/app/scripts/modules/core/job/job.directive.html
@@ -1,0 +1,44 @@
+<div class="rollup-pod-server-group clickable clickable-row"
+     waypoint="{{viewModel.waypoint}}"
+     ng-click="loadDetails($event)"
+     ng-class="{
+        disabled: viewModel.job.isDisabled,
+        active: $state.includes('**.job', {region: viewModel.job.region, accountId: viewModel.job.account, job: viewModel.job.name, provider: viewModel.job.type})
+     }">
+  <div class="cluster-container">
+    <div class="server-group-title" sticky-header added-offset-height="69"
+         sticky-if="headerIsSticky()">
+      <div class="container-fluid no-padding">
+        <div class="row">
+          <div class="col-md-8 col-sm-6 section-title">
+            <input type="checkbox" ng-if="sortFilter.multiselect"
+                   ng-checked="multiselectModel.jobIsSelected(job)"/>
+            <cloud-provider-logo provider="viewModel.job.type" height="16px" width="16px"></cloud-provider-logo>
+            <span class="server-group-sequence">{{ viewModel.jobSequence }}</span><span ng-if="viewModel.jenkins">:</span>
+          </div>
+          <div class="col-md-4 col-sm-6 text-right">
+            <health-counts container="viewModel.job.instanceCounts"></health-counts>
+            <running-tasks-tag
+                ng-if="viewModel.job.runningTasks.length || viewModel.job.executions.length"
+                application="application" tasks="viewModel.job.runningTasks" executions="viewModel.job.executions"></running-tasks-tag>
+            <load-balancers-tag
+                ng-if="viewModel.job.loadBalancers.length"
+                server-group="viewModel.job" max-display="1"></load-balancers-tag>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="instance-list" ng-if="sortFilter.showAllInstances">
+      <div ng-if="!sortFilter.listInstances">
+        <instances highlight="sortFilter.filter" instances="viewModel.instances"></instances>
+      </div>
+      <div ng-if="sortFilter.listInstances">
+        <instance-list instances="viewModel.instances"
+                       sort-filter="sortFilter"
+                       has-discovery="hasDiscovery"
+                       server-group="viewModel.job"
+                       has-load-balancers="hasLoadBalancers"></instance-list>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/scripts/modules/core/job/job.directive.js
+++ b/app/scripts/modules/core/job/job.directive.js
@@ -1,0 +1,84 @@
+'use strict';
+
+let angular = require('angular');
+
+module.exports = angular.module('spinnaker.core.job.job.directive', [
+  require('../cluster/filter/clusterFilter.service'),
+  require('../cluster/filter/clusterFilter.model'),
+  require('../cluster/filter/multiselect.model'),
+  require('../instance/instances.directive'),
+  require('../instance/instanceList.directive'),
+  require('./job.transformer'),
+])
+  .directive('job', function ($rootScope, $timeout, $filter, _, clusterFilterService,
+                              MultiselectModel, ClusterFilterModel, jobTransformer) {
+    return {
+      restrict: 'E',
+      templateUrl: require('./job.directive.html'),
+      scope: {
+        cluster: '=',
+        job: '=',
+        application: '=',
+        parentHeading: '=',
+        hasLoadBalancers: '=',
+        hasDiscovery: '=',
+      },
+      link: function (scope) {
+
+        let lastStringVal = null;
+        scope.sortFilter = ClusterFilterModel.sortFilter;
+        scope.multiselectModel = MultiselectModel;
+
+        scope.$state = $rootScope.$state;
+
+        function setViewModel() {
+          var filteredInstances = scope.job.instances.filter(clusterFilterService.shouldShowInstance);
+
+          var job = scope.job;
+
+          let viewModel = {
+            waypoint: [job.account, job.region, job.name].join(':'),
+            job: job,
+            jobSequence: $filter('serverGroupSequence')(job.name),
+            jenkins: null,
+            hasBuildInfo: !!job.buildInfo,
+            instances: filteredInstances,
+          };
+
+          let modelStringVal = JSON.stringify(viewModel, jobTransformer.jsonReplacer);
+
+          if (lastStringVal !== modelStringVal) {
+            scope.viewModel = viewModel;
+            lastStringVal = modelStringVal;
+          }
+
+          viewModel.job.runningTasks = job.runningTasks;
+          viewModel.job.executions = job.executions;
+        }
+
+        scope.loadDetails = function(event) {
+          $timeout(() => {
+            if (event.isDefaultPrevented() || (event.originalEvent && (event.originalEvent.defaultPrevented || event.originalEvent.target.href))) {
+              return;
+            }
+            MultiselectModel.toggleServerGroup(scope.job);
+            event.preventDefault();
+          });
+        };
+
+        setViewModel();
+
+        scope.headerIsSticky = function() {
+          if (!scope.sortFilter.showAllInstances) {
+            return false;
+          }
+          if (scope.sortFilter.listInstances) {
+            return scope.viewModel.instances.length > 1;
+          }
+          return scope.viewModel.instances.length > 20;
+        };
+
+        scope.$watch('sortFilter', setViewModel, true);
+      }
+    };
+});

--- a/app/scripts/modules/core/job/job.module.js
+++ b/app/scripts/modules/core/job/job.module.js
@@ -5,4 +5,5 @@ let angular = require('angular');
 module.exports = angular
   .module('spinnaker.core.job', [
     require('./job.transformer.js'),
+    require('./job.directive.js'),
   ]);

--- a/app/scripts/modules/core/job/job.read.service.js
+++ b/app/scripts/modules/core/job/job.read.service.js
@@ -1,0 +1,18 @@
+'use strict';
+
+let angular = require('angular');
+
+module.exports = angular
+  .module('spinnaker.core.job.read.service', [
+    require('exports?"restangular"!imports?_=lodash!restangular'),
+  ])
+  .factory('jobReader', function (Restangular) {
+
+    function getJob(application, account, region, jobName) {
+      return Restangular.one('applications', application).all('jobs').all(account).all(region).one(jobName).get();
+    }
+
+    return {
+      getJob: getJob,
+    };
+  });

--- a/app/scripts/modules/core/navigation/states.provider.js
+++ b/app/scripts/modules/core/navigation/states.provider.js
@@ -145,6 +145,41 @@ module.exports = angular.module('spinnaker.core.navigation.states.provider', [
         }
       };
 
+      var jobDetails = {
+        name: 'job',
+        url: '/jobDetails/:provider/:accountId/:region/:job',
+        views: {
+          'detail@../insight': {
+            templateProvider: ['$templateCache', '$stateParams', 'cloudProviderRegistry', function($templateCache, $stateParams, cloudProviderRegistry) {
+              return $templateCache.get(cloudProviderRegistry.getValue($stateParams.provider, 'job.detailsTemplateUrl')); }],
+            controllerProvider: ['$stateParams', 'cloudProviderRegistry', function($stateParams, cloudProviderRegistry) {
+              return cloudProviderRegistry.getValue($stateParams.provider, 'job.detailsController');
+            }],
+            controllerAs: 'ctrl'
+          }
+        },
+        resolve: {
+          job: ['$stateParams', function($stateParams) {
+            return {
+              name: $stateParams.job,
+              accountId: $stateParams.accountId,
+              region: $stateParams.region
+            };
+          }]
+        },
+        data: {
+          pageTitleDetails: {
+            title: 'Job Details',
+            nameParam: 'job',
+            accountParam: 'accountId',
+            regionParam: 'region'
+          },
+          history: {
+            type: 'jobs',
+          },
+        }
+      };
+
       var loadBalancerDetails = {
         name: 'loadBalancerDetails',
         url: '/loadBalancerDetails/:provider/:accountId/:region/:vpcId/:name',
@@ -276,6 +311,7 @@ module.exports = angular.module('spinnaker.core.navigation.states.provider', [
           children: [
             loadBalancerDetails,
             serverGroupDetails,
+            jobDetails,
             instanceDetails,
             securityGroupDetails,
             multipleInstances,
@@ -305,6 +341,7 @@ module.exports = angular.module('spinnaker.core.navigation.states.provider', [
           children: [
             loadBalancerDetails,
             serverGroupDetails,
+            jobDetails,
             instanceDetails,
             securityGroupDetails,
           ],
@@ -332,6 +369,7 @@ module.exports = angular.module('spinnaker.core.navigation.states.provider', [
           children: [
             loadBalancerDetails,
             serverGroupDetails,
+            jobDetails,
             securityGroupDetails,
           ]
         }

--- a/app/scripts/modules/kubernetes/job/details/details.controller.js
+++ b/app/scripts/modules/kubernetes/job/details/details.controller.js
@@ -1,0 +1,89 @@
+'use strict';
+/* jshint camelcase:false */
+
+let angular = require('angular');
+
+module.exports = angular.module('spinnaker.job.details.kubernetes.controller', [
+  require('angular-ui-router'),
+  require('../../../core/job/job.read.service.js'),
+  require('../../../core/serverGroup/configure/common/runningExecutions.service.js'),
+  require('../../../core/utils/lodash.js'),
+  require('../../../core/insight/insightFilterState.model.js'),
+])
+  .controller('kubernetesJobDetailsController', function ($scope, $state, app, job, InsightFilterStateModel,
+                                                          jobReader, $uibModal,
+                                                          runningExecutionsService, _) {
+    let application = app;
+
+    $scope.state = {
+      loading: true
+    };
+
+    $scope.InsightFilterStateModel = InsightFilterStateModel;
+
+    function extractJobSummary() {
+      var summary = _.find(application.serverGroups.data, function (toCheck) {
+        return toCheck.name === job.name && toCheck.account === job.accountId && toCheck.region === job.region && toCheck.category == 'job';
+      });
+      if (!summary) {
+        application.loadBalancers.data.some(function (loadBalancer) {
+          if (loadBalancer.account === job.accountId && loadBalancer.region === job.region) {
+            return loadBalancer.jobs.some(function (possibleJob) {
+              if (possibleJob.name === job.name) {
+                summary = possibleJob;
+                return true;
+              }
+            });
+          }
+        });
+      }
+      return summary;
+    }
+
+    this.showYaml = function showYaml() {
+      $scope.userDataModalTitle = 'Job YAML';
+      $scope.userData = $scope.job.yaml;
+      $uibModal.open({
+        templateUrl: require('../../../core/serverGroup/details/userData.html'),
+        controller: 'CloseableModalCtrl',
+        scope: $scope
+      });
+    };
+
+    function retrieveJob() {
+      var summary = extractJobSummary();
+      return jobReader.getJob(application.name, job.accountId, job.region, job.name).then(function(details) {
+        cancelLoader();
+
+        var restangularlessDetails = details.plain();
+        angular.extend(restangularlessDetails, summary);
+
+        $scope.job = restangularlessDetails;
+        $scope.runningExecutions = function() {
+          return runningExecutionsService.filterRunningExecutions($scope.job.executions);
+        };
+      },
+        autoClose
+      );
+    }
+
+    function autoClose() {
+      if ($scope.$$destroyed) {
+        return;
+      }
+      $state.params.allowModalToStayOpen = true;
+      $state.go('^', null, {location: 'replace'});
+    }
+
+    function cancelLoader() {
+      $scope.state.loading = false;
+    }
+
+    retrieveJob().then(() => {
+      // If the user navigates away from the view before the initial retrieveJob call completes,
+      // do not bother subscribing to the refresh
+      if (!$scope.$$destroyed) {
+        app.jobs.onRefresh($scope, retrieveJob);
+      }
+    });
+  });

--- a/app/scripts/modules/kubernetes/job/details/details.html
+++ b/app/scripts/modules/kubernetes/job/details/details.html
@@ -1,0 +1,210 @@
+<div class="details-panel"
+     ng-class="{ disabled: job.isDisabled }">
+
+  <div class="header" ng-if="state.loading">
+      <div class="close-button">
+          <a class="btn btn-link"
+             ui-sref="^">
+              <span class="glyphicon glyphicon-remove"></span>
+          </a>
+      </div>
+      <h4 class="text-center">
+          <span us-spinner="{radius:20, width:6, length: 12}"></span>
+      </h4>
+  </div>
+
+
+  <div class="header" ng-if="!state.loading">
+    <div class="close-button">
+      <a class="btn btn-link"
+          ui-sref="^">
+        <span class="glyphicon glyphicon-remove"></span>
+      </a>
+    </div>
+    <div class="header-text">
+      <cloud-provider-logo provider="job.type" height="36px" width="36px" style="margin-right: 10px"></cloud-provider-logo>
+      <h3 select-on-dbl-click>
+        {{job.name}}
+      </h3>
+    </div>
+    <div>
+      <div class="actions" ng-class="{ insights: job.insightActions.length > 0 }">
+        <div class="dropdown" uib-dropdown dropdown-append-to-body>
+          <button type="button" class="btn btn-sm btn-primary dropdown-toggle" uib-dropdown-toggle>
+            Job Actions <span class="caret"></span>
+          </button>
+          <ul class="dropdown-menu" uib-dropdown-menu role="menu">
+          </ul>
+        </div>
+        <div class="dropdown" ng-if="job.insightActions.length > 0" uib-dropdown dropdown-append-to-body>
+          <button type="button" class="btn btn-sm btn-default dropdown-toggle" uib-dropdown-toggle>
+            Insight <span class="caret"></span>
+          </button>
+          <ul class="dropdown-menu" uib-dropdown-menu role="menu">
+            <li ng-repeat="action in job.insightActions"><a target=_blank href="{{action.url}}">{{action.label}}</a></li>
+          </ul>
+        </div>
+        <div class="clearfix"></div>
+      </div>
+    </div>
+  </div>
+  <div class="content" ng-if="!state.loading">
+    <h4 class="text-center" ng-if="job.isDisabled">[SERVER GROUP IS DISABLED]</h4>
+    <collapsible-section heading="Running Tasks" expanded="true" body-class="details-running-tasks" ng-if="job.runningTasks.length > 0 || runningExecutions().length > 0">
+      <div class="container-fluid no-padding" ng-repeat="task in job.runningTasks | orderBy:'-startTime'">
+        <div class="row">
+          <div class="col-md-12">
+            <strong>
+              {{task.name}}
+            </strong>
+          </div>
+        </div>
+        <div class="row" ng-repeat="step in task.steps | displayableTasks">
+          <div class="col-md-7 col-md-offset-0">
+            <span class="small"><status-glyph item="step"></status-glyph></span> {{step.name | robotToHuman }}
+          </div>
+          <div class="col-md-4 text-right">
+            {{step.runningTimeInMs | duration }}
+          </div>
+        </div>
+      </div>
+
+      <div class="container-fluid no-padding" ng-repeat="execution in runningExecutions()">
+        <div class="row">
+          <div class="col-md-12">
+            <strong>
+              Pipeline: {{execution.name}}
+            </strong>
+          </div>
+        </div>
+        <div class="row" ng-repeat="stage in execution.stages">
+          <div class="col-md-7 col-md-offset-0">
+            <span class="small"><status-glyph item="stage"></status-glyph></span> {{stage.name | robotToHuman }}
+          </div>
+          <div class="col-md-4 text-right">
+            {{stage.runningTimeInMs | duration }}
+          </div>
+        </div>
+      </div>
+
+    </collapsible-section>
+    <collapsible-section heading="Job Information" expanded="true">
+      <dl class="dl-horizontal" ng-class="InsightFilterStateModel.filtersExpanded ? 'dl-narrow' : 'dl-wide'">
+        <dt>Created</dt>
+        <dd>{{job.createdTime | timestamp }}</dd>
+        <dt>In</dt>
+        <dd><account-tag account="job.account" pad="right"></account-tag><dd>
+        <dt>Namespace<dt>
+        <dd>{{job.region}}</dd>
+        <dt>Kind</dt>
+        <dd>{{job.job.kind}}</dd>
+        <dt>YAML</dt>
+        <dd><a href ng-click="ctrl.showYaml()">Show YAML</a></dd>
+      </dl>
+    </collapsible-section>
+    <collapsible-section heading="Replicas" expanded="true">
+      <dl class="dl-horizontal"
+          ng-class="InsightFilterStateModel.filtersExpanded ? 'dl-narrow' : 'dl-wide'" >
+        <dt>Desired</dt>
+        <dd>{{job.capacity.desired}}</dd>
+        <dt>Current</dt>
+        <dd>{{job.instances.length}}</dd>
+      </dl>
+    </collapsible-section>
+    <collapsible-section heading="Health" expanded="true">
+      <dl class="dl-horizontal"
+          ng-class="InsightFilterStateModel.filtersExpanded ? 'dl-narrow' : 'dl-wide'"
+          ng-if="job">
+        <dt>Instances</dt>
+        <dd>
+          <health-counts container="job.instanceCounts" class="pull-left"></health-counts>
+        </dd>
+      </dl>
+    </collapsible-section>
+    <collapsible-section ng-repeat="container in job.deployDescription.containers" heading="{{container.name}}">
+    <dl class="dl-horizontal"
+        ng-class="InsightFilterStateModel.filtersExpanded ? 'dl-narrow' : 'dl-wide'" >
+        <dt>Name</dt>
+        <dd>{{container.name}}</dd>
+        <dt>Registry</dt>
+        <dd>{{container.imageDescription.registry}}</dd>
+        <dt>Image</dt>
+        <dd>{{container.imageDescription.repository}}</dd>
+        <dt>Tag</dt>
+        <dd>{{container.imageDescription.tag}}</dd>
+        <hr>
+        <div ng-if="container.limits">
+          <b>Limits</b>
+          <hr>
+          <div ng-if="container.limits.cpu">
+            <dt>CPU Limit</dt>
+            <dd>{{container.limits.cpu}}</dd>
+          </div>
+          <div ng-if="container.limits.memory">
+            <dt>Memory Limit</dt>
+            <dd>{{container.limits.memory}}</dd>
+          </div>
+        </div>
+        <div ng-if="container.requests">
+          <b>Requests</b>
+          <hr>
+          <div ng-if="container.requests.cpu">
+            <dt>CPU Request</dt>
+            <dd>{{container.requests.cpu}}</dd>
+          </div>
+          <div ng-if="container.requests.memory">
+            <dt>Memory Request</dt>
+            <dd>{{container.requests.memory}}</dd>
+          </div>
+        </div>
+        <div ng-if="container.readinessProbe">
+          <b>Readiness Probe</b>
+          <hr>
+          <dt>Success Threshold</dt>
+          <dd>{{container.readinessProbe.successThreshold}}</dd>
+          <dt>Failure Threshold</dt>
+          <dd>{{container.readinessProbe.failureThreshold}}</dd>
+          <dt>Period</dt>
+          <dd>{{container.readinessProbe.periodSeconds}}</dd>
+          <dt>Initial Delay</dt>
+          <dd>{{container.readinessProbe.initialDelaySeconds}}</dd>
+          <dt>Timeout</dt>
+          <dd>{{container.readinessProbe.timeoutSeconds}}</dd>
+        </div>
+        <div ng-if="container.livenessProbe">
+          <b>Liveness Probe</b>
+          <hr>
+          <dt>Success Threshold</dt>
+          <dd>{{container.livenessProbe.successThreshold}}</dd>
+          <dt>Failure Threshold</dt>
+          <dd>{{container.livenessProbe.failureThreshold}}</dd>
+          <dt>Period</dt>
+          <dd>{{container.livenessProbe.periodSeconds}}</dd>
+          <dt>Initial Delay</dt>
+          <dd>{{container.livenessProbe.initialDelaySeconds}}</dd>
+          <dt>Timeout</dt>
+          <dd>{{container.livenessProbe.timeoutSeconds}}</dd>
+        </div>
+    </dl>
+      </collapsible-section>
+    <collapsible-section heading="Labels">
+      <div ng-if="!job.labels">No labels associated with this job</div>
+      <dl ng-repeat="(key, value) in job.labels" class="dl-horizontal"
+          ng-class="InsightFilterStateModel.filtersExpanded ? 'dl-narrow' : 'dl-wide'" >
+        {{key}}: {{value}}
+      </dl>
+    </collapsible-section>
+    <collapsible-section heading="Logs">
+      <ul>
+        <li ng-if="job.logsLink">
+          <a href="{{job.logsLink}}" target="_blank">Developers Console Logs</a>
+          <copy-to-clipboard
+              class="copy-to-clipboard copy-to-clipboard-sm"
+              text="{{job.logsLink}}"
+              tool-tip="Copy to clipboard">
+          </copy-to-clipboard>
+        </li>
+      </ul>
+    </collapsible-section>
+  </div>
+</div>

--- a/app/scripts/modules/kubernetes/job/job.module.js
+++ b/app/scripts/modules/kubernetes/job/job.module.js
@@ -6,4 +6,5 @@ module.exports = angular.module('spinnaker.job.kubernetes', [
   require('./transformer.js'),
   require('./configure/CommandBuilder.js'),
   require('./configure/wizard/Clone.controller.js'),
+  require('./details/details.controller.js'),
 ]);

--- a/app/scripts/modules/kubernetes/kubernetes.module.js
+++ b/app/scripts/modules/kubernetes/kubernetes.module.js
@@ -83,10 +83,12 @@ module.exports = angular.module('spinnaker.kubernetes', [
         configurationService: 'kubernetesServerGroupConfigurationService',
       },
       job: {
-        transformer: 'kubernetesJobTransformer',
         cloneJobController: 'kubernetesCloneJobController',
         cloneJobTemplateUrl: require('./job/configure/wizard/wizard.html'),
         commandBuilder: 'kubernetesJobCommandBuilder',
+        detailsTemplateUrl: require('./job/details/details.html'),
+        detailsController: 'kubernetesJobDetailsController',
+        transformer: 'kubernetesJobTransformer',
       },
     });
   });

--- a/test/mock/mockApplicationData.js
+++ b/test/mock/mockApplicationData.js
@@ -22,6 +22,7 @@ module.exports = angular
       heading : 'prod',
       subgroups : [ {
         heading : 'in-eu-east-2-only',
+        category: 'serverGroup',
         hasDiscovery: false,
         hasLoadBalancers: false,
         subgroups : [ {
@@ -53,6 +54,7 @@ module.exports = angular
         heading : 'test',
         subgroups : [ {
           heading : 'in-us-west-1-only',
+          category: 'serverGroup',
           hasDiscovery: false,
           hasLoadBalancers: false,
           subgroups : [ {


### PR DESCRIPTION
@anotherchrisberry @duftler 

Allows user to select jobs in cluster screen and brings up a job dialog:

![jobdetails](https://cloud.githubusercontent.com/assets/4874941/14999735/1f6aa7c2-1159-11e6-82f9-d2710d774d56.png)

I still need to get filters to work, and make new widgets for completed (failed and succeeded) jobs.