### PR TITLE
(gce) more l7 fixes

### DIFF
--- a/app/scripts/modules/core/help/helpContents.js
+++ b/app/scripts/modules/core/help/helpContents.js
@@ -151,13 +151,14 @@ module.exports = angular.module('spinnaker.core.help.contents', [])
       '<li><b>Auto Subnet Network</b>: Server groups will be automatically assigned to the specified region\'s subnet.</li>' +
       '<li><b>Custom Subnet Network</b>: A subnet must be selected for the server group. If no subnets have been created for the specified region, you will not be able to provision the server group.</li>' +
       '</ul>',
-    'gce.serverGroup.loadBalancingPolicy.maxRatePerInstance': 'The maximum number of requests per second that can be sent to the backend instance group.',
-    'gce.serverGroup.loadBalancingPolicy.maxUtilization': 'The maximum CPU utilization allowed for the backend. CPU utilization is calculated by averaging CPU use across all instances in the backend instance group.',
+    'gce.serverGroup.loadBalancingPolicy.balancingMode': 'Tells the load balancer when the backend is at capacity. If a backend is at capacity, new requests are routed to the nearest region that can handle requests. The balancing mode can be based on CPU utilization or requests per second (RPS).',
+    'gce.serverGroup.loadBalancingPolicy.maxRatePerInstance': 'The maximum number of requests per second that can be sent to the backend instance group. Input must be a number greater than zero.',
+    'gce.serverGroup.loadBalancingPolicy.maxUtilization': 'The maximum CPU utilization allowed for the backend. CPU utilization is calculated by averaging CPU use across all instances in the backend instance group. Input must be a number between 0 and 100.',
     'gce.serverGroup.loadBalancingPolicy.capacityScaler': `
       An additional control to manage your maximum CPU utilization or RPS.
       If you want your instances to operate at a max 80% CPU utilization, set your balancing mode to 80% max CPU utilization and your capacity to 100%.
-      If you want to cut instance utilization by half, set your balancing mode to 80% max CPU utilization and your capacity to 50%.`,
-    'gce.serverGroup.loadBalancingPolicy.listeningPort': 'A load balancer sends traffic to an instance group through a named port.',
+      If you want to cut instance utilization by half, set your balancing mode to 80% max CPU utilization and your capacity to 50%. Input must be a number between 0 and 100.`,
+    'gce.serverGroup.loadBalancingPolicy.listeningPort': 'A load balancer sends traffic to an instance group through a named port. Input must be a port number (i.e., between 1 and 65535).',
     'pipeline.config.optionalStage': '' +
       '<p>When this option is enabled, stage will only execute when the supplied expression evaluates true.</p>' +
       '<p>The expression <em>does not</em> need to be wrapped in ${ and }.</p>',

--- a/app/scripts/modules/google/loadBalancer/elSevenUtils.service.js
+++ b/app/scripts/modules/google/loadBalancer/elSevenUtils.service.js
@@ -1,0 +1,12 @@
+'use strict';
+
+let angular = require('angular');
+
+module.exports = angular.module('spinnaker.deck.gce.elSevenUtils.service', [])
+  .factory('elSevenUtils', function () {
+    function isElSeven (loadBalancer) {
+      return loadBalancer.loadBalancerType === 'HTTP';
+    }
+
+    return { isElSeven };
+  });

--- a/app/scripts/modules/google/serverGroup/configure/serverGroupCommandBuilder.service.js
+++ b/app/scripts/modules/google/serverGroup/configure/serverGroupCommandBuilder.service.js
@@ -228,6 +228,7 @@ module.exports = angular.module('spinnaker.gce.serverGroupCommandBuilder.service
           max: 0,
           desired: 1
         },
+        backendServiceMetadata: [],
         persistentDiskType: 'pd-ssd',
         persistentDiskSizeGb: 10,
         localSSDCount: 1,
@@ -288,6 +289,7 @@ module.exports = angular.module('spinnaker.gce.serverGroupCommandBuilder.service
         credentials: serverGroup.account,
         loadBalancers: extractLoadBalancers(serverGroup.asg),
         loadBalancingPolicy: _.cloneDeep(serverGroup.loadBalancingPolicy),
+        backendServiceMetadata: serverGroup.asg['backend-service-names'],
         securityGroups: serverGroup.securityGroups,
         region: serverGroup.region,
         capacity: {

--- a/app/scripts/modules/google/serverGroup/configure/wizard/cloneServerGroup.gce.controller.js
+++ b/app/scripts/modules/google/serverGroup/configure/wizard/cloneServerGroup.gce.controller.js
@@ -95,7 +95,8 @@ module.exports = angular.module('spinnaker.serverGroup.configure.gce.cloneServer
           .config({ scope: $scope, form: 'form'})
           .register({ page: 'location', subForm: 'basicSettings' })
           .register({ page: 'capacity', subForm: 'capacitySubForm' })
-          .register({ page: 'zones', subForm: 'zonesSubForm' });
+          .register({ page: 'zones', subForm: 'zonesSubForm' })
+          .register({ page: 'load-balancers', subForm: 'loadBalancerSubForm'});
       });
     }
 

--- a/app/scripts/modules/google/serverGroup/configure/wizard/loadBalancers/elSevenOptions/backendServiceSelector.component.html
+++ b/app/scripts/modules/google/serverGroup/configure/wizard/loadBalancers/elSevenOptions/backendServiceSelector.component.html
@@ -5,6 +5,7 @@
   <div class="col-md-8">
     <ui-select multiple
                nested
+               required
                ng-model="$ctrl.command.backendServices[$ctrl.loadBalancerName]"
                class="form-control input-sm">
       <ui-select-match>{{$item}}</ui-select-match>

--- a/app/scripts/modules/google/serverGroup/configure/wizard/loadBalancers/loadBalancers.html
+++ b/app/scripts/modules/google/serverGroup/configure/wizard/loadBalancers/loadBalancers.html
@@ -1,3 +1,5 @@
-<div>
-  <gce-server-group-load-balancer-selector command="command"></gce-server-group-load-balancer-selector>
-</div>
+<ng-form name="loadBalancerSubForm">
+  <div>
+    <gce-server-group-load-balancer-selector command="command"></gce-server-group-load-balancer-selector>
+  </div>
+</ng-form>

--- a/app/scripts/modules/google/serverGroup/configure/wizard/loadBalancingPolicy/loadBalancingPolicySelector.component.html
+++ b/app/scripts/modules/google/serverGroup/configure/wizard/loadBalancingPolicy/loadBalancingPolicySelector.component.html
@@ -6,13 +6,14 @@
       </div>
       <div class="col-md-2"><input type="number"
                                    name="listeningPort"
+                                   required
                                    class="form-control input-sm"
                                    ng-model="$ctrl.command.loadBalancingPolicy.listeningPort"
                                    max="{{ $ctrl.maxPort }}"
                                    min="1"/></div>
       <div class="col-md-4 error-message"
            ng-if="loadBalancingPolicySubForm.listeningPort.$error.min || loadBalancingPolicySubForm.listeningPort.$error.max">
-        Must be between 0 and {{ $ctrl.maxPort }}.
+        Must be between 1 and {{ $ctrl.maxPort }}.
       </div>
     </div>
   </collapsible-section>
@@ -20,6 +21,7 @@
     <div class="form-group">
       <div class="col-md-5 sm-label-right">
         <b>Balancing Mode</b>
+        <help-field key="gce.serverGroup.loadBalancingPolicy.balancingMode"></help-field>
       </div>
       <div class="col-md-3">
         <ui-select ng-model="$ctrl.command.loadBalancingPolicy.balancingMode" class="form-control input-sm" required>
@@ -38,6 +40,7 @@
         </div>
         <div class="col-md-2"><input type="number"
                                      name="maxUtilization"
+                                     required
                                      class="form-control input-sm"
                                      ng-model="$ctrl.maxUtilizationView"
                                      ng-init="$ctrl.setView('maxUtilizationView', $ctrl.command.loadBalancingPolicy.maxUtilization)"
@@ -73,6 +76,7 @@
       </div>
       <div class="col-md-2"><input type="number"
                                    name="capacityScaler"
+                                   required
                                    class="form-control input-sm"
                                    ng-model="$ctrl.capacityScalerView"
                                    ng-init="$ctrl.setView('capacityScalerView', $ctrl.command.loadBalancingPolicy.capacityScaler)"

--- a/app/scripts/modules/google/serverGroup/configure/wizard/serverGroupWizard.html
+++ b/app/scripts/modules/google/serverGroup/configure/wizard/serverGroupWizard.html
@@ -10,7 +10,7 @@
       <v2-wizard-page key="location" label="Basic Settings" mark-complete-on-view="false">
         <ng-include src="pages.basicSettings"></ng-include>
       </v2-wizard-page>
-      <v2-wizard-page key="load-balancers" label="Load Balancers" done="true">
+      <v2-wizard-page key="load-balancers" label="Load Balancers" mark-complete-on-view="false">
         <ng-include src="pages.loadBalancers"></ng-include>
       </v2-wizard-page>
       <v2-wizard-page key="security-groups" label="Security Groups" done="true">

--- a/app/scripts/modules/openstack/loadBalancer/loadBalancerSelectField.directive.js
+++ b/app/scripts/modules/openstack/loadBalancer/loadBalancerSelectField.directive.js
@@ -7,7 +7,7 @@ module.exports = angular.module('spinnaker.openstack.loadBalancer.loadBalancerSe
   require('../../core/loadBalancer/loadBalancer.read.service.js'),
   require('../common/selectField.component.js')
 ])
-  .directive('osLoadBalancerSelectField', function (_, loadBalancerReader, cacheInitializer, infrastructureCaches, $rootScope) {
+  .directive('osLoadBalancerSelectField', function (_, loadBalancerReader) {
     return {
       restrict: 'E',
       templateUrl: require('../common/cacheBackedSelectField.template.html'),


### PR DESCRIPTION
@jtk54 please review

- makes backend service, port name mapping, and capacity metrics required in the server group wizard.

- disables deregistering from load balancer if server group is attached to an l7 load balancer.