### PR TITLE
fix(entityTags): do not pre-optimize tag retrieval in data source

### DIFF
--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/core",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/core/src/serverGroup/serverGroup.dataSource.js
+++ b/app/scripts/modules/core/src/serverGroup/serverGroup.dataSource.js
@@ -1,4 +1,3 @@
-import {uniq} from 'lodash';
 const angular = require('angular');
 
 import {DataSourceConfig} from '../application/service/applicationDataSource';
@@ -37,8 +36,8 @@ module.exports = angular
       if (!SETTINGS.feature.entityTags) {
         return $q.when(null);
       }
-      const serverGroupNames = uniq(serverGroups.map(g => g.name));
-      const clusterNames = uniq(serverGroups.map(g => g.cluster));
+      const serverGroupNames = serverGroups.map(g => g.name);
+      const clusterNames = serverGroups.map(g => g.cluster);
       const serverGroupTagger = entityTagsReader.getAllEntityTags('serverGroup', serverGroupNames).then(tags => {
         serverGroups.forEach(serverGroup => {
           serverGroup.entityTags = tags.find(t => t.entityRef.entityId === serverGroup.name &&


### PR DESCRIPTION
Having put in a nice fix yesterday to the entity tag reader to fetch the correct number of tags, I failed to account for an upstream optimization that reduced the number of tags the entity tag reader would consider, which is...not good.