### PR TITLE
fix(netflix): do not allow users to specify useSourceCapacity for canaries

### DIFF
--- a/app/scripts/modules/amazon/serverGroup/configure/wizard/capacity/capacitySelector.directive.html
+++ b/app/scripts/modules/amazon/serverGroup/configure/wizard/capacity/capacitySelector.directive.html
@@ -6,7 +6,7 @@
     </div>
   </div>
 
-  <div class="form-group">
+  <div class="form-group" ng-if="!vm.command.viewState.readOnlyFields.useSourceCapacity">
     <div class="col-md-3 sm-label-right">Capacity</div>
     <div class="col-md-9 radio">
       <label>

--- a/app/scripts/modules/netflix/pipeline/stage/canary/canaryStage.js
+++ b/app/scripts/modules/netflix/pipeline/stage/canary/canaryStage.js
@@ -367,7 +367,7 @@ module.exports = angular.module('spinnaker.netflix.pipeline.stage.canaryStage', 
     function configureServerGroupCommandForEditing(command) {
       command.viewState.disableStrategySelection = true;
       command.viewState.hideClusterNamePreview = true;
-      command.viewState.readOnlyFields = { credentials: true, region: true, subnet: true };
+      command.viewState.readOnlyFields = { credentials: true, region: true, subnet: true, useSourceCapacity: true };
       delete command.strategy;
     }
 
@@ -393,7 +393,8 @@ module.exports = angular.module('spinnaker.netflix.pipeline.stage.canaryStage', 
                   command.viewState.overrides = {
                     capacity: {
                       min: 1, max: 1, desired: 1,
-                    }
+                    },
+                    useSourceCapacity: false,
                   };
                   command.viewState.disableNoTemplateSelection = true;
                   command.viewState.customTemplateMessage = 'Select a template to configure the canary and baseline ' +


### PR DESCRIPTION
It never makes sense to use source capacity on canaries, since they will try to look up capacity on a cluster that should not exist.