### PR TITLE
fix(core/cluster): Use `redirectTo` hook to switch to pipelines when server groups are disabled

### DIFF
--- a/app/scripts/modules/core/cluster/allClusters.controller.js
+++ b/app/scripts/modules/core/cluster/allClusters.controller.js
@@ -29,12 +29,6 @@ module.exports = angular.module('spinnaker.core.cluster.allClusters.controller',
 ])
   .controller('AllClustersCtrl', function($scope, app, $uibModal, $timeout, providerSelectionService, clusterFilterService, $state,
                                           ClusterFilterModel, MultiselectModel, InsightFilterStateModel, serverGroupCommandBuilder, cloudProviderRegistry) {
-
-    if (app.serverGroups.disabled) {
-      $state.go('^.^' + app.dataSources.find(ds => ds.sref && !ds.disabled).sref, {}, {location: 'replace'});
-      return;
-    }
-
     this.application = app;
     ClusterFilterModel.activate();
     this.initialized = false;

--- a/app/scripts/modules/core/serverGroup/serverGroup.states.ts
+++ b/app/scripts/modules/core/serverGroup/serverGroup.states.ts
@@ -32,6 +32,19 @@ module(SERVER_GROUP_STATES, [
       // and deal with the exception in the AllClustersCtrl
       ready: (app: Application) => app.getDataSource('serverGroups').ready().catch(() => null),
     },
+    redirectTo: (transition) => {
+      return transition.injector().getAsync('app').then((app: Application) => {
+        if (app.serverGroups.disabled) {
+          const relativeSref = app.dataSources.find(ds => ds.sref && !ds.disabled).sref;
+          const params = transition.params();
+          // Target the state relative to the `clusters` state
+          const options = { relative: transition.to().name };
+          // Up two state levels first
+          return transition.router.stateService.target('^.^' + relativeSref, params, options);
+        }
+        return null;
+      });
+    },
     params: stateConfigProvider.buildDynamicParams(filterModelConfig),
     data: {
       pageTitleSection: {


### PR DESCRIPTION
@anotherchrisberry @jrsquared PTAL