### PR TITLE
(core) show task account/region if available in tasks view

### DIFF
--- a/app/scripts/modules/core/task/tasks.html
+++ b/app/scripts/modules/core/task/tasks.html
@@ -84,6 +84,9 @@
                 <div class="task-name">
                   <a href id="task-{{task.id}}"><span class="glyphicon glyphicon-chevron-{{tasks.isExpanded(task.id) ? 'down' : 'right'}}"></span></a>
                   {{task.name}}
+                  <account-tag account="task.getValueFor('credentials')" pad="both"></account-tag>
+                  <span ng-if="task.getValueFor('region')">({{task.getValueFor('region')}})</span>
+                  <span ng-if="!task.getValueFor('region') && task.getValueFor('regions')">({{task.getValueFor('regions').join(', ')}})</span>
                 </div>
 
                 <div ng-if="tasks.getFirstDeployServerGroupName(task)" class="task-name">


### PR DESCRIPTION
This whole screen needs a rewrite, but for now, let's add in the account and region, if available, to the task summary row on the Tasks tab.

<img width="444" alt="screen shot 2016-09-25 at 7 57 08 pm" src="https://cloud.githubusercontent.com/assets/73450/18821374/4e9642a4-835a-11e6-9b99-5828e0dc14f2.png">
