### PR TITLE
refactor(core): rollup imported exports from core module

### DIFF
--- a/app/scripts/modules/amazon/subnet/subnetSelectField.component.ts
+++ b/app/scripts/modules/amazon/subnet/subnetSelectField.component.ts
@@ -1,7 +1,7 @@
 import {module} from 'angular';
 import {get} from 'lodash';
 
-import {ISubnet} from 'core/subnet/subnet.read.service';
+import {ISubnet} from 'core/domain';
 import {Application} from 'core/application/application.model';
 import {AWSProviderSettings} from '../aws.settings';
 

--- a/app/scripts/modules/core/account/index.ts
+++ b/app/scripts/modules/core/account/index.ts
@@ -1,0 +1,2 @@
+export * from './account.service';
+export * from './AccountTag';

--- a/app/scripts/modules/core/api/index.ts
+++ b/app/scripts/modules/core/api/index.ts
@@ -1,0 +1,1 @@
+export * from './api.service';

--- a/app/scripts/modules/core/application/index.ts
+++ b/app/scripts/modules/core/application/index.ts
@@ -1,0 +1,7 @@
+export * from './application.model';
+export * from './applicationModel.builder';
+export * from './listExtractor/listExtractor.service';
+export * from './service/application.read.service';
+export * from './service/application.write.service';
+export * from './service/applicationDataSource';
+export * from './service/applicationDataSource.registry';

--- a/app/scripts/modules/core/authentication/index.ts
+++ b/app/scripts/modules/core/authentication/index.ts
@@ -1,0 +1,1 @@
+export * from './authentication.service';

--- a/app/scripts/modules/core/cache/index.ts
+++ b/app/scripts/modules/core/cache/index.ts
@@ -1,0 +1,5 @@
+export * from './cacheInitializer.service';
+export * from './collapsibleSectionStateCache';
+export * from './infrastructureCaches.service';
+export * from './infrastructureCacheConfig';
+export * from './viewStateCache.service';

--- a/app/scripts/modules/core/cancelModal/index.ts
+++ b/app/scripts/modules/core/cancelModal/index.ts
@@ -1,0 +1,1 @@
+export * from './cancelModal.service';

--- a/app/scripts/modules/core/ci/index.ts
+++ b/app/scripts/modules/core/ci/index.ts
@@ -1,0 +1,1 @@
+export * from './igor.service';

--- a/app/scripts/modules/core/cloudProvider/index.ts
+++ b/app/scripts/modules/core/cloudProvider/index.ts
@@ -1,0 +1,3 @@
+export * from './providerSelection/providerSelection.service';
+export * from './cloudProvider.registry';
+export * from './CloudProviderLogo';

--- a/app/scripts/modules/core/cluster/index.ts
+++ b/app/scripts/modules/core/cluster/index.ts
@@ -1,0 +1,2 @@
+export * from './cluster.service';
+export * from './task.matcher';

--- a/app/scripts/modules/core/config/index.ts
+++ b/app/scripts/modules/core/config/index.ts
@@ -1,0 +1,1 @@
+export * from './settings';

--- a/app/scripts/modules/core/confirmationModal/index.ts
+++ b/app/scripts/modules/core/confirmationModal/index.ts
@@ -1,0 +1,1 @@
+export * from './confirmationModal.service';

--- a/app/scripts/modules/core/delivery/index.ts
+++ b/app/scripts/modules/core/delivery/index.ts
@@ -1,0 +1,2 @@
+export * from './service/execution.service';
+export * from './executionGroup/execution/Execution';

--- a/app/scripts/modules/core/entityTag/index.ts
+++ b/app/scripts/modules/core/entityTag/index.ts
@@ -1,0 +1,3 @@
+export * from './entityTags.read.service';
+export * from './entityTags.write.service';
+export * from './clusterTargetBuilder.service';

--- a/app/scripts/modules/core/filterModel/index.ts
+++ b/app/scripts/modules/core/filterModel/index.ts
@@ -1,0 +1,1 @@
+export * from './FilterTags';

--- a/app/scripts/modules/core/help/index.ts
+++ b/app/scripts/modules/core/help/index.ts
@@ -1,0 +1,1 @@
+export * from './helpContents.registry';

--- a/app/scripts/modules/core/history/index.ts
+++ b/app/scripts/modules/core/history/index.ts
@@ -1,0 +1,1 @@
+export * from './recentHistory.service';

--- a/app/scripts/modules/core/image/index.ts
+++ b/app/scripts/modules/core/image/index.ts
@@ -1,0 +1,1 @@
+export * from './image.reader';

