### PR TITLE
Add a "force" checkbox to the cancel pipeline modal dialog

### DIFF
--- a/app/scripts/modules/core/cancelModal/cancel.html
+++ b/app/scripts/modules/core/cancelModal/cancel.html
@@ -1,0 +1,49 @@
+<div modal-page class="cancel-modal">
+  <form role="form" class="container-fluid no-padding" ng-submit="ctrl.confirm()">
+    <modal-close dismiss="$dismiss()"></modal-close>
+    <div class="modal-header">
+      <h3>{{params.header}}</h3>
+    </div>
+    <div class="modal-body cancel-modal">
+      <div ng-if="params.body" ng-bind-html="params.body"></div>
+      <div ng-if="state.error">
+        <div class="alert alert-danger">
+          <h4>An exception occurred:</h4>
+          <p>
+            {{errorMessage || 'No details provided.'}}
+          </p>
+        </div>
+      </div>
+      <task-reason command="params"></task-reason>
+      <div class="force-cancel" ng-if="params.forceable">
+        <div class="row">
+          <div class="col-md-3 sm-label-right">
+            <label for="force">Force</label>
+          </div>
+          <div class="col-md-7">
+            <input id="force" type="checkbox" ng-model="params.force">
+          </div>
+        </div>
+        <div class="row" ng-if="params.forceable && params.force">
+          <div class="col-md-push-3 col-md-7">
+            <div class="alert alert-info" role="alert">
+              <strong>Note:</strong> This option will force the pipeline to cancel. It should only be used if the task or pipeline hangs.
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="modal-footer">
+      <button class="btn btn-default"
+              type="button"
+              ng-click="ctrl.cancel()">{{params.cancelButtonText}}</button>
+      <button class="btn btn-primary"
+              type="submit"
+              ng-disabled="state.submitting || ctrl.formDisabled()"
+              ng-click="ctrl.confirm()">
+        <button-busy-indicator ng-if="state.submitting"></button-busy-indicator>
+        {{params.buttonText}}
+      </button>
+    </div>
+  </form>
+</div>

--- a/app/scripts/modules/core/cancelModal/cancel.less
+++ b/app/scripts/modules/core/cancelModal/cancel.less
@@ -1,0 +1,3 @@
+div.cancel-modal input {
+  margin-top: 10px;
+}

--- a/app/scripts/modules/core/cancelModal/cancelModal.controller.ts
+++ b/app/scripts/modules/core/cancelModal/cancelModal.controller.ts
@@ -1,0 +1,44 @@
+import {module} from 'angular';
+import {IModalServiceInstance} from 'angular-ui-bootstrap';
+import IScope = ng.IScope;
+
+require('./cancel.less');
+
+interface ICancelModalScope extends IScope {
+  state: any;
+  params: any;
+  errorMessage: string;
+}
+
+export class CancelModalCtrl {
+
+  constructor(public $scope: ICancelModalScope, private $uibModalInstance: IModalServiceInstance, private params: any) {
+    this.$scope.params = params;
+
+    this.$scope.state = {
+      submitting: false
+    };
+  }
+
+  formDisabled = () => this.$scope.state.submitting;
+
+  showError(exception: string): void {
+    this.$scope.state.error = true;
+    this.$scope.state.submitting = false;
+    this.$scope.errorMessage = exception;
+  }
+
+  confirm(): void {
+    if (!this.formDisabled()) {
+      this.$scope.state.submitting = true;
+      this.params.submitMethod(this.params.reason, this.params.force).then(this.$uibModalInstance.close, this.showError);
+    }
+  };
+
+  cancel = () => this.$uibModalInstance.dismiss();
+}
+
+export const CANCEL_MODAL_CONTROLLER = 'spinnaker.core.cancelModal.controller';
+module(CANCEL_MODAL_CONTROLLER, [
+  require('angular-ui-bootstrap')
+]).controller('cancelModalCtrl', CancelModalCtrl);

--- a/app/scripts/modules/core/cancelModal/cancelModal.service.ts
+++ b/app/scripts/modules/core/cancelModal/cancelModal.service.ts
@@ -1,0 +1,47 @@
+import {module} from 'angular';
+import {IModalService, IModalSettings} from 'angular-ui-bootstrap';
+import {CANCEL_MODAL_CONTROLLER} from './cancelModal.controller';
+
+export interface ICancelModalParams {
+  body?: string;
+  buttonText: string;
+  cancelButtonText?: string;
+  forceable?: boolean;
+  header: string;
+  submitMethod: (args: any) => ng.IPromise<any>;
+}
+
+export class CancelModalService {
+
+  private defaults: Partial<ICancelModalParams> = {
+    cancelButtonText: 'Cancel',
+    forceable: false
+  };
+
+  public constructor(private $uibModal: IModalService, private $sce: ng.ISCEService) {}
+
+  public confirm(params: ICancelModalParams): ng.IPromise<any> {
+    const extendedParams: ICancelModalParams = Object.assign({}, this.defaults, params);
+
+    if (extendedParams.body) {
+      extendedParams.body = this.$sce.trustAsHtml(extendedParams.body);
+    }
+
+    const modalArgs: IModalSettings = {
+      templateUrl: require('./cancel.html'),
+      controller: 'cancelModalCtrl',
+      controllerAs: 'ctrl',
+      resolve: {
+        params: () => extendedParams
+      }
+    };
+
+    return this.$uibModal.open(modalArgs).result;
+  }
+}
+
+export const CANCEL_MODAL_SERVICE = 'spinnaker.core.cancelModal.service';
+module(CANCEL_MODAL_SERVICE, [
+  require('angular-ui-bootstrap'),
+  CANCEL_MODAL_CONTROLLER,
+]).service('cancelModalService', CancelModalService);

--- a/app/scripts/modules/core/delivery/service/execution.service.js
+++ b/app/scripts/modules/core/delivery/service/execution.service.js
@@ -131,7 +131,7 @@ module.exports = angular.module('spinnaker.core.delivery.executions.service', [
       return deferred.promise;
     }
 
-    function cancelExecution(application, executionId, reason) {
+    function cancelExecution(application, executionId, force, reason) {
       var deferred = $q.defer();
       $http({
         method: 'PUT',
@@ -144,6 +144,7 @@ module.exports = angular.module('spinnaker.core.delivery.executions.service', [
           'cancel',
         ].join('/'),
         params: {
+          force: force,
           reason: reason
         }
       }).then(


### PR DESCRIPTION
* Adds a `force=true` parameter to the backend request if checked
* Corresponds with the following PR’s in Gate and Orca:
  * https://github.com/spinnaker/orca/pull/1188
  * https://github.com/spinnaker/gate/pull/345
* The checkbox will only show if the execution engine is `v2`