### PR TITLE
(core) provide more context in error when entity tag load fails

### DIFF
--- a/app/scripts/modules/core/delivery/stageFailureMessage/stageFailureMessage.component.ts
+++ b/app/scripts/modules/core/delivery/stageFailureMessage/stageFailureMessage.component.ts
@@ -21,7 +21,7 @@ class StageFailureMessageCtrl implements ng.IComponentController {
       if (this.isFailed === undefined) {
         this.isFailed = true;
       }
-      this.failedTask = this.stage.tasks.find(t => t.status === 'TERMINAL' || t.status === 'STOPPED');
+      this.failedTask = (this.stage.tasks || []).find(t => t.status === 'TERMINAL' || t.status === 'STOPPED');
     }
   }
 

--- a/app/scripts/modules/core/entityTag/entityTags.read.service.ts
+++ b/app/scripts/modules/core/entityTag/entityTags.read.service.ts
@@ -33,7 +33,7 @@ export class EntityTagsReader {
         result.resolve(allTags);
       })
       .catch(() => {
-        this.$exceptionHandler(new Error('Failed to load entity tags.'));
+        this.$exceptionHandler(new Error(`Failed to load ${entityType} entity tags; groups: \n${idGroups.join('\n')}`));
         result.resolve([]);
       });
 


### PR DESCRIPTION
For whatever reason, this is happening more frequently than I expected. Trying to get more context to see why.

Also guarding against tasks not being present on a failed task, just because