### PR TITLE
(all providers) Stop using local cache for checking name collisions when creating a load balancer

### DIFF
--- a/app/scripts/modules/amazon/loadBalancer/configure/createLoadBalancer.controller.spec.js
+++ b/app/scripts/modules/amazon/loadBalancer/configure/createLoadBalancer.controller.spec.js
@@ -1,23 +1,27 @@
 'use strict';
 
+import {APPLICATION_MODEL_BUILDER} from 'core/application/applicationModel.builder';
+
 describe('Controller: awsCreateLoadBalancerCtrl', function () {
 
   // load the controller's module
   beforeEach(
     window.module(
-      require('./createLoadBalancer.controller')
+      require('./createLoadBalancer.controller'),
+      APPLICATION_MODEL_BUILDER
     )
   );
 
   // Initialize the controller and a mock scope
-  beforeEach(window.inject(function ($controller, $rootScope) {
+  beforeEach(window.inject(function ($controller, $rootScope, applicationModelBuilder) {
     this.settings = {};
     this.$scope = $rootScope.$new();
+    const app = applicationModelBuilder.createApplication({key: 'loadBalancers', lazy: true});
     this.initialize = () => {
       this.ctrl = $controller('awsCreateLoadBalancerCtrl', {
         $scope: this.$scope,
         $uibModalInstance: {dismiss: angular.noop, result: {then: angular.noop}},
-        application: {name: 'app', defaultCredentials: {}, defaultRegions: {}},
+        application: app,
         loadBalancer: null,
         isNew: true,
         forPipelineConfig: false,

--- a/app/scripts/modules/azure/loadBalancer/configure/createLoadBalancer.controller.spec.js
+++ b/app/scripts/modules/azure/loadBalancer/configure/createLoadBalancer.controller.spec.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import {API_SERVICE} from 'core/api/api.service';
+import {APPLICATION_MODEL_BUILDER} from 'core/application/applicationModel.builder';
 
 describe('Controller: azureCreateLoadBalancerCtrl', function () {
 
@@ -11,18 +12,20 @@ describe('Controller: azureCreateLoadBalancerCtrl', function () {
   beforeEach(
     window.module(
       require('./createLoadBalancer.controller'),
-      API_SERVICE
+      API_SERVICE,
+      APPLICATION_MODEL_BUILDER
     )
   );
 
   // Initialize the controller and a mock scope
-  beforeEach(window.inject(function ($controller, $rootScope, _API_) {
+  beforeEach(window.inject(function ($controller, $rootScope, _API_, applicationModelBuilder) {
     API = _API_;
+    const app = applicationModelBuilder.createApplication({key: 'loadBalancers', lazy: true});
     this.$scope = $rootScope.$new();
     this.ctrl = $controller('azureCreateLoadBalancerCtrl', {
       $scope: this.$scope,
       $uibModalInstance: { dismiss: angular.noop, result: { then: angular.noop } },
-      application: {name: 'app'},
+      application: app,
       loadBalancer: null,
       isNew: true
     });
@@ -47,13 +50,11 @@ describe('Controller: azureCreateLoadBalancerCtrl', function () {
 
   it('makes the expected REST calls for data for a new loadbalancer', function() {
     $http.when('GET', API.baseUrl + '/networks').respond([]);
-    $http.when('GET', API.baseUrl + '/loadBalancers?provider=azure').respond([]);
     $http.when('GET', API.baseUrl + '/securityGroups').respond({});
     $http.when('GET', API.baseUrl + '/credentials').respond([]);
     $http.when('GET', API.baseUrl + '/credentials/azure-test').respond([]);
     $http.when('GET', API.baseUrl + '/subnets').respond([]);
 
-    $http.expectGET(API.baseUrl + '/loadBalancers?provider=azure');
     $http.flush();
   });
 

--- a/app/scripts/modules/azure/loadBalancer/loadBalancer.transformer.js
+++ b/app/scripts/modules/azure/loadBalancer/loadBalancer.transformer.js
@@ -60,7 +60,7 @@ module.exports = angular.module('spinnaker.azure.loadBalancer.transformer', [
     }
 
     function constructNewLoadBalancerTemplate(application) {
-      var defaultCredentials = application.defaultCredentials || settings.providers.azure.defaults.account,
+      var defaultCredentials = application.defaultCredentials.azure || settings.providers.azure.defaults.account,
           defaultRegion = application.defaultRegion || settings.providers.azure.defaults.region;
       return {
         stack: '',

--- a/app/scripts/modules/cloudfoundry/loadBalancer/configure/CreateLoadBalancerCtrl.spec.js
+++ b/app/scripts/modules/cloudfoundry/loadBalancer/configure/CreateLoadBalancerCtrl.spec.js
@@ -1,5 +1,6 @@
 'use strict';
 
+import {APPLICATION_MODEL_BUILDER} from 'core/application/applicationModel.builder';
 
 describe('Controller: cfCreateLoadBalancerCtrl', function () {
 
@@ -8,17 +9,19 @@ describe('Controller: cfCreateLoadBalancerCtrl', function () {
   // load the controller's module
   beforeEach(function() {
       window.module(
-        require('./CreateLoadBalancerCtrl.js')
+        require('./CreateLoadBalancerCtrl.js'),
+        APPLICATION_MODEL_BUILDER
       );
     });
 
   // Initialize the controller and a mock scope
-  beforeEach(window.inject(function ($controller, $rootScope, _modalWizardService_) {
+  beforeEach(window.inject(function ($controller, $rootScope, _modalWizardService_, applicationModelBuilder) {
     this.$scope = $rootScope.$new();
+    const app = applicationModelBuilder.createApplication({key: 'loadBalancers', lazy: true});
     this.ctrl = $controller('cfCreateLoadBalancerCtrl', {
       $scope: this.$scope,
       $uibModalInstance: { dismiss: angular.noop, result: { then: angular.noop } },
-      application: {name: 'testApp'},
+      application: app,
       loadBalancer: null,
       isNew: true
     });
@@ -31,11 +34,11 @@ describe('Controller: cfCreateLoadBalancerCtrl', function () {
     expect(lb.name).toBeUndefined();
 
     this.ctrl.updateName();
-    expect(lb.name).toBe('testApp');
+    expect(lb.name).toBe('app');
 
     this.$scope.loadBalancer.stack = 'testStack';
     this.ctrl.updateName();
-    expect(lb.name).toBe('testApp-testStack');
+    expect(lb.name).toBe('app-testStack');
   });
 
 });

--- a/app/scripts/modules/google/loadBalancer/configure/network/createLoadBalancer.controller.spec.js
+++ b/app/scripts/modules/google/loadBalancer/configure/network/createLoadBalancer.controller.spec.js
@@ -1,5 +1,6 @@
 'use strict';
 
+import {APPLICATION_MODEL_BUILDER} from 'core/application/applicationModel.builder';
 
 describe('Controller: gceCreateLoadBalancerCtrl', function () {
 
@@ -8,17 +9,19 @@ describe('Controller: gceCreateLoadBalancerCtrl', function () {
   // load the controller's module
   beforeEach(function() {
       window.module(
-        require('./createLoadBalancer.controller.js')
+        require('./createLoadBalancer.controller.js'),
+        APPLICATION_MODEL_BUILDER
       );
     });
 
   // Initialize the controller and a mock scope
-  beforeEach(window.inject(function ($controller, $rootScope, _v2modalWizardService_) {
+  beforeEach(window.inject(function ($controller, $rootScope, _v2modalWizardService_, applicationModelBuilder) {
     this.$scope = $rootScope.$new();
+    const app = applicationModelBuilder.createApplication({key: 'loadBalancers', lazy: true});
     this.ctrl = $controller('gceCreateLoadBalancerCtrl', {
       $scope: this.$scope,
       $uibModalInstance: { dismiss: angular.noop, result: { then: angular.noop } },
-      application: {name: 'testApp'},
+      application: app,
       loadBalancer: null,
       isNew: true
     });
@@ -51,11 +54,11 @@ describe('Controller: gceCreateLoadBalancerCtrl', function () {
     expect(lb.name).toBeUndefined();
 
     this.ctrl.updateName();
-    expect(lb.name).toBe('testApp');
+    expect(lb.name).toBe('app');
 
     this.$scope.loadBalancer.stack = 'testStack';
     this.ctrl.updateName();
-    expect(lb.name).toBe('testApp-testStack');
+    expect(lb.name).toBe('app-testStack');
   });
 
   it('should make the health check tab invisible then visible again', function() {


### PR DESCRIPTION
When creating a load balancer, it would populate the list of load balancers from a local cache that could be out of date.

This change:
* will always refresh the list of load balancers before creating a new one.
* will only compare against application level load balancers. Since we enforce uniqueness of application names and enforce load balancers name start with the application name, no need to compare against the entire list.