### PR TITLE
refactor(core): Refactor security group types to make sense

### DIFF
--- a/app/scripts/modules/amazon/src/loadBalancer/configure/common/createAmazonLoadBalancer.controller.ts
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/common/createAmazonLoadBalancer.controller.ts
@@ -8,10 +8,10 @@ import {
   Application,
   CacheInitializerService,
   IAccount,
-  IGroupsByAccount,
+  ISecurityGroupsByAccountSourceData,
   InfrastructureCacheService,
   IRegion,
-  IRegionAccount,
+  ISecurityGroup,
   ISubnet,
   LoadBalancerWriter,
   NamingService,
@@ -55,8 +55,8 @@ export abstract class CreateAmazonLoadBalancerCtrl {
   public existingLoadBalancerNames: string[];
   public viewState: ICreateAmazonLoadBalancerViewState;
   private accounts: IAccount[];
-  private allSecurityGroups: IGroupsByAccount;
-  public availableSecurityGroups: IRegionAccount[];
+  private allSecurityGroups: ISecurityGroupsByAccountSourceData;
+  public availableSecurityGroups: ISecurityGroup[];
   private availabilityZones: string[];
   protected certificateTypes: string[];
   public defaultSecurityGroups: string[] = [];
@@ -192,7 +192,7 @@ export abstract class CreateAmazonLoadBalancerCtrl {
     });
   }
 
-  private availableGroupsSorter(a: IRegionAccount, b: IRegionAccount): number {
+  private availableGroupsSorter(a: ISecurityGroup, b: ISecurityGroup): number {
     if (this.defaultSecurityGroups) {
       if (this.defaultSecurityGroups.includes(a.name)) {
         return -1;

--- a/app/scripts/modules/amazon/src/securityGroup/securityGroup.reader.ts
+++ b/app/scripts/modules/amazon/src/securityGroup/securityGroup.reader.ts
@@ -1,10 +1,10 @@
 import { module } from 'angular';
 
-import { IIndexedSecurityGroups, ISecurityGroup } from '@spinnaker/core';
+import { ISecurityGroupsByAccount, ISecurityGroup } from '@spinnaker/core';
 
 export class AwsSecurityGroupReader {
 
-  public resolveIndexedSecurityGroup(indexedSecurityGroups: IIndexedSecurityGroups, container: ISecurityGroup, securityGroupId: string): ISecurityGroup  {
+  public resolveIndexedSecurityGroup(indexedSecurityGroups: ISecurityGroupsByAccount, container: ISecurityGroup, securityGroupId: string): ISecurityGroup  {
     return indexedSecurityGroups[container.account][container.region][securityGroupId];
   }
 }

--- a/app/scripts/modules/core/src/serverGroup/configure/common/serverGroupCommandBuilder.service.ts
+++ b/app/scripts/modules/core/src/serverGroup/configure/common/serverGroupCommandBuilder.service.ts
@@ -4,7 +4,7 @@ import { Application } from 'core/application/application.model';
 import { ILoadBalancer, ISecurityGroup, ISubnet, IEntityTags } from 'core/domain';
 import { ICapacity } from 'core/serverGroup/serverGroupWriter.service';
 import { IDeploymentStrategy } from 'core/deploymentStrategy';
-import { IGroupsByAccount } from 'core/securityGroup/securityGroupReader.service';
+import { ISecurityGroupsByAccountSourceData } from 'core/securityGroup/securityGroupReader.service';
 import { IRegion, IAggregatedAccounts } from 'core/account/account.service';
 
 export interface IServerGroupCommandBuilderOptions {
@@ -69,7 +69,7 @@ export interface IServerGroupCommandBackingData {
     }
   }
   scalingProcesses: string[];
-  securityGroups: IGroupsByAccount;
+  securityGroups: ISecurityGroupsByAccountSourceData;
 }
 
 export interface IServerGroupCommand extends IServerGroupCommandResult {


### PR DESCRIPTION
Starting to add a few things to security groups and trying to reason about the current structure was... miserable. Rename some of the types and reuse others that already existed.