### PR TITLE
(core) remove warning for missing angular module from loader

### DIFF
--- a/angular-loader/index.js
+++ b/angular-loader/index.js
@@ -61,7 +61,6 @@ module.exports = function(source, inputSourceMap) {
     // TODO: generate a new source map using inputSourceMap.
     this.callback(null, output.code, inputSourceMap);
   } else {
-    this.emitWarning('No angular module found in ' + this.resource);
     this.callback(null, source, inputSourceMap);
   }
 };


### PR DESCRIPTION
This was useful when the loader was being developed, but it seems to be noise now.