### PR TITLE
fix(scroll): Update react-hybrid to 0.0.12 

### DIFF
--- a/app/scripts/modules/core/.npmignore
+++ b/app/scripts/modules/core/.npmignore
@@ -1,0 +1,5 @@
+yalc.*
+.*
+tsconfig.json
+webpack.config.js
+

--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/core",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/core/src/delivery/executions/executions.html
+++ b/app/scripts/modules/core/src/delivery/executions/executions.html
@@ -1,4 +1,4 @@
-<div class="secondary-panel insight" ng-if="!$ctrl.application.notFound"
+<div class="insight" ng-if="!$ctrl.application.notFound"
      ng-class="$ctrl.InsightFilterStateModel.filtersExpanded ? 'filters-expanded' : 'filters-collapsed'">
   <div class="nav">
     <h3 class="filters-placeholder">

--- a/app/scripts/modules/core/src/delivery/executions/executions.less
+++ b/app/scripts/modules/core/src/delivery/executions/executions.less
@@ -2,7 +2,6 @@
 
 [ui-view="pipelines"] {
   padding-top: 0 !important;
-  overflow-y: auto;
 }
 executions {
   display: flex;

--- a/app/scripts/modules/core/src/insight/insightLayout.component.html
+++ b/app/scripts/modules/core/src/insight/insightLayout.component.html
@@ -1,4 +1,4 @@
-<div class="secondary-panel insight" ng-if="!$ctrl.app.notFound"
+<div class="insight" ng-if="!$ctrl.app.notFound"
      ng-class="$ctrl.InsightFilterStateModel.filtersExpanded ? 'filters-expanded' : 'filters-collapsed'">
   <div ui-view="nav" ng-if="!$ctrl.InsightFilterStateModel.filtersHidden" class="nav"></div>
   <div ui-view="master" class="nav-content" data-scroll-id="nav-content"></div>

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@types/classnames": "^2.2.0",
-    "@uirouter/react-hybrid": "^0.0.10",
+    "@uirouter/react-hybrid": "^0.0.12",
     "@uirouter/rx": "^0.4.1",
     "@uirouter/visualizer": "^4.0.0",
     "Select2": "git://github.com/select2/select2.git#3.4.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -349,9 +349,9 @@
   version "5.0.5"
   resolved "https://registry.yarnpkg.com/@uirouter/core/-/core-5.0.5.tgz#4fafae8b89e1bee321b0ed32e69ab66547c055c6"
 
-"@uirouter/react-hybrid@^0.0.10":
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/@uirouter/react-hybrid/-/react-hybrid-0.0.10.tgz#0ba5ddeb267bbc7d5143b5abf52c0b8a41bbb426"
+"@uirouter/react-hybrid@^0.0.12":
+  version "0.0.12"
+  resolved "https://registry.yarnpkg.com/@uirouter/react-hybrid/-/react-hybrid-0.0.12.tgz#c090c3415a551b28a17dbc4b44d6ef38f9f038bf"
   dependencies:
     "@uirouter/angularjs" "1.0.5-SNAPSHOT.20170711"
     "@uirouter/core" "5.0.5"


### PR DESCRIPTION
v0.0.12 passes `secondary-panel` class through to the `ui-view`
