### PR TITLE
(cloudfoundry) Convert to V2ModalWizard

### DIFF
--- a/app/scripts/modules/cloudfoundry/loadBalancer/configure/createLoadBalancer.html
+++ b/app/scripts/modules/cloudfoundry/loadBalancer/configure/createLoadBalancer.html
@@ -1,5 +1,5 @@
-<modal-wizard heading="Create New Load Balancer">
-  <wizard-page key="Location" label="Location">
+<v2-modal-wizard heading="Create New Load Balancer">
+  <v2-wizard-page key="Location" label="Location">
     <ng-include src="pages.location"></ng-include>
-  </wizard-page>
-</modal-wizard>
+  </v2-wizard-page>
+</v2-modal-wizard>


### PR DESCRIPTION
The original modal wizard directives are being killed.  These files were converted to the V2ModalWizard.

@gregturn 
Please test and merge this PR as soon as you can.