### PR TITLE
refactor(bake/core): Replace bake stage choose base OS radio buttons for dropdown

### DIFF
--- a/app/scripts/modules/amazon/pipeline/stages/bake/awsBakeStage.js
+++ b/app/scripts/modules/amazon/pipeline/stages/bake/awsBakeStage.js
@@ -146,10 +146,6 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.aws.bakeStage', [
       return $scope.viewState.roscoMode || $scope.stage.varFileName;
     };
 
-    this.getBaseOsDescription = function(baseOsOption) {
-      return baseOsOption.id + (baseOsOption.shortDescription ? ' (' + baseOsOption.shortDescription + ')' : '');
-    };
-
     $scope.$watch('stage', deleteEmptyProperties, true);
 
     initialize();

--- a/app/scripts/modules/amazon/pipeline/stages/bake/bakeStage.html
+++ b/app/scripts/modules/amazon/pipeline/stages/bake/bakeStage.html
@@ -13,12 +13,7 @@
              ng-model="stage.package"/>
     </stage-config-field>
     <stage-config-field label="Base OS">
-      <label class="radio-inline" ng-repeat="baseOsOption in baseOsOptions">
-        <input type="radio"
-               ng-model="stage.baseOs"
-               ng-value="baseOsOption.id"/>
-        {{bakeStageCtrl.getBaseOsDescription(baseOsOption)}} <help-field content="{{baseOsOption.detailedDescription}}" />
-      </label>
+      <bake-stage-choose-os model="stage.baseOs" base-os-options="baseOsOptions"></bake-stage-choose-os>
     </stage-config-field>
     <stage-config-field label="VM Type">
       <label class="radio-inline" ng-repeat="vmType in vmTypes">

--- a/app/scripts/modules/azure/pipeline/stages/bake/azureBakeStage.js
+++ b/app/scripts/modules/azure/pipeline/stages/bake/azureBakeStage.js
@@ -140,10 +140,6 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.azure.bakeStage',
       return $scope.viewState.roscoMode || $scope.stage.varFileName;
     };
 
-    this.getBaseOsDescription = function(baseOsOption) {
-      return baseOsOption.id + (baseOsOption.shortDescription ? ' (' + baseOsOption.shortDescription + ')' : '');
-    };
-
     $scope.$watch('stage', deleteEmptyProperties, true);
 
     initialize();

--- a/app/scripts/modules/azure/pipeline/stages/bake/bakeStage.html
+++ b/app/scripts/modules/azure/pipeline/stages/bake/bakeStage.html
@@ -13,13 +13,7 @@
              ng-model="stage.package"/>
     </stage-config-field>
     <stage-config-field label="Base OS">
-      <label class="radio-inline" ng-repeat="baseOsOption in baseOsOptions">
-        <input type="radio"
-               ng-model="stage.baseOs"
-               ng-value="baseOsOption.id"
-               ng-change="bakeStageCtrl.baseOsChanged()"/>
-        {{bakeStageCtrl.getBaseOsDescription(baseOsOption)}} <help-field content="{{baseOsOption.detailedDescription}}" />
-      </label>
+      <bake-stage-choose-os model="stage.baseOs" base-os-options="baseOsOptions"></bake-stage-choose-os>
     </stage-config-field>
     <stage-config-field label="Base Label">
       <label class="radio-inline" ng-repeat="baseLabel in baseLabelOptions">

--- a/app/scripts/modules/core/pipeline/config/stages/bake/bakeStageChooseOs.component.html
+++ b/app/scripts/modules/core/pipeline/config/stages/bake/bakeStageChooseOs.component.html
@@ -1,0 +1,16 @@
+<ui-select ng-if="!$ctrl.showRadioButtons" ng-model="$ctrl.model" required class="form-control input-sm">
+  <ui-select-match placeholder="Select a base OS">
+    <span ng-bind-html="$ctrl.getBaseOsDescription($select.selected)"></span>
+  </ui-select-match>
+  <ui-select-choices repeat="baseOsOption.id as baseOsOption in $ctrl.baseOsOptions | filter: $select.search">
+    <strong ng-bind-html="$ctrl.getBaseOsDescription(baseOsOption)"></strong>
+    <div ng-bind-html="$ctrl.getBaseOsDetailedDescription(baseOsOption)"></div>
+  </ui-select-choices>
+</ui-select>
+
+<label ng-if="$ctrl.showRadioButtons" class="radio-inline" ng-repeat="baseOsOption in $ctrl.baseOsOptions">
+  <input type="radio"
+         ng-model="$ctrl.model"
+         ng-value="baseOsOption.id"/>
+  {{$ctrl.getBaseOsDescription(baseOsOption)}} <help-field content="{{$ctrl.getBaseOsDetailedDescription(baseOsOption)}}" />
+</label>

