### PR TITLE
(core) switch assign order in load balancer writer

### DIFF
--- a/app/scripts/modules/core/loadBalancer/loadBalancer.write.service.ts
+++ b/app/scripts/modules/core/loadBalancer/loadBalancer.write.service.ts
@@ -14,7 +14,7 @@ export interface ILoadBalancerUpsertDescription extends IJob {
   healthCheckPath?: string;
 }
 
-export interface ILoadBalancerDeleteDescription {
+export interface ILoadBalancerDeleteDescription extends IJob {
   cloudProvider: string;
   loadBalancerName: string;
   credentials: string;
@@ -29,34 +29,27 @@ export class LoadBalancerWriter {
   public constructor(private infrastructureCaches: InfrastructureCacheService, private taskExecutor: TaskExecutor) {}
 
   public deleteLoadBalancer(command: ILoadBalancerDeleteDescription, application: Application): ng.IPromise<ITask> {
-    const job: IJob = {
-      type: 'deleteLoadBalancer',
-    };
-
-    Object.assign(job, command);
+    command.type = 'deleteLoadBalancer';
 
     this.infrastructureCaches.clearCache('loadBalancers');
 
     return this.taskExecutor.executeTask({
-      job: [job],
+      job: [command],
       application: application,
       description: `Delete load balancer: ${command.loadBalancerName}`
     });
   }
 
   public upsertLoadBalancer(command: ILoadBalancerUpsertDescription, application: Application, descriptor: string, params: any = {}): ng.IPromise<ITask> {
-    const job: IJob = {
-      type: 'upsertLoadBalancer'
-    };
-
-    Object.assign(job, command, params);
+    Object.assign(command, params);
+    command.type = 'upsertLoadBalancer';
 
     this.infrastructureCaches.clearCache('loadBalancers');
 
     return this.taskExecutor.executeTask({
-      job: [job],
+      job: [command],
       application: application,
-      description: `${descriptor} Load Balancer: ${job['name']}`,
+      description: `${descriptor} Load Balancer: ${command['name']}`,
     });
   }
 }

--- a/app/scripts/modules/google/loadBalancer/configure/ssl/gceCreateSslLoadBalancer.controller.ts
+++ b/app/scripts/modules/google/loadBalancer/configure/ssl/gceCreateSslLoadBalancer.controller.ts
@@ -43,7 +43,7 @@ class SslLoadBalancer implements IGceLoadBalancer {
   account: string;
   certificate: string;
   backendService: IGceBackendService = { healthCheck: { healthCheckType: 'TCP' } } as IGceBackendService;
-  get cloudProvider(): string { return 'gce'; };
+  cloudProvider: string;
   get name(): string { return this.loadBalancerName; }
   constructor (public region = 'global') {}
 }
@@ -203,6 +203,7 @@ class SslLoadBalancerCtrl extends CommonGceLoadBalancerCtrl implements ng.ICompo
     let descriptor = this.isNew ? 'Create' : 'Update';
     let toSubmitLoadBalancer = _.cloneDeep(this.loadBalancer) as ISslLoadBalancerUpsertDescription;
     toSubmitLoadBalancer.backendService.name = toSubmitLoadBalancer.name;
+    toSubmitLoadBalancer.cloudProvider = 'gce';
     delete toSubmitLoadBalancer['instances'];
 
     this.taskMonitor.submit(() => this.loadBalancerWriter.upsertLoadBalancer(toSubmitLoadBalancer,

--- a/app/scripts/modules/netflix/pipeline/stage/properties/create/propertyStage.js
+++ b/app/scripts/modules/netflix/pipeline/stage/properties/create/propertyStage.js
@@ -7,6 +7,7 @@ import {AUTHENTICATION_SERVICE} from 'core/authentication/authentication.service
 import {CLOUD_PROVIDER_REGISTRY} from 'core/cloudProvider/cloudProvider.registry';
 
 module.exports = angular.module('spinnaker.netflix.pipeline.stage.propertyStage', [
+  AUTHENTICATION_SERVICE,
   require('core/application/listExtractor/listExtractor.service.js'),
   CLOUD_PROVIDER_REGISTRY,
   require('core/config/settings.js'),


### PR DESCRIPTION
@anotherchrisberry or @icfantv please review.

A load balancer has a property `type` (I see this in the load balancer model in Clouddriver), which is the cloud provider identifier string. This string can override `job.type` in the load balancer writer.

Also I've explicitly set the `cloudProvider` field for Google SSL load balancers, since sometimes that description is not created from the SslLoadBalancer class and does not get the `cloudProvider` getter.