### PR TITLE
(titus) allow users to pick security groups from select list

### DIFF
--- a/app/scripts/modules/amazon/serverGroup/configure/serverGroupConfiguration.service.js
+++ b/app/scripts/modules/amazon/serverGroup/configure/serverGroupConfiguration.service.js
@@ -87,6 +87,7 @@ module.exports = angular.module('spinnaker.aws.serverGroup.configure.service', [
         backingData.filtered = {};
         backingData.scalingProcesses = autoScalingProcessService.listProcesses();
         command.backingData = backingData;
+        backingData.filtered.securityGroups = getRegionalSecurityGroups(command);
         configureVpcId(command);
         if (command.viewState.disableImageSelection) {
           configureInstanceTypes(command);

--- a/app/scripts/modules/amazon/serverGroup/configure/wizard/securityGroups/securityGroupSelector.directive.html
+++ b/app/scripts/modules/amazon/serverGroup/configure/wizard/securityGroups/securityGroupSelector.directive.html
@@ -1,9 +1,11 @@
 <div class="form-group">
-  <div class="col-md-3 sm-label-right"><b>Security Groups</b></div>
+  <div class="col-md-3 sm-label-right" ng-if="!vm.hideLabel">
+    <b>Security Groups <span ng-if="vm.optional">(optional)</span></b>
+  </div>
   <div class="col-md-9">
-    <ui-select multiple ng-model="vm.command.securityGroups" class="form-control input-sm">
+    <ui-select multiple ng-model="vm.groupsToEdit" class="form-control input-sm">
       <ui-select-match>{{$item.name}} ({{$item.id}})</ui-select-match>
-      <ui-select-choices repeat="securityGroup.id as securityGroup in vm.command.backingData.filtered.securityGroups | anyFieldFilter: {name: $select.search, id: $select.search}">
+      <ui-select-choices repeat="securityGroup.id as securityGroup in vm.availableGroups | anyFieldFilter: {name: $select.search, id: $select.search}">
         <span ng-bind-html="securityGroup.name | highlight: $select.search"></span>
         (<span ng-bind-html="securityGroup.id  | highlight: $select.search"></span>)
       </ui-select-choices>
@@ -12,7 +14,7 @@
 </div>
 
 <div class="form-group small" style="margin-top: 20px">
-  <div class="col-md-9 col-md-offset-3">
+  <div class="col-md-{{vm.hideLabel ? 12 : 9}} col-md-offset-{{vm.hideLabel ? 0 : 3}}">
     <p>
       <span ng-if="vm.refreshing"><span class="small glyphicon glyphicon-refresh glyphicon-spinning"></span></span>
       Security groups

--- a/app/scripts/modules/amazon/serverGroup/configure/wizard/securityGroups/securityGroupSelector.directive.js
+++ b/app/scripts/modules/amazon/serverGroup/configure/wizard/securityGroups/securityGroupSelector.directive.js
@@ -14,6 +14,11 @@ module.exports = angular
       scope: {},
       bindToController: {
         command: '=',
+        optional: '=',
+        availableGroups: '<',
+        hideLabel: '<',
+        refresh: '&?',
+        groupsToEdit: '=',
       },
       controllerAs: 'vm',
       controller: 'awsServerGroupSecurityGroupsSelectorCtrl',
@@ -25,8 +30,12 @@ module.exports = angular
 
     this.refreshSecurityGroups = () => {
       this.refreshing = true;
-      awsServerGroupConfigurationService.refreshSecurityGroups(this.command).then(() => {
-        this.refreshing = false;
-      });
+      if (this.refresh) {
+        this.refresh().then(() => this.refreshing = false);
+      } else {
+        awsServerGroupConfigurationService.refreshSecurityGroups(this.command).then(() => {
+          this.refreshing = false;
+        });
+      }
     };
   });

--- a/app/scripts/modules/amazon/serverGroup/configure/wizard/securityGroups/securityGroups.html
+++ b/app/scripts/modules/amazon/serverGroup/configure/wizard/securityGroups/securityGroups.html
@@ -1,4 +1,7 @@
-<div class="row">
+<div class="row" ng-if="state.loaded">
   <server-group-security-groups-removed command="command"></server-group-security-groups-removed>
-  <server-group-security-group-selector command="command"></server-group-security-group-selector>
+  <server-group-security-group-selector command="command"
+                                        groups-to-edit="command.securityGroups"
+                                        available-groups="command.backingData.filtered.securityGroups"></server-group-security-group-selector>
+
 </div>

--- a/app/scripts/modules/amazon/serverGroup/configure/wizard/securityGroups/securityGroupsRemoved.directive.html
+++ b/app/scripts/modules/amazon/serverGroup/configure/wizard/securityGroups/securityGroupsRemoved.directive.html
@@ -1,10 +1,11 @@
-<div class="col-md-12" ng-if="vm.command.viewState.dirty.securityGroups">
+<div class="col-md-12" ng-if="vm.command.viewState.dirty.securityGroups || vm.removed.length">
   <div class="alert alert-warning">
     <p><span class="glyphicon glyphicon-warning-sign"></span>
       The following security groups could not be found in the selected account/region/VPC and were removed:
     </p>
     <ul>
       <li ng-repeat="securityGroup in vm.command.viewState.dirty.securityGroups">{{securityGroup}}</li>
+      <li ng-repeat="securityGroup in vm.removed">{{securityGroup}}</li>
     </ul>
     <p class="text-right">
       <a class="btn btn-sm btn-default dirty-flag-dismiss" href ng-click="vm.acknowledgeSecurityGroupRemoval()">Okay</a>

--- a/app/scripts/modules/amazon/serverGroup/configure/wizard/securityGroups/securityGroupsRemoved.directive.js
+++ b/app/scripts/modules/amazon/serverGroup/configure/wizard/securityGroups/securityGroupsRemoved.directive.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import {has} from 'lodash';
+
 let angular = require('angular');
 
 module.exports = angular
@@ -12,12 +14,18 @@ module.exports = angular
       scope: {},
       bindToController: {
         command: '=',
+        removed: '=',
       },
       controllerAs: 'vm',
       controller: 'awsServerGroupSecurityGroupsRemovedCtrl',
     };
   }).controller('awsServerGroupSecurityGroupsRemovedCtrl', function () {
     this.acknowledgeSecurityGroupRemoval = () => {
-      this.command.viewState.dirty.securityGroups = null;
+      if (has(this.command, 'viewState.dirty')) {
+        this.command.viewState.dirty.securityGroups = null;
+      }
+      if (this.removed && this.removed.length) {
+        this.removed.length = 0;
+      }
     };
   });

