### PR TITLE
(core) do not set header to 100% when un-stickying

### DIFF
--- a/app/scripts/modules/core/application/application.less
+++ b/app/scripts/modules/core/application/application.less
@@ -5,7 +5,7 @@
   margin-bottom: 0;
   background-color: #f8f8f8;
   flex: 0 0 auto;
-  z-index: 3;
+  z-index: 5;
   .application-name {
     display: inline-block;
   }

--- a/app/scripts/modules/core/utils/stickyHeader/stickyHeader.less
+++ b/app/scripts/modules/core/utils/stickyHeader/stickyHeader.less
@@ -9,7 +9,6 @@
   }
   .not-sticky {
     top: unset;
-    width: 100%;
     z-index: 3;
   }
 }


### PR DESCRIPTION
Fixes an issue where un-stuck execution headers sometimes appear shorter.