### PR TITLE
(netflix) clarify label/help text on canary config

### DIFF
--- a/app/scripts/modules/core/help/helpContents.js
+++ b/app/scripts/modules/core/help/helpContents.js
@@ -250,7 +250,7 @@ module.exports = angular.module('spinnaker.core.help.contents', [])
       '<p>The <em>lowest</em> strategy means that the cluster with the lowest score is used as the rolled up score</p>' +
       '<p>The <em>average</em> strategy takes the average of all the canary scores</p>',
 
-    'pipeline.config.canary.delayBeforeAnalysis': '<p>The number of minutes to wait before generating an initial canary score.</p>',
+    'pipeline.config.canary.delayBeforeAnalysis': '<p>The number of minutes until the first ACA measurement interval begins.</p>',
 
     'pipeline.config.canary.notificationHours': '<p>Hours at which to send a notification (comma separated)</p>',
 

--- a/app/scripts/modules/netflix/pipeline/stage/canary/canaryStage.html
+++ b/app/scripts/modules/netflix/pipeline/stage/canary/canaryStage.html
@@ -88,7 +88,7 @@
         class-name="form-control input-sm">
     </canary-analysis-name-selector>
   </stage-config-field>
-  <stage-config-field label="Delay">
+  <stage-config-field label="Warmup Period">
     <input type="text" required ng-model="stage.canary.canaryConfig.canaryAnalysisConfig.beginCanaryAnalysisAfterMins"
            class="form-control input-sm" style="display: inline-block; width: 20%"/>
     <span class="form-control-static">


### PR DESCRIPTION
This is based on feedback from Greg B (SPIN-516).

I don't know the canary functionality well enough to say this is better, but assuming Greg does.

@cfieber or @zanthrash does this seem better to you?