### PR TITLE
fix deep link issue with pipeline configs

### DIFF
--- a/app/scripts/modules/core/pipeline/config/pipelineConfig.controller.js
+++ b/app/scripts/modules/core/pipeline/config/pipelineConfig.controller.js
@@ -30,6 +30,7 @@ module.exports = angular.module('spinnaker.core.pipeline.config.controller', [
     };
 
     if (!application.notFound) {
+      application.pipelineConfigs.activate();
       application.pipelineConfigs.ready().then(this.initialize);
     }
 

--- a/app/scripts/modules/core/pipeline/config/pipelineConfig.controller.spec.js
+++ b/app/scripts/modules/core/pipeline/config/pipelineConfig.controller.spec.js
@@ -39,7 +39,8 @@ describe('Controller: PipelineConfigCtrl', function () {
 
   it('should wait until pipeline configs are loaded before initializing', function () {
     scope.application = {};
-    applicationReader.addSectionToApplication({key: 'pipelineConfigs', lazy: true}, scope.application);
+    applicationReader.addSectionToApplication({key: 'pipelineConfigs', lazy: true, loader: angular.noop}, scope.application);
+    spyOn(scope.application.pipelineConfigs, 'activate').and.callFake(angular.noop);
     let vm = controller('PipelineConfigCtrl', {
       $scope: scope,
       $stateParams: {
@@ -52,6 +53,7 @@ describe('Controller: PipelineConfigCtrl', function () {
     scope.$digest();
 
     expect(vm.state.pipelinesLoaded).toBe(true);
+    expect(scope.application.pipelineConfigs.activate.calls.count()).toBe(1);
   });
 });
 


### PR DESCRIPTION
`pipelineConfigs` are lazy loaded now, so we need to activate that section when loading the config page