### PR TITLE
fix(provider/kubernetes): fixes bug with edit server group dialog delays

### DIFF
--- a/app/scripts/modules/kubernetes/serverGroup/configure/configuration.service.js
+++ b/app/scripts/modules/kubernetes/serverGroup/configure/configuration.service.js
@@ -17,8 +17,15 @@ module.exports = angular.module('spinnaker.serverGroup.configure.kubernetes.conf
 
       // this ensures we get the images we need when cloning or copying a server group template.
       let queries = command.containers
-        .map(c => grabImageAndTag(c.imageDescription.imageId));
-
+         .filter(c => {
+          return !c.imageDescription.fromContext;
+         })
+        .map(c => {
+          if (c.imageDescription.fromTrigger) {
+            return c.imageDescription.repository;
+          } else {
+            return grabImageAndTag(c.imageDescription.imageId);
+          }});
       if (query) {
         queries.push(query);
       }


### PR DESCRIPTION
When the pipeline has a docker registry trigger the value of c.imageDescription.imageId contains the (Tag resolved at runtime) from the trigger. This causes calls to the find image api to return [] and the calls are set up to run 10 times until a non empty result set is returned. These repeated calls to find image delay the dialog opening and the user is stuck watching a spinner for 10-20s. By switching to using c.imageDescription.repository, the find image calls return actual results and the dialog opens immediately.

https://spinnakerteam.slack.com/archives/C2W6RE0N4/p1495225548313863