### PR TITLE
(aws) prefer bakePackageName to package in bake details

### DIFF
--- a/app/scripts/modules/amazon/pipeline/stages/bake/bakeExecutionDetails.html
+++ b/app/scripts/modules/amazon/pipeline/stages/bake/bakeExecutionDetails.html
@@ -11,7 +11,7 @@
           <dt>Region</dt>
           <dd>{{stage.context.region}}</dd>
           <dt>Package</dt>
-          <dd>{{stage.context.package}}</dd>
+          <dd>{{stage.context.bakePackageName || stage.context.package}}</dd>
         </dl>
       </div>
       <div class="col-md-6">


### PR DESCRIPTION
If the actual package name is available, show that, e.g.
<img width="488" alt="screen shot 2016-09-28 at 4 13 08 pm" src="https://cloud.githubusercontent.com/assets/73450/18935683/832360e0-8596-11e6-854c-64f40cf2220a.png">

@spinnaker/netflix-reviewers Thoughts?