### PR TITLE
fix(provider/amazon): Only enforce TG naming to be based on appname

### DIFF
--- a/app/scripts/modules/amazon/package.json
+++ b/app/scripts/modules/amazon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/amazon",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/application/createApplicationLoadBalancer.controller.ts
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/application/createApplicationLoadBalancer.controller.ts
@@ -195,9 +195,9 @@ class CreateApplicationLoadBalancerCtrl extends CreateAmazonLoadBalancerCtrl {
 
   private modifyTargetGroupName(name: string, add: boolean): string {
     if (add) {
-      return `${this.loadBalancerCommand.name}-${name}`;
+      return `${this.application.name}-${name}`;
     }
-    return name.replace(`${this.loadBalancerCommand.name}-`, '');
+    return name.replace(`${this.application.name}-`, '');
   }
 
   private manageTargetGroupNames(command: IAmazonApplicationLoadBalancerUpsertCommand, add: boolean): void {

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/application/targetGroups.html
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/application/targetGroups.html
@@ -6,7 +6,7 @@
           <div class="wizard-pod-row header">
             <div class="wizard-pod-row-title">Group Name</div>
             <div class="wizard-pod-row-contents">
-              <span class="group-name-prefix">{{ctrl.loadBalancerCommand.name}}-</span>
+              <span class="group-name-prefix">{{ctrl.application.name}}-</span>
               <input class="form-control input-sm target-group-name"
                      type="text"
                      ng-model="targetGroup.name"
@@ -14,6 +14,7 @@
                      validate-unique="ctrl.existingTargetGroupNames"
                      validate-ignore-case="true"
                      name="targetGroupName{{$index}}"
+                     ng-maxlength="32 - ctrl.application.name.length"
                      required/>
               <a href class="sm-label" ng-click="ctrl.removeTargetGroup($index)"><span class="glyphicon glyphicon-trash"></span></a>
             </div>


### PR DESCRIPTION
Also do not allow the user to enter a target group name that will be longer than 32 characters (AWS limit)

@christopherthielen PTAL
@cfieber FYI