### PR TITLE
Add docker repo:tag to pipeline

### DIFF
--- a/app/scripts/modules/core/delivery/status/executionStatus.html
+++ b/app/scripts/modules/core/delivery/status/executionStatus.html
@@ -25,6 +25,9 @@
     <li ng-if="::vm.execution.trigger.buildInfo.url">
       {{ ::vm.execution.trigger.buildInfo | buildDisplayName }}
     </li>
+    <li ng-if="::vm.execution.trigger.tag">
+      {{ ::vm.execution.trigger.repository }}:{{ ::vm.execution.trigger.tag}}
+    </li>
     <span ng-switch="::vm.execution.trigger.type">
       <li ng-switch-when="jenkins">
         {{ ::vm.execution.trigger.job}}


### PR DESCRIPTION
Id like to see which docker image triggered the pipeline at a quick glance.  Adding it to the execution status like Jenkins does.