### PR TITLE
(core) fixes visual bug in confirmation modal

### DIFF
--- a/app/scripts/modules/core/confirmationModal/confirm.html
+++ b/app/scripts/modules/core/confirmationModal/confirm.html
@@ -27,7 +27,7 @@
       <task-reason ng-if="(taskMonitor || taskMonitors) && params.askForReason" command="params"></task-reason>
     </div>
     <div class="modal-footer">
-      <user-verification verification="verification" account="params.account" label="params.verificationLabel" autofocus="true"></user-verification>
+      <user-verification ng-if="!state.submitting" verification="verification" account="params.account" label="params.verificationLabel" autofocus="true"></user-verification>
       <button class="btn btn-default"
               type="button"
               ng-click="ctrl.cancel()">{{params.cancelButtonText}}</button>

--- a/app/scripts/modules/google/serverGroup/details/resize/resizeServerGroup.controller.js
+++ b/app/scripts/modules/google/serverGroup/details/resize/resizeServerGroup.controller.js
@@ -45,6 +45,7 @@ module.exports = angular.module('spinnaker.google.serverGroup.details.resize.con
     };
 
     this.resize = function () {
+      this.submitting = true;
       if (!this.isValid()) {
         return;
       }

--- a/app/scripts/modules/google/serverGroup/details/resize/resizeServerGroup.html
+++ b/app/scripts/modules/google/serverGroup/details/resize/resizeServerGroup.html
@@ -1,6 +1,6 @@
 <div modal-page class="confirmation-modal">
   <task-monitor monitor="taskMonitor"></task-monitor>
-  <form role="form">
+  <form role="form" ng-if="!ctrl.submitting">
     <modal-close></modal-close>
     <div class="modal-header">
       <h3>Resize {{serverGroup.name}}</h3>

--- a/app/scripts/modules/google/serverGroup/details/rollback/rollbackServerGroup.controller.js
+++ b/app/scripts/modules/google/serverGroup/details/rollback/rollbackServerGroup.controller.js
@@ -42,6 +42,7 @@ module.exports = angular.module('spinnaker.google.serverGroup.details.rollback.c
       };
 
       this.rollback = function () {
+        this.submitting = true;
         if (!this.isValid()) {
           return;
         }

--- a/app/scripts/modules/google/serverGroup/details/rollback/rollbackServerGroup.html
+++ b/app/scripts/modules/google/serverGroup/details/rollback/rollbackServerGroup.html
@@ -1,6 +1,6 @@
 <div modal-page class="confirmation-modal">
   <task-monitor monitor="taskMonitor"></task-monitor>
-  <form role="form">
+  <form role="form" ng-if="!ctrl.submitting">
     <modal-close></modal-close>
     <div class="modal-header">
       <h3>Rollback {{serverGroup.name}}</h3>


### PR DESCRIPTION
@anotherchrisberry small change to core confirmation modal. 

It fixes a little visual bug: if you type in a user confirmation (e.g. in a confirm resize modal), press enter, then press another key, you'll get a something like this:
![visualbug](https://cloud.githubusercontent.com/assets/13868700/16665839/0f0298d6-4453-11e6-9a6a-819803a13dbd.png)
