### PR TITLE
(core): pull angular-cron-gen library internally

### DIFF
--- a/app/scripts/modules/core/pipeline/config/triggers/cron/cronPicker.html
+++ b/app/scripts/modules/core/pipeline/config/triggers/cron/cronPicker.html
@@ -2,96 +2,76 @@
   <div class="row">
     <div class="col-md-12">
       <select class="form-control input-sm"
-              ng-model="state.activeTab"
-              ng-change="regenerateCron(state)"
+              ng-model="$ctrl.activeTab"
+              ng-change="$ctrl.regenerateCron()"
               ng-options="tab for tab in ['minutes', 'hourly', 'daily', 'weekly', 'monthly', 'advanced']"></select>
     </div>
   </div>
   <div class="cron-gen-container">
-    <div ng-if="state.activeTab === 'minutes'">
-      <div class="row" ng-init="regenerateCron(state)">
+    <div ng-if="$ctrl.activeTab === 'minutes'">
+      <div class="row" ng-init="$ctrl.regenerateCron()">
         <div class="col-md-12">
           <input class="form-control input-sm"
                  type="number"
                  min="1"
                  max="59"
-                 ng-change="regenerateCron(state)"
-                 ng-model="state.minutes.minutes"
-                 ng-required="state.activeTab === 'minutes'">
-          minute<span ng-if="state.minutes.minutes > 1">s</span>
+                 ng-change="$ctrl.regenerateCron()"
+                 ng-model="$ctrl.state.minutes.minutes"
+                 ng-required="$ctrl.activeTab === 'minutes'">
+          minute<span ng-if="$ctrl.state.minutes.minutes > 1">s</span>
         </div>
       </div>
     </div>
-    <div ng-if="state.activeTab === 'hourly'">
+    <div ng-if="$ctrl.activeTab === 'hourly'">
       <div class="row">
         <div class="col-md-12">
-          <input type="radio"
-                 value="every"
-                 name="hourly-radio"
-                 ng-change="regenerateCron(state)"
-                 ng-model="state.hourly.subTab">
           Every
           <input class="form-control input-sm"
                  type="number"
                  min="1"
                  max="23"
-                 ng-change="regenerateCron(state)"
-                 ng-model="state.hourly.every.hours"
-                 ng-required="state.activeTab === 'hourly' && state.hourly.subTab === 'every'">
-          hour<span ng-if="state.hourly.every.hours> 1">s</span>
-        </div>
-      </div>
-      <div class="row">
-        <div class="col-md-12">
-          <input type="radio"
-                 value="specific"
-                 ng-change="regenerateCron(state)"
-                 ng-model="state.hourly.subTab"
-                 name="hourly-radio">
-          At
-          <select class="form-control input-sm"
-                  ng-change="regenerateCron(state)"
-                  ng-model="state.hourly.specific.hours"
-                  ng-options="hour as padNumber(hour) for hour in selectOptions.hours"
-                  ng-required="state.activeTab === 'hourly' && state.hourly.subTab === 'specific'">
-          </select>
-          :
-          <select class="form-control input-sm"
-                  ng-change="regenerateCron(state)"
-                  ng-model="state.hourly.specific.minutes"
-                  ng-options="minute as padNumber(minute) for minute in selectOptions.minutes"
-                  ng-required="state.activeTab === 'hourly' && state.hourly.subTab === 'specific'">
-          </select>
-          <system-timezone></system-timezone>
+                 ng-change="$ctrl.regenerateCron()"
+                 ng-model="$ctrl.state.hourly.hours"
+                 ng-required="$ctrl.activeTab === 'hourly'">
+          hour<span ng-if="$ctrl.state.hourly.hours > 1">s</span>
+          on minute
+          <input class="form-control input-sm"
+                 type="number"
+                 min="0"
+                 max="59"
+                 ng-change="$ctrl.regenerateCron()"
+                 ng-model="$ctrl.state.hourly.minutes"
+                 ng-required="$ctrl.activeTab === 'hourly'">
         </div>
       </div>
     </div>
-    <div ng-if="state.activeTab === 'daily'">
+    <div ng-if="$ctrl.activeTab === 'daily'">
       <div class="row">
         <div class="col-md-12">
           <input type="radio"
                  value="everyDays"
                  name="daily-radio"
