### PR TITLE
Avoid setting a default `interestingHealthProviderNames` (even if pla…

### DIFF
--- a/app/scripts/modules/amazon/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/amazon/instance/details/instance.details.controller.js
@@ -255,9 +255,6 @@ module.exports = angular.module('spinnaker.instance.detail.aws.controller', [
       };
 
       var submitMethod = (params = {}) => {
-        if (app.attributes && app.attributes.platformHealthOnly) {
-          params.interestingHealthProviderNames = ['Amazon'];
-        }
         return instanceWriter.rebootInstance(instance, app, params);
       };
 

--- a/app/scripts/modules/amazon/pipeline/stages/cloneServerGroup/awsCloneServerGroupStage.js
+++ b/app/scripts/modules/amazon/pipeline/stages/cloneServerGroup/awsCloneServerGroupStage.js
@@ -41,10 +41,6 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.aws.cloneServerGr
     stage.cloudProvider = 'aws';
     stage.cloudProviderType = 'aws';
 
-    if (stage.isNew && $scope.application.attributes.platformHealthOnly) {
-      stage.interestingHealthProviderNames = ['Amazon'];
-    }
-
     if (!stage.credentials && $scope.application.defaultCredentials.aws) {
       stage.credentials = $scope.application.defaultCredentials.aws;
     }

--- a/app/scripts/modules/amazon/pipeline/stages/disableAsg/awsDisableAsgStage.js
+++ b/app/scripts/modules/amazon/pipeline/stages/disableAsg/awsDisableAsgStage.js
@@ -45,10 +45,6 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.aws.disableAsgSta
     stage.regions = stage.regions || [];
     stage.cloudProvider = 'aws';
 
-    if (stage.isNew && $scope.application.attributes.platformHealthOnly) {
-      stage.interestingHealthProviderNames = ['Amazon'];
-    }
-
     if (!stage.credentials && $scope.application.defaultCredentials.aws) {
       stage.credentials = $scope.application.defaultCredentials.aws;
     }

--- a/app/scripts/modules/amazon/pipeline/stages/disableCluster/awsDisableClusterStage.js
+++ b/app/scripts/modules/amazon/pipeline/stages/disableCluster/awsDisableClusterStage.js
@@ -41,10 +41,6 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.aws.disableCluste
     stage.regions = stage.regions || [];
     stage.cloudProvider = 'aws';
 
-    if (stage.isNew && $scope.application.attributes.platformHealthOnly) {
-      stage.interestingHealthProviderNames = ['Amazon'];
-    }
-
     if (!stage.credentials && $scope.application.defaultCredentials.aws) {
       stage.credentials = $scope.application.defaultCredentials.aws;
     }

--- a/app/scripts/modules/amazon/pipeline/stages/enableAsg/awsEnableAsgStage.js
+++ b/app/scripts/modules/amazon/pipeline/stages/enableAsg/awsEnableAsgStage.js
@@ -49,10 +49,6 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.aws.enableAsgStag
     stage.regions = stage.regions || [];
     stage.cloudProvider = 'aws';
 
-    if (stage.isNew && $scope.application.attributes.platformHealthOnly) {
-      stage.interestingHealthProviderNames = ['Amazon'];
-    }
-
     if (!stage.credentials && $scope.application.defaultCredentials.aws) {
       stage.credentials = $scope.application.defaultCredentials.aws;
     }

--- a/app/scripts/modules/amazon/pipeline/stages/resizeAsg/awsResizeAsgStage.js
+++ b/app/scripts/modules/amazon/pipeline/stages/resizeAsg/awsResizeAsgStage.js
@@ -84,10 +84,6 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.aws.resizeAsgStag
     }
     stage.cloudProvider = 'aws';
 
-    if (stage.isNew && $scope.application.attributes.platformHealthOnly) {
-      stage.interestingHealthProviderNames = ['Amazon'];
-    }
-
     if (!stage.credentials && $scope.application.defaultCredentials.aws) {
       stage.credentials = $scope.application.defaultCredentials.aws;
     }

--- a/app/scripts/modules/amazon/serverGroup/configure/serverGroupCommandBuilder.service.js
+++ b/app/scripts/modules/amazon/serverGroup/configure/serverGroupCommandBuilder.service.js
@@ -71,10 +71,6 @@ module.exports = angular.module('spinnaker.aws.serverGroupCommandBuilder.service
             },
           };
 
-          if (application && application.attributes && application.attributes.platformHealthOnly) {
-            command.interestingHealthProviderNames = ['Amazon'];
-          }
-
           return command;
         });
     }
