### PR TITLE
(gce) fix host and path rules modal

### DIFF
--- a/app/scripts/modules/google/loadBalancer/details/hostAndPathRules/hostAndPathRules.service.js
+++ b/app/scripts/modules/google/loadBalancer/details/hostAndPathRules/hostAndPathRules.service.js
@@ -6,17 +6,20 @@ module.exports = angular.module('spinnaker.deck.gce.loadBalancer.hostAndPathRule
   .factory('hostAndPathRulesService', function() {
 
     function buildTable(hostRules, defaultService) {
-      let defaultRow = buildRow('Any unmatched (default)', 'Any unmatched (default)', defaultService);
+      let defaultRow = buildRow('Any unmatched (default)', 'Any unmatched (default)', defaultService.name);
+      if (hostRules.length === 0) {
+        return [ defaultRow ];
+      }
 
       return hostRules.reduce((rows, hostRule) => {
         let [ hostPattern ] = hostRule.hostPatterns;
         let { defaultService, pathRules } = hostRule.pathMatcher;
 
-        rows.push(buildRow(hostPattern, '/*', defaultService));
+        rows.push(buildRow(hostPattern, '/*', defaultService.name));
 
         return rows.concat(pathRules.reduce((rows, pathRule) => {
           let { backendService, paths } = pathRule;
-          return rows.concat(paths.map(path => buildRow(hostPattern, path, backendService)));
+          return rows.concat(paths.map(path => buildRow(hostPattern, path, backendService.name)));
         }, []));
       }, [ defaultRow ]);
     }

--- a/app/scripts/modules/google/loadBalancer/details/loadBalancerDetail.controller.js
+++ b/app/scripts/modules/google/loadBalancer/details/loadBalancerDetail.controller.js
@@ -29,11 +29,11 @@ module.exports = angular.module('spinnaker.loadBalancer.gce.details.controller',
     function extractLoadBalancer() {
       $scope.loadBalancer = application.loadBalancers.data.filter(function (test) {
         var testVpc = test.vpcId || null;
-        return test.name === loadBalancer.name && test.region === loadBalancer.region && test.account === loadBalancer.accountId && testVpc === loadBalancer.vpcId;
+        return test.name === loadBalancer.name && (test.region === loadBalancer.region || test.region === 'global') && test.account === loadBalancer.accountId && testVpc === loadBalancer.vpcId;
       })[0];
 
       if ($scope.loadBalancer) {
-        var detailsLoader = loadBalancerReader.getLoadBalancerDetails($scope.loadBalancer.provider, loadBalancer.accountId, loadBalancer.region, loadBalancer.name);
+        var detailsLoader = loadBalancerReader.getLoadBalancerDetails($scope.loadBalancer.provider, loadBalancer.accountId, $scope.loadBalancer.region, $scope.loadBalancer.name);
         return detailsLoader.then(function(details) {
           $scope.state.loading = false;
           var filtered = details.filter(function(test) {
@@ -44,7 +44,7 @@ module.exports = angular.module('spinnaker.loadBalancer.gce.details.controller',
             $scope.loadBalancer.account = loadBalancer.accountId;
 
             accountService.getCredentialsKeyedByAccount('gce').then(function(credentialsKeyedByAccount) {
-              if (loadBalancer.region === 'global') {
+              if ($scope.loadBalancer.region === 'global') {
                 $scope.loadBalancer.elb.availabilityZones = [ 'All zones' ];
               } else {
                 $scope.loadBalancer.elb.availabilityZones = _.find(credentialsKeyedByAccount[loadBalancer.accountId].regions, { name: loadBalancer.region }).zones.sort();
@@ -110,7 +110,7 @@ module.exports = angular.module('spinnaker.loadBalancer.gce.details.controller',
         loadBalancer.providerType = $scope.loadBalancer.provider;
         return loadBalancerWriter.deleteLoadBalancer(loadBalancer, application, {
           loadBalancerName: loadBalancer.name,
-          region: loadBalancer.region,
+          region: $scope.loadBalancer.region,
         });
       };
 


### PR DESCRIPTION
Fixes host and path rules modal.
Allows L7 load balancer details panel to open from the clusters tab. (The approach here isn't great, but the core pieces assume that serverGroup.region === loadBalancer.region. I'll wait until the rest of the L7 pieces are in place before coming up with a better approach.)

@duftler @jtk54 please review.