--- a/app/scripts/modules/core/index.ts
+++ b/app/scripts/modules/core/index.ts
@@ -1,0 +1,55 @@
+export * from './account';
+export * from './api';
+export * from './application';
+export * from './authentication';
+
+export * from './cache';
+export * from './cancelModal';
+export * from './ci';
+export * from './cloudProvider';
+export * from './cluster';
+export * from './config';
+export * from './confirmationModal';
+
+export * from './delivery';
+export * from './domain';
+
+export * from './entityTag';
+
+export * from './filterModel';
+
+export * from './help';
+export * from './history';
+
+export * from './image';
+export * from './instance';
+
+export * from './loadBalancer';
+
+export * from './modal';
+
+export * from './naming';
+
+export * from './navigation';
+export * from './network';
+
+export * from './orchestratedItem';
+export * from './overrideRegistry';
+
+export * from './pageTitle';
+export * from './pipeline';
+export * from './presentation';
+
+export * from './react';
+export * from './retry';
+
+export * from './scheduler';
+export * from './search';
+export * from './securityGroup';
+export * from './serverGroup';
+export * from './serviceAccount';
+export * from './subnet';
+
+export * from './task';
+
+export * from './utils';

--- a/app/scripts/modules/core/instance/index.ts
+++ b/app/scripts/modules/core/instance/index.ts
@@ -1,0 +1,2 @@
+export * from './instance.read.service';
+export * from './instance.write.service';

--- a/app/scripts/modules/core/loadBalancer/index.ts
+++ b/app/scripts/modules/core/loadBalancer/index.ts
@@ -1,0 +1,2 @@
+export * from './loadBalancer.read.service';
+export * from './loadBalancer.write.service';

--- a/app/scripts/modules/core/modal/index.ts
+++ b/app/scripts/modules/core/modal/index.ts
@@ -1,0 +1,3 @@
+export * from './buttons/SubmitButton';
+export { V2_MODAL_WIZARD_COMPONENT, V2ModalWizard } from './wizard/v2modalWizard.component';
+export { WizardPage, V2_MODAL_WIZARD_SERVICE, V2ModalWizardService, WizardPageState } from './wizard/v2modalWizard.service';

--- a/app/scripts/modules/core/naming/index.ts
+++ b/app/scripts/modules/core/naming/index.ts
@@ -1,0 +1,1 @@
+export * from './naming.service';

--- a/app/scripts/modules/core/navigation/index.ts
+++ b/app/scripts/modules/core/navigation/index.ts
@@ -1,0 +1,2 @@
+export * from './state.provider';
+export * from './urlBuilder.service'

--- a/app/scripts/modules/core/network/index.ts
+++ b/app/scripts/modules/core/network/index.ts
@@ -1,0 +1,1 @@
+export * from './network.read.service';

--- a/app/scripts/modules/core/orchestratedItem/index.ts
+++ b/app/scripts/modules/core/orchestratedItem/index.ts
@@ -1,0 +1,1 @@
+export * from './orchestratedItem.transformer';

--- a/app/scripts/modules/core/overrideRegistry/index.ts
+++ b/app/scripts/modules/core/overrideRegistry/index.ts
@@ -1,0 +1,1 @@
+export * from './override.registry';

--- a/app/scripts/modules/core/pageTitle/index.ts
+++ b/app/scripts/modules/core/pageTitle/index.ts
@@ -1,0 +1,1 @@
+export * from './pageTitle.service';

--- a/app/scripts/modules/core/pipeline/config/stages/templates/index.ts
+++ b/app/scripts/modules/core/pipeline/config/stages/templates/index.ts
@@ -1,0 +1,5 @@
+export const destroyAsgExecutionDetailsTemplate = require('core/pipeline/config/stages/destroyAsg/templates/destroyAsgExecutionDetails.template.html');
+export const disableAsgExecutionDetailsTemplate = require('core/pipeline/config/stages/disableAsg/templates/disableAsgExecutionDetails.template.html');
+export const enableAsgExecutionDetailsTemplate = require('core/pipeline/config/stages/enableAsg/templates/enableAsgExecutionDetails.template.html');
+export const shrinkClusterExecutionDetailsTemplate = require('core/pipeline/config/stages/shrinkCluster/templates/shrinkClusterExecutionDetails.template.html');
+export const addExtendedAttributesTemplate = require('core/pipeline/config/stages/bake/modal/addExtendedAttribute.html');

--- a/app/scripts/modules/core/pipeline/index.ts
+++ b/app/scripts/modules/core/pipeline/index.ts
@@ -1,0 +1,6 @@
+export * from './config/stages/bake/BakeExecutionLabel';
+export * from './config/stages/bake/bakery.service';
+export * from './config/stages/stageConstants';
+export * from './config/pipelineConfigProvider';
+export * from './config/stages/templates';
+export * from './config/services/pipelineConfig.service';

