### PR TITLE
feat(provider/amazon): Enforce target group naming convention

### DIFF
--- a/app/scripts/modules/amazon/src/domain/IAmazonLoadBalancerSourceData.ts
+++ b/app/scripts/modules/amazon/src/domain/IAmazonLoadBalancerSourceData.ts
@@ -100,18 +100,26 @@ export interface IAmazonTargetGroupSourceData {
   vpcId: string;
 }
 
+export interface IApplicationLoadBalancerCertificateSourceData {
+  certificateArn: string;
+}
+
+export interface IApplicationLoadBalancerListenerSourceData {
+  certificates?: IApplicationLoadBalancerCertificateSourceData[];
+  defaultActions: {
+    targetGroupName: string;
+    type: 'forward';
+  }[];
+  listenerArn: string;
+  loadBalancerName: string;
+  port: number;
+  protocol: 'HTTP' | 'HTTPS';
+  sslPolicy?: string;
+}
+
 export interface IApplicationLoadBalancerSourceData extends IAmazonLoadBalancerSourceData {
   ipAddressType: 'ipv4' | 'dualstack';
-  listeners: {
-    defaultActions: {
-      targetGroupName: string;
-      type: 'forward';
-    }[];
-    listenerArn: string;
-    loadBalancerName: string;
-    port: number;
-    protocol: string;
-  }[];
+  listeners: IApplicationLoadBalancerListenerSourceData[];
   loadBalancerArn: string;
   loadBalancerType: 'application' | 'network';
   state: {

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/application/targetGroups.html
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/application/targetGroups.html
@@ -6,14 +6,15 @@
           <div class="wizard-pod-row header">
             <div class="wizard-pod-row-title">Group Name</div>
             <div class="wizard-pod-row-contents">
+              <span class="group-name-prefix">{{ctrl.loadBalancerCommand.name}}-</span>
               <input class="form-control input-sm target-group-name"
-                          type="text"
-                          ng-model="targetGroup.name"
-                          ng-model-options="{ allowInvalid: true }"
-                          validate-unique="ctrl.existingTargetGroupNames"
-                          validate-ignore-case="true"
-                          name="targetGroupName{{$index}}"
-                          required/>
+                     type="text"
+                     ng-model="targetGroup.name"
+                     ng-model-options="{ allowInvalid: true }"
+                     validate-unique="ctrl.existingTargetGroupNames"
+                     validate-ignore-case="true"
+                     name="targetGroupName{{$index}}"
+                     required/>
               <a href class="sm-label" ng-click="ctrl.removeTargetGroup($index)"><span class="glyphicon glyphicon-trash"></span></a>
             </div>
           </div>
@@ -21,11 +22,18 @@
             <div class="wizard-pod-row-title">Backend Connection</div>
             <div class="wizard-pod-row-contents">
               <span class="wizard-pod-content">
-                <label>Protocol</label> <select class="form-control input-sm inline-number" ng-model="targetGroup.protocol"
-                          ng-options="protocol for protocol in ['HTTP','HTTPS']"></select>
+                <label>Protocol </label>
+                <select class="form-control input-sm inline-number"
+                        ng-model="targetGroup.protocol"
+                        ng-options="protocol for protocol in ['HTTP','HTTPS']">
+                </select>
               </span>
               <span class="wizard-pod-content">
-                <label>Port</label> <input class="form-control input-sm inline-number" ng-model="targetGroup.port" type="text" required/>
+                <label>Port </label>
+                <input class="form-control input-sm inline-number"
+                       ng-model="targetGroup.port"
+                       type="text"
+                       required/>
               </span>
             </div>
           </div>
@@ -33,20 +41,39 @@
             <div class="wizard-pod-row-title">Healthcheck</div>
             <div class="wizard-pod-row-contents">
               <span class="wizard-pod-content">
-              <label>Protocol</label> <select class="form-control input-sm inline-number" ng-model="targetGroup.healthCheckProtocol"
-                        ng-options="protocol for protocol in ['HTTP','HTTPS']"></select>
+                <label>Protocol </label>
+                <select class="form-control input-sm inline-number"
+                        ng-model="targetGroup.healthCheckProtocol"
+                        ng-options="protocol for protocol in ['HTTP','HTTPS']">
+                </select>
               </span>
               <span class="wizard-pod-content">
-                <label>Port</label> <input class="form-control input-sm inline-number" ng-model="targetGroup.healthCheckPort" type="text" required/>
+                <label>Port </label>
+                <input class="form-control input-sm inline-number"
+                       ng-model="targetGroup.healthCheckPort"
+                       type="text"
+                       required/>
               </span>
               <span class="wizard-pod-content">
-                <label>Path</label> <input class="form-control input-sm inline-text" ng-model="targetGroup.healthCheckPath" type="text" required/>
+                <label>Path </label>
+                <input class="form-control input-sm inline-text"
+                       ng-model="targetGroup.healthCheckPath"
+                       type="text"
+                       required/>
               </span>
               <span class="wizard-pod-content">
-                <label>Timeout</label> <input class="form-control input-sm inline-number" ng-model="targetGroup.healthCheckTimeout" type="text" required/>
+                <label>Timeout </label>
+                <input class="form-control input-sm inline-number"
+                       ng-model="targetGroup.healthCheckTimeout"
+                       type="text"
+                       required/>
               </span>
               <span class="wizard-pod-content">
-                <label>Interval</label> <input class="form-control input-sm inline-number" ng-model="targetGroup.healthCheckInterval" type="text" required/>
+                <label>Interval </label>
+                <input class="form-control input-sm inline-number"
+                       ng-model="targetGroup.healthCheckInterval"
+                       type="text"
+                       required/>
               </span>
             </div>
           </div>
@@ -54,10 +81,18 @@
             <div class="wizard-pod-row-title">Healthcheck Threshold</div>
             <div class="wizard-pod-row-contents">
               <span class="wizard-pod-content">
-                <label>Healthy</label> <input class="form-control input-sm inline-number" ng-model="targetGroup.healthyThreshold" type="number" required/>
+                <label>Healthy </label>
+                <input class="form-control input-sm inline-number"
+                       ng-model="targetGroup.healthyThreshold"
+                       type="number"
+                       required/>
               </span>
               <span class="wizard-pod-content">
-                <label>Unhealthy</label> <input class="form-control input-sm inline-number" ng-model="targetGroup.unhealthyThreshold" type="number" required/>
+                <label>Unhealthy </label>
+                <input class="form-control input-sm inline-number"
+                       ng-model="targetGroup.unhealthyThreshold"
+                       type="number"
+                       required/>
               </span>
             </div>
           </div>

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/classic/createClassicLoadBalancer.controller.ts
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/classic/createClassicLoadBalancer.controller.ts
@@ -82,11 +82,11 @@ export class CreateClassicLoadBalancerCtrl extends CreateAmazonLoadBalancerCtrl 
     }
   }
 
-  protected formatListeners(): IPromise<void> {
-    return this.accountService.getAccountDetails(this.loadBalancerCommand.credentials).then((account) => {
-      this.loadBalancerCommand.listeners.forEach((listener) => {
+  protected formatListeners(command: IAmazonClassicLoadBalancerUpsertCommand): IPromise<void> {
+    return this.accountService.getAccountDetails(command.credentials).then((account) => {
+      command.listeners.forEach((listener) => {
         listener.sslCertificateId = this.certificateIdAsARN(account.accountId, listener.sslCertificateName,
-          this.loadBalancerCommand.region, listener.sslCertificateType || this.certificateTypes[0]);
+          command.region, listener.sslCertificateType || this.certificateTypes[0]);
       });
     });
   }
@@ -124,10 +124,10 @@ export class CreateClassicLoadBalancerCtrl extends CreateAmazonLoadBalancerCtrl 
       this.certificates && Object.keys(this.certificates).length > 0;
   }
 
-  protected formatCommand(): void {
-    this.setAvailabilityZones(this.loadBalancerCommand);
-    this.clearSecurityGroupsIfNotInVpc(this.loadBalancerCommand);
-    this.addHealthCheckToCommand(this.loadBalancerCommand);
+  protected formatCommand(command: IAmazonClassicLoadBalancerUpsertCommand): void {
+    this.setAvailabilityZones(command);
+    this.clearSecurityGroupsIfNotInVpc(command);
+    this.addHealthCheckToCommand(command);
   }
 
   private clearSecurityGroupsIfNotInVpc(loadBalancer: IAmazonClassicLoadBalancerUpsertCommand): void {

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/common/configure.less
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/common/configure.less
@@ -57,6 +57,10 @@
       .wizard-pod-content {
         padding: 0 10px 5px 0;
       }
+      .group-name-prefix {
+        flex-grow: 2;
+        white-space: nowrap;
+      }
       .rules-table {
         thead {
           th {

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/common/createAmazonLoadBalancer.controller.ts
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/common/createAmazonLoadBalancer.controller.ts
@@ -1,7 +1,7 @@
 import { IScope, IPromise } from 'angular';
 import { IModalInstanceService } from 'angular-ui-bootstrap';
 import { StateService } from '@uirouter/angularjs';
-import { chain, clone, find, filter, map, trimEnd, uniq, values } from 'lodash';
+import { chain, clone, cloneDeep, find, filter, map, trimEnd, uniq, values } from 'lodash';
 
 import {
   AccountService,
@@ -426,23 +426,24 @@ export abstract class CreateAmazonLoadBalancerCtrl {
 
   protected abstract showSslCertificateNameField(): boolean;
 
-  protected abstract formatListeners(): IPromise<void>;
+  protected abstract formatListeners(command: IAmazonLoadBalancerUpsertCommand): IPromise<void>;
 
-  protected abstract formatCommand(): void;
+  protected abstract formatCommand(command: IAmazonLoadBalancerUpsertCommand): void;
 
   public submit(): void {
     const descriptor = this.isNew ? 'Create' : 'Update';
+    const loadBalancerCommandFormatted = cloneDeep(this.loadBalancerCommand);
 
     if (this.forPipelineConfig) {
       // don't submit to backend for creation. Just return the loadBalancerCommand object
-      this.formatListeners().then(() => {
-        this.$uibModalInstance.close(this.loadBalancerCommand);
+      this.formatListeners(loadBalancerCommandFormatted).then(() => {
+        this.$uibModalInstance.close(loadBalancerCommandFormatted);
       });
     } else {
       this.taskMonitor.submit(() => {
-          return this.formatListeners().then(() => {
-            this.formatCommand();
-            return this.loadBalancerWriter.upsertLoadBalancer(this.loadBalancerCommand, this.application, descriptor);
+          return this.formatListeners(loadBalancerCommandFormatted).then(() => {
+            this.formatCommand(loadBalancerCommandFormatted);
+            return this.loadBalancerWriter.upsertLoadBalancer(loadBalancerCommandFormatted, this.application, descriptor);
           });
         }
       );

--- a/app/scripts/modules/amazon/src/loadBalancer/loadBalancer.transformer.ts
+++ b/app/scripts/modules/amazon/src/loadBalancer/loadBalancer.transformer.ts
@@ -220,10 +220,10 @@ export class AwsLoadBalancerTransformer {
 
       // Convert listeners
       if (elb.listeners) {
-        toEdit.listeners = elb.listeners.map((listener: any) => {
+        toEdit.listeners = elb.listeners.map((listener) => {
           const certificates: IALBListenerCertificate[] = [];
           if (listener.certificates) {
-            listener.certificates.forEach((cert: any) => {
+            listener.certificates.forEach((cert) => {
               const certArnParts = cert.certificateArn.split(':');
               const certParts = certArnParts[5].split('/');
               certificates.push({
@@ -233,6 +233,10 @@ export class AwsLoadBalancerTransformer {
               });
             });
           }
+
+          (listener.defaultActions || []).forEach((action) => {
+            action.targetGroupName = action.targetGroupName.replace(`${loadBalancer.name}-`, '');
+          });
 
           return {
             protocol: listener.protocol,
@@ -248,7 +252,7 @@ export class AwsLoadBalancerTransformer {
       if (elb.targetGroups) {
         toEdit.targetGroups = elb.targetGroups.map((targetGroup: any) => {
           return {
-            name: targetGroup.targetGroupName,
+            name: targetGroup.targetGroupName.replace(`${loadBalancer.name}-`, ''),
             protocol: targetGroup.protocol,
             port: targetGroup.port,
             healthCheckProtocol: targetGroup.healthCheckProtocol,
@@ -312,7 +316,7 @@ export class AwsLoadBalancerTransformer {
     const defaultCredentials = application.defaultCredentials.aws || AWSProviderSettings.defaults.account,
         defaultRegion = application.defaultRegions.aws || AWSProviderSettings.defaults.region,
         defaultSubnetType = AWSProviderSettings.defaults.subnetType,
-        defaultTargetGroupName = `${application.name}-alb-targetGroup`;
+        defaultTargetGroupName = `targetgroup`;
     return {
       name: undefined,
       availabilityZones: undefined,


### PR DESCRIPTION
Force target group names to start with load balancer name because reasons.

<img width="641" alt="screen shot 2017-06-26 at 10 42 42 am" src="https://user-images.githubusercontent.com/56971/27552431-3f629e7a-5a5c-11e7-975c-a26b1cd79aed.png">
<img width="609" alt="screen shot 2017-06-26 at 10 42 50 am" src="https://user-images.githubusercontent.com/56971/27552438-4409ee24-5a5c-11e7-8b39-b3bed51c9942.png">

@anotherchrisberry or @christopherthielen PTAL