### PR TITLE
(aws) fixing regression where ssl cert name was not show when editing a ELB

### DIFF
--- a/app/scripts/modules/amazon/loadBalancer/loadBalancer.transformer.js
+++ b/app/scripts/modules/amazon/loadBalancer/loadBalancer.transformer.js
@@ -111,6 +111,7 @@ module.exports = angular.module('spinnaker.aws.loadBalancer.transformer', [
               externalProtocol: listener.protocol,
               externalPort: listener.loadBalancerPort,
               sslCertificateId: listener.sslcertificateId,
+              sslCertificateName: listener.sslcertificateId,
               sslCertificateType: listener.sslCertificateType
             };
           });


### PR DESCRIPTION
@icfantv PTAL