### PR TITLE
feat(pipelines): show accounts from config if no executions found

### DIFF
--- a/app/scripts/modules/amazon/pipeline/stages/destroyAsg/awsDestroyAsgStage.js
+++ b/app/scripts/modules/amazon/pipeline/stages/destroyAsg/awsDestroyAsgStage.js
@@ -12,6 +12,8 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.aws.destroyAsgSta
       templateUrl: require('./destroyAsgStage.html'),
       executionDetailsUrl: require('core/pipeline/config/stages/destroyAsg/templates/destroyAsgExecutionDetails.template.html'),
       executionStepLabelUrl: require('./destroyAsgStepLabel.html'),
+      accountExtractor: (stage) => [stage.context.credentials],
+      configAccountExtractor: (stage) => [stage.credentials],
       validators: [
         {
           type: 'targetImpedance',

--- a/app/scripts/modules/amazon/pipeline/stages/resizeAsg/awsResizeAsgStage.js
+++ b/app/scripts/modules/amazon/pipeline/stages/resizeAsg/awsResizeAsgStage.js
@@ -16,6 +16,8 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.aws.resizeAsgStag
       templateUrl: require('./resizeAsgStage.html'),
       executionDetailsUrl: require('./resizeAsgExecutionDetails.html'),
       executionStepLabelUrl: require('./resizeAsgStepLabel.html'),
+      accountExtractor: (stage) => [stage.context.credentials],
+      configAccountExtractor: (stage) => [stage.credentials],
       validators: [
         {
           type: 'targetImpedance',

--- a/app/scripts/modules/amazon/pipeline/stages/scaleDownCluster/awsScaleDownClusterStage.js
+++ b/app/scripts/modules/amazon/pipeline/stages/scaleDownCluster/awsScaleDownClusterStage.js
@@ -11,6 +11,8 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.aws.scaleDownClus
       cloudProvider: 'aws',
       templateUrl: require('./scaleDownClusterStage.html'),
       executionDetailsUrl: require('./scaleDownClusterExecutionDetails.html'),
+      accountExtractor: (stage) => [stage.context.credentials],
+      configAccountExtractor: (stage) => [stage.credentials],
       validators: [
         { type: 'requiredField', fieldName: 'cluster' },
         { type: 'requiredField', fieldName: 'remainingFullSizeServerGroups', fieldLabel: 'Keep [X] full size Server Groups'},

--- a/app/scripts/modules/amazon/pipeline/stages/shrinkCluster/awsShrinkClusterStage.js
+++ b/app/scripts/modules/amazon/pipeline/stages/shrinkCluster/awsShrinkClusterStage.js
@@ -11,7 +11,8 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.aws.shrinkCluster
       cloudProvider: 'aws',
       templateUrl: require('./shrinkClusterStage.html'),
       executionDetailsUrl: require('core/pipeline/config/stages/shrinkCluster/templates/shrinkClusterExecutionDetails.template.html'),
-      accountExtractor: (stage) => stage.context.credentials,
+      accountExtractor: (stage) => [stage.context.credentials],
+      configAccountExtractor: (stage) => [stage.credentials],
       validators: [
         { type: 'requiredField', fieldName: 'cluster' },
         { type: 'requiredField', fieldName: 'shrinkToSize', fieldLabel: 'shrink to [X] Server Groups'},

--- a/app/scripts/modules/azure/pipeline/stages/destroyAsg/azureDestroyAsgStage.js
+++ b/app/scripts/modules/azure/pipeline/stages/destroyAsg/azureDestroyAsgStage.js
@@ -13,6 +13,8 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.azure.destroyAsgS
       templateUrl: require('./destroyAsgStage.html'),
       executionDetailsUrl: require('core/pipeline/config/stages/destroyAsg/templates/destroyAsgExecutionDetails.template.html'),
       executionStepLabelUrl: require('./destroyAsgStepLabel.html'),
+      accountExtractor: (stage) => [stage.context.credentials],
+      configAccountExtractor: (stage) => [stage.credentials],
       validators: [
         {
           type: 'targetImpedance',

--- a/app/scripts/modules/cloudfoundry/pipeline/stages/destroyAsg/cfDestroyAsgStage.js
+++ b/app/scripts/modules/cloudfoundry/pipeline/stages/destroyAsg/cfDestroyAsgStage.js
@@ -13,6 +13,8 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.cf.destroyAsgStag
       templateUrl: require('./destroyAsgStage.html'),
       executionDetailsUrl: require('core/pipeline/config/stages/destroyAsg/templates/destroyAsgExecutionDetails.template.html'),
       executionStepLabelUrl: require('./destroyAsgStepLabel.html'),
+      accountExtractor: (stage) => [stage.context.credentials],
+      configAccountExtractor: (stage) => [stage.credentials],
       validators: [
         {
           type: 'targetImpedance',

--- a/app/scripts/modules/cloudfoundry/pipeline/stages/scaleDownCluster/cfScaleDownClusterStage.js
+++ b/app/scripts/modules/cloudfoundry/pipeline/stages/scaleDownCluster/cfScaleDownClusterStage.js
@@ -13,6 +13,8 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.cf.scaleDownClust
       cloudProvider: 'cf',
       templateUrl: require('./scaleDownClusterStage.html'),
       executionDetailsUrl: require('./scaleDownClusterExecutionDetails.html'),
+      accountExtractor: (stage) => [stage.context.credentials],
+      configAccountExtractor: (stage) => [stage.credentials],
       validators: [
         { type: 'requiredField', fieldName: 'cluster' },
         { type: 'requiredField', fieldName: 'remainingFullSizeServerGroups', fieldLabel: 'Keep [X] full size Server Groups'},

--- a/app/scripts/modules/cloudfoundry/pipeline/stages/shrinkCluster/cfShrinkClusterStage.js
+++ b/app/scripts/modules/cloudfoundry/pipeline/stages/shrinkCluster/cfShrinkClusterStage.js
@@ -10,6 +10,8 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.cf.shrinkClusterS
       cloudProvider: 'cf',
       templateUrl: require('./shrinkClusterStage.html'),
       executionDetailsUrl: require('core/pipeline/config/stages/shrinkCluster/templates/shrinkClusterExecutionDetails.template.html'),
+      accountExtractor: (stage) => [stage.context.credentials],
+      configAccountExtractor: (stage) => [stage.credentials],
       validators: [
         { type: 'requiredField', fieldName: 'cluster' },
         { type: 'requiredField', fieldName: 'shrinkToSize', fieldLabel: 'shrink to [X] Server Groups'},

--- a/app/scripts/modules/core/delivery/executionGroup/executionGroup.directive.html
+++ b/app/scripts/modules/core/delivery/executionGroup/executionGroup.directive.html
@@ -16,6 +16,8 @@
         <account-label-color ng-if="vm.viewState.showAccounts"
                              ng-repeat="account in vm.deploymentAccounts"
                              account="{{account}}"></account-label-color>
+        <account-label-color ng-repeat="account in vm.group.targetAccounts"
+                             account="{{account}}"></account-label-color>
         <h4 class="execution-group-title">
           {{ vm.group.heading }}
           <span ng-if="vm.pipelineConfig.description" class="glyphicon glyphicon-info-sign" uib-tooltip="{{ vm.pipelineConfig.description }}"></span>

--- a/app/scripts/modules/core/delivery/status/executionStatus.html
+++ b/app/scripts/modules/core/delivery/status/executionStatus.html
@@ -44,7 +44,7 @@
         {{ ::vm.execution.startTime | relativeTime }}
       </li>
     </span>
-    <li ng-repeat="parameter in ::vm.parameters">
+    <li class="break-word" ng-repeat="parameter in ::vm.parameters">
       {{::parameter.key}}: {{::parameter.value}}
     </li>
   </ul>

--- a/app/scripts/modules/core/pipeline/config/stages/deploy/deployStage.js
+++ b/app/scripts/modules/core/pipeline/config/stages/deploy/deployStage.js
@@ -37,6 +37,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.deployStage', [
         },
       ],
       accountExtractor: (stage) => (stage.context.clusters || []).map(c => c.account),
+      configAccountExtractor: (stage) => (stage.clusters || []).map(c => c.account),
       strategy: true,
     });
   })

--- a/app/scripts/modules/google/pipeline/stages/destroyAsg/gceDestroyAsgStage.js
+++ b/app/scripts/modules/google/pipeline/stages/destroyAsg/gceDestroyAsgStage.js
@@ -11,6 +11,8 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.gce.destroyAsgSta
       templateUrl: require('./destroyAsgStage.html'),
       executionDetailsUrl: require('core/pipeline/config/stages/destroyAsg/templates/destroyAsgExecutionDetails.template.html'),
       executionStepLabelUrl: require('./destroyAsgStepLabel.html'),
+      accountExtractor: (stage) => [stage.context.credentials],
+      configAccountExtractor: (stage) => [stage.credentials],
       validators: [
         {
           type: 'targetImpedance',

--- a/app/scripts/modules/google/pipeline/stages/resizeAsg/gceResizeAsgStage.js
+++ b/app/scripts/modules/google/pipeline/stages/resizeAsg/gceResizeAsgStage.js
@@ -17,6 +17,8 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.gce.resizeAsgStag
       templateUrl: require('./resizeAsgStage.html'),
       executionDetailsUrl: require('./resizeAsgExecutionDetails.html'),
       executionStepLabelUrl: require('./resizeAsgStepLabel.html'),
+      accountExtractor: (stage) => [stage.context.credentials],
+      configAccountExtractor: (stage) => [stage.credentials],
       validators: [
         {
           type: 'targetImpedance',

--- a/app/scripts/modules/google/pipeline/stages/scaleDownCluster/gceScaleDownClusterStage.js
+++ b/app/scripts/modules/google/pipeline/stages/scaleDownCluster/gceScaleDownClusterStage.js
@@ -13,6 +13,8 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.gce.scaleDownClus
       cloudProvider: 'gce',
       templateUrl: require('./scaleDownClusterStage.html'),
       executionDetailsUrl: require('./scaleDownClusterExecutionDetails.html'),
+      accountExtractor: (stage) => [stage.context.credentials],
+      configAccountExtractor: (stage) => [stage.credentials],
       validators: [
         { type: 'requiredField', fieldName: 'cluster' },
         { type: 'requiredField', fieldName: 'remainingFullSizeServerGroups', fieldLabel: 'Keep [X] full size Server Groups'},

--- a/app/scripts/modules/google/pipeline/stages/shrinkCluster/gceShrinkClusterStage.js
+++ b/app/scripts/modules/google/pipeline/stages/shrinkCluster/gceShrinkClusterStage.js
@@ -12,6 +12,8 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.gce.shrinkCluster
       cloudProvider: 'gce',
       templateUrl: require('./shrinkClusterStage.html'),
       executionDetailsUrl: require('core/pipeline/config/stages/shrinkCluster/templates/shrinkClusterExecutionDetails.template.html'),
+      accountExtractor: (stage) => [stage.context.credentials],
+      configAccountExtractor: (stage) => [stage.credentials],
       validators: [
         { type: 'requiredField', fieldName: 'cluster' },
         { type: 'requiredField', fieldName: 'shrinkToSize', fieldLabel: 'shrink to [X] Server Groups'},

--- a/app/scripts/modules/kubernetes/pipeline/stages/destroyAsg/kubernetesDestroyAsgStage.js
+++ b/app/scripts/modules/kubernetes/pipeline/stages/destroyAsg/kubernetesDestroyAsgStage.js
@@ -11,6 +11,8 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.kubernetes.destro
       templateUrl: require('./destroyAsgStage.html'),
       executionDetailsUrl: require('./destroyAsgExecutionDetails.html'),
       executionStepLabelUrl: require('./destroyAsgStepLabel.html'),
+      accountExtractor: (stage) => [stage.context.credentials],
+      configAccountExtractor: (stage) => [stage.credentials],
       validators: [
         {
           type: 'targetImpedance',

--- a/app/scripts/modules/kubernetes/pipeline/stages/shrinkCluster/shrinkClusterStage.js
+++ b/app/scripts/modules/kubernetes/pipeline/stages/shrinkCluster/shrinkClusterStage.js
@@ -13,6 +13,8 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.kubernetes.shrink
       cloudProvider: 'kubernetes',
       templateUrl: require('./shrinkClusterStage.html'),
       executionDetailsUrl: require('./shrinkClusterExecutionDetails.html'),
+      accountExtractor: (stage) => [stage.context.credentials],
+      configAccountExtractor: (stage) => [stage.credentials],
       validators: [
         { type: 'requiredField', fieldName: 'cluster' },
         { type: 'requiredField', fieldName: 'shrinkToSize', fieldLabel: 'shrink to [X] Server Groups'},

--- a/app/scripts/modules/netflix/pipeline/stage/canary/canaryStage.js
+++ b/app/scripts/modules/netflix/pipeline/stage/canary/canaryStage.js
@@ -46,6 +46,7 @@ module.exports = angular.module('spinnaker.netflix.pipeline.stage.canaryStage', 
         controller: 'CanaryStageCtrl',
         controllerAs: 'canaryStageCtrl',
         accountExtractor: (stage) => (stage.context.clusterPairs || []).map(c => c.baseline.account),
+        configAccountExtractor: (stage) => (stage.clusterPairs || []).map(c => c.baseline.account),
         validators: [
           {
             type: 'stageBeforeType',

--- a/app/scripts/modules/openstack/pipeline/stages/destroyAsg/openstackDestroyAsgStage.js
+++ b/app/scripts/modules/openstack/pipeline/stages/destroyAsg/openstackDestroyAsgStage.js
@@ -11,6 +11,8 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.openstack.destroy
       templateUrl: require('./destroyAsgStage.html'),
       executionDetailsUrl: require('core/pipeline/config/stages/destroyAsg/templates/destroyAsgExecutionDetails.template.html'),
       executionStepLabelUrl: require('./destroyAsgStepLabel.html'),
+      accountExtractor: (stage) => [stage.context.credentials],
+      configAccountExtractor: (stage) => [stage.credentials],
       validators: [
         {
           type: 'targetImpedance',

--- a/app/scripts/modules/openstack/pipeline/stages/resizeAsg/openstackResizeAsgStage.js
+++ b/app/scripts/modules/openstack/pipeline/stages/resizeAsg/openstackResizeAsgStage.js
@@ -16,6 +16,8 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.openstack.resizeA
       templateUrl: require('./resizeAsgStage.html'),
       executionDetailsUrl: require('./resizeAsgExecutionDetails.html'),
       executionStepLabelUrl: require('./resizeAsgStepLabel.html'),
+      accountExtractor: (stage) => [stage.context.credentials],
+      configAccountExtractor: (stage) => [stage.credentials],
       validators: [
         {
           type: 'targetImpedance',

--- a/app/scripts/modules/openstack/pipeline/stages/scaleDownCluster/openstackScaleDownClusterStage.js
+++ b/app/scripts/modules/openstack/pipeline/stages/scaleDownCluster/openstackScaleDownClusterStage.js
@@ -11,6 +11,8 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.openstack.scaleDo
       cloudProvider: 'openstack',
       templateUrl: require('./scaleDownClusterStage.html'),
       executionDetailsUrl: require('./scaleDownClusterExecutionDetails.html'),
+      accountExtractor: (stage) => [stage.context.credentials],
+      configAccountExtractor: (stage) => [stage.credentials],
       validators: [
         { type: 'requiredField', fieldName: 'cluster' },
         { type: 'requiredField', fieldName: 'remainingFullSizeServerGroups', fieldLabel: 'Keep [X] full size Server Groups'},

--- a/app/scripts/modules/openstack/pipeline/stages/shrinkCluster/openstackShrinkClusterStage.js
+++ b/app/scripts/modules/openstack/pipeline/stages/shrinkCluster/openstackShrinkClusterStage.js
@@ -11,6 +11,8 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.openstack.shrinkC
       cloudProvider: 'openstack',
       templateUrl: require('./shrinkClusterStage.html'),
       executionDetailsUrl: require('core/pipeline/config/stages/shrinkCluster/templates/shrinkClusterExecutionDetails.template.html'),
+      accountExtractor: (stage) => [stage.context.credentials],
+      configAccountExtractor: (stage) => [stage.credentials],
       validators: [
         { type: 'requiredField', fieldName: 'cluster' },
         { type: 'requiredField', fieldName: 'shrinkToSize', fieldLabel: 'shrink to [X] Server Groups'},

--- a/app/scripts/modules/titus/pipeline/stages/destroyAsg/titusDestroyAsgStage.js
+++ b/app/scripts/modules/titus/pipeline/stages/destroyAsg/titusDestroyAsgStage.js
@@ -13,6 +13,8 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.titus.destroyAsgS
       templateUrl: require('./destroyAsgStage.html'),
       executionDetailsUrl: require('core/pipeline/config/stages/destroyAsg/templates/destroyAsgExecutionDetails.template.html'),
       executionStepLabelUrl: require('./destroyAsgStepLabel.html'),
+      accountExtractor: (stage) => [stage.context.credentials],
+      configAccountExtractor: (stage) => [stage.credentials],
       validators: [
         {
           type: 'targetImpedance',

--- a/app/scripts/modules/titus/pipeline/stages/resizeAsg/titusResizeAsgStage.js
+++ b/app/scripts/modules/titus/pipeline/stages/resizeAsg/titusResizeAsgStage.js
@@ -16,6 +16,8 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.titus.resizeAsgSt
       templateUrl: require('./resizeAsgStage.html'),
       executionDetailsUrl: require('./resizeAsgExecutionDetails.html'),
       executionStepLabelUrl: require('./resizeAsgStepLabel.html'),
+      accountExtractor: (stage) => [stage.context.credentials],
+      configAccountExtractor: (stage) => [stage.credentials],
       validators: [
         {
           type: 'targetImpedance',

--- a/app/scripts/modules/titus/pipeline/stages/scaleDownCluster/titusScaleDownClusterStage.js
+++ b/app/scripts/modules/titus/pipeline/stages/scaleDownCluster/titusScaleDownClusterStage.js
@@ -11,6 +11,8 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.titus.scaleDownCl
       cloudProvider: 'titus',
       templateUrl: require('./scaleDownClusterStage.html'),
       executionDetailsUrl: require('./scaleDownClusterExecutionDetails.html'),
+      accountExtractor: (stage) => [stage.context.credentials],
+      configAccountExtractor: (stage) => [stage.credentials],
       validators: [
         { type: 'requiredField', fieldName: 'cluster' },
         { type: 'requiredField', fieldName: 'remainingFullSizeServerGroups', fieldLabel: 'Keep [X] full size Server Groups'},

--- a/app/scripts/modules/titus/pipeline/stages/shrinkCluster/titusShrinkClusterStage.js
+++ b/app/scripts/modules/titus/pipeline/stages/shrinkCluster/titusShrinkClusterStage.js
@@ -11,6 +11,8 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.titus.shrinkClust
       cloudProvider: 'titus',
       templateUrl: require('./shrinkClusterStage.html'),
       executionDetailsUrl: require('core/pipeline/config/stages/shrinkCluster/templates/shrinkClusterExecutionDetails.template.html'),
+      accountExtractor: (stage) => [stage.context.credentials],
+      configAccountExtractor: (stage) => [stage.credentials],
       validators: [
         { type: 'requiredField', fieldName: 'cluster' },
         { type: 'requiredField', fieldName: 'shrinkToSize', fieldLabel: 'shrink to [X] Server Groups'},


### PR DESCRIPTION
If a pipeline has never run, there are no executions from which to extract account info. We can still pull that data from the config.