### PR TITLE
Support unlocks via the UI

### DIFF
--- a/app/scripts/modules/core/pipeline/config/actions/actions.module.js
+++ b/app/scripts/modules/core/pipeline/config/actions/actions.module.js
@@ -9,4 +9,6 @@ module.exports = angular.module('spinnaker.core.pipeline.config.actions', [
   require('./history/showHistory.controller'),
   require('./enable/enable.module'),
   require('./disable/disable.module'),
+  require('./lock/lock.module'),
+  require('./unlock/unlock.module'),
 ]);

--- a/app/scripts/modules/core/pipeline/config/actions/lock/lock.module.js
+++ b/app/scripts/modules/core/pipeline/config/actions/lock/lock.module.js
@@ -1,0 +1,32 @@
+'use strict';
+
+let angular = require('angular');
+
+module.exports = angular.module('spinnaker.core.pipeline.config.actions.lock', [
+  require('../../services/services.module.js'),
+])
+  .controller('LockPipelineModalCtrl', function($uibModalInstance, pipelineConfigService, pipeline) {
+    this.viewState = {};
+    this.pipelineName = pipeline.name;
+    this.cancel = $uibModalInstance.dismiss;
+
+    this.command = {
+      allowUnlockUi: true
+    };
+
+    this.lockPipeline = () => {
+      pipeline.locked = {
+        ui: true,
+        allowUnlockUi: this.command.allowUnlockUi,
+        description: this.command.description,
+      };
+      return pipelineConfigService.savePipeline(pipeline).then(
+        () => $uibModalInstance.close(),
+        (response) => {
+          this.viewState.saveError = true;
+          this.viewState.errorMessage = response.message || 'No message provided';
+        }
+      );
+    };
+
+  });

--- a/app/scripts/modules/core/pipeline/config/actions/lock/lockPipelineModal.html
+++ b/app/scripts/modules/core/pipeline/config/actions/lock/lockPipelineModal.html
@@ -1,0 +1,47 @@
+<div modal-page>
+  <modal-close></modal-close>
+  <div class="modal-header">
+    <h3>Really Lock Pipeline?</h3>
+  </div>
+  <div class="modal-body">
+    <div class="alert alert-danger" ng-if="ctrl.viewState.saveError">
+      <p>Could not lock pipeline.</p>
+      <p><b>Reason: </b>{{ctrl.viewState.errorMessage}}</p>
+      <p><a href ng-click="ctrl.viewState.saveError = false">[dismiss]</a></p>
+    </div>
+    <form role="form" name="form" class="form-horizontal">
+      <div class="form-group">
+        <div class="col-md-12">
+          <p>Are you sure you want to lock {{ctrl.pipelineName}}?</p>
+          <p>This will prevent any further modification to this pipeline made via the Spinnaker UI.</p>
+        </div>
+      </div>
+
+      <div class="form-group form-inline">
+        <div class="col-md-3 sm-label-right">
+          Allow Unlock via UI
+        </div>
+
+        <div class="col-md-6">
+          <input type="checkbox" class="input-sm" ng-model="ctrl.command.allowUnlockUi" style="margin: 0"/>
+        </div>
+      </div>
+      <div class="form-group form-inline">
+        <div class="col-md-3 sm-label-right">
+          Description
+        </div>
+        <div class="col-md-9">
+          <input type="text" class="form-control input-sm" style="width: 100%" ng-model="ctrl.command.description"
+                 placeholder="This pipeline is locked and does not allow modification">
+        </div>
+      </div>
+    </form>
+  </div>
+  <div class="modal-footer">
+    <button class="btn btn-default" ng-click="ctrl.cancel()">Cancel</button>
+    <button class="btn btn-primary"
+            ng-click="ctrl.lockPipeline()">
+      Lock pipeline
+    </button>
+  </div>
+</div>

