### PR TITLE
feat(kubernetes): Configure Service Account Name

### DIFF
--- a/app/scripts/modules/kubernetes/pipeline/stages/runJob/runJobStage.html
+++ b/app/scripts/modules/kubernetes/pipeline/stages/runJob/runJobStage.html
@@ -24,6 +24,12 @@
     </div>
   </stage-config-field>
 
+  <stage-config-field label="Service Account Name">
+    <div>
+      <input type="text" class="form-control input-sm" ng-model="ctrl.stage.serviceAccountName">
+    </div>
+  </stage-config-field>
+
   <stage-config-field label="Image">
     <div class="form-group" ng-if="ctrl.hasDockerPipelineTriggers()">
       <div>

--- a/app/scripts/modules/kubernetes/serverGroup/configure/wizard/advancedSettings.html
+++ b/app/scripts/modules/kubernetes/serverGroup/configure/wizard/advancedSettings.html
@@ -1,5 +1,31 @@
 <ng-form name="advancedSettings">
   <div class="form-group form-horizontal">
+
+    <div class="form-group">
+      <div class="col-md-4 sm-label-right">
+        Service Account Name
+      </div>
+      <div class="col-md-7">
+        <input type="text" class="form-control input-sm" ng-model="command.serviceAccountName">
+      </div>
+    </div>
+
+    <div class="form-group">
+      <div class="col-md-4 sm-label-right">
+        Termination Grace Period
+        <help-field key="kubernetes.serverGroup.terminationGracePeriodSeconds"></help-field>
+      </div>
+      <div class="col-md-3">
+        <div class="input-group">
+          <input type="number" min="0"
+                 class="form-control input-sm"
+                 name="terminationGracePeriodSeconds"
+                 ng-model="command.terminationGracePeriodSeconds" required/>
+          <span class="input-group-addon">seconds</span>
+        </div>
+      </div>
+    </div>
+
     <div class="col-md-12">
       <map-editor model="command.replicaSetAnnotations"
                   label="Replica Set Annotations"
@@ -19,22 +45,6 @@
                   label="Node Selector"
                   add-button-label="Add Node Selector"
                   labels-left="true"></map-editor>
-    </div>
-
-    <div class="form-group">
-      <div class="col-md-4 sm-label-right">
-        Termination Grace Period
-        <help-field key="kubernetes.serverGroup.terminationGracePeriodSeconds"></help-field>
-      </div>
-      <div class="col-md-3">
-        <div class="input-group">
-          <input type="number" min="0"
-             class="form-control input-sm"
-             name="terminationGracePeriodSeconds"
-             ng-model="command.terminationGracePeriodSeconds" required/>
-          <span class="input-group-addon">seconds</span>
-        </div>
-      </div>
     </div>
 
   </div>

--- a/app/scripts/modules/kubernetes/serverGroup/details/details.html
+++ b/app/scripts/modules/kubernetes/serverGroup/details/details.html
@@ -246,6 +246,10 @@
       </div>
     </collapsible-section>
     <collapsible-section heading="Advanced Settings">
+      <dl ng-if="serverGroup.deployDescription.serviceAccountName">
+        <dt>Service Account Name</dt>
+        <dd>{{serverGroup.deployDescription.serviceAccountName}}</dd>
+      </dl>
       <dl>
         <dt>Termination Grace Period</dt>
         <dd>{{serverGroup.deployDescription.terminationGracePeriodSeconds}}&nbsp;second(s)</dd>


### PR DESCRIPTION
Allows configurable Service Account Name for Server Groups and Run Job
configuration to enable applications access to the Kubernetes API if
need be. Default behavior is to assign the `default` Service Account if
left blank. I also added it to the Server Group details. Note, if the
service account is `default`, it will not show up as the API doesn't
return it with the ReplicaSet/Deployment.

#### Server Group Config
![image](https://user-images.githubusercontent.com/3324110/27497069-6d7873d8-581e-11e7-8200-b1fc6c8a5f73.png)


#### Server Group Details
![image](https://user-images.githubusercontent.com/3324110/27497178-deead1c8-581e-11e7-80df-92d07ad9445d.png)

#### Run Job Stage
![image](https://user-images.githubusercontent.com/3324110/27497194-f086ab6e-581e-11e7-917d-0805bdc13e6d.png)


@danielpeach PTAL
@lwander FYI