### PR TITLE
perf(pipelines): only watch status, execution label line counts

### DIFF
--- a/app/scripts/modules/core/delivery/service/execution.service.spec.js
+++ b/app/scripts/modules/core/delivery/service/execution.service.spec.js
@@ -310,12 +310,14 @@ describe('Service: executionService', function () {
       let original = {
         id:1,
         stringVal: 'ac',
-        stageSummaries: originalStages.slice()
+        stageSummaries: originalStages.slice(),
+        graphStatusHash: 'COMPLETED:RUNNING:RUNNING:NOT_STARTED',
       };
       let updated = {
         id:1,
         stringVal: 'ab',
-        stageSummaries: updatedStages.slice()
+        stageSummaries: updatedStages.slice(),
+        graphStatusHash: 'COMPLETED:RUNNING:RUNNING:NOT_STARTED',
       };
       let execs = [updated];
       application.executions.data = [original];

--- a/app/scripts/modules/core/pipeline/config/graph/pipeline.graph.component.ts
+++ b/app/scripts/modules/core/pipeline/config/graph/pipeline.graph.component.ts
@@ -337,11 +337,9 @@ export class PipelineGraphController implements ng.IComponentController {
     this.updateGraph();
     if (this.shouldValidate) {
       this.$scope.$watch('$ctrl.pipeline', debounce(() => this.pipelineConfigValidator.validatePipeline(this.pipeline), 300), true);
-    } else {
-      this.$scope.$watch('$ctrl.pipeline', () => this.updateGraph(), true);
     }
     this.$scope.$watch('$ctrl.viewState', () => { this.updateGraph(); }, true);
-    this.$scope.$watch('$ctrl.execution', () => this.updateGraph(), true);
+    this.$scope.$watch('$ctrl.execution.graphStatusHash', () => this.updateGraph());
     this.$(this.$window).bind('resize.pipelineGraph-' + graphId, handleWindowResize);
 
     this.$scope.$on('$destroy', () => {


### PR DESCRIPTION
We don't need to watch the entire execution as a deep watch on the pipeline graph - just the status and the extra label lines.