### PR TITLE
fix(force cancel pipeline): Display force checkbox by default

### DIFF
--- a/app/scripts/modules/core/delivery/executionGroup/execution/Execution.tsx
+++ b/app/scripts/modules/core/delivery/executionGroup/execution/Execution.tsx
@@ -166,7 +166,7 @@ export class Execution extends React.Component<IExecutionProps, IExecutionState>
     cancelModalService.confirm({
       header: `Really stop execution of ${this.props.execution.name}?`,
       buttonText: `Stop running ${this.props.execution.name}`,
-      forceable: this.props.execution.executionEngine === 'v2',
+      forceable: this.props.execution.executionEngine !== 'v1',
       body: hasDeployStage ? '<b>Note:</b> Any deployments that have begun will continue and need to be cleaned up manually.' : null,
       submitMethod: (reason, force) => executionService.cancelExecution(this.props.application, this.props.execution.id, force, reason)
     });

--- a/app/scripts/modules/core/delivery/service/execution.service.spec.js
+++ b/app/scripts/modules/core/delivery/service/execution.service.spec.js
@@ -41,7 +41,7 @@ describe('Service: executionService', function () {
     it('should wait until pipeline is not running, then resolve', function () {
       let completed = false;
       let executionId = 'abc';
-      let cancelUrl = [ SETTINGS.gateUrl, 'applications', 'deck', 'pipelines', executionId, 'cancel' ].join('/');
+      let cancelUrl = [ SETTINGS.gateUrl, 'pipelines', executionId, 'cancel' ].join('/');
       let checkUrl = [ SETTINGS.gateUrl, 'pipelines', executionId ].join('/');
       let application = { name: 'deck', executions: { refresh: () => $q.when(null) } };
 
@@ -61,7 +61,7 @@ describe('Service: executionService', function () {
     it('should propagate rejection from failed cancel', function () {
       let failed = false;
       let executionId = 'abc';
-      let cancelUrl = [ SETTINGS.gateUrl, 'applications', 'deck', 'pipelines', executionId, 'cancel' ].join('/');
+      let cancelUrl = [ SETTINGS.gateUrl, 'pipelines', executionId, 'cancel' ].join('/');
       let application = { name: 'deck', executions: { refresh: () => $q.when(null) } };
 
       $httpBackend.expectPUT(cancelUrl).respond(500, []);

--- a/app/scripts/modules/core/delivery/service/execution.service.ts
+++ b/app/scripts/modules/core/delivery/service/execution.service.ts
@@ -136,8 +136,6 @@ export class ExecutionService {
         method: 'PUT',
         url: [
           SETTINGS.gateUrl,
-          'applications',
-          application.name,
           'pipelines',
           executionId,
           'cancel',


### PR DESCRIPTION
ExecutionEngine 'v2' is now default, so the force checkbox should be displayed by default.
This commit also change the cancel pipeline endpoint, the previous one is [deprecated](https://github.com/spinnaker/gate/blob/master/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ApplicationController.groovy#L93).