--- a/app/scripts/modules/core/presentation/LabelComponent.tsx
+++ b/app/scripts/modules/core/presentation/LabelComponent.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import {IStage} from 'core/domain/IStage';
+import {IStage} from 'core/domain';
 
 interface ILabelComponentProps {
   stage: IStage;

--- a/app/scripts/modules/core/presentation/index.ts
+++ b/app/scripts/modules/core/presentation/index.ts
@@ -1,0 +1,3 @@
+export * from './HoverablePopover';
+export * from './Tooltip';
+export * from './LabelComponent';

--- a/app/scripts/modules/core/retry/index.ts
+++ b/app/scripts/modules/core/retry/index.ts
@@ -1,0 +1,1 @@
+export * from './retry.service';

--- a/app/scripts/modules/core/scheduler/index.ts
+++ b/app/scripts/modules/core/scheduler/index.ts
@@ -1,0 +1,1 @@
+export * from './scheduler.factory';

--- a/app/scripts/modules/core/search/index.ts
+++ b/app/scripts/modules/core/search/index.ts
@@ -1,0 +1,3 @@
+export * from './search.service';
+export * from './infrastructure/infrastructureSearch.service';
+export * from './searchResult/searchResultFormatter.registry';

--- a/app/scripts/modules/core/securityGroup/index.ts
+++ b/app/scripts/modules/core/securityGroup/index.ts
@@ -1,0 +1,2 @@
+export * from './securityGroupReader.service';
+export * from './securityGroupWriter.service';

--- a/app/scripts/modules/core/serverGroup/index.ts
+++ b/app/scripts/modules/core/serverGroup/index.ts
@@ -1,0 +1,8 @@
+export * from './serverGroupReader.service';
+export * from './serverGroupWriter.service';
+export * from './details/serverGroupWarningMessage.service';
+export * from './metrics/cloudMetrics.read.service';
+export * from './configure/common/serverGroupCommandBuilder.service';
+export * from './configure/common/serverGroupCommandRegistry.provider';
+
+export const userDataTemplate = require('./details/userData.html');

--- a/app/scripts/modules/core/serviceAccount/index.ts
+++ b/app/scripts/modules/core/serviceAccount/index.ts
@@ -1,0 +1,1 @@
+export * from './serviceAccount.service';

--- a/app/scripts/modules/core/subnet/index.ts
+++ b/app/scripts/modules/core/subnet/index.ts
@@ -1,0 +1,1 @@
+export * from './subnet.read.service';

--- a/app/scripts/modules/core/subnet/subnet.read.service.spec.ts
+++ b/app/scripts/modules/core/subnet/subnet.read.service.spec.ts
@@ -1,7 +1,8 @@
 import {mock} from 'angular';
 
 import {API_SERVICE, Api} from 'core/api/api.service';
-import {SUBNET_READ_SERVICE, SubnetReader, ISubnet} from 'core/subnet/subnet.read.service';
+import {SUBNET_READ_SERVICE, SubnetReader} from 'core/subnet/subnet.read.service';
+import {ISubnet} from 'core/domain';
 
 describe('subnetReader', function() {
 

--- a/app/scripts/modules/core/subnet/subnet.read.service.ts
+++ b/app/scripts/modules/core/subnet/subnet.read.service.ts
@@ -1,17 +1,7 @@
 import {module} from 'angular';
 import {INFRASTRUCTURE_CACHE_SERVICE, InfrastructureCacheService} from 'core/cache/infrastructureCaches.service';
 import {API_SERVICE, Api} from 'core/api/api.service';
-
-export interface ISubnet {
-  id: string;
-  name: string;
-  account: string;
-  region: string;
-  type: string;
-  label: string;
-  purpose: string;
-  deprecated: boolean;
-}
+import { ISubnet } from 'core/domain';
 
 export class SubnetReader {
 

--- a/app/scripts/modules/core/task/index.ts
+++ b/app/scripts/modules/core/task/index.ts
@@ -1,0 +1,3 @@
+export * from './taskExecutor';
+export * from './task.read.service';
+export * from './monitor/taskMonitor.builder';

--- a/app/scripts/modules/core/utils/index.ts
+++ b/app/scripts/modules/core/utils/index.ts
@@ -1,0 +1,7 @@
+export * from './uuid.service';
+export * from './scrollTo/scrollTo.service';
+export * from './timeFormatters';
+export * from './json/json.utility.service';
+export * from './stickyHeader/StickyContainer';
+export * from './stickyHeader/Sticky';
+export * from './tsDecorators/directiveFactoryDecorator';

--- a/app/scripts/modules/google/loadBalancer/configure/common/commonLoadBalancerCommandBuilder.service.ts
+++ b/app/scripts/modules/google/loadBalancer/configure/common/commonLoadBalancerCommandBuilder.service.ts
@@ -6,7 +6,8 @@ import {
   LOAD_BALANCER_READ_SERVICE, LoadBalancerReader,
   ILoadBalancersByAccount
 } from 'core/loadBalancer/loadBalancer.read.service';
-import {SUBNET_READ_SERVICE, SubnetReader, ISubnet} from 'core/subnet/subnet.read.service';
+import {ISubnet} from 'core/domain';
+import {SUBNET_READ_SERVICE, SubnetReader} from 'core/subnet/subnet.read.service';
 import {GCE_HEALTH_CHECK_READER, GceHealthCheckReader} from 'google/healthCheck/healthCheck.read.service';
 import {INetwork} from 'core/network/network.read.service';
 import {IGceHealthCheck} from 'google/domain/healthCheck';


### PR DESCRIPTION
Not too exciting. I went through the app and found references to core that can be exposed in a common index.ts file.

The structure I'm going with not deep: just an index.ts file in the module directory, rolled up in an index.ts file in the root of the core directory.

Next PR will replace all `import {} from 'core/...'` with `import {} from 'core'`, or something similar...