### PR TITLE
fix(core): update account tag color on account change

### DIFF
--- a/app/scripts/modules/core/src/account/accountTag.component.ts
+++ b/app/scripts/modules/core/src/account/accountTag.component.ts
@@ -16,6 +16,10 @@ class AccountTagController implements IController {
       this.accountType = isProdAccount ? 'prod' : this.account;
     });
   }
+
+  public $onChanges(): void {
+    this.$onInit();
+  }
 }
 
 export class AccountTagComponent implements IComponentOptions {


### PR DESCRIPTION
If the account changes from a prod account to a non-prod account, the tag will not necessarily update its color.