### PR TITLE
(netflix) show manual failure message on canary stage

### DIFF
--- a/app/scripts/modules/netflix/pipeline/stage/canary/canaryStage.transformer.js
+++ b/app/scripts/modules/netflix/pipeline/stage/canary/canaryStage.transformer.js
@@ -25,6 +25,12 @@ module.exports = angular.module('spinnaker.netflix.pipeline.stage.canary.transfo
 
     function getException (stage) {
       orchestratedItemTransformer.defineProperties(stage);
+      if (stage.isFailed && _.has(stage, 'context.canary.canaryResult')) {
+        let result = stage.context.canary.canaryResult;
+        if (result.overallResult === 'FAILURE' && result.message) {
+          return `Canary terminated by user. Reason: ${result.message}`;
+        }
+      }
       return stage.isFailed ? stage.failureMessage : null;
     }
 


### PR DESCRIPTION
If the user manually halts a canary stage, we currently do not surface the message they enter, so the stage failure message is:
```Monitor Canary failure: Orchestration completed.```
which is not very helpful.

This PR surfaces the message the user entered, so they'll see, e.g.
```Monitor Canary failure: Canary terminated by user. Reason: Bad features metadata jar.```