### PR TITLE
fix(core): Protect against undefined nodes in the pipeline graph

### DIFF
--- a/app/scripts/modules/core/src/delivery/service/executions.transformer.service.js
+++ b/app/scripts/modules/core/src/delivery/service/executions.transformer.service.js
@@ -252,7 +252,7 @@ module.exports = angular.module('spinnaker.core.delivery.executionTransformer.se
         } else {
           stage.requisiteStageRefIds.forEach(function (parentId) {
             var parent = _.find(stages, { refId: parentId });
-            if (parent.phase === undefined) {
+            if (!parent || parent.phase === undefined) {
               phaseResolvable = false;
             } else {
               phase = Math.max(phase, parent.phase);

--- a/app/scripts/modules/core/src/pipeline/config/graph/pipeline.graph.component.ts
+++ b/app/scripts/modules/core/src/pipeline/config/graph/pipeline.graph.component.ts
@@ -110,7 +110,8 @@ export class PipelineGraphController implements ng.IComponentController {
     if (!allPhasesResolved) {
       this.applyPhasesAndLink(nodes);
     } else {
-      this.$scope.phaseCount = maxBy(nodes, 'phase').phase;
+      const highestPhaseNode = maxBy(nodes, 'phase');
+      this.$scope.phaseCount = highestPhaseNode ? highestPhaseNode.phase : 0;
       if (this.$scope.phaseCount > 6) {
         this.$scope.nodeRadius = 6;
         this.$scope.labelOffsetX = this.$scope.nodeRadius + 3;


### PR DESCRIPTION
Getting some console errors for undefined nodes, protect against this case.