### PR TITLE
refactor(provider/amazon): Separate load balancer types

### DIFF
--- a/app/scripts/modules/amazon/src/domain/IAmazonLoadBalancer.ts
+++ b/app/scripts/modules/amazon/src/domain/IAmazonLoadBalancer.ts
@@ -1,10 +1,11 @@
-import { ILoadBalancer, IInstance, IInstanceCounts, IServerGroup, ISubnet } from '@spinnaker/core';
+import { IAmazonLoadBalancerSourceData } from './IAmazonLoadBalancerSourceData';
+import { ILoadBalancer, IInstance, IInstanceCounts, IServerGroup, ISubnet, IUpsertLoadBalancerCommand } from '@spinnaker/core';
 
 export interface IAmazonLoadBalancer extends ILoadBalancer {
   availabilityZones?: string[];
   credentials?: string;
   detachedInstances?: IInstance[];
-  elb?: any;
+  elb?: IAmazonLoadBalancerSourceData;
   isInternal?: boolean;
   regionZones: string[];
   subnets?: string[];
@@ -13,9 +14,9 @@ export interface IAmazonLoadBalancer extends ILoadBalancer {
 }
 
 export interface IClassicListener {
-  internalProtocol: string;
+  internalProtocol: 'HTTP' | 'HTTPS' | 'TCP' | 'SSL';
   internalPort: number;
-  externalProtocol: string;
+  externalProtocol: 'HTTP' | 'HTTPS' | 'TCP' | 'SSL';
   externalPort: number;
   sslCertificateType?: string;
 }
@@ -38,18 +39,19 @@ export interface IAmazonApplicationLoadBalancer extends IAmazonLoadBalancer {
   ipAddressType?: string; // returned from clouddriver
 }
 
-export interface IALBListenerActions {
+export interface IListenerAction {
   targetGroupName: string;
   type: string;
 }
 
 export interface IALBListenerCertificate {
+  certificateArn: string;
   type: string;
   name: string;
 }
 export interface IALBListener {
   certificates: IALBListenerCertificate[];
-  defaultActions: IALBListenerActions[];
+  defaultActions: IListenerAction[];
   port: number;
   protocol: string;
   sslPolicy?: string;
@@ -63,9 +65,9 @@ export interface ITargetGroupAttributes {
 }
 
 export interface ITargetGroup {
-  account?: string; // returned from clouddriver
+  account: string; // returned from clouddriver
   attributes?: ITargetGroupAttributes;
-  cloudProvider?: string; // returned from clouddriver
+  cloudProvider: string; // returned from clouddriver
   detachedInstances?: IInstance[];
   healthCheckProtocol: string;
   healthCheckPort: number;
@@ -76,14 +78,88 @@ export interface ITargetGroup {
   unhealthyThreshold: number;
   instanceCounts?: IInstanceCounts;
   instances?: IInstance[];
-  loadBalancerNames?: string[]; // returned from clouddriver
+  loadBalancerNames: string[]; // returned from clouddriver
   name: string;
   port: number;
   protocol: string;
   provider?: string;
-  region?: string; // returned from clouddriver
+  region: string; // returned from clouddriver
   serverGroups?: IServerGroup[];
-  type?: string; // returned from clouddriver
+  type: string; // returned from clouddriver
   vpcId?: string;
   vpcName?: string;
+}
+
+export interface IUpsertAmazonLoadBalancerCommand extends IUpsertLoadBalancerCommand {
+  availabilityZones: { [region: string]: string[] };
+  isInternal: boolean;
+  // If loadBalancerType is not provided, will default to 'classic' for bwc
+  loadBalancerType?: 'classic' | 'application' | 'network';
+  regionZones: string[];
+  securityGroups: string[];
+  subnetType: string;
+  vpcId: string;
+}
+
+export interface IClassicListenerCommand extends IClassicListener {
+  sslCertificateId?: string;
+  sslCertificateName?: string;
+}
+
+export interface IUpsertAmazonClassicLoadBalancerCommand extends IUpsertAmazonLoadBalancerCommand {
+  healthCheck: string;
+  healthCheckPath: string;
+  healthCheckProtocol: string;
+  healthCheckPort: number;
+  healthInterval?: number;
+  healthTimeout?: number;
+  healthyThreshold?: number;
+  listeners: IClassicListenerCommand[];
+  unhealthyThreshold?: number;
+}
+
+export interface IUpsertAmazonApplicationLoadBalancerCommand extends IUpsertAmazonLoadBalancerCommand {
+  listeners: {
+    certificates?: { certificateArn: string }[];
+    protocol: 'HTTP' | 'HTTPS';
+    port: number;
+    sslPolicy?: string;
+    defaultActions: IListenerAction[];
+    rules?: {
+      actions: IListenerAction[];
+      priority: number;
+      ruleConditions: {
+        field: 'path-pattern' | 'host-header';
+        values: string[];
+      }[];
+    }[];
+  }[];
+  targetGroups: {
+    name: string;
+    protocol: 'HTTP' | 'HTTPS';
+    port: number;
+    attributes: {
+      // Defaults to 300
+      deregistrationDelay?: number;
+      // Defaults to false
+      stickinessEnabled?: boolean;
+      // Defaults to 'lb_cookie'. The only option for now, but they promise there will be more...
+      stickinessType?: 'lb_cookie';
+      // Defaults to 86400
+      stickinessDuration?: number;
+    };
+    // Defaults to 10
+    healthCheckInterval?: number;
+    // Defaults to '200-299'
+    healthCheckMatcher?: string;
+    healthCheckPath: string;
+    healthCheckPort: string;
+    healthCheckProtocol: 'HTTP' | 'HTTPS';
+    // Defaults to 10
+    healthyThreshold?: number;
+    // Defaults to 5
+    healthCheckTimeout?: number;
+    // Defaults to 2
+    unhealthyThreshold?: number;
+  }[];
 }

--- a/app/scripts/modules/amazon/src/domain/IAmazonLoadBalancerSourceData.ts
+++ b/app/scripts/modules/amazon/src/domain/IAmazonLoadBalancerSourceData.ts
@@ -1,0 +1,149 @@
+import { ILoadBalancerSourceData } from '@spinnaker/core';
+
+export interface IAmazonContainerServerGroupSourceData {
+  detachedInstances: string[];
+  isDisabled: boolean;
+  name: string;
+  region: string;
+}
+
+export interface IAmazonLoadBalancerServerGroupSourceData extends IAmazonContainerServerGroupSourceData {
+  instances: IAmazonLoadBalancerInstanceSourceData[];
+}
+
+export interface IAmazonTargetGroupServerGroupSourceData extends IAmazonContainerServerGroupSourceData {
+  instances: IAmazonTargetGroupInstanceSourceData[];
+}
+
+export interface IAmazonInstanceHealthSourceData {
+  type: string;
+  state: 'InService' | 'OutOfService' | 'Unknown';
+  reasonCode: 'ELB' | 'Instance' | 'N/A';
+  description: string;
+}
+
+export interface IAmazonTargetHealthSourceData {
+  description: string;
+  reason: string;
+  state: 'initial' | 'healthy' | 'unhealthy' | 'unused' | 'draining';
+}
+
+export interface IClassicListenerSourceData {
+  instancePort: number;
+  instanceProtocol: string;
+  loadBalancerPort: number;
+  protocol: string;
+}
+
+export interface IAmazonLoadBalancerSourceData extends ILoadBalancerSourceData {
+  account: string;
+  availabilityZones: string[];
+  cloudProvider: string;
+  createdTime: number;
+  dnsname: string;
+  loadBalancerName: string;
+  name: string;
+  region: string;
+  scheme: 'internal' | 'internet-facing';
+  securityGroups: string[];
+  serverGroups: IAmazonLoadBalancerServerGroupSourceData[];
+  subnets: string[];
+  type: string;
+  vpcId: string;
+  // Some of the backend in clouddriver returns a vpcid (lowecase) only,
+  // and was cached with some of that. Until caches roll off and we are
+  // sure clouddriver is cleaed up, leave this dirtiness in here
+  vpcid?: string;
+}
+
+export interface IAmazonLoadBalancerInstanceSourceData {
+  id: string;
+  zone: string;
+  health: IAmazonInstanceHealthSourceData;
+}
+
+export interface IAmazonTargetGroupInstanceSourceData {
+  id: string;
+  zone: string;
+  health: IAmazonTargetHealthSourceData;
+}
+
+export interface IAmazonTargetGroupSourceData {
+  account: string;
+  attributes: {
+    'deregistration_delay.timeout_seconds': number;
+    'stickiness.enabled': boolean;
+    'stickiness.lb_cookie.duration_seconds': number;
+    'stickiness.type': 'lb_cookie';
+  };
+  cloudProvider: string;
+  healthCheckIntervalSeconds: number;
+  healthCheckPath: string;
+  healthCheckPort: string;
+  healthCheckProtocol: string;
+  healthCheckTimeoutSeconds: number;
+  healthyThresholdCount: number;
+  instances: string[];
+  loadBalancerNames: string[];
+  matcher: {
+    httpCode: string;
+  };
+  name: string;
+  port: number;
+  protocol: string;
+  region: string;
+  serverGroups: IAmazonTargetGroupServerGroupSourceData[];
+  targetGroupArn: string;
+  targetGroupName: string;
+  type: string;
+  unhealthyThresholdCount: number;
+  vpcId: string;
+}
+
+export interface IApplicationLoadBalancerSourceData extends IAmazonLoadBalancerSourceData {
+  ipAddressType: 'ipv4' | 'dualstack';
+  listeners: {
+    defaultActions: {
+      targetGroupName: string;
+      type: 'forward';
+    }[];
+    listenerArn: string;
+    loadBalancerName: string;
+    port: number;
+    protocol: string;
+  }[];
+  loadBalancerArn: string;
+  loadBalancerType: 'application' | 'network';
+  state: {
+    code: 'active' | 'provisioning' | 'failed';
+    reason?: string;
+  };
+  targetGroups: IAmazonTargetGroupSourceData[];
+}
+
+export interface IClassicLoadBalancerSourceData extends IAmazonLoadBalancerSourceData {
+  healthCheck: {
+    healthyThreshold: number;
+    interval: number;
+    target: string;
+    timeout: number;
+    unhealthyThreshold: number;
+  }
+  instances: string[];
+  listenerDescriptions: { listener: IClassicListenerSourceData, policyNames: string[] }[];
+  policies: {
+    appCookieStickinessPolicies: {
+      CookieName: string;
+      PolicyName: string;
+    }[];
+    lbcookieStickinessPolicies: {
+      CookieExpirationPeriod: string;
+      PolicyName: string;
+    }[];
+    otherPolicies: any[];
+  }
+  sourceSecurityGroup: {
+    groupName: string;
+    ownerAlias: string;
+  };
+}

--- a/app/scripts/modules/amazon/src/domain/index.ts
+++ b/app/scripts/modules/amazon/src/domain/index.ts
@@ -1,4 +1,5 @@
 export * from './IAmazonLoadBalancer';
+export * from './IAmazonLoadBalancerSourceData';
 export * from './IAmazonHealth';
 export * from './IAmazonScalingPolicy';
 export * from './IAmazonServerGroup';

--- a/app/scripts/modules/azure/loadBalancer/loadBalancer.transformer.js
+++ b/app/scripts/modules/azure/loadBalancer/loadBalancer.transformer.js
@@ -34,7 +34,6 @@ module.exports = angular.module('spinnaker.azure.loadBalancer.transformer', [
 
     function convertLoadBalancerForEditing(loadBalancer) {
       var toEdit = {
-        editMode: true,
         region: loadBalancer.region,
         credentials: loadBalancer.account,
         name: loadBalancer.name,

--- a/app/scripts/modules/core/src/domain/ILoadBalancer.ts
+++ b/app/scripts/modules/core/src/domain/ILoadBalancer.ts
@@ -3,6 +3,13 @@ import { IServerGroup } from './IServerGroup';
 import { IInstanceCounts } from './IInstanceCounts';
 import { IInstance } from './IInstance';
 
+export interface ILoadBalancerSourceData {
+  cloudProvider?: string;
+  name?: string;
+  provider?: string;
+  type?: string;
+}
+
 export interface ILoadBalancer extends ITaggedEntity {
   account?: string;
   cloudProvider?: string;
@@ -17,10 +24,10 @@ export interface ILoadBalancer extends ITaggedEntity {
   securityGroups?: string[];
   serverGroups?: IServerGroup[];
   stack?: string;
-  type?: string;
   vpcId?: string;
   vpcName?: string;
   searchField?: string;
+  type?: string;
   listenerDescriptions?: any[];
 }
 
@@ -30,4 +37,12 @@ export interface ILoadBalancerGroup {
   serverGroups?: IServerGroup[];
   subgroups?: ILoadBalancerGroup[];
   searchField?: string;
+}
+
+export interface IUpsertLoadBalancerCommand {
+  credentials: string;
+  detail?: string;
+  name: string;
+  region: string;
+  stack?: string;
 }

--- a/app/scripts/modules/core/src/loadBalancer/loadBalancer.read.service.ts
+++ b/app/scripts/modules/core/src/loadBalancer/loadBalancer.read.service.ts
@@ -1,13 +1,13 @@
-import {module} from 'angular';
+import { IPromise, IQService, module } from 'angular';
 
-import {API_SERVICE, Api} from 'core/api/api.service';
-import {INFRASTRUCTURE_CACHE_SERVICE, InfrastructureCacheService} from 'core/cache/infrastructureCaches.service';
-import {NAMING_SERVICE, NamingService, IComponentName} from 'core/naming/naming.service';
-import {ILoadBalancer} from 'core/domain';
+import { API_SERVICE, Api } from 'core/api/api.service';
+import { INFRASTRUCTURE_CACHE_SERVICE, InfrastructureCacheService } from 'core/cache/infrastructureCaches.service';
+import { NAMING_SERVICE, NamingService, IComponentName } from 'core/naming/naming.service';
+import { ILoadBalancer, ILoadBalancerSourceData } from 'core/domain';
 
 export interface ILoadBalancersByRegion {
   name: string;
-  loadBalancers: ILoadBalancer[];
+  loadBalancers: ILoadBalancerSourceData[];
 }
 
 export interface ILoadBalancersByAccount {
@@ -17,31 +17,31 @@ export interface ILoadBalancersByAccount {
 
 export class LoadBalancerReader {
 
-  public constructor(private $q: ng.IQService, private API: Api, private namingService: NamingService,
+  public constructor(private $q: IQService, private API: Api, private namingService: NamingService,
                      private loadBalancerTransformer: any, private infrastructureCaches: InfrastructureCacheService) {
     'ngInject';
   }
 
-  public loadLoadBalancers(applicationName: string): ng.IPromise<ILoadBalancer[]> {
+  public loadLoadBalancers(applicationName: string): IPromise<ILoadBalancerSourceData[]> {
     return this.API.one('applications', applicationName).all('loadBalancers').getList()
-      .then((loadBalancers: ILoadBalancer[]) => {
+      .then((loadBalancers: ILoadBalancerSourceData[]) => {
         loadBalancers = this.loadBalancerTransformer.normalizeLoadBalancerSet(loadBalancers);
         return this.$q.all(loadBalancers.map(lb => this.normalizeLoadBalancer(lb)));
       });
   }
 
-  public getLoadBalancerDetails(cloudProvider: string, account: string, region: string, name: string): ng.IPromise<ILoadBalancer[]> {
+  public getLoadBalancerDetails(cloudProvider: string, account: string, region: string, name: string): IPromise<ILoadBalancerSourceData[]> {
     return this.API.all('loadBalancers').all(account).all(region).all(name).withParams({'provider': cloudProvider}).get();
   }
 
-  public listLoadBalancers(cloudProvider: string): ng.IPromise<ILoadBalancersByAccount[]> {
+  public listLoadBalancers(cloudProvider: string): IPromise<ILoadBalancersByAccount[]> {
     return this.API.all('loadBalancers')
       .useCache(this.infrastructureCaches.get('loadBalancers'))
       .withParams({provider: cloudProvider})
       .getList();
   }
 
-  private normalizeLoadBalancer(loadBalancer: ILoadBalancer): ng.IPromise<ILoadBalancer> {
+  private normalizeLoadBalancer(loadBalancer: ILoadBalancerSourceData): IPromise<ILoadBalancer> {
     return this.loadBalancerTransformer.normalizeLoadBalancer(loadBalancer).then((lb: ILoadBalancer) => {
       const nameParts: IComponentName = this.namingService.parseLoadBalancerName(lb.name);
       lb.stack = nameParts.stack;

--- a/app/scripts/modules/google/src/loadBalancer/loadBalancer.transformer.js
+++ b/app/scripts/modules/google/src/loadBalancer/loadBalancer.transformer.js
@@ -70,7 +70,6 @@ module.exports = angular.module('spinnaker.gce.loadBalancer.transformer', [])
     function convertLoadBalancerForEditing(loadBalancer) {
       var toEdit = {
         provider: 'gce',
-        editMode: true,
         region: loadBalancer.region,
         credentials: loadBalancer.account,
         listeners: [],


### PR DESCRIPTION
A first pass at separating out load balancer types. There is still some confusion around what gets transformed after the load balancers get read, and the different data structures when load balancers are retrieved as group vs a single load balancer, but this gets us a LOT closer to actual valid shapes.