### PR TITLE
(titus) surface run job failure message

### DIFF
--- a/app/scripts/modules/titus/pipeline/stages/runJob/runJobExecutionDetails.html
+++ b/app/scripts/modules/titus/pipeline/stages/runJob/runJobExecutionDetails.html
@@ -22,8 +22,8 @@
         </dl>
       </div>
     </div>
-    <stage-failure-message stage="stage"
-                           message="stage.context.completionDetails.message"></stage-failure-message>
+    <stage-failure-message stage="stage" ng-if="stage.isFailed"
+                           message="stage.failureMessage || stage.context.completionDetails.message"></stage-failure-message>
 
     <div class="row" ng-if="stage.context.jobStatus.completionDetails.taskId">
       <div class="col-md-12">


### PR DESCRIPTION
Don't show the failure message if the job succeeded; otherwise, look for the failure in the stage context, then look in the completion details.

@tomaslin PTAL