### PR TITLE
refactor(*): replace glyphicon-asterisk with fa-cog

### DIFF
--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/location/ServerGroupBasicSettings.controller.js
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/location/ServerGroupBasicSettings.controller.js
@@ -20,7 +20,7 @@ module.exports = angular.module('spinnaker.serverGroup.configure.aws.basicSettin
     function searchImages(q) {
       $scope.command.backingData.filtered.images = [
         {
-          message: '<span class="glyphicon glyphicon-spinning glyphicon-asterisk"></span> Finding results matching "' + q + '"...'
+          message: '<span class="fa fa-cog fa-spin"></span> Finding results matching "' + q + '"...'
         }
       ];
       return Observable.fromPromise(

--- a/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/chart/metricAlarmChart.component.html
+++ b/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/chart/metricAlarmChart.component.html
@@ -2,7 +2,7 @@
   <h5 class="text-center">
     <span ng-if="$ctrl.chartData.noData">No data available</span>
     <span ng-if="$ctrl.chartData.loading">
-      <span class="glyphicon glyphicon-asterisk glyphicon-spinning"></span>
+      <span class="fa fa-cog fa-spin"></span>
       loading...
     </span>
   </h5>

--- a/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/upsert/alarm/alarmConfigurer.component.html
+++ b/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/upsert/alarm/alarmConfigurer.component.html
@@ -28,7 +28,7 @@
     </select>
     <span class="input-label" style="vertical-align: top; margin-top: 7px"> of </span>
     <div class="text-center" style="display: inline-block; width: 100px; margin-top: 7px" ng-if="!$ctrl.viewState.metricsLoaded">
-      <span class="glyphicon glyphicon-spinning glyphicon-asterisk"></span>
+      <span class="fa fa-cog fa-spin"></span>
     </div>
     <div style="display: inline-block; width: 500px" ng-if="$ctrl.viewState.metricsLoaded">
       <select class="form-control input-sm"

--- a/app/scripts/modules/core/src/application/applications.html
+++ b/app/scripts/modules/core/src/application/applications.html
@@ -20,7 +20,7 @@
   </div>
   <div class="container">
     <h2 ng-if="!applicationsLoaded" class="text-center" style="margin-bottom: 250px">
-      <span class="glyphicon glyphicon-asterisk glyphicon-spinning"></span>
+      <span class="fa fa-cog fa-3x fa-spin"></span>
     </h2>
     <div class="infrastructure-section">
       <table ng-if="applicationsLoaded" class="table table-hover">

--- a/app/scripts/modules/core/src/application/config/dataSources/applicationDataSourceEditor.component.html
+++ b/app/scripts/modules/core/src/application/config/dataSources/applicationDataSourceEditor.component.html
@@ -21,7 +21,7 @@
         <span class="fa fa-check-circle-o"></span> Save Changes
       </span>
       <span ng-if="$ctrl.saving" class="pulsing">
-        <span class="glyphicon glyphicon-asterisk glyphicon-spinning"></span> Saving&hellip;
+        <span class="fa fa-cog fa-spin"></span> Saving&hellip;
       </span>
     </button>
     <div class="error-message" ng-if="$ctrl.saveError">There was an error saving your changes. Please try again.</div>

--- a/app/scripts/modules/core/src/application/config/dataSources/applicationDataSourceEditor.component.ts
+++ b/app/scripts/modules/core/src/application/config/dataSources/applicationDataSourceEditor.component.ts
@@ -71,8 +71,12 @@ export class DataSourceEditorController implements ng.IComponentController {
     })
       .then(() => {
         this.application.attributes.dataSources = newDataSources;
-        this.explicitlyEnabled.forEach(key => this.application.getDataSource(key).disabled = false);
-        this.explicitlyDisabled.forEach(key => this.application.getDataSource(key).disabled = true);
+        this.explicitlyEnabled
+          .filter(k => this.application.getDataSource(k))
+          .forEach(key => this.application.getDataSource(key).disabled = false);
+        this.explicitlyDisabled
+          .filter(k => this.application.getDataSource(k))
+          .forEach(key => this.application.getDataSource(key).disabled = true);
         this.application.refresh(true);
         this.saving = false;
         this.isDirty = false;

--- a/app/scripts/modules/core/src/application/config/footer/configSectionFooter.component.html
+++ b/app/scripts/modules/core/src/application/config/footer/configSectionFooter.component.html
@@ -12,7 +12,7 @@
                 <span class="fa fa-check-circle-o"></span> Save Changes
               </span>
               <span ng-if="$ctrl.viewState.saving" class="pulsing">
-                <span class="glyphicon glyphicon-asterisk glyphicon-spinning"></span> Saving&hellip;
+                <span class="fa fa-cog fa-spin"></span> Saving&hellip;
               </span>
     </button>
     <div class="error-message" ng-if="$ctrl.viewState.saveError">There was an error saving your changes. Please try again.</div>

--- a/app/scripts/modules/core/src/application/config/trafficGuard/trafficGuardConfig.component.html
+++ b/app/scripts/modules/core/src/application/config/trafficGuard/trafficGuardConfig.component.html
@@ -7,7 +7,7 @@
     </div>
   </div>
   <div class="row" ng-if="$ctrl.initializing">
-    <h4 class="text-center"><span class="glyphicon glyphicon-asterisk glyphicon-spinning"></span></h4>
+    <h4 class="text-center"><span class="fa fa-2x fa-cog fa-spin"></span></h4>
   </div>
   <div class="row" ng-if="!$ctrl.initializing">
     <div class="col-md-10 col-md-offset-1">

--- a/app/scripts/modules/core/src/delivery/executionGroup/ExecutionGroup.tsx
+++ b/app/scripts/modules/core/src/delivery/executionGroup/ExecutionGroup.tsx
@@ -205,7 +205,7 @@ export class ExecutionGroup extends React.Component<IProps, IState> {
                       <h4 style={{visibility: pipelineDisabled ? 'hidden' : 'visible'}}>
                         <a className="btn btn-xs btn-link" onClick={this.handleTriggerClicked}>
                           { this.state.triggeringExecution ?
-                            <span><span className="glyphicon glyphicon-asterisk glyphicon-spinning"/> Starting Manual Execution&hellip;</span> :
+                            <span><span className="fa fa-cog fa-spin"/> Starting Manual Execution&hellip;</span> :
                             <span><span className="glyphicon glyphicon-play"/> Start Manual Execution</span>
                           }
                         </a>

--- a/app/scripts/modules/core/src/delivery/executions/executions.html
+++ b/app/scripts/modules/core/src/delivery/executions/executions.html
@@ -28,8 +28,8 @@
            ng-click="vm.triggerPipeline()"
            ng-disabled="vm.viewState.triggeringExecution">
             <span ng-if="vm.viewState.triggeringExecution" class="pulsing">
-              <span class="glyphicon glyphicon-asterisk glyphicon-spinning visible-md-inline visible-sm-inline" uib-tooltip="Starting Execution"></span>
-              <span class="glyphicon glyphicon-asterisk glyphicon-spinning visible-lg-inline"></span>
+              <span class="fa fa-cog fa-spin visible-md-inline visible-sm-inline" uib-tooltip="Starting Execution"></span>
+              <span class="fa fa-cog fa-spin visible-lg-inline"></span>
               <span class="visible-xl-inline">Starting Execution</span>&hellip;
             </span>
           <span ng-if="!vm.viewState.triggeringExecution">

--- a/app/scripts/modules/core/src/pipeline/config/actions/history/showHistory.modal.html
+++ b/app/scripts/modules/core/src/pipeline/config/actions/history/showHistory.modal.html
@@ -4,7 +4,7 @@
     <h3>Pipeline Revision History</h3>
   </div>
   <div class="modal-body" ng-if="ctrl.state.loading">
-    <h4 class="text-center"><span class="glyphicon glyphicon-asterisk glyphicon-spinning"></span></h4>
+    <h4 class="text-center"><span class="fa fa-cog fa-spin fa-3x"></span></h4>
   </div>
   <div class="modal-body" ng-if="ctrl.state.error">
     <h4 class="text-center">There was an error loading the history for this pipeline.</h4>

--- a/app/scripts/modules/core/src/pipeline/config/actions/rename/renamePipelineModal.html
+++ b/app/scripts/modules/core/src/pipeline/config/actions/rename/renamePipelineModal.html
@@ -40,7 +40,7 @@
             ng-click="renamePipelineModalCtrl.renamePipeline()">
       <span ng-if="!viewState.saving" class="fa fa-check-circle-o"></span>
       <span ng-if="viewState.saving" class="pulsing">
-        <span class="glyphicon glyphicon-asterisk glyphicon-spinning"></span>
+        <span class="fa fa-cog fa-spin"></span>
       </span>
       Rename {{pipeline.strategy === true ? 'Strategy' : 'Pipeline'}}
     </button>

--- a/app/scripts/modules/core/src/pipeline/config/pipelineConfigurer.html
+++ b/app/scripts/modules/core/src/pipeline/config/pipelineConfigurer.html
@@ -139,7 +139,7 @@
             <span class="fa fa-check-circle-o"></span> Save Changes
           </span>
           <span ng-if="viewState.saving" class="pulsing">
-            <span class="glyphicon glyphicon-asterisk glyphicon-spinning"></span> Saving&hellip;
+            <span class="fa fa-cog fa-spin"></span> Saving&hellip;
           </span>
         </button>
         <span ng-if="!pipeline.locked && !viewState.isDirty" class="btn btn-link disabled"><span class="fa fa-check-circle-o"></span> In sync with server</span>

--- a/app/scripts/modules/core/src/pipeline/config/stages/executionWindows/atlasGraph.component.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/executionWindows/atlasGraph.component.ts
@@ -316,7 +316,7 @@ class AtlasGraphComponent implements ng.IComponentOptions {
           <div class="no-data-overlay" ng-if="$ctrl.chartData.loading || $ctrl.chartData.noData">
             <h5 class="text-center">
               <span ng-if="$ctrl.chartData.loading">
-                <span class="glyphicon glyphicon-asterisk glyphicon-spinning"></span>
+                <span class="fa fa-cog fa-spin"></span>
                 loading...
               </span>
             </h5>

--- a/app/scripts/modules/core/src/pipeline/config/stages/jenkins/jenkinsStage.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/jenkins/jenkinsStage.html
@@ -40,7 +40,7 @@
         </ui-select>
       </div>
       <div class="text-center" ng-if="stage.master && !viewState.jobsLoaded">
-        <span class="glyphicon glyphicon-asterisk glyphicon-spinning"></span>
+        <span class="fa fa-cog fa-spin"></span>
       </div>
     </div>
     <div class="col-md-1 text-center" ng-if="!viewState.masterIsParameterized && !viewState.jobIsParameterized">

--- a/app/scripts/modules/core/src/pipeline/config/stages/travis/travisStage.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/travis/travisStage.html
@@ -40,7 +40,7 @@
         </ui-select>
       </div>
       <div class="text-center" ng-if="$ctrl.stage.master && !$ctrl.viewState.jobsLoaded">
-        <span class="glyphicon glyphicon-asterisk glyphicon-spinning"></span>
+        <span class="fa fa-cog fa-spin"></span>
       </div>
     </div>
     <div class="col-md-1 text-center"

--- a/app/scripts/modules/core/src/pipeline/config/triggers/jenkins/jenkinsTrigger.html
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/jenkins/jenkinsTrigger.html
@@ -32,7 +32,7 @@
         </ui-select>
       </div>
       <div class="text-center" ng-if="trigger.master && !viewState.jobsLoaded">
-        <span class="glyphicon glyphicon-asterisk glyphicon-spinning"></span>
+        <span class="fa fa-cog fa-spin"></span>
       </div>
     </div>
     <div class="col-md-1 text-center">

--- a/app/scripts/modules/core/src/pipeline/config/triggers/jenkins/jenkinsTriggerOptions.directive.html
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/jenkins/jenkinsTriggerOptions.directive.html
@@ -4,7 +4,7 @@
   <label class="col-md-4 sm-label-right">Build</label>
   <div class="col-md-6" ng-if="vm.viewState.buildsLoading">
     <p class="form-control-static text-center" >
-      <span class="glyphicon glyphicon-asterisk glyphicon-spinning"></span>
+      <span class="fa fa-cog fa-spin"></span>
     </p>
   </div>
   <div class="col-md-6" ng-if="vm.viewState.loadError">Error loading builds!</div>

--- a/app/scripts/modules/core/src/pipeline/config/triggers/pipeline/pipelineTriggerOptions.directive.html
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/pipeline/pipelineTriggerOptions.directive.html
@@ -2,7 +2,7 @@
   <label class="col-md-4 sm-label-right">Execution</label>
   <div class="col-md-6" ng-if="vm.viewState.executionsLoading">
     <p class="form-control-static text-center" >
-      <span class="glyphicon glyphicon-asterisk glyphicon-spinning"></span>
+      <span class="fa fa-cog fa-spin"></span>
     </p>
   </div>
   <div class="col-md-6" ng-if="vm.viewState.loadError">Error loading executions!</div>

--- a/app/scripts/modules/core/src/pipeline/config/triggers/travis/travisTrigger.html
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/travis/travisTrigger.html
@@ -32,7 +32,7 @@
       </ui-select>
     </div>
     <div class="text-center" ng-if="$ctrl.trigger.master && !$ctrl.viewState.jobsLoaded">
-      <span class="glyphicon glyphicon-asterisk glyphicon-spinning"></span>
+      <span class="fa fa-cog fa-spin"></span>
     </div>
   </div>
   <div class="col-md-1 text-center">

--- a/app/scripts/modules/core/src/pipeline/config/triggers/travis/travisTriggerOptions.component.html
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/travis/travisTriggerOptions.component.html
@@ -2,7 +2,7 @@
   <label class="col-md-4 sm-label-right">Build</label>
   <div class="col-md-6" ng-if="$ctrl.viewState.buildsLoading">
     <p class="form-control-static text-center">
-      <span class="glyphicon glyphicon-asterisk glyphicon-spinning"></span>
+      <span class="fa fa-cog fa-spin"></span>
     </p>
   </div>
   <div class="col-md-6" ng-if="$ctrl.viewState.loadError">Error loading builds!</div>

--- a/app/scripts/modules/core/src/presentation/less/imports/animations.less
+++ b/app/scripts/modules/core/src/presentation/less/imports/animations.less
@@ -60,7 +60,7 @@
 
 .spinning(@duration: 4) {
   transform: translateZ(0);
-  -webkit-animation:spin ~"@{duration}s" steps(15*@duration) infinite;
-  -moz-animation:spin ~"@{duration}s" steps(15*@duration) infinite;
-  animation:spin ~"@{duration}s" steps(15*@duration) infinite;
+  -webkit-animation:spin ~"@{duration}s" steps(30*@duration) infinite;
+  -moz-animation:spin ~"@{duration}s" steps(30*@duration) infinite;
+  animation:spin ~"@{duration}s" steps(30*@duration) infinite;
 }

--- a/app/scripts/modules/core/src/presentation/main.less
+++ b/app/scripts/modules/core/src/presentation/main.less
@@ -1022,6 +1022,11 @@ tfoot .add-new {
   .spinning();
 }
 
+.fa.fa-spin {
+  .spinning();
+  opacity: 0.7;
+}
+
 a.help-field {
   color: @mid_lighter_grey;
   opacity: 0.8;

--- a/app/scripts/modules/core/src/projects/dashboard/dashboard.html
+++ b/app/scripts/modules/core/src/projects/dashboard/dashboard.html
@@ -13,7 +13,7 @@
           cluster="cluster"
           ></project-cluster>
       <div class="text-center" ng-if="!vm.state.clusters.loaded">
-        <span class="glyphicon glyphicon-asterisk glyphicon-spinning"></span>
+        <span class="fa fa-cog fa-spin"></span>
       </div>
       <h4 ng-if="!vm.project.config.clusters.length">No clusters configured</h4>
       <h4 ng-if="vm.state.clusters.error">There was a problem loading the clusters for this project.</h4>
@@ -25,7 +25,7 @@
                              refresh="vm.refreshExecutions()"></component-refresher>
       </h3>
       <div class="text-center" ng-if="!vm.state.executions.loaded">
-        <span class="glyphicon glyphicon-asterisk glyphicon-spinning"></span>
+        <span class="fa fa-cog fa-spin"></span>
       </div>
       <project-pipeline
         ng-repeat="execution in vm.executions"

--- a/app/scripts/modules/core/src/projects/projects.html
+++ b/app/scripts/modules/core/src/projects/projects.html
@@ -20,7 +20,7 @@
   </div>
   <div class="container">
     <h2 ng-if="!projectsLoaded" class="text-center" style="margin-bottom: 250px">
-      <span class="glyphicon glyphicon-asterisk glyphicon-spinning"></span>
+      <span class="fa fa-cog fa-spin"></span>
     </h2>
     <table ng-if="projectsLoaded" class="table table-hover">
       <thead>

--- a/app/scripts/modules/core/src/search/infrastructure/infrastructure.html
+++ b/app/scripts/modules/core/src/search/infrastructure/infrastructure.html
@@ -95,7 +95,7 @@
     </div>
   </div>
   <h2 ng-if="viewState.searching" class="text-center" style="margin-bottom: 25px">
-    <i class="fa fa-circle-o-notch fa-spin"></i>
+    <span class="fa fa-cog fa-spin"></span>
   </h2>
   <div ng-if="ctrl.noMatches() && !viewState.searching" class="container">
     <div class="row">

--- a/app/scripts/modules/core/src/snapshot/diff/snapshotDiff.modal.html
+++ b/app/scripts/modules/core/src/snapshot/diff/snapshotDiff.modal.html
@@ -4,7 +4,7 @@
     <h3>Application Snapshot History</h3>
   </div>
   <div class="modal-body" ng-if="ctrl.state.loading">
-    <h4 class="text-center"><span class="glyphicon glyphicon-asterisk glyphicon-spinning"></span></h4>
+    <h4 class="text-center"><span class="fa fa-cog fa-spin"></span></h4>
   </div>
   <div class="modal-body flex-fill" ng-if="!ctrl.state.loading">
     <div class="form-inline modal-history-header">

--- a/app/scripts/modules/core/src/task/monitor/taskMonitorStatus.component.js
+++ b/app/scripts/modules/core/src/task/monitor/taskMonitorStatus.component.js
@@ -16,7 +16,7 @@ module.exports = angular
           </li>
         </ul>
         <ul class="task task-progress task-progress-running" ng-if="$ctrl.monitor.task.isActive">
-          <li><span class="glyphicon glyphicon-spinning glyphicon-asterisk"></span></li>
+          <li><span class="fa fa-cog fa-spin"></span></li>
         </ul>
         <ul class="task task-progress task-progress-refresh" ng-if="$ctrl.monitor.task.isCompleted">
           <li>

--- a/app/scripts/modules/docker/src/pipeline/trigger/dockerTriggerOptions.directive.html
+++ b/app/scripts/modules/docker/src/pipeline/trigger/dockerTriggerOptions.directive.html
@@ -2,7 +2,7 @@
   <label class="col-md-4 sm-label-right">Tag</label>
   <div class="col-md-6" ng-if="vm.viewState.tagsLoading">
     <p class="form-control-static text-center">
-      <span class="glyphicon glyphicon-asterisk glyphicon-spinning"></span>
+      <span class="fa fa-cog fa-spin"></span>
     </p>
   </div>
   <div class="col-md-6" ng-if="vm.viewState.loadError">Error loading tags!</div>

--- a/app/scripts/modules/google/serverGroup/configure/wizard/location/basicSettings.controller.js
+++ b/app/scripts/modules/google/serverGroup/configure/wizard/location/basicSettings.controller.js
@@ -21,7 +21,7 @@ module.exports = angular.module('spinnaker.google.serverGroup.configure.wizard.b
     function searchImages(q) {
       $scope.command.backingData.filtered.images = [
         {
-          message: '<span class="glyphicon glyphicon-spinning glyphicon-asterisk"></span> Finding results matching "' + q + '"...'
+          message: '<span class="fa fa-cog fa-spin"></span> Finding results matching "' + q + '"...'
         }
       ];
       return Observable.fromPromise(

--- a/app/scripts/modules/kubernetes/serverGroup/configure/wizard/BasicSettings.controller.js
+++ b/app/scripts/modules/kubernetes/serverGroup/configure/wizard/BasicSettings.controller.js
@@ -18,7 +18,7 @@ module.exports = angular.module('spinnaker.serverGroup.configure.kubernetes.basi
     function searchImages(q) {
       $scope.command.backingData.filtered.images = [
         {
-          message: '<span class="glyphicon glyphicon-spinning glyphicon-asterisk"></span> Finding results matching "' + q + '"...'
+          message: '<span class="fa fa-cog fa-spin"></span> Finding results matching "' + q + '"...'
         }
       ];
       return Observable.fromPromise(

--- a/app/scripts/modules/netflix/ci/detail/detailTab/detailTabView.html
+++ b/app/scripts/modules/netflix/ci/detail/detailTab/detailTabView.html
@@ -37,7 +37,7 @@
           Get more results
         </a>
         <span is-visible="ctrl.viewState.loadingMore && !ctrl.viewState.isRunning">
-          <span class="small glyphicon glyphicon-asterisk glyphicon-spinning"></span> Retrieving more...
+          <span class="fa fa-cog fa-spin"></span> Retrieving more...
         </span>
         <a is-visible="ctrl.content.length > 50" href ng-click="ctrl.scrollToTop()" class="pull-right">Back to top</a>
       </div>

--- a/app/scripts/modules/netflix/ci/trigger/ciTriggerHandler.component.html
+++ b/app/scripts/modules/netflix/ci/trigger/ciTriggerHandler.component.html
@@ -12,7 +12,7 @@
     <label class="col-md-4 sm-label-right">Branch</label>
     <div class="col-md-6" ng-if="$ctrl.viewState.branches.loading">
       <p class="form-control-static text-center">
-        <span class="glyphicon glyphicon-asterisk glyphicon-spinning"></span>
+        <span class="fa fa-cog fa-spin"></span>
       </p>
     </div>
     <div class="col-md-6" ng-if="$ctrl.viewState.branches.loadError">Error loading branches!</div>
@@ -44,7 +44,7 @@
     <label class="col-md-4 sm-label-right">Commit</label>
     <div class="col-md-6" ng-if="$ctrl.viewState.commits.loading">
       <p class="form-control-static text-center">
-        <span class="glyphicon glyphicon-asterisk glyphicon-spinning"></span>
+        <span class="fa fa-cog fa-spin"></span>
       </p>
     </div>
     <div class="col-md-6" ng-if="$ctrl.viewState.commits.loadError">Error loading commits!</div>
@@ -76,7 +76,7 @@
     <label class="col-md-4 sm-label-right">Tag</label>
     <div class="col-md-6" ng-if="$ctrl.viewState.tags.loading">
       <p class="form-control-static text-center">
-        <span class="glyphicon glyphicon-asterisk glyphicon-spinning"></span>
+        <span class="fa fa-cog fa-spin"></span>
       </p>
     </div>
     <div class="col-md-6" ng-if="$ctrl.viewState.tags.loadError">Error loading tags!</div>

--- a/app/scripts/modules/netflix/migrator/migrator.modal.submitting.html
+++ b/app/scripts/modules/netflix/migrator/migrator.modal.submitting.html
@@ -19,7 +19,7 @@
           </li>
         </ul>
         <ul class="task task-progress task-progress-running">
-          <li><span class="glyphicon glyphicon-spinning glyphicon-asterisk"></span></li>
+          <li><span class="fa fa-cog fa-spin"></span></li>
         </ul>
       </div>
     </div>

--- a/app/scripts/modules/netflix/migrator/pipeline/pipeline.migrator.modal.html
+++ b/app/scripts/modules/netflix/migrator/pipeline/pipeline.migrator.modal.html
@@ -9,7 +9,7 @@
 
       <div ng-if="vm.state === 'initialize'" class="migration-options">
         <h3 class="text-center">
-          <span class="small glyphicon glyphicon-asterisk glyphicon-spinning"></span>
+          <span class="fa fa-cog fa-spin"></span>
         </h3>
       </div>
 

--- a/app/scripts/modules/netflix/migrator/serverGroup/serverGroup.migrator.modal.html
+++ b/app/scripts/modules/netflix/migrator/serverGroup/serverGroup.migrator.modal.html
@@ -8,7 +8,7 @@
     <div class="modal-body">
       <div ng-if="vm.state === 'initialize'" class="migration-options">
         <h3 class="text-center">
-          <span class="small glyphicon glyphicon-asterisk glyphicon-spinning"></span>
+          <span class="fa fa-cog fa-spin"></span>
         </h3>
       </div>
 

--- a/app/scripts/modules/netflix/pipeline/stage/chap/chapStage.html
+++ b/app/scripts/modules/netflix/pipeline/stage/chap/chapStage.html
@@ -1,7 +1,7 @@
 <div class="form-horizontal">
   <stage-config-field label="Test Case">
     <div class="text-center" ng-if="!stageCtrl.viewState.testCasesLoaded">
-      <span class="glyphicon glyphicon-asterisk glyphicon-spinning"></span>
+      <span class="fa fa-cog fa-spin"></span>
     </div>
     <ui-select ng-model="stage.testCaseId" class="form-control input-sm" ng-if="stageCtrl.viewState.testCasesLoaded">
       <ui-select-match>

--- a/app/scripts/modules/openstack/serverGroup/configure/wizard/instance/ServerGroupInstanceSettings.controller.js
+++ b/app/scripts/modules/openstack/serverGroup/configure/wizard/instance/ServerGroupInstanceSettings.controller.js
@@ -29,7 +29,7 @@ module.exports = angular.module('spinnaker.serverGroup.configure.openstack.insta
       ensureCommandBackingDataFilteredExists();
       $scope.command.backingData.filtered.images = [
         {
-          message: '<span class="glyphicon glyphicon-spinning glyphicon-asterisk"></span> Finding results matching "' + q + '"...'
+          message: '<span class="fa fa-cog fa-spin"></span> Finding results matching "' + q + '"...'
         }
       ];
       return Observable.fromPromise(


### PR DESCRIPTION
We currently use four slightly different spinners to represent a loading state:
 * circle-notch on infrastructure
 * glyphicon-asterisk in most places
 * us-spinner in a lot of places
 * fa-cog in a handful of places

This gets us down to two (fa-cog, us-spinner); us-spinner will be done in a separate PR...

There are two _other_ spinning icons:
 * glyphicon-refresh
 * the donut for running tasks
but they represent different things, so won't go away.