### PR TITLE
make file-relative package friendly for yarn install

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "int": "protractor protractor.conf.js"
   },
   "devDependencies": {
-    "angular-loader": "./angular-loader",
+    "angular-loader": "file:./angular-loader",
     "angular-mocks": "^1.5.8",
     "angulartics": "^1.1.2",
     "angulartics-google-analytics": "^0.2.0",


### PR DESCRIPTION
We're still a ways out from supporting Yarn (mostly because it doesn't run `postinstall` commands), but this will at least let you run `yarn` against deck to do most of the package installation (still need to run `npm install` after `yarn` task completes).