### PR TITLE
Fix Fast Property Create NPE

### DIFF
--- a/app/scripts/modules/netflix/fastProperties/domain/propertyPipelineStage.ts
+++ b/app/scripts/modules/netflix/fastProperties/domain/propertyPipelineStage.ts
@@ -36,7 +36,9 @@ export class PropertyPipelineStage implements IStage {
     this.cmcTicket = propertyCopy.cmcTicket;
     this.delete = command.type === PropertyCommandType.DELETE;
 
-    this.originalProperties.push(command.originalProperty);
+    if (command.originalProperty) {
+      this.originalProperties.push(command.originalProperty);
+    }
     this.persistedProperties.push(propertyCopy);
   }
 


### PR DESCRIPTION
Fixes the submission of 'null' for originalProperties when there is no orignal state for a property e.g. when creating a new one.