### PR TITLE
fix(netflix): clarify help text when setting up PagerDuty integration

### DIFF
--- a/app/scripts/modules/netflix/pagerDuty/pagerDuty.read.service.ts
+++ b/app/scripts/modules/netflix/pagerDuty/pagerDuty.read.service.ts
@@ -14,7 +14,7 @@ export class PagerDutyReader {
   public constructor(private API: Api) {}
 
   public listServices(): Observable<IPagerDutyService[]> {
-    return Observable.fromPromise(this.API.one('pagerDuty/services').useCache().getList());
+    return Observable.fromPromise(this.API.one('pagerDuty/services').getList());
   }
 }
 


### PR DESCRIPTION
Now there's a v2 integration from PagerDuty, which is the default, and we are not going to deal with that right now, so this updates the help text on the field to explain to users that they should select the v1 integration.

A couple of other improvements:
1. The response to get the list of services from gate comes back in less than 100ms, so we don't need to cache it, since caching it means users need to refresh the entire page to get new services.
2. Auto-refreshing the list every ten seconds, so they don't need to close the modal to get the latest list of services if they just recently added one.