### PR TITLE
Travis support for deck

### DIFF
--- a/app/scripts/modules/amazon/serverGroup/details/serverGroupDetails.aws.controller.js
+++ b/app/scripts/modules/amazon/serverGroup/details/serverGroupDetails.aws.controller.js
@@ -376,7 +376,9 @@ module.exports = angular.module('spinnaker.serverGroup.details.aws.controller', 
     };
 
     this.buildJenkinsLink = () => {
-      if (this.serverGroup && this.serverGroup.buildInfo && this.serverGroup.buildInfo.jenkins) {
+      if (this.serverGroup && this.serverGroup.buildInfo && this.serverGroup.buildInfo.buildInfoUrl) {
+        return this.serverGroup.buildInfo.buildInfoUrl;
+      } else if (this.serverGroup && this.serverGroup.buildInfo && this.serverGroup.buildInfo.jenkins) {
         var jenkins = this.serverGroup.buildInfo.jenkins;
         return jenkins.host + 'job/' + jenkins.name + '/' + jenkins.number;
       }

--- a/app/scripts/modules/core/serverGroup/serverGroup.directive.js
+++ b/app/scripts/modules/core/serverGroup/serverGroup.directive.js
@@ -46,7 +46,7 @@ module.exports = angular.module('spinnaker.core.serverGroup.serverGroup.directiv
           };
 
           if (serverGroup.buildInfo && serverGroup.buildInfo.jenkins &&
-              (serverGroup.buildInfo.jenkins.host || serverGroup.buildInfo.jenkins.fullUrl)) {
+              (serverGroup.buildInfo.jenkins.host || serverGroup.buildInfo.jenkins.fullUrl || serverGroup.buildInfo.buildInfoUrl)) {
             var jenkins = serverGroup.buildInfo.jenkins;
 
             viewModel.jenkins = {
@@ -58,6 +58,9 @@ module.exports = angular.module('spinnaker.core.serverGroup.serverGroup.directiv
             }
             if (serverGroup.buildInfo.jenkins.fullUrl) {
               viewModel.jenkins.href = serverGroup.buildInfo.jenkins.fullUrl;
+            }
+            if (serverGroup.buildInfo.buildInfoUrl) {
+              viewModel.jenkins.href = serverGroup.buildInfo.buildInfoUrl;
             }
           }
 


### PR DESCRIPTION
Part of a series of PR adding build info support for travis integration on AWS
by adding new build_info_url tag to the images in order to be able to full fill the build info correctly for travis.

This PR checks if the build_info_url is present and uses it as ci link

This is the final result
![screen shot 2016-06-02 at 10 11 01](https://cloud.githubusercontent.com/assets/10425379/15742610/54ebb480-28c0-11e6-9492-bf270072b4fb.png)

Related PRs
spinnaker/orca#856
spinnaker/rosco#102
https://github.com/spinnaker/clouddriver/pull/652
