### PR TITLE
provider/kubernetes: Non primary account failing to load

### DIFF
--- a/app/scripts/modules/kubernetes/cluster/configure/CommandBuilder.js
+++ b/app/scripts/modules/kubernetes/cluster/configure/CommandBuilder.js
@@ -17,6 +17,8 @@ module.exports = angular.module('spinnaker.kubernetes.clusterCommandBuilder.serv
           firstKubernetesAccount = _.find(application.accounts, function (applicationAccount) {
             return kubernetesAccountNames.indexOf(applicationAccount) !== -1;
           });
+        } else if (kubernetesAccountNames.length) {
+          firstKubernetesAccount = kubernetesAccountNames[0];
         }
 
         var defaultAccountIsValid = defaultAccount && kubernetesAccountNames.indexOf(defaultAccount) !== -1;


### PR DESCRIPTION
This loads the first configured account as a backup when no primary account were selected. Otherwise the create server group dialog fails to load. (Create load balancer & security group already work).