### PR TITLE
fix(core): trim spaces from pipeline name before delete

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/services/pipelineConfig.service.ts
+++ b/app/scripts/modules/core/src/pipeline/config/services/pipelineConfig.service.ts
@@ -48,7 +48,7 @@ export class PipelineConfigService {
   }
 
   public deletePipeline(applicationName: string, pipeline: IPipeline, pipelineName: string): IPromise<void> {
-    return this.API.one(pipeline.strategy ? 'strategies' : 'pipelines').one(applicationName, pipelineName).remove();
+    return this.API.one(pipeline.strategy ? 'strategies' : 'pipelines').one(applicationName, pipelineName.trim()).remove();
   }
 
   public savePipeline(pipeline: IPipeline): IPromise<void> {


### PR DESCRIPTION
- pipeline deletes will fail if the name has leading whitespace
- Trimming the whitespace before submitting to the backend