### PR TITLE
(core) move logged out message to modal

### DIFF
--- a/app/scripts/modules/core/authentication/loggedOut.modal.controller.js
+++ b/app/scripts/modules/core/authentication/loggedOut.modal.controller.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const angular = require('angular');
+
+require('./loggedOut.modal.less');
+
+module.exports = angular
+  .module('spinnaker.core.authentication.loggedOut.modal.controller', [])
+  .controller('LoggedOutModalCtrl', function ($window) {
+    this.login = () => {
+      $window.location.reload();
+      return true;
+    };
+  });

--- a/app/scripts/modules/core/authentication/loggedOut.modal.html
+++ b/app/scripts/modules/core/authentication/loggedOut.modal.html
@@ -1,0 +1,18 @@
+<div modal-page class="modal-logged-out">
+  <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+  <svg width="162px" height="143px" viewBox="0 0 162 143">
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+      <g transform="translate(3.000000, 3.000000)">
+        <polygon id="Fill-1" fill="#E8AE2F" points="0 138 81 0 156 138"></polygon>
+        <polygon id="Stroke-3" stroke="#000000" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" points="0 138 81 0 156 138"></polygon>
+      </g>
+    </g>
+    <div class="glyphicon glyphicon-hourglass"></div>
+  </svg>
+  <h3>You have been logged out.</h3>
+  <p>Please click below or refresh your browser to log back in.</p>
+  <p>
+    <button class="btn btn-primary" ng-click="ctrl.login()">Refresh and log me back in</button>
+  </p>
+</div>

--- a/app/scripts/modules/core/authentication/loggedOut.modal.less
+++ b/app/scripts/modules/core/authentication/loggedOut.modal.less
@@ -1,0 +1,20 @@
+.modal-logged-out {
+  text-align: center;
+  padding: 30px 60px;
+
+  h3 {
+    margin: 30px 0;
+  }
+
+  p {
+    margin-bottom: 30px;
+  }
+
+  .glyphicon-hourglass {
+    display: block;
+    top: -83px;
+    left: 2px;
+    height: 0;
+    font-size: 62px;
+  }
+}

--- a/app/scripts/modules/core/modal/modals.less
+++ b/app/scripts/modules/core/modal/modals.less
@@ -24,6 +24,12 @@
   }
 }
 
+.modal-squared {
+  .modal-content {
+    border-radius: 0;
+  }
+}
+
 .modal-header {
   background-color: #f5f5f5;
   h3 {


### PR DESCRIPTION
Getting pretty serious about telling people they've been logged out - moving from a top banner to a modal:
![screen shot 2016-08-11 at 1 43 32 pm](https://cloud.githubusercontent.com/assets/73450/17604252/dc3fc40e-5fc9-11e6-8a98-ea32b45e5b2a.png)

@danielpeach @duftler any concerns with this change?