### PR TITLE
fix(provider/amazon): Require target groups to have unique names

### DIFF
--- a/app/scripts/modules/amazon/src/loadBalancer/configure/application/configure.less
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/application/configure.less
@@ -46,3 +46,12 @@
     }
   }
 }
+
+// We still care if a target group name is already used, so force the styles
+// that angular uses for invalid, even if pristine. This should/will go away
+// when converting to react, so doing it this way to not waste more time.
+.target-group-name.ng-invalid {
+  border-color: #843534;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #ce8483;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #ce8483;
+}

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/application/targetGroups.html
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/application/targetGroups.html
@@ -6,9 +6,13 @@
           <div class="wizard-pod-row header">
             <div class="wizard-pod-row-title">GROUP NAME</div>
             <div class="wizard-pod-row-contents">
-              <input class="form-control input-sm"
+              <input class="form-control input-sm target-group-name"
                           type="text"
                           ng-model="targetGroup.name"
+                          ng-model-options="{ allowInvalid: true }"
+                          validate-unique="ctrl.existingTargetGroupNames"
+                          validate-ignore-case="true"
+                          name="targetGroupName{{$index}}"
                           required/>
               <a href class="sm-label" ng-click="ctrl.removeTargetGroup($index)"><span class="glyphicon glyphicon-trash"></span></a>
             </div>

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/choice/awsLoadBalancerChoice.modal.ts
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/choice/awsLoadBalancerChoice.modal.ts
@@ -17,16 +17,16 @@ class AwsLoadBalancerChoiceCtrl implements IComponentController {
     'ngInject';
   }
 
-  public $onInit (): void {
+  public $onInit(): void {
     this.choices = LoadBalancerTypes;
     this.choice = this.choices[0];
   }
 
-  public onChoiceSelection (choice: IAwsLoadBalancerConfig): void {
+  public onChoiceSelection(choice: IAwsLoadBalancerConfig): void {
     this.choice = choice;
   }
 
-  public choose (): void {
+  public choose(): void {
     this.$uibModalInstance.dismiss();
     this.$uibModal.open({
       templateUrl: this.choice.createTemplateUrl,


### PR DESCRIPTION
We could definitely do a better job surfacing the errors, auto-updating the listeners to match updated names, and generating better names, but this forces the rule so I can move on to other, bigger ALB-related tasks. Will look at the other details later.