### PR TITLE
feat(pipelines): provide observable to surface execution group updates

### DIFF
--- a/app/scripts/modules/core/delivery/filter/executionFilter.model.ts
+++ b/app/scripts/modules/core/delivery/filter/executionFilter.model.ts
@@ -4,6 +4,7 @@ import {extend} from 'lodash';
 
 import {ICache} from 'core/cache/deckCache.service';
 import {VIEW_STATE_CACHE_SERVICE, ViewStateCacheService} from 'core/cache/viewStateCache.service';
+import {Subject} from 'rxjs/Subject';
 
 export class ExecutionFilterModel {
   // Store count globally for 180 days
@@ -21,6 +22,7 @@ export class ExecutionFilterModel {
   public addTags: () => void;
   public clearFilters: () => void;
   public applyParamsToUrl: () => void;
+  public groupsUpdated: Subject<void> = new Subject<void>();
 
   static get $inject(): string[] { return ['$rootScope', 'filterModelService', 'urlParser', 'viewStateCache']; }
 

--- a/app/scripts/modules/core/delivery/filter/executionFilter.service.ts
+++ b/app/scripts/modules/core/delivery/filter/executionFilter.service.ts
@@ -52,6 +52,7 @@ export class ExecutionFilterService {
       waypointService.restoreToWaypoint(application.name);
       this.executionFilterModel.addTags();
       this.lastApplication = application;
+      executionFilterModel.groupsUpdated.next();
       return groups;
     }, 25);
   }


### PR DESCRIPTION
This is a short-term workaround to not using redux for our data stores.

I considered making this more like the `application.onRefresh` method, where you pass in a method and we handle the subscription internally, but, since we do the actual group updating outside the model, and, again, this is a short-term thing, let's just go with it, eh.