### PR TITLE
(amazon) front-load existing security groups in filtered data

### DIFF
--- a/app/scripts/modules/amazon/serverGroup/configure/serverGroupConfiguration.service.js
+++ b/app/scripts/modules/amazon/serverGroup/configure/serverGroupConfiguration.service.js
@@ -313,7 +313,15 @@ module.exports = angular.module('spinnaker.aws.serverGroup.configure.service', [
           result.dirty.securityGroups = removed;
         }
       }
-      command.backingData.filtered.securityGroups = newRegionalSecurityGroups;
+      command.backingData.filtered.securityGroups = newRegionalSecurityGroups.sort((a, b) => {
+        if (command.securityGroups.includes(a.id)) {
+          return -1;
+        }
+        if (command.securityGroups.includes(b.id)) {
+          return 1;
+        }
+        return a.name.localeCompare(b.name);
+      });
       return result;
     }
 

--- a/app/scripts/modules/titus/securityGroup/securityGroupPicker.component.ts
+++ b/app/scripts/modules/titus/securityGroup/securityGroupPicker.component.ts
@@ -111,7 +111,15 @@ class SecurityGroupPickerController implements ng.IComponentController {
         this.groupsRemoved.next(removed);
       }
     }
-    this.availableGroups = newRegionalSecurityGroups;
+    this.availableGroups = newRegionalSecurityGroups.sort((a, b) => {
+      if (this.groupsToEdit.includes(a.id)) {
+        return -1;
+      }
+      if (this.groupsToEdit.includes(b.id)) {
+        return 1;
+      }
+      return a.name.localeCompare(b.name);
+    });
     this.loaded = true;
   }
 


### PR DESCRIPTION
Now I remember why we didn't paginate this in the first place: for the ui-select options to work, we need to ensure that existing options are not removed by the `filter`.

Rather than remove the filtering, let's double down on the complexity by sorting the existing security groups and making sure they are always first in the array.