### PR TITLE
(aws) default to use source capacity in aws deploy via template

### DIFF
--- a/app/scripts/modules/amazon/serverGroup/configure/serverGroupCommandBuilder.aws.service.spec.js
+++ b/app/scripts/modules/amazon/serverGroup/configure/serverGroupCommandBuilder.aws.service.spec.js
@@ -121,9 +121,13 @@ describe('Service: awsServerGroup', function () {
   });
 
   describe('buildServerGroupCommandFromExisting', function () {
-    it('retains non-core suspended processes', function () {
+
+    beforeEach(function () {
       spyOn(this.accountService, 'getPreferredZonesByAccount').and.returnValue(this.$q.when([]));
       spyOn(this.subnetReader, 'listSubnets').and.returnValue(this.$q.when([]));
+    });
+
+    it('retains non-core suspended processes', function () {
       var serverGroup = {
         asg: {
           availabilityZones: [],
@@ -143,6 +147,25 @@ describe('Service: awsServerGroup', function () {
 
       this.$scope.$digest();
       expect(command.suspendedProcesses).toEqual(['AZRebalance']);
+    });
+
+    it('sets source capacity flags when creating for pipeline', function () {
+      var serverGroup = {
+        asg: {
+          availabilityZones: [],
+          vpczoneIdentifier: '',
+          suspendedProcesses: []
+        }
+      };
+      var command = null;
+      this.service.buildServerGroupCommandFromExisting({}, serverGroup, 'editPipeline').then(function(result) {
+        command = result;
+      });
+
+      this.$scope.$digest();
+
+      expect(command.viewState.useSimpleCapacity).toBe(false);
+      expect(command.useSourceCapacity).toBe(true);
     });
   });
 

--- a/app/scripts/modules/amazon/serverGroup/configure/serverGroupCommandBuilder.service.js
+++ b/app/scripts/modules/amazon/serverGroup/configure/serverGroupCommandBuilder.service.js
@@ -212,7 +212,7 @@ module.exports = angular.module('spinnaker.aws.serverGroupCommandBuilder.service
           },
         };
 
-        if (mode === 'clone') {
+        if (mode === 'clone' || mode === 'editPipeline') {
           command.useSourceCapacity = true;
           command.viewState.useSimpleCapacity = false;
         }


### PR DESCRIPTION
When using an existing server group as a template in a deploy stage, it's almost always the case that the user will want to use the source capacity on subsequent deploys. This sets that as the default.