### PR TITLE
(google) filter backend services by kind

### DIFF
--- a/app/scripts/modules/google/backendService/backendService.reader.js
+++ b/app/scripts/modules/google/backendService/backendService.reader.js
@@ -10,11 +10,18 @@ module.exports = angular.module('spinnaker.deck.gce.backendService.reader.servic
   ])
   .factory('gceBackendServiceReader', function (API, infrastructureCaches) {
 
-    function listBackendServices () {
-      return API
-        .all('search')
-        .useCache(infrastructureCaches.backendServices)
-        .getList({q:'', type: 'backendServices'});
+    function listBackendServices (kind) {
+      if (kind) {
+        return listBackendServices()
+          .then(([services]) => {
+            return services.results.filter((service) => service.kind === kind);
+          });
+      } else {
+        return API
+          .all('search')
+          .useCache(infrastructureCaches.backendServices)
+          .getList({q:'', type: 'backendServices'});
+      }
     }
 
     return { listBackendServices };

--- a/app/scripts/modules/google/loadBalancer/configure/http/commandBuilder.service.js
+++ b/app/scripts/modules/google/loadBalancer/configure/http/commandBuilder.service.js
@@ -133,9 +133,8 @@ module.exports = angular.module('spinnaker.deck.gce.httpLoadBalancer.backing.ser
     }
 
     function getBackendServices () {
-      return gceBackendServiceReader.listBackendServices()
-        .then(([response]) => {
-          let backendServices = response.results;
+      return gceBackendServiceReader.listBackendServices('globalBackendService')
+        .then((backendServices) => {
           backendServices.forEach((service) => {
             service.healthCheck = service.healthCheckLink.split('/').pop();
 


### PR DESCRIPTION
Since the search endpoint for backend services now returns two kinds of services, we need a way to filter them. 

@duftler or @jtk54 please review.