### PR TITLE
fix(amazon): preserve existing security groups on ELB edit

### DIFF
--- a/app/scripts/modules/amazon/loadBalancer/configure/createLoadBalancer.controller.js
+++ b/app/scripts/modules/amazon/loadBalancer/configure/createLoadBalancer.controller.js
@@ -159,6 +159,12 @@ module.exports = angular.module('spinnaker.loadBalancer.aws.create.controller', 
       }
     }
 
+    function availableGroupsSorter(a, b) {
+      return $scope.loadBalancer.securityGroups.includes(a.id) ? -1 :
+        $scope.loadBalancer.securityGroups.includes(b.id) ? 1 :
+          0;
+    }
+
     function updateAvailableSecurityGroups(availableVpcIds) {
       var account = $scope.loadBalancer.credentials,
         region = $scope.loadBalancer.region;
@@ -166,7 +172,7 @@ module.exports = angular.module('spinnaker.loadBalancer.aws.create.controller', 
       if (account && region && allSecurityGroups[account] && allSecurityGroups[account].aws[region]) {
         $scope.availableSecurityGroups = _.filter(allSecurityGroups[account].aws[region], function(securityGroup) {
           return availableVpcIds.includes(securityGroup.vpcId);
-        });
+        }).sort(availableGroupsSorter); // push existing groups to top
         $scope.existingSecurityGroupNames = _.map($scope.availableSecurityGroups, 'name');
         var existingNames = defaultSecurityGroups.filter(function(defaultName) {
           return $scope.existingSecurityGroupNames.includes(defaultName);


### PR DESCRIPTION
We already have similar code in the server group modal, where we are using the same infinite scroll item limiting business.