### PR TITLE
(Openstack) Show all security groups on create server group

### DIFF
--- a/app/scripts/modules/openstack/common/cacheBackedMultiSelect.template.html
+++ b/app/scripts/modules/openstack/common/cacheBackedMultiSelect.template.html
@@ -10,7 +10,7 @@
     </ui-select>
   </div>
   <div class="col-md-1 sm-label-left">
-    <a href="" ng-click="cache.refresh()" uib-tooltip-template="refreshTooltipTemplate">
+    <a href="" ng-click="forceRefreshCache()" uib-tooltip-template="refreshTooltipTemplate">
       <span class="glyphicon glyphicon-refresh" ng-class="{'glyphicon-spinning':cache.loading}"></span>
     </a>
   </div>

--- a/app/scripts/modules/openstack/loadBalancer/configure/wizard/interface.html
+++ b/app/scripts/modules/openstack/loadBalancer/configure/wizard/interface.html
@@ -2,10 +2,10 @@
   <div class="modal-body">
     <network-select-field model="loadBalancer.networkId" help-key="openstack.loadBalancer.network" read-only="!isNew"></network-select-field>
 
-    <os-app-cache-backed-multi-select-field label="Security Groups"
-                                            cache-key="securityGroups"
-                                            filter="filter"
+    <os-cache-backed-multi-select-field label="Security Groups"
+                                            cache="allSecurityGroups"
+                                            refresh-cache="updateSecurityGroups"
                                             required="true"
-                                            model="loadBalancer.securityGroups"></os-app-cache-backed-multi-select-field>
+                                            model="loadBalancer.securityGroups"></os-cache-backed-multi-select-field>
   </div>
 </ng-form>

--- a/app/scripts/modules/openstack/loadBalancer/configure/wizard/upsert.controller.spec.js
+++ b/app/scripts/modules/openstack/loadBalancer/configure/wizard/upsert.controller.spec.js
@@ -93,6 +93,7 @@ describe('Controller: openstackCreateLoadBalancerCtrl', function () {
     this.mockLoadBalancerReader = addDeferredMock({}, 'listLoadBalancers');
     this.mockAccountService = addDeferredMock({}, 'listAccounts');
     this.mockLoadBalancerWriter = addDeferredMock({}, 'upsertLoadBalancer');
+    this.mockSecurityGroupReader = addDeferredMock({}, 'getAllSecurityGroups');
     this.mockTaskMonitor = {
       submit: jasmine.createSpy('taskMonitor.submit')
     };
@@ -114,7 +115,8 @@ describe('Controller: openstackCreateLoadBalancerCtrl', function () {
         loadBalancerReader: this.mockLoadBalancerReader,
         accountService: this.mockAccountService,
         loadBalancerWriter: this.mockLoadBalancerWriter,
-        taskMonitorService: this.mockTaskMonitorService
+        taskMonitorService: this.mockTaskMonitorService,
+        securityGroupReader: this.mockSecurityGroupReader,
       });
     };
   }));

