### PR TITLE
feat(provider/amazon): Add certificate service and cleanup ALB listeners CRUD UI

### DIFF
--- a/app/scripts/modules/amazon/src/certificates/amazon.certificate.read.service.ts
+++ b/app/scripts/modules/amazon/src/certificates/amazon.certificate.read.service.ts
@@ -1,0 +1,52 @@
+import { module, IQService, IPromise } from 'angular';
+import { groupBy, sortBy } from 'lodash';
+
+import { ACCOUNT_SERVICE, AccountService, ICertificate, CERTIFICATE_READ_SERVICE, CertificateReader } from '@spinnaker/core';
+
+export interface IAmazonCertificate extends ICertificate {
+  arn: string;
+  uploadDate: number;
+}
+
+export class AmazonCertificateReader {
+
+  private cachedAmazonCertificates: { [accountId: number]: IAmazonCertificate[] };
+
+  constructor(private $q: IQService,
+              private certificateReader: CertificateReader,
+              private accountService: AccountService) {
+    'ngInject';
+  }
+
+  public listCertificates(): IPromise<{ [accountId: number]: IAmazonCertificate[] }> {
+    if (this.cachedAmazonCertificates) {
+      return this.$q.when(this.cachedAmazonCertificates);
+    }
+    return this.certificateReader.listCertificatesByProvider('aws').then((certificates: IAmazonCertificate[]) => {
+      // This account grouping should really go into clouddriver but since it's not, put it here for now.
+      return this.accountService.getAllAccountDetailsForProvider('aws').then((allAccountDetails) => {
+        const accountIdToName = allAccountDetails.reduce((acc, accountDetails) => {
+          acc[accountDetails.accountId] = accountDetails.name;
+          return acc;
+        }, {} as {[id: string]: string});
+
+        const sortedCertificates = sortBy(certificates, 'serverCertificateName');
+        this.cachedAmazonCertificates = groupBy(sortedCertificates, (cert) => {
+          const [, , , , accountId] = cert.arn.split(':');
+          return accountIdToName[accountId] || 'unknown';
+        });
+        return this.cachedAmazonCertificates;
+      });
+    });
+  }
+
+  public resetCache(): void {
+    this.cachedAmazonCertificates = null;
+  }
+}
+
+export const AMAZON_CERTIFICATE_READ_SERVICE = 'spinnaker.amazon.certificate.read.service';
+module(AMAZON_CERTIFICATE_READ_SERVICE, [
+  ACCOUNT_SERVICE,
+  CERTIFICATE_READ_SERVICE
+]).service('amazonCertificateReader', AmazonCertificateReader);

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/application/listeners.html
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/application/listeners.html
@@ -1,58 +1,81 @@
 <div class="container-fluid form-horizontal">
   <div class="form-group">
     <div class="col-md-12">
+      <div class="wizard-pod" ng-repeat="listener in ctrl.loadBalancerCommand.listeners">
+        <div>
+          <div class="wizard-pod-row header">
+            <div class="wizard-pod-row-title">Listen On</div>
+            <div class="wizard-pod-row-contents spread">
+              <div>
+                <span class="wizard-pod-content">
+                  <label>Protocol</label>
+                  <select class="form-control input-sm inline-number" ng-model="listener.protocol" style="width:80px;"
+                          ng-change="ctrl.listenerProtocolChanged(listener)"
+                          ng-options="protocol for protocol in ['HTTP','HTTPS']"></select>
+                </span>
+                <span class="wizard-pod-content">
+                  <label>Port</label>
+                  <input class="form-control input-sm inline-number" type="text" min="0" ng-model="listener.port"
+                        style="width:80px;" required/>
+                </span>
+              </div>
+              <div>
+                <a href class="sm-label" ng-click="ctrl.removeListener($index)">
+                  <span class="glyphicon glyphicon-trash"></span>
+                </a>
+              </div>
+            </div>
+          </div>
+          <div class="wizard-pod-row" ng-if="ctrl.showSslCertificateNameField()">
+            <div class="wizard-pod-row-title">Certificate</div>
+            <div class="wizard-pod-row-contents">
+              <div ng-repeat="certificate in listener.certificates"
+                 style="width:100%;display:flex;flex-direction:row;">
+                <select class="form-control input-sm inline-number"
+                        style="width:45px;"
+                        ng-model="certificate.type"
+                        ng-options="certificateType for certificateType in ['iam','acm']"></select>
+                <select ng-if="ctrl.showCertificateSelect(certificate)" class="form-control input-sm" ng-model="certificate.name" required
+                        ng-options="certificate.serverCertificateName as certificate.serverCertificateName for certificate in ctrl.certificates[ctrl.loadBalancerCommand.credentials]"></select>
+                <input ng-if="!ctrl.showCertificateSelect(certificate)" class="form-control input-sm no-spel" style="display:inline-block;"
+                       type="text"
+                       ng-model="certificate.name"
+                       required/>
+              </div>
+            </div>
+          </div>
+          <div class="wizard-pod-row">
+            <div class="wizard-pod-row-title" style="height:30px">Rules</div>
+            <div class="wizard-pod-row-contents" style="padding:0;">
+              <table class="table table-condensed packed rules-table">
+                <thead>
+                  <th>If</th>
+                  <th>Then</th>
+                  <th>Target</th>
+                </thead>
+                <tbody>
+                  <tr ng-repeat="action in listener.defaultActions">
+                    <td>Default</td>
+                    <td>forward to</td>
+                    <td>
+                      <select class="form-control input-sm" ng-model="action.targetGroupName"
+                              ng-options="targetGroup.name as targetGroup.name for targetGroup in ctrl.loadBalancerCommand.targetGroups" required></select>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
       <table class="table table-condensed packed">
