### PR TITLE
feat(webhooks): Add preconfigurable webhook support

### DIFF
--- a/app/scripts/modules/core/src/domain/IStage.ts
+++ b/app/scripts/modules/core/src/domain/IStage.ts
@@ -5,4 +5,5 @@ export interface IStage {
   requisiteStageRefIds: (string | number)[];
   [k: string]: any;
   isNew?: boolean;
+  alias?: string;
 }

--- a/app/scripts/modules/core/src/domain/IStageTypeConfig.ts
+++ b/app/scripts/modules/core/src/domain/IStageTypeConfig.ts
@@ -19,4 +19,5 @@ export interface IStageTypeConfig extends IStageOrTriggerTypeConfig {
   restartable?: boolean;
   synthetic?: boolean;
   nameToCheckInTest?: string;
+  configuration?: any;
 }

--- a/app/scripts/modules/core/src/pipeline/config/stages/stage.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/stage.html
@@ -12,7 +12,7 @@
                    style="width: 250px"
                    class="form-control input-sm"
                    autofocus
-                   on-select="stageConfigCtrl.selectStageType($item.key)">
+                   on-select="stageConfigCtrl.selectStageType($item)">
           <ui-select-match>
             <strong>{{$select.selected.label}}</strong>
           </ui-select-match>

--- a/app/scripts/modules/core/src/pipeline/config/stages/stage.module.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/stage.module.js
@@ -61,8 +61,8 @@ module.exports = angular.module('spinnaker.core.pipeline.config.stage', [
       });
     }
 
