### PR TITLE
(core) avoid duplicate usages on security group view

### DIFF
--- a/app/scripts/modules/core/securityGroup/filter/securityGroup.filter.service.spec.js
+++ b/app/scripts/modules/core/securityGroup/filter/securityGroup.filter.service.spec.js
@@ -36,7 +36,7 @@ describe('Service: securityGroupFilterService', function () {
     };
     resultJson = [
       { heading: 'us-east-1', vpcName: '', securityGroup: app.securityGroups.data[0], },
-      { heading: 'us-west-1', vpcName: 'main', securityGroup: app.securityGroups.data[1], },
+      { heading: 'us-west-1 (main)', vpcName: 'main', securityGroup: app.securityGroups.data[1], },
       { heading: 'us-east-1', vpcName: '', securityGroup: app.securityGroups.data[2], }
     ];
     SecurityGroupFilterModel.clearFilters();

--- a/app/scripts/modules/core/securityGroup/securityGroup.directive.js
+++ b/app/scripts/modules/core/securityGroup/securityGroup.directive.js
@@ -11,7 +11,8 @@ module.exports = angular.module('spinnaker.core.securityGroup.directive', [])
       scope: {
         application: '=',
         securityGroup: '=',
-        sortFilter: '='
+        sortFilter: '=',
+        heading: '=',
       },
       link: function (scope, el) {
         var base = el.parent().inheritedData('$uiView').state;

--- a/app/scripts/modules/core/securityGroup/securityGroup.html
+++ b/app/scripts/modules/core/securityGroup/securityGroup.html
@@ -4,7 +4,7 @@
      ng-class="{active: $state.includes('**.securityGroupDetails', {region: securityGroup.region, accountId: securityGroup.accountName, name: securityGroup.name, vpcId: securityGroup.vpcId, provider: securityGroup.provider})}">
 
   <h6 sticky-header added-offset-height="39">
-    <span class="glyphicon glyphicon-transfer"></span> {{securityGroup.region | uppercase}}
+    <span class="glyphicon glyphicon-transfer"></span> {{heading | uppercase}}
   </h6>
 
   <div class="cluster-container">

--- a/app/scripts/modules/core/securityGroup/securityGroupPod.html
+++ b/app/scripts/modules/core/securityGroup/securityGroupPod.html
@@ -19,6 +19,7 @@
       <security-group
           application="application"
           security-group="subgroup.securityGroup"
+          heading="subgroup.heading"
           sort-filter="sortFilter"></security-group>
     </div>
   </div>


### PR DESCRIPTION
Addressing three problems here:

  1. It's hard to tell what VPC a security group is in without clicking on it and looking at the details
  2. If there are two security groups with the same name in the same region (e.g. VPC and Classic), their display order is not guaranteed and may change with each application refresh
  3. Usage fields are not made unique, since `_.uniq` does not take a comparator as its second argument.