### PR TITLE
(core) allow alerts/notices to be configured at the cluster level

### DIFF
--- a/app/scripts/modules/amazon/serverGroup/details/serverGroupDetails.aws.controller.js
+++ b/app/scripts/modules/amazon/serverGroup/details/serverGroupDetails.aws.controller.js
@@ -12,6 +12,7 @@ import {SERVER_GROUP_READER} from 'core/serverGroup/serverGroupReader.service';
 import {SERVER_GROUP_WRITER} from 'core/serverGroup/serverGroupWriter.service';
 import {SERVER_GROUP_WARNING_MESSAGE_SERVICE} from 'core/serverGroup/details/serverGroupWarningMessage.service';
 import {RUNNING_TASKS_DETAILS_COMPONENT} from 'core/serverGroup/details/runningTasks.component';
+import {NAMING_SERVICE} from 'core/naming/naming.service';
 
 require('../configure/serverGroup.configure.aws.module.js');
 
@@ -25,6 +26,7 @@ module.exports = angular.module('spinnaker.serverGroup.details.aws.controller', 
   ACCOUNT_SERVICE,
   VIEW_SCALING_ACTIVITIES_LINK,
   ADD_ENTITY_TAG_LINKS_COMPONENT,
+  NAMING_SERVICE,
   require('../../vpc/vpcTag.directive.js'),
   require('./scalingProcesses/autoScalingProcess.service.js'),
   SERVER_GROUP_READER,
@@ -43,7 +45,7 @@ module.exports = angular.module('spinnaker.serverGroup.details.aws.controller', 
   .controller('awsServerGroupDetailsCtrl', function ($scope, $state, app, serverGroup,
                                                      serverGroupReader, awsServerGroupCommandBuilder, $uibModal,
                                                      confirmationModalService, serverGroupWriter, subnetReader,
-                                                     autoScalingProcessService,
+                                                     autoScalingProcessService, namingService,
                                                      awsServerGroupTransformer, accountService,
                                                      serverGroupWarningMessageService, overrideRegistry) {
 
@@ -151,7 +153,7 @@ module.exports = angular.module('spinnaker.serverGroup.details.aws.controller', 
                 this.scheduledActionsDisabled = this.serverGroup.scheduledActions.length && this.autoScalingProcesses
                     .filter(p => !p.enabled)
                     .some(p => ['Launch','Terminate','ScheduledAction'].includes(p.name));
-
+                configureEntityTagTargets();
               } else {
                 autoClose();
               }
@@ -168,6 +170,37 @@ module.exports = angular.module('spinnaker.serverGroup.details.aws.controller', 
         app.serverGroups.onRefresh($scope, retrieveServerGroup);
       }
     });
+
+    let configureEntityTagTargets = () => {
+      const clusterName = namingService.getClusterNameFromServerGroupName(this.serverGroup.name);
+      this.entityTagTargets = [
+        {
+          type: 'serverGroup',
+          label: `just ${this.serverGroup.name}`,
+          owner: this.serverGroup
+        },
+        {
+          type: 'cluster',
+          label: `all server groups in **${this.serverGroup.region}** in ${clusterName}`,
+          owner: {
+            name: namingService.getClusterNameFromServerGroupName(this.serverGroup.name),
+            cloudProvider: 'aws',
+            region: this.serverGroup.region,
+            account: this.serverGroup.account,
+          }
+        },
+        {
+          type: 'cluster',
+          label: `all server groups in **all regions** in ${clusterName}`,
+          owner: {
+            name: namingService.getClusterNameFromServerGroupName(this.serverGroup.name),
+            cloudProvider: 'aws',
+            region: '*',
+            account: this.serverGroup.account,
+          }
+        },
+      ];
+    };
 
     this.isEnableLocked = () => {
       if (this.serverGroup.isDisabled) {

--- a/app/scripts/modules/amazon/serverGroup/details/serverGroupDetails.aws.controller.spec.js
+++ b/app/scripts/modules/amazon/serverGroup/details/serverGroupDetails.aws.controller.spec.js
@@ -19,7 +19,7 @@ describe('Controller: AWS ServerGroupDetailsCtrl', function () {
       controller = $controller('awsServerGroupDetailsCtrl', {
         $scope: $scope,
         app: application,
-        serverGroup: {}
+        serverGroup: { name: 'foo-v001' }
       });
     })
   );

--- a/app/scripts/modules/core/cluster/clusterPod.html
+++ b/app/scripts/modules/core/cluster/clusterPod.html
@@ -9,6 +9,8 @@
                 <account-label-color account="{{parentHeading}}"></account-label-color>
                 <span class="glyphicon glyphicon-th"></span>
                 {{grouping.heading}}
+                <entity-ui-tags component="grouping" application="application" entity-type="cluster" class="inverse"
+                                on-update="application.serverGroups.refresh()"></entity-ui-tags>
                 <health-counts container="grouping.cluster.instanceCounts"></health-counts>
               </div>
             </h5>
@@ -20,7 +22,11 @@
   <div class="rollup-details">
     <div class="pod-subgroup" ng-repeat="subgroup in grouping.subgroups">
       <h6 class="subgroup-title"
-          sticky-header added-offset-height="39">{{subgroup.heading}}</h6>
+          sticky-header added-offset-height="39">
+        {{subgroup.heading}}
+        <entity-ui-tags component="subgroup" application="application" entity-type="cluster"
+                        on-update="application.serverGroups.refresh()"></entity-ui-tags>
+      </h6>
       <server-group
         ng-repeat="serverGroup in subgroup.serverGroups | orderBy:'-name'"
         ng-if="grouping.cluster.category === 'serverGroup'"

--- a/app/scripts/modules/core/cluster/filter/clusterFilter.service.ts
+++ b/app/scripts/modules/core/cluster/filter/clusterFilter.service.ts
@@ -4,6 +4,7 @@ import {Application} from 'core/application/application.model';
 import {ServerGroup} from '../../domain/serverGroup';
 import {ICluster} from 'core/domain';
 import {Instance} from '../../domain/instance';
+import {IEntityTags} from '../../domain/IEntityTags';
 
 interface IParentGrouping {
   subgroups: IClusterSubgroup[] | IServerGroupSubgroup[];
@@ -13,6 +14,7 @@ export interface IClusterGroup extends IParentGrouping {
   heading: string;
   key: string;
   subgroups: IClusterSubgroup[];
+  entityTags?: IEntityTags;
 }
 
 export interface IClusterSubgroup extends IParentGrouping {
@@ -23,6 +25,7 @@ export interface IClusterSubgroup extends IParentGrouping {
   subgroups: IServerGroupSubgroup[];
   hasDiscovery?: boolean;
   hasLoadBalancers?: boolean;
+  entityTags: IEntityTags;
 }
 
 export interface IServerGroupSubgroup {
@@ -30,6 +33,7 @@ export interface IServerGroupSubgroup {
   key: string;
   category: string;
   serverGroups: ServerGroup[];
+  entityTags: IEntityTags;
 }
 
 type Grouping = IClusterGroup | IClusterSubgroup | IServerGroupSubgroup;
@@ -66,6 +70,7 @@ export class ClusterFilterService {
               category: category,
               serverGroups: regionGroup,
               key: `${region}:${category}`,
+              entityTags: (regionGroup[0].clusterEntityTags || []).find(t => t.entityRef['region'] === region),
             });
           });
 
@@ -79,6 +84,7 @@ export class ClusterFilterService {
               key: `${cluster}:${category}`,
               cluster: appCluster,
               subgroups: sortBy(regionGroups, 'heading'),
+              entityTags: (clusterGroup[0].clusterEntityTags || []).find(t => t.entityRef['region'] === '*'),
             });
           }
         });
