### PR TITLE
fix(pipelines): consider providesFor field when selecting stage provider

### DIFF
--- a/app/scripts/modules/titus/pipeline/stages/bake/titusBakeStage.js
+++ b/app/scripts/modules/titus/pipeline/stages/bake/titusBakeStage.js
@@ -11,7 +11,6 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.titus.titusBakeSt
       provides: 'bake',
       useBaseProvider: true,
       cloudProvider: 'titus',
-      providesFor: ['titus'],
       templateUrl: require('./bakeStage.html'),
       executionDetailsUrl: require('./bakeExecutionDetails.html'),
       validators: []

--- a/app/scripts/modules/titus/pipeline/stages/runJob/titusRunJobStage.js
+++ b/app/scripts/modules/titus/pipeline/stages/runJob/titusRunJobStage.js
@@ -10,7 +10,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.titus.runJobStage
     pipelineConfigProvider.registerStage({
       provides: 'runJob',
       useBaseProvider: true,
-      cloudProvider: 'aws',
+      cloudProvider: 'titus',
       providesFor: ['aws', 'titus'],
       templateUrl: require('./runJobStage.html'),
       executionDetailsUrl: require('./runJobExecutionDetails.html'),


### PR DESCRIPTION
The code around multi-provider stages is a mess and needs to be addressed at some point (I'm hoping to refactor it in April). In the meantime, this change will consider the `providesFor` field when selecting the cloud provider implementation for a given stage.

This really only affects Netflix, as we've used this `providesFor` field to handle Titus functionality.