### PR TITLE
(core) make yellow color for failed_continue status darker

### DIFF
--- a/app/scripts/modules/core/presentation/less/imports/colors.less
+++ b/app/scripts/modules/core/presentation/less/imports/colors.less
@@ -62,7 +62,7 @@
 
 @stage-succeeded: #769D3E;
 @stage-terminal: #b82525;
-@stage-failed_continue: #ffe63b;
+@stage-failed_continue: #edbb3c;
 @stage-running: #2275b8;
 @stage-default: #cccccc;
 @stage-stopped: #777777;


### PR DESCRIPTION
Current:
<img width="1039" alt="screen shot 2016-10-20 at 11 19 36 pm" src="https://cloud.githubusercontent.com/assets/73450/19588619/c9a662e2-971b-11e6-856f-bf140320e1a5.png">

Changing to:
<img width="1037" alt="screen shot 2016-10-20 at 11 20 06 pm" src="https://cloud.githubusercontent.com/assets/73450/19588622/cf585e34-971b-11e6-8359-9425fde53e58.png">