-        <thead>
         <tr>
-          <th style="width:70px;">Protocol</th>
-          <th style="width:70px;">Port</th>
-          <th></th>
-          <th>Targets</th>
-          <th ng-if="ctrl.showSslCertificateNameField()">Certificates</th>
-          <th></th>
-        </tr>
-        </thead>
-        <tbody>
-        <tr ng-repeat="listener in ctrl.loadBalancerCommand.listeners">
-          <td><select class="form-control input-sm" ng-model="listener.protocol"
-                      ng-change="ctrl.listenerProtocolChanged(listener)"
-                      ng-options="protocol for protocol in ['HTTP','HTTPS']"></select></td>
-          <td><input class="form-control input-sm" type="text" min="0" ng-model="listener.port"
-                     required/></td>
-          <td class="small" style="padding-top: 10px;">&rarr;</td>
-
           <td>
-            <div ng-repeat="action in listener.defaultActions">
-              <select class="form-control input-sm" ng-model="action.targetGroupName"
-                      ng-options="targetGroup.name as targetGroup.name for targetGroup in ctrl.loadBalancerCommand.targetGroups" required></select>
-            </div>
-          </td>
-          <td ng-if="ctrl.showSslCertificateNameField()">
-            <div ng-repeat="certificate in listener.certificates"
-                 style="width: 100%;display: flex;flex-direction: row;">
-              <select class="form-control input-sm inline-number"
-                      style="width:45px;"
-                      ng-model="certificate.type"
-                      ng-options="certificateType for certificateType in ['iam','acm']"></select>
-              <input class="form-control input-sm no-spel" style="display:inline-block;"
-                     type="text"
-                     ng-model="certificate.name"
-                     required/>
-            </div>
-          </td>
-          <td><a href class="sm-label" ng-click="ctrl.removeListener($index)"><span
-            class="glyphicon glyphicon-trash"></span></a></td>
-        </tr>
-        </tbody>
-        <tfoot>
-        <tr>
-          <td colspan="{{ctrl.showSslCertificateNameField() ? 6 : 5}}">
             <button class="add-new col-md-12" ng-click="ctrl.addListener()"><span
               class="glyphicon glyphicon-plus-sign"></span> Add new listener
             </button>
           </td>
         </tr>
-        </tfoot>
       </table>
     </div>
   </div>

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/application/targetGroups.html
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/application/targetGroups.html
@@ -4,7 +4,7 @@
       <div class="wizard-pod" ng-repeat="targetGroup in ctrl.loadBalancerCommand.targetGroups">
         <div>
           <div class="wizard-pod-row header">
-            <div class="wizard-pod-row-title">GROUP NAME</div>
+            <div class="wizard-pod-row-title">Group Name</div>
             <div class="wizard-pod-row-contents">
               <input class="form-control input-sm target-group-name"
                           type="text"
@@ -18,7 +18,7 @@
             </div>
           </div>
           <div class="wizard-pod-row">
-            <div class="wizard-pod-row-title">INCOMING CONNECTION</div>
+            <div class="wizard-pod-row-title">Backend Connection</div>
             <div class="wizard-pod-row-contents">
               <span class="wizard-pod-content">
                 <label>Protocol</label> <select class="form-control input-sm inline-number" ng-model="targetGroup.protocol"
