### PR TITLE
(core) fix load order on task view, refresh tasks when task starts

### DIFF
--- a/app/scripts/modules/core/task/monitor/taskMonitorService.js
+++ b/app/scripts/modules/core/task/monitor/taskMonitorService.js
@@ -61,6 +61,9 @@ module.exports = angular.module('spinnaker.tasks.monitor.service', [
       monitor.handleTaskSuccess = function (task) {
         let applicationName = monitor.application ? monitor.application.name : 'ad-hoc';
         monitor.task = task;
+        if (monitor.application) {
+          monitor.application.runningOrchestrations.refresh();
+        }
         taskReader.waitUntilTaskCompletes(applicationName, task, monitor.monitorInterval)
           .then(monitor.onTaskComplete, monitor.setError);
       };

--- a/app/scripts/modules/core/task/monitor/taskMonitorService.spec.js
+++ b/app/scripts/modules/core/task/monitor/taskMonitorService.spec.js
@@ -34,8 +34,9 @@ describe('Service: taskMonitorService', function () {
       let monitor = taskMonitorService.buildTaskMonitor({
         onTaskComplete: () => completeCalled = true,
         modalInstance: { result: $q.defer().promise },
-        application: { name: 'deck' },
+        application: { name: 'deck', runningOrchestrations: { refresh: angular.noop } },
       });
+      spyOn(monitor.application.runningOrchestrations, 'refresh');
 
       monitor.submit(operation);
 
@@ -48,6 +49,7 @@ describe('Service: taskMonitorService', function () {
       $timeout.flush();
       $http.flush();
       expect(monitor.task.isCompleted).toBe(false);
+      expect(monitor.application.runningOrchestrations.refresh.calls.count()).toBe(1);
 
       $http.expectGET(['/applications', 'deck', 'tasks', 'a'].join('/')).respond(200, { status: 'SUCCEEDED' });
       $timeout.flush(); // complete second time
@@ -87,7 +89,7 @@ describe('Service: taskMonitorService', function () {
       let monitor = taskMonitorService.buildTaskMonitor({
         onTaskComplete: () => completeCalled = true,
         modalInstance: { result: $q.defer().promise },
-        application: { name: 'deck' },
+        application: { name: 'deck', runningOrchestrations: { refresh: angular.noop } }
       });
 
       monitor.submit(operation);

--- a/app/scripts/modules/core/task/tasks.controller.js
+++ b/app/scripts/modules/core/task/tasks.controller.js
@@ -254,6 +254,8 @@ module.exports = angular.module('spinnaker.core.task.controller', [
 
     initializeViewState();
 
+    application.tasks.activate();
+
     application.tasks.ready().then(() => {
       $scope.viewState.loading = false;
       $scope.viewState.loadError = app.tasks.loadFailure;
@@ -262,7 +264,6 @@ module.exports = angular.module('spinnaker.core.task.controller', [
       }
     });
 
-    application.tasks.activate();
     application.activeState = application.tasks;
     $scope.$on('$destroy', () => {
       application.activeState = application;


### PR DESCRIPTION
Refreshing the running tasks attaches them immediately to the object being operated against, which is nice.

Also fixing the initialization order in the tasks view. Since the tasks are lazy loaded, we need to activate the tasks _before_ we call `ready()` on the section, or it'll always return immediately.