### PR TITLE
fix(core): assign unique namespaces to waypoint* directives

### DIFF
--- a/app/scripts/modules/core/src/utils/waypoints/waypoint.directive.js
+++ b/app/scripts/modules/core/src/utils/waypoints/waypoint.directive.js
@@ -4,7 +4,7 @@ import { WAYPOINT_SERVICE } from './waypoint.service';
 
 const angular = require('angular');
 
-module.exports = angular.module('spinnaker.core.utils.waypoints.container.directive', [
+module.exports = angular.module('spinnaker.core.utils.waypoints.directive', [
   WAYPOINT_SERVICE
 ])
   .directive('waypoint', function () {

--- a/app/scripts/modules/core/src/utils/waypoints/waypoint.service.ts
+++ b/app/scripts/modules/core/src/utils/waypoints/waypoint.service.ts
@@ -100,4 +100,4 @@ export class WaypointService {
 
 export const WAYPOINT_SERVICE = 'spinnaker.core.utils.waypoints.service';
 module(WAYPOINT_SERVICE, [])
-  .factory('waypointService', () => new WaypointService());
+  .service('waypointService', WaypointService);


### PR DESCRIPTION
`waypointContainer` and `waypoint` directives both declare the same module, clobbering each other, so only one directive is actually available.

If you're wondering how this was working for the past two years, it's because the `waypointContainer` directive was loaded _after_ `waypoint`. A recent refactor (it doesn't matter which one, or who did it, or whether they tested this particular feature) switched that load order, so `waypointContainer` essentially disappeared.

All `waypoint` does is remove its jQuery data, which may not even be necessary, but let's leave it in place.