### PR TITLE
fix(applications): shrink header for long application names

### DIFF
--- a/app/scripts/modules/core/src/application/application.component.ts
+++ b/app/scripts/modules/core/src/application/application.component.ts
@@ -11,6 +11,7 @@ export class ApplicationController implements IComponentController {
 
   public app: Application;
   public refreshTooltipTemplate = require('./applicationRefresh.tooltip.html');
+  public compactHeader = false;
 
   constructor(private recentHistoryService: RecentHistoryService, private $uibModal: IModalService) {
     'ngInject';
@@ -31,6 +32,9 @@ export class ApplicationController implements IComponentController {
       this.recentHistoryService.removeLastItem('applications');
       return;
     }
+    if (this.app.name.length > 20) {
+      this.compactHeader = true;
+    }
     this.app.enableAutoRefresh();
   }
 
@@ -47,7 +51,7 @@ const applicationComponent: IComponentOptions = {
   },
   controller: ApplicationController,
   template: `
-    <div class="page-header">
+    <div class="page-header" ng-class="{'compact-header': $ctrl.compactHeader}">
       <div ng-if="$ctrl.app.notFound">
         <h2 class="text-center">Application Not Found</h2>
         <p class="text-center" style="margin-bottom: 20px">Please check your URL - we can't find any data for <em>{{$ctrl.app.name}}</em>.</p>

--- a/app/scripts/modules/core/src/application/application.less
+++ b/app/scripts/modules/core/src/application/application.less
@@ -6,6 +6,38 @@ application {
   flex: 1 1 auto;
 }
 
+.compactH2() {
+  float: left;
+  font-size: 160%;
+  min-width: 120px;
+  margin-right: 30px;
+  margin-top: 15px;
+  .fa-window-maximize, .glyphicon-equalizer {
+    width: 28px;
+    height: 28px;
+    line-height: 24px;
+    font-size: 14px;
+  }
+}
+
+.compactPageButton() {
+  margin-top: 16px;
+}
+
+.compactHeaderPadding() {
+  padding: 0 10px;
+}
+
+.compact-header .application-header {
+  .compactHeaderPadding();
+  .page-button {
+    .compactPageButton();
+  }
+  h2 {
+    .compactH2();
+  }
+}
+
 .application-header {
   margin-top: 0;
   margin-bottom: 0;
@@ -17,7 +49,7 @@ application {
   z-index: 5;
   border: 0;
   @media (max-width: 1400px) {
-    padding: 0 10px;
+    .compactHeaderPadding();
   }
   .header-right {
     flex: 1 1 auto;
@@ -30,7 +62,7 @@ application {
     display: inline-block;
     margin-top: 15px;
     @media (min-width: 708px) and (max-width: 1400px) {
-      margin-top: 16px;
+      .compactPageButton();
     }
     .btn-danger {
       background-color: @unhealthy_red;
@@ -59,17 +91,7 @@ application {
       margin-left: 0;
     }
     @media (min-width: 708px) and (max-width: 1400px) {
-      float: left;
-      font-size: 160%;
-      min-width: 120px;
-      margin-right: 30px;
-      margin-top: 15px;
-      .fa-window-maximize, .glyphicon-equalizer {
-        width: 28px;
-        height: 28px;
-        line-height: 24px;
-        font-size: 14px;
-      }
+      .compactH2();
     }
 
     a {

--- a/app/scripts/modules/core/src/application/nav/applicationNav.component.less
+++ b/app/scripts/modules/core/src/application/nav/applicationNav.component.less
@@ -49,13 +49,26 @@ application-nav, secondary-application-nav, .application-nav {
   }
 }
 
+.compact(@font-size) {
+  font-size: @font-size;
+  padding: 15px 10px 13px 10px;
+}
+
+.compact-header {
+  application-nav a {
+    .compact(14px);
+  }
+  secondary-application-nav a {
+    .compact(12px);
+  }
+}
+
 application-nav {
   a {
     font-size: 18px;
     font-weight: 600;
     @media (max-width: 1400px) {
-      font-size: 14px;
-      padding: 15px 10px 13px 10px;
+      .compact(14px)
     }
   }
 }
@@ -65,8 +78,7 @@ secondary-application-nav {
     font-size: 14px;
     padding: 18px 10px 27px;
     @media (max-width: 1400px) {
-      font-size: 12px;
-      padding: 15px 10px 13px 10px;
+      .compact(12px)
     }
   }
 }

--- a/app/scripts/modules/core/src/presentation/main.less
+++ b/app/scripts/modules/core/src/presentation/main.less
@@ -1171,6 +1171,9 @@ body, html {
       h2 {
         margin-top: 10px;
       }
+      &.compact-header {
+        height: auto;
+      }
       @media (min-width: 768px) and (max-width: 1400px) {
         height: auto;
       }


### PR DESCRIPTION
Currently, when an application's name is very long, the UI does terrible things:
<img width="1366" alt="screen shot 2017-05-26 at 11 18 38 am" src="https://cloud.githubusercontent.com/assets/73450/26507575/dc1f5b32-4205-11e7-860e-c64eb49c5658.png">

Three options here:
1. Let the header overflow by removing the `height: 80px` style: <img width="1328" alt="screen shot 2017-05-26 at 11 21 01 am" src="https://cloud.githubusercontent.com/assets/73450/26507584/e60dd0e2-4205-11e7-9620-9f15ac679fd4.png">

2. Cut off the text after some number of characters to make it fit: <img width="1370" alt="screen shot 2017-05-26 at 11 22 59 am" src="https://cloud.githubusercontent.com/assets/73450/26507599/f845fd3e-4205-11e7-8d53-ff563f6869c3.png">

3. Shrink the header after a number of characters, and treat it the same way we treat narrower windows:
<img width="1394" alt="screen shot 2017-05-26 at 11 35 28 am" src="https://cloud.githubusercontent.com/assets/73450/26507940/7b83ac18-4207-11e7-85da-379d5156cef4.png">

This PR implements (3). I think (2) is a bad option - you end up cutting an awful lot of the application name to make it fit once you have a large number of nav options. I'd entertain (1), but it ends up eating a _lot_ of vertical space.
