### PR TITLE
(k8s) require container selection has visual cue

### DIFF
--- a/app/scripts/modules/core/forms/uiSelect.decorator.js
+++ b/app/scripts/modules/core/forms/uiSelect.decorator.js
@@ -68,6 +68,20 @@ module.exports = function($provide) {
         //Set reference to ngModel from uiSelectCtrl
         $select.ngModel = ngModel;
 
+        if (angular.isDefined(attrs.required)) {
+          $select.ngModel.$validators.validateRequired = (modelValue) => {
+            if (angular.isDefined(modelValue)) {
+              if (angular.isArray(modelValue)) {
+                return modelValue.length > 0;
+              } else {
+                return true;
+              }
+            } else {
+              return false;
+            }
+          };
+        }
+
         $select.choiceGrouped = function(group) {
           return $select.isGrouped && group && group.name;
         };

--- a/app/scripts/modules/kubernetes/serverGroup/configure/wizard/basicSettings.html
+++ b/app/scripts/modules/kubernetes/serverGroup/configure/wizard/basicSettings.html
@@ -1,109 +1,107 @@
-<form name="form" class="container-fluid form-horizontal" ng-controller="kubernetesServerGroupBasicSettingsController as basicSettingsController" novalidate>
-  <ng-form name="basicSettings">
-    <div class="form-group">
-      <div class="col-md-3 sm-label-right">
-        <b>Account</b>
-      </div>
-      <div class="col-md-7">
-        <account-select-field component="command" field="account" accounts="command.backingData.accounts" provider="'kubernetes'"></account-select-field>
-      </div>
+<ng-form name="basicSettings" ng-controller="kubernetesServerGroupBasicSettingsController as basicSettingsController" novalidate>
+  <div class="form-group">
+    <div class="col-md-3 sm-label-right">
+      <b>Account</b>
     </div>
-      <namespace-select-field component="command" field="namespace" account="command.account" namespaces="command.backingData.filtered.namespaces"></namespace-select-field>
-    <div class="form-group">
-      <div class="col-md-3 sm-label-right">
-        Stack
-        <help-field key="kubernetes.serverGroup.stack"></help-field>
-      </div>
-      <div class="col-md-7"><input type="text"
-                                   class="form-control input-sm"
-                                   ng-pattern="basicSettingsController.stackPattern"
-                                   name="stack"
-                                   ng-model="command.stack"/></div>
+    <div class="col-md-7">
+      <account-select-field component="command" field="account" accounts="command.backingData.accounts" provider="'kubernetes'"></account-select-field>
     </div>
-    <div class="form-group row slide-in animated" ng-if="basicSettings.stack.$error.pattern">
-      <div class="col-sm-9 col-sm-offset-2 error-message">
-        <span>Only dot(.) and underscore(_) special characters are allowed in the Stack field.</span>
-      </div>
+  </div>
+    <namespace-select-field component="command" field="namespace" account="command.account" namespaces="command.backingData.filtered.namespaces"></namespace-select-field>
+  <div class="form-group">
+    <div class="col-md-3 sm-label-right">
+      Stack
+      <help-field key="kubernetes.serverGroup.stack"></help-field>
     </div>
-    <div class="form-group">
-      <div class="col-md-3 sm-label-right">
-        Detail
-        <help-field key="kubernetes.serverGroup.detail"></help-field>
-      </div>
-      <div class="col-md-7"><input type="text" class="form-control input-sm"
-                                   ng-pattern="basicSettingsController.detailPattern"
-                                   name="details"
-                                   ng-model="command.freeFormDetails"/></div>
+    <div class="col-md-7"><input type="text"
+                                 class="form-control input-sm"
+                                 ng-pattern="basicSettingsController.stackPattern"
+                                 name="stack"
+                                 ng-model="command.stack"/></div>
+  </div>
+  <div class="form-group row slide-in animated" ng-if="basicSettings.stack.$error.pattern">
+    <div class="col-sm-9 col-sm-offset-2 error-message">
+      <span>Only dot(.) and underscore(_) special characters are allowed in the Stack field.</span>
     </div>
-    <div class="form-group row slide-in animated" ng-if="basicSettings.details.$error.pattern">
-      <div class="col-sm-9 col-sm-offset-2 error-message">
-        <span>Only dot(.), underscore(_), and dash(-) special characters are allowed in the Detail field.</span>
-      </div>
+  </div>
+  <div class="form-group">
+    <div class="col-md-3 sm-label-right">
+      Detail
+      <help-field key="kubernetes.serverGroup.detail"></help-field>
     </div>
+    <div class="col-md-7"><input type="text" class="form-control input-sm"
+                                 ng-pattern="basicSettingsController.detailPattern"
+                                 name="details"
+                                 ng-model="command.freeFormDetails"/></div>
+  </div>
+  <div class="form-group row slide-in animated" ng-if="basicSettings.details.$error.pattern">
+    <div class="col-sm-9 col-sm-offset-2 error-message">
+      <span>Only dot(.), underscore(_), and dash(-) special characters are allowed in the Detail field.</span>
+    </div>
+  </div>
 
-    <div class="col-md-12" ng-if="command.viewState.dirty.containers">
-      <div class="alert alert-warning">
-        <p><span class="glyphicon glyphicon-warning-sign"></span>
-          The following containers are not registered in the above namespace/account and were removed:
-        </p>
-        <ul>
-          <li ng-repeat="removed in command.viewState.dirty.containers">{{removed}}</li>
-        </ul>
-        <p class="text-right">
-          <a class="btn btn-sm btn-default dirty-flag-dismiss" href ng-click="command.viewState.dirty.containers = null">Okay</a>
-        </p>
-      </div>
+  <div class="col-md-12" ng-if="command.viewState.dirty.containers">
+    <div class="alert alert-warning">
+      <p><span class="glyphicon glyphicon-warning-sign"></span>
+        The following containers are not registered in the above namespace/account and were removed:
+      </p>
+      <ul>
+        <li ng-repeat="removed in command.viewState.dirty.containers">{{removed}}</li>
+      </ul>
+      <p class="text-right">
+        <a class="btn btn-sm btn-default dirty-flag-dismiss" href ng-click="command.viewState.dirty.containers = null">Okay</a>
+      </p>
     </div>
+  </div>
 
-    <div class="form-group">
-      <div class="col-md-3 sm-label-right"><b>Containers</b>
-      <help-field key="kubernetes.serverGroup.containers"></help-field>
-      </div>
-      <div class="col-md-9">
-        <ui-select multiple ng-model="command.containers" class="form-control input-sm">
-          <ui-select-match>{{$item.imageDescription.imageId}}</ui-select-match>
-          <ui-select-choices 
-            repeat="container in command.backingData.filtered.containers | filter: { imageDescription: { imageId: $select.search } } | orderBy:'imageDescription.imageId'" 
-            group-by="command.groupByRegistry"
-            refresh="basicSettingsController.searchImages($select.search)">
-            <span ng-bind-html="container.imageDescription.imageId | highlight: $select.search"></span>
-          </ui-select-choices>
-        </ui-select>
-      </div>
+  <div class="form-group">
+    <div class="col-md-3 sm-label-right"><b>Containers</b>
+    <help-field key="kubernetes.serverGroup.containers"></help-field>
     </div>
-    <deployment-strategy-selector label-columns="3" field-columns="9" ng-if="!command.viewState.disableStrategySelection && command.selectedProvider" command="command"></deployment-strategy-selector>
-    <div class="form-group" ng-if="!command.viewState.hideClusterNamePreview">
-      <div class="col-md-9 col-md-offset-2">
-        <div class="well-compact" ng-class="basicSettingsController.showPreviewAsWarning() ? 'alert alert-warning' : 'well'">
-          <h5 class="text-center">
-            <p>Your server group will be in the cluster:</p>
+    <div class="col-md-9">
+      <ui-select multiple name="containerSelect" ng-model="command.containers" class="form-control input-sm" required>
+        <ui-select-match>{{$item.imageDescription.imageId}}</ui-select-match>
+        <ui-select-choices
+          repeat="container in command.backingData.filtered.containers | filter: { imageDescription: { imageId: $select.search } } | orderBy:'imageDescription.imageId'"
+          group-by="command.groupByRegistry"
+          refresh="basicSettingsController.searchImages($select.search)">
+          <span ng-bind-html="container.imageDescription.imageId | highlight: $select.search"></span>
+        </ui-select-choices>
+      </ui-select>
+    </div>
+  </div>
+  <deployment-strategy-selector label-columns="3" field-columns="9" ng-if="!command.viewState.disableStrategySelection && command.selectedProvider" command="command"></deployment-strategy-selector>
+  <div class="form-group" ng-if="!command.viewState.hideClusterNamePreview">
+    <div class="col-md-9 col-md-offset-2">
+      <div class="well-compact" ng-class="basicSettingsController.showPreviewAsWarning() ? 'alert alert-warning' : 'well'">
+        <h5 class="text-center">
+          <p>Your server group will be in the cluster:</p>
+          <p>
+            <strong>
+              {{basicSettingsController.getNamePreview()}}
+              <span ng-if="basicSettingsController.createsNewCluster()"> (new cluster)</span>
+            </strong>
+          </p>
+          <div ng-if="!basicSettingsController.createsNewCluster() && command.viewState.mode === 'create' && latestServerGroup">
             <p>
-              <strong>
-                {{basicSettingsController.getNamePreview()}}
-                <span ng-if="basicSettingsController.createsNewCluster()"> (new cluster)</span>
-              </strong>
+              There is already a server group in this cluster. Do you want to clone it?
             </p>
-            <div ng-if="!basicSettingsController.createsNewCluster() && command.viewState.mode === 'create' && latestServerGroup">
-              <p>
-                There is already a server group in this cluster. Do you want to clone it?
-              </p>
-              <p>
-                Cloning copies the entire configuration from the selected server group, allowing you
-                to modify whichever fields (e.g. image) you need to change in the new server group.
-              </p>
-              <p>
-                To clone a server group, select "Clone" from the "Server Group Actions" menu in the details view of the
-                server group.
-              </p>
-              <p>
-                <a href ng-click="basicSettingsController.navigateToLatestServerGroup()">
-                  Go to details for {{latestServerGroup.name}}
-                </a>
-              </p>
-            </div>
-          </h5>
-        </div>
+            <p>
+              Cloning copies the entire configuration from the selected server group, allowing you
+              to modify whichever fields (e.g. image) you need to change in the new server group.
+            </p>
+            <p>
+              To clone a server group, select "Clone" from the "Server Group Actions" menu in the details view of the
+              server group.
+            </p>
+            <p>
+              <a href ng-click="basicSettingsController.navigateToLatestServerGroup()">
+                Go to details for {{latestServerGroup.name}}
+              </a>
+            </p>
+          </div>
+        </h5>
       </div>
     </div>
-  </ng-form>
-</form>
+  </div>
+</ng-form>

--- a/app/scripts/modules/kubernetes/serverGroup/configure/wizard/wizard.html
+++ b/app/scripts/modules/kubernetes/serverGroup/configure/wizard/wizard.html
@@ -1,33 +1,35 @@
-<div>
-  <div ng-if="state.requiresTemplateSelection">
-    <ng-include src="pages.templateSelection"></ng-include>
-  </div>
-  <div ng-if="!state.loaded" style="height: 200px">
-    <h3 us-spinner="{radius:30, width:8, length: 16}"></h3>
-  </div>
-  <v2-modal-wizard ng-if="state.loaded && !state.requiresTemplateSelection" heading="{{title}}">
-    <v2-wizard-page key="location" label="Basic Settings" mark-complete-on-view="false">
-      <ng-include src="pages.basicSettings"></ng-include>
-    </v2-wizard-page>
-    <v2-wizard-page key="load-balancers" label="Load Balancers" done="true">
-      <ng-include src="pages.loadBalancers"></ng-include>
-    </v2-wizard-page>
-    <v2-wizard-page key="replicas" label="Replicas" done="true">
-      <ng-include src="pages.replicas"></ng-include>
-    </v2-wizard-page>
-    <v2-wizard-page key="volumes" label="Volume Sources" done="true">
-      <ng-include src="pages.volumes"></ng-include>
-    </v2-wizard-page>
-    <div ng-repeat="container in command.containers">
-      <v2-wizard-page key="container-{{$index}}" label="Container {{container.image}}" done="true">
-        <kubernetes-container-configurer command="command" index="$index" container="container"></kubernetes-container-configurer>
-      </v2-wizard-page>
+<form name="form" class="container-fluid form-horizontal">
+  <div>
+    <div ng-if="state.requiresTemplateSelection">
+      <ng-include src="pages.templateSelection"></ng-include>
     </div>
-  </v2-modal-wizard>
-</div>
-<div class="modal-footer" ng-if="!state.requiresTemplateSelection && state.loaded">
-  <button ng-disabled="taskMonitor.submitting" class="btn btn-default btn-cancel" ng-click="ctrl.cancel()">Cancel</button>
-  <submit-button ng-if="ctrl.showSubmitButton()" is-disabled="!ctrl.isValid() || taskMonitor.submitting"
-                 label="command.viewState.submitButtonLabel"
-                 submitting="taskMonitor.submitting" on-click="ctrl.clone()" is-new="true"></submit-button>
-</div>
+    <div ng-if="!state.loaded" style="height: 200px">
+      <h3 us-spinner="{radius:30, width:8, length: 16}"></h3>
+    </div>
+    <v2-modal-wizard ng-if="state.loaded && !state.requiresTemplateSelection" heading="{{title}}">
+      <v2-wizard-page key="location" label="Basic Settings" mark-complete-on-view="false">
+        <ng-include src="pages.basicSettings"></ng-include>
+      </v2-wizard-page>
+      <v2-wizard-page key="load-balancers" label="Load Balancers" done="true">
+        <ng-include src="pages.loadBalancers"></ng-include>
+      </v2-wizard-page>
+      <v2-wizard-page key="replicas" label="Replicas" done="true">
+        <ng-include src="pages.replicas"></ng-include>
+      </v2-wizard-page>
+      <v2-wizard-page key="volumes" label="Volume Sources" done="true">
+        <ng-include src="pages.volumes"></ng-include>
+      </v2-wizard-page>
+      <div ng-repeat="container in command.containers">
+        <v2-wizard-page key="container-{{$index}}" label="Container {{container.image}}" done="true">
+          <kubernetes-container-configurer command="command" index="$index" container="container"></kubernetes-container-configurer>
+        </v2-wizard-page>
+      </div>
+    </v2-modal-wizard>
+  </div>
+  <div class="modal-footer" ng-if="!state.requiresTemplateSelection && state.loaded">
+    <button ng-disabled="taskMonitor.submitting" class="btn btn-default btn-cancel" ng-click="ctrl.cancel()">Cancel</button>
+    <submit-button ng-if="ctrl.showSubmitButton()" is-disabled="!ctrl.isValid() || taskMonitor.submitting"
+                   label="command.viewState.submitButtonLabel"
+                   submitting="taskMonitor.submitting" on-click="ctrl.clone()" is-new="true"></submit-button>
+  </div>
+</form>


### PR DESCRIPTION
(k8s) require container selection has visual cue
@lwander this is all so that the little dot next to "Basic Settings" is grey instead of green if you haven't picked a container.

@anotherchrisberry PTAL, I had to modify the uiSelect decorator to make required work properly. This seems to be a known bug for ui-select-match. Let me know if you have a better idea.