### PR TITLE
(core) fixes check precondition for openstack

### DIFF
--- a/app/scripts/modules/core/pipeline/config/preconditions/selector/preconditionSelector.directive.js
+++ b/app/scripts/modules/core/pipeline/config/preconditions/selector/preconditionSelector.directive.js
@@ -60,6 +60,16 @@ module.exports = angular.module('spinnaker.core.pipeline.config.preconditions.se
 
       let accountFilter = (cluster) => cluster.account === $scope.precondition.context.credentials;
       $scope.regions = appListExtractorService.getRegions([$scope.application], accountFilter);
+
+      //Setting cloudProvider when account is updated
+      let providerFilter = (account) => account.name === $scope.precondition.context.credentials;
+      let accountsArray = $scope.accounts;
+      if (accountsArray !== null && accountsArray !== undefined) {
+        let account = accountsArray.find(providerFilter);
+        if (account !== null && account !== undefined) {
+          $scope.precondition.cloudProvider = account.type;
+        }
+      }
     };
 
     this.reset = () => {


### PR DESCRIPTION
$scope.precondition.cloudProvider was never set during this pipeline stage, so I have added code to set the variable to the proper cloud provider during the "accountUpdated" step. 