### PR TITLE
(aws) Allow selection of VPC load balancers on Classic ASGs

### DIFF
--- a/app/scripts/modules/amazon/loadBalancer/details/loadBalancerDetail.controller.js
+++ b/app/scripts/modules/amazon/loadBalancer/details/loadBalancerDetail.controller.js
@@ -25,24 +25,18 @@ module.exports = angular.module('spinnaker.loadBalancer.aws.details.controller',
     $scope.InsightFilterStateModel = InsightFilterStateModel;
 
     function extractLoadBalancer() {
-      if (!loadBalancer.vpcId) {
-        loadBalancer.vpcId = null;
-      }
-      $scope.loadBalancer = app.loadBalancers.data.filter(function (test) {
-        var testVpc = test.vpcId || null;
-        return test.name === loadBalancer.name && test.region === loadBalancer.region && test.account === loadBalancer.accountId && testVpc === loadBalancer.vpcId;
-      })[0];
+      let [appLoadBalancer] = app.loadBalancers.data.filter(function (test) {
+        return test.name === loadBalancer.name && test.region === loadBalancer.region && test.account === loadBalancer.accountId;
+      });
 
-      if ($scope.loadBalancer) {
-        var detailsLoader = loadBalancerReader.getLoadBalancerDetails($scope.loadBalancer.provider, loadBalancer.accountId, loadBalancer.region, loadBalancer.name);
+      if (appLoadBalancer) {
+        var detailsLoader = loadBalancerReader.getLoadBalancerDetails('aws', loadBalancer.accountId, loadBalancer.region, loadBalancer.name);
         return detailsLoader.then(function(details) {
+          $scope.loadBalancer = appLoadBalancer;
           $scope.state.loading = false;
           var securityGroups = [];
-          var filtered = details.filter(function(test) {
-            return test.vpcid === loadBalancer.vpcId || (!test.vpcid && !loadBalancer.vpcId);
-          });
-          if (filtered.length) {
-            $scope.loadBalancer.elb = filtered[0];
+          if (details.length) {
+            $scope.loadBalancer.elb = details[0];
             $scope.loadBalancer.account = loadBalancer.accountId;
 
             if ($scope.loadBalancer.elb.availabilityZones) {

--- a/app/scripts/modules/amazon/serverGroup/configure/serverGroupConfiguration.service.spec.js
+++ b/app/scripts/modules/amazon/serverGroup/configure/serverGroupConfiguration.service.spec.js
@@ -37,7 +37,6 @@ describe('Service: awsServerGroupConfiguration', function () {
               {
                 name: 'us-east-1',
                 loadBalancers: [
-                  { region: 'us-east-1', vpcId: null, name: 'elb-1' },
                   { region: 'us-east-1', vpcId: 'vpc-1', name: 'elb-1' },
                 ]
               }
@@ -54,7 +53,6 @@ describe('Service: awsServerGroupConfiguration', function () {
               {
                 name: 'us-east-1',
                 loadBalancers: [
-                  { region: 'us-east-1', vpcId: null, name: 'elb-2' },
                   { region: 'us-east-1', vpcId: 'vpc-2', name: 'elb-2' },
                 ]
               },
@@ -193,7 +191,8 @@ describe('Service: awsServerGroupConfiguration', function () {
     it('matches existing load balancers based on name - no VPC', function () {
       var result = service.configureLoadBalancerOptions(this.command);
 
-      expect(this.command.loadBalancers).toEqual(['elb-1']);
+      expect(this.command.loadBalancers).toEqual([]);
+      expect(this.command.vpcLoadBalancers).toEqual(['elb-1']);
       expect(result).toEqual({ dirty: { }});
     });
 
@@ -212,6 +211,22 @@ describe('Service: awsServerGroupConfiguration', function () {
 
       expect(this.command.loadBalancers).toEqual(['elb-2']);
       expect(result).toEqual({ dirty: { loadBalancers: ['elb-1']}});
+    });
+
+    it('moves load balancers to vpcLoadBalancers when vpc is de-selected', function () {
+      this.command.loadBalancers = ['elb-1'];
+      this.command.vpcId = 'vpc-1';
+      var result = service.configureLoadBalancerOptions(this.command);
+
+      expect(this.command.loadBalancers).toEqual(['elb-1']);
+      expect(result).toEqual({ dirty: {} });
+
+      this.command.vpcId = null;
+      result = service.configureLoadBalancerOptions(this.command);
+      expect(result).toEqual({ dirty: {} });
+      expect(this.command.vpcLoadBalancers).toEqual(['elb-1']);
+      expect(this.command.loadBalancers).toEqual([]);
+
     });
 
     it('sets dirty all unmatched load balancers - VPC', function () {

--- a/app/scripts/modules/amazon/serverGroup/configure/wizard/loadBalancers/loadBalancerSelector.directive.html
+++ b/app/scripts/modules/amazon/serverGroup/configure/wizard/loadBalancers/loadBalancerSelector.directive.html
@@ -1,44 +1,65 @@
 <div class="row">
-<div class="col-md-12" ng-if="vm.command.viewState.dirty.loadBalancers">
-  <div class="alert alert-warning">
-    <p><span class="glyphicon glyphicon-warning-sign"></span>
-      The following load balancers could not be found in the selected account/region/VPC and were removed:
-    </p>
-    <ul>
-      <li ng-repeat="loadBalancer in vm.command.viewState.dirty.loadBalancers">{{loadBalancer}}</li>
-    </ul>
-    <p class="text-right">
-      <a class="btn btn-sm btn-default dirty-flag-dismiss" href ng-click="vm.command.viewState.dirty.loadBalancers = null">Okay</a>
-    </p>
+  <div class="col-md-12" ng-if="vm.command.viewState.dirty.loadBalancers">
+    <div class="alert alert-warning">
+      <p><span class="glyphicon glyphicon-warning-sign"></span>
+        The following load balancers could not be found in the selected account/region/VPC and were removed:
+      </p>
+      <ul>
+        <li ng-repeat="loadBalancer in vm.command.viewState.dirty.loadBalancers">{{loadBalancer}}</li>
+      </ul>
+      <p class="text-right">
+        <a class="btn btn-sm btn-default dirty-flag-dismiss" href ng-click="vm.command.viewState.dirty.loadBalancers = null">Okay</a>
+      </p>
+    </div>
   </div>
-</div>
 
-<div class="form-group">
-  <div class="col-md-3 sm-label-right"><b>Load Balancers</b></div>
-  <div class="col-md-9">
-    <ui-select ng-if="vm.command.backingData.filtered.loadBalancers.length"
-               multiple
-               ng-model="vm.command.loadBalancers"
-               class="form-control input-sm">
-      <ui-select-match>{{$item}}</ui-select-match>
-      <ui-select-choices repeat="loadBalancer in vm.command.backingData.filtered.loadBalancers | filter: $select.search">
-        <span ng-bind-html="loadBalancer | highlight: $select.search"></span>
-      </ui-select-choices>
-    </ui-select>
+  <div class="form-group">
+    <div class="col-md-3 sm-label-right"><b>Load Balancers</b></div>
+    <div class="col-md-9">
+      <ui-select ng-if="vm.command.backingData.filtered.loadBalancers.length"
+                 multiple
+                 ng-model="vm.command.loadBalancers"
+                 class="form-control input-sm">
+        <ui-select-match>{{$item}}</ui-select-match>
+        <ui-select-choices repeat="loadBalancer in vm.command.backingData.filtered.loadBalancers | filter: $select.search">
+          <span ng-bind-html="loadBalancer | highlight: $select.search"></span>
+        </ui-select-choices>
+      </ui-select>
+    </div>
   </div>
-</div>
+  <div class="form-group" ng-if="!vm.command.vpcId">
+    <div ng-if="!vm.command.vpcLoadBalancers.length && !vm.showVpcLoadBalancers">
+      <div class="col-md-9 col-md-offset-3">
+        <a href ng-click="vm.showVpcLoadBalancers = true">Add VPC Load Balancers</a>
+      </div>
+    </div>
+    <div ng-if="vm.command.vpcLoadBalancers.length || vm.showVpcLoadBalancers">
+      <div class="col-md-3 sm-label-right"><b>VPC Load Balancers</b></div>
+      <div class="col-md-9">
+        <ui-select ng-if="vm.command.backingData.filtered.vpcLoadBalancers.length"
+                   multiple
+                   ng-model="vm.command.vpcLoadBalancers"
+                   class="form-control input-sm">
+          <ui-select-match>{{$item}}</ui-select-match>
+          <ui-select-choices repeat="loadBalancer in vm.command.backingData.filtered.vpcLoadBalancers | filter: $select.search">
+            <span ng-bind-html="loadBalancer | highlight: $select.search"></span>
+          </ui-select-choices>
+        </ui-select>
+      </div>
+    </div>
+  </div>
 
-<div class="form-group small" style="margin-top: 20px">
-  <div class="col-md-9 col-md-offset-3">
-    <p>
-      <span ng-if="vm.refreshing"><span class="small glyphicon glyphicon-refresh glyphicon-spinning"></span></span>
-      Load balancers
-      <span ng-if="!vm.refreshing">last refreshed {{ vm.getLoadBalancerRefreshTime() | timestamp }}</span>
-      <span ng-if="vm.refreshing"> refreshing...</span>
-    </p>
-    <p>If you're not finding a load balancer that was recently added,
-      <a href ng-click="vm.refreshLoadBalancers()">click here</a> to refresh the list.
-    </p>
+  <div class="form-group small" style="margin-top: 20px">
+    <div class="col-md-9 col-md-offset-3">
+      <p>
+        <span ng-if="vm.refreshing"><span class="small glyphicon glyphicon-refresh glyphicon-spinning"></span></span>
+        Load balancers
+        <span ng-if="!vm.refreshing">last refreshed {{ vm.getLoadBalancerRefreshTime() | timestamp }}</span>
+        <span ng-if="vm.refreshing"> refreshing...</span>
+      </p>
+      <p>If you're not finding a load balancer that was recently added,
+        <a href ng-click="vm.refreshLoadBalancers()">click here</a> to refresh the list.
+      </p>
+    </div>
   </div>
-</div>
 </div>

--- a/app/scripts/modules/amazon/serverGroup/serverGroup.transformer.js
+++ b/app/scripts/modules/amazon/serverGroup/serverGroup.transformer.js
@@ -78,6 +78,7 @@ module.exports = angular.module('spinnaker.aws.serverGroup.transformer', [
       command.cloudProvider = 'aws';
       command.availabilityZones = {};
       command.availabilityZones[command.region] = base.availabilityZones;
+      command.loadBalancers = (base.loadBalancers || []).concat(base.vpcLoadBalancers || []);
       command.account = command.credentials;
       if (!command.ramdiskId) {
         delete command.ramdiskId; // TODO: clean up in kato? - should ignore if empty string

--- a/app/scripts/modules/core/loadBalancer/loadBalancer/loadBalancersTag.html
+++ b/app/scripts/modules/core/loadBalancer/loadBalancer/loadBalancersTag.html
@@ -15,7 +15,7 @@
     </div>
     <a
       ng-repeat="loadBalancer in serverGroup.loadBalancers | orderBy:'toString()'"
-      ui-sref=".loadBalancerDetails({region: serverGroup.region, accountId: serverGroup.account, name: loadBalancer, vpcId: serverGroup.vpcId, provider: serverGroup.type})"
+      ui-sref=".loadBalancerDetails({region: serverGroup.region, accountId: serverGroup.account, name: loadBalancer, provider: serverGroup.type})"
       >{{loadBalancer}}
     </a>
   </div>
@@ -23,7 +23,7 @@
     <button
        class="btn btn-link no-padding"
        ng-repeat="loadBalancer in serverGroup.loadBalancers | orderBy:'toString()'"
-       ui-sref=".loadBalancerDetails({region: serverGroup.region, accountId: serverGroup.account, name: loadBalancer, vpcId: serverGroup.vpcId, provider: serverGroup.type})"
+       ui-sref=".loadBalancerDetails({region: serverGroup.region, accountId: serverGroup.account, name: loadBalancer, provider: serverGroup.type})"
        ui-sref-active="active"
        uib-tooltip="Load Balancer: {{loadBalancer}}">
       <span class="icon">


### PR DESCRIPTION
AWS allows users to attach any load balancer to any ASG, regardless of its VPC association.

We're taking a more opinionated approach here, only allowing Classic ASGs to attach to VPC load balancers (not letting VPC ASGs attach to Classic ELBs). This is to help folks migrate away from Classic by slowly shifting traffic over to VPC instances.

We don't expect this to be heavily utilized, but it's important for teams that need to migrate over incrementally.

@zanthrash PTAL

<img width="646" alt="screen shot 2016-05-13 at 11 37 39 am" src="https://cloud.githubusercontent.com/assets/73450/15258268/78c6b16e-18ff-11e6-8167-e7e3c552c088.png">

(If the link is clicked, or VPC load balancers have been selected)
<img width="644" alt="screen shot 2016-05-13 at 11 36 23 am" src="https://cloud.githubusercontent.com/assets/73450/15258271/7cdb8ee6-18ff-11e6-9912-99548b827741.png">
