### PR TITLE
(k8s) http header support in wizard

### DIFF
--- a/app/scripts/modules/kubernetes/container/probe.directive.html
+++ b/app/scripts/modules/kubernetes/container/probe.directive.html
@@ -132,6 +132,34 @@
           </select>
         </div>
       </div>
+      <hr>
+      <div ng-repeat="header in probeController.probe.handler.httpGetAction.httpHeaders"
+        class="form-group">
+        <div class="form-group">
+          <div class="col-md-3 sm-label-right">
+            Name
+          </div>
+          <div class="col-md-3">
+            <input class="form-control input-sm" ng-model="header.name"/>
+          </div>
+          <div class="col-md-1 sm-label-right">
+            Value
+          </div>
+          <div class="col-md-3">
+            <input class="form-control input-sm" name="details" ng-model="header.value"/>
+          </div>
+          <div class="col-md-1">
+            <button class="btn btn-sm btn-default"
+                    ng-click="probeController.deleteHttpHeader(probeController.probe.handler.httpGetAction, $index)">
+              <span class="glyphicon glyphicon-trash visible-lg-inline"></span>
+            </button>
+          </div>
+        </div>
+      </div>
+      <button class="add-new col-md-12"
+              ng-click="probeController.addHttpHeader(probeController.probe.handler.httpGetAction)">
+        <span class="glyphicon glyphicon-plus-sign"></span> Add HTTP Header
+      </button>
     </div>
   </div>
 </form>

--- a/app/scripts/modules/kubernetes/container/probe.directive.js
+++ b/app/scripts/modules/kubernetes/container/probe.directive.js
@@ -90,5 +90,18 @@ module.exports = angular.module('spinnaker.kubernetes.container.probe.directive'
       }
     };
 
+    this.addHttpHeader = function(getAction) {
+      getAction.httpHeaders = getAction.httpHeaders || [];
+      getAction.httpHeaders.push({});
+    };
+
+    this.deleteHttpHeader = function(getAction, index) {
+      if (getAction.httpHeaders.length < 2) {
+        delete getAction.httpHeaders;
+      } else {
+        getAction.httpHeaders.splice(index, 1);
+      }
+    };
+
     this.prepareProbe();
   });


### PR DESCRIPTION
(k8s) http header support in wizard. Headers are copied properly for cloning and pipelines.

@lwander PTAL

<img width="463" alt="screen shot 2016-07-10 at 6 50 32 pm" src="https://cloud.githubusercontent.com/assets/13868700/16716619/bee52754-46cf-11e6-9957-aee243c69c43.png">
