### PR TITLE
Support locked (aka not editable via UI) pipelines

### DIFF
--- a/app/scripts/modules/core/pipeline/config/actions/json/editPipelineJson.module.js
+++ b/app/scripts/modules/core/pipeline/config/actions/json/editPipelineJson.module.js
@@ -27,7 +27,8 @@ module.exports = angular.module('spinnaker.core.pipeline.config.actions.editJson
       $scope.isStrategy = pipelineCopy.strategy || false;
 
       $scope.command = {
-        pipelineJSON: JSON.stringify(pipelineCopy, null, 2)
+        pipelineJSON: JSON.stringify(pipelineCopy, null, 2),
+        locked: pipelineCopy.locked,
       };
     };
 

--- a/app/scripts/modules/core/pipeline/config/actions/json/editPipelineJsonModal.html
+++ b/app/scripts/modules/core/pipeline/config/actions/json/editPipelineJsonModal.html
@@ -1,14 +1,16 @@
 <div modal-page class="flex-fill">
   <modal-close></modal-close>
   <div class="modal-header">
-    <h3>Edit {{isStrategy === true ? 'Strategy' : 'Pipeline'}} JSON</h3>
+    <h3><span ng-if="!command.locked">Edit </span>{{isStrategy === true ? 'Strategy' : 'Pipeline'}} JSON</h3>
   </div>
   <div class="modal-body flex-fill">
     <div class="row">
       <div class="col-md-12">
         <p>
           The JSON below represents the {{isStrategy === true ? 'strategy' : 'pipeline'}} configuration in its persisted state.
-          You can change it here or use this to quickly copy a {{isStrategy === true ? 'strategy' : 'pipeline'}}.
+          <span ng-if="!command.locked">
+            You can change it here or use this to quickly copy a {{isStrategy === true ? 'strategy' : 'pipeline'}}.
+          </span>
         </p>
       </div>
     </div>
@@ -17,7 +19,7 @@
         <textarea class="code form-control flex-fill" ng-model="command.pipelineJSON"></textarea>
       </div>
     </form>
-    <div class="row">
+    <div class="row" ng-if="!command.locked">
       <div class="col-md-12">
         <p>
           <strong>Note:</strong> Clicking "Update {{isStrategy === true ? 'Strategy' : 'Pipeline'}}" below will not save your changes to the server - it only
@@ -35,7 +37,8 @@
   <div class="modal-footer">
     <button class="btn btn-default" ng-click="editPipelineJsonModalCtrl.cancel()">Cancel</button>
     <button class="btn btn-primary"
-            ng-click="editPipelineJsonModalCtrl.updatePipeline()">
+            ng-click="editPipelineJsonModalCtrl.updatePipeline()"
+            ng-if="!command.locked">
       <span class="glyphicon glyphicon-ok-circle"></span> Update {{isStrategy === true ? 'Strategy' : 'Pipeline'}}
     </button>
   </div>

--- a/app/scripts/modules/core/pipeline/config/actions/pipelineConfigActions.html
+++ b/app/scripts/modules/core/pipeline/config/actions/pipelineConfigActions.html
@@ -3,11 +3,14 @@
     {{pipeline.strategy === true ? 'Strategy' : 'Pipeline'}} Actions <span class="caret"></span>
   </button>
   <ul class="dropdown-menu" uib-dropdown-menu role="menu">
-    <li><a href ng-click="pipelineConfigurerCtrl.renamePipeline()">Rename</a></li>
-    <li><a href ng-click="pipelineConfigurerCtrl.deletePipeline()">Delete</a></li>
-    <li ng-if="pipeline.disabled"><a href ng-click="pipelineConfigurerCtrl.enablePipeline()">Enable</a></li>
-    <li ng-if="!pipeline.disabled"><a href ng-click="pipelineConfigurerCtrl.disablePipeline()">Disable</a></li>
-    <li><a href ng-click="pipelineConfigurerCtrl.editPipelineJson()">Edit as JSON</a></li>
+    <li ng-if="!pipeline.locked"><a href ng-click="pipelineConfigurerCtrl.renamePipeline()">Rename</a></li>
+    <li ng-if="!pipeline.locked"><a href ng-click="pipelineConfigurerCtrl.deletePipeline()">Delete</a></li>
+    <li ng-if="!pipeline.locked && pipeline.disabled"><a href ng-click="pipelineConfigurerCtrl.enablePipeline()">Enable</a></li>
+    <li ng-if="!pipeline.locked && !pipeline.disabled"><a href ng-click="pipelineConfigurerCtrl.disablePipeline()">Disable</a></li>
+
+    <li ng-if="pipeline.locked"><a href ng-click="pipelineConfigurerCtrl.editPipelineJson()">Show JSON</a></li>
+    <li ng-if="!pipeline.locked"><a href ng-click="pipelineConfigurerCtrl.editPipelineJson()">Edit as JSON</a></li>
+
     <li ng-if="viewState.hasHistory"><a href ng-click="pipelineConfigurerCtrl.showHistory()">Show Revision History</a></li>
     <li ng-if="!viewState.hasHistory"><a class="disabled">No version history found</a></li>
   </ul>

