### PR TITLE
fix(netflix) prevent blesk from pushing down other content

### DIFF
--- a/app/scripts/modules/core/presentation/main.less
+++ b/app/scripts/modules/core/presentation/main.less
@@ -1179,7 +1179,7 @@ body, html {
     min-height: 40px;
   }
   .spinnaker-content {
-    height: calc(~"100% - 40px");
+    flex: 1 1;
     .page-header {
       margin: 0;
       border-bottom: none;

--- a/app/scripts/modules/netflix/blesk/blesk.less
+++ b/app/scripts/modules/netflix/blesk/blesk.less
@@ -1,0 +1,20 @@
+@import "~core/presentation/less/imports/colors.less";
+
+.blesk-wrapper {
+  background-color: @pod_header_blue;
+  #blesk {
+    flex: 0 0 auto;
+    padding: 0;
+    .bleskOuter {
+      z-index: 10;
+      border-radius: 0;
+      margin-bottom: -10px;
+    }
+    .blesk-ui-info {
+      background-color: @lightest_grey;
+      border-color: @spinnaker-link-color;
+      color: @spinnaker-link-color;
+    }
+  }
+
+}

--- a/app/scripts/modules/netflix/blesk/blesk.module.ts
+++ b/app/scripts/modules/netflix/blesk/blesk.module.ts
@@ -1,12 +1,12 @@
 import {ITimeoutService, element, module} from 'angular';
 import {NetflixSettings} from '../netflix.settings';
 
-require('./bleskOverrides.css');
+require('./blesk.less');
 
 class BleskService {
 
   private static BLESK_DIV =
-    '<div id="blesk" class="container" data-appid="spinnaker" style="flex: 0 0 auto; padding: 0;"></div>';
+    '<div class="blesk-wrapper"><div id="blesk" class="container" data-appid="spinnaker"></div></div>';
   private static BLESK_SCRIPT =
     '<script async src="https://blesk.prod.netflix.net/static/js/blesk.js"></script>';
 

--- a/app/scripts/modules/netflix/blesk/bleskOverrides.css
+++ b/app/scripts/modules/netflix/blesk/bleskOverrides.css
@@ -1,1 +1,0 @@
-#blesk .bleskOuter { z-index: 10; }


### PR DESCRIPTION
Turns out fixing the height of the content wasn't a great idea.

Also cleaning up look/feel for blesk notifications to make them look okay in Spinnaker.