### PR TITLE
fix(core): Fix default on account/region select field

### DIFF
--- a/app/scripts/modules/core/account/accountSelectField.directive.html
+++ b/app/scripts/modules/core/account/accountSelectField.directive.html
@@ -4,6 +4,7 @@
         ng-change="vm.onChange()"
         ng-if="!vm.readOnly"
         required>
+  <option value="" disabled>Select...</option>
   <option ng-repeat="account in vm.primaryAccounts" value="{{account}}" ng-selected="vm.component[vm.field] === account">{{account}}</option>
   <option ng-if="vm.primaryAccounts.length && vm.secondaryAccounts.length" disabled>---------------</option>
   <option ng-repeat="account in vm.secondaryAccounts" value="{{account}}" ng-selected="vm.component[vm.field] === account">{{account}}</option>

--- a/app/scripts/modules/core/account/accountSelectField.directive.js
+++ b/app/scripts/modules/core/account/accountSelectField.directive.js
@@ -54,6 +54,10 @@ module.exports = angular
           this.secondaryAccounts = _.xor(accountNames, this.primaryAccounts).sort();
           this.mergedAccounts = _.flatten([this.primaryAccounts, this.secondaryAccounts]);
         }
+
+        if (this.component && (!this.mergedAccounts || !this.mergedAccounts.includes(this.component[this.field]))) {
+          this.component[this.field] = null;
+        }
       });
     };
 

--- a/app/scripts/modules/core/region/regionSelectField.directive.html
+++ b/app/scripts/modules/core/region/regionSelectField.directive.html
@@ -7,6 +7,7 @@
             ng-model="component[field]"
             ng-change="onChange()"
             required>
+      <option value="" disabled>Select...</option>
       <option ng-repeat="region in regions" value="{{region.name}}" ng-selected="component[field] === region.name">{{region.name}} {{region.deprecated ? '(deprecated in the \'' + account + '\' account)' : ''}}</option>
     </select>
     <p ng-if="readOnly" class="form-control-static">{{component[field]}}</p>

--- a/app/scripts/modules/core/region/regionSelectField.directive.spec.js
+++ b/app/scripts/modules/core/region/regionSelectField.directive.spec.js
@@ -39,15 +39,15 @@ describe('Directives: regionSelectField', function () {
     var elem = this.compile(html)(scope);
     scope.$digest();
 
-    expect(elem.find('option').length).toBe(1);
+    expect(elem.find('option').length).toBe(2);
 
     scope.regions = [{name: 'us-east-1'}, {name: 'us-west-1'}];
     scope.$digest();
 
     var options = elem.find('option');
-    var expected = ['us-east-1', 'us-west-1'];
+    var expected = ['', 'us-east-1', 'us-west-1'];
 
-    expect(options.length).toBe(2);
+    expect(options.length).toBe(3);
     options.each(function(idx, option) {
       expect(option.value).toBe(expected[idx]);
     });
@@ -66,7 +66,7 @@ describe('Directives: regionSelectField', function () {
     scope.$digest();
 
     var options = elem.find('option');
-    expect(options[1].selected).toBe(true);
+    expect(options[2].selected).toBe(true);
 
   });
 });


### PR DESCRIPTION
If the default value isn't found in the list of options, [angularjs sets it](http://stackoverflow.com/questions/12654631/why-does-angularjs-include-an-empty-option-in-select) to '?'. Since '?' _technically_ isn't an empty string, the field is incorrectly listed as valid.

I also added the 'Select...' placeholder to be displayed when the value is empty

### Before:
![screen shot 2017-04-17 at 2 16 12 pm](https://cloud.githubusercontent.com/assets/11282622/25105607/362a6e96-237a-11e7-8614-fee7ff93cbc5.png)
![screen shot 2017-04-17 at 2 18 44 pm](https://cloud.githubusercontent.com/assets/11282622/25105611/3ddb77ca-237a-11e7-8d9e-c13ee10fee55.png)

### After:
![screen shot 2017-04-17 at 2 14 16 pm](https://cloud.githubusercontent.com/assets/11282622/25105593/262f5ab0-237a-11e7-94a6-35e3730ea598.png)
![screen shot 2017-04-17 at 2 18 20 pm](https://cloud.githubusercontent.com/assets/11282622/25105603/337af3aa-237a-11e7-912c-1e37bbc4381e.png)