### PR TITLE
(core) use one-time binding wherever possible in executions view

### DIFF
--- a/app/scripts/modules/core/delivery/executionGroup/execution/execution.directive.html
+++ b/app/scripts/modules/core/delivery/executionGroup/execution/execution.directive.html
@@ -1,56 +1,56 @@
-<div class="execution" id="execution-{{vm.execution.id}}">
-  <execution-status execution="vm.execution"
-                    toggle-details="vm.toggleDetails"
-                    showing-details="vm.showDetails"
-                    standalone="vm.standalone">
+<div class="execution" id="execution-{{::vm.execution.id}}">
+  <execution-status execution="::vm.execution"
+                    toggle-details="::vm.toggleDetails"
+                    showing-details="::vm.showDetails"
+                    standalone="::vm.standalone">
   </execution-status>
   <div class="execution-bar">
     <div class="stages" ng-class="{'show-durations': vm.sortFilter.showStageDuration}">
-      <div ng-repeat="stage in vm.execution.stageSummaries"
+      <div ng-repeat="stage in ::vm.execution.stageSummaries"
            class="clickable stage stage-type-{{::stage.type.toLowerCase()}}
                   execution-marker execution-marker-{{::stage.status.toLowerCase()}}
-                  {{stage.isRunning ? 'glowing' : ''}}"
-           ng-style="{width: 100/vm.execution.stageSummaries.length + '%', 'background-color': stage.color}"
-           uib-tooltip-template="stage.labelTemplateUrl"
+                  {{::stage.isRunning ? 'glowing' : ''}}"
+           ng-style="::{width: 100/vm.execution.stageSummaries.length + '%', 'background-color': stage.color}"
+           uib-tooltip-template="::stage.labelTemplateUrl"
            tooltip-title="(Click for details)"
            tooltip-placement="bottom"
            ng-click="vm.toggleDetails({executionId: vm.execution.id, index: $index})">
-        <span class="duration">{{::stage.runningTimeInMs | duration}}</span>
+        <span class="duration">{{stage.runningTimeInMs | duration}}</span>
       </div>
-      <div ng-if="!vm.execution.stageSummaries.length" class="text-center">
+      <div ng-if="::!vm.execution.stageSummaries.length" class="text-center">
         No stages found.
         <a target="_blank" ng-href="{{vm.pipelinesUrl + vm.execution.id}}">Source</a>
       </div>
     </div>
     <div class="execution-summary">
-      Status: <span class="status execution-status execution-status-{{vm.execution.status.toLowerCase()}}">{{vm.execution.status}}</span>
-      <span ng-if="vm.execution.canceledBy">
-        by {{vm.execution.canceledBy}} &mdash; {{vm.execution.endTime | timestamp}}
+      Status: <span class="status execution-status execution-status-{{::vm.execution.status.toLowerCase()}}">{{::vm.execution.status}}</span>
+      <span ng-if="::vm.execution.canceledBy">
+        by {{::vm.execution.canceledBy}} &mdash; {{::vm.execution.endTime | timestamp}}
       </span>
       <span class="pull-right">Duration: {{vm.execution.runningTimeInMs | duration}}</span>
     </div>
   </div>
   <div class="execution-actions">
     <a href
-       ng-if="vm.execution.isRunning"
+       ng-if="::vm.execution.isRunning"
        ng-click="vm.pauseExecution(); $event.stopPropagation();"
        uib-tooltip="Pause execution">
       <span class="glyphicon glyphicon-pause"></span>
     </a>
     <a href
-       ng-if="vm.execution.isPaused"
+       ng-if="::vm.execution.isPaused"
        ng-click="vm.resumeExecution(); $event.stopPropagation();"
        uib-tooltip="Resume execution">
       <span class="glyphicon glyphicon-play"></span>
     </a>
     <a href
-       ng-if="!vm.execution.isActive"
+       ng-if="::!vm.execution.isActive"
        ng-click="vm.deleteExecution(); $event.stopPropagation();"
        uib-tooltip="Delete execution">
       <span class="glyphicon glyphicon-trash"></span>
     </a>
     <a href
-       ng-if="vm.execution.isActive"
+       ng-if="::vm.execution.isActive"
        ng-click="vm.cancelExecution(); $event.stopPropagation();"
        uib-tooltip="Cancel execution">
       <span class="glyphicon glyphicon-remove-circle"></span>
@@ -58,25 +58,25 @@
   </div>
 
   <div ng-if="vm.showDetails()" class="execution-graph">
-    <pipeline-graph ng-if="vm.execution.parallel"
-                    execution="vm.execution"
-                    on-node-click="vm.toggleDetails"
-                    view-state="vm.viewState">
+    <pipeline-graph ng-if="::vm.execution.parallel"
+                    execution="::vm.execution"
+                    on-node-click="::vm.toggleDetails"
+                    view-state="::vm.viewState">
 
     </pipeline-graph>
   </div>
 
   <div ng-if="vm.showDetails()" class="execution-details">
     <div class="row">
