### PR TITLE
SPIN-1921: Fix upsert of projects.

### DIFF
--- a/app/scripts/modules/core/api/api.service.spec.js
+++ b/app/scripts/modules/core/api/api.service.spec.js
@@ -3,18 +3,20 @@
 describe('API Service', function () {
   let API;
   let $httpBackend;
-  const baseUrl = 'https://spinnaker-api-prestaging.mgmttest.netflix.net';
+  let baseUrl;
 
   beforeEach(
     window.module(
-      require('./api.service')
+      require('./api.service'),
+      require('../config/settings')
     )
   );
 
   beforeEach(
-    window.inject(function (_API_, _$httpBackend_) {
+    window.inject(function (_API_, _$httpBackend_, settings) {
       API = _API_;
       $httpBackend = _$httpBackend_;
+      baseUrl = settings.gateUrl;
     })
   );
 

--- a/app/scripts/modules/core/projects/service/project.write.service.js
+++ b/app/scripts/modules/core/projects/service/project.write.service.js
@@ -18,6 +18,7 @@ module.exports = angular
             project: project
           }
         ],
+        project: project,
         description: descriptor + ' project: ' + project.name
       });
     }
@@ -32,6 +33,7 @@ module.exports = angular
             },
           }
         ],
+        project: project,
         description: 'Delete project: ' + project.name
       });
     }

--- a/app/scripts/modules/core/task/task.write.service.js
+++ b/app/scripts/modules/core/task/task.write.service.js
@@ -14,7 +14,7 @@ module.exports = angular
     }
 
     function postTaskCommand(taskCommand) {
-      return getEndpoint(taskCommand.application).post(taskCommand);
+      return getEndpoint(taskCommand.application || taskCommand.project).post(taskCommand);
     }
 
     function cancelTask(application, taskId) {


### PR DESCRIPTION
Upserting a project doesn't correctly pull the project name out of the taskCommand when creating the URL for the POST method.  This cases a 405 Method Not Allowed error.

Adding the project to the taskCommand payload to the taskExecutor.  Also checking for project name when constructing the url for the POST call.

@anotherchrisberry PTAL