### PR TITLE
Use Username instead of Email to identify authenticated user

### DIFF
--- a/app/scripts/modules/core/authentication/authentication.initializer.service.js
+++ b/app/scripts/modules/core/authentication/authentication.initializer.service.js
@@ -17,8 +17,8 @@ module.exports = angular.module('spinnaker.authentication.initializer.service', 
       }
       $http.get(settings.authEndpoint)
         .success(function (data) {
-          if (data.email) {
-            authenticationService.setAuthenticatedUser(data.email);
+          if (data.username) {
+            authenticationService.setAuthenticatedUser(data.username);
           } else {
             loginNotification();
           }
@@ -30,8 +30,8 @@ module.exports = angular.module('spinnaker.authentication.initializer.service', 
       $rootScope.authenticating = true;
       $http.get(settings.authEndpoint)
         .success(function (data) {
-          if (data.email) {
-            authenticationService.setAuthenticatedUser(data.email);
+          if (data.username) {
+            authenticationService.setAuthenticatedUser(data.username);
             $rootScope.authenticating = false;
           } else {
             loginRedirect();

--- a/app/scripts/modules/core/authentication/authentication.provider.spec.js
+++ b/app/scripts/modules/core/authentication/authentication.provider.spec.js
@@ -26,7 +26,7 @@ describe('authenticationProvider: application startup', function() {
   describe('authenticateUser', function() {
     it('requests authentication from gate, then sets authentication name field', function() {
       if(!this.settings.authEnabled) { pending(); } //prevents the test from running if authentication is not enabled
-      this.$http.whenGET(this.settings.authEndpoint).respond(200, {email: 'joe!'});
+      this.$http.whenGET(this.settings.authEndpoint).respond(200, {username: 'joe!'});
       this.$timeout.flush();
       this.$http.flush();
 


### PR DESCRIPTION
Same as https://github.com/spinnaker/gate/pull/257

It should prevent infinite loop when using Github OAuth when no public is defined for the user.

@ttomsu @anotherchrisberry PTAL