### PR TITLE
fix(pipelines): fix reordering of pipeline/strategy configs

### DIFF
--- a/app/scripts/modules/core/delivery/filter/executionFilter.controller.js
+++ b/app/scripts/modules/core/delivery/filter/executionFilter.controller.js
@@ -85,10 +85,11 @@ module.exports = angular.module('spinnaker.core.delivery.filter.executionFilter.
       disabled: true,
       stop: () => {
         $analytics.eventTrack('Reordered pipeline', {category: 'Pipelines'});
-        var dirty = [];
-        this.application.pipelineConfigs.data.forEach((pipeline, index) => {
-          if (pipeline.index !== index) {
-            pipeline.index = index;
+        const dirty = [];
+        this.application.pipelineConfigs.data.concat(this.application.strategyConfigs.data).forEach((pipeline) => {
+          const newIndex = this.pipelineNames.indexOf(pipeline.name);
+          if (pipeline.index !== newIndex) {
+            pipeline.index = newIndex;
             dirty.push(pipeline);
           }
         });

--- a/app/scripts/modules/core/delivery/filter/filterNav.html
+++ b/app/scripts/modules/core/delivery/filter/filterNav.html
@@ -25,7 +25,7 @@
 
     <filter-section heading="Pipelines" expanded="true">
       <div class="form"
-           ng-model="vm.application.pipelineConfigs.data"
+           ng-model="vm.pipelineNames"
            ui-sortable="vm.pipelineSortOptions">
         <div ng-repeat="pipeline in vm.pipelineNames" class="checkbox sortable">
           <div>


### PR DESCRIPTION
I honestly don't know how this has ever worked. We're using a different field for the `ng-model` and the `ng-repeat`.

The important (?) thing is this makes more sense and works, allowing predictable reordering of pipeline configs, including the last item in the list.