### PR TITLE
chore(netflix): remove unnecessary dependency injections

### DIFF
--- a/app/scripts/modules/netflix/fastProperties/wizard/propertyScope/propertyScope.component.ts
+++ b/app/scripts/modules/netflix/fastProperties/wizard/propertyScope/propertyScope.component.ts
@@ -47,7 +47,6 @@ class FastPropertyScopeComponent implements IComponentOptions {
 export const FAST_PROPERTY_SCOPE_COMPONENT = 'spinnaker.netflix.fastProperty.scope.component';
 
 module(FAST_PROPERTY_SCOPE_COMPONENT, [
-  require('core/search/searchResult/searchResult.directive'),
   FAST_PROPERTY_READ_SERVICE,
   FAST_PROPERTY_SCOPE_SEARCH_COMPONENT
 ])

--- a/app/scripts/modules/netflix/fastProperties/wizard/propertyScope/propertyScopeReadOnly.component.ts
+++ b/app/scripts/modules/netflix/fastProperties/wizard/propertyScope/propertyScopeReadOnly.component.ts
@@ -40,7 +40,6 @@ class FastPropertyScopeReadOnlyComponent implements IComponentOptions {
 export const FAST_PROPERTY_SCOPE_READ_ONLY_COMPONENT = 'spinnaker.netflix.fastProperty.scope.readOnly.component';
 
 module(FAST_PROPERTY_SCOPE_READ_ONLY_COMPONENT, [
-  require('core/search/searchResult/searchResult.directive'),
   FAST_PROPERTY_READ_SERVICE,
   FAST_PROPERTY_SCOPE_SEARCH_CATEGORY_SERVICE
 ])

--- a/app/scripts/modules/netflix/fastProperties/wizard/propertyScope/propertyScopeUpdatable.component.ts
+++ b/app/scripts/modules/netflix/fastProperties/wizard/propertyScope/propertyScopeUpdatable.component.ts
@@ -46,7 +46,6 @@ class FastPropertyScopeReadOnlyComponent implements IComponentOptions {
 export const FAST_PROPERTY_SCOPE_UPDATABLE_COMPONENT = 'spinnaker.netflix.fastProperty.scope.updatable.component';
 
 module(FAST_PROPERTY_SCOPE_UPDATABLE_COMPONENT, [
-  require('core/search/searchResult/searchResult.directive'),
   FAST_PROPERTY_READ_SERVICE,
   FAST_PROPERTY_SCOPE_SEARCH_CATEGORY_SERVICE
 ])

--- a/app/scripts/modules/netflix/pipeline/stage/canary/canaryStage.module.js
+++ b/app/scripts/modules/netflix/pipeline/stage/canary/canaryStage.module.js
@@ -10,7 +10,6 @@ module.exports = angular.module('spinnaker.netflix.pipeline.stage.canary', [
   require('./canaryStage.js'),
   require('./canaryExecutionDetails.controller.js'),
   require('./canaryExecutionSummary.controller.js'),
-  require('core/deploymentStrategy/deploymentStrategy.module.js'),
   require('./canaryDeployment/canaryDeployment.module.js'),
   require('./canaryStage.transformer.js'),
   CANARY_SCORE_COMPONENT,

--- a/app/scripts/modules/netflix/pipeline/stage/properties/index.js
+++ b/app/scripts/modules/netflix/pipeline/stage/properties/index.js
@@ -12,7 +12,6 @@ module.exports = angular.module('spinnaker.netflix.pipeline.stage.property', [
   require('./create/persistedPropertyList.component'),
   require('./create/property.component'),
   require('./create/propertyExecutionDetails.controller.js'),
-  require('core/deploymentStrategy/deploymentStrategy.module'),
   ACCOUNT_SERVICE,
   NAMING_SERVICE,
   require('../../../fastProperties/wizard/propertyDetails/fastPropertyConstraintsSelector.directive'),

--- a/app/scripts/modules/netflix/pipeline/stage/quickPatchAsg/bulkQuickPatchStage/bulkQuickPatchStage.module.js
+++ b/app/scripts/modules/netflix/pipeline/stage/quickPatchAsg/bulkQuickPatchStage/bulkQuickPatchStage.module.js
@@ -4,7 +4,4 @@ let angular = require('angular');
 
 module.exports = angular.module('spinnaker.netflix.pipeline.stage.quickPatchAsg.bulkQuickPatch', [
   require('./bulkQuickPatchStage.js'),
-  require('core/pipeline/config/stages/stage.module.js'),
-  require('core/pipeline/config/stages/core/stage.core.module.js'),
-  require('core/account/account.module.js'),
 ]);

--- a/app/scripts/modules/netflix/pipeline/stage/quickPatchAsg/quickPatchAsgStage.module.js
+++ b/app/scripts/modules/netflix/pipeline/stage/quickPatchAsg/quickPatchAsgStage.module.js
@@ -4,7 +4,4 @@ let angular = require('angular');
 
 module.exports = angular.module('spinnaker.netflix.pipeline.stage.quickPatchAsg', [
   require('./quickPatchAsgStage.js'),
-  require('core/pipeline/config/stages/stage.module.js'),
-  require('core/pipeline/config/stages/core/stage.core.module.js'),
-  require('core/account/account.module.js'),
 ]);


### PR DESCRIPTION
these don't need to be included, as they're not used in the modules themselves (or are included within the child modules themselves)