### PR TITLE
changed size of ssl field so full text for terminated_https displays

### DIFF
--- a/app/scripts/modules/openstack/loadBalancer/configure/wizard/listeners.html
+++ b/app/scripts/modules/openstack/loadBalancer/configure/wizard/listeners.html
@@ -9,7 +9,7 @@
           <th>External Port</th>
           <th></th>
           <th>Internal Port</th>
-          <th ng-if="ctrl.showSslCertificateIdField()" width="30%">SSL Certificate Name</th>
+          <th ng-if="ctrl.showSslCertificateIdField()" width="25%">SSL Certificate Name</th>
           <th></th>
         </tr>
         </thead>

--- a/app/scripts/modules/openstack/loadBalancer/configure/wizard/upsert.controller.js
+++ b/app/scripts/modules/openstack/loadBalancer/configure/wizard/upsert.controller.js
@@ -196,7 +196,7 @@ module.exports = angular.module('spinnaker.loadBalancer.openstack.create.control
 
     this.showSslCertificateIdField = function() {
       return $scope.loadBalancer.listeners.some(function(listener) {
-        return listener.externalProtocol === 'TERMINATED_HTTPS' || listener.externalProtocol === 'SSL';
+        return listener.externalProtocol === 'TERMINATED_HTTPS';
       });
     };
 


### PR DESCRIPTION
Also removed ssl reference as it's not an option for externalProtocol

Before:
<img width="611" alt="screen shot 2016-09-14 at 8 42 20 am" src="https://cloud.githubusercontent.com/assets/2137281/18514429/3623826a-7a57-11e6-9572-16ed87cc1106.png">

After:
<img width="622" alt="screen shot 2016-09-14 at 8 36 15 am" src="https://cloud.githubusercontent.com/assets/2137281/18514399/18e278be-7a57-11e6-95ed-e8afc1f11279.png">
