### PR TITLE
fix(core): fix CSS regressions on multiselect

### DIFF
--- a/app/scripts/modules/core/modal/modals.less
+++ b/app/scripts/modules/core/modal/modals.less
@@ -333,7 +333,9 @@ abbr.select2-search-choice-close {
       background-image: none;
       background-color: transparent;
       box-shadow: none;
-      div, span span {
+      div, span {
+        cursor: text;
+        user-select: auto;
         padding: 5px;
         width: calc(~"100% - 40px");
         display: inline-block;


### PR DESCRIPTION
Not sure when this regression happened, but i just started noticing it a week or two ago:

Current:
<img width="559" alt="screen shot 2017-04-14 at 1 43 19 pm" src="https://cloud.githubusercontent.com/assets/73450/25055554/5b8483f2-2118-11e7-970f-ae86ba36173e.png">

PR:
<img width="554" alt="screen shot 2017-04-14 at 1 39 35 pm" src="https://cloud.githubusercontent.com/assets/73450/25055558/60bf72a0-2118-11e7-902c-7f416df2bae0.png">

Also making the text editable in the selections.