### PR TITLE
(core) allow multiple tasks to be executed in same browser session

### DIFF
--- a/app/scripts/modules/core/task/task.write.service.js
+++ b/app/scripts/modules/core/task/task.write.service.js
@@ -9,10 +9,8 @@ module.exports = angular
   ])
   .factory('taskWriter', function(API, taskReader, $q, $timeout) {
 
-    var endpoint = API.all('applications');
-
     function getEndpoint(application) {
-      return endpoint.all(application).all('tasks');
+      return API.all('applications').all(application).all('tasks');
     }
 
     function postTaskCommand(taskCommand) {


### PR DESCRIPTION
Since the `taskWriter` is a singleton, calls to `getEndpoint` currently stack on top of one another, so Deck tries posting tasks to:
* `applications/app/tasks`, then
* `applications/app/tasks/app/tasks`, then
* `applications/app/tasks/app/tasks/app/tasks`, etc.

cc @zanthrash 