### PR TITLE
fix(pipelines): render account tag inline on time boundary view

### DIFF
--- a/app/scripts/modules/core/delivery/executionGroup/executionGroup.less
+++ b/app/scripts/modules/core/delivery/executionGroup/executionGroup.less
@@ -22,7 +22,6 @@
 
 .execution-group-heading, .execution-name {
   .account-tag {
-    display: flex;
     min-height: 37px;
     line-height: 16px;
     align-items: center;
@@ -50,6 +49,9 @@
   }
 }
 .execution-group-heading {
+  .account-tag {
+    display: flex;
+  }
   display: flex;
   padding: 0;
   margin-top: 3px;


### PR DESCRIPTION
right now, each tag takes up the entire width of the execution bar, which is not great