### PR TITLE
provider/core: changed name from serialize application to save snapshot

### DIFF
--- a/app/scripts/modules/core/application/config/applicationSnapshotSection.component.html
+++ b/app/scripts/modules/core/application/config/applicationSnapshotSection.component.html
@@ -6,7 +6,7 @@
         <p>
           Taking an application snapshot will save the current state of the infrastructure to a storage bucket <br>
           using <a href="https://www.terraform.io/docs/configuration/index.html">Terraform's config language</a>.
-          Currently only GCE and GCS are supported.
+          Currently only GCE infrastructure and GCS or S3 storage are supported.
         </p>
 
         <button class="btn btn-link" ng-click="$ctrl.takeSnapshot()"><span

--- a/app/scripts/modules/core/snapshot/snapshot.write.service.js
+++ b/app/scripts/modules/core/snapshot/snapshot.write.service.js
@@ -17,7 +17,7 @@ module.exports = angular
       accountDetails.forEach((accountDetail) => {
         if (cloudProviderRegistry.getValue(accountDetail.cloudProvider, 'snapshotsEnabled')) {
           jobs.push({
-            type: 'serializeApplication',
+            type: 'saveSnapshot',
             credentials: accountDetail.name,
             applicationName: app.name,
             cloudProvider: accountDetail.cloudProvider,
@@ -53,7 +53,7 @@ module.exports = angular
         return taskExecutor.executeTask({
           job: jobs,
           application: app,
-          description: 'Serialize Application: ' + app.name
+          description: 'Take Snapshot of ' + app.name
         });
       });
     }


### PR DESCRIPTION
Changed the name from serializeApplication to saveSnapshot. Not too much here because Dan changed most of the names when he added the diff view. PTAL @lwander 