### PR TITLE
(core) avoid NPE on missing scheduler in execution directive

### DIFF
--- a/app/scripts/modules/core/delivery/executionGroup/execution/execution.directive.js
+++ b/app/scripts/modules/core/delivery/executionGroup/execution/execution.directive.js
@@ -145,10 +145,10 @@ module.exports = angular
           refreshing = false;
         });
       });
+      $scope.$on('$destroy', () => activeRefresher.unsubscribe());
     }
 
     $scope.$on('$destroy', () => {
-      activeRefresher.unsubscribe();
       if (this.isActive()) {
         this.hideDetails();
       }


### PR DESCRIPTION
maybe don't call unsubscribe if we never created the scheduler in the first place