### PR TITLE
Allow `ssh:` links

### DIFF
--- a/app/scripts/modules/core/core.module.js
+++ b/app/scripts/modules/core/core.module.js
@@ -228,7 +228,7 @@ module.exports = angular
     $qProvider.errorOnUnhandledRejections(false);
   })
   .config(function($compileProvider) {
-    $compileProvider.aHrefSanitizationWhitelist(/^\s*(https?|mailto|hipchat|slack):/);
+    $compileProvider.aHrefSanitizationWhitelist(/^\s*(https?|mailto|hipchat|slack|ssh):/);
     // Angular 1.6 defaults preAssignBindingsEnabled to false, reset to true to mimic 1.5 behavior.
     // See https://docs.angularjs.org/guide/migration#migrate1.5to1.6-ng-services-$compile
     $compileProvider.preAssignBindingsEnabled(true);


### PR DESCRIPTION
Allow `ssh://` links, useful for one-click SSH access to servers from Spinnaker.