### PR TITLE
SPIN-1900: Track scrollbar position on pipeline graph

### DIFF
--- a/app/scripts/modules/core/pipeline/config/graph/pipeline.graph.directive.js
+++ b/app/scripts/modules/core/pipeline/config/graph/pipeline.graph.directive.js
@@ -22,6 +22,14 @@ module.exports = angular.module('spinnaker.core.pipeline.config.graph.directive'
       templateUrl: require('./pipelineGraph.directive.html'),
       link: function (scope, elem) {
 
+        // track and save the graph scroll position for executions so it doesn't get reset to
+        // zero every second due to repaint.
+        elem.on('mousewheel', function() {
+          if(scope.execution) {
+            pipelineGraphService.xScrollOffset[scope.execution.id] = elem.scrollLeft();
+          }
+        });
+
         var minLabelWidth = 100;
 
         scope.nodeRadius = 8;
@@ -238,6 +246,14 @@ module.exports = angular.module('spinnaker.core.pipeline.config.graph.directive'
             scope.graphWidth = '100%';
             scope.graphClass = '';
           }
+
+          // get the saved horizontal scroll position for executions
+          if(scope.execution) {
+            let offsetForId = pipelineGraphService.xScrollOffset[scope.execution.id] || 0;
+            console.info('offset', offsetForId);
+            elem.scrollLeft(offsetForId);
+          }
+
         }
 
         function applyNodeHeights() {
@@ -321,7 +337,6 @@ module.exports = angular.module('spinnaker.core.pipeline.config.graph.directive'
           setNodePositions();
           createLinks();
           applyAllNodes();
-
         }
 
         var handleWindowResize = _.throttle(function() {

--- a/app/scripts/modules/core/pipeline/config/graph/pipeline.graph.directive.js
+++ b/app/scripts/modules/core/pipeline/config/graph/pipeline.graph.directive.js
@@ -250,7 +250,6 @@ module.exports = angular.module('spinnaker.core.pipeline.config.graph.directive'
           // get the saved horizontal scroll position for executions
           if(scope.execution) {
             let offsetForId = pipelineGraphService.xScrollOffset[scope.execution.id] || 0;
-            console.info('offset', offsetForId);
             elem.scrollLeft(offsetForId);
           }
 

--- a/app/scripts/modules/core/pipeline/config/graph/pipelineGraph.service.js
+++ b/app/scripts/modules/core/pipeline/config/graph/pipelineGraph.service.js
@@ -8,6 +8,8 @@ module.exports = angular
   ])
   .factory('pipelineGraphService', function () {
 
+    let xScrollOffset = {};
+
     function generateExecutionGraph(execution, viewState) {
       let nodes = [];
       (execution.stageSummaries || []).forEach(function(stage, idx) {
@@ -82,6 +84,7 @@ module.exports = angular
     }
 
     return {
+      xScrollOffset: xScrollOffset,
       generateExecutionGraph: generateExecutionGraph,
       generateConfigGraph: generateConfigGraph,
     };


### PR DESCRIPTION
Cadmium has a very long pipeline graph that and the overflow-x: auto kicks in.

Due to the change in the fetch interval to 1 second, when every the user scrolls the to the right when the graph repaints it resets the letfScroll on the graph to zero, creating a very frustrating user experience.

This seem to only happen when the pipeline is Running.

This fix adds a mousewheel event (scroll was not firing) on the <pipeline-graph> element.  It then saves the scrollLeft posisiton of the scrollbar off to the pipelineGraphService.

When the svg graph redraws it get the scrollLeft offset from the service and sets it.  This prevents the scroll bar from jumping back to the zero position every second.

@anotherchrisberry PTAL