### PR TITLE
(core): prevent clobbering of cert name on error

### DIFF
--- a/app/scripts/modules/amazon/loadBalancer/configure/createLoadBalancer.controller.js
+++ b/app/scripts/modules/amazon/loadBalancer/configure/createLoadBalancer.controller.js
@@ -304,7 +304,7 @@ module.exports = angular.module('spinnaker.loadBalancer.aws.create.controller', 
     let formatListeners = () => {
       return accountService.getAccountDetails($scope.loadBalancer.credentials).then((account) => {
         $scope.loadBalancer.listeners.forEach((listener) => {
-          listener.sslCertificateId = certificateIdAsARN(account.accountId, listener.sslCertificateId,
+          listener.sslCertificateId = certificateIdAsARN(account.accountId, listener.sslCertificateName,
             $scope.loadBalancer.region, listener.sslCertificateType || this.certificateTypes[0]);
         });
       });
@@ -406,7 +406,7 @@ module.exports = angular.module('spinnaker.loadBalancer.aws.create.controller', 
       }
     };
 
-    this.showSslCertificateIdField = function() {
+    this.showSslCertificateNameField = function() {
       return $scope.loadBalancer.listeners.some(function(listener) {
         return listener.externalProtocol === 'HTTPS' || listener.externalProtocol === 'SSL';
       });

--- a/app/scripts/modules/amazon/loadBalancer/configure/createLoadBalancer.controller.spec.js
+++ b/app/scripts/modules/amazon/loadBalancer/configure/createLoadBalancer.controller.spec.js
@@ -55,23 +55,23 @@ describe('Controller: awsCreateLoadBalancerCtrl', function () {
 
     this.$scope.loadBalancer = loadBalancer;
 
-    expect(this.ctrl.showSslCertificateIdField()).toBe(false);
+    expect(this.ctrl.showSslCertificateNameField()).toBe(false);
 
     loadBalancer.listeners.push({ externalProtocol: 'HTTP' });
-    expect(this.ctrl.showSslCertificateIdField()).toBe(false);
+    expect(this.ctrl.showSslCertificateNameField()).toBe(false);
 
     loadBalancer.listeners.push({ externalProtocol: 'TCP' });
-    expect(this.ctrl.showSslCertificateIdField()).toBe(false);
+    expect(this.ctrl.showSslCertificateNameField()).toBe(false);
 
     loadBalancer.listeners.push({ externalProtocol: 'SSL' });
-    expect(this.ctrl.showSslCertificateIdField()).toBe(true);
+    expect(this.ctrl.showSslCertificateNameField()).toBe(true);
 
     loadBalancer.listeners = [{externalProtocol: 'HTTP'}];
     loadBalancer.listeners.push({ externalProtocol: 'HTTPS' });
-    expect(this.ctrl.showSslCertificateIdField()).toBe(true);
+    expect(this.ctrl.showSslCertificateNameField()).toBe(true);
 
     loadBalancer.listeners = [ { externalProtocol: 'HTTPS' }, { externalProtocol: 'HTTPS' }];
-    expect(this.ctrl.showSslCertificateIdField()).toBe(true);
+    expect(this.ctrl.showSslCertificateNameField()).toBe(true);
   });
 
   describe('prependForwardSlash', function () {

--- a/app/scripts/modules/amazon/loadBalancer/configure/listeners.html
+++ b/app/scripts/modules/amazon/loadBalancer/configure/listeners.html
@@ -9,8 +9,8 @@
           <th></th>
           <th>Internal Protocol</th>
           <th>Internal Port</th>
-          <th ng-if="ctrl.showSslCertificateIdField() && ctrl.certificateTypes.length > 1" width="10%">SSL Certificate Type</th>
-          <th ng-if="ctrl.showSslCertificateIdField()" width="30%">SSL Certificate Name</th>
+          <th ng-if="ctrl.showSslCertificateNameField() && ctrl.certificateTypes.length > 1" width="10%">SSL Certificate Type</th>
+          <th ng-if="ctrl.showSslCertificateNameField()" width="30%">SSL Certificate Name</th>
           <th></th>
         </tr>
         </thead>
@@ -26,17 +26,17 @@
                       ng-options="protocol for protocol in ['HTTP','HTTPS','TCP','SSL']"></select></td>
           <td><input class="form-control input-sm" type="number" min="0" ng-model="listener.internalPort"
                      required/></td>
-          <td ng-if="ctrl.showSslCertificateIdField() && ctrl.certificateTypes.length > 1">
+          <td ng-if="ctrl.showSslCertificateNameField() && ctrl.certificateTypes.length > 1">
             <select ng-if="(listener.externalProtocol === 'HTTPS' || listener.externalProtocol === 'SSL')"
                     class="form-control input-sm"
                     ng-model="listener.sslCertificateType"
                     ng-options="certificateType for certificateType in ['iam','acm']"></select>
           </td>
-          <td ng-if="ctrl.showSslCertificateIdField()">
+          <td ng-if="ctrl.showSslCertificateNameField()">
             <input ng-if="listener.externalProtocol === 'HTTPS' || listener.externalProtocol === 'SSL'"
                    class="form-control input-sm no-spel"
                    type="text"
-                   ng-model="listener.sslCertificateId"
+                   ng-model="listener.sslCertificateName"
                    required/></td>
           </td>
           <td><a href class="sm-label" ng-click="ctrl.removeListener($index)"><span
@@ -45,7 +45,7 @@
         </tbody>
         <tfoot>
         <tr>
-          <td colspan="{{ctrl.showSslCertificateIdField() ? 7 : 5}}">
+          <td colspan="{{ctrl.showSslCertificateNameField() ? 7 : 5}}">
             <button class="add-new col-md-12" ng-click="ctrl.addListener()"><span
               class="glyphicon glyphicon-plus-sign"></span> Add new port mapping
             </button>


### PR DESCRIPTION
* prevent the clobbering of the ELB listener's cert name with the
formatted version if an error occurs during form submission (say,
due to validation).