### PR TITLE
Fix JS error posting to Atlas Alerts

### DIFF
--- a/app/scripts/modules/netflix/alert/alertHandler.js
+++ b/app/scripts/modules/netflix/alert/alertHandler.js
@@ -49,12 +49,12 @@ module.exports = angular
             }
           ],
         };
-        if (navigator.sendBeacon) {
-          navigator.sendBeacon(settings.alert.url, JSON.stringify(payload));
-        } else {
-          $log.warn('no beacon support :(');
-          $.post(settings.alert.url, JSON.stringify(payload));
-        }
+
+        $.ajax(settings.alert.url, {
+          method: 'POST',
+          data: JSON.stringify(payload),
+          contentType: 'application/json'
+        });
       };
     });
   });


### PR DESCRIPTION
Errors were not posting to Atlas b/c the Atlas endpoint is http and we are hosted out of https, so error were not being sent because of a Mixed Content error

We are now posting to GATE and letting it post to ATLAS.

Removing the sending via navigator becon b/c it defaults the Contet-Type to text/plain and you cant set headers, so just using the ajax POST.

@anotherchrisberry PTAL