### PR TITLE
fix(pipelines): fix float on health counts

### DIFF
--- a/app/scripts/modules/core/src/healthCounts/healthCounts.less
+++ b/app/scripts/modules/core/src/healthCounts/healthCounts.less
@@ -14,6 +14,11 @@
 
 health-counts {
   display: inherit; // Since health-counts wraps a react component with a .health-counts class that does all the layout now, make this component not have layout
+  &.no-float {
+    .instance-health-counts {
+      float: none;
+    }
+  }
 }
 
 .health-counts {


### PR DESCRIPTION
fixes a minor regression (only visible when a deploy stage is waiting for instances to come up) in the rendering of the health counts, where they are getting floated to the right, outside the parenthetical status indicator.