### PR TITLE
(core) clean up non-modal wizard navigation style

### DIFF
--- a/app/scripts/modules/core/modal/wizard/modalWizard.less
+++ b/app/scripts/modules/core/modal/wizard/modalWizard.less
@@ -17,9 +17,15 @@ v2-modal-wizard {
       }
     }
     .wizard-navigation {
-      border: 1px solid @mid_light_grey;
+      background-color: transparent;
+      li.current, li:hover {
+        a {
+          color: @dark_blue_background;
+        }
+      }
       a {
         padding-left: 10px;
+        color: @spinnaker-link-color;
         &::before {
           width: 0;
           height: 0;


### PR DESCRIPTION
Current:
<img width="366" alt="screen shot 2016-10-31 at 2 47 40 pm" src="https://cloud.githubusercontent.com/assets/73450/19872887/45e3a6e8-9f79-11e6-93d7-00e95e972fae.png">


PR:
<img width="359" alt="screen shot 2016-10-31 at 2 47 51 pm" src="https://cloud.githubusercontent.com/assets/73450/19872890/4af4133e-9f79-11e6-81d0-c1eba91f7932.png">