--- a/app/scripts/modules/core/pipeline/config/stages/bake/bakeStageChooseOs.component.ts
+++ b/app/scripts/modules/core/pipeline/config/stages/bake/bakeStageChooseOs.component.ts
@@ -1,0 +1,41 @@
+import {IComponentController, IComponentOptions, module} from 'angular';
+
+export interface IBaseOsOption {
+  id: string;
+  shortDescription?: string;
+  detailedDescription: string;
+  isImageFamily?: boolean;
+}
+
+export class BakeStageChooseOSController implements IComponentController {
+
+  public model: any;
+  public baseOsOptions: IBaseOsOption[];
+
+  private showRadioButtons = false;
+
+  public $onInit(): void {
+    this.showRadioButtons = this.baseOsOptions.length <= 2;
+  }
+
+  public getBaseOsDescription(baseOsOption: IBaseOsOption): String {
+    return baseOsOption.id + (baseOsOption.shortDescription ? ' (' + baseOsOption.shortDescription + ')' : '');
+  }
+
+  public getBaseOsDetailedDescription(baseOsOption: IBaseOsOption): String {
+    return baseOsOption.detailedDescription + (baseOsOption.isImageFamily ? ' (family)' : '');
+  }
+}
+
+class BakeStageChooseOSComponent implements IComponentOptions {
+  public bindings: any = {
+    baseOsOptions: '<',
+    model: '='
+  };
+  public controller: any = BakeStageChooseOSController;
+  public templateUrl: string = require('./bakeStageChooseOs.component.html')
+}
+
+export const PIPELINE_BAKE_STAGE_CHOOSE_OS = 'spinnaker.core.pipeline.bake.chooseOS.component';
+module(PIPELINE_BAKE_STAGE_CHOOSE_OS, [])
+  .component('bakeStageChooseOs', new BakeStageChooseOSComponent());

--- a/app/scripts/modules/core/pipeline/config/stages/stage.module.js
+++ b/app/scripts/modules/core/pipeline/config/stages/stage.module.js
@@ -7,6 +7,7 @@ import {API_SERVICE} from 'core/api/api.service';
 import {CONFIRMATION_MODAL_SERVICE} from 'core/confirmationModal/confirmationModal.service';
 import {PIPELINE_CONFIG_PROVIDER} from 'core/pipeline/config/pipelineConfigProvider';
 import {PIPELINE_CONFIG_SERVICE} from 'core/pipeline/config/services/pipelineConfig.service';
+import {PIPELINE_BAKE_STAGE_CHOOSE_OS} from 'core/pipeline/config/stages/bake/bakeStageChooseOs.component';
 
 module.exports = angular.module('spinnaker.core.pipeline.config.stage', [
   API_SERVICE,
@@ -16,6 +17,7 @@ module.exports = angular.module('spinnaker.core.pipeline.config.stage', [
   require('./overrideFailure/overrideFailure.component.js'),
   require('./optionalStage/optionalStage.directive.js'),
   CONFIRMATION_MODAL_SERVICE,
+  PIPELINE_BAKE_STAGE_CHOOSE_OS,
   ACCOUNT_SERVICE,
   require('./core/stageConfigField/stageConfigField.directive.js'),
 ])

--- a/app/scripts/modules/docker/pipeline/stages/bake/bakeStage.html
+++ b/app/scripts/modules/docker/pipeline/stages/bake/bakeStage.html
@@ -16,12 +16,7 @@
              ng-model="stage.extendedAttributes['docker_target_image_tag']"/>
   </stage-config-field>
   <stage-config-field label="Base OS">
-    <label class="radio-inline" ng-repeat="baseOsOption in baseOsOptions">
-      <input type="radio"
-             ng-model="stage.baseOs"
-             ng-value="baseOsOption.id"/>
-      {{bakeStageCtrl.getBaseOsDescription(baseOsOption)}} <help-field content="{{baseOsOption.detailedDescription}}" />
-    </label>
+    <bake-stage-choose-os model="stage.baseOs" base-os-options="baseOsOptions"></bake-stage-choose-os>
   </stage-config-field>
 
   <stage-config-field label="Base Label">

--- a/app/scripts/modules/docker/pipeline/stages/bake/dockerBakeStage.js
+++ b/app/scripts/modules/docker/pipeline/stages/bake/dockerBakeStage.js
@@ -78,10 +78,6 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.docker.bakeStage'
       });
     }
 
