### PR TITLE
Pin `min` capacity to `desired`  capacity when rolling back

### DIFF
--- a/app/scripts/modules/amazon/serverGroup/details/rollback/rollbackServerGroup.html
+++ b/app/scripts/modules/amazon/serverGroup/details/rollback/rollbackServerGroup.html
@@ -42,13 +42,16 @@
           <ol>
             <li>Enable <em>{{ command.rollbackContext.restoreServerGroupName || 'previous server group' }}</em></li>
             <li>Resize <em>{{ command.rollbackContext.restoreServerGroupName || 'previous server group' }}</em> to [
-              <strong>min</strong>: {{serverGroup.capacity.min}},
+              <strong>min</strong>: {{serverGroup.capacity.desired}},
               <strong>max</strong>: {{ serverGroup.capacity.max }},
               <strong>desired</strong>: {{ serverGroup.capacity.desired }}
-            ]</li>
+            ]<br/>(minimum capacity pinned at {{serverGroup.capacity.desired}} to prevent autoscaling down during rollback)
+            </li>
             <li>Disable {{ serverGroup.name }}</li>
+            <li>Restore minimum capacity of <em>{{ command.rollbackContext.restoreServerGroupName || 'previous server group' }}</em> [
+              <strong>min</strong>: {{ serverGroup.capacity.min }}
+            ]</li>
           </ol>
-
           <p>
             This rollback will affect server groups in {{ serverGroup.account }} ({{ serverGroup.region }}).
           </p>


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/388652/25249967/ae9e74b2-25c8-11e7-9a39-88ffa913669a.png)
