### PR TITLE
(kubernetes) restyle resize stage selectors

### DIFF
--- a/app/scripts/modules/kubernetes/pipeline/stages/resizeAsg/resizeStage.html
+++ b/app/scripts/modules/kubernetes/pipeline/stages/resizeAsg/resizeStage.html
@@ -1,4 +1,4 @@
-<div ng-controller="kubernetesResizeStageController as resizeStageCtrl">
+<div ng-controller="kubernetesResizeStageController as resizeStageCtrl" class="kubernetes-resize-stage">
   <div ng-if="!pipeline.strategy">
     <div ng-if="viewState.loading">
       <h4 class="text-center">
@@ -37,40 +37,40 @@
     </stage-config-field>
     <div class="form-group" ng-if="stage.resizeType === 'pct'">
       <div class="col-md-9 col-md-offset-3">
-        <label class="col-md-2 sm-label-right" style="margin-left:0;padding-left:0">Resize Percentage</label>
-        <div class="col-md-2">
-          <input type="number" min="0" ng-model="stage.scalePct" class="form-control input-sm"/>
+        <label class="col-md-2 sm-label-right small nested-label">Resize Percentage</label>
+        <div class="col-md-3">
+          <div class="input-group input-group-sm">
+            <input type="number" min="0" ng-model="stage.scalePct" class="form-control input-sm"/><span class="input-group-addon">%</span>
+          </div>
         </div>
       </div>
       <div class="col-md-9 col-md-offset-3">
-        <em class="subinput-note">This is the percentage by which the target server group's capacity will be scaled</em>
+        <em class="subinput-note small">This is the percentage by which the target server group's capacity will be scaled</em>
       </div>
     </div>
     <div class="form-group" ng-if="stage.resizeType === 'incr'">
       <div class="col-md-9 col-md-offset-3">
-        <label class="col-md-2 sm-label-right" style="margin-left:0;padding-left:0">Resize-by Amount</label>
-        <div class="col-md-2">
+        <label class="col-md-2 sm-label-right small nested-label">Resize-by Amount</label>
+        <div class="col-md-3">
           <input type="number" min="0" ng-model="stage.scaleNum" class="form-control input-sm"/>
         </div>
       </div>
 
       <div class="col-md-9 col-md-offset-3">
-        <em class="subinput-note">This is the exact amount by which the target server group's capacity will be scaled</em>
+        <em class="subinput-note small">This is the exact amount by which the target server group's capacity will be scaled</em>
       </div>
     </div>
   </div>
   <div class="form-group" ng-if="stage.action === 'scale_exact'">
     <div class="col-md-9 col-md-offset-3">
-      <label class="col-md-2 sm-label-right" style="margin-left:0;padding-left:0">Match Capacity</label>
-      <div class="col-md-9">
-        <div class="col-md-2">
-          <input type="number" ng-model="stage.capacity.desired" class="form-control input-sm"/>
-        </div>
+      <label class="col-md-2 sm-label-right small nested-label">Match Capacity</label>
+      <div class="col-md-3">
+        <input type="number" ng-model="stage.capacity.desired" class="form-control input-sm"/>
       </div>
     </div>
 
     <div class="col-md-9 col-md-offset-3">
-      <em class="subinput-note">This is the exact amount to which the target server group will be scaled</em>
+      <em class="subinput-note small">This is the exact amount to which the target server group will be scaled</em>
     </div>
   </div>
   <stage-platform-health-override application="application"

--- a/app/scripts/modules/kubernetes/pipeline/stages/resizeAsg/resizeStage.js
+++ b/app/scripts/modules/kubernetes/pipeline/stages/resizeAsg/resizeStage.js
@@ -3,6 +3,8 @@
 let angular = require('angular');
 import {ACCOUNT_SERVICE} from 'core/account/account.service';
 
+import './resizeStage.less';
+
 module.exports = angular.module('spinnaker.core.pipeline.stage.kubernetes.resizeStage', [
   require('core/application/modal/platformHealthOverride.directive.js'),
   ACCOUNT_SERVICE,

--- a/app/scripts/modules/kubernetes/pipeline/stages/resizeAsg/resizeStage.less
+++ b/app/scripts/modules/kubernetes/pipeline/stages/resizeAsg/resizeStage.less
@@ -1,0 +1,7 @@
+.kubernetes-resize-stage {
+  .nested-label {
+    margin-left: 0;
+    margin-top: 7px;
+    padding: 0;
+  }
+}


### PR DESCRIPTION
@lwander or @skim1420 
The new pipeline edit stage layout squashed some of the resize stage fields.

<img width="626" alt="screen shot 2016-11-23 at 9 20 09 am" src="https://cloud.githubusercontent.com/assets/13868700/20565370/49b35ffa-b15f-11e6-970d-ffe3e4d216fd.png">
