### PR TITLE
(core) use server group region in security group tab to link to serve…

### DIFF
--- a/app/scripts/modules/core/securityGroup/securityGroup.html
+++ b/app/scripts/modules/core/securityGroup/securityGroup.html
@@ -15,7 +15,7 @@
       <div ng-repeat="serverGroup in securityGroup.usages.serverGroups | orderBy:'-name'"
            class="rollup-row" ng-class="{disabled: serverGroup.isDisabled}">
         <a
-            ui-sref=".serverGroup({region: securityGroup.region, accountId: securityGroup.account, serverGroup: serverGroup.name, provider: securityGroup.provider})"
+            ui-sref=".serverGroup({region: serverGroup.region, accountId: securityGroup.account, serverGroup: serverGroup.name, provider: securityGroup.provider})"
             ui-sref-active="active">
           <span class="icon icon-server-group icon-{{securityGroup.provider}} small"></span> {{serverGroup.name}}
         </a>

--- a/app/scripts/modules/core/securityGroup/securityGroup.read.service.js
+++ b/app/scripts/modules/core/securityGroup/securityGroup.read.service.js
@@ -116,7 +116,11 @@ module.exports = angular.module('spinnaker.core.securityGroup.read.service', [
               var securityGroup = resolve(application.securityGroupsIndex, serverGroup, securityGroupId);
               attachUsageFields(securityGroup);
               if (!securityGroup.usages.serverGroups.some(sg => sg.name === serverGroup.name)) {
-                securityGroup.usages.serverGroups.push({name: serverGroup.name, isDisabled: serverGroup.isDisabled});
+                securityGroup.usages.serverGroups.push({
+                  name: serverGroup.name,
+                  isDisabled: serverGroup.isDisabled,
+                  region: serverGroup.region,
+                });
               }
               securityGroups.push(securityGroup);
             } catch (e) {


### PR DESCRIPTION
…r group details

@anotherchrisberry please review. This fixes a GCE bug that prevented server group details from rendering within the security group tab. I tested this for AWS and Kubernetes.