### PR TITLE
(aws) filter instance types by VPC

### DIFF
--- a/app/scripts/modules/amazon/instance/awsInstanceType.service.js
+++ b/app/scripts/modules/amazon/instance/awsInstanceType.service.js
@@ -234,12 +234,16 @@ module.exports = angular.module('spinnaker.aws.instanceType.service', [
 
     let families = {
       paravirtual: ['c1', 'c3', 'hi1', 'hs1', 'm1', 'm2', 'm3', 't1'],
-      hvm: ['c3', 'c4', 'd2', 'i2', 'g2', 'r3', 'm3', 'm4', 't2']
+      hvm: ['c3', 'c4', 'd2', 'i2', 'g2', 'm3', 'm4', 'r3', 't2', 'x1'],
+      vpcOnly: ['c4', 'm4', 't2', 'x1'],
     };
 
-    function filterInstanceTypesByVirtualizationType(instanceTypes, virtualizationType) {
+    function filterInstanceTypes(instanceTypes, virtualizationType, vpcOnly) {
       return instanceTypes.filter((instanceType) => {
         let [family] = instanceType.split('.');
+        if (!vpcOnly && families.vpcOnly.indexOf(family) > -1) {
+          return false;
+        }
         return families[virtualizationType].indexOf(family) > -1;
       });
     }
@@ -248,7 +252,7 @@ module.exports = angular.module('spinnaker.aws.instanceType.service', [
       getCategories: getCategories,
       getAvailableTypesForRegions: getAvailableTypesForRegions,
       getAllTypesByRegion: getAllTypesByRegion,
-      filterInstanceTypesByVirtualizationType: filterInstanceTypesByVirtualizationType,
+      filterInstanceTypes: filterInstanceTypes,
     };
   }
 );

--- a/app/scripts/modules/amazon/instance/awsInstanceType.service.spec.js
+++ b/app/scripts/modules/amazon/instance/awsInstanceType.service.spec.js
@@ -113,6 +113,15 @@ describe('Service: InstanceType', function () {
       expect(results).toEqual(['m2.xlarge']);
     });
 
+    it('filters instance types by VPC and virtualization type', function () {
+      let types = ['c4.a', 'c3.a', 'c4.a', 'c1.a'];
+      let service = this.awsInstanceTypeService;
+      expect(service.filterInstanceTypes(types, 'hvm', true)).toEqual(['c4.a', 'c3.a', 'c4.a']);
+      expect(service.filterInstanceTypes(types, 'hvm', false)).toEqual(['c3.a']);
+      expect(service.filterInstanceTypes(types, 'paravirtual', true)).toEqual(['c3.a', 'c1.a']);
+      expect(service.filterInstanceTypes(types, 'paravirtual', false)).toEqual(['c3.a', 'c1.a']);
+    });
+
   });
 
 });

--- a/app/scripts/modules/amazon/serverGroup/configure/serverGroupConfiguration.service.js
+++ b/app/scripts/modules/amazon/serverGroup/configure/serverGroupConfiguration.service.js
@@ -180,7 +180,7 @@ module.exports = angular.module('spinnaker.aws.serverGroup.configure.service', [
       if (command.region && (command.virtualizationType || command.viewState.disableImageSelection)) {
         var filtered = awsInstanceTypeService.getAvailableTypesForRegions(command.backingData.instanceTypes, [command.region]);
         if (command.virtualizationType) {
-          filtered = awsInstanceTypeService.filterInstanceTypesByVirtualizationType(filtered, command.virtualizationType);
+          filtered = awsInstanceTypeService.filterInstanceTypes(filtered, command.virtualizationType, !!command.vpcId);
         }
         if (command.instanceType && filtered.indexOf(command.instanceType) === -1) {
           result.dirty.instanceType = command.instanceType;
@@ -397,6 +397,7 @@ module.exports = angular.module('spinnaker.aws.serverGroup.configure.service', [
           .find({purpose: command.subnetType, account: command.credentials, region: command.region});
         command.vpcId = subnet ? subnet.vpcId : null;
       }
+      angular.extend(result.dirty, configureInstanceTypes(command).dirty);
       return result;
     }
 

--- a/app/scripts/modules/amazon/serverGroup/configure/wizard/CloneServerGroup.aws.controller.spec.js
+++ b/app/scripts/modules/amazon/serverGroup/configure/wizard/CloneServerGroup.aws.controller.spec.js
@@ -67,6 +67,7 @@ describe('Controller: awsCloneServerGroup', function () {
           mode: 'clone',
           imageId: 'ami-123',
           usePreferredZones: true,
+          dirty: {},
         }
       };
     };
@@ -82,6 +83,7 @@ describe('Controller: awsCloneServerGroup', function () {
         viewState: {
           mode: 'create',
           usePreferredZones: true,
+          dirty: {},
         }
       };
     };


### PR DESCRIPTION
Newer instance types are only available in VPC, so we should prevent users from attempting to launch VPC-only instances in EC2 Classic.