### PR TITLE
(google) fix error caused by SSL load balancer in project

### DIFF
--- a/app/scripts/modules/google/loadBalancer/loadBalancer.transformer.js
+++ b/app/scripts/modules/google/loadBalancer/loadBalancer.transformer.js
@@ -57,7 +57,7 @@ module.exports = angular.module('spinnaker.gce.loadBalancer.transformer', [])
       loadBalancer.provider = loadBalancer.type;
       loadBalancer.instances = _.chain(activeServerGroups).map('instances').flatten().value();
       loadBalancer.detachedInstances = _.chain(activeServerGroups).map('detachedInstances').flatten().value();
-      if (_.has(loadBalancer, 'backendService.healthCheck')) {
+      if (_.get(loadBalancer, 'backendService.healthCheck')) {
         loadBalancer.backendService.healthCheck.timeout = loadBalancer.backendService.healthCheck.timeoutSec;
         loadBalancer.backendService.healthCheck.interval = loadBalancer.backendService.healthCheck.checkIntervalSec;
       }


### PR DESCRIPTION
Deck throws an error when it tries to load a Google SSL load balancer without a health check.

@duftler or @jtk54 