### PR TITLE
(core) retry tagging before failing; make retryService tolerate failure

### DIFF
--- a/app/scripts/modules/docker/image/docker.image.reader.service.ts
+++ b/app/scripts/modules/docker/image/docker.image.reader.service.ts
@@ -27,7 +27,7 @@ export class DockerImageReaderService implements IImageReader {
   }
 
   public findImages(params: IFindImageParams): ng.IPromise<IDockerImage[]> {
-    return this.retryService.buildRetrySequence(() => this.API.all('images/find')
+    return this.retryService.buildRetrySequence<IDockerImage[]>(() => this.API.all('images/find')
       .getList(params), (results: IDockerImage[]) => (results.length > 0), 10, 1000)
       .then((results: IDockerImage[]) => results)
       .catch((): IDockerImage[] => []);


### PR DESCRIPTION
For whatever reason, we get intermittent failures loading entity tags. I don't have good info on why they're failing, but it seems to be transient. Adding a single retry in the event the `GET` fails the first time.

@danielpeach PTAL - I modified the retry service to handle failures, but I am not totally sure that's in line with your intent in that service. If not, I can change my code and add a method that explicitly handles a failure case like the one we're seeing here.