### PR TITLE
(aws) set name, credentials on security group clone operation

### DIFF
--- a/app/scripts/modules/amazon/securityGroup/clone/cloneSecurityGroup.controller.js
+++ b/app/scripts/modules/amazon/securityGroup/clone/cloneSecurityGroup.controller.js
@@ -20,6 +20,9 @@ module.exports = angular
       ingress: require('../configure/createSecurityGroupIngress.html'),
     };
 
+    securityGroup.credentials = securityGroup.accountName;
+    $scope.namePreview = securityGroup.name;
+
     angular.extend(this, $controller('awsConfigSecurityGroupMixin', {
       $scope: $scope,
       $uibModalInstance: $uibModalInstance,


### PR DESCRIPTION
This has been broken for an unknown amount of time.