### PR TITLE
fix(aws): change "deprecated" to "not recommended" on rolling push

### DIFF
--- a/app/scripts/modules/amazon/package.json
+++ b/app/scripts/modules/amazon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/amazon",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/amazon/src/deploymentStrategy/rollingPush.strategy.ts
+++ b/app/scripts/modules/amazon/src/deploymentStrategy/rollingPush.strategy.ts
@@ -1,8 +1,10 @@
 import { DeploymentStrategyRegistry } from '@spinnaker/core';
 
 DeploymentStrategyRegistry.registerStrategy({
-  label: 'Rolling Push (deprecated)',
-  description: 'Updates the launch configuration for this server group, then terminates instances incrementally, replacing them with instances launched with the updated configuration',
+  label: 'Rolling Push (not recommended)',
+  description: `Updates the launch configuration for this server group, then terminates instances incrementally,
+    replacing them with instances launched with the updated configuration. This is not a best practice - it goes against
+    the principles of immutable infrastructure - but may be necessary in some cases.`,
   key: 'rollingpush',
   providerRestricted: true,
   additionalFields: ['termination.totalRelaunches', 'termination.concurrentRelaunches', 'termination.order', 'termination.relaunchAllInstances'],


### PR DESCRIPTION
We field a lot of questions about the "deprecated" label on the rolling push strategy. Really, it's never been deprecated - there are no plans to remove rolling push as an option for AWS. It's just not recommended or considered a best practice.
<img width="391" alt="screen shot 2017-06-16 at 11 37 03 am" src="https://user-images.githubusercontent.com/73450/27240049-30f90080-5288-11e7-9c4c-6759defc354c.png">

