### PR TITLE
(titus): fix constraint array -> string mapping

### DIFF
--- a/app/scripts/modules/titus/serverGroup/configure/ServerGroupCommandBuilder.js
+++ b/app/scripts/modules/titus/serverGroup/configure/ServerGroupCommandBuilder.js
@@ -70,8 +70,8 @@ module.exports = angular.module('spinnaker.titus.serverGroupCommandBuilder.servi
         entryPoint: serverGroup.entryPoint,
         iamProfile: serverGroup.iamProfile,
         securityGroups: serverGroup.securityGroups,
-        hardConstraints: serverGroup.hardConstraints,
-        softConstraints: serverGroup.softConstraints,
+        hardConstraints: serverGroup.hardConstraints.join(),
+        softConstraints: serverGroup.softConstraints.join(),
         inService: serverGroup.disabled ? false : true,
         source: {
           account: serverGroup.account,
@@ -113,6 +113,8 @@ module.exports = angular.module('spinnaker.titus.serverGroupCommandBuilder.servi
 
       return asyncLoader.then(function(asyncData) {
         var command = asyncData.command;
+        command.hardConstraints = command.hardConstraints.join();
+        command.softConstraints = command.softConstraints.join();
 
         var viewState = {
           disableImageSelection: true,


### PR DESCRIPTION
* fix issue in deck whereby the hard and soft constraints come from the
server as arrays, but are modified as comma-delimited strings in the
advanced settings section of cloning a server group.
* also fixed this issue in pipelines for adding a server group in a
deploy stage for when the configuration is copied from an existing titus
server group.