### PR TITLE
(core) calculate next run on mouseenter

### DIFF
--- a/app/scripts/modules/core/delivery/executionGroup/executionGroup.directive.html
+++ b/app/scripts/modules/core/delivery/executionGroup/executionGroup.directive.html
@@ -24,9 +24,8 @@
           </h4>
         </div>
         <div class="col-md-7 col-sm-7 text-right execution-group-actions" ng-if="vm.viewState.canConfigure">
-          <h4 ng-if="vm.viewState.isRetired"><span class="label-retired" uib-tooltip="The configuration for this pipeline has been renamed or deleted.">RETIRED</span></h4>
-          <triggers-tag pipeline="vm.pipelineConfig"></triggers-tag>
-          <next-run-tag pipeline="vm.pipelineConfig"></next-run-tag>
+          <triggers-tag is-visible="!vm.pipelineConfig.disabled" pipeline="vm.pipelineConfig"></triggers-tag>
+          <next-run-tag ng-if="!vm.pipelineConfig.disabled" pipeline="vm.pipelineConfig"></next-run-tag>
           <h4>
             <a href
                class="btn btn-xs btn-link link-inverse"

--- a/app/scripts/modules/core/delivery/executionGroup/executionGroup.directive.js
+++ b/app/scripts/modules/core/delivery/executionGroup/executionGroup.directive.js
@@ -59,7 +59,6 @@ module.exports = angular
       poll: null,
       canTriggerPipelineManually: this.pipelineConfig,
       canConfigure: this.pipelineConfig,
-      isRetired: ExecutionFilterModel.sortFilter.groupBy === 'name' && !this.pipelineConfig,
       showPipelineName: ExecutionFilterModel.sortFilter.groupBy !== 'name',
     };
 

--- a/app/scripts/modules/core/delivery/triggers/nextRun.component.js
+++ b/app/scripts/modules/core/delivery/triggers/nextRun.component.js
@@ -15,7 +15,7 @@ module.exports = angular
     },
     controller: function (momentService, settings) {
 
-      function setScheduled() {
+      this.updateSchedule = () => {
         if (!this.pipeline) {
           return;
         }
@@ -42,18 +42,21 @@ module.exports = angular
           }
         });
         if (nextTimes.length) {
+          this.hasNextScheduled = true;
           this.nextScheduled = Math.min(...nextTimes);
-          this.nextDuration = momentService(this.nextScheduled).fromNow();
         }
-      }
+      };
 
-      this.$onInit = setScheduled;
+      this.$onInit = this.updateSchedule;
+
+      this.getNextDuration = () => momentService(this.nextScheduled).fromNow();
     },
     template: `
-      <span is-visible="$ctrl.nextScheduled">
+      <span is-visible="$ctrl.hasNextScheduled">
         <span class="glyphicon glyphicon-time"
               popover-placement="left"
               popover-trigger="mouseenter"
-              uib-popover="Next run: {{$ctrl.nextScheduled | timestamp}} ({{$ctrl.nextDuration}})"></span>
+              ng-mouseenter="$ctrl.updateSchedule()"
+              uib-popover="Next run: {{$ctrl.nextScheduled | timestamp}} ({{$ctrl.getNextDuration()}})"></span>
       </span>`
   });


### PR DESCRIPTION
Nobody has complained about this, but the "next run" calculations are only done when the component first renders, so the calculations (especially the human-readable part) can appear incorrect as time marches forward.