### PR TITLE
(core) trigger executions refreshStream when replacing

### DIFF
--- a/app/scripts/modules/core/delivery/executionGroup/execution/execution.directive.js
+++ b/app/scripts/modules/core/delivery/executionGroup/execution/execution.directive.js
@@ -121,7 +121,7 @@ module.exports = angular
       });
     };
 
-    let activeRefresher = schedulerFactory.createScheduler(2000);
+    let activeRefresher = schedulerFactory.createScheduler(1000);
 
     if (this.execution.isRunning && !this.standalone) {
       let refreshing = false;

--- a/app/scripts/modules/core/delivery/service/execution.service.js
+++ b/app/scripts/modules/core/delivery/service/execution.service.js
@@ -248,8 +248,12 @@ module.exports = angular.module('spinnaker.core.delivery.executions.service', [
       if (application.executions.data && application.executions.data.length) {
         application.executions.data.forEach((t, idx) => {
           if (execution.id === t.id) {
-            transformExecution(application, execution);
-            application.executions.data[idx] = execution;
+            execution.stringVal = JSON.stringify(execution);
+            if (t.stringVal !== execution.stringVal) {
+              transformExecution(application, execution);
+              application.executions.data[idx] = execution;
+              application.executions.refreshStream.onNext();
+            }
           }
         });
       }


### PR DESCRIPTION
  1. If the execution is unchanged, leave it be
  2. Add the `stringVal` so it doesn't necessarily get swapped out when all the executions are reloaded
  3. Make sure to call the `refreshStream.onNext` so that the execution groups are updated