### PR TITLE
(core) task cleanup, search improvements

### DIFF
--- a/app/scripts/modules/azure/loadBalancer/loadBalancer.write.service.js
+++ b/app/scripts/modules/azure/loadBalancer/loadBalancer.write.service.js
@@ -42,7 +42,7 @@ module.exports = angular
       var operation = taskExecutor.executeTask({
         job: [params],
         application: application,
-        description: 'Delete load balancer: ' + loadBalancer.name + ' in ' + loadBalancer.accountId + ':' + loadBalancer.region
+        description: 'Delete load balancer: ' + loadBalancer.name
       });
 
       infrastructureCaches.clearCache('loadBalancers');

--- a/app/scripts/modules/azure/securityGroup/securityGroup.write.service.js
+++ b/app/scripts/modules/azure/securityGroup/securityGroup.write.service.js
@@ -42,7 +42,7 @@ module.exports = angular
       var operation = taskExecutor.executeTask({
         job: [params],
         application: application,
-        description: 'Delete Security Group: ' + securityGroup.name + ' in ' + securityGroup.accountId + ':' + securityGroup.region
+        description: 'Delete Security Group: ' + securityGroup.name
       });
 
       infrastructureCaches.clearCache('securityGroup');

--- a/app/scripts/modules/core/loadBalancer/loadBalancer.write.service.js
+++ b/app/scripts/modules/core/loadBalancer/loadBalancer.write.service.js
@@ -21,7 +21,7 @@ module.exports = angular
       var operation = taskExecutor.executeTask({
         job: [params],
         application: application,
-        description: 'Delete load balancer: ' + loadBalancer.name + ' in ' + loadBalancer.accountId + ':' + loadBalancer.region
+        description: 'Delete load balancer: ' + loadBalancer.name
       });
 
       infrastructureCaches.clearCache('loadBalancers');

--- a/app/scripts/modules/core/securityGroup/securityGroup.write.service.js
+++ b/app/scripts/modules/core/securityGroup/securityGroup.write.service.js
@@ -40,7 +40,7 @@ module.exports = angular
       var operation = taskExecutor.executeTask({
         job: [params],
         application: application,
-        description: 'Delete Security Group: ' + securityGroup.name + ' in ' + (params.accountId || securityGroup.accountId) + ':' + securityGroup.region
+        description: 'Delete Security Group: ' + securityGroup.name
       });
 
       infrastructureCaches.clearCache('securityGroups');