-                 ng-change="regenerateCron(state)"
-                 ng-model="state.daily.subTab"
+                 ng-change="$ctrl.regenerateCron()"
+                 ng-model="$ctrl.state.daily.subTab"
                  checked="checked">
           Every
           <input class="form-control input-sm"
                  type="number"
                  min="1"
                  max="31"
-                 ng-change="regenerateCron(state)"
-                 ng-model="state.daily.everyDays.days"
-                 ng-required="state.activeTab === 'daily' && state.daily.subTab === 'everyDays'">
-          day<span ng-if="state.daily.everyDays.days > 1">s</span>
+                 ng-disabled="$ctrl.state.daily.subTab !== 'everyDays'"
+                 ng-change="$ctrl.regenerateCron()"
+                 ng-model="$ctrl.state.daily.everyDays.days"
+                 ng-required="$ctrl.activeTab === 'daily' && $ctrl.state.daily.subTab === 'everyDays'">
+          day<span ng-if="$ctrl.state.daily.everyDays.days > 1">s</span>
         </div>
       </div>
       <div class="row">
         <div class="col-md-12">
           <input type="radio"
                  value="everyWeekDay"
-                 ng-change="regenerateCron(state)"
-                 ng-model="state.daily.subTab"
+                 ng-change="$ctrl.regenerateCron()"
+                 ng-model="$ctrl.state.daily.subTab"
                  name="daily-radio">
           Every week day
         </div>
@@ -99,135 +79,150 @@
       <div class="row">
         <div class="col-md-12">
           Start time
-          <select class="form-control input-sm"
-                  ng-change="regenerateCron(state)"
-                  ng-required="state.activeTab === 'daily'"
-                  ng-model="state.daily.hours"
-                  ng-options="hour as padNumber(hour) for hour in selectOptions.hours">
-          </select>
-          :
-          <select class="form-control input-sm"
-                  ng-change="regenerateCron(state)"
-                  ng-required="state.activeTab === 'daily'"
-                  ng-model="state.daily.minutes"
-                  ng-options="minute as padNumber(minute) for minute in selectOptions.minutes">
-          </select>
+          <cron-gen-time-select class="visible-xs-inline-block visible-sm-inline-block visible-md-inline-block visible-lg-inline-block"
+                                ng-if="$ctrl.state.daily.subTab === 'everyDays'"
+                                is-required="state.activeTab === 'daily'"
+                                select-class="$ctrl.parsedOptions.formSelectClass"
+                                is-disabled="$ctrl.activeTab !== 'daily'"
+                                on-change="$ctrl.regenerateCron()"
+                                model="$ctrl.state.daily.everyDays"
+                                use-24-hour-time="$ctrl.parsedOptions.use24HourTime"
+                                hide-seconds="$ctrl.parsedOptions.hideSeconds">
+          </cron-gen-time-select>
+          <cron-gen-time-select class="visible-xs-inline-block visible-sm-inline-block visible-md-inline-block visible-lg-inline-block"
+                                ng-if="$ctrl.state.daily.subTab === 'everyWeekDay'"
+                                is-required="state.activeTab === 'daily'"
+                                select-class="$ctrl.parsedOptions.formSelectClass"
+                                is-disabled="$ctrl.activeTab !== 'daily'"
+                                on-change="$ctrl.regenerateCron()"
+                                model="$ctrl.state.daily.everyWeekDay"
+                                use-24-hour-time="$ctrl.parsedOptions.use24HourTime"
+                                hide-seconds="$ctrl.parsedOptions.hideSeconds">
+          </cron-gen-time-select>
           <system-timezone></system-timezone>
         </div>
       </div>
     </div>
-    <div ng-if="state.activeTab === 'weekly'">
+    <div ng-if="$ctrl.activeTab === 'weekly'">
       <div class="row">
         <div class="col-md-12">
           <div class="btn-group">
             <label ng-repeat="day in [{k: 'SUN', l: 'Sun'}, {k: 'MON', l: 'Mon'}, {k: 'TUE', l: 'Tue'}, {k: 'WED', l: 'Wed'}, {k: 'THU', l: 'Thu'}, {k: 'FRI', l: 'Fri'}, {k: 'SAT', l: 'Sat'}]"
                    class="btn btn-default"
                    uib-btn-checkbox
