### PR TITLE
(core) do not try to set app instance port on missing application

### DIFF
--- a/app/scripts/modules/core/application/config/applicationConfig.controller.js
+++ b/app/scripts/modules/core/application/config/applicationConfig.controller.js
@@ -18,9 +18,10 @@ module.exports = angular
   ])
   .controller('ApplicationConfigController', function ($state, app, settings) {
     this.application = app;
-    this.application.attributes.instancePort = this.application.attributes.instancePort || settings.defaultInstancePort || null;
     this.feature = settings.feature;
     if (app.notFound) {
       $state.go('home.infrastructure', null, {location: 'replace'});
+    } else {
+      this.application.attributes.instancePort = this.application.attributes.instancePort || settings.defaultInstancePort || null;
     }
   });


### PR DESCRIPTION
We sometimes get an error when a user deletes an application and the `attributes` do not exist. This prevents that.