--- a/app/scripts/modules/core/pipeline/config/actions/pipelineConfigActions.html
+++ b/app/scripts/modules/core/pipeline/config/actions/pipelineConfigActions.html
@@ -7,6 +7,8 @@
     <li ng-if="!pipeline.locked"><a href ng-click="pipelineConfigurerCtrl.deletePipeline()">Delete</a></li>
     <li ng-if="!pipeline.locked && pipeline.disabled"><a href ng-click="pipelineConfigurerCtrl.enablePipeline()">Enable</a></li>
     <li ng-if="!pipeline.locked && !pipeline.disabled"><a href ng-click="pipelineConfigurerCtrl.disablePipeline()">Disable</a></li>
+    <li ng-if="!pipeline.locked"><a href ng-click="pipelineConfigurerCtrl.lockPipeline()">Lock</a></li>
+    <li ng-if="pipeline.locked && pipeline.locked.allowUnlockUi"><a href ng-click="pipelineConfigurerCtrl.unlockPipeline()">Unlock</a></li>
 
     <li ng-if="pipeline.locked"><a href ng-click="pipelineConfigurerCtrl.editPipelineJson()">Show JSON</a></li>
     <li ng-if="!pipeline.locked"><a href ng-click="pipelineConfigurerCtrl.editPipelineJson()">Edit as JSON</a></li>

--- a/app/scripts/modules/core/pipeline/config/actions/unlock/unlock.module.js
+++ b/app/scripts/modules/core/pipeline/config/actions/unlock/unlock.module.js
@@ -1,0 +1,24 @@
+'use strict';
+
+let angular = require('angular');
+
+module.exports = angular.module('spinnaker.core.pipeline.config.actions.unlock', [
+  require('../../services/services.module.js'),
+])
+  .controller('unlockPipelineModalCtrl', function($uibModalInstance, pipelineConfigService, pipeline) {
+    this.viewState = {};
+    this.pipelineName = pipeline.name;
+    this.cancel = $uibModalInstance.dismiss;
+
+    this.unlockPipeline = () => {
+      delete pipeline.locked;
+      return pipelineConfigService.savePipeline(pipeline).then(
+        () => $uibModalInstance.close(),
+        (response) => {
+          this.viewState.saveError = true;
+          this.viewState.errorMessage = response.message || 'No message provided';
+        }
+      );
+    };
+
+  });

--- a/app/scripts/modules/core/pipeline/config/actions/unlock/unlockPipelineModal.html
+++ b/app/scripts/modules/core/pipeline/config/actions/unlock/unlockPipelineModal.html
@@ -1,0 +1,27 @@
+<div modal-page>
+  <modal-close></modal-close>
+  <div class="modal-header">
+    <h3>Really Unlock Pipeline?</h3>
+  </div>
+  <div class="modal-body">
+    <div class="alert alert-danger" ng-if="ctrl.viewState.saveError">
+      <p>Could not unlock pipeline.</p>
+      <p><b>Reason: </b>{{ctrl.viewState.errorMessage}}</p>
+      <p><a href ng-click="ctrl.viewState.saveError = false">[dismiss]</a></p>
+    </div>
+    <form role="form" name="form" class="form-horizontal">
+      <div class="form-group">
+        <div class="col-md-12">
+          <p>Are you sure you want to unlock and allow modifications to {{ctrl.pipelineName}}?</p>
+        </div>
+      </div>
+    </form>
+  </div>
+  <div class="modal-footer">
+    <button class="btn btn-default" ng-click="ctrl.cancel()">Cancel</button>
+    <button class="btn btn-primary"
+            ng-click="ctrl.unlockPipeline()">
+      Unlock pipeline
+    </button>
+  </div>
+</div>

--- a/app/scripts/modules/core/pipeline/config/pipelineConfigurer.html
+++ b/app/scripts/modules/core/pipeline/config/pipelineConfigurer.html
@@ -28,7 +28,7 @@
       <div ng-include="pipelineConfigurerCtrl.actionsTemplateUrl"></div>
     </div>
     <div class="band band-info" ng-if="pipeline.locked">
-      <span class="glyphicon glyphicon small glyphicon-lock"></span> This pipeline is locked and does not allow modification
+      <span class="glyphicon glyphicon small glyphicon-lock"></span> {{ pipeline.locked.description || "This pipeline is locked and does not allow modification" }}
     </div>
   </div>
   <div class="pipeline-contents">
