### PR TITLE
(netflix) Allow Fast property scope to be updated.

### DIFF
--- a/app/scripts/modules/netflix/fastProperties/domain/propertyCommand.model.spec.ts
+++ b/app/scripts/modules/netflix/fastProperties/domain/propertyCommand.model.spec.ts
@@ -1,5 +1,6 @@
 import {PropertyCommand} from './propertyCommand.model';
 import {PropertyCommandType} from './propertyCommandType.enum';
+import {Scope} from './scope.domain';
 
 describe('propertyCommand model', function () {
 
@@ -34,4 +35,76 @@ describe('propertyCommand model', function () {
       expect(propCommand.submitButtonLabel()).toBe('Submit');
     });
   });
+
+  describe('check to move to new scope', function () {
+    it('is move to new scope if originalScope and selectedScope are different', function () {
+      let command: PropertyCommand = new PropertyCommand();
+      let origScope = new Scope();
+      origScope.env = 'prod';
+      origScope.appId = 'mahe';
+      let selectedScope = new Scope();
+      selectedScope.env = 'prod';
+      selectedScope.appId = 'newApp';
+
+      command.originalScope = origScope;
+      command.scope = selectedScope;
+
+      expect(command.isMoveToNewScope()).toBe(true);
+    });
+
+    it('is not a move to new scope if originalScope and selectedScope are same but have different instance counts', function () {
+      let command: PropertyCommand = new PropertyCommand();
+      let origScope = new Scope();
+      origScope.env = 'prod';
+      origScope.appId = 'mahe';
+      origScope.instanceCounts = {up: 1};
+      let selectedScope = new Scope();
+      selectedScope.env = 'prod';
+      selectedScope.appId = 'mahe';
+      selectedScope.instanceCounts = {up: 99};
+
+      command.originalScope = origScope;
+      command.scope = selectedScope;
+
+      expect(command.isMoveToNewScope()).toBe(false);
+    });
+
+
+    it('is not a move to a new scope if the originalScope and the selected scope are the same ', function () {
+      let command: PropertyCommand = new PropertyCommand();
+      let scope = new Scope();
+      scope.env = 'prod';
+      scope.appId = 'mahe';
+
+      command.originalScope = scope;
+      command.scope = scope;
+
+      expect(command.isMoveToNewScope()).toBe(false);
+    });
+
+    it('is not a move to a new scope if there is no new selected scope', function () {
+      let command: PropertyCommand = new PropertyCommand();
+      let scope = new Scope();
+      scope.env = 'prod';
+      scope.appId = 'mahe';
+
+      command.originalScope = scope;
+      command.scope = null;
+
+      expect(command.isMoveToNewScope()).toBe(false);
+    });
+
+    it('is not a move to a new scope if there is no new scope', function () {
+      let command: PropertyCommand = new PropertyCommand();
+      let scope = new Scope();
+      scope.env = 'prod';
+      scope.appId = 'mahe';
+
+      command.originalScope = null;
+      command.scope = scope;
+
+      expect(command.isMoveToNewScope()).toBe(false);
+    });
+  });
+
 });

--- a/app/scripts/modules/netflix/fastProperties/domain/propertyCommand.model.ts
+++ b/app/scripts/modules/netflix/fastProperties/domain/propertyCommand.model.ts
@@ -1,4 +1,4 @@
-
+import {isEqual, omit} from 'lodash';
 import {Scope} from '../domain/scope.domain';
 import {Property} from '../domain/property.domain';
 import {PropertyPipeline} from './propertyPipeline.domain';
@@ -7,11 +7,13 @@ import {PropertyCommandType} from './propertyCommandType.enum';
 import {IUser} from 'core/authentication/authentication.service';
 import {IAccount} from 'core/account/account.service';
 import {IPlatformProperty} from './platformProperty.model';
