### PR TITLE
fix(ChAP): Fix canary report link for ChAP

### DIFF
--- a/app/scripts/modules/netflix/pipeline/stage/chap/chapExecutionDetails.controller.js
+++ b/app/scripts/modules/netflix/pipeline/stage/chap/chapExecutionDetails.controller.js
@@ -14,36 +14,41 @@ module.exports = angular.module('spinnaker.netflix.pipeline.stage.chap.execution
 
     $scope.configSections = ['testRunDetails', 'taskStatus'];
 
-    let initialized = () => {
+    const initialized = () => {
+      const run = $scope.stage.context.run;
       $scope.detailsSection = $stateParams.details;
-      $scope.canaryReportUrl = [
-        NetflixSettings.chap.canaryReportBaseUrl,
-        $scope.stage.context.run.testCase.properties.account,
-        $scope.stage.context.run.testCase.properties.region,
-        $scope.stage.context.run.properties.acaConfigId,
-        $scope.stage.context.run.properties.analysisId,
-      ].join('/');
+
+      $scope.canaryReports = Object.keys(run.properties.analysisIds).map(key => ({
+        key,
+        url: [
+          NetflixSettings.chap.canaryReportBaseUrl,
+          run.testCase.properties.account,
+          run.testCase.properties.region,
+          key,
+          run.properties.analysisIds[key],
+        ].join('/')
+      }));
 
       $scope.testCaseUrl = [
         NetflixSettings.chap.chapBaseUrl,
         'testcases',
-        $scope.stage.context.run.testCase.id,
+        run.testCase.id,
       ].join('/');
 
       $scope.runUrl = [
         NetflixSettings.chap.chapBaseUrl,
         'runs',
-        $scope.stage.context.run.id,
+        run.id,
       ].join('/');
 
       $scope.fitScenarioUrl = [
         NetflixSettings.chap.fitBaseUrl,
         'scenarios',
-        $scope.stage.context.run.testCase.properties.scenario,
+        run.testCase.properties.scenario,
       ].join('/');
     };
 
-    let initialize = () => executionDetailsSectionService.synchronizeSection($scope.configSections, initialized);
+    const initialize = () => executionDetailsSectionService.synchronizeSection($scope.configSections, initialized);
 
     initialize();
 

--- a/app/scripts/modules/netflix/pipeline/stage/chap/chapExecutionDetails.html
+++ b/app/scripts/modules/netflix/pipeline/stage/chap/chapExecutionDetails.html
@@ -34,8 +34,11 @@
           <div>
             <a href="{{runUrl}}" target="_blank">Run Details</a>
           </div>
-          <div>
-            <a href="{{canaryReportUrl}}" target="_blank">Canary Report</a>
+          <div ng-repeat="canaryReport in canaryReports">
+            <a href="{{canaryReport.url}}" target="_blank">
+              Canary Report
+              <span ng-if="canaryReports.length > 1"> ({{ canaryReport.key }})</span>
+            </a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
ChAP can have multiple canary reports.  This update renders a list of canary report links.  If there are more than one, the report key is shown in parentheses