### PR TITLE
(core) prevent copying strategies into pipelines and vice versa

### DIFF
--- a/app/scripts/modules/core/pipeline/config/copyStage/copyStage.modal.html
+++ b/app/scripts/modules/core/pipeline/config/copyStage/copyStage.modal.html
@@ -44,7 +44,7 @@
           <h3 us-spinner="{radius:4, width:2, length: 2}"></h3>
         </div>
         <div class="col-md-7 no-stages-message" ng-if="copyStageModalCtrl.stages.length === 0">
-          <p>This application has no stages.</p>
+          <p>This application has no {{ copyStageModalCtrl.forStrategyConfig ? 'strategy' : 'pipeline' }} stages.</p>
         </div>
       </div>
     </form>

--- a/app/scripts/modules/core/pipeline/config/pipelineConfigurer.js
+++ b/app/scripts/modules/core/pipeline/config/pipelineConfigurer.js
@@ -89,6 +89,7 @@ module.exports = angular.module('spinnaker.core.pipeline.config.pipelineConfigur
         controllerAs: 'copyStageModalCtrl',
         resolve: {
           application: () => $scope.application,
+          forStrategyConfig: () => $scope.pipeline.strategy,
         }
       }).result.then(stageTemplate => ctrl.addStage(stageTemplate));
     };


### PR DESCRIPTION
@anotherchrisberry @duftler 

Matt brought up a very good point that we shouldn't be able to copy strategy stages into pipeline configs and vice versa.