### PR TITLE
(netflix) Add back Fast Property key/value search.

### DIFF
--- a/app/scripts/modules/netflix/fastProperties/view/fastProperties.controller.js
+++ b/app/scripts/modules/netflix/fastProperties/view/fastProperties.controller.js
@@ -16,7 +16,7 @@ module.exports = angular
   .controller('FastPropertiesController', function ($scope, $filter, $state, $urlRouter, $stateParams, $location, $uibModal, settings, app, fastPropertyReader) {
 
     let vm = this;
-    let filterNames = ['app','env', 'region', 'stack', 'cluster'];
+    let filterNames = ['key', 'value', 'app','env', 'region', 'stack', 'cluster'];
 
     vm.application = app;
 
@@ -145,17 +145,19 @@ module.exports = angular
       });
     };
 
-    let scopeFilterPredicateFactory = (scopeLabel) => {
+    let filterPredicateFactory = (filterLabel) => {
       return (property) => {
         let scopeAttrList = $scope.filters.list
-          .filter((filter) => filter.label === scopeLabel)
+          .filter((filter) => filter.label === filterLabel)
           .map((filter) => filter.value);
-        return scopeAttrList.length ? normalizeForNone(scopeAttrList).includes(property.scope[scopeLabel]) : true;
+
+        let item = property.scope[filterLabel] || property[filterLabel];
+        return (scopeAttrList.length && item) ? normalizeForNone(scopeAttrList).includes(item) : true;
       };
     };
 
 
-    let predicateList = filterNames.map(name => scopeFilterPredicateFactory(name));
+    let predicateList = filterNames.map(name => filterPredicateFactory(name));
 
     let filters = {
       showall: (propertiesList) => {
@@ -215,6 +217,7 @@ module.exports = angular
       $location.search('q', vm.searchTerm);
 
       if(vm.searchTerm.length) {
+        vm.clearFilters();
         vm.fetchingProperties = true;
         vm.propertiesList = undefined;
         vm.searchError = undefined;

--- a/app/scripts/modules/netflix/fastProperties/view/fastPropertyFilterSearch.component.ts
+++ b/app/scripts/modules/netflix/fastProperties/view/fastPropertyFilterSearch.component.ts
@@ -3,6 +3,8 @@ import {module} from 'angular';
 
 interface IFastProperty {
   scope: IFastPropertyScope;
+  key: string;
+  value: string;
 }
 
 interface IFastPropertyScope {
@@ -78,6 +80,7 @@ class FastPropertyFilterSearchController implements ng.IComponentController {
     this.filters.list = uniqWith(copy, (a: any, b: any) => a.label === b.label && a.value === b.value);
     this.$element.find('input').val('');
     this.showSearchResults = false;
+    this.query = null;
   }
 
 
@@ -170,6 +173,8 @@ class FastPropertyFilterSearchController implements ng.IComponentController {
   private createFilterCategories(properties: IFastProperty[]) {
     this.categories = properties.reduce((acc: any, property: IFastProperty) => {
       let scope: IFastPropertyScope = property.scope;
+      acc = this.addToList(acc, 'key', property.key );
+      acc = this.addToList(acc, 'value', property.value);
       acc = this.addToList(acc, 'app', scope.app );
       acc = this.addToList(acc, 'env', scope.env );
       acc = this.addToList(acc, 'region', scope.region );
@@ -177,7 +182,6 @@ class FastPropertyFilterSearchController implements ng.IComponentController {
       acc = this.addToList(acc, 'cluster', scope.cluster);
       return acc;
     }, []);
-
   }
 
   private addToList(acc: any[], scopeKey: string, scopeValue: string): any {


### PR DESCRIPTION
Searching for property keys was prominant in the old UI and got forgotten in the new.

This adds it back via the filter mechinism.

It also cleans up the filter tags when a new search is done on the global view.

@anotherchrisberry @icfantv PTAL