### PR TITLE
fix(clusters): preserve filters when clicking active item

### DIFF
--- a/app/scripts/modules/core/cluster/filter/multiselect.model.js
+++ b/app/scripts/modules/core/cluster/filter/multiselect.model.js
@@ -130,6 +130,9 @@ module.exports = angular
           job: serverGroup.name,
         };
         if (isClusterChildState()) {
+          if ($state.includes('**.serverGroup', params)) {
+            return;
+          }
           $state.go('^.' + serverGroup.category, params);
         } else {
           $state.go('.' + serverGroup.category, params);

--- a/app/scripts/modules/core/instance/instances.directive.js
+++ b/app/scripts/modules/core/instance/instances.directive.js
@@ -68,7 +68,9 @@ module.exports = angular.module('spinnaker.core.instance.instances.directive', [
               };
               scope.activeInstance = params;
               // also stolen from uiSref directive
-              $state.go('.instanceDetails', params, {relative: base, inherit: true});
+              if (!$state.includes('**.instanceDetails', params)) {
+                $state.go('.instanceDetails', params, {relative: base, inherit: true});
+              }
               event.target.className += ' active';
               event.preventDefault();
             }


### PR DESCRIPTION
For whatever reason, clicking an active instance or server group in the clusters view clears the navigation filters. This prevents the attempted state navigation if the user is already there, preserving the filters.