### PR TITLE
(core) surface alerts in data source tabs

### DIFF
--- a/app/scripts/modules/core/application/application.model.spec.ts
+++ b/app/scripts/modules/core/application/application.model.spec.ts
@@ -9,6 +9,7 @@ import {
   InstanceCounts,
   LoadBalancer
 } from '../domain';
+import {IEntityTag, IEntityTags} from '../domain/IEntityTags';
 
 describe ('Application Model', function () {
 
@@ -110,6 +111,62 @@ describe ('Application Model', function () {
 
         expect(application.getDataSource('lazySource').data).toEqual([]);
         expect(application.getDataSource('lazySource').loaded).toBe(false);
+      });
+
+      it('adds entityTags that contain alerts if found on data', function () {
+        const alertTag: IEntityTag = { name: 'spinnaker_ui_alert:alert1', value: { message: 'an alert' } };
+        const tags: IEntityTags = {
+          id: 'zzzz',
+          tags: [ alertTag ],
+          tagsMetadata: null,
+          entityRef: null,
+          alerts: [ alertTag ],
+          notices: []
+        };
+        const nonAlertTags: IEntityTags = {
+          id: 'zzzz',
+          tags: [ { name: 'spinnaker_ui_notice:notice1', value: { message: 'a notice' } } ],
+          tagsMetadata: null,
+          entityRef: null,
+          alerts: [],
+          notices: [ { name: 'spinnaker_ui_notice:notice1', value: { message: 'a notice' } } ]
+        };
+        const serverGroups: ServerGroup[] = [
+          {
+            account: 'test',
+            cloudProvider: 'aws',
+            cluster: 'myapp',
+            instanceCounts: null,
+            instances: [],
+            name: 'myapp-v001',
+            region: 'us-east-1',
+            type: 'aws',
+            entityTags: tags
+          },
+          {
+            account: 'test',
+            cloudProvider: 'aws',
+            cluster: 'myapp',
+            instanceCounts: null,
+            instances: [],
+            name: 'myapp-v001',
+            region: 'us-east-1',
+            type: 'aws',
+            entityTags: nonAlertTags
+          },
+          {
+            account: 'test',
+            cloudProvider: 'aws',
+            cluster: 'myapp',
+            instanceCounts: null,
+            instances: [],
+            name: 'myapp-no-alerts-v002',
+            region: 'us-east-1',
+            type: 'aws',
+          }
+        ];
+        configureApplication(serverGroups, [], []);
+        expect(application.getDataSource('serverGroups').alerts).toEqual([tags]);
       });
     });
 

