### PR TITLE
provider/kubernetes: Fix docker trigger

### DIFF
--- a/app/scripts/modules/core/pipeline/config/triggers/docker/dockerTrigger.module.js
+++ b/app/scripts/modules/core/pipeline/config/triggers/docker/dockerTrigger.module.js
@@ -35,6 +35,7 @@ module.exports = angular.module('spinnaker.core.pipeline.trigger.docker', [
       if (!$scope.accountMap) {
         return;
       }
+      trigger.registry = $scope.registryMap[trigger.account];
       $scope.organizations = $scope.accountMap[trigger.account] || [];
       if ($scope.organizations.indexOf(trigger.organization) < 0) {
         trigger.organization = null;
@@ -81,6 +82,10 @@ module.exports = angular.module('spinnaker.core.pipeline.trigger.docker', [
     function initializeImages() {
       loadImages().then(function (images) {
         $scope.images = images;
+        $scope.registryMap = images.reduce((map, image) => {
+          map[image.account] = image.registry;
+          return map;
+        }, {});
         $scope.accountMap = images.reduce((map, image) => {
           let key = image.account;
           if (!key) {


### PR DESCRIPTION
Replacing `registry` with `account` broke the trigger logic in Orca. Pointed out by @leelasharma