### PR TITLE
(core) use min-height instead of height on rollup title cell

### DIFF
--- a/app/scripts/modules/core/cluster/rollups.less
+++ b/app/scripts/modules/core/cluster/rollups.less
@@ -182,7 +182,7 @@ server-group {
   }
   h5 {
     line-height: 39px;
-    height: 39px;
+    min-height: 39px;
     margin: 0;
     font-size: 110%;
     font-weight: 300;


### PR DESCRIPTION
This fixes an obscure(ish) issue where a cluster has a really long name that stretches to two lines, but does not have any instances reporting health, so there is no instance health counter.