@@ -212,10 +208,6 @@ module.exports = angular.module('spinnaker.aws.serverGroupCommandBuilder.service
             dirty: {},
           },
         };
-
-        if (application && application.attributes && application.attributes.platformHealthOnly) {
-          command.interestingHealthProviderNames = ['Amazon'];
-        }
 
         if (mode === 'clone') {
           command.useSourceCapacity = true;

--- a/app/scripts/modules/amazon/serverGroup/details/resize/resizeServerGroup.controller.js
+++ b/app/scripts/modules/amazon/serverGroup/details/resize/resizeServerGroup.controller.js
@@ -27,10 +27,6 @@ module.exports = angular.module('spinnaker.amazon.serverGroup.details.resize.con
     $scope.command.advancedMode = serverGroup.asg.minSize !== serverGroup.asg.maxSize;
 
     if (application && application.attributes) {
-      if (application.attributes.platformHealthOnly) {
-        $scope.command.interestingHealthProviderNames = ['Amazon'];
-      }
-
       $scope.command.platformHealthOnlyShowOverride = application.attributes.platformHealthOnlyShowOverride;
     }
 

--- a/app/scripts/modules/amazon/serverGroup/details/rollback/rollbackServerGroup.controller.js
+++ b/app/scripts/modules/amazon/serverGroup/details/rollback/rollbackServerGroup.controller.js
@@ -23,10 +23,6 @@ module.exports = angular.module('spinnaker.amazon.serverGroup.details.rollback.c
       };
 
       if (application && application.attributes) {
-        if (application.attributes.platformHealthOnly) {
-          $scope.command.interestingHealthProviderNames = ['Amazon'];
-        }
-
         $scope.command.platformHealthOnlyShowOverride = application.attributes.platformHealthOnlyShowOverride;
       }
 

--- a/app/scripts/modules/amazon/serverGroup/details/serverGroupDetails.aws.controller.js
+++ b/app/scripts/modules/amazon/serverGroup/details/serverGroupDetails.aws.controller.js
@@ -212,10 +212,6 @@ module.exports = angular.module('spinnaker.serverGroup.details.aws.controller', 
         }
       };
 
-      if (app.attributes.platformHealthOnly) {
-        confirmationModalParams.interestingHealthProviderNames = ['Amazon'];
-      }
-
       confirmationModalService.confirm(confirmationModalParams);
 
     };
@@ -259,10 +255,6 @@ module.exports = angular.module('spinnaker.serverGroup.details.aws.controller', 
         askForReason: true
       };
 
-      if (app.attributes.platformHealthOnly) {
-        confirmationModalParams.interestingHealthProviderNames = ['Amazon'];
-      }
-
       confirmationModalService.confirm(confirmationModalParams);
     };
 
@@ -288,10 +280,6 @@ module.exports = angular.module('spinnaker.serverGroup.details.aws.controller', 
         submitMethod: submitMethod,
         askForReason: true
       };
-
-      if (app.attributes.platformHealthOnly) {
-        confirmationModalParams.interestingHealthProviderNames = ['Amazon'];
-      }
 
       confirmationModalService.confirm(confirmationModalParams);
     };

--- a/app/scripts/modules/cloudfoundry/pipeline/stages/disableAsg/cfDisableAsgStage.js
+++ b/app/scripts/modules/cloudfoundry/pipeline/stages/disableAsg/cfDisableAsgStage.js
@@ -51,10 +51,6 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.cf.disableAsgStag
     stage.regions = stage.regions || [];
     stage.cloudProvider = 'cf';
 
-    if (stage.isNew && $scope.application.attributes.platformHealthOnly) {
-      stage.interestingHealthProviderNames = ['Google'];
-    }
-
     if (!stage.credentials && $scope.application.defaultCredentials.cf) {
       stage.credentials = $scope.application.defaultCredentials.cf;
     }

--- a/app/scripts/modules/cloudfoundry/pipeline/stages/disableCluster/cfDisableClusterStage.js
+++ b/app/scripts/modules/cloudfoundry/pipeline/stages/disableCluster/cfDisableClusterStage.js
@@ -44,10 +44,6 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.cf.disableCluster
     stage.regions = stage.regions || [];
     stage.cloudProvider = 'cf';
 
-    if (stage.isNew && $scope.application.attributes.platformHealthOnly) {
-      stage.interestingHealthProviderNames = ['Google'];
-    }
-
     if (!stage.credentials && $scope.application.defaultCredentials.cf) {
       stage.credentials = $scope.application.defaultCredentials.cf;
     }

