### PR TITLE
(Openstack) Bug fix for advanced resizing

### DIFF
--- a/app/scripts/modules/openstack/serverGroup/details/resize/resizeServerGroup.controller.js
+++ b/app/scripts/modules/openstack/serverGroup/details/resize/resizeServerGroup.controller.js
@@ -12,11 +12,11 @@ module.exports = angular.module('spinnaker.openstack.serverGroup.details.resize.
 
     $scope.serverGroup = serverGroup;
     $scope.currentSize = {
-      min: serverGroup.scalingConfig.min,
-      max: serverGroup.scalingConfig.max,
+      min: serverGroup.scalingConfig.minSize,
+      max: serverGroup.scalingConfig.maxSize,
       desired: serverGroup.scalingConfig.desiredSize
     };
-
+    
     $scope.verification = {};
 
     $scope.command = {


### PR DESCRIPTION
Min and max were left pointing to undefined variables. They now point at the proper values and the front end now reflects the correct min and max.