### PR TITLE
fix(traffic_guards): Allow accounts w/ namespaces to use traffic guards

### DIFF
--- a/app/scripts/modules/core/src/account/account.service.ts
+++ b/app/scripts/modules/core/src/account/account.service.ts
@@ -33,6 +33,7 @@ export interface IAccountDetails extends IAccount {
   environment: string;
   primaryAccount: boolean;
   regions: IRegion[];
+  namespaces?: string[];
 }
 
 export interface IAggregatedAccounts {

--- a/app/scripts/modules/core/src/application/config/trafficGuard/trafficGuardConfig.component.html
+++ b/app/scripts/modules/core/src/application/config/trafficGuard/trafficGuardConfig.component.html
@@ -39,7 +39,7 @@
                     ng-change="$ctrl.configChanged()"
                     required
                     ng-if="guard.account">
-              <option ng-repeat="region in $ctrl.regionsByAccount[guard.account]" value="{{region}}">{{region}}</option>
+              <option ng-repeat="location in $ctrl.locationsByAccount[guard.account]" value="{{location}}">{{location}}</option>
             </select>
           </td>
           <td>


### PR DESCRIPTION
I'm seeing one strange thing, and I don't know if it's intentional. Any attempt to disable a k8s server group in stage like "destroy" or a pipeline fails because of the traffic guard, but a direct "disable" operation greets me with this dialog: 
![disable-traffic-guards](https://user-images.githubusercontent.com/4874941/27410209-e5fd3bb6-569a-11e7-8af4-7a4279a16088.png)
and the disable succeeds if I enter "0". Is that right?

@tomaslin @duftler FYI
