### PR TITLE
Set default values for chaos monkey config

### DIFF
--- a/app/scripts/modules/core/chaosMonkey/chaosMonkeyNewApplicationConfig.component.ts
+++ b/app/scripts/modules/core/chaosMonkey/chaosMonkeyNewApplicationConfig.component.ts
@@ -11,7 +11,12 @@ export class ChaosMonkeyNewApplicationConfigController {
     this.enabled = settings.feature && settings.feature.chaosMonkey;
     if (this.enabled) {
       this.applicationConfig.chaosMonkey = {
-        enabled: this.enabled
+        enabled: this.enabled,
+        meanTimeBetweenKillsInWorkDays: 2,
+        minTimeBetweenKillsInWorkDays: 1,
+        grouping: 'cluster',
+        regionsAreIndependent: true,
+        exceptions: []
       };
     }
   }


### PR DESCRIPTION
On app creation, when chaos monkey is enabled, set the chaos monkey config values to the defaults.

This restores the behavior to what it was before chaos monkey code was moved from netflix to core.

cc @anotherchrisberry 