### PR TITLE
(core) allow stage validator to check parent triggers

### DIFF
--- a/app/scripts/modules/amazon/pipeline/stages/bake/awsBakeStage.js
+++ b/app/scripts/modules/amazon/pipeline/stages/bake/awsBakeStage.js
@@ -25,6 +25,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.aws.bakeStage', [
         { type: 'requiredField', fieldName: 'regions', },
         { type: 'stageOrTriggerBeforeType',
           stageType: 'jenkins',
+          checkParentTriggers: true,
           message: 'Bake stages should always have a Jenkins stage or trigger preceding them.<br> Otherwise, ' +
         'Spinnaker will bake and deploy the most-recently built package.'}
       ],

--- a/app/scripts/modules/azure/pipeline/stages/bake/azureBakeStage.js
+++ b/app/scripts/modules/azure/pipeline/stages/bake/azureBakeStage.js
@@ -25,6 +25,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.azure.bakeStage',
         { type: 'requiredField', fieldName: 'regions', },
         { type: 'stageOrTriggerBeforeType',
           stageType: 'jenkins',
+          checkParentTriggers: true,
           message: 'Bake stages should always have a Jenkins stage or trigger preceding them.<br> Otherwise, ' +
         'Spinnaker will bake and deploy the most-recently built package.'}
       ],

--- a/app/scripts/modules/core/pipeline/config/validation/pipelineConfigValidation.service.js
+++ b/app/scripts/modules/core/pipeline/config/validation/pipelineConfigValidation.service.js
@@ -9,7 +9,44 @@ module.exports = angular.module('spinnaker.core.pipeline.config.validator.servic
   require('../services/pipelineConfigService.js'),
   require('../../../naming/naming.service.js'),
 ])
