### PR TITLE
Fixes SPIN-1772 Promise-ifying all the things.

### DIFF
--- a/app/scripts/modules/amazon/serverGroup/details/serverGroupDetails.aws.controller.spec.js
+++ b/app/scripts/modules/amazon/serverGroup/details/serverGroupDetails.aws.controller.spec.js
@@ -12,9 +12,11 @@ describe('Controller: AWS ServerGroupDetailsCtrl', function () {
   );
 
   beforeEach(
-    window.inject( function($controller, $rootScope, applicationReader) {
+    window.inject( function($controller, $q, $rootScope, applicationReader) {
       $scope = $rootScope.$new();
-      let application = {};
+      let application = {
+        ready: () => $q.when(1)
+      };
       applicationReader.addSectionToApplication({key: 'serverGroups', lazy: true}, application);
       applicationReader.addSectionToApplication({key: 'loadBalancers', lazy: true}, application);
       controller = $controller('awsServerGroupDetailsCtrl', {


### PR DESCRIPTION
On initial load of the application the code would attempt to read from the application severGropus before they were loaded causing some asg detail info to go missing (i.e. vpcId)

 This was causing the vpcId not to be bound to the asg details on load and in turn display "None (EC2 Classic)" in the VPC field for ASGs that where in vpc0.

 This changes leverages the app.ready() promise to verify that all the apps bits are in place before we read them.

 @anotherchrisberry PTAL