### PR TITLE
(core) up chevrons are right chevrons; New pipeline button, smaller p…

### DIFF
--- a/app/scripts/modules/core/account/collapsibleAccountTag.directive.js
+++ b/app/scripts/modules/core/account/collapsibleAccountTag.directive.js
@@ -17,7 +17,7 @@ module.exports = angular
       },
       controllerAs: 'vm',
       controller: function ($scope, accountService) {
-        this.getIcon = () => this.state.expanded ? 'down' : 'up';
+        this.getIcon = () => this.state.expanded ? 'down' : 'right';
 
         let getAccountType = () => {
           accountService.challengeDestructiveActions(this.account).then((challenge) => {

--- a/app/scripts/modules/core/application/application.html
+++ b/app/scripts/modules/core/application/application.html
@@ -13,7 +13,7 @@
     </div>
     <span ng-include="ctrl.applicationNavTemplate"></span>
     <div class="page-button pull-right" ng-if="application.attributes.pdApiKey">
-      <button class="btn btn-xs btn-danger"
+      <button class="btn btn-xs btn-danger btn-page-owner"
               ng-click="ctrl.pageApplicationOwner()"
               uib-tooltip="Page application owner">
         <span class="glyphicon glyphicon-phone-alt"></span>

--- a/app/scripts/modules/core/application/application.less
+++ b/app/scripts/modules/core/application/application.less
@@ -14,6 +14,13 @@
     @media (min-width: 708px) and (max-width: 1200px) {
       margin-top: 16px;
     }
+    .btn-danger {
+      color: @unhealthy_red;
+      background-color: transparent;
+      border-color: transparent;
+      padding: 0 5px;
+      font-size: 14px;
+    }
   }
   h2 {
     @media (min-width: 708px) and (max-width: 1200px) {

--- a/app/scripts/modules/core/cluster/filter/collapsibleFilterSection.directive.js
+++ b/app/scripts/modules/core/cluster/filter/collapsibleFilterSection.directive.js
@@ -18,7 +18,7 @@ module.exports = angular
         var expanded = (scope.expanded === 'true');
         scope.state = {expanded: expanded};
         scope.getIcon = function () {
-          return scope.state.expanded ? 'down' : 'up';
+          return scope.state.expanded ? 'down' : 'right';
         };
 
         scope.toggle = function () {

--- a/app/scripts/modules/core/delivery/create/createPipelineButton.html
+++ b/app/scripts/modules/core/delivery/create/createPipelineButton.html
@@ -1,6 +1,10 @@
-<a href
-   analytics-on="click"
-   analytics-category="Pipelines"
-   analytics-event="Create Pipeline"
-   ng-click="buttonCtrl.createPipeline()">Create New ...
-</a>
+<button class="btn btn-sm btn-default"
+        analytics-on="click"
+        analytics-category="Pipelines"
+        analytics-event="Create Pipeline"
+        style="margin-right: 5px"
+        ng-click="buttonCtrl.createPipeline()">
+  <span class="glyphicon glyphicon-plus-sign visible-xl-inline"></span>
+  <span class="glyphicon glyphicon-plus-sign hidden-xl-inline" uib-tooltip="Create Pipeline or Strategy"></span>
+  <span class="visible-xl-inline">New</span>
+</button>

--- a/app/scripts/modules/core/delivery/executionGroup/executionGroup.directive.html
+++ b/app/scripts/modules/core/delivery/executionGroup/executionGroup.directive.html
@@ -13,7 +13,7 @@
         <div class="col-md-5 col-sm-5">
           <h4 class="execution-group-title">
             <span class="glyphicon"
-                  ng-class="{'glyphicon-chevron-up': !vm.viewState.open, 'glyphicon-chevron-down': vm.viewState.open}">
+                  ng-class="{'glyphicon-chevron-right': !vm.viewState.open, 'glyphicon-chevron-down': vm.viewState.open}">
             </span>
             <span class="execution-group-title">
               {{ vm.group.heading }}

--- a/app/scripts/modules/core/delivery/executionGroup/executionGroup.less
+++ b/app/scripts/modules/core/delivery/executionGroup/executionGroup.less
@@ -65,7 +65,10 @@
 
 .execution-group-actions {
   h4 {
-    margin-left: 40px
+    margin-left: 20px;
+    @media (min-width: 1200px) {
+      margin-left: 40px;
+    }
   }
 }
 

--- a/app/scripts/modules/core/delivery/executions/executions.html
+++ b/app/scripts/modules/core/delivery/executions/executions.html
@@ -82,12 +82,12 @@
             <span ng-if="vm.viewState.triggeringExecution" class="pulsing">
               <span class="glyphicon glyphicon-asterisk glyphicon-spinning visible-md-inline visible-sm-inline" uib-tooltip="Starting Execution"></span>
               <span class="glyphicon glyphicon-asterisk glyphicon-spinning visible-lg-inline"></span>
-              <span class="visible-lg-inline">Starting Execution</span>&hellip;
+              <span class="visible-xl-inline">Starting Execution</span>&hellip;
             </span>
             <span ng-if="!vm.viewState.triggeringExecution">
               <span class="glyphicon glyphicon-play visible-lg-inline"></span>
               <span class="glyphicon glyphicon-play visible-md-inline visible-sm-inline" uib-tooltip="Start Manual Execution"></span>
-              <span class="visible-lg-inline">Start Manual Execution</span>
+              <span class="visible-xl-inline">Start Manual Execution</span>
             </span>
           </a>
         </div>

--- a/app/scripts/modules/core/delivery/executions/executions.less
+++ b/app/scripts/modules/core/delivery/executions/executions.less
@@ -25,6 +25,10 @@ executions {
         font-weight: normal;
       }
     }
+    font-size: 90%;
+    @media (min-width: 1400px) {
+      font-size: 100%;
+    }
   }
 }
 

--- a/app/scripts/modules/core/delivery/status/executionStatus.html
+++ b/app/scripts/modules/core/delivery/status/executionStatus.html
@@ -56,7 +56,7 @@
      analytics-event="Execution details toggled (Details link)"
      ng-click="vm.toggleDetails({executionId: vm.execution.id})">
     <span class="small glyphicon"
-          ng-class="vm.showingDetails() ? 'glyphicon-chevron-down' : 'glyphicon-chevron-up'">
+          ng-class="vm.showingDetails() ? 'glyphicon-chevron-down' : 'glyphicon-chevron-right'">
     </span>
     Details
   </a>

--- a/app/scripts/modules/core/pipeline/config/createNew.html
+++ b/app/scripts/modules/core/pipeline/config/createNew.html
@@ -1,13 +1,15 @@
 <div class="dropdown pull-left" style="margin-right:10px"  uib-dropdown>
+    <create-pipeline-button application="application"></create-pipeline-button>
     <button type="button" class="btn btn-sm btn-default dropdown-toggle"
             analytics-on="click"
             analytics-category="Pipelines"
             analytics-event="Configure (top level)"
             uib-dropdown-toggle>
-        Configure <span class="caret"></span>
+      <span class="visible-xl-inline"><span class="glyphicon glyphicon-cog"></span> Configure</span>
+      <span class="hidden-xl-inline" uib-tooltip="Configure pipelines"><span class="glyphicon glyphicon-cog"></span></span>
+      <span class="caret"></span>
     </button>
     <ul class="dropdown-menu" uib-dropdown-menu role="menu">
-        <li><create-pipeline-button application="application"></create-pipeline-button></li>
         <li class="dropdown-header" style="margin-top:0" ng-if="application.pipelineConfigs.data.length">PIPELINES</li>
         <li ng-repeat="pipeline in application.pipelineConfigs.data">
           <a href

--- a/app/scripts/modules/core/pipeline/config/pipelineConfig.less
+++ b/app/scripts/modules/core/pipeline/config/pipelineConfig.less
@@ -129,8 +129,8 @@ pipeline-configurer {
 
   .permalink {
     position: absolute;
-    top: 34px;
-    right: 245px;
+    top: 36px;
+    right: 345px;
     font-size: 80%;
     .fade-in(0.15, 0.4); // hack: prevent shifting of actions button during sliding animation
   }

--- a/app/scripts/modules/core/presentation/collapsibleSection/collapsibleSection.directive.js
+++ b/app/scripts/modules/core/presentation/collapsibleSection/collapsibleSection.directive.js
@@ -32,7 +32,7 @@ module.exports = angular.module('spinnaker.core.presentation.collapsibleSection.
         }
         scope.state = {expanded: expanded};
         scope.getIcon = function() {
-          return scope.state.expanded ? 'down' : 'up';
+          return scope.state.expanded ? 'down' : 'right';
         };
 
         scope.getClassType = function() {

--- a/app/scripts/modules/core/presentation/main.less
+++ b/app/scripts/modules/core/presentation/main.less
@@ -1258,3 +1258,15 @@ ul.checkmap {
   border-bottom: 1px solid @light_grey;
   padding-bottom: 10px;
 }
+
+.visible-xl-inline {
+  display: none !important;
+}
+@media (min-width: 1400px) {
+  .visible-xl-inline {
+    display: inline !important;
+  }
+  .hidden-xl-inline {
+    display: none !important;
+  }
+}

--- a/app/scripts/modules/core/task/tasks.html
+++ b/app/scripts/modules/core/task/tasks.html
@@ -82,7 +82,7 @@
             <tr class="clickable" ng-click="tasks.toggleDetails(task.id)" ng-repeat-start="task in tasks.resultPage()">
               <td>
                 <div class="task-name">
-                  <a href id="task-{{task.id}}"><span class="glyphicon glyphicon-chevron-{{tasks.isExpanded(task.id) ? 'down' : 'up'}}"></span></a>
+                  <a href id="task-{{task.id}}"><span class="glyphicon glyphicon-chevron-{{tasks.isExpanded(task.id) ? 'down' : 'right'}}"></span></a>
                   {{task.name}}
                 </div>
 

--- a/app/scripts/modules/netflix/fastProperties/applicationProperties.html
+++ b/app/scripts/modules/netflix/fastProperties/applicationProperties.html
@@ -37,7 +37,7 @@
        <div class="rollout" ng-show="fp.promotions.length > 0">
 
          <div class="clickable" ng-click="fp.togglePromotionPane()">
-           <span class="pull-left glyphicon glyphicon-chevron-{{fp.promotionPaneOpen ? 'down' : 'up'}}"></span>
+           <span class="pull-left glyphicon glyphicon-chevron-{{fp.promotionPaneOpen ? 'down' : 'right'}}"></span>
 
            <h3>
              Rollouts

--- a/app/scripts/modules/netflix/fastProperties/fastPropertyPromotion.directive.html
+++ b/app/scripts/modules/netflix/fastProperties/fastPropertyPromotion.directive.html
@@ -24,7 +24,7 @@
           ng-repeat-start="promotion in fpPromotion.filteredPromotions"
           ng-click="fpPromotion.toggleRolloutDetails(promotion)">
         <td>
-          <span class="pull-left glyphicon glyphicon-chevron-{{fpPromotion.isRolloutDetailsOpen(promotion.id) ? 'down' : 'up'}}"></span>
+          <span class="pull-left glyphicon glyphicon-chevron-{{fpPromotion.isRolloutDetailsOpen(promotion.id) ? 'down' : 'right'}}"></span>
         </td>
         <td>
           {{ promotion.key }}


### PR DESCRIPTION
…hone

Four changes:
* making the "up" chevron point to the right to indicate a section is collapsed
* adding a "New" button to create a pipeline, since discoverability is not great in the "Configure" dropdown (which gets a cog to be consistent with the other buttons in that bar)
* making the "Page application owner" button less overpowering
* making the pipeline headers more readable on narrower screens