### PR TITLE
fix(gce): prevent npe when loading server group wizard in project wit…

### DIFF
--- a/app/scripts/modules/google/src/serverGroup/configure/serverGroupConfiguration.service.js
+++ b/app/scripts/modules/google/src/serverGroup/configure/serverGroupConfiguration.service.js
@@ -472,7 +472,7 @@ module.exports = angular.module('spinnaker.serverGroup.configure.gce.configurati
     }
 
     function getXpnHostProjectIfAny(network) {
-      if (network.includes('/')) {
+      if (network && network.includes('/')) {
         return network.split('/')[0] + '/';
       } else {
         return '';


### PR DESCRIPTION
…hout default network

@duftler 

I think this bug only occurs if your default account (i.e., the one that's auto-selected in the server group wizard) corresponds to a GCE project without a default network.