### PR TITLE
fix(kubernetes): Delete Security Group Namespace

### DIFF
--- a/app/scripts/modules/kubernetes/securityGroup/details/details.controller.js
+++ b/app/scripts/modules/kubernetes/securityGroup/details/details.controller.js
@@ -103,6 +103,7 @@ module.exports = angular.module('spinnaker.securityGroup.kubernetes.details.cont
         return securityGroupWriter.deleteSecurityGroup(securityGroup, application, {
           cloudProvider: $scope.securityGroup.type,
           securityGroupName: securityGroup.name,
+          namespace: $scope.securityGroup.region,
         });
       };
 


### PR DESCRIPTION
Deleting Security Groups in a namespace other than default would error
out becuase it wasn't passing namespace to the securityGroupWriter.
