### PR TITLE
(core) add tooltip to global search

### DIFF
--- a/app/scripts/modules/core/search/global/globalSearch.controller.js
+++ b/app/scripts/modules/core/search/global/globalSearch.controller.js
@@ -12,11 +12,13 @@ module.exports = angular.module('spinnaker.core.search.global.controller', [
   require('../../history/recentHistory.service.js'),
 ])
   .controller('GlobalSearchCtrl', function($scope, $element, infrastructureSearchService, recentHistoryService,
-                                           $stateParams, _, $, $log, clusterFilterService, $analytics) {
+                                           $stateParams, _, $, $log, clusterFilterService, $analytics, $sce) {
     var ctrl = this;
     var search = infrastructureSearchService();
 
     $scope.showSearchResults = false;
+
+    ctrl.tooltip = $sce.trustAsHtml('Keyboard shortcut: <span class="keyboard-key">/</span>');
 
     function reset() {
       $scope.querying = false;

--- a/app/scripts/modules/core/search/global/globalSearch.directive.html
+++ b/app/scripts/modules/core/search/global/globalSearch.directive.html
@@ -12,7 +12,7 @@
                ng-paste="ctrl.dispatchQueryInput($event)"
                ng-cut="ctrl.dispatchQueryInput($event)"
           />
-        <span class="glyphicon glyphicon-search form-control-feedback"></span>
+        <span class="glyphicon glyphicon-search form-control-feedback" uib-tooltip-html="ctrl.tooltip" tooltip-placement="right"></span>
       </div>
     </div>
   </form>

--- a/app/scripts/modules/core/search/global/globalSearch.less
+++ b/app/scripts/modules/core/search/global/globalSearch.less
@@ -50,6 +50,9 @@
       }
     }
   }
+  .glyphicon-search {
+    pointer-events: initial;
+  }
 }
 
 .global-search-header {


### PR DESCRIPTION
We had this long ago, but it stopped working with some update and we never restored it. I am guessing the vast majority of users don't know you can just type `/` to get to the global search...
<img width="331" alt="screen shot 2016-08-09 at 1 03 32 pm" src="https://cloud.githubusercontent.com/assets/73450/17531680/cd503c24-5e31-11e6-8f7c-4842dc03bbae.png">
