### PR TITLE
fix(core): avoid NPE when extracting accounts for pipeline execution …

### DIFF
--- a/app/scripts/modules/core/delivery/filter/executionFilter.service.js
+++ b/app/scripts/modules/core/delivery/filter/executionFilter.service.js
@@ -114,7 +114,7 @@ module.exports = angular
           configAccounts.push(...stageConfig.configAccountExtractor(stage));
         }
       });
-      return _.uniq(_.flattenDeep(configAccounts)).filter(a => !a.includes('${')); // exclude parameterized accounts
+      return _.uniq(_.compact(_.flattenDeep(configAccounts))).filter(a => !a.includes('${')); // exclude parameterized accounts
     }
 
     function fixName(execution, application) {


### PR DESCRIPTION
…headers

@anotherchrisberry or @icfantv please review.

Fails on `!a.includes` if any of the accounts are undefined.
