### PR TITLE
feat(core): mutating request debug mode

### DIFF
--- a/app/scripts/modules/core/core.module.js
+++ b/app/scripts/modules/core/core.module.js
@@ -24,6 +24,7 @@ import {REPLACE_FILTER} from './filter/replace.filter';
 import {PIPELINE_TEMPLATE_MODULE} from './pipeline/config/templates/pipelineTemplate.module';
 import {HEALTH_COUNTS_COMPONENT} from './healthCounts/healthCounts.component';
 import {CORE_PAGETITLE_SERVICE} from './pageTitle/pageTitle.service';
+import {INTERCEPTOR_MODULE} from './interceptor/interceptor.module';
 
 require('../../../fonts/spinnaker/icons.css');
 
@@ -95,6 +96,7 @@ module.exports = angular
 
     INSIGHT_NGMODULE.name,
     require('./instance/instance.module.js'),
+    INTERCEPTOR_MODULE,
 
     require('./loadBalancer/loadBalancer.module.js'),
 

--- a/app/scripts/modules/core/interceptor/debug.interceptor.ts
+++ b/app/scripts/modules/core/interceptor/debug.interceptor.ts
@@ -1,0 +1,32 @@
+import {module, IRequestConfig, IHttpInterceptor, IHttpProvider} from 'angular';
+import {$log, $location} from 'ngimport';
+import {JSON_UTILITY_SERVICE, JsonUtilityService} from 'core/utils/json/json.utility.service';
+import autoBindMethods from 'class-autobind-decorator';
+
+@autoBindMethods
+export class DebugInterceptor implements IHttpInterceptor {
+
+  constructor(private jsonUtilityService: JsonUtilityService) { 'ngInject'; }
+
+  public request(config: IRequestConfig): IRequestConfig {
+    try { // This is a great opportunity to break Deck, so be careful.
+      this.logMutatingRequest(config);
+    } catch (e) {
+      $log.warn('Debug interceptor bug: ', e.message);
+    }
+    return config;
+  }
+
+  private logMutatingRequest(config: IRequestConfig): void {
+    if ($location.url() &&
+        $location.url().includes('debug=true') &&
+        ['POST', 'PUT', 'DELETE'].includes(config.method)) {
+      $log.log(`${config.method}: ${config.url} \n`, this.jsonUtilityService.makeSortedStringFromObject(config.data));
+    }
+  }
+}
+
+export const DEBUG_INTERCEPTOR = 'spinnaker.core.debug.interceptor';
+module(DEBUG_INTERCEPTOR, [JSON_UTILITY_SERVICE])
+  .service('debugInterceptor', DebugInterceptor)
+  .config(($httpProvider: IHttpProvider) => $httpProvider.interceptors.push('debugInterceptor'));

--- a/app/scripts/modules/core/interceptor/interceptor.module.ts
+++ b/app/scripts/modules/core/interceptor/interceptor.module.ts
@@ -1,0 +1,8 @@
+import {module} from 'angular';
+
+import {DEBUG_INTERCEPTOR} from './debug.interceptor';
+
+export const INTERCEPTOR_MODULE = 'spinnaker.core.interceptor.module';
+module(INTERCEPTOR_MODULE, [
+  DEBUG_INTERCEPTOR,
+]);

--- a/app/scripts/modules/core/navigation/state.provider.ts
+++ b/app/scripts/modules/core/navigation/state.provider.ts
@@ -17,6 +17,10 @@ export class StateConfigProvider implements IServiceProvider {
   private root: INestedState = {
     name: 'home',
     abstract: true,
+    url: '?{debug:boolean}',
+    params: {
+      debug: { dynamic: true }
+    },
     children: [],
   };
 


### PR DESCRIPTION
@anotherchrisberry or @jrsquared please review.

Dumps a mutating request body to the console if `debug=true` is present as a query parameter (in the browser, not in the outgoing request).

I bet no one is going to discover this, so it would be nice in the future to have a better way to turn this mode on / consume the output.
