### PR TITLE
(core) use $http to send exception alert

### DIFF
--- a/app/scripts/modules/netflix/alert/alertHandler.js
+++ b/app/scripts/modules/netflix/alert/alertHandler.js
@@ -8,11 +8,13 @@ module.exports = angular
     require('../../core/authentication/authentication.service.js'),
   ])
   .config(function ($provide) {
-    $provide.decorator('$exceptionHandler', function($delegate, settings, authenticationService, $) {
+    $provide.decorator('$exceptionHandler', function($delegate, settings, authenticationService, $injector) {
       let currentVersion = require('../../../../../version.json');
 
       return function(exception, cause) {
         $delegate(exception, cause);
+        // using injector access to avoid a circular dependency
+        let $http = $injector.get('$http');
         if (!settings.alert) {
           return;
         }
@@ -50,11 +52,7 @@ module.exports = angular
           ],
         };
 
-        $.ajax(settings.alert.url, {
-          method: 'POST',
-          data: JSON.stringify(payload),
-          contentType: 'application/json'
-        });
+        $http.post(settings.alert.url, payload);
       };
     });
   });


### PR DESCRIPTION
Using jQuery's `ajax` method does not pass the request through the authorization interceptor, so auth headers are not included and the request is intercepted by Gate when auth is enabled.