### PR TITLE
(core) increase contrast range on running stage opacity animation

### DIFF
--- a/app/scripts/modules/core/presentation/less/imports/animations.less
+++ b/app/scripts/modules/core/presentation/less/imports/animations.less
@@ -23,13 +23,13 @@
 
 @-webkit-keyframes animate-glow {
   0% { opacity: 0.9; }
-  50% { opacity: 0.65; }
+  50% { opacity: 0.4; }
   100% { opacity: 0.9; }
 }
 
 @-moz-keyframes animate-glow {
   0% { opacity: 0.9; }
-  50% { opacity: 0.65; }
+  50% { opacity: 0.4; }
   100% { opacity: 0.9; }
 }
 


### PR DESCRIPTION
When a stage is running, there is a CSS animation that makes it glow, but it's very subtle and folks often don't notice is. This change just bumps the contrast to make the running stage more obvious.

Partially addresses https://github.com/spinnaker/spinnaker/issues/1327, but we still want to add some other visual indicator to manual judgment stages that are awaiting judgment.