### PR TITLE
(aws) add alerts/notices to security groups

### DIFF
--- a/app/scripts/modules/amazon/securityGroup/details/securityGroupDetail.controller.js
+++ b/app/scripts/modules/amazon/securityGroup/details/securityGroupDetail.controller.js
@@ -23,6 +23,7 @@ module.exports = angular.module('spinnaker.securityGroup.aws.details.controller'
                                                     confirmationModalService, securityGroupWriter, securityGroupReader,
                                                     recentHistoryService, $uibModal, cloudProviderRegistry) {
 
+    this.application = app;
     const application = app;
     const securityGroup = resolvedSecurityGroup;
 
@@ -41,9 +42,12 @@ module.exports = angular.module('spinnaker.securityGroup.aws.details.controller'
         if (!details || _.isEmpty( details )) {
           fourOhFour();
         } else {
-          $scope.securityGroup = details;
-          $scope.ipRules = buildIpRulesModel(details);
-          $scope.securityGroupRules = buildSecurityGroupRulesModel(details);
+          const applicationSecurityGroup = securityGroupReader.getApplicationSecurityGroup(application, securityGroup.accountId, securityGroup.region, securityGroup.name);
+
+          angular.extend(securityGroup, applicationSecurityGroup, details);
+          $scope.securityGroup = securityGroup;
+          $scope.ipRules = buildIpRulesModel(securityGroup);
+          $scope.securityGroupRules = buildSecurityGroupRulesModel(securityGroup);
         }
       },
         fourOhFour

--- a/app/scripts/modules/amazon/securityGroup/details/securityGroupDetail.html
+++ b/app/scripts/modules/amazon/securityGroup/details/securityGroupDetail.html
@@ -19,6 +19,10 @@
       <span class="glyphicon glyphicon-transfer"></span>
       <h3 select-on-dbl-click>
         {{securityGroup.name || '(not found)'}}
+        <entity-ui-tags component="securityGroup"
+                        application="ctrl.application"
+                        entity-type="securityGroup"
+                        on-update="ctrl.application.securityGroups.refresh()"></entity-ui-tags>
       </h3>
     </div>
     <div class="actions">
@@ -30,6 +34,10 @@
           <li><a href ng-click="ctrl.editInboundRules()">Edit Inbound Rules</a></li>
           <li><a href ng-click="ctrl.deleteSecurityGroup()">Delete Security Group</a></li>
           <li><a href ng-click="ctrl.cloneSecurityGroup()">Clone Security Group</a></li>
+          <add-entity-tag-links component="securityGroup"
+                                application="ctrl.application"
+                                entity-type="securityGroup"
+                                on-update="ctrl.application.securityGroups.refresh()"></add-entity-tag-links>
         </ul>
       </div>
     </div>

--- a/app/scripts/modules/core/domain/ISecurityGroup.ts
+++ b/app/scripts/modules/core/domain/ISecurityGroup.ts
@@ -1,3 +1,4 @@
+import {IEntityTags} from './IEntityTags';
 export interface ILoadBalancerUsage {
   name: string;
 }
@@ -19,6 +20,7 @@ export interface ISecurityGroup {
   accountName?: string;
   cloudProvider?: string;
   credentials?: string;
+  entityTags?: IEntityTags;
   id?: string;
   inferredName?: boolean;
   name?: string;

--- a/app/scripts/modules/core/domain/serverGroup.ts
+++ b/app/scripts/modules/core/domain/serverGroup.ts
@@ -19,10 +19,9 @@ export interface ServerGroup {
   category?: string;
   cloudProvider: string;
   cluster: string;
-  entityTags?: IEntityTags;
   clusterEntityTags?: IEntityTags[];
   detail?: string;
-  runningExecutions?: Execution[];
+  entityTags?: IEntityTags;
   instanceCounts: InstanceCounts;
   instanceType?: string;
   instances: Instance[];
@@ -32,6 +31,7 @@ export interface ServerGroup {
   name: string;
   provider?: string;
   region: string;
+  runningExecutions?: Execution[];
   runningTasks?: ITask[];
   searchField?: string;
   securityGroups?: string[];

--- a/app/scripts/modules/core/entityTag/entityRef.builder.ts
+++ b/app/scripts/modules/core/entityTag/entityRef.builder.ts
@@ -3,6 +3,7 @@ import {ILoadBalancer} from '../domain/loadBalancer';
 import {Application} from '../application/application.model';
 import {IEntityRef} from '../domain/IEntityTags';
 import {ICluster} from '../domain/ICluster';
+import {ISecurityGroup} from '../domain/ISecurityGroup';
 
 export class EntityRefBuilder {
 
@@ -44,6 +45,17 @@ export class EntityRefBuilder {
     };
   }
 
+  public static buildSecurityGroupRef(securityGroup: ISecurityGroup): IEntityRef {
+    return {
+      cloudProvider: securityGroup.cloudProvider,
+      entityType: 'securitygroup',
+      entityId: securityGroup.name,
+      account: securityGroup.accountName,
+      region: securityGroup.region,
+      vpcId: securityGroup.vpcId,
+    };
+  }
+
   public static getBuilder(type: string): (entity: any) => IEntityRef {
     switch (type) {
       case 'application':
@@ -54,6 +66,8 @@ export class EntityRefBuilder {
         return this.buildLoadBalancerRef;
       case 'cluster':
         return this.buildClusterRef;
+      case 'securityGroup':
+        return this.buildSecurityGroupRef;
       default:
         return null;
     }

--- a/app/scripts/modules/core/entityTag/entityTags.help.ts
+++ b/app/scripts/modules/core/entityTag/entityTags.help.ts
@@ -11,6 +11,26 @@ const helpContents: any[] = [
     key: 'entityTags.serverGroup.notice',
     contents: `<p>Notices provide additional context for a server group. When present, an info icon 
       <i class="fa fa-info-circle"></i> will be displayed in the clusters view next to the server group.</p>`
+  },
+  {
+    key: 'entityTags.loadBalancer.alert',
+    contents: `<p>Alerts indicate an issue with a load balancer. When present, an alert icon 
+      <i class="fa fa-exclamation-triangle"></i> will be displayed in the load balancers view next to the server group.</p>`
+  },
+  {
+    key: 'entityTags.loadBalancer.notice',
+    contents: `<p>Notices provide additional context for a load balancer. When present, an info icon 
+      <i class="fa fa-info-circle"></i> will be displayed in the load balancers view next to the server group.</p>`
+  },
+  {
+    key: 'entityTags.securityGroup.notice',
+    contents: `<p>Notices provide additional context for a security group. When present, an info icon 
+      <i class="fa fa-info-circle"></i> will be displayed in the security groups view next to the security group.</p>`
+  },
+  {
+    key: 'entityTags.securityGroup.alert',
+    contents: `<p>Alerts indicate an issue with a security group. When present, an alert icon 
+      <i class="fa fa-exclamation-triangle"></i> will be displayed in the security groups view next to the security group.</p>`
   }
   ];
 

--- a/app/scripts/modules/core/securityGroup/securityGroup.html
+++ b/app/scripts/modules/core/securityGroup/securityGroup.html
@@ -4,7 +4,10 @@
      ng-class="{active: $state.includes('**.securityGroupDetails', {region: securityGroup.region, accountId: securityGroup.accountName, name: securityGroup.name, vpcId: securityGroup.vpcId, provider: securityGroup.provider})}">
 
   <h6 sticky-header added-offset-height="39">
-    <span class="glyphicon glyphicon-transfer"></span> {{heading | uppercase}}
+    <span class="glyphicon glyphicon-transfer"></span>
+    {{heading | uppercase}}
+    <entity-ui-tags component="securityGroup" application="application" entity-type="securityGroup"
+                    on-update="application.securityGroups.refresh()"></entity-ui-tags>
   </h6>
 
   <div class="cluster-container">


### PR DESCRIPTION
Nothing too exciting here. Had to extend the `securityGroup` on the scope to get the tags in place (we follow a similar pattern on instances, server groups, and load balancers).