### PR TITLE
fix(aws): remove debounce from ui-select, use inf-scroll

### DIFF
--- a/app/scripts/modules/amazon/serverGroup/details/securityGroup/editSecurityGroups.modal.controller.js
+++ b/app/scripts/modules/amazon/serverGroup/details/securityGroup/editSecurityGroups.modal.controller.js
@@ -27,6 +27,14 @@ module.exports = angular.module('spinnaker.serverGroup.details.aws.securityGroup
       verification: {},
     };
 
+    this.infiniteScroll = {
+      currentItems: 20,
+    };
+
+    this.addMoreItems = () => this.infiniteScroll.currentItems += 20;
+
+    this.resetCurrentItems = () => this.infiniteScroll.currentItems = 20;
+
     this.isValid = () => this.state.verification.verified;
 
     securityGroupReader.getAllSecurityGroups().then(allGroups => {
@@ -34,7 +42,15 @@ module.exports = angular.module('spinnaker.serverGroup.details.aws.securityGroup
           region = serverGroup.region,
           vpcId = serverGroup.vpcId;
       this.availableSecurityGroups = _.get(allGroups, [account, 'aws', region].join('.'), [])
-        .filter(group => group.vpcId === vpcId);
+        .filter(group => group.vpcId === vpcId).sort((a, b) => {
+          if (this.command.securityGroups.some(g => g.id === a.id)) {
+            return -1;
+          }
+          if (this.command.securityGroups.some(g => g.id === b.id)) {
+            return 1;
+          }
+          return a.name.localeCompare(b.name);
+        });
       this.state.securityGroupsLoaded = true;
     });
 

--- a/app/scripts/modules/amazon/serverGroup/details/securityGroup/editSecurityGroups.modal.html
+++ b/app/scripts/modules/amazon/serverGroup/details/securityGroup/editSecurityGroups.modal.html
@@ -10,10 +10,12 @@
         <div class="col-md-10 col-md-offset-1">
           <ui-select multiple
                      ng-model="$ctrl.command.securityGroups"
-                     ng-model-options="{debounce: 300}"
+                     uis-open-close="$ctrl.resetCurrentItems()"
                      class="form-control input-sm">
             <ui-select-match>{{$item.name}} ({{$item.id}})</ui-select-match>
-            <ui-select-choices repeat="securityGroup as securityGroup in $ctrl.availableSecurityGroups | anyFieldFilter: {name: $select.search, id: $select.search}">
+            <ui-select-choices repeat="securityGroup as securityGroup in $ctrl.availableSecurityGroups | filter: $select.search | limitTo: $ctrl.infiniteScroll.currentItems"
+                               infinite-scroll="$ctrl.addMoreItems()"
+                               infinite-scroll-distance="4">
               <span ng-bind-html="securityGroup.name | highlight: $select.search"></span>
               (<span ng-bind-html="securityGroup.id  | highlight: $select.search"></span>)
             </ui-select-choices>


### PR DESCRIPTION
Surprise, `debounce` doesn't work with ui-select, so it ends up not pushing new changes to the model once a user starts typing to filter the list of security groups.

(We have very similar code in the create/clone modal, just didn't update it here)