### PR TITLE
(core) auto-bind this in class-level methods

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ['es2015']
+  "presets": ["es2015"]
 }

--- a/app/scripts/modules/amazon/securityGroup/configure/EditSecurityGroupCtrl.js
+++ b/app/scripts/modules/amazon/securityGroup/configure/EditSecurityGroupCtrl.js
@@ -41,7 +41,7 @@ module.exports = angular.module('spinnaker.securityGroup.aws.edit.controller', [
       application: application,
       title: 'Updating your security group',
       modalInstance: $uibModalInstance,
-      onTaskComplete: application.securityGroups.refresh,
+      onTaskComplete: () => application.securityGroups.refresh(),
     });
 
     securityGroup.securityGroupIngress = _(securityGroup.inboundRules)

--- a/app/scripts/modules/amazon/serverGroup/details/advancedSettings/editAsgAdvancedSettings.modal.controller.js
+++ b/app/scripts/modules/amazon/serverGroup/details/advancedSettings/editAsgAdvancedSettings.modal.controller.js
@@ -30,7 +30,7 @@ module.exports = angular.module('spinnaker.serverGroup.details.aws.advancedSetti
         modalInstance: $uibModalInstance,
         application: application,
         title: 'Update Advanced Settings for ' + serverGroup.name,
-        onTaskComplete: application.serverGroups.refresh,
+        onTaskComplete: () => application.serverGroups.refresh(),
       };
 
       $scope.taskMonitor = taskMonitorService.buildTaskMonitor(taskMonitorConfig);

--- a/app/scripts/modules/amazon/serverGroup/details/scalingProcesses/modifyScalingProcesses.controller.js
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingProcesses/modifyScalingProcesses.controller.js
@@ -75,7 +75,7 @@ module.exports = angular.module('spinnaker.serverGroup.details.aws.autoscaling.p
         modalInstance: $uibModalInstance,
         application: application,
         title: 'Update Auto Scaling Processes for ' + serverGroup.name,
-        onTaskComplete: application.serverGroups.refresh,
+        onTaskComplete: () => application.serverGroups.refresh(),
       };
 
       $scope.taskMonitor = taskMonitorService.buildTaskMonitor(taskMonitorConfig);

--- a/app/scripts/modules/amazon/serverGroup/details/scheduledAction/editScheduledActions.modal.controller.js
+++ b/app/scripts/modules/amazon/serverGroup/details/scheduledAction/editScheduledActions.modal.controller.js
@@ -52,7 +52,7 @@ module.exports = angular.module('spinnaker.serverGroup.details.aws.scheduledActi
         modalInstance: $uibModalInstance,
         application: application,
         title: 'Update Scheduled Actions for ' + serverGroup.name,
-        onTaskComplete: application.serverGroups.refresh,
+        onTaskComplete: () => application.serverGroups.refresh(),
       };
 
       $scope.taskMonitor = taskMonitorService.buildTaskMonitor(taskMonitorConfig);

--- a/app/scripts/modules/amazon/serverGroup/details/securityGroup/editSecurityGroups.modal.controller.js
+++ b/app/scripts/modules/amazon/serverGroup/details/securityGroup/editSecurityGroups.modal.controller.js
@@ -45,7 +45,7 @@ module.exports = angular.module('spinnaker.serverGroup.details.aws.securityGroup
         modalInstance: $uibModalInstance,
         application: application,
         title: 'Update Security Groups for ' + serverGroup.name,
-        onTaskComplete: application.serverGroups.refresh,
+        onTaskComplete: () => application.serverGroups.refresh(),
       };
 
       this.taskMonitor = taskMonitorService.buildTaskMonitor(taskMonitorConfig);

--- a/app/scripts/modules/cloudfoundry/serverGroup/details/resize/resizeServerGroup.controller.js
+++ b/app/scripts/modules/cloudfoundry/serverGroup/details/resize/resizeServerGroup.controller.js
@@ -57,7 +57,7 @@ module.exports = angular.module('spinnaker.cf.serverGroup.details.resize.control
         modalInstance: $uibModalInstance,
         application: application,
         title: 'Resizing ' + serverGroup.name,
-        onTaskComplete: application.serverGroups.refresh,
+        onTaskComplete: () => application.serverGroups.refresh(),
       };
 
       $scope.taskMonitor = taskMonitorService.buildTaskMonitor(taskMonitorConfig);

--- a/app/scripts/modules/google/securityGroup/configure/editSecurityGroup.controller.js
+++ b/app/scripts/modules/google/securityGroup/configure/editSecurityGroup.controller.js
@@ -38,7 +38,7 @@ module.exports = angular.module('spinnaker.google.securityGroup.edit.controller'
       application: application,
       title: 'Updating your security group',
       modalInstance: $uibModalInstance,
-      onTaskComplete: application.securityGroups.refresh,
+      onTaskComplete: () => application.securityGroups.refresh(),
     });
 
     securityGroup.sourceRanges = _.map(securityGroup.sourceRanges, function(sourceRange) {

--- a/app/scripts/modules/openstack/serverGroup/details/resize/resizeServerGroup.controller.js
+++ b/app/scripts/modules/openstack/serverGroup/details/resize/resizeServerGroup.controller.js
@@ -66,7 +66,7 @@ module.exports = angular.module('spinnaker.openstack.serverGroup.details.resize.
         modalInstance: $uibModalInstance,
         application: application,
         title: 'Resizing ' + serverGroup.name,
-        onTaskComplete: application.serverGroups.refresh,
+        onTaskComplete: () => application.serverGroups.refresh(),
       };
 
       $scope.taskMonitor = taskMonitorService.buildTaskMonitor(taskMonitorConfig);


### PR DESCRIPTION
Throwing this out there for discussion.

Much as I love how clean class-level methods are, they don't behave well when called as a result of a promise, e.g.
```javascript
class Foo {
  this.bar = 3;
  baz() {
    console.log(this.bar)
  }
}
...
let foo = new Foo();
somePromise().then(foo.baz); // throws an exception: "cannot read property 'baz' of undefined"
```
There are a couple of ways to get around this:
```javascript
// (1) Invoke via anonymous function
somePromise().then(() => foo.baz());
```
or
```javascript
// (2) Declare method using arrow function, binding 'this' to the class instance
class Foo {
  this.bar = 3;
  public baz = () => {
    console.log(this.bar);
}
let foo = new Foo();
somePromise().then(foo.baz); // logs "3"
```
Preferences on (1) vs. (2)? I prefer (2): it's less surprising to me. But if we go with (2), I'd prefer we declare all class-level methods this way - even those that likely won't be called via a promise, or those that don't reference `this` in their body.

I'm not opposed to (1), and not in love with (2).

@zanthrash @icfantv @danielpeach what are your thoughts on this? Is there a better, third (or fourth) way around this?