### PR TITLE
fix(crontrigger): fix radio buttons when multiple cron triggers exist

### DIFF
--- a/app/scripts/modules/core/pipeline/config/triggers/cron/cronPicker.html
+++ b/app/scripts/modules/core/pipeline/config/triggers/cron/cronPicker.html
@@ -50,7 +50,7 @@
         <div class="col-md-12">
           <input type="radio"
                  value="everyDays"
-                 name="daily-radio"
+                 name="daily-radio-{{$ctrl.name}}"
                  ng-change="$ctrl.regenerateCron()"
                  ng-model="$ctrl.state.daily.subTab"
                  checked="checked">
@@ -72,7 +72,7 @@
                  value="everyWeekDay"
                  ng-change="$ctrl.regenerateCron()"
                  ng-model="$ctrl.state.daily.subTab"
-                 name="daily-radio">
+                 name="daily-radio-{{$ctrl.name}}">
           Every week day
         </div>
       </div>
@@ -139,7 +139,7 @@
                  value="specificDay"
                  ng-change="$ctrl.regenerateCron()"
                  ng-model="$ctrl.state.monthly.subTab"
-                 name="monthly-radio"
+                 name="monthly-radio-{{$ctrl.name}}"
                  checked="checked">
           On the
           <select class="month-days"
@@ -168,7 +168,7 @@
                  value="specificWeekDay"
                  ng-change="$ctrl.regenerateCron()"
                  ng-model="$ctrl.state.monthly.subTab"
-                 name="monthly-radio">
+                 name="monthly-radio-{{$ctrl.name}}">
           <select class="form-control input-sm"
                   ng-change="$ctrl.regenerateCron()"
                   ng-model="$ctrl.state.monthly.specificWeekDay.monthWeek"

--- a/app/scripts/modules/core/pipeline/config/triggers/cron/cronTrigger.html
+++ b/app/scripts/modules/core/pipeline/config/triggers/cron/cronTrigger.html
@@ -6,6 +6,7 @@
     <div class="col-md-9">
       <cron-gen ng-model="vm.trigger.cronExpression"
                 options="vm.cronOptions"
+                name="{{vm.trigger.id}}"
                 template-url="spinnaker-custom-cron-picker-template"></cron-gen>
     </div>
   </div>


### PR DESCRIPTION
This was kind of a fun (?) one. If there are multiple cron triggers on the page with the same frequency options, only one is selectable, since the fields all have the same name.

Adding `name` to the `cronGen` component options makes it available in the template, and it's a UUID, so this fixes that problem...