### PR TITLE
(core) always show disabled warning if any instances present; fix ver…

### DIFF
--- a/app/scripts/modules/core/serverGroup/details/serverGroupWarningMessage.service.ts
+++ b/app/scripts/modules/core/serverGroup/details/serverGroupWarningMessage.service.ts
@@ -46,7 +46,9 @@ export class ServerGroupWarningMessageService {
     const remainingActiveServerGroups: ServerGroup[] = this.getOtherServerGroupsInCluster(application, serverGroup)
       .filter(s => !s.isDisabled && s.instanceCounts.up > 0);
 
-    if (remainingActiveServerGroups.length) {
+    const hasOtherInstances = this.getOtherServerGroupsInCluster(application, serverGroup).some(s => s.instances.length > 0);
+
+    if (hasOtherInstances) {
       const totalActiveInstances = remainingActiveServerGroups.reduce((acc: number, s: ServerGroup) => {
         return s.instanceCounts.up + acc;
       }, serverGroup.instanceCounts.up);
@@ -66,6 +68,7 @@ export class ServerGroupWarningMessageService {
           (<span class="verification-text">${activeInstancesAfterDisable}</span>) after disabling this server group.`;
 
       params.textToVerify = `${activeInstancesAfterDisable}`;
+      delete params.account;
     }
   }
 


### PR DESCRIPTION
…ify text

`account` always overrides the `textToVerify` field, so let's just, um, take it out of the equation.

Also showing the warning if there are _any_ other instances in the cluster, not just up instances, since that might be a surprise - if they've already disabled the other active server group, they won't get the warning right now.