### PR TITLE
refactor(core): move react module to core

### DIFF
--- a/app/scripts/app.ts
+++ b/app/scripts/app.ts
@@ -2,8 +2,6 @@ import * as angular from 'angular';
 
 import {NETFLIX_MODULE} from './modules/netflix/netflix.module';
 import {APPENGINE_MODULE} from './modules/appengine/appengine.module';
-import {AUTHENTICATION_SERVICE} from './modules/core/authentication/authentication.service';
-import {REACT_MODULE} from './modules/core/react.module';
 
 module.exports = angular.module('netflix.spinnaker', [
   NETFLIX_MODULE,
@@ -17,6 +15,4 @@ module.exports = angular.module('netflix.spinnaker', [
   require('./modules/openstack/openstack.module.js'),
   require('./modules/docker/docker.module.js'),
   APPENGINE_MODULE,
-  AUTHENTICATION_SERVICE,
-  REACT_MODULE
 ]);

--- a/app/scripts/modules/core/core.module.js
+++ b/app/scripts/modules/core/core.module.js
@@ -25,6 +25,7 @@ import {PIPELINE_TEMPLATE_MODULE} from './pipeline/config/templates/pipelineTemp
 import {HEALTH_COUNTS_COMPONENT} from './healthCounts/healthCounts.component';
 import {CORE_PAGETITLE_SERVICE} from './pageTitle/pageTitle.service';
 import {INTERCEPTOR_MODULE} from './interceptor/interceptor.module';
+import {REACT_MODULE} from './react.module';
 
 require('../../../fonts/spinnaker/icons.css');
 
@@ -146,6 +147,7 @@ module.exports = angular
     require('./pipeline/config/preconditions/types/expression/expression.precondition.type.module.js'),
     require('./presentation/presentation.module.js'),
     REPLACE_FILTER,
+    REACT_MODULE,
 
     require('./search/search.module.js'),
     require('./securityGroup/securityGroup.module.js'),


### PR DESCRIPTION
react module is probably better in core, auth service doesn't need to be in app (it's loaded as part of auth module in core)