### PR TITLE
fix(core): hide judgment inputs if manual judgment succeeded

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/manualJudgment/ManualJudgmentApproval.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/manualJudgment/ManualJudgmentApproval.tsx
@@ -82,7 +82,7 @@ export class ManualJudgmentApproval extends React.Component<IManualJudgmentAppro
     const options: Select.Option[] = (stage.context.judgmentInputs || [])
       .map((o: {value: string}) => { return {value: o.value, label: o.value}; });
 
-    const showOptions = status !== 'SKIPPED' && (!stage.context.judgmentStatus || status === 'RUNNING');
+    const showOptions = !['SKIPPED', 'SUCCEEDED'].includes(status) && (!stage.context.judgmentStatus || status === 'RUNNING');
 
     const hasInstructions = !!stage.context.instructions;
     const { ButtonBusyIndicator } = NgReact;

--- a/app/scripts/modules/core/src/pipeline/config/stages/manualJudgment/manualJudgmentExecutionDetails.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/manualJudgment/manualJudgmentExecutionDetails.html
@@ -1,9 +1,9 @@
 <div ng-controller="ManualJudgmentExecutionDetailsCtrl as manualCtrl">
   <execution-details-section-nav sections="configSections"></execution-details-section-nav>
   <div class="step-section-details" ng-if="detailsSection === 'manualJudgment'">
-    <dl class="dl-narrow dl-horizontal no-margin">
-      <dt ng-if="stage.context.judgmentStatus || stage.status === 'SKIPPED'">Judgment</dt>
-      <dd ng-if="stage.context.judgmentStatus">{{ stage.context.judgmentStatus | robotToHuman }}</dd>
+    <dl class="no-margin">
+      <dt ng-if-start="stage.context.judgmentStatus || ['SKIPPED', 'SUCCEEDED'].includes(stage.status)">Judgment</dt>
+      <dd ng-if-end>{{ (stage.context.judgmentStatus || 'No judgment made') | robotToHuman }}</dd>
       <dd ng-if="stage.status === 'SKIPPED'">Skipped</dd>
       <dt ng-if="stage.context.lastModifiedBy">Judged By</dt>
       <dd ng-if="stage.context.lastModifiedBy">


### PR DESCRIPTION
A recent change to Orca allows stages to be considered successful if they time out, which was introduced specifically to allow manual judgment stages to act more optionally and not fail. This is something we're doing on some internal stuff at Netflix.

If the stage is complete, though, we want to hide the judgment options, which is what this change does.