### PR TITLE
feat(provider/oraclebmcs): Implement security groups for Oracle BMCS

### DIFF
--- a/app/scripts/modules/oracle/oraclebmcs.module.js
+++ b/app/scripts/modules/oracle/oraclebmcs.module.js
@@ -31,6 +31,10 @@ module.exports = angular.module('spinnaker.oraclebmcs', [
   require('./image/image.reader.js'),
   // Instances
   require('./instance/details/instance.details.controller.js'),
+  // Security Groups
+  require('./securityGroup/securityGroup.reader.js'),
+  require('./securityGroup/securityGroup.transformer.js'),
+  require('./securityGroup/configure/createSecurityGroup.controller.js'),
 ])
   .config(function (cloudProviderRegistryProvider) {
     cloudProviderRegistryProvider.registerProvider('oraclebmcs', {
@@ -57,6 +61,10 @@ module.exports = angular.module('spinnaker.oraclebmcs', [
         detailsTemplateUrl: require('./instance/details/instanceDetails.html')
       },
       securityGroup: {
+        reader: 'oraclebmcsSecurityGroupReader',
+        transformer: 'oraclebmcsSecurityGroupTransformer',
+        createSecurityGroupTemplateUrl: require('./securityGroup/configure/createSecurityGroup.html'),
+        createSecurityGroupController: 'oraclebmcsCreateSecurityGroupCtrl'
       }
     });
   });

--- a/app/scripts/modules/oracle/securityGroup/configure/configSecurityGroup.mixin.controller.js
+++ b/app/scripts/modules/oracle/securityGroup/configure/configSecurityGroup.mixin.controller.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const angular = require('angular');
+
+import {
+  ACCOUNT_SERVICE,
+  SECURITY_GROUP_WRITER,
+  SECURITY_GROUP_READER,
+  V2_MODAL_WIZARD_SERVICE,
+} from '@spinnaker/core';
+
+module.exports = angular
+  .module('spinnaker.oraclebmcs.securityGroup.baseConfig.controller', [
+    SECURITY_GROUP_WRITER,
+    SECURITY_GROUP_READER,
+    ACCOUNT_SERVICE,
+    V2_MODAL_WIZARD_SERVICE,
+    require('angular-ui-router').default,
+  ])
+  .controller('oraclebmcsConfigSecurityGroupMixin', function ($scope,
+                                                              $state,
+                                                              $uibModalInstance,
+                                                              taskMonitorService,
+                                                              application,
+                                                              securityGroup,
+                                                              securityGroupReader,
+                                                              securityGroupWriter,
+                                                              accountService,
+                                                              v2modalWizardService) {
+
+    $scope.wizard = v2modalWizardService;
+
+    this.initializeSecurityGroups = () => {
+      return $scope.state.securityGroupsLoaded = true;
+    };
+
+    this.cancel = () => {
+      $uibModalInstance.dismiss();
+    };
+  });

--- a/app/scripts/modules/oracle/securityGroup/configure/createSecurityGroup.controller.js
+++ b/app/scripts/modules/oracle/securityGroup/configure/createSecurityGroup.controller.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const angular = require('angular');
+
+import {
+  INFRASTRUCTURE_CACHE_SERVICE,
+  CACHE_INITIALIZER_SERVICE,
+} from '@spinnaker/core';
+
+module.exports = angular.module('spinnaker.oraclebmcs.securityGroup.create.controller', [
+  INFRASTRUCTURE_CACHE_SERVICE,
+  CACHE_INITIALIZER_SERVICE,
+  require('angular-ui-router').default,
+  require('./configSecurityGroup.mixin.controller.js'),
+])
+  .controller('oraclebmcsCreateSecurityGroupCtrl', function ($scope, $uibModalInstance, $state, $controller,
+                                                             cacheInitializer, infrastructureCaches,
+                                                             application, securityGroup) {
+
+    angular.extend(this, $controller('oraclebmcsConfigSecurityGroupMixin', {
+      $scope: $scope,
+      $uibModalInstance: $uibModalInstance,
+      application: application,
+      securityGroup: securityGroup
+    }));
+  });

--- a/app/scripts/modules/oracle/securityGroup/configure/createSecurityGroup.html
+++ b/app/scripts/modules/oracle/securityGroup/configure/createSecurityGroup.html
@@ -1,0 +1,16 @@
+<ng-form role="form" name="form" novalidate>
+  <v2-modal-wizard heading="Create New Oracle BMC Security Group" dismiss="$dismiss()">
+    <div class="container-fluid form-horizontal">
+      <div class="modal-body">
+        <div class="col-md-12 well">
+          <h5>Create Security Group</h5>
+          <p>We don't currently support the ability to create security groups through the Spinnaker UI for Oracle Bare Metal.</p>
+          <p>You can use the Oracle Bare Metal console to create and manage your Security Groups.</p>
+        </div>
+      </div>
+    </div>
+  </v2-modal-wizard>
+  <div class="modal-footer">
+    <button class="btn btn-default" ng-click="ctrl.cancel()">Cancel</button>
+  </div>
+</ng-form>

--- a/app/scripts/modules/oracle/securityGroup/securityGroup.reader.js
+++ b/app/scripts/modules/oracle/securityGroup/securityGroup.reader.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const angular = require('angular');
+
+module.exports = angular.module('spinnaker.oraclebmcs.securityGroup.reader', [
+])
+  .factory('oraclebmcsSecurityGroupReader', function () {
+
+    function resolveIndexedSecurityGroup(indexedSecurityGroups, container, securityGroupId) {
+      return indexedSecurityGroups[container.account][container.region][securityGroupId];
+    }
+
+    return {
+      resolveIndexedSecurityGroup: resolveIndexedSecurityGroup,
+    };
+  });

--- a/app/scripts/modules/oracle/securityGroup/securityGroup.transformer.js
+++ b/app/scripts/modules/oracle/securityGroup/securityGroup.transformer.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const angular = require('angular');
+
+import {
+  NETWORK_READ_SERVICE
+} from '@spinnaker/core';
+
+import _ from 'lodash';
+
+module.exports = angular.module('spinnaker.oraclebmcs.securityGroup.transformer', [
+  NETWORK_READ_SERVICE
+])
+  .factory('oraclebmcsSecurityGroupTransformer', function (networkReader) {
+
+    const provider = 'oraclebmcs';
+
+    function normalizeSecurityGroup(securityGroup) {
+      return networkReader.listNetworksByProvider(provider)
+        .then(_.partial(addVcnNameToSecurityGroup, securityGroup));
+    }
+
+    function addVcnNameToSecurityGroup(securityGroup, vcns) {
+      const matches = vcns.find(vcn => vcn.id === securityGroup.network);
+      securityGroup.vpcName = matches.length ? matches[0].name : '';
+    }
+
+    return {
+      normalizeSecurityGroup: normalizeSecurityGroup
+    };
+  });


### PR DESCRIPTION
Adds security groups for Oracle Bare Metal Cloud provider.

We decided against allowing the creation of security groups through the UI due to some complexity in how they are implemented in Bare Metal. 

![screen shot 2017-05-19 at 14 50 09](https://cloud.githubusercontent.com/assets/733944/26251607/c01d42ce-3ca5-11e7-8242-5fdd43e9ed15.png)

![screen shot 2017-05-19 at 14 50 04](https://cloud.githubusercontent.com/assets/733944/26251613/c589ce3a-3ca5-11e7-8fa7-e9066fd4260d.png)

