### PR TITLE
(netflix) add titus security group reader

### DIFF
--- a/app/scripts/modules/titus/securityGroup/securityGroup.read.service.js
+++ b/app/scripts/modules/titus/securityGroup/securityGroup.read.service.js
@@ -1,0 +1,17 @@
+'use strict';
+
+let angular = require('angular');
+
+module.exports = angular.module('spinnaker.titus.securityGroup.reader', [
+])
+  .factory('titusSecurityGroupReader', function () {
+
+    function resolveIndexedSecurityGroup(indexedSecurityGroups, container, securityGroupId) {
+      let account = container.account.replace('titus', '').replace('vpc', '');
+      return indexedSecurityGroups[account][container.region][securityGroupId];
+    }
+
+    return {
+      resolveIndexedSecurityGroup: resolveIndexedSecurityGroup,
+    };
+  });

--- a/app/scripts/modules/titus/titus.module.js
+++ b/app/scripts/modules/titus/titus.module.js
@@ -12,6 +12,7 @@ templates.keys().forEach(function(key) {
 
 module.exports = angular.module('spinnaker.titus', [
   require('../core/cloudProvider/cloudProvider.registry.js'),
+  require('./securityGroup/securityGroup.read.service'),
   require('./serverGroup/details/serverGroupDetails.titus.controller.js'),
   require('./serverGroup/configure/ServerGroupCommandBuilder.js'),
   require('./serverGroup/configure/wizard/CloneServerGroup.titus.controller.js'),
@@ -36,10 +37,12 @@ module.exports = angular.module('spinnaker.titus', [
         commandBuilder: 'titusServerGroupCommandBuilder',
         configurationService: 'titusServerGroupConfigurationService',
       },
+      securityGroup: {
+        reader: 'titusSecurityGroupReader',
+      },
       instance: {
         detailsTemplateUrl: require('./instance/details/instanceDetails.html'),
         detailsController: 'titusInstanceDetailsCtrl'
       }
     });
   });
-


### PR DESCRIPTION
Titus gets its security groups from AWS - it does not have its own concept of security groups.

Note that we do not surface security groups in the server groups view, so I'm not totally sure why we're returning them at all in the server group details (@tomaslin would know). But this change will, at least, prevent the flapping that occurs right now when clicking on anything in the security groups tab.