### PR TITLE
(core) increased notifier size

### DIFF
--- a/app/scripts/modules/core/widgets/notifier/notifier.component.less
+++ b/app/scripts/modules/core/widgets/notifier/notifier.component.less
@@ -4,11 +4,12 @@ notifier {
   z-index: 30;
   display: block;
   position: fixed;
-  bottom: 10px;
-  right: 10px;
+  width: 100%;
+  bottom: 5px;
   .user-notification {
     .fade-in(0.1);
-    max-width: 400px;
+    text-align: center;
+    font-size: 120%;
     margin: 10px;
     padding: 10px;
     background-color: @bootstrap_info;


### PR DESCRIPTION
@anotherchrisberry 
A user felt that the logged out notification was way too discreet. 

![notifier](https://cloud.githubusercontent.com/assets/13868700/16698735/bfa58fd4-451d-11e6-94d6-d6cbc6665f31.png)
