### PR TITLE
fix(projects): fix rewrite from /project to /project/dashboard

### DIFF
--- a/app/scripts/modules/core/projects/projects.states.ts
+++ b/app/scripts/modules/core/projects/projects.states.ts
@@ -36,6 +36,7 @@ module(PROJECTS_STATES_CONFIG, [
 
   const project: INestedState = {
     name: 'project',
+    abstract: true,
     url: '/projects/{project}',
     resolve: {
       projectConfiguration: ['$stateParams', 'projectReader', ($stateParams: IProjectStateParms, projectReader: any) => {


### PR DESCRIPTION
Not sure when (or why) this stopped working, but at some point, navigating to `/projects/{project}` stopped automatically rewriting to `/projects/{project}/dashboard`, despite the rewrite rule.

Making the base project state `abstract` fixes this. No idea why. If someone sees this and is more familiar with ui-router, I'd love to understand what's happening here.