### PR TITLE
(titus) fix validation on image selection

### DIFF
--- a/app/scripts/modules/titus/serverGroup/configure/ServerGroupCommandBuilder.js
+++ b/app/scripts/modules/titus/serverGroup/configure/ServerGroupCommandBuilder.js
@@ -49,7 +49,8 @@ module.exports = angular.module('spinnaker.titus.serverGroupCommandBuilder.servi
           useSimpleCapacity: true,
           usePreferredZones: true,
           mode: defaults.mode || 'create',
-        }
+        },
+        securityGroups: [],
       };
 
       return $q.when(command);

--- a/app/scripts/modules/titus/serverGroup/configure/wizard/CloneServerGroup.titus.controller.js
+++ b/app/scripts/modules/titus/serverGroup/configure/wizard/CloneServerGroup.titus.controller.js
@@ -83,11 +83,10 @@ module.exports = angular.module('spinnaker.serverGroup.configure.titus.cloneServ
     }
 
     this.isValid = function () {
-      return $scope.command && ($scope.command.viewState.disableImageSelection || $scope.command.image !== null) &&
+      return $scope.command && ($scope.command.viewState.disableImageSelection || $scope.command.imageId) &&
         ($scope.command.credentials !== null) &&
         ($scope.command.region !== null) &&
         ($scope.command.capacity.desired !== null) &&
-        $scope.command.imageId &&
         v2modalWizardService.isComplete();
     };
 


### PR DESCRIPTION
`imageId` is no longer a field we care about - we want to make sure `tag` is selected.

Also fixing initialization of security groups.

@tomaslin PTAL