### PR TITLE
refactor(gce) makes autoHealing configurer generic

### DIFF
--- a/app/scripts/modules/google/domain/autoHealingPolicy.ts
+++ b/app/scripts/modules/google/domain/autoHealingPolicy.ts
@@ -1,0 +1,10 @@
+export interface IGceAutoHealingPolicy {
+  healthCheck?: string;
+  initialDelaySec?: number;
+  maxUnavailable?: IMaxUnavailable;
+}
+
+interface IMaxUnavailable {
+  fixed?: number;
+  percent?: number;
+}

--- a/app/scripts/modules/google/domain/index.ts
+++ b/app/scripts/modules/google/domain/index.ts
@@ -3,3 +3,4 @@ export * from './healthCheck';
 export * from './subnet';
 export * from './network';
 export * from './loadBalancer';
+export * from './autoHealingPolicy';

--- a/app/scripts/modules/google/serverGroup/configure/wizard/autoHealingPolicy/autoHealingPolicy.html
+++ b/app/scripts/modules/google/serverGroup/configure/wizard/autoHealingPolicy/autoHealingPolicy.html
@@ -1,1 +1,16 @@
-<gce-auto-healing-policy-selector command="command"><gce-auto-healing-policy-selector>
+<div class="form-group">
+  <div class="col-md-3 sm-label-right">
+    <b>Enable AutoHealing</b>
+  </div>
+  <div class="col-md-6 checkbox">
+    <label>
+      <input type="checkbox" ng-model="command.enableAutoHealing"/>
+    </label>
+  </div>
+</div>
+<gce-auto-healing-policy-selector ng-if="command.enableAutoHealing"
+                                  on-health-check-refresh="ctrl.onHealthCheckRefresh()"
+                                  set-auto-healing-policy="ctrl.setAutoHealingPolicy(autoHealingPolicy)"
+                                  http-health-checks="command.backingData.filtered.httpHealthChecks"
+                                  enabled="command.enableAutoHealing"
+                                  auto-healing-policy="command.autoHealingPolicy"></gce-auto-healing-policy-selector>

--- a/app/scripts/modules/google/serverGroup/configure/wizard/autoHealingPolicy/autoHealingPolicySelector.component.html
+++ b/app/scripts/modules/google/serverGroup/configure/wizard/autoHealingPolicy/autoHealingPolicySelector.component.html
@@ -1,28 +1,18 @@
 <ng-form name="autoHealingPolicySubForm">
   <div class="form-group">
     <div class="col-md-3 sm-label-right">
-      <b>Enable AutoHealing</b>
-    </div>
-    <div class="col-md-6 checkbox">
-      <label>
-        <input type="checkbox" ng-model="$ctrl.command.enableAutoHealing" ng-change="$ctrl.setAutoHealing()"/>
-      </label>
-    </div>
-  </div>
-  <div class="form-group" ng-if="$ctrl.command.enableAutoHealing">
-    <div class="col-md-3 sm-label-right">
       <b>HTTP Health Check</b>
     </div>
     <div class="col-md-6">
-      <ui-select ng-model="$ctrl.command.autoHealingPolicy.healthCheck" class="form-control input-sm" required>
+      <ui-select ng-model="$ctrl.autoHealingPolicy.healthCheck" class="form-control input-sm" required>
         <ui-select-match placeholder="Select...">{{$select.selected}}</ui-select-match>
-        <ui-select-choices repeat="httpHealthCheck in $ctrl.command.backingData.filtered.httpHealthChecks | filter: $select.search">
+        <ui-select-choices repeat="httpHealthCheck in $ctrl.httpHealthChecks | filter: $select.search">
           <span ng-bind-html="httpHealthCheck | highlight: $select.search"></span>
         </ui-select-choices>
       </ui-select>
     </div>
   </div>
-  <div class="form-group" ng-if="$ctrl.command.enableAutoHealing">
+  <div class="form-group">
     <div class="col-md-3 sm-label-right">
       <b>Initial Delay</b>
     </div>
