### PR TITLE
provider/netflix: support VPC migration when no provider specified on canaries

### DIFF
--- a/app/scripts/modules/netflix/migrator/pipeline/pipeline.migrator.directive.js
+++ b/app/scripts/modules/netflix/migrator/pipeline/pipeline.migrator.directive.js
@@ -39,7 +39,7 @@ module.exports = angular
 
     function testCluster(stage) {
       return function(cluster) {
-        if (!cluster.subnetType && cluster.provider === 'aws') {
+        if (!cluster.subnetType && (!cluster.provider || cluster.provider === 'aws')) {
           $scope.showAction = true;
           if (cluster.strategy !== '') {
             actionableDeployStages.push({strategy: cluster.strategy, name: stage.name});


### PR DESCRIPTION
Canary stages don't have a `provider` field