### PR TITLE
(core) allow users to configure traffic protected clusters

### DIFF
--- a/app/scripts/modules/core/application/config/applicationConfig.controller.js
+++ b/app/scripts/modules/core/application/config/applicationConfig.controller.js
@@ -1,5 +1,6 @@
 import {APPLICATION_DATA_SOURCE_EDITOR} from './dataSources/applicationDataSourceEditor.component';
 import {CHAOS_MONKEY_CONFIG_COMPONENT} from 'core/chaosMonkey/chaosMonkeyConfig.component';
+import {TRAFFIC_GUARD_CONFIG_COMPONENT} from './trafficGuard/trafficGuardConfig.component';
 
 let angular = require('angular');
 
@@ -13,6 +14,7 @@ module.exports = angular
     require('./applicationSnapshotSection.component.js'),
     APPLICATION_DATA_SOURCE_EDITOR,
     CHAOS_MONKEY_CONFIG_COMPONENT,
+    TRAFFIC_GUARD_CONFIG_COMPONENT,
     require('./links/applicationLinks.component.js'),
     require('../../config/settings.js')
   ])

--- a/app/scripts/modules/core/application/config/applicationConfig.view.html
+++ b/app/scripts/modules/core/application/config/applicationConfig.view.html
@@ -18,6 +18,9 @@
     <v2-wizard-page key="chaos" label="Chaos Monkey" done="true" ng-if="config.feature.chaosMonkey">
       <chaos-monkey-config application="config.application"></chaos-monkey-config>
     </v2-wizard-page>
+    <v2-wizard-page key="traffic-guards" label="Traffic Guards" done="true">
+      <traffic-guard-config application="config.application"></traffic-guard-config>
+    </v2-wizard-page>
     <v2-wizard-page key="snapshot" label="Serialize Application" done="true" ng-if="config.feature.snapshots">
       <application-snapshot-section application="config.application"></application-snapshot-section>
     </v2-wizard-page>

--- a/app/scripts/modules/core/application/config/trafficGuard/trafficGuardConfig.component.html
+++ b/app/scripts/modules/core/application/config/trafficGuard/trafficGuardConfig.component.html
@@ -1,0 +1,71 @@
+<div class="panel panel-default">
+  <div class="panel-body form-inline">
+    <div class="row">
+      <div class="col-md-12">
+        <p>Traffic Guards allow you to specify critical clusters that should always have active instances. If a user
+          or process tries to delete, disable, or resize the server group, Spinnaker will verify the operation will not
+          leave the cluster with no active instances, and fail the operation if it would.</p>
+      </div>
+    </div>
+    <div class="row" ng-if="$ctrl.initializing">
+      <h4 class="text-center"><span class="glyphicon glyphicon-asterisk glyphicon-spinning"></span></h4>
+    </div>
+    <div class="row" ng-if="!$ctrl.initializing">
+      <div class="col-md-10 col-md-offset-1">
+        <table class="table table-condensed">
+          <thead>
+            <tr>
+              <th>Account</th>
+              <th>Region <help-field key="trafficGuard.region"></help-field></th>
+              <th>Stack <help-field key="trafficGuard.stack"></help-field></th>
+              <th>Detail <help-field key="trafficGuard.detail"></help-field></th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+          <tr ng-repeat="guard in $ctrl.config">
+            <td>
+              <account-select-field
+                component="guard"
+                field="account"
+                provider="'aws'"
+                accounts="$ctrl.accounts"
+                on-change="$ctrl.configChanged()"></account-select-field>
+            </td>
+            <td>
+              <span ng-if="!guard.account">(select account)</span>
+              <select class="form-control input-sm"
+                      ng-model="guard.location"
+                      ng-change="$ctrl.configChanged()"
+                      ng-if="guard.account">
+                <option ng-repeat="region in $ctrl.regionsByAccount[guard.account]" value="{{region}}">{{region}}</option>
+              </select>
+            </td>
+            <td>
+              <input type="text" class="form-control input-sm"
+                     ng-model="guard.stack"
+                     ng-change="$ctrl.configChanged()"
+                     required/>
+            </td>
+            <td>
+              <input type="text" class="form-control input-sm"
+                     ng-model="guard.detail"
+                     ng-change="$ctrl.configChanged()"
+                     required/>
+            </td>
+            <td><a href ng-click="$ctrl.removeGuard($index)"><span class="glyphicon glyphicon-trash" uib-tooltip="Remove guard"></span></a></td>
+          </tr>
+          </tbody>
+        </table>
+        <button class="btn btn-block btn-add-trigger add-new" ng-click="$ctrl.addGuard()">
+          <span class="glyphicon glyphicon-plus-sign"></span> Add Traffic Guard
+        </button>
+      </div>
+    </div>
+    <div class="row">
+      <config-section-footer application="$ctrl.application"
+                             config="$ctrl.config"
+                             view-state="$ctrl.viewState"
+                             config-field="trafficGuards"></config-section-footer>
+    </div>
+  </div>

