### PR TITLE
(gce) backend services in load balancer details

### DIFF
--- a/app/scripts/modules/core/help/helpContents.js
+++ b/app/scripts/modules/core/help/helpContents.js
@@ -130,7 +130,8 @@ module.exports = angular.module('spinnaker.core.help.contents', [])
     'gce.httpLoadBalancer.port': 'HTTP requests can be load balanced based on port 80 or port 8080. HTTPS requests can be load balanced on port 443.',
     'gce.httpLoadBalancer.certificate': 'The name of an SSL certificate. If specified, Spinnaker will create an HTTPS load balancer.',
     'gce.httpLoadBalancer.namedPort': `
-      Incoming traffic is directed through a named port (for Spinnaker, the named port is <b>http</b>).
+      For HTTP(S) load balancers,
+      incoming traffic is directed through a named port (for Spinnaker, the named port is <b>http</b>).
       The mapping from named port to port number is specified per server group
       and can be configured within the server group creation dialogue under <b>Port Name Mapping</b>.`,
     'gce.serverGroup.resizeWithAutoscalingPolicy': `

--- a/app/scripts/modules/google/loadBalancer/details/healthCheck/healthCheck.component.html
+++ b/app/scripts/modules/google/loadBalancer/details/healthCheck/healthCheck.component.html
@@ -1,3 +1,5 @@
+<dt>Name</dt>
+<dd>{{$ctrl.healthCheck.name}}</dd>
 <dt>Target</dt>
 <dd>{{$ctrl.healthCheck.target}}</dd>
 <dt>Timeout</dt>

--- a/app/scripts/modules/google/loadBalancer/details/loadBalancerDetail.controller.js
+++ b/app/scripts/modules/google/loadBalancer/details/loadBalancerDetail.controller.js
@@ -51,7 +51,10 @@ module.exports = angular.module('spinnaker.loadBalancer.gce.details.controller',
 
             accountService.getCredentialsKeyedByAccount('gce').then(function(credentialsKeyedByAccount) {
               if (elSevenUtils.isElSeven($scope.loadBalancer)) {
-                $scope.loadBalancer.elb.availabilityZones = [ 'All zones' ];
+                $scope.loadBalancer.elb.availabilityZones = ['All zones'];
+                $scope.loadBalancer.elb.backendServices = getBackendServices($scope.loadBalancer);
+                $scope.loadBalancer.elb.healthChecks = getUniqueHealthChecks($scope.loadBalancer.elb.backendServiceHealthChecks);
+
               } else {
                 $scope.loadBalancer.elb.availabilityZones = _.find(credentialsKeyedByAccount[loadBalancer.accountId].regions, { name: loadBalancer.region }).zones.sort();
               }
@@ -91,6 +94,28 @@ module.exports = angular.module('spinnaker.loadBalancer.gce.details.controller',
         return loadBalancerReader
           .getLoadBalancerDetails($scope.loadBalancer.provider, loadBalancer.accountId, $scope.loadBalancer.region, $scope.loadBalancer.name);
       }
+    }
+
+    function getBackendServices (loadBalancer) {
+      var backendServices = [loadBalancer.defaultService];
+
+      if (loadBalancer.hostRules.length) {
+        backendServices = _.chain(loadBalancer.hostRules)
+          .reduce((services, hostRule) => {
+            services.push(hostRule.pathMatcher.defaultService);
+            return services.concat(_.map(hostRule.pathMatcher.pathRules, 'backendService'));
+          }, backendServices)
+          .uniqBy('name')
+          .value();
+      }
+      return backendServices;
+    }
+
+    function getUniqueHealthChecks(healthChecksKeyedByBackendService) {
+      return _.chain(healthChecksKeyedByBackendService)
+        .map(_.identity)
+        .uniqBy(_.isEqual)
+        .value();
     }
 
     function autoClose() {

--- a/app/scripts/modules/google/loadBalancer/details/loadBalancerDetails.html
+++ b/app/scripts/modules/google/loadBalancer/details/loadBalancerDetails.html
@@ -121,22 +121,36 @@
     </collapsible-section>
     <collapsible-section heading="Listeners">
       <dl>
-        <dt>Load Balancer &rarr; Instance</dt>
+        <dt>Load Balancer &rarr; Instance
+          <help-field ng-if="ctrl.isElSeven(loadBalancer)" key="gce.httpLoadBalancer.namedPort"></help-field>
+        </dt>
         <dd ng-repeat="listener in loadBalancer.elb.listenerDescriptions">
           {{listener.listener.protocol}}:{{listener.listener.loadBalancerPort}}
           &rarr;
           {{listener.listener.instanceProtocol}}:{{listener.listener.instancePort}}
-            <help-field ng-if="ctrl.isElSeven(loadBalancer)" key="gce.httpLoadBalancer.namedPort"></help-field>
         </dd>
+      </dl>
+    </collapsible-section>
+    <collapsible-section heading="Backend Services" ng-if="ctrl.isElSeven(loadBalancer)">
+      <dl ng-class="InsightFilterStateModel.filtersExpanded ? '' : 'dl-horizontal dl-wide'">
+        <div ng-repeat="service in loadBalancer.elb.backendServices">
+          <hr ng-if="$index > 0">
+          <dt>Name</dt>
+          <dd>{{service.name}}</dd>
+          <dt>Health Check</dt>
+          <dd>{{service.healthCheck.name}}</dd>
+          <dt>Session Affinity</dt>
+          <dd>{{service.sessionAffinity}}</dd>
+          <dt ng-if="service.sessionAffinity === 'GENERATED_COOKIE'">Affinity Cookie TTL</dt>
+          <dd ng-if="service.sessionAffinity === 'GENERATED_COOKIE'">{{service.affinityCookieTtlSec}}</dd>
+        </div>
       </dl>
     </collapsible-section>
     <collapsible-section heading="Health Checks">
       <dl ng-class="InsightFilterStateModel.filtersExpanded ? '' : 'dl-horizontal dl-wide'">
         <gce-health-check ng-if="!ctrl.isElSeven(loadBalancer)" health-check="loadBalancer.elb.healthCheck"></gce-health-check>
-        <div ng-if="ctrl.isElSeven(loadBalancer)" ng-repeat="(serviceName, healthCheck) in loadBalancer.elb.backendServiceHealthChecks">
+        <div ng-if="ctrl.isElSeven(loadBalancer)" ng-repeat="healthCheck in loadBalancer.elb.healthChecks">
           <hr ng-if="$index > 0">
-          <dt>Backend Service Name</dt>
-          <dd>{{ serviceName }}</dd>
           <gce-health-check health-check="healthCheck"></gce-health-check>
         </div>
       </dl>


### PR DESCRIPTION
@jtk54 
![backend_service_details](https://cloud.githubusercontent.com/assets/13868700/19056685/c854180c-8998-11e6-9470-a4b33b67d6db.png)
 
What do you think about just listing all of the health checks (after deduping, without the "Backend Service Name" header), since the relationship between health checks and backend services should be clear now?