### PR TITLE
do not load load balancer details until all app load balancers are ready

### DIFF
--- a/app/scripts/modules/amazon/loadBalancer/details/loadBalancerDetail.controller.js
+++ b/app/scripts/modules/amazon/loadBalancer/details/loadBalancerDetail.controller.js
@@ -81,7 +81,7 @@ module.exports = angular.module('spinnaker.loadBalancer.aws.details.controller',
       $state.go('^', null, {location: 'replace'});
     }
 
-    extractLoadBalancer().then(() => {
+    app.loadBalancers.ready().then(extractLoadBalancer).then(() => {
       // If the user navigates away from the view before the initial extractLoadBalancer call completes,
       // do not bother subscribing to the refresh
       if (!$scope.$$destroyed) {

--- a/app/scripts/modules/azure/loadBalancer/details/loadBalancerDetail.controller.js
+++ b/app/scripts/modules/azure/loadBalancer/details/loadBalancerDetail.controller.js
@@ -63,7 +63,7 @@ module.exports = angular.module('spinnaker.azure.loadBalancer.details.controller
       return $q.when(null);
     }
 
-    extractLoadBalancer().then(() => {
+    app.loadBalancers.ready().then(extractLoadBalancer).then(() => {
       // If the user navigates away from the view before the initial extractLoadBalancer call completes,
       // do not bother subscribing to the refresh
       if (!$scope.$$destroyed) {

--- a/app/scripts/modules/cloudfoundry/loadBalancer/details/LoadBalancerDetailsCtrl.js
+++ b/app/scripts/modules/cloudfoundry/loadBalancer/details/LoadBalancerDetailsCtrl.js
@@ -66,7 +66,7 @@ module.exports = angular.module('spinnaker.loadBalancer.cf.details.controller', 
       $state.go('^', null, {location: 'replace'});
     }
 
-    extractLoadBalancer().then(() => {
+    app.loadBalancers.ready().then(extractLoadBalancer).then(() => {
       // If the user navigates away from the view before the initial extractLoadBalancer call completes,
       // do not bother subscribing to the refresh
       if (!$scope.$$destroyed) {

--- a/app/scripts/modules/google/loadBalancer/details/loadBalancerDetail.controller.js
+++ b/app/scripts/modules/google/loadBalancer/details/loadBalancerDetail.controller.js
@@ -73,7 +73,7 @@ module.exports = angular.module('spinnaker.loadBalancer.gce.details.controller',
       $state.go('^', null, {location: 'replace'});
     }
 
-    extractLoadBalancer().then(() => {
+    app.loadBalancers.ready().then(extractLoadBalancer).then(() => {
       // If the user navigates away from the view before the initial extractLoadBalancer call completes,
       // do not bother subscribing to the refresh
       if (!$scope.$$destroyed) {


### PR DESCRIPTION
Deep linking doesn't work so great without this, since we extract the load balancer from the application data, then layer in the details.