### PR TITLE
chore(routing): upgrade to ui-router 1.0.rc1

### DIFF
--- a/app/scripts/modules/amazon/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/amazon/instance/details/instance.details.controller.js
@@ -11,7 +11,7 @@ import {SETTINGS} from 'core/config/settings';
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.instance.detail.aws.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   require('angular-ui-bootstrap'),
   INSTANCE_WRITE_SERVICE,
   INSTANCE_READ_SERVICE,

--- a/app/scripts/modules/amazon/loadBalancer/configure/createLoadBalancer.controller.js
+++ b/app/scripts/modules/amazon/loadBalancer/configure/createLoadBalancer.controller.js
@@ -17,7 +17,7 @@ import {AWSProviderSettings} from '../../aws.settings';
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.loadBalancer.aws.create.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   LOAD_BALANCER_WRITE_SERVICE,
   ACCOUNT_SERVICE,
   require('../loadBalancer.transformer.js'),

--- a/app/scripts/modules/amazon/loadBalancer/details/loadBalancerDetail.controller.js
+++ b/app/scripts/modules/amazon/loadBalancer/details/loadBalancerDetail.controller.js
@@ -10,7 +10,7 @@ import {SUBNET_READ_SERVICE} from 'core/subnet/subnet.read.service';
 import {SECURITY_GROUP_READER} from 'core/securityGroup/securityGroupReader.service';
 
 module.exports = angular.module('spinnaker.loadBalancer.aws.details.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   SECURITY_GROUP_READER,
   LOAD_BALANCER_WRITE_SERVICE,
   LOAD_BALANCER_READ_SERVICE,

--- a/app/scripts/modules/amazon/pipeline/stages/bake/bakeExecutionDetails.controller.js
+++ b/app/scripts/modules/amazon/pipeline/stages/bake/bakeExecutionDetails.controller.js
@@ -6,7 +6,7 @@ import {SETTINGS} from 'core/config/settings';
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.bake.aws.executionDetails.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   EXECUTION_DETAILS_SECTION_SERVICE,
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ])

--- a/app/scripts/modules/amazon/pipeline/stages/cloneServerGroup/cloneServerGroupExecutionDetails.controller.js
+++ b/app/scripts/modules/amazon/pipeline/stages/cloneServerGroup/cloneServerGroupExecutionDetails.controller.js
@@ -9,7 +9,7 @@ import {URL_BUILDER_SERVICE} from 'core/navigation/urlBuilder.service';
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.cloneServerGroup.aws.executionDetails.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   CLUSTER_FILTER_SERVICE,
   EXECUTION_DETAILS_SECTION_SERVICE,
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),

--- a/app/scripts/modules/amazon/pipeline/stages/disableCluster/disableClusterExecutionDetails.controller.js
+++ b/app/scripts/modules/amazon/pipeline/stages/disableCluster/disableClusterExecutionDetails.controller.js
@@ -5,7 +5,7 @@ import {EXECUTION_DETAILS_SECTION_SERVICE} from 'core/delivery/details/execution
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.disableCluster.aws.executionDetails.controller', [
-    require('angular-ui-router'),
+    require('angular-ui-router').default,
     EXECUTION_DETAILS_SECTION_SERVICE,
     require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ])

--- a/app/scripts/modules/amazon/pipeline/stages/findAmi/findAmiExecutionDetails.controller.js
+++ b/app/scripts/modules/amazon/pipeline/stages/findAmi/findAmiExecutionDetails.controller.js
@@ -5,7 +5,7 @@ import {EXECUTION_DETAILS_SECTION_SERVICE} from 'core/delivery/details/execution
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.findAmi.aws.executionDetails.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   EXECUTION_DETAILS_SECTION_SERVICE,
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ])

--- a/app/scripts/modules/amazon/pipeline/stages/findImageFromTags/findImageFromTagsExecutionDetails.controller.js
+++ b/app/scripts/modules/amazon/pipeline/stages/findImageFromTags/findImageFromTagsExecutionDetails.controller.js
@@ -6,7 +6,7 @@ let angular = require('angular');
 
 module.exports = angular
   .module('spinnaker.core.pipeline.stage.findImageFromTags.aws.executionDetails.controller', [
-    require('angular-ui-router'),
+    require('angular-ui-router').default,
     EXECUTION_DETAILS_SECTION_SERVICE,
     require('core/delivery/details/executionDetailsSectionNav.directive.js'),
   ])

--- a/app/scripts/modules/amazon/pipeline/stages/modifyScalingProcess/modifyScalingProcessExecutionDetails.controller.js
+++ b/app/scripts/modules/amazon/pipeline/stages/modifyScalingProcess/modifyScalingProcessExecutionDetails.controller.js
@@ -5,7 +5,7 @@ import {EXECUTION_DETAILS_SECTION_SERVICE} from 'core/delivery/details/execution
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.modifyScalingProcess.executionDetails.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   EXECUTION_DETAILS_SECTION_SERVICE,
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ])

--- a/app/scripts/modules/amazon/pipeline/stages/resizeAsg/resizeAsgExecutionDetails.controller.js
+++ b/app/scripts/modules/amazon/pipeline/stages/resizeAsg/resizeAsgExecutionDetails.controller.js
@@ -5,7 +5,7 @@ import {EXECUTION_DETAILS_SECTION_SERVICE} from 'core/delivery/details/execution
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.resizeAsg.aws.executionDetails.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   EXECUTION_DETAILS_SECTION_SERVICE,
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ])

--- a/app/scripts/modules/amazon/pipeline/stages/scaleDownCluster/scaleDownClusterExecutionDetails.controller.js
+++ b/app/scripts/modules/amazon/pipeline/stages/scaleDownCluster/scaleDownClusterExecutionDetails.controller.js
@@ -5,7 +5,7 @@ import {EXECUTION_DETAILS_SECTION_SERVICE} from 'core/delivery/details/execution
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.scaleDownCluster.aws.executionDetails.controller', [
-    require('angular-ui-router'),
+    require('angular-ui-router').default,
     EXECUTION_DETAILS_SECTION_SERVICE,
     require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ])

--- a/app/scripts/modules/amazon/pipeline/stages/tagImage/tagImageExecutionDetails.controller.js
+++ b/app/scripts/modules/amazon/pipeline/stages/tagImage/tagImageExecutionDetails.controller.js
@@ -6,7 +6,7 @@ let angular = require('angular');
 
 module.exports = angular
   .module('spinnaker.core.pipeline.stage.tagImage.aws.executionDetails.controller', [
-    require('angular-ui-router'),
+    require('angular-ui-router').default,
     EXECUTION_DETAILS_SECTION_SERVICE,
     require('core/delivery/details/executionDetailsSectionNav.directive.js'),
   ])

--- a/app/scripts/modules/amazon/securityGroup/configure/CreateSecurityGroupCtrl.js
+++ b/app/scripts/modules/amazon/securityGroup/configure/CreateSecurityGroupCtrl.js
@@ -6,7 +6,7 @@ import {INFRASTRUCTURE_CACHE_SERVICE} from 'core/cache/infrastructureCaches.serv
 import {CACHE_INITIALIZER_SERVICE} from 'core/cache/cacheInitializer.service';
 
 module.exports = angular.module('spinnaker.amazon.securityGroup.create.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   INFRASTRUCTURE_CACHE_SERVICE,
   CACHE_INITIALIZER_SERVICE,
 ])

