### PR TITLE
(aws) remove/hide warmup on scale down step policies

### DIFF
--- a/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/popover/scalingPolicyPopover.component.html
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/popover/scalingPolicyPopover.component.html
@@ -72,11 +72,11 @@
     <dd ng-if="$ctrl.policy.minAdjustmentMagnitude">
       increments of at least {{$ctrl.policy.minAdjustmentMagnitude}} instance<span ng-if="$ctrl.policy.minAdjustmentMagnitude > 1">s</span>
     </dd>
-    <dt ng-if="$ctrl.policy.cooldown || $ctrl.policy.estimatedInstanceWarmup">wait</dt>
+    <dt ng-if="$ctrl.showWait">wait</dt>
     <dd ng-if="$ctrl.policy.cooldown">
       {{$ctrl.policy.cooldown}} seconds before allowing another scaling activity.
     </dd>
-    <dd ng-if="$ctrl.policy.estimatedInstanceWarmup">
+    <dd ng-if="$ctrl.showWait && $ctrl.policy.estimatedInstanceWarmup">
       {{$ctrl.policy.estimatedInstanceWarmup}} seconds to warm up after each step.
     </dd>
   </dl>

--- a/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/popover/scalingPolicyPopover.component.js
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/popover/scalingPolicyPopover.component.js
@@ -13,6 +13,18 @@ module.exports = angular
     },
     templateUrl: require('./scalingPolicyPopover.component.html'),
     controller: function() {
-      this.alarm = this.policy.alarms[0];
+
+      this.$onInit = () => {
+        this.alarm = this.policy.alarms[0];
+
+        let showWait = false;
+        if (this.policy.cooldown) {
+          showWait = true;
+        }
+        if (this.policy.stepAdjustments && this.policy.stepAdjustments.length) {
+          showWait = this.policy.stepAdjustments[0].operator !== 'decrease';
+        }
+        this.showWait = showWait;
+      };
     }
   });

--- a/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/upsertScalingPolicy.controller.js
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/upsertScalingPolicy.controller.js
@@ -169,6 +169,7 @@ module.exports = angular
         command.step.stepAdjustments.forEach((step) => {
           if (this.viewState.operator === 'Remove') {
             step.scalingAdjustment = 0 - step.scalingAdjustment;
+            delete command.step.estimatedInstanceWarmup;
           }
           if (step.metricIntervalLowerBound !== undefined) {
             step.metricIntervalLowerBound -= command.alarm.threshold;


### PR DESCRIPTION
@ajordens this should fix the issue we were seeing earlier tonight in two ways:

 1. Hide the warmup if the operation is a scale down, since it's confusing to show it
 2. Actually remove the warmup field if the operation is a scale down, since AWS will store it unnecessarily.