### PR TITLE
fix(aws): restore $onInit to ingress security group selector

### DIFF
--- a/app/scripts/modules/amazon/src/securityGroup/configure/ingressRuleGroupSelector.component.ts
+++ b/app/scripts/modules/amazon/src/securityGroup/configure/ingressRuleGroupSelector.component.ts
@@ -73,6 +73,10 @@ class IngressRuleSelectorController implements IComponentController {
     this.rule.vpcId = undefined;
   };
 
+  public $onInit(): void {
+    this.setAvailableSecurityGroups();
+  }
+
   public $onDestroy() {
     this.coordinatesChanged.unsubscribe();
     this.allSecurityGroupsUpdated.unsubscribe();


### PR DESCRIPTION
Kind of important to initialize the component.