### PR TITLE
(core) reload pipeline view when navigating between executions

### DIFF
--- a/app/scripts/modules/core/cluster/filter/multiselect.model.js
+++ b/app/scripts/modules/core/cluster/filter/multiselect.model.js
@@ -37,7 +37,7 @@ module.exports = angular
         $state.go('^');
       }
       if (!$state.includes('**.multipleInstances') && instancesSelected) {
-        if ($state.includes('**.clusters.*')) {
+        if (isClusterChildState()) {
           // from a child state, e.g. instanceDetails
           $state.go('^.multipleInstances');
         } else {
@@ -49,7 +49,7 @@ module.exports = angular
         return;
       }
       if (!$state.includes('**.multipleServerGroups') && this.serverGroups.length) {
-        if ($state.includes('**.clusters.*')) {
+        if (isClusterChildState()) {
           $state.go('^.multipleServerGroups');
         } else {
           $state.go('.multipleServerGroups');
@@ -130,7 +130,7 @@ module.exports = angular
           serverGroup: serverGroup.name,
           job: serverGroup.name,
         };
-        if ($state.includes('**.clusters.*')) {
+        if (isClusterChildState()) {
           $state.go('^.' + serverGroup.category, params);
         } else {
           $state.go('.' + serverGroup.category, params);
@@ -158,7 +158,7 @@ module.exports = angular
     this.toggleInstance = (serverGroup, instanceId) => {
       if (!ClusterFilterModel.sortFilter.multiselect) {
         let params = {provider: serverGroup.type, instanceId: instanceId};
-        if ($state.includes('**.clusters.*')) {
+        if (isClusterChildState()) {
           $state.go('^.instanceDetails', params);
         } else {
           $state.go('.instanceDetails', params);
@@ -191,6 +191,10 @@ module.exports = angular
     this.instanceIsSelected = (serverGroup, instanceId) => {
       let group = this.getOrCreateInstanceGroup(serverGroup);
       return group.instanceIds.indexOf(instanceId) > -1;
+    };
+
+    let isClusterChildState = () => {
+      return $state.$current.name.split('.').pop() !== 'clusters';
     };
 
     return this;

--- a/app/scripts/modules/core/cluster/filter/multiselect.model.spec.js
+++ b/app/scripts/modules/core/cluster/filter/multiselect.model.spec.js
@@ -37,14 +37,14 @@ describe('Multiselect Model', function () {
         it('navigates to multipleInstances child view when not already there and instances are selected', function () {
           this.instanceGroup.instanceIds.push('i-123');
           this.instanceGroup.instanceIds.push('i-124');
-          this.currentStates = ['**.clusters'];
+          $state.$current = { name: 'clusters' };
           MultiselectModel.syncNavigation();
           expect(this.result).toBe('.multipleInstances');
         });
 
         it('navigates to multipleInstances child view when not already there and an instance is selected', function () {
           this.instanceGroup.instanceIds.push('i-123');
-          this.currentStates = ['**.clusters'];
+          $state.$current = { name: 'clusters' };
           MultiselectModel.syncNavigation();
           expect(this.result).toBe('.multipleInstances');
         });
@@ -52,7 +52,7 @@ describe('Multiselect Model', function () {
         it('navigates to multipleInstances sibling view when not already there and instances are selected', function () {
           this.instanceGroup.instanceIds.push('i-123');
           this.instanceGroup.instanceIds.push('i-124');
-          this.currentStates = ['**.clusters.*', '**.clusters.instanceDetails'];
+          $state.$current = { name: 'clusters.instanceDetails' };
           MultiselectModel.syncNavigation();
           expect(this.result).toBe('^.multipleInstances');
         });
@@ -78,7 +78,7 @@ describe('Multiselect Model', function () {
         });
 
         it('navigates to multipleServerGroups child view when not already there and group is selected', function () {
-          this.currentStates = ['**.clusters'];
+          $state.$current = { name: 'clusters' };
           MultiselectModel.toggleServerGroup(this.serverGroup);
           expect(this.result).toBe('.multipleServerGroups');
         });
@@ -116,6 +116,7 @@ describe('Multiselect Model', function () {
 
       it('navigates to details child view when multiselect is not enabled and not in clusters child view', function () {
         ClusterFilterModel.sortFilter.multiselect = false;
+        $state.$current = { name: 'clusters' };
         MultiselectModel.toggleServerGroup(this.serverGroup);
         expect(this.result).toBe('.serverGroup');
       });

--- a/app/scripts/modules/core/delivery/executionBuild/executionBuildNumber.directive.html
+++ b/app/scripts/modules/core/delivery/executionBuild/executionBuildNumber.directive.html
@@ -2,7 +2,8 @@
    analytics-on="click"
    analytics-category="Pipeline"
    analytics-event="Execution build number clicked - parent pipeline"
-   ui-sref="^.executionDetails.execution({application: execution.trigger.parentPipelineApplication, executionId: execution.trigger.parentPipelineId})">
+   ui-sref="^.executionDetails.execution({application: execution.trigger.parentPipelineApplication, executionId: execution.trigger.parentPipelineId})"
+   ui-sref-opts="{inherit: false, reload: 'home.applications.application.pipelines.executionDetails'}">
   {{::execution.trigger.parentPipelineName}}
 </a>
 <a ng-if="::execution.buildInfo.number"

--- a/app/scripts/modules/core/pipeline/config/stages/pipeline/pipelineExecutionDetails.html
+++ b/app/scripts/modules/core/pipeline/config/stages/pipeline/pipelineExecutionDetails.html
@@ -18,7 +18,7 @@
         <div class="well alert alert-info">
           <a ng-if="stage.context.executionId"
              ui-sref="home.applications.application.pipelines.executionDetails.execution({ application: stage.context.application, executionId: stage.context.executionId })"
-             ui-sref-opts="{inherit: false}">View Pipeline Execution</a>
+             ui-sref-opts="{inherit: false, reload: 'home.applications.application.pipelines.executionDetails'}">View Pipeline Execution</a>
         </div>
       </div>
     </div>

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "angular-sanitize": "^1.5.8",
     "angular-spinner": "^0.5.1",
     "angular-ui-bootstrap": "1.3.1",
-    "angular-ui-router": "=0.2.13",
+    "angular-ui-router": "=0.3.0",
     "angular-ui-sortable": "^0.13.4",
     "angular-wizard": "^0.5.3",
     "bootstrap": "3.3.5",


### PR DESCRIPTION
In order to get `reload` to accept and process a string, we have to bump the version of ui-router (the string option was documented in 0.2.5, but not actually implemented until sometime after 0.2.13).

Unfortunately, the `$state.includes` matching is broken when glob-matching on `**.someState.*` due to https://github.com/angular-ui/ui-router/commit/e39b27a2cb7d88525c446a041f9fbf1553202010. We only use that matching check in one spot, fortunately, so it's something to be aware of. I don't expect they'll fix it, as that commit is 20 months old and I don't see any issues in the repo related to it, so we may be the only folks trying to update to a newer version of the router depending on it. And the workaround is pretty simple.

@zanthrash @icfantv PTAL