### PR TITLE
JIRA-1849: Runtime issue with ACA Task stage details.

### DIFF
--- a/app/scripts/modules/netflix/pipeline/stage/acaTask/acaTaskExecutionDetails.controller.js
+++ b/app/scripts/modules/netflix/pipeline/stage/acaTask/acaTaskExecutionDetails.controller.js
@@ -28,20 +28,21 @@ module.exports = angular.module('spinnaker.netflix.pipeline.stage.acaTask.detail
           $scope.baseline = $scope.stage.context.baseline;
           $scope.canaryDeployments = $scope.canary.canaryDeployments;
         }
+
+        $scope.deployment = $scope.stage.context;
+
+        $scope.viewState = {
+          loadingHistory: true,
+          loadingHistoryError: false,
+        };
+
+        executionDetailsSectionService.synchronizeSection($scope.configSections);
+        $scope.detailsSection = $stateParams.details;
+
+
+        $scope.loadHistory();
       });
 
-      $scope.deployment = $scope.stage.context;
-
-      $scope.viewState = {
-        loadingHistory: true,
-        loadingHistoryError: false,
-      };
-
-      executionDetailsSectionService.synchronizeSection($scope.configSections);
-      $scope.detailsSection = $stateParams.details;
-
-
-      $scope.loadHistory();
     }
 
 


### PR DESCRIPTION
Switching b/t 2 ACA tasks stages would display stale detail info.  This was due to a race condition between fetching the canary on stage change and fetching its detail info.

@anotherchrisberry PTAL