### PR TITLE
fix(docker): make tag optional, do not set to null if undefined

### DIFF
--- a/app/scripts/modules/docker/image/dockerImageAndTagSelector.component.html
+++ b/app/scripts/modules/docker/image/dockerImageAndTagSelector.component.html
@@ -65,8 +65,7 @@
            class="form-control input-sm"
            ng-model="$ctrl.tag"
            ng-disabled="$ctrl.viewState.imagesRefreshing || !$ctrl.repository"
-           ng-change="$ctrl.updateTag()"
-           required/>
+           ng-change="$ctrl.updateTag()"/>
   </div>
 </div>
 <div class="form-group" ng-if="!$ctrl.specifyTagByRegex">

--- a/app/scripts/modules/docker/image/dockerImageAndTagSelector.component.ts
+++ b/app/scripts/modules/docker/image/dockerImageAndTagSelector.component.ts
@@ -84,14 +84,14 @@ export class DockerImageAndTagSelectorController implements ng.IComponentControl
 
   private updateTag(): void {
     if (this.specifyTagByRegex) {
-      if (trim(this.tag) === '') {
+      if (trim(this.tag) === '' && this.tag) {
         this.tag = null;
       }
     } else {
       if (this.repositoryMap) {
         const key = this.repository;
         this.tags = this.repositoryMap[key] || [];
-        if (!this.tags.includes(this.tag)) {
+        if (!this.tags.includes(this.tag) && this.tag) {
           this.tag = null;
         }
       }


### PR DESCRIPTION
The help text indicates the field is optional, but for some reason it's marked as required in the HTML, and we have handlers that will set it to `null`, so maybe it's not required? Functionally, it appears to be optional.

Setting it to `null` is bad news, because either we don't send the `null` value to Front50, or Front50 strips out the `null` field, so it's never persisted. But it does change the structure of the pipeline whenever the trigger config loads, so the pipeline will always show the "Save Changes" button.