### PR TITLE
feat(core): implement external search API in infrastructure search

### DIFF
--- a/app/scripts/modules/core/src/naming/naming.service.ts
+++ b/app/scripts/modules/core/src/naming/naming.service.ts
@@ -8,7 +8,7 @@ export interface IComponentName {
 }
 
 export class NamingService {
-  private VERSION_PATTERN: RegExp = /(v\d{3})/;
+  public static VERSION_PATTERN: RegExp = /(v\d{3})/;
 
   public parseServerGroupName(serverGroupName: string): IComponentName {
     const result: IComponentName = {
@@ -22,7 +22,7 @@ export class NamingService {
       return result;
     }
     const split: string[] = serverGroupName.split('-'),
-          isVersioned = this.VERSION_PATTERN.test(split[split.length - 1]);
+          isVersioned = NamingService.VERSION_PATTERN.test(split[split.length - 1]);
 
     result.application = split[0];
 
@@ -61,7 +61,7 @@ export class NamingService {
 
   public getClusterNameFromServerGroupName(serverGroupName: string): string {
     const split = serverGroupName.split('-'),
-      isVersioned = this.VERSION_PATTERN.test(split[split.length - 1]);
+      isVersioned = NamingService.VERSION_PATTERN.test(split[split.length - 1]);
 
     if (isVersioned) {
       split.pop();
@@ -71,7 +71,7 @@ export class NamingService {
 
   public getSequence(serverGroupName: string): string {
     const split = serverGroupName.split('-'),
-      isVersioned = this.VERSION_PATTERN.test(split[split.length - 1]);
+      isVersioned = NamingService.VERSION_PATTERN.test(split[split.length - 1]);
 
     if (isVersioned) {
       return split.pop();

--- a/app/scripts/modules/core/src/navigation/index.ts
+++ b/app/scripts/modules/core/src/navigation/index.ts
@@ -1,3 +1,4 @@
 export * from './state.provider';
+export * from './urlBuilder.registry';
 export * from './urlBuilder.service'
 export * from './urlParser';

--- a/app/scripts/modules/core/src/navigation/urlBuilder.registry.ts
+++ b/app/scripts/modules/core/src/navigation/urlBuilder.registry.ts
@@ -1,0 +1,15 @@
+import { IUrlBuilder } from '@spinnaker/core';
+
+export class UrlBuilderRegistry {
+  private builders: { [key: string]: IUrlBuilder} = {};
+
+  public register(key: string, builder: IUrlBuilder) {
+    this.builders[key] = builder;
+  }
+
+  public getBuilder(key: string): IUrlBuilder {
+    return this.builders[key];
+  }
+}
+
+export const urlBuilderRegistry = new UrlBuilderRegistry();

--- a/app/scripts/modules/core/src/search/externalSearch.registry.ts
+++ b/app/scripts/modules/core/src/search/externalSearch.registry.ts
@@ -1,0 +1,47 @@
+import { IPromise } from 'angular';
+import { $q, $log } from 'ngimport';
+
+import { ISearchResult, ISearchResultFormatter, IUrlBuilder, urlBuilderRegistry } from '@spinnaker/core';
+import { searchResultFormatterRegistry } from './searchResult/searchResultFormatter.registry';
+
+/**
+ * External search registry entries add a section to the infrastructure search
+ */
+export interface IExternalSearchConfig {
+  /**
+   * Provides the display text of the search entry. Can include HTML
+   */
+  formatter: ISearchResultFormatter;
+
+  /**
+   * Method to fetch search results
+   * @param query
+   */
+  search: (query: string) => IPromise<ISearchResult[]>;
+
+  /**
+   * Class to build the URL for search results
+   */
+  urlBuilder: IUrlBuilder
+}
+
+export class ExternalSearchRegistry {
+  private registry: {[key: string]: IExternalSearchConfig} = {};
+
+  public register(key: string, searchConfig: IExternalSearchConfig) {
+    searchResultFormatterRegistry.register(key, searchConfig.formatter);
+    urlBuilderRegistry.register(key, searchConfig.urlBuilder);
+    this.registry[key] = searchConfig;
+  }
+
+  public search(query: string): IPromise<ISearchResult[]> {
+    return $q.all(Object.keys(this.registry).map(k => this.registry[k].search(query)))
+      .then((searchResults: ISearchResult[][]) => [].concat.apply([], searchResults))
+      .catch((e) => {
+        $log.warn('External search error:', e);
+        return [];
+      });
+  }
+}
+
+export const externalSearchRegistry = new ExternalSearchRegistry();

--- a/app/scripts/modules/core/src/search/index.ts
+++ b/app/scripts/modules/core/src/search/index.ts
@@ -1,3 +1,4 @@
-export * from './search.service';
+export * from './externalSearch.registry';
 export * from './infrastructure/infrastructureSearch.service';
+export * from './search.service';
 export * from './searchResult/searchResultFormatter.registry';

--- a/app/scripts/modules/core/src/search/infrastructure/infrastructure.html
+++ b/app/scripts/modules/core/src/search/infrastructure/infrastructure.html
@@ -82,10 +82,10 @@
               </div>
               <div class="details-container list-group">
                 <a class="list-group-item"
-                   ng-repeat="result in category.results | searchRank: query"
+                   ng-repeat="result in ::category.results | searchRank: query"
                    ng-click="ctrl.clearFilters(result)"
-                   href="{{ result.href }}">
-                  <search-result item="result"></search-result>
+                   href="{{ ::result.href }}">
+                  <search-result item="::result"></search-result>
                 </a>
               </div>
             </div>

--- a/app/scripts/modules/core/src/search/searchResult/searchResult.directive.html
+++ b/app/scripts/modules/core/src/search/searchResult/searchResult.directive.html
@@ -1,5 +1,5 @@
 <span class="search-result">
   <account-tag
-      account="item.account || item.params.account || item.params.accountId || item.params.accountName"></account-tag>
-  {{ item.displayName }}
+      account="::(item.account || item.params.account || item.params.accountId || item.params.accountName)"></account-tag>
+  <span ng-bind-html="::item.displayName"></span>
 </span>


### PR DESCRIPTION
Allows search integration without adding custom functionality (e.g. proxying) to Gate or any other service.

The expectation is that the searches will return in a reasonable amount of time, since all search results must be resolved before rendering. We may want to revisit that later, although I'm not crazy about it, as it would add some jank to the page.

Also added some one-time bindings to search results on the infrastructure page, and tweaked the search results to allow HTML.