### PR TITLE
fix scheduler; hold requests when auth is expired

### DIFF
--- a/app/scripts/modules/core/authentication/authentication.interceptor.service.js
+++ b/app/scripts/modules/core/authentication/authentication.interceptor.service.js
@@ -15,12 +15,12 @@ module.exports = angular.module('spinnaker.authentication.interceptor.service', 
         if (config.url === settings.authEndpoint || config.url.indexOf('http') !== 0) {
           deferred.resolve(config);
         } else {
-          if (authenticationService.getAuthenticatedUser().authenticated) {
+          let user = authenticationService.getAuthenticatedUser();
+          // only send the request if the user has authenticated within the refresh window for auth calls
+          if (user.authenticated && user.lastAuthenticated + (settings.authTtl || 600000) > new Date().getTime()) {
             deferred.resolve(config);
           } else {
-            authenticationService.onAuthentication(function () {
-              deferred.resolve(config);
-            });
+            authenticationService.onAuthentication(() => deferred.resolve(config));
           }
         }
         return deferred.promise;

--- a/app/scripts/modules/core/authentication/authentication.interceptor.spec.js
+++ b/app/scripts/modules/core/authentication/authentication.interceptor.spec.js
@@ -68,7 +68,7 @@ describe('authenticationInterceptor', function() {
       var resolved = null;
       var request = { url: 'http://some-server.spinnaker.org' };
 
-      spyOn(authenticationService, 'getAuthenticatedUser').and.returnValue({ authenticated: true });
+      spyOn(authenticationService, 'getAuthenticatedUser').and.returnValue({ authenticated: true, lastAuthenticated: new Date().getTime() });
 
       interceptor.request(request).then(function(result) { resolved = result; });
       $rootScope.$digest();

--- a/app/scripts/modules/core/authentication/authentication.module.js
+++ b/app/scripts/modules/core/authentication/authentication.module.js
@@ -16,7 +16,7 @@ module.exports = angular.module('spinnaker.authentication', [
   .run(function (schedulerFactory, authenticationInitializer, settings) {
     if (settings.authEnabled) {
       // schedule deck to re-authenticate every 10 min.
-      schedulerFactory.createScheduler(600000).subscribe(authenticationInitializer.reauthenticateUser);
+      schedulerFactory.createScheduler(settings.authTtl || 600000).subscribe(authenticationInitializer.reauthenticateUser);
       authenticationInitializer.authenticateUser();
     }
   })

--- a/app/scripts/modules/core/authentication/authentication.service.js
+++ b/app/scripts/modules/core/authentication/authentication.service.js
@@ -17,6 +17,7 @@ module.exports = angular.module('spinnaker.authentication.service', [
       if (authenticatedUser) {
         user.name = authenticatedUser;
         user.authenticated = true;
+        user.lastAuthenticated = new Date().getTime();
       }
       onAuthenticationEvents.forEach(function(event) {
         event();

--- a/settings.js
+++ b/settings.js
@@ -75,6 +75,7 @@ window.spinnakerSettings = {
     }
   },
   authEnabled: process.env.AUTH === 'enabled',
+  authTtl: 600000,
   gitSources: ['stash', 'github'],
   triggerTypes: ['git', 'pipeline', 'docker', 'cron', 'jenkins'],
   feature: {


### PR DESCRIPTION
At some point, `pausable` seems to have stopped working altogether - at least the `pause` call has stopped `paus`ing requests, which is the whole point of using `pausable`. It's not hard to mimic the `pause`/`resume` behavior with a local variable, so there.

That's part 1. Part 2 holds pending http requests when the user authentication is older than the refresh window. This should hold calls whenever the authentication check is happening, then allow them through when authentication is successful.

@zanthrash PTAL