### PR TITLE
fix(core): initialize strategy selector

### DIFF
--- a/app/scripts/modules/core/src/deploymentStrategy/deploymentStrategySelector.component.ts
+++ b/app/scripts/modules/core/src/deploymentStrategy/deploymentStrategySelector.component.ts
@@ -19,6 +19,7 @@ export class DeploymentStrategySelectorController implements IComponentControlle
 
   public $onInit() {
     this.strategies = DeploymentStrategyRegistry.listStrategies(this.command.selectedProvider || this.command.cloudProvider);
+    this.selectStrategy();
   }
 
   public selectStrategy(): void {


### PR DESCRIPTION
This isn't a problem for ad-hoc deploys (since they default to no strategy), but, when editing clusters in pipelines, if you have "red-black" or "custom" selected, the additional fields aren't displayed unless you switch to a different strategy, then back.