### PR TITLE
provider/cf: Allow resizing to include memory and disk

### DIFF
--- a/app/scripts/modules/cloudfoundry/pipeline/stages/resizeAsg/cfResizeAsgStage.js
+++ b/app/scripts/modules/cloudfoundry/pipeline/stages/resizeAsg/cfResizeAsgStage.js
@@ -50,18 +50,6 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.cf.resizeAsgStage
 
     $scope.scaleActions = [
       {
-        label: 'Scale Up',
-        val: 'scale_up',
-      },
-      {
-        label: 'Scale Down',
-        val: 'scale_down'
-      },
-      {
-        label: 'Scale to Cluster Size',
-        val: 'scale_to_cluster'
-      },
-      {
         label: 'Scale to Exact Size',
         val: 'scale_exact'
       },
@@ -83,9 +71,6 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.cf.resizeAsgStage
     stage.target = stage.target || $scope.resizeTargets[0].val;
     stage.action = stage.action || $scope.scaleActions[0].val;
     stage.resizeType = stage.resizeType || $scope.resizeTypes[0].val;
-    if (stage.resizeType === 'exact') {
-      stage.action = 'scale_exact';
-    }
     stage.cloudProvider = 'cf';
 
     if (!stage.credentials && $scope.application.defaultCredentials) {

--- a/app/scripts/modules/cloudfoundry/pipeline/stages/resizeAsg/resizeAsgStage.html
+++ b/app/scripts/modules/cloudfoundry/pipeline/stages/resizeAsg/resizeAsgStage.html
@@ -12,10 +12,6 @@
     <stage-config-field label="Account">
       <account-select-field component="stage" field="credentials" accounts="accounts" provider="'cf'" on-change="resizeAsgStageCtrl.accountUpdated()" required></account-select-field>
     </stage-config-field>
-    <stage-config-field label="Regions">
-      <p ng-if="!stage.credentials" class="form-control-static">(Select an Account)</p>
-      <checklist ng-if="stage.credentials" items="regions" model="stage.regions" inline="true" include-select-all-button="true"></checklist>
-    </stage-config-field>
     <stage-config-field label="Target">
       <target-select model="stage" options="resizeTargets"></target-select>
     </stage-config-field>
@@ -28,64 +24,27 @@
         <option>Select an action...</option>
       </select>
     </stage-config-field>
-    <div ng-if="stage.action !== 'scale_exact'">
-      <stage-config-field label="{{stage.action === 'scale_to_cluster' ? 'Additional Capacity' : 'Type'}}">
-          <select class="form-control input-sm"
-                  required
-                  ng-model="stage.resizeType"
-                  ng-change="resizeAsgStageCtrl.updateResizeType()"
-                  ng-options="t.val as t.label for t in resizeTypes">
-            <option>Select an action...</option>
-          </select>
-      </stage-config-field>
-      <div class="form-group" ng-if="stage.resizeType === 'pct'">
-        <div class="col-md-9 col-md-offset-3">
-          <label class="col-md-2 sm-label-right" style="font-size:12px;line-height:13px;margin-left:0;padding-left:0">Resize Percentage</label>
-          <div class="col-md-2">
-            <input type="number" min="0" ng-model="stage.scalePct"
-                   class="form-control input-sm" />
-          </div>
-        </div>
-        <div class="col-md-9 col-md-offset-3">
-          <em class="subinput-note">This is the percentage by which the target server group's capacity will be increased</em>
-        </div>
-
-      </div>
-      <div class="form-group" ng-if="stage.resizeType === 'incr'">
-        <div class="col-md-9 col-md-offset-3">
-          <label class="col-md-2 sm-label-right" style="margin-left:0;padding-left:0">Resize-by Amount</label>
-          <div class="col-md-2">
-            <input type="number" min="0" ng-model="stage.scaleNum"
-                   class="form-control input-sm" />
-          </div>
-        </div>
-
-        <div class="col-md-9 col-md-offset-3">
-          <em class="subinput-note">This is the exact amount by which the target server group's capacity will be increased</em>
-        </div>
-      </div>
-    </div>
     <div class="form-group" ng-if="stage.action === 'scale_exact'">
       <div class="col-md-9 col-md-offset-3 small">
         <div class="col-md-9">
-          <div class="col-md-2 col-md-offset-3">Min</div>
-          <div class="col-md-2">Max</div>
-          <div class="col-md-2">Desired</div>
+          <div class="col-md-2 col-md-offset-3">Instances</div>
+          <div class="col-md-2">Memory (MB)</div>
+          <div class="col-md-2">Disk Limit (MB)</div>
         </div>
       </div>
       <div class="col-md-9 col-md-offset-3">
         <label class="col-md-2 sm-label-right small" style="margin-left:0;padding-left:0">Match Capacity</label>
         <div class="col-md-9">
           <div class="col-md-2">
-            <input type="number" ng-model="stage.capacity.min"
+            <input type="number" ng-model="stage.newSize"
                    class="form-control input-sm" />
           </div>
           <div class="col-md-2">
-            <input type="number" ng-model="stage.capacity.max"
+            <input type="number" ng-model="stage.memory"
                    class="form-control input-sm" />
           </div>
           <div class="col-md-2">
-            <input type="number" ng-model="stage.capacity.desired"
+            <input type="number" ng-model="stage.disk"
                    class="form-control input-sm" />
           </div>
         </div>

--- a/app/scripts/modules/cloudfoundry/serverGroup/details/resize/resizeServerGroup.controller.js
+++ b/app/scripts/modules/cloudfoundry/serverGroup/details/resize/resizeServerGroup.controller.js
@@ -10,19 +10,16 @@ module.exports = angular.module('spinnaker.cf.serverGroup.details.resize.control
   .controller('cfResizeServerGroupCtrl', function($scope, $uibModalInstance, serverGroupWriter, taskMonitorService,
                                                    application, serverGroup) {
 
-    // TODO: Rip out min/max and just use desired capacity.
     $scope.serverGroup = serverGroup;
-    $scope.currentSize = {
-      min: serverGroup.asg.minSize,
-      max: serverGroup.asg.maxSize,
-      desired: serverGroup.asg.desiredCapacity,
-      newSize: null
-    };
 
     $scope.verification = {};
 
-    $scope.command = angular.copy($scope.currentSize);
-    $scope.command.advancedMode = serverGroup.asg.minSize !== serverGroup.asg.maxSize;
+    $scope.command = {
+      newSize: serverGroup.asg.desiredCapacity,
+      memory: serverGroup.memory,
+      disk: serverGroup.disk == 0 ? 1024 : serverGroup.disk,
+    };
+
 
     if (application && application.attributes) {
       if (application.attributes.platformHealthOnly) {
@@ -37,25 +34,24 @@ module.exports = angular.module('spinnaker.cf.serverGroup.details.resize.control
       if (!$scope.verification.verified) {
         return false;
       }
-      return command.advancedMode ?
-        command.min <= command.max && command.desired >= command.min && command.desired <= command.max :
-        command.newSize !== null;
+      return command.newSize !== null;
     };
 
     this.resize = function () {
       if (!this.isValid()) {
         return;
       }
-      var capacity = { min: $scope.command.min, max: $scope.command.max, desired: $scope.command.desired };
-      if (!$scope.command.advancedMode) {
-        capacity = { min: $scope.command.newSize, max: $scope.command.newSize, desired: $scope.command.newSize };
-      }
+      var newSize = $scope.command.newSize;
+      var memory = $scope.command.memory;
+      var disk = $scope.command.disk;
 
       var submitMethod = function() {
         return serverGroupWriter.resizeServerGroup(serverGroup, application, {
-          capacity: capacity,
+          capacity: { min: newSize, max: newSize, desired: newSize },
           serverGroupName: serverGroup.name,
-          targetSize: capacity.desired, // TODO(GLT): Unify on this or capacity
+          targetSize: newSize, // TODO(GLT): Unify on this or capacity
+          memory: memory,
+          disk: disk,
           region: serverGroup.region,
           interestingHealthProviderNames: $scope.command.interestingHealthProviderNames,
         });

--- a/app/scripts/modules/cloudfoundry/serverGroup/details/resize/resizeServerGroup.html
+++ b/app/scripts/modules/cloudfoundry/serverGroup/details/resize/resizeServerGroup.html
@@ -6,87 +6,78 @@
       <h3>Resize {{serverGroup.name}}</h3>
     </div>
     <div class="modal-body container-fluid form-horizontal">
-      <div ng-if="command.advancedMode">
-        <div class="form-group">
-          <div class="col-md-12">
-            <p>Sets up auto-scaling for this server group.</p>
-            <p>To disable auto-scaling, use the <a href ng-click="command.advancedMode = false">Simple Mode</a>.</p>
-          </div>
+      <div class="form-group">
+        <div class="col-md-12">
+          <p>Sets desired number of instances, memory, and disk limit.</p>
         </div>
-        <div class="form-group">
-          <div class="col-md-2 col-md-offset-3"><b>Min</b></div>
-          <div class="col-md-2"><b>Max</b></div>
-          <div class="col-md-2"><b>Desired</b></div>
-        </div>
-        <div class="form-group">
-          <div class="col-md-3 text-right"><b>Current</b></div>
-          <div class="col-md-2"><b>{{currentSize.min}}</b></div>
-          <div class="col-md-2"><b>{{currentSize.max}}</b></div>
-          <div class="col-md-2"><b>{{currentSize.desired}}</b></div>
-        </div>
-        <div class="form-group">
-          <div class="col-md-3 text-right"><b>New</b></div>
-          <div class="col-md-2"><input type="number"
-                                       class="form-control input-sm"
-                                       ng-model="command.min"
-                                       min="0"
-                                       required
-                                       max="{{command.max}}"/></div>
-          <div class="col-md-2"><input type="number"
-                                       class="form-control input-sm"
-                                       ng-model="command.max"
-                                       required
-                                       min="{{command.min}}"/></div>
-          <div class="col-md-2"><input type="number"
-                                       class="form-control input-sm"
-                                       ng-model="command.desired"
-                                       required
-                                       min="{{command.min}}"
-                                       max="{{command.max}}"/></div>
-        </div>
-
       </div>
-      <div ng-if="!command.advancedMode">
-        <div class="form-group">
-          <div class="col-md-12">
-            <p>Sets min, max, and desired instance counts to the same value.</p>
-            <p> To allow true auto-scaling, use the <a href ng-click="command.advancedMode = true">Advanced Mode</a>.</p>
-          </div>
+      <div class="form-group">
+        <div class="col-md-12">
+          <h4>Current size:</h4>
         </div>
-        <div class="form-group">
-          <div class="col-md-12">
-            <h4>Current size:</h4>
-          </div>
+      </div>
+      <div class="form-group form-inline">
+        <div class="col-md-11 col-md-offset-1">
+          <label>
+            <input type="number"
+                   class="form-control input-sm"
+                   ng-model="serverGroup.asg.desiredCapacity"
+                   style="width: 60px"
+                   readonly/>
+            instance<span ng-if="serverGroup.asg.desiredCapacity != 1">s</span>,
+          </label>
+          <label>
+            <input type="number"
+                   class="form-control input-sm"
+                   ng-model="serverGroup.memory"
+                   style="width: 60px"
+                   readonly/>
+            MB memory, and
+          </label>
+          <label>
+            <input type="number"
+                   class="form-control input-sm"
+                   ng-model="serverGroup.disk"
+                   style="width: 60px"
+                   readonly/>
+            MB disk limit
+          </label>
         </div>
-        <div class="form-group form-inline">
-          <div class="col-md-11 col-md-offset-1">
-            <label>
-              <input type="number"
-                     class="form-control input-sm"
-                     ng-model="currentSize.desired"
-                     style="width: 60px"
-                     readonly/>
-              instance<span ng-if="currentSize.desired > 1">s</span>
-            </label>
-          </div>
+      </div>
+      <div class="form-group">
+        <div class="col-md-12">
+          <h4>Resize to:</h4>
         </div>
-        <div class="form-group">
-          <div class="col-md-12">
-            <h4>Resize to:</h4>
-          </div>
-        </div>
-        <div class="form-group form-inline">
-          <div class="col-md-11 col-md-offset-1">
-            <label>
-              <input type="number"
-                     class="form-control input-sm highlight-pristine"
-                     ng-model="command.newSize"
-                     min="0"
-                     required
-                     style="width: 60px"/>
-              instances
-            </label>
-          </div>
+      </div>
+      <div class="form-group form-inline">
+        <div class="col-md-11 col-md-offset-1">
+          <label>
+            <input type="number"
+                   class="form-control input-sm highlight-pristine"
+                   ng-model="command.newSize"
+                   min="0"
+                   required
+                   style="width: 60px"/>
+            instance<span ng-if="command.newSize != 1">s</span>,
+          </label>
+          <label>
+            <input type="number"
+                   class="form-control input-sm highlight-pristine"
+                   ng-model="command.memory"
+                   min="0"
+                   required
+                   style="width: 60px"/>
+            MB memory, and
+          </label>
+          <label>
+            <input type="number"
+                   class="form-control input-sm highlight-pristine"
+                   ng-model="command.disk"
+                   min="0"
+                   required
+                   style="width: 60px"/>
+            MB disk limit
+          </label>
         </div>
       </div>
       <div class="row" ng-if="command.platformHealthOnlyShowOverride">

--- a/app/scripts/modules/cloudfoundry/serverGroup/details/serverGroupDetails.html
+++ b/app/scripts/modules/cloudfoundry/serverGroup/details/serverGroupDetails.html
@@ -114,24 +114,13 @@
     </collapsible-section>
     <collapsible-section heading="Size" expanded="true">
       <dl class="dl-horizontal"
-          ng-class="InsightFilterStateModel.filtersExpanded ? 'dl-narrow' : 'dl-wide'"
-          ng-if="serverGroup.asg.minSize === serverGroup.asg.maxSize">
-        <dt>Min/Max</dt>
-        <dd>{{serverGroup.asg.desiredCapacity}}</dd>
-        <dt>Current</dt>
-        <dd>{{serverGroup.instances.length}}</dd>
-      </dl>
-      <dl class="dl-horizontal"
-          ng-class="InsightFilterStateModel.filtersExpanded ? 'dl-narrow' : 'dl-wide'"
-          ng-if="serverGroup.asg.minSize !== serverGroup.asg.maxSize">
-        <dt>Min</dt>
-        <dd>{{serverGroup.asg.minSize}}</dd>
-        <dt>Desired</dt>
-        <dd>{{serverGroup.asg.desiredCapacity}}</dd>
-        <dt>Max</dt>
-        <dd>{{serverGroup.asg.maxSize}}</dd>
-        <dt>Current</dt>
-        <dd>{{serverGroup.instances.length}}</dd>
+          ng-class="InsightFilterStateModel.filtersExpanded ? 'dl-narrow' : 'dl-wide'">
+        <dt>Instances</dt>
+        <dd>{{serverGroup.nativeApplication.instances}}</dd>
+        <dt>Memory</dt>
+        <dd>{{serverGroup.memory}}</dd>
+        <dt>Disk Limit</dt>
+        <dd>{{serverGroup.disk}}</dd>
       </dl>
       <a href ng-click="ctrl.resizeServerGroup()">Resize Server Group</a>
     </collapsible-section>


### PR DESCRIPTION
Expand CF's "Resize" options (at both server group and inside Resize Server Group stage) to also support resizing memory and disk limit.

Depends on https://github.com/spinnaker/clouddriver/pull/910
Resolves: https://github.com/spring-cloud/spring-cloud-spinnaker/issues/55