### PR TITLE
perf(aws): do not overfetch execution for ASG source/changes

### DIFF
--- a/app/scripts/modules/core/entityTag/entitySource.component.ts
+++ b/app/scripts/modules/core/entityTag/entitySource.component.ts
@@ -11,6 +11,7 @@ class EntitySourceCtrl implements ng.IComponentController {
   public popoverTemplate: string = require('./entitySource.popover.html');
   public execution: IExecution;
   public executionNotFound: boolean;
+  private loadingExecution = false;
 
   static get $inject() { return ['executionService']; }
 
@@ -18,12 +19,16 @@ class EntitySourceCtrl implements ng.IComponentController {
 
   public $onInit(): void {
     this.executionType = 'Task';
+    if (this.execution || this.loadingExecution) {
+      return;
+    }
     if (this.metadata && this.metadata.value.executionType === 'pipeline') {
       this.executionType = 'Pipeline';
+      this.loadingExecution = true;
       this.executionService.getExecution(this.metadata.value.executionId).then(
         (execution: IExecution) => this.execution = execution,
         () => this.executionNotFound = true
-      );
+      ).finally(() => this.loadingExecution = false);
     }
   }
 


### PR DESCRIPTION
Currently, with entity tags enabled, if we find a provenance tag on a server group, we'll fetch the execution five times when the server group details is initially rendered, then three times whenever it's refreshed. This is because we don't cache the result of that fetch in either the `entityTagSource` or `viewChangesLink` components.

With this PR, we'll typically only fetch the execution twice: once when each component first renders. After that, the result is cached.

For `entityTagSource`, there's no concern: it's just used to generate a deep link, and that won't change, even if the execution is still running.

For `viewChangesLink`, we'll continue refetching (but only once per cycle) in the rare case the deploy stage is still running and hasn't added commits or jardiffs to its context.