### PR TITLE
Added configurable trigger with sensible defaults for help-field directive.

### DIFF
--- a/app/scripts/modules/core/help/helpField.directive.html
+++ b/app/scripts/modules/core/help/helpField.directive.html
@@ -6,6 +6,6 @@
         ng-mouseenter="tooltipShown()"
         ng-mouseleave="tooltipHidden()"
         popover-placement="{{contents.placement}}"
-        popover-trigger="mouseenter focus">
+        popover-trigger="{{trigger}}">
   <span class="small glyphicon glyphicon-question-sign"></span>
 </a>

--- a/app/scripts/modules/core/help/helpField.directive.js
+++ b/app/scripts/modules/core/help/helpField.directive.js
@@ -34,7 +34,8 @@ module.exports = angular
         fallback: '@',
         content: '@',
         placement: '@',
-        expand: '='
+        expand: '=',
+        trigger: '@'
       },
       link: {
         pre: function (scope) {
@@ -42,9 +43,10 @@ module.exports = angular
             if (!scope.content && scope.key) {
               scope.content = helpContentsRegistry.getHelpField(scope.key) || helpContents[scope.key] || scope.fallback;
             }
+            scope.trigger = scope.trigger || 'mouseenter focus';
             scope.contents = {
               content: scope.content,
-              placement: scope.placement || 'top'
+              placement: scope.placement || 'top',
             };
           }
           applyContents();


### PR DESCRIPTION
Need to make the trigger configurable for the fast porperty scope constraints help text.

If no trigger is set on the directive then the previously hardcoded 'mouseenter foucus'  trigger is used.

@icfantv @anotherchrisberry PTAL