### PR TITLE
core: added a section to the application config tab to serialize the application infrastructure

### DIFF
--- a/app/scripts/modules/core/application/config/applicationConfig.controller.js
+++ b/app/scripts/modules/core/application/config/applicationConfig.controller.js
@@ -9,10 +9,13 @@ module.exports = angular
     require('./applicationNotifications.directive.js'),
     require('./applicationCacheManagement.directive.js'),
     require('./deleteApplicationSection.directive.js'),
+    require('./serializeApplicationSection.component.js'),
     require('./links/applicationLinks.component.js'),
+    require('../../config/settings.js')
   ])
-  .controller('ApplicationConfigController', function ($state, app) {
+  .controller('ApplicationConfigController', function ($state, app, settings) {
     this.application = app;
+    this.serialization = settings.feature.serialization;
     if (app.notFound) {
       $state.go('home.infrastructure', null, {location: 'replace'});
     }

--- a/app/scripts/modules/core/application/config/applicationConfig.view.html
+++ b/app/scripts/modules/core/application/config/applicationConfig.view.html
@@ -3,5 +3,6 @@
   <application-notifications application="config.application" notifications="config.notifications"></application-notifications>
   <application-links application="config.application"></application-links>
   <application-cache-management application="config.application"></application-cache-management>
+  <serialize-application-section application="config.application" ng-if="config.serialization"></serialize-application-section>
   <delete-application-section application="config.application"></delete-application-section>
 </div>

--- a/app/scripts/modules/core/application/config/serializeApplicationSection.component.html
+++ b/app/scripts/modules/core/application/config/serializeApplicationSection.component.html
@@ -1,0 +1,19 @@
+<div class="row">
+  <div class="col-md-7">
+    <h4>Serialize Application</h4>
+    <div class="panel panel-default">
+      <div class="panel-body">
+        <p>
+          Serializing the application will save the current state of the infrastructure to a storage bucket <br>
+          using <a href="https://www.terraform.io/docs/configuration/index.html">Terraform's config language</a>.
+          Currently only GCE and GCS are supported.
+        </p>
+
+        <button class="btn btn-link" ng-click="$ctrl.serializeApplication()"><span
+          class="glyphicon glyphicon-cloud-download"></span> Serialize Application
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+

--- a/app/scripts/modules/core/application/config/serializeApplicationSection.component.js
+++ b/app/scripts/modules/core/application/config/serializeApplicationSection.component.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const angular = require('angular');
+
+module.exports = angular
+  .module('spinnaker.core.application.config.serialize.component', [
+    require('angular-ui-router'),
+    require('./../../serialize/serialize.write.service.js'),
+    require('../../confirmationModal/confirmationModal.service.js'),
+    require('../../overrideRegistry/override.registry.js'),
+  ])
+  .component('serializeApplicationSection', {
+    templateUrl: require('./serializeApplicationSection.component.html'),
+    bindings: {
+      application: '=',
+    },
+    controller: function ($state, serializeWriter, confirmationModalService) {
+      if (this.application.notFound) {
+        return;
+      }
+
+      this.serializeApplication = () => {
+
+        var submitMethod = () => {
+          return serializeWriter.serializeApplication(this.application.attributes);
+        };
+
+        var taskMonitor = {
+          application: this.application,
+          title: 'Serializing ' + this.application.name,
+          hasKatoTask: true,
+          onTaskComplete: () => {
+            $state.go('home.infrastructure');
+          }
+        };
+
+        confirmationModalService.confirm({
+          header: 'Are you sure you want to serialize: ' + this.application.name + '?',
+          buttonText: 'Serialize',
+          provider: 'gce',
+          taskMonitorConfig: taskMonitor,
+          submitMethod: submitMethod
+        });
+      };
+    }
+  });

--- a/app/scripts/modules/core/serialize/serialize.write.service.js
+++ b/app/scripts/modules/core/serialize/serialize.write.service.js
@@ -1,0 +1,51 @@
+'use strict';
+
+let angular = require('angular');
+
+module.exports = angular
+  .module('spinnaker.serialize.write.service', [
+    require('../task/taskExecutor.js'),
+    require('../utils/lodash.js'),
+    require('../account/account.service.js')
+  ])
+  .factory('serializeWriter', function($q, taskExecutor, accountService, _) {
+
+    let serializationProviders = ['gce'];
+
+    function buildJobs(app, accountDetails) {
+      let jobs = [];
+      accountDetails.forEach((accountDetail) => {
+        if (serializationProviders.includes(accountDetail.cloudProvider)) {
+          jobs.push({
+            type: 'serializeApplication',
+            credentials: accountDetail.name,
+            applicationName: app.name,
+            cloudProvider: accountDetail.cloudProvider,
+          });
+        }
+      });
+      return jobs;
+    }
+
+    function loadAccountDetails(app) {
+      let accounts = _.isString(app.accounts) ? app.accounts.split(',') : [];
+      let accountDetailPromises = accounts.map(account => accountService.getAccountDetails(account));
+      return $q.all(accountDetailPromises);
+    }
+
+    function serializeApplication(app) {
+      return loadAccountDetails(app).then(function(accountDetails) {
+        let jobs = buildJobs(app, accountDetails);
+        return taskExecutor.executeTask({
+          job: jobs,
+          application: app,
+          description: 'Serialize Application: ' + app.name
+        });
+      });
+    }
+
+    return {
+      serializeApplication: serializeApplication,
+    };
+
+  });

--- a/settings.js
+++ b/settings.js
@@ -97,5 +97,6 @@ window.spinnakerSettings = {
     // whether stages affecting infrastructure (like "Create Load Balancer") should be enabled or not
     infrastructureStages: process.env.INFRA_STAGES === 'enabled',
     jobs: false,
+    serialization: false,
   },
 };


### PR DESCRIPTION
![serialize_example](https://cloud.githubusercontent.com/assets/11478311/17069849/e0ae9158-5026-11e6-8c3e-2117fa6f1b38.png)

Added a section to the config tab to serialize the application. Feature flag for serialize must be set to true in settings.js in order to view the section. PTAL @lwander @duftler @danielpeach 