### PR TITLE
Azure bug fix: failed to create server group using selected vnet/subnet

### DIFF
--- a/app/scripts/modules/azure/serverGroup/serverGroup.transformer.js
+++ b/app/scripts/modules/azure/serverGroup/serverGroup.transformer.js
@@ -38,6 +38,8 @@ module.exports = angular.module('spinnaker.azure.serverGroup.transformer', [
         freeFormDetails: command.freeFormDetails,
         account: command.credentials,
         selectedProvider: 'azure',
+        vnet: command.vnet,
+        subnet: command.subnet,
         capacity: {
           useSourceCapacity: false,
           min: command.sku.capacity,


### PR DESCRIPTION
Bug fix: we are failing to submit the expected configuration when creating the server group using the user selected vnet and subnet.