### PR TITLE
(various): update bake stage adv opts visibility

### DIFF
--- a/app/scripts/modules/amazon/pipeline/stages/bake/awsBakeStage.js
+++ b/app/scripts/modules/amazon/pipeline/stages/bake/awsBakeStage.js
@@ -87,6 +87,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.aws.bakeStage', [
           $scope.stage.baseLabel = $scope.baseLabelOptions[0];
         }
         $scope.viewState.roscoMode = settings.feature.roscoMode;
+        $scope.showAdvancedOptions = showAdvanced();
         $scope.viewState.loading = false;
       });
     }
@@ -97,6 +98,12 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.aws.bakeStage', [
           delete $scope.stage[key];
         }
       });
+    }
+
+    function showAdvanced() {
+      const stg = $scope.stage;
+      return !!(stg.templateFileName || (stg.extendedAttributes && _.size(stg.extendedAttributes) > 0) ||
+        stg.varFileName || stg.baseName || stg.baseAmi || stg.amiName || stg.amiSuffix || stg.enhancedNetworking);
     }
 
     this.addExtendedAttribute = function() {

--- a/app/scripts/modules/amazon/pipeline/stages/bake/bakeStage.html
+++ b/app/scripts/modules/amazon/pipeline/stages/bake/bakeStage.html
@@ -59,13 +59,13 @@
       <div class="col-md-9 col-md-offset-1">
         <div class="checkbox">
           <label>
-            <input type="checkbox" ng-model="stage.showAdvancedOptions">
+            <input type="checkbox" ng-model="showAdvancedOptions">
             <strong>Show Advanced Options</strong>
           </label>
         </div>
       </div>
     </div>
-    <div ng-class="{collapse: stage.showAdvancedOptions !== true, 'collapse.in': stage.showAdvancedOptions === true}">
+    <div ng-class="{collapse: showAdvancedOptions !== true, 'collapse.in': !showAdvancedOptions === true}">
       <stage-config-field label="Template File Name" help-key="pipeline.config.bake.templateFileName"
                           ng-if="bakeStageCtrl.showTemplateFileName()">
         <input type="text" class="form-control input-sm"

--- a/app/scripts/modules/azure/pipeline/stages/bake/bakeStage.html
+++ b/app/scripts/modules/azure/pipeline/stages/bake/bakeStage.html
@@ -44,7 +44,7 @@
       <input type="text" class="form-control input-sm"
               ng-model="stage.baseName"/>
     </stage-config-field>
-    <div ng-class="{collapse: stage.showAdvancedOptions !== true, 'collapse.in': stage.showAdvancedOptions === true}">
+    <div ng-class="{collapse: showAdvancedOptions !== true, 'collapse.in': showAdvancedOptions === true}">
       <stage-config-field label="Template File Name" help-key="pipeline.config.bake.templateFileName"
                           ng-if="bakeStageCtrl.showTemplateFileName()">
         <input type="text" class="form-control input-sm"

--- a/app/scripts/modules/google/pipeline/stages/bake/bakeStage.html
+++ b/app/scripts/modules/google/pipeline/stages/bake/bakeStage.html
@@ -36,13 +36,13 @@
     <div class="col-md-9 col-md-offset-1">
       <div class="checkbox">
         <label>
-          <input type="checkbox" ng-model="stage.showAdvancedOptions">
+          <input type="checkbox" ng-model="showAdvancedOptions">
           <strong>Show Advanced Options</strong>
         </label>
       </div>
     </div>
   </div>
-  <div ng-class="{collapse: stage.showAdvancedOptions !== true, 'collapse.in': stage.showAdvancedOptions === true}">
+  <div ng-class="{collapse: showAdvancedOptions !== true, 'collapse.in': showAdvancedOptions === true}">
     <stage-config-field label="Template File Name" help-key="pipeline.config.bake.templateFileName"
                         ng-if="bakeStageCtrl.showTemplateFileName()">
       <input type="text" class="form-control input-sm"

--- a/app/scripts/modules/openstack/pipeline/stages/bake/bakeStage.html
+++ b/app/scripts/modules/openstack/pipeline/stages/bake/bakeStage.html
@@ -41,7 +41,7 @@
       </div>
     </stage-config-field>
 
-    <div ng-class="{collapse: stage.showAdvancedOptions !== true, 'collapse.in': stage.showAdvancedOptions === true}">
+    <div ng-class="{collapse: showAdvancedOptions !== true, 'collapse.in': showAdvancedOptions === true}">
       <stage-config-field label="Template File Name" help-key="pipeline.config.bake.templateFileName"
                           ng-if="bakeStageCtrl.showTemplateFileName()">
         <input type="text" class="form-control input-sm"

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@types/angular-mocks": "1.5.8",
     "@types/angular-ui-bootstrap": "^0.13.38",
     "@types/angular-ui-router": "^1.1.35",
-    "@types/jasmine": "^2.5.38",
+    "@types/jasmine": "2.5.41",
     "@types/jquery": "^2.0.34",
     "@types/lodash": "4.14.41",
     "@types/moment-timezone": "^0.2.32",


### PR DESCRIPTION
* update the bake stage to automatically expand the advanced options
section if any of the advanced options are populated.  This will now
ignore the `showAdvancedOptions` property on the stage object.
* update package.json to downgrade the typings for jasmine to get the
compiler to stop complaining about jasmine's typings file.  This error
goes away in TS 2.1.