-  .factory('pipelineConfigValidator', function($log, pipelineConfig, pipelineConfigService, namingService) {
+  .factory('pipelineConfigValidator', function($log, pipelineConfig, pipelineConfigService, namingService, $q) {
+
+    // Stores application pipeline configs so we don't needlessly fetch them every time we validate the pipeline
+    let pipelineCache = new Map();
+
+    let clearCache = () => {
+      pipelineCache.clear();
+    };
+
+    let addTriggers = (pipelines, pipelineIdToFind, stagesToTest) => {
+      let [match] = pipelines.filter(p => p.id === pipelineIdToFind);
+      if (match) {
+        stagesToTest.push(...match.triggers);
+      }
+    };
+
+    function addExternalTriggers(trigger, stagesToTest, deferred) {
+      pipelineConfigService.getPipelinesForApplication(trigger.application).then(pipelines => {
+        pipelineCache.set(trigger.application, pipelines);
+        addTriggers(pipelines, trigger.pipeline, stagesToTest);
+        deferred.resolve();
+      });
+    }
+
+    function addPipelineTriggers(pipeline, stagesToTest) {
+      let pipelineTriggers = pipeline.triggers.filter(t => t.type === 'pipeline');
+      let parentTriggersToCheck = [];
+      pipelineTriggers.forEach(trigger => {
+        let deferred = $q.defer();
+        if (pipelineCache.has(trigger.application)) {
+          addTriggers(pipelineCache.get(trigger.application), trigger.pipeline, stagesToTest);
+        } else {
+          addExternalTriggers(trigger, stagesToTest, deferred);
+          parentTriggersToCheck.push(deferred.promise);
+        }
+      });
+      return parentTriggersToCheck;
+    }
 
     var validators = {
       stageOrTriggerBeforeType: function(pipeline, index, validationConfig, messages) {
@@ -20,9 +57,12 @@ module.exports = angular.module('spinnaker.core.pipeline.config.validator.servic
         }
         stagesToTest = stagesToTest.concat(pipeline.triggers);
 
-        if (stagesToTest.every((stage) => stageTypes.indexOf(stage.type) === -1)) {
-          messages.push(validationConfig.message);
-        }
+        var parentTriggersToCheck = validationConfig.checkParentTriggers ? addPipelineTriggers(pipeline, stagesToTest) : [];
+        return $q.all(parentTriggersToCheck).then(() => {
+          if (stagesToTest.every((stage) => stageTypes.indexOf(stage.type) === -1)) {
+            messages.push(validationConfig.message);
+          }
+        });
       },
       stageBeforeType: function(pipeline, index, validationConfig, messages) {
         if (pipeline.strategy === true && pipeline.stages[index].type === 'deploy') {
@@ -39,7 +79,7 @@ module.exports = angular.module('spinnaker.core.pipeline.config.validator.servic
         }
       },
       checkRequiredField: function(pipeline, stage, validationConfig, config, messages) {
-       if (pipeline.strategy === true && ['cluster', 'regions', 'zones', 'credentials'].indexOf(validationConfig.fieldName) > -1) {
+        if (pipeline.strategy === true && ['cluster', 'regions', 'zones', 'credentials'].indexOf(validationConfig.fieldName) > -1) {
           return;
         }
 
@@ -104,7 +144,8 @@ module.exports = angular.module('spinnaker.core.pipeline.config.validator.servic
     function validatePipeline(pipeline) {
       var stages = pipeline.stages || [],
           triggers = pipeline.triggers || [],
-          messages = [];
+          messages = [],
+          asyncValidations = [];
 
       triggers.forEach(function(trigger, index) {
         let config = pipelineConfig.getTriggerConfig(trigger.type);
@@ -129,7 +170,7 @@ module.exports = angular.module('spinnaker.core.pipeline.config.validator.servic
             }
             switch(validator.type) {
               case 'stageOrTriggerBeforeType':
-                validators.stageOrTriggerBeforeType(pipeline, index, validator, messages);
+                asyncValidations.push(validators.stageOrTriggerBeforeType(pipeline, index, validator, messages));
                 break;
               case 'stageBeforeType':
                 validators.stageBeforeType(pipeline, index, validator, messages);
@@ -149,10 +190,13 @@ module.exports = angular.module('spinnaker.core.pipeline.config.validator.servic
           });
         }
       });
-      return _.uniq(messages);
+      return $q.all(asyncValidations).then(() => {
+        return _.uniq(messages);
+      });
     }
 
     return {
       validatePipeline: validatePipeline,
+      clearCache: clearCache,
     };
   });

--- a/app/scripts/modules/core/pipeline/config/validation/pipelineConfigValidator.directive.js
+++ b/app/scripts/modules/core/pipeline/config/validation/pipelineConfigValidator.directive.js
@@ -19,8 +19,10 @@ module.exports = angular.module('spinnaker.core.pipeline.config.validator.direct
   .controller('PipelineConfigValidatorCtrl', function($scope, pipelineConfigValidator) {
 
     function validate() {
-      $scope.messages = pipelineConfigValidator.validatePipeline($scope.pipeline);
+      pipelineConfigValidator.validatePipeline($scope.pipeline).then(messages => $scope.messages = messages);
     }
+
+    pipelineConfigValidator.clearCache();
 
     $scope.$watch('pipeline', validate, true);
 

--- a/app/scripts/modules/openstack/pipeline/stages/bake/openstackBakeStage.js
+++ b/app/scripts/modules/openstack/pipeline/stages/bake/openstackBakeStage.js
@@ -25,6 +25,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.openstack.bakeSta
         { type: 'requiredField', fieldName: 'regions', },
         { type: 'stageOrTriggerBeforeType',
           stageType: 'jenkins',
+          checkParentTriggers: true,
           message: 'Bake stages should always have a Jenkins stage or trigger preceding them.<br> Otherwise, ' +
         'Spinnaker will bake and deploy the most-recently built package.'}
       ],


### PR DESCRIPTION
When a pipeline triggers a child pipeline, and the child pipeline has a bake stage, Orca will look at the parent pipeline's trigger for package information.

We've had this behavior in Orca for about a year, but we never updated the validators in Deck, so folks still get this warning, even though it's not a valid warning, which just trains people to ignore those warnings.

This change allows `stageOrTriggerBeforeType` validators to declare they should `checkParentTriggers`, which will result in the validator fetching the pipeline config for the trigger and add its triggers to the list of things to check.

Not crazy about bringing async behavior into the validator but I don't think there's a way around it, and I think the way I've done it is not intrusive or burdensome for new validators.

Actual code changes are not huge, but I had to update the tests to deal with async so cleaned up a few other things in the process.

@zanthrash @icfantv @danielpeach PTAL