### PR TITLE
(core) increase CSS selector specificity on execution details tabs

### DIFF
--- a/app/scripts/modules/core/delivery/details/executionDetails.less
+++ b/app/scripts/modules/core/delivery/details/executionDetails.less
@@ -10,7 +10,7 @@ execution {
       font-weight: 600;
     }
 
-    .nav {
+    .nav.nav-pills {
       background-color: transparent;
       border: 0;
       padding-left: 0;


### PR DESCRIPTION
Recent CSS updates I made set the width of the `nav` to 260px, which was meant for the side nav; unfortunately, we also use `nav` in the execution steps.