### PR TITLE
(Openstack) adding rollback functionality for openstack

### DIFF
--- a/app/scripts/modules/openstack/common/footer.directive.html
+++ b/app/scripts/modules/openstack/common/footer.directive.html
@@ -1,0 +1,11 @@
+<div class="modal-footer">
+  <user-verification account="vm.account" verification="vm.verification"></user-verification>
+  <button type="submit" ng-click="vm.action()" style="display:none"></button> <!-- Allows form submission via enter keypress-->
+  <button class="btn btn-default" ng-click="vm.cancel()">Cancel</button>
+  <button type="submit"
+          class="btn btn-primary"
+          ng-click="vm.action()"
+          ng-disabled="!vm.isValid()">
+    Submit
+  </button>
+</div>

--- a/app/scripts/modules/openstack/common/footer.directive.js
+++ b/app/scripts/modules/openstack/common/footer.directive.js
@@ -1,0 +1,23 @@
+'use strict';
+
+let angular = require('angular');
+
+module.exports = angular
+  .module('spinnaker.openstack.footer.directive', [
+  ])
+  .directive('openstackFooter', function () {
+    return {
+      restrict: 'E',
+      templateUrl: require('./footer.directive.html'),
+      scope: {},
+      bindToController: {
+        action: '&',
+        isValid: '&',
+        cancel: '&',
+        account: '=?',
+        verification: '=?',
+      },
+      controllerAs: 'vm',
+      controller: angular.noop,
+    };
+  });

--- a/app/scripts/modules/openstack/serverGroup/details/rollback/rollbackServerGroup.controller.js
+++ b/app/scripts/modules/openstack/serverGroup/details/rollback/rollbackServerGroup.controller.js
@@ -1,0 +1,61 @@
+'use strict';
+
+let angular = require('angular');
+
+module.exports = angular.module('spinnaker.openstack.serverGroup.details.rollback.controller', [
+      require('../../../../core/application/modal/platformHealthOverride.directive.js'),
+      require('../../../../core/serverGroup/serverGroup.write.service.js'),
+      require('../../../../core/task/monitor/taskMonitorService.js'),
+      require('../../../common/footer.directive.js'),
+    ])
+    .controller('openstackRollbackServerGroupCtrl', function ($scope, $uibModalInstance, serverGroupWriter,
+                                                        taskMonitorService,
+                                                        application, serverGroup, disabledServerGroups) {
+      $scope.serverGroup = serverGroup;
+      $scope.disabledServerGroups = disabledServerGroups.sort((a, b) => b.name.localeCompare(a.name));
+      $scope.verification = {};
+
+      $scope.command = {
+        rollbackType: 'EXPLICIT',
+        rollbackContext: {
+          rollbackServerGroupName: serverGroup.name
+        }
+      };
+
+      if (application && application.attributes) {
+        $scope.command.platformHealthOnlyShowOverride = application.attributes.platformHealthOnlyShowOverride;
+      }
+
+      this.isValid = function () {
+        var command = $scope.command;
+        if (!$scope.verification.verified) {
+          return false;
+        }
+
+        return command.rollbackContext.restoreServerGroupName !== undefined;
+      };
+
+      this.rollback = function () {
+        if (!this.isValid()) {
+          return;
+        }
+
+        var submitMethod = function () {
+          return serverGroupWriter.rollbackServerGroup(serverGroup, application, $scope.command);
+        };
+
+        var taskMonitorConfig = {
+          modalInstance: $uibModalInstance,
+          application: application,
+          title: 'Rollback ' + serverGroup.name,
+        };
+
+        $scope.taskMonitor = taskMonitorService.buildTaskMonitor(taskMonitorConfig);
+
+        $scope.taskMonitor.submit(submitMethod);
+      };
+
+      this.cancel = function () {
+        $uibModalInstance.dismiss();
+      };
+    });

