### PR TITLE
Adding more goodness to SpEL autocomplete

### DIFF
--- a/app/scripts/modules/core/widgets/spelText/jsonListBuilder.js
+++ b/app/scripts/modules/core/widgets/spelText/jsonListBuilder.js
@@ -30,15 +30,15 @@ module.exports = angular
 
         let entry = isFinite(parseInt(key)) ? `${parent}[${parseInt(key)}]` : `${parent}['${key}']`;
 
-        if( !(angular.isObject(node[key]) || angular.isArray(node[key]) ) ) {
+        let value = node[key];
+        if( !(angular.isObject(value) || angular.isArray(value) ) ) {
 
 
           if ( !ignoreList.some( (ignoreItem) => {
               let testerString = `[\'${ignoreItem}`;
               return entry.substr(0, testerString.length) === testerString;
             })) {
-
-            array.push(entry);
+            array.push({leaf: entry, value: value});
 
           }
         }

--- a/app/scripts/modules/core/widgets/spelText/jsonListBuilder.spec.js
+++ b/app/scripts/modules/core/widgets/spelText/jsonListBuilder.spec.js
@@ -20,68 +20,68 @@ describe('jsonListBuilder', function () {
     it('a simple json with one attribute', function () {
       let json = { name: 'foo'};
       let result = builder.convertJsonKeysToBracketedList(json);
-      expect(result).toEqual([`['name']`]);
+      expect(result).toEqual([{leaf:`['name']`, value: 'foo'}]);
     });
 
 
     it('a simple json with multiple attributes', function () {
       let json = { name: 'foo', bar: 'baz'};
       let result = builder.convertJsonKeysToBracketedList(json);
-      expect(result).toEqual([`['name']`, `['bar']`]);
+      expect(result).toEqual([{leaf: `['name']`, value: 'foo'}, {leaf:`['bar']`, value: 'baz'}]);
     });
 
     it('nested objects', function () {
       let json = { name: {foo: 'bar'}};
       let result = builder.convertJsonKeysToBracketedList(json);
-      expect(result).toEqual([`['name']['foo']`]);
+      expect(result).toEqual([{leaf:`['name']['foo']`, value: 'bar'}]);
     });
 
     it('nested objects with multivalues', function () {
       let json = { name: {foo: 'bar', baz: 2}};
       let result = builder.convertJsonKeysToBracketedList(json);
-      expect(result).toEqual([`['name']['foo']`, `['name']['baz']`]);
+      expect(result).toEqual([{leaf:`['name']['foo']`, value: 'bar'}, {leaf:`['name']['baz']`, value: 2}]);
     });
 
     it('deep nested objects', function () {
       let json = { name: { baz: { context: {foo: 2}}}};
       let result = builder.convertJsonKeysToBracketedList(json);
-      expect(result).toEqual([`['name']['baz']['context']['foo']`]);
+      expect(result).toEqual([{leaf:`['name']['baz']['context']['foo']`, value: 2}]);
     });
 
     it('deep nested objects with multivalues', function () {
       let json = { name: { baz: { context: {foo: 2, boom: 'go'}}}};
       let result = builder.convertJsonKeysToBracketedList(json);
-      expect(result).toEqual([ `['name']['baz']['context']['foo']`, `['name']['baz']['context']['boom']`]);
+      expect(result).toEqual([ {leaf:`['name']['baz']['context']['foo']`, value: 2}, {leaf:`['name']['baz']['context']['boom']`, value: 'go'}]);
     });
 
     it('json with an array of strings', function () {
       let json = { name: ['foo'] };
       let result = builder.convertJsonKeysToBracketedList(json);
-      expect(result).toEqual([`['name'][0]`]);
+      expect(result).toEqual([{leaf:`['name'][0]`, value: 'foo'}]);
     });
 
     it('json with an array of multiple strings', function () {
       let json = { name: ['foo', 'bar'] };
       let result = builder.convertJsonKeysToBracketedList(json);
-      expect(result).toEqual([`['name'][0]`, `['name'][1]`]);
+      expect(result).toEqual([{leaf:`['name'][0]`, value: 'foo'}, {leaf:`['name'][1]`, value: 'bar'}]);
     });
 
     it('json with an array of one object', function () {
       let json = { name: [{foo: 2}] };
       let result = builder.convertJsonKeysToBracketedList(json);
-      expect(result).toEqual([`['name'][0]['foo']`]);
+      expect(result).toEqual([{leaf:`['name'][0]['foo']`, value: 2}]);
     });
 
     it('json with an array of two object', function () {
       let json = { name: [{foo: 2}, {foo:3}] };
       let result = builder.convertJsonKeysToBracketedList(json);
-      expect(result).toEqual([`['name'][1]['foo']`, `['name'][0]['foo']`]);
+      expect(result).toEqual([{leaf:`['name'][1]['foo']`, value: 3}, {leaf:`['name'][0]['foo']`, value: 2}]);
     });
 
     it('json with dots in the key name', function () {
       let json = { 'notification.type': 'foo', 'deploy.server.group': {'server.group.name': 'baz'} };
       let result = builder.convertJsonKeysToBracketedList(json);
-      expect(result).toEqual([`['notification.type']`,`['deploy.server.group']['server.group.name']`]);
+      expect(result).toEqual([{leaf:`['notification.type']`, value: 'foo'}, {leaf:`['deploy.server.group']['server.group.name']`, value: 'baz'}]);
     });
 
   });
@@ -91,14 +91,14 @@ describe('jsonListBuilder', function () {
       let json = { name: {foo: 2}, task:{bar: 3}};
       let ignoreList = ['task'];
       let result = builder.convertJsonKeysToBracketedList(json, ignoreList);
-      expect(result).toEqual([`['name']['foo']`]);
+      expect(result).toEqual([{leaf:`['name']['foo']`, value: 2}]);
     });
 
     it('should include the task node deeper in the tree from the list', function () {
       let json = { name: {foo: 2}, joy: {task:{bar: 3}}};
       let ignoreList = ['name'];
       let result = builder.convertJsonKeysToBracketedList(json, ignoreList);
-      expect(result).toEqual([`['joy']['task']['bar']`]);
+      expect(result).toEqual([{leaf:`['joy']['task']['bar']`, value: 3}]);
     });
   });
 

