### PR TITLE
(core) make room for long image name in server group label

### DIFF
--- a/app/scripts/modules/core/cluster/rollups.less
+++ b/app/scripts/modules/core/cluster/rollups.less
@@ -366,6 +366,9 @@ load-balancers-tag {
 
   .section-title {
     min-height: 24px;
+    span {
+      font-size: 13px;
+    }
   }
 
   .clickable-row {

--- a/app/scripts/modules/core/serverGroup/serverGroup.directive.html
+++ b/app/scripts/modules/core/serverGroup/serverGroup.directive.html
@@ -13,7 +13,7 @@
          sticky-if="headerIsSticky()">
       <div class="container-fluid no-padding">
         <div class="row">
-          <div class="col-md-8 col-sm-6 section-title">
+          <div class="col-md-{{ viewModel.images ? 9 : 8 }} col-sm-6 section-title">
             <input type="checkbox" ng-if="sortFilter.multiselect"
                    ng-checked="multiselectModel.serverGroupIsSelected(serverGroup)"/>
             <cloud-provider-logo provider="viewModel.serverGroup.type" height="16px" width="16px"></cloud-provider-logo>
@@ -30,7 +30,7 @@
               (No build info)
             </span>
           </div>
-          <div class="col-md-4 col-sm-6 text-right">
+          <div class="col-md-{{ viewModel.images ? 3 : 4 }} col-sm-6 text-right">
             <health-counts container="viewModel.serverGroup.instanceCounts"></health-counts>
             <running-tasks-tag
                 ng-if="viewModel.serverGroup.runningTasks.length || viewModel.serverGroup.executions.length"


### PR DESCRIPTION
@anotherchrisberry let me know what you think about this. If the image has a sha, then the label will always wrap, since there's only room for ~50 characters.

Before:
![before](https://cloud.githubusercontent.com/assets/13868700/19442551/a906c12e-9457-11e6-9266-938f00a0d214.png)

After:
![after](https://cloud.githubusercontent.com/assets/13868700/19442563/ae15ee06-9457-11e6-85d5-30133d036b94.png)


