### PR TITLE
(docker) better behavior for manual execution when trigger is not ful…

### DIFF
--- a/app/scripts/modules/core/pipeline/config/triggers/docker/dockerTrigger.module.js
+++ b/app/scripts/modules/core/pipeline/config/triggers/docker/dockerTrigger.module.js
@@ -18,12 +18,20 @@ module.exports = angular.module('spinnaker.core.pipeline.trigger.docker', [
       templateUrl: require('./dockerTrigger.html'),
       popoverLabelUrl: require('./dockerPopoverLabel.html'),
       manualExecutionHandler: 'dockerTriggerExecutionHandler',
+      validators: [
+        { type: 'requiredField', fieldName: 'account',
+          message: '<strong>Registry</strong> is a required field for Docker Registry triggers.'},
+        { type: 'requiredField', fieldName: 'organization',
+          message: '<strong>Organization</strong> is a required field for Docker Registry triggers.' },
+        { type: 'requiredField', fieldName: 'repository',
+          message: '<strong>Image</strong> is a required field for Docker Registry triggers.'},
+      ],
     });
   })
   .factory('dockerTriggerExecutionHandler', function ($q) {
     return {
       formatLabel: (trigger) => {
-        return $q.when(`(Docker Registry) ${trigger.account}: ${trigger.repository}`);
+        return $q.when(`(Docker Registry) ${trigger.account ? trigger.account + ':' : ''} ${trigger.repository || ''}`);
       },
       selectorTemplate: require('./selectorTemplate.html'),
     };

--- a/app/scripts/modules/core/pipeline/config/triggers/docker/dockerTriggerOptions.directive.html
+++ b/app/scripts/modules/core/pipeline/config/triggers/docker/dockerTriggerOptions.directive.html
@@ -11,8 +11,7 @@
     <ui-select class="form-control input-sm"
                ng-model="vm.viewState.selectedTag"
                on-select="vm.updateSelectedTag($item)"
-               reset-search-input="false"
-               ng-if="vm.tags.length">
+               reset-search-input="false">
       <ui-select-match placeholder="Select...">
         <span>
           <strong>{{$select.selected}}</strong>

--- a/app/scripts/modules/core/pipeline/config/triggers/docker/dockerTriggerOptions.directive.js
+++ b/app/scripts/modules/core/pipeline/config/triggers/docker/dockerTriggerOptions.directive.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import {Observable, Subject} from 'rxjs';
+import _ from 'lodash';
 
 const angular = require('angular');
 
@@ -80,7 +81,14 @@ module.exports = angular
       queryStream.next(formatQuery(query));
     };
 
-    let formatQuery = (query) => `*${this.command.trigger.repository.split('/').pop()}:${query}*`;
+    let formatQuery = (query) => {
+      let repository = _.get(this, 'command.trigger.repository');
+      if (repository) {
+        return `${this.command.trigger.repository.split('/').pop()}:${query}`;
+      } else {
+        return query;
+      }
+    };
 
     $scope.$watch(() => this.command.trigger, initialize);
   });


### PR DESCRIPTION
…ly configured

@lwander @anotherchrisberry 
Current behavior:
If you haven't configured all the fields for your docker triggers properly, the manual trigger modal is filled with nulls and undefineds and spinners for no clear reason.

New behavior:
- Warnings in pipeline config that you haven't configured your docker registry trigger.
- Trigger modal lets you pick and search from all available images (in the case that you haven't specified repository/registry/image)

![trigger_error](https://cloud.githubusercontent.com/assets/13868700/19357391/719b1f34-913f-11e6-8045-f07c24adf938.png)
.

