### PR TITLE
fix(netflix): do not navigate to root on jira click

### DIFF
--- a/app/scripts/modules/core/presentation/main.less
+++ b/app/scripts/modules/core/presentation/main.less
@@ -1393,6 +1393,7 @@ ul.checkmap {
       clear: both;
       color: #333333;
       white-space: nowrap;
+      cursor: pointer;
       &:hover, &:focus {
         background-color: #f5f5f5;
         text-decoration: none;

--- a/app/scripts/modules/netflix/feedback/Feedback.tsx
+++ b/app/scripts/modules/netflix/feedback/Feedback.tsx
@@ -53,10 +53,12 @@ export class Feedback extends React.Component<IFeedbackProps, IFeedbackState> {
           <span className="hidden-xs hidden-sm">Help</span>
         </CustomToggle>
         <CustomMenu bsRole="menu">
-          <MenuItem onClick={this.showModal}>
-            <span className="glyphicon glyphicon-envelope"/>
-            Create an issue in JIRA
-          </MenuItem>
+          <li role="presentation">
+            <a onClick={this.showModal}>
+              <span className="glyphicon glyphicon-envelope"/>
+              Create an issue in JIRA
+            </a>
+          </li>
           { this.state.slackConfig && (
             <MenuItem href={slackUrl} target={slackTarget}>
               <span className="icon"><span className="glyphicon icon-bubbles"/></span>


### PR DESCRIPTION
According to React Bootstrap docs, `<MenuItem>` is going to set an `href` on the anchor, even if you omit it, and it's going to navigate to it before calling the `onClick` or `onSelect` handlers. The solution, it seems, is to just not use `<MenuItem>` for non-links.

@jrsquared FYI - you probably never noticed it (I didn't) because, when testing, you were already at the root of the application, i.e. `http://localhost:9000/#`, so the navigation didn't do anything.