### PR TITLE
feat(kubernetes): Allow Run Job trigger tag

### DIFF
--- a/app/scripts/modules/kubernetes/pipeline/stages/runJob/runJobExecutionDetails.html
+++ b/app/scripts/modules/kubernetes/pipeline/stages/runJob/runJobExecutionDetails.html
@@ -9,7 +9,12 @@
           <dt>Namespace</dt>
           <dd>{{stage.context.namespace}}</dd>
           <dt>Image</dt>
-          <dd>{{[stage.context.container.imageDescription.repository, stage.context.container.imageDescription.tag].join(':')}}</dd>
+          <dd ng-if="!stage.context.container.imageDescription.fromTrigger">
+            {{[stage.context.container.imageDescription.repository, stage.context.container.imageDescription.tag].join(':')}}
+          </dd>
+          <dd ng-if="stage.context.container.imageDescription.fromTrigger">
+            {{[stage.context.container.imageDescription.repository, execution.trigger.tag].join(':')}}
+          </dd>
         </dl>
       </div>
     </div>

--- a/app/scripts/modules/kubernetes/pipeline/stages/runJob/runJobStage.html
+++ b/app/scripts/modules/kubernetes/pipeline/stages/runJob/runJobStage.html
@@ -19,17 +19,43 @@
   </stage-config-field>
 
   <stage-config-field label="Image">
-    <docker-image-and-tag-selector
-      specify-tag-by-regex="false"
-      account="ctrl.stage.container.imageDescription.account"
-      organization="ctrl.stage.container.imageDescription.organization"
-      registry="ctrl.stage.container.imageDescription.registry"
-      repository="ctrl.stage.container.imageDescription.repository"
-      tag="ctrl.stage.container.imageDescription.tag"
-      show-registry="true"
-      on-change="ctrl.onChange"></docker-image-and-tag-selector>
+    <div class="form-group" ng-if="ctrl.hasDockerPipelineTriggers()">
+      <div>
+        <label class="sm-label">
+          Resolve from Trigger
+        </label>
+        <input type="checkbox"
+               style="margin-left: 20px"
+               ng-model="ctrl.stage.container.imageDescription.fromTrigger"/>
+      </div>
+    </div>
+    <div ng-if="!ctrl.stage.container.imageDescription.fromTrigger">
+      <docker-image-and-tag-selector
+        specify-tag-by-regex="false"
+        account="ctrl.stage.container.imageDescription.account"
+        organization="ctrl.stage.container.imageDescription.organization"
+        registry="ctrl.stage.container.imageDescription.registry"
+        repository="ctrl.stage.container.imageDescription.repository"
+        tag="ctrl.stage.container.imageDescription.tag"
+        show-registry="true"
+        on-change="ctrl.onChange"></docker-image-and-tag-selector>
+    </div>
+    <div ng-if="ctrl.stage.container.imageDescription.fromTrigger" class="form-group">
+        <div class="sm-label-right col-md-3">
+        Trigger
+        </div>
+        <div class="col-md-9">
+          <ui-select ng-model="ctrl.container"
+                    class="form-control input-sm"
+                    ng-change="ctrl.updateContainerImage()" required>
+            <ui-select-match>{{ctrl.container}}</ui-select-match>
+            <ui-select-choices repeat="image in ctrl.triggerImages() | filter: $select.search | orderBy">
+              <span ng-bind-html="image | highlight: $select.search"></span>
+            </ui-select-choices>
+          </ui-select>
+        </div>
+    </div>
   </stage-config-field>
-
   <stage-config-field label="Commands" help-key="kubernetes.containers.command">
     <kubernetes-container-commands commands="ctrl.stage.container.command">
     </kubernetes-container-commands>

--- a/app/scripts/modules/kubernetes/pipeline/stages/runJob/runJobStage.js
+++ b/app/scripts/modules/kubernetes/pipeline/stages/runJob/runJobStage.js
@@ -23,13 +23,44 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.kubernetes.runJob
       validators: [
         { type: 'requiredField', fieldName: 'account' },
         { type: 'requiredField', fieldName: 'namespace' },
-        { type: 'requiredField', fieldName: 'container.imageDescription.tag', fieldLabel: 'tag' },
+        { type: 'custom', validate: (_pipeline, stage) => {
+          let response = null;
+
+          if (stage.container.imageDescription.fromTrigger === false && !stage.container.imageDescription.tag) {
+            response = '<strong>Tag</strong> is a required field for Run Job stages.';
+          } else if (stage.container.imageDescription.fromTrigger === true && !stage.container.imageDescription.registry) {
+            response = '<strong>Trigger</strong> is a required field for Run Job stages.';
+          }
+
+          return response;
+        }},
       ]
     });
   }).controller('kubernetesRunJobStageCtrl', function($scope, accountService) {
+
     this.stage = $scope.stage;
+    this.pipeline = $scope.pipeline;
+    this.container = null;
+
+    const buildImageDescriptor = (image) => {
+      let descriptor = `${image.account}/${image.repository}`;
+      if (image.tag) {
+        descriptor += `:${image.tag}`;
+      }
+      return descriptor;
+    };
+
     if (!_.has(this.stage, 'container.name')) {
       _.set(this.stage, 'container.name', Date.now().toString());
+    }
+
+    if (!_.has(this.stage, 'container.imageDescription.fromTrigger')) {
+      _.set(this.stage, 'container.imageDescription.fromTrigger', false);
+    }
+
+
+    if (this.stage.container.imageDescription.fromTrigger === true) {
+      this.container = buildImageDescriptor(this.stage.container.imageDescription);
     }
 
     accountService.getUniqueAttributeForAllAccounts('kubernetes', 'namespaces')
@@ -52,4 +83,39 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.kubernetes.runJob
     this.onChange = (changes) => {
       this.stage.container.imageDescription.registry = changes.registry;
     };
+
+    this.triggerImages = () => {
+
+      if (this.pipeline.triggers.length <= 0) {
+        return [];
+      }
+
+      return this.pipeline.triggers.filter((trigger) => {
+        return trigger.type === 'docker' && trigger.enabled === true;
+      }).map((trigger) => {
+        return buildImageDescriptor(trigger);
+      });
+    };
+
+    this.hasDockerPipelineTriggers = () => {
+      return this.triggerImages().length > 0;
+    };
+
+    this.updateContainerImage = () => {
+
+      const trigger = this.pipeline.triggers.find((trigger) => buildImageDescriptor(trigger) === this.container);
+
+      if (trigger) {
+        this.stage.container.imageDescription.account = trigger.account;
+        this.stage.container.imageDescription.organization = trigger.organization;
+        this.stage.container.imageDescription.repository = trigger.repository;
+        this.stage.container.imageDescription.registry = trigger.registry;
+        if (trigger.tag) {
+          this.stage.container.imageDescription.tag = trigger.tag;
+        } else {
+          this.stage.container.imageDescription.tag = null;
+        }
+      }
+    };
+
   });


### PR DESCRIPTION
Support resolving Run Job container tags from triggers. There are a
couple of things that can be improved here but this is basic
implementation. One thing to think about is what happens if there are 2
docker triggers and the pipeline is triggered by one that isn't used for
this job. What happens?

Changes include:

* Checkbox for selecting if you want to resolve from trigger
* If the box is checked, a list of Docker triggers is presented
* The Run Job Execution Details will not print the tag is it's from a
  trigger

Fixes [#1566](https://github.com/spinnaker/spinnaker/issues/1566)