### PR TITLE
refactor(pipelines): convert wait/execution window actions to React

### DIFF
--- a/app/scripts/modules/core/config/settings.ts
+++ b/app/scripts/modules/core/config/settings.ts
@@ -80,6 +80,7 @@ export const SETTINGS: ISpinnakerSettings = (<any>window).spinnakerSettings;
 SETTINGS.feature = SETTINGS.feature || {};
 SETTINGS.analytics = SETTINGS.analytics || {};
 SETTINGS.providers = SETTINGS.providers || {};
+SETTINGS.defaultTimeZone = SETTINGS.defaultTimeZone || 'America/Los_Angeles';
 
 // A helper to make resetting settings to steady state after running tests easier
 const originalSettings: ISpinnakerSettings = cloneDeep(SETTINGS);

--- a/app/scripts/modules/core/core.module.js
+++ b/app/scripts/modules/core/core.module.js
@@ -24,18 +24,19 @@ import {REPLACE_FILTER} from './filter/replace.filter';
 
 require('../../../fonts/spinnaker/icons.css');
 
-require('Select2');
-require('jquery-ui');
+import 'Select2';
+import 'jquery-ui';
 // Must come after jquery-ui - we want the bootstrap tooltip, JavaScript is fun
-require('bootstrap/dist/js/bootstrap.js');
-require('bootstrap/dist/css/bootstrap.css');
-require('select2-bootstrap-css/select2-bootstrap.css');
-require('Select2/select2.css');
-require('ui-select/dist/select.css');
+import 'bootstrap/dist/js/bootstrap.js';
+import 'bootstrap/dist/css/bootstrap.css';
+import 'select2-bootstrap-css/select2-bootstrap.css';
+import 'Select2/select2.css';
+import 'ui-select/dist/select.css';
 
-require('source-sans-pro');
+import 'source-sans-pro';
 
-require('font-awesome/css/font-awesome.css');
+import 'font-awesome/css/font-awesome.css';
+import 'react-select/dist/react-select.css';
 
 // load all templates into the $templateCache
 var templates = require.context('./', true, /\.html$/);

--- a/app/scripts/modules/core/delivery/executionGroup/execution/execution.less
+++ b/app/scripts/modules/core/delivery/executionGroup/execution/execution.less
@@ -1,6 +1,6 @@
 @import "../../../presentation/less/imports/commonImports.less";
 
