### PR TITLE
(aws) only set vpcId on cross-account ingress rules

### DIFF
--- a/app/scripts/modules/amazon/securityGroup/configure/EditSecurityGroupCtrl.js
+++ b/app/scripts/modules/amazon/securityGroup/configure/EditSecurityGroupCtrl.js
@@ -47,10 +47,11 @@ module.exports = angular.module('spinnaker.securityGroup.aws.edit.controller', [
     securityGroup.securityGroupIngress = _(securityGroup.inboundRules)
       .filter(rule => rule.securityGroup)
       .map(rule => rule.portRanges.map(portRange => {
+          let vpcId = rule.securityGroup.vpcId === securityGroup.vpcId ? null : rule.securityGroup.vpcId;
           return {
             accountName: rule.securityGroup.accountName || rule.securityGroup.accountId,
             accountId: rule.securityGroup.accountId,
-            vpcId: rule.securityGroup.vpcId,
+            vpcId: vpcId,
             id: rule.securityGroup.id,
             name: rule.securityGroup.name,
             type: rule.protocol,


### PR DESCRIPTION
Corresponding change in Clouddriver to address https://github.com/spinnaker/spinnaker/issues/1020 here: https://github.com/spinnaker/clouddriver/pull/817