### PR TITLE
feat(netflix): add TTL to properties, scope editor on stage

### DIFF
--- a/app/scripts/modules/core/utils/timeFormatters.ts
+++ b/app/scripts/modules/core/utils/timeFormatters.ts
@@ -52,6 +52,16 @@ export const fastPropertyTime = memoize((input: any) => {
   }
 });
 
+export const fastPropertyTtl = (input: any, seconds: number) => {
+  if (input) {
+    input = input.replace('[UTC]', '');
+    const thisMoment = moment(input);
+    return thisMoment.isValid() ? thisMoment.add(seconds, 'second').format('YYYY-MM-DD HH:mm:ss z') : '-';
+  } else {
+    return '--';
+  }
+};
+
 export function timePickerTime(input: any) {
   if (input && !isNaN(input.hours) && !isNaN(input.minutes)) {
     const hours = parseInt(input.hours, 10),

--- a/app/scripts/modules/netflix/fastProperties/domain/property.domain.ts
+++ b/app/scripts/modules/netflix/fastProperties/domain/property.domain.ts
@@ -15,6 +15,8 @@ export class Property {
   public cmcTicket: string;
   public region?: string;
   public stack?: string;
+  public ttl?: number;
+  public ts: string;
 
   public appId: string;
   public scope: Scope;
@@ -45,6 +47,7 @@ export class Property {
     property.value = platformProperty.value;
     property.email = platformProperty.email;
     property.cmcTicket = platformProperty.updatedBy;
+    property.ttl = platformProperty.ttl;
 
     return property;
   }

--- a/app/scripts/modules/netflix/fastProperties/fastProperties.help.ts
+++ b/app/scripts/modules/netflix/fastProperties/fastProperties.help.ts
@@ -1,0 +1,16 @@
+import {module} from 'angular';
+import {HELP_CONTENTS_REGISTRY, HelpContentsRegistry} from 'core/help/helpContents.registry';
+
+const helpContents: any[] = [
+  {
+    key: 'fastProperty.ttl',
+    contents: `<p>Sets an expiration date on the property.</p>
+               <p>Leave blank or set to "0" to <b>not</b> set an expiration date.</p>`
+  },
+];
+
+export const FAST_PROPERTIES_HELP = 'spinnaker.netflix.fastProperties.help';
+module(FAST_PROPERTIES_HELP, [HELP_CONTENTS_REGISTRY])
+  .run((helpContentsRegistry: HelpContentsRegistry) => {
+    helpContents.forEach((entry: any) => helpContentsRegistry.register(entry.key, entry.contents));
+  });

--- a/app/scripts/modules/netflix/fastProperties/fastProperties.module.ts
+++ b/app/scripts/modules/netflix/fastProperties/fastProperties.module.ts
@@ -1,20 +1,21 @@
-'use strict';
+import { module } from 'angular';
 
 import { FAST_PROPERTY_SEARCH_COMPONENT } from './view/filter/fastPropertyFilterSearch.component';
 import { FAST_PROPERTY_DETAILS_CONTROLLER } from './view/details/fastPropertyDetails.controller';
 import { CREATE_FAST_PROPERTY_WIZARD_CONTROLLER } from './wizard/createFastPropertyWizard.controller';
+import { FAST_PROPERTIES_HELP } from './fastProperties.help';
 import { FAST_PROPERTY_STATES} from './fastProperties.states';
-let angular = require('angular');
 
 import './fastProperties.less';
 import './global/fastPropertyFilterSearch.less';
 import 'netflix/canary/canary.less';
 
-module.exports = angular
-  .module('spinnaker.netflix.fastProperties', [
+export const FAST_PROPERTIES_MODULE = 'spinnaker.netflix.fastProperties';
+module(FAST_PROPERTIES_MODULE, [
     FAST_PROPERTY_STATES,
     CREATE_FAST_PROPERTY_WIZARD_CONTROLLER,
     FAST_PROPERTY_DETAILS_CONTROLLER,
+    FAST_PROPERTIES_HELP,
     require('./fastProperty.dataSource'),
     FAST_PROPERTY_SEARCH_COMPONENT,
   ]);

--- a/app/scripts/modules/netflix/fastProperties/view/details/fastPropertyDetails.controller.ts
+++ b/app/scripts/modules/netflix/fastProperties/view/details/fastPropertyDetails.controller.ts
@@ -11,6 +11,7 @@ import { FAST_PROPERTY_HISTORY_COMPONENT } from '../history/fastPropertyHistory.
 import { Application } from 'core/application/application.model';
 import { Property } from '../../domain/property.domain';
 import { stateEvents } from 'core/state.events';
+import { fastPropertyTtl } from 'core/utils/timeFormatters';
 
 export class FastPropertyDetailsController {
 
@@ -18,6 +19,7 @@ export class FastPropertyDetailsController {
   private locationChangeSuccessSubscription: Subscription;
   private dataRefreshUnsubscribe: () => void;
   public propertyNotFound = false;
+  public propertyExpires: string;
 
   constructor(private $uibModal: IModalService,
               private fastPropertyReader: FastPropertyReaderService,
@@ -62,6 +64,11 @@ export class FastPropertyDetailsController {
       .then((results: Property) => {
         this.property = results;
         this.propertyNotFound = false;
+        if (this.property.ttl && this.property.ts) {
+          this.propertyExpires = fastPropertyTtl(this.property.ts, this.property.ttl);
+        } else {
+          this.propertyExpires = null;
+        }
       })
       .catch(() => {
         const otherEnv = env === 'prod' ? 'test' : 'prod';

--- a/app/scripts/modules/netflix/fastProperties/view/details/fastPropertyDetails.html
+++ b/app/scripts/modules/netflix/fastProperties/view/details/fastPropertyDetails.html
@@ -70,6 +70,9 @@
         <dt>Updated On</dt>
         <dd>{{details.property.ts | fastPropertyTime}}</dd>
 
+        <dt ng-if="details.propertyExpires">Expires</dt>
+        <dd ng-if="details.propertyExpires">{{details.propertyExpires}}</dd>
+
         <dt>CMC Ticket</dt>
         <dd>{{details.property.cmcTicket}}</dd>
       </dl>

--- a/app/scripts/modules/netflix/fastProperties/wizard/propertyDetails/propertyDetails.component.html
+++ b/app/scripts/modules/netflix/fastProperties/wizard/propertyDetails/propertyDetails.component.html
@@ -124,6 +124,28 @@
         </div>
       </div>
 
+
+      <!--
+        TTL
+      -->
+
+      <div class="form-group row">
+        <div class="col-sm-3 sm-label-right">
+          TTL (seconds)
+          <help-field key="fastProperty.ttl"></help-field>
+        </div>
+        <div class="col-sm-9">
+          <input
+            type="number"
+            name="ttl"
+            class="form-control input-sm"
+            style="width: 100px"
+            min="0"
+            ng-disabled="$ctrl.isDeleting || $ctrl.disableAll"
+            ng-model="$ctrl.command.property.ttl"/>
+        </div>
+      </div>
+
     </div>
 
     <!--

--- a/app/scripts/modules/netflix/netflix.module.ts
+++ b/app/scripts/modules/netflix/netflix.module.ts
@@ -4,19 +4,20 @@ import {
   APPLICATION_DATA_SOURCE_REGISTRY,
   ApplicationDataSourceRegistry
 } from 'core/application/service/applicationDataSource.registry';
-import {AVAILABILITY_DIRECTIVE} from './availability/availability.directive';
-import {BLESK_MODULE} from './blesk/blesk.module';
-import {CANARY_ANALYSIS_NAME_SELECTOR_COMPONENT} from './canary/canaryAnalysisNameSelector.component';
-import {CLOUD_PROVIDER_REGISTRY, CloudProviderRegistry} from 'core/cloudProvider/cloudProvider.registry';
-import {EXCEPTION_HANDLER} from './exception/exceptionHandler';
-import {FEEDBACK_COMPONENT} from './feedback/feedback.component';
-import {ISOLATED_TESTING_TARGET_STAGE_MODULE} from './pipeline/stage/isolatedTestingTarget/isolatedTestingTargetStage.module';
-import {NETFLIX_APPLICATION_MODULE} from './application';
-import {NETFLIX_HELP_REGISTRY} from './help/netflixHelpContents.registry';
-import {NetflixSettings} from './netflix.settings';
-import {RESERVATION_REPORT_COMPONENT} from './report/reservationReport.component';
-import {TABLEAU_STATES} from './tableau/tableau.states';
-import {TEMPLATE_OVERRIDES} from './templateOverride/templateOverrides.module';
+import { AVAILABILITY_DIRECTIVE } from './availability/availability.directive';
+import { BLESK_MODULE } from './blesk/blesk.module';
+import { CANARY_ANALYSIS_NAME_SELECTOR_COMPONENT } from './canary/canaryAnalysisNameSelector.component';
+import { CLOUD_PROVIDER_REGISTRY, CloudProviderRegistry } from 'core/cloudProvider/cloudProvider.registry';
+import { EXCEPTION_HANDLER } from './exception/exceptionHandler';
+import { FAST_PROPERTIES_MODULE } from './fastProperties/fastProperties.module';
+import { FEEDBACK_COMPONENT } from './feedback/feedback.component';
+import { ISOLATED_TESTING_TARGET_STAGE_MODULE } from './pipeline/stage/isolatedTestingTarget/isolatedTestingTargetStage.module';
+import { NETFLIX_APPLICATION_MODULE } from './application';
+import { NETFLIX_HELP_REGISTRY } from './help/netflixHelpContents.registry';
+import { NetflixSettings } from './netflix.settings';
+import { RESERVATION_REPORT_COMPONENT } from './report/reservationReport.component';
+import { TABLEAU_STATES } from './tableau/tableau.states';
+import { TEMPLATE_OVERRIDES } from './templateOverride/templateOverrides.module';
 
 // load all templates into the $templateCache
 const templates = require.context('./', true, /\.html$/);
@@ -32,6 +33,7 @@ module(NETFLIX_MODULE, [
   CANARY_ANALYSIS_NAME_SELECTOR_COMPONENT,
   CLOUD_PROVIDER_REGISTRY,
   EXCEPTION_HANDLER,
+  FAST_PROPERTIES_MODULE,
   FEEDBACK_COMPONENT,
   ISOLATED_TESTING_TARGET_STAGE_MODULE,
   NETFLIX_APPLICATION_MODULE,
@@ -40,7 +42,6 @@ module(NETFLIX_MODULE, [
   TABLEAU_STATES,
   TEMPLATE_OVERRIDES,
 
-  require('./fastProperties/fastProperties.module.js'),
   require('./instance/aws/netflixAwsInstanceDetails.controller.js'),
   require('./instance/titus/netflixTitusInstanceDetails.controller.js'),
   require('./pipeline/stage/canary/canaryStage.module.js'),

--- a/app/scripts/modules/netflix/pipeline/stage/properties/create/persistedPropertyList.component.html
+++ b/app/scripts/modules/netflix/pipeline/stage/properties/create/persistedPropertyList.component.html
@@ -8,7 +8,7 @@
 
 
 <div class="form-group">
-  <div class="col-md-7 col-md-offset-2">
+  <div class="col-md-8 col-md-offset-3">
     <p ng-if="!propertyList.stage.persistedProperties.length">
       You don't have any persisted properties configured.
     </p>

--- a/app/scripts/modules/netflix/pipeline/stage/properties/create/persistedPropertyList.component.js
+++ b/app/scripts/modules/netflix/pipeline/stage/properties/create/persistedPropertyList.component.js
@@ -25,7 +25,8 @@ module.exports = angular
       }
       var newProperty = {
         updatedBy: user.name,
-        sourceOfUpdate: 'spinnaker'
+        sourceOfUpdate: 'spinnaker',
+        ttl: 0,
       };
       vm.stage.persistedProperties.push(newProperty);
     };

--- a/app/scripts/modules/netflix/pipeline/stage/properties/create/property.component.html
+++ b/app/scripts/modules/netflix/pipeline/stage/properties/create/property.component.html
@@ -66,7 +66,11 @@
     </constraints-selector>
   </stage-config-field>
 
+  <stage-config-field label="TTL (seconds)" help-key="fastProperty.ttl">
+    <input type="number"
+           class="form-control input-sm"
+           style="width: 100px"
+           ng-model="propertyCtrl.property.ttl"/>
+  </stage-config-field>
+
 </div>
-
-
-

--- a/app/scripts/modules/netflix/pipeline/stage/properties/create/propertyStage.html
+++ b/app/scripts/modules/netflix/pipeline/stage/properties/create/propertyStage.html
@@ -7,19 +7,19 @@
             <h4 class="section">Properties</h4>
             <stage-config-field
               label="Copy From Stage"
-              ng-if="propertyStage.hasPreviousPropertyStages()">
+              ng-if="ctrl.hasPreviousPropertyStages()">
 
               <div class="row" style="margin-bottom: 10px">
                 <div class="col-md-10">
                   <select
                     name="previousStageName"
                     class="form-control input-sm"
-                    ng-model="propertyStage.stage.copiedFromName"
-                    ng-options="name for name in propertyStage.getPreviousPropertyStageNames()">
+                    ng-model="ctrl.stage.copiedFromName"
+                    ng-options="name for name in ctrl.getPreviousPropertyStageNames()">
                   </select>
                 </div>
                 <div class="col-md-2">
-                  <button class="btn btn-primary btn-sm pull-right" ng-click="propertyStage.setStageFromPrevious()">Copy</button>
+                  <button class="btn btn-primary btn-sm pull-right" ng-click="ctrl.setStageFromPrevious()">Copy</button>
                 </div>
               </div>
             </stage-config-field>
@@ -28,20 +28,20 @@
             <div class="form-horizontal fp-scope-config-view">
 
               <persisted-property-create-list
-                stage="propertyStage.stage"
-                property-list="propertyStage.appPropertyList">
+                stage="ctrl.stage"
+                property-list="ctrl.appPropertyList">
               </persisted-property-create-list>
 
               <h4 class="section">Scope</h4>
 
-              <div ng-if="!propertyStage.scopeSelected">
+              <div ng-if="!ctrl.scopeSelected">
                 <stage-config-field label="Environment">
                   <select
                     autofocus
                     name="env"
                     class="form-control input-sm"
-                    ng-model="propertyStage.stage.scope.env"
-                    ng-change="propertyStage.resetScope()"
+                    ng-model="ctrl.stage.scope.env"
+                    ng-change="ctrl.resetScope()"
                     required
                     ng-options="env for env in ['prod', 'test']">
                   </select>
@@ -52,10 +52,10 @@
                   <input
                     type="checkbox"
                     style="margin-top: 10px"
-                    ng-model="propertyStage.stage.rollbackProperties" >
+                    ng-model="ctrl.stage.rollbackProperties" >
                 </stage-config-field>
 
-                <stage-config-field ng-if="!propertyStage.applicationsLoaded">
+                <stage-config-field ng-if="!ctrl.applicationsLoaded">
                   <div
                     style="margin: 35px"
                     us-spinner="{radius:8, width:3, length:5}">
@@ -63,80 +63,118 @@
                 </stage-config-field>
               </div>
 
-              <stage-config-field label="Scope selection" ng-if="propertyStage.scopeSelected">
-                <div class="form-control-static">
-                  <a href ng-click="propertyStage.resetScope()">Select new scope</a>
-                </div>
-              </stage-config-field>
+              <div ng-if="ctrl.applicationsLoaded && !ctrl.scopeSelected">
 
-              <div ng-if="propertyStage.applicationsLoaded">
-
-                <stage-config-field label="Choose Scope" ng-if="!propertyStage.scopeSelected">
+                <stage-config-field label="Choose Scope" ng-if="!ctrl.scopeSelected">
                   <fast-property-scope-search-component
-                    on-scope-selected="propertyStage.selectScope(scopeOption)"
-                    env="{{propertyStage.stage.scope.env}}"
+                    on-scope-selected="ctrl.selectScope(scopeOption)"
+                    env="{{ctrl.stage.scope.env}}"
                     application-name="application.name">
                   </fast-property-scope-search-component>
                 </stage-config-field>
 
               </div>
 
-              <stage-config-field label="Selected Scope" ng-if="propertyStage.scopeSelected">
-                <div>
-                  <table class="table">
-                    <tbody>
-                    <tr ng-if="propertyStage.stage.scope.env">
-                      <td><b>Env</b></td>
-                      <td>{{propertyStage.stage.scope.env}}</td>
-                    </tr>
-                    <tr ng-if="propertyStage.stage.scope.appId">
-                      <td><b>App</b></td>
-                      <td>{{propertyStage.stage.scope.appId}}</td>
-                    </tr>
-                    <tr ng-if="propertyStage.stage.scope.appIdList">
-                      <td><b>Apps</b></td>
-                      <td>{{propertyStage.stage.scope.appIdList.join(', ')}}</td>
-                    </tr>
-                    <tr ng-if="propertyStage.stage.scope.region">
-                      <td><b>Region</b></td>
-                      <td>{{propertyStage.stage.scope.region}}</td>
-                    </tr>
-                    <tr ng-if="propertyStage.stage.scope.stack">
-                      <td><b>Stack</b></td>
-                      <td>{{propertyStage.stage.scope.stack}}</td>
-                    </tr>
-                    <tr ng-if="propertyStage.stage.scope.cluster">
-                      <td><b>Cluster</b></td>
-                      <td>{{propertyStage.stage.scope.cluster}}</td>
-                    </tr>
-                    <tr ng-if="propertyStage.stage.scope.asg">
-                      <td><b>ASG</b></td>
-                      <td>{{propertyStage.stage.scope.asg}}</td>
-                    </tr>
-                    <tr ng-if="propertyStage.stage.scope.zone">
-                      <td><b>Zone</b></td>
-                      <td>{{propertyStage.stage.scope.zone}}</td>
-                    </tr>
-                    <tr ng-if="propertyStage.stage.scope.serverId">
-                      <td><b>Instance</b></td>
-                      <td>{{propertyStage.stage.scope.serverId}}</td>
-                    </tr>
-                    <tr ng-if="propertyStage.stage.scope.instanceCounts">
-                      <td><b>Instance Count</b></td>
-                      <td style="color:#b82525; font-weight: 600; font-size: larger; padding-top: 6px; margin-left: 9px">{{propertyStage.stage.scope.instanceCounts.up}} instances</td>
-                    </tr>
-                    </tbody>
-                  </table>
+              <div class="form-group" ng-if="ctrl.scopeSelected">
+                <div class="col-md-3 sm-label-right">
+                  Selected Scope
+                  <div style="font-weight: 400">
+                    <a href ng-click="ctrl.resetScope()">Select new scope</a>
+                  </div>
                 </div>
+                <div class="col-md-8">
+                  <div>
+                    <table class="table">
+                      <tbody>
+                      <tr ng-if="ctrl.stage.scope.env || ctrl.customizingScope">
+                        <td><b>Env</b></td>
+                        <td>
+                          <span ng-if="!ctrl.customizingScope">{{ctrl.stage.scope.env}}</span>
+                          <input class="form-control input-sm" ng-model="ctrl.stage.scope.env" ng-if="ctrl.customizingScope"/>
+                        </td>
+                      </tr>
+                      <tr ng-if="ctrl.stage.scope.appId || ctrl.customizingScope">
+                        <td><b>App</b></td>
+                        <td>
+                          <span ng-if="!ctrl.customizingScope">{{ctrl.stage.scope.appId}}</span>
+                          <input class="form-control input-sm" ng-model="ctrl.stage.scope.appId" ng-if="ctrl.customizingScope"/>
+                        </td>
+                      </tr>
+                      <tr ng-if="ctrl.stage.scope.appIdList || ctrl.customizingScope">
+                        <td><b>Apps</b></td>
+                        <td>
+                          <span ng-if="!ctrl.customizingScope">{{ctrl.stage.scope.appIdList.join(', ')}}</span>
+                          <input class="form-control input-sm"
+                                 placeholder="comma-separated list"
+                                 ng-model="ctrl.appIdList"
+                                 ng-change="ctrl.appIdListChanged()"
+                                 ng-if="ctrl.customizingScope"/>
+                        </td>
+                      </tr>
+                      <tr ng-if="ctrl.stage.scope.region || ctrl.customizingScope">
+                        <td><b>Region</b></td>
+                        <td>
+                          <span ng-if="!ctrl.customizingScope">{{ctrl.stage.scope.region}}</span>
+                          <input class="form-control input-sm" ng-model="ctrl.stage.scope.region" ng-if="ctrl.customizingScope"/>
+                        </td>
+                      </tr>
+                      <tr ng-if="ctrl.stage.scope.stack || ctrl.customizingScope">
+                        <td><b>Stack</b></td>
+                        <td>
+                          <span ng-if="!ctrl.customizingScope">{{ctrl.stage.scope.stack}}</span>
+                          <input class="form-control input-sm" ng-model="ctrl.stage.scope.stack" ng-if="ctrl.customizingScope"/>
+                        </td>
+                      </tr>
+                      <tr ng-if="ctrl.stage.scope.cluster || ctrl.customizingScope">
+                        <td><b>Cluster</b></td>
+                        <td>
+                          <span ng-if="!ctrl.customizingScope">{{ctrl.stage.scope.cluster}}</span>
+                          <input class="form-control input-sm" ng-model="ctrl.stage.scope.cluster" ng-if="ctrl.customizingScope"/>
+                        </td>
+                      </tr>
+                      <tr ng-if="ctrl.stage.scope.asg || ctrl.customizingScope">
+                        <td><b>ASG</b></td>
+                        <td>
+                          <span ng-if="!ctrl.customizingScope">{{ctrl.stage.scope.asg}}</span>
+                          <input class="form-control input-sm" ng-model="ctrl.stage.scope.asg" ng-if="ctrl.customizingScope"/>
+                        </td>
+                      </tr>
+                      <tr ng-if="ctrl.stage.scope.zone || ctrl.customizingScope">
+                        <td><b>Zone</b></td>
+                        <td>
+                          <span ng-if="!ctrl.customizingScope">{{ctrl.stage.scope.zone}}</span>
+                          <input class="form-control input-sm" ng-model="ctrl.stage.scope.zone" ng-if="ctrl.customizingScope"/>
+                        </td>
+                      </tr>
+                      <tr ng-if="ctrl.stage.scope.serverId || ctrl.customizingScope">
+                        <td><b>Instance</b></td>
+                        <td>
+                          <span ng-if="!ctrl.customizingScope">{{ctrl.stage.scope.serverId}}</span>
+                          <input class="form-control input-sm" ng-model="ctrl.stage.scope.serverId" ng-if="ctrl.customizingScope"/>
+                        </td>
+                      </tr>
+                      <tr ng-if="ctrl.stage.scope.instanceCounts && !ctrl.customizingScope">
+                        <td><b>Instance Count</b></td>
+                        <td style="color:#b82525; font-weight: 600; font-size: larger; padding-top: 6px; margin-left: 9px">{{ctrl.stage.scope.instanceCounts.up}} instances</td>
+                      </tr>
+                      </tbody>
+                      <tfoot ng-if="!ctrl.customizingScope">
+                      <tr>
+                        <td colspan="2"><a href ng-click="ctrl.customizeScope()">Edit scope fields</a></td>
+                      </tr>
+                      </tfoot>
+                    </table>
+                  </div>
+                </div>
+              </div>
 
-              </stage-config-field>
 
 
 
               <h4 class="section">Notifications</h4>
 
               <stage-config-field label="Email">
-                <input type="text" class="form-control input-sm" ng-model="propertyStage.stage.email">
+                <input type="text" class="form-control input-sm" ng-model="ctrl.stage.email">
               </stage-config-field>
             </div>
           </div>

--- a/app/scripts/modules/netflix/pipeline/stage/properties/create/propertyStage.js
+++ b/app/scripts/modules/netflix/pipeline/stage/properties/create/propertyStage.js
@@ -23,7 +23,7 @@ module.exports = angular.module('spinnaker.netflix.pipeline.stage.propertyStage'
         executionSummaryUrl: require('./propertyExecutionSummary.html'),
         executionLabelComponent: PropertyExecutionLabel,
         controller: 'PropertyStageCtrl',
-        controllerAs: 'propertyStage',
+        controllerAs: 'ctrl',
         accountExtractor: (stage) => stage.context.scope.env,
         validators: [
           { type: 'requiredField', fieldName: 'email' },
@@ -80,6 +80,7 @@ module.exports = angular.module('spinnaker.netflix.pipeline.stage.propertyStage'
     vm.resetScope = () => {
       vm.stage.scope = {env: vm.stage.scope.env};
       vm.scopeSelected = false;
+      this.customizingScope = false;
     };
 
     vm.refreshAppList = (query) => {
@@ -113,6 +114,14 @@ module.exports = angular.module('spinnaker.netflix.pipeline.stage.propertyStage'
       vm.applicationSelected(vm.stage.scope.appIdList);
     };
 
+    vm.customizeScope = () => {
+      this.customizingScope = true;
+      this.appIdList = $scope.stage.scope.appIdList.join(', ');
+    };
+
+    vm.appIdListChanged = () => {
+      $scope.stage.scope.appIdList = this.appIdList ? this.appIdList.split(/,\s?/) : [];
+    };
 
     vm.applicationsLoaded = false;
     getPropertiesForApp($scope.application.name);


### PR DESCRIPTION
Wishing I'd put this into the 5k line PR yesterday to hide how ugly it is, but this allows users to enter a TTL when creating a fast property, and also lets them edit the scope once it's been selected without having to go into the JSON editor view.