### PR TITLE
feat(core/entityTag): Wait 100ms before showing entity tag popover

### DIFF
--- a/app/scripts/modules/core/src/entityTag/notifications/NotificationsPopover.tsx
+++ b/app/scripts/modules/core/src/entityTag/notifications/NotificationsPopover.tsx
@@ -193,6 +193,7 @@ export class NotificationsPopover extends React.Component<INotificationsPopoverP
     return (
       <span className={`tag-marker small ${className || ''}`} onMouseEnter={this.fireGAEvent}>
         <HoverablePopover
+          delayShow={100}
           placement={placement}
           hOffsetPercent={hOffsetPercent}
           template={Notifications}


### PR DESCRIPTION
This adds `delayShow` and `delayHide` props and improves mouseenter/over and mouseleave handling.