### PR TITLE
fix(aws/netflix): fix diff view when no metadata

### DIFF
--- a/app/scripts/modules/amazon/serverGroup/details/serverGroupDetails.aws.controller.js
+++ b/app/scripts/modules/amazon/serverGroup/details/serverGroupDetails.aws.controller.js
@@ -158,7 +158,7 @@ module.exports = angular.module('spinnaker.serverGroup.details.aws.controller', 
                 configureEntityTagTargets();
 
                 this.changeConfig = {
-                  metadata: this.serverGroup.entityTags.creationMetadata
+                  metadata: get(this.serverGroup.entityTags, 'creationMetadata')
                 };
               } else {
                 autoClose();

--- a/app/scripts/modules/core/diffs/viewChangesLink.component.ts
+++ b/app/scripts/modules/core/diffs/viewChangesLink.component.ts
@@ -1,4 +1,4 @@
-import {IComponentController, IComponentOptions, ILogService, module} from 'angular';
+import {IComponentController, IComponentOptions, module} from 'angular';
 import {IModalInstanceService, IModalService} from 'angular-ui-bootstrap';
 
 import {ICreationMetadata, ICreationMetadataTag} from 'core/domain';
@@ -47,11 +47,10 @@ class ViewChangesLinkController implements IComponentController {
   public jarDiffs: IJarDiff;
 
   static get $inject(): string[] {
-    return ['$log', '$uibModal', 'executionService'];
+    return ['$uibModal', 'executionService'];
   }
 
-  constructor(private $log: ILogService,
-              private $uibModal: IModalService,
+  constructor(private $uibModal: IModalService,
               private executionService: any) {}
 
   private setJarDiffs(): void {
@@ -75,17 +74,19 @@ class ViewChangesLinkController implements IComponentController {
   }
 
   public $onInit(): void {
-    if (!this.changeConfig.metadata && !this.changeConfig.commits && !this.changeConfig.jarDiffs) {
-      this.$log.error('either metadata or one or both of commits/jarDiffs must be specified in the change config');
-    }
 
-    if (this.changeConfig.metadata && this.changeConfig.metadata.value.executionType === 'pipeline') {
-      const value: ICreationMetadata = this.changeConfig.metadata.value;
-      this.lookForDiffs(value.stageId, value.executionId);
-    } else {
-      this.commits = this.changeConfig.commits;
-      this.jarDiffs = this.changeConfig.jarDiffs;
-      this.setJarDiffs();
+    if (this.changeConfig.metadata) {
+      if (this.changeConfig.metadata.value.executionType === 'pipeline') {
+        const value: ICreationMetadata = this.changeConfig.metadata.value;
+        this.lookForDiffs(value.stageId, value.executionId);
+      }
+    } else if (this.changeConfig.jarDiffs || this.changeConfig.commits) {
+      this.commits = this.changeConfig.commits || [];
+      this.jarDiffs = this.changeConfig.jarDiffs || null;
+      if (this.jarDiffs) {
+        this.setJarDiffs();
+      }
+
       if (this.hasJarChanges || this.commits.length) {
         this.changesAvailable = true;
       }

--- a/app/scripts/modules/core/pipeline/config/stages/deploy/deployExecutionDetails.controller.js
+++ b/app/scripts/modules/core/pipeline/config/stages/deploy/deployExecutionDetails.controller.js
@@ -25,8 +25,19 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.deploy.details.co
 
     $scope.configSections = ['deploymentConfig', 'taskStatus'];
 
+    function areJarDiffsEmpty() {
+      let result = true;
+
+      const jarDiffs = $scope.stage.context.jarDiffs;
+      if (!_.isEmpty(jarDiffs)) {
+        result = !Object.keys(jarDiffs).some(key => Array.isArray(jarDiffs[key]) && jarDiffs[key].length);
+      }
+
+      return result;
+    }
+
     if ($scope.stage.context) {
-      if (($scope.stage.context.commits && $scope.stage.context.commits.length > 0) || !_.isEmpty($scope.stage.context.jarDiffs)) {
+      if (($scope.stage.context.commits && $scope.stage.context.commits.length > 0) || !areJarDiffsEmpty($scope.stage.context.jarDiffs)) {
         $scope.configSections.push('changes');
       }
     }


### PR DESCRIPTION
* fix View Changes functionality when no metadata is present on ASGs.
* fix Pipeline execution view around changes when one or both of
commits/jarDiffs are missing.