### PR TITLE
feat(pipeline/RunJob): Allow container name conf

### DIFF
--- a/app/scripts/modules/kubernetes/pipeline/stages/runJob/runJobStage.html
+++ b/app/scripts/modules/kubernetes/pipeline/stages/runJob/runJobStage.html
@@ -18,6 +18,12 @@
     </namespace-select-field>
   </stage-config-field>
 
+  <stage-config-field label="Container Name">
+    <div>
+      <input type="text" class="form-control input-sm" ng-model="ctrl.stage.container.name">
+    </div>
+  </stage-config-field>
+
   <stage-config-field label="Image">
     <div class="form-group" ng-if="ctrl.hasDockerPipelineTriggers()">
       <div>

--- a/app/scripts/modules/kubernetes/pipeline/stages/runJob/runJobStage.js
+++ b/app/scripts/modules/kubernetes/pipeline/stages/runJob/runJobStage.js
@@ -48,7 +48,7 @@ module.exports = angular.module('spinnaker.kubernetes.pipeline.stage.runJobStage
     };
 
     if (!_.has(this.stage, 'container.name')) {
-      _.set(this.stage, 'container.name', Date.now().toString());
+      _.set(this.stage, 'container.name', 'job');
     }
 
     if (!_.has(this.stage, 'container.imageDescription.fromTrigger')) {


### PR DESCRIPTION
Allow configuring container name in the RunJob stage. The default name
was the current date which makes it difficult to pin point containers for
logging purposes. Also, changes the default container name to `job`
since Clouddriver does that for containers without a name anyway.

Addresses [#1770](https://github.com/spinnaker/spinnaker/issues/1770)

#### Screenshot
![image](https://user-images.githubusercontent.com/3324110/27349634-93304f3c-55bd-11e7-9614-ddbdb2e50861.png)

@danielpeach PTAL!

