### PR TITLE
(core) remove stageCounter

### DIFF
--- a/app/scripts/modules/core/pipeline/config/actions/json/editPipelineJson.module.js
+++ b/app/scripts/modules/core/pipeline/config/actions/json/editPipelineJson.module.js
@@ -14,14 +14,6 @@ module.exports = angular.module('spinnaker.core.pipeline.config.actions.editJson
       delete obj.application;
       delete obj.index;
       delete obj.id;
-      delete obj.stageCounter;
-    }
-
-    function updateStageCounter() {
-      if (pipeline.parallel) {
-        let stageIds = pipeline.stages.map((stage) => Number(stage.refId));
-        stageIds.forEach((stageId) => pipeline.stageCounter = Math.max(pipeline.stageCounter, stageId));
-      }
     }
 
     this.initialize = function() {
@@ -47,8 +39,6 @@ module.exports = angular.module('spinnaker.core.pipeline.config.actions.editJson
 
         removeImmutableFields(parsed);
         angular.extend(pipeline, parsed);
-        updateStageCounter();
-
         $uibModalInstance.close();
       } catch (e) {
         $scope.command.invalid = true;

--- a/app/scripts/modules/core/pipeline/config/actions/json/editPipelineJsonModal.controller.spec.js
+++ b/app/scripts/modules/core/pipeline/config/actions/json/editPipelineJsonModal.controller.spec.js
@@ -109,22 +109,4 @@ describe('Controller: renamePipelineModal', function() {
     expect(this.$scope.command.errorMessage).not.toBe(null);
   });
 
-  it ('updateApplicationFromJson sets the stage counter based on max value of refIds', function () {
-    var pipeline = {
-      application: 'myApp',
-      name: 'foo',
-      stageCounter: 4,
-      parallel: true,
-      stages: [
-        {refId: '3'},
-        {refId: '13'}
-      ]
-    };
-    this.initializeController(pipeline);
-    this.$scope.command = {pipelineJSON: JSON.stringify(pipeline)};
-    this.controller.updatePipeline();
-
-    expect(pipeline.stageCounter).toBe(13);
-  });
-
 });

--- a/app/scripts/modules/core/pipeline/config/pipelineConfigurer.js
+++ b/app/scripts/modules/core/pipeline/config/pipelineConfigurer.js
@@ -89,12 +89,8 @@ module.exports = angular.module('spinnaker.core.pipeline.config.pipelineConfigur
       var newStage = { isNew: true };
       $scope.pipeline.stages = $scope.pipeline.stages || [];
       if ($scope.pipeline.parallel) {
-        if (!$scope.pipeline.stageCounter) {
-          $scope.pipeline.stageCounter = Math.max(...$scope.pipeline.stages.map(s => Number(s.refId) || 0)) + 1;
-        }
-        $scope.pipeline.stageCounter++;
+        newStage.refId = Math.max(0, ...$scope.pipeline.stages.map(s => Number(s.refId) || 0)) + 1 + '';
         newStage.requisiteStageRefIds = [];
-        newStage.refId = $scope.pipeline.stageCounter + ''; // needs to be a string
         if ($scope.pipeline.stages.length && $scope.viewState.section === 'stage') {
           newStage.requisiteStageRefIds.push($scope.pipeline.stages[$scope.viewState.stageIndex].refId);
         }
@@ -239,10 +235,8 @@ module.exports = angular.module('spinnaker.core.pipeline.config.pipelineConfigur
       var original = angular.fromJson($scope.viewState.original);
       if (original.parallel) {
         $scope.pipeline.parallel = true;
-        $scope.pipeline.stageCounter = original.stageCounter;
       } else {
         delete $scope.pipeline.parallel;
-        delete $scope.pipeline.stageCounter;
       }
       $scope.pipeline.stages = original.stages;
       $scope.pipeline.triggers = original.triggers;
@@ -280,7 +274,6 @@ module.exports = angular.module('spinnaker.core.pipeline.config.pipelineConfigur
         appConfig: copy.appConfig || {},
         limitConcurrent: copy.limitConcurrent,
         keepWaitingPipelines: copy.keepWaitingPipelines,
-        stageCounter: copy.stageCounter,
         parameterConfig: copy.parameterConfig,
         notifications: copy.notifications,
         persistedProperties: copy.persistedProperties,

--- a/app/scripts/modules/core/pipeline/config/services/pipelineConfigService.js
+++ b/app/scripts/modules/core/pipeline/config/services/pipelineConfigService.js
@@ -120,22 +120,18 @@ module.exports = angular.module('spinnaker.core.pipeline.config.services.configS
     }
 
     function enableParallelExecution(pipeline) {
-      pipeline.stageCounter = 0;
-      pipeline.stages.forEach(function(stage) {
-        pipeline.stageCounter++;
-        stage.refId = pipeline.stageCounter + '';
-        if (pipeline.stageCounter > 1) {
-          stage.requisiteStageRefIds = [(pipeline.stageCounter - 1) + ''];
+      pipeline.stages.forEach((stage, index) => {
+        stage.refId = index + '';
+        if (index > 0) {
+          stage.requisiteStageRefIds = [(index - 1) + ''];
         } else {
           stage.requisiteStageRefIds = [];
         }
       });
       pipeline.parallel = true;
-      pipeline.stageCounter = pipeline.stages.length;
     }
 
     function disableParallelExecution(pipeline) {
-      delete pipeline.stageCounter;
       pipeline.stages.forEach(function(stage) {
         delete stage.refId;
         delete stage.requisiteStageRefIds;


### PR DESCRIPTION
The `stageCounter` doesn't need to exist. We are better off getting the next `refId` for a stage by incrementing the max value of the other stages' `refId`s.

@zanthrash PTAL