### PR TITLE
(kubernetes): Render kubernetes events

### DIFF
--- a/app/scripts/modules/core/presentation/main.less
+++ b/app/scripts/modules/core/presentation/main.less
@@ -324,6 +324,22 @@ html {
   }
 }
 
+.glyphicon-Warn {
+  &:before {
+    content: "\26A0";
+    color: @unhealthy_red;
+    font-weight: bold;
+  }
+}
+
+.glyphicon-Normal {
+  &:before {
+    content: "\2022";
+    color: @healthy_green_border;
+    font-weight: bold;
+  }
+}
+
 .glyphicon-Up-triangle {
   &:before {
     content: "\25B2";

--- a/app/scripts/modules/kubernetes/event/event.directive.html
+++ b/app/scripts/modules/kubernetes/event/event.directive.html
@@ -1,0 +1,24 @@
+<div ng-controller="kubernetesEventController as ctrl" ng-class="dl-wide">
+  <div ng-if="ctrl.displayMessage">
+    <span uib-tooltip="{{ctrl.first | timestamp}} &rarr; {{ctrl.last | timestamp }}">
+      <span ng-if="ctrl.type === 'Warning'">
+        <span class="glyphicon glyphicon-Warn"></span>
+      </span>
+      <span ng-if="ctrl.type === 'Normal'">
+        <span class="glyphicon glyphicon-Normal"></span>
+      </span>
+      <span ng-if="ctrl.type === 'Unknown'">
+        ?
+      </span>
+      &times; {{ctrl.count}}
+    </span>
+    <div>
+      {{ctrl.reason}}:
+      {{ctrl.displayMessage}}
+      <a href ng-click="ctrl.showMessage()">...</a>
+    </div>
+  </div>
+  <div ng-if="!ctrl.displayMessage">
+    No message.
+  </div>
+</div>

--- a/app/scripts/modules/kubernetes/event/event.directive.js
+++ b/app/scripts/modules/kubernetes/event/event.directive.js
@@ -1,0 +1,34 @@
+'use strict';
+
+let angular = require('angular');
+
+module.exports = angular.module('spinnaker.kubernetes.event.event.directive', [])
+  .directive('kubernetesEvent', function () {
+    return {
+      restrict: 'E',
+      templateUrl: require('./event.directive.html'),
+      scope: {
+        event: '=',
+      }
+    };
+  }).controller('kubernetesEventController', function ($scope, $uibModal) {
+    if ($scope.event.message) {
+      this.displayMessage = $scope.event.message.substring(0, 25);
+    }
+
+    this.type = $scope.event.type;
+    this.count = $scope.event.count;
+    this.first = $scope.event.firstOccurrence;
+    this.last = $scope.event.lastOccurrence;
+    this.reason = $scope.event.reason;
+
+    this.showMessage = function showMessage() {
+      $scope.userDataModalTitle = 'Message';
+      $scope.userData = $scope.event.message;
+      $uibModal.open({
+        templateUrl: require('../../core/serverGroup/details/userData.html'),
+        controller: 'CloseableModalCtrl',
+        scope: $scope
+      });
+    };
+  });

--- a/app/scripts/modules/kubernetes/instance/details/details.html
+++ b/app/scripts/modules/kubernetes/instance/details/details.html
@@ -189,8 +189,16 @@
           <p>Exit Code: {{instance.containerStatuses[$index].state.terminated.exitCode}}</p>
           <p>Signal: {{instance.containerStatuses[$index].state.terminated.signal}}</p>
           </dd>
-        </collapsible-section>
+        </div>
       </div>
-    </div>
+    </collapsible-section>
+    <collapsible-section heading="Events">
+      <div ng-if="instance.events && instance.events.length > 0">
+        <kubernetes-event ng-repeat="event in instance.events" event="event"/>
+      </div>
+      <div ng-if="!(instance.events && instance.events.length > 0)">
+        No events.
+      </div>
+    </collapsible-section>
   </div>
 </div>

--- a/app/scripts/modules/kubernetes/kubernetes.module.js
+++ b/app/scripts/modules/kubernetes/kubernetes.module.js
@@ -22,6 +22,7 @@ module.exports = angular.module('spinnaker.kubernetes', [
   require('./cluster/cluster.kubernetes.module.js'),
   require('./container/configurer.directive.js'),
   require('./container/probe.directive.js'),
+  require('./event/event.directive.js'),
   require('./instance/details/details.kubernetes.module.js'),
   require('./loadBalancer/configure/configure.kubernetes.module.js'),
   require('./loadBalancer/details/details.kubernetes.module.js'),


### PR DESCRIPTION
Render events for kubernetes pods (more resources incoming). 

@danielpeach PTAL, @duftler FYI

Timestamps show on hover-over
![v6wxvqjrxyw](https://cloud.githubusercontent.com/assets/4874941/18100765/35a13330-6eba-11e6-9563-53f0a5c0caf5.png)

Events are listed with how often they occur and brief summary
![1khnj8lszsn](https://cloud.githubusercontent.com/assets/4874941/18100766/36f814c4-6eba-11e6-8d52-f8db281e5320.png)

All details are expanded by clicking the ellipses. 
![lvdpntk6us1](https://cloud.githubusercontent.com/assets/4874941/18100767/3816e178-6eba-11e6-85f1-c4f78f542a0d.png)


