### PR TITLE
(core) better error handling for new app loading

### DIFF
--- a/app/scripts/modules/core/application/application.controller.js
+++ b/app/scripts/modules/core/application/application.controller.js
@@ -25,14 +25,9 @@ module.exports = angular.module('spinnaker.application.controller', [
     var hotkeyBind = hotkeys.bindTo($scope);
     var applicationHotkeys = [
       {
-        combo: 'ctrl+alt+0',
-        description: 'Pipeline Config',
-        callback: () => $state.go('home.applications.application.pipelineConfig'),
-      },
-      {
         combo: 'ctrl+alt+1',
         description: 'Pipelines',
-        callback: () => $state.go('home.applications.application.executions'),
+        callback: () => $state.go('home.applications.application.pipelines.executions'),
       },
       {
         combo: 'ctrl+alt+2',

--- a/app/scripts/modules/core/application/application.model.ts
+++ b/app/scripts/modules/core/application/application.model.ts
@@ -54,6 +54,12 @@ export class Application {
   public attributes: any = <any>{};
 
   /**
+   * Indicates that the application was not found in Front50
+   * @type {boolean}
+   */
+  public notFound: boolean = false;
+
+  /**
    * Returns a data source based on its key. Data sources can be accessed on the application directly via the key,
    * e.g. application.serverGroups, but this is the preferred access method, as it allows type inference
    * @param key

--- a/app/scripts/modules/core/application/config/dataSources/applicationDataSourceEditor.component.ts
+++ b/app/scripts/modules/core/application/config/dataSources/applicationDataSourceEditor.component.ts
@@ -27,6 +27,9 @@ export class DataSourceEditorController implements ng.IComponentController {
   constructor(private applicationWriter: any) {}
 
   $onInit() {
+    if (this.application.notFound) {
+      return;
+    }
     if (!this.application.attributes) {
       this.application.attributes = {};
     }

--- a/app/scripts/modules/core/application/service/applicationDataSource.ts
+++ b/app/scripts/modules/core/application/service/applicationDataSource.ts
@@ -125,7 +125,7 @@ export class ApplicationDataSource {
     }
 
     if (!config.activeState) {
-      this.activeState = '**.' + config.key + '.**';
+      this.activeState = '**' + this.sref + '.**';
     }
   }
 

--- a/app/scripts/modules/core/delivery/filter/executionFilter.model.js
+++ b/app/scripts/modules/core/delivery/filter/executionFilter.model.js
@@ -75,8 +75,8 @@ module.exports = angular
     });
 
     function isExecutionState(stateName) {
-      return stateName === 'home.applications.application.executions' ||
-        stateName === 'home.project.application.executions';
+      return stateName === 'home.applications.application.pipelines.executions' ||
+        stateName === 'home.project.application.pipelines.executions';
     }
 
     function isExecutionStateOrChild(stateName) {

--- a/app/scripts/modules/core/history/recentHistory.service.js
+++ b/app/scripts/modules/core/history/recentHistory.service.js
@@ -75,8 +75,26 @@ module.exports = angular.module('spinnaker.core.history.service', [
     }
 
     function getItems(type) {
-      var items = cache.get(type);
-      return items ? _.sortBy(items, 'accessTime').reverse() : [];
+      // Note: "application.executions" and "application.pipelineConfig" can be removed after 10/31/16
+      let replacements = [
+        {
+          state: 'application.executions',
+          replacement: 'application.pipelines.executions'
+        },
+        {
+          state: 'application.pipelineConfig',
+          replacement: 'application.pipelines.pipelineConfig'
+        },
+      ];
+      var items = cache.get(type) || [];
+      items.forEach(item => {
+        replacements.forEach(replacement => {
+          if (item.state && item.state.includes(replacement.state)) {
+            item.state = item.state.replace(replacement.state, replacement.replacement);
+          }
+        });
+      });
+      return _.sortBy(items, 'accessTime').reverse();
     }
 
     /**

--- a/app/scripts/modules/core/history/recentHistory.service.spec.js
+++ b/app/scripts/modules/core/history/recentHistory.service.spec.js
@@ -1,5 +1,3 @@
-'use strict';
-
 describe('recent history service', function() {
 
   var service, deckCacheFactory, backingCache;

--- a/app/scripts/modules/core/widgets/spelText/spelText.decorator.js
+++ b/app/scripts/modules/core/widgets/spelText/spelText.decorator.js
@@ -15,7 +15,7 @@ let decorateFn = function ($delegate, jsonListBuilder, spelAutocomplete) {
       link.apply(this, arguments);
 
       let type = el.attr('type');
-      if (type === 'checkbox' || type === 'radio' || type === 'search'  || el.closest('.no-spel').size()) {
+      if (type === 'checkbox' || type === 'radio' || type === 'search' || el.closest('.no-spel').size()) {
         return;
       }
 


### PR DESCRIPTION
* gracefully handle recent item entries for applications where the user was last on some executions view
* removing invalid hotkey entry
* adding `notFound` as a field on the application and using it to decide if we should initialize the data source config component - config page routes back to `/infrastructure` immediately if it's the case, but the component still initializes and throws a NPE
* correctly set default `activeState` based on `sref`, not `key`

@zanthrash @icfantv PTAL