### PR TITLE
fix(kubernetes): replicas targetCPUUtilizationPercentage can be larger than 100

### DIFF
--- a/app/scripts/modules/kubernetes/serverGroup/configure/wizard/replicas.html
+++ b/app/scripts/modules/kubernetes/serverGroup/configure/wizard/replicas.html
@@ -53,9 +53,9 @@
         </div>
         <div class="col-md-3">
           <div class="input-group">
+            <!-- Current utilization is based on requested CPU: it can be lager than 100% -->
             <input type="number" class="form-control input-sm" name="details" ng-model="command.scalingPolicy.cpuUtilization.target"
-                                                                              min="0"
-                                                                              max="100"/>
+                                                                              min="0" />
             <span class="input-group-addon">%</span>
           </div>
         </div>


### PR DESCRIPTION
## Issue

Kubernetes Horizontal autoscaling's CPU utilization is calculated by `requested` CPU, and in some cases, it can be larger than 100%.

## Example:

If you want to over provision your Node you would define small CPU request compared to your CPU limit. It can be useful if you have different small applications with temporary traffic.

From my cluster:
```
NAME                      REFERENCE                             TARGET    CURRENT   MINPODS   MAXPODS
alert-worker              Deployment/alert-worker               1050%       986%    2         10 
```
=>

```
request: 10m
limit: 150m
wanted target: 70%
target to set: 1050%
 ->
(150m * 0.7) / 10m = 10.5 => 1050%
```
In Kubernetes the `targetCPUUtilizationPercentage` has a type `int32` but I didn't find any validation for it.