### PR TITLE
fix(kubernetes) update user selected load balancer

### DIFF
--- a/app/scripts/modules/kubernetes/loadBalancer/configure/wizard/upsert.controller.js
+++ b/app/scripts/modules/kubernetes/loadBalancer/configure/wizard/upsert.controller.js
@@ -67,6 +67,7 @@ module.exports = angular.module('spinnaker.loadBalancer.kubernetes.create.contro
     });
 
     function initializeEditMode() {
+      $scope.state.accountsLoaded = true;
     }
 
     function initializeCreateMode() {
@@ -103,7 +104,6 @@ module.exports = angular.module('spinnaker.loadBalancer.kubernetes.create.contro
     if (loadBalancer) {
       $scope.loadBalancer = kubernetesLoadBalancerTransformer.convertLoadBalancerForEditing(loadBalancer);
       initializeEditMode();
-      initializeCreateMode();
     } else {
       $scope.loadBalancer = kubernetesLoadBalancerTransformer.constructNewLoadBalancerTemplate();
       updateLoadBalancerNames();


### PR DESCRIPTION
The issue is that a load balancer can't be updated. Another one will be updated or created.

There're two reasons:
1. `$scope.loadBalancer.account` will be set to the first found account among all accounts as https://github.com/spinnaker/deck/blob/7427282bfea29a779d71b2e609be9a9f2d962f7c/app/scripts/modules/kubernetes/loadBalancer/configure/wizard/upsert.controller.js#L84 shows
2. $scope.loadBalancer is actually `loadBalancer.description`. But the `description.account` in the API response is null. This is fixed in https://github.com/spinnaker/clouddriver/pull/1527