### PR TITLE
(k8s) fixes error causing command backing data to be included in pipe…

### DIFF
--- a/app/scripts/modules/kubernetes/cluster/configure/CommandBuilder.js
+++ b/app/scripts/modules/kubernetes/cluster/configure/CommandBuilder.js
@@ -213,7 +213,8 @@ module.exports = angular.module('spinnaker.kubernetes.clusterCommandBuilder.serv
       };
     }
 
-    function buildClusterCommandFromPipeline(app, command, current, pipeline) {
+    function buildClusterCommandFromPipeline(app, originalCommand, current, pipeline) {
+      let command = _.cloneDeep(originalCommand);
       let contextImages = findUpstreamImages(current, pipeline.stages) || [];
       contextImages = contextImages.concat(findTriggerImages(pipeline.triggers));
       command.containers = reconcileUpstreamImages(command.containers, contextImages);


### PR DESCRIPTION
…line JSON

GCE also copies the command before entering the edit modal:
https://github.com/spinnaker/deck/blob/master/app/scripts/modules/google/serverGroup/configure/serverGroupCommandBuilder.service.js#L361

@lwander 