### PR TITLE
(core) reload pipeline view when navigating between executions

### DIFF
--- a/app/scripts/modules/core/delivery/executionBuild/executionBuildNumber.directive.html
+++ b/app/scripts/modules/core/delivery/executionBuild/executionBuildNumber.directive.html
@@ -2,7 +2,8 @@
    analytics-on="click"
    analytics-category="Pipeline"
    analytics-event="Execution build number clicked - parent pipeline"
-   ui-sref="^.executionDetails.execution({application: execution.trigger.parentPipelineApplication, executionId: execution.trigger.parentPipelineId})">
+   ui-sref="^.executionDetails.execution({application: execution.trigger.parentPipelineApplication, executionId: execution.trigger.parentPipelineId})"
+   ui-sref-opts="{inherit: false, reload: 'home.applications.application.pipelines.executionDetails'}">
   {{::execution.trigger.parentPipelineName}}
 </a>
 <a ng-if="::execution.buildInfo.number"

--- a/app/scripts/modules/core/pipeline/config/stages/pipeline/pipelineExecutionDetails.html
+++ b/app/scripts/modules/core/pipeline/config/stages/pipeline/pipelineExecutionDetails.html
@@ -18,7 +18,7 @@
         <div class="well alert alert-info">
           <a ng-if="stage.context.executionId"
              ui-sref="home.applications.application.pipelines.executionDetails.execution({ application: stage.context.application, executionId: stage.context.executionId })"
-             ui-sref-opts="{inherit: false}">View Pipeline Execution</a>
+             ui-sref-opts="{inherit: false, reload: 'home.applications.application.pipelines.executionDetails'}">View Pipeline Execution</a>
         </div>
       </div>
     </div>

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "angular-sanitize": "^1.5.8",
     "angular-spinner": "^0.5.1",
     "angular-ui-bootstrap": "1.3.1",
-    "angular-ui-router": "=0.2.13",
+    "angular-ui-router": "=0.2.18",
     "angular-ui-sortable": "^0.13.4",
     "angular-wizard": "^0.5.3",
     "bootstrap": "3.3.5",


### PR DESCRIPTION
for @tomaslin 

Have to update ui-router to 0.2.18 for the `reload: string` implementation (it was documented in 0.2.5, but not actually implemented until one of the later releases).