### PR TITLE
Scope Fast Property to multiple apps

### DIFF
--- a/app/scripts/modules/netflix/fastProperties/domain/scope.domain.spec.ts
+++ b/app/scripts/modules/netflix/fastProperties/domain/scope.domain.spec.ts
@@ -29,6 +29,43 @@ describe('Scope Domain Spec', function () {
 
     });
   });
+
+  describe('prep a scope for submission', function () {
+
+    it('has no appId', function () {
+      let scope = new Scope();
+
+      let readyScope = scope.forSubmit('prod');
+      expect(readyScope.appIdList).toEqual([])
+    });
+
+    it('has single appId', function () {
+      let scope = new Scope();
+
+      scope.appId = "deck";
+
+      let readyScope = scope.forSubmit('prod');
+      expect(readyScope.appIdList).toEqual(['deck'])
+    });
+
+    it('has multiple comma delimited appId', function () {
+      let scope = new Scope();
+
+      scope.appId = "deck,demo";
+
+      let readyScope = scope.forSubmit('prod');
+      expect(readyScope.appIdList).toEqual(['deck', 'demo'])
+    });
+
+    it('has multiple comma delimited appId with whitespace', function () {
+      let scope = new Scope();
+
+      scope.appId = "deck , demo";
+
+      let readyScope = scope.forSubmit('prod');
+      expect(readyScope.appIdList).toEqual(['deck', 'demo'])
+    });
+  });
 });
 
 

--- a/app/scripts/modules/netflix/fastProperties/domain/scope.domain.ts
+++ b/app/scripts/modules/netflix/fastProperties/domain/scope.domain.ts
@@ -39,6 +39,11 @@ export class Scope {
     return scope;
   }
 
