### PR TITLE
(titus) allow port entry via number list

### DIFF
--- a/app/scripts/modules/core/forms/forms.module.js
+++ b/app/scripts/modules/core/forms/forms.module.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import numberListModule from './numberList/numberList.component';
+
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.forms', [
@@ -9,4 +11,5 @@ module.exports = angular.module('spinnaker.core.forms', [
   require('./ignoreEmptyDelete.directive.js'),
   require('./buttonBusyIndicator/buttonBusyIndicator.directive.js'),
   require('./mapEditor/mapEditor.component.js'),
+  numberListModule,
 ]);

--- a/app/scripts/modules/core/forms/numberList/numberList.component.less
+++ b/app/scripts/modules/core/forms/numberList/numberList.component.less
@@ -1,0 +1,31 @@
+number-list {
+  .row-number {
+    margin-bottom: 5px;
+    button {
+      display: inline-block;
+    }
+  }
+  [type="number"], [type="text"], .add-new {
+    display: inline-block;
+    width: calc(~"100% - 75px");
+  }
+  .add-new {
+    padding: 1px 5px;
+    margin-bottom: 5px;
+    margin-right: 10px;
+  }
+  .btn-group-spel {
+    display: inline-block;
+    position: absolute;
+    right: 0;
+    top: 5px;
+  }
+}
+
+.no-spel {
+  number-list {
+    .btn-group-spel {
+      display: none;
+    }
+  }
+}

--- a/app/scripts/modules/core/forms/numberList/numberList.component.spec.ts
+++ b/app/scripts/modules/core/forms/numberList/numberList.component.spec.ts
@@ -1,0 +1,116 @@
+import listModule from './numberList.component';
+import {NumberListConstraints} from './numberList.component';
+
+describe('Component: numberList', () => {
+
+  var $compile: ng.ICompileService,
+      model: number[],
+      stringModel: string,
+      $scope: ng.IScope,
+      elem: any,
+      constraints: NumberListConstraints,
+      onChange: () => any;
+
+  beforeEach(angular.mock.module(listModule));
+
+  beforeEach(angular.mock.inject((_$compile_: ng.ICompileService, $rootScope: ng.IScope) => {
+    $compile = _$compile_;
+    $scope = $rootScope.$new();
+  }));
+
+  let initialize = (startModel: number[]) => {
+    model = startModel;
+    $scope['data'] = {
+      model: startModel,
+      constraints: constraints,
+      onChange: onChange,
+    };
+    if (stringModel) {
+      $scope['data'].model = stringModel;
+    }
+
+    let dom = `<number-list model="data.model" constraints="data.constraints" on-change="data.onChange()"></number-list>`;
+    elem = $compile(dom)($scope);
+    $scope.$digest();
+  };
+
+  describe('initialization', () => {
+    it('initializes with an empty number input on an empty list, but does not add empty entry to model', () => {
+      initialize([]);
+      expect(elem.find('input[type="number"]').size()).toBe(1);
+      expect(model.length).toBe(0);
+    });
+
+    it('initializes with existing numbers', () => {
+      initialize([1, 4]);
+      expect(elem.find('input[type="number"]').size()).toBe(2);
+      expect(elem.find('input[type="number"]')[0].value).toBe('1');
+      expect(elem.find('input[type="number"]')[1].value).toBe('4');
+      expect(model.length).toBe(2);
+    });
+
+    it('does not show delete button on first entry', () => {
+      initialize([]);
+      expect(elem.find('.glyphicon-trash').size()).toBe(0);
+    });
+  });
+
+  describe('model synchronization', () => {
+    it('does not add invalid entry to model', () => {
+      initialize([]);
+      elem.find('input[type="number"]').val('invalid').change();
+      elem.find('input[type="number"]').change();
+      $scope.$digest();
+      expect(model).toEqual([]);
+
+      elem.find('input[type="number"]').val('3').change();
+      elem.find('input[type="number"]').change();
+      $scope.$digest();
+      expect(model).toEqual([3]);
+    });
+
+    it('removes an entry when remove button clicked', () => {
+      initialize([1, 2]);
+      elem.find('.glyphicon-trash').click();
+      $scope.$digest();
+      expect(model).toEqual([1]);
+    });
+
+    it('does not add empty entry to model when add button is clicked', () => {
+      initialize([]);
+      elem.find('.add-new').click();
+      $scope.$digest();
+      expect(elem.find('input[type="number"]').size()).toBe(2);
+      expect(model).toEqual([]);
+    });
+
+    it('calls onChange event if present', () => {
+      let onChangeCalled: boolean = false;
+      onChange = () => { onChangeCalled = true; };
+      initialize([1]);
+      elem.find('input[type="number"]').val('2').change();
+      $scope.$digest();
+      expect(onChangeCalled).toBe(true);
+    });
+  });
+
+  describe('validation', () => {
+    it('marks invalid fields', () => {
+      constraints = {
+        min: 4,
+        max: 10
+      };
+      initialize([1, 5, 50]);
+      expect(elem.find('.ng-invalid').size()).toBe(2);
+    });
+  });
+
+  describe('spEl handling', () => {
+    it('shows a text field instead of number fields when spel is detected', () => {
+      stringModel = '${parameters.ports}';
+      initialize([]);
+      expect(elem.find('input[type="number"]').size()).toBe(0);
+      expect(elem.find('input[type="text"]').size()).toBe(1);
+    });
+  });
+});

