### PR TITLE
chore(less): use (reference) to import less, remove copyright headers

### DIFF
--- a/app/scripts/modules/amazon/serverGroup/configure/wizard/advancedSettings/advancedSettings.component.html
+++ b/app/scripts/modules/amazon/serverGroup/configure/wizard/advancedSettings/advancedSettings.component.html
@@ -1,19 +1,3 @@
-<!--
-  ~ Copyright 2016 Netflix, Inc.
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~    http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <div class="container-fluid form-horizontal">
   <div class="form-group">
     <div class="col-md-5 sm-label-right"><b>Cooldown</b></div>

--- a/app/scripts/modules/core/application/application.less
+++ b/app/scripts/modules/core/application/application.less
@@ -1,4 +1,4 @@
-@import "../presentation/less/imports/commonImports.less";
+@import (reference) "~core/presentation/less/imports/commonImports.less";
 
 .application-header {
   margin-top: 0;

--- a/app/scripts/modules/core/application/config/links/applicationLinks.component.less
+++ b/app/scripts/modules/core/application/config/links/applicationLinks.component.less
@@ -1,4 +1,4 @@
-@import "../../../presentation/less/imports/commonImports.less";
+@import (reference) "~core/presentation/less/imports/colors.less";
 
 application-links {
   .row-heading {

--- a/app/scripts/modules/core/application/nav/applicationNav.component.less
+++ b/app/scripts/modules/core/application/nav/applicationNav.component.less
@@ -1,4 +1,4 @@
-@import "~core/presentation/less/imports/commonImports.less";
+@import (reference) "~core/presentation/less/imports/colors.less";
 
 application-nav, secondary-application-nav, .application-nav {
   display: inline-block;

--- a/app/scripts/modules/core/application/newapplication.less
+++ b/app/scripts/modules/core/application/newapplication.less
@@ -1,21 +1,3 @@
-/*
- * Copyright 2014 Netflix, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-@import "../presentation/less/imports/commonImports.less";
-
 #pagerDutyApiKeyLabel {
   font-size: 0.95em;
 }

--- a/app/scripts/modules/core/cloudProvider/cloudProviderLogo.less
+++ b/app/scripts/modules/core/cloudProvider/cloudProviderLogo.less
@@ -1,5 +1,3 @@
-@import "../presentation/less/imports/commonImports.less";
-
 .cloud-provider-logo {
   display: inline-block;
   margin-right: 3px;

--- a/app/scripts/modules/core/cluster/rollups.less
+++ b/app/scripts/modules/core/cluster/rollups.less
@@ -1,20 +1,4 @@
-/*
- * Copyright 2014 Netflix, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-@import "../presentation/less/imports/commonImports.less";
+@import (reference) "~core/presentation/less/imports/commonImports.less";
 
 server-group {
   input[type="checkbox"] {

--- a/app/scripts/modules/core/delivery/details/executionDetails.less
+++ b/app/scripts/modules/core/delivery/details/executionDetails.less
@@ -1,4 +1,4 @@
-@import "../../presentation/less/imports/commonImports.less";
+@import (reference) "~core/presentation/less/imports/commonImports.less";
 
 .execution {
   execution-details, .execution-details {

--- a/app/scripts/modules/core/delivery/executionGroup/execution/execution.less
+++ b/app/scripts/modules/core/delivery/executionGroup/execution/execution.less
@@ -1,4 +1,4 @@
-@import "../../../presentation/less/imports/commonImports.less";
+@import (reference) "~core/presentation/less/imports/commonImports.less";
 
 .execution {
   .label {

--- a/app/scripts/modules/core/delivery/executionGroup/execution/executionMarker.less
+++ b/app/scripts/modules/core/delivery/executionGroup/execution/executionMarker.less
@@ -1,4 +1,4 @@
-@import "../../../presentation/less/imports/commonImports.less";
+@import (reference) "~core/presentation/less/imports/commonImports.less";
 
 .execution-marker.stage {
   margin-top: 0;

--- a/app/scripts/modules/core/delivery/executionGroup/executionGroup.less
+++ b/app/scripts/modules/core/delivery/executionGroup/executionGroup.less
@@ -1,4 +1,4 @@
-@import "~core/presentation/less/imports/commonImports.less";
+@import (reference) "~core/presentation/less/imports/commonImports.less";
 
 .execution-group-container {
   padding: 10px 30px 0;

--- a/app/scripts/modules/core/delivery/executions/executions.less
+++ b/app/scripts/modules/core/delivery/executions/executions.less
@@ -1,4 +1,4 @@
-@import "../../presentation/less/imports/commonImports.less";
+@import (reference) "~core/presentation/less/imports/commonImports.less";
 
 [ui-view="pipelines"] {
   padding-top: 0 !important;

--- a/app/scripts/modules/core/entityTag/entityTagDetails.component.less
+++ b/app/scripts/modules/core/entityTag/entityTagDetails.component.less
@@ -1,4 +1,4 @@
-@import "../presentation/less/imports/commonImports.less";
+@import (reference) "~core/presentation/less/imports/commonImports.less";
 
 entity-tag-details {
   .tag {

--- a/app/scripts/modules/core/entityTag/entityTagEditor.modal.less
+++ b/app/scripts/modules/core/entityTag/entityTagEditor.modal.less
@@ -1,4 +1,4 @@
-@import "../presentation/less/imports/commonImports.less";
+@import (reference) "~core/presentation/less/imports/commonImports.less";
 
 .entity-tag-editor-modal {
   .preview {

--- a/app/scripts/modules/core/entityTag/entityUiTags.component.less
+++ b/app/scripts/modules/core/entityTag/entityUiTags.component.less
@@ -1,4 +1,4 @@
-@import "../presentation/less/imports/commonImports.less";
+@import (reference) "~core/presentation/less/imports/commonImports.less";
 
 .entity-tag {
   &.fa-exclamation-triangle {

--- a/app/scripts/modules/core/entityTag/entityUiTags.popover.less
+++ b/app/scripts/modules/core/entityTag/entityUiTags.popover.less
@@ -1,4 +1,4 @@
-@import "~core/presentation/less/imports/commonImports.less";
+@import (reference) "~core/presentation/less/imports/commonImports.less";
 
 .entity-tags-popover {
   padding: 10px;

--- a/app/scripts/modules/core/forms/checklist/checklist.directive.html
+++ b/app/scripts/modules/core/forms/checklist/checklist.directive.html
@@ -1,18 +1,3 @@
-<!--
-  ~ Copyright 2014 Netflix, Inc.
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~     http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
 <ul class="checklist" ng-if="!inline">
   <li ng-repeat="item in items">
     <label>

--- a/app/scripts/modules/core/forms/checklist/checklist.directive.js
+++ b/app/scripts/modules/core/forms/checklist/checklist.directive.js
@@ -1,19 +1,3 @@
-/*
- * Copyright 2014 Netflix, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 'use strict';
 
 let angular = require('angular');

--- a/app/scripts/modules/core/forms/checklist/checklist.directive.spec.js
+++ b/app/scripts/modules/core/forms/checklist/checklist.directive.spec.js
@@ -1,19 +1,3 @@
-/*
- * Copyright 2014 Netflix, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 'use strict';
 
 describe('Directives: checklist', function () {

--- a/app/scripts/modules/core/forms/checkmap/checkmap.directive.js
+++ b/app/scripts/modules/core/forms/checkmap/checkmap.directive.js
@@ -1,19 +1,3 @@
-/*
- * Copyright 2015 Google, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 'use strict';
 
 import _ from 'lodash';

--- a/app/scripts/modules/core/healthCounts/healthCounts.less
+++ b/app/scripts/modules/core/healthCounts/healthCounts.less
@@ -1,20 +1,4 @@
-/*
- * Copyright 2014 Netflix, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-@import "../presentation/less/imports/commonImports.less";
+@import (reference) "~core/presentation/less/imports/commonImports.less";
 
 .glyphicon {
   &.healthy {

--- a/app/scripts/modules/core/instance/instanceSelection.less
+++ b/app/scripts/modules/core/instance/instanceSelection.less
@@ -1,20 +1,4 @@
-/*
- * Copyright 2014 Netflix, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-@import "../presentation/less/imports/commonImports.less";
+@import (reference) "~core/presentation/less/imports/commonImports.less";
 
 .panel-default > .panel-heading {
   background-color: transparent;

--- a/app/scripts/modules/core/loadBalancer/loadBalancer/loadBalancerPod.directive.less
+++ b/app/scripts/modules/core/loadBalancer/loadBalancer/loadBalancerPod.directive.less
@@ -1,20 +1,4 @@
-/*
- * Copyright 2015 Netflix, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-@import "../../presentation/less/imports/commonImports.less";
+@import (reference) "~core/presentation/less/imports/commonImports.less";
 
 load-balancer-pod {
   .cluster-container {

--- a/app/scripts/modules/core/modal/modals.less
+++ b/app/scripts/modules/core/modal/modals.less
@@ -1,4 +1,4 @@
-@import "../presentation/less/imports/commonImports.less";
+@import (reference) "~core/presentation/less/imports/commonImports.less";
 
 .modal-backdrop {
   z-index: 10002;

--- a/app/scripts/modules/core/modal/wizard/modalWizard.less
+++ b/app/scripts/modules/core/modal/wizard/modalWizard.less
@@ -1,4 +1,4 @@
-@import "../../presentation/less/imports/commonImports.less";
+@import (reference) "~core/presentation/less/imports/commonImports.less";
 
 @indicator-size: 14px;
 @indicator-radius: @indicator-size/2;

--- a/app/scripts/modules/core/navigation/navigation.less
+++ b/app/scripts/modules/core/navigation/navigation.less
@@ -1,20 +1,4 @@
-/*
- * Copyright 2014 Netflix, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-@import "../presentation/less/imports/commonImports.less";
+@import (reference) "~core/presentation/less/imports/commonImports.less";
 
 .secondary-panel {
   > div {

--- a/app/scripts/modules/core/pipeline/config/actions/history/showHistory.less
+++ b/app/scripts/modules/core/pipeline/config/actions/history/showHistory.less
@@ -1,4 +1,4 @@
-@import "../../../../presentation/less/imports/commonImports.less";
+@import (reference) "~core/presentation/less/imports/commonImports.less";
 
 .modal-show-history {
   .modal-history-header {

--- a/app/scripts/modules/core/pipeline/config/graph/pipelineGraph.less
+++ b/app/scripts/modules/core/pipeline/config/graph/pipelineGraph.less
@@ -1,4 +1,4 @@
-@import "../../../presentation/less/imports/commonImports.less";
+@import (reference) "~core/presentation/less/imports/commonImports.less";
 
 pipeline-graph {
   display: block;

--- a/app/scripts/modules/core/pipeline/config/pipelineConfig.less
+++ b/app/scripts/modules/core/pipeline/config/pipelineConfig.less
@@ -1,4 +1,4 @@
-@import "../../presentation/less/imports/commonImports.less";
+@import (reference) "~core/presentation/less/imports/commonImports.less";
 
 .new-pipeline {
   .fade-in(0.4);

--- a/app/scripts/modules/core/pipeline/config/stages/executionWindows/executionWindows.less
+++ b/app/scripts/modules/core/pipeline/config/stages/executionWindows/executionWindows.less
@@ -1,4 +1,4 @@
-@import "../../../../presentation/less/imports/commonImports.less";
+@import (reference) "~core/presentation/less/imports/commonImports.less";
 
 execution-windows {
   .execution-window-graph {

--- a/app/scripts/modules/core/pipeline/pipelines.less
+++ b/app/scripts/modules/core/pipeline/pipelines.less
@@ -1,4 +1,4 @@
-@import "../presentation/less/imports/commonImports.less";
+@import (reference) "~core/presentation/less/imports/commonImports.less";
 
 .pipelines {
   overflow-x: hidden;

--- a/app/scripts/modules/core/presentation/details.less
+++ b/app/scripts/modules/core/presentation/details.less
@@ -1,4 +1,4 @@
-@import "./less/imports/commonImports.less";
+@import (reference) "~core/presentation/less/imports/commonImports.less";
 
 .details-panel {
   &.health-status-Healthy {

--- a/app/scripts/modules/core/presentation/isVisible/isVisible.directive.js
+++ b/app/scripts/modules/core/presentation/isVisible/isVisible.directive.js
@@ -1,19 +1,3 @@
-/*
- * Copyright 2014 Netflix, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 'use strict';
 
 let angular = require('angular');

--- a/app/scripts/modules/core/presentation/less/imports/animations.less
+++ b/app/scripts/modules/core/presentation/less/imports/animations.less
@@ -1,20 +1,4 @@
-/*
- * Copyright 2014 Netflix, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-@import "./colors.less";
+@import (reference) "./colors.less";
 
 .glowing(@duration: 1.75) {
   -webkit-animation: animate-glow ~"@{duration}s" steps(12*@duration) infinite;

--- a/app/scripts/modules/core/presentation/less/imports/colors.less
+++ b/app/scripts/modules/core/presentation/less/imports/colors.less
@@ -1,19 +1,3 @@
-/*
- * Copyright 2014 Netflix, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 @text-color: #333333;
 @configure-link-color: #6a6a6a;
 @spinnaker-blue: #2275B8;

--- a/app/scripts/modules/core/presentation/less/imports/mixins.less
+++ b/app/scripts/modules/core/presentation/less/imports/mixins.less
@@ -1,6 +1,6 @@
 /* Common mixins extracted from Bootstrap */
 
-@import "./colors.less";
+@import (reference) "./colors.less";
 
 .text-right() {
   text-align: right;

--- a/app/scripts/modules/core/presentation/main.less
+++ b/app/scripts/modules/core/presentation/main.less
@@ -1,20 +1,4 @@
-/*
- * Copyright 2014 Netflix, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-@import "./less/imports/commonImports.less";
+@import (reference) "~core/presentation/less/imports/commonImports.less";
 
 @fixed-header-z-index: 1030;
 

--- a/app/scripts/modules/core/presentation/navPopover.less
+++ b/app/scripts/modules/core/presentation/navPopover.less
@@ -1,4 +1,4 @@
-@import "./less/imports/commonImports.less";
+@import (reference) "~core/presentation/less/imports/commonImports.less";
 
 .nav-popover {
   font-weight: 600;

--- a/app/scripts/modules/core/presentation/navigation/pageNavigation.less
+++ b/app/scripts/modules/core/presentation/navigation/pageNavigation.less
@@ -1,4 +1,4 @@
-@import '../less/imports/commonImports.less';
+@import (reference) "~core/presentation/less/imports/commonImports.less";
 
 page-navigator {
   display: block;

--- a/app/scripts/modules/core/presentation/refresher/componentRefresher.directive.less
+++ b/app/scripts/modules/core/presentation/refresher/componentRefresher.directive.less
@@ -1,4 +1,4 @@
-@import "../less/imports/commonImports.less";
+@import (reference) "~core/presentation/less/imports/commonImports.less";
 
 component-refresher {
   .glyphicon-refresh {

--- a/app/scripts/modules/core/projects/dashboard/cluster/projectCluster.less
+++ b/app/scripts/modules/core/projects/dashboard/cluster/projectCluster.less
@@ -1,20 +1,4 @@
-/*
- * Copyright 2015 Netflix, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-@import "../../../presentation/less/imports/commonImports.less";
+@import (reference) "~core/presentation/less/imports/commonImports.less";
 
 project-cluster {
   .cluster-name {

--- a/app/scripts/modules/core/projects/dashboard/dashboard.less
+++ b/app/scripts/modules/core/projects/dashboard/dashboard.less
@@ -1,21 +1,3 @@
-/*
- * Copyright 2015 Netflix, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-@import "../../presentation/less/imports/commonImports.less";
-
 .project-dashboard {
   overflow-y: auto;
   h3 {

--- a/app/scripts/modules/core/projects/dashboard/pipeline/projectPipeline.less
+++ b/app/scripts/modules/core/projects/dashboard/pipeline/projectPipeline.less
@@ -1,4 +1,4 @@
-@import "~core/presentation/less/imports/commonImports.less";
+@import (reference) "~core/presentation/less/imports/commonImports.less";
 
 project-pipeline {
   display: block;

--- a/app/scripts/modules/core/projects/project.less
+++ b/app/scripts/modules/core/projects/project.less
@@ -1,20 +1,4 @@
-/*
- * Copyright 2015 Netflix, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-@import "../presentation/less/imports/commonImports.less";
+@import (reference) "~core/presentation/less/imports/commonImports.less";
 
 .spinnaker-container .spinnaker-content {
   .project-header.page-header {

--- a/app/scripts/modules/core/search/global/globalSearch.less
+++ b/app/scripts/modules/core/search/global/globalSearch.less
@@ -1,4 +1,4 @@
-@import "../../presentation/less/imports/commonImports.less";
+@import (reference) "~core/presentation/less/imports/commonImports.less";
 
 .global-search {
   .navbar-form {

--- a/app/scripts/modules/core/search/infrastructure/infrastructure.less
+++ b/app/scripts/modules/core/search/infrastructure/infrastructure.less
@@ -1,20 +1,4 @@
-/*
- * Copyright 2014 Netflix, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-@import "../../presentation/less/imports/commonImports.less";
+@import (reference) "~core/presentation/less/imports/commonImports.less";
 
 .infrastructure {
   display: flex;

--- a/app/scripts/modules/core/search/infrastructure/project/infrastructureProject.directive.less
+++ b/app/scripts/modules/core/search/infrastructure/project/infrastructureProject.directive.less
@@ -1,20 +1,4 @@
-/*
- * Copyright 2014 Netflix, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-@import "../../../presentation/less/imports/commonImports.less";
+@import (reference) "~core/presentation/less/imports/commonImports.less";
 
 infrastructure-project {
   display: block;

--- a/app/scripts/modules/core/securityGroup/securityGroupPod.directive.less
+++ b/app/scripts/modules/core/securityGroup/securityGroupPod.directive.less
@@ -1,21 +1,3 @@
-/*
- * Copyright 2015 Netflix, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-@import "../presentation/less/imports/commonImports.less";
-
 security-group-pod {
   .rollup-details {
     .disabled {

--- a/app/scripts/modules/core/serverGroup/configure/common/instanceTypeSelector.directive.less
+++ b/app/scripts/modules/core/serverGroup/configure/common/instanceTypeSelector.directive.less
@@ -1,5 +1,3 @@
-@import '../../../presentation/less/imports/commonImports.less';
-
 instance-type-selector {
   tr {
     &.unavailable {

--- a/app/scripts/modules/core/serverGroup/details/multipleServerGroup.component.less
+++ b/app/scripts/modules/core/serverGroup/details/multipleServerGroup.component.less
@@ -1,4 +1,4 @@
-@import "../../presentation/less/imports/commonImports.less";
+@import (reference) "~core/presentation/less/imports/commonImports.less";
 
 multiple-server-group {
   display: block;

--- a/app/scripts/modules/core/task/monitor/taskMonitor.directive.less
+++ b/app/scripts/modules/core/task/monitor/taskMonitor.directive.less
@@ -1,4 +1,4 @@
-@import "../../presentation/less/imports/commonImports.less";
+@import (reference) "~core/presentation/less/imports/commonImports.less";
 
 task-monitor {
   display: block;

--- a/app/scripts/modules/core/task/tasks.less
+++ b/app/scripts/modules/core/task/tasks.less
@@ -1,4 +1,4 @@
-@import "../presentation/less/imports/commonImports.less";
+@import (reference) "~core/presentation/less/imports/commonImports.less";
 
 .tasks-wrapper {
   display: flex;

--- a/app/scripts/modules/core/task/verification/userVerification.directive.less
+++ b/app/scripts/modules/core/task/verification/userVerification.directive.less
@@ -1,4 +1,4 @@
-@import "../../presentation/less/imports/commonImports.less";
+@import (reference) "~core/presentation/less/imports/commonImports.less";
 
 user-verification {
   text-align: right;

--- a/app/scripts/modules/core/utils/stickyHeader/stickyHeader.less
+++ b/app/scripts/modules/core/utils/stickyHeader/stickyHeader.less
@@ -1,4 +1,4 @@
-@import "~core/presentation/less/imports/commonImports.less";
+@import (reference) "~core/presentation/less/imports/commonImports.less";
 
 .sticky-header {
   .shadowed {

--- a/app/scripts/modules/core/whatsNew/whatsNew.less
+++ b/app/scripts/modules/core/whatsNew/whatsNew.less
@@ -1,4 +1,4 @@
-@import "../presentation/less/imports/commonImports.less";
+@import (reference) "~core/presentation/less/imports/commonImports.less";
 
 .navbar-inverse .navbar-nav > li.whats-new > a {
   &.unread {

--- a/app/scripts/modules/core/widgets/notifier/notifier.component.less
+++ b/app/scripts/modules/core/widgets/notifier/notifier.component.less
@@ -1,4 +1,4 @@
-@import "../../presentation/less/imports/commonImports.less";
+@import (reference) "~core/presentation/less/imports/commonImports.less";
 
 notifier {
   .user-notifications {

--- a/app/scripts/modules/netflix/availability/availability.less
+++ b/app/scripts/modules/netflix/availability/availability.less
@@ -1,4 +1,4 @@
-@import "../../core/presentation/less/imports/commonImports.less";
+@import (reference) "~core/presentation/less/imports/commonImports.less";
 
 .availability-nav {
   .dropdown-toggle {

--- a/app/scripts/modules/netflix/blesk/blesk.less
+++ b/app/scripts/modules/netflix/blesk/blesk.less
@@ -1,4 +1,4 @@
-@import "~core/presentation/less/imports/colors.less";
+@import (reference) "~core/presentation/less/imports/colors.less";
 
 .blesk-wrapper {
   background-color: @pod_header_blue;

--- a/app/scripts/modules/netflix/canary/canary.less
+++ b/app/scripts/modules/netflix/canary/canary.less
@@ -1,4 +1,4 @@
-@import "../../core/presentation/less/imports/commonImports.less";
+@import (reference) "~core/presentation/less/imports/commonImports.less";
 
 .canary-summary {
   .canary-deployment-row {

--- a/app/scripts/modules/netflix/ci/ci.less
+++ b/app/scripts/modules/netflix/ci/ci.less
@@ -1,4 +1,4 @@
-@import "../../core/presentation/less/imports/commonImports.less";
+@import (reference) "~core/presentation/less/imports/commonImports.less";
 
 .nav-ci {
   margin-top:20px;

--- a/app/scripts/modules/netflix/fastProperties/fastProperties.less
+++ b/app/scripts/modules/netflix/fastProperties/fastProperties.less
@@ -1,4 +1,4 @@
-@import "~core/presentation/less/imports/commonImports.less";
+@import (reference) "~core/presentation/less/imports/commonImports.less";
 
 .fast-property-table {
   th {

--- a/app/scripts/modules/netflix/fastProperties/global/fastPropertyFilterSearch.less
+++ b/app/scripts/modules/netflix/fastProperties/global/fastPropertyFilterSearch.less
@@ -1,4 +1,4 @@
-@import "~core/presentation/less/imports/commonImports.less";
+@import (reference) "~core/presentation/less/imports/commonImports.less";
 
 @keyframes bgPulse {
   100% {

--- a/app/scripts/modules/netflix/fastProperties/scope/fastPropetyScopeSearch.less
+++ b/app/scripts/modules/netflix/fastProperties/scope/fastPropetyScopeSearch.less
@@ -1,4 +1,4 @@
-@import "../../../core/presentation/less/imports/commonImports.less";
+@import (reference) "~core/presentation/less/imports/commonImports.less";
 
 .fp-scope-search {
   margin-top: 6px;

--- a/app/scripts/modules/netflix/fastProperties/wizard/propertyStrategy/propertyStrategy.component.less
+++ b/app/scripts/modules/netflix/fastProperties/wizard/propertyStrategy/propertyStrategy.component.less
@@ -1,4 +1,4 @@
-@import "../../../../core/presentation/less/imports/commonImports.less";
+@import (reference) "~core/presentation/less/imports/commonImports.less";
 
 
 .strategy-button-group {

--- a/app/scripts/modules/netflix/migrator/migrator.less
+++ b/app/scripts/modules/netflix/migrator/migrator.less
@@ -1,4 +1,4 @@
-@import "../../core/presentation/less/imports/commonImports.less";
+@import (reference) "~core/presentation/less/imports/commonImports.less";
 
 .migrator-modal {
   .task-progress-status {

--- a/app/scripts/modules/netflix/pipeline/stage/canary/canary.less
+++ b/app/scripts/modules/netflix/pipeline/stage/canary/canary.less
@@ -1,4 +1,4 @@
-@import "~core/presentation/less/imports/colors.less";
+@import (reference) "~core/presentation/less/imports/colors.less";
 
 div.canary-score {
   div.progress {

--- a/app/scripts/modules/netflix/pipeline/stage/canary/canaryScore.component.less
+++ b/app/scripts/modules/netflix/pipeline/stage/canary/canaryScore.component.less
@@ -1,4 +1,4 @@
-@import "~core/presentation/less/imports/commonImports.less";
+@import (reference) "~core/presentation/less/imports/commonImports.less";
 
 .score.label {
   font-size: 110%;

--- a/app/scripts/modules/netflix/report/reservationReport.component.less
+++ b/app/scripts/modules/netflix/report/reservationReport.component.less
@@ -1,4 +1,5 @@
-@import "../../core/presentation/less/imports/commonImports.less";
+@import (reference) "~core/presentation/less/imports/commonImports.less";
+
 reservation-report {
   display: block;
   margin-bottom: 20px;

--- a/app/scripts/modules/netflix/tableau/tableau.less
+++ b/app/scripts/modules/netflix/tableau/tableau.less
@@ -1,4 +1,4 @@
-@import "../../core/presentation/less/imports/commonImports.less";
+@import (reference) "~core/presentation/less/imports/commonImports.less";
 
 .tableau-dashboard {
   width: 100%;

--- a/app/scripts/modules/openstack/loadBalancer/loadBalancer.less
+++ b/app/scripts/modules/openstack/loadBalancer/loadBalancer.less
@@ -1,4 +1,4 @@
-@import "../../core/presentation/less/imports/commonImports.less";
+@import (reference) "~core/presentation/less/imports/commonImports.less";
 
 .health-check .status-code {
     display: inline-block;

--- a/app/scripts/modules/titus/migration/titusMigrationConfig.component.less
+++ b/app/scripts/modules/titus/migration/titusMigrationConfig.component.less
@@ -1,4 +1,4 @@
-@import "~core/presentation/less/imports/colors.less";
+@import (reference) "~core/presentation/less/imports/colors.less";
 
 titus-migration-config {
   .migration-config {


### PR DESCRIPTION
Using `(reference)` avoids pulling the actual contents of the imported file into the importing file.

This trims all of 100kb off the (non-gzipped) app bundled, bringing it down from 7.2 to 7.1 MB, so it's not really going to be noticeable to anyone.

Also removing copyright headers, since they're only in a few files and not needed.