### PR TITLE
fix(executions): add alias to deploy for v3 executions

### DIFF
--- a/app/scripts/modules/core/pipeline/config/stages/deploy/deployStage.js
+++ b/app/scripts/modules/core/pipeline/config/stages/deploy/deployStage.js
@@ -16,6 +16,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.deployStage', [
       description: 'Deploys the previously baked or found image',
       strategyDescription: 'Deploys the image specified',
       key: 'deploy',
+      alias: 'createServerGroup',
       templateUrl: require('./deployStage.html'),
       executionDetailsUrl: require('./deployExecutionDetails.html'),
       controller: 'DeployStageCtrl',


### PR DESCRIPTION
`deploy` stages are coming in as `createServerGroup` in v3 executions