### PR TITLE
refactor(core): flatten select2, misc lib build fixes

### DIFF
--- a/app/scripts/modules/core/src/core.module.js
+++ b/app/scripts/modules/core/src/core.module.js
@@ -9,13 +9,14 @@ import 'bootstrap/dist/js/bootstrap.js';
 
 import 'font-awesome/css/font-awesome.css';
 import 'react-select/dist/react-select.css';
-import 'Select2';
-import 'select2-bootstrap-css/select2-bootstrap.css';
-import 'Select2/select2.css';
+import 'ui-select/dist/select.css';
+
+// use require instead of import to ensure insertion order is preserved
+require('Select2/select2.css');
+require('select2-bootstrap-css/select2-bootstrap.css');
 
 import 'source-sans-pro';
 import Spinner from 'spin.js';
-import 'ui-select/dist/select.css';
 
 import { ANALYTICS_MODULE } from './analytics/analytics.module';
 import { APPLICATION_BOOTSTRAP_MODULE } from './bootstrap/applicationBootstrap.module';

--- a/app/scripts/modules/core/src/healthCounts/HealthCounts.tsx
+++ b/app/scripts/modules/core/src/healthCounts/HealthCounts.tsx
@@ -8,31 +8,31 @@ import { Tooltip } from 'core/presentation/Tooltip';
 
 import './healthCounts.less';
 
-interface IProps {
+export interface IHealthCountsPros {
   container: IInstanceCounts;
   additionalLegendText?: string;
   legendPlacement?: Placement;
-};
+}
 
-interface IState {
+export interface IHealthCountsState {
   percentLabel: string;
   statusClass: string;
   total: number;
-};
+}
 
 @autoBindMethods
