### PR TITLE
(netflix) display server group provenance if available

### DIFF
--- a/app/scripts/modules/amazon/serverGroup/details/serverGroupDetails.aws.controller.js
+++ b/app/scripts/modules/amazon/serverGroup/details/serverGroupDetails.aws.controller.js
@@ -13,6 +13,7 @@ import {SERVER_GROUP_WRITER} from 'core/serverGroup/serverGroupWriter.service';
 import {SERVER_GROUP_WARNING_MESSAGE_SERVICE} from 'core/serverGroup/details/serverGroupWarningMessage.service';
 import {RUNNING_TASKS_DETAILS_COMPONENT} from 'core/serverGroup/details/runningTasks.component';
 import {CLUSTER_TARGET_BUILDER} from 'core/entityTag/clusterTargetBuilder.service';
+import {ENTITY_SOURCE_COMPONENT} from 'core/entityTag/entitySource.component';
 
 require('../configure/serverGroup.configure.aws.module.js');
 
@@ -27,6 +28,7 @@ module.exports = angular.module('spinnaker.serverGroup.details.aws.controller', 
   VIEW_SCALING_ACTIVITIES_LINK,
   ADD_ENTITY_TAG_LINKS_COMPONENT,
   CLUSTER_TARGET_BUILDER,
+  ENTITY_SOURCE_COMPONENT,
   require('../../vpc/vpcTag.directive.js'),
   require('./scalingProcesses/autoScalingProcess.service.js'),
   SERVER_GROUP_READER,

--- a/app/scripts/modules/amazon/serverGroup/details/serverGroupDetails.html
+++ b/app/scripts/modules/amazon/serverGroup/details/serverGroupDetails.html
@@ -82,7 +82,7 @@
         <dd><vpc-tag vpc-id="ctrl.serverGroup.vpcId"></vpc-tag></dd>
         <dt ng-if="ctrl.serverGroup.vpcId">Subnet</dt>
         <dd ng-if="ctrl.serverGroup.vpcId">{{ctrl.serverGroup.subnetType || 'None (EC2 Classic)'}}</dd>
-        <dt>Availability Zones</dt>
+        <dt>Zones</dt>
         <dd>
           <ul>
             <li ng-repeat="zone in ctrl.serverGroup.asg.availabilityZones">{{zone}}</li>

--- a/app/scripts/modules/core/delivery/delivery.states.ts
+++ b/app/scripts/modules/core/delivery/delivery.states.ts
@@ -40,9 +40,12 @@ module(DELIVERY_STATES, [
     }
   };
 
+  // a specific stage can be deep linked by providing either refId or stageId,
+  // which will be resolved to stage or step by the executionDetails controller to stage/step parameters,
+  // replacing the URL
   const executionDetails: INestedState = {
     name: 'execution',
-    url: '/:executionId?refId&stage&step&details',
+    url: '/:executionId?refId&stage&step&details&stageId',
     params: {
       stage: {
         value: '0',

--- a/app/scripts/modules/core/delivery/details/executionDetails.controller.js
+++ b/app/scripts/modules/core/delivery/details/executionDetails.controller.js
@@ -11,7 +11,30 @@ module.exports = angular.module('spinnaker.executionDetails.controller', [
 
     controller.standalone = $scope.standalone || false;
 
+    function getStageParams(stageId) {
+      const summaries = ($scope.execution.stageSummaries || []);
+      const stageIndex = summaries.findIndex(s => (s.stages || []).some(s2 => s2.id === stageId));
+      if (stageIndex !== -1) {
+        const stepIndex = (summaries[stageIndex].stages || []).findIndex(s => s.id === stageId);
+        if (stepIndex !== -1) {
+          return {
+            stage: stageIndex,
+            step: stepIndex,
+            stageId: null,
+          };
+        }
+      }
+      return null;
+    }
+
     function getCurrentStage() {
+      if ($stateParams.stageId) {
+        const params = getStageParams($stateParams.stageId);
+        if (params) {
+          $state.go('.', params, {replace: true});
+          return params.stage;
+        }
+      }
       if ($stateParams.refId) {
         let stages = $scope.execution.stageSummaries || [];
         let currentStageIndex = _.findIndex(stages, { refId: $stateParams.refId });

--- a/app/scripts/modules/core/domain/IEntityTags.ts
+++ b/app/scripts/modules/core/domain/IEntityTags.ts
@@ -6,6 +6,21 @@ export interface IEntityTagsMetadata {
   lastModifiedBy: string;
 }
 
+export interface ICreationMetadata {
+  executionType: 'orchestration' | 'pipeline',
+  stageId?: string;
+  executionId?: string;
+  pipelineConfigId?: string;
+  application?: string;
+  user?: string;
+  description?: string;
+  comments?: string;
+}
+
+export interface ICreationMetadataTag extends IEntityTag {
+  value: ICreationMetadata;
+}
+
 export interface IEntityTag {
   name: string;
   value: any;
@@ -25,6 +40,7 @@ export interface IEntityTags {
   entityRef: IEntityRef;
   alerts: IEntityTag[];
   notices: IEntityTag[];
+  creationMetadata?: ICreationMetadataTag;
 }
 
 export interface IEntityRef {

--- a/app/scripts/modules/core/entityTag/entitySource.component.ts
+++ b/app/scripts/modules/core/entityTag/entitySource.component.ts
@@ -1,0 +1,63 @@
+import {module} from 'angular';
+import {ICreationMetadataTag} from 'core/domain/IEntityTags';
+import {IExecution} from '../domain/IExecution';
+
+class EntitySourceCtrl implements ng.IComponentController {
+  public relativePath = '^.^.^';
+  public metadata: ICreationMetadataTag;
+  public executionType: string;
+  public popoverTemplate: string = require('./entitySource.popover.html');
+  public execution: IExecution;
+  public executionNotFound: boolean;
+
+  static get $inject() { return ['executionService']; }
+
+  constructor(private executionService: any) {}
+
+  public $onInit(): void {
+    this.executionType = 'Task';
+    if (this.metadata && this.metadata.value.executionType === 'pipeline') {
+      this.executionType = 'Pipeline';
+      this.executionService.getExecution(this.metadata.value.executionId).then(
+        (execution: IExecution) => this.execution = execution,
+        () => this.executionNotFound = true
+      );
+    }
+  }
+
+  public $onChanges(): void {
+    this.$onInit();
+  }
+
+}
+
+class EntitySourceComponent implements ng.IComponentOptions {
+  public bindings: any = {
+    metadata: '=',
+    relativePath: '=?',
+  };
+  public controller: any = EntitySourceCtrl;
+  public template = `
+    <div ng-if="$ctrl.metadata">
+      <dt>Source</dt>
+      <dd>
+        <span uib-popover-template="$ctrl.popoverTemplate"
+              popover-placement="left"
+              popover-trigger="mouseenter">
+          <span ng-if="$ctrl.executionNotFound">pipeline (not found)</span>
+          <a ng-if="!$ctrl.executionNotFound && $ctrl.metadata.value.executionType === 'pipeline'" 
+             ui-sref="{{$ctrl.relativePath}}.pipelines.executionDetails.execution({application: $ctrl.metadata.value.application, executionId: $ctrl.metadata.value.executionId, stageId: $ctrl.metadata.value.stageId})">
+            pipeline
+          </a>
+          <a ng-if="$ctrl.metadata.value.executionType === 'orchestration'"
+             ui-sref="{{$ctrl.relativePath}}.tasks.taskDetails({application: $ctrl.metadata.value.application, taskId: $ctrl.metadata.value.executionId})">
+            task
+          </a>
+        </span>
+      </dd>
+    </div>
+  `;
+}
+
+export const ENTITY_SOURCE_COMPONENT = 'spinnaker.core.entityTag.entitySource.component';
+module(ENTITY_SOURCE_COMPONENT, []).component('entitySource', new EntitySourceComponent());

--- a/app/scripts/modules/core/entityTag/entitySource.popover.html
+++ b/app/scripts/modules/core/entityTag/entitySource.popover.html
@@ -1,0 +1,17 @@
+<dl>
+  <dt>{{$ctrl.executionType}}</dt>
+  <dd>{{$ctrl.metadata.value.description}}</dd>
+  <div ng-if="$ctrl.execution">
+    <dt>Triggered by</dt>
+    <dd ng-if="$ctrl.metadata.value.user">{{$ctrl.metadata.value.user}}</dd>
+    <dd ng-if="!$ctrl.metadata.value.user">{{$ctrl.execution.trigger.type}}</dd>
+  </div>
+  <div ng-if="!$ctrl.execution && $ctrl.metadata.value.user">
+    <dt>User</dt>
+    <dd>{{$ctrl.metadata.value.user}}</dd>
+  </div>
+  <div ng-if="$ctrl.metadata.value.comments">
+    <dt>Comments</dt>
+    <dd marked="$ctrl.metadata.value.comments"></dd>
+  </div>
+</dl>

--- a/app/scripts/modules/core/entityTag/entityTags.read.service.ts
+++ b/app/scripts/modules/core/entityTag/entityTags.read.service.ts
@@ -2,7 +2,7 @@ import {module} from 'angular';
 import {get} from 'lodash';
 
 import {API_SERVICE, Api} from 'core/api/api.service';
-import {IEntityTags, IEntityTag} from '../domain/IEntityTags';
+import {IEntityTags, IEntityTag, ICreationMetadataTag} from '../domain/IEntityTags';
 import {RETRY_SERVICE, RetryService} from 'core/retry/retry.service';
 
 export class EntityTagsReader {
@@ -52,6 +52,7 @@ export class EntityTagsReader {
         entityTag.tags.forEach(tag => this.addTagMetadata(entityTag, tag));
         entityTag.alerts = entityTag.tags.filter(t => t.name.startsWith('spinnaker_ui_alert:'));
         entityTag.notices = entityTag.tags.filter(t => t.name.startsWith('spinnaker_ui_notice:'));
+        entityTag.creationMetadata = entityTag.tags.find(t => t.name === 'spinnaker:metadata') as ICreationMetadataTag;
         allTags.push(entityTag);
       });
     });

--- a/app/scripts/modules/core/presentation/details.less
+++ b/app/scripts/modules/core/presentation/details.less
@@ -94,7 +94,7 @@
         padding-top: 10px;
       }
       .glyphicon, .icon {
-        display: table-cell;
+        display: inline-block;
         vertical-align: middle;
         top: 50%;
         color: @healthy_green;

--- a/app/scripts/modules/netflix/serverGroup/awsServerGroupDetails.html
+++ b/app/scripts/modules/netflix/serverGroup/awsServerGroupDetails.html
@@ -81,6 +81,7 @@
       <dl class="dl-horizontal dl-flex">
         <dt>Created</dt>
         <dd>{{ctrl.serverGroup.createdTime | timestamp}}</dd>
+        <entity-source metadata="ctrl.serverGroup.entityTags.creationMetadata"></entity-source>
         <dt>In</dt>
         <dd>
           <account-tag account="ctrl.serverGroup.account" pad="right"></account-tag>
@@ -91,7 +92,7 @@
         <dd><vpc-tag vpc-id="ctrl.serverGroup.vpcId"></vpc-tag></dd>
         <dt ng-if="ctrl.serverGroup.vpcId">Subnet</dt>
         <dd ng-if="ctrl.serverGroup.vpcId">{{ctrl.serverGroup.subnetType || 'None (EC2 Classic)'}}</dd>
-        <dt>Availability Zones</dt>
+        <dt>Zones</dt>
         <dd>
           <ul>
             <li ng-repeat="zone in ctrl.serverGroup.asg.availabilityZones">{{zone}}</li>

--- a/app/scripts/modules/titus/serverGroup/details/serverGroupDetails.html
+++ b/app/scripts/modules/titus/serverGroup/details/serverGroupDetails.html
@@ -68,6 +68,7 @@
         <dd><a href="{{ serverGroup.apiEndpoint }}v2/jobs/{{serverGroup.id}}?taskState=ANY" target="_blank">{{serverGroup.id}}</a></dd>
         <dt>Created</dt>
         <dd>{{serverGroup.createdTime | timestamp}}</dd>
+        <entity-source metadata="serverGroup.entityTags.creationMetadata"></entity-source>
         <dt ng-if="serverGroup.iamProfile">IAM Profile</dt>
         <dd ng-if="serverGroup.iamProfile">{{serverGroup.iamProfile}}</dd>
       </dl>


### PR DESCRIPTION
* if present, show the task/pipeline details
* changing "Availability Zones" label to "Zones", which actually fits without spilling into an ellipsis after "Availability"
* allow deep linking to a specific stage via `stageId` parameter on an execution URL

@jrsquared or @zanthrash or @icfantv PTAL