### PR TITLE
fix(netflix): use angular.equals to compare fp scopes

### DIFF
--- a/app/scripts/modules/netflix/fastProperties/domain/propertyCommand.model.ts
+++ b/app/scripts/modules/netflix/fastProperties/domain/propertyCommand.model.ts
@@ -1,6 +1,7 @@
-import {isEqual, omit} from 'lodash';
-import {Scope} from '../domain/scope.domain';
-import {Property} from '../domain/property.domain';
+import {omit} from 'lodash';
+import {equals} from 'angular';
+import {Scope} from './scope.domain';
+import {Property} from './property.domain';
 import {PropertyPipeline} from './propertyPipeline.domain';
 import {PropertyStrategy} from './propertyStrategy.domain';
 import {PropertyCommandType} from './propertyCommandType.enum';
@@ -72,9 +73,9 @@ export class PropertyCommand {
 
   public isMoveToNewScope(): boolean {
     if (this.scopes.length > 0 && this.originalScope) {
-      return !isEqual(
-        omit(this.scopes[0], ['instanceCounts']),
-        omit(this.originalScope, ['instanceCounts'])
+      return !equals(
+        omit(this.scopes[0], ['instanceCounts', 'env']),
+        omit(this.originalScope, ['instanceCounts', 'env'])
       );
     }
     return false;


### PR DESCRIPTION
Two issues:
1. `isEqual` does not work well once Angular comes into the picture, as it adds things like `$$hashKey` to the Angular-rendered object.
2. `env` is not set on the new `Scope`, (but is also not editable when selecting a property scope), so needs to be omitted when making the comparison.