-                   ng-class="{active: state.weekly[day.k]}"
-                   ng-click="regenerateCron(state)"
-                   ng-model="state.weekly[day.k]">{{day.l}}</label>
+                   ng-class="{active: $ctrl.state.weekly[day.k]}"
+                   ng-click="$ctrl.regenerateCron()"
+                   ng-model="$ctrl.state.weekly[day.k]">{{day.l}}</label>
           </div>
         </div>
       </div>
       <div class="row">
         <div class="col-md-12">
           Start time
-          <select class="form-control input-sm"
-                  ng-change="regenerateCron(state)"
-                  ng-required="state.activeTab === 'weekly'"
-                  ng-model="state.weekly.hours"
-                  ng-options="hour as padNumber(hour) for hour in selectOptions.hours">
-          </select>
-          :
-          <select class="form-control input-sm"
-                  ng-change="regenerateCron(state)"
-                  ng-required="state.activeTab === 'weekly'"
-                  ng-model="state.weekly.minutes"
-                  ng-options="minute as padNumber(minute) for minute in selectOptions.minutes">
-          </select>
+          <cron-gen-time-select class="visible-xs-inline-block visible-sm-inline-block visible-md-inline-block visible-lg-inline-block"
+                                is-required="state.activeTab === 'weekly'"
+                                select-class="$ctrl.parsedOptions.formSelectClass"
+                                is-disabled="$ctrl.activeTab !== 'weekly'"
+                                on-change="$ctrl.regenerateCron();"
+                                model="$ctrl.state.weekly"
+                                use-24-hour-time="$ctrl.parsedOptions.use24HourTime"
+                                hide-seconds="$ctrl.parsedOptions.hideSeconds">
+          </cron-gen-time-select>
           <system-timezone></system-timezone>
         </div>
       </div>
     </div>
-    <div ng-if="state.activeTab === 'monthly'">
+    <div ng-if="$ctrl.activeTab === 'monthly'">
       <div class="row">
         <div class="col-md-12">
           <input type="radio"
                  value="specificDay"
-                 ng-change="regenerateCron(state)"
-                 ng-model="state.monthly.subTab"
+                 ng-change="$ctrl.regenerateCron()"
+                 ng-model="$ctrl.state.monthly.subTab"
                  name="monthly-radio"
                  checked="checked">
-          Day
-          <input class="form-control input-sm"
-                 type="number"
-                 min="1"
-                 max="31"
-                 ng-change="regenerateCron(state)"
-                 ng-model="state.monthly.specificDay.day"
-                 ng-required="state.activeTab === 'monthly' && state.monthly.subTab === 'specificDay'">
+          On the
+          <select class="month-days"
+                  ng-disabled="$ctrl.state.monthly.subTab !== 'specificDay'"
+                  ng-change="$ctrl.regenerateCron()"
+                  ng-model="$ctrl.state.monthly.specificDay.day"
+                  ng-required="$ctrl.activeTab === 'monthly' && $ctrl.state.monthly.subTab === 'specificDay'"
+                  ng-options="monthDaysWithLast as $ctrl.monthDayDisplay(monthDaysWithLast) for monthDaysWithLast in $ctrl.selectOptions.monthDaysWithLasts"
+                  ng-class="$ctrl.parsedOptions.formSelectClass">
+          </select>
           of every
           <input class="form-control input-sm"
                  type="number"
                  min="1"
                  max="11"
-                 ng-change="regenerateCron(state)"
-                 ng-model="state.monthly.specificDay.months"
-                 ng-required="state.activeTab === 'monthly' && state.monthly.subTab === 'specificDay'">
-          month<span ng-if="state.monthly.specificDay.months > 1">s</span>
+                 ng-change="$ctrl.regenerateCron()"
+                 ng-model="$ctrl.state.monthly.specificDay.months"
+                 ng-required="$ctrl.activeTab === 'monthly' && $ctrl.state.monthly.subTab === 'specificDay'"
+                 ng-disabled="$ctrl.state.monthly.subTab !== 'specificDay'">
+          month<span ng-if="$ctrl.state.monthly.specificDay.months > 1">s</span>
         </div>
       </div>
       <div class="row">
         <div class="col-md-12">
           <input type="radio"
                  value="specificWeekDay"
-                 ng-change="regenerateCron(state)"
-                 ng-model="state.monthly.subTab"
+                 ng-change="$ctrl.regenerateCron()"
+                 ng-model="$ctrl.state.monthly.subTab"
                  name="monthly-radio">
           <select class="form-control input-sm"
