### PR TITLE
feat(gce): makes `associate public ip` an application setting

### DIFF
--- a/app/scripts/modules/core/help/helpContents.js
+++ b/app/scripts/modules/core/help/helpContents.js
@@ -145,6 +145,7 @@ module.exports = angular.module('spinnaker.core.help.contents', [])
     'gce.securityGroup.sourceCIDRs': 'Traffic is only allowed from sources that match one of these CIDR ranges, or one of the source tags above.',
     'gce.securityGroup.sourceTags': 'Traffic is only allowed from sources that match one of these tags, or one of the source CIDR ranges below.',
     'gce.securityGroup.targetTags': 'Traffic is only allowed if the target instance has one of these tags.',
+    'gce.serverGroup.associatePublicIpAddress.providerField': 'Check if new GCE server groups in this application should be assigned a public IP address by default.',
     'gce.serverGroup.resizeWithAutoscalingPolicy': `
       Setting the desired instance count for a server group with an autoscaler is not supported by Spinnaker;
       if the desired instance count differs from the instance count that the autoscaler wants to maintain for its configured metrics,

--- a/app/scripts/modules/google/applicationProviderFields/gceFields.html
+++ b/app/scripts/modules/google/applicationProviderFields/gceFields.html
@@ -1,0 +1,11 @@
+<div class="form-group row">
+  <div class="col-sm-3 sm-label-right">GCE Settings</div>
+  <div class="col-sm-9 checkbox" style="margin-bottom: 0; margin-top: 5px">
+    <label>
+      <input type="checkbox"
+             ng-init="$ctrl.initializeApplicationField('gce.associatePublicIpAddress')"
+             ng-model="$ctrl.application.providerSettings.gce.associatePublicIpAddress"/>
+      Associate Public IP Address <help-field key="gce.serverGroup.associatePublicIpAddress.providerField"></help-field>
+    </label>
+  </div>
+</div>

--- a/app/scripts/modules/google/gce.module.js
+++ b/app/scripts/modules/google/gce.module.js
@@ -108,7 +108,10 @@ module.exports = angular.module('spinnaker.gce', [
       subnet: {
         renderer: 'gceSubnetRenderer',
       },
-      snapshotsEnabled: true
+      snapshotsEnabled: true,
+      applicationProviderFields:{
+        templateUrl: require('./applicationProviderFields/gceFields.html'),
+      },
     });
   });
 

--- a/app/scripts/modules/google/serverGroup/configure/serverGroupCommandBuilder.service.js
+++ b/app/scripts/modules/google/serverGroup/configure/serverGroupCommandBuilder.service.js
@@ -240,6 +240,8 @@ module.exports = angular.module('spinnaker.gce.serverGroupCommandBuilder.service
       var defaultCredentials = defaults.account || GCEProviderSettings.defaults.account;
       var defaultRegion = defaults.region || GCEProviderSettings.defaults.region;
       var defaultZone = defaults.zone || GCEProviderSettings.defaults.zone;
+      var associatePublicIpAddress = _.has(application, 'attributes.providerSettings.gce.associatePublicIpAddress') ?
+        application.attributes.providerSettings.gce.associatePublicIpAddress : true;
 
       var command = {
         application: application.name,
@@ -248,7 +250,7 @@ module.exports = angular.module('spinnaker.gce.serverGroupCommandBuilder.service
         zone: defaultZone,
         regional: false, // TODO(duftler): Externalize this default alongside defaultRegion and defaultZone.
         network: 'default',
-        associatePublicIpAddress: true,
+        associatePublicIpAddress: associatePublicIpAddress,
         canIpForward: false,
         strategy: '',
         capacity: {

--- a/halconfig/settings.js
+++ b/halconfig/settings.js
@@ -17,7 +17,8 @@ var gce = {
     account: '{%google.default.account%}',
     region: '{%google.default.region%}',
     zone: '{%google.default.zone%}'
-  }
+  },
+  associatePublicIpAddress: true,
 };
 var kubernetes = {
   defaults: {

--- a/settings.js
+++ b/settings.js
@@ -50,6 +50,7 @@ window.spinnakerSettings = {
         region: 'us-central1',
         zone: 'us-central1-f',
       },
+      associatePublicIpAddress: true,
     },
     titus: {
       defaults: {


### PR DESCRIPTION
@duftler please review.

Closes https://github.com/spinnaker/spinnaker/issues/1638.

This is an application-level setting, not an account setting. The default for new applications can be set in `settings.js`.

![provider_settings](https://cloud.githubusercontent.com/assets/13868700/26015970/1b145d7c-3731-11e7-8edd-86ba69f21cd5.png)