+  public copy() {
+    let scope = new Scope();
+    return Object.assign(scope, this);
+  }
+
   public getBaseOfScope() {
     if (this.serverId) { return this.serverId; }
     if (this.zone) { return this.zone; }
@@ -63,7 +68,7 @@ export class Scope {
   public forSubmit(env: string): Scope {
     let copy: Scope = Object.assign({}, this);
     copy.env = env;
-    copy.appIdList = [this.appId];
+    copy.appIdList = this.appId ? this.appId.split(',').map(appName => appName.trim()) : [];
     delete copy.instanceCounts;
     delete copy.appId;
     return copy;

--- a/app/scripts/modules/netflix/fastProperties/scope/categoryButtonList.component.html
+++ b/app/scripts/modules/netflix/fastProperties/scope/categoryButtonList.component.html
@@ -1,100 +1,67 @@
-  <div
-    class="scope-button-container">
 
-    <button
-      ng-if="$ctrl.categoryName === 'Applications'"
-      ng-click="$ctrl.selectScope($ctrl.scopeOption)"
-      class="fast-property-scope-button">
+  <div>
+    <table
+      class="table table-hover table-condensed">
+      <thead>
+        <tr>
+          <th colspan="2">
+            {{$ctrl.categoryName}}
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          class="scope-row"
+          ng-repeat="scopeOption in $ctrl.scopeOptions"
+          ng-if="scopeOption.instanceCounts.up > 0"
+          ng-click="$ctrl.selectScope(scopeOption)">
+          <td width="10%">
+            <span class="badge badge-impact-count" ng-class="{positive: scopeOption.instanceCounts.up > 0}">{{scopeOption.instanceCounts.up}}</span>
+          </td>
+          <td width="90" class="scope-cell">
+            <span ng-if="scopeOption.appId"><b>{{scopeOption.appId}}</b></span>
+            <span ng-if="scopeOption.region">{{scopeOption.region}}</span>
+            <span ng-if="scopeOption.stack">{{scopeOption.stack}}</span>
+            <span ng-if="scopeOption.cluster">{{scopeOption.cluster}}</span>
+            <span ng-if="scopeOption.asg">{{scopeOption.asg}}</span>
+            <span ng-if="scopeOption.serverId">{{scopeOption.serverId}}</span>
+            <span ng-if="$ctrl.categoryName === 'Global'">All Instances</span>
+          </td>
+        </tr>
 
-      <div>
-        <span ng-if="$ctrl.scopeOption.region">{{$ctrl.scopeOption.region}}</span>
-        <span ng-if="$ctrl.scopeOption.appId"><b>{{$ctrl.scopeOption.appId}}</b></span>
-      </div>
+        <tr ng-if="($ctrl.scopeOption | filter: $ctrl.noImpact).length">
+          <td colspan="2">
+            There are <span class="noticeText">{{($ctrl.scopeOption | filter: $ctrl.noImpact).length}}</span>
+            <span><b>{{category.category}}</b></span> scopes that have no impact.
+            <button
+              ng-click="$ctrl.toggleNoInpactList(category.category)"
+              class="btn btn-default btn-xs">
+              <span ng-if="$ctrl.showNoImpactListForCategory[category.category]">Hide</span>
+              <span ng-if="!$ctrl.showNoImpactListForCategory[category.category]">Show</span>
+            </button>
+          </td>
+        </tr >
 
-      <span class="badge badge-impact-count" ng-class="{positive: $ctrl.scopeOption.instanceCounts.up > 0}">{{$ctrl.scopeOption.instanceCounts.up}}</span>
-    </button>
-
-    <button
-      ng-if="$ctrl.categoryName === 'Clusters'"
-      ng-click="$ctrl.selectScope($ctrl.scopeOption)"
-      class="fast-property-scope-button">
-
-      <div>
-        <span ng-if="$ctrl.scopeOption.appId">{{$ctrl.scopeOption.appId}}</span>
-        <span ng-if="$ctrl.scopeOption.stack">...</span>
-        <span ng-if="$ctrl.scopeOption.cluster"><b>{{$ctrl.scopeOption.cluster}}</b></span>
-      </div>
-
-      <span class="badge badge-impact-count" ng-class="{positive: $ctrl.scopeOption.instanceCounts.up > 0}">{{$ctrl.scopeOption.instanceCounts.up}}</span>
-    </button>
-
-    <button
-      ng-if="$ctrl.categoryName === 'Server Groups'"
-      ng-click="$ctrl.selectScope($ctrl.scopeOption)"
-      class="fast-property-scope-button">
-
-      <div>
-        <span ng-if="$ctrl.scopeOption.region">{{$ctrl.scopeOption.region}}</span>
-        <span ng-if="$ctrl.scopeOption.appId">{{$ctrl.scopeOption.appId}}</span>
-        <span ng-if="$ctrl.scopeOption.stack || $ctrl.scopeOption.cluster">...</span>
-        <span ng-if="$ctrl.scopeOption.asg"><b>{{$ctrl.scopeOption.asg}}</b></span>
-      </div>
-
-      <span class="badge badge-impact-count" ng-class="{positive: $ctrl.scopeOption.instanceCounts.up > 0}">{{$ctrl.scopeOption.instanceCounts.up}}</span>
-    </button>
-
-    <button
-      ng-if="$ctrl.categoryName === 'Stack'"
-      ng-click="$ctrl.selectScope($ctrl.scopeOption)"
-      class="fast-property-scope-button">
-
-      <div>
-        <span ng-if="$ctrl.scopeOption.region">{{$ctrl.scopeOption.region}}</span>
-        <span ng-if="$ctrl.scopeOption.appId">{{$ctrl.scopeOption.appId}}</span>
-        <span ng-if="$ctrl.scopeOption.cluster">...</span>
-        <span ng-if="$ctrl.scopeOption.stack"><b>{{$ctrl.scopeOption.stack}}</b></span>
-      </div>
-
-      <span class="badge badge-impact-count" ng-class="{positive: $ctrl.scopeOption.instanceCounts.up > 0}">{{$ctrl.scopeOption.instanceCounts.up}}</span>
-    </button>
-
-
-    <button
-      ng-if="$ctrl.categoryName === 'Regions'"
-      ng-click="$ctrl.selectScope($ctrl.scopeOption)"
-      class="fast-property-scope-button">
-
-      <div>
-        <span ng-if="$ctrl.scopeOption.region"><b>{{$ctrl.scopeOption.region}}</b></span>
-      </div>
-      <span class="badge badge-impact-count" ng-class="{positive: $ctrl.scopeOption.instanceCounts.up > 0}">{{$ctrl.scopeOption.instanceCounts.up}}</span>
-    </button>
-
-    <button
-      ng-if="$ctrl.categoryName === 'Global'"
-      ng-click="$ctrl.selectScope($ctrl.scopeOption)"
-      class="fast-property-scope-button">
-
-      <div>
-        <div class="global-label">All Instances</div>
-      </div>
-      <span class="badge badge-impact-count" ng-class="{positive: $ctrl.scopeOption.instanceCounts.up > 0}">{{$ctrl.scopeOption.instanceCounts.up}}</span>
-    </button>
-
-    <button
-      class="fast-property-scope-button"
-      ng-if="$ctrl.categoryName === 'Instances'"
-      ng-click="$ctrl.selectScope($ctrl.scopeOption)">
-
-      <div>
-        <span ng-if="$ctrl.scopeOption.region">{{$ctrl.scopeOption.region}}</span>
-        <span ng-if="$ctrl.scopeOption.appId">{{$ctrl.scopeOption.appId}}</span>
-        <span ng-if="$ctrl.scopeOption.stack || $ctrl.scopeOption.cluster || $ctrl.scopeOption.asg">...</span>
-        <span ng-if="$ctrl.scopeOption.serverId"><b>{{$ctrl.scopeOption.serverId}}</b></span>
-      </div>
-
-      <span class="badge badge-impact-count" ng-class="{positive: $ctrl.scopeOption.instanceCounts.up > 0}">{{$ctrl.scopeOption.instanceCounts.up}}</span>
-    </button>
+        <tr
+          class="scope-row"
+          ng-repeat="scopeOption in $ctrl.scopeOptions"
+          ng-click="$ctrl.selectScope(scopeOption)"
+          ng-if="scopeOption.instanceCounts.up === 0 && $ctrl.showNoImpactListForCategory[category.category]" >
+          <td width="10%">
+            <span class="badge badge-impact-count" ng-class="{positive: scopeOption.instanceCounts.up > 0}">{{scopeOption.instanceCounts.up}}</span>
+          </td>
+          <td width="90" class="scope-cell">
+            <span ng-if="scopeOption.appId"><b>{{scopeOption.appId}}</b></span>
+            <span ng-if="scopeOption.region">{{scopeOption.region}}</span>
+            <span ng-if="scopeOption.cluster">{{scopeOption.cluster}}</span>
+            <span ng-if="scopeOption.stack">{{scopeOption.stack}}</span>
+            <span ng-if="scopeOption.asg">{{scopeOption.asg}}</span>
+            <span ng-if="scopeOption.serverId">{{scopeOption.serverId}}</span>
+            <span ng-if="$ctrl.categoryName === 'Global'">All Instances</span>
+          </td>
+        </tr>
+      </tbody>
+    </table>
 
   </div>
 

--- a/app/scripts/modules/netflix/fastProperties/scope/categoryButtonList.component.ts
+++ b/app/scripts/modules/netflix/fastProperties/scope/categoryButtonList.component.ts
@@ -5,9 +5,20 @@ export class CategoryButtonListComponentController implements ng.IComponentContr
   public scopeOption: any;
   public categoryName: string;
   public onSelectScope: Function;
+  public showNoImpactListForCategory: any = {};
 
   public selectScope(scopeOption: any) {
     this.onSelectScope({scopeOption: scopeOption});
+  }
+
+  public noImpact(categoryScope: any) {
+    return categoryScope.instanceCounts.up < 1;
+  }
+
+  public toggleNoInpactList(categoryName: string) {
+    this.showNoImpactListForCategory[categoryName] = this.showNoImpactListForCategory[categoryName]
+      ? !this.showNoImpactListForCategory[categoryName]
+      : true;
   }
 
 }
@@ -16,7 +27,7 @@ class CategoryButtonListComponent implements ng.IComponentOptions {
   public templateUrl: string = require('./categoryButtonList.component.html');
   public controller: any = CategoryButtonListComponentController;
   public bindings: any = {
-    scopeOption: '=',
+    scopeOptions: '=',
     categoryName: '<',
     onSelectScope: '&'
   };

--- a/app/scripts/modules/netflix/fastProperties/scope/fastPropertyScopeSearch.component.html
+++ b/app/scripts/modules/netflix/fastProperties/scope/fastPropertyScopeSearch.component.html
@@ -29,45 +29,10 @@
     ng-if="!$ctrl.querying && category.scopes.length"
     class="scope-category-container">
 
-    <div class="category-heading">{{category.category}}</div>
-
-    <div
-      ng-repeat="scopeOption in category.scopes"
-      ng-if="scopeOption.instanceCounts.up > 0"
-      class="scope-button-container">
-      <category-button-list-component
-        on-select-scope="$ctrl.selectScope(scopeOption)"
-        category-name="category.category"
-        scope-option="scopeOption">
-      </category-button-list-component>
-    </div>
-
-    <div ng-if="(category.scopes | filter: $ctrl.noImpact).length">
-      There are <span class="noticeText">{{(category.scopes | filter: $ctrl.noImpact).length}}</span>
-      <span><b>{{category.category}}</b></span> scopes that have no impact.
-      <button
-        ng-click="$ctrl.toggleNoInpactList(category.category)"
-        class="btn btn-default btn-xs">
-        <span ng-if="$ctrl.showNoImpactListForCategory[category.category]">Hide</span>
-        <span ng-if="!$ctrl.showNoImpactListForCategory[category.category]">Show</span>
-      </button>
-    </div>
-
-    <div
-      ng-if="$ctrl.showNoImpactListForCategory[category.category]"
-      class="scope-category-container">
-
-      <div
-        ng-repeat="scopeOption in category.scopes"
-        ng-if="scopeOption.instanceCounts.up === 0"
-        class="scope-button-container">
-        <category-button-list-component
-          on-select-scope="$ctrl.selectScope(scopeOption)"
-          category-name="category.category"
-          scope-option="scopeOption">
-        </category-button-list-component>
-      </div>
-
-    </div>
+    <category-button-list-component
+      on-select-scope="$ctrl.selectScope(scopeOption)"
+      category-name="category.category"
+      scope-options="category.scopes">
+    </category-button-list-component>
   </div>
 </div>

--- a/app/scripts/modules/netflix/fastProperties/scope/fastPropertyScopeSearch.component.ts
+++ b/app/scripts/modules/netflix/fastProperties/scope/fastPropertyScopeSearch.component.ts
@@ -177,16 +177,22 @@ export class FastPropertyScopeSearchComponentController implements ng.IComponent
   }
 
   private addStackCategory(categories: any[]) {
+    let applicationCategory = categories
+      .find((cat: any) => cat.category === 'Applications');
+    let applicationNames = applicationCategory ? applicationCategory.results.map((item: any) => item.application) : [];
+
     let appsClusters = values(this.applicationDictionary).reduce((acc: any[], app: Application): any[] => {
-      app.clusters.forEach((cluster: ICluster) => {
-        cluster.serverGroups.forEach((serverGroup: ServerGroup) => {
-          acc.push({
-            region: serverGroup.region,
-            application: app.name,
-            cluster: serverGroup.cluster
+      if (applicationNames.includes(app.name)) {
+        app.clusters.forEach((cluster: ICluster) => {
+          cluster.serverGroups.forEach((serverGroup: ServerGroup) => {
+            acc.push({
+              region: serverGroup.region,
+              application: app.name,
+              cluster: serverGroup.cluster
+            });
           });
         });
-      });
+      }
       return uniqWith(acc, isEqual);
     }, []);
 

--- a/app/scripts/modules/netflix/fastProperties/scope/fastPropetyScopeSearch.less
+++ b/app/scripts/modules/netflix/fastProperties/scope/fastPropetyScopeSearch.less
@@ -75,7 +75,7 @@
   top: -8px;
 }
 
-.scope-button-container .badge-impact-count.positive {
+.badge-impact-count.positive {
   background: @unhealthy_red;
 }
 
@@ -129,6 +129,24 @@ button.fast-property-scope-button {
   color: @unhealthy_red;
 }
 
+tr.scope-row {
+  cursor: pointer;
+}
+
+td.scope-cell span {
+  margin-right: 5px;
+}
+
+td.scope-cell span:last-of-type {
+  font-weight: bold;
+}
+
+td.scope-cell span:not(:first-of-type):before {
+  content: "\27A1" ;
+  margin-right: 0.5em;
+  margin-left: 0.5em;
+  color: @spinnaker-blue;
+}
 
 .keyboard-key {
   color: @code-yellow;

--- a/app/scripts/modules/netflix/fastProperties/wizard/propertyScope/propertyScope.component.html
+++ b/app/scripts/modules/netflix/fastProperties/wizard/propertyScope/propertyScope.component.html
@@ -16,7 +16,7 @@
         LEFT COLUMN
         Only rendered if the form is creating a new FP
       -->
-      <div class="col-md-8" style="display: flex; flex-direction: column">
+      <div class="col-md-7" style="display: flex; flex-direction: column">
 
         <div class="row">
           <div class="col-md-12">
@@ -33,49 +33,126 @@
       <!--
        RIGHT COLUMN
        -->
-      <div class="col-md-4">
-        <h4 ng-if="$ctrl.selectedScope.instanceCounts">
-          Impact Count:
-          <span class="attention">{{$ctrl.selectedScope.instanceCounts.up}}</span>
-        </h4>
+      <div class="col-md-5">
+        <div class="row" ng-if="$ctrl.selectedScope">
+          <div class="col-md-9">
+            <h4 ng-if="$ctrl.selectedScope.instanceCounts">
+              Impact Count:
+              <span class="attention">{{$ctrl.selectedScope.instanceCounts.up}}</span>
+            </h4>
+          </div>
+          <div class="col-md-3">
+            <a
+              href
+              class="btn btn-link"
+              ng-if="!$ctrl.isEditing"
+              ng-click="$ctrl.toggleEditScope()">
+              <i class="fa fa-edit"></i>
+            </a>
+          </div>
+        </div>
 
         <div>
-          <table class="table table-hover">
+          <table class="table table-hover" style="margin-bottom: 5px" >
             <tbody>
             <tr ng-if="$ctrl.selectedScope.env">
               <td><b>Env</b></td>
-              <td>{{$ctrl.selectedScope.env}}</td>
+              <td> {{$ctrl.selectedScope.env}} </td>
             </tr>
             <tr ng-if="$ctrl.selectedScope.appId">
               <td><b>Apps</b></td>
-              <td>{{$ctrl.selectedScope.appId}}</td>
+              <td>
+                <span ng-if="!$ctrl.isEditing">
+                  {{$ctrl.selectedScope.appId}}
+                </span>
+                <input
+                  class="form-control"
+                  ng-if="$ctrl.isEditing"
+                  type="text" ng-model="$ctrl.selectedScope.appId">
+              </td>
             </tr>
             <tr ng-if="$ctrl.selectedScope.region">
               <td><b>Region</b></td>
-              <td>{{$ctrl.selectedScope.region}}</td>
+              <td>
+                <span ng-if="!$ctrl.isEditing">
+                  {{$ctrl.selectedScope.region}}
+                </span>
+                <input
+                  class="form-control"
+                  ng-if="$ctrl.isEditing"
+                  type="text" ng-model="$ctrl.selectedScope.region">
+              </td>
             </tr>
             <tr ng-if="$ctrl.selectedScope.stack">
               <td><b>Stack</b></td>
-              <td>{{$ctrl.selectedScope.stack}}</td>
+              <td>
+                <span ng-if="!$ctrl.isEditing">
+                  {{$ctrl.selectedScope.stack}}
+                </span>
+                <input
+                  class="form-control"
+                  ng-if="$ctrl.isEditing"
+                  type="text" ng-model="$ctrl.selectedScope.stack">
+              </td>
             </tr>
             <tr ng-if="$ctrl.selectedScope.cluster">
-              <td><b>Cluster</></td>
-              <td>{{$ctrl.selectedScope.cluster}}</td>
+              <td><b>Cluster</b></td>
+              <td>
+                <span ng-if="!$ctrl.isEditing">
+                  {{$ctrl.selectedScope.cluster}}
+                </span>
+                <input
+                  class="form-control"
+                  ng-if="$ctrl.isEditing"
+                  type="text" ng-model="$ctrl.selectedScope.cluster">
+              </td>
+
             </tr>
             <tr ng-if="$ctrl.selectedScope.asg">
               <td><b>ASG</b></td>
-              <td>{{$ctrl.selectedScope.asg}}</td>
+              <td>
+                <span ng-if="!$ctrl.isEditing">
+                  {{$ctrl.selectedScope.asg}}
+                </span>
+                <input
+                  class="form-control"
+                  ng-if="$ctrl.isEditing"
+                  type="text" ng-model="$ctrl.selectedScope.asg">
+              </td>
             </tr>
             <tr ng-if="$ctrl.selectedScope.zone">
               <td><b>Zone</b></td>
-              <td>{{$ctrl.selectedScope.zone}}</td>
+              <td>
+                <span ng-if="!$ctrl.isEditing">
+                  {{$ctrl.selectedScope.zone}}
+                </span>
+                <input
+                  class="form-control"
+                  ng-if="$ctrl.isEditing"
+                  type="text" ng-model="$ctrl.selectedScope.zone">
+              </td>
             </tr>
             <tr ng-if="$ctrl.selectedScope.serverId">
               <td><b>Instance</b></td>
-              <td>{{$ctrl.selectedScope.serverId}}</td>
+              <td>
+                <span ng-if="!$ctrl.isEditing">
+                  {{$ctrl.selectedScope.serverId}}
+                </span>
+                <input
+                  class="form-control"
+                  ng-if="$ctrl.isEditing"
+                  type="text" ng-model="$ctrl.selectedScope.serverId">
+              </td>
             </tr>
             </tbody>
           </table>
+            <button
+              class="btn btn-primary btn-xs"
+              ng-if="$ctrl.isEditing"
+              ng-click="$ctrl.toggleEditScope()"
+              type="button">
+              Save Scope
+            </button>
         </div>
       </div>
     </div>

--- a/app/scripts/modules/netflix/fastProperties/wizard/propertyScope/propertyScope.component.ts
+++ b/app/scripts/modules/netflix/fastProperties/wizard/propertyScope/propertyScope.component.ts
@@ -11,8 +11,13 @@ export class FastPropertyScopeComponentController implements ng.IComponentContro
   public command: PropertyCommand;
 
   public selectScope(scopeOption: Scope) {
-    this.selectedScope = scopeOption;
-    this.command.scope = scopeOption;
+    this.selectedScope = scopeOption.copy();
+    this.command.scope = this.selectedScope;
+  }
+
+  public toggleEditScope() {
+    this.isEditing = !this.isEditing;
+
   }
 }
 


### PR DESCRIPTION
- Downstream orca change needed to make this work (https://github.com/spinnaker/orca/pull/1192), but this can go in before.
- Made changes to the way scopes are laid out.
- Selected scopes can also be edited to allow for scoping Fast Properties to ASGs that have yet to be created.  This is useful for FP that are needed at startup.

![mahe_ _fast_properties_ _fast_property_details__undefined_undefined_](https://cloud.githubusercontent.com/assets/66639/23369315/91b7193c-fcd6-11e6-8ad3-7a720091886a.jpg)

@anotherchrisberry @icfantv @jrsquared PTAL