### PR TITLE
(core) validate response data is not authentication page-like

### DIFF
--- a/app/scripts/modules/core/cache/deckCacheFactory.js
+++ b/app/scripts/modules/core/cache/deckCacheFactory.js
@@ -4,8 +4,9 @@ let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.cache.deckCacheFactory', [
   require('angular-cache'),
+  require('../config/settings'),
 ])
-.factory('deckCacheFactory', function(CacheFactory, $log) {
+.factory('deckCacheFactory', function(CacheFactory, $log, settings) {
 
     var caches = Object.create(null);
 
@@ -59,6 +60,14 @@ module.exports = angular.module('spinnaker.core.cache.deckCacheFactory', [
     var selfClearingLocalStorage = {
       setItem: function(k, v) {
         try {
+          if (k.indexOf(settings.gateUrl) > -1) {
+            let response = JSON.parse(v);
+            if (response.value && Array.isArray(response.value) && response.value.length > 2 && Array.isArray(response.value[2])) {
+              if (response.value[2]['content-type'] && response.value[2]['content-type'].indexOf('application/json') < 0) {
+                return;
+              }
+            }
+          }
           window.localStorage.setItem(k, v);
           cacheProxy[k] = v;
         } catch (e) {

--- a/app/scripts/modules/core/pipeline/config/services/pipelineConfigService.spec.js
+++ b/app/scripts/modules/core/pipeline/config/services/pipelineConfigService.spec.js
@@ -76,7 +76,7 @@ describe('pipelineConfigService', function () {
         var json = JSON.parse(data);
         posted.push({index: json.index, name: json.name});
         return true;
-      }).respond(200, '');
+      }).respond(200, {});
 
       this.service.getPipelinesForApplication('app');
       this.$scope.$digest();


### PR DESCRIPTION
If authentication expires, ajax requests follow the redirect and end up getting a 200 response with the authentication page, so they're not rejected.

This change looks for `<html` as the start string of a response, then triggers reauthentication and rejects the request.

In the cache factory, we won't set an item if it's an http response following a similar pattern.

Tested locally "pretty extensively".

@zanthrash PTAL