### PR TITLE
prefer buildInfoUrl over jenkins details when showing link to ci build

### DIFF
--- a/app/scripts/modules/core/delivery/service/executions.transformer.service.js
+++ b/app/scripts/modules/core/delivery/service/executions.transformer.service.js
@@ -299,7 +299,7 @@ module.exports = angular.module('spinnaker.core.delivery.executionTransformer.se
         let jenkins = deploymentDetails[0].jenkins;
         execution.buildInfo = {
           number: jenkins.number,
-          url: `${jenkins.host}job/${jenkins.name}/${jenkins.number}`
+          url: deploymentDetails[0].buildInfoUrl || `${jenkins.host}job/${jenkins.name}/${jenkins.number}`
         };
       }
     }

--- a/app/scripts/modules/core/delivery/service/executions.transformer.service.spec.js
+++ b/app/scripts/modules/core/delivery/service/executions.transformer.service.spec.js
@@ -307,5 +307,17 @@ describe('executionTransformerService', function() {
       this.transformer.transformExecution({}, execution);
       expect(execution.buildInfo.number).toBe(6);
     });
+
+    it('prefers buildInfoUrl to jenkins details', function () {
+      deployStage = { type: 'deploy', context: {
+        deploymentDetails: [
+          { jenkins: { number: 3, host: 'http://jenkinshost/', name: 'jobName' },
+            buildInfoUrl: "http://custom/url" }
+        ]
+      }};
+      let execution = { stages: [ deployStage ] };
+      this.transformer.transformExecution({}, execution);
+      expect(execution.buildInfo).toEqual({ number: 3, url: 'http://custom/url'});
+    });
   });
 });


### PR DESCRIPTION
This makes buildInfoUrl being preferred over constructing one from the jenkins object.
