### PR TITLE
(aws) require certificate on HTTPS/SSL listeners

### DIFF
--- a/app/scripts/modules/amazon/loadBalancer/configure/editLoadBalancer.html
+++ b/app/scripts/modules/amazon/loadBalancer/configure/editLoadBalancer.html
@@ -1,25 +1,27 @@
-<v2-modal-wizard heading="Edit {{loadBalancer.name}}: {{loadBalancer.region}}: {{loadBalancer.credentials}}">
-  <v2-wizard-page key="Location" label="Location" render="{{forPipelineConfig}}">
-    <ng-include src="pages.location"></ng-include>
-  </v2-wizard-page>
-  <v2-wizard-page key="Security Groups" label="Security Groups" done="true" render="{{!!loadBalancer.vpcId}}">
-    <ng-include src="pages.securityGroups"></ng-include>
-  </v2-wizard-page>
-  <v2-wizard-page key="Listeners" label="Listeners" done="true">
-    <ng-include src="pages.listeners"></ng-include>
-  </v2-wizard-page>
-  <v2-wizard-page key="Health Check" label="Health Check" done="true">
-    <ng-include src="pages.healthCheck"></ng-include>
-  </v2-wizard-page>
-  <v2-wizard-page key="Advanced Settings" label="Advanced Settings" done="true">
-    <ng-include src="pages.advancedSettings"></ng-include>
-  </v2-wizard-page>
-</v2-modal-wizard>
-<div class="modal-footer">
-  <button ng-disabled="taskMonitor.submitting" class="btn btn-default"
-          ng-click="ctrl.cancel()">Cancel
-  </button>
-  <submit-button is-disabled="form.$invalid || taskMonitor.submitting"
-                 submitting="taskMonitor.submitting" on-click="ctrl.submit()"
-                 is-new="isNew" label="submitButtonLabel"></submit-button>
-</div>
+<form name="form" class="form-horizontal">
+  <v2-modal-wizard heading="Edit {{loadBalancer.name}}: {{loadBalancer.region}}: {{loadBalancer.credentials}}">
+    <v2-wizard-page key="Location" label="Location" render="{{forPipelineConfig}}">
+      <ng-include src="pages.location"></ng-include>
+    </v2-wizard-page>
+    <v2-wizard-page key="Security Groups" label="Security Groups" done="true" render="{{!!loadBalancer.vpcId}}">
+      <ng-include src="pages.securityGroups"></ng-include>
+    </v2-wizard-page>
+    <v2-wizard-page key="Listeners" label="Listeners" done="true">
+      <ng-include src="pages.listeners"></ng-include>
+    </v2-wizard-page>
+    <v2-wizard-page key="Health Check" label="Health Check" done="true">
+      <ng-include src="pages.healthCheck"></ng-include>
+    </v2-wizard-page>
+    <v2-wizard-page key="Advanced Settings" label="Advanced Settings" done="true">
+      <ng-include src="pages.advancedSettings"></ng-include>
+    </v2-wizard-page>
+  </v2-modal-wizard>
+  <div class="modal-footer">
+    <button ng-disabled="taskMonitor.submitting" class="btn btn-default"
+            ng-click="ctrl.cancel()">Cancel
+    </button>
+    <submit-button is-disabled="form.$invalid || taskMonitor.submitting"
+                   submitting="taskMonitor.submitting" on-click="ctrl.submit()"
+                   is-new="isNew" label="submitButtonLabel"></submit-button>
+  </div>
+</form>

--- a/app/scripts/modules/amazon/loadBalancer/configure/listeners.html
+++ b/app/scripts/modules/amazon/loadBalancer/configure/listeners.html
@@ -26,13 +26,17 @@
                       ng-options="protocol for protocol in ['HTTP','HTTPS','TCP','SSL']"></select></td>
           <td><input class="form-control input-sm" type="number" min="0" ng-model="listener.internalPort"
                      required/></td>
-          <td ng-if="ctrl.showSslCertificateIdField() && listener.externalProtocol !== 'HTTPS' && listener.externalProtocol !== 'SSL'"></td>
-          <td ng-if="ctrl.certificateTypes.length > 1 && (listener.externalProtocol === 'HTTPS' || listener.externalProtocol === 'SSL')">
-            <select class="form-control input-sm" ng-model="listener.sslCertificateType"
+          <td>
+            <select ng-if="ctrl.certificateTypes.length > 1 && (listener.externalProtocol === 'HTTPS' || listener.externalProtocol === 'SSL')"
+                    class="form-control input-sm"
+                    ng-model="listener.sslCertificateType"
                     ng-options="certificateType for certificateType in ['iam','acm']"></select>
           </td>
-          <td ng-if="listener.externalProtocol === 'HTTPS' || listener.externalProtocol === 'SSL'">
-            <input class="form-control input-sm no-spel" type="text" ng-model="listener.sslCertificateId"
+          <td>
+            <input ng-if="listener.externalProtocol === 'HTTPS' || listener.externalProtocol === 'SSL'"
+                   class="form-control input-sm no-spel"
+                   type="text"
+                   ng-model="listener.sslCertificateId"
                    required/></td>
           </td>
           <td><a href class="sm-label" ng-click="ctrl.removeListener($index)"><span


### PR DESCRIPTION
`form.$invalid` doesn't do much when there's no `form`, which is only the case when editing an existing load balancer.

Also fixing alignment of delete button when there are both secure and non-secure listeners.