### PR TITLE
Filter fixes

### DIFF
--- a/app/index.deck
+++ b/app/index.deck
@@ -1,7 +1,7 @@
 <!doctype html>
 <html class="no-js" ng-app="netflix.spinnaker">
 <head>
-  <title ng-bind="pageTitle">Spinnaker</title>
+  <title>Spinnaker</title>
   <meta charset="utf-8">
   <meta name="description" content="">
   <meta name="viewport" content="width=device-width">

--- a/app/scripts/modules/core/cluster/all.html
+++ b/app/scripts/modules/core/cluster/all.html
@@ -1,4 +1,4 @@
-<div class="header row header-clusters">
+<div class="header row header-clusters" ng-if="ctrl.initialized">
   <div class="col-lg-9 col-md-10 col-sm-10">
     <h3>
       Clusters <span class="small"><help-field key="cluster.description"></help-field></span>

--- a/app/scripts/modules/core/cluster/allClusters.controller.js
+++ b/app/scripts/modules/core/cluster/allClusters.controller.js
@@ -33,6 +33,7 @@ module.exports = angular.module('spinnaker.core.cluster.allClusters.controller',
                                           ClusterFilterModel, MultiselectModel, InsightFilterStateModel, serverGroupCommandBuilder, cloudProviderRegistry) {
 
     this.$onInit = () => {
+      InsightFilterStateModel.filtersHidden = true; // hidden to prevent filter flashing for on-demand apps
       const groupsUpdatedSubscription = clusterFilterService.groupsUpdatedStream.subscribe(() => clusterGroupsUpdated());
       this.application = app;
       ClusterFilterModel.activate();
@@ -45,7 +46,10 @@ module.exports = angular.module('spinnaker.core.cluster.allClusters.controller',
       this.createLabel = 'Create Server Group';
 
       app.getDataSource('serverGroups').ready().then(
-        () => updateClusterGroups(),
+        () => {
+          InsightFilterStateModel.filtersHidden = false;
+          updateClusterGroups();
+        },
         () => this.clustersLoadError()
       );
 

--- a/app/scripts/modules/core/cluster/cluster.service.ts
+++ b/app/scripts/modules/core/cluster/cluster.service.ts
@@ -9,7 +9,7 @@ import {Application} from '../application/application.model';
 import {ICluster, IClusterSummary} from '../domain/ICluster';
 import {IExecutionStage} from '../domain/IExecutionStage';
 import {IExecution} from '../domain/IExecution';
-import {CLUSTER_FILTER_MODEL} from './filter/clusterFilter.model';
+import { CLUSTER_FILTER_MODEL, ClusterFilterModel } from './filter/clusterFilter.model';
 
 export class ClusterService {
 
@@ -17,7 +17,7 @@ export class ClusterService {
               private API: Api,
               private serverGroupTransformer: any,
               private namingService: NamingService,
-              private ClusterFilterModel: any,
+              private ClusterFilterModel: ClusterFilterModel,
               private filterModelService: any) {
     'ngInject';
   }
@@ -30,7 +30,7 @@ export class ClusterService {
       if (dataSource.fetchOnDemand) {
         dataSource.clusters = clusters;
         serverGroupLoader.withParams({
-          clusters: this.filterModelService.getCheckValues(this.ClusterFilterModel.sortFilter.clusters).join()
+          clusters: this.filterModelService.getCheckValues(this.ClusterFilterModel.asFilterModel.sortFilter.clusters).join()
         });
       } else {
         this.reconcileClusterDeepLink();
@@ -46,7 +46,7 @@ export class ClusterService {
   // if the application is deep linked via "clusters:", but the app is not "fetchOnDemand" sized, convert the parameters
   // to the normal, filterable structure
   private reconcileClusterDeepLink() {
-    const selectedClusters: string[] = this.filterModelService.getCheckValues(this.ClusterFilterModel.sortFilter.clusters);
+    const selectedClusters: string[] = this.filterModelService.getCheckValues(this.ClusterFilterModel.asFilterModel.sortFilter.clusters);
     if (selectedClusters && selectedClusters.length) {
       const clusterNames: string[] = [];
       const accountNames: string[] = [];
@@ -58,10 +58,10 @@ export class ClusterService {
         }
       });
       if (clusterNames.length) {
-        accountNames.forEach(account => this.ClusterFilterModel.sortFilter.account[account] = true);
-        this.ClusterFilterModel.sortFilter.filter = `clusters:${clusterNames.join()}`;
-        this.ClusterFilterModel.sortFilter.clusters = {};
-        this.ClusterFilterModel.applyParamsToUrl();
+        accountNames.forEach(account => this.ClusterFilterModel.asFilterModel.sortFilter.account[account] = true);
+        this.ClusterFilterModel.asFilterModel.sortFilter.filter = `clusters:${clusterNames.join()}`;
+        this.ClusterFilterModel.asFilterModel.sortFilter.clusters = {};
+        this.ClusterFilterModel.asFilterModel.applyParamsToUrl();
       }
     }
   }

--- a/app/scripts/modules/core/pageTitle/pageTitle.service.spec.js
+++ b/app/scripts/modules/core/pageTitle/pageTitle.service.spec.js
@@ -18,7 +18,7 @@ describe('Service: pageTitleService', function() {
       var scope = this.$rootScope;
 
       expect(scope.routing).toBeFalsy();
-      expect(document.title).toBe('');
+      document.title = 'Spinnaker!';
 
       this.pageTitleService.handleRoutingStart();
       expect(scope.routing).toBeTruthy();

--- a/app/scripts/modules/core/pageTitle/pageTitle.service.ts
+++ b/app/scripts/modules/core/pageTitle/pageTitle.service.ts
@@ -30,13 +30,12 @@ interface IPageDataParts {
 }
 
 export class PageTitleService {
-  public static $inject = [ '$rootScope', '$stateParams', '$transitions' ];
-
   private previousPageTitle = 'Spinnaker';
+  private routeCount = 0;
 
   constructor(private $rootScope: IScope, private $stateParams: StateParams, $transitions: TransitionService) {
-    $rootScope.routing = 0;
-
+    'ngInject';
+    document.title = 'Spinnaker: Loading...';
     $transitions.onStart({}, transition => {
       this.handleRoutingStart();
       const onSuccess = () => this.handleRoutingSuccess(transition.to().data);
@@ -46,13 +45,15 @@ export class PageTitleService {
   }
 
   public handleRoutingStart(): void {
-    this.$rootScope.routing++;
+    this.routeCount++;
     this.previousPageTitle = document.title;
+    this.setRoutingFlag();
     document.title = 'Spinnaker: Loading...';
   }
 
   public handleRoutingError(rejection: Rejection): void {
-    this.$rootScope.routing--;
+    this.routeCount--;
+    this.setRoutingFlag();
     const cancelled = rejection.type === RejectType.ABORTED;
     document.title = cancelled ? this.previousPageTitle : 'Spinnaker: Error';
   }
@@ -126,6 +127,10 @@ export class PageTitleService {
       section: this.configureSection(data.pageTitleSection),
       details: this.configureDetails(data.pageTitleDetails)
     };
+  }
+
+  private setRoutingFlag() {
+    this.$rootScope.routing = this.routeCount > 0;
   }
 }
 

--- a/app/scripts/modules/core/serverGroup/serverGroup.states.ts
+++ b/app/scripts/modules/core/serverGroup/serverGroup.states.ts
@@ -27,11 +27,6 @@ module(SERVER_GROUP_STATES, [
         controllerAs: 'ctrl'
       }
     },
-    resolve: {
-      // prevents flash of filters if fetchOnDemand is enabled; catch any exceptions so the route resolves
-      // and deal with the exception in the AllClustersCtrl
-      ready: (app: Application) => app.getDataSource('serverGroups').ready().catch(() => null),
-    },
     redirectTo: (transition) => {
       return transition.injector().getAsync('app').then((app: Application) => {
         if (app.serverGroups.disabled) {

--- a/app/scripts/modules/core/task/tasks.controller.js
+++ b/app/scripts/modules/core/task/tasks.controller.js
@@ -17,7 +17,7 @@ module.exports = angular.module('spinnaker.core.task.controller', [
   CONFIRMATION_MODAL_SERVICE,
   DISPLAYABLE_TASKS_FILTER
 ])
-  .controller('TasksCtrl', function ($scope, $state, $q, app, viewStateCache, taskWriter, confirmationModalService) {
+  .controller('TasksCtrl', function ($scope, $state, $stateParams, $q, app, viewStateCache, taskWriter, confirmationModalService) {
 
     if (app.notFound) {
       return;
@@ -54,7 +54,18 @@ module.exports = angular.module('spinnaker.core.task.controller', [
       viewState.itemsPerPage = tasksViewStateCache.get('#common') ? tasksViewStateCache.get('#common').itemsPerPage : 20;
 
       $scope.viewState = viewState;
+      setTaskFilter();
     }
+
+    const setTaskFilter = () => {
+      const taskId = $stateParams.taskId;
+      if (!$scope.viewState.expandedTasks.includes(taskId)) {
+        controller.toggleDetails(taskId);
+      }
+      $scope.viewState.nameFilter = taskId;
+      $scope.viewState.taskStateFilter = '';
+      controller.sortTasksAndResetPaginator();
+    };
 
     controller.taskStateFilter = 'All';
     controller.application = application;
@@ -241,19 +252,6 @@ module.exports = angular.module('spinnaker.core.task.controller', [
     // angular ui btn-radio doesn't support the ng-change or ng-click directives
     $scope.$watch('viewState.taskStateFilter', controller.sortTasksAndResetPaginator);
     $scope.$watch('viewState', cacheViewState, true);
-
-    // The taskId will not be available in the $stateParams that would be passed into this controller
-    // because that field belongs to a child state. So we have to watch for a $stateChangeSuccess event, then set
-    // the value on the scope
-    $scope.$on('$stateChangeSuccess', function(event, toState, toParams) {
-      var taskId = toParams.taskId;
-      if (!$scope.viewState.expandedTasks.includes(taskId)) {
-        controller.toggleDetails(taskId);
-      }
-      $scope.viewState.nameFilter = taskId;
-      $scope.viewState.taskStateFilter = '';
-      controller.sortTasksAndResetPaginator();
-    });
 
     initializeViewState();
 


### PR DESCRIPTION
Three tweaks here (in separate commits):
1. Deep links to tasks were broken after the ui-router upgrade, since the workaround that was in place is no longer needed.
2. Fixed rendering for on-demand clusters. Because the `resolve` in the clusters state was relying on the application to be ready, the transition we were firing off via the `applyParamsToUrl` was getting rejected and nothing was being shown on the page.
3. Tweaked the page title service. Since the `onStart` event is delayed a bit, for very large applications, the users sees the browser URL while the routing starts up, and doesn't see the spinner for a second or two, which gives the impression that something is broken or frozen.

@christopherthielen or @jrsquared PTAL