### PR TITLE
(core) allow pipeline reorder after refresh

### DIFF
--- a/app/scripts/modules/core/delivery/filter/executionFilter.service.js
+++ b/app/scripts/modules/core/delivery/filter/executionFilter.service.js
@@ -191,6 +191,7 @@ module.exports = angular
           groupsToRemove.push(idx);
         } else {
           oldGroup.runningExecutions = newGroup.runningExecutions;
+          oldGroup.config = newGroup.config;
           diffExecutions(oldGroup, newGroup);
         }
       });


### PR DESCRIPTION
Fixes bug where pipelines could not be reordered after application refresh -- a refresh caused pipeline config references to be lost.

@anotherchrisberry please review.