### PR TITLE
(core) use pipeline stage as template

### DIFF
--- a/app/scripts/modules/core/domain/IPipeline.ts
+++ b/app/scripts/modules/core/domain/IPipeline.ts
@@ -1,0 +1,15 @@
+import {Trigger} from './trigger';
+import {IStage} from "./IStage";
+
+export interface IPipeline {
+  application: string;
+  id: string;
+  index: number;
+  keepWaitingPipelines: boolean;
+  lastModifiedBy: string;
+  limitConcurrent: boolean;
+  name: string;
+  parallel: boolean;
+  triggers: Trigger[];
+  stages: IStage[];
+}

--- a/app/scripts/modules/core/domain/IStage.ts
+++ b/app/scripts/modules/core/domain/IStage.ts
@@ -1,0 +1,5 @@
+export interface IStage {
+  name: string;
+  type: string;
+  refId: string;
+}

--- a/app/scripts/modules/core/domain/index.ts
+++ b/app/scripts/modules/core/domain/index.ts
@@ -10,3 +10,5 @@ export * from './instanceCounts';
 export * from './ISecurityGroup';
 export * from './ICredentials';
 export * from './IVpc';
+export * from './IStage';
+export * from './IPipeline';

--- a/app/scripts/modules/core/pipeline/config/copyStage/copyStage.modal.controller.ts
+++ b/app/scripts/modules/core/pipeline/config/copyStage/copyStage.modal.controller.ts
@@ -1,0 +1,98 @@
+import {flatten} from 'lodash';
+import {module} from 'angular';
+
+import {API_SERVICE, Api} from 'core/api/api.service';
+import {Application} from 'core/application/application.model';
+import {COPY_STAGE_CARD_COMPONENT} from './copyStageCard.component';
+import {IPipeline, IStage} from 'core/domain/index';
+
+import './copyStage.modal.less';
+
+interface IStageWrapper {
+  pipeline: string;
+  stage: IStage;
+}
+
+class CopyStageModalCtrl implements ng.IComponentController {
+  public applications: Application[];
+  public stages: IStageWrapper[];
+  public viewState = { loading: true, error: false };
+  public selectedStage: IStageWrapper;
+
+  private uncopiableStageTypes: Set<string> = new Set(['deploy']);
+
+  static get $inject() { return ['$q', 'API', 'application', 'applicationReader', '$uibModalInstance']; }
+
+  constructor (private $q: ng.IQService,
+               private API: Api,
+               public application: Application,
+               private applicationReader: any,
+               private $uibModalInstance: any) { }
+
+  public $onInit (): void {
+    this.$q.all({
+      stages: this.getStagesForApplication(this.application.name),
+      applications: this.applicationReader.listApplications(),
+    })
+    .then(({ stages, applications }) => {
+      this.stages = stages;
+      this.applications = applications;
+      this.viewState.loading = false;
+      this.viewState.error = false;
+    })
+    .catch(() => {
+      this.viewState.loading = false;
+      this.viewState.error = true;
+    });
+  }
+
+  public onApplicationSelect (selected: Application): void {
+    this.viewState.loading = true;
+    this.getStagesForApplication(selected.name)
+      .then((stages) => {
+        this.stages = stages;
+        this.viewState.loading = false;
+        this.viewState.error = false;
+      })
+      .catch(() => {
+        this.viewState.loading = false;
+        this.viewState.error = true;
+      });
+  }
+
+  public cancel (): void {
+    this.$uibModalInstance.dismiss();
+  }
+
+  public copyStage (): void {
+    this.$uibModalInstance.close(this.selectedStage.stage);
+  }
+
+  private getStagesForApplication (applicationName: string): ng.IPromise<IStageWrapper[]> {
+    return this.API.one('applications')
+      .one(applicationName)
+      .all('pipelineConfigs')
+      .getList()
+      .then((pipelines: IPipeline[]) => {
+        let nestedStageWrappers = pipelines
+          .map((pipeline) => {
+            return (pipeline.stages || [])
+              .filter((stage: IStage) => !this.uncopiableStageTypes.has(stage.type))
+              .map((stage: IStage) => {
+                return { pipeline: pipeline.name, stage: stage };
+              });
+          });
+
+        return flatten(nestedStageWrappers);
+      });
+  }
+}
+
+export const COPY_STAGE_MODAL_CONTROLLER = 'spinnaker.core.copyStage.modal.controller';
+
+module(COPY_STAGE_MODAL_CONTROLLER, [
+    API_SERVICE,
+    COPY_STAGE_CARD_COMPONENT,
+    require('core/application/service/applications.read.service.js'),
+  ])
+  .controller('CopyStageModalCtrl', CopyStageModalCtrl);