--- a/app/scripts/modules/openstack/serverGroup/configure/wizard/Clone.controller.js
+++ b/app/scripts/modules/openstack/serverGroup/configure/wizard/Clone.controller.js
@@ -49,7 +49,7 @@ module.exports = angular.module('spinnaker.openstack.serverGroup.configure.clone
     function configureCommand() {
       serverGroupCommand.viewState.contextImages = $scope.contextImages;
       $scope.contextImages = null;
-      openstackServerGroupConfigurationService.configureCommand(application, serverGroupCommand).then(function () {
+      openstackServerGroupConfigurationService.configureCommand(application, serverGroupCommand).then(function() {
         $scope.state.loaded = true;
         initializeWizardState();
         initializeWatches();

--- a/app/scripts/modules/openstack/serverGroup/configure/wizard/access/AccessSettings.controller.js
+++ b/app/scripts/modules/openstack/serverGroup/configure/wizard/access/AccessSettings.controller.js
@@ -5,19 +5,31 @@ let angular = require('angular');
 module.exports = angular.module('spinnaker.serverGroup.configure.openstack.accessSettings', [
   require('angular-ui-router'),
   require('angular-ui-bootstrap'),
-  require('../../../../common/appCacheBackedMultiSelectField.directive.js'),
+  require('../../../../common/cacheBackedMultiSelectField.directive.js'),
 ]).controller('openstackServerGroupAccessSettingsCtrl', function($scope, loadBalancerReader, securityGroupReader, networkReader, v2modalWizardService) {
 
-  function updateFilter() {
-    $scope.filter = {
+  // Loads all load balancers in the current application, region, and account
+  $scope.updateLoadBalancers = function() {
+    var filter = {
       account: $scope.command.credentials,
       region: $scope.command.region
     };
-  }
+    $scope.application.loadBalancers.refresh();
+    $scope.allLoadBalancers = _.filter($scope.application.loadBalancers.data, filter);
+  };
+  $scope.$watch('command.credentials', $scope.updateLoadBalancers);
+  $scope.$watch('command.region', $scope.updateLoadBalancers);
+  $scope.$watch('application.loadBalancers', $scope.updateLoadBalancers);
+  $scope.updateLoadBalancers();
 
-  $scope.$watch('command.credentials', updateFilter);
-  $scope.$watch('command.region', updateFilter);
-  updateFilter();
+  // Loads all security groups in the current region and account
+  $scope.updateSecurityGroups = function() {
+    $scope.allSecurityGroups = getSecurityGroups();
+  };
+  // The backingData the getSecurityGroups gets resolved after the form is loaded, so lets watch it
+  $scope.$watch(function() {
+    return _.map(getSecurityGroups(), 'id').join();
+  }, $scope.updateSecurityGroups);
 
   $scope.$watch('accessSettings.$valid', function(newVal) {
     if (newVal) {
@@ -27,5 +39,9 @@ module.exports = angular.module('spinnaker.serverGroup.configure.openstack.acces
       v2modalWizardService.markIncomplete('access-settings');
     }
   });
+
+  function getSecurityGroups() {
+    return _.get($scope.command.backingData, 'filtered.securityGroups', []);
+  }
 
 });

--- a/app/scripts/modules/openstack/serverGroup/configure/wizard/access/accessSettings.html
+++ b/app/scripts/modules/openstack/serverGroup/configure/wizard/access/accessSettings.html
@@ -16,17 +16,17 @@
       </div>
     </div>
 
-    <os-app-cache-backed-multi-select-field label="Load Balancers"
-                                            cache-key="loadBalancers"
-                                            filter="filter"
+    <os-cache-backed-multi-select-field label="Load Balancers"
+                                            cache="allLoadBalancers"
+                                            refresh-cache="updateLoadBalancers"
                                             required="false"
-                                            model="command.loadBalancers"></os-app-cache-backed-multi-select-field>
+                                            model="command.loadBalancers"></os-cache-backed-multi-select-field>
 
-    <os-app-cache-backed-multi-select-field label="Security Groups"
-                                            cache-key="securityGroups"
-                                            filter="filter"
+    <os-cache-backed-multi-select-field label="Security Groups"
+                                            cache="allSecurityGroups"
+                                            refresh-cache="updateSecurityGroups"
                                             required="true"
-                                            model="command.securityGroups"></os-app-cache-backed-multi-select-field>
+                                            model="command.securityGroups"></os-cache-backed-multi-select-field>
 
     <div class="form-group">
       <div class="col-md-5 sm-label-left">
@@ -61,4 +61,3 @@
     </ng-form>
   </div>
 </div>
-


### PR DESCRIPTION
When creating a server group (or a load balancer), the list of security groups to choose from should be all security groups in that account and region. This allows having common security groups platform services like logging servers, service discovery servers, etc.

To accomplish this, the `appCacheBackedMultiSelect` directive had to be updated to allow passing
in an explicit cache instead of having the directive read the cache via cache key from the application list.