### PR TITLE
AcaTask stage correctly fail stage when ACA fails

### DIFF
--- a/app/scripts/modules/netflix/pipeline/stage/acaTask/acaTaskStage.transformer.js
+++ b/app/scripts/modules/netflix/pipeline/stage/acaTask/acaTaskStage.transformer.js
@@ -31,17 +31,20 @@ module.exports = angular.module('spinnaker.netflix.pipeline.stage.acaTask.transf
           var status = stage.status;
 
           var canaryStatus = stage.context.canary.status;
+
+          var canaryResult = stage.context.canary.canaryResult && stage.context.canary.canaryResult.overallResult;
+
           if (canaryStatus && status !== 'CANCELED') {
             if (canaryStatus.status === 'LAUNCHED' || canaryStatus.status === 'RUNNING') {
               status = 'RUNNING';
             }
-            if (canaryStatus.complete) {
+            if (canaryStatus.complete && canaryResult === 'SUCCESS') {
               status = 'SUCCEEDED';
             }
             if (canaryStatus.status === 'DISABLED') {
               status = 'DISABLED';
             }
-            if (canaryStatus.status === 'FAILED') {
+            if (canaryStatus.status === 'FAILED' || canaryResult === 'FAILURE') {
               status = 'FAILED';
             }
             if (canaryStatus.status === 'TERMINATED') {


### PR DESCRIPTION
The ACA Task trasnsformer was not considering the overall result state of the canary
when setting the state of the sage.

This also sets the stage as SUCCEDED when the canary status is marked as competed AND
the overallResult of the canary are SUCCESS.

@anotherchrisberry @icfantv PTAL