### PR TITLE
fix(kubernetes): resize modal bug and restyling

### DIFF
--- a/app/scripts/modules/kubernetes/serverGroup/details/resize/resize.html
+++ b/app/scripts/modules/kubernetes/serverGroup/details/resize/resize.html
@@ -1,11 +1,11 @@
 <div modal-page class="confirmation-modal">
   <task-monitor monitor="taskMonitor"></task-monitor>
-  <form role="form">
+  <form role="form" name="kubernetesResizeForm">
     <modal-close (dismiss)="$dismiss()"></modal-close>
     <div class="modal-header">
       <h3>Resize {{serverGroup.name}}</h3>
     </div>
-    <div class="modal-body confirmation-modal" ng-show="serverGroup.autoscalerStatus !== null">
+    <div class="modal-body confirmation-modal" ng-if="serverGroup.autoscalerStatus !== null">
       <div class="form-horizontal">
         <div class="form-group form-inline">
           <div class="col-md-3 col-md-offset-3">Min</div>
@@ -21,7 +21,7 @@
                      class="form-control input-sm"
                      ng-model="serverGroup.deployDescription.capacity.min"
                      readonly/>
-              <span class="input-group-addon">pods</span>
+              <span class="input-group-addon">pod<span ng-if="serverGroup.deployDescription.capacity.min > 1">s</span></span>
             </div>
           </div>
           <div class="col-md-3">
@@ -30,7 +30,7 @@
                      class="form-control input-sm"
                      ng-model="serverGroup.deployDescription.capacity.max"
                      readonly/>
-              <span class="input-group-addon">pods</span>
+              <span class="input-group-addon">pod<span ng-if="serverGroup.deployDescription.capacity.max > 1">s</span></span>
             </div>
           </div>
         </div>
@@ -46,7 +46,7 @@
                      min="0"
                      max="{{command.capacity.max}}"
                      required/>
-              <span class="input-group-addon">pods</span>
+              <span class="input-group-addon">pod<span ng-if="command.capacity.min > 1">s</span></span>
             </div>
           </div>
           <div class="col-md-3">
@@ -56,7 +56,7 @@
                      ng-model="command.capacity.max"
                      min="{{command.capacity.min}}"
                      required/>
-              <span class="input-group-addon">pods</span>
+              <span class="input-group-addon">pod<span ng-if="command.capacity.max > 1">s</span></span>
             </div>
           </div>
         </div>
@@ -87,31 +87,35 @@
       </div>
       <task-reason command="command"></task-reason>
     </div>
-    <div class="modal-body confirmation-modal" ng-show="serverGroup.autoscalerStatus === null">
+    <div class="modal-body confirmation-modal" ng-if="serverGroup.autoscalerStatus === null">
       <div class="form-horizontal">
         <div class="form-group form-inline">
           <div class="col-md-3 sm-label-right">
-            Current size
+            Current
           </div>
-          <div class="col-md-6">
-            <input type="number"
-                   class="form-control input-sm"
-                   ng-model="currentSize.desired"
-                   readonly/>
-            pods<span ng-if="currentSize.desired > 1">s</span>
+          <div class="col-md-3">
+            <div class="input-group">
+              <input type="number"
+                     class="form-control input-sm highlight-pristine"
+                     ng-model="currentSize.desired"
+                     readonly/>
+              <span class="input-group-addon">pod<span ng-if="currentSize.desired > 1">s</span></span>
+            </div>
           </div>
         </div>
         <div class="form-group form-inline">
           <div class="col-md-3 sm-label-right">
-            Resize to
+            Desired
           </div>
-          <div class="col-md-6">
-            <input type="number"
-                   class="form-control input-sm highlight-pristine"
-                   ng-model="command.capacity.desired"
-                   min="0"
-                   required/>
-           pods
+          <div class="col-md-3">
+            <div class="input-group">
+              <input type="number"
+                     class="form-control input-sm highlight-pristine"
+                     ng-model="command.capacity.desired"
+                     min="0"
+                     required/>
+              <span class="input-group-addon">pod<span ng-if="command.capacity.desired > 1">s</span></span>
+            </div>
           </div>
         </div>
       </div>
@@ -133,7 +137,7 @@
       <button type="submit"
               class="btn btn-primary"
               ng-click="ctrl.resize()"
-              ng-disabled="!ctrl.isValid()">
+              ng-disabled="!ctrl.isValid() || !kubernetesResizeForm.$valid">
         Submit
       </button>
     </div>


### PR DESCRIPTION
@lwander please review.

Sets min/max/desired to be equal in the resize description (without an autoscaler). This is what GCE does for a resize operation, and it prevents things like this:

<img width="285" alt="screen shot 2017-03-31 at 10 01 40 am" src="https://cloud.githubusercontent.com/assets/13868700/24553717/13318264-15f9-11e7-8a58-8f7e32b327f0.png">

Before:
<img width="553" alt="screen shot 2017-03-30 at 4 21 19 pm" src="https://cloud.githubusercontent.com/assets/13868700/24553508/6b2a0b18-15f8-11e7-90f1-28d258bb1c58.png">
<img width="543" alt="screen shot 2017-03-30 at 4 21 32 pm" src="https://cloud.githubusercontent.com/assets/13868700/24553515/706f0038-15f8-11e7-8b51-4fe8e4368a3b.png">
After:
<img width="546" alt="screen shot 2017-03-30 at 5 17 08 pm" src="https://cloud.githubusercontent.com/assets/13868700/24553520/737767b6-15f8-11e7-9e8c-6b530dda2318.png">
<img width="546" alt="screen shot 2017-03-30 at 5 17 18 pm" src="https://cloud.githubusercontent.com/assets/13868700/24553524/75c30534-15f8-11e7-8db9-2cfd9066c059.png">