--- a/app/scripts/modules/core/application/nav/applicationNav.component.js
+++ b/app/scripts/modules/core/application/nav/applicationNav.component.js
@@ -1,8 +1,11 @@
+import {DATA_SOURCE_ALERTS_COMPONENT} from 'core/entityTag/dataSourceAlerts.component';
+
 let angular = require('angular');
 
 module.exports = angular
   .module('spinnaker.core.application.nav.component', [
     require('angular-ui-router'),
+    DATA_SOURCE_ALERTS_COMPONENT,
   ])
   .component('applicationNav', {
     bindings: {
@@ -17,6 +20,7 @@ module.exports = angular
              analytics-event="{{dataSource.title}}"
              ng-class="{active: $ctrl.isActive(dataSource)}">
             {{dataSource.label}}
+             <ds-alerts alerts="dataSource.alerts"></ds-alerts>
             <span class="badge"
                   ng-if="dataSource.badge && $ctrl.application[dataSource.badge].data.length">
               {{$ctrl.application[dataSource.badge].data.length}}

--- a/app/scripts/modules/core/application/service/applicationDataSource.ts
+++ b/app/scripts/modules/core/application/service/applicationDataSource.ts
@@ -1,5 +1,7 @@
 import {Subject} from 'rxjs';
 import {Application} from '../application.model';
+import {IEntityTags} from 'core/domain/IEntityTags';
+import {get} from 'lodash';
 
 export class DataSourceConfig {
 
@@ -235,7 +237,14 @@ export class ApplicationDataSource {
   /**
    * The actual data (if any) for the data source. This field should only be populated by the "loader" method.
    */
-  public data: Array<any> = [];
+  public data: any[] = [];
+
+  /**
+   * If entity tags are enabled, and any of the data has entity tags with alerts, they will be added to the data source
+   * on load, and the alerts will be displayed in the tab next to the tab name.
+   */
+  public alerts: IEntityTags[];
+
 
   /**
    * A timestamp indicating the last time the data source was successfully refreshed
@@ -397,6 +406,7 @@ export class ApplicationDataSource {
           if (this.afterLoad) {
             this.afterLoad(this.application);
           }
+          this.addAlerts();
           this.dataUpdated();
         });
       })
@@ -417,6 +427,15 @@ export class ApplicationDataSource {
       if (!this.loaded) {
         this.refresh();
       }
+    }
+  }
+
+  private addAlerts(): void {
+    this.alerts = [];
+    if (this.data && this.data.length) {
+      this.alerts = this.data
+        .filter((d: any) => get(d, 'entityTags.alerts.length', 0))
+        .map((d: any) => d['entityTags'] as IEntityTags);
     }
   }
 }

--- a/app/scripts/modules/core/entityTag/dataSourceAlerts.component.ts
+++ b/app/scripts/modules/core/entityTag/dataSourceAlerts.component.ts
@@ -1,0 +1,66 @@
+import {module} from 'angular';
+import {IEntityTag} from 'core/domain/IEntityTags';
+
+class DataSourceAlertsCtrl implements ng.IComponentController {
+
+  public alerts: IEntityTag[] = [];
+
+  public popoverTemplate: string = require('./dataSourceAlerts.popover.html');
+  public displayPopover: boolean;
+
+  private popoverClose: ng.IPromise<void>;
+
+  static get $inject() { return ['$timeout']; }
+
+  public constructor(private $timeout: ng.ITimeoutService) {}
+
+  // Popover bits allow the popover to stay open when hovering to allow users to click on links, highlight text, etc.
+  // We may end up extracting this into a common widget if we want to use it elsewhere
+
+  public showPopover(): void {
+    this.displayPopover = true;
+  }
+
+  public popoverHovered(): void {
+    if (this.popoverClose) {
+      this.$timeout.cancel(this.popoverClose);
+      this.popoverClose = null;
+    }
+  }
+
+  public hidePopover(defer: boolean): void {
+    if (defer) {
+      this.popoverClose = this.$timeout(() => {
+        this.displayPopover = false;
+      }, 500);
+    } else {
+      this.displayPopover = false;
+    }
+  }
+
+}
+
+class DataSourceAlertsComponent implements ng.IComponentOptions {
+  public bindings: any = {
+    alerts: '=',
+  };
+  public controller: any = DataSourceAlertsCtrl;
+  public template: string = `
+    <span ng-if="$ctrl.alerts.length > 0"
+          class="tag-marker small" 
+          ng-mouseover="$ctrl.showPopover()" 
+          ng-mouseleave="$ctrl.hidePopover(true)">
+      <span uib-popover-template="$ctrl.popoverTemplate"
+            popover-placement="auto top"
+            popover-trigger="none"
+            popover-is-open="$ctrl.displayPopover"
+            popover-class="no-padding">
+        <i class="fa fa-exclamation-triangle"></i>
+      </span>
+    </span>  
+  `;
+}
+
+export const DATA_SOURCE_ALERTS_COMPONENT = 'spinnaker.core.entityTag.dataSourceAlerts.component';
+module(DATA_SOURCE_ALERTS_COMPONENT, [])
+  .component('dsAlerts', new DataSourceAlertsComponent()); // "ds" because "data" is parsed differently by Angular :(

--- a/app/scripts/modules/core/entityTag/dataSourceAlerts.popover.html
+++ b/app/scripts/modules/core/entityTag/dataSourceAlerts.popover.html
@@ -1,0 +1,17 @@
+<div ng-mouseenter="$ctrl.popoverHovered()" ng-mouseleave="$ctrl.hidePopover(false)" class="entity-tags-popover">
+  <div ng-repeat="tag in $ctrl.alerts" class="entity-tag-message">
+    <div>
+      <strong>{{tag.entityRef.entityId}}</strong>
+      <span ng-if="tag.entityRef.account || tag.entityRef.region">
+        (
+        <account-tag account="tag.entityRef.account" ng-if="tag.entityRef.account"></account-tag>
+        <span ng-bind="tag.entityRef.region"></span>
+        )
+      </span>
+    </div>
+    <div ng-repeat="alert in tag.alerts">
+      <div marked="alert.value.message"></div>
+      <div class="small text-right" title="{{alert.lastModified | timestamp}}">{{alert.lastModified | relativeTime}}</div>
+    </div>
+  </div>
+</div>

--- a/app/scripts/modules/core/entityTag/entityUiTags.component.ts
+++ b/app/scripts/modules/core/entityTag/entityUiTags.component.ts
@@ -34,6 +34,10 @@ class EntityUiTagsCtrl implements ng.IComponentController {
       this.alerts = this.component.entityTags.alerts;
       this.notices = this.component.entityTags.notices;
       this.hasTags = this.alerts.length + this.notices.length > 0;
+    } else {
+      this.alerts = [];
+      this.notices = [];
+      this.hasTags = false;
     }
   }
 

--- a/app/scripts/modules/core/entityTag/entityUiTags.popover.html
+++ b/app/scripts/modules/core/entityTag/entityUiTags.popover.html
@@ -1,9 +1,12 @@
 <div ng-mouseenter="$ctrl.popoverHovered()" ng-mouseleave="$ctrl.hidePopover(false)" class="entity-tags-popover">
   <div ng-repeat="tag in $ctrl.popoverContents" class="entity-tag-message">
     <div marked="tag.value.message"></div>
-    <div class="actions actions-popover">
-      <a href ng-click="$ctrl.editTag(tag)"><span class="glyphicon glyphicon-cog" uib-popover="Edit {{tag.type}}"></span></a>
-      <a href ng-click="$ctrl.deleteTag(tag)"><span class="glyphicon glyphicon-trash" uib-popover="Delete {{tag.type}}"></span></a>
+    <div class="small">
+      <span class="small pull-left" title="{{tag.lastModified | timestamp}}">{{tag.lastModified | relativeTime}}</span>
+      <div class="actions actions-popover">
+        <a href ng-click="$ctrl.editTag(tag)"><span class="glyphicon glyphicon-cog" uib-popover="Edit {{tag.type}}"></span></a>
+        <a href ng-click="$ctrl.deleteTag(tag)"><span class="glyphicon glyphicon-trash" uib-popover="Delete {{tag.type}}"></span></a>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
<img width="538" alt="screen shot 2017-01-10 at 12 00 38 pm" src="https://cloud.githubusercontent.com/assets/73450/21822653/dc1f8a6a-d72c-11e6-9197-1caca7876c9b.png">

Also adding a timestamp to existing alerts/notices:
<img width="420" alt="screen shot 2017-01-10 at 12 01 51 pm" src="https://cloud.githubusercontent.com/assets/73450/21822656/e64b1f18-d72c-11e6-8549-e2495847f9f2.png">
