### PR TITLE
fix(history): ignore undefined params when replacing history entry

### DIFF
--- a/app/scripts/modules/core/src/history/recentHistory.service.spec.ts
+++ b/app/scripts/modules/core/src/history/recentHistory.service.spec.ts
@@ -59,9 +59,9 @@ describe('recent history service', () => {
       expect(ids).toEqual(['new item', 0, 1, 2, 3]);
     });
 
-    it('removes previous entry and adds replacement if params match', () => {
+    it('removes previous entry and adds replacement if params match, ignoring undefined values', () => {
       initializeCache(3);
-      service.addItem('whatever', 'state', {id: 1});
+      service.addItem('whatever', 'state', {id: 1, someUndefinedValue: undefined});
       const ids = service.getItems('whatever').map((item) => { return item.params.id; });
       expect(ids).toEqual([1, 0, 2]);
     });

--- a/app/scripts/modules/core/src/history/recentHistory.service.ts
+++ b/app/scripts/modules/core/src/history/recentHistory.service.ts
@@ -1,6 +1,6 @@
 import { module } from 'angular';
 import * as moment from 'moment';
-import { omit, sortBy, find } from 'lodash';
+import { omit, omitBy, isUndefined, sortBy, find } from 'lodash';
 
 import { UUIDGenerator } from 'core/utils/uuid.service';
 import { DECK_CACHE_SERVICE, ICache, DeckCacheService } from 'core/cache/deckCache.service';
@@ -124,7 +124,7 @@ export class RecentHistoryService {
 
   private getExisting(items: IRecentHistoryEntry[], params: any, keyParams: string[]): IRecentHistoryEntry {
     if (!keyParams || !keyParams.length) {
-      return find(items, { params: params });
+      return find(items, { params: omitBy(params, isUndefined) });
     }
     return items.find(item => keyParams.every(p => item.params[p] === params[p]));
   }


### PR DESCRIPTION
Fixes a minor regression with the ui-router 1 upgrade.

ui-router now includes all parameters, including absent (i.e. undefined) ones, in the state change event parameters. angular-cache will not store undefined keys, so when we get them out of the cache, they're just not there, and the `find` call from lodash doesn't match, since it does consider those `undefined` values.

The simple solution is to omit the undefined keys.