### PR TITLE
feat(provider/oraclebmcs): Add initial scaffolding for Oracle BMCS

### DIFF
--- a/app/scripts/modules/oracle/cache/cacheConfigurer.service.js
+++ b/app/scripts/modules/oracle/cache/cacheConfigurer.service.js
@@ -1,0 +1,30 @@
+'use strict';
+
+let angular = require('angular');
+
+import {ACCOUNT_SERVICE} from 'core/account/account.service';
+import {NETWORK_READ_SERVICE} from 'core/network/network.read.service';
+
+module.exports = angular.module('spinnaker.oraclebmcs.cache.initializer', [
+  ACCOUNT_SERVICE,
+  NETWORK_READ_SERVICE
+])
+  .factory('oraclebmcsCacheConfigurer', function (accountService, networkReader) {
+
+    let config = Object.create(null);
+    let provider = 'oraclebmcs';
+
+    config.credentials = {
+      initializers: [ () => accountService.listAccounts(provider) ],
+    };
+
+    config.account = {
+      initializers: [ () => accountService.getCredentialsKeyedByAccount(provider) ],
+    };
+
+    config.networks = {
+      initializers: [ () => networkReader.listNetworksByProvider(provider) ],
+    };
+
+    return config;
+  });

--- a/app/scripts/modules/oracle/image/image.reader.js
+++ b/app/scripts/modules/oracle/image/image.reader.js
@@ -1,0 +1,38 @@
+'use strict';
+
+import {API_SERVICE} from 'core/api/api.service';
+
+let angular = require('angular');
+
+module.exports = angular.module('spinnaker.oraclebmcs.image.reader', [API_SERVICE])
+  .factory('oraclebmcsImageReader', function ($q, API) {
+
+    function findImages(params) {
+      return API
+        .one('images/find')
+        .withParams(params)
+        .get()
+        .catch(function() { return []; });
+    }
+
+    function getImage(imageId, region, credentials) {
+      return API
+        .one('images')
+        .one(credentials)
+        .one(region)
+        .one(imageId)
+        .withParams({provider: 'oraclebmcs'})
+        .get()
+        .then(function(results) {
+          return results && results.length ? results[0] : null;
+        },
+        function() {
+          return null;
+        });
+    }
+
+    return {
+      findImages,
+      getImage,
+    };
+  });

--- a/app/scripts/modules/oracle/oraclebmcs.module.js
+++ b/app/scripts/modules/oracle/oraclebmcs.module.js
@@ -1,0 +1,37 @@
+'use strict';
+
+import {CLOUD_PROVIDER_REGISTRY} from 'core/cloudProvider/cloudProvider.registry';
+
+let angular = require('angular');
+
+let templates = require.context('./', true, /\.html$/);
+templates.keys().forEach(function(key) {
+  templates(key);
+});
+
+module.exports = angular.module('spinnaker.oraclebmcs', [
+  CLOUD_PROVIDER_REGISTRY,
+  // Cache
+  require('./cache/cacheConfigurer.service.js'),
+  // Images
+  require('./image/image.reader.js')
+])
+  .config(function (cloudProviderRegistryProvider) {
+    cloudProviderRegistryProvider.registerProvider('oraclebmcs', {
+      name: 'Oracle',
+      cache: {
+        configurer: 'oraclebmcsCacheConfigurer',
+      },
+      image: {
+        reader: 'oraclebmcsImageReader',
+      },
+      loadBalancer: {
+      },
+      serverGroup: {
+      },
+      instance: {
+      },
+      securityGroup: {
+      }
+    });
+  });

--- a/app/scripts/modules/oracle/oraclebmcs.settings.ts
+++ b/app/scripts/modules/oracle/oraclebmcs.settings.ts
@@ -1,0 +1,13 @@
+import { IProviderSettings, SETTINGS } from 'core/config/settings';
+
+export interface IOracleBMCSProviderSettings extends IProviderSettings {
+  defaults: {
+    account?: string;
+    region?: string;
+  };
+}
+
+export const OracleBMCSProviderSettings: IOracleBMCSProviderSettings = <IOracleBMCSProviderSettings>SETTINGS.providers.oraclebmcs || { defaults: {} };
+if (OracleBMCSProviderSettings) {
+  OracleBMCSProviderSettings.resetToOriginal = SETTINGS.resetToOriginal;
+}


### PR DESCRIPTION
This change adds some initial scaffolding for the Oracle BMCS provider. 

I chose the image and cache modules to merge first since they're fairly small.