### PR TITLE
(core, SPIN-2438) Re-fix Pipeline Details Toggle

### DIFF
--- a/app/scripts/modules/core/delivery/executionGroup/execution/execution.directive.js
+++ b/app/scripts/modules/core/delivery/executionGroup/execution/execution.directive.js
@@ -46,7 +46,7 @@ module.exports = angular
     };
 
     this.toggleDetails = (node) => {
-      if (node.executionId === $state.params.executionId && $state.current.name.includes('.executions.execution')) {
+      if (node.executionId === $state.params.executionId && $state.current.name.includes('.executions.execution') && node.index === undefined) {
         $state.go('^');
         return;
       }


### PR DESCRIPTION
Fixes the details toggle when clicking on the stages and stage nodes.