### PR TITLE
(core) get tasks from non-deprecated endpoint

### DIFF
--- a/app/scripts/modules/core/serverGroup/serverGroup.write.service.spec.js
+++ b/app/scripts/modules/core/serverGroup/serverGroup.write.service.spec.js
@@ -38,7 +38,7 @@ describe('serverGroupWriter', function () {
         return true;
       }).respond(200, {ref: '/1'});
 
-      $httpBackend.expectGET(API.baseUrl + '/applications/appName/tasks/1').respond({});
+      $httpBackend.expectGET(API.baseUrl + '/tasks/1').respond({});
 
       serverGroupWriter.cloneServerGroup(command, { name: 'appName', tasks: { refresh: angular.noop } });
 

--- a/app/scripts/modules/core/task/monitor/taskMonitorService.spec.js
+++ b/app/scripts/modules/core/task/monitor/taskMonitorService.spec.js
@@ -50,13 +50,13 @@ describe('Service: taskMonitorService', function () {
 
       $timeout.flush(); // still running first time
 
-      $http.expectGET([API.baseUrl, 'applications', 'deck', 'tasks', 'a'].join('/')).respond(200, { status: 'RUNNING' });
+      $http.expectGET([API.baseUrl, 'tasks', 'a'].join('/')).respond(200, { status: 'RUNNING' });
       $timeout.flush();
       $http.flush();
       expect(monitor.task.isCompleted).toBe(false);
       expect(monitor.application.runningOrchestrations.refresh.calls.count()).toBe(1);
 
-      $http.expectGET([API.baseUrl, 'applications', 'deck', 'tasks', 'a'].join('/')).respond(200, { status: 'SUCCEEDED' });
+      $http.expectGET([API.baseUrl, 'tasks', 'a'].join('/')).respond(200, { status: 'SUCCEEDED' });
       $timeout.flush(); // complete second time
       $http.flush();
 
@@ -104,12 +104,12 @@ describe('Service: taskMonitorService', function () {
 
       $timeout.flush(); // still running first time
 
-      $http.expectGET([API.baseUrl, 'applications', 'deck', 'tasks', 'a'].join('/')).respond(200, { status: 'RUNNING' });
+      $http.expectGET([API.baseUrl, 'tasks', 'a'].join('/')).respond(200, { status: 'RUNNING' });
       $timeout.flush();
       $http.flush();
       expect(monitor.task.isCompleted).toBe(false);
 
-      $http.expectGET([API.baseUrl, 'applications', 'deck', 'tasks', 'a'].join('/')).respond(200, { status: 'TERMINAL' });
+      $http.expectGET([API.baseUrl, 'tasks', 'a'].join('/')).respond(200, { status: 'TERMINAL' });
       $timeout.flush(); // complete second time
       $http.flush();
 

--- a/app/scripts/modules/core/task/task.read.service.js
+++ b/app/scripts/modules/core/task/task.read.service.js
@@ -57,7 +57,7 @@ module.exports = angular
         deferred.reject(task);
       } else {
         task.poller = $timeout(() => {
-          getTask(application, task.id).then((updated) => {
+          getTask(task.id).then((updated) => {
             updateTask(task, updated);
             waitUntilTaskMatches(application, task, closure, failureClosure, interval)
               .then(deferred.resolve, deferred.reject);
@@ -71,8 +71,8 @@ module.exports = angular
       return waitUntilTaskMatches(application, task, (task) => task.isCompleted, (task) => task.isFailed, interval);
     }
 
-    function getTask(applicationName, taskId) {
-      return API.one('applications', applicationName).one('tasks', taskId).get()
+    function getTask(taskId) {
+      return API.one('tasks', taskId).get()
         .then((task) => {
           orchestratedItemTransformer.defineProperties(task);
           if (task.steps && task.steps.length) {

--- a/app/scripts/modules/core/task/task.read.service.spec.js
+++ b/app/scripts/modules/core/task/task.read.service.spec.js
@@ -33,12 +33,12 @@ describe('Service: taskReader', function () {
     }
 
     beforeEach(function () {
-      service.getTask('deck', 1).then((result) => task = result);
+      service.getTask(1).then((result) => task = result);
     });
 
     it('resolves immediately if task already matches', function () {
 
-      $http.whenGET(API.baseUrl + '/applications/deck/tasks/1').respond(200, {
+      $http.whenGET(API.baseUrl + '/tasks/1').respond(200, {
         id: 1,
         foo: 3,
         status: 'SUCCEEDED'
@@ -57,7 +57,7 @@ describe('Service: taskReader', function () {
 
     it('fails immediate if failure closure provided and task matches it', function () {
 
-      $http.whenGET(API.baseUrl + '/applications/deck/tasks/1').respond(200, {
+      $http.whenGET(API.baseUrl + '/tasks/1').respond(200, {
         id: 1,
         foo: 3,
         status: 'SUCCEEDED'
@@ -81,7 +81,7 @@ describe('Service: taskReader', function () {
     });
 
     it('polls task and resolves when it matches', function () {
-      $http.expectGET(API.baseUrl + '/applications/deck/tasks/1').respond(200, { id: 1, status: 'RUNNING' });
+      $http.expectGET(API.baseUrl + '/tasks/1').respond(200, { id: 1, status: 'RUNNING' });
 
       var completed = false,
           failed = false;
@@ -101,13 +101,13 @@ describe('Service: taskReader', function () {
       expect(failed).toBe(false);
 
       // still running
-      $http.expectGET(API.baseUrl + '/applications/deck/tasks/1').respond(200, { id: 1, status: 'RUNNING' });
+      $http.expectGET(API.baseUrl + '/tasks/1').respond(200, { id: 1, status: 'RUNNING' });
       cycle();
       expect(completed).toBe(false);
       expect(failed).toBe(false);
 
       // succeeds
-      $http.expectGET(API.baseUrl + '/applications/deck/tasks/1').respond(200, { id: 1, status: 'SUCCEEDED' });
+      $http.expectGET(API.baseUrl + '/tasks/1').respond(200, { id: 1, status: 'SUCCEEDED' });
       cycle();
       expect(completed).toBe(true);
       expect(failed).toBe(false);
@@ -115,7 +115,7 @@ describe('Service: taskReader', function () {
     });
 
     it('polls task and rejects when it matches failure closure', function () {
-      $http.expectGET(API.baseUrl + '/applications/deck/tasks/1').respond(200, { id: 1, status: 'RUNNING' });
+      $http.expectGET(API.baseUrl + '/tasks/1').respond(200, { id: 1, status: 'RUNNING' });
 
       var completed = false,
           failed = false;
@@ -135,13 +135,13 @@ describe('Service: taskReader', function () {
       expect(failed).toBe(false);
 
       // still running
-      $http.expectGET(API.baseUrl + '/applications/deck/tasks/1').respond(200, { id: 1, status: 'RUNNING' });
+      $http.expectGET(API.baseUrl + '/tasks/1').respond(200, { id: 1, status: 'RUNNING' });
       cycle();
       expect(completed).toBe(false);
       expect(failed).toBe(false);
 
       // succeeds
-      $http.expectGET(API.baseUrl + '/applications/deck/tasks/1').respond(200, { id: 1, status: 'TERMINAL' });
+      $http.expectGET(API.baseUrl + '/tasks/1').respond(200, { id: 1, status: 'TERMINAL' });
       cycle();
       expect(completed).toBe(false);
       expect(failed).toBe(true);
@@ -149,7 +149,7 @@ describe('Service: taskReader', function () {
     });
 
     it('polls task and rejects if task is not returned from getTask call', function () {
-      $http.expectGET(API.baseUrl + '/applications/deck/tasks/1').respond(500, {});
+      $http.expectGET(API.baseUrl + '/tasks/1').respond(500, {});
 
       var completed = false,
           failed = false;
@@ -172,14 +172,14 @@ describe('Service: taskReader', function () {
   describe('task running time', function () {
 
     function execute() {
-      service.getTask('deck', 1).then(function (resolved) { task = resolved; });
+      service.getTask(1).then(function (resolved) { task = resolved; });
 
       $http.flush();
       scope.$digest();
     }
 
     it('uses start time to calculate running time if endTime is zero', function () {
-      $http.whenGET(API.baseUrl + '/applications/deck/tasks/1').respond(200, {
+      $http.whenGET(API.baseUrl + '/tasks/1').respond(200, {
         id: 2,
         status: 'SUCCEEDED',
         startTime: new Date(),
@@ -192,7 +192,7 @@ describe('Service: taskReader', function () {
     });
 
     it('uses start time to calculate running time if endTime is not present', function () {
-      $http.whenGET(API.baseUrl + '/applications/deck/tasks/1').respond(200, {
+      $http.whenGET(API.baseUrl + '/tasks/1').respond(200, {
         id: 2,
         status: 'SUCCEEDED',
         startTime: new Date()
@@ -206,7 +206,7 @@ describe('Service: taskReader', function () {
     it('calculates running time based on start and end times', function () {
       var start = new Date().getTime(),
           end = start + 120 * 1000;
-      $http.whenGET(API.baseUrl + '/applications/deck/tasks/1').respond(200, {
+      $http.whenGET(API.baseUrl + '/tasks/1').respond(200, {
         id: 2,
         status: 'SUCCEEDED',
         startTime: start,
@@ -221,7 +221,7 @@ describe('Service: taskReader', function () {
     it('handles offset between server and client by taking the max value of current time and start time', function () {
       let now = new Date().getTime(),
           offset = 200000;
-      $http.whenGET(API.baseUrl + '/applications/deck/tasks/1').respond(200, {
+      $http.whenGET(API.baseUrl + '/tasks/1').respond(200, {
         id: 2,
         status: 'SUCCEEDED',
         startTime: now + offset

--- a/app/scripts/modules/core/task/task.write.service.js
+++ b/app/scripts/modules/core/task/task.write.service.js
@@ -19,7 +19,7 @@ module.exports = angular
 
     function cancelTask(application, taskId) {
       return getEndpoint(application).one(taskId).one('cancel').put().then(() =>
-        taskReader.getTask(application, taskId).then((task) =>
+        taskReader.getTask(taskId).then((task) =>
           taskReader.waitUntilTaskMatches(application, task, (task) => task.status === 'CANCELED')
         )
       );

--- a/app/scripts/modules/core/task/task.write.service.spec.js
+++ b/app/scripts/modules/core/task/task.write.service.spec.js
@@ -33,7 +33,7 @@ describe('Service: taskWriter', function () {
       let completed = false;
       let taskId = 'abc';
       let cancelUrl = [API.baseUrl, 'applications', 'deck', 'tasks', taskId, 'cancel'].join('/');
-      let checkUrl = [API.baseUrl, 'applications', 'deck', 'tasks', taskId].join('/');
+      let checkUrl = [API.baseUrl, 'tasks', taskId].join('/');
       let application = 'deck';
 
       $httpBackend.expectPUT(cancelUrl).respond(200, []);

--- a/app/scripts/modules/core/task/taskExecutor.js
+++ b/app/scripts/modules/core/task/taskExecutor.js
@@ -34,7 +34,7 @@ module.exports = angular.module('spinnaker.core.taskExecutor', [
           if (owner.tasks && owner.tasks.refresh) {
             owner.tasks.refresh();
           }
-          return taskReader.getTask(owner.name, taskId);
+          return taskReader.getTask(taskId);
         },
         function(response) {
           var error = {


### PR DESCRIPTION
Apparently the `/applications/{app}/tasks/{taskId}` endpoint in Gate was deprecated 20 months ago in favor of `/tasks/{taskId}`.

For @tomaslin 