### PR TITLE
feat(provider/kubernetes): Add termination grace period seconds to Se…

### DIFF
--- a/app/scripts/modules/core/help/helpContents.js
+++ b/app/scripts/modules/core/help/helpContents.js
@@ -375,6 +375,7 @@ module.exports = angular.module('spinnaker.core.help.contents', [])
     'kubernetes.serverGroup.detail': '(Optional) A string of free-form alphanumeric characters and hyphens to describe any other variables.',
     'kubernetes.serverGroup.containers': '(Required) Select at least one image to run in this server group (pod). ' +
     'If multiple images are selected, they will be colocated and replicated equally.',
+    'kubernetes.serverGroup.terminationGracePeriodSeconds': '(Required) Termination grace period in <b>seconds</b>. You can customize the termination grace period setting (terminationGracePeriodSeconds). Because server groups (pods) represent running processes on nodes in the cluster, it is important to allow those processes to gracefully terminate when they are no longer needed (vs. being violently killed and having no chance to clean up). Default is <b>30</b> seconds.',
     'kubernetes.serverGroup.autoscaling.enabled': 'If selected, a horizontal autoscaler will be attached to this replica set.',
     'kubernetes.serverGroup.autoscaling.min': 'The smallest number of pods to be deployed.',
     'kubernetes.serverGroup.autoscaling.max': 'The largest number of pods to be deployed.',

--- a/app/scripts/modules/kubernetes/cluster/configure/CommandBuilder.js
+++ b/app/scripts/modules/kubernetes/cluster/configure/CommandBuilder.js
@@ -50,6 +50,7 @@ module.exports = angular.module('spinnaker.kubernetes.clusterCommandBuilder.serv
         volumeSources: [],
         buildImageId: buildImageId,
         groupByRegistry: groupByRegistry,
+        terminationGracePeriodSeconds: 30,
         viewState: {
           mode: defaults.mode || 'create',
           disableStrategySelection: true,

--- a/app/scripts/modules/kubernetes/serverGroup/configure/wizard/advancedSettings.html
+++ b/app/scripts/modules/kubernetes/serverGroup/configure/wizard/advancedSettings.html
@@ -8,5 +8,22 @@
 
     <kubernetes-annotation-configurer component="command" field="nodeSelector" label="Node Selector">
     </kubernetes-annotation-configurer>
+
+    <div class="form-group">
+      <div class="col-md-4 sm-label-right">
+        Termination Grace Period
+        <help-field key="kubernetes.serverGroup.terminationGracePeriodSeconds"></help-field>
+      </div>
+      <div class="col-md-3">
+        <div class="input-group">
+          <input type="number" min="0"
+             class="form-control input-sm"
+             name="terminationGracePeriodSeconds"
+             ng-model="command.terminationGracePeriodSeconds" required/>
+          <span class="input-group-addon">seconds</span>
+        </div>
+      </div>
+    </div>
+
   </div>
 </ng-form>

--- a/app/scripts/modules/kubernetes/serverGroup/details/details.html
+++ b/app/scripts/modules/kubernetes/serverGroup/details/details.html
@@ -245,5 +245,11 @@
         No events.
       </div>
     </collapsible-section>
+    <collapsible-section heading="Advanced Settings">
+      <dl>
+        <dt>Termination Grace Period</dt>
+        <dd>{{serverGroup.deployDescription.terminationGracePeriodSeconds}}&nbsp;second(s)</dd>
+      </dl>
+    </collapsible-section>
   </div>
 </div>


### PR DESCRIPTION
Adds Termination Grace Period field (terminationGracePeriodSeconds property of Kubernetes) to the Server Group creation wizard and Server Group Information panel. Adds support for https://github.com/spinnaker/spinnaker/issues/1107

https://github.com/spinnaker/clouddriver/pull/1572

@spinnaker/reviewers