### PR TITLE
(gce) improve e2e test start-up script

### DIFF
--- a/test/google/README.md
+++ b/test/google/README.md
@@ -1,7 +1,6 @@
 # Deck end-to-end tests
 
 The tests in this directory are a work in progress. They do not perfectly clean up the resources they create.
-If you have not run these tests before, switch to a node version > 6,
-then run `npm install` from this directory (not from the Deck project root).
+If you have not run these tests before, run `npm install` from this directory (not from the Deck project root).
 To run the tests, run `npm test` (from this directory).
 

--- a/test/google/e2e/tests/createServerGroup.e2e.js
+++ b/test/google/e2e/tests/createServerGroup.e2e.js
@@ -45,6 +45,7 @@ describe('Create Server Group', function () {
         The behavior inside the test does not match the behavior inside the protractor REPL.
       */
       browser.actions().mouseDown(modal.imageSelector).perform();
+      browser.sleep(1000);
       modal.firstImage.click();
 
       // Scrolls down modal to instanceTypeSelector.

--- a/test/google/google_int.sh
+++ b/test/google/google_int.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+. ~/.nvm/nvm.sh
+
+nvm install $npm_package_engines_node
 
 ./node_modules/protractor/bin/webdriver-manager update
-protractor protractor.conf.js
+./node_modules/protractor/bin/protractor protractor.conf.js
+

--- a/test/google/package.json
+++ b/test/google/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "test": "sh ./google_int.sh"
   },
+  "engines": {
+    "node": "6.5.0"
+  },
   "author": "",
   "license": "ISC",
   "devDependencies": {

--- a/test/google/tasks/createServerGroup/task.js
+++ b/test/google/tasks/createServerGroup/task.js
@@ -1,3 +1,5 @@
+'use strict';
+
 let job = require('./job.js'),
   findImages = require('../utils/findImages'),
   { account, cloudProvider, region, zone } = require('../../config.json');


### PR DESCRIPTION
Cleans up startup script, adds a sleep for a flaky test. @duftler or @lwander please reivew.