### PR TITLE
feat(provider/kubernetes): Add Run Job Pod Labels

### DIFF
--- a/app/scripts/modules/kubernetes/annotation/annotationConfigurer.component.ts
+++ b/app/scripts/modules/kubernetes/annotation/annotationConfigurer.component.ts
@@ -46,7 +46,7 @@ class KubernetesAnnotationConfigurer implements ng.IComponentController {
   }
 }
 
-class KubernetesAnnotationConfigurerComponent implements ng.IComponentOptions {
+export class KubernetesAnnotationConfigurerComponent implements ng.IComponentOptions {
   public bindings: any = {
     component: '<',
     field: '@',

--- a/app/scripts/modules/kubernetes/kubernetes.module.js
+++ b/app/scripts/modules/kubernetes/kubernetes.module.js
@@ -5,6 +5,7 @@ const angular = require('angular');
 import { CLOUD_PROVIDER_REGISTRY, DeploymentStrategyRegistry } from '@spinnaker/core';
 
 import { KUBERNETES_ANNOTATION_CONFIGURER } from './annotation/annotationConfigurer.component';
+import { KUBERNETES_LABEL_CONFIGURER } from './label/labelConfigurer.component';
 import { KUBERNETES_KEY_VALUE_DETAILS } from './common/keyValueDetails.component';
 import { KUBERNETES_SECURITY_CONTEXT_SELECTOR } from './container/securityContext/securityContextSelector.component';
 import { KUBERNETES_HELP } from './help/kubernetes.help';
@@ -27,6 +28,7 @@ module.exports = angular.module('spinnaker.kubernetes', [
   require('./instance/details/details.kubernetes.module.js'),
   CLOUD_PROVIDER_REGISTRY,
   KUBERNETES_ANNOTATION_CONFIGURER,
+  KUBERNETES_LABEL_CONFIGURER,
   KUBERNETES_KEY_VALUE_DETAILS,
   KUBERNETES_SECURITY_CONTEXT_SELECTOR,
   KUBERNETES_HELP,

--- a/app/scripts/modules/kubernetes/label/labelConfigurer.component.html
+++ b/app/scripts/modules/kubernetes/label/labelConfigurer.component.html
@@ -1,0 +1,25 @@
+<table class="table table-condensed packed tags" style="border-top: 2px solid white;">
+  <tr ng-repeat="view in $ctrl.annotationViews track by $index">
+    <td class="table-label"><b>Key</b></td>
+    <td>
+      <input class="form-control input-sm" type="text" ng-model="view.key" required ng-change="$ctrl.onKeyOrValueChange($event)">
+    </td>
+    <td class="table-label"><b>Value</b></td>
+    <td>
+      <input class="form-control input-sm" type="text" ng-model="view.value" required ng-change="$ctrl.onKeyOrValueChange($event)">
+    </td>
+    <td class="table-remove-button">
+      <a class="btn btn-link sm-label" ng-click="$ctrl.remove($index)">
+        <span class="glyphicon glyphicon-trash"></span>
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td colspan="5">
+      <button class="add-new col-md-12" ng-click="$ctrl.add($event)">
+        <span class="glyphicon glyphicon-plus-sign"></span> Add labels
+      </button>
+    </td>
+  </tr>
+</table>
+

--- a/app/scripts/modules/kubernetes/label/labelConfigurer.component.ts
+++ b/app/scripts/modules/kubernetes/label/labelConfigurer.component.ts
@@ -1,0 +1,11 @@
+import {module} from 'angular';
+import {KubernetesAnnotationConfigurerComponent} from '../annotation/annotationConfigurer.component'
+
+
+export class KubernetesLabelConfigurerComponent extends KubernetesAnnotationConfigurerComponent {
+  public templateUrl: string = require('./labelConfigurer.component.html')
+}
+
+export const KUBERNETES_LABEL_CONFIGURER = 'spinnaker.kubernetes.label.configurer.component';
+module(KUBERNETES_LABEL_CONFIGURER, [])
+  .component('kubernetesLabelConfigurer', new KubernetesLabelConfigurerComponent());

--- a/app/scripts/modules/kubernetes/pipeline/stages/runJob/runJobStage.html
+++ b/app/scripts/modules/kubernetes/pipeline/stages/runJob/runJobStage.html
@@ -75,6 +75,13 @@
     <kubernetes-container-volumes volume-sources="ctrl.stage.volumeSources" volume-mounts="ctrl.stage.container.volumeMounts">
     </kubernetes-container-volumes>
   </stage-config-field>
+
+  <stage-config-field label="Labels">
+    <kubernetes-label-configurer component="ctrl.stage" field="labels">
+    </kubernetes-label-configurer>
+  </stage-config-field>
+
+
   <stage-config-field label="Security Context">
     <kubernetes-security-context-selector component="ctrl.stage.container">
     </kubernetes-security-context-selector>


### PR DESCRIPTION
Adds the ability to add labels to the Run Job pod definition. This is
useful for pin pointing pods for loggin purposes. I took the route of
createing a Label Configurer that extends the Annotation Configurer.
This is primarily because it performs the same function (creting a map
of labels/annotations) so it does the same work. I can refactor if
necessary.

Part of [#1683](https://github.com/spinnaker/spinnaker/issues/1683)

Related Clouddriver PR: https://github.com/spinnaker/clouddriver/pull/1683

@danielpeach @lwander PTAL
