### PR TITLE
fix(gce): normalize server group load balancers

### DIFF
--- a/app/scripts/modules/core/cluster/cluster.service.js
+++ b/app/scripts/modules/core/cluster/cluster.service.js
@@ -15,9 +15,9 @@ module.exports = angular.module('spinnaker.core.cluster.service', [
 ])
   .factory('clusterService', function ($q, API, serverGroupTransformer, namingService) {
 
-    function loadServerGroups(applicationName) {
+    function loadServerGroups(application) {
       var serverGroupLoader = $q.all({
-        serverGroups: API.one('applications').one(applicationName).all('serverGroups').getList().then(g => g, () => []),
+        serverGroups: API.one('applications').one(application.name).all('serverGroups').getList().then(g => g, () => []),
       });
       return serverGroupLoader.then(function(results) {
         results.serverGroups = results.serverGroups || [];
@@ -28,7 +28,7 @@ module.exports = angular.module('spinnaker.core.cluster.service', [
             serverGroup.category = 'serverGroup'
           );
 
-        return $q.all(results.serverGroups.map(serverGroupTransformer.normalizeServerGroup));
+        return $q.all(results.serverGroups.map(serverGroup => serverGroupTransformer.normalizeServerGroup(serverGroup, application)));
       });
     }
 

--- a/app/scripts/modules/core/serverGroup/serverGroup.dataSource.js
+++ b/app/scripts/modules/core/serverGroup/serverGroup.dataSource.js
@@ -15,7 +15,7 @@ module.exports = angular
   .run(function($q, applicationDataSourceRegistry, clusterService, entityTagsReader, serverGroupTransformer, settings) {
 
     let loadServerGroups = (application) => {
-      return clusterService.loadServerGroups(application.name);
+      return clusterService.loadServerGroups(application);
     };
 
     let addServerGroups = (application, serverGroups) => {

--- a/app/scripts/modules/core/serverGroup/serverGroup.transformer.js
+++ b/app/scripts/modules/core/serverGroup/serverGroup.transformer.js
@@ -7,9 +7,9 @@ module.exports = angular.module('spinnaker.core.serverGroup.transformer', [
 ])
   .factory('serverGroupTransformer', function (serviceDelegate) {
 
-    function normalizeServerGroup(serverGroup) {
+    function normalizeServerGroup(serverGroup, application) {
       return serviceDelegate.getDelegate(serverGroup.provider || serverGroup.type, 'serverGroup.transformer').
-        normalizeServerGroup(serverGroup);
+        normalizeServerGroup(serverGroup, application);
     }
 
     function convertServerGroupCommandToDeployConfiguration(base) {

--- a/app/scripts/modules/google/serverGroup/serverGroup.transformer.spec.js
+++ b/app/scripts/modules/google/serverGroup/serverGroup.transformer.spec.js
@@ -1,0 +1,57 @@
+'use strict';
+
+describe('gceServerGroupTransformer', () => {
+  let transformer, $q, $scope;
+  beforeEach(
+    window.module(
+      require('./serverGroup.transformer.js')
+    )
+  );
+
+  beforeEach(() => {
+    window.inject((_$q_, $rootScope, _gceServerGroupTransformer_) => {
+      $q = _$q_;
+      $scope = $rootScope.$new();
+      transformer = _gceServerGroupTransformer_;
+    });
+  });
+
+  describe('normalize server group load balancers', () => {
+    let app;
+    beforeEach(() => {
+      app = {
+        getDataSource: () => {
+          return {
+            ready: () => $q.resolve(),
+            data: [
+              {name: 'network-load-balancer'},
+              {name: 'internal-load-balancer'},
+              {name: 'url-map-name',
+               listeners: [{name: 'http-load-balancer-listener'}, {name: 'https-load-balancer-listener'}]}
+            ]
+          };
+        }
+      };
+    });
+
+    it('should map listener names to url map names', function () {
+      let serverGroup = {
+        loadBalancers: [
+          'network-load-balancer',
+          'internal-load-balancer',
+          'http-load-balancer-listener',
+          'https-load-balancer-listener'
+        ]
+      };
+
+      let normalizedServerGroup;
+      transformer.normalizeServerGroup(serverGroup, app)
+        .then(normalized => normalizedServerGroup = normalized);
+      $scope.$digest();
+      expect(normalizedServerGroup.loadBalancers.length).toBe(3);
+      expect(normalizedServerGroup.loadBalancers.includes('url-map-name')).toEqual(true);
+      expect(normalizedServerGroup.loadBalancers.includes('network-load-balancer')).toEqual(true);
+      expect(normalizedServerGroup.loadBalancers.includes('internal-load-balancer')).toEqual(true);
+    });
+  });
+});


### PR DESCRIPTION
@jtk54 or @duftler please review.

This fixes the load balancer tags for HTTP(S) load balancers:
![load_balancer_tag](https://cloud.githubusercontent.com/assets/13868700/24256041/89c96ee2-0fbd-11e7-83ce-8729d907cbd6.png)

This is a lingering issue from the listener -> url map transformation we have to do in the UI.

@anotherchrisberry FYI - I made a slight change in the core server group transformer.

