### PR TITLE
(aws) fix cert type table cell visibility

### DIFF
--- a/app/scripts/modules/amazon/loadBalancer/configure/createLoadBalancer.html
+++ b/app/scripts/modules/amazon/loadBalancer/configure/createLoadBalancer.html
@@ -1,4 +1,4 @@
-<form name="form" class="form-horizontal">
+<form name="form" class="form-horizontal" novalidate>
   <v2-modal-wizard heading="{{forPipelineConfig ? 'Configure Load Balancer' : 'Create New Load Balancer'}}">
     <v2-wizard-page key="Location" label="Location">
       <ng-include src="pages.location"></ng-include>

--- a/app/scripts/modules/amazon/loadBalancer/configure/editLoadBalancer.html
+++ b/app/scripts/modules/amazon/loadBalancer/configure/editLoadBalancer.html
@@ -1,4 +1,4 @@
-<form name="form" class="form-horizontal">
+<form name="form" class="form-horizontal" novalidate>
   <v2-modal-wizard heading="Edit {{loadBalancer.name}}: {{loadBalancer.region}}: {{loadBalancer.credentials}}">
     <v2-wizard-page key="Location" label="Location" render="{{forPipelineConfig}}">
       <ng-include src="pages.location"></ng-include>

--- a/app/scripts/modules/amazon/loadBalancer/configure/listeners.html
+++ b/app/scripts/modules/amazon/loadBalancer/configure/listeners.html
@@ -26,13 +26,13 @@
                       ng-options="protocol for protocol in ['HTTP','HTTPS','TCP','SSL']"></select></td>
           <td><input class="form-control input-sm" type="number" min="0" ng-model="listener.internalPort"
                      required/></td>
-          <td>
-            <select ng-if="ctrl.certificateTypes.length > 1 && (listener.externalProtocol === 'HTTPS' || listener.externalProtocol === 'SSL')"
+          <td ng-if="ctrl.showSslCertificateIdField() && ctrl.certificateTypes.length > 1">
+            <select ng-if="(listener.externalProtocol === 'HTTPS' || listener.externalProtocol === 'SSL')"
                     class="form-control input-sm"
                     ng-model="listener.sslCertificateType"
                     ng-options="certificateType for certificateType in ['iam','acm']"></select>
           </td>
-          <td>
+          <td ng-if="ctrl.showSslCertificateIdField()">
             <input ng-if="listener.externalProtocol === 'HTTPS' || listener.externalProtocol === 'SSL'"
                    class="form-control input-sm no-spel"
                    type="text"


### PR DESCRIPTION
* hide SSL cert select table cell using same visibility conditions
as column header.
* hide SSL cert name table cell using same visibility conditions as
column header.
* turn off HTML5 form validation for create/edit load balancer dialog
form.

@anotherchrisberry @zanthrash PTAL
@kmarquardsen it appears you cloned `listeners.html` for openstack, you may be interested in these changes.