### PR TITLE
fix(popover): stringify popover triggers

### DIFF
--- a/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/scalingPolicySummary.component.html
+++ b/app/scripts/modules/amazon/serverGroup/details/scalingPolicy/scalingPolicySummary.component.html
@@ -2,7 +2,7 @@
   <div uib-popover-template="$ctrl.popoverTemplate"
        popover-placement="left"
        popover-title="{{$ctrl.policy.policyName}}"
-       popover-trigger="mouseenter">
+       popover-trigger="'mouseenter'">
     <div>
       <strong>Whenever</strong>
       {{alarm.statistic}} of <span class="alarm-name">{{alarm.metricName}}</span>

--- a/app/scripts/modules/core/delivery/manualExecution/manualPipelineExecution.html
+++ b/app/scripts/modules/core/delivery/manualExecution/manualPipelineExecution.html
@@ -136,7 +136,7 @@
             There is <a uib-popover-template="vm.notificationTooltip" popover-placement="bottom">one notification</a> configured for this pipeline
           </div>
           <div ng-if="vm.notifications.length > 1" class="small">
-            There are <a uib-popover-template="vm.notificationTooltip" popover-placement="bottom" popover-trigger="mouseenter">{{vm.notifications.length}} notifications</a> configured for this pipeline</div>
+            There are <a uib-popover-template="vm.notificationTooltip" popover-placement="bottom" popover-trigger="'mouseenter'">{{vm.notifications.length}} notifications</a> configured for this pipeline</div>
         </div>
       </div>
       <div class="form-group" ng-if="vm.command.notificationEnabled">

--- a/app/scripts/modules/core/delivery/triggers/nextRun.component.js
+++ b/app/scripts/modules/core/delivery/triggers/nextRun.component.js
@@ -55,7 +55,7 @@ module.exports = angular
       <span is-visible="$ctrl.hasNextScheduled">
         <span class="glyphicon glyphicon-time"
               popover-placement="left"
