### PR TITLE
(docker) fix tag initialization, optimize loading

### DIFF
--- a/app/scripts/modules/docker/image/dockerImageAndTagSelector.component.spec.ts
+++ b/app/scripts/modules/docker/image/dockerImageAndTagSelector.component.spec.ts
@@ -1,0 +1,93 @@
+import {mock} from 'angular';
+import {
+  DockerImageAndTagSelectorController,
+  DOCKER_IMAGE_AND_TAG_SELECTOR_COMPONENT
+} from './dockerImageAndTagSelector.component';
+import {AccountService, IAccount} from 'core/account/account.service';
+import {DockerImageReaderService, IDockerImage} from './docker.image.reader.service';
+
+describe('dockerImageAndTagSelector controller', () => {
+  let $ctrl: DockerImageAndTagSelectorController,
+      accountService: AccountService,
+      dockerImageReader: DockerImageReaderService,
+      $componentController: ng.IComponentControllerService,
+      $q: ng.IQService,
+      $scope: ng.IScope;
+
+  let organization: string,
+      registry: string,
+      repository: string,
+      tag: string,
+      account: string,
+      showRegistry: boolean;
+
+  beforeEach(mock.module(DOCKER_IMAGE_AND_TAG_SELECTOR_COMPONENT));
+
+  beforeEach(mock.inject((_accountService_: AccountService,
+                          _dockerImageReader_: DockerImageReaderService,
+                          _$componentController_: ng.IComponentControllerService,
+                          _$q_: ng.IQService,
+                          $rootScope: ng.IRootScopeService) => {
+    accountService = _accountService_;
+    dockerImageReader = _dockerImageReader_;
+    $componentController = _$componentController_;
+    $q = _$q_;
+    $scope = $rootScope.$new();
+  }));
+
+  let initialize = (accounts: IAccount[], images: IDockerImage[]) => {
+    spyOn(accountService, 'listAccounts').and.returnValue($q.when(accounts));
+    spyOn(dockerImageReader, 'findImages').and.returnValue($q.when(images));
+    $ctrl = <DockerImageAndTagSelectorController>$componentController(
+      'dockerImageAndTagSelector',
+      { accountService, dockerImageReader },
+      { organization, registry, repository, tag, account, showRegistry }
+    );
+    $ctrl.$onInit();
+    $scope.$digest();
+  };
+
+  describe('option initialization', () => {
+
+    beforeEach(() => {
+      organization = 'my-org';
+      repository = 'my-org/my-repo';
+      registry = 'registry1';
+      showRegistry = true;
+    });
+
+    it('fully initializes options when all arguments provided to controller', () => {
+      const accounts: IAccount[] = [
+        { name: 'account1', accountId: '1', requiredGroupMembership: [], type: 'docker' }
+      ];
+      const images: IDockerImage[] = [
+        { account: 'account1', registry: 'registry1', repository: 'my-org/my-repo', tag: 'latest' }
+      ];
+
+      initialize(accounts, images);
+      expect($ctrl.accounts).toEqual(['account1']);
+      expect($ctrl.organizations).toEqual(['my-org']);
+      expect($ctrl.repositories).toEqual(['my-org/my-repo']);
+      expect($ctrl.tags).toEqual(['latest']);
+    });
+  });
+
+  it('de-duplicates organizations, tags, repositories', () => {
+    const accounts: IAccount[] = [
+      { name: 'account1', accountId: '1', requiredGroupMembership: [], type: 'docker' },
+      { name: 'account2', accountId: '3', requiredGroupMembership: [], type: 'docker' },
+    ];
+    const images: IDockerImage[] = [
+      { account: 'account1', registry: 'registry1', repository: 'my-org/my-repo', tag: 'latest' },
+      { account: 'account1', registry: 'registry1', repository: 'my-org/my-repo', tag: 'latest' },
+      { account: 'account1', registry: 'registry1', repository: 'my-org/my-repo', tag: '1.1' },
+      { account: 'account2', registry: 'registry1', repository: 'my-org/my-repo', tag: 'latest' }
+    ];
+
+    initialize(accounts, images);
+    expect($ctrl.accounts).toEqual(['account1', 'account2']);
+    expect($ctrl.organizations).toEqual(['my-org']);
+    expect($ctrl.repositories).toEqual(['my-org/my-repo']);
+    expect($ctrl.tags).toEqual(['latest', '1.1']);
+  });
+});

--- a/app/scripts/modules/netflix/fastProperties/domain/scope.domain.spec.ts
+++ b/app/scripts/modules/netflix/fastProperties/domain/scope.domain.spec.ts
@@ -25,7 +25,7 @@ describe('Scope Domain Spec', function () {
         expect(result[prop]).toBe(platformProperty[prop]);
       });
 
-      expect(result['propertyId']).toBeUndefined()
+      expect(result['propertyId']).toBeUndefined();
 
     });
   });

--- a/app/scripts/modules/netflix/fastProperties/wizard/propertyDetails/propertyDetails.component.spec.ts
+++ b/app/scripts/modules/netflix/fastProperties/wizard/propertyDetails/propertyDetails.component.spec.ts
@@ -39,7 +39,7 @@ describe('propertyDetailsComponent test', function () {
     });
 
     it('constructor should handle missing property on the PropertyCommand', function () {
-      let data:{command: PropertyCommand, isEditing: boolean, isDeleting: boolean} = {
+      let data: {command: PropertyCommand, isEditing: boolean, isDeleting: boolean} = {
         command: new PropertyCommand(),
         isEditing: false,
         isDeleting: false,


### PR DESCRIPTION
This was initially a one-line change: moving `this.updateOrganizationsList()` down so it executes after `this.updateRepositoryMap(images)`. This ensures tags are pre-populated when the controller initializes with existing data.

All the other changes are performance optimizations. I wouldn't have even noticed them, but I had my browser console open and noticed, when the modal opens, warnings like this:
```
[Violation] Long running JavaScript task took 974ms
```
It was pretty consistently running between 900 and 1100 ms, and it's blocking. Running the profiler showed almost all of that time being spent in the `all.includes(...)` calls - not what I expected, but I guess it makes sense when there are 35k+ images. 

The easy fix is to jam everything into the array, then remove duplicates at the end via `_.uniq`. This drops initialization to < 150ms (I didn't measure, but Chrome won't warn unless it's > 150ms), and the select fields are available almost immediately, so it's a nice little fix.

Added a couple of very rudimentary tests to verify de-duping works as expected.

I manually tested against all the Titus pieces and expect the other usages will work fine, too.

@icfantv or @danielpeach PTAL