### PR TITLE
(core) provide more context when waiting for up instances in deploy s…

### DIFF
--- a/app/scripts/modules/amazon/aws.module.js
+++ b/app/scripts/modules/amazon/aws.module.js
@@ -67,6 +67,7 @@ module.exports = angular.module('spinnaker.aws', [
         cloneServerGroupController: 'awsCloneServerGroupCtrl',
         commandBuilder: 'awsServerGroupCommandBuilder',
         configurationService: 'awsServerGroupConfigurationService',
+        scalingActivitiesEnabled: true,
       },
       instance: {
         instanceTypeService: 'awsInstanceTypeService',

--- a/app/scripts/modules/core/healthCounts/healthCounts.directive.js
+++ b/app/scripts/modules/core/healthCounts/healthCounts.directive.js
@@ -31,7 +31,7 @@ module.exports = angular.module('spinnaker.core.healthCounts.directive', [
             succeeded = container.succeeded || 0,
             failed = container.failed || 0,
             unknown = container.unknown || 0,
-            total = up + down + unknown + succeeded + failed,
+            total = container.total || up + down + unknown + succeeded + failed,
             healthPercent = total ? parseInt((up + succeeded) * 100 / total) : 'n/a';
 
           scope.healthPercent = healthPercent;

--- a/app/scripts/modules/core/healthCounts/healthCounts.less
+++ b/app/scripts/modules/core/healthCounts/healthCounts.less
@@ -28,22 +28,29 @@
   }
 }
 
-.instance-health-counts, .securityGroup-counts {
-  .pull-right;
-  padding-left: 5px;
-}
-.instance-health-counts {
-  .glyphicon {
-    top: 0;
+health-counts {
+  .instance-health-counts {
+    float: right;
+    padding-left: 5px;
   }
-  .healthy {
-    color: #8cad6e;
+  &.no-float {
+    .instance-health-counts {
+      float: none;
+    }
   }
-  .unhealthy {
-    color: @unhealthy_orange;
-  }
-  .dead {
-    color: #D9534F;
+  .instance-health-counts {
+    .glyphicon {
+      top: 0;
+    }
+    .healthy {
+      color: #8cad6e;
+    }
+    .unhealthy {
+      color: @unhealthy_orange;
+    }
+    .dead {
+      color: #D9534F;
+    }
   }
 }
 

--- a/app/scripts/modules/core/naming/naming.service.ts
+++ b/app/scripts/modules/core/naming/naming.service.ts
@@ -52,6 +52,16 @@ export class NamingService {
     return clusterName;
   }
 
+  public getClusterNameFromServerGroupName(serverGroupName: string): string {
+    const split = serverGroupName.split('-'),
+      isVersioned = this.VERSION_PATTERN.test(split[split.length - 1]);
+
+    if (isVersioned) {
+      split.pop();
+    }
+    return split.join('-');
+  }
+
   public getSequence(serverGroupName: string): string {
     const split = serverGroupName.split('-'),
       isVersioned = this.VERSION_PATTERN.test(split[split.length - 1]);

--- a/app/scripts/modules/core/pipeline/config/stages/deploy/deployExecutionDetails.html
+++ b/app/scripts/modules/core/pipeline/config/stages/deploy/deployExecutionDetails.html
@@ -41,6 +41,44 @@
     </div>
     <stage-failure-message stage="stage" message="stage.failureMessage"></stage-failure-message>
 
+    <div class="well alert-info" ng-if="showWaitingMessage">
+      <p ng-if="waitingForUpInstances">
+        <strong>
+          Waiting for {{stage.context.targetDesiredSize}} instance<span ng-if="stage.context.targetDesiredSize !== 1">s</span> to appear healthy.
+        </strong>
+        <br/>
+        <span ng-if="stage.context.lastCapacityCheck.total === 0">
+            (no instances found yet)
+        </span>
+        <span ng-if="stage.context.lastCapacityCheck.total !== 0">
+          ( current status: <health-counts container="stage.context.lastCapacityCheck" class="no-float"></health-counts>)
+        </span>
+      </p>
+      <div ng-if="showScalingActivitiesLink">
+        <p>
+          If your instances are not launching, there might be a problem with your configuration.
+        </p>
+        <p>
+          <strong>
+            <view-scaling-activities-link server-group="scalingActivitiesTarget"></view-scaling-activities-link>
+          </strong>
+          to troubleshoot common configuration issues.
+        </p>
+      </div>
+      <div ng-if="showPlatformHealthOverrideMessage">
+        <p>
+          By default, Spinnaker does not consider cloud provider health (i.e. whether your instances have launched and are running)
+          as a reliable indicator of instance health.
+        </p>
+        <p>
+          If your instances do not provide a health indicator known to Spinnaker
+          (e.g. a discovery service or load balancers), you should configure your application to
+          consider only cloud provider health when executing tasks. This option is available under Application Attributes
+          in the <a ui-sref="home.applications.application.config({application: application.name})">Config tab</a>.
+        </p>
+      </div>
+    </div>
+
     <div class="row" ng-if="deployed.length">
       <div class="col-md-12">
         <div class="well alert alert-info">

--- a/app/scripts/modules/core/serverGroup/serverGroup.read.service.js
+++ b/app/scripts/modules/core/serverGroup/serverGroup.read.service.js
@@ -21,7 +21,7 @@ module.exports = angular
         .all('scalingActivities')
         .withParams({
           region: serverGroup.region,
-          provider: serverGroup.provider
+          provider: serverGroup.cloudProvider
         })
         .getList()
         .then(function(activities) {


### PR DESCRIPTION
…tage

Conditionally adds one or more messages to the deployment stage details:
<img width="488" alt="screen shot 2016-12-04 at 4 29 08 pm" src="https://cloud.githubusercontent.com/assets/73450/20870646/852673b2-ba40-11e6-9aeb-69182ff245df.png">

1. If the "wait for up instances" task is running and we've got some instances reporting _something_, we'll show the first message to provide a status update.

2. Additionally, for AWS, we'll show the second message ("If your instances are not launching...") after three minutes if the total number of instances does not match the configured desired capacity. This is meant to help users diagnose issues with their launch configuration or capacity issues that are preventing instances from launching. We also show this message if the task failed and the above criteria are met.

3. If, after three minutes, all instances are in an unknown state and the application is not already configured with the platformHealthOverride flag, we'll show the third message ("By default, Spinnaker does not consider cloud provider health..."). We show this message if the task failed and the above criteria are met.

Open to suggestions on wording and other scenarios we might want to flag.

PTAL @duftler @spinnaker/netflix-reviewers 
