### PR TITLE
(core, SPIN-2438) Fix Pipeline Details Toggle

### DIFF
--- a/app/scripts/modules/core/delivery/executionGroup/execution/execution.directive.js
+++ b/app/scripts/modules/core/delivery/executionGroup/execution/execution.directive.js
@@ -46,7 +46,7 @@ module.exports = angular
     };
 
     this.toggleDetails = (node) => {
-      if (node.index === undefined && $state.current.name.includes('.executions.execution')) {
+      if (node.executionId === $state.params.executionId && $state.current.name.includes('.executions.execution')) {
         $state.go('^');
         return;
       }


### PR DESCRIPTION
The "Details" toggle in the pipelines tab would open the first time you clicked it and then if
the "Details" link on another pipeline was click all the details sections of all the pipelines would close.
One would then have to re-click the "Details" link to open up the details view.

This fixs the toggle to be inline with expected behavior.