### PR TITLE
(core) wait until new version has been seen for three minutes before …

### DIFF
--- a/app/scripts/modules/core/config/versionCheck.service.js
+++ b/app/scripts/modules/core/config/versionCheck.service.js
@@ -10,23 +10,30 @@ module.exports = angular
   .factory('versionCheckService', function ($http, $timeout, notifierService, $log, $filter) {
 
     let currentVersion = require('../../../../../version.json');
+    let newVersionSeenCount = 0;
 
     $log.debug('Deck version', currentVersion.version, 'created', $filter('timestamp')(currentVersion.created));
 
     let checkVersion = () => {
       let url = '/version.json?_=' + new Date().getTime();
-      $timeout(() => $http.get(url).then(versionRetrieved, checkVersion), 15000);
+      $timeout(() => $http.get(url).then(versionRetrieved, checkVersion), 30000);
     };
 
     let versionRetrieved = (response) => {
       let data = response.data;
       if (data.version === currentVersion.version) {
+        newVersionSeenCount = 0;
         checkVersion();
       } else {
-        $log.debug('New Deck version:', data.version, 'created', $filter('timestamp')(data.created));
-        notifierService.publish(
-          `A new version of Spinnaker is available
-            <a role="button" class="action" onclick="document.location.reload(true)">Refresh</a>`);
+        newVersionSeenCount++;
+        if (newVersionSeenCount < 6) {
+          checkVersion();
+        } else {
+          $log.debug('New Deck version:', data.version, 'created', $filter('timestamp')(data.created));
+          notifierService.publish(
+            `A new version of Spinnaker is available
+              <a role="button" class="action" onclick="document.location.reload(true)">Refresh</a>`);
+        }
       }
     };
 


### PR DESCRIPTION
…prompting user to refresh

In the middle of a red/black deployment, both versions will be served for a time by Deck. Wait until the new version has been seen six consecutive times (over the span of three minutes) so we have more confidence it's really ready.

@zanthrash PTAL