--- a/app/scripts/modules/core/domain/ICredentials.ts
+++ b/app/scripts/modules/core/domain/ICredentials.ts
@@ -1,0 +1,6 @@
+export interface ICredentials {
+  name: string;
+  environment: string;
+  accountType: string;
+  cloudProvider: string;
+}

--- a/app/scripts/modules/core/domain/ISecurityGroup.ts
+++ b/app/scripts/modules/core/domain/ISecurityGroup.ts
@@ -1,0 +1,5 @@
+export interface ISecurityGroup {
+  name: string;
+  id: string;
+  vpcId: string;
+}

--- a/app/scripts/modules/core/domain/IVpc.ts
+++ b/app/scripts/modules/core/domain/IVpc.ts
@@ -1,0 +1,7 @@
+export interface IVpc {
+  account: string;
+  id: string;
+  name: string;
+  region: string;
+  cloudProvider: string;
+}

--- a/app/scripts/modules/core/domain/index.ts
+++ b/app/scripts/modules/core/domain/index.ts
@@ -7,3 +7,6 @@ export * from './loadBalancer';
 export * from './serverGroupp';
 export * from './health';
 export * from './instanceCounts';
+export * from './ISecurityGroup';
+export * from './ICredentials';
+export * from './IVpc';

--- a/app/scripts/modules/core/modal/wizard/v2wizardPage.component.ts
+++ b/app/scripts/modules/core/modal/wizard/v2wizardPage.component.ts
@@ -86,7 +86,7 @@ export class WizardPageController implements ng.IComponentController {
 
     this.state = {
       rendered: this.render,
-      done: this.done,
+      done: this.done || !this.mandatory,
       dirty: false,
       required: this.mandatory,
       markCompleteOnView: this.markCompleteOnView

--- a/app/scripts/modules/netflix/serverGroup/wizard/securityGroups/awsServerGroupSecurityGroups.html
+++ b/app/scripts/modules/netflix/serverGroup/wizard/securityGroups/awsServerGroupSecurityGroups.html
@@ -1,5 +1,7 @@
-<div class="row">
+<div class="row" ng-if="state.loaded">
     <server-group-security-groups-removed command="command"></server-group-security-groups-removed>
     <netflix-security-group-diff command="command"></netflix-security-group-diff>
-    <server-group-security-group-selector command="command"></server-group-security-group-selector>
+    <server-group-security-group-selector command="command"
+                                          groups-to-edit="command.securityGroups"
+                                          available-groups="command.backingData.filtered.securityGroups"></server-group-security-group-selector>
 </div>

--- a/app/scripts/modules/titus/domain/ITitusCredentials.ts
+++ b/app/scripts/modules/titus/domain/ITitusCredentials.ts
@@ -1,0 +1,6 @@
+import {ICredentials} from 'core/domain/ICredentials';
+
+export interface ITitusCredentials extends ICredentials {
+  awsAccount: string;
+  awsVpc: string;
+}

--- a/app/scripts/modules/titus/domain/index.ts
+++ b/app/scripts/modules/titus/domain/index.ts
@@ -1,0 +1,1 @@
+export * from './ITitusCredentials';

--- a/app/scripts/modules/titus/pipeline/stages/runJob/runJobStage.html
+++ b/app/scripts/modules/titus/pipeline/stages/runJob/runJobStage.html
@@ -1,6 +1,7 @@
 <div ng-controller="titusRunJobStageCtrl as runJobCtrl" class="form-horizontal">
   <stage-config-field label="Account">
     <account-select-field component="stage" field="credentials" accounts="backingData.credentials"
+                          on-change="runJobCtrl.accountChanged()"
                           provider="'titus'"></account-select-field>
   </stage-config-field>
 
@@ -11,6 +12,7 @@
                            field="region"
                            account="stage.credentials"
                            regions="regions"
+                           on-change="runJobCtrl.regionChanged()"
                            provider="'titus'"></region-select-field>
     </div>
   </div>
@@ -69,8 +71,15 @@
     </stage-config-field>
 
     <stage-config-field label="Security Groups">
-      <input type="text" class="form-control input-sm" name="cpu" ng-model="stage.cluster.securityGroups"/>
-      (Comma separated list of ids)
+      <div ng-if="!stage.credentials || !stage.cluster.region">Select an account and region</div>
+      <titus-security-group-picker ng-if="runJobCtrl.loaded && stage.credentials && stage.cluster.region"
+                                   command="stage"
+                                   hide-label="true"
+                                   groups-to-edit="stage.cluster.securityGroups"
+                                   removed-groups="runJobCtrl.removedGroups"
+                                   groups-removed="runJobCtrl.groupsRemovedStream"
+                                   account-changed="runJobCtrl.accountChangedStream"
+                                   region-changed="runJobCtrl.regionChangedStream"></titus-security-group-picker></titus-security-group-picker>
     </stage-config-field>
 
     <stage-config-field label="Environment (optional)">

--- a/app/scripts/modules/titus/securityGroup/securityGroup.read.service.js
+++ b/app/scripts/modules/titus/securityGroup/securityGroup.read.service.js
@@ -7,7 +7,8 @@ module.exports = angular.module('spinnaker.titus.securityGroup.reader', [
   .factory('titusSecurityGroupReader', function () {
 
     function resolveIndexedSecurityGroup(indexedSecurityGroups, container, securityGroupId) {
-      let account = container.account.replace('titus', '').replace('vpc', '');
+      // TODO: this is bad, but this method is not async and making it async is going to be non-trivial
+      let account = container.account.replace('titus', '').replace('vpc', '').replace('dev', 'test');
       return indexedSecurityGroups[account][container.region][securityGroupId];
     }
 

--- a/app/scripts/modules/titus/securityGroup/securityGroupPicker.component.ts
+++ b/app/scripts/modules/titus/securityGroup/securityGroupPicker.component.ts
@@ -1,0 +1,152 @@
+import {module} from 'angular';
+import * as _ from 'lodash';
+import {Subject, Subscription} from 'rxjs';
+
+import {ITitusCredentials} from '../domain';
+import {ISecurityGroup, IVpc} from 'core/domain';
+
+class SecurityGroupPickerController implements ng.IComponentController {
+  public securityGroups: any;
+  public availableGroups: ISecurityGroup[];
+  public credentials: ITitusCredentials[];
+  public command: any;
+  public groupsToEdit: string[];
+  public removedGroups: string[];
+  public availableSecurityGroups: any[];
+  public accountChanged: Subject<void>;
+  public regionChanged: Subject<void>;
+  public groupsRemoved: Subject<string[]>;
+  public hideLabel: boolean;
+  public loaded: boolean = false;
+  private vpcs: IVpc[];
+  private subscriptions: Subscription[];
+
+  static get $inject(): string[] { return ['$q', 'securityGroupReader', 'accountService', 'cacheInitializer', 'vpcReader']; }
+
+  public constructor(private $q: ng.IQService, private securityGroupReader: any, private accountService: any,
+                     private cacheInitializer: any, private vpcReader: any) {}
+
+  public $onInit(): void {
+    let credentialLoader: ng.IPromise<void> = this.accountService.getCredentialsKeyedByAccount('titus').then((credentials: ITitusCredentials[]) => {
+      this.credentials = credentials;
+    });
+    let groupLoader: ng.IPromise<void> = this.securityGroupReader.getAllSecurityGroups().then((groups: any[]) => {
+      this.securityGroups = groups;
+    });
+    let vpcLoader: ng.IPromise<void> = this.vpcReader.listVpcs().then((vpcs: IVpc[]) => this.vpcs = vpcs);
+    this.$q.all([credentialLoader, groupLoader, vpcLoader]).then(() => this.configureSecurityGroupOptions());
+    this.subscriptions = [
+      this.accountChanged.subscribe(() => this.configureSecurityGroupOptions()),
+      this.regionChanged.subscribe(() => this.configureSecurityGroupOptions())
+    ];
+  }
+
+  public $onDestroy(): void {
+    this.subscriptions.forEach(s => s.unsubscribe());
+  }
+
+  private getCredentials(): ITitusCredentials {
+    return this.credentials[this.command.credentials];
+  }
+
+  private getAwsAccount(): string {
+    return this.getCredentials().awsAccount;
+  }
+
+  private getRegion(): string {
+    return this.command.region || (this.command.cluster ? this.command.cluster.region : null);
+  }
+
+  private getVpcId(): string {
+    let credentials = this.getCredentials();
+    let match = this.vpcs.find(vpc =>
+      vpc.name === credentials.awsVpc
+      && vpc.account === credentials.awsAccount
+      && vpc.region === this.getRegion()
+      && vpc.cloudProvider === 'aws'
+    );
+    return match ? match.id : null;
+  }
+
+  private getRegionalSecurityGroups(): ISecurityGroup[] {
+    let newSecurityGroups: any = this.securityGroups[this.getAwsAccount()] || { aws: {}};
+    return _.chain<ISecurityGroup>(newSecurityGroups.aws[this.getRegion()])
+      .filter({vpcId: this.getVpcId()})
+      .sortBy('name')
+      .value();
+  }
+
+  public refreshSecurityGroups(skipCommandReconfiguration: boolean): void {
+    return this.cacheInitializer.refreshCache('securityGroups').then(() => {
+      return this.securityGroupReader.getAllSecurityGroups().then((securityGroups: any[]) => {
+        this.securityGroups = securityGroups;
+        if (!skipCommandReconfiguration) {
+          this.configureSecurityGroupOptions();
+        }
+      });
+    });
+  }
+
+  private configureSecurityGroupOptions(): void {
+    let currentOptions = this.availableGroups;
+    let newRegionalSecurityGroups = this.getRegionalSecurityGroups();
+    if (currentOptions && this.groupsToEdit) {
+      // not initializing - we are actually changing groups
+      let currentGroupNames: string[] = this.groupsToEdit.map((groupId: string) => {
+        let match = currentOptions.find(o => o.id === groupId);
+        return match ? match.name : groupId;
+      });
+
+      let matchedGroups: ISecurityGroup[] = this.groupsToEdit.map((groupId: string) => {
+        let securityGroup: any = currentOptions.find(o => o.id === groupId || o.name === groupId);
+        return securityGroup ? securityGroup.name : null;
+      }).map((groupName: string) => newRegionalSecurityGroups.find(g => g.name === groupName)).filter((group: any) => group);
+
+      let matchedGroupNames: string[] = matchedGroups.map(g => g.name);
+      let removed: string[] = _.xor(currentGroupNames, matchedGroupNames);
+      this.groupsToEdit = matchedGroups.map(g => g.id);
+      if (removed.length) {
+        this.removedGroups.length = 0;
+        this.removedGroups.push(...removed);
+        this.groupsRemoved.next(removed);
+      }
+    }
+    this.availableGroups = newRegionalSecurityGroups;
+    this.loaded = true;
+  }
+
+}
+
+class SecurityGroupPickerComponent implements ng.IComponentOptions {
+  public bindings: any = {
+    command: '<',
+    accountChanged: '<',
+    regionChanged: '<',
+    groupsRemoved: '<',
+    removedGroups: '<',
+    groupsToEdit: '=',
+    hideLabel: '<',
+  };
+  public controller: ng.IComponentController = SecurityGroupPickerController;
+  public template: string = `
+    <div class="clearfix" ng-if="$ctrl.loaded">
+      <server-group-security-groups-removed removed="$ctrl.removedGroups"></server-group-security-groups-removed>
+      <server-group-security-group-selector command="$ctrl.command" hide-label="$ctrl.hideLabel" 
+          groups-to-edit="$ctrl.groupsToEdit"
+          optional="true" refresh="$ctrl.refreshSecurityGroups()" 
+          available-groups="$ctrl.availableGroups"></server-group-security-group-selector>
+    </div>
+`;
+}
+
+const moduleName = 'spinnaker.titus.securityGroup.picker.component';
+
+module(moduleName, [
+  require('core/account/account.service'),
+  require('core/securityGroup/securityGroup.read.service'),
+  require('core/cache/cacheInitializer'),
+  require('amazon/vpc/vpc.read.service'),
+])
+  .component('titusSecurityGroupPicker', new SecurityGroupPickerComponent());
+
+export default moduleName;

--- a/app/scripts/modules/titus/serverGroup/configure/serverGroupBasicSettingsDirective.html
+++ b/app/scripts/modules/titus/serverGroup/configure/serverGroupBasicSettingsDirective.html
@@ -12,6 +12,7 @@
                        field="region"
                        account="command.credentials"
                        regions="command.backingData.filtered.regions"
+                       on-change="command.regionChanged()"
                        provider="'titus'"></region-select-field>
   <!--<titus-zone-select-field label-columns="2" component="command" field="zone" account="command.credentials" zones="command.backingData.filtered.zones"></titus-zone-select-field>-->
   <!--<titus-network-select-field label-columns="2" component="command" field="network" account="command.credentials" networks="command.backingData.filtered.networks"></titus-network-select-field>-->

--- a/app/scripts/modules/titus/serverGroup/configure/wizard/CloneServerGroup.titus.controller.js
+++ b/app/scripts/modules/titus/serverGroup/configure/wizard/CloneServerGroup.titus.controller.js
@@ -1,9 +1,11 @@
 'use strict';
 
 let angular = require('angular');
+import securityGroupPickerModule from '../../../securityGroup/securityGroupPicker.component';
 
 module.exports = angular.module('spinnaker.serverGroup.configure.titus.cloneServerGroup', [
   require('angular-ui-router'),
+  securityGroupPickerModule,
 ])
   .controller('titusCloneServerGroupCtrl', function($scope, $uibModalInstance, $q, $state,
                                                   serverGroupWriter, v2modalWizardService, taskMonitorService,
@@ -14,6 +16,7 @@ module.exports = angular.module('spinnaker.serverGroup.configure.titus.cloneServ
       basicSettings: require('./basicSettings.html'),
       resources: require('./resources.html'),
       capacity: require('./capacity.html'),
+      securityGroups: require('./securityGroups.html'),
       parameters: require('./parameters.html'),
     };
 
@@ -68,9 +71,12 @@ module.exports = angular.module('spinnaker.serverGroup.configure.titus.cloneServ
       onTaskComplete: onTaskComplete,
     });
 
+    let securityGroupsRemoved = () => v2modalWizardService.markDirty('securityGroups');
+
     function configureCommand() {
       titusServerGroupConfigurationService.configureCommand(serverGroupCommand).then(function () {
         $scope.state.loaded = true;
+        serverGroupCommand.viewState.groupsRemovedStream.subscribe(securityGroupsRemoved);
       });
     }
 

--- a/app/scripts/modules/titus/serverGroup/configure/wizard/parameters.html
+++ b/app/scripts/modules/titus/serverGroup/configure/wizard/parameters.html
@@ -7,15 +7,6 @@
                                    ng-model="command.iamProfile"/></div>
     </div>
     <div class="form-group">
-      <div class="col-md-5 sm-label-right"><b>Security Groups (optional)</b></div>
-      <div class="col-md-5">
-        <input type="text" class="form-control input-sm no-spel" name="cpu" ng-model="command.securityGroups" />
-      </div>
-      <div class="col-md-offset-5 col-md-5">
-        (Comma separated list of ids)
-      </div>
-    </div>
-    <div class="form-group">
       <div class="col-md-5 sm-label-right"><b>Soft Constraints(optional)</b></div>
       <div class="col-md-5">
         <input type="text" class="form-control input-sm no-spel" name="cpu" ng-model="command.softConstraints" />

--- a/app/scripts/modules/titus/serverGroup/configure/wizard/securityGroups.html
+++ b/app/scripts/modules/titus/serverGroup/configure/wizard/securityGroups.html
@@ -1,0 +1,7 @@
+<titus-security-group-picker ng-if="state.loaded"
+                             command="command"
+                             groups-to-edit="command.securityGroups"
+                             removed-groups="command.viewState.removedGroups"
+                             groups-removed="command.viewState.groupsRemovedStream"
+                             account-changed="command.viewState.accountChangedStream"
+                             region-changed="command.viewState.regionChangedStream"></titus-security-group-picker>

--- a/app/scripts/modules/titus/serverGroup/configure/wizard/serverGroupWizard.html
+++ b/app/scripts/modules/titus/serverGroup/configure/wizard/serverGroupWizard.html
@@ -16,6 +16,9 @@
       <v2-wizard-page key="capacity" label="Capacity">
         <ng-include src="pages.capacity"></ng-include>
       </v2-wizard-page>
+      <v2-wizard-page key="securityGroups" label="Security Groups" mandatory="false">
+        <ng-include src="pages.securityGroups"></ng-include>
+      </v2-wizard-page>
       <v2-wizard-page key="parameters" label="Advanced Settings" mandatory="false">
         <ng-include src="pages.parameters"></ng-include>
       </v2-wizard-page>


### PR DESCRIPTION
A modest refactoring of the existing security group selector from the AWS server group modal, repurposing it to work for the Titus server group modal and the Titus run job stage.

I'm trying to not repeat the mistakes of the past with the server group configuration modals, where changes cascade and it's almost impossible to follow what's going on. Instead, I'm moving the logic into distinct components, then using Observables on the command itself to emit changes. 

I think this is going to be a much better pattern when refactoring. I didn't go all-in on changing the AWS command here, since I'd like to test this for a bit and work out design issues.

Adding some interfaces into the domain modules for VPC, Security Group, and Credentials, named based on the doc @icfantv put out last night. I'm interested in feedback on how I implemented those (and everything else, but that's probably the easiest thing to follow).

@zanthrash @icfantv @tomaslin PTAL