--- a/app/scripts/modules/core/forms/numberList/numberList.component.ts
+++ b/app/scripts/modules/core/forms/numberList/numberList.component.ts
@@ -1,0 +1,148 @@
+import {module} from 'angular';
+import './numberList.component.less';
+
+export interface NumberListConstraints {
+  min: number;
+  max: number;
+}
+
+export class NumberListController implements ng.IComponentController {
+  public model: number[] | string;
+  public constraints: NumberListConstraints;
+  public label: string;
+  public backingModel: number[];
+  public parameterized: boolean;
+  public onChange: () => any;
+
+  public synchronize(): void {
+    let model: number[] | string = this.model; // typescript union type woes
+    if (model instanceof Array) {
+      (<number[]> model).length = 0;
+      this.backingModel.forEach(num => {
+        if (num !== null) {
+          (<number[]> model).push(num);
+        }
+      });
+      model.sort((a, b) => a - b);
+    }
+    if (this.onChange) {
+      this.onChange();
+    }
+  }
+
+  public addNumber(): void {
+    if (typeof this.model === 'string') {
+      return;
+    }
+    this.backingModel.push(null);
+    this.synchronize();
+  }
+
+  public remove(index: number): void {
+    if (typeof this.model === 'string') {
+      return;
+    }
+    if (this.backingModel.length > index) {
+      this.backingModel.splice(index, 1);
+      this.synchronize();
+    }
+  }
+
+  public toggleParameterization(enable: boolean): void {
+    if (enable === this.parameterized) {
+      return;
+    }
+    if (enable) {
+      this.model = '${}';
+    } else {
+      this.model = [];
+      this.backingModel = [null];
+    }
+    this.parameterized = enable;
+    this.synchronize();
+  }
+
+  public $onInit(): void {
+    this.model = this.model || [];
+    if (typeof this.model === 'string') {
+      this.parameterized = true;
+      return;
+    }
+    this.backingModel = [].concat(this.model);
+    if (!this.model.length) {
+      this.backingModel.push(null);
+    }
+    if (!this.constraints) {
+      this.constraints = {
+        min: Number.NEGATIVE_INFINITY,
+        max: Number.POSITIVE_INFINITY
+      };
+    }
+    if (isNaN(this.constraints.min)) {
+      this.constraints.min = Number.NEGATIVE_INFINITY;
+    }
+    if (isNaN(this.constraints.max)) {
+      this.constraints.max = Number.POSITIVE_INFINITY;
+    }
+    if (!this.label) {
+      this.label = 'Item';
+    }
+  }
+}
+
+class NumberListComponent implements ng.IComponentOptions {
+  public bindings: any = {
+    model: '=',
+    constraints: '<?',
+    label: '@',
+    onChange: '&',
+  };
+
+  public controller: ng.IComponentController = NumberListController;
+  public template: string = `
+    <div ng-if="$ctrl.parameterized">
+      <input type="text" class="form-control input-sm" ng-model="$ctrl.model"/>
+    </div>
+    <div class="btn-group btn-group-xs btn-group-spel" role="group">
+      <button type="button"
+              class="btn btn-default"
+              ng-click="$ctrl.toggleParameterization(false)"
+              ng-class="{active: $ctrl.parameterized}"
+              uib-tooltip="Toggle to enter numbers">
+              Num
+      </button>
+      <button type="button"
+              class="btn btn-default"
+              ng-class="{active: !$ctrl.parameterized}"
+              ng-click="$ctrl.toggleParameterization(true)"
+              uib-tooltip="Toggle to enter expression">
+              $\{…\}
+      </button>
+    </div>
+    <div ng-if="!$ctrl.parameterized" class="row-number" ng-repeat="entry in $ctrl.backingModel track by $index">
+      <input type="number"
+             class="form-control input-sm"
+             ng-model="$ctrl.backingModel[$index]" 
+             ng-min="$ctrl.constraints.min" 
+             ng-max="$ctrl.constraints.max"
+             ng-change="$ctrl.synchronize()"
+             />
+      <button class="btn btn-link btn-sm" ng-click="$ctrl.remove($index)" ng-if="$index > 0"><span class="glyphicon glyphicon-trash"></span></button>
+    </div>
+    <div>
+      <button class="btn btn-xs btn-block add-new"
+              is-visible="!$ctrl.parameterized"
+              ng-click="$ctrl.addNumber()">
+        <span class="glyphicon glyphicon-plus-sign"></span>
+        Add {{$ctrl.label}}
+      </button>
+    </div>
+`;
+}
+
+const moduleName = 'spinnaker.core.forms.numberList';
+
+module(moduleName, [])
+  .component('numberList', new NumberListComponent());
+
+export default moduleName;

