### PR TITLE
(core) remove "(no build info)" label on server groups without build …

### DIFF
--- a/app/scripts/modules/core/serverGroup/serverGroup.directive.html
+++ b/app/scripts/modules/core/serverGroup/serverGroup.directive.html
@@ -26,9 +26,6 @@
             <span ng-if="viewModel.images">
               {{ viewModel.images }}
             </span>
-            <span ng-if="!viewModel.hasBuildInfo">
-              (No build info)
-            </span>
             <entity-ui-tags component="serverGroup" application="application" entity-type="serverGroup"
                           on-update="application.serverGroups.refresh()"></entity-ui-tags>
           </div>


### PR DESCRIPTION
…info

It's confusing to a lot of folks, especially in OSS land.

@spinnaker/reviewers any concerns with this change?