### PR TITLE
Allow a user to deploy w/ only an ami id (backing image may not be in…

### DIFF
--- a/app/scripts/modules/amazon/instance/awsInstanceType.service.js
+++ b/app/scripts/modules/amazon/instance/awsInstanceType.service.js
@@ -241,6 +241,10 @@ module.exports = angular.module('spinnaker.aws.instanceType.service', [
 
     function filterInstanceTypes(instanceTypes, virtualizationType, vpcOnly) {
       return instanceTypes.filter((instanceType) => {
+        if (virtualizationType === '*') {
+          // show all instance types
+          return true;
+        }
         let [family] = instanceType.split('.');
         if (!vpcOnly && families.vpcOnly.indexOf(family) > -1) {
           return false;

--- a/app/scripts/modules/amazon/serverGroup/configure/wizard/location/ServerGroupBasicSettings.controller.js
+++ b/app/scripts/modules/amazon/serverGroup/configure/wizard/location/ServerGroupBasicSettings.controller.js
@@ -29,7 +29,24 @@ module.exports = angular.module('spinnaker.serverGroup.configure.aws.basicSettin
           q: q,
           region: $scope.command.region
         })
-      );
+      ).map(function (result) {
+        if (result.length === 0 && q.startsWith('ami-') && q.length === 12) {
+          // allow 'advanced' users to continue with just an ami id (backing image may not have been indexed yet)
+          let record = {
+            imageName: q,
+            amis: {},
+            attributes: {
+              virtualizationType: '*',
+            }
+          };
+
+          // trust that the specific image exists in the selected region
+          record.amis[$scope.command.region] = [q];
+          result = [record];
+        }
+
+        return result;
+      });
     }
 
     var imageSearchResultsStream = new Subject();


### PR DESCRIPTION
…dexed yet)

Probably an "advanced" feature but common enough that we should support it.

- All instance types are available (cannot filter w/o virtualization type)