### PR TITLE
(core) remove angular-wizard dependency

### DIFF
--- a/app/scripts/modules/core/core.module.js
+++ b/app/scripts/modules/core/core.module.js
@@ -22,8 +22,6 @@ require('select2-bootstrap-css/select2-bootstrap.css');
 require('Select2/select2.css');
 require('ui-select/dist/select.css');
 
-require('angular-wizard/dist/angular-wizard.css');
-
 require('source-sans-pro');
 
 require('font-awesome/css/font-awesome.css');

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "angular-ui-bootstrap": "1.3.1",
     "angular-ui-router": "=0.2.13",
     "angular-ui-sortable": "^0.13.4",
-    "angular-wizard": "^0.5.3",
     "bootstrap": "3.3.5",
     "clipboard": "^1.5.12",
     "d3": "^3.5.6",


### PR DESCRIPTION
This was only sticking around to support the legacy modal wizards.