### PR TITLE
fix(pipelines): inject app, set on scope in pipeline configurer

### DIFF
--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/core",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/core/src/delivery/details/singleExecutionDetails.controller.js
+++ b/app/scripts/modules/core/src/delivery/details/singleExecutionDetails.controller.js
@@ -10,14 +10,13 @@ module.exports = angular.module('spinnaker.singleExecutionDetails.controller', [
     EXECUTION_SERVICE,
     SCHEDULER_FACTORY,
   ])
-  .controller('SingleExecutionDetailsCtrl', function ($scope, $state, executionService, schedulerFactory) {
+  .controller('SingleExecutionDetailsCtrl', function ($scope, $state, executionService, schedulerFactory, app) {
 
     let executionScheduler = schedulerFactory.createScheduler(5000);
 
     let getExecution = () => {
-      let application = $scope.application;
-      this.application = application;
-      if ($scope.application.notFound) {
+      this.application = app;
+      if (this.application.notFound) {
         return;
       }
       executionService.getExecution($state.params.executionId).then((execution) => {

--- a/app/scripts/modules/core/src/pipeline/config/pipelineConfig.controller.js
+++ b/app/scripts/modules/core/src/pipeline/config/pipelineConfig.controller.js
@@ -7,18 +7,17 @@ const angular = require('angular');
 module.exports = angular.module('spinnaker.core.pipeline.config.controller', [
   require('angular-ui-router').default,
 ])
-  .controller('PipelineConfigCtrl', function($scope, $stateParams) {
+  .controller('PipelineConfigCtrl', function($scope, $stateParams, app) {
 
-    let application = $scope.application;
-
+    this.application = app;
     this.state = {
       pipelinesLoaded: false,
     };
 
     this.initialize = () => {
-      this.pipelineConfig = _.find(application.pipelineConfigs.data, { id: $stateParams.pipelineId });
+      this.pipelineConfig = _.find(app.pipelineConfigs.data, { id: $stateParams.pipelineId });
       if (!this.pipelineConfig) {
-          this.pipelineConfig = _.find(application.strategyConfigs.data, { id: $stateParams.pipelineId });
+          this.pipelineConfig = _.find(app.strategyConfigs.data, { id: $stateParams.pipelineId });
           if(!this.pipelineConfig) {
             this.state.notFound = true;
           }
@@ -26,8 +25,8 @@ module.exports = angular.module('spinnaker.core.pipeline.config.controller', [
       this.state.pipelinesLoaded = true;
     };
 
-    if (!application.notFound) {
-      application.pipelineConfigs.activate();
-      application.pipelineConfigs.ready().then(this.initialize);
+    if (!app.notFound) {
+      app.pipelineConfigs.activate();
+      app.pipelineConfigs.ready().then(this.initialize);
     }
   });

--- a/app/scripts/modules/core/src/pipeline/config/pipelineConfig.controller.spec.js
+++ b/app/scripts/modules/core/src/pipeline/config/pipelineConfig.controller.spec.js
@@ -22,36 +22,38 @@ describe('Controller: PipelineConfigCtrl', function () {
   );
 
   it('should initialize immediately if pipeline configs are already present', function () {
-    scope.application = applicationModelBuilder.createApplication({key: 'pipelineConfigs', lazy: true});
-    scope.application.pipelineConfigs.data = [ { id: 'a' } ];
-    scope.application.pipelineConfigs.loaded = true;
+    const application = applicationModelBuilder.createApplication({key: 'pipelineConfigs', lazy: true});
+    application.pipelineConfigs.data = [ { id: 'a' } ];
+    application.pipelineConfigs.loaded = true;
 
     let vm = controller('PipelineConfigCtrl', {
       $scope: scope,
       $stateParams: {
         pipelineId: 'a'
-      }
+      },
+      app: application
     });
     scope.$digest();
     expect(vm.state.pipelinesLoaded).toBe(true);
   });
 
   it('should wait until pipeline configs are loaded before initializing', function () {
-    scope.application = applicationModelBuilder.createApplication({key: 'pipelineConfigs', lazy: true});
-    spyOn(scope.application.pipelineConfigs, 'activate').and.callFake(angular.noop);
+    const application = applicationModelBuilder.createApplication({key: 'pipelineConfigs', lazy: true});
+    spyOn(application.pipelineConfigs, 'activate').and.callFake(angular.noop);
     let vm = controller('PipelineConfigCtrl', {
       $scope: scope,
       $stateParams: {
         pipelineId: 'a'
-      }
+      },
+      app: application
     });
 
-    scope.application.pipelineConfigs.data.push({id: 'a'});
-    scope.application.pipelineConfigs.dataUpdated();
+    application.pipelineConfigs.data.push({id: 'a'});
+    application.pipelineConfigs.dataUpdated();
     scope.$digest();
 
     expect(vm.state.pipelinesLoaded).toBe(true);
-    expect(scope.application.pipelineConfigs.activate.calls.count()).toBe(1);
+    expect(application.pipelineConfigs.activate.calls.count()).toBe(1);
   });
 });
 

--- a/app/scripts/modules/core/src/pipeline/config/pipelineConfig.html
+++ b/app/scripts/modules/core/src/pipeline/config/pipelineConfig.html
@@ -6,11 +6,11 @@
   </div>
   <div class="row">
     <div class="col-md-10 col-md-offset-1">
-      <pipeline-configurer pipeline="vm.pipelineConfig" application="application"></pipeline-configurer>
+      <pipeline-configurer pipeline="vm.pipelineConfig" application="vm.application"></pipeline-configurer>
     </div>
   </div>
 </div>
-<div class="row" ng-if="!application.notFound && !vm.state.pipelinesLoaded" style="min-height: 300px">
+<div class="row" ng-if="!vm.application.notFound && !vm.state.pipelinesLoaded" style="min-height: 300px">
   <h4 class="text-center">
     <span us-spinner="{radius:20, width:6, length: 12}"></span>
   </h4>


### PR DESCRIPTION
Someday, the pipeline configurer will go away (it's an artifact of the days when we displayed all application pipeline configs in the same view), but not today.