### PR TITLE
updates rendering of up/down flag on load balancer 

### DIFF
--- a/app/scripts/modules/core/instance/instanceListBody.directive.js
+++ b/app/scripts/modules/core/instance/instanceListBody.directive.js
@@ -66,7 +66,7 @@ module.exports = angular.module('spinnaker.core.instance.instanceListBody.direct
           let row = '<td>';
           loadBalancers.forEach(function (loadBalancer) {
             var tooltip = loadBalancer.state === 'OutOfService' ? loadBalancer.description.replace(/"/g, '&quot;') : null;
-            var icon = loadBalancer.state === 'InService' ? 'Up' : 'Down';
+            var icon = (loadBalancer.healthState === 'Up' || loadBalancer.state === 'InService') ? 'Up' : 'Down';
 
             if (tooltip) {
               tooltipEnabled = true;

--- a/app/scripts/modules/core/instance/loadBalancer/health.html
+++ b/app/scripts/modules/core/instance/loadBalancer/health.html
@@ -1,7 +1,7 @@
-<div style="display:inline-block" uib-tooltip="{{loadBalancer.state === 'OutOfService' ? loadBalancer.description : ''}}" tooltip-placement="left">
-  <span ng-if="loadBalancer.state === 'InService'"
+<div style="display:inline-block" uib-tooltip="{{healthState !== 'Up' ? loadBalancer.description : ''}}" tooltip-placement="left">
+  <span ng-if="healthState === 'Up'"
         class="glyphicon glyphicon-Up-triangle"></span>
-  <span ng-if="loadBalancer.state === 'OutOfService'"
+  <span ng-if="healthState === 'OutOfService'"
         class="glyphicon glyphicon-Down-triangle"></span>
   <span>{{name}}</span>
 </div>

--- a/app/scripts/modules/core/instance/loadBalancer/instanceLoadBalancerHealth.directive.js
+++ b/app/scripts/modules/core/instance/loadBalancer/instanceLoadBalancerHealth.directive.js
@@ -12,6 +12,7 @@ module.exports = angular.module('spinnaker.core.instance.loadBalancer.health.dir
       },
       templateUrl: require('./health.html'),
       link: function(scope) {
+        scope.healthState = scope.loadBalancer.healthState || (scope.loadBalancer.state === 'InService' ? 'Up' : 'OutOfService');
         scope.name = scope.loadBalancer.name || scope.loadBalancer.loadBalancerName;
       }
     };


### PR DESCRIPTION
uses the healthState attribute (if available, comes from spinnaker/clouddriver#1003) instead of recomputing meanings of AWS fields on the front end

falls back to using the value of state if healthState is not present, so this should be safely deployable independent of the corresponding clouddriver change that adds that new attribute

@anotherchrisberry PTAL