-      <execution-details execution="vm.execution" application="vm.application" standalone="vm.standalone">
+      <execution-details execution="::vm.execution" application="::vm.application" standalone="::vm.standalone">
       </execution-details>
     </div>
     <div class="row permalinks text-right">
       <div class="col-md-12">
         <a target="_blank" ng-href="{{vm.pipelinesUrl + vm.execution.id}}">Source</a>
         |
-        <a ng-href="{{vm.getUrl()}}">Permalink</a>
-        <copy-to-clipboard text="{{vm.getUrl()}}" tool-tip="Copy permalink to clipboard"></copy-to-clipboard>
+        <a ng-href="{{::vm.getUrl()}}">Permalink</a>
+        <copy-to-clipboard text="{{::vm.getUrl()}}" tool-tip="Copy permalink to clipboard"></copy-to-clipboard>
       </div>
     </div>
   </div>

--- a/app/scripts/modules/core/delivery/status/executionStatus.html
+++ b/app/scripts/modules/core/delivery/status/executionStatus.html
@@ -1,9 +1,9 @@
 <div class="execution-status-section">
-  <h4 class="execution-name" ng-if="vm.filter.groupBy !== 'name'">{{vm.execution.name}}</h4>
+  <h4 class="execution-name" ng-if="::vm.filter.groupBy !== 'name'">{{::vm.execution.name}}</h4>
   <span class="trigger-type" ng-switch="vm.execution.trigger.type"
-        ng-class="{subheading: vm.filter.groupBy !== 'name'}">
+        ng-class="::{subheading: vm.filter.groupBy !== 'name'}">
     <h5 class="build-number">
-      <execution-build-number execution="vm.execution"></execution-build-number>
+      <execution-build-number execution="::vm.execution"></execution-build-number>
     </h5>
      <h5 ng-switch-when="jenkins" class="execution-type">
        Triggered Build
@@ -15,35 +15,35 @@
       Pipeline
     </h5>
     <h5 ng-switch-when="cron" class="execution-type">
-      Cron<br/>{{ vm.execution.trigger.cronExpression }}
+      Cron<br/>{{ ::vm.execution.trigger.cronExpression }}
     </h5>
     <h5 ng-switch-default class="execution-type">
-      {{ vm.execution.trigger.type }}
+      {{ ::vm.execution.trigger.type }}
     </h5>
   </span>
   <ul class="trigger-details">
-    <li ng-if="vm.execution.trigger.buildInfo.url">
-      {{ vm.execution.trigger.buildInfo | buildDisplayName }}
+    <li ng-if="::vm.execution.trigger.buildInfo.url">
+      {{ ::vm.execution.trigger.buildInfo | buildDisplayName }}
     </li>
-    <span ng-switch="vm.execution.trigger.type">
+    <span ng-switch="::vm.execution.trigger.type">
       <li ng-switch-when="jenkins">
-        {{ vm.execution.trigger.job}}
+        {{ ::vm.execution.trigger.job}}
       </li>
       <li ng-switch-when="manual">
-        {{ vm.execution | executionUser }}
+        {{ ::vm.execution | executionUser }}
       </li>
       <li ng-switch-when="pipeline">
-        {{ vm.execution | executionUser }}
+        {{ ::vm.execution | executionUser }}
       </li>
       <li>
-        {{ vm.execution.startTime | timestamp }}
+        {{ ::vm.execution.startTime | timestamp }}
       </li>
     </span>
-    <li ng-repeat="parameter in vm.parameters">
-      {{parameter.key}}: {{parameter.value}}
+    <li ng-repeat="parameter in ::vm.parameters">
+      {{::parameter.key}}: {{::parameter.value}}
     </li>
   </ul>
-  <a href ng-if="!vm.standalone" ng-click="vm.toggleDetails({executionId: vm.execution.id})">
+  <a href ng-if="::!vm.standalone" ng-click="vm.toggleDetails({executionId: vm.execution.id})">
     <span class="small glyphicon"
           ng-class="vm.showingDetails() ? 'glyphicon-chevron-down' : 'glyphicon-chevron-up'">
     </span>


### PR DESCRIPTION
Because we do this thing where we replace an execution if anything in its JSON changes between refreshes, we don't need to add watches for most fields in the executions view.

We _do_ need watches on the running time (since active stages will increment, even if nothing changes in the JSON of the execution) and the details toggle.

Adding these one-time bindings cuts the number of watches on the executions view by around half and everything consequently feels a little snappier when clicking around on the page, especially with lots of executions showing.