### PR TITLE
Use Application Gateway as a Load Balancer for Azure 

### DIFF
--- a/app/scripts/modules/azure/loadBalancer/configure/createLoadBalancer.controller.spec.js
+++ b/app/scripts/modules/azure/loadBalancer/configure/createLoadBalancer.controller.spec.js
@@ -34,7 +34,7 @@ describe('Controller: azureCreateLoadBalancerCtrl', function () {
     expect(lb.probes.length).toEqual(1);
     expect(lb.loadBalancingRules.length).toEqual(1);
 
-    expect(lb.loadBalancingRules[0].protocol).toEqual('TCP');
+    expect(lb.loadBalancingRules[0].protocol).toEqual('HTTP');
 
     expect(this.$scope.existingLoadBalancerNames).toEqual(undefined);
     expect(lb.providerType).toEqual(undefined);

--- a/app/scripts/modules/azure/loadBalancer/configure/healthCheck.html
+++ b/app/scripts/modules/azure/loadBalancer/configure/healthCheck.html
@@ -5,17 +5,17 @@
         <thead>
           <tr>
             <th width="35%">Protocol</th>
-            <th width="30%">Port</th>
+            <th width="30%">Host</th>
             <th><span ng-if="ctrl.requiresHealthCheckPath()">Path</span></th>
           </tr>
         </thead>
         <tbody>
           <tr>
             <td>
-              <select class="form-control input-sm" ng-model="loadBalancer.probes[0].probeProtocol" required ng-options="protocol for protocol in ['HTTP', 'HTTPS', 'SSL', 'TCP']"></select>
+              <select class="form-control input-sm" ng-model="loadBalancer.probes[0].probeProtocol" required ng-options="protocol for protocol in ['HTTP']"></select>
             </td>
             <td>
-              <input class="form-control input-sm" type="number" ng-model="loadBalancer.probes[0].probePort" required min="0" />
+              <input class="form-control input-sm" type="text" ng-model="loadBalancer.probes[0].probePort" />
             </td>
             <td>
               <input ng-if="ctrl.requiresHealthCheckPath()" class="form-control input-sm" type="text" ng-model="loadBalancer.probes[0].probePath"
@@ -48,6 +48,15 @@
         </div>
         <div class="col-md-4">
           <input class="form-control input-sm" type="number" min="0" ng-model="loadBalancer.probes[0].unhealthyThreshold" />
+        </div>
+      </div>
+      <div class="form-group">
+        <div class="col-md-6 sm-label-right">
+          <b>Timeout</b>
+          <help-field key="loadBalancer.probes.timeout" />
+        </div>
+        <div class="col-md-4">
+          <input class="form-control input-sm" type="number" min="0" ng-model="loadBalancer.probes[0].timeout" />
         </div>
       </div>
     </div>

--- a/app/scripts/modules/azure/loadBalancer/configure/listeners.html
+++ b/app/scripts/modules/azure/loadBalancer/configure/listeners.html
@@ -14,7 +14,7 @@
         <tbody>
           <tr ng-repeat="rule in loadBalancer.loadBalancingRules">
             <td>
-              <select class="form-control input-sm" ng-model="rule.protocol" ng-options="protocol for protocol in ['UDP','TCP']"></select>
+              <select class="form-control input-sm" ng-model="rule.protocol" ng-options="protocol for protocol in ['HTTP']"></select>
             </td>
             <td>
               <input class="form-control input-sm" type="number" min="0" ng-model="rule.externalPort" required/>

--- a/app/scripts/modules/azure/loadBalancer/loadBalancer.transformer.js
+++ b/app/scripts/modules/azure/loadBalancer/loadBalancer.transformer.js
@@ -77,17 +77,18 @@ module.exports = angular.module('spinnaker.azure.loadBalancer.transformer', [
           {
             probeName: '',
             probeProtocol: 'HTTP',
-            probePort: 7001,
-            probePath: '/healthcheck',
-            probeInterval: 10,
-            unhealthyThreshold: 2
+            probePort: 'www.bing.com',
+            probePath: '/',
+            probeInterval: 30,
+            unhealthyThreshold: 8,
+			timeout: 120
           }
         ],
         securityGroups: [],
         loadBalancingRules: [
           {
             ruleName: '',
-            protocol: 'TCP',
+            protocol: 'HTTP',
             externalPort: 80,
             backendPort: 8080,
             probeName: '',

--- a/app/scripts/modules/azure/serverGroup/details/serverGroupDetails.azure.controller.js
+++ b/app/scripts/modules/azure/serverGroup/details/serverGroupDetails.azure.controller.js
@@ -186,8 +186,10 @@ module.exports = angular.module('spinnaker.azure.serverGroup.details.controller'
         title: 'Enabling ' + serverGroup.name,
       };
 
-      var submitMethod = function () {
-        return serverGroupWriter.enableServerGroup(serverGroup, app);
+      var submitMethod = (params) => {
+        return serverGroupWriter.enableServerGroup(serverGroup, app, angular.extend(params, {
+          interestingHealthProviderNames: [] // bypass the check for now; will change this later to ['azureService']
+        }));
       };
 
       confirmationModalService.confirm({

--- a/app/scripts/modules/core/pipeline/config/stages/destroyAsg/azure/azureDestroyAsgStage.js
+++ b/app/scripts/modules/core/pipeline/config/stages/destroyAsg/azure/azureDestroyAsgStage.js
@@ -53,7 +53,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.azure.destroyAsgS
     stage.regions = stage.regions || [];
     stage.cloudProvider = 'azure';
 
-    stage.interestingHealthProviderNames = ['azureService'];
+    stage.interestingHealthProviderNames = []; // bypass the check for now; will change this later to ['azureService']
 
     if (!stage.credentials && $scope.application.defaultCredentials.azure) {
       stage.credentials = $scope.application.defaultCredentials.azure;

--- a/app/scripts/modules/core/pipeline/config/stages/disableAsg/azure/azureDisableAsgStage.js
+++ b/app/scripts/modules/core/pipeline/config/stages/disableAsg/azure/azureDisableAsgStage.js
@@ -47,7 +47,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.azure.disableAsgS
     stage.cloudProvider = 'azure';
 
     if (stage.isNew && $scope.application.attributes.platformHealthOnly) {
-      stage.interestingHealthProviderNames = ['azureService'];
+      stage.interestingHealthProviderNames = []; // bypass the check for now; will change this later to ['azureService']
     }
 
     if (!stage.credentials && $scope.application.defaultCredentials.azure) {

--- a/app/scripts/modules/core/pipeline/config/stages/enableAsg/azure/azureEnableAsgStage.js
+++ b/app/scripts/modules/core/pipeline/config/stages/enableAsg/azure/azureEnableAsgStage.js
@@ -50,7 +50,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.azure.enableAsgSt
     stage.cloudProvider = 'azure';
 
     if (stage.isNew && $scope.application.attributes.platformHealthOnly) {
-      stage.interestingHealthProviderNames = [ 'azureService' ];
+      stage.interestingHealthProviderNames = []; // bypass the check for now; will change this later to ['azureService']
     }
 
     if (!stage.credentials && $scope.application.defaultCredentials.azure) {


### PR DESCRIPTION
This enable Azure Application Gateway as the Spinnaker Load Balancer when targeting Azure cloud. Only HTTP protocol is supported at the moment (HTTPS will be added later).

Fixed couple issue related to instance health check; we need to shortcut these checks for now.
