### PR TITLE
fix(travis stage): Travis trigger component not working properly

### DIFF
--- a/app/scripts/modules/core/pipeline/config/triggers/travis/selectorTemplate.html
+++ b/app/scripts/modules/core/pipeline/config/triggers/travis/selectorTemplate.html
@@ -1,0 +1,1 @@
+<travis-trigger-options command="vm.command"></travis-trigger-options>

--- a/app/scripts/modules/core/pipeline/config/triggers/travis/travisTrigger.module.ts
+++ b/app/scripts/modules/core/pipeline/config/triggers/travis/travisTrigger.module.ts
@@ -121,6 +121,6 @@ module(TRAVIS_TRIGGER, [
     formatLabel: (trigger: IBuildTrigger) => {
       return $q.when(`(Travis) ${trigger.master}: ${trigger.job}`);
     },
-    selectorTemplate: '<travis-trigger-options command="vm.command"></travis-trigger-options>',
+    selectorTemplate: require('./selectorTemplate.html'),
   };
 }).controller('TravisTriggerCtrl', TravisTrigger);

--- a/app/scripts/modules/core/pipeline/config/triggers/travis/travisTriggerOptions.component.spec.ts
+++ b/app/scripts/modules/core/pipeline/config/triggers/travis/travisTriggerOptions.component.spec.ts
@@ -3,7 +3,7 @@ import {mock, IScope, IQProvider, IQService, IControllerService, IRootScopeServi
 import {IgorService} from 'core/ci/igor.service';
 import {IBuild} from 'core/domain/IBuild';
 import {IBuildTrigger} from 'core/domain/ITrigger';
-import {TRAVIS_TRIGGER_OPTIONS_COMPONENT, TravisTriggerOptions} from './travisTriggerOptions.component';
+import {TRAVIS_TRIGGER_OPTIONS_COMPONENT, TravisTriggerOptionsController} from './travisTriggerOptions.component';
 
 interface ICommand {
   trigger: IBuildTrigger;
@@ -42,7 +42,7 @@ describe('Travis Trigger: TravisTriggerOptionsCtrl', () => {
   }));
 
   const initialize = () => {
-    return $ctrl(TravisTriggerOptions, {
+    return $ctrl(TravisTriggerOptionsController, {
       igorService: igorService,
       $scope: $scope,
     }, {command: command});

--- a/app/scripts/modules/core/pipeline/config/triggers/travis/travisTriggerOptions.component.ts
+++ b/app/scripts/modules/core/pipeline/config/triggers/travis/travisTriggerOptions.component.ts
@@ -1,4 +1,4 @@
-import {module, IScope} from 'angular';
+import {module, IScope, IComponentOptions} from 'angular';
 
 import {IGOR_SERVICE, IgorService} from 'core/ci/igor.service';
 import {IBuild} from 'core/domain/IBuild';
@@ -9,7 +9,7 @@ interface IViewState {
   selectedBuild: IBuild;
 }
 
-export class TravisTriggerOptions {
+export class TravisTriggerOptionsController {
   public viewState: IViewState;
   public command: any;
   public builds: IBuild[];
@@ -65,17 +65,16 @@ export class TravisTriggerOptions {
   };
 }
 
+class TravisTriggerOptionsComponent implements IComponentOptions {
+  public bindings: any = {
+    command: '='
+  };
+  public templateUrl = require('./travisTriggerOptions.component.html');
+  public controller: any = TravisTriggerOptionsController;
+}
+
 export const TRAVIS_TRIGGER_OPTIONS_COMPONENT = 'spinnaker.core.pipeline.config.triggers.travis.options.component';
+
 module(TRAVIS_TRIGGER_OPTIONS_COMPONENT, [
   IGOR_SERVICE
-]).component('travisTriggerOptions', () => {
-  return {
-    restrict: 'E',
-    templateUrl: require('./travisTriggerOptions.component.html'),
-    bindToController: {
-      command: '=',
-    },
-    controller: 'TravisTriggerOptionsCtrl',
-    scope: {}
-  };
-}).controller('TravisTriggerOptionsCtrl', TravisTriggerOptions);
+]).component('travisTriggerOptions', new TravisTriggerOptionsComponent());


### PR DESCRIPTION
Fixed by properly converting the 'travis-trigger-options' directive into a component in a more "typescripty" way and replacing `bindToController` with `bindings`.

<img width="607" alt="skjermbilde 2017-03-30 kl 15 39 51" src="https://cloud.githubusercontent.com/assets/155558/24507259/4870138a-1560-11e7-88a1-1c70c716f072.png">