### PR TITLE
(core) limit URL size when fetching tags

### DIFF
--- a/app/scripts/modules/core/entityTag/entityTags.read.service.spec.ts
+++ b/app/scripts/modules/core/entityTag/entityTags.read.service.spec.ts
@@ -1,0 +1,62 @@
+import {mock} from 'angular';
+
+import {EntityTagsReader, ENTITY_TAGS_READ_SERVICE} from './entityTags.read.service';
+import IProvideService = angular.auto.IProvideService;
+
+describe('entityTags reader', () => {
+
+  let $http: ng.IHttpBackendService;
+  let $q: ng.IQService;
+  let $scope: ng.IScope;
+  let $exceptionHandler: ng.IExceptionHandlerService;
+  let service: EntityTagsReader;
+  let settings: any;
+
+  beforeEach(mock.module(ENTITY_TAGS_READ_SERVICE));
+
+  beforeEach(mock.module(($exceptionHandlerProvider: ng.IExceptionHandlerProvider, $provide: IProvideService) => {
+    $exceptionHandlerProvider.mode('log');
+    return $provide.constant('settings', {
+      gateUrl: 'http://gate',
+      entityTags: {
+        maxUrlLength: 55,
+      },
+    });
+  }));
+
+  beforeEach(
+    mock.inject(($httpBackend: ng.IHttpBackendService,
+                 _$q_: ng.IQService,
+                 $rootScope: ng.IRootScopeService,
+                 _$exceptionHandler_: ng.IExceptionHandlerService,
+                 entityTagsReader: EntityTagsReader,
+                 _settings_: any) => {
+      $http = $httpBackend;
+      $q = _$q_;
+      $scope = $rootScope.$new();
+      service = entityTagsReader;
+      settings = _settings_;
+      $exceptionHandler = _$exceptionHandler_;
+    }));
+
+  it('returns an empty list instead of failing if tags cannot be loaded', () => {
+    $http.expectGET(`${settings.gateUrl}/tags?entityId=a,b&entityType=servergroups`).respond(400, 'bad request');
+    let result: any = null;
+    service.getAllEntityTags('serverGroups', ['a', 'b']).then(r => result = r);
+    $http.flush();
+    expect(result).toEqual([]);
+    expect(($exceptionHandler as any)['errors'].length).toBe(1);
+  });
+
+  it('collates entries into groups when there are too many', () => {
+    $http.expectGET(`http://gate/tags?entityId=a,b&entityType=servergroups`).respond(200, []);
+    $http.expectGET(`http://gate/tags?entityId=c,d&entityType=servergroups`).respond(200, []);
+
+    let result: any = null;
+    service.getAllEntityTags('serverGroups', ['a', 'b', 'c', 'd']).then(r => result = r);
+    $http.flush();
+    $scope.$digest();
+    expect(result).toEqual([]);
+    expect(($exceptionHandler as any)['errors'].length).toBe(0);
+  });
+});

--- a/app/scripts/modules/core/entityTag/entityTags.read.service.ts
+++ b/app/scripts/modules/core/entityTag/entityTags.read.service.ts
@@ -1,28 +1,53 @@
 import {module} from 'angular';
+import {get} from 'lodash';
+
 import {API_SERVICE, Api} from 'core/api/api.service';
 import {IEntityTags, IEntityTag} from '../domain/IEntityTags';
 
 export class EntityTagsReader {
 
-  static get $inject() { return ['API', '$q']; }
+  static get $inject() { return ['API', '$q', '$exceptionHandler', 'settings']; }
 
-  public constructor(private API: Api, private $q: ng.IQService) {}
+  constructor(private API: Api,
+                     private $q: ng.IQService,
+                     private $exceptionHandler: ng.IExceptionHandlerService,
+                     private settings: any) {}
 
   public getAllEntityTags(entityType: string, entityIds: string[]): ng.IPromise<IEntityTags[]> {
-    const source = this.API.one('tags')
+    const idGroups: string[] = this.collateEntityIds(entityType, entityIds);
+    const sources = idGroups.map(idGroup => this.API.one('tags')
         .withParams({
           entityType: entityType.toLowerCase(),
-          entityId: entityIds.join(',')
-        }).getList();
+          entityId: idGroup
+        }).getList()
+    );
 
