### PR TITLE
(core) actively refresh running executions when displayed

### DIFF
--- a/app/scripts/modules/core/delivery/details/singleExecutionDetails.controller.js
+++ b/app/scripts/modules/core/delivery/details/singleExecutionDetails.controller.js
@@ -22,6 +22,10 @@ module.exports = angular.module('spinnaker.singleExecutionDetails.controller', [
       {
         this.execution = execution;
         executionService.transformExecution(this.application, this.execution);
+        if (!execution.isActive) {
+          executionScheduler.dispose();
+          executionLoader.dispose();
+        }
       }, () => {
         this.execution = null;
         this.stateNotFound = true;

--- a/app/scripts/modules/core/delivery/service/execution.service.js
+++ b/app/scripts/modules/core/delivery/service/execution.service.js
@@ -244,6 +244,17 @@ module.exports = angular.module('spinnaker.core.delivery.executions.service', [
       }
     }
 
+    function updateExecution(application, execution) {
+      if (application.executions.data && application.executions.data.length) {
+        application.executions.data.forEach((t, idx) => {
+          if (execution.id === t.id) {
+            transformExecution(application, execution);
+            application.executions.data[idx] = execution;
+          }
+        });
+      }
+    }
+
     return {
       getExecutions: getExecutions,
       getExecution: getExecution,
@@ -259,5 +270,6 @@ module.exports = angular.module('spinnaker.core.delivery.executions.service', [
       getSectionCacheKey: getSectionCacheKey,
       getProjectExecutions: getProjectExecutions,
       addExecutionsToApplication: addExecutionsToApplication,
+      updateExecution: updateExecution,
     };
   });

--- a/app/scripts/modules/core/scheduler/scheduler.factory.js
+++ b/app/scripts/modules/core/scheduler/scheduler.factory.js
@@ -78,8 +78,11 @@ module.exports = angular.module('spinnaker.core.scheduler', [
         subscribe: scheduler.subscribe.bind(scheduler),
         scheduleImmediate: scheduleImmediate,
         dispose: () => {
-          scheduler.onNext(false);
-          scheduler.dispose();
+          suspended = true;
+          if (scheduler) {
+            scheduler.onNext(false);
+            scheduler.dispose();
+          }
           scheduler = null;
           source = null;
           $timeout.cancel(pendingRun);


### PR DESCRIPTION
With these changes, the `<execution>` directive will more aggressively poll and update (once every two seconds) any running executions, which makes monitoring running executions a little easier.