### PR TITLE
fix(provider/amazon): Check to make sure cache types exists before showing refresh

### DIFF
--- a/app/scripts/modules/core/src/application/config/applicationCacheManagement.directive.html
+++ b/app/scripts/modules/core/src/application/config/applicationCacheManagement.directive.html
@@ -8,7 +8,7 @@
   <div class="col-md-3"><strong>Last Updated</strong></div>
   <div class="col-md-1 text-center"><strong>Refresh</strong></div>
 </div>
-<div class="row">
+<div class="row" ng-if="vm.hasCache('instanceTypes')">
   <div class="col-md-3 col-md-offset-1">Instance Types</div>
   <div class="col-md-3">{{vm.getCacheInfo('instanceTypes').ageMax | timestamp}}</div>
   <div class="col-md-1 text-center">
@@ -18,7 +18,7 @@
     </a>
   </div>
 </div>
-<div class="row">
+<div class="row" ng-if="vm.hasCache('loadBalancers')">
   <div class="col-md-3 col-md-offset-1">Load Balancers</div>
   <div class="col-md-3">{{vm.getCacheInfo('loadBalancers').ageMax | timestamp}}</div>
   <div class="col-md-1 text-center">
@@ -28,7 +28,7 @@
     </a>
   </div>
 </div>
-<div class="row">
+<div class="row" ng-if="vm.hasCache('securityGroups')">
   <div class="col-md-3 col-md-offset-1">Security Groups</div>
   <div class="col-md-3">{{vm.getCacheInfo('securityGroups').ageMax | timestamp}}</div>
   <div class="col-md-1 text-center">
@@ -38,7 +38,7 @@
     </a>
   </div>
 </div>
-<div class="row">
+<div class="row" ng-if="vm.hasCache('subnets')">
   <div class="col-md-3 col-md-offset-1">Subnets</div>
   <div class="col-md-3">{{vm.getCacheInfo('subnets').ageMax | timestamp}}</div>
   <div class="col-md-1 text-center">
@@ -48,7 +48,7 @@
     </a>
   </div>
 </div>
-<div class="row">
+<div class="row" ng-if="vm.hasCache('networks')">
   <div class="col-md-3 col-md-offset-1">VPCs/Networks</div>
   <div class="col-md-3">{{vm.getCacheInfo('networks').ageMax | timestamp}}</div>
   <div class="col-md-1 text-center">

--- a/app/scripts/modules/core/src/application/config/applicationCacheManagement.directive.js
+++ b/app/scripts/modules/core/src/application/config/applicationCacheManagement.directive.js
@@ -37,6 +37,10 @@ module.exports = angular
         });
     };
 
+    this.hasCache = (cache) => {
+      return infrastructureCaches.get(cache) !== undefined;
+    };
+
     this.getCacheInfo = (cache) => {
       return infrastructureCaches.get(cache).getStats();
     };


### PR DESCRIPTION
Added these checks when adding certificate caching since it's provider specific. Even after ripping out certificate caching, figured these checks were still nice to have.

@anotherchrisberry PTAL