### PR TITLE
(aws) handle standalone views when resource not found

### DIFF
--- a/app/scripts/modules/amazon/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/amazon/instance/details/instance.details.controller.js
@@ -163,8 +163,15 @@ module.exports = angular.module('spinnaker.instance.detail.aws.controller', [
       if ($scope.$$destroyed) {
         return;
       }
-      $state.params.allowModalToStayOpen = true;
-      $state.go('^', null, {location: 'replace'});
+      if (app.isStandalone) {
+        $scope.instanceId = instance.instanceId;
+        $scope.state.loading = false;
+        $scope.state.notFound = true;
+        recentHistoryService.removeLastItem('instances');
+      } else {
+        $state.params.allowModalToStayOpen = true;
+        $state.go('^', null, {location: 'replace'});
+      }
     }
 
     this.canDeregisterFromLoadBalancer = function() {

--- a/app/scripts/modules/amazon/instance/details/instanceDetails.html
+++ b/app/scripts/modules/amazon/instance/details/instanceDetails.html
@@ -1,3 +1,7 @@
+<div class="text-center" ng-if="state.notFound">
+  <h3>Could not find instance {{instanceId}}.</h3>
+  <a ui-sref="home.infrastructure">Back to search results</a>
+</div>
 <div class="details-panel">
   <div class="header" ng-if="state.loading">
     <div class="close-button" ng-if="!state.standalone">
@@ -11,7 +15,7 @@
     </h4>
   </div>
 
-  <div class="header" ng-if="!state.loading">
+  <div class="header" ng-if="!state.loading && !state.notFound">
     <div class="close-button" ng-if="!state.standalone">
       <a class="btn btn-link"
          ui-sref="^">

--- a/app/scripts/modules/amazon/securityGroup/details/securityGroupDetail.controller.js
+++ b/app/scripts/modules/amazon/securityGroup/details/securityGroupDetail.controller.js
@@ -13,10 +13,11 @@ module.exports = angular.module('spinnaker.securityGroup.aws.details.controller'
   require('../clone/cloneSecurityGroup.controller.js'),
   require('core/utils/selectOnDblClick.directive.js'),
   require('core/cloudProvider/cloudProvider.registry.js'),
+  require('core/history/recentHistory.service'),
 ])
   .controller('awsSecurityGroupDetailsCtrl', function ($scope, $state, resolvedSecurityGroup, app, InsightFilterStateModel,
                                                     confirmationModalService, securityGroupWriter, securityGroupReader,
-                                                    $uibModal, cloudProviderRegistry) {
+                                                    recentHistoryService, $uibModal, cloudProviderRegistry) {
 
     const application = app;
     const securityGroup = resolvedSecurityGroup;
@@ -87,8 +88,15 @@ module.exports = angular.module('spinnaker.securityGroup.aws.details.controller'
       if ($scope.$$destroyed) {
         return;
       }
-      $state.params.allowModalToStayOpen = true;
-      $state.go('^', null, {location: 'replace'});
+      if (app.isStandalone) {
+        $scope.group = securityGroup.name;
+        $scope.state.notFound = true;
+        $scope.state.loading = false;
+        recentHistoryService.removeLastItem('securityGroups');
+      } else {
+        $state.params.allowModalToStayOpen = true;
+        $state.go('^', null, {location: 'replace'});
+      }
     }
 
     extractSecurityGroup().then(() => {

--- a/app/scripts/modules/amazon/securityGroup/details/securityGroupDetail.html
+++ b/app/scripts/modules/amazon/securityGroup/details/securityGroupDetail.html
@@ -1,4 +1,8 @@
-<div class="details-panel">
+<div class="text-center" ng-if="state.notFound">
+  <h3>Could not find security group {{group}}.</h3>
+  <a ui-sref="home.infrastructure">Back to search results</a>
+</div>
+<div class="details-panel" ng-if="!state.notFound">
   <div class="header">
     <div class="close-button" ng-if="!state.standalone">
       <a class="btn btn-link"

--- a/app/scripts/modules/netflix/instance/aws/instanceDetails.html
+++ b/app/scripts/modules/netflix/instance/aws/instanceDetails.html
@@ -1,4 +1,8 @@
-<div class="details-panel">
+<div class="text-center" ng-if="state.notFound">
+  <h3>Could not find instance {{instanceId}}.</h3>
+  <a ui-sref="home.infrastructure">Back to search results</a>
+</div>
+<div class="details-panel" ng-if="!state.notFound">
   <div class="header" ng-if="state.loading">
     <div class="close-button" ng-if="!state.standalone">
       <a class="btn btn-link"
@@ -11,7 +15,7 @@
     </h4>
   </div>
 
-  <div class="header" ng-if="!state.loading">
+  <div class="header" ng-if="!state.loading && !state.notFound">
     <div class="close-button" ng-if="!state.standalone">
       <a class="btn btn-link"
          ui-sref="^">


### PR DESCRIPTION
Provide a message that the resource is not found, remove it from recent history, and allow the user to navigate back to the home screen.