### PR TITLE
(appengine) ad hoc clone server group

### DIFF
--- a/app/scripts/modules/appengine/serverGroup/configure/serverGroupCommandBuilder.service.ts
+++ b/app/scripts/modules/appengine/serverGroup/configure/serverGroupCommandBuilder.service.ts
@@ -3,7 +3,7 @@ import {get, intersection} from 'lodash';
 
 import {Application} from 'core/application/application.model';
 import {AccountService, ACCOUNT_SERVICE} from 'core/account/account.service';
-import {IAppengineAccount, IAppengineGitTrigger, IAppengineJenkinsTrigger, GitCredentialType} from 'appengine/domain/index';
+import {IAppengineAccount, IAppengineGitTrigger, IAppengineJenkinsTrigger, GitCredentialType, IAppengineServerGroup} from 'appengine/domain/index';
 import {IStage, IPipeline, IGitTrigger, IJenkinsTrigger} from 'core/domain/index';
 import {AppengineDeployDescription} from '../transformer';
 
@@ -82,6 +82,15 @@ export class AppengineServerGroupCommandBuilder {
       });
   }
 
+  public buildServerGroupCommandFromExisting(app: Application, serverGroup: IAppengineServerGroup): IPromise<IAppengineServerGroupCommand> {
+    return this.buildNewServerGroupCommand(app, 'appengine', 'clone')
+      .then(command => {
+        command.stack = serverGroup.stack;
+        command.freeFormDetails = serverGroup.detail;
+        return command;
+      });
+  }
+
   public buildNewServerGroupCommandForPipeline(_stage: IStage, pipeline: IPipeline): {backingData: {triggerOptions: Array<IAppengineGitTrigger | IAppengineJenkinsTrigger>}} {
     // We can't copy server group configuration for App Engine, and can't build the full command here because we don't have
     // access to the application.
@@ -121,6 +130,8 @@ export class AppengineServerGroupCommandBuilder {
         return 'Add';
       case 'editPipeline':
         return 'Done';
+      case 'clone':
+        return 'Clone';
       default:
         return 'Create';
     }

--- a/app/scripts/modules/appengine/serverGroup/configure/wizard/basicSettings.html
+++ b/app/scripts/modules/appengine/serverGroup/configure/wizard/basicSettings.html
@@ -109,7 +109,7 @@
         </ui-select>
       </div>
 
-      <div class="col-md-7 col-md-offset-3" ng-if="command.viewState.mode !== 'create'">
+      <div class="col-md-7 col-md-offset-3" ng-if="command.viewState.mode === 'createPipeline' || command.viewState.mode === 'editPipeline'">
         <span class="pull-right small" ng-if="!command.fromTrigger">
           <a href ng-click="basicSettingsCtrl.toggleResolveViaTrigger()">Resolve via trigger</a>
         </span>

--- a/app/scripts/modules/appengine/serverGroup/configure/wizard/cloneServerGroup.controller.ts
+++ b/app/scripts/modules/appengine/serverGroup/configure/wizard/cloneServerGroup.controller.ts
@@ -35,7 +35,7 @@ class AppengineCloneServerGroupCtrl {
               private serverGroupWriter: ServerGroupWriter,
               commandBuilder: AppengineServerGroupCommandBuilder) {
 
-    if (['create', 'editPipeline'].includes(get<string>(serverGroupCommand, 'viewState.mode'))) {
+    if (['create', 'clone', 'editPipeline'].includes(get<string>(serverGroupCommand, 'viewState.mode'))) {
       $scope.command = serverGroupCommand;
       this.state.loading = false;
     } else {
@@ -62,12 +62,15 @@ class AppengineCloneServerGroupCtrl {
     let mode = this.$scope.command.viewState.mode;
     if (['editPipeline', 'createPipeline'].includes(mode)) {
       return this.$uibModalInstance.close(this.$scope.command);
+    } else {
+      let command = copy(this.$scope.command);
+      // Make sure we're sending off a create operation, because there's no such thing as clone for App Engine.
+      command.viewState.mode = 'create';
+      let submitMethod = () => this.serverGroupWriter.cloneServerGroup(command, this.$scope.application);
+      this.taskMonitor.submit(submitMethod);
+
+      return null;
     }
-
-    let submitMethod = () => this.serverGroupWriter.cloneServerGroup(copy(this.$scope.command), this.$scope.application);
-    this.taskMonitor.submit(submitMethod);
-
-    return null;
   }
 }
 

--- a/app/scripts/modules/appengine/serverGroup/details/details.html
+++ b/app/scripts/modules/appengine/serverGroup/details/details.html
@@ -70,6 +70,11 @@
               class="disabled">
               <a href>Destroy</a>
           </li>
+          <li uib-tooltip="It is not possible to clone an App Engine server group's full 
+                           launch configuration. However, clicking this button will allow
+                           you to deploy into this server group's cluster.">
+            <a href ng-click="ctrl.cloneServerGroup()">Clone</a>
+          </li>
         </ul>
       </div>
       <div class="clearfix"></div>

--- a/app/scripts/modules/core/domain/serverGroup.ts
+++ b/app/scripts/modules/core/domain/serverGroup.ts
@@ -35,6 +35,7 @@ export interface ServerGroup {
   runningTasks?: ITask[];
   searchField?: string;
   securityGroups?: string[];
+  stack?: string;
   stringVal?: string;
   tags?: any;
   type: string;


### PR DESCRIPTION
@lwander or @jtk54 or @duftler please review.

Not sure if this is a great idea, but I think there should be a convenient way of deploying into the same cluster for App Engine, even if we can't copy over the rest of the server group's configuration.

![clone](https://cloud.githubusercontent.com/assets/13868700/22565943/0a6701ea-e958-11e6-891c-f6947514e263.png)
