### PR TITLE
(google) create / clone / destroy server group with ssl lb

### DIFF
--- a/app/scripts/modules/google/serverGroup/configure/serverGroupConfiguration.service.js
+++ b/app/scripts/modules/google/serverGroup/configure/serverGroupConfiguration.service.js
@@ -332,7 +332,7 @@ module.exports = angular.module('spinnaker.serverGroup.configure.gce.configurati
     }
 
     function isRelevantLoadBalancer(command, loadBalancer) {
-      return elSevenUtils.isElSeven(loadBalancer) || loadBalancer.region === command.region;
+      return loadBalancer.region === command.region || loadBalancer.region === 'global';
     }
 
     function mapListenerNameToUrlMapName (loadBalancerNames, newLoadBalancerObjects) {

--- a/app/scripts/modules/google/serverGroup/configure/wizard/cloneServerGroup.gce.controller.js
+++ b/app/scripts/modules/google/serverGroup/configure/wizard/cloneServerGroup.gce.controller.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import _ from 'lodash';
+
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.serverGroup.configure.gce.cloneServerGroup', [
@@ -232,6 +234,8 @@ module.exports = angular.module('spinnaker.serverGroup.configure.gce.cloneServer
             metadata['global-load-balancer-names'] =
               metadata['global-load-balancer-names']
                 .concat(loadBalancerDetails.listeners.map(listener => listener.name));
+          } else if (loadBalancerDetails.loadBalancerType === 'SSL') {
+            metadata['global-load-balancer-names'].push(name);
           } else {
             metadata['load-balancer-names'].push(name);
           }
@@ -257,6 +261,24 @@ module.exports = angular.module('spinnaker.serverGroup.configure.gce.cloneServer
       return metadata;
     }
 
+    function collectLoadBalancerNamesForCommand (loadBalancerIndex, loadBalancerMetadata) {
+      var loadBalancerNames = [];
+      if (loadBalancerMetadata['load-balancer-names']) {
+        loadBalancerNames = loadBalancerNames.concat(loadBalancerMetadata['load-balancer-names'].split(','));
+      }
+
+      var selectedSslLoadBalancerNames = _.chain(loadBalancerIndex)
+        .filter({loadBalancerType: 'SSL'})
+        .map('name')
+        .intersection(
+          loadBalancerMetadata['global-load-balancer-names']
+            ? loadBalancerMetadata['global-load-balancer-names'].split(',')
+            : [])
+        .value();
+
+      return loadBalancerNames.concat(selectedSslLoadBalancerNames);
+    }
+
     this.submit = function () {
       generateDiskDescriptors();
 
@@ -267,9 +289,9 @@ module.exports = angular.module('spinnaker.serverGroup.configure.gce.cloneServer
         $scope.command.backendServices);
 
       var origLoadBalancers = $scope.command.loadBalancers;
-      $scope.command.loadBalancers = loadBalancerMetadata['load-balancer-names']
-        ? loadBalancerMetadata['load-balancer-names'].split(',')
-        : [];
+      $scope.command.loadBalancers = collectLoadBalancerNamesForCommand(
+        $scope.command.backingData.filtered.loadBalancerIndex,
+        loadBalancerMetadata);
 
       angular.extend($scope.command.instanceMetadata, loadBalancerMetadata);
 

--- a/app/scripts/modules/google/serverGroup/configure/wizard/loadBalancers/loadBalancerSelector.directive.js
+++ b/app/scripts/modules/google/serverGroup/configure/wizard/loadBalancers/loadBalancerSelector.directive.js
@@ -40,7 +40,9 @@ module.exports = angular
         let index = this.command.backingData.filtered.loadBalancerIndex;
         let selected = this.command.loadBalancers;
 
-        return angular.isDefined(selected) && _.some(selected, s => index[s].loadBalancerType === 'HTTP');
+        return angular.isDefined(selected) && _.some(selected, s => {
+            return index[s].loadBalancerType === 'HTTP' || index[s].loadBalancerType === 'SSL';
+          });
       }
     };
 


### PR DESCRIPTION
I'll follow up with a PR that will allow the SSL details to be rendered properly.

Just to be explicit about the payload that Deck is forming: the name of the selected SSL load balancer is included in the `global-load-balancer-names` metadata and under `loadBalancers`.

@duftler or @jtk54 please review.
