### PR TITLE
fix(kubernetes/runJob): Remove check for enabled on Run Job trigger option

### DIFF
--- a/app/scripts/modules/kubernetes/pipeline/stages/runJob/runJobStage.js
+++ b/app/scripts/modules/kubernetes/pipeline/stages/runJob/runJobStage.js
@@ -88,7 +88,7 @@ module.exports = angular.module('spinnaker.kubernetes.pipeline.stage.runJobStage
       }
 
       return this.pipeline.triggers.filter((trigger) => {
-        return trigger.type === 'docker' && trigger.enabled === true;
+        return trigger.type === 'docker';
       }).map((trigger) => {
         return buildImageDescriptor(trigger);
       });


### PR DESCRIPTION
When I put this in at first, I didn't account for all scenarios. It
works for triggers that are always enabled. To support "one click
deployment" scenarios where you trigger a manual execution, then select
an image you wouldn't see the trigger show up in the list of available
triggers. By removing the check, you can select any trigger you define
and use that. If that trigger is used automatically or manually is
outside the scope of this feature.

ping @danielpeach 
