### PR TITLE
makes resize stage match capacity inputs wider

### DIFF
--- a/app/scripts/modules/amazon/pipeline/stages/resizeAsg/resizeAsgStage.html
+++ b/app/scripts/modules/amazon/pipeline/stages/resizeAsg/resizeAsgStage.html
@@ -68,22 +68,22 @@
   <div class="form-group" ng-if="stage.action === 'scale_exact'">
     <div class="col-md-9 col-md-offset-3 small">
       <div class="col-md-9">
-        <div class="col-md-2 col-md-offset-3">Min</div>
-        <div class="col-md-2">Max</div>
-        <div class="col-md-2">Desired</div>
+        <div class="col-md-3 col-md-offset-3">Min</div>
+        <div class="col-md-3">Max</div>
+        <div class="col-md-3">Desired</div>
       </div>
     </div>
     <div class="col-md-9 col-md-offset-3">
       <label class="col-md-2 sm-label-right small" style="margin-left:0;padding-left:0">Match Capacity</label>
 
       <div class="col-md-9">
-        <div class="col-md-2">
+        <div class="col-md-3">
           <input type="number" ng-model="stage.capacity.min" class="form-control input-sm"/>
         </div>
-        <div class="col-md-2">
+        <div class="col-md-3">
           <input type="number" ng-model="stage.capacity.max" class="form-control input-sm"/>
         </div>
-        <div class="col-md-2">
+        <div class="col-md-3">
           <input type="number" ng-model="stage.capacity.desired" class="form-control input-sm"/>
         </div>
       </div>

--- a/app/scripts/modules/cloudfoundry/pipeline/stages/resizeAsg/resizeAsgStage.html
+++ b/app/scripts/modules/cloudfoundry/pipeline/stages/resizeAsg/resizeAsgStage.html
@@ -27,23 +27,23 @@
     <div class="form-group" ng-if="stage.action === 'scale_exact'">
       <div class="col-md-9 col-md-offset-3 small">
         <div class="col-md-9">
-          <div class="col-md-2 col-md-offset-3">Instances</div>
-          <div class="col-md-2">Memory (MB)</div>
-          <div class="col-md-2">Disk Limit (MB)</div>
+          <div class="col-md-3 col-md-offset-3">Instances</div>
+          <div class="col-md-3">Memory (MB)</div>
+          <div class="col-md-3">Disk Limit (MB)</div>
         </div>
       </div>
       <div class="col-md-9 col-md-offset-3">
         <label class="col-md-2 sm-label-right small" style="margin-left:0;padding-left:0">Match Capacity</label>
         <div class="col-md-9">
-          <div class="col-md-2">
+          <div class="col-md-3">
             <input type="number" ng-model="stage.newSize"
                    class="form-control input-sm" />
           </div>
-          <div class="col-md-2">
+          <div class="col-md-3">
             <input type="number" ng-model="stage.memory"
                    class="form-control input-sm" />
           </div>
-          <div class="col-md-2">
+          <div class="col-md-3">
             <input type="number" ng-model="stage.disk"
                    class="form-control input-sm" />
           </div>

--- a/app/scripts/modules/google/pipeline/stages/resizeAsg/resizeAsgStage.html
+++ b/app/scripts/modules/google/pipeline/stages/resizeAsg/resizeAsgStage.html
@@ -64,21 +64,21 @@
   <div class="form-group" ng-if="stage.action === 'scale_exact'">
     <div class="col-md-9 col-md-offset-3 small">
       <div class="col-md-9">
-        <div class="col-md-2 col-md-offset-3">Min</div>
-        <div class="col-md-2">Max</div>
-        <div class="col-md-2">Desired</div>
+        <div class="col-md-3 col-md-offset-3">Min</div>
+        <div class="col-md-3">Max</div>
+        <div class="col-md-3">Desired</div>
       </div>
     </div>
     <div class="col-md-9 col-md-offset-3">
       <label class="col-md-2 sm-label-right small" style="margin-left:0;padding-left:0">Match Capacity</label>
       <div class="col-md-9">
