### PR TITLE
(core) fix refresh calls on objects

### DIFF
--- a/app/scripts/modules/core/delivery/service/execution.service.js
+++ b/app/scripts/modules/core/delivery/service/execution.service.js
@@ -84,7 +84,7 @@ module.exports = angular.module('spinnaker.core.delivery.executions.service', [
 
     function waitUntilPipelineIsCancelled(application, executionId) {
       return waitUntilExecutionMatches(executionId, (execution) => execution.status === 'CANCELED')
-        .then(application.executions.refresh);
+        .then(() => application.executions.refresh());
     }
 
     function waitUntilPipelineIsDeleted(application, executionId) {
@@ -93,7 +93,7 @@ module.exports = angular.module('spinnaker.core.delivery.executions.service', [
         () => $timeout(() => waitUntilPipelineIsDeleted(application, executionId).then(deferred.resolve), 1000),
         deferred.resolve
       );
-      deferred.promise.then(application.executions.refresh);
+      deferred.promise.then(() => application.executions.refresh());
       return deferred.promise;
     }
 
@@ -131,7 +131,7 @@ module.exports = angular.module('spinnaker.core.delivery.executions.service', [
           'pause',
         ].join('/')
       }).then(
-        () => waitUntilExecutionMatches(executionId, matcher).then(application.executions.refresh).then(deferred.resolve),
+        () => waitUntilExecutionMatches(executionId, matcher).then(() => application.executions.refresh()).then(deferred.resolve),
         (exception) => deferred.reject(exception && exception.data ? exception.message : null)
     );
       return deferred.promise;
@@ -152,7 +152,7 @@ module.exports = angular.module('spinnaker.core.delivery.executions.service', [
           'resume',
         ].join('/')
       }).then(
-        () => waitUntilExecutionMatches(executionId, matcher).then(application.executions.refresh).then(deferred.resolve),
+        () => waitUntilExecutionMatches(executionId, matcher).then(() => application.executions.refresh()).then(deferred.resolve),
         (exception) => deferred.reject(exception && exception.data ? exception.message : null)
     );
       return deferred.promise;

--- a/app/scripts/modules/core/task/tasks.controller.js
+++ b/app/scripts/modules/core/task/tasks.controller.js
@@ -106,7 +106,7 @@ module.exports = angular.module('spinnaker.core.task.controller', [
     controller.cancelTask = function(taskId) {
       var task = application.tasks.data.filter(function(task) { return task.id === taskId; })[0];
       var submitMethod = function () {
-        return taskWriter.cancelTask(application.name, taskId).then(application.tasks.refresh);
+        return taskWriter.cancelTask(application.name, taskId).then(() => application.tasks.refresh());
       };
 
       confirmationModalService.confirm({
@@ -120,7 +120,7 @@ module.exports = angular.module('spinnaker.core.task.controller', [
     controller.deleteTask = function(taskId) {
       var task = application.tasks.data.filter(function(task) { return task.id === taskId; })[0];
       var submitMethod = function () {
-        return taskWriter.deleteTask(taskId).then(application.tasks.refresh);
+        return taskWriter.deleteTask(taskId).then(() => application.tasks.refresh());
       };
 
       confirmationModalService.confirm({


### PR DESCRIPTION
Using classes with private fields means we can't be fancy with our `then` calls.

@zanthrash @icfantv FYI