### PR TITLE
(aws) hack in CSS fix for n3-charts library

### DIFF
--- a/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/chart/LineChartHack.css
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/chart/LineChartHack.css
@@ -1,0 +1,121 @@
+/*
+  This is a copy of the n3-charts/build/LineChart.css file with the unicode newline escape sequences stripped out.
+  This file should be removed as soon as possible. See https://github.com/n3-charts/line-chart/issues/512 for updates.
+*/
+.chart-legend {
+  margin-left: 20px; }
+.chart-legend .item {
+  cursor: pointer;
+  font-family: sans-serif;
+  height: 16px;
+  font-size: 0.8em;
+  font-weight: 100;
+  display: inline-block;
+  margin-right: 10px; }
+.chart-legend .item > * {
+  vertical-align: middle;
+  display: inline-block; }
+.chart-legend .item > .legend-label {
+  height: 16px;
+  line-height: 17px; }
+.chart-legend .item > .icon {
+  width: 16px;
+  border-radius: 50%;
+  height: 16px;
+  margin-right: 5px;
+  background-repeat: no-repeat;
+  background-position: 50% 25%; }
+.chart-legend .item.legend-hidden {
+  opacity: 0.4; }
+.chart-legend .item.column > .icon {
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' style='fill: white;' width='10' height='10'><rect y='2' width='2' height='8'/><rect x='4' y='5' width='2' height='5'/><rect x='8' y='3' width='2' height='7'/></svg>"); }
+.chart-legend .item.dot > .icon {
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' style='fill: white;' width='10' height='10'><circle cx='5' cy='6' r='2'/></svg>"); }
+.chart-legend .item.dashed-line > .icon {
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' style='fill: white;' width='10' height='10'>         <g style=\"stroke: white; fill: none; stroke-dasharray: 4px,2px;\">           <path d='M0,6 L10,6'/>         </g>       </svg>"); }
+.chart-legend .item.line > .icon {
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' style='fill: white;' width='10' height='10'>         <g style=\"stroke: white;\">           <path d='M0,6 L10,6'/>         </g>       </svg>"); }
+.chart-legend .item.area > .icon {
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' style='fill: white;' width='10' height='10'><polygon points='0,10 2.428,3 5,6 7.625,5 10,10 10,10 0,10'/></svg>"); }
+
+.tooltip-line {
+  stroke: grey;
+  stroke-width: 1;
+  shape-rendering: crispEdges; }
+
+.tooltip-dot {
+  stroke-width: 2px;
+  fill: white; }
+
+.chart-tooltip {
+  position: absolute;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  background-color: white;
+  z-index: 100;
+  box-shadow: 1px 1px 2px rgba(61, 61, 61, 0.5);
+  padding: 5px 10px;
+  border-radius: 1px;
+  font-family: sans-serif;
+  font-weight: 100; }
+.chart-tooltip > .abscissas {
+  margin-bottom: 5px;
+  font-size: 0.7em;
+  white-space: nowrap; }
+.chart-tooltip .tooltip-item {
+  font-size: 0.8em;
+  white-space: nowrap; }
+.chart-tooltip .tooltip-item:not(:last-child) {
+  margin-bottom: 0.2em; }
+.chart-tooltip .tooltip-item > * {
+  display: inline-block; }
+.chart-tooltip .tooltip-item > *:not(:last-child) {
+  margin-right: 0.4em; }
+.chart-tooltip .tooltip-item .color-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%; }
+.chart-tooltip .tooltip-item .y-value {
+  font-weight: 500; }
+
+.chart {
+  position: relative;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none; }
+.chart .axis {
+  font: 10px Roboto;
+  shape-rendering: crispEdges; }
+.chart .axis.x2-axis {
+  display: none; }
+.chart .axis > path {
+  fill: none;
+  stroke: black; }
+.chart .axis > .tick > text {
+  fill: black; }
+.chart .axis > .tick > line {
+  stroke: black; }
+.chart .grid .tick > text {
+  display: none; }
+.chart .grid .tick > line {
+  stroke: #eee;
+  stroke-width: 1;
+  shape-rendering: crispEdges; }
+.chart .dot-series circle {
+  fill: white;
+  stroke-width: 2px; }
+.chart .line-series path {
+  stroke-width: 1px; }
+.chart .column-series {
+  fill-opacity: 0.3; }
+.chart .area-series {
+  opacity: 0.3; }
+.chart .chart-brush {
+  fill: rgba(166, 166, 166, 0.5); }
+.chart .hline {
+  shape-rendering: crispEdges;
+  stroke-width: 1px; }

--- a/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/chart/metricAlarmChart.component.js
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/chart/metricAlarmChart.component.js
@@ -2,7 +2,10 @@
 
 const angular = require('angular');
 
-require('style!n3-charts/build/LineChart.min.css');
+// TODO: Remove LineChartHack, replace require with commented out one once
+// https://github.com/n3-charts/line-chart/issues/512 is resolved
+// require('style!n3-charts/build/LineChart.css');
+require('./LineChartHack.css');
 require('./metricAlarmChart.component.less');
 
 module.exports = angular


### PR DESCRIPTION
Probably not the worst hack in the application.

Workaround for https://github.com/n3-charts/line-chart/issues/512, which is causing the scaling policy charts to be styled incorrectly.