### PR TITLE
use package.json node version on start up

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,12 +44,13 @@
     "zone.js": "^0.6.23"
   },
   "engines": {
-    "node": ">=4.0.0",
+    "node": "7.0.0",
     "npm": ">=2.0.0"
   },
   "scripts": {
     "build": "webpack --bail",
-    "start": "webpack-dev-server",
+    "start": "sh ./start.sh",
+    "start-dev-server": "webpack-dev-server",
     "test": "karma start",
     "postinstall": "typings install",
     "int": "protractor protractor.conf.js"

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+NODE_VERSION=$(node -v)
+
+if [[ $NODE_VERSION != $npm_package_engines_node ]]; then
+  if [[ -f $HOME/.nvm/nvm.sh ]]; then
+    echo "Updating your node version to $npm_package_engines_node..."
+    . $HOME/.nvm/nvm.sh
+    nvm use $npm_package_engines_node
+
+    if [[ $? != 0 ]]; then
+      echo "Installing node $npm_package_engines_node..."
+      nvm install $npm_package_engines_node
+    fi
+  else
+    echo "Trying to start Deck with node $NODE_VERSION, nvm not found..."
+  fi
+fi
+
+npm run start-dev-server


### PR DESCRIPTION
@anotherchrisberry
If you use the wrong node version, it's not at all obvious why `npm start` fails. If this approach is too heavy-handed, I could just log a loud warning if you're not using the right node version.

@skim1420 fyi