### PR TITLE
(core) pull application configured accounts into application accounts

### DIFF
--- a/app/scripts/modules/core/application/application.model.ts
+++ b/app/scripts/modules/core/application/application.model.ts
@@ -149,7 +149,7 @@ export class Application {
   }
 
   private setApplicationAccounts(): void {
-    let accounts = this.accounts;
+    let accounts = this.accounts.concat(this.attributes.accounts || []);
     this.dataSources
       .filter(ds => ds.credentialsField !== undefined)
       .forEach(ds => accounts = accounts.concat(ds.data.map(d => d[ds.credentialsField])));


### PR DESCRIPTION
@anotherchrisberry please review. @ttomsu FYI.

We run into trouble if we don't have accounts from the application config in places like this: https://github.com/spinnaker/deck/blob/master/app/scripts/modules/google/serverGroup/configure/serverGroupCommandBuilder.service.js#L209-L225

If you don't have any running infrastructure and your account isn't the default AND your account name isn't `my-account-name`, then your account won't be set correctly. There's similar logic in the openstack and kubernetes `serverGroupCommandBuilders`, and there might be lots of other places with similar issues.