### PR TITLE
Making the standalone pipeline view refresh the pipeline-graph

### DIFF
--- a/app/scripts/modules/core/delivery/executionGroup/execution/execution.directive.html
+++ b/app/scripts/modules/core/delivery/executionGroup/execution/execution.directive.html
@@ -79,10 +79,10 @@
   </div>
 
   <div ng-if="vm.showDetails()" class="execution-graph">
-    <pipeline-graph ng-if="::vm.execution.parallel"
-                    execution="::vm.execution"
-                    on-node-click="::vm.toggleDetails"
-                    view-state="::vm.viewState">
+    <pipeline-graph ng-if="vm.execution.parallel"
+                    execution="vm.execution"
+                    on-node-click="vm.toggleDetails"
+                    view-state="vm.viewState">
 
     </pipeline-graph>
   </div>

--- a/app/scripts/modules/core/pipeline/config/graph/pipeline.graph.directive.js
+++ b/app/scripts/modules/core/pipeline/config/graph/pipeline.graph.directive.js
@@ -346,6 +346,7 @@ module.exports = angular.module('spinnaker.core.pipeline.config.graph.directive'
 
         scope.$watch('pipeline', updateGraph, true);
         scope.$watch('viewState', updateGraph, true);
+        scope.$watch('execution', updateGraph, true);
         $($window).bind('resize.pipelineGraph-' + graphId, handleWindowResize);
 
         scope.$on('$destroy', function() {


### PR DESCRIPTION
In the standalone view, when there are multiple nested pipelines, the pipeline-grap does not update when the execution changes on the scope.

@anotherchrisberry @icfantv PTAL