### PR TITLE
(core) clarify that deployment strategies affect all server groups

### DIFF
--- a/app/scripts/modules/core/deploymentStrategy/strategies/highlander/highlander.strategy.module.js
+++ b/app/scripts/modules/core/deploymentStrategy/strategies/highlander/highlander.strategy.module.js
@@ -6,7 +6,7 @@ module.exports = angular.module('spinnaker.core.deploymentStrategy.highlander', 
   .config(function(deploymentStrategyConfigProvider) {
     deploymentStrategyConfigProvider.registerStrategy({
       label: 'Highlander',
-      description: 'Destroys previous server group as soon as new server group passes health checks',
+      description: 'Destroys <i>all</i> previous server groups in the cluster as soon as new server group passes health checks',
       key: 'highlander',
     });
   });

--- a/app/scripts/modules/core/deploymentStrategy/strategies/redblack/redblack.strategy.module.js
+++ b/app/scripts/modules/core/deploymentStrategy/strategies/redblack/redblack.strategy.module.js
@@ -6,7 +6,7 @@ module.exports = angular.module('spinnaker.core.deploymentStrategy.redblack', []
   .config(function(deploymentStrategyConfigProvider) {
     deploymentStrategyConfigProvider.registerStrategy({
       label: 'Red/Black',
-      description: 'Disables previous server group as soon as new server group passes health checks',
+      description: 'Disables <i>all</i> previous server groups in the cluster as soon as new server group passes health checks',
       key: 'redblack',
       providers: ['aws', 'gce', 'cf', 'kubernetes', 'titus'],
       additionalFields: ['scaleDown', 'maxRemainingAsgs'],


### PR DESCRIPTION
A user pointed out that the current text is misleading, since highlander and red/black affect all previous server groups, not just the base server group.