### PR TITLE
(core) better manage instance tooltip lifecycle

### DIFF
--- a/app/scripts/modules/core/instance/instances.directive.js
+++ b/app/scripts/modules/core/instance/instances.directive.js
@@ -16,9 +16,14 @@ module.exports = angular.module('spinnaker.core.instance.instances.directive', [
       },
       link: function (scope, elem) {
         var $state = scope.$parent.$state;
-        let tooltipsApplied = false;
+        let tooltipTargets = [];
 
         var base = elem.parent().inheritedData('$uiView').state;
+
+        let removeTooltips = () => {
+          tooltipTargets.forEach(target => $(target).tooltip('destroy'));
+          tooltipTargets.length = 0;
+        };
 
         function renderInstances() {
           scope.activeInstance = null;
@@ -42,10 +47,7 @@ module.exports = angular.module('spinnaker.core.instance.instances.directive', [
             }).join('') + '</div>';
 
           if (innerHtml !== elem.get(0).innerHTML) {
-            if (tooltipsApplied) {
-              $('[data-toggle="tooltip"]', elem).tooltip('destroy');
-              tooltipsApplied = false;
-            }
+            removeTooltips();
             elem.get(0).innerHTML = innerHtml;
           }
         }
@@ -74,11 +76,9 @@ module.exports = angular.module('spinnaker.core.instance.instances.directive', [
         });
 
         elem.mouseover((event) => {
-          if (tooltipsApplied) {
-            $(event.target, elem).tooltip('show');
-          } else {
-            $(event.target, elem).tooltip({placement: 'top', container: 'body', animation: false, selector: '[data-toggle="tooltip"]'}).tooltip('show');
-            tooltipsApplied = true;
+          if (!tooltipTargets.includes(event.target) && event.target.hasAttribute('data-toggle')) {
+            $(event.target).tooltip({animation: false}).tooltip('show');
+            tooltipTargets.push(event.target);
           }
         });
 
@@ -92,10 +92,7 @@ module.exports = angular.module('spinnaker.core.instance.instances.directive', [
         scope.$on('$locationChangeSuccess', clearActiveState);
 
         scope.$on('$destroy', function() {
-          if (tooltipsApplied) {
-            $('[data-toggle="tooltip"]', elem).tooltip('destroy');
-            tooltipsApplied = false;
-          }
+          removeTooltips();
           elem.unbind('mouseover');
           elem.unbind('click');
         });


### PR DESCRIPTION
Oh the joy of managing the DOM directly, using a framework and two libraries with complementary features.

Right now, if an instance tooltip is visible when the element is removed from the page (typically because the state of the server group has changed), the tooltip sticks to the page, because Bootstrap tooltips attached via the `selector` are basically impossible to get a handle on. I thought I'd fixed this two weeks ago but it's come back, or I was delusional.

The new approach attaches the tooltip on mouseover, stores a reference to the DOM node itself, then removes all of them whenever the contents of the instance list are replaced or removed.