### PR TITLE
(core) pin jquery ui to 1.10.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "clipboard": "git://github.com/zenorocha/clipboard.js.git#v1.3.1",
     "d3": "^3.5.6",
     "jquery": "2.1.4",
-    "jquery-ui": "^1.10.5",
+    "jquery-ui": "~1.10.5",
     "loader-utils": "^0.2.11",
     "lodash": "^3.10.1",
     "moment-timezone": "^0.4.0",


### PR DESCRIPTION
something is breaking sortable in 1.12.0, which prevents sorting pipelines and links