### PR TITLE
SpEL autocomplete

### DIFF
--- a/app/scripts/modules/core/delivery/service/execution.service.js
+++ b/app/scripts/modules/core/delivery/service/execution.service.js
@@ -260,6 +260,18 @@ module.exports = angular.module('spinnaker.core.delivery.executions.service', [
       }
     }
 
+    function getLastExecutionForApplicationByConfigId(appName, configId) {
+      return getFilteredExecutions(appName, {}, 1 )
+        .then((executions) => {
+          return executions.filter((execution) => {
+            return execution.pipelineConfigId === configId;
+          });
+        })
+        .then((executionsByConfigId) => {
+          return executionsByConfigId[0];
+        });
+    }
+
     return {
       getExecutions: getExecutions,
       getExecution: getExecution,
@@ -276,5 +288,6 @@ module.exports = angular.module('spinnaker.core.delivery.executions.service', [
       getProjectExecutions: getProjectExecutions,
       addExecutionsToApplication: addExecutionsToApplication,
       updateExecution: updateExecution,
+      getLastExecutionForApplicationByConfigId: getLastExecutionForApplicationByConfigId,
     };
   });

--- a/app/scripts/modules/core/widgets/spelText/jsonListBuilder.js
+++ b/app/scripts/modules/core/widgets/spelText/jsonListBuilder.js
@@ -1,0 +1,65 @@
+'use strict';
+
+
+let angular = require('angular');
+
+module.exports = angular
+  .module('spinnaker.core.widget.jsonListBuilder', [])
+  .factory('jsonListBuilder', function() {
+
+    let convertJsonKeysToBracketedList = (json, ignoreList = []) => {
+      let stack = [];
+      let array = [];
+      let parentList = [];
+
+      stack.push(json);
+
+      while(stack.length !== 0) {
+        let node = stack.pop();
+        let keys = Object.keys(node);
+        let p = parentList.pop() || '';
+        processKeys(keys, node, parentList, p, stack, array, ignoreList);
+      }
+
+      return array;
+    };
+
+
+    let processKeys = (keys, node, parentList, parent, stack, array, ignoreList) => {
+      keys.forEach( (key) => {
+
+        let entry = isFinite(parseInt(key)) ? `${parent}[${parseInt(key)}]` : `${parent}['${key}']`;
+
+        if( !(angular.isObject(node[key]) || angular.isArray(node[key]) ) ) {
+
+
+          if ( !ignoreList.some( (ignoreItem) => {
+              let testerString = `[\'${ignoreItem}`;
+              return entry.substr(0, testerString.length) === testerString;
+            })) {
+
+            array.push(entry);
+
+          }
+        }
+
+        if(angular.isObject(node[key])) {
+          parentList.push(entry);
+          stack.push(node[key]);
+        }
+      });
+    };
+
+
+    let escapeForRegEx = (item) => {
+      if (item) {
+        return item.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&');
+      }
+    };
+
+
+    return {
+      convertJsonKeysToBracketedList: convertJsonKeysToBracketedList,
+      escapeForRegEx: escapeForRegEx
+    };
+  });

