### PR TITLE
Support rudimentary templating in default IAM roles

### DIFF
--- a/app/scripts/modules/amazon/serverGroup/configure/serverGroupCommandBuilder.service.js
+++ b/app/scripts/modules/amazon/serverGroup/configure/serverGroupCommandBuilder.service.js
@@ -34,6 +34,9 @@ module.exports = angular.module('spinnaker.aws.serverGroupCommandBuilder.service
           var keyPair = credentials ? credentials.defaultKeyPair : null;
           var applicationAwsSettings = _.get(application, 'attributes.providerSettings.aws', {});
 
+          var defaultIamRole = settings.providers.aws.defaults.iamRole || 'BaseIAMRole';
+          defaultIamRole = defaultIamRole.replace('{{application}}', application.name);
+
           var command = {
             application: application.name,
             credentials: defaultCredentials,
@@ -51,7 +54,7 @@ module.exports = angular.module('spinnaker.aws.serverGroupCommandBuilder.service
             instanceMonitoring: false,
             ebsOptimized: false,
             selectedProvider: 'aws',
-            iamRole: 'BaseIAMRole', // TODO: should not be hard coded here
+            iamRole: defaultIamRole,
             terminationPolicies: ['Default'],
             vpcId: null,
             availabilityZones: availabilityZones,

--- a/app/scripts/modules/amazon/serverGroup/configure/serverGroupCommandBuilder.spec.js
+++ b/app/scripts/modules/amazon/serverGroup/configure/serverGroupCommandBuilder.spec.js
@@ -9,11 +9,12 @@ describe('awsServerGroupCommandBuilder', function() {
     )
   );
 
-  beforeEach(window.inject(function(awsServerGroupCommandBuilder, accountService, $q, $rootScope, subnetReader, instanceTypeService) {
+  beforeEach(window.inject(function(awsServerGroupCommandBuilder, accountService, $q, $rootScope, subnetReader, instanceTypeService, _settings_) {
     this.awsServerGroupCommandBuilder = awsServerGroupCommandBuilder;
     this.$scope = $rootScope;
     this.instanceTypeService = instanceTypeService;
     this.$q = $q;
+    this.settings = _settings_;
     spyOn(accountService, 'getPreferredZonesByAccount').and.returnValue($q.when(AccountServiceFixture.preferredZonesByAccount));
     spyOn(accountService, 'getCredentialsKeyedByAccount').and.returnValue($q.when(AccountServiceFixture.credentialsKeyedByAccount));
     spyOn(subnetReader, 'listSubnets').and.returnValue($q.when([]));
@@ -26,6 +27,7 @@ describe('awsServerGroupCommandBuilder', function() {
 
     it('initializes to default values, setting usePreferredZone flag to true', function () {
       var command = null;
+      this.settings.providers.aws.defaults.iamRole = '{{application}}IAMRole';
       this.awsServerGroupCommandBuilder.buildNewServerGroupCommand({name: 'appo', defaultCredentials: {}, defaultRegions: {}}, 'aws').then(function(result) {
         command = result;
       });
@@ -34,6 +36,7 @@ describe('awsServerGroupCommandBuilder', function() {
 
       expect(command.viewState.usePreferredZones).toBe(true);
       expect(command.availabilityZones).toEqual(['a', 'b', 'c']);
+      expect(command.iamRole).toBe('appoIAMRole');
     });
 
 

--- a/settings.js
+++ b/settings.js
@@ -27,7 +27,8 @@ window.spinnakerSettings = {
     aws: {
       defaults: {
         account: 'test',
-        region: 'us-east-1'
+        region: 'us-east-1',
+        iamRole: 'BaseIAMRole',
       },
       defaultSecurityGroups: [],
       loadBalancers: {


### PR DESCRIPTION
- Currently only handles {[application}}