### PR TITLE
(appengine) correct destroy server group logic

### DIFF
--- a/app/scripts/modules/appengine/serverGroup/details/details.controller.ts
+++ b/app/scripts/modules/appengine/serverGroup/details/details.controller.ts
@@ -108,6 +108,23 @@ class AppengineServerGroupDetailsController {
     }
   }
 
+  public canDestroyServerGroup(): boolean {
+    if (this.serverGroup) {
+      if (this.serverGroup.disabled) {
+        return true;
+      }
+
+      let expectedAllocations = this.expectedAllocationsAfterDisableOperation(this.serverGroup, this.app);
+      if (expectedAllocations) {
+        return Object.keys(expectedAllocations).length > 0;
+      } else {
+        return false;
+      }
+    } else {
+      return false;
+    }
+  }
+
   public destroyServerGroup(): void {
     let taskMonitor = {
       application: this.app,

--- a/app/scripts/modules/appengine/serverGroup/details/details.html
+++ b/app/scripts/modules/appengine/serverGroup/details/details.html
@@ -60,10 +60,10 @@
               Disable
             </a>
           </li>
-          <li ng-if="ctrl.canDisableServerGroup()">
+          <li ng-if="ctrl.canDestroyServerGroup()">
             <a href ng-click="ctrl.destroyServerGroup()">Destroy</a>
           </li>
-          <li ng-if="!ctrl.canDisableServerGroup()"
+          <li ng-if="!ctrl.canDestroyServerGroup()"
               uib-tooltip="You cannot destroy a server group if it is the only server group
                            receiving traffic from a load balancer. You may be able to delete
                            this server group's load balancer."


### PR DESCRIPTION
@lwander correct logic for destroying a server group.