### PR TITLE
(core) guard against missing triggers on nextRun tag

### DIFF
--- a/app/scripts/modules/core/delivery/triggers/nextRun.component.js
+++ b/app/scripts/modules/core/delivery/triggers/nextRun.component.js
@@ -19,7 +19,7 @@ module.exports = angular
         if (!this.pipeline) {
           return;
         }
-        let crons = this.pipeline.triggers.filter(t => t.type === 'cron' && t.enabled);
+        let crons = (this.pipeline.triggers || []).filter(t => t.type === 'cron' && t.enabled);
         let nextTimes = [];
         crons.forEach(cron => {
           let parts = cron.cronExpression.split(' ');


### PR DESCRIPTION
In this cruel world, there are pipelines configured without `triggers`