### PR TITLE
feat(amazon): allow default VPC specification for security group crea…

### DIFF
--- a/app/scripts/modules/amazon/src/aws.settings.ts
+++ b/app/scripts/modules/amazon/src/aws.settings.ts
@@ -11,6 +11,7 @@ export interface IAWSProviderSettings extends IProviderSettings {
     region?: string;
     iamRole?: string;
     subnetType?: string;
+    vpc?: string;
   };
   defaultSecurityGroups?: string[];
   loadBalancers?: {
@@ -27,5 +28,5 @@ export interface IAWSProviderSettings extends IProviderSettings {
 
 export const AWSProviderSettings: IAWSProviderSettings = <IAWSProviderSettings>SETTINGS.providers.aws || { defaults: {} };
 if (AWSProviderSettings) {
-  AWSProviderSettings.resetToOriginal = SETTINGS.resetToOriginal;
+  AWSProviderSettings.resetToOriginal = SETTINGS.resetProvider('aws');
 }

--- a/app/scripts/modules/amazon/src/securityGroup/configure/CreateSecurityGroup.controller.spec.js
+++ b/app/scripts/modules/amazon/src/securityGroup/configure/CreateSecurityGroup.controller.spec.js
@@ -156,6 +156,17 @@ describe('Controller: CreateSecurityGroup', function () {
       expect(map(this.$scope.vpcs, 'label').sort()).toEqual(['vpc 1', 'vpc 2']);
     });
 
+    it('loves a default VPC!', function () {
+      AWSProviderSettings.defaults.vpc = 'vpc 2';
+      AWSProviderSettings.classicLaunchLockout = -1;
+      this.initializeCtrl();
+      this.$scope.securityGroup.credentials = 'test';
+      this.$scope.securityGroup.regions = ['us-east-1'];
+      this.ctrl.regionUpdated();
+      this.$scope.$digest();
+      expect(this.$scope.securityGroup.vpcId).toBe('vpc2-te');
+    });
+
     describe('security group removal', function () {
       beforeEach(function () {
         spyOn(this.v2modalWizardService, 'markDirty').and.returnValue(null);

--- a/app/scripts/modules/appengine/appengine.settings.ts
+++ b/app/scripts/modules/appengine/appengine.settings.ts
@@ -9,5 +9,5 @@ export interface IAppengineProviderSettings extends IProviderSettings {
 
 export const AppengineProviderSettings: IAppengineProviderSettings = <IAppengineProviderSettings>SETTINGS.providers.appengine || { defaults: {} };
 if (AppengineProviderSettings) {
-  AppengineProviderSettings.resetToOriginal = SETTINGS.resetToOriginal;
+  AppengineProviderSettings.resetToOriginal = SETTINGS.resetProvider('appengine');
 }

--- a/app/scripts/modules/azure/azure.settings.ts
+++ b/app/scripts/modules/azure/azure.settings.ts
@@ -9,5 +9,5 @@ export interface IAzureProviderSettings extends IProviderSettings {
 
 export const AzureProviderSettings: IAzureProviderSettings = <IAzureProviderSettings>SETTINGS.providers.azure || { defaults: {} };
 if (AzureProviderSettings) {
-  AzureProviderSettings.resetToOriginal = SETTINGS.resetToOriginal;
+  AzureProviderSettings.resetToOriginal = SETTINGS.resetProvider('azure');
 }

--- a/app/scripts/modules/cloudfoundry/cf.settings.ts
+++ b/app/scripts/modules/cloudfoundry/cf.settings.ts
@@ -9,5 +9,5 @@ export interface ICloudFoundryProviderSettings extends IProviderSettings {
 
 export const CloudFoundryProviderSettings: ICloudFoundryProviderSettings = <ICloudFoundryProviderSettings>SETTINGS.providers.cf || { defaults: {} };
 if (CloudFoundryProviderSettings) {
-  CloudFoundryProviderSettings.resetToOriginal = SETTINGS.resetToOriginal;
+  CloudFoundryProviderSettings.resetToOriginal = SETTINGS.resetProvider('cf');
 }

--- a/app/scripts/modules/core/src/config/settings.ts
+++ b/app/scripts/modules/core/src/config/settings.ts
@@ -75,6 +75,7 @@ export interface ISpinnakerSettings {
   };
   [key: string]: any;
   resetToOriginal: () => void;
+  resetProvider: (provider: string) => () => void;
   changelog?: {
     gistId: string;
     fileName: string;
@@ -92,4 +93,15 @@ SETTINGS.defaultTimeZone = SETTINGS.defaultTimeZone || 'America/Los_Angeles';
 
 // A helper to make resetting settings to steady state after running tests easier
 const originalSettings: ISpinnakerSettings = cloneDeep(SETTINGS);
-SETTINGS.resetToOriginal = () => { merge(SETTINGS, originalSettings); };
+SETTINGS.resetToOriginal = () => {
+  Object.keys(SETTINGS).forEach(k => delete SETTINGS[k]);
+  merge(SETTINGS, originalSettings);
+};
+
+SETTINGS.resetProvider = (provider: string) => {
+  return () => {
+    const providerSettings: IProviderSettings = SETTINGS.providers[provider];
+    Object.keys(providerSettings).filter(k => k !== 'resetToOriginal').forEach(k => delete (providerSettings as any)[k]);
+    merge(providerSettings, originalSettings.providers[provider]);
+  };
+};

--- a/app/scripts/modules/google/src/gce.settings.ts
+++ b/app/scripts/modules/google/src/gce.settings.ts
@@ -10,5 +10,5 @@ export interface IGCEProviderSettings extends IProviderSettings {
 
 export const GCEProviderSettings: IGCEProviderSettings = <IGCEProviderSettings>SETTINGS.providers.gce || { defaults: {} };
 if (GCEProviderSettings) {
-  GCEProviderSettings.resetToOriginal = SETTINGS.resetToOriginal;
+  GCEProviderSettings.resetToOriginal = SETTINGS.resetProvider('gce');
 }

--- a/app/scripts/modules/kubernetes/kubernetes.settings.ts
+++ b/app/scripts/modules/kubernetes/kubernetes.settings.ts
@@ -12,5 +12,5 @@ export interface IKubernetesProviderSettings extends IProviderSettings {
 
 export const KubernetesProviderSettings: IKubernetesProviderSettings = <IKubernetesProviderSettings>SETTINGS.providers.kubernetes || { defaults: {} };
 if (KubernetesProviderSettings) {
-  KubernetesProviderSettings.resetToOriginal = SETTINGS.resetToOriginal;
+  KubernetesProviderSettings.resetToOriginal = SETTINGS.resetProvider('kubernetes');
 }

--- a/app/scripts/modules/openstack/openstack.settings.ts
+++ b/app/scripts/modules/openstack/openstack.settings.ts
@@ -9,5 +9,5 @@ export interface IOpenStackProviderSettings extends IProviderSettings {
 
 export const OpenStackProviderSettings: IOpenStackProviderSettings = <IOpenStackProviderSettings>SETTINGS.providers.openstack || { defaults: {} };
 if (OpenStackProviderSettings) {
-  OpenStackProviderSettings.resetToOriginal = SETTINGS.resetToOriginal;
+  OpenStackProviderSettings.resetToOriginal = SETTINGS.resetProvider('openstack');
 }

--- a/app/scripts/modules/oracle/oraclebmcs.settings.ts
+++ b/app/scripts/modules/oracle/oraclebmcs.settings.ts
@@ -9,5 +9,5 @@ export interface IOracleBMCSProviderSettings extends IProviderSettings {
 
 export const OracleBMCSProviderSettings: IOracleBMCSProviderSettings = <IOracleBMCSProviderSettings>SETTINGS.providers.oraclebmcs || { defaults: {} };
 if (OracleBMCSProviderSettings) {
-  OracleBMCSProviderSettings.resetToOriginal = SETTINGS.resetToOriginal;
+  OracleBMCSProviderSettings.resetToOriginal = SETTINGS.resetProvider('oraclebmcs');
 }


### PR DESCRIPTION
…tion

Allows specification of a default VPC when creating security groups.

Also fixes `resetToOriginal` everywhere. In `settings.ts`, it was potentially not working because, since it's just doing a `merge` of the original properties, it would leave in place any fields added during a test, e.g.
```javascript
SETTINGS.propertyThatDoesNotExist = 1;
SETTINGS.resetToOriginal();
SETTINGS.propertyThatDoesNotExist // still 1
```
On providers, calling `resetToOriginal` on SETTINGS would actually overwrite the provider on SETTINGS, but since the exported provider value is a field that's been replaced (because it's the best webpack can do IIRC) and not a live reference, it's gone, too.