### PR TITLE
chore(netflix/ci): add  scm reader test suite

### DIFF
--- a/app/scripts/modules/netflix/ci/services/ciBuild.read.service.spec.ts
+++ b/app/scripts/modules/netflix/ci/services/ciBuild.read.service.spec.ts
@@ -2,7 +2,7 @@ import * as moment from 'moment';
 import {IHttpBackendService, mock} from 'angular';
 
 import {SETTINGS} from 'core/config/settings';
-import {Api, API_SERVICE} from 'core/api/api.service';
+import {API_SERVICE} from 'core/api/api.service';
 import {
   CI_BUILD_READ_SERVICE, CiBuildReader, ICiBuild
 } from 'netflix/ci/services/ciBuild.read.service';
@@ -12,15 +12,12 @@ describe('CiBuildReader', () => {
 
   const CI_BUILD_URL = `${SETTINGS.gateUrl}/ci/builds`;
   let $http: IHttpBackendService;
-  let API: Api;
   let ciBuildReader: CiBuildReader;
 
   beforeEach(mock.module(API_SERVICE, CI_BUILD_READ_SERVICE));
   beforeEach(mock.inject((_$httpBackend_: IHttpBackendService,
-                          _API_: Api,
                           _ciBuildReader_: CiBuildReader) => {
     $http = _$httpBackend_;
-    API = _API_;
     ciBuildReader = _ciBuildReader_;
   }));
 

--- a/app/scripts/modules/netflix/ci/services/scm.read.service.ts
+++ b/app/scripts/modules/netflix/ci/services/scm.read.service.ts
@@ -32,7 +32,7 @@ export interface ITag {
   commitId: string;
 }
 
-export class ScmReadService {
+export class ScmReader {
 
   static get $inject() { return ['API']; }
   constructor(private API: Api) {}
@@ -58,5 +58,5 @@ export class ScmReadService {
   }
 }
 
-export const SCM_SERVICE = 'spinnaker.netflix.ci.scm.read.service';
-module(SCM_SERVICE, [API_SERVICE]).service('scmReader', ScmReadService);
+export const SCM_READ_SERVICE = 'spinnaker.netflix.ci.scm.read.service';
+module(SCM_READ_SERVICE, [API_SERVICE]).service('scmReader', ScmReader);

--- a/app/scripts/modules/netflix/ci/trigger/ci.trigger.handler.component.ts
+++ b/app/scripts/modules/netflix/ci/trigger/ci.trigger.handler.component.ts
@@ -1,5 +1,5 @@
 import {IComponentController, IComponentOptions, module} from 'angular';
-import {IBranch, ScmReadService, SCM_SERVICE, ITag, ICommit} from '../services/scm.read.service';
+import {IBranch, ScmReader, SCM_READ_SERVICE, ITag, ICommit} from '../services/scm.read.service';
 import {IGitTrigger} from 'core/domain/ITrigger';
 
 interface IViewState {
@@ -32,7 +32,7 @@ class NetflixCiTriggerHandlerController implements IComponentController {
   public buildSources = ['branch', 'commit', 'tag'];
 
   static get $inject() { return ['scmReader']; }
-  constructor(private scmReader: ScmReadService) {}
+  constructor(private scmReader: ScmReader) {}
 
   public $onInit(): void {
     const trigger: IGitTrigger = this.command.trigger;
@@ -145,6 +145,6 @@ class NetflixCiTriggerHandlerComponent implements IComponentOptions {
 
 export const NETFLIX_CI_TRIGGER_HANDLER_COMPONENT = 'spinnaker.netflix.ci.trigger.handler.component';
 module(NETFLIX_CI_TRIGGER_HANDLER_COMPONENT, [
-  SCM_SERVICE,
+  SCM_READ_SERVICE,
 ])
   .component('netflixCiTriggerHandler', new NetflixCiTriggerHandlerComponent());


### PR DESCRIPTION
* add test suite for scm reader service
* rename reader to be consistent with rest of deck.
