### PR TITLE
(core) display hidden stage if it fails

### DIFF
--- a/app/scripts/modules/core/delivery/details/defaultExecutionDetails.html
+++ b/app/scripts/modules/core/delivery/details/defaultExecutionDetails.html
@@ -1,0 +1,7 @@
+<div class="step-section-details">
+  <div class="row">
+    <execution-step-details item="stage"></execution-step-details>
+  </div>
+</div>
+
+<stage-failure-message stage="stage" message="stage.failureMessage"></stage-failure-message>

--- a/app/scripts/modules/core/delivery/details/executionDetails.controller.js
+++ b/app/scripts/modules/core/delivery/details/executionDetails.controller.js
@@ -69,9 +69,10 @@ module.exports = angular.module('spinnaker.executionDetails.controller', [
           $scope.stageSummary = stageSummary;
           $scope.stage = step;
           var stageConfig = pipelineConfig.getStageConfig(step);
-          if (stageConfig) {
-            return stageConfig.executionDetailsUrl || null;
+          if (stageConfig && stageConfig.executionDetailsUrl) {
+            return stageConfig.executionDetailsUrl;
           }
+          return require('./defaultExecutionDetails.html');
         }
       }
       return null;

--- a/app/scripts/modules/core/delivery/service/executions.transformer.service.js
+++ b/app/scripts/modules/core/delivery/service/executions.transformer.service.js
@@ -124,9 +124,8 @@ module.exports = angular.module('spinnaker.core.delivery.executionTransformer.se
 
     function flattenAndFilter(stage) {
       return flattenStages([], stage)
-        .filter(function(stage) {
-          return !hiddenStageTypes.includes(stage.type) && stage.initializationStage !== true;
-        });
+        .filter(stage => stage.isFailed ||
+          (!hiddenStageTypes.includes(stage.type) && stage.initializationStage !== true));
     }
 
     function getCurrentStages(execution) {

--- a/app/scripts/modules/core/domain/taskStep.ts
+++ b/app/scripts/modules/core/domain/taskStep.ts
@@ -1,3 +1,4 @@
 export interface TaskStep {
   name: string;
+  status: string;
 }

--- a/app/scripts/modules/core/task/displayableTasks.filter.ts
+++ b/app/scripts/modules/core/task/displayableTasks.filter.ts
@@ -9,7 +9,7 @@ export function displayableTaskFilter() {
   return function (input: TaskStep[]): TaskStep[] {
     if (input) {
       return input.filter((test: TaskStep) => {
-        return !blacklist.includes(test.name);
+        return !blacklist.includes(test.name) || test.status === 'TERMINAL';
       });
     }
   };


### PR DESCRIPTION
If a hidden stage (e.g. `determineTargetServerGroup`) fails, it's not surfaced in the UI, and the stage summary has in incorrect status, so it's not marked as terminal (since it's derived from the child stages).

Also providing a very generic default template for stages that have no template, which just surfaces the tasks and any failure message.