-                  ng-change="regenerateCron(state)"
-                  ng-model="state.monthly.specificWeekDay.monthWeek"
-                  ng-required="state.activeTab === 'monthly' && state.monthly.subTab === 'specificWeekDay'"
-                  ng-options="monthWeek as monthWeekDisplay(monthWeek) for monthWeek in selectOptions.monthWeeks">
+                  ng-change="$ctrl.regenerateCron()"
+                  ng-model="$ctrl.state.monthly.specificWeekDay.monthWeek"
+                  ng-required="$ctrl.activeTab === 'monthly' && $ctrl.state.monthly.subTab === 'specificWeekDay'"
+                  ng-options="monthWeek as $ctrl.monthWeekDisplay(monthWeek) for monthWeek in $ctrl.selectOptions.monthWeeks"
+                  ng-disabled="$ctrl.state.monthly.subTab !== 'specificWeekDay'">
           </select>
           <select class="form-control input-sm"
-                  ng-change="regenerateCron(state)"
-                  ng-model="state.monthly.specificWeekDay.day"
-                  ng-required="state.activeTab === 'monthly' && state.monthly.subTab === 'specificWeekDay'"
-                  ng-options="day as dayDisplay(day) for day in selectOptions.days">
+                  ng-change="$ctrl.regenerateCron()"
+                  ng-model="$ctrl.state.monthly.specificWeekDay.day"
+                  ng-required="$ctrl.activeTab === 'monthly' && $ctrl.state.monthly.subTab === 'specificWeekDay'"
+                  ng-options="day as $ctrl.dayDisplay(day) for day in $ctrl.selectOptions.days"
+                  ng-disabled="$ctrl.state.monthly.subTab !== 'specificWeekDay'">
           </select>
           of every
           <input class="form-control input-sm"
                  type="number"
                  min="1"
                  max="11"
-                 ng-change="regenerateCron(state)"
-                 ng-model="state.monthly.specificWeekDay.months"
-                 ng-required="state.activeTab === 'monthly' && state.monthly.subTab === 'specificWeekDay'">
-          month<span ng-if="state.monthly.specificWeekDay.months > 1">s</span>
+                 ng-change="$ctrl.regenerateCron()"
+                 ng-model="$ctrl.state.monthly.specificWeekDay.months"
+                 ng-required="$ctrl.activeTab === 'monthly' && $ctrl.state.monthly.subTab === 'specificWeekDay'"
+                 ng-disabled="$ctrl.state.monthly.subTab !== 'specificWeekDay'">
+          month<span ng-if="$ctrl.state.monthly.specificWeekDay.months > 1">s</span>
         </div>
       </div>
       <div class="row">
         <div class="col-md-12">
           Start time
-          <select class="form-control input-sm"
-                  ng-change="regenerateCron(state)"
-                  ng-required="state.activeTab === 'monthly'"
-                  ng-model="state.monthly.hours"
-                  ng-options="hour as padNumber(hour) for hour in selectOptions.hours">
-          </select>
-          :
-          <select class="form-control input-sm"
-                  ng-change="regenerateCron(state)"
-                  ng-required="state.activeTab === 'monthly'"
-                  ng-model="state.monthly.minutes"
-                  ng-options="minute as padNumber(minute) for minute in selectOptions.minutes">
-          </select>
+          <cron-gen-time-select class="visible-xs-inline-block visible-sm-inline-block visible-md-inline-block visible-lg-inline-block"
+                                ng-if="$ctrl.state.monthly.subTab === 'specificDay'"
+                                is-required="state.activeTab === 'monthly'"
+                                select-class="$ctrl.parsedOptions.formSelectClass"
+                                is-disabled="$ctrl.activeTab !== 'monthly'"
+                                on-change="$ctrl.regenerateCron();"
+                                model="$ctrl.state.monthly.specificDay"
+                                use-24-hour-time="$ctrl.parsedOptions.use24HourTime"
+                                hide-seconds="$ctrl.parsedOptions.hideSeconds">
+          </cron-gen-time-select>
+          <cron-gen-time-select class="visible-xs-inline-block visible-sm-inline-block visible-md-inline-block visible-lg-inline-block"
+                                ng-if="$ctrl.state.monthly.subTab === 'specificWeekDay'"
+                                is-required="state.activeTab === 'monthly'"
+                                select-class="$ctrl.parsedOptions.formSelectClass"
+                                is-disabled="$ctrl.activeTab !== 'monthly'"
+                                on-change="$ctrl.regenerateCron();"
+                                model="$ctrl.state.monthly.specificWeekDay"
+                                use-24-hour-time="$ctrl.parsedOptions.use24HourTime"
+                                hide-seconds="$ctrl.parsedOptions.hideSeconds">
+          </cron-gen-time-select>
           <system-timezone></system-timezone>
         </div>
       </div>
     </div>
