### PR TITLE
Enhance fast property execution details

### DIFF
--- a/app/scripts/modules/netflix/pipeline/stage/properties/create/propertyExecutionDetails.controller.js
+++ b/app/scripts/modules/netflix/pipeline/stage/properties/create/propertyExecutionDetails.controller.js
@@ -16,11 +16,14 @@ module.exports = angular.module('spinnaker.netflix.pipeline.stage.property.detai
 
     let initialized = () => {
       $scope.detailsSection = $stateParams.details;
-      $scope.properties = $scope.stage.context.persistedProperties;
+      $scope.properties = getPropertiesForAction($scope.stage.context);
+      $scope.originalProperties = extractProperties($scope.stage.context.originalProperties);
       $scope.rolledBack = $scope.stage.context.rollbackProperties;
       $scope.notificationEmail = $scope.stage.context.email;
       $scope.cmcTicket = $scope.stage.context.cmcTicket;
       $scope.scope = $scope.stage.context.scope;
+      $scope.propertyAction = $scope.stage.context.propertyAction;
+      $scope.pipelineStatus = $scope.execution.status;
     };
 
     this.propertyScopeForDisplay = () => {
@@ -32,10 +35,30 @@ module.exports = angular.module('spinnaker.netflix.pipeline.stage.property.detai
       return $scope.stage.context.exception.details.error;
     };
 
+    this.isExecutionTerminalOrCanceled = () => {
+      return $scope.pipelineStatus === 'TERMINAL' || $scope.pipelineStatus === 'CANCELED';
+    };
+
+    this.wasCreateAction = () => {
+      return $scope.propertyAction === 'CREATE';
+    };
+
     let initialize = () => executionDetailsSectionService.synchronizeSection($scope.configSections, initialized);
 
     initialize();
 
     $scope.$on('$stateChangeSuccess', initialize);
+
+    let getPropertiesForAction = (stageContext) => {
+      if (stageContext.propertyAction === 'DELETE' && stageContext.originalProperties) {
+        return extractProperties(stageContext.originalProperties);
+      }
+      return stageContext.persistedProperties;
+    };
+
+    let extractProperties = (propertyList) => {
+      if (propertyList.length) return propertyList.map( prop => prop.property );
+    };
+
 
   });

--- a/app/scripts/modules/netflix/pipeline/stage/properties/create/propertyExecutionDetails.html
+++ b/app/scripts/modules/netflix/pipeline/stage/properties/create/propertyExecutionDetails.html
@@ -48,7 +48,7 @@
         <div class="alert alert-danger" ng-if="propertyDetailsCtrl.isExecutionTerminalOrCanceled()">
           <p>This pipeline ended with a status of {{pipelineStatus}}. The property was rolled back to its original state.</p>
           <p ng-if="propertyAction && propertyDetailsCtrl.wasCreateAction()">
-            Properties that were created during this stage where deleted.
+            Properties that where created during this stage where deleted.
           </p>
           <table class="table" ng-if="propertyAction && !propertyDetailsCtrl.wasCreateAction()">
             <thead>

--- a/app/scripts/modules/netflix/pipeline/stage/properties/create/propertyExecutionDetails.html
+++ b/app/scripts/modules/netflix/pipeline/stage/properties/create/propertyExecutionDetails.html
@@ -4,6 +4,9 @@
   <div class="step-section-details" ng-if="detailsSection === 'propertiesConfig'">
     <div class="row">
       <div class="col-md-12">
+        <div ng-if="propertyAction">
+          <b>Action Taken:</b> {{propertyAction}}
+        </div>
         <table class="table">
           <thead>
             <td><strong>Key</strong></td>
@@ -37,14 +40,37 @@
 
     </div>
 
-    <div class="row" ng-if="stage.context.exception">
+    <div class="row" ng-if="stage.context.exception || propertyDetailsCtrl.isExecutionTerminalOrCanceled()">
       <div class="col-md-12">
-        <div class="well alert alert-danger">
-          <!--{{stage.context.exception}}-->
+        <div class="alert alert-danger" ng-if="stage.context.exception" >
           {{propertyDetailsCtrl.getErrorMessage()}}
+        </div>
+        <div class="alert alert-danger" ng-if="propertyDetailsCtrl.isExecutionTerminalOrCanceled()">
+          <p>This pipeline ended with a status of {{pipelineStatus}}. The property was rolled back to its original state.</p>
+          <p ng-if="propertyAction && propertyDetailsCtrl.wasCreateAction()">
+            Properties that were created during this stage where deleted.
+          </p>
+          <table class="table" ng-if="propertyAction && !propertyDetailsCtrl.wasCreateAction()">
+            <thead>
+            <td><strong>Key</strong></td>
+            <td><strong>Value</strong></td>
+            </thead>
+            <tbody>
+            <tr ng-repeat="prop in originalProperties">
+              <td>
+                <strong>{{ prop.key }}</strong>
+              </td>
+              <td>
+                <strong>{{ prop.value }}</strong>
+              </td>
+            </tr>
+            </tbody>
+          </table>
         </div>
       </div>
     </div>
+
+
   </div>
 
   <div class="step-section-details" ng-if="detailsSection === 'taskStatus'">

--- a/app/scripts/modules/netflix/pipeline/stage/properties/create/propertyExecutionLabel.html
+++ b/app/scripts/modules/netflix/pipeline/stage/properties/create/propertyExecutionLabel.html
@@ -1,3 +1,3 @@
 <span class="stage-label">
-  <span>{{stage.name}}</span>
+  <span>{{stage.name}} {{stage.masterStage.context.propertyAction}}</span>
 </span>


### PR DESCRIPTION
- Added the action type (CREATE, UPDATE, DELETE) to the execution label and added it in the status tab.
- When pipeline fails it will now let the user know that the properties were rolled back and displays the rolled back state.
- Properties that were deleted were not displaying any key/value pairs in the details tab.

@anotherchrisberry @icfantv @jrsquared PTAL