### PR TITLE
fix(core): Fix sticky-headers in react

### DIFF
--- a/app/scripts/modules/core/delivery/executionGroup/ExecutionGroups.tsx
+++ b/app/scripts/modules/core/delivery/executionGroup/ExecutionGroups.tsx
@@ -32,13 +32,7 @@ export class ExecutionGroups extends React.Component<IProps, IState> {
       groups: executionFilterModel.groups,
       showingDetails: this.showingDetails()
     }
-  }
 
-  private showingDetails(): boolean {
-    return $state.includes('**.execution');
-  }
-
-  public componentDidMount(): void {
     this.applicationRefreshUnsubscribe = this.props.application.executions.onRefresh(null, () => { this.forceUpdate(); });
     this.groupsUpdatedSubscription = executionFilterModel.groupsUpdated.subscribe(() => { this.setState({groups: executionFilterModel.groups}); });
     this.stateChangeSuccessSubscription = stateEvents.stateChangeSuccess.subscribe(() => {
@@ -47,6 +41,10 @@ export class ExecutionGroups extends React.Component<IProps, IState> {
         this.setState({showingDetails: detailsShown});
       }
     });
+  }
+
+  private showingDetails(): boolean {
+    return $state.includes('**.execution');
   }
 
   public componentWillUnmount(): void {

--- a/app/scripts/modules/core/utils/stickyHeader/Sticky.tsx
+++ b/app/scripts/modules/core/utils/stickyHeader/Sticky.tsx
@@ -53,16 +53,15 @@ export class Sticky extends React.Component<IProps, IState> {
       return;
     }
 
+    this.recomputeState = throttle(this.recomputeState, 50, {trailing: true});
+  }
 
-    this.stickySubscription = context.stickyContainer.elementMounted.subscribe((element: HTMLElement) => {
+  private setContainerElement(element: HTMLElement): void {
       this.stickyContainerElement = element;
       if (!this.props.stickyIf || this.props.stickyIf()) {
         this.addEventListeners(this.recomputeState);
         this.recomputeState();
       }
-    });
-
-    this.recomputeState = throttle(this.recomputeState, 50, {trailing: true});
   }
 
   private outerHeight(el: HTMLElement): number {
@@ -128,7 +127,6 @@ export class Sticky extends React.Component<IProps, IState> {
       Sticky.RECOMPUTE_EVENTS.forEach((event) => {
         this.stickyContainerElement.addEventListener(event, callback);
       });
-      this.recomputeState();
     }
   }
 
@@ -142,6 +140,14 @@ export class Sticky extends React.Component<IProps, IState> {
 
   private refCallback(element: HTMLElement): void {
     this.stickyElement = element;
+  }
+
+  public componentDidMount(): void {
+    if (this.context.stickyContainer.element) {
+      this.setContainerElement(this.context.stickyContainer.element);
+    } else {
+      this.stickySubscription = this.context.stickyContainer.elementMounted.subscribe(this.setContainerElement);
+    }
   }
 
   public componentWillReceiveProps(nextProps: IProps): void {

--- a/app/scripts/modules/core/utils/stickyHeader/StickyContainer.tsx
+++ b/app/scripts/modules/core/utils/stickyHeader/StickyContainer.tsx
@@ -13,6 +13,7 @@ export class StickyContainer extends React.Component<any, any> {
     stickyContainer: PropTypes.any
   };
 
+  public element: HTMLElement;
   public elementMounted: Subject<HTMLDivElement> = new Subject<HTMLDivElement>();
   private elementMountedAlready = false;
 
@@ -21,6 +22,7 @@ export class StickyContainer extends React.Component<any, any> {
   }
 
   public refCallback(element: HTMLDivElement): void {
+    this.element = element;
     if (!this.elementMountedAlready) {
       this.elementMounted.next(element);
       this.elementMountedAlready = true;


### PR DESCRIPTION
Since the sticky component listened for the `<StickyContainer>` component to mount to get the subscription, if you set filters and then cleared them, the new `<Sticky>` components would not have listeners attached.