@@ -30,7 +30,7 @@
             </div>
           </div>
           <div class="wizard-pod-row">
-            <div class="wizard-pod-row-title">HEALTHCHECK</div>
+            <div class="wizard-pod-row-title">Healthcheck</div>
             <div class="wizard-pod-row-contents">
               <span class="wizard-pod-content">
               <label>Protocol</label> <select class="form-control input-sm inline-number" ng-model="targetGroup.healthCheckProtocol"
@@ -51,7 +51,7 @@
             </div>
           </div>
           <div class="wizard-pod-row">
-            <div class="wizard-pod-row-title">HEALTHCHECK THRESHOLD</div>
+            <div class="wizard-pod-row-title">Healthcheck Threshold</div>
             <div class="wizard-pod-row-contents">
               <span class="wizard-pod-content">
                 <label>Healthy</label> <input class="form-control input-sm inline-number" ng-model="targetGroup.healthyThreshold" type="number" required/>
@@ -62,7 +62,7 @@
             </div>
           </div>
           <div class="wizard-pod-row">
-            <div class="wizard-pod-row-title">ATTRIBUTES</div>
+            <div class="wizard-pod-row-title">Attributes</div>
             <div class="wizard-pod-row-contents">
               <span class="wizard-pod-content">
                 <label>Dereg. Delay</label><help-field key="aws.targetGroup.attributes.deregistrationDelay"></help-field> <input class="form-control input-sm inline-number" ng-model="targetGroup.attributes.deregistrationDelay" type="number"/>

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/classic/createClassicLoadBalancer.controller.spec.ts
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/classic/createClassicLoadBalancer.controller.spec.ts
@@ -7,6 +7,7 @@ import { APPLICATION_MODEL_BUILDER,
   SecurityGroupReader
 } from '@spinnaker/core';
 
+import { AMAZON_CERTIFICATE_READ_SERVICE, AmazonCertificateReader } from 'amazon/certificates/amazon.certificate.read.service';
 import { AWSProviderSettings } from 'amazon/aws.settings';
 import { IAmazonClassicLoadBalancer, IAmazonClassicLoadBalancerUpsertCommand } from 'amazon/domain';
 import { AwsLoadBalancerTransformer } from 'amazon/loadBalancer/loadBalancer.transformer';
