### PR TITLE
(aws) send amiName when updating security groups

### DIFF
--- a/app/scripts/modules/core/serverGroup/serverGroup.write.service.js
+++ b/app/scripts/modules/core/serverGroup/serverGroup.write.service.js
@@ -117,6 +117,7 @@ module.exports = angular
         serverGroupName: serverGroup.name,
         credentials: serverGroup.account,
         region: serverGroup.region,
+        amiName: serverGroup.launchConfig.imageId,
         type: 'updateSecurityGroupsForServerGroup'
       };
       return taskExecutor.executeTask({


### PR DESCRIPTION
Needed for non-default-bake-account updates

cc @ajordens 