### PR TITLE
(Openstack) Clear floatingNetworkId correctly.

### DIFF
--- a/app/scripts/modules/openstack/serverGroup/configure/ServerGroupCommandBuilder.js
+++ b/app/scripts/modules/openstack/serverGroup/configure/ServerGroupCommandBuilder.js
@@ -20,6 +20,7 @@ module.exports = angular.module('spinnaker.openstack.serverGroupCommandBuilder.s
           application: application.name,
           credentials: defaultCredentials,
           region: defaultRegion,
+          associatePublicIpAddress: false,
           strategy: '',
           stack: '',
           freeFormDetails: '',
@@ -105,7 +106,7 @@ module.exports = angular.module('spinnaker.openstack.serverGroupCommandBuilder.s
           angular.extend(command, {
             instanceType: serverGroup.launchConfig.instanceType,
             associatePublicIpAddress: serverGroup.launchConfig.associatePublicIpAddress,
-            ramdiskId: serverGroup.launchConfig.ramdiskId,
+            floatingNetworkId: serverGroup.launchConfig.floatingNetworkId
           });
 
           command.securityGroups = serverGroup.launchConfig.securityGroups || [];
@@ -140,4 +141,3 @@ module.exports = angular.module('spinnaker.openstack.serverGroupCommandBuilder.s
       buildServerGroupCommandFromPipeline: buildServerGroupCommandFromPipeline
     };
   });
-

--- a/app/scripts/modules/openstack/serverGroup/configure/wizard/access/AccessSettings.controller.js
+++ b/app/scripts/modules/openstack/serverGroup/configure/wizard/access/AccessSettings.controller.js
@@ -22,6 +22,8 @@ module.exports = angular.module('spinnaker.serverGroup.configure.openstack.acces
   $scope.$watch('application.loadBalancers', $scope.updateLoadBalancers);
   $scope.updateLoadBalancers();
 
+  $scope.$watch('command.associatePublicIpAddress', resetFloatingNetworkIp);
+
   // Loads all security groups in the current region and account
   $scope.updateSecurityGroups = function() {
     $scope.allSecurityGroups = getSecurityGroups();
@@ -44,4 +46,9 @@ module.exports = angular.module('spinnaker.serverGroup.configure.openstack.acces
     return _.get($scope.command.backingData, 'filtered.securityGroups', []);
   }
 
+  function resetFloatingNetworkIp() {
+    if ($scope.command.associatePublicIpAddress === false) {
+      $scope.command.floatingNetworkId = undefined;
+    }
+  }
 });

--- a/app/scripts/modules/openstack/serverGroup/configure/wizard/access/accessSettings.html
+++ b/app/scripts/modules/openstack/serverGroup/configure/wizard/access/accessSettings.html
@@ -45,11 +45,6 @@
           No
         </label>
       </div>
-      <div class="col-md-2 radio">
-        <label>
-          <input type="radio" ng-model="command.associatePublicIpAddress" ng-value="null"/>
-          Default
-        </label>
       </div>
     </div>
 

--- a/app/scripts/modules/openstack/serverGroup/details/serverGroupDetails.html
+++ b/app/scripts/modules/openstack/serverGroup/details/serverGroupDetails.html
@@ -161,9 +161,6 @@
         <dt ng-if="ctrl.serverGroup.image.properties.kernel_id">Kernel ID</dt>
         <dd ng-if="ctrl.serverGroup.image.properties.kernel_id">{{ctrl.serverGroup.image.properties.kernel_id}}</dd>
 
-        <dt ng-if="ctrl.serverGroup.image.properties.ramdisk_id">Ramdisk ID</dt>
-        <dd ng-if="ctrl.serverGroup.image.properties.ramdisk_id">{{ctrl.serverGroup.image.properties.ramdisk_id}}</dd>
-
         <dt ng-if="ctrl.serverGroup.launchConfig.associatePublicIpAddress">Floating IP Network</dt>
         <dd ng-if="ctrl.serverGroup.launchConfig.associatePublicIpAddress">{{ctrl.floatingNetworkName || ctrl.serverGroup.launchConfig.floatingNetworkId}} <span ng-if="ctrl.floatingNetworkName">({{ctrl.serverGroup.launchConfig.floatingNetworkId}})</span></dd>
       </dl>


### PR DESCRIPTION
The radio button to enable adding a fip to each instance or not did not
clear out the selection. Clouddriver decides to associate a fip based on
that selection being set or not. So, clearing it when choosing not have
one.