### PR TITLE
chore(travis): Do not perform gradle build for travis pull requests

### DIFF
--- a/gradle/buildViaTravis.sh
+++ b/gradle/buildViaTravis.sh
@@ -2,11 +2,17 @@
 # This script will build the project.
 
 if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
-  echo -e "Build Pull Request #$TRAVIS_PULL_REQUEST => Branch [$TRAVIS_BRANCH]"
-  ./gradlew -Prelease.useLastTag=true build
+  echo -e "Skipping build (running unit tests only) for Pull Request #$TRAVIS_PULL_REQUEST => Branch [$TRAVIS_BRANCH]"
+  source ~/.nvm/nvm.sh
+  NODE_JS_VERSION=`node -e 'console.log(require("./package.json").engines.node)'`;
+  nvm use $NODE_JS_VERSION
+
+  ./node_modules/.bin/karma start --single-run
+
 elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" == "" ]; then
   echo -e 'Build Branch with Snapshot => Branch ['$TRAVIS_BRANCH']'
   ./gradlew -Prelease.travisci=true -PbintrayUser="${bintrayUser}" -PbintrayKey="${bintrayKey}" build snapshot --stacktrace
+
 elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" != "" ]; then
   echo -e 'Build Branch for Release => Branch ['$TRAVIS_BRANCH']  Tag ['$TRAVIS_TAG']'
   case "$TRAVIS_TAG" in
@@ -19,8 +25,10 @@ elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" != "" ]; then
     ./gradlew -PdeckVersion="${TRAVIS_TAG}" -Prelease.travisci=true -Prelease.useLastTag=true -PbintrayUser="${bintrayUser}" -PbintrayKey="${bintrayKey}" final --stacktrace
     ;;
   esac
+
 else
   echo -e 'WARN: Should not be here => Branch ['$TRAVIS_BRANCH']  Tag ['$TRAVIS_TAG']  Pull Request ['$TRAVIS_PULL_REQUEST']'
   ./gradlew -Prelease.useLastTag=true build
+
 fi
 

--- a/gradle/installViaTravis.sh
+++ b/gradle/installViaTravis.sh
@@ -2,16 +2,31 @@
 # This script will build the project.
 
 if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
-  echo -e "Assemble Pull Request #$TRAVIS_PULL_REQUEST => Branch [$TRAVIS_BRANCH]"
-  ./gradlew assemble
+  NODE_JS_VERSION=`node -e 'console.log(require("./package.json").engines.node)'`;
+  echo -e "Installing/activating nodejs v$NODE_JS_VERSION"
+
+  # http://austinpray.com/ops/2015/09/20/change-travis-node-version.html
+  # Clear out whatever version of NVM Travis has. ; Their version of NVM is probably old.
+  rm -rf ~/.nvm
+  git clone https://github.com/creationix/nvm.git ~/.nvm
+
+  # Checkout the latest stable nvm tag.
+  (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`)
+
+  source ~/.nvm/nvm.sh
+  nvm install $NODE_JS_VERSION
+
 elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" == "" ]; then
   echo -e 'Assemble Branch with Snapshot => Branch ['$TRAVIS_BRANCH']'
   ./gradlew -Prelease.travisci=true assemble
+
 elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" != "" ]; then
   echo -e 'Assemble Branch for Release => Branch ['$TRAVIS_BRANCH']  Tag ['$TRAVIS_TAG']'
   ./gradlew -PdeckVersion="${TRAVIS_TAG}" -Prelease.travisci=true -Prelease.useLastTag=true assemble
+
 else
   echo -e 'WARN: Should not be here => Branch ['$TRAVIS_BRANCH']  Tag ['$TRAVIS_TAG']  Pull Request ['$TRAVIS_PULL_REQUEST']'
   ./gradlew assemble
+
 fi
 


### PR DESCRIPTION
This PR modifies travis config to skip the gradle build
The change only takes effect when processing a travis pull request.  When a branch is merged into master, the normal gradle build is run to create artifacts.