### PR TITLE
(core) do not mark jenkins stages as changed when initializing

### DIFF
--- a/app/scripts/modules/core/pipeline/config/stages/jenkins/jenkinsStage.html
+++ b/app/scripts/modules/core/pipeline/config/stages/jenkins/jenkinsStage.html
@@ -79,7 +79,8 @@
 
   <stage-config-field label="Wait for results" help-key="jenkins.waitForCompletion">
     <input type="checkbox" class="input-sm" name="waitForCompletion"
-           ng-model="stage.waitForCompletion"/>
+           ng-model="viewState.waitForCompletion"
+           ng-change="jenkinsStageCtrl.waitForCompletionChanged()"/>
   </stage-config-field>
 
   <div class="form-group">

--- a/app/scripts/modules/core/pipeline/config/stages/jenkins/jenkinsStage.js
+++ b/app/scripts/modules/core/pipeline/config/stages/jenkins/jenkinsStage.js
@@ -29,7 +29,6 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.jenkinsStage', [
     $scope.stage = stage;
     $scope.stage.failPipeline = ($scope.stage.failPipeline === undefined ? true : $scope.stage.failPipeline);
     $scope.stage.continuePipeline = ($scope.stage.continuePipeline === undefined ? false : $scope.stage.continuePipeline);
-    $scope.stage.waitForCompletion = ($scope.stage.waitForCompletion === undefined ? true : $scope.stage.waitForCompletion);
 
     $scope.viewState = {
       mastersLoaded: false,
@@ -37,11 +36,14 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.jenkinsStage', [
       jobsLoaded: false,
       jobsRefreshing: false,
       failureOption: 'fail',
-      markUnstableAsSuccessful: !!stage.markUnstableAsSuccessful
+      markUnstableAsSuccessful: !!stage.markUnstableAsSuccessful,
+      waitForCompletion: stage.waitForCompletion || stage.waitForCompletion === undefined,
     };
 
     // Using viewState to avoid marking pipeline as dirty if field is not set
     this.markUnstableChanged = () => stage.markUnstableAsSuccessful = $scope.viewState.markUnstableAsSuccessful;
+
+    this.waitForCompletionChanged = () => stage.waitForCompletion = $scope.viewState.waitForCompletion;
 
     function initializeMasters() {
       igorService.listMasters().then(function (masters) {


### PR DESCRIPTION
Same thing we did on the `markUnstableAsSuccessful` flag - use the view state to avoid having the pipeline appear changed based on initialization of `waitForCompletion`, which is `true` if it's undefined.

cc @tomaslin 