### PR TITLE
(core) bind spel autocomplete on pipeline config objects only

### DIFF
--- a/app/scripts/modules/core/widgets/spelText/spelAutocomplete.service.js
+++ b/app/scripts/modules/core/widgets/spelText/spelAutocomplete.service.js
@@ -289,7 +289,7 @@ module.exports = angular
     };
 
     let addPipelineInfo = (pipelineConfig) => {
-      if(pipelineConfig) {
+      if(pipelineConfig && pipelineConfig.id) {
         return getLastExecutionByPipelineConfig(pipelineConfig)
           .then((lastExecution) => {
             return lastExecution || pipelineConfig;


### PR DESCRIPTION
There are `pipelineConfig` objects in the scope of the executions view that are just strings, so we end up making a bunch of invalid calls to get the latest execution.