### PR TITLE
(aws) automatically set internal flag on load balancer creation

### DIFF
--- a/app/scripts/modules/amazon/loadBalancer/configure/createLoadBalancer.controller.js
+++ b/app/scripts/modules/amazon/loadBalancer/configure/createLoadBalancer.controller.js
@@ -353,11 +353,18 @@ module.exports = angular.module('spinnaker.loadBalancer.aws.create.controller', 
         updateAvailableSecurityGroups(availableVpcIds);
       if (subnetPurpose) {
         $scope.loadBalancer.vpcId = availableVpcIds.length ? availableVpcIds[0] : null;
+        if (!$scope.state.hideInternalFlag && !$scope.state.internalFlagToggled) {
+          $scope.loadBalancer.isInternal = subnetPurpose.indexOf('internal') > -1;
+        }
         v2modalWizardService.includePage('Security Groups');
       } else {
         $scope.loadBalancer.vpcId = null;
         v2modalWizardService.excludePage('Security Groups');
       }
+    };
+
+    this.internalFlagChanged = () => {
+      $scope.state.internalFlagToggled = true;
     };
 
     this.removeListener = function(index) {

--- a/app/scripts/modules/amazon/loadBalancer/configure/createLoadBalancer.controller.spec.js
+++ b/app/scripts/modules/amazon/loadBalancer/configure/createLoadBalancer.controller.spec.js
@@ -108,6 +108,51 @@ describe('Controller: awsCreateLoadBalancerCtrl', function () {
       expect(this.$scope.state.hideInternalFlag).toBe(true);
     });
 
+    it('should set the flag based on purpose when subnet is updated', function () {
+      this.initialize();
+
+      this.$scope.subnets = [
+        { purpose: 'internal/old', vpcIds: [] },
+        { purpose: 'internal/new', vpcIds: [] },
+        { purpose: 'external', vpcIds: [] }
+      ];
+      this.$scope.loadBalancer.subnetType = 'internal/old';
+      this.ctrl.subnetUpdated();
+      expect(this.$scope.loadBalancer.isInternal).toBe(true);
+
+      this.$scope.loadBalancer.subnetType = 'external';
+      this.ctrl.subnetUpdated();
+      expect(this.$scope.loadBalancer.isInternal).toBe(false);
+
+      this.$scope.loadBalancer.subnetType = 'internal/new';
+      this.ctrl.subnetUpdated();
+      expect(this.$scope.loadBalancer.isInternal).toBe(true);
+    });
+
+    it('should leave the flag once it has been toggled', function () {
+      this.initialize();
+
+      this.$scope.subnets = [
+        { purpose: 'internal/old', vpcIds: [] },
+        { purpose: 'internal/new', vpcIds: [] },
+        { purpose: 'external', vpcIds: [] }
+      ];
+      this.$scope.loadBalancer.isInternal = false;
+      this.$scope.state.internalFlagToggled = true;
+
+      this.$scope.loadBalancer.subnetType = 'internal/old';
+      this.ctrl.subnetUpdated();
+      expect(this.$scope.loadBalancer.isInternal).toBe(false);
+
+      this.$scope.loadBalancer.subnetType = 'external';
+      this.ctrl.subnetUpdated();
+      expect(this.$scope.loadBalancer.isInternal).toBe(false);
+
+      this.$scope.loadBalancer.subnetType = 'internal/new';
+      this.ctrl.subnetUpdated();
+      expect(this.$scope.loadBalancer.isInternal).toBe(false);
+    });
+
     it('should leave the flag and not set a state value if inferInternalFlagFromSubnet is false or not defined', function () {
       this.settings.providers = {
         aws: { loadBalancers: { inferInternalFlagFromSubnet: true }}

--- a/app/scripts/modules/amazon/loadBalancer/configure/createLoadBalancerProperties.html
+++ b/app/scripts/modules/amazon/loadBalancer/configure/createLoadBalancerProperties.html
@@ -82,6 +82,7 @@
       <div class="col-md-3 sm-label-right"><b>Internal</b></div>
       <div class="col-md-7 checkbox">
         <label><input type="checkbox"
+                      ng-change="ctrl.internalFlagChanged()"
                       ng-model="loadBalancer.isInternal"/>
           Create an internal load balancer
         </label>

--- a/app/scripts/modules/google/serverGroup/details/resize/resizeServerGroup.controller.spec.js
+++ b/app/scripts/modules/google/serverGroup/details/resize/resizeServerGroup.controller.spec.js
@@ -17,7 +17,7 @@ describe('Controller: gceResizeServerGroupCtrl', function () {
     window.module(
       require('./resizeServerGroup.controller'),
       require('../../../autoscalingPolicy/autoscalingPolicy.write.service.js'),
-      require('../../../../core/serverGroup/serverGroup.write.service.js'),
+      require('../../../../core/serverGroup/serverGroup.write.service.js')
     )
   );
 


### PR DESCRIPTION
If the user has not explicitly toggled the load balancer's `isInternal` flag, try to set it from the purpose.

@zanthrash PTAL