### PR TITLE
Support for adding Webhook triggers to the Deck UI.

### DIFF
--- a/app/scripts/modules/core/help/helpContents.js
+++ b/app/scripts/modules/core/help/helpContents.js
@@ -230,6 +230,11 @@ module.exports = angular.module('spinnaker.core.help.contents', [])
     '<p><strong>Example: every Monday at 10 am</strong></p><samp>0 0 10 ? * 2</samp>' +
     '<p><strong>Note:</strong> values for "DayOfWeek" are 1-7, where Sunday is 1, Monday is 2, etc. You can also use MON,TUE,WED, etc.',
 
+    'pipeline.config.webhook.constraints': '<p><strong>Constraints</strong> are keys (and optionally values) that must be in the webhook payload for this trigger to start a pipeline.' +
+      '<p>If only a constraint key is populated, then this field name must be present but the value can be any string (including an empty string)' +
+      '<p>If both key and value are populated, then both must match the payload in the webhook for the pipeline to start.' +
+      '<br>Example:<br>&nbsp;&nbsp;&nbsp;Key: &nbsp;projectName<br>&nbsp;&nbsp;&nbsp Value: &nbsp; myProject',
+
     'cluster.description': '<p>A cluster is a collection of server groups with the same name (stack + detail) in the same account.</p>',
     'pipeline.config.findAmi.cluster': 'The cluster to look at when selecting the image to use in this pipeline.',
     'pipeline.config.findAmi.imageNamePattern': 'A regex used to match the name of the image. Must result in exactly one match to succeed. Empty is treated as match any.',

--- a/app/scripts/modules/core/pipeline/config/triggers/trigger.module.js
+++ b/app/scripts/modules/core/pipeline/config/triggers/trigger.module.js
@@ -9,6 +9,7 @@ module.exports = angular.module('spinnaker.core.pipeline.config.trigger', [
     require('./git/gitTrigger.module.js'),
     require('./jenkins/jenkinsTrigger.module.js'),
     require('./pipeline/pipelineTrigger.module.js'),
+    require('./webhook/webhookTrigger.module.js'),
     require('./trigger.directive.js'),
     require('./triggers.directive.js'),
   ]);

--- a/app/scripts/modules/core/pipeline/config/triggers/webhook/webhookPopoverLabel.html
+++ b/app/scripts/modules/core/pipeline/config/triggers/webhook/webhookPopoverLabel.html
@@ -1,0 +1,3 @@
+<div>
+  <strong>Webhook Source:</strong> {{trigger.source}}
+</div>

--- a/app/scripts/modules/core/pipeline/config/triggers/webhook/webhookTrigger.html
+++ b/app/scripts/modules/core/pipeline/config/triggers/webhook/webhookTrigger.html
@@ -1,0 +1,30 @@
+<ng-form name="webhookForm">
+
+    <div class="row">
+      <div class="col-md-3 sm-label-right">
+        Webhook URL
+      </div>
+      <div class="col-md-6">{{vm.endpointUrl}}</div>
+    </div>
+
+    <div class="form-group row">
+      <label class="col-md-3 sm-label-right">
+        <b>Constraints</b>
+        <help-field key="pipeline.config.webhook.constraints"></help-field>
+      </label>
+      <div class="col-sm-9">
+        <map-editor model="trigger.constraints" add-button-label="Add New Constraint" allow-empty="true" on-change="vm.updateExamplePayload()"></map-editor>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-md-3 sm-label-right">
+        Example Webhook Payload
+      </div>
+      <div class="col-sm-9">
+        <pre>{{examplePayload | json}}</pre>
+      </div>
+    </div>
+
+</ng-form>
+

--- a/app/scripts/modules/core/pipeline/config/triggers/webhook/webhookTrigger.module.js
+++ b/app/scripts/modules/core/pipeline/config/triggers/webhook/webhookTrigger.module.js
@@ -1,0 +1,36 @@
+'use strict';
+
+let angular = require('angular');
+
+module.exports = angular.module('spinnaker.core.pipeline.trigger.webhook', [
+    require('../../../../../core/config/settings.js'),
+  ])
+  .config(function (pipelineConfigProvider) {
+    pipelineConfigProvider.registerTrigger({
+      label: 'Webhook',
+      description: 'Executes the pipeline on a Webhook POST',
+      key: 'webhook',
+      controller: 'WebhookTriggerCtrl',
+      controllerAs: 'vm',
+      templateUrl: require('./webhookTrigger.html'),
+      popoverLabelUrl: require('./webhookPopoverLabel.html'),
+    });
+  })
+  .controller('WebhookTriggerCtrl', function (trigger, $scope, settings) {
+
+    this.endpointUrl = [settings.gateUrl, 'webhooks', 'webhook'].join('/');
+    $scope.trigger = trigger;
+
+    /* If this is a new trigger and constraints have not been set
+        yet, create a map to hold them in and initialise it with
+        application and pipeline names. */
+    $scope.trigger.constraints = $scope.trigger.constraints || {
+      application: $scope.application.name,
+      pipeline: $scope.pipeline.name
+    };
+
+    this.updateExamplePayload = () => $scope.examplePayload = angular.copy($scope.trigger.constraints);
+
+    this.updateExamplePayload();
+
+  });

--- a/settings.js
+++ b/settings.js
@@ -76,7 +76,7 @@ window.spinnakerSettings = {
   },
   authEnabled: process.env.AUTH === 'enabled',
   gitSources: ['stash', 'github'],
-  triggerTypes: ['git', 'pipeline', 'docker', 'cron', 'jenkins'],
+  triggerTypes: ['git', 'pipeline', 'docker', 'cron', 'jenkins', 'webhook'],
   feature: {
     pipelines: true,
     notifications: false,


### PR DESCRIPTION
- Can choose Webhook from trigger list.
- Determines URL of webhook endpoint in Gate.
- Provides ability to configure constraints which must match the payload content.

Superceeds PR #2214 