### PR TITLE
(core) guard against null cluster in filtering

### DIFF
--- a/app/scripts/modules/core/pipeline/config/preconditions/selector/preconditionSelector.directive.js
+++ b/app/scripts/modules/core/pipeline/config/preconditions/selector/preconditionSelector.directive.js
@@ -59,7 +59,7 @@ module.exports = angular.module('spinnaker.core.pipeline.config.preconditions.se
         return;
       }
 
-      let accountFilter = (cluster) => cluster.account === $scope.precondition.context.credentials;
+      let accountFilter = (cluster) => cluster ? cluster.account === $scope.precondition.context.credentials : true;
       $scope.regions = appListExtractorService.getRegions([$scope.application], accountFilter);
 
       //Setting cloudProvider when account is updated

--- a/app/scripts/modules/core/widgets/accountNamespaceClusterSelector.component.js
+++ b/app/scripts/modules/core/widgets/accountNamespaceClusterSelector.component.js
@@ -33,7 +33,7 @@ module.exports = angular
         let namespaces;
 
         let setNamespaceList = () => {
-          let accountFilter = (cluster) => cluster.account === vm.component.credentials;
+          let accountFilter = (cluster) => cluster ? cluster.account === vm.component.credentials : true;
           // TODO(lwander): Move away from regions to namespaces here.
           let namespaceList = appListExtractorService.getRegions([vm.application], accountFilter);
           vm.namespaces = namespaceList.length ? namespaceList : namespaces;

--- a/app/scripts/modules/core/widgets/accountRegionClusterSelector.component.js
+++ b/app/scripts/modules/core/widgets/accountRegionClusterSelector.component.js
@@ -36,9 +36,7 @@ module.exports = angular
         let regions;
 
         let setRegionList = () => {
-          let accountFilter = (cluster) => {
-            return cluster ? cluster.account === vm.component.credentials : true;
-          };
+          let accountFilter = (cluster) => cluster ? cluster.account === vm.component.credentials : true;
           let regionList = appListExtractorService.getRegions([vm.application], accountFilter);
           vm.regions = showAllRegions ? regions : regionList.length ? regionList : regions;
         };

--- a/app/scripts/modules/kubernetes/namespace/multiSelectField.component.js
+++ b/app/scripts/modules/kubernetes/namespace/multiSelectField.component.js
@@ -32,7 +32,7 @@ module.exports = angular
         let namespaces;
 
         let setNamespaceList = () => {
-          let accountFilter = (cluster) => cluster.account === vm.component.credentials;
+          let accountFilter = (cluster) => cluster ? cluster.account === vm.component.credentials : true;
           let namespaceList = appListExtractorService.getRegions([vm.application], accountFilter);
           vm.namespaces = namespaceList.length ? namespaceList : namespaces;
         };

--- a/app/scripts/modules/netflix/pipeline/stage/quickPatchAsg/quickPatchAsgStage.js
+++ b/app/scripts/modules/netflix/pipeline/stage/quickPatchAsg/quickPatchAsgStage.js
@@ -46,7 +46,7 @@ module.exports = angular.module('spinnaker.netflix.pipeline.stage.quickPatchAsgS
     });
 
     $scope.accountUpdated = function() {
-      let accountFilter = (cluster) => cluster.account === $scope.stage.credentials;
+      let accountFilter = (cluster) => cluster ? cluster.account === $scope.stage.credentials : true;
 
       $scope.regions = appListExtractorService.getRegions([$scope.application], accountFilter)
         .map((region) => ({name: region}));


### PR DESCRIPTION
@zanthrash PTAL. I just copied the logic from `accountRegionClusterSelector.component.js` into the other places with similar logic, not sure if this is totally correct.