### PR TITLE
(core) dedupe security groups

### DIFF
--- a/app/scripts/modules/core/securityGroup/securityGroup.read.service.js
+++ b/app/scripts/modules/core/securityGroup/securityGroup.read.service.js
@@ -169,6 +169,7 @@ module.exports = angular.module('spinnaker.core.securityGroup.read.service', [
           }
         }
       }
+      data = _.uniq(data);
 
       if (notFoundCaught && retryIfNotFound) {
         $log.warn('Clearing security group cache and trying again...');


### PR DESCRIPTION
@anotherchrisberry @duftler 

A very small change, but I'm not sure what changed to make it necessary. If two server groups share a security group, the security group will be counted twice here: https://github.com/spinnaker/deck/blob/master/app/scripts/modules/core/securityGroup/securityGroup.read.service.js#L112-L125.