### PR TITLE
provider/kubernetes: Create job details dialog

### DIFF
--- a/app/scripts/modules/core/cluster/cluster.service.js
+++ b/app/scripts/modules/core/cluster/cluster.service.js
@@ -64,6 +64,8 @@ module.exports = angular.module('spinnaker.core.cluster.service', [
         unknown: 0,
         starting: 0,
         outOfService: 0,
+        succeeded: 0,
+        failed: 0,
         total: 0,
       };
       var operand = cluster.serverGroups || cluster.jobs || [];
@@ -77,6 +79,8 @@ module.exports = angular.module('spinnaker.core.cluster.service', [
         cluster.instanceCounts.unknown += serverGroup.instanceCounts.unknown || 0;
         cluster.instanceCounts.starting += serverGroup.instanceCounts.starting || 0;
         cluster.instanceCounts.outOfService += serverGroup.instanceCounts.outOfService || 0;
+        cluster.instanceCounts.succeeded += serverGroup.instanceCounts.succeeded || 0;
+        cluster.instanceCounts.failed += serverGroup.instanceCounts.failed || 0;
       });
     }
 

--- a/app/scripts/modules/core/cluster/rollups.less
+++ b/app/scripts/modules/core/cluster/rollups.less
@@ -396,6 +396,25 @@ load-balancers-tag {
       .server-group-title {
         background-color: #ffffff;
       }
+      &.running {
+        background-color: @active_pod_blue;
+        .pulsing(1.0);
+        .server-group-title {
+          background-color: @active_pod_blue;
+        }
+      }
+      &.failed {
+        background-color: @failed_job;
+        .server-group-title {
+          background-color: @failed_job;
+        }
+      }
+      &.succeeded {
+        background-color: @succeeded_job;
+        .server-group-title {
+          background-color: @succeeded_job;
+        }
+      }
       &.active {
         background-color: @active_pod_blue;
         .server-group-title {

--- a/app/scripts/modules/core/healthCounts/healthCounts.directive.js
+++ b/app/scripts/modules/core/healthCounts/healthCounts.directive.js
@@ -28,9 +28,11 @@ module.exports = angular.module('spinnaker.core.healthCounts.directive', [
           var container = scope.container || {},
             up = container.up || 0,
             down = container.down || 0,
+            succeeded = container.succeeded || 0,
+            failed = container.failed || 0,
             unknown = container.unknown || 0,
-            total = up + down + unknown,
-            healthPercent = total ? parseInt(up * 100 / total) : 'n/a';
+            total = up + down + unknown + succeeded + failed,
+            healthPercent = total ? parseInt((up + succeeded) * 100 / total) : 'n/a';
 
           scope.healthPercent = healthPercent;
           scope.healthPercentLabel = total ? '%' : '';

--- a/app/scripts/modules/core/healthCounts/healthCounts.html
+++ b/app/scripts/modules/core/healthCounts/healthCounts.html
@@ -14,6 +14,14 @@
     <span ng-if="container.up || container.down || container.unknown">/</span>
     {{ container.outOfService }} <span class="glyphicon glyphicon-OutOfService-triangle disabled small"></span>
   </span>
+  <span ng-if="container.succeeded">
+    <span ng-if="container.up || container.down || container.unknown || container.outOfService">/</span>
+    {{ container.succeeded }} <span class="glyphicon glyphicon-Succeeded-triangle disabled small"></span>
+  </span>
+  <span ng-if="container.failed">
+    <span ng-if="container.up || container.down || container.unknown || container.outOfService || container.succeeded">/</span>
+    {{ container.failed }} <span class="glyphicon glyphicon-Failed-triangle disabled small"></span>
+  </span>
   <span ng-if="container.unknown !== container.total">
   : <span class="{{healthStatus}}">
       {{healthPercent}}{{healthPercentLabel}}

--- a/app/scripts/modules/core/healthCounts/healthLegend.html
+++ b/app/scripts/modules/core/healthCounts/healthLegend.html
@@ -16,5 +16,13 @@
       <td><span class="glyphicon glyphicon-minus disabled small"></span></td>
       <td>Out of Service</td>
     </tr>
+    <tr>
+      <td><span class="glyphicon glyphicon-Succeeded-triangle small"></span></td>
+      <td>Terminated successfully</td>
+    </tr>
+    <tr>
+      <td><span class="glyphicon glyphicon-Failed-triangle small"></span></td>
+      <td>Terminated unsuccessfully</td>
+    </tr>
   </tbody>
 </table>

--- a/app/scripts/modules/core/job/job.directive.html
+++ b/app/scripts/modules/core/job/job.directive.html
@@ -3,7 +3,10 @@
      ng-click="loadDetails($event)"
      ng-class="{
         disabled: viewModel.job.isDisabled,
-        active: $state.includes('**.job', {region: viewModel.job.region, accountId: viewModel.job.account, job: viewModel.job.name, provider: viewModel.job.type})
+        active: $state.includes('**.job', {region: viewModel.job.region, accountId: viewModel.job.account, job: viewModel.job.name, provider: viewModel.job.type}),
+        failed: viewModel.failed,
+        succeeded: viewModel.succeeded,
+        running: viewModel.running
      }">
   <div class="cluster-container">
     <div class="server-group-title" sticky-header added-offset-height="69"

--- a/app/scripts/modules/core/job/job.directive.js
+++ b/app/scripts/modules/core/job/job.directive.js
@@ -40,9 +40,14 @@ module.exports = angular.module('spinnaker.core.job.job.directive', [
             waypoint: [job.account, job.region, job.name].join(':'),
             job: job,
             jobSequence: $filter('serverGroupSequence')(job.name),
-            jenkins: null,
+            failed: job.jobState == 'Failed',
+            succeeded: job.jobState == 'Succeeded',
+            running: job.jobState == 'Running',
             hasBuildInfo: !!job.buildInfo,
-            instances: filteredInstances,
+            instances: filteredInstances.map((instance) => {
+              instance.id = instance.instanceId;
+              return instance;
+            }),
           };
 
           let modelStringVal = JSON.stringify(viewModel, jobTransformer.jsonReplacer);

--- a/app/scripts/modules/core/presentation/less/imports/colors.less
+++ b/app/scripts/modules/core/presentation/less/imports/colors.less
@@ -26,6 +26,8 @@
 @light_grey: #EBEBEB;
 @lighter_grey: #EEEEEE;
 @lightest_grey: #F8F8F8;
+@succeeded_job: #E6FFE6;
+@failed_job: #FFE6E6;
 
 @secondary_panel_grey: #f1f1f1;
 

--- a/app/scripts/modules/core/presentation/main.less
+++ b/app/scripts/modules/core/presentation/main.less
@@ -357,6 +357,24 @@ html {
   .pulsing(1.0);
 }
 
+.glyphicon-Failed-triangle {
+  &:before {
+    content: "\2717";
+    font-weight: 900;
+    color: @unhealthy_red;
+    font-size: 120%;
+  }
+}
+
+.glyphicon-Succeeded-triangle {
+  &:before {
+    content: "\2713";
+    font-weight: 900;
+    color: @healthy_green_border;
+    font-size: 120%;
+  }
+}
+
 dl {
   word-break: break-word;
 }


### PR DESCRIPTION
Running jobs now pulse, failed ones are red, and successful ones are green:

![jobstates](https://cloud.githubusercontent.com/assets/4874941/15094038/9190919e-1466-11e6-9a50-bb54605290a0.png)

There is a green checkmark for successful jobs, and a red X for failed ones.