### PR TITLE
(aws) avoid duplicate load balancer declarations when including vpcLo…

### DIFF
--- a/app/scripts/modules/amazon/serverGroup/configure/serverGroupConfiguration.service.js
+++ b/app/scripts/modules/amazon/serverGroup/configure/serverGroupConfiguration.service.js
@@ -364,6 +364,8 @@ module.exports = angular.module('spinnaker.aws.serverGroup.configure.service', [
         command.loadBalancers = _.intersection(newLoadBalancers, matched);
         if (!command.vpcId) {
           command.vpcLoadBalancers = _.intersection(vpcLoadBalancers, matched);
+        } else {
+          delete command.vpcLoadBalancers;
         }
         if (removed.length) {
           result.dirty.loadBalancers = removed;


### PR DESCRIPTION
…adBalancers

This covers a scenario in which a user has a Classic cluster configured in their pipeline with a VPC load balancer, then changes the cluster to VPC. We remove any Classic load balancers, but we don't remove the `vpcLoadBalancers` array. When the user clicks "Done" to persist the config changes, the `vpcLoadBalancers` get `concat`ed into the `loadBalancers` array, creating duplicates.