### PR TITLE
fix(titus): URL decode params to allow expressions in Bake package name

### DIFF
--- a/app/scripts/modules/titus/pipeline/stages/bake/titusBakeStage.js
+++ b/app/scripts/modules/titus/pipeline/stages/bake/titusBakeStage.js
@@ -77,7 +77,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.titus.titusBakeSt
 
       let buildParams = $.param(stage.repository.buildParameters);
       if (buildParams.length > 0) {
-        url += '&' + buildParams;
+        url += '&' + decodeURIComponent(buildParams);
       }
       stage.package = url;
     };


### PR DESCRIPTION
- This ensures to url decode the parameters on the repo url