### PR TITLE
allow ~ in titus server group detail

### DIFF
--- a/app/scripts/modules/titus/serverGroup/configure/serverGroupBasicSettingsDirective.html
+++ b/app/scripts/modules/titus/serverGroup/configure/serverGroupBasicSettingsDirective.html
@@ -42,7 +42,7 @@
   </div>
   <div class="form-group row slide-in" ng-if="basicSettings.details.$error.pattern">
       <div class="col-sm-9 col-sm-offset-2 error-message">
-          <span>Only dot(.), underscore(_), caret (^), and dash(-) special characters are allowed in the Detail field.</span>
+          <span>Only dot(.), underscore(_), caret (^), tilde (~), and dash(-) special characters are allowed in the Detail field.</span>
       </div>
   </div>
   <div ng-if="!command.viewState.disableImageSelection">

--- a/app/scripts/modules/titus/serverGroup/configure/serverGroupBasicSettingsSelector.directive.js
+++ b/app/scripts/modules/titus/serverGroup/configure/serverGroupBasicSettingsSelector.directive.js
@@ -29,8 +29,8 @@ module.exports = angular.module('spinnaker.serverGroup.configure.titus.basicSett
     this.detailPattern = {
       test: function (detail) {
         var pattern = $scope.command.viewState.templatingEnabled ?
-          /^([a-zA-Z_0-9._$-{}\\\^]*(\${.+})*)*$/ :
-          /^[a-zA-Z_0-9._$-{}\\\^]*$/;
+          /^([a-zA-Z_0-9._$-{}\\\^~]*(\${.+})*)*$/ :
+          /^[a-zA-Z_0-9._$-{}\\\^~]*$/;
 
         return isNotExpressionLanguage(detail) ? pattern.test(detail) : true;
       }


### PR DESCRIPTION
We recently allowed a `~` character in the detail section of a server group name ( Netflix/frigga#20 )

I feel like there is a solid chance that there is somewhere else that cares about tilde but in doing some initial testing I didn't find it...