### PR TITLE
fix(core) hide capacity in deploy execution details if unnecessary

### DIFF
--- a/app/scripts/modules/core/pipeline/config/stages/deploy/deployExecutionDetails.html
+++ b/app/scripts/modules/core/pipeline/config/stages/deploy/deployExecutionDetails.html
@@ -28,7 +28,7 @@
           <dd ng-if="provider === 'aws'">{{stage.context.subnetType || '[none]'}}</dd>
           <dt>Strategy</dt>
           <dd>{{stage.context.strategy || '[none]'}}</dd>
-          <dt>Capacity</dt>
+          <dt ng-if="stage.context.capacity || stage.context.useSourceCapacity">Capacity</dt>
           <dd ng-if="!stage.context.capacity">
             {{stage.context.targetSize}}
           </dd>


### PR DESCRIPTION
@icfantv please review.

App Engine has no notion of capacity at deploy time, so there's nothing to populate here.
