### PR TITLE
feat(provider/kubernetes): Support resourceField

### DIFF
--- a/app/scripts/modules/kubernetes/container/configurer.directive.html
+++ b/app/scripts/modules/kubernetes/container/configurer.directive.html
@@ -100,7 +100,7 @@
       <div class="sm-label-left">
         <b>Environment Variables</b>
       </div>
-      <kubernetes-container-environment-variables env-vars="container.envVars">
+      <kubernetes-container-environment-variables containers="command.containers" env-vars="container.envVars">
       </kubernetes-container-environment-variables>
     </div>
   </collapsible-section>

--- a/app/scripts/modules/kubernetes/container/environmentVariables.component.html
+++ b/app/scripts/modules/kubernetes/container/environmentVariables.component.html
@@ -82,6 +82,34 @@
                    ng-model="envVar.envSource.fieldRef.fieldPath">
           </div>
         </div>
+        <div class="form-group" ng-switch-when="Resource Field Ref">
+          <div class="col-md-3 sm-label-right">
+            Container Name
+          </div>
+          <div class="col-md-3">
+            <select class="form-control input-sm"
+                    ng-model="envVar.envSource.resourceFieldRef.containerName"
+                    ng-options="name for name in $ctrl.containerNames"></select>
+          </div>
+          <div class="col-md-12"/>
+          <div class="col-md-3 sm-label-right">
+            Resource
+          </div>
+          <div class="col-md-3">
+            <select class="form-control input-sm"
+                    ng-model="envVar.envSource.resourceFieldRef.resource"
+                    ng-options="resource for resource in $ctrl.resourceRefFieldResourceOptions"></select>
+          </div>
+          <div class="col-md-12"/>
+          <div class="col-md-3 sm-label-right">
+            Divisor
+          </div>
+          <div class="col-md-3">
+            <select class="form-control input-sm"
+                    ng-model="envVar.envSource.resourceFieldRef.divisor"
+                    ng-options="resource for resource in $ctrl.resourceRefFieldDivisorOptions"></select>
+          </div>
+        </div>
       </div>
     </td>
   </tr>


### PR DESCRIPTION
* Added support for resourceField env vars in Server Groups

I've added `Container Name`, `Resource`, and `Divisor` inline with the `Source` selector, but that can be adjusted if needed.

I have a question about the `Container Name` field: It is a required field and must be the name of a container within the pod. Kubernetes unfortunately silently fails with invalid input. I'd _like_ to make this a picklist of the container names in the pod, but currently the environmentVariables component doesn't have that state. Does it make sense to push down the list of container names into this field?
 
<img width="653" alt="screen shot 2017-07-06 at 9 49 24 am" src="https://user-images.githubusercontent.com/791000/27914884-7e11b470-6232-11e7-8e0c-4080102a87df.png">

Addresses spinnaker/spinnaker#1815