### PR TITLE
(core) guard against missing trigger in autocomplete

### DIFF
--- a/app/scripts/modules/core/widgets/spelText/spelAutocomplete.service.js
+++ b/app/scripts/modules/core/widgets/spelText/spelAutocomplete.service.js
@@ -255,8 +255,8 @@ module.exports = angular
         codedHelperParamsCopy = pipelineHasParameters
                                   ? codedHelperParamsCopy
                                   : codedHelperParamsCopy.filter((param) => param.name !== 'parameters');
-
-        let hasJenkinsTriggerOrStage = pipeline.trigger.type === 'jenkins' || pipeline.stages.some((stage) => stage.type === 'jenkins');
+        let trigger = pipeline.trigger || {};
+        let hasJenkinsTriggerOrStage = trigger.type === 'jenkins' || pipeline.stages.some((stage) => stage.type === 'jenkins');
         codedHelperParamsCopy = hasJenkinsTriggerOrStage
           ? codedHelperParamsCopy
           : codedHelperParamsCopy.filter((param) => param.name.indexOf('scmInfo') === -1);


### PR DESCRIPTION
If the pipeline has never run, there won't be a `trigger` field, since the `pipeline` will be the pipeline config itself, and we'll get a NPE.

@zanthrash PTAL