### PR TITLE
(aws) make alarm configuration chart zoomable

### DIFF
--- a/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/chart/metricAlarmChart.component.js
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/chart/metricAlarmChart.component.js
@@ -126,7 +126,6 @@ module.exports = angular
         this.chartOptions = {
           margin: this.margins || {top: 5, left: 5},
           tooltipHook: tooltipHook,
-          drawLegend: false,
           series: [
             {
               axis: 'y',
@@ -170,6 +169,10 @@ module.exports = angular
             y: {ticks: ticks.y},
             x2: {ticks: 0}, // hide right hand x-axis labels
             y2: {ticks: 0} // hide top y-axis labels
+          },
+          zoom: {
+            x: true,
+            y: true
           }
         };
         updateChartData();

--- a/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/chart/metricAlarmChart.component.less
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/chart/metricAlarmChart.component.less
@@ -1,7 +1,7 @@
 metric-alarm-chart {
   position: relative;
   display: block;
-  margin-bottom: 50px;
+  margin-bottom: 35px;
   .chart {
     .line-series {
       path {

--- a/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/alarm/alarmConfigurer.component.html
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/alarm/alarmConfigurer.component.html
@@ -120,7 +120,7 @@
 
 <div class="row" ng-if="$ctrl.alarm.metricName">
   <div class="col-md-10 col-md-offset-1">
-    <div style="height: 150px">
+    <div style="height: 220px">
       <metric-alarm-chart alarm="$ctrl.alarm"
                           ng-if="$ctrl.alarm"
                           style="height: 150px;"
@@ -129,6 +129,8 @@
                           margins="{top: 10, left: 50}"
                           stats="$ctrl.viewState"
                           server-group="$ctrl.serverGroup"></metric-alarm-chart>
+      <div class="small help-contents" style="margin-left: 45px"><b>Note:</b> to zoom in, hold down the alt key and use your
+        mouse to select an area. Double-click to zoom back out.</div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Lets users zoom into a portion of the graph by holding down the alt key and clicking and dragging to select a portion of the chart.

Unfortunately, the alt key behavior is baked into the chart library, presumably because the library also has a panning option, which relies on clicking and dragging.