### PR TITLE
(core) position tab alert on bottom, avoid overflow

### DIFF
--- a/app/scripts/modules/core/entityTag/dataSourceAlerts.component.ts
+++ b/app/scripts/modules/core/entityTag/dataSourceAlerts.component.ts
@@ -52,7 +52,7 @@ class DataSourceAlertsComponent implements ng.IComponentOptions {
           ng-mouseover="$ctrl.showPopover()" 
           ng-mouseleave="$ctrl.hidePopover(true)">
       <span uib-popover-template="$ctrl.popoverTemplate"
-            popover-placement="auto top"
+            popover-placement="bottom"
             popover-trigger="none"
             popover-is-open="$ctrl.displayPopover"
             popover-class="no-padding">

--- a/app/scripts/modules/core/presentation/main.less
+++ b/app/scripts/modules/core/presentation/main.less
@@ -1321,6 +1321,8 @@ ul.checkmap {
 .popover.no-padding {
   .popover-content {
     padding: 0;
+    max-height: 50vh;
+    overflow-y: auto;
   }
 }
 


### PR DESCRIPTION
If there are so many alerts that the popover won't fit on the page, it ends up overflowing off the bottom of the screen, which is...no good. This change restricts the popover to half the screen height and allows scrolling in the event it doesn't fit.