### PR TITLE
Sort AWS instance types by family then class size

### DIFF
--- a/app/scripts/modules/amazon/instance/awsInstanceType.service.js
+++ b/app/scripts/modules/amazon/instance/awsInstanceType.service.js
@@ -214,6 +214,55 @@ module.exports = angular.module('spinnaker.aws.instanceType.service', [
         });
     };
 
+    let instanceClassOrder = ['xlarge', 'large', 'medium', 'small', 'micro', 'nano'];
+
+    function sortTypesByFamilyAndSize(o1, o2) {
+      var type1 = o1.split('.'),
+          type2 = o2.split('.');
+
+      if (type1.length !== 2 || type2.length !== 2) {
+        return 0;
+      }
+
+      let [family1, class1] = type1;
+      let [family2, class2] = type2;
+
+      if (family1 !== family2) {
+        if (family1 > family2) {
+          return 1;
+        } else if (family1 < family2) {
+          return -1;
+        }
+        return 0;
+      }
+
+      let t1Idx = instanceClassOrder.findIndex(el => class1.endsWith(el));
+      let t2Idx = instanceClassOrder.findIndex(el => class2.endsWith(el));
+
+      if (t1Idx === -1 || t2Idx === -1) {
+        return 0;
+      }
+
+      if (t1Idx === 0 && t2Idx === 0) {
+        let size1 = parseInt(class1.replace('xlarge', '')) || 0;
+        let size2 = parseInt(class2.replace('xlarge', '')) || 0;
+
+        if (size2 < size1) {
+          return 1;
+        } else if (size2 > size1) {
+          return -1;
+        }
+        return 0;
+      }
+
+      if (t1Idx > t2Idx) {
+        return -1;
+      } else if (t1Idx < t2Idx) {
+        return 1;
+      }
+      return 0;
+    }
+
     function getAvailableTypesForRegions(availableRegions, selectedRegions) {
       selectedRegions = selectedRegions || [];
       var availableTypes = [];
@@ -230,7 +279,7 @@ module.exports = angular.module('spinnaker.aws.instanceType.service', [
         }
       });
 
-      return availableTypes.sort();
+      return availableTypes.sort(sortTypesByFamilyAndSize);
     }
 
     let families = {

--- a/app/scripts/modules/amazon/instance/awsInstanceType.service.spec.js
+++ b/app/scripts/modules/amazon/instance/awsInstanceType.service.spec.js
@@ -39,6 +39,16 @@ describe('Service: InstanceType', function () {
       {account: 'test', region: 'us-west-2', name: 'm2.xlarge', availabilityZone: 'us-west-2b'},
       {account: 'test', region: 'eu-west-1', name: 'hs1.8xlarge', availabilityZone: 'eu-west-1c'},
       {account: 'test', region: 'eu-west-1', name: 'm2.xlarge', availabilityZone: 'eu-west-1c'},
+      {account: 'test', region: 'us-east-1', name: 'm4.2xlarge', availabilityZone: 'us-east-1c'},
+      {account: 'test', region: 'us-east-1', name: 't2.nano', availabilityZone: 'us-east-1c'},
+      {account: 'test', region: 'us-east-1', name: 't2.micro', availabilityZone: 'us-east-1c'},
+      {account: 'test', region: 'us-east-1', name: 'm4.xlarge', availabilityZone: 'us-east-1c'},
+      {account: 'test', region: 'us-east-1', name: 'm4.4xlarge', availabilityZone: 'us-east-1c'},
+      {account: 'test', region: 'us-east-1', name: 't2.medium', availabilityZone: 'us-east-1c'},
+      {account: 'test', region: 'us-east-1', name: 'm4.large', availabilityZone: 'us-east-1c'},
+      {account: 'test', region: 'us-east-1', name: 'm4.16xlarge', availabilityZone: 'us-east-1c'},
+      {account: 'test', region: 'us-east-1', name: 'm4.10xlarge', availabilityZone: 'us-east-1c'},
+      {account: 'test', region: 'us-east-1', name: 't2.loltiny', availabilityZone: 'us-east-1c'},
     ];
 
     infrastructureCaches.createCache('instanceTypes', {});
@@ -120,6 +130,31 @@ describe('Service: InstanceType', function () {
       expect(service.filterInstanceTypes(types, 'hvm', false)).toEqual(['c3.a']);
       expect(service.filterInstanceTypes(types, 'paravirtual', true)).toEqual(['c3.a', 'c1.a']);
       expect(service.filterInstanceTypes(types, 'paravirtual', false)).toEqual(['c3.a', 'c1.a']);
+    });
+
+    it('sorts instance types by family then class size', function() {
+      this.$httpBackend.expectGET(API.baseUrl + '/instanceTypes').respond(200, this.allTypes);
+
+      var results = null,
+          service = this.awsInstanceTypeService;
+
+      this.awsInstanceTypeService.getAllTypesByRegion().then(function(result) {
+        results = service.getAvailableTypesForRegions(result, ['us-east-1']);
+      });
+
+      this.$httpBackend.flush();
+      expect(results).toEqual([
+        'm4.large',
+        'm4.xlarge',
+        'm4.2xlarge',
+        'm4.4xlarge',
+        'm4.10xlarge',
+        'm4.16xlarge',
+        't2.nano',
+        't2.micro',
+        't2.medium',
+        't2.loltiny'
+      ]);
     });
 
   });


### PR DESCRIPTION
Porting sorting work from clouddriver (spinnaker/clouddriver#1128) into deck since the cache doesn't persist ordering. Whoops.

<img width="428" alt="screen shot 2016-10-12 at 4 33 44 pm" src="https://cloud.githubusercontent.com/assets/108741/19331995/06378ac2-909d-11e6-95c2-231ad661a5dd.png">


PTAL @ajordens @anotherchrisberry 