### PR TITLE
(aws) alert user to impedance with suspended processes

### DIFF
--- a/app/scripts/modules/amazon/serverGroup/details/serverGroupDetails.aws.controller.js
+++ b/app/scripts/modules/amazon/serverGroup/details/serverGroupDetails.aws.controller.js
@@ -95,10 +95,6 @@ module.exports = angular.module('spinnaker.serverGroup.details.aws.controller', 
               this.serverGroup = plainDetails;
               this.applyAccountDetails(this.serverGroup);
 
-              this.runningExecutions = () => {
-                return runningExecutionsService.filterRunningExecutions(this.serverGroup.executions);
-              };
-
               if (!_.isEmpty(this.serverGroup)) {
 
                 this.image = details.image ? details.image : undefined;
@@ -134,6 +130,12 @@ module.exports = angular.module('spinnaker.serverGroup.details.aws.controller', 
                 this.disabledDate = autoScalingProcessService.getDisabledDate(this.serverGroup);
                 awsServerGroupTransformer.normalizeServerGroupDetails(this.serverGroup);
                 this.scalingPolicies = this.serverGroup.scalingPolicies;
+                this.scalingPoliciesDisabled = this.scalingPolicies.length && this.autoScalingProcesses
+                    .filter(p => !p.enabled)
+                    .some(p => ['Launch','Terminate','AlarmNotification'].indexOf(p.name) > -1);
+                this.scheduledActionsDisabled = this.serverGroup.scheduledActions.length && this.autoScalingProcesses
+                    .filter(p => !p.enabled)
+                    .some(p => ['Launch','Terminate','ScheduledAction'].indexOf(p.name) > -1);
 
               } else {
                 autoClose();
@@ -151,6 +153,22 @@ module.exports = angular.module('spinnaker.serverGroup.details.aws.controller', 
         app.serverGroups.onRefresh($scope, retrieveServerGroup);
       }
     });
+
+    this.runningExecutions = () => {
+      return runningExecutionsService.filterRunningExecutions(this.serverGroup.executions);
+    };
+
+    this.isEnableLocked = () => {
+      if (this.serverGroup.isDisabled) {
+        let resizeTasks = (this.serverGroup.runningTasks || [])
+          .filter(task => _.get(task, 'execution.stages', []).some(
+            stage => stage.type === 'resizeServerGroup'));
+        if (resizeTasks.length) {
+          return true;
+        }
+      }
+      return false;
+    };
 
     this.destroyServerGroup = () => {
       var serverGroup = this.serverGroup;

--- a/app/scripts/modules/amazon/serverGroup/details/serverGroupDetails.html
+++ b/app/scripts/modules/amazon/serverGroup/details/serverGroupDetails.html
@@ -38,7 +38,14 @@
             <li role="presentation" class="divider" ng-if=" !ctrl.serverGroup.isDisabled"></li>
             <li><a href ng-click="ctrl.resizeServerGroup()">Resize</a></li>
             <li><a href ng-if=" !ctrl.serverGroup.isDisabled" ng-click="ctrl.disableServerGroup()">Disable</a></li>
-            <li><a href ng-if="ctrl.serverGroup.isDisabled" ng-click="ctrl.enableServerGroup()">Enable</a></li>
+            <li><a href ng-if="ctrl.serverGroup.isDisabled && !ctrl.isEnableLocked()" ng-click="ctrl.enableServerGroup()">Enable</a></li>
+            <li class="disabled" ng-if="ctrl.isEnableLocked()">
+              <a uib-tooltip="Cannot enable this server group until resize operation completes"
+                 tooltip-placement="left">
+                <span class="small glyphicon glyphicon-lock"></span>
+                Enable
+              </a>
+            </li>
             <li><a href ng-click="ctrl.destroyServerGroup()">Destroy</a></li>
             <li><a href ng-click="ctrl.cloneServerGroup(ctrl.serverGroup)">Clone</a></li>
             <li><migrator application="ctrl.application" server-group="ctrl.serverGroup"></migrator></li>
@@ -56,7 +63,7 @@
       </div>
     </div>
   </div>
-  <div class="info-band" ng-if="ctrl.serverGroup.isDisabled">
+  <div class="band band-info" ng-if="ctrl.serverGroup.isDisabled">
     Disabled {{ctrl.disabledDate | timestamp}}
   </div>
   <div class="content" ng-if="!ctrl.state.loading">
@@ -196,19 +203,6 @@
         <dd ng-if=" !ctrl.serverGroup.launchConfig.userData">[none]</dd>
       </dl>
     </collapsible-section>
-    <collapsible-section heading="Scaling Processes">
-      <ul class="scaling-processes">
-        <li ng-repeat="process in ctrl.autoScalingProcesses">
-          <span is-visible="process.enabled" class="glyphicon glyphicon-ok small"></span>
-          <span ng-class="{'text-disabled': !process.enabled}">{{process.name}}</span>
-          <help-field content="{{process.description}}" placement="bottom"></help-field>
-          <div ng-if="process.suspensionDate" class="text-disabled small" style="margin-left: 35px">
-            Suspended {{process.suspensionDate | timestamp}}
-          </div>
-        </li>
-      </ul>
-      <a href ng-click="ctrl.toggleScalingProcesses()">Edit Scaling Processes</a>
-    </collapsible-section>
     <collapsible-section heading="Security Groups">
       <ul>
         <li ng-repeat="securityGroup in ctrl.securityGroups | orderBy:'name'">
@@ -219,19 +213,58 @@
       </ul>
       <a href ng-click="ctrl.updateSecurityGroups()" ng-if="ctrl.serverGroup.vpcId">Edit Security Groups</a>
     </collapsible-section>
-    <collapsible-section heading="Scaling Policies">
-      <scaling-policy-summary ng-repeat="policy in ctrl.scalingPolicies track by policy.policyARN"
-                      policy="policy"
-                      server-group="ctrl.serverGroup"
-                      application="ctrl.application"></scaling-policy-summary>
-      <add-scaling-policy-button server-group="ctrl.serverGroup"
-                                 application="ctrl.application"></add-scaling-policy-button>
+    <collapsible-section cache-key="Scaling Processes">
+      <section-heading>
+        <span ng-if="ctrl.scalingPoliciesDisabled" class="glyphicon glyphicon-exclamation-sign warning-text"
+              uib-tooltip="Some scaling processes are disabled that may prevent scaling policies from working"></span>
+        <span ng-if="ctrl.scheduledActionsDisabled" class="glyphicon glyphicon-exclamation-sign warning-text"
+              uib-tooltip="Some scaling processes are disabled that may prevent scheduled actions from working"></span>
+        Scaling Processes
+      </section-heading>
+      <section-body>
+        <ul class="scaling-processes">
+          <li ng-repeat="process in ctrl.autoScalingProcesses">
+            <span is-visible="process.enabled" class="glyphicon glyphicon-ok small"></span>
+            <span ng-class="{'text-disabled': !process.enabled}">{{process.name}}</span>
+            <help-field content="{{process.description}}" placement="bottom"></help-field>
+            <div ng-if="process.suspensionDate" class="text-disabled small" style="margin-left: 35px">
+              Suspended {{process.suspensionDate | timestamp}}
+            </div>
+          </li>
+        </ul>
+        <a href ng-click="ctrl.toggleScalingProcesses()">Edit Scaling Processes</a>
+      </section-body>
     </collapsible-section>
-    <collapsible-section heading="Scheduled Actions">
-      <scheduled-action ng-repeat="action in ctrl.serverGroup.scheduledActions" action="action"></scheduled-action>
-      <p ng-if="ctrl.serverGroup.scheduledActions.length"><strong>Note:</strong> Schedules are evaluated in UTC.</p>
-      <p ng-if=" !ctrl.serverGroup.scheduledActions.length">No Scheduled Actions are configured for this server group.</p>
-      <a href ng-click="ctrl.editScheduledActions()">Edit Scheduled Actions</a>
+    <collapsible-section cache-key="Scaling Policies">
+      <section-heading>
+        <span ng-if="ctrl.scalingPoliciesDisabled" class="glyphicon glyphicon-exclamation-sign warning-text"
+              uib-tooltip="Some scaling processes are disabled that may prevent scaling policies from working"></span>
+        Scaling Policies
+      </section-heading>
+      <section-body>
+        <div class="band band-warning" ng-if="ctrl.scalingPoliciesDisabled">
+          Some scaling processes are disabled that may prevent scaling policies from working.
+        </div>
+        <scaling-policy-summary ng-repeat="policy in ctrl.scalingPolicies track by policy.policyARN"
+                                policy="policy"
+                                server-group="ctrl.serverGroup"
+                                application="ctrl.application"></scaling-policy-summary>
+        <add-scaling-policy-button server-group="ctrl.serverGroup"
+                                   application="ctrl.application"></add-scaling-policy-button>
+      </section-body>
+    </collapsible-section>
+    <collapsible-section cache-key="Scheduled Actions">
+      <section-heading>
+        <span ng-if="ctrl.scheduledActionsDisabled" class="glyphicon glyphicon-exclamation-sign warning-text"
+              uib-tooltip="Some scaling processes are disabled that may prevent scheduled actions from working"></span>
+        Scheduled Actions
+      </section-heading>
+      <section-body>
+        <scheduled-action ng-repeat="action in ctrl.serverGroup.scheduledActions" action="action"></scheduled-action>
+        <p ng-if="ctrl.serverGroup.scheduledActions.length"><strong>Note:</strong> Schedules are evaluated in UTC.</p>
+        <p ng-if="!ctrl.serverGroup.scheduledActions.length">No Scheduled Actions are configured for this server group.</p>
+        <a href ng-click="ctrl.editScheduledActions()">Edit Scheduled Actions</a>
+      </section-body>
     </collapsible-section>
     <collapsible-section heading="Tags">
       <div ng-if=" !ctrl.serverGroup.asg.tags.length">No tags associated with this server group</div>

--- a/app/scripts/modules/core/presentation/collapsibleSection/collapsibleSection.directive.html
+++ b/app/scripts/modules/core/presentation/collapsibleSection/collapsibleSection.directive.html
@@ -3,8 +3,10 @@
     <h4 class="collapsible-{{getClassType()}}heading">
       <span class="glyphicon glyphicon-chevron-{{getIcon()}}"></span>
       {{heading}}
+      <span ng-transclude="heading"></span>
       <help-field ng-if="helpKey" key="{{helpKey}}" placement="right"></help-field>
     </h4>
   </a>
-  <div class="content-body" ng-class="bodyClass" ng-if="state.expanded" ng-transclude></div>
+  <div class="content-body" ng-class="bodyClass" ng-if="heading && state.expanded" ng-transclude></div>
+  <div class="content-body" ng-class="bodyClass" ng-if="!heading && state.expanded" ng-transclude="body"></div>
 </div>

--- a/app/scripts/modules/core/presentation/collapsibleSection/collapsibleSection.directive.js
+++ b/app/scripts/modules/core/presentation/collapsibleSection/collapsibleSection.directive.js
@@ -9,19 +9,27 @@ module.exports = angular.module('spinnaker.core.presentation.collapsibleSection.
     return {
       restrict: 'E',
       replace: true,
-      transclude: true,
+      transclude: {
+        heading: '?sectionHeading',
+        body: '?sectionBody'
+      },
       scope: {
         heading: '@',
         expanded: '@?',
         bodyClass: '@?',
+        cacheKey: '@?',
         helpKey: '@',
         subsection: '=',
       },
       templateUrl: require('./collapsibleSection.directive.html'),
       link: function(scope) {
-        var expanded = collapsibleSectionStateCache.isSet(scope.heading) ?
-          collapsibleSectionStateCache.isExpanded(scope.heading) :
+        let cacheKey = scope.cacheKey || scope.heading;
+        let expanded = true;
+        if (cacheKey) {
+          expanded = collapsibleSectionStateCache.isSet(cacheKey) ?
+            collapsibleSectionStateCache.isExpanded(cacheKey) :
           scope.expanded === 'true';
+        }
         scope.state = {expanded: expanded};
         scope.getIcon = function() {
           return scope.state.expanded ? 'down' : 'up';
@@ -33,7 +41,9 @@ module.exports = angular.module('spinnaker.core.presentation.collapsibleSection.
 
         scope.toggle = function() {
           scope.state.expanded = !scope.state.expanded;
-          collapsibleSectionStateCache.setExpanded(scope.heading, scope.state.expanded);
+          if (cacheKey) {
+            collapsibleSectionStateCache.setExpanded(cacheKey, scope.state.expanded);
+          }
         };
       }
     };

--- a/app/scripts/modules/core/presentation/details.less
+++ b/app/scripts/modules/core/presentation/details.less
@@ -30,12 +30,22 @@
   }
 }
 
-.info-band {
-  background-color: @mid_grey;
-  color: #ffffff;
+.band {
   margin: 5px 0;
   padding: 5px;
   text-align: center;
+  color: #ffffff;
+  &.band-info {
+    background-color: @mid_grey;
+  }
+  &.band-warning {
+    background-color: @unhealthy_red;
+  }
+}
+.collapsible-section {
+  .band {
+    margin: 5px -20px;
+  }
 }
 
 .details-panel {

--- a/app/scripts/modules/netflix/serverGroup/awsServerGroupDetails.html
+++ b/app/scripts/modules/netflix/serverGroup/awsServerGroupDetails.html
@@ -38,7 +38,14 @@
             <li role="presentation" class="divider" ng-if="!ctrl.serverGroup.isDisabled"></li>
             <li><a href ng-click="ctrl.resizeServerGroup()">Resize</a></li>
             <li><a href ng-if="!ctrl.serverGroup.isDisabled" ng-click="ctrl.disableServerGroup()">Disable</a></li>
-            <li><a href ng-if="ctrl.serverGroup.isDisabled" ng-click="ctrl.enableServerGroup()">Enable</a></li>
+            <li><a href ng-if="ctrl.serverGroup.isDisabled && !ctrl.isEnableLocked()" ng-click="ctrl.enableServerGroup()">Enable</a></li>
+            <li class="disabled" ng-if="ctrl.isEnableLocked()">
+              <a uib-tooltip="Cannot enable this server group until resize operation completes"
+                 tooltip-placement="left">
+                <span class="small glyphicon glyphicon-lock"></span>
+                Enable
+              </a>
+            </li>
             <li><a href ng-click="ctrl.destroyServerGroup()">Destroy</a></li>
             <li><a href ng-click="ctrl.cloneServerGroup(ctrl.serverGroup)">Clone</a></li>
             <li><migrator application="ctrl.application" server-group="ctrl.serverGroup"></migrator></li>
@@ -56,7 +63,7 @@
       </div>
     </div>
   </div>
-  <div class="info-band" ng-if="ctrl.serverGroup.isDisabled">
+  <div class="band band-info" ng-if="ctrl.serverGroup.isDisabled">
     Disabled {{ctrl.disabledDate | timestamp}}
   </div>
   <div class="content" ng-if="!ctrl.state.loading">
@@ -118,7 +125,6 @@
             <li ng-repeat="zone in ctrl.serverGroup.asg.availabilityZones">{{zone}}</li>
           </ul>
         </dd>
-
       </dl>
     </collapsible-section>
     <collapsible-section heading="Size" expanded="true">
@@ -196,19 +202,6 @@
         <dd ng-if="!ctrl.serverGroup.launchConfig.userData">[none]</dd>
       </dl>
     </collapsible-section>
-    <collapsible-section heading="Scaling Processes">
-      <ul class="scaling-processes">
-        <li ng-repeat="process in ctrl.autoScalingProcesses">
-          <span is-visible="process.enabled" class="glyphicon glyphicon-ok small"></span>
-          <span ng-class="{'text-disabled': !process.enabled}">{{process.name}}</span>
-          <help-field content="{{process.description}}" placement="bottom"></help-field>
-          <div ng-if="process.suspensionDate" class="text-disabled small" style="margin-left: 35px">
-            Suspended {{process.suspensionDate | timestamp}}
-          </div>
-        </li>
-      </ul>
-      <a href ng-click="ctrl.toggleScalingProcesses()">Edit Scaling Processes</a>
-    </collapsible-section>
     <collapsible-section heading="Security Groups">
       <ul>
         <li ng-repeat="securityGroup in ctrl.securityGroups | orderBy:'name'">
@@ -222,19 +215,58 @@
     <collapsible-section heading="Networking">
       <nflx-server-group-networking server-group="ctrl.serverGroup" application="ctrl.application"></nflx-server-group-networking>
     </collapsible-section>
-    <collapsible-section heading="Scaling Policies">
-      <scaling-policy-summary ng-repeat="policy in ctrl.scalingPolicies track by policy.policyARN"
-                      policy="policy"
-                      server-group="ctrl.serverGroup"
-                      application="ctrl.application"></scaling-policy-summary>
-      <add-scaling-policy-button server-group="ctrl.serverGroup"
-                                 application="ctrl.application"></add-scaling-policy-button>
+    <collapsible-section cache-key="Scaling Processes">
+      <section-heading>
+        <span ng-if="ctrl.scalingPoliciesDisabled" class="glyphicon glyphicon-exclamation-sign warning-text"
+              uib-tooltip="Some scaling processes are disabled that may prevent scaling policies from working"></span>
+        <span ng-if="ctrl.scheduledActionsDisabled" class="glyphicon glyphicon-exclamation-sign warning-text"
+              uib-tooltip="Some scaling processes are disabled that may prevent scheduled actions from working"></span>
+        Scaling Processes
+      </section-heading>
+      <section-body>
+        <ul class="scaling-processes">
+          <li ng-repeat="process in ctrl.autoScalingProcesses">
+            <span is-visible="process.enabled" class="glyphicon glyphicon-ok small"></span>
+            <span ng-class="{'text-disabled': !process.enabled}">{{process.name}}</span>
+            <help-field content="{{process.description}}" placement="bottom"></help-field>
+            <div ng-if="process.suspensionDate" class="text-disabled small" style="margin-left: 35px">
+              Suspended {{process.suspensionDate | timestamp}}
+            </div>
+          </li>
+        </ul>
+        <a href ng-click="ctrl.toggleScalingProcesses()">Edit Scaling Processes</a>
+      </section-body>
     </collapsible-section>
-    <collapsible-section heading="Scheduled Actions">
-      <scheduled-action ng-repeat="action in ctrl.serverGroup.scheduledActions" action="action"></scheduled-action>
-      <p ng-if="ctrl.serverGroup.scheduledActions.length"><strong>Note:</strong> Schedules are evaluated in UTC.</p>
-      <p ng-if="!ctrl.serverGroup.scheduledActions.length">No Scheduled Actions are configured for this server group.</p>
-      <a href ng-click="ctrl.editScheduledActions()">Edit Scheduled Actions</a>
+    <collapsible-section cache-key="Scaling Policies">
+      <section-heading>
+        <span ng-if="ctrl.scalingPoliciesDisabled" class="glyphicon glyphicon-exclamation-sign warning-text"
+              uib-tooltip="Some scaling processes are disabled that may prevent scaling policies from working"></span>
+        Scaling Policies
+      </section-heading>
+      <section-body>
+        <div class="band band-warning" ng-if="ctrl.scalingPoliciesDisabled">
+          Some scaling processes are disabled that may prevent scaling policies from working.
+        </div>
+        <scaling-policy-summary ng-repeat="policy in ctrl.scalingPolicies track by policy.policyARN"
+                                policy="policy"
+                                server-group="ctrl.serverGroup"
+                                application="ctrl.application"></scaling-policy-summary>
+        <add-scaling-policy-button server-group="ctrl.serverGroup"
+                                   application="ctrl.application"></add-scaling-policy-button>
+      </section-body>
+    </collapsible-section>
+    <collapsible-section cache-key="Scheduled Actions">
+      <section-heading>
+        <span ng-if="ctrl.scheduledActionsDisabled" class="glyphicon glyphicon-exclamation-sign warning-text"
+              uib-tooltip="Some scaling processes are disabled that may prevent scheduled actions from working"></span>
+        Scheduled Actions
+      </section-heading>
+      <section-body>
+        <scheduled-action ng-repeat="action in ctrl.serverGroup.scheduledActions" action="action"></scheduled-action>
+        <p ng-if="ctrl.serverGroup.scheduledActions.length"><strong>Note:</strong> Schedules are evaluated in UTC.</p>
+        <p ng-if="!ctrl.serverGroup.scheduledActions.length">No Scheduled Actions are configured for this server group.</p>
+        <a href ng-click="ctrl.editScheduledActions()">Edit Scheduled Actions</a>
+      </section-body>
     </collapsible-section>
     <collapsible-section heading="Tags">
       <div ng-if="!ctrl.serverGroup.asg.tags.length">No tags associated with this server group</div>


### PR DESCRIPTION
We've run into some unfortunate situations where users inadvertently disable autoscaling. This happens when a user resizes a disable ASG, then enables the ASG before the resize completes.

When the resize operation starts, Orca flips on the Launch and Terminate processes. The enable operation enables Launch, Terminate, and AddToLoadBalancer. After the ASG has been resized, Orca flips Launch and Terminate back to their original state.

This PR does two things:
 1. Adds a warning icon next to the Scaling Processes and Scaling Policies/Scheduled Actions section heading if Launch or Terminate are disabled and the ASG has scaling policies or scheduled actions
<img width="402" alt="screen shot 2016-06-24 at 11 29 07 am" src="https://cloud.githubusercontent.com/assets/73450/16346952/ebaee9f6-39fe-11e6-9f06-90fb9fb1aea0.png">

 2. Disables the "Enable" action if a resize operation is running
<img width="523" alt="screen shot 2016-06-24 at 10 24 14 am" src="https://cloud.githubusercontent.com/assets/73450/16345946/84d85b18-39f9-11e6-9845-c2fc77926cfd.png">


There's still a chance the user can mess this up - if the running tasks do not get attached to the ASG right away, for example - but it's much less likely, and the locks should provide some visibility into the "bad" state.