-              popover-trigger="mouseenter"
+              popover-trigger="'mouseenter'"
               ng-mouseenter="$ctrl.updateSchedule()"
               uib-popover="Next run: {{$ctrl.nextScheduled | timestamp}} ({{$ctrl.getNextDuration()}})"></span>
       </span>`

--- a/app/scripts/modules/core/entityTag/dataSourceAlerts.component.ts
+++ b/app/scripts/modules/core/entityTag/dataSourceAlerts.component.ts
@@ -72,7 +72,7 @@ class DataSourceAlertsComponent implements ng.IComponentOptions {
             analytics-category="Alerts hovered"
             analytics-label="{{$ctrl.analyticsLabel}}"
             popover-placement="bottom"
-            popover-trigger="none"
+            popover-trigger="'none'"
             popover-is-open="$ctrl.displayPopover"
             popover-class="no-padding">
         <i class="entity-tag fa fa-exclamation-triangle"></i>

--- a/app/scripts/modules/core/entityTag/entitySource.component.ts
+++ b/app/scripts/modules/core/entityTag/entitySource.component.ts
@@ -50,7 +50,7 @@ class EntitySourceComponent implements ng.IComponentOptions {
       <dd>
         <span uib-popover-template="$ctrl.popoverTemplate"
               popover-placement="left"
-              popover-trigger="mouseenter">
+              popover-trigger="'mouseenter'">
           <span ng-if="$ctrl.executionNotFound">pipeline (not found)</span>
           <a ng-if="!$ctrl.executionNotFound && $ctrl.metadata.value.executionType === 'pipeline'"
              ui-sref="{{$ctrl.relativePath}}.pipelines.executionDetails.execution({application: $ctrl.metadata.value.application, executionId: $ctrl.metadata.value.executionId, stageId: $ctrl.metadata.value.stageId})">

--- a/app/scripts/modules/core/entityTag/entityUiTags.component.ts
+++ b/app/scripts/modules/core/entityTag/entityUiTags.component.ts
@@ -154,7 +154,7 @@ class EntityUiTagsComponent implements ng.IComponentOptions {
             ng-mouseleave="$ctrl.hidePopover(true)">
         <span uib-popover-template="$ctrl.popoverTemplate"
               popover-placement="auto top"
-              popover-trigger="none"
+              popover-trigger="'none'"
               analytics-on="mouseenter"
               analytics-category="Notice hovered"
               analytics-label="{{$ctrl.alertAnalyticsLabel}}"
@@ -169,7 +169,7 @@ class EntityUiTagsComponent implements ng.IComponentOptions {
             ng-mouseleave="$ctrl.hidePopover(true)">
         <span uib-popover-template="$ctrl.popoverTemplate"
               popover-placement="auto top"
-              popover-trigger="none"
+              popover-trigger="'none'"
               analytics-on="mouseenter"
               analytics-category="Notice hovered"
               analytics-label="{{$ctrl.noticeAnalyticsLabel}}"

--- a/app/scripts/modules/core/help/helpField.component.ts
+++ b/app/scripts/modules/core/help/helpField.component.ts
@@ -103,7 +103,7 @@ class HelpFieldComponent implements ng.IComponentOptions {
               ng-mouseleave="$ctrl.hidePopover(true)"
               popover-placement="{{$ctrl.contents.placement}}"
               popover-is-open="$ctrl.displayPopover"
-              popover-trigger="none"
+              popover-trigger="'none'"
               ng-bind-html="$ctrl.label">
       </a>
     </div>
@@ -117,7 +117,7 @@ class HelpFieldComponent implements ng.IComponentOptions {
               ng-mouseleave="$ctrl.hidePopover(true)"
               popover-placement="{{$ctrl.contents.placement}}"
               popover-is-open="$ctrl.displayPopover"
-              popover-trigger="none">
+              popover-trigger="'none'">
         <span class="small glyphicon glyphicon-question-sign"></span>
       </a>
     </div>

--- a/app/scripts/modules/core/pipeline/config/graph/pipelineGraph.component.html
+++ b/app/scripts/modules/core/pipeline/config/graph/pipelineGraph.component.html
@@ -17,7 +17,7 @@
     <g uib-popover-template="warningsPopover"
        popover-placement="auto"
        popover-enable="stage.hasWarnings"
-       popover-trigger="mouseenter">
+       popover-trigger="'mouseenter'">
       <circle ng-attr-r="{{::nodeRadius}}"
               class="clickable stage-type-{{::stage.masterStage.type.toLowerCase()}} execution-marker execution-marker-{{::stage.status.toLowerCase()}}"
               ng-class="{active: stage.isActive}"

--- a/app/scripts/modules/core/pipeline/config/pipelineConfigurer.html
+++ b/app/scripts/modules/core/pipeline/config/pipelineConfigurer.html
@@ -118,7 +118,7 @@
                 ng-if="pipelineConfigurerCtrl.validations.hasWarnings"
                 uib-popover-template="pipelineConfigurerCtrl.warningsPopover"
                 popover-placement="left-bottom"
-                popover-trigger="mouseenter">
+                popover-trigger="'mouseenter'">
         <i class="fa fa-exclamation-triangle" style="font-size: 125%;"></i>
         </button>
         <span ng-if="viewState.saveError" class="alert alert-danger">

--- a/app/scripts/modules/netflix/availability/availability.trend.html
+++ b/app/scripts/modules/netflix/availability/availability.trend.html
@@ -8,7 +8,7 @@
         ng-mouseleave="$ctrl.hidePopover(i, true)"
         popover-placement="top"
         popover-is-open="$ctrl.popoverOpen[i]"
-        popover-trigger="none">
+        popover-trigger="'none'">
         <circle ng-attr-r="{{dot.r}}" ng-attr-cx="{{dot.cx}}" ng-attr-cy="{{dot.cy}}" class="score-fill-{{dot.score}}"></circle>
       </g>
     </g>


### PR DESCRIPTION
As of ui-bootstrap 2.x, `popover-trigger` requires strings wrapped in quotes.