### PR TITLE
(core) improve readability of health counters/load balancer button

### DIFF
--- a/app/scripts/modules/core/cluster/rollups.less
+++ b/app/scripts/modules/core/cluster/rollups.less
@@ -266,7 +266,7 @@ running-tasks-tag {
   border: 1px solid #777777;
   padding: 0;
   border-radius: 3px;
-  box-shadow: 0px 0px 5px 2px #dddddd;
+  box-shadow: 0 0 2px 0 #dddddd;
   min-width: 150px;
   div {
     font-weight: 600;
@@ -326,7 +326,7 @@ load-balancers-tag {
 
   .btn-multiple-load-balancers {
     text-align: right;
-    margin-right: 15px;
+    margin-right: 3px;
     &:hover {
       text-decoration: none;
     }
@@ -336,18 +336,16 @@ load-balancers-tag {
     .icon-elb {
       height: 0;
       width: 0;
-      &::before {
-        text-shadow: #2A6496 0 0 1px;
-      }
     }
     .counter {
-      color: #2A6496;
+      color: @spinnaker-link-color;
       background-color: #fff;
-      box-shadow: 0 0 2px #2A6496;
-      right: -28px;
-      font-size: 90%;
+      border: 1px solid @spinnaker-link-color;
+      right: 0;
+      top: -3px;
+      font-size: 100%;
       padding: 1px 4px;
-      border-radius: 6px;
+      border-radius: 4px;
     }
     span {
       position: relative;

--- a/app/scripts/modules/core/healthCounts/healthCounts.less
+++ b/app/scripts/modules/core/healthCounts/healthCounts.less
@@ -33,7 +33,9 @@
   padding-left: 5px;
 }
 .instance-health-counts {
-
+  .glyphicon {
+    top: 0;
+  }
   .healthy {
     color: #8cad6e;
   }

--- a/app/scripts/modules/core/loadBalancer/loadBalancer/loadBalancersTag.html
+++ b/app/scripts/modules/core/loadBalancer/loadBalancer/loadBalancersTag.html
@@ -4,9 +4,11 @@
       ng-if="serverGroup.loadBalancers.length > maxDisplay"
       ng-click="popover.show = !popover.show; $event.stopPropagation();"
       uib-tooltip="{{popover.show ? 'Hide' : 'Show'}} all {{serverGroup.loadBalancers.length}} load balancers">
-    <span class="badge counter">{{serverGroup.loadBalancers.length}}</span>
-    <span class="icon">
-      <span class="icon-elb"></span>
+    <span class="badge counter">
+      <span class="icon">
+        <span class="icon-elb"></span>
+      </span>
+      {{serverGroup.loadBalancers.length}}
     </span>
   </button>
   <div class="menu-load-balancers" ng-if="popover.show">

--- a/app/scripts/modules/core/presentation/main.less
+++ b/app/scripts/modules/core/presentation/main.less
@@ -338,7 +338,7 @@ html {
     content: "\2666";
     font-weight: 900;
     color: @missing_health;
-    font-size: 120%;
+    font-size: 85%;
   }
   display: inline-block;
   padding-bottom: 3px;


### PR DESCRIPTION
Changes to:
*Multiple load balancers button*
Current:
<img width="115" alt="screen shot 2016-07-06 at 7 45 19 pm" src="https://cloud.githubusercontent.com/assets/73450/16641100/375d4868-43b2-11e6-85e4-4e4fc11a6127.png">

Revised to:
<img width="130" alt="screen shot 2016-07-06 at 10 49 05 pm" src="https://cloud.githubusercontent.com/assets/73450/16643692/e012782a-43cb-11e6-8ba0-b6cc91ceef10.png">

*Instance counters (unknown/starting icon - blue diamond)*
Current:
<img width="125" alt="screen shot 2016-07-06 at 10 49 47 pm" src="https://cloud.githubusercontent.com/assets/73450/16643724/2b9c1efe-43cc-11e6-842e-18ed37902b97.png">

Revised to (smaller):
<img width="121" alt="screen shot 2016-07-06 at 10 49 55 pm" src="https://cloud.githubusercontent.com/assets/73450/16643720/26845094-43cc-11e6-8c75-5d22333157fb.png">