@@ -30,7 +20,7 @@
       <div class="input-group">
     		<input type="number"
     			class="form-control input-sm"
-    			ng-model="$ctrl.command.autoHealingPolicy.initialDelaySec"
+    			ng-model="$ctrl.autoHealingPolicy.initialDelaySec"
     			min="0"
     			max="2147483647"
     			required/>
@@ -38,7 +28,7 @@
       </div>
   	</div>
   </div>
-  <div class="form-group" ng-if="$ctrl.command.enableAutoHealing" ng-switch on="$ctrl.command.viewState.maxUnavailableMetric">
+  <div class="form-group" ng-switch on="$ctrl.viewState.maxUnavailableMetric">
     <div class="col-md-3 sm-label-right">
       <b>Max Unavailable <help-field key="gce.serverGroup.maxUnavailable"></help-field></b>
     </div>
@@ -50,7 +40,7 @@
     <div class="col-md-3" ng-switch-when="percent">
       <div class="input-group">
         <input class="form-control input-sm"
-               ng-model="$ctrl.command.autoHealingPolicy.maxUnavailable.percent"
+               ng-model="$ctrl.autoHealingPolicy.maxUnavailable.percent"
                required
                type="number" min="0" max="100"/>
         <span class="input-group-addon">%</span>
@@ -59,24 +49,24 @@
     <div class="col-md-3" ng-switch-when="fixed">
       <input class="form-control input-sm"
              required
-             ng-model="$ctrl.command.autoHealingPolicy.maxUnavailable.fixed"
+             ng-model="$ctrl.autoHealingPolicy.maxUnavailable.fixed"
              type="number" min="0" max="2147483647"/>
     </div>
     <div class="col-md-3">
-      <select ng-model="$ctrl.command.viewState.maxUnavailableMetric"
-              ng-change="$ctrl.manageMaxUnavailableMetric($ctrl.command.viewState.maxUnavailableMetric)"
+      <select ng-model="$ctrl.viewState.maxUnavailableMetric"
+              ng-change="$ctrl.manageMaxUnavailableMetric($ctrl.viewState.maxUnavailableMetric)"
               ng-options="metric for metric in ['percent', 'fixed']"
               class="form-control input-sm">
         <option value="">-- select metric --</option>
       </select>
     </div>
   </div>
-  <div class="form-group small" style="margin-top: 20px" ng-if="$ctrl.command.enableAutoHealing">
+  <div class="form-group small" style="margin-top: 20px">
     <div class="col-md-6 col-md-offset-3">
       <gce-cache-refresh cache-key="httpHealthChecks"
-                         cache-key-alias="http health checks" 
+                         cache-key-alias="http health checks"
                          on-refresh="$ctrl.onHealthCheckRefresh()">
-      </gce-cache-refresh>  
+      </gce-cache-refresh>
     </div>
   </div>
 </ng-form>

--- a/app/scripts/modules/google/serverGroup/configure/wizard/cloneServerGroup.gce.controller.js
+++ b/app/scripts/modules/google/serverGroup/configure/wizard/cloneServerGroup.gce.controller.js
@@ -338,6 +338,14 @@ module.exports = angular.module('spinnaker.serverGroup.configure.gce.cloneServer
       );
     };
 
+    this.onHealthCheckRefresh = function() {
+      gceServerGroupConfigurationService.refreshHttpHealthChecks($scope.command);
+    };
+
+    this.setAutoHealingPolicy = function(autoHealingPolicy) {
+      $scope.command.autoHealingPolicy = autoHealingPolicy;
+    };
+
     this.cancel = function () {
       $uibModalInstance.dismiss();
     };


### PR DESCRIPTION
Pulls out all of the server group wizard-specific pieces from the auto healing policy configurer. There should be no changes in functionality or appearance.

Tested this manually for create/clone/pipeline deploy stages.

@duftler or @jtk54 please review.