-    <div ng-if="state.activeTab === 'advanced'">
+    <div ng-if="$ctrl.activeTab === 'advanced'">
       <div class="row">
         <div class="col-md-12">
           <strong>Expression</strong>
@@ -236,15 +231,15 @@
                  class="form-control input-sm"
                  cron-validator
                  cron-validation-messages="validation.messages"
-                 ng-change="regenerateCron(state)"
-                 ng-model="state.advanced.expression">
+                 ng-change="$ctrl.regenerateCron()"
+                 ng-model="$ctrl.state.advanced.expression">
         </div>
       </div>
       <div class="row">
         <div class="col-md-12">
-          <p>More details about how to create these expressions can be found <a
-            href="http://www.quartz-scheduler.org/documentation/quartz-2.x/tutorials/crontrigger.html"
-            target="_blank">here</a>.</p>
+          <p>More details about how to create these expressions can be found
+            <a href="http://www.quartz-scheduler.org/documentation/quartz-2.x/tutorials/crontrigger.html"
+               target="_blank">here</a>.</p>
         </div>
       </div>
       <div class="row" ng-if="validation.messages.description && !validation.messages.error">

--- a/app/scripts/modules/core/pipeline/config/triggers/cron/cronTrigger.html
+++ b/app/scripts/modules/core/pipeline/config/triggers/cron/cronTrigger.html
@@ -5,7 +5,8 @@
     </label>
     <div class="col-md-9">
       <cron-gen ng-model="vm.trigger.cronExpression"
-                options="vm.cronOptions"></cron-gen>
+                options="vm.cronOptions"
+                template-url="spinnaker-custom-cron-picker-template"></cron-gen>
     </div>
   </div>
 

--- a/app/scripts/modules/core/pipeline/config/triggers/cron/cronTrigger.module.js
+++ b/app/scripts/modules/core/pipeline/config/triggers/cron/cronTrigger.module.js
@@ -37,7 +37,10 @@ module.exports = angular.module('spinnaker.core.pipeline.trigger.cron', [
     trigger.cronExpression = trigger.cronExpression || '0 0 10 ? * MON-FRI *';
 
     this.cronOptions = {
-      templateUrl: require('./cronPicker.html'),
+      formSelectClass: 'form-control input-sm',
+      hideAdvancedTab: false,
+      hideSeconds: true,
+      use24HourTime: true
     };
 
-  });
+  }).run($templateCache => $templateCache.put('spinnaker-custom-cron-picker-template', $templateCache.get(require('./cronPicker.html'))));

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "Select2": "git://github.com/select2/select2.git#3.4.8",
     "angular": "~1.5.8",
     "angular-cache": "^4.2.2",
-    "angular-cron-gen": "0.0.6",
+    "angular-cron-gen": "0.0.21",
     "angular-filter": "^0.5.4",
     "angular-hotkeys": "^1.5.0",
     "angular-marked": "0.0.17",


### PR DESCRIPTION
* pull angular-cron-gen library internally to deck to fix several issues with the library.
* the latest version of the library will not allow angular expressions for the new `template-url` property as it uses the `templateUrl` function which executes before the scope is initialized so any scoped property value is not accessible.  this means that our template value set via a controller property is not accessible.  this is a long-standing issue [in the core library](https://github.com/angular/angular.js/issues/2895) and it doesn't look to be fixed anytime soon.
* an hourly cron trigger set in the UI to execute start at a specific time actually generates a daily cron expression so the portion of the hourly cron trigger that allows starting at a specific time was removed from deck's cron picker template.
* the regex used by the library to match hourly cron expressions was incorrectly matching daily cron expressions which was resulting the UI displaying `hourly` instead of `daily` in the select so the regex for hourly was fixed to properly test for matching hourly cron expressions.