### PR TITLE
fix(core): avoid NPE when disabling autorefresh

### DIFF
--- a/app/scripts/modules/core/src/application/application.component.ts
+++ b/app/scripts/modules/core/src/application/application.component.ts
@@ -35,7 +35,9 @@ export class ApplicationController implements IComponentController {
   }
 
   public $onDestroy() {
-    this.app.disableAutoRefresh();
+    if (!this.app.notFound) {
+      this.app.disableAutoRefresh();
+    }
   }
 }
 

--- a/app/scripts/modules/core/src/application/application.model.ts
+++ b/app/scripts/modules/core/src/application/application.model.ts
@@ -154,14 +154,13 @@ export class Application {
   /**
    * This is really only used by the ApplicationController - it manages the refresh cycle for the overall application
    * and halts refresh when switching applications or navigating to a non-application view
-   * @param $scope
    */
   public enableAutoRefresh(): void {
     this.dataLoader = this.scheduler.subscribe(() => this.refresh());
   }
 
   public disableAutoRefresh(): void {
-    this.dataLoader.unsubscribe();
+    this.dataLoader && this.dataLoader.unsubscribe();
     this.scheduler.unsubscribe();
   }
 


### PR DESCRIPTION
If the app is not found, there will be no `dataLoader` from which to unsubscribe, so don't call `disableAutoRefresh` when moving to a different application.

In case someone calls `disableAutoRefresh` anyway (they never should, but who knows), we'll verify the `dataLoader` has been assigned before calling `unsubscribe` on it.