### PR TITLE
(google): Fixed L7 type check.

### DIFF
--- a/app/scripts/modules/google/loadBalancer/elSevenUtils.service.js
+++ b/app/scripts/modules/google/loadBalancer/elSevenUtils.service.js
@@ -7,7 +7,7 @@ module.exports = angular.module('spinnaker.deck.gce.elSevenUtils.service', [])
     const region = 'global';
 
     function isElSeven (lb) {
-      return (lb.provider === 'gce' || lb.type === 'gce') && (lb.loadBalancerType === 'HTTP' || lb.region === region);
+      return (lb.provider === 'gce' || lb.type === 'gce') && (lb.loadBalancerType === 'HTTP' && lb.region === region);
     }
 
     function isHttps (lb) {


### PR DESCRIPTION
L7 check was 'if global or HTTP', since SSL LBs are global, this needs modified. @danielpeach please review.