### PR TITLE
fix(core): unique package for analytics service; external version.json

### DIFF
--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/core",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/core/src/analytics/analytics.service.js
+++ b/app/scripts/modules/core/src/analytics/analytics.service.js
@@ -5,7 +5,7 @@ import {SETTINGS} from 'core/config/settings';
 const angular = require('angular');
 
 module.exports = angular
-  .module('spinnaker.core.analytics', [
+  .module('spinnaker.core.analytics.service', [
     require('angulartics'),
     require('angulartics-google-analytics'),
   ])

--- a/app/scripts/modules/core/webpack.config.js
+++ b/app/scripts/modules/core/webpack.config.js
@@ -21,6 +21,7 @@ module.exports = {
     umdNamedDefine: true,
   },
   externals: {
+    'root/version.json': 'root/version.json',
     '@uirouter/angularjs': '@uirouter/angularjs',
     '@uirouter/core': '@uirouter/core',
     'angular': 'angular',


### PR DESCRIPTION
* package collision on analytics (module and service were using the same package name and clobbering each other)
* moving `version.json` to an external so it can be built in the library consumer
* bumping core version