### PR TITLE
(gce) Added 'enableCDN' option for L7 upsert.

### DIFF
--- a/app/scripts/modules/google/loadBalancer/configure/http/backendService/backendService.component.html
+++ b/app/scripts/modules/google/loadBalancer/configure/http/backendService/backendService.component.html
@@ -101,6 +101,15 @@
       </div>
     </div>
 
+    <div class="form-group">
+      <div class="col-md-4 sm-label-right">
+        <b>Enable CDN</b>
+      </div>
+      <div class="col-md-4">
+        <input type="checkbox" ng-model="$ctrl.backendService.enableCDN"/>
+      </div>
+    </div>
+
     <div class="form-group" ng-if="$ctrl.backendService.sessionAffinity === 'Generated Cookie'">
       <div class="col-md-4 sm-label-right">
         <b>Affinity Cookie TTL Seconds</b>


### PR DESCRIPTION
Adds checkbox for `enableCDN` for each `backendService`. 
![enablecdn](https://cloud.githubusercontent.com/assets/5456773/21196718/b00f8032-c206-11e6-803c-341e753c4643.png)
