### PR TITLE
Adding SSL docker configuration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.adoc
+++ b/README.adoc
@@ -21,6 +21,7 @@ Environment variables can be used to configure application behavior. The followi
 
 * `AUTH` enable/disable authentication (default is disabled, enable by setting `AUTH=enabled`).
 * `TIMEZONE` set the default timezone (default is 'America/Los_Angeles' - see http://momentjs.com/timezone/docs/#/data-utilities/ for options)
+* `DECK_CERT` enable SSL (set to the fully qualified path to cert file, and `DECK_KEY` must be set to the fully qualified path to the key file)
 
 The following external resources can be specified with environment variables:
 

--- a/docker/spinnaker.conf.ssl
+++ b/docker/spinnaker.conf.ssl
@@ -1,0 +1,14 @@
+<VirtualHost {%DECK_HOST%}:{%DECK_PORT%}>
+  SSLEngine on
+  SSLCertificateFile "{%DECK_CERT_PATH%}"
+  SSLCertificateKeyFile "{%DECK_KEY_PATH%}"
+  
+  DocumentRoot /opt/deck/html
+
+  ProxyPass "/gate" "{%API_HOST%}" retry=0
+  ProxyPassReverse "/gate" "{%API_HOST%}"
+
+  <Directory "/opt/deck/html/">
+    Require all granted
+  </Directory>
+</VirtualHost>


### PR DESCRIPTION
Set env variable `DECK_CERT=/pat/to/cert.crt` to configure apache with SSL. Must also set `DECK_KEY=/path/to/key.key`. Without these env vars set, apache starts up normally.

My custom settings.js wasn't getting picked up properly when I started my docker container, so moving settings.js to the directory that the ui is now served from (/opt/deck/html) if a custom file exists in /opt/spinnaker/config.

@lwander take a look please? 