### PR TITLE
(build) remove comments, unused variables from output code

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var HtmlWebpackPlugin = require('html-webpack-plugin');
-var CommonsChunkPlugin = require('webpack/lib/optimize/CommonsChunkPlugin');
+var webpack = require('webpack');
 var HappyPack = require('happypack');
 var happyThreadPool = HappyPack.ThreadPool({size: 6});
 var path = require('path');
@@ -82,8 +82,14 @@ module.exports = {
     root: nodeModulePath
   },
   plugins: [
-    new CommonsChunkPlugin('vendor', 'vendor.bundle.js'),
-    new CommonsChunkPlugin('init.js'),
+    new webpack.optimize.UglifyJsPlugin({
+      mangle: false,
+      beautify: true,
+      comments: false,
+      sourceMap: false,
+    }),
+    new webpack.optimize.CommonsChunkPlugin('vendor', 'vendor.bundle.js'),
+    new webpack.optimize.CommonsChunkPlugin('init.js'),
     new HtmlWebpackPlugin({
       title: 'Spinnaker',
       template: './app/index.html',


### PR DESCRIPTION
I tried this some time ago, but it always hung, which I finally traced to the `sourceMap` generation. Disabling that results in a successful (and still fast) build.

The plugin (in this configuration) does a couple of things:
 1. removes comments from the output bundles
 2. removes unused parameters and unreachable code

Results:
vendor bundle drops from 4.3 MB to 2.9 MB
app bundle drops from 6.1 to 5.2

I'll be curious to see what this ends up at once it's gzipped.