### PR TITLE
fix(pipelines): fix alignment on multi-line account labels

### DIFF
--- a/app/scripts/modules/core/delivery/executionGroup/executionGroup.less
+++ b/app/scripts/modules/core/delivery/executionGroup/executionGroup.less
@@ -14,7 +14,7 @@
   &.clickable.heading-sticky {
     box-shadow: none;
     .shadowed {
-      box-shadow: 0px 8px 6px -6px @mid_lighter_grey;
+      box-shadow: 0 8px 6px -6px @mid_lighter_grey;
     }
   }
   .clearfix();
@@ -22,11 +22,12 @@
 
 .execution-group-heading, .execution-name {
   .account-tag {
+    display: flex;
+    min-height: 37px;
+    line-height: 16px;
+    align-items: center;
     flex: 0 0 auto;
     padding: 0 15px;
-    height: 37px;
-    line-height: 37px;
-    display: inline-block;
     border-right: 1px solid @lightest_grey;
     color: #ffffff;
     background-color: #777;


### PR DESCRIPTION
Current:
<img width="1079" alt="screen shot 2017-04-01 at 9 11 45 pm" src="https://cloud.githubusercontent.com/assets/73450/24584353/d9aaaf70-171f-11e7-9bb0-65790b38c59d.png">

This PR:
<img width="1084" alt="screen shot 2017-04-01 at 9 09 35 pm" src="https://cloud.githubusercontent.com/assets/73450/24584355/dfcf05ea-171f-11e7-9c33-cc2e7a6c17be.png">

Still gonna run into problems when someone is targeting five accounts with long names, but we can deal with that when we need to...