### PR TITLE
(core) put account/region into separate columns in tasks views

### DIFF
--- a/app/scripts/modules/core/task/tasks.html
+++ b/app/scripts/modules/core/task/tasks.html
@@ -69,11 +69,13 @@
         <table class="table table-condensed">
           <thead>
             <tr>
-              <th width="36%">Task</th>
+              <th width="30%">Task</th>
+              <th width="5%">Account</th>
+              <th width="8%">Region</th>
               <th width="12%">Progress</th>
               <th width="12%">Started</th>
               <th width="12%">Ended</th>
-              <th width="12%">Running Time</th>
+              <th width="8%">Running Time</th>
               <th>User</th>
               <th>Actions</th>
             </tr>
@@ -84,9 +86,6 @@
                 <div class="task-name">
                   <a href id="task-{{task.id}}"><span class="glyphicon glyphicon-chevron-{{tasks.isExpanded(task.id) ? 'down' : 'right'}}"></span></a>
                   {{task.name}}
-                  <account-tag account="task.getValueFor('credentials')" pad="both"></account-tag>
-                  <span ng-if="task.getValueFor('region')">({{task.getValueFor('region')}})</span>
-                  <span ng-if="!task.getValueFor('region') && task.getValueFor('regions')">({{task.getValueFor('regions').join(', ')}})</span>
                 </div>
 
                 <div ng-if="tasks.getFirstDeployServerGroupName(task)" class="task-name">
@@ -100,6 +99,13 @@
                   </span>
 
                 </div>
+              </td>
+              <td>
+                <account-tag account="task.getValueFor('credentials')" pad="both"></account-tag>
+              </td>
+              <td>
+                <span ng-if="task.getValueFor('region')">({{task.getValueFor('region')}})</span>
+                <span ng-if="!task.getValueFor('region') && task.getValueFor('regions')">({{task.getValueFor('regions').join(', ')}})</span>
               </td>
               <td>
                 <task-progress-bar task="task"></task-progress-bar>


### PR DESCRIPTION
it's nice that they're there but hard to read when they're all over the place horizontally.

Current:
<img width="1385" alt="screen shot 2016-10-07 at 11 51 38 am" src="https://cloud.githubusercontent.com/assets/73450/19201847/7704532e-8c84-11e6-944b-58c90df8d6fb.png">

PR:
<img width="1385" alt="screen shot 2016-10-07 at 11 51 07 am" src="https://cloud.githubusercontent.com/assets/73450/19201853/7c26140a-8c84-11e6-9452-45bd867b78fc.png">
