### PR TITLE
(gce) prevent invalid selection of instance types for location

### DIFF
--- a/app/scripts/modules/core/help/helpContents.js
+++ b/app/scripts/modules/core/help/helpContents.js
@@ -113,7 +113,7 @@ module.exports = angular.module('spinnaker.core.help.contents', [])
     'gce.instance.serviceAccount': '<p>Service accounts authenticate applications running on your virtual machine instances to other Google Cloud Platform services. Valid values are either "default" or the full email address of a custom service account.</p>',
     'gce.instance.authScopes': '<p>Service account scopes specify which Google Cloud Platform APIs your instances can authenticate with, and define the level of access that your instances have with those services.</p>',
     'gce.instance.authScopes.cloud-platform': '<p>The instances in this server group have full API access to all Google Cloud services.</p>',
-    'gce.instanceType.32core': '<p>32-core machine types are in Beta and are available only in Ivy Bridge and Haswell zones. Attempting to provision a 32-core machine in an unsupported zone will result in a <b>machine type not found</b> error message.</p>',
+    'gce.instanceType.32core': '<p>32-core machine types are in Beta and are available only in Ivy Bridge and Haswell zones.</p><p>They are not available in these locations:<ul><li>us-central1-a</li><li>europe-west1-b</li><li>europe-west1 (when deploying regionally)</li></p>',
     'gce.loadBalancer.detail': '<p>(Optional) <b>Detail</b> is a string of free-form alphanumeric characters and hyphens to describe any other variables.</p>',
     'gce.loadBalancer.advancedSettings.healthInterval': '<p>Configures the interval, in seconds, between load balancer health checks.</p><p>Default: <b>10</b></p>',
     'gce.loadBalancer.advancedSettings.healthyThreshold': '<p>Configures the number of healthy observations before reinstituting an instance into the load balancer’s traffic rotation.</p><p>Default: <b>10</b></p>',

--- a/app/scripts/modules/google/instance/gceVCpuMaxByLocation.value.js
+++ b/app/scripts/modules/google/instance/gceVCpuMaxByLocation.value.js
@@ -1,0 +1,32 @@
+'use strict';
+
+let angular = require('angular');
+
+/**
+ * Zones that support Haswell and Ivy Bridge processors can support custom machine types up to 32 vCPUs.
+ * Zones that support Sandy Bridge processors can support up to 16 vCPUs.
+ * This list should be kept in sync with the corresponding list in clouddriver:
+ * @link { https://github.com/spinnaker/clouddriver/blob/master/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/StandardGceAttributeValidator.groovy }
+ */
+module.exports = angular.module('spinnaker.gce.instance.vCpuMaxByLocation.value', [
+  require('../../core/utils/lodash.js')
+])
+  .constant('gceVCpuMaxByLocation', {
+    'us-east1-b': 32,
+    'us-east1-c': 32,
+    'us-east1-d': 32,
+    'us-central1-a': 16,
+    'us-central1-b': 32,
+    'us-central1-c': 32,
+    'us-central1-f': 32,
+    'europe-west1-b': 16,
+    'europe-west1-c': 32,
+    'europe-west1-d': 32,
+    'asia-east1-a': 32,
+    'asia-east1-b': 32,
+    'asia-east1-c': 32,
+    'us-east1': 32,
+    'us-central1': 32,
+    'europe-west1': 16,
+    'asia-east1': 32,
+  });

--- a/app/scripts/modules/google/serverGroup/configure/serverGroupConfiguration.service.js
+++ b/app/scripts/modules/google/serverGroup/configure/serverGroupConfiguration.service.js
@@ -145,7 +145,8 @@ module.exports = angular.module('spinnaker.serverGroup.configure.gce.configurati
 
     function configureStandardInstanceTypes(command) {
       let result = { dirty: {} };
-      let filtered = gceInstanceTypeService.getAvailableTypesForRegions(command.backingData.instanceTypes, [command.region]);
+      let locations = command.regional ? [ command.region ] : [ command.zone ];
+      let filtered = gceInstanceTypeService.getAvailableTypesForLocations(command.backingData.instanceTypes, locations);
       filtered = sortInstanceTypes(filtered);
       let instanceType = command.instanceType;
       if (_.every([ instanceType, !_.startsWith(instanceType, 'custom'), !_.contains(filtered, instanceType) ])) {
@@ -511,7 +512,7 @@ module.exports = angular.module('spinnaker.serverGroup.configure.gce.configurati
         }
         command.viewState.dirty = command.viewState.dirty || {};
         angular.extend(command.viewState.dirty, result.dirty);
-        angular.extend(command.viewState.dirty, configureCustomInstanceTypes(command).dirty);
+        angular.extend(command.viewState.dirty, configureInstanceTypes(command).dirty);
         return result;
       };
 

--- a/app/scripts/modules/google/serverGroup/configure/wizard/customInstance/customInstanceBuilder.gce.service.js
+++ b/app/scripts/modules/google/serverGroup/configure/wizard/customInstance/customInstanceBuilder.gce.service.js
@@ -3,37 +3,13 @@
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.serverGroup.customInstanceBuilder.gce.service', [
-  require('../../../../../core/utils/lodash.js')
+  require('../../../../../core/utils/lodash.js'),
+  require('../../../../instance/gceVCpuMaxByLocation.value.js'),
 ])
-  .factory('gceCustomInstanceBuilderService', function(_) {
-    /**
-     * Zones that support Haswell and Ivy Bridge processors can support custom machine types up to 32 vCPUs.
-     * Zones that support Sandy Bridge processors can support up to 16 vCPUs.
-     * This list should be kept in sync with the corresponding list in clouddriver:
-     * @link { https://github.com/spinnaker/clouddriver/blob/master/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/StandardGceAttributeValidator.groovy }
-    */
-    let cpuMaxByLocation = {
-      'us-east1-b': 32,
-      'us-east1-c': 32,
-      'us-east1-d': 32,
-      'us-central1-a': 16,
-      'us-central1-b': 32,
-      'us-central1-c': 32,
-      'us-central1-f': 32,
-      'europe-west1-b': 16,
-      'europe-west1-c': 32,
-      'europe-west1-d': 32,
-      'asia-east1-a': 32,
-      'asia-east1-b': 32,
-      'asia-east1-c': 32,
-      'us-east1': 32,
-      'us-central1': 32,
-      'europe-west1': 32,
-      'asia-east1': 32
-    };
+  .factory('gceCustomInstanceBuilderService', function(gceVCpuMaxByLocation, _) {
 
     function vCpuCountForLocationIsValid(vCpuCount, location) {
-      return vCpuCount <= cpuMaxByLocation[location];
+      return vCpuCount <= gceVCpuMaxByLocation[location];
     }
 
     /*
@@ -47,7 +23,7 @@ module.exports = angular.module('spinnaker.serverGroup.customInstanceBuilder.gce
     }
 
     function generateValidVCpuListForLocation(location) {
-      let max = cpuMaxByLocation[location];
+      let max = gceVCpuMaxByLocation[location];
       return [ 1, ..._.range(2, max, 2), max ];
     }
 


### PR DESCRIPTION
(gce) prevent invalid selection of instance types for location

"getAvailableTypesForRegions" is kept as an alias of "getAvailableTypesForLocations" because it is one of the core functions expected of a provider.

@duftler PTAL