-        <div class="col-md-2">
+        <div class="col-md-3">
           <input type="number" ng-model="stage.capacity.min" class="form-control input-sm"/>
         </div>
-        <div class="col-md-2">
+        <div class="col-md-3">
           <input type="number" ng-model="stage.capacity.max" class="form-control input-sm"/>
         </div>
-        <div class="col-md-2">
+        <div class="col-md-3">
           <input type="number" ng-model="stage.capacity.desired" class="form-control input-sm"/>
         </div>
       </div>

--- a/app/scripts/modules/openstack/pipeline/stages/resizeAsg/resizeAsgStage.html
+++ b/app/scripts/modules/openstack/pipeline/stages/resizeAsg/resizeAsgStage.html
@@ -68,22 +68,22 @@
   <div class="form-group" ng-if="stage.action === 'scale_exact'">
     <div class="col-md-9 col-md-offset-3 small">
       <div class="col-md-9">
-        <div class="col-md-2 col-md-offset-3">Min</div>
-        <div class="col-md-2">Max</div>
-        <div class="col-md-2">Desired</div>
+        <div class="col-md-3 col-md-offset-3">Min</div>
+        <div class="col-md-3">Max</div>
+        <div class="col-md-3">Desired</div>
       </div>
     </div>
     <div class="col-md-9 col-md-offset-3">
       <label class="col-md-2 sm-label-right small" style="margin-left:0;padding-left:0">Match Capacity</label>
 
       <div class="col-md-9">
-        <div class="col-md-2">
+        <div class="col-md-3">
           <input type="number" min="0" max="{{stage.capacity.desired}}" ng-model="stage.capacity.min" class="form-control input-sm"/>
         </div>
-        <div class="col-md-2">
+        <div class="col-md-3">
           <input type="number" min="{{stage.capacity.desired}}" ng-model="stage.capacity.max" class="form-control input-sm"/>
         </div>
-        <div class="col-md-2">
+        <div class="col-md-3">
           <input type="number" min="{{stage.capacity.min}}" max="{{stage.capacity.max}}" ng-model="stage.capacity.desired" class="form-control input-sm"/>
         </div>
       </div>

--- a/app/scripts/modules/titus/pipeline/stages/resizeAsg/resizeAsgStage.html
+++ b/app/scripts/modules/titus/pipeline/stages/resizeAsg/resizeAsgStage.html
@@ -68,22 +68,22 @@
   <div class="form-group" ng-if="stage.action === 'scale_exact'">
     <div class="col-md-9 col-md-offset-3 small">
       <div class="col-md-9">
-        <div class="col-md-2 col-md-offset-3">Min</div>
-        <div class="col-md-2">Max</div>
-        <div class="col-md-2">Desired</div>
+        <div class="col-md-3 col-md-offset-3">Min</div>
+        <div class="col-md-3">Max</div>
+        <div class="col-md-3">Desired</div>
       </div>
     </div>
     <div class="col-md-9 col-md-offset-3">
       <label class="col-md-2 sm-label-right small" style="margin-left:0;padding-left:0">Match Capacity</label>
 
       <div class="col-md-9">
-        <div class="col-md-2">
+        <div class="col-md-3">
           <input type="number" ng-model="stage.capacity.min" class="form-control input-sm"/>
         </div>
-        <div class="col-md-2">
+        <div class="col-md-3">
           <input type="number" ng-model="stage.capacity.max" class="form-control input-sm"/>
         </div>
-        <div class="col-md-2">
+        <div class="col-md-3">
           <input type="number" ng-model="stage.capacity.desired" class="form-control input-sm"/>
         </div>
       </div>


### PR DESCRIPTION
@duftler or @anotherchrisberry 

The "match capacity" fields are a little too small, and it's hard to see values longer than one digit. I've made the changes for all providers, except Kubernetes, which does not have a comparable set of fields.

![min_max_desired](https://cloud.githubusercontent.com/assets/13868700/20766365/3b2d5c1a-b704-11e6-944e-70cb8ea4ebcb.png)
