### PR TITLE
(core) allow cron configuration via UI selector

### DIFF
--- a/app/scripts/modules/core/pipeline/config/triggers/cron/cron.validator.service.js
+++ b/app/scripts/modules/core/pipeline/config/triggers/cron/cron.validator.service.js
@@ -8,6 +8,12 @@ module.exports = angular.module('spinnaker.core.pipeline.trigger.cron.validation
   .factory('cronValidationService', function(API) {
 
     function validate(expression) {
+      let segments = expression.split(' ');
+      // ignore the last segment (year) if it's '*', since it just clutters up the description
+      if (segments.length === 7 && segments[6] === '*') {
+        segments.pop();
+        expression = segments.join(' ');
+      }
       return API.one('cron').one('validate').withParams({expression: expression}, {}).get();
     }
 

--- a/app/scripts/modules/core/pipeline/config/triggers/cron/cronPicker.html
+++ b/app/scripts/modules/core/pipeline/config/triggers/cron/cronPicker.html
@@ -1,0 +1,262 @@
+<div class="cron-gen-main form-inline no-spel" ng-init="validation={messages: {}}">
+  <div class="row">
+    <div class="col-md-12">
+      <select class="form-control input-sm"
+              ng-model="state.activeTab"
+              ng-change="regenerateCron(state)"
+              ng-options="tab for tab in ['minutes', 'hourly', 'daily', 'weekly', 'monthly', 'advanced']"></select>
+    </div>
+  </div>
+  <div class="cron-gen-container">
+    <div ng-if="state.activeTab === 'minutes'">
+      <div class="row" ng-init="regenerateCron(state)">
+        <div class="col-md-12">
+          <input class="form-control input-sm"
+                 type="number"
+                 min="1"
+                 max="59"
+                 ng-change="regenerateCron(state)"
+                 ng-model="state.minutes.minutes"
+                 ng-required="state.activeTab === 'minutes'">
+          minute<span ng-if="state.minutes.minutes > 1">s</span>
+        </div>
+      </div>
+    </div>
+    <div ng-if="state.activeTab === 'hourly'">
+      <div class="row">
+        <div class="col-md-12">
+          <input type="radio"
+                 value="every"
+                 name="hourly-radio"
+                 ng-change="regenerateCron(state)"
+                 ng-model="state.hourly.subTab">
+          Every
+          <input class="form-control input-sm"
+                 type="number"
+                 min="1"
+                 max="23"
+                 ng-change="regenerateCron(state)"
+                 ng-model="state.hourly.every.hours"
+                 ng-required="state.activeTab === 'hourly' && state.hourly.subTab === 'every'">
+          hour<span ng-if="state.hourly.every.hours> 1">s</span>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-md-12">
+          <input type="radio"
+                 value="specific"
+                 ng-change="regenerateCron(state)"
+                 ng-model="state.hourly.subTab"
+                 name="hourly-radio">
+          At
+          <select class="form-control input-sm"
+                  ng-change="regenerateCron(state)"
+                  ng-model="state.hourly.specific.hours"
+                  ng-options="hour as padNumber(hour) for hour in selectOptions.hours"
+                  ng-required="state.activeTab === 'hourly' && state.hourly.subTab === 'specific'">
+          </select>
+          :
+          <select class="form-control input-sm"
+                  ng-change="regenerateCron(state)"
+                  ng-model="state.hourly.specific.minutes"
+                  ng-options="minute as padNumber(minute) for minute in selectOptions.minutes"
+                  ng-required="state.activeTab === 'hourly' && state.hourly.subTab === 'specific'">
+          </select>
+          <system-timezone></system-timezone>
+        </div>
+      </div>
+    </div>
+    <div ng-if="state.activeTab === 'daily'">
+      <div class="row">
+        <div class="col-md-12">
+          <input type="radio"
+                 value="everyDays"
+                 name="daily-radio"
+                 ng-change="regenerateCron(state)"
+                 ng-model="state.daily.subTab"
+                 checked="checked">
+          Every
+          <input class="form-control input-sm"
+                 type="number"
+                 min="1"
+                 max="31"
+                 ng-change="regenerateCron(state)"
+                 ng-model="state.daily.everyDays.days"
+                 ng-required="state.activeTab === 'daily' && state.daily.subTab === 'everyDays'">
+          day<span ng-if="state.daily.everyDays.days > 1">s</span>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-md-12">
+          <input type="radio"
+                 value="everyWeekDay"
+                 ng-change="regenerateCron(state)"
+                 ng-model="state.daily.subTab"
+                 name="daily-radio">
+          Every week day
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-md-12">
+          Start time
+          <select class="form-control input-sm"
+                  ng-change="regenerateCron(state)"
+                  ng-required="state.activeTab === 'daily'"
+                  ng-model="state.daily.hours"
+                  ng-options="hour as padNumber(hour) for hour in selectOptions.hours">
+          </select>
+          :
+          <select class="form-control input-sm"
+                  ng-change="regenerateCron(state)"
+                  ng-required="state.activeTab === 'daily'"
+                  ng-model="state.daily.minutes"
+                  ng-options="minute as padNumber(minute) for minute in selectOptions.minutes">
+          </select>
+          <system-timezone></system-timezone>
+        </div>
+      </div>
+    </div>
+    <div ng-if="state.activeTab === 'weekly'">
+      <div class="row">
+        <div class="col-md-12">
+          <div class="btn-group">
+            <label ng-repeat="day in [{k: 'SUN', l: 'Sun'}, {k: 'MON', l: 'Mon'}, {k: 'TUE', l: 'Tue'}, {k: 'WED', l: 'Wed'}, {k: 'THU', l: 'Thu'}, {k: 'FRI', l: 'Fri'}, {k: 'SAT', l: 'Sat'}]"
+                   class="btn btn-default"
+                   uib-btn-checkbox
+                   ng-class="{active: state.weekly[day.k]}"
+                   ng-click="regenerateCron(state)"
+                   ng-model="state.weekly[day.k]">{{day.l}}</label>
+          </div>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-md-12">
+          Start time
+          <select class="form-control input-sm"
+                  ng-change="regenerateCron(state)"
+                  ng-required="state.activeTab === 'weekly'"
+                  ng-model="state.weekly.hours"
+                  ng-options="hour as padNumber(hour) for hour in selectOptions.hours">
+          </select>
+          :
+          <select class="form-control input-sm"
+                  ng-change="regenerateCron(state)"
+                  ng-required="state.activeTab === 'weekly'"
+                  ng-model="state.weekly.minutes"
+                  ng-options="minute as padNumber(minute) for minute in selectOptions.minutes">
+          </select>
+          <system-timezone></system-timezone>
+        </div>
+      </div>
+    </div>
+    <div ng-if="state.activeTab === 'monthly'">
+      <div class="row">
+        <div class="col-md-12">
+          <input type="radio"
+                 value="specificDay"
+                 ng-change="regenerateCron(state)"
+                 ng-model="state.monthly.subTab"
+                 name="monthly-radio"
+                 checked="checked">
+          Day
+          <input class="form-control input-sm"
+                 type="number"
+                 min="1"
+                 max="31"
+                 ng-change="regenerateCron(state)"
+                 ng-model="state.monthly.specificDay.day"
+                 ng-required="state.activeTab === 'monthly' && state.monthly.subTab === 'specificDay'">
+          of every
+          <input class="form-control input-sm"
+                 type="number"
+                 min="1"
+                 max="11"
+                 ng-change="regenerateCron(state)"
+                 ng-model="state.monthly.specificDay.months"
+                 ng-required="state.activeTab === 'monthly' && state.monthly.subTab === 'specificDay'">
+          month<span ng-if="state.monthly.specificDay.months > 1">s</span>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-md-12">
+          <input type="radio"
+                 value="specificWeekDay"
+                 ng-change="regenerateCron(state)"
+                 ng-model="state.monthly.subTab"
+                 name="monthly-radio">
+          <select class="form-control input-sm"
+                  ng-change="regenerateCron(state)"
+                  ng-model="state.monthly.specificWeekDay.monthWeek"
+                  ng-required="state.activeTab === 'monthly' && state.monthly.subTab === 'specificWeekDay'"
+                  ng-options="monthWeek as monthWeekDisplay(monthWeek) for monthWeek in selectOptions.monthWeeks">
+          </select>
+          <select class="form-control input-sm"
+                  ng-change="regenerateCron(state)"
+                  ng-model="state.monthly.specificWeekDay.day"
+                  ng-required="state.activeTab === 'monthly' && state.monthly.subTab === 'specificWeekDay'"
+                  ng-options="day as dayDisplay(day) for day in selectOptions.days">
+          </select>
+          of every
+          <input class="form-control input-sm"
+                 type="number"
+                 min="1"
+                 max="11"
+                 ng-change="regenerateCron(state)"
+                 ng-model="state.monthly.specificWeekDay.months"
+                 ng-required="state.activeTab === 'monthly' && state.monthly.subTab === 'specificWeekDay'">
+          month<span ng-if="state.monthly.specificWeekDay.months > 1">s</span>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-md-12">
+          Start time
+          <select class="form-control input-sm"
+                  ng-change="regenerateCron(state)"
+                  ng-required="state.activeTab === 'monthly'"
+                  ng-model="state.monthly.hours"
+                  ng-options="hour as padNumber(hour) for hour in selectOptions.hours">
+          </select>
+          :
+          <select class="form-control input-sm"
+                  ng-change="regenerateCron(state)"
+                  ng-required="state.activeTab === 'monthly'"
+                  ng-model="state.monthly.minutes"
+                  ng-options="minute as padNumber(minute) for minute in selectOptions.minutes">
+          </select>
+          <system-timezone></system-timezone>
+        </div>
+      </div>
+    </div>
+    <div ng-if="state.activeTab === 'advanced'">
+      <div class="row">
+        <div class="col-md-12">
+          <strong>Expression</strong>
+          <help-field key="pipeline.config.cron.expression"></help-field>
+          <input type="text"
+                 class="form-control input-sm"
+                 cron-validator
+                 cron-validation-messages="validation.messages"
+                 ng-change="regenerateCron(state)"
+                 ng-model="state.advanced.expression">
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-md-12">
+          <p>More details about how to create these expressions can be found <a
+            href="http://www.quartz-scheduler.org/documentation/quartz-2.x/tutorials/crontrigger.html"
+            target="_blank">here</a>.</p>
+        </div>
+      </div>
+      <div class="row" ng-if="validation.messages.description && !validation.messages.error">
+        <div class="col-md-12">
+          <p><strong>Will run {{validation.messages.description}}</strong></p>
+        </div>
+      </div>
+      <div class="row slide-in" ng-if="validation.messages.error">
+        <div class="col-md-12 error-message">
+          {{validation.messages.error}}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/scripts/modules/core/pipeline/config/triggers/cron/cronTrigger.html
+++ b/app/scripts/modules/core/pipeline/config/triggers/cron/cronTrigger.html
@@ -1,30 +1,11 @@
 <ng-form name="cronForm">
-  <div class="form-group">
+  <div class="form-group" style="margin-top: 10px">
     <label class="col-md-3 sm-label-right">
-      CRON Expression
-      <help-field key="pipeline.config.cron.expression"></help-field>
+      Frequency
     </label>
-    <div class="col-md-3">
-      <input type="text" class="form-control input-sm"
-             ng-model="vm.trigger.cronExpression"
-             ng-change="vm.compressWhitespace()"
-             name="cronExpression"
-             required
-             cron-validator
-             cron-validation-messages="vm.validationMessages"
-          />
-    </div>
-  </div>
-  <div class="form-group" ng-if="vm.validationMessages.description && !cronForm.cronExpression.$invalid">
-    <div class="col-md-8 col-md-offset-3">
-      <p>(will run {{vm.validationMessages.description}})</p>
-    </div>
-  </div>
-
-
-  <div class="form-group row slide-in" ng-if="cronForm.cronExpression.$error.cronExpression">
-    <div class="col-sm-9 col-sm-offset-3 error-message">
-      {{vm.validationMessages.error}}
+    <div class="col-md-9">
+      <cron-gen ng-model="vm.trigger.cronExpression"
+                options="vm.cronOptions"></cron-gen>
     </div>
   </div>
 

--- a/app/scripts/modules/core/pipeline/config/triggers/cron/cronTrigger.less
+++ b/app/scripts/modules/core/pipeline/config/triggers/cron/cronTrigger.less
@@ -1,0 +1,10 @@
+trigger {
+  .cron-gen-main {
+    .row {
+      margin-bottom: 10px;
+    }
+    input[type="radio"] {
+      margin-right: 4px;
+    }
+  }
+}

--- a/app/scripts/modules/core/pipeline/config/triggers/cron/cronTrigger.module.js
+++ b/app/scripts/modules/core/pipeline/config/triggers/cron/cronTrigger.module.js
@@ -3,8 +3,10 @@
 let angular = require('angular');
 
 import {UUIDGenerator} from 'core/utils/uuid.service';
+import './cronTrigger.less';
 
 module.exports = angular.module('spinnaker.core.pipeline.trigger.cron', [
+    require('angular-cron-gen'),
     require('../trigger.directive.js'),
     require('core/serviceAccount/serviceAccount.service.js'),
     require('./cron.validator.directive.js'),
@@ -32,5 +34,10 @@ module.exports = angular.module('spinnaker.core.pipeline.trigger.cron', [
     this.validationMessages = {};
 
     trigger.id = trigger.id || UUIDGenerator.generateUuid();
+    trigger.cronExpression = trigger.cronExpression || '0 0 10 ? * MON-FRI *';
+
+    this.cronOptions = {
+      templateUrl: require('./cronPicker.html'),
+    };
 
   });

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "Select2": "git://github.com/select2/select2.git#3.4.8",
     "angular": "~1.5.8",
     "angular-cache": "^4.2.2",
+    "angular-cron-gen": "0.0.6",
     "angular-filter": "^0.5.4",
     "angular-hotkeys": "^1.5.0",
     "angular-marked": "0.0.17",


### PR DESCRIPTION
Heavy template customization of https://github.com/vincentjames501/angular-cron-gen to allow users to select CRON expressions via the UI, e.g.

<img width="853" alt="screen shot 2016-11-15 at 6 12 05 pm" src="https://cloud.githubusercontent.com/assets/73450/20332207/1c23dc8c-ab5f-11e6-8a4b-ac0b8d11876e.png">
<img width="851" alt="screen shot 2016-11-15 at 6 12 25 pm" src="https://cloud.githubusercontent.com/assets/73450/20332208/1c243f56-ab5f-11e6-83da-7b02f72412c4.png">
