### PR TITLE
(netflix) fix pipeline name, navigate to new pipeline on modal close

### DIFF
--- a/app/scripts/modules/netflix/migrator/pipeline/pipeline.migrator.directive.html
+++ b/app/scripts/modules/netflix/migrator/pipeline/pipeline.migrator.directive.html
@@ -1,1 +1,3 @@
-<a ng-hide="!showAction" href ng-click="migratorActionCtrl.previewMigration()">Migrate to VPC0</a>
+<a ng-hide="!showAction && !migrated" href ng-click="migratorActionCtrl.previewMigration()">
+  {{migrated ? 'View migrated pipeline' : 'Migrate to VPC0'}}
+</a>

--- a/app/scripts/modules/netflix/migrator/pipeline/pipeline.migrator.directive.js
+++ b/app/scripts/modules/netflix/migrator/pipeline/pipeline.migrator.directive.js
@@ -29,7 +29,7 @@ module.exports = angular
       controllerAs: 'migratorActionCtrl',
     };
   })
-  .controller('PipelineMigratorActionCtrl', function ($scope, $uibModal, vpcReader, settings) {
+  .controller('PipelineMigratorActionCtrl', function ($scope, $uibModal, $state, vpcReader, settings) {
 
     $scope.showAction = false;
 
@@ -49,6 +49,10 @@ module.exports = angular
     }
 
     if (settings.feature.vpcMigrator) {
+      let [migrated] = $scope.application.pipelineConfigs.data.filter(test => test.name === $scope.pipeline.name + ' - vpc0');
+      if (migrated) {
+        $scope.migrated = migrated;
+      }
       var stages = $scope.pipeline.stages || [];
       stages.forEach((stage) => {
         if (stage.type === 'deploy') {
@@ -66,6 +70,10 @@ module.exports = angular
     }
 
     this.previewMigration = function () {
+      if ($scope.migrated) {
+        $state.go('^.pipelineConfig', {pipelineId: $scope.migrated.id});
+        return;
+      }
       $uibModal.open({
         templateUrl: require('./pipeline.migrator.modal.html'),
         controller: 'PipelineMigratorCtrl as vm',
@@ -97,6 +105,7 @@ module.exports = angular
       executing: false,
       error: false,
       migrationComplete: false,
+      targetName: pipeline.name + ' - vpc0',
     };
 
     // shared component used by "submitting" overlay to indicate what's being operated against
@@ -126,16 +135,11 @@ module.exports = angular
       taskReader.waitUntilTaskCompletes(application.name, task).then(dryRunComplete, errorMode);
     };
 
-    let reinitialize = () => {
-      pipelineConfigService.getPipelinesForApplication(application.name).then((pipelines) => {
-        application.pipelines = pipelines;
-        // TODO: pipeline ID is not yet populated in the task result from Tide, so build it out based on name
-        var [newPipeline] = pipelines.filter(function(test) {
-          return test.name.indexOf(pipeline.name + ' - vpc0') === 0;
-        });
-        if (newPipeline) {
-          $state.go('^.pipelineConfig', {pipelineId: newPipeline.id});
-        }
+    let migrationComplete = () => {
+      application.pipelineConfigs.refresh().then(() => {
+        this.viewState.executing = false;
+        this.viewState.migrationComplete = true;
+
         if (this.preview.securityGroups && this.preview.securityGroups.length) {
           cacheInitializer.refreshCache('securityGroups');
         }
@@ -143,12 +147,6 @@ module.exports = angular
           cacheInitializer.refreshCache('loadBalancers');
         }
       });
-    };
-
-    let migrationComplete = () => {
-      this.viewState.executing = false;
-      this.viewState.migrationComplete = true;
-      reinitialize();
     };
 
     let migrationStarted = (task) => {
@@ -178,6 +176,13 @@ module.exports = angular
     let executor = migratorService.executeMigration(migrationConfig);
 
     executor.then(dryRunStarted, errorMode);
+
+    this.close = () => {
+      var [newPipeline] = application.pipelineConfigs.data.filter(test => {
+        return test.name.indexOf(this.viewState.targetName) === 0;
+      });
+      $state.go('^.pipelineConfig', {pipelineId: newPipeline.id});
+    };
 
     this.cancel = () => {
       $timeout.cancel(this.task.poller);

--- a/app/scripts/modules/netflix/migrator/pipeline/pipeline.migrator.modal.html
+++ b/app/scripts/modules/netflix/migrator/pipeline/pipeline.migrator.modal.html
@@ -20,7 +20,7 @@
         <div class="col-md-10 col-md-offset-1">
           <div ng-if="!vm.viewState.migrationComplete">
             <p>This will create new pipeline named
-              <strong>{{vm.preview.pipelines[0].mutationDetails.pipelineToCreate.name}}</strong>. All triggers will be disabled.</p>
+              <strong>{{vm.viewState.targetName}}</strong>. All triggers will be disabled.</p>
             <p ng-if="!vm.preview.securityGroups.length && !vm.preview.loadBalancers.length">
               All load balancers and security groups needed for server groups deployed in the pipeline have already
               been migrated to VPC0, so this will just create the new pipeline.
@@ -47,7 +47,7 @@
           </div>
           <div ng-if="vm.viewState.migrationComplete">
             <p>The new pipeline named
-              <strong>{{vm.preview.pipelines[0].mutationDetails.pipelineToCreate.name}}</strong> is available for review.</p>
+              <strong>{{vm.viewState.targetName}}</strong> is available for review.</p>
           </div>
           <div ng-if="vm.actionableDeployStages.length && vm.viewState.migrationComplete" class="alert alert-warning">
             <h4 style="margin-top:0;">Important</h4>
@@ -105,7 +105,12 @@
     </div>
 
     <div class="modal-footer" ng-if="!vm.viewState.error && !vm.viewState.executing">
-      <button class="btn btn-default" ng-click="vm.cancel()">{{vm.viewState.migrationComplete ? 'Close' : 'Cancel'}}</button>
+      <button class="btn btn-primary"
+              ng-if="vm.viewState.migrationComplete"
+              ng-click="vm.close()">Review {{vm.viewState.targetName}}</button>
+      <button class="btn btn-default"
+              ng-if="!vm.viewState.migrationComplete"
+              ng-click="vm.cancel()">Cancel</button>
       <button class="btn btn-primary"
               ng-if="!vm.viewState.executing && !vm.viewState.computing && !vm.viewState.migrationComplete"
               ng-click="vm.submit()">


### PR DESCRIPTION
* infer new pipeline name from current pipeline
* change the "Close" button to "Review {{new name}}"
* if the pipeline has already been migrated, replace "Migrate to VPC0" with a link to "View migrated pipeline"
* don't navigate to the new pipeline config until the user clicks the "Review" button