### PR TITLE
feat(core): require app name in appModelBuilder.createApplication

### DIFF
--- a/app/scripts/modules/amazon/src/loadBalancer/configure/classic/createClassicLoadBalancer.controller.spec.ts
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/classic/createClassicLoadBalancer.controller.spec.ts
@@ -42,7 +42,7 @@ describe('Controller: awsCreateClassicLoadBalancerCtrl', () => {
     securityGroupReader = _securityGroupReader_;
     accountService = _accountService_;
     subnetReader = _subnetReader_;
-    const app = applicationModelBuilder.createApplication({key: 'loadBalancers', lazy: true});
+    const app = applicationModelBuilder.createApplication('app', {key: 'loadBalancers', lazy: true});
     initialize = (loadBalancer: IAmazonClassicLoadBalancer = null) => {
       if (loadBalancer) {
         spyOn(awsLoadBalancerTransformer, 'convertClassicLoadBalancerForEditing').and.returnValue(loadBalancer);

--- a/app/scripts/modules/amazon/src/loadBalancer/details/loadBalancerDetails.controller.spec.ts
+++ b/app/scripts/modules/amazon/src/loadBalancer/details/loadBalancerDetails.controller.spec.ts
@@ -33,7 +33,7 @@ describe('Controller: LoadBalancerDetailsCtrl', function () {
                  applicationModelBuilder: ApplicationModelBuilder) => {
         $scope = $rootScope.$new();
         $state = _$state_;
-        const app = applicationModelBuilder.createApplication({key: 'loadBalancers', lazy: true});
+        const app = applicationModelBuilder.createApplication('app', {key: 'loadBalancers', lazy: true});
         app.loadBalancers.data.push(loadBalancer);
         controller = $controller(AwsLoadBalancerDetailsController, {
           $scope: $scope,

--- a/app/scripts/modules/azure/instance/details/instance.details.controller.spec.js
+++ b/app/scripts/modules/azure/instance/details/instance.details.controller.spec.js
@@ -21,7 +21,7 @@ describe('Controller: azureInstanceDetailsCtrl', function () {
       instanceReader = _instanceReader_;
       $q = _$q_;
 
-      application = applicationModelBuilder.createApplication({key: 'loadBalancers', lazy: true}, {key: 'serverGroups', lazy: true});
+      application = applicationModelBuilder.createApplication('app', {key: 'loadBalancers', lazy: true}, {key: 'serverGroups', lazy: true});
 
       this.createController = function(application, instance) {
         controller = $controller('azureInstanceDetailsCtrl', {

--- a/app/scripts/modules/azure/loadBalancer/configure/createLoadBalancer.controller.spec.js
+++ b/app/scripts/modules/azure/loadBalancer/configure/createLoadBalancer.controller.spec.js
@@ -19,7 +19,7 @@ describe('Controller: azureCreateLoadBalancerCtrl', function () {
   // Initialize the controller and a mock scope
   beforeEach(window.inject(function ($controller, $rootScope, _API_, applicationModelBuilder) {
     API = _API_;
-    const app = applicationModelBuilder.createApplication({key: 'loadBalancers', lazy: true});
+    const app = applicationModelBuilder.createApplication('app', {key: 'loadBalancers', lazy: true});
     this.$scope = $rootScope.$new();
     this.ctrl = $controller('azureCreateLoadBalancerCtrl', {
       $scope: this.$scope,

--- a/app/scripts/modules/azure/loadBalancer/details/loadBalancerDetail.controller.spec.js
+++ b/app/scripts/modules/azure/loadBalancer/details/loadBalancerDetail.controller.spec.js
@@ -25,7 +25,7 @@ describe('Controller: azureLoadBalancerDetailsCtrl', function () {
       function($controller, $rootScope, _$state_, applicationModelBuilder) {
         $scope = $rootScope.$new();
         $state = _$state_;
-        let app = applicationModelBuilder.createApplication({key: 'loadBalancers', lazy: true});
+        let app = applicationModelBuilder.createApplication('app', {key: 'loadBalancers', lazy: true});
         app.loadBalancers.data.push(loadBalancer);
         controller = $controller('azureLoadBalancerDetailsCtrl', {
           $scope: $scope,

--- a/app/scripts/modules/cloudfoundry/loadBalancer/configure/CreateLoadBalancerCtrl.spec.js
+++ b/app/scripts/modules/cloudfoundry/loadBalancer/configure/CreateLoadBalancerCtrl.spec.js
@@ -17,7 +17,7 @@ describe('Controller: cfCreateLoadBalancerCtrl', function () {
   // Initialize the controller and a mock scope
   beforeEach(window.inject(function ($controller, $rootScope, _v2modalWizardService_, applicationModelBuilder) {
     this.$scope = $rootScope.$new();
-    const app = applicationModelBuilder.createApplication({key: 'loadBalancers', lazy: true});
+    const app = applicationModelBuilder.createApplication('app', {key: 'loadBalancers', lazy: true});
     this.ctrl = $controller('cfCreateLoadBalancerCtrl', {
       $scope: this.$scope,
       $uibModalInstance: { dismiss: angular.noop, result: { then: angular.noop } },

--- a/app/scripts/modules/cloudfoundry/loadBalancer/details/LoadBalancerDetailsCtrl.spec.js
+++ b/app/scripts/modules/cloudfoundry/loadBalancer/details/LoadBalancerDetailsCtrl.spec.js
@@ -25,7 +25,7 @@ describe('Controller: LoadBalancerDetailsCtrl', function () {
       function($controller, $rootScope, _$state_, applicationModelBuilder) {
         $scope = $rootScope.$new();
         $state = _$state_;
-        let app = applicationModelBuilder.createApplication({key: 'loadBalancers', lazy: true});
+        let app = applicationModelBuilder.createApplication('app', {key: 'loadBalancers', lazy: true});
         app.loadBalancers.data.push(loadBalancer);
         controller = $controller('cfLoadBalancerDetailsCtrl', {
           $scope: $scope,

--- a/app/scripts/modules/cloudfoundry/serverGroup/details/serverGroupDetails.cf.controller.spec.js
+++ b/app/scripts/modules/cloudfoundry/serverGroup/details/serverGroupDetails.cf.controller.spec.js
@@ -14,7 +14,7 @@ describe('Controller: cfServerGroupDetailsCtrl', function () {
   beforeEach(
     window.inject(function ($rootScope, $controller, applicationModelBuilder) {
       scope = $rootScope.$new();
-      let app = applicationModelBuilder.createApplication({key: 'serverGroups', lazy: true}, {key: 'loadBalancers', lazy: true});
+      let app = applicationModelBuilder.createApplication('app', {key: 'serverGroups', lazy: true}, {key: 'loadBalancers', lazy: true});
       controller = $controller('cfServerGroupDetailsCtrl', {
         $scope: scope,
         app: app,

--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/core",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/core/src/application/application.model.spec.ts
+++ b/app/scripts/modules/core/src/application/application.model.spec.ts
@@ -55,7 +55,7 @@ describe ('Application Model', function () {
     spyOn(securityGroupReader, 'getApplicationSecurityGroups').and.callFake(function(_app: Application, groupsByName: any[]) {
       return $q.when(groupsByName || []);
     });
-    application = applicationModelBuilder.createApplication(applicationDataSourceRegistry.getDataSources());
+    application = applicationModelBuilder.createApplication('app', applicationDataSourceRegistry.getDataSources());
     application.refresh();
     $scope.$digest();
   }

--- a/app/scripts/modules/core/src/application/applicationModel.builder.ts
+++ b/app/scripts/modules/core/src/application/applicationModel.builder.ts
@@ -16,13 +16,13 @@ export class ApplicationModelBuilder {
   }
 
   /**
-   * This is only used in tests
+   * This is mostly used in tests
    */
-  public createApplication(...dataSources: any[]): Application {
+  public createApplication(name: string, ...dataSources: any[]): Application {
     if (Array.isArray(dataSources[0])) {
       dataSources = dataSources[0];
     }
-    const application = new Application('app', this.schedulerFactory.createScheduler(), this.$q, this.$log);
+    const application = new Application(name, this.schedulerFactory.createScheduler(), this.$q, this.$log);
     dataSources.forEach(ds => this.addDataSource(new DataSourceConfig(ds), application));
     return application;
   }

--- a/app/scripts/modules/core/src/application/config/dataSources/applicationDataSourceEditor.component.spec.ts
+++ b/app/scripts/modules/core/src/application/config/dataSources/applicationDataSourceEditor.component.spec.ts
@@ -40,6 +40,7 @@ describe('Component: Application Data Source Editor', () => {
 
   beforeEach(() => {
     application = applicationModelBuilder.createApplication(
+      'app',
       {
         key: 'optionalSource',
         optional: true,

--- a/app/scripts/modules/core/src/application/listExtractor/listExtractor.service.spec.ts
+++ b/app/scripts/modules/core/src/application/listExtractor/listExtractor.service.spec.ts
@@ -10,7 +10,7 @@ describe('appListExtractorService', function () {
       applicationModelBuilder: ApplicationModelBuilder;
 
   const buildApplication = (serverGroups: any[] = []): Application => {
-    const application: Application = applicationModelBuilder.createApplication({key: 'serverGroups', lazy: true});
+    const application: Application = applicationModelBuilder.createApplication('app', {key: 'serverGroups', lazy: true});
     application.getDataSource('serverGroups').data = serverGroups;
     return application;
   };

--- a/app/scripts/modules/core/src/chaosMonkey/chaosMonkeyExceptions.component.spec.ts
+++ b/app/scripts/modules/core/src/chaosMonkey/chaosMonkeyExceptions.component.spec.ts
@@ -53,7 +53,7 @@ describe('Controller: ChaosMonkeyExceptions', () => {
 
       initializeController(null);
       $ctrl.application =
-        applicationBuilder.createApplication({key: 'serverGroups', data: [], ready: () => $q.when(null), loaded: true});
+        applicationBuilder.createApplication('app', {key: 'serverGroups', data: [], ready: () => $q.when(null), loaded: true});
       $ctrl.config = new ChaosMonkeyConfig($ctrl.application.attributes.chaosMonkey || {});
 
       $ctrl.$onInit();

--- a/app/scripts/modules/core/src/cloudProvider/providerSelection/providerSelection.service.spec.ts
+++ b/app/scripts/modules/core/src/cloudProvider/providerSelection/providerSelection.service.spec.ts
@@ -73,7 +73,7 @@ describe('providerSelectionService: API', () => {
     providers = [];
     delete SETTINGS.defaultProvider;
 
-    application = applicationBuilder.createApplication();
+    application = applicationBuilder.createApplication('app');
     application.attributes = { cloudProviders: 'testProvider' };
 
     config = {

--- a/app/scripts/modules/core/src/cluster/cluster.service.spec.ts
+++ b/app/scripts/modules/core/src/cluster/cluster.service.spec.ts
@@ -35,6 +35,7 @@ describe('Service: Cluster', function () {
     ClusterFilterModel = _ClusterFilterModel_;
 
     application = applicationModelBuilder.createApplication(
+      'app',
       {key: 'serverGroups'},
       {key: 'runningExecutions'},
       {key: 'runningTasks'}

--- a/app/scripts/modules/core/src/cluster/filter/clusterFilter.service.spec.ts
+++ b/app/scripts/modules/core/src/cluster/filter/clusterFilter.service.spec.ts
@@ -46,7 +46,7 @@ describe('Service: clusterFilterService', function () {
     );
 
     this.buildApplication = (json: any) => {
-      const app = applicationModelBuilder.createApplication({key: 'serverGroups', lazy: true});
+      const app = applicationModelBuilder.createApplication('app', {key: 'serverGroups', lazy: true});
       if (json.serverGroups) {
         app.getDataSource('serverGroups').data = _.cloneDeep(json.serverGroups.data);
       }

--- a/app/scripts/modules/core/src/delivery/create/CreatePipelineModal.spec.tsx
+++ b/app/scripts/modules/core/src/delivery/create/CreatePipelineModal.spec.tsx
@@ -39,6 +39,7 @@ describe('CreatePipelineModal', () => {
     $scope = $rootScope.$new();
     initializeComponent = (configs = []) => {
       application = applicationModelBuilder.createApplication(
+        'app',
         {
           key: 'pipelineConfigs',
           lazy: true,

--- a/app/scripts/modules/core/src/delivery/delivery.dataSource.spec.ts
+++ b/app/scripts/modules/core/src/delivery/delivery.dataSource.spec.ts
@@ -46,7 +46,7 @@ describe('Delivery Data Source', function () {
 
   function configureApplication() {
     applicationDataSourceRegistry.registerDataSource({key: 'serverGroups'});
-    application = applicationModelBuilder.createApplication(applicationDataSourceRegistry.getDataSources());
+    application = applicationModelBuilder.createApplication('app', applicationDataSourceRegistry.getDataSources());
     application.refresh();
     $scope.$digest();
   }

--- a/app/scripts/modules/core/src/delivery/executions/executions.controller.spec.js
+++ b/app/scripts/modules/core/src/delivery/executions/executions.controller.spec.js
@@ -25,7 +25,7 @@ describe('Controller: pipelineExecutions', function () {
       $timeout = _$timeout_;
       scrollToService = _scrollToService_;
       spyOn(executionFilterModel.asFilterModel, 'applyParamsToUrl').and.callFake(() => {});
-      application = applicationModelBuilder.createApplication({key: 'executions', lazy: true}, {key: 'pipelineConfigs', lazy: true});
+      application = applicationModelBuilder.createApplication('app', {key: 'executions', lazy: true}, {key: 'pipelineConfigs', lazy: true});
 
       this.initializeController = function (data) {
         scope.application = application;

--- a/app/scripts/modules/core/src/delivery/filter/executionFilter.service.spec.ts
+++ b/app/scripts/modules/core/src/delivery/filter/executionFilter.service.spec.ts
@@ -47,7 +47,7 @@ describe('Service: executionFilterService', function () {
   describe('Updating execution groups', function () {
 
     it('limits executions per pipeline', function (done) {
-      const application: Application = modelBuilder.createApplication({key: 'executions', lazy: true}, {key: 'pipelineConfigs', lazy: true});
+      const application: Application = modelBuilder.createApplication('app', {key: 'executions', lazy: true}, {key: 'pipelineConfigs', lazy: true});
       application.getDataSource('executions').data = [
         { pipelineConfigId: '1', name: 'pipeline 1', endTime: 1, stages: [] },
         { pipelineConfigId: '1', name: 'pipeline 1', endTime: 2, stages: [] },

--- a/app/scripts/modules/core/src/instance/details/multipleInstances.controller.spec.js
+++ b/app/scripts/modules/core/src/instance/details/multipleInstances.controller.spec.js
@@ -19,7 +19,7 @@ describe('Controller: MultipleInstances', function () {
       MultiselectModel = _MultiselectModel_;
 
       this.createController = function (serverGroups) {
-        let application = applicationModelBuilder.createApplication({key: 'serverGroups', lazy: true});
+        let application = applicationModelBuilder.createApplication('app', {key: 'serverGroups', lazy: true});
         application.serverGroups.data = serverGroups;
         application.serverGroups.loaded = true;
         this.application = application;

--- a/app/scripts/modules/core/src/instance/instance.write.service.spec.ts
+++ b/app/scripts/modules/core/src/instance/instance.write.service.spec.ts
@@ -62,7 +62,7 @@ describe('Service: instance writer', function () {
         launchTime: 2,
 
       };
-      const application: Application = applicationModelBuilder.createApplication({key: 'serverGroups', lazy: true});
+      const application: Application = applicationModelBuilder.createApplication('app', {key: 'serverGroups', lazy: true});
       let executedTask: IJob = null;
 
       spyOn(taskExecutor, 'executeTask').and.callFake((task: ITaskCommand) => {
@@ -106,7 +106,7 @@ describe('Service: instance writer', function () {
     });
 
     it('only sends jobs for groups with instances', () => {
-      const application: Application = applicationModelBuilder.createApplication();
+      const application: Application = applicationModelBuilder.createApplication('app');
       addInstance(serverGroupB, {id: 'i-234', health: [], healthState: 'Up', zone: 'a', launchTime: 2});
       addInstance(serverGroupB, {id: 'i-345', health: [], healthState: 'Up', zone: 'a', launchTime: 2});
       service.terminateInstances(
@@ -126,7 +126,7 @@ describe('Service: instance writer', function () {
     });
 
     it('includes additional job properties for terminate and shrink', () => {
-      const application: Application = applicationModelBuilder.createApplication();
+      const application: Application = applicationModelBuilder.createApplication('app');
       addInstance(serverGroupA, {id: 'i-234', health: [], healthState: 'Up', zone: 'a', launchTime: 2});
       addInstance(serverGroupA, {id: 'i-345', health: [], healthState: 'Up', zone: 'a', launchTime: 2});
       service.terminateInstancesAndShrinkServerGroups(
@@ -148,7 +148,7 @@ describe('Service: instance writer', function () {
     });
 
     it('includes a useful descriptor on terminate instances', () => {
-      const application: Application = applicationModelBuilder.createApplication();
+      const application: Application = applicationModelBuilder.createApplication('app');
       addInstance(serverGroupA, {id: 'i-123', health: [], healthState: 'Up', zone: 'a', launchTime: 2});
 
       service.terminateInstances([getInstanceGroup(serverGroupA)], application);
@@ -160,7 +160,7 @@ describe('Service: instance writer', function () {
     });
 
     it('includes a useful descriptor on reboot instances', function () {
-      const application: Application = applicationModelBuilder.createApplication();
+      const application: Application = applicationModelBuilder.createApplication('app');
       addInstance(serverGroupA, {id: 'i-123', health: [], healthState: 'Up', zone: 'a', launchTime: 2});
 
       service.rebootInstances([getInstanceGroup(serverGroupA)], application);
@@ -172,7 +172,7 @@ describe('Service: instance writer', function () {
     });
 
     it('includes a useful descriptor on disable in discovery', function () {
-      const application: Application = applicationModelBuilder.createApplication();
+      const application: Application = applicationModelBuilder.createApplication('app');
       addInstance(serverGroupA, {id: 'i-123', health: [], healthState: 'Up', zone: 'a', launchTime: 2});
 
       service.disableInstancesInDiscovery([getInstanceGroup(serverGroupA)], application);
@@ -184,7 +184,7 @@ describe('Service: instance writer', function () {
     });
 
     it('includes a useful descriptor on enable in discovery', function () {
-      const application: Application = applicationModelBuilder.createApplication();
+      const application: Application = applicationModelBuilder.createApplication('app');
       addInstance(serverGroupA, {id: 'i-123', health: [], healthState: 'Up', zone: 'a', launchTime: 2});
 
       service.enableInstancesInDiscovery([getInstanceGroup(serverGroupA)], application);

--- a/app/scripts/modules/core/src/loadBalancer/LoadBalancersTag.spec.tsx
+++ b/app/scripts/modules/core/src/loadBalancer/LoadBalancersTag.spec.tsx
@@ -26,7 +26,7 @@ describe('<LoadBalancersTag />', () => {
   beforeEach(mock.inject((_$q_: IQService, $rootScope: IScope, applicationModelBuilder: ApplicationModelBuilder) => {
     $q = _$q_;
     $scope = $rootScope.$new();
-    application = applicationModelBuilder.createApplication({
+    application = applicationModelBuilder.createApplication('app', {
       key: 'loadBalancers',
       loader: () => $q.when(null),
       onLoad: () => $q.when(null),

--- a/app/scripts/modules/core/src/loadBalancer/filter/loadBalancer.filter.service.spec.ts
+++ b/app/scripts/modules/core/src/loadBalancer/filter/loadBalancer.filter.service.spec.ts
@@ -32,7 +32,7 @@ describe('Service: loadBalancerFilterService', function () {
   });
 
   beforeEach(function () {
-    app = modelBuilder.createApplication({key: 'loadBalancers', lazy: true});
+    app = modelBuilder.createApplication('app', {key: 'loadBalancers', lazy: true});
     app.getDataSource('loadBalancers').data = [
       { name: 'elb-1', region: 'us-east-1', account: 'test', vpcName: '', serverGroups: [],
         instanceCounts: {down: 0, starting: 0, outOfService: 0 }, usages: {}},

--- a/app/scripts/modules/core/src/pipeline/config/actions/delete/deletePipelineModal.controller.spec.js
+++ b/app/scripts/modules/core/src/pipeline/config/actions/delete/deletePipelineModal.controller.spec.js
@@ -12,7 +12,7 @@ describe('Controller: deletePipelineModal', function() {
 
   beforeEach(window.inject(function($controller, $rootScope, $log, $q, pipelineConfigService, $state, applicationModelBuilder) {
     this.$q = $q;
-    this.application = applicationModelBuilder.createApplication({
+    this.application = applicationModelBuilder.createApplication('app', {
       key: 'pipelineConfigs',
       lazy: true,
       loader: () => this.$q.when(null),

--- a/app/scripts/modules/core/src/pipeline/config/actions/rename/renamePipelineModal.controller.spec.js
+++ b/app/scripts/modules/core/src/pipeline/config/actions/rename/renamePipelineModal.controller.spec.js
@@ -12,7 +12,7 @@ describe('Controller: renamePipelineModal', function() {
 
   beforeEach(window.inject(function($controller, $rootScope, $log, $q, pipelineConfigService, applicationModelBuilder) {
     this.$q = $q;
-    this.application = applicationModelBuilder.createApplication({
+    this.application = applicationModelBuilder.createApplication('app', {
       key: 'pipelineConfigs',
       lazy: true,
       loader: () => this.$q.when(null),

--- a/app/scripts/modules/core/src/pipeline/config/pipelineConfig.controller.spec.js
+++ b/app/scripts/modules/core/src/pipeline/config/pipelineConfig.controller.spec.js
@@ -22,7 +22,7 @@ describe('Controller: PipelineConfigCtrl', function () {
   );
 
   it('should initialize immediately if pipeline configs are already present', function () {
-    const application = applicationModelBuilder.createApplication({key: 'pipelineConfigs', lazy: true});
+    const application = applicationModelBuilder.createApplication('app', {key: 'pipelineConfigs', lazy: true});
     application.pipelineConfigs.data = [ { id: 'a' } ];
     application.pipelineConfigs.loaded = true;
 
@@ -38,7 +38,7 @@ describe('Controller: PipelineConfigCtrl', function () {
   });
 
   it('should wait until pipeline configs are loaded before initializing', function () {
-    const application = applicationModelBuilder.createApplication({key: 'pipelineConfigs', lazy: true});
+    const application = applicationModelBuilder.createApplication('app', {key: 'pipelineConfigs', lazy: true});
     spyOn(application.pipelineConfigs, 'activate').and.callFake(angular.noop);
     let vm = controller('PipelineConfigCtrl', {
       $scope: scope,

--- a/app/scripts/modules/core/src/securityGroup/securityGroupReader.service.spec.ts
+++ b/app/scripts/modules/core/src/securityGroup/securityGroupReader.service.spec.ts
@@ -55,6 +55,7 @@ describe('Service: securityGroupReader', function () {
     let data: any[] = null;
 
     const application: Application = applicationModelBuilder.createApplication(
+      'app',
       {
         key: 'securityGroups',
         data: [],
@@ -100,7 +101,7 @@ describe('Service: securityGroupReader', function () {
 
   it('adds security group names across accounts, falling back to the ID if none found', function () {
     let details: ISecurityGroupDetail = null;
-    const application: Application = applicationModelBuilder.createApplication();
+    const application: Application = applicationModelBuilder.createApplication('app');
     application['securityGroupsIndex'] = {
       test: {'us-east-1': {'sg-2': {name: 'matched'}}},
       prod: {'us-east-1': {'sg-2': {name: 'matched-prod'}}}
@@ -131,6 +132,7 @@ describe('Service: securityGroupReader', function () {
   it('should clear cache, then reload security groups and try again if a security group is not found', function () {
     let data: ISecurityGroup[] = null;
     const application: Application = applicationModelBuilder.createApplication(
+      'app',
       {
         key: 'securityGroups',
       },

--- a/app/scripts/modules/core/src/serverGroup/details/multipleServerGroups.controller.spec.js
+++ b/app/scripts/modules/core/src/serverGroup/details/multipleServerGroups.controller.spec.js
@@ -22,7 +22,7 @@ describe('Controller: MultipleServerGroups', function () {
       ClusterFilterModel.sortFilter.multiselect = true;
 
       this.createController = function (serverGroups) {
-        let application = applicationModelBuilder.createApplication({key: 'serverGroups', lazy: true});
+        let application = applicationModelBuilder.createApplication('app', {key: 'serverGroups', lazy: true});
         application.serverGroups.data = serverGroups;
         application.serverGroups.loaded = true;
         this.application = application;

--- a/app/scripts/modules/core/src/serverGroup/details/serverGroupWarningMessage.service.spec.ts
+++ b/app/scripts/modules/core/src/serverGroup/details/serverGroupWarningMessage.service.spec.ts
@@ -20,7 +20,7 @@ describe('serverGroupWarningMessageService', () => {
                           _applicationModelBuilder_: ApplicationModelBuilder) => {
     service = serverGroupWarningMessageService;
     applicationModelBuilder = _applicationModelBuilder_;
-    app = applicationModelBuilder.createApplication();
+    app = applicationModelBuilder.createApplication('app');
   }));
 
   describe('addDestroyWarningMessage', () => {

--- a/app/scripts/modules/core/src/serverGroup/serverGroupWriter.service.spec.ts
+++ b/app/scripts/modules/core/src/serverGroup/serverGroupWriter.service.spec.ts
@@ -66,7 +66,7 @@ describe('serverGroupWriter', function () {
       }).respond(200, {ref: '/1'});
 
       const application: TestApplication =
-        <TestApplication>applicationModelBuilder.createApplication(applicationDataSourceRegistry.getDataSources());
+        <TestApplication>applicationModelBuilder.createApplication('app', applicationDataSourceRegistry.getDataSources());
       application.tasks = {
         refresh: noop
       };
@@ -83,7 +83,7 @@ describe('serverGroupWriter', function () {
     beforeEach(() => {
 
       const application: Application =
-        applicationModelBuilder.createApplication(applicationDataSourceRegistry.getDataSources());
+        applicationModelBuilder.createApplication('app', applicationDataSourceRegistry.getDataSources());
       command = {
         viewState: {
           mode: 'create',

--- a/app/scripts/modules/core/src/task/monitor/taskMonitor.builder.spec.ts
+++ b/app/scripts/modules/core/src/task/monitor/taskMonitor.builder.spec.ts
@@ -54,7 +54,7 @@ describe('Service: taskMonitorBuilder', () => {
 
       const operation = () => $q.when(task);
       const monitor = taskMonitorBuilder.buildTaskMonitor({
-        application: applicationModelBuilder.createApplication({key: 'runningTasks', lazy: true}),
+        application: applicationModelBuilder.createApplication('app', {key: 'runningTasks', lazy: true}),
         title: 'some task',
         modalInstance: { result: $q.defer().promise } as IModalServiceInstance,
         onTaskComplete: () => completeCalled = true,
@@ -87,7 +87,7 @@ describe('Service: taskMonitorBuilder', () => {
       const task = { failureMessage: 'it failed' };
       const operation = () => $q.reject(task);
       const monitor = taskMonitorBuilder.buildTaskMonitor({
-        application: applicationModelBuilder.createApplication({key: 'runningTasks', lazy: true}),
+        application: applicationModelBuilder.createApplication('app', {key: 'runningTasks', lazy: true}),
         title: 'a task',
         modalInstance: { result: $q.defer().promise } as IModalServiceInstance,
         onTaskComplete: () => completeCalled = true,
@@ -111,7 +111,7 @@ describe('Service: taskMonitorBuilder', () => {
 
       const operation = () => $q.when(task);
       const monitor = taskMonitorBuilder.buildTaskMonitor({
-        application: applicationModelBuilder.createApplication({key: 'runningTasks', lazy: true}),
+        application: applicationModelBuilder.createApplication('app', {key: 'runningTasks', lazy: true}),
         title: 'a task',
         modalInstance: { result: $q.defer().promise } as IModalServiceInstance,
         onTaskComplete: () => completeCalled = true,

--- a/app/scripts/modules/core/src/task/task.dataSource.spec.ts
+++ b/app/scripts/modules/core/src/task/task.dataSource.spec.ts
@@ -36,7 +36,7 @@ describe('Task Data Source', function () {
 
   function configureApplication() {
     applicationDataSourceRegistry.registerDataSource({key: 'serverGroups'});
-    application = applicationModelBuilder.createApplication(applicationDataSourceRegistry.getDataSources());
+    application = applicationModelBuilder.createApplication('app', applicationDataSourceRegistry.getDataSources());
     application.refresh();
     application.getDataSource('tasks').activate();
     $scope.$digest();

--- a/app/scripts/modules/core/src/task/tasks.controller.spec.js
+++ b/app/scripts/modules/core/src/task/tasks.controller.spec.js
@@ -19,7 +19,7 @@ describe('Controller: tasks', function () {
       taskWriter = _taskWriter_;
 
       this.initializeController = (tasks) => {
-        let application = applicationModelBuilder.createApplication({key: 'tasks', lazy: true});
+        let application = applicationModelBuilder.createApplication('app', {key: 'tasks', lazy: true});
         application.tasks.activate = angular.noop;
         application.tasks.data = tasks || [];
         application.tasks.loaded = true;

--- a/app/scripts/modules/google/src/loadBalancer/configure/network/createLoadBalancer.controller.spec.js
+++ b/app/scripts/modules/google/src/loadBalancer/configure/network/createLoadBalancer.controller.spec.js
@@ -17,7 +17,7 @@ describe('Controller: gceCreateLoadBalancerCtrl', function () {
   // Initialize the controller and a mock scope
   beforeEach(window.inject(function ($controller, $rootScope, _v2modalWizardService_, applicationModelBuilder) {
     this.$scope = $rootScope.$new();
-    const app = applicationModelBuilder.createApplication({key: 'loadBalancers', lazy: true});
+    const app = applicationModelBuilder.createApplication('app', {key: 'loadBalancers', lazy: true});
     this.ctrl = $controller('gceCreateLoadBalancerCtrl', {
       $scope: this.$scope,
       $uibModalInstance: { dismiss: angular.noop, result: { then: angular.noop } },

--- a/app/scripts/modules/google/src/loadBalancer/details/loadBalancerDetail.controller.spec.js
+++ b/app/scripts/modules/google/src/loadBalancer/details/loadBalancerDetail.controller.spec.js
@@ -27,7 +27,7 @@ describe('Controller: LoadBalancerDetailsCtrl', function () {
       function($controller, $rootScope, _$state_, applicationModelBuilder) {
         $scope = $rootScope.$new();
         $state = _$state_;
-        let app = applicationModelBuilder.createApplication({key: 'loadBalancers', lazy: true});
+        let app = applicationModelBuilder.createApplication('app', {key: 'loadBalancers', lazy: true});
         app.loadBalancers.data.push(loadBalancer);
         controller = $controller('gceLoadBalancerDetailsCtrl', {
           $scope: $scope,

--- a/app/scripts/modules/openstack/loadBalancer/configure/wizard/upsert.controller.spec.js
+++ b/app/scripts/modules/openstack/loadBalancer/configure/wizard/upsert.controller.spec.js
@@ -78,7 +78,7 @@ describe('Controller: openstackCreateLoadBalancerCtrl', function () {
       close: jasmine.createSpy('modal.close')
     };
 
-    this.mockApplication = applicationModelBuilder.createApplication({key: 'loadBalancers', lazy: false, data: this.testData.loadBalancerList});
+    this.mockApplication = applicationModelBuilder.createApplication('app', {key: 'loadBalancers', lazy: false, data: this.testData.loadBalancerList});
     spyOn(this.mockApplication.loadBalancers, 'refresh').and.callThrough();
     this.mockApplication.loadBalancers.onNextRefresh = jasmine.createSpy('application.loadBalancers.onNextRefresh').and.callFake(function(scope, callback) {
       testSuite.applicationRefreshCallback = callback;

--- a/app/scripts/modules/openstack/securityGroup/configure/wizard/upsert.controller.spec.js
+++ b/app/scripts/modules/openstack/securityGroup/configure/wizard/upsert.controller.spec.js
@@ -57,7 +57,7 @@ describe('Controller: openstackCreateSecurityGroupCtrl', function() {
       dismiss: jasmine.createSpy(),
       close: jasmine.createSpy()
     };
-    let application = applicationModelBuilder.createApplication({key: 'securityGroups', onLoad: angular.noop, loader: angular.noop});
+    let application = applicationModelBuilder.createApplication('app', {key: 'securityGroups', onLoad: angular.noop, loader: angular.noop});
     application.securityGroups.refresh = jasmine.createSpy();
     application.securityGroups.onNextRefresh = jasmine.createSpy().and.callFake(function (scope, callback) {
       testSuite.applicationRefreshCallback = callback;


### PR DESCRIPTION
This was how the call signature was originally, but I removed the app name param because I didn't think we need it and surprise now I need it somewhere because I found a place in our internal code that actually constructs the entire application via the application reader to get a single bit of data out of it which results in a ton of totally unnecessary reads. So it's going back in.