### PR TITLE
fix(pipelineconfig): only cache stage/section state

### DIFF
--- a/app/scripts/modules/core/pipeline/config/pipelineConfigurer.js
+++ b/app/scripts/modules/core/pipeline/config/pipelineConfigurer.js
@@ -49,7 +49,6 @@ module.exports = angular.module('spinnaker.core.pipeline.config.pipelineConfigur
     $scope.viewState = configViewStateCache.get(buildCacheKey()) || {
       section: 'triggers',
       stageIndex: 0,
-      saving: false,
     };
 
     let setOriginal = (pipeline) => $scope.viewState.original = angular.toJson(pipeline);
@@ -349,14 +348,13 @@ module.exports = angular.module('spinnaker.core.pipeline.config.pipelineConfigur
     };
 
     function cacheViewState() {
-      var toCache = angular.copy($scope.viewState);
-      delete toCache.original;
+      const toCache = { section: $scope.viewState.section, stageIndex: $scope.viewState.stageIndex };
       configViewStateCache.put(buildCacheKey(), toCache);
     }
 
     $scope.$watch('pipeline', markDirty, true);
     $scope.$watch('viewState.original', markDirty);
-    $scope.$watch('viewState', cacheViewState, true);
+    $scope.$watchGroup(['viewState.section', 'viewState.stageIndex'], cacheViewState);
 
     this.navigateTo({section: $scope.viewState.section, index: $scope.viewState.stageIndex});
 

--- a/app/scripts/modules/core/pipeline/config/services/pipelineConfig.service.ts
+++ b/app/scripts/modules/core/pipeline/config/services/pipelineConfig.service.ts
@@ -21,7 +21,7 @@ export class PipelineConfigService {
                      private API: Api,
                      private authenticationService: AuthenticationService,
                      viewStateCache: ViewStateCacheService) {
-    this.configViewStateCache = viewStateCache.createCache('pipelineConfig', { version: 1 });
+    this.configViewStateCache = viewStateCache.createCache('pipelineConfig', { version: 2 });
   }
 
   private buildViewStateCacheKey(applicationName: string, pipelineName: string): string {


### PR DESCRIPTION
This whole controller is due for a rewrite, just not today.

We're currently persisting some values to local storage we absolutely shouldn't be, because the `viewState` object holds transient values, like the JSON of the pipeline config, the saving state, whether the pipeline config has history or not. We should only persist two values to local storage: the section, and the stage index.

The view can get into a state right now where, when doing something like editing the JSON of the pipeline, the save button goes into "saving..." mode, even though nothing is being saved.

Bumping the `version` field on the cache will clear out any existing cached values.