### PR TITLE
Wait for up instances fixes

### DIFF
--- a/app/scripts/modules/core/pipeline/config/stages/deploy/deployExecutionDetails.controller.js
+++ b/app/scripts/modules/core/pipeline/config/stages/deploy/deployExecutionDetails.controller.js
@@ -122,7 +122,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.deploy.details.co
     initialize();
 
     $scope.$on('$stateChangeSuccess', initialize);
-    if (_.has($scope.application, 'executions.onRefresh')) {
+    if (_.hasIn($scope.application, 'executions.onRefresh')) {
       $scope.application.executions.onRefresh($scope, initialize);
     }
 

--- a/app/scripts/modules/core/pipeline/config/stages/deploy/deployExecutionDetails.controller.js
+++ b/app/scripts/modules/core/pipeline/config/stages/deploy/deployExecutionDetails.controller.js
@@ -86,7 +86,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.deploy.details.co
         $scope.showWaitingMessage = true;
         $scope.waitingForUpInstances = activeWaitTask.status === 'RUNNING';
         const lastCapacity = stage.context.lastCapacityCheck;
-        const waitDurationExceeded = activeWaitTask.runningTimeInMs > moment.duration(3, 'minutes').asMilliseconds();
+        const waitDurationExceeded = activeWaitTask.runningTimeInMs > moment.duration(5, 'minutes').asMilliseconds();
         lastCapacity.total = lastCapacity.up + lastCapacity.down + lastCapacity.outOfService + lastCapacity.unknown + lastCapacity.succeeded + lastCapacity.failed;
 
         if (cloudProviderRegistry.getValue(stage.context.cloudProvider, 'serverGroup.scalingActivitiesEnabled')) {

--- a/app/scripts/modules/core/pipeline/config/stages/deploy/deployExecutionDetails.controller.spec.js
+++ b/app/scripts/modules/core/pipeline/config/stages/deploy/deployExecutionDetails.controller.spec.js
@@ -180,7 +180,7 @@ describe('DeployExecutionDetailsCtrl', function() {
       this.initializeController();
       expect(this.$scope.showScalingActivitiesLink).toBe(false);
 
-      this.$scope.stage.tasks[1].runningTimeInMs = 3 * 60 * 1000 + 1;
+      this.$scope.stage.tasks[1].runningTimeInMs = 5 * 60 * 1000 + 1;
       this.initializeController();
       expect(this.$scope.showScalingActivitiesLink).toBe(true);
     });
@@ -190,7 +190,7 @@ describe('DeployExecutionDetailsCtrl', function() {
       this.$scope.stage.context.capacity = { desired: 1 };
       this.$scope.stage.tasks[0].status = 'COMPLETED';
       this.$scope.stage.tasks[1].status = 'RUNNING';
-      this.$scope.stage.tasks[1].runningTimeInMs = 3 * 60 * 1000 + 1;
+      this.$scope.stage.tasks[1].runningTimeInMs = 5 * 60 * 1000 + 1;
       this.$scope.application.attributes = {};
       this.initializeController();
       expect(this.$scope.showPlatformHealthOverrideMessage).toBe(true);


### PR DESCRIPTION
* `_.has` does not check an object's prototype, so the `onRefresh` was never being configured
* three minutes is a little too short in practice to determine that instances do not register any health, so bumping it to five minutes