### PR TITLE
refactor(build): avoid linting twice

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -40,10 +40,8 @@ function configure(IS_TEST) {
     },
     module: {
       rules: [
-        {enforce: 'pre', test: /\.(spec\.)?tsx?$/, use: 'tslint-loader'},
-        {enforce: 'pre', test: /\.(spec\.)?js$/, loader: 'eslint-loader'},
         {test: /\.json$/, loader: 'json-loader'},
-        {test: /\.tsx?$/, use: ['ng-annotate-loader', 'awesome-typescript-loader'], exclude: /node_modules/},
+        {test: /\.tsx?$/, use: ['ng-annotate-loader', 'awesome-typescript-loader', 'tslint-loader'], exclude: /node_modules/},
         {test: /\.(woff|otf|ttf|eot|svg|png|gif|ico)(.*)?$/, use: 'file-loader'},
         {test: /\.js$/, use: ['happypack/loader?id=js'], exclude: /node_modules(?!\/clipboard)/},
         {


### PR DESCRIPTION
Not sure the backstory here, but it appears we are currently running es-lint twice. The HappyPack JS config already includes the `eslint-loader`, so with the `pre` rule we end up running it two times - but the first is never cached, so we're always re-running it.

Locally, I see a 15-20 second improvement in cold start (no cache), and 20-25 second improvement with a warmed cache.

I also played around with `cache-loader`, which seems even better after the initial run (~35 seconds faster); however, cold starts were ~20 seconds _slower_ than the current build, so I'm not as excited there. Still something to consider/play around with.