### PR TITLE
JIRA-1888: Remove dependency on Restangular.

### DIFF
--- a/app/scripts/modules/amazon/image/image.reader.js
+++ b/app/scripts/modules/amazon/image/image.reader.js
@@ -3,15 +3,15 @@
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.aws.image.reader', [
-  require('exports?"restangular"!imports?_=lodash!restangular'),
+  require('../../core/api/api.service')
 ])
-  .factory('awsImageReader', function ($q, Restangular) {
+  .factory('awsImageReader', function ($q, API) {
 
     function findImages(params) {
       if (!params.q || params.q.length < 3) {
         return $q.when([{message: 'Please enter at least 3 characters...'}]);
       }
-      return Restangular.all('images/find').getList(params, {})
+      return API.one('images/find').withParams(params).get()
         .then(function(results) {
           return results;
         },
@@ -21,7 +21,14 @@ module.exports = angular.module('spinnaker.aws.image.reader', [
     }
 
     function getImage(amiName, region, credentials) {
-      return Restangular.all('images').one(credentials).one(region).all(amiName).getList({provider: 'aws'}).then(function(results) {
+      return API
+        .one('images')
+        .one(credentials)
+        .one(region)
+        .one(amiName)
+        .withParams({provider: 'aws'})
+        .get()
+        .then(function(results) {
           return results && results.length ? results[0] : null;
         },
         function() {

--- a/app/scripts/modules/amazon/image/image.reader.spec.js
+++ b/app/scripts/modules/amazon/image/image.reader.spec.js
@@ -18,17 +18,18 @@
 
 describe('Service: aws Image Reader', function() {
 
-  var service, $http, scope;
+  var service, $http, scope, API;
 
   beforeEach(
     window.module(
-      require('./image.reader.js')
+      require('./image.reader.js'),
+      require('../../core/api/api.service')
     )
   );
 
 
-  beforeEach(window.inject(function (awsImageReader, $httpBackend, $rootScope) {
-
+  beforeEach(window.inject(function (awsImageReader, $httpBackend, $rootScope, _API_) {
+    API = _API_;
     service = awsImageReader;
     $http = $httpBackend;
     scope = $rootScope.$new();
@@ -45,7 +46,7 @@ describe('Service: aws Image Reader', function() {
     var query = 'abc', region = 'us-west-1';
 
     function buildQueryString() {
-      return '/images/find?provider=aws&q=' + query + '&region=' + region;
+      return API.baseUrl + '/images/find?provider=aws&q=' + query + '&region=' + region;
     }
 
     it('queries gate when 3 characters are supplied', function() {
@@ -122,7 +123,7 @@ describe('Service: aws Image Reader', function() {
     var imageName = 'abc', region = 'us-west-1', credentials = 'test';
 
     function buildQueryString() {
-      return ['/images', credentials, region, imageName].join('/') + '?provider=aws';
+      return [API.baseUrl, 'images', credentials, region, imageName].join('/') + '?provider=aws';
     }
 
     it('returns null if server returns 404 or an empty list', function() {

--- a/app/scripts/modules/amazon/instance/awsInstanceType.service.js
+++ b/app/scripts/modules/amazon/instance/awsInstanceType.service.js
@@ -3,13 +3,13 @@
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.aws.instanceType.service', [
-  require('exports?"restangular"!imports?_=lodash!restangular'),
+  require('../../core/api/api.service'),
   require('../../core/cache/deckCacheFactory.js'),
   require('../../core/utils/lodash.js'),
   require('../../core/config/settings.js'),
   require('../../core/cache/infrastructureCaches.js'),
 ])
-  .factory('awsInstanceTypeService', function ($http, $q, settings, _, Restangular, infrastructureCaches) {
+  .factory('awsInstanceTypeService', function ($http, $q, settings, _, API, infrastructureCaches) {
 
     var m3 = {
       type: 'm3',
@@ -199,8 +199,8 @@ module.exports = angular.module('spinnaker.aws.instanceType.service', [
       if (cached) {
         return $q.when(cached);
       }
-      return Restangular.all('instanceTypes')
-        .getList().then(function (types) {
+      return API.one('instanceTypes').get()
+        .then(function (types) {
           var result = _(types)
             .map(function (type) {
               return { region: type.region, account: type.account, name: type.name, key: [type.region, type.account, type.name].join(':') };

--- a/app/scripts/modules/amazon/instance/awsInstanceType.service.spec.js
+++ b/app/scripts/modules/amazon/instance/awsInstanceType.service.spec.js
@@ -18,15 +18,18 @@
 
 describe('Service: InstanceType', function () {
 
+  let API;
+
   beforeEach(function() {
       window.module(
-        require('./awsInstanceType.service')
+        require('./awsInstanceType.service'),
+        require('../../core/api/api.service')
       );
   });
 
 
-  beforeEach(window.inject(function (_awsInstanceTypeService_, _$httpBackend_, _settings_, infrastructureCaches) {
-
+  beforeEach(window.inject(function (_awsInstanceTypeService_, _$httpBackend_, _settings_, _API_, infrastructureCaches) {
+    API = _API_;
     this.awsInstanceTypeService = _awsInstanceTypeService_;
     this.$httpBackend = _$httpBackend_;
     this.settings = _settings_;
@@ -52,7 +55,7 @@ describe('Service: InstanceType', function () {
 
     it('returns types, indexed by region', function () {
 
-      this.$httpBackend.expectGET('/instanceTypes').respond(200, this.allTypes);
+      this.$httpBackend.expectGET( API.baseUrl + '/instanceTypes').respond(200, this.allTypes);
 
       var results = null;
       this.awsInstanceTypeService.getAllTypesByRegion().then(function(result) {
@@ -69,7 +72,7 @@ describe('Service: InstanceType', function () {
   describe('getAvailableTypesForRegions', function() {
 
     it('returns results for a single region', function() {
-      this.$httpBackend.expectGET('/instanceTypes').respond(200, this.allTypes);
+      this.$httpBackend.expectGET(API.baseUrl + '/instanceTypes').respond(200, this.allTypes);
 
       var results = null,
           service = this.awsInstanceTypeService;
@@ -83,7 +86,7 @@ describe('Service: InstanceType', function () {
     });
 
     it('returns empty list for region with no instance types', function() {
-      this.$httpBackend.expectGET('/instanceTypes').respond(200, this.allTypes);
+      this.$httpBackend.expectGET(API.baseUrl + '/instanceTypes').respond(200, this.allTypes);
 
       var results = null,
           service = this.awsInstanceTypeService;
@@ -97,7 +100,7 @@ describe('Service: InstanceType', function () {
     });
 
     it('returns an intersection when multiple regions are provided', function() {
-      this.$httpBackend.expectGET('/instanceTypes').respond(200, this.allTypes);
+      this.$httpBackend.expectGET(API.baseUrl + '/instanceTypes').respond(200, this.allTypes);
 
       var results = null,
           service = this.awsInstanceTypeService;

--- a/app/scripts/modules/amazon/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/amazon/instance/details/instance.details.controller.js
@@ -131,7 +131,6 @@ module.exports = angular.module('spinnaker.instance.detail.aws.controller', [
             if ($scope.$$destroyed) {
               return;
             }
-            details = details.plain();
             $scope.state.loading = false;
             extractHealthMetrics(instanceSummary, details);
             $scope.instance = _.defaults(details, instanceSummary);

--- a/app/scripts/modules/amazon/instance/details/instance.details.controller.spec.js
+++ b/app/scripts/modules/amazon/instance/details/instance.details.controller.spec.js
@@ -48,11 +48,7 @@ describe('Controller: awsInstanceDetailsCtrl', function () {
       };
 
       spyOn(instanceReader, 'getInstanceDetails').and.returnValue(
-        $q.when({
-          plain: function() {
-            return details;
-          }
-        })
+        $q.when(details)
       );
       var application = { attributes: {} };
 

--- a/app/scripts/modules/amazon/keyPairs/keyPairs.read.service.js
+++ b/app/scripts/modules/amazon/keyPairs/keyPairs.read.service.js
@@ -4,14 +4,14 @@ let angular = require('angular');
 
 module.exports = angular
   .module('spinnaker.keyPairs.read.service', [
-    require('exports?"restangular"!imports?_=lodash!restangular'),
+    require('../../core/api/api.service')
   ])
-  .factory('keyPairsReader', function ($q, Restangular) {
+  .factory('keyPairsReader', function ($q, API) {
 
     function listKeyPairs() {
-      return Restangular.all('keyPairs')
-        .withHttpConfig({cache: true})
-        .getList()
+      return API.one('keyPairs')
+        .useCache()
+        .get()
         .then(keyPairs => keyPairs.sort((a, b) => a.keyName.localeCompare(b.keyName)));
     }
 

--- a/app/scripts/modules/amazon/securityGroup/details/securityGroupDetail.controller.js
+++ b/app/scripts/modules/amazon/securityGroup/details/securityGroupDetail.controller.js
@@ -34,7 +34,7 @@ module.exports = angular.module('spinnaker.securityGroup.aws.details.controller'
       return securityGroupReader.getSecurityGroupDetails(application, securityGroup.accountId, securityGroup.provider, securityGroup.region, securityGroup.vpcId, securityGroup.name).then(function (details) {
         $scope.state.loading = false;
 
-        if (!details || _.isEmpty( details.plain())) {
+        if (!details || _.isEmpty( details )) {
           fourOhFour();
         } else {
           $scope.securityGroup = details;
@@ -67,7 +67,7 @@ module.exports = angular.module('spinnaker.securityGroup.aws.details.controller'
         size: 'lg',
         resolve: {
           securityGroup: function() {
-            return angular.copy($scope.securityGroup.plain());
+            return angular.copy($scope.securityGroup);
           },
           application: function() { return application; }
         }
@@ -82,7 +82,7 @@ module.exports = angular.module('spinnaker.securityGroup.aws.details.controller'
         size: 'lg',
         resolve: {
           securityGroup: function() {
-            var securityGroup = angular.copy($scope.securityGroup.plain());
+            var securityGroup = angular.copy($scope.securityGroup);
             if(securityGroup.region) {
               securityGroup.regions = [securityGroup.region];
             }

--- a/app/scripts/modules/amazon/serverGroup/configure/serverGroupCommandBuilder.service.js
+++ b/app/scripts/modules/amazon/serverGroup/configure/serverGroupCommandBuilder.service.js
@@ -3,7 +3,6 @@
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.aws.serverGroupCommandBuilder.service', [
-  require('exports?"restangular"!imports?_=lodash!restangular'),
   require('../../../core/account/account.service.js'),
   require('../../../core/subnet/subnet.read.service.js'),
   require('../../../core/instance/instanceTypeService.js'),
@@ -11,7 +10,7 @@ module.exports = angular.module('spinnaker.aws.serverGroupCommandBuilder.service
   require('./serverGroupConfiguration.service.js'),
   require('../../../core/utils/lodash.js'),
 ])
-  .factory('awsServerGroupCommandBuilder', function (settings, Restangular, $q,
+  .factory('awsServerGroupCommandBuilder', function (settings, $q,
                                                      accountService, subnetReader, namingService, instanceTypeService,
                                                      awsServerGroupConfigurationService, _) {
 

--- a/app/scripts/modules/amazon/serverGroup/details/serverGroupDetails.aws.controller.js
+++ b/app/scripts/modules/amazon/serverGroup/details/serverGroupDetails.aws.controller.js
@@ -87,7 +87,7 @@ module.exports = angular.module('spinnaker.serverGroup.details.aws.controller', 
             .then((details) => {
               cancelLoader();
 
-              var plainDetails = details.plain();
+              var plainDetails = details;
               angular.extend(plainDetails, summary);
               // it's possible the summary was not found because the clusters are still loading
               plainDetails.account = serverGroup.accountId;

--- a/app/scripts/modules/amazon/vpc/vpc.read.service.js
+++ b/app/scripts/modules/amazon/vpc/vpc.read.service.js
@@ -22,7 +22,7 @@ module.exports = angular
           if (vpc.deprecated) {
             vpc.label += ' (deprecated)';
           }
-          return vpc.plain();
+          return vpc;
         });
         cachedVpcs = results;
         return results;

--- a/app/scripts/modules/amazon/vpc/vpc.read.service.spec.js
+++ b/app/scripts/modules/amazon/vpc/vpc.read.service.spec.js
@@ -2,15 +2,17 @@
 
 describe('vpcReader', function() {
 
-  var service, $http, $scope;
+  var service, $http, $scope, API;
 
   beforeEach(
     window.module(
-      require('./vpc.read.service.js')
+      require('./vpc.read.service.js'),
+      require('../../core/api/api.service')
     )
   );
 
-  beforeEach(window.inject(function ($httpBackend, $rootScope, _vpcReader_) {
+  beforeEach(window.inject(function ($httpBackend, $rootScope, _vpcReader_, _API_) {
+    API = _API_;
     service = _vpcReader_;
     $http = $httpBackend;
     $scope = $rootScope.$new();
@@ -21,7 +23,7 @@ describe('vpcReader', function() {
   });
 
   beforeEach(function() {
-    $http.whenGET('/networks/aws').respond(200, [
+    $http.whenGET(API.baseUrl + '/networks/aws').respond(200, [
       { name: 'vpc1', id: 'vpc-1', deprecated: true },
       { name: 'vpc2', id: 'vpc-2', deprecated: false },
       { name: 'vpc3', id: 'vpc-3' },

--- a/app/scripts/modules/azure/image/image.reader.js
+++ b/app/scripts/modules/azure/image/image.reader.js
@@ -3,12 +3,12 @@
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.azure.image.reader', [
-  require('exports?"restangular"!imports?_=lodash!restangular'),
+  require('../../core/api/api.service')
 ])
-  .factory('azureImageReader', function ($q, Restangular) {
+  .factory('azureImageReader', function ($q, API) {
 
     function findImages(params) {
-      return Restangular.all('images/find').getList(params, {})
+      return API.one('images/find').get(params)
         .then(function(results) {
           return results;
         },
@@ -18,7 +18,14 @@ module.exports = angular.module('spinnaker.azure.image.reader', [
     }
 
     function getImage(amiName, region, credentials) {
-      return Restangular.all('images').one(credentials).one(region).all(amiName).getList({provider: 'azure'}).then(function(results) {
+      return API
+        .one('images')
+        .one(credentials)
+        .one(region)
+        .one(amiName)
+        .withParams({provider: 'azure'})
+        .get()
+        .then(function(results) {
           return results && results.length ? results[0] : null;
         },
         function() {

--- a/app/scripts/modules/azure/image/image.reader.spec.js
+++ b/app/scripts/modules/azure/image/image.reader.spec.js
@@ -18,20 +18,20 @@
 
 describe('Service: Azure Image Reader', function() {
 
-  var service, $http;
+  var service, $http, API;
 
   beforeEach(
     window.module(
-      require('./image.reader.js')
+      require('./image.reader.js'),
+      require('../../core/api/api.service')
     )
   );
 
 
-  beforeEach(window.inject(function (azureImageReader, $httpBackend) {
-
+  beforeEach(window.inject(function (azureImageReader, $httpBackend, _API_) {
+    API = _API_;
     service = azureImageReader;
     $http = $httpBackend;
-
   }));
 
   afterEach(function() {
@@ -44,7 +44,7 @@ describe('Service: Azure Image Reader', function() {
     var query = 'abc', region = 'usw';
 
     function buildQueryString() {
-      return '/images/find?provider=azure&q=' + query + '&region=' + region;
+      return API.baseUrl + '/images/find?provider=azure&q=' + query + '&region=' + region;
     }
 
     it('queries gate when 3 characters are supplied', function() {
@@ -106,7 +106,7 @@ describe('Service: Azure Image Reader', function() {
     var imageName = 'abc', region = 'usw', credentials = 'test';
 
     function buildQueryString() {
-      return ['/images', credentials, region, imageName].join('/') + '?provider=azure';
+      return [API.baseUrl, 'images', credentials, region, imageName].join('/') + '?provider=azure';
     }
 
     it('returns null if server returns 404 or an empty list', function() {

--- a/app/scripts/modules/azure/instance/azureInstanceType.service.js
+++ b/app/scripts/modules/azure/instance/azureInstanceType.service.js
@@ -3,13 +3,13 @@
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.azure.instanceType.service', [
-  require('exports?"restangular"!imports?_=lodash!restangular'),
+  require('../../core/api/api.service'),
   require('../../core/cache/deckCacheFactory.js'),
   require('../../core/utils/lodash.js'),
   require('../../core/config/settings.js'),
   require('../../core/cache/infrastructureCaches.js'),
 ])
-  .factory('azureInstanceTypeService', function ($http, $q, settings, _, Restangular, infrastructureCaches) {
+  .factory('azureInstanceTypeService', function ($http, $q, settings, _, API, infrastructureCaches) {
 
     var m3 = {
       type: 'M3',
@@ -260,8 +260,10 @@ module.exports = angular.module('spinnaker.azure.instanceType.service', [
       if (cached) {
         return $q.when(cached);
       }
-      return Restangular.all('instanceTypes')
-        .getList().then(function (types) {
+      return API
+        .one('instanceTypes')
+        .get()
+        .then(function (types) {
           var result = _(types)
             .map(function (type) {
               return { region: type.region, account: type.account, name: type.name, key: [type.region, type.account, type.name].join(':') };

--- a/app/scripts/modules/azure/instance/azureInstanceType.service.spec.js
+++ b/app/scripts/modules/azure/instance/azureInstanceType.service.spec.js
@@ -18,15 +18,18 @@
 
 describe('Service: InstanceType', function () {
 
+  let API;
+
   beforeEach(function() {
       window.module(
-        require('./azureInstanceType.service')
+        require('./azureInstanceType.service'),
+        require('../../core/api/api.service')
       );
   });
 
 
-  beforeEach(window.inject(function (_azureInstanceTypeService_, _$httpBackend_, _settings_, infrastructureCaches) {
-
+  beforeEach(window.inject(function (_azureInstanceTypeService_, _$httpBackend_, _settings_, infrastructureCaches, _API_) {
+    API = _API_;
     this.azureInstanceTypeService = _azureInstanceTypeService_;
     this.$httpBackend = _$httpBackend_;
     this.settings = _settings_;
@@ -52,7 +55,7 @@ describe('Service: InstanceType', function () {
 
     it('returns types, indexed by region', function () {
 
-      this.$httpBackend.expectGET('/instanceTypes').respond(200, this.allTypes);
+      this.$httpBackend.expectGET(API.baseUrl + '/instanceTypes').respond(200, this.allTypes);
 
       var results = null;
       this.azureInstanceTypeService.getAllTypesByRegion().then(function(result) {
@@ -69,7 +72,7 @@ describe('Service: InstanceType', function () {
   describe('getAvailableTypesForRegions', function() {
 
     it('returns results for a single region', function() {
-      this.$httpBackend.expectGET('/instanceTypes').respond(200, this.allTypes);
+      this.$httpBackend.expectGET(API.baseUrl + '/instanceTypes').respond(200, this.allTypes);
 
       var results = null,
           service = this.azureInstanceTypeService;
@@ -83,7 +86,7 @@ describe('Service: InstanceType', function () {
     });
 
     it('returns empty list for region with no instance types', function() {
-      this.$httpBackend.expectGET('/instanceTypes').respond(200, this.allTypes);
+      this.$httpBackend.expectGET(API.baseUrl + '/instanceTypes').respond(200, this.allTypes);
 
       var results = null,
           service = this.azureInstanceTypeService;
@@ -97,7 +100,7 @@ describe('Service: InstanceType', function () {
     });
 
     it('returns an intersection when multiple regions are provided', function() {
-      this.$httpBackend.expectGET('/instanceTypes').respond(200, this.allTypes);
+      this.$httpBackend.expectGET(API.baseUrl + '/instanceTypes').respond(200, this.allTypes);
 
       var results = null,
           service = this.azureInstanceTypeService;

--- a/app/scripts/modules/azure/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/azure/instance/details/instance.details.controller.js
@@ -120,7 +120,6 @@ module.exports = angular.module('spinnaker.azure.instance.detail.controller', [
         extraData.region = region;
         recentHistoryService.addExtraDataToLatest('instances', extraData);
         return instanceReader.getInstanceDetails(account, region, instance.instanceId).then(function(details) {
-          details = details.plain();
           $scope.state.loading = false;
           extractHealthMetrics(instanceSummary, details);
           $scope.instance = _.defaults(details, instanceSummary);

--- a/app/scripts/modules/azure/instance/details/instance.details.controller.spec.js
+++ b/app/scripts/modules/azure/instance/details/instance.details.controller.spec.js
@@ -48,11 +48,7 @@ describe('Controller: azureInstanceDetailsCtrl', function () {
       };
 
       spyOn(instanceReader, 'getInstanceDetails').and.returnValue(
-        $q.when({
-          plain: function() {
-            return details;
-          }
-        })
+        $q.when(details)
       );
       var application = {};
 

--- a/app/scripts/modules/azure/loadBalancer/configure/createLoadBalancer.controller.spec.js
+++ b/app/scripts/modules/azure/loadBalancer/configure/createLoadBalancer.controller.spec.js
@@ -3,16 +3,19 @@
 describe('Controller: azureCreateLoadBalancerCtrl', function () {
 
   var $http;
+  var API;
 
   // load the controller's module
   beforeEach(
     window.module(
-      require('./createLoadBalancer.controller')
+      require('./createLoadBalancer.controller'),
+      require('../../../core/api/api.service')
     )
   );
 
   // Initialize the controller and a mock scope
-  beforeEach(window.inject(function ($controller, $rootScope) {
+  beforeEach(window.inject(function ($controller, $rootScope, _API_) {
+    API = _API_;
     this.$scope = $rootScope.$new();
     this.ctrl = $controller('azureCreateLoadBalancerCtrl', {
       $scope: this.$scope,
@@ -41,13 +44,13 @@ describe('Controller: azureCreateLoadBalancerCtrl', function () {
   });
 
   it('makes the expected REST calls for data for a new loadbalancer', function() {
-    $http.when('GET', '/loadBalancers?provider=azure').respond([]);
-    $http.when('GET', '/securityGroups').respond({});
-    $http.when('GET', '/credentials').respond([]);
-    $http.when('GET', '/credentials/azure-test').respond([]);
-    $http.when('GET', '/subnets').respond([]);
+    $http.when('GET', API.baseUrl + '/loadBalancers?provider=azure').respond([]);
+    $http.when('GET', API.baseUrl + '/securityGroups').respond({});
+    $http.when('GET', API.baseUrl + '/credentials').respond([]);
+    $http.when('GET', API.baseUrl + '/credentials/azure-test').respond([]);
+    $http.when('GET', API.baseUrl + '/subnets').respond([]);
 
-    $http.expectGET('/loadBalancers?provider=azure');
+    $http.expectGET(API.baseUrl + '/loadBalancers?provider=azure');
     $http.flush();
   });
 

--- a/app/scripts/modules/azure/securityGroup/details/securityGroupDetail.controller.js
+++ b/app/scripts/modules/azure/securityGroup/details/securityGroupDetail.controller.js
@@ -29,7 +29,7 @@ module.exports = angular.module('spinnaker.azure.securityGroup.azure.details.con
       return securityGroupReader.getSecurityGroupDetails(application, securityGroup.accountId, securityGroup.provider, securityGroup.region, securityGroup.vpcId, securityGroup.name).then(function (details) {
         $scope.state.loading = false;
 
-        if (!details || _.isEmpty( details.plain())) {
+        if (!details || _.isEmpty( details)) {
           fourOhFour();
         } else {
           $scope.securityGroup = details;
@@ -58,7 +58,7 @@ module.exports = angular.module('spinnaker.azure.securityGroup.azure.details.con
         controller: 'azureEditSecurityGroupCtrl as ctrl',
         resolve: {
           securityGroup: function() {
-            return angular.copy($scope.securityGroup.plain());
+            return angular.copy($scope.securityGroup);
           },
           application: function() { return application; }
         }
@@ -72,7 +72,7 @@ module.exports = angular.module('spinnaker.azure.securityGroup.azure.details.con
         controller: 'azureCloneSecurityGroupController as ctrl',
         resolve: {
           securityGroup: function() {
-            var securityGroup = angular.copy($scope.securityGroup.plain());
+            var securityGroup = angular.copy($scope.securityGroup);
             if(securityGroup.region) {
               securityGroup.regions = [securityGroup.region];
             }

--- a/app/scripts/modules/azure/serverGroup/details/serverGroupDetails.azure.controller.js
+++ b/app/scripts/modules/azure/serverGroup/details/serverGroupDetails.azure.controller.js
@@ -51,11 +51,10 @@ module.exports = angular.module('spinnaker.azure.serverGroup.details.controller'
       return serverGroupReader.getServerGroup(app.name, serverGroup.accountId, serverGroup.region, serverGroup.name).then(function(details) {
         cancelLoader();
 
-        var restangularlessDetails = details.plain();
-        angular.extend(restangularlessDetails, summary);
-        restangularlessDetails.account = serverGroup.accountId; // it's possible the summary was not found because the clusters are still loading
+        angular.extend(details, summary);
+        details.account = serverGroup.accountId; // it's possible the summary was not found because the clusters are still loading
 
-        $scope.serverGroup = restangularlessDetails;
+        $scope.serverGroup = details;
 
         if (!_.isEmpty($scope.serverGroup)) {
 

--- a/app/scripts/modules/azure/subnet/subnet.read.service.js
+++ b/app/scripts/modules/azure/subnet/subnet.read.service.js
@@ -4,14 +4,14 @@ let angular = require('angular');
 
 module.exports = angular
   .module('spinnaker.azure.subnet.read.service', [
-    require('exports?"restangular"!imports?_=lodash!restangular'),
+    require('../../core/api/api.service'),
     require('../../core/cache/infrastructureCaches.js')
   ])
-  .factory('azureSubnetReader', function (Restangular, infrastructureCaches) {
+  .factory('azureSubnetReader', function (API, infrastructureCaches) {
 
     function listSubnets() {
-      return Restangular.all('subnets')
-        .withHttpConfig({cache: infrastructureCaches.subnets})
+      return API.all('subnets')
+        .useCache(infrastructureCaches.subnets)
         .getList()
         .then(function(subnets) {
           return subnets.map(function(subnet) {
@@ -20,7 +20,7 @@ module.exports = angular
             if (subnet.deprecated) {
               subnet.label += ' (deprecated)';
             }
-            return subnet.plain();
+            return subnet;
           });
         });
     }

--- a/app/scripts/modules/azure/subnet/subnet.read.service.spec.js
+++ b/app/scripts/modules/azure/subnet/subnet.read.service.spec.js
@@ -2,15 +2,17 @@
 
 describe('azureSubnetReader', function() {
 
-  var service, $http, $scope;
+  var service, $http, $scope, API;
 
   beforeEach(
     window.module(
-      require('./subnet.read.service.js')
+      require('./subnet.read.service.js'),
+      require('../../core/api/api.service')
     )
   );
 
-  beforeEach(window.inject(function ($httpBackend, $rootScope, _azureSubnetReader_) {
+  beforeEach(window.inject(function ($httpBackend, $rootScope, _azureSubnetReader_, _API_) {
+    API = _API_;
     service = _azureSubnetReader_;
     $http = $httpBackend;
     $scope = $rootScope.$new();
@@ -19,7 +21,7 @@ describe('azureSubnetReader', function() {
 
   it('adds label to subnet, including (deprecated) if deprecated field is true', function () {
 
-    $http.whenGET('/subnets').respond(200, [
+    $http.whenGET(API.baseUrl + '/subnets').respond(200, [
       { purpose: 'internal', deprecated: true },
       { purpose: 'external', deprecated: false },
       { purpose: 'internal' },

--- a/app/scripts/modules/cloudfoundry/image/image.reader.js
+++ b/app/scripts/modules/cloudfoundry/image/image.reader.js
@@ -3,12 +3,12 @@
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.cf.image.reader', [
-  require('exports?"restangular"!imports?_=lodash!restangular')
+  require('../../core/api/api.service')
 ])
-  .factory('cfImageReader', function ($q, Restangular) {
+  .factory('cfImageReader', function ($q, API) {
 
     function findImages(params) {
-      return Restangular.all('images/find').getList(params, {}).then(function(results) {
+      return API.all('images/find').getList(params).then(function(results) {
           return results;
         },
         function() {

--- a/app/scripts/modules/cloudfoundry/instance/cfInstanceTypeService.js
+++ b/app/scripts/modules/cloudfoundry/instance/cfInstanceTypeService.js
@@ -3,7 +3,6 @@
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.cf.instanceType.service', [
-  require('exports?"restangular"!imports?_=lodash!restangular'),
   require('../../core/cache/deckCacheFactory.js'),
   require('../../core/utils/lodash.js'),
 ])

--- a/app/scripts/modules/cloudfoundry/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/cloudfoundry/instance/details/instance.details.controller.js
@@ -120,7 +120,6 @@ module.exports = angular.module('spinnaker.instance.detail.cf.controller', [
         extraData.region = region;
         recentHistoryService.addExtraDataToLatest('instances', extraData);
         return instanceReader.getInstanceDetails(account, region, instance.instanceId).then(function(details) {
-          details = details.plain();
           $scope.state.loading = false;
           extractHealthMetrics(instanceSummary, details);
           $scope.instance = _.defaults(details, instanceSummary);

--- a/app/scripts/modules/cloudfoundry/securityGroup/details/SecurityGroupDetailsCtrl.js
+++ b/app/scripts/modules/cloudfoundry/securityGroup/details/SecurityGroupDetailsCtrl.js
@@ -45,7 +45,7 @@ module.exports = angular.module('spinnaker.securityGroup.cf.details.controller',
       securityGroupReader.getSecurityGroupDetails(application, securityGroup.accountId, securityGroup.provider, securityGroup.region, securityGroup.vpcId, securityGroup.name).then(function (details) {
         $scope.state.loading = false;
 
-        if (!details || _.isEmpty( details.plain())) {
+        if (!details || _.isEmpty( details ) ) {
           fourOhFour();
         } else {
           $scope.securityGroup = details;

--- a/app/scripts/modules/cloudfoundry/serverGroup/configure/ServerGroupCommandBuilder.js
+++ b/app/scripts/modules/cloudfoundry/serverGroup/configure/ServerGroupCommandBuilder.js
@@ -3,14 +3,13 @@
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.cf.serverGroupCommandBuilder.service', [
-  require('exports?"restangular"!imports?_=lodash!restangular'),
   require('../../../core/cache/deckCacheFactory.js'),
   require('../../../core/account/account.service.js'),
   require('../../../core/instance/instanceTypeService.js'),
   require('../../../core/naming/naming.service.js'),
   require('../../../core/utils/lodash.js'),
 ])
-  .factory('cfServerGroupCommandBuilder', function (settings, Restangular, $q,
+  .factory('cfServerGroupCommandBuilder', function (settings, $q,
                                                      accountService, instanceTypeService, namingService, _) {
 
     function populateTags(instanceTemplateTags, command) {

--- a/app/scripts/modules/cloudfoundry/serverGroup/details/serverGroupDetails.cf.controller.js
+++ b/app/scripts/modules/cloudfoundry/serverGroup/details/serverGroupDetails.cf.controller.js
@@ -54,12 +54,11 @@ module.exports = angular.module('spinnaker.serverGroup.details.cf.controller', [
         return serverGroupReader.getServerGroup(application.name, serverGroup.accountId, serverGroup.region, serverGroup.name).then(function(details) {
           cancelLoader();
 
-          var restangularlessDetails = details.plain();
           // it's possible the summary was not found because the clusters are still loading
-          restangularlessDetails.account = serverGroup.accountId;
-          angular.extend(restangularlessDetails, summary);
+          details.account = serverGroup.accountId;
+          angular.extend(details, summary);
 
-          $scope.serverGroup = restangularlessDetails;
+          $scope.serverGroup = details;
           $scope.runningExecutions = function() {
             return runningExecutionsService.filterRunningExecutions($scope.serverGroup.executions);
           };

--- a/app/scripts/modules/core/account/account.service.js
+++ b/app/scripts/modules/core/account/account.service.js
@@ -3,13 +3,13 @@
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.account.service', [
-  require('exports?"restangular"!imports?_=lodash!restangular'),
+  require('../api/api.service'),
   require('../utils/lodash.js'),
   require('../cache/infrastructureCaches.js'),
   require('../config/settings.js'),
   require('../cloudProvider/cloudProvider.registry.js'),
 ])
-  .factory('accountService', function(settings, $log, _, Restangular, $q, infrastructureCaches, cloudProviderRegistry) {
+  .factory('accountService', function(settings, $log, _, API, $q, infrastructureCaches, cloudProviderRegistry) {
 
     let getAllAccountDetailsForProvider = _.memoize((providerName) => {
       return listAccounts(providerName)
@@ -55,10 +55,10 @@ module.exports = angular.module('spinnaker.core.account.service', [
           return _.filter(accounts, { type: provider });
         });
       }
-      return Restangular
-        .all('credentials')
-        .withHttpConfig({cache: true})
-        .getList();
+      return API
+        .one('credentials')
+        .useCache()
+        .get();
     }
 
     let listProviders = (application) => {
@@ -81,10 +81,10 @@ module.exports = angular.module('spinnaker.core.account.service', [
       var deferred = $q.defer();
       listAccounts(provider).then(function(accounts) {
         $q.all(accounts.reduce(function(acc, account) {
-          acc[account.name] = Restangular
-            .all('credentials')
+          acc[account.name] = API
+            .one('credentials')
             .one(account.name)
-            .withHttpConfig({cache: true})
+            .useCache()
             .get();
           return acc;
         }, {})).then(function(result) {
@@ -131,8 +131,10 @@ module.exports = angular.module('spinnaker.core.account.service', [
     });
 
     function getAccountDetails(accountName) {
-      return Restangular.one('credentials', accountName)
-        .withHttpConfig({cache: true})
+      return API
+        .one('credentials')
+        .one(accountName)
+        .useCache()
         .get();
     }
 

--- a/app/scripts/modules/core/account/account.service.spec.js
+++ b/app/scripts/modules/core/account/account.service.spec.js
@@ -2,16 +2,18 @@
 
 describe('Service: accountService ', function () {
 
-  var accountService, $http, settings, cloudProviderRegistry;
+  var accountService, $http, settings, cloudProviderRegistry, API;
 
   beforeEach(
     window.module(
-      require('./account.service')
+      require('./account.service'),
+      require('../../core/api/api.service')
     )
   );
 
   beforeEach(
-    window.inject(function (_accountService_, $httpBackend, _settings_, _cloudProviderRegistry_) {
+    window.inject(function (_accountService_, $httpBackend, _settings_, _cloudProviderRegistry_, _API_) {
+      API = _API_;
       accountService = _accountService_;
       $http = $httpBackend;
       settings = _settings_;
@@ -21,7 +23,7 @@ describe('Service: accountService ', function () {
   );
 
   it('should filter the list of accounts by provider when supplied', function () {
-    $http.expectGET('/credentials').respond(200, [
+    $http.expectGET(API.baseUrl + '/credentials').respond(200, [
       {name: 'test', type: 'aws'},
       {name: 'prod', type: 'aws'},
       {name: 'prod', type: 'gce'},
@@ -42,13 +44,13 @@ describe('Service: accountService ', function () {
   describe('getAllAccountDetailsForProvider', function () {
 
     it('should return details for each account', function () {
-      $http.expectGET('/credentials').respond(200, [
+      $http.expectGET(API.baseUrl + '/credentials').respond(200, [
         {name: 'test', type: 'aws'},
         {name: 'prod', type: 'aws'},
       ]);
 
-      $http.expectGET('/credentials/test').respond(200, { a: 1});
-      $http.expectGET('/credentials/prod').respond(200, { a: 2});
+      $http.expectGET(API.baseUrl + '/credentials/test').respond(200, { a: 1});
+      $http.expectGET(API.baseUrl + '/credentials/prod').respond(200, { a: 2});
 
       var details = null;
       accountService.getAllAccountDetailsForProvider('aws').then((results) => {
@@ -64,7 +66,7 @@ describe('Service: accountService ', function () {
     });
 
     it('should fall back to an empty array if an exception occurs when listing accounts', function () {
-      $http.expectGET('/credentials').respond(429, null);
+      $http.expectGET(API.baseUrl + '/credentials').respond(429, null);
 
       var details = null;
       accountService.getAllAccountDetailsForProvider('aws').then((results) => {
@@ -77,13 +79,13 @@ describe('Service: accountService ', function () {
     });
 
     it('should fall back to an empty array if an exception occurs when getting details for an account', function () {
-      $http.expectGET('/credentials').respond(200, [
+      $http.expectGET(API.baseUrl + '/credentials').respond(200, [
         {name: 'test', type: 'aws'},
         {name: 'prod', type: 'aws'},
       ]);
 
-      $http.expectGET('/credentials/test').respond(500, null);
-      $http.expectGET('/credentials/prod').respond(200, { a: 2});
+      $http.expectGET(API.baseUrl + '/credentials/test').respond(500, null);
+      $http.expectGET(API.baseUrl + '/credentials/prod').respond(200, { a: 2});
 
       var details = null;
       accountService.getAllAccountDetailsForProvider('aws').then((results) => {
@@ -101,7 +103,7 @@ describe('Service: accountService ', function () {
 
     beforeEach(function() {
       this.registeredProviders = ['aws', 'gce', 'cf'];
-      $http.whenGET('/credentials').respond(200,
+      $http.whenGET(API.baseUrl + '/credentials').respond(200,
         [ { type: 'aws' }, { type: 'gce' }, { type: 'cf' }]
       );
 

--- a/app/scripts/modules/core/api/api.service.js
+++ b/app/scripts/modules/core/api/api.service.js
@@ -1,0 +1,120 @@
+'use strict';
+
+
+let angular = require('angular');
+
+module.exports = angular
+  .module('spinnaker.core.api.provider', [
+    require('../config/settings')
+  ])
+  .factory('API', function ($http, settings) {
+    const baseUrl = settings.gateUrl;
+
+    // these config params will be sent on calls to backend
+    const defaultParams = {
+      timeout: settings.pollSchedule * 2 + 5000
+    };
+
+    var getData = (results) => results.data;
+
+    let baseReturn = function(config) {
+      return {
+        config: config,
+        one: one(config),
+        all: one(config),
+        useCache: useCacheFn(config),
+        withParams: withParamsFn(config),
+        data: dataFn(config),
+        get: getFn(config),
+        getList: getFn(config),
+        post: postFn(config),
+        remove: removeFn(config),
+        put: putFn(config),
+      };
+    };
+
+    var useCacheFn = (config) => {
+      return function(useCache = true) {
+        config.cache = useCache;
+        return baseReturn(config);
+      };
+    };
+
+    var withParamsFn = (config) => {
+      return function(params) {
+        if(params) { config.params = params; }
+        return baseReturn(config);
+      };
+    };
+
+    // sets the data for PUT and POST methods
+    var dataFn = (config) => {
+      return function(data) {
+        if(data) { config.data = data; }
+        return baseReturn(config);
+      };
+    };
+
+    // GET METHOD CALL
+    let getFn = (config) => {
+      return function(params) {
+        config.method = 'get';
+        angular.extend(config, defaultParams);
+        if(params) { config.params = params; }
+        return $http(config).then(getData);
+      };
+    };
+
+    // POST METHOD CALL
+    let postFn = (config) => {
+      return function(data) {
+        config.method = 'post';
+        if(data) { config.data = data; }
+        angular.extend(config, defaultParams);
+        return $http(config).then(getData);
+      };
+    };
+
+    // DELETE METHOD CALL
+    let removeFn = (config) => {
+      return function(params) {
+        config.method = 'delete';
+        if(params) { config.params = params; }
+        angular.extend(config, defaultParams);
+        return $http(config).then(getData);
+      };
+    };
+
+    // PUT METHOD CALL
+    let putFn = (config) => {
+      return function(data) {
+        config.method = 'put';
+        if(data) { config.data = data; }
+        angular.extend(config, defaultParams);
+        return $http(config).then(getData);
+      };
+    };
+
+    var one = function(config) {
+      return function(...urls) {
+        urls.forEach( function(url) {
+          config.url = url ? `${config.url}/${url}` : config.url;
+        });
+        return baseReturn(config);
+      };
+    };
+
+    var init = function(...urls) {
+      let config = {url: baseUrl};
+      urls.forEach( function(url) {
+        config.url = `${config.url}/${url}`;
+      });
+      return baseReturn(config);
+    };
+
+    return {
+      one: init,
+      all: init,
+      baseUrl: baseUrl
+    };
+  });

--- a/app/scripts/modules/core/api/api.service.spec.js
+++ b/app/scripts/modules/core/api/api.service.spec.js
@@ -1,0 +1,269 @@
+'use strict';
+
+describe('API Service', function () {
+  let API;
+  let $httpBackend;
+  const baseUrl = 'https://spinnaker-api-prestaging.mgmttest.netflix.net';
+
+  beforeEach(
+    window.module(
+      require('./api.service')
+    )
+  );
+
+  beforeEach(
+    window.inject(function (_API_, _$httpBackend_) {
+      API = _API_;
+      $httpBackend = _$httpBackend_;
+    })
+  );
+
+  afterEach(function() {
+    $httpBackend.verifyNoOutstandingExpectation();
+    $httpBackend.verifyNoOutstandingRequest();
+  });
+
+
+  describe('creating the  config with "one" function', function () {
+    it('missing url should create a default config with the base url', function () {
+      let result = API.one();
+      expect(result.config).toEqual({url: baseUrl});
+    });
+
+    it('single url should create a default config with the base url', function () {
+      let result = API.one('foo');
+      expect(result.config).toEqual({url: `${baseUrl}/foo`});
+    });
+
+    it('multiple calls to "one" should create a default config with the base url and build out the url', function () {
+      let result = API.one('foo').one('bar');
+      expect(result.config).toEqual({url: `${baseUrl}/foo/bar`});
+    });
+
+    it('should allow for multiple urls to be added to the url', function () {
+      let result = API.one('foo', 'bar');
+      expect(result.config).toEqual({url: `${baseUrl}/foo/bar`});
+    });
+  });
+
+  describe('creating the  config with "all" function', function () {
+    it('missing url should create a default config with the base url', function () {
+      let result = API.all();
+      expect(result.config).toEqual({url: baseUrl});
+    });
+
+    it('single url should create a default config with the base url', function () {
+      let result = API.all('foo');
+      expect(result.config).toEqual({url: `${baseUrl}/foo`});
+    });
+
+    it('multiple calls to "all" should create a default config with the base url and build out the url', function () {
+      let result = API.all('foo').all('bar');
+      expect(result.config).toEqual({url: `${baseUrl}/foo/bar`});
+    });
+
+    it('should allow for multiple urls to be added to the url', function () {
+      let result = API.all('foo', 'bar');
+      expect(result.config).toEqual({url: `${baseUrl}/foo/bar`});
+    });
+  });
+
+  describe('creating the  config with mix of "one" and "all" function', function () {
+    it('single url should create a default config with the base url', function () {
+      let result = API.all('foo').one('bar');
+      expect(result.config).toEqual({url: `${baseUrl}/foo/bar`});
+    });
+
+    it('multiple calls to "all" should create a default config with the base url and build out the url', function () {
+      let result = API.one('foo').all('bar');
+      expect(result.config).toEqual({url: `${baseUrl}/foo/bar`});
+    });
+
+    it('should allow for multiple urls to be added to the url', function () {
+      let result = API.all('foo', 'bar').one('baz');
+      expect(result.config).toEqual({url: `${baseUrl}/foo/bar/baz`});
+    });
+  });
+
+
+  describe('creating multiple endpoints', function () {
+    it('should not stomp on each other', function () {
+      let first = API.one('bar');
+      let second = API.one('foo');
+
+      expect(first.config).toEqual({url: `${baseUrl}/bar`});
+      expect(second.config).toEqual({url: `${baseUrl}/foo`});
+    });
+  });
+
+  describe('create config with data', function () {
+    it('should not alter the config if no data object passed', function () {
+      let result = API.one('foo').data();
+      expect(result.config).toEqual({url: `${baseUrl}/foo`});
+    });
+
+    it('should add data to the config if data object passed', function () {
+      let data = {bar: 'baz'};
+      let result = API.one('foo').data(data);
+      expect(result.config).toEqual({url: `${baseUrl}/foo`, data: data});
+    });
+  });
+
+  describe('create a config with params', function () {
+    it('when no params are provided do not alter config', function () {
+      let result = API.one('foo').withParams();
+      expect(result.config).toEqual({url: `${baseUrl}/foo`});
+    });
+
+    it('when params are provided', function () {
+      let result = API.one('foo').withParams({one: 1});
+      expect(result.config).toEqual({url: `${baseUrl}/foo`, params: {one: 1} });
+    });
+  });
+
+  describe('useCache()', function () {
+    it('should set cache to "true" if no params set', function () {
+      let result = API.one('foo').useCache();
+      expect(result.config.cache).toBe(true);
+    });
+
+    it('should set cache to "false" if explicitly  set', function () {
+      let result = API.one('foo').useCache(false);
+      expect(result.config.cache).toBe(false);
+    });
+
+    it('should set cache to cache object if explicitly set', function () {
+      let cacheObj = {count: 1};
+      let result = API.one('foo').useCache(cacheObj);
+      expect(result.config.cache).toBe(cacheObj);
+    });
+  });
+
+
+  describe('get(): create a url with a "GET" method', function () {
+    it('should create the url and issue a get request with the "one" function', function () {
+      $httpBackend.expectGET(`${baseUrl}/foo`).respond(200);
+
+      API.one('foo').get();
+
+      $httpBackend.flush();
+    });
+
+    it('should create the url and issue a get request with the "all" function', function () {
+      $httpBackend.expectGET(`${baseUrl}/foo/bar`).respond(200);
+
+      API.all('foo', 'bar').get();
+
+      $httpBackend.flush();
+    });
+
+    it('should take a param object with one param', function () {
+      $httpBackend.expectGET(`${baseUrl}/foo/bar?param1=2`).respond(200);
+
+      API.one('foo', 'bar').get({param1: 2});
+
+      $httpBackend.flush();
+    });
+
+    it('should take a param object with multiple params', function () {
+      $httpBackend.expectGET(`${baseUrl}/foo/bar?param1=2&param2=foo`).respond(200);
+
+      API.one('foo', 'bar').get({param1: 2, param2: 'foo'});
+
+      $httpBackend.flush();
+    });
+  });
+
+  describe('getList(): create a url with a "GET" method', function () {
+    it('should create the url and issue a get request with the "one" function', function () {
+      $httpBackend.expectGET(`${baseUrl}/foo`).respond(200);
+
+      API.one('foo').getList();
+
+      $httpBackend.flush();
+    });
+
+    it('should create the url and issue a get request with the "all" function', function () {
+      $httpBackend.expectGET(`${baseUrl}/foo/bar`).respond(200);
+
+      API.all('foo', 'bar').getList();
+
+      $httpBackend.flush();
+    });
+
+    it('should take a param object with one param', function () {
+      $httpBackend.expectGET(`${baseUrl}/foo/bar?param1=2`).respond(200);
+
+      API.one('foo', 'bar').getList({param1: 2});
+
+      $httpBackend.flush();
+    });
+
+    it('should take a param object with multiple params', function () {
+      $httpBackend.expectGET(`${baseUrl}/foo/bar?param1=2&param2=foo`).respond(200);
+
+      API.one('foo', 'bar').getList({param1: 2, param2: 'foo'});
+
+      $httpBackend.flush();
+    });
+  });
+
+  describe('post(): create a url with a "POST" method', function () {
+    it('should create the url and make a POST call', function () {
+      $httpBackend.expectPOST(`${baseUrl}/foo`).respond(200);
+
+      API.one('foo').post();
+
+      $httpBackend.flush();
+    });
+
+    it('should create the url and POST with data', function () {
+      let data = {bar: 7};
+      $httpBackend.expectPOST(`${baseUrl}/foo`, data).respond(200);
+
+      API.one('foo').post(data);
+
+      $httpBackend.flush();
+    });
+  });
+
+  describe('put(): create a url with a "PUT" method', function () {
+    it('should create the url and make a POST call', function () {
+      $httpBackend.expectPUT(`${baseUrl}/foo`).respond(200);
+
+      API.one('foo').put();
+
+      $httpBackend.flush();
+    });
+
+    it('should create the url and PUT with data', function () {
+      let data = {bar: 7};
+      $httpBackend.expectPUT(`${baseUrl}/foo`, data).respond(200);
+
+      API.one('foo').put(data);
+
+      $httpBackend.flush();
+    });
+  });
+
+  describe('remove(): create a url with a "DELETE" method', function () {
+    it('should create the url and make a DELETE call', function () {
+      $httpBackend.expectDELETE(`${baseUrl}/foo`).respond(200);
+
+      API.one('foo').remove();
+
+      $httpBackend.flush();
+    });
+
+    it('should create the url with params and  make a DELETE call', function () {
+      let params = {bar: 7};
+      $httpBackend.expectDELETE(`${baseUrl}/foo?bar=7`).respond(200);
+
+      API.one('foo').remove(params);
+
+      $httpBackend.flush();
+    });
+
+
+  });
+});

--- a/app/scripts/modules/core/application/service/applications.read.service.js
+++ b/app/scripts/modules/core/application/service/applications.read.service.js
@@ -4,7 +4,6 @@ let angular = require('angular');
 
 module.exports = angular
   .module('spinnaker.applications.read.service', [
-    require('exports?"restangular"!imports?_=lodash!restangular'),
     require('../../cluster/cluster.service.js'),
     require('../../task/task.read.service.js'),
     require('../../loadBalancer/loadBalancer.read.service.js'),
@@ -15,17 +14,15 @@ module.exports = angular
     require('../../pipeline/config/services/pipelineConfigService.js'),
     require('../../utils/rx.js'),
     require('../../utils/lodash.js'),
+    require('../../api/api.service'),
   ])
-  .factory('applicationReader', function ($q, $log, Restangular, _, rx, $http, settings, $location,
+  .factory('applicationReader', function ($q, $log, _, rx, $http, settings, $location, API,
                                             clusterService, taskReader, loadBalancerReader, securityGroupReader,
                                             schedulerFactory, pipelineConfigService, executionService,
                                             serverGroupTransformer) {
 
     function listApplications() {
-      return Restangular
-        .all('applications')
-        .withHttpConfig({cache: true})
-        .getList();
+      return API.one('applications').useCache().get();
     }
 
     let addTasks = (application, tasks) => {

--- a/app/scripts/modules/core/ci/jenkins/igor.service.js
+++ b/app/scripts/modules/core/ci/jenkins/igor.service.js
@@ -4,29 +4,24 @@ let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.ci.jenkins.igor.service', [
   require('../../config/settings.js'),
-  require('exports?"restangular"!imports?_=lodash!restangular'),
+  require('../../api/api.service'),
 ])
-  .factory('igorService', function (settings, Restangular) {
-    var RestangularNoEncoding;
-
-    RestangularNoEncoding = Restangular.withConfig(function(RestangularConfigurer) {
-      RestangularConfigurer.setEncodeIds(false);
-    });
+  .factory('igorService', function (settings, API) {
 
     function listMasters() {
-      return Restangular.one('v2').one('builds').getList();
+      return API.one('v2').one('builds').get();
     }
 
     function listJobsForMaster(master) {
-      return Restangular.one('v2').one('builds', master).all('jobs').getList();
+      return API.one('v2').one('builds').one(master).one('jobs').get();
     }
 
     function listBuildsForJob(master, job) {
-      return RestangularNoEncoding.one('v2').one('builds', master).one('builds').one(job).getList();
+      return API.one('v2').one('builds').one(master).one('builds').one(job).get();
     }
 
     function getJobConfig(master, job) {
-      return RestangularNoEncoding.one('v2').one('builds', master).one('jobs', job).get();
+      return API.one('v2').one('builds').one(master).one('jobs').one(job).get();
     }
 
     return {

--- a/app/scripts/modules/core/cluster/cluster.service.js
+++ b/app/scripts/modules/core/cluster/cluster.service.js
@@ -6,18 +6,18 @@ let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.cluster.service', [
   require('../naming/naming.service.js'),
-  require('exports?"restangular"!imports?_=lodash!restangular'),
+  require('../api/api.service'),
   require('../utils/lodash.js'),
   require('../serverGroup/serverGroup.transformer.js'),
   require('../job/job.transformer.js'),
 ])
-  .factory('clusterService', function ($q, Restangular, _, serverGroupTransformer,
+  .factory('clusterService', function ($q, API, _, serverGroupTransformer,
                                        jobTransformer, namingService) {
 
     function loadServerGroups(applicationName) {
       var serverGroupLoader = $q.all({
-        serverGroups: Restangular.one('applications', applicationName).all('serverGroups').getList().then(g => g, () => []),
-        jobs: Restangular.one('applications', applicationName).all('jobs').getList().then(jobs => jobs, () => []),
+        serverGroups: API.one('applications').one(applicationName).all('serverGroups').getList().then(g => g, () => []),
+        jobs: API.one('applications').one(applicationName).all('jobs').getList().then(jobs => jobs, () => []),
       });
       return serverGroupLoader.then(function(results) {
         results.serverGroups = results.serverGroups || [];
@@ -284,11 +284,11 @@ module.exports = angular.module('spinnaker.core.cluster.service', [
     }
 
     function getCluster(application, account, cluster) {
-      return Restangular.one('applications', application).one('clusters', account).one(cluster).get();
+      return API.one('applications').one(application).one('clusters', account).one(cluster).get();
     }
 
     function getClusters(application) {
-      return Restangular.one('applications', application).one('clusters').get();
+      return API.one('applications').one(application).one('clusters').get();
     }
 
     function addServerGroupsToApplication(application, serverGroups = []) {

--- a/app/scripts/modules/core/core.module.js
+++ b/app/scripts/modules/core/core.module.js
@@ -35,7 +35,6 @@ module.exports = angular
     require('angular-ui-router'),
     require('angular-ui-bootstrap'),
     require('exports?"angular.filter"!angular-filter'),
-    require('exports?"restangular"!imports?_=lodash!restangular'),
     require('exports?"ui.select"!ui-select'),
     require('imports?define=>false!exports?"angularSpinner"!angular-spinner'),
 
@@ -48,6 +47,8 @@ module.exports = angular
     require('./authentication/authentication.module.js'),
 
     require('./bootstrap/applicationBootstrap.directive.js'),
+
+    require('./api/api.service'),
 
     require('./cache/caches.module.js'),
     require('./cloudProvider/cloudProviderLogo.directive.js'),
@@ -184,10 +185,6 @@ module.exports = angular
   .config(function($uibModalProvider) {
     $uibModalProvider.options.backdrop = 'static';
     $uibModalProvider.options.keyboard = false;
-  })
-  .config(function(RestangularProvider, settings) {
-    RestangularProvider.setBaseUrl(settings.gateUrl);
-    RestangularProvider.setDefaultHttpFields({timeout: settings.pollSchedule * 2 + 5000}); // TODO: replace with apiHost call
   })
   .config(function($httpProvider) {
     $httpProvider.defaults.headers.patch = {

--- a/app/scripts/modules/core/delivery/create/createPipelineModal.controller.js
+++ b/app/scripts/modules/core/delivery/create/createPipelineModal.controller.js
@@ -36,11 +36,7 @@ module.exports = angular.module('spinnaker.core.pipeline.create.controller', [
 
     this.createPipeline = () => {
       var template = $scope.command.template;
-      if (template.fromServer) {
-        template = angular.copy(template.plain());
-      } else {
-        template = angular.copy(template);
-      }
+      template = angular.copy(template);
       if ($scope.command.template === noTemplate && $scope.command.parallel) {
         pipelineConfigService.enableParallelExecution(template);
       }

--- a/app/scripts/modules/core/delivery/create/createPipelineModal.controller.spec.js
+++ b/app/scripts/modules/core/delivery/create/createPipelineModal.controller.spec.js
@@ -117,16 +117,10 @@ describe('Controller: createPipelineModal', function() {
         application: 'the_app',
         name: 'old_name',
         stages: [{name: 'the_stage'}],
-        triggers: [{name: 'the_trigger'}],
-        fromServer: true,
-        plain: angular.noop
+        triggers: [{name: 'the_trigger'}]
       };
       var application = {};
 
-      spyOn(toCopy, 'plain').and.callFake(function () {
-        toCopy.isPlainNow = true;
-        return toCopy;
-      });
       this.initializeController(application);
       application.pipelineConfigs.data = [toCopy];
       spyOn(application.pipelineConfigs, 'refresh').and.callFake(() => {
@@ -149,7 +143,6 @@ describe('Controller: createPipelineModal', function() {
       expect(submitted.application).toBe('the_app');
       expect(submitted.stages.length).toBe(1);
       expect(submitted.triggers.length).toBe(1);
-      expect(submitted.isPlainNow).toBe(true);
     });
 
     it('should insert new pipeline as last one in application and set its index', function () {

--- a/app/scripts/modules/core/delivery/filter/executionFilter.service.spec.js
+++ b/app/scripts/modules/core/delivery/filter/executionFilter.service.spec.js
@@ -2,7 +2,6 @@
 
 describe('Service: executionFilterService', function () {
 
-
   var service;
   var ExecutionFilterModel;
   var $timeout;

--- a/app/scripts/modules/core/instance/instance.read.service.js
+++ b/app/scripts/modules/core/instance/instance.read.service.js
@@ -4,16 +4,16 @@ let angular = require('angular');
 
 module.exports = angular
   .module('spinnaker.core.instance.read.service', [
-    require('exports?"restangular"!imports?_=lodash!restangular')
+    require('../api/api.service')
   ])
-  .factory('instanceReader', function (Restangular) {
+  .factory('instanceReader', function (API) {
 
     function getInstanceDetails(account, region, id) {
-      return Restangular.all('instances').one(account).one(region).one(id).get();
+      return API.one('instances').one(account).one(region).one(id).get();
     }
 
     function getConsoleOutput(account, region, id, provider) {
-      return Restangular.all('instances').all(account).all(region).one(id, 'console').get({provider: provider});
+      return API.one('instances').all(account).all(region).one(id, 'console').withParams({provider: provider}).get();
     }
 
     return {

--- a/app/scripts/modules/core/job/configure/common/jobCommandBuilder.js
+++ b/app/scripts/modules/core/job/configure/common/jobCommandBuilder.js
@@ -3,15 +3,15 @@
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.job.configure.common.service', [
-  require('exports?"restangular"!imports?_=lodash!restangular'),
   require('../../../cache/deckCacheFactory.js'),
   require('../../../cloudProvider/serviceDelegate.service.js'),
-  require('../../../config/settings.js')
+  require('../../../config/settings.js'),
+  require('../../job.read.service')
 ])
-  .factory('jobCommandBuilder', function (settings, Restangular, serviceDelegate) {
+  .factory('jobCommandBuilder', function (settings, serviceDelegate, jobReader) {
 
     function getJob(application, account, region, jobName) {
-      return Restangular.one('applications', application).all('jobs').all(account).all(region).one(jobName).get();
+      return jobReader.getJob(application, account, region, jobName);
     }
 
     function getDelegate(provider) {

--- a/app/scripts/modules/core/job/job.read.service.js
+++ b/app/scripts/modules/core/job/job.read.service.js
@@ -4,12 +4,12 @@ let angular = require('angular');
 
 module.exports = angular
   .module('spinnaker.core.job.read.service', [
-    require('exports?"restangular"!imports?_=lodash!restangular'),
+    require('../api/api.service')
   ])
-  .factory('jobReader', function (Restangular) {
+  .factory('jobReader', function (API) {
 
     function getJob(application, account, region, jobName) {
-      return Restangular.one('applications', application).all('jobs').all(account).all(region).one(jobName).get();
+      return API.one('applications').one(application).all('jobs').all(account).all(region).one(jobName).get();
     }
 
     return {

--- a/app/scripts/modules/core/network/network.read.service.js
+++ b/app/scripts/modules/core/network/network.read.service.js
@@ -4,21 +4,22 @@ let angular = require('angular');
 
 module.exports = angular
   .module('spinnaker.core.network.read.service', [
-    require('exports?"restangular"!imports?_=lodash!restangular'),
     require('../utils/lodash.js'),
-    require('../cache/infrastructureCaches.js')
+    require('../cache/infrastructureCaches.js'),
+    require('../api/api.service')
   ])
-  .factory('networkReader', function (Restangular, infrastructureCaches ) {
+
+  .factory('networkReader', function (API, infrastructureCaches ) {
 
     function listNetworks() {
-      return Restangular.one('networks')
-        .withHttpConfig({cache: infrastructureCaches.networks})
+      return API.one('networks')
+        .useCache(infrastructureCaches.networks)
         .get();
     }
 
     function listNetworksByProvider(cloudProvider) {
-      return Restangular.one('networks', cloudProvider)
-        .withHttpConfig({cache: infrastructureCaches.networks})
+      return API.one('networks').one(cloudProvider)
+        .useCache(infrastructureCaches.networks)
         .getList();
     }
 

--- a/app/scripts/modules/core/notification/notification.service.js
+++ b/app/scripts/modules/core/notification/notification.service.js
@@ -3,16 +3,16 @@
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.notification.service', [
-  require('exports?"restangular"!imports?_=lodash!restangular'),
+  require('../api/api.service')
 ])
-  .factory('notificationService', function (settings, Restangular) {
+  .factory('notificationService', function (settings, API) {
 
     function getNotificationsForApplication(applicationName) {
-      return Restangular.one('notifications/application', applicationName).get();
+      return API.one('notifications').one('application', applicationName).get();
     }
 
     function saveNotificationsForApplication(applicationName, notifications) {
-      return Restangular.all('notifications/application/' + applicationName).post(notifications);
+      return API.one('notifications').one('application', applicationName).data(notifications).post();
     }
 
     return {

--- a/app/scripts/modules/core/pipeline/config/actions/json/editPipelineJson.module.js
+++ b/app/scripts/modules/core/pipeline/config/actions/json/editPipelineJson.module.js
@@ -17,7 +17,7 @@ module.exports = angular.module('spinnaker.core.pipeline.config.actions.editJson
     }
 
     this.initialize = function() {
-      var toCopy = pipeline.hasOwnProperty('plain') ? pipeline.plain() : pipeline;
+      var toCopy = pipeline;
       var pipelineCopy = _.cloneDeep(toCopy, function (value) {
         if (value && value.$$hashKey) {
           delete value.$$hashKey;

--- a/app/scripts/modules/core/pipeline/config/actions/json/editPipelineJsonModal.controller.spec.js
+++ b/app/scripts/modules/core/pipeline/config/actions/json/editPipelineJsonModal.controller.spec.js
@@ -46,14 +46,10 @@ describe('Controller: renamePipelineModal', function() {
     pipeline.stage.foo[0].$$hashKey = '01F';
     pipeline.stage.bar.$$hashKey = '01G';
     pipeline.plain = function() { return pipeline; };
-    spyOn(pipeline, 'plain').and.callThrough();
 
     this.controller.initialize();
 
     var converted = JSON.parse(this.$scope.command.pipelineJSON);
-
-    // restangular fields
-    expect(pipeline.plain).toHaveBeenCalled();
 
     // name
     expect(converted.name).toBeUndefined();

--- a/app/scripts/modules/core/pipeline/config/pipelineConfigurer.js
+++ b/app/scripts/modules/core/pipeline/config/pipelineConfigurer.js
@@ -253,7 +253,7 @@ module.exports = angular.module('spinnaker.core.pipeline.config.pipelineConfigur
     }
 
     function getPlain(pipeline) {
-      var base = pipeline.fromServer ? pipeline.plain() : pipeline;
+      var base = pipeline;
       var copy = _.cloneDeep(base);
       copy.stages.forEach(cleanStageForDiffing);
       return {

--- a/app/scripts/modules/core/pipeline/config/services/pipelineConfigService.spec.js
+++ b/app/scripts/modules/core/pipeline/config/services/pipelineConfigService.spec.js
@@ -4,15 +4,17 @@ describe('pipelineConfigService', function () {
   beforeEach(
     window.module(
       require('./pipelineConfigService'),
-      require('../../../utils/lodash.js')
+      require('../../../utils/lodash.js'),
+      require('../../../api/api.service')
     )
   );
 
-  beforeEach(window.inject(function (pipelineConfigService, $httpBackend, $rootScope, ___) {
+  beforeEach(window.inject(function (pipelineConfigService, $httpBackend, $rootScope, ___, _API_) {
     this._ = ___;
     this.service = pipelineConfigService;
     this.$http = $httpBackend;
     this.$scope = $rootScope.$new();
+    this.API = _API_;
   }));
 
   describe('savePipeline', function () {
@@ -25,7 +27,7 @@ describe('pipelineConfigService', function () {
         ]
       };
 
-      this.$http.expectPOST('/pipelines').respond(200, '');
+      this.$http.expectPOST(this.API.baseUrl + '/pipelines').respond(200, '');
 
       this.service.savePipeline(pipeline);
       this.$scope.$digest();
@@ -49,7 +51,7 @@ describe('pipelineConfigService', function () {
         { name: 'first', index: 0, stages: []},
         { name: 'third', index: 2, stages: []},
       ];
-      this.$http.expectGET('/applications/app/pipelineConfigs').respond(200, fromServer);
+      this.$http.expectGET(this.API.baseUrl + '/applications/app/pipelineConfigs').respond(200, fromServer);
 
       this.service.getPipelinesForApplication('app').then(function(pipelines) {
         result = pipelines;
@@ -69,8 +71,8 @@ describe('pipelineConfigService', function () {
       ];
 
       var posted = [];
-      this.$http.expectGET('/applications/app/pipelineConfigs').respond(200, fromServer);
-      this.$http.whenPOST('/pipelines', function(data) {
+      this.$http.expectGET(this.API.baseUrl + '/applications/app/pipelineConfigs').respond(200, fromServer);
+      this.$http.whenPOST(this.API.baseUrl + '/pipelines', function(data) {
         var json = JSON.parse(data);
         posted.push({index: json.index, name: json.name});
         return true;

--- a/app/scripts/modules/core/pipeline/config/stages/bake/bakery.service.js
+++ b/app/scripts/modules/core/pipeline/config/stages/bake/bakery.service.js
@@ -3,11 +3,11 @@
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.bake.service', [
-  require('exports?"restangular"!imports?_=lodash!restangular'),
+  require('../../../../api/api.service'),
   require('../../../../account/account.service.js'),
   require('../../../../config/settings.js'),
 ])
-  .factory('bakeryService', function($q, _, Restangular, accountService, settings) {
+  .factory('bakeryService', function($q, _, API, accountService, settings) {
 
     function getRegions(provider) {
       if (_.has(settings, `providers.${provider}.bakeryRegions`)) {
@@ -22,9 +22,10 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.bake.service', [
           return _.find(options, { cloudProvider: provider });
         });
       }
-      return Restangular
-        .all('bakery/options')
-        .withHttpConfig({cache: true})
+      return API
+        .one('bakery')
+        .one('options')
+        .useCache()
         .getList();
     }
 

--- a/app/scripts/modules/core/pipeline/config/stages/stage.module.js
+++ b/app/scripts/modules/core/pipeline/config/stages/stage.module.js
@@ -4,6 +4,7 @@ let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.config.stage', [
   require('../../../utils/lodash.js'),
+  require('../../../api/api.service'),
   require('../pipelineConfigProvider.js'),
   require('../services/pipelineConfigService.js'),
   require('./overrideTimeout/overrideTimeout.directive.js'),
@@ -176,10 +177,15 @@ module.exports = angular.module('spinnaker.core.pipeline.config.stage', [
     $scope.$watch('stage.type', this.selectStage);
     $scope.$watch('viewState.stageIndex', this.selectStage);
   })
-  .controller('RestartStageCtrl', function($scope, $stateParams, $http, Restangular, confirmationModalService) {
+  .controller('RestartStageCtrl', function($scope, $stateParams, $http, API, confirmationModalService) {
     var restartStage = function () {
-      return Restangular.one('pipelines', $stateParams.executionId).one('stages', $scope.stage.id).one('restart')
-        .customPUT({skip: false})
+      return API
+        .one('pipelines')
+        .one($stateParams.executionId)
+        .one('stages', $scope.stages.id)
+        .one('restart')
+        .data({skip: false})
+        .put()
         .then(function () {
           $scope.stage.isRestarting = true;
         });

--- a/app/scripts/modules/core/pipeline/config/triggers/cron/cron.validator.service.js
+++ b/app/scripts/modules/core/pipeline/config/triggers/cron/cron.validator.service.js
@@ -3,12 +3,12 @@
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.trigger.cron.validation.service', [
-    require('exports?"restangular"!imports?_=lodash!restangular'),
+    require('../../../../api/api.service')
   ])
-  .factory('cronValidationService', function(Restangular) {
+  .factory('cronValidationService', function(API) {
 
     function validate(expression) {
-      return Restangular.one('cron', 'validate').get({expression: expression}, {});
+      return API.one('cron').one('validate').withParams({expression: expression}, {}).get();
     }
 
     return {

--- a/app/scripts/modules/core/pipeline/pipelines.module.js
+++ b/app/scripts/modules/core/pipeline/pipelines.module.js
@@ -5,7 +5,6 @@ let angular = require('angular');
 require('./pipelines.less');
 
 module.exports = angular.module('spinnaker.core.pipeline', [
-  require('exports?"restangular"!imports?_=lodash!restangular'),
   require('exports?"ui.sortable"!angular-ui-sortable'),
   require('../utils/lodash.js'),
   require('./config/pipelineConfig.module.js'),

--- a/app/scripts/modules/core/securityGroup/securityGroup.read.service.spec.js
+++ b/app/scripts/modules/core/securityGroup/securityGroup.read.service.spec.js
@@ -4,19 +4,22 @@ describe('Service: securityGroupReader', function () {
 
   var securityGroupReader,
     $http,
-    $scope;
+    $scope,
+    API;
 
   beforeEach(
     window.module(
-      require('./securityGroup.read.service.js')
+      require('./securityGroup.read.service.js'),
+      require('../api/api.service')
     )
   );
 
   beforeEach(
-    window.inject(function (_securityGroupReader_, $httpBackend,
+    window.inject(function (_securityGroupReader_, $httpBackend, _API_,
                             $rootScope, $q, securityGroupTransformer, _serviceDelegate_) {
       securityGroupReader = _securityGroupReader_;
       $http = $httpBackend;
+      API = _API_;
       $scope = $rootScope.$new();
       spyOn(securityGroupTransformer, 'normalizeSecurityGroup').and.callFake((securityGroup) => {
         return $q.when(securityGroup);
@@ -87,7 +90,7 @@ describe('Service: securityGroupReader', function () {
       },
     };
 
-    $http.expectGET('/securityGroups/test/us-east-1/sg-123?provider=aws&vpcId=vpc-1').respond(200, {
+    $http.expectGET(API.baseUrl + '/securityGroups/test/us-east-1/sg-123?provider=aws&vpcId=vpc-1').respond(200, {
       inboundRules: [
         { securityGroup: { accountName: 'test', id: 'sg-345' }},
         { securityGroup: { accountName: 'test', id: 'sg-2' }},
@@ -124,7 +127,7 @@ describe('Service: securityGroupReader', function () {
       ]}
     };
 
-    $http.expectGET('/securityGroups').respond(200, {
+    $http.expectGET(API.baseUrl + '/securityGroups').respond(200, {
       test: {
         aws: {
           'us-east-1': [

--- a/app/scripts/modules/core/serverGroup/configure/common/serverGroupCommandBuilder.js
+++ b/app/scripts/modules/core/serverGroup/configure/common/serverGroupCommandBuilder.js
@@ -3,15 +3,15 @@
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.serverGroup.configure.common.service', [
-  require('exports?"restangular"!imports?_=lodash!restangular'),
+  require('../../../api/api.service'),
   require('../../../cache/deckCacheFactory.js'),
   require('../../../cloudProvider/serviceDelegate.service.js'),
   require('../../../config/settings.js')
 ])
-  .factory('serverGroupCommandBuilder', function (settings, Restangular, serviceDelegate) {
+  .factory('serverGroupCommandBuilder', function (settings, API, serviceDelegate) {
 
     function getServerGroup(application, account, region, serverGroupName) {
-      return Restangular.one('applications', application).all('serverGroups').all(account).all(region).one(serverGroupName).get();
+      return API.one('applications').one(application).all('serverGroups').all(account).all(region).one(serverGroupName).call();
     }
 
     function getDelegate(provider) {

--- a/app/scripts/modules/core/serverGroup/serverGroup.read.service.js
+++ b/app/scripts/modules/core/serverGroup/serverGroup.read.service.js
@@ -4,23 +4,27 @@ let angular = require('angular');
 
 module.exports = angular
   .module('spinnaker.core.serverGroup.read.service', [
-    require('exports?"restangular"!imports?_=lodash!restangular'),
+    require('../api/api.service')
   ])
-  .factory('serverGroupReader', function (Restangular, $log) {
+  .factory('serverGroupReader', function (API, $log) {
 
     function getServerGroup(application, account, region, serverGroupName) {
-      return Restangular.one('applications', application).all('serverGroups').all(account).all(region).one(serverGroupName).get();
+      return API.one('applications').one(application).all('serverGroups').all(account).all(region).one(serverGroupName).get();
     }
 
     function getServerGroupEndpoint(application, account, clusterName, serverGroupName) {
-      return Restangular.one('applications', application).all('clusters').all(account).all(clusterName).one('serverGroups', serverGroupName);
+      return API.one('applications').one(application).all('clusters').all(account).all(clusterName).one('serverGroups', serverGroupName);
     }
 
     function getScalingActivities(application, account, clusterName, serverGroupName, region, provider) {
-      return getServerGroupEndpoint(application, account, clusterName, serverGroupName).all('scalingActivities').getList({
-        region: region,
-        provider: provider
-      }).then(function(activities) {
+      return getServerGroupEndpoint(application, account, clusterName, serverGroupName)
+        .all('scalingActivities')
+        .withParams({
+          region: region,
+          provider: provider
+        })
+        .getList()
+        .then(function(activities) {
           return activities;
         },
         function(error) {

--- a/app/scripts/modules/core/subnet/subnet.read.service.spec.js
+++ b/app/scripts/modules/core/subnet/subnet.read.service.spec.js
@@ -2,15 +2,17 @@
 
 describe('subnetReader', function() {
 
-  var service, $http, $scope;
+  var service, $http, $scope, API;
 
   beforeEach(
     window.module(
-      require('./subnet.read.service.js')
+      require('./subnet.read.service.js'),
+      require('../api/api.service')
     )
   );
 
-  beforeEach(window.inject(function ($httpBackend, $rootScope, _subnetReader_) {
+  beforeEach(window.inject(function ($httpBackend, $rootScope, _subnetReader_, _API_) {
+    API = _API_;
     service = _subnetReader_;
     $http = $httpBackend;
     $scope = $rootScope.$new();
@@ -19,7 +21,7 @@ describe('subnetReader', function() {
 
   it('adds label to subnet, including (deprecated) if deprecated field is true', function () {
 
-    $http.whenGET('/subnets').respond(200, [
+    $http.whenGET(API.baseUrl + '/subnets').respond(200, [
       { purpose: 'internal', deprecated: true },
       { purpose: 'external', deprecated: false },
       { purpose: 'internal' },

--- a/app/scripts/modules/core/task/monitor/taskMonitorService.spec.js
+++ b/app/scripts/modules/core/task/monitor/taskMonitorService.spec.js
@@ -7,20 +7,25 @@ describe('Service: taskMonitorService', function () {
       $scope,
       $timeout,
       $http,
-      orchestratedItemTransformer;
+      orchestratedItemTransformer,
+      API;
 
   beforeEach(
-    window.module('spinnaker.tasks.monitor.service')
+    window.module(
+      require('./taskMonitorService'),
+      require('../../api/api.service')
+    )
   );
 
   beforeEach(
-    window.inject(function (_taskMonitorService_, _$q_, $rootScope, _$timeout_, $httpBackend, _orchestratedItemTransformer_) {
+    window.inject(function (_taskMonitorService_, _$q_, $rootScope, _$timeout_, $httpBackend, _orchestratedItemTransformer_, _API_) {
       taskMonitorService = _taskMonitorService_;
       $q = _$q_;
       $scope = $rootScope.$new();
       $timeout = _$timeout_;
       $http = $httpBackend;
       orchestratedItemTransformer = _orchestratedItemTransformer_;
+      API = _API_;
     })
   );
 
@@ -45,13 +50,13 @@ describe('Service: taskMonitorService', function () {
 
       $timeout.flush(); // still running first time
 
-      $http.expectGET(['/applications', 'deck', 'tasks', 'a'].join('/')).respond(200, { status: 'RUNNING' });
+      $http.expectGET([API.baseUrl, 'applications', 'deck', 'tasks', 'a'].join('/')).respond(200, { status: 'RUNNING' });
       $timeout.flush();
       $http.flush();
       expect(monitor.task.isCompleted).toBe(false);
       expect(monitor.application.runningOrchestrations.refresh.calls.count()).toBe(1);
 
-      $http.expectGET(['/applications', 'deck', 'tasks', 'a'].join('/')).respond(200, { status: 'SUCCEEDED' });
+      $http.expectGET([API.baseUrl, 'applications', 'deck', 'tasks', 'a'].join('/')).respond(200, { status: 'SUCCEEDED' });
       $timeout.flush(); // complete second time
       $http.flush();
 
@@ -99,12 +104,12 @@ describe('Service: taskMonitorService', function () {
 
       $timeout.flush(); // still running first time
 
-      $http.expectGET(['/applications', 'deck', 'tasks', 'a'].join('/')).respond(200, { status: 'RUNNING' });
+      $http.expectGET([API.baseUrl, 'applications', 'deck', 'tasks', 'a'].join('/')).respond(200, { status: 'RUNNING' });
       $timeout.flush();
       $http.flush();
       expect(monitor.task.isCompleted).toBe(false);
 
-      $http.expectGET(['/applications', 'deck', 'tasks', 'a'].join('/')).respond(200, { status: 'TERMINAL' });
+      $http.expectGET([API.baseUrl, 'applications', 'deck', 'tasks', 'a'].join('/')).respond(200, { status: 'TERMINAL' });
       $timeout.flush(); // complete second time
       $http.flush();
 

--- a/app/scripts/modules/core/task/task.read.service.spec.js
+++ b/app/scripts/modules/core/task/task.read.service.spec.js
@@ -2,16 +2,18 @@
 
 describe('Service: taskReader', function () {
 
-  var service, $http, scope, timeout, task;
+  var service, $http, scope, timeout, task, API;
 
   beforeEach(
     window.module(
-      require('./task.read.service')
+      require('./task.read.service'),
+      require('../api/api.service')
     )
   );
 
 
-  beforeEach(window.inject(function (taskReader, $httpBackend, $rootScope, $timeout) {
+  beforeEach(window.inject(function (taskReader, $httpBackend, $rootScope, $timeout, _API_) {
+    API = _API_;
     service = taskReader;
     $http = $httpBackend;
     timeout = $timeout;
@@ -36,7 +38,7 @@ describe('Service: taskReader', function () {
 
     it('resolves immediately if task already matches', function () {
 
-      $http.whenGET('/applications/deck/tasks/1').respond(200, {
+      $http.whenGET(API.baseUrl + '/applications/deck/tasks/1').respond(200, {
         id: 1,
         foo: 3,
         status: 'SUCCEEDED'
@@ -55,7 +57,7 @@ describe('Service: taskReader', function () {
 
     it('fails immediate if failure closure provided and task matches it', function () {
 
-      $http.whenGET('/applications/deck/tasks/1').respond(200, {
+      $http.whenGET(API.baseUrl + '/applications/deck/tasks/1').respond(200, {
         id: 1,
         foo: 3,
         status: 'SUCCEEDED'
@@ -79,7 +81,7 @@ describe('Service: taskReader', function () {
     });
 
     it('polls task and resolves when it matches', function () {
-      $http.expectGET('/applications/deck/tasks/1').respond(200, { id: 1, status: 'RUNNING' });
+      $http.expectGET(API.baseUrl + '/applications/deck/tasks/1').respond(200, { id: 1, status: 'RUNNING' });
 
       var completed = false,
           failed = false;
@@ -99,13 +101,13 @@ describe('Service: taskReader', function () {
       expect(failed).toBe(false);
 
       // still running
-      $http.expectGET('/applications/deck/tasks/1').respond(200, { id: 1, status: 'RUNNING' });
+      $http.expectGET(API.baseUrl + '/applications/deck/tasks/1').respond(200, { id: 1, status: 'RUNNING' });
       cycle();
       expect(completed).toBe(false);
       expect(failed).toBe(false);
 
       // succeeds
-      $http.expectGET('/applications/deck/tasks/1').respond(200, { id: 1, status: 'SUCCEEDED' });
+      $http.expectGET(API.baseUrl + '/applications/deck/tasks/1').respond(200, { id: 1, status: 'SUCCEEDED' });
       cycle();
       expect(completed).toBe(true);
       expect(failed).toBe(false);
@@ -113,7 +115,7 @@ describe('Service: taskReader', function () {
     });
 
     it('polls task and rejects when it matches failure closure', function () {
-      $http.expectGET('/applications/deck/tasks/1').respond(200, { id: 1, status: 'RUNNING' });
+      $http.expectGET(API.baseUrl + '/applications/deck/tasks/1').respond(200, { id: 1, status: 'RUNNING' });
 
       var completed = false,
           failed = false;
@@ -133,13 +135,13 @@ describe('Service: taskReader', function () {
       expect(failed).toBe(false);
 
       // still running
-      $http.expectGET('/applications/deck/tasks/1').respond(200, { id: 1, status: 'RUNNING' });
+      $http.expectGET(API.baseUrl + '/applications/deck/tasks/1').respond(200, { id: 1, status: 'RUNNING' });
       cycle();
       expect(completed).toBe(false);
       expect(failed).toBe(false);
 
       // succeeds
-      $http.expectGET('/applications/deck/tasks/1').respond(200, { id: 1, status: 'TERMINAL' });
+      $http.expectGET(API.baseUrl + '/applications/deck/tasks/1').respond(200, { id: 1, status: 'TERMINAL' });
       cycle();
       expect(completed).toBe(false);
       expect(failed).toBe(true);
@@ -147,7 +149,7 @@ describe('Service: taskReader', function () {
     });
 
     it('polls task and rejects if task is not returned from getTask call', function () {
-      $http.expectGET('/applications/deck/tasks/1').respond(500, {});
+      $http.expectGET(API.baseUrl + '/applications/deck/tasks/1').respond(500, {});
 
       var completed = false,
           failed = false;
@@ -177,7 +179,7 @@ describe('Service: taskReader', function () {
     }
 
     it('uses start time to calculate running time if endTime is zero', function () {
-      $http.whenGET('/applications/deck/tasks/1').respond(200, {
+      $http.whenGET(API.baseUrl + '/applications/deck/tasks/1').respond(200, {
         id: 2,
         status: 'SUCCEEDED',
         startTime: new Date(),
@@ -190,7 +192,7 @@ describe('Service: taskReader', function () {
     });
 
     it('uses start time to calculate running time if endTime is not present', function () {
-      $http.whenGET('/applications/deck/tasks/1').respond(200, {
+      $http.whenGET(API.baseUrl + '/applications/deck/tasks/1').respond(200, {
         id: 2,
         status: 'SUCCEEDED',
         startTime: new Date()
@@ -204,7 +206,7 @@ describe('Service: taskReader', function () {
     it('calculates running time based on start and end times', function () {
       var start = new Date().getTime(),
           end = start + 120 * 1000;
-      $http.whenGET('/applications/deck/tasks/1').respond(200, {
+      $http.whenGET(API.baseUrl + '/applications/deck/tasks/1').respond(200, {
         id: 2,
         status: 'SUCCEEDED',
         startTime: start,
@@ -219,7 +221,7 @@ describe('Service: taskReader', function () {
     it('handles offset between server and client by taking the max value of current time and start time', function () {
       let now = new Date().getTime(),
           offset = 200000;
-      $http.whenGET('/applications/deck/tasks/1').respond(200, {
+      $http.whenGET(API.baseUrl + '/applications/deck/tasks/1').respond(200, {
         id: 2,
         status: 'SUCCEEDED',
         startTime: now + offset

--- a/app/scripts/modules/core/task/task.write.service.js
+++ b/app/scripts/modules/core/task/task.write.service.js
@@ -4,12 +4,12 @@ let angular = require('angular');
 
 module.exports = angular
   .module('spinnaker.core.task.write.service', [
-    require('exports?"restangular"!imports?_=lodash!restangular'),
+    require('../api/api.service'),
     require('./task.read.service.js'),
   ])
-  .factory('taskWriter', function(Restangular, taskReader, $q, $timeout) {
+  .factory('taskWriter', function(API, taskReader, $q, $timeout) {
 
-    var endpoint = Restangular.all('applications');
+    var endpoint = API.all('applications');
 
     function getEndpoint(application) {
       return endpoint.all(application).all('tasks');
@@ -30,7 +30,7 @@ module.exports = angular
     function waitUntilTaskIsDeleted(taskId) {
       // wait until the task is gone, i.e. the promise from the get() is rejected, before succeeding
       var deferred = $q.defer();
-      Restangular.one('tasks', taskId).get().then(
+      API.one('tasks', taskId).get().then(
         () => {
           $timeout(() => {
             // task is still present, try again
@@ -52,7 +52,7 @@ module.exports = angular
     }
 
     function deleteTask(taskId) {
-      return Restangular.one('tasks', taskId).remove().then(() => waitUntilTaskIsDeleted(taskId));
+      return API.one('tasks', taskId).remove().then(() => waitUntilTaskIsDeleted(taskId));
     }
 
     return {

--- a/app/scripts/modules/core/task/task.write.service.spec.js
+++ b/app/scripts/modules/core/task/task.write.service.spec.js
@@ -5,18 +5,21 @@ describe('Service: taskWriter', function () {
   var taskWriter;
   var $httpBackend;
   var timeout;
+  var API;
 
   beforeEach(
     window.module(
-      require('./task.write.service')
+      require('./task.write.service'),
+      require('../api/api.service')
     )
   );
 
   beforeEach(
-    window.inject(function (_taskWriter_, _$httpBackend_, _$timeout_) {
+    window.inject(function (_taskWriter_, _$httpBackend_, _$timeout_, _API_) {
       taskWriter = _taskWriter_;
       $httpBackend = _$httpBackend_;
       timeout = _$timeout_;
+      API = _API_;
     })
   );
 
@@ -29,8 +32,8 @@ describe('Service: taskWriter', function () {
     it('should wait until task is canceled, then resolve', function () {
       let completed = false;
       let taskId = 'abc';
-      let cancelUrl = ['', 'applications', 'deck', 'tasks', taskId, 'cancel'].join('/');
-      let checkUrl = ['', 'applications', 'deck', 'tasks', taskId].join('/');
+      let cancelUrl = [API.baseUrl, 'applications', 'deck', 'tasks', taskId, 'cancel'].join('/');
+      let checkUrl = [API.baseUrl, 'applications', 'deck', 'tasks', taskId].join('/');
       let application = 'deck';
 
       $httpBackend.expectPUT(cancelUrl).respond(200, []);
@@ -55,8 +58,8 @@ describe('Service: taskWriter', function () {
     it('should wait until task is gone, then resolve', function () {
       let completed = false;
       let taskId = 'abc';
-      let deleteUrl = ['', 'tasks', taskId].join('/');
-      let checkUrl = ['', 'tasks', taskId].join('/');
+      let deleteUrl = [API.baseUrl, 'tasks', taskId].join('/');
+      let checkUrl = [API.baseUrl, 'tasks', taskId].join('/');
 
       $httpBackend.expectDELETE(deleteUrl).respond(200, []);
 

--- a/app/scripts/modules/docker/image/image.reader.js
+++ b/app/scripts/modules/docker/image/image.reader.js
@@ -2,18 +2,21 @@
 
 let angular = require('angular');
 
-module.exports = angular.module('spinnaker.docker.image.reader', [])
-    .factory('dockerImageReader', function ($q, Restangular) {
-        function findImages(params) {
-            return Restangular.all('images/find').getList(params, {}).then(function(results) {
-                    return results;
-                },
-                function() {
-                    return [];
-                });
-        }
+module.exports = angular
+  .module('spinnaker.docker.image.reader', [
+    require('../../core/api/api.service')
+  ])
+  .factory('dockerImageReader', function ($q, API) {
+    function findImages (params) {
+      return API.all('images/find').getList(params).then(function (results) {
+          return results;
+        },
+        function () {
+          return [];
+        });
+    }
 
-        return {
-            findImages: findImages,
-        };
-    });
+    return {
+      findImages: findImages,
+    };
+  });

--- a/app/scripts/modules/google/image/image.reader.js
+++ b/app/scripts/modules/google/image/image.reader.js
@@ -3,12 +3,12 @@
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.gce.image.reader', [
-  require('exports?"restangular"!imports?_=lodash!restangular'),
+  require('../../core/api/api.service')
 ])
-  .factory('gceImageReader', function ($q, Restangular) {
+  .factory('gceImageReader', function ($q, API) {
 
     function findImages(params) {
-      return Restangular.all('images/find').getList(params, {}).then(function(results) {
+      return API.all('images/find').getList(params).then(function(results) {
           return results;
         },
         function() {

--- a/app/scripts/modules/google/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/google/instance/details/instance.details.controller.js
@@ -120,7 +120,6 @@ module.exports = angular.module('spinnaker.instance.detail.gce.controller', [
         extraData.region = region;
         recentHistoryService.addExtraDataToLatest('instances', extraData);
         return instanceReader.getInstanceDetails(account, region, instance.instanceId).then(function(details) {
-          details = details.plain();
           $scope.state.loading = false;
           extractHealthMetrics(instanceSummary, details);
           $scope.instance = _.defaults(details, instanceSummary);

--- a/app/scripts/modules/google/instance/gceInstanceType.service.js
+++ b/app/scripts/modules/google/instance/gceInstanceType.service.js
@@ -3,7 +3,6 @@
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.gce.instanceType.service', [
-  require('exports?"restangular"!imports?_=lodash!restangular'),
   require('../../core/cache/deckCacheFactory.js'),
   require('../../core/utils/lodash.js'),
   require('../instance/gceVCpuMaxByLocation.value.js'),

--- a/app/scripts/modules/google/securityGroup/details/securityGroupDetail.controller.js
+++ b/app/scripts/modules/google/securityGroup/details/securityGroupDetail.controller.js
@@ -51,7 +51,7 @@ module.exports = angular.module('spinnaker.securityGroup.gce.details.controller'
       return securityGroupReader.getSecurityGroupDetails(application, securityGroup.accountId, securityGroup.provider, securityGroup.region, securityGroup.vpcId, securityGroup.name).then(function (details) {
         $scope.state.loading = false;
 
-        if (!details || _.isEmpty( details.plain())) {
+        if (!details || _.isEmpty( details )) {
           fourOhFour();
         } else {
           $scope.securityGroup = details;
@@ -131,7 +131,7 @@ module.exports = angular.module('spinnaker.securityGroup.gce.details.controller'
         size: 'lg',
         resolve: {
           securityGroup: function() {
-            return angular.copy($scope.securityGroup.plain());
+            return angular.copy($scope.securityGroup);
           },
           application: function() { return application; }
         }
@@ -146,7 +146,7 @@ module.exports = angular.module('spinnaker.securityGroup.gce.details.controller'
         size: 'lg',
         resolve: {
           securityGroup: function() {
-            var securityGroup = angular.copy($scope.securityGroup.plain());
+            var securityGroup = angular.copy($scope.securityGroup);
             if(securityGroup.region) {
               securityGroup.regions = [securityGroup.region];
             }

--- a/app/scripts/modules/google/serverGroup/configure/serverGroupCommandBuilder.service.js
+++ b/app/scripts/modules/google/serverGroup/configure/serverGroupCommandBuilder.service.js
@@ -3,7 +3,6 @@
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.gce.serverGroupCommandBuilder.service', [
-  require('exports?"restangular"!imports?_=lodash!restangular'),
   require('../../../core/cache/deckCacheFactory.js'),
   require('../../../core/account/account.service.js'),
   require('../../../core/instance/instanceTypeService.js'),
@@ -11,7 +10,7 @@ module.exports = angular.module('spinnaker.gce.serverGroupCommandBuilder.service
   require('../../../core/utils/lodash.js'),
   require('./../../instance/custom/customInstanceBuilder.gce.service.js'),
 ])
-  .factory('gceServerGroupCommandBuilder', function (settings, Restangular, $q,
+  .factory('gceServerGroupCommandBuilder', function (settings, $q,
                                                      accountService, instanceTypeService, namingService, _,
                                                      gceCustomInstanceBuilderService) {
 

--- a/app/scripts/modules/google/serverGroup/details/serverGroupDetails.gce.controller.js
+++ b/app/scripts/modules/google/serverGroup/details/serverGroupDetails.gce.controller.js
@@ -70,12 +70,11 @@ module.exports = angular.module('spinnaker.serverGroup.details.gce.controller', 
       return serverGroupReader.getServerGroup(app.name, serverGroup.accountId, serverGroup.region, serverGroup.name).then((details) => {
         cancelLoader();
 
-        var plainDetails = details.plain();
-        angular.extend(plainDetails, summary);
+        angular.extend(details, summary);
         // it's possible the summary was not found because the clusters are still loading
-        plainDetails.account = serverGroup.accountId;
+        details.account = serverGroup.accountId;
 
-        this.serverGroup = plainDetails;
+        this.serverGroup = details;
         this.runningExecutions = () => {
           return runningExecutionsService.filterRunningExecutions(this.serverGroup.executions);
         };

--- a/app/scripts/modules/kubernetes/image/image.reader.js
+++ b/app/scripts/modules/kubernetes/image/image.reader.js
@@ -2,10 +2,12 @@
 
 let angular = require('angular');
 
-module.exports = angular.module('spinnaker.kubernetes.image.reader', [])
-  .factory('kubernetesImageReader', function ($q, Restangular) {
+module.exports = angular.module('spinnaker.kubernetes.image.reader', [
+  require('../../core/api/api.service')
+])
+  .factory('kubernetesImageReader', function ($q, API) {
     function findImages(params) {
-      return Restangular.all('images/find').getList(params, {}).then(function(results) {
+      return API.all('images/find').getList(params).then(function(results) {
           return results;
         },
         function() {

--- a/app/scripts/modules/kubernetes/instance/details/details.controller.js
+++ b/app/scripts/modules/kubernetes/instance/details/details.controller.js
@@ -99,7 +99,6 @@ module.exports = angular.module('spinnaker.instance.detail.kubernetes.controller
         extraData.namespace = namespace;
         recentHistoryService.addExtraDataToLatest('instances', extraData);
         return instanceReader.getInstanceDetails(account, namespace, instance.instanceId).then(function(details) {
-          details = details.plain();
           $scope.state.loading = false;
           $scope.instance = _.defaults(details, instanceSummary);
           $scope.instance.account = account;

--- a/app/scripts/modules/kubernetes/job/details/details.controller.js
+++ b/app/scripts/modules/kubernetes/job/details/details.controller.js
@@ -55,10 +55,9 @@ module.exports = angular.module('spinnaker.job.details.kubernetes.controller', [
       return jobReader.getJob(application.name, job.accountId, job.region, job.name).then(function(details) {
         cancelLoader();
 
-        var restangularlessDetails = details.plain();
-        angular.extend(restangularlessDetails, summary);
+        angular.extend(details, summary);
 
-        $scope.job = restangularlessDetails;
+        $scope.job = details;
         $scope.runningExecutions = function() {
           return runningExecutionsService.filterRunningExecutions($scope.job.executions);
         };

--- a/app/scripts/modules/kubernetes/securityGroup/details/details.controller.js
+++ b/app/scripts/modules/kubernetes/securityGroup/details/details.controller.js
@@ -34,7 +34,7 @@ module.exports = angular.module('spinnaker.securityGroup.kubernetes.details.cont
       return securityGroupReader.getSecurityGroupDetails(application, securityGroup.accountId, securityGroup.provider, securityGroup.region, securityGroup.vpcId, securityGroup.name).then(function (details) {
         $scope.state.loading = false;
 
-        if (!details || _.isEmpty( details.plain())) {
+        if (!details || _.isEmpty(details)) {
           autoClose();
         } else {
           $scope.securityGroup = details;

--- a/app/scripts/modules/kubernetes/serverGroup/details/details.controller.js
+++ b/app/scripts/modules/kubernetes/serverGroup/details/details.controller.js
@@ -61,10 +61,9 @@ module.exports = angular.module('spinnaker.serverGroup.details.kubernetes.contro
       return serverGroupReader.getServerGroup(application.name, serverGroup.accountId, serverGroup.region, serverGroup.name).then(function(details) {
         cancelLoader();
 
-        var restangularlessDetails = details.plain();
-        angular.extend(restangularlessDetails, summary);
+        angular.extend(details, summary);
 
-        $scope.serverGroup = restangularlessDetails;
+        $scope.serverGroup = details;
         $scope.runningExecutions = function() {
           return runningExecutionsService.filterRunningExecutions($scope.serverGroup.executions);
         };

--- a/app/scripts/modules/netflix/canary/canary.read.service.js
+++ b/app/scripts/modules/netflix/canary/canary.read.service.js
@@ -5,16 +5,16 @@ let angular = require('angular');
 
 module.exports = angular
   .module('spinnaker.netflix.canary.read.service', [
-    require('exports?"restangular"!imports?_=lodash!restangular'),
+    require('../../core/api/api.service')
   ])
-  .factory('canaryReadService', function(Restangular) {
+  .factory('canaryReadService', function(API) {
 
     let getCanaryById = (canaryId) => {
-      return Restangular.one('canaries').one(canaryId).get();
+      return API.one('canaries').one(canaryId).get();
     };
 
     let getCanaryConfigsByApplication = (applicationName) => {
-      return Restangular.one('canaryConfigs').one(applicationName).getList();
+      return API.one('canaryConfigs').one(applicationName).getList();
     };
 
     return {

--- a/app/scripts/modules/netflix/canary/canaryAnalysisNameSelector.directive.js
+++ b/app/scripts/modules/netflix/canary/canaryAnalysisNameSelector.directive.js
@@ -5,7 +5,7 @@ let angular = require('angular');
 
 module.exports = angular
   .module('spinnaker.core.canary.canaryAnalysisNameSelector.directive', [
-    require('exports?"restangular"!imports?_=lodash!restangular'),
+    require('../../core/api/api.service')
   ])
   .directive('canaryAnalysisNameSelector', () => {
     return {
@@ -18,11 +18,11 @@ module.exports = angular
       },
       controllerAs: 'ctrl',
       templateUrl: require('./canaryAnalysisNameSelector.directive.html'),
-      controller: function(Restangular) {
+      controller: function(API) {
         let vm = this;
         vm.nameList = [];
 
-        Restangular.one('canaryConfig').all('names').getList()
+        API.one('canaryConfig').all('names').getList()
           .then(
             (results) => vm.nameList = results,
             () => vm.nameList = []

--- a/app/scripts/modules/netflix/fastProperties/fastProperty.read.service.js
+++ b/app/scripts/modules/netflix/fastProperties/fastProperty.read.service.js
@@ -4,30 +4,30 @@ let angular = require('angular');
 
 module.exports = angular
   .module('spinnaker.netflix.fastProperties.read.service', [
-    require('exports?"restangular"!imports?_=lodash!restangular'),
+    require('../../core/api/api.service'),
     require('../../core/cache/deckCacheFactory.js'),
     require('../canary/canary.read.service')
   ])
-  .factory('fastPropertyReader', function (Restangular, canaryReadService, $q, $log) {
+  .factory('fastPropertyReader', function (API, canaryReadService, $q, $log) {
 
     function fetchForAppName(appName) {
-      return Restangular.all('fastproperties').all('application').one(appName).get();
+      return API.all('fastproperties').all('application').one(appName).get();
     }
 
     function getPropByIdAndEnv(id, env) {
-      return Restangular.all('fastproperties').one('id', id).one('env', env).get();
+      return API.all('fastproperties').one('id', id).one('env', env).get();
     }
 
     function fetchImpactCountForScope(fastPropertyScope) {
-      return Restangular.all('fastproperties').all('impact').post(fastPropertyScope);
+      return API.all('fastproperties').all('impact').post(fastPropertyScope);
     }
 
     function loadPromotions() {
-      return Restangular.all('fastproperties').all('promotions').getList();
+      return API.all('fastproperties').all('promotions').getList();
     }
 
     function loadPromotionsByApp(appName) {
-      return Restangular.all('fastproperties').one('promotions', appName).getList()
+      return API.all('fastproperties').one('promotions', appName).getList()
         .then( (promotionList) => {
 
           return $q.all(promotionList.map((promotion) => {

--- a/app/scripts/modules/netflix/fastProperties/fastProperty.write.service.js
+++ b/app/scripts/modules/netflix/fastProperties/fastProperty.write.service.js
@@ -4,24 +4,24 @@ let angular = require('angular');
 
 module.exports = angular
   .module('spinnaker.netflix.fastProperties.write.service', [
-    require('exports?"restangular"!imports?_=lodash!restangular'),
+    require('../../core/api/api.service'),
     require('../../core/utils/lodash.js'),
     require('../../core/authentication/authentication.service.js')
   ])
-  .factory('fastPropertyWriter', function (Restangular, authenticationService, _) {
+  .factory('fastPropertyWriter', function (API, authenticationService, _) {
 
     function upsertFastProperty(fastProperty) {
       //var payload = createPromotedPayload(fastProperty);
       fastProperty.updatedBy = authenticationService.getAuthenticatedUser().name;
       fastProperty.sourceOfUpdate = 'spinnaker';
-      return Restangular
+      return API
         .all('fastproperties')
         .all('promote')
         .post(fastProperty);
     }
 
     function deleteFastProperty(fastProperty) {
-      return Restangular.all('fastproperties')
+      return API.all('fastproperties')
         .all('delete')
         .remove({
           propId: fastProperty.propertyId,
@@ -31,19 +31,19 @@ module.exports = angular
     }
 
     function continuePromotion(promotionId) {
-      return Restangular.all('fastproperties')
+      return API.all('fastproperties')
         .one('promote', promotionId)
-        .customPUT(null, null, {pass:true});
+        .put({pass:true});
     }
 
     function stopPromotion(promotionId) {
-      return Restangular.all('fastproperties')
+      return API.all('fastproperties')
         .one('promote', promotionId)
-        .customPUT(null, null, {pass:false});
+        .put({pass:false});
     }
 
     function deletePromotion(promotionId) {
-      return Restangular.all('fastproperties')
+      return API.all('fastproperties')
         .all('promote')
         .remove({
           promotionId: promotionId

--- a/app/scripts/modules/netflix/pipeline/stage/canary/canaryDeployment/canaryDeploymentHistory.service.js
+++ b/app/scripts/modules/netflix/pipeline/stage/canary/canaryDeployment/canaryDeploymentHistory.service.js
@@ -3,12 +3,12 @@
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.netflix.pipeline.stages.canary.deployment.history.service', [
-  require('exports?"restangular"!imports?_=lodash!restangular'),
+  require('../../../../../core/api/api.service')
 ])
-  .factory('canaryDeploymentHistoryService', function (Restangular) {
+  .factory('canaryDeploymentHistoryService', function (API) {
 
     function getAnalysisHistory(canaryDeploymentId) {
-      return Restangular.one('canaryDeployments').one(canaryDeploymentId).all('canaryAnalysisHistory').getList();
+      return API.one('canaryDeployments').one(canaryDeploymentId).all('canaryAnalysisHistory').getList();
     }
 
     return {

--- a/app/scripts/modules/netflix/serverGroup/diff/diff.service.js
+++ b/app/scripts/modules/netflix/serverGroup/diff/diff.service.js
@@ -3,23 +3,23 @@
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.diff.service', [
-  require('exports?"restangular"!imports?_=lodash!restangular'),
+  require('../../../core/api/api.service'),
   require('../../../core/utils/lodash.js'),
   require('../../../core/config/settings.js'),
 ])
-  .factory('diffService', function (_, Restangular, $q, settings) {
+  .factory('diffService', function (_, API, $q, settings) {
 
     function getClusterDiffForAccount(accountName, clusterName) {
       if (!settings.feature.clusterDiff) {
         return $q.when({});
       }
-      return Restangular
+      return API
         .all('diff')
         .all('cluster')
         .one(accountName, clusterName)
         .get().then(
           (diff) => {
-            return diff.plain();
+            return diff;
           },
           () => {
             return {};

--- a/app/scripts/modules/netflix/serverGroup/networking/elasticIp.read.service.js
+++ b/app/scripts/modules/netflix/serverGroup/networking/elasticIp.read.service.js
@@ -4,11 +4,11 @@ let angular = require('angular');
 
 module.exports = angular
   .module('spinnaker.aws.serverGroup.details.elasticIp.read.service', [
-    require('exports?"restangular"!imports?_=lodash!restangular'),
+    require('../../../core/api/api.service')
   ])
-  .factory('elasticIpReader', function (Restangular, $log) {
+  .factory('elasticIpReader', function (API, $log) {
     function getElasticIpsForCluster(application, account, clusterName, region) {
-      return Restangular.one('applications', application).all('clusters').all(account).all(clusterName).one('elasticIps').all(region)
+      return API.one('applications', application).all('clusters').all(account).all(clusterName).one('elasticIps').all(region)
         .getList()
         .then(function (elasticIps) {
           return elasticIps;

--- a/app/scripts/modules/netflix/serverGroup/networking/networking.controller.js
+++ b/app/scripts/modules/netflix/serverGroup/networking/networking.controller.js
@@ -16,7 +16,7 @@ module.exports = angular.module('spinnaker.aws.serverGroup.details.networking.co
       var application = this.application;
       elasticIpReader.getElasticIpsForCluster(application.name, serverGroup.account, serverGroup.cluster, serverGroup.region)
         .then((elasticIps) => {
-          this.elasticIps = elasticIps.plain ? elasticIps.plain() : [];
+          this.elasticIps = elasticIps ? elasticIps : [];
         });
     };
 

--- a/app/scripts/modules/openstack/image/image.reader.js
+++ b/app/scripts/modules/openstack/image/image.reader.js
@@ -3,12 +3,12 @@
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.openstack.image.reader', [
-  require('exports?"restangular"!imports?_=lodash!restangular')
+  require('../../core/api/api.service')
 ])
-  .factory('openstackImageReader', function ($q, Restangular) {
+  .factory('openstackImageReader', function ($q, API) {
 
     function findImages(params) {
-      return Restangular.all('images/find').getList(params, {})
+      return API.all('images/find').getList(params)
         .then(function(results) {
           return results;
         })
@@ -18,7 +18,7 @@ module.exports = angular.module('spinnaker.openstack.image.reader', [
     }
 
     function getImage(amiName, region, credentials) {
-      return Restangular.all('images').one(credentials).one(region).all(amiName).getList({provider: 'openstack'}).then(function(results) {
+      return API.all('images').one(credentials).one(region).all(amiName).getList({provider: 'openstack'}).then(function(results) {
           return results && results.length ? results[0] : null;
         })
         .catch(function() {

--- a/app/scripts/modules/titus/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/titus/instance/details/instance.details.controller.js
@@ -77,7 +77,6 @@ module.exports = angular.module('spinnaker.instance.detail.titus.controller', [
         extraData.region = region;
         recentHistoryService.addExtraDataToLatest('instances', extraData);
         return instanceReader.getInstanceDetails(account, region, instance.instanceId).then(function(details) {
-          details = details.plain();
           $scope.state.loading = false;
           extractHealthMetrics(instanceSummary, details);
           $scope.instance = _.defaults(details, instanceSummary);

--- a/app/scripts/modules/titus/serverGroup/configure/ServerGroupCommandBuilder.js
+++ b/app/scripts/modules/titus/serverGroup/configure/ServerGroupCommandBuilder.js
@@ -3,12 +3,11 @@
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.titus.serverGroupCommandBuilder.service', [
-  require('exports?"restangular"!imports?_=lodash!restangular'),
   require('../../../core/cache/deckCacheFactory.js'),
   require('../../../core/account/account.service.js'),
   require('../../../core/naming/naming.service.js')
 ])
-  .factory('titusServerGroupCommandBuilder', function (settings, Restangular, $q,
+  .factory('titusServerGroupCommandBuilder', function (settings, $q,
                                                      accountService, namingService) {
     function buildNewServerGroupCommand(application, defaults) {
       defaults = defaults || {};

--- a/app/scripts/modules/titus/serverGroup/details/serverGroupDetails.titus.controller.js
+++ b/app/scripts/modules/titus/serverGroup/details/serverGroupDetails.titus.controller.js
@@ -41,12 +41,11 @@ module.exports = angular.module('spinnaker.serverGroup.details.titus.controller'
       return serverGroupReader.getServerGroup(application.name, serverGroup.accountId, serverGroup.region, serverGroup.name).then(function(details) {
         cancelLoader();
 
-        var restangularlessDetails = details.plain();
         // it's possible the summary was not found because the clusters are still loading
-        restangularlessDetails.account = serverGroup.accountId;
-        angular.extend(restangularlessDetails, summary);
+        details.account = serverGroup.accountId;
+        angular.extend(details, summary);
 
-        $scope.serverGroup = restangularlessDetails;
+        $scope.serverGroup = details;
         $scope.runningExecutions = function() {
           return runningExecutionsService.filterRunningExecutions($scope.serverGroup.executions);
         };

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "loader-utils": "^0.2.11",
     "lodash": "^3.10.1",
     "moment-timezone": "^0.4.0",
-    "restangular": "~1.4.0",
     "rx": "=4.0.6",
     "select2-bootstrap-css": "git://github.com/t0m/select2-bootstrap-css.git#v1.3.1",
     "source-map": "^0.4.4",

--- a/settings.js
+++ b/settings.js
@@ -82,7 +82,7 @@ window.spinnakerSettings = {
       botName: 'spinnakerbot'
     }
   },
-  authEnabled: process.env.AUTH === 'enabled',
+  authEnabled: true,
   authTtl: 600000,
   gitSources: ['stash', 'github'],
   triggerTypes: ['git', 'pipeline', 'docker', 'cron', 'jenkins'],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,7 +14,7 @@ module.exports = {
   entry: {
     settings: './settings.js',
     app: './app/scripts/app.js',
-    vendor: ['jquery', 'angular', 'angular-animate', 'angular-ui-bootstrap', 'angular-ui-router', 'restangular',
+    vendor: ['jquery', 'angular', 'angular-animate', 'angular-ui-bootstrap', 'angular-ui-router',
       'source-sans-pro', 'angular-cache', 'angular-marked', 'angular-messages', 'angular-sanitize',
       'bootstrap', 'clipboard', 'd3', 'jquery-ui', 'moment-timezone', 'rx'
     ]


### PR DESCRIPTION
Added an API service (core/api/api.service.js) that handles the construction of all REST calls.  This service mimics the fluid API style of Restangular. 

Why do this:
- Restangular is great but we where only using a small subset of it's features.
- Restangular "pollutes" the return payload with attributes and additional functions that we never use.
- Retangular pins us to an older version of lodash.js


@anotherchrisberry PTAL

@duftler @danielpeach @spinnaker/microsoft @spinnaker/veritas @gregturn  @spinnaker/target please pull down and kick the tires, let me know if anything is broken for your cloud