### PR TITLE
(aws) guard against clusters already in target when migrating

### DIFF
--- a/app/scripts/modules/netflix/migrator/migrator.service.js
+++ b/app/scripts/modules/netflix/migrator/migrator.service.js
@@ -41,8 +41,8 @@ module.exports = angular
         let region = Object.keys(clusterResult.cluster.availabilityZones)[0];
         clusterResult.region = region;
         regions.push(region);
-        clusterResult.securityGroupMigrations.forEach(m => m.created.forEach(c => c.region = region));
-        clusterResult.loadBalancerMigrations.forEach(m => {
+        (clusterResult.securityGroupMigrations || []).forEach(m => m.created.forEach(c => c.region = region));
+        (clusterResult.loadBalancerMigrations || []).forEach(m => {
           m.accountName = clusterResult.cluster.account;
           m.region = region;
           m.securityGroups.forEach(s => s.created.forEach(c => c.region = region));


### PR DESCRIPTION
If they're already in the target, they won't have any `*Migrations` fields, but let's not blow up the migration monitoring.