-execution {
+.execution {
   .label {
     text-transform: uppercase;
     border-radius: 0;

--- a/app/scripts/modules/core/delivery/triggers/NextRunTag.tsx
+++ b/app/scripts/modules/core/delivery/triggers/NextRunTag.tsx
@@ -32,7 +32,7 @@ export class NextRunTag extends React.Component<IProps, IState> {
         const hours = parts[2];
         if (!isNaN(parseInt(hours, 10))) {
           const allHours = hours.split('/');
-          const tz = SETTINGS.defaultTimeZone || 'America/Los_Angeles';
+          const tz = SETTINGS.defaultTimeZone;
           let offset = moment.tz.zone(tz).offset(Date.now());
           if (offset) {
             offset /= 60;

--- a/app/scripts/modules/core/pipeline/config/stages/executionWindows/ExecutionWindowActions.tsx
+++ b/app/scripts/modules/core/pipeline/config/stages/executionWindows/ExecutionWindowActions.tsx
@@ -1,0 +1,115 @@
+import * as React from 'react';
+
+import {IExecution, IExecutionStage} from 'core/domain';
+import {ButtonBusyIndicator} from 'core/forms/buttonBusyIndicator/ButtonBusyIndicator';
+import {Application} from 'core/application/application.model';
+import {confirmationModalService} from 'core/confirmationModal/confirmationModal.service';
+import {executionService} from 'core/delivery/service/execution.service';
+import {timePickerTime} from 'core/utils/timeFormatters';
+import {SystemTimezone} from 'core/utils/SystemTimezone';
+import {DAYS_OF_WEEK} from './daysOfWeek';
+
+interface IProps {
+  execution: IExecution;
+  stage: IExecutionStage;
+  application: Application;
+}
+
+interface IState {
+  submitting: boolean;
+  dayText: string;
+}
+
+interface IExecutionWindowWhitelistEntry {
+  startHour: number;
+  startMin: number;
+  endHour: number;
+  endMin: number;
+}
+
+export class ExecutionWindowActions extends React.Component<IProps, IState> {
+  constructor(props: IProps) {
+    super(props);
+    const days = props.stage.context.restrictedExecutionWindow.days;
+    let dayText = 'Everyday';
+    if (days && days.length > 0) {
+      dayText = this.replaceDays(days).join(', ');
+    }
+    this.state = {
+      submitting: false,
+      dayText: dayText,
+    };
+  }
+
+  private finishWaiting = (): void => {
+    const stage = this.props.stage,
+          executionId = this.props.execution.id;
+
+    const matcher = (execution: IExecution) => {
+      const match = execution.stages.find((test) => test.id === stage.id);
+      return match.status !== 'RUNNING';
+    };
+
+    const data = {skipRemainingWait: true};
+    confirmationModalService.confirm({
+      header: 'Really skip execution window?',
+      buttonText: 'Skip',
+      body: '<p>The pipeline will proceed immediately, continuing to the next step in the stage.</p>',
+      submitMethod: () => {
+        this.setState({submitting: true});
+        return executionService.patchExecution(executionId, stage.id, data)
+          .then(() => executionService.waitUntilExecutionMatches(executionId, matcher));
+      }
+    });
+  };
+
+  private replaceDays(days: number[]): string[] {
+    const daySet = new Set(days);
+    return DAYS_OF_WEEK.filter(day => daySet.has(day.ordinal)).map(day => day.label);
+  }
+
+  public render() {
+    const stage = this.props.stage;
+    return (
+      <div>
+        <h5>Execution Windows Configuration</h5>
+        <strong>Stage execution can only run:</strong>
+        <dl className="dl-narrow dl-horizontal">
+          {stage.context.restrictedExecutionWindow.whitelist.map((entry: IExecutionWindowWhitelistEntry, index: number) => {
+            return (
+              <div key={index}>
+                <dt>From</dt>
+                <dd>
+                  {timePickerTime({hours: entry.startHour, minutes: entry.startMin})}
+                  <strong style={{display: 'inline-block', margin: '0 5px'}}> to </strong>
+                  {timePickerTime({hours: entry.endHour, minutes: entry.endMin})}
+                  <strong> <SystemTimezone/> </strong>
+                </dd>
+              </div>
+            );
+          })}
+          <dt>On</dt>
+          <dd>{this.state.dayText}</dd>
+        </dl>
+        {stage.context.skipRemainingWait && (
+          <div>
+            <span>(skipped </span>
+            {stage.context.lastModifiedBy && (
+              <span> by {stage.context.lastModifiedBy}</span>
+            )}
+            )
+          </div>
+        )}
+        {stage.isSuspended && (
+          <button className="btn btn-xs btn-primary" onClick={this.finishWaiting}>
+            {this.state.submitting && (<ButtonBusyIndicator/>)}
+            {!this.state.submitting && (
+              <span style={{marginRight: '5px'}} className="small glyphicon glyphicon-fast-forward"/>
+            )}
+            Skip remaining window
+          </button>
+        )}
+      </div>
+    );
+  }
+}

--- a/app/scripts/modules/core/pipeline/config/stages/executionWindows/atlasGraph.component.ts
+++ b/app/scripts/modules/core/pipeline/config/stages/executionWindows/atlasGraph.component.ts
@@ -253,7 +253,7 @@ class ExecutionWindowAtlasGraphController implements ng.IComponentController {
 
   private createWindow(window: IExecutionWindow, dayOffset: number): IWindowData {
     const today = new Date();
-    const zone: string = SETTINGS.defaultTimeZone || 'America/Los_Angeles';
+    const zone: string = SETTINGS.defaultTimeZone;
 
     const start = momentTimezone.tz(today, zone)
         .hour(window.displayStart.getHours())

--- a/app/scripts/modules/core/pipeline/config/stages/executionWindows/executionWindowActions.component.ts
+++ b/app/scripts/modules/core/pipeline/config/stages/executionWindows/executionWindowActions.component.ts
@@ -1,0 +1,8 @@
+import {module} from 'angular';
+import {react2angular} from 'react2angular';
+
+import {ExecutionWindowActions} from './ExecutionWindowActions';
+
+export const EXECUTION_WINDOW_ACTIONS_COMPONENT = 'spinnaker.core.pipeline.config.stages.executionWindowActions.component';
+module(EXECUTION_WINDOW_ACTIONS_COMPONENT, [])
+  .component('executionWindowActions', react2angular(ExecutionWindowActions, ['execution', 'stage', 'application']));

--- a/app/scripts/modules/core/pipeline/config/stages/executionWindows/executionWindowsDetails.controller.js
+++ b/app/scripts/modules/core/pipeline/config/stages/executionWindows/executionWindowsDetails.controller.js
@@ -1,9 +1,7 @@
 'use strict';
 
-import {DAYS_OF_WEEK} from './daysOfWeek';
-import {CONFIRMATION_MODAL_SERVICE} from 'core/confirmationModal/confirmationModal.service';
 import {EXECUTION_DETAILS_SECTION_SERVICE} from 'core/delivery/details/executionDetailsSection.service';
-import {EXECUTION_SERVICE} from 'core/delivery/service/execution.service';
+import {EXECUTION_WINDOW_ACTIONS_COMPONENT} from './executionWindowActions.component';
 
 let angular = require('angular');
 
@@ -11,60 +9,14 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.executionWindows.
   require('angular-ui-router'),
   EXECUTION_DETAILS_SECTION_SERVICE,
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),
-  EXECUTION_SERVICE,
-  CONFIRMATION_MODAL_SERVICE,
+  EXECUTION_WINDOW_ACTIONS_COMPONENT
 ])
-  .controller('ExecutionWindowsDetailsCtrl', function ($scope, $stateParams, executionDetailsSectionService, executionService, confirmationModalService) {
+  .controller('ExecutionWindowsDetailsCtrl', function ($scope, $stateParams, executionDetailsSectionService) {
 
     $scope.configSections = ['windowConfig', 'taskStatus'];
 
     let initialized = () => {
       $scope.detailsSection = $stateParams.details;
-      $scope.dayText = getDayText();
-    };
-
-    // yes, this is ugly - when we replace the execution window w/ an ng2 component, this will go away.  i promise
-    function replaceDays(days) {
-      const daySet = new Set(days);
-      return DAYS_OF_WEEK.filter(day => daySet.has(day.ordinal)).map(day => day.label);
-    }
-
-    // ditto
-    function getDayText() {
-      let dayText = 'Everyday';
-      const days = $scope.stage.context.restrictedExecutionWindow.days;
-      if (days && (days.length > 0)) {
-        const daysAsText = replaceDays(days);
-        dayText = daysAsText.join(', ');
-      }
-
-      return dayText;
-    }
-
-    this.finishWaiting = () => {
-      let stage = $scope.stage;
-      let matcher = (execution) => {
-        let match = execution.stages.find((test) => test.id === stage.id);
-        return match.status !== 'RUNNING';
-      };
-
-      let data = {skipRemainingWait: true};
-      confirmationModalService.confirm({
-        header: 'Really skip execution window?',
-        buttonText: 'Skip',
-        body: '<p>The pipeline will proceed immediately, continuing to the next step in the stage.</p>',
-        submitMethod: () => {
-          return executionService.patchExecution($scope.execution.id, $scope.stage.id, data)
-            .then(() => executionService.waitUntilExecutionMatches($scope.execution.id, matcher))
-            .then(() => {
-              executionService.getExecution($scope.execution.id).then(execution => {
-                if (!$scope.$$destroyed) {
-                  executionService.updateExecution($scope.application, execution);
-                }
-              });
-            });
-        }
-      });
     };
 
     let initialize = () => executionDetailsSectionService.synchronizeSection($scope.configSections, initialized);

--- a/app/scripts/modules/core/pipeline/config/stages/executionWindows/executionWindowsDetails.html
+++ b/app/scripts/modules/core/pipeline/config/stages/executionWindows/executionWindowsDetails.html
@@ -1,44 +1,12 @@
 <div ng-controller="ExecutionWindowsDetailsCtrl as ctrl">
   <execution-details-section-nav sections="configSections"></execution-details-section-nav>
   <div class="step-section-details" ng-if="detailsSection === 'windowConfig'">
-    <div class="row">
-      <div class="col-md-12">
-        <h5>Execution Windows Configuration</h5>
-        <strong>Stage execution can only run:</strong>
-        <dl class="dl-narrow dl-horizontal">
-          <div ng-repeat="window in stage.context.restrictedExecutionWindow.whitelist">
-            <dt>From</dt>
-            <dd>
-              {{ {hours: window.startHour, minutes: window.startMin} | timePickerTime }}
-              <strong>&nbsp;to&nbsp;</strong>
-              {{ {hours: window.endHour, minutes: window.endMin} | timePickerTime }}
-              <strong>&nbsp;<system-timezone></system-timezone></strong>
-            </dd>
-          </div>
-          <dt>On</dt>
-          <dd>{{ ::dayText }}</dd>
-        </dl>
-      </div>
-    </div>
-    <div class="row" ng-if="stage.context.skipRemainingWait">
-      <div class="col-md-12">
-        (skipped
-        <span ng-if="stage.context.lastModifiedBy">by {{stage.context.lastModifiedBy}}</span>)
-      </div>
-    </div>
-    <div class="row" ng-if="stage.isSuspended">
-      <div class="col-md-12">
-        <button class="btn btn-xs btn-primary" ng-click="ctrl.finishWaiting()">
-          <span style="margin-right: 5px" class="small glyphicon glyphicon-fast-forward"></span>
-          Skip remaining window
-        </button>
-      </div>
-    </div>
+    <execution-window-actions application="application" execution="execution" stage="stage"></execution-window-actions>
   </div>
 
-    <div class="step-section-details" ng-if="detailsSection === 'taskStatus'">
-      <div class="row">
-        <execution-step-details item="stage"></execution-step-details>
-      </div>
+  <div class="step-section-details" ng-if="detailsSection === 'taskStatus'">
+    <div class="row">
+      <execution-step-details item="stage"></execution-step-details>
     </div>
+  </div>
 </div>

--- a/app/scripts/modules/core/pipeline/config/stages/manualJudgment/ManualJudgmentApproval.tsx
+++ b/app/scripts/modules/core/pipeline/config/stages/manualJudgment/ManualJudgmentApproval.tsx
@@ -1,7 +1,6 @@
 import {IPromise} from 'angular';
 import * as React from 'react';
 import * as Select from 'react-select';
-import 'react-select/dist/react-select.css';
 
 import {IExecution} from 'core/domain/IExecution';
 import {IExecutionStage} from 'core/domain/IExecutionStage';
@@ -30,7 +29,7 @@ export class ManualJudgmentApproval extends React.Component<IProps, IState> {
       judgmentDecision: null,
       judgmentInput: {},
       error: false,
-    }
+    };
   }
 
   private provideJudgment(judgmentDecision: string): IPromise<void> {

--- a/app/scripts/modules/core/pipeline/config/stages/wait/SkipWait.tsx
+++ b/app/scripts/modules/core/pipeline/config/stages/wait/SkipWait.tsx
@@ -1,0 +1,99 @@
+import * as React from 'react';
+
+import {IExecution, IExecutionStage} from 'core/domain';
+import {ButtonBusyIndicator} from 'core/forms/buttonBusyIndicator/ButtonBusyIndicator';
+import {Application} from 'core/application/application.model';
+import {confirmationModalService} from 'core/confirmationModal/confirmationModal.service';
+import {executionService} from 'core/delivery/service/execution.service';
+import {duration} from 'core/utils/timeFormatters';
+import {OrchestratedItemRunningTime} from 'core/delivery/executionGroup/execution/OrchestratedItemRunningTime';
+
+interface IProps {
+  execution: IExecution;
+  stage: IExecutionStage;
+  application: Application;
+}
+
+interface IState {
+  submitting: boolean;
+  remainingWait?: string;
+}
+
+export class SkipWait extends React.Component<IProps, IState> {
+  private runningTime: OrchestratedItemRunningTime;
+
+  constructor(props: IProps) {
+    super(props);
+    this.state = {
+      submitting: false,
+    };
+  }
+
+  private setRemainingWait = (time: number): void => {
+    this.setState({remainingWait: duration(this.props.stage.context.waitTime * 1000 - time) });
+  };
+
+  private skipRemainingWait = (): void => {
+    const stage = this.props.stage;
+    const matcher = (execution: IExecution) => {
+      const match = execution.stages.find((test) => test.id === stage.id);
+      return match.status !== 'RUNNING';
+    };
+
+    const data = { skipRemainingWait: true };
+    confirmationModalService.confirm({
+      header: 'Really skip wait?',
+      buttonText: 'Skip',
+      body: '<p>The pipeline will proceed immediately, marking this stage completed.</p>',
+      submitMethod: () => {
+        this.setState({submitting: true});
+        return executionService.patchExecution(this.props.execution.id, stage.id, data)
+          .then(() => executionService.waitUntilExecutionMatches(this.props.execution.id, matcher));
+      }
+    });
+  };
+
+  public componentDidMount() {
+    this.runningTime = new OrchestratedItemRunningTime(this.props.stage, (time: number) => this.setRemainingWait(time));
+  }
+
+  public componentWillReceiveProps() {
+    this.runningTime.checkStatus();
+  }
+
+  public componentWillUnmount() {
+    this.runningTime.reset();
+  }
+
+  public render() {
+    const stage = this.props.stage;
+    return (
+      <div>
+        <div>
+          <b>Wait time: </b>
+          {stage.context.waitTime} seconds
+          { stage.context.skipRemainingWait && (
+            <span>(skipped after {duration(stage.runningTimeInMs)})</span>
+          )}
+        </div>
+        { stage.isRunning && (
+          <div>
+            <div>
+              <b>Remaining: </b>
+              {this.state.remainingWait}
+            </div>
+            <div>
+              <button className="btn btn-xs btn-primary" onClick={this.skipRemainingWait}>
+                {this.state.submitting && (<ButtonBusyIndicator/>)}
+                {!this.state.submitting && (
+                  <span style={{marginRight: '5px'}} className="small glyphicon glyphicon-fast-forward"/>
+                )}
+                Skip remaining wait
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    )
+  }
+}

--- a/app/scripts/modules/core/pipeline/config/stages/wait/skipWait.component.ts
+++ b/app/scripts/modules/core/pipeline/config/stages/wait/skipWait.component.ts
@@ -1,0 +1,8 @@
+import {module} from 'angular';
+import {react2angular} from 'react2angular';
+
+import {SkipWait} from './SkipWait';
+
+export const SKIP_WAIT_COMPONENT = 'spinnaker.core.pipeline.config.stages.wait.component';
+module(SKIP_WAIT_COMPONENT, [])
+  .component('skipWaitSelector', react2angular(SkipWait, ['execution', 'stage', 'application']));

--- a/app/scripts/modules/core/pipeline/config/stages/wait/waitExecutionDetails.controller.js
+++ b/app/scripts/modules/core/pipeline/config/stages/wait/waitExecutionDetails.controller.js
@@ -1,8 +1,7 @@
 'use strict';
 
-import {CONFIRMATION_MODAL_SERVICE} from 'core/confirmationModal/confirmationModal.service';
 import {EXECUTION_DETAILS_SECTION_SERVICE} from 'core/delivery/details/executionDetailsSection.service';
-import {EXECUTION_SERVICE} from 'core/delivery/service/execution.service';
+import {SKIP_WAIT_COMPONENT} from './skipWait.component';
 
 let angular = require('angular');
 
@@ -10,38 +9,14 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.wait.executionDet
   require('angular-ui-router'),
   EXECUTION_DETAILS_SECTION_SERVICE,
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),
-  EXECUTION_SERVICE,
-  CONFIRMATION_MODAL_SERVICE,
+  SKIP_WAIT_COMPONENT,
 ])
-  .controller('WaitExecutionDetailsCtrl', function ($scope, $stateParams, executionDetailsSectionService, executionService, confirmationModalService) {
+  .controller('WaitExecutionDetailsCtrl', function ($scope, $stateParams, executionDetailsSectionService) {
 
     $scope.configSections = ['waitConfig', 'taskStatus'];
 
     let initialized = () => {
       $scope.detailsSection = $stateParams.details;
-    };
-
-    this.getRemainingWait = () => {
-      return $scope.stage.context.waitTime * 1000 - $scope.stage.runningTimeInMs;
-    };
-
-    this.finishWaiting = () => {
-      let stage = $scope.stage;
-      let matcher = (execution) => {
-        let match = execution.stages.find((test) => test.id === stage.id);
-        return match.status !== 'RUNNING';
-      };
-
-      let data = { skipRemainingWait: true };
-      confirmationModalService.confirm({
-        header: 'Really skip wait?',
-        buttonText: 'Skip',
-        body: '<p>The pipeline will proceed immediately, marking this stage completed.</p>',
-        submitMethod: () => {
-          return executionService.patchExecution($scope.execution.id, $scope.stage.id, data)
-            .then(() => executionService.waitUntilExecutionMatches($scope.execution.id, matcher));
-        }
-      });
     };
 
     let initialize = () => executionDetailsSectionService.synchronizeSection($scope.configSections, initialized);

--- a/app/scripts/modules/core/pipeline/config/stages/wait/waitExecutionDetails.html
+++ b/app/scripts/modules/core/pipeline/config/stages/wait/waitExecutionDetails.html
@@ -1,28 +1,7 @@
 <div ng-controller="WaitExecutionDetailsCtrl as ctrl">
   <execution-details-section-nav sections="configSections"></execution-details-section-nav>
   <div class="step-section-details" ng-if="detailsSection === 'waitConfig'">
-    <div class="row">
-      <div class="col-md-12">
-        <dl class="dl-narrow dl-horizontal">
-          <dt>Wait Time</dt>
-          <dd>
-            {{stage.context.waitTime}} seconds
-            <span ng-if="stage.context.skipRemainingWait"> (skipped after {{stage.runningTimeInMs | duration}})</span>
-          </dd>
-          <dt ng-if="stage.isRunning">Remaining</dt>
-          <dd ng-if="stage.isRunning">
-            {{ctrl.getRemainingWait() | duration }}
-            <div>
-              <button class="btn btn-xs btn-primary" ng-click="ctrl.finishWaiting()">
-                <span style="margin-right: 5px" class="small glyphicon glyphicon-fast-forward"></span>
-                Skip remaining wait
-              </button>
-            </div>
-          </dd>
-        </dl>
-      </div>
-    </div>
-
+    <skip-wait-selector application="application" execution="execution" stage="stage"></skip-wait-selector>
     <stage-failure-message stage="stage" message="stage.failureMessage"></stage-failure-message>
 
     <div class="row" ng-if="stage.context.execution.logs">

--- a/app/scripts/modules/core/utils/SystemTimezone.tsx
+++ b/app/scripts/modules/core/utils/SystemTimezone.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import * as moment from 'moment';
+
+import { SETTINGS } from 'core/config/settings';
+
+export class SystemTimezone extends React.Component<any, any> {
+  public render() {
+    const zone = SETTINGS.defaultTimeZone;
+    return (<span>{moment.tz(Date.now(), zone).zoneAbbr()}</span>);
+  }
+}

--- a/app/scripts/modules/core/utils/timeFormatters.ts
+++ b/app/scripts/modules/core/utils/timeFormatters.ts
@@ -1,7 +1,10 @@
-import { IComponentController, IComponentOptions, module } from 'angular';
+import { module } from 'angular';
 import * as moment from 'moment';
+import { react2angular } from 'react2angular';
 
 import { SETTINGS } from 'core/config/settings';
+
+import { SystemTimezone } from './SystemTimezone';
 
 const isInputValid = (input: any) => !(!input || isNaN(input) || input < 0);
 
@@ -25,7 +28,7 @@ export function timestamp(input: any) {
   if (!isInputValid(input)) {
     return '-';
   }
-  const tz = SETTINGS.defaultTimeZone || 'America/Los_Angeles';
+  const tz = SETTINGS.defaultTimeZone;
   const thisMoment = moment.tz(parseInt(input, 10), tz);
   return thisMoment.isValid() ? thisMoment.format('YYYY-MM-DD HH:mm:ss z') : '-';
 }
@@ -67,18 +70,6 @@ export function timePickerTime(input: any) {
   return '-';
 }
 
-export class SystemTimeZoneController implements IComponentController {
-  public tz: string;
-  constructor() {
-    const zone = SETTINGS.defaultTimeZone || 'America/Los_Angeles';
-    this.tz = moment.tz(new Date().getTime(), zone).zoneAbbr();
-  }
-}
-export class SystemTimeZoneComponent implements IComponentOptions {
-  public controller: any = SystemTimeZoneController;
-  public template = `<span ng-bind="$ctrl.tz"></span>`;
-}
-
 export const TIME_FORMATTERS = 'spinnaker.core.utils.timeFormatters';
 module(TIME_FORMATTERS, [])
   .filter('timestamp', () => timestamp)
@@ -86,4 +77,4 @@ module(TIME_FORMATTERS, [])
   .filter('duration', () => duration)
   .filter('fastPropertyTime', () => fastPropertyTime)
   .filter('timePickerTime', () => timePickerTime)
-  .component('systemTimezone', new SystemTimeZoneComponent());
+  .component('systemTimezone', react2angular(SystemTimezone));


### PR DESCRIPTION
Nothing exciting here, just moving logic out of execution details and into React.

One thing that's not clear to me is when to put things on the `state` and when to make things private methods/fields on the component class. Would appreciate feedback on that...