### PR TITLE
fix(kubernetes): Search not working if result contained K8S load balancer

### DIFF
--- a/app/scripts/modules/core/src/navigation/urlBuilder.service.ts
+++ b/app/scripts/modules/core/src/navigation/urlBuilder.service.ts
@@ -12,6 +12,7 @@ export interface IUrlBuilderInput {
   instanceId?: string;
   loadBalancer?: string;
   name?: string;
+  namespace?: string;
   project?: string;
   provider?: string;
   region?: string;
@@ -211,7 +212,7 @@ class LoadBalancersUrlBuilder implements IUrlBuilder {
       {
         application: input.application,
         name: input.loadBalancer,
-        region: input.region,
+        region: input.region ||  input.namespace,
         accountId: input.account,
         vpcId: input.vpcId,
         provider: input.provider,


### PR DESCRIPTION
Ui-router returned null for the href for the state if region was missing, resulting in a Javascript crash (`Uncaught TypeError: Cannot read property 'includes' of null`).
This commit fixes this by mapping Kubernetes namespace to region.

@anotherchrisberry @jrsquared PTAL