### PR TITLE
(core) add flag feature to server groups

### DIFF
--- a/app/scripts/modules/amazon/serverGroup/details/serverGroupDetails.aws.controller.js
+++ b/app/scripts/modules/amazon/serverGroup/details/serverGroupDetails.aws.controller.js
@@ -3,6 +3,7 @@
 import _ from 'lodash';
 
 import {ACCOUNT_SERVICE} from 'core/account/account.service';
+import {ADD_ENTITY_TAG_LINKS_COMPONENT} from 'core/entityTag/addEntityTagLinks.component';
 import {CONFIRMATION_MODAL_SERVICE} from 'core/confirmationModal/confirmationModal.service';
 import {VIEW_SCALING_ACTIVITIES_LINK} from 'core/serverGroup/details/scalingActivities/viewScalingActivitiesLink.component';
 import {SERVER_GROUP_READER_SERVICE} from 'core/serverGroup/serverGroupReader.service';
@@ -22,6 +23,7 @@ module.exports = angular.module('spinnaker.serverGroup.details.aws.controller', 
   require('core/overrideRegistry/override.registry.js'),
   ACCOUNT_SERVICE,
   VIEW_SCALING_ACTIVITIES_LINK,
+  ADD_ENTITY_TAG_LINKS_COMPONENT,
   require('../../vpc/vpcTag.directive.js'),
   require('./scalingProcesses/autoScalingProcess.service.js'),
   SERVER_GROUP_READER_SERVICE,

--- a/app/scripts/modules/core/application/application.model.spec.ts
+++ b/app/scripts/modules/core/application/application.model.spec.ts
@@ -135,6 +135,7 @@ describe ('Application Model', function () {
           account: 'test',
           region: 'us-west-2',
           type: 'aws',
+          cloudProvider: 'aws',
           instances: [],
           instanceCounts: <InstanceCounts>{}
         }],

--- a/app/scripts/modules/core/chaosMonkey/chaosMonkey.help.ts
+++ b/app/scripts/modules/core/chaosMonkey/chaosMonkey.help.ts
@@ -1,5 +1,5 @@
 import {module} from 'angular';
-import {HELP_CONTENTS_REGISTRY} from 'core/help/helpContents.registry';
+import {HELP_CONTENTS_REGISTRY, HelpContentsRegistry} from 'core/help/helpContents.registry';
 
 const helpContents: any[] = [
   {
@@ -46,6 +46,6 @@ const helpContents: any[] = [
 
 export const CHAOS_MONKEY_HELP = 'spinnaker.core.chaosMonkey.help.contents';
 module(CHAOS_MONKEY_HELP, [HELP_CONTENTS_REGISTRY])
-  .run((helpContentsRegistry: any) => {
+  .run((helpContentsRegistry: HelpContentsRegistry) => {
     helpContents.forEach((entry: any) => helpContentsRegistry.register(entry.key, entry.contents));
 });

--- a/app/scripts/modules/core/core.module.js
+++ b/app/scripts/modules/core/core.module.js
@@ -23,6 +23,8 @@ require('angular-wizard/dist/angular-wizard.css');
 
 require('source-sans-pro');
 
+require('font-awesome/css/font-awesome.css');
+
 // load all templates into the $templateCache
 var templates = require.context('./', true, /\.html$/);
 templates.keys().forEach(function(key) {

--- a/app/scripts/modules/core/domain/IEntityTags.ts
+++ b/app/scripts/modules/core/domain/IEntityTags.ts
@@ -1,0 +1,35 @@
+export interface IEntityTagsMetadata {
+  name: string;
+  created: number;
+  lastModified: number;
+  createdBy: string;
+  lastModifiedBy: string;
+}
+
+export interface IEntityTag {
+  name: string;
+  value: any;
+  created?: number;
+  lastModified?: number;
+  createdBy?: string;
+  lastModifiedBy?: string;
+}
+
+export interface IEntityTags {
+  id: string;
+  idPattern?: string;
+  lastModified?: number;
+  lastModifiedBy?: string;
+  tags: IEntityTag[];
+  tagsMetadata: IEntityTagsMetadata[];
+  entityRef: IEntityRef;
+  alerts: IEntityTag[];
+  notices: IEntityTag[];
+}
+
+export interface IEntityRef {
+  cloudProvider: string;
+  entityType: string;
+  entityId: string;
+  [attribute: string]: any;
+}

--- a/app/scripts/modules/core/domain/index.ts
+++ b/app/scripts/modules/core/domain/index.ts
@@ -13,5 +13,6 @@ export * from './IVpc';
 export * from './IStage';
 export * from './IPipeline';
 export * from './instance';
-export * from './IStrategy';
+export * from './IStrategy'
+export * from './IEntityTags';
 export * from './ICluster';

--- a/app/scripts/modules/core/domain/loadBalancer.ts
+++ b/app/scripts/modules/core/domain/loadBalancer.ts
@@ -2,7 +2,7 @@ import { InstanceCounts } from './instanceCounts';
 import { Instance } from './instance';
 
 export class LoadBalancer {
-
+  public cloudProvider: string;
   constructor(
     public name?: string,
     public type?: string,
@@ -14,5 +14,7 @@ export class LoadBalancer {
     public instanceCounts?: InstanceCounts,
     public provider?: string,
     public instances?: Instance[]
-  ) { }
+  ) {
+    this.cloudProvider = this.type || this.provider;
+  }
 }

--- a/app/scripts/modules/core/domain/serverGroup.ts
+++ b/app/scripts/modules/core/domain/serverGroup.ts
@@ -1,15 +1,18 @@
-import { Instance } from './instance';
-import { InstanceCounts } from './instanceCounts';
-import { Execution } from './execution';
-import { ITask } from '../task/task.read.service';
+import {IEntityTags} from './IEntityTags';
+import {Instance} from './instance';
+import {InstanceCounts} from './instanceCounts';
+import {Execution} from './execution';
+import {ITask} from '../task/task.read.service';
+
 
 export interface ServerGroup {
   account: string;
   app?: string;
   buildInfo?: any;
   category?: string;
-  cloudProvider?: string;
+  cloudProvider: string;
   cluster: string;
+  entityTags?: IEntityTags;
   detail?: string;
   executions?: Execution[];
   instanceCounts: InstanceCounts;

--- a/app/scripts/modules/core/entityTag/addEntityTagLinks.component.ts
+++ b/app/scripts/modules/core/entityTag/addEntityTagLinks.component.ts
@@ -1,0 +1,96 @@
+import {module} from 'angular';
+import {has} from 'lodash';
+
+import {IModalService} from '../../../../types/angular-ui-bootstrap';
+
+import {IEntityTag} from 'core/domain';
+import {ENTITY_TAG_EDITOR_CTRL, EntityTagEditorCtrl} from './entityTagEditor.controller';
+import {ENTITY_TAGS_HELP} from './entityTags.help';
+import {Application} from 'core/application/application.model';
+
+import './entityTagDetails.component.less';
+import {ENTITY_TAG_WRITER, EntityTagWriter} from './entityTags.write.service';
+
+class AddEntityTagLinksCtrl implements ng.IComponentController {
+  public tags: IEntityTag[];
+  public application: Application;
+  public tagType: string;
+
+  private component: any;
+  private entityType: string;
+  private onUpdate: () => any;
+
+  static get $inject() { return ['$uibModal', 'confirmationModalService', 'entityTagWriter']; }
+
+  public constructor(private $uibModal: IModalService, private confirmationModalService: any,
+                     private entityTagWriter: EntityTagWriter) {}
+
+  public $onInit(): void {
+    if (this.component.entityTags) {
+      this.tags = this.component.entityTags.tags
+        .filter((t: IEntityTag) => has(t, 'value.type') && t.value.type === this.tagType)
+        .sort((a: IEntityTag, b: IEntityTag) => a.created - b.created);
+    }
+  }
+
+  public $onChanges(): void {
+    this.$onInit();
+  }
+
+  public addTag(tagType: string): void {
+    this.$uibModal.open({
+      templateUrl: require('./entityTagEditor.modal.html'),
+      controller: EntityTagEditorCtrl,
+      controllerAs: '$ctrl',
+      resolve: {
+        tag: (): IEntityTag => {
+          return {
+            name: null,
+            value: {
+              message: null,
+              type: tagType,
+            },
+          };
+        },
+        isNew: (): boolean => true,
+        owner: (): any => this.component,
+        entityType: (): string => this.entityType,
+        application: (): Application => this.application,
+        onUpdate: (): any => this.onUpdate,
+      }
+    });
+  }
+
+}
+
+class AddEntityTagLinksComponent implements ng.IComponentOptions {
+  public bindings: any = {
+    component: '<',
+    application: '<',
+    entityType: '@',
+    onUpdate: '&?',
+    tagType: '@',
+  };
+  public controller: any = AddEntityTagLinksCtrl;
+  public template: string = `
+    <li role="presentation" class="divider"></li>
+    <li>
+      <a href ng-click="$ctrl.addTag('notice')">
+        Add notice <help-field key="entityTags.{{$ctrl.entityType}}.notice"></help-field>
+      </a>
+    </li>
+    <li>
+      <a href ng-click="$ctrl.addTag('alert')">
+        Add alert <help-field key="entityTags.{{$ctrl.entityType}}.alert"></help-field>
+      </a>
+    </li>
+  `;
+}
+
+export const ADD_ENTITY_TAG_LINKS_COMPONENT = 'spinnaker.core.entityTag.details.component';
+module(ADD_ENTITY_TAG_LINKS_COMPONENT, [
+  ENTITY_TAG_EDITOR_CTRL,
+  ENTITY_TAG_WRITER,
+  ENTITY_TAGS_HELP
+])
+  .component('addEntityTagLinks', new AddEntityTagLinksComponent());

--- a/app/scripts/modules/core/entityTag/entityRef.builder.ts
+++ b/app/scripts/modules/core/entityTag/entityRef.builder.ts
@@ -1,0 +1,48 @@
+import {ServerGroup} from '../domain/serverGroup';
+import {LoadBalancer} from '../domain/loadBalancer';
+import {Application} from '../application/application.model';
+import {IEntityRef} from '../domain/IEntityTags';
+
+export class EntityRefBuilder {
+
+  public static buildServerGroupRef(serverGroup: ServerGroup): IEntityRef {
+    return {
+      cloudProvider: serverGroup.cloudProvider,
+      entityType: 'servergroup',
+      entityId: serverGroup.name,
+      account: serverGroup.account,
+      region: serverGroup.region,
+    };
+  }
+
+  public static buildLoadBalancerRef(loadBalancer: LoadBalancer): IEntityRef {
+    return {
+      cloudProvider: loadBalancer.cloudProvider,
+      entityType: 'loadbalancer',
+      entityId: loadBalancer.name,
+      account: loadBalancer.account,
+      region: loadBalancer.region,
+    };
+  }
+
+  public static buildApplicationRef(application: Application): IEntityRef {
+    return {
+      cloudProvider: '*',
+      entityType: 'application',
+      entityId: application.name,
+    };
+  }
+
+  public static getBuilder(type: string): (entity: any) => IEntityRef {
+    switch (type) {
+      case 'application':
+        return this.buildApplicationRef;
+      case 'serverGroup':
+        return this.buildServerGroupRef;
+      case 'loadBalancer':
+        return this.buildLoadBalancerRef;
+      default:
+        return null;
+    }
+  }
+}

--- a/app/scripts/modules/core/entityTag/entityTagDetails.component.less
+++ b/app/scripts/modules/core/entityTag/entityTagDetails.component.less
@@ -1,0 +1,27 @@
+@import "../presentation/less/imports/commonImports.less";
+
+entity-tag-details {
+  .tag {
+    padding: 5px;
+    margin-bottom: 10px;
+  }
+  .fa {
+    margin-right: 5px;
+    margin-top: 4px;
+  }
+  .actions {
+    .btn-link:last-child {
+      padding-right: 0;
+    }
+  }
+  .tag-contents {
+    display: flex;
+    flex-direction: row;
+    .fa {
+      flex: 0 0 auto;
+    }
+    [marked] {
+      flex: 1 1 auto;
+    }
+  }
+}

--- a/app/scripts/modules/core/entityTag/entityTagEditor.controller.ts
+++ b/app/scripts/modules/core/entityTag/entityTagEditor.controller.ts
@@ -1,0 +1,50 @@
+import {module} from 'angular';
+import {ENTITY_TAG_WRITER, EntityTagWriter} from './entityTags.write.service';
+import {IModalServiceInstance} from '../../../../types/angular-ui-bootstrap';
+import {Application} from '../application/application.model';
+import {UUIDGenerator} from '../utils/uuid.service';
+import {IEntityTag} from 'core/domain';
+import './entityTagEditor.modal.less';
+
+export class EntityTagEditorCtrl implements ng.IComponentController {
+
+  public taskMonitor: any;
+
+  static get $inject() {
+    return ['$uibModalInstance', 'entityTagWriter', 'taskMonitorService', 'owner', 'application', 'entityType',
+      'tag', 'onUpdate', 'isNew'];
+  }
+
+  public constructor(private $uibModalInstance: IModalServiceInstance,
+                     private entityTagWriter: EntityTagWriter,
+                     private taskMonitorService: any,
+                     private owner: any,
+                     private application: Application,
+                     private entityType: string,
+                     private tag: IEntityTag,
+                     private onUpdate: () => any,
+                     public isNew: boolean) {}
+
+  public $onInit(): void {
+    this.tag.name = this.tag.name || `spinnaker_ui_${this.tag.value.type}:${UUIDGenerator.generateUuid()}`;
+  }
+
+  public cancel(): void {
+    this.$uibModalInstance.dismiss();
+  }
+
+  public upsertTag(): void {
+    this.taskMonitor = this.taskMonitorService.buildTaskMonitor({
+      modalInstance: this.$uibModalInstance,
+      application: this.application,
+      title: `${this.isNew ? 'Create' : 'Update'} ${this.tag.value.type} for ${this.owner.name}`,
+      onTaskComplete: () => this.onUpdate(),
+    });
+
+    this.taskMonitor.submit(() => this.entityTagWriter.upsertEntityTag(this.application, this.tag, this.owner, this.entityType, this.isNew));
+  }
+}
+
+export const ENTITY_TAG_EDITOR_CTRL = 'spinnaker.core.entityTag.editor.controller';
+module(ENTITY_TAG_EDITOR_CTRL, [ENTITY_TAG_WRITER])
+  .controller('EntityTagEditorCtrl', EntityTagEditorCtrl);

--- a/app/scripts/modules/core/entityTag/entityTagEditor.modal.html
+++ b/app/scripts/modules/core/entityTag/entityTagEditor.modal.html
@@ -1,0 +1,40 @@
+<div modal-page class="entity-tag-editor-modal">
+  <task-monitor monitor="$ctrl.taskMonitor"></task-monitor>
+  <modal-close dismiss="$ctrl.cancel()"></modal-close>
+  <div class="modal-header">
+    <h3>{{$ctrl.isNew ? 'Create' : 'Update'}} {{$ctrl.tag.value.type}}</h3>
+  </div>
+  <div class="modal-body">
+    <form role="form" name="form" class="form-horizontal" ng-submit="$ctrl.upsertTag()">
+      <div class="row">
+        <div class="col-md-10 col-md-offset-1">
+          <div class="form-group">
+            <div class="col-md-3 sm-label-right">
+              <b>Message</b>
+            </div>
+            <div class="col-md-9">
+              <textarea ng-model="$ctrl.tag.value.message" class="form-control input-sm" rows="5" required></textarea>
+              <div class="small text-right">Markdown is okay <help-field key="markdown.examples"></help-field></div>
+            </div>
+          </div>
+          <div class="form-group preview" ng-if="$ctrl.tag.value.message">
+            <div class="col-md-3 sm-label-right">
+              <b>Preview</b>
+            </div>
+            <div class="col-md-9">
+              <div marked="$ctrl.tag.value.message"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </form>
+  </div>
+  <div class="modal-footer">
+    <button class="btn btn-default" ng-click="$ctrl.cancel()">Cancel</button>
+    <button class="btn btn-primary"
+            ng-disabled="form.$invalid || $ctrl.viewState.submitting"
+            ng-click="$ctrl.upsertTag()">
+      <span class="glyphicon glyphicon-ok-circle"></span> {{$ctrl.isNew ? 'Create' : 'Update'}} {{$ctrl.tag.value.type}}
+    </button>
+  </div>
+</div>

--- a/app/scripts/modules/core/entityTag/entityTagEditor.modal.less
+++ b/app/scripts/modules/core/entityTag/entityTagEditor.modal.less
@@ -1,0 +1,10 @@
+@import "../presentation/less/imports/commonImports.less";
+
+.entity-tag-editor-modal {
+  .preview {
+    background-color: lighten(@light_blue_background, 10%);
+    [marked] {
+      padding-top: 5px;
+    }
+  }
+}

--- a/app/scripts/modules/core/entityTag/entityTags.help.ts
+++ b/app/scripts/modules/core/entityTag/entityTags.help.ts
@@ -1,0 +1,21 @@
+import {module} from 'angular';
+import {HELP_CONTENTS_REGISTRY, HelpContentsRegistry} from 'core/help/helpContents.registry';
+
+const helpContents: any[] = [
+  {
+    key: 'entityTags.serverGroup.alert',
+    contents: `<p>Alerts indicate an issue with a server group. When present, an alert icon 
+      <i class="fa fa-exclamation-triangle"></i> will be displayed in the clusters view next to the server group.</p>`
+  },
+  {
+    key: 'entityTags.serverGroup.notice',
+    contents: `<p>Notices provide additional context for a server group. When present, an info icon 
+      <i class="fa fa-info-circle"></i> will be displayed in the clusters view next to the server group.</p>`
+  }
+  ];
+
+export const ENTITY_TAGS_HELP = 'spinnaker.core.entityTag.help';
+module(ENTITY_TAGS_HELP, [HELP_CONTENTS_REGISTRY])
+  .run((helpContentsRegistry: HelpContentsRegistry) => {
+    helpContents.forEach((entry: any) => helpContentsRegistry.register(entry.key, entry.contents));
+});

--- a/app/scripts/modules/core/entityTag/entityTags.read.service.ts
+++ b/app/scripts/modules/core/entityTag/entityTags.read.service.ts
@@ -1,0 +1,41 @@
+import {module} from 'angular';
+import {API_SERVICE, Api} from 'core/api/api.service';
+import {IEntityTags, IEntityTag} from '../domain/IEntityTags';
+
+export class EntityTagsReader {
+
+  static get $inject() { return ['API', '$q']; }
+
+  public constructor(private API: Api, private $q: ng.IQService) {}
+
+  public getAllEntityTags(entityType: string, entityIds: string[]): ng.IPromise<IEntityTags[]> {
+    const source = this.API.one('tags')
+        .withParams({
+          entityType: entityType.toLowerCase(),
+          entityId: entityIds.join(',')
+        }).getList();
+
+    return source.then((entityTags: IEntityTags[]) => {
+      entityTags.forEach(entityTag => {
+        entityTag.tags.forEach(tag => this.addTagMetadata(entityTag, tag));
+        entityTag.alerts = entityTag.tags.filter(t => t.name.startsWith('spinnaker_ui_alert:'));
+        entityTag.notices = entityTag.tags.filter(t => t.name.startsWith('spinnaker_ui_notice:'));
+      });
+      return entityTags;
+    });
+  }
+
+  private addTagMetadata(entityTag: IEntityTags, tag: IEntityTag): void {
+    const metadata = entityTag.tagsMetadata.find(m => m.name === tag.name);
+    if (metadata) {
+      tag.created = metadata.created;
+      tag.createdBy = metadata.createdBy;
+      tag.lastModified = metadata.lastModified;
+      tag.lastModifiedBy = metadata.lastModifiedBy;
+    }
+  }
+}
+
+export const ENTITY_TAGS_READ_SERVICE = 'spinnaker.core.entityTag.read.service';
+module(ENTITY_TAGS_READ_SERVICE, [API_SERVICE])
+  .service('entityTagsReader', EntityTagsReader);

--- a/app/scripts/modules/core/entityTag/entityTags.write.service.ts
+++ b/app/scripts/modules/core/entityTag/entityTags.write.service.ts
@@ -1,0 +1,53 @@
+import {module} from 'angular';
+import {TASK_EXECUTOR, TaskExecutor} from '../task/taskExecutor';
+import {Application} from 'core/application/application.model';
+import {EntityRefBuilder} from './entityRef.builder';
+import {IEntityRef, IEntityTags, IEntityTag} from '../domain/IEntityTags';
+
+export class EntityTagWriter {
+
+  static get $inject() { return ['$q', 'taskExecutor']; }
+
+  public constructor(private $q: ng.IQService, private taskExecutor: TaskExecutor) {}
+
+  public upsertEntityTag(application: Application, tag: IEntityTag, owner: any, entityType: string, isNew: boolean): ng.IPromise<any> {
+    const refBuilder: (entity: any) => IEntityRef = EntityRefBuilder.getBuilder(entityType);
+    if (refBuilder) {
+      return this.taskExecutor.executeTask({
+        application: application,
+        description: `${isNew ? 'Create' : 'Update'} entity tag on ${owner.name}`,
+        job: [
+          {
+            type: 'upsertEntityTags',
+            application: application.name,
+            entityId: owner.name,
+            entityRef: refBuilder(owner),
+            tags: [tag],
+            isPartial: true,
+          }
+        ]
+      });
+    }
+    return this.$q.reject(`No processor found for entity type: ${entityType}`);
+  }
+
+  public deleteEntityTag(application: Application, owner: any, entityTag: IEntityTags, tag: string) {
+    return this.taskExecutor.executeTask({
+      application: application,
+      description: `Delete entity tag on ${owner.name}`,
+      job: [
+        {
+          type: 'deleteEntityTags',
+          application: application.name,
+          id: entityTag.id,
+          tags: [tag],
+        }
+      ]
+    });
+  }
+}
+
+
+export const ENTITY_TAG_WRITER = 'spinnaker.core.entityTag.write.service';
+module(ENTITY_TAG_WRITER, [TASK_EXECUTOR])
+  .service('entityTagWriter', EntityTagWriter);

--- a/app/scripts/modules/core/entityTag/entityUiTags.component.less
+++ b/app/scripts/modules/core/entityTag/entityUiTags.component.less
@@ -1,0 +1,18 @@
+@import "../presentation/less/imports/commonImports.less";
+
+entity-ui-tags {
+  position: relative;
+  .tag-marker {
+    display: inline-block;
+    margin-left: 5px;
+    font-size: 15px;
+  }
+  &.inverse {
+    .fa-exclamation-triangle {
+      color: @alert-background;
+    }
+    .fa-info-circle {
+      color: @light_blue_background;
+    }
+  }
+}

--- a/app/scripts/modules/core/entityTag/entityUiTags.popover.html
+++ b/app/scripts/modules/core/entityTag/entityUiTags.popover.html
@@ -1,0 +1,9 @@
+<div ng-mouseenter="$ctrl.popoverHovered()" ng-mouseleave="$ctrl.hidePopover(false)" class="entity-tags-popover">
+  <div ng-repeat="tag in $ctrl.popoverContents" class="entity-tag-message">
+    <div marked="tag.value.message"></div>
+    <div class="actions actions-popover">
+      <a href ng-click="$ctrl.editTag(tag)"><span class="glyphicon glyphicon-cog" uib-popover="Edit {{tag.type}}"></span></a>
+      <a href ng-click="$ctrl.deleteTag(tag)"><span class="glyphicon glyphicon-trash" uib-popover="Delete {{tag.type}}"></span></a>
+    </div>
+  </div>
+</div>

--- a/app/scripts/modules/core/entityTag/entityUiTags.popover.less
+++ b/app/scripts/modules/core/entityTag/entityUiTags.popover.less
@@ -1,0 +1,14 @@
+@import "~core/presentation/less/imports/commonImports.less";
+
+.entity-tags-popover {
+  padding: 10px;
+  .entity-tag-message {
+    min-width: 150px;
+    &:not(:first-child) {
+      padding-top: 10px;
+      margin-top: 5px;
+      border-top: 1px solid @mid_light_grey;
+
+    }
+  }
+}

--- a/app/scripts/modules/core/help/helpContents.js
+++ b/app/scripts/modules/core/help/helpContents.js
@@ -491,4 +491,5 @@ module.exports = angular.module('spinnaker.core.help.contents', [])
     'titus.bake.imageName': '(Optional) The name for the image, e.g. <samp>igor</samp> for <samp>spinnaker/igor</samp>Defaults to [git project name].[git repo name].',
     'titus.bake.tags': '(Optional) Comma separated. By default, the <samp>latest</samp> tag is updated. Adds additional tags to label this image <samp>1.0.0-unstable,1.0.0-rc1</samp>',
     'titus.bake.buildParameters': '(Optional) Build time variables to be passed to the Docker image. These are the set of values passed to --build-args in the command line.',
+    'markdown.examples': 'Some examples of markdown syntax: <br/> *<em>emphasis</em>* <br/> **<b>strong</b>** <br/> [link text](http://url-goes-here)',
   });

--- a/app/scripts/modules/core/modal/modals.less
+++ b/app/scripts/modules/core/modal/modals.less
@@ -430,3 +430,10 @@ abbr.select2-search-choice-close {
 .slide-in {
   .slide-down(0.3s);
 }
+
+.actions-popover {
+  text-align: right;
+  .glyphicon {
+    padding: 0 5px;
+  }
+}

--- a/app/scripts/modules/core/presentation/less/imports/colors.less
+++ b/app/scripts/modules/core/presentation/less/imports/colors.less
@@ -43,6 +43,7 @@
 @unhealthy_red: #b82525;
 @unhealthy_red_border: darken(@unhealthy_red, 10%);
 @text_error: darken(@unhealthy_red, 20%);
+@alert-background: #EBCCD1;
 
 @unhealthy_orange: #F0AD4E;
 @warning-background: #faebcc;

--- a/app/scripts/modules/core/presentation/main.less
+++ b/app/scripts/modules/core/presentation/main.less
@@ -1291,3 +1291,35 @@ ul.checkmap {
     display: none !important;
   }
 }
+
+.popover.no-padding {
+  .popover-content {
+    padding: 0;
+  }
+}
+
+.fa-exclamation-triangle {
+  color: @unhealthy_red;
+}
+.fa-info-circle {
+  color: @spinnaker-blue;
+}
+
+// duplicated from bootstrap core
+// needed to render components in dropdowns correctly
+.dropdown-menu {
+  li {
+    > a {
+      display: block;
+      padding: 3px 20px;
+      clear: both;
+      color: #333333;
+      white-space: nowrap;
+      &:hover, &:focus {
+        background-color: #f5f5f5;
+        text-decoration: none;
+        color: #262626;
+      }
+    }
+  }
+}

--- a/app/scripts/modules/core/serverGroup/serverGroup.dataSource.js
+++ b/app/scripts/modules/core/serverGroup/serverGroup.dataSource.js
@@ -1,26 +1,45 @@
 import {DataSourceConfig} from '../application/service/applicationDataSource';
 import {APPLICATION_DATA_SOURCE_REGISTRY} from '../application/service/applicationDataSource.registry';
+import {ENTITY_TAGS_READ_SERVICE} from '../entityTag/entityTags.read.service';
 
 let angular = require('angular');
 
 module.exports = angular
   .module('spinnaker.core.serverGroup.dataSource', [
     APPLICATION_DATA_SOURCE_REGISTRY,
+    ENTITY_TAGS_READ_SERVICE,
     require('../cluster/cluster.service'),
+    require('core/config/settings'),
   ])
-  .run(function($q, applicationDataSourceRegistry, clusterService, serverGroupTransformer) {
+  .run(function($q, applicationDataSourceRegistry, clusterService, entityTagsReader, serverGroupTransformer, settings) {
 
     let loadServerGroups = (application) => {
       return clusterService.loadServerGroups(application.name);
     };
 
     let addServerGroups = (application, serverGroups) => {
-      serverGroups.forEach(serverGroup => serverGroup.stringVal = JSON.stringify(serverGroup, serverGroupTransformer.jsonReplacer));
-      application.clusters = clusterService.createServerGroupClusters(serverGroups);
-      let data = clusterService.addServerGroupsToApplication(application, serverGroups);
-      clusterService.addTasksToServerGroups(application);
-      clusterService.addExecutionsToServerGroups(application);
-      return $q.when(data);
+      return addTags(serverGroups).then(() => {
+        serverGroups.forEach(serverGroup => serverGroup.stringVal = JSON.stringify(serverGroup, serverGroupTransformer.jsonReplacer));
+        application.clusters = clusterService.createServerGroupClusters(serverGroups);
+        let data = clusterService.addServerGroupsToApplication(application, serverGroups);
+        clusterService.addTasksToServerGroups(application);
+        clusterService.addExecutionsToServerGroups(application);
+        return data;
+      });
+    };
+
+    let addTags = (serverGroups) => {
+      if (!settings.feature.entityTags) {
+        return $q.when(null);
+      }
+      const entityIds = serverGroups.map(g => g.name);
+      return entityTagsReader.getAllEntityTags('serverGroup', entityIds).then(tags => {
+        serverGroups.forEach(serverGroup => {
+          serverGroup.entityTags = tags.find(t => t.entityRef.entityId === serverGroup.name &&
+            t.entityRef.account === serverGroup.account &&
+            t.entityRef.region === serverGroup.region);
+        });
+      });
     };
 
     applicationDataSourceRegistry.registerDataSource(new DataSourceConfig({

--- a/app/scripts/modules/core/serverGroup/serverGroup.directive.html
+++ b/app/scripts/modules/core/serverGroup/serverGroup.directive.html
@@ -29,6 +29,8 @@
             <span ng-if="!viewModel.hasBuildInfo">
               (No build info)
             </span>
+            <entity-ui-tags component="serverGroup" application="application" entity-type="serverGroup"
+                          on-update="application.serverGroups.refresh()"></entity-ui-tags>
           </div>
           <div class="col-md-{{ viewModel.images ? 3 : 4 }} col-sm-6 text-right">
             <health-counts container="viewModel.serverGroup.instanceCounts"></health-counts>

--- a/app/scripts/modules/core/serverGroup/serverGroup.directive.js
+++ b/app/scripts/modules/core/serverGroup/serverGroup.directive.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import {CLUSTER_FILTER_SERVICE} from 'core/cluster/filter/clusterFilter.service';
+import {ENTITY_UI_TAGS_COMPONENT} from 'core/entityTag/entityUiTags.component';
 
 let angular = require('angular');
 
@@ -11,6 +12,7 @@ module.exports = angular.module('spinnaker.core.serverGroup.serverGroup.directiv
   require('../instance/instances.directive'),
   require('../instance/instanceList.directive'),
   require('./serverGroup.transformer'),
+  ENTITY_UI_TAGS_COMPONENT,
 ])
   .directive('serverGroup', function ($rootScope, $timeout, $filter, clusterFilterService,
                                       MultiselectModel, ClusterFilterModel, serverGroupTransformer) {

--- a/app/scripts/modules/core/task/taskExecutor.ts
+++ b/app/scripts/modules/core/task/taskExecutor.ts
@@ -9,6 +9,7 @@ export interface IJob {
   source?: string;
   type?: string;
   user?: string;
+  [attribute: string]: any;
 }
 
 export interface ITaskCommand {

--- a/app/scripts/modules/netflix/serverGroup/awsServerGroupDetails.html
+++ b/app/scripts/modules/netflix/serverGroup/awsServerGroupDetails.html
@@ -25,6 +25,8 @@
       <cloud-provider-logo provider="ctrl.serverGroup.type" height="36px" width="36px" style="margin-right: 10px"></cloud-provider-logo>
       <h3 select-on-dbl-click>
         {{ctrl.serverGroup.name}}
+        <entity-ui-tags component="ctrl.serverGroup" application="ctrl.application" entity-type="serverGroup"
+                        on-update="ctrl.application.serverGroups.refresh()"></entity-ui-tags>
       </h3>
     </div>
     <div>
@@ -49,6 +51,10 @@
             <li><a href ng-click="ctrl.destroyServerGroup()">Destroy</a></li>
             <li><a href ng-click="ctrl.cloneServerGroup(ctrl.serverGroup)">Clone</a></li>
             <li><migrator application="ctrl.application" server-group="ctrl.serverGroup"></migrator></li>
+            <add-entity-tag-links component="ctrl.serverGroup"
+                                  application="ctrl.application"
+                                  entity-type="serverGroup"
+                                  on-update="ctrl.application.serverGroups.refresh()"></add-entity-tag-links>
           </ul>
         </div>
         <div class="dropdown" ng-if="ctrl.serverGroup.insightActions.length > 0" uib-dropdown dropdown-append-to-body>

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "clipboard": "^1.5.12",
     "d3": "^3.5.6",
     "diff-match-patch": "^1.0.0",
+    "font-awesome": "^4.7.0",
     "jquery": "2.1.4",
     "jquery-textcomplete": "1.6.1",
     "jquery-ui": "~1.10.5",

--- a/settings.js
+++ b/settings.js
@@ -9,6 +9,7 @@ var authEnabled = process.env.AUTH_ENABLED === 'false' ? false : true;
 var netflixMode = process.env.NETFLIX_MODE === 'true' ? true : false;
 var chaosEnabled = netflixMode || process.env.CHAOS_ENABLED === 'true' ? true : false;
 var fiatEnabled = process.env.FIAT_ENABLED === 'true' ? true : false;
+var entityTagsEnabled = process.env.ENTITY_TAGS_ENABLED == 'true' ? true : false;
 
 window.spinnakerSettings = {
   checkForUpdates: true,
@@ -99,6 +100,7 @@ window.spinnakerSettings = {
   gitSources: ['stash', 'github'],
   triggerTypes: ['git', 'pipeline', 'docker', 'cron', 'jenkins'],
   feature: {
+    entityTags: entityTagsEnabled,
     fiatEnabled: fiatEnabled,
     pipelines: true,
     notifications: false,


### PR DESCRIPTION
Adds rudimentary support to add notices and alerts to server groups via the UI, using the new entity tags features in Gate/Orca/Clouddriver.

We're restricting the functionality to the Netflix build, since it's very early days and we want to iron things out with the UI (and backend) before releasing it in the wild. It also requires a running ElasticSearch node, which is not part of the standard Spinnaker installation.

An example of a server group with notices and alerts configured:
![screen shot 2017-01-05 at 2 43 49 pm](https://cloud.githubusercontent.com/assets/73450/21700767/e889c31c-d356-11e6-97a0-d9638f8cdad9.png)
![screen shot 2017-01-05 at 2 54 24 pm](https://cloud.githubusercontent.com/assets/73450/21700853/4c79726e-d357-11e6-85ba-a213a7a10838.png)

Notices can be added to an _existing_ server group via REST calls, or via the inspector panel:
![screen shot 2017-01-05 at 2 58 28 pm](https://cloud.githubusercontent.com/assets/73450/21700896/85b29934-d357-11e6-92e2-111d6bf60e3b.png)

There are a number of limitations:
* the server group must exist before adding tags via the UI
* tags are not deleted when a server group is destroyed
* while the tagging API supports multiple entity types (e.g. applications, clusters, load balancers, security groups), we're only providing UI support for server groups to start
* tags cannot be created in a pipeline, or when creating/cloning a server group

We're hoping to get lots of internal feedback and iterate on this functionality, then make it widely available.