### PR TITLE
fix(pipeline_templates): wrap variable name

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/templates/Variable.less
+++ b/app/scripts/modules/core/src/pipeline/config/templates/Variable.less
@@ -8,5 +8,7 @@
   code {
     color: black;
     margin-right: 3px;
+    max-width: 100px;
+    word-break: break-all;
   }
 }

--- a/app/scripts/modules/core/src/pipeline/config/templates/Variable.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/templates/Variable.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
-import {IVariableMetadata} from './pipelineTemplate.service';
-import {IVariable, IVariableInputBuilder} from './inputs/variableInput.service';
 import autoBindMethods from 'class-autobind-decorator';
-import {VariableMetadataHelpField} from './VariableMetadataHelpField';
+
 import { ReactInjector } from 'core/reactShims';
 
-import './Variable.less';
+import { IVariableMetadata } from './pipelineTemplate.service';
+import { IVariable, IVariableInputBuilder } from './inputs/variableInput.service';
+import { VariableMetadataHelpField } from './VariableMetadataHelpField';
 
-export interface IVariableState { }
+import './Variable.less';
 
 export interface IVariableProps {
   variableMetadata: IVariableMetadata;
@@ -16,7 +16,7 @@ export interface IVariableProps {
 }
 
 @autoBindMethods
-export class Variable extends React.Component<IVariableProps, IVariableState> {
+export class Variable extends React.Component<IVariableProps, null> {
 
   private getVariableInput(): JSX.Element {
     const input: IVariableInputBuilder = ReactInjector.variableInputService.getInputForType(this.props.variableMetadata.type);


### PR DESCRIPTION
Wrap variable names in pipeline template variable config modal (instead of hiding parts of them). I guess I could do something clever to break the variable names non-arbitrarily...but who knows what conventions people are using for variable names.

@anotherchrisberry 