### PR TITLE
(core) do not refresh orchestrations on task complete for standalone …

### DIFF
--- a/app/scripts/modules/core/task/monitor/taskMonitorService.js
+++ b/app/scripts/modules/core/task/monitor/taskMonitorService.js
@@ -61,7 +61,7 @@ module.exports = angular.module('spinnaker.tasks.monitor.service', [
       monitor.handleTaskSuccess = function (task) {
         let applicationName = monitor.application ? monitor.application.name : 'ad-hoc';
         monitor.task = task;
-        if (monitor.application) {
+        if (_.has(monitor, 'application.runningOrchestrations.refresh')) {
           monitor.application.runningOrchestrations.refresh();
         }
         taskReader.waitUntilTaskCompletes(applicationName, task, monitor.monitorInterval)


### PR DESCRIPTION
…apps

If the user is viewing the object (typically a security group) in a standalone view via search, there won't be any `runningOrchestrations` to `refresh`.