### PR TITLE
Adds link to Expression Docs on text inputs

### DIFF
--- a/app/scripts/modules/core/widgets/index.js
+++ b/app/scripts/modules/core/widgets/index.js
@@ -8,4 +8,5 @@ module.exports = angular
     require('./accountRegionClusterSelector.component'),
     require('./scopeClusterSelector.directive'),
     require('./notifier/notifier.component.js'),
+    require('./spelText/spelText.decorator'),
   ]);

--- a/app/scripts/modules/core/widgets/spelText/spel.less
+++ b/app/scripts/modules/core/widgets/spelText/spel.less
@@ -1,0 +1,14 @@
+a.spelLink {
+  margin-left: 10px;
+  animation: fadein 1s;
+}
+
+@keyframes fade-in {
+  from { opacity: 0}
+  to {opacity: 1}
+}
+
+@-webkit-keyframes fade-in {
+  from { opacity: 0}
+  to {opacity: 1}
+}

--- a/app/scripts/modules/core/widgets/spelText/spelText.decorator.js
+++ b/app/scripts/modules/core/widgets/spelText/spelText.decorator.js
@@ -1,0 +1,42 @@
+'use strict';
+
+let angular = require('angular');
+require('./spel.less');
+
+let decorateFn = function ($delegate) {
+  var directive = $delegate[0];
+
+  var link = directive.link.pre;
+
+  directive.compile = function () {
+    return function (scope, el) {
+
+      link.apply(this, arguments);
+      function listener (evt) {
+        let hasSpelPrefix = evt.target.value.indexOf('${') > -1;
+        let hasLink = el.nextAll('.spelLink');
+        if (hasSpelPrefix) {
+          if (hasLink.length < 1) {
+            el.after('<a class="spelLink" href="http://www.spinnaker.io/docs/pipeline-expressions-guide" target="_blank">Expression Docs</a>');
+          }
+        } else {
+          hasLink.fadeOut( 500, function() { this.remove(); });
+        }
+      }
+
+      el.bind('keyup', listener);
+    };
+  };
+
+  return $delegate;
+};
+
+
+module.exports = angular
+  .module('spinnaker.core.widget.spelText', [])
+  .config( function($provide) {
+    $provide.decorator('inputDirective', decorateFn);
+    $provide.decorator('textareaDirective', decorateFn);
+  });
+
+


### PR DESCRIPTION
Decorates the input and textarea directives and detects if the user starts typing a SpEL in the fields (looks for the '${' string).  If detected, it injects a link to the spinnaker.io documentation under the text field.

If the SpEL is removed so is the link.

@anotherchrisberry PTAL