### PR TITLE
Expose Global ACA Dataset & Add email recipiants for Canary Stages

### DIFF
--- a/app/scripts/modules/core/help/helpContents.js
+++ b/app/scripts/modules/core/help/helpContents.js
@@ -253,6 +253,8 @@ module.exports = angular.module('spinnaker.core.help.contents', [])
     'pipeline.config.canary.baselineVersion': '<p>The Canary stage will inspect the specified cluster to determine which version to deploy as the baseline in each cluster pair.</p>',
     'pipeline.config.canary.lookback':'<p>By default ACA will look at the entire duration of the canary for its analysis. Setting a look-back duration limits the number of minutes that the canary will use for it\'s analysis report.<br> <b>Useful for long running canaries that span multiple days.</b></p>',
     'pipeline.config.canary.continueOnUnhealthy':'<p>Continue the pipeline if the ACA comes back as <b>UNHEALTHY</b></p>',
+    'pipeline.config.canary.watchers': '<p>Comma separated list of emails to receive notifications of canary events.</p>',
+    'pipeline.config.canary.useGlobalDataset': '<p>Uses the global atlas dataset instead of the region specific dataset for ACA</p>',
 
     'pipeline.config.cron.expression': '<strong>Format (Year is optional)</strong><p><samp>Seconds  Minutes  Hour  DayOfMonth  Month  DayOfWeek  (Year)</samp></p>' +
     '<p><strong>Example: every 30 minutes</strong></p><samp>0 0/30 * * * ?</samp>' +

--- a/app/scripts/modules/netflix/pipeline/stage/acaTask/acaTaskStage.html
+++ b/app/scripts/modules/netflix/pipeline/stage/acaTask/acaTaskStage.html
@@ -73,6 +73,14 @@
 
   <div class="checkbox col-md-offset-1">
     <label>
+      <input type="checkbox" ng-model="stage.canary.canaryConfig.canaryAnalysisConfig.useGlobalDataset"/>
+      <b>Use Global Atlas Dataset</b>
+      <help-field key="pipeline.config.canary.useGlobalDataset"></help-field>
+    </label>
+  </div>
+
+  <div class="checkbox col-md-offset-1">
+    <label>
       <input type="checkbox" ng-model="stage.canary.canaryConfig.canaryAnalysisConfig.useLookback"/>
       <b>Use Look-back</b>
       <help-field key="pipeline.config.canary.lookback"></help-field>
@@ -105,6 +113,16 @@
            class="form-control input-sm" />
   </stage-config-field>
 
+  <h5>Watchers</h5>
+  <div class="horizontal-rule"></div>
+  <stage-config-field
+    help-key="pipeline.config.canary.watchers"
+    ng-keyup="acaTaskStageCtrl.updateWatchersList()"
+    ng-paste="acaTaskStageCtrl.updateWatchersList()"
+    label="Emails">
+    <textarea ng-model="acaTaskStageCtrl.recipients"
+           class="form-control input-sm" ></textarea>
+  </stage-config-field>
 
   <h5>Metric Scope<help-field key="pipeline.config.canary.baselineVersion"></help-field></h5>
   <div class="horizontal-rule"></div>

--- a/app/scripts/modules/netflix/pipeline/stage/canary/canaryStage.html
+++ b/app/scripts/modules/netflix/pipeline/stage/canary/canaryStage.html
@@ -107,6 +107,14 @@
 
   <div class="checkbox col-md-offset-1">
     <label>
+      <input type="checkbox" ng-model="stage.canary.canaryConfig.canaryAnalysisConfig.useGlobalDataset"/>
+      <b>Use Global Atlas Dataset</b>
+      <help-field key="pipeline.config.canary.useGlobalDataset"></help-field>
+    </label>
+  </div>
+
+  <div class="checkbox col-md-offset-1">
+    <label>
       <input type="checkbox" ng-model="stage.canary.canaryConfig.canaryAnalysisConfig.useLookback"/>
       <b>Use Look-back</b>
       <help-field key="pipeline.config.canary.lookback"></help-field>
@@ -137,6 +145,17 @@
   <stage-config-field label="Email">
     <input type="email" required ng-model="stage.canary.owner"
            class="form-control input-sm" />
+  </stage-config-field>
+
+  <h5>Watchers</h5>
+  <div class="horizontal-rule"></div>
+  <stage-config-field
+    help-key="pipeline.config.canary.watchers"
+    ng-keyup="canaryStageCtrl.updateWatchersList()"
+    ng-paste="canaryStageCtrl.updateWatchersList()"
+    label="Emails">
+    <textarea ng-model="canaryStageCtrl.recipients"
+              class="form-control input-sm" ></textarea>
   </stage-config-field>
 
   <h5>Baseline Version <help-field key="pipeline.config.canary.baselineVersion"></help-field></h5>

--- a/app/scripts/modules/netflix/pipeline/stage/canary/canaryStage.js
+++ b/app/scripts/modules/netflix/pipeline/stage/canary/canaryStage.js
@@ -47,11 +47,29 @@ module.exports = angular.module('spinnaker.netflix.pipeline.stage.canaryStage', 
     $scope.stage.canary.canaryConfig.canaryAnalysisConfig.notificationHours = $scope.stage.canary.canaryConfig.canaryAnalysisConfig.notificationHours || [];
     $scope.stage.canary.canaryConfig.canaryAnalysisConfig.useLookback = $scope.stage.canary.canaryConfig.canaryAnalysisConfig.useLookback || false;
     $scope.stage.canary.canaryConfig.canaryAnalysisConfig.lookbackMins = $scope.stage.canary.canaryConfig.canaryAnalysisConfig.lookbackMins || 0;
-
+    $scope.stage.canary.canaryConfig.canaryAnalysisConfig.useGlobalDataset = $scope.stage.canary.canaryConfig.canaryAnalysisConfig.useGlobalDataset || false;
     $scope.stage.canary.canaryConfig.actionsForUnhealthyCanary = $scope.stage.canary.canaryConfig.actionsForUnhealthyCanary || [
       {action: 'DISABLE'},
       {action: 'TERMINATE', delayBeforeActionInMins: 60}
     ];
+
+    this.recipients = $scope.stage.canary.watchers
+      ? angular.isArray($scope.stage.canary.watchers)
+        ? $scope.stage.canary.watchers.join(', ')
+        : $scope.stage.canary.watchers
+      : '';
+
+  
+    this.updateWatchersList = () => {
+      if(this.recipients.indexOf('${') > -1) { //check if SpEL; we don't want to convert to array
+        $scope.stage.canary.watchers = this.recipients;
+      } else {
+        $scope.stage.canary.watchers = [];
+        this.recipients.split(',').forEach((email) => {
+          $scope.stage.canary.watchers.push(email.trim());
+        });
+      }
+    };
 
     this.terminateUnhealthyCanaryEnabled = function (isEnabled) {
       if (isEnabled === true) {


### PR DESCRIPTION
- SPIN-1920: Expose option to select the global Atlas dataset for both ACATaskStage and CanaryStage.
- SPIN-1939: Add email recipients to ACATask and Canary Stages, allows for comma seperated list of emails or a SpEL

@anotherchrisberry PTAL