### PR TITLE
(core) move class assignment on pipeline stages to ng-class

### DIFF
--- a/app/scripts/modules/core/delivery/executionGroup/execution/execution.directive.html
+++ b/app/scripts/modules/core/delivery/executionGroup/execution/execution.directive.html
@@ -7,10 +7,9 @@
   <div class="execution-bar">
     <div class="stages" ng-class="{'show-durations': vm.sortFilter.showStageDuration}">
       <div ng-repeat="stage in ::vm.execution.stageSummaries"
-           class="clickable stage stage-type-{{::stage.type.toLowerCase()}}
-                  execution-marker execution-marker-{{stage.status.toLowerCase()}}
-                  {{vm.isActive($index) ? 'active' : ''}} {{stage.isRunning ? 'glowing' : ''}}"
+           class="clickable stage execution-marker"
            ng-style="::{width: 100/vm.execution.stageSummaries.length + '%', 'background-color': stage.color}"
+           ng-class="['stage-type-' + stage.type.toLowerCase(), 'execution-marker-' + stage.status.toLowerCase(), vm.isActive($index) ? 'active' : '', stage.isRunning ? 'glowing' : '']"
            uib-tooltip-template="::stage.labelTemplateUrl"
            tooltip-title="(Click for details)"
            tooltip-placement="bottom"


### PR DESCRIPTION
For some reason, Angular has decided to stop removing the old `execution-marker-{{stage.status.toLowerCase()}}` class when it changes. Instead, it's just adding the new class, so we end up with multiple `execution-marker-xxx` classes on the div when its status changes.

The only thing I can think is it has something to do with removing angular-animate a few days ago. While that doesn't make a lot of sense, I'm less interested in figuring out the root cause of this issue and more interested in "making it work as expected", and this change does that. We also end up with fewer watchers on the page, although I'm not convinced we're saving anything - it could just be that the `ng-class` watcher is more computationally complex.