### PR TITLE
(core) use IRegionalCluster for entityRef building

### DIFF
--- a/app/scripts/modules/core/domain/ICluster.ts
+++ b/app/scripts/modules/core/domain/ICluster.ts
@@ -2,7 +2,6 @@ import {ServerGroup} from './serverGroup';
 
 export interface ICluster {
   account: string;
-  region: string;
   cloudProvider: string;
   category: string;
   name: string;

--- a/app/scripts/modules/core/domain/IRegionalCluster.ts
+++ b/app/scripts/modules/core/domain/IRegionalCluster.ts
@@ -1,0 +1,5 @@
+import {ICluster} from './ICluster';
+
+export interface IRegionalCluster extends ICluster {
+  region: string;
+}

--- a/app/scripts/modules/core/entityTag/entityRef.builder.ts
+++ b/app/scripts/modules/core/entityTag/entityRef.builder.ts
@@ -2,8 +2,8 @@ import {ServerGroup} from '../domain/serverGroup';
 import {ILoadBalancer} from '../domain/loadBalancer';
 import {Application} from '../application/application.model';
 import {IEntityRef} from '../domain/IEntityTags';
-import {ICluster} from '../domain/ICluster';
 import {ISecurityGroup} from '../domain/ISecurityGroup';
+import {IRegionalCluster} from '../domain/IRegionalCluster';
 
 export class EntityRefBuilder {
 
@@ -35,7 +35,7 @@ export class EntityRefBuilder {
     };
   }
 
-  public static buildClusterRef(cluster: ICluster): IEntityRef {
+  public static buildRegionalClusterRef(cluster: IRegionalCluster): IEntityRef {
     return {
       cloudProvider: cluster.cloudProvider,
       entityType: 'cluster',
@@ -65,7 +65,7 @@ export class EntityRefBuilder {
       case 'loadBalancer':
         return this.buildLoadBalancerRef;
       case 'cluster':
-        return this.buildClusterRef;
+        return this.buildRegionalClusterRef;
       case 'securityGroup':
         return this.buildSecurityGroupRef;
       default:


### PR DESCRIPTION
`region` is not really a field on clusters - it was added for entity tags to allow scoping, but that's not applicable to clusters generally.