### PR TITLE
(core) Fixed issue with around stage error messages not displaying when navigating from one stage to another.

### DIFF
--- a/app/scripts/modules/core/delivery/stageFailureMessage/stageFailureMessage.component.ts
+++ b/app/scripts/modules/core/delivery/stageFailureMessage/stageFailureMessage.component.ts
@@ -40,7 +40,7 @@ class StageFailureMessageComponent implements ng.IComponentOptions {
   };
   public controller: any = StageFailureMessageCtrl;
   public template: string = `
-    <div class="row" ng-if="$ctrl.isFailed">
+    <div class="row" ng-if="$ctrl.isFailed || $ctrl.messages.length || $ctrl.message">
       <div class="col-md-12">
         <div class="alert alert-danger">
           <div ng-if="$ctrl.message || !$ctrl.messages.length">

--- a/app/scripts/modules/netflix/pipeline/stage/canary/canaryStage.transformer.js
+++ b/app/scripts/modules/netflix/pipeline/stage/canary/canaryStage.transformer.js
@@ -150,6 +150,11 @@ module.exports = angular.module('spinnaker.netflix.pipeline.stage.canary.transfo
           if (getException(monitorStage)) {
             stage.exceptions.push('Monitor Canary failure: ' + getException(monitorStage));
           }
+
+          if (getException(deployParent)) {
+            stage.exceptions.push('Deploy Canary failure' + getException(deployParent));
+          }
+
           deployStages.forEach((deployStage) => {
             if (getException(deployStage)) {
               stage.exceptions.push(deployStage.name + ': ' + getException(deployStage));


### PR DESCRIPTION
(netflix) SPIN-2285: Display exceptions when there is an exception when deploying a canary cluster