### PR TITLE
(core) fix copy-to-clipboard link on task permalink

### DIFF
--- a/app/scripts/modules/core/task/tasks.controller.js
+++ b/app/scripts/modules/core/task/tasks.controller.js
@@ -22,6 +22,8 @@ module.exports = angular.module('spinnaker.core.task.controller', [
     var controller = this;
     const application = app;
 
+    $scope.$state = $state;
+
     var tasksViewStateCache = viewStateCache.tasks || viewStateCache.createCache('tasks', { version: 1 });
 
     function cacheViewState() {


### PR DESCRIPTION
Either this never worked or we had `$state` on the `$rootScope` and removed it at some point. Probably the latter. Probably my fault. Let's not point fingers, though; the important thing is we're fixing today's problems today.