### PR TITLE
(aws) clean up security group upsert command

### DIFF
--- a/app/scripts/modules/amazon/securityGroup/configure/EditSecurityGroupCtrl.js
+++ b/app/scripts/modules/amazon/securityGroup/configure/EditSecurityGroupCtrl.js
@@ -55,7 +55,7 @@ module.exports = angular.module('spinnaker.securityGroup.aws.edit.controller', [
             accountId: rule.securityGroup.accountId,
             vpcId: vpcId,
             id: rule.securityGroup.id,
-            name: rule.securityGroup.name,
+            name: rule.securityGroup.inferredName ? null : rule.securityGroup.name,
             type: rule.protocol,
             startPort: portRange.startPort,
             endPort: portRange.endPort,
@@ -85,9 +85,21 @@ module.exports = angular.module('spinnaker.securityGroup.aws.edit.controller', [
     $scope.taskMonitor.onApplicationRefresh = $uibModalInstance.dismiss;
 
     this.upsert = function () {
+
+      let group = $scope.securityGroup;
+      let command = {
+        credentials: group.accountName,
+        name: group.name,
+        description: group.description,
+        vpcId: group.vpcId,
+        region: group.region,
+        securityGroupIngress: group.securityGroupIngress,
+        ipIngress: group.ipIngress
+      };
+
       $scope.taskMonitor.submit(
         function() {
-          return securityGroupWriter.upsertSecurityGroup($scope.securityGroup, application, 'Update');
+          return securityGroupWriter.upsertSecurityGroup(command, application, 'Update');
         }
       );
     };

--- a/app/scripts/modules/amazon/securityGroup/configure/ingressRuleGroupSelector.component.html
+++ b/app/scripts/modules/amazon/securityGroup/configure/ingressRuleGroupSelector.component.html
@@ -1,6 +1,6 @@
 <span class="form-control-static" ng-if="$ctrl.rule.existing">
   <account-tag account="$ctrl.rule.accountName" ng-if="$ctrl.rule.accountName !== $ctrl.securityGroup.accountName"></account-tag>
-  {{$ctrl.rule.name}}
+  {{$ctrl.rule.name || $ctrl.rule.id}}
 </span>
 
 <div ng-if="$ctrl.rule.crossAccountEnabled && $ctrl.securityGroup.regions.length === 1" class="cross-account-select">

--- a/app/scripts/modules/core/securityGroup/securityGroup.read.service.js
+++ b/app/scripts/modules/core/securityGroup/securityGroup.read.service.js
@@ -217,7 +217,12 @@ module.exports = angular.module('spinnaker.core.securityGroup.read.service', [
             let inboundGroup = inboundRule.securityGroup;
             if (!inboundGroup.name) {
               let applicationSecurityGroup = getApplicationSecurityGroup(application, inboundGroup.accountName, details.region, inboundGroup.id);
-              inboundGroup.name = applicationSecurityGroup ? applicationSecurityGroup.name : inboundGroup.id;
+              if (applicationSecurityGroup) {
+                inboundGroup.name = applicationSecurityGroup.name;
+              } else {
+                inboundGroup.name = inboundGroup.id;
+                inboundGroup.inferredName = true;
+              }
             }
           });
         }

--- a/app/scripts/modules/core/securityGroup/securityGroup.read.service.spec.js
+++ b/app/scripts/modules/core/securityGroup/securityGroup.read.service.spec.js
@@ -89,8 +89,11 @@ describe('Service: securityGroupReader', function () {
 
     expect(details.securityGroupRules.length).toBe(3);
     expect(details.securityGroupRules[0].securityGroup.name).toBe('sg-345');
+    expect(details.securityGroupRules[0].securityGroup.inferredName).toBe(true);
     expect(details.securityGroupRules[1].securityGroup.name).toBe('matched');
+    expect(details.securityGroupRules[1].securityGroup.inferredName).toBeFalsy();
     expect(details.securityGroupRules[2].securityGroup.name).toBe('matched-prod');
+    expect(details.securityGroupRules[2].securityGroup.inferredName).toBeFalsy();
   });
 
   it('should clear cache, then reload security groups and try again if a security group is not found', function () {


### PR DESCRIPTION
Addresses a long-standing issue where an upsert task never completes because we're sending an invalid name in ingress rules if we don't know about the account. Orca then tries to match the name with what comes back from Clouddriver, which never happens.

@zanthrash @icfantv PTAL