### PR TITLE
fix(pipelines): avoid NPE rendering execution groups

### DIFF
--- a/app/scripts/modules/core/delivery/executionGroup/ExecutionGroup.tsx
+++ b/app/scripts/modules/core/delivery/executionGroup/ExecutionGroup.tsx
@@ -8,6 +8,7 @@ import autoBindMethods from 'class-autobind-decorator';
 
 import { AccountLabelColor } from 'core/account/AccountLabelColor';
 import { Application } from 'core/application/application.model';
+import { IPipeline } from 'core/domain/IPipeline';
 import { Execution } from './execution/Execution';
 import { IExecution, IExecutionGroup, IPipelineCommand } from 'core/domain';
 import { NextRunTag } from 'core/delivery/triggers/NextRunTag';
@@ -31,7 +32,7 @@ interface IProps {
 
 interface IState {
   deploymentAccounts: string[];
-  pipelineConfig: any;
+  pipelineConfig: IPipeline;
   triggeringExecution: boolean;
   open: boolean;
   poll: IPromise<any>;
@@ -42,16 +43,16 @@ interface IState {
 
 @autoBindMethods
 export class ExecutionGroup extends React.Component<IProps, IState> {
-  private strategyConfig: any;
+  private strategyConfig: IPipeline;
   private expandUpdatedSubscription: Subscription;
   private stateChangeSuccessSubscription: Subscription;
 
   constructor(props: IProps) {
     super(props);
 
-    this.strategyConfig = find(this.props.application.strategyConfigs.data, { name: this.props.group.heading });
+    this.strategyConfig = find(this.props.application.strategyConfigs.data, { name: this.props.group.heading }) as IPipeline;
 
-    const pipelineConfig = find(this.props.application.pipelineConfigs.data, { name: this.props.group.heading });
+    const pipelineConfig = find(this.props.application.pipelineConfigs.data, { name: this.props.group.heading }) as IPipeline;
     const sectionCacheKey = this.getSectionCacheKey();
 
     this.state = {
@@ -191,8 +192,8 @@ export class ExecutionGroup extends React.Component<IProps, IState> {
                 </h4>
                 { this.state.canConfigure && (
                   <div className="text-right execution-group-actions">
-                    <TriggersTag pipeline={pipelineConfig}/>
-                    <NextRunTag pipeline={pipelineConfig}/>
+                    { pipelineConfig && <TriggersTag pipeline={pipelineConfig}/>}
+                    { pipelineConfig && <NextRunTag pipeline={pipelineConfig}/>}
                     <h4>
                       <a className="btn btn-xs btn-link" onClick={this.handleConfigureClicked}>
                         <span className="glyphicon glyphicon-cog"/>

--- a/app/scripts/modules/core/delivery/executionGroup/executionGroup.less
+++ b/app/scripts/modules/core/delivery/executionGroup/executionGroup.less
@@ -31,7 +31,6 @@
     color: #ffffff;
     background-color: #777;
     text-transform: uppercase;
-    min-width: 72px;
     text-align: center;
     &.account-tag-prod {
       background-color: @unhealthy_red;

--- a/app/scripts/modules/core/domain/IPipeline.ts
+++ b/app/scripts/modules/core/domain/IPipeline.ts
@@ -3,6 +3,7 @@ import {ITrigger} from './ITrigger';
 
 export interface IPipeline {
   application: string;
+  description?: string;
   executionEngine: string;
   id: string;
   index: number;

--- a/app/scripts/modules/core/pipeline/config/services/pipelineConfig.service.ts
+++ b/app/scripts/modules/core/pipeline/config/services/pipelineConfig.service.ts
@@ -1,4 +1,4 @@
-import {module} from 'angular';
+import {IPromise, IQService, module} from 'angular';
 import {sortBy, uniq} from 'lodash';
 
 import {API_SERVICE, Api} from 'core/api/api.service';
@@ -17,7 +17,7 @@ export class PipelineConfigService {
 
   static get $inject() { return ['$q', 'API', 'authenticationService', 'viewStateCache']; }
 
-  public constructor(private $q: ng.IQService,
+  public constructor(private $q: IQService,
                      private API: Api,
                      private authenticationService: AuthenticationService,
                      viewStateCache: ViewStateCacheService) {
@@ -28,7 +28,7 @@ export class PipelineConfigService {
     return `${applicationName}:${pipelineName}`;
   }
 
-  public getPipelinesForApplication(applicationName: string): ng.IPromise<IPipeline[]> {
+  public getPipelinesForApplication(applicationName: string): IPromise<IPipeline[]> {
     return this.API.one('applications').one(applicationName).all('pipelineConfigs').getList()
       .then((pipelines: IPipeline[]) => {
         pipelines.forEach(p => p.stages = p.stages || []);
@@ -36,7 +36,7 @@ export class PipelineConfigService {
       });
   }
 
-  public getStrategiesForApplication(applicationName: string) {
+  public getStrategiesForApplication(applicationName: string): IPromise<IPipeline[]> {
     return this.API.one('applications').one(applicationName).all('strategyConfigs').getList()
       .then((pipelines: IPipeline[]) => {
       pipelines.forEach(p => p.stages = p.stages || []);
@@ -44,15 +44,15 @@ export class PipelineConfigService {
     });
   }
 
-  public getHistory(id: string, count = 20): ng.IPromise<IPipeline[]> {
+  public getHistory(id: string, count = 20): IPromise<IPipeline[]> {
     return this.API.one('pipelineConfigs', id).all('history').withParams({count: count}).getList();
   }
 
-  public deletePipeline(applicationName: string, pipeline: IPipeline, pipelineName: string): ng.IPromise<void> {
+  public deletePipeline(applicationName: string, pipeline: IPipeline, pipelineName: string): IPromise<void> {
     return this.API.one(pipeline.strategy ? 'strategies' : 'pipelines').one(applicationName, pipelineName).remove();
   }
 
-  public savePipeline(pipeline: IPipeline): ng.IPromise<void> {
+  public savePipeline(pipeline: IPipeline): IPromise<void> {
     delete pipeline.isNew;
     pipeline.stages.forEach(function(stage) {
       delete stage.isNew;
@@ -63,13 +63,13 @@ export class PipelineConfigService {
     return this.API.one( pipeline.strategy ? 'strategies' : 'pipelines').data(pipeline).post();
   }
 
-  public renamePipeline(applicationName: string, pipeline: IPipeline, currentName: string, newName: string): ng.IPromise<void> {
+  public renamePipeline(applicationName: string, pipeline: IPipeline, currentName: string, newName: string): IPromise<void> {
     this.configViewStateCache.remove(this.buildViewStateCacheKey(applicationName, currentName));
     pipeline.name = newName;
     return this.API.one(pipeline.strategy ? 'strategies' : 'pipelines').one(pipeline.id).data(pipeline).put();
   }
 
-  public triggerPipeline(applicationName: string, pipelineName: string, body: any = {}): ng.IPromise<ITriggerPipelineResponse> {
+  public triggerPipeline(applicationName: string, pipelineName: string, body: any = {}): IPromise<ITriggerPipelineResponse> {
     body.user = this.authenticationService.getAuthenticatedUser().name;
     return this.API.one('pipelines').one(applicationName).one(pipelineName).data(body).post();
   }
@@ -112,17 +112,17 @@ export class PipelineConfigService {
     return uniq(upstreamStages);
   }
 
-  public startAdHocPipeline(body: any): ng.IPromise<void> {
+  public startAdHocPipeline(body: any): IPromise<void> {
     body.user = this.authenticationService.getAuthenticatedUser().name;
     return this.API.one('pipelines').one('start').data(body).post();
   }
 
-  private sortPipelines(pipelines: IPipeline[]): ng.IPromise<IPipeline[]> {
+  private sortPipelines(pipelines: IPipeline[]): IPromise<IPipeline[]> {
 
     const sorted = sortBy(pipelines, ['index', 'name']);
 
     // if there are pipelines with a bad index, fix that
-    const toReindex: ng.IPromise<void>[] = [];
+    const toReindex: IPromise<void>[] = [];
     if (sorted && sorted.length) {
       sorted.forEach((pipeline, index) => {
         if (pipeline.index !== index) {


### PR DESCRIPTION
If there's a strategy in an application, we currently fail to render any executions because the `<NextRunTag>` looks at the `pipelineConfig`, which is null. Since we will never need that tag (or the `<TriggersTag>`) on a strategy, the easiest course of action is to simply not render them.

One thing I've noticed in this case is React does not do so great when it hits an exception. In an application where the last execution is a strategy, no execution groups render right now - you have the side filters and a blank middle section of the page.