### PR TITLE
(core) allow user to add ad-hoc notification to pipeline execution

### DIFF
--- a/app/scripts/modules/core/delivery/manualExecution/manualPipelineExecution.html
+++ b/app/scripts/modules/core/delivery/manualExecution/manualPipelineExecution.html
@@ -124,6 +124,26 @@
         </div>
       </div>
 
+      <div class="form-group">
+        <label class="col-md-4 sm-label-right">Notifications</label>
+        <div class="col-md-8">
+          <div class="checkbox checkbox-notify">
+            <label>
+              <input type="checkbox" ng-model="vm.command.notificationEnabled"> Notify me when the pipeline completes
+            </label>
+          </div>
+          <div ng-if="vm.notifications.length === 1" class="small">
+            There is <a uib-popover-template="vm.notificationTooltip" popover-placement="bottom">one notification</a> configured for this pipeline
+          </div>
+          <div ng-if="vm.notifications.length > 1" class="small">
+            There are <a uib-popover-template="vm.notificationTooltip" popover-placement="bottom" popover-trigger="mouseenter">{{vm.notifications.length}} notifications</a> configured for this pipeline</div>
+        </div>
+      </div>
+      <div class="form-group" ng-if="vm.command.notificationEnabled">
+        <div class="col-md-8 col-md-offset-2">
+          <notification-selector notification="vm.command.notification"></notification-selector>
+        </div>
+      </div>
     </div>
 
     <div class="modal-footer">

--- a/app/scripts/modules/core/delivery/manualExecution/manualPipelineExecution.less
+++ b/app/scripts/modules/core/delivery/manualExecution/manualPipelineExecution.less
@@ -1,3 +1,12 @@
 .manual-execution-parameters-description {
   margin-top: 20px;
 }
+.notifications-list {
+  font-size: 90%;
+  padding-top: 7px;
+  text-align: left;
+  ul {
+    list-style-type: none;
+    padding-left: 20px;
+  }
+}

--- a/app/scripts/modules/core/delivery/manualExecution/notifications.tooltip.html
+++ b/app/scripts/modules/core/delivery/manualExecution/notifications.tooltip.html
@@ -1,0 +1,10 @@
+<div class="notifications-list">
+  <ul>
+    <li ng-repeat="notification in vm.notifications">
+      <b>{{notification.address}}</b> when:
+      <ul>
+        <li ng-repeat="when in notification.when">{{when|notificationWhen}}</li>
+      </ul>
+    </li>
+  </ul>
+</div>

--- a/app/scripts/modules/core/notification/selector/notificationSelector.directive.js
+++ b/app/scripts/modules/core/notification/selector/notificationSelector.directive.js
@@ -11,6 +11,7 @@ module.exports = angular.module('spinnaker.core.notification.selector.directive'
         notification: '=',
         level: '='
       },
+      scope: {},
       templateUrl: require('./notificationSelector.html'),
       controller: 'NotificationSelectorCtrl',
       controllerAs: 'vm'


### PR DESCRIPTION
UI changes to go with https://github.com/spinnaker/gate/pull/259

Adds a single notification whenever the pipeline fails or completes, prefilled with the user's email address (if authenticated).

(Updated PR with a less obtrusive view of existing notifications)

<img width="586" alt="screen shot 2016-07-20 at 9 13 47 am" src="https://cloud.githubusercontent.com/assets/73450/16994172/175cd430-4e5b-11e6-8e52-17cbfad78356.png">
<img width="591" alt="screen shot 2016-07-20 at 9 13 41 am" src="https://cloud.githubusercontent.com/assets/73450/16994171/175a0dfe-4e5b-11e6-98ce-8c34ca113cef.png">
<img width="568" alt="screen shot 2016-07-20 at 9 19 59 am" src="https://cloud.githubusercontent.com/assets/73450/16994186/2b3e8c0a-4e5b-11e6-8cd3-f95dc4ccdd54.png">
