### PR TITLE
(core) only validate app name against active providers

### DIFF
--- a/app/scripts/modules/core/application/modal/validation/applicationName.validator.spec.ts
+++ b/app/scripts/modules/core/application/modal/validation/applicationName.validator.spec.ts
@@ -2,12 +2,14 @@ import {mock} from 'angular';
 
 import {ApplicationNameValidator, IApplicationNameValidationResult, APPLICATION_NAME_VALIDATOR} from './applicationName.validator';
 import {ExampleApplicationNameValidator, ExampleApplicationNameValidator2, EXAMPLE_APPLICATION_NAME_VALIDATOR} from './exampleApplicationName.validator';
+import {AccountService} from 'core/account/account.service';
 
 describe('Validator: applicationName', () => {
 
   let validator: ApplicationNameValidator,
       validator1: ExampleApplicationNameValidator,
-      validator2: ExampleApplicationNameValidator2;
+      validator2: ExampleApplicationNameValidator2,
+      $scope: ng.IScope;
 
   beforeEach(
     mock.module(
@@ -17,23 +19,33 @@ describe('Validator: applicationName', () => {
   );
 
   beforeEach(mock.inject((applicationNameValidator: ApplicationNameValidator,
-                                  exampleApplicationNameValidator: ExampleApplicationNameValidator,
-                                  exampleApplicationNameValidator2: ExampleApplicationNameValidator2) => {
+                          exampleApplicationNameValidator: ExampleApplicationNameValidator,
+                          exampleApplicationNameValidator2: ExampleApplicationNameValidator2,
+                          $rootScope: ng.IRootScopeService,
+                          accountService: AccountService,
+                          $q: ng.IQService) => {
     validator = applicationNameValidator;
     validator1 = exampleApplicationNameValidator;
     validator2 = exampleApplicationNameValidator2;
+    $scope = $rootScope;
+    spyOn(accountService, 'listProviders').and.returnValue($q.when([validator1.provider, validator2.provider]));
   }));
 
   describe('warning messages', () => {
     it('aggregates warning messages when multiple or no providers are specified', () => {
-      let result: IApplicationNameValidationResult = validator.validate(validator1.COMMON_WARNING_CONDITION, []);
+      let result: IApplicationNameValidationResult = null;
+      validator.validate(validator1.COMMON_WARNING_CONDITION, [])
+        .then(r => result = r);
+      $scope.$digest();
       expect(result.warnings.length).toBe(2);
       expect(result.warnings[0].cloudProvider).toEqual(validator1.provider);
       expect(result.warnings[0].message).toEqual(validator1.COMMON_WARNING_MESSAGE);
       expect(result.warnings[1].cloudProvider).toEqual(validator2.provider);
       expect(result.warnings[1].message).toEqual(validator2.COMMON_WARNING_MESSAGE);
 
-      result = validator.validate(validator1.COMMON_WARNING_CONDITION, [validator1.provider, validator2.provider]);
+      validator.validate(validator1.COMMON_WARNING_CONDITION, [validator1.provider, validator2.provider])
+        .then(r => result = r);
+      $scope.$digest();
       expect(result.warnings[0].message).toEqual(validator1.COMMON_WARNING_MESSAGE);
       expect(result.warnings[0].cloudProvider).toEqual(validator1.provider);
       expect(result.warnings[1].cloudProvider).toEqual(validator2.provider);
@@ -41,10 +53,15 @@ describe('Validator: applicationName', () => {
     });
 
     it('provides warnings only from provider when specified', () => {
-      let result: IApplicationNameValidationResult = validator.validate(validator1.WARNING_CONDITION, [validator2.provider]);
+      let result: IApplicationNameValidationResult = null;
+      validator.validate(validator1.WARNING_CONDITION, [validator2.provider])
+        .then(r => result = r);
+      $scope.$digest();
       expect(result.warnings.length).toBe(0);
 
-      result = validator.validate(validator1.WARNING_CONDITION, [validator1.provider]);
+      validator.validate(validator1.WARNING_CONDITION, [validator1.provider])
+        .then(r => result = r);
+      $scope.$digest();
       expect(result.warnings.length).toBe(1);
       expect(result.warnings[0].cloudProvider).toEqual(validator1.provider);
       expect(result.warnings[0].message).toEqual(validator1.WARNING_MESSAGE);
@@ -53,14 +70,19 @@ describe('Validator: applicationName', () => {
 
   describe('error messages', () => {
     it('aggregates error messages when multiple or no providers are specified', () => {
-      let result: IApplicationNameValidationResult = validator.validate(validator1.COMMON_ERROR_CONDITION, []);
+      let result: IApplicationNameValidationResult = null;
+      validator.validate(validator1.COMMON_ERROR_CONDITION, [])
+        .then(r => result = r);
+      $scope.$digest();
       expect(result.errors.length).toBe(2);
       expect(result.errors[0].cloudProvider).toEqual(validator1.provider);
       expect(result.errors[0].message).toEqual(validator1.COMMON_ERROR_MESSAGE);
       expect(result.errors[1].cloudProvider).toEqual(validator2.provider);
       expect(result.errors[1].message).toEqual(validator2.COMMON_ERROR_MESSAGE);
 
-      result = validator.validate(validator1.COMMON_ERROR_CONDITION, [validator1.provider, validator2.provider]);
+      validator.validate(validator1.COMMON_ERROR_CONDITION, [validator1.provider, validator2.provider])
+        .then(r => result = r);
+      $scope.$digest();
       expect(result.errors[0].message).toEqual(validator1.COMMON_ERROR_MESSAGE);
       expect(result.errors[0].cloudProvider).toEqual(validator1.provider);
       expect(result.errors[1].cloudProvider).toEqual(validator2.provider);
@@ -68,10 +90,15 @@ describe('Validator: applicationName', () => {
     });
 
     it('provides errors only from provider when specified', () => {
-      let result: IApplicationNameValidationResult = validator.validate(validator1.ERROR_CONDITION, [validator2.provider]);
+      let result: IApplicationNameValidationResult = null;
+      validator.validate(validator1.ERROR_CONDITION, [validator2.provider])
+        .then(r => result = r);
+      $scope.$digest();
       expect(result.errors.length).toBe(0);
 
-      result = validator.validate(validator1.ERROR_CONDITION, [validator1.provider]);
+      validator.validate(validator1.ERROR_CONDITION, [validator1.provider])
+        .then(r => result = r);
+      $scope.$digest();
       expect(result.errors.length).toBe(1);
       expect(result.errors[0].cloudProvider).toEqual(validator1.provider);
       expect(result.errors[0].message).toEqual(validator1.ERROR_MESSAGE);

--- a/app/scripts/modules/core/application/modal/validation/applicationNameValidationMessages.component.ts
+++ b/app/scripts/modules/core/application/modal/validation/applicationNameValidationMessages.component.ts
@@ -18,7 +18,7 @@ class ApplicationNameValidationMessagesController implements ng.IComponentContro
   public constructor(private applicationNameValidator: ApplicationNameValidator) {}
 
   public $onChanges(changes: ng.IOnChangesObject): void {
-    this.messages = this.applicationNameValidator.validate(this.name, this.cloudProviders);
+    this.applicationNameValidator.validate(this.name, this.cloudProviders).then(r => this.messages = r);
   }
 }
 

--- a/app/scripts/modules/core/application/modal/validation/validateApplicationName.directive.spec.ts
+++ b/app/scripts/modules/core/application/modal/validation/validateApplicationName.directive.spec.ts
@@ -5,11 +5,14 @@ import {
   ExampleApplicationNameValidator2
 } from './exampleApplicationName.validator';
 import {VALIDATE_APPLICATION_NAME} from './validateApplicationName.directive';
+import {AccountService} from 'core/account/account.service';
 
 describe('Validator: validateApplicationName', function () {
 
   let validator1: ExampleApplicationNameValidator,
-      validator2: ExampleApplicationNameValidator2;
+      validator2: ExampleApplicationNameValidator2,
+      accountService: AccountService,
+      $q: ng.IQService;
 
   beforeEach(
     mock.module(
@@ -19,12 +22,15 @@ describe('Validator: validateApplicationName', function () {
   );
 
   beforeEach(mock.inject(function ($rootScope: ng.IRootScopeService, $compile: ng.ICompileService,
-                                           exampleApplicationNameValidator: ExampleApplicationNameValidator,
-                                           exampleApplicationNameValidator2: ExampleApplicationNameValidator2) {
+                                   exampleApplicationNameValidator: ExampleApplicationNameValidator,
+                                   exampleApplicationNameValidator2: ExampleApplicationNameValidator2,
+                                   _accountService_: AccountService, _$q_: ng.IQService) {
     this.$rootScope = $rootScope;
     this.compile = $compile;
     validator1 = exampleApplicationNameValidator;
     validator2 = exampleApplicationNameValidator2;
+    accountService = _accountService_;
+    $q = _$q_;
   }));
 
   beforeEach(function() {
@@ -47,6 +53,10 @@ describe('Validator: validateApplicationName', function () {
   });
 
   describe('valid cases', function () {
+
+    beforeEach(() => {
+      spyOn(accountService, 'listProviders').and.returnValue($q.when([validator1.provider, validator2.provider]));
+    });
 
     it('should be valid when no provider selected and name does not match warning or error condition', function () {
       this.initialize('zz' + validator1.WARNING_CONDITION, []);
@@ -86,7 +96,20 @@ describe('Validator: validateApplicationName', function () {
     });
   });
 
+  describe('provider checks', function () {
+
+    it('should not run validators on providers with no accounts configured', function () {
+      spyOn(accountService, 'listProviders').and.returnValue($q.when([validator1.provider]));
+      this.initialize(validator2.ERROR_CONDITION, []);
+      expect(this.isValid()).toBe(true);
+    });
+  });
+
   describe ('invalid cases', function () {
+
+    beforeEach(() => {
+      spyOn(accountService, 'listProviders').and.returnValue($q.when([validator1.provider, validator2.provider]));
+    });
 
     it('should be invalid if name is invalid for any provider and none specified', function () {
       this.initialize(validator1.ERROR_CONDITION, []);
@@ -107,6 +130,11 @@ describe('Validator: validateApplicationName', function () {
   });
 
   describe ('value/option changes', function () {
+
+    beforeEach(() => {
+      spyOn(accountService, 'listProviders').and.returnValue($q.when([validator1.provider, validator2.provider]));
+    });
+
     it ('should flip when providers change', function () {
       this.initialize(validator2.ERROR_CONDITION, [validator1.provider]);
       expect(this.isValid()).toBe(true);

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -40,6 +40,10 @@ module.exports = function(config) {
       Chrome_travis_ci: {
         base: 'Chrome',
         flags: ['--no-sandbox']
+      },
+      ChromeActive: {
+        base: 'Chrome',
+        flags: [ '--override-plugin-power-saver-for-testing=0' ]
       }
     },
 
@@ -59,7 +63,7 @@ module.exports = function(config) {
     port: 8081,
 
     browsers: [
-      process.env.TRAVIS ? 'Chrome_travis_ci' : 'Chrome',
+      process.env.TRAVIS ? 'Chrome_travis_ci' : 'ChromeActive',
     ],
 
     colors: true,


### PR DESCRIPTION
Gets the list of providers from the account service instead of the provider registry (since all providers are always in the registry, even if the user has not configured them).

Had to make the validator async, which made this a much more involved PR than it would have been otherwise.

Also adding a flag to Chrome so it runs tests quickly, even if the window is in the background.

fixes https://github.com/spinnaker/spinnaker/issues/1379