### PR TITLE
(k8s) adds support for kuberntes config map as volume source

### DIFF
--- a/app/scripts/modules/core/help/helpContents.js
+++ b/app/scripts/modules/core/help/helpContents.js
@@ -424,6 +424,7 @@ module.exports = angular.module('spinnaker.core.help.contents', [])
     'kubernetes.service.externalIps': 'IP addresses for which nodes in the cluster also accept traffic. This is not managed by Kubernetes and the ' +
     'responsibility of the user to configure.',
     'kubernetes.pod.volume': '<p>A storage volume to be mounted and shared by containers in this pod. The lifecycle depends on the volume type selected.</p>' +
+    '<p><b>CONFIGMAP</b>: Intended to act as a reference to multiple properties files. Similar to the /etc directory, and the files within, on a Linux computer.</p>' +
     '<p><b>EMPTYDIR</b>: A transient volume tied to the lifecycle of this pod.</p>' +
     '<p><b>HOSTPATH</b>: A directory on the host node. Most pods do not need this.</p>' +
     '<p><b>PERSISTENTVOLUMECLAIM</b>: An already created persistent volume claim to be bound by this pod.</p>' +

--- a/app/scripts/modules/kubernetes/container/volumes.component.html
+++ b/app/scripts/modules/kubernetes/container/volumes.component.html
@@ -1,5 +1,5 @@
 <table class="table table-condensed packed tags" style="border-top: 2px solid white;">
-  <tr ng-repeat="source in $ctrl.volumeSources track by $index">
+  <tr ng-repeat="source in $ctrl.volumeSources track by $index" ng-init="sourceIndex = $index">
     <td>
       <div class="form-group">
         <div class="col-md-4 sm-label-right">
@@ -16,6 +16,49 @@
           <button class="btn btn-sm btn-default" ng-click="$ctrl.removeVolume($index)">
             <span class="glyphicon glyphicon-trash visible-lg-inline"></span>
             <span class="visible-lg-inline">Remove</span>
+          </button>
+        </div>
+      </div>
+      <div class="form-group" ng-show="source.type === 'CONFIGMAP'">
+        <div class="col-md-4 sm-label-right">
+          Config Map Name
+        </div>
+        <div class="col-md-4">
+          <input type="text" class="form-control input-sm" name="path" ng-model="source.configMap.configMapName"/>
+        </div>
+      </div>
+      <div class="form-group" ng-show="source.type === 'CONFIGMAP'">
+        <div class="col-md-4 sm-label-right" style="padding-top: 2px;">
+          Items
+          <help-field key="kubernetes.pod.volume.configMap.items"></help-field>
+        </div>
+        <div class="col-md-8">
+          <table class="table table-condensed packed tags" style="border-top: 2px solid white">
+            <thead>
+            <tr>
+              <th>Key</th>
+              <th>Path</th>
+              <th></th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr ng-repeat="item in source.configMap.items track by $index" ng-init="itemIndex = $index">
+              <td>
+                <input class="form-control input-sm" type="text" ng-model="item.key">
+              </td>
+              <td>
+                <input class="form-control input-sm" ng-pattern="$ctrl.relativePathPattern" type="text" ng-model="item.path">
+              </td>
+              <td class="table-remove-button">
+                <a class="btn btn-link sm-label" style="margin-top: 0;" ng-click="$ctrl.removeItem(sourceIndex, itemIndex)">
+                  <span class="glyphicon glyphicon-trash"></span>
+                </a>
+              </td>
+            </tr>
+            </tbody>
+          </table>
+          <button class="add-new col-md-12" ng-click="$ctrl.addItem(sourceIndex)">
+            <span class="glyphicon glyphicon-plus-sign"></span> Add item
           </button>
         </div>
       </div>

--- a/app/scripts/modules/kubernetes/container/volumes.component.js
+++ b/app/scripts/modules/kubernetes/container/volumes.component.js
@@ -16,9 +16,10 @@ module.exports = angular.module('spinnaker.deck.kubernetes.volumes.component', [
         }
       });
 
-      this.volumeTypes = ['EMPTYDIR', 'HOSTPATH', 'PERSISTENTVOLUMECLAIM', 'SECRET'];
+      this.volumeTypes = ['CONFIGMAP', 'EMPTYDIR', 'HOSTPATH', 'PERSISTENTVOLUMECLAIM', 'SECRET'];
       this.mediumTypes = ['DEFAULT', 'MEMORY'];
       this.pathPattern = '^/.*$';
