### PR TITLE
(core) rollback ui-router to 0.2.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "angular-sanitize": "^1.5.8",
     "angular-spinner": "^0.5.1",
     "angular-ui-bootstrap": "1.3.1",
-    "angular-ui-router": "=0.3.0",
+    "angular-ui-router": "=0.2.13",
     "angular-ui-sortable": "^0.13.4",
     "angular-wizard": "^0.5.3",
     "bootstrap": "3.3.5",


### PR DESCRIPTION
0.3.0 drops query parameters that it doesn't know about when navigating to the same state, e.g. if you're on `/clusters?q=v001` and click the Clusters tab, the filters get dropped.

I think we're stuck with 0.2.13 for the foreseeable future, which is not the end of the world, but something to remember.

@zanthrash @icfantv FYI