### PR TITLE
hide category filter if only one category; fix cluster sorting

### DIFF
--- a/app/scripts/modules/core/cluster/filter/clusterFilter.controller.js
+++ b/app/scripts/modules/core/cluster/filter/clusterFilter.controller.js
@@ -61,6 +61,7 @@ module.exports = angular.module('cluster', [
       ctrl.providerTypeHeadings = getHeadingsForOption('type');
       ctrl.stackHeadings = ['(none)'].concat(getHeadingsForOption('stack'));
       ctrl.availabilityZoneHeadings = getAvailabilityZones();
+      ctrl.categoryHeadings = getHeadingsForOption('category');
       ctrl.clearFilters = clearFilters;
       $scope.clusters = app.clusters;
     };

--- a/app/scripts/modules/core/cluster/filter/clusterFilter.service.js
+++ b/app/scripts/modules/core/cluster/filter/clusterFilter.service.js
@@ -277,7 +277,7 @@ module.exports = angular
 
         groups.push( {
           heading: accountKey,
-          subgroups: _.sortBy(clusterGroups, ['heading', 'category']),
+          subgroups: _.sortByAll(clusterGroups, ['heading', 'category']),
         } );
       });
 
@@ -424,7 +424,6 @@ module.exports = angular
     return {
       updateClusterGroups: updateClusterGroups,
       filterServerGroupsForDisplay: filterServerGroupsForDisplay,
-      sortGroupsByHeading: sortGroupsByHeading,
       clearFilters: clearFilters,
       shouldShowInstance: shouldShowInstance,
       overrideFiltersForUrl: overrideFiltersForUrl,

--- a/app/scripts/modules/core/cluster/filter/filterNav.html
+++ b/app/scripts/modules/core/cluster/filter/filterNav.html
@@ -33,10 +33,10 @@
     </div>
   </filter-section>
 
-  <filter-section heading="Category" expanded="true">
-    <div class="checkbox" ng-repeat="category in clustersFilters.categoryHeadings | orderBy: 'toString()' ">
+  <filter-section heading="Category" expanded="true" ng-if="clustersFilters.categoryHeadings.length > 1">
+    <div class="checkbox" ng-repeat="heading in clustersFilters.categoryHeadings | orderBy: 'toString()' ">
       <label>
-        <input type="checkbox" ng-model="sortFilter.category[heading]" ng-change="clustersFilters.updateClusterGroups()"/>{{heading}}
+        <input type="checkbox" ng-model="sortFilter.category[heading]" ng-change="clustersFilters.updateClusterGroups()"/>{{heading | robotToHuman}}
       </label>
     </div>
   </filter-section>


### PR DESCRIPTION
We're still on lodash v3.10.x, so `_.sortBy` and `_.sortByAll` are different methods.

Also, hide the "Category" filters if there's only one category. Also, display the category if one is present.