### PR TITLE
(core) return providers in alphabetical order

### DIFF
--- a/app/scripts/modules/core/account/account.service.js
+++ b/app/scripts/modules/core/account/account.service.js
@@ -71,9 +71,9 @@ module.exports = angular.module('spinnaker.core.account.service', [
             settings.defaultProviders ?
               settings.defaultProviders :
               availableRegisteredProviders;
-          return _.intersection(availableRegisteredProviders, appProviders);
+          return _.intersection(availableRegisteredProviders, appProviders).sort();
         }
-        return availableRegisteredProviders;
+        return availableRegisteredProviders.sort();
       });
     };
 

--- a/app/scripts/modules/core/account/account.service.spec.js
+++ b/app/scripts/modules/core/account/account.service.spec.js
@@ -112,7 +112,7 @@ describe('Service: accountService ', function () {
 
     it('should list all providers when no application provided', function () {
 
-      let test = (result) => expect(result).toEqual(['aws', 'gce', 'cf']);
+      let test = (result) => expect(result).toEqual(['aws', 'cf', 'gce']);
 
       accountService.listProviders().then(test);
 
@@ -132,7 +132,7 @@ describe('Service: accountService ', function () {
     it('should fall back to the defaultProviders if none configured for the application', function () {
       let application = { attributes: {} };
 
-      let test = (result) => expect(result).toEqual(['gce', 'cf']);
+      let test = (result) => expect(result).toEqual(['cf', 'gce']);
 
       settings.defaultProviders = ['gce', 'cf'];
 
@@ -144,7 +144,7 @@ describe('Service: accountService ', function () {
     it('should return the intersection of those configured for the application and those available from the server', function () {
       let application = { attributes: { cloudProviders: 'gce,cf,unicron' } };
 
-      let test = (result) => expect(result).toEqual(['gce', 'cf']);
+      let test = (result) => expect(result).toEqual(['cf', 'gce']);
 
       settings.defaultProviders = ['aws'];
 
@@ -168,7 +168,7 @@ describe('Service: accountService ', function () {
     it('should fall back to all registered available providers if no defaults configured and none configured on app', function () {
       let application = { attributes: {} };
 
-      let test = (result) => expect(result).toEqual(['aws', 'gce', 'cf']);
+      let test = (result) => expect(result).toEqual(['aws', 'cf', 'gce']);
 
       delete settings.defaultProviders;
 

--- a/app/scripts/modules/core/cloudProvider/providerSelection/providerSelector.directive.js
+++ b/app/scripts/modules/core/cloudProvider/providerSelection/providerSelector.directive.js
@@ -19,7 +19,7 @@ module.exports = angular.module('spinnaker.providerSelection.directive', [
       templateUrl: require('./providerSelector.html'),
       link: function(scope) {
         scope.initialized = false;
-        var getProviderList = scope.providers ? $q.when(scope.providers) : accountService.listProviders();
+        var getProviderList = scope.providers ? $q.when(scope.providers.sort()) : accountService.listProviders();
         getProviderList.then(function(providers) {
           scope.initialized = true;
           if (!providers.length) {


### PR DESCRIPTION
for @tomaslin 