### PR TITLE
Add ability to refresh select fields for openstack cached entities

### DIFF
--- a/app/scripts/modules/openstack/cache/cacheConfigurer.service.js
+++ b/app/scripts/modules/openstack/cache/cacheConfigurer.service.js
@@ -7,8 +7,10 @@ module.exports = angular.module('spinnaker.openstack.cache.initializer', [
   require('../../core/loadBalancer/loadBalancer.read.service.js'),
   require('../../core/instance/instanceTypeService.js'),
   require('../../core/securityGroup/securityGroup.read.service.js'),
+  require('../../core/network/network.read.service.js'),
+  require('../../core/subnet/subnet.read.service.js'),
 ])
-  .factory('openstackCacheConfigurer', function (accountService, instanceTypeService, loadBalancerReader) {
+  .factory('openstackCacheConfigurer', function (accountService, instanceTypeService, loadBalancerReader, networkReader, subnetReader) {
 
     let config = Object.create(null);
 
@@ -22,6 +24,14 @@ module.exports = angular.module('spinnaker.openstack.cache.initializer', [
 
     config.loadBalancers = {
       initializers: [ () => loadBalancerReader.listLoadBalancers('openstack') ],
+    };
+
+    config.networks = {
+      initializers: [ () => networkReader.listNetworksByProvider('openstack') ],
+    };
+
+    config.subnets = {
+      initializers: [ () => subnetReader.listSubnetsByProvider('openstack') ],
     };
 
     return config;

--- a/app/scripts/modules/openstack/common/cacheBackedSelectField.template.html
+++ b/app/scripts/modules/openstack/common/cacheBackedSelectField.template.html
@@ -1,0 +1,7 @@
+<select-field value="model" options="options"
+              label="{{label}}" label-column-size="{{labelColumnSize}}"
+              value-column-size="{{valueColumnSize}}"
+              help-key="{{helpKey}}" on-change="onValueChanged(value)"
+              read-only="readOnly" allow-no-selection="allowNoSelection"
+              no-options-message="{{noOptionsMessage}}" no-selection-message="{{noSelectionMessage}}"
+              option-update="updateOptions" backing-cache="{{backingCache}}"></select-field>

--- a/app/scripts/modules/openstack/common/refresh.tooltip.html
+++ b/app/scripts/modules/openstack/common/refresh.tooltip.html
@@ -1,0 +1,4 @@
+<p ng-if="$ctrl.refreshing">{{$ctrl.label}} list is <strong>refreshing</strong>.</p>
+<p ng-if="!$ctrl.refreshing">Click <span class="small glyphicon glyphicon-refresh"></span> to refresh {{$ctrl.label}} list.</p>
+<p>Last Updated:<br>{{$ctrl.lastRefresh | timestamp }}<br>({{$ctrl.lastRefresh | relativeTime }})</p>
+<p class='small'><strong>Note:</strong> Due to caching, data may be delayed up to 2 minutes</p>

--- a/app/scripts/modules/openstack/common/selectField.component.html
+++ b/app/scripts/modules/openstack/common/selectField.component.html
@@ -11,4 +11,7 @@
       <option ng-repeat="option in $ctrl.options" value="{{option.value}}" ng-selected="$ctrl.value === option.value">{{option.label}}</option>
     </select>
   </div>
+  <div class="col-md-1 sm-label-left" ng-if="showRefresh">
+    <a href="" ng-click="$ctrl.refresh()" uib-tooltip-template="$ctrl.refreshTooltipTemplate"><span class="glyphicon glyphicon-refresh" ng-class="{'glyphicon-spinning':$ctrl.refreshing}"></span></a>
+  </div>
 </div>

--- a/app/scripts/modules/openstack/instance/openstackInstanceType.service.js
+++ b/app/scripts/modules/openstack/instance/openstackInstanceType.service.js
@@ -1,0 +1,75 @@
+'use strict';
+
+let angular = require('angular');
+
+module.exports = angular.module('spinnaker.openstack.instanceType.service', [
+  require('../../core/api/api.service'),
+  require('../../core/cache/deckCacheFactory.js'),
+  require('../../core/utils/lodash.js'),
+  require('../../core/config/settings.js'),
+  require('../../core/cache/infrastructureCaches.js'),
+])
+  .factory('openstackInstanceTypeService', function ($http, $q, settings, _, API, infrastructureCaches) {
+    var categories = [
+      {
+        type: 'custom',
+        label: 'Custom Type',
+        families: [],
+        icon: 'asterisk'
+      }
+    ];
+
+    function getCategories() {
+      return $q.when(categories);
+    }
+
+    var getAllTypesByRegion = function getAllTypesByRegion() {
+      var cached = infrastructureCaches.instanceTypes.get('openstack');
+      if (cached) {
+        return $q.when(cached);
+      }
+      return API.one('instanceTypes').get()
+        .then(function (types) {
+          var result = _(types)
+            .map(function (type) {
+              return { region: type.region, account: type.account, name: type.name, key: [type.region, type.account, type.name].join(':') };
+            })
+            .uniq('key')
+            .groupBy('region')
+            .valueOf();
+          infrastructureCaches.instanceTypes.put('openstack', result);
+          return result;
+        });
+    };
+
+    function getAvailableTypesForRegions(availableRegions, selectedRegions) {
+      selectedRegions = selectedRegions || [];
+      var availableTypes = [];
+
+      // prime the list of available types
+      if (selectedRegions && selectedRegions.length) {
+        availableTypes = _.pluck(availableRegions[selectedRegions[0]], 'name');
+      }
+
+      // this will perform an unnecessary intersection with the first region, which is fine
+      selectedRegions.forEach(function(selectedRegion) {
+        if (availableRegions[selectedRegion]) {
+          availableTypes = _.intersection(availableTypes, _.pluck(availableRegions[selectedRegion], 'name'));
+        }
+      });
+
+      return availableTypes.sort();
+    }
+
+    function filterInstanceTypesByVirtualizationType(instanceTypes/*, virtualizationType*/) {
+      return instanceTypes;
+    }
+
+    return {
+      getCategories: getCategories,
+      getAvailableTypesForRegions: getAvailableTypesForRegions,
+      getAllTypesByRegion: getAllTypesByRegion,
+      filterInstanceTypesByVirtualizationType: filterInstanceTypesByVirtualizationType,
+    };
+  }
+);

--- a/app/scripts/modules/openstack/instance/osInstanceTypeSelectField.directive.js
+++ b/app/scripts/modules/openstack/instance/osInstanceTypeSelectField.directive.js
@@ -1,0 +1,53 @@
+'use strict';
+
+let angular = require('angular');
+
+module.exports = angular.module('spinnaker.openstack.instance.instanceTypeSelectField', [
+  require('../../core/utils/lodash'),
+  require('../../core/instance/instanceTypeService.js'),
+  require('../common/selectField.component.js')
+])
+  .directive('osInstanceTypeSelectField', function (_, instanceTypeService) {
+    return {
+      restrict: 'E',
+      templateUrl: require('../common/cacheBackedSelectField.template.html'),
+      scope: {
+        region: '<',
+        readOnly: '=',
+        labelColumnSize: '@',
+        label: '@',
+        helpKey: '@',
+        valueColumnSize: '@',
+        model: '=',
+        onChange: '&',
+        allowNoSelection: '=',
+        noOptionsMessage: '@',
+        noSelectionMessage: '@'
+      },
+      link: function(scope) {
+        _.defaults(scope, {
+          label: 'Instance Type',
+          labelColumnSize: 3,
+          valueColumnSize: 7,
+          options: [],
+          backingCache: 'instanceTypes',
+
+          updateOptions: function() {
+            return instanceTypeService.getAllTypesByRegion('openstack').then(function(result) {
+              scope.options = _(result[scope.region] || [])
+                  .map(function(t) { return {label: t.name, value: t.name}; })
+                  .sortBy(function(o) { return o.label; })
+                  .valueOf();
+            });
+          },
+
+          onValueChanged: function(newValue) {
+            scope.model = newValue;
+            if( scope.onChange ) {
+              scope.onChange({instanceType: newValue});
+            }
+          }
+        });
+      }
+    };
+});

--- a/app/scripts/modules/openstack/loadBalancer/configure/wizard/interface.html
+++ b/app/scripts/modules/openstack/loadBalancer/configure/wizard/interface.html
@@ -14,7 +14,7 @@
         </select>
       </div>
     </div>
-    <network-select-field model="loadBalancer.networkId" help-key="openstack.loadBalancer.network" on-change="ctrl.onNetworkChanged(network)" read-only="!isNew"></network-select-field>
+    <network-select-field model="loadBalancer.networkId" help-key="openstack.loadBalancer.network" read-only="!isNew"></network-select-field>
     <div class="form-group">
       <div class="col-md-3 sm-label-right">
         Port

--- a/app/scripts/modules/openstack/loadBalancer/configure/wizard/location.html
+++ b/app/scripts/modules/openstack/loadBalancer/configure/wizard/location.html
@@ -54,7 +54,7 @@
         </div>
       </div>
 
-      <os-subnet-select-field model="loadBalancer.subnetId" filter="subnetFilter" help-key="openstack.loadBalancer.subnet" on-change="ctrl.onSubnetChanged(subnet)" read-only="!isNew"></os-subnet-select-field>
+      <os-subnet-select-field model="loadBalancer.subnetId" filter="subnetFilter" help-key="openstack.loadBalancer.subnet" read-only="!isNew"></os-subnet-select-field>
 
       <div class="form-group">
         <div class="col-md-7 col-md-offset-3" ng-if="locationForm.stackName.$error.pattern">

--- a/app/scripts/modules/openstack/loadBalancer/configure/wizard/upsert.controller.js
+++ b/app/scripts/modules/openstack/loadBalancer/configure/wizard/upsert.controller.js
@@ -150,14 +150,6 @@ module.exports = angular.module('spinnaker.loadBalancer.openstack.create.control
       $scope.subnetFilter = {type: 'openstack', account: $scope.loadBalancer.account, region: $scope.loadBalancer.region};
     };
 
-    this.onSubnetChanged = function(subnetId) {
-      $scope.loadBalancer.subnetId = subnetId;
-    };
-
-    this.onNetworkChanged = function(networkId) {
-      $scope.loadBalancer.networkId = networkId;
-    };
-
     this.onDistributionChanged = function(distribution) {
       $scope.loadBalancer.method = distribution;
     };

--- a/app/scripts/modules/openstack/loadBalancer/configure/wizard/upsert.controller.spec.js
+++ b/app/scripts/modules/openstack/loadBalancer/configure/wizard/upsert.controller.spec.js
@@ -122,7 +122,6 @@ describe('Controller: openstackCreateLoadBalancerCtrl', function () {
     it('has the expected methods and properties', function() {
       expect(this.ctrl.updateName).toBeDefined();
       expect(this.ctrl.accountUpdated).toBeDefined();
-      expect(this.ctrl.onSubnetChanged).toBeDefined();
       expect(this.ctrl.addStatusCode).toBeDefined();
       expect(this.ctrl.removeStatusCode).toBeDefined();
       expect(this.ctrl.prependForwardSlash).toBeDefined();
@@ -202,17 +201,6 @@ describe('Controller: openstackCreateLoadBalancerCtrl', function () {
 
           it('- updates the subnet filter', function() {
             expect(this.$scope.subnetFilter).toEqual({type: 'openstack', account: this.$scope.loadBalancer.account, region: this.$scope.loadBalancer.region});
-          });
-
-          describe('& subnet updated', function() {
-            beforeEach(function() {
-              this.$scope.loadBalancer.subnet = this.testData.subnet;
-              this.ctrl.onSubnetChanged();
-            });
-
-            it('loads the list of networks', function() {
-              //TODO (jcwest)... work in progress.... may not be needed
-            });
           });
 
           describe('& account selection changed', function() {
@@ -358,7 +346,6 @@ describe('Controller: openstackCreateLoadBalancerCtrl', function () {
     it('has the expected methods and properties', function() {
       expect(this.ctrl.updateName).toBeDefined();
       expect(this.ctrl.accountUpdated).toBeDefined();
-      expect(this.ctrl.onSubnetChanged).toBeDefined();
       expect(this.ctrl.addStatusCode).toBeDefined();
       expect(this.ctrl.removeStatusCode).toBeDefined();
       expect(this.ctrl.prependForwardSlash).toBeDefined();

--- a/app/scripts/modules/openstack/loadBalancer/loadBalancerSelectField.directive.js
+++ b/app/scripts/modules/openstack/loadBalancer/loadBalancerSelectField.directive.js
@@ -2,40 +2,42 @@
 
 let angular = require('angular');
 
-module.exports = angular.module('spinnaker.openstack.network.networkSelectField.directive', [
+module.exports = angular.module('spinnaker.openstack.loadBalancer.loadBalancerSelectField.directive', [
   require('../../core/utils/lodash'),
-  require('../../core/network/network.read.service.js'),
+  require('../../core/loadBalancer/loadBalancer.read.service.js'),
   require('../common/selectField.component.js')
 ])
-  .directive('networkSelectField', function (_, networkReader) {
+  .directive('osLoadBalancerSelectField', function (_, loadBalancerReader, cacheInitializer, infrastructureCaches, $rootScope) {
     return {
       restrict: 'E',
       templateUrl: require('../common/cacheBackedSelectField.template.html'),
       scope: {
-        label: '@',
+        readOnly: '=',
         labelColumnSize: '@',
+        label: '@',
         helpKey: '@',
+        valueColumnSize: '@',
         model: '=',
         filter: '=',
         onChange: '&',
-        readOnly: '=',
         allowNoSelection: '=',
         noOptionsMessage: '@',
         noSelectionMessage: '@'
       },
       link: function(scope) {
         _.defaults(scope, {
-          label: 'Network',
+          label: 'Load Balancer',
           labelColumnSize: 3,
           valueColumnSize: 7,
           options: [],
-          backingCache: 'networks',
+          filter: {},
+          backingCache: 'loadBalancers',
 
           updateOptions: function() {
-            return networkReader.listNetworksByProvider('openstack').then(function(networks) {
-              scope.options = _(networks)
+            return loadBalancerReader.listLoadBalancers('openstack').then(function(loadBalancers) {
+              scope.options = _(loadBalancers)
                 .filter(scope.filter || {})
-                .map(function(a) { return {label: a.name, value: a.id}; })
+                .map(function(s) { return {label: s.name, value: s.id}; })
                 .sortBy(function(o) { return o.label; })
                 .valueOf();
 
@@ -46,10 +48,9 @@ module.exports = angular.module('spinnaker.openstack.network.networkSelectField.
           onValueChanged: function(newValue) {
             scope.model = newValue;
             if( scope.onChange ) {
-              scope.onChange({network: newValue});
+              scope.onChange({loadBalancer: newValue});
             }
           }
-
         });
 
         scope.$watch('filter', function() { scope.$broadcast('updateOptions'); });

--- a/app/scripts/modules/openstack/network/networkSelectField.directive.html
+++ b/app/scripts/modules/openstack/network/networkSelectField.directive.html
@@ -1,5 +1,0 @@
-<select-field value="model" options="networks"
-              label="{{label}}" label-column-size="{{labelColumnSize}}"
-              help-key="{{helpKey}}" on-change="onChange({network: value})"
-              read-only="readOnly" allow-no-selection="allowNoSelection"
-              no-options-message="{{noOptionsMessage}}" no-selection-message="{{noSelectionMessage}}"></select-field>

--- a/app/scripts/modules/openstack/openstack.module.js
+++ b/app/scripts/modules/openstack/openstack.module.js
@@ -11,6 +11,7 @@ _.forEach(templates.keys(), function(key) {
 });
 
 module.exports = angular.module('spinnaker.openstack', [
+  require('./instance/openstackInstanceType.service.js'),
   require('./serverGroup/configure/ServerGroupCommandBuilder.js'),
   require('./serverGroup/configure/serverGroup.configure.openstack.module.js'),
   require('./serverGroup/configure/wizard/Clone.controller.js'),
@@ -40,6 +41,12 @@ module.exports = angular.module('spinnaker.openstack', [
       },
       search: {
         resultFormatter: 'openstackSearchResultFormatter',
+      },
+      image: {
+        reader: 'openstackImageReader',
+      },
+      instance: {
+        instanceTypeService: 'openstackInstanceTypeService',
       },
       securityGroup: {
         reader: 'openstackSecurityGroupReader',

--- a/app/scripts/modules/openstack/subnet/subnetSelectField.directive.html
+++ b/app/scripts/modules/openstack/subnet/subnetSelectField.directive.html
@@ -1,5 +1,0 @@
-<select-field value="model" options="subnets"
-              label="{{label}}" label-column-size="{{labelColumnSize}}"
-              help-key="{{helpKey}}" on-change="onChange({subnet: value})"
-              read-only="readOnly" allow-no-selection="allowNoSelection"
-              no-options-message="{{noOptionsMessage}}" no-selection-message="{{noSelectionMessage}}"></select-field>


### PR DESCRIPTION
Add ability to refresh select fields for openstack cached entities.
Refactor select fields to consolidate common functionality.
Add select field directives for load balancers and instance types.