### PR TITLE
refactor(entitytags): do not throw exception on entity tag load failure

### DIFF
--- a/app/scripts/modules/core/entityTag/entityTags.read.service.spec.ts
+++ b/app/scripts/modules/core/entityTag/entityTags.read.service.spec.ts
@@ -1,14 +1,13 @@
-import {mock} from 'angular';
+import { IHttpBackendService, IQService, ITimeoutService, mock } from 'angular';
 
 import {EntityTagsReader, ENTITY_TAGS_READ_SERVICE} from './entityTags.read.service';
 import {SETTINGS} from 'core/config/settings';
 
 describe('entityTags reader', () => {
 
-  let $http: ng.IHttpBackendService;
-  let $q: ng.IQService;
-  let $timeout: ng.ITimeoutService;
-  let $exceptionHandler: ng.IExceptionHandlerService;
+  let $http: IHttpBackendService;
+  let $q: IQService;
+  let $timeout: ITimeoutService;
   let service: EntityTagsReader;
 
   beforeEach(function () {
@@ -22,20 +21,14 @@ describe('entityTags reader', () => {
 
   beforeEach(mock.module(ENTITY_TAGS_READ_SERVICE));
 
-  beforeEach(mock.module(($exceptionHandlerProvider: ng.IExceptionHandlerProvider) => {
-    $exceptionHandlerProvider.mode('log');
-  }));
-
   beforeEach(
-    mock.inject(($httpBackend: ng.IHttpBackendService,
-                 _$q_: ng.IQService,
-                 _$exceptionHandler_: ng.IExceptionHandlerService,
+    mock.inject(($httpBackend: IHttpBackendService,
+                 _$q_: IQService,
                  entityTagsReader: EntityTagsReader,
-                 _$timeout_: ng.ITimeoutService) => {
+                 _$timeout_: ITimeoutService) => {
       $http = $httpBackend;
       $q = _$q_;
       service = entityTagsReader;
-      $exceptionHandler = _$exceptionHandler_;
       $timeout = _$timeout_;
     }));
 
@@ -49,7 +42,6 @@ describe('entityTags reader', () => {
     $timeout.flush();
     $http.flush();
     expect(result).toEqual([]);
-    expect(($exceptionHandler as any)['errors'].length).toBe(1);
   });
 
   it('collates entries into groups when there are too many', () => {
@@ -61,7 +53,6 @@ describe('entityTags reader', () => {
     $http.flush();
     $timeout.flush();
     expect(result).toEqual([]);
-    expect(($exceptionHandler as any)['errors'].length).toBe(0);
   });
 
   it('retries server group fetch once on exceptions', () => {
@@ -73,6 +64,5 @@ describe('entityTags reader', () => {
     $timeout.flush();
     $http.flush();
     expect(result).toEqual([]);
-    expect(($exceptionHandler as any)['errors'].length).toBe(0);
   });
 });

--- a/app/scripts/modules/core/entityTag/entityTags.read.service.ts
+++ b/app/scripts/modules/core/entityTag/entityTags.read.service.ts
@@ -1,4 +1,4 @@
-import {module, IQService, IExceptionHandlerService, IPromise, IDeferred} from 'angular';
+import {module, IQService, IPromise, IDeferred} from 'angular';
 import {get, uniq} from 'lodash';
 
 import {API_SERVICE, Api} from 'core/api/api.service';
@@ -8,11 +8,10 @@ import {SETTINGS} from 'core/config/settings';
 
 export class EntityTagsReader {
 
-  static get $inject() { return ['API', '$q', '$exceptionHandler', 'retryService']; }
+  static get $inject() { return ['API', '$q', 'retryService']; }
 
   constructor(private API: Api,
               private $q: IQService,
-              private $exceptionHandler: IExceptionHandlerService,
               private retryService: RetryService) {}
 
   public getAllEntityTags(entityType: string, entityIds: string[]): IPromise<IEntityTags[]> {
@@ -38,7 +37,6 @@ export class EntityTagsReader {
         result.resolve(allTags);
       })
       .catch(() => {
-        this.$exceptionHandler(new Error(`Failed to load ${entityType} entity tags; groups: \n${idGroups.join('\n')}`));
         result.resolve([]);
       });
 


### PR DESCRIPTION
We get error reports several times a week about entity tags failing to load. @jrsquared traced the cause to when a user closes their laptop in the middle of an application refresh cycle, then later reopens after their VPN connection has been broken.

The error reports are just noise at this point, so we should remove the exception handling.