### PR TITLE
(core) remove bower preinstall step

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "build": "node ./node_modules/webpack/bin/webpack.js",
     "start": "node ./node_modules/webpack-dev-server/bin/webpack-dev-server.js",
     "test": "./node_modules/karma/bin/karma start",
-    "preinstall": "npm install -g bower@1.4.1",
     "int": "protractor protractor.conf.js"
   },
   "devDependencies": {


### PR DESCRIPTION
Do we need bower installed still? Let's find out...