### PR TITLE
fix(aws): render enabled ASG metrics in details panel

### DIFF
--- a/app/scripts/modules/amazon/serverGroup/details/advancedSettings/editAsgAdvancedSettings.modal.html
+++ b/app/scripts/modules/amazon/serverGroup/details/advancedSettings/editAsgAdvancedSettings.modal.html
@@ -19,9 +19,9 @@
         </div>
         <div class="col-md-6">
 
-          <ui-select multiple ng-model="$ctrl.command.enabledMetrics" class="form-control input-sm">
+          <ui-select multiple ng-model="command.enabledMetrics" class="form-control input-sm">
             <ui-select-match>{{$item}}</ui-select-match>
-            <ui-select-choices repeat="enabledMetric in $ctrl.command.backingData.enabledMetrics | filter: $select.search | orderBy: 'toString()'">
+            <ui-select-choices repeat="enabledMetric in command.backingData.enabledMetrics | filter: $select.search | orderBy: 'toString()'">
               <span ng-bind-html="enabledMetric | highlight: $select.search"></span>
             </ui-select-choices>
           </ui-select>

--- a/app/scripts/modules/amazon/serverGroup/details/serverGroupDetails.aws.controller.js
+++ b/app/scripts/modules/amazon/serverGroup/details/serverGroupDetails.aws.controller.js
@@ -110,6 +110,7 @@ module.exports = angular.module('spinnaker.serverGroup.details.aws.controller', 
               if (!isEmpty(this.serverGroup)) {
 
                 this.image = details.image ? details.image : undefined;
+                this.enabledMetrics = get(this.serverGroup, 'asg.enabledMetrics', []).map(m => m.metric);
 
                 var vpc = this.serverGroup.asg ? this.serverGroup.asg.vpczoneIdentifier : '';
 

--- a/app/scripts/modules/amazon/serverGroup/details/serverGroupDetails.html
+++ b/app/scripts/modules/amazon/serverGroup/details/serverGroupDetails.html
@@ -273,8 +273,8 @@
       <dl class="horizontal-when-filters-collapsed">
         <dt>Cooldown</dt>
         <dd>{{ctrl.serverGroup.asg.defaultCooldown}} seconds</dd>
-        <dt>Enabled Metrics</dt>
-        <dd>{{ctrl.serverGroup.asg.enabledMetrics.join(', ')}}</dd>
+        <dt ng-if="ctrl.enabledMetrics.length">Enabled Metrics</dt>
+        <dd ng-if="ctrl.enabledMetrics.length">{{ctrl.enabledMetrics.join(', ')}}</dd>
         <dt>Health Check Type</dt>
         <dd>{{ctrl.serverGroup.asg.healthCheckType}}</dd>
         <dt>Grace Period</dt>

--- a/app/scripts/modules/netflix/serverGroup/awsServerGroupDetails.html
+++ b/app/scripts/modules/netflix/serverGroup/awsServerGroupDetails.html
@@ -271,8 +271,8 @@
       <dl class="horizontal-when-filters-collapsed">
         <dt>Cooldown</dt>
         <dd>{{ctrl.serverGroup.asg.defaultCooldown}} seconds</dd>
-        <dt>Enabled Metrics</dt>
-        <dd>{{ctrl.serverGroup.asg.enabledMetrics.join(', ')}}</dd>
+        <dt ng-if="ctrl.enabledMetrics.length">Enabled Metrics</dt>
+        <dd ng-if="ctrl.enabledMetrics.length">{{ctrl.enabledMetrics.join(', ')}}</dd>
         <dt>Health Check Type</dt>
         <dd>{{ctrl.serverGroup.asg.healthCheckType}}</dd>
         <dt>Grace Period</dt>


### PR DESCRIPTION
The `enabledMetrics` field on an ASG is a list of objects, so we need to transform it to render properly in the UI.

Also fixing the option selector when editing an existing ASG.

Should fix https://github.com/spinnaker/spinnaker/issues/1575