+import {PropertyPipelineStage} from './propertyPipelineStage';
 
 export class PropertyCommand {
   public property: Property;
   public originalProperty: Property;
   public scope: Scope;
+  public originalScope: Scope;
   public pipeline: PropertyPipeline;
   public strategy: PropertyStrategy;
   public type: PropertyCommandType;
@@ -24,24 +26,57 @@ export class PropertyCommand {
     this.property = new Property('prod');
   }
 
-  isReadyForStrategy() {
+  public isReadyForStrategy(): boolean {
     return !!(this.property && this.scope);
   }
 
-  isReadyForPipeline() {
-    return this.isReadyForStrategy && this.strategy;
+  public isReadyForPipeline(): boolean {
+    return this.isReadyForStrategy() && !!this.strategy;
   }
 
-  buildPropertyAndScope(platformProperty: IPlatformProperty) {
+  public buildPropertyAndScope(platformProperty: IPlatformProperty) {
     this.property = Property.build(platformProperty);
     this.scope = Scope.build(platformProperty);
+    this.originalScope = Scope.build(platformProperty);
   }
 
-  getTypeAsString() {
+  public buildPropertyStages(user: IUser): PropertyPipelineStage[] {
+    let stages: PropertyPipelineStage[] = [];
+    if (this.isMoveToNewScope()) {
+      let createStage = PropertyPipelineStage.newPropertyStage(user, this);
+      let deleteStage = PropertyPipelineStage.deletePropertyStage(user, this, createStage);
+      stages = [createStage, deleteStage];
+    } else {
+      stages.push(PropertyPipelineStage.upsertPropertyStage(user, this));
+    }
+
+    return stages;
+  }
+
+  public scopeForSubmit(): Scope {
+    return this.scope.forSubmit(this.property.env);
+  }
+
+  public originalScopeForSubmit(): Scope {
+    return this.originalScope ? this.originalScope.forSubmit(this.property.env) : this.scopeForSubmit();
+  }
+
+
+  public isMoveToNewScope(): boolean {
+    if (this.scope && this.originalScope) {
+      return !isEqual(
+        omit(this.scope, ['instanceCounts']),
+        omit(this.originalScope, ['instanceCounts'])
+      );
+    }
+    return false;
+  }
+
+  public getTypeAsString(): string {
     return PropertyCommandType[this.type];
   }
 
-  submitButtonLabel() {
+  public submitButtonLabel(): string {
     let typeAsString = this.getTypeAsString();
     return typeAsString
               ? `${this.getTypeAsString().charAt(0).toUpperCase()}${this.getTypeAsString().slice(1).toLowerCase()}`

--- a/app/scripts/modules/netflix/fastProperties/domain/propertyPipelineStage.ts
+++ b/app/scripts/modules/netflix/fastProperties/domain/propertyPipelineStage.ts
@@ -18,28 +18,74 @@ export class PropertyPipelineStage implements IStage {
   persistedProperties: Property[] = [];
   originalProperties: Property[] = [];
   requisiteStageRefIds: (string | number)[] = [];
+  description: string;
 
-  constructor(user: IUser, command: PropertyCommand, previousStage?: IStage) {
-    let propertyCopy: Property = copy(command.property);
+  static clonePropertyForStage(user: IUser, property: Property): Property {
+    let propertyCopy: Property = copy(property);
     propertyCopy.updatedBy = user.name;
     propertyCopy.cmcTicket = user.name;
 
     delete propertyCopy.env;
 
+    return propertyCopy;
+  }
 
+  static addOriginalProperty(stage: PropertyPipelineStage, command: PropertyCommand): IStage {
+    if (command.originalProperty) {
+      stage.originalProperties.push(command.originalProperty);
+    }
+    return stage;
+  }
+
+  public static newPropertyStage(user: IUser, command: PropertyCommand, previousStage?: IStage): PropertyPipelineStage {
+    let property: Property = PropertyPipelineStage.clonePropertyForStage(user, command.property);
+    property.propertyId = null;
+
+    let scope: Scope = command.scopeForSubmit();
+
+    let stage = new PropertyPipelineStage(property, scope, previousStage);
+    stage.delete = false;
+    stage.description = `Create new property for ${property.key}`;
+
+    PropertyPipelineStage.addOriginalProperty(stage, command);
+
+    return stage;
+  }
+
+  public static deletePropertyStage(user: IUser, command: PropertyCommand, previousStage?: IStage): PropertyPipelineStage {
+    let property: Property = PropertyPipelineStage.clonePropertyForStage(user, command.property);
+    let scope: Scope = command.originalScopeForSubmit();
+    let stage = new PropertyPipelineStage(property, scope, previousStage);
+    stage.delete = true;
+    stage.description = `Deleting property for ${property.key}`;
+    PropertyPipelineStage.addOriginalProperty(stage, command);
+
+    return stage;
+  }
+
+  public static upsertPropertyStage(user: IUser, command: PropertyCommand, previousStage?: IStage): PropertyPipelineStage {
+    let property: Property = PropertyPipelineStage.clonePropertyForStage(user, command.property);
+    let scope: Scope = command.scopeForSubmit();
+    let stage = new PropertyPipelineStage(property, scope, previousStage);
+    stage.delete = command.type === PropertyCommandType.DELETE;
+    stage.description = `Upserting property for ${property.key}`;
+    PropertyPipelineStage.addOriginalProperty(stage, command);
+
+    return stage;
+  }
+
+
+  constructor(property: Property, scope: Scope, previousStage?: IStage) {
     this.refId = previousStage ? `${toInteger(previousStage.refId) + 1}` : '1';
     this.requisiteStageRefIds = previousStage ? [previousStage.refId] : [];
     this.type = 'createProperty';
     this.name = 'Persisted Properties';
-    this.scope = command.scope.forSubmit(command.property.env);
-    this.email = propertyCopy.email;
-    this.cmcTicket = propertyCopy.cmcTicket;
-    this.delete = command.type === PropertyCommandType.DELETE;
+    this.email = property.email;
+    this.cmcTicket = property.cmcTicket;
 
-    if (command.originalProperty) {
-      this.originalProperties.push(command.originalProperty);
-    }
-    this.persistedProperties.push(propertyCopy);
+    this.scope = scope;
+    this.persistedProperties.push(property);
   }
+
 
 }

--- a/app/scripts/modules/netflix/fastProperties/wizard/deleteFastPropertyWizard.controller.ts
+++ b/app/scripts/modules/netflix/fastProperties/wizard/deleteFastPropertyWizard.controller.ts
@@ -1,7 +1,7 @@
 import {module} from 'angular';
 
 import { FAST_PROPERTY_DETAILS_COMPONENT } from './propertyDetails/propertyDetails.componet';
-import { FAST_PROPERTY_SCOPE_READ_ONLY_COMPONENT } from './propertyScope/propertyScopeReadOnly.componet';
+import { FAST_PROPERTY_SCOPE_READ_ONLY_COMPONENT } from './propertyScope/propertyScopeReadOnly.component';
 import { FAST_PROPERTY_REVIEW_COMPONENT } from './propertyReview/propertyReview.componet';
 import { FAST_PROPERTY_STRATEGY_COMPONENT } from './propertyStrategy/propertyStrategy.componet';
 import { PropertyCommandType }from '../domain/propertyCommandType.enum';

--- a/app/scripts/modules/netflix/fastProperties/wizard/propertyReview/propertyReview.component.html
+++ b/app/scripts/modules/netflix/fastProperties/wizard/propertyReview/propertyReview.component.html
@@ -52,7 +52,10 @@
       <b>{{$ctrl.command.strategy.displayName}}</b> used to create a pipeline with <b class="attention">{{$ctrl.command.pipeline.stages.length}}</b> stage(s):
 
       <ul>
-        <li ng-repeat="stage in $ctrl.command.pipeline.stages"><b>{{stage.name}}</b></li>
+        <li ng-repeat="stage in $ctrl.command.pipeline.stages">
+          <b>{{stage.name}}</b>
+          <span ng-if="stage.description">({{stage.description}})</span>
+        </li>
       </ul>
 
     </div>

--- a/app/scripts/modules/netflix/fastProperties/wizard/propertyScope/propertyScope.component.ts
+++ b/app/scripts/modules/netflix/fastProperties/wizard/propertyScope/propertyScope.component.ts
@@ -1,10 +1,10 @@
-import { module } from 'angular';
+import { module, IComponentController, IComponentOptions} from 'angular';
 import { FAST_PROPERTY_SCOPE_SEARCH_COMPONENT } from '../../scope/fastPropertyScopeSearch.component';
 import { FAST_PROPERTY_READ_SERVICE } from '../../fastProperty.read.service';
 import {PropertyCommand} from '../../domain/propertyCommand.model';
 import {Scope} from '../../domain/scope.domain';
 
-export class FastPropertyScopeComponentController implements ng.IComponentController {
+export class FastPropertyScopeComponentController implements IComponentController {
   public isEditing = false;
   public impactCount: string;
   public impactLoading: boolean;
@@ -22,7 +22,7 @@ export class FastPropertyScopeComponentController implements ng.IComponentContro
   }
 }
 
-class FastPropertyScopeComponent implements ng.IComponentOptions {
+class FastPropertyScopeComponent implements IComponentOptions {
   public templateUrl: string = require('./propertyScope.component.html');
   public controller: any = FastPropertyScopeComponentController;
   public bindings: any = {

--- a/app/scripts/modules/netflix/fastProperties/wizard/propertyScope/propertyScopeReadOnly.component.ts
+++ b/app/scripts/modules/netflix/fastProperties/wizard/propertyScope/propertyScopeReadOnly.component.ts
@@ -20,14 +20,12 @@ export class FastPropertyScopeReadOnlyComponentController implements ng.ICompone
     ];
   }
 
-  constructor(
-    fastPropertyScopeSearchCategoryService: any ) {
+  constructor(fastPropertyScopeSearchCategoryService: any ) {
     fastPropertyScopeSearchCategoryService.getImpactForScope(this.command.scope)
       .then((counts: IImpactCounts) => {
         this.command.scope.instanceCounts = counts;
         return this.command.scope;
       });
-
   }
 
   public selectScope(scopeOption: Scope) {

--- a/app/scripts/modules/netflix/fastProperties/wizard/propertyScope/propertyScopeUpdatable.component.html
+++ b/app/scripts/modules/netflix/fastProperties/wizard/propertyScope/propertyScopeUpdatable.component.html
@@ -1,0 +1,225 @@
+<form role="form" novalidate name="fastPropertyScopeForm">
+  <div class="modal-body">
+    <div class="row" style="display: flex; flex-wrap: wrap">
+
+      <p>Setting the <b>scope</b> of a property determines what instances will have access to a given property.</p>
+      <p>
+        Properties can be scoped to a <b>Region, Application, Cluster, ASG, or Instance</b>.  Properties can also be scoped
+        <b>Globally</b> but it is considered bad practice unless absolutely necessary.
+      </p>
+
+      <p>
+        Enter an <b>Application, Cluster, ASG, or Instance</b> to get a list of scopes
+        and the number of potential instances that scope will impact.
+      </p>
+      <!--
+        LEFT COLUMN
+        Only rendered if the form is creating a new FP
+      -->
+      <div class="col-md-7" style="display: flex; flex-direction: column">
+
+        <div class="row">
+          <div class="col-md-12">
+            <fast-property-scope-search-component
+              on-scope-selected="$ctrl.selectScope(scopeOption)"
+              application-name="$ctrl.command.applicationName"
+              env="{{$ctrl.command.property.env}}">
+            </fast-property-scope-search-component>
+          </div>
+        </div>
+
+      </div>
+
+      <!--
+       RIGHT COLUMN
+       -->
+      <div class="col-md-5">
+        <h3>Original Scope</h3>
+        <div class="row" ng-if="$ctrl.command.originalScope">
+          <div class="col-md-9">
+            <h4 ng-if="$ctrl.command.originalScope.instanceCounts">
+              Impact Count:
+              <span class="attention">{{$ctrl.command.originalScope.instanceCounts.up}}</span>
+            </h4>
+          </div>
+        </div>
+        <table class="table table-hover">
+          <tbody>
+          <tr ng-if="$ctrl.command.originalScope.env">
+            <td><b>Env</b></td>
+            <td>{{$ctrl.command.originalScope.env}}</td>
+          </tr>
+          <tr ng-if="$ctrl.command.originalScope.appId">
+            <td><b>Apps</b></td>
+            <td>{{$ctrl.command.originalScope.appId}}</td>
+          </tr>
+          <tr ng-if="$ctrl.command.originalScope.region">
+            <td><b>Region</b></td>
+            <td>{{$ctrl.command.originalScope.region}}</td>
+          </tr>
+          <tr ng-if="$ctrl.command.originalScope.stack">
+            <td><b>Stack</b></td>
+            <td>{{$ctrl.command.originalScope.stack}}</td>
+          </tr>
+          <tr ng-if="$ctrl.command.originalScope.cluster">
+            <td><b>Cluster</></td>
+            <td>{{$ctrl.command.originalScope.cluster}}</td>
+          </tr>
+          <tr ng-if="$ctrl.command.originalScope.asg">
+            <td><b>ASG</b></td>
+            <td>{{$ctrl.command.originalScope.asg}}</td>
+          </tr>
+          <tr ng-if="$ctrl.command.originalScope.zone">
+            <td><b>Zone</b></td>
+            <td>{{$ctrl.command.originalScope.zone}}</td>
+          </tr>
+          <tr ng-if="$ctrl.command.originalScope.serverId">
+            <td><b>Instance</b></td>
+            <td>{{$ctrl.command.originalScope.serverId}}</td>
+          </tr>
+          </tbody>
+        </table>
+
+
+        <h3 ng-if="$ctrl.selectedScope">New Scope</h3>
+        <div class="row" ng-if="$ctrl.selectedScope">
+          <div class="col-md-9">
+            <h4 ng-if="$ctrl.selectedScope.instanceCounts">
+              Impact Count:
+              <span class="attention">{{$ctrl.selectedScope.instanceCounts.up}}</span>
+            </h4>
+          </div>
+          <div class="col-md-3">
+            <a
+              href
+              class="btn btn-link"
+              ng-if="!$ctrl.isEditing"
+              ng-click="$ctrl.toggleEditScope()">
+              <i class="fa fa-edit"></i>
+            </a>
+          </div>
+        </div>
+        <div>
+          <table class="table table-hover" style="margin-bottom: 5px" >
+            <tbody>
+            <tr ng-if="$ctrl.selectedScope.env">
+              <td><b>Env</b></td>
+              <td> {{$ctrl.selectedScope.env}} </td>
+            </tr>
+            <tr ng-if="$ctrl.selectedScope.appId">
+              <td><b>Apps</b></td>
+              <td>
+                <span ng-if="!$ctrl.isEditing">
+                  {{$ctrl.selectedScope.appId}}
+                </span>
+                <input
+                  class="form-control"
+                  ng-if="$ctrl.isEditing"
+                  type="text" ng-model="$ctrl.selectedScope.appId">
+              </td>
+            </tr>
+            <tr ng-if="$ctrl.selectedScope.region">
+              <td><b>Region</b></td>
+              <td>
+                <span ng-if="!$ctrl.isEditing">
+                  {{$ctrl.selectedScope.region}}
+                </span>
+                <input
+                  class="form-control"
+                  ng-if="$ctrl.isEditing"
+                  type="text" ng-model="$ctrl.selectedScope.region">
+              </td>
+            </tr>
+            <tr ng-if="$ctrl.selectedScope.stack">
+              <td><b>Stack</b></td>
+              <td>
+                <span ng-if="!$ctrl.isEditing">
+                  {{$ctrl.selectedScope.stack}}
+                </span>
+                <input
+                  class="form-control"
+                  ng-if="$ctrl.isEditing"
+                  type="text" ng-model="$ctrl.selectedScope.stack">
+              </td>
+            </tr>
+            <tr ng-if="$ctrl.selectedScope.cluster">
+              <td><b>Cluster</b></td>
+              <td>
+                <span ng-if="!$ctrl.isEditing">
+                  {{$ctrl.selectedScope.cluster}}
+                </span>
+                <input
+                  class="form-control"
+                  ng-if="$ctrl.isEditing"
+                  type="text" ng-model="$ctrl.selectedScope.cluster">
+              </td>
+
+            </tr>
+            <tr ng-if="$ctrl.selectedScope.asg">
+              <td><b>ASG</b></td>
+              <td>
+                <span ng-if="!$ctrl.isEditing">
+                  {{$ctrl.selectedScope.asg}}
+                </span>
+                <input
+                  class="form-control"
+                  ng-if="$ctrl.isEditing"
+                  type="text" ng-model="$ctrl.selectedScope.asg">
+              </td>
+            </tr>
+            <tr ng-if="$ctrl.selectedScope.zone">
+              <td><b>Zone</b></td>
+              <td>
+                <span ng-if="!$ctrl.isEditing">
+                  {{$ctrl.selectedScope.zone}}
+                </span>
+                <input
+                  class="form-control"
+                  ng-if="$ctrl.isEditing"
+                  type="text" ng-model="$ctrl.selectedScope.zone">
+              </td>
+            </tr>
+            <tr ng-if="$ctrl.selectedScope.serverId">
+              <td><b>Instance</b></td>
+              <td>
+                <span ng-if="!$ctrl.isEditing">
+                  {{$ctrl.selectedScope.serverId}}
+                </span>
+                <input
+                  class="form-control"
+                  ng-if="$ctrl.isEditing"
+                  type="text" ng-model="$ctrl.selectedScope.serverId">
+              </td>
+            </tr>
+            </tbody>
+          </table>
+          <button
+            class="btn btn-primary btn-xs"
+            ng-if="$ctrl.isEditing"
+            ng-click="$ctrl.toggleEditScope()"
+            type="button">
+            Save Scope
+          </button>
+          <button
+            class="btn btn-default btn-xs"
+            ng-if="$ctrl.selectedScope"
+            ng-click="$ctrl.removeNewScope()"
+            type="button">
+            Remove new scope
+          </button>
+        </div>
+      </div>
+
+    <!--
+      ERROR MESSAGES
+    -->
+    <div class="form-group row slide-in" ng-if="fastPropertyScopeForm.$invalid">
+      <div class="col-sm-8 col-sm-offset-4 error-message">
+        <div ng-messages="fastPropertyScopeForm.region.$error" ng-if="fastPropertyScopeForm.region.$touched">
+          <p ng-message="required">Select region</p>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</form>

--- a/app/scripts/modules/netflix/fastProperties/wizard/propertyScope/propertyScopeUpdatable.component.ts
+++ b/app/scripts/modules/netflix/fastProperties/wizard/propertyScope/propertyScopeUpdatable.component.ts
@@ -1,0 +1,59 @@
+import { module, IComponentController, IComponentOptions} from 'angular';
+import { FAST_PROPERTY_SCOPE_SEARCH_CATEGORY_SERVICE, FastPropertyScopeCategoryService } from '../../scope/fastPropertyScopeSearchCategory.service';
+import { FAST_PROPERTY_READ_SERVICE } from '../../fastProperty.read.service';
+import {PropertyCommand} from '../../domain/propertyCommand.model';
+import {Scope} from '../../domain/scope.domain';
+import {IImpactCounts} from '../../domain/impactCounts.interface';
+
+export class FastPropertyScopeReadOnlyComponentController implements IComponentController {
+  public isEditing = false;
+  public impactCount: string;
+  public selectedScope: any;
+  public command: PropertyCommand;
+
+
+  static get $inject() {
+    return [
+      'fastPropertyScopeSearchCategoryService',
+    ];
+  }
+
+  constructor(fastPropertyScopeSearchCategoryService: FastPropertyScopeCategoryService) {
+    fastPropertyScopeSearchCategoryService.getImpactForScope(this.command.originalScope)
+      .then((counts: IImpactCounts) => {
+        this.command.originalScope.instanceCounts = counts;
+        return this.command.originalScope;
+      });
+  }
+
+  public selectScope(scopeOption: Scope): void {
+    this.selectedScope = scopeOption.copy();
+    this.command.scope = this.selectedScope;
+  }
+
+  public toggleEditScope(): void {
+    this.isEditing = !this.isEditing;
+  }
+
+  public removeNewScope(): void {
+    this.selectedScope = null;
+    this.command.scope = this.command.originalScope.copy();
+  }
+}
+
+class FastPropertyScopeReadOnlyComponent implements IComponentOptions {
+  public templateUrl: string = require('./propertyScopeUpdatable.component.html');
+  public controller: any = FastPropertyScopeReadOnlyComponentController;
+  public bindings: any = {
+    command: '='
+  };
+}
+
+export const FAST_PROPERTY_SCOPE_UPDATABLE_COMPONENT = 'spinnaker.netflix.fastProperty.scope.updatable.component';
+
+module(FAST_PROPERTY_SCOPE_UPDATABLE_COMPONENT, [
+  require('core/search/searchResult/searchResult.directive'),
+  FAST_PROPERTY_READ_SERVICE,
+  FAST_PROPERTY_SCOPE_SEARCH_CATEGORY_SERVICE
+])
+  .component('fastPropertyScopeUpdatable', new FastPropertyScopeReadOnlyComponent());

--- a/app/scripts/modules/netflix/fastProperties/wizard/updateFastPropertyWizard.controller.ts
+++ b/app/scripts/modules/netflix/fastProperties/wizard/updateFastPropertyWizard.controller.ts
@@ -1,8 +1,8 @@
-import {module} from 'angular';
+import {module, IScope} from 'angular';
 
-import IModalServiceInstance = angular.ui.bootstrap.IModalServiceInstance;
+import { IModalServiceInstance } from 'angular-ui-bootstrap';
 import { FAST_PROPERTY_DETAILS_COMPONENT } from './propertyDetails/propertyDetails.componet';
-import { FAST_PROPERTY_SCOPE_READ_ONLY_COMPONENT } from './propertyScope/propertyScopeReadOnly.componet';
+import { FAST_PROPERTY_SCOPE_UPDATABLE_COMPONENT } from './propertyScope/propertyScopeUpdatable.component';
 import { FAST_PROPERTY_REVIEW_COMPONENT } from './propertyReview/propertyReview.componet';
 import { FAST_PROPERTY_STRATEGY_COMPONENT } from './propertyStrategy/propertyStrategy.componet';
 import { APPLICATION_READ_SERVICE, ApplicationReader } from 'core/application/service/application.read.service';
@@ -36,7 +36,7 @@ class UpdateFastPropertyWizardController {
   };
 
   constructor (
-    public $scope: ng.IScope,
+    public $scope: IScope,
     public $uibModalInstance: IModalServiceInstance,
     public title: string,
     public applicationName: string,
@@ -82,7 +82,7 @@ export const UPDATE_FAST_PROPERTY_WIZARD_CONTROLLER = 'spinnaker.netflix.fastPro
 
 module(UPDATE_FAST_PROPERTY_WIZARD_CONTROLLER, [
   FAST_PROPERTY_DETAILS_COMPONENT,
-  FAST_PROPERTY_SCOPE_READ_ONLY_COMPONENT,
+  FAST_PROPERTY_SCOPE_UPDATABLE_COMPONENT,
   FAST_PROPERTY_STRATEGY_COMPONENT,
   FAST_PROPERTY_REVIEW_COMPONENT,
   APPLICATION_READ_SERVICE,

--- a/app/scripts/modules/netflix/fastProperties/wizard/updateFastPropertyWizard.html
+++ b/app/scripts/modules/netflix/fastProperties/wizard/updateFastPropertyWizard.html
@@ -13,7 +13,7 @@
       </v2-wizard-page>
 
       <v2-wizard-page key="scope" label="Scope" mark-complete-on-view="false">
-        <fast-property-scope-read-only command="ctrl.command"></fast-property-scope-read-only>
+        <fast-property-scope-updatable command="ctrl.command"></fast-property-scope-updatable>
       </v2-wizard-page>
 
       <v2-wizard-page key="strategy" label="Strategy" mark-complete-on-view="false">


### PR DESCRIPTION
Once a Fast Property has been set the scope can't be easily updated b/c the key of the
Property is a pipe delimited string of the property key and all the values of its scope.

To get around that limitation we create 2 Persisted property stages.  The first one will
create a new property with the new scope.  Once that completes we follow up with a delete property
stage that cleans up the original property.

When editing the property the user will be shown the original scope and they will be able to select the new scope.  If they choose to update the scope they can remove it and only an upsert property stage will be used.

@anotherchrisberry @icfantv @jrsquared  PTAL