### PR TITLE
fix(webhooks): allow empty payload in webhook stage

### DIFF
--- a/app/scripts/modules/core/pipeline/config/stages/webhook/webhookStage.ts
+++ b/app/scripts/modules/core/pipeline/config/stages/webhook/webhookStage.ts
@@ -1,4 +1,4 @@
-import {module, extend} from 'angular';
+import {module} from 'angular';
 
 import {JSON_UTILITY_SERVICE, JsonUtilityService} from 'core/utils/json/json.utility.service';
 import {PIPELINE_CONFIG_PROVIDER} from 'core/pipeline/config/pipelineConfigProvider';
@@ -41,11 +41,7 @@ export class WebhookStage {
     this.command.invalid = false;
     this.command.errorMessage = '';
     try {
-      const parsed = JSON.parse(this.command.payloadJSON);
-      if (!this.stage.payload) {
-        this.stage.payload = {};
-      }
-      extend(this.stage.payload, parsed);
+      this.stage.payload = this.command.payloadJSON ? JSON.parse(this.command.payloadJSON) : null;
     } catch (e) {
       this.command.invalid = true;
       this.command.errorMessage = e.message;


### PR DESCRIPTION
It's sometimes desirable to send no payload in a webhook stage. The current implementation does not allow this, however, and will refuse to update the `payload` field if left blank once something has been added.

Also, the use of `extend` means that properties cannot be removed from the payload field once they've been added, e.g. if I enter `{"a":1, "b":2}` in the textarea, then remove `"b":2`, the contents of the field still ends up as `{"a":1, "b":2}`. I can't think of a reason why we'd want to merge properties from the textarea into the `payload` field rather than replace it.

@amanya PTAL