### PR TITLE
fix(tests): exclude /lib/ from test context

### DIFF
--- a/karma-shim.js
+++ b/karma-shim.js
@@ -20,4 +20,4 @@ beforeEach(angular.mock.module('bcherny/ngimport'));
 require('./test/helpers/customMatchers');
 
 const testContext = require.context('./app/scripts/', true, /\.spec\.(js|ts|tsx)$/);
-testContext.keys().forEach(testContext);
+testContext.keys().filter(k => !k.includes('/lib/')).forEach(testContext);


### PR DESCRIPTION
This only matters when you've run the `lib` builds for core, amazon, docker, etc, as they leave artifacts in the `/lib` directory, which karma doesn't like.

Opted for a `filter` call here as opposed to making the regex more convoluted.

Possibly better fix involves not outputting the spec files in `/lib`, who knows what that looks like...