--- a/app/scripts/modules/core/application/config/trafficGuard/trafficGuardConfig.component.ts
+++ b/app/scripts/modules/core/application/config/trafficGuard/trafficGuardConfig.component.ts
@@ -1,0 +1,87 @@
+import {module, toJson} from 'angular';
+import {cloneDeep} from 'lodash';
+
+import {
+  ACCOUNT_SERVICE, AccountService, IAccountDetails, IRegion,
+  IAggregatedAccounts
+} from 'core/account/account.service';
+import {Application} from 'core/application/application.model';
+import {IViewState} from '../footer/configSectionFooter.component';
+import {TRAFFIC_GUARD_CONFIG_HELP} from './trafficGuardConfig.help';
+
+interface ITrafficGuard {
+  account: string;
+  location: string;
+  stack: string;
+  detail: string;
+}
+
+export class TrafficGuardConfigController {
+
+  public application: Application;
+  public accounts: IAccountDetails[] = [];
+  public regionsByAccount: { [account: string]: string[] };
+  public config: ITrafficGuard[];
+  public initializing: boolean = true;
+
+  public viewState: IViewState = {
+    originalConfig: null,
+    originalStringVal: null,
+    saving: false,
+    saveError: false,
+    isDirty: false,
+  };
+
+  static get $inject() { return ['accountService']; }
+
+  public constructor(private accountService: AccountService) {}
+
+  public $onInit(): void {
+    if (this.application.notFound) {
+      return;
+    }
+    this.config = this.application.attributes.trafficGuards || [];
+    this.viewState.originalConfig = cloneDeep(this.config);
+    this.viewState.originalStringVal = toJson(this.viewState.originalConfig);
+
+    this.accountService.getCredentialsKeyedByAccount().then((aggregated: IAggregatedAccounts) => {
+      this.accounts = Object.keys(aggregated)
+        .map((name: string) => aggregated[name])
+        .filter((details: IAccountDetails) => details.regions);
+      this.regionsByAccount = {};
+      this.accounts.forEach((details: IAccountDetails) => {
+        this.regionsByAccount[details.name] = ['*'].concat(details.regions.map((region: IRegion) => region.name));
+      });
+      this.initializing = false;
+    });
+  }
+
+  public addGuard(): void {
+    this.config.push({ account: null, location: null, stack: null, detail: null });
+    this.configChanged();
+  };
+
+  public removeGuard(index: number): void {
+    this.config.splice(index, 1);
+    this.configChanged();
+  };
+
+  public configChanged(): void {
+    this.viewState.isDirty = this.viewState.originalStringVal !== toJson(this.config);
+  }
+}
+
+class TrafficGuardConfigComponent implements ng.IComponentOptions {
+  public bindings: any = {
+    application: '=',
+  };
+  public controller: any = TrafficGuardConfigController;
+  public templateUrl: string = require('./trafficGuardConfig.component.html');
+}
+
+export const TRAFFIC_GUARD_CONFIG_COMPONENT = 'spinnaker.core.application.config.trafficGuard.component';
+module(TRAFFIC_GUARD_CONFIG_COMPONENT, [
+  ACCOUNT_SERVICE,
+  TRAFFIC_GUARD_CONFIG_HELP,
+])
+  .component('trafficGuardConfig', new TrafficGuardConfigComponent());

--- a/app/scripts/modules/core/application/config/trafficGuard/trafficGuardConfig.help.ts
+++ b/app/scripts/modules/core/application/config/trafficGuard/trafficGuardConfig.help.ts
@@ -1,0 +1,25 @@
+import {module} from 'angular';
+import {HELP_CONTENTS_REGISTRY, HelpContentsRegistry} from 'core/help/helpContents.registry';
+
+const helpContents: any[] = [
+  {
+    key: 'trafficGuard.region',
+    contents: '<p>Required; you can select the wildcard (*) to include all regions.</p>'
+  },
+  {
+    key: 'trafficGuard.stack',
+    contents: `<p>Optional; you can use the wildcard (*) to include all stacks (including no stack). 
+               To apply the guard <em>only</em> to a cluster without a stack, leave this field blank.</p>`
+  },
+  {
+    key: 'trafficGuard.detail',
+    contents: `<p>Optional; you can use the wildcard (*) to include all stacks (including no detail). 
+               To apply the guard <em>only</em> to a cluster without a detail, leave this field blank.</p>`
+  },
+];
+
+export const TRAFFIC_GUARD_CONFIG_HELP = 'spinnaker.core.application.config.trafficGuard.help.contents';
+module(TRAFFIC_GUARD_CONFIG_HELP, [HELP_CONTENTS_REGISTRY])
+  .run((helpContentsRegistry: HelpContentsRegistry) => {
+    helpContents.forEach((entry: any) => helpContentsRegistry.register(entry.key, entry.contents));
+  });

--- a/app/scripts/modules/netflix/application/applicationConfig.html
+++ b/app/scripts/modules/netflix/application/applicationConfig.html
@@ -21,6 +21,9 @@
     <v2-wizard-page key="chaos" label="Chaos Monkey" done="true">
       <chaos-monkey-config application="config.application"></chaos-monkey-config>
     </v2-wizard-page>
+    <v2-wizard-page key="traffic-guards" label="Traffic Guards" done="true">
+      <traffic-guard-config application="config.application"></traffic-guard-config>
+    </v2-wizard-page>
     <v2-wizard-page key="delete" label="Delete Application" done="true">
       <delete-application-section application="config.application"></delete-application-section>
     </v2-wizard-page>


### PR DESCRIPTION
Companion PR to https://github.com/spinnaker/orca/pull/1178; allows users to declare certain clusters as protected or critical or...basically, clusters that should never be empty, or only have disabled server groups.

I'm mostly looking for feedback on the wording and look-and-feel...
<img width="1008" alt="screen shot 2017-02-12 at 7 51 55 pm" src="https://cloud.githubusercontent.com/assets/73450/22870676/57cf528a-f15e-11e6-9e76-c2534a0ac7b7.png">
