### PR TITLE
(core) cache node_modules between builds, use Travis's Chromium

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,19 +4,16 @@ jdk:
 sudo: required
 dist: trusty
 before_install:
- - export CHROME_BIN=/usr/bin/google-chrome
+ - export CHROME_BIN=chromium-browser
  - export DISPLAY=:99.0
  - sh -e /etc/init.d/xvfb start
- - sudo apt-get update
- - sudo apt-get install -y libappindicator1 fonts-liberation
- - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
- - sudo dpkg -i google-chrome*.deb
 install: gradle/installViaTravis.sh
 script: gradle/buildViaTravis.sh
 before_cache: gradle/prepCaches.sh
 cache:
   directories:
   - $HOME/.gradle
+  - node_modules
 env:
   global:
   - secure: c5RGrL+JcaGsI18MOMLW6kZoQRteiFrbfOoDY5JjJb7ZaACynZu1DdZ83p19nNhdzpSKBqFv/iKx7QN9vqQDXlh0M2fefWYVuh9QHhmQyyqgcc9X7pYZ2OrsLjUg2J0GZcSYaqaX/TjWuJL1lpQbdiiKqhgi915eWHLghvIgEy05UyvZVLRTVClDSeMGEKbnJ480B6crG4ads8pT3dGzVd4+WmtoAJWJpeSxMD4UEmxQ509QV9h4jKiTjPb2LZ4e1W+HLrtNm7x/g2id5IiP70GrL2MGw/V1ptlybkUOumtfZoZWOOMmTCuktG5xLM9ldp64TXhZJ/e1jTr3U4m9k4HZJRmdpJONSY8rduZiqBfoLnGWW8/FQssrbrsNhpUGEPuknRZPOVcQiSQnVHPe0+zJrCHS6OhMhkfozw2o/guE4uLtnAkLtsaCb0ZK8f+dSoQwhG4erdwOala7UqdSgtqMyU5D0Lwc2FGGb1XbiLFuLMTWn5BEs6hX+i5mAv/osxuRW3RIJpU5DOhbKq9Bv95EIMhgGvUotNBVubsdOgUK/7D43bTEpUHshCAUsnBPhWt85eido4sAth2FEcbxeIvLFAq117rR9ZbhpyZ+wVR8N8EuEC/FPGQNzprYxE9qOOIG++d4SvP1YYDlg3z88mz6C8+gYZYF7upro+7MhtA=

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,5 +1,8 @@
 'use strict';
 
+var HappyPack = require('happypack');
+var happyThreadPool = HappyPack.ThreadPool({ size: 6 });
+
 module.exports = function(config) {
   config.set({
     autoWatch: true,
@@ -39,7 +42,7 @@ module.exports = function(config) {
           },
           {
             test: /\.js$/,
-            loader: 'ng-annotate!angular!babel!envify!eslint',
+            loader: 'happypack/loader?id=jstest',
             exclude: /node_modules(?!\/clipboard)/,
           },
           {
@@ -67,6 +70,16 @@ module.exports = function(config) {
           }
         ]
       },
+      plugins: [
+        new HappyPack({
+          id: 'jstest',
+          loaders: [ 'ng-annotate!angular!babel!envify!eslint' ],
+          threadPool: happyThreadPool,
+          cacheContext: {
+            env: process.env,
+          },
+        }),
+      ],
       watch: true,
     },
 


### PR DESCRIPTION
Not totally in love with caching `node_modules`, but it cuts a couple of minutes off the build.

Using Chromium (it's preinstalled on Travis boxes) cuts another minute or so off the build.

@zanthrash @icfantv PTAL