-    function getConfig(type) {
-      return pipelineConfig.getStageConfig({type: type});
+    function getConfig(stage) {
+      return pipelineConfig.getStageConfig(stage);
     }
 
     $scope.groupDependencyOptions = function(stage) {
@@ -94,8 +94,9 @@ module.exports = angular.module('spinnaker.core.pipeline.config.stage', [
       });
     };
 
-    this.selectStageType = (type) => {
-      $scope.stage.type = type;
+    this.selectStageType = stage => {
+      $scope.stage.type = stage.key;
+      $scope.stage.alias = stage.alias;
       this.selectStage();
     };
 
@@ -132,7 +133,7 @@ module.exports = angular.module('spinnaker.core.pipeline.config.stage', [
       });
 
       if (type) {
-        let config = getConfig(type);
+        let config = getConfig($scope.stage);
         if (config) {
           $scope.canConfigureNotifications = !$scope.pipeline.strategy && !config.disableNotifications;
           $scope.description = config.description;
@@ -172,7 +173,7 @@ module.exports = angular.module('spinnaker.core.pipeline.config.stage', [
     function updateStageName(config, oldVal) {
       // apply a default name if the type changes and the user has not specified a name
       if (oldVal) {
-        var oldConfig = getConfig(oldVal);
+        var oldConfig = getConfig({type: oldVal});
         if (oldConfig && $scope.stage.name === oldConfig.label) {
           $scope.stage.name = config.label;
         }

--- a/app/scripts/modules/core/src/pipeline/config/stages/webhook/webhookStage.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/webhook/webhookStage.html
@@ -58,11 +58,20 @@
       </tfoot>
     </table>
   </stage-config-field>
-  <stage-config-field label="Wait for completion" help-key="pipeline.config.webhook.waitForCompletion">
-    <input type="checkbox" class="input-sm" name="waitForCompletion"
-           ng-model="$ctrl.viewState.waitForCompletion"
-           ng-change="$ctrl.waitForCompletionChanged()"/>
-  </stage-config-field>
+  <div class="form-group">
+    <div class="col-md-8 col-md-offset-1">
+      <div class="checkbox pull-left">
+        <label>
+          <input type="checkbox"
+                 name="waitForCompletion"
+                 ng-model="$ctrl.viewState.waitForCompletion"
+                 ng-change="$ctrl.waitForCompletionChanged()"/>
+          <strong>Wait for completion</strong>
+          <help-field key="pipeline.config.webhook.waitForCompletion"></help-field>
+        </label>
+      </div>
+    </div>
+  </div>
   <div ng-class="{collapse: $ctrl.viewState.waitForCompletion !== true, 'collapse.in': !$ctrl.viewState.waitForCompletion === true}">
     <div class="form-group">
       <div class="col-md-3 sm-label-right">Status URL</div>
@@ -105,7 +114,7 @@
             <input type="text"
                    class="form-control input-sm"
                    ng-model="$ctrl.stage.statusUrlJsonPath"
-                   required />
+                   required/>
           </stage-config-field>
         </div>
       </div>

--- a/app/scripts/modules/core/src/pipeline/config/stages/webhook/webhookStage.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/webhook/webhookStage.html
@@ -1,8 +1,11 @@
 <div class="form-horizontal">
-  <stage-config-field label="Webhook URL">
+  <div class="alert alert-info" ng-if="$ctrl.preconfiguredProperties.length">
+    <strong>Note:</strong> {{$ctrl.noUserConfigurableFields ? 'All' : 'Some'}} of the settings of this stage are preconfigured, and cannot be changed.
+  </div>
+  <stage-config-field label="Webhook URL" ng-if="$ctrl.displayField('url')">
     <input type="text" class="form-control input-sm" ng-model="$ctrl.stage.url"/>
   </stage-config-field>
-  <stage-config-field label="Method">
+  <stage-config-field label="Method" ng-if="$ctrl.displayField('method')">
     <ui-select ng-model="$ctrl.stage.method" class="form-control input-sm">
       <ui-select-match placeholder="Select a method...">{{$select.selected}}</ui-select-match>
       <ui-select-choices repeat="method in $ctrl.methods | filter: $select.search">
@@ -12,7 +15,7 @@
   </stage-config-field>
   <stage-config-field label="Payload"
                       help-key="pipeline.config.webhook.payload"
-                      ng-if="$ctrl.stage.method !== 'GET' && $ctrl.stage.method !== 'HEAD'">
+                      ng-if="$ctrl.stage.method !== 'GET' && $ctrl.stage.method !== 'HEAD' && $ctrl.displayField('payload')">
     <textarea class="code form-control flex-fill"
               rows="5"
               ng-model="$ctrl.command.payloadJSON"
@@ -24,8 +27,8 @@
         </div>
       </div>
   </stage-config-field>
-  <stage-config-field label="Custom Headers" help-key="pipeline.config.webhook.customHeaders">
-    <table class="table table-condensed packed">
+  <stage-config-field label="Custom Headers" help-key="pipeline.config.webhook.customHeaders" ng-if="$ctrl.displayField('headers')">
+    <table class="table table-condensed packed" ng-if="$ctrl.customHeaderCount() > 0">
       <thead>
         <tr>
           <th style="width:40%">Key</th>
@@ -34,7 +37,7 @@
         </tr>
       </thead>
       <tbody>
-        <tr ng-repeat="(key,value) in $ctrl.stage.customHeaders">
+        <tr ng-repeat="(key, value) in $ctrl.stage.customHeaders">
           <td>
             <strong class="small">{{key}}</strong>
           </td>
@@ -47,18 +50,16 @@
           </td>
         </tr>
       </tbody>
-      <tfoot>
-        <tr>
-          <td colspan="7">
-            <button class="btn btn-block btn-sm add-new" ng-click="$ctrl.addCustomHeader()">
-              <span class="glyphicon glyphicon-plus-sign"></span> Add Custom Header
-            </button>
-          </td>
-        </tr>
-      </tfoot>
     </table>
+    <div class="row">
+      <div class="col-md-12">
+        <button class="btn btn-block btn-sm add-new" ng-click="$ctrl.addCustomHeader()">
+          <span class="glyphicon glyphicon-plus-sign"></span> Add Custom Header
+        </button>
+      </div>
+    </div>
   </stage-config-field>
-  <div class="form-group">
+  <div class="form-group" ng-if="$ctrl.displayField('waitForCompletion')">
     <div class="col-md-8 col-md-offset-1">
       <div class="checkbox pull-left">
         <label>
@@ -73,7 +74,7 @@
     </div>
   </div>
   <div ng-class="{collapse: $ctrl.viewState.waitForCompletion !== true, 'collapse.in': !$ctrl.viewState.waitForCompletion === true}">
-    <div class="form-group">
+    <div class="form-group" ng-if="$ctrl.displayField('statusUrlResolution')">
       <div class="col-md-3 sm-label-right">Status URL</div>
       <div class="col-md-9 radio">
         <label>
@@ -108,7 +109,7 @@
           <help-field key="pipeline.config.webhook.useStatusUrlFromLocationHeaderFalse"></help-field>
         </label>
       </div>
-      <div class="form-group" ng-if="$ctrl.viewState.statusUrlResolution === 'webhookResponse'">
+      <div class="form-group" ng-if="$ctrl.viewState.statusUrlResolution === 'webhookResponse' && $ctrl.displayField('statusUrlJsonPath')">
         <div class="col-md-offset-3">
           <stage-config-field label="Status URL path" help-key="pipeline.config.webhook.statusUrlJsonPath">
             <input type="text"
@@ -120,31 +121,36 @@
       </div>
     </div>
     <stage-config-field label="Status JsonPath"
-                        help-key="pipeline.config.webhook.statusJsonPath">
+                        help-key="pipeline.config.webhook.statusJsonPath"
+                        ng-if="$ctrl.displayField('statusJsonPath')">
       <input type="text"
              class="form-control input-sm"
              ng-model="$ctrl.stage.statusJsonPath"/>
     </stage-config-field>
     <stage-config-field label="Progress location"
-                        help-key="pipeline.config.webhook.progressJsonPath">
+                        help-key="pipeline.config.webhook.progressJsonPath"
+                        ng-if="$ctrl.displayField('progressJsonPath')">
       <input type="text"
              class="form-control input-sm"
              ng-model="$ctrl.stage.progressJsonPath"/>
     </stage-config-field>
     <stage-config-field label="SUCCESS status mapping"
-                        help-key="pipeline.config.webhook.successStatuses">
+                        help-key="pipeline.config.webhook.successStatuses"
+                        ng-if="$ctrl.displayField('successStatuses')">
       <input type="text"
              class="form-control input-sm"
              ng-model="$ctrl.stage.successStatuses"/>
     </stage-config-field>
     <stage-config-field label="CANCELED status mapping"
-                        help-key="pipeline.config.webhook.canceledStatuses">
+                        help-key="pipeline.config.webhook.canceledStatuses"
+                        ng-if="$ctrl.displayField('canceledStatuses')">
       <input type="text"
              class="form-control input-sm"
              ng-model="$ctrl.stage.canceledStatuses"/>
     </stage-config-field>
     <stage-config-field label="TERMINAL status mapping"
-                        help-key="pipeline.config.webhook.terminalStatuses">
+                        help-key="pipeline.config.webhook.terminalStatuses"
+                        ng-if="$ctrl.displayField('terminalStatuses')">
       <input type="text"
              class="form-control input-sm"
              ng-model="$ctrl.stage.terminalStatuses"/>

--- a/app/scripts/modules/core/src/pipeline/config/stages/webhook/webhookStage.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/webhook/webhookStage.ts
@@ -1,8 +1,9 @@
 import {module} from 'angular';
+import {IModalService} from 'angular-ui-bootstrap';
 
 import {JSON_UTILITY_SERVICE, JsonUtilityService} from 'core/utils/json/json.utility.service';
-import {PIPELINE_CONFIG_PROVIDER} from 'core/pipeline/config/pipelineConfigProvider';
-import {IModalService} from 'angular-ui-bootstrap';
+import {PIPELINE_CONFIG_PROVIDER, PipelineConfigProvider} from 'core/pipeline/config/pipelineConfigProvider';
+import {API_SERVICE, Api} from 'core/api/api.service';
 
 interface IViewState {
   waitForCompletion?: boolean;
@@ -20,14 +21,26 @@ export interface ICustomHeader {
   value: string;
 }
 
+interface IPreconfiguredWebhook {
+  type: string;
+  label: string;
+  noUserConfigurableFields: boolean
+  description?: string;
+  waitForCompletion?: boolean
+  preconfiguredProperties?: string[];
+}
+
 export class WebhookStage {
   public command: ICommand;
   public viewState: IViewState;
   public methods: string[];
+  public preconfiguredProperties: string[];
+  public noUserConfigurableFields: boolean;
 
   constructor(public stage: any,
               private jsonUtilityService: JsonUtilityService,
-              private $uibModal: IModalService) {
+              private $uibModal: IModalService,
+              private pipelineConfig: PipelineConfigProvider) {
     'ngInject';
     this.methods = ['GET', 'HEAD', 'POST', 'PUT', 'DELETE'];
 
@@ -41,6 +54,13 @@ export class WebhookStage {
     };
 
     this.stage.statusUrlResolution = this.viewState.statusUrlResolution;
+
+    const stageConfig = this.pipelineConfig.getStageConfig(this.stage);
+    if (stageConfig && stageConfig.configuration) {
+      this.preconfiguredProperties = stageConfig.configuration.preconfiguredProperties || [];
+      this.noUserConfigurableFields = stageConfig.configuration.noUserConfigurableFields;
+      this.viewState.waitForCompletion = stageConfig.configuration.waitForCompletion || this.viewState.waitForCompletion;
+    }
   }
 
   public updatePayload(): void {
@@ -62,6 +82,10 @@ export class WebhookStage {
     this.stage.statusUrlResolution = this.viewState.statusUrlResolution;
   }
 
+  public customHeaderCount(): number {
+    return this.stage.customHeaders ? Object.keys(this.stage.customHeaders).length : 0;
+  }
+
   public removeCustomHeader(key: string): void {
     delete this.stage.customHeaders[key];
   }
@@ -78,14 +102,19 @@ export class WebhookStage {
       this.stage.customHeaders[customHeader.key] = customHeader.value;
     });
   }
+
+  public displayField(field: string): boolean {
+    return !this.preconfiguredProperties || !this.preconfiguredProperties.some(property => property === field);
+  }
 }
 
 export const WEBHOOK_STAGE = 'spinnaker.core.pipeline.stage.webhookStage';
 
 module(WEBHOOK_STAGE, [
   JSON_UTILITY_SERVICE,
-  PIPELINE_CONFIG_PROVIDER
-]).config((pipelineConfigProvider: any) => {
+  PIPELINE_CONFIG_PROVIDER,
+  API_SERVICE
+]).config((pipelineConfigProvider: PipelineConfigProvider) => {
   pipelineConfigProvider.registerStage({
     label: 'Webhook',
     description: 'Runs a Webhook job',
@@ -97,7 +126,27 @@ module(WEBHOOK_STAGE, [
     executionDetailsUrl: require('./webhookExecutionDetails.html'),
     validators: [
       {type: 'requiredField', fieldName: 'url'},
-    ],
-    strategy: true,
+    ]
   });
+}).run((pipelineConfig: PipelineConfigProvider, API: Api) => {
+  API.one('webhooks').all('preconfigured').getList().then((preconfiguredWebhooks: Array<IPreconfiguredWebhook>) => {
+    preconfiguredWebhooks.forEach((preconfiguredWebhook: IPreconfiguredWebhook) => pipelineConfig.registerStage({
+      label: preconfiguredWebhook.label,
+      description: preconfiguredWebhook.description,
+      key: preconfiguredWebhook.type,
+      alias: 'preconfiguredWebhook',
+      restartable: true,
+      controller: 'WebhookStageCtrl',
+      controllerAs: '$ctrl',
+      templateUrl: require('./webhookStage.html'),
+      executionDetailsUrl: require('./webhookExecutionDetails.html'),
+      validators: [],
+      configuration: {
+        preconfiguredProperties: preconfiguredWebhook.preconfiguredProperties,
+        waitForCompletion: preconfiguredWebhook.waitForCompletion,
+        noUserConfigurableFields: preconfiguredWebhook.noUserConfigurableFields
+      }
+    }))
+  })
+
 }).controller('WebhookStageCtrl', WebhookStage);


### PR DESCRIPTION
This PR adds support for webhook stages that are configured in the Orca and appears more or less as native stages in Deck.

<img width="895" alt="skjermbilde 2017-05-09 kl 15 08 39" src="https://cloud.githubusercontent.com/assets/155558/25855077/7651bace-34d2-11e7-80ed-030723034abc.png">
<img width="858" alt="skjermbilde 2017-05-09 kl 15 09 55" src="https://cloud.githubusercontent.com/assets/155558/25855081/78416a5a-34d2-11e7-8d47-1a98d3e066c2.png">

Corresponds with https://github.com/spinnaker/orca/pull/1329 and https://github.com/spinnaker/gate/pull/389