### PR TITLE
fix(pipelines): allow stage to declare executionAlias value

### DIFF
--- a/app/scripts/modules/core/src/domain/IStageTypeConfig.ts
+++ b/app/scripts/modules/core/src/domain/IStageTypeConfig.ts
@@ -12,6 +12,7 @@ export interface IStageTypeConfig extends IStageOrTriggerTypeConfig {
   cloudProvider?: string;
   cloudProviders?: string[];
   alias?: string;
+  addAliasToConfig?: boolean;
   useBaseProvider?: boolean;
   executionLabelComponent?: React.Component<{ stage: IExecutionStageSummary }, any>;
   accountExtractor?: (stage: IStage) => string;

--- a/app/scripts/modules/core/src/pipeline/config/stages/stage.module.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/stage.module.js
@@ -96,7 +96,9 @@ module.exports = angular.module('spinnaker.core.pipeline.config.stage', [
 
     this.selectStageType = stage => {
       $scope.stage.type = stage.key;
-      $scope.stage.alias = stage.alias;
+      if (stage.addAliasToConfig) {
+        $scope.stage.alias = stage.alias;
+      }
       this.selectStage();
     };
 

--- a/app/scripts/modules/core/src/pipeline/config/stages/webhook/webhookStage.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/webhook/webhookStage.ts
@@ -135,6 +135,7 @@ module(WEBHOOK_STAGE, [
       description: preconfiguredWebhook.description,
       key: preconfiguredWebhook.type,
       alias: 'preconfiguredWebhook',
+      addAliasToConfig: true,
       restartable: true,
       controller: 'WebhookStageCtrl',
       controllerAs: '$ctrl',


### PR DESCRIPTION
Running into an issue with the `alias` being applied to the pipeline stage config: Orca will interpret that as the stage type to run, which causes problems, especially as the original intent of the field was to allow backwards compatibility when refactoring stages. None of this is documented - the stage config options are very cryptic and need extensive comments to explain them (I barely understand what they do).

Will submit a separate PR to add comments to the config interface once I figure out what the fields mean.