--- a/app/scripts/modules/openstack/serverGroup/details/rollback/rollbackServerGroup.html
+++ b/app/scripts/modules/openstack/serverGroup/details/rollback/rollbackServerGroup.html
@@ -1,0 +1,65 @@
+<div modal-page class="confirmation-modal">
+  <task-monitor monitor="taskMonitor"></task-monitor>
+  <form role="form">
+    <modal-close></modal-close>
+    <div class="modal-header">
+      <h3>Rollback {{serverGroup.name}}</h3>
+    </div>
+    <div class="modal-body confirmation-modal">
+      <div class="row">
+        <div class="col-sm-3 sm-label-right">
+          Restore to
+        </div>
+        <div class="col-sm-6">
+          <ui-select ng-model="command.rollbackContext.restoreServerGroupName" class="form-control input-sm">
+            <ui-select-match placeholder="Select...">{{$select.selected.name}}</ui-select-match>
+            <ui-select-choices repeat="serverGroup.name as serverGroup in disabledServerGroups">
+              <span ng-bind-html="serverGroup.name"></span>
+            </ui-select-choices>
+          </ui-select>
+        </div>
+      </div>
+
+      <div class="row" ng-if="command.platformHealthOnlyShowOverride">
+        <div class="col-sm-10 col-sm-offset-1">
+          <platform-health-override command="command"
+                                    platform-health-type="'Openstack'"
+                                    show-help-details="true"
+                                    field-columns="12">
+          </platform-health-override>
+        </div>
+      </div>
+
+      <task-reason command="command"></task-reason>
+
+      <div class="row">
+        <div class="col-sm-4 sm-label-right">
+          Rollback Operations
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-sm-11 col-sm-offset-1">
+          <ol>
+            <li>Enable <em>{{ command.rollbackContext.restoreServerGroupName || 'previous server group' }}</em></li>
+            <li>Resize <em>{{ command.rollbackContext.restoreServerGroupName || 'previous server group' }}</em> to [
+              <strong>min</strong>: {{serverGroup.capacity.min}},
+              <strong>max</strong>: {{ serverGroup.capacity.max }},
+              <strong>desired</strong>: {{ serverGroup.capacity.desired }}
+            ]</li>
+            <li>Disable {{ serverGroup.name }}</li>
+          </ol>
+
+          <p>
+            This rollback will affect server groups in {{ serverGroup.account }} ({{ serverGroup.region }}).
+          </p>
+        </div>
+      </div>
+
+    </div>
+    <openstack-footer action="ctrl.rollback()"
+                cancel="ctrl.cancel()"
+                is-valid="ctrl.isValid()"
+                account="serverGroup.account"
+                verification="verification"></openstack-footer>
+  </form>
+</div>

--- a/app/scripts/modules/openstack/serverGroup/details/serverGroup.details.module.js
+++ b/app/scripts/modules/openstack/serverGroup/details/serverGroup.details.module.js
@@ -4,5 +4,6 @@ let angular = require('angular');
 
 module.exports = angular.module('spinnaker.openstack.serverGroup.details', [
   require('./serverGroupDetails.openstack.controller.js'),
-  require('./resize/resizeServerGroup.controller.js')
+  require('./resize/resizeServerGroup.controller.js'),
+  require('./rollback/rollbackServerGroup.controller.js')
 ]);

--- a/app/scripts/modules/openstack/serverGroup/details/serverGroupDetails.openstack.controller.js
+++ b/app/scripts/modules/openstack/serverGroup/details/serverGroupDetails.openstack.controller.js
@@ -28,7 +28,7 @@ module.exports = angular.module('spinnaker.serverGroup.details.openstack.control
                                                      confirmationModalService, _, serverGroupWriter, subnetReader,
                                                      securityGroupReader, loadBalancerReader, runningExecutionsService,
                                                      accountService, serverGroupWarningMessageService,
-                                                     openstackServerGroupTransformer) {
+                                                     openstackServerGroupTransformer, overrideRegistry) {
     var ctrl = this;
     this.state = {
       loading: true
@@ -242,7 +242,18 @@ module.exports = angular.module('spinnaker.serverGroup.details.openstack.control
     };
 
     this.rollbackServerGroup = () => {
-      alert('Not yet implemented.'); // eslint-disable-line no-alert
+      $uibModal.open({
+        templateUrl: overrideRegistry.getTemplate('openstack.rollback.modal', require('./rollback/rollbackServerGroup.html')),
+        controller: 'openstackRollbackServerGroupCtrl as ctrl',
+        resolve: {
+          serverGroup: () => this.serverGroup,
+          disabledServerGroups: () => {
+            var cluster = _.find(app.clusters, {name: this.serverGroup.cluster, account: this.serverGroup.account});
+            return _.filter(cluster.serverGroups, {isDisabled: true, region: this.serverGroup.region});
+          },
+          application: () => app
+        }
+      });
     };
 
     this.resizeServerGroup = () => {


### PR DESCRIPTION
Closes issue 1114

Rollback functionality details:
Rollback must be done on an enabled server group. After clicking rollback under server group actions, you must select a disabled server group within the same cluster in the drop down. Running rollback will enable the selected disabled server group, resize it to match the size of the active selected server group, and then disable the selected server group.