### PR TITLE
(gce) integrate ilb into GCE lb details view and server group wizard

### DIFF
--- a/app/scripts/modules/google/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/google/instance/details/instance.details.controller.js
@@ -219,16 +219,16 @@ module.exports = angular.module('spinnaker.instance.detail.gce.controller', [
     this.canDeregisterFromLoadBalancer = function() {
       var instance = $scope.instance;
       // TODO(dpeach): remove when it's possible to degister from l7 load balancer.
-      var attachedToElSeven = _.chain(app.loadBalancers.data)
-        .filter(elSevenUtils.isElSeven)
+      var loadBalancerDoesNotSupportDeregister = _.chain(app.loadBalancers.data)
+        .filter((lb) => elSevenUtils.isElSeven(lb) || lb.loadBalancerType === 'INTERNAL')
         .map('name')
-        .intersection(instance.loadBalancers)
+        .intersection(instance.loadBalancers || [])
         .value()
         .length;
 
       if (!instance.loadBalancers ||
           !instance.loadBalancers.length ||
-          attachedToElSeven) {
+          loadBalancerDoesNotSupportDeregister) {
         return false;
       }
       var hasLoadBalancerHealth = instance.health.some(function(health) {

--- a/app/scripts/modules/google/loadBalancer/details/loadBalancerType/loadBalancerType.component.js
+++ b/app/scripts/modules/google/loadBalancer/details/loadBalancerType/loadBalancerType.component.js
@@ -12,16 +12,14 @@ module.exports = angular.module('spinnaker.deck.gce.loadBalancer.loadBalancerTyp
     },
     controller: function () {
       this.type = (function(lb) {
-        if (lb.loadBalancerType === 'NETWORK') {
-          return 'NETWORK';
-        }
-
         if (lb.loadBalancerType === 'HTTP') {
           if (_.isString(lb.certificate)) {
             return 'HTTPS';
           } else {
             return 'HTTP';
           }
+        } else {
+          return lb.loadBalancerType;
         }
       })(this.loadBalancer);
     }

--- a/app/scripts/modules/google/serverGroup/configure/wizard/loadBalancers/loadBalancerSelector.directive.html
+++ b/app/scripts/modules/google/serverGroup/configure/wizard/loadBalancers/loadBalancerSelector.directive.html
@@ -22,7 +22,7 @@
                  class="form-control input-sm">
         <ui-select-match>
           {{$item}}
-          <gce-el-seven-options-generator ng-if="vm.command.backingData.filtered.loadBalancerIndex[$item].backendServices.length"
+          <gce-el-seven-options-generator ng-if="vm.isElSeven(vm.command.backingData.filtered.loadBalancerIndex[$item])"
                                         command="vm.command" load-balancer-name="{{:: $item}}">
           </gce-el-seven-options-generator>
         </ui-select-match>

--- a/app/scripts/modules/google/serverGroup/configure/wizard/loadBalancers/loadBalancerSelector.directive.js
+++ b/app/scripts/modules/google/serverGroup/configure/wizard/loadBalancers/loadBalancerSelector.directive.js
@@ -6,8 +6,9 @@ import _ from 'lodash';
 module.exports = angular
   .module('spinnaker.google.serverGroup.configure.wizard.loadBalancers.selector.directive', [
     require('core/cache/infrastructureCaches.js'),
-    require('../../serverGroupConfiguration.service.js'),
+    require('google/loadBalancer/elSevenUtils.service.js'),
     require('./elSevenOptions/elSevenOptionsGenerator.component.js'),
+    require('../../serverGroupConfiguration.service.js'),
   ])
   .directive('gceServerGroupLoadBalancerSelector', function () {
     return {
@@ -20,7 +21,9 @@ module.exports = angular
       controllerAs: 'vm',
       controller: 'gceServerGroupLoadBalancerSelectorCtrl',
     };
-  }).controller('gceServerGroupLoadBalancerSelectorCtrl', function (gceServerGroupConfigurationService, infrastructureCaches) {
+  }).controller('gceServerGroupLoadBalancerSelectorCtrl', function (elSevenUtils,
+                                                                    gceServerGroupConfigurationService,
+                                                                    infrastructureCaches) {
     this.getLoadBalancerRefreshTime = () => {
       return infrastructureCaches.loadBalancers.getStats().ageMax;
     };
@@ -40,4 +43,6 @@ module.exports = angular
         return angular.isDefined(selected) && _.some(selected, s => index[s].loadBalancerType === 'HTTP');
       }
     };
+
+    this.isElSeven = elSevenUtils.isElSeven;
   });


### PR DESCRIPTION
@jtk54 

For ILBs:
- Load balancer details should render properly
- Server group wizard should render properly

Create & Clone server group seems to work fine with no changes: on the operation description, the ILB name is added to `loadBalancers` and within the `load-balancer-names` metadata. 