### PR TITLE
refactor(core): Stop injecting global settings via angular and provide some typings around settings

### DIFF
--- a/app/scripts/modules/amazon/aws.settings.ts
+++ b/app/scripts/modules/amazon/aws.settings.ts
@@ -1,0 +1,31 @@
+import { IProviderSettings, SETTINGS } from 'core/config/settings';
+
+interface IClassicLaunchWhitelist {
+  region: string;
+  credentials: string;
+}
+
+export interface IAWSProviderSettings extends IProviderSettings {
+  defaults: {
+    account: string;
+    region: string;
+    iamRole: string;
+    subnetType?: string;
+  };
+  defaultSecurityGroups: string[];
+  loadBalancers: {
+    inferInternalFlagFromSubnet: boolean;
+    certificateTypes?: string[];
+  };
+  useAmiBlockDeviceMappings: boolean;
+  classicLaunchLockout?: number;
+  classicLaunchWhitelist?: IClassicLaunchWhitelist[];
+  metrics?: {
+    customNamespaces?: string[];
+  };
+}
+
+export const AWSProviderSettings: IAWSProviderSettings = <IAWSProviderSettings>SETTINGS.providers.aws;
+if (AWSProviderSettings) {
+  AWSProviderSettings.resetToOriginal = SETTINGS.resetToOriginal;
+}

--- a/app/scripts/modules/amazon/instance/awsInstanceType.service.js
+++ b/app/scripts/modules/amazon/instance/awsInstanceType.service.js
@@ -8,10 +8,9 @@ let angular = require('angular');
 
 module.exports = angular.module('spinnaker.aws.instanceType.service', [
   API_SERVICE,
-  require('core/config/settings.js'),
   INFRASTRUCTURE_CACHE_SERVICE
 ])
