### PR TITLE
(core) calculate extra label lines on jenkins/bake stages

### DIFF
--- a/app/scripts/modules/amazon/pipeline/stages/bake/awsBakeStage.js
+++ b/app/scripts/modules/amazon/pipeline/stages/bake/awsBakeStage.js
@@ -20,6 +20,9 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.aws.bakeStage', [
       templateUrl: require('./bakeStage.html'),
       executionDetailsUrl: require('./bakeExecutionDetails.html'),
       executionLabelTemplateUrl: require('core/pipeline/config/stages/bake/bakeExecutionLabel.html'),
+      extraLabelLines: (stage) => {
+        return stage.masterStage.context.allPreviouslyBaked || stage.masterStage.context.somePreviouslyBaked ? 1 : 0;
+      },
       defaultTimeoutMs: 60 * 60 * 1000, // 60 minutes
       validators: [
         { type: 'requiredField', fieldName: 'package', },

--- a/app/scripts/modules/azure/pipeline/stages/bake/azureBakeStage.js
+++ b/app/scripts/modules/azure/pipeline/stages/bake/azureBakeStage.js
@@ -20,6 +20,9 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.azure.bakeStage',
       templateUrl: require('./bakeStage.html'),
       executionDetailsUrl: require('./bakeExecutionDetails.html'),
       executionLabelTemplateUrl: require('core/pipeline/config/stages/bake/bakeExecutionLabel.html'),
+      extraLabelLines: (stage) => {
+        return stage.masterStage.context.allPreviouslyBaked || stage.masterStage.context.somePreviouslyBaked ? 1 : 0;
+      },
       defaultTimeoutMs: 60 * 60 * 1000, // 60 minutes
       validators: [
         { type: 'requiredField', fieldName: 'package', },

--- a/app/scripts/modules/core/delivery/service/executions.transformer.service.js
+++ b/app/scripts/modules/core/delivery/service/executions.transformer.service.js
@@ -262,6 +262,7 @@ module.exports = angular.module('spinnaker.core.delivery.executionTransformer.se
       var stageConfig = pipelineConfig.getStageConfig(stage);
       if (stageConfig) {
         stage.labelTemplateUrl = stageConfig.executionLabelTemplateUrl || executionBarLabelTemplate;
+        stage.extraLabelLines = stageConfig.extraLabelLines;
       }
     }
 

--- a/app/scripts/modules/core/pipeline/config/graph/pipeline.graph.directive.js
+++ b/app/scripts/modules/core/pipeline/config/graph/pipeline.graph.directive.js
@@ -262,7 +262,8 @@ module.exports = angular.module('spinnaker.core.pipeline.config.graph.directive'
           scope.graphHeight = 0;
           scope.nodes.forEach(function(nodes) {
             nodes.forEach(function(node) {
-              placeholderNode.html('<a href>' + node.name + '</a>');
+              const extraLines = node.extraLabelLines ? '<div>x</div>'.repeat(node.extraLabelLines) : '';
+              placeholderNode.html('<a href>' + node.name + extraLines + '</a>');
               node.height = placeholderNode.height() + scope.rowPadding;
             });
             scope.graphHeight = Math.max(_.sumBy(nodes, 'height'), scope.graphHeight);

--- a/app/scripts/modules/core/pipeline/config/graph/pipelineGraph.service.js
+++ b/app/scripts/modules/core/pipeline/config/graph/pipelineGraph.service.js
@@ -21,6 +21,7 @@ module.exports = angular
           stage: stage,
           masterStage: stage.masterStage,
           labelTemplateUrl: stage.labelTemplateUrl,
+          extraLabelLines: stage.extraLabelLines ? stage.extraLabelLines(stage) : 0,
           parents: [],
           children: [],
           parentLinks: [],

--- a/app/scripts/modules/core/pipeline/config/stages/bake/bakeExecutionLabel.html
+++ b/app/scripts/modules/core/pipeline/config/stages/bake/bakeExecutionLabel.html
@@ -1,6 +1,5 @@
 <span class="stage-label">
   {{ stage.name }}
-  {{ stage.context | json}}
   <span class="small" ng-if="stage.masterStage.context.allPreviouslyBaked">
     <br/>
     (previously baked)

--- a/app/scripts/modules/core/pipeline/config/stages/jenkins/jenkinsStage.js
+++ b/app/scripts/modules/core/pipeline/config/stages/jenkins/jenkinsStage.js
@@ -18,6 +18,13 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.jenkinsStage', [
       templateUrl: require('./jenkinsStage.html'),
       executionDetailsUrl: require('./jenkinsExecutionDetails.html'),
       executionLabelTemplateUrl: require('./jenkinsExecutionLabel.html'),
+      extraLabelLines: (stage) => {
+        if (!stage.masterStage.context || !stage.masterStage.context.buildInfo) {
+          return 0;
+        }
+        let lines = stage.masterStage.context.buildInfo.number ? 1 : 0;
+        return lines + (stage.masterStage.context.buildInfo.testResults || []).length;
+      },
       defaultTimeoutMs: 2 * 60 * 60 * 1000, // 2 hours
       validators: [
         { type: 'requiredField', fieldName: 'job', },

--- a/app/scripts/modules/docker/pipeline/stages/bake/dockerBakeStage.js
+++ b/app/scripts/modules/docker/pipeline/stages/bake/dockerBakeStage.js
@@ -24,6 +24,9 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.docker.bakeStage'
       templateUrl: require('./bakeStage.html'),
       executionDetailsUrl: require('./bakeExecutionDetails.html'),
       executionLabelTemplateUrl: require('core/pipeline/config/stages/bake/bakeExecutionLabel.html'),
+      extraLabelLines: (stage) => {
+        return stage.masterStage.context.allPreviouslyBaked || stage.masterStage.context.somePreviouslyBaked ? 1 : 0;
+      },
       defaultTimeoutMs: 60 * 60 * 1000, // 60 minutes
       validators: [
         { type: 'requiredField', fieldName: 'package', },

--- a/app/scripts/modules/google/pipeline/stages/bake/gceBakeStage.js
+++ b/app/scripts/modules/google/pipeline/stages/bake/gceBakeStage.js
@@ -20,6 +20,9 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.gce.bakeStage', [
       templateUrl: require('./bakeStage.html'),
       executionDetailsUrl: require('./bakeExecutionDetails.html'),
       executionLabelTemplateUrl: require('core/pipeline/config/stages/bake/bakeExecutionLabel.html'),
+      extraLabelLines: (stage) => {
+        return stage.masterStage.context.allPreviouslyBaked || stage.masterStage.context.somePreviouslyBaked ? 1 : 0;
+      },
       defaultTimeoutMs: 60 * 60 * 1000, // 60 minutes
       validators: [
         { type: 'requiredField', fieldName: 'package', },

--- a/app/scripts/modules/openstack/pipeline/stages/bake/openstackBakeStage.js
+++ b/app/scripts/modules/openstack/pipeline/stages/bake/openstackBakeStage.js
@@ -20,6 +20,9 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.openstack.bakeSta
       templateUrl: require('./bakeStage.html'),
       executionDetailsUrl: require('./bakeExecutionDetails.html'),
       executionLabelTemplateUrl: require('core/pipeline/config/stages/bake/bakeExecutionLabel.html'),
+      extraLabelLines: (stage) => {
+        return stage.masterStage.context.allPreviouslyBaked || stage.masterStage.context.somePreviouslyBaked ? 1 : 0;
+      },
       defaultTimeoutMs: 60 * 60 * 1000, // 60 minutes
       validators: [
         { type: 'requiredField', fieldName: 'package', },


### PR DESCRIPTION
If a Jenkins stage has test results, we add a new line to the stage label in the graph for each set of test results. Also, if it has a build number (and if it has test results, it probably has a build number), we also add a line for that. When we calculate the height of the label (to draw the pipeline graph), we currently don't take those extra lines into consideration, so the labels just bleed on top of each other and you can't see the full results without hovering over the label or clicking on the stage, which kind of defeats the purpose of showing them in the label.

Adding a simple check to stages with custom labels that span multiple lines to take those extra lines into consideration.

This has been bugging for a long time and I've been waiting for someone to complain about it but nobody has so I'm fixing it anyway.