### PR TITLE
fix(core/pipeline): handle long cluster names

### DIFF
--- a/app/scripts/modules/core/pipeline/config/stages/deploy/deployStage.html
+++ b/app/scripts/modules/core/pipeline/config/stages/deploy/deployStage.html
@@ -25,7 +25,7 @@
         <td>
           <account-tag account="cluster.account"></account-tag>
         </td>
-        <td>
+        <td style="word-break: break-all;">
           {{ deployStageCtrl.getClusterName(cluster) }}
         </td>
         <td>


### PR DESCRIPTION
* modify the cluster column to not shove everything off the containing
viewport when the cluster name is super long.
