### PR TITLE
(core) message in pipeline config dropdown if no pipelines exist

### DIFF
--- a/app/scripts/modules/core/pipeline/config/createNew.html
+++ b/app/scripts/modules/core/pipeline/config/createNew.html
@@ -10,6 +10,11 @@
       <span class="caret"></span>
     </button>
     <ul class="dropdown-menu" uib-dropdown-menu role="menu">
+        <li class="dropdown-header"
+            style="margin-top:0"
+            ng-if="!(application.pipelineConfigs.data.length || application.strategyConfigs.data.length)">
+          None yet, click <span style="margin-left: 2px;" class="glyphicon glyphicon-plus-sign"></span> New
+        </li>
         <li class="dropdown-header" style="margin-top:0" ng-if="application.pipelineConfigs.data.length">PIPELINES</li>
         <li ng-repeat="pipeline in application.pipelineConfigs.data">
           <a href


### PR DESCRIPTION
@anotherchrisberry 

I think this dropdown is a little confusing for completely new users -- it's unclear that you would be configuring existing pipelines -- so it looks like a bug if there's nothing there.

Before:
![dropdown_bug](https://cloud.githubusercontent.com/assets/13868700/19361506/e5b269d4-9150-11e6-8211-7abbcade4dad.png)

After:
![new_dropdown](https://cloud.githubusercontent.com/assets/13868700/19361515/eb76b104-9150-11e6-9c3c-397515078d87.png)

