### PR TITLE
fix(executions): auto-navigate away from missing execution

### DIFF
--- a/app/scripts/modules/core/delivery/executions/executions.controller.js
+++ b/app/scripts/modules/core/delivery/executions/executions.controller.js
@@ -71,6 +71,15 @@ module.exports = angular.module('spinnaker.core.delivery.executions.controller',
     application.executions.activate();
     application.pipelineConfigs.activate();
 
+    application.executions.onRefresh($scope, () => {
+      // if an execution was selected but is no longer present, navigate up
+      if ($state.params.executionId) {
+        if (application.getDataSource('executions').data.every(e => e.id !== $state.params.executionId)) {
+          $state.go('.^');
+        }
+      }
+    });
+
     $q.all([application.executions.ready(), application.pipelineConfigs.ready()]).then(() => {
       this.updateExecutionGroups();
       if ($stateParams.executionId) {


### PR DESCRIPTION
This has always been something of an issue, but it's more apparent now, as we fade out inactive pipelines when another execution has been routed to.