### PR TITLE
(core) only take kato failure message from failed task

### DIFF
--- a/app/scripts/modules/core/orchestratedItem/orchestratedItem.transformer.spec.ts
+++ b/app/scripts/modules/core/orchestratedItem/orchestratedItem.transformer.spec.ts
@@ -60,6 +60,9 @@ describe('orchestratedItem transformer', () => {
         context: {
           'kato.tasks': [
             {
+              status: {
+                failed: true,
+              },
               exception: {
                 message: 'failed!'
               }
@@ -83,6 +86,9 @@ describe('orchestratedItem transformer', () => {
               message: 'this one is fine'
             },
             {
+              status: {
+                failed: true,
+              },
               exception: {
                 message: 'failed!'
               }
@@ -149,6 +155,9 @@ describe('orchestratedItem transformer', () => {
             key: 'kato.tasks',
             value: [
               {
+                status: {
+                  failed: true,
+                },
                 history: [
                   { status: 'i am fine' },
                   { status: 'i am terrible' }
@@ -168,6 +177,9 @@ describe('orchestratedItem transformer', () => {
             key: 'kato.tasks',
             value: [
               {
+                status: {
+                  failed: true,
+                },
                 exception: {
                   message: 'I am the exception'
                 },
@@ -217,7 +229,7 @@ describe('orchestratedItem transformer', () => {
       expect(getMessage(task)).toBe(null);
     });
 
-    it('gets orchestration message from last kato task', () => {
+    it('gets orchestration message from failed kato task', () => {
       let task = {
         variables: [
           {
@@ -229,6 +241,9 @@ describe('orchestratedItem transformer', () => {
                 ],
               },
               {
+                status: {
+                  failed: true,
+                },
                 history: [
                   { status: 'i am the second' },
                 ],

--- a/app/scripts/modules/core/orchestratedItem/orchestratedItem.transformer.ts
+++ b/app/scripts/modules/core/orchestratedItem/orchestratedItem.transformer.ts
@@ -97,8 +97,12 @@ export class OrchestratedItemTransformer {
   private getOrchestrationException(task: ITask): string {
     const katoTasks: any[] = task.getValueFor('kato.tasks');
     if (katoTasks && katoTasks.length) {
-      const steps: TaskStep[] = katoTasks[katoTasks.length - 1].history;
-      const exception: any = katoTasks[katoTasks.length - 1].exception;
+      const failedTask: any = katoTasks.find(t => t.status && t.status.failed);
+      if (!failedTask) {
+        return null;
+      }
+      const steps: TaskStep[] = failedTask.history;
+      const exception: any = failedTask.exception;
       if (exception) {
         return exception.message;
       }


### PR DESCRIPTION
Otherwise, every stage that succeeds will have an error message if it does any clouddriver operations.