### PR TITLE
feat(aws): Updating instance types to default new families

### DIFF
--- a/app/scripts/modules/amazon/instance/awsInstanceType.service.js
+++ b/app/scripts/modules/amazon/instance/awsInstanceType.service.js
@@ -12,62 +12,38 @@ module.exports = angular.module('spinnaker.aws.instanceType.service', [
 ])
   .factory('awsInstanceTypeService', function ($http, $q, API, infrastructureCaches) {
 
-    var m3 = {
-      type: 'm3',
+    var m4 = {
+      type: 'm4',
       description: 'This family includes the m3 instance types and provides a balance of compute, memory, and network resources, and it is a good choice for many applications.',
       instanceTypes: [
         {
-          name: 'm3.medium',
-          label: 'Medium',
-          cpu: 1,
-          memory: 3.75,
-          storage: {
-            type: 'SSD',
-            size: 4,
-            count: 1
-          },
+          name: 'm4.large',
+          label: 'Large',
+          cpu: 2,
+          memory: 8,
+          storage: { type: 'EBS' },
           costFactor: 1
         },
         {
-          name: 'm3.large',
-          label: 'Large',
-          cpu: 2,
-          memory: 7.5,
-          storage: {
-            type: 'SSD',
-            size: 32,
-            count: 1
-          },
-          costFactor: 2
-        },
-        {
-          name: 'm3.xlarge',
+          name: 'm4.xlarge',
           label: 'XLarge',
           cpu: 4,
-          memory: 15,
-          storage: {
-            type: 'SSD',
-            size: 40,
-            count: 2
-          },
+          memory: 16,
+          storage: { type: 'EBS' },
           costFactor: 2
         },
         {
-          name: 'm3.2xlarge',
+          name: 'm4.2xlarge',
           label: '2XLarge',
           cpu: 8,
-          memory: 30,
-          storage: {
-            type: 'SSD',
-            size: 80,
-            count: 2
-          },
-          costFactor: 3
+          memory: 32,
+          storage: { type: 'EBS' },
+          costFactor: 2
         }
       ]
     };
 
-    var t2 = {
+    var t2gp = {
       type: 't2',
       description: 't2 instances are a good choice for workloads that don’t use the full CPU often or consistently, but occasionally need to burst (e.g. web servers, developer environments and small databases).',
       instanceTypes: [
@@ -90,24 +66,37 @@ module.exports = angular.module('spinnaker.aws.instanceType.service', [
       ]
     };
 
-    var m3micro = {
-      type: 'm3',
-      description: 'This family includes the m3 instance types and provides a balance of compute, memory, and network resources, and it is a good choice for many applications.',
+    var t2 = {
+      type: 't2',
+      description: 't2 instances are a good choice for workloads that don’t use the full CPU often or consistently, but occasionally need to burst (e.g. web servers, developer environments and small databases).',
       instanceTypes: [
         {
-          name: 'm3.medium',
-          label: 'Medium',
+          name: 't2.nano',
+          label: 'Nano',
           cpu: 1,
-          memory: 3.75,
-          storage: {
-            type: 'SSD',
-            size: 4,
-            count: 1
-          },
+          memory: 0.5,
+          storage: { type: 'EBS' },
+          costFactor: 1
+        },
+        {
+          name: 't2.micro',
+          label: 'Micro',
+          cpu: 1,
+          memory: 1,
+          storage: { type: 'EBS' },
+          costFactor: 1
+        },
+        {
+          name: 't2.small',
+          label: 'Small',
+          cpu: 1,
+          memory: 2,
+          storage: { type: 'EBS' },
           costFactor: 1
         }
       ]
     };
+
 
     var r3 = {
       type: 'r3',
@@ -168,7 +157,7 @@ module.exports = angular.module('spinnaker.aws.instanceType.service', [
       {
         type: 'general',
         label: 'General Purpose',
-        families: [ m3 ],
+        families: [ m4, t2gp ],
         icon: 'hdd'
       },
       {
@@ -180,7 +169,7 @@ module.exports = angular.module('spinnaker.aws.instanceType.service', [
       {
         type: 'micro',
         label: 'Micro Utility',
-        families: [t2, m3micro],
+        families: [t2],
         icon: 'hdd'
       },
       {


### PR DESCRIPTION
Updating `r3 -> r4` family has been postponed into May. When r4 comes around, I'll replace the `SSD Storage` column with the default root EBS volume size, as no instance family will be using instance storage.

<img width="638" alt="screen shot 2017-04-20 at 1 19 55 pm" src="https://cloud.githubusercontent.com/assets/108741/25250919/63c8bfac-25cc-11e7-9088-57aded42e937.png">

<img width="645" alt="screen shot 2017-04-20 at 1 20 02 pm" src="https://cloud.githubusercontent.com/assets/108741/25250922/6564f358-25cc-11e7-8ee2-44a0e28b3a92.png">

@spinnaker/netflix-reviewers PTAL