--- a/app/scripts/modules/core/task/tasks.controller.js
+++ b/app/scripts/modules/core/task/tasks.controller.js
@@ -85,6 +85,9 @@ module.exports = angular.module('spinnaker.core.task.controller', [
         controller.sortedTasks = _.filter(joinedLists, function(task) {
           return task.name.toLowerCase().indexOf(normalizedSearch) !== -1 ||
             task.id.toLowerCase().indexOf(normalizedSearch) !== -1 ||
+            (task.getValueFor('credentials') || '').toLowerCase().indexOf(normalizedSearch) !== -1 ||
+            (task.getValueFor('region') || '').toLowerCase().indexOf(normalizedSearch) !== -1 ||
+            (task.getValueFor('regions') || []).join(' ').toLowerCase().indexOf(normalizedSearch) !== -1 ||
             (task.getValueFor('user') || '').toLowerCase().indexOf(normalizedSearch) !== -1;
         });
       }
@@ -165,7 +168,7 @@ module.exports = angular.module('spinnaker.core.task.controller', [
 
     controller.getFirstDeployServerGroupName = function(task) {
       if(task.execution && task.execution.stages) {
-        var stage = findStageWithTaskInExecution(task.execution, ['createCopyLastAsg', 'createDeploy']);
+        var stage = findStageWithTaskInExecution(task.execution, ['createCopyLastAsg', 'createDeploy', 'cloneServerGroup', 'createServerGroup']);
         return _.chain(stage)
           .get('context')
           .get('deploy.server.groups')

--- a/app/scripts/modules/core/task/tasks.html
+++ b/app/scripts/modules/core/task/tasks.html
@@ -91,7 +91,7 @@
                 <div ng-if="tasks.getFirstDeployServerGroupName(task)" class="task-name">
                   <a href><span class="glyphicon glyphicon-none"></span></a>
                   <span ng-if="tasks.getProviderForServerGroupByTask(task)">
-                    Deployed <a ui-sref="home.applications.application.insight.clusters.serverGroup({application: application.name, serverGroup: tasks.getFirstDeployServerGroupName(task), accountId: tasks.getAccountId(task), region: tasks.getRegion(task), provider: tasks.getProviderForServerGroupByTask(task)})" ng-click="$event.stopPropagation()"> {{tasks.getFirstDeployServerGroupName(task)}}</a>
+                    Deployed <a ui-sref="^.insight.clusters.serverGroup({application: application.name, serverGroup: tasks.getFirstDeployServerGroupName(task), accountId: tasks.getAccountId(task), region: tasks.getRegion(task), provider: tasks.getProviderForServerGroupByTask(task)})" ng-click="$event.stopPropagation()"> {{tasks.getFirstDeployServerGroupName(task)}}</a>
                   </span>
 
                   <span ng-if="!tasks.getProviderForServerGroupByTask(task)">
@@ -104,8 +104,8 @@
                 <account-tag account="task.getValueFor('credentials')" pad="both"></account-tag>
               </td>
               <td>
-                <span ng-if="task.getValueFor('region')">({{task.getValueFor('region')}})</span>
-                <span ng-if="!task.getValueFor('region') && task.getValueFor('regions')">({{task.getValueFor('regions').join(', ')}})</span>
+                <span ng-if="task.getValueFor('region')">{{task.getValueFor('region')}}</span>
+                <span ng-if="!task.getValueFor('region') && task.getValueFor('regions')">{{task.getValueFor('regions').join(', ')}}</span>
               </td>
               <td>
                 <task-progress-bar task="task"></task-progress-bar>
@@ -139,7 +139,7 @@
             <tr ng-repeat="step in task.steps | displayableTasks"
                 ng-if="tasks.isExpanded(task.id)"
                 class="task-step">
-              <td colspan="2">
+              <td colspan="4">
                 <status-glyph item="step"></status-glyph>
                 {{step.name | robotToHuman }}
               </td>
@@ -154,17 +154,17 @@
               </td>
             </tr>
             <tr class="task-error-message danger" ng-if="task.isFailed && tasks.isExpanded(task.id)">
-              <td colspan="7">
+              <td colspan="9">
                 <strong>Exception:</strong> {{task.failureMessage || 'No reason provided'}}
               </td>
             </tr>
             <tr ng-if="tasks.isExpanded(task.id) && task.getValueFor('reason')" class="task-reason">
-              <td colspan="7">
+              <td colspan="9">
                 <strong>Reason:</strong> {{task.getValueFor('reason')}}
               </td>
             </tr>
             <tr ng-if="tasks.isExpanded(task.id)" ng-repeat-end>
-              <td colspan="7" class="small text-right">
+              <td colspan="9" class="small text-right">
                 <a href="{{tasksUrl + task.id}}" target="_blank">Source</a> | <a target="_blank" ui-sref=".taskDetails({taskId: task.id})">Permalink</a>
                 <copy-to-clipboard text="{{$state.href('.taskDetails', {taskId: task.id}, {absolute:true} )}}" tool-tip="Copy permalink to clipboard"></copy-to-clipboard>
               </td>


### PR DESCRIPTION
As this whole view is in need of a rewrite, I don't want to spend too much time on it. However...

* removing account/region from delete security group/load balancer tasks (since we now display them in the tasks view as columns)
* adding account/region to the searchable fields
* including `cloneServerGroup` and `createServerGroup` in the list of tasks to look for deployed server groups (we switched over to these tasks almost a year ago)
* fixing column widths