### PR TITLE
fix(application): avoid URL flashing when application not found

### DIFF
--- a/app/scripts/modules/core/src/application/applicationModel.builder.ts
+++ b/app/scripts/modules/core/src/application/applicationModel.builder.ts
@@ -35,6 +35,7 @@ export class ApplicationModelBuilder {
 
   public createNotFoundApplication(name: string): Application {
     const application = new Application(name, this.schedulerFactory.createScheduler(), this.$q, this.$log);
+    this.addDataSource(new DataSourceConfig({key: 'serverGroups', lazy: true}), application);
     application.notFound = true;
     return application;
   }


### PR DESCRIPTION
Current behavior is pretty bad, as the URL bounces back and forth between `/applications/{app}` and `/applications/{app}/clusters` indefinitely, and does not show the error message that the application can't be found.