### PR TITLE
(core) prevent badges from contributing to app ready, add afterLoad

### DIFF
--- a/app/scripts/modules/core/application/service/applicationDataSource.ts
+++ b/app/scripts/modules/core/application/service/applicationDataSource.ts
@@ -63,7 +63,9 @@ export class DataSourceConfig {
   public activeState: string;
 
   /**
-   * Determines whether the data source appears on the application header. Default: true
+   * Determines whether the data source appears on the application header and contributes to the application's ready state.
+   *
+   * Default: true
    */
   public visible: boolean = true;
 
@@ -91,6 +93,12 @@ export class DataSourceConfig {
    * will remain unchanged.
    */
   public onLoad: {(fn: any): ng.IPromise<any>};
+
+  /**
+   * (Optional) A method that is called after the "onLoad" method resolves. The data source's data will be populated
+   * when this method is called.
+   */
+  public afterLoad: {(application: Application): void};
 
   /**
    * If the data source should contribute to the application's default credentials setting, this field should be set
@@ -237,7 +245,12 @@ export class ApplicationDataSource {
   /**
    * See DataSourceConfig#onLoad
    */
-  public onLoad: {(Application: any, fn: any): ng.IPromise<any>};
+  public onLoad: {(application: Application, fn: any): ng.IPromise<any>};
+
+  /**
+   * See DataSourceConfig#afterLoad
+   */
+  public afterLoad: {(application: Application): void};
 
   /**
    * See DataSourceConfig#loader
@@ -379,6 +392,9 @@ export class ApplicationDataSource {
           this.loading = false;
           this.loadFailure = false;
           this.lastRefresh = new Date().getTime();
+          if (this.afterLoad) {
+            this.afterLoad(this.application);
+          }
           this.dataUpdated();
         });
       })

--- a/app/scripts/modules/core/delivery/delivery.dataSource.js
+++ b/app/scripts/modules/core/delivery/delivery.dataSource.js
@@ -39,10 +39,13 @@ module.exports = angular
 
     let addRunningExecutions = (application, data) => {
       executionService.transformExecutions(application, data);
-      clusterService.addExecutionsToServerGroups(application);
       return $q.when(data);
     };
 
+    let runningExecutionsLoaded = (application) => {
+      clusterService.addExecutionsToServerGroups(application);
+      application.getDataSource('serverGroups').dataUpdated();
+    };
 
     if (settings.feature && settings.feature.pipelines !== false) {
       applicationDataSourceRegistry.registerDataSource(new DataSourceConfig({
@@ -71,6 +74,7 @@ module.exports = angular
         visible: false,
         loader: loadRunningExecutions,
         onLoad: addRunningExecutions,
+        afterLoad: runningExecutionsLoaded,
       }));
     }
 

--- a/app/scripts/modules/core/task/task.dataSource.js
+++ b/app/scripts/modules/core/task/task.dataSource.js
@@ -24,8 +24,12 @@ module.exports = angular
     };
 
     let addRunningTasks = (application, data) => {
-      clusterService.addTasksToServerGroups(application);
       return $q.when(data);
+    };
+
+    let runningTasksLoaded = (application) => {
+      clusterService.addTasksToServerGroups(application);
+      application.getDataSource('serverGroups').dataUpdated();
     };
 
     applicationDataSourceRegistry.registerDataSource(new DataSourceConfig({
@@ -34,6 +38,7 @@ module.exports = angular
       badge: 'runningTasks',
       loader: loadTasks,
       onLoad: addTasks,
+      afterLoad: runningTasksLoaded,
       lazy: true,
     }));
 

--- a/app/scripts/modules/netflix/ci/ci.controller.js
+++ b/app/scripts/modules/netflix/ci/ci.controller.js
@@ -28,9 +28,13 @@ module.exports = angular.module('spinnaker.netflix.ci.controller', [
       }
     };
 
+    dataSource.activate();
     dataSource.ready().then(this.getBuilds);
     dataSource.onRefresh($scope, this.getBuilds);
 
-    $scope.$on('$destroy', () => CiFilterModel.searchFilter = '');
+    $scope.$on('$destroy', () => {
+      CiFilterModel.searchFilter = '';
+      dataSource.deactivate();
+    });
   });
 

--- a/app/scripts/modules/netflix/ci/ci.dataSource.js
+++ b/app/scripts/modules/netflix/ci/ci.dataSource.js
@@ -37,6 +37,7 @@ module.exports = angular
         label: 'CI',
         optional: true,
         optIn: true,
+        lazy: true,
         description: 'Container-based continuous integration (alpha)',
         loader: loadBuilds,
         onLoad: buildsLoaded,


### PR DESCRIPTION
A few fixes/improvements:
 * Clarifying the `visible` field's role: if set on a data source, it should not contribute to the application's `ready` state, although it should refresh when the application is refreshed. This prevents failure to load the badges from loading the rest of the application.
 * Adding an `afterLoad` method to data sources. I noticed the running tasks and executions do not show up on affected server groups for an entire application refresh cycle, since the data is added to the data source _after_ the `onLoad` method is called.
 * Setting the CI data source to lazy. There's no need to load the CI data unless the user is on the CI tab.