### PR TITLE
fix(entitytags): include maxResults parameter when retrieving tags

### DIFF
--- a/app/scripts/modules/core/src/entityTag/entityTags.read.service.spec.ts
+++ b/app/scripts/modules/core/src/entityTag/entityTags.read.service.spec.ts
@@ -35,7 +35,7 @@ describe('entityTags reader', () => {
   afterEach(SETTINGS.resetToOriginal);
 
   it('returns an empty list instead of failing if tags cannot be loaded', () => {
-    $http.whenGET(`${SETTINGS.gateUrl}/tags?entityId=a,b&entityType=servergroups`).respond(400, 'bad request');
+    $http.whenGET(`${SETTINGS.gateUrl}/tags?entityId=a,b&entityType=servergroups&maxResults=2`).respond(400, 'bad request');
     let result: any = null;
     service.getAllEntityTags('serverGroups', ['a', 'b']).then(r => result = r);
     $http.flush();
@@ -44,23 +44,23 @@ describe('entityTags reader', () => {
     expect(result).toEqual([]);
   });
 
-  it('collates entries into groups when there are too many', () => {
-    $http.expectGET(`http://gate/tags?entityId=a,b&entityType=servergroups`).respond(200, []);
-    $http.expectGET(`http://gate/tags?entityId=c,d&entityType=servergroups`).respond(200, []);
+  it('collates entries into groups when there are too many, including maxResults', () => {
+    $http.expectGET(`http://gate/tags?entityId=a,b&entityType=servergroups&maxResults=2`).respond(200, []);
+    $http.expectGET(`http://gate/tags?entityId=c,d&entityType=servergroups&maxResults=4`).respond(200, []);
 
     let result: any = null;
-    service.getAllEntityTags('serverGroups', ['a', 'b', 'c', 'd']).then(r => result = r);
+    service.getAllEntityTags('serverGroups', ['a', 'b', 'c', 'd', 'd', 'd']).then(r => result = r);
     $http.flush();
     $timeout.flush();
     expect(result).toEqual([]);
   });
 
   it('retries server group fetch once on exceptions', () => {
-    $http.expectGET(`${SETTINGS.gateUrl}/tags?entityId=a,b&entityType=servergroups`).respond(400, 'bad request');
+    $http.expectGET(`${SETTINGS.gateUrl}/tags?entityId=a,b&entityType=servergroups&maxResults=2`).respond(400, 'bad request');
     let result: any = null;
     service.getAllEntityTags('serverGroups', ['a', 'b']).then(r => result = r);
     $http.flush();
-    $http.expectGET(`${SETTINGS.gateUrl}/tags?entityId=a,b&entityType=servergroups`).respond(200, []);
+    $http.expectGET(`${SETTINGS.gateUrl}/tags?entityId=a,b&entityType=servergroups&maxResults=2`).respond(200, []);
     $timeout.flush();
     $http.flush();
     expect(result).toEqual([]);


### PR DESCRIPTION
The clouddriver endpoint defaults the `maxResults` parameter to `100` when retrieving entity tags. This is fine, except when we are passing a list of more than 100 entities, we'll only get the first 100 results.

Since we dedupe the list of tags before sending the request, we can't just count on the number of `entityId`s we send in - we need to actually declare how many we might get back.