### PR TITLE
fix(core): bump zone version

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "source-sans-pro": "^2.0.10",
     "spin.js": "git://github.com/fgnass/spin.js.git#2.3.1",
     "ui-select": "^0.19.6",
-    "zone.js": "^0.7.6"
+    "zone.js": "^0.8.4"
   },
   "devDependencies": {
     "@types/angular": "1.5.20",


### PR DESCRIPTION
@icfantv or @anotherchrisberry please review.

Deck won't run because Angular 2 lists `zone.js@^0.8.4` as a peer dependency (it builds, but won't run in the browser).
(https://github.com/angular/angular/blob/master/packages/core/package.json#L13)

I am a little confused how we should keep up with their version of `zone.js`. 
There's an NPM issue (that actually references this exact Angular 2 dependency) https://github.com/npm/npm/issues/11213, but there's no solution.

