### PR TITLE
(docker) allow docker bake stage via feature flag

### DIFF
--- a/app/scripts/modules/core/pipeline/config/stages/baseProviderStage/baseProviderStage.js
+++ b/app/scripts/modules/core/pipeline/config/stages/baseProviderStage/baseProviderStage.js
@@ -4,9 +4,13 @@ let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.baseProviderStage', [
   require('../../../../utils/lodash.js'),
+  require('../../../../config/settings'),
   require('../../../../cloudProvider/providerSelection/providerSelector.directive.js'),
 ])
-  .controller('BaseProviderStageCtrl', function($scope, stage, accountService, pipelineConfig, _) {
+  .controller('BaseProviderStageCtrl', function($scope, stage, accountService, pipelineConfig, _, settings) {
+
+    // Docker Bake is wedged in here because it doesn't really fit our existing cloud provider paradigm
+    let dockerBakeEnabled = _.get(settings, 'feature.dockerBake') && stage.type === 'bake';
 
     $scope.stage = stage;
 
@@ -15,9 +19,16 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.baseProviderStage
 
     var stageProviders = pipelineConfig.getProvidersFor(stage.type);
 
+    if (dockerBakeEnabled) {
+      stageProviders.push({cloudProvider: 'docker'});
+    }
+
     accountService.listProviders($scope.application).then(function (providers) {
       $scope.viewState.loading = false;
       var availableProviders = _.intersection(providers, _.pluck(stageProviders, 'cloudProvider'));
+      if (dockerBakeEnabled) {
+        availableProviders.push('docker');
+      }
       if (availableProviders.length === 1) {
         $scope.stage.cloudProviderType = availableProviders[0];
       } else {


### PR DESCRIPTION
In the interest of under-engineering until we have a better idea of any similar use cases, expose the docker bake stage via a feature flag.

@duftler PTAL - does this work for you? Would need to set `dockerBake: true` in the `feature` block in settings.js to see this, which ends up exposing the existing docker bake stage.