### PR TITLE
Openstack:Pipeline :: Replaced Amazon with Openstack in Clone Server Group.

### DIFF
--- a/app/scripts/modules/openstack/pipeline/stages/cloneServerGroup/openstackCloneServerGroupStage.js
+++ b/app/scripts/modules/openstack/pipeline/stages/cloneServerGroup/openstackCloneServerGroupStage.js
@@ -44,7 +44,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.openstack.cloneSe
     stage.cloudProviderType = 'openstack';
 
     if (stage.isNew && $scope.application.attributes.platformHealthOnlyShowOverride && $scope.application.attributes.platformHealthOnly) {
-      stage.interestingHealthProviderNames = ['Amazon'];
+      stage.interestingHealthProviderNames = ['Openstack'];
     }
 
     if (!stage.credentials && $scope.application.defaultCredentials.openstack) {


### PR DESCRIPTION
Type error, Replaced word Amazon with Openstack