### PR TITLE
feat(provider/kubernetes): Add termination grace period seconds to Se…

### DIFF
--- a/app/scripts/modules/core/help/helpContents.js
+++ b/app/scripts/modules/core/help/helpContents.js
@@ -373,6 +373,7 @@ module.exports = angular.module('spinnaker.core.help.contents', [])
     'kubernetes.serverGroup.detail': '(Optional) A string of free-form alphanumeric characters and hyphens to describe any other variables.',
     'kubernetes.serverGroup.containers': '(Required) Select at least one image to run in this server group (pod). ' +
     'If multiple images are selected, they will be colocated and replicated equally.',
+    'kubernetes.serverGroup.terminationGracePeriodSeconds': '(Required) Termination grace period in <b>seconds</b>. You can customize the termination grace period setting (terminationGracePeriodSeconds). Because server groups (pods) represent running processes on nodes in the cluster, it is important to allow those processes to gracefully terminate when they are no longer needed (vs being violently killed and having no chance to clean up). Default is <b>30</b> seconds.',
     'kubernetes.serverGroup.autoscaling.enabled': 'If selected, a horizontal autoscaler will be attached to this replica set.',
     'kubernetes.serverGroup.autoscaling.min': 'The smallest number of pods to be deployed.',
     'kubernetes.serverGroup.autoscaling.max': 'The largest number of pods to be deployed.',

--- a/app/scripts/modules/kubernetes/cluster/configure/CommandBuilder.js
+++ b/app/scripts/modules/kubernetes/cluster/configure/CommandBuilder.js
@@ -50,6 +50,7 @@ module.exports = angular.module('spinnaker.kubernetes.clusterCommandBuilder.serv
         volumeSources: [],
         buildImageId: buildImageId,
         groupByRegistry: groupByRegistry,
+        terminationGracePeriodSeconds: 30,
         viewState: {
           mode: defaults.mode || 'create',
           disableStrategySelection: true,

--- a/app/scripts/modules/kubernetes/serverGroup/configure/wizard/basicSettings.html
+++ b/app/scripts/modules/kubernetes/serverGroup/configure/wizard/basicSettings.html
@@ -40,6 +40,17 @@
     </div>
   </div>
 
+  <div class="form-group">
+    <div class="col-md-3 sm-label-right">
+      TERM Grace Period
+      <help-field key="kubernetes.serverGroup.terminationGracePeriodSeconds"></help-field>
+    </div>
+    <div class="col-md-2"><input type="number" min="0"
+                                 class="form-control input-sm"
+                                 name="terminationGracePeriodSeconds"
+                                 ng-model="command.terminationGracePeriodSeconds" required/></div>
+  </div>
+
   <div class="col-md-12" ng-if="command.viewState.dirty.containers">
     <div class="alert alert-warning">
       <p><span class="glyphicon glyphicon-warning-sign"></span>

--- a/app/scripts/modules/kubernetes/serverGroup/details/details.html
+++ b/app/scripts/modules/kubernetes/serverGroup/details/details.html
@@ -74,6 +74,8 @@
         <dd ng-show="serverGroup.revision">{{serverGroup.revision}}</dd>
         <dt>Kube UI</dt>
         <dd><a href={{ctrl.uiLink()}} target="_blank">{{serverGroup.name}}</a></dd>
+        <dt>TERM Period</dt>
+        <dd>{{serverGroup.deployDescription.terminationGracePeriodSeconds}}&nbsp;second(s)</dd>
       </dl>
     </collapsible-section>
     <collapsible-section heading="Health" expanded="true">


### PR DESCRIPTION
Adds TERM Grace Period field (terminationGracePeriodSeconds property of Kubernetes) to the Server Group creation wizard and Server Group Information panel. Adds support for https://github.com/spinnaker/spinnaker/issues/1107

Please also see https://github.com/spinnaker/clouddriver/pull/1569

@spinnaker/reviewers