### PR TITLE
(kubernetes) instance refresh fix

### DIFF
--- a/app/scripts/modules/kubernetes/instance/details/details.controller.js
+++ b/app/scripts/modules/kubernetes/instance/details/details.controller.js
@@ -260,7 +260,7 @@ module.exports = angular.module('spinnaker.instance.detail.kubernetes.controller
       //     is no point in subscribing to the refresh
       //  2. If this is a standalone instance, there is no application that will refresh
       if (!$scope.$$destroyed && !app.isStandalone) {
-        app.serverGroups.onRefresh(retrieveInstance);
+        app.serverGroups.onRefresh($scope, retrieveInstance);
       }
     });
 


### PR DESCRIPTION
(kubernetes) instance refresh fix

This was preventing instances from being updated. 

It was also the source of the "$scope.$on is not a function" error that Steven reported.

@lwander PTAL