### PR TITLE
Add BitBucket support

### DIFF
--- a/app/scripts/modules/core/application/modal/editApplication.html
+++ b/app/scripts/modules/core/application/modal/editApplication.html
@@ -46,7 +46,7 @@
         <div class="col-sm-9">
           <select
             class="form-control input-sm"
-            ng-options="repoType for repoType in ['stash', 'github']"
+            ng-options="repoType for repoType in ['stash', 'github', 'bitbucket']"
             ng-model="editApp.applicationAttributes.repoType">
             <option value="">Select Repo Type</option>
           </select>

--- a/app/scripts/modules/core/application/modal/newapplication.html
+++ b/app/scripts/modules/core/application/modal/newapplication.html
@@ -59,7 +59,7 @@
         <div class="col-sm-9">
           <select
             class="form-control input-sm"
-            ng-options="repoType for repoType in ['stash', 'github']"
+            ng-options="repoType for repoType in ['stash', 'github', 'bitbucket']"
             ng-model="newAppModal.application.repoType">
             <option value="">Select Repo Type</option>
           </select>

--- a/app/scripts/modules/core/pipeline/config/triggers/git/gitTrigger.html
+++ b/app/scripts/modules/core/pipeline/config/triggers/git/gitTrigger.html
@@ -15,7 +15,7 @@
   </div>
   <div class="form-group">
     <label class="col-md-3 sm-label-right">
-      {{vm.trigger.source === 'stash' ? 'Project' : 'Organization or User'}}
+      {{ displayText['pipeline.config.git.project'][vm.trigger.source] }}
       <help-field key="pipeline.config.git.project"></help-field>
     </label>
 
@@ -24,13 +24,13 @@
              ng-model="vm.trigger.project"
              name="project"
              required
-             placeholder="{{vm.trigger.source === 'stash' ? 'Project' : 'Organization or user'}} name, i.e. {{vm.trigger.source === 'stash' ? 'SPKR for stash.mycorp.com/projects/SPKR/repos/echo' : 'spinnaker for github.com/spinnaker/echo'}}"
+             placeholder="{{ displayText['vm.trigger.project'][vm.trigger.source] }}"
       />
     </div>
   </div>
   <div class="form-group">
     <label class="col-md-3 sm-label-right">
-      {{vm.trigger.source === 'stash' ? 'Repo Name' : 'Project'}}
+      {{ displayText['pipeline.config.git.slug'][vm.trigger.source] }}
       <help-field key="pipeline.config.git.slug"></help-field>
     </label>
     <div class="col-md-9">
@@ -38,7 +38,7 @@
              ng-model="vm.trigger.slug"
              name="slug"
              required
-             placeholder="{{vm.trigger.source === 'stash' ? 'Repository' : 'Project'}} name (not the url), i.e, {{vm.trigger.source === 'stash' ? 'echo for stash.mycorp.com/projects/SPKR/repos/echo' : 'echo for github.com/spinnaker/echo' }}"
+             placeholder="{{ displayText['vm.trigger.slug'][vm.trigger.source] }}"
              pattern="^((?!\:\/\/).)*$"
       />
     </div>

--- a/app/scripts/modules/core/pipeline/config/triggers/git/gitTrigger.module.js
+++ b/app/scripts/modules/core/pipeline/config/triggers/git/gitTrigger.module.js
@@ -35,7 +35,7 @@ module.exports = angular.module('spinnaker.core.pipeline.trigger.git', [
     serviceAccountService.getServiceAccounts().then(accounts => {
       this.serviceAccounts = accounts || [];
     });
-    $scope.gitTriggerTypes = ['stash', 'github'];
+    $scope.gitTriggerTypes = ['stash', 'github', 'bitbucket'];
 
     if (settings && settings.gitSources) {
       $scope.gitTriggerTypes = settings.gitSources;
@@ -50,6 +50,29 @@ module.exports = angular.module('spinnaker.core.pipeline.trigger.git', [
         trigger.branch = null;
       }
     }
+
+    $scope.displayText = {
+      'pipeline.config.git.project': {
+        'bitbucket': 'Team or User',
+        'github': 'Organization or User',
+        'stash': 'Project',
+      },
+      'pipeline.config.git.slug': {
+        'bitbucket': 'Repo name',
+        'github': 'Project',
+        'stash': 'Repo name'
+      },
+      'vm.trigger.project': {
+        'bitbucket': 'Team or User name, i.e. spinnaker for bitbucket.org/spinnaker/echo',
+        'github': 'Organization or User name, i.e. spinnaker for github.com/spinnaker/echo',
+        'stash': 'Project name, i.e. SPKR for stash.mycorp.com/projects/SPKR/repos/echo'
+      },
+      'vm.trigger.slug': {
+        'bitbucket': 'Repository name (not the url), i.e, echo for bitbucket.org/spinnaker/echo',
+        'github': 'Project name (not the url), i.e, echo for github.com/spinnaker/echo',
+        'stash': 'Repository name (not the url), i.e, echo for stash.mycorp.com/projects/SPKR/repos/echo'
+      }
+    };
 
     $scope.$watch('trigger.branch', updateBranch);
   });

--- a/app/scripts/modules/netflix/application/createApplication.modal.html
+++ b/app/scripts/modules/netflix/application/createApplication.modal.html
@@ -61,7 +61,7 @@
         <div class="col-sm-9">
           <select
               class="form-control input-sm"
-              ng-options="repoType for repoType in ['stash', 'github']"
+              ng-options="repoType for repoType in ['stash', 'github', 'bitbucket']"
               ng-model="newAppModal.application.repoType">
             <option value="">Select Repo Type</option>
           </select>

--- a/app/scripts/modules/netflix/application/editApplication.modal.html
+++ b/app/scripts/modules/netflix/application/editApplication.modal.html
@@ -48,7 +48,7 @@
         <div class="col-sm-9">
           <select
               class="form-control input-sm"
-              ng-options="repoType for repoType in ['stash', 'github']"
+              ng-options="repoType for repoType in ['stash', 'github', 'bitbucket']"
               ng-model="editApp.applicationAttributes.repoType">
             <option value="">Select Repo Type</option>
           </select>

--- a/halconfig/settings.js
+++ b/halconfig/settings.js
@@ -103,7 +103,7 @@ window.spinnakerSettings = {
   },
   authEnabled: authEnabled,
   authTtl: 600000,
-  gitSources: ['stash', 'github'],
+  gitSources: ['stash', 'github', 'bitbucket'],
   triggerTypes: ['git', 'pipeline', 'docker', 'cron', 'jenkins'],
   feature: {
     entityTags: entityTagsEnabled,

--- a/settings.js
+++ b/settings.js
@@ -98,7 +98,7 @@ window.spinnakerSettings = {
   },
   authEnabled: authEnabled,
   authTtl: 600000,
-  gitSources: ['stash', 'github'],
+  gitSources: ['stash', 'github', 'bitbucket'],
   triggerTypes: ['git', 'pipeline', 'docker', 'cron', 'jenkins'],
   feature: {
     entityTags: entityTagsEnabled,


### PR DESCRIPTION
PR [#153](https://github.com/spinnaker/igor/pull/153) has been opened against Igor.
PR [#137](https://github.com/spinnaker/echo/pull/137) has been opened against Echo.
PR [#346](https://github.com/spinnaker/gate/pull/346) has been opened against Gate.

BitBucket Server (a.k.a. Stash) support already exists. This adds BitBucket Cloud support of pipeline triggers based on BitBucket webhooks and provides Orca the ability to retrieve a list of commits from BitBucket as part of it's GetCommits stage.