### PR TITLE
hold non-auth calls when auth is expired

### DIFF
--- a/app/scripts/modules/core/authentication/authentication.initializer.service.js
+++ b/app/scripts/modules/core/authentication/authentication.initializer.service.js
@@ -41,6 +41,7 @@ module.exports = angular.module('spinnaker.authentication.initializer.service', 
     }
 
     function loginNotification() {
+      authenticationService.authenticationExpired();
       userLoggedOut = true;
       notifierService.publish(`You have been logged out. <a role="button" class="action" onclick="document.location.reload()">Log in</a>`);
     }

--- a/app/scripts/modules/core/authentication/authentication.service.js
+++ b/app/scripts/modules/core/authentication/authentication.service.js
@@ -30,10 +30,15 @@ module.exports = angular.module('spinnaker.authentication.service', [
     function onAuthentication(event) {
       onAuthenticationEvents.push(event);
     }
+    
+    function authenticationExpired() {
+      user.authenticated = false;
+    }
 
     return {
       setAuthenticatedUser: setAuthenticatedUser,
       getAuthenticatedUser: getAuthenticatedUser,
       onAuthentication: onAuthentication,
+      authenticationExpired: authenticationExpired,
     };
   });


### PR DESCRIPTION
Once authentication has expired, we should stop sending requests to gate, since they're just going to start the redirect-to-auth process.

We already do this before the user has been authenticated, so we just need to return the user object to that same state by setting the `authenticated` flag to false.