### PR TITLE
fix(core) do not allow free-form text in group membership config

### DIFF
--- a/app/scripts/modules/core/application/modal/groupMembershipConfigurer.component.html
+++ b/app/scripts/modules/core/application/modal/groupMembershipConfigurer.component.html
@@ -2,8 +2,6 @@
   <div class="col-sm-3 sm-label-right">Group Membership</div>
   <div class="col-sm-2">
     <ui-select multiple
-               tagging
-               tagging-label=""
                class="form-control input-sm"
                style="width: 200px;"
                ng-model="$ctrl.requiredGroupMembership">


### PR DESCRIPTION
@ttomsu @PerGon please review.

@PerGon this affects the recent work you did on this component. It prevents users from selecting roles they do not have (though the autocomplete functionality still works). 
