### PR TITLE
(aws) make ELB certificate types configurable

### DIFF
--- a/app/scripts/modules/amazon/loadBalancer/configure/createLoadBalancer.controller.js
+++ b/app/scripts/modules/amazon/loadBalancer/configure/createLoadBalancer.controller.js
@@ -301,6 +301,8 @@ module.exports = angular.module('spinnaker.loadBalancer.aws.create.controller', 
       });
     }
 
+    this.certificateTypes = _.get(settings, 'providers.aws.loadBalancers.certificateTypes', ['iam', 'acm']);
+
     initializeController();
 
     // Controller API

--- a/app/scripts/modules/amazon/loadBalancer/configure/listeners.html
+++ b/app/scripts/modules/amazon/loadBalancer/configure/listeners.html
@@ -9,7 +9,7 @@
           <th></th>
           <th>Internal Protocol</th>
           <th>Internal Port</th>
-          <th ng-if="ctrl.showSslCertificateIdField()" width="10%">SSL Certificate Type</th>
+          <th ng-if="ctrl.showSslCertificateIdField() && ctrl.certificateTypes.length > 1" width="10%">SSL Certificate Type</th>
           <th ng-if="ctrl.showSslCertificateIdField()" width="30%">SSL Certificate Name</th>
           <th></th>
         </tr>
@@ -27,7 +27,7 @@
           <td><input class="form-control input-sm" type="number" min="0" ng-model="listener.internalPort"
                      required/></td>
           <td ng-if="ctrl.showSslCertificateIdField() && listener.externalProtocol !== 'HTTPS' && listener.externalProtocol !== 'SSL'"></td>
-          <td ng-if="listener.externalProtocol === 'HTTPS' || listener.externalProtocol === 'SSL'">
+          <td ng-if="ctrl.certificateTypes.length > 1 && (listener.externalProtocol === 'HTTPS' || listener.externalProtocol === 'SSL')">
             <select class="form-control input-sm" ng-model="listener.sslCertificateType"
                     ng-options="certificateType for certificateType in ['iam','acm']"></select>
           </td>


### PR DESCRIPTION
Hide the SSL Certificate Type field if only one listener type is configured.