### PR TITLE
feat(webhooks): allow custom headers on webhook call

### DIFF
--- a/app/scripts/modules/core/help/helpContents.js
+++ b/app/scripts/modules/core/help/helpContents.js
@@ -543,4 +543,5 @@ module.exports = angular.module('spinnaker.core.help.contents', [])
     'pipeline.config.webhook.successStatuses': 'Comma-separated list of strings that will be considered as SUCCESS status.',
     'pipeline.config.webhook.canceledStatuses': 'Comma-separated list of strings that will be considered as CANCELED status.',
     'pipeline.config.webhook.terminalStatuses': 'Comma-separated list of strings that will be considered as TERMINAL status.',
+    'pipeline.config.webhook.customHeaders': 'Key-value pairs to be sent as additional headers to the service.',
   });

--- a/app/scripts/modules/core/pipeline/config/stages/webhook/modal/addCustomHeader.controller.modal.ts
+++ b/app/scripts/modules/core/pipeline/config/stages/webhook/modal/addCustomHeader.controller.modal.ts
@@ -1,0 +1,20 @@
+import {module} from 'angular';
+import {IModalInstanceService} from 'angular-ui-bootstrap';
+
+export class WebhookStageAddCustomHeader {
+  static get $inject() {
+    return ['$scope', '$uibModalInstance'];
+  }
+
+  constructor (private $scope: ng.IScope, private $uibModalInstance: IModalInstanceService) {}
+
+  public submit(): void {
+    this.$uibModalInstance.close(this.$scope.customHeader);
+  }
+}
+
+export const WEBHOOK_STAGE_ADD_CUSTOM_HEADER_MODAL_CONTROLLER = 'spinnaker.core.pipeline.stage.webhookStage.modal.addCustomHeader';
+
+module(WEBHOOK_STAGE_ADD_CUSTOM_HEADER_MODAL_CONTROLLER,
+       [],
+).controller('WebhookStageAddCustomHeaderCtrl', WebhookStageAddCustomHeader);

--- a/app/scripts/modules/core/pipeline/config/stages/webhook/modal/addCustomHeader.html
+++ b/app/scripts/modules/core/pipeline/config/stages/webhook/modal/addCustomHeader.html
@@ -1,0 +1,45 @@
+<div modal-page>
+  <modal-close dismiss="$dismiss()"></modal-close>
+  <div class="modal-header">
+    <h3 data-purpose="modal-header">Add Custom Header</h3>
+  </div>
+
+  <form role="form" class="container-fluid" novalidate name="addCustomHeaderForm">
+    <div class="modal-body">
+      <div class="form-group row">
+        <div class="col-sm-3 sm-label-right">Key</div>
+        <div class="col-sm-9">
+          <input type="text"
+                 class="form-control input-sm "
+                 ng-model="customHeader.key"
+                 placeholder="enter a header key"
+                 required>
+          </input>
+        </div>
+      </div>
+      <div class="form-group row">
+        <div class="col-sm-3 sm-label-right">Value</div>
+        <div class="col-sm-9">
+          <input type="text"
+                 class="form-control input-sm "
+                 ng-model="customHeader.value"
+                 placeholder="enter a header value"
+                 required>
+          </input>
+        </div>
+      </div>
+    </div>
+
+    <div class="modal-footer">
+      <a href class="btn btn-default" ng-click="$dismiss()">Cancel</a>
+      <button type="submit"
+              class="btn btn-primary"
+              data-purpose="submit"
+              ng-click="addCustomHeader.submit()"
+              ng-disabled="addCustomHeaderForm.$invalid"
+        >
+        <span class="glyphicon glyphicon-ok-circle"></span> Add
+      </button>
+    </div>
+  </form>
+</div>

--- a/app/scripts/modules/core/pipeline/config/stages/webhook/webhookStage.html
+++ b/app/scripts/modules/core/pipeline/config/stages/webhook/webhookStage.html
@@ -18,11 +18,45 @@
               ng-model="$ctrl.command.payloadJSON"
               ng-change="$ctrl.updatePayload()"/>
 
-    <div class="form-group row slide-in" ng-if="$ctrl.command.invalid">
-      <div class="col-sm-9 col-sm-offset-3 error-message">
-        Error: {{$ctrl.command.errorMessage}}
+      <div class="form-group row slide-in" ng-if="$ctrl.command.invalid">
+        <div class="col-sm-9 col-sm-offset-3 error-message">
+          Error: {{$ctrl.command.errorMessage}}
+        </div>
       </div>
