### PR TITLE
fix(aws): restrict rolling push strategy to AWS

### DIFF
--- a/app/scripts/modules/amazon/src/aws.module.ts
+++ b/app/scripts/modules/amazon/src/aws.module.ts
@@ -114,4 +114,4 @@ module(AMAZON_MODULE, [
   });
 });
 
-DeploymentStrategyRegistry.registerProvider('aws', ['custom', 'redblack', 'rollingPush']);
+DeploymentStrategyRegistry.registerProvider('aws', ['custom', 'redblack', 'rollingpush']);

--- a/app/scripts/modules/amazon/src/deploymentStrategy/rollingPush.strategy.ts
+++ b/app/scripts/modules/amazon/src/deploymentStrategy/rollingPush.strategy.ts
@@ -4,6 +4,7 @@ DeploymentStrategyRegistry.registerStrategy({
   label: 'Rolling Push (deprecated)',
   description: 'Updates the launch configuration for this server group, then terminates instances incrementally, replacing them with instances launched with the updated configuration',
   key: 'rollingpush',
+  providerRestricted: true,
   additionalFields: ['termination.totalRelaunches', 'termination.concurrentRelaunches', 'termination.order', 'termination.relaunchAllInstances'],
   additionalFieldsTemplateUrl: require('./additionalFields.html'),
   initializationMethod: (command) => {


### PR DESCRIPTION
This is a very AWS-specific strategy (also, this is a regression)