@@ -400,6 +406,9 @@ export class ClusterFilterService {
         }
         if (newGroup.hasOwnProperty('serverGroups')) {
           this.diffServerGroups(oldGroup as IServerGroupSubgroup, newGroup as IServerGroupSubgroup);
+        }
+        if (oldGroup.entityTags || newGroup.entityTags) {
+          oldGroup.entityTags = newGroup.entityTags;
         }
       }
     });

--- a/app/scripts/modules/core/domain/ICluster.ts
+++ b/app/scripts/modules/core/domain/ICluster.ts
@@ -2,6 +2,8 @@ import {ServerGroup} from './serverGroup';
 
 export interface ICluster {
   account: string;
+  region: string;
+  cloudProvider: string;
   category: string;
   name: string;
   serverGroups: ServerGroup[];

--- a/app/scripts/modules/core/domain/serverGroup.ts
+++ b/app/scripts/modules/core/domain/serverGroup.ts
@@ -20,6 +20,7 @@ export interface ServerGroup {
   cloudProvider: string;
   cluster: string;
   entityTags?: IEntityTags;
+  clusterEntityTags?: IEntityTags[];
   detail?: string;
   runningExecutions?: Execution[];
   instanceCounts: InstanceCounts;

--- a/app/scripts/modules/core/entityTag/addEntityTagLinks.component.ts
+++ b/app/scripts/modules/core/entityTag/addEntityTagLinks.component.ts
@@ -1,41 +1,28 @@
 import {module} from 'angular';
-import {has} from 'lodash';
-
 import {IModalService} from 'angular-ui-bootstrap';
 
 import {IEntityTag} from 'core/domain';
-import {ENTITY_TAG_EDITOR_CTRL, EntityTagEditorCtrl} from './entityTagEditor.controller';
+import {IEntityRef} from 'core/domain/IEntityTags';
+import {ENTITY_TAG_EDITOR_CTRL, EntityTagEditorCtrl, IOwnerOption} from './entityTagEditor.controller';
 import {ENTITY_TAGS_HELP} from './entityTags.help';
 import {Application} from 'core/application/application.model';
-
-import './entityTagDetails.component.less';
 import {ENTITY_TAG_WRITER, EntityTagWriter} from './entityTags.write.service';
 
+import './entityTagDetails.component.less';
+
 class AddEntityTagLinksCtrl implements ng.IComponentController {
-  public tags: IEntityTag[];
   public application: Application;
   public tagType: string;
 
   private component: any;
   private entityType: string;
   private onUpdate: () => any;
+  private ownerOptions: IOwnerOption[];
 
   static get $inject() { return ['$uibModal', 'confirmationModalService', 'entityTagWriter']; }
 
   public constructor(private $uibModal: IModalService, private confirmationModalService: any,
                      private entityTagWriter: EntityTagWriter) {}
-
-  public $onInit(): void {
-    if (this.component.entityTags) {
-      this.tags = this.component.entityTags.tags
-        .filter((t: IEntityTag) => has(t, 'value.type') && t.value.type === this.tagType)
-        .sort((a: IEntityTag, b: IEntityTag) => a.created - b.created);
-    }
-  }
-
-  public $onChanges(): void {
-    this.$onInit();
-  }
 
   public addTag(tagType: string): void {
     this.$uibModal.open({
@@ -56,11 +43,12 @@ class AddEntityTagLinksCtrl implements ng.IComponentController {
         owner: (): any => this.component,
         entityType: (): string => this.entityType,
         application: (): Application => this.application,
+        entityRef: (): IEntityRef => null,
         onUpdate: (): any => this.onUpdate,
+        ownerOptions: (): IOwnerOption[] => this.ownerOptions,
       }
     });
   }
-
 }
 
 class AddEntityTagLinksComponent implements ng.IComponentOptions {
@@ -70,6 +58,7 @@ class AddEntityTagLinksComponent implements ng.IComponentOptions {
     entityType: '@',
     onUpdate: '&?',
     tagType: '@',
+    ownerOptions: '<?',
   };
   public controller: any = AddEntityTagLinksCtrl;
   public template: string = `

--- a/app/scripts/modules/core/entityTag/dataSourceAlerts.component.ts
+++ b/app/scripts/modules/core/entityTag/dataSourceAlerts.component.ts
@@ -19,6 +19,7 @@ class DataSourceAlertsCtrl implements ng.IComponentController {
 
   public showPopover(): void {
     this.displayPopover = true;
+    this.popoverHovered();
   }
 
   public popoverHovered(): void {

--- a/app/scripts/modules/core/entityTag/entityRef.builder.ts
+++ b/app/scripts/modules/core/entityTag/entityRef.builder.ts
@@ -2,6 +2,7 @@ import {ServerGroup} from '../domain/serverGroup';
 import {ILoadBalancer} from '../domain/loadBalancer';
 import {Application} from '../application/application.model';
 import {IEntityRef} from '../domain/IEntityTags';
+import {ICluster} from '../domain/ICluster';
 
 export class EntityRefBuilder {
 
@@ -33,6 +34,16 @@ export class EntityRefBuilder {
     };
   }
 
+  public static buildClusterRef(cluster: ICluster): IEntityRef {
+    return {
+      cloudProvider: cluster.cloudProvider,
+      entityType: 'cluster',
+      entityId: cluster.name,
+      account: cluster.account,
+      region: cluster.region,
+    };
+  }
+
   public static getBuilder(type: string): (entity: any) => IEntityRef {
     switch (type) {
       case 'application':
@@ -41,6 +52,8 @@ export class EntityRefBuilder {
         return this.buildServerGroupRef;
       case 'loadBalancer':
         return this.buildLoadBalancerRef;
+      case 'cluster':
+        return this.buildClusterRef;
       default:
         return null;
     }

--- a/app/scripts/modules/core/entityTag/entityTagEditor.modal.html
+++ b/app/scripts/modules/core/entityTag/entityTagEditor.modal.html
@@ -27,6 +27,27 @@
           </div>
         </div>
       </div>
+      <div ng-if="$ctrl.ownerOptions.length">
+        <div class="row">
+          <div class="col-md-10 col-md-offset-1">
+            <div class="form-group">
+              <div class="col-md-3 sm-label-right">
+                <b>Applies to</b>
+              </div>
+              <div class="col-md-9">
+                <div ng-repeat="option in $ctrl.ownerOptions">
+                  <div class="radio">
+                    <label>
+                      <input type="radio" ng-model="$ctrl.owner" ng-value="option.owner" ng-change="$ctrl.ownerChanged(option)"/>
+                      <span marked="option.label"></span>
+                    </label>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
     </form>
   </div>
   <div class="modal-footer">

--- a/app/scripts/modules/core/entityTag/entityTagEditor.modal.less
+++ b/app/scripts/modules/core/entityTag/entityTagEditor.modal.less
@@ -7,4 +7,11 @@
       padding-top: 5px;
     }
   }
+  label {
+    [marked] {
+      p {
+        margin-bottom: 0;
+      }
+    }
+  }
 }

--- a/app/scripts/modules/core/entityTag/entityTags.write.service.ts
+++ b/app/scripts/modules/core/entityTag/entityTags.write.service.ts
@@ -1,7 +1,6 @@
 import {module} from 'angular';
 import {TASK_EXECUTOR, TaskExecutor} from '../task/taskExecutor';
 import {Application} from 'core/application/application.model';
-import {EntityRefBuilder} from './entityRef.builder';
 import {IEntityRef, IEntityTags, IEntityTag} from '../domain/IEntityTags';
 
 export class EntityTagWriter {
@@ -10,25 +9,21 @@ export class EntityTagWriter {
 
   public constructor(private $q: ng.IQService, private taskExecutor: TaskExecutor) {}
 
-  public upsertEntityTag(application: Application, tag: IEntityTag, owner: any, entityType: string, isNew: boolean): ng.IPromise<any> {
-    const refBuilder: (entity: any) => IEntityRef = EntityRefBuilder.getBuilder(entityType);
-    if (refBuilder) {
-      return this.taskExecutor.executeTask({
-        application: application,
-        description: `${isNew ? 'Create' : 'Update'} entity tag on ${owner.name}`,
-        job: [
-          {
-            type: 'upsertEntityTags',
-            application: application.name,
-            entityId: owner.name,
-            entityRef: refBuilder(owner),
-            tags: [tag],
-            isPartial: true,
-          }
-        ]
-      });
-    }
-    return this.$q.reject(`No processor found for entity type: ${entityType}`);
+  public upsertEntityTag(application: Application, tag: IEntityTag, entityRef: IEntityRef, isNew: boolean): ng.IPromise<any> {
+    return this.taskExecutor.executeTask({
+      application: application,
+      description: `${isNew ? 'Create' : 'Update'} entity tag on ${entityRef.entityId}`,
+      job: [
+        {
+          type: 'upsertEntityTags',
+          application: application.name,
+          entityId: entityRef.entityId,
+          entityRef: entityRef,
+          tags: [tag],
+          isPartial: true,
+        }
+      ]
+    });
   }
 
   public deleteEntityTag(application: Application, owner: any, entityTag: IEntityTags, tag: string) {

--- a/app/scripts/modules/core/entityTag/entityUiTags.component.ts
+++ b/app/scripts/modules/core/entityTag/entityUiTags.component.ts
@@ -7,14 +7,12 @@ import {IModalService} from 'angular-ui-bootstrap';
 import {EntityTagEditorCtrl} from './entityTagEditor.controller';
 
 import './entityUiTags.popover.less';
+import {IEntityRef} from '../domain/IEntityTags';
 
 class EntityUiTagsCtrl implements ng.IComponentController {
 
-  public alerts: IEntityTag[] = [];
-  public notices: IEntityTag[] = [];
   public application: Application;
   public entityType: string;
-  public hasTags: boolean = false;
   public popoverTemplate: string = require('./entityUiTags.popover.html');
   public popoverType: string;
   public displayPopover: boolean;
@@ -28,22 +26,6 @@ class EntityUiTagsCtrl implements ng.IComponentController {
 
   public constructor(private $timeout: ng.ITimeoutService, private $uibModal: IModalService,
                      private confirmationModalService: any, private entityTagWriter: EntityTagWriter) {}
-
-  public $onInit(): void {
-    if (this.component.entityTags) {
-      this.alerts = this.component.entityTags.alerts;
-      this.notices = this.component.entityTags.notices;
-      this.hasTags = this.alerts.length + this.notices.length > 0;
-    } else {
-      this.alerts = [];
-      this.notices = [];
-      this.hasTags = false;
-    }
-  }
-
-  public $onChanges(): void {
-    this.$onInit();
-  }
 
   public $onDestroy(): void {
     if (this.popoverClose) {
@@ -89,7 +71,9 @@ class EntityUiTagsCtrl implements ng.IComponentController {
         owner: (): any => this.component,
         entityType: (): string => this.entityType,
         application: (): Application => this.application,
-        onUpdate: (): any => this.onUpdate
+        onUpdate: (): any => this.onUpdate,
+        ownerOptions: (): any => null,
+        entityRef: (): IEntityRef => this.component.entityTags.entityRef,
       }
     });
   }
@@ -100,8 +84,9 @@ class EntityUiTagsCtrl implements ng.IComponentController {
 
   public showPopover(type: string): void {
     this.popoverType = type;
-    this.popoverContents = type === 'alert' ? this.alerts : this.notices;
+    this.popoverContents = type === 'alert' ? this.component.entityTags.alerts : this.component.entityTags.notices;
     this.displayPopover = true;
+    this.popoverHovered();
   }
 
   public popoverHovered(): void {
@@ -134,8 +119,8 @@ class EntityUiTagsComponent implements ng.IComponentOptions {
   };
   public controller: any = EntityUiTagsCtrl;
   public template: string = `
-    <span ng-if="$ctrl.hasTags">
-      <span ng-if="$ctrl.alerts.length > 0"
+    <span ng-if="$ctrl.component.entityTags.alerts.length + $ctrl.component.entityTags.notices.length > 0">
+      <span ng-if="$ctrl.component.entityTags.alerts.length > 0"
             class="tag-marker" 
             ng-mouseover="$ctrl.showPopover('alert')" 
             ng-mouseleave="$ctrl.hidePopover(true)">
@@ -147,7 +132,7 @@ class EntityUiTagsComponent implements ng.IComponentOptions {
           <i class="fa fa-exclamation-triangle"></i>
         </span>
       </span>
-      <span ng-if="$ctrl.notices.length > 0"
+      <span ng-if="$ctrl.component.entityTags.notices.length > 0"
             class="tag-marker"
             ng-mouseover="$ctrl.showPopover('notice')" 
             ng-mouseleave="$ctrl.hidePopover(true)">

--- a/app/scripts/modules/netflix/serverGroup/awsServerGroupDetails.html
+++ b/app/scripts/modules/netflix/serverGroup/awsServerGroupDetails.html
@@ -25,7 +25,9 @@
       <cloud-provider-logo provider="ctrl.serverGroup.type" height="36px" width="36px" style="margin-right: 10px"></cloud-provider-logo>
       <h3 select-on-dbl-click>
         {{ctrl.serverGroup.name}}
-        <entity-ui-tags component="ctrl.serverGroup" application="ctrl.application" entity-type="serverGroup"
+        <entity-ui-tags component="ctrl.serverGroup"
+                        application="ctrl.application"
+                        entity-type="serverGroup"
                         on-update="ctrl.application.serverGroups.refresh()"></entity-ui-tags>
       </h3>
     </div>
@@ -54,6 +56,7 @@
             <add-entity-tag-links component="ctrl.serverGroup"
                                   application="ctrl.application"
                                   entity-type="serverGroup"
+                                  owner-options="ctrl.entityTagTargets"
                                   on-update="ctrl.application.serverGroups.refresh()"></add-entity-tag-links>
           </ul>
         </div>

--- a/test/mock/mockApplicationData.js
+++ b/test/mock/mockApplicationData.js
@@ -27,10 +27,12 @@ module.exports = angular
         key: 'in-eu-east-2-only:serverGroup',
         hasDiscovery: false,
         hasLoadBalancers: false,
+        entityTags: undefined,
         subgroups : [ {
           heading : 'eu-east-2',
           category: 'serverGroup',
           key: 'eu-east-2:serverGroup',
+          entityTags: undefined,
           serverGroups : [ {
             cluster: 'in-eu-east-2-only',
             category: 'serverGroup',
@@ -62,10 +64,12 @@ module.exports = angular
           key: 'in-us-west-1-only:serverGroup',
           hasDiscovery: false,
           hasLoadBalancers: false,
+          entityTags: undefined,
           subgroups : [ {
             heading : 'us-west-1',
             category: 'serverGroup',
             key: 'us-west-1:serverGroup',
+            entityTags: undefined,
             serverGroups : [ {
               cluster: 'in-us-west-1-only',
               category: 'serverGroup',


### PR DESCRIPTION
Adding the ability to specify a scope when creating a notice/alert. This is specifically targeted to clusters, but could be applied to other entities.
<img width="587" alt="screen shot 2017-01-19 at 10 07 13 am" src="https://cloud.githubusercontent.com/assets/73450/22119107/23b353ee-de2f-11e6-872a-051e699f4af4.png">

Results in:
<img width="706" alt="screen shot 2017-01-19 at 10 09 17 am" src="https://cloud.githubusercontent.com/assets/73450/22119171/67aae72e-de2f-11e6-84a1-6a316fc73f3e.png">
(cross-region alert, regional notice)

This lets users create alerts/notices and have them persist across deployments.

I expect this functionality to continue to evolve as internal users provide feedback, hence the lack of tests.
