### PR TITLE
fix(travis stage): Bake stages do not recognize Travis stage or trigger

### DIFF
--- a/app/scripts/modules/amazon/pipeline/stages/bake/awsBakeStage.js
+++ b/app/scripts/modules/amazon/pipeline/stages/bake/awsBakeStage.js
@@ -29,9 +29,9 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.aws.bakeStage', [
         { type: 'requiredField', fieldName: 'package', },
         { type: 'requiredField', fieldName: 'regions', },
         { type: 'stageOrTriggerBeforeType',
-          stageType: 'jenkins',
+          stageTypes: ['jenkins', 'travis'],
           checkParentTriggers: true,
-          message: 'Bake stages should always have a Jenkins stage or trigger preceding them.<br> Otherwise, ' +
+          message: 'Bake stages should always have a Jenkins/Travis stage or trigger preceding them.<br> Otherwise, ' +
         'Spinnaker will bake and deploy the most-recently built package.'}
       ],
       restartable: true,

--- a/app/scripts/modules/azure/pipeline/stages/bake/azureBakeStage.js
+++ b/app/scripts/modules/azure/pipeline/stages/bake/azureBakeStage.js
@@ -30,9 +30,9 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.azure.bakeStage',
         { type: 'requiredField', fieldName: 'package', },
         { type: 'requiredField', fieldName: 'regions', },
         { type: 'stageOrTriggerBeforeType',
-          stageType: 'jenkins',
+          stageTypes: ['jenkins', 'travis'],
           checkParentTriggers: true,
-          message: 'Bake stages should always have a Jenkins stage or trigger preceding them.<br> Otherwise, ' +
+          message: 'Bake stages should always have a Jenkins/Travis stage or trigger preceding them.<br> Otherwise, ' +
         'Spinnaker will bake and deploy the most-recently built package.'}
       ],
       restartable: true,

--- a/app/scripts/modules/netflix/pipeline/stage/quickPatchAsg/quickPatchAsgStage.js
+++ b/app/scripts/modules/netflix/pipeline/stage/quickPatchAsg/quickPatchAsgStage.js
@@ -27,9 +27,9 @@ module.exports = angular.module('spinnaker.netflix.pipeline.stage.quickPatchAsgS
         validators: [
           {
             type: 'stageOrTriggerBeforeType',
-            stageType: 'jenkins',
+            stageTypes: ['jenkins', 'travis'],
             checkParentTriggers: true,
-            message: 'You must have a Jenkins stage or trigger before a Quick Patch stage.'
+            message: 'You must have a Jenkins/Travis stage or trigger before a Quick Patch stage.'
           },
           {type: 'requiredField', fieldName: 'clusterName', fieldLabel: 'cluster'},
           {type: 'requiredField', fieldName: 'credentials', fieldLabel: 'account'},

--- a/app/scripts/modules/openstack/pipeline/stages/bake/openstackBakeStage.js
+++ b/app/scripts/modules/openstack/pipeline/stages/bake/openstackBakeStage.js
@@ -30,9 +30,9 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.openstack.bakeSta
         { type: 'requiredField', fieldName: 'package', },
         { type: 'requiredField', fieldName: 'regions', },
         { type: 'stageOrTriggerBeforeType',
-          stageType: 'jenkins',
+          stageTypes: ['jenkins', 'travis'],
           checkParentTriggers: true,
-          message: 'Bake stages should always have a Jenkins stage or trigger preceding them.<br> Otherwise, ' +
+          message: 'Bake stages should always have a Jenkins/Travis stage or trigger preceding them.<br> Otherwise, ' +
         'Spinnaker will bake and deploy the most-recently built package.'}
       ],
       restartable: true,


### PR DESCRIPTION
This commit adds Travis stages or triggers as valid predecessors to the bake stages.

<img width="493" alt="skjermbilde 2017-04-03 kl 10 04 08" src="https://cloud.githubusercontent.com/assets/155558/24602065/87667bbc-185b-11e7-8047-e6d9509b7c6e.png">
