### PR TITLE
fix(security groups): prevent page flashing on security groups

### DIFF
--- a/app/scripts/modules/core/securityGroup/AllSecurityGroupsCtrl.js
+++ b/app/scripts/modules/core/securityGroup/AllSecurityGroupsCtrl.js
@@ -72,19 +72,15 @@ module.exports = angular.module('spinnaker.core.securityGroup.all.controller', [
 
     this.updateSecurityGroups = _.debounce(updateSecurityGroups, 200);
 
-    function handleRefresh() {
-      if (app.securityGroups.loaded && app.loadBalancers.loaded && app.serverGroups.loaded) {
-        updateSecurityGroups();
-      }
-    }
+    let handleRefresh = () => {
+      this.updateSecurityGroups();
+    };
 
     handleRefresh();
 
     app.activeState = app.securityGroups;
     $scope.$on('$destroy', () => app.activeState = app);
 
-    app.serverGroups.onRefresh($scope, handleRefresh);
-    app.loadBalancers.onRefresh($scope, handleRefresh);
     app.securityGroups.onRefresh($scope, handleRefresh);
   }
 );

--- a/app/scripts/modules/core/securityGroup/filter/SecurityGroupFilterCtrl.js
+++ b/app/scripts/modules/core/securityGroup/filter/SecurityGroupFilterCtrl.js
@@ -55,8 +55,6 @@ module.exports = angular.module('securityGroup.filter.controller', [
 
     this.initialize();
 
-    app.serverGroups.onRefresh($scope, this.initialize);
-    app.loadBalancers.onRefresh($scope, this.initialize);
     app.securityGroups.onRefresh($scope, this.initialize);
 
     $scope.$on('$destroy', $rootScope.$on('$locationChangeSuccess', () => {


### PR DESCRIPTION
Long ago, it mattered that we refreshed security groups whenever we refreshed load balancers and server groups. We don't really need to do that now, as the security group loader considers the state of those other data sources.

cc @jrsquared 