### PR TITLE
(kubernetes) Only strip underscores from names

### DIFF
--- a/app/scripts/modules/kubernetes/serverGroup/configure/configuration.service.js
+++ b/app/scripts/modules/kubernetes/serverGroup/configure/configuration.service.js
@@ -63,7 +63,7 @@ module.exports = angular.module('spinnaker.serverGroup.configure.kubernetes.conf
     function mapImageToContainer(command) {
       return (image) => {
         return {
-          name: image.repository.replace(/\W/g, '').toLowerCase(),
+          name: image.repository.replace(/_/g, '').toLowerCase(),
           imageDescription: {
             repository: image.repository,
             tag: image.tag,


### PR DESCRIPTION
@danielpeach @leelasharma

Turns out the only invalid character in a docker repo name is the underscore: https://github.com/docker/docker/blob/f63cdf0260cf6287d28a589a79d3f947def6a569/runtime.go#L33 - so we can keep the dash.