### PR TITLE
chore(core): downgrade @types/react to 15.0.35

### DIFF
--- a/app/scripts/modules/core/src/presentation/formsy/components/TextArea.tsx
+++ b/app/scripts/modules/core/src/presentation/formsy/components/TextArea.tsx
@@ -16,8 +16,6 @@ export interface ITextAreaProps extends IFormComponentProps, React.HTMLAttribute
   Help?: React.ReactElement<any>;
   /** The class string to place on the textarea */
   className?: string;
-  /** the number of horizontal rows contained in the textarea */
-  rows?: number;
   /** A callback for when the textarea value changes */
   onChange?(event: ChangeEvent<HTMLTextAreaElement>): void;
 }

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@types/moment-timezone": "^0.2.34",
     "@types/node": "7.0.5",
     "@types/prop-types": "^15.5.1",
-    "@types/react": "^15.0.38",
+    "@types/react": "15.0.35",
     "@types/react-bootstrap": "^0.0.49",
     "@types/react-dom": "^15.5.0",
     "@types/react-ga": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -309,9 +309,9 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^15.0.22", "@types/react@^15.0.23", "@types/react@^15.0.38":
-  version "15.0.38"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-15.0.38.tgz#6afea31a9fe66304af474106ba372ddaba449995"
+"@types/react@*", "@types/react@15.0.35", "@types/react@^15.0.22", "@types/react@^15.0.23":
+  version "15.0.35"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-15.0.35.tgz#4672923cd502d03e1480d03816ebc5a719fb86da"
 
 "@types/source-map@*":
   version "0.5.0"


### PR DESCRIPTION
The type definitions are a bit shaky in 15.0.>35 (36,37,38 have come out in the past three days), so let's pin this to 35 for now.