### PR TITLE
(core) show stopped stages in lighter red

### DIFF
--- a/app/scripts/modules/core/delivery/executionGroup/execution/execution.less
+++ b/app/scripts/modules/core/delivery/executionGroup/execution/execution.less
@@ -1,18 +1,6 @@
 @import "../../../presentation/less/imports/commonImports.less";
 
 execution {
-  .label-succeeded {
-    background-color: @healthy_green_border;
-  }
-  .label-terminal, .label-terminated {
-    background-color: @unhealthy_red;
-  }
-  .label-failed_continue {
-    background-color: @stage-failed_continue;
-  }
-  .label-running, .label-launched {
-    background-color: @spinnaker-blue;
-  }
   .label {
     text-transform: uppercase;
     border-radius: 0;
@@ -21,6 +9,24 @@ execution {
     .glyphicon {
       color: #ffffff;
     }
+    &.label-succeeded {
+      background-color: @healthy_green_border;
+    }
+    &.label-terminal, &.label-terminated {
+      background-color: @unhealthy_red;
+    }
+    &.label-failed_continue {
+      background-color: @stage-failed_continue;
+      color: @text-color;
+    }
+    &.label-running, &.label-launched {
+      background-color: @spinnaker-blue;
+    }
+    &.label-stopped {
+      background-color: @stage-stopped;
+      color: @text-color;
+    }
+
   }
   .timestamp {
     color: @mid_grey;

--- a/app/scripts/modules/core/delivery/executions/executions.less
+++ b/app/scripts/modules/core/delivery/executions/executions.less
@@ -105,4 +105,14 @@ executions {
     fill: @stage-succeeded;
     background-color: @stage-succeeded;
   }
+  &.execution-marker-stopped {
+    fill: @stage-stopped;
+    background-color: @stage-stopped;
+  }
+  &.execution-marker-stopped {
+    &.stage-type-checkpreconditions, &.stage-type-manualjudgment {
+      fill: @stage-stopped-intentional;
+      background-color: @stage-stopped-intentional;
+    }
+  }
 }

--- a/app/scripts/modules/core/presentation/less/imports/colors.less
+++ b/app/scripts/modules/core/presentation/less/imports/colors.less
@@ -63,6 +63,7 @@
 @stage-succeeded: #769D3E;
 @stage-terminal: #b82525;
 @stage-failed_continue: #ffe63b;
+@stage-stopped: lighten(@unhealthy_red, 33%);
 @stage-running: #2275b8;
 @stage-default: #cccccc;
-@stage-stopped: #777777;
+@stage-stopped-intentional: #777777;


### PR DESCRIPTION
<img width="445" alt="screen shot 2016-12-01 at 11 37 43 am" src="https://cloud.githubusercontent.com/assets/73450/20812117/3e2c55f8-b7c5-11e6-9321-b17ac9279982.png">

Check preconditions and manual judgment stages will still be a darker gray when the judgment was "Stop"
<img width="318" alt="screen shot 2016-12-01 at 11 41 25 am" src="https://cloud.githubusercontent.com/assets/73450/20812118/3e2ea7b8-b7c5-11e6-914c-789307aa8fb7.png">
