### PR TITLE
guard against undefined while loading docker image

### DIFF
--- a/app/scripts/modules/core/pipeline/config/triggers/docker/dockerTrigger.module.js
+++ b/app/scripts/modules/core/pipeline/config/triggers/docker/dockerTrigger.module.js
@@ -87,6 +87,9 @@ module.exports = angular.module('spinnaker.core.pipeline.trigger.docker', [
         }, {});
         $scope.accounts = Object.keys($scope.accountMap);
         $scope.organizationMap = images.reduce((map, image) => {
+          if (!image.repository) {
+            return map;
+          }
           let parts = image.repository.split('/');
           parts.pop();
           let key = `${image.account}/${parts.join('/')}`;


### PR DESCRIPTION
noticed this issue when I was using docker registry as trigger. The docker 'organizations' were showing fine, but the 'image' drop down showed nothing. It was because the returned list contains {} elements. This fixes the issue. 