### PR TITLE
(kubernetes) Get `kind` from server group object

### DIFF
--- a/app/scripts/modules/kubernetes/serverGroup/details/details.html
+++ b/app/scripts/modules/kubernetes/serverGroup/details/details.html
@@ -103,7 +103,7 @@
         <dt>Namespace<dt>
         <dd>{{serverGroup.region}}</dd>
         <dt>Kind</dt>
-        <dd>{{serverGroup.replicationController.kind}}</dd>
+        <dd>{{serverGroup.kind}}</dd>
         <dt>YAML</dt>
         <dd><a href ng-click="ctrl.showYaml()">Show YAML</a></dd>
       </dl>


### PR DESCRIPTION
It's not guaranteed that the details view will receive a replication controller anymore. 

@danielpeach 