### PR TITLE
fix(clusters/loadBalancers): fix false positive change detections

### DIFF
--- a/app/scripts/modules/core/loadBalancer/filter/loadBalancer.filter.service.js
+++ b/app/scripts/modules/core/loadBalancer/filter/loadBalancer.filter.service.js
@@ -178,7 +178,7 @@ module.exports = angular
     function diffServerGroups(oldGroup, newGroup) {
       var toRemove = [];
       oldGroup.serverGroups.forEach(function(serverGroup, idx) {
-        serverGroup.stringVal = angular.toJson(serverGroup);
+        serverGroup.stringVal = serverGroup.stringVal || angular.toJson(serverGroup);
         var newServerGroup = _.find(newGroup.serverGroups, { name: serverGroup.name, account: serverGroup.account, region: serverGroup.region });
         if (!newServerGroup) {
           $log.debug('server group no longer found, removing:', serverGroup.name, serverGroup.account, serverGroup.region);

--- a/app/scripts/modules/core/serverGroup/serverGroup.dataSource.js
+++ b/app/scripts/modules/core/serverGroup/serverGroup.dataSource.js
@@ -6,14 +6,16 @@ import {APPLICATION_DATA_SOURCE_REGISTRY} from '../application/service/applicati
 import {ENTITY_TAGS_READ_SERVICE} from '../entityTag/entityTags.read.service';
 import {SETTINGS} from 'core/config/settings';
 import {CLUSTER_SERVICE} from 'core/cluster/cluster.service';
+import {JSON_UTILITY_SERVICE} from 'core/utils/json/json.utility.service';
 
 module.exports = angular
   .module('spinnaker.core.serverGroup.dataSource', [
     APPLICATION_DATA_SOURCE_REGISTRY,
     ENTITY_TAGS_READ_SERVICE,
     CLUSTER_SERVICE,
+    JSON_UTILITY_SERVICE,
   ])
-  .run(function($q, applicationDataSourceRegistry, clusterService, entityTagsReader, serverGroupTransformer) {
+  .run(function($q, applicationDataSourceRegistry, clusterService, entityTagsReader, serverGroupTransformer, jsonUtilityService) {
 
     let loadServerGroups = (application) => {
       return clusterService.loadServerGroups(application);
@@ -21,7 +23,8 @@ module.exports = angular
 
     let addServerGroups = (application, serverGroups) => {
       return addTags(serverGroups).then(() => {
-        serverGroups.forEach(serverGroup => serverGroup.stringVal = JSON.stringify(serverGroup, serverGroupTransformer.jsonReplacer));
+        serverGroups.forEach(serverGroup => serverGroup.stringVal =
+          jsonUtilityService.makeSortedStringFromAngularObject(serverGroup, ['executions', 'runningTasks']));
         application.clusters = clusterService.createServerGroupClusters(serverGroups);
         let data = clusterService.addServerGroupsToApplication(application, serverGroups);
         clusterService.addTasksToServerGroups(application);

--- a/app/scripts/modules/core/utils/json/json.utility.service.ts
+++ b/app/scripts/modules/core/utils/json/json.utility.service.ts
@@ -68,6 +68,20 @@ export class JsonUtilityService {
     return JSON.stringify(obj, null, 2);
   }
 
+  public makeSortedStringFromAngularObject(obj: any, omit: string[] = []): string {
+    const replacer = (key: string, value: string) => {
+      let val = value;
+      if (typeof key === 'string' && key.charAt(0) === '$' && key.charAt(1) === '$') {
+        val = undefined;
+      }
+      if (omit.includes(key)) {
+        val = undefined;
+      }
+      return val;
+    };
+    return JSON.stringify(this.sortObject(obj), replacer);
+  }
+
   public diff(left: any, right: any, sortKeys = false): IJsonDiff {
     if (sortKeys) {
       left = this.makeSortedString(left);


### PR DESCRIPTION
Did this ever work as expected? Maybe? Server groups probably worked until recently; load balancers, nope.

We use `stringVal` as a means to determine whether to replace elements and force a re-render via Angular's change detection. This works pretty well, unless we nest that value in itself on every refresh (load balancers), or we add entity tags, which are non-deterministically added to the server group, depending on whether the call to fetch cluster tags or the call to fetch server group tags comes back first (`stringify` serializes properties in the order in which they're added to an object).

So, we'll just alphabetize those strings when we generate them.