### PR TITLE
tweak tslint rules

### DIFF
--- a/app/scripts/modules/core/application/service/applicationDataSource.ts
+++ b/app/scripts/modules/core/application/service/applicationDataSource.ts
@@ -80,7 +80,7 @@ export class DataSourceConfig {
    * It does *not* automatically populate the "data" field of the data source - that is the responsibility of the
    * "onLoad" method.
    */
-  public loader: {(any: any): ng.IPromise<any>};
+  public loader: {(fn: any): ng.IPromise<any>};
 
   /**
    * A method that is called when the "loader" method resolves. The method must return a promise. If the "loader"
@@ -90,7 +90,7 @@ export class DataSourceConfig {
    * If the onLoad method resolves with a null value, the result will be discarded and the data source's "data" field
    * will remain unchanged.
    */
-  public onLoad: {(any: any): ng.IPromise<any>};
+  public onLoad: {(fn: any): ng.IPromise<any>};
 
   /**
    * If the data source should contribute to the application's default credentials setting, this field should be set
@@ -237,12 +237,12 @@ export class ApplicationDataSource {
   /**
    * See DataSourceConfig#onLoad
    */
-  public onLoad: {(Application: any, any: any): ng.IPromise<any>};
+  public onLoad: {(Application: any, fn: any): ng.IPromise<any>};
 
   /**
    * See DataSourceConfig#loader
    */
-  public loader: {(any: any): ng.IPromise<any>};
+  public loader: {(fn: any): ng.IPromise<any>};
 
   private refreshStream: Subject<any> = new Subject();
 

--- a/app/scripts/modules/core/chaosMonkey/chaosMonkeyConfigFooter.component.spec.ts
+++ b/app/scripts/modules/core/chaosMonkey/chaosMonkeyConfigFooter.component.spec.ts
@@ -8,7 +8,7 @@ describe('Component: ChaosMonkeyConfigFooter', () => {
       $q: ng.IQService,
       $scope: ng.IScope;
 
-  let initializeController = (data) => {
+  let initializeController = (data: any) => {
     $ctrl = <ChaosMonkeyConfigFooterController> $componentController(
       'chaosMonkeyConfigFooter',
       { $scope: null, applicationWriter: applicationWriter },
@@ -34,7 +34,7 @@ describe('Component: ChaosMonkeyConfigFooter', () => {
     it('replaces contents of config with original config', () => {
       var data = {
         viewState: {
-          originalConfig: { exceptions: [], enabled: false }
+          originalConfig: { exceptions: ([] as any), enabled: false }
         },
         config: {
           exceptions: [ {account: 'prod', region: 'us-east-1'} ],

--- a/app/scripts/modules/core/chaosMonkey/chaosMonkeyExceptions.component.spec.ts
+++ b/app/scripts/modules/core/chaosMonkey/chaosMonkeyExceptions.component.spec.ts
@@ -8,7 +8,7 @@ describe('Controller: ChaosMonkeyExceptions', () => {
       $scope: ng.IScope,
       $q: ng.IQService;
 
-  let initializeController = (data) => {
+  let initializeController = (data: any) => {
     $ctrl = <ChaosMonkeyExceptionsController> $componentController(
       'chaosMonkeyExceptions',
       { $scope: null, accountService: accountService, $q: $q },
@@ -33,13 +33,13 @@ describe('Controller: ChaosMonkeyExceptions', () => {
 
     it('gets all accounts, then adds wildcard and regions per account to vm', () => {
       let accounts = [ {name: 'prod'}, {name: 'test'} ];
-      let details = {
+      let details: any = {
         prod: { name: 'prod', regions: [ {name: 'us-east-1'}, {name: 'us-west-1'}] },
         test: { name: 'test', regions: [ {name: 'us-west-2'}, {name: 'eu-west-1'}] }
       };
 
       spyOn(accountService, 'listAccounts').and.returnValue($q.when(accounts));
-      spyOn(accountService, 'getAccountDetails').and.callFake((accountName) => {
+      spyOn(accountService, 'getAccountDetails').and.callFake((accountName: string): ng.IPromise<any> => {
         return $q.when(details[accountName]);
       });
 

--- a/app/scripts/modules/core/help/helpContents.registry.spec.ts
+++ b/app/scripts/modules/core/help/helpContents.registry.spec.ts
@@ -6,7 +6,7 @@ describe('Help contents registry', () => {
 
   beforeEach(angular.mock.module(helpRegistryModule));
 
-  beforeEach(angular.mock.inject((helpContentsRegistry) => registry = helpContentsRegistry));
+  beforeEach(angular.mock.inject((helpContentsRegistry: HelpContentsRegistry) => registry = helpContentsRegistry));
 
   describe('Override functionality', () => {
     it('overrides existing value', () => {

--- a/tslint.json
+++ b/tslint.json
@@ -38,7 +38,7 @@
     "no-debugger": true,
     "no-duplicate-key": true,
     "no-duplicate-variable": true,
-    "no-empty": false,
+    "no-empty": true,
     "no-eval": true,
     "no-inferrable-types": true,
     "no-shadowed-variable": true,
@@ -53,12 +53,15 @@
     "object-literal-sort-keys": false,
     "one-line": [
       true,
+      "check-catch",
+      "check-else",
       "check-open-brace",
       "check-whitespace"
     ],
     "quotemark": [
       true,
-      "single"
+      "single",
+      "avoid-escape"
     ],
     "radix": true,
     "semicolon": [
@@ -78,7 +81,11 @@
         "variable-declaration": "nospace"
       }
     ],
-    "variable-name": false,
+    "variable-name": [
+      true,
+      "ban-keywords",
+      "allow-leading-underscore"
+    ],
     "whitespace": [
       true,
       "check-branch",


### PR DESCRIPTION
I bailed on the import ordering because it seems like a pain, and also the opposite of what I think we agreed we want (third-party modules first), since internal modules all come from a directory path, i.e. `./`, which is alphabetically before node modules.

@icfantv @zanthrash @danielpeach PTAL