### PR TITLE
Use newlines so that group memberships doesn't get trailing whitespaces

### DIFF
--- a/app/scripts/modules/core/application/modal/groupMembershipConfigurer.component.html
+++ b/app/scripts/modules/core/application/modal/groupMembershipConfigurer.component.html
@@ -8,7 +8,9 @@
                style="width: 200px;"
                ng-model="$ctrl.requiredGroupMembership">
       <ui-select-match>{{$item}}</ui-select-match>
-      <ui-select-choices repeat="choice in []">{{choice}}</ui-select-choices>
+      <ui-select-choices repeat="choice in []">
+          {{choice}}
+      </ui-select-choices>
     </ui-select>
   </div>
 </div>


### PR DESCRIPTION
Before this patch, group memberships were stored in front50 with a trailing whitespace at the end. cc. @ttomsu 