### PR TITLE
feat(provider/amazon): Load certificates on demand

### DIFF
--- a/app/scripts/modules/amazon/src/loadBalancer/configure/common/createAmazonLoadBalancer.controller.ts
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/common/createAmazonLoadBalancer.controller.ts
@@ -29,11 +29,9 @@ import './configure.less';
 
 export interface ICreateAmazonLoadBalancerViewState {
   accountsLoaded: boolean;
-  certificateRefreshTime: number;
   currentItems: number;
   hideInternalFlag: boolean;
   internalFlagToggled: boolean;
-  refreshingCertificates: boolean;
   refreshingSecurityGroups: boolean;
   removedSecurityGroups: string[];
   securityGroupRefreshTime: number;
@@ -94,11 +92,9 @@ export abstract class CreateAmazonLoadBalancerCtrl {
 
     this.viewState = {
       accountsLoaded: false,
-      certificateRefreshTime: this.infrastructureCaches.get('certificates').getStats().ageMax,
       currentItems: 25,
       hideInternalFlag: false,
       internalFlagToggled: false,
-      refreshingCertificates: false,
       refreshingSecurityGroups: false,
       removedSecurityGroups: [],
       securityGroupRefreshTime: this.infrastructureCaches.get('securityGroups').getStats().ageMax,
@@ -344,21 +340,9 @@ export abstract class CreateAmazonLoadBalancerCtrl {
       });
     });
   };
-  private setCertificateRefreshTime(): void {
-    this.viewState.certificateRefreshTime = this.infrastructureCaches.get('certificates').getStats().ageMax;
-  }
 
   private setSecurityGroupRefreshTime(): void {
     this.viewState.securityGroupRefreshTime = this.infrastructureCaches.get('securityGroups').getStats().ageMax;
-  }
-
-  public refreshCertificates(): void {
-    this.viewState.refreshingCertificates = true;
-    this.cacheInitializer.refreshCache('certificates').then(() => {
-      this.viewState.refreshingCertificates = false;
-      this.setCertificateRefreshTime();
-      this.loadCertificates();
-    });
   }
 
   public addItems(): void {

--- a/app/scripts/modules/core/src/certificates/certificate.read.service.ts
+++ b/app/scripts/modules/core/src/certificates/certificate.read.service.ts
@@ -1,6 +1,5 @@
 import { IPromise, module } from 'angular';
 
-import { INFRASTRUCTURE_CACHE_SERVICE, InfrastructureCacheService } from 'core/cache/infrastructureCaches.service';
 import { API_SERVICE, Api } from 'core/api/api.service';
 
 export interface ICertificate {
@@ -12,21 +11,19 @@ export interface ICertificate {
 
 export class CertificateReader {
 
-  public constructor(private API: Api, private infrastructureCaches: InfrastructureCacheService) { 'ngInject'; }
+  public constructor(private API: Api) { 'ngInject'; }
 
   public listCertificates(): IPromise<ICertificate[]> {
     return this.API.one('certificates')
-      .useCache(this.infrastructureCaches.get('certificates'))
       .getList();
   }
 
   public listCertificatesByProvider(cloudProvider: string): IPromise<ICertificate[]> {
     return this.API.one('certificates').one(cloudProvider)
-      .useCache(this.infrastructureCaches.get('certificates'))
       .getList();
   }
 }
 
 export const CERTIFICATE_READ_SERVICE = 'spinnaker.core.certificate.read.service';
-module(CERTIFICATE_READ_SERVICE, [API_SERVICE, INFRASTRUCTURE_CACHE_SERVICE])
+module(CERTIFICATE_READ_SERVICE, [API_SERVICE])
   .service('certificateReader', CertificateReader);


### PR DESCRIPTION
The number of times that certificates are needed (only when creating or editing a load balancer) are too few to really justify a cache. Caching also provides a disconnect between time added to AWS and time they show up in the UI.