### PR TITLE
(all) replace indexOf() < 0 with !includes

### DIFF
--- a/app/scripts/modules/amazon/serverGroup/configure/serverGroupCommandBuilder.service.js
+++ b/app/scripts/modules/amazon/serverGroup/configure/serverGroupCommandBuilder.service.js
@@ -203,7 +203,7 @@ module.exports = angular.module('spinnaker.aws.serverGroupCommandBuilder.service
           },
           suspendedProcesses: (serverGroup.asg.suspendedProcesses || [])
             .map((process) => process.processName)
-            .filter((name) => enabledProcesses.indexOf(name) < 0),
+            .filter((name) => !enabledProcesses.includes(name)),
           tags: serverGroup.tags || {},
           useAmiBlockDeviceMappings: applicationAwsSettings.useAmiBlockDeviceMappings || false,
           viewState: {

--- a/app/scripts/modules/core/api/api.service.js
+++ b/app/scripts/modules/core/api/api.service.js
@@ -17,7 +17,7 @@ module.exports = angular
     };
 
     var getData = (results) => {
-      if (results.headers('content-type') && results.headers('content-type').indexOf('application/json') < 0) {
+      if (results.headers('content-type') && !results.headers('content-type').includes('application/json')) {
         authenticationInitializer.reauthenticateUser();
         return $q.reject(results);
       }

--- a/app/scripts/modules/core/cache/cacheInitializer.js
+++ b/app/scripts/modules/core/cache/cacheInitializer.js
@@ -40,7 +40,7 @@ module.exports = angular.module('spinnaker.core.cache.initializer', [
       });
       accountService.listProviders().then((availableProviders) => {
         cloudProviderRegistry.listRegisteredProviders().forEach((provider) => {
-          if (availableProviders.indexOf(provider) < 0) {
+          if (!availableProviders.includes(provider)) {
             return;
           }
           if (serviceDelegate.hasDelegate(provider, 'cache.configurer')) {

--- a/app/scripts/modules/core/cache/deckCacheFactory.js
+++ b/app/scripts/modules/core/cache/deckCacheFactory.js
@@ -63,7 +63,7 @@ module.exports = angular.module('spinnaker.core.cache.deckCacheFactory', [
           if (k.indexOf(settings.gateUrl) > -1) {
             let response = JSON.parse(v);
             if (response.value && Array.isArray(response.value) && response.value.length > 2 && Array.isArray(response.value[2])) {
-              if (response.value[2]['content-type'] && response.value[2]['content-type'].indexOf('application/json') < 0) {
+              if (response.value[2]['content-type'] && !response.value[2]['content-type'].includes('application/json')) {
                 return;
               }
             }

--- a/app/scripts/modules/core/cluster/filter/clusterFilter.service.js
+++ b/app/scripts/modules/core/cluster/filter/clusterFilter.service.js
@@ -158,7 +158,7 @@ module.exports = angular
           let remainingKeys = serverGroups.map(MultiselectModel.makeServerGroupKey);
           let toRemove = [];
           MultiselectModel.serverGroups.forEach((group, index) => {
-            if (remainingKeys.indexOf(group.key) < 0) {
+            if (!remainingKeys.includes(group.key)) {
               toRemove.push(index);
             }
           });

--- a/app/scripts/modules/core/delivery/service/executions.transformer.service.js
+++ b/app/scripts/modules/core/delivery/service/executions.transformer.service.js
@@ -121,7 +121,7 @@ module.exports = angular.module('spinnaker.core.delivery.executionTransformer.se
     function flattenAndFilter(stage) {
       return flattenStages([], stage)
         .filter(function(stage) {
-          return hiddenStageTypes.indexOf(stage.type) < 0 && stage.initializationStage !== true;
+          return !hiddenStageTypes.includes(stage.type) && stage.initializationStage !== true;
         });
     }
 

--- a/app/scripts/modules/core/delivery/status/executionStatus.directive.js
+++ b/app/scripts/modules/core/delivery/status/executionStatus.directive.js
@@ -38,7 +38,7 @@ module.exports = angular
 
     if (this.execution.trigger && this.execution.trigger.parameters) {
       this.parameters = Object.keys(this.execution.trigger.parameters).sort()
-        .filter((paramKey) => this.execution.isStrategy ? strategyExclusions.indexOf(paramKey) < 0 : true)
+        .filter((paramKey) => this.execution.isStrategy ? !strategyExclusions.includes(paramKey) : true)
         .map((paramKey) => {
           return { key: paramKey, value: this.execution.trigger.parameters[paramKey] };
         });

--- a/app/scripts/modules/core/pipeline/config/triggers/trigger.html
+++ b/app/scripts/modules/core/pipeline/config/triggers/trigger.html
@@ -27,7 +27,7 @@
           <div class="trigger-body"></div>
         </div>
       </div>
-      <div class="form-group" ng-if="trigger.type && triggerCtrl.disableAutoTriggering.indexOf(trigger.type) < 0">
+      <div class="form-group" ng-if="trigger.type && !triggerCtrl.disableAutoTriggering.includes(trigger.type)">
         <div class="col-md-8 col-md-offset-1">
           <div class="row">
             <div class="col-md-8 col-md-offset-3 checkbox">

--- a/app/scripts/modules/core/serverGroup/configure/common/basicSettingsMixin.controller.js
+++ b/app/scripts/modules/core/serverGroup/configure/common/basicSettingsMixin.controller.js
@@ -83,7 +83,7 @@ module.exports = angular
     };
 
     let isNotExpressionLanguage = (field) => {
-      return field && field.indexOf('${') < 0;
+      return field && !field.includes('${');
     };
 
   });

--- a/app/scripts/modules/docker/image/dockerImageAndTagSelector.component.js
+++ b/app/scripts/modules/docker/image/dockerImageAndTagSelector.component.js
@@ -30,7 +30,7 @@ module.exports = angular.module('spinnaker.deck.docker.imageAndTagSelector.compo
 
         this.registry = $scope.registryMap[this.account];
         $scope.organizations = $scope.accountMap[this.account] || [];
-        if ($scope.organizations.indexOf(this.organization) < 0) {
+        if (!$scope.organizations.includes(this.organization)) {
           this.organization = null;
         }
         updateRepositoryList();
@@ -42,7 +42,7 @@ module.exports = angular.module('spinnaker.deck.docker.imageAndTagSelector.compo
         }
         let key = `${this.account}/${this.organization || '' }`;
         $scope.repositories = $scope.organizationMap[key] || [];
-        if ($scope.repositories.indexOf(this.repository) < 0) {
+        if (!$scope.repositories.includes(this.repository)) {
           this.repository = null;
         }
         updateTag();
@@ -62,7 +62,7 @@ module.exports = angular.module('spinnaker.deck.docker.imageAndTagSelector.compo
           }
           let key = this.repository;
           $scope.tags = $scope.repositoryMap[key] || [];
-          if ($scope.tags.indexOf(this.tag) < 0) {
+          if (!$scope.tags.includes(this.tag)) {
             this.tag = null;
           }
         };
@@ -84,7 +84,7 @@ module.exports = angular.module('spinnaker.deck.docker.imageAndTagSelector.compo
             let parts = image.repository.split('/');
             parts.pop();
             let org = parts.join('/');
-            if (all.indexOf(org) < 0) {
+            if (!all.includes(org)) {
               map[key] = all.concat(org);
             }
             return map;
@@ -98,7 +98,7 @@ module.exports = angular.module('spinnaker.deck.docker.imageAndTagSelector.compo
             parts.pop();
             let key = `${image.account}/${parts.join('/')}`;
             let all = map[key] || [];
-            if (all.indexOf(image.repository) < 0) {
+            if (!all.includes(image.repository)) {
               map[key] = all.concat(image.repository);
             }
             return map;
@@ -113,7 +113,7 @@ module.exports = angular.module('spinnaker.deck.docker.imageAndTagSelector.compo
 
             let key = image.repository;
             let all = map[key] || [];
-            if (all.indexOf(image.tag) < 0) {
+            if (!all.includes(image.tag)) {
               map[key] = all.concat(image.tag);
             }
 

--- a/app/scripts/modules/netflix/migrator/pipeline/pipeline.migrator.directive.js
+++ b/app/scripts/modules/netflix/migrator/pipeline/pipeline.migrator.directive.js
@@ -165,7 +165,7 @@ module.exports = angular
     this.accountChanged = () => {
       let subnets = this.accountMapping.map(m => m.target).map(a => this.subnetsByAccount[a]);
       this.subnets = _.intersection.apply(null, subnets);
-      if (this.subnets.indexOf(this.targetSubnet) < 0) {
+      if (!this.subnets.includes(this.targetSubnet)) {
         this.targetSubnet = this.subnets[0];
       }
     };

--- a/app/scripts/modules/netflix/migrator/serverGroup/serverGroup.migrator.directive.js
+++ b/app/scripts/modules/netflix/migrator/serverGroup/serverGroup.migrator.directive.js
@@ -121,7 +121,7 @@ module.exports = angular
 
     this.filterKeyPairs = () => {
       this.filteredKeyPairs = (this.keyPairs || []).filter(kp => kp.account === this.target.credentials).map(kp => kp.name);
-      if (this.filteredKeyPairs.indexOf(this.target.keyName) < 0) {
+      if (!this.filteredKeyPairs.includes(this.target.keyName)) {
         this.target.keyName = null;
       }
     };

--- a/app/scripts/modules/titus/serverGroup/configure/serverGroupBasicSettingsSelector.directive.js
+++ b/app/scripts/modules/titus/serverGroup/configure/serverGroupBasicSettingsSelector.directive.js
@@ -35,7 +35,7 @@ module.exports = angular.module('spinnaker.serverGroup.configure.titus.basicSett
     };
 
     let isNotExpressionLanguage = (field) => {
-      return field && field.indexOf('${') < 0;
+      return field && !field.includes('${');
     };
 
   });


### PR DESCRIPTION
Newer browsers allow us to use `String.prototype.includes` and `Array.prototype.includes` instead of having to rely on `indexOf` to determine if a substring is present in a string, or an item is present in an array.

There are going to be several of these pull requests, each taking a different variant of `indexOf` out of the codebase ( `> -1`, `!== -1`, `=== -1`). I'm breaking them up so they're easier to review.

cc @lwander @duftler @danielpeach @zanthrash @icfantv 