### PR TITLE
fix(application): avoid refresh icon wobble on narrow screens

### DIFF
--- a/app/scripts/modules/core/src/application/application.less
+++ b/app/scripts/modules/core/src/application/application.less
@@ -58,7 +58,7 @@
       min-width: 120px;
       margin-right: 30px;
       margin-top: 15px;
-      .fa {
+      .fa-window-maximize, .glyphicon-equalizer {
         width: 28px;
         height: 28px;
         line-height: 24px;


### PR DESCRIPTION
thanks for pointing this out @jrsquared 