### PR TITLE
(aws) params should have default value in security group upsert

### DIFF
--- a/app/scripts/modules/core/securityGroup/securityGroupWriter.service.ts
+++ b/app/scripts/modules/core/securityGroup/securityGroupWriter.service.ts
@@ -42,14 +42,14 @@ export class SecurityGroupWriter {
   public upsertSecurityGroup(securityGroup: ISecurityGroup,
                              application: Application,
                              description: string,
-                             params: ISecurityGroupJob): ng.IPromise<ITask> {
+                             params: any = {}): ng.IPromise<ITask> {
 
     params.type = 'upsertSecurityGroup';
     params.credentials = securityGroup.credentials || securityGroup.accountName;
-    Object.assign(params, securityGroup);
+    let job: ISecurityGroupJob = Object.assign(params, securityGroup);
 
     const operation: ng.IPromise<ITask> = this.executor.executeTask({
-      job: [params],
+      job: [job],
       application: application,
       description: `${description} Security Group: ${securityGroup.name}`
     });


### PR DESCRIPTION
@icfantv some of the places where `upsertSecurityGroup` is called do not call it with `params`, which causes an error. 

Also, many of the places that do call it with `params` don't match the `ISecurityGroupJob` interface... not sure if you'd prefer I massage the callsites or leave `params` as `any`.