### PR TITLE
(core) fix click target on pipelines with > 40 stages; slow refresh rate based on size

### DIFF
--- a/app/scripts/modules/core/delivery/executionGroup/execution/execution.directive.js
+++ b/app/scripts/modules/core/delivery/executionGroup/execution/execution.directive.js
@@ -128,9 +128,10 @@ module.exports = angular
       });
     };
 
-    let activeRefresher = schedulerFactory.createScheduler(1000);
+    let activeRefresher = null;
 
     if (this.execution.isRunning && !this.standalone) {
+      activeRefresher = schedulerFactory.createScheduler(1000 * Math.ceil(this.execution.stages.length / 10));
       let refreshing = false;
       activeRefresher.subscribe(() => {
         if (refreshing) {

--- a/app/scripts/modules/core/delivery/executionGroup/execution/execution.less
+++ b/app/scripts/modules/core/delivery/executionGroup/execution/execution.less
@@ -91,14 +91,13 @@ execution-status {
   .stages {
     .duration {
       font-weight: 600;
-      padding-top: 1px;
-      display: inline-block;
-      visibility: hidden;
+      line-height: 20px;
+      display: none;
     }
     &.show-durations {
       .stage {
         .duration {
-          visibility: visible;
+          display: inline-block;
         }
         min-width: 50px;
         border-left-color: #FFFFFF;


### PR DESCRIPTION
Two changes to make pipelines a little more usable when they are extremely large:
 1. Replace the `visibility: hidden|visible` with `display: none|inline-block` on the duration tags. Using `visibility` is confusing the browser when the user clicks on the enclosing `div`, preventing navigation when it's significantly smaller than the duration tag.
 2. Slow down the auto refresh when there are more than ten stages in a pipeline, slowing it to 2 seconds for pipelines with 11-20 stages, 3 second for 21-30 stages, etc.

@zanthrash PTAL. This makes Cadmium a little more usable in the non-standalone view. It's still kinda laggy but better than current behavior.