### PR TITLE
(core) selectively update existing pipelines when changes detected

### DIFF
--- a/app/scripts/modules/core/delivery/executionGroup/execution/execution.directive.html
+++ b/app/scripts/modules/core/delivery/executionGroup/execution/execution.directive.html
@@ -8,12 +8,10 @@
     <div class="stages" ng-class="{'show-durations': vm.sortFilter.showStageDuration}">
       <div ng-repeat="stage in ::vm.execution.stageSummaries"
            class="clickable stage stage-type-{{::stage.type.toLowerCase()}}
-                  execution-marker execution-marker-{{::stage.status.toLowerCase()}}
+                  execution-marker execution-marker-{{stage.status.toLowerCase()}}
                   {{vm.isActive($index) ? 'active' : ''}} {{stage.isRunning ? 'glowing' : ''}}"
            ng-style="::{width: 100/vm.execution.stageSummaries.length + '%', 'background-color': stage.color}"
            uib-tooltip-template="::stage.labelTemplateUrl"
-           ng-style="{width: 100/vm.execution.stageSummaries.length + '%', 'background-color': stage.color}"
-           uib-tooltip-template="stage.labelTemplateUrl"
            tooltip-title="(Click for details)"
            tooltip-placement="bottom"
            analytics-on="click"

--- a/app/scripts/modules/core/delivery/service/execution.service.spec.js
+++ b/app/scripts/modules/core/delivery/service/execution.service.spec.js
@@ -294,9 +294,50 @@ describe('Service: executionService', function () {
       expect(application.executions.data).toEqual([original, newOne]);
     });
 
-    it('should replace an existing execution if stringVal has changed', function () {
-      let original = {id:1, stringVal: 'ac'};
-      let updated = {id:1, stringVal: 'ab'};
+    it('should update mutated states in an existing execution if stringVal has changed', function () {
+      var originalStages = [
+        { id: 'a', status: 'COMPLETED' },
+        { id: 'b', status: 'RUNNING' },
+        { id: 'c', status: 'RUNNING' },
+        { id: 'd', status: 'NOT_STARTED' }
+      ];
+      var updatedStages = [
+        { id: 'a', status: 'COMPLETED' },
+        { id: 'b', status: 'RUNNING', newField: 'x' },
+        { id: 'c', status: 'RUNNING' },
+        { id: 'd', status: 'NOT_STARTED' }
+      ];
+      let original = {
+        id:1,
+        stringVal: 'ac',
+        stageSummaries: originalStages.slice()
+      };
+      let updated = {
+        id:1,
+        stringVal: 'ab',
+        stageSummaries: updatedStages.slice()
+      };
+      let execs = [updated];
+      application.executions.data = [original];
+
+      executionService.addExecutionsToApplication(application, execs);
+
+      expect(application.executions.data).toEqual([updated]);
+      expect(application.executions.data).not.toBe([updated]);
+      expect(application.executions.data[0].stageSummaries[0]).toBe(originalStages[0]);
+      expect(application.executions.data[0].stageSummaries[0]).toEqual(updatedStages[0]);
+      expect(application.executions.data[0].stageSummaries[1]).toBe(originalStages[1]);
+      expect(application.executions.data[0].stageSummaries[1]).toEqual(updatedStages[1]);
+      expect(application.executions.data[0].stageSummaries[2]).toBe(originalStages[2]);
+      expect(application.executions.data[0].stageSummaries[2]).toEqual(updatedStages[2]);
+      expect(application.executions.data[0].stageSummaries[3]).toBe(originalStages[3]);
+      expect(application.executions.data[0].stageSummaries[3]).toEqual(updatedStages[3]);
+
+    });
+
+    it('should replace an existing execution if status changes', function () {
+      let original = {id:1, stringVal: 'ac', status: 'RUNNING'};
+      let updated = {id:1, stringVal: 'ab', status: 'COMPLETED'};
       let execs = [updated];
       application.executions.data = [original];
 


### PR DESCRIPTION
When a pipeline execution changes, we replace the entire thing in place, which can cause flickering in the UI, as Angular removes the entire DOM tree for that pipeline and re-renders it. This has been the case for a long time, but it's exacerbated on running pipelines, which refresh every second and are more naturally more volatile.

These changes make the replacement more granular to avoid unnecessary re-rendering of huge swaths of the DOM. We'll still replace the entire execution if its status changes (e.g. goes from not started to started, started to completed), but otherwise we'll just replace the _contents_ of any stage that has changed. By leaving the actual stage object in the execution, we get better performance and much less DOM thrashing (at the cost of added complexity).

@zanthrash PTAL