### PR TITLE
(aws) call onChange when subnet selector initialized

### DIFF
--- a/app/scripts/modules/amazon/subnet/subnetSelectField.directive.js
+++ b/app/scripts/modules/amazon/subnet/subnetSelectField.directive.js
@@ -46,6 +46,9 @@ module.exports = angular.module('spinnaker.subnet.subnetSelectField.directive', 
           if (subnets.length) {
             if (!scope.component[scope.field] && !scope.readOnly) {
               scope.component[scope.field] = subnets[0].purpose;
+              if (scope.onChange) {
+                scope.onChange();
+              }
             }
           }
         }


### PR DESCRIPTION
Fixes an issue where the load balancer's `isInternal` flag was not being displayed when the Create Load Balancer modal first opens

cc @robzienert 