+      this.relativePathPattern = '^[^/].*';
 
       this.defaultHostPath = () => {
         return {
@@ -45,6 +46,28 @@ module.exports = angular.module('spinnaker.deck.kubernetes.volumes.component', [
         };
       };
 
+      this.defaultConfigMap = () => {
+        return {
+          configMapName: '',
+          items: [this.defaultItem()],
+        };
+      };
+
+      this.defaultItem = () => {
+        return {
+          key: '',
+          path: '',
+        };
+      };
+
+      this.addItem = (sourceIndex) => {
+        this.volumeSources[sourceIndex].configMap.items.push(this.defaultItem());
+      };
+
+      this.removeItem = (sourceIndex, itemIndex) => {
+        this.volumeSources[sourceIndex].configMap.items.splice(itemIndex, 1);
+      };
+
       this.defaultVolumeSource = (name = '') => {
         return {
           type: this.volumeTypes[0],
@@ -53,6 +76,7 @@ module.exports = angular.module('spinnaker.deck.kubernetes.volumes.component', [
           emptyDir: this.defaultEmptyDir(),
           defaultPersistentVolumeClaim: this.defaultPersistentVolumeClaim(),
           secret: this.defaultSecret(),
+          configMap: this.defaultConfigMap(),
         };
       };
 
@@ -88,6 +112,10 @@ module.exports = angular.module('spinnaker.deck.kubernetes.volumes.component', [
 
           if (!source.secret) {
             source.secret = this.defaultSecret();
+          }
+
+          if (!source.configMap) {
+            source.configMap = this.defaultConfigMap();
           }
 
           return source;

--- a/app/scripts/modules/kubernetes/serverGroup/configure/wizard/volumes.controller.js
+++ b/app/scripts/modules/kubernetes/serverGroup/configure/wizard/volumes.controller.js
@@ -5,9 +5,10 @@ let angular = require('angular');
 module.exports = angular.module('spinnaker.serverGroup.configure.kubernetes.volumes', [
 ])
   .controller('kubernetesServerGroupVolumesController', function($scope) {
-    this.volumeTypes = ['EMPTYDIR', 'HOSTPATH', 'PERSISTENTVOLUMECLAIM', 'SECRET'];
+    this.volumeTypes = ['CONFIGMAP', 'EMPTYDIR', 'HOSTPATH', 'PERSISTENTVOLUMECLAIM', 'SECRET'];
     this.mediumTypes = ['DEFAULT', 'MEMORY'];
     this.pathPattern = '^/.*$';
+    this.relativePathPattern = '^[^/].*';
 
     this.defaultHostPath = function() {
       return {
@@ -34,6 +35,28 @@ module.exports = angular.module('spinnaker.serverGroup.configure.kubernetes.volu
       };
     };
 
+    this.defaultConfigMap = function() {
+      return {
+        configMapName: '',
+        items: [this.defaultItem()],
+      };
+    };
+
+    this.defaultItem = function() {
+      return {
+        key: '',
+        path: '',
+      };
+    };
+
+    this.addItem = function(sourceIndex) {
+      $scope.command.volumeSources[sourceIndex].configMap.items.push(this.defaultItem());
+    };
+
+    this.removeItem = function(sourceIndex, itemIndex) {
+      $scope.command.volumeSources[sourceIndex].configMap.items.splice(itemIndex, 1);
+    };
+
     this.defaultVolume = function() {
       return {
         type: this.volumeTypes[0],
@@ -42,6 +65,7 @@ module.exports = angular.module('spinnaker.serverGroup.configure.kubernetes.volu
         emptyDir: this.defaultEmptyDir(),
         defaultPersistentVolumeClaim: this.defaultPersistentVolumeClaim(),
         secret: this.defaultSecret(),
+        configMap: this.defaultConfigMap(),
       };
     };
 
@@ -70,6 +94,10 @@ module.exports = angular.module('spinnaker.serverGroup.configure.kubernetes.volu
 
         if (!source.secret) {
           source.secret = this.defaultSecret();
+        }
+
+        if (!source.configMap) {
+          source.configMap = this.defaultConfigMap();
         }
 
         return source;

--- a/app/scripts/modules/kubernetes/serverGroup/configure/wizard/volumes.html
+++ b/app/scripts/modules/kubernetes/serverGroup/configure/wizard/volumes.html
@@ -1,5 +1,5 @@
 <div class="form-group container-fluid form-horizontal" ng-controller="kubernetesServerGroupVolumesController as volumesController">
-  <div ng-repeat="source in command.volumeSources">
+  <div ng-repeat="source in command.volumeSources" ng-init="sourceIndex = $index">
     <div class="form-group">
       <div class="col-md-3 sm-label-right">
         Volume Source
@@ -24,6 +24,49 @@
       </div>
       <div class="col-md-4">
         <input type="text" class="form-control input-sm" name="path" ng-model="source.name"/>
+      </div>
+    </div>
+    <div class="form-group" ng-show="source.type === 'CONFIGMAP'">
+      <div class="col-md-3 sm-label-right">
+        Config Map Name
+      </div>
+      <div class="col-md-4">
+        <input type="text" class="form-control input-sm" name="path" ng-model="source.configMap.configMapName"/>
+      </div>
+    </div>
+    <div class="form-group" ng-show="source.type === 'CONFIGMAP'">
+      <div class="col-md-3 sm-label-right">
+        Items
+        <help-field key="kubernetes.pod.volume.configMap.items"></help-field>
+      </div>
+      <div class="col-md-8">
+        <table class="table table-condensed packed tags">
+          <thead>
+            <tr>
+              <th>Key</th>
+              <th>Path</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+          <tr ng-repeat="item in source.configMap.items track by $index" ng-init="itemIndex = $index">
+            <td>
+              <input class="form-control input-sm" type="text" ng-model="item.key">
+            </td>
+            <td>
+              <input class="form-control input-sm" type="text" ng-pattern="volumesController.relativePathPattern" ng-model="item.path">
+            </td>
+            <td class="table-remove-button">
+              <a class="btn btn-link sm-label" style="margin-top: 0;" ng-click="volumesController.removeItem(sourceIndex, itemIndex)">
+                <span class="glyphicon glyphicon-trash"></span>
+              </a>
+            </td>
+          </tr>
+          </tbody>
+        </table>
+        <button class="add-new col-md-12" ng-click="volumesController.addItem(sourceIndex)">
+          <span class="glyphicon glyphicon-plus-sign"></span> Add item
+        </button>
       </div>
     </div>
     <div class="form-group" ng-show="source.type === 'EMPTYDIR'">


### PR DESCRIPTION
@lwander please review.

Closes https://github.com/spinnaker/spinnaker/issues/1215

I would like to find a better way to handle the overlap between the Run Job stage config and the Deploy config, but it isn't obvious how to do so since there are a bunch of slight differences (especially in the templates)
![configmap](https://cloud.githubusercontent.com/assets/13868700/22896667/f9c3ea0c-f1ee-11e6-9afc-bd05ca3c8062.png)
.