### PR TITLE
(core) cluster filters filter zones and regions by account

### DIFF
--- a/app/scripts/modules/core/cluster/filter/clusterFilter.controller.spec.js
+++ b/app/scripts/modules/core/cluster/filter/clusterFilter.controller.spec.js
@@ -23,39 +23,102 @@ describe('ClusterFilter Controller', function () {
   );
 
   describe('getAvailabilityZoneHeadings', function () {
+    describe('where all regions are available', function () {
+      beforeEach(function() {
+        spyOn(controller, 'getRegionHeadings').and.returnValue(['us-west-1', 'us-east-2']);
+      });
 
-    it('has no regions selected should return all AZs', function () {
-      let zones = ['us-west-1a', 'us-west-1c'];
-      controller.availabilityZoneHeadings = zones;
+      it('has no regions selected should return all AZs', function () {
+        let zones = ['us-west-1a', 'us-west-1c'];
+        controller.availabilityZoneHeadings = zones;
 
-      let results = controller.getAvailabilityZoneHeadings();
-      expect(results).toEqual(zones);
+        let results = controller.getAvailabilityZoneHeadings();
+        expect(results).toEqual(zones);
+      });
+
+      it('should return us-west-1a zone when us-west-1 region is selected', function() {
+        controller.availabilityZoneHeadings = ['us-west-1a', 'us-east-2c'];
+        scope.sortFilter.region = { 'us-west-1': true };
+
+        let results = controller.getAvailabilityZoneHeadings();
+        expect(results).toEqual(['us-west-1a']);
+      });
+
+      it('should return empty list when region is selected that has no AZs', function() {
+        controller.availabilityZoneHeadings = ['us-west-2a', 'us-east-2c'];
+        scope.sortFilter.region = { 'us-west-1': true };
+
+        let results = controller.getAvailabilityZoneHeadings();
+        expect(results).toEqual([]);
+      });
+
+      it('should return all AZ when all regions are selected', function() {
+        let zones = ['us-west-1a', 'us-east-2c'];
+        controller.availabilityZoneHeadings = zones;
+        scope.sortFilter.region = { 'us-west-1': true, 'us-east-2': true};
+
+        let results = controller.getAvailabilityZoneHeadings();
+        expect(results).toEqual(zones);
+      });
     });
 
-    it('should return us-west-1a zone when us-west-1 region is selected', function() {
-      controller.availabilityZoneHeadings = ['us-west-1a', 'us-east-2c'];
-      scope.sortFilter.region = { 'us-west-1': true };
+    describe('where regions have been filtered', function () {
+      it('no regions available, no regions selected, should return no AZs', function () {
+        spyOn(controller, 'getRegionHeadings').and.returnValue([]);
+        let zones = ['us-west-1a', 'us-west-1c'];
+        controller.availabilityZoneHeadings = zones;
 
-      let results = controller.getAvailabilityZoneHeadings();
-      expect(results).toEqual(['us-west-1a']);
+        let results = controller.getAvailabilityZoneHeadings();
+        expect(results).toEqual([]);
+      });
+
+      it('us-west-1 region available, no regions selected, should return us-west-1a AZ', function () {
+        spyOn(controller, 'getRegionHeadings').and.returnValue(['us-west-1']);
+        let zones = ['us-west-1a', 'us-east-2c'];
+        controller.availabilityZoneHeadings = zones;
+
+        let results = controller.getAvailabilityZoneHeadings();
+        expect(results).toEqual(['us-west-1a']);
+      });
+    });
+  });
+
+  describe('getRegionHeadings', function () {
+    beforeEach(function () {
+      controller.regionsKeyedByAccount = {
+        'my-aws-account': ['us-west-2', 'us-west-1', 'eu-east-2'],
+        'my-google-account': ['us-central1', 'asia-east1', 'europe-west1']
+      };
     });
 
-    it('should return empty list when region is selected that has no AZs', function() {
-      controller.availabilityZoneHeadings = ['us-west-2a', 'us-east-2c'];
-      scope.sortFilter.region = { 'us-west-1': true };
+    it('should return all regions if no accounts selected', function () {
+      scope.sortFilter.account = {};
+      let regions = ['us-west-2', 'us-west-1', 'eu-east-2', 'us-central1', 'asia-east1', 'europe-west1'];
+      controller.regionHeadings = regions;
 
-      let results = controller.getAvailabilityZoneHeadings();
-      expect(results).toEqual([]);
+      let results = controller.getRegionHeadings();
+
+      expect(results.length).toEqual(6);
     });
 
-    it('should return all AZ when all regions are selected', function() {
-      let zones = ['us-west-1a', 'us-east-2c'];
-      controller.availabilityZoneHeadings = zones;
-      scope.sortFilter.region = { 'us-west-1': true, 'us-east-2c': true};
+    it('should return regions for account if account is selected', function () {
+      scope.sortFilter.account = { 'my-google-account' : true };
+      let regions = ['us-west-2', 'us-west-1', 'eu-east-2', 'us-central1', 'asia-east1', 'europe-west1'];
+      controller.regionHeadings = regions;
 
-      let results = controller.getAvailabilityZoneHeadings();
-      expect(results).toEqual(zones);
+      let results = controller.getRegionHeadings();
+
+      expect(results).toEqual(['us-central1', 'asia-east1', 'europe-west1']);
     });
 
+    it('should return all regions if all accounts are selected', function () {
+      scope.sortFilter.account = { 'my-google-account' : true, 'my-aws-account' : true };
+      let regions = ['us-west-2', 'us-west-1', 'eu-east-2', 'us-central1', 'asia-east1', 'europe-west1'];
+      controller.regionHeadings = regions;
+
+      let results = controller.getRegionHeadings();
+
+      expect(results.length).toEqual(6);
+    });
   });
 });

--- a/app/scripts/modules/core/cluster/filter/clusterFilter.model.spec.js
+++ b/app/scripts/modules/core/cluster/filter/clusterFilter.model.spec.js
@@ -25,11 +25,20 @@ describe('Cluster Filter Model', function () {
       $state.params = {};
     });
 
+    let regionsKeyedByAccount;
+    beforeEach(function() {
+      regionsKeyedByAccount = {
+        'my-aws-account': ['us-west-2', 'us-west-1', 'eu-east-2'],
+        'my-google-account': ['us-central1', 'asia-east1', 'europe-west1']
+      };
+    });
+
     describe('removing checked AZs if region is not selected', () => {
       it('should remove the us-west-1a AZ if the eu-west-1 region is selected and us-west-1 region is not', function () {
         ClusterFilterModel.sortFilter.availabilityZone = {'us-west-1a': true};
         ClusterFilterModel.sortFilter.region = {'eu-west-1': true};
-        ClusterFilterModel.removeCheckedAvailabilityZoneIfRegionIsNotChecked();
+
+        ClusterFilterModel.reconcileDependentFilters(regionsKeyedByAccount);
 
         expect(ClusterFilterModel.getSelectedAvailabilityZones()).toEqual([]);
       });
@@ -37,7 +46,8 @@ describe('Cluster Filter Model', function () {
       it('should keep the us-west-1a AZ if no region is selected', function () {
         ClusterFilterModel.sortFilter.availabilityZone = {'us-west-1a': true};
         ClusterFilterModel.sortFilter.region = {};
-        ClusterFilterModel.removeCheckedAvailabilityZoneIfRegionIsNotChecked();
+
+        ClusterFilterModel.reconcileDependentFilters(regionsKeyedByAccount);
 
         expect(ClusterFilterModel.getSelectedAvailabilityZones()).toEqual(['us-west-1a']);
       });
@@ -45,7 +55,8 @@ describe('Cluster Filter Model', function () {
       it('should keep the us-west-1a AZ if us-west-1 and some other region are selected', function () {
         ClusterFilterModel.sortFilter.availabilityZone = {'us-west-1a': true};
         ClusterFilterModel.sortFilter.region = {'us-west-1' : true, 'eu-east-2' : true};
-        ClusterFilterModel.removeCheckedAvailabilityZoneIfRegionIsNotChecked();
+
+        ClusterFilterModel.reconcileDependentFilters(regionsKeyedByAccount);
 
         expect(ClusterFilterModel.getSelectedAvailabilityZones()).toEqual(['us-west-1a']);
       });
@@ -54,15 +65,103 @@ describe('Cluster Filter Model', function () {
         ClusterFilterModel.sortFilter.availabilityZone = {'us-west-1a': true};
         ClusterFilterModel.sortFilter.region = {'us-west-1' : true, 'eu-east-2' : true};
 
-        ClusterFilterModel.removeCheckedAvailabilityZoneIfRegionIsNotChecked();
-        expect(ClusterFilterModel.getSelectedAvailabilityZones()).toEqual(['us-west-1a']);
+        ClusterFilterModel.reconcileDependentFilters(regionsKeyedByAccount);
 
         ClusterFilterModel.sortFilter.region = {'us-west-1' : false, 'eu-east-2' : true};
 
-        ClusterFilterModel.removeCheckedAvailabilityZoneIfRegionIsNotChecked();
+        ClusterFilterModel.reconcileDependentFilters(regionsKeyedByAccount);
+
         expect(ClusterFilterModel.getSelectedAvailabilityZones()).toEqual([]);
       });
     });
 
+    describe('removing checked regions if corresponding accounts are not selected', function () {
+      it('should remove us-central1 region if only my-aws-account is selected', function () {
+        ClusterFilterModel.sortFilter.account = { 'my-aws-account' : true };
+        ClusterFilterModel.sortFilter.region = { 'us-central1' : true };
+
+        ClusterFilterModel.reconcileDependentFilters(regionsKeyedByAccount);
+
+        expect(ClusterFilterModel.getSelectedRegions()).toEqual([]);
+      });
+
+      it('should keep us-central1 region if my-google-account is selected', function () {
+        ClusterFilterModel.sortFilter.account = { 'my-google-account' : true };
+        ClusterFilterModel.sortFilter.region = { 'us-central1' : true };
+
+        ClusterFilterModel.reconcileDependentFilters(regionsKeyedByAccount);
+
+        expect(ClusterFilterModel.getSelectedRegions()).toEqual(['us-central1']);
+      });
+
+      it('should keep asia-east1 region if my-google-account and some other account are selected', function () {
+        ClusterFilterModel.sortFilter.account = { 'my-google-account' : true, 'my-aws-account' : true };
+        ClusterFilterModel.sortFilter.region = { 'asia-east1' : true };
+
+        ClusterFilterModel.reconcileDependentFilters(regionsKeyedByAccount);
+
+        expect(ClusterFilterModel.getSelectedRegions()).toEqual(['asia-east1']);
+      });
+
+      it('should remove us-central1 and asia-east1 regions if my-google-account and some other account are selected and then my-google-account is unselected', function () {
+        ClusterFilterModel.sortFilter.account = { 'my-google-account' : true, 'my-aws-account' : true };
+        ClusterFilterModel.sortFilter.region = { 'us-central1' : true, 'asia-east1' : true };
+
+        ClusterFilterModel.reconcileDependentFilters(regionsKeyedByAccount);
+
+        expect(ClusterFilterModel.getSelectedRegions()).toEqual(['us-central1', 'asia-east1']);
+
+        ClusterFilterModel.sortFilter.account = { 'my-google-account' : false, 'my-aws-account' : true };
+
+        ClusterFilterModel.reconcileDependentFilters(regionsKeyedByAccount);
+
+        expect(ClusterFilterModel.getSelectedRegions()).toEqual([]);
+      });
+
+    });
+
+    describe('removing checked AZs if corresponding accounts are not selected', function () {
+      it('should remove us-central1-f AZ if only my-aws-account is selected', function () {
+        ClusterFilterModel.sortFilter.account = { 'my-aws-account' : true };
+        ClusterFilterModel.sortFilter.availabilityZone = { 'us-central1-f': true };
+
+        ClusterFilterModel.reconcileDependentFilters(regionsKeyedByAccount);
+
+        expect(ClusterFilterModel.getSelectedAvailabilityZones()).toEqual([]);
+      });
+
+      it('should keep us-central1-f AZ if my-google-account is selected', function () {
+        ClusterFilterModel.sortFilter.account = { 'my-google-account' : true };
+        ClusterFilterModel.sortFilter.availabilityZone = { 'us-central1-f': true };
+
+        ClusterFilterModel.reconcileDependentFilters(regionsKeyedByAccount);
+
+        expect(ClusterFilterModel.getSelectedAvailabilityZones()).toEqual(['us-central1-f']);
+      });
+
+      it('should keep asia-east1-b AZ if my-google-account and some other account are selected', function () {
+        ClusterFilterModel.sortFilter.account = { 'my-google-account' : true, 'my-aws-account' : true };
+        ClusterFilterModel.sortFilter.availabilityZone = { 'asia-east1-b': true };
+
+        ClusterFilterModel.reconcileDependentFilters(regionsKeyedByAccount);
+
+        expect(ClusterFilterModel.getSelectedAvailabilityZones()).toEqual(['asia-east1-b']);
+      });
+
+      it('should remove us-central1-f AZ if my-google-account and some other account are selected and then my-google-account is unselected', function () {
+        ClusterFilterModel.sortFilter.account = { 'my-google-account' : true, 'my-aws-account' : true };
+        ClusterFilterModel.sortFilter.availabilityZone = { 'us-central1-f': true };
+
+        ClusterFilterModel.reconcileDependentFilters(regionsKeyedByAccount);
+
+        expect(ClusterFilterModel.getSelectedAvailabilityZones()).toEqual(['us-central1-f']);
+
+        ClusterFilterModel.sortFilter.account = { 'my-google-account' : false, 'my-aws-account' : true };
+
+        ClusterFilterModel.reconcileDependentFilters(regionsKeyedByAccount);
+
+        expect(ClusterFilterModel.getSelectedAvailabilityZones()).toEqual([]);
+      });
+    });
   });
 });

--- a/app/scripts/modules/core/cluster/filter/filterNav.html
+++ b/app/scripts/modules/core/cluster/filter/filterNav.html
@@ -26,7 +26,7 @@
   </filter-section>
 
   <filter-section heading="Region" expanded="true">
-    <div class="checkbox" ng-repeat="heading in clustersFilters.regionHeadings | orderBy: 'toString()' ">
+    <div class="checkbox" ng-repeat="heading in clustersFilters.getRegionHeadings() | orderBy: 'toString()' ">
       <label>
         <input type="checkbox" ng-model="sortFilter.region[heading]" ng-change="clustersFilters.updateClusterGroups()"/>{{heading}}
       </label>

--- a/app/scripts/modules/google/serverGroup/configure/wizard/loadBalancers/loadBalancerSelector.directive.js
+++ b/app/scripts/modules/google/serverGroup/configure/wizard/loadBalancers/loadBalancerSelector.directive.js
@@ -36,7 +36,7 @@ module.exports = angular
         let index = this.command.backingData.filtered.loadBalancerIndex;
         let selected = this.command.loadBalancers;
 
-        return selected.some(s => index[s].loadBalancerType === 'HTTP');
+        return angular.isDefined(selected) && _.some(selected, s => index[s].loadBalancerType === 'HTTP');
       }
     };
   });


### PR DESCRIPTION
(core) cluster filters filter zones and regions by account
(e.g., if you click on an account checkbox, it will filter the region and zone checkboxes).

@anotherchrisberry please review, @duftler fyi

I'll make the load balancer filters consistent with this behavior.