-    this.getBaseOsDescription = function(baseOsOption) {
-      return baseOsOption.id + (baseOsOption.shortDescription ? ' (' + baseOsOption.shortDescription + ')' : '');
-    };
-
     $scope.$watch('stage', deleteEmptyProperties, true);
 
     initialize();

--- a/app/scripts/modules/google/pipeline/stages/bake/bakeStage.html
+++ b/app/scripts/modules/google/pipeline/stages/bake/bakeStage.html
@@ -4,12 +4,7 @@
            ng-model="stage.package"/>
   </stage-config-field>
   <stage-config-field label="Base OS">
-    <label class="radio-inline" ng-repeat="baseOsOption in baseOsOptions">
-      <input type="radio"
-             ng-model="stage.baseOs"
-             ng-value="baseOsOption.id"/>
-      {{bakeStageCtrl.getBaseOsDescription(baseOsOption)}} <help-field content="{{bakeStageCtrl.getHelpFieldContent(baseOsOption)}}" />
-    </label>
+    <bake-stage-choose-os model="stage.baseOs" base-os-options="baseOsOptions"></bake-stage-choose-os>
   </stage-config-field>
 
   <stage-config-field label="Base Label">

--- a/app/scripts/modules/google/pipeline/stages/bake/gceBakeStage.js
+++ b/app/scripts/modules/google/pipeline/stages/bake/gceBakeStage.js
@@ -126,14 +126,6 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.gce.bakeStage', [
       return $scope.viewState.roscoMode || $scope.stage.varFileName;
     };
 
-    this.getBaseOsDescription = function(baseOsOption) {
-      return baseOsOption.id + (baseOsOption.shortDescription ? ' (' + baseOsOption.shortDescription + ')' : '');
-    };
-
-    this.getHelpFieldContent = function(baseOsOption) {
-      return baseOsOption.detailedDescription + (baseOsOption.isImageFamily ? ' (family)' : '');
-    };
-
     $scope.$watch('stage', deleteEmptyProperties, true);
 
     initialize();

--- a/app/scripts/modules/openstack/pipeline/stages/bake/bakeStage.html
+++ b/app/scripts/modules/openstack/pipeline/stages/bake/bakeStage.html
@@ -13,12 +13,7 @@
              ng-model="stage.package"/>
     </stage-config-field>
     <stage-config-field label="Base OS">
-      <label class="radio-inline" ng-repeat="baseOsOption in baseOsOptions">
-        <input type="radio"
-               ng-model="stage.baseOs"
-               ng-value="baseOsOption.id"/>
-        {{bakeStageCtrl.getBaseOsDescription(baseOsOption)}} <help-field content="{{baseOsOption.detailedDescription}}" />
-      </label>
+      <bake-stage-choose-os model="stage.baseOs" base-os-options="baseOsOptions"></bake-stage-choose-os>
     </stage-config-field>
 
     <stage-config-field label="Base Label">

--- a/app/scripts/modules/openstack/pipeline/stages/bake/openstackBakeStage.js
+++ b/app/scripts/modules/openstack/pipeline/stages/bake/openstackBakeStage.js
@@ -94,10 +94,6 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.openstack.bakeSta
       return $scope.viewState.roscoMode || $scope.stage.templateFileName;
     };
 
-    this.getBaseOsDescription = function(baseOsOption) {
-      return baseOsOption.id + (baseOsOption.shortDescription ? ' (' + baseOsOption.shortDescription + ')' : '');
-    };
-
     $scope.$watch('stage', deleteEmptyProperties, true);
 
     initialize();


### PR DESCRIPTION
This consolidates some of the copy/pasted code around the choice of the base os in the bake stage.
Created a component and used a dropdown instead of radio buttons.
Dropdown looks better in my opinion and is more scalable in case of many possible base OS.

Screenshot of old version:
![image](https://cloud.githubusercontent.com/assets/725020/25663903/403b168c-3019-11e7-8953-f2fd57eefb91.png)

Screenshot of proposed version:
![image](https://cloud.githubusercontent.com/assets/725020/25663928/559de626-3019-11e7-97c5-7e9fee43c47f.png)
Another screenshot of new version:
![image](https://cloud.githubusercontent.com/assets/725020/25663945/678cf228-3019-11e7-8c29-89c75ef742d2.png)

