### PR TITLE
fix(deck): Add check for isZeroLengthText response

### DIFF
--- a/app/scripts/modules/core/api/api.service.ts
+++ b/app/scripts/modules/core/api/api.service.ts
@@ -47,7 +47,8 @@ export class Api {
       if (contentType) {
         const isJson = contentType.includes('application/json');
         const isZeroLengthHtml = (contentType.includes('text/html') && (result.data === ''));
-        if (!(isJson || isZeroLengthHtml)) {
+        const isZeroLengthText = (contentType.includes('text/plain') && (result.data === ''));
+        if (!(isJson || isZeroLengthHtml || isZeroLengthText)) {
           this.authenticationIntializer.reauthenticateUser();
           reject(result);
         }


### PR DESCRIPTION
Ran into an issue when saving pipelines where I would submit a request
to save and the response coming back had a Content-Type of text/plain
which would cause the request to "fail" regardless of if it actually
succeeded or not. Adds a check to allow zero length text plain headers
as well.

@danielpeach - I wasn't able to repro this locally. The only diff between my environment and my deployment is Auth is enabled. I pointed Front50 at the _same_ bucket and didn't get the `Content-Type: text/plain` response header. I'll keep trying though.

@anotherchrisberry - Daniel suggested that I tag you on this since this could affect local caches.