@@ -120,7 +120,8 @@
           </span>
         </button>
         <span ng-if="!pipeline.locked && !viewState.isDirty" class="btn btn-link disabled"><span class="glyphicon glyphicon-ok-circle"></span> In sync with server</span>
-        <span ng-if="pipeline.locked" class="btn btn-link disabled" uib-tooltip="This pipeline is locked and does not allow modification">
+        <span ng-if="pipeline.locked" class="btn btn-link disabled"
+              uib-tooltip="{{ pipeline.locked.description || 'This pipeline is locked and does not allow modification'}}">
           <span class="glyphicon glyphicon-lock"></span> Pipeline is locked
         </span>
       </div>

--- a/app/scripts/modules/core/pipeline/config/pipelineConfigurer.js
+++ b/app/scripts/modules/core/pipeline/config/pipelineConfigurer.js
@@ -170,6 +170,30 @@ module.exports = angular.module('spinnaker.core.pipeline.config.pipelineConfigur
       $scope.pipeline.disabled = !$scope.pipeline.disabled;
     }
 
+    this.lockPipeline = () => {
+      $uibModal.open({
+        templateUrl: require('./actions/lock/lockPipelineModal.html'),
+        controller: 'LockPipelineModalCtrl as ctrl',
+        resolve: {
+          pipeline: () => original
+        }
+      }).result.then(function() {
+        $scope.pipeline.locked = original.locked;
+      })
+    };
+
+    this.unlockPipeline = () => {
+      $uibModal.open({
+        templateUrl: require('./actions/unlock/unlockPipelineModal.html'),
+        controller: 'unlockPipelineModalCtrl as ctrl',
+        resolve: {
+          pipeline: () => original
+        }
+      }).result.then(function () {
+        delete $scope.pipeline.locked;
+      })
+    };
+
     this.showHistory = () => {
       $uibModal.open({
         templateUrl: require('./actions/history/showHistory.modal.html'),

--- a/app/scripts/modules/netflix/templateOverride/pipelineConfigActions.html
+++ b/app/scripts/modules/netflix/templateOverride/pipelineConfigActions.html
@@ -7,6 +7,8 @@
     <li ng-if="!pipeline.locked"><a href ng-click="pipelineConfigurerCtrl.deletePipeline()">Delete</a></li>
     <li ng-if="!pipeline.locked && pipeline.disabled"><a href ng-click="pipelineConfigurerCtrl.enablePipeline()">Enable</a></li>
     <li ng-if="!pipeline.locked && !pipeline.disabled"><a href ng-click="pipelineConfigurerCtrl.disablePipeline()">Disable</a></li>
+    <li ng-if="!pipeline.locked"><a href ng-click="pipelineConfigurerCtrl.lockPipeline()">Lock</a></li>
+    <li ng-if="pipeline.locked && pipeline.locked.allowUnlockUi"><a href ng-click="pipelineConfigurerCtrl.unlockPipeline()">Unlock</a></li>
 
     <li ng-if="pipeline.locked"><a href ng-click="pipelineConfigurerCtrl.editPipelineJson()">Show JSON</a></li>
     <li ng-if="!pipeline.locked"><a href ng-click="pipelineConfigurerCtrl.editPipelineJson()">Edit as JSON</a></li>


### PR DESCRIPTION
The expanded pipeline config structure is now:

```
locked: {
  ui: true,
  allowUnlockUi: true, // optional
  description: "This pipeline is locked as per xyz" // optional
}
```

![image](https://cloud.githubusercontent.com/assets/388652/19008589/2fb7b758-8721-11e6-81c6-21a1f64bd45f.png)

![image](https://cloud.githubusercontent.com/assets/388652/19008599/359df600-8721-11e6-8759-38e95038cbd1.png)

![image](https://cloud.githubusercontent.com/assets/388652/19008609/42212000-8721-11e6-896d-8bb40a09de74.png)

![image](https://cloud.githubusercontent.com/assets/388652/19008613/478de8de-8721-11e6-8967-b67165d88d89.png)
