### PR TITLE
fix(pipelines): correct diff on stages, smaller stringVal, dedupes

### DIFF
--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/core",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/core/src/delivery/service/executions.transformer.service.js
+++ b/app/scripts/modules/core/src/delivery/service/executions.transformer.service.js
@@ -235,7 +235,10 @@ module.exports = angular.module('spinnaker.core.delivery.executionTransformer.se
       var allPhasesResolved = true;
       // remove any invalid requisiteStageRefIds, set requisiteStageRefIds to empty for synthetic stages
       stages.forEach(function (stage) {
-        stage.requisiteStageRefIds = stage.requisiteStageRefIds || [];
+        if (_.has(stage, 'context.requisiteIds')) {
+          stage.context.requisiteIds = _.uniq(stage.context.requisiteIds);
+        }
+        stage.requisiteStageRefIds = _.uniq(stage.requisiteStageRefIds || []);
         stage.requisiteStageRefIds = stage.requisiteStageRefIds.filter(function(parentId) {
           return _.find(stages, { refId: parentId });
         });


### PR DESCRIPTION
1. Omit a couple other fields when computing the `stringVal` for an execution: `requisiteIds`, `requisiteStageRefIds` - this is to deal with a weird bug in Orca where restarted stages can end up with 500k+ entries in that field
2. Dedupe the fields above, again just to get around the Orca bug
3. Correctly calculate whether stages have changed when synchronizing by looking at the stage itself, not the entire execution (which is always gonna be different, duh). This makes a (not really) surprisingly big difference.
4. When computing the `stringVal` for an execution, omit completed/not started stages. These should not ever change and thus should not factor into the `stringVal`, which is used to determine if the execution has changed.

There will probably be some bugs here, but the best way to find out is through post-hoc code review and/or user complaints.