### PR TITLE
Fixes SPIN-1797

### DIFF
--- a/app/scripts/modules/amazon/vpc/vpcTag.directive.js
+++ b/app/scripts/modules/amazon/vpc/vpcTag.directive.js
@@ -11,12 +11,13 @@ module.exports = angular.module('spinnaker.vpc.tag.directive', [
       scope: {
         vpcId: '=',
       },
-      template: '<span class="vpc-tag">{{vpcLabel}}</span>',
+      template: `
+        <span ng-if="!vpcId" class="loader"></span>
+        <span ng-if="vpcId" class="vpc-tag">{{vpcLabel}}</span>
+        `,
       link: function(scope) {
         function applyLabel() {
-          if (!scope.vpcId) {
-            scope.vpcLabel = 'None (EC2 Classic)';
-          } else {
+          if (scope.vpcId) {
             vpcReader.getVpcName(scope.vpcId).then(function (name) {
               scope.vpcLabel = '(' + scope.vpcId + ')';
 

--- a/app/scripts/modules/amazon/vpc/vpcTag.directive.spec.js
+++ b/app/scripts/modules/amazon/vpc/vpcTag.directive.spec.js
@@ -23,20 +23,22 @@ describe('Directives: vpcTag', function () {
     it('displays default message when no vpcId supplied', function () {
       var domNode = this.compile('<vpc-tag></vpc-tag>')(this.scope);
       this.scope.$digest();
-      expect(domNode.find('span').text()).toBe('None (EC2 Classic)');
+      // expect(domNode.find('span').text()).toBe('None (EC2 Classic)');
+      expect(domNode.find('span').hasClass('loader')).toBe(true);
+
     });
 
     it('displays default message when undefined vpcId supplied', function () {
       var domNode = this.compile('<vpc-tag vpc-id="notDefined"></vpc-tag>')(this.scope);
       this.scope.$digest();
-      expect(domNode.find('span').text()).toBe('None (EC2 Classic)');
+      expect(domNode.find('span').hasClass('loader')).toBe(true);
     });
 
     it('displays default message when null vpcId supplied', function () {
       this.scope.vpcId = null;
       var domNode = this.compile('<vpc-tag vpc-id="vpcId"></vpc-tag>')(this.scope);
       this.scope.$digest();
-      expect(domNode.find('span').text()).toBe('None (EC2 Classic)');
+      expect(domNode.find('span').hasClass('loader')).toBe(true);
     });
   });
 


### PR DESCRIPTION
Initial load of the vpcTag was showing "EC2 Classic" as it's label if the vpc data was not pulled down.  Once it was loaded the correct subnet would show.  This was leading to some confusion to users who had recently upgraded to VPC0.

Removed the default "EC2 (Classic)" label and replaced with a spinner.