### PR TITLE
(core) remove default export on applicationDataSourceRegistry

### DIFF
--- a/app/scripts/modules/core/application/config/appConfig.dataSource.js
+++ b/app/scripts/modules/core/application/config/appConfig.dataSource.js
@@ -1,11 +1,11 @@
 import {DataSourceConfig} from '../service/applicationDataSource';
-import registryModule from '../service/applicationDataSource.registry';
+import {APPLICATION_DATA_SOURCE_REGISTRY} from '../service/applicationDataSource.registry';
 
 let angular = require('angular');
 
 module.exports = angular
   .module('spinnaker.core.application.config.dataSource', [
-    registryModule,
+    APPLICATION_DATA_SOURCE_REGISTRY,
   ])
   .run(function($q, applicationDataSourceRegistry) {
     applicationDataSourceRegistry.registerDataSource(new DataSourceConfig({

--- a/app/scripts/modules/core/application/service/applicationDataSource.registry.ts
+++ b/app/scripts/modules/core/application/service/applicationDataSource.registry.ts
@@ -38,9 +38,7 @@ export class ApplicationDataSourceRegistry {
   }
 }
 
-const moduleName = 'spinnaker.core.application.section.registry';
+export const APPLICATION_DATA_SOURCE_REGISTRY = 'spinnaker.core.application.section.registry';
 
-module(moduleName, [])
+module(APPLICATION_DATA_SOURCE_REGISTRY, [])
   .service('applicationDataSourceRegistry', ApplicationDataSourceRegistry);
-
-export default moduleName;

--- a/app/scripts/modules/core/application/service/applications.read.service.js
+++ b/app/scripts/modules/core/application/service/applications.read.service.js
@@ -1,4 +1,4 @@
-import dataSourceModule from './applicationDataSource.registry';
+import {APPLICATION_DATA_SOURCE_REGISTRY} from './applicationDataSource.registry';
 import {API_SERVICE} from 'core/api/api.service';
 import {ApplicationDataSource, DataSourceConfig} from '../service/applicationDataSource';
 import {Application} from '../application.model';
@@ -9,7 +9,7 @@ module.exports = angular
   .module('spinnaker.applications.read.service', [
     require('../../scheduler/scheduler.factory.js'),
     API_SERVICE,
-    dataSourceModule,
+    APPLICATION_DATA_SOURCE_REGISTRY,
     require('../../presentation/robotToHumanFilter/robotToHuman.filter'),
   ])
   .factory('applicationReader', function ($q, $log, $filter, $http, settings, API, schedulerFactory,

--- a/app/scripts/modules/core/delivery/delivery.dataSource.js
+++ b/app/scripts/modules/core/delivery/delivery.dataSource.js
@@ -1,11 +1,11 @@
 import {DataSourceConfig} from '../application/service/applicationDataSource';
-import dataSourceRegistryModule from '../application/service/applicationDataSource.registry';
+import {APPLICATION_DATA_SOURCE_REGISTRY} from '../application/service/applicationDataSource.registry';
 
 let angular = require('angular');
 
 module.exports = angular
   .module('spinnaker.core.delivery.dataSource', [
-    dataSourceRegistryModule,
+    APPLICATION_DATA_SOURCE_REGISTRY,
     require('./service/execution.service'),
     require('../pipeline/config/services/pipelineConfigService'),
     require('../cluster/cluster.service'),

--- a/app/scripts/modules/core/delivery/delivery.dataSource.spec.ts
+++ b/app/scripts/modules/core/delivery/delivery.dataSource.spec.ts
@@ -1,6 +1,6 @@
 import {Application} from '../application/application.model';
 import modelBuilderModule from '../application/applicationModel.builder';
-import dataSourceRegistryModule from '../application/service/applicationDataSource.registry';
+import {APPLICATION_DATA_SOURCE_REGISTRY} from '../application/service/applicationDataSource.registry';
 
 describe('Delivery Data Source', function () {
 
@@ -17,7 +17,7 @@ describe('Delivery Data Source', function () {
       require('./delivery.dataSource'),
       require('./service/execution.service'),
       require('../pipeline/config/services/pipelineConfigService'),
-      dataSourceRegistryModule,
+      APPLICATION_DATA_SOURCE_REGISTRY,
       modelBuilderModule
   ));
 

--- a/app/scripts/modules/core/loadBalancer/loadBalancer.dataSource.js
+++ b/app/scripts/modules/core/loadBalancer/loadBalancer.dataSource.js
@@ -1,11 +1,11 @@
 import {DataSourceConfig} from '../application/service/applicationDataSource';
-import dataSourceRegistryModule from '../application/service/applicationDataSource.registry';
+import {APPLICATION_DATA_SOURCE_REGISTRY} from '../application/service/applicationDataSource.registry';
 
 let angular = require('angular');
 
 module.exports = angular
   .module('spinnaker.core.loadBalancer.dataSource', [
-    dataSourceRegistryModule,
+    APPLICATION_DATA_SOURCE_REGISTRY,
     require('./loadBalancer.read.service'),
   ])
   .run(function($q, applicationDataSourceRegistry, loadBalancerReader) {

--- a/app/scripts/modules/core/securityGroup/securityGroup.dataSource.js
+++ b/app/scripts/modules/core/securityGroup/securityGroup.dataSource.js
@@ -1,11 +1,11 @@
 import {DataSourceConfig} from '../application/service/applicationDataSource';
-import dataSourceRegistryModule from '../application/service/applicationDataSource.registry';
+import {APPLICATION_DATA_SOURCE_REGISTRY} from '../application/service/applicationDataSource.registry';
 
 let angular = require('angular');
 
 module.exports = angular
   .module('spinnaker.core.securityGroup.dataSource', [
-    dataSourceRegistryModule,
+    APPLICATION_DATA_SOURCE_REGISTRY,
     require('./securityGroup.read.service'),
   ])
   .run(function($q, applicationDataSourceRegistry, securityGroupReader) {

--- a/app/scripts/modules/core/serverGroup/serverGroup.dataSource.js
+++ b/app/scripts/modules/core/serverGroup/serverGroup.dataSource.js
@@ -1,11 +1,11 @@
 import {DataSourceConfig} from '../application/service/applicationDataSource';
-import dataSourceRegistryModule from '../application/service/applicationDataSource.registry';
+import {APPLICATION_DATA_SOURCE_REGISTRY} from '../application/service/applicationDataSource.registry';
 
 let angular = require('angular');
 
 module.exports = angular
   .module('spinnaker.core.serverGroup.dataSource', [
-    dataSourceRegistryModule,
+    APPLICATION_DATA_SOURCE_REGISTRY,
     require('../cluster/cluster.service'),
   ])
   .run(function($q, applicationDataSourceRegistry, clusterService, serverGroupTransformer) {

--- a/app/scripts/modules/core/task/task.dataSource.js
+++ b/app/scripts/modules/core/task/task.dataSource.js
@@ -1,11 +1,11 @@
 import {DataSourceConfig} from '../application/service/applicationDataSource';
-import dataSourceRegistryModule from '../application/service/applicationDataSource.registry';
+import {APPLICATION_DATA_SOURCE_REGISTRY} from '../application/service/applicationDataSource.registry';
 
 let angular = require('angular');
 
 module.exports = angular
   .module('spinnaker.core.task.dataSource', [
-    dataSourceRegistryModule,
+    APPLICATION_DATA_SOURCE_REGISTRY,
     require('./task.read.service'),
     require('../cluster/cluster.service'),
   ])

--- a/app/scripts/modules/core/task/task.dataSource.spec.ts
+++ b/app/scripts/modules/core/task/task.dataSource.spec.ts
@@ -1,6 +1,6 @@
 import {Application} from '../application/application.model';
 import modelBuilderModule from '../application/applicationModel.builder';
-import dataSourceRegistryModule from '../application/service/applicationDataSource.registry';
+import {APPLICATION_DATA_SOURCE_REGISTRY} from '../application/service/applicationDataSource.registry';
 
 describe('Task Data Source', function () {
 
@@ -15,7 +15,7 @@ describe('Task Data Source', function () {
     angular.mock.module(
       require('./task.dataSource'),
       require('./task.read.service'),
-      dataSourceRegistryModule,
+      APPLICATION_DATA_SOURCE_REGISTRY,
       modelBuilderModule
     ));
 

--- a/app/scripts/modules/netflix/ci/ci.controller.spec.js
+++ b/app/scripts/modules/netflix/ci/ci.controller.spec.js
@@ -1,5 +1,5 @@
 import MODEL_BUILDER from 'core/application/applicationModel.builder';
-import DATA_SOURCE_REGISTRY from 'core/application/service/applicationDataSource.registry';
+import {APPLICATION_DATA_SOURCE_REGISTRY} from 'core/application/service/applicationDataSource.registry';
 
 describe('Controller: NetflixCiCtrl', function () {
 
@@ -9,7 +9,7 @@ describe('Controller: NetflixCiCtrl', function () {
     window.module(
       require('./ci.controller.js'),
       MODEL_BUILDER,
-      DATA_SOURCE_REGISTRY
+      APPLICATION_DATA_SOURCE_REGISTRY
     )
   );
 

--- a/app/scripts/modules/netflix/ci/ci.dataSource.js
+++ b/app/scripts/modules/netflix/ci/ci.dataSource.js
@@ -1,12 +1,12 @@
 import {DataSourceConfig} from 'core/application/service/applicationDataSource';
-import dataSourceRegistryModule from 'core/application/service/applicationDataSource.registry';
+import {APPLICATION_DATA_SOURCE_REGISTRY} from 'core/application/service/applicationDataSource.registry';
 
 let angular = require('angular');
 
 module.exports = angular
   .module('spinnaker.netflix.ci.dataSource', [
     require('core/config/settings'),
-    dataSourceRegistryModule,
+    APPLICATION_DATA_SOURCE_REGISTRY,
     require('./build.read.service'),
   ])
   .run(function($q, applicationDataSourceRegistry, settings, buildService) {

--- a/app/scripts/modules/netflix/ci/ci.dataSource.spec.ts
+++ b/app/scripts/modules/netflix/ci/ci.dataSource.spec.ts
@@ -1,14 +1,14 @@
 import {Application} from 'core/application/application.model';
 import APPLICATION_MODEL_BUILDER, {ApplicationModelBuilder} from '../../core/application/applicationModel.builder';
 import IProvideService = angular.auto.IProvideService;
-import DATA_SOURCE_REGISTRY from 'core/application/service/applicationDataSource.registry';
+import {APPLICATION_DATA_SOURCE_REGISTRY} from 'core/application/service/applicationDataSource.registry';
 
 describe('CI Data Source', function () {
   beforeEach(
     angular.mock.module(
       require('./ci.dataSource'),
       APPLICATION_MODEL_BUILDER,
-      DATA_SOURCE_REGISTRY,
+      APPLICATION_DATA_SOURCE_REGISTRY,
       function($provide: IProvideService) {
         return $provide.constant('settings', {
           feature: { netflixMode: true }

--- a/app/scripts/modules/netflix/fastProperties/fastProperty.dataSource.js
+++ b/app/scripts/modules/netflix/fastProperties/fastProperty.dataSource.js
@@ -1,12 +1,12 @@
 import {DataSourceConfig} from 'core/application/service/applicationDataSource';
-import dataSourceRegistryModule from 'core/application/service/applicationDataSource.registry';
+import {APPLICATION_DATA_SOURCE_REGISTRY} from 'core/application/service/applicationDataSource.registry';
 
 let angular = require('angular');
 
 module.exports = angular
   .module('spinnaker.netflix.fastProperty.dataSource', [
     require('core/config/settings'),
-    dataSourceRegistryModule
+    APPLICATION_DATA_SOURCE_REGISTRY,
   ])
   .run(function($q, applicationDataSourceRegistry, settings) {
 

--- a/app/scripts/modules/netflix/netflix.module.js
+++ b/app/scripts/modules/netflix/netflix.module.js
@@ -1,4 +1,4 @@
-import dataSourceRegistryModule from 'core/application/service/applicationDataSource.registry';
+import {APPLICATION_DATA_SOURCE_REGISTRY} from 'core/application/service/applicationDataSource.registry';
 
 let angular = require('angular');
 
@@ -40,7 +40,7 @@ module.exports = angular
 
     require('./tableau/states'),
     require('./ci/ci.module'),
-    dataSourceRegistryModule,
+    APPLICATION_DATA_SOURCE_REGISTRY,
   ])
   .run(function(cloudProviderRegistry, applicationDataSourceRegistry, settings) {
     if (settings.feature && settings.feature.netflixMode) {

--- a/app/scripts/modules/netflix/tableau/tableau.dataSource.js
+++ b/app/scripts/modules/netflix/tableau/tableau.dataSource.js
@@ -1,12 +1,12 @@
 import {DataSourceConfig} from 'core/application/service/applicationDataSource';
-import dataSourceRegistryModule from 'core/application/service/applicationDataSource.registry';
+import {APPLICATION_DATA_SOURCE_REGISTRY} from 'core/application/service/applicationDataSource.registry';
 
 let angular = require('angular');
 
 module.exports = angular
   .module('spinnaker.netflix.tableau.dataSource', [
     require('core/config/settings'),
-    dataSourceRegistryModule
+    APPLICATION_DATA_SOURCE_REGISTRY,
   ])
   .run(function($q, applicationDataSourceRegistry, settings) {
     if (settings.feature && settings.feature.tableau) {


### PR DESCRIPTION
We're going to move away from `export default` with the module name, so there will be a number of pull requests like this one.

cc @danielpeach - we'll try to get a TS style guide together in the next week or so to spell this stuff out. I think we have most of the pieces in place, just need to hammer it into a wiki page on GH.