### PR TITLE
Adding image name, tag and organization to the docker bake stage

### DIFF
--- a/app/scripts/modules/core/help/helpContents.js
+++ b/app/scripts/modules/core/help/helpContents.js
@@ -232,6 +232,9 @@ module.exports = angular.module('spinnaker.core.help.contents', [])
     'pipeline.config.bake.package': '<p>The name of the package you want installed (without any version identifiers).</p>' +
     '<p>If your build produces a deb file named "myapp_1.27-h343", you would want to enter "myapp" here.</p>' +
     '<p>If there are multiple packages (space separated), then they will be installed in the order they are entered.</p>',
+    'pipeline.config.docker.bake.targetImage': '<p>The name of the resulting docker image.</p>',
+    'pipeline.config.docker.bake.targetImageTag': '<p>The tag of the resulting docker image, defaults to commit hash if available.</p>',
+    'pipeline.config.docker.bake.organization': '<p>The name of the organization or repo to use for the resulting docker image.</p>',
     'pipeline.config.bake.baseAmi': '<p>(Optional) ami-????????</p>',
     'pipeline.config.bake.amiSuffix': '<p>(Optional) String of date in format YYYYMMDDHHmm, default is calculated from timestamp,</p>',
     'pipeline.config.bake.enhancedNetworking': '<p>(Optional) Enable enhanced networking (sr-iov) support for image (requires hvm and trusty base_os).</p>',

--- a/app/scripts/modules/docker/pipeline/stages/bake/bakeExecutionDetails.html
+++ b/app/scripts/modules/docker/pipeline/stages/bake/bakeExecutionDetails.html
@@ -6,18 +6,24 @@
         <dl class="dl-narrow dl-horizontal">
           <dt if-multiple-providers>Provider</dt>
           <dd if-multiple-providers>Docker</dd>
+          <dt>Organization</dt>
+          <dd>{{stage.context.organization}}</dd>
+          <dt>Image Name</dt>
+          <dd>{{stage.context.ami_name}}</dd>
+          <dt>Image Tag</dt>
+          <dd>{{stage.context.extendedAttributes['docker_target_image_tag']}}</dd>
           <dt>Image</dt>
           <dd>{{stage.context.ami}}</dd>
-          <dt>Region</dt>
-          <dd>{{stage.context.region}}</dd>
-          <dt>Package</dt>
-          <dd>{{stage.context.package}}</dd>
         </dl>
       </div>
       <div class="col-md-6">
         <dl class="dl-narrow dl-horizontal">
           <dt>Base OS</dt>
           <dd>{{stage.context.baseOs}}</dd>
+          <dt>Region</dt>
+          <dd>{{stage.context.region}}</dd>
+          <dt>Package</dt>
+          <dd>{{stage.context.package}}</dd>
           <dt>Label</dt>
           <dd>{{stage.context.baseLabel}}</dd>
         </dl>

--- a/app/scripts/modules/docker/pipeline/stages/bake/bakeStage.html
+++ b/app/scripts/modules/docker/pipeline/stages/bake/bakeStage.html
@@ -3,6 +3,18 @@
       <input type="text" class="form-control input-sm"
              ng-model="stage.package"/>
   </stage-config-field>
+  <stage-config-field label="Organization" help-key="pipeline.config.docker.bake.organization">
+    <input type="text" class="form-control input-sm"
+             ng-model="stage.organization"/>
+  </stage-config-field>
+  <stage-config-field label="Image Name" help-key="pipeline.config.docker.bake.targetImage">
+    <input type="text" class="form-control input-sm"
+             ng-model="stage.ami_name"/>
+  </stage-config-field>
+  <stage-config-field label="Image tag" help-key="pipeline.config.docker.bake.targetImageTag">
+    <input type="text" class="form-control input-sm"
+             ng-model="stage.extendedAttributes['docker_target_image_tag']"/>
+  </stage-config-field>
   <stage-config-field label="Base OS">
     <label class="radio-inline" ng-repeat="baseOsOption in baseOsOptions">
       <input type="radio"


### PR DESCRIPTION
These changes are related to (but not dependent on) this PR https://github.com/spinnaker/rosco/pull/172

The motivation here is to add support for specifying common parameters in the docker bake stage. Not quite sure about the fields in `bakeExecutionDetails.html`, so please comment if someone has strong opinions on this. 