### PR TITLE
(core) instance details list word break

### DIFF
--- a/app/scripts/modules/appengine/instance/details/details.controller.ts
+++ b/app/scripts/modules/appengine/instance/details/details.controller.ts
@@ -26,7 +26,7 @@ class AppengineInstanceDetailsController {
     An App Engine instance is 'Out Of Service' if no load balancers are directing traffic to its server group.`;
 
   static get $inject() {
-    return ['$scope', '$state', '$q', 'app', 'instanceReader', 'instanceWriter', 'confirmationModalService', 'instance'];
+    return ['$q', 'app', 'instanceReader', 'instanceWriter', 'confirmationModalService', 'instance'];
   }
 
   constructor(private $q: IQService,

--- a/app/scripts/modules/core/cluster/rollups.less
+++ b/app/scripts/modules/core/cluster/rollups.less
@@ -79,6 +79,13 @@ server-group {
 @instance-width: 12px;
 @instance-height: 18px;
 
+table.instances {
+  table-layout: fixed;
+  td {
+    word-break: break-all;
+  }
+}
+
 .instances {
   border: none;
   line-height: 10px;


### PR DESCRIPTION
@icfantv or @anotherchrisberry please review. Not sure if this will render properly for AWS.

Before:
![oldinstancedetails](https://cloud.githubusercontent.com/assets/13868700/22898458/62e159c4-f1f5-11e6-9ed2-bfe8f11609dd.png)

After:
![instance_details](https://cloud.githubusercontent.com/assets/13868700/22898426/462e70aa-f1f5-11e6-882f-89aa4d527177.png)