-export class HealthCounts extends React.Component<IProps, IState> {
-  public static defaultProps: Partial<IProps> = {
+export class HealthCounts extends React.Component<IHealthCountsPros, IHealthCountsState> {
+  public static defaultProps: Partial<IHealthCountsPros> = {
     legendPlacement: 'top',
     container: {} as IInstanceCounts
   };
 
-  constructor(props: IProps) {
+  constructor(props: IHealthCountsPros) {
     super(props);
     this.state = this.calculatePercent(props.container);
   }
 
-  private calculatePercent(container: IInstanceCounts): IState {
+  private calculatePercent(container: IInstanceCounts): IHealthCountsState {
     container = container || {} as IInstanceCounts;
 
     const up = container.up || 0,
@@ -53,7 +53,7 @@ export class HealthCounts extends React.Component<IProps, IState> {
     return { percentLabel, statusClass, total };
   }
 
-  public componentWillReceiveProps(nextProps: IProps): void {
+  public componentWillReceiveProps(nextProps: IHealthCountsPros): void {
     if (!isEqual(nextProps.container, this.props.container)) {
       this.setState(this.calculatePercent(nextProps.container));
     }

--- a/app/scripts/modules/core/src/modal/modals.less
+++ b/app/scripts/modules/core/src/modal/modals.less
@@ -210,9 +210,6 @@ select.select2 {
 
 .modal-body {
   .select2-container {
-    .select2-chosen {
-      padding-left: 0;
-    }
     .select2-drop {
       position: fixed;
       top: auto;

--- a/app/scripts/modules/core/src/pipeline/config/templates/Variable.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/templates/Variable.tsx
@@ -7,16 +7,16 @@ import { ReactInjector } from 'core/reactShims';
 
 import './Variable.less';
 
-interface IState { }
+export interface IVariableState { }
 
-interface IProps {
+export interface IVariableProps {
   variableMetadata: IVariableMetadata;
   variable: IVariable;
   onChange: (variable: IVariable) => void;
 }
 
 @autoBindMethods
-export class Variable extends React.Component<IProps, IState> {
+export class Variable extends React.Component<IVariableProps, IVariableState> {
 
   private getVariableInput(): JSX.Element {
     const input: IVariableInputBuilder = ReactInjector.variableInputService.getInputForType(this.props.variableMetadata.type);

--- a/app/scripts/modules/core/src/pipeline/config/templates/VariableError.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/templates/VariableError.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import {IVariableError} from './inputs/variableInput.service'
 
-interface IProps {
+export interface IVariableErrorProps {
   errors: IVariableError[]
 }
 
-interface IState { }
+export interface IVariableErrorState { }
 
-export class VariableError extends React.Component<IProps, IState> {
+export class VariableError extends React.Component<IVariableErrorProps, IVariableErrorState> {
 
   public render() {
     return (

--- a/app/scripts/modules/core/src/pipeline/config/templates/VariableMetadataHelpField.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/templates/VariableMetadataHelpField.tsx
@@ -3,13 +3,13 @@ import * as React from 'react';
 import { NgReact } from 'core/reactShims';
 import { IVariableMetadata } from './pipelineTemplate.service';
 
-interface IProps {
+export interface IVariableMetadataHelpFieldProps {
   metadata: IVariableMetadata
 }
 
-interface IState { }
+export interface IVariableMetadataHelpFieldState { }
 
-export class VariableMetadataHelpField extends React.Component<IProps, IState> {
+export class VariableMetadataHelpField extends React.Component<IVariableMetadataHelpFieldProps, IVariableMetadataHelpFieldState> {
 
    public render() {
      const { HelpField } = NgReact;

--- a/app/scripts/modules/core/src/presentation/main.less
+++ b/app/scripts/modules/core/src/presentation/main.less
@@ -1231,11 +1231,6 @@ ul.select2-results {
       border: 1px solid @unhealthy_red_border;
     }
   }
-  .select2-choice {
-    .select2-chosen {
-      padding-left: 0;
-    }
-  }
 }
 
 .select2-container.input-sm.direction-up {

--- a/app/scripts/modules/core/tsconfig.json
+++ b/app/scripts/modules/core/tsconfig.json
@@ -26,7 +26,7 @@
     "removeComments": false,
     "rootDir": "./src",
     "skipLibCheck": true,
-    "sourceMap": true,
+    "sourceMap": false,
     "strictNullChecks": false, // should really get to a place where we can turn this on
     "target": "es6",
     "typeRoots": [

--- a/app/scripts/modules/core/webpack.config.js
+++ b/app/scripts/modules/core/webpack.config.js
@@ -32,7 +32,7 @@ module.exports = {
     angular: 'angular',
     'jquery-ui': 'jquery-ui',
     'jquery-textcomplete': 'jquery-textcomplete',
-    'angular-ui-sortable': 'angular-ui-sortable',
+    'exports-loader?"ui.sortable"!angular-ui-sortable': 'exports-loader?"ui.sortable"!angular-ui-sortable',
     'angular-spinner': 'angular-spinner',
     'select2-bootstrap-css/select2-bootstrap.css': 'select2-bootstrap-css/select2-bootstrap.css',
     'angulartics-google-analytics': 'angulartics-google-analytics',
@@ -86,11 +86,11 @@ module.exports = {
     ],
     alias: {
       '@spinnaker/core': path.join(__dirname, 'src'),
-      'core': path.join(__dirname, 'src')
+      'core': path.join(__dirname, 'src'),
+      'root': basePath,
     }
   },
   watch:  process.env.WATCH === 'true',
-  devtool: 'source-map',
   module: {
     rules: [
       {enforce: 'pre', test: /\.(spec\.)?tsx?$/, use: 'tslint-loader', exclude: exclusionPattern},
@@ -132,8 +132,8 @@ module.exports = {
     new webpack.optimize.UglifyJsPlugin({
       mangle: false,
       beautify: true,
-      comments: false,
-      sourceMap: true,
+      comments: true,
+      sourceMap: false,
     }),
     new HappyPack({
       id: 'lib-html',


### PR DESCRIPTION
* exporting interfaces on React components
* tweaking select2 CSS loading to ensure order (also removes gradient from the selects to make them more consistent with the rest of the application)
* disabling sourcemap generation, since it fails on library builds and is going to take a lot of work to fix