--- a/app/scripts/modules/titus/pipeline/stages/runJob/runJobStage.html
+++ b/app/scripts/modules/titus/pipeline/stages/runJob/runJobStage.html
@@ -55,15 +55,13 @@
   <div ng-class="{collapse: stage.showAdvancedOptions !== true, 'collapse.in': stage.showAdvancedOptions === true}">
 
     <stage-config-field label="Allocate IP">
-      <input type="checkbox" class="form-control input-sm" name="allocateIpAddress"
+      <input type="checkbox" class="input-sm" name="allocateIpAddress"
              ng-model="stage.cluster.resources.allocateIpAddress"/>
     </stage-config-field>
 
-    <stage-config-field label="Ports" ng-if="!stage.cluster.resources.allocateIpAddress">
-      <input type="text" class="form-control input-sm" name="cpu" ng-model="stage.cluster.resources.ports"/>
-      (Comma separated)
+    <stage-config-field label="Ports" ng-if="!stage.cluster.resources.allocateIpAddress" field-columns="3">
+      <number-list model="stage.cluster.resources.ports" label="Port" constraints="{min: 1, max: 65535}"></number-list>
     </stage-config-field>
-
     <stage-config-field label="IAM Instance Profile (optional)">
       <input type="text"
              class="form-control input-sm"

--- a/app/scripts/modules/titus/serverGroup/configure/wizard/resources.html
+++ b/app/scripts/modules/titus/serverGroup/configure/wizard/resources.html
@@ -1,4 +1,7 @@
-<form ng-controller="titusInstanceResourcesCtrl" class="container-fluid form-horizontal" name="form" novalidate>
+<form ng-controller="titusInstanceResourcesCtrl"
+      class="container-fluid form-horizontal"
+      ng-class="{'no-spel': command.viewState.mode !== 'editPipeline'}"
+      name="form" novalidate>
   <div class="modal-body">
     <div class="form-group">
       <div class="col-md-3 sm-label-right"><b>CPU(s)</b></div>
@@ -27,16 +30,13 @@
     <div class="form-group">
       <div class="col-md-3 sm-label-right"><b>Allocate IP?</b></div>
       <div class="col-md-5">
-        <input type="checkbox" class="form-control input-sm" name="allocateIpAddress" ng-model="command.resources.allocateIpAddress" />
+        <input type="checkbox" name="allocateIpAddress" ng-model="command.resources.allocateIpAddress" />
       </div>
     </div>
     <div class="form-group" ng-if="!command.resources.allocateIpAddress">
       <div class="col-md-3 sm-label-right"><b>Ports</b></div>
       <div class="col-md-5">
-        <input type="text" class="form-control input-sm no-spel" name="cpu" ng-model="command.resources.ports" />
-      </div>
-      <div class="col-md-4">
-        (Comma separated)
+        <number-list model="command.resources.ports" label="Port" constraints="{min: 1, max: 65535}"></number-list>
       </div>
     </div>
   </div>

--- a/app/scripts/modules/titus/serverGroup/serverGroup.transformer.js
+++ b/app/scripts/modules/titus/serverGroup/serverGroup.transformer.js
@@ -19,10 +19,6 @@ module.exports = angular
         delete command.source;
       }
       command.account = command.credentials;
-      if (command.resources.ports) {
-        var ports = '' + command.resources.ports;
-        command.resources.ports = ports.split(/\s*,\s*/);
-      }
       if (command.securityGroups) {
         var securityGroups = '' + command.securityGroups;
         command.securityGroups = securityGroups.split(/\s*,\s*/);


### PR DESCRIPTION
Adding a new component to allow entering a list of numbers with validation on min/max.

Supports spEl expressions conditionally based on `no-spel` class presence on parent element.

Tests written against the DOM instead of just the controller to see how that goes with TS. It's not too bad.

Not in love with the position of the spEl toggle so that might change based on feedback.

_`.no-spel` on parent class, invalid number_
<img width="325" alt="screen shot 2016-10-10 at 7 47 35 pm" src="https://cloud.githubusercontent.com/assets/73450/19257216/aaede998-8f22-11e6-9267-699c4ed83032.png">

_invalid/valid number, delete button_
<img width="312" alt="screen shot 2016-10-10 at 7 47 51 pm" src="https://cloud.githubusercontent.com/assets/73450/19257217/aaee6fc6-8f22-11e6-92e2-0bca5d8262d8.png">

_spEl-enabled_
<img width="412" alt="screen shot 2016-10-10 at 8 25 15 pm" src="https://cloud.githubusercontent.com/assets/73450/19257843/bb8f8572-8f27-11e6-8d66-4802993362c0.png">

_numeric, spEl available_
<img width="415" alt="screen shot 2016-10-10 at 8 25 27 pm" src="https://cloud.githubusercontent.com/assets/73450/19257846/c45d5cf6-8f27-11e6-996e-d3567f4b083f.png">
