### PR TITLE
(gce) makes backend service session affinity more human readable

### DIFF
--- a/app/scripts/modules/google/loadBalancer/configure/common/sessionAffinityNameMaps.ts
+++ b/app/scripts/modules/google/loadBalancer/configure/common/sessionAffinityNameMaps.ts
@@ -1,0 +1,15 @@
+import * as _ from 'lodash';
+
+interface StringMap {
+  [key: string]: string;
+}
+
+export const sessionAffinityViewToModelMap: StringMap = {
+  'None': 'NONE',
+  'Client IP': 'CLIENT_IP',
+  'Generated Cookie': 'GENERATED_COOKIE',
+  'Client IP and protocol': 'CLIENT_IP_PROTO',
+  'Client IP, port and protocol': 'CLIENT_IP_PORT_PROTO',
+};
+
+export const sessionAffinityModelToViewMap = _.invert<StringMap, StringMap>(sessionAffinityViewToModelMap);

--- a/app/scripts/modules/google/loadBalancer/configure/http/backendService/backendService.component.html
+++ b/app/scripts/modules/google/loadBalancer/configure/http/backendService/backendService.component.html
@@ -100,14 +100,14 @@
             {{$select.selected}}
           </ui-select-match>
           <ui-select-choices
-            repeat="sessionAffinity in ['NONE', 'CLIENT_IP', 'GENERATED_COOKIE'] | filter: $select.search">
+            repeat="sessionAffinity in ['None', 'Client IP', 'Generated Cookie'] | filter: $select.search">
             <div ng-bind-html="sessionAffinity | highlight: $select.search"></div>
           </ui-select-choices>
         </ui-select>
       </div>
     </div>
 
-    <div class="form-group" ng-if="$ctrl.backendService.sessionAffinity === 'GENERATED_COOKIE'">
+    <div class="form-group" ng-if="$ctrl.backendService.sessionAffinity === 'Generated Cookie'">
       <div class="col-md-4 sm-label-right">
         <b>Affinity Cookie TTL Seconds</b>
       </div>

--- a/app/scripts/modules/google/loadBalancer/configure/http/commandBuilder.service.js
+++ b/app/scripts/modules/google/loadBalancer/configure/http/commandBuilder.service.js
@@ -1,7 +1,8 @@
 'use strict';
 
-import {HttpLoadBalancerTemplate, ListenerTemplate} from './templates';
 import * as _ from 'lodash';
+import {HttpLoadBalancerTemplate, ListenerTemplate} from './templates';
+import {sessionAffinityModelToViewMap} from '../common/sessionAffinityNameMaps';
 
 let angular = require('angular');
 
@@ -140,6 +141,8 @@ module.exports = angular.module('spinnaker.deck.gce.httpLoadBalancer.backing.ser
 
             let ttlIsDefined = typeof service.affinityCookieTtlSec === 'string';
             service.affinityCookieTtlSec = ttlIsDefined ? Number(service.affinityCookieTtlSec) : null;
+
+            service.sessionAffinity = sessionAffinityModelToViewMap[service.sessionAffinity] || service.sessionAffinity;
           });
 
           return backendServices;

--- a/app/scripts/modules/google/loadBalancer/details/backendService/backendService.component.ts
+++ b/app/scripts/modules/google/loadBalancer/details/backendService/backendService.component.ts
@@ -10,7 +10,7 @@ class GceBackendServiceDetailsComponent implements ng.IComponentOptions {
     <dt>Health Check</dt>
     <dd>{{$ctrl.backendService.healthCheck.name}}</dd>
     <dt ng-if="$ctrl.backendService.sessionAffinity">Session Affinity</dt>
-    <dd ng-if="$ctrl.backendService.sessionAffinity">{{$ctrl.backendService.sessionAffinity}}</dd>
+    <dd ng-if="$ctrl.backendService.sessionAffinity">{{$ctrl.backendService.sessionAffinity | gceSessionAffinityFilter}}</dd>
     <dt ng-if="$ctrl.backendService.sessionAffinity === 'GENERATED_COOKIE'">Affinity Cookie TTL</dt>
     <dd ng-if="$ctrl.backendService.sessionAffinity === 'GENERATED_COOKIE'">{{$ctrl.backendService.affinityCookieTtlSec}}</dd>`;
 }

--- a/app/scripts/modules/google/loadBalancer/details/backendService/sessionAffinity.filter.ts
+++ b/app/scripts/modules/google/loadBalancer/details/backendService/sessionAffinity.filter.ts
@@ -1,0 +1,15 @@
+import {module} from 'angular';
+import {sessionAffinityModelToViewMap} from '../../configure/common/sessionAffinityNameMaps';
+
+function gceSessionAffinityFilter() {
+  return function (modelValue: string): string {
+    return sessionAffinityModelToViewMap[modelValue] || modelValue;
+  };
+}
+
+const moduleName = 'spinnaker.gce.loadBalancer.details.sessionAffinity.filter';
+
+module(moduleName, [])
+  .filter('gceSessionAffinityFilter', gceSessionAffinityFilter);
+
+export default moduleName;

--- a/app/scripts/modules/google/loadBalancer/details/loadBalancerDetail.controller.js
+++ b/app/scripts/modules/google/loadBalancer/details/loadBalancerDetail.controller.js
@@ -3,6 +3,7 @@
 import _ from 'lodash';
 import gceLoadBalancerDeleteModal from './deleteModal/deleteModal.controller';
 import gceBackendServiceDetailsComponent from './backendService/backendService.component';
+import gceSessionAffinityFilter from './backendService/sessionAffinity.filter';
 
 let angular = require('angular');
 
@@ -23,6 +24,7 @@ module.exports = angular.module('spinnaker.loadBalancer.gce.details.controller',
   require('../configure/choice/loadBalancerTypeToWizardMap.constant.js'),
   gceBackendServiceDetailsComponent,
   gceLoadBalancerDeleteModal,
+  gceSessionAffinityFilter,
 ])
   .controller('gceLoadBalancerDetailsCtrl', function ($scope, $state, $uibModal, loadBalancer, app, InsightFilterStateModel,
                                                       confirmationModalService, accountService, elSevenUtils,


### PR DESCRIPTION
@duftler or @jtk54 

For ILBs, I made all the options say nice human readable things, rather than having people select and see things like "CLIENT_IP_PORT_PROTO". This PR makes this consistent for the HTTP(S) load balancer wizard and for the load balancer details view.

![session_affinity_readable](https://cloud.githubusercontent.com/assets/13868700/19780278/6efa89ae-9c52-11e6-8cbf-02059926d7e7.png)
