### PR TITLE
fix(pipelines) better handle execution details on small screen

### DIFF
--- a/app/scripts/modules/core/delivery/details/executionDetails.less
+++ b/app/scripts/modules/core/delivery/details/executionDetails.less
@@ -19,7 +19,7 @@ execution {
       align-items: stretch;
       flex-wrap: wrap;
       .stage-summary, .stage-details {
-        flex: 0 0 50%;
+        flex: 1 0 50%;
         min-width: 400px;
       }
       .stage-details {

--- a/app/scripts/modules/core/presentation/main.less
+++ b/app/scripts/modules/core/presentation/main.less
@@ -284,7 +284,6 @@ html {
   }
   .full-content {
     margin: 0 25px;
-    transition: width 0.25s linear;
     flex-direction: column;
     width: 100%;
     @media (max-width:768px) {

--- a/app/scripts/modules/core/utils/stickyHeader/stickyHeader.directive.ts
+++ b/app/scripts/modules/core/utils/stickyHeader/stickyHeader.directive.ts
@@ -35,7 +35,7 @@ export class StickyHeaderController implements ng.IComponentController {
     this.$scrollableContainer = this.$element.closest('[sticky-headers]');
     this.isSticky = false;
     this.notifyOnly = this.$attrs.notifyOnly === 'true';
-    this.positionHeader = throttle(this.positionHeader, 50);
+    this.positionHeader = throttle(this.positionHeader, 50, {trailing: true});
 
     if (!this.$scrollableContainer.length) {
       this.$log.warn('No parent container with attribute "sticky-header"; headers will not stick.');


### PR DESCRIPTION
If there's less than 800px for the execution details, fills the entire width of the details panel.

Also, better handle sticky headers on window resize or hiding of filters.