### PR TITLE
(core) correctly destroy tooltips when instances are removed from view

### DIFF
--- a/app/scripts/modules/core/instance/instances.directive.js
+++ b/app/scripts/modules/core/instance/instances.directive.js
@@ -74,8 +74,12 @@ module.exports = angular.module('spinnaker.core.instance.instances.directive', [
         });
 
         elem.mouseover((event) => {
-          $(event.target, elem).tooltip({placement: 'top', container: 'body', animation: false}).tooltip('show');
-          tooltipsApplied = true;
+          if (tooltipsApplied) {
+            $(event.target, elem).tooltip('show');
+          } else {
+            $(event.target, elem).tooltip({placement: 'top', container: 'body', animation: false, selector: '[data-toggle="tooltip"]'}).tooltip('show');
+            tooltipsApplied = true;
+          }
         });
 
         function clearActiveState() {


### PR DESCRIPTION
Turns out the Bootstrap tooltip is not exactly like the jQuery UI tooltip - removing via delegation requires a `selector` be passed in on instantiation.

This also cuts down on the number of tooltips we attempt to apply.

@zanthrash @icfantv PTAL