### PR TITLE
(core) fix multiselect toggle behavior, handle longer instance ids

### DIFF
--- a/app/scripts/modules/core/cluster/rollups.less
+++ b/app/scripts/modules/core/cluster/rollups.less
@@ -420,6 +420,9 @@ load-balancers-tag {
       margin-top: -5px;
       margin-bottom: 10px;
       font-size: 90%;
+      th, td {
+        padding: 5px 1px;
+      }
     }
   }
   h5, h6 {

--- a/app/scripts/modules/core/instance/instanceList.directive.html
+++ b/app/scripts/modules/core/instance/instanceList.directive.html
@@ -1,13 +1,13 @@
 <table ng-if="instances.length" class="table table-hover table-condensed instances">
   <thead>
   <tr>
-    <th width="4%" ng-if="sortFilter.multiselect"><input type="checkbox" ng-checked="instanceGroup.selectAll" ng-click="selectAllClicked($event)"/></th>
+    <th width="3%" ng-if="sortFilter.multiselect"><input type="checkbox" ng-checked="instanceGroup.selectAll" ng-click="selectAllClicked($event)"/></th>
     <th width="{{::columnWidth.id}}%" sort-toggle key="id" label="Instance" sort-model="sortFilter.instanceSort" on-change="applyParamsToUrl()"></th>
     <th width="{{::columnWidth.launchTime}}%" sort-toggle key="launchTime" label="Launch Time" default="true" sort-model="sortFilter.instanceSort" on-change="applyParamsToUrl()"></th>
     <th width="{{::columnWidth.zone}}%" sort-toggle key="availabilityZone" label="Zone" sort-model="sortFilter.instanceSort" on-change="applyParamsToUrl()"></th>
     <th ng-if="::hasDiscovery" width="{{::columnWidth.discovery}}%" class="text-center" sort-toggle key="discoveryState" label="Discovery" sort-model="sortFilter.instanceSort" on-change="applyParamsToUrl()"></th>
     <th ng-if="::hasLoadBalancers" width="{{::columnWidth.loadBalancers}}%" sort-toggle key="loadBalancerSort" label="Load Balancers" sort-model="sortFilter.instanceSort" on-change="applyParamsToUrl()"></th>
-    <th ng-if="::showProviderHealth" width="{{::columnWidth.cloudProvider}}%" class="text-center" sort-toggle key="providerHealth" label="Cloud Provider" sort-model="sortFilter.instanceSort" on-change="applyParamsToUrl()"></th>
+    <th ng-if="::showProviderHealth" width="{{::columnWidth.cloudProvider}}%" class="text-center" sort-toggle key="providerHealth" label="Provider" sort-model="sortFilter.instanceSort" on-change="applyParamsToUrl()"></th>
 
   </tr>
   </thead>

--- a/app/scripts/modules/core/instance/instanceList.directive.js
+++ b/app/scripts/modules/core/instance/instanceList.directive.js
@@ -39,12 +39,12 @@ module.exports = angular.module('spinnaker.core.instance.instanceList.directive'
         scope.showProviderHealth = !scope.hasDiscovery && !scope.hasLoadBalancers;
 
         scope.columnWidth = {
-          id: 14,
+          id: 20,
           launchTime: 23,
-          zone: 13,
+          zone: 12,
           discovery: 16,
-          loadBalancers: 34,
-          cloudProvider: 34,
+          loadBalancers: 31,
+          cloudProvider: 31,
         };
 
         if (!scope.hasDiscovery) {

--- a/app/scripts/modules/core/instance/instanceListBody.directive.js
+++ b/app/scripts/modules/core/instance/instanceListBody.directive.js
@@ -139,6 +139,7 @@ module.exports = angular.module('spinnaker.core.instance.instanceListBody.direct
         }
 
         function renderInstances() {
+          instanceGroup = MultiselectModel.getOrCreateInstanceGroup(scope.serverGroup);
           var instances = (scope.instances || [])
             .filter(clusterFilterService.shouldShowInstance)
             .sort(instanceSorter);


### PR DESCRIPTION
The `instanceGroups` get cleared whenever "Edit Multiple" is toggled, so we need to re-fetch it every time we re-render instances.

Also providing some more space for instance ids to accommodate Amazon's new, longer ids.