### PR TITLE
(docker): Shrink size of image list in buildinfo

### DIFF
--- a/app/scripts/modules/core/serverGroup/serverGroup.directive.html
+++ b/app/scripts/modules/core/serverGroup/serverGroup.directive.html
@@ -24,10 +24,7 @@
               Build: #{{ viewModel.jenkins.number }}
             </a>
             <span ng-if="viewModel.images">
-              Images:
-              <ul class="list-unstyled">
-                <li ng-repeat="image in viewModel.images">{{ image }}</li>
-              </ul>
+              {{ viewModel.images }}
             </span>
             <span ng-if="!viewModel.hasBuildInfo">
               (No build info)

--- a/app/scripts/modules/core/serverGroup/serverGroup.directive.js
+++ b/app/scripts/modules/core/serverGroup/serverGroup.directive.js
@@ -63,7 +63,7 @@ module.exports = angular.module('spinnaker.core.serverGroup.serverGroup.directiv
               viewModel.jenkins.href = serverGroup.buildInfo.buildInfoUrl;
             }
           } else if (_.has(serverGroup, 'buildInfo.images')) {
-            viewModel.images = serverGroup.buildInfo.images;
+            viewModel.images = serverGroup.buildInfo.images.join(', ');
           }
 
           let modelStringVal = JSON.stringify(viewModel, serverGroupTransformer.jsonReplacer);


### PR DESCRIPTION
The vertical spacing of the image list was throwing off the UI a little. I shrunk the image list down to a comma separated list and I think it looks a little better without sacrificing readability: 
![xbjpahzvvhx](https://cloud.githubusercontent.com/assets/4874941/17894355/0fd391c8-6917-11e6-83f5-e90efe081bbf.png)

@danielpeach @bfarrell PTAL