-    return source.then((entityTags: IEntityTags[]) => {
-      entityTags.forEach(entityTag => {
+    let result: ng.IDeferred<IEntityTags[]> = this.$q.defer();
+
+    this.$q.all(sources).then(
+      (entityTagGroups: IEntityTags[][]) => {
+        const allTags: IEntityTags[] = this.flattenTagsAndAddMetadata(entityTagGroups);
+        result.resolve(allTags);
+      })
+      .catch((error: any) => {
+        this.$exceptionHandler(new Error(error), 'Failed to load entity tags');
+        result.resolve([]);
+      });
+
+    return result.promise;
+  }
+
+  private flattenTagsAndAddMetadata(entityTagGroups: IEntityTags[][]): IEntityTags[] {
+    const allTags: IEntityTags[] = [];
+    entityTagGroups.forEach(entityTagGroup => {
+      entityTagGroup.forEach(entityTag => {
         entityTag.tags.forEach(tag => this.addTagMetadata(entityTag, tag));
         entityTag.alerts = entityTag.tags.filter(t => t.name.startsWith('spinnaker_ui_alert:'));
         entityTag.notices = entityTag.tags.filter(t => t.name.startsWith('spinnaker_ui_notice:'));
+        allTags.push(entityTag);
       });
-      return entityTags;
     });
+    return allTags;
   }
 
   private addTagMetadata(entityTag: IEntityTags, tag: IEntityTag): void {
@@ -34,8 +59,40 @@ export class EntityTagsReader {
       tag.lastModifiedBy = metadata.lastModifiedBy;
     }
   }
+
+  private collateEntityIds(entityType: string, entityIds: string[]): string[] {
+    const baseUrlLength = `${this.settings.gateUrl}/tags?entityType=${entityType}&entityIds=`.length;
+    const maxIdGroupLength = get(this.settings, 'entityTags.maxUrlLength', 4000) - baseUrlLength;
+    const idGroups: string[] = [];
+    const joinedEntityIds = entityIds.join(',');
+
+    if (joinedEntityIds.length > maxIdGroupLength) {
+      let index = 0,
+        currentLength = 0,
+        currentGroup: string[] = [];
+      while (index < entityIds.length) {
+        if (currentLength + entityIds[index].length + 1 > maxIdGroupLength) {
+          idGroups.push(currentGroup.join(','));
+          currentGroup.length = 0;
+          currentLength = 0;
+        }
+        currentGroup.push(entityIds[index]);
+        currentLength += entityIds[index].length + 1;
+        index++;
+      }
+      if (currentGroup.length) {
+        idGroups.push(currentGroup.join(','));
+      }
+    } else {
+      idGroups.push(joinedEntityIds);
+    }
+
+    return idGroups;
+  }
 }
 
 export const ENTITY_TAGS_READ_SERVICE = 'spinnaker.core.entityTag.read.service';
-module(ENTITY_TAGS_READ_SERVICE, [API_SERVICE])
-  .service('entityTagsReader', EntityTagsReader);
+module(ENTITY_TAGS_READ_SERVICE, [
+  API_SERVICE,
+  require('core/config/settings'),
+]).service('entityTagsReader', EntityTagsReader);


### PR DESCRIPTION
We ran into an issue where an application had > 150 server groups (and all had pretty long names), which blew out Gate.

This splits the URL for fetching tags into parallel fetches, then aggregates them.

If any of the calls fail, it will not break the UI - we just won't have the tags loaded, and we'll (at Netflix, at least) be notified of the load failure via the alert handler.