### PR TITLE
(k8s) fix job clone wizard

### DIFF
--- a/app/scripts/modules/kubernetes/job/configure/wizard/Clone.controller.js
+++ b/app/scripts/modules/kubernetes/job/configure/wizard/Clone.controller.js
@@ -14,7 +14,7 @@ module.exports = angular.module('spinnaker.job.configure.kubernetes.clone', [
                                                        v2modalWizardService, taskMonitorService,
                                                        kubernetesServerGroupConfigurationService,
                                                        jobCommand, application, title,
-                                                       wizardSubFormValidation) {
+                                                       wizardSubFormValidation, $timeout) {
     $scope.pages = {
       templateSelection: require('./templateSelection.html'),
       basicSettings: require('../../../serverGroup/configure/wizard/basicSettings.html'),
@@ -48,8 +48,8 @@ module.exports = angular.module('spinnaker.job.configure.kubernetes.clone', [
       jobCommand.viewState.contextImages = $scope.contextImages;
       $scope.contextImages = null;
       kubernetesServerGroupConfigurationService.configureCommand(application, jobCommand).then(function () {
-        $scope.state.loaded = true;
-        initializeWizardState();
+        $scope.state.loaded = true; // allows wizard directive to run (after digest).
+        $timeout(initializeWizardState); // wait for digest.
         initializeWatches();
       });
     }
@@ -64,7 +64,7 @@ module.exports = angular.module('spinnaker.job.configure.kubernetes.clone', [
       if (mode === 'clone' || mode === 'editPipeline') {
         v2modalWizardService.markComplete('location');
         v2modalWizardService.markComplete('load-balancers');
-        v2modalWizardService.markComplete('replicas');
+        v2modalWizardService.markComplete('completion');
         v2modalWizardService.markComplete('volumes');
       }
 


### PR DESCRIPTION
Fixes the job clone wizard (bug surfaces when trying to edit a job in a pipeline). I made a similar fix in the server group wizard controller but forgot to update jobs.

Also updated the markComplete calls, since the job wizard does not have a replicas page.

@lwander PTAL