### PR TITLE
(titus) Adding a UI element for runtimeLimitSecs for the titus runJob stage

### DIFF
--- a/app/scripts/modules/core/help/helpContents.js
+++ b/app/scripts/modules/core/help/helpContents.js
@@ -476,6 +476,7 @@ module.exports = angular.module('spinnaker.core.help.contents', [])
     'openstack.network.floatpool': 'The network from which to allocate a floating ip',
     'openstack.serverGroup.userData': '<p>Provides a script that will run when each server group instance starts.</p>',
     'openstack.serverGroup.tags': '<p>Key-value pairs of metadata that will be associate to each server group instance.</p>',
+    'titus.deploy.runtimeLimitSecs': '<p>(Batch) Maximum amount of time (in seconds) a batch job is allowed to run</p>',
     'titus.deploy.propertyFile': '<p>(Optional) Configures the name to the file used to pass in properties to later stages in the Spinnaker pipeline. The file must be saved into the /logs directory during execution</p>',
     'titus.deploy.iamProfile': 'AWS IAM instance profile to assign to this service',
     'titus.deploy.capacityGroup': 'Used by Titus to ensure capacity guarantees, defaults to the application name if not provided',

--- a/app/scripts/modules/titus/pipeline/stages/runJob/runJobStage.html
+++ b/app/scripts/modules/titus/pipeline/stages/runJob/runJobStage.html
@@ -52,6 +52,10 @@
            required/>
   </stage-config-field>
 
+  <stage-config-field label="Runtime Limit (Seconds)" help-key="titus.deploy.runtimeLimitSecs">
+    <input type="number" class="form-control input-sm" name="runtimeLimitSecs" ng-model="stage.cluster.runtimeLimitSecs" min="1" required/>
+  </stage-config-field>
+
   <stage-config-field label="Property File" help-key="titus.deploy.propertyFile">
     <input type="text" class="form-control input-sm" name="propertyFile" ng-model="stage.propertyFile"/>
   </stage-config-field>

--- a/app/scripts/modules/titus/pipeline/stages/runJob/titusRunJobStage.js
+++ b/app/scripts/modules/titus/pipeline/stages/runJob/titusRunJobStage.js
@@ -20,7 +20,8 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.titus.runJobStage
         {type: 'requiredField', fieldName: 'cluster.region'},
         {type: 'requiredField', fieldName: 'cluster.resources.cpu'},
         {type: 'requiredField', fieldName: 'cluster.resources.memory'},
-        {type: 'requiredField', fieldName: 'cluster.resources.disk'}
+        {type: 'requiredField', fieldName: 'cluster.resources.disk'},
+        {type: 'requiredField', fieldName: 'cluster.runtimeLimitSecs'}
       ]
     });
   }).controller('titusRunJobStageCtrl', function ($scope, accountService, $q) {
@@ -128,6 +129,8 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.titus.runJobStage
         desired: 1
       };
     }
+
+    stage.cluster.runtimeLimitSecs = stage.cluster.runtimeLimitSecs || 60;
 
     stage.deferredInitialization = true;
     $q.all({


### PR DESCRIPTION
- added required ```runtimeLimitSecs``` text field
- default is set to 60s

- This change will ensure this field isn't set to 0, which translates
to a titus container running indefinitely.