### PR TITLE
(amazon) always use "Average" for metricAggregationType

### DIFF
--- a/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/upsertScalingPolicy.controller.js
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/upsertScalingPolicy.controller.js
@@ -91,7 +91,7 @@ module.exports = angular
       let threshold = command.alarm.threshold;
       command.step = {
         estimatedInstanceWarmup: policy.estimatedInstanceWarmup || command.cooldown || 600,
-        metricAggregationType: command.alarm.statistic,
+        metricAggregationType: 'Average',
       };
       command.step.stepAdjustments = policy.stepAdjustments.map((adjustment) => {
         let step = {


### PR DESCRIPTION
We currently conflate the alarm `statistic` with the step `metricAggregationType`.

Via the AWS console, a user cannot set the `metricAggregationType` - it's always 'Average' - so we'll follow suit.