### PR TITLE
fix(routing): do not add array field to params if not specified

### DIFF
--- a/app/scripts/modules/core/navigation/state.provider.ts
+++ b/app/scripts/modules/core/navigation/state.provider.ts
@@ -57,8 +57,10 @@ export class StateConfigProvider implements IServiceProvider {
       acc[param] = {
         type: p.type || 'string',
         dynamic: true,
-        array: p.array,
       };
+      if (p.array) {
+        acc[param].array = true;
+      }
       return acc;
     }, {});
   }


### PR DESCRIPTION
This was wreaking havoc on inverse-boolean params.