### PR TITLE
fix(core): improve error message on script stage failure

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/core/baseExecutionDetails.controller.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/core/baseExecutionDetails.controller.ts
@@ -10,8 +10,8 @@ export interface IExecutionDetailsScope extends IScope {
 
 export class BaseExecutionDetailsCtrl {
   constructor (public $scope: IExecutionDetailsScope,
-               private $stateParams: StateParams,
-               private executionDetailsSectionService: ExecutionDetailsSectionService) {
+               protected $stateParams: StateParams,
+               protected executionDetailsSectionService: ExecutionDetailsSectionService) {
     this.$scope.$on('$stateChangeSuccess', () => this.initialize());
   }
 

--- a/app/scripts/modules/core/src/pipeline/config/stages/script/scriptExecutionDetails.controller.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/script/scriptExecutionDetails.controller.ts
@@ -1,0 +1,32 @@
+import { module } from 'angular';
+import { get } from 'lodash';
+import { StateParams } from '@uirouter/core';
+
+import { BaseExecutionDetailsCtrl, IExecutionDetailsScope } from '../core/baseExecutionDetails.controller';
+import { ExecutionDetailsSectionService, IStage } from '@spinnaker/core';
+
+export class ScriptExecutionDetailsCtrl extends BaseExecutionDetailsCtrl {
+
+  public scriptRanAndFailed = false;
+
+  constructor (public $scope: IExecutionDetailsScope,
+               protected $stateParams: StateParams,
+               protected executionDetailsSectionService: ExecutionDetailsSectionService) {
+    super($scope, $stateParams, executionDetailsSectionService);
+  }
+
+  public $onInit(): void {
+    super.$onInit();
+    this.setScriptFailureFlag();
+  }
+
+  private setScriptFailureFlag(): void {
+    const stage: IStage = this.$scope.stage;
+    if (stage.isFailed && !stage.failureMessage && get(stage.context, 'buildInfo.result') === 'FAILURE') {
+      this.scriptRanAndFailed = true;
+    }
+  }
+}
+
+export const SCRIPT_EXECUTION_DETAILS_CONTROLLER = 'spinnaker.core.pipeline.stages.script.executionDetails.controller';
+module(SCRIPT_EXECUTION_DETAILS_CONTROLLER, []).controller('ScriptExecutionDetailsCtrl', ScriptExecutionDetailsCtrl);

--- a/app/scripts/modules/core/src/pipeline/config/stages/script/scriptExecutionDetails.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/script/scriptExecutionDetails.html
@@ -1,4 +1,4 @@
-<div ng-controller="BaseExecutionDetailsCtrl">
+<div ng-controller="ScriptExecutionDetailsCtrl as ctrl">
   <execution-details-section-nav sections="configSections"></execution-details-section-nav>
   <div class="step-section-details" ng-if="detailsSection === 'scriptConfig'">
     <div class="row">
@@ -19,7 +19,7 @@
       </div>
     </div>
 
-    <div class="row ng-scope" ng-if="stage.context.buildInfo.url">
+    <div class="row ng-scope" ng-if="!ctrl.scriptRanAndFailed && stage.context.buildInfo.url">
       <div class="col-md-12">
         <div class="well alert alert-info">
           <a ng-if="stage.context.buildInfo.url"
@@ -29,7 +29,18 @@
       </div>
     </div>
 
-    <stage-failure-message stage="stage" message="failureMessage"></stage-failure-message>
+    <div ng-if="ctrl.scriptRanAndFailed">
+      <div class="alert alert-danger">
+        Script execution failed.
+        Check <a ng-if="stage.context.buildInfo.url"
+                 href="{{stage.context.buildInfo.url}}consoleText"
+                 target="_blank">the script results</a> for details.
+      </div>
+    </div>
+
+    <stage-failure-message ng-if="!ctrl.scriptRanAndFailed"
+                           stage="stage"
+                           message="stage.failureMessage"></stage-failure-message>
   </div>
 
   <div class="step-section-details" ng-if="detailsSection === 'taskStatus'">

--- a/app/scripts/modules/core/src/pipeline/config/stages/script/scriptStage.module.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/script/scriptStage.module.js
@@ -1,9 +1,9 @@
 'use strict';
 
 const angular = require('angular');
+import { SCRIPT_EXECUTION_DETAILS_CONTROLLER } from './scriptExecutionDetails.controller';
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.script', [
   require('./scriptStage.js'),
-  require('../stage.module.js'),
-  require('../core/stage.core.module.js'),
+  SCRIPT_EXECUTION_DETAILS_CONTROLLER,
 ]);


### PR DESCRIPTION
We've gotten user complaints that troubleshooting a failed script execution is not obvious:
<img width="473" alt="screen shot 2017-06-25 at 6 44 31 pm" src="https://user-images.githubusercontent.com/73450/27521895-6239e718-59d6-11e7-8ef6-aefaf60590fe.png">

Users are not seeing the "Script Results" link above, or not understanding that they can see the output of the script by clicking on the link 

This PR makes the link more obvious:
<img width="418" alt="screen shot 2017-06-25 at 6 43 39 pm" src="https://user-images.githubusercontent.com/73450/27521888-463b6096-59d6-11e7-9f1b-459544ecf5d8.png">
