### PR TITLE
fix(aws): send vpcId when deleting load balancers

### DIFF
--- a/app/scripts/modules/amazon/loadBalancer/details/loadBalancerDetail.controller.js
+++ b/app/scripts/modules/amazon/loadBalancer/details/loadBalancerDetail.controller.js
@@ -149,6 +149,7 @@ module.exports = angular.module('spinnaker.loadBalancer.aws.details.controller',
         loadBalancerName: $scope.loadBalancer.name,
         regions: [$scope.loadBalancer.region],
         credentials: $scope.loadBalancer.account,
+        vpcId: _.get($scope.loadBalancer, 'elb.vpcid', null),
       };
 
       const submitMethod = () => loadBalancerWriter.deleteLoadBalancer(command, app);


### PR DESCRIPTION
Without the vpcId, the force cache refresh operation will not evict the load balancer from the cache, because it is looking for a key with the vpcId in it, which isn't supplied, so...the load balancer just gets stuck in the cache until a new redis instance is primed.