### PR TITLE
(aws) do not overwrite subnet in cluster config if read-only

### DIFF
--- a/app/scripts/modules/amazon/subnet/subnetSelectField.directive.html
+++ b/app/scripts/modules/amazon/subnet/subnetSelectField.directive.html
@@ -13,6 +13,6 @@
       <option ng-if="activeSubnets.length && deprecatedSubnets.length" disabled>---------------</option>
       <option ng-repeat="subnet in deprecatedSubnets | orderBy: 'label'" value="{{subnet.purpose}}" ng-selected="component[field] === subnet.purpose">{{subnet.label}}</option>
     </select>
-    <p ng-if="readOnly" class="form-control-static">{{component[field]}}</p>
+    <p ng-if="readOnly" class="form-control-static">{{component[field] || 'None (EC2 Classic)'}}</p>
   </div>
 </div>

--- a/app/scripts/modules/amazon/subnet/subnetSelectField.directive.js
+++ b/app/scripts/modules/amazon/subnet/subnetSelectField.directive.js
@@ -44,7 +44,7 @@ module.exports = angular.module('spinnaker.subnet.subnetSelectField.directive', 
           scope.activeSubnets = subnets.filter(function(subnet) { return !subnet.deprecated; });
           scope.deprecatedSubnets = subnets.filter(function(subnet) { return subnet.deprecated; });
           if (subnets.length) {
-            if (!scope.component[scope.field]) {
+            if (!scope.component[scope.field] && !scope.readOnly) {
               scope.component[scope.field] = subnets[0].purpose;
             }
           }


### PR DESCRIPTION
Otherwise, the user might think there's a subnet configured when there isn't one.