### PR TITLE
fix(instances): preserve filters when double-clicking

### DIFF
--- a/app/scripts/modules/core/cluster/filter/multiselect.model.js
+++ b/app/scripts/modules/core/cluster/filter/multiselect.model.js
@@ -161,6 +161,9 @@ module.exports = angular
       if (!ClusterFilterModel.sortFilter.multiselect) {
         let params = {provider: serverGroup.type, instanceId: instanceId};
         if (isClusterChildState()) {
+          if ($state.includes('**.instanceDetails', params)) {
+            return;
+          }
           $state.go('^.instanceDetails', params);
         } else {
           $state.go('.instanceDetails', params);


### PR DESCRIPTION
Followup to a commit last week, preventing removal of filters when clicking an instance or server group - we didn't take into account the case where the "with details" box is checked. This fixes that scenario.