### PR TITLE
(kubernetes) restore namespace in rollback command

### DIFF
--- a/app/scripts/modules/kubernetes/serverGroup/details/rollback/rollback.controller.js
+++ b/app/scripts/modules/kubernetes/serverGroup/details/rollback/rollback.controller.js
@@ -25,6 +25,7 @@ module.exports = angular.module('spinnaker.kubernetes.serverGroup.details.rollba
         rollbackContext: {
           rollbackServerGroupName: serverGroup.name
         },
+        namespace: serverGroup.namespace,
         interestingHealthProviderNames: ['KubernetesService']
       };
 


### PR DESCRIPTION
@danielpeach PTAL 

Looks like this was dropped at some point