### PR TITLE
(core) fixes execution filter refresh

### DIFF
--- a/app/scripts/modules/core/delivery/service/execution.service.js
+++ b/app/scripts/modules/core/delivery/service/execution.service.js
@@ -4,12 +4,13 @@ let angular = require('angular');
 module.exports = angular.module('spinnaker.core.delivery.executions.service', [
   require('../../cache/deckCacheFactory.js'),
   require('../../utils/appendTransform.js'),
+  require('../../utils/lodash.js'),
   require('../../config/settings.js'),
   require('../filter/executionFilter.model.js'),
   require('./executions.transformer.service.js')
 ])
   .factory('executionService', function($http, $timeout, $q, $log, ExecutionFilterModel, $state,
-                                         settings, appendTransform, executionsTransformer) {
+                                        _, settings, appendTransform, executionsTransformer) {
 
     const activeStatuses = ['RUNNING', 'SUSPENDED', 'PAUSED', 'NOT_STARTED'];
     const runningLimit = 30;
@@ -18,7 +19,7 @@ module.exports = angular.module('spinnaker.core.delivery.executions.service', [
       return getFilteredExecutions(applicationName, {statuses: activeStatuses, limit: runningLimit});
     }
 
-    function getFilteredExecutions(applicationName, {statuses = Object.keys(ExecutionFilterModel.sortFilter.status || {}), limit = ExecutionFilterModel.sortFilter.count} = {}) {
+    function getFilteredExecutions(applicationName, {statuses = Object.keys(_.filter(ExecutionFilterModel.sortFilter.status) || {}), limit = ExecutionFilterModel.sortFilter.count} = {}) {
       let url = [ settings.gateUrl, 'applications', applicationName, `pipelines?limit=${limit}`].join('/');
       if (statuses.length) {
         url += '&statuses=' + statuses.map((status) => status.toUpperCase()).join(',');


### PR DESCRIPTION
(core) fixes execution filter refresh
Currently, the query string will include RUNNING even if sortFilter.status = { RUNNING: false }.

@anotherchrisberry please review

