### PR TITLE
(aws) retain vpcId on ingress rules when editing

### DIFF
--- a/app/scripts/modules/amazon/securityGroup/configure/ingressRuleGroupSelector.component.js
+++ b/app/scripts/modules/amazon/securityGroup/configure/ingressRuleGroupSelector.component.js
@@ -81,7 +81,7 @@ module.exports = angular
       };
 
       let reconcileRuleVpc = (filtered) => {
-        if (this.rule.vpcId) {
+        if (this.rule.vpcId && !this.rule.existing) {
           if (!this.securityGroup.vpcId) {
             this.rule.vpcId = null;
             this.rule.name = null;


### PR DESCRIPTION
If the rule already exists, don't try to update the `vpcId` field, since that rule may be from another account, and that account might not be managed by Spinnaker, so we don't know how to reconcile the `vpcId`