### PR TITLE
fix(kubernetes): update load balancer list when namespace changes

### DIFF
--- a/app/scripts/modules/kubernetes/securityGroup/configure/wizard/upsert.controller.js
+++ b/app/scripts/modules/kubernetes/securityGroup/configure/wizard/upsert.controller.js
@@ -155,18 +155,17 @@ module.exports = angular.module('spinnaker.securityGroup.kubernetes.create.contr
     };
 
     this.accountUpdated = function() {
-      $q.all({
-        accountDetails: accountService.getAccountDetails($scope.securityGroup.account),
-        loadBalancers: loadBalancerReader.listLoadBalancers('kubernetes'),
-      }).then(function(backingData) {
-        $scope.namespaces = backingData.accountDetails.namespaces;
-        $scope.loadBalancers = getLoadBalancerNames(backingData.loadBalancers);
-        ctrl.namespaceUpdated();
-      });
+      accountService.getAccountDetails($scope.securityGroup.account)
+        .then(function(accountDetails) {
+          $scope.namespaces = accountDetails.namespaces;
+          ctrl.namespaceUpdated();
+        });
     };
 
     this.namespaceUpdated = function() {
       updateSecurityGroupNames();
+      loadBalancerReader.listLoadBalancers('kubernetes')
+        .then(loadBalancers => $scope.loadBalancers = getLoadBalancerNames(loadBalancers));
       ctrl.updateName();
     };
 


### PR DESCRIPTION
When changing namespace, the load balancer list wasn't being updated.
This is important because you might want to associate rules with load
balancers in the same namespace or associate rules with load balancers in other namespaces. It may be worth updating further in the
future to configure namespace for the SG as well as namespace for the
LB.

Fixes [#1535](https://github.com/spinnaker/spinnaker/issues/1535)