### PR TITLE
(aws) send empty string for subnet type when cloning into Classic

### DIFF
--- a/app/scripts/modules/amazon/serverGroup/serverGroup.transformer.js
+++ b/app/scripts/modules/amazon/serverGroup/serverGroup.transformer.js
@@ -91,7 +91,7 @@ module.exports = angular.module('spinnaker.aws.serverGroup.transformer', [
       delete command.vpcId;
 
       if (!command.subnetType) {
-        delete command.subnetType;
+        command.subnetType = '';
       }
       return command;
     }

--- a/app/scripts/modules/amazon/serverGroup/serverGroup.transformer.spec.js
+++ b/app/scripts/modules/amazon/serverGroup/serverGroup.transformer.spec.js
@@ -52,7 +52,7 @@ describe('awsServerGroupTransformer', function () {
 
   describe('command transforms', function () {
 
-    it('removes subnetType property when null', function () {
+    it('sets subnetType property to empty string when null', function () {
       var command = {
         viewState: {
           mode: 'create',
@@ -64,7 +64,7 @@ describe('awsServerGroupTransformer', function () {
       };
 
       var transformed = transformer.convertServerGroupCommandToDeployConfiguration(command);
-      expect(transformed.subnetType).toBe(undefined);
+      expect(transformed.subnetType).toBe('');
 
       command.subnetType = 'internal';
       transformed = transformer.convertServerGroupCommandToDeployConfiguration(command);


### PR DESCRIPTION
First, let me say I am not loving this.

When cloning an ASG that's in a VPC, if the user sets the subnet type to "None (EC2 Classic)", we remove the `subnetType` field altogether.

However, when Clouddriver gets to this line:
https://github.com/spinnaker/clouddriver/blob/master/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/CopyLastAsgAtomicOperation.groovy#L138
```groovy
if (ancestorAsg.VPCZoneIdentifier) {
  task.updateStatus BASE_PHASE, "Looking up subnet type..."
  newDescription.subnetType = description.subnetType != null ? description.subnetType : getPurposeForSubnet(sourceRegion, ancestorAsg.VPCZoneIdentifier.tokenize(',').getAt(0))
  task.updateStatus BASE_PHASE, "Found: ${newDescription.subnetType}."
}
```
it replaces the intentionally missing subnet type with the one from the ancestor. By passing in an empty string, we don't overwrite the field.

The rest of the code in `BasicAmazonDeployHandler`, `AutoScalingWorker`, `LaunchConfigurationBuilder` all uses groovy truth to check for subnetType, so it ends up "working as expected".

@cfieber WDYT? I think this is ugly and may burn us down the road. Then again, it took ~2 years for this edge case to appear, so maybe not...
