### PR TITLE
(netflix) clear migration task after dry run

### DIFF
--- a/app/scripts/modules/netflix/migrator/pipeline/pipeline.migrator.directive.js
+++ b/app/scripts/modules/netflix/migrator/pipeline/pipeline.migrator.directive.js
@@ -258,6 +258,7 @@ module.exports = angular
 
     this.submit = () => {
       this.state = 'migrate';
+      this.task = null;
       migratorService.executeMigration(application, buildCommand(false)).then(migrationStarted, errorMode);
     };
   });

--- a/app/scripts/modules/netflix/migrator/serverGroup/serverGroup.migrator.directive.js
+++ b/app/scripts/modules/netflix/migrator/serverGroup/serverGroup.migrator.directive.js
@@ -179,6 +179,7 @@ module.exports = angular
 
     // Button handlers
     this.submit = () => {
+      this.task = null;
       this.state = 'migrate';
       let config = buildMigrationConfig();
       config.dryRun = false;


### PR DESCRIPTION
removes the brief flash of the dry run results when starting the migration