-  .factory('awsInstanceTypeService', function ($http, $q, settings, API, infrastructureCaches) {
+  .factory('awsInstanceTypeService', function ($http, $q, API, infrastructureCaches) {
 
     var m3 = {
       type: 'm3',

--- a/app/scripts/modules/amazon/instance/awsInstanceType.service.spec.js
+++ b/app/scripts/modules/amazon/instance/awsInstanceType.service.spec.js
@@ -14,11 +14,10 @@ describe('Service: InstanceType', function () {
   });
 
 
-  beforeEach(window.inject(function (_awsInstanceTypeService_, _$httpBackend_, _settings_, _API_, infrastructureCaches) {
+  beforeEach(window.inject(function (_awsInstanceTypeService_, _$httpBackend_, _API_, infrastructureCaches) {
     API = _API_;
     this.awsInstanceTypeService = _awsInstanceTypeService_;
     this.$httpBackend = _$httpBackend_;
-    this.settings = _settings_;
 
     this.allTypes = [
       {account: 'test', region: 'us-west-2', name: 'm1.small', availabilityZone: 'us-west-2a'},

--- a/app/scripts/modules/amazon/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/amazon/instance/details/instance.details.controller.js
@@ -6,6 +6,7 @@ import {CONFIRMATION_MODAL_SERVICE} from 'core/confirmationModal/confirmationMod
 import {INSTANCE_READ_SERVICE} from 'core/instance/instance.read.service';
 import {INSTANCE_WRITE_SERVICE} from 'core/instance/instance.write.service';
 import {RECENT_HISTORY_SERVICE} from 'core/history/recentHistory.service';
+import {SETTINGS} from 'core/config/settings';
 
 let angular = require('angular');
 
@@ -19,11 +20,10 @@ module.exports = angular.module('spinnaker.instance.detail.aws.controller', [
   CONFIRMATION_MODAL_SERVICE,
   RECENT_HISTORY_SERVICE,
   require('core/utils/selectOnDblClick.directive.js'),
-  require('core/config/settings.js'),
   CLOUD_PROVIDER_REGISTRY,
   require('core/instance/details/instanceLinks.component'),
 ])
-  .controller('awsInstanceDetailsCtrl', function ($scope, $state, $uibModal, settings,
+  .controller('awsInstanceDetailsCtrl', function ($scope, $state, $uibModal,
                                                   instanceWriter, confirmationModalService, recentHistoryService,
                                                   cloudProviderRegistry, instanceReader, instance, app, $q, overrides) {
 
@@ -33,7 +33,7 @@ module.exports = angular.module('spinnaker.instance.detail.aws.controller', [
     $scope.state = {
       loading: true,
       standalone: app.isStandalone,
-      instancePort: _.get(app, 'attributes.instancePort') || settings.defaultInstancePort || 80,
+      instancePort: _.get(app, 'attributes.instancePort') || SETTINGS.defaultInstancePort || 80,
     };
 
     $scope.application = app;

--- a/app/scripts/modules/amazon/loadBalancer/configure/createLoadBalancer.controller.js
+++ b/app/scripts/modules/amazon/loadBalancer/configure/createLoadBalancer.controller.js
@@ -12,6 +12,7 @@ import {CACHE_INITIALIZER_SERVICE} from 'core/cache/cacheInitializer.service';
 import {SECURITY_GROUP_READER} from 'core/securityGroup/securityGroupReader.service';
 import {SUBNET_SELECT_FIELD_COMPONENT} from '../../subnet/subnetSelectField.component';
 import {TASK_MONITOR_BUILDER} from 'core/task/monitor/taskMonitor.builder';
+import {AWSProviderSettings} from '../../aws.settings';
 
 let angular = require('angular');
 
@@ -31,13 +32,12 @@ module.exports = angular.module('spinnaker.loadBalancer.aws.create.controller', 
   require('core/region/regionSelectField.directive.js'),
   require('core/account/accountSelectField.directive.js'),
   SUBNET_SELECT_FIELD_COMPONENT,
-  require('core/config/settings.js'),
 ])
   .controller('awsCreateLoadBalancerCtrl', function($scope, $uibModalInstance, $state,
                                                     accountService, awsLoadBalancerTransformer, securityGroupReader,
                                                     cacheInitializer, infrastructureCaches,
                                                     v2modalWizardService, loadBalancerWriter, taskMonitorBuilder,
-                                                    subnetReader, namingService, settings,
+                                                    subnetReader, namingService,
                                                     application, loadBalancer, isNew, forPipelineConfig) {
 
     var ctrl = this;
@@ -111,11 +111,11 @@ module.exports = angular.module('spinnaker.loadBalancer.aws.create.controller', 
 
     function initializeCreateMode() {
       preloadSecurityGroups();
-      if (_.has(settings, 'providers.aws.defaultSecurityGroups')) {
-        defaultSecurityGroups = settings.providers.aws.defaultSecurityGroups;
-      }
-      if (_.has(settings, 'providers.aws.loadBalancers.inferInternalFlagFromSubnet')) {
-        if (settings.providers.aws.loadBalancers.inferInternalFlagFromSubnet) {
+      if (AWSProviderSettings) {
+        if (AWSProviderSettings.defaultSecurityGroups) {
+          defaultSecurityGroups = AWSProviderSettings.defaultSecurityGroups;
+        }
+        if (AWSProviderSettings.loadBalancers && AWSProviderSettings.loadBalancers.inferInternalFlagFromSubnet) {
           delete $scope.loadBalancer.isInternal;
           $scope.state.hideInternalFlag = true;
         }
@@ -296,7 +296,7 @@ module.exports = angular.module('spinnaker.loadBalancer.aws.create.controller', 
       });
     };
 
-    this.certificateTypes = _.get(settings, 'providers.aws.loadBalancers.certificateTypes', ['iam', 'acm']);
+    this.certificateTypes = AWSProviderSettings.loadBalancers && AWSProviderSettings.loadBalancers.certificateTypes || ['iam', 'acm'];
 
     initializeController();
 

--- a/app/scripts/modules/amazon/loadBalancer/configure/createLoadBalancer.controller.spec.js
+++ b/app/scripts/modules/amazon/loadBalancer/configure/createLoadBalancer.controller.spec.js
@@ -1,9 +1,9 @@
 'use strict';
 
 import {APPLICATION_MODEL_BUILDER} from 'core/application/applicationModel.builder';
+import {AWSProviderSettings} from '../../aws.settings';
 
 describe('Controller: awsCreateLoadBalancerCtrl', function () {
-
   // load the controller's module
   beforeEach(
     window.module(
@@ -14,7 +14,6 @@ describe('Controller: awsCreateLoadBalancerCtrl', function () {
 
   // Initialize the controller and a mock scope
   beforeEach(window.inject(function ($controller, $rootScope, applicationModelBuilder) {
-    this.settings = {};
     this.$scope = $rootScope.$new();
     const app = applicationModelBuilder.createApplication({key: 'loadBalancers', lazy: true});
     this.initialize = () => {
@@ -24,11 +23,12 @@ describe('Controller: awsCreateLoadBalancerCtrl', function () {
         application: app,
         loadBalancer: null,
         isNew: true,
-        forPipelineConfig: false,
-        settings: this.settings,
+        forPipelineConfig: false
       });
     };
   }));
+
+  afterEach(AWSProviderSettings.resetToOriginal);
 
   it('requires health check path for HTTP/S', function () {
     this.initialize();
@@ -105,9 +105,7 @@ describe('Controller: awsCreateLoadBalancerCtrl', function () {
 
   describe('isInternal flag', function () {
     it('should remove the flag and set a state value if inferInternalFlagFromSubnet is true', function () {
-      this.settings.providers = {
-        aws: { loadBalancers: { inferInternalFlagFromSubnet: true }}
-      };
+      AWSProviderSettings.loadBalancers.inferInternalFlagFromSubnet = true;
       this.initialize();
 
       expect(this.$scope.loadBalancer.isInternal).toBe(undefined);
@@ -160,38 +158,24 @@ describe('Controller: awsCreateLoadBalancerCtrl', function () {
     });
 
     it('should leave the flag and not set a state value if inferInternalFlagFromSubnet is false or not defined', function () {
-      this.settings.providers = {
-        aws: { loadBalancers: { inferInternalFlagFromSubnet: true }}
-      };
+      AWSProviderSettings.loadBalancers.inferInternalFlagFromSubnet = true;
 
       this.initialize();
       expect(this.$scope.loadBalancer.isInternal).toBe(undefined);
       expect(this.$scope.state.hideInternalFlag).toBe(true);
 
-      this.settings.providers.aws.loadBalancers.inferInternalFlagFromSubnet = false;
+      AWSProviderSettings.loadBalancers.inferInternalFlagFromSubnet = false;
       this.initialize();
       expect(this.$scope.loadBalancer.isInternal).toBe(false);
       expect(this.$scope.state.hideInternalFlag).toBeUndefined();
 
-      delete this.settings.providers.aws.loadBalancers.inferInternalFlagFromSubnet;
-      this.initialize();
-
-      expect(this.$scope.loadBalancer.isInternal).toBe(false);
-      expect(this.$scope.state.hideInternalFlag).toBeUndefined();
-
-      delete this.settings.providers.aws.loadBalancers;
+      delete AWSProviderSettings.loadBalancers.inferInternalFlagFromSubnet;
       this.initialize();
 
       expect(this.$scope.loadBalancer.isInternal).toBe(false);
       expect(this.$scope.state.hideInternalFlag).toBeUndefined();
 
-      delete this.settings.providers.aws;
-      this.initialize();
-
-      expect(this.$scope.loadBalancer.isInternal).toBe(false);
-      expect(this.$scope.state.hideInternalFlag).toBeUndefined();
-
-      delete this.settings.providers;
+      delete AWSProviderSettings.loadBalancers;
       this.initialize();
 
       expect(this.$scope.loadBalancer.isInternal).toBe(false);

--- a/app/scripts/modules/amazon/loadBalancer/loadBalancer.transformer.js
+++ b/app/scripts/modules/amazon/loadBalancer/loadBalancer.transformer.js
@@ -1,13 +1,14 @@
 'use strict';
 
 import _ from 'lodash';
+import {AWSProviderSettings} from '../aws.settings';
 
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.aws.loadBalancer.transformer', [
   require('../vpc/vpc.read.service.js'),
 ])
-  .factory('awsLoadBalancerTransformer', function (settings, vpcReader) {
+  .factory('awsLoadBalancerTransformer', function (vpcReader) {
 
     function updateHealthCounts(container) {
       var instances = container.instances;
@@ -137,9 +138,9 @@ module.exports = angular.module('spinnaker.aws.loadBalancer.transformer', [
     }
 
     function constructNewLoadBalancerTemplate(application) {
-      var defaultCredentials = application.defaultCredentials.aws || settings.providers.aws.defaults.account,
-          defaultRegion = application.defaultRegions.aws || settings.providers.aws.defaults.region,
-          defaultSubnetType = settings.providers.aws.defaults.subnetType;
+      var defaultCredentials = application.defaultCredentials.aws || AWSProviderSettings.defaults.account,
+          defaultRegion = application.defaultRegions.aws || AWSProviderSettings.defaults.region,
+          defaultSubnetType = AWSProviderSettings.defaults.subnetType;
       return {
         stack: '',
         detail: '',

--- a/app/scripts/modules/amazon/pipeline/stages/bake/awsBakeStage.js
+++ b/app/scripts/modules/amazon/pipeline/stages/bake/awsBakeStage.js
@@ -2,6 +2,7 @@
 
 import _ from 'lodash';
 import {BAKERY_SERVICE} from 'core/pipeline/config/stages/bake/bakery.service';
+import {SETTINGS} from 'core/config/settings';
 
 let angular = require('angular');
 
@@ -36,7 +37,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.aws.bakeStage', [
       restartable: true,
     });
   })
-  .controller('awsBakeStageCtrl', function($scope, bakeryService, $q, authenticationService, settings, $uibModal) {
+  .controller('awsBakeStageCtrl', function($scope, bakeryService, $q, authenticationService, $uibModal) {
 
     $scope.stage.extendedAttributes = $scope.stage.extendedAttributes || {};
     $scope.stage.regions = $scope.stage.regions || [];
@@ -86,7 +87,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.aws.bakeStage', [
         if (!$scope.stage.baseLabel && $scope.baseLabelOptions && $scope.baseLabelOptions.length) {
           $scope.stage.baseLabel = $scope.baseLabelOptions[0];
         }
-        $scope.viewState.roscoMode = settings.feature.roscoMode;
+        $scope.viewState.roscoMode = SETTINGS.feature.roscoMode;
         $scope.showAdvancedOptions = showAdvanced();
         $scope.viewState.loading = false;
       });

--- a/app/scripts/modules/amazon/pipeline/stages/bake/bakeExecutionDetails.controller.js
+++ b/app/scripts/modules/amazon/pipeline/stages/bake/bakeExecutionDetails.controller.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import {EXECUTION_DETAILS_SECTION_SERVICE} from 'core/delivery/details/executionDetailsSection.service';
+import {SETTINGS} from 'core/config/settings';
 
 let angular = require('angular');
 
@@ -10,15 +11,15 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.bake.aws.executio
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ])
   .controller('awsBakeExecutionDetailsCtrl', function ($scope, $stateParams, executionDetailsSectionService,
-                                                       $interpolate, settings) {
+                                                       $interpolate) {
 
     $scope.configSections = ['bakeConfig', 'taskStatus'];
 
     let initialized = () => {
       $scope.detailsSection = $stateParams.details;
       $scope.provider = $scope.stage.context.cloudProviderType || 'aws';
-      $scope.roscoMode = settings.feature.roscoMode;
-      $scope.bakeryDetailUrl = $interpolate(settings.bakeryDetailUrl);
+      $scope.roscoMode = SETTINGS.feature.roscoMode;
+      $scope.bakeryDetailUrl = $interpolate(SETTINGS.bakeryDetailUrl);
     };
 
     let initialize = () => executionDetailsSectionService.synchronizeSection($scope.configSections, initialized);

--- a/app/scripts/modules/amazon/securityGroup/configure/CreateSecurityGroup.controller.spec.js
+++ b/app/scripts/modules/amazon/securityGroup/configure/CreateSecurityGroup.controller.spec.js
@@ -1,15 +1,18 @@
 'use strict';
 
-import _ from 'lodash';
+import { map } from 'lodash';
+
+import {AWSProviderSettings} from '../../aws.settings';
 
 describe('Controller: CreateSecurityGroup', function () {
-
   beforeEach(
     window.module(
       require('./CreateSecurityGroupCtrl.js'),
       require('./configSecurityGroup.mixin.controller.js')
     )
   );
+
+  afterEach(AWSProviderSettings.resetToOriginal);
 
   describe('filtering', function() {
 
@@ -91,8 +94,7 @@ describe('Controller: CreateSecurityGroup', function () {
           securityGroupWriter: this.securityGroupWriter,
           vpcReader: this.vpcReader,
           application: this.application || { attributes: {}},
-          securityGroup: { regions: [], securityGroupIngress: [] },
-          settings: this.settings || {},
+          securityGroup: { regions: [], securityGroupIngress: [] }
         });
         this.$scope.$digest();
       };
@@ -145,12 +147,12 @@ describe('Controller: CreateSecurityGroup', function () {
       this.$scope.securityGroup.regions = ['us-east-1', 'us-west-1'];
       this.ctrl.accountUpdated();
       this.$scope.$digest();
-      expect(_.map(this.$scope.vpcs, 'label').sort()).toEqual(['vpc 2']);
+      expect(map(this.$scope.vpcs, 'label').sort()).toEqual(['vpc 2']);
 
       this.$scope.securityGroup.regions = ['us-east-1'];
       this.ctrl.accountUpdated();
       this.$scope.$digest();
-      expect(_.map(this.$scope.vpcs, 'label').sort()).toEqual(['vpc 1', 'vpc 2']);
+      expect(map(this.$scope.vpcs, 'label').sort()).toEqual(['vpc 1', 'vpc 2']);
     });
 
     describe('security group removal', function () {
@@ -207,13 +209,13 @@ describe('Controller: CreateSecurityGroup', function () {
       });
 
       it('does not hide classic when classicLaunchLockout not configured', function () {
-        this.settings = { providers: { aws: {} } };
+        AWSProviderSettings.classicLaunchLockout = undefined;
         init(this);
         expect(this.$scope.hideClassic).toBe(false);
       });
 
       it('does not hide classic when application has no attributes', function () {
-        this.settings = { providers: { aws: { classicLaunchLockout: 10 } } };
+        AWSProviderSettings.classicLaunchLockout = 10;
         init(this);
         expect(this.$scope.hideClassic).toBe(false);
 
@@ -229,35 +231,35 @@ describe('Controller: CreateSecurityGroup', function () {
       });
 
       it('hides classic when application createTs is numeric and the same as lockout', function () {
-        this.settings = { providers: { aws: { classicLaunchLockout: 10 } } };
+        AWSProviderSettings.classicLaunchLockout = 10;
         this.application = { attributes: { createTs: 10}};
         init(this);
         expect(this.$scope.hideClassic).toBe(true);
       });
 
       it('hides classic when application createTs is numeric and after lockout', function () {
-        this.settings = { providers: { aws: { classicLaunchLockout: 10 } } };
+        AWSProviderSettings.classicLaunchLockout = 10;
         this.application = { attributes: { createTs: 11}};
         init(this);
         expect(this.$scope.hideClassic).toBe(true);
       });
 
       it('hides classic when application createTs is a string and the same as lockout', function () {
-        this.settings = { providers: { aws: { classicLaunchLockout: 10 } } };
+        AWSProviderSettings.classicLaunchLockout = 10;
         this.application = { attributes: { createTs: '10'}};
         init(this);
         expect(this.$scope.hideClassic).toBe(true);
       });
 
       it('hides classic when application createTs is a string and after lockout', function () {
-        this.settings = { providers: { aws: { classicLaunchLockout: 10 } } };
+        AWSProviderSettings.classicLaunchLockout = 10;
         this.application = { attributes: { createTs: '11'}};
         init(this);
         expect(this.$scope.hideClassic).toBe(true);
       });
 
       it('sets vpcId to first active if classic is locked', function () {
-        this.settings = { providers: { aws: { classicLaunchLockout: 10 } } };
+        AWSProviderSettings.classicLaunchLockout = 10;
         this.application = { attributes: { createTs: 10}};
         this.initializeCtrl();
 
@@ -270,7 +272,7 @@ describe('Controller: CreateSecurityGroup', function () {
       });
 
       it('leaves vpcId alone if already selected and classic locked', function () {
-        this.settings = { providers: { aws: { classicLaunchLockout: 10 } } };
+        AWSProviderSettings.classicLaunchLockout = 10;
 
         this.application = { attributes: { createTs: 10}};
         this.initializeCtrl();

--- a/app/scripts/modules/amazon/securityGroup/configure/CreateSecurityGroupCtrl.js
+++ b/app/scripts/modules/amazon/securityGroup/configure/CreateSecurityGroupCtrl.js
@@ -9,11 +9,10 @@ module.exports = angular.module('spinnaker.amazon.securityGroup.create.controlle
   require('angular-ui-router'),
   INFRASTRUCTURE_CACHE_SERVICE,
   CACHE_INITIALIZER_SERVICE,
-  require('core/config/settings.js'),
 ])
   .controller('awsCreateSecurityGroupCtrl', function($scope, $uibModalInstance, $state, $controller,
                                                      cacheInitializer, infrastructureCaches,
-                                                     application, securityGroup, settings ) {
+                                                     application, securityGroup) {
 
     $scope.pages = {
       location: require('./createSecurityGroupProperties.html'),
@@ -26,8 +25,7 @@ module.exports = angular.module('spinnaker.amazon.securityGroup.create.controlle
       $scope: $scope,
       $uibModalInstance: $uibModalInstance,
       application: application,
-      securityGroup: securityGroup,
-      settings: settings,
+      securityGroup: securityGroup
     }));
 
     $scope.state.isNew = true;

--- a/app/scripts/modules/amazon/securityGroup/configure/configSecurityGroup.mixin.controller.js
+++ b/app/scripts/modules/amazon/securityGroup/configure/configSecurityGroup.mixin.controller.js
@@ -9,6 +9,7 @@ import {V2_MODAL_WIZARD_SERVICE} from 'core/modal/wizard/v2modalWizard.service';
 import {SECURITY_GROUP_READER} from 'core/securityGroup/securityGroupReader.service';
 import {SECURITY_GROUP_WRITER} from 'core/securityGroup/securityGroupWriter.service';
 import {TASK_MONITOR_BUILDER} from 'core/task/monitor/taskMonitor.builder';
+import {AWSProviderSettings} from '../../aws.settings';
 
 module.exports = angular
   .module('spinnaker.amazon.securityGroup.baseConfig.controller', [
@@ -19,7 +20,6 @@ module.exports = angular
     ACCOUNT_SERVICE,
     require('../../vpc/vpc.read.service'),
     V2_MODAL_WIZARD_SERVICE,
-    require('core/config/settings'),
     require('./ingressRuleGroupSelector.component'),
   ])
   .controller('awsConfigSecurityGroupMixin', function ($scope,
@@ -34,8 +34,7 @@ module.exports = angular
                                                        v2modalWizardService,
                                                        cacheInitializer,
                                                        infrastructureCaches,
-                                                       vpcReader,
-                                                       settings) {
+                                                       vpcReader) {
 
 
 
@@ -154,7 +153,7 @@ module.exports = angular
         });
         $scope.vpcs = available;
 
-        let lockoutDate = _.get(settings, 'providers.aws.classicLaunchLockout');
+        let lockoutDate = AWSProviderSettings.classicLaunchLockout;
         if (!securityGroup.id && lockoutDate) {
           let createTs = Number(_.get(application, 'attributes.createTs', 0));
           if (createTs >= lockoutDate) {

--- a/app/scripts/modules/amazon/serverGroup/configure/serverGroupCommandBuilder.aws.service.spec.js
+++ b/app/scripts/modules/amazon/serverGroup/configure/serverGroupCommandBuilder.aws.service.spec.js
@@ -1,7 +1,8 @@
 'use strict';
 
-describe('Service: awsServerGroup', function () {
+import {AWSProviderSettings} from '../../aws.settings';
 
+describe('Service: awsServerGroup', function () {
   beforeEach(
     window.module(
       require('./serverGroupCommandBuilder.service.js')
@@ -10,16 +11,17 @@ describe('Service: awsServerGroup', function () {
 
   beforeEach(
     window.inject(function (_$httpBackend_, awsServerGroupCommandBuilder, _accountService_, _instanceTypeService_, _$q_,
-                            _settings_, _subnetReader_, $rootScope) {
+                            _subnetReader_, $rootScope) {
       this.$httpBackend = _$httpBackend_;
       this.service = awsServerGroupCommandBuilder;
       this.accountService = _accountService_;
       this.subnetReader = _subnetReader_;
       this.$q = _$q_;
-      this.settings = _settings_;
       this.$scope = $rootScope;
       spyOn(_instanceTypeService_, 'getCategoryForInstanceType').and.returnValue(_$q_.when('custom'));
   }));
+
+  afterEach(AWSProviderSettings.resetToOriginal);
 
   describe('buildServerGroupCommandFromPipeline', function () {
 
@@ -37,24 +39,9 @@ describe('Service: awsServerGroup', function () {
         }
       };
 
-      this.settings.providers.aws.defaults.account = 'test';
-      this.settings.providers.aws.defaults.region = 'us-east-1';
-
-      this.settings.preferredZonesByAccount = {
-        test: {
-          'us-west-1': ['a', 'b'],
-          'us-east-1': ['d', 'e'],
-        },
-        prod: {
-          'us-west-1': ['d', 'g'],
-          'us-east-1': ['d', 'e'],
-          'eu-west-1': ['a', 'm']
-        },
-        default: {
-          'us-west-1': ['a', 'c'],
-          'us-east-1': ['d', 'e'],
-          'eu-west-1': ['a', 'm']
-        }
+      AWSProviderSettings.defaults = {
+        account: 'test',
+        region: 'us-east-1'
       };
 
       spyOn(this.accountService, 'getAvailabilityZonesForAccountAndRegion').and.returnValue(

--- a/app/scripts/modules/amazon/serverGroup/configure/serverGroupCommandBuilder.service.js
+++ b/app/scripts/modules/amazon/serverGroup/configure/serverGroupCommandBuilder.service.js
@@ -1,10 +1,12 @@
 'use strict';
 
 import _ from 'lodash';
+
 import {ACCOUNT_SERVICE} from 'core/account/account.service';
 import {INSTANCE_TYPE_SERVICE} from 'core/instance/instanceType.service';
 import {NAMING_SERVICE} from 'core/naming/naming.service';
 import {SUBNET_READ_SERVICE} from 'core/subnet/subnet.read.service';
+import {AWSProviderSettings} from '../../aws.settings';
 
 let angular = require('angular');
 
@@ -15,17 +17,16 @@ module.exports = angular.module('spinnaker.aws.serverGroupCommandBuilder.service
   NAMING_SERVICE,
   require('./serverGroupConfiguration.service.js'),
 ])
-  .factory('awsServerGroupCommandBuilder', function (settings, $q,
-                                                     accountService, subnetReader, namingService, instanceTypeService,
+  .factory('awsServerGroupCommandBuilder', function ($q, accountService, subnetReader, namingService, instanceTypeService,
                                                      awsServerGroupConfigurationService) {
 
     function buildNewServerGroupCommand (application, defaults) {
       defaults = defaults || {};
       var credentialsLoader = accountService.getCredentialsKeyedByAccount('aws');
 
-      var defaultCredentials = defaults.account || application.defaultCredentials.aws || settings.providers.aws.defaults.account;
-      var defaultRegion = defaults.region || application.defaultRegions.aws || settings.providers.aws.defaults.region;
-      var defaultSubnet = defaults.subnet || settings.providers.aws.defaults.subnetType || '';
+      var defaultCredentials = defaults.account || application.defaultCredentials.aws || AWSProviderSettings.defaults.account;
+      var defaultRegion = defaults.region || application.defaultRegions.aws || AWSProviderSettings.defaults.region;
+      var defaultSubnet = defaults.subnet || AWSProviderSettings.defaults.subnetType || '';
 
       var preferredZonesLoader = accountService.getAvailabilityZonesForAccountAndRegion('aws', defaultCredentials, defaultRegion);
 
@@ -40,7 +41,7 @@ module.exports = angular.module('spinnaker.aws.serverGroupCommandBuilder.service
           var keyPair = credentials ? credentials.defaultKeyPair : null;
           var applicationAwsSettings = _.get(application, 'attributes.providerSettings.aws', {});
 
-          var defaultIamRole = settings.providers.aws.defaults.iamRole || 'BaseIAMRole';
+          var defaultIamRole = AWSProviderSettings.defaults.iamRole || 'BaseIAMRole';
           defaultIamRole = defaultIamRole.replace('{{application}}', application.name);
 
           var command = {

--- a/app/scripts/modules/amazon/serverGroup/configure/serverGroupCommandBuilder.spec.js
+++ b/app/scripts/modules/amazon/serverGroup/configure/serverGroupCommandBuilder.spec.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import {AWSProviderSettings} from '../../aws.settings';
+
 describe('awsServerGroupCommandBuilder', function() {
   const AccountServiceFixture = require('../../../../../../test/fixture/AccountServiceFixtures');
 
@@ -9,12 +11,11 @@ describe('awsServerGroupCommandBuilder', function() {
     )
   );
 
-  beforeEach(window.inject(function(awsServerGroupCommandBuilder, accountService, $q, $rootScope, subnetReader, instanceTypeService, _settings_) {
+  beforeEach(window.inject(function(awsServerGroupCommandBuilder, accountService, $q, $rootScope, subnetReader, instanceTypeService) {
     this.awsServerGroupCommandBuilder = awsServerGroupCommandBuilder;
     this.$scope = $rootScope;
     this.instanceTypeService = instanceTypeService;
     this.$q = $q;
-    this.settings = _settings_;
     spyOn(accountService, 'getPreferredZonesByAccount').and.returnValue($q.when(AccountServiceFixture.preferredZonesByAccount));
     spyOn(accountService, 'getCredentialsKeyedByAccount').and.returnValue($q.when(AccountServiceFixture.credentialsKeyedByAccount));
     spyOn(subnetReader, 'listSubnets').and.returnValue($q.when([]));
@@ -23,11 +24,13 @@ describe('awsServerGroupCommandBuilder', function() {
     );
   }));
 
+  afterEach(AWSProviderSettings.resetToOriginal);
+
   describe('buildNewServerGroupCommand', function() {
 
     it('initializes to default values, setting usePreferredZone flag to true', function () {
       var command = null;
-      this.settings.providers.aws.defaults.iamRole = '{{application}}IAMRole';
+      AWSProviderSettings.defaults.iamRole = '{{application}}IAMRole';
       this.awsServerGroupCommandBuilder.buildNewServerGroupCommand({name: 'appo', defaultCredentials: {}, defaultRegions: {}}, 'aws').then(function(result) {
         command = result;
       });

--- a/app/scripts/modules/amazon/serverGroup/configure/wizard/CloneServerGroup.aws.controller.spec.js
+++ b/app/scripts/modules/amazon/serverGroup/configure/wizard/CloneServerGroup.aws.controller.spec.js
@@ -16,7 +16,7 @@ describe('Controller: awsCloneServerGroup', function () {
   );
 
   beforeEach(function() {
-    window.inject(function ($controller, $rootScope, accountService, serverGroupWriter, awsImageReader, settings,
+    window.inject(function ($controller, $rootScope, accountService, serverGroupWriter, awsImageReader,
                      searchService, awsInstanceTypeService, v2modalWizardService, securityGroupReader, taskMonitorBuilder,
                      awsServerGroupConfigurationService, $q, subnetReader, keyPairsReader, loadBalancerReader) {
 
@@ -30,7 +30,6 @@ describe('Controller: awsCloneServerGroup', function () {
       this.securityGroupReader = securityGroupReader;
       this.awsServerGroupConfigurationService = awsServerGroupConfigurationService;
       this.taskMonitorBuilder = taskMonitorBuilder;
-      this.settings = settings;
       this.subnetReader = subnetReader;
       this.keyPairsReader = keyPairsReader;
       this.loadBalancerReader = loadBalancerReader;
@@ -94,7 +93,6 @@ describe('Controller: awsCloneServerGroup', function () {
       window.inject(function ($controller) {
         this.ctrl = $controller('awsCloneServerGroupCtrl', {
           $scope: this.$scope,
-          settings: this.settings,
           $uibModalInstance: this.modalInstance,
           accountService: this.accountService,
           serverGroupWriter: this.serverGroupWriter,
@@ -212,7 +210,6 @@ describe('Controller: awsCloneServerGroup', function () {
       window.inject(function ($controller) {
         this.ctrl = $controller('awsCloneServerGroupCtrl', {
           $scope: this.$scope,
-          settings: this.settings,
           $uibModalInstance: this.modalInstance,
           accountService: this.accountService,
           serverGroupWriter: this.serverGroupWriter,
@@ -367,7 +364,6 @@ describe('Controller: awsCloneServerGroup', function () {
       window.inject(function ($controller) {
         this.ctrl = $controller('awsCloneServerGroupCtrl', {
           $scope: this.$scope,
-          settings: this.settings,
           $uibModalInstance: this.modalInstance,
           accountService: this.accountService,
           serverGroupWriter: this.serverGroupWriter,

--- a/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/alarm/alarmConfigurer.component.js
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/upsert/alarm/alarmConfigurer.component.js
@@ -2,13 +2,14 @@
 
 import _ from 'lodash';
 import {Subject} from 'rxjs';
+
 import {CLOUD_METRICS_READ_SERVICE} from 'core/serverGroup/metrics/cloudMetrics.read.service';
+import {AWSProviderSettings} from '../../../../../aws.settings';
 
 const angular = require('angular');
 
 module.exports = angular
   .module('spinnaker.aws.serverGroup.details.scalingPolicy.alarm.configurer', [
-    require('core/config/settings.js'),
     CLOUD_METRICS_READ_SERVICE,
     require('./dimensionsEditor.component.js'),
   ])
@@ -20,12 +21,12 @@ module.exports = angular
       boundsChanged: '&',
     },
     templateUrl: require('./alarmConfigurer.component.html'),
-    controller: function (cloudMetricsReader, settings) {
+    controller: function (cloudMetricsReader) {
 
       // AWS does not provide an API to get this, so we're baking it in. If you use custom namespaces, add them to
       // the settings.js block for aws as an array, e.g. aws { metrics: { customNamespaces: ['myns1', 'other'] } }
       this.namespaces =
-        _.get(settings, 'providers.aws.metrics.customNamespaces', []).concat([
+        _.get(AWSProviderSettings, 'metrics.customNamespaces', []).concat([
           'AWS/AutoScaling',
           'AWS/Billing',
           'AWS/CloudFront',

--- a/app/scripts/modules/amazon/subnet/subnetSelectField.component.ts
+++ b/app/scripts/modules/amazon/subnet/subnetSelectField.component.ts
@@ -3,11 +3,7 @@ import {get} from 'lodash';
 
 import {ISubnet} from 'core/subnet/subnet.read.service';
 import {Application} from 'core/application/application.model';
-
-export interface IClassicLaunchWhitelist {
-  region: string;
-  credentials: string;
-}
+import {AWSProviderSettings} from '../aws.settings';
 
 class SubnetSelectFieldController implements ng.IComponentController {
   public subnets: ISubnet[];
@@ -23,10 +19,6 @@ class SubnetSelectFieldController implements ng.IComponentController {
   public helpKey: string;
   public labelColumns: string;
 
-  static get $inject() { return ['settings']; }
-
-  constructor(private settings: any) {}
-
   public $onInit(): void {
     this.$onChanges();
   }
@@ -37,7 +29,7 @@ class SubnetSelectFieldController implements ng.IComponentController {
   }
 
   private setClassicLock(): void {
-    const lockoutDate: number = get<number>(this.settings, 'providers.aws.classicLaunchLockout');
+    const lockoutDate: number = AWSProviderSettings.classicLaunchLockout;
     if (lockoutDate) {
       const appCreationDate: number = Number(get(this.application, 'attributes.createTs', 0));
       if (appCreationDate > lockoutDate) {
@@ -45,7 +37,7 @@ class SubnetSelectFieldController implements ng.IComponentController {
         return;
       }
     }
-    const classicWhitelist: IClassicLaunchWhitelist[] = get<IClassicLaunchWhitelist[]>(this.settings, 'providers.aws.classicLaunchWhitelist');
+    const classicWhitelist = AWSProviderSettings.classicLaunchWhitelist;
     if (classicWhitelist) {
       this.hideClassic = classicWhitelist.every(e => e.region !== this.region || e.credentials !== this.component.credentials);
     }
@@ -84,5 +76,4 @@ class SubnetSelectFieldComponent implements ng.IComponentOptions {
 
 export const SUBNET_SELECT_FIELD_COMPONENT = 'spinnaker.amazon.subnet.subnetSelectField.component';
 module(SUBNET_SELECT_FIELD_COMPONENT, [
-  require('core/config/settings'),
 ]).component('subnetSelectField', new SubnetSelectFieldComponent());

--- a/app/scripts/modules/amazon/validation/applicationName.validator.ts
+++ b/app/scripts/modules/amazon/validation/applicationName.validator.ts
@@ -1,16 +1,11 @@
-import * as _ from 'lodash';
 import {module} from 'angular';
 import {
   APPLICATION_NAME_VALIDATOR,
   IApplicationNameValidator, ApplicationNameValidator
 } from 'core/application/modal/validation/applicationName.validator';
+import {AWSProviderSettings} from '../aws.settings';
 
 class AmazonApplicationNameValidator implements IApplicationNameValidator {
-
-  static get $inject() { return ['settings']; }
-
-  public constructor(private settings: any) {}
-
   private validateSpecialCharacters(name: string, errors: string[]): void {
     let pattern = /^[a-zA-Z_0-9.]*$/g;
     if (!pattern.test(name)) {
@@ -19,7 +14,7 @@ class AmazonApplicationNameValidator implements IApplicationNameValidator {
   }
 
   private validateClassicLock(warnings: string[]): void {
-  let lockoutDate = _.get(this.settings, 'providers.aws.classicLaunchLockout');
+  let lockoutDate = AWSProviderSettings.classicLaunchLockout;
   if (lockoutDate && lockoutDate < new Date().getTime()) {
     warnings.push('New applications deployed to AWS are restricted to VPC; you cannot create server groups, ' +
       'load balancers, or security groups in EC2 Classic.');
@@ -89,7 +84,6 @@ export const AMAZON_APPLICATION_NAME_VALIDATOR = 'spinnaker.amazon.validation.ap
 
 module(AMAZON_APPLICATION_NAME_VALIDATOR, [
   APPLICATION_NAME_VALIDATOR,
-  require('core/config/settings')
 ])
   .service('awsApplicationNameValidator', AmazonApplicationNameValidator)
   .run((applicationNameValidator: ApplicationNameValidator, awsApplicationNameValidator: IApplicationNameValidator) => {

--- a/app/scripts/modules/appengine/appengine.settings.ts
+++ b/app/scripts/modules/appengine/appengine.settings.ts
@@ -1,0 +1,13 @@
+import { IProviderSettings, SETTINGS } from 'core/config/settings';
+
+export interface IAppengineProviderSettings extends IProviderSettings {
+  defaults: {
+    account: string;
+    editLoadBalancerStageEnabled: boolean;
+  };
+}
+
+export const AppengineProviderSettings: IAppengineProviderSettings = <IAppengineProviderSettings>SETTINGS.providers.appengine;
+if (AppengineProviderSettings) {
+  AppengineProviderSettings.resetToOriginal = SETTINGS.resetToOriginal;
+}

--- a/app/scripts/modules/appengine/pipeline/stages/editLoadBalancer/appengineEditLoadBalancerStage.ts
+++ b/app/scripts/modules/appengine/pipeline/stages/editLoadBalancer/appengineEditLoadBalancerStage.ts
@@ -1,11 +1,12 @@
 import {module} from 'angular';
 import {IModalService} from 'angular-ui-bootstrap';
-import {cloneDeep, get} from 'lodash';
+import {cloneDeep} from 'lodash';
 
 import {CloudProviderRegistry} from 'core/cloudProvider/cloudProvider.registry';
 import {ILoadBalancer} from 'core/domain/index';
 import {APPENGINE_EDIT_LOAD_BALANCER_EXECUTION_DETAILS_CTRL} from './appengineEditLoadBalancerExecutionDetails.controller';
 import {APPENGINE_LOAD_BALANCER_CHOICE_MODAL_CTRL} from './loadBalancerChoice.modal.controller';
+import {AppengineProviderSettings} from '../../../appengine.settings';
 
 class AppengineEditLoadBalancerStageCtrl {
   static get $inject() { return ['$scope', '$uibModal', 'cloudProviderRegistry']; }
@@ -55,9 +56,8 @@ export const APPENGINE_EDIT_LOAD_BALANCER_STAGE = 'spinnaker.appengine.pipeline.
 module(APPENGINE_EDIT_LOAD_BALANCER_STAGE, [
   APPENGINE_EDIT_LOAD_BALANCER_EXECUTION_DETAILS_CTRL,
   APPENGINE_LOAD_BALANCER_CHOICE_MODAL_CTRL,
-  require('core/config/settings.js'),
-]).config((pipelineConfigProvider: any, settings: any) => {
-    if (get(settings, 'providers.appengine.defaults.editLoadBalancerStageEnabled')) {
+]).config((pipelineConfigProvider: any) => {
+    if (AppengineProviderSettings.defaults.editLoadBalancerStageEnabled) {
       pipelineConfigProvider.registerStage({
         label: 'Edit Load Balancer',
         description: 'Edits a load balancer',

--- a/app/scripts/modules/appengine/serverGroup/configure/serverGroupCommandBuilder.service.ts
+++ b/app/scripts/modules/appengine/serverGroup/configure/serverGroupCommandBuilder.service.ts
@@ -1,11 +1,12 @@
 import {module, IQService, IPromise} from 'angular';
-import {get, intersection} from 'lodash';
+import {intersection} from 'lodash';
 
 import {Application} from 'core/application/application.model';
 import {AccountService, ACCOUNT_SERVICE} from 'core/account/account.service';
 import {IAppengineAccount, IAppengineGitTrigger, IAppengineJenkinsTrigger, GitCredentialType, IAppengineServerGroup} from 'appengine/domain/index';
 import {IStage, IPipeline, IGitTrigger, IJenkinsTrigger} from 'core/domain/index';
 import {AppengineDeployDescription} from '../transformer';
+import {AppengineProviderSettings} from '../../appengine.settings';
 
 export interface IAppengineServerGroupCommand {
   application?: string;
@@ -40,7 +41,7 @@ interface IViewState {
 }
 
 export class AppengineServerGroupCommandBuilder {
-  static get $inject() { return ['$q', 'accountService', 'settings']; }
+  static get $inject() { return ['$q', 'accountService']; }
 
   private static getTriggerOptions(pipeline: IPipeline): Array<IAppengineGitTrigger | IAppengineJenkinsTrigger> {
     return (pipeline.triggers || [])
@@ -54,7 +55,7 @@ export class AppengineServerGroupCommandBuilder {
       });
   }
 
-  constructor(private $q: IQService, private accountService: AccountService, private settings: any) { }
+  constructor(private $q: IQService, private accountService: AccountService) { }
 
   public buildNewServerGroupCommand(app: Application,
                                     selectedProvider = 'appengine',
@@ -115,7 +116,7 @@ export class AppengineServerGroupCommandBuilder {
 
   private getCredentials(accounts: IAppengineAccount[], application: Application): string {
     let accountNames: string[] = (accounts || []).map((account) => account.name);
-    let defaultCredentials: string = get(this.settings, 'settings.providers.gce.defaults.account') as string;
+    let defaultCredentials: string = AppengineProviderSettings.defaults.account;
     let firstApplicationAccount: string = intersection(application.accounts || [], accountNames)[0];
 
     return accountNames.includes(defaultCredentials) ?

--- a/app/scripts/modules/azure/azure.settings.ts
+++ b/app/scripts/modules/azure/azure.settings.ts
@@ -1,0 +1,13 @@
+import { IProviderSettings, SETTINGS } from 'core/config/settings';
+
+export interface IAzureProviderSettings extends IProviderSettings {
+  defaults: {
+    account: string;
+    region: string;
+  };
+}
+
+export const AzureProviderSettings: IAzureProviderSettings = <IAzureProviderSettings>SETTINGS.providers.azure;
+if (AzureProviderSettings) {
+  AzureProviderSettings.resetToOriginal = SETTINGS.resetToOriginal;
+}

--- a/app/scripts/modules/azure/instance/azureInstanceType.service.js
+++ b/app/scripts/modules/azure/instance/azureInstanceType.service.js
@@ -8,10 +8,9 @@ import {INFRASTRUCTURE_CACHE_SERVICE} from 'core/cache/infrastructureCaches.serv
 
 module.exports = angular.module('spinnaker.azure.instanceType.service', [
   API_SERVICE,
-  require('core/config/settings.js'),
   INFRASTRUCTURE_CACHE_SERVICE,
 ])
-  .factory('azureInstanceTypeService', function ($http, $q, settings, API, infrastructureCaches) {
+  .factory('azureInstanceTypeService', function ($http, $q, API, infrastructureCaches) {
 
     var m3 = {
       type: 'M3',

--- a/app/scripts/modules/azure/instance/azureInstanceType.service.spec.js
+++ b/app/scripts/modules/azure/instance/azureInstanceType.service.spec.js
@@ -14,11 +14,10 @@ describe('Service: InstanceType', function () {
   });
 
 
-  beforeEach(window.inject(function (_azureInstanceTypeService_, _$httpBackend_, _settings_, infrastructureCaches, _API_) {
+  beforeEach(window.inject(function (_azureInstanceTypeService_, _$httpBackend_, infrastructureCaches, _API_) {
     API = _API_;
     this.azureInstanceTypeService = _azureInstanceTypeService_;
     this.$httpBackend = _$httpBackend_;
-    this.settings = _settings_;
 
     this.allTypes = [
       {account: 'test', region: 'us-west-2', name: 'm1.small', availabilityZone: 'us-west-2a'},

--- a/app/scripts/modules/azure/loadBalancer/loadBalancer.transformer.js
+++ b/app/scripts/modules/azure/loadBalancer/loadBalancer.transformer.js
@@ -2,11 +2,13 @@
 
 import _ from 'lodash';
 
+import {AzureProviderSettings} from '../azure.settings';
+
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.azure.loadBalancer.transformer', [
 ])
-  .factory('azureLoadBalancerTransformer', function ($q, settings) {
+  .factory('azureLoadBalancerTransformer', function ($q) {
 
     function normalizeLoadBalancer(loadBalancer) {
       loadBalancer.serverGroups.forEach(function(serverGroup) {
@@ -60,8 +62,8 @@ module.exports = angular.module('spinnaker.azure.loadBalancer.transformer', [
     }
 
     function constructNewLoadBalancerTemplate(application) {
-      var defaultCredentials = application.defaultCredentials.azure || settings.providers.azure.defaults.account,
-          defaultRegion = application.defaultRegion || settings.providers.azure.defaults.region;
+      var defaultCredentials = application.defaultCredentials.azure || AzureProviderSettings.defaults.account,
+          defaultRegion = application.defaultRegion || AzureProviderSettings.defaults.region;
       return {
         stack: '',
         detail: 'frontend',

--- a/app/scripts/modules/azure/pipeline/stages/bake/azureBakeStage.js
+++ b/app/scripts/modules/azure/pipeline/stages/bake/azureBakeStage.js
@@ -1,7 +1,9 @@
 'use strict';
 
 import _ from 'lodash';
+
 import {BAKERY_SERVICE} from 'core/pipeline/config/stages/bake/bakery.service';
+import {SETTINGS} from 'core/config/settings';
 
 let angular = require('angular');
 
@@ -36,7 +38,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.azure.bakeStage',
       restartable: true,
     });
   })
-  .controller('azureBakeStageCtrl', function($scope, bakeryService, $q, authenticationService, settings, $uibModal) {
+  .controller('azureBakeStageCtrl', function($scope, bakeryService, $q, authenticationService, $uibModal) {
 
     $scope.stage.extendedAttributes = $scope.stage.extendedAttributes || {};
     $scope.stage.regions = $scope.stage.regions || [];
@@ -81,7 +83,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.azure.bakeStage',
         if (!$scope.stage.baseLabel && $scope.baseLabelOptions && $scope.baseLabelOptions.length) {
           $scope.stage.baseLabel = $scope.baseLabelOptions[0];
         }
-        $scope.viewState.roscoMode = settings.feature.roscoMode;
+        $scope.viewState.roscoMode = SETTINGS.feature.roscoMode;
         $scope.viewState.loading = false;
       });
     }

--- a/app/scripts/modules/azure/pipeline/stages/bake/bakeExecutionDetails.controller.js
+++ b/app/scripts/modules/azure/pipeline/stages/bake/bakeExecutionDetails.controller.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import {EXECUTION_DETAILS_SECTION_SERVICE} from 'core/delivery/details/executionDetailsSection.service';
+import {SETTINGS} from 'core/config/settings';
 
 let angular = require('angular');
 
@@ -10,15 +11,15 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.bake.azure.execut
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ])
   .controller('azureBakeExecutionDetailsCtrl', function ($scope, $stateParams, executionDetailsSectionService,
-                                                       $interpolate, settings) {
+                                                       $interpolate) {
 
     $scope.configSections = ['bakeConfig', 'taskStatus'];
 
     let initialized = () => {
       $scope.detailsSection = $stateParams.details;
       $scope.provider = $scope.stage.context.cloudProviderType || 'azure';
-      $scope.roscoMode = settings.feature.roscoMode;
-      $scope.bakeryDetailUrl = $interpolate(settings.bakeryDetailUrl);
+      $scope.roscoMode = SETTINGS.feature.roscoMode;
+      $scope.bakeryDetailUrl = $interpolate(SETTINGS.bakeryDetailUrl);
     };
 
     let initialize = () => executionDetailsSectionService.synchronizeSection($scope.configSections, initialized);

--- a/app/scripts/modules/cloudfoundry/cf.settings.ts
+++ b/app/scripts/modules/cloudfoundry/cf.settings.ts
@@ -1,0 +1,13 @@
+import { IProviderSettings, SETTINGS } from 'core/config/settings';
+
+export interface ICloudFoundryProviderSettings extends IProviderSettings {
+  defaults: {
+    account: string;
+    region: string;
+  };
+}
+
+export const CloudFoundryProviderSettings: ICloudFoundryProviderSettings = <ICloudFoundryProviderSettings>SETTINGS.providers.cf;
+if (CloudFoundryProviderSettings) {
+  CloudFoundryProviderSettings.resetToOriginal = SETTINGS.resetToOriginal;
+}

--- a/app/scripts/modules/cloudfoundry/loadBalancer/loadBalancer.transformer.js
+++ b/app/scripts/modules/cloudfoundry/loadBalancer/loadBalancer.transformer.js
@@ -2,10 +2,12 @@
 
 import _ from 'lodash';
 
+import {CloudFoundryProviderSettings} from '../cf.settings';
+
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.cf.loadBalancer.transformer', [])
-  .factory('cfLoadBalancerTransformer', function ($q, settings) {
+  .factory('cfLoadBalancerTransformer', function ($q) {
 
     function updateHealthCounts(container) {
       var instances = container.instances;
@@ -67,8 +69,8 @@ module.exports = angular.module('spinnaker.cf.loadBalancer.transformer', [])
         cloudProvider: 'cf',
         stack: '',
         detail: '',
-        credentials: settings.providers.cf ? settings.providers.cf.defaults.account : null,
-        region: settings.providers.cf ? settings.providers.cf.defaults.region : null,
+        credentials: CloudFoundryProviderSettings ? CloudFoundryProviderSettings.defaults.account : null,
+        region: CloudFoundryProviderSettings ? CloudFoundryProviderSettings.defaults.region : null,
       };
     }
 

--- a/app/scripts/modules/cloudfoundry/pipeline/stages/findAmi/cfFindAmiStage.js
+++ b/app/scripts/modules/cloudfoundry/pipeline/stages/findAmi/cfFindAmiStage.js
@@ -3,12 +3,12 @@
 let angular = require('angular');
 import {ACCOUNT_SERVICE} from 'core/account/account.service';
 import {LIST_EXTRACTOR_SERVICE} from 'core/application/listExtractor/listExtractor.service';
+import {CloudFoundryProviderSettings} from '../../../cf.settings';
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.cf.findAmiStage', [
   LIST_EXTRACTOR_SERVICE,
   require('./findAmiExecutionDetails.controller.js'),
   ACCOUNT_SERVICE,
-  require('core/config/settings.js')
 ])
   .config(function(pipelineConfigProvider) {
     pipelineConfigProvider.registerStage({
@@ -22,7 +22,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.cf.findAmiStage',
         { type: 'requiredField', fieldName: 'credentials' }
       ]
     });
-  }).controller('cfFindAmiStageCtrl', function($scope, accountService, appListExtractorService, settings) {
+  }).controller('cfFindAmiStageCtrl', function($scope, accountService, appListExtractorService) {
     var ctrl = this;
 
     let stage = $scope.stage;
@@ -51,7 +51,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.cf.findAmiStage',
     };
 
     ctrl.updateRegions = function() {
-      let preferredZoneList = settings.providers.cf.preferredZonesByAccount[$scope.stage.credentials];
+      let preferredZoneList = CloudFoundryProviderSettings.preferredZonesByAccount[$scope.stage.credentials];
       stage.regions = Object.keys(preferredZoneList);
     };
 

--- a/app/scripts/modules/cloudfoundry/serverGroup/configure/ServerGroupCommandBuilder.js
+++ b/app/scripts/modules/cloudfoundry/serverGroup/configure/ServerGroupCommandBuilder.js
@@ -5,6 +5,7 @@ import _ from 'lodash';
 import {ACCOUNT_SERVICE} from 'core/account/account.service';
 import {INSTANCE_TYPE_SERVICE} from 'core/instance/instanceType.service';
 import {NAMING_SERVICE} from 'core/naming/naming.service';
+import {CloudFoundryProviderSettings} from '../../cf.settings';
 
 let angular = require('angular');
 
@@ -13,8 +14,7 @@ module.exports = angular.module('spinnaker.cf.serverGroupCommandBuilder.service'
   INSTANCE_TYPE_SERVICE,
   NAMING_SERVICE,
 ])
-  .factory('cfServerGroupCommandBuilder', function (settings, $q,
-                                                     accountService, instanceTypeService, namingService) {
+  .factory('cfServerGroupCommandBuilder', function ($q, accountService, instanceTypeService, namingService) {
 
     function populateTags(instanceTemplateTags, command) {
       if (instanceTemplateTags && instanceTemplateTags.items) {
@@ -45,8 +45,8 @@ module.exports = angular.module('spinnaker.cf.serverGroupCommandBuilder.service'
     function buildNewServerGroupCommand(application, defaults) {
       defaults = defaults || {};
 
-      var defaultCredentials = defaults.account || settings.providers.cf.defaults.account;
-      var defaultRegion = defaults.region || settings.providers.cf.defaults.region;
+      var defaultCredentials = defaults.account || CloudFoundryProviderSettings.defaults.account;
+      var defaultRegion = defaults.region || CloudFoundryProviderSettings.defaults.region;
 
       var command = {
         application: application.name,

--- a/app/scripts/modules/core/account/account.service.spec.ts
+++ b/app/scripts/modules/core/account/account.service.spec.ts
@@ -2,11 +2,11 @@ import {mock} from 'angular';
 import {API_SERVICE, Api} from 'core/api/api.service';
 import {ACCOUNT_SERVICE, AccountService, IAccount} from 'core/account/account.service';
 import {CloudProviderRegistry} from '../cloudProvider/cloudProvider.registry';
+import {SETTINGS} from 'core/config/settings';
 
 describe('Service: accountService', () => {
 
   let $http: ng.IHttpBackendService;
-  let settings: any;
   let cloudProviderRegistry: CloudProviderRegistry;
   let API: Api;
   let accountService: AccountService;
@@ -16,16 +16,16 @@ describe('Service: accountService', () => {
   beforeEach(
     mock.inject(
       function ($httpBackend: ng.IHttpBackendService,
-                _settings_: any,
                 _cloudProviderRegistry_: CloudProviderRegistry,
                 _API_: Api,
                 _accountService_: AccountService) {
         $http = $httpBackend;
-        settings = _settings_;
         cloudProviderRegistry = _cloudProviderRegistry_;
         API = _API_;
         accountService = _accountService_;
       }));
+
+  afterEach(SETTINGS.resetToOriginal);
 
   it('should filter the list of accounts by provider when supplied', () => {
     $http.expectGET(`${API.baseUrl}/credentials`).respond(200, [
@@ -128,7 +128,7 @@ describe('Service: accountService', () => {
 
       const application: any = {attributes: { cloudProviders: [] }};
       const test: any = (result: string[]) => expect(result).toEqual(['cf', 'gce']);
-      settings.defaultProviders = ['gce', 'cf'];
+      SETTINGS.defaultProviders = ['gce', 'cf'];
       accountService.listProviders(application).then(test);
       $http.flush();
     });
@@ -137,7 +137,7 @@ describe('Service: accountService', () => {
 
       const application: any = {attributes: {cloudProviders: ['gce', 'cf', 'unicron']}};
       const test: any = (result: string[]) => expect(result).toEqual(['cf', 'gce']);
-      settings.defaultProviders = ['aws'];
+      SETTINGS.defaultProviders = ['aws'];
       accountService.listProviders(application).then(test);
       $http.flush();
     });
@@ -146,7 +146,7 @@ describe('Service: accountService', () => {
 
       const application: any = {attributes: {cloudProviders: ['lamp', 'ceiling', 'fan']}};
       const test: any = (result: string[]) => expect(result).toEqual([]);
-      settings.defaultProviders = 'aws';
+      SETTINGS.defaultProviders = ['foo'];
       accountService.listProviders(application).then(test);
       $http.flush();
     });
@@ -155,7 +155,7 @@ describe('Service: accountService', () => {
 
       const application: any = {attributes: { cloudProviders: [] }};
       const test: any = (result: string[]) => expect(result).toEqual(['aws', 'cf', 'gce']);
-      delete settings.defaultProviders;
+      delete SETTINGS.defaultProviders;
       accountService.listProviders(application).then(test);
       $http.flush();
     });

--- a/app/scripts/modules/core/account/account.service.ts
+++ b/app/scripts/modules/core/account/account.service.ts
@@ -4,6 +4,7 @@ import {module} from 'angular';
 import {Application} from 'core/application/application.model';
 import {API_SERVICE, Api} from 'core/api/api.service';
 import {CLOUD_PROVIDER_REGISTRY, CloudProviderRegistry} from '../cloudProvider/cloudProvider.registry';
+import {SETTINGS} from 'core/config/settings';
 
 export interface IRegion {
   account?: string;
@@ -47,12 +48,11 @@ export interface IAccountZone {
 export class AccountService {
 
   static get $inject() {
-    return ['$log', '$q', 'settings', 'cloudProviderRegistry', 'API'];
+    return ['$log', '$q', 'cloudProviderRegistry', 'API'];
   }
 
   constructor(private $log: ng.ILogService,
               private $q: ng.IQService,
-              private settings: any,
               private cloudProviderRegistry: CloudProviderRegistry,
               private API: Api) {
   }
@@ -185,8 +185,8 @@ export class AccountService {
           if (application.attributes.cloudProviders.length) {
             result = application.attributes.cloudProviders;
           } else {
-            if (this.settings.defaultProviders) {
-              result = this.settings.defaultProviders;
+            if (SETTINGS.defaultProviders) {
+              result = SETTINGS.defaultProviders;
             } else {
               result = available;
             }
@@ -204,7 +204,6 @@ export class AccountService {
 
 export const ACCOUNT_SERVICE = 'spinnaker.core.account.service';
 module(ACCOUNT_SERVICE, [
-  require('core/config/settings'),
   CLOUD_PROVIDER_REGISTRY,
   API_SERVICE
 ])

--- a/app/scripts/modules/core/analytics/analytics.service.js
+++ b/app/scripts/modules/core/analytics/analytics.service.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import {SETTINGS} from 'core/config/settings';
+
 const angular = require('angular');
 
 module.exports = angular
@@ -7,8 +9,8 @@ module.exports = angular
     require('angulartics'),
     require('angulartics-google-analytics'),
   ])
-  .run(function ($window, settings) {
-    if (settings.analytics && settings.analytics.ga) {
-      $window.ga('create', settings.analytics.ga, 'auto');
+  .run(function ($window) {
+    if (SETTINGS.analytics.ga) {
+      $window.ga('create', SETTINGS.analytics.ga, 'auto');
     }
   });

--- a/app/scripts/modules/core/api/api.service.spec.ts
+++ b/app/scripts/modules/core/api/api.service.spec.ts
@@ -2,6 +2,7 @@ import Spy = jasmine.Spy;
 import {mock, noop} from 'angular';
 import {AuthenticationInitializer} from '../authentication/authentication.initializer.service';
 import {API_SERVICE, Api} from './api.service';
+import {SETTINGS} from 'core/config/settings';
 
 describe('API Service', function () {
   let API: Api;
@@ -11,8 +12,7 @@ describe('API Service', function () {
 
   beforeEach(
     mock.module(
-      API_SERVICE,
-      require('../config/settings')
+      API_SERVICE
     )
   );
 
@@ -20,11 +20,10 @@ describe('API Service', function () {
     mock.inject(
       function (_API_: Api,
                 _$httpBackend_: ng.IHttpBackendService,
-                settings: any,
                 _authenticationInitializer_: AuthenticationInitializer) {
       API = _API_;
       $httpBackend = _$httpBackend_;
-      baseUrl = settings.gateUrl;
+      baseUrl = SETTINGS.gateUrl;
       authenticationInitializer = _authenticationInitializer_;
     }));
 

--- a/app/scripts/modules/core/api/api.service.ts
+++ b/app/scripts/modules/core/api/api.service.ts
@@ -4,6 +4,7 @@ import {
   AUTHENTICATION_INITIALIZER_SERVICE,
   AuthenticationInitializer
 } from '../authentication/authentication.initializer.service';
+import {SETTINGS} from 'core/config/settings';
 
 interface DefaultParams {
   timeout: number;
@@ -26,7 +27,7 @@ export interface IRequestBuilder {
 export class Api {
 
   static get $inject() {
-    return ['$q', '$http', 'settings', 'authenticationInitializer'];
+    return ['$q', '$http', 'authenticationInitializer'];
   }
 
   private gateUrl: string;
@@ -34,11 +35,10 @@ export class Api {
 
   constructor(private $q: IQService,
               private $http: IHttpService,
-              settings: any,
               private authenticationIntializer: AuthenticationInitializer) {
-    this.gateUrl = settings.gateUrl;
+    this.gateUrl = SETTINGS.gateUrl;
     this.defaultParams = {
-      timeout: settings.pollSchedule * 2 + 5000
+      timeout: SETTINGS.pollSchedule * 2 + 5000
     };
   }
 
@@ -191,7 +191,7 @@ export class Api {
 
 const API_SERVICE_NAME = 'API';
 export const API_SERVICE = 'spinnaker.core.api.provider';
-module(API_SERVICE, [require('../config/settings'), AUTHENTICATION_INITIALIZER_SERVICE])
+module(API_SERVICE, [AUTHENTICATION_INITIALIZER_SERVICE])
   .service(API_SERVICE_NAME, Api);
 
 export const API_SERVICE_PROVIDER: Provider = {

--- a/app/scripts/modules/core/application/applications.controller.spec.js
+++ b/app/scripts/modules/core/application/applications.controller.spec.js
@@ -1,9 +1,6 @@
 'use strict';
 
-
 describe('Controller: Applications', function() {
-
-
   beforeEach(
     window.module(
       require('./applications.controller'),
@@ -23,10 +20,9 @@ describe('Controller: Applications', function() {
 
     // Initialize the controller and a mock scope
     beforeEach(window.inject(function ($controller, $rootScope, $window, $q, $uibModal, $log, $filter, accountService,
-                                $state, $timeout, settings, applicationReader) {
+                                $state, $timeout, applicationReader) {
 
       this.$scope = $rootScope.$new();
-      this.settings = settings;
       this.$q = $q;
       this.accountService = accountService;
       this.applicationReader = applicationReader;

--- a/app/scripts/modules/core/application/config/applicationConfig.controller.js
+++ b/app/scripts/modules/core/application/config/applicationConfig.controller.js
@@ -1,6 +1,7 @@
 import {APPLICATION_DATA_SOURCE_EDITOR} from './dataSources/applicationDataSourceEditor.component';
 import {CHAOS_MONKEY_CONFIG_COMPONENT} from 'core/chaosMonkey/chaosMonkeyConfig.component';
 import {TRAFFIC_GUARD_CONFIG_COMPONENT} from './trafficGuard/trafficGuardConfig.component';
+import {SETTINGS} from 'core/config/settings';
 
 let angular = require('angular');
 
@@ -16,14 +17,13 @@ module.exports = angular
     CHAOS_MONKEY_CONFIG_COMPONENT,
     TRAFFIC_GUARD_CONFIG_COMPONENT,
     require('./links/applicationLinks.component.js'),
-    require('../../config/settings.js')
   ])
-  .controller('ApplicationConfigController', function ($state, app, settings) {
+  .controller('ApplicationConfigController', function ($state, app) {
     this.application = app;
-    this.feature = settings.feature;
+    this.feature = SETTINGS.feature;
     if (app.notFound) {
       $state.go('home.infrastructure', null, {location: 'replace'});
     } else {
-      this.application.attributes.instancePort = this.application.attributes.instancePort || settings.defaultInstancePort || null;
+      this.application.attributes.instancePort = this.application.attributes.instancePort || SETTINGS.defaultInstancePort || null;
     }
   });

--- a/app/scripts/modules/core/application/config/links/applicationLinks.component.js
+++ b/app/scripts/modules/core/application/config/links/applicationLinks.component.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import {CONFIG_SECTION_FOOTER} from '../footer/configSectionFooter.component';
+import {SETTINGS} from 'core/config/settings';
 
 require('./applicationLinks.component.less');
 
@@ -11,7 +12,6 @@ const angular = require('angular');
 module.exports = angular
   .module('spinnaker.core.application.config.applicationLinks.component', [
     require('./editLinks.modal.controller'),
-    require('core/config/settings'),
     require('angular-ui-bootstrap'),
     CONFIG_SECTION_FOOTER,
   ])
@@ -20,14 +20,14 @@ module.exports = angular
       application: '=',
     },
     templateUrl: require('./applicationLinks.component.html'),
-    controller: function($uibModal, settings) {
+    controller: function($uibModal) {
 
       let initialize = () => {
         if (this.application.notFound) {
           return;
         }
 
-        this.sections = _.cloneDeep(this.application.attributes.instanceLinks || settings.defaultInstanceLinks || []);
+        this.sections = _.cloneDeep(this.application.attributes.instanceLinks || SETTINGS.defaultInstanceLinks || []);
 
         this.viewState = {
           originalSections: _.cloneDeep(this.sections),
@@ -41,14 +41,14 @@ module.exports = angular
       };
 
       this.setDefaultLinkState = () => {
-        this.usingDefaultLinks = angular.toJson(this.sections) === angular.toJson(settings.defaultInstanceLinks);
-        this.defaultLinksConfigured = !!settings.defaultInstanceLinks;
+        this.usingDefaultLinks = angular.toJson(this.sections) === angular.toJson(SETTINGS.defaultInstanceLinks);
+        this.defaultLinksConfigured = !!SETTINGS.defaultInstanceLinks;
       };
 
       this.revert = initialize;
 
       this.useDefaultLinks = () => {
-        this.sections = _.cloneDeep(settings.defaultInstanceLinks);
+        this.sections = _.cloneDeep(SETTINGS.defaultInstanceLinks);
         this.configChanged();
       };
 

--- a/app/scripts/modules/core/application/modal/applicationProviderFields.component.js
+++ b/app/scripts/modules/core/application/modal/applicationProviderFields.component.js
@@ -2,13 +2,13 @@
 
 import _ from 'lodash';
 import {CLOUD_PROVIDER_REGISTRY} from 'core/cloudProvider/cloudProvider.registry';
+import {SETTINGS} from 'core/config/settings';
 
 const angular = require('angular');
 
 module.exports = angular
   .module('spinnaker.core.application.modal.applicationProviderFields.directive', [
     CLOUD_PROVIDER_REGISTRY,
-    require('../../config/settings.js'),
   ])
   .component('applicationProviderFields', {
       templateUrl: require('./applicationProviderFields.component.html'),
@@ -18,9 +18,9 @@ module.exports = angular
       },
       controller: 'ApplicationProviderFieldsCtrl',
   })
-  .controller('ApplicationProviderFieldsCtrl', function(cloudProviderRegistry, settings) {
+  .controller('ApplicationProviderFieldsCtrl', function(cloudProviderRegistry) {
     const templateUrlPath = 'applicationProviderFields.templateUrl';
-    let defaultProviderFields = settings.providers;
+    let defaultProviderFields = SETTINGS.providers;
 
     this.initializeApplicationField = (fieldPath) => {
       let applicationFieldPath = 'providerSettings.' + fieldPath;

--- a/app/scripts/modules/core/application/modal/applicationProviderFields.component.spec.js
+++ b/app/scripts/modules/core/application/modal/applicationProviderFields.component.spec.js
@@ -1,12 +1,12 @@
 'use strict';
 
-describe('Controller: ApplicationProviderFieldsCtrl', function () {
+import _ from 'lodash';
+import {SETTINGS} from 'core/config/settings';
 
+describe('Controller: ApplicationProviderFieldsCtrl', function () {
   let controller,
     scope,
-    cloudProviderRegistry,
-    settings,
-    _ = require('lodash');
+    cloudProviderRegistry;
 
   beforeEach(
     window.module(
@@ -14,17 +14,12 @@ describe('Controller: ApplicationProviderFieldsCtrl', function () {
     )
   );
 
+  beforeEach(() => { SETTINGS.providers.aws.defaultPath = '/path/to/somewhere'; });
+
   beforeEach(
     window.inject(function ($rootScope, $controller, _cloudProviderRegistry_) {
       scope = $rootScope.$new(),
-      cloudProviderRegistry = _cloudProviderRegistry_,
-      settings = {
-        providers: {
-          aws: {
-            defaultPath: '/path/to/somewhere',
-          }
-        },
-      };
+      cloudProviderRegistry = _cloudProviderRegistry_;
 
       let application = {
         cloudProviders: [],
@@ -37,18 +32,17 @@ describe('Controller: ApplicationProviderFieldsCtrl', function () {
 
       spyOn(cloudProviderRegistry, 'getValue').and.returnValue('path/to/template');
       spyOn(cloudProviderRegistry, 'hasValue').and.returnValue(true);
-
       controller = $controller('ApplicationProviderFieldsCtrl', {
         $scope: scope,
-        cloudProviderRegistry: cloudProviderRegistry,
-        settings,
-        _,
+        cloudProviderRegistry: cloudProviderRegistry
       }, {
         application,
         cloudProviders,
       });
     })
   );
+
+  afterEach(SETTINGS.resetToOriginal);
 
   it('should instantiate the controller', function () {
     expect(controller).toBeDefined();
@@ -107,8 +101,7 @@ describe('Controller: ApplicationProviderFieldsCtrl', function () {
     });
 
     it('does not mutate the application if the path does not exist within the global provider settings', function() {
-
-      _.set(settings, 'providers.aws', undefined);
+      SETTINGS.providers.aws = undefined;
       let applicationBeforeFunctionCall = _.cloneDeep(controller.application);
 
       controller.initializeApplicationField('aws.defaultPath');
@@ -117,15 +110,13 @@ describe('Controller: ApplicationProviderFieldsCtrl', function () {
 
     });
 
-    it(`mutates the application to match the global provider settings 
+    it(`mutates the application to match the global provider settings
       if the setting has not been defined within the application`,
       function() {
+        controller.initializeApplicationField('aws.defaultPath');
 
-      controller.initializeApplicationField('aws.defaultPath');
-
-      expect(_.get(controller.application, 'providerSettings.aws.defaultPath')).toEqual('/path/to/somewhere');
-
-    });
+        expect(_.get(controller.application, 'providerSettings.aws.defaultPath')).toEqual('/path/to/somewhere');
+      });
 
   });
 

--- a/app/scripts/modules/core/application/modal/createApplication.modal.controller.js
+++ b/app/scripts/modules/core/application/modal/createApplication.modal.controller.js
@@ -8,6 +8,7 @@ import {APPLICATION_NAME_VALIDATION_MESSAGES} from './validation/applicationName
 import {TASK_READ_SERVICE} from 'core/task/task.read.service';
 import {VALIDATE_APPLICATION_NAME} from './validation/validateApplicationName.directive';
 import {CHAOS_MONKEY_NEW_APPLICATION_CONFIG_COMPONENT} from 'core/chaosMonkey/chaosMonkeyNewApplicationConfig.component';
+import {SETTINGS} from 'core/config/settings';
 
 let angular = require('angular');
 
@@ -18,7 +19,6 @@ module.exports = angular
     APPLICATION_READ_SERVICE,
     ACCOUNT_SERVICE,
     TASK_READ_SERVICE,
-    require('../../config/settings'),
     APPLICATION_NAME_VALIDATION_MESSAGES,
     VALIDATE_APPLICATION_NAME,
     require('./applicationProviderFields.component.js'),
@@ -26,8 +26,7 @@ module.exports = angular
     CHAOS_MONKEY_NEW_APPLICATION_CONFIG_COMPONENT,
   ])
   .controller('CreateApplicationModalCtrl', function($scope, $q, $log, $state, $uibModalInstance, accountService,
-                                                     applicationWriter, applicationReader, taskReader, $timeout,
-                                                     settings) {
+                                                     applicationWriter, applicationReader, taskReader, $timeout) {
 
     let applicationLoader = applicationReader.listApplications();
     applicationLoader.then((applications) => this.data.appNameList = _.map(applications, 'name'));
@@ -51,7 +50,7 @@ module.exports = angular
     this.application = {
       accounts: [],
       cloudProviders: [],
-      instancePort: settings.defaultInstancePort || null,
+      instancePort: SETTINGS.defaultInstancePort || null,
     };
 
     let submitting = () => {

--- a/app/scripts/modules/core/application/modal/groupMembershipConfigurer.component.js
+++ b/app/scripts/modules/core/application/modal/groupMembershipConfigurer.component.js
@@ -1,20 +1,19 @@
 'use strict';
+import {SETTINGS} from 'core/config/settings';
 
 let angular = require('angular');
 
-module.exports = angular.module('spinnaker.deck.core.applicationModal.groupMembership.component', [
-    require('../../config/settings.js')
-  ])
+module.exports = angular.module('spinnaker.deck.core.applicationModal.groupMembership.component', [])
   .component('groupMembershipConfigurer', {
     bindings: {
       requiredGroupMembership: '='
     },
     templateUrl: require('./groupMembershipConfigurer.component.html'),
-    controller: function (settings, authenticationService) {
+    controller: function (authenticationService) {
 
       this.availableRoles = authenticationService.getAuthenticatedUser().roles;
 
-      this.fiatEnabled = settings.feature.fiatEnabled;
+      this.fiatEnabled = SETTINGS.feature.fiatEnabled;
       if (!this.fiatEnabled) {
         return;
       }

--- a/app/scripts/modules/core/application/modal/validation/exampleApplicationName.validator.ts
+++ b/app/scripts/modules/core/application/modal/validation/exampleApplicationName.validator.ts
@@ -4,6 +4,7 @@ import {
   ApplicationNameValidator, IValidationResult
 } from './applicationName.validator';
 import {CLOUD_PROVIDER_REGISTRY, CloudProviderRegistry} from 'core/cloudProvider/cloudProvider.registry';
+import {SETTINGS} from 'core/config/settings';
 
 export class ExampleApplicationNameValidator implements IApplicationNameValidator {
 
@@ -81,7 +82,6 @@ export const EXAMPLE_APPLICATION_NAME_VALIDATOR = 'spinnaker.core.application.mo
 module(EXAMPLE_APPLICATION_NAME_VALIDATOR, [
   APPLICATION_NAME_VALIDATOR,
   CLOUD_PROVIDER_REGISTRY,
-  require('core/config/settings.js'),
 ]).service('exampleApplicationNameValidator', ExampleApplicationNameValidator)
   .service('exampleApplicationNameValidator2', ExampleApplicationNameValidator2)
   .run((applicationNameValidator: ApplicationNameValidator,
@@ -90,9 +90,9 @@ module(EXAMPLE_APPLICATION_NAME_VALIDATOR, [
     applicationNameValidator.registerValidator('example', exampleApplicationNameValidator);
     applicationNameValidator.registerValidator('example2', exampleApplicationNameValidator2);
   })
-  .config((cloudProviderRegistryProvider: CloudProviderRegistry, settings: any) => {
-    settings.providers.example = {};
-    settings.providers.example2 = {};
+  .config((cloudProviderRegistryProvider: CloudProviderRegistry) => {
+    SETTINGS.providers.example = { defaults: { account: 'test' }, resetToOriginal: () => {} };
+    SETTINGS.providers.example2 = { defaults: { account: 'test' }, resetToOriginal: () => {} };
     cloudProviderRegistryProvider.registerProvider('example', {name: 'example'});
     cloudProviderRegistryProvider.registerProvider('example2', {name: 'example2'});
   });

--- a/app/scripts/modules/core/authentication/authentication.initializer.service.ts
+++ b/app/scripts/modules/core/authentication/authentication.initializer.service.ts
@@ -6,6 +6,7 @@ import {IModalService, IModalStackService} from 'angular-ui-bootstrap';
 import {IDeckRootScope} from '../domain/deckRootScope';
 import {REDIRECT_SERVICE, RedirectService} from './redirect.service';
 import {AUTHENTICATION_SERVICE, AuthenticationService} from './authentication.service';
+import {SETTINGS} from 'core/config/settings';
 
 interface IAuthResponse {
   username: string;
@@ -17,7 +18,7 @@ export class AuthenticationInitializer {
   static get $inject(): string[] {
     return [
       '$location', '$rootScope', '$http', '$uibModal', '$uibModalStack',
-      'settings', 'redirectService', 'authenticationService'
+      'redirectService', 'authenticationService'
     ];
   }
 
@@ -29,13 +30,12 @@ export class AuthenticationInitializer {
               private $http: ng.IHttpService,
               private $uibModal: IModalService,
               private $uibModalStack: IModalStackService,
-              private settings: any,
               private redirectService: RedirectService,
               private authenticationService: AuthenticationService) {
   }
 
   private checkForReauthentication(): void {
-    this.$http.get(this.settings.authEndpoint)
+    this.$http.get(SETTINGS.authEndpoint)
       .then((response: ng.IHttpPromiseCallbackArg<IAuthResponse>) => {
         if (response.data.username) {
           this.authenticationService.setAuthenticatedUser({
@@ -72,12 +72,12 @@ export class AuthenticationInitializer {
 
   private loginRedirect(): void {
     const callback: string = encodeURIComponent(this.$location.absUrl());
-    this.redirectService.redirect(`${this.settings.gateUrl}/auth/redirect?to=${callback}`);
+    this.redirectService.redirect(`${SETTINGS.gateUrl}/auth/redirect?to=${callback}`);
   }
 
   public authenticateUser() {
     this.$rootScope.authenticating = true;
-    this.$http.get(this.settings.authEndpoint)
+    this.$http.get(SETTINGS.authEndpoint)
       .then((response: ng.IHttpPromiseCallbackArg<IAuthResponse>) => {
         if (response.data.username) {
           this.authenticationService.setAuthenticatedUser({
@@ -95,7 +95,7 @@ export class AuthenticationInitializer {
 
   public reauthenticateUser(): void {
     if (!this.userLoggedOut) {
-      this.$http.get(this.settings.authEndpoint)
+      this.$http.get(SETTINGS.authEndpoint)
         .then((response: ng.IHttpPromiseCallbackArg<IAuthResponse>) => {
           if (response.data.username) {
             this.authenticationService.setAuthenticatedUser({
@@ -119,7 +119,7 @@ export class AuthenticationInitializer {
         transformResponse: (response: string) => response,
       };
 
-      this.$http.get(`${this.settings.gateUrl}/auth/logout`, config)
+      this.$http.get(`${SETTINGS.gateUrl}/auth/logout`, config)
         .then(() => this.loggedOutSequence(), () => this.loggedOutSequence());
     }
   }
@@ -134,7 +134,6 @@ export class AuthenticationInitializer {
 export const AUTHENTICATION_INITIALIZER_SERVICE = 'spinnaker.authentication.initializer.service';
 module(AUTHENTICATION_INITIALIZER_SERVICE, [
   require('angular-ui-bootstrap'),
-  require('../config/settings'),
   REDIRECT_SERVICE,
   AUTHENTICATION_SERVICE,
   require('./loggedOut.modal.controller')

--- a/app/scripts/modules/core/authentication/authentication.interceptor.spec.ts
+++ b/app/scripts/modules/core/authentication/authentication.interceptor.spec.ts
@@ -3,11 +3,11 @@ import {mock, module} from 'angular';
 
 import {AUTHENTICATION_INTERCEPTOR_SERVICE, AuthenticationInterceptor} from './authentication.interceptor.service';
 import {AUTHENTICATION_SERVICE, AuthenticationService} from './authentication.service';
+import {SETTINGS} from 'core/config/settings';
 
 describe('authenticationInterceptor', function() {
 
   let interceptor: AuthenticationInterceptor,
-    settings: any,
     authenticationService: AuthenticationService,
     $rootScope: ng.IRootScopeService;
 
@@ -19,16 +19,14 @@ describe('authenticationInterceptor', function() {
       return injector.get(AuthenticationService);
     });
 
-  beforeEach(mock.module(require('../config/settings'), AUTHENTICATION_INTERCEPTOR_SERVICE));
+  beforeEach(mock.module(AUTHENTICATION_INTERCEPTOR_SERVICE));
 
   beforeEach(
     mock.inject(
       function (_$q_: ng.IQService,
-                _settings_: any,
                 _authenticationService_: AuthenticationService,
                 _$rootScope_: ng.IRootScopeService,
                 _authenticationInterceptor_: AuthenticationInterceptor) {
-        settings = _settings_;
         authenticationService = _authenticationService_;
         $rootScope = _$rootScope_;
         interceptor = _authenticationInterceptor_;
@@ -37,7 +35,7 @@ describe('authenticationInterceptor', function() {
   describe('non-intercepted requests', function() {
     it('resolves immediately for auth endpoint', function() {
       let resolved: ng.IRequestConfig = null;
-      const request: ng.IRequestConfig = { url: settings.authEndpoint, method: 'GET' };
+      const request: ng.IRequestConfig = { url: SETTINGS.authEndpoint, method: 'GET' };
       interceptor.request(request).then(function(result) { resolved = result; });
       $rootScope.$digest();
       expect(resolved).toBe(request);

--- a/app/scripts/modules/core/authentication/authentication.module.ts
+++ b/app/scripts/modules/core/authentication/authentication.module.ts
@@ -2,13 +2,13 @@ import {AUTHENTICATION_INTERCEPTOR_SERVICE} from './authentication.interceptor.s
 import {AUTHENTICATION_INITIALIZER_SERVICE, AuthenticationInitializer} from './authentication.initializer.service';
 import {REDIRECT_SERVICE} from './redirect.service';
 import {AUTHENTICATION_SERVICE} from './authentication.service';
+import {SETTINGS} from 'core/config/settings';
 
 let angular = require('angular');
 
 export const AUTHENTICATION = 'spinnaker.authentication';
 angular.module(AUTHENTICATION, [
   AUTHENTICATION_SERVICE,
-  require('../config/settings.js'),
   REDIRECT_SERVICE,
   AUTHENTICATION_INITIALIZER_SERVICE,
   AUTHENTICATION_INTERCEPTOR_SERVICE,
@@ -18,10 +18,10 @@ angular.module(AUTHENTICATION, [
   .config(function ($httpProvider: ng.IHttpProvider) {
     $httpProvider.interceptors.push('gateRequestInterceptor');
   })
-  .factory('gateRequestInterceptor', function (settings: any) {
+  .factory('gateRequestInterceptor', function () {
     return {
       request: function (config: ng.IRequestConfig) {
-        if (config.url.indexOf(settings.gateUrl) === 0) {
+        if (config.url.indexOf(SETTINGS.gateUrl) === 0) {
           config.withCredentials = true;
         }
         return config;
@@ -29,11 +29,10 @@ angular.module(AUTHENTICATION, [
     };
   })
   .run(function (schedulerFactory: any,
-                 authenticationInitializer: AuthenticationInitializer,
-                 settings: any) {
-    if (settings.authEnabled) {
+                 authenticationInitializer: AuthenticationInitializer) {
+    if (SETTINGS.authEnabled) {
       // schedule deck to re-authenticate every 10 min.
-      schedulerFactory.createScheduler(settings.authTtl || 600000)
+      schedulerFactory.createScheduler(SETTINGS.authTtl || 600000)
         .subscribe(() => authenticationInitializer.reauthenticateUser());
       authenticationInitializer.authenticateUser();
     }

--- a/app/scripts/modules/core/authentication/authentication.provider.spec.ts
+++ b/app/scripts/modules/core/authentication/authentication.provider.spec.ts
@@ -4,9 +4,13 @@ import {IDeckRootScope} from 'core/domain/deckRootScope';
 import {RedirectService} from './redirect.service';
 import {AuthenticationService} from './authentication.service';
 import {AUTHENTICATION} from './authentication.module';
+import {SETTINGS} from 'core/config/settings';
 
 declare let window: any;
 describe('authenticationProvider: application startup', function () {
+  beforeEach(function () {
+    SETTINGS.authEnabled = true;
+  });
 
   beforeEach(function () {
     window.spinnakerSettings.authEnabled = true;
@@ -17,7 +21,6 @@ describe('authenticationProvider: application startup', function () {
   let authenticationService: AuthenticationService,
     $timeout: ng.ITimeoutService,
     $http: ng.IHttpBackendService,
-    settings: any,
     redirectService: RedirectService,
     $location: ng.ILocationService,
     $rootScope: IDeckRootScope;
@@ -27,7 +30,6 @@ describe('authenticationProvider: application startup', function () {
       (_authenticationService_: AuthenticationService,
        _$timeout_: ng.ITimeoutService,
        _$httpBackend_: ng.IHttpBackendService,
-       _settings_: any,
        _redirectService_: RedirectService,
        _$location_: ng.ILocationService,
        _$rootScope_: IDeckRootScope) => {
@@ -36,22 +38,18 @@ describe('authenticationProvider: application startup', function () {
         $timeout = _$timeout_;
         $http = _$httpBackend_;
 
-        settings = _settings_;
-        settings.authEnabled = true;
 
         redirectService = _redirectService_;
         $location = _$location_;
         $rootScope = _$rootScope_;
       }));
 
-  afterEach(function () {
-    settings.authEnabled = false;
-  });
+  afterEach(SETTINGS.resetToOriginal);
 
   describe('authenticateUser', () => {
     it('requests authentication from gate, then sets authentication name field', function () {
 
-      $http.whenGET(settings.authEndpoint).respond(200, {username: 'joe!'});
+      $http.whenGET(SETTINGS.authEndpoint).respond(200, {username: 'joe!'});
       $timeout.flush();
       $http.flush();
 
@@ -63,7 +61,7 @@ describe('authenticationProvider: application startup', function () {
     it('requests authentication from gate, then opens modal and redirects on 401', function () {
       let redirectUrl = 'abc';
       spyOn(redirectService, 'redirect').and.callFake((url: string) => redirectUrl = url);
-      $http.whenGET(settings.authEndpoint).respond(401, null, {'X-AUTH-REDIRECT-URL': '/authUp'});
+      $http.whenGET(SETTINGS.authEndpoint).respond(401, null, {'X-AUTH-REDIRECT-URL': '/authUp'});
       $rootScope.$digest();
       $http.flush();
 
@@ -71,7 +69,7 @@ describe('authenticationProvider: application startup', function () {
       expect($rootScope.authenticating).toBe(true);
       expect(authenticationService.getAuthenticatedUser().name).toBe('[anonymous]');
       expect(authenticationService.getAuthenticatedUser().authenticated).toBe(false);
-      expect(redirectUrl).toBe(`${settings.gateUrl}/auth/redirect?to=${callback}`);
+      expect(redirectUrl).toBe(`${SETTINGS.gateUrl}/auth/redirect?to=${callback}`);
     });
   });
 });

--- a/app/scripts/modules/core/authentication/userMenu/userMenu.directive.js
+++ b/app/scripts/modules/core/authentication/userMenu/userMenu.directive.js
@@ -2,21 +2,21 @@
 
 import {AUTHENTICATION_INITIALIZER_SERVICE} from '../authentication.initializer.service';
 import {AUTHENTICATION_SERVICE} from '../authentication.service';
+import {SETTINGS} from 'core/config/settings';
 
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.authentication.userMenu.directive', [
-  require('../../config/settings.js'),
   AUTHENTICATION_INITIALIZER_SERVICE,
   AUTHENTICATION_SERVICE
 ])
-  .directive('userMenu', function(settings, authenticationService, authenticationInitializer) {
+  .directive('userMenu', function(authenticationService, authenticationInitializer) {
     return {
       restrict: 'E',
       replace: true,
       templateUrl: require('./userMenu.directive.html'),
       link: function(scope) {
-        scope.authEnabled = settings.authEnabled;
+        scope.authEnabled = SETTINGS.authEnabled;
         scope.user = authenticationService.getAuthenticatedUser();
         scope.showLogOutDropdown = () => authenticationService.getAuthenticatedUser().authenticated;
         scope.logOut = () => authenticationInitializer.logOut();

--- a/app/scripts/modules/core/authentication/userMenu/userMenu.directive.spec.js
+++ b/app/scripts/modules/core/authentication/userMenu/userMenu.directive.spec.js
@@ -1,7 +1,9 @@
 'use strict';
 
+import {SETTINGS} from 'core/config/settings';
+
 describe('Directives: userMenu', function () {
-  var $scope, $compile, settings, authenticationService;
+  var $scope, $compile, authenticationService;
 
   require('./userMenu.directive.html');
   beforeEach(window.module(
@@ -9,13 +11,14 @@ describe('Directives: userMenu', function () {
   ));
 
   beforeEach(
-    window.inject(function ($rootScope, _$compile_, _settings_, _authenticationService_) {
+    window.inject(function ($rootScope, _$compile_, _authenticationService_) {
       $scope = $rootScope.$new();
       $compile = _$compile_;
-      settings = _settings_;
       authenticationService = _authenticationService_;
     })
   );
+
+  afterEach(SETTINGS.resetToOriginal);
 
   function createUserMenu(givenScope) {
     var domNode;
@@ -32,7 +35,7 @@ describe('Directives: userMenu', function () {
     it('displays nothing when auth is not enabled', function () {
       var domNode;
 
-      settings.authEnabled = false;
+      SETTINGS.authEnabled = false;
       domNode = createUserMenu($scope);
 
       expect(domNode.size()).toBe(0);
@@ -41,7 +44,7 @@ describe('Directives: userMenu', function () {
     it('displays the user menu when auth is enabled', function () {
       var domNode;
 
-      settings.authEnabled = true;
+      SETTINGS.authEnabled = true;
       spyOn(authenticationService, 'getAuthenticatedUser').and.returnValue({'name': 'sam mulligan'});
       domNode = createUserMenu($scope);
 
@@ -51,7 +54,7 @@ describe('Directives: userMenu', function () {
     it('displays the user name for both large and small screens', function () {
       var domNode;
 
-      settings.authEnabled = true;
+      SETTINGS.authEnabled = true;
       spyOn(authenticationService, 'getAuthenticatedUser').and.returnValue({'name': 'sam mulligan'});
       domNode = createUserMenu($scope);
 

--- a/app/scripts/modules/core/authentication/userMenu/userMenu.module.js
+++ b/app/scripts/modules/core/authentication/userMenu/userMenu.module.js
@@ -8,7 +8,6 @@ require('./userMenu.less');
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.authentication.userMenu', [
-  require('../../config/settings.js'),
   AUTHENTICATION_SERVICE,
   require('./userMenu.directive.js')
 ]);

--- a/app/scripts/modules/core/cache/deckCache.service.ts
+++ b/app/scripts/modules/core/cache/deckCache.service.ts
@@ -1,6 +1,8 @@
 import * as moment from 'moment';
 import {module} from 'angular';
 
+import {SETTINGS} from 'core/config/settings';
+
 interface ILocalStorage {
   getItem: (key: string) => void;
   removeItem: (key: string) => void;
@@ -13,11 +15,11 @@ interface ICacheProxy {
 
 class SelfClearingLocalStorage implements ILocalStorage {
 
-  constructor(private $log: ng.ILogService, private settings: any, private cacheProxy: ICacheProxy) {}
+  constructor(private $log: ng.ILogService, private cacheProxy: ICacheProxy) {}
 
   public setItem(k: string, v: any) {
     try {
-      if (k.includes(this.settings.gateUrl)) {
+      if (k.includes(SETTINGS.gateUrl)) {
         const response = JSON.parse(v);
         if (response.value && Array.isArray(response.value) && (response.value.length > 2) && Array.isArray(response.value[2])) {
 
@@ -111,7 +113,7 @@ export interface ICacheMap {
 export class DeckCacheService {
 
   static get $inject(): string[] {
-    return ['$log', 'CacheFactory', 'settings'];
+    return ['$log', 'CacheFactory'];
   }
 
   private caches: ICacheMap = Object.create(null);
@@ -201,7 +203,7 @@ export class DeckCacheService {
       disabled: cacheConfig.disabled,
       maxAge: cacheConfig.maxAge || moment.duration(2, 'days').asMilliseconds(),
       recycleFreq: moment.duration(5, 'seconds').asMilliseconds(),
-      storageImpl: new SelfClearingLocalStorage(this.$log, this.settings, this.cacheProxy),
+      storageImpl: new SelfClearingLocalStorage(this.$log, this.cacheProxy),
       storageMode: 'localStorage',
       storagePrefix: DeckCacheService.getStoragePrefix(key, currentVersion)
     });
@@ -211,8 +213,7 @@ export class DeckCacheService {
   }
 
   constructor(private $log: ng.ILogService,
-              private CacheFactory: any,
-              private settings: any) {}
+              private CacheFactory: any) {}
 
   public clearCache(namespace: string, key: string): void {
     if (this.caches[key] && this.caches[key].destroy) {
@@ -233,6 +234,5 @@ export class DeckCacheService {
 export const DECK_CACHE_SERVICE = 'spinnaker.core.cache.deckCacheService';
 module(DECK_CACHE_SERVICE, [
   require('angular-cache'),
-  require('core/config/settings')
 ])
   .service('deckCacheFactory', DeckCacheService);

--- a/app/scripts/modules/core/chaosMonkey/chaosMonkeyConfig.component.ts
+++ b/app/scripts/modules/core/chaosMonkey/chaosMonkeyConfig.component.ts
@@ -6,6 +6,7 @@ import {CHAOS_MONKEY_HELP} from './chaosMonkey.help';
 import {CHAOS_MONKEY_EXCEPTIONS_COMPONENT} from './chaosMonkeyExceptions.component';
 import {CONFIG_SECTION_FOOTER, IViewState} from '../application/config/footer/configSectionFooter.component';
 import {Application} from '../application/application.model';
+import {SETTINGS} from 'core/config/settings';
 
 import './chaosMonkeyConfig.component.less';
 
@@ -42,8 +43,6 @@ export class ChaosMonkeyConfigController implements ng.IComponentController {
     isDirty: false,
   };
 
-  public constructor(private settings: any) {}
-
   public $onInit(): void {
     if (this.application.notFound) {
       return;
@@ -51,7 +50,7 @@ export class ChaosMonkeyConfigController implements ng.IComponentController {
     this.config = new ChaosMonkeyConfig(this.application.attributes.chaosMonkey || {});
     this.viewState.originalConfig = _.cloneDeep(this.config);
     this.viewState.originalStringVal = toJson(this.viewState.originalConfig);
-    this.chaosEnabled = this.settings.feature && this.settings.feature.chaosMonkey;
+    this.chaosEnabled = SETTINGS.feature.chaosMonkey;
     this.groupingOptions = [
       { key: 'app', label: 'App' },
       { key: 'stack', label: 'Stack' },
@@ -74,7 +73,6 @@ class ChaosMonkeyConfigComponent implements ng.IComponentOptions {
 
 export const CHAOS_MONKEY_CONFIG_COMPONENT = 'spinnaker.core.chaosMonkey.config.component';
 module(CHAOS_MONKEY_CONFIG_COMPONENT, [
-  require('../config/settings'),
   CLUSTER_MATCHES_COMPONENT,
   CHAOS_MONKEY_EXCEPTIONS_COMPONENT,
   CHAOS_MONKEY_HELP,

--- a/app/scripts/modules/core/chaosMonkey/chaosMonkeyNewApplicationConfig.component.ts
+++ b/app/scripts/modules/core/chaosMonkey/chaosMonkeyNewApplicationConfig.component.ts
@@ -1,14 +1,13 @@
 import {module} from 'angular';
 
+import {SETTINGS} from 'core/config/settings';
+
 export class ChaosMonkeyNewApplicationConfigController {
-
-  static get $inject() { return ['settings']; }
-
   public enabled = false;
   public applicationConfig: any;
 
-  public constructor(settings: any) {
-    this.enabled = settings.feature && settings.feature.chaosMonkey;
+  public constructor() {
+    this.enabled = SETTINGS.feature.chaosMonkey;
     if (this.enabled) {
       this.applicationConfig.chaosMonkey = {
         enabled: this.enabled,
@@ -47,7 +46,5 @@ class ChaosMonkeyNewApplicationConfigComponent implements ng.IComponentOptions {
 }
 
 export const CHAOS_MONKEY_NEW_APPLICATION_CONFIG_COMPONENT = 'spinnaker.core.chaosMonkey.newApplication.config.component';
-module(CHAOS_MONKEY_NEW_APPLICATION_CONFIG_COMPONENT, [
-  require('../config/settings')
-])
+module(CHAOS_MONKEY_NEW_APPLICATION_CONFIG_COMPONENT, [])
 .component('chaosMonkeyNewApplicationConfig', new ChaosMonkeyNewApplicationConfigComponent());

--- a/app/scripts/modules/core/ci/jenkins/igor.service.js
+++ b/app/scripts/modules/core/ci/jenkins/igor.service.js
@@ -5,10 +5,9 @@ import {API_SERVICE} from 'core/api/api.service';
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.ci.jenkins.igor.service', [
-  require('../../config/settings.js'),
   API_SERVICE,
 ])
-  .factory('igorService', function (settings, API) {
+  .factory('igorService', function (API) {
 
     function listMasters() {
       return API.one('v2').one('builds').get();

--- a/app/scripts/modules/core/cloudProvider/cloudProvider.registry.ts
+++ b/app/scripts/modules/core/cloudProvider/cloudProvider.registry.ts
@@ -2,6 +2,8 @@
 import {module} from 'angular';
 import {cloneDeep} from 'lodash';
 
+import {SETTINGS} from 'core/config/settings';
+
 export interface ICloudProviderLogo {
   path: string;
 }
@@ -18,16 +20,12 @@ export class CloudProviderRegistry {
    */
   private providers: Map<string, ICloudProviderConfig> = new Map();
 
-  static get $inject() { return ['settings']; }
-
-  public constructor(private settings: any) {}
-
   public $get(): CloudProviderRegistry {
     return this;
   }
 
   public registerProvider(cloudProvider: string, config: ICloudProviderConfig): void {
-    if (this.settings.providers && this.settings.providers[cloudProvider]) {
+    if (SETTINGS.providers[cloudProvider]) {
       this.providers.set(cloudProvider, config);
     }
   }
@@ -91,6 +89,5 @@ export class CloudProviderRegistry {
 }
 
 export const CLOUD_PROVIDER_REGISTRY = 'spinnaker.core.cloudProvider.registry';
-module(CLOUD_PROVIDER_REGISTRY, [
-  require('core/config/settings')
-]).provider('cloudProviderRegistry', CloudProviderRegistry);
+module(CLOUD_PROVIDER_REGISTRY, [])
+  .provider('cloudProviderRegistry', CloudProviderRegistry);

--- a/app/scripts/modules/core/cloudProvider/providerSelection/providerSelection.service.js
+++ b/app/scripts/modules/core/cloudProvider/providerSelection/providerSelection.service.js
@@ -1,15 +1,16 @@
 'use strict';
 
 let angular = require('angular');
+
 import {ACCOUNT_SERVICE} from 'core/account/account.service';
 import {CLOUD_PROVIDER_REGISTRY} from 'core/cloudProvider/cloudProvider.registry';
+import {SETTINGS} from 'core/config/settings';
 
 module.exports = angular.module('spinnaker.providerSelection.service', [
   ACCOUNT_SERVICE,
-  require('../../config/settings.js'),
   CLOUD_PROVIDER_REGISTRY,
 ])
-  .factory('providerSelectionService', function($uibModal, $q, accountService, settings, cloudProviderRegistry) {
+  .factory('providerSelectionService', function($uibModal, $q, accountService, cloudProviderRegistry) {
     function selectProvider(application, feature) {
       return accountService.listProviders(application).then((providers) => {
 
@@ -41,7 +42,7 @@ module.exports = angular.module('spinnaker.providerSelection.service', [
         } else if (reducedProviders.length === 1) {
           provider = $q.when(reducedProviders[0]);
         } else {
-          provider = $q.when(settings.defaultProvider || 'aws');
+          provider = $q.when(SETTINGS.defaultProvider || 'aws');
         }
         return provider;
       });

--- a/app/scripts/modules/core/cloudProvider/providerSelection/providerSelection.service.spec.js
+++ b/app/scripts/modules/core/cloudProvider/providerSelection/providerSelection.service.spec.js
@@ -1,6 +1,7 @@
 'use strict';
 import {ACCOUNT_SERVICE} from 'core/account/account.service';
 import {CLOUD_PROVIDER_REGISTRY} from 'core/cloudProvider/cloudProvider.registry';
+import {SETTINGS} from 'core/config/settings';
 
 describe('providerSelectionService: API', () => {
 
@@ -40,8 +41,8 @@ describe('providerSelectionService: API', () => {
     });
   });
 
-  beforeEach(() => {
-    window.spinnakerSettings.providers.testProvider = {
+  beforeEach(function () {
+    SETTINGS.providers.testProvider = {
       defaults: {
         account: 'testProviderAccount',
         region: 'testProviderRegion'
@@ -49,12 +50,14 @@ describe('providerSelectionService: API', () => {
     };
   });
 
+  afterEach(SETTINGS.resetToOriginal);
+
   let application, config;
   beforeEach(() => {
 
     hasValue = false;
     providers = [];
-    delete window.spinnakerSettings.defaultProvider;
+    delete SETTINGS.defaultProvider;
 
     application = {
       name: 'testApplication',
@@ -72,7 +75,7 @@ describe('providerSelectionService: API', () => {
   it('should use the specified, default provider if the requested provider cannot be found', () => {
 
     let provider = '';
-    window.spinnakerSettings.defaultProvider = 'defaultProvider';
+    SETTINGS.defaultProvider = 'defaultProvider';
 
     cloudProvider.registerProvider('fakeProvider', config);
     providerService.selectProvider(application, 'securityGroup').then((_provider) => {

--- a/app/scripts/modules/core/cloudProvider/providerSelection/providerSelector.directive.js
+++ b/app/scripts/modules/core/cloudProvider/providerSelection/providerSelector.directive.js
@@ -39,7 +39,7 @@ module.exports = angular.module('spinnaker.providerSelection.directive', [
       },
     };
   })
-  .controller('ProviderSelectCtrl', function($scope, $uibModalInstance, settings, cloudProviderRegistry, providerOptions) {
+  .controller('ProviderSelectCtrl', function($scope, $uibModalInstance, cloudProviderRegistry, providerOptions) {
 
     $scope.command = {
       provider: ''

--- a/app/scripts/modules/core/config/settings.js
+++ b/app/scripts/modules/core/config/settings.js
@@ -1,6 +1,0 @@
-'use strict';
-
-let angular = require('angular');
-
-module.exports = angular.module('spinnaker.core.config.settings', [])
-  .constant('settings', window.spinnakerSettings);

--- a/app/scripts/modules/core/config/settings.ts
+++ b/app/scripts/modules/core/config/settings.ts
@@ -1,0 +1,88 @@
+import {cloneDeep, merge} from 'lodash';
+
+export interface IProviderSettings {
+  defaults: {
+    account: string;
+  };
+  resetToOriginal: () => void;
+}
+
+interface INotificationSettings {
+  email: {
+    enabled: boolean;
+  };
+  hipchat: {
+    enabled: boolean;
+    botName: string;
+  };
+  sms: {
+    enabled: boolean;
+  };
+  slack: {
+    enabled: boolean;
+    botName: string;
+  };
+}
+
+export interface IFeatures {
+  entityTags?: boolean;
+  fiatEnabled?: boolean;
+  pipelines?: boolean;
+  notifications?: boolean;
+  clusterDiff?: boolean;
+  roscoMode?: boolean;
+  chaosMonkey?: boolean;
+  // whether stages affecting infrastructure (like "Create Load Balancer") should be enabled or not
+  infrastructureStages?: boolean;
+  jobs?: boolean;
+  snapshots?: boolean;
+  dockerBake?: boolean;
+  [key: string]: any;
+}
+
+export interface ISpinnakerSettings {
+  checkForUpdates: boolean;
+  debugEnabled: boolean;
+  defaultProviders: string[];
+  gateUrl: string;
+  bakeryDetailUrl: string;
+  authEndpoint: string;
+  pollSchedule: number;
+  defaultTimeZone: string; // see http://momentjs.com/timezone/docs/#/data-utilities/
+  defaultCategory: string;
+  defaultInstancePort: number;
+  providers?: {
+    [key: string]: IProviderSettings; // allows custom providers not typed in here (good for testing too)
+  };
+  notifications: INotificationSettings;
+  authEnabled: boolean;
+  authTtl: number;
+  gitSources: string[];
+  triggerTypes: string[];
+  analytics: {
+    ga?: boolean;
+  };
+  feature: IFeatures;
+  executionWindow?: {
+    atlas?: {
+      regions: { label: string, baseUrl: string }[];
+      url: string;
+    }
+  };
+  entityTags?: {
+    maxUrlLength?: number;
+  };
+  [key: string]: any;
+  resetToOriginal: () => void;
+}
+
+export const SETTINGS: ISpinnakerSettings = (<any>window).spinnakerSettings;
+
+// Make sure to set up some reasonable default settings fields so we do not have to keep checking if they exist everywhere
+SETTINGS.feature = SETTINGS.feature || {};
+SETTINGS.analytics = SETTINGS.analytics || {};
+SETTINGS.providers = SETTINGS.providers || {};
+
+// A helper to make resetting settings to steady state after running tests easier
+const originalSettings: ISpinnakerSettings = cloneDeep(SETTINGS);
+SETTINGS.resetToOriginal = () => { merge(SETTINGS, originalSettings); };

--- a/app/scripts/modules/core/config/versionCheck.service.ts
+++ b/app/scripts/modules/core/config/versionCheck.service.ts
@@ -1,5 +1,7 @@
 import {module} from 'angular';
 
+import {SETTINGS} from 'core/config/settings';
+
 interface IDeckVersion {
   version: string;
   created: number;
@@ -58,12 +60,11 @@ class VersionCheckService {
 
 export const VERSION_CHECK_SERVICE = 'spinnaker.core.config.versionCheck.service';
 module(VERSION_CHECK_SERVICE, [
-  require('./settings'),
   require('../widgets/notifier/notifier.service'),
   require('core/scheduler/scheduler.factory'),
 ]).service('versionCheckService', VersionCheckService)
-  .run((versionCheckService: VersionCheckService, settings: any) => {
-    if (settings.checkForUpdates) {
+  .run((versionCheckService: VersionCheckService) => {
+    if (SETTINGS.checkForUpdates) {
       versionCheckService.initialize();
     }
   });

--- a/app/scripts/modules/core/core.module.js
+++ b/app/scripts/modules/core/core.module.js
@@ -12,6 +12,7 @@ import {APPLICATIONS_STATE_PROVIDER} from './application/applications.state.prov
 import {INFRASTRUCTURE_STATES} from './search/infrastructure/infrastructure.states';
 import {VERSION_CHECK_SERVICE} from './config/versionCheck.service';
 import {CORE_WIDGETS_MODULE} from './widgets';
+import {SETTINGS} from 'core/config/settings';
 
 require('../../../fonts/spinnaker/icons.css');
 
@@ -61,7 +62,6 @@ module.exports = angular
     require('./cloudProvider/serviceDelegate.service.js'),
     require('./cluster/cluster.module.js'),
     VERSION_CHECK_SERVICE,
-    require('./config/settings.js'),
 
     require('./delivery/delivery.module.js'),
     require('./deploymentStrategy/deploymentStrategy.module.js'),
@@ -136,10 +136,10 @@ module.exports = angular
     CORE_WIDGETS_MODULE,
     require('./validation/validation.module.js'),
   ])
-  .run(function($rootScope, $log, $state, settings) {
+  .run(function($rootScope, $log, $state) {
     window.Spinner = Spinner;
 
-    $rootScope.feature = settings.feature;
+    $rootScope.feature = SETTINGS.feature;
 
     $rootScope.$state = $state; // TODO: Do we really need this?
 
@@ -177,8 +177,8 @@ module.exports = angular
   .run(function (cacheInitializer) {
     cacheInitializer.initialize();
   })
-  .config(function ($logProvider, settings) {
-    $logProvider.debugEnabled(settings.debugEnabled);
+  .config(function ($logProvider) {
+    $logProvider.debugEnabled(SETTINGS.debugEnabled);
   })
   .config(function($uibTooltipProvider) {
     $uibTooltipProvider.options({

--- a/app/scripts/modules/core/delivery/delivery.dataSource.js
+++ b/app/scripts/modules/core/delivery/delivery.dataSource.js
@@ -1,6 +1,8 @@
 import {DataSourceConfig} from '../application/service/applicationDataSource';
 import {APPLICATION_DATA_SOURCE_REGISTRY} from '../application/service/applicationDataSource.registry';
 import {PIPELINE_CONFIG_SERVICE} from 'core/pipeline/config/services/pipelineConfig.service';
+import {SETTINGS} from 'core/config/settings';
+
 let angular = require('angular');
 
 module.exports = angular
@@ -8,10 +10,9 @@ module.exports = angular
     APPLICATION_DATA_SOURCE_REGISTRY,
     require('./service/execution.service'),
     PIPELINE_CONFIG_SERVICE,
-    require('../cluster/cluster.service'),
-    require('../config/settings'),
+    require('../cluster/cluster.service')
   ])
-  .run(function($q, applicationDataSourceRegistry, executionService, pipelineConfigService, clusterService, settings) {
+  .run(function($q, applicationDataSourceRegistry, executionService, pipelineConfigService, clusterService) {
 
     let addExecutions = (application, executions) => {
       executionService.transformExecutions(application, executions);
@@ -47,7 +48,7 @@ module.exports = angular
       application.getDataSource('serverGroups').dataUpdated();
     };
 
-    if (settings.feature && settings.feature.pipelines !== false) {
+    if (SETTINGS.feature.pipelines !== false) {
       applicationDataSourceRegistry.registerDataSource(new DataSourceConfig({
         optional: true,
         key: 'executions',

--- a/app/scripts/modules/core/delivery/executionGroup/execution/execution.directive.js
+++ b/app/scripts/modules/core/delivery/executionGroup/execution/execution.directive.js
@@ -2,6 +2,7 @@
 
 import {CONFIRMATION_MODAL_SERVICE} from 'core/confirmationModal/confirmationModal.service';
 import {CANCEL_MODAL_SERVICE} from 'core/cancelModal/cancelModal.service';
+import {SETTINGS} from 'core/config/settings';
 
 let angular = require('angular');
 
@@ -31,10 +32,10 @@ module.exports = angular
     };
   })
   .controller('ExecutionCtrl', function ($scope, $location, $stateParams, $state, urlParser, schedulerFactory,
-                                         settings, ExecutionFilterModel, executionService, cancelModalService,
+                                         ExecutionFilterModel, executionService, cancelModalService,
                                          confirmationModalService) {
 
-    this.pipelinesUrl = [settings.gateUrl, 'pipelines/'].join('/');
+    this.pipelinesUrl = [SETTINGS.gateUrl, 'pipelines/'].join('/');
 
     this.showDetails = () => {
       return this.standalone === true || ( this.execution.id === $stateParams.executionId &&

--- a/app/scripts/modules/core/delivery/service/execution.service.js
+++ b/app/scripts/modules/core/delivery/service/execution.service.js
@@ -1,20 +1,21 @@
 'use strict';
 
 import _ from 'lodash';
+
 import {API_SERVICE} from 'core/api/api.service';
+import {SETTINGS} from 'core/config/settings';
 
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.delivery.executions.service', [
   require('../../utils/appendTransform.js'),
-  require('../../config/settings.js'),
   require('../filter/executionFilter.model.js'),
   require('./executions.transformer.service.js'),
   require('core/pipeline/config/pipelineConfigProvider.js'),
   API_SERVICE
 ])
   .factory('executionService', function($http, API, $timeout, $q, $log, ExecutionFilterModel, $state,
-                                        settings, appendTransform, executionsTransformer, pipelineConfig) {
+                                        appendTransform, executionsTransformer, pipelineConfig) {
 
     const activeStatuses = ['RUNNING', 'SUSPENDED', 'PAUSED', 'NOT_STARTED'];
     const runningLimit = 30;
@@ -137,7 +138,7 @@ module.exports = angular.module('spinnaker.core.delivery.executions.service', [
       $http({
         method: 'PUT',
         url: [
-          settings.gateUrl,
+          SETTINGS.gateUrl,
           'applications',
           application.name,
           'pipelines',
@@ -164,7 +165,7 @@ module.exports = angular.module('spinnaker.core.delivery.executions.service', [
       $http({
         method: 'PUT',
         url: [
-          settings.gateUrl,
+          SETTINGS.gateUrl,
           'pipelines',
           executionId,
           'pause',
@@ -185,7 +186,7 @@ module.exports = angular.module('spinnaker.core.delivery.executions.service', [
       $http({
         method: 'PUT',
         url: [
-          settings.gateUrl,
+          SETTINGS.gateUrl,
           'pipelines',
           executionId,
           'resume',
@@ -202,7 +203,7 @@ module.exports = angular.module('spinnaker.core.delivery.executions.service', [
       $http({
         method: 'DELETE',
         url: [
-          settings.gateUrl,
+          SETTINGS.gateUrl,
           'pipelines',
           executionId,
         ].join('/')
@@ -340,12 +341,12 @@ module.exports = angular.module('spinnaker.core.delivery.executions.service', [
     }
 
     function patchExecution(executionId, stageId, data) {
-      var targetUrl = [settings.gateUrl, 'pipelines', executionId, 'stages', stageId].join('/');
+      var targetUrl = [SETTINGS.gateUrl, 'pipelines', executionId, 'stages', stageId].join('/');
       var request = {
         method: 'PATCH',
         url: targetUrl,
         data: data,
-        timeout: settings.pollSchedule * 2 + 5000
+        timeout: SETTINGS.pollSchedule * 2 + 5000
       };
       return $http(request).then(resp => resp.data);
     }

--- a/app/scripts/modules/core/delivery/service/execution.service.spec.js
+++ b/app/scripts/modules/core/delivery/service/execution.service.spec.js
@@ -1,10 +1,11 @@
 'use strict';
 
+import {SETTINGS} from 'core/config/settings';
+
 describe('Service: executionService', function () {
 
   var executionService;
   var $httpBackend;
-  var settings;
   var timeout;
   var $q;
 
@@ -15,10 +16,9 @@ describe('Service: executionService', function () {
   );
 
   beforeEach(
-    window.inject(function (_executionService_, _$httpBackend_, _settings_, _$timeout_, _$q_, ExecutionFilterModel) {
+    window.inject(function (_executionService_, _$httpBackend_, _$timeout_, _$q_, ExecutionFilterModel) {
       executionService = _executionService_;
       $httpBackend = _$httpBackend_;
-      settings = _settings_;
       timeout = _$timeout_;
       $q = _$q_;
       ExecutionFilterModel.sortFilter.count = 3;
@@ -34,8 +34,8 @@ describe('Service: executionService', function () {
     it('should wait until pipeline is not running, then resolve', function () {
       let completed = false;
       let executionId = 'abc';
-      let cancelUrl = [ settings.gateUrl, 'applications', 'deck', 'pipelines', executionId, 'cancel' ].join('/');
-      let checkUrl = [ settings.gateUrl, 'pipelines', executionId ].join('/');
+      let cancelUrl = [ SETTINGS.gateUrl, 'applications', 'deck', 'pipelines', executionId, 'cancel' ].join('/');
+      let checkUrl = [ SETTINGS.gateUrl, 'pipelines', executionId ].join('/');
       let application = { name: 'deck', executions: { refresh: () => $q.when(null) } };
 
       $httpBackend.expectPUT(cancelUrl).respond(200, []);
@@ -54,7 +54,7 @@ describe('Service: executionService', function () {
     it('should propagate rejection from failed cancel', function () {
       let failed = false;
       let executionId = 'abc';
-      let cancelUrl = [ settings.gateUrl, 'applications', 'deck', 'pipelines', executionId, 'cancel' ].join('/');
+      let cancelUrl = [ SETTINGS.gateUrl, 'applications', 'deck', 'pipelines', executionId, 'cancel' ].join('/');
       let application = { name: 'deck', executions: { refresh: () => $q.when(null) } };
 
       $httpBackend.expectPUT(cancelUrl).respond(500, []);
@@ -69,8 +69,8 @@ describe('Service: executionService', function () {
     it('should wait until pipeline is missing, then resolve', function () {
       let completed = false;
       let executionId = 'abc';
-      let deleteUrl = [ settings.gateUrl, 'pipelines', executionId ].join('/');
-      let checkUrl = [ settings.gateUrl, 'pipelines', executionId ].join('/');
+      let deleteUrl = [ SETTINGS.gateUrl, 'pipelines', executionId ].join('/');
+      let checkUrl = [ SETTINGS.gateUrl, 'pipelines', executionId ].join('/');
       let application = { name: 'deck', executions: { refresh: () => $q.when(null) } };
 
       $httpBackend.expectDELETE(deleteUrl).respond(200, []);
@@ -89,7 +89,7 @@ describe('Service: executionService', function () {
     it('should propagate rejection from failed delete', function () {
       let failed = false;
       let executionId = 'abc';
-      let deleteUrl = [ settings.gateUrl, 'pipelines', executionId ].join('/');
+      let deleteUrl = [ SETTINGS.gateUrl, 'pipelines', executionId ].join('/');
       let application = { name: 'deck', executions: { refresh: () => $q.when(null) } };
 
       $httpBackend.expectDELETE(deleteUrl).respond(500, []);
@@ -104,8 +104,8 @@ describe('Service: executionService', function () {
     it('should wait until pipeline is PAUSED, then resolve', function () {
       let completed = false;
       let executionId = 'abc';
-      let pauseUrl = [ settings.gateUrl, 'pipelines', executionId, 'pause' ].join('/');
-      let singleExecutionUrl = [ settings.gateUrl, 'pipelines', executionId ].join('/');
+      let pauseUrl = [ SETTINGS.gateUrl, 'pipelines', executionId, 'pause' ].join('/');
+      let singleExecutionUrl = [ SETTINGS.gateUrl, 'pipelines', executionId ].join('/');
       let application = { name: 'deck', executions: { refresh: () => $q.when(null) } };
 
       $httpBackend.expectPUT(pauseUrl).respond(200, []);
@@ -127,8 +127,8 @@ describe('Service: executionService', function () {
     it('should wait until pipeline is RUNNING, then resolve', function () {
       let completed = false;
       let executionId = 'abc';
-      let pauseUrl = [ settings.gateUrl, 'pipelines', executionId, 'resume' ].join('/');
-      let singleExecutionUrl = [ settings.gateUrl, 'pipelines', executionId ].join('/');
+      let pauseUrl = [ SETTINGS.gateUrl, 'pipelines', executionId, 'resume' ].join('/');
+      let singleExecutionUrl = [ SETTINGS.gateUrl, 'pipelines', executionId ].join('/');
       let application = { name: 'deck', executions: { refresh: () => $q.when(null) } };
 
       $httpBackend.expectPUT(pauseUrl).respond(200, []);
@@ -150,7 +150,7 @@ describe('Service: executionService', function () {
 
     it('should resolve the promise if a 200 response is received with empty array', function() {
       let url = [
-          settings.gateUrl,
+          SETTINGS.gateUrl,
           'applications',
           'deck',
           'pipelines?limit=3',
@@ -174,7 +174,7 @@ describe('Service: executionService', function () {
 
     it('should reject the promise if a 429 response is received', function() {
       let url = [
-        settings.gateUrl,
+        SETTINGS.gateUrl,
         'applications',
         'deck',
         'pipelines?limit=3',
@@ -200,7 +200,7 @@ describe('Service: executionService', function () {
 
     it('resolves when the execution matches the closure', function () {
       let executionId = 'abc',
-          url = [settings.gateUrl, 'pipelines', executionId].join('/'),
+          url = [SETTINGS.gateUrl, 'pipelines', executionId].join('/'),
           succeeded = false;
 
       $httpBackend.expectGET(url).respond(200, { thingToMatch: true });
@@ -216,7 +216,7 @@ describe('Service: executionService', function () {
 
     it('polls until the execution matches, then resolves', function () {
       let executionId = 'abc',
-          url = [settings.gateUrl, 'pipelines', executionId].join('/'),
+          url = [SETTINGS.gateUrl, 'pipelines', executionId].join('/'),
           succeeded = false;
 
       $httpBackend.expectGET(url).respond(200, { thingToMatch: false });
@@ -246,7 +246,7 @@ describe('Service: executionService', function () {
 
     it('rejects if execution retrieval fails', function () {
       let executionId = 'abc',
-          url = [settings.gateUrl, 'pipelines', executionId].join('/'),
+          url = [SETTINGS.gateUrl, 'pipelines', executionId].join('/'),
           succeeded = false,
           failed = false;
 

--- a/app/scripts/modules/core/delivery/service/executions.transformer.service.spec.js
+++ b/app/scripts/modules/core/delivery/service/executions.transformer.service.spec.js
@@ -312,7 +312,7 @@ describe('executionTransformerService', function() {
       deployStage = { type: 'deploy', context: {
         deploymentDetails: [
           { jenkins: { number: 3, host: 'http://jenkinshost/', name: 'jobName' },
-            buildInfoUrl: "http://custom/url" }
+            buildInfoUrl: 'http://custom/url' }
         ]
       }};
       let execution = { stages: [ deployStage ] };

--- a/app/scripts/modules/core/delivery/triggers/nextRun.component.js
+++ b/app/scripts/modules/core/delivery/triggers/nextRun.component.js
@@ -3,17 +3,17 @@
 const angular = require('angular');
 
 import {later} from 'core/utils/later/later';
+import {SETTINGS} from 'core/config/settings';
 
 module.exports = angular
   .module('spinnaker.core.deliver.triggers.nextRun', [
-    require('../../utils/moment'),
-    require('../../config/settings'),
+    require('../../utils/moment')
   ])
   .component('nextRunTag', {
     bindings: {
       pipeline: '<'
     },
-    controller: function (momentService, settings) {
+    controller: function (momentService) {
 
       this.updateSchedule = () => {
         if (!this.pipeline) {
@@ -26,7 +26,7 @@ module.exports = angular
           let hours = parts[2];
           if (!isNaN(parseInt(hours))) {
             let allHours = hours.split('/');
-            let tz = settings.defaultTimeZone || 'America/Los_Angeles';
+            let tz = SETTINGS.defaultTimeZone || 'America/Los_Angeles';
             var offset = momentService.tz.zone(tz).offset(new Date());
             if (offset) {
               offset /= 60;

--- a/app/scripts/modules/core/deploymentStrategy/strategies/custom/custom.strategy.module.js
+++ b/app/scripts/modules/core/deploymentStrategy/strategies/custom/custom.strategy.module.js
@@ -2,14 +2,15 @@
 
 let angular = require('angular');
 
+import {SETTINGS} from 'core/config/settings';
+
 module.exports = angular.module('spinnaker.core.deploymentStrategy.custom', [
   require('./customStrategySelector.directive.js'),
   require('./customStrategySelector.controller.js'),
-  require('core/utils/timeFormatters.js'),
-  require('core/config/settings.js'),
+  require('core/utils/timeFormatters.js')
 ])
-  .config(function(deploymentStrategyConfigProvider, settings) {
-    if (settings.feature && settings.feature.pipelines !== false) {
+  .config(function(deploymentStrategyConfigProvider) {
+    if (SETTINGS.feature.pipelines !== false) {
       deploymentStrategyConfigProvider.registerStrategy({
         label: 'Custom',
         description: 'Runs a custom deployment strategy',

--- a/app/scripts/modules/core/entityTag/entityTags.read.service.ts
+++ b/app/scripts/modules/core/entityTag/entityTags.read.service.ts
@@ -4,16 +4,16 @@ import {get} from 'lodash';
 import {API_SERVICE, Api} from 'core/api/api.service';
 import {IEntityTags, IEntityTag, ICreationMetadataTag} from '../domain/IEntityTags';
 import {RETRY_SERVICE, RetryService} from 'core/retry/retry.service';
+import {SETTINGS} from 'core/config/settings';
 
 export class EntityTagsReader {
 
-  static get $inject() { return ['API', '$q', '$exceptionHandler', 'retryService', 'settings']; }
+  static get $inject() { return ['API', '$q', '$exceptionHandler', 'retryService']; }
 
   constructor(private API: Api,
               private $q: ng.IQService,
               private $exceptionHandler: ng.IExceptionHandlerService,
-              private retryService: RetryService,
-              private settings: any) {}
+              private retryService: RetryService) {}
 
   public getAllEntityTags(entityType: string, entityIds: string[]): ng.IPromise<IEntityTags[]> {
     if (!entityIds || !entityIds.length) {
@@ -70,8 +70,8 @@ export class EntityTagsReader {
   }
 
   private collateEntityIds(entityType: string, entityIds: string[]): string[] {
-    const baseUrlLength = `${this.settings.gateUrl}/tags?entityType=${entityType}&entityIds=`.length;
-    const maxIdGroupLength = get(this.settings, 'entityTags.maxUrlLength', 4000) - baseUrlLength;
+    const baseUrlLength = `${SETTINGS.gateUrl}/tags?entityType=${entityType}&entityIds=`.length;
+    const maxIdGroupLength = get(SETTINGS, 'entityTags.maxUrlLength', 4000) - baseUrlLength;
     const idGroups: string[] = [];
     const joinedEntityIds = entityIds.join(',');
 
@@ -103,6 +103,5 @@ export class EntityTagsReader {
 export const ENTITY_TAGS_READ_SERVICE = 'spinnaker.core.entityTag.read.service';
 module(ENTITY_TAGS_READ_SERVICE, [
   API_SERVICE,
-  RETRY_SERVICE,
-  require('core/config/settings'),
+  RETRY_SERVICE
 ]).service('entityTagsReader', EntityTagsReader);

--- a/app/scripts/modules/core/instance/details/instanceLinks.component.js
+++ b/app/scripts/modules/core/instance/details/instanceLinks.component.js
@@ -2,14 +2,14 @@
 
 import _ from 'lodash';
 
+import {SETTINGS} from 'core/config/settings';
+
 const angular = require('angular');
 
 require('./instanceLinks.component.less');
 
 module.exports = angular
-  .module('spinnaker.core.instance.details.instanceLinks', [
-    require('../../config/settings'),
-  ])
+  .module('spinnaker.core.instance.details.instanceLinks', [])
   .component('instanceLinks', {
     bindings: {
       address: '=',
@@ -17,9 +17,9 @@ module.exports = angular
       instance: '=',
     },
     templateUrl: require('./instanceLinks.component.html'),
-    controller: function(settings, $interpolate) {
-      this.port = _.get(this.application, 'attributes.instancePort', settings.defaultInstancePort) || 80;
-      this.sections = _.cloneDeep(_.get(this.application, 'attributes.instanceLinks', settings.defaultInstanceLinks) || []);
+    controller: function($interpolate) {
+      this.port = _.get(this.application, 'attributes.instancePort', SETTINGS.defaultInstancePort) || 80;
+      this.sections = _.cloneDeep(_.get(this.application, 'attributes.instanceLinks', SETTINGS.defaultInstanceLinks) || []);
       this.sections.forEach(section => {
         section.links = section.links.map(link => {
           let port = link.path.indexOf(':') === 0 || !this.port ? '' : ':' + this.port;

--- a/app/scripts/modules/core/loadBalancer/loadBalancer.dataSource.js
+++ b/app/scripts/modules/core/loadBalancer/loadBalancer.dataSource.js
@@ -2,6 +2,7 @@ import {DataSourceConfig} from '../application/service/applicationDataSource';
 import {APPLICATION_DATA_SOURCE_REGISTRY} from '../application/service/applicationDataSource.registry';
 import {ENTITY_TAGS_READ_SERVICE} from '../entityTag/entityTags.read.service';
 import {LOAD_BALANCER_READ_SERVICE} from 'core/loadBalancer/loadBalancer.read.service';
+import {SETTINGS} from 'core/config/settings';
 
 let angular = require('angular');
 
@@ -9,10 +10,9 @@ module.exports = angular
   .module('spinnaker.core.loadBalancer.dataSource', [
     APPLICATION_DATA_SOURCE_REGISTRY,
     ENTITY_TAGS_READ_SERVICE,
-    LOAD_BALANCER_READ_SERVICE,
-    require('core/config/settings'),
+    LOAD_BALANCER_READ_SERVICE
   ])
-  .run(function($q, applicationDataSourceRegistry, loadBalancerReader, entityTagsReader, settings) {
+  .run(function($q, applicationDataSourceRegistry, loadBalancerReader, entityTagsReader) {
 
     let loadLoadBalancers = (application) => {
       return loadBalancerReader.loadLoadBalancers(application.name);
@@ -23,7 +23,7 @@ module.exports = angular
     };
 
     let addTags = (loadBalancers) => {
-      if (!settings.feature.entityTags) {
+      if (!SETTINGS.feature.entityTags) {
         return $q.when(loadBalancers);
       }
       const entityIds = loadBalancers.map(lb => lb.name);

--- a/app/scripts/modules/core/loadBalancer/loadBalancer.transformer.js
+++ b/app/scripts/modules/core/loadBalancer/loadBalancer.transformer.js
@@ -6,7 +6,7 @@ let angular = require('angular');
 module.exports = angular.module('spinnaker.core.loadBalancer.transformer', [
   require('../cloudProvider/serviceDelegate.service.js'),
 ])
-  .factory('loadBalancerTransformer', function (settings, serviceDelegate) {
+  .factory('loadBalancerTransformer', function (serviceDelegate) {
 
     function normalizeLoadBalancer(loadBalancer) {
       return serviceDelegate.getDelegate(loadBalancer.provider || loadBalancer.type, 'loadBalancer.transformer').

--- a/app/scripts/modules/core/notification/notification.service.js
+++ b/app/scripts/modules/core/notification/notification.service.js
@@ -5,7 +5,7 @@ import {API_SERVICE} from 'core/api/api.service';
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.notification.service', [API_SERVICE])
-  .factory('notificationService', function (settings, API) {
+  .factory('notificationService', function (API) {
 
     function getNotificationsForApplication(applicationName) {
       return API.one('notifications').one('application', applicationName).get();

--- a/app/scripts/modules/core/notification/notificationTypeConfig.provider.js
+++ b/app/scripts/modules/core/notification/notificationTypeConfig.provider.js
@@ -1,17 +1,17 @@
 'use strict';
 
+import {SETTINGS} from 'core/config/settings';
+
 let angular = require('angular');
 
 module.exports = angular
-  .module('spinnaker.core.notification.type.config', [
-    require('../config/settings')
-  ])
-  .provider('notificationTypeConfig', function(settings) {
+  .module('spinnaker.core.notification.type.config', [])
+  .provider('notificationTypeConfig', function() {
 
     var notificationTypes = [];
 
     function registerNotificationType(config) {
-      config.config = settings.notifications[config.key] || { enabled: true };
+      config.config = SETTINGS.notifications[config.key] || { enabled: true };
       notificationTypes.push(config);
     }
 

--- a/app/scripts/modules/core/pipeline/config/pipelineConfigProvider.js
+++ b/app/scripts/modules/core/pipeline/config/pipelineConfigProvider.js
@@ -2,20 +2,20 @@
 
 import _ from 'lodash';
 
+import {SETTINGS} from 'core/config/settings';
+
 let angular = require('angular');
 
-module.exports = angular.module('spinnaker.core.pipeline.config.configProvider', [
-  require('../../config/settings.js'),
-])
-  .provider('pipelineConfig', function(settings) {
+module.exports = angular.module('spinnaker.core.pipeline.config.configProvider', [])
+  .provider('pipelineConfig', function() {
 
     var triggerTypes = [],
         stageTypes = [],
         transformers = [];
 
     function registerTrigger(triggerConfig) {
-      if (settings && settings.triggerTypes) {
-        if (settings.triggerTypes.indexOf(triggerConfig.key) >= 0) {
+      if (SETTINGS.triggerTypes) {
+        if (SETTINGS.triggerTypes.indexOf(triggerConfig.key) >= 0) {
           triggerTypes.push(triggerConfig);
         }
       } else {
@@ -92,7 +92,7 @@ module.exports = angular.module('spinnaker.core.pipeline.config.configProvider',
       }
 
       // Docker Bake is wedged in here because it doesn't really fit our existing cloud provider paradigm
-      let dockerBakeEnabled = _.get(settings, 'feature.dockerBake') && type.key === 'bake';
+      let dockerBakeEnabled = SETTINGS.feature.dockerBake && type.key === 'bake';
 
       if (dockerBakeEnabled) {
         providers = angular.copy(providers);

--- a/app/scripts/modules/core/pipeline/config/stages/bake/bakery.service.ts
+++ b/app/scripts/modules/core/pipeline/config/stages/bake/bakery.service.ts
@@ -1,7 +1,9 @@
 import {get, has} from 'lodash';
 import {module} from 'angular';
+
 import {ACCOUNT_SERVICE, AccountService} from 'core/account/account.service';
 import {API_SERVICE, Api} from 'core/api/api.service';
+import {SETTINGS} from 'core/config/settings';
 
 interface IBaseImage {
   id: string;
@@ -17,14 +19,13 @@ interface IBaseOsOptions {
 
 export class BakeryService {
 
-  static get $inject() { return ['$q', 'API', 'accountService', 'settings']; }
+  static get $inject() { return ['$q', 'API', 'accountService']; }
 
-  public constructor(private $q: ng.IQService, private API: Api, private accountService: AccountService,
-                     private settings: any) {}
+  public constructor(private $q: ng.IQService, private API: Api, private accountService: AccountService) {}
 
   public getRegions(provider: string): ng.IPromise<string[]> {
-    if (has(this.settings, `providers.${provider}.bakeryRegions`)) {
-      return this.$q.when(get(this.settings, `providers.${provider}.bakeryRegions`));
+    if (has(SETTINGS, `providers.${provider}.bakeryRegions`)) {
+      return this.$q.when(get(SETTINGS, `providers.${provider}.bakeryRegions`));
     }
     return this.accountService.getUniqueAttributeForAllAccounts(provider, 'regions')
       .then((regions: string[]) => regions.sort());
@@ -58,5 +59,4 @@ export const BAKERY_SERVICE = 'spinnaker.core.pipeline.bakery.service';
 module(BAKERY_SERVICE, [
   API_SERVICE,
   ACCOUNT_SERVICE,
-  require('core/config/settings'),
 ]).service('bakeryService', BakeryService);

--- a/app/scripts/modules/core/pipeline/config/stages/baseProviderStage/baseProviderStage.js
+++ b/app/scripts/modules/core/pipeline/config/stages/baseProviderStage/baseProviderStage.js
@@ -1,17 +1,16 @@
 'use strict';
 
-import _ from 'lodash';
+import {SETTINGS} from 'core/config/settings';
 
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.baseProviderStage', [
-  require('core/config/settings'),
   require('core/cloudProvider/providerSelection/providerSelector.directive.js'),
 ])
-  .controller('BaseProviderStageCtrl', function($scope, stage, accountService, pipelineConfig, settings) {
+  .controller('BaseProviderStageCtrl', function($scope, stage, accountService, pipelineConfig) {
 
     // Docker Bake is wedged in here because it doesn't really fit our existing cloud provider paradigm
-    let dockerBakeEnabled = _.get(settings, 'feature.dockerBake') && stage.type === 'bake';
+    let dockerBakeEnabled = SETTINGS.feature.dockerBake && stage.type === 'bake';
 
     $scope.stage = stage;
 

--- a/app/scripts/modules/core/pipeline/config/stages/createLoadBalancer/createLoadBalancerStage.js
+++ b/app/scripts/modules/core/pipeline/config/stages/createLoadBalancer/createLoadBalancerStage.js
@@ -1,16 +1,17 @@
 'use strict';
 
 import {CLOUD_PROVIDER_REGISTRY} from 'core/cloudProvider/cloudProvider.registry';
+import {SETTINGS} from 'core/config/settings';
 
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.createLoadBalancerStage', [
   CLOUD_PROVIDER_REGISTRY,
 ])
-  .config(function(pipelineConfigProvider, settings) {
+  .config(function(pipelineConfigProvider) {
 
     // Register this stage only if infrastructure stages are enabled in settings.js
-    if (settings.feature && settings.feature.infrastructureStages) {
+    if (SETTINGS.feature.infrastructureStages) {
       pipelineConfigProvider.registerStage({
         key: 'upsertLoadBalancers',
         label: 'Create Load Balancers',

--- a/app/scripts/modules/core/pipeline/config/stages/executionWindows/atlasGraph.component.ts
+++ b/app/scripts/modules/core/pipeline/config/stages/executionWindows/atlasGraph.component.ts
@@ -3,6 +3,8 @@ import {has} from 'lodash';
 import {module} from 'angular';
 import {Subject} from 'rxjs';
 
+import {SETTINGS} from 'core/config/settings';
+
 interface IExecutionWindow {
   displayStart: Date;
   displayEnd: Date;
@@ -56,7 +58,7 @@ interface IChartData {
 
 interface IAtlasRegion {
   label: string;
-  url: string;
+  baseUrl: string;
 }
 
 interface IWindowData {
@@ -86,9 +88,9 @@ class ExecutionWindowAtlasGraphController implements ng.IComponentController {
   // Used to determine how tall to make the execution window bars - it's just the max of the SPS data
   private maxCount = 0;
 
-  static get $inject() { return ['$http', '$filter', 'settings']; }
+  static get $inject() { return ['$http', '$filter']; }
 
-  public constructor(private $http: ng.IHttpService, private $filter: any, private settings: any) {}
+  public constructor(private $http: ng.IHttpService, private $filter: any) {}
 
   public buildGraph(): void {
     if (!this.stage.restrictedExecutionWindow.atlasEnabled) {
@@ -143,7 +145,7 @@ class ExecutionWindowAtlasGraphController implements ng.IComponentController {
   }
 
   public $onInit(): void {
-    this.atlasEnabled = has(this.settings, 'executionWindow.atlas');
+    this.atlasEnabled = has(SETTINGS, 'executionWindow.atlas');
     if (!this.atlasEnabled) {
       return;
     }
@@ -202,7 +204,7 @@ class ExecutionWindowAtlasGraphController implements ng.IComponentController {
       }
     };
 
-    this.regions = this.settings.executionWindow.atlas.regions;
+    this.regions = SETTINGS.executionWindow.atlas.regions;
     this.buildGraph();
   }
 
@@ -251,7 +253,7 @@ class ExecutionWindowAtlasGraphController implements ng.IComponentController {
 
   private createWindow(window: IExecutionWindow, dayOffset: number): IWindowData {
     const today = new Date();
-    const zone: string = this.settings.defaultTimeZone || 'America/Los_Angeles';
+    const zone: string = SETTINGS.defaultTimeZone || 'America/Los_Angeles';
 
     const start = momentTimezone.tz(today, zone)
         .hour(window.displayStart.getHours())
@@ -271,8 +273,8 @@ class ExecutionWindowAtlasGraphController implements ng.IComponentController {
   }
 
   private getAtlasUrl(): string {
-    let base: string = this.settings.executionWindow.atlas.regions.find((r: any) => r.label === this.stage.restrictedExecutionWindow.currentRegion).baseUrl;
-    return base + this.settings.executionWindow.atlas.url;
+    let base: string = SETTINGS.executionWindow.atlas.regions.find((r: IAtlasRegion) => r.label === this.stage.restrictedExecutionWindow.currentRegion).baseUrl;
+    return base + SETTINGS.executionWindow.atlas.url;
   }
 
 }
@@ -289,7 +291,7 @@ class AtlasGraphComponent implements ng.IComponentOptions {
       <div class="col-md-9 col-md-offset-1">
         <div class="checkbox">
           <label>
-            <input type="checkbox" ng-false-value="undefined" 
+            <input type="checkbox" ng-false-value="undefined"
                    ng-model="$ctrl.stage.restrictedExecutionWindow.atlasEnabled"
                    ng-change="$ctrl.toggleEnabled()"/>
             <strong> Show SPS graphs</strong>
@@ -301,7 +303,7 @@ class AtlasGraphComponent implements ng.IComponentOptions {
       <div class="form-group" style="margin-top: 20px">
         <div class="col-md-3 col-md-offset-1">
           Region
-          <select class="input-sm" ng-model="$ctrl.stage.restrictedExecutionWindow.currentRegion" 
+          <select class="input-sm" ng-model="$ctrl.stage.restrictedExecutionWindow.currentRegion"
                   ng-options="region.label as region.label for region in $ctrl.regions"
                   ng-change="$ctrl.buildGraph()"></select>
         </div>

--- a/app/scripts/modules/core/pipeline/config/stages/manualJudgment/manualJudgment.service.js
+++ b/app/scripts/modules/core/pipeline/config/stages/manualJudgment/manualJudgment.service.js
@@ -4,10 +4,9 @@ const angular = require('angular');
 
 module.exports = angular
   .module('spinnaker.core.pipeline.stage.manualJudgment.service', [
-    require('core/config/settings.js'),
     require('core/delivery/service/execution.service.js'),
   ])
-  .factory('manualJudgmentService', function($http, $q, settings, executionService) {
+  .factory('manualJudgmentService', function($http, $q, executionService) {
 
     let provideJudgment = (execution, stage, judgment, input) => {
       let matcher = (execution) => {

--- a/app/scripts/modules/core/pipeline/config/stages/manualJudgment/manualJudgment.service.spec.js
+++ b/app/scripts/modules/core/pipeline/config/stages/manualJudgment/manualJudgment.service.spec.js
@@ -1,8 +1,10 @@
 'use strict';
 
+import {SETTINGS} from 'core/config/settings';
+
 describe('Service: manualJudgment', function () {
 
-  var $scope, service, $http, $q, settings, executionService;
+  var $scope, service, $http, $q, executionService;
 
   beforeEach(
     window.module(
@@ -11,13 +13,12 @@ describe('Service: manualJudgment', function () {
   );
 
   beforeEach(
-    window.inject(function ($rootScope, manualJudgmentService, $httpBackend, _$q_, _settings_,
+    window.inject(function ($rootScope, manualJudgmentService, $httpBackend, _$q_,
                             _executionService_) {
       $scope = $rootScope.$new();
       service = manualJudgmentService;
       $http = $httpBackend;
       $q = _$q_;
-      settings = _settings_;
       executionService = _executionService_;
     })
   );
@@ -26,7 +27,7 @@ describe('Service: manualJudgment', function () {
     beforeEach(function() {
       this.execution = { id: 'ex-id' };
       this.stage = { id: 'stage-id' };
-      this.requestUrl = [settings.gateUrl, 'pipelines', this.execution.id, 'stages', this.stage.id].join('/');
+      this.requestUrl = [SETTINGS.gateUrl, 'pipelines', this.execution.id, 'stages', this.stage.id].join('/');
     });
 
     it('should resolve when execution status matches request', function () {

--- a/app/scripts/modules/core/pipeline/config/stages/manualJudgment/manualJudgmentStage.js
+++ b/app/scripts/modules/core/pipeline/config/stages/manualJudgment/manualJudgmentStage.js
@@ -1,10 +1,10 @@
 'use strict';
 
+import {SETTINGS} from 'core/config/settings';
+
 let angular = require('angular');
 
-module.exports = angular.module('spinnaker.core.pipeline.stage.manualJudgmentStage', [
-  require('core/config/settings.js'),
-])
+module.exports = angular.module('spinnaker.core.pipeline.stage.manualJudgmentStage', [])
   .config(function (pipelineConfigProvider) {
     pipelineConfigProvider.registerStage({
       label: 'Manual Judgment',
@@ -20,8 +20,8 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.manualJudgmentSta
       disableNotifications: true,
     });
   })
-  .controller('ManualJudgmentStageCtrl', function($scope, $uibModal, settings) {
-    $scope.authEnabled = settings.authEnabled;
+  .controller('ManualJudgmentStageCtrl', function($scope, $uibModal) {
+    $scope.authEnabled = SETTINGS.authEnabled;
     $scope.stage.notifications = $scope.stage.notifications || [];
     $scope.stage.judgmentInputs = $scope.stage.judgmentInputs || [];
     $scope.stage.failPipeline = ($scope.stage.failPipeline === undefined ? true : $scope.stage.failPipeline);

--- a/app/scripts/modules/core/pipeline/config/triggers/cron/cronTrigger.module.js
+++ b/app/scripts/modules/core/pipeline/config/triggers/cron/cronTrigger.module.js
@@ -4,6 +4,7 @@ let angular = require('angular');
 
 import {UUIDGenerator} from 'core/utils/uuid.service';
 import {SERVICE_ACCOUNT_SERVICE} from 'core/serviceAccount/serviceAccount.service.ts';
+import {SETTINGS} from 'core/config/settings';
 import './cronTrigger.less';
 
 module.exports = angular.module('spinnaker.core.pipeline.trigger.cron', [
@@ -31,10 +32,10 @@ module.exports = angular.module('spinnaker.core.pipeline.trigger.cron', [
       ]
     });
   })
-  .controller('CronTriggerCtrl', function(trigger, settings, serviceAccountService) {
+  .controller('CronTriggerCtrl', function(trigger, serviceAccountService) {
 
     this.trigger = trigger;
-    this.fiatEnabled = settings.feature.fiatEnabled;
+    this.fiatEnabled = SETTINGS.feature.fiatEnabled;
 
     serviceAccountService.getServiceAccounts().then(accounts => {
       this.serviceAccounts = accounts || [];

--- a/app/scripts/modules/core/pipeline/config/triggers/docker/dockerTrigger.module.js
+++ b/app/scripts/modules/core/pipeline/config/triggers/docker/dockerTrigger.module.js
@@ -6,9 +6,9 @@ let angular = require('angular');
 import {DOCKER_IMAGE_READER} from 'docker/image/docker.image.reader.service';
 import {DOCKER_IMAGE_AND_TAG_SELECTOR_COMPONENT} from 'docker/image/dockerImageAndTagSelector.component';
 import {SERVICE_ACCOUNT_SERVICE} from 'core/serviceAccount/serviceAccount.service.ts';
+import {SETTINGS} from 'core/config/settings';
 
 module.exports = angular.module('spinnaker.core.pipeline.trigger.docker', [
-    require('core/config/settings.js'),
     SERVICE_ACCOUNT_SERVICE,
     DOCKER_IMAGE_READER,
     require('./dockerTriggerOptions.directive.js'),
@@ -43,9 +43,9 @@ module.exports = angular.module('spinnaker.core.pipeline.trigger.docker', [
       selectorTemplate: require('./selectorTemplate.html'),
     };
   })
-  .controller('DockerTriggerCtrl', function (trigger, settings, serviceAccountService) {
+  .controller('DockerTriggerCtrl', function (trigger, serviceAccountService) {
     this.trigger = trigger;
-    this.fiatEnabled = settings.feature.fiatEnabled;
+    this.fiatEnabled = SETTINGS.feature.fiatEnabled;
 
     serviceAccountService.getServiceAccounts().then(accounts => {
       this.serviceAccounts = accounts || [];

--- a/app/scripts/modules/core/pipeline/config/triggers/docker/dockerTriggerOptions.directive.js
+++ b/app/scripts/modules/core/pipeline/config/triggers/docker/dockerTriggerOptions.directive.js
@@ -9,7 +9,6 @@ const angular = require('angular');
 
 module.exports = angular
   .module('spinnaker.core.pipeline.config.triggers.docker.options.directive', [
-    require('core/config/settings.js'),
     DOCKER_IMAGE_READER,
   ])
   .directive('dockerTriggerOptions', function () {

--- a/app/scripts/modules/core/pipeline/config/triggers/git/gitTrigger.module.js
+++ b/app/scripts/modules/core/pipeline/config/triggers/git/gitTrigger.module.js
@@ -1,12 +1,13 @@
 'use strict';
 
 import _ from 'lodash';
+
 import {SERVICE_ACCOUNT_SERVICE} from 'core/serviceAccount/serviceAccount.service.ts';
+import {SETTINGS} from 'core/config/settings';
 
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.trigger.git', [
-    require('core/config/settings.js'),
     SERVICE_ACCOUNT_SERVICE,
   ])
   .config(function (pipelineConfigProvider) {
@@ -28,17 +29,17 @@ module.exports = angular.module('spinnaker.core.pipeline.trigger.git', [
       ]
     });
   })
-  .controller('GitTriggerCtrl', function (trigger, $scope, settings, serviceAccountService) {
+  .controller('GitTriggerCtrl', function (trigger, $scope, serviceAccountService) {
     this.trigger = trigger;
-    this.fiatEnabled = settings.feature.fiatEnabled;
+    this.fiatEnabled = SETTINGS.feature.fiatEnabled;
 
     serviceAccountService.getServiceAccounts().then(accounts => {
       this.serviceAccounts = accounts || [];
     });
     $scope.gitTriggerTypes = ['stash', 'github', 'bitbucket'];
 
-    if (settings && settings.gitSources) {
-      $scope.gitTriggerTypes = settings.gitSources;
+    if (SETTINGS.gitSources) {
+      $scope.gitTriggerTypes = SETTINGS.gitSources;
     }
 
     if ($scope.gitTriggerTypes.length == 1) {

--- a/app/scripts/modules/core/pipeline/config/triggers/jenkins/jenkinsTrigger.module.js
+++ b/app/scripts/modules/core/pipeline/config/triggers/jenkins/jenkinsTrigger.module.js
@@ -2,6 +2,7 @@
 
 let angular = require('angular');
 import {SERVICE_ACCOUNT_SERVICE} from 'core/serviceAccount/serviceAccount.service.ts';
+import {SETTINGS} from 'core/config/settings';
 
 module.exports = angular.module('spinnaker.core.pipeline.config.trigger.jenkins', [
   require('./jenkinsTriggerOptions.directive.js'),
@@ -47,10 +48,10 @@ module.exports = angular.module('spinnaker.core.pipeline.config.trigger.jenkins'
       selectorTemplate: require('./selectorTemplate.html'),
     };
   })
-  .controller('JenkinsTriggerCtrl', function($scope, trigger, igorService, settings, serviceAccountService) {
+  .controller('JenkinsTriggerCtrl', function($scope, trigger, igorService, serviceAccountService) {
 
     $scope.trigger = trigger;
-    this.fiatEnabled = settings.feature.fiatEnabled;
+    this.fiatEnabled = SETTINGS.feature.fiatEnabled;
     serviceAccountService.getServiceAccounts().then(accounts => {
       this.serviceAccounts = accounts || [];
     });

--- a/app/scripts/modules/core/pipeline/config/triggers/trigger.directive.js
+++ b/app/scripts/modules/core/pipeline/config/triggers/trigger.directive.js
@@ -1,10 +1,11 @@
 'use strict';
 
+import {SETTINGS} from 'core/config/settings';
+
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.config.trigger.triggerDirective', [
-  require('../pipelineConfigProvider'),
-  require('core/config/settings'),
+  require('../pipelineConfigProvider')
 ])
   .directive('trigger', function() {
     return {
@@ -22,11 +23,11 @@ module.exports = angular.module('spinnaker.core.pipeline.config.trigger.triggerD
       }
     };
   })
-  .controller('TriggerCtrl', function($scope, $element, pipelineConfig, $compile, $controller, $templateCache, settings) {
+  .controller('TriggerCtrl', function($scope, $element, pipelineConfig, $compile, $controller, $templateCache) {
     var triggerTypes = pipelineConfig.getTriggerTypes();
     $scope.options = triggerTypes;
 
-    this.disableAutoTriggering = settings.disableAutoTriggering || [];
+    this.disableAutoTriggering = SETTINGS.disableAutoTriggering || [];
 
     this.removeTrigger = function(trigger) {
       var triggerIndex = $scope.pipeline.triggers.indexOf(trigger);

--- a/app/scripts/modules/core/pipeline/config/validation/pipelineConfig.validator.spec.ts
+++ b/app/scripts/modules/core/pipeline/config/validation/pipelineConfig.validator.spec.ts
@@ -1,5 +1,4 @@
 import Spy = jasmine.Spy;
-import IProvideService = angular.auto.IProvideService;
 import {mock} from 'angular';
 
 import {PipelineConfigService} from '../services/pipelineConfig.service';
@@ -18,9 +17,9 @@ import {IStage} from 'core/domain/IStage';
 import {IPipeline} from 'core/domain/IPipeline';
 import {IServiceAccountAccessValidationConfig, ITriggerWithServiceAccount} from './serviceAccountAccess.validator';
 import {ServiceAccountService} from 'core/serviceAccount/serviceAccount.service';
+import {SETTINGS} from 'core/config/settings';
 
 describe('pipelineConfigValidator', () => {
-
   let pipeline: IPipeline,
       validate: () => void,
       validationResults: IPipelineValidationResults,
@@ -79,14 +78,9 @@ describe('pipelineConfigValidator', () => {
     )
   );
 
-  beforeEach(
-    mock.module(($provide: IProvideService) => {
-      return $provide.constant('settings', {
-        feature: {
-          fiatEnabled: true,
-        }
-      });
-  }));
+  beforeEach(function () {
+    SETTINGS.feature.fiatEnabled = true;
+  });
 
   beforeEach(mock.inject((_pipelineConfigValidator_: PipelineConfigValidator,
                           _pipelineConfig_: any,
@@ -107,6 +101,8 @@ describe('pipelineConfigValidator', () => {
       $rootScope.$new().$digest();
     };
   }));
+
+  afterEach(SETTINGS.resetToOriginal);
 
   describe('validation', () => {
 

--- a/app/scripts/modules/core/pipeline/config/validation/serviceAccountAccess.validator.ts
+++ b/app/scripts/modules/core/pipeline/config/validation/serviceAccountAccess.validator.ts
@@ -7,6 +7,7 @@ import {
 import {IPipeline, IStage} from 'core/domain/index';
 import {PIPELINE_CONFIG_SERVICE} from '../services/pipelineConfig.service';
 import {ServiceAccountService} from 'core/serviceAccount/serviceAccount.service';
+import {SETTINGS} from 'core/config/settings';
 
 export interface ITriggerWithServiceAccount extends IStage {
   runAsUser: string;
@@ -18,16 +19,16 @@ export interface IServiceAccountAccessValidationConfig extends IValidatorConfig 
 
 export class ServiceAccountAccessValidator implements IStageOrTriggerValidator {
 
-  static get $inject() { return ['serviceAccountService', 'settings']; }
+  static get $inject() { return ['serviceAccountService']; }
 
-  constructor(private serviceAccountService: ServiceAccountService, private settings: any) {}
+  constructor(private serviceAccountService: ServiceAccountService) {}
 
   public validate(_pipeline: IPipeline,
                   stage: ITriggerWithServiceAccount,
                   validator: IServiceAccountAccessValidationConfig,
                   _config: IStageOrTriggerTypeConfig): ng.IPromise<string> {
 
-    if (this.settings.feature.fiatEnabled) {
+    if (SETTINGS.feature.fiatEnabled) {
       return this.serviceAccountService.getServiceAccounts()
         .then((serviceAccounts: string[]) => {
           if (stage.runAsUser && !serviceAccounts.includes(stage.runAsUser)) {

--- a/app/scripts/modules/core/projects/projects.controller.spec.js
+++ b/app/scripts/modules/core/projects/projects.controller.spec.js
@@ -20,10 +20,9 @@ describe('Controller: Projects', function() {
 
     // Initialize the controller and a mock scope
     beforeEach(window.inject(function ($controller, $rootScope, $window, $q, $uibModal, $log, $filter,
-                                $state, $timeout, settings, projectReader) {
+                                $state, $timeout, projectReader) {
 
       this.$scope = $rootScope.$new();
-      this.settings = settings;
       this.$q = $q;
       this.projectReader = projectReader;
 

--- a/app/scripts/modules/core/projects/service/project.read.service.js
+++ b/app/scripts/modules/core/projects/service/project.read.service.js
@@ -2,35 +2,37 @@
 
 let angular = require('angular');
 
+import {SETTINGS} from 'core/config/settings';
+
 module.exports = angular
   .module('spinnaker.core.projects.read.service', [
   ])
-  .factory('projectReader', function ($http, settings) {
+  .factory('projectReader', function ($http) {
 
     function listProjects() {
-      let url = [settings.gateUrl, 'projects'].join('/');
+      let url = [SETTINGS.gateUrl, 'projects'].join('/');
       return $http({
         method: 'GET',
         url: url,
-        timeout: settings.pollSchedule * 2 + 5000, // TODO: replace with apiHost call
+        timeout: SETTINGS.pollSchedule * 2 + 5000, // TODO: replace with apiHost call
       }).then((resp) => resp.data);
     }
 
     function getProjectConfig(projectName) {
-      let url = [settings.gateUrl, 'projects', projectName].join('/');
+      let url = [SETTINGS.gateUrl, 'projects', projectName].join('/');
       return $http({
         method: 'GET',
         url: url,
-        timeout: settings.pollSchedule * 2 + 5000, // TODO: replace with apiHost call
+        timeout: SETTINGS.pollSchedule * 2 + 5000, // TODO: replace with apiHost call
       }).then((resp) => resp.data);
     }
 
     function getProjectClusters(projectName) {
-      let url = [settings.gateUrl, 'projects', projectName, 'clusters'].join('/');
+      let url = [SETTINGS.gateUrl, 'projects', projectName, 'clusters'].join('/');
       return $http({
         method: 'GET',
         url: url,
-        timeout: settings.pollSchedule * 2 + 5000, // TODO: replace with apiHost call
+        timeout: SETTINGS.pollSchedule * 2 + 5000, // TODO: replace with apiHost call
       }).then((resp) => resp.data);
     }
 

--- a/app/scripts/modules/core/scheduler/scheduler.factory.js
+++ b/app/scripts/modules/core/scheduler/scheduler.factory.js
@@ -2,14 +2,14 @@
 
 import {Observable, Subject} from 'rxjs';
 
+import {SETTINGS} from 'core/config/settings';
+
 let angular = require('angular');
 
-module.exports = angular.module('spinnaker.core.scheduler', [
-  require('../config/settings.js')
-])
-  .factory('schedulerFactory', function (settings, $log, $window, $timeout) {
+module.exports = angular.module('spinnaker.core.scheduler', [])
+  .factory('schedulerFactory', function ($log, $window, $timeout) {
 
-    function createScheduler(pollSchedule = settings.pollSchedule) {
+    function createScheduler(pollSchedule = SETTINGS.pollSchedule) {
       var scheduler = new Subject();
 
       let lastRunTimestamp = new Date().getTime();

--- a/app/scripts/modules/core/scheduler/scheduler.factory.spec.js
+++ b/app/scripts/modules/core/scheduler/scheduler.factory.spec.js
@@ -8,12 +8,7 @@ describe('scheduler', function() {
   beforeEach(function() {
     var pollSchedule = 25;
     window.module(
-      require('./scheduler.factory.js'),
-      function($provide) {
-        return $provide.constant('settings', {
-          pollSchedule: pollSchedule,
-        });
-      }
+      require('./scheduler.factory.js')
     );
 
     this.pollSchedule = pollSchedule;

--- a/app/scripts/modules/core/search/search.service.js
+++ b/app/scripts/modules/core/search/search.service.js
@@ -2,8 +2,10 @@
 
 let angular = require('angular');
 
+import {SETTINGS} from 'core/config/settings';
+
 module.exports = angular.module('spinnaker.core.search.service', [])
-  .factory('searchService', function($q, $http, $log, settings) {
+  .factory('searchService', function($q, $http, $log) {
 
     var defaultPageSize = 500;
 
@@ -17,9 +19,9 @@ module.exports = angular.module('spinnaker.core.search.service', [])
       };
 
       return $http({
-        url: settings.gateUrl + '/search',
+        url: SETTINGS.gateUrl + '/search',
         params: angular.extend(defaultParams, params),
-        timeout: settings.pollSchedule * 2 + 5000, // TODO: replace with apiHost call
+        timeout: SETTINGS.pollSchedule * 2 + 5000, // TODO: replace with apiHost call
       })
         .then(
           function(response) {

--- a/app/scripts/modules/core/securityGroup/AllSecurityGroupsCtrl.js
+++ b/app/scripts/modules/core/securityGroup/AllSecurityGroupsCtrl.js
@@ -3,6 +3,7 @@
 import _ from 'lodash';
 
 import {CLOUD_PROVIDER_REGISTRY} from 'core/cloudProvider/cloudProvider.registry';
+import {SETTINGS} from 'core/config/settings';
 
 let angular = require('angular');
 
@@ -10,12 +11,11 @@ module.exports = angular.module('spinnaker.core.securityGroup.all.controller', [
   require('./filter/securityGroup.filter.service.js'),
   require('./filter/securityGroup.filter.model.js'),
   require('../cloudProvider/providerSelection/providerSelection.service.js'),
-  require('../config/settings.js'),
   require('angular-ui-bootstrap'),
   CLOUD_PROVIDER_REGISTRY,
 ])
   .controller('AllSecurityGroupsCtrl', function($scope, app, $uibModal, $timeout,
-                                                providerSelectionService, settings, cloudProviderRegistry,
+                                                providerSelectionService, cloudProviderRegistry,
                                                 SecurityGroupFilterModel, securityGroupFilterService) {
 
     SecurityGroupFilterModel.activate();
@@ -46,8 +46,8 @@ module.exports = angular.module('spinnaker.core.securityGroup.all.controller', [
     this.createSecurityGroup = function createSecurityGroup() {
       providerSelectionService.selectProvider(app, 'securityGroup').then(function(selectedProvider) {
         let provider = cloudProviderRegistry.getValue(selectedProvider, 'securityGroup');
-        var defaultCredentials = app.defaultCredentials[selectedProvider] || settings.providers[selectedProvider].defaults.account,
-            defaultRegion = app.defaultRegions[selectedProvider] || settings.providers[selectedProvider].defaults.region;
+        var defaultCredentials = app.defaultCredentials[selectedProvider] || SETTINGS.providers[selectedProvider].defaults.account,
+            defaultRegion = app.defaultRegions[selectedProvider] || SETTINGS.providers[selectedProvider].defaults.region;
         $uibModal.open({
           templateUrl: provider.createSecurityGroupTemplateUrl,
           controller: `${provider.createSecurityGroupController} as ctrl`,

--- a/app/scripts/modules/core/securityGroup/securityGroupReader.service.ts
+++ b/app/scripts/modules/core/securityGroup/securityGroupReader.service.ts
@@ -8,6 +8,7 @@ import {Application} from 'core/application/application.model';
 import {ISecurityGroup, ILoadBalancer, ServerGroup, IServerGroupUsage} from 'core/domain';
 import {SECURITY_GROUP_TRANSFORMER_SERVICE, SecurityGroupTransformerService} from './securityGroupTransformer.service';
 import {ENTITY_TAGS_READ_SERVICE, EntityTagsReader} from 'core/entityTag/entityTags.read.service';
+import {SETTINGS} from 'core/config/settings';
 
 interface IRegionAccount {
   account: string;
@@ -286,7 +287,7 @@ export class SecurityGroupReader {
   }
 
   private addEntityTags(securityGroups: ISecurityGroup[]): ng.IPromise<ISecurityGroup[]> {
-    if (!this.settings.feature.entityTags) {
+    if (!SETTINGS.feature.entityTags) {
       return this.$q.when(securityGroups);
     }
     const entityIds = securityGroups.map(sg => sg.name);
@@ -304,7 +305,6 @@ export class SecurityGroupReader {
     return [
       '$log',
       '$q',
-      'settings',
       'searchService',
       'namingService',
       'API',
@@ -317,7 +317,6 @@ export class SecurityGroupReader {
 
   constructor(private $log: ng.ILogService,
               private $q: ng.IQService,
-              private settings: any,
               private searchService: any,
               private namingService: NamingService,
               private API: Api,

--- a/app/scripts/modules/core/serverGroup/configure/common/serverGroupCommandBuilder.service.ts
+++ b/app/scripts/modules/core/serverGroup/configure/common/serverGroupCommandBuilder.service.ts
@@ -48,7 +48,6 @@ export class ServerGroupCommandBuilderService {
 
 export const SERVER_GROUP_COMMAND_BUILDER_SERVICE = 'spinnaker.core.serverGroup.configure.common.service';
 module(SERVER_GROUP_COMMAND_BUILDER_SERVICE, [
-  require('core/cloudProvider/serviceDelegate.service.js'),
-  require('core/config/settings.js')
+  require('core/cloudProvider/serviceDelegate.service.js')
 ])
   .service('serverGroupCommandBuilder', ServerGroupCommandBuilderService);

--- a/app/scripts/modules/core/serverGroup/metrics/cloudMetrics.read.service.ts
+++ b/app/scripts/modules/core/serverGroup/metrics/cloudMetrics.read.service.ts
@@ -1,4 +1,5 @@
 import {module} from 'angular';
+
 import {API_SERVICE, Api} from 'core/api/api.service';
 
 export interface ICloudMetricDescriptor {
@@ -31,6 +32,5 @@ export class CloudMetricsReader {
 export const CLOUD_METRICS_READ_SERVICE = 'spinnaker.core.serverGroup.metrics.read.service';
 
 module(CLOUD_METRICS_READ_SERVICE, [
-  require('core/config/settings'),
-  API_SERVICE,
+  API_SERVICE
 ]).service('cloudMetricsReader', CloudMetricsReader);

--- a/app/scripts/modules/core/serverGroup/serverGroup.dataSource.js
+++ b/app/scripts/modules/core/serverGroup/serverGroup.dataSource.js
@@ -4,15 +4,15 @@ let angular = require('angular');
 import {DataSourceConfig} from '../application/service/applicationDataSource';
 import {APPLICATION_DATA_SOURCE_REGISTRY} from '../application/service/applicationDataSource.registry';
 import {ENTITY_TAGS_READ_SERVICE} from '../entityTag/entityTags.read.service';
+import {SETTINGS} from 'core/config/settings';
 
 module.exports = angular
   .module('spinnaker.core.serverGroup.dataSource', [
     APPLICATION_DATA_SOURCE_REGISTRY,
     ENTITY_TAGS_READ_SERVICE,
-    require('../cluster/cluster.service'),
-    require('core/config/settings'),
+    require('../cluster/cluster.service')
   ])
-  .run(function($q, applicationDataSourceRegistry, clusterService, entityTagsReader, serverGroupTransformer, settings) {
+  .run(function($q, applicationDataSourceRegistry, clusterService, entityTagsReader, serverGroupTransformer) {
 
     let loadServerGroups = (application) => {
       return clusterService.loadServerGroups(application);
@@ -30,7 +30,7 @@ module.exports = angular
     };
 
     let addTags = (serverGroups) => {
-      if (!settings.feature.entityTags) {
+      if (!SETTINGS.feature.entityTags) {
         return $q.when(null);
       }
       const serverGroupNames = uniq(serverGroups.map(g => g.name));

--- a/app/scripts/modules/core/serviceAccount/serviceAccount.service.ts
+++ b/app/scripts/modules/core/serviceAccount/serviceAccount.service.ts
@@ -1,14 +1,16 @@
 import {module} from 'angular';
+
 import {API_SERVICE, Api} from 'core/api/api.service';
+import {SETTINGS} from 'core/config/settings';
 
 export class ServiceAccountService {
 
-  static get $inject() { return ['$q', 'API', 'settings']; }
+  static get $inject() { return ['$q', 'API']; }
 
-  constructor(private $q: ng.IQService, private API: Api, private settings: any) {}
+  constructor(private $q: ng.IQService, private API: Api) {}
 
   public getServiceAccounts(): ng.IPromise<string[]> {
-    if (!this.settings.feature.fiatEnabled) {
+    if (!SETTINGS.feature.fiatEnabled) {
       return this.$q.resolve([]);
     } else {
       return this.API.one('auth').one('user').one('serviceAccounts').get();
@@ -18,6 +20,5 @@ export class ServiceAccountService {
 
 export const SERVICE_ACCOUNT_SERVICE = 'spinnaker.core.serviceAccount.service';
 module(SERVICE_ACCOUNT_SERVICE, [
-  API_SERVICE,
-  require('../config/settings.js'),
+  API_SERVICE
 ]).service('serviceAccountService', ServiceAccountService);

--- a/app/scripts/modules/core/snapshot/snapshot.read.service.spec.js
+++ b/app/scripts/modules/core/snapshot/snapshot.read.service.spec.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import {SETTINGS} from 'core/config/settings';
+
 describe('Service: SnapshotRead', function() {
   const application = 'snapshotReadTest';
   const account = 'my-google-account';
@@ -8,16 +10,15 @@ describe('Service: SnapshotRead', function() {
   beforeEach(
     window.module(require('./snapshot.read.service.js')));
 
-  beforeEach(window.inject(function($httpBackend, settings, snapshotReader) {
+  beforeEach(window.inject(function($httpBackend, snapshotReader) {
     this.$httpBackend = $httpBackend;
-    this.settings = settings;
     this.snapshotReader = snapshotReader;
   }));
 
   describe('getSnapshotHistory', function () {
     it('makes request to correct gate endpoint', function () {
       this.$httpBackend
-        .expectGET(`${this.settings.gateUrl}/applications/snapshotReadTest/snapshots/my-google-account/history?limit=20`)
+        .expectGET(`${SETTINGS.gateUrl}/applications/snapshotReadTest/snapshots/my-google-account/history?limit=20`)
         .respond([]);
       this.snapshotReader.getSnapshotHistory(application, account, params);
 
@@ -26,7 +27,7 @@ describe('Service: SnapshotRead', function() {
 
     it('returns what the endpoint returns', function () {
       this.$httpBackend
-        .whenGET(`${this.settings.gateUrl}/applications/snapshotReadTest/snapshots/my-google-account/history?limit=20`)
+        .whenGET(`${SETTINGS.gateUrl}/applications/snapshotReadTest/snapshots/my-google-account/history?limit=20`)
         .respond([{ infrastructure: 'myInfrastructure' }]);
 
       this.snapshotReader.getSnapshotHistory(application, account, params)
@@ -42,7 +43,7 @@ describe('Service: SnapshotRead', function() {
 
     it('does not fail if not passed parameters', function () {
       this.$httpBackend
-        .expectGET(`${this.settings.gateUrl}/applications/snapshotReadTest/snapshots/my-google-account/history`)
+        .expectGET(`${SETTINGS.gateUrl}/applications/snapshotReadTest/snapshots/my-google-account/history`)
         .respond([]);
       try {
         this.snapshotReader.getSnapshotHistory(application, account)

--- a/app/scripts/modules/core/task/tasks.controller.js
+++ b/app/scripts/modules/core/task/tasks.controller.js
@@ -5,6 +5,7 @@ import _ from 'lodash';
 import {CONFIRMATION_MODAL_SERVICE} from 'core/confirmationModal/confirmationModal.service';
 import {VIEW_STATE_CACHE_SERVICE} from 'core/cache/viewStateCache.service';
 import {DISPLAYABLE_TASKS_FILTER} from './displayableTasks.filter';
+import {SETTINGS} from 'core/config/settings';
 
 let angular = require('angular');
 
@@ -14,10 +15,9 @@ module.exports = angular.module('spinnaker.core.task.controller', [
   VIEW_STATE_CACHE_SERVICE,
   require('./task.write.service.js'),
   CONFIRMATION_MODAL_SERVICE,
-  DISPLAYABLE_TASKS_FILTER,
-  require('../config/settings.js'),
+  DISPLAYABLE_TASKS_FILTER
 ])
-  .controller('TasksCtrl', function ($scope, $state, $q, settings, app, viewStateCache, taskWriter, confirmationModalService) {
+  .controller('TasksCtrl', function ($scope, $state, $q, app, viewStateCache, taskWriter, confirmationModalService) {
 
     if (app.notFound) {
       return;
@@ -41,7 +41,7 @@ module.exports = angular.module('spinnaker.core.task.controller', [
       });
     }
 
-    $scope.tasksUrl = [settings.gateUrl, 'applications', application.name, 'tasks/'].join('/');
+    $scope.tasksUrl = [SETTINGS.gateUrl, 'applications', application.name, 'tasks/'].join('/');
     $scope.filterCountOptions = [10, 20, 30, 50, 100, 200];
 
     function initializeViewState() {

--- a/app/scripts/modules/core/utils/renderIfFeature.component.ts
+++ b/app/scripts/modules/core/utils/renderIfFeature.component.ts
@@ -1,13 +1,13 @@
 import {module} from 'angular';
 
+import {SETTINGS} from '../config/settings';
+
 class RenderIfFeatureController implements ng.IComponentController {
   public feature: string;
   public featureEnabled = false;
 
-  constructor(private settings: any) {}
-
   public $onInit(): void {
-    this.featureEnabled = this.feature && this.settings.feature[this.feature];
+    this.featureEnabled = this.feature && SETTINGS.feature[this.feature];
   }
 }
 
@@ -19,5 +19,5 @@ class RenderIfFeatureComponent implements ng.IComponentOptions {
 }
 
 export const RENDER_IF_FEATURE = 'spinnaker.core.renderIfFeature.directive';
-module(RENDER_IF_FEATURE, [require('core/config/settings.js')])
+module(RENDER_IF_FEATURE, [])
   .component('renderIfFeature', new RenderIfFeatureComponent());

--- a/app/scripts/modules/core/utils/timeFormatters.js
+++ b/app/scripts/modules/core/utils/timeFormatters.js
@@ -2,13 +2,14 @@
 
 let angular = require('angular');
 
+import {SETTINGS} from 'core/config/settings';
+
 module.exports = angular.module('spinnaker.core.utils.timeFormatters', [
-  require('./moment.js'),
-  require('../config/settings.js'),
+  require('./moment.js')
 ])
-  .filter('timestamp', function(momentService, settings) {
+  .filter('timestamp', function(momentService) {
     return function(input) {
-      var tz = settings.defaultTimeZone || 'America/Los_Angeles';
+      var tz = SETTINGS.defaultTimeZone || 'America/Los_Angeles';
       if (!input || isNaN(input) || input < 0) {
         return '-';
       }
@@ -72,8 +73,8 @@ module.exports = angular.module('spinnaker.core.utils.timeFormatters', [
   })
   .component('systemTimezone', {
     template: `<span ng-bind="$ctrl.tz"></span>`,
-    controller: function(momentService, settings) {
-      var zone = settings.defaultTimeZone || 'America/Los_Angeles';
+    controller: function(momentService) {
+      var zone = SETTINGS.defaultTimeZone || 'America/Los_Angeles';
       this.tz = momentService.tz(new Date().getTime(), zone).zoneAbbr();
     }
   });

--- a/app/scripts/modules/core/utils/timeFormatters.spec.js
+++ b/app/scripts/modules/core/utils/timeFormatters.spec.js
@@ -1,10 +1,17 @@
 'use strict';
 
+import {SETTINGS} from 'core/config/settings';
+
 describe('Filter: timeFormatters', function() {
+  beforeEach(function () {
+    SETTINGS.defaultTimeZone = 'Etc/GMT+0';
+  });
 
   beforeEach(
     window.module('spinnaker.core.utils.timeFormatters')
   );
+
+  afterEach(SETTINGS.resetToOriginal);
 
   describe('timePickerTime', function() {
 
@@ -13,9 +20,8 @@ describe('Filter: timeFormatters', function() {
     describe('timePicker', function () {
       beforeEach(
         window.inject(
-          function($filter, settings) {
+          function($filter) {
             filter = $filter('timePickerTime');
-            settings.defaultTimeZone = 'Etc/GMT+0';
           }
         )
       );

--- a/app/scripts/modules/docker/pipeline/stages/bake/bakeExecutionDetails.controller.js
+++ b/app/scripts/modules/docker/pipeline/stages/bake/bakeExecutionDetails.controller.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import {EXECUTION_DETAILS_SECTION_SERVICE} from 'core/delivery/details/executionDetailsSection.service';
+import {SETTINGS} from 'core/config/settings';
 
 let angular = require('angular');
 
@@ -10,14 +11,14 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.bake.docker.execu
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ])
   .controller('dockerBakeExecutionDetailsCtrl', function ($scope, $stateParams, executionDetailsSectionService,
-                                                          $interpolate, settings) {
+                                                          $interpolate) {
 
     $scope.configSections = ['bakeConfig', 'taskStatus'];
 
     let initialized = () => {
       $scope.detailsSection = $stateParams.details;
       $scope.provider = $scope.stage.context.cloudProviderType || 'docker';
-      $scope.bakeryDetailUrl = $interpolate(settings.bakeryDetailUrl);
+      $scope.bakeryDetailUrl = $interpolate(SETTINGS.bakeryDetailUrl);
     };
 
     let initialize = () => executionDetailsSectionService.synchronizeSection($scope.configSections, initialized);

--- a/app/scripts/modules/google/gce.settings.ts
+++ b/app/scripts/modules/google/gce.settings.ts
@@ -1,0 +1,14 @@
+import { IProviderSettings, SETTINGS } from 'core/config/settings';
+
+export interface IGCEProviderSettings extends IProviderSettings {
+  defaults: {
+    account: string;
+    region: string;
+    zone: string;
+  };
+}
+
+export const GCEProviderSettings: IGCEProviderSettings = <IGCEProviderSettings>SETTINGS.providers.gce;
+if (GCEProviderSettings) {
+  GCEProviderSettings.resetToOriginal = SETTINGS.resetToOriginal;
+}

--- a/app/scripts/modules/google/loadBalancer/configure/http/commandBuilder.service.js
+++ b/app/scripts/modules/google/loadBalancer/configure/http/commandBuilder.service.js
@@ -5,6 +5,7 @@ import {HttpLoadBalancerTemplate, ListenerTemplate} from './templates';
 import {sessionAffinityModelToViewMap} from '../common/sessionAffinityNameMaps';
 import {ACCOUNT_SERVICE} from 'core/account/account.service';
 import {LOAD_BALANCER_READ_SERVICE} from 'core/loadBalancer/loadBalancer.read.service';
+import {GCEProviderSettings} from '../../../gce.settings';
 
 let angular = require('angular');
 
@@ -23,7 +24,7 @@ module.exports = angular.module('spinnaker.deck.gce.httpLoadBalancer.backing.ser
                                                           gceCertificateReader,
                                                           gceHttpHealthCheckReader,
                                                           gceHttpLoadBalancerTransformer,
-                                                          loadBalancerReader, settings) {
+                                                          loadBalancerReader) {
 
     function buildCommand ({ originalLoadBalancer, isNew }) {
       originalLoadBalancer = _.cloneDeep(originalLoadBalancer);
@@ -67,7 +68,7 @@ module.exports = angular.module('spinnaker.deck.gce.httpLoadBalancer.backing.ser
 
     function buildLoadBalancer (isNew, loadBalancer) {
       let loadBalancerTemplate =
-        new HttpLoadBalancerTemplate(_.get(settings, 'providers.gce.defaults.account') || null);
+        new HttpLoadBalancerTemplate(GCEProviderSettings.defaults.account || null);
 
       let mixinData;
       if (isNew) {

--- a/app/scripts/modules/google/loadBalancer/configure/http/createHttpLoadBalancer.controller.js
+++ b/app/scripts/modules/google/loadBalancer/configure/http/createHttpLoadBalancer.controller.js
@@ -26,7 +26,7 @@ module.exports = angular.module('spinnaker.deck.gce.loadBalancer.createHttp.cont
   require('./listeners/listener.component.js'),
   require('./transformer.service.js'),
 ])
-  .controller('gceCreateHttpLoadBalancerCtrl', function ($scope, $uibModal, settings, $uibModalInstance, application, taskMonitorBuilder,
+  .controller('gceCreateHttpLoadBalancerCtrl', function ($scope, $uibModal, $uibModalInstance, application, taskMonitorBuilder,
                                                          loadBalancer, isNew, loadBalancerWriter, taskExecutor,
                                                          gceHttpLoadBalancerWriter, $state, wizardSubFormValidation,
                                                          gceHttpLoadBalancerCommandBuilder, gceHttpLoadBalancerTransformer) {

--- a/app/scripts/modules/google/loadBalancer/configure/internal/gceCreateInternalLoadBalancer.controller.ts
+++ b/app/scripts/modules/google/loadBalancer/configure/internal/gceCreateInternalLoadBalancer.controller.ts
@@ -13,6 +13,7 @@ import {CommonGceLoadBalancerCtrl} from '../common/commonLoadBalancer.controller
 import {INFRASTRUCTURE_CACHE_SERVICE, InfrastructureCacheService} from 'core/cache/infrastructureCaches.service';
 import {LOAD_BALANCER_WRITE_SERVICE, LoadBalancerWriter} from 'core/loadBalancer/loadBalancer.write.service';
 import {TASK_MONITOR_BUILDER, TaskMonitorBuilder} from 'core/task/monitor/taskMonitor.builder';
+import {GCEProviderSettings} from '../../../gce.settings';
 
 class ViewState {
   constructor(public sessionAffinity: string) {}
@@ -86,7 +87,6 @@ class InternalLoadBalancerCtrl extends CommonGceLoadBalancerCtrl implements ng.I
                                   'loadBalancerWriter',
                                   'wizardSubFormValidation',
                                   'taskMonitorBuilder',
-                                  'settings',
                                   '$state',
                                   'infrastructureCaches']; }
 
@@ -100,7 +100,6 @@ class InternalLoadBalancerCtrl extends CommonGceLoadBalancerCtrl implements ng.I
                private loadBalancerWriter: LoadBalancerWriter,
                private wizardSubFormValidation: any,
                private taskMonitorBuilder: TaskMonitorBuilder,
-               private settings: any,
                $state: IStateService,
                infrastructureCaches: InfrastructureCacheService) {
     super($scope, application, $uibModalInstance, $state, infrastructureCaches);
@@ -114,8 +113,8 @@ class InternalLoadBalancerCtrl extends CommonGceLoadBalancerCtrl implements ng.I
           this.initializeEditMode();
         } else {
           this.loadBalancer = new InternalLoadBalancer(
-            this.settings.providers.gce
-            ? this.settings.providers.gce.defaults.region
+            GCEProviderSettings
+            ? GCEProviderSettings.defaults.region
             : null);
         }
 

--- a/app/scripts/modules/google/loadBalancer/configure/ssl/gceCreateSslLoadBalancer.controller.ts
+++ b/app/scripts/modules/google/loadBalancer/configure/ssl/gceCreateSslLoadBalancer.controller.ts
@@ -16,6 +16,7 @@ import {
   ILoadBalancerUpsertDescription
 } from 'core/loadBalancer/loadBalancer.write.service';
 import {TASK_MONITOR_BUILDER, TaskMonitorBuilder} from 'core/task/monitor/taskMonitor.builder';
+import {GCEProviderSettings} from '../../../gce.settings';
 
 class ViewState {
   constructor(public sessionAffinity: string) {}
@@ -88,7 +89,6 @@ class SslLoadBalancerCtrl extends CommonGceLoadBalancerCtrl implements ng.ICompo
                                   'loadBalancerWriter',
                                   'wizardSubFormValidation',
                                   'taskMonitorBuilder',
-                                  'settings',
                                   '$state',
                                   'infrastructureCaches']; }
 
@@ -102,7 +102,6 @@ class SslLoadBalancerCtrl extends CommonGceLoadBalancerCtrl implements ng.ICompo
                private loadBalancerWriter: LoadBalancerWriter,
                private wizardSubFormValidation: any,
                private taskMonitorBuilder: TaskMonitorBuilder,
-               private settings: any,
                $state: IStateService,
                infrastructureCaches: InfrastructureCacheService) {
     super($scope, application, $uibModalInstance, $state, infrastructureCaches);
@@ -116,8 +115,8 @@ class SslLoadBalancerCtrl extends CommonGceLoadBalancerCtrl implements ng.ICompo
           this.initializeEditMode();
         } else {
           this.loadBalancer = new SslLoadBalancer(
-            this.settings.providers.gce
-            ? this.settings.providers.gce.defaults.region
+            GCEProviderSettings
+            ? GCEProviderSettings.defaults.region
             : null);
         }
 

--- a/app/scripts/modules/google/loadBalancer/loadBalancer.transformer.js
+++ b/app/scripts/modules/google/loadBalancer/loadBalancer.transformer.js
@@ -2,10 +2,12 @@
 
 import _ from 'lodash';
 
+import {GCEProviderSettings} from '../gce.settings';
+
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.gce.loadBalancer.transformer', [])
-  .factory('gceLoadBalancerTransformer', function ($q, settings) {
+  .factory('gceLoadBalancerTransformer', function ($q) {
 
     function updateHealthCounts(container) {
       var instances = container.instances;
@@ -128,8 +130,8 @@ module.exports = angular.module('spinnaker.gce.loadBalancer.transformer', [])
         provider: 'gce',
         stack: '',
         detail: '',
-        credentials: settings.providers.gce ? settings.providers.gce.defaults.account : null,
-        region: settings.providers.gce ? settings.providers.gce.defaults.region : null,
+        credentials: GCEProviderSettings.defaults.account,
+        region: GCEProviderSettings.defaults.region,
         healthCheckProtocol: 'HTTP',
         healthCheckPort: 80,
         healthCheckPath: '/',

--- a/app/scripts/modules/google/pipeline/stages/bake/bakeExecutionDetails.controller.js
+++ b/app/scripts/modules/google/pipeline/stages/bake/bakeExecutionDetails.controller.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import {EXECUTION_DETAILS_SECTION_SERVICE} from 'core/delivery/details/executionDetailsSection.service';
+import {SETTINGS} from 'core/config/settings';
 
 let angular = require('angular');
 
@@ -10,15 +11,15 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.bake.gce.executio
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ])
   .controller('gceBakeExecutionDetailsCtrl', function ($scope, $stateParams, executionDetailsSectionService,
-                                                       $interpolate, settings) {
+                                                       $interpolate) {
 
     $scope.configSections = ['bakeConfig', 'taskStatus'];
 
     let initialized = () => {
       $scope.detailsSection = $stateParams.details;
       $scope.provider = $scope.stage.context.cloudProviderType || 'gce';
-      $scope.roscoMode = settings.feature.roscoMode;
-      $scope.bakeryDetailUrl = $interpolate(settings.bakeryDetailUrl);
+      $scope.roscoMode = SETTINGS.feature.roscoMode;
+      $scope.bakeryDetailUrl = $interpolate(SETTINGS.bakeryDetailUrl);
     };
 
     let initialize = () => executionDetailsSectionService.synchronizeSection($scope.configSections, initialized);

--- a/app/scripts/modules/google/pipeline/stages/bake/gceBakeStage.js
+++ b/app/scripts/modules/google/pipeline/stages/bake/gceBakeStage.js
@@ -2,6 +2,7 @@
 
 import _ from 'lodash';
 import {BAKERY_SERVICE} from 'core/pipeline/config/stages/bake/bakery.service';
+import {SETTINGS} from 'core/config/settings';
 
 let angular = require('angular');
 
@@ -30,7 +31,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.gce.bakeStage', [
       restartable: true,
     });
   })
-  .controller('gceBakeStageCtrl', function($scope, bakeryService, $q, authenticationService, settings, $uibModal) {
+  .controller('gceBakeStageCtrl', function($scope, bakeryService, $q, authenticationService, $uibModal) {
 
     $scope.stage.extendedAttributes = $scope.stage.extendedAttributes || {};
     $scope.stage.region = 'global';
@@ -58,7 +59,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.gce.bakeStage', [
         if (!$scope.stage.baseLabel && $scope.baseLabelOptions && $scope.baseLabelOptions.length) {
           $scope.stage.baseLabel = $scope.baseLabelOptions[0];
         }
-        $scope.viewState.roscoMode = settings.feature.roscoMode;
+        $scope.viewState.roscoMode = SETTINGS.feature.roscoMode;
         $scope.showAdvancedOptions = showAdvanced();
         $scope.viewState.loading = false;
       });

--- a/app/scripts/modules/google/serverGroup/configure/serverGroupCommandBuilder.service.js
+++ b/app/scripts/modules/google/serverGroup/configure/serverGroupCommandBuilder.service.js
@@ -5,6 +5,7 @@ import _ from 'lodash';
 import {ACCOUNT_SERVICE} from 'core/account/account.service';
 import {INSTANCE_TYPE_SERVICE} from 'core/instance/instanceType.service';
 import {NAMING_SERVICE} from 'core/naming/naming.service';
+import {GCEProviderSettings} from '../../gce.settings';
 
 let angular = require('angular');
 
@@ -15,8 +16,7 @@ module.exports = angular.module('spinnaker.gce.serverGroupCommandBuilder.service
   require('./../../instance/custom/customInstanceBuilder.gce.service.js'),
   require('./wizard/hiddenMetadataKeys.value.js'),
 ])
-  .factory('gceServerGroupCommandBuilder', function (settings, $q,
-                                                     accountService, instanceTypeService, namingService,
+  .factory('gceServerGroupCommandBuilder', function ($q, accountService, instanceTypeService, namingService,
                                                      gceCustomInstanceBuilderService,
                                                      gceServerGroupHiddenMetadataKeys) {
 
@@ -237,9 +237,9 @@ module.exports = angular.module('spinnaker.gce.serverGroupCommandBuilder.service
     function buildNewServerGroupCommand(application, defaults) {
       defaults = defaults || {};
 
-      var defaultCredentials = defaults.account || settings.providers.gce.defaults.account;
-      var defaultRegion = defaults.region || settings.providers.gce.defaults.region;
-      var defaultZone = defaults.zone || settings.providers.gce.defaults.zone;
+      var defaultCredentials = defaults.account || GCEProviderSettings.defaults.account;
+      var defaultRegion = defaults.region || GCEProviderSettings.defaults.region;
+      var defaultZone = defaults.zone || GCEProviderSettings.defaults.zone;
 
       var command = {
         application: application.name,

--- a/app/scripts/modules/google/serverGroup/configure/serverGroupConfiguration.service.js
+++ b/app/scripts/modules/google/serverGroup/configure/serverGroupConfiguration.service.js
@@ -9,6 +9,7 @@ import {NETWORK_READ_SERVICE} from 'core/network/network.read.service';
 import {SUBNET_READ_SERVICE} from 'core/subnet/subnet.read.service';
 import {CACHE_INITIALIZER_SERVICE} from 'core/cache/cacheInitializer.service';
 import {SECURITY_GROUP_READER} from 'core/securityGroup/securityGroupReader.service';
+import {GCEProviderSettings} from '../../gce.settings';
 
 let angular = require('angular');
 
@@ -30,7 +31,7 @@ module.exports = angular.module('spinnaker.serverGroup.configure.gce.configurati
   .factory('gceServerGroupConfigurationService', function(gceImageReader, accountService, securityGroupReader,
                                                           gceInstanceTypeService, cacheInitializer,
                                                           $q, loadBalancerReader, networkReader, subnetReader,
-                                                          settings, gceCustomInstanceBuilderService, elSevenUtils,
+                                                          gceCustomInstanceBuilderService, elSevenUtils,
                                                           gceHttpHealthCheckReader, gceTagManager,
                                                           gceLoadBalancerSetTransformer) {
 
@@ -541,7 +542,7 @@ module.exports = angular.module('spinnaker.serverGroup.configure.gce.configurati
       command.regionalChanged = function regionalChanged() {
         var result = { dirty: {} };
         var filteredData = command.backingData.filtered;
-        var defaults = settings.providers.gce.defaults;
+        var defaults = GCEProviderSettings.defaults;
         if (command.regional) {
           command.zone = null;
         } else if (!command.zone) {

--- a/app/scripts/modules/google/serverGroup/configure/wizard/loadBalancers/loadBalancerSelector.directive.spec.js
+++ b/app/scripts/modules/google/serverGroup/configure/wizard/loadBalancers/loadBalancerSelector.directive.spec.js
@@ -1,6 +1,8 @@
 'use strict';
 
 let angular = require('angular');
+
+import {SETTINGS} from 'core/config/settings';
 require('./loadBalancerSelector.directive.html');
 
 describe('Directive: GCE Load Balancers Selector', function() {
@@ -20,15 +22,14 @@ describe('Directive: GCE Load Balancers Selector', function() {
   beforeEach(window.inject(function(_gceServerGroupConfigurationService_,
                                     _cacheInitializer_,
                                     _infrastructureCaches_,
-                                    _momentService_,
-                                    settings) {
+                                    _momentService_) {
     gceServerGroupConfigurationService = _gceServerGroupConfigurationService_;
 
 
     const lastRefreshed = (new Date('2015-01-01T00:00:00')).getTime();
     _cacheInitializer_.refreshCache('loadBalancers');
     _infrastructureCaches_.get('loadBalancers').getStats = function() { return {ageMax: lastRefreshed}; };
-    var m = _momentService_.tz(lastRefreshed, settings.defaultTimeZone);
+    var m = _momentService_.tz(lastRefreshed, SETTINGS.defaultTimeZone);
     expectedTime = m.format('YYYY-MM-DD HH:mm:ss z');
 
     selector = angular.element('<gce-server-group-load-balancer-selector command="command" />');

--- a/app/scripts/modules/kubernetes/cluster/configure/CommandBuilder.js
+++ b/app/scripts/modules/kubernetes/cluster/configure/CommandBuilder.js
@@ -1,15 +1,16 @@
 'use strict';
 
 import _ from 'lodash';
+
 import {ACCOUNT_SERVICE} from 'core/account/account.service';
+import {KubernetesProviderSettings} from '../../kubernetes.settings';
 
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.kubernetes.clusterCommandBuilder.service', [
-  require('core/config/settings.js'),
-  ACCOUNT_SERVICE,
+  ACCOUNT_SERVICE
 ])
-  .factory('kubernetesClusterCommandBuilder', function (settings, accountService) {
+  .factory('kubernetesClusterCommandBuilder', function (accountService) {
     function attemptToSetValidAccount(application, defaultAccount, command) {
       return accountService.listAccounts('kubernetes').then(function(kubernetesAccounts) {
         var kubernetesAccountNames = _.map(kubernetesAccounts, 'name');
@@ -35,7 +36,7 @@ module.exports = angular.module('spinnaker.kubernetes.clusterCommandBuilder.serv
     }
 
     function buildNewClusterCommand(application, defaults = {}) {
-      var defaultAccount = defaults.account || settings.providers.kubernetes.defaults.account;
+      var defaultAccount = defaults.account || KubernetesProviderSettings.defaults.account;
 
       var command = {
         account: defaultAccount,

--- a/app/scripts/modules/kubernetes/kubernetes.settings.ts
+++ b/app/scripts/modules/kubernetes/kubernetes.settings.ts
@@ -1,0 +1,14 @@
+import { IProviderSettings, SETTINGS } from 'core/config/settings';
+
+export interface IKubernetesProviderSettings extends IProviderSettings {
+  defaults: {
+    account: string;
+    namespace: string;
+    proxy: string;
+  };
+}
+
+export const KubernetesProviderSettings: IKubernetesProviderSettings = <IKubernetesProviderSettings>SETTINGS.providers.kubernetes;
+if (KubernetesProviderSettings) {
+  KubernetesProviderSettings.resetToOriginal = SETTINGS.resetToOriginal;
+}

--- a/app/scripts/modules/kubernetes/loadBalancer/transformer.js
+++ b/app/scripts/modules/kubernetes/loadBalancer/transformer.js
@@ -2,10 +2,12 @@
 
 import _ from 'lodash';
 
+import {KubernetesProviderSettings} from '../kubernetes.settings';
+
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.kubernetes.loadBalancer.transformer', [])
-  .factory('kubernetesLoadBalancerTransformer', function ($q, settings) {
+  .factory('kubernetesLoadBalancerTransformer', function ($q) {
     function normalizeLoadBalancer(loadBalancer) {
       loadBalancer.provider = loadBalancer.type;
       loadBalancer.instances = [];
@@ -48,8 +50,8 @@ module.exports = angular.module('spinnaker.kubernetes.loadBalancer.transformer',
         stack: '',
         detail: '',
         serviceType: 'ClusterIP',
-        account: settings.providers.kubernetes ? settings.providers.kubernetes.defaults.account : null,
-        namespace: settings.providers.kubernetes ? settings.providers.kubernetes.defaults.namespace : null,
+        account: KubernetesProviderSettings.defaults.account,
+        namespace: KubernetesProviderSettings.defaults.namespace,
         ports: [
           {
             protocol: 'TCP',

--- a/app/scripts/modules/kubernetes/proxy/ui.service.js
+++ b/app/scripts/modules/kubernetes/proxy/ui.service.js
@@ -2,15 +2,15 @@
 
 let angular = require('angular');
 
-module.exports = angular.module('spinnaker.proxy.kubernetes.ui.service', [
-  require('core/config/settings.js'),
-])
-  .factory('kubernetesProxyUiService', function(settings) {
+import {KubernetesProviderSettings} from '../kubernetes.settings';
+
+module.exports = angular.module('spinnaker.proxy.kubernetes.ui.service', [])
+  .factory('kubernetesProxyUiService', function() {
     let apiPrefix = 'api/v1/proxy/namespaces/kube-system/services/kubernetes-dashboard/#';
 
     function getHost(accountName) {
-      let host = settings.providers.kubernetes.defaults.proxy;
-      let account = settings.providers.kubernetes[accountName];
+      let host = KubernetesProviderSettings.defaults.proxy;
+      let account = KubernetesProviderSettings[accountName];
 
       if (account && account.proxy) {
         host = account.proxy;

--- a/app/scripts/modules/kubernetes/securityGroup/transformer.js
+++ b/app/scripts/modules/kubernetes/securityGroup/transformer.js
@@ -2,9 +2,11 @@
 
 let angular = require('angular');
 
+import {KubernetesProviderSettings} from '../kubernetes.settings';
+
 module.exports = angular.module('spinnaker.kubernetes.securityGroup.transformer', [
 ])
-  .factory('kubernetesSecurityGroupTransformer', function (settings, $q) {
+  .factory('kubernetesSecurityGroupTransformer', function ($q) {
 
     function normalizeSecurityGroup(securityGroup) {
       return $q.when(securityGroup); // no-op
@@ -15,8 +17,8 @@ module.exports = angular.module('spinnaker.kubernetes.securityGroup.transformer'
         provider: 'kubernetes',
         stack: '',
         detail: '',
-        account: settings.providers.kubernetes ? settings.providers.kubernetes.defaults.account : null,
-        namespace: settings.providers.kubernetes ? settings.providers.kubernetes.defaults.namespace : null,
+        account: KubernetesProviderSettings.defaults.account,
+        namespace: KubernetesProviderSettings.defaults.namespace,
         ingress: {
           serviceName: '',
           port: null,

--- a/app/scripts/modules/kubernetes/serverGroup/configure/CommandBuilder.js
+++ b/app/scripts/modules/kubernetes/serverGroup/configure/CommandBuilder.js
@@ -6,12 +6,11 @@ import {ACCOUNT_SERVICE} from 'core/account/account.service';
 import {NAMING_SERVICE} from 'core/naming/naming.service';
 
 module.exports = angular.module('spinnaker.kubernetes.serverGroupCommandBuilder.service', [
-  require('core/config/settings.js'),
   ACCOUNT_SERVICE,
   NAMING_SERVICE,
   require('../../cluster/cluster.kubernetes.module.js'),
 ])
-  .factory('kubernetesServerGroupCommandBuilder', function (settings, $q, accountService, namingService,
+  .factory('kubernetesServerGroupCommandBuilder', function ($q, accountService, namingService,
                                                             kubernetesClusterCommandBuilder) {
     function buildNewServerGroupCommand(application, defaults = {}) {
       var command = kubernetesClusterCommandBuilder.buildNewClusterCommand(application, defaults);

--- a/app/scripts/modules/netflix/alert/alertHandler.js
+++ b/app/scripts/modules/netflix/alert/alertHandler.js
@@ -1,23 +1,23 @@
 'use strict';
 
 import {AUTHENTICATION_SERVICE} from 'core/authentication/authentication.service';
+import {SETTINGS} from 'core/config/settings';
 
 let angular = require('angular');
 
 module.exports = angular
   .module('spinnaker.netflix.alert.handler', [
-    require('core/config/settings.js'),
     AUTHENTICATION_SERVICE
   ])
   .config(function ($provide) {
-    $provide.decorator('$exceptionHandler', function($delegate, settings, authenticationService, $injector) {
+    $provide.decorator('$exceptionHandler', function($delegate, authenticationService, $injector) {
       let currentVersion = require('../../../../../version.json');
 
       return function(exception, cause) {
         $delegate(exception, cause);
         // using injector access to avoid a circular dependency
         let $http = $injector.get('$http');
-        if (!settings.alert) {
+        if (!SETTINGS.alert) {
           return;
         }
         let message = exception.message;
@@ -45,16 +45,16 @@ module.exports = angular
           actions: [
             {
               action: 'email',
-              suppressTimeSecs: settings.alert.throttleInSeconds,
-              to: settings.alert.recipients,
-              subject: settings.alert.subject || '[Spinnaker] Error in Deck',
-              htmlTemplate: settings.alert.template || 'spinnaker_deck_error',
+              suppressTimeSecs: SETTINGS.alert.throttleInSeconds,
+              to: SETTINGS.alert.recipients,
+              subject: SETTINGS.alert.subject || '[Spinnaker] Error in Deck',
+              htmlTemplate: SETTINGS.alert.template || 'spinnaker_deck_error',
               incidentKey: exception.message,
             }
           ],
         };
 
-        $http.post(settings.alert.url, payload);
+        $http.post(SETTINGS.alert.url, payload);
       };
     });
   });

--- a/app/scripts/modules/netflix/application/netflixCreateApplicationModal.controller.js
+++ b/app/scripts/modules/netflix/application/netflixCreateApplicationModal.controller.js
@@ -5,6 +5,7 @@ import {APPLICATION_READ_SERVICE} from 'core/application/service/application.rea
 import {APPLICATION_WRITE_SERVICE} from 'core/application/service/application.write.service';
 import {ACCOUNT_SERVICE} from 'core/account/account.service';
 import {UI_SELECT_COMPONENT} from 'core/widgets/uiSelect.component';
+import {SETTINGS} from 'core/config/settings';
 
 module.exports = angular
   .module('spinnaker.netflix.application.create.modal.controller', [
@@ -12,12 +13,10 @@ module.exports = angular
     APPLICATION_WRITE_SERVICE,
     APPLICATION_READ_SERVICE,
     ACCOUNT_SERVICE,
-    require('core/config/settings.js'),
     PAGER_DUTY_SELECT_FIELD_COMPONENT,
     UI_SELECT_COMPONENT
   ])
   .controller('netflixCreateApplicationModalCtrl', function($controller, $scope, $q, $log, $state, $uibModalInstance,
-                                                            settings,
                                                             accountService, applicationWriter, applicationReader) {
 
     angular.extend(this, $controller('CreateApplicationModalCtrl', {
@@ -31,7 +30,7 @@ module.exports = angular
       applicationReader: applicationReader
     }));
 
-    this.chaosEnabled = settings.feature.chaosMonkey;
+    this.chaosEnabled = SETTINGS.feature.chaosMonkey;
 
     if (this.chaosEnabled) {
       this.application.chaosMonkey = {

--- a/app/scripts/modules/netflix/blesk/blesk.module.ts
+++ b/app/scripts/modules/netflix/blesk/blesk.module.ts
@@ -1,4 +1,5 @@
 import {ITimeoutService, element, module} from 'angular';
+import {NetflixSettings} from '../netflix.settings';
 
 require('./bleskOverrides.css');
 
@@ -18,10 +19,10 @@ class BleskService {
 }
 
 export const BLESK_MODULE = 'spinnaker.netflix.blesk';
-module(BLESK_MODULE, [require('core/config/settings.js')])
+module(BLESK_MODULE, [])
   .service('blesk', BleskService)
-  .run(($timeout: ITimeoutService, settings: any, blesk: BleskService) => {
-    if (settings.feature && settings.feature.blesk) {
+  .run(($timeout: ITimeoutService, blesk: BleskService) => {
+    if (NetflixSettings.feature.blesk) {
       $timeout(blesk.initialize, 5000); // delay on init so auth can occur and DOM can finish loading
     }
   });

--- a/app/scripts/modules/netflix/ci/build.read.service.js
+++ b/app/scripts/modules/netflix/ci/build.read.service.js
@@ -5,15 +5,15 @@ let angular = require('angular');
 import {API_SERVICE} from 'core/api/api.service';
 import {CI_FILTER_MODEL} from './ci.filter.model';
 import {ORCHESTRATED_ITEM_TRANSFORMER} from 'core/orchestratedItem/orchestratedItem.transformer';
+import {SETTINGS} from 'core/config/settings';
 
 module.exports = angular
   .module('spinnaker.netflix.ci.build.read.service', [
     API_SERVICE,
     CI_FILTER_MODEL,
-    require('core/config/settings'),
     ORCHESTRATED_ITEM_TRANSFORMER,
   ])
-  .factory('buildService', function (API, settings, orchestratedItemTransformer, CiFilterModel) {
+  .factory('buildService', function (API, orchestratedItemTransformer, CiFilterModel) {
 
     const MAX_LINES = 4095;
 
@@ -53,7 +53,7 @@ module.exports = angular
     }
 
     function getBuildRawLogLink(buildId) {
-      return [settings.gateUrl, 'ci', 'builds', buildId, 'rawOutput'].join('/');
+      return [SETTINGS.gateUrl, 'ci', 'builds', buildId, 'rawOutput'].join('/');
     }
 
     function builds() {

--- a/app/scripts/modules/netflix/ci/ci.dataSource.js
+++ b/app/scripts/modules/netflix/ci/ci.dataSource.js
@@ -1,17 +1,17 @@
 import {DataSourceConfig} from 'core/application/service/applicationDataSource';
 import {APPLICATION_DATA_SOURCE_REGISTRY} from 'core/application/service/applicationDataSource.registry';
+import {NetflixSettings} from '../netflix.settings';
 
 let angular = require('angular');
 
 module.exports = angular
   .module('spinnaker.netflix.ci.dataSource', [
-    require('core/config/settings'),
     APPLICATION_DATA_SOURCE_REGISTRY,
     require('./build.read.service'),
   ])
-  .run(function($q, applicationDataSourceRegistry, settings, buildService) {
+  .run(function($q, applicationDataSourceRegistry, buildService) {
 
-    if (settings.feature && settings.feature.netflixMode) {
+    if (NetflixSettings.feature.netflixMode) {
       let loadRunningBuilds = (application) => {
         let attr = application.attributes;
         return buildService.getRunningBuilds(attr.repoType, attr.repoProjectKey, attr.repoSlug);

--- a/app/scripts/modules/netflix/ci/ci.dataSource.spec.ts
+++ b/app/scripts/modules/netflix/ci/ci.dataSource.spec.ts
@@ -3,32 +3,30 @@ import {mock} from 'angular';
 import {Application} from 'core/application/application.model';
 import {APPLICATION_MODEL_BUILDER, ApplicationModelBuilder} from 'core/application/applicationModel.builder';
 import {APPLICATION_DATA_SOURCE_REGISTRY} from 'core/application/service/applicationDataSource.registry';
-import IProvideService = angular.auto.IProvideService;
+import {NetflixSettings} from '../netflix.settings';
 
 describe('CI Data Source', function () {
+  beforeEach(function () {
+    NetflixSettings.feature.netflixMode = true;
+  });
+
   beforeEach(
     mock.module(
       require('./ci.dataSource'),
       APPLICATION_MODEL_BUILDER,
-      APPLICATION_DATA_SOURCE_REGISTRY,
-      function($provide: IProvideService) {
-        return $provide.constant('settings', {
-          feature: { netflixMode: true }
-        });
-      }
+      APPLICATION_DATA_SOURCE_REGISTRY
     )
   );
 
   beforeEach(
     mock.inject(
-      function(buildService: any, $httpBackend: ng.IHttpBackendService, settings: any, $q: ng.IQService,
+      function(buildService: any, $httpBackend: ng.IHttpBackendService, $q: ng.IQService,
                applicationModelBuilder: ApplicationModelBuilder, $rootScope: ng.IRootScopeService,
                applicationDataSourceRegistry: any) {
         this.buildService = buildService;
         this.applicationDataSourceRegistry = applicationDataSourceRegistry;
         this.$http = $httpBackend;
         this.$q = $q;
-        this.settings = settings;
         this.builder = applicationModelBuilder;
         this.$scope = $rootScope.$new();
         this.applicationModelBuilder = applicationModelBuilder;
@@ -36,6 +34,8 @@ describe('CI Data Source', function () {
       }
     )
   );
+
+  afterEach(NetflixSettings.resetToOriginal);
 
   describe('load builds', function () {
     it('only calls build service when all configuration values are present', function () {

--- a/app/scripts/modules/netflix/fastProperties/dataNav/fastProperties.controller.js
+++ b/app/scripts/modules/netflix/fastProperties/dataNav/fastProperties.controller.js
@@ -2,6 +2,7 @@
 
 import _ from 'lodash';
 import { CREATE_FAST_PROPERTY_WIZARD_CONTROLLER } from '../wizard/createFastPropertyWizard.controller';
+import {NetflixSettings} from '../../netflix.settings';
 
 
 let angular = require('angular');
@@ -13,11 +14,11 @@ module.exports = angular
     require('../fastProperty.read.service.js'),
     CREATE_FAST_PROPERTY_WIZARD_CONTROLLER,
   ])
-  .controller('FastPropertiesController', function ($scope, $filter, $state, $stateParams, $location, $uibModal, settings, fastPropertyReader) {
+  .controller('FastPropertiesController', function ($scope, $filter, $state, $stateParams, $location, $uibModal, fastPropertyReader) {
     let vm = this;
     let filterNames = ['app','env', 'region', 'stack', 'cluster'];
 
-    vm.isOn = settings.feature.fastProperty;
+    vm.isOn = NetflixSettings.feature.fastProperty;
     vm.fetchingProperties = false;
 
     $scope.filters = {list: []};

--- a/app/scripts/modules/netflix/fastProperties/fastProperty.dataSource.js
+++ b/app/scripts/modules/netflix/fastProperties/fastProperty.dataSource.js
@@ -1,16 +1,16 @@
 import {DataSourceConfig} from 'core/application/service/applicationDataSource';
 import {APPLICATION_DATA_SOURCE_REGISTRY} from 'core/application/service/applicationDataSource.registry';
+import {NetflixSettings} from '../netflix.settings';
 
 let angular = require('angular');
 
 module.exports = angular
   .module('spinnaker.netflix.fastProperty.dataSource', [
-    require('core/config/settings'),
-    APPLICATION_DATA_SOURCE_REGISTRY,
+    APPLICATION_DATA_SOURCE_REGISTRY
   ])
-  .run(function($q, applicationDataSourceRegistry, settings) {
+  .run(function($q, applicationDataSourceRegistry) {
 
-    if (settings.feature && settings.feature.fastProperty && settings.feature.netflixMode) {
+    if (NetflixSettings.feature.fastProperty && NetflixSettings.feature.netflixMode) {
       applicationDataSourceRegistry.registerDataSource(new DataSourceConfig({
         key: 'properties',
         sref: '.propInsights.properties',

--- a/app/scripts/modules/netflix/fastProperties/view/fastProperties.controller.js
+++ b/app/scripts/modules/netflix/fastProperties/view/fastProperties.controller.js
@@ -1,8 +1,9 @@
 'use strict';
 
-import {isArray, uniqWith, flatten, compact, uniq, values, isEmpty, sortBy, groupBy, debounce } from 'lodash';
+import { isArray, uniqWith, flatten, compact, uniq, values, isEmpty, sortBy, groupBy, debounce } from 'lodash';
 import { CREATE_FAST_PROPERTY_WIZARD_CONTROLLER } from '../wizard/createFastPropertyWizard.controller';
 import { FAST_PROPERTY_READ_SERVICE } from '../fastProperty.read.service';
+import { NetflixSettings } from '../../netflix.settings';
 
 let angular = require('angular');
 
@@ -14,14 +15,14 @@ module.exports = angular
     require('./fastPropertyTable.directive.js'),
     CREATE_FAST_PROPERTY_WIZARD_CONTROLLER,
   ])
-  .controller('FastPropertiesController', function ($scope, $filter, $state, $urlRouter, $stateParams, $location, $uibModal, settings, app, fastPropertyReader) {
+  .controller('FastPropertiesController', function ($scope, $filter, $state, $urlRouter, $stateParams, $location, $uibModal, app, fastPropertyReader) {
 
     let vm = this;
     let filterNames = ['substring', 'key', 'value', 'app','env', 'region', 'stack', 'cluster'];
 
     vm.application = app;
 
-    vm.isOn = settings.feature.fastProperty;
+    vm.isOn = NetflixSettings.feature.fastProperty;
     vm.fetchingProperties = false;
 
     $scope.filters = {list: []};

--- a/app/scripts/modules/netflix/feedback/feedback.directive.ts
+++ b/app/scripts/modules/netflix/feedback/feedback.directive.ts
@@ -1,7 +1,8 @@
-import { module } from 'angular';
+import {module} from 'angular';
 import {IModalService} from 'angular-ui-bootstrap';
 
-import { DirectiveFactory } from 'core/utils/tsDecorators/directiveFactoryDecorator';
+import {DirectiveFactory} from 'core/utils/tsDecorators/directiveFactoryDecorator';
+import {NetflixSettings} from '../netflix.settings';
 
 import './feedback.less';
 
@@ -10,16 +11,15 @@ import './feedback.less';
 // component because we style the li based on information in the controller..,
 export class FeedbackController implements ng.IComponentController {
   static get $inject(): string[] {
-    return ['$location', '$scope', '$uibModal', 'settings'];
+    return ['$location', '$scope', '$uibModal'];
   }
 
   constructor (private $location: ng.ILocationService,
                private $scope: any,
-               private $uibModal: IModalService,
-               private settings: any) {}
+               private $uibModal: IModalService) {}
 
   public initialize(): void {
-    this.$scope.slackConfig = this.settings.feedback ? this.settings.feedback.slack : null;
+    this.$scope.slackConfig = NetflixSettings.feedback ? NetflixSettings.feedback.slack : null;
 
     this.$scope.state = {
       open: false,
@@ -59,6 +59,5 @@ class FeedbackDirective implements ng.IDirective {
 }
 
 export const FEEDBACK_DIRECTIVE = 'spinnaker.netflix.feedback.directive';
-module(FEEDBACK_DIRECTIVE, [
-  require('core/config/settings')
-]).directive('feedback', <any>FeedbackDirective);
+module(FEEDBACK_DIRECTIVE, [])
+  .directive('feedback', <any>FeedbackDirective);

--- a/app/scripts/modules/netflix/feedback/feedback.modal.controller.ts
+++ b/app/scripts/modules/netflix/feedback/feedback.modal.controller.ts
@@ -2,6 +2,7 @@ import { module } from 'angular';
 import { IModalServiceInstance } from 'angular-ui-bootstrap';
 
 import { AUTHENTICATION_SERVICE, AuthenticationService } from 'core/authentication/authentication.service';
+import { NetflixSettings } from '../netflix.settings';
 
 interface IFeedback {
   title: string;
@@ -27,7 +28,6 @@ class FeedbackModalController implements ng.IComponentController {
       '$location',
       '$http',
       '$uibModalInstance',
-      'settings',
       'authenticationService'
     ];
   }
@@ -35,7 +35,6 @@ class FeedbackModalController implements ng.IComponentController {
   constructor (private $location: ng.ILocationService,
                private $http: ng.IHttpService,
                private $uibModalInstance: IModalServiceInstance,
-               private settings: any,
                private authenticationService: AuthenticationService) {}
 
   public $onInit (): void {
@@ -80,7 +79,7 @@ class FeedbackModalController implements ng.IComponentController {
 
   public submit(): void {
     this.state = this.states.SUBMITTING;
-    this.$http.post(this.settings.feedbackUrl, this.buildRequestBody())
+    this.$http.post(NetflixSettings.feedbackUrl, this.buildRequestBody())
       .then((result: any) => {
         this.state = this.states.SUBMITTED;
         this.issueUrl = result.data.url;
@@ -98,7 +97,6 @@ class FeedbackModalController implements ng.IComponentController {
 
 export const FEEDBACK_MODAL_CONTROLLER = 'spinnaker.netflix.feedback.modal.controller';
 module(FEEDBACK_MODAL_CONTROLLER, [
-  require('core/config/settings'),
   AUTHENTICATION_SERVICE
 ])
 .controller('FeedbackModalCtrl', FeedbackModalController);

--- a/app/scripts/modules/netflix/help/netflixHelpContents.registry.js
+++ b/app/scripts/modules/netflix/help/netflixHelpContents.registry.js
@@ -1,15 +1,15 @@
 'use strict';
 
 import {HELP_CONTENTS_REGISTRY} from 'core/help/helpContents.registry';
+import {NetflixSettings} from '../netflix.settings';
 
 const angular = require('angular');
 
 module.exports = angular
   .module('spinnaker.netflix.help.registry', [
     HELP_CONTENTS_REGISTRY,
-    require('core/config/settings.js'),
   ])
-  .run(function(helpContentsRegistry, settings) {
+  .run(function(helpContentsRegistry) {
     let helpContents = [
       {
         key: 'application.legacyUdf',
@@ -80,7 +80,7 @@ module.exports = angular
         contents: 'The availability trends for the Netflix streaming service represented as percentage of expected stream starts acheived and the number of \'nines\' of that availability. <a href="http://go/availabilitycontextdoc" target="_blank">Click here</a> for more details.'
       }
     ];
-    if (settings.feature && settings.feature.netflixMode) {
+    if (NetflixSettings.feature.netflixMode) {
       helpContents.forEach((entry) => helpContentsRegistry.registerOverride(entry.key, entry.contents));
     }
   });

--- a/app/scripts/modules/netflix/instance/aws/netflixAwsInstanceDetails.controller.js
+++ b/app/scripts/modules/netflix/instance/aws/netflixAwsInstanceDetails.controller.js
@@ -18,10 +18,9 @@ module.exports = angular.module('spinnaker.netflix.instance.aws.controller', [
   CONFIRMATION_MODAL_SERVICE,
   RECENT_HISTORY_SERVICE,
   require('core/utils/selectOnDblClick.directive.js'),
-  require('core/config/settings.js'),
   require('amazon/instance/details/instance.details.controller.js'),
 ])
-  .controller('netflixAwsInstanceDetailsCtrl', function ($scope, $state, $uibModal, settings,
+  .controller('netflixAwsInstanceDetailsCtrl', function ($scope, $state, $uibModal,
                                                          instanceWriter, confirmationModalService, recentHistoryService,
                                                          accountService,
                                                          instanceReader, instance, app, $q, $controller) {
@@ -45,7 +44,6 @@ module.exports = angular.module('spinnaker.netflix.instance.aws.controller', [
       $scope: $scope,
       $state: $state,
       $uibModal: $uibModal,
-      settings: settings,
       instanceWriter: instanceWriter,
       confirmationModalService: confirmationModalService,
       recentHistoryService: recentHistoryService,

--- a/app/scripts/modules/netflix/instance/titus/netflixTitusInstanceDetails.controller.js
+++ b/app/scripts/modules/netflix/instance/titus/netflixTitusInstanceDetails.controller.js
@@ -18,10 +18,9 @@ module.exports = angular.module('spinnaker.netflix.instance.titus.controller', [
   CONFIRMATION_MODAL_SERVICE,
   RECENT_HISTORY_SERVICE,
   require('core/utils/selectOnDblClick.directive.js'),
-  require('core/config/settings.js'),
   require('../../../titus/instance/details/instance.details.controller.js'),
 ])
-  .controller('netflixTitusInstanceDetailsCtrl', function ($scope, $state, $uibModal, settings,
+  .controller('netflixTitusInstanceDetailsCtrl', function ($scope, $state, $uibModal,
                                                          instanceWriter, confirmationModalService, recentHistoryService,
                                                          accountService, instanceReader, instance, app, $q, $controller) {
 
@@ -37,7 +36,6 @@ module.exports = angular.module('spinnaker.netflix.instance.titus.controller', [
       $scope: $scope,
       $state: $state,
       $uibModal: $uibModal,
-      settings: settings,
       instanceWriter: instanceWriter,
       confirmationModalService: confirmationModalService,
       recentHistoryService: recentHistoryService,

--- a/app/scripts/modules/netflix/migrator/pipeline/pipeline.migrator.directive.js
+++ b/app/scripts/modules/netflix/migrator/pipeline/pipeline.migrator.directive.js
@@ -9,6 +9,7 @@ import {SUBNET_READ_SERVICE} from 'core/subnet/subnet.read.service';
 import {TASK_READ_SERVICE} from 'core/task/task.read.service';
 import {CACHE_INITIALIZER_SERVICE} from 'core/cache/cacheInitializer.service';
 import {PIPELINE_CONFIG_SERVICE} from 'core/pipeline/config/services/pipelineConfig.service';
+import {NetflixSettings} from '../../netflix.settings';
 
 require('../migrator.less');
 
@@ -16,7 +17,6 @@ module.exports = angular
   .module('spinnaker.migrator.pipeline.directive', [
     require('angular-ui-bootstrap'),
     require('amazon/vpc/vpc.read.service.js'),
-    require('core/config/settings.js'),
     SUBNET_READ_SERVICE,
     require('../migrator.service.js'),
     AUTO_SCROLL_DIRECTIVE,
@@ -43,7 +43,7 @@ module.exports = angular
       controllerAs: 'migratorActionCtrl',
     };
   })
-  .controller('PipelineMigratorActionCtrl', function ($scope, $uibModal, $state, vpcReader, settings) {
+  .controller('PipelineMigratorActionCtrl', function ($scope, $uibModal, $state) {
 
     $scope.showAction = false;
 
@@ -60,7 +60,7 @@ module.exports = angular
       };
     }
 
-    if (settings.feature.vpcMigrator) {
+    if (NetflixSettings.feature.vpcMigrator) {
       let migrated = $scope.application.pipelineConfigs.data.find(test => test.name === $scope.pipeline.name + ' - vpc0');
       if (migrated) {
         $scope.migrated = migrated;

--- a/app/scripts/modules/netflix/migrator/serverGroup/serverGroup.migrator.directive.js
+++ b/app/scripts/modules/netflix/migrator/serverGroup/serverGroup.migrator.directive.js
@@ -3,6 +3,7 @@
 require('../migrator.less');
 import {AUTO_SCROLL_DIRECTIVE} from 'core/presentation/autoScroll/autoScroll.directive';
 import {SUBNET_READ_SERVICE} from 'core/subnet/subnet.read.service';
+import {NetflixSettings} from '../../netflix.settings';
 
 import _ from 'lodash';
 
@@ -12,7 +13,6 @@ module.exports = angular
   .module('spinnaker.migrator.directive', [
     require('angular-ui-bootstrap'),
     require('amazon/vpc/vpc.read.service.js'),
-    require('core/config/settings.js'),
     SUBNET_READ_SERVICE,
     require('../migrator.service.js'),
     AUTO_SCROLL_DIRECTIVE,
@@ -35,10 +35,10 @@ module.exports = angular
       controllerAs: 'migratorActionCtrl',
     };
   })
-  .controller('MigratorActionCtrl', function ($scope, $uibModal, vpcReader, settings) {
+  .controller('MigratorActionCtrl', function ($scope, $uibModal, vpcReader) {
 
     vpcReader.getVpcName($scope.serverGroup.vpcId).then(function (name) {
-      $scope.showAction = !name && settings.feature.vpcMigrator;
+      $scope.showAction = !name && NetflixSettings.feature.vpcMigrator;
     });
 
     this.previewMigration = function () {

--- a/app/scripts/modules/netflix/netflix.module.ts
+++ b/app/scripts/modules/netflix/netflix.module.ts
@@ -7,6 +7,7 @@ import {TABLEAU_STATES} from './tableau/tableau.states';
 import {ISOLATED_TESTING_TARGET_STAGE_MODULE} from './pipeline/stage/isolatedTestingTarget/isolatedTestingTargetStage.module';
 import {FEEDBACK_MODULE} from './feedback/feedback.module';
 import {AVAILABILITY_DIRECTIVE} from './availability/availability.directive';
+import {NetflixSettings} from './netflix.settings';
 
 // load all templates into the $templateCache
 const templates = require.context('./', true, /\.html$/);
@@ -43,18 +44,14 @@ module('spinnaker.netflix', [
   require('./application/netflixCreateApplicationModal.controller.js'),
   require('./application/netflixEditApplicationModal.controller.js'),
   require('./help/netflixHelpContents.registry.js'),
-
-  require('core/config/settings.js'),
-
   TABLEAU_STATES,
   require('./ci/ci.module'),
   APPLICATION_DATA_SOURCE_REGISTRY,
   CLOUD_PROVIDER_REGISTRY,
 ])
   .run((cloudProviderRegistry: CloudProviderRegistry,
-        applicationDataSourceRegistry: ApplicationDataSourceRegistry,
-        settings: any) => {
-    if (settings.feature && settings.feature.netflixMode) {
+        applicationDataSourceRegistry: ApplicationDataSourceRegistry) => {
+    if (NetflixSettings.feature.netflixMode) {
       cloudProviderRegistry.overrideValue(
         'aws',
         'instance.detailsTemplateUrl',

--- a/app/scripts/modules/netflix/netflix.settings.ts
+++ b/app/scripts/modules/netflix/netflix.settings.ts
@@ -1,0 +1,38 @@
+import { IFeatures, ISpinnakerSettings, SETTINGS } from 'core/config/settings';
+
+interface INetflixFeatures extends IFeatures {
+  blesk?: boolean;
+  fastProperty?: boolean;
+  netflixMode?: boolean;
+  tableau?: boolean;
+  vpcMigrator?: boolean;
+}
+
+export interface INetflixSettings extends ISpinnakerSettings {
+  chap?: {
+    canaryReportBaseUrl: string;
+    chapBaseUrl: string;
+    fitBaseUrl: string;
+  };
+  feedback?: {
+    slack?: {
+      team: string;
+      teamName: string;
+      helpChannel: string;
+      helpChannelName: string;
+    }
+  };
+  feedbackUrl: string;
+  tableau?: {
+    appSourceUrl: string;
+    summarySourceUrl: string;
+  };
+  whatsNew: {
+    gistId: string;
+    fileName: string;
+    accessToken?: string;
+  };
+  feature: INetflixFeatures;
+}
+
+export const NetflixSettings: INetflixSettings = <INetflixSettings>SETTINGS;

--- a/app/scripts/modules/netflix/pipeline/stage/acaTask/acaTaskStage.js
+++ b/app/scripts/modules/netflix/pipeline/stage/acaTask/acaTaskStage.js
@@ -2,17 +2,17 @@
 
 import {ACCOUNT_SERVICE} from 'core/account/account.service';
 import {CLOUD_PROVIDER_REGISTRY} from 'core/cloudProvider/cloudProvider.registry';
+import {NetflixSettings} from '../../../netflix.settings';
 
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.netflix.pipeline.stage.acaTaskStage', [
   CLOUD_PROVIDER_REGISTRY,
-  require('core/config/settings.js'),
   require('../canary/canaryExecutionSummary.controller'),
   ACCOUNT_SERVICE,
 ])
-  .config(function (pipelineConfigProvider, settings) {
-    if (settings.feature && settings.feature.netflixMode) {
+  .config(function (pipelineConfigProvider) {
+    if (NetflixSettings.feature.netflixMode) {
       pipelineConfigProvider.registerStage({
         label: 'ACA Task',
         description: 'Runs a canary task against an existing cluster, asg, or query',

--- a/app/scripts/modules/netflix/pipeline/stage/canary/actions/endCanary.controller.js
+++ b/app/scripts/modules/netflix/pipeline/stage/canary/actions/endCanary.controller.js
@@ -2,11 +2,13 @@
 
 let angular = require('angular');
 
+import {SETTINGS} from 'core/config/settings';
+
 module.exports = angular.module('spinnaker.netflix.pipeline.stage.canary.actions.override.result.controller', [
   require('angular-ui-router'),
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ])
-  .controller('EndCanaryCtrl', function ($scope, $http, $uibModalInstance, settings, canaryId) {
+  .controller('EndCanaryCtrl', function ($scope, $http, $uibModalInstance, canaryId) {
 
     $scope.command = {
       reason: null,
@@ -17,7 +19,7 @@ module.exports = angular.module('spinnaker.netflix.pipeline.stage.canary.actions
 
     this.endCanary = function() {
       $scope.state = 'submitting';
-      var targetUrl = [settings.gateUrl, 'canaries', canaryId, 'end'].join('/');
+      var targetUrl = [SETTINGS.gateUrl, 'canaries', canaryId, 'end'].join('/');
       $http.put(targetUrl, $scope.command)
         .success(function() {
           $scope.state = 'success';

--- a/app/scripts/modules/netflix/pipeline/stage/canary/actions/generateScore.controller.js
+++ b/app/scripts/modules/netflix/pipeline/stage/canary/actions/generateScore.controller.js
@@ -2,11 +2,13 @@
 
 let angular = require('angular');
 
+import {SETTINGS} from 'core/config/settings';
+
 module.exports = angular.module('spinnaker.netflix.pipeline.stage.canary.actions.generate.score.controller', [
   require('angular-ui-router'),
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ])
-  .controller('GenerateScoreCtrl', function ($scope, $http, $uibModalInstance, settings, canaryId) {
+  .controller('GenerateScoreCtrl', function ($scope, $http, $uibModalInstance, canaryId) {
 
     $scope.command = {
       duration: null,
@@ -17,7 +19,7 @@ module.exports = angular.module('spinnaker.netflix.pipeline.stage.canary.actions
 
     this.generateCanaryScore = function() {
       $scope.state = 'submitting';
-      var targetUrl = [settings.gateUrl, 'canaries', canaryId, 'generateCanaryResult'].join('/');
+      var targetUrl = [SETTINGS.gateUrl, 'canaries', canaryId, 'generateCanaryResult'].join('/');
       $http.post(targetUrl, $scope.command)
         .success(function() {
           $scope.state = 'success';

--- a/app/scripts/modules/netflix/pipeline/stage/canary/canaryExecutionSummary.controller.js
+++ b/app/scripts/modules/netflix/pipeline/stage/canary/canaryExecutionSummary.controller.js
@@ -9,7 +9,7 @@ module.exports = angular.module('spinnaker.netflix.pipeline.stage.canary.summary
   require('./actions/endCanary.controller.js'),
   require('../../../../core/pipeline/config/pipelineConfigProvider.js')
 ])
-  .controller('CanaryExecutionSummaryCtrl', function ($scope, $http, settings, $uibModal, pipelineConfig) {
+  .controller('CanaryExecutionSummaryCtrl', function ($scope, $http, $uibModal, pipelineConfig) {
 
     this.generateCanaryScore = function() {
       $uibModal.open({

--- a/app/scripts/modules/netflix/pipeline/stage/canary/canaryStage.js
+++ b/app/scripts/modules/netflix/pipeline/stage/canary/canaryStage.js
@@ -7,16 +7,16 @@ import {CLOUD_PROVIDER_REGISTRY} from 'core/cloudProvider/cloudProvider.registry
 import {SERVER_GROUP_COMMAND_BUILDER_SERVICE} from 'core/serverGroup/configure/common/serverGroupCommandBuilder.service';
 import {LIST_EXTRACTOR_SERVICE} from 'core/application/listExtractor/listExtractor.service';
 import {CANARY_SCORE_CONFIG_COMPONENT} from './canaryScore.component';
+import {NetflixSettings} from '../../../netflix.settings';
 
 module.exports = angular.module('spinnaker.netflix.pipeline.stage.canaryStage', [
   LIST_EXTRACTOR_SERVICE,
   CLOUD_PROVIDER_REGISTRY,
   SERVER_GROUP_COMMAND_BUILDER_SERVICE,
   CANARY_SCORE_CONFIG_COMPONENT,
-  require('core/pipeline/config/pipelineConfigProvider'),
-  require('core/config/settings.js'),
+  require('core/pipeline/config/pipelineConfigProvider')
 ])
-  .config(function (pipelineConfigProvider, settings) {
+  .config(function (pipelineConfigProvider) {
 
     function isExpression(value) {
       return isString(value) && value.includes('${');
@@ -31,7 +31,7 @@ module.exports = angular.module('spinnaker.netflix.pipeline.stage.canaryStage', 
       return result;
     }
 
-    if (settings.feature && settings.feature.netflixMode) {
+    if (NetflixSettings.feature.netflixMode) {
 
       pipelineConfigProvider.registerStage({
         label: 'Canary',

--- a/app/scripts/modules/netflix/pipeline/stage/chap/chapExecutionDetails.controller.js
+++ b/app/scripts/modules/netflix/pipeline/stage/chap/chapExecutionDetails.controller.js
@@ -1,23 +1,23 @@
 'use strict';
 
 import {EXECUTION_DETAILS_SECTION_SERVICE} from 'core/delivery/details/executionDetailsSection.service';
+import {NetflixSettings} from '../../../netflix.settings';
 
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.netflix.pipeline.stage.chap.executionDetails.controller', [
   require('angular-ui-router'),
   EXECUTION_DETAILS_SECTION_SERVICE,
-  require('core/delivery/details/executionDetailsSectionNav.directive'),
-  require('core/config/settings'),
+  require('core/delivery/details/executionDetailsSectionNav.directive')
 ])
-  .controller('ChapExecutionDetailsCtrl', function ($scope, $stateParams, executionDetailsSectionService, settings) {
+  .controller('ChapExecutionDetailsCtrl', function ($scope, $stateParams, executionDetailsSectionService) {
 
     $scope.configSections = ['testRunDetails', 'taskStatus'];
 
     let initialized = () => {
       $scope.detailsSection = $stateParams.details;
       $scope.canaryReportUrl = [
-        settings.chap.canaryReportBaseUrl,
+        NetflixSettings.chap.canaryReportBaseUrl,
         $scope.stage.context.run.testCase.properties.account,
         $scope.stage.context.run.testCase.properties.region,
         $scope.stage.context.run.properties.acaConfigId,
@@ -25,19 +25,19 @@ module.exports = angular.module('spinnaker.netflix.pipeline.stage.chap.execution
       ].join('/');
 
       $scope.testCaseUrl = [
-        settings.chap.chapBaseUrl,
+        NetflixSettings.chap.chapBaseUrl,
         'testcases',
         $scope.stage.context.run.testCase.id,
       ].join('/');
 
       $scope.runUrl = [
-        settings.chap.chapBaseUrl,
+        NetflixSettings.chap.chapBaseUrl,
         'runs',
         $scope.stage.context.run.id,
       ].join('/');
 
       $scope.fitScenarioUrl = [
-        settings.chap.fitBaseUrl,
+        NetflixSettings.chap.fitBaseUrl,
         'scenarios',
         $scope.stage.context.run.testCase.properties.scenario,
       ].join('/');

--- a/app/scripts/modules/netflix/pipeline/stage/chap/chapStage.js
+++ b/app/scripts/modules/netflix/pipeline/stage/chap/chapStage.js
@@ -2,17 +2,18 @@
 
 let angular = require('angular');
 
+import {NetflixSettings} from '../../../netflix.settings';
+
 module.exports = angular.module('spinnaker.netflix.pipeline.stage.chap', [
   require('core/pipeline/config/pipelineConfigProvider.js'),
   require('./chapStage.controller'),
-  require('./chapExecutionDetails.controller'),
-  require('core/config/settings.js'),
-]).config(function (pipelineConfigProvider, settings) {
-  if (settings.feature && settings.feature.netflixMode && settings.chap) {
+  require('./chapExecutionDetails.controller')
+]).config(function (pipelineConfigProvider) {
+  if (NetflixSettings.feature.netflixMode && NetflixSettings.chap) {
     pipelineConfigProvider.registerStage({
       label: 'ChAP',
       description: 'Run a ChAP test case',
-      extendedDescription: `<a target="_blank" href="${settings.chap.chapBaseUrl}">
+      extendedDescription: `<a target="_blank" href="${NetflixSettings.chap.chapBaseUrl}">
           <span class="small glyphicon glyphicon-file"></span> Documentation</a>`,
       key: 'chap',
       controller: 'ChapStageCtrl',

--- a/app/scripts/modules/netflix/pipeline/stage/isolatedTestingTarget/isolatedTestingTargetStage.ts
+++ b/app/scripts/modules/netflix/pipeline/stage/isolatedTestingTarget/isolatedTestingTargetStage.ts
@@ -10,6 +10,7 @@ import {SERVER_GROUP_COMMAND_BUILDER_SERVICE} from 'core/serverGroup/configure/c
 import {SERVER_GROUP_READER, ServerGroupReader} from 'core/serverGroup/serverGroupReader.service';
 import {NAMING_SERVICE, NamingService} from 'core/naming/naming.service';
 import {EDIT_VIP_MODAL_CONTROLLER} from './editVip.modal.controller';
+import {NetflixSettings} from '../../../netflix.settings';
 
 interface IVipOverride {
   oldVip: string;
@@ -248,11 +249,10 @@ module(ISOLATED_TESTING_TARGET_STAGE, [
   NAMING_SERVICE,
   CLOUD_PROVIDER_REGISTRY,
   SERVER_GROUP_COMMAND_BUILDER_SERVICE,
-  SERVER_GROUP_READER,
-  require('core/config/settings.js'),
+  SERVER_GROUP_READER
 ])
-  .config((pipelineConfigProvider: any, settings: any) => {
-    if (settings.feature && settings.feature.netflixMode) {
+  .config((pipelineConfigProvider: any) => {
+    if (NetflixSettings.feature.netflixMode) {
       pipelineConfigProvider.registerStage({
         label: 'Isolated Testing Target',
         description: 'Launches a cluster with a unique VIP to allow for testing on an isolated cluster',

--- a/app/scripts/modules/netflix/pipeline/stage/properties/create/propertyStage.js
+++ b/app/scripts/modules/netflix/pipeline/stage/properties/create/propertyStage.js
@@ -5,14 +5,14 @@ let angular = require('angular');
 
 import {AUTHENTICATION_SERVICE} from 'core/authentication/authentication.service';
 import {FAST_PROPERTY_READ_SERVICE} from 'netflix/fastProperties/fastProperty.read.service';
+import {NetflixSettings} from '../../../../netflix.settings';
 
 module.exports = angular.module('spinnaker.netflix.pipeline.stage.propertyStage', [
   AUTHENTICATION_SERVICE,
-  require('core/config/settings.js'),
   FAST_PROPERTY_READ_SERVICE
 ])
-  .config(function (pipelineConfigProvider, settings) {
-    if (settings.feature && settings.feature.netflixMode) {
+  .config(function (pipelineConfigProvider) {
+    if (NetflixSettings.feature.netflixMode) {
       pipelineConfigProvider.registerStage({
         label: 'Persisted Properties',
         description: 'Deploy persisted properties',

--- a/app/scripts/modules/netflix/pipeline/stage/quickPatchAsg/quickPatchAsgStage.js
+++ b/app/scripts/modules/netflix/pipeline/stage/quickPatchAsg/quickPatchAsgStage.js
@@ -4,15 +4,15 @@ let angular = require('angular');
 
 import {CORE_WIDGETS_MODULE} from 'core/widgets';
 import {LIST_EXTRACTOR_SERVICE} from 'core/application/listExtractor/listExtractor.service';
+import {NetflixSettings} from '../../../netflix.settings';
 
 module.exports = angular.module('spinnaker.netflix.pipeline.stage.quickPatchAsgStage', [
   require('core/pipeline/config/pipelineConfigProvider.js'),
   LIST_EXTRACTOR_SERVICE,
-  require('core/config/settings.js'),
   CORE_WIDGETS_MODULE
 ])
-  .config(function(pipelineConfigProvider, settings) {
-    if (settings.feature && settings.feature.netflixMode) {
+  .config(function(pipelineConfigProvider) {
+    if (NetflixSettings.feature.netflixMode) {
       pipelineConfigProvider.registerStage({
         label: 'Quick Patch Server Group',
         description: 'Quick Patches a server group',

--- a/app/scripts/modules/netflix/report/reservationReport.directive.spec.js
+++ b/app/scripts/modules/netflix/report/reservationReport.directive.spec.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import {matchers} from '../../../../../test/helpers/customMatchers';
+import {SETTINGS} from 'core/config/settings';
 
 describe('Directives: reservation report', function () {
 
@@ -11,16 +12,15 @@ describe('Directives: reservation report', function () {
     jasmine.addMatchers(matchers);
   });
 
-  beforeEach(window.inject(function ($rootScope, $compile, reservationReportReader, $httpBackend, settings, accountService, $q) {
+  beforeEach(window.inject(function ($rootScope, $compile, reservationReportReader, $httpBackend, accountService, $q) {
     this.scope = $rootScope.$new();
     this.compile = $compile;
     this.reservationReportReader = reservationReportReader;
     this.$http = $httpBackend;
-    this.settings = settings;
 
     spyOn(accountService, 'challengeDestructiveActions').and.returnValue($q.when(false));
 
-    this.$http.expectGET([this.settings.gateUrl, 'reports', 'reservation', 'v2'].join('/')).respond(200, {
+    this.$http.expectGET([SETTINGS.gateUrl, 'reports', 'reservation', 'v2'].join('/')).respond(200, {
       reservations: [
         { availabilityZone: 'us-east-1a', instanceType: 'm3.medium', os: 'LINUX', region: 'us-east-1',
           accounts: {

--- a/app/scripts/modules/netflix/report/reservationReport.read.service.js
+++ b/app/scripts/modules/netflix/report/reservationReport.read.service.js
@@ -2,14 +2,14 @@
 
 let angular = require('angular');
 
+import {SETTINGS} from 'core/config/settings';
+
 module.exports = angular
-  .module('spinnaker.amazon.instance.report.reservation.read.service', [
-    require('core/config/settings.js'),
-  ])
-  .factory('reservationReportReader', function ($http, settings) {
+  .module('spinnaker.amazon.instance.report.reservation.read.service', [])
+  .factory('reservationReportReader', function ($http) {
 
     function getReservations() {
-      return $http.get([settings.gateUrl, 'reports', 'reservation', 'v2'].join('/'))
+      return $http.get([SETTINGS.gateUrl, 'reports', 'reservation', 'v2'].join('/'))
           .then((response) => response.data);
     }
 

--- a/app/scripts/modules/netflix/serverGroup/networking/elasticIp.controller.js
+++ b/app/scripts/modules/netflix/serverGroup/networking/elasticIp.controller.js
@@ -3,16 +3,17 @@
 let angular = require('angular');
 
 import {TASK_MONITOR_BUILDER} from 'core/task/monitor/taskMonitor.builder';
+import {SETTINGS} from 'core/config/settings';
 
 module.exports = angular.module('spinnaker.aws.serverGroup.details.elasticIp.controller', [
   require('./elasticIp.write.service.js'),
   TASK_MONITOR_BUILDER,
 ])
   .controller('ElasticIpCtrl', function($scope, $uibModalInstance, elasticIpWriter, taskMonitorBuilder,
-                                        application, serverGroup, elasticIp, onTaskComplete, settings) {
+                                        application, serverGroup, elasticIp, onTaskComplete) {
     $scope.serverGroup = serverGroup;
     $scope.elasticIp = elasticIp;
-    $scope.gateUrl = settings.gateUrl;
+    $scope.gateUrl = SETTINGS.gateUrl;
 
     $scope.verification = {};
 

--- a/app/scripts/modules/netflix/serverGroup/wizard/serverGroupCommandConfigurer.service.js
+++ b/app/scripts/modules/netflix/serverGroup/wizard/serverGroupCommandConfigurer.service.js
@@ -5,11 +5,11 @@ const angular = require('angular');
 import {V2_MODAL_WIZARD_SERVICE} from 'core/modal/wizard/v2modalWizard.service';
 import {NAMING_SERVICE} from 'core/naming/naming.service';
 import {SERVER_GROUP_COMMAND_REGISTRY_PROVIDER} from 'core/serverGroup/configure/common/serverGroupCommandRegistry.provider';
+import {NetflixSettings} from '../../netflix.settings';
 
 module.exports = angular
   .module('spinnaker.netflix.serverGroup.configurer.service', [
     NAMING_SERVICE,
-    require('core/config/settings.js'),
     SERVER_GROUP_COMMAND_REGISTRY_PROVIDER,
     V2_MODAL_WIZARD_SERVICE,
   ])
@@ -26,8 +26,8 @@ module.exports = angular
     };
 
   })
-  .run(function(serverGroupCommandRegistry, netflixServerGroupCommandConfigurer, settings) {
-    if (settings.feature && settings.feature.netflixMode) {
+  .run(function(serverGroupCommandRegistry, netflixServerGroupCommandConfigurer) {
+    if (NetflixSettings.feature.netflixMode) {
       serverGroupCommandRegistry.register('aws', netflixServerGroupCommandConfigurer);
     }
   });

--- a/app/scripts/modules/netflix/tableau/application/appTableau.controller.js
+++ b/app/scripts/modules/netflix/tableau/application/appTableau.controller.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import {AUTHENTICATION_SERVICE} from 'core/authentication/authentication.service';
+import {NetflixSettings} from '../../netflix.settings';
 
 let angular = require('angular');
 
@@ -8,14 +9,13 @@ require('./../tableau.less');
 
 module.exports = angular
   .module('spinnaker.netflix.tableau.application.controller', [
-    require('core/config/settings'),
     AUTHENTICATION_SERVICE
   ])
-  .controller('AppTableauCtrl', function ($sce, app, settings, authenticationService) {
+  .controller('AppTableauCtrl', function ($sce, app, authenticationService) {
 
     this.$onInit = () => {
       let [user] = authenticationService.getAuthenticatedUser().name.split('@');
-      let url = settings.tableau.appSourceUrl
+      let url = NetflixSettings.tableau.appSourceUrl
         .replace('${app}', app.name)
         .replace('${user}', user);
       this.srcUrl = $sce.trustAsResourceUrl(url);

--- a/app/scripts/modules/netflix/tableau/summary/summaryTableau.controller.js
+++ b/app/scripts/modules/netflix/tableau/summary/summaryTableau.controller.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import {AUTHENTICATION_SERVICE} from 'core/authentication/authentication.service';
+import {NetflixSettings} from '../../netflix.settings';
 
 let angular = require('angular');
 
@@ -8,13 +9,12 @@ require('./../tableau.less');
 
 module.exports = angular
   .module('spinnaker.netflix.tableau.summary.controller', [
-    require('core/config/settings'),
     AUTHENTICATION_SERVICE
   ])
-  .controller('SummaryTableauCtrl', function ($sce, settings, authenticationService) {
+  .controller('SummaryTableauCtrl', function ($sce, authenticationService) {
     this.$onInit = () => {
       let [user] = authenticationService.getAuthenticatedUser().name.split('@');
-      let url = settings.tableau.summarySourceUrl
+      let url = NetflixSettings.tableau.summarySourceUrl
         .replace('${user}', user);
       this.srcUrl = $sce.trustAsResourceUrl(url);
     };

--- a/app/scripts/modules/netflix/tableau/tableau.dataSource.js
+++ b/app/scripts/modules/netflix/tableau/tableau.dataSource.js
@@ -1,15 +1,15 @@
 import {DataSourceConfig} from 'core/application/service/applicationDataSource';
 import {APPLICATION_DATA_SOURCE_REGISTRY} from 'core/application/service/applicationDataSource.registry';
+import {NetflixSettings} from '../netflix.settings';
 
 let angular = require('angular');
 
 module.exports = angular
   .module('spinnaker.netflix.tableau.dataSource', [
-    require('core/config/settings'),
-    APPLICATION_DATA_SOURCE_REGISTRY,
+    APPLICATION_DATA_SOURCE_REGISTRY
   ])
-  .run(function($q, applicationDataSourceRegistry, settings) {
-    if (settings.feature && settings.feature.tableau) {
+  .run(function($q, applicationDataSourceRegistry) {
+    if (NetflixSettings.feature.tableau) {
       applicationDataSourceRegistry.registerDataSource(new DataSourceConfig({
         key: 'analytics',
         sref: '.analytics',

--- a/app/scripts/modules/netflix/templateOverride/templateOverrides.module.js
+++ b/app/scripts/modules/netflix/templateOverride/templateOverrides.module.js
@@ -3,14 +3,14 @@
 const angular = require('angular');
 
 import {OVERRIDE_REGISTRY} from 'core/overrideRegistry/override.registry';
+import {NetflixSettings} from '../netflix.settings';
 
 module.exports = angular
   .module('spinnaker.netflix.templateOverride.templateOverrides', [
-    OVERRIDE_REGISTRY,
-    require('core/config/settings.js'),
+    OVERRIDE_REGISTRY
   ])
-  .run(function(overrideRegistry, settings) {
-    if (settings.feature && settings.feature.netflixMode) {
+  .run(function(overrideRegistry) {
+    if (NetflixSettings.feature.netflixMode) {
       let templates = [
         { key: 'applicationConfigView', value: require('../application/applicationConfig.html') },
         { key: 'applicationAttributesDirective', value: require('../application/applicationAttributes.directive.html') },

--- a/app/scripts/modules/netflix/whatsNew/whatsNew.read.service.js
+++ b/app/scripts/modules/netflix/whatsNew/whatsNew.read.service.js
@@ -2,17 +2,17 @@
 
 let angular = require('angular');
 
-module.exports = angular.module('spinnaker.netflix.whatsNew.read.service', [
-  require('core/config/settings.js')
-])
-  .factory('whatsNewReader', function ($http, settings, $log) {
+import {NetflixSettings} from '../netflix.settings';
+
+module.exports = angular.module('spinnaker.netflix.whatsNew.read.service', [])
+  .factory('whatsNewReader', function ($http, $log) {
     function extractFileContent(data) {
-      return data.files[settings.whatsNew.fileName].content;
+      return data.files[NetflixSettings.whatsNew.fileName].content;
     }
 
     function getWhatsNewContents() {
-      var gistId = settings.whatsNew.gistId,
-          accessToken = settings.whatsNew.accessToken || null,
+      var gistId = NetflixSettings.whatsNew.gistId,
+          accessToken = NetflixSettings.whatsNew.accessToken || null,
         url = ['https://api.github.com/gists/', gistId].join('');
       if (accessToken) {
         url += '?access_token=' + accessToken;

--- a/app/scripts/modules/netflix/whatsNew/whatsNew.read.service.spec.js
+++ b/app/scripts/modules/netflix/whatsNew/whatsNew.read.service.spec.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import {NetflixSettings} from '../netflix.settings';
+
 describe('Service: whatsNew reader ', function () {
 
   beforeEach(
@@ -8,16 +10,15 @@ describe('Service: whatsNew reader ', function () {
     )
   );
 
-  beforeEach(window.inject(function(whatsNewReader, $httpBackend, settings) {
+  beforeEach(window.inject(function(whatsNewReader, $httpBackend) {
     this.reader = whatsNewReader;
     this.$http = $httpBackend;
-    this.settings = settings;
   }));
 
   describe('getContents', function() {
 
     beforeEach(function() {
-      var gistId = this.settings.whatsNew.gistId;
+      var gistId = NetflixSettings.whatsNew.gistId;
       this.url = ['https://api.github.com/gists/', gistId].join('');
     });
 
@@ -29,7 +30,7 @@ describe('Service: whatsNew reader ', function () {
             files: {},
           };
 
-      response.files[this.settings.whatsNew.fileName] = {
+      response.files[NetflixSettings.whatsNew.fileName] = {
         content: 'expected content',
       };
 

--- a/app/scripts/modules/openstack/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/openstack/instance/details/instance.details.controller.js
@@ -8,6 +8,7 @@ import {CONFIRMATION_MODAL_SERVICE} from 'core/confirmationModal/confirmationMod
 import {INSTANCE_READ_SERVICE} from 'core/instance/instance.read.service';
 import {INSTANCE_WRITE_SERVICE} from 'core/instance/instance.write.service';
 import {RECENT_HISTORY_SERVICE} from 'core/history/recentHistory.service';
+import {SETTINGS} from 'core/config/settings';
 
 module.exports = angular.module('spinnaker.instance.detail.openstack.controller', [
   require('angular-ui-router'),
@@ -18,11 +19,10 @@ module.exports = angular.module('spinnaker.instance.detail.openstack.controller'
   CONFIRMATION_MODAL_SERVICE,
   RECENT_HISTORY_SERVICE,
   require('core/utils/selectOnDblClick.directive.js'),
-  require('core/config/settings.js'),
   CLOUD_PROVIDER_REGISTRY,
   require('core/instance/details/instanceLinks.component'),
 ])
-  .controller('openstackInstanceDetailsCtrl', function ($scope, $state, $uibModal, settings,
+  .controller('openstackInstanceDetailsCtrl', function ($scope, $state, $uibModal,
                                                instanceWriter, confirmationModalService, recentHistoryService,
                                                cloudProviderRegistry, instanceReader, instance, app, $q, overrides) {
 
@@ -32,7 +32,7 @@ module.exports = angular.module('spinnaker.instance.detail.openstack.controller'
     $scope.state = {
       loading: true,
       standalone: app.isStandalone,
-      instancePort: _.get(app, 'attributes.instancePort') || settings.defaultInstancePort || 80,
+      instancePort: _.get(app, 'attributes.instancePort') || SETTINGS.defaultInstancePort || 80,
     };
 
     $scope.application = app;

--- a/app/scripts/modules/openstack/instance/openstackInstanceType.service.js
+++ b/app/scripts/modules/openstack/instance/openstackInstanceType.service.js
@@ -8,10 +8,9 @@ import {INFRASTRUCTURE_CACHE_SERVICE} from 'core/cache/infrastructureCaches.serv
 
 module.exports = angular.module('spinnaker.openstack.instanceType.service', [
   API_SERVICE,
-  require('core/config/settings.js'),
   INFRASTRUCTURE_CACHE_SERVICE
 ])
-  .factory('openstackInstanceTypeService', function ($http, $q, settings, API, infrastructureCaches) {
+  .factory('openstackInstanceTypeService', function ($http, $q, API, infrastructureCaches) {
     var categories = [
       {
         type: 'custom',

--- a/app/scripts/modules/openstack/loadBalancer/configure/wizard/upsert.controller.spec.js
+++ b/app/scripts/modules/openstack/loadBalancer/configure/wizard/upsert.controller.spec.js
@@ -2,6 +2,7 @@
 
 import _ from 'lodash';
 import {APPLICATION_MODEL_BUILDER} from 'core/application/applicationModel.builder';
+import {OpenStackProviderSettings} from '../../../openstack.settings';
 
 describe('Controller: openstackCreateLoadBalancerCtrl', function () {
 
@@ -15,13 +16,12 @@ describe('Controller: openstackCreateLoadBalancerCtrl', function () {
 
   // Initialize the controller and a mock scope
   var testSuite;
-  beforeEach(window.inject(function ($controller, $rootScope, $q, settings, applicationModelBuilder) {
+  beforeEach(window.inject(function ($controller, $rootScope, $q, applicationModelBuilder) {
     testSuite = this;
-    this.settings = settings;
 
     this.loadBalancerDefaults = {
       provider: 'openstack',
-      account: settings.providers.openstack ? settings.providers.openstack.defaults.account : null,
+      account: OpenStackProviderSettings.defaults.account,
       stack: '',
       detail: '',
       subnetId: '',
@@ -341,7 +341,7 @@ describe('Controller: openstackCreateLoadBalancerCtrl', function () {
 
   describe('initialized for edit', function() {
     beforeEach(function() {
-      this.settings.providers.openstack.defaults.account = 'account1';
+      OpenStackProviderSettings.defaults.account = 'account1';
       this.createController(angular.copy(this.testData.loadBalancerList[3]));
     });
 

--- a/app/scripts/modules/openstack/loadBalancer/transformer.js
+++ b/app/scripts/modules/openstack/loadBalancer/transformer.js
@@ -2,13 +2,15 @@
 
 import _ from 'lodash';
 
+import {OpenStackProviderSettings} from '../openstack.settings';
+
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.openstack.loadBalancer.transformer', [])
-  .factory('openstackLoadBalancerTransformer', function ($q, settings) {
+  .factory('openstackLoadBalancerTransformer', function ($q) {
     var defaults = {
       provider: 'openstack',
-      account: settings.providers.openstack ? settings.providers.openstack.defaults.account : null,
+      account: OpenStackProviderSettings.defaults.account,
       stack: '',
       detail: '',
       subnetId: '',

--- a/app/scripts/modules/openstack/openstack.settings.ts
+++ b/app/scripts/modules/openstack/openstack.settings.ts
@@ -1,0 +1,13 @@
+import { IProviderSettings, SETTINGS } from 'core/config/settings';
+
+export interface IOpenStackProviderSettings extends IProviderSettings {
+  defaults: {
+    account: string;
+    region: string;
+  };
+}
+
+export const OpenStackProviderSettings: IOpenStackProviderSettings = <IOpenStackProviderSettings>SETTINGS.providers.openstack;
+if (OpenStackProviderSettings) {
+  OpenStackProviderSettings.resetToOriginal = SETTINGS.resetToOriginal;
+}

--- a/app/scripts/modules/openstack/pipeline/stages/bake/bakeExecutionDetails.controller.js
+++ b/app/scripts/modules/openstack/pipeline/stages/bake/bakeExecutionDetails.controller.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import {EXECUTION_DETAILS_SECTION_SERVICE} from 'core/delivery/details/executionDetailsSection.service';
+import {SETTINGS} from 'core/config/settings';
 
 let angular = require('angular');
 
@@ -10,15 +11,15 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.bake.openstack.ex
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ])
   .controller('openstackBakeExecutionDetailsCtrl', function ($scope, $stateParams, executionDetailsSectionService,
-                                                       $interpolate, settings) {
+                                                       $interpolate) {
 
     $scope.configSections = ['bakeConfig', 'taskStatus'];
 
     let initialized = () => {
       $scope.detailsSection = $stateParams.details;
       $scope.provider = $scope.stage.context.cloudProviderType || 'openstack';
-      $scope.roscoMode = settings.feature.roscoMode;
-      $scope.bakeryDetailUrl = $interpolate(settings.bakeryDetailUrl);
+      $scope.roscoMode = SETTINGS.feature.roscoMode;
+      $scope.bakeryDetailUrl = $interpolate(SETTINGS.bakeryDetailUrl);
     };
 
     let initialize = () => executionDetailsSectionService.synchronizeSection($scope.configSections, initialized);

--- a/app/scripts/modules/openstack/pipeline/stages/bake/openstackBakeStage.js
+++ b/app/scripts/modules/openstack/pipeline/stages/bake/openstackBakeStage.js
@@ -1,7 +1,9 @@
 'use strict';
 
 import _ from 'lodash';
+
 import {BAKERY_SERVICE} from 'core/pipeline/config/stages/bake/bakery.service';
+import {SETTINGS} from 'core/config/settings';
 
 let angular = require('angular');
 
@@ -36,7 +38,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.openstack.bakeSta
       restartable: true,
     });
   })
-  .controller('openstackBakeStageCtrl', function($scope, bakeryService, $q, authenticationService, settings) {
+  .controller('openstackBakeStageCtrl', function($scope, bakeryService, $q, authenticationService) {
 
     $scope.stage.extendedAttributes = $scope.stage.extendedAttributes || {};
     $scope.stage.regions = $scope.stage.regions || [];
@@ -73,7 +75,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.openstack.bakeSta
         if (!$scope.stage.baseOs && $scope.baseOsOptions && $scope.baseOsOptions.length) {
           $scope.stage.baseOs = $scope.baseOsOptions[0].id;
         }
-        $scope.viewState.roscoMode = settings.feature.roscoMode;
+        $scope.viewState.roscoMode = SETTINGS.feature.roscoMode;
         $scope.viewState.loading = false;
       });
     }

--- a/app/scripts/modules/openstack/securityGroup/configure/wizard/upsert.controller.spec.js
+++ b/app/scripts/modules/openstack/securityGroup/configure/wizard/upsert.controller.spec.js
@@ -1,7 +1,7 @@
 import {APPLICATION_MODEL_BUILDER} from 'core/application/applicationModel.builder';
+import {OpenStackProviderSettings} from '../../../openstack.settings';
 
 describe('Controller: openstackCreateSecurityGroupCtrl', function() {
-
   // load the controller's module
   beforeEach(
     window.module(
@@ -10,12 +10,13 @@ describe('Controller: openstackCreateSecurityGroupCtrl', function() {
     )
   );
 
+  afterEach(OpenStackProviderSettings.resetToOriginal);
+
   // Initialize the controller and a mock scope
   var testSuite;
-  beforeEach(window.inject(function ($controller, $rootScope, $q, settings, applicationModelBuilder) {
+  beforeEach(window.inject(function ($controller, $rootScope, $q, applicationModelBuilder) {
     testSuite = this;
-    this.settings = settings;
-    this.settings.providers.openstack.defaults.account = 'account1';
+    OpenStackProviderSettings.defaults.account = 'account1';
 
     this.testData = {
       securityGroupList: [

--- a/app/scripts/modules/openstack/securityGroup/details/details.controller.spec.js
+++ b/app/scripts/modules/openstack/securityGroup/details/details.controller.spec.js
@@ -8,10 +8,7 @@ describe('Controller: openstackSecurityGroupDetailsController', function() {
   );
 
   // Initialize the controller and a mock scope
-  beforeEach(window.inject(function ($controller, $rootScope, $q, settings) {
-    this.settings = settings;
-
-
+  beforeEach(window.inject(function ($controller, $rootScope, $q) {
     this.editSecurityGroup = {
         name: 'example-TestSecurityGroup1',
         region: 'TestRegion1',

--- a/app/scripts/modules/openstack/securityGroup/transformer.js
+++ b/app/scripts/modules/openstack/securityGroup/transformer.js
@@ -2,9 +2,11 @@
 
 let angular = require('angular');
 
+import {OpenStackProviderSettings} from '../openstack.settings';
+
 module.exports = angular.module('spinnaker.openstack.securityGroup.transformer', [
 ])
-  .factory('openstackSecurityGroupTransformer', function (settings, $q) {
+  .factory('openstackSecurityGroupTransformer', function ($q) {
 
     function normalizeSecurityGroup(securityGroup) {
       return $q.when(securityGroup);
@@ -17,7 +19,7 @@ module.exports = angular.module('spinnaker.openstack.securityGroup.transformer',
         stack: '',
         description: '',
         detail: '',
-        account: settings.providers.openstack ? settings.providers.openstack.defaults.account : null,
+        account: OpenStackProviderSettings.defaults.account,
         rules: [],
       };
     }

--- a/app/scripts/modules/openstack/serverGroup/configure/ServerGroupCommandBuilder.js
+++ b/app/scripts/modules/openstack/serverGroup/configure/ServerGroupCommandBuilder.js
@@ -4,16 +4,18 @@ import _ from 'lodash';
 
 let angular = require('angular');
 
+import {OpenStackProviderSettings} from '../../openstack.settings';
+
 module.exports = angular.module('spinnaker.openstack.serverGroupCommandBuilder.service', [
   require('../../image/image.reader.js'),
 ])
-  .factory('openstackServerGroupCommandBuilder', function ($q, openstackImageReader, subnetReader, loadBalancerReader, settings, namingService, applicationReader) {
+  .factory('openstackServerGroupCommandBuilder', function ($q, openstackImageReader, subnetReader, loadBalancerReader, namingService, applicationReader) {
 
     function buildNewServerGroupCommand(application, defaults) {
       defaults = defaults || {};
 
-      var defaultCredentials = defaults.account || application.defaultCredentials.openstack || settings.providers.openstack.defaults.account;
-      var defaultRegion = defaults.region || application.defaultRegions.openstack || settings.providers.openstack.defaults.region;
+      var defaultCredentials = defaults.account || application.defaultCredentials.openstack || OpenStackProviderSettings.defaults.account;
+      var defaultRegion = defaults.region || application.defaultRegions.openstack || OpenStackProviderSettings.defaults.region;
 
       return $q.when({
           selectedProvider: 'openstack',

--- a/app/scripts/modules/openstack/subnet/subnetSelectField.directive.js
+++ b/app/scripts/modules/openstack/subnet/subnetSelectField.directive.js
@@ -6,11 +6,10 @@ import {SUBNET_READ_SERVICE} from 'core/subnet/subnet.read.service';
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.openstack.subnet.subnetSelectField.directive', [
-  require('core/config/settings'),
   SUBNET_READ_SERVICE,
   require('../common/selectField.component.js')
 ])
-  .directive('osSubnetSelectField', function (settings, subnetReader) {
+  .directive('osSubnetSelectField', function (subnetReader) {
     return {
       restrict: 'E',
       templateUrl: require('../common/cacheBackedSelectField.template.html'),

--- a/app/scripts/modules/titus/pipeline/stages/bake/bakeExecutionDetails.controller.js
+++ b/app/scripts/modules/titus/pipeline/stages/bake/bakeExecutionDetails.controller.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import {EXECUTION_DETAILS_SECTION_SERVICE} from 'core/delivery/details/executionDetailsSection.service';
+import {SETTINGS} from 'core/config/settings';
 
 let angular = require('angular');
 
@@ -10,14 +11,14 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.bake.titus.execut
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ])
   .controller('titusBakeExecutionDetailsCtrl', function ($scope, $stateParams, executionDetailsSectionService,
-                                                          $interpolate, settings) {
+                                                          $interpolate) {
 
     $scope.configSections = ['bakeConfig', 'taskStatus'];
 
     let initialized = () => {
       $scope.detailsSection = $stateParams.details;
       $scope.provider = $scope.stage.context.cloudProviderType || 'titus';
-      $scope.bakeryDetailUrl = $interpolate(settings.bakeryDetailUrl);
+      $scope.bakeryDetailUrl = $interpolate(SETTINGS.bakeryDetailUrl);
     };
 
     let initialize = () => executionDetailsSectionService.synchronizeSection($scope.configSections, initialized);

--- a/app/scripts/modules/titus/serverGroup/configure/ServerGroupCommandBuilder.js
+++ b/app/scripts/modules/titus/serverGroup/configure/ServerGroupCommandBuilder.js
@@ -4,20 +4,21 @@ let angular = require('angular');
 
 import {ACCOUNT_SERVICE} from 'core/account/account.service';
 import {NAMING_SERVICE} from 'core/naming/naming.service';
+import {TitusProviderSettings} from '../../titus.settings';
 
 module.exports = angular.module('spinnaker.titus.serverGroupCommandBuilder.service', [
   ACCOUNT_SERVICE,
   NAMING_SERVICE,
 ])
-  .factory('titusServerGroupCommandBuilder', function (settings, $q,
+  .factory('titusServerGroupCommandBuilder', function ($q,
                                                        accountService, namingService) {
     function buildNewServerGroupCommand(application, defaults) {
       defaults = defaults || {};
 
-      var defaultCredentials = defaults.account || settings.providers.titus.defaults.account;
-      var defaultRegion = defaults.region || settings.providers.titus.defaults.region;
-      var defaultZone = defaults.zone || settings.providers.titus.defaults.zone;
-      var defaultIamProfile = settings.providers.titus.defaults.iamProfile || '{{application}}InstanceProfile';
+      var defaultCredentials = defaults.account || TitusProviderSettings.defaults.account;
+      var defaultRegion = defaults.region || TitusProviderSettings.defaults.region;
+      var defaultZone = defaults.zone || TitusProviderSettings.defaults.zone;
+      var defaultIamProfile = TitusProviderSettings.defaults.iamProfile || '{{application}}InstanceProfile';
       defaultIamProfile = defaultIamProfile.replace('{{application}}', application.name);
 
       var command = {

--- a/app/scripts/modules/titus/serverGroup/configure/serverGroupCommandBuilder.spec.js
+++ b/app/scripts/modules/titus/serverGroup/configure/serverGroupCommandBuilder.spec.js
@@ -1,25 +1,27 @@
 'use strict';
 
-describe('titusServerGroupCommandBuilder', function() {
+import {TitusProviderSettings} from '../../titus.settings';
 
+describe('titusServerGroupCommandBuilder', function() {
   beforeEach(
     window.module(
       require('./ServerGroupCommandBuilder.js')
     )
   );
 
-  beforeEach(window.inject(function(titusServerGroupCommandBuilder, namingService, $q, $rootScope, _settings_) {
+  beforeEach(window.inject(function(titusServerGroupCommandBuilder, namingService, $q, $rootScope) {
     this.titusServerGroupCommandBuilder = titusServerGroupCommandBuilder;
     this.$scope = $rootScope;
     this.$q = $q;
-    this.settings = _settings_;
     this.namingService = namingService;
   }));
+
+  afterEach(TitusProviderSettings.resetToOriginal);
 
   describe('buildNewServerGroupCommand', function() {
     it('should initializes to default values', function () {
       var command = null;
-      this.settings.providers.titus.defaults.iamProfile = '{{application}}InstanceProfile';
+      TitusProviderSettings.defaults.iamProfile = '{{application}}InstanceProfile';
       this.titusServerGroupCommandBuilder.buildNewServerGroupCommand({ name: 'titusApp' }).then(function(result) {
         command = result;
       });

--- a/app/scripts/modules/titus/titus.settings.ts
+++ b/app/scripts/modules/titus/titus.settings.ts
@@ -1,0 +1,14 @@
+import { IProviderSettings, SETTINGS } from 'core/config/settings';
+
+export interface ITitusProviderSettings extends IProviderSettings {
+  defaults: {
+    account: string;
+    region: string;
+    iamProfile: string;
+  };
+}
+
+export const TitusProviderSettings: ITitusProviderSettings = <ITitusProviderSettings>SETTINGS.providers.titus;
+if (TitusProviderSettings) {
+  TitusProviderSettings.resetToOriginal = SETTINGS.resetToOriginal;
+}


### PR DESCRIPTION
The global settings were passed around by injecting them with an angular constant. Since we're in the ES6 world, it makes more sense to import them.  `settings` was interleaved throughout much of deck and breaking it out into a standard ES6 module makes general refactoring much easier...
This still wraps the window.spinnakerSettings that the angular one wrapped, but in a much cleaner fashion.

Also in this is providing typings for the settings that I know about, while still satisfying typescript for fields that we do not know about yet. (by using `[key: string]: any` where applicable in `settings.ts`)

There's a lot of changes in here, but it's all mainly the same thing...
* _classes_: remove settings injection, add settings import
* _tests_: remove settings injection, add settings import, setup a default settings fallback for changes from tests.
* There were a few places we were injecting settings when we didn't need to as well, so removed those without replacing with an import.

@anotherchrisberry @zanthrash @icfantv @danielpeach PTAL