### PR TITLE
refactor(executions): better render accounts, headings in executions

### DIFF
--- a/app/scripts/modules/core/delivery/executionGroup/execution/execution.directive.html
+++ b/app/scripts/modules/core/delivery/executionGroup/execution/execution.directive.html
@@ -1,5 +1,9 @@
 <div class="execution" id="execution-{{::vm.execution.id}}" ng-class="vm.showDetails() ? 'show-details' : 'details-hidden'">
-  <div class="execution-overview">
+  <div class="execution-overview group-by-{{::vm.filter.groupBy}}">
+    <h4 class="execution-name" ng-if="::vm.filter.groupBy !== 'name'">
+      <account-label-color ng-repeat="account in vm.execution.deploymentTargets" account="{{account}}"></account-label-color>
+      {{::vm.execution.name}}
+    </h4>
     <execution-status execution="::vm.execution"
                       toggle-details="::vm.toggleDetails"
                       showing-details="::vm.showDetails"

--- a/app/scripts/modules/core/delivery/executionGroup/execution/execution.directive.js
+++ b/app/scripts/modules/core/delivery/executionGroup/execution/execution.directive.js
@@ -37,6 +37,8 @@ module.exports = angular
 
     this.pipelinesUrl = [SETTINGS.gateUrl, 'pipelines/'].join('/');
 
+    this.filter = ExecutionFilterModel.sortFilter;
+
     this.showDetails = () => {
       return this.standalone === true || ( this.execution.id === $stateParams.executionId &&
         $state.includes('**.execution.**') );
@@ -91,7 +93,6 @@ module.exports = angular
       executionId: this.execution.id,
       canTriggerPipelineManually: this.pipelineConfig,
       canConfigure: this.pipelineConfig,
-      showPipelineName: ExecutionFilterModel.sortFilter.groupBy !== 'name',
       showStageDuration: ExecutionFilterModel.sortFilter.showStageDuration,
     };
 

--- a/app/scripts/modules/core/delivery/executionGroup/execution/execution.less
+++ b/app/scripts/modules/core/delivery/executionGroup/execution/execution.less
@@ -93,7 +93,6 @@ execution-status {
   display: inline-block;
   width: calc(~"100% - 235px");
   vertical-align: top;
-  padding-top: 20px;
   .stages {
     .duration {
       font-weight: 600;

--- a/app/scripts/modules/core/delivery/executionGroup/executionGroup.directive.html
+++ b/app/scripts/modules/core/delivery/executionGroup/executionGroup.directive.html
@@ -13,7 +13,9 @@
             ng-class="{'glyphicon-chevron-right': !vm.viewState.open, 'glyphicon-chevron-down': vm.viewState.open}">
       </span>
       <div class="shadowed">
-        <account-label-color ng-repeat="account in vm.deploymentAccounts" account="{{account}}"></account-label-color>
+        <account-label-color ng-if="vm.viewState.showAccounts"
+                             ng-repeat="account in vm.deploymentAccounts"
+                             account="{{account}}"></account-label-color>
         <h4 class="execution-group-title">
           {{ vm.group.heading }}
           <span ng-if="vm.pipelineConfig.description" class="glyphicon glyphicon-info-sign" uib-tooltip="{{ vm.pipelineConfig.description }}"></span>

--- a/app/scripts/modules/core/delivery/executionGroup/executionGroup.directive.js
+++ b/app/scripts/modules/core/delivery/executionGroup/executionGroup.directive.js
@@ -67,7 +67,7 @@ module.exports = angular
       poll: null,
       canTriggerPipelineManually: this.pipelineConfig,
       canConfigure: this.pipelineConfig || this.strategyConfig,
-      showPipelineName: ExecutionFilterModel.sortFilter.groupBy !== 'name',
+      showAccounts: ExecutionFilterModel.sortFilter.groupBy === 'name',
     };
 
     $scope.$on('$destroy', () => {

--- a/app/scripts/modules/core/delivery/executionGroup/executionGroup.less
+++ b/app/scripts/modules/core/delivery/executionGroup/executionGroup.less
@@ -20,22 +20,7 @@
   .clearfix();
 }
 
-.execution-group-heading {
-  display: flex;
-  padding: 0;
-  margin-top: 3px;
-  color: @default_link_hover;
-  height: 37px;
-  .pipeline-toggle {
-    background-color: @lightest_grey;
-    display: inline-block;
-    padding: 10px 10px 10px 0;
-    height: 36px;
-    flex: 0 0 auto;
-  }
-  a {
-    font-weight: 600;
-  }
+.execution-group-heading, .execution-name {
   .account-tag {
     flex: 0 0 auto;
     padding: 0 15px;
@@ -51,6 +36,33 @@
     &.account-tag-prod {
       background-color: @unhealthy_red;
     }
+  }
+}
+
+.execution-name {
+  .account-tag {
+    height: 20px;
+    line-height: 20px;
+    min-width: 50px;
+    font-size: 14px;
+    padding: 0 10px;
+  }
+}
+.execution-group-heading {
+  display: flex;
+  padding: 0;
+  margin-top: 3px;
+  color: @default_link_hover;
+  height: 37px;
+  .pipeline-toggle {
+    background-color: @lightest_grey;
+    display: inline-block;
+    padding: 10px 10px 10px 0;
+    height: 36px;
+    flex: 0 0 auto;
+  }
+  a {
+    font-weight: 600;
   }
   h4 {
     font-weight: 600;

--- a/app/scripts/modules/core/delivery/executions/executions.less
+++ b/app/scripts/modules/core/delivery/executions/executions.less
@@ -71,6 +71,15 @@ executions {
       padding: 10px;
       background-color: #ffffff;
       border: 1px solid @mid_light_grey;
+      .execution-name {
+        margin-top: 0;
+        font-weight: 600;
+      }
+      &.group-by-name {
+        .execution-bar {
+          padding-top: 20px;
+        }
+      }
     }
   }
 }

--- a/app/scripts/modules/core/delivery/status/executionStatus.html
+++ b/app/scripts/modules/core/delivery/status/executionStatus.html
@@ -1,5 +1,4 @@
 <div class="execution-status-section">
-  <h4 class="execution-name" ng-if="::vm.filter.groupBy !== 'name'">{{::vm.execution.name}}</h4>
   <span class="trigger-type" ng-switch="vm.execution.trigger.type"
         ng-class="::{subheading: vm.filter.groupBy !== 'name'}">
     <h5 class="build-number">

--- a/app/scripts/modules/core/pipeline/config/graph/pipelineGraph.service.ts
+++ b/app/scripts/modules/core/pipeline/config/graph/pipelineGraph.service.ts
@@ -6,7 +6,6 @@ export interface IExecutionViewState {
   executionId: string;
   canTriggerPipelineManually: boolean;
   canConfigure: boolean;
-  showPipelineName: boolean;
   showStageDuration: boolean;
   section: string;
   stageIndex: number;


### PR DESCRIPTION
* Don't show account targets in the header unless it's grouped by pipeline
* Do show account targets in pipeline name header when not grouped by pipeline
* Remove unused `showPipelineName` field