### PR TITLE
(appengine) url details for server groups and load balancers

### DIFF
--- a/app/scripts/modules/appengine/appengine.module.js
+++ b/app/scripts/modules/appengine/appengine.module.js
@@ -2,6 +2,7 @@ import {module} from 'angular';
 
 import {APPENGINE_CACHE_CONFIGURER} from './cache/cacheConfigurer.service';
 import {APPENGINE_CLONE_SERVER_GROUP_CTRL} from './serverGroup/configure/wizard/cloneServerGroup.controller';
+import {APPENGINE_COMPONENT_URL_DETAILS} from './common/componentUrlDetails.component';
 import {APPENGINE_HELP_CONTENTS_REGISTRY} from './helpContents/appengineHelpContents';
 import {APPENGINE_INSTANCE_DETAILS_CTRL} from './instance/details/details.controller';
 import {APPENGINE_LOAD_BALANCER_MODULE} from './loadBalancer/loadBalancer.module';
@@ -9,7 +10,7 @@ import {APPENGINE_SERVER_GROUP_BASIC_SETTINGS_CTRL} from './serverGroup/configur
 import {APPENGINE_SERVER_GROUP_COMMAND_BUILDER} from './serverGroup/configure/serverGroupCommandBuilder.service';
 import {APPENGINE_SERVER_GROUP_DETAILS_CONTROLLER} from './serverGroup/details/details.controller';
 import {APPENGINE_SERVER_GROUP_TRANSFORMER} from './serverGroup/transformer';
