### PR TITLE
fix(canary): do not break on canary expressions

### DIFF
--- a/app/scripts/modules/netflix/pipeline/stage/canary/canaryScore.component.ts
+++ b/app/scripts/modules/netflix/pipeline/stage/canary/canaryScore.component.ts
@@ -1,3 +1,4 @@
+import {isString} from 'lodash';
 import {module} from 'angular';
 
 require('./canary.less');
@@ -11,10 +12,19 @@ class CanaryScoreConfigComponentCtrl implements ng.IComponentController {
   public successful: number;
   public unhealthy: number;
   public invalid = false;
+  public hasExpressions = false;
+
+  private isExpression(scoreValue: string): boolean {
+    return isString(scoreValue) && scoreValue.includes('${');
+  }
 
   public $onInit() {
-    this.successful = parseInt(this.successfulScore, 10);
-    this.unhealthy = parseInt(this.unhealthyScore, 10);
+    if (this.isExpression(this.unhealthyScore) || this.isExpression(this.successfulScore)) {
+      this.hasExpressions = true;
+    } else {
+      this.successful = parseInt(this.successfulScore, 10);
+      this.unhealthy = parseInt(this.unhealthyScore, 10);
+    }
   }
 
   public onUpdate() {
@@ -37,7 +47,15 @@ class CanaryScoreConfigComponent implements ng.IComponentOptions {
   };
   public controller: any = CanaryScoreConfigComponentCtrl;
   public template = `
-    <div class="canary-score">
+    <div ng-if="$ctrl.hasExpressions" class="form-group">
+      <div class="col-md-2 col-md-offset-1 sm-label-right">
+        <label>Canary Scores</label>
+      </div>
+      <div class="col-md-9 form-control-static">
+        Expressions are currently being used for canary scores.
+      </div>
+    </div>
+    <div class="canary-score" ng-if="!$ctrl.hasExpressions">
       <div class="form-group">
         <div class="col-md-2 col-md-offset-1 sm-label-right">
           <label>Unhealthy Score</label>
@@ -78,7 +96,7 @@ class CanaryScoreConfigComponent implements ng.IComponentOptions {
         </div>
       </div>
     </div>
-`;
+  `;
 }
 
 export const CANARY_SCORE_CONFIG_COMPONENT = 'spinnaker.netflix.canary.score.component';

--- a/app/scripts/modules/netflix/pipeline/stage/canary/canaryStage.html
+++ b/app/scripts/modules/netflix/pipeline/stage/canary/canaryStage.html
@@ -137,15 +137,20 @@
   <stage-config-field ng-if="stage.canary.canaryConfig.canaryAnalysisConfig.useLookback">
     <div class="form-group">
       <div class="col-md-9">
-        with a look-back duration of
-        <input type="number"
-               min="1"
-               max="{{stage.canary.canaryConfig.lifetimeHours * 60}}"
-               ng-required="stage.canary.canaryConfig.canaryAnalysisConfig.useLookback"
-               ng-disabled="!stage.canary.canaryConfig.canaryAnalysisConfig.useLookback"
-               ng-model="stage.canary.canaryConfig.canaryAnalysisConfig.lookbackMins"
-               class="form-control input-sm" style="display: inline-block; margin: 0 5px; width: 15%"/>
-        minutes
+        <p class="form-control-static" ng-if='isExpression(stage.canary.canaryConfig.canaryAnalysisConfig.lookbackMins)'>
+          Using a sliding lookback duration defined by an expression viewable in the pipeline JSON editor.
+        </p>
+        <span ng-if="!isExpression(stage.canary.canaryConfig.canaryAnalysisConfig.lookbackMins)">
+          with a look-back duration of
+          <input type="number"
+                 min="1"
+                 max="{{stage.canary.canaryConfig.lifetimeHours * 60}}"
+                 ng-required="stage.canary.canaryConfig.canaryAnalysisConfig.useLookback"
+                 ng-disabled="!stage.canary.canaryConfig.canaryAnalysisConfig.useLookback"
+                 ng-model="stage.canary.canaryConfig.canaryAnalysisConfig.lookbackMins"
+                 class="form-control input-sm" style="display: inline-block; margin: 0 5px; width: 15%"/>
+          minutes
+        </span>
       </div>
     </div>
     <div class="error-message col-md-12"
@@ -169,14 +174,20 @@
     <input type="text" ng-model="canaryStageCtrl.notificationHours"
            class="form-control input-sm" ng-change="canaryStageCtrl.splitNotificationHours()"/>
   </stage-config-field>
-  <stage-config-field label="Report Frequency" help-key="pipeline.config.canary.canaryInterval" field-columns="3">
-    <input type="number"
-           required
-           min="1"
-           max="{{stage.canary.canaryConfig.lifetimeHours * 60}}"
-           ng-model="stage.canary.canaryConfig.canaryAnalysisConfig.canaryAnalysisIntervalMins"
-           class="form-control input-sm" style="width: 33%; display: inline-block"/>
-    <span class="form-control-static"> minutes</span>
+  <stage-config-field label="Report Frequency" help-key="pipeline.config.canary.canaryInterval" field-columns="9">
+    <p class="form-control-static"
+          ng-if="isExpression(stage.canary.canaryConfig.canaryAnalysisConfig.canaryAnalysisIntervalMins)">
+      The report frequency is defined via an expression in the pipeline JSON editor.
+    </p>
+    <span ng-if="!isExpression(stage.canary.canaryConfig.canaryAnalysisConfig.canaryAnalysisIntervalMins)">
+      <input type="number"
+             required
+             min="1"
+             max="{{stage.canary.canaryConfig.lifetimeHours * 60}}"
+             ng-model="stage.canary.canaryConfig.canaryAnalysisConfig.canaryAnalysisIntervalMins"
+             class="form-control input-sm" style="width: 33%; display: inline-block"/>
+      <span class="form-control-static"> minutes</span>
+    </span>
   </stage-config-field>
   <stage-config-field label="Report Email" key="pipeline.config.canary.owner">
     <input type="email" required ng-model="stage.canary.owner"
@@ -222,7 +233,10 @@
   </div>
   <div class="form-group">
     <div class="col-md-11 col-md-offset-1">
-      <div class="checkbox">
+      <div ng-if="isExpression(stage.scaleUp.delay) || isExpression(stage.scaleUp.capacity)">
+        This canary stage has a scale up delay or capacity defined via an expression in the pipeline JSON editor.
+      </div>
+      <div class="checkbox" ng-if="!isExpression(stage.scaleUp.delay) && !isExpression(stage.scaleUp.capacity)">
         <label>
           <input type="checkbox"
                  style="margin-top: 8px;"


### PR DESCRIPTION
* add very rudimentary support to indicate the user that they're using
expressions for canary field values but do not allow them to edit it
directly.  rather, we want them to edit via the pipeline JSON editor.
* do not barf on loading canary stages using expressions as canary field
values.