--- a/app/scripts/modules/core/widgets/spelText/jsonListBuilder.spec.js
+++ b/app/scripts/modules/core/widgets/spelText/jsonListBuilder.spec.js
@@ -1,0 +1,113 @@
+'use strict';
+
+describe('jsonListBuilder', function () {
+
+  let builder;
+
+  beforeEach(
+    window.module(
+      require('./jsonListBuilder')
+    )
+  );
+
+  beforeEach(
+    window.inject(function(jsonListBuilder) {
+      builder = jsonListBuilder;
+    })
+  );
+
+  describe('create a list with only the leaf keys', function () {
+    it('a simple json with one attribute', function () {
+      let json = { name: 'foo'};
+      let result = builder.convertJsonKeysToBracketedList(json);
+      expect(result).toEqual([`['name']`]);
+    });
+
+
+    it('a simple json with multiple attributes', function () {
+      let json = { name: 'foo', bar: 'baz'};
+      let result = builder.convertJsonKeysToBracketedList(json);
+      expect(result).toEqual([`['name']`, `['bar']`]);
+    });
+
+    it('nested objects', function () {
+      let json = { name: {foo: 'bar'}};
+      let result = builder.convertJsonKeysToBracketedList(json);
+      expect(result).toEqual([`['name']['foo']`]);
+    });
+
+    it('nested objects with multivalues', function () {
+      let json = { name: {foo: 'bar', baz: 2}};
+      let result = builder.convertJsonKeysToBracketedList(json);
+      expect(result).toEqual([`['name']['foo']`, `['name']['baz']`]);
+    });
+
+    it('deep nested objects', function () {
+      let json = { name: { baz: { context: {foo: 2}}}};
+      let result = builder.convertJsonKeysToBracketedList(json);
+      expect(result).toEqual([`['name']['baz']['context']['foo']`]);
+    });
+
+    it('deep nested objects with multivalues', function () {
+      let json = { name: { baz: { context: {foo: 2, boom: 'go'}}}};
+      let result = builder.convertJsonKeysToBracketedList(json);
+      expect(result).toEqual([ `['name']['baz']['context']['foo']`, `['name']['baz']['context']['boom']`]);
+    });
+
+    it('json with an array of strings', function () {
+      let json = { name: ['foo'] };
+      let result = builder.convertJsonKeysToBracketedList(json);
+      expect(result).toEqual([`['name'][0]`]);
+    });
+
+    it('json with an array of multiple strings', function () {
+      let json = { name: ['foo', 'bar'] };
+      let result = builder.convertJsonKeysToBracketedList(json);
+      expect(result).toEqual([`['name'][0]`, `['name'][1]`]);
+    });
+
+    it('json with an array of one object', function () {
+      let json = { name: [{foo: 2}] };
+      let result = builder.convertJsonKeysToBracketedList(json);
+      expect(result).toEqual([`['name'][0]['foo']`]);
+    });
+
+    it('json with an array of two object', function () {
+      let json = { name: [{foo: 2}, {foo:3}] };
+      let result = builder.convertJsonKeysToBracketedList(json);
+      expect(result).toEqual([`['name'][1]['foo']`, `['name'][0]['foo']`]);
+    });
+
+    it('json with dots in the key name', function () {
+      let json = { 'notification.type': 'foo', 'deploy.server.group': {'server.group.name': 'baz'} };
+      let result = builder.convertJsonKeysToBracketedList(json);
+      expect(result).toEqual([`['notification.type']`,`['deploy.server.group']['server.group.name']`]);
+    });
+
+  });
+
+  describe('create list with and exclude list', function () {
+    it('should exclude the top task node from the list', function () {
+      let json = { name: {foo: 2}, task:{bar: 3}};
+      let ignoreList = ['task'];
+      let result = builder.convertJsonKeysToBracketedList(json, ignoreList);
+      expect(result).toEqual([`['name']['foo']`]);
+    });
+
+    it('should include the task node deeper in the tree from the list', function () {
+      let json = { name: {foo: 2}, joy: {task:{bar: 3}}};
+      let ignoreList = ['name'];
+      let result = builder.convertJsonKeysToBracketedList(json, ignoreList);
+      expect(result).toEqual([`['joy']['task']['bar']`]);
+    });
+  });
+
+  describe('escape string for regex', function () {
+    it('should escape parens', function () {
+      let item = 'Deploy (safari, release, 10%)';
+      let result = builder.escapeForRegEx(item);
+      expect(result).toEqual('Deploy \\(safari, release, 10%\\)');
+    });
+  });
+
+});

