### PR TITLE
chore(amazon): ensure module names all start with "spinnaker.amazon"

### DIFF
--- a/app/scripts/modules/amazon/src/cache/cacheConfigurer.service.js
+++ b/app/scripts/modules/amazon/src/cache/cacheConfigurer.service.js
@@ -11,7 +11,7 @@ import {
 
 import { VPC_READ_SERVICE } from '../vpc/vpc.read.service';
 
-module.exports = angular.module('spinnaker.aws.cache.initializer', [
+module.exports = angular.module('spinnaker.amazon.cache.initializer', [
   ACCOUNT_SERVICE,
   LOAD_BALANCER_READ_SERVICE,
   INSTANCE_TYPE_SERVICE,

--- a/app/scripts/modules/amazon/src/image/image.reader.js
+++ b/app/scripts/modules/amazon/src/image/image.reader.js
@@ -4,7 +4,7 @@ const angular = require('angular');
 
 import { API_SERVICE } from '@spinnaker/core';
 
-module.exports = angular.module('spinnaker.aws.image.reader', [API_SERVICE])
+module.exports = angular.module('spinnaker.amazon.image.reader', [API_SERVICE])
   .factory('awsImageReader', function ($q, API) {
 
     function findImages(params) {

--- a/app/scripts/modules/amazon/src/instance/awsInstanceType.service.js
+++ b/app/scripts/modules/amazon/src/instance/awsInstanceType.service.js
@@ -5,7 +5,7 @@ import _ from 'lodash';
 
 import { API_SERVICE, INFRASTRUCTURE_CACHE_SERVICE } from '@spinnaker/core';
 
-module.exports = angular.module('spinnaker.aws.instanceType.service', [
+module.exports = angular.module('spinnaker.amazon.instanceType.service', [
   API_SERVICE,
   INFRASTRUCTURE_CACHE_SERVICE
 ])

--- a/app/scripts/modules/amazon/src/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/amazon/src/instance/details/instance.details.controller.js
@@ -12,7 +12,7 @@ import {
   SETTINGS
 } from '@spinnaker/core';
 
-module.exports = angular.module('spinnaker.instance.detail.aws.controller', [
+module.exports = angular.module('spinnaker.amazon.instance.details.controller', [
   require('angular-ui-router').default,
   require('angular-ui-bootstrap'),
   INSTANCE_WRITE_SERVICE,

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/createLoadBalancer.controller.js
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/createLoadBalancer.controller.js
@@ -17,7 +17,7 @@ import {
 import { AWSProviderSettings } from '../../aws.settings';
 import { SUBNET_SELECT_FIELD_COMPONENT } from '../../subnet/subnetSelectField.component';
 
-module.exports = angular.module('spinnaker.loadBalancer.aws.create.controller', [
+module.exports = angular.module('spinnaker.amazon.loadBalancer.create.controller', [
   require('angular-ui-router').default,
   LOAD_BALANCER_WRITE_SERVICE,
   ACCOUNT_SERVICE,

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/loadBalancerAvailabilityZoneSelector.directive.js
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/loadBalancerAvailabilityZoneSelector.directive.js
@@ -2,7 +2,7 @@
 
 const angular = require('angular');
 
-module.exports = angular.module('spinnaker.loadBalancers.configure.aws.loadBalancerZoneSelector.directive', [
+module.exports = angular.module('spinnaker.amazon.loadBalancerZoneSelector.directive', [
 ])
   .directive('loadBalancerAvailabilityZoneSelector', function() {
     return {

--- a/app/scripts/modules/amazon/src/loadBalancer/details/targetGroupDetails.controller.ts
+++ b/app/scripts/modules/amazon/src/loadBalancer/details/targetGroupDetails.controller.ts
@@ -74,7 +74,7 @@ export class AwsTargetGroupDetailsController {
 }
 
 
-export const AWS_TARGET_GROUP_DETAILS_CTRL = 'spinnaker.aws.loadBalancer.details.targetGroupDetails.controller';
+export const AWS_TARGET_GROUP_DETAILS_CTRL = 'spinnaker.amazon.loadBalancer.details.targetGroupDetails.controller';
 module(AWS_TARGET_GROUP_DETAILS_CTRL, [
   require('angular-ui-router').default,
 ]).controller('awsTargetGroupDetailsCtrl', AwsTargetGroupDetailsController);

--- a/app/scripts/modules/amazon/src/loadBalancer/loadBalancer.transformer.js
+++ b/app/scripts/modules/amazon/src/loadBalancer/loadBalancer.transformer.js
@@ -6,7 +6,7 @@ import _ from 'lodash';
 import { AWSProviderSettings } from '../aws.settings';
 import { VPC_READ_SERVICE } from '../vpc/vpc.read.service';
 
-module.exports = angular.module('spinnaker.aws.loadBalancer.transformer', [
+module.exports = angular.module('spinnaker.amazon.loadBalancer.transformer', [
   VPC_READ_SERVICE,
 ])
   .factory('awsLoadBalancerTransformer', function (vpcReader) {

--- a/app/scripts/modules/amazon/src/securityGroup/configure/EditSecurityGroupCtrl.js
+++ b/app/scripts/modules/amazon/src/securityGroup/configure/EditSecurityGroupCtrl.js
@@ -5,7 +5,7 @@ import _ from 'lodash';
 
 import { ACCOUNT_SERVICE, SECURITY_GROUP_WRITER, TASK_MONITOR_BUILDER } from '@spinnaker/core';
 
-module.exports = angular.module('spinnaker.securityGroup.aws.edit.controller', [
+module.exports = angular.module('spinnaker.amazon.securityGroup.edit.controller', [
   require('angular-ui-router').default,
   ACCOUNT_SERVICE,
   TASK_MONITOR_BUILDER,

--- a/app/scripts/modules/amazon/src/securityGroup/details/securityGroupDetail.controller.js
+++ b/app/scripts/modules/amazon/src/securityGroup/details/securityGroupDetail.controller.js
@@ -11,7 +11,7 @@ import {
   SECURITY_GROUP_WRITER
 } from '@spinnaker/core';
 
-module.exports = angular.module('spinnaker.securityGroup.aws.details.controller', [
+module.exports = angular.module('spinnaker.amazon.securityGroup.details.controller', [
   require('angular-ui-router').default,
   SECURITY_GROUP_READER,
   SECURITY_GROUP_WRITER,

--- a/app/scripts/modules/amazon/src/securityGroup/securityGroup.transformer.js
+++ b/app/scripts/modules/amazon/src/securityGroup/securityGroup.transformer.js
@@ -4,7 +4,7 @@ const angular = require('angular');
 
 import { VPC_READ_SERVICE } from '../vpc/vpc.read.service';
 
-module.exports = angular.module('spinnaker.aws.securityGroup.transformer', [
+module.exports = angular.module('spinnaker.amazon.securityGroup.transformer', [
   VPC_READ_SERVICE,
 ])
   .factory('awsSecurityGroupTransformer', function (vpcReader) {

--- a/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupCommandBuilder.service.js
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupCommandBuilder.service.js
@@ -7,7 +7,7 @@ import { ACCOUNT_SERVICE, INSTANCE_TYPE_SERVICE, NAMING_SERVICE, SUBNET_READ_SER
 
 import { AWSProviderSettings } from 'amazon/aws.settings';
 
-module.exports = angular.module('spinnaker.aws.serverGroupCommandBuilder.service', [
+module.exports = angular.module('spinnaker.amazon.serverGroupCommandBuilder.service', [
   ACCOUNT_SERVICE,
   SUBNET_READ_SERVICE,
   INSTANCE_TYPE_SERVICE,

--- a/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupConfiguration.service.js
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupConfiguration.service.js
@@ -15,7 +15,7 @@ import {
 
 import { KEY_PAIRS_READ_SERVICE } from 'amazon/keyPairs/keyPairs.read.service';
 
-module.exports = angular.module('spinnaker.aws.serverGroup.configure.service', [
+module.exports = angular.module('spinnaker.amazon.serverGroup.configure.service', [
   require('../../image/image.reader.js'),
   ACCOUNT_SERVICE,
   NAMING_SERVICE,

--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/CloneServerGroup.aws.controller.js
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/CloneServerGroup.aws.controller.js
@@ -10,7 +10,7 @@ import {
   V2_MODAL_WIZARD_SERVICE
 } from '@spinnaker/core';
 
-module.exports = angular.module('spinnaker.aws.cloneServerGroup.controller', [
+module.exports = angular.module('spinnaker.amazon.cloneServerGroup.controller', [
   require('angular-ui-router').default,
   require('../serverGroupConfiguration.service.js'),
   SERVER_GROUP_WRITER,

--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/location/ServerGroupBasicSettings.controller.js
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/location/ServerGroupBasicSettings.controller.js
@@ -6,7 +6,7 @@ import { Observable, Subject } from 'rxjs';
 import { IMAGE_READER, NAMING_SERVICE, V2_MODAL_WIZARD_SERVICE } from '@spinnaker/core';
 import { SUBNET_SELECT_FIELD_COMPONENT } from 'amazon/subnet/subnetSelectField.component';
 
-module.exports = angular.module('spinnaker.serverGroup.configure.aws.basicSettings', [
+module.exports = angular.module('spinnaker.amazon.serverGroup.configure.basicSettings', [
   require('angular-ui-router').default,
   require('angular-ui-bootstrap'),
   V2_MODAL_WIZARD_SERVICE,

--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/templateSelection/deployInitializer.controller.js
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/templateSelection/deployInitializer.controller.js
@@ -5,7 +5,7 @@ import _ from 'lodash';
 
 import { SERVER_GROUP_READER } from '@spinnaker/core';
 
-module.exports = angular.module('spinnaker.serverGroup.configure.aws.deployInitialization.controller', [
+module.exports = angular.module('spinnaker.amazon.serverGroup.configure.deployInitialization.controller', [
   SERVER_GROUP_READER,
   require('../../serverGroupCommandBuilder.service.js'),
 ])

--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/zones/availabilityZoneSelector.directive.js
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/zones/availabilityZoneSelector.directive.js
@@ -2,7 +2,7 @@
 
 const angular = require('angular');
 
-module.exports = angular.module('spinnaker.serverGroups.configure.aws.wizard.zoneSelector.directive', [
+module.exports = angular.module('spinnaker.amazon.serverGroups.configure.wizard.zoneSelector.directive', [
 ])
   .directive('availabilityZoneSelector', function() {
     return {

--- a/app/scripts/modules/amazon/src/serverGroup/details/advancedSettings/editAsgAdvancedSettings.modal.controller.js
+++ b/app/scripts/modules/amazon/src/serverGroup/details/advancedSettings/editAsgAdvancedSettings.modal.controller.js
@@ -4,7 +4,7 @@ const angular = require('angular');
 
 import { TASK_EXECUTOR, TASK_MONITOR_BUILDER } from '@spinnaker/core';
 
-module.exports = angular.module('spinnaker.serverGroup.details.aws.advancedSettings.editAsgAdvancedSettings.modal.controller', [
+module.exports = angular.module('spinnaker.amazon.serverGroup.editAsgAdvancedSettings.modal.controller', [
   TASK_MONITOR_BUILDER,
   TASK_EXECUTOR,
   require('../../configure/serverGroupCommandBuilder.service.js'),

--- a/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/chart/metricAlarmChart.component.js
+++ b/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/chart/metricAlarmChart.component.js
@@ -13,7 +13,7 @@ import './LineChartHack.css';
 import './metricAlarmChart.component.less';
 
 module.exports = angular
-  .module('spinnaker.aws.serverGroup.details.scalingPolicy.metricAlarmChart.component', [
+  .module('spinnaker.amazon.serverGroup.details.scalingPolicy.metricAlarmChart.component', [
     CLOUD_METRICS_READ_SERVICE,
     require('exports-loader?"n3-line-chart"!n3-charts/build/LineChart.js'),
   ])

--- a/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/scalingPolicy.write.service.js
+++ b/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/scalingPolicy.write.service.js
@@ -5,7 +5,7 @@ const angular = require('angular');
 import { TASK_EXECUTOR } from '@spinnaker/core';
 
 module.exports = angular
-  .module('spinnaker.aws.serverGroup.details.scalingPolicy.write.service', [
+  .module('spinnaker.amazon.serverGroup.details.scalingPolicy.write.service', [
     TASK_EXECUTOR,
   ])
   .factory('scalingPolicyWriter', function (taskExecutor) {

--- a/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/scalingPolicySummary.component.js
+++ b/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/scalingPolicySummary.component.js
@@ -8,7 +8,7 @@ import { SCALING_POLICY_POPOVER } from './popover/scalingPolicyPopover.component
 
 import './scalingPolicySummary.component.less';
 
-module.exports = angular.module('spinnaker.aws.serverGroup.details.scalingPolicy.component', [
+module.exports = angular.module('spinnaker.amazon.serverGroup.details.scalingPolicy.component', [
   require('./scalingPolicy.write.service.js'),
   require('./upsert/upsertScalingPolicy.controller.js'),
   SCALING_POLICY_POPOVER,

--- a/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/upsert/alarm/alarmConfigurer.component.js
+++ b/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/upsert/alarm/alarmConfigurer.component.js
@@ -9,7 +9,7 @@ import { AWSProviderSettings } from 'amazon/aws.settings';
 
 
 module.exports = angular
-  .module('spinnaker.aws.serverGroup.details.scalingPolicy.alarm.configurer', [
+  .module('spinnaker.amazon.serverGroup.details.scalingPolicy.alarm.configurer', [
     CLOUD_METRICS_READ_SERVICE,
     require('./dimensionsEditor.component.js'),
   ])

--- a/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/upsert/alarm/dimensionsEditor.component.js
+++ b/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/upsert/alarm/dimensionsEditor.component.js
@@ -9,7 +9,7 @@ import { Observable, Subject } from 'rxjs';
 import './dimensionsEditor.component.less';
 
 module.exports = angular
-  .module('spinnaker.aws.serverGroup.details.scalingPolicy.dimensionEditor', [
+  .module('spinnaker.amazon.serverGroup.details.scalingPolicy.dimensionEditor', [
     CLOUD_METRICS_READ_SERVICE,
   ])
   .component('dimensionsEditor', {

--- a/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/upsert/simple/simplePolicyAction.component.js
+++ b/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/upsert/simple/simplePolicyAction.component.js
@@ -3,7 +3,7 @@
 const angular = require('angular');
 
 module.exports = angular
-  .module('spinnaker.aws.serverGroup.details.scalingPolicy.upsert.actions.simplePolicy', [
+  .module('spinnaker.amazon.serverGroup.details.scalingPolicy.upsert.actions.simplePolicy', [
   ])
   .component('awsSimplePolicyAction', {
     bindings: {

--- a/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/upsert/upsertScalingPolicy.controller.js
+++ b/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/upsert/upsertScalingPolicy.controller.js
@@ -9,7 +9,7 @@ import { STEP_POLICY_ACTION } from './step/stepPolicyAction.component';
 import './upsertScalingPolicy.modal.less';
 
 module.exports = angular
-  .module('spinnaker.aws.serverGroup.details.scalingPolicy.upsertScalingPolicy.controller', [
+  .module('spinnaker.amazon.serverGroup.details.scalingPolicy.upsertScalingPolicy.controller', [
     require('../scalingPolicy.write.service.js'),
     require('exports-loader?"n3-line-chart"!n3-charts/build/LineChart.js'),
     require('./simple/simplePolicyAction.component.js'),

--- a/app/scripts/modules/amazon/src/serverGroup/details/scalingProcesses/autoScalingProcess.service.js
+++ b/app/scripts/modules/amazon/src/serverGroup/details/scalingProcesses/autoScalingProcess.service.js
@@ -2,7 +2,7 @@
 
 const angular = require('angular');
 
-module.exports = angular.module('spinnaker.serverGroup.details.aws.autoscaling.process', [])
+module.exports = angular.module('spinnaker.amazon.serverGroup.details.autoscaling.process', [])
   .factory('autoScalingProcessService', function() {
     function listProcesses() {
       return [

--- a/app/scripts/modules/amazon/src/serverGroup/details/scalingProcesses/modifyScalingProcesses.controller.js
+++ b/app/scripts/modules/amazon/src/serverGroup/details/scalingProcesses/modifyScalingProcesses.controller.js
@@ -5,7 +5,7 @@ import _ from 'lodash';
 
 import { TASK_EXECUTOR, TASK_MONITOR_BUILDER } from '@spinnaker/core';
 
-module.exports = angular.module('spinnaker.serverGroup.details.aws.autoscaling.process.controller', [
+module.exports = angular.module('spinnaker.amazon.serverGroup.details.autoscaling.process.controller', [
   TASK_MONITOR_BUILDER,
   TASK_EXECUTOR,
   ])

--- a/app/scripts/modules/amazon/src/serverGroup/details/scheduledAction/editScheduledActions.modal.controller.js
+++ b/app/scripts/modules/amazon/src/serverGroup/details/scheduledAction/editScheduledActions.modal.controller.js
@@ -4,7 +4,7 @@ const angular = require('angular');
 
 import { TASK_EXECUTOR, TASK_MONITOR_BUILDER } from '@spinnaker/core';
 
-module.exports = angular.module('spinnaker.serverGroup.details.aws.scheduledActions.editScheduledActions.modal.controller', [
+module.exports = angular.module('spinnaker.amazon.serverGroup.details.scheduledActions.editScheduledActions.modal.controller', [
   TASK_MONITOR_BUILDER,
   TASK_EXECUTOR,
 ])

--- a/app/scripts/modules/amazon/src/serverGroup/details/securityGroup/editSecurityGroups.modal.controller.js
+++ b/app/scripts/modules/amazon/src/serverGroup/details/securityGroup/editSecurityGroups.modal.controller.js
@@ -5,7 +5,7 @@ import _ from 'lodash';
 
 import { SECURITY_GROUP_READER, SERVER_GROUP_WRITER, TASK_EXECUTOR, TASK_MONITOR_BUILDER } from '@spinnaker/core';
 
-module.exports = angular.module('spinnaker.serverGroup.details.aws.securityGroup.editSecurityGroups.modal.controller', [
+module.exports = angular.module('spinnaker.amazon.serverGroup.details.securityGroup.editSecurityGroups.modal.controller', [
   TASK_MONITOR_BUILDER,
   SERVER_GROUP_WRITER,
   SECURITY_GROUP_READER,

--- a/app/scripts/modules/amazon/src/serverGroup/details/serverGroupDetails.aws.controller.js
+++ b/app/scripts/modules/amazon/src/serverGroup/details/serverGroupDetails.aws.controller.js
@@ -17,7 +17,7 @@ import {
   ServerGroupTemplates,
 } from '@spinnaker/core';
 
-module.exports = angular.module('spinnaker.serverGroup.details.aws.controller', [
+module.exports = angular.module('spinnaker.amazon.serverGroup.details.controller', [
   require('angular-ui-router').default,
   SERVER_GROUP_CONFIGURE_MODULE,
   CONFIRMATION_MODAL_SERVICE,

--- a/app/scripts/modules/amazon/src/serverGroup/serverGroup.transformer.js
+++ b/app/scripts/modules/amazon/src/serverGroup/serverGroup.transformer.js
@@ -5,7 +5,7 @@ import _ from 'lodash';
 
 import { VPC_READ_SERVICE } from '../vpc/vpc.read.service';
 
-module.exports = angular.module('spinnaker.aws.serverGroup.transformer', [
+module.exports = angular.module('spinnaker.amazon.serverGroup.transformer', [
     VPC_READ_SERVICE,
   ])
   .factory('awsServerGroupTransformer', function (vpcReader) {

--- a/app/scripts/modules/amazon/src/vpc/vpcTag.directive.js
+++ b/app/scripts/modules/amazon/src/vpc/vpcTag.directive.js
@@ -4,7 +4,7 @@ const angular = require('angular');
 
 import { VPC_READ_SERVICE } from '../vpc/vpc.read.service';
 
-module.exports = angular.module('spinnaker.vpc.tag.directive', [
+module.exports = angular.module('spinnaker.amazon.vpc.tag.directive', [
   VPC_READ_SERVICE,
 ])
   .directive('vpcTag', function(vpcReader) {


### PR DESCRIPTION
Not getting too prescriptive, just makes everything (probably) in the `amazon` package start with `spinnaker.amazon`.