### PR TITLE
(kubernetes) Select correct health provider names for k8s

### DIFF
--- a/app/scripts/modules/kubernetes/cluster/configure/CommandBuilder.js
+++ b/app/scripts/modules/kubernetes/cluster/configure/CommandBuilder.js
@@ -29,9 +29,7 @@ module.exports = angular.module('spinnaker.kubernetes.clusterCommandBuilder.serv
     }
 
     function applyHealthProviders(application, command) {
-      if (application && application.attributes && application.attributes.platformHealthOnly) {
-        command.interestingHealthProviderNames = ['Kubernetes'];
-      }
+      command.interestingHealthProviderNames = ['KubernetesContainer', 'KubernetesPod'];
     }
 
     function buildNewClusterCommand(application, defaults = {}) {

--- a/app/scripts/modules/kubernetes/serverGroup/transformer.js
+++ b/app/scripts/modules/kubernetes/serverGroup/transformer.js
@@ -22,7 +22,6 @@ module.exports = angular
       delete command.viewState;
       delete command.backingData;
       delete command.selectedProvider;
-      delete command.interestingHealthProviderNames;
 
       command.region = command.namespace;
 


### PR DESCRIPTION
@danielpeach fyi

The Create/Clone operations were associating the wrong health provider name, causing unhealthy configured pods to deploy correctly. I ignore application-level health config since Kubernetes only exposes platform health, making selecting the health providers redundant.