### PR TITLE
(aws) import minified version of LineChart css file

### DIFF
--- a/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/chart/metricAlarmChart.component.js
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/chart/metricAlarmChart.component.js
@@ -2,7 +2,7 @@
 
 const angular = require('angular');
 
-require('style!n3-charts/build/LineChart.css');
+require('style!n3-charts/build/LineChart.min.css');
 require('./metricAlarmChart.component.less');
 
 module.exports = angular


### PR DESCRIPTION
We're seeing an issue where the build output from Travis is dropping some `\a` characters from the LineChart.css file. I cannot reproduce this locally. I am crossing my fingers that bringing in the minified version of the CSS will somehow sweep this problem under the rug.