--- a/app/scripts/modules/cloudfoundry/pipeline/stages/enableAsg/cfEnableAsgStage.js
+++ b/app/scripts/modules/cloudfoundry/pipeline/stages/enableAsg/cfEnableAsgStage.js
@@ -50,10 +50,6 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.cf.enableAsgStage
     stage.regions = stage.regions || [];
     stage.cloudProvider = 'cf';
 
-    if (stage.isNew && $scope.application.attributes.platformHealthOnly) {
-      stage.interestingHealthProviderNames = ['Cloud Foundry'];
-    }
-
     if (!stage.credentials && $scope.application.defaultCredentials.cf) {
       stage.credentials = $scope.application.defaultCredentials.cf;
     }

--- a/app/scripts/modules/cloudfoundry/serverGroup/details/resize/resizeServerGroup.controller.js
+++ b/app/scripts/modules/cloudfoundry/serverGroup/details/resize/resizeServerGroup.controller.js
@@ -22,10 +22,6 @@ module.exports = angular.module('spinnaker.cf.serverGroup.details.resize.control
 
 
     if (application && application.attributes) {
-      if (application.attributes.platformHealthOnly) {
-        $scope.command.interestingHealthProviderNames = ['Cloud Foundry'];
-      }
-
       $scope.command.platformHealthOnlyShowOverride = application.attributes.platformHealthOnlyShowOverride;
     }
 

--- a/app/scripts/modules/core/instance/instance.write.service.js
+++ b/app/scripts/modules/core/instance/instance.write.service.js
@@ -124,6 +124,7 @@ module.exports = angular
       params.zone = instance.placement.availabilityZone;
       params.credentials = instance.account;
       params.cloudProvider = instance.providerType;
+      params.application = application.name;
 
       return taskExecutor.executeTask({
         job: [params],

--- a/app/scripts/modules/google/pipeline/stages/cloneServerGroup/gceCloneServerGroupStage.js
+++ b/app/scripts/modules/google/pipeline/stages/cloneServerGroup/gceCloneServerGroupStage.js
@@ -41,10 +41,6 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.gce.cloneServerGr
     stage.cloudProvider = 'gce';
     stage.cloudProviderType = 'gce';
 
-    if (stage.isNew && $scope.application.attributes.platformHealthOnly) {
-      stage.interestingHealthProviderNames = ['Google'];
-    }
-
     if (!stage.credentials && $scope.application.defaultCredentials.gce) {
       stage.credentials = $scope.application.defaultCredentials.gce;
     }

--- a/app/scripts/modules/google/pipeline/stages/disableAsg/gceDisableAsgStage.js
+++ b/app/scripts/modules/google/pipeline/stages/disableAsg/gceDisableAsgStage.js
@@ -44,10 +44,6 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.gce.disableAsgSta
     stage.regions = stage.regions || [];
     stage.cloudProvider = 'gce';
 
-    if (stage.isNew && $scope.application.attributes.platformHealthOnly) {
-      stage.interestingHealthProviderNames = ['Google'];
-    }
-
     if (!stage.credentials && $scope.application.defaultCredentials.gce) {
       stage.credentials = $scope.application.defaultCredentials.gce;
     }

--- a/app/scripts/modules/google/pipeline/stages/disableCluster/gceDisableClusterStage.js
+++ b/app/scripts/modules/google/pipeline/stages/disableCluster/gceDisableClusterStage.js
@@ -37,10 +37,6 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.gce.disableCluste
     stage.regions = stage.regions || [];
     stage.cloudProvider = 'gce';
 
-    if (stage.isNew && $scope.application.attributes.platformHealthOnly) {
-      stage.interestingHealthProviderNames = ['Google'];
-    }
-
     if (!stage.credentials && $scope.application.defaultCredentials.gce) {
       stage.credentials = $scope.application.defaultCredentials.gce;
     }

--- a/app/scripts/modules/google/pipeline/stages/enableAsg/gceEnableAsgStage.js
+++ b/app/scripts/modules/google/pipeline/stages/enableAsg/gceEnableAsgStage.js
@@ -41,10 +41,6 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.gce.enableAsgStag
     stage.regions = stage.regions || [];
     stage.cloudProvider = 'gce';
 
-    if (stage.isNew && $scope.application.attributes.platformHealthOnly) {
-      stage.interestingHealthProviderNames = ['Google'];
-    }
-
     if (!stage.credentials && $scope.application.defaultCredentials.gce) {
       stage.credentials = $scope.application.defaultCredentials.gce;
     }

--- a/app/scripts/modules/google/pipeline/stages/resizeAsg/gceResizeAsgStage.js
+++ b/app/scripts/modules/google/pipeline/stages/resizeAsg/gceResizeAsgStage.js
@@ -85,10 +85,6 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.gce.resizeAsgStag
     stage.cloudProvider = 'gce';
     stage.cloudProviderType = 'gce';
 
-    if (stage.isNew && $scope.application.attributes.platformHealthOnly) {
-      stage.interestingHealthProviderNames = ['Google'];
-    }
-
     if (!stage.credentials && $scope.application.defaultCredentials.gce) {
       stage.credentials = $scope.application.defaultCredentials.gce;
     }

--- a/app/scripts/modules/google/serverGroup/configure/serverGroupCommandBuilder.service.js
+++ b/app/scripts/modules/google/serverGroup/configure/serverGroupCommandBuilder.service.js
@@ -256,10 +256,6 @@ module.exports = angular.module('spinnaker.gce.serverGroupCommandBuilder.service
         }
       };
 
-      if (application && application.attributes && application.attributes.platformHealthOnly) {
-        command.interestingHealthProviderNames = ['Google'];
-      }
-
       attemptToSetValidCredentials(application, defaultCredentials, command);
 
       return $q.when(command);
@@ -323,10 +319,6 @@ module.exports = angular.module('spinnaker.gce.serverGroupCommandBuilder.service
       if (!command.regional) {
         command.zone = serverGroup.zones[0];
         command.source.zone = serverGroup.zones[0];
-      }
-
-      if (application && application.attributes && application.attributes.platformHealthOnly) {
-        command.interestingHealthProviderNames = ['Google'];
       }
 
       populateAutoHealingPolicy(serverGroup, command);

--- a/app/scripts/modules/google/serverGroup/details/resize/resizeServerGroup.controller.js
+++ b/app/scripts/modules/google/serverGroup/details/resize/resizeServerGroup.controller.js
@@ -19,10 +19,6 @@ module.exports = angular.module('spinnaker.google.serverGroup.details.resize.con
     $scope.formMethods = {};
 
     if (application && application.attributes) {
-      if (application.attributes.platformHealthOnly) {
-        $scope.command.interestingHealthProviderNames = ['Google'];
-      }
-
       $scope.command.platformHealthOnlyShowOverride = application.attributes.platformHealthOnlyShowOverride;
     }
 

--- a/app/scripts/modules/google/serverGroup/details/rollback/rollbackServerGroup.controller.js
+++ b/app/scripts/modules/google/serverGroup/details/rollback/rollbackServerGroup.controller.js
@@ -25,10 +25,6 @@ module.exports = angular.module('spinnaker.google.serverGroup.details.rollback.c
       };
 
       if (application && application.attributes) {
-        if (application.attributes.platformHealthOnly) {
-          $scope.command.interestingHealthProviderNames = ['Google'];
-        }
-
         $scope.command.platformHealthOnlyShowOverride = application.attributes.platformHealthOnlyShowOverride;
       }
 

--- a/app/scripts/modules/google/serverGroup/details/serverGroupDetails.gce.controller.js
+++ b/app/scripts/modules/google/serverGroup/details/serverGroupDetails.gce.controller.js
@@ -287,10 +287,6 @@ module.exports = angular.module('spinnaker.serverGroup.details.gce.controller', 
         }
       };
 
-      if (app.attributes.platformHealthOnly) {
-        confirmationModalParams.interestingHealthProviderNames = ['Google'];
-      }
-
       confirmationModalService.confirm(confirmationModalParams);
     };
 
@@ -331,10 +327,6 @@ module.exports = angular.module('spinnaker.serverGroup.details.gce.controller', 
         askForReason: true,
       };
 
-      if (app.attributes.platformHealthOnly) {
-        confirmationModalParams.interestingHealthProviderNames = ['Google'];
-      }
-
       confirmationModalService.confirm(confirmationModalParams);
     };
 
@@ -358,10 +350,6 @@ module.exports = angular.module('spinnaker.serverGroup.details.gce.controller', 
         submitMethod: submitMethod,
         askForReason: true,
       };
-
-      if (app.attributes.platformHealthOnly) {
-        confirmationModalParams.interestingHealthProviderNames = ['Google'];
-      }
 
       confirmationModalService.confirm(confirmationModalParams);
     };

