### PR TITLE
(core) guard against missing summary when synchronizing executions

### DIFF
--- a/app/scripts/modules/core/delivery/service/execution.service.js
+++ b/app/scripts/modules/core/delivery/service/execution.service.js
@@ -278,11 +278,15 @@ module.exports = angular.module('spinnaker.core.delivery.executions.service', [
     function synchronizeExecution(current, updated) {
       (updated.stageSummaries || []).forEach((updatedSummary, idx) => {
         let currentSummary = current.stageSummaries[idx];
-        // if the stage was not already completed, update it in place if it has changed to save Angular
-        // from removing, then re-rendering every DOM node
-        if (!updatedSummary.isComplete || !current.isComplete) {
-          if (JSON.stringify(current, jsonReplacer) !== JSON.stringify(updatedSummary, jsonReplacer)) {
-            Object.assign(currentSummary, updatedSummary);
+        if (!currentSummary) {
+          current.stageSummaries.push(updatedSummary);
+        } else {
+          // if the stage was not already completed, update it in place if it has changed to save Angular
+          // from removing, then re-rendering every DOM node
+          if (!updatedSummary.isComplete || !current.isComplete) {
+            if (JSON.stringify(current, jsonReplacer) !== JSON.stringify(updatedSummary, jsonReplacer)) {
+              Object.assign(currentSummary, updatedSummary);
+            }
           }
         }
         current.stringVal = updated.stringVal;


### PR DESCRIPTION
It's extremely rare, and if we're being honest, I'm not sure how it happens, but sometimes we get an error where `currentSummary` in the code below is null, so the `Object.assign` call barfs. My guess is this happens right when a pipeline starts and we have retrieved it, and there are no stages at all, and thus the `stageSummaries` is empty.