### PR TITLE
fix(serverGroups): cluster disable warning update

### DIFF
--- a/app/scripts/modules/core/serverGroup/details/serverGroupWarningMessage.service.spec.ts
+++ b/app/scripts/modules/core/serverGroup/details/serverGroupWarningMessage.service.spec.ts
@@ -150,6 +150,35 @@ describe('serverGroupWarningMessageService', () => {
       expect(params.account).toBeUndefined();
     });
 
+    it('adds warning if it\'s the last active ASG', () => {
+      serverGroup = {
+        account: 'test',
+        cloudProvider: 'aws',
+        cluster: 'foo',
+        instanceCounts: { up: 1, down: 0, succeeded: 0, failed: 0, unknown: 0, outOfService: 0 },
+        instances: [{id: 'a', launchTime: 1, zone: 'b', health: null}],
+        name: 'foo-v000',
+        region: 'us-east-1',
+        type: 'a'
+      };
+
+      app.clusters = [
+        {
+          name: 'foo',
+          account: 'test',
+          cloudProvider: '',
+          category: '',
+          serverGroups: [serverGroup]
+        }
+      ];
+      const params: IConfirmationModalParams = {account: 'prod'};
+      service.addDisableWarningMessage(app, serverGroup, params);
+      expect(params.body).toBeDefined();
+      expect(params.body.includes('<li>')).toBe(false);
+      expect(params.textToVerify).toBe('0');
+      expect(params.account).toBeUndefined();
+    });
+
     it('adds remaining server groups to the body if they have up instances, removes account from params', () => {
       serverGroup = {
         account: 'test',

--- a/app/scripts/modules/core/serverGroup/details/serverGroupWarningMessage.service.ts
+++ b/app/scripts/modules/core/serverGroup/details/serverGroupWarningMessage.service.ts
@@ -32,12 +32,12 @@ export class ServerGroupWarningMessageService {
       return;
     }
 
-    const remainingActiveServerGroups: ServerGroup[] = this.getOtherServerGroupsInCluster(application, serverGroup)
-      .filter(s => !s.isDisabled && s.instanceCounts.up > 0);
+    const otherServerGroupsInCluster: ServerGroup[] = this.getOtherServerGroupsInCluster(application, serverGroup);
+    const remainingActiveServerGroups: ServerGroup[] =
+      otherServerGroupsInCluster.filter(s => !s.isDisabled && s.instanceCounts.up > 0);
+    const hasOtherInstances = otherServerGroupsInCluster.some(s => s.instances.length > 0);
 
-    const hasOtherInstances = this.getOtherServerGroupsInCluster(application, serverGroup).some(s => s.instances.length > 0);
-
-    if (hasOtherInstances) {
+    if (hasOtherInstances || remainingActiveServerGroups.length === 0 || otherServerGroupsInCluster.length === 0) {
       const totalActiveInstances = remainingActiveServerGroups.reduce((acc: number, s: ServerGroup) => {
         return s.instanceCounts.up + acc;
       }, serverGroup.instanceCounts.up);


### PR DESCRIPTION
* updated sensitivity around disabling clusters.  specifically, added
checks for corner cases such that a cluster could be disabled and the
user not given added context as to the ramifications of the disable
action.  this change now adds checks for if it's the last active cluster
or if it's the only cluster remaining.