--- a/app/scripts/modules/openstack/serverGroup/details/serverGroupDetails.openstack.controller.js
+++ b/app/scripts/modules/openstack/serverGroup/details/serverGroupDetails.openstack.controller.js
@@ -169,10 +169,6 @@ module.exports = angular.module('spinnaker.serverGroup.details.openstack.control
         }
       };
 
-      if (app.attributes.platformHealthOnly) {
-        confirmationModalParams.interestingHealthProviderNames = ['Openstack'];
-      }
-
       confirmationModalService.confirm(confirmationModalParams);
 
     };
@@ -216,10 +212,6 @@ module.exports = angular.module('spinnaker.serverGroup.details.openstack.control
         askForReason: true
       };
 
-      if (app.attributes.platformHealthOnly) {
-        confirmationModalParams.interestingHealthProviderNames = ['Openstack'];
-      }
-
       confirmationModalService.confirm(confirmationModalParams);
     };
 
@@ -245,10 +237,6 @@ module.exports = angular.module('spinnaker.serverGroup.details.openstack.control
         submitMethod: submitMethod,
         askForReason: true
       };
-
-      if (app.attributes.platformHealthOnly) {
-        confirmationModalParams.interestingHealthProviderNames = ['Openstack'];
-      }
 
       confirmationModalService.confirm(confirmationModalParams);
     };

