### PR TITLE
(core) sync ui-router state when manually changing url

### DIFF
--- a/app/scripts/modules/core/filterModel/filter.model.service.js
+++ b/app/scripts/modules/core/filterModel/filter.model.service.js
@@ -8,7 +8,7 @@ module.exports = angular
   .module('spinnaker.core.filterModel.service', [
     require('angular-ui-router'),
   ])
-.factory('filterModelService', function ($location, $state, $stateParams, $timeout) {
+.factory('filterModelService', function ($location, $state, $stateParams, $urlRouter, $timeout) {
 
     function isFilterable(sortFilterModel) {
       return _.size(sortFilterModel) > 0 && _.some(sortFilterModel);
@@ -299,6 +299,7 @@ module.exports = angular
         filterModelConfig.forEach(function (property) {
           $location.search(property.param, converters[property.type].toParam(filterModel, property));
         });
+        $urlRouter.update(true);
       };
     }
 


### PR DESCRIPTION
Fixes a bug that's been around for well over a year.

Sometimes, when manually changing the URL through `$location.search`, ui-router does not update its internal state, where it keeps a `location` variable. When Angular eventually broadcasts a `$locationChangeSuccess` event, ui-router resets the `$location.search` to the previous query parameters.

Calling `$urlRouter.update(true)` sets ui-router's `location` to the current URL and prevents the reset.

@zanthrash PTAL