### PR TITLE
provider/kubernetes: No slash in container name

### DIFF
--- a/app/scripts/modules/kubernetes/serverGroup/configure/configuration.service.js
+++ b/app/scripts/modules/kubernetes/serverGroup/configure/configuration.service.js
@@ -63,7 +63,7 @@ module.exports = angular.module('spinnaker.serverGroup.configure.kubernetes.conf
     function mapImageToContainer(command) {
       return (image) => {
         return {
-          name: image.repository.replace(/_/g, '').toLowerCase(),
+          name: image.repository.replace(/_/g, '').replace(/\//g, '-').toLowerCase(),
           imageDescription: {
             repository: image.repository,
             tag: image.tag,


### PR DESCRIPTION
@danielpeach 

I replace `/` (which appears in repo/image) with a `-` to make the resulting container name more readable.