### PR TITLE
fix(appconfig): do not overwrite cloudProviders when editing app

### DIFF
--- a/app/scripts/modules/core/application/service/application.write.service.ts
+++ b/app/scripts/modules/core/application/service/application.write.service.ts
@@ -69,7 +69,9 @@ export class ApplicationWriter {
     const jobs: IJob[] = [];
     const command = commandTransformer(application);
     command.accounts = application.accounts.join(',');
-    command.cloudProviders = application.cloudProviders ? application.cloudProviders.join(',') : [];
+    if (application.cloudProviders) {
+      command.cloudProviders = application.cloudProviders.join(',');
+    }
     delete command.account;
     application.accounts.forEach(account => {
       jobs.push({


### PR DESCRIPTION
A number of config sections don't send the list of cloud providers to the application writer, so they end up getting overwritten when a user saves them. Really, we should only set the `cloudProviders` field if it's explicitly sent.