@@ -19,10 +20,12 @@ describe('Controller: awsCreateClassicLoadBalancerCtrl', () => {
       securityGroupReader: SecurityGroupReader,
       accountService: AccountService,
       subnetReader: SubnetReader,
+      amazonCertificateReader: AmazonCertificateReader,
       initialize: (loadBalancer?: IAmazonClassicLoadBalancer) => void;
 
   beforeEach(
     mock.module(
+      AMAZON_CERTIFICATE_READ_SERVICE,
       AWS_CREATE_CLASSIC_LOAD_BALANCER_CTRL,
       APPLICATION_MODEL_BUILDER
     )
@@ -34,6 +37,7 @@ describe('Controller: awsCreateClassicLoadBalancerCtrl', () => {
                           _$q_: IQService,
                           _accountService_: AccountService,
                           _subnetReader_: SubnetReader,
+                          _amazonCertificateReader_: AmazonCertificateReader,
                           applicationModelBuilder: ApplicationModelBuilder,
                           _securityGroupReader_: SecurityGroupReader,
                           awsLoadBalancerTransformer: AwsLoadBalancerTransformer) => {
@@ -42,6 +46,7 @@ describe('Controller: awsCreateClassicLoadBalancerCtrl', () => {
     securityGroupReader = _securityGroupReader_;
     accountService = _accountService_;
     subnetReader = _subnetReader_;
+    amazonCertificateReader = _amazonCertificateReader_;
     const app = applicationModelBuilder.createApplication('app', {key: 'loadBalancers', lazy: true});
     initialize = (loadBalancer: IAmazonClassicLoadBalancer = null) => {
       if (loadBalancer) {
@@ -58,6 +63,7 @@ describe('Controller: awsCreateClassicLoadBalancerCtrl', () => {
         securityGroupReader: securityGroupReader,
         accountService: accountService,
         subnetReader: subnetReader,
+        amazonCertificateReader: amazonCertificateReader,
         awsLoadBalancerTransformer: awsLoadBalancerTransformer,
       });
       controller.$onInit();
@@ -246,6 +252,7 @@ describe('Controller: awsCreateClassicLoadBalancerCtrl', () => {
       spyOn(securityGroupReader, 'getAllSecurityGroups').and.returnValue($q.when(availableSecurityGroups));
       spyOn(accountService, 'getAccountDetails').and.returnValue($q.when([{name: 'test'}]));
       spyOn(subnetReader, 'listSubnets').and.returnValue($q.when([{account: 'test', region: 'us-east-1', vpcId: 'vpc-1'}]));
+      spyOn(amazonCertificateReader, 'listCertificates').and.returnValue($q.when([]));
       initialize(existingLoadBalancer);
       $scope.$digest();
       expect(controller.availableSecurityGroups.map(g => g.name)).toEqual(['d', 'a', 'b', 'c']);
@@ -273,6 +280,7 @@ describe('Controller: awsCreateClassicLoadBalancerCtrl', () => {
       spyOn(subnetReader, 'listSubnets').and.returnValue($q.when([
         {account: 'test', region: 'us-east-1', vpcId: 'vpc-1', purpose: 'external'}
       ]));
+      spyOn(amazonCertificateReader, 'listCertificates').and.returnValue($q.when([]));
       initialize();
       $scope.$digest();
       expect(controller.availableSecurityGroups.map(g => g.name)).toEqual(['sg-a', 'a', 'b', 'c', 'd']);

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/classic/createClassicLoadBalancer.controller.ts
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/classic/createClassicLoadBalancer.controller.ts
@@ -23,7 +23,8 @@ import {
   V2_MODAL_WIZARD_SERVICE
 } from '@spinnaker/core';
 
-import { AWS_LOAD_BALANCER_TRANFORMER, AwsLoadBalancerTransformer } from 'amazon/loadBalancer/loadBalancer.transformer';
+import { AMAZON_CERTIFICATE_READ_SERVICE, AmazonCertificateReader } from 'amazon/certificates/amazon.certificate.read.service';
+import { AWS_LOAD_BALANCER_TRANSFORMER, AwsLoadBalancerTransformer } from 'amazon/loadBalancer/loadBalancer.transformer';
 import { IAmazonClassicLoadBalancer, IAmazonClassicLoadBalancerUpsertCommand, IClassicListenerDescription } from 'amazon/domain';
 import { CreateAmazonLoadBalancerCtrl } from '../common/createAmazonLoadBalancer.controller';
 import { SUBNET_SELECT_FIELD_COMPONENT } from 'amazon/subnet/subnetSelectField.component';
@@ -45,6 +46,7 @@ export class CreateClassicLoadBalancerCtrl extends CreateAmazonLoadBalancerCtrl 
               protected accountService: AccountService,
               protected awsLoadBalancerTransformer: AwsLoadBalancerTransformer,
               securityGroupReader: SecurityGroupReader,
+              amazonCertificateReader: AmazonCertificateReader,
               cacheInitializer: CacheInitializerService,
               infrastructureCaches: InfrastructureCacheService,
               v2modalWizardService: any,
@@ -57,7 +59,7 @@ export class CreateClassicLoadBalancerCtrl extends CreateAmazonLoadBalancerCtrl 
               protected isNew: boolean,
               protected forPipelineConfig: boolean) {
     'ngInject';
-    super($scope, $uibModalInstance, $state, accountService, securityGroupReader, cacheInitializer, infrastructureCaches, v2modalWizardService, loadBalancerWriter, taskMonitorBuilder, subnetReader, namingService, application, isNew, forPipelineConfig);
+    super($scope, $uibModalInstance, $state, accountService, securityGroupReader, amazonCertificateReader, cacheInitializer, infrastructureCaches, v2modalWizardService, loadBalancerWriter, taskMonitorBuilder, subnetReader, namingService, application, isNew, forPipelineConfig);
   }
 
   protected initializeController(): void {
@@ -116,6 +118,12 @@ export class CreateClassicLoadBalancerCtrl extends CreateAmazonLoadBalancerCtrl 
     });
   }
 
+  public showCertificateSelect(listener: IClassicListenerDescription): boolean {
+    return listener.sslCertificateType === 'iam' &&
+      (listener.externalProtocol === 'HTTPS' || listener.externalProtocol === 'SSL') &&
+      this.certificates && Object.keys(this.certificates).length > 0;
+  }
+
   protected formatCommand(): void {
     this.setAvailabilityZones(this.loadBalancerCommand);
     this.clearSecurityGroupsIfNotInVpc(this.loadBalancerCommand);
@@ -145,8 +153,9 @@ module(AWS_CREATE_CLASSIC_LOAD_BALANCER_CTRL, [
   require('@uirouter/angularjs').default,
   LOAD_BALANCER_WRITE_SERVICE,
   ACCOUNT_SERVICE,
-  AWS_LOAD_BALANCER_TRANFORMER,
+  AWS_LOAD_BALANCER_TRANSFORMER,
   SECURITY_GROUP_READER,
+  AMAZON_CERTIFICATE_READ_SERVICE,
   V2_MODAL_WIZARD_SERVICE,
   TASK_MONITOR_BUILDER,
   SUBNET_READ_SERVICE,

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/classic/listeners.html
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/classic/listeners.html
@@ -33,7 +33,11 @@
                     ng-options="certificateType for certificateType in ['iam','acm']"></select>
           </td>
           <td ng-if="ctrl.showSslCertificateNameField()">
-            <input ng-if="listener.externalProtocol === 'HTTPS' || listener.externalProtocol === 'SSL'"
+            <select ng-if="ctrl.showCertificateSelect(listener) && (listener.externalProtocol === 'HTTPS' || listener.externalProtocol === 'SSL')"
+                    class="form-control input-sm" ng-model="listener.sslCertificateName" required
+                    ng-options="certificate.serverCertificateName as certificate.serverCertificateName for certificate in ctrl.certificates[ctrl.loadBalancerCommand.credentials]"></select>
+
+            <input ng-if="!ctrl.showCertificateSelect(listener) && (listener.externalProtocol === 'HTTPS' || listener.externalProtocol === 'SSL')"
                    class="form-control input-sm no-spel"
                    type="text"
                    ng-model="listener.sslCertificateName"

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/common/configure.less
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/common/configure.less
@@ -13,14 +13,23 @@
     padding: 5px;
     border-bottom: 1px solid @lighter_grey;
 
+    label {
+      font-weight: 400;
+      padding-right: 5px;
+    }
+
     &.header {
       .wizard-pod-row-title {
         font-weight: 800;
       }
       .wizard-pod-row-contents {
         flex-wrap: nowrap;
+        padding: 0;
         label {
           font-weight: 600;
+        }
+        .wizard-pod-content {
+          padding: 0 10px 0 0;
         }
       }
       background-color: @lighter_grey;
@@ -34,15 +43,45 @@
       font-weight: 600;
       text-align: right;
       margin-right: 10px;
+      width: 100px;
     }
     .wizard-pod-row-contents {
       display: flex;
       width: 100%;
       align-items: baseline;
       flex-wrap: wrap;
-      .wizard-pod-content {
-        padding: 5px 10px;
+      padding: 5px 0;
+      &.spread {
+        justify-content: space-between;
       }
+      .wizard-pod-content {
+        padding: 0 10px 5px 0;
+      }
+      .rules-table {
+        thead {
+          th {
+            font-weight: 600;
+          }
+        }
+        td {
+          vertical-align: middle;
+        }
+        >tbody {
+          >tr:first-child {
+            >td {
+              border-top: none;
+            }
+          }
+        }
+      }
+    }
+  }
+  .wizard-pod-rule {
+    .wizard-pod-rule-conditions {
+      display: inline-block;
+    }
+    .wizard-pod-rule-action {
+      display: inline-block;
     }
   }
 }

--- a/app/scripts/modules/amazon/src/loadBalancer/loadBalancer.module.ts
+++ b/app/scripts/modules/amazon/src/loadBalancer/loadBalancer.module.ts
@@ -4,7 +4,7 @@ import { AWS_CREATE_APPLICATION_LOAD_BALANCER_CTRL } from './configure/applicati
 import { AWS_CREATE_CLASSIC_LOAD_BALANCER_CTRL } from './configure/classic/createClassicLoadBalancer.controller';
 import { AWS_LOAD_BALANCER_CHOICE_MODAL } from './configure/choice/awsLoadBalancerChoice.modal';
 import { AWS_LOAD_BALANCER_DETAILS_CTRL } from './details/loadBalancerDetails.controller';
-import { AWS_LOAD_BALANCER_TRANFORMER } from './loadBalancer.transformer';
+import { AWS_LOAD_BALANCER_TRANSFORMER } from './loadBalancer.transformer';
 import { AWS_TARGET_GROUP_DETAILS_CTRL } from './details/targetGroupDetails.controller';
 import { TARGET_GROUP_STATES } from './targetGroup.states';
 
@@ -15,7 +15,7 @@ module(AWS_LOAD_BALANCER_MODULE, [
   AWS_CREATE_APPLICATION_LOAD_BALANCER_CTRL,
   AWS_LOAD_BALANCER_CHOICE_MODAL,
   AWS_LOAD_BALANCER_DETAILS_CTRL,
-  AWS_LOAD_BALANCER_TRANFORMER,
+  AWS_LOAD_BALANCER_TRANSFORMER,
   AWS_TARGET_GROUP_DETAILS_CTRL,
   TARGET_GROUP_STATES
 ]);

--- a/app/scripts/modules/amazon/src/loadBalancer/loadBalancer.transformer.ts
+++ b/app/scripts/modules/amazon/src/loadBalancer/loadBalancer.transformer.ts
@@ -364,8 +364,8 @@ export class AwsLoadBalancerTransformer {
   }
 }
 
-export const AWS_LOAD_BALANCER_TRANFORMER = 'spinnaker.amazon.loadBalancer.transformer';
-module(AWS_LOAD_BALANCER_TRANFORMER, [
+export const AWS_LOAD_BALANCER_TRANSFORMER = 'spinnaker.amazon.loadBalancer.transformer';
+module(AWS_LOAD_BALANCER_TRANSFORMER, [
   VPC_READ_SERVICE
 ])
   .service('awsLoadBalancerTransformer', AwsLoadBalancerTransformer);

--- a/app/scripts/modules/core/src/certificates/certificate.read.service.ts
+++ b/app/scripts/modules/core/src/certificates/certificate.read.service.ts
@@ -1,0 +1,32 @@
+import { IPromise, module } from 'angular';
+
+import { INFRASTRUCTURE_CACHE_SERVICE, InfrastructureCacheService } from 'core/cache/infrastructureCaches.service';
+import { API_SERVICE, Api } from 'core/api/api.service';
+
+export interface ICertificate {
+  expiration: number;
+  path: string;
+  serverCertificateId: string;
+  serverCertificateName: string;
+}
+
+export class CertificateReader {
+
+  public constructor(private API: Api, private infrastructureCaches: InfrastructureCacheService) { 'ngInject'; }
+
+  public listCertificates(): IPromise<ICertificate[]> {
+    return this.API.one('certificates')
+      .useCache(this.infrastructureCaches.get('certificates'))
+      .getList();
+  }
+
+  public listCertificatesByProvider(cloudProvider: string): IPromise<ICertificate[]> {
+    return this.API.one('certificates').one(cloudProvider)
+      .useCache(this.infrastructureCaches.get('certificates'))
+      .getList();
+  }
+}
+
+export const CERTIFICATE_READ_SERVICE = 'spinnaker.core.certificate.read.service';
+module(CERTIFICATE_READ_SERVICE, [API_SERVICE, INFRASTRUCTURE_CACHE_SERVICE])
+  .service('certificateReader', CertificateReader);

--- a/app/scripts/modules/core/src/certificates/index.ts
+++ b/app/scripts/modules/core/src/certificates/index.ts
@@ -1,0 +1,1 @@
+export * from './certificate.read.service';

--- a/app/scripts/modules/core/src/index.ts
+++ b/app/scripts/modules/core/src/index.ts
@@ -5,6 +5,7 @@ export * from './authentication';
 
 export * from './cache';
 export * from './cancelModal';
+export * from './certificates';
 export * from './ci';
 export * from './cloudProvider';
 export * from './cluster';

--- a/app/scripts/modules/core/src/presentation/less/imports/colors.less
+++ b/app/scripts/modules/core/src/presentation/less/imports/colors.less
@@ -10,7 +10,7 @@
 @mid_lighter_grey: #999999;
 @mid_light_grey: #d9d9d9;
 @light_grey: #EBEBEB;
-@lighter_grey: #EEEEEE;
+@lighter_grey: #EFEFEF;
 @lightest_grey: #F8F8F8;
 @succeeded_job: #E6FFE6;
 @failed_job: #FFE6E6;


### PR DESCRIPTION
* Add a certificate service to cache the list of server certificates
* Convert load balancer (classic and application) certificate inputs to selects to use the new cache service
* A few minor CSS tweaks for the listeners in ALBs
* Fixes the bug where you couldn't actually put in a certificate for an HTTPS listener on an ALB

Relies on https://github.com/spinnaker/gate/pull/414 and https://github.com/spinnaker/clouddriver/pull/1702