### PR TITLE
(nflx): update dockerfile to remove postinstall

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,4 @@ WORKDIR deck
 
 RUN npm install
 
-RUN npm run postinstall
-
 CMD npm start


### PR DESCRIPTION
* with the conversion to at-types, the npm postinstall script is no
longer needed since typings are installed via project dependencies.