-    </div>
+  </stage-config-field>
+  <stage-config-field label="Custom Headers" help-key="pipeline.config.webhook.customHeaders">
+    <table class="table table-condensed packed">
+      <thead>
+        <tr>
+          <th style="width:40%">Key</th>
+          <th style="width:60%">Value</th>
+          <th class="text-right">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr ng-repeat="(key,value) in $ctrl.stage.customHeaders">
+          <td>
+            <strong class="small">{{key}}</strong>
+          </td>
+          <td>
+            <input type="text" required ng-model="$ctrl.stage.customHeaders[key]"
+                   class="form-control input-sm"/>
+          </td>
+          <td class="text-right">
+            <a class="small" href ng-click="$ctrl.removeCustomHeader(key)">Remove</a>
+          </td>
+        </tr>
+      </tbody>
+      <tfoot>
+        <tr>
+          <td colspan="7">
+            <button class="btn btn-block btn-sm add-new" ng-click="$ctrl.addCustomHeader()">
+              <span class="glyphicon glyphicon-plus-sign"></span> Add Custom Header
+            </button>
+          </td>
+        </tr>
+      </tfoot>
+    </table>
   </stage-config-field>
   <stage-config-field label="Wait for completion" help-key="pipeline.config.webhook.waitForCompletion">
     <input type="checkbox" class="input-sm" name="waitForCompletion"

--- a/app/scripts/modules/core/pipeline/config/stages/webhook/webhookStage.module.ts
+++ b/app/scripts/modules/core/pipeline/config/stages/webhook/webhookStage.module.ts
@@ -4,6 +4,7 @@ import {WEBHOOK_STAGE} from './webhookStage';
 import {IGOR_SERVICE} from 'core/ci/igor.service';
 import {TIME_FORMATTERS} from 'core/utils/timeFormatters';
 import {WEBHOOK_EXECUTION_DETAILS_CONTROLLER} from './webhookExecutionDetails.controller';
+import {WEBHOOK_STAGE_ADD_CUSTOM_HEADER_MODAL_CONTROLLER} from './modal/addCustomHeader.controller.modal';
 
 export const WEBHOOK_STAGE_MODULE = 'spinnaker.core.pipeline.stage.webhook';
 module(WEBHOOK_STAGE_MODULE, [
@@ -13,4 +14,5 @@ module(WEBHOOK_STAGE_MODULE, [
   TIME_FORMATTERS,
   IGOR_SERVICE,
   WEBHOOK_EXECUTION_DETAILS_CONTROLLER,
+  WEBHOOK_STAGE_ADD_CUSTOM_HEADER_MODAL_CONTROLLER,
 ]);

--- a/app/scripts/modules/core/pipeline/config/stages/webhook/webhookStage.ts
+++ b/app/scripts/modules/core/pipeline/config/stages/webhook/webhookStage.ts
@@ -2,6 +2,7 @@ import {module} from 'angular';
 
 import {JSON_UTILITY_SERVICE, JsonUtilityService} from 'core/utils/json/json.utility.service';
 import {PIPELINE_CONFIG_PROVIDER} from 'core/pipeline/config/pipelineConfigProvider';
+import {IModalService} from 'angular-ui-bootstrap';
 
 interface IViewState {
   waitForCompletion?: boolean;
@@ -14,9 +15,14 @@ interface ICommand {
   payloadJSON: string;
 }
 
+export interface ICustomHeader {
+  key: string;
+  value: string;
+}
+
 export class WebhookStage {
   static get $inject() {
-    return ['stage', 'jsonUtilityService'];
+    return ['stage', 'jsonUtilityService', '$uibModal'];
   }
 
   public command: ICommand;
@@ -24,7 +30,8 @@ export class WebhookStage {
   public methods: string[];
 
   constructor(public stage: any,
-              private jsonUtilityService: JsonUtilityService) {
+              private jsonUtilityService: JsonUtilityService,
+              private $uibModal: IModalService) {
     this.methods = ['GET', 'HEAD', 'POST', 'PUT', 'DELETE'];
 
     this.viewState = {
@@ -56,6 +63,22 @@ export class WebhookStage {
     this.stage.statusUrlResolution = this.viewState.statusUrlResolution;
   }
 
+  public removeCustomHeader(key: string): void {
+    delete this.stage.customHeaders[key];
+  }
+
+  public addCustomHeader(): void {
+    if (!this.stage.customHeaders) {
+      this.stage.customHeaders = {};
+    }
+    this.$uibModal.open({
+      templateUrl: require('core/pipeline/config/stages/webhook/modal/addCustomHeader.html'),
+      controller: 'WebhookStageAddCustomHeaderCtrl',
+      controllerAs: 'addCustomHeader',
+    }).result.then((customHeader: ICustomHeader) => {
+      this.stage.customHeaders[customHeader.key] = customHeader.value;
+    });
+  }
 }
 
 export const WEBHOOK_STAGE = 'spinnaker.core.pipeline.stage.webhookStage';


### PR DESCRIPTION
This will add support for customizing request headers that will be sent to the service called by the webhook stage.

Depends on https://github.com/spinnaker/orca/pull/1301

![image](https://cloud.githubusercontent.com/assets/4490611/25456902/92ffda64-2ad4-11e7-9121-0d63bb7bf88e.png)

@anotherchrisberry @jervi PTAL