### PR TITLE
fix(aws/k8s): specify protocol on load balancer links based on ports/…

### DIFF
--- a/app/scripts/modules/amazon/loadBalancer/details/loadBalancerDetail.controller.js
+++ b/app/scripts/modules/amazon/loadBalancer/details/loadBalancerDetail.controller.js
@@ -29,26 +29,32 @@ module.exports = angular.module('spinnaker.loadBalancer.aws.details.controller',
 
     this.application = app;
 
-    function extractLoadBalancer() {
+    let extractLoadBalancer = () => {
       let appLoadBalancer = app.loadBalancers.data.find(function (test) {
         return test.name === loadBalancer.name && test.region === loadBalancer.region && test.account === loadBalancer.accountId;
       });
 
       if (appLoadBalancer) {
         var detailsLoader = loadBalancerReader.getLoadBalancerDetails('aws', loadBalancer.accountId, loadBalancer.region, loadBalancer.name);
-        return detailsLoader.then(function(details) {
+        return detailsLoader.then((details) => {
           $scope.loadBalancer = appLoadBalancer;
           $scope.state.loading = false;
           var securityGroups = [];
           if (details.length) {
             $scope.loadBalancer.elb = details[0];
             $scope.loadBalancer.account = loadBalancer.accountId;
+            if (details[0].listenerDescriptions) {
+              this.elbProtocol = 'http:';
+              if (details[0].listenerDescriptions.some(l => l.listener.protocol === 'HTTPS')) {
+                this.elbProtocol = 'https:';
+              }
+            }
 
             if ($scope.loadBalancer.elb.availabilityZones) {
               $scope.loadBalancer.elb.availabilityZones.sort();
             }
 
-            $scope.loadBalancer.elb.securityGroups.forEach(function (securityGroupId) {
+            $scope.loadBalancer.elb.securityGroups.forEach((securityGroupId) => {
               var match = securityGroupReader.getApplicationSecurityGroup(app, loadBalancer.accountId, loadBalancer.region, securityGroupId);
               if (match) {
                 securityGroups.push(match);
@@ -78,7 +84,7 @@ module.exports = angular.module('spinnaker.loadBalancer.aws.details.controller',
       }
 
       return $q.when(null);
-    }
+    };
 
     function autoClose() {
       if ($scope.$$destroyed) {

--- a/app/scripts/modules/amazon/loadBalancer/details/loadBalancerDetail.html
+++ b/app/scripts/modules/amazon/loadBalancer/details/loadBalancerDetail.html
@@ -90,7 +90,7 @@
       <dl class="horizontal-when-filters-collapsed">
         <dt ng-if="loadBalancer.elb.dnsname">DNS Name</dt>
         <dd>
-          <a target=_blank href="//{{loadBalancer.elb.dnsname}}">{{loadBalancer.elb.dnsname}}</a>
+          <a target=_blank href="{{ctrl.elbProtocol}}//{{loadBalancer.elb.dnsname}}">{{loadBalancer.elb.dnsname}}</a>
           <copy-to-clipboard
               class="copy-to-clipboard copy-to-clipboard-sm"
               text="{{loadBalancer.elb.dnsname}}"

--- a/app/scripts/modules/kubernetes/loadBalancer/details/details.html
+++ b/app/scripts/modules/kubernetes/loadBalancer/details/details.html
@@ -104,7 +104,7 @@
       <dl ng-if="loadBalancer.service.status.loadBalancer.ingress.length">
         <dt>Ingress</dt>
         <dd ng-repeat="ingress in loadBalancer.service.status.loadBalancer.ingress">
-          <a ng-if="ingress.hostname" target="_blank" href="//{{ingress.hostname}}">
+          <a ng-if="ingress.hostname" target="_blank" href="{{ctrl.ingressProtocol}}//{{ingress.hostname}}">
             {{ingress.hostname}}
           </a>
           <copy-to-clipboard


### PR DESCRIPTION
…listeners

If "HTTPS" is found, use that; otherwise, use "HTTP".

Tested on AWS; @lwander or @danielpeach can you try this on Kubernetes? I'm really guessing here.