### PR TITLE
Fixes SPIN-1772

### DIFF
--- a/app/scripts/modules/core/serverGroup/configure/common/basicSettingsMixin.controller.js
+++ b/app/scripts/modules/core/serverGroup/configure/common/basicSettingsMixin.controller.js
@@ -64,8 +64,8 @@ module.exports = angular
     this.stackPattern = {
       test: function(stack) {
         var pattern = $scope.command.viewState.templatingEnabled ?
-          /^([a-zA-Z_0-9._]*(\${.+})*)*$/ :
-          /^[a-zA-Z_0-9._]*$/;
+          /^([a-zA-Z_0-9._${}]*(\${.+})*)*$/ :
+          /^[a-zA-Z_0-9._${}]*$/;
         return pattern.test(stack);
       }
     };
@@ -73,8 +73,8 @@ module.exports = angular
     this.detailPattern = {
       test: function(detail) {
         var pattern = $scope.command.viewState.templatingEnabled ?
-          /^([a-zA-Z_0-9._-]*(\${.+})*)*$/ :
-          /^[a-zA-Z_0-9._-]*$/;
+          /^([a-zA-Z_0-9._${}-]*(\${.+})*)*$/ :
+          /^[a-zA-Z_0-9._${}-]*$/;
         return pattern.test(detail);
       }
     };

--- a/app/scripts/modules/core/serverGroup/configure/common/basicSettingsMixin.controller.spec.js
+++ b/app/scripts/modules/core/serverGroup/configure/common/basicSettingsMixin.controller.spec.js
@@ -42,9 +42,9 @@ describe('Basic Settings Mixin Controller:', function () {
       expect(test('-a')).toBe(false);
       expect(test('a-')).toBe(false);
       expect(test('-')).toBe(false);
-      expect(test('$')).toBe(false);
+      expect(test('$')).toBe(true);
       expect(test('9*')).toBe(false);
-      expect(test('${a}')).toBe(false);
+      expect(test('${a}')).toBe(true);
     });
 
     it('detail should accept underscores, letters, numbers, dashes, and nothing', function() {
@@ -63,11 +63,11 @@ describe('Basic Settings Mixin Controller:', function () {
 
     it('detail should fail on various special characters', function () {
       var test = controller.detailPattern.test;
-      expect(test('$')).toBe(false);
+      expect(test('$')).toBe(true);
       expect(test('9*')).toBe(false);
       expect(test('#9')).toBe(false);
       expect(test('1@9')).toBe(false);
-      expect(test('${a}')).toBe(false);
+      expect(test('${a}')).toBe(true);
     });
   });
 


### PR DESCRIPTION
Adjusting validation regexes to allow $, {, and } chararacters for the stack and details fields.