### PR TITLE
(core) adds check for promise in load balancer reader

### DIFF
--- a/app/scripts/modules/appengine/serverGroup/details/details.controller.ts
+++ b/app/scripts/modules/appengine/serverGroup/details/details.controller.ts
@@ -87,7 +87,8 @@ class AppengineServerGroupDetailsController {
         if (!this.$scope.$$destroyed) {
           this.app.getDataSource('serverGroups').onRefresh(this.$scope, () => this.extractServerGroup(serverGroup));
         }
-      });
+      })
+      .catch(() => this.autoClose());
   }
 
   public canDisableServerGroup(): boolean {
@@ -433,8 +434,7 @@ class AppengineServerGroupDetailsController {
 
         this.serverGroup = Object.assign(fromApp, serverGroupDetails);
         this.state.loading = false;
-      })
-      .catch(() => this.autoClose());
+      });
   }
 }
 

--- a/app/scripts/modules/core/loadBalancer/loadBalancer.read.service.ts
+++ b/app/scripts/modules/core/loadBalancer/loadBalancer.read.service.ts
@@ -42,7 +42,9 @@ export class LoadBalancerReader {
   }
 
   private normalizeLoadBalancer(loadBalancer: ILoadBalancer): ng.IPromise<ILoadBalancer> {
-    return this.loadBalancerTransformer.normalizeLoadBalancer(loadBalancer).then((lb: ILoadBalancer) => {
+    let normalized = this.loadBalancerTransformer.normalizeLoadBalancer(loadBalancer);
+    normalized = normalized.then ? normalized : this.$q.resolve(normalized);
+    return normalized.then((lb: ILoadBalancer) => {
       const nameParts: IComponentName = this.namingService.parseLoadBalancerName(lb.name);
       lb.stack = nameParts.stack;
       lb.detail = nameParts.freeFormDetails;


### PR DESCRIPTION
@anotherchrisberry quick fix - the new load balancer reader assumes that each provider's `normalizeLoadBalancer` function returns a promise, which is only true for a few of the providers.

(Also moved some App Engine error handling logic).