--- a/app/scripts/modules/core/pipeline/config/pipelineConfig.less
+++ b/app/scripts/modules/core/pipeline/config/pipelineConfig.less
@@ -47,6 +47,10 @@ pipeline-configurer {
   background-color: #ffffff;
   border: 1px solid @mid_light_grey;
 
+  .band {
+    margin: 0 -15px 0 -15px;
+  }
+
   .pipeline-config-heading {
     margin-left: -15px;
     margin-right: -15px;

--- a/app/scripts/modules/core/pipeline/config/pipelineConfigurer.html
+++ b/app/scripts/modules/core/pipeline/config/pipelineConfigurer.html
@@ -7,11 +7,11 @@
       <a href class="nav-popover"
          ng-click="navMenuState.showMenu = !navMenuState.showMenu"
          ng-blur="pipelineConfigurerCtrl.hideNavigationMenu()">
-        {{pipeline.name}} <span ng-if="pipeline.disabled">(disabled)</span>
+        {{pipeline.name}}
+        <span ng-if="pipeline.disabled">(disabled)</span>
       </a>
       <pipeline-config-errors pipeline="pipeline"></pipeline-config-errors>
     </h3>
-
 
     <div class="permalink">
       <a target="_blank"
@@ -26,6 +26,9 @@
     </div>
     <div class="pipeline-actions text-right">
       <div ng-include="pipelineConfigurerCtrl.actionsTemplateUrl"></div>
+    </div>
+    <div class="band band-info" ng-if="pipeline.locked">
+      <span class="glyphicon glyphicon small glyphicon-lock"></span> This pipeline is locked and does not allow modification
     </div>
   </div>
   <div class="pipeline-contents">
@@ -88,7 +91,7 @@
 
     <div class="row pipeline-footer">
       <div class="col-md-3">
-        <button is-visible="viewState.isDirty" class="btn btn-default"
+        <button is-visible="!pipeline.locked && viewState.isDirty" class="btn btn-default"
                 analytics-on="click"
                 analytics-category="Pipeline Config"
                 analytics-event="Revert changes clicked"
@@ -103,7 +106,8 @@
              analytics-event="Error saving changes dismissed"
              ng-click="viewState.saveError = false">[dismiss]</a>
         </span>
-        <button ng-if="viewState.isDirty" ng-disabled="!pipelineConfigurerCtrl.isValid()" class="btn btn-primary"
+
+        <button ng-if="!pipeline.locked && viewState.isDirty" ng-disabled="!pipelineConfigurerCtrl.isValid()" class="btn btn-primary"
                 analytics-on="click"
                 analytics-category="Pipeline Config"
                 analytics-event="Save pipeline clicked"
@@ -115,7 +119,10 @@
             <span class="glyphicon glyphicon-asterisk glyphicon-spinning"></span> Saving&hellip;
           </span>
         </button>
-        <span ng-if="!viewState.isDirty" class="btn btn-link disabled"><span class="glyphicon glyphicon-ok-circle"></span> In sync with server</span>
+        <span ng-if="!pipeline.locked && !viewState.isDirty" class="btn btn-link disabled"><span class="glyphicon glyphicon-ok-circle"></span> In sync with server</span>
+        <span ng-if="pipeline.locked" class="btn btn-link disabled" uib-tooltip="This pipeline is locked and does not allow modification">
+          <span class="glyphicon glyphicon-lock"></span> Pipeline is locked
+        </span>
       </div>
 
     </div>

--- a/app/scripts/modules/netflix/templateOverride/pipelineConfigActions.html
+++ b/app/scripts/modules/netflix/templateOverride/pipelineConfigActions.html
@@ -3,11 +3,14 @@
     {{pipeline.strategy === true ? 'Strategy' : 'Pipeline'}} Actions <span class="caret"></span>
   </button>
   <ul class="dropdown-menu" uib-dropdown-menu role="menu">
-    <li><a href ng-click="pipelineConfigurerCtrl.renamePipeline()">Rename</a></li>
-    <li><a href ng-click="pipelineConfigurerCtrl.deletePipeline()">Delete</a></li>
-    <li ng-if="pipeline.disabled"><a href ng-click="pipelineConfigurerCtrl.enablePipeline()">Enable</a></li>
-    <li ng-if="!pipeline.disabled"><a href ng-click="pipelineConfigurerCtrl.disablePipeline()">Disable</a></li>
-    <li><a href ng-click="pipelineConfigurerCtrl.editPipelineJson()">Edit as JSON</a></li>
+    <li ng-if="!pipeline.locked"><a href ng-click="pipelineConfigurerCtrl.renamePipeline()">Rename</a></li>
+    <li ng-if="!pipeline.locked"><a href ng-click="pipelineConfigurerCtrl.deletePipeline()">Delete</a></li>
+    <li ng-if="!pipeline.locked && pipeline.disabled"><a href ng-click="pipelineConfigurerCtrl.enablePipeline()">Enable</a></li>
+    <li ng-if="!pipeline.locked && !pipeline.disabled"><a href ng-click="pipelineConfigurerCtrl.disablePipeline()">Disable</a></li>
+
+    <li ng-if="pipeline.locked"><a href ng-click="pipelineConfigurerCtrl.editPipelineJson()">Show JSON</a></li>
+    <li ng-if="!pipeline.locked"><a href ng-click="pipelineConfigurerCtrl.editPipelineJson()">Edit as JSON</a></li>
+
     <li ng-if="viewState.hasHistory"><a href ng-click="pipelineConfigurerCtrl.showHistory()">Show Revision History</a></li>
     <li ng-if="!viewState.hasHistory"><a class="disabled">No version history found</a></li>
     <li><pipeline-migrator pipeline="pipeline" application="application"></pipeline-migrator></li>


### PR DESCRIPTION
- New 'locked' pipeline config attribute
- All locked pipelines must be modified via the API

![image](https://cloud.githubusercontent.com/assets/388652/18976439/bb88f0c8-8666-11e6-8446-3b2108454860.png)

![image](https://cloud.githubusercontent.com/assets/388652/18976448/c432e5c6-8666-11e6-8c71-82c5670c4455.png)
