### PR TITLE
fix(travis stage): Tabs should be displayed in execution details

### DIFF
--- a/app/scripts/modules/core/pipeline/config/stages/travis/travisExecutionDetails.html
+++ b/app/scripts/modules/core/pipeline/config/stages/travis/travisExecutionDetails.html
@@ -1,5 +1,5 @@
 <div ng-controller="TravisExecutionDetailsCtrl as ctrl">
-  <execution-details-section-nav sections="configSections"></execution-details-section-nav>
+  <execution-details-section-nav sections="ctrl.configSections"></execution-details-section-nav>
   <div class="step-section-details" ng-if="ctrl.detailsSection === 'travisConfig'">
     <div class="row">
       <div class="col-md-{{ctrl.stage.context.buildInfo.testResults ? 6 : 12}}">


### PR DESCRIPTION
The new Travis stage was missing tabs in the execution details:
<img width="546" alt="skjermbilde 2017-03-28 kl 12 36 53" src="https://cloud.githubusercontent.com/assets/155558/24401188/a2f89268-13b3-11e7-987f-6fd4bf060737.png">

After this fix:
<img width="537" alt="skjermbilde 2017-03-28 kl 12 40 49" src="https://cloud.githubusercontent.com/assets/155558/24401227/ce568ca8-13b3-11e7-88e0-c0aadd72474c.png">
