### PR TITLE
(netflix) Fast properties impact count on env.

### DIFF
--- a/app/scripts/modules/netflix/fastProperties/domain/scope.domain.ts
+++ b/app/scripts/modules/netflix/fastProperties/domain/scope.domain.ts
@@ -39,6 +39,17 @@ export class Scope {
     return scope;
   }
 
+  public getBaseOfScope() {
+    if (this.serverId) { return this.serverId; }
+    if (this.zone) { return this.zone; }
+    if (this.asg) { return this.asg; }
+    if (this.cluster) { return this.cluster; }
+    if (this.stack) { return this.stack; }
+    if (this.region) { return this.region; }
+    if (this.appId) { return this.appId; }
+    return 'GLOBAL';
+  }
+
   public getCategory() {
     if (this.serverId) { return CATEGORY.INSTANCES; }
     if (this.zone || this.asg) { return CATEGORY.SERVER_GROUPS; }

--- a/app/scripts/modules/netflix/fastProperties/fastProperties.less
+++ b/app/scripts/modules/netflix/fastProperties/fastProperties.less
@@ -167,3 +167,6 @@ dl.fastProperty-list dt {
   font-size: 16px;
 }
 
+.attention {
+  color: @unhealthy_red;
+}

--- a/app/scripts/modules/netflix/fastProperties/scope/fastPropertyScopeSearch.component.ts
+++ b/app/scripts/modules/netflix/fastProperties/scope/fastPropertyScopeSearch.component.ts
@@ -40,6 +40,12 @@ export class FastPropertyScopeSearchComponentController implements ng.IComponent
     ];
   }
 
