### PR TITLE
feat(provider/oraclebmcs): Implement findAmi pipeline stage

### DIFF
--- a/app/scripts/modules/oracle/oraclebmcs.module.js
+++ b/app/scripts/modules/oracle/oraclebmcs.module.js
@@ -22,6 +22,7 @@ module.exports = angular.module('spinnaker.oraclebmcs', [
   require('./pipeline/stages/resizeAsg/resizeAsgStage.js'),
   require('./pipeline/stages/scaleDownCluster/scaleDownClusterStage.js'),
   require('./pipeline/stages/shrinkCluster/shrinkClusterStage.js'),
+  require('./pipeline/stages/findAmi/findAmiStage.js'),
   // Server Groups
   require('./serverGroup/serverGroup.transformer.js'),
   require('./serverGroup/configure/serverGroup.configure.module.js'),

--- a/app/scripts/modules/oracle/pipeline/disableAsg/disableAsgStage.html
+++ b/app/scripts/modules/oracle/pipeline/disableAsg/disableAsgStage.html
@@ -1,0 +1,18 @@
+<div ng-controller="oraclebmcsDisableAsgStageCtrl as disableAsgStageCtrl" class="form-horizontal">
+  <div ng-if="!pipeline.strategy">
+
+    <account-region-cluster-selector
+      application="application"
+      component="stage"
+      accounts="accounts">
+    </account-region-cluster-selector>
+
+  </div>
+  <stage-config-field label="Target">
+    <target-select model="stage" options="targets"></target-select>
+  </stage-config-field>
+  <stage-platform-health-override application="application"
+                                  stage="stage"
+                                  platform-health-type="'Google'">
+  </stage-platform-health-override>
+</div>

--- a/app/scripts/modules/oracle/pipeline/disableAsg/disableAsgStage.js
+++ b/app/scripts/modules/oracle/pipeline/disableAsg/disableAsgStage.js
@@ -1,0 +1,60 @@
+'use strict';
+
+let angular = require('angular');
+import {StageConstants} from 'core/pipeline/config/stages/stageConstants';
+import {ACCOUNT_SERVICE} from 'core/account/account.service';
+
+module.exports = angular.module('spinnaker.oraclebmcs.pipeline.stage.disableAsgStage', [
+  require('core/application/modal/platformHealthOverride.directive.js'),
+  ACCOUNT_SERVICE,
+])
+  .config(function(pipelineConfigProvider) {
+    pipelineConfigProvider.registerStage({
+      provides: 'disableServerGroup',
+      cloudProvider: 'oraclebmcs',
+      templateUrl: require('./disableAsgStage.html'),
+      executionDetailsUrl: require('core/pipeline/config/stages/disableAsg/templates/disableAsgExecutionDetails.template.html'),
+      executionStepLabelUrl: require('./disableAsgStepLabel.html'),
+      validators: [
+        {
+          type: 'targetImpedance',
+          message: 'This pipeline will attempt to disable a server group without deploying a new version into the same cluster.'
+        },
+        { type: 'requiredField', fieldName: 'cluster' },
+        { type: 'requiredField', fieldName: 'target', },
+        { type: 'requiredField', fieldName: 'regions', },
+        { type: 'requiredField', fieldName: 'credentials', fieldLabel: 'account'},
+      ],
+    });
+  }).controller('oraclebmcsDisableAsgStageCtrl', function($scope, accountService) {
+
+    let stage = $scope.stage;
+
+    let provider = 'oraclebmcs';
+
+    $scope.state = {
+      accounts: false,
+      regionsLoaded: false
+    };
+
+    accountService.listAccounts(provider).then(function (accounts) {
+      $scope.accounts = accounts;
+      $scope.state.accounts = true;
+    });
+
+    $scope.targets = StageConstants.TARGET_LIST;
+
+    stage.regions = stage.regions || [];
+    stage.cloudProvider = provider;
+
+    if (!stage.credentials && $scope.application.defaultCredentials.oraclebmcs) {
+      stage.credentials = $scope.application.defaultCredentials.oraclebmcs;
+    }
+    if (!stage.regions.length && $scope.application.defaultRegions.gce) {
+      stage.regions.push($scope.application.defaultRegions.oraclebmcs);
+    }
+
+    if (!stage.target) {
+      stage.target = $scope.targets[0].val;
+    }
+  });

--- a/app/scripts/modules/oracle/pipeline/disableAsg/disableAsgStepLabel.html
+++ b/app/scripts/modules/oracle/pipeline/disableAsg/disableAsgStepLabel.html
@@ -1,0 +1,5 @@
+<span class="task-label">
+  Disable Server Group:
+  {{step.context.serverGroupName}}
+  ({{step.context.region}})
+</span>

--- a/app/scripts/modules/oracle/pipeline/stages/findAmi/findAmiExecutionDetails.html
+++ b/app/scripts/modules/oracle/pipeline/stages/findAmi/findAmiExecutionDetails.html
@@ -1,0 +1,42 @@
+<div ng-controller="BaseExecutionDetailsCtrl">
+  <execution-details-section-nav sections="configSections"></execution-details-section-nav>
+  <div class="step-section-details" ng-if="detailsSection === 'findImageConfig'">
+    <div class="row">
+      <div class="col-md-6">
+        <dl class="dl-narrow dl-horizontal">
+          <dt>Account</dt>
+          <dd>
+            <account-tag account="stage.context.credentials"></account-tag>
+          </dd>
+          <dt ng-if="stage.context.regions">Regions</dt>
+          <dd ng-if="stage.context.regions">{{stage.context.regions.join(', ')}}</dd>
+          <dt>Cluster</dt>
+          <dd>{{stage.context.cluster}}</dd>
+        </dl>
+      </div>
+    </div>
+    <stage-failure-message stage="stage" message="stage.failureMessage"></stage-failure-message>
+
+    <div class="row" ng-if="stage.context.amiDetails">
+      <div class="col-md-12">
+        <div class="well alert alert-info">
+          <h4>Results</h4>
+          <dl ng-repeat="image in stage.context.amiDetails" class="dl-narrow dl-horizontal">
+            <dt>Region</dt>
+            <dd>{{image.region}}</dd>
+            <dt>Image ID</dt>
+            <dd>{{image.imageId}}</dd>
+            <dt>Name</dt>
+            <dd>{{image.imageName}}</dd>
+          </dl>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="step-section-details" ng-if="detailsSection === 'taskStatus'">
+    <div class="row">
+      <execution-step-details item="stage"></execution-step-details>
+    </div>
+  </div>
+</div>

--- a/app/scripts/modules/oracle/pipeline/stages/findAmi/findAmiStage.html
+++ b/app/scripts/modules/oracle/pipeline/stages/findAmi/findAmiStage.html
@@ -1,0 +1,23 @@
+<div ng-controller="oraclebmcsFindAmiStageCtrl as findAmiCtrl" class="form-horizontal">
+  <account-region-cluster-selector
+    application="application"
+    component="stage"
+    accounts="accounts">
+  </account-region-cluster-selector>
+
+  <stage-config-field label="Server Group Selection">
+    <ui-select ng-model="stage.selectionStrategy" class="form-control input-sm">
+      <ui-select-match placeholder="None">{{$select.selected.label}}</ui-select-match>
+      <ui-select-choices repeat="strategy.val as strategy in selectionStrategies | filter: $select.search">
+        <strong ng-bind-html="strategy.label | highlight: $select.search"></strong>
+        <div ng-bind-html="strategy.description"></div>
+      </ui-select-choices>
+    </ui-select>
+  </stage-config-field>
+  <stage-config-field label="Server Group Filters">
+    <label class="checkbox-inline">
+      <input type="checkbox" ng-model="stage.onlyEnabled"/>
+      Only consider enabled Server Groups
+    </label>
+  </stage-config-field>
+</div>

--- a/app/scripts/modules/oracle/pipeline/stages/findAmi/findAmiStage.js
+++ b/app/scripts/modules/oracle/pipeline/stages/findAmi/findAmiStage.js
@@ -1,0 +1,79 @@
+'use strict';
+
+const angular = require('angular');
+
+import {
+  ACCOUNT_SERVICE,
+  PIPELINE_CONFIG_PROVIDER
+} from '@spinnaker/core';
+
+module.exports = angular.module('spinnaker.oraclebmcs.pipeline.stage.findAmiStage', [
+  PIPELINE_CONFIG_PROVIDER,
+  ACCOUNT_SERVICE,
+])
+  .config(function(pipelineConfigProvider) {
+    pipelineConfigProvider.registerStage({
+      provides: 'findImage',
+      cloudProvider: 'oraclebmcs',
+      templateUrl: require('./findAmiStage.html'),
+      executionDetailsUrl: require('./findAmiExecutionDetails.html'),
+      executionConfigSections: ['findImageConfig', 'taskStatus'],
+      validators: [
+        { type: 'requiredField', fieldName: 'cluster' },
+        { type: 'requiredField', fieldName: 'selectionStrategy', fieldLabel: 'Server Group Selection'},
+        { type: 'requiredField', fieldName: 'regions' },
+        { type: 'requiredField', fieldName: 'credentials' }
+      ]
+    });
+  }).controller('oraclebmcsFindAmiStageCtrl', ($scope, accountService) => {
+
+    const provider = 'oraclebmcs';
+
+    let stage = $scope.stage;
+
+    $scope.state = {
+      accounts: false,
+      regionsLoaded: false
+    };
+
+    accountService.listAccounts(provider).then(accounts => {
+      $scope.accounts = accounts;
+      $scope.state.accounts = true;
+    });
+
+    $scope.selectionStrategies = [{
+      label: 'Largest',
+      val: 'LARGEST',
+      description: 'When multiple server groups exist, prefer the server group with the most instances'
+    }, {
+      label: 'Newest',
+      val: 'NEWEST',
+      description: 'When multiple server groups exist, prefer the newest'
+    }, {
+      label: 'Oldest',
+      val: 'OLDEST',
+      description: 'When multiple server groups exist, prefer the oldest'
+    }, {
+      label: 'Fail',
+      val: 'FAIL',
+      description: 'When multiple server groups exist, fail'
+    }];
+
+    stage.regions = stage.regions || [];
+    stage.cloudProvider = provider;
+    stage.selectionStrategy = stage.selectionStrategy || $scope.selectionStrategies[0].val;
+
+    if (angular.isUndefined(stage.onlyEnabled)) {
+      stage.onlyEnabled = true;
+    }
+
+    if (!stage.credentials && $scope.application.defaultCredentials.oraclebmcs) {
+      stage.credentials = $scope.application.defaultCredentials.oraclebmcs;
+    }
+
+    if (!stage.regions.length && $scope.application.defaultRegions.oraclebmcs) {
+      stage.regions.push($scope.application.defaultRegions.oraclebmcs);
+    }
+
+    $scope.$watch('stage.credentials', $scope.accountUpdated);
+  });


### PR DESCRIPTION
Adds another pipeline stage for the Oracle BMCS cloud provider.

![screen shot 2017-05-23 at 11 23 47](https://cloud.githubusercontent.com/assets/733944/26350348/c3b0a70c-3faa-11e7-8126-07929accef67.png)
