### PR TITLE
refactor(core): make stage execution handling pluggable

### DIFF
--- a/app/scripts/modules/core/src/delivery/manualExecution/manualPipelineExecution.controller.js
+++ b/app/scripts/modules/core/src/delivery/manualExecution/manualPipelineExecution.controller.js
@@ -117,7 +117,8 @@ module.exports = angular.module('spinnaker.core.delivery.manualPipelineExecution
       addTriggers();
       this.triggerUpdated();
 
-      this.showRebakeOption = pipeline.stages.some((stage) => stage.type === 'bake');
+      const additionalTemplates = pipeline.stages.map(stage => pipelineConfig.getManualExecutionHandlerForStage(stage));
+      this.stageTemplates = _.uniq(_.compact(additionalTemplates));
 
       if (pipeline.parameterConfig && pipeline.parameterConfig.length) {
         this.parameters = {};

--- a/app/scripts/modules/core/src/delivery/manualExecution/manualPipelineExecution.controller.spec.js
+++ b/app/scripts/modules/core/src/delivery/manualExecution/manualPipelineExecution.controller.spec.js
@@ -59,29 +59,6 @@ describe('Controller: ManualPipelineExecution', function () {
         expect(this.ctrl.currentlyRunningExecutions).toEqual([application.executions.data[1]]);
       });
 
-      it('sets showRebakeOption if any stage is a bake stage', function () {
-        let application = {
-          pipelineConfigs: { data: [
-            {
-              id: 'a',
-              triggers: [],
-              stages: [ {type: 'not-a-bake'}, {type: 'also-not-a-bake'}]
-            },
-            {
-              id: 'b',
-              triggers: [],
-              stages: [ {type: 'not-a-bake'}, {type: 'bake'}]
-            },
-          ]},
-          executions: { data: []}
-        };
-
-        this.initializeController(application, application.pipelineConfigs.data[0]);
-        expect(this.ctrl.showRebakeOption).toBe(false);
-        this.initializeController(application, application.pipelineConfigs.data[1]);
-        expect(this.ctrl.showRebakeOption).toBe(true);
-      });
-
       it('sets parameters if present', function () {
         let application = {
           pipelineConfigs: { data: [

--- a/app/scripts/modules/core/src/delivery/manualExecution/manualPipelineExecution.html
+++ b/app/scripts/modules/core/src/delivery/manualExecution/manualPipelineExecution.html
@@ -6,7 +6,7 @@
     <h3 ng-if="vm.command.pipeline && !vm.triggers.length">Confirm Execution</h3>
     <h3 ng-if="!vm.command.pipeline">Select Pipeline</h3>
   </div>
-  <form role="form">
+  <ng-form name="manualExecutionForm">
     <div class="modal-body container-fluid form-horizontal">
       <div class="form-group" ng-if="vm.pipelineOptions">
         <label class="col-md-4 sm-label-right">Pipeline</label>
@@ -65,17 +65,6 @@
         <div ng-include="vm.triggerTemplate"></div>
       </div>
 
-      <div class="form-group" ng-if="vm.showRebakeOption">
-        <label class="col-md-4 sm-label-right">Rebake</label>
-        <div class="checkbox col-md-6">
-          <label>
-            <input type="checkbox" ng-model="vm.command.trigger.rebake"/>
-            Force Rebake
-          </label>
-          <help-field key="execution.forceRebake"></help-field>
-        </div>
-      </div>
-
       <div ng-if="vm.command.pipeline.parameterConfig !== undefined && vm.command.pipeline.parameterConfig.length">
         <p class="manual-execution-parameters-description">This pipeline is parameterized. Please enter values for the parameters below.</p>
         <div class="form-group" ng-repeat="parameter in vm.command.pipeline.parameterConfig">
@@ -101,27 +90,8 @@
         </div>
       </div>
 
-      <div ng-if="vm.hasStageOf('createProperty')">
-
-        <p class="manual-execution-parameters-description">This pipeline contains <b>Persisted Property Stages</b>. Please enter the properties and values for each stage below.</p>
-
-        <div ng-repeat="stage in vm.getStagesOf('createProperty')">
-          <h4>Stage: {{stage.name}}</h4>
-          <p><b>Scope:</b> {{stage.scope | inlinePropertyScope}}</p>
-
-          <label>
-            Enable Rollback <help-field key="pipeline.config.fastProperty.rollback"></help-field>
-            <input
-              type="checkbox"
-              style="margin-top: 10px; margin-left: 10px;"
-              ng-model="stage.rollbackProperties" >
-          </label>
-
-          <persisted-property-create-list
-            stage="stage"
-            property-list="stage.persistedProperties">
-          </persisted-property-create-list>
-        </div>
+      <div ng-repeat="template in vm.stageTemplates">
+        <div ng-include="template"></div>
       </div>
 
       <div class="form-group">
@@ -150,10 +120,10 @@
       <button type="button" class="btn btn-default" ng-click="vm.cancel()">Cancel</button>
       <button type="submit"
               class="btn btn-primary"
-              ng-disabled="!vm.command.pipeline"
+              ng-disabled="!vm.command.pipeline || !manualExecutionForm.$valid"
               ng-click="vm.execute()">
         <span class="glyphicon glyphicon-play"></span> Run
       </button>
     </div>
-  </form>
+  </ng-form>
 </div>

--- a/app/scripts/modules/core/src/domain/IStageOrTriggerTypeConfig.ts
+++ b/app/scripts/modules/core/src/domain/IStageOrTriggerTypeConfig.ts
@@ -1,6 +1,7 @@
 import { IValidatorConfig } from '../pipeline/config/validation/pipelineConfig.validator';
 
 export interface IStageOrTriggerTypeConfig {
+  manualExecutionHandler?: string;
   label: string;
   description: string;
   key: string;

--- a/app/scripts/modules/core/src/domain/ITriggerTypeConfig.ts
+++ b/app/scripts/modules/core/src/domain/ITriggerTypeConfig.ts
@@ -1,5 +1,5 @@
 import { IStageOrTriggerTypeConfig } from './IStageOrTriggerTypeConfig';
 
 export interface ITriggerTypeConfig extends IStageOrTriggerTypeConfig {
-  manualExecutionHandler?: string;
+  // surely something will want to go in here
 }

--- a/app/scripts/modules/core/src/pipeline/config/pipelineConfigProvider.spec.ts
+++ b/app/scripts/modules/core/src/pipeline/config/pipelineConfigProvider.spec.ts
@@ -63,11 +63,11 @@ describe('pipelineConfigProvider: API', function() {
       expect(map(providers, 'nameToCheckInTest').sort()).toEqual(['a', 'b']);
     }));
 
-    it('augments provider stages with parent keys, labels, and descriptions', mock.inject(function() {
-      const baseStage = {key: 'c', useBaseProvider: true, description: 'c description', label: 'the c'},
-          augmentedA = {key: 'd', provides: 'c', description: 'c description', label: 'the c'} as any,
-          augmentedB = {key: 'e', provides: 'c', description: 'c description', label: 'the c'},
-          augmentedC = {key: 'c', provides: 'c', description: 'c description', label: 'the c'};
+    it('augments provider stages with parent keys, labels, manualExecutionHandlers, and descriptions', mock.inject(function() {
+      const baseStage = {key: 'c', useBaseProvider: true, description: 'c description', label: 'the c', manualExecutionHandler: 'a'},
+          augmentedA = {key: 'd', provides: 'c', description: 'c description', label: 'the c', manualExecutionHandler: 'a'} as any,
+          augmentedB = {key: 'e', provides: 'c', description: 'c description', label: 'the c', manualExecutionHandler: 'a'},
+          augmentedC = {key: 'c', provides: 'c', description: 'c description', label: 'the c', manualExecutionHandler: 'a'};
       configurer.registerStage(baseStage as IStageTypeConfig);
       configurer.registerStage({key: 'd', provides: 'c'} as IStageTypeConfig);
       configurer.registerStage({key: 'e', provides: 'c'} as IStageTypeConfig);
@@ -77,14 +77,14 @@ describe('pipelineConfigProvider: API', function() {
       expect(service.getStageConfig({type: 'd'} as any)).toEqual(augmentedA);
     }));
 
-    it('allows provider stages to override of label, description', mock.inject(function() {
-      configurer.registerStage({key: 'a', useBaseProvider: true, description: 'a1', label: 'aa'} as IStageTypeConfig);
-      configurer.registerStage({key: 'b', provides: 'a', description: 'b1', label: 'bb'} as IStageTypeConfig);
+    it('allows provider stages to override of label, description, manualExecutionHandler', mock.inject(function() {
+      configurer.registerStage({key: 'a', useBaseProvider: true, description: 'a1', label: 'aa', manualExecutionHandler: 'a'} as IStageTypeConfig);
+      configurer.registerStage({key: 'b', provides: 'a', description: 'b1', label: 'bb', manualExecutionHandler: 'b'} as IStageTypeConfig);
       configurer.registerStage({key: 'c', provides: 'a'} as IStageTypeConfig);
       expect(service.getStageTypes() as any[]).toEqual([
-        {key: 'a', useBaseProvider: true, description: 'a1', label: 'aa'},
-        {key: 'b', provides: 'a', description: 'b1', label: 'bb'},
-        {key: 'c', provides: 'a', description: 'a1', label: 'aa'}
+        {key: 'a', useBaseProvider: true, description: 'a1', label: 'aa', manualExecutionHandler: 'a'},
+        {key: 'b', provides: 'a', description: 'b1', label: 'bb', manualExecutionHandler: 'b'},
+        {key: 'c', provides: 'a', description: 'a1', label: 'aa', manualExecutionHandler: 'a'}
       ]);
     }));
 

--- a/app/scripts/modules/core/src/pipeline/config/stages/bake/bakeExecutionHandler.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/bake/bakeExecutionHandler.html
@@ -1,0 +1,10 @@
+<div class="form-group">
+  <label class="col-md-4 sm-label-right">Rebake</label>
+  <div class="checkbox col-md-6">
+    <label>
+      <input type="checkbox" ng-model="vm.command.trigger.rebake"/>
+      Force Rebake
+    </label>
+    <help-field key="execution.forceRebake"></help-field>
+  </div>
+</div>

--- a/app/scripts/modules/core/src/pipeline/config/stages/bake/bakeStage.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/bake/bakeStage.js
@@ -16,6 +16,7 @@ module.exports = angular
       description: 'Bakes an image in the specified region',
       key: 'bake',
       restartable: true,
+      manualExecutionHandler: require('./bakeExecutionHandler.html'),
     });
   })
   .run(function(pipelineConfig, bakeStageTransformer) {

--- a/app/scripts/modules/core/src/pipeline/config/triggers/jenkins/jenkinsTriggerOptions.directive.html
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/jenkins/jenkinsTriggerOptions.directive.html
@@ -1,4 +1,6 @@
 <div class="form-group">
+  <!-- Prevents form from being submitted before builds have had a chance to load -->
+  <input type="hidden" required ng-model="vm.viewState.selectedBuild" ng-if="vm.viewState.buildsLoading"/>
   <label class="col-md-4 sm-label-right">Build</label>
   <div class="col-md-6" ng-if="vm.viewState.buildsLoading">
     <p class="form-control-static text-center" >

--- a/app/scripts/modules/netflix/pipeline/stage/properties/create/property.component.html
+++ b/app/scripts/modules/netflix/pipeline/stage/properties/create/property.component.html
@@ -43,6 +43,7 @@
       type="text"
       rows="{{propertyCtrl.getValueRowCount(propertyCtrl.property.value)}}"
       required
+      placeholder="required"
       ng-model="propertyCtrl.property.value"
       class="form-control input-sm">
     </textarea>
@@ -54,6 +55,7 @@
       type="text"
       rows="{{propertyCtrl.getValueRowCount(propertyCtrl.property.description)}}"
       required
+      placeholder="required"
       ng-model="propertyCtrl.property.description"
       class="form-control input-sm">
     </textarea>

--- a/app/scripts/modules/netflix/pipeline/stage/properties/create/propertyExecutionHandler.html
+++ b/app/scripts/modules/netflix/pipeline/stage/properties/create/propertyExecutionHandler.html
@@ -1,0 +1,19 @@
+<p class="manual-execution-parameters-description">This pipeline contains <b>Persisted Property Stages</b>. Please enter the properties and values for each stage below.</p>
+
+<div ng-repeat="stage in vm.getStagesOf('createProperty')">
+  <h4>Stage: {{stage.name}}</h4>
+  <p><b>Scope:</b> {{stage.scope | inlinePropertyScope}}</p>
+
+  <label>
+    Enable Rollback <help-field key="pipeline.config.fastProperty.rollback"></help-field>
+    <input
+      type="checkbox"
+      style="margin-top: 10px; margin-left: 10px;"
+      ng-model="stage.rollbackProperties" >
+  </label>
+
+  <persisted-property-create-list
+    stage="stage"
+    property-list="stage.persistedProperties">
+  </persisted-property-create-list>
+</div>

--- a/app/scripts/modules/netflix/pipeline/stage/properties/create/propertyStage.js
+++ b/app/scripts/modules/netflix/pipeline/stage/properties/create/propertyStage.js
@@ -29,6 +29,7 @@ module.exports = angular.module('spinnaker.netflix.pipeline.stage.propertyStage'
         validators: [
           { type: 'requiredField', fieldName: 'email' },
         ],
+        manualExecutionHandler: require('./propertyExecutionHandler.html'),
       });
     }
   })


### PR DESCRIPTION
Just templates, they're just templates.

But they can prevent form submission by marking fields as `required`.

Also preventing a manual execution with a Jenkins trigger if no build has been selected.

I believe this is the last bit of netflix-specific code in core...