### PR TITLE
Chaos Monkey exceptions: Don't restrict to aws

### DIFF
--- a/app/scripts/modules/netflix/chaosMonkey/chaosMonkeyExceptions.directive.js
+++ b/app/scripts/modules/netflix/chaosMonkey/chaosMonkeyExceptions.directive.js
@@ -30,7 +30,7 @@ module.exports = angular
       this.config.exceptions.splice(index, 1);
     };
 
-    accountService.listAccounts('aws').then((accounts) => {
+    accountService.listAccounts().then((accounts) => {
       $q.all(accounts.map((account) => accountService.getAccountDetails(account.name)))
         .then((details) => {
           this.accounts = details;


### PR DESCRIPTION
Don't restrict accounts for Chaos Monkey exceptions to aws. This will enable users to add exceptions for apps running on Titus.