### PR TITLE
fix(core): avoid NPE rendering header for missing apps

### DIFF
--- a/app/scripts/modules/core/src/application/ApplicationComponent.tsx
+++ b/app/scripts/modules/core/src/application/ApplicationComponent.tsx
@@ -27,12 +27,11 @@ export class ApplicationComponent extends React.Component<IApplicationComponentP
 
   constructor(props: IApplicationComponentProps) {
     super(props);
+    this.state = this.parseState(props);
     if (props.app.notFound) {
       ReactInjector.recentHistoryService.removeLastItem('applications');
       return;
     }
-
-    this.state = this.parseState(props);
 
     DebugWindow.application = props.app;
     props.app.enableAutoRefresh();


### PR DESCRIPTION
We still want to set the state if the application is not found, as the `render` method depends on `state.compactHeader`.