### PR TITLE
(appengine) start and stop tasks

### DIFF
--- a/app/scripts/modules/appengine/appengine.module.js
+++ b/app/scripts/modules/appengine/appengine.module.js
@@ -10,8 +10,9 @@ import {APPENGINE_LOAD_BALANCER_MODULE} from './loadBalancer/loadBalancer.module
 import {APPENGINE_PIPELINE_MODULE} from './pipeline/pipeline.module';
 import {APPENGINE_SERVER_GROUP_BASIC_SETTINGS_CTRL} from './serverGroup/configure/wizard/basicSettings.controller';
 import {APPENGINE_SERVER_GROUP_COMMAND_BUILDER} from './serverGroup/configure/serverGroupCommandBuilder.service';
-import {APPENGINE_SERVER_GROUP_DETAILS_CONTROLLER} from './serverGroup/details/details.controller';
+import {APPENGINE_SERVER_GROUP_DETAILS_CTRL} from './serverGroup/details/details.controller';
 import {APPENGINE_SERVER_GROUP_TRANSFORMER} from './serverGroup/transformer';
+import {APPENGINE_SERVER_GROUP_WRITER} from './serverGroup/writer/serverGroup.write.service';
 
 let templates = require.context('./', true, /\.html$/);
 templates.keys().forEach(function(key) {
@@ -31,8 +32,9 @@ module(APPENGINE_MODULE, [
     APPENGINE_PIPELINE_MODULE,
     APPENGINE_SERVER_GROUP_BASIC_SETTINGS_CTRL,
     APPENGINE_SERVER_GROUP_COMMAND_BUILDER,
-    APPENGINE_SERVER_GROUP_DETAILS_CONTROLLER,
+    APPENGINE_SERVER_GROUP_DETAILS_CTRL,
     APPENGINE_SERVER_GROUP_TRANSFORMER,
+    APPENGINE_SERVER_GROUP_WRITER,
   ])
   .config((cloudProviderRegistryProvider) => {
     cloudProviderRegistryProvider.registerProvider('appengine', {

--- a/app/scripts/modules/appengine/domain/IAppengineServerGroup.ts
+++ b/app/scripts/modules/appengine/domain/IAppengineServerGroup.ts
@@ -2,4 +2,11 @@ import {ServerGroup} from 'core/domain/index';
 
 export interface IAppengineServerGroup extends ServerGroup {
   disabled: boolean;
+  env: 'FLEXIBLE' | 'STANDARD';
+  scalingPolicy: IAppengineScalingPolicy;
+  servingStatus: 'SERVING' | 'STOPPED';
+}
+
+export interface IAppengineScalingPolicy {
+  type: 'AUTOMATIC' | 'MANUAL' | 'BASIC';
 }

--- a/app/scripts/modules/appengine/serverGroup/details/details.html
+++ b/app/scripts/modules/appengine/serverGroup/details/details.html
@@ -32,6 +32,16 @@
           Server Group Actions <span class="caret"></span>
         </button>
         <ul class="dropdown-menu" uib-dropdown-menu role="menu">
+          <li ng-if="ctrl.canStopServerGroup()">
+            <a href ng-click="ctrl.stopServerGroup()">
+              Stop
+            </a>
+          </li>
+          <li ng-if="ctrl.canStartServerGroup()">
+            <a href ng-click="ctrl.startServerGroup()">
+              Start
+            </a>
+          </li>
           <li ng-if="ctrl.serverGroup.disabled">
             <a href ng-click="ctrl.enableServerGroup()">
               Enable

--- a/app/scripts/modules/appengine/serverGroup/writer/serverGroup.write.service.ts
+++ b/app/scripts/modules/appengine/serverGroup/writer/serverGroup.write.service.ts
@@ -1,0 +1,59 @@
+import {module} from 'angular';
+
+import {TASK_EXECUTOR, ITaskCommand, TaskExecutor, IJob} from 'core/task/taskExecutor';
+import {ITask} from 'core/task/task.read.service';
+import {Application} from 'core/application/application.model';
+import {IAppengineServerGroup} from 'appengine/domain/index';
+
+interface IAppengineServerGroupWriteJob extends IJob {
+  serverGroupName: string;
+  region: string;
+  credentials: string;
+  cloudProvider: string;
+}
+
+export class AppengineServerGroupWriter {
+  static get $inject() { return ['taskExecutor']; }
+
+  constructor(private taskExecutor: TaskExecutor) {}
+
+  public startServerGroup(serverGroup: IAppengineServerGroup, application: Application): ng.IPromise<ITask> {
+    let job = this.buildJob(serverGroup, application, 'startAppEngineServerGroup');
+
+    let command: ITaskCommand = {
+      job: [job],
+      application,
+      description: `Start Server Group: ${serverGroup.name}`,
+    };
+
+    return this.taskExecutor.executeTask(command);
+  }
+
+  public stopServerGroup(serverGroup: IAppengineServerGroup, application: Application): ng.IPromise<ITask> {
+    let job = this.buildJob(serverGroup, application, 'stopAppEngineServerGroup');
+
+    let command: ITaskCommand = {
+      job: [job],
+      application,
+      description: `Stop Server Group: ${serverGroup.name}`,
+    };
+
+    return this.taskExecutor.executeTask(command);
+  }
+
+  private buildJob(serverGroup: IAppengineServerGroup, application: Application, type: string): IAppengineServerGroupWriteJob {
+    return {
+      type,
+      region: serverGroup.region,
+      serverGroupName: serverGroup.name,
+      credentials: serverGroup.account,
+      cloudProvider: 'appengine',
+      application: application.name
+    };
+  }
+}
+
+export const APPENGINE_SERVER_GROUP_WRITER = 'spinnaker.appengine.serverGroup.write.service';
+
+module(APPENGINE_SERVER_GROUP_WRITER, [TASK_EXECUTOR])
+  .service('appengineServerGroupWriter', AppengineServerGroupWriter);


### PR DESCRIPTION
@duftler or @lwander please review. Depends on https://github.com/spinnaker/orca/pull/1103 and https://github.com/spinnaker/clouddriver/pull/1345.

I can't see any use case for stopping a server group that is serving traffic, but it's consistent with what the cloud console UI and gcloud allow. I've included a warning message.

<img width="570" alt="screen shot 2016-12-29 at 3 24 59 pm" src="https://cloud.githubusercontent.com/assets/13868700/21554341/eb15ee1e-cddc-11e6-89e1-e75419fbf5f1.png">
