### PR TITLE
Find Image from Tags

### DIFF
--- a/app/scripts/modules/core/core.module.js
+++ b/app/scripts/modules/core/core.module.js
@@ -103,6 +103,7 @@ module.exports = angular
     require('./pipeline/config/stages/enableAsg/enableAsgStage.module.js'),
     require('./pipeline/config/stages/executionWindows/executionWindowsStage.module.js'),
     require('./pipeline/config/stages/findAmi/findAmiStage.module.js'),
+    require('./pipeline/config/stages/findImageFromTags/findImageFromTagsStage.module.js'),
     require('./pipeline/config/stages/jenkins/jenkinsStage.module.js'),
     require('./pipeline/config/stages/manualJudgment/manualJudgmentStage.module.js'),
     require('./pipeline/config/stages/tagImage/tagImageStage.module.js'),

--- a/app/scripts/modules/core/pipeline/config/stages/deploy/deployStage.js
+++ b/app/scripts/modules/core/pipeline/config/stages/deploy/deployStage.js
@@ -22,7 +22,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.deployStage', [
       validators: [
         {
           type: 'stageBeforeType',
-          stageTypes: ['bake', 'findAmi', 'findImage'],
+          stageTypes: ['bake', 'findAmi', 'findImage', 'findImageFromTags'],
           message: 'You must have a Bake or Find Image stage before any deploy stage.',
           skipValidation: (pipeline, stage) => {
             if (!stage.clusters || !stage.clusters.length) {

--- a/app/scripts/modules/core/pipeline/config/stages/findAmi/findAmiStage.js
+++ b/app/scripts/modules/core/pipeline/config/stages/findAmi/findAmiStage.js
@@ -10,7 +10,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.findAmiStage', [
     pipelineConfigProvider.registerStage({
       useBaseProvider: true,
       key: 'findImage',
-      label: 'Find Image',
+      label: 'Find Image from Cluster',
       description: 'Finds an image to deploy from an existing cluster'
     });
   });

--- a/app/scripts/modules/core/pipeline/config/stages/findImageFromTags/findImageFromTagsExecutionDetails.controller.js
+++ b/app/scripts/modules/core/pipeline/config/stages/findImageFromTags/findImageFromTagsExecutionDetails.controller.js
@@ -1,0 +1,22 @@
+'use strict';
+
+let angular = require('angular');
+
+module.exports = angular
+  .module('spinnaker.core.pipeline.stage.findImageFromTags.executionDetails.controller', [
+    require('angular-ui-router'),
+    require('../../../../delivery/details/executionDetailsSection.service.js'),
+    require('../../../../delivery/details/executionDetailsSectionNav.directive.js'),
+  ])
+  .controller('FindImageFromTagsExecutionDetailsCtrl', function ($scope, $stateParams, executionDetailsSectionService) {
+
+    $scope.configSections = ['findImageFromTags', 'taskStatus'];
+
+    function initialize() {
+      executionDetailsSectionService.synchronizeSection($scope.configSections);
+      $scope.detailsSection = $stateParams.details;
+    }
+
+    initialize();
+    $scope.$on('$stateChangeSuccess', initialize, true);
+  });

--- a/app/scripts/modules/core/pipeline/config/stages/findImageFromTags/findImageFromTagsExecutionDetails.html
+++ b/app/scripts/modules/core/pipeline/config/stages/findImageFromTags/findImageFromTagsExecutionDetails.html
@@ -1,0 +1,42 @@
+<div ng-controller="TagImageExecutionDetailsCtrl as tagImageCtrl">
+  <execution-details-section-nav sections="configSections"></execution-details-section-nav>
+  <div class="step-section-details" ng-if="detailsSection === 'findImageFromTags'">
+    <div class="row">
+      <div class="col-md-12">
+        <dl class="dl-narrow dl-horizontal">
+          <dt>Regions</dt>
+          <dd>{{stage.context.regions.join(', ')}}</dd>
+          <dt>Tags</dt>
+          <dd>
+            <span ng-repeat="(key, val) in stage.context.tags">
+              {{key}}:{{val}}{{$last ? '' : ', '}}
+            </span>
+          </dd>
+        </dl>
+      </div>
+    </div>
+    <stage-failure-message is-failed="stage.isFailed" message="stage.failureMessage"></stage-failure-message>
+
+    <div class="row" ng-if="stage.context.amiDetails">
+      <div class="col-md-12">
+        <div class="well alert alert-info">
+          <h4>Results</h4>
+          <dl ng-repeat="image in stage.context.amiDetails" class="dl-narrow dl-horizontal">
+            <dt>Region</dt>
+            <dd>{{image.region}}</dd>
+            <dt>Image ID</dt>
+            <dd>{{image.imageId}}</dd>
+            <dt>Name</dt>
+            <dd>{{image.imageName}}</dd>
+          </dl>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="step-section-details" ng-if="detailsSection === 'taskStatus'">
+    <div class="row">
+      <execution-step-details item="stage"></execution-step-details>
+    </div>
+  </div>
+</div>

--- a/app/scripts/modules/core/pipeline/config/stages/findImageFromTags/findImageFromTagsStage.html
+++ b/app/scripts/modules/core/pipeline/config/stages/findImageFromTags/findImageFromTagsStage.html
@@ -1,0 +1,12 @@
+<div class="form-horizontal">
+  <stage-config-field label="Package">
+    <input type="text" class="form-control input-sm"
+           ng-model="stage.packageName"/>
+  </stage-config-field>
+  <stage-config-field label="Regions">
+    <checklist items="regions" model="stage.regions" inline="true" include-select-all-button="true"></checklist>
+  </stage-config-field>
+  <stage-config-field label="Tags">
+    <map-editor model="stage.tags" allow-empty="true"></map-editor>
+  </stage-config-field>
+</div>

--- a/app/scripts/modules/core/pipeline/config/stages/findImageFromTags/findImageFromTagsStage.js
+++ b/app/scripts/modules/core/pipeline/config/stages/findImageFromTags/findImageFromTagsStage.js
@@ -1,0 +1,32 @@
+'use strict';
+
+let angular = require('angular');
+
+module.exports = angular.module('spinnaker.core.pipeline.stage.findImageFromTagsStage', [
+  require('../bake/bakery.service.js'),
+])
+  .config(function (pipelineConfigProvider) {
+    pipelineConfigProvider.registerStage({
+      label: 'Find Image from Tags',
+      description: 'Finds an image to deploy from existing tags',
+      key: 'findImageFromTags',
+      cloudProvider: 'aws',
+      controller: 'FindImageFromTagsStageCtrl',
+      controllerAs: 'findImageFromTagsStageCtrl',
+      templateUrl: require('./findImageFromTagsStage.html'),
+      executionDetailsUrl: require('./findImageFromTagsExecutionDetails.html'),
+      validators: [
+        { type: 'requiredField', fieldName: 'packageName', },
+        { type: 'requiredField', fieldName: 'regions', },
+        { type: 'requiredField', fieldName: 'tags', },
+      ],
+    });
+  })
+  .controller('FindImageFromTagsStageCtrl', function($scope, bakeryService) {
+    $scope.stage.tags = $scope.stage.tags || {};
+    $scope.stage.regions = $scope.stage.regions || [];
+
+    bakeryService.getRegions('aws').then(function(regions) {
+      $scope.regions = regions;
+    });
+  });

--- a/app/scripts/modules/core/pipeline/config/stages/findImageFromTags/findImageFromTagsStage.module.js
+++ b/app/scripts/modules/core/pipeline/config/stages/findImageFromTags/findImageFromTagsStage.module.js
@@ -1,0 +1,10 @@
+'use strict';
+
+let angular = require('angular');
+
+module.exports = angular.module('spinnaker.core.pipeline.stage.findImageFromTags', [
+  require('../stage.module.js'),
+  require('../core/stage.core.module.js'),
+  require('./findImageFromTagsExecutionDetails.controller.js'),
+  require('./findImageFromTagsStage.js'),
+]);


### PR DESCRIPTION
- Similar to `Find Image from Cluster` but supports scenarios where an image is not currently deployed (but is tagged)
- Relates to the `Tag Image` stage