### PR TITLE
Fixes Auto Scaling bug.

### DIFF
--- a/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/step/stepPolicyAction.component.js
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/step/stepPolicyAction.component.js
@@ -16,6 +16,7 @@ module.exports = angular
     templateUrl: require('./stepPolicyAction.component.html'),
     controller: function () {
       this.operatorChanged = () => {
+        this.command.adjustmentType = this.viewState.operator === 'Set to' ? 'ExactCapacity' : 'ChangeInCapacity';
         this.adjustmentTypeOptions = this.viewState.operator === 'Set to' ?
           ['instances'] :
           ['instances', 'percent of group'];


### PR DESCRIPTION
Setting the command.adjustentType when the viewState.operator changees.

When the Action operator changed it did not set it's value on the command.adjustmentType; which is what is sent in the POST to /task

This resulted in the task to always post the default "ChangeInCapacity" and now allow "ExactCapacity" to be set on the command object when the "Set to" option was chosen.

@anotherchrisberry PTAL