### PR TITLE
(core) stage duration dividers are now white

### DIFF
--- a/app/scripts/modules/core/delivery/executionGroup/execution/execution.less
+++ b/app/scripts/modules/core/delivery/executionGroup/execution/execution.less
@@ -101,14 +101,18 @@ execution-status {
           visibility: visible;
         }
         min-width: 50px;
-        border-left-color: #222222;
+        border-left-color: #FFFFFF;
         &.active {
-          border-right-width: 0;
+          border-color: #222222;
+
           &:first-child {
             border-left-width: 1px;
           }
           &:last-child {
             border-right-width: 1px;
+          }
+          & + .stage {
+            border-left-color: transparent;
           }
         }
       }


### PR DESCRIPTION
This looks 100 times better.

_Before_
<img width="826" alt="screen shot 2016-06-21 at 6 24 43 pm" src="https://cloud.githubusercontent.com/assets/73450/16251737/79e62762-37dd-11e6-9e57-1236ee2965bf.png">

After
<img width="825" alt="screen shot 2016-06-21 at 6 24 06 pm" src="https://cloud.githubusercontent.com/assets/73450/16251741/7e355fd6-37dd-11e6-95e8-997d83835100.png">
