### PR TITLE
(core) switch stage constants to getters

### DIFF
--- a/app/scripts/modules/core/pipeline/config/stages/stageConstants.ts
+++ b/app/scripts/modules/core/pipeline/config/stages/stageConstants.ts
@@ -5,54 +5,61 @@ export interface IStageConstant {
 }
 
 export class StageConstants {
+  public static get TARGET_LIST(): IStageConstant[] {
+    return StageConstants.targetList;
+  }
 
-  public static TARGET_LIST: IStageConstant[] =
-    Object.freeze([
-      Object.freeze({
+  public static get STRATEGY_TRAFFIC_OPTIONS(): IStageConstant[] {
+    return StageConstants.strategyTrafficOptions;
+  }
+
+  private static targetList: IStageConstant[] =
+    [
+      {
         label: 'Newest Server Group',
         val: 'current_asg_dynamic',
         description: 'Selects the most recently deployed server group when this <b>stage</b> starts.'
-      }),
-      Object.freeze({
+      },
+      {
         label: 'Previous Server Group',
         val: 'ancestor_asg_dynamic',
         description: 'Selects the second-most recently deployed server group when this <b>stage</b> starts.'
-      }),
-      Object.freeze({
+      },
+      {
         label: 'Oldest Server Group',
         val: 'oldest_asg_dynamic',
         description: 'Selects the least recently deployed server group when this <b>stage</b> starts.'
-      }),
-      Object.freeze({
+      },
+      {
         label: '(Deprecated) Current Server Group',
         val: 'current_asg',
         description: 'Selects the most recently deployed server group when the <b>pipeline</b> starts, ignoring any changes ' +
         'to the state of the cluster caused by upstream stages.'
-      }),
-      Object.freeze({
+      },
+      {
         label: '(Deprecated) Last Server Group',
         val: 'ancestor_asg',
         description: 'Selects the second-most recently deployed server group when the <b>pipeline</b> starts, ignoring any changes ' +
         'to the state of the cluster caused by upstream stages.'
-      })
-    ]);
+      }
+    ];
 
-  public static STRATEGY_TRAFFIC_OPTIONS: IStageConstant[] =
-    Object.freeze([
-      Object.freeze({
+  private static strategyTrafficOptions: IStageConstant[] =
+    [
+      {
         label: 'From Cluster Configuration',
         val: 'inherit',
         description: 'Traffic options are set in the advanced options tab of the deploy stage that calls the strategy'
-      }),
-      Object.freeze({
+      },
+      {
         label: 'Always Enable',
         description: 'Always send client requests to new instances',
         val: 'enable'
-      }),
-      Object.freeze({
+      },
+      {
         label: 'Always Disable',
         description: 'Never send client requests to new instances',
         val: 'disable'
-      })
-    ]);
+      }
+    ];
 }


### PR DESCRIPTION
@icfantv or @duftler please review

This fixes the `Target` dropdowns for pipeline stages - they are currently empty.

`Object.freeze` causes errors when Angular tries to mutate the objects - hopefully using getters here is a good enough compromise.