### PR TITLE
(gce) Make L7 listeners readonly except for certs.

### DIFF
--- a/app/scripts/modules/google/loadBalancer/configure/http/listeners/listener.component.html
+++ b/app/scripts/modules/google/loadBalancer/configure/http/listeners/listener.component.html
@@ -14,6 +14,7 @@
                  ng-maxlength="63"
                  class="form-control input-sm"
                  ng-model="$ctrl.listener.name"
+                 ng-readonly="$ctrl.listener.created"
                  validate-unique="$ctrl.existingListenerNames()"
                  validate-ignore-case="true"
                  name="listenerName"/>
@@ -27,6 +28,7 @@
           <input type="text"
                  class="form-control input-sm"
                  ng-model="$ctrl.listener.stack"
+                 ng-readonly="$ctrl.listener.created"
                  name="stackName"
                  ng-change="$ctrl.updateName($ctrl.listener, $ctrl.application.name)"
                  ng-pattern="/^[a-z0-9]*$/"/>
@@ -37,6 +39,7 @@
           <input type="text"
                  class="form-control input-sm"
                  ng-model="$ctrl.listener.detail"
+                 ng-readonly="$ctrl.listener.created"
                  name="detailName"
                  ng-change="$ctrl.updateName($ctrl.listener, $ctrl.application.name)"
                  ng-pattern="/^[a-z0-9-]*$/"/>
@@ -54,7 +57,7 @@
         <div class="col-md-2 sm-label-right">Port<help-field key="gce.httpLoadBalancer.port"></help-field></div>
         <div class="col-md-3">
           <ui-select ng-model="$ctrl.listener.port"
-                     ng-disabled="$ctrl.preventPortChange()"
+                     ng-disabled="$ctrl.listener.created"
                      required
                      class="form-control input-sm">
             <ui-select-match>
@@ -71,6 +74,7 @@
           </div>
           <div class="col-md-3">
             <ui-select ng-model="$ctrl.listener.certificate"
+                       ng-disabled="$ctrl.listener.created && !$ctrl.listener.certificate"
                        required
                        class="form-control input-sm">
               <ui-select-match allow-clear placeholder="Select...">{{$select.selected}}</ui-select-match>

--- a/app/scripts/modules/google/loadBalancer/configure/http/listeners/listener.component.js
+++ b/app/scripts/modules/google/loadBalancer/configure/http/listeners/listener.component.js
@@ -15,14 +15,7 @@ module.exports = angular.module('spinnaker.deck.gce.httpLoadBalancer.listener.co
     templateUrl: require('./listener.component.html'),
     controller: function () {
       this.certificates = this.command.backingData.certificates;
-      this.originalListener = _.cloneDeep(this.listener);
       let loadBalancerMap = this.command.backingData.loadBalancerMap;
-
-      this.preventPortChange = () => {
-        return this.listener.created &&
-          this.originalListener.name === this.listener.name &&
-          (this.originalListener.port === 443 || this.originalListener.port === '443');
-      };
 
       this.getName = (listener, applicationName) => {
         let listenerName = [applicationName, (listener.stack || ''), (listener.detail || '')].join('-');


### PR DESCRIPTION
This makes all the forwarding rule attributes read-only after creation for L7 upsert. Certs can still be changed to support rotation.

![editable](https://cloud.githubusercontent.com/assets/5456773/21230866/4f0b9614-c2b4-11e6-829a-30a92880ae61.png)
