### PR TITLE
(gce) s/provider/cloudProvider in load balancer controllers

### DIFF
--- a/app/scripts/modules/google/loadBalancer/configure/internal/gceCreateInternalLoadBalancer.controller.ts
+++ b/app/scripts/modules/google/loadBalancer/configure/internal/gceCreateInternalLoadBalancer.controller.ts
@@ -221,7 +221,7 @@ class InternalLoadBalancerCtrl extends CommonGceLoadBalancerCtrl implements ng.I
     let descriptor = this.isNew ? 'Create' : 'Update';
     let toSubmitLoadBalancer = _.cloneDeep(this.loadBalancer) as any;
     toSubmitLoadBalancer.ports = toSubmitLoadBalancer.ports.split(',').map((port: string) => port.trim());
-    toSubmitLoadBalancer.provider = 'gce';
+    toSubmitLoadBalancer.cloudProvider = 'gce';
     toSubmitLoadBalancer.name = toSubmitLoadBalancer.loadBalancerName;
     toSubmitLoadBalancer.backendService.name = toSubmitLoadBalancer.loadBalancerName;
     delete toSubmitLoadBalancer.instances;

--- a/app/scripts/modules/google/loadBalancer/configure/ssl/gceCreateSslLoadBalancer.controller.ts
+++ b/app/scripts/modules/google/loadBalancer/configure/ssl/gceCreateSslLoadBalancer.controller.ts
@@ -193,7 +193,7 @@ class SslLoadBalancerCtrl extends CommonGceLoadBalancerCtrl implements ng.ICompo
   public submit (): void {
     let descriptor = this.isNew ? 'Create' : 'Update';
     let toSubmitLoadBalancer = _.cloneDeep(this.loadBalancer) as any;
-    toSubmitLoadBalancer.provider = 'gce';
+    toSubmitLoadBalancer.cloudProvider = 'gce';
     toSubmitLoadBalancer.name = toSubmitLoadBalancer.loadBalancerName;
     toSubmitLoadBalancer.backendService.name = toSubmitLoadBalancer.loadBalancerName;
     delete toSubmitLoadBalancer.instances;


### PR DESCRIPTION
@jtk54 please review.

These controllers relied on the load balancer writer to switch `provider` to `cloudProvider` in the upsert payload. We lost that right here: https://github.com/spinnaker/deck/commit/02f2d60acf75c5fd0d0fe829888405836dacf5bc#diff-948391bc7db35044eb30e399c038f7e4L34