### PR TITLE
(core) move page app owner button to the right

### DIFF
--- a/app/scripts/modules/core/application/application.html
+++ b/app/scripts/modules/core/application/application.html
@@ -12,6 +12,13 @@
       <p class="text-center">Please check your URL - we can't find any data for <em>{{application.name}}</em>.</p>
     </div>
     <span ng-include="ctrl.applicationNavTemplate"></span>
+    <div class="page-button pull-right">
+      <button class="btn btn-xs btn-danger"
+              ng-click="ctrl.pageApplicationOwner()"
+              uib-tooltip="Page application owner">
+        <span class="glyphicon glyphicon-phone-alt"></span>
+      </button>
+    </div>
   </div>
   <div class="scrollable-columns">
     <div class="secondary-panel" ui-view="insight"></div>

--- a/app/scripts/modules/core/application/application.less
+++ b/app/scripts/modules/core/application/application.less
@@ -8,8 +8,14 @@
   .application-name {
     display: inline-block;
   }
+  .page-button {
+    margin-top: 30px;
+    @media (min-width: 708px) and (max-width: 1200px) {
+      margin-top: 16px;
+    }
+  }
   h2 {
-    @media (min-width: 708px) and (max-width: 992px) {
+    @media (min-width: 708px) and (max-width: 1200px) {
       float: left;
       font-size: 160%;
       min-width: 120px;
@@ -27,8 +33,13 @@
     display: inline-block;
   }
   ul {
+    @media (min-width: 992px) and (max-width: 1200px) {
+      li {
+        margin-top: 10px;
+        font-size: 90%;
+      }
+    }
     @media (min-width: 708px) and (max-width: 992px) {
-      display: block;
       li {
         margin-top: 10px;
         font-size: 85%;

--- a/app/scripts/modules/core/application/applicationNav.html
+++ b/app/scripts/modules/core/application/applicationNav.html
@@ -55,11 +55,4 @@
       Config
     </a>
   </li>
-  <li style="padding:10px 0 0 10px" ng-if="application.attributes.pdApiKey">
-    <button class="btn btn-xs btn-danger"
-            ng-click="ctrl.pageApplicationOwner()"
-            uib-tooltip="Page application owner">
-      <span class="glyphicon glyphicon-phone-alt"></span>
-    </button>
-  </li>
 </ul>

--- a/app/scripts/modules/netflix/application/applicationNav.html
+++ b/app/scripts/modules/netflix/application/applicationNav.html
@@ -62,11 +62,4 @@
       Config
     </a>
   </li>
-  <li style="padding:10px 0 0 10px" ng-if="application.attributes.pdApiKey">
-    <button class="btn btn-xs btn-danger"
-            ng-click="ctrl.pageApplicationOwner()"
-            uib-tooltip="Page application owner">
-      <span class="glyphicon glyphicon-phone-alt"></span>
-    </button>
-  </li>
 </ul>


### PR DESCRIPTION
Per discussions with our designer, we're moving the "Page application owner" button to the right edge of the header:

_Current_
<img width="1419" alt="screen shot 2016-06-28 at 1 18 43 pm" src="https://cloud.githubusercontent.com/assets/73450/16430919/e9e41ede-3d32-11e6-86c6-c6da1a56c3fd.png">

_Revised_
<img width="1421" alt="screen shot 2016-06-28 at 1 18 55 pm" src="https://cloud.githubusercontent.com/assets/73450/16430926/efc9e54a-3d32-11e6-9760-828637fd96cf.png">

Also making the header a little cleaner for smaller screens and longer application names