### PR TITLE
(gce) standard select fields for custom instance builder

### DIFF
--- a/app/scripts/modules/google/serverGroup/configure/wizard/customInstance/customInstanceBuilder.html
+++ b/app/scripts/modules/google/serverGroup/configure/wizard/customInstance/customInstanceBuilder.html
@@ -5,13 +5,10 @@
     <help-field key="gce.instance.customInstance.cores"></help-field>
   </div>
   <div class="col-md-3">
-    <ui-select ng-model="command.viewState.customInstance.vCpuCount"
-               class="form-control input-sm">
-      <ui-select-match placeholder="Select...">{{ $select.selected }}</ui-select-match>
-      <ui-select-choices repeat="vCpuCount in command.backingData.customInstanceTypes.vCpuList | filter: $select.search">
-        <span ng-bind-html="vCpuCount | highlight: $select.search"></span>
-      </ui-select-choices>
-    </ui-select>
+    <select class="form-control input-sm"
+            ng-options="vCpuCount for vCpuCount in command.backingData.customInstanceTypes.vCpuList"
+            ng-model="command.viewState.customInstance.vCpuCount">
+    </select>
   </div>
 </div>
 <div class="form-group">
@@ -20,12 +17,9 @@
     <help-field key="gce.instance.customInstance.memory"></help-field>
   </div>
   <div class="col-md-3">
-    <ui-select ng-model="command.viewState.customInstance.memory"
-               class="form-control input-sm">
-      <ui-select-match placeholder="Select...">{{ $select.selected }}</ui-select-match>
-      <ui-select-choices repeat="memory in command.backingData.customInstanceTypes.memoryList | filter: $select.search">
-        <span ng-bind-html="memory | highlight: $select.search"></span>
-      </ui-select-choices>
-    </ui-select>
+    <select class="form-control input-sm"
+            ng-options="memory for memory in command.backingData.customInstanceTypes.memoryList"
+            ng-model="command.viewState.customInstance.memory">
+    </select>
   </div>
 </div>


### PR DESCRIPTION
@duftler 

Swap ui-select field for standard select field. You can't type your choices in, but it also doesn't take 5-10 seconds for the field to open. 

![custom_instance_select](https://cloud.githubusercontent.com/assets/13868700/19855872/281028f2-9f4d-11e6-8045-70b165b0d2d8.png)
