### PR TITLE
(gce) fixes bug that prevented clone wizard instance type population

### DIFF
--- a/app/scripts/modules/google/serverGroup/configure/serverGroupConfiguration.service.js
+++ b/app/scripts/modules/google/serverGroup/configure/serverGroupConfiguration.service.js
@@ -174,7 +174,6 @@ module.exports = angular.module('spinnaker.serverGroup.configure.gce.configurati
       if (_.some([ !vCpuCount, !gceCustomInstanceBuilderService.vCpuCountForLocationIsValid(vCpuCount, location)] )) {
         vCpuCount = _.get(command, 'backingData.customInstanceTypes.vCpuList[0]');
         _.set(command, 'viewState.customInstance.vCpuCount', vCpuCount);
-        command.instanceType = null;
       }
 
       _.set(


### PR DESCRIPTION
(gce) fixes bug that prevented clone wizard instance type population

@duftler PTAL

This line was supposed to clear the instance type when the custom fields are malformed (e.g. when you pick a zone that doesn't support the vCPU count), but the rest of the function handles this logic properly (and doesn't cause the bug).