### PR TITLE
fix(core): prevents incorrectly defaulting to AWS for stage configs

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/pipelineConfigProvider.ts
+++ b/app/scripts/modules/core/src/pipeline/config/pipelineConfigProvider.ts
@@ -152,7 +152,7 @@ export class PipelineConfigProvider implements IServiceProvider {
       case 1:
         return matches[0];
       default:
-        const provider = stage.cloudProvider || 'aws';
+        const provider = stage.cloudProvider || stage.cloudProviderType || 'aws';
         const matchesForStageCloudProvider = matches.filter(stageType => {
           return stageType.cloudProvider === provider;
         });


### PR DESCRIPTION
@anotherchrisberry it turns out this really is necessary.

@lwander fyi