### PR TITLE
fix(core): remove application accounts before saving

### DIFF
--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/core",
-  "version": "0.0.10",
+  "version": "0.0.12",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/core/src/application/service/application.write.service.ts
+++ b/app/scripts/modules/core/src/application/service/application.write.service.ts
@@ -70,6 +70,7 @@ export class ApplicationWriter {
     if (application.cloudProviders) {
       command.cloudProviders = application.cloudProviders.join(',');
     }
+    delete command.accounts;
     jobs.push({
       type: type,
       application: command,


### PR DESCRIPTION
`accounts` gets set by the directive that renders the attributes on the config screen, but it sets it as an array, which is no good, since we're no longer re-assembling that into a comma-delimited string.

Separate PR forthcoming in Gate to clean up account merging...