### PR TITLE
Bumping the font size down 1px for the details h3 tag

### DIFF
--- a/app/scripts/modules/core/presentation/details.less
+++ b/app/scripts/modules/core/presentation/details.less
@@ -109,7 +109,7 @@
         padding: 0;
         font-weight: 600;
         line-height: 1;
-        font-size: 20px;
+        font-size: 19px;
       }
     }
     .actions {


### PR DESCRIPTION
This is prevent the new longer instance ids from wrapping in the header.