### PR TITLE
fix(ui): fix scroll on pipeline config

### DIFF
--- a/app/scripts/modules/core/presentation/main.less
+++ b/app/scripts/modules/core/presentation/main.less
@@ -1179,7 +1179,10 @@ body, html {
     min-height: 40px;
   }
   .spinnaker-content {
-    flex: 1 1;
+    height: calc(~"100% - 40px");
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
     .page-header {
       margin: 0;
       border-bottom: none;

--- a/app/scripts/modules/core/utils/stickyHeader/stickyHeader.directive.ts
+++ b/app/scripts/modules/core/utils/stickyHeader/stickyHeader.directive.ts
@@ -42,10 +42,6 @@ export class StickyHeaderController implements ng.IComponentController {
       return;
     }
 
-    if (!this.notifyOnly) {
-      this.$scrollableContainer.css({position: 'relative'});
-    }
-
     this.addedOffsetHeight = this.$attrs.addedOffsetHeight ? parseInt(this.$attrs.addedOffsetHeight, 10) : 0;
 
     // fun thing about modals is they use a CSS transform, which resets position: fixed element placement -

--- a/app/scripts/modules/netflix/blesk/blesk.less
+++ b/app/scripts/modules/netflix/blesk/blesk.less
@@ -2,6 +2,7 @@
 
 .blesk-wrapper {
   background-color: @pod_header_blue;
+  flex: 0 0;
   #blesk {
     flex: 0 0 auto;
     padding: 0;

--- a/app/scripts/modules/netflix/blesk/blesk.module.ts
+++ b/app/scripts/modules/netflix/blesk/blesk.module.ts
@@ -11,8 +11,8 @@ class BleskService {
     '<script async src="https://blesk.prod.netflix.net/static/js/blesk.js"></script>';
 
   public initialize(): void {
-    if (element('.spinnaker-header').length && !element('#blesk').length) {
-      element('.spinnaker-header').after(BleskService.BLESK_DIV);
+    if (element('.spinnaker-content').length && !element('#blesk').length) {
+      element('.spinnaker-content').prepend(BleskService.BLESK_DIV);
       element('body').append(BleskService.BLESK_SCRIPT);
     }
   }

--- a/app/scripts/modules/netflix/fastProperties/dataNav/fpRollout.less
+++ b/app/scripts/modules/netflix/fastProperties/dataNav/fpRollout.less
@@ -7,4 +7,9 @@
       display: none;
     }
   }
+  .execution-group-heading {
+    .execution-group-actions {
+      display: none;
+    }
+  }
 }


### PR DESCRIPTION
This is definitely the last set of bug fixes for the UI refresh.
* fixed an issue where the pipeline config screen was not scrollable
* removed the `position: relative` on the sticky headers container, since it doesn't seem to be doing anything except cutting off the tooltips on very long instance IDs in the clusters view