--- a/app/scripts/modules/core/widgets/spelText/spel.less
+++ b/app/scripts/modules/core/widgets/spelText/spel.less
@@ -61,3 +61,44 @@ input.borderless {
 .button-input > .form-control:focus {
   box-shadow: none;
 }
+
+
+span.marker {
+  display: inline;
+  padding: .2em .6em .3em;
+  font-size: 75%;
+  font-weight: bold;
+  line-height: 1;
+  color: #fff;
+  text-align: center;
+  white-space: nowrap;
+  vertical-align: baseline;
+  border-radius: .25em;
+}
+
+span.marker.param {
+  background-color: #FFAE4C;
+  color: #7F5726;
+}
+
+span.marker.stage{
+  background-color: #cbb4fa;
+  color: #302A3B
+}
+
+span.marker.function {
+  background-color: #a3b2e3;
+  color: #484e63
+};
+
+span.marker.param:before {
+  content: "p";
+}
+
+span.marker.stage:before {
+  content: "stage";
+}
+
+span.marker.function:before {
+  content: "fn";
+}

--- a/app/scripts/modules/core/widgets/spelText/spelAutocomplete.service.js
+++ b/app/scripts/modules/core/widgets/spelText/spelAutocomplete.service.js
@@ -1,0 +1,326 @@
+'use strict';
+
+
+let angular = require('angular');
+
+module.exports = angular
+  .module('spinnaker.core.widget.spelAutocomplete', [
+    require('./jsonListBuilder'),
+    require('../../delivery/service/execution.service'),
+  ])
+  .factory('spelAutocomplete', function($q, jsonListBuilder, executionService) {
+    let brackets = [{open: '(', close: ')'}, {open: '[', close: ']'}, ];
+    let quotes = [{open: '\'', close: '\'' }, {open: '\"', close: '\"' }];
+    let helperFunctions = ['alphanumerical', 'readJson', 'fromUrl', 'jsonFromUrl', 'judgment', 'stage', 'toBoolean', 'toFloat', 'toInt', 'toJson'];
+    let helperParams = ['execution', 'parameters', 'trigger', 'scmInfo', 'scmInfo.sha1', 'scmInfo.branch', 'deployedServerGroups'];
+    let codedHelperParams = helperParams.map((param) => {
+      return {name: param, type: 'param'};
+    });
+
+    let textcompleteConfig = [
+      {
+        id: 'SpEL wrapper',
+        match: /\$(\w*)$/,
+        search: function(item, callback) {
+          callback(['${...}']);
+        },
+        index: 1,
+        replace: function replace() {
+          return ['${ ', ' }'];
+        }
+      },
+      {
+        id: 'match quotes',
+        match: /("|')(\w*)$/,
+        index: 1,
+        search: function(term, callback) {
+          let found = quotes.filter((quote) => {
+            if (quote.open.indexOf(term) === 0) {
+              return quote;
+            }
+          });
+          callback(found);
+        },
+        template: function() {
+          return `'...'`;
+        },
+        replace: function replace() {
+          return [`'` , `'`];
+        }
+      },
+      {
+        id: 'match brackets',
+        match: /(\[|\(|')(\w*)$/,
+        index: 1,
+        search: function(term, callback) {
+          let found = brackets.filter((bracket) => {
+            if (bracket.open.indexOf(term) === 0) {
+              return bracket;
+            }
+          });
+          callback(found);
+        },
+        template: function(value) {
+          return `${value.open}...${value.close}`;
+        },
+        replace: function replace(bracket) {
+          return [`${bracket.open}  ` , `  ${bracket.close}`];
+        }
+      },
+      {
+        id: 'helper functions',
+        match: /#(\w*)$/,
+        index: 1,
+        search: function (term, callback) {
+          callback(helperFunctions.filter((helper) => {
+            if(helper.indexOf(term) === 0) {
+              return helper;
+            }
+          }));
+        },
+        template: (value) => {
+          return `<span class="marker function"></span> #${value}`;
+        },
+
+        replace: function replace(helper) {
+          if (helper === 'toJson') {
+            return [`#${helper}(`, ')'];
+          }
+          return [`#${helper}( '`, `' )`];
+        }
+      }
+    ];
+
+
+    let paramInList = (checkParam) => {
+      return (testParam) => checkParam.name === testParam.name;
+    };
+
+
+    let addToTextcompleteConfig = (configList = [], textcompleteConfig) => {
+      let textcompleteConfigCopy = textcompleteConfig.slice(0);
+
+      configList.forEach((newConfig) => {
+        if(textcompleteConfig.filter( (config) => config.id === newConfig.id ).length === 0) {
+          return textcompleteConfigCopy.push(newConfig);
+        }
+      });
+
+      return textcompleteConfigCopy;
+    };
+
+
+    let addStageDataForAutocomplete = (pipeline, textcompleteConfig) => {
+      if(pipeline && pipeline.stages) {
+        let configList = pipeline.stages.map((stage) => {
+
+          let stageList = jsonListBuilder.convertJsonKeysToBracketedList(stage, ['task']);
+
+          return {
+            id: `stage config for ${stage.name}`,
+            match: new RegExp(`#stage\\(\\s*'${jsonListBuilder.escapeForRegEx(stage.name)}'\\s*\\)(.*)$`),
+            index: 1,
+            search: (term, callback) => {
+              callback(stageList.filter( (item) => {
+                if (item.indexOf(term) > -1) {
+                  return item;
+                }
+              }));
+            },
+            replace: (param) => {
+              return `#stage('${stage.name}')${param}`;
+            }
+          };
+
+        });
+        return addToTextcompleteConfig(configList, textcompleteConfig);
+      }
+
+      return textcompleteConfig;
+
+    };
+
+
+    let addManualJudgementConfigForAutocomplete = (pipeline, textcompleteConfig) => {
+      if(pipeline && pipeline.stages) {
+
+        let manualJudgementStageList = pipeline.stages.filter((stage) => stage.type === 'manualJudgment');
+
+        let configList = manualJudgementStageList.map((stage) => {
+          let stageList = jsonListBuilder.convertJsonKeysToBracketedList(stage);
+
+          return {
+            id: `judgement config for ${stage.name}`,
+            match: new RegExp(`#judgement\\(\\s*'\\s*${jsonListBuilder.escapeForRegEx(stage.name)}'\\s*\\)(.*)$`),
+            index: 1,
+            search: (term, callback) => {
+              callback(stageList.filter((item) => {
+                if (item.indexOf(term) > -1) {
+                  return item;
+                }
+              }));
+            },
+            replace: (param) => {
+              return `#judgement('${stage.name}')${param}`;
+            }
+          };
+
+        });
+
+        return addToTextcompleteConfig(configList, textcompleteConfig);
+      }
+
+      return textcompleteConfig;
+
+    };
+
+
+    let addTriggerConfigForAutocomplete = (pipeline, textcompleteConfig) => {
+
+      if(pipeline && pipeline.trigger) {
+        let triggerAsList = [pipeline.trigger];
+        let configList = triggerAsList.map((trigger) => {
+          let triggerInfoList = jsonListBuilder.convertJsonKeysToBracketedList(trigger);
+          return {
+            id: `trigger config: ${trigger.type}`,
+            match: /trigger(\w*|\s*)$/,
+            index: 1,
+            search: (term, callback) => {
+              callback(triggerInfoList.filter( (item) => {
+                if (item.indexOf(term) > -1) {
+                  return item;
+                }
+              }));
+            },
+            replace: function replace(value) {
+              return `trigger${value}`;
+            }
+          };
+        });
+
+        return addToTextcompleteConfig(configList, textcompleteConfig);
+      }
+
+      return textcompleteConfig;
+    };
+
+
+    let addParameterConfigForAutocomplete = (pipeline, textcompleteConfig) => {
+      if(pipeline && pipeline.trigger && pipeline.trigger.parameters) {
+        let paramsAsList = [pipeline.trigger.parameters];
+        let configList = paramsAsList.map((params) => {
+          let paramsInfoList = jsonListBuilder.convertJsonKeysToBracketedList(params);
+          return {
+            id: `parameter config: ${Object.keys(params).join(',')}`,
+            match: /parameters(\w*|\s*)$/,
+            index: 1,
+            search: (term, callback) => {
+              callback(paramsInfoList.filter( (item) => {
+                if (item.indexOf(term) > -1) {
+                  return item;
+                }
+              }));
+            },
+            replace: function replace(value) {
+              return `parameters${value}`;
+            }
+          };
+        });
+
+        return addToTextcompleteConfig(configList, textcompleteConfig);
+      }
+
+      return textcompleteConfig;
+    };
+
+
+    let addStageNamesToCodeHelperList = (pipeline, textcompleteConfig) => {
+      if (pipeline && pipeline.stages) {
+        let codedHelperParamsCopy = codedHelperParams.slice(0);
+
+        pipeline.stages.forEach((stage) => {
+          let newParam = {name: stage.name, type: stage.type};
+          if (codedHelperParamsCopy.filter(paramInList(newParam)).length === 0) {
+            codedHelperParamsCopy.push({name: stage.name, type: 'stage'});
+          }
+        });
+
+        let configList = [{
+          id: 'params',
+          match: /(\s*|\w*)\?(\s*|\w*|')$/,
+          index: 2,
+          search: function (term, callback) {
+            callback(codedHelperParamsCopy.filter((param) => {
+              if (param.name.indexOf(term) > -1 || param.type.indexOf(term) > -1) {
+                return param;
+              }
+            }));
+          },
+          template: function (value) {
+            return `<span class="marker ${value.type}"></span> ${value.name}`;
+          },
+          replace: function replace (param) {
+            return `${param.name}`;
+          }
+        }];
+
+        return addToTextcompleteConfig(configList, textcompleteConfig);
+      }
+      return textcompleteConfig;
+    };
+
+    let executionCache = {};
+
+    let getLastExecutionByPipelineConfig = (pipelineConfig) => {
+      if(executionCache[pipelineConfig.id]) {
+        return $q.when(executionCache[pipelineConfig.id]);
+      } else {
+        return executionService
+          .getLastExecutionForApplicationByConfigId(pipelineConfig.application, pipelineConfig.id)
+          .then((execution) => {
+            if(execution) {
+              executionCache[pipelineConfig.id] = execution;
+              return execution;
+            } else {
+              return null;
+            }
+          });
+      }
+    };
+
+    let addPipelineInfo = (pipelineConfig) => {
+      if(pipelineConfig) {
+        return getLastExecutionByPipelineConfig(pipelineConfig)
+          .then((lastExecution) => {
+            return lastExecution || pipelineConfig;
+          })
+          .then((pipeline) => {
+            return addStageNamesToCodeHelperList(
+              pipeline,
+              addStageDataForAutocomplete(
+                pipeline,
+                addManualJudgementConfigForAutocomplete(
+                  pipeline,
+                  addTriggerConfigForAutocomplete(
+                    pipeline,
+                    addParameterConfigForAutocomplete(
+                      pipeline,
+                      textcompleteConfig.slice(0)
+                    )
+                  )
+                )
+              )
+            );
+          });
+      } else {
+        return $q.when(textcompleteConfig);
+      }
+
+    };
+
+    return {
+      textcompleteConfig: textcompleteConfig,
+      addPipelineInfo: addPipelineInfo
+    };
+
+  });

--- a/app/scripts/modules/core/widgets/spelText/spelText.decorator.js
+++ b/app/scripts/modules/core/widgets/spelText/spelText.decorator.js
@@ -2,22 +2,36 @@
 
 let angular = require('angular');
 require('./spel.less');
+require('jquery-textcomplete');
 
-let decorateFn = function ($delegate) {
-  var directive = $delegate[0];
+let decorateFn = function ($delegate, jsonListBuilder, spelAutocomplete) {
+  let directive = $delegate[0];
 
-  var link = directive.link.pre;
+  let link = directive.link.pre;
 
   directive.compile = function () {
     return function (scope, el) {
 
       link.apply(this, arguments);
+
+      // the textcomplete plugin needs input texts to marked as 'contenteditable'
+      el.attr('contenteditable', true);
+      spelAutocomplete.addPipelineInfo(scope.pipeline).then((textcompleteConfig) => {
+        el.textcomplete(textcompleteConfig, {maxCount: 50});
+      });
+
       function listener (evt) {
-        let hasSpelPrefix = evt.target.value.indexOf('${') > -1;
+
+        let hasSpelPrefix = evt.target.value.indexOf('$') > -1;
         let hasLink = el.parent().nextAll('.spelLink');
+
+
         if (hasSpelPrefix) {
           if (hasLink.length < 1) {
+            // Add the link to the docs under the input/textarea
             el.parent().after('<a class="spelLink" href="http://www.spinnaker.io/docs/pipeline-expressions-guide" target="_blank">Expression Docs</a>');
+
+
           }
         } else {
           hasLink.fadeOut( 500, function() { this.remove(); });
@@ -33,7 +47,10 @@ let decorateFn = function ($delegate) {
 
 
 module.exports = angular
-  .module('spinnaker.core.widget.spelText', [])
+  .module('spinnaker.core.widget.spelText', [
+    require('./spelAutocomplete.service'),
+    require('./jsonListBuilder'),
+  ])
   .config( function($provide) {
     $provide.decorator('inputDirective', decorateFn);
     $provide.decorator('textareaDirective', decorateFn);

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "d3": "^3.5.6",
     "diff-match-patch": "^1.0.0",
     "jquery": "2.1.4",
+    "jquery-textcomplete": "1.6.1",
     "jquery-ui": "~1.10.5",
     "later": "^1.2.0",
     "loader-utils": "^0.2.11",


### PR DESCRIPTION
Allows for context specific autocomplete for the SpEL in textareas and text inputs

At this time it shows a list of the functions, helper params, and stage names.
Also uses the last execution and walks the json and builds out the paths to the leafs for autocomplete.  
If no execution is found it will use the pipeline config to build the paths to the leafs.

There is context aware autocomplete around the #stage, #judgement helper functions as well as the 'parameters' and 'triggers' helper params.

NOTE:  I have plans to do some refactoring to remove some of the boilerplate.

@anotherchrisberry PTAL