### PR TITLE
fix(docker/titus): switch registry when changing accounts

### DIFF
--- a/app/scripts/modules/titus/pipeline/stages/runJob/titusRunJobStage.js
+++ b/app/scripts/modules/titus/pipeline/stages/runJob/titusRunJobStage.js
@@ -42,6 +42,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.titus.runJobStage
 
     this.accountChanged = () => {
       this.accountChangedStream.next(null);
+      setRegistry();
       this.updateRegions();
 
     };
@@ -65,6 +66,12 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.titus.runJobStage
     this.onChange = (changes) => {
       stage.registry = changes.registry;
     };
+
+    function setRegistry() {
+      if (stage.credentials) {
+        stage.registry = $scope.backingData.credentialsKeyedByAccount[stage.credentials].registry;
+      }
+    }
 
     function updateImageId() {
       if ($scope.stage.repository && $scope.stage.tag) {
@@ -133,7 +140,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.titus.runJobStage
         stage.credentials = backingData.credentials[0];
       }
 
-      stage.registry = backingData.credentialsKeyedByAccount[stage.credentials].registry;
+      setRegistry();
       return $q.all([]).then(() => {
         vm.updateRegions();
         this.loaded = true;

--- a/app/scripts/modules/titus/serverGroup/configure/serverGroupConfiguration.service.js
+++ b/app/scripts/modules/titus/serverGroup/configure/serverGroupConfiguration.service.js
@@ -48,6 +48,7 @@ module.exports = angular.module('spinnaker.serverGroup.configure.titus.configura
         var backingData = command.backingData;
         configureZones(command);
         if (command.credentials) {
+          command.registry = backingData.credentialsKeyedByAccount[command.credentials].registry;
           backingData.filtered.regions = backingData.credentialsKeyedByAccount[command.credentials].regions;
           if (!backingData.filtered.regions.some(r => r.name === command.region)) {
             command.region = null;


### PR DESCRIPTION
Kind of surprised we haven't heard complaints about this before.

When the user switches accounts on a Run Job stage or when configuring a new server group in Titus, we don't update the registry, so they're still picking organizations and images from the previous registry (if the registry is different between the old and new account selection).

Most of the time, this seems to be a non-issue because there's a lot of overlap (at least at Netflix) between the registries - people seems to be publishing most images to both.

However, if they've chosen an organization that's _not_ in both, we'll potentially switch the registry in the run job stage when it initializes after they've saved it. Since the selector component has already started loading the images for the old registry, there's a race condition and it won't load them for the second one (it's still loading).

So two changes: 
 1. don't halt loading images when the registry changes just because we're already loading them
 2. switch registries when switching accounts

@icfantv PTAL