### PR TITLE
(core) move Job interface to taskExecutor

### DIFF
--- a/app/scripts/modules/core/application/service/application.write.service.spec.ts
+++ b/app/scripts/modules/core/application/service/application.write.service.spec.ts
@@ -1,6 +1,7 @@
 import {mock} from 'angular';
 
-import {APPLICATION_WRITE_SERVICE, ApplicationWriter, IApplicationAttributes, IJob} from './application.write.service';
+import {APPLICATION_WRITE_SERVICE, ApplicationWriter, IApplicationAttributes} from './application.write.service';
+import {IJob} from 'core/task/taskExecutor';
 
 describe('Service: applicationWriter', function () {
   let applicationWriter: ApplicationWriter;

--- a/app/scripts/modules/core/application/service/application.write.service.ts
+++ b/app/scripts/modules/core/application/service/application.write.service.ts
@@ -1,15 +1,7 @@
 import {cloneDeep} from 'lodash';
 import {module} from 'angular';
 import {Application} from '../application.model';
-import {TASK_EXECUTOR, TaskExecutor} from 'core/task/taskExecutor';
-
-export interface IJob {
-  type: string;
-  application: any;
-  account?: string;
-  user?: string;
-  providerType?: string;
-}
+import {TASK_EXECUTOR, IJob, TaskExecutor} from 'core/task/taskExecutor';
 
 export interface IApplicationAttributes {
   name: string;

--- a/app/scripts/modules/core/task/taskExecutor.ts
+++ b/app/scripts/modules/core/task/taskExecutor.ts
@@ -1,14 +1,20 @@
 import {module} from 'angular';
 import {AUTHENTICATION_SERVICE, AuthenticationService} from '../authentication/authentication.service';
 import {TASK_READ_SERVICE, TaskReader, ITask} from 'core/task/task.read.service';
-import {IJob} from '../application/service/application.write.service';
 
 export interface ITaskCommand {
   application?: any;
   project?: any;
   job: IJob[];
   description: string;
+}
 
+export interface IJob {
+  type: string;
+  application: any;
+  account?: string;
+  user?: string;
+  providerType?: string;
 }
 
 export class TaskExecutor {


### PR DESCRIPTION
The `IJob` interface is generic and belongs in the taskExecutor (or maybe as a standalone file, but for now, it's at least more appropriate here).