### PR TITLE
(core) added flag for skipping tests for buildDeb

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,9 @@ task webpack(type: NodeTask) {
 task karma(type: NodeTask) {
   script = file('node_modules/karma/bin/karma')
   args = ["start", "--single-run", "--reporters", "progress,jenkins"]
+  if (project.hasProperty('skipTests')) {
+    karma.enabled = false
+  }
 }
 
 task generateVersionFile << {


### PR DESCRIPTION
@ewiseblatt 
It seems safest to do it this way. 

@anotherchrisberry 

