### PR TITLE
fix(pipelines): remove refId param after resolving deep link

### DIFF
--- a/app/scripts/modules/core/src/delivery/delivery.states.ts
+++ b/app/scripts/modules/core/src/delivery/delivery.states.ts
@@ -40,6 +40,9 @@ module(DELIVERY_STATES, [
       },
       step: {
         value: '0',
+      },
+      refId: {
+        value: null,
       }
     },
     data: {


### PR DESCRIPTION
Fixes a regression from the ui-router upgrade which is preventing the removal of the `refId` param from deep links to a specific stage, which then prevents navigation to other stages, as it keeps seeing the `refId` parameter and replacing the `stage` param to point back to whatever it's resolved via the `refId` param.