### PR TITLE
fix(pipelines): force stage config rerender on refId change

### DIFF
--- a/app/scripts/modules/core/pipeline/config/stages/stage.module.js
+++ b/app/scripts/modules/core/pipeline/config/stages/stage.module.js
@@ -180,6 +180,7 @@ module.exports = angular.module('spinnaker.core.pipeline.config.stage', [
     $scope.$on('pipeline-json-edited', this.selectStage);
     $scope.$watch('stage.type', this.selectStage);
     $scope.$watch('viewState.stageIndex', this.selectStage);
+    $scope.$watch('stage.refId', this.selectStage);
   })
   .controller('RestartStageCtrl', function($scope, $stateParams, $http, API, confirmationModalService) {
     var restartStage = function () {


### PR DESCRIPTION
We currently only re-render the stage configuration if the index changes or the type changes. However, if you have two stages of the same type, and remove the second one, the UI won't update, because neither of those fields will change.

@jrsquared PTAL - this is what we were discussing earlier this morning.