-import {CONDITIONAL_DESCRIPTION_LIST_ITEM} from './common/conditionalDescriptionListItem.component';
+import {APPENGINE_CONDITIONAL_DESCRIPTION_LIST_ITEM} from './common/conditionalDescriptionListItem.component';
 
 let templates = require.context('./', true, /\.html$/);
 templates.keys().forEach(function(key) {
@@ -21,6 +22,8 @@ export const APPENGINE_MODULE = 'spinnaker.appengine';
 module(APPENGINE_MODULE, [
     APPENGINE_CACHE_CONFIGURER,
     APPENGINE_CLONE_SERVER_GROUP_CTRL,
+    APPENGINE_COMPONENT_URL_DETAILS,
+    APPENGINE_CONDITIONAL_DESCRIPTION_LIST_ITEM,
     APPENGINE_HELP_CONTENTS_REGISTRY,
     APPENGINE_INSTANCE_DETAILS_CTRL,
     APPENGINE_LOAD_BALANCER_MODULE,
@@ -28,7 +31,6 @@ module(APPENGINE_MODULE, [
     APPENGINE_SERVER_GROUP_COMMAND_BUILDER,
     APPENGINE_SERVER_GROUP_DETAILS_CONTROLLER,
     APPENGINE_SERVER_GROUP_TRANSFORMER,
-    CONDITIONAL_DESCRIPTION_LIST_ITEM,
   ])
   .config((cloudProviderRegistryProvider) => {
     cloudProviderRegistryProvider.registerProvider('appengine', {

--- a/app/scripts/modules/appengine/common/componentUrlDetails.component.ts
+++ b/app/scripts/modules/appengine/common/componentUrlDetails.component.ts
@@ -1,0 +1,26 @@
+import {module, IComponentOptions} from 'angular';
+
+class AppengineComponentUrlDetailsComponent implements IComponentOptions {
+  public bindings: any = {component: '<'};
+  public template: string = `
+    <dt>HTTPS</dt>
+    <dl class="small">
+      <a href="{{$ctrl.component.httpsUrl}}" target="_blank">{{$ctrl.component.httpsUrl}}</a>
+      <copy-to-clipboard class="copy-to-clipboard copy-to-clipboard-sm"
+                         tool-tip="Copy URL to clipboard"
+                         text="{{$ctrl.component.httpsUrl}}"></copy-to-clipboard>
+    </dl>
+    <dt>HTTP</dt>
+    <dl class="small">
+      <a href="{{$ctrl.component.httpUrl}}" target="_blank">{{$ctrl.component.httpUrl}}</a>
+      <copy-to-clipboard class="copy-to-clipboard copy-to-clipboard-sm"
+                         tool-tip="Copy URL to clipboard"
+                         text="{{$ctrl.component.httpUrl}}"></copy-to-clipboard>
+    </dl>
+  `;
+}
+
+export const APPENGINE_COMPONENT_URL_DETAILS = 'spinnaker.appengine.componentUrlDetails.component';
+
+module(APPENGINE_COMPONENT_URL_DETAILS, [])
+  .component('appengineComponentUrlDetails', new AppengineComponentUrlDetailsComponent());

--- a/app/scripts/modules/appengine/common/conditionalDescriptionListItem.component.ts
+++ b/app/scripts/modules/appengine/common/conditionalDescriptionListItem.component.ts
@@ -1,6 +1,6 @@
 import {module, IComponentOptions} from 'angular';
 
-class ConditionalDescriptionListItem implements IComponentOptions {
+class AppengineConditionalDescriptionListItem implements IComponentOptions {
   public bindings: any = {label: '@', key: '@', component: '<'};
   public transclude: boolean = true;
   public template: string = `
@@ -9,7 +9,7 @@ class ConditionalDescriptionListItem implements IComponentOptions {
   `;
 }
 
-export const CONDITIONAL_DESCRIPTION_LIST_ITEM = 'spinnaker.appengine.conditionalDescriptionListItem';
+export const APPENGINE_CONDITIONAL_DESCRIPTION_LIST_ITEM = 'spinnaker.appengine.conditionalDescriptionListItem';
 
-module(CONDITIONAL_DESCRIPTION_LIST_ITEM, [])
-  .component('conditionalDtDd', new ConditionalDescriptionListItem());
+module(APPENGINE_CONDITIONAL_DESCRIPTION_LIST_ITEM, [])
+  .component('appengineConditionalDtDd', new AppengineConditionalDescriptionListItem());

--- a/app/scripts/modules/appengine/instance/details/details.html
+++ b/app/scripts/modules/appengine/instance/details/details.html
@@ -43,7 +43,7 @@
         </dd>
         <dt>Region</dt>
         <dd>{{ctrl.instance.region}}</dd>
-        <conditional-dt-dd component="ctrl.instance" key="vmZoneName" label="Zone"></conditional-dt-dd>
+        <appengine-conditional-dt-dd component="ctrl.instance" key="vmZoneName" label="Zone"></appengine-conditional-dt-dd>
       </dl>
     </collapsible-section>
     <collapsible-section heading="Status" expanded="true">
@@ -61,25 +61,25 @@
     </collapsible-section>
     <collapsible-section heading="Metrics" expanded="true">
       <dl class="dl-horizontal dl-narrow">
-        <conditional-dt-dd component="ctrl.instance" key="instanceStatus" label="Availability">
+        <appengine-conditional-dt-dd component="ctrl.instance" key="instanceStatus" label="Availability">
           <help-field key="appengine.instance.availability"></help-field>
-        </conditional-dt-dd>
-        <conditional-dt-dd component="ctrl.instance" key="averageLatency" label="Average Latency">
+        </appengine-conditional-dt-dd>
+        <appengine-conditional-dt-dd component="ctrl.instance" key="averageLatency" label="Average Latency">
           <help-field key="appengine.instance.averageLatency"></help-field>
-        </conditional-dt-dd>
-        <conditional-dt-dd component="ctrl.instance" key="errors" label="Errors">
+        </appengine-conditional-dt-dd>
+        <appengine-conditional-dt-dd component="ctrl.instance" key="errors" label="Errors">
           <help-field key="appengine.instance.errors"></help-field>
-        </conditional-dt-dd>
-        <conditional-dt-dd component="ctrl.instance" key="qps" label="QPS">
+        </appengine-conditional-dt-dd>
+        <appengine-conditional-dt-dd component="ctrl.instance" key="qps" label="QPS">
           <help-field key="appengine.instance.qps"></help-field>
-        </conditional-dt-dd>
-        <conditional-dt-dd component="ctrl.instance" key="requests" label="Requests">
+        </appengine-conditional-dt-dd>
+        <appengine-conditional-dt-dd component="ctrl.instance" key="requests" label="Requests">
           <help-field key="appengine.instance.requests"></help-field>
-        </conditional-dt-dd>
-        <conditional-dt-dd component="ctrl.instance" key="vmStatus" label="VM Status">
+        </appengine-conditional-dt-dd>
+        <appengine-conditional-dt-dd component="ctrl.instance" key="vmStatus" label="VM Status">
           <help-field key="appengine.instance.vmStatus"></help-field>
-        </conditional-dt-dd>
-        <conditional-dt-dd component="ctrl.instance" key="vmDebugEnabled" label="Debug Enabled"></conditional-dt-dd>
+        </appengine-conditional-dt-dd>
+        <appengine-conditional-dt-dd component="ctrl.instance" key="vmDebugEnabled" label="Debug Enabled"></appengine-conditional-dt-dd>
       </dl>
     </collapsible-section>
   </div>

--- a/app/scripts/modules/appengine/loadBalancer/details/details.html
+++ b/app/scripts/modules/appengine/loadBalancer/details/details.html
@@ -77,5 +77,10 @@
         </ul>
       </dl>
     </collapsible-section>
+    <collapsible-section heading="DNS" expanded="true">
+      <dl class="dl-narrow">
+        <appengine-component-url-details component="ctrl.loadBalancer"></appengine-component-url-details>
+      </dl>
+    </collapsible-section>
   </div>
 </div>

--- a/app/scripts/modules/appengine/serverGroup/details/details.html
+++ b/app/scripts/modules/appengine/serverGroup/details/details.html
@@ -90,5 +90,10 @@
         </dd>
       </dl>
     </collapsible-section>
+    <collapsible-section heading="DNS" expanded="true">
+      <dl class="dl-narrow">
+        <appengine-component-url-details component="ctrl.serverGroup"></appengine-component-url-details>
+      </dl>
+    </collapsible-section>
   </div>
 </div>


### PR DESCRIPTION
@duftler or @lwander or @jtk54 please review

Also re-scoped `conditionalDdDt` component as `appengineConditionalDdDt`.

![url_details](https://cloud.githubusercontent.com/assets/13868700/21277128/bdcfbb22-c3a2-11e6-85ee-a632862f17c7.png)
