### PR TITLE
Fast Property performance improvements

### DIFF
--- a/app/scripts/modules/netflix/fastProperties/dataNav/fastPropertyFilter.directive.ts
+++ b/app/scripts/modules/netflix/fastProperties/dataNav/fastPropertyFilter.directive.ts
@@ -36,7 +36,6 @@ class FastPropertyFilterDirective implements ng.IDirective {
           let tagBody = {label: field, value: attr};
           copy.push(scope.createFilterTag(tagBody));
           scope.filters.list = uniqWith(copy, (a: any, b: any) => a.label === b.label && a.value === b.value);
-          scope.$apply();
           return '';
         }
       };

--- a/app/scripts/modules/netflix/fastProperties/dataNav/fastPropertyFilterSearch.less
+++ b/app/scripts/modules/netflix/fastProperties/dataNav/fastPropertyFilterSearch.less
@@ -18,7 +18,7 @@
     z-index: 10000;
     li {
       color: #999;
-      max-width: 300px;
+      max-width: 500px;
       strong {
         font-weight: 600;
       }

--- a/app/scripts/modules/netflix/fastProperties/domain/scope.domain.ts
+++ b/app/scripts/modules/netflix/fastProperties/domain/scope.domain.ts
@@ -39,17 +39,6 @@ export class Scope {
     return scope;
   }
 
-  public getBaseOfScope() {
-    if (this.serverId) { return this.serverId; }
-    if (this.zone) { return this.zone; }
-    if (this.asg) { return this.asg; }
-    if (this.cluster) { return this.cluster; }
-    if (this.stack) { return this.stack; }
-    if (this.region) { return this.region; }
-    if (this.appId) { return this.appId; }
-    return 'GLOBAL';
-  }
-
   public getCategory() {
     if (this.serverId) { return CATEGORY.INSTANCES; }
     if (this.zone || this.asg) { return CATEGORY.SERVER_GROUPS; }

--- a/app/scripts/modules/netflix/fastProperties/scope/fastPropertyScopeSearch.component.html
+++ b/app/scripts/modules/netflix/fastProperties/scope/fastPropertyScopeSearch.component.html
@@ -20,10 +20,9 @@
 
 <div ng-if="$ctrl.query" >
 
-  <div class="searching"
-    ng-if="$ctrl.querying">
-    <h3>Searching...</h3>
-  </div>
+  <h2 ng-if="$ctrl.querying" class="text-center">
+    <span class="glyphicon glyphicon-asterisk glyphicon-spinning"></span>
+  </h2>
 
   <div
     ng-repeat="category in $ctrl.categories | orderBy: 'order' "

--- a/app/scripts/modules/netflix/fastProperties/view/fastPropertyFilterSearch.component.html
+++ b/app/scripts/modules/netflix/fastProperties/view/fastPropertyFilterSearch.component.html
@@ -4,7 +4,7 @@
       <input type="search"
              class="form-control"
              ng-model="fpFilter.query"
-             ng-focus="fpFilter.displayResults()"
+             ng-focus="fpFilter.displayResults($event)"
              ng-keyup="fpFilter.dispatchQueryInput($event)"
              ng-blur="fpFilter.searchFieldBlurred($event)"
              ng-paste="fpFilter.dispatchQueryInput($event)"
@@ -19,39 +19,20 @@
 
   <ul class="dropdown-menu"
       role="menu"
-      ng-if="!querying && showRecentItems">
-    <li ng-repeat-start="category in recentItems" class="category-heading">
-      <div class="category-heading">Recent {{ category.category }}</div>
-    </li>
-    <li ng-repeat="result in category.results | limitTo: 5"
-        ng-repeat-end
-        ng-mouseover="fpFilter.focussedResult = result"
-        class="result">
-      <a ng-keydown="fpFilter.navigateResults($event)"
-         analytics-on="click"
-         analytics-category="Global Search"
-         analytics-event="Recent Item Selected"
-         ui-sref="{{ result.state }}(result.params)"
-         ng-click="fpFilter.hideResults()"
-         ng-focus="fpFilter.focussedResult = result">
-        <search-result item="result"></search-result>
-      </a>
-    </li>
-  </ul>
-
-  <ul class="dropdown-menu"
-      role="menu"
       role="menu"
       ng-if="!fpFilter.querying && fpFilter.showSearchResults">
+    <li>
+      <div class="category-heading"></div>
+    </li>
     <li ng-repeat-start="category in fpFilter.filteredCategories" class="category-heading">
       <div class="category-heading">{{ category.category }}</div>
     </li>
-    <li ng-repeat="result in category.results"
+    <li ng-repeat="result in category.results | limitTo: 10 track by result"
         ng-repeat-end
         ng-mouseover="fpFilter.focussedResult = result"
         class="result">
       <a ng-keydown="fpFilter.navigateResults($event)" ng-click="fpFilter.tagAndClearFilter(category.category, result)" href
-         ng-focus="ctrl.focussedResult = result">
+         ng-focus="fpFilter.focussedResult = result">
         {{result}}
       </a>
     </li>

--- a/app/scripts/modules/netflix/fastProperties/view/fastPropertyFilterSearch.component.ts
+++ b/app/scripts/modules/netflix/fastProperties/view/fastPropertyFilterSearch.component.ts
@@ -51,8 +51,8 @@ class FastPropertyFilterSearchController implements ng.IComponentController {
     this.showSearchResults = true;
   }
 
-  public displayResults(): void {
-    if (this.query) {
+  public displayResults(event: any): void {
+    if (this.query && (this.query !== event.target.value)) {
       this.executeQuery();
     } else {
       this.displayAllCategories();
@@ -122,6 +122,7 @@ class FastPropertyFilterSearchController implements ng.IComponentController {
         return;
       }
     }
+
     this.executeQuery();
 
   }
@@ -185,10 +186,13 @@ class FastPropertyFilterSearchController implements ng.IComponentController {
   }
 
   private addToList(acc: any[], scopeKey: string, scopeValue: string): any {
-    if (scopeValue) {
+    if (scopeValue && scopeKey) {
       let categoryIndex = findIndex(acc, ['category', scopeKey]);
       if (categoryIndex > -1) {
-        acc[categoryIndex].results = Array.from(new Set(acc[categoryIndex].results).add(scopeValue));
+        let categoryResults = acc[categoryIndex].results;
+        if (categoryResults.indexOf(scopeValue) === -1) {
+          categoryResults.push(scopeValue);
+        }
       } else {
         acc.push({category: scopeKey, results: ['none', scopeValue]});
       }
@@ -198,11 +202,10 @@ class FastPropertyFilterSearchController implements ng.IComponentController {
 }
 
 
-
 class FastPropertyFilterSearchComponent implements ng.IComponentOptions {
 
   public bindings: any = {
-    'properties': '=',
+    'properties': '<',
     'filters': '=',
     'createFilterTag': '='
   };

--- a/app/scripts/modules/netflix/fastProperties/view/fastPropertyPodTable.html
+++ b/app/scripts/modules/netflix/fastProperties/view/fastPropertyPodTable.html
@@ -1,44 +1,6 @@
-
-<table class="table table-hover" style="word-break: break-all">
-  <thead style="border-top: none">
-  <tr>
-    <th width="20%" ng-if="$ctrl.groupedBy !== 'property'">Property</th>
-    <th width="20%">Value</th>
-    <th width="10%" ng-if="$ctrl.groupedBy !== 'app'">Application</th>
-    <th width="5%">Env</th>
-    <th width="10%">Region</th>
-    <th width="10%">Stack</th>
-    <th width="10%">Scope</th>
-  </tr>
-  </thead>
-  <tbody>
-  <tr
-    class="clickable"
-    ng-repeat="property in $ctrl.properties"
-    ng-click="$ctrl.showPropertyDetails(property.propertyId)"
-    >
-    <td ng-if="$ctrl.groupedBy !== 'property'">
-      {{ property.key }}
-    </td>
-    <td >
-      {{ property.value }}
-    </td>
-    <td ng-if="$ctrl.groupedBy !== 'app'">
-      {{ property.appId }}
-    </td>
-    <td>
-      <account-tag account="property.env" pad="right"></account-tag>
-    </td>
-    <td>
-      {{ property.scope.region }}
-    </td>
-    <td>
-      {{ property.scope.stack }}
-    </td>
-    <td>
-      {{ $ctrl.getBaseOfScope(property.scope) }}
-    </td>
-  </tr>
-  </tbody>
-</table>
+<fast-property-table
+  properties="$ctrl.properties"
+  grouped-by="$ctrl.groupedBy"
+  show-details="$ctrl.showPropertyDetails(propertyId)">
+</fast-property-table>
 

--- a/app/scripts/modules/netflix/fastProperties/view/fastPropertyPods.component.js
+++ b/app/scripts/modules/netflix/fastProperties/view/fastPropertyPods.component.js
@@ -10,7 +10,7 @@ module.exports = angular
   .component('fastPropertyPods', {
     templateUrl: require('./fastPropertyPods.html'),
     bindings: {
-      properties: '=',
+      properties: '<',
       groupedBy: '=?'
     },
     controller: function($state, $stateParams) {
@@ -52,17 +52,6 @@ module.exports = angular
     },
     controller: function($state) {
       let vm = this;
-
-      vm.getBaseOfScope = (scope) => {
-        if (scope.serverId) { return scope.serverId; }
-        if (scope.zone) { return scope.zone; }
-        if (scope.asg) { return scope.asg; }
-        if (scope.cluster) { return scope.cluster; }
-        if (scope.stack) { return scope.stack; }
-        if (scope.region) { return scope.region; }
-        if (scope.appId) { return scope.appId; }
-        return 'GLOBAL';
-      };
 
       vm.showPropertyDetails = (propertyId) => {
         if ($state.current.name.includes('.data.properties')) {

--- a/app/scripts/modules/netflix/fastProperties/view/fastPropertyPods.html
+++ b/app/scripts/modules/netflix/fastProperties/view/fastPropertyPods.html
@@ -3,29 +3,31 @@
 </div>
 
 
-<div
-  ng-repeat="(key, properties) in fpPod.properties" >
-  <div class="row rollup-entry sub-group" ng-if="fpPod.isGrouped()" >
+<div ng-if="fpPod.isGrouped()">
+  <div
+    ng-repeat="(key, properties) in fpPod.properties" >
+    <div class="row rollup-entry sub-group">
 
-    <div class="rollup-summary">
-      <div class="container-fluid no-padding">
-        <div class="row">
-          <div class="col-md-12">
-            <div class="rollup-title-cell">
-              <h5 style="margin-left: 15px">
-                <span class="glyphicon glyphicon-equalizer"></span>
-                {{key}}
-              </h5>
+      <div class="rollup-summary">
+        <div class="container-fluid no-padding">
+          <div class="row">
+            <div class="col-md-12">
+              <div class="rollup-title-cell">
+                <h5 style="margin-left: 15px">
+                  <span class="glyphicon glyphicon-equalizer"></span>
+                  {{key}}
+                </h5>
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
 
-    <div class="rollup-details" style="margin: 15px; border-top: none">
-      <fast-property-pod-table properties="properties" grouped-by="fpPod.groupedBy"></fast-property-pod-table>
-    </div>
+      <div class="rollup-details" style="margin: 15px; border-top: none">
+        <fast-property-pod-table properties="properties" grouped-by="fpPod.groupedBy"></fast-property-pod-table>
+      </div>
 
+    </div>
   </div>
 </div>
 

--- a/app/scripts/modules/netflix/fastProperties/view/fastPropertyTable.directive.js
+++ b/app/scripts/modules/netflix/fastProperties/view/fastPropertyTable.directive.js
@@ -1,0 +1,93 @@
+'use strict';
+
+
+let angular = require('angular');
+
+module.exports = angular.module('spinnaker.netflix.fastProperties.view.tableRow.directive', [
+  require('core/utils/jQuery.js'),
+])
+  .directive('fastPropertyTable', function ($timeout) {
+    return {
+      restrict: 'E',
+      scope: {
+        properties: '=',
+        groupedBy: '=?',
+        showDetails: '&',
+      },
+      link: function (scope, elem) {
+
+        function renderInstances() {
+          var properties = scope.properties;
+
+          let tableHeader = `
+          <table class="table table-hover" style="word-break: break-all">
+          <thead style="border-top: none">
+          <tr>
+            <th width="20%" ng-if="scope.groupedBy !== 'property'">Property</th>
+            <th width="20%">Value</th>
+            <th width="10%" ng-if="scope.groupedBy !== 'app'">Application</th>
+            <th width="5%">Env</th>
+            <th width="10%">Region</th>
+            <th width="10%">Stack</th>
+            <th width="10%">Scope</th>
+          </tr>
+          </thead>
+          <tbody>
+          `;
+
+          let tableFooter = `
+            </tbody>
+          </table>`;
+
+          let innerHtml = tableHeader + properties.map(function(property) {
+
+              return `
+
+              <tr data-property-id="${property.propertyId}">
+                <td>${property.key}</td>
+                <td>${property.value || ''}</td>
+                <td>${property.appId}</td>
+                <td><span class="label label-default account-label account-label-${property.env}">${property.env}</span></td>
+                <td>${property.scope.region}</td>
+                <td>${property.scope.stack}</td>
+                <td>${getBaseOfScope(property.scope)}</td>
+              </tr>
+              `;
+
+            }).join('') + tableFooter;
+
+          if (innerHtml !== elem.get(0).innerHTML) {
+            elem.get(0).innerHTML = innerHtml;
+          }
+        }
+
+
+        let getBaseOfScope = (scope) => {
+          if (scope.serverId) { return scope.serverId; }
+          if (scope.zone) { return scope.zone; }
+          if (scope.asg) { return scope.asg; }
+          if (scope.cluster) { return scope.cluster; }
+          if (scope.stack) { return scope.stack; }
+          if (scope.region) { return scope.region; }
+          if (scope.appId) { return scope.appId; }
+          if (scope.app) { return scope.app; }
+          return 'GLOBAL';
+        };
+
+        elem.click(function(event) {
+          $timeout(function() {
+            let propertyId = event.target.getAttribute('data-property-id') || event.target.parentElement.getAttribute('data-property-id');
+            scope.showDetails({propertyId: propertyId});
+          });
+        });
+
+        scope.$on('$destroy', function() {
+          elem.unbind('click');
+        });
+
+        scope.$watch('properties', renderInstances);
+        scope.$watch('groupedBy', renderInstances);
+      }
+    };
+  });
+

--- a/app/scripts/modules/netflix/fastProperties/view/properties.html
+++ b/app/scripts/modules/netflix/fastProperties/view/properties.html
@@ -14,7 +14,7 @@
         </div>
 
         <div class="form-group"
-             ng-if="fp.propertiesList"
+             ng-if="!fp.application && fp.propertiesList"
              style="margin-left: 10px">
           <label for="propertyGroup">Group</label>
           <div class="btn-group"
@@ -57,7 +57,7 @@
         <div style="margin-top: 5px" class="fast-property-filter-tags">
           <filter-tags
             tags="filters.list"
-            tag-cleared="fp.filterAndGroup(fp.propertiesList)"
+            tag-cleared="fp.updateFilter()"
             clear-filters="fp.clearFilters()">
           </filter-tags>
         </div>


### PR DESCRIPTION
Reduces the number of watches on a the Propertie tab by using our good friend Mr. innerHtml to
render the list of properties.  This is necessary for applications that have a lot of properties. (I'm looking at you API)

Also made some improvements around the filtering, and the filter tag generation.

Other small cosmetic tweeks:
- increased the max-width on the filter dropdown list
- Added spinners to indicate something was happening.

@anotherchrisberry @icfantv PTAL