### PR TITLE
(review only) how cache initializers should be written

### DIFF
--- a/app/scripts/modules/core/cache/infrastructureCacheConfig.js
+++ b/app/scripts/modules/core/cache/infrastructureCacheConfig.js
@@ -38,4 +38,6 @@ module.exports = angular.module('spinnaker.core.cache.infrastructure.config', []
     backendServices: {
       version: 2,
     },
+    credentials: {},
+    buildMasters: {},
   });


### PR DESCRIPTION
@icfantv This is what the cache initializer should be as a baseline for refactoring to TS. The problem is that the `extendConfig` call is async but is not handled as such, so...it's confusing, and kind of a miracle it works at all right now without blowing up.