### PR TITLE
fix(core): import from base rxjs

### DIFF
--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/core",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/core/src/presentation/HoverablePopover.tsx
+++ b/app/scripts/modules/core/src/presentation/HoverablePopover.tsx
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { Overlay, Popover, PopoverProps } from 'react-bootstrap';
-import { Observable } from 'rxjs/Observable';
-import { Subject } from 'rxjs/Subject';
-import { Subscription } from 'rxjs/Subscription';
+import { Observable, Subject, Subscription } from 'rxjs';
 import autoBindMethods from 'class-autobind-decorator';
 
 import { Placement } from 'core/presentation';


### PR DESCRIPTION
@christopherthielen sorry, I should have caught this in your PR earlier. We need to import directly from `rxjs` for library builds. I never figured out why, but something gets confused and breaks when we do deep imports like this, and it's not noticeable until you pull in core as a library.