### PR TITLE
perf(netflix): improve fast property selector performance

### DIFF
--- a/app/scripts/modules/netflix/pipeline/stage/properties/create/property.component.html
+++ b/app/scripts/modules/netflix/pipeline/stage/properties/create/property.component.html
@@ -21,7 +21,9 @@
         </ui-select-match>
 
         <ui-select-choices
-          repeat="property in propertyCtrl.getPropertyList($select.search) | filter: $select.search">
+          refresh="propertyCtrl.refreshOptions($select.search)"
+          refresh-delay="0"
+          repeat="property in propertyCtrl.filteredProperties | filter: $select.search">
           <div ng-bind-html="property | highlight: $select.search"></div>
         </ui-select-choices>
 

--- a/app/scripts/modules/netflix/pipeline/stage/properties/create/property.component.js
+++ b/app/scripts/modules/netflix/pipeline/stage/properties/create/property.component.js
@@ -18,23 +18,23 @@ module.exports =
     templateUrl: require('./property.component.html'),
   })
   .controller('PropertyController', function () {
-    let vm = this;
+    this.filteredProperties = [];
 
-    vm.remove = function(property) {
-      var index = vm.stage.persistedProperties.indexOf(property);
-      vm.stage.persistedProperties.splice(index, 1);
+    this.remove = (property) => {
+      const index = this.stage.persistedProperties.indexOf(property);
+      this.stage.persistedProperties.splice(index, 1);
     };
 
-    vm.getValueRowCount = (inputValue) => {
+    this.getValueRowCount = (inputValue) => {
       return inputValue ? inputValue.split(/\n/).length : 1;
     };
 
-    vm.getPropertyList = _.debounce((search) => {
-      let newPropKeyList = vm.propertyList.map(prop => prop.key);
+    this.refreshOptions = (search) => {
+      const newPropKeyList = this.propertyList.map(prop => prop.key);
       if (search && !newPropKeyList.includes(search)) {
         newPropKeyList.unshift(search);
       }
-      return _.uniq(newPropKeyList);
-    }, 200);
+      this.filteredProperties = _.uniq(newPropKeyList);
+    };
 
   });


### PR DESCRIPTION
The current code does this kinda wonky thing where it debounces the options selector, which occurs out of band of the Angular digest cycle, so the filtered list will only appear when the next digest cycle wraps up - which, in the case of the pipeline config screen, can be up to 30 seconds.

The slightly better way to handle this is to use the `refresh` attribute and set the list of properties on the component controller itself.

Even if there are thousands of properties for a given app, the performance probably isn't _that_ much different without the debouncing. This way, at least, the performance is good for apps that only have a few or a few hundred, and not inexplicably bad.