### PR TITLE
changed size of ssl field so full text for terminated_https displays

### DIFF
--- a/app/scripts/modules/openstack/loadBalancer/configure/wizard/listeners.html
+++ b/app/scripts/modules/openstack/loadBalancer/configure/wizard/listeners.html
@@ -9,7 +9,7 @@
           <th>External Port</th>
           <th></th>
           <th>Internal Port</th>
-          <th ng-if="ctrl.showSslCertificateIdField()" width="30%">SSL Certificate Name</th>
+          <th ng-if="ctrl.showSslCertificateIdField()" width="25%">SSL Certificate Name</th>
           <th></th>
         </tr>
         </thead>

--- a/app/scripts/modules/openstack/loadBalancer/configure/wizard/upsert.controller.js
+++ b/app/scripts/modules/openstack/loadBalancer/configure/wizard/upsert.controller.js
@@ -196,7 +196,7 @@ module.exports = angular.module('spinnaker.loadBalancer.openstack.create.control
 
     this.showSslCertificateIdField = function() {
       return $scope.loadBalancer.listeners.some(function(listener) {
-        return listener.externalProtocol === 'TERMINATED_HTTPS' || listener.externalProtocol === 'SSL';
+        return listener.externalProtocol === 'TERMINATED_HTTPS';
       });
     };
 

--- a/app/scripts/modules/openstack/loadBalancer/configure/wizard/upsert.controller.spec.js
+++ b/app/scripts/modules/openstack/loadBalancer/configure/wizard/upsert.controller.spec.js
@@ -36,7 +36,7 @@ describe('Controller: openstackCreateLoadBalancerCtrl', function () {
       listeners: [
         {
           internalPort: 443,
-          externalProtocol: 'TERMINATED_HTTPS',
+          externalProtocol: 'HTTP',
           externalPort: 443
         }
       ]

--- a/app/scripts/modules/openstack/loadBalancer/transformer.js
+++ b/app/scripts/modules/openstack/loadBalancer/transformer.js
@@ -25,7 +25,7 @@ module.exports = angular.module('spinnaker.openstack.loadBalancer.transformer', 
       listeners: [
         {
           internalPort: 443,
-          externalProtocol: 'TERMINATED_HTTPS',
+          externalProtocol: 'HTTP',
           externalPort: 443
         }
       ]


### PR DESCRIPTION
changed default listener protocol to http
removed ssl reference since it's not an option for externalProtocol
