### PR TITLE
(aws) trigger onChange when setting subnet initial value

### DIFF
--- a/app/scripts/modules/amazon/subnet/subnetSelectField.directive.js
+++ b/app/scripts/modules/amazon/subnet/subnetSelectField.directive.js
@@ -32,6 +32,9 @@ module.exports = angular.module('spinnaker.subnet.subnetSelectField.directive', 
             scope.hideClassic = true;
             if (!scope.component[scope.field] && scope.subnets && scope.subnets.length) {
               scope.component[scope.field] = scope.subnets[0].purpose;
+              if (scope.onChange) {
+                scope.onChange();
+              }
             }
           }
         }


### PR DESCRIPTION
If `hideClassic` is set and an `onChange` method is configured, we should fire the `onChange` event when auto-selecting a subnet for users.