### PR TITLE
fix(core): reduce badge size in compact headers

### DIFF
--- a/app/scripts/modules/core/src/application/nav/applicationNav.component.less
+++ b/app/scripts/modules/core/src/application/nav/applicationNav.component.less
@@ -61,6 +61,13 @@ application-nav, secondary-application-nav, .application-nav {
   secondary-application-nav a {
     .compact(12px);
   }
+  application-nav, secondary-application-nav, .application-nav {
+    .badge {
+      font-size: 10px;
+      margin-top: -2px;
+      margin-bottom: 2px;
+    }
+  }
 }
 
 application-nav {


### PR DESCRIPTION
Otherwise, the header is a couple pixels too tall and pulls the carat up, leaving a gap between it and the bottom of the header.