+  public $onChanges(changes: any) {
+    if (!changes.env.isFirstChange()) {
+      this.executeQuery();
+    }
+  }
+
   public $onInit() {
     this.accountService.getAllAccountDetailsForProvider('aws')
       .then((accounts: any) => {
@@ -86,7 +92,7 @@ export class FastPropertyScopeSearchComponentController implements ng.IComponent
   public selectResult(category: string, selected: any) {
     this.selectedResult = selected;
     this.showSearchResults = false;
-    this.scopeOptionsForDisplay = this.fastPropertyScopeSearchCategoryService.buildScopeList(this.categories, category, selected);
+    this.scopeOptionsForDisplay = this.fastPropertyScopeSearchCategoryService.buildScopeList(this.categories, category, selected, this.env);
   }
 
   public displayResults() {
@@ -192,7 +198,7 @@ export class FastPropertyScopeSearchComponentController implements ng.IComponent
   private createScopesForEachCategoryResult(categories: any[]) {
     return categories.map((category) => {
       category.scopes = category.results.reduce((acc: any[], result: any) => {
-        this.fastPropertyScopeSearchCategoryService.buildScopeList(this.applicationDictionary, category.category, result)
+        this.fastPropertyScopeSearchCategoryService.buildScopeList(this.applicationDictionary, category.category, result, this.env)
           .forEach((scope: any) => acc.push(scope));
         return acc;
       }, []);
@@ -216,7 +222,8 @@ class FastPropertyScopeSearchComponent implements ng.IComponentOptions {
   public controller: any = FastPropertyScopeSearchComponentController;
   public bindings: any = {
     onScopeSelected: '&',
-    applicationName: '='
+    applicationName: '=',
+    env: '@',
   };
 }
 

--- a/app/scripts/modules/netflix/fastProperties/scope/fastPropertyScopeSearchCategory.service.spec.ts
+++ b/app/scripts/modules/netflix/fastProperties/scope/fastPropertyScopeSearchCategory.service.spec.ts
@@ -1,0 +1,56 @@
+import {mock} from 'angular';
+
+import {FAST_PROPERTY_SCOPE_SEARCH_CATEGORY_SERVICE, FastPropertyScopeCategoryService} from './fastPropertyScopeSearchCategory.service';
+
+describe('FastPropertyScopeSearchCategory Service', function () {
+
+  let service: FastPropertyScopeCategoryService;
+
+  beforeEach((mock.module(FAST_PROPERTY_SCOPE_SEARCH_CATEGORY_SERVICE)));
+
+  beforeEach(
+    mock.inject(
+      function ( _fastPropertyScopeSearchCategoryService_: FastPropertyScopeCategoryService) {
+        service = _fastPropertyScopeSearchCategoryService_;
+      }));
+
+
+  let testMatch = (env: string, account: string, result: boolean) => {
+    expect(service.scopeEnvMatchesAccount(env, account)).toBe(result);
+  };
+
+  describe('scopeEnvMatchesAccount', () => {
+
+    it('should match if env = test and account = test', () => {
+      testMatch('test', 'test', true);
+    });
+
+    it('should match if env = prod and account = prod', () => {
+      testMatch('prod', 'prod', true);
+    });
+
+    it('should NOT match if env = test and account = prod', () => {
+      testMatch('test', 'prod', false);
+    });
+
+    it('should match if env = test and account contains the word test', () => {
+      testMatch('test', 'persistancetest', true);
+      testMatch('test', 'testaccount', true);
+    });
+
+    it('should match if env = prod and account does not contain the word test', () => {
+      testMatch('prod', 'mce', true);
+      testMatch('prod', 'persistence', true);
+      testMatch('prod', 'seg', true);
+    });
+
+    it('should not match if env = test and account does NOT contain the word test', () => {
+      testMatch('test', 'mce', false);
+      testMatch('test', 'persistence', false);
+      testMatch('test', 'seg', false);
+    });
+
+
+  });
+
+});

--- a/app/scripts/modules/netflix/fastProperties/wizard/createFastPropertyWizard.controller.ts
+++ b/app/scripts/modules/netflix/fastProperties/wizard/createFastPropertyWizard.controller.ts
@@ -54,7 +54,7 @@ class CreateFastPropertyWizardController {
 
 
   public isValid(): boolean {
-    return !!this.command.pipeline;
+    return !!this.command.pipeline && !!this.command.property.isValid();
   }
 
   public cancel(): void {

--- a/app/scripts/modules/netflix/fastProperties/wizard/propertyDetails/propertyDetails.componet.ts
+++ b/app/scripts/modules/netflix/fastProperties/wizard/propertyDetails/propertyDetails.componet.ts
@@ -1,6 +1,7 @@
 import { module } from 'angular';
 import {PropertyCommand} from '../../domain/propertyCommand.model';
 import {Property} from '../../domain/property.domain';
+import {AUTHENTICATION_SERVICE, AuthenticationService, IUser} from 'core/authentication/authentication.service';
 
 export class FastPropertyDetailsComponentController implements ng.IComponentController {
   public isEditing: boolean;
@@ -11,11 +12,17 @@ export class FastPropertyDetailsComponentController implements ng.IComponentCont
     return inputValue ? inputValue.split(/\n/).length : 1;
   };
 
-  public constructor() {
+  public constructor( authenticationService: AuthenticationService ) {
     // If the property has an existing id then we want to preserve it's stage for rollback
-    if (this.command && this.command.property && this.command.property.propertyId) {
-      this.command.originalProperty = Property.copy(this.command.property);
+    if (this.command && this.command.property) {
+      if (this.command.property.propertyId) {
+        this.command.originalProperty = Property.copy(this.command.property);
+      }
+
+      let user: IUser = authenticationService.getAuthenticatedUser();
+      this.command.property.email = user.name;
     }
+
   }
 }
 
@@ -32,5 +39,6 @@ class FastPropertyDetailsComponent implements ng.IComponentOptions {
 export const FAST_PROPERTY_DETAILS_COMPONENT = 'spinnaker.netflix.fastProperties.details.component';
 
 module(FAST_PROPERTY_DETAILS_COMPONENT, [
+  AUTHENTICATION_SERVICE
 ])
   .component('fastPropertyDetails', new FastPropertyDetailsComponent());

--- a/app/scripts/modules/netflix/fastProperties/wizard/propertyReview/propertyReview.component.html
+++ b/app/scripts/modules/netflix/fastProperties/wizard/propertyReview/propertyReview.component.html
@@ -3,19 +3,23 @@
   <div class="row">
     <!--Property Stuff-->
     <div
-      class="col-md-6"
-      ng-if="$ctrl.command.property.isValid()">
+      class="col-md-6">
       <h4>Property Info</h4>
       <div>
-        <b>Type:</b> {{$ctrl.command.getTypeAsString()}}
+        <b>Type:</b>
+        <span>{{$ctrl.command.getTypeAsString()}}<span>
       </div>
 
       <div>
-        <b>Key:</b> {{$ctrl.command.property.key}}
+        <b>Key:</b>
+        <span ng-if="$ctrl.command.property.key">{{$ctrl.command.property.key}}</span>
+        <span ng-if="!$ctrl.command.property.key" class="attention">Please enter property key.</span>
       </div>
 
       <div>
-        <b>Value:</b> {{$ctrl.command.property.value}}
+        <b>Value:</b>
+        <span ng-if="$ctrl.command.property.value">{{$ctrl.command.property.value}}</span>
+        <span ng-if="!$ctrl.command.property.value" class="attention">Please enter property value.</span>
       </div>
     </div>
 
@@ -34,7 +38,7 @@
       </div>
 
       <div>
-        <b>Instances Impacted:</b> <b style="color: red;">{{$ctrl.command.scope.instanceCounts.up}}</b>
+        <b>Instances Impacted:</b> <b class="attention">{{$ctrl.command.scope.instanceCounts.up}}</b>
       </div>
     </div>
 
@@ -45,7 +49,7 @@
     <div
       class="col-md-12"
       ng-if="$ctrl.command.pipeline.stages">
-      <b>{{$ctrl.command.strategy.displayName}}</b> used to create a pipeline with <b style="color: red;">{{$ctrl.command.pipeline.stages.length}}</b> stage(s):
+      <b>{{$ctrl.command.strategy.displayName}}</b> used to create a pipeline with <b class="attention">{{$ctrl.command.pipeline.stages.length}}</b> stage(s):
 
       <ul>
         <li ng-repeat="stage in $ctrl.command.pipeline.stages"><b>{{stage.name}}</b></li>

--- a/app/scripts/modules/netflix/fastProperties/wizard/propertyScope/propertyScope.component.html
+++ b/app/scripts/modules/netflix/fastProperties/wizard/propertyScope/propertyScope.component.html
@@ -1,8 +1,5 @@
 <form role="form" novalidate name="fastPropertyScopeForm">
-  <div class="modal-body" ng-if="!$ctrl.command.property.isValid()">
-    <h4>Enter Property Details</h4>
-  </div>
-  <div class="modal-body" ng-if="$ctrl.command.property.isValid()">
+  <div class="modal-body">
     <div class="row" style="display: flex; flex-wrap: wrap">
 
       <p>Setting the <b>scope</b> of a property determines what instances will have access to a given property.</p>
@@ -25,7 +22,8 @@
           <div class="col-md-12">
             <fast-property-scope-search-component
               on-scope-selected="$ctrl.selectScope(scopeOption)"
-              application-name="$ctrl.command.applicationName">
+              application-name="$ctrl.command.applicationName"
+              env="{{$ctrl.command.property.env}}">
             </fast-property-scope-search-component>
           </div>
         </div>
@@ -38,7 +36,7 @@
       <div class="col-md-4">
         <h4 ng-if="$ctrl.selectedScope.instanceCounts">
           Impact Count:
-          <span style="color:red;">{{$ctrl.selectedScope.instanceCounts.up}}</span>
+          <span class="attention">{{$ctrl.selectedScope.instanceCounts.up}}</span>
         </h4>
 
         <div>

--- a/app/scripts/modules/netflix/pipeline/stage/properties/create/propertyStage.html
+++ b/app/scripts/modules/netflix/pipeline/stage/properties/create/propertyStage.html
@@ -2,8 +2,6 @@
   <div class="modal-body">
     <div class="row">
 
-      <!--{{propertyStage.stage}}-->
-
       <div class="row">
           <div class="col-md-12">
             <h4 class="section">Properties</h4>
@@ -42,6 +40,7 @@
                   name="env"
                   class="form-control input-sm"
                   ng-model="propertyStage.stage.scope.env"
+                  ng-change="propertyStage.resetScope()"
                   required
                   ng-options="env for env in ['prod', 'test']">
                 </select>
@@ -67,13 +66,13 @@
                 <stage-config-field label="Choose Scope">
                   <fast-property-scope-search-component
                     on-scope-selected="propertyStage.selectScope(scopeOption)"
+                    env="{{propertyStage.stage.scope.env}}"
                     application-name="application.name">
                   </fast-property-scope-search-component>
                 </stage-config-field>
 
-                <stage-config-field label="Seleced Scope">
-
-                  <div ng-if="propertyStage.stage.scope.instanceCounts">
+                <stage-config-field label="Seleced Scope" ng-if="propertyStage.stage.scope.instanceCounts">
+                  <div>
                     <table class="table table-hover">
                       <tbody>
                       <tr ng-if="propertyStage.stage.scope.env">

--- a/app/scripts/modules/netflix/pipeline/stage/properties/create/propertyStage.js
+++ b/app/scripts/modules/netflix/pipeline/stage/properties/create/propertyStage.js
@@ -71,6 +71,10 @@ module.exports = angular.module('spinnaker.netflix.pipeline.stage.propertyStage'
       vm.stage.scope.appIdList = [vm.stage.scope.appId];
     };
 
+    vm.resetScope = () => {
+      vm.stage.scope = {env: vm.stage.scope.env};
+    };
+
     vm.refreshAppList = (query) => {
       vm.applicationList = query ? applicationList
         .filter((app) => {


### PR DESCRIPTION
- Impact count calculations now take the selected environment into consideration (SPIN-2330 &  SPIN-2349)
- Scope selectors now start loading as soon as the modal opens vs. after a key/value pair were entered.
- Email address in now prepopulated with logged in users email.
- Small validation and messaging tweaks when CRUDing a FP.

@anotherchrisberry @icfantv @jrsquared PTAL