### PR TITLE
favor .find to destructuring + .filter

### DIFF
--- a/app/scripts/modules/amazon/loadBalancer/details/loadBalancerDetail.controller.js
+++ b/app/scripts/modules/amazon/loadBalancer/details/loadBalancerDetail.controller.js
@@ -26,7 +26,7 @@ module.exports = angular.module('spinnaker.loadBalancer.aws.details.controller',
     $scope.InsightFilterStateModel = InsightFilterStateModel;
 
     function extractLoadBalancer() {
-      let [appLoadBalancer] = app.loadBalancers.data.filter(function (test) {
+      let appLoadBalancer = app.loadBalancers.data.find(function (test) {
         return test.name === loadBalancer.name && test.region === loadBalancer.region && test.account === loadBalancer.accountId;
       });
 

--- a/app/scripts/modules/amazon/securityGroup/configure/ingressRuleGroupSelector.component.js
+++ b/app/scripts/modules/amazon/securityGroup/configure/ingressRuleGroupSelector.component.js
@@ -42,8 +42,8 @@ module.exports = angular
         regions.forEach(region => {
           var regionalVpcId = null;
           if (vpcId) {
-            var [baseVpc] = this.vpcs.filter(vpc => vpc.id === vpcId),
-                [regionalVpc] = this.vpcs.filter(vpc => vpc.account === account && vpc.region === region && vpc.name === baseVpc.name);
+            let baseVpc = this.vpcs.find(vpc => vpc.id === vpcId),
+                regionalVpc = this.vpcs.find(vpc => vpc.account === account && vpc.region === region && vpc.name === baseVpc.name);
             regionalVpcId = regionalVpc ? regionalVpc.id : undefined;
           }
 
@@ -87,8 +87,8 @@ module.exports = angular
             this.rule.name = null;
             return;
           }
-          let [baseVpc] = filtered.filter(vpc => vpc.id === this.rule.vpcId),
-              [regionalVpc] = filtered.filter(vpc => vpc.account === this.rule.accountName && vpc.name === baseVpc.name);
+          let baseVpc = filtered.find(vpc => vpc.id === this.rule.vpcId),
+              regionalVpc = filtered.find(vpc => vpc.account === this.rule.accountName && vpc.name === baseVpc.name);
           if (regionalVpc) {
             this.rule.vpcId = regionalVpc.id;
           } else {

--- a/app/scripts/modules/amazon/serverGroup/configure/serverGroupConfiguration.service.js
+++ b/app/scripts/modules/amazon/serverGroup/configure/serverGroupConfiguration.service.js
@@ -234,7 +234,7 @@ module.exports = angular.module('spinnaker.aws.serverGroup.configure.service', [
               ami: image.amis ? image.amis[command.region][0] : null
             };
           });
-        var [match] = regionalImages.filter((image) => image.imageName === command.amiName);
+        let match = regionalImages.find((image) => image.imageName === command.amiName);
         if (command.amiName && !match) {
           result.dirty.amiName = true;
           command.amiName = null;

--- a/app/scripts/modules/amazon/serverGroup/configure/wizard/CloneServerGroup.aws.controller.js
+++ b/app/scripts/modules/amazon/serverGroup/configure/wizard/CloneServerGroup.aws.controller.js
@@ -46,7 +46,7 @@ module.exports = angular.module('spinnaker.aws.cloneServerGroup.controller', [
       if ($scope.$$destroyed) {
         return;
       }
-      let [cloneStage] = $scope.taskMonitor.task.execution.stages.filter((stage) => stage.type === 'cloneServerGroup');
+      let cloneStage = $scope.taskMonitor.task.execution.stages.find((stage) => stage.type === 'cloneServerGroup');
       if (cloneStage && cloneStage.context['deploy.server.groups']) {
         let newServerGroupName = cloneStage.context['deploy.server.groups'][$scope.command.region];
         if (newServerGroupName) {

--- a/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/alarm/alarmConfigurer.component.js
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/alarm/alarmConfigurer.component.js
@@ -181,7 +181,7 @@ module.exports = angular
             results.forEach(transformAvailableMetric);
             this.metrics = results.sort((a, b) => a.label.localeCompare(b.label));
             let currentDimensions = alarm.dimensions.sort(dimensionSorter).map(d => d.value).join(', ');
-            let [selected] = this.metrics.filter(metric =>
+            let selected = this.metrics.find(metric =>
               metric.name === alarm.metricName && metric.namespace === alarm.namespace &&
               metric.dimensionValues === currentDimensions
             );

--- a/app/scripts/modules/amazon/serverGroup/details/scalingProcesses/autoScalingProcess.service.js
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingProcesses/autoScalingProcess.service.js
@@ -67,7 +67,7 @@ module.exports = angular.module('spinnaker.serverGroup.details.aws.autoscaling.p
     function getDisabledDate(serverGroup) {
       if (serverGroup.isDisabled) {
         let processes = normalizeScalingProcesses(serverGroup);
-        let [disabledProcess] = processes.filter((process) => process.name === 'AddToLoadBalancer' && !process.enabled);
+        let disabledProcess = processes.find((process) => process.name === 'AddToLoadBalancer' && !process.enabled);
         if (disabledProcess) {
           return disabledProcess.suspensionDate;
         }

--- a/app/scripts/modules/azure/serverGroup/configure/wizard/CloneServerGroup.azure.controller.js
+++ b/app/scripts/modules/azure/serverGroup/configure/wizard/CloneServerGroup.azure.controller.js
@@ -39,7 +39,7 @@ module.exports = angular.module('spinnaker.azure.cloneServerGroup.controller', [
       if ($scope.$$destroyed) {
         return;
       }
-      let [cloneStage] = $scope.taskMonitor.task.execution.stages.filter((stage) => stage.type === 'cloneServerGroup');
+      let cloneStage = $scope.taskMonitor.task.execution.stages.find((stage) => stage.type === 'cloneServerGroup');
       if (cloneStage && cloneStage.context['deploy.server.groups']) {
         let newServerGroupName = cloneStage.context['deploy.server.groups'][$scope.command.region];
         if (newServerGroupName) {

--- a/app/scripts/modules/cloudfoundry/serverGroup/configure/wizard/CloneServerGroupCtrl.js
+++ b/app/scripts/modules/cloudfoundry/serverGroup/configure/wizard/CloneServerGroupCtrl.js
@@ -37,7 +37,7 @@ module.exports = angular.module('spinnaker.serverGroup.configure.cf.cloneServerG
       if ($scope.$$destroyed) {
         return;
       }
-      let [cloneStage] = $scope.taskMonitor.task.execution.stages.filter((stage) => stage.type === 'cloneServerGroup');
+      let cloneStage = $scope.taskMonitor.task.execution.stages.find((stage) => stage.type === 'cloneServerGroup');
       if (cloneStage && cloneStage.context['deploy.server.groups']) {
         let newServerGroupName = cloneStage.context['deploy.server.groups'][$scope.command.region];
         if (newServerGroupName) {

--- a/app/scripts/modules/core/application/application.model.ts
+++ b/app/scripts/modules/core/application/application.model.ts
@@ -67,8 +67,7 @@ export class Application {
    * @param key
    */
   public getDataSource(key: string): ApplicationDataSource {
-    let [dataSource] = this.dataSources.filter(ds => ds.key === key);
-    return dataSource;
+    return this.dataSources.find(ds => ds.key === key);
   }
 
   /**

--- a/app/scripts/modules/core/cluster/filter/clusterFilter.service.js
+++ b/app/scripts/modules/core/cluster/filter/clusterFilter.service.js
@@ -122,7 +122,7 @@ module.exports = angular
       if (ClusterFilterModel.sortFilter.listInstances && ClusterFilterModel.sortFilter.multiselect) {
         let instancesSelected = 0;
         MultiselectModel.instanceGroups.forEach((instanceGroup) => {
-          let [match] = serverGroups.filter((serverGroup) => {
+          let match = serverGroups.find((serverGroup) => {
             return serverGroup.name === instanceGroup.serverGroup &&
               serverGroup.region === instanceGroup.region &&
               serverGroup.account === instanceGroup.account &&
@@ -291,14 +291,13 @@ module.exports = angular
     }, 25);
 
     function getCluster(application, clusterName, account, category) {
-      let [match] = (application.clusters || []).filter(c => c.account === account && c.name === clusterName && c.category === category);
-      return match;
+      return (application.clusters || []).find(c => c.account === account && c.name === clusterName && c.category === category);
     }
 
     function diffSubgroups(oldGroups, newGroups) {
       var groupsToRemove = [];
       oldGroups.forEach(function(oldGroup, idx) {
-        var [newGroup] = (newGroups || []).filter(group =>
+        let newGroup = (newGroups || []).find(group =>
             group.heading === oldGroup.heading &&
             group.category === oldGroup.category);
         if (!newGroup) {

--- a/app/scripts/modules/core/cluster/filter/multiselect.model.js
+++ b/app/scripts/modules/core/cluster/filter/multiselect.model.js
@@ -83,7 +83,7 @@ module.exports = angular
           account = serverGroup.account,
           region = serverGroup.region,
           cloudProvider = serverGroup.type;
-      let [result] = this.instanceGroups.filter((instanceGroup) => {
+      let result = this.instanceGroups.find((instanceGroup) => {
         return instanceGroup.serverGroup === serverGroupName &&
           instanceGroup.account === account &&
           instanceGroup.region === region &&
@@ -138,7 +138,7 @@ module.exports = angular
       }
       this.deselectAllInstances();
       let key = this.makeServerGroupKey(serverGroup),
-          [selected] = this.serverGroups.filter((sg) => sg.key === key);
+          selected = this.serverGroups.find((sg) => sg.key === key);
       if (selected) {
         this.serverGroups.splice(this.serverGroups.indexOf(selected), 1);
       } else {

--- a/app/scripts/modules/core/delivery/service/execution.service.js
+++ b/app/scripts/modules/core/delivery/service/execution.service.js
@@ -69,7 +69,7 @@ module.exports = angular.module('spinnaker.core.delivery.executions.service', [
     function waitUntilNewTriggeredPipelineAppears(application, pipelineName, triggeredPipelineId) {
 
       return getRunningExecutions(application.name).then(function(executions) {
-        var [match] = executions.filter(function(execution) {
+        let match = executions.find(function(execution) {
           return execution.id === triggeredPipelineId;
         });
         var deferred = $q.defer();

--- a/app/scripts/modules/core/instance/details/multipleInstances.controller.js
+++ b/app/scripts/modules/core/instance/details/multipleInstances.controller.js
@@ -174,10 +174,8 @@ module.exports = angular.module('spinnaker.core.instance.details.multipleInstanc
      */
 
     function getServerGroup(group) {
-      let [serverGroup] = app.serverGroups.data.filter((serverGroup) => serverGroup.name === group.serverGroup &&
+      return app.serverGroups.data.find((serverGroup) => serverGroup.name === group.serverGroup &&
           serverGroup.account === group.account && serverGroup.region === group.region);
-
-      return serverGroup;
     }
 
     function getInstanceDetails(group, instanceId) {
@@ -187,8 +185,7 @@ module.exports = angular.module('spinnaker.core.instance.details.multipleInstanc
         return null;
       }
 
-      let [instance] = serverGroup.instances.filter((instance) => instance.id === instanceId);
-      return instance || {};
+      return serverGroup.instances.find((instance) => instance.id === instanceId) || {};
     }
 
     let makeInstanceModel = (group, instanceId) => {

--- a/app/scripts/modules/core/loadBalancer/loadBalancersTag.component.ts
+++ b/app/scripts/modules/core/loadBalancer/loadBalancersTag.component.ts
@@ -16,9 +16,9 @@ export class LoadBalancersTagController implements ng.IComponentController {
     this.application.getDataSource('loadBalancers').ready().then(() => {
       let serverGroup: ServerGroup = this.serverGroup;
       this.loadBalancers = serverGroup.loadBalancers.map( (lbName: string) => {
-        let [match] = this.application.getDataSource('loadBalancers')
+        let match = this.application.getDataSource('loadBalancers')
           .data
-          .filter((lb: LoadBalancer): boolean => {
+          .find((lb: LoadBalancer): boolean => {
             return lb.name === lbName
               && lb.account === serverGroup.account
               && lb.region === serverGroup.region

--- a/app/scripts/modules/core/pipeline/config/stages/executionWindows/executionWindowsDetails.controller.js
+++ b/app/scripts/modules/core/pipeline/config/stages/executionWindows/executionWindowsDetails.controller.js
@@ -44,7 +44,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.executionWindows.
     this.finishWaiting = () => {
       let stage = $scope.stage;
       let matcher = (execution) => {
-        let [match] = execution.stages.filter((test) => test.id === stage.id);
+        let match = execution.stages.find((test) => test.id === stage.id);
         return match.status !== 'RUNNING';
       };
 

--- a/app/scripts/modules/core/pipeline/config/stages/manualJudgment/manualJudgment.service.js
+++ b/app/scripts/modules/core/pipeline/config/stages/manualJudgment/manualJudgment.service.js
@@ -11,7 +11,7 @@ module.exports = angular
 
     let provideJudgment = (execution, stage, judgment, input) => {
       let matcher = (execution) => {
-        let [match] = execution.stages.filter((test) => test.id === stage.id);
+        let match = execution.stages.find((test) => test.id === stage.id);
         return match && match.status !== 'RUNNING';
       };
       let data = {judgmentStatus: judgment, judgmentInput: input};

--- a/app/scripts/modules/core/pipeline/config/stages/wait/waitExecutionDetails.controller.js
+++ b/app/scripts/modules/core/pipeline/config/stages/wait/waitExecutionDetails.controller.js
@@ -27,7 +27,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.wait.executionDet
     this.finishWaiting = () => {
       let stage = $scope.stage;
       let matcher = (execution) => {
-        let [match] = execution.stages.filter((test) => test.id === stage.id);
+        let match = execution.stages.find((test) => test.id === stage.id);
         return match.status !== 'RUNNING';
       };
 

--- a/app/scripts/modules/core/pipeline/config/triggers/pipeline/pipelineTrigger.module.js
+++ b/app/scripts/modules/core/pipeline/config/triggers/pipeline/pipelineTrigger.module.js
@@ -31,7 +31,7 @@ module.exports = angular.module('spinnaker.core.pipeline.config.trigger.pipeline
       formatLabel: (trigger) => {
 
         let loadSuccess = (pipelines) => {
-          let [pipeline] = pipelines.filter((config) => config.id === trigger.pipeline);
+          let pipeline = pipelines.find((config) => config.id === trigger.pipeline);
           return pipeline ? `(Pipeline) ${trigger.application}: ${pipeline.name}` : '[pipeline not found]';
         };
 
@@ -98,7 +98,7 @@ module.exports = angular.module('spinnaker.core.pipeline.config.trigger.pipeline
     $scope.userSuppliedParameters = {};
 
     this.updateParam = function(parameter) {
-      if($scope.useDefaultParameters[parameter] === true) {
+      if ($scope.useDefaultParameters[parameter] === true) {
         delete $scope.userSuppliedParameters[parameter];
         delete $scope.trigger.parameters[parameter];
       } else if($scope.userSuppliedParameters[parameter]) {

--- a/app/scripts/modules/core/serverGroup/details/multipleServerGroups.controller.js
+++ b/app/scripts/modules/core/serverGroup/details/multipleServerGroups.controller.js
@@ -87,7 +87,7 @@ module.exports = angular.module('spinnaker.core.serverGroup.details.multipleServ
       let retrieveServerGroups = () => {
         this.serverGroups = MultiselectModel.serverGroups.map(multiselectGroup => {
           let group = _.cloneDeep(multiselectGroup);
-          let [match] = app.serverGroups.data.filter(check => check.name === group.name && check.account === group.account && check.region === group.region);
+          let match = app.serverGroups.data.find(check => check.name === group.name && check.account === group.account && check.region === group.region);
           if (match) {
             group.instanceCounts = _.cloneDeep(match.instanceCounts);
             group.disabled = match.isDisabled;

--- a/app/scripts/modules/core/subnet/subnet.read.service.js
+++ b/app/scripts/modules/core/subnet/subnet.read.service.js
@@ -51,7 +51,7 @@ module.exports = angular
 
     function getSubnetPurpose(id) {
       return listSubnets().then(subnets => {
-        let [match] = subnets.filter(test => test.id === id);
+        let match = subnets.find(test => test.id === id);
         return match ? match.purpose : null;
       });
     }

--- a/app/scripts/modules/core/task/taskProgressBar.directive.js
+++ b/app/scripts/modules/core/task/taskProgressBar.directive.js
@@ -20,7 +20,7 @@ module.exports = angular.module('spinnaker.core.task.progressBar.directive', [])
         scope.progressStyle = { width: stepsComplete.length / task.steps.length * 100 + '%' };
 
         if (task.isRunning) {
-          let [currentStep] = task.steps.filter(step => step.hasNotStarted || step.isRunning);
+          let currentStep = task.steps.find(step => step.hasNotStarted || step.isRunning);
           if (currentStep) {
             var currentStepIndex = task.steps.indexOf(currentStep) + 1;
             scope.tooltip = $sce.trustAsHtml('Step ' + currentStepIndex + ' of ' + task.steps.length + ': ' + $filter('robotToHuman')(currentStep.name));
@@ -28,7 +28,7 @@ module.exports = angular.module('spinnaker.core.task.progressBar.directive', [])
         }
 
         if (task.isFailed) {
-          var [failedStep] = task.steps.filter(step => step.isFailed || step.isSuspended);
+          let failedStep = task.steps.find(step => step.isFailed || step.isSuspended);
 
           if (failedStep && task.failureMessage) {
             var failedStepIndex = task.steps.indexOf(failedStep) + 1;

--- a/app/scripts/modules/google/serverGroup/configure/wizard/cloneServerGroup.gce.controller.js
+++ b/app/scripts/modules/google/serverGroup/configure/wizard/cloneServerGroup.gce.controller.js
@@ -46,7 +46,7 @@ module.exports = angular.module('spinnaker.serverGroup.configure.gce.cloneServer
       if ($scope.$$destroyed) {
         return;
       }
-      let [cloneStage] = $scope.taskMonitor.task.execution.stages.filter((stage) => stage.type === 'cloneServerGroup');
+      let cloneStage = $scope.taskMonitor.task.execution.stages.find((stage) => stage.type === 'cloneServerGroup');
       if (cloneStage && cloneStage.context['deploy.server.groups']) {
         let newServerGroupName = cloneStage.context['deploy.server.groups'][$scope.command.region];
         if (newServerGroupName) {

--- a/app/scripts/modules/kubernetes/cluster/configure/CommandBuilder.js
+++ b/app/scripts/modules/kubernetes/cluster/configure/CommandBuilder.js
@@ -135,7 +135,7 @@ module.exports = angular.module('spinnaker.kubernetes.clusterCommandBuilder.serv
       let result = [];
       containers.forEach((container) => {
         if (container.imageDescription.fromContext) {
-          let [matchingImage] = upstreamImages.filter((image) => container.imageDescription.stageId === image.stageId);
+          let matchingImage = upstreamImages.find((image) => container.imageDescription.stageId === image.stageId);
           if (matchingImage) {
             container.imageDescription.cluster = matchingImage.cluster;
             container.imageDescription.pattern = matchingImage.pattern;
@@ -143,7 +143,7 @@ module.exports = angular.module('spinnaker.kubernetes.clusterCommandBuilder.serv
             result.push(container);
           }
         } else if (container.imageDescription.fromTrigger) {
-          let [matchingImage] = upstreamImages.filter((image) => {
+          let matchingImage = upstreamImages.find((image) => {
             return container.imageDescription.registry === image.registry
               && container.imageDescription.repository === image.repository
               && container.imageDescription.tag === image.tag;
@@ -176,7 +176,7 @@ module.exports = angular.module('spinnaker.kubernetes.clusterCommandBuilder.serv
         });
       }
       current.requisiteStageRefIds.forEach(function(id) {
-        let [next] = all.filter((stage) => stage.refId === id);
+        let next = all.find((stage) => stage.refId === id);
         if (next) {
           result = result.concat(findUpstreamImages(next, all, visited));
         }

--- a/app/scripts/modules/netflix/migrator/migrator.service.js
+++ b/app/scripts/modules/netflix/migrator/migrator.service.js
@@ -95,7 +95,7 @@ module.exports = angular
     let addAccountNames = (results) => {
       accountService.getAllAccountDetailsForProvider('aws').then(accounts => {
         results.securityGroups.forEach(group => {
-          let [match] = accounts.filter(a => a.accountId === group.accountId);
+          let match = accounts.find(a => a.accountId === group.accountId);
           group.accountName = match ? match.name : group.accountId;
         });
       });

--- a/app/scripts/modules/netflix/migrator/pipeline/pipeline.migrator.directive.js
+++ b/app/scripts/modules/netflix/migrator/pipeline/pipeline.migrator.directive.js
@@ -55,7 +55,7 @@ module.exports = angular
     }
 
     if (settings.feature.vpcMigrator) {
-      let [migrated] = $scope.application.pipelineConfigs.data.filter(test => test.name === $scope.pipeline.name + ' - vpc0');
+      let migrated = $scope.application.pipelineConfigs.data.find(test => test.name === $scope.pipeline.name + ' - vpc0');
       if (migrated) {
         $scope.migrated = migrated;
       }
@@ -244,7 +244,7 @@ module.exports = angular
     };
 
     this.close = () => {
-      var [newPipeline] = application.pipelineConfigs.data.filter(test => {
+      let newPipeline = application.pipelineConfigs.data.find(test => {
         return test.name.indexOf(this.viewState.targetName) === 0;
       });
       $state.go('^.pipelineConfig', {pipelineId: newPipeline.id});

--- a/app/scripts/modules/openstack/loadBalancer/details/details.controller.js
+++ b/app/scripts/modules/openstack/loadBalancer/details/details.controller.js
@@ -26,7 +26,7 @@ module.exports = angular.module('spinnaker.loadBalancer.openstack.details.contro
       $scope.InsightFilterStateModel = InsightFilterStateModel;
 
       function extractLoadBalancer() {
-        let [appLoadBalancer] = app.loadBalancers.data.filter(function (test) {
+        let appLoadBalancer = app.loadBalancers.data.find(function (test) {
           return test.name === loadBalancer.name &&
             test.region === loadBalancer.region &&
             test.account === loadBalancer.accountId;

--- a/app/scripts/modules/openstack/serverGroup/configure/ServerGroupCommandBuilder.js
+++ b/app/scripts/modules/openstack/serverGroup/configure/ServerGroupCommandBuilder.js
@@ -7,7 +7,7 @@ let angular = require('angular');
 module.exports = angular.module('spinnaker.openstack.serverGroupCommandBuilder.service', [
   require('../../image/image.reader.js'),
 ])
-  .factory('openstackServerGroupCommandBuilder', function ($q, openstackImageReader, subnetReader, loadBalancerReader, settings, namingService, applicationReader, openstackServerGroupTransformer) {
+  .factory('openstackServerGroupCommandBuilder', function ($q, openstackImageReader, subnetReader, loadBalancerReader, settings, namingService, applicationReader) {
 
     function buildNewServerGroupCommand(application, defaults) {
       defaults = defaults || {};

--- a/app/scripts/modules/titus/serverGroup/configure/wizard/CloneServerGroup.titus.controller.js
+++ b/app/scripts/modules/titus/serverGroup/configure/wizard/CloneServerGroup.titus.controller.js
@@ -31,7 +31,7 @@ module.exports = angular.module('spinnaker.serverGroup.configure.titus.cloneServ
       if ($scope.$$destroyed) {
         return;
       }
-      let [cloneStage] = $scope.taskMonitor.task.execution.stages.filter((stage) => stage.type === 'cloneServerGroup');
+      let cloneStage = $scope.taskMonitor.task.execution.stages.find((stage) => stage.type === 'cloneServerGroup');
       if (cloneStage && cloneStage.context['deploy.server.groups']) {
         let newServerGroupName = cloneStage.context['deploy.server.groups'][$scope.command.region];
         if (newServerGroupName) {


### PR DESCRIPTION
Long ago, Chrome didn't support `Array.prototype.find`, and some of us (mostly me) got in the bad habit of destructuring the first item out of a `filter` operation to get around it.

All major browsers now support `find`, so this PR cleans up code for readability.

Also removing an unused parameter that the linter is yelling about.

@zanthrash for you