### PR TITLE
Protection against doing a strategy-based deploy and not sending traf…

### DIFF
--- a/app/scripts/modules/amazon/serverGroup/configure/serverGroupConfiguration.service.js
+++ b/app/scripts/modules/amazon/serverGroup/configure/serverGroupConfiguration.service.js
@@ -55,6 +55,13 @@ module.exports = angular.module('spinnaker.aws.serverGroup.configure.service', [
         return command.suspendedProcesses.indexOf(process) !== -1;
       };
 
+      command.onStrategyChange = function (strategy) {
+        // Any strategy other than None or Custom should force traffic to be enabled
+        if (strategy.key !== '' && strategy.key !== 'custom') {
+          command.suspendedProcesses = (command.suspendedProcesses || []).filter(p => p !== 'AddToLoadBalancer');
+        }
+      };
+
       command.regionIsDeprecated = () => {
         return _.has(command, 'backingData.filtered.regions') &&
           command.backingData.filtered.regions.some((region) => region.name === command.region && region.deprecated);

--- a/app/scripts/modules/amazon/serverGroup/configure/wizard/location/basicSettings.html
+++ b/app/scripts/modules/amazon/serverGroup/configure/wizard/location/basicSettings.html
@@ -96,7 +96,9 @@
           <label>
             <input type="checkbox"
                    ng-click="command.toggleSuspendedProcess('AddToLoadBalancer')"
-                   ng-checked="!command.processIsSuspended('AddToLoadBalancer')"/>
+                   ng-checked="!command.processIsSuspended('AddToLoadBalancer')"
+                   ng-disabled="command.strategy !== '' && command.strategy !== 'custom'"
+            />
             Send client requests to new instances
           </label>
         </div>

--- a/app/scripts/modules/core/deploymentStrategy/deploymentStrategySelector.directive.html
+++ b/app/scripts/modules/core/deploymentStrategy/deploymentStrategySelector.directive.html
@@ -4,7 +4,7 @@
     <help-field key="core.serverGroup.strategy"></help-field>
   </div>
   <div class="col-md-{{fieldColumns || 10}}">
-    <ui-select ng-model="command.strategy" class="form-control input-sm">
+    <ui-select ng-model="command.strategy" class="form-control input-sm" on-select="command.onStrategyChange($item)">
       <ui-select-match placeholder="None">{{$select.selected.label}}</ui-select-match>
       <ui-select-choices repeat="strategy.key as strategy in deploymentStrategies | filter: $select.search">
         <strong ng-bind-html="strategy.label | highlight: $select.search"></strong>

--- a/app/scripts/modules/core/help/helpContents.js
+++ b/app/scripts/modules/core/help/helpContents.js
@@ -47,8 +47,9 @@ module.exports = angular.module('spinnaker.core.help.contents', [])
     'aws.serverGroup.tags': '(Optional) <b>Tags</b> are propagated to the instances in this cluster.',
     'aws.serverGroup.allImages': 'Search for an image that does not match the name of your application.',
     'aws.serverGroup.filterImages': 'Select from a pre-filtered list of images matching the name of your application.',
-    'aws.serverGroup.traffic': 'Enables the "AddToLoadBalancer" scaling process, which is used by Spinnaker and ' +
-    ' discovery services to determine if the server group is enabled.',
+    'aws.serverGroup.traffic': '' +
+      '<p>Enables the "AddToLoadBalancer" scaling process, which is used by Spinnaker and discovery services to determine if the server group is enabled.</p>' +
+      '<p>Will be automatically enabled when any non "custom" deployment strategy is selected.</p>',
     'aws.securityGroup.vpc': '<p>The VPC to which this security group will apply.</p>' +
       '<p>If you wish to use VPC but are unsure which VPC to use, the most common one is "Main".</p>' +
       '<p>If you do not wish to use VPC, select "None".</p>',
@@ -171,8 +172,9 @@ module.exports = angular.module('spinnaker.core.help.contents', [])
       If you want to cut instance utilization by half, set your balancing mode to 80% max CPU utilization and your capacity to 50%. Input must be a number between 0 and 100.`,
     'gce.serverGroup.loadBalancingPolicy.listeningPort': 'A load balancer sends traffic to an instance group through a named port. Input must be a port number (i.e., between 1 and 65535).',
     'gce.serverGroup.traffic': 'Registers the server group with any associated load balancers. These registrations are used by Spinnaker to determine if the server group is enabled.',
-    'titus.serverGroup.traffic': 'Enables the "inService" property, which is used by Spinnaker and ' +
-    ' discovery services to determine if the server group is enabled.',
+    'titus.serverGroup.traffic': '' +
+      '<p>Enables the "inService" scaling process, which is used by Spinnaker and discovery services to determine if the server group is enabled.</p>' +
+      '<p>Will be automatically enabled when any non "custom" deployment strategy is selected.</p>',
     'pipeline.config.optionalStage': '' +
       '<p>When this option is enabled, stage will only execute when the supplied expression evaluates true.</p>' +
       '<p>The expression <em>does not</em> need to be wrapped in ${ and }.</p>',

--- a/app/scripts/modules/titus/serverGroup/configure/serverGroupBasicSettingsDirective.html
+++ b/app/scripts/modules/titus/serverGroup/configure/serverGroupBasicSettingsDirective.html
@@ -67,7 +67,9 @@
       <div class="checkbox">
         <label>
           <input type="checkbox"
-                 ng-model="command.inService"/>
+                 ng-model="command.inService"
+                 ng-disabled="command.strategy !== '' && command.strategy !== 'custom'"
+          />
           Send client requests to new instances
         </label>
       </div>

--- a/app/scripts/modules/titus/serverGroup/configure/serverGroupConfiguration.service.js
+++ b/app/scripts/modules/titus/serverGroup/configure/serverGroupConfiguration.service.js
@@ -9,6 +9,12 @@ module.exports = angular.module('spinnaker.serverGroup.configure.titus.configura
 
 
     function configureCommand(command) {
+      command.onStrategyChange = function (strategy) {
+        // Any strategy other than None or Custom should force traffic to be enabled
+        if (strategy.key !== '' && strategy.key !== 'custom') {
+          command.inService = true;
+        }
+      };
       command.image = command.viewState.imageId;
       return $q.all({
         credentialsKeyedByAccount: accountService.getCredentialsKeyedByAccount('titus'),


### PR DESCRIPTION
…fic to the new instances

Previously behavior would launch a new disabled ASG + disable the current active ASG ...
potentially leaving a cluster with no active ASGs.

This PR takes the position that traffic should be enabled whenever a non "custom" deploy strategy
is used.

![image](https://cloud.githubusercontent.com/assets/388652/18653378/54cd9a80-7e8e-11e6-9567-a479b640006b.png)

![image](https://cloud.githubusercontent.com/assets/388652/18653383/5e2c37d0-7e8e-11e6-9a36-b4296a6f4cf4.png)

![image](https://cloud.githubusercontent.com/assets/388652/18653388/65ba89fc-7e8e-11e6-8b7f-6e5262201916.png)
