### PR TITLE
allow user to show stage durations

### DIFF
--- a/app/scripts/modules/core/delivery/executionGroup/execution/execution.directive.html
+++ b/app/scripts/modules/core/delivery/executionGroup/execution/execution.directive.html
@@ -5,16 +5,18 @@
                     standalone="vm.standalone">
   </execution-status>
   <div class="execution-bar">
-    <div class="stages">
+    <div class="stages" ng-class="{'show-durations': vm.sortFilter.showStageDuration}">
       <div ng-repeat="stage in vm.execution.stageSummaries"
-           class="clickable stage stage-type-{{stage.type.toLowerCase()}}
-                  execution-marker execution-marker-{{stage.status.toLowerCase()}}
-                  {{vm.isActive($index) ? 'active' : ''}} {{stage.isRunning ? 'glowing' : ''}}"
+           class="clickable stage stage-type-{{::stage.type.toLowerCase()}}
+                  execution-marker execution-marker-{{::stage.status.toLowerCase()}}
+                  {{stage.isRunning ? 'glowing' : ''}}"
            ng-style="{width: 100/vm.execution.stageSummaries.length + '%', 'background-color': stage.color}"
            uib-tooltip-template="stage.labelTemplateUrl"
            tooltip-title="(Click for details)"
            tooltip-placement="bottom"
-           ng-click="vm.toggleDetails({executionId: vm.execution.id, index: $index})"></div>
+           ng-click="vm.toggleDetails({executionId: vm.execution.id, index: $index})">
+        <span class="duration">{{::stage.runningTimeInMs | duration}}</span>
+      </div>
       <div ng-if="!vm.execution.stageSummaries.length" class="text-center">
         No stages found.
         <a target="_blank" ng-href="{{vm.pipelinesUrl + vm.execution.id}}">Source</a>

--- a/app/scripts/modules/core/delivery/executionGroup/execution/execution.directive.js
+++ b/app/scripts/modules/core/delivery/executionGroup/execution/execution.directive.js
@@ -75,7 +75,10 @@ module.exports = angular
       canTriggerPipelineManually: this.pipelineConfig,
       canConfigure: this.pipelineConfig,
       showPipelineName: ExecutionFilterModel.sortFilter.groupBy !== 'name',
+      showStageDuration: ExecutionFilterModel.sortFilter.showStageDuration,
     };
+
+    this.sortFilter = ExecutionFilterModel.sortFilter;
 
     this.deleteExecution = () => {
       confirmationModalService.confirm({

--- a/app/scripts/modules/core/delivery/executionGroup/execution/execution.less
+++ b/app/scripts/modules/core/delivery/executionGroup/execution/execution.less
@@ -88,14 +88,38 @@ execution-status {
   width: calc(~"100% - 235px");
   vertical-align: top;
   padding-top: 20px;
+  .stages {
+    .duration {
+      font-weight: 600;
+      padding-top: 1px;
+      display: inline-block;
+      visibility: hidden;
+    }
+    &.show-durations {
+      .stage {
+        .duration {
+          visibility: visible;
+        }
+        border-left-color: #222222;
+      }
+    }
+  }
   .stage {
     margin-top: 0;
     display: inline-block;
     height: 20px;
     opacity: 0.65;
     transition: 0.2s all;
+    text-align: center;
+    padding: 0 10px;
+    color: #000000;
+    font-size: 90%;
+    border-left: 1px solid transparent;
     &:hover, &.active {
       opacity: 1;
+    }
+    &:first-child {
+      border-left-width: 0;
     }
     &.active {
       border: 1px solid @dark_grey;

--- a/app/scripts/modules/core/delivery/executions/executions.html
+++ b/app/scripts/modules/core/delivery/executions/executions.html
@@ -42,6 +42,12 @@
           </select>
           executions per pipeline
         </div>
+        <div class="form-group checkbox">
+          <label>
+            <input type="checkbox" ng-model="vm.filter.showStageDuration">
+            stage durations
+          </label>
+        </div>
         <div class="form-group pull-right">
           <a href class="btn btn-sm btn-primary"
              ng-click="vm.triggerPipeline()"

--- a/app/scripts/modules/core/delivery/executions/executions.less
+++ b/app/scripts/modules/core/delivery/executions/executions.less
@@ -16,6 +16,9 @@ executions {
     .form-group {
       margin-right: 20px;
     }
+    .checkbox {
+      height: 24px;
+    }
   }
 }
 

--- a/app/scripts/modules/core/delivery/filter/executionFilter.model.js
+++ b/app/scripts/modules/core/delivery/filter/executionFilter.model.js
@@ -21,12 +21,13 @@ module.exports = angular
 
     function getCachedViewState() {
       let cached = configViewStateCache.get('#global') || {},
-          defaults = { count: 2, groupBy: 'name' };
+          defaults = { count: 2, groupBy: 'name', showDurations: false };
       return angular.extend(defaults, cached);
     }
 
     var groupCount = getCachedViewState().count;
     var groupBy = getCachedViewState().groupBy;
+    var showDurations = getCachedViewState().showDurations;
 
     this.mostRecentApplication = null;
 
@@ -39,7 +40,7 @@ module.exports = angular
     filterModelService.configureFilterModel(this, filterModelConfig);
 
     function cacheConfigViewState() {
-      configViewStateCache.put('#global', { count: groupCount, groupBy: groupBy });
+      configViewStateCache.put('#global', { count: groupCount, groupBy: groupBy, showDurations: showDurations });
     }
 
     // A nice way to avoid watches is to define a property on an object
@@ -59,6 +60,16 @@ module.exports = angular
       },
       set: function(grouping) {
         groupBy = grouping;
+        cacheConfigViewState();
+      }
+    });
+
+    Object.defineProperty(this.sortFilter, 'showDurations', {
+      get: function() {
+        return groupCount;
+      },
+      set: function(count) {
+        groupCount = count;
         cacheConfigViewState();
       }
     });


### PR DESCRIPTION
Adds a checkbox to the top of the page to allow users to see how long each stage took.

Unselected (current behavior):
<img width="1101" alt="screen shot 2016-06-04 at 12 03 19 am" src="https://cloud.githubusercontent.com/assets/73450/15798262/c828e558-29e7-11e6-8de6-68465ce359ab.png">

Selected:
<img width="1100" alt="screen shot 2016-06-04 at 12 03 10 am" src="https://cloud.githubusercontent.com/assets/73450/15798264/cd1221c4-29e7-11e6-9b15-e48ffd8ffd5a.png">