--- a/app/scripts/modules/core/widgets/spelText/spel.less
+++ b/app/scripts/modules/core/widgets/spelText/spel.less
@@ -91,6 +91,11 @@ span.marker.function {
   color: #484e63
 };
 
+span.marker.value{
+  background-color: #a3b2e3;
+  color: #484e63
+};
+
 span.marker.param:before {
   content: "p";
 }
@@ -101,4 +106,18 @@ span.marker.stage:before {
 
 span.marker.function:before {
   content: "fn";
+}
+
+.spel-dropdown {
+  max-height: 400px;
+  overflow-y: scroll;
+}
+
+.spel-value-separator {
+  font-size: 70%;
+  color: #484e63;
+}
+
+.textcomplete-item.active .spel-value-separator {
+  color: #fff;
 }

--- a/app/scripts/modules/core/widgets/spelText/spelText.decorator.js
+++ b/app/scripts/modules/core/widgets/spelText/spelText.decorator.js
@@ -17,7 +17,11 @@ let decorateFn = function ($delegate, jsonListBuilder, spelAutocomplete) {
       // the textcomplete plugin needs input texts to marked as 'contenteditable'
       el.attr('contenteditable', true);
       spelAutocomplete.addPipelineInfo(scope.pipeline).then((textcompleteConfig) => {
-        el.textcomplete(textcompleteConfig, {maxCount: 50});
+        el.textcomplete(textcompleteConfig, {
+          maxCount: 1000,
+          zIndex: 5000,
+          dropdownClassName: 'dropdown-menu textcomplete-dropdown spel-dropdown'
+        });
       });
 
       function listener (evt) {


### PR DESCRIPTION
- Show the value of the previous execution leaf notes in the dropdown list.
- Dropdown list now has a max height with y-overflow scrolling
- Don't show #judgment function if no Manual Judgment stage found
- Don't show 'parameters' param if no params in pipeline
- Don't show 'scmInfo' param if there is not a Jenkins trigger or Jenkins stage
- Autocomlete now works for "execution", and "deployedServerGroups"
- z-index is fixed for dropdown in modal windows.

![spindemo_ _pipeline_config](https://cloud.githubusercontent.com/assets/66639/17912576/55827aa4-6949-11e6-8447-577034fc3b95.png)

@anotherchrisberry PTAL