### PR TITLE
feat(core): include help on instance port, align checkboxes

### DIFF
--- a/app/scripts/modules/core/src/application/application.module.ts
+++ b/app/scripts/modules/core/src/application/application.module.ts
@@ -1,6 +1,4 @@
-'use strict';
-
-const angular = require('angular');
+import { module } from 'angular';
 
 import './ApplicationSearchResultFormatter';
 import { SECONDARY_APPLICATION_NAV_COMPONENT } from './nav/secondaryNav.component';
@@ -8,9 +6,10 @@ import { APPLICATION_STATE_PROVIDER } from './application.state.provider';
 import { APPLICATIONS_STATE_PROVIDER } from './applications.state.provider';
 import { APPLICATION_COMPONENT } from './application.component';
 import { PERMISSIONS_CONFIGURER_COMPONENT } from './modal/permissionsConfigurer.component';
+import { UPSERT_APPLICATION_HELP } from './modal/upsertApplication.help';
 
-module.exports = angular
-  .module('spinnaker.application', [
+export const APPLICATION_MODULE = 'spinnaker.core.application';
+module(APPLICATION_MODULE, [
     APPLICATION_STATE_PROVIDER,
     APPLICATIONS_STATE_PROVIDER,
     APPLICATION_COMPONENT,
@@ -24,4 +23,5 @@ module.exports = angular
     require('./nav/applicationNav.component'),
     SECONDARY_APPLICATION_NAV_COMPONENT,
     PERMISSIONS_CONFIGURER_COMPONENT,
+    UPSERT_APPLICATION_HELP,
   ]);

--- a/app/scripts/modules/core/src/application/modal/editApplication.html
+++ b/app/scripts/modules/core/src/application/modal/editApplication.html
@@ -112,7 +112,7 @@
 
       <div class="form-group row">
         <div class="col-sm-3 sm-label-right">Instance Health</div>
-        <div class="col-sm-9 checkbox" style="margin-bottom: 0">
+        <div class="col-sm-9 sm-control-field checkbox">
           <label>
             <input type="checkbox"
                    ng-model="editApp.applicationAttributes.platformHealthOnly"
@@ -124,7 +124,7 @@
       </div>
 
       <div class="form-group row">
-        <div class="col-sm-9 col-sm-offset-3 checkbox" style="margin-top: 0">
+        <div class="col-sm-9 col-sm-offset-3 sm-control-field checkbox">
           <label>
             <input type="checkbox"
                    ng-model="editApp.applicationAttributes.platformHealthOnlyShowOverride"
@@ -147,7 +147,10 @@
       </div>
 
       <div class="form-group row">
-        <div class="col-sm-3 sm-label-right">Instance Port</div>
+        <div class="col-sm-3 sm-label-right">
+          Instance Port
+          <help-field key="application.instance.port"></help-field>
+        </div>
         <div class="col-sm-2">
           <input type="number"
                  min="0"
@@ -160,10 +163,12 @@
 
       <div class="form-group row">
         <div class="col-sm-3 sm-label-right">Pipeline Behavior</div>
-        <div class="col-sm-9">
-          <input type="checkbox"
-                 ng-model="editApp.applicationAttributes.enableRestartRunningExecutions">
-          Enable restarting running pipelines
+        <div class="col-sm-9 sm-control-field checkbox">
+          <label>
+            <input type="checkbox"
+                   ng-model="editApp.applicationAttributes.enableRestartRunningExecutions">
+            Enable restarting running pipelines
+          </label>
           <help-field key="application.enableRestartRunningExecutions"></help-field>
         </div>
       </div>

--- a/app/scripts/modules/core/src/application/modal/newapplication.html
+++ b/app/scripts/modules/core/src/application/modal/newapplication.html
@@ -127,7 +127,7 @@
 
       <div class="form-group row">
         <div class="col-sm-3 sm-label-right">Instance Health</div>
-        <div class="col-sm-9 checkbox" style="margin-bottom: 0; margin-top: 5px">
+        <div class="col-sm-9 sm-control-field checkbox">
           <label>
             <input type="checkbox"
                    ng-model="newAppModal.application.platformHealthOnly"/>
@@ -139,7 +139,7 @@
 
       <div class="form-group row">
         <div class="col-sm-3 sm-label-right"></div>
-        <div class="col-sm-9 checkbox" style="margin-top: 0">
+        <div class="col-sm-9 sm-control-field checkbox">
           <label>
             <input type="checkbox"
                    ng-model="newAppModal.application.platformHealthOnlyShowOverride"
@@ -162,7 +162,10 @@
       </div>
 
       <div class="form-group row">
-        <div class="col-sm-3 sm-label-right">Instance Port</div>
+        <div class="col-sm-3 sm-label-right">
+          Instance Port
+          <help-field key="application.instance.port"></help-field>
+        </div>
         <div class="col-sm-2">
           <input type="number"
                  min="0"
@@ -175,10 +178,12 @@
 
       <div class="form-group row">
         <div class="col-sm-3 sm-label-right">Pipeline Behavior</div>
-        <div class="col-sm-9">
-          <input type="checkbox"
-                 ng-model="editApp.applicationAttributes.enableRestartRunningExecutions">
-          Enable restarting running pipelines
+        <div class="col-sm-9 sm-control-field checkbox">
+          <label>
+            <input type="checkbox"
+                   ng-model="editApp.applicationAttributes.enableRestartRunningExecutions">
+            Enable restarting running pipelines
+          </label>
           <help-field key="application.enableRestartRunningExecutions"></help-field>
         </div>
       </div>

--- a/app/scripts/modules/core/src/application/modal/upsertApplication.help.ts
+++ b/app/scripts/modules/core/src/application/modal/upsertApplication.help.ts
@@ -1,0 +1,32 @@
+import {module} from 'angular';
+import {HELP_CONTENTS_REGISTRY, HelpContentsRegistry} from 'core/help/helpContents.registry';
+
+const helpContents: {[key: string]: string} = {
+  'application.platformHealthOnly': `
+        When this option is enabled, instance status as reported by the cloud provider will be considered sufficient to
+        determine task completion. When this option is disabled, tasks will normally need health status reported by some other health provider (e.g. a
+        load balancer or discovery service) to determine task completion.`,
+  'application.showPlatformHealthOverride': 'When this option is enabled, users will be able to toggle the option above on a task-by-task basis.',
+  'application.permissions': `
+      <ul>
+        <li>To read from this application, a user must be a member of at least one group with read access.</li>
+        <li>To write to this application, a user must be a member of at least one group with write access.</li>
+        <li>If no permissions are specified, any user can read from or write to this application.</li>
+        <li>These permissions will only be enforced if Fiat is enabled.</li>
+      </ul>
+    `,
+  'application.enableRestartRunningExecutions': `
+        When this option is enabled, users will be able to restart pipeline stages while a pipeline is still running.
+        This behavior can have varying unexpected results and is <b>not recommended</b> to enable.`,
+  'application.instance.port': `
+     <p>This field is only used to generate links within Spinnaker to a running instance when viewing an
+     instance's details.</p> The instance port can be used or overridden for specific links configured for your
+     application (via the Config screen).
+  `,
+};
+
+export const UPSERT_APPLICATION_HELP = 'spinnaker.core.application.upsert.help.contents';
+module(UPSERT_APPLICATION_HELP, [HELP_CONTENTS_REGISTRY])
+  .run((helpContentsRegistry: HelpContentsRegistry) => {
+    Object.keys(helpContents).forEach(key => helpContentsRegistry.register(key, helpContents[key]));
+  });

--- a/app/scripts/modules/core/src/core.module.js
+++ b/app/scripts/modules/core/src/core.module.js
@@ -20,6 +20,7 @@ import Spinner from 'spin.js';
 
 import { ANALYTICS_MODULE } from './analytics/analytics.module';
 import { APPLICATION_BOOTSTRAP_MODULE } from './bootstrap/applicationBootstrap.module';
+import { APPLICATION_MODULE } from './application/application.module';
 import { AUTHENTICATION_MODULE } from './authentication/authentication.module';
 import { CANCEL_MODAL_MODULE } from './cancelModal/cancelModal.module';
 import { CLOUD_PROVIDER_MODULE } from './cloudProvider/cloudProvider.module';
@@ -65,7 +66,7 @@ module.exports = angular
     require('angular-spinner').angularSpinner.name,
 
     ANALYTICS_MODULE,
-    require('./application/application.module'),
+    APPLICATION_MODULE,
     APPLICATION_BOOTSTRAP_MODULE,
     AUTHENTICATION_MODULE,
 

--- a/app/scripts/modules/core/src/help/help.contents.ts
+++ b/app/scripts/modules/core/src/help/help.contents.ts
@@ -7,19 +7,6 @@ export interface IHelpContents {
 export const HELP_CONTENTS = 'spinnaker.core.help.contents';
 module(HELP_CONTENTS, [])
   .constant('helpContents', {
-    'application.platformHealthOnly': `
-        When this option is enabled, instance status as reported by the cloud provider will be considered sufficient to
-        determine task completion. When this option is disabled, tasks will normally need health status reported by some other health provider (e.g. a
-        load balancer or discovery service) to determine task completion.`,
-    'application.showPlatformHealthOverride': 'When this option is enabled, users will be able to toggle the option above on a task-by-task basis.',
-    'application.permissions': `
-      <ul>
-        <li>To read from this application, a user must be a member of at least one group with read access.</li>
-        <li>To write to this application, a user must be a member of at least one group with write access.</li>
-        <li>If no permissions are specified, any user can read from or write to this application.</li>
-        <li>These permissions will only be enforced if Fiat is enabled.</li>
-      </ul>
-    `,
     'core.serverGroup.strategy': 'The deployment strategy tells Spinnaker what to do with the previous version of the server group.',
     'cluster.search': `
         Quickly filter the displayed server groups by the following fields:
@@ -225,9 +212,6 @@ module(HELP_CONTENTS, [])
     'travis.waitForCompletion': 'if unchecked, marks the stage as successful right away without waiting for the Travis job to complete',
     'script.waitForCompletion': 'if unchecked, marks the stage as successful right away without waiting for the script to complete',
     'markdown.examples': 'Some examples of markdown syntax: <br/> *<em>emphasis</em>* <br/> **<b>strong</b>** <br/> [link text](http://url-goes-here)',
-    'application.enableRestartRunningExecutions': `
-        When this option is enabled, users will be able to restart pipeline stages while a pipeline is still running.
-        This behavior can have varying unexpected results and is <b>not recommended</b> to enable.`,
     'pipeline.config.webhook.payload': 'JSON payload to be added to the webhook call.',
     'pipeline.config.webhook.waitForCompletion': 'If not checked, we consider the stage succeeded if the webhook returns an HTTP status code 2xx, otherwise it will be failed. If checked, it will poll a status url (defined below) to determine the progress of the stage.',
     'pipeline.config.webhook.statusUrlResolutionIsGetMethod': 'Use the webhook\'s URL with GET method as status endpoint.',

--- a/app/scripts/modules/core/src/presentation/main.less
+++ b/app/scripts/modules/core/src/presentation/main.less
@@ -607,6 +607,10 @@ body > .container {
   }
 }
 
+.sm-control-field {
+  margin-top: 5px;
+}
+
 .sm-label-left {
   text-align: left;
 }


### PR DESCRIPTION
* adds some explanatory text to the cryptic "Instance Port" field.
* moves application modal help to its own file
* fixes the alignment of some checkboxes and their labels in the create/edit application modals