### PR TITLE
(gce) remove zones from load balancer details view

### DIFF
--- a/app/scripts/modules/google/loadBalancer/details/loadBalancerDetail.controller.js
+++ b/app/scripts/modules/google/loadBalancer/details/loadBalancerDetail.controller.js
@@ -55,14 +55,10 @@ module.exports = angular.module('spinnaker.loadBalancer.gce.details.controller',
             $scope.loadBalancer.elb = filtered[0];
             $scope.loadBalancer.account = loadBalancer.accountId;
 
-            accountService.getCredentialsKeyedByAccount('gce').then(function(credentialsKeyedByAccount) {
+            accountService.getCredentialsKeyedByAccount('gce').then(function() {
               if (elSevenUtils.isElSeven($scope.loadBalancer)) {
-                $scope.loadBalancer.elb.availabilityZones = ['All zones'];
                 $scope.loadBalancer.elb.backendServices = getBackendServices($scope.loadBalancer);
                 $scope.loadBalancer.elb.healthChecks = getUniqueHealthChecks($scope.loadBalancer.elb.backendServiceHealthChecks);
-
-              } else {
-                $scope.loadBalancer.elb.availabilityZones = _.find(credentialsKeyedByAccount[loadBalancer.accountId].regions, { name: loadBalancer.region }).zones.sort();
               }
             });
           }

--- a/app/scripts/modules/google/loadBalancer/details/loadBalancerDetails.html
+++ b/app/scripts/modules/google/loadBalancer/details/loadBalancerDetails.html
@@ -48,16 +48,12 @@
         <dt>Created</dt>
         <dd>{{loadBalancer.elb.createdTime | timestamp}}</dd>
         <dt>In</dt>
-        <dd><account-tag account="loadBalancer.account" pad="right"></account-tag> {{loadBalancer.region}}</dd>
+        <dd><account-tag account="loadBalancer.account" pad="right"></account-tag></dd>
+        <dt>Region</dt>
+        <dd>{{loadBalancer.region}}</dd>
         <dt>Type</dt>
         <dd>
           <gce-load-balancer-type load-balancer="loadBalancer"></gce-load-balancer-type>
-        </dd>
-        <dt>Zones</dt>
-        <dd>
-          <ul>
-            <li ng-repeat="availabilityZone in loadBalancer.elb.availabilityZones">{{availabilityZone}}</li>
-          </ul>
         </dd>
         <dt ng-if="loadBalancer.serverGroups.length">Server Groups</dt>
         <dd ng-if="loadBalancer.serverGroups.length">


### PR DESCRIPTION
@jtk54 or @duftler 
Removed zones from load balancer details view, moved region to its own heading. The top detail panel now closely matches the corresponding panel for Kubernetes.

![region_details](https://cloud.githubusercontent.com/assets/13868700/19856927/fe8fe300-9f51-11e6-9012-a00bd329bdde.png)
