### PR TITLE
Bug fix - failed to select vnet in arbitrary resource group

### DIFF
--- a/app/scripts/modules/azure/loadBalancer/configure/createLoadBalancer.controller.js
+++ b/app/scripts/modules/azure/loadBalancer/configure/createLoadBalancer.controller.js
@@ -169,14 +169,17 @@ module.exports = angular.module('spinnaker.azure.loadBalancer.create.controller'
           region = $scope.loadBalancer.region;
       $scope.loadBalancer.selectedVnet = null;
       $scope.loadBalancer.vnet = null;
+      $scope.loadBalancer.vnetResourceGroup = null;
       ctrl.selectedVnets = [ ];
 
-      networkReader.listNetworksByProvider('azure').then(function(vnets) {
-        vnets.map(function(vnet) {
-          if (vnet.account === account && vnet.region === region) {
-            ctrl.selectedVnets.push(vnet);
-          }
-        });
+      networkReader.listNetworks().then(function(vnets) {
+        if (vnets.azure) {
+          vnets.azure.forEach((vnet) => {
+            if (vnet.account === account && vnet.region === region) {
+              ctrl.selectedVnets.push(vnet);
+            }
+          });
+        }
       });
 
       ctrl.subnetUpdated();
@@ -190,6 +193,7 @@ module.exports = angular.module('spinnaker.azure.loadBalancer.create.controller'
 
     this.selectedVnetChanged = function(item) {
       $scope.loadBalancer.vnet = item.name;
+      $scope.loadBalancer.vnetResourceGroup = item.resourceGroup;
       $scope.loadBalancer.selectedSubnet = null;
       $scope.loadBalancer.subnet = null;
       ctrl.selectedSubnets = [ ];
@@ -230,6 +234,7 @@ module.exports = angular.module('spinnaker.azure.loadBalancer.create.controller'
 
           if($scope.loadBalancer.selectedVnet) {
             $scope.loadBalancer.vnet = $scope.loadBalancer.selectedVnet.name;
+            $scope.loadBalancer.vnetResourceGroup = $scope.loadBalancer.selectedVnet.resourceGroup;
           }
 
           if($scope.loadBalancer.selectedSubnet) {

--- a/app/scripts/modules/azure/loadBalancer/configure/createLoadBalancer.controller.spec.js
+++ b/app/scripts/modules/azure/loadBalancer/configure/createLoadBalancer.controller.spec.js
@@ -44,7 +44,7 @@ describe('Controller: azureCreateLoadBalancerCtrl', function () {
   });
 
   it('makes the expected REST calls for data for a new loadbalancer', function() {
-    $http.when('GET', API.baseUrl + '/networks/azure').respond([]);
+    $http.when('GET', API.baseUrl + '/networks').respond([]);
     $http.when('GET', API.baseUrl + '/loadBalancers?provider=azure').respond([]);
     $http.when('GET', API.baseUrl + '/securityGroups').respond({});
     $http.when('GET', API.baseUrl + '/credentials').respond([]);

--- a/app/scripts/modules/azure/serverGroup/configure/serverGroupCommandBuilder.service.js
+++ b/app/scripts/modules/azure/serverGroup/configure/serverGroupCommandBuilder.service.js
@@ -74,6 +74,7 @@ module.exports = angular.module('spinnaker.azure.serverGroupCommandBuilder.servi
         securityGroupName: serverGroup.securityGroupName,
         region: serverGroup.region,
         vnet: serverGroup.vnet,
+        vnetResourceGroup: serverGroup.vnetResourceGroup,
         subnet: serverGroup.subnet,
         sku: serverGroup.sku,
         capacity: {

--- a/app/scripts/modules/azure/serverGroup/configure/serverGroupConfiguration.service.js
+++ b/app/scripts/modules/azure/serverGroup/configure/serverGroupConfiguration.service.js
@@ -184,12 +184,14 @@ module.exports = angular.module('spinnaker.azure.serverGroup.configure.service',
         // reset previous set values
         command.loadBalancerName = null;
         command.vnet = null;
+        command.vnetResourceGroup = null;
         command.subnet = null;
         command.selectedSubnet = null;
         command.selectedVnet = null;
         command.selectedVnetSubnets = [];
         command.viewState.networkSettingsConfigured = false;
-        command.securityGroup = null;
+        command.selectedSecurityGroup = null;
+        command.securityGroupName = null;
 
         return result;
       };

--- a/app/scripts/modules/azure/serverGroup/configure/wizard/CloneServerGroup.azure.controller.js
+++ b/app/scripts/modules/azure/serverGroup/configure/wizard/CloneServerGroup.azure.controller.js
@@ -101,6 +101,7 @@ module.exports = angular.module('spinnaker.azure.cloneServerGroup.controller', [
       if (mode === 'clone' || mode === 'editPipeline') {
         v2modalWizardService.markComplete('basic-settings');
         v2modalWizardService.markComplete('load-balancers');
+        v2modalWizardService.markComplete('network-settings');
         v2modalWizardService.markComplete('security-groups');
       }
     }
@@ -124,6 +125,7 @@ module.exports = angular.module('spinnaker.azure.cloneServerGroup.controller', [
     function processCommandUpdateResult(result) {
       if (result.dirty.loadBalancers) {
         v2modalWizardService.markDirty('load-balancers');
+        v2modalWizardService.markDirty('network-settings');
       }
       if (result.dirty.securityGroups) {
         v2modalWizardService.markDirty('security-groups');

--- a/app/scripts/modules/azure/serverGroup/configure/wizard/loadBalancers/ServerGroupLoadBalancers.controller.js
+++ b/app/scripts/modules/azure/serverGroup/configure/wizard/loadBalancers/ServerGroupLoadBalancers.controller.js
@@ -18,26 +18,28 @@ module.exports = angular.module('spinnaker.azure.serverGroup.configure.loadBalan
       loadBalancerReader.getLoadBalancerDetails('azure', $scope.command.credentials, $scope.command.region, item).then (function (LBs) {
         if (LBs && LBs.length === 1) {
           var selectedLoadBalancer = LBs[0];
-          networkReader.listNetworksByProvider('azure').then(function(vnets) {
-            vnets.map(function(selectedVnet) {
-              if (selectedVnet.account === $scope.command.credentials && selectedVnet.region === $scope.command.region && selectedVnet.name == selectedLoadBalancer.vnet) {
-                $scope.command.selectedVnet = selectedVnet;
-                selectedVnet.subnets.map(function(subnet) {
-                  var addSubnet = true;
-                  if (subnet.devices) {
-                    subnet.devices.map(function(device) {
-                      // only add subnets that are not assigned to an ApplicationGateway
-                      if (device && device.type === 'applicationGateways') {
-                        addSubnet = false;
-                      }
-                    });
-                  }
-                  if (addSubnet) {
-                    $scope.command.selectedVnetSubnets.push(subnet.name);
-                  }
-                });
-              }
-            });
+          networkReader.listNetworks().then(function(vnets) {
+            if (vnets.azure) {
+              vnets.azure.forEach((selectedVnet) => {
+                if (selectedVnet.account === $scope.command.credentials && selectedVnet.region === $scope.command.region && selectedVnet.name == selectedLoadBalancer.vnet) {
+                  $scope.command.selectedVnet = selectedVnet;
+                  selectedVnet.subnets.map(function(subnet) {
+                    var addSubnet = true;
+                    if (subnet.devices) {
+                      subnet.devices.map(function(device) {
+                        // only add subnets that are not assigned to an ApplicationGateway
+                        if (device && device.type === 'applicationGateways') {
+                          addSubnet = false;
+                        }
+                      });
+                    }
+                    if (addSubnet) {
+                      $scope.command.selectedVnetSubnets.push(subnet.name);
+                    }
+                  });
+                }
+              });
+            }
           });
         }
       });

--- a/app/scripts/modules/azure/serverGroup/configure/wizard/securityGroup/ServerGroupSecurityGroups.controller.js
+++ b/app/scripts/modules/azure/serverGroup/configure/wizard/securityGroup/ServerGroupSecurityGroups.controller.js
@@ -5,11 +5,12 @@ let angular = require('angular');
 module.exports = angular.module('spinnaker.azure.serverGroup.configure.securityGroups.controller', [
   require('../../../../../core/modal/wizard/v2modalWizard.service.js'),
   ])
-  .controller('azureServerGroupSecurityGroupsCtrl', function(v2modalWizardService) {
+  .controller('azureServerGroupSecurityGroupsCtrl', function($scope, v2modalWizardService) {
     v2modalWizardService.markClean('security-groups');
     v2modalWizardService.markComplete('security-groups');
 
-    this.securityGroupChanged = () => {
+    this.securityGroupChanged = function(securityGroup) {
+      $scope.command.securityGroupName = securityGroup.id;
       v2modalWizardService.markComplete('security-groups');
     };
   });

--- a/app/scripts/modules/azure/serverGroup/configure/wizard/securityGroup/serverGroupSecurityGroupsSelector.directive.html
+++ b/app/scripts/modules/azure/serverGroup/configure/wizard/securityGroup/serverGroupSecurityGroupsSelector.directive.html
@@ -3,9 +3,9 @@
   <div class="form-group">
     <div class="col-md-3 sm-label-right"><b>Security Groups</b></div>
     <div class="col-md-7">
-      <ui-select ng-model="command.securityGroupName" class="form-control input-sm" on-select="securityGroupCtrl.securityGroupChanged()">
+      <ui-select ng-model="command.selectedSecurityGroup" class="form-control input-sm" on-select="securityGroupCtrl.securityGroupChanged($item)">
         <ui-select-match placeholder="select a security group">{{$select.selected.id}}</ui-select-match>
-        <ui-select-choices repeat="securityGroup.id for securityGroup in command.backingData.filtered.securityGroups | anyFieldFilter: {name: $select.search, id: $select.search}">
+        <ui-select-choices repeat="securityGroup in command.backingData.filtered.securityGroups | anyFieldFilter: {name: $select.search, id: $select.search}">
           <span ng-bind-html="securityGroup.id | highlight: $select.search"></span>
         </ui-select-choices>
       </ui-select>

--- a/app/scripts/modules/azure/serverGroup/serverGroup.transformer.js
+++ b/app/scripts/modules/azure/serverGroup/serverGroup.transformer.js
@@ -39,6 +39,7 @@ module.exports = angular.module('spinnaker.azure.serverGroup.transformer', [
         account: command.credentials,
         selectedProvider: 'azure',
         vnet: command.vnet,
+        vnetResourceGroup: command.vnetResourceGroup,
         subnet: command.subnet,
         capacity: {
           useSourceCapacity: false,


### PR DESCRIPTION
When creating an azure load balancer and server group, the selected virtual network can be from a different resource group then the one corresponding to the application.