### PR TITLE
fix(pipelines): prevent page navigator from unsticking in config

### DIFF
--- a/app/scripts/modules/core/presentation/navigation/pageNavigator.component.ts
+++ b/app/scripts/modules/core/presentation/navigation/pageNavigator.component.ts
@@ -3,28 +3,31 @@ import {PageNavigationState, PAGE_NAVIGATION_STATE} from './pageNavigationState'
 import {throttle} from 'lodash';
 import {ScrollToService, SCROLL_TO_SERVICE} from 'core/utils/scrollTo/scrollTo.service';
 import {PAGE_SECTION_COMPONENT} from './pageSection.component';
+import {UUIDGenerator} from 'core/utils/uuid.service';
 import './pageNavigation.less';
 
 class PageNavigatorController implements ng.IComponentController {
   public scrollableContainer: string;
   private container: JQuery;
   private navigator: JQuery;
+  private id: string;
 
-  private static get EVENT_KEY(): string { return 'scroll.pageNavigation'; }
+  private getEventKey(): string { return `scroll.pageNavigation.${this.id}`; }
 
   static get $inject() { return ['$element', 'scrollToService', 'pageNavigationState']; }
 
   public constructor(private $element: JQuery, private scrollToService: ScrollToService, public pageNavigationState: PageNavigationState) {}
 
   public $onInit(): void {
+    this.id = UUIDGenerator.generateUuid();
     this.pageNavigationState.reset();
     this.container = this.$element.closest(this.scrollableContainer);
-    this.container.bind(PageNavigatorController.EVENT_KEY, throttle(() => this.handleScroll(), 20));
+    this.container.bind(this.getEventKey(), throttle(() => this.handleScroll(), 20));
     this.navigator = this.$element.find('.page-navigation');
   }
 
   public $onDestroy(): void {
-    this.container.unbind(PageNavigatorController.EVENT_KEY);
+    this.container.unbind(this.getEventKey());
   }
 
   public setCurrentSection(key: string): void {


### PR DESCRIPTION
Kind of a silly edge case, but: using `ng-if`, combined with a stateful service (page navigator) to register and reset pages means that, when moving from a stage back to the Configuration (i.e. `<triggers>`), the `<triggers>` content sets up its page navigator, then the `<pipeline-config-stage>` destroys its navigator and unregisters the scroll handler, which keeps the page navigator (since there's only ever one) from sticking.

The cleanest workaround is to just make the event namespace unique, so order is not important when binding/unbinding the navigators.

@jrsquared PTAL