### PR TITLE
(core) indicate rename pipeline is happening; fix dirty state after r…

### DIFF
--- a/app/scripts/modules/core/pipeline/config/actions/rename/rename.module.js
+++ b/app/scripts/modules/core/pipeline/config/actions/rename/rename.module.js
@@ -24,6 +24,7 @@ module.exports = angular.module('spinnaker.core.pipeline.config.actions.rename',
 
     this.renamePipeline = function() {
       pipeline.name = $scope.newName;
+      $scope.viewState.saving = true;
       return pipelineConfigService.renamePipeline(application.name, pipeline, currentName, $scope.command.newName).then(
         function() {
           $scope.pipeline.name = $scope.command.newName;
@@ -36,6 +37,7 @@ module.exports = angular.module('spinnaker.core.pipeline.config.actions.rename',
         },
         function(response) {
           $log.warn(response);
+          $scope.viewState.saving = false;
           $scope.viewState.saveError = true;
           $scope.viewState.errorMessage = response.message || 'No message provided';
         }

--- a/app/scripts/modules/core/pipeline/config/actions/rename/renamePipelineModal.html
+++ b/app/scripts/modules/core/pipeline/config/actions/rename/renamePipelineModal.html
@@ -36,9 +36,13 @@
   <div class="modal-footer">
     <button class="btn btn-default" ng-click="renamePipelineModalCtrl.cancel()">Cancel</button>
     <button class="btn btn-primary"
-            ng-disabled="form.$invalid || pipeline.name === command.newName"
+            ng-disabled="form.$invalid || pipeline.name === command.newName || viewState.saving"
             ng-click="renamePipelineModalCtrl.renamePipeline()">
-      <span class="glyphicon glyphicon-ok-circle"></span> Rename {{pipeline.strategy === true ? 'Strategy' : 'Pipeline'}}
+      <span ng-if="!viewState.saving" class="glyphicon glyphicon-ok-circle"></span>
+      <span ng-if="viewState.saving" class="pulsing">
+        <span class="glyphicon glyphicon-asterisk glyphicon-spinning"></span>
+      </span>
+      Rename {{pipeline.strategy === true ? 'Strategy' : 'Pipeline'}}
     </button>
   </div>
 </div>

--- a/app/scripts/modules/core/pipeline/config/pipelineConfigurer.js
+++ b/app/scripts/modules/core/pipeline/config/pipelineConfigurer.js
@@ -145,7 +145,9 @@ module.exports = angular.module('spinnaker.core.pipeline.config.pipelineConfigur
         }
       }).result.then(function() {
           $scope.pipeline.name = original.name;
-          $scope.viewState.original = angular.toJson(original);
+          $scope.viewState.original = angular.toJson(getPlain(original));
+          $scope.viewState.originalPipelineName = original.name;
+          markDirty();
         });
     };
 
@@ -214,18 +216,20 @@ module.exports = angular.module('spinnaker.core.pipeline.config.pipelineConfigur
           viewState = $scope.viewState;
 
       $scope.viewState.saving = true;
-      pipelineConfigService.savePipeline(pipeline).then(
-        function() {
-          viewState.original = angular.toJson(getPlain(pipeline));
-          viewState.originalPipelineName = pipeline.name;
-          markDirty();
-          $scope.viewState.saving = false;
-        },
-        function() {
-          $scope.viewState.saveError = true;
-          $scope.viewState.saving = false;
-        }
-      );
+      pipelineConfigService.savePipeline(pipeline)
+        .then($scope.application.pipelineConfigs.refresh)
+        .then(
+          function() {
+            viewState.original = angular.toJson(getPlain(pipeline));
+            viewState.originalPipelineName = pipeline.name;
+            markDirty();
+            $scope.viewState.saving = false;
+          },
+          function() {
+            $scope.viewState.saveError = true;
+            $scope.viewState.saving = false;
+          }
+        );
     };
 
     this.revertPipelineChanges = function() {


### PR DESCRIPTION
…ename

Fixes an edge case where a user renames a pipeline, then makes a change to the pipeline without navigating, saves the pipeline, then navigates away from the pipeline, then back to the pipeline before the application's pipeline configs have refreshed.

Also adds a busy indicator to the save button on the rename modal.