### PR TITLE
(core) customizable default port, instance links

### DIFF
--- a/app/scripts/modules/amazon/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/amazon/instance/details/instance.details.controller.js
@@ -15,6 +15,7 @@ module.exports = angular.module('spinnaker.instance.detail.aws.controller', [
   require('../../../core/utils/selectOnDblClick.directive.js'),
   require('../../../core/config/settings.js'),
   require('../../../core/cloudProvider/cloudProvider.registry.js'),
+  require('../../../core/instance/details/instanceLinks.component'),
 ])
   .controller('awsInstanceDetailsCtrl', function ($scope, $state, $uibModal, InsightFilterStateModel, settings,
                                                instanceWriter, confirmationModalService, recentHistoryService,
@@ -27,9 +28,11 @@ module.exports = angular.module('spinnaker.instance.detail.aws.controller', [
     $scope.state = {
       loading: true,
       standalone: app.isStandalone,
+      instancePort: app.attributes.instancePort || settings.defaultInstancePort || 80,
     };
 
     $scope.InsightFilterStateModel = InsightFilterStateModel;
+    $scope.application = app;
 
     function extractHealthMetrics(instance, latest) {
       // do not backfill on standalone instances

--- a/app/scripts/modules/amazon/instance/details/instance.details.controller.spec.js
+++ b/app/scripts/modules/amazon/instance/details/instance.details.controller.spec.js
@@ -54,7 +54,7 @@ describe('Controller: awsInstanceDetailsCtrl', function () {
           }
         })
       );
-      var application = {};
+      var application = { attributes: {} };
 
       applicationReader.addSectionToApplication({key: 'loadBalancers', lazy: true}, application);
       application.loadBalancers.data = [];
@@ -102,7 +102,7 @@ describe('Controller: awsInstanceDetailsCtrl', function () {
         })
       );
 
-      var application = {};
+      var application = { attributes: {} };
 
       applicationReader.addSectionToApplication({key: 'loadBalancers', lazy: true}, application);
       application.loadBalancers.data = [];

--- a/app/scripts/modules/amazon/instance/details/instanceDetails.html
+++ b/app/scripts/modules/amazon/instance/details/instanceDetails.html
@@ -116,7 +116,7 @@
       <dl ng-class="InsightFilterStateModel.filtersExpanded ? '' : 'dl-horizontal'">
         <dt ng-if="instance.privateDnsName">Private DNS Name</dt>
         <dd ng-if="instance.privateDnsName">
-          <a href="http://{{instance.privateDnsName}}:7001" target="_blank">{{instance.privateDnsName}}</a>
+          <a href="http://{{instance.privateDnsName}}:{{state.instancePort}}" target="_blank">{{instance.privateDnsName}}</a>
           <copy-to-clipboard
               class="copy-to-clipboard copy-to-clipboard-sm"
               text="{{instance.privateDnsName}}"
@@ -125,7 +125,7 @@
         </dd>
         <dt ng-if="instance.publicDnsName">Public DNS Name</dt>
         <dd ng-if="instance.publicDnsName">
-          <a href="http://{{instance.publicDnsName}}:7001" target="_blank">{{instance.publicDnsName}}</a>
+          <a href="http://{{instance.publicDnsName}}:{{state.instancePort}}" target="_blank">{{instance.publicDnsName}}</a>
           <copy-to-clipboard
               class="copy-to-clipboard copy-to-clipboard-sm"
               text="{{instance.publicDnsName}}"
@@ -134,7 +134,7 @@
         </dd>
         <dt ng-if="instance.privateIpAddress">Private IP Address</dt>
         <dd ng-if="instance.privateIpAddress">
-          <a href="http://{{instance.privateIpAddress}}:7001" target="_blank">{{instance.privateIpAddress}}</a>
+          <a href="http://{{instance.privateIpAddress}}:{{state.instancePort}}" target="_blank">{{instance.privateIpAddress}}</a>
           <copy-to-clipboard
               class="copy-to-clipboard copy-to-clipboard-sm"
               text="{{instance.privateIpAddress}}"
@@ -143,7 +143,7 @@
         </dd>
         <dt ng-if="instance.publicIpAddress">Public IP Address</dt>
         <dd ng-if="instance.publicIpAddress">
-          <a href="http://{{instance.publicIpAddress}}:7001" target="_blank">{{instance.publicIpAddress}}</a>
+          <a href="http://{{instance.publicIpAddress}}:{{state.instancePort}}" target="_blank">{{instance.publicIpAddress}}</a>
           <copy-to-clipboard
               class="copy-to-clipboard copy-to-clipboard-sm"
               text="{{instance.publicIpAddress}}"
@@ -168,12 +168,13 @@
         <dd ng-repeat-end>{{tag.value}}</dd>
       </dl>
     </collapsible-section>
-    <collapsible-section heading="Logs" ng-if="baseIpAddress">
+    <collapsible-section heading="Console Output" ng-if="baseIpAddress">
       <ul>
         <li>
           <console-output-link instance="instance"></console-output-link>
         </li>
       </ul>
     </collapsible-section>
+    <instance-links address="baseIpAddress" application="application" instance="instance"></instance-links>
   </div>
 </div>

--- a/app/scripts/modules/cloudfoundry/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/cloudfoundry/instance/details/instance.details.controller.js
@@ -13,6 +13,7 @@ module.exports = angular.module('spinnaker.instance.detail.cf.controller', [
   require('../../../core/history/recentHistory.service.js'),
   require('../../../core/utils/selectOnDblClick.directive.js'),
   require('../../../core/cloudProvider/cloudProvider.registry.js'),
+  require('../../../core/instance/details/instanceLinks.component'),
 ])
   .controller('cfInstanceDetailsCtrl', function ($scope, $q, $state, $uibModal, InsightFilterStateModel,
                                                  instanceWriter, confirmationModalService, recentHistoryService,
@@ -26,6 +27,7 @@ module.exports = angular.module('spinnaker.instance.detail.cf.controller', [
       standalone: app.isStandalone,
     };
 
+    $scope.application = app;
     $scope.InsightFilterStateModel = InsightFilterStateModel;
 
     function extractHealthMetrics(instance, latest) {

--- a/app/scripts/modules/cloudfoundry/instance/details/instanceDetails.html
+++ b/app/scripts/modules/cloudfoundry/instance/details/instanceDetails.html
@@ -143,21 +143,6 @@
         </li>
       </ul>
     </collapsible-section>
-    <collapsible-section heading="Netflix Configuration" ng-if="baseIpAddress">
-      <ul>
-        <li>
-          <a href="http://{{baseIpAddress}}:8077/baseserver#view=props" target="_blank">Properties Console</a>
-        </li>
-        <li>
-          <a href="http://{{baseIpAddress}}:8077/baseserver#view=jars" target="_blank">Libraries Console</a>
-        </li>
-        <li>
-          <a href="http://{{baseIpAddress}}:8077/AdminNetflixConfiguration/machineReadableProps" target="_blank">Machine Readable Properties</a>
-        </li>
-        <li>
-          <a href="http://{{baseIpAddress}}:8077/AdminNetflixConfiguration/webapp/META-INF/MANIFEST.MF" target="_blank">Manifest</a>
-        </li>
-      </ul>
-    </collapsible-section>
+    <instance-links address="baseIpAddress" application="application" instance="instance"></instance-links>
   </div>
 </div>

--- a/app/scripts/modules/core/application/config/applicationConfig.controller.js
+++ b/app/scripts/modules/core/application/config/applicationConfig.controller.js
@@ -9,6 +9,7 @@ module.exports = angular
     require('./applicationNotifications.directive.js'),
     require('./applicationCacheManagement.directive.js'),
     require('./deleteApplicationSection.directive.js'),
+    require('./applicationLinks.component.js'),
   ])
   .controller('ApplicationConfigController', function ($state, app) {
     this.application = app;

--- a/app/scripts/modules/core/application/config/applicationConfig.view.html
+++ b/app/scripts/modules/core/application/config/applicationConfig.view.html
@@ -1,6 +1,7 @@
 <div class="container">
   <application-attributes application="config.application"></application-attributes>
   <application-notifications application="config.application" notifications="config.notifications"></application-notifications>
+  <application-links application="config.application"></application-links>
   <application-cache-management application="config.application"></application-cache-management>
   <delete-application-section application="config.application"></delete-application-section>
 </div>

--- a/app/scripts/modules/core/application/config/applicationLinks.component.html
+++ b/app/scripts/modules/core/application/config/applicationLinks.component.html
@@ -1,0 +1,89 @@
+<div class="row">
+  <div class="col-md-7">
+    <h4>Instance Links</h4>
+    <div class="panel panel-default">
+      <div class="panel-body">
+        <p>Links appear in the instance details panel and provide a shortcut to common features,
+          such as logs, health, etc.</p>
+
+        <div ng-repeat="section in $ctrl.sections" style="margin-top: 10px">
+          <div class="row">
+            <div class="col-md-3 sm-label-right">Section heading</div>
+            <div class="col-md-9">
+              <div class="row">
+                <div class="col-md-4" style="padding-right: 0">
+                  <input type="text" class="form-control input" ng-model="section.title" ng-change="$ctrl.configChanged()"/>
+                </div>
+                <div class="col-md-2 col-md-offset-6" style="padding: 5px 0">
+                  <a href ng-click="$ctrl.removeSection($index)" uib-tooltip="Remove section">
+                    <span class="glyphicon glyphicon-trash"></span>
+                  </a>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="row" style="margin-top: 10px">
+            <div class="col-md-3 sm-label-right">Links</div>
+            <div class="col-md-9">
+              <div class="row" ng-repeat="link in section.links"
+                   style="padding-bottom: 5px">
+                <div class="col-md-4" style="padding-right: 0">
+                  <input class="form-control input-sm" type="text"
+                         placeholder="Label, e.g. Health"
+                         ng-change="$ctrl.configChanged()"
+                         ng-model="link.title"/>
+                </div>
+                <div class="col-md-6">
+                  <input class="form-control input-sm" type="text"
+                         placeholder="Path, e.g. /health, :7002/alt-port-link"
+                         ng-change="$ctrl.configChanged()"
+                         ng-model="link.path"/>
+                </div>
+                <div class="col-md-2" style="padding: 5px 0">
+                  <a href ng-click="$ctrl.removeLink(section, $index)"><span class="glyphicon glyphicon-trash"></span></a>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="row">
+            <div class="col-md-8 col-md-offset-3">
+              <button class="btn btn-block add-new small" ng-click="$ctrl.addLink(section)">
+                <span class="glyphicon glyphicon-plus-sign"></span> Add Link
+              </button>
+            </div>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col-md-10 col-md-offset-1">
+            <button class="btn btn-block add-new" ng-click="$ctrl.addSection()">
+              <span class="glyphicon glyphicon-plus-sign"></span> Add Section
+            </button>
+          </div>
+        </div>
+
+        <div class="row pipeline-footer">
+          <div class="col-md-3">
+            <button class="btn btn-default" ng-click="$ctrl.revert()"
+                    ng-if="$ctrl.viewState.isDirty"
+                    style="visibility: visible;"><span class="glyphicon glyphicon-flash"></span> Revert
+            </button>
+          </div>
+          <div class="col-md-9 text-right">
+            <button class="btn btn-primary" ng-if="$ctrl.viewState.isDirty"
+                    ng-click="$ctrl.save()">
+              <span ng-if="!$ctrl.viewState.saving">
+                <span class="glyphicon glyphicon-ok-circle"></span> Save Changes
+              </span>
+              <span ng-if="$ctrl.viewState.saving" class="pulsing">
+                <span class="glyphicon glyphicon-asterisk glyphicon-spinning"></span> Saving&hellip;
+              </span>
+            </button>
+            <div class="error-message" ng-if="$ctrl.viewState.saveError">There was an error saving your changes. Please try again.</div>
+            <span ng-if="!$ctrl.viewState.isDirty" class="btn btn-link disabled"><span class="glyphicon glyphicon-ok-circle"></span> In sync with server</span>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/scripts/modules/core/application/config/applicationLinks.component.js
+++ b/app/scripts/modules/core/application/config/applicationLinks.component.js
@@ -1,0 +1,80 @@
+'use strict';
+
+const angular = require('angular');
+
+module.exports = angular
+  .module('spinnaker.core.application.config.applicationLinks.component', [
+    require('../../utils/lodash'),
+    require('../service/applications.write.service'),
+    require('../../config/settings'),
+  ])
+  .component('applicationLinks', {
+    bindings: {
+      application: '=',
+    },
+    templateUrl: require('./applicationLinks.component.html'),
+    controller: function(applicationWriter, settings, _) {
+
+      let initialize = () => {
+        if (this.application.notFound) {
+          return;
+        }
+
+        this.sections = _.cloneDeep(this.application.attributes.instanceLinks || settings.defaultInstanceLinks || []);
+
+        this.viewState = {
+          originalSections: _.cloneDeep(this.sections),
+          originalStringVal: JSON.stringify(this.sections),
+          saving: false,
+          saveError: false,
+          isDirty: false,
+        };
+      };
+
+      this.revert = initialize;
+
+      this.save = () => {
+        this.viewState.saving = true;
+        this.viewState.saveError = false;
+        applicationWriter.updateApplication({
+          name: this.application.name,
+          accounts: this.application.attributes.accounts,
+          instanceLinks: angular.copy(this.sections),
+        })
+          .then(() => {
+            let sections = _.cloneDeep(angular.copy(this.sections));
+            this.application.attributes.instanceLinks = sections;
+            initialize();
+          }, () => {
+            this.viewState.saving = false;
+            this.viewState.saveError = true;
+          });
+      };
+
+      this.addLink = (section) => {
+        section.links.push({title: '', path: ''});
+        this.configChanged();
+      };
+
+      this.removeLink = (section, index) => {
+        section.links.splice(index, 1);
+        this.configChanged();
+      };
+
+      this.addSection = () => {
+        this.sections.push({title: '', links: []});
+        this.configChanged();
+      };
+
+      this.removeSection = (index) => {
+        this.sections.splice(index, 1);
+        this.configChanged();
+      };
+
+      this.configChanged = () => {
+        this.viewState.isDirty = this.viewState.originalStringVal !== JSON.stringify(angular.copy(this.sections));
+      };
+
+      this.$onInit = initialize;
+    }
+  });

--- a/app/scripts/modules/core/application/modal/createApplication.modal.controller.js
+++ b/app/scripts/modules/core/application/modal/createApplication.modal.controller.js
@@ -10,12 +10,14 @@ module.exports = angular
     require('../../utils/lodash.js'),
     require('../../account/account.service.js'),
     require('../../task/task.read.service.js'),
+    require('../../config/settings'),
     require('./validation/applicationNameValidationMessages.directive.js'),
     require('./validation/validateApplicationName.directive.js'),
     require('./applicationProviderFields.component.js'),
   ])
   .controller('CreateApplicationModalCtrl', function($scope, $q, $log, $state, $uibModalInstance, accountService,
-                                                     applicationWriter, applicationReader, _, taskReader, $timeout) {
+                                                     applicationWriter, applicationReader, _, taskReader, $timeout,
+                                                     settings) {
 
     let applicationLoader = applicationReader.listApplications();
     applicationLoader.then((applications) => this.data.appNameList = _.pluck(applications, 'name'));
@@ -38,6 +40,8 @@ module.exports = angular
     };
     this.application = {
       cloudProviders: [],
+      instancePort: settings.defaultInstancePort || null,
+      instanceLinks: settings.defaultInstanceLinks || [],
     };
 
     let submitting = () => {
@@ -81,7 +85,6 @@ module.exports = angular
       return applicationWriter.createApplication(this.application)
         .then(waitUntilApplicationIsCreated, createApplicationFailure);
     };
-
 
     this.submit = () => {
       submitting();

--- a/app/scripts/modules/core/application/modal/editApplication.controller.modal.js
+++ b/app/scripts/modules/core/application/modal/editApplication.controller.modal.js
@@ -9,9 +9,10 @@ module.exports = angular
     require('../../account/account.service.js'),
     require('../../task/task.read.service.js'),
     require('./applicationProviderFields.component.js'),
+    require('../../config/settings'),
   ])
   .controller('EditApplicationController', function ($window, $state, $uibModalInstance, application, applicationWriter,
-                                                     _, accountService, taskReader) {
+                                                     _, accountService, taskReader, settings) {
     var vm = this;
     this.data = {};
     this.state = {
@@ -20,6 +21,7 @@ module.exports = angular
     vm.errorMsgs = [];
     vm.application = application;
     vm.applicationAttributes = _.cloneDeep(application.attributes);
+    vm.applicationAttributes.instancePort = vm.applicationAttributes.instancePort || settings.defaultInstancePort || null;
     vm.applicationAttributes.cloudProviders = application.attributes.cloudProviders ?
       application.attributes.cloudProviders.split(',') :
       [];

--- a/app/scripts/modules/core/application/modal/editApplication.html
+++ b/app/scripts/modules/core/application/modal/editApplication.html
@@ -52,7 +52,7 @@
           </select>
         </div>
       </div>
-      <div class="form-group row">
+      <div class="form-group row" ng-if="editApp.applicationAttributes.repoType">
         <div class="col-sm-3 sm-label-right">Repo Project</div>
         <div class="col-sm-9">
           <input type="text"
@@ -61,7 +61,7 @@
                  placeholder="Enter your source repository project name"/>
         </div>
       </div>
-      <div class="form-group row">
+      <div class="form-group row" ng-if="editApp.applicationAttributes.repoType">
         <div class="col-sm-3 sm-label-right">Repo Name</div>
         <div class="col-sm-9">
           <input type="text"
@@ -136,6 +136,18 @@
             Show health override option for each operation
             <help-field key="application.showPlatformHealthOverride"></help-field>
           </label>
+        </div>
+      </div>
+
+      <div class="form-group row">
+        <div class="col-sm-3 sm-label-right">Instance Port</div>
+        <div class="col-sm-2">
+          <input type="number"
+                 min="0"
+                 max="65536"
+                 class="form-control input-sm"
+                 ng-model="editApp.applicationAttributes.instancePort"
+                 name="instancePort"/>
         </div>
       </div>
 

--- a/app/scripts/modules/core/application/modal/newapplication.html
+++ b/app/scripts/modules/core/application/modal/newapplication.html
@@ -64,7 +64,7 @@
           </select>
         </div>
       </div>
-      <div class="form-group row">
+      <div class="form-group row" ng-if="newAppModal.application.repoType">
         <div class="col-sm-3 sm-label-right">Repo Project</div>
         <div class="col-sm-9">
           <input type="text"
@@ -73,7 +73,7 @@
                  placeholder="Enter your source repository project name"/>
         </div>
       </div>
-      <div class="form-group row">
+      <div class="form-group row" ng-if="newAppModal.application.repoType">
         <div class="col-sm-3 sm-label-right">Repo Name</div>
         <div class="col-sm-9">
           <input type="text"
@@ -151,6 +151,19 @@
           </label>
         </div>
       </div>
+
+      <div class="form-group row">
+        <div class="col-sm-3 sm-label-right">Instance Port</div>
+        <div class="col-sm-2">
+          <input type="number"
+                 min="0"
+                 max="65536"
+                 class="form-control input-sm"
+                 ng-model="newAppModal.application.instancePort"
+                 name="instancePort"/>
+        </div>
+      </div>
+
       <div class="form-group row slide-in animated" ng-if="newAppModal.state.errorMessages.length">
         <div class="col-md-12">
           <div class="alert alert-danger">

--- a/app/scripts/modules/core/instance/details/instanceLinks.component.html
+++ b/app/scripts/modules/core/instance/details/instanceLinks.component.html
@@ -1,0 +1,7 @@
+<collapsible-section ng-repeat="section in $ctrl.sections" heading="{{section.title}}" ng-if="section.links.length">
+  <ul>
+    <li ng-repeat="link in section.links">
+      <a href="{{link.url}}" target="_blank">{{link.title}}</a>
+    </li>
+  </ul>
+</collapsible-section>

--- a/app/scripts/modules/core/instance/details/instanceLinks.component.js
+++ b/app/scripts/modules/core/instance/details/instanceLinks.component.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const angular = require('angular');
+
+require('./instanceLinks.component.less');
+
+module.exports = angular
+  .module('spinnaker.core.instance.details.instanceLinks', [
+    require('../../config/settings'),
+    require('../../utils/lodash')
+  ])
+  .component('instanceLinks', {
+    bindings: {
+      address: '=',
+      application: '=',
+      instance: '=',
+    },
+    templateUrl: require('./instanceLinks.component.html'),
+    controller: function(settings, _, $interpolate) {
+      this.port = this.application.attributes.instancePort || settings.defaultInstancePort;
+      this.sections = _.cloneDeep(this.application.attributes.instanceLinks || settings.defaultInstanceLinks || []);
+      this.sections.forEach(section => {
+        section.links = section.links.map(link => {
+          let port = link.path.indexOf(':') === 0 || !this.port ? '' : ':' + this.port;
+          let url = link.path;
+          // handle interpolated variables
+          if (url.indexOf('{{') > -1) {
+            url = $interpolate(url)(this.instance);
+          }
+          // handle relative paths
+          if (url.indexOf('//') === -1) {
+            url = `http://${this.address + port + url}`;
+          }
+          return {
+            url: url,
+            title: link.title || link.path
+          };
+        });
+      });
+    }
+  });

--- a/app/scripts/modules/core/instance/details/instanceLinks.component.less
+++ b/app/scripts/modules/core/instance/details/instanceLinks.component.less
@@ -1,0 +1,5 @@
+instance-links {
+  .collapsible-section:first-child {
+    border-top-width: 0 !important;
+  }
+}

--- a/app/scripts/modules/core/presentation/main.less
+++ b/app/scripts/modules/core/presentation/main.less
@@ -627,6 +627,11 @@ body > .container {
   cursor: pointer;
   background-color: transparent;
 
+  &.small {
+    padding: 4px;
+    font-size: 80%;
+  }
+
   &:hover, &:focus, &:active {
     border-color: #000;
     color: #000;

--- a/app/scripts/modules/google/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/google/instance/details/instance.details.controller.js
@@ -13,6 +13,7 @@ module.exports = angular.module('spinnaker.instance.detail.gce.controller', [
   require('../../../core/history/recentHistory.service.js'),
   require('../../../core/utils/selectOnDblClick.directive.js'),
   require('../../../core/cloudProvider/cloudProvider.registry.js'),
+  require('../../../core/instance/details/instanceLinks.component'),
 ])
   .controller('gceInstanceDetailsCtrl', function ($scope, $state, $uibModal, InsightFilterStateModel,
                                                   instanceWriter, confirmationModalService, recentHistoryService,
@@ -27,6 +28,7 @@ module.exports = angular.module('spinnaker.instance.detail.gce.controller', [
     };
 
     $scope.InsightFilterStateModel = InsightFilterStateModel;
+    $scope.application = app;
 
     function extractHealthMetrics(instance, latest) {
       // do not backfill on standalone instances

--- a/app/scripts/modules/google/instance/details/instanceDetails.html
+++ b/app/scripts/modules/google/instance/details/instanceDetails.html
@@ -205,5 +205,6 @@
         </li>
       </ul>
     </collapsible-section>
+    <instance-links address="baseIpAddress" application="application" instance="instance"></instance-links>
   </div>
 </div>

--- a/app/scripts/modules/netflix/application/applicationConfig.html
+++ b/app/scripts/modules/netflix/application/applicationConfig.html
@@ -1,6 +1,7 @@
 <div class="container">
   <application-attributes application="config.application"></application-attributes>
   <application-notifications application="config.application" notifications="config.notifications"></application-notifications>
+  <application-links application="config.application"></application-links>
   <application-cache-management application="config.application"></application-cache-management>
   <chaos-monkey-config application="config.application"></chaos-monkey-config>
   <delete-application-section application="config.application"></delete-application-section>

--- a/app/scripts/modules/netflix/application/createApplication.modal.html
+++ b/app/scripts/modules/netflix/application/createApplication.modal.html
@@ -73,7 +73,7 @@
           </select>
         </div>
       </div>
-      <div class="form-group row">
+      <div class="form-group row" ng-if="newAppModal.application.repoType">
         <div class="col-sm-3 sm-label-right">Repo Project</div>
         <div class="col-sm-9">
           <input type="text"
@@ -82,7 +82,7 @@
                  placeholder="Enter your source repository project name"/>
         </div>
       </div>
-      <div class="form-group row">
+      <div class="form-group row" ng-if="newAppModal.application.repoType">
         <div class="col-sm-3 sm-label-right">Repo Name</div>
         <div class="col-sm-9">
           <input type="text"
@@ -169,6 +169,18 @@
             Show health override option for each operation
             <help-field key="application.showPlatformHealthOverride"></help-field>
           </label>
+        </div>
+      </div>
+
+      <div class="form-group row">
+        <div class="col-sm-3 sm-label-right">Instance Port</div>
+        <div class="col-sm-2">
+          <input type="number"
+                 min="0"
+                 max="65536"
+                 class="form-control input-sm"
+                 ng-model="newAppModal.application.instancePort"
+                 name="instancePort"/>
         </div>
       </div>
 

--- a/app/scripts/modules/netflix/application/editApplication.modal.html
+++ b/app/scripts/modules/netflix/application/editApplication.modal.html
@@ -63,7 +63,7 @@
           </select>
         </div>
       </div>
-      <div class="form-group row">
+      <div class="form-group row" ng-if="editApp.applicationAttributes.repoType">
         <div class="col-sm-3 sm-label-right">Repo Project</div>
         <div class="col-sm-9">
           <input type="text"
@@ -72,7 +72,7 @@
                  placeholder="Enter your source repository project name"/>
         </div>
       </div>
-      <div class="form-group row">
+      <div class="form-group row" ng-if="editApp.applicationAttributes.repoType">
         <div class="col-sm-3 sm-label-right">Repo Name</div>
         <div class="col-sm-9">
           <input type="text"
@@ -144,6 +144,19 @@
             Show health override option for each operation
             <help-field key="application.showPlatformHealthOverride"></help-field>
           </label>
+        </div>
+      </div>
+
+
+      <div class="form-group row">
+        <div class="col-sm-3 sm-label-right">Instance Port</div>
+        <div class="col-sm-2">
+          <input type="number"
+                 min="0"
+                 max="65536"
+                 class="form-control input-sm"
+                 ng-model="editApp.applicationAttributes.instancePort"
+                 name="instancePort"/>
         </div>
       </div>
 

--- a/app/scripts/modules/netflix/instance/aws/instanceDetails.html
+++ b/app/scripts/modules/netflix/instance/aws/instanceDetails.html
@@ -123,7 +123,7 @@
       <dl ng-class="InsightFilterStateModel.filtersExpanded ? '' : 'dl-horizontal'">
         <dt ng-if="instance.privateDnsName">Private DNS Name</dt>
         <dd ng-if="instance.privateDnsName">
-          <a href="http://{{instance.privateDnsName}}:7001" target="_blank">{{instance.privateDnsName}}</a>
+          <a href="http://{{instance.privateDnsName}}:{{state.instancePort}}" target="_blank">{{instance.privateDnsName}}</a>
           <copy-to-clipboard
               class="copy-to-clipboard copy-to-clipboard-sm"
               text="{{instance.privateDnsName}}"
@@ -132,7 +132,7 @@
         </dd>
         <dt ng-if="instance.publicDnsName">Public DNS Name</dt>
         <dd ng-if="instance.publicDnsName">
-          <a href="http://{{instance.publicDnsName}}:7001" target="_blank">{{instance.publicDnsName}}</a>
+          <a href="http://{{instance.publicDnsName}}:{{state.instancePort}}" target="_blank">{{instance.publicDnsName}}</a>
           <copy-to-clipboard
               class="copy-to-clipboard copy-to-clipboard-sm"
               text="{{instance.publicDnsName}}"
@@ -141,7 +141,7 @@
         </dd>
         <dt ng-if="instance.privateIpAddress">Private IP Address</dt>
         <dd ng-if="instance.privateIpAddress">
-          <a href="http://{{instance.privateIpAddress}}:7001" target="_blank">{{instance.privateIpAddress}}</a>
+          <a href="http://{{instance.privateIpAddress}}:{{state.instancePort}}" target="_blank">{{instance.privateIpAddress}}</a>
           <copy-to-clipboard
               class="copy-to-clipboard copy-to-clipboard-sm"
               text="{{instance.privateIpAddress}}"
@@ -150,7 +150,7 @@
         </dd>
         <dt ng-if="instance.publicIpAddress">Public IP Address</dt>
         <dd ng-if="instance.publicIpAddress">
-          <a href="http://{{instance.publicIpAddress}}:7001" target="_blank">{{instance.publicIpAddress}}</a>
+          <a href="http://{{instance.publicIpAddress}}:{{state.instancePort}}" target="_blank">{{instance.publicIpAddress}}</a>
           <copy-to-clipboard
               class="copy-to-clipboard copy-to-clipboard-sm"
               text="{{instance.publicIpAddress}}"
@@ -186,46 +186,9 @@
         </li>
       </ul>
     </collapsible-section>
-    <collapsible-section heading="Logs" ng-if="baseIpAddress">
-      <ul>
-        <li>
-          <a href="http://{{baseIpAddress}}:7001/AdminLogs/list?view=tomcat/catalina.out" target="_blank">catalina.out</a>
-        </li>
-        <li>
-          <a href="http://{{baseIpAddress}}:7001/AdminLogs/list" target="_blank">Log File Archive</a>
-        </li>
-        <li>
-          <a href="http://{{baseIpAddress}}:7001/AdminLogs/threaddumps" target="_blank">Thread Dumps</a>
-        </li>
-        <li>
-          <a href="http://{{baseIpAddress}}:7001/AdminProxyInfo" target="_blank">Admin Proxy Info</a>
-        </li>
-        <li>
-          <a href="http://{{baseIpAddress}}:7001/AdminProxyStatus" target="_blank">Admin Proxy Status</a>
-        </li>
-        <li>
-          <a href="http://{{baseIpAddress}}:7001/AdminGCViz/index" target="_blank">GC Visualization</a>
-        </li>
-        <li>
-          <console-output-link instance="instance"></console-output-link>
-        </li>
-      </ul>
+    <collapsible-section heading="Console Output" ng-if="baseIpAddress">
+      <console-output-link instance="instance"></console-output-link>
     </collapsible-section>
-    <collapsible-section heading="Netflix Configuration" ng-if="baseIpAddress">
-      <ul>
-        <li>
-          <a href="http://{{baseIpAddress}}:8077/baseserver#view=props" target="_blank">Properties Console</a>
-        </li>
-        <li>
-          <a href="http://{{baseIpAddress}}:8077/baseserver#view=jars" target="_blank">Libraries Console</a>
-        </li>
-        <li>
-          <a href="http://{{baseIpAddress}}:8077/AdminNetflixConfiguration/machineReadableProps" target="_blank">Machine Readable Properties</a>
-        </li>
-        <li>
-          <a href="http://{{baseIpAddress}}:8077/AdminNetflixConfiguration/webapp/META-INF/MANIFEST.MF" target="_blank">Manifest</a>
-        </li>
-      </ul>
-    </collapsible-section>
+    <instance-links address="baseIpAddress" application="application" instance="instance"></instance-links>
   </div>
 </div>

--- a/app/scripts/modules/netflix/instance/titan/instanceDetails.html
+++ b/app/scripts/modules/netflix/instance/titan/instanceDetails.html
@@ -130,11 +130,6 @@
         <li><a href="{{instance.stdoutLive}}" target="_blank">Console Output</a></li>
       </ul>
     </collapsible-section>
-    <!--<collapsible-section heading="Netflix Configuration" ng-if="baseIpAddress">-->
-    <!--<ul>-->
-    <!--<li>Properties Console (TBD)</li>-->
-    <!--<li>Machine Readable Properties (TBD)</li>-->
-    <!--</ul>-->
-    <!--</collapsible-section>-->
+    <instance-links address="baseIpAddress" application="application" instance="instance"></instance-links>
   </div>
 </div>

--- a/app/scripts/modules/titan/instance/details/instanceDetails.html
+++ b/app/scripts/modules/titan/instance/details/instanceDetails.html
@@ -31,20 +31,9 @@
           <ul class="dropdown-menu" uib-dropdown-menu role="menu">
             <li><a href ng-click="ctrl.enableInstanceInDiscovery()" ng-if="ctrl.canRegisterWithDiscovery()">Enable in Discovery</a></li>
             <li><a href ng-click="ctrl.disableInstanceInDiscovery()" ng-if="ctrl.hasHealthState('Discovery', 'Up')">Disable in Discovery</a></li>
-            <!--<li><a href ng-click="ctrl.registerInstanceWithLoadBalancer()" ng-if="ctrl.canRegisterWithLoadBalancer()">Register with Load Balancer</a></li>-->
-            <!--<li><a href ng-click="ctrl.deregisterInstanceFromLoadBalancer()" ng-if="ctrl.canDeregisterFromLoadBalancer()">Deregister from Load Balancer</a></li>-->
-            <!--<li role="presentation" class="divider" ng-if="instance.health.length > 0"></li>-->
             <li><a href ng-click="ctrl.terminateInstance()">Terminate</a></li>
           </ul>
         </div>
-        <!--<div class="dropdown" ng-if="instance.insightActions.length > 0" uib-dropdown>-->
-          <!--<button type="button" class="btn btn-sm btn-default dropdown-toggle" uib-dropdown-toggle>-->
-            <!--Insight <span class="caret"></span>-->
-          <!--</button>-->
-          <!--<ul class="dropdown-menu" uib-dropdown-menu role="menu">-->
-            <!--<li ng-repeat="action in instance.insightActions"><a target=_blank href="{{action.url}}">{{action.label}}</a></li>-->
-          <!--</ul>-->
-        <!--</div>-->
         <div class="clearfix"></div>
       </div>
     </div>
@@ -114,22 +103,11 @@
         <p>Could not find the instance. No other details provided.</p>
       </div>
     </div>
-    <!--<collapsible-section heading="SSH" ng-if="!instance.notFound">-->
-      <!--<dl>-->
-        <!--<dt ng-if="instance.sshLink">SSH into this docker container</dt>-->
-        <!--<dd ng-if="instance.sshLink"><a href="{{instance.sshLink}}" target="_blank">SSH</a></dd>-->
-      <!--</dl>-->
-    <!--</collapsible-section>-->
     <collapsible-section heading="Logs">
       <ul>
         <li><a href="{{instance.stdoutLive}}" target="_blank">Console Output</a></li>
       </ul>
     </collapsible-section>
-    <!--<collapsible-section heading="Netflix Configuration" ng-if="baseIpAddress">-->
-      <!--<ul>-->
-        <!--<li>Properties Console (TBD)</li>-->
-        <!--<li>Machine Readable Properties (TBD)</li>-->
-      <!--</ul>-->
-    <!--</collapsible-section>-->
+    <instance-links address="baseIpAddress" application="application" instance="instance"></instance-links>
   </div>
 </div>

--- a/settings.js
+++ b/settings.js
@@ -15,6 +15,8 @@ window.spinnakerSettings = {
   pollSchedule: 30000,
   defaultTimeZone: process.env.TIMEZONE || 'America/Los_Angeles', // see http://momentjs.com/timezone/docs/#/data-utilities/
   defaultCategory: 'serverGroup',
+  defaultInstancePort: 80,
+  defaultInstanceLinks: [],
   providers: {
     azure: {
       defaults: {


### PR DESCRIPTION
Adds two new fields to the application attributes: `instancePort` and `instanceLinks`. `instancePort` is used to generate links into instances in the application; `instanceLinks` provides a custom "Links" section in the instance details.

I'm not sure how this works with GCP and Kubernetes - @duftler @lwander does it make sense to include the instance port in the instance DNS links for those providers?