### PR TITLE
Removes run as user UI elements in trigger-from-pipeline config

### DIFF
--- a/app/scripts/modules/core/pipeline/config/triggers/pipeline/pipelineTrigger.html
+++ b/app/scripts/modules/core/pipeline/config/triggers/pipeline/pipelineTrigger.html
@@ -56,11 +56,4 @@
       <checklist items="statusOptions" model="trigger.status" inline="true"></checklist>
     </div>
   </div>
-
-  <div class="form-group" ng-if="pipelineTriggerCtrl.fiatEnabled">
-    <run-as-user-selector service-accounts="pipelineTriggerCtrl.serviceAccounts"
-                          component="trigger"
-                          field="runAsUser">
-    </run-as-user-selector>
-  </div>
 </div>

--- a/app/scripts/modules/core/pipeline/config/triggers/pipeline/pipelineTrigger.module.js
+++ b/app/scripts/modules/core/pipeline/config/triggers/pipeline/pipelineTrigger.module.js
@@ -8,7 +8,6 @@ module.exports = angular.module('spinnaker.core.pipeline.config.trigger.pipeline
   require('../../services/pipelineConfigService.js'),
   require('../../pipelineConfigProvider.js'),
   require('core/application/service/applications.read.service.js'),
-  require('core/serviceAccount/serviceAccount.service.js'),
   require('../trigger.directive.js'),
   require('./pipelineTriggerOptions.directive.js'),
 ])
@@ -46,13 +45,9 @@ module.exports = angular.module('spinnaker.core.pipeline.config.trigger.pipeline
       selectorTemplate: require('./selectorTemplate.html'),
     };
   })
-  .controller('pipelineTriggerCtrl', function ($scope, trigger, pipelineConfigService, applicationReader, settings, serviceAccountService) {
+  .controller('pipelineTriggerCtrl', function ($scope, trigger, pipelineConfigService, applicationReader) {
 
     $scope.trigger = trigger;
-    this.fiatEnabled = settings.feature.fiatEnabled;
-    serviceAccountService.getServiceAccounts().then(accounts => {
-      this.serviceAccounts = accounts || [];
-    });
 
     if (!$scope.trigger.application) {
       $scope.trigger.application = $scope.application.name;


### PR DESCRIPTION
Turns out we don't need runAsUser for pipelines triggering pipelines.

@anotherchrisberry @danielpeach 

tag: https://github.com/spinnaker/fiat/issues/114