### PR TITLE
(core) do not try to fetch tags if no entities present

### DIFF
--- a/app/scripts/modules/core/entityTag/entityTags.read.service.ts
+++ b/app/scripts/modules/core/entityTag/entityTags.read.service.ts
@@ -14,6 +14,9 @@ export class EntityTagsReader {
                      private settings: any) {}
 
   public getAllEntityTags(entityType: string, entityIds: string[]): ng.IPromise<IEntityTags[]> {
+    if (!entityIds || !entityIds.length) {
+      return this.$q.when([]);
+    }
     const idGroups: string[] = this.collateEntityIds(entityType, entityIds);
     const sources = idGroups.map(idGroup => this.API.one('tags')
         .withParams({
@@ -29,8 +32,8 @@ export class EntityTagsReader {
         const allTags: IEntityTags[] = this.flattenTagsAndAddMetadata(entityTagGroups);
         result.resolve(allTags);
       })
-      .catch((error: any) => {
-        this.$exceptionHandler(new Error(error), 'Failed to load entity tags');
+      .catch(() => {
+        this.$exceptionHandler(new Error('Failed to load entity tags.'));
         result.resolve([]);
       });
 


### PR DESCRIPTION
save a trip to the server if there's nothing to fetch; also fix the error message to avoid getting a message of `[object Object]`