### PR TITLE
(all providers) Show that an instance is not found instead of failing siliently

### DIFF
--- a/app/scripts/modules/amazon/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/amazon/instance/details/instance.details.controller.js
@@ -155,7 +155,8 @@ module.exports = angular.module('spinnaker.instance.detail.aws.controller', [
       }
 
       if (!instanceSummary) {
-        autoClose();
+        $scope.instanceIdNotFound = instance.instanceId;
+        $scope.state.loading = false;
       }
 
       return $q.when(null);
@@ -166,9 +167,9 @@ module.exports = angular.module('spinnaker.instance.detail.aws.controller', [
         return;
       }
       if (app.isStandalone) {
-        $scope.instanceId = instance.instanceId;
         $scope.state.loading = false;
-        $scope.state.notFound = true;
+        $scope.instanceIdNotFound = instance.instanceId;
+        $scope.state.notFoundStandalone = true;
         recentHistoryService.removeLastItem('instances');
       } else {
         $state.params.allowModalToStayOpen = true;

--- a/app/scripts/modules/amazon/instance/details/instanceDetails.html
+++ b/app/scripts/modules/amazon/instance/details/instanceDetails.html
@@ -1,8 +1,8 @@
-<div class="text-center" ng-if="state.notFound">
-  <h3>Could not find instance {{instanceId}}.</h3>
+<div class="text-center" ng-if="state.notFoundStandalone">
+  <h3>Could not find instance {{instanceIdNotFound}}.</h3>
   <a ui-sref="home.infrastructure">Back to search results</a>
 </div>
-<div class="details-panel">
+<div class="details-panel" ng-if="!state.notFoundStandalone">
   <div class="header" ng-if="state.loading">
     <div class="close-button" ng-if="!state.standalone">
       <a class="btn btn-link"
@@ -15,7 +15,7 @@
     </h4>
   </div>
 
-  <div class="header" ng-if="!state.loading && !state.notFound">
+  <div class="header" ng-if="!state.loading">
     <div class="close-button" ng-if="!state.standalone">
       <a class="btn btn-link"
          ui-sref="^">
@@ -25,7 +25,7 @@
     <div class="header-text">
       <span class="glyphicon glyphicon-hdd {{instance.healthState}}"></span>
       <h3 select-on-dbl-click>
-        {{instance.instanceId}}
+        {{instance ? instance.instanceId ? instanceIdNotFound }}
       </h3>
     </div>
     <div>
@@ -57,7 +57,7 @@
       </div>
     </div>
   </div>
-  <div class="content" ng-if="!state.loading">
+  <div class="content" ng-if="!state.loading && instance">
     <collapsible-section heading="Instance Information" expanded="true">
       <dl class="dl-horizontal dl-flex">
         <dt>Launched</dt>
@@ -113,12 +113,7 @@
         </dd>
       </dl>
     </collapsible-section>
-    <div class="content-section" ng-if="instance.notFound">
-      <div class="content-body">
-        <p>Could not find the instance. No other details provided.</p>
-      </div>
-    </div>
-    <collapsible-section heading="DNS" ng-if="!instance.notFound">
+    <collapsible-section heading="DNS">
       <dl class="horizontal-when-filters-collapsed">
         <dt ng-if="instance.privateDnsName">Private DNS Name</dt>
         <dd ng-if="instance.privateDnsName">
@@ -167,7 +162,7 @@
         </dd>
       </dl>
     </collapsible-section>
-    <collapsible-section ng-if="!instance.notFound" heading="Security Groups">
+    <collapsible-section heading="Security Groups">
         <ul>
           <li ng-repeat="securityGroup in instance.securityGroups | orderBy:'groupName'">
             <a ui-sref="^.securityGroupDetails({name:securityGroup.groupName, accountId: instance.account, region: instance.region, vpcId: instance.vpcId, provider: instance.provider})">
@@ -176,7 +171,7 @@
           </li>
         </ul>
     </collapsible-section>
-    <collapsible-section ng-if="!instance.notFound" heading="Tags">
+    <collapsible-section heading="Tags">
       <div ng-if=" !instance.tags.length">No tags associated with this server</div>
       <dl ng-if="instance.tags.length">
         <dt ng-repeat-start="tag in instance.tags | orderBy: 'key.toLowerCase()'">{{tag.key}}</dt>
@@ -191,5 +186,12 @@
       </ul>
     </collapsible-section>
     <instance-links address="baseIpAddress" application="application" instance="instance"></instance-links>
+  </div>
+  <div class="content" ng-if="!state.loading && !instance">
+    <div class="content-section">
+      <div class="content-body text-center">
+        <h3>Instance not found.</h3>
+      </div>
+    </div>
   </div>
 </div>

--- a/app/scripts/modules/appengine/instance/details/details.html
+++ b/app/scripts/modules/appengine/instance/details/details.html
@@ -21,7 +21,7 @@
     <div class="header-text">
       <span class="glyphicon glyphicon-hdd {{ctrl.instance.healthState}}"></span>
       <h3 select-on-dbl-click>
-        {{ctrl.instance.name}}
+        {{ctrl.instance ? ctrl.instance.name : ctrl.instanceIdNotFound}}
       </h3>
     </div>
     <div>
@@ -38,7 +38,7 @@
       </div>
     </div>
   </div>
-  <div class="content" ng-if="!ctrl.state.loading">
+  <div class="content" ng-if="!ctrl.state.loading && ctrl.instance">
     <collapsible-section heading="Instance Information" expanded="true">
       <dl class="dl-horizontal dl-narrow">
         <dt>Launched</dt>
@@ -96,5 +96,12 @@
         <appengine-conditional-dt-dd component="ctrl.instance" key="vmDebugEnabled" label="Debug Enabled"></appengine-conditional-dt-dd>
       </dl>
     </collapsible-section>
+  </div>
+  <div class="content" ng-if="!ctrl.state.loading && !ctrl.instance">
+    <div class="content-section">
+      <div class="content-body text-center">
+        <h3>Instance not found.</h3>
+      </div>
+    </div>
   </div>
 </div>

--- a/app/scripts/modules/azure/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/azure/instance/details/instance.details.controller.js
@@ -146,7 +146,8 @@ module.exports = angular.module('spinnaker.azure.instance.detail.controller', [
       }
 
       if (!instanceSummary) {
-        $state.go('^');
+        $scope.instanceIdNotFound = instance.instanceId;
+        $scope.state.loading = false;
       }
 
       return $q.when(null);

--- a/app/scripts/modules/azure/instance/details/instanceDetails.html
+++ b/app/scripts/modules/azure/instance/details/instanceDetails.html
@@ -21,11 +21,11 @@
     <div class="header-text">
       <span class="glyphicon glyphicon-hdd {{instance.healthState}}"></span>
       <h3 select-on-dbl-click>
-        {{instance.instanceId}}
+        {{instance ? instance.instanceId : instanceIdNotFound}}
       </h3>
     </div>
   </div>
-  <div class="content" ng-if="!state.loading">
+  <div class="content" ng-if="!state.loading && instance">
     <collapsible-section heading="Instance Information" expanded="true">
       <dl class="dl-horizontal dl-flex">
         <dt>Launched</dt>
@@ -47,9 +47,11 @@
         </dd>
       </dl>
     </collapsible-section>
-    <div class="content-section" ng-if="instance.notFound">
-      <div class="content-body">
-        <p>Could not find the instance. No other details provided.</p>
+  </div>
+  <div class="content" ng-if="!state.loading && !instance">
+    <div class="content-section">
+      <div class="content-body text-center">
+        <h3>Instance not found.</h3>
       </div>
     </div>
   </div>

--- a/app/scripts/modules/cloudfoundry/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/cloudfoundry/instance/details/instance.details.controller.js
@@ -144,7 +144,8 @@ module.exports = angular.module('spinnaker.instance.detail.cf.controller', [
       }
 
       if (!instanceSummary) {
-        autoClose();
+        $scope.instanceIdNotFound = instance.instanceId;
+        $scope.state.loading = false;
       }
       return $q.when(null);
     }

--- a/app/scripts/modules/cloudfoundry/instance/details/instanceDetails.html
+++ b/app/scripts/modules/cloudfoundry/instance/details/instanceDetails.html
@@ -21,7 +21,7 @@
     <div class="header-text">
       <span class="glyphicon glyphicon-hdd {{instance.healthState}}"></span>
       <h3 select-on-dbl-click>
-        {{instance.instanceId}}
+        {{instance ? instance.instanceId : instanceIdNotFound}}
       </h3>
     </div>
     <div>
@@ -52,7 +52,7 @@
       </div>
     </div>
   </div>
-  <div class="content" ng-if="!state.loading">
+  <div class="content" ng-if="!state.loading && instance">
     <collapsible-section heading="Instance Information" expanded="true">
       <dl class="dl-horizontal dl-flex">
         <dt>Launched</dt>
@@ -96,12 +96,7 @@
         </dd>
       </dl>
     </collapsible-section>
-    <div class="content-section" ng-if="instance.notFound">
-      <div class="content-body">
-        <p>Could not find the instance. No other details provided.</p>
-      </div>
-    </div>
-    <collapsible-section heading="DNS" ng-if="!instance.notFound">
+    <collapsible-section heading="DNS">
       <dl class="horizontal-when-filters-collapsed">
         <dt ng-if="instance.internalDnsName">Internal DNS Name</dt>
         <dd ng-if="instance.internalDnsName"><a href="http://{{instance.internalDnsName}}" target="_blank">{{instance.internalDnsName}}</a></dd>
@@ -111,7 +106,7 @@
         <dd ng-if="instance.externalIpAddress"><a href="http://{{instance.externalIpAddress}}" target="_blank">{{instance.externalIpAddress}}</a></dd>
       </dl>
     </collapsible-section>
-    <collapsible-section ng-if="!instance.notFound" heading="Security Groups">
+    <collapsible-section heading="Security Groups">
         <ul>
           <li ng-repeat="securityGroup in instance.securityGroups | orderBy:'groupName'">
             <a ui-sref="^.securityGroupDetails({name:securityGroup.groupName, accountId: instance.account, region: 'global', provider: instance.provider})">
@@ -144,5 +139,12 @@
       </ul>
     </collapsible-section>
     <instance-links address="baseIpAddress" application="application" instance="instance"></instance-links>
+  </div>
+  <div class="content" ng-if="!state.loading && !instance">
+    <div class="content-section">
+      <div class="content-body text-center">
+        <h3>Instance not found.</h3>
+      </div>
+    </div>
   </div>
 </div>

--- a/app/scripts/modules/google/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/google/instance/details/instance.details.controller.js
@@ -162,7 +162,8 @@ module.exports = angular.module('spinnaker.instance.detail.gce.controller', [
       }
 
       if (!instanceSummary) {
-        autoClose();
+        $scope.instanceIdNotFound = instance.instanceId;
+        $scope.state.loading = false;
       }
 
       return $q.when(null);

--- a/app/scripts/modules/google/instance/details/instanceDetails.html
+++ b/app/scripts/modules/google/instance/details/instanceDetails.html
@@ -21,7 +21,7 @@
     <div class="header-text">
       <span class="glyphicon glyphicon-hdd {{instance.healthState}}"></span>
       <h3 select-on-dbl-click>
-        {{instance.instanceId}}
+        {{instance ? instance.instanceId : instanceIdNotFound}}
       </h3>
       <copy-to-clipboard
           ng-if="instance.gcloudSSHCommand"
@@ -59,7 +59,7 @@
       </div>
     </div>
   </div>
-  <div class="content" ng-if="!state.loading">
+  <div class="content" ng-if="!state.loading && instance">
     <collapsible-section heading="Instance Information" expanded="true">
       <dl class="dl-horizontal dl-flex">
         <dt>Launched</dt>
@@ -113,12 +113,7 @@
         </dd>
       </dl>
     </collapsible-section>
-    <div class="content-section" ng-if="instance.notFound">
-      <div class="content-body">
-        <p>Could not find the instance. No other details provided.</p>
-      </div>
-    </div>
-    <collapsible-section heading="DNS" ng-if="!instance.notFound">
+    <collapsible-section heading="DNS">
       <dl class="horizontal-when-filters-collapsed">
         <dt ng-if="instance.internalDnsName">Internal DNS Name</dt>
         <dd ng-if="instance.internalDnsName">
@@ -149,7 +144,7 @@
         </dd>
       </dl>
     </collapsible-section>
-    <collapsible-section ng-if="!instance.notFound" heading="Security Groups">
+    <collapsible-section heading="Security Groups">
         <ul>
           <li ng-repeat="securityGroup in instance.securityGroups | orderBy:'groupName'">
             <a ui-sref="^.securityGroupDetails({name:securityGroup.groupName, accountId: instance.account, region: 'global', provider: instance.provider})">
@@ -177,7 +172,7 @@
         </dd>
       </dl>
     </collapsible-section>
-    <collapsible-section heading="SSH" ng-if="!instance.notFound">
+    <collapsible-section heading="SSH">
       <dl>
         <dt ng-if="instance.sshLink">SSH into this instance</dt>
         <dd ng-if="instance.sshLink">
@@ -206,5 +201,12 @@
       </ul>
     </collapsible-section>
     <instance-links address="baseIpAddress" application="application" instance="instance"></instance-links>
+  </div>
+  <div class="content" ng-if="!state.loading && !instance">
+    <div class="content-section">
+      <div class="content-body text-center">
+        <h3>Instance not found.</h3>
+      </div>
+    </div>
   </div>
 </div>

--- a/app/scripts/modules/kubernetes/instance/details/details.controller.js
+++ b/app/scripts/modules/kubernetes/instance/details/details.controller.js
@@ -134,7 +134,8 @@ module.exports = angular.module('spinnaker.instance.detail.kubernetes.controller
       }
 
       if (!instanceSummary) {
-        autoClose();
+        $scope.instanceIdNotFound = instance.instanceId;
+        $scope.state.loading = false;
       }
 
       return $q.when(null);

--- a/app/scripts/modules/kubernetes/instance/details/details.html
+++ b/app/scripts/modules/kubernetes/instance/details/details.html
@@ -21,7 +21,7 @@
     <div class="header-text">
       <span class="glyphicon glyphicon-hdd {{instance.healthState}}"></span>
       <h3 select-on-dbl-click>
-        {{instance.instanceId}}
+        {{instance ? instance.instanceId : instanceIdNotFound}}
       </h3>
     </div>
     <div>
@@ -49,7 +49,7 @@
       </div>
     </div>
   </div>
-  <div class="content" ng-if="!state.loading">
+  <div class="content" ng-if="!state.loading && instance">
     <collapsible-section heading="Instance Information" expanded="true">
       <dl class="dl-horizontal dl-flex">
         <dt>Launched</dt>
@@ -87,12 +87,7 @@
         </dd>
       </dl>
     </collapsible-section>
-    <div class="content-section" ng-if="instance.notFound">
-      <div class="content-body">
-        <p>Could not find the instance. No other details provided.</p>
-      </div>
-    </div>
-    <collapsible-section heading="DNS" ng-if="!instance.notFound">
+    <collapsible-section heading="DNS">
       <dl class="horizontal-when-filters-collapsed">
         <dt ng-if="instance.dnsPolicy">DNS Policy</dt>
         <dd ng-if="instance.dnsPolicy">
@@ -117,7 +112,7 @@
         </dd>
       </dl>
     </collapsible-section>
-    <collapsible-section ng-if="!instance.notFound" heading="Labels">
+    <collapsible-section heading="Labels">
       <dl class="dl-horizontal dl-flex">
         <kubernetes-key-value-details map="instance.metadata.labels">
         </kubernetes-key-value-details>
@@ -201,5 +196,12 @@
         No events.
       </div>
     </collapsible-section>
+  </div>
+  <div class="content" ng-if="!state.loading && !instance">
+    <div class="content-section">
+      <div class="content-body text-center">
+        <h3>Instance not found.</h3>
+      </div>
+    </div>
   </div>
 </div>

--- a/app/scripts/modules/netflix/instance/aws/instanceDetails.html
+++ b/app/scripts/modules/netflix/instance/aws/instanceDetails.html
@@ -1,8 +1,8 @@
-<div class="text-center" ng-if="state.notFound">
+<div class="text-center" ng-if="state.notFoundStandalone">
   <h3>Could not find instance {{instanceId}}.</h3>
   <a ui-sref="home.infrastructure">Back to search results</a>
 </div>
-<div class="details-panel" ng-if="!state.notFound">
+<div class="details-panel" ng-if="!state.notFoundStandalone">
   <div class="header" ng-if="state.loading">
     <div class="close-button" ng-if="!state.standalone">
       <a class="btn btn-link"
@@ -15,7 +15,7 @@
     </h4>
   </div>
 
-  <div class="header" ng-if="!state.loading && !state.notFound">
+  <div class="header" ng-if="!state.loading">
     <div class="close-button" ng-if="!state.standalone">
       <a class="btn btn-link"
          ui-sref="^">
@@ -25,10 +25,11 @@
     <div class="header-text">
       <span class="glyphicon glyphicon-hdd {{instance.healthState}}"></span>
       <h3 select-on-dbl-click>
-        {{instance.instanceId}}
+        {{instance ? instance.instanceId : instanceIdNotFound}}
       </h3>
 
       <copy-to-clipboard
+          ng-if="instance"
           class="copy-to-clipboard"
           text="ssh -t {{ctrl.bastionHost}} 'oq-ssh --region {{instance.region}} {{instance.instanceId}}'"
           tool-tip="Copy SSH command to clipboard">
@@ -64,7 +65,7 @@
       </div>
     </div>
   </div>
-  <div class="content" ng-if="!state.loading">
+  <div class="content" ng-if="!state.loading && instance">
     <collapsible-section heading="Instance Information" expanded="true">
       <dl class="dl-horizontal dl-flex">
         <dt>Launched</dt>
@@ -120,12 +121,7 @@
         </dd>
       </dl>
     </collapsible-section>
-    <div class="content-section" ng-if="instance.notFound">
-      <div class="content-body">
-        <p>Could not find the instance. No other details provided.</p>
-      </div>
-    </div>
-    <collapsible-section heading="DNS" ng-if="!instance.notFound">
+    <collapsible-section heading="DNS">
       <dl class="horizontal-when-filters-collapsed">
         <dt ng-if="instance.privateDnsName">Private DNS Name</dt>
         <dd ng-if="instance.privateDnsName">
@@ -192,7 +188,7 @@
         </dd>
       </dl>
     </collapsible-section>
-    <collapsible-section ng-if="!instance.notFound" heading="Security Groups">
+    <collapsible-section heading="Security Groups">
       <ul>
         <li ng-repeat="securityGroup in instance.securityGroups | orderBy:'groupName'">
           <a ui-sref="^.securityGroupDetails({name:securityGroup.groupName, accountId: instance.account, region: instance.region, vpcId: instance.vpcId, provider: instance.provider})">
@@ -209,5 +205,12 @@
       </ul>
     </collapsible-section>
     <instance-links address="baseIpAddress" application="application" instance="instance"></instance-links>
+  </div>
+  <div class="content" ng-if="!state.loading && !instance">
+    <div class="content-section">
+      <div class="content-body text-center">
+        <h3>Instance not found.</h3>
+      </div>
+    </div>
   </div>
 </div>

--- a/app/scripts/modules/netflix/instance/titus/instanceDetails.html
+++ b/app/scripts/modules/netflix/instance/titus/instanceDetails.html
@@ -18,10 +18,11 @@
     <div class="header-text">
       <span class="glyphicon glyphicon-hdd {{instance.healthState}}"></span>
       <h3 select-on-dbl-click>
-        {{instance.id}}
+        {{instance ? instance.id : instanceIdNotFound}}
       </h3>
 
       <copy-to-clipboard
+        ng-if="instance"
         class="copy-to-clipboard"
         text="ssh -t {{ctrl.bastionHost}} 'titus-ssh {{ctrl.bastionStack}} -region {{instance.region}} -id {{instance.id}}'"
         tool-tip="Copy titus-ssh command to clipboard">
@@ -51,7 +52,7 @@
       </div>
     </div>
   </div>
-  <div class="content" ng-if="!state.loading">
+  <div class="content" ng-if="!state.loading && instance">
     <collapsible-section heading="Titus Task Information" expanded="true">
       <dl class="dl-horizontal dl-flex">
         <dt>Task Id</dt>
@@ -129,16 +130,18 @@
         </li>
       </ul>
     </collapsible-section>
-    <div class="content-section" ng-if="instance.notFound">
-      <div class="content-body">
-        <p>Could not find the instance. No other details provided.</p>
-      </div>
-    </div>
     <collapsible-section heading="Task Logs">
       <ul>
         <li><a href="{{ctrl.titusUiEndpoint}}tasklogs.html?tid={{instance.id}}" target="_blank">Task Logs</a></li>
       </ul>
     </collapsible-section>
     <instance-links address="baseIpAddress" application="application" instance="instance"></instance-links>
+  </div>
+  <div class="content" ng-if="!state.loading && !instance">
+    <div class="content-section">
+      <div class="content-body text-center">
+        <h3>Instance not found.</h3>
+      </div>
+    </div>
   </div>
 </div>

--- a/app/scripts/modules/openstack/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/openstack/instance/details/instance.details.controller.js
@@ -149,7 +149,8 @@ module.exports = angular.module('spinnaker.instance.detail.openstack.controller'
       }
 
       if (!instanceSummary) {
-        autoClose();
+        $scope.instanceIdNotFound = instance.instanceId;
+        $scope.state.loading = false;
       }
 
       return $q.when(null);

--- a/app/scripts/modules/openstack/instance/details/instanceDetails.html
+++ b/app/scripts/modules/openstack/instance/details/instanceDetails.html
@@ -21,7 +21,7 @@
     <div class="header-text">
       <span class="glyphicon glyphicon-hdd {{instance.healthState}}"></span>
       <h3 select-on-dbl-click>
-        {{instance.instanceId}}
+        {{instance ? instance.instanceId : instanceIdNotFound}}
       </h3>
     </div>
     <div>
@@ -50,7 +50,7 @@
       </div>
     </div>
   </div>
-  <div class="content" ng-if="!state.loading">
+  <div class="content" ng-if="!state.loading && instance">
     <collapsible-section heading="Instance Information" expanded="true">
       <dl class="dl-horizontal dl-flex">
         <dt>ID</dt>
@@ -107,12 +107,7 @@
         </dd>
       </dl>
     </collapsible-section>
-    <div class="content-section" ng-if="instance.notFound">
-      <div class="content-body">
-        <p>Could not find the instance. No other details provided.</p>
-      </div>
-    </div>
-    <collapsible-section heading="DNS" ng-if="!instance.notFound">
+    <collapsible-section heading="DNS">
       <dl class="horizontal-when-filters-collapsed">
         <dt ng-if="instance.ipv4">Private IP Address</dt>
         <dd ng-if="instance.ipv4">
@@ -143,7 +138,7 @@
         </dd>
       </dl>
     </collapsible-section>
-    <collapsible-section ng-if="!instance.notFound" heading="Security Groups">
+    <collapsible-section heading="Security Groups">
         <ul>
           <li ng-repeat="securityGroup in instance.securityGroups | orderBy:'groupName'">
             <a ui-sref="^.securityGroupDetails({name:securityGroup.groupName, accountId: instance.account, region: instance.region, vpcId: instance.vpcId, provider: instance.provider})">
@@ -152,7 +147,7 @@
           </li>
         </ul>
     </collapsible-section>
-    <collapsible-section ng-if="!instance.notFound" heading="Metadata">
+    <collapsible-section heading="Metadata">
       <div ng-if=" !instance.metadata">No metadata associated with this server</div>
       <dl ng-if="instance.metadata">
         <dt ng-repeat-start="(key,value) in instance.metadata">{{key}}</dt>
@@ -166,5 +161,12 @@
         </li>
       </ul>
     </collapsible-section>
+  </div>
+  <div class="content" ng-if="!state.loading && !instance">
+    <div class="content-section">
+      <div class="content-body text-center">
+        <h3>Instance not found.</h3>
+      </div>
+    </div>
   </div>
 </div>

--- a/app/scripts/modules/titus/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/titus/instance/details/instance.details.controller.js
@@ -99,7 +99,8 @@ module.exports = angular.module('spinnaker.instance.detail.titus.controller', [
       }
 
       if (!instanceSummary) {
-        autoClose();
+        $scope.instanceIdNotFound = instance.instanceId;
+        $scope.state.loading = false;
       }
       return $q.when(null);
     }


### PR DESCRIPTION
We used to fail silently (confusing) when trying to directly navigate to an instance. This change will keep the instance details panel up, but with a message that the instance could not be found.
<img width="323" alt="screen shot 2017-02-08 at 11 43 15 am" src="https://cloud.githubusercontent.com/assets/56971/22754264/d0734660-edf3-11e6-93ff-a40a7eed8785.png">