--- a/app/scripts/modules/titus/serverGroup/configure/ServerGroupCommandBuilder.js
+++ b/app/scripts/modules/titus/serverGroup/configure/ServerGroupCommandBuilder.js
@@ -40,10 +40,6 @@ module.exports = angular.module('spinnaker.titus.serverGroupCommandBuilder.servi
         }
       };
 
-      if (application && application.attributes && application.attributes.platformHealthOnly) {
-        command.interestingHealthProviderNames = ['Titus'];
-      }
-
       return $q.when(command);
   }
 
@@ -99,10 +95,6 @@ module.exports = angular.module('spinnaker.titus.serverGroupCommandBuilder.servi
           mode: mode,
         },
       };
-
-      if (application && application.attributes && application.attributes.platformHealthOnly) {
-        command.interestingHealthProviderNames = ['Titus'];
-      }
 
       if (mode !== 'editPipeline') {
         command.imageId = serverGroup.image.dockerImageName + ':' + serverGroup.image.dockerImageVersion;

--- a/app/scripts/modules/titus/serverGroup/details/resize/resizeServerGroup.controller.js
+++ b/app/scripts/modules/titus/serverGroup/details/resize/resizeServerGroup.controller.js
@@ -22,10 +22,6 @@ module.exports = angular.module('spinnaker.titus.serverGroup.details.resize.cont
     $scope.command.advancedMode = serverGroup.capacity.min !== serverGroup.capacity.max;
 
     if (application && application.attributes) {
-      if (application.attributes.platformHealthOnly) {
-        $scope.command.interestingHealthProviderNames = ['Titus'];
-      }
-
       $scope.command.platformHealthOnlyShowOverride = application.attributes.platformHealthOnlyShowOverride;
     }
 

--- a/app/scripts/modules/titus/serverGroup/details/serverGroupDetails.titus.controller.js
+++ b/app/scripts/modules/titus/serverGroup/details/serverGroupDetails.titus.controller.js
@@ -139,10 +139,6 @@ module.exports = angular.module('spinnaker.serverGroup.details.titus.controller'
         }
       };
 
-      if (app.attributes.platformHealthOnly) {
-        confirmationModalParams.interestingHealthProviderNames = ['Titus'];
-      }
-
       confirmationModalService.confirm(confirmationModalParams);
     };
 
@@ -189,10 +185,6 @@ module.exports = angular.module('spinnaker.serverGroup.details.titus.controller'
         submitMethod: submitMethod
       };
 
-      if (app.attributes.platformHealthOnly) {
-        confirmationModalParams.interestingHealthProviderNames = ['Titus'];
-      }
-
       confirmationModalService.confirm(confirmationModalParams);
     };
 
@@ -223,10 +215,6 @@ module.exports = angular.module('spinnaker.serverGroup.details.titus.controller'
         platformHealthType: 'Titus',
         submitMethod: submitMethod
       };
-
-      if (app.attributes.platformHealthOnly) {
-        confirmationModalParams.interestingHealthProviderNames = ['Titus'];
-      }
 
       confirmationModalService.confirm(confirmationModalParams);
 


### PR DESCRIPTION
…tformHealthOnly is true)

Rather, `interestingHealthProviderNames` (unless overridden) should be determined when the
task is actually executed in orca.

Protects against a situation where someone:
1) Sets `platformHealthOnly: true`
2) Creates a pipeline
3) Sets `platformHealthOnly: false` at some point in the future (think days/weeks)
4) Runs pipeline

Currently, the pipeline will snapshot `interestingHealthProviderNames` at the point in time that
a stage is created.