### PR TITLE
(core) guard against null regions field in getUniqueAttributeForAllAc…

### DIFF
--- a/app/scripts/modules/core/account/account.service.js
+++ b/app/scripts/modules/core/account/account.service.js
@@ -101,6 +101,7 @@ module.exports = angular.module('spinnaker.core.account.service', [
             let attributes = _(credentialsByAccount)
               .pluck(attribute)
               .flatten()
+              .compact()
               .map(reg => reg.name || reg)
               .uniq()
               .value();


### PR DESCRIPTION
…counts

@spinnaker/google-reviewers might want to do the same in `getUniqueGceZonesForAllAccounts` - I am not sure if `regions` can be null there, but apparently it can on the AWS side...