### PR TITLE
(core) return null as runningTimeInMs when item has not started

### DIFF
--- a/app/scripts/modules/core/domain/IOrchestratedItem.ts
+++ b/app/scripts/modules/core/domain/IOrchestratedItem.ts
@@ -1,6 +1,9 @@
 export interface ITimedItem {
   startTime: number;
   endTime: number;
+  /**
+   * runningTimeInMs will be null if the item has not started
+   */
   runningTimeInMs: number;
 }
 

--- a/app/scripts/modules/core/orchestratedItem/orchestratedItem.transformer.ts
+++ b/app/scripts/modules/core/orchestratedItem/orchestratedItem.transformer.ts
@@ -124,6 +124,9 @@ export class OrchestratedItemTransformer {
 
   private calculateRunningTime(item: IOrchestratedItem): () => number {
     return () => {
+      if (!item.startTime) {
+        return null;
+      }
       const normalizedNow: number = Math.max(Date.now(), item.startTime);
       return (item.endTime || normalizedNow) - item.startTime;
     };

--- a/app/scripts/modules/core/utils/timeFormatters.js
+++ b/app/scripts/modules/core/utils/timeFormatters.js
@@ -9,7 +9,7 @@ module.exports = angular.module('spinnaker.core.utils.timeFormatters', [
   .filter('timestamp', function(momentService, settings) {
     return function(input) {
       var tz = settings.defaultTimeZone || 'America/Los_Angeles';
-      if (!input) {
+      if (!input || isNaN(input) || input < 0) {
         return '-';
       }
       var moment = momentService.tz(isNaN(parseInt(input)) ? input : parseInt(input), tz);
@@ -24,6 +24,9 @@ module.exports = angular.module('spinnaker.core.utils.timeFormatters', [
   })
   .filter('duration', function(momentService) {
     return function(input) {
+      if (!input || isNaN(input) || input < 0) {
+        return '-';
+      }
       var moment = momentService.utc(isNaN(parseInt(input)) ? input : parseInt(input));
       var format = moment.hours() ? 'HH:mm:ss' : 'mm:ss';
       var dayLabel = '';

--- a/app/scripts/modules/core/utils/timeFormatters.spec.js
+++ b/app/scripts/modules/core/utils/timeFormatters.spec.js
@@ -55,9 +55,27 @@ describe('Filter: timeFormatters', function() {
       it('returns nothing when invalid values are provided', function() {
         expect(filter()).toBe('-');
         expect(filter(null)).toBe('-');
+        expect(filter(-1)).toBe('-');
+        expect(filter('a')).toBe('-');
       });
       it('returns formatted date when valid value is provided', function () {
         expect(filter(1445707299020)).toBe('2015-10-24 17:21:39 GMT');
+      });
+    });
+
+    describe('duration', function () {
+      beforeEach(
+        window.inject(
+          function($filter) {
+            filter = $filter('timestamp');
+          }
+        )
+      );
+      it('returns nothing when invalid values are provided', function () {
+        expect(filter()).toBe('-');
+        expect(filter(null)).toBe('-');
+        expect(filter(-1)).toBe('-');
+        expect(filter('a')).toBe('-');
       });
     });
   });


### PR DESCRIPTION
When cutting this over to TS, I fixed some really bad code that was returning `NaN` for `runningTimeInMs`, but didn't do a good job testing it against a running pipeline.

Now explicitly short-circuiting and returning null if the item has not started.