--- a/app/scripts/modules/core/pipeline/config/copyStage/copyStage.modal.html
+++ b/app/scripts/modules/core/pipeline/config/copyStage/copyStage.modal.html
@@ -1,0 +1,66 @@
+<div modal-page class="copy-stage-modal">
+  <modal-close dismiss="$dismiss()"></modal-close>
+  <div class="modal-header">
+    <h3>Copy Stage</h3>
+  </div>
+  <div class="modal-body">
+    <div class="alert alert-danger" ng-if="copyStageModalCtrl.viewState.error">
+      <p>Could not load stages.</p>
+    </div>
+    <form role="form" name="form" class="form-horizontal" ng-submit="copyStageModalCtrl.copyStage()">
+      <div class="form-group">
+        <div class="col-md-3 sm-label-right">
+          <b>From Application</b>
+        </div>
+        <div class="col-md-7">
+          <ui-select class="form-control input-sm"
+                     on-select="copyStageModalCtrl.onApplicationSelect($item)"
+                     ng-model="copyStageModalCtrl.application">
+            <ui-select-match>
+              <span>{{$select.selected.name}}</span>
+            </ui-select-match>
+            <ui-select-choices repeat="application in copyStageModalCtrl.applications | filter: $select.search">
+              <span ng-bind-html="application.name"></span>
+            </ui-select-choices>
+          </ui-select>
+        </div>
+      </div>
+      <div class="form-group">
+        <div class="col-md-3 sm-label-right">
+          <b>Copy Stage</b>
+        </div>
+        <div class="col-md-7" ng-if="!copyStageModalCtrl.viewState.loading && copyStageModalCtrl.stages.length > 0">
+          <ui-select ng-model="copyStageModalCtrl.selectedStage"
+                     class="form-control input-sm bordered-choices">
+            <ui-select-match>
+              <span>{{$select.selected.stage.name}}</span>
+            </ui-select-match>
+            <ui-select-choices repeat="stageWrapper in copyStageModalCtrl.stages | filter: $select.search">
+              <copy-stage-card stage-wrapper="stageWrapper"></copy-stage-card>
+            </ui-select-choices>
+          </ui-select>
+        </div>
+        <div class="col-md-7" ng-if="copyStageModalCtrl.viewState.loading" style="margin-top: 5px;">
+          <h3 us-spinner="{radius:4, width:2, length: 2}"></h3>
+        </div>
+        <div class="col-md-7 no-stages-message" ng-if="copyStageModalCtrl.stages.length === 0">
+          <p>This application has no stages.</p>
+        </div>
+      </div>
+    </form>
+    <div class="row">
+      <div class="col-md-offset-3 col-md-7">
+        <div class="well">
+          <p class="small">It is not possible to copy a deploy stage, and deploy stages will not be included in the list above.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="modal-footer">
+    <button class="btn btn-default" ng-click="copyStageModalCtrl.cancel()">Cancel</button>
+    <button class="btn btn-primary"
+            ng-click="copyStageModalCtrl.copyStage()">
+      <span class="glyphicon glyphicon-ok-circle"></span> Copy Stage
+    </button>
+  </div>
+</div>

--- a/app/scripts/modules/core/pipeline/config/copyStage/copyStage.modal.less
+++ b/app/scripts/modules/core/pipeline/config/copyStage/copyStage.modal.less
@@ -1,0 +1,26 @@
+.bordered-choices {
+  .ui-select-choices-row-inner {
+    border-bottom: 1px solid #ddd;
+  }
+}
+
+copy-stage-card {
+  p {
+    margin: 0;
+  }
+}
+
+.copy-stage-modal {
+  .no-stages-message {
+    padding: .5rem 2rem;
+  }
+
+  .well {
+    margin-bottom: 0;
+    padding: 10px;
+
+    p {
+      margin: 0;
+    }
+  }
+}

--- a/app/scripts/modules/core/pipeline/config/copyStage/copyStageCard.component.ts
+++ b/app/scripts/modules/core/pipeline/config/copyStage/copyStageCard.component.ts
@@ -1,0 +1,34 @@
+import {module} from 'angular';
+
+import {CLOUD_PROVIDER_LOGO} from 'core/cloudProvider/cloudProviderLogo.component';
+
+class CopyStageCardComponent implements ng.IComponentOptions {
+  public bindings: any = {
+    stageWrapper: '<'
+  };
+  public template: string = `
+    <div class="row">
+      <div class="col-md-10">
+        <b>{{::$ctrl.stageWrapper.stage.name}}</b>
+      </div>
+      <div class="col-md-2">
+        <cloud-provider-logo ng-if="$ctrl.stageWrapper.stage.cloudProviderType"
+                             class="pull-right"
+                             height="10px"
+                             width="10px"
+                             provider="$ctrl.stageWrapper.stage.cloudProviderType">
+        </cloud-provider-logo>
+      </div>
+    </div>
+    <p><b>Type:</b> {{::$ctrl.stageWrapper.stage.type | robotToHuman}}</p>
+    <p><b>Pipeline:</b> {{::$ctrl.stageWrapper.pipeline}}</p>
+    <p class="small">{{::$ctrl.stageWrapper.stage.comments}}</p>
+  `;
+}
+
+export const COPY_STAGE_CARD_COMPONENT = 'spinnaker.core.copyStageCard.component';
+
+module(COPY_STAGE_CARD_COMPONENT, [
+    CLOUD_PROVIDER_LOGO,
+  ])
+  .component('copyStageCard', new CopyStageCardComponent());

--- a/app/scripts/modules/core/pipeline/config/pipelineConfigurer.html
+++ b/app/scripts/modules/core/pipeline/config/pipelineConfigurer.html
@@ -77,13 +77,22 @@
         <pipeline-graph view-state="viewState" pipeline="pipeline" on-node-click="pipelineConfigurerCtrl.navigateTo"></pipeline-graph>
       </div>
       <div class="row">
-        <div class="col-md-12">
+        <div class="col-md-8">
           <button class="btn btn-block btn-sm add-new"
                   analytics-on="click"
                   analytics-category="Pipeline Config"
                   analytics-event="Add stage button clicked"
                   ng-click="pipelineConfigurerCtrl.addStage()">
             <span class="glyphicon glyphicon-plus-sign"></span> Add stage
+          </button>
+        </div>
+        <div class="col-md-4">
+          <button class="btn btn-block btn-sm add-new"
+                  analytics-on="click"
+                  analytics-category="Pipeline Config"
+                  analytics-event="Copy existing stage button clicked"
+                  ng-click="pipelineConfigurerCtrl.copyExistingStage()">
+            <span class="glyphicon glyphicon-share-alt"></span> Copy an existing stage
           </button>
         </div>
       </div>

--- a/app/scripts/modules/core/pipeline/config/pipelineConfigurer.js
+++ b/app/scripts/modules/core/pipeline/config/pipelineConfigurer.js
@@ -69,8 +69,7 @@ module.exports = angular.module('spinnaker.core.pipeline.config.pipelineConfigur
       });
     };
 
-    this.addStage = function() {
-      var newStage = { isNew: true };
+    this.addStage = function(newStage = { isNew: true }) {
       $scope.pipeline.stages = $scope.pipeline.stages || [];
       if ($scope.pipeline.parallel) {
         newStage.refId = Math.max(0, ...$scope.pipeline.stages.map(s => Number(s.refId) || 0)) + 1 + '';
@@ -81,6 +80,17 @@ module.exports = angular.module('spinnaker.core.pipeline.config.pipelineConfigur
       }
       $scope.pipeline.stages.push(newStage);
       this.navigateToStage($scope.pipeline.stages.length - 1);
+    };
+
+    this.copyExistingStage = function() {
+      $uibModal.open({
+        templateUrl: require('./copyStage/copyStage.modal.html'),
+        controller: 'CopyStageModalCtrl',
+        controllerAs: 'copyStageModalCtrl',
+        resolve: {
+          application: () => $scope.application,
+        }
+      }).result.then(stageTemplate => ctrl.addStage(stageTemplate));
     };
 
     var ctrl = this;

--- a/app/scripts/modules/core/pipeline/pipelines.module.js
+++ b/app/scripts/modules/core/pipeline/pipelines.module.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import {AUTHENTICATION} from 'core/authentication/authentication.module';
+import {COPY_STAGE_MODAL_CONTROLLER} from './config/copyStage/copyStage.modal.controller';
 
 let angular = require('angular');
 
@@ -11,6 +12,7 @@ module.exports = angular.module('spinnaker.core.pipeline', [
   require('./config/pipelineConfig.module.js'),
   require('../cache/viewStateCache.js'),
   AUTHENTICATION,
+  COPY_STAGE_MODAL_CONTROLLER,
   require('../notification/notifications.module.js'),
   require('../cache/deckCacheFactory.js'),
 ]);


### PR DESCRIPTION
@duftler @anotherchrisberry please review.

Allows a pipeline stage to be copied from one pipeline to another.
![copy_stage_modal](https://cloud.githubusercontent.com/assets/13868700/20367375/336ac6da-ac1d-11e6-921c-813e8a16f9d0.png)
![existing_stage_button](https://cloud.githubusercontent.com/assets/13868700/20367406/4c8d48f4-ac1d-11e6-8707-6c13907a2204.png)
