### PR TITLE
feat(react): Route to react components; use react UISref components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ test/google/node_modules/
 .awcache/
 .gradle/
 .happypack/
+.yalc
+yalc.lock
 build/
 dist/
 lib/

--- a/app/scripts/modules/amazon/package.json
+++ b/app/scripts/modules/amazon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/amazon",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/amazon/src/loadBalancer/TargetGroup.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/TargetGroup.tsx
@@ -1,11 +1,9 @@
 import * as React from 'react';
 import autoBindMethods from 'class-autobind-decorator';
-import { $timeout } from 'ngimport';
-import { get, isEqual, last, orderBy } from 'lodash';
-import { PathNode } from '@uirouter/angularjs';
-import { Subscription } from 'rxjs';
+import { orderBy } from 'lodash';
+import { UISref, UISrefActive } from '@uirouter/react';
 
-import { HealthCounts, LoadBalancerInstances, LoadBalancerServerGroup, ReactInjector } from '@spinnaker/core';
+import { HealthCounts, LoadBalancerInstances, LoadBalancerServerGroup } from '@spinnaker/core';
 
 import { IAmazonApplicationLoadBalancer, ITargetGroup } from 'amazon/domain/IAmazonLoadBalancer';
 
@@ -18,74 +16,10 @@ export interface ITargetGroupProps {
   showInstances: boolean;
 }
 
-export interface ITargetGroupState {
-  active: boolean;
-}
-
 @autoBindMethods
