### PR TITLE
(core) show instance counts in load balancers menu

### DIFF
--- a/app/scripts/modules/core/cluster/rollups.less
+++ b/app/scripts/modules/core/cluster/rollups.less
@@ -275,8 +275,18 @@ running-tasks-tag {
     display: block;
   }
   a {
+    display: flex;
+    justify-content: space-between;
     border-bottom: 1px solid #d1d1d1;
     white-space: nowrap;
+
+    health-counts {
+      margin-left: 5px;
+      .instance-health-counts {
+        float: none !important;
+      }
+    }
+
     &:last-child {
       border-bottom-width: 0;
     }
@@ -331,7 +341,7 @@ load-balancers-tag {
     height: 0;
     width: 0;
   }
-  .counter {
+  .badge-counter {
     color: @spinnaker-link-color;
     background-color: #fff;
     border: 1px solid @spinnaker-link-color;

--- a/app/scripts/modules/core/loadBalancer/loadBalancer/loadBalancersTag.html
+++ b/app/scripts/modules/core/loadBalancer/loadBalancer/loadBalancersTag.html
@@ -7,7 +7,7 @@
       analytics-category="Cluster Pod"
       analytics-event="Toggle Load Balancers Menu ({{popover.show}})"
       uib-tooltip="{{popover.show ? 'Hide' : 'Show'}} all {{serverGroup.loadBalancers.length}} load balancers">
-    <span class="badge counter">
+    <span class="badge badge-counter">
       <span class="icon">
         <span class="icon-elb"></span>
       </span>
@@ -19,12 +19,14 @@
       Load Balancers
     </div>
     <a
-      ng-repeat="loadBalancer in serverGroup.loadBalancers | orderBy:'toString()'"
+      ng-repeat="loadBalancer in loadBalancers | orderBy: name"
       analytics-on="click"
       analytics-category="Cluster Pod"
       analytics-event="Load Load Balancer Details (multiple menu)"
-      ui-sref=".loadBalancerDetails({region: serverGroup.region, accountId: serverGroup.account, name: loadBalancer, provider: serverGroup.type})"
-      >{{loadBalancer}}
+      ui-sref=".loadBalancerDetails({region: serverGroup.region, accountId: serverGroup.account, name: loadBalancer.name, provider: serverGroup.type})"
+      >
+      <span class="name">{{loadBalancer.name}}</span>
+      <health-counts container="loadBalancer.instanceCounts"></health-counts>
     </a>
   </div>
   <span class="btn-load-balancer" ng-if="serverGroup.loadBalancers.length <= maxDisplay">
@@ -37,7 +39,7 @@
        ui-sref=".loadBalancerDetails({region: serverGroup.region, accountId: serverGroup.account, name: loadBalancer, provider: serverGroup.type})"
        ui-sref-active="active"
        uib-tooltip="Load Balancer: {{loadBalancer}}">
-      <span class="badge counter">
+      <span class="badge badge-counter">
         <span class="icon">
           <span class="icon-elb"></span>
         </span>

--- a/app/scripts/modules/core/loadBalancer/loadBalancersTag.directive.js
+++ b/app/scripts/modules/core/loadBalancer/loadBalancersTag.directive.js
@@ -9,11 +9,20 @@ module.exports = angular.module('spinnaker.core.loadBalancer.tag.directive', [])
       replace: false,
       templateUrl: require('./loadBalancer/loadBalancersTag.html'),
       scope: {
+        application: '=',
         serverGroup: '=',
         maxDisplay: '='
       },
       link: function(scope) {
         scope.popover = { show: false };
+        scope.application.loadBalancers.ready().then(() => {
+          scope.loadBalancers = scope.serverGroup.loadBalancers.map(lbName => {
+            let serverGroup = scope.serverGroup;
+            let [match] = scope.application.loadBalancers.data
+              .filter(lb => lb.name === lbName && lb.account === serverGroup.account && lb.region === serverGroup.region);
+            return match;
+          });
+        });
       }
     };
   }

--- a/app/scripts/modules/core/serverGroup/serverGroup.directive.html
+++ b/app/scripts/modules/core/serverGroup/serverGroup.directive.html
@@ -37,7 +37,7 @@
                 application="application" tasks="viewModel.serverGroup.runningTasks" executions="viewModel.serverGroup.executions"></running-tasks-tag>
             <load-balancers-tag
                 ng-if="viewModel.serverGroup.loadBalancers.length"
-                server-group="viewModel.serverGroup" max-display="1"></load-balancers-tag>
+                server-group="viewModel.serverGroup" max-display="1" application="application"></load-balancers-tag>
           </div>
         </div>
       </div>


### PR DESCRIPTION
When there are a lot of load balancers attached to a single server group, show the health counts for each load balancer, since we already have all that info.
<img width="324" alt="screen shot 2016-09-21 at 11 48 10 pm" src="https://cloud.githubusercontent.com/assets/73450/18739102/fa19a5a6-8055-11e6-9e63-142d53ebbc25.png">
Any concerns or objections?
