### PR TITLE
fix(core): restore spinning animation

### DIFF
--- a/app/scripts/modules/core/presentation/main.less
+++ b/app/scripts/modules/core/presentation/main.less
@@ -1,4 +1,4 @@
-@import (reference) "~core/presentation/less/imports/commonImports.less";
+@import "~core/presentation/less/imports/commonImports.less";
 
 @fixed-header-z-index: 1030;
 

--- a/app/scripts/modules/netflix/fastProperties/scope/fastPropertyScopeSearchCategory.service.ts
+++ b/app/scripts/modules/netflix/fastProperties/scope/fastPropertyScopeSearchCategory.service.ts
@@ -269,7 +269,7 @@ export class FastPropertyScopeCategoryService {
   public getApplicationByName(applicationName: string): ng.IPromise<Application> {
     return this.applicationReader.getApplication(applicationName)
       .then((application: Application) => {
-        return application.refresh(true)
+        return application.serverGroups.ready()
           .then(() => {
             return application;
           });

--- a/app/scripts/modules/netflix/fastProperties/view/ApplicationProperties.tsx
+++ b/app/scripts/modules/netflix/fastProperties/view/ApplicationProperties.tsx
@@ -3,7 +3,6 @@ import { groupBy } from 'lodash';
 import { Subscription } from 'rxjs/Subscription';
 import autoBindMethods from 'class-autobind-decorator';
 import { Subject } from 'rxjs/Subject';
-import { Tooltip } from 'react-bootstrap';
 
 import { Property } from '../domain/property.domain';
 import { Application } from 'core/application/application.model';
@@ -155,11 +154,8 @@ export class ApplicationProperties extends React.Component<IProps, IState> {
           </div>
           <div className="form-group pull-right">
             <button className="btn btn-sm btn-default" onClick={this.createFastProperty} style={{margin: '3px'}}>
-              <span className="glyphicon glyphicon-plus-sign visible-lg-inline"/>
-              <Tooltip value="Create Fast Property" id="createFastProperty">
-                <span className="glyphicon glyphicon-plus-sign visible-md-inline visible-sm-inline"/>
-              </Tooltip>
-              <span className="visible-lg-inline"> Create Fast Property</span>
+              <span className="glyphicon glyphicon-plus-sign"/>
+              <span> Create Fast Property</span>
             </button>
           </div>
 


### PR DESCRIPTION
* make sure animations are actually included _somewhere_ on the page
* fix fast property scope initialization
* remove tooltip on smaller screen - there's already tons of space in the header, no need to hide the label