### PR TITLE
(core) include codelyzer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "babel-loader": "^6.2.5",
     "babel-preset-es2015": "^6.13.2",
     "bower-webpack-plugin": "^0.1.8",
+    "codelyzer": "0.0.28",
     "css-loader": "^0.23.1",
     "envify": "^1.2.1",
     "envify-loader": "^0.1.0",


### PR DESCRIPTION
@icfantv I can't run deck without this - did you install it locally, maybe?