-export class TargetGroup extends React.Component<ITargetGroupProps, ITargetGroupState> {
-  private stateChangeListener: Subscription;
-  private baseRef: string;
-
-  constructor(props: ITargetGroupProps) {
-    super(props);
-    this.state = { active: this.isActive() };
-
-    const { stateEvents } = ReactInjector;
-
-    this.stateChangeListener = stateEvents.stateChangeSuccess.subscribe(
-      () => {
-        const active = this.isActive();
-        if (this.state.active !== active) {
-          this.setState({active});
-        }
-      }
-    );
-  }
-
-  private isActive(): boolean {
-    const { targetGroup } = this.props;
-    return ReactInjector.$state.includes('**.targetGroupDetails', {region: targetGroup.region, accountId: targetGroup.account, name: targetGroup.name, vpcId: targetGroup.vpcId, provider: targetGroup.cloudProvider});
-  }
-
-  private loadDetails(event: React.MouseEvent<HTMLElement>): void {
-    event.persist();
-    const { $state } = ReactInjector;
-    $timeout(() => {
-      const { loadBalancer, targetGroup } = this.props;
-      // anything handled by ui-sref or actual links should be ignored
-      if (event.defaultPrevented || (event.nativeEvent && event.nativeEvent.defaultPrevented)) {
-        return;
-      }
-      event.stopPropagation();
-      const params = {
-        loadBalancerName: loadBalancer.name,
-        region: targetGroup.region,
-        accountId: targetGroup.account,
-        name: targetGroup.name,
-        vpcId: targetGroup.vpcId,
-        provider: targetGroup.cloudProvider,
-      };
-
-      if (isEqual($state.params, params)) {
-        // already there
-        return;
-      }
-      // also stolen from uiSref directive
-      $state.go('.targetGroupDetails', params, {relative: this.baseRef, inherit: true});
-    });
-  }
-
-  public componentWillUnmount(): void {
-    this.stateChangeListener.unsubscribe();
-  }
-
-  private refCallback(element: HTMLElement): void {
-    this.baseRef = this.baseRef || last(get<PathNode[]>($(element).parent().inheritedData('$uiView'), '$cfg.path')).state.name;
-  }
-
+export class TargetGroup extends React.Component<ITargetGroupProps, void> {
   public render(): React.ReactElement<TargetGroup> {
-    const { targetGroup, showInstances, showServerGroups } = this.props;
+    const { targetGroup, showInstances, showServerGroups, loadBalancer } = this.props;
 
     const ServerGroups = orderBy(targetGroup.serverGroups, ['isDisabled', 'name'], ['asc', 'desc']).map((serverGroup) => (
       <LoadBalancerServerGroup
@@ -98,16 +32,29 @@ export class TargetGroup extends React.Component<ITargetGroupProps, ITargetGroup
       />
     ));
 
+    const params = {
+      loadBalancerName: loadBalancer.name,
+      region: targetGroup.region,
+      accountId: targetGroup.account,
+      name: targetGroup.name,
+      vpcId: targetGroup.vpcId,
+      provider: targetGroup.cloudProvider,
+    };
+
     return (
-      <div className="target-group-container container-fluid no-padding" ref={this.refCallback}>
-        <div className={`clickable clickable-row row no-margin-top target-group-header${this.state.active ? ' active' : ''}`} onClick={this.loadDetails}>
-          <div className="col-md-8 target-group-title">
-              {targetGroup.name}
-          </div>
-          <div className="col-md-4 text-right">
-            <HealthCounts container={targetGroup.instanceCounts}/>
-          </div>
-        </div>
+      <div className="target-group-container container-fluid no-padding">
+        <UISrefActive class="active">
+          <UISref to=".targetGroupDetails" params={params}>
+            <div className={`clickable clickable-row row no-margin-top target-group-header`}>
+              <div className="col-md-8 target-group-title">
+                  {targetGroup.name}
+              </div>
+              <div className="col-md-4 text-right">
+                <HealthCounts container={targetGroup.instanceCounts}/>
+              </div>
+            </div>
+          </UISref>
+        </UISrefActive>
         {showServerGroups && ServerGroups}
         {!showServerGroups && showInstances && <LoadBalancerInstances serverGroups={targetGroup.serverGroups} instances={targetGroup.instances} />}
       </div>

--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/core",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/core/src/core.module.ts
+++ b/app/scripts/modules/core/src/core.module.ts
@@ -10,8 +10,9 @@ import 'react-select/dist/react-select.css';
 import 'ui-select/dist/select.css';
 
 import UI_ROUTER from '@uirouter/angularjs';
+const UI_ROUTER_STATE_EVENTS_SHIM = 'ui.router.state.events';
 require('@uirouter/angularjs/release/stateEvents');
-const UI_ROUTER_STATE_SHIM = 'ui.router.state.events';
+import { UI_ROUTER_REACT_HYBRID } from '@uirouter/react-hybrid';
 
 // use require instead of import to ensure insertion order is preserved
 require('Select2/select2.css');
@@ -55,7 +56,9 @@ module(CORE_MODULE, [
   require('angular-messages'),
   require('angular-sanitize'),
   UI_ROUTER,
-  UI_ROUTER_STATE_SHIM,
+  UI_ROUTER_STATE_EVENTS_SHIM,
+  UI_ROUTER_REACT_HYBRID,
+  REACT_MODULE, // must precede modules which register states
   require('angular-ui-bootstrap'),
   require('ui-select'),
   require('angular-spinner').angularSpinner.name,
@@ -98,7 +101,6 @@ module(CORE_MODULE, [
   require('./presentation/presentation.module'),
   require('./projects/projects.module'),
 
-  REACT_MODULE,
   REGION_MODULE,
 
   require('./search/search.module'),

--- a/app/scripts/modules/core/src/instance/instances.component.ts
+++ b/app/scripts/modules/core/src/instance/instances.component.ts
@@ -105,7 +105,7 @@ export class InstancesController implements IComponentController {
 
     this.$element.mouseover((event) => {
       if (!this.tooltipTargets.includes(event.target) && event.target.hasAttribute('data-toggle')) {
-        $(event.target).tooltip({animation: false}).tooltip('show');
+        $(event.target).tooltip({animation: false} as JQueryUI.TooltipOptions).tooltip('show');
         this.tooltipTargets.push(event.target);
       }
     });

--- a/app/scripts/modules/core/src/loadBalancer/LoadBalancerServerGroup.tsx
+++ b/app/scripts/modules/core/src/loadBalancer/LoadBalancerServerGroup.tsx
@@ -1,12 +1,10 @@
 import * as React from 'react';
-import * as $ from 'jquery';
 import * as classNames from 'classnames';
 import autoBindMethods from 'class-autobind-decorator';
-import { clone, last, get } from 'lodash';
-import { PathNode } from '@uirouter/angularjs';
-import { Subscription } from 'rxjs';
+import { clone } from 'lodash';
+import { UISref, UISrefActive } from '@uirouter/react';
 
-import { NgReact, ReactInjector } from 'core/reactShims';
+import { NgReact } from 'core/reactShims';
 import { IServerGroup, IInstance } from 'core/domain';
 
 import { CloudProviderLogo } from 'core/cloudProvider/CloudProviderLogo';
@@ -22,69 +20,27 @@ export interface ILoadBalancerServerGroupProps {
 
 export interface ILoadBalancerServerGroupState {
   instances: IInstance[];
-  active: boolean;
 }
 
 @autoBindMethods
 export class LoadBalancerServerGroup extends React.Component<ILoadBalancerServerGroupProps, ILoadBalancerServerGroupState> {
-  private baseRef: string;
-  private stateChangeListener: Subscription;
-
   constructor(props: ILoadBalancerServerGroupProps) {
     super(props);
     this.state = this.getState(props);
-
-    const { stateEvents } = ReactInjector;
-
-    this.stateChangeListener = stateEvents.stateChangeSuccess.subscribe(
-      () => {
-        const active = this.isActive();
-        if (this.state.active !== active) {
-          this.setState({active});
-        }
-      }
-    );
-  }
-
-  private isActive(): boolean {
-    const { cloudProvider, serverGroup } = this.props;
-    return ReactInjector.$state.includes('**.serverGroup', {region: serverGroup.region, accountId: serverGroup.account, serverGroup: serverGroup.name, provider: cloudProvider});
-  }
-
-
-  private handleServerGroupClicked(event: React.MouseEvent<HTMLElement>): void {
-    event.stopPropagation();
-    const { serverGroup, region, account, cloudProvider } = this.props;
-    const params = {
-      region: serverGroup.region || region,
-      accountId: account,
-      serverGroup: serverGroup.name,
-      provider: cloudProvider
-    };
-    ReactInjector.$state.go('.serverGroup', params, { relative: this.baseRef, inherit: true });
   }
 
   private getState(props: ILoadBalancerServerGroupProps): ILoadBalancerServerGroupState {
     return {
       instances: clone(props.serverGroup.instances),
-      active: this.isActive()
     };
-  }
-
-  private refCallback(element: HTMLElement): void {
-    this.baseRef = this.baseRef || last(get<PathNode[]>($(element).parent().inheritedData('$uiView'), '$cfg.path')).state.name;
   }
 
   public componentWillReceiveProps(nextProps: ILoadBalancerServerGroupProps): void {
     this.setState(this.getState(nextProps));
   }
 
-  public componentWillUnmount(): void {
-    this.stateChangeListener.unsubscribe();
-  }
-
   public render(): React.ReactElement<LoadBalancerServerGroup> {
-    const { cloudProvider, serverGroup, showInstances } = this.props;
+    const { cloudProvider, serverGroup, showInstances, account, region } = this.props;
     const { Instances } = NgReact;
 
     const className = classNames({
@@ -92,31 +48,37 @@ export class LoadBalancerServerGroup extends React.Component<ILoadBalancerServer
       'clickable-row': true,
       'no-margin-top': true,
       disabled: serverGroup.isDisabled,
-      active: this.state.active
     });
 
+    const params = {
+      region: serverGroup.region || region,
+      accountId: account,
+      serverGroup: serverGroup.name,
+      provider: cloudProvider
+    };
+
     return (
-      <div
-        className={className}
-        onClick={this.handleServerGroupClicked}
-        ref={this.refCallback}
-      >
-        <div className="server-group-title container-fluid no-padding">
-          <div className="row">
-            <div className="col-md-8">
-              <CloudProviderLogo provider={cloudProvider} height={'14px'} width={'14px'}/> {serverGroup.name}
+      <UISrefActive class="active">
+        <UISref to=".serverGroup" params={params}>
+          <div className={className} >
+            <div className="server-group-title container-fluid no-padding">
+              <div className="row">
+                <div className="col-md-8">
+                  <CloudProviderLogo provider={cloudProvider} height={'14px'} width={'14px'}/> {serverGroup.name}
+                </div>
+                <div className="col-md-4 text-right">
+                  <HealthCounts container={serverGroup.instanceCounts}/>
+                </div>
+              </div>
             </div>
-            <div className="col-md-4 text-right">
-              <HealthCounts container={serverGroup.instanceCounts}/>
-            </div>
+            { showInstances && (
+              <div className="instance-list">
+                <Instances instances={this.state.instances}/>
+              </div>
+            )}
           </div>
-        </div>
-        { showInstances && (
-          <div className="instance-list">
-            <Instances instances={this.state.instances}/>
-          </div>
-        )}
-      </div>
+        </UISref>
+      </UISrefActive>
     );
   }
 }

--- a/app/scripts/modules/core/src/loadBalancer/loadBalancer.states.ts
+++ b/app/scripts/modules/core/src/loadBalancer/loadBalancer.states.ts
@@ -6,6 +6,7 @@ import { APPLICATION_STATE_PROVIDER, ApplicationStateProvider } from 'core/appli
 import { CloudProviderRegistry } from '../cloudProvider/cloudProvider.registry';
 import { filterModelConfig } from 'core/loadBalancer/filter/loadBalancerFilter.model';
 import { LOAD_BALANCERS_COMPONENT } from 'core/loadBalancer/loadBalancers.component';
+import { LoadBalancers } from 'core/loadBalancer/LoadBalancers';
 
 export const LOAD_BALANCER_STATES = 'spinnaker.core.loadBalancer.states';
 module(LOAD_BALANCER_STATES, [
@@ -69,7 +70,7 @@ module(LOAD_BALANCER_STATES, [
         template: '<load-balancer-filter app="$resolve.app"></load-balancer-filter>',
       },
       'master': {
-        template: '<load-balancers app="$resolve.app" style="display: flex;flex: 1 1 auto"></load-balancers>',
+        component: LoadBalancers, $type: 'react'
       }
     },
     params: stateConfigProvider.buildDynamicParams(filterModelConfig),

--- a/app/scripts/modules/core/src/navigation/state.provider.ts
+++ b/app/scripts/modules/core/src/navigation/state.provider.ts
@@ -1,14 +1,26 @@
 import { IServiceProvider, module } from 'angular';
 import { isEqual, isPlainObject } from 'lodash';
-import { Ng1StateDeclaration, ParamDeclaration, UrlRouterProvider, UrlService } from '@uirouter/angularjs';
+import {
+  Ng1StateDeclaration, Ng1ViewDeclaration, ParamDeclaration, UrlRouterProvider, UrlService
+} from '@uirouter/angularjs';
 
 import { STATE_HELPER, StateHelper } from './stateHelper.provider';
 import { IFilterConfig } from '../filterModel/IFilterModel';
 
 import './navigation.less';
+import { ReactViewDeclaration } from '@uirouter/react';
 
-export interface INestedState extends Ng1StateDeclaration {
+// Typescript kludge to widen interfaces so INestedState can support both react and angular views
+export interface IReactHybridIntermediate extends Ng1StateDeclaration {
   children?: INestedState[];
+  component?: any;
+  views?: { [key: string]: any };
+}
+
+export interface INestedState extends IReactHybridIntermediate {
+  children?: INestedState[];
+  component?: React.ComponentClass<any> | string;
+  views?: { [key: string]: ReactViewDeclaration | Ng1ViewDeclaration; };
 }
 
 export class StateConfigProvider implements IServiceProvider {

--- a/app/scripts/modules/core/src/navigation/stateHelper.provider.ts
+++ b/app/scripts/modules/core/src/navigation/stateHelper.provider.ts
@@ -1,12 +1,12 @@
 import { copy, module } from 'angular';
-import { StateProvider } from '@uirouter/angularjs';
+import { StateRegistry, StateDeclaration } from '@uirouter/core';
 import { INestedState } from './state.provider';
 
 export class StateHelper implements ng.IServiceProvider {
 
   private registeredStates: string[] = [];
 
-  constructor(private $stateProvider: StateProvider) { 'ngInject'; }
+  constructor(private $stateRegistryProvider: StateRegistry) { 'ngInject'; }
 
   public setNestedState(state: INestedState, keepOriginalNames = false) {
     const newState: INestedState = copy(state);
@@ -17,7 +17,7 @@ export class StateHelper implements ng.IServiceProvider {
     }
     if (!this.registeredStates.includes(newState.name)) {
       this.registeredStates.push(newState.name);
-      this.$stateProvider.state(newState);
+      this.$stateRegistryProvider.register(newState as StateDeclaration);
     }
 
     if (newState.children && newState.children.length) {

--- a/app/scripts/modules/core/src/reactShims/index.ts
+++ b/app/scripts/modules/core/src/reactShims/index.ts
@@ -2,3 +2,4 @@ export * from './react.injector';
 export * from './ngReact';
 export * from './state.events';
 export * from './react.module';
+export * from './react.uirouter';

--- a/app/scripts/modules/core/src/reactShims/react.module.ts
+++ b/app/scripts/modules/core/src/reactShims/react.module.ts
@@ -1,13 +1,15 @@
 import {module} from 'angular';
 import 'ngimport';
 import { STATE_EVENTS } from './state.events';
+import { REACT_UIROUTER } from './react.uirouter';
 import { ReactInjector } from './react.injector';
 import { NgReact } from './ngReact';
 
-export const REACT_MODULE = 'spinnaker.react';
+export const REACT_MODULE = 'spinnaker.core.react';
 module(REACT_MODULE, [
   'bcherny/ngimport',
   STATE_EVENTS,
+  REACT_UIROUTER,
 ]).run(function ($injector: any) {
   // Make angular services importable and Convert angular components to react
   ReactInjector.initialize($injector);

--- a/app/scripts/modules/core/src/reactShims/react.uirouter.css
+++ b/app/scripts/modules/core/src/reactShims/react.uirouter.css
@@ -1,0 +1,4 @@
+react-ui-view-adapter {
+  flex: 1 1 auto;
+  display: flex;
+}

--- a/app/scripts/modules/core/src/reactShims/react.uirouter.tsx
+++ b/app/scripts/modules/core/src/reactShims/react.uirouter.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+
+import { module } from 'angular';
+import { ReactViewDeclaration } from '@uirouter/react';
+import { StateObject, UIRouter } from '@uirouter/core';
+import './react.uirouter.css';
+
+export const REACT_UIROUTER = 'spinnaker.core.react.uirouter';
+const hybridModule = module(REACT_UIROUTER, ['ui.router']);
+
+// UI-Router React 0.5.0 provides resolve data as a prop called `resolves`.
+// This decorator spreads each individual resolved value to its _own prop_.
+//
+// e.g., instead of `props.resolves.myresolve` you can access `props.myresolve`
+hybridModule.config(['$uiRouterProvider', (router: UIRouter) => {
+  router.stateRegistry.decorator('views', (state: StateObject, parentDecorator) => {
+    'ngNoInject';
+    const views = parentDecorator(state);
+
+    const BindResolvesToProps = (Component: any) => ({ resolves, ...props }: any) =>
+        React.createElement(Component, { ...props, ...resolves });
+
+    Object.keys(views).forEach(key => {
+      const view: ReactViewDeclaration = views[key];
+      if (view.$type === 'react' && typeof view.component === 'function') {
+        view.component = BindResolvesToProps(view.component);
+      }
+    });
+
+    return views;
+  });
+}]);

--- a/app/scripts/modules/core/src/securityGroup/securityGroup.directive.js
+++ b/app/scripts/modules/core/src/securityGroup/securityGroup.directive.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const angular = require('angular');
-import { get, last } from 'lodash';
 
 module.exports = angular.module('spinnaker.core.securityGroup.directive', [])
   .directive('securityGroup', function ($rootScope, $timeout, SecurityGroupFilterModel) {
@@ -15,37 +14,19 @@ module.exports = angular.module('spinnaker.core.securityGroup.directive', [])
         sortFilter: '=',
         heading: '=',
       },
-      link: function (scope, el) {
-        var base = last(get(el.parent().inheritedData('$uiView'), '$cfg.path')).state.name;
-
+      link: function (scope) {
         scope.sortFilter = SecurityGroupFilterModel.sortFilter;
         scope.$state = $rootScope.$state;
 
-        scope.loadDetails = function(e) {
-          $timeout(function() {
-            var securityGroup = scope.securityGroup;
-            // anything handled by ui-sref or actual links should be ignored
-            if (e.isDefaultPrevented() || (e.originalEvent && e.originalEvent.target.href)) {
-              return;
-            }
-            var params = {
-              application: scope.application.name,
-              region: securityGroup.region,
-              accountId: securityGroup.accountName,
-              name: securityGroup.name,
-              vpcId: securityGroup.vpcId,
-              provider: securityGroup.provider,
-            };
-
-            if (angular.equals(scope.$state.params, params)) {
-              // already there
-              return;
-            }
-            // also stolen from uiSref directive
-            scope.$state.go('.securityGroupDetails', params, {relative: base, inherit: true});
-          });
+        const securityGroup = scope.securityGroup;
+        scope.srefParams = {
+          application: scope.application.name,
+          region: securityGroup.region,
+          accountId: securityGroup.accountName,
+          name: securityGroup.name,
+          vpcId: securityGroup.vpcId,
+          provider: securityGroup.provider,
         };
-
       }
     };
   }

--- a/app/scripts/modules/core/src/securityGroup/securityGroup.html
+++ b/app/scripts/modules/core/src/securityGroup/securityGroup.html
@@ -1,6 +1,6 @@
 <div class="pod-subgroup clickable clickable-row clearfix"
-     ng-click="loadDetails($event)"
-     ng-class="{active: $state.includes('**.securityGroupDetails', {region: securityGroup.region, accountId: securityGroup.accountName, name: securityGroup.name, vpcId: securityGroup.vpcId, provider: securityGroup.provider})}">
+     ui-sref=".securityGroupDetails(srefParams)"
+     ui-sref-active="active">
   <sticky-header added-offset-height="36">
     <h6>
       <span class="glyphicon glyphicon-transfer"></span>

--- a/app/scripts/modules/core/src/utils/stickyHeader/stickyHeader.component.ts
+++ b/app/scripts/modules/core/src/utils/stickyHeader/stickyHeader.component.ts
@@ -42,7 +42,7 @@ export class StickyHeaderController implements ng.IComponentController {
     // fun thing about modals is they use a CSS transform, which resets position: fixed element placement -
     // but not offset() positioning, so we need to take that into account when calculating the fixed position
     const $modalDialog = this.$element.closest('div.modal-dialog');
-    this.topOffset = $modalDialog.size() > 0 ? parseInt($modalDialog.css('marginTop'), 10) : 0;
+    this.topOffset = $modalDialog.length > 0 ? parseInt($modalDialog.css('marginTop'), 10) : 0;
 
     if (this.stickyIf !== undefined) {
       this.$scope.$watch(this.stickyIf, (sticky: boolean) => this.toggleSticky(sticky));

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@types/classnames": "^2.2.0",
-    "@uirouter/angularjs": "^1.0.3",
+    "@uirouter/react-hybrid": "0.0.3",
     "@uirouter/rx": "^0.4.1",
     "@uirouter/visualizer": "^4.0.0",
     "Select2": "git://github.com/select2/select2.git#3.4.8",
@@ -87,6 +87,7 @@
     "@types/enzyme": "^2.7.9",
     "@types/jasmine": "2.5.47",
     "@types/jquery": "^2.0.34",
+    "@types/jqueryui": "^1.11.32",
     "@types/js-yaml": "3.5.30",
     "@types/lodash": "^4.14.64",
     "@types/marked": "^0.0.28",

--- a/yarn.lock
+++ b/yarn.lock
@@ -231,6 +231,12 @@
   version "2.0.43"
   resolved "https://registry.yarnpkg.com/@types/jquery/-/jquery-2.0.43.tgz#e30d971d56dce22bf0d62e02bd4b28a7ffdba076"
 
+"@types/jqueryui@^1.11.32":
+  version "1.11.32"
+  resolved "https://registry.yarnpkg.com/@types/jqueryui/-/jqueryui-1.11.32.tgz#5a21bdedd6517c21baef754889931b7d27b5fb3e"
+  dependencies:
+    "@types/jquery" "*"
+
 "@types/js-yaml@3.5.30":
   version "3.5.30"
   resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-3.5.30.tgz#f555118c022318e57e36d803379cb8ee38ee20a7"
@@ -333,15 +339,31 @@
     "@types/tapable" "*"
     "@types/uglify-js" "*"
 
-"@uirouter/angularjs@^1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@uirouter/angularjs/-/angularjs-1.0.3.tgz#518b875542b4d86dd1aaf5f4262ccee416f2c166"
+"@uirouter/angularjs@git://github.com/angular-ui/ui-router.git#1.0.3-hybrid-2.0.0-5":
+  version "1.0.3-hybrid-2.0.0-5"
+  resolved "git://github.com/angular-ui/ui-router.git#f429ea3b40fdc85dfdd9e2808ef14c73c071184a"
   dependencies:
-    "@uirouter/core" "5.0.3"
+    "@uirouter/core" "^5.0.3"
 
-"@uirouter/core@5.0.3":
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/@uirouter/core/-/core-5.0.3.tgz#e2b5b1e45190e20c67ba4e15c013de5d4e0ccab3"
+"@uirouter/core@=5.0.4", "@uirouter/core@^5.0.3":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@uirouter/core/-/core-5.0.4.tgz#798b9ec0f2cf58b234cce75fa2634b4698a44aca"
+
+"@uirouter/react-hybrid@0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@uirouter/react-hybrid/-/react-hybrid-0.0.3.tgz#78b737d151ccfb3cc4e91f5a47a6a4987522cf62"
+  dependencies:
+    "@uirouter/angularjs" "git://github.com/angular-ui/ui-router#1.0.3-hybrid-2.0.0-5"
+    "@uirouter/core" "=5.0.4"
+    "@uirouter/react" "git://github.com/ui-router/react#0.5.0-react-hybrid-0.0.1"
+    watch "^1.0.2"
+
+"@uirouter/react@git://github.com/ui-router/react.git#0.5.0-react-hybrid-0.0.1":
+  version "0.5.0-react-hybrid-0.0.1"
+  resolved "git://github.com/ui-router/react.git#75c7efb4c475a591d3b451053b20601a83e3fc8c"
+  dependencies:
+    "@uirouter/core" "^5.0.3"
+    classnames "^2.2.5"
 
 "@uirouter/rx@^0.4.1":
   version "0.4.1"
@@ -2510,6 +2532,12 @@ evp_bytestokey@^1.0.0:
   dependencies:
     create-hash "^1.1.1"
 
+exec-sh@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.2.0.tgz#14f75de3f20d286ef933099b2ce50a90359cef10"
+  dependencies:
+    merge "^1.1.3"
+
 exit-hook@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
@@ -3888,6 +3916,10 @@ memory-fs@^0.4.0, memory-fs@~0.4.1:
 merge-descriptors@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
+
+merge@^1.1.3:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
 
 methods@~1.1.2:
   version "1.1.2"
@@ -6103,6 +6135,13 @@ warning@^3.0.0:
   resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
   dependencies:
     loose-envify "^1.0.0"
+
+watch@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/watch/-/watch-1.0.2.tgz#340a717bde765726fa0aa07d721e0147a551df0c"
+  dependencies:
+    exec-sh "^0.2.0"
+    minimist "^1.2.0"
 
 watchpack@^1.3.1:
   version "1.3.1"


### PR DESCRIPTION
- Removes ` @uirouter/angularjs`
- Adds `@uirouter/react-hybrid` which depends on `@uirouter/react` and `@uirouter/angularjs`
- Switch to `@uirouter/react` components `UISref` and `UISrefActive` and remove `inheritedData()` workaround
- Routes to `LoadBalancers` react component
- Bumps `core` and `amazon` versions 