--- a/app/scripts/modules/amazon/securityGroup/configure/EditSecurityGroupCtrl.js
+++ b/app/scripts/modules/amazon/securityGroup/configure/EditSecurityGroupCtrl.js
@@ -8,7 +8,7 @@ import {SECURITY_GROUP_WRITER} from 'core/securityGroup/securityGroupWriter.serv
 import {TASK_MONITOR_BUILDER} from 'core/task/monitor/taskMonitor.builder';
 
 module.exports = angular.module('spinnaker.securityGroup.aws.edit.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   ACCOUNT_SERVICE,
   TASK_MONITOR_BUILDER,
   SECURITY_GROUP_WRITER

--- a/app/scripts/modules/amazon/securityGroup/configure/configSecurityGroup.mixin.controller.js
+++ b/app/scripts/modules/amazon/securityGroup/configure/configSecurityGroup.mixin.controller.js
@@ -13,7 +13,7 @@ import {AWSProviderSettings} from '../../aws.settings';
 
 module.exports = angular
   .module('spinnaker.amazon.securityGroup.baseConfig.controller', [
-    require('angular-ui-router'),
+    require('angular-ui-router').default,
     TASK_MONITOR_BUILDER,
     SECURITY_GROUP_READER,
     SECURITY_GROUP_WRITER,

--- a/app/scripts/modules/amazon/securityGroup/details/securityGroupDetail.controller.js
+++ b/app/scripts/modules/amazon/securityGroup/details/securityGroupDetail.controller.js
@@ -10,7 +10,7 @@ import {SECURITY_GROUP_READER} from 'core/securityGroup/securityGroupReader.serv
 import {SECURITY_GROUP_WRITER} from 'core/securityGroup/securityGroupWriter.service';
 
 module.exports = angular.module('spinnaker.securityGroup.aws.details.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   SECURITY_GROUP_READER,
   SECURITY_GROUP_WRITER,
   CONFIRMATION_MODAL_SERVICE,

--- a/app/scripts/modules/amazon/serverGroup/configure/wizard/CloneServerGroup.aws.controller.js
+++ b/app/scripts/modules/amazon/serverGroup/configure/wizard/CloneServerGroup.aws.controller.js
@@ -9,7 +9,7 @@ import {SERVER_GROUP_WRITER} from 'core/serverGroup/serverGroupWriter.service';
 import {TASK_MONITOR_BUILDER} from 'core/task/monitor/taskMonitor.builder';
 
 module.exports = angular.module('spinnaker.aws.cloneServerGroup.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   require('core/application/modal/platformHealthOverride.directive.js'),
   require('../serverGroupConfiguration.service.js'),
   SERVER_GROUP_WRITER,

--- a/app/scripts/modules/amazon/serverGroup/configure/wizard/location/ServerGroupBasicSettings.controller.js
+++ b/app/scripts/modules/amazon/serverGroup/configure/wizard/location/ServerGroupBasicSettings.controller.js
@@ -10,7 +10,7 @@ import {SUBNET_SELECT_FIELD_COMPONENT} from 'amazon/subnet/subnetSelectField.com
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.serverGroup.configure.aws.basicSettings', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   require('angular-ui-bootstrap'),
   require('core/serverGroup/configure/common/basicSettingsMixin.controller.js'),
   V2_MODAL_WIZARD_SERVICE,

--- a/app/scripts/modules/amazon/serverGroup/details/serverGroupDetails.aws.controller.js
+++ b/app/scripts/modules/amazon/serverGroup/details/serverGroupDetails.aws.controller.js
@@ -18,7 +18,7 @@ import {ENTITY_SOURCE_COMPONENT} from 'core/entityTag/entitySource.component';
 require('../configure/serverGroup.configure.aws.module.js');
 
 module.exports = angular.module('spinnaker.serverGroup.details.aws.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   require('core/application/modal/platformHealthOverride.directive.js'),
   CONFIRMATION_MODAL_SERVICE,
   SERVER_GROUP_WRITER,

--- a/app/scripts/modules/appengine/pipeline/stages/editLoadBalancer/appengineEditLoadBalancerExecutionDetails.controller.ts
+++ b/app/scripts/modules/appengine/pipeline/stages/editLoadBalancer/appengineEditLoadBalancerExecutionDetails.controller.ts
@@ -21,7 +21,7 @@ class AppengineEditLoadBalancerExecutionDetailsCtrl extends BaseExecutionDetails
 
 export const APPENGINE_EDIT_LOAD_BALANCER_EXECUTION_DETAILS_CTRL = 'spinnaker.appengine.editLoadBalancerExecutionDetails.controller';
 module(APPENGINE_EDIT_LOAD_BALANCER_EXECUTION_DETAILS_CTRL, [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   EXECUTION_DETAILS_SECTION_SERVICE,
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ]).controller('appengineEditLoadBalancerExecutionDetailsCtrl', AppengineEditLoadBalancerExecutionDetailsCtrl);

--- a/app/scripts/modules/appengine/pipeline/stages/startServerGroup/appengineStartServerGroupExecutionDetails.controller.ts
+++ b/app/scripts/modules/appengine/pipeline/stages/startServerGroup/appengineStartServerGroupExecutionDetails.controller.ts
@@ -22,7 +22,7 @@ class AppengineStartServerGroupExecutionDetailsCtrl extends BaseExecutionDetails
 export const APPENGINE_START_SERVER_GROUP_EXECUTION_DETAILS_CTRL = 'spinnaker.appengine.pipeline.stage.startServerGroup.executionDetails.controller';
 
 module(APPENGINE_START_SERVER_GROUP_EXECUTION_DETAILS_CTRL, [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   EXECUTION_DETAILS_SECTION_SERVICE,
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ]).controller('appengineStartServerGroupExecutionDetailsCtrl', AppengineStartServerGroupExecutionDetailsCtrl);

--- a/app/scripts/modules/appengine/pipeline/stages/stopServerGroup/appengineStopServerGroupExecutionDetails.controller.ts
+++ b/app/scripts/modules/appengine/pipeline/stages/stopServerGroup/appengineStopServerGroupExecutionDetails.controller.ts
@@ -22,7 +22,7 @@ class AppengineStopServerGroupExecutionDetailsCtrl extends BaseExecutionDetailsC
 export const APPENGINE_STOP_SERVER_GROUP_EXECUTION_DETAILS_CTRL = 'spinnaker.appengine.pipeline.stage.stopServerGroup.executionDetails.controller';
 
 module(APPENGINE_STOP_SERVER_GROUP_EXECUTION_DETAILS_CTRL, [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   EXECUTION_DETAILS_SECTION_SERVICE,
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ]).controller('appengineStopServerGroupExecutionDetailsCtrl', AppengineStopServerGroupExecutionDetailsCtrl);

--- a/app/scripts/modules/azure/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/azure/instance/details/instance.details.controller.js
@@ -10,7 +10,7 @@ import {RECENT_HISTORY_SERVICE} from 'core/history/recentHistory.service';
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.azure.instance.detail.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   require('angular-ui-bootstrap'),
   INSTANCE_WRITE_SERVICE,
   INSTANCE_READ_SERVICE,

--- a/app/scripts/modules/azure/loadBalancer/configure/createLoadBalancer.controller.js
+++ b/app/scripts/modules/azure/loadBalancer/configure/createLoadBalancer.controller.js
@@ -13,7 +13,7 @@ import {LOAD_BALANCER_WRITE_SERVICE} from 'core/loadBalancer/loadBalancer.write.
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.azure.loadBalancer.create.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   LOAD_BALANCER_WRITE_SERVICE,
   ACCOUNT_SERVICE,
   require('../loadBalancer.transformer.js'),

--- a/app/scripts/modules/azure/loadBalancer/details/loadBalancerDetail.controller.js
+++ b/app/scripts/modules/azure/loadBalancer/details/loadBalancerDetail.controller.js
@@ -9,7 +9,7 @@ import {LOAD_BALANCER_READ_SERVICE} from 'core/loadBalancer/loadBalancer.read.se
 import {LOAD_BALANCER_WRITE_SERVICE} from 'core/loadBalancer/loadBalancer.write.service';
 
 module.exports = angular.module('spinnaker.azure.loadBalancer.details.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   SECURITY_GROUP_READER,
   LOAD_BALANCER_WRITE_SERVICE,
   LOAD_BALANCER_READ_SERVICE,

--- a/app/scripts/modules/azure/pipeline/stages/bake/bakeExecutionDetails.controller.js
+++ b/app/scripts/modules/azure/pipeline/stages/bake/bakeExecutionDetails.controller.js
@@ -6,7 +6,7 @@ import {SETTINGS} from 'core/config/settings';
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.bake.azure.executionDetails.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   EXECUTION_DETAILS_SECTION_SERVICE,
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ])

--- a/app/scripts/modules/azure/securityGroup/configure/CreateSecurityGroupCtrl.js
+++ b/app/scripts/modules/azure/securityGroup/configure/CreateSecurityGroupCtrl.js
@@ -7,7 +7,7 @@ import {TASK_MONITOR_BUILDER} from 'core/task/monitor/taskMonitor.builder';
 
 module.exports = angular
   .module('spinnaker.azure.securityGroup.create.controller', [
-    require('angular-ui-router'),
+    require('angular-ui-router').default,
     TASK_MONITOR_BUILDER,
     require('../securityGroup.write.service.js'),
     require('core/region/regionSelectField.directive.js'),

--- a/app/scripts/modules/azure/securityGroup/configure/EditSecurityGroupCtrl.js
+++ b/app/scripts/modules/azure/securityGroup/configure/EditSecurityGroupCtrl.js
@@ -9,7 +9,7 @@ import {SECURITY_GROUP_READER} from 'core/securityGroup/securityGroupReader.serv
 import {TASK_MONITOR_BUILDER} from 'core/task/monitor/taskMonitor.builder';
 
 module.exports = angular.module('spinnaker.azure.securityGroup.azure.edit.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   ACCOUNT_SERVICE,
   INFRASTRUCTURE_CACHE_SERVICE,
   CACHE_INITIALIZER_SERVICE,

--- a/app/scripts/modules/azure/securityGroup/configure/configSecurityGroup.mixin.controller.js
+++ b/app/scripts/modules/azure/securityGroup/configure/configSecurityGroup.mixin.controller.js
@@ -11,7 +11,7 @@ import {TASK_MONITOR_BUILDER} from 'core/task/monitor/taskMonitor.builder';
 
 module.exports = angular
   .module('spinnaker.azure.securityGroup.baseConfig.controller', [
-    require('angular-ui-router'),
+    require('angular-ui-router').default,
     TASK_MONITOR_BUILDER,
     SECURITY_GROUP_READER,
     SECURITY_GROUP_WRITER,

--- a/app/scripts/modules/azure/securityGroup/details/securityGroupDetail.controller.js
+++ b/app/scripts/modules/azure/securityGroup/details/securityGroupDetail.controller.js
@@ -9,7 +9,7 @@ let angular = require('angular');
 import {SECURITY_GROUP_READER} from 'core/securityGroup/securityGroupReader.service';
 
 module.exports = angular.module('spinnaker.azure.securityGroup.azure.details.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   SECURITY_GROUP_READER,
   require('../securityGroup.write.service.js'),
   CONFIRMATION_MODAL_SERVICE,

--- a/app/scripts/modules/azure/securityGroup/securityGroup.write.service.js
+++ b/app/scripts/modules/azure/securityGroup/securityGroup.write.service.js
@@ -8,7 +8,7 @@ import {INFRASTRUCTURE_CACHE_SERVICE} from 'core/cache/infrastructureCaches.serv
 
 module.exports = angular
   .module('spinnaker.azure.securityGroup.write.service', [
-    require('angular-ui-router'),
+    require('angular-ui-router').default,
     TASK_EXECUTOR,
     INFRASTRUCTURE_CACHE_SERVICE
   ])

--- a/app/scripts/modules/azure/serverGroup/configure/wizard/CloneServerGroup.azure.controller.js
+++ b/app/scripts/modules/azure/serverGroup/configure/wizard/CloneServerGroup.azure.controller.js
@@ -7,7 +7,7 @@ import {SERVER_GROUP_WRITER} from 'core/serverGroup/serverGroupWriter.service';
 import {TASK_MONITOR_BUILDER} from 'core/task/monitor/taskMonitor.builder';
 
 module.exports = angular.module('spinnaker.azure.cloneServerGroup.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   require('../serverGroupConfiguration.service.js'),
   require('../../serverGroup.transformer.js'),
   SERVER_GROUP_WRITER,

--- a/app/scripts/modules/azure/serverGroup/configure/wizard/basicSettings/ServerGroupBasicSettings.controller.js
+++ b/app/scripts/modules/azure/serverGroup/configure/wizard/basicSettings/ServerGroupBasicSettings.controller.js
@@ -7,7 +7,7 @@ import {V2_MODAL_WIZARD_SERVICE} from 'core/modal/wizard/v2modalWizard.service';
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.azure.serverGroup.configure.basicSettings', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   require('angular-ui-bootstrap'),
   require('./image.regional.filter.js'),
   require('core/serverGroup/configure/common/basicSettingsMixin.controller.js'),

--- a/app/scripts/modules/azure/serverGroup/details/serverGroupDetails.azure.controller.js
+++ b/app/scripts/modules/azure/serverGroup/details/serverGroupDetails.azure.controller.js
@@ -13,7 +13,7 @@ require('../configure/serverGroup.configure.azure.module.js');
 
 
 module.exports = angular.module('spinnaker.azure.serverGroup.details.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   require('../configure/serverGroupCommandBuilder.service.js'),
   SERVER_GROUP_READER,
   require('core/utils/selectOnDblClick.directive.js'),

--- a/app/scripts/modules/cloudfoundry/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/cloudfoundry/instance/details/instance.details.controller.js
@@ -11,7 +11,7 @@ import {RECENT_HISTORY_SERVICE} from 'core/history/recentHistory.service';
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.instance.detail.cf.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   require('angular-ui-bootstrap'),
   INSTANCE_WRITE_SERVICE,
   INSTANCE_READ_SERVICE,

--- a/app/scripts/modules/cloudfoundry/loadBalancer/configure/CreateLoadBalancerCtrl.js
+++ b/app/scripts/modules/cloudfoundry/loadBalancer/configure/CreateLoadBalancerCtrl.js
@@ -7,7 +7,7 @@ import {LOAD_BALANCER_WRITE_SERVICE} from 'core/loadBalancer/loadBalancer.write.
 import {TASK_MONITOR_BUILDER} from 'core/task/monitor/taskMonitor.builder';
 import {V2_MODAL_WIZARD_SERVICE} from 'core/modal/wizard/v2modalWizard.service';
 module.exports = angular.module('spinnaker.loadBalancer.cf.create.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   LOAD_BALANCER_WRITE_SERVICE,
   ACCOUNT_SERVICE,
   require('../loadBalancer.transformer.js'),

--- a/app/scripts/modules/cloudfoundry/loadBalancer/details/LoadBalancerDetailsCtrl.js
+++ b/app/scripts/modules/cloudfoundry/loadBalancer/details/LoadBalancerDetailsCtrl.js
@@ -8,7 +8,7 @@ import {LOAD_BALANCER_WRITE_SERVICE} from 'core/loadBalancer/loadBalancer.write.
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.loadBalancer.cf.details.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   ACCOUNT_SERVICE,
   CONFIRMATION_MODAL_SERVICE,
   LOAD_BALANCER_WRITE_SERVICE,

--- a/app/scripts/modules/cloudfoundry/pipeline/stages/cloneServerGroup/cloneServerGroupExecutionDetails.controller.js
+++ b/app/scripts/modules/cloudfoundry/pipeline/stages/cloneServerGroup/cloneServerGroupExecutionDetails.controller.js
@@ -9,7 +9,7 @@ import {URL_BUILDER_SERVICE} from 'core/navigation/urlBuilder.service';
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.cloneServerGroup.cf.executionDetails.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   CLUSTER_FILTER_SERVICE,
   EXECUTION_DETAILS_SECTION_SERVICE,
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),

--- a/app/scripts/modules/cloudfoundry/pipeline/stages/disableCluster/disableClusterExecutionDetails.controller.js
+++ b/app/scripts/modules/cloudfoundry/pipeline/stages/disableCluster/disableClusterExecutionDetails.controller.js
@@ -5,7 +5,7 @@ import {EXECUTION_DETAILS_SECTION_SERVICE} from 'core/delivery/details/execution
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.disableCluster.cf.executionDetails.controller', [
-    require('angular-ui-router'),
+    require('angular-ui-router').default,
     EXECUTION_DETAILS_SECTION_SERVICE,
     require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ])

--- a/app/scripts/modules/cloudfoundry/pipeline/stages/findAmi/findAmiExecutionDetails.controller.js
+++ b/app/scripts/modules/cloudfoundry/pipeline/stages/findAmi/findAmiExecutionDetails.controller.js
@@ -5,7 +5,7 @@ import {EXECUTION_DETAILS_SECTION_SERVICE} from 'core/delivery/details/execution
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.findAmi.cf.executionDetails.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   EXECUTION_DETAILS_SECTION_SERVICE,
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ])

--- a/app/scripts/modules/cloudfoundry/pipeline/stages/resizeAsg/resizeAsgExecutionDetails.controller.js
+++ b/app/scripts/modules/cloudfoundry/pipeline/stages/resizeAsg/resizeAsgExecutionDetails.controller.js
@@ -5,7 +5,7 @@ import {EXECUTION_DETAILS_SECTION_SERVICE} from 'core/delivery/details/execution
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.resizeAsg.cf.executionDetails.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   EXECUTION_DETAILS_SECTION_SERVICE,
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ])

--- a/app/scripts/modules/cloudfoundry/pipeline/stages/scaleDownCluster/scaleDownClusterExecutionDetails.controller.js
+++ b/app/scripts/modules/cloudfoundry/pipeline/stages/scaleDownCluster/scaleDownClusterExecutionDetails.controller.js
@@ -5,7 +5,7 @@ import {EXECUTION_DETAILS_SECTION_SERVICE} from 'core/delivery/details/execution
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.scaleDownCluster.cf.executionDetails.controller', [
-    require('angular-ui-router'),
+    require('angular-ui-router').default,
     EXECUTION_DETAILS_SECTION_SERVICE,
     require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ])

--- a/app/scripts/modules/cloudfoundry/securityGroup/details/SecurityGroupDetailsCtrl.js
+++ b/app/scripts/modules/cloudfoundry/securityGroup/details/SecurityGroupDetailsCtrl.js
@@ -7,7 +7,7 @@ import {ACCOUNT_SERVICE} from 'core/account/account.service';
 import {SECURITY_GROUP_READER} from 'core/securityGroup/securityGroupReader.service';
 
 module.exports = angular.module('spinnaker.securityGroup.cf.details.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   ACCOUNT_SERVICE,
   SECURITY_GROUP_READER,
   require('core/utils/selectOnDblClick.directive.js'),

--- a/app/scripts/modules/cloudfoundry/serverGroup/configure/wizard/CloneServerGroupCtrl.js
+++ b/app/scripts/modules/cloudfoundry/serverGroup/configure/wizard/CloneServerGroupCtrl.js
@@ -5,7 +5,7 @@ import {V2_MODAL_WIZARD_SERVICE} from 'core/modal/wizard/v2modalWizard.service';
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.serverGroup.configure.cf.cloneServerGroup', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   V2_MODAL_WIZARD_SERVICE,
 ])
   .controller('cfCloneServerGroupCtrl', function($scope, $uibModalInstance, $q, $state,

--- a/app/scripts/modules/cloudfoundry/serverGroup/details/serverGroupDetails.cf.controller.js
+++ b/app/scripts/modules/cloudfoundry/serverGroup/details/serverGroupDetails.cf.controller.js
@@ -12,7 +12,7 @@ let angular = require('angular');
 
 
 module.exports = angular.module('spinnaker.serverGroup.details.cf.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   require('../configure/ServerGroupCommandBuilder.js'),
   SERVER_GROUP_WARNING_MESSAGE_SERVICE,
   SERVER_GROUP_READER,

--- a/app/scripts/modules/core/application/application.controller.js
+++ b/app/scripts/modules/core/application/application.controller.js
@@ -9,7 +9,7 @@ require('./application.less');
 
 module.exports = angular.module('spinnaker.application.controller', [
   require('exports-loader?"cfp.hotkeys"!angular-hotkeys'),
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   RECENT_HISTORY_SERVICE,
   require('../presentation/refresher/componentRefresher.directive.js'),
 ])

--- a/app/scripts/modules/core/application/applications.controller.js
+++ b/app/scripts/modules/core/application/applications.controller.js
@@ -9,7 +9,7 @@ import {VIEW_STATE_CACHE_SERVICE} from 'core/cache/viewStateCache.service';
 import {OVERRIDE_REGISTRY} from 'core/overrideRegistry/override.registry';
 
 module.exports = angular.module('spinnaker.applications.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   APPLICATION_READ_SERVICE,
   ACCOUNT_SERVICE,
   ANY_FIELD_FILTER,

--- a/app/scripts/modules/core/application/config/applicationConfig.controller.js
+++ b/app/scripts/modules/core/application/config/applicationConfig.controller.js
@@ -7,7 +7,7 @@ let angular = require('angular');
 
 module.exports = angular
   .module('spinnaker.core.application.config.controller', [
-    require('angular-ui-router'),
+    require('angular-ui-router').default,
     require('./applicationAttributes.directive.js'),
     require('./applicationNotifications.directive.js'),
     require('./applicationCacheManagement.directive.js'),

--- a/app/scripts/modules/core/application/config/applicationSnapshotSection.component.js
+++ b/app/scripts/modules/core/application/config/applicationSnapshotSection.component.js
@@ -6,7 +6,7 @@ const angular = require('angular');
 
 module.exports = angular
   .module('spinnaker.core.application.config.serialize.component', [
-    require('angular-ui-router'),
+    require('angular-ui-router').default,
     require('./../../snapshot/snapshot.write.service.js'),
     CONFIRMATION_MODAL_SERVICE,
     require('core/snapshot/diff/viewSnapshotDiffButton.component.js'),

--- a/app/scripts/modules/core/application/config/deleteApplicationSection.directive.js
+++ b/app/scripts/modules/core/application/config/deleteApplicationSection.directive.js
@@ -8,7 +8,7 @@ import {OVERRIDE_REGISTRY} from 'core/overrideRegistry/override.registry';
 
 module.exports = angular
   .module('spinnaker.core.application.config.delete.directive', [
-    require('angular-ui-router'),
+    require('angular-ui-router').default,
     APPLICATION_WRITE_SERVICE,
     CONFIRMATION_MODAL_SERVICE,
     OVERRIDE_REGISTRY,

--- a/app/scripts/modules/core/application/modal/createApplication.modal.controller.js
+++ b/app/scripts/modules/core/application/modal/createApplication.modal.controller.js
@@ -14,7 +14,7 @@ let angular = require('angular');
 
 module.exports = angular
   .module('spinnaker.application.create.modal.controller', [
-    require('angular-ui-router'),
+    require('angular-ui-router').default,
     APPLICATION_WRITE_SERVICE,
     APPLICATION_READ_SERVICE,
     ACCOUNT_SERVICE,

--- a/app/scripts/modules/core/application/nav/applicationNav.component.js
+++ b/app/scripts/modules/core/application/nav/applicationNav.component.js
@@ -6,7 +6,7 @@ require('./applicationNav.component.less');
 
 module.exports = angular
   .module('spinnaker.core.application.nav.component', [
-    require('angular-ui-router'),
+    require('angular-ui-router').default,
     DATA_SOURCE_ALERTS_COMPONENT,
   ])
   .component('applicationNav', {

--- a/app/scripts/modules/core/cluster/allClusters.controller.js
+++ b/app/scripts/modules/core/cluster/allClusters.controller.js
@@ -25,7 +25,7 @@ module.exports = angular.module('spinnaker.core.cluster.allClusters.controller',
   INSIGHT_NGMODULE.name,
   require('angular-ui-bootstrap'),
   CLOUD_PROVIDER_REGISTRY,
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
 ])
   .controller('AllClustersCtrl', function($scope, app, $uibModal, $timeout, providerSelectionService, clusterFilterService, $state,
                                           ClusterFilterModel, MultiselectModel, InsightFilterStateModel, serverGroupCommandBuilder, cloudProviderRegistry) {

--- a/app/scripts/modules/core/cluster/filter/clusterFilter.service.ts
+++ b/app/scripts/modules/core/cluster/filter/clusterFilter.service.ts
@@ -469,7 +469,7 @@ export class ClusterFilterService {
 
 export const CLUSTER_FILTER_SERVICE = 'spinnaker.core.cluster.filter.service';
 module(CLUSTER_FILTER_SERVICE, [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   require('./clusterFilter.model'),
   require('./multiselect.model'),
   require('../../utils/waypoints/waypoint.service'),

--- a/app/scripts/modules/core/cluster/filter/multiselect.model.js
+++ b/app/scripts/modules/core/cluster/filter/multiselect.model.js
@@ -6,7 +6,7 @@ let angular = require('angular');
 
 module.exports = angular
   .module('spinnaker.core.cluster.filter.multiselect.model', [
-    require('angular-ui-router'),
+    require('angular-ui-router').default,
     require('./clusterFilter.model'),
   ])
   .factory('MultiselectModel', function ($state, ClusterFilterModel) {

--- a/app/scripts/modules/core/core.module.js
+++ b/app/scripts/modules/core/core.module.js
@@ -50,7 +50,7 @@ module.exports = angular
   .module('spinnaker.core', [
     require('angular-messages'),
     require('angular-sanitize'),
-    require('angular-ui-router'),
+    require('angular-ui-router').default,
     require('angular-ui-bootstrap'),
     require('exports-loader?"angular.filter"!angular-filter'),
     require('exports-loader?"ui.select"!ui-select'),

--- a/app/scripts/modules/core/delivery/details/executionDetails.controller.js
+++ b/app/scripts/modules/core/delivery/details/executionDetails.controller.js
@@ -5,7 +5,7 @@ import {PIPELINE_CONFIG_PROVIDER} from 'core/pipeline/config/pipelineConfigProvi
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.executionDetails.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   PIPELINE_CONFIG_PROVIDER
 ])
   .controller('executionDetails', function($scope, $stateParams, $state, pipelineConfig) {

--- a/app/scripts/modules/core/delivery/details/executionDetailsSection.service.ts
+++ b/app/scripts/modules/core/delivery/details/executionDetailsSection.service.ts
@@ -36,5 +36,5 @@ export class ExecutionDetailsSectionService {
 
 export const EXECUTION_DETAILS_SECTION_SERVICE = 'spinnaker.executionDetails.section.service';
 module(EXECUTION_DETAILS_SECTION_SERVICE, [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
 ]).service('executionDetailsSectionService', ExecutionDetailsSectionService);

--- a/app/scripts/modules/core/delivery/details/singleExecutionDetails.controller.js
+++ b/app/scripts/modules/core/delivery/details/singleExecutionDetails.controller.js
@@ -6,7 +6,7 @@ import {SCHEDULER_FACTORY} from 'core/scheduler/scheduler.factory';
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.singleExecutionDetails.controller', [
-    require('angular-ui-router'),
+    require('angular-ui-router').default,
     EXECUTION_SERVICE,
     SCHEDULER_FACTORY,
   ])

--- a/app/scripts/modules/core/filterModel/filter.model.service.js
+++ b/app/scripts/modules/core/filterModel/filter.model.service.js
@@ -6,7 +6,7 @@ let angular = require('angular');
 
 module.exports = angular
   .module('spinnaker.core.filterModel.service', [
-    require('angular-ui-router'),
+    require('angular-ui-router').default,
   ])
 .factory('filterModelService', function ($location, $state, $stateParams, $urlRouter, $timeout) {
 

--- a/app/scripts/modules/core/insight/insight.module.ts
+++ b/app/scripts/modules/core/insight/insight.module.ts
@@ -3,7 +3,7 @@ import {module} from 'angular';
 import { COLLAPSIBLE_SECTION_STATE_CACHE } from 'core/cache/collapsibleSectionStateCache';
 
 export const INSIGHT_NGMODULE = module('spinnaker.core.insight', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   COLLAPSIBLE_SECTION_STATE_CACHE,
 ]);
 

--- a/app/scripts/modules/core/instance/details/multipleInstances.controller.js
+++ b/app/scripts/modules/core/instance/details/multipleInstances.controller.js
@@ -6,7 +6,7 @@ import {INSTANCE_WRITE_SERVICE} from 'core/instance/instance.write.service';
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.instance.details.multipleInstances.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   INSTANCE_WRITE_SERVICE,
   CONFIRMATION_MODAL_SERVICE,
   require('../../cluster/filter/multiselect.model'),

--- a/app/scripts/modules/core/navigation/state.provider.ts
+++ b/app/scripts/modules/core/navigation/state.provider.ts
@@ -57,7 +57,7 @@ export class StateConfigProvider implements ng.IServiceProvider {
 
 export const STATE_CONFIG_PROVIDER = 'spinnaker.core.navigation.state.config.provider';
 module(STATE_CONFIG_PROVIDER, [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   STATE_HELPER,
 ]).provider('stateConfig', StateConfigProvider)
   .config(($urlRouterProvider: IUrlRouterProvider) => {

--- a/app/scripts/modules/core/navigation/urlBuilder.service.ts
+++ b/app/scripts/modules/core/navigation/urlBuilder.service.ts
@@ -439,5 +439,5 @@ export class UrlBuilderService {
 }
 
 export const URL_BUILDER_SERVICE = 'spinnaker.core.navigation.urlBuilder.service';
-module(URL_BUILDER_SERVICE, [require('angular-ui-router')])
+module(URL_BUILDER_SERVICE, [require('angular-ui-router').default])
   .service('urlBuilderService', UrlBuilderService);

--- a/app/scripts/modules/core/pageTitle/pageTitle.service.js
+++ b/app/scripts/modules/core/pageTitle/pageTitle.service.js
@@ -4,7 +4,7 @@ let angular = require('angular');
 
 module.exports = angular
   .module('spinnaker.core.pageTitle.service',
-    [require('angular-ui-router')]
+    [require('angular-ui-router').default]
   )
   .factory('pageTitleService', function($rootScope, $stateParams) {
 

--- a/app/scripts/modules/core/pipeline/config/actions/delete/delete.module.js
+++ b/app/scripts/modules/core/pipeline/config/actions/delete/delete.module.js
@@ -6,7 +6,7 @@ import {PIPELINE_CONFIG_SERVICE} from 'core/pipeline/config/services/pipelineCon
 
 module.exports = angular.module('spinnaker.core.pipeline.config.actions.delete', [
   PIPELINE_CONFIG_SERVICE,
-  require('angular-ui-router')
+  require('angular-ui-router').default
 ])
   .controller('DeletePipelineModalCtrl', function($scope, $uibModalInstance, $log,
                                                   pipelineConfigService,

--- a/app/scripts/modules/core/pipeline/config/pipelineConfig.controller.js
+++ b/app/scripts/modules/core/pipeline/config/pipelineConfig.controller.js
@@ -5,7 +5,7 @@ import _ from 'lodash';
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.config.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
 ])
   .controller('PipelineConfigCtrl', function($scope, $stateParams) {
 

--- a/app/scripts/modules/core/pipeline/config/stages/checkPreconditions/checkPreconditionsExecutionDetails.controller.js
+++ b/app/scripts/modules/core/pipeline/config/stages/checkPreconditions/checkPreconditionsExecutionDetails.controller.js
@@ -5,7 +5,7 @@ import {EXECUTION_DETAILS_SECTION_SERVICE} from 'core/delivery/details/execution
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.pipelines.stage.checkPreconditions.executionDetails.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   EXECUTION_DETAILS_SECTION_SERVICE,
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ])

--- a/app/scripts/modules/core/pipeline/config/stages/createLoadBalancer/createLoadBalancerExecutionDetails.controller.js
+++ b/app/scripts/modules/core/pipeline/config/stages/createLoadBalancer/createLoadBalancerExecutionDetails.controller.js
@@ -6,7 +6,7 @@ import {CLOUD_PROVIDER_REGISTRY} from 'core/cloudProvider/cloudProvider.registry
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.createLoadBalancer.executionDetails.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   EXECUTION_DETAILS_SECTION_SERVICE,
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),
   CLOUD_PROVIDER_REGISTRY,

--- a/app/scripts/modules/core/pipeline/config/stages/deploy/deployExecutionDetails.controller.js
+++ b/app/scripts/modules/core/pipeline/config/stages/deploy/deployExecutionDetails.controller.js
@@ -12,7 +12,7 @@ import {URL_BUILDER_SERVICE} from 'core/navigation/urlBuilder.service';
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.deploy.details.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   CLUSTER_FILTER_SERVICE,
   EXECUTION_DETAILS_SECTION_SERVICE,
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),

--- a/app/scripts/modules/core/pipeline/config/stages/destroyAsg/templates/destroyAsgExecutionDetails.controller.ts
+++ b/app/scripts/modules/core/pipeline/config/stages/destroyAsg/templates/destroyAsgExecutionDetails.controller.ts
@@ -22,7 +22,7 @@ class DestroyAsgExecutionDetailsCtrl extends BaseExecutionDetailsCtrl {
 export const DESTROY_ASG_EXECUTION_DETAILS_CTRL = 'spinnaker.core.pipeline.stage.destroyAsg.executionDetails.controller';
 
 module(DESTROY_ASG_EXECUTION_DETAILS_CTRL, [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   EXECUTION_DETAILS_SECTION_SERVICE,
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ]).controller('destroyAsgExecutionDetailsCtrl', DestroyAsgExecutionDetailsCtrl);

--- a/app/scripts/modules/core/pipeline/config/stages/disableAsg/templates/disableAsgExecutionDetails.controller.ts
+++ b/app/scripts/modules/core/pipeline/config/stages/disableAsg/templates/disableAsgExecutionDetails.controller.ts
@@ -22,7 +22,7 @@ class DisableAsgExecutionDetailsCtrl extends BaseExecutionDetailsCtrl {
 export const DISABLE_ASG_EXECUTION_DETAILS_CTRL = 'spinnaker.core.pipeline.stage.disableAsg.executionDetails.controller';
 
 module(DISABLE_ASG_EXECUTION_DETAILS_CTRL, [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   EXECUTION_DETAILS_SECTION_SERVICE,
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ]).controller('disableAsgExecutionDetailsCtrl', DisableAsgExecutionDetailsCtrl);

--- a/app/scripts/modules/core/pipeline/config/stages/enableAsg/templates/enableAsgExecutionDetails.controller.ts
+++ b/app/scripts/modules/core/pipeline/config/stages/enableAsg/templates/enableAsgExecutionDetails.controller.ts
@@ -22,7 +22,7 @@ class EnableAsgExecutionDetailsCtrl extends BaseExecutionDetailsCtrl {
 export const ENABLE_ASG_EXECUTION_DETAILS_CTRL = 'spinnaker.core.pipeline.stage.enableAsg.executionDetails.controller';
 
 module(ENABLE_ASG_EXECUTION_DETAILS_CTRL, [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   EXECUTION_DETAILS_SECTION_SERVICE,
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ]).controller('enableAsgExecutionDetailsCtrl', EnableAsgExecutionDetailsCtrl);

--- a/app/scripts/modules/core/pipeline/config/stages/executionWindows/executionWindowsDetails.controller.js
+++ b/app/scripts/modules/core/pipeline/config/stages/executionWindows/executionWindowsDetails.controller.js
@@ -6,7 +6,7 @@ import {EXECUTION_WINDOW_ACTIONS_COMPONENT} from './executionWindowActions.compo
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.executionWindows.details.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   EXECUTION_DETAILS_SECTION_SERVICE,
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),
   EXECUTION_WINDOW_ACTIONS_COMPONENT

--- a/app/scripts/modules/core/pipeline/config/stages/jenkins/jenkinsExecutionDetails.controller.js
+++ b/app/scripts/modules/core/pipeline/config/stages/jenkins/jenkinsExecutionDetails.controller.js
@@ -5,7 +5,7 @@ import {EXECUTION_DETAILS_SECTION_SERVICE} from 'core/delivery/details/execution
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.jenkins.executionDetails.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   EXECUTION_DETAILS_SECTION_SERVICE,
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ])

--- a/app/scripts/modules/core/pipeline/config/stages/manualJudgment/manualJudgmentExecutionDetails.controller.js
+++ b/app/scripts/modules/core/pipeline/config/stages/manualJudgment/manualJudgmentExecutionDetails.controller.js
@@ -7,7 +7,7 @@ import {MANUAL_JUDGMENT_COMPONENT} from './manualJudgment.component';
 
 module.exports = angular
     .module('spinnaker.core.pipeline.stage.manualJudgment.executionDetails.controller', [
-    require('angular-ui-router'),
+    require('angular-ui-router').default,
     MANUAL_JUDGMENT_COMPONENT,
     EXECUTION_DETAILS_SECTION_SERVICE,
     require('core/delivery/details/executionDetailsSectionNav.directive.js'),

--- a/app/scripts/modules/core/pipeline/config/stages/pipeline/pipelineExecutionDetails.controller.js
+++ b/app/scripts/modules/core/pipeline/config/stages/pipeline/pipelineExecutionDetails.controller.js
@@ -6,7 +6,7 @@ import {EXECUTION_DETAILS_SECTION_SERVICE} from 'core/delivery/details/execution
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.pipeline.executionDetails.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   EXECUTION_DETAILS_SECTION_SERVICE,
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ])

--- a/app/scripts/modules/core/pipeline/config/stages/script/scriptExecutionDetails.controller.js
+++ b/app/scripts/modules/core/pipeline/config/stages/script/scriptExecutionDetails.controller.js
@@ -5,7 +5,7 @@ import {EXECUTION_DETAILS_SECTION_SERVICE} from 'core/delivery/details/execution
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.script.executionDetails.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   EXECUTION_DETAILS_SECTION_SERVICE,
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ])

--- a/app/scripts/modules/core/pipeline/config/stages/shrinkCluster/templates/shrinkClusterExecutionDetails.controller.ts
+++ b/app/scripts/modules/core/pipeline/config/stages/shrinkCluster/templates/shrinkClusterExecutionDetails.controller.ts
@@ -22,7 +22,7 @@ class ShrinkClusterExecutionDetailsCtrl extends BaseExecutionDetailsCtrl {
 export const SHRINK_CLUSTER_EXECUTION_DETAILS_CTRL = 'spinnaker.core.pipeline.stage.shrinkCluster.executionDetails.controller';
 
 module(SHRINK_CLUSTER_EXECUTION_DETAILS_CTRL, [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   EXECUTION_DETAILS_SECTION_SERVICE,
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ]).controller('shrinkClusterExecutionDetailsCtrl', ShrinkClusterExecutionDetailsCtrl);

--- a/app/scripts/modules/core/pipeline/config/stages/wait/waitExecutionDetails.controller.js
+++ b/app/scripts/modules/core/pipeline/config/stages/wait/waitExecutionDetails.controller.js
@@ -6,7 +6,7 @@ import {SKIP_WAIT_COMPONENT} from './skipWait.component';
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.wait.executionDetails.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   EXECUTION_DETAILS_SECTION_SERVICE,
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),
   SKIP_WAIT_COMPONENT,

--- a/app/scripts/modules/core/projects/projects.controller.js
+++ b/app/scripts/modules/core/projects/projects.controller.js
@@ -6,7 +6,7 @@ import {ACCOUNT_SERVICE} from 'core/account/account.service';
 import {VIEW_STATE_CACHE_SERVICE} from 'core/cache/viewStateCache.service';
 
 module.exports = angular.module('spinnaker.projects.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   require('./service/project.write.service.js'),
   require('./service/project.read.service.js'),
   ACCOUNT_SERVICE,

--- a/app/scripts/modules/core/serverGroup/configure/common/basicSettingsMixin.controller.js
+++ b/app/scripts/modules/core/serverGroup/configure/common/basicSettingsMixin.controller.js
@@ -10,7 +10,7 @@ let angular = require('angular');
 module.exports = angular
   .module('spinnaker.core.serverGroup.basicSettings.controller', [
     require('angular-ui-bootstrap'),
-    require('angular-ui-router'),
+    require('angular-ui-router').default,
     NAMING_SERVICE,
     IMAGE_READER,
   ])

--- a/app/scripts/modules/core/serverGroup/details/multipleServerGroups.controller.js
+++ b/app/scripts/modules/core/serverGroup/details/multipleServerGroups.controller.js
@@ -6,7 +6,7 @@ import {SERVER_GROUP_WRITER} from 'core/serverGroup/serverGroupWriter.service';
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.serverGroup.details.multipleServerGroups.controller', [
-    require('angular-ui-router'),
+    require('angular-ui-router').default,
     SERVER_GROUP_WRITER,
     CONFIRMATION_MODAL_SERVICE,
     require('../../cluster/filter/multiselect.model'),

--- a/app/scripts/modules/core/task/tasks.controller.js
+++ b/app/scripts/modules/core/task/tasks.controller.js
@@ -10,7 +10,7 @@ import {SETTINGS} from 'core/config/settings';
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.task.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   require('./taskProgressBar.directive.js'),
   VIEW_STATE_CACHE_SERVICE,
   require('./task.write.service.js'),

--- a/app/scripts/modules/docker/pipeline/stages/bake/bakeExecutionDetails.controller.js
+++ b/app/scripts/modules/docker/pipeline/stages/bake/bakeExecutionDetails.controller.js
@@ -6,7 +6,7 @@ import {SETTINGS} from 'core/config/settings';
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.bake.docker.executionDetails.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   EXECUTION_DETAILS_SECTION_SERVICE,
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ])

--- a/app/scripts/modules/google/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/google/instance/details/instance.details.controller.js
@@ -12,7 +12,7 @@ import {GCE_HTTP_LOAD_BALANCER_UTILS} from 'google/loadBalancer/httpLoadBalancer
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.instance.detail.gce.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   require('angular-ui-bootstrap'),
   INSTANCE_WRITE_SERVICE,
   INSTANCE_READ_SERVICE,

--- a/app/scripts/modules/google/loadBalancer/configure/http/createHttpLoadBalancer.controller.js
+++ b/app/scripts/modules/google/loadBalancer/configure/http/createHttpLoadBalancer.controller.js
@@ -11,7 +11,7 @@ require('./httpLoadBalancerWizard.component.less');
 
 module.exports = angular.module('spinnaker.deck.gce.loadBalancer.createHttp.controller', [
   require('angular-ui-bootstrap'),
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   require('./backendService/backendService.component.js'),
   require('./basicSettings/basicSettings.component.js'),
   GCE_CACHE_REFRESH,

--- a/app/scripts/modules/google/loadBalancer/configure/network/createLoadBalancer.controller.js
+++ b/app/scripts/modules/google/loadBalancer/configure/network/createLoadBalancer.controller.js
@@ -8,7 +8,7 @@ import {LOAD_BALANCER_WRITE_SERVICE} from 'core/loadBalancer/loadBalancer.write.
 import {TASK_MONITOR_BUILDER} from 'core/task/monitor/taskMonitor.builder';
 
 module.exports = angular.module('spinnaker.loadBalancer.gce.create.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   LOAD_BALANCER_WRITE_SERVICE,
   ACCOUNT_SERVICE,
   require('../../loadBalancer.transformer.js'),

--- a/app/scripts/modules/google/loadBalancer/details/loadBalancerDetail.controller.js
+++ b/app/scripts/modules/google/loadBalancer/details/loadBalancerDetail.controller.js
@@ -14,7 +14,7 @@ import {GCE_HTTP_LOAD_BALANCER_UTILS} from 'google/loadBalancer/httpLoadBalancer
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.loadBalancer.gce.details.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   ACCOUNT_SERVICE,
   LOAD_BALANCER_WRITE_SERVICE,
   LOAD_BALANCER_READ_SERVICE,

--- a/app/scripts/modules/google/pipeline/stages/bake/bakeExecutionDetails.controller.js
+++ b/app/scripts/modules/google/pipeline/stages/bake/bakeExecutionDetails.controller.js
@@ -6,7 +6,7 @@ import {SETTINGS} from 'core/config/settings';
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.bake.gce.executionDetails.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   EXECUTION_DETAILS_SECTION_SERVICE,
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ])

--- a/app/scripts/modules/google/pipeline/stages/cloneServerGroup/cloneServerGroupExecutionDetails.controller.js
+++ b/app/scripts/modules/google/pipeline/stages/cloneServerGroup/cloneServerGroupExecutionDetails.controller.js
@@ -9,7 +9,7 @@ import {URL_BUILDER_SERVICE} from 'core/navigation/urlBuilder.service';
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.cloneServerGroup.gce.executionDetails.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   CLUSTER_FILTER_SERVICE,
   EXECUTION_DETAILS_SECTION_SERVICE,
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),

--- a/app/scripts/modules/google/pipeline/stages/disableCluster/disableClusterExecutionDetails.controller.js
+++ b/app/scripts/modules/google/pipeline/stages/disableCluster/disableClusterExecutionDetails.controller.js
@@ -5,7 +5,7 @@ import {EXECUTION_DETAILS_SECTION_SERVICE} from 'core/delivery/details/execution
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.disableCluster.gce.executionDetails.controller', [
-    require('angular-ui-router'),
+    require('angular-ui-router').default,
     EXECUTION_DETAILS_SECTION_SERVICE,
     require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ])

--- a/app/scripts/modules/google/pipeline/stages/findAmi/findAmiExecutionDetails.controller.js
+++ b/app/scripts/modules/google/pipeline/stages/findAmi/findAmiExecutionDetails.controller.js
@@ -5,7 +5,7 @@ import {EXECUTION_DETAILS_SECTION_SERVICE} from 'core/delivery/details/execution
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.findAmi.gce.executionDetails.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   EXECUTION_DETAILS_SECTION_SERVICE,
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ])

--- a/app/scripts/modules/google/pipeline/stages/findImageFromTags/findImageFromTagsExecutionDetails.controller.js
+++ b/app/scripts/modules/google/pipeline/stages/findImageFromTags/findImageFromTagsExecutionDetails.controller.js
@@ -6,7 +6,7 @@ let angular = require('angular');
 
 module.exports = angular
   .module('spinnaker.core.pipeline.stage.findImageFromTags.gce.executionDetails.controller', [
-    require('angular-ui-router'),
+    require('angular-ui-router').default,
     EXECUTION_DETAILS_SECTION_SERVICE,
     require('core/delivery/details/executionDetailsSectionNav.directive.js'),
   ])

--- a/app/scripts/modules/google/pipeline/stages/resizeAsg/resizeAsgExecutionDetails.controller.js
+++ b/app/scripts/modules/google/pipeline/stages/resizeAsg/resizeAsgExecutionDetails.controller.js
@@ -5,7 +5,7 @@ import {EXECUTION_DETAILS_SECTION_SERVICE} from 'core/delivery/details/execution
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.resizeAsg.gce.executionDetails.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   EXECUTION_DETAILS_SECTION_SERVICE,
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ])

--- a/app/scripts/modules/google/pipeline/stages/scaleDownCluster/scaleDownClusterExecutionDetails.controller.js
+++ b/app/scripts/modules/google/pipeline/stages/scaleDownCluster/scaleDownClusterExecutionDetails.controller.js
@@ -5,7 +5,7 @@ import {EXECUTION_DETAILS_SECTION_SERVICE} from 'core/delivery/details/execution
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.scaleDownCluster.gce.executionDetails.controller', [
-    require('angular-ui-router'),
+    require('angular-ui-router').default,
     EXECUTION_DETAILS_SECTION_SERVICE,
     require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ])

--- a/app/scripts/modules/google/pipeline/stages/tagImage/tagImageExecutionDetails.controller.js
+++ b/app/scripts/modules/google/pipeline/stages/tagImage/tagImageExecutionDetails.controller.js
@@ -6,7 +6,7 @@ let angular = require('angular');
 
 module.exports = angular
   .module('spinnaker.core.pipeline.stage.tagImage.gce.executionDetails.controller', [
-    require('angular-ui-router'),
+    require('angular-ui-router').default,
     EXECUTION_DETAILS_SECTION_SERVICE,
     require('core/delivery/details/executionDetailsSectionNav.directive.js'),
   ])

--- a/app/scripts/modules/google/securityGroup/configure/ConfigSecurityGroupMixin.controller.js
+++ b/app/scripts/modules/google/securityGroup/configure/ConfigSecurityGroupMixin.controller.js
@@ -15,7 +15,7 @@ import './securityGroup.configure.less';
 
 module.exports = angular
   .module('spinnaker.google.securityGroup.baseConfig.controller', [
-    require('angular-ui-router'),
+    require('angular-ui-router').default,
     TASK_MONITOR_BUILDER,
     ACCOUNT_SERVICE,
     NETWORK_READ_SERVICE,

--- a/app/scripts/modules/google/securityGroup/configure/createSecurityGroup.controller.js
+++ b/app/scripts/modules/google/securityGroup/configure/createSecurityGroup.controller.js
@@ -6,7 +6,7 @@ import {ACCOUNT_SERVICE} from 'core/account/account.service';
 import {INFRASTRUCTURE_CACHE_SERVICE} from 'core/cache/infrastructureCaches.service';
 
 module.exports = angular.module('spinnaker.gce.securityGroup.create.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   ACCOUNT_SERVICE,
   INFRASTRUCTURE_CACHE_SERVICE,
 ])

--- a/app/scripts/modules/google/securityGroup/configure/editSecurityGroup.controller.js
+++ b/app/scripts/modules/google/securityGroup/configure/editSecurityGroup.controller.js
@@ -8,7 +8,7 @@ import {SECURITY_GROUP_WRITER} from 'core/securityGroup/securityGroupWriter.serv
 import {TASK_MONITOR_BUILDER} from 'core/task/monitor/taskMonitor.builder';
 
 module.exports = angular.module('spinnaker.google.securityGroup.edit.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   ACCOUNT_SERVICE,
   INFRASTRUCTURE_CACHE_SERVICE,
   TASK_MONITOR_BUILDER,

--- a/app/scripts/modules/google/securityGroup/details/securityGroupDetail.controller.js
+++ b/app/scripts/modules/google/securityGroup/details/securityGroupDetail.controller.js
@@ -11,7 +11,7 @@ import {SECURITY_GROUP_WRITER} from 'core/securityGroup/securityGroupWriter.serv
 import {GCE_SECURITY_GROUP_HELP_TEXT_SERVICE} from '../securityGroupHelpText.service';
 
 module.exports = angular.module('spinnaker.securityGroup.gce.details.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   ACCOUNT_SERVICE,
   SECURITY_GROUP_READER,
   SECURITY_GROUP_WRITER,

--- a/app/scripts/modules/google/serverGroup/configure/wizard/cloneServerGroup.gce.controller.js
+++ b/app/scripts/modules/google/serverGroup/configure/wizard/cloneServerGroup.gce.controller.js
@@ -7,7 +7,7 @@ import {INSTANCE_TYPE_SERVICE} from 'core/instance/instanceType.service';
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.serverGroup.configure.gce.cloneServerGroup', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   require('core/application/modal/platformHealthOverride.directive.js'),
   require('./../../../instance/custom/customInstanceBuilder.gce.service.js'),
   INSTANCE_TYPE_SERVICE,

--- a/app/scripts/modules/google/serverGroup/configure/wizard/location/basicSettings.controller.js
+++ b/app/scripts/modules/google/serverGroup/configure/wizard/location/basicSettings.controller.js
@@ -9,7 +9,7 @@ import {NAMING_SERVICE} from 'core/naming/naming.service';
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.google.serverGroup.configure.wizard.basicSettings.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   require('angular-ui-bootstrap'),
   require('core/serverGroup/configure/common/basicSettingsMixin.controller.js'),
   V2_MODAL_WIZARD_SERVICE,

--- a/app/scripts/modules/google/serverGroup/details/serverGroupDetails.gce.controller.js
+++ b/app/scripts/modules/google/serverGroup/details/serverGroupDetails.gce.controller.js
@@ -14,7 +14,7 @@ import {CLUSTER_TARGET_BUILDER} from 'core/entityTag/clusterTargetBuilder.servic
 require('../configure/serverGroup.configure.gce.module.js');
 
 module.exports = angular.module('spinnaker.serverGroup.details.gce.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   require('../configure/serverGroupCommandBuilder.service.js'),
   require('core/application/modal/platformHealthOverride.directive.js'),
   SERVER_GROUP_WARNING_MESSAGE_SERVICE,

--- a/app/scripts/modules/kubernetes/instance/details/details.controller.js
+++ b/app/scripts/modules/kubernetes/instance/details/details.controller.js
@@ -11,7 +11,7 @@ import {RECENT_HISTORY_SERVICE} from 'core/history/recentHistory.service';
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.instance.detail.kubernetes.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   require('angular-ui-bootstrap'),
   INSTANCE_WRITE_SERVICE,
   INSTANCE_READ_SERVICE,

--- a/app/scripts/modules/kubernetes/loadBalancer/configure/wizard/upsert.controller.js
+++ b/app/scripts/modules/kubernetes/loadBalancer/configure/wizard/upsert.controller.js
@@ -8,7 +8,7 @@ import {V2_MODAL_WIZARD_SERVICE} from 'core/modal/wizard/v2modalWizard.service';
 import {TASK_MONITOR_BUILDER} from 'core/task/monitor/taskMonitor.builder';
 
 module.exports = angular.module('spinnaker.loadBalancer.kubernetes.create.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   LOAD_BALANCER_WRITE_SERVICE,
   ACCOUNT_SERVICE,
   V2_MODAL_WIZARD_SERVICE,

--- a/app/scripts/modules/kubernetes/loadBalancer/details/details.controller.js
+++ b/app/scripts/modules/kubernetes/loadBalancer/details/details.controller.js
@@ -9,7 +9,7 @@ let angular = require('angular');
 import _ from 'lodash';
 
 module.exports = angular.module('spinnaker.loadBalancer.kubernetes.details.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   ACCOUNT_SERVICE,
   CONFIRMATION_MODAL_SERVICE,
   LOAD_BALANCER_WRITE_SERVICE,

--- a/app/scripts/modules/kubernetes/pipeline/stages/disableCluster/disableClusterExecutionDetails.controller.js
+++ b/app/scripts/modules/kubernetes/pipeline/stages/disableCluster/disableClusterExecutionDetails.controller.js
@@ -5,7 +5,7 @@ import {EXECUTION_DETAILS_SECTION_SERVICE} from 'core/delivery/details/execution
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.disableCluster.kubernetes.executionDetails.controller', [
-    require('angular-ui-router'),
+    require('angular-ui-router').default,
     EXECUTION_DETAILS_SECTION_SERVICE,
     require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ])

--- a/app/scripts/modules/kubernetes/pipeline/stages/enableAsg/enableAsgExecutionDetails.controller.js
+++ b/app/scripts/modules/kubernetes/pipeline/stages/enableAsg/enableAsgExecutionDetails.controller.js
@@ -5,7 +5,7 @@ import {EXECUTION_DETAILS_SECTION_SERVICE} from 'core/delivery/details/execution
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.enableAsg.kubernetes.executionDetails.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   EXECUTION_DETAILS_SECTION_SERVICE,
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ])

--- a/app/scripts/modules/kubernetes/pipeline/stages/findAmi/findAmiExecutionDetails.controller.js
+++ b/app/scripts/modules/kubernetes/pipeline/stages/findAmi/findAmiExecutionDetails.controller.js
@@ -5,7 +5,7 @@ import {EXECUTION_DETAILS_SECTION_SERVICE} from 'core/delivery/details/execution
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.findAmi.kubernetes.executionDetails.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   EXECUTION_DETAILS_SECTION_SERVICE,
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ])

--- a/app/scripts/modules/kubernetes/pipeline/stages/resizeAsg/resizeExecutionDetails.controller.js
+++ b/app/scripts/modules/kubernetes/pipeline/stages/resizeAsg/resizeExecutionDetails.controller.js
@@ -5,7 +5,7 @@ import {EXECUTION_DETAILS_SECTION_SERVICE} from 'core/delivery/details/execution
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.resizeAsg.kubernetes.executionDetails.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   EXECUTION_DETAILS_SECTION_SERVICE,
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ])

--- a/app/scripts/modules/kubernetes/pipeline/stages/runJob/runJobExecutionDetails.controller.js
+++ b/app/scripts/modules/kubernetes/pipeline/stages/runJob/runJobExecutionDetails.controller.js
@@ -4,7 +4,7 @@ let angular = require('angular');
 
 module.exports = angular
   .module('spinnaker.core.pipeline.stage.disableCluster.kubernetes.runJobExecutionDetails.controller', [
-    require('angular-ui-router'),
+    require('angular-ui-router').default,
   ])
   .controller('kubernetesRunJobExecutionDetailsCtrl', function ($scope, $stateParams, executionDetailsSectionService) {
 

--- a/app/scripts/modules/kubernetes/pipeline/stages/scaleDownCluster/scaleDownClusterExecutionDetails.controller.js
+++ b/app/scripts/modules/kubernetes/pipeline/stages/scaleDownCluster/scaleDownClusterExecutionDetails.controller.js
@@ -5,7 +5,7 @@ import {EXECUTION_DETAILS_SECTION_SERVICE} from 'core/delivery/details/execution
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.scaleDownCluster.kubernetes.executionDetails.controller', [
-    require('angular-ui-router'),
+    require('angular-ui-router').default,
     EXECUTION_DETAILS_SECTION_SERVICE,
     require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ])

--- a/app/scripts/modules/kubernetes/pipeline/stages/shrinkCluster/shrinkClusterExecutionDetails.controller.js
+++ b/app/scripts/modules/kubernetes/pipeline/stages/shrinkCluster/shrinkClusterExecutionDetails.controller.js
@@ -5,7 +5,7 @@ import {EXECUTION_DETAILS_SECTION_SERVICE} from 'core/delivery/details/execution
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.shrinkCluster.kubernetes.executionDetails.controller', [
-    require('angular-ui-router'),
+    require('angular-ui-router').default,
     EXECUTION_DETAILS_SECTION_SERVICE,
     require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ])

--- a/app/scripts/modules/kubernetes/securityGroup/configure/wizard/upsert.controller.js
+++ b/app/scripts/modules/kubernetes/securityGroup/configure/wizard/upsert.controller.js
@@ -10,7 +10,7 @@ import {SECURITY_GROUP_WRITER} from 'core/securityGroup/securityGroupWriter.serv
 import {TASK_MONITOR_BUILDER} from 'core/task/monitor/taskMonitor.builder';
 
 module.exports = angular.module('spinnaker.securityGroup.kubernetes.create.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   LOAD_BALANCER_READ_SERVICE,
   SECURITY_GROUP_READER,
   SECURITY_GROUP_WRITER,

--- a/app/scripts/modules/kubernetes/securityGroup/details/details.controller.js
+++ b/app/scripts/modules/kubernetes/securityGroup/details/details.controller.js
@@ -10,7 +10,7 @@ import {SECURITY_GROUP_READER} from 'core/securityGroup/securityGroupReader.serv
 import {SECURITY_GROUP_WRITER} from 'core/securityGroup/securityGroupWriter.service';
 
 module.exports = angular.module('spinnaker.securityGroup.kubernetes.details.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   ACCOUNT_SERVICE,
   SECURITY_GROUP_READER,
   SECURITY_GROUP_WRITER,

--- a/app/scripts/modules/kubernetes/serverGroup/configure/wizard/BasicSettings.controller.js
+++ b/app/scripts/modules/kubernetes/serverGroup/configure/wizard/BasicSettings.controller.js
@@ -7,7 +7,7 @@ import {NAMING_SERVICE} from 'core/naming/naming.service';
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.serverGroup.configure.kubernetes.basicSettings', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   require('angular-ui-bootstrap'),
   require('core/serverGroup/configure/common/basicSettingsMixin.controller.js'),
   V2_MODAL_WIZARD_SERVICE,

--- a/app/scripts/modules/kubernetes/serverGroup/configure/wizard/Clone.controller.js
+++ b/app/scripts/modules/kubernetes/serverGroup/configure/wizard/Clone.controller.js
@@ -7,7 +7,7 @@ import {SERVER_GROUP_WRITER} from 'core/serverGroup/serverGroupWriter.service';
 import {TASK_MONITOR_BUILDER} from 'core/task/monitor/taskMonitor.builder';
 
 module.exports = angular.module('spinnaker.serverGroup.configure.kubernetes.clone', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   require('core/application/modal/platformHealthOverride.directive.js'),
   SERVER_GROUP_WRITER,
   V2_MODAL_WIZARD_SERVICE,

--- a/app/scripts/modules/kubernetes/serverGroup/details/details.controller.js
+++ b/app/scripts/modules/kubernetes/serverGroup/details/details.controller.js
@@ -10,7 +10,7 @@ import {SERVER_GROUP_WRITER} from 'core/serverGroup/serverGroupWriter.service';
 import {RUNNING_TASKS_DETAILS_COMPONENT} from 'core/serverGroup/details/runningTasks.component';
 
 module.exports = angular.module('spinnaker.serverGroup.details.kubernetes.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   require('../configure/configure.kubernetes.module.js'),
   CONFIRMATION_MODAL_SERVICE,
   SERVER_GROUP_WARNING_MESSAGE_SERVICE,

--- a/app/scripts/modules/netflix/application/netflixCreateApplicationModal.controller.ts
+++ b/app/scripts/modules/netflix/application/netflixCreateApplicationModal.controller.ts
@@ -60,7 +60,7 @@ class NetflixCreateApplicationModalController {
 }
 export const NETFLIX_CREATE_APPLICATION_MODAL_CONTROLLER = 'spinnaker.netflix.application.create.modal.controller';
 module(NETFLIX_CREATE_APPLICATION_MODAL_CONTROLLER, [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   APPLICATION_WRITE_SERVICE,
   APPLICATION_READ_SERVICE,
   ACCOUNT_SERVICE,

--- a/app/scripts/modules/netflix/application/netflixEditApplicationModal.controller.ts
+++ b/app/scripts/modules/netflix/application/netflixEditApplicationModal.controller.ts
@@ -40,7 +40,7 @@ class NetflixEditApplicationModalController {
 
 export const NETFLIX_EDIT_APPLICATION_MODAL_CONTROLLER = 'spinnaker.netflix.application.edit.modal.controller';
 module(NETFLIX_EDIT_APPLICATION_MODAL_CONTROLLER, [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   APPLICATION_WRITE_SERVICE,
   ACCOUNT_SERVICE,
   PAGER_DUTY_SELECT_FIELD_COMPONENT,

--- a/app/scripts/modules/netflix/ci/ci.controller.js
+++ b/app/scripts/modules/netflix/ci/ci.controller.js
@@ -8,7 +8,7 @@ import {CiFilterModel} from './ciFilter.model';
 import './ci.less';
 
 module.exports = angular.module('spinnaker.netflix.ci.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
 ])
   .controller('NetflixCiCtrl', function ($scope, $state, app) {
     const dataSource = app.getDataSource('ci');

--- a/app/scripts/modules/netflix/ci/detail/detail.controller.js
+++ b/app/scripts/modules/netflix/ci/detail/detail.controller.js
@@ -7,7 +7,7 @@ const angular = require('angular');
 
 module.exports = angular
   .module('spinnaker.netflix.ci.detail.controller', [
-    require('angular-ui-router'),
+    require('angular-ui-router').default,
     CI_BUILD_READ_SERVICE,
     SCHEDULER_FACTORY,
   ])

--- a/app/scripts/modules/netflix/ci/detail/detailTab/detailTab.controller.js
+++ b/app/scripts/modules/netflix/ci/detail/detailTab/detailTab.controller.js
@@ -9,7 +9,7 @@ const angular = require('angular');
 
 module.exports = angular
   .module('spinnaker.netflix.ci.detail.detailTab.controller', [
-    require('angular-ui-router'),
+    require('angular-ui-router').default,
     CI_BUILD_READ_SERVICE,
     SCHEDULER_FACTORY,
   ])

--- a/app/scripts/modules/netflix/fastProperties/dataNav/fastProperties.controller.js
+++ b/app/scripts/modules/netflix/fastProperties/dataNav/fastProperties.controller.js
@@ -10,7 +10,7 @@ let angular = require('angular');
 
 module.exports = angular
   .module('spinnaker.netflix.fastProperties.controller', [
-    require('angular-ui-router'),
+    require('angular-ui-router').default,
     require('../fastProperty.read.service.js'),
     CREATE_FAST_PROPERTY_WIZARD_CONTROLLER,
   ])

--- a/app/scripts/modules/netflix/fastProperties/view/fastProperties.controller.js
+++ b/app/scripts/modules/netflix/fastProperties/view/fastProperties.controller.js
@@ -10,7 +10,7 @@ let angular = require('angular');
 
 module.exports = angular
   .module('spinnaker.netflix.fastProperties.controller', [
-    require('angular-ui-router'),
+    require('angular-ui-router').default,
     FAST_PROPERTY_READ_SERVICE,
     require('./fastPropertyTable.directive.js'),
     CREATE_FAST_PROPERTY_WIZARD_CONTROLLER,

--- a/app/scripts/modules/netflix/fastProperties/view/fastPropertyDetails.controller.ts
+++ b/app/scripts/modules/netflix/fastProperties/view/fastPropertyDetails.controller.ts
@@ -92,7 +92,7 @@ export class FastPropertyDetailsController {
 export const FAST_PROPERTY_DETAILS_CONTROLLER = 'spinnaker.netflix.globalFastProperties.details.controller';
 
 module(FAST_PROPERTY_DETAILS_CONTROLLER, [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   FAST_PROPERTY_READ_SERVICE,
   require('../fastProperty.write.service'),
   UPDATE_FAST_PROPERTY_WIZARD_CONTROLLER,

--- a/app/scripts/modules/netflix/fastProperties/view/fastPropertyPodTable.component.ts
+++ b/app/scripts/modules/netflix/fastProperties/view/fastPropertyPodTable.component.ts
@@ -42,5 +42,5 @@ class FastPropertyPodTable implements IComponentOptions {
 export const FAST_PROPERTY_POD_TABLE = 'spinnaker.netflix.globalFastProperty.podTable.component';
 
 module(FAST_PROPERTY_POD_TABLE, [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
 ]).component('fastPropertyPodTable', new FastPropertyPodTable());

--- a/app/scripts/modules/netflix/fastProperties/view/fastPropertyPods.component.ts
+++ b/app/scripts/modules/netflix/fastProperties/view/fastPropertyPods.component.ts
@@ -69,7 +69,7 @@ class FastPropertyPods implements IComponentOptions {
 export const FAST_PROPERTY_PODS = 'spinnaker.netflix.globalFastProperty.pods.component';
 
 module(FAST_PROPERTY_PODS, [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
 ])
   .component('fastPropertyPods', new FastPropertyPods());
 

--- a/app/scripts/modules/netflix/instance/aws/netflixAwsInstanceDetails.controller.js
+++ b/app/scripts/modules/netflix/instance/aws/netflixAwsInstanceDetails.controller.js
@@ -10,7 +10,7 @@ import {INSTANCE_WRITE_SERVICE} from 'core/instance/instance.write.service';
 import {RECENT_HISTORY_SERVICE} from 'core/history/recentHistory.service';
 
 module.exports = angular.module('spinnaker.netflix.instance.aws.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   require('angular-ui-bootstrap'),
   ACCOUNT_SERVICE,
   INSTANCE_WRITE_SERVICE,

--- a/app/scripts/modules/netflix/instance/titus/netflixTitusInstanceDetails.controller.js
+++ b/app/scripts/modules/netflix/instance/titus/netflixTitusInstanceDetails.controller.js
@@ -10,7 +10,7 @@ import {INSTANCE_WRITE_SERVICE} from 'core/instance/instance.write.service';
 import {RECENT_HISTORY_SERVICE} from 'core/history/recentHistory.service';
 
 module.exports = angular.module('spinnaker.netflix.instance.titus.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   require('angular-ui-bootstrap'),
   ACCOUNT_SERVICE,
   INSTANCE_WRITE_SERVICE,

--- a/app/scripts/modules/netflix/pipeline/stage/acaTask/acaTaskExecutionDetails.controller.js
+++ b/app/scripts/modules/netflix/pipeline/stage/acaTask/acaTaskExecutionDetails.controller.js
@@ -6,7 +6,7 @@ import {EXECUTION_DETAILS_SECTION_SERVICE} from 'core/delivery/details/execution
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.netflix.pipeline.stage.acaTask.details.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   CLUSTER_FILTER_SERVICE,
   EXECUTION_DETAILS_SECTION_SERVICE,
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),

--- a/app/scripts/modules/netflix/pipeline/stage/canary/actions/endCanary.controller.js
+++ b/app/scripts/modules/netflix/pipeline/stage/canary/actions/endCanary.controller.js
@@ -5,7 +5,7 @@ let angular = require('angular');
 import {SETTINGS} from 'core/config/settings';
 
 module.exports = angular.module('spinnaker.netflix.pipeline.stage.canary.actions.override.result.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ])
   .controller('EndCanaryCtrl', function ($scope, $http, $uibModalInstance, canaryId) {

--- a/app/scripts/modules/netflix/pipeline/stage/canary/actions/generateScore.controller.js
+++ b/app/scripts/modules/netflix/pipeline/stage/canary/actions/generateScore.controller.js
@@ -5,7 +5,7 @@ let angular = require('angular');
 import {SETTINGS} from 'core/config/settings';
 
 module.exports = angular.module('spinnaker.netflix.pipeline.stage.canary.actions.generate.score.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ])
   .controller('GenerateScoreCtrl', function ($scope, $http, $uibModalInstance, canaryId) {

--- a/app/scripts/modules/netflix/pipeline/stage/canary/canaryDeployment/canaryDeploymentExecutionDetails.controller.js
+++ b/app/scripts/modules/netflix/pipeline/stage/canary/canaryDeployment/canaryDeploymentExecutionDetails.controller.js
@@ -7,7 +7,7 @@ import {URL_BUILDER_SERVICE} from 'core/navigation/urlBuilder.service';
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.netflix.pipeline.stage.canary.canaryDeployment.details.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   CLUSTER_FILTER_SERVICE,
   EXECUTION_DETAILS_SECTION_SERVICE,
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),

--- a/app/scripts/modules/netflix/pipeline/stage/canary/canaryExecutionDetails.controller.js
+++ b/app/scripts/modules/netflix/pipeline/stage/canary/canaryExecutionDetails.controller.js
@@ -5,7 +5,7 @@ import {EXECUTION_DETAILS_SECTION_SERVICE} from 'core/delivery/details/execution
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.netflix.pipeline.stage.canary.details.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   EXECUTION_DETAILS_SECTION_SERVICE,
   require('core/delivery/details/executionDetailsSectionNav.directive.js')
 ])

--- a/app/scripts/modules/netflix/pipeline/stage/canary/canaryExecutionSummary.controller.js
+++ b/app/scripts/modules/netflix/pipeline/stage/canary/canaryExecutionSummary.controller.js
@@ -5,7 +5,7 @@ import {PIPELINE_CONFIG_PROVIDER} from 'core/pipeline/config/pipelineConfigProvi
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.netflix.pipeline.stage.canary.summary.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),
   require('./actions/generateScore.controller.js'),
   require('./actions/endCanary.controller.js'),

--- a/app/scripts/modules/netflix/pipeline/stage/chap/chapExecutionDetails.controller.js
+++ b/app/scripts/modules/netflix/pipeline/stage/chap/chapExecutionDetails.controller.js
@@ -6,7 +6,7 @@ import {NetflixSettings} from '../../../netflix.settings';
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.netflix.pipeline.stage.chap.executionDetails.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   EXECUTION_DETAILS_SECTION_SERVICE,
   require('core/delivery/details/executionDetailsSectionNav.directive')
 ])

--- a/app/scripts/modules/netflix/pipeline/stage/properties/create/propertyExecutionDetails.controller.js
+++ b/app/scripts/modules/netflix/pipeline/stage/properties/create/propertyExecutionDetails.controller.js
@@ -6,7 +6,7 @@ import {EXECUTION_DETAILS_SECTION_SERVICE} from 'core/delivery/details/execution
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.netflix.pipeline.stage.property.details.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   EXECUTION_DETAILS_SECTION_SERVICE,
   require('core/delivery/details/executionDetailsSectionNav.directive.js')
 ])

--- a/app/scripts/modules/netflix/pipeline/stage/quickPatchAsg/bulkQuickPatchStage/bulkQuickPatchStageExecutionDetails.controller.js
+++ b/app/scripts/modules/netflix/pipeline/stage/quickPatchAsg/bulkQuickPatchStage/bulkQuickPatchStageExecutionDetails.controller.js
@@ -5,7 +5,7 @@ import {EXECUTION_DETAILS_SECTION_SERVICE} from 'core/delivery/details/execution
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.quickPatchAsg.bulkQuickPatchStage.executionDetails.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   EXECUTION_DETAILS_SECTION_SERVICE,
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ])

--- a/app/scripts/modules/netflix/pipeline/stage/quickPatchAsg/quickPatchAsgExecutionDetails.controller.js
+++ b/app/scripts/modules/netflix/pipeline/stage/quickPatchAsg/quickPatchAsgExecutionDetails.controller.js
@@ -5,7 +5,7 @@ import {EXECUTION_DETAILS_SECTION_SERVICE} from 'core/delivery/details/execution
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.netflix.pipeline.stage.quickPatchAsg.executionDetails.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   EXECUTION_DETAILS_SECTION_SERVICE,
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ])

--- a/app/scripts/modules/openstack/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/openstack/instance/details/instance.details.controller.js
@@ -11,7 +11,7 @@ import {RECENT_HISTORY_SERVICE} from 'core/history/recentHistory.service';
 import {SETTINGS} from 'core/config/settings';
 
 module.exports = angular.module('spinnaker.instance.detail.openstack.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   require('angular-ui-bootstrap'),
   INSTANCE_WRITE_SERVICE,
   INSTANCE_READ_SERVICE,

--- a/app/scripts/modules/openstack/loadBalancer/configure/wizard/upsert.controller.js
+++ b/app/scripts/modules/openstack/loadBalancer/configure/wizard/upsert.controller.js
@@ -11,7 +11,7 @@ import {TASK_MONITOR_BUILDER} from 'core/task/monitor/taskMonitor.builder';
 require('../../loadBalancer.less');
 
 module.exports = angular.module('spinnaker.loadBalancer.openstack.create.controller', [
-    require('angular-ui-router'),
+    require('angular-ui-router').default,
     LOAD_BALANCER_WRITE_SERVICE,
     ACCOUNT_SERVICE,
     V2_MODAL_WIZARD_SERVICE,

--- a/app/scripts/modules/openstack/loadBalancer/details/details.controller.js
+++ b/app/scripts/modules/openstack/loadBalancer/details/details.controller.js
@@ -7,7 +7,7 @@ import {LOAD_BALANCER_WRITE_SERVICE} from 'core/loadBalancer/loadBalancer.write.
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.loadBalancer.openstack.details.controller', [
-    require('angular-ui-router'),
+    require('angular-ui-router').default,
     ACCOUNT_SERVICE,
     CONFIRMATION_MODAL_SERVICE,
     LOAD_BALANCER_WRITE_SERVICE,

--- a/app/scripts/modules/openstack/pipeline/stages/bake/bakeExecutionDetails.controller.js
+++ b/app/scripts/modules/openstack/pipeline/stages/bake/bakeExecutionDetails.controller.js
@@ -6,7 +6,7 @@ import {SETTINGS} from 'core/config/settings';
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.bake.openstack.executionDetails.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   EXECUTION_DETAILS_SECTION_SERVICE,
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ])

--- a/app/scripts/modules/openstack/pipeline/stages/cloneServerGroup/cloneServerGroupExecutionDetails.controller.js
+++ b/app/scripts/modules/openstack/pipeline/stages/cloneServerGroup/cloneServerGroupExecutionDetails.controller.js
@@ -9,7 +9,7 @@ import {URL_BUILDER_SERVICE} from 'core/navigation/urlBuilder.service';
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.cloneServerGroup.openstack.executionDetails.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   CLUSTER_FILTER_SERVICE,
   EXECUTION_DETAILS_SECTION_SERVICE,
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),

--- a/app/scripts/modules/openstack/pipeline/stages/disableCluster/disableClusterExecutionDetails.controller.js
+++ b/app/scripts/modules/openstack/pipeline/stages/disableCluster/disableClusterExecutionDetails.controller.js
@@ -5,7 +5,7 @@ import {EXECUTION_DETAILS_SECTION_SERVICE} from 'core/delivery/details/execution
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.disableCluster.openstack.executionDetails.controller', [
-    require('angular-ui-router'),
+    require('angular-ui-router').default,
     EXECUTION_DETAILS_SECTION_SERVICE,
     require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ])

--- a/app/scripts/modules/openstack/pipeline/stages/findAmi/findAmiExecutionDetails.controller.js
+++ b/app/scripts/modules/openstack/pipeline/stages/findAmi/findAmiExecutionDetails.controller.js
@@ -5,7 +5,7 @@ import {EXECUTION_DETAILS_SECTION_SERVICE} from 'core/delivery/details/execution
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.findAmi.openstack.executionDetails.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   EXECUTION_DETAILS_SECTION_SERVICE,
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ])

--- a/app/scripts/modules/openstack/pipeline/stages/resizeAsg/resizeAsgExecutionDetails.controller.js
+++ b/app/scripts/modules/openstack/pipeline/stages/resizeAsg/resizeAsgExecutionDetails.controller.js
@@ -5,7 +5,7 @@ import {EXECUTION_DETAILS_SECTION_SERVICE} from 'core/delivery/details/execution
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.resizeAsg.openstack.executionDetails.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   EXECUTION_DETAILS_SECTION_SERVICE,
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ])

--- a/app/scripts/modules/openstack/pipeline/stages/scaleDownCluster/scaleDownClusterExecutionDetails.controller.js
+++ b/app/scripts/modules/openstack/pipeline/stages/scaleDownCluster/scaleDownClusterExecutionDetails.controller.js
@@ -5,7 +5,7 @@ import {EXECUTION_DETAILS_SECTION_SERVICE} from 'core/delivery/details/execution
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.scaleDownCluster.openstack.executionDetails.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   EXECUTION_DETAILS_SECTION_SERVICE,
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ])

--- a/app/scripts/modules/openstack/securityGroup/configure/wizard/upsert.controller.js
+++ b/app/scripts/modules/openstack/securityGroup/configure/wizard/upsert.controller.js
@@ -8,7 +8,7 @@ import {SECURITY_GROUP_WRITER} from 'core/securityGroup/securityGroupWriter.serv
 import {TASK_MONITOR_BUILDER} from 'core/task/monitor/taskMonitor.builder';
 
 module.exports = angular.module('spinnaker.securityGroup.openstack.create.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   SECURITY_GROUP_READER,
   SECURITY_GROUP_WRITER,
   ACCOUNT_SERVICE,

--- a/app/scripts/modules/openstack/securityGroup/details/details.controller.js
+++ b/app/scripts/modules/openstack/securityGroup/details/details.controller.js
@@ -9,7 +9,7 @@ import {SECURITY_GROUP_READER} from 'core/securityGroup/securityGroupReader.serv
 import {SECURITY_GROUP_WRITER} from 'core/securityGroup/securityGroupWriter.service';
 
 module.exports = angular.module('spinnaker.securityGroup.openstack.details.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   CONFIRMATION_MODAL_SERVICE,
   SECURITY_GROUP_READER,
   SECURITY_GROUP_WRITER,

--- a/app/scripts/modules/openstack/serverGroup/configure/wizard/Clone.controller.js
+++ b/app/scripts/modules/openstack/serverGroup/configure/wizard/Clone.controller.js
@@ -7,7 +7,7 @@ import {SERVER_GROUP_WRITER} from 'core/serverGroup/serverGroupWriter.service';
 import {TASK_MONITOR_BUILDER} from 'core/task/monitor/taskMonitor.builder';
 
 module.exports = angular.module('spinnaker.openstack.serverGroup.configure.clone', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   require('core/application/modal/platformHealthOverride.directive.js'),
   SERVER_GROUP_WRITER,
   V2_MODAL_WIZARD_SERVICE,

--- a/app/scripts/modules/openstack/serverGroup/configure/wizard/ServerGroupBasicSettings.controller.js
+++ b/app/scripts/modules/openstack/serverGroup/configure/wizard/ServerGroupBasicSettings.controller.js
@@ -7,7 +7,7 @@ import {NAMING_SERVICE} from 'core/naming/naming.service';
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.openstack.serverGroup.configure.basicSettings', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   require('angular-ui-bootstrap'),
   require('core/serverGroup/configure/common/basicSettingsMixin.controller.js'),
   V2_MODAL_WIZARD_SERVICE,

--- a/app/scripts/modules/openstack/serverGroup/configure/wizard/access/AccessSettings.controller.js
+++ b/app/scripts/modules/openstack/serverGroup/configure/wizard/access/AccessSettings.controller.js
@@ -3,7 +3,7 @@
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.serverGroup.configure.openstack.accessSettings', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   require('angular-ui-bootstrap'),
   require('../../../../common/cacheBackedMultiSelectField.directive.js'),
 ]).controller('openstackServerGroupAccessSettingsCtrl', function($scope, loadBalancerReader, securityGroupReader, networkReader, v2modalWizardService) {

--- a/app/scripts/modules/openstack/serverGroup/configure/wizard/instance/ServerGroupInstanceSettings.controller.js
+++ b/app/scripts/modules/openstack/serverGroup/configure/wizard/instance/ServerGroupInstanceSettings.controller.js
@@ -9,7 +9,7 @@ import {NAMING_SERVICE} from 'core/naming/naming.service';
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.serverGroup.configure.openstack.instanceSettings', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   require('angular-ui-bootstrap'),
   require('core/serverGroup/configure/common/basicSettingsMixin.controller.js'),
   V2_MODAL_WIZARD_SERVICE,

--- a/app/scripts/modules/openstack/serverGroup/configure/wizard/location/ServerGroupBasicSettings.controller.js
+++ b/app/scripts/modules/openstack/serverGroup/configure/wizard/location/ServerGroupBasicSettings.controller.js
@@ -6,7 +6,7 @@ import {V2_MODAL_WIZARD_SERVICE} from 'core/modal/wizard/v2modalWizard.service';
 import {NAMING_SERVICE} from 'core/naming/naming.service';
 
 module.exports = angular.module('spinnaker.serverGroup.configure.openstack.basicSettings', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   require('angular-ui-bootstrap'),
   require('core/serverGroup/configure/common/basicSettingsMixin.controller.js'),
   V2_MODAL_WIZARD_SERVICE,

--- a/app/scripts/modules/openstack/serverGroup/details/serverGroupDetails.openstack.controller.js
+++ b/app/scripts/modules/openstack/serverGroup/details/serverGroupDetails.openstack.controller.js
@@ -16,7 +16,7 @@ import {RUNNING_TASKS_DETAILS_COMPONENT} from 'core/serverGroup/details/runningT
 require('../configure/serverGroup.configure.openstack.module.js');
 
 module.exports = angular.module('spinnaker.serverGroup.details.openstack.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   require('core/application/modal/platformHealthOverride.directive.js'),
   CONFIRMATION_MODAL_SERVICE,
   SERVER_GROUP_WRITER,

--- a/app/scripts/modules/titus/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/titus/instance/details/instance.details.controller.js
@@ -10,7 +10,7 @@ import {INSTANCE_WRITE_SERVICE} from 'core/instance/instance.write.service';
 import {RECENT_HISTORY_SERVICE} from 'core/history/recentHistory.service';
 
 module.exports = angular.module('spinnaker.instance.detail.titus.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   require('angular-ui-bootstrap'),
   INSTANCE_WRITE_SERVICE,
   INSTANCE_READ_SERVICE,

--- a/app/scripts/modules/titus/pipeline/stages/bake/bakeExecutionDetails.controller.js
+++ b/app/scripts/modules/titus/pipeline/stages/bake/bakeExecutionDetails.controller.js
@@ -6,7 +6,7 @@ import {SETTINGS} from 'core/config/settings';
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.bake.titus.executionDetails.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   EXECUTION_DETAILS_SECTION_SERVICE,
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ])

--- a/app/scripts/modules/titus/pipeline/stages/cloneServerGroup/cloneServerGroupExecutionDetails.controller.js
+++ b/app/scripts/modules/titus/pipeline/stages/cloneServerGroup/cloneServerGroupExecutionDetails.controller.js
@@ -9,7 +9,7 @@ import {URL_BUILDER_SERVICE} from 'core/navigation/urlBuilder.service';
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.cloneServerGroup.titus.executionDetails.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   CLUSTER_FILTER_SERVICE,
   EXECUTION_DETAILS_SECTION_SERVICE,
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),

--- a/app/scripts/modules/titus/pipeline/stages/disableCluster/disableClusterExecutionDetails.controller.js
+++ b/app/scripts/modules/titus/pipeline/stages/disableCluster/disableClusterExecutionDetails.controller.js
@@ -5,7 +5,7 @@ import {EXECUTION_DETAILS_SECTION_SERVICE} from 'core/delivery/details/execution
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.disableCluster.titus.executionDetails.controller', [
-    require('angular-ui-router'),
+    require('angular-ui-router').default,
     EXECUTION_DETAILS_SECTION_SERVICE,
     require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ])

--- a/app/scripts/modules/titus/pipeline/stages/findAmi/findAmiExecutionDetails.controller.js
+++ b/app/scripts/modules/titus/pipeline/stages/findAmi/findAmiExecutionDetails.controller.js
@@ -5,7 +5,7 @@ import {EXECUTION_DETAILS_SECTION_SERVICE} from 'core/delivery/details/execution
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.findAmi.titus.executionDetails.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   EXECUTION_DETAILS_SECTION_SERVICE,
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ])

--- a/app/scripts/modules/titus/pipeline/stages/resizeAsg/resizeAsgExecutionDetails.controller.js
+++ b/app/scripts/modules/titus/pipeline/stages/resizeAsg/resizeAsgExecutionDetails.controller.js
@@ -5,7 +5,7 @@ import {EXECUTION_DETAILS_SECTION_SERVICE} from 'core/delivery/details/execution
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.resizeAsg.titus.executionDetails.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   EXECUTION_DETAILS_SECTION_SERVICE,
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ])

--- a/app/scripts/modules/titus/pipeline/stages/runJob/runJobExecutionDetails.controller.js
+++ b/app/scripts/modules/titus/pipeline/stages/runJob/runJobExecutionDetails.controller.js
@@ -6,7 +6,7 @@ import {EXECUTION_DETAILS_SECTION_SERVICE} from 'core/delivery/details/execution
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.runJob.titus.executionDetails.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   EXECUTION_DETAILS_SECTION_SERVICE,
   require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ])

--- a/app/scripts/modules/titus/pipeline/stages/scaleDownCluster/scaleDownClusterExecutionDetails.controller.js
+++ b/app/scripts/modules/titus/pipeline/stages/scaleDownCluster/scaleDownClusterExecutionDetails.controller.js
@@ -5,7 +5,7 @@ import {EXECUTION_DETAILS_SECTION_SERVICE} from 'core/delivery/details/execution
 let angular = require('angular');
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.scaleDownCluster.titus.executionDetails.controller', [
-    require('angular-ui-router'),
+    require('angular-ui-router').default,
     EXECUTION_DETAILS_SECTION_SERVICE,
     require('core/delivery/details/executionDetailsSectionNav.directive.js'),
 ])

--- a/app/scripts/modules/titus/serverGroup/configure/wizard/CloneServerGroup.titus.controller.js
+++ b/app/scripts/modules/titus/serverGroup/configure/wizard/CloneServerGroup.titus.controller.js
@@ -4,7 +4,7 @@ let angular = require('angular');
 import {TITUS_SECURITY_GROUP_PICKER} from 'titus/securityGroup/securityGroupPicker.component';
 
 module.exports = angular.module('spinnaker.serverGroup.configure.titus.cloneServerGroup', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   TITUS_SECURITY_GROUP_PICKER
 ])
   .controller('titusCloneServerGroupCtrl', function($scope, $uibModalInstance, $q, $state,

--- a/app/scripts/modules/titus/serverGroup/details/serverGroupDetails.titus.controller.js
+++ b/app/scripts/modules/titus/serverGroup/details/serverGroupDetails.titus.controller.js
@@ -12,7 +12,7 @@ import {RUNNING_TASKS_DETAILS_COMPONENT} from 'core/serverGroup/details/runningT
 import {CLUSTER_TARGET_BUILDER} from 'core/entityTag/clusterTargetBuilder.service';
 
 module.exports = angular.module('spinnaker.serverGroup.details.titus.controller', [
-  require('angular-ui-router'),
+  require('angular-ui-router').default,
   ACCOUNT_SERVICE,
   require('../configure/ServerGroupCommandBuilder.js'),
   SERVER_GROUP_WARNING_MESSAGE_SERVICE,

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "ui-select": "^0.19.6"
   },
   "devDependencies": {
-    "@types/angular": "1.6.10",
+    "@types/angular": "1.6.3",
     "@types/angular-mocks": "1.5.9",
     "@types/angular-ui-bootstrap": "^0.13.41",
     "@types/angular-ui-router": "^1.1.35",
@@ -95,7 +95,7 @@
     "@types/webpack": "^2.2.4",
     "@types/webpack-env": "^1.13.0",
     "angular-loader": "file:./angular-loader",
-    "angular-mocks": "1.5.8",
+    "angular-mocks": "1.6.3",
     "angulartics": "^1.1.2",
     "angulartics-google-analytics": "^0.2.0",
     "awesome-typescript-loader": "^3.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,9 +20,15 @@
   dependencies:
     "@types/angular" "*"
 
-"@types/angular@*", "@types/angular@1.6.10", "@types/angular@^1.6.7", "@types/angular@^1.6.9":
+"@types/angular@*", "@types/angular@^1.6.7", "@types/angular@^1.6.9":
   version "1.6.10"
   resolved "https://registry.yarnpkg.com/@types/angular/-/angular-1.6.10.tgz#1c6a458305c85b16c98fe5173b843a836dbc2b67"
+  dependencies:
+    "@types/jquery" "*"
+
+"@types/angular@1.6.3":
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/@types/angular/-/angular-1.6.3.tgz#48d0d86cec90ffe3fd90e134da6d54759351f799"
   dependencies:
     "@types/jquery" "*"
 
@@ -465,9 +471,9 @@ angular-messages@~1.6.3:
   version "1.6.4"
   resolved "https://registry.yarnpkg.com/angular-messages/-/angular-messages-1.6.4.tgz#9ec9c1393293b14de54161d2f849776489e980fe"
 
-angular-mocks@1.5.8:
-  version "1.5.8"
-  resolved "https://registry.yarnpkg.com/angular-mocks/-/angular-mocks-1.5.8.tgz#2e9399056669f286a681396bc35ae0d7c5c70d16"
+angular-mocks@1.6.3:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/angular-mocks/-/angular-mocks-1.6.3.tgz#12fafc0f1e0903f16864004ba375bf3fb9101ef1"
 
 angular-sanitize@~1.6.3:
   version "1.6.4"


### PR DESCRIPTION
Still need to do some testing, but I'm sure it's fine, it's just the router and we barely do anything unusual with it.

I did not go as far as I could have with this PR in refactoring: the filter models could probably extend from a base class instead of the `asFilterModel` assignment, the parameter management could almost certainly be cleaned up more. I wanted to make as few changes as possible and avoid anything too drastic when something inevitably breaks.

@christopherthielen PTAL