### PR TITLE
(netflix) wait for server groups to be loaded before initializing can…

### DIFF
--- a/app/scripts/modules/netflix/pipeline/stage/acaTask/acaTaskStage.js
+++ b/app/scripts/modules/netflix/pipeline/stage/acaTask/acaTaskStage.js
@@ -3,7 +3,6 @@
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.netflix.pipeline.stage.acaTaskStage', [
-  require('../../../../core/application/listExtractor/listExtractor.service'),
   require('../../../../core/serverGroup/configure/common/serverGroupCommandBuilder.js'),
   require('../../../../core/cloudProvider/cloudProvider.registry.js'),
   require('../../../../core/config/settings.js'),
@@ -30,7 +29,7 @@ module.exports = angular.module('spinnaker.netflix.pipeline.stage.acaTaskStage',
   .controller('AcaTaskStageCtrl', function ($scope, $uibModal, stage,
                                            namingService, providerSelectionService,
                                            authenticationService, cloudProviderRegistry,
-                                           serverGroupCommandBuilder, awsServerGroupTransformer, accountService, appListExtractorService) {
+                                           serverGroupCommandBuilder, awsServerGroupTransformer, accountService) {
 
     var user = authenticationService.getAuthenticatedUser();
     $scope.stage = stage;
@@ -66,7 +65,6 @@ module.exports = angular.module('spinnaker.netflix.pipeline.stage.acaTaskStage',
 
     accountService.listAccounts('aws').then(function(accounts) {
       $scope.accounts = accounts;
-      setClusterList();
     });
 
 
@@ -93,37 +91,5 @@ module.exports = angular.module('spinnaker.netflix.pipeline.stage.acaTaskStage',
         return 0;
       });
     };
-
-    this.getRegion = function(cluster) {
-      var availabilityZones = cluster.availabilityZones;
-      if (availabilityZones) {
-        var regions = Object.keys(availabilityZones);
-        if (regions && regions.length) {
-          return regions[0];
-        }
-      }
-      return 'n/a';
-    };
-
-    let clusterFilter = (cluster) => {
-      return $scope.stage.baseline.account ? cluster.account === $scope.stage.baseline.account : true;
-    };
-
-    let setClusterList = () => {
-      $scope.clusterList = appListExtractorService.getClusters([$scope.application], clusterFilter);
-    };
-
-    $scope.resetSelectedCluster = () => {
-      $scope.stage.baseline.cluster = undefined;
-      setClusterList();
-    };
-
-
-
-    function getClusterName(cluster) {
-      return namingService.getClusterName(cluster.application, cluster.stack, cluster.freeFormDetails);
-    }
-
-    this.getClusterName = getClusterName;
 
   });

--- a/app/scripts/modules/netflix/pipeline/stage/canary/canaryStage.html
+++ b/app/scripts/modules/netflix/pipeline/stage/canary/canaryStage.html
@@ -172,6 +172,7 @@
   </stage-config-field>
   <stage-config-field label="Cluster">
     <cluster-selector
+      ng-if="application.serverGroups.loaded"
       clusters="clusterList"
       model="stage.baseline.cluster">
     </cluster-selector>

--- a/app/scripts/modules/netflix/pipeline/stage/canary/canaryStage.js
+++ b/app/scripts/modules/netflix/pipeline/stage/canary/canaryStage.js
@@ -101,8 +101,8 @@ module.exports = angular.module('spinnaker.netflix.pipeline.stage.canaryStage', 
       return terminateAction ? terminateAction.delayBeforeActionInMins : 60;
     };
 
-    accountService.listAccounts('aws').then(function(accounts) {
-      $scope.accounts = accounts;
+    $scope.application.serverGroups.ready().then(() => {
+      accountService.listAccounts('aws').then(accounts => $scope.accounts = accounts);
       setClusterList();
     });
 


### PR DESCRIPTION
…ary cluster picker

Avoids a race condition where the user comes into the canary config view from a deep link and the server groups are not yet loaded.

Ended up removing a bunch of code from the acaTaskStage that appears to be unused.

@zanthrash PTAL