### PR TITLE
fix(provider/amazon): Fix missing information for ALB target groups

### DIFF
--- a/app/scripts/modules/amazon/src/loadBalancer/configure/application/listeners.html
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/application/listeners.html
@@ -27,7 +27,7 @@
                       ng-options="targetGroup.name as targetGroup.name for targetGroup in ctrl.loadBalancerCommand.targetGroups" required></select>
             </div>
           </td>
-          <td>
+          <td ng-if="ctrl.showSslCertificateNameField()">
             <div ng-repeat="certificate in listener.certificates"
                  style="width: 100%;display: flex;flex-direction: row;">
               <select class="form-control input-sm inline-number"

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/common/createAmazonLoadBalancer.controller.ts
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/common/createAmazonLoadBalancer.controller.ts
@@ -196,6 +196,7 @@ export abstract class CreateAmazonLoadBalancerCtrl {
   }
 
   private updateAvailableSecurityGroups(availableVpcIds: string[]): void {
+    this.defaultSecurityGroups = this.defaultSecurityGroups || [];
     const account = this.loadBalancerCommand.credentials,
           region = this.loadBalancerCommand.region;
 

--- a/app/scripts/modules/amazon/src/loadBalancer/loadBalancer.transformer.ts
+++ b/app/scripts/modules/amazon/src/loadBalancer/loadBalancer.transformer.ts
@@ -254,8 +254,8 @@ export class AwsLoadBalancerTransformer {
             healthCheckProtocol: targetGroup.healthCheckProtocol,
             healthCheckPort: targetGroup.healthCheckPort,
             healthCheckPath: targetGroup.healthCheckPath,
-            healthTimeout: targetGroup.healthCheckTimeoutSeconds,
-            healthInterval: targetGroup.healthCheckIntervalSeconds,
+            healthCheckTimeout: targetGroup.healthCheckTimeoutSeconds,
+            healthCheckInterval: targetGroup.healthCheckIntervalSeconds,
             healthyThreshold: targetGroup.healthyThresholdCount,
             unhealthyThreshold: targetGroup.unhealthyThresholdCount,
             attributes: {


### PR DESCRIPTION
* If there were no default security groups, would not render the security group names in the edit LB dialog
* Would not render health check timeout or health check interval in the target group edit details