### PR TITLE
pin Typescript to 2.0.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "ts-loader": "^0.8.2",
     "tslint": "^3.15.1",
     "tslint-loader": "^2.1.5",
-    "typescript": "^2.0.7",
+    "typescript": "2.0.9",
     "typings": "^1.3.3",
     "url-loader": "^0.5.6",
     "webpack": "^1.9.11",


### PR DESCRIPTION
The latest release (2.1.4) is not compatible with codelyzer. I am honestly not sure what codelyzer is doing, but will investigate later.