### PR TITLE
fix(pipelines): show custom label as tooltip, fix canary score

### DIFF
--- a/app/scripts/modules/core/pipeline/config/stages/core/ExecutionBarLabel.tsx
+++ b/app/scripts/modules/core/pipeline/config/stages/core/ExecutionBarLabel.tsx
@@ -33,10 +33,10 @@ export class ExecutionBarLabel extends React.Component<IExecutionBarLabelProps, 
       );
     }
     if (executionMarker) {
+      const LabelComponent = stage.labelComponent;
       const tooltip = (
         <Tooltip id={stage.id}>
-          {stage.name}
-          {inSuspendedExecutionWindow && (<div>(waiting for execution window)</div>)}
+          <LabelComponent application={application} execution={execution} stage={stage}/>
         </Tooltip>
       );
       return (

--- a/app/scripts/modules/netflix/pipeline/stage/canary/CanaryExecutionLabel.tsx
+++ b/app/scripts/modules/netflix/pipeline/stage/canary/CanaryExecutionLabel.tsx
@@ -6,7 +6,7 @@ import {IExecutionStageSummary} from 'core/domain/index';
 
 export class CanaryExecutionLabel extends React.Component<{ stage: IExecutionStageSummary }, any> {
   public render() {
-    const canary = get<any>(this.props, 'stage.masterStage.context', {});
+    const canary = get<any>(this.props, 'stage.masterStage.context.canary', {});
     const canaryHealth = canary.health || {};
     const canaryResult = canary.canaryResult || {};
     return (


### PR DESCRIPTION
Two small changes:
1. Use the custom label if supplied for the stage tooltip
2. Fix the canary score (netflix module only) in the canary label