### PR TITLE
Adds continureOnUnhealthy to canaryConfig

### DIFF
--- a/app/scripts/modules/core/help/helpContents.js
+++ b/app/scripts/modules/core/help/helpContents.js
@@ -220,6 +220,7 @@ module.exports = angular.module('spinnaker.core.help.contents', [])
     'pipeline.config.canary.scaleUpDelay': '<p>Minutes to delay before initiating canary scale up</p>',
     'pipeline.config.canary.baselineVersion': '<p>The Canary stage will inspect the specified cluster to determine which version to deploy as the baseline in each cluster pair.</p>',
     'pipeline.config.canary.lookback':'<p>By default ACA will look at the entire duration of the canary for its analysis. Setting a look-back duration limits the number of minutes that the canary will use for it\'s analysis report.<br> <b>Useful for long running canaries that span multiple days.</b></p>',
+    'pipeline.config.canary.continueOnUnhealthy':'<p>Continue the pipeline if the ACA comes back as <b>UNHEALTHY</b></p>',
 
     'pipeline.config.cron.expression': '<strong>Format (Year is optional)</strong><p><samp>Seconds  Minutes  Hour  DayOfMonth  Month  DayOfWeek  (Year)</samp></p>' +
     '<p><strong>Example: every 30 minutes</strong></p><samp>0 0/30 * * * ?</samp>' +

--- a/app/scripts/modules/netflix/pipeline/stage/acaTask/acaTaskExecutionDetails.html
+++ b/app/scripts/modules/netflix/pipeline/stage/acaTask/acaTaskExecutionDetails.html
@@ -151,11 +151,11 @@
         </div>
         <div class="row" ng-if="canary.canaryDeployments.length > 0">
           <div class="col-md-4 sm-label-right compact">Baseline</div>
-          <div class="col-md-6">{{canary.canaryDeployments[0].baseline}}</div>
+          <div class="col-md-8" style="word-wrap: break-word">{{canary.canaryDeployments[0].baseline}}</div>
         </div>
         <div class="row" ng-if="canary.canaryDeployments.length > 0">
           <div class="col-md-4 sm-label-right compact">Canary</div>
-          <div class="col-md-6">{{canary.canaryDeployments[0].canary}}</div>
+          <div class="col-md-8" style="word-wrap: break-word">{{canary.canaryDeployments[0].canary}}</div>
         </div>
       </div>
       <div class="col-md-12 canary-config-section">
@@ -163,8 +163,8 @@
         <div class="horizontal-rule"></div>
         <div class="row">
           <div class="col-md-4 sm-label-right compact">Config Name</div>
-          <div class="col-md-6">
-            <a href="http://canary.prod.netflix.net/ui/canaryTasks/{{baseline.account}}/{{canaryConfig.canaryAnalysisConfig.name}}" target="_blank">
+          <div class="col-md-8" style="word-wrap: break-word">
+            <a href="http://canary.prod.netflix.net/ui/queryLists/{{canaryConfig.canaryAnalysisConfig.name}}/edit" target="_blank">
               {{canaryConfig.canaryAnalysisConfig.name}}
             </a>
           </div>

--- a/app/scripts/modules/netflix/pipeline/stage/acaTask/acaTaskStage.html
+++ b/app/scripts/modules/netflix/pipeline/stage/acaTask/acaTaskStage.html
@@ -37,6 +37,13 @@
     </div>
   </div>
 
+  <div class="checkbox col-md-offset-1">
+    <label>
+      <input type="checkbox" ng-model="stage.canary.canaryConfig.continueOnUnhealthy"/>
+      <b>Continue on Unhealthy</b>
+      <help-field key="pipeline.config.canary.continueOnUnhealthy"></help-field>
+    </label>
+  </div>
 
   <h5>Analysis Config</h5>
 


### PR DESCRIPTION
This allows pipeline to continue if the canary comes back unhealthy.
Candmium requested this feature b/c they want to put ad a manual judgement after the ACA task stage.

- Aslo fixes long baseline and canary strings from blowing out of their boundries on the ACA task summary view.
- Fixes the link back to the RTA ACA configuration page.

@anotherchrisberry PTAL

NOTE: Do not merge until downstream ORCA changes are in place.