### PR TITLE
refactor(*): Update typescript to 2.4 and fix breaking changes

### DIFF
--- a/app/scripts/modules/amazon/src/loadBalancer/configure/choice/awsLoadBalancerChoice.modal.ts
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/choice/awsLoadBalancerChoice.modal.ts
@@ -1,4 +1,4 @@
-import { IComponentController, module } from 'angular';
+import { IController, module } from 'angular';
 import { IModalInstanceService } from 'angular-ui-bootstrap';
 
 import { Application } from '@spinnaker/core';
@@ -7,7 +7,7 @@ import { IAwsLoadBalancerConfig, LoadBalancerTypes } from './LoadBalancerTypes';
 
 import './awsLoadBalancerChoice.less'
 
-class AwsLoadBalancerChoiceCtrl implements IComponentController {
+class AwsLoadBalancerChoiceCtrl implements IController {
   public choices: IAwsLoadBalancerConfig[];
   public choice: IAwsLoadBalancerConfig;
 

--- a/app/scripts/modules/amazon/src/loadBalancer/details/loadBalancerDetails.controller.ts
+++ b/app/scripts/modules/amazon/src/loadBalancer/details/loadBalancerDetails.controller.ts
@@ -1,4 +1,4 @@
-import { IPromise, IQService, IScope, module } from 'angular';
+import { IController, IPromise, IQService, IScope, module } from 'angular';
 import { IModalService } from 'angular-ui-bootstrap';
 import { StateService } from '@uirouter/angularjs';
 import { cloneDeep, head, get, sortBy } from 'lodash';
@@ -37,7 +37,7 @@ export interface ILoadBalancerFromStateParams {
   name: string;
 }
 
-export class AwsLoadBalancerDetailsController {
+export class AwsLoadBalancerDetailsController implements IController {
   public application: Application;
   public elbProtocol: string;
   public listeners: {in: string, target: ITargetGroup}[];

--- a/app/scripts/modules/amazon/src/loadBalancer/details/targetGroupDetails.controller.ts
+++ b/app/scripts/modules/amazon/src/loadBalancer/details/targetGroupDetails.controller.ts
@@ -1,4 +1,4 @@
-import { IPromise, IQService, IScope, module } from 'angular';
+import { IController, IPromise, IQService, IScope, module } from 'angular';
 import { StateService } from '@uirouter/angularjs';
 
 import { Application, ILoadBalancer } from '@spinnaker/core';
@@ -13,7 +13,7 @@ export interface ITargetGroupFromStateParams {
   vpcId: string;
 }
 
-export class AwsTargetGroupDetailsController {
+export class AwsTargetGroupDetailsController implements IController {
   private targetGroupFromParams: ITargetGroupFromStateParams;
   public application: Application;
   public state = { loading: true };

--- a/app/scripts/modules/amazon/src/loadBalancer/loadBalancer.transformer.ts
+++ b/app/scripts/modules/amazon/src/loadBalancer/loadBalancer.transformer.ts
@@ -107,7 +107,7 @@ export class AwsLoadBalancerTransformer {
     targetGroup.detachedInstances = chain(activeServerGroups).map('detachedInstances').flatten<IInstance>().value();
     this.updateHealthCounts(targetGroup);
 
-    return this.vpcReader.listVpcs().then((vpcs: IVpc[]) => this.addVpcNameToContainer(targetGroup)(vpcs));
+    return this.vpcReader.listVpcs().then((vpcs: IVpc[]) => this.addVpcNameToContainer(targetGroup)(vpcs) as ITargetGroup);
   }
 
   public normalizeLoadBalancer(loadBalancer: IAmazonLoadBalancer): IPromise<IAmazonLoadBalancer> {
@@ -125,7 +125,7 @@ export class AwsLoadBalancerTransformer {
     loadBalancer.instances = chain(activeServerGroups).map('instances').flatten<IInstance>().value();
     loadBalancer.detachedInstances = chain(activeServerGroups).map('detachedInstances').flatten<IInstance>().value();
     this.updateHealthCounts(loadBalancer);
-    return this.vpcReader.listVpcs().then((vpcs: IVpc[]) => this.addVpcNameToContainer(loadBalancer)(vpcs));
+    return this.vpcReader.listVpcs().then((vpcs: IVpc[]) => this.addVpcNameToContainer(loadBalancer)(vpcs) as IAmazonLoadBalancer);
   }
 
   public convertClassicLoadBalancerForEditing(loadBalancer: IAmazonClassicLoadBalancer): IAmazonClassicLoadBalancerUpsertCommand {

--- a/app/scripts/modules/amazon/src/securityGroup/configure/ingressRuleGroupSelector.component.ts
+++ b/app/scripts/modules/amazon/src/securityGroup/configure/ingressRuleGroupSelector.component.ts
@@ -1,4 +1,4 @@
-import { IComponentController, IComponentOptions, module } from 'angular';
+import { IController, IComponentOptions, module } from 'angular';
 import { Subject } from 'rxjs';
 import { get, intersection, uniq } from 'lodash';
 
@@ -21,7 +21,7 @@ interface ISecurityGroupCommand extends ISecurityGroup {
   credentials: string;
 }
 
-class IngressRuleSelectorController implements IComponentController {
+class IngressRuleSelectorController implements IController {
 
   public rule: IRuleCommand;
   public securityGroup: ISecurityGroupCommand;

--- a/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupConfiguration.service.ts
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupConfiguration.service.ts
@@ -163,14 +163,14 @@ export class AwsServerGroupConfigurationService {
       enabledMetrics: this.$q.when(clone(this.enabledMetrics)),
       healthCheckTypes: this.$q.when(clone(this.healthCheckTypes)),
       terminationPolicies: this.$q.when(clone(this.terminationPolicies)),
-    }).then((backingData: IAmazonServerGroupCommandBackingData) => {
+    }).then((backingData: Partial<IAmazonServerGroupCommandBackingData>) => {
       let loadBalancerReloader = this.$q.when(null);
       let securityGroupReloader = this.$q.when(null);
       let instanceTypeReloader = this.$q.when(null);
       backingData.accounts = keys(backingData.credentialsKeyedByAccount);
       backingData.filtered = {} as IAmazonServerGroupCommandBackingDataFiltered;
       backingData.scalingProcesses = this.autoScalingProcessService.listProcesses();
-      command.backingData = backingData;
+      command.backingData = backingData as IAmazonServerGroupCommandBackingData;
       this.configureVpcId(command);
       backingData.filtered.securityGroups = this.getRegionalSecurityGroups(command);
       if (command.viewState.disableImageSelection) {

--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/loadBalancers/loadBalancerSelector.component.ts
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/loadBalancers/loadBalancerSelector.component.ts
@@ -1,10 +1,10 @@
-import { IComponentController, IComponentOptions, module } from 'angular';
+import { IController, IComponentOptions, module } from 'angular';
 
 import { INFRASTRUCTURE_CACHE_SERVICE, InfrastructureCacheService } from '@spinnaker/core';
 
 import { AWS_SERVER_GROUP_CONFIGURATION_SERVICE, AwsServerGroupConfigurationService } from 'amazon/serverGroup/configure/serverGroupConfiguration.service';
 
-class LoadBalancerSelectorController implements IComponentController {
+class LoadBalancerSelectorController implements IController {
   public command: any;
 
   public refreshTime: number;

--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/targetGroups/targetGroupSelector.component.ts
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/targetGroups/targetGroupSelector.component.ts
@@ -1,10 +1,10 @@
-import { IComponentController, IComponentOptions, module } from 'angular';
+import { IController, IComponentOptions, module } from 'angular';
 
 import { INFRASTRUCTURE_CACHE_SERVICE, InfrastructureCacheService } from '@spinnaker/core';
 
 import { AWS_SERVER_GROUP_CONFIGURATION_SERVICE, AwsServerGroupConfigurationService } from 'amazon/serverGroup/configure/serverGroupConfiguration.service';
 
-class TargetGroupSelectorController implements IComponentController {
+class TargetGroupSelectorController implements IController {
   public command: any;
 
   public refreshTime: number;

--- a/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/detailsSummary.component.ts
+++ b/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/detailsSummary.component.ts
@@ -1,11 +1,11 @@
-import { IComponentController, IComponentOptions, module } from 'angular';
+import { IController, IComponentOptions, module } from 'angular';
 
 import { Application, IServerGroup } from '@spinnaker/core';
 
 import { ScalingPolicyTypeRegistry } from './ScalingPolicyTypeRegistry';
 import { IScalingPolicy } from 'amazon/domain';
 
-class ScalingPolicyDetailsSummaryController implements IComponentController {
+class ScalingPolicyDetailsSummaryController implements IController {
 
   public templateUrl: string;
   public policy: IScalingPolicy;

--- a/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/upsert/alarm/metricSelector.component.ts
+++ b/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/upsert/alarm/metricSelector.component.ts
@@ -1,4 +1,4 @@
-import { IComponentController, IComponentOptions, module } from 'angular';
+import { IController, IComponentOptions, module } from 'angular';
 
 import { Dictionary, get } from 'lodash';
 import { Subject } from 'rxjs';
@@ -26,7 +26,7 @@ const dimensionSorter = (a: IMetricAlarmDimension, b: IMetricAlarmDimension): nu
   return a.name.localeCompare(b.name);
 };
 
-export class MetricSelectorController implements IComponentController {
+export class MetricSelectorController implements IController {
 
   public alarmUpdated: Subject<void>;
   public namespaceUpdated = new Subject();

--- a/app/scripts/modules/amazon/src/subnet/subnetSelectField.component.ts
+++ b/app/scripts/modules/amazon/src/subnet/subnetSelectField.component.ts
@@ -1,10 +1,10 @@
-import { module } from 'angular';
+import { IController, module } from 'angular';
 import { get } from 'lodash';
 
 import { Application, ISubnet } from '@spinnaker/core';
 import { AWSProviderSettings } from '../aws.settings';
 
-class SubnetSelectFieldController implements ng.IComponentController {
+class SubnetSelectFieldController implements IController {
   public subnets: ISubnet[];
   public activeSubnets: ISubnet[];
   public deprecatedSubnets: ISubnet[];

--- a/app/scripts/modules/appengine/common/conditionalDescriptionListItem.component.ts
+++ b/app/scripts/modules/appengine/common/conditionalDescriptionListItem.component.ts
@@ -1,6 +1,6 @@
-import {module, IComponentOptions, IFilterService, IComponentController} from 'angular';
+import {module, IComponentOptions, IFilterService, IController} from 'angular';
 
-class AppengineConditionalDescriptionListItemCtrl implements IComponentController {
+class AppengineConditionalDescriptionListItemCtrl implements IController {
   public label: string;
   public key: string;
   public component: any;

--- a/app/scripts/modules/appengine/instance/details/details.controller.ts
+++ b/app/scripts/modules/appengine/instance/details/details.controller.ts
@@ -1,4 +1,4 @@
-import { IPromise, IQService, module } from 'angular';
+import { IController, IPromise, IQService, module } from 'angular';
 import { cloneDeep, flattenDeep } from 'lodash';
 
 import {
@@ -27,7 +27,7 @@ interface InstanceContainer {
   instances: IAppengineInstance[];
 }
 
-class AppengineInstanceDetailsController {
+class AppengineInstanceDetailsController implements IController {
   public state = {loading: true};
   public instance: IAppengineInstance;
   public instanceIdNotFound: string;

--- a/app/scripts/modules/appengine/loadBalancer/configure/wizard/advancedSettings.component.ts
+++ b/app/scripts/modules/appengine/loadBalancer/configure/wizard/advancedSettings.component.ts
@@ -1,7 +1,7 @@
-import {module} from 'angular';
-import {AppengineLoadBalancerUpsertDescription} from 'appengine/loadBalancer/transformer';
+import { IController, IComponentOptions, module} from 'angular';
+import { AppengineLoadBalancerUpsertDescription} from 'appengine/loadBalancer/transformer';
 
-class AppengineLoadBalancerAdvancedSettingsCtrl implements ng.IComponentController {
+class AppengineLoadBalancerAdvancedSettingsCtrl implements IController {
   public state = {error: false};
   public loadBalancer: AppengineLoadBalancerUpsertDescription;
 
@@ -23,7 +23,7 @@ class AppengineLoadBalancerAdvancedSettingsCtrl implements ng.IComponentControll
   }
 }
 
-class AppengineLoadBalancerAdvancedSettingsComponent implements ng.IComponentOptions {
+class AppengineLoadBalancerAdvancedSettingsComponent implements IComponentOptions {
   public bindings: any = {loadBalancer: '=', application: '<'};
   public template = `
     <ng-form name="advancedSettingsForm">

--- a/app/scripts/modules/appengine/loadBalancer/configure/wizard/allocationConfigurationRow.component.ts
+++ b/app/scripts/modules/appengine/loadBalancer/configure/wizard/allocationConfigurationRow.component.ts
@@ -1,8 +1,8 @@
-import {module} from 'angular';
-import {uniq} from 'lodash';
-import {IAppengineAllocationDescription} from 'appengine/loadBalancer/transformer';
+import { IController, IComponentOptions, module } from 'angular';
+import { uniq } from 'lodash';
+import { IAppengineAllocationDescription } from 'appengine/loadBalancer/transformer';
 
-class AppengineAllocationConfigurationRowCtrl implements ng.IComponentController {
+class AppengineAllocationConfigurationRowCtrl implements IController {
   public allocationDescription: IAppengineAllocationDescription;
   public serverGroupOptions: string[];
 
@@ -15,7 +15,7 @@ class AppengineAllocationConfigurationRowCtrl implements ng.IComponentController
   }
 }
 
-class AppengineAllocationConfigurationRowComponent implements ng.IComponentOptions {
+class AppengineAllocationConfigurationRowComponent implements IComponentOptions {
   public bindings: any = {allocationDescription: '<', removeAllocation: '&', serverGroupOptions: '<', onAllocationChange: '&'};
   public template = `
     <div class="form-group">

--- a/app/scripts/modules/appengine/loadBalancer/configure/wizard/basicSettings.component.ts
+++ b/app/scripts/modules/appengine/loadBalancer/configure/wizard/basicSettings.component.ts
@@ -1,9 +1,9 @@
-import {module} from 'angular';
-import {difference} from 'lodash';
+import { IController, module } from 'angular';
+import { difference } from 'lodash';
 
-import {AppengineLoadBalancerUpsertDescription} from 'appengine/loadBalancer/transformer';
+import { AppengineLoadBalancerUpsertDescription } from 'appengine/loadBalancer/transformer';
 
-class AppengineLoadBalancerSettingsController implements ng.IComponentController {
+class AppengineLoadBalancerSettingsController implements IController {
   public loadBalancer: AppengineLoadBalancerUpsertDescription;
   public serverGroupOptions: string[];
   public forPipelineConfig: boolean;

--- a/app/scripts/modules/appengine/loadBalancer/configure/wizard/stageAllocationConfigurationRow.component.ts
+++ b/app/scripts/modules/appengine/loadBalancer/configure/wizard/stageAllocationConfigurationRow.component.ts
@@ -1,11 +1,11 @@
-import { module } from 'angular';
+import { IController, IComponentOptions, module } from 'angular';
 import { uniq } from 'lodash';
 
 import { Application, StageConstants } from '@spinnaker/core';
 
 import { IAppengineAllocationDescription } from 'appengine/loadBalancer/transformer';
 
-class AppengineStageAllocationLabelCtrl implements ng.IComponentController {
+class AppengineStageAllocationLabelCtrl implements IController {
   public inputViewValue: string;
   private allocationDescription: IAppengineAllocationDescription;
 
@@ -45,13 +45,13 @@ class AppengineStageAllocationLabelCtrl implements ng.IComponentController {
   }
 }
 
-class AppengineStageAllocationLabel implements ng.IComponentOptions {
+class AppengineStageAllocationLabel implements IComponentOptions {
   public bindings: any = {allocationDescription: '<'};
   public controller: any = AppengineStageAllocationLabelCtrl;
   public template = `<input ng-model="$ctrl.inputViewValue" type="text" class="form-control input-sm" readonly/>`;
 }
 
-class AppengineStageAllocationConfigurationRowCtrl implements ng.IComponentController {
+class AppengineStageAllocationConfigurationRowCtrl implements IController {
   public allocationDescription: IAppengineAllocationDescription;
   public serverGroupOptions: string[];
   public targets = StageConstants.TARGET_LIST;
@@ -84,7 +84,7 @@ class AppengineStageAllocationConfigurationRowCtrl implements ng.IComponentContr
   }
 }
 
-class AppengineStageAllocationConfigurationRow implements ng.IComponentOptions {
+class AppengineStageAllocationConfigurationRow implements IComponentOptions {
   public bindings: any = {
     application: '<',
     region: '@',

--- a/app/scripts/modules/appengine/loadBalancer/configure/wizard/wizard.controller.ts
+++ b/app/scripts/modules/appengine/loadBalancer/configure/wizard/wizard.controller.ts
@@ -1,4 +1,4 @@
-import { module } from 'angular';
+import { IController, module } from 'angular';
 import { cloneDeep } from 'lodash';
 import { IModalServiceInstance } from 'angular-ui-bootstrap';
 import { StateService } from '@uirouter/angularjs';
@@ -20,7 +20,7 @@ import {
 
 import './wizard.less';
 
-class AppengineLoadBalancerWizardController {
+class AppengineLoadBalancerWizardController implements IController {
   public state = {loading: true};
   public loadBalancer: AppengineLoadBalancerUpsertDescription;
   public heading: string;

--- a/app/scripts/modules/appengine/loadBalancer/details/details.controller.ts
+++ b/app/scripts/modules/appengine/loadBalancer/details/details.controller.ts
@@ -1,4 +1,4 @@
-import { IScope, module } from 'angular';
+import { IController, IScope, module } from 'angular';
 import { IModalService } from 'angular-ui-bootstrap';
 import { StateService } from '@uirouter/angularjs';
 import { cloneDeep } from 'lodash';
@@ -21,7 +21,7 @@ interface ILoadBalancerFromStateParams {
   name: string;
 }
 
-class AppengineLoadBalancerDetailsController {
+class AppengineLoadBalancerDetailsController implements IController {
   public state = { loading: true };
   private loadBalancerFromParams: ILoadBalancerFromStateParams;
   public loadBalancer: IAppengineLoadBalancer;

--- a/app/scripts/modules/appengine/pipeline/stages/appengineStage.controller.ts
+++ b/app/scripts/modules/appengine/pipeline/stages/appengineStage.controller.ts
@@ -1,11 +1,11 @@
-import { IPromise } from 'angular';
+import { IController, IPromise } from 'angular';
 
 import { AccountService, StageConstants } from '@spinnaker/core';
 
 import { AppengineHealth } from 'appengine/common/appengineHealth';
 import { IAppengineAccount, IAppengineStageScope } from 'appengine/domain';
 
-export class AppengineStageCtrl {
+export class AppengineStageCtrl implements IController {
   constructor(protected $scope: IAppengineStageScope, protected accountService: AccountService) {
     $scope.platformHealth = AppengineHealth.PLATFORM;
   }

--- a/app/scripts/modules/appengine/pipeline/stages/editLoadBalancer/appengineEditLoadBalancerStage.ts
+++ b/app/scripts/modules/appengine/pipeline/stages/editLoadBalancer/appengineEditLoadBalancerStage.ts
@@ -1,4 +1,4 @@
-import { module } from 'angular';
+import { IController, module } from 'angular';
 import { IModalService } from 'angular-ui-bootstrap';
 import { cloneDeep } from 'lodash';
 
@@ -7,7 +7,7 @@ import { CloudProviderRegistry, ILoadBalancer } from '@spinnaker/core';
 import { AppengineProviderSettings } from 'appengine/appengine.settings';
 import { APPENGINE_LOAD_BALANCER_CHOICE_MODAL_CTRL } from './loadBalancerChoice.modal.controller';
 
-class AppengineEditLoadBalancerStageCtrl {
+class AppengineEditLoadBalancerStageCtrl implements IController {
   constructor(public $scope: any,
               private $uibModal: IModalService,
               private cloudProviderRegistry: CloudProviderRegistry) {

--- a/app/scripts/modules/appengine/pipeline/stages/editLoadBalancer/loadBalancerChoice.modal.controller.ts
+++ b/app/scripts/modules/appengine/pipeline/stages/editLoadBalancer/loadBalancerChoice.modal.controller.ts
@@ -1,10 +1,10 @@
-import { module } from 'angular';
+import { IController, module } from 'angular';
 import { IModalService, IModalServiceInstance } from 'angular-ui-bootstrap';
 import { cloneDeep } from 'lodash';
 
 import { Application, CloudProviderRegistry, ILoadBalancer } from '@spinnaker/core';
 
-class AppengineLoadBalancerChoiceModalCtrl {
+class AppengineLoadBalancerChoiceModalCtrl implements IController {
   public state = {loading: true};
   public loadBalancers: ILoadBalancer[];
   public selectedLoadBalancer: ILoadBalancer;

--- a/app/scripts/modules/appengine/serverGroup/configure/wizard/basicSettings.controller.ts
+++ b/app/scripts/modules/appengine/serverGroup/configure/wizard/basicSettings.controller.ts
@@ -1,4 +1,4 @@
-import { extend, IControllerService, IScope, module } from 'angular';
+import { extend, IController, IControllerService, IScope, module } from 'angular';
 import { StateService } from '@uirouter/angularjs';
 import { set } from 'lodash';
 
@@ -11,7 +11,7 @@ interface IAppengineBasicSettingsScope extends IScope {
   command: IAppengineServerGroupCommand;
 }
 
-class AppengineServerGroupBasicSettingsCtrl {
+class AppengineServerGroupBasicSettingsCtrl implements IController {
   constructor(public $scope: IAppengineBasicSettingsScope,
               $state: StateService,
               $controller: IControllerService,

--- a/app/scripts/modules/appengine/serverGroup/configure/wizard/cloneServerGroup.controller.ts
+++ b/app/scripts/modules/appengine/serverGroup/configure/wizard/cloneServerGroup.controller.ts
@@ -1,4 +1,4 @@
-import { IScope, copy, module } from 'angular';
+import { IController, IScope, copy, module } from 'angular';
 import { IModalInstanceService } from 'angular-ui-bootstrap';
 import { get, merge } from 'lodash';
 
@@ -18,7 +18,7 @@ import { APPENGINE_DYNAMIC_BRANCH_LABEL } from './dynamicBranchLabel.component';
 
 import './serverGroupWizard.less';
 
-class AppengineCloneServerGroupCtrl {
+class AppengineCloneServerGroupCtrl implements IController {
   public pages: {[pageKey: string]: string} = {
     'basicSettings': require('./basicSettings.html'),
     'advancedSettings': require('./advancedSettings.html'),

--- a/app/scripts/modules/appengine/serverGroup/configure/wizard/configFiles.component.ts
+++ b/app/scripts/modules/appengine/serverGroup/configure/wizard/configFiles.component.ts
@@ -1,6 +1,6 @@
-import {module} from 'angular';
+import { IController, module } from 'angular';
 
-class AppengineConfigFileConfigurerCtrl implements ng.IComponentController {
+class AppengineConfigFileConfigurerCtrl implements IController {
   public command: {configFiles: string[]};
 
   public $onInit(): void {

--- a/app/scripts/modules/appengine/serverGroup/details/details.controller.ts
+++ b/app/scripts/modules/appengine/serverGroup/details/details.controller.ts
@@ -1,4 +1,4 @@
-import { IScope, module } from 'angular';
+import { IController, IScope, module } from 'angular';
 import { IModalService } from 'angular-ui-bootstrap';
 import { cloneDeep, get, map, mapValues, reduce } from 'lodash';
 
@@ -32,7 +32,7 @@ interface IServerGroupFromStateParams {
   name: string;
 }
 
-class AppengineServerGroupDetailsController {
+class AppengineServerGroupDetailsController implements IController {
   public state = { loading: true };
   public serverGroup: IAppengineServerGroup;
 

--- a/app/scripts/modules/canary/canary/canaryAnalysisNameSelector.component.ts
+++ b/app/scripts/modules/canary/canary/canaryAnalysisNameSelector.component.ts
@@ -1,8 +1,8 @@
-import { IComponentController, IComponentOptions, module } from 'angular';
+import { IController, IComponentOptions, module } from 'angular';
 
 import { Api, API_SERVICE, SETTINGS } from '@spinnaker/core';
 
-class CanaryAnalysisNameSelectorController implements IComponentController {
+class CanaryAnalysisNameSelectorController implements IController {
 
   public nameList: string[] = [];
   public queryListUrl: string;

--- a/app/scripts/modules/canary/canary/canaryScores.component.ts
+++ b/app/scripts/modules/canary/canary/canaryScores.component.ts
@@ -1,9 +1,9 @@
-import { module } from 'angular';
+import { IController, module } from 'angular';
 import { isString } from 'lodash';
 
 import './canary.less';
 
-class CanaryScoresConfigComponentCtrl implements ng.IComponentController {
+class CanaryScoresConfigComponentCtrl implements IController {
 
   public unhealthyScore: string;
   public successfulScore: string;

--- a/app/scripts/modules/core/src/account/account.service.ts
+++ b/app/scripts/modules/core/src/account/account.service.ts
@@ -140,7 +140,7 @@ export class AccountService {
           .flatten().compact()
           .map((region: IRegion) => region.name || region)
           .uniq()
-          .value();
+          .value() as string[];
       });
   }
 

--- a/app/scripts/modules/core/src/account/accountTag.component.ts
+++ b/app/scripts/modules/core/src/account/accountTag.component.ts
@@ -1,10 +1,10 @@
-import {module, IComponentController, IComponentOptions} from 'angular';
+import {module, IController, IComponentOptions} from 'angular';
 
 import {ACCOUNT_SERVICE, AccountService} from 'core/account/account.service';
 
 import './accountTag.less';
 
-class AccountTagController implements IComponentController {
+class AccountTagController implements IController {
   public account: string;
 
   public accountType: string;

--- a/app/scripts/modules/core/src/application/applications.component.ts
+++ b/app/scripts/modules/core/src/application/applications.component.ts
@@ -1,4 +1,4 @@
-import { IComponentController, IComponentOptions, IFilterService, IScope, module } from 'angular';
+import { IController, IComponentOptions, IFilterService, IScope, module } from 'angular';
 import { IModalService } from 'angular-ui-bootstrap';
 import { StateService } from '@uirouter/angularjs';
 
@@ -18,7 +18,7 @@ export interface IApplicationPagination {
   maxSize: number;
 }
 
-export class ApplicationsController implements IComponentController {
+export class ApplicationsController implements IController {
   private accounts: IAccount[];
   public applications: IApplicationSummary[];
   private applicationsViewStateCache: ICache;

--- a/app/scripts/modules/core/src/application/config/dataSources/applicationDataSourceEditor.component.ts
+++ b/app/scripts/modules/core/src/application/config/dataSources/applicationDataSourceEditor.component.ts
@@ -1,12 +1,12 @@
-import {module} from 'angular';
+import { IController, module } from 'angular';
 
-import {Application} from '../../application.model';
-import {ApplicationDataSource} from '../../service/applicationDataSource';
-import {APPLICATION_WRITE_SERVICE, ApplicationWriter} from 'core/application/service/application.write.service';
+import { Application } from '../../application.model';
+import { ApplicationDataSource } from '../../service/applicationDataSource';
+import { APPLICATION_WRITE_SERVICE, ApplicationWriter } from 'core/application/service/application.write.service';
 
 import './applicationDataSourceEditor.component.less';
 
-export class DataSourceEditorController implements ng.IComponentController {
+export class DataSourceEditorController implements IController {
 
   public application: Application;
 

--- a/app/scripts/modules/core/src/application/config/footer/configSectionFooter.component.ts
+++ b/app/scripts/modules/core/src/application/config/footer/configSectionFooter.component.ts
@@ -1,8 +1,8 @@
-import {copy, module, toJson} from 'angular';
-import {cloneDeep} from 'lodash';
+import { IController, IComponentOptions, copy, module, toJson } from 'angular';
+import { cloneDeep } from 'lodash';
 
-import {APPLICATION_WRITE_SERVICE, ApplicationWriter} from 'core/application/service/application.write.service';
-import {Application} from 'core/application/application.model';
+import { APPLICATION_WRITE_SERVICE, ApplicationWriter } from 'core/application/service/application.write.service';
+import { Application } from 'core/application/application.model';
 
 import './configSectionFooter.component.less';
 
@@ -14,7 +14,7 @@ export interface IConfigSectionFooterViewState {
   isDirty: boolean;
 }
 
-export class ConfigSectionFooterController implements ng.IComponentController {
+export class ConfigSectionFooterController implements IController {
 
   public viewState: IConfigSectionFooterViewState;
   public application: Application;
@@ -55,7 +55,7 @@ export class ConfigSectionFooterController implements ng.IComponentController {
   }
 }
 
-class ConfigSectionFooterComponent implements ng.IComponentOptions {
+class ConfigSectionFooterComponent implements IComponentOptions {
   public bindings: any = {
     application: '=',
     config: '=',

--- a/app/scripts/modules/core/src/application/modal/PermissionsConfigurer.tsx
+++ b/app/scripts/modules/core/src/application/modal/PermissionsConfigurer.tsx
@@ -155,7 +155,7 @@ export class PermissionsConfigurer extends React.Component<IPermissionsConfigure
     }
   }
 
-  private handleDeletePermission(rowIndex: number): (option: Select.Option) => void {
+  private handleDeletePermission(rowIndex: number): (event: React.MouseEvent<HTMLElement>) => void {
     return () => {
       const permissionRows = cloneDeep(this.state.permissionRows);
       permissionRows.splice(rowIndex, 1);

--- a/app/scripts/modules/core/src/application/modal/validation/applicationNameValidationMessages.component.ts
+++ b/app/scripts/modules/core/src/application/modal/validation/applicationNameValidationMessages.component.ts
@@ -1,4 +1,4 @@
-import {module} from 'angular';
+import { IController, module } from 'angular';
 import {
   APPLICATION_NAME_VALIDATOR,
   ApplicationNameValidator, IApplicationNameValidationResult
@@ -8,7 +8,7 @@ import {
  * This directive is responsible for rendering error and warning messages to the screen when creating a new application.
  * It does NOT set the validity of the form field - that is handled by the validateApplicationName directive.
  */
-class ApplicationNameValidationMessagesController implements ng.IComponentController {
+class ApplicationNameValidationMessagesController implements IController {
   public name: string;
   public cloudProviders: string[];
   public messages: IApplicationNameValidationResult;

--- a/app/scripts/modules/core/src/application/modal/validation/validateApplicationName.directive.ts
+++ b/app/scripts/modules/core/src/application/modal/validation/validateApplicationName.directive.ts
@@ -1,4 +1,4 @@
-import {module} from 'angular';
+import { IController, IDeferred, IDirective, INgModelController, IQService, IScope, module } from 'angular';
 import { DirectiveFactory } from 'core/utils/tsDecorators/directiveFactoryDecorator';
 import {
   APPLICATION_NAME_VALIDATOR,
@@ -15,18 +15,18 @@ interface IValidateNameAttrs  {
  * applicationNameValidationMessages component.
  */
 
-class ValidateApplicationNameController implements ng.IComponentController {
+class ValidateApplicationNameController implements IController {
 
-  public model: ng.INgModelController;
+  public model: INgModelController;
   public cloudProviders: string[];
   public $attrs: IValidateNameAttrs;
-  public $scope: ng.IScope;
+  public $scope: IScope;
 
-  public constructor(private applicationNameValidator: ApplicationNameValidator, private $q: ng.IQService) {}
+  public constructor(private applicationNameValidator: ApplicationNameValidator, private $q: IQService) {}
 
   public initialize() {
     this.model.$asyncValidators['validateApplicationName'] = (value: string) => {
-      const deferred: ng.IDeferred<boolean> = this.$q.defer();
+      const deferred: IDeferred<boolean> = this.$q.defer();
       this.applicationNameValidator.validate(value, this.cloudProviders)
         .then((result: IApplicationNameValidationResult) => {
           if (result.errors.length) {
@@ -43,7 +43,7 @@ class ValidateApplicationNameController implements ng.IComponentController {
 
 
 @DirectiveFactory('applicationNameValidator')
-class ValidateApplicationNameDirective implements ng.IDirective {
+class ValidateApplicationNameDirective implements IDirective {
   public restrict = 'A';
   public controller: any = ValidateApplicationNameController;
   public controllerAs = '$ctrl';
@@ -52,7 +52,7 @@ class ValidateApplicationNameDirective implements ng.IDirective {
     cloudProviders: '<',
   };
 
-  public link($scope: ng.IScope, _$element: JQuery, $attrs: IValidateNameAttrs, ctrl: ng.INgModelController) {
+  public link($scope: IScope, _$element: JQuery, $attrs: IValidateNameAttrs, ctrl: INgModelController) {
     const $ctrl: ValidateApplicationNameController = $scope['$ctrl'];
     $ctrl.$scope = $scope;
     $ctrl.$attrs = $attrs;

--- a/app/scripts/modules/core/src/application/nav/applicationNav.component.ts
+++ b/app/scripts/modules/core/src/application/nav/applicationNav.component.ts
@@ -1,4 +1,4 @@
-import { module, IComponentController, IComponentOptions } from 'angular';
+import { module, IController, IComponentOptions } from 'angular';
 import { StateService } from '@uirouter/angularjs';
 
 import { Application } from 'core/application/application.model';
@@ -6,7 +6,7 @@ import { ApplicationDataSource } from 'core/application/service/applicationDataS
 
 import './applicationNav.component.less';
 
-class ApplicationNavController implements IComponentController {
+class ApplicationNavController implements IController {
   public application: Application;
 
   constructor(private $state: StateService) { 'ngInject'; }

--- a/app/scripts/modules/core/src/application/nav/applicationNavSecondary.component.ts
+++ b/app/scripts/modules/core/src/application/nav/applicationNavSecondary.component.ts
@@ -1,10 +1,10 @@
-import { module, IComponentController, IComponentOptions } from 'angular';
+import { module, IController, IComponentOptions } from 'angular';
 
 import { Application } from '../application.model';
 import { ApplicationDataSource } from '../service/applicationDataSource';
 import { StateService } from '@uirouter/angularjs';
 
-class ApplicationNavSecondaryComponentController implements IComponentController {
+class ApplicationNavSecondaryComponentController implements IController {
 
   public application: Application;
 

--- a/app/scripts/modules/core/src/bootstrap/spinnaker.component.ts
+++ b/app/scripts/modules/core/src/bootstrap/spinnaker.component.ts
@@ -1,3 +1,5 @@
+import { IController } from 'angular';
+
 import { bootstrapModule } from './bootstrap.module';
 import { OverrideRegistry } from 'core/overrideRegistry';
 import { IFeatures, SETTINGS } from '@spinnaker/core';
@@ -18,7 +20,7 @@ const template = `
   <notifier></notifier>
 `;
 
-class SpinnakerController {
+class SpinnakerController implements IController {
   public spinnakerHeaderTemplate: string;
   public feature: IFeatures;
   constructor (overrideRegistry: OverrideRegistry) {

--- a/app/scripts/modules/core/src/cancelModal/cancelModal.controller.ts
+++ b/app/scripts/modules/core/src/cancelModal/cancelModal.controller.ts
@@ -1,4 +1,4 @@
-import { module, IScope } from 'angular';
+import { module, IController, IScope } from 'angular';
 import { IModalServiceInstance } from 'angular-ui-bootstrap';
 
 import './cancel.less';
@@ -9,7 +9,7 @@ export interface ICancelModalScope extends IScope {
   errorMessage: string;
 }
 
-export class CancelModalCtrl {
+export class CancelModalCtrl implements IController {
 
   constructor(public $scope: ICancelModalScope, private $uibModalInstance: IModalServiceInstance, private params: any) {
     this.$scope.params = params;

--- a/app/scripts/modules/core/src/chaosMonkey/chaosMonkeyConfig.component.ts
+++ b/app/scripts/modules/core/src/chaosMonkey/chaosMonkeyConfig.component.ts
@@ -1,4 +1,4 @@
-import { module, toJson } from 'angular';
+import { IController, module, toJson } from 'angular';
 import * as _ from 'lodash';
 
 import { SETTINGS } from 'core/config/settings';
@@ -33,7 +33,7 @@ export class ChaosMonkeyConfig {
   }
 }
 
-export class ChaosMonkeyConfigController implements ng.IComponentController {
+export class ChaosMonkeyConfigController implements IController {
 
   public application: Application;
   public config: ChaosMonkeyConfig;

--- a/app/scripts/modules/core/src/cluster/clusterPod.component.ts
+++ b/app/scripts/modules/core/src/cluster/clusterPod.component.ts
@@ -1,11 +1,11 @@
-import { module, IComponentController, IComponentOptions } from 'angular';
+import { module, IController, IComponentOptions } from 'angular';
 
 import { Application } from 'core/application/application.model';
 import { ClusterFilterModel } from 'core/cluster/filter/clusterFilter.model';
 import { URL_BUILDER_SERVICE, UrlBuilderService } from 'core/navigation/urlBuilder.service';
 import { SERVER_GROUP_COMPONENT } from 'core/serverGroup/serverGroup.component';
 
-class ClusterPodController implements IComponentController {
+class ClusterPodController implements IController {
   public grouping: any;
   public sortFilter: any;
   public application: Application;

--- a/app/scripts/modules/core/src/cluster/onDemand/onDemandClusterPicker.component.ts
+++ b/app/scripts/modules/core/src/cluster/onDemand/onDemandClusterPicker.component.ts
@@ -1,4 +1,4 @@
-import { IComponentController, IComponentOptions, IScope, module } from 'angular';
+import { IController, IComponentOptions, IScope, module } from 'angular';
 
 import { Application } from 'core/application/application.model';
 import { IClusterSummary } from 'core/domain/ICluster';
@@ -6,7 +6,7 @@ import { CLUSTER_FILTER_MODEL, ClusterFilterModel } from '../filter/clusterFilte
 
 import './onDemandClusterPicker.component.less';
 
-class OnDemandClusterPickerController implements IComponentController {
+class OnDemandClusterPickerController implements IController {
   public application: Application;
   public availableClusters: IClusterSummary[];
   public lastSelection: string;

--- a/app/scripts/modules/core/src/delivery/delivery.states.ts
+++ b/app/scripts/modules/core/src/delivery/delivery.states.ts
@@ -57,7 +57,9 @@ module(DELIVERY_STATES, [
     name: 'executionDetails',
     url: '/details',
     views: {
-      'pipelines': 'singleExecutionDetails'
+      'pipelines': {
+        component: 'singleExecutionDetails',
+      }
     },
     abstract: true,
     children: [executionDetails],

--- a/app/scripts/modules/core/src/delivery/stageFailureMessage/stageFailureMessage.component.ts
+++ b/app/scripts/modules/core/src/delivery/stageFailureMessage/stageFailureMessage.component.ts
@@ -1,14 +1,14 @@
-import {module} from 'angular';
+import { IController, module } from 'angular';
 
-import {IStageStep} from 'core/domain/IStageStep';
-import {IExecutionStage} from 'core/domain/IExecutionStage';
+import { IStageStep } from 'core/domain/IStageStep';
+import { IExecutionStage } from 'core/domain/IExecutionStage';
 
 interface IFailureOnChanges extends ng.IOnChangesObject {
   isFailed: ng.IChangesObject<boolean>;
   stage: ng.IChangesObject<IExecutionStage>;
 }
 
-class StageFailureMessageCtrl implements ng.IComponentController {
+class StageFailureMessageCtrl implements IController {
 
   public isFailed: boolean;
   public message: string;

--- a/app/scripts/modules/core/src/delivery/status/executionStatus.component.ts
+++ b/app/scripts/modules/core/src/delivery/status/executionStatus.component.ts
@@ -1,4 +1,4 @@
-import { IComponentController, IComponentOptions, module } from 'angular';
+import { IController, IComponentOptions, module } from 'angular';
 
 import { EXECUTION_FILTER_MODEL, ExecutionFilterModel } from 'core/delivery';
 import { IExecution } from 'core/domain';
@@ -6,7 +6,7 @@ import { EXECUTION_USER_FILTER } from './executionUser.filter';
 
 import './executionStatus.less';
 
-export class ExecutionStatusController implements IComponentController {
+export class ExecutionStatusController implements IController {
   public execution: IExecution;
   public toggleDetails: (stageIndex?: number) => void;
   public showingDetails: boolean;

--- a/app/scripts/modules/core/src/deploymentStrategy/deploymentStrategySelector.component.ts
+++ b/app/scripts/modules/core/src/deploymentStrategy/deploymentStrategySelector.component.ts
@@ -1,4 +1,4 @@
-import { IComponentController, IComponentOptions, module } from 'angular';
+import { IController, IComponentOptions, module } from 'angular';
 import { unset } from 'lodash';
 
 import { DeploymentStrategyRegistry, IDeploymentStrategy } from 'core/deploymentStrategy';
@@ -9,7 +9,7 @@ export interface IDeploymentCommand {
   strategy: string;
 }
 
-export class DeploymentStrategySelectorController implements IComponentController {
+export class DeploymentStrategySelectorController implements IController {
   public command: IDeploymentCommand;
   public labelColumns = 3;
   public fieldColumns = 6;

--- a/app/scripts/modules/core/src/deploymentStrategy/strategies/custom/customStrategySelector.component.ts
+++ b/app/scripts/modules/core/src/deploymentStrategy/strategies/custom/customStrategySelector.component.ts
@@ -1,4 +1,4 @@
-import { IComponentController, IComponentOptions, module } from 'angular';
+import { IController, IComponentOptions, module } from 'angular';
 
 import { APPLICATION_READ_SERVICE, ApplicationReader } from 'core/application/service/application.read.service';
 import { PIPELINE_CONFIG_SERVICE, PipelineConfigService } from 'core/pipeline/config/services/pipelineConfig.service';
@@ -21,7 +21,7 @@ interface ICustomStrategyCommand {
   pipelineParameters?: { [key: string]: any };
 }
 
-class CustomStrategySelectorController implements IComponentController {
+class CustomStrategySelectorController implements IController {
 
   public command: ICustomStrategyCommand;
   public state: ICustomStrategyState = {

--- a/app/scripts/modules/core/src/diffs/jarDiff.component.ts
+++ b/app/scripts/modules/core/src/diffs/jarDiff.component.ts
@@ -1,4 +1,4 @@
-import {IComponentController, IComponentOptions, module} from 'angular';
+import { IController, IComponentOptions, module } from 'angular';
 
 export interface IJarDiffItem {
   displayDiff: string;
@@ -15,7 +15,7 @@ export interface IJarDiff {
   upgraded: IJarDiffItem[];
 }
 
-class JarDiffComponentController implements IComponentController {
+class JarDiffComponentController implements IController {
 
   public jarDiffs: IJarDiff;
   public hasJarDiffs = false;

--- a/app/scripts/modules/core/src/diffs/viewChangesLink.component.ts
+++ b/app/scripts/modules/core/src/diffs/viewChangesLink.component.ts
@@ -1,12 +1,12 @@
-import {extend} from 'lodash';
-import {IComponentController, IComponentOptions, module} from 'angular';
-import {IModalInstanceService, IModalService} from 'angular-ui-bootstrap';
+import { extend } from 'lodash';
+import { IController, IComponentOptions, module } from 'angular';
+import { IModalInstanceService, IModalService } from 'angular-ui-bootstrap';
 
-import {IBuildDiffInfo, ICreationMetadata, ICreationMetadataTag, IJenkinsInfo} from 'core/domain';
-import {ICommit} from './commitHistory.component';
-import {COMMIT_HISTORY_COMPONENT} from './commitHistory.component';
-import {EXECUTION_SERVICE, ExecutionService} from 'core/delivery/service/execution.service';
-import {JAR_DIFF_COMPONENT, IJarDiff} from './jarDiff.component';
+import { IBuildDiffInfo, ICreationMetadata, ICreationMetadataTag, IJenkinsInfo } from 'core/domain';
+import { ICommit } from './commitHistory.component';
+import { COMMIT_HISTORY_COMPONENT } from './commitHistory.component';
+import { EXECUTION_SERVICE, ExecutionService } from 'core/delivery/service/execution.service';
+import { JAR_DIFF_COMPONENT, IJarDiff } from './jarDiff.component';
 
 export interface IViewChangesConfig {
   buildInfo?: IBuildDiffInfo;
@@ -52,7 +52,7 @@ class ViewChangesModalController {
   }
 }
 
-class ViewChangesLinkController implements IComponentController {
+class ViewChangesLinkController implements IController {
 
   public changeConfig: IViewChangesConfig;
   public viewType: string;

--- a/app/scripts/modules/core/src/entityTag/addEntityTagLinks.component.ts
+++ b/app/scripts/modules/core/src/entityTag/addEntityTagLinks.component.ts
@@ -1,10 +1,10 @@
-import { module } from 'angular';
+import { IController, IComponentOptions, module } from 'angular';
 
 import { Application, IEntityTag } from 'core';
 import { EntityTagEditor, IEntityTagEditorProps, IOwnerOption } from './EntityTagEditor';
 import { ENTITY_TAGS_HELP } from './entityTags.help';
 
-class AddEntityTagLinksCtrl implements ng.IComponentController {
+class AddEntityTagLinksCtrl implements IController {
   public application: Application;
   public tagType: string;
 
@@ -37,7 +37,7 @@ class AddEntityTagLinksCtrl implements ng.IComponentController {
   }
 }
 
-class AddEntityTagLinksComponent implements ng.IComponentOptions {
+class AddEntityTagLinksComponent implements IComponentOptions {
   public bindings: any = {
     component: '<',
     application: '<',

--- a/app/scripts/modules/core/src/entityTag/entitySource.component.ts
+++ b/app/scripts/modules/core/src/entityTag/entitySource.component.ts
@@ -1,10 +1,10 @@
-import {module} from 'angular';
+import { IController, module } from 'angular';
 
-import {ICreationMetadataTag} from 'core/domain/IEntityTags';
-import {IExecution} from '../domain/IExecution';
-import {EXECUTION_SERVICE, ExecutionService} from 'core/delivery/service/execution.service';
+import { ICreationMetadataTag } from 'core/domain/IEntityTags';
+import { IExecution } from '../domain/IExecution';
+import { EXECUTION_SERVICE, ExecutionService } from 'core/delivery/service/execution.service';
 
-class EntitySourceCtrl implements ng.IComponentController {
+class EntitySourceCtrl implements IController {
   public relativePath = '^.^.^';
   public metadata: ICreationMetadataTag;
   public executionType: string;

--- a/app/scripts/modules/core/src/forms/numberList/numberList.component.ts
+++ b/app/scripts/modules/core/src/forms/numberList/numberList.component.ts
@@ -1,4 +1,4 @@
-import { IComponentController, IComponentOptions, module } from 'angular';
+import { IController, IComponentOptions, module } from 'angular';
 import './numberList.component.less';
 
 export interface NumberListConstraints {
@@ -6,7 +6,7 @@ export interface NumberListConstraints {
   max: number;
 }
 
-export class NumberListController implements IComponentController {
+export class NumberListController implements IController {
   public model: number[] | string;
   public constraints: NumberListConstraints;
   public label: string;

--- a/app/scripts/modules/core/src/help/helpField.component.ts
+++ b/app/scripts/modules/core/src/help/helpField.component.ts
@@ -1,4 +1,4 @@
-import { IComponentController, IComponentOptions, IPromise, ITimeoutService, module } from 'angular';
+import { IController, IComponentOptions, IPromise, ITimeoutService, module } from 'angular';
 
 import { HELP_CONTENTS } from './help.contents';
 import { HELP_CONTENTS_REGISTRY, HelpContentsRegistry } from './helpContents.registry';
@@ -8,7 +8,7 @@ export interface IHelpFieldContents {
   placement: string;
 }
 
-export class HelpFieldCtrl implements IComponentController {
+export class HelpFieldCtrl implements IController {
 
   public content: string;
   public expand: boolean;

--- a/app/scripts/modules/core/src/insight/insightFilter.component.ts
+++ b/app/scripts/modules/core/src/insight/insightFilter.component.ts
@@ -1,7 +1,8 @@
-import {InsightFilterStateModel} from './insightFilterState.model';
-import {INSIGHT_NGMODULE} from './insight.module';
+import { IController } from 'angular';
+import { InsightFilterStateModel } from './insightFilterState.model';
+import { INSIGHT_NGMODULE } from './insight.module';
 
-export class InsightFilterCtrl {
+export class InsightFilterCtrl implements IController {
   constructor(public insightFilterStateModel: InsightFilterStateModel) { 'ngInject'; }
 }
 

--- a/app/scripts/modules/core/src/instance/instances.component.ts
+++ b/app/scripts/modules/core/src/instance/instances.component.ts
@@ -1,7 +1,7 @@
 import * as $ from 'jquery';
 import { get, last } from 'lodash';
 import { StateParams, PathNode, StateService } from '@uirouter/core';
-import { IChangesObject, IComponentController, IComponentOptions, IOnChangesObject, IRootScopeService, IScope, ITimeoutService, module } from 'angular';
+import { IChangesObject, IController, IComponentOptions, IOnChangesObject, IRootScopeService, IScope, ITimeoutService, module } from 'angular';
 
 import { IInstance } from 'core/domain';
 
@@ -15,7 +15,7 @@ export interface IOnChanges extends IOnChangesObject {
   highlight: IChangesObject<string>;
 }
 
-export class InstancesController implements IComponentController {
+export class InstancesController implements IController {
   public instances: IInstance[];
   public highlight: string;
 

--- a/app/scripts/modules/core/src/modal/wizard/v2modalWizard.component.ts
+++ b/app/scripts/modules/core/src/modal/wizard/v2modalWizard.component.ts
@@ -1,10 +1,10 @@
-import {module} from 'angular';
-import {V2_WIZARD_PAGE_COMPONENT} from './v2wizardPage.component';
-import {V2_MODAL_WIZARD_SERVICE} from './v2modalWizard.service';
+import { IController, module } from 'angular';
+import { V2_WIZARD_PAGE_COMPONENT } from './v2wizardPage.component';
+import { V2_MODAL_WIZARD_SERVICE } from './v2modalWizard.service';
 
 import './modalWizard.less';
 
-export class V2ModalWizard implements ng.IComponentController {
+export class V2ModalWizard implements IController {
 
   public wizard: any;
   public heading: string;

--- a/app/scripts/modules/core/src/modal/wizard/v2wizardPage.component.ts
+++ b/app/scripts/modules/core/src/modal/wizard/v2wizardPage.component.ts
@@ -1,6 +1,6 @@
-import {module} from 'angular';
+import { IController, module } from 'angular';
 
-import {V2_MODAL_WIZARD_SERVICE} from './v2modalWizard.service';
+import { V2_MODAL_WIZARD_SERVICE } from './v2modalWizard.service';
 /**
  * Wizard page directive
  * possible attributes:
@@ -24,7 +24,7 @@ export interface WizardPageState {
   markCompleteOnView: boolean;
 }
 
-export class WizardPageController implements ng.IComponentController {
+export class WizardPageController implements IController {
   /**
    * when set to false, the wizard will not consider this page when isComplete is called
    * default: false

--- a/app/scripts/modules/core/src/pipeline/config/actions/history/diffView.component.ts
+++ b/app/scripts/modules/core/src/pipeline/config/actions/history/diffView.component.ts
@@ -1,7 +1,7 @@
-import { IComponentController, IComponentOptions, module } from 'angular';
+import { IController, IComponentOptions, module } from 'angular';
 import { IJsonDiff } from 'core/utils/json/json.utility.service';
 
-class DiffViewController implements IComponentController {
+class DiffViewController implements IController {
 
   public diff: IJsonDiff;
 

--- a/app/scripts/modules/core/src/pipeline/config/actions/json/editPipelineJsonModal.controller.ts
+++ b/app/scripts/modules/core/src/pipeline/config/actions/json/editPipelineJsonModal.controller.ts
@@ -1,5 +1,5 @@
 import {cloneDeepWith} from 'lodash';
-import {extend, module, IComponentController} from 'angular';
+import {extend, module, IController} from 'angular';
 import {IModalServiceInstance} from 'angular-ui-bootstrap';
 
 import {JSON_UTILITY_SERVICE, JsonUtilityService} from 'core/utils/json/json.utility.service';
@@ -12,7 +12,7 @@ export interface IEditPipelineJsonModalCommand {
   locked: boolean;
 }
 
-export class EditPipelineJsonModalCtrl implements IComponentController {
+export class EditPipelineJsonModalCtrl implements IController {
 
   public isStrategy: boolean;
   public command: IEditPipelineJsonModalCommand;

--- a/app/scripts/modules/core/src/pipeline/config/copyStage/copyStage.modal.controller.ts
+++ b/app/scripts/modules/core/src/pipeline/config/copyStage/copyStage.modal.controller.ts
@@ -1,5 +1,5 @@
 import { flatten } from 'lodash';
-import { IComponentController, IPromise, IQService, module } from 'angular';
+import { IController, IPromise, IQService, module } from 'angular';
 import { IModalInstanceService } from 'angular-ui-bootstrap';
 
 import { API_SERVICE, Api } from 'core/api/api.service';
@@ -19,7 +19,7 @@ interface IStageWrapper {
   stage: IStage;
 }
 
-class CopyStageModalCtrl implements IComponentController {
+class CopyStageModalCtrl implements IController {
   public applications: IApplicationSummary[];
   public stages: IStageWrapper[];
   public viewState = { loading: true, error: false };

--- a/app/scripts/modules/core/src/pipeline/config/graph/pipeline.graph.component.ts
+++ b/app/scripts/modules/core/src/pipeline/config/graph/pipeline.graph.component.ts
@@ -1,4 +1,4 @@
-import { ISCEService, module } from 'angular';
+import { IController, ISCEService, module } from 'angular';
 import { debounce, filter, find, flatten, forOwn, groupBy, max, maxBy, sortBy, sum, sumBy, throttle, uniq } from 'lodash';
 import * as $ from 'jquery';
 
@@ -10,7 +10,7 @@ import { LABEL_COMPONENT } from 'core/presentation/label.component';
 
 import './pipelineGraph.less';
 
-export class PipelineGraphController implements ng.IComponentController {
+export class PipelineGraphController implements IController {
   public pipeline: IPipeline;
   public execution: IExecution;
   public viewState: IExecutionViewState;

--- a/app/scripts/modules/core/src/pipeline/config/stages/bake/bakeStageChooseOs.component.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/bake/bakeStageChooseOs.component.ts
@@ -1,4 +1,4 @@
-import {IComponentController, IComponentOptions, module} from 'angular';
+import { IController, IComponentOptions, module } from 'angular';
 
 export interface IBaseOsOption {
   id: string;
@@ -7,7 +7,7 @@ export interface IBaseOsOption {
   isImageFamily?: boolean;
 }
 
-export class BakeStageChooseOSController implements IComponentController {
+export class BakeStageChooseOSController implements IController {
 
   public model: any;
   public baseOsOptions: IBaseOsOption[];

--- a/app/scripts/modules/core/src/pipeline/config/stages/executionWindows/atlasGraph.component.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/executionWindows/atlasGraph.component.ts
@@ -1,9 +1,9 @@
+import { IController, module } from 'angular';
 import * as momentTimezone from 'moment-timezone';
-import {has} from 'lodash';
-import {module} from 'angular';
-import {Subject} from 'rxjs';
+import { has } from 'lodash';
+import { Subject } from 'rxjs';
 
-import {SETTINGS} from 'core/config/settings';
+import { SETTINGS } from 'core/config/settings';
 
 interface IExecutionWindow {
   displayStart: Date;
@@ -66,7 +66,7 @@ interface IWindowData {
   end: number;
 }
 
-class ExecutionWindowAtlasGraphController implements ng.IComponentController {
+class ExecutionWindowAtlasGraphController implements IController {
   // configured in settings
   public regions: IAtlasRegion[];
 

--- a/app/scripts/modules/core/src/pipeline/config/stages/executionWindows/executionWindowDayPicker.component.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/executionWindows/executionWindowDayPicker.component.ts
@@ -1,4 +1,4 @@
-const angular = require('angular');
+import { IController, module, noop } from 'angular';
 
 import { DAYS_OF_WEEK } from './daysOfWeek';
 
@@ -6,7 +6,7 @@ interface IWindowConfig {
   days: number[];
 }
 
-class ExecutionWindowDayPickerController implements ng.IComponentController {
+class ExecutionWindowDayPickerController implements IController {
 
   public DAYS_OF_WEEK: any = DAYS_OF_WEEK;
   public windowConfig: IWindowConfig;
@@ -14,7 +14,7 @@ class ExecutionWindowDayPickerController implements ng.IComponentController {
 
   public $onInit(): void {
     if (!this.onChange) {
-      this.onChange = angular.noop;
+      this.onChange = noop;
     }
   }
 
@@ -69,5 +69,5 @@ class ExecutionWindowDayPickerComponent implements ng.IComponentOptions {
   public templateUrl: string = require('./executionWindowDayPicker.component.html');
 }
 
-angular.module(EXECUTION_WINDOWS_DAY_PICKER, [])
+module(EXECUTION_WINDOWS_DAY_PICKER, [])
   .component('executionWindowDayPicker', new ExecutionWindowDayPickerComponent());

--- a/app/scripts/modules/core/src/pipeline/config/stages/travis/travisExecutionDetails.controller.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/travis/travisExecutionDetails.controller.ts
@@ -1,13 +1,13 @@
-import {module, IScope} from 'angular';
-import {StateParams} from '@uirouter/angularjs';
-import {get} from 'lodash';
+import { IController, IScope, module } from 'angular';
+import { StateParams } from '@uirouter/angularjs';
+import { get } from 'lodash';
 
 import {
   EXECUTION_DETAILS_SECTION_SERVICE,
   ExecutionDetailsSectionService
 } from 'core/delivery/details/executionDetailsSection.service';
 
-export class TravisExecutionDetailsCtrl {
+export class TravisExecutionDetailsCtrl implements IController {
   public configSections = ['travisConfig', 'taskStatus'];
   public detailsSection: string;
   public failureMessage: string;

--- a/app/scripts/modules/core/src/pipeline/config/stages/travis/travisStage.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/travis/travisStage.ts
@@ -1,11 +1,11 @@
-import {PIPELINE_CONFIG_PROVIDER} from 'core/pipeline/config/pipelineConfigProvider';
-import {module, IScope} from 'angular';
+import { PIPELINE_CONFIG_PROVIDER } from 'core/pipeline/config/pipelineConfigProvider';
+import { IController, IScope, module } from 'angular';
 import * as moment from 'moment';
 
-import {SETTINGS} from 'core/config/settings';
-import {IGOR_SERVICE, IgorService, BuildServiceType} from 'core/ci/igor.service';
-import {IJobConfig, ParameterDefinitionList, IStage} from 'core/domain';
-import {TravisExecutionLabel} from './TravisExecutionLabel';
+import { SETTINGS } from 'core/config/settings';
+import { IGOR_SERVICE, IgorService, BuildServiceType } from 'core/ci/igor.service';
+import { IJobConfig, ParameterDefinitionList, IStage } from 'core/domain';
+import { TravisExecutionLabel } from './TravisExecutionLabel';
 
 export interface ITravisStageViewState {
   mastersLoaded: boolean;
@@ -19,7 +19,7 @@ export interface ITravisStageViewState {
   jobIsParameterized?: boolean;
 }
 
-export class TravisStage {
+export class TravisStage implements IController {
   public viewState: ITravisStageViewState;
   public useDefaultParameters: any;
   public userSuppliedParameters: any;

--- a/app/scripts/modules/core/src/pipeline/config/stages/unmatchedStageTypeStage/unmatchedStageTypeStage.controller.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/unmatchedStageTypeStage/unmatchedStageTypeStage.controller.ts
@@ -1,9 +1,9 @@
-import {module, IComponentController, IScope, isDefined} from 'angular';
+import {module, IController, IScope, isDefined} from 'angular';
 import {cloneDeep, isEqual} from 'lodash';
 import {JSON_UTILITY_SERVICE, JsonUtilityService} from 'core/utils/json/json.utility.service';
 import {IStage} from 'core/domain/IStage';
 
-export class UnmatchedStageTypeStageCtrl implements IComponentController {
+export class UnmatchedStageTypeStageCtrl implements IController {
   public stageJson: string;
   public errorMessage: string;
   public textareaRows: number;

--- a/app/scripts/modules/core/src/pipeline/config/stages/webhook/modal/addCustomHeader.controller.modal.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/webhook/modal/addCustomHeader.controller.modal.ts
@@ -1,7 +1,7 @@
-import {module} from 'angular';
-import {IModalInstanceService} from 'angular-ui-bootstrap';
+import { IController, module } from 'angular';
+import { IModalInstanceService } from 'angular-ui-bootstrap';
 
-export class WebhookStageAddCustomHeader {
+export class WebhookStageAddCustomHeader implements IController {
   constructor (private $scope: ng.IScope, private $uibModalInstance: IModalInstanceService) { 'ngInject'; }
 
   public submit(): void {

--- a/app/scripts/modules/core/src/pipeline/config/stages/webhook/webhookExecutionDetails.controller.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/webhook/webhookExecutionDetails.controller.ts
@@ -1,13 +1,13 @@
-import {module, IScope} from 'angular';
-import {StateParams} from '@uirouter/angularjs';
-import {get} from 'lodash';
+import { IController, IScope, module } from 'angular';
+import { StateParams } from '@uirouter/angularjs';
+import { get } from 'lodash';
 
 import {
   EXECUTION_DETAILS_SECTION_SERVICE,
   ExecutionDetailsSectionService
 } from 'core/delivery/details/executionDetailsSection.service';
 
-export class WebhookExecutionDetailsCtrl {
+export class WebhookExecutionDetailsCtrl implements IController {
   public configSections = ['webhookConfig', 'taskStatus'];
   public detailsSection: string;
   public failureMessage: string;

--- a/app/scripts/modules/core/src/pipeline/config/stages/webhook/webhookStage.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/webhook/webhookStage.ts
@@ -1,9 +1,9 @@
-import {module} from 'angular';
-import {IModalService} from 'angular-ui-bootstrap';
+import { IController, module } from 'angular';
+import { IModalService } from 'angular-ui-bootstrap';
 
-import {JSON_UTILITY_SERVICE, JsonUtilityService} from 'core/utils/json/json.utility.service';
-import {PIPELINE_CONFIG_PROVIDER, PipelineConfigProvider} from 'core/pipeline/config/pipelineConfigProvider';
-import {API_SERVICE, Api} from 'core/api/api.service';
+import { JSON_UTILITY_SERVICE, JsonUtilityService } from 'core/utils/json/json.utility.service';
+import { PIPELINE_CONFIG_PROVIDER, PipelineConfigProvider } from 'core/pipeline/config/pipelineConfigProvider';
+import { API_SERVICE, Api } from 'core/api/api.service';
 
 export interface IWebhookStageViewState {
   waitForCompletion?: boolean;
@@ -30,7 +30,7 @@ interface IPreconfiguredWebhook {
   preconfiguredProperties?: string[];
 }
 
-export class WebhookStage {
+export class WebhookStage implements IController {
   public command: IWebhookStageCommand;
   public viewState: IWebhookStageViewState;
   public methods: string[];

--- a/app/scripts/modules/core/src/pipeline/config/templates/configurePipelineTemplateModal.controller.ts
+++ b/app/scripts/modules/core/src/pipeline/config/templates/configurePipelineTemplateModal.controller.ts
@@ -1,4 +1,4 @@
-import { module, IComponentController, IScope, IHttpPromiseCallbackArg, IPromise } from 'angular';
+import { module, IController, IScope, IHttpPromiseCallbackArg, IPromise } from 'angular';
 import { IModalInstanceService } from 'angular-ui-bootstrap';
 import { load, dump } from 'js-yaml';
 import autoBindMethods from 'class-autobind-decorator';
@@ -28,7 +28,7 @@ export interface IState {
 }
 
 @autoBindMethods
-export class ConfigurePipelineTemplateModalController implements IComponentController {
+export class ConfigurePipelineTemplateModalController implements IController {
 
   public pipelineName: string;
   public variableMetadataGroups: IVariableMetadataGroup[];

--- a/app/scripts/modules/core/src/pipeline/config/triggers/git/git.trigger.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/git/git.trigger.ts
@@ -1,12 +1,12 @@
-import {IScope, module} from 'angular';
-import {has, trim} from 'lodash';
+import { IController, IScope, module } from 'angular';
+import { has, trim } from 'lodash';
 
-import {SETTINGS} from 'core/config/settings';
-import {IGitTrigger} from 'core/domain/ITrigger';
-import {PIPELINE_CONFIG_PROVIDER} from 'core/pipeline/config/pipelineConfigProvider';
-import {SERVICE_ACCOUNT_SERVICE, ServiceAccountService} from 'core/serviceAccount/serviceAccount.service';
+import { SETTINGS } from 'core/config/settings';
+import { IGitTrigger } from 'core/domain/ITrigger';
+import { PIPELINE_CONFIG_PROVIDER } from 'core/pipeline/config/pipelineConfigProvider';
+import { SERVICE_ACCOUNT_SERVICE, ServiceAccountService } from 'core/serviceAccount/serviceAccount.service';
 
-class GitTriggerController {
+class GitTriggerController implements IController {
 
   public fiatEnabled: boolean = SETTINGS.feature.fiatEnabled;
   public serviceAccounts: string[] = [];

--- a/app/scripts/modules/core/src/pipeline/config/triggers/travis/travisTrigger.module.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/travis/travisTrigger.module.ts
@@ -1,11 +1,11 @@
-import {module, IScope, IQService} from 'angular';
+import { IController, IQService, IScope, module } from 'angular';
 
-import {IGOR_SERVICE, IgorService, BuildServiceType} from 'core/ci/igor.service';
-import {PIPELINE_CONFIG_PROVIDER} from 'core/pipeline/config/pipelineConfigProvider';
-import {SERVICE_ACCOUNT_SERVICE, ServiceAccountService} from 'core/serviceAccount/serviceAccount.service';
-import {IBuildTrigger} from 'core/domain/ITrigger';
-import {TRAVIS_TRIGGER_OPTIONS_COMPONENT} from './travisTriggerOptions.component';
-import {SETTINGS} from 'core/config/settings';
+import { IGOR_SERVICE, IgorService, BuildServiceType } from 'core/ci/igor.service';
+import { PIPELINE_CONFIG_PROVIDER } from 'core/pipeline/config/pipelineConfigProvider';
+import { SERVICE_ACCOUNT_SERVICE, ServiceAccountService } from 'core/serviceAccount/serviceAccount.service';
+import { IBuildTrigger } from 'core/domain/ITrigger';
+import { TRAVIS_TRIGGER_OPTIONS_COMPONENT } from './travisTriggerOptions.component';
+import { SETTINGS } from 'core/config/settings';
 
 export interface ITravisTriggerViewState {
   mastersLoaded: boolean;
@@ -14,7 +14,7 @@ export interface ITravisTriggerViewState {
   jobsRefreshing: boolean;
 }
 
-export class TravisTrigger {
+export class TravisTrigger implements IController {
   public viewState: ITravisTriggerViewState;
   public masters: string[];
   public jobs: string[];

--- a/app/scripts/modules/core/src/presentation/autoScroll/autoScroll.directive.ts
+++ b/app/scripts/modules/core/src/presentation/autoScroll/autoScroll.directive.ts
@@ -1,4 +1,4 @@
-import { module } from 'angular';
+import { IController, IDirective, IScope, ITimeoutService, module } from 'angular';
 import { Subject } from 'rxjs';
 
 import { DirectiveFactory } from 'core/utils/tsDecorators/directiveFactoryDecorator';
@@ -8,14 +8,14 @@ export interface AutoScrollAttrs {
   autoScroll: string;
 }
 
-export class AutoScrollController implements ng.IComponentController {
+export class AutoScrollController implements IController {
   public autoScrollParent: string;
   public autoScrollEnabled: string;
   public onScroll: (event: Event) => void;
   public scrollToTop: Subject<boolean>;
   public $element: JQuery;
   public $attrs: AutoScrollAttrs;
-  public $scope: ng.IScope;
+  public $scope: IScope;
 
   private scrollableContainer: JQuery;
   private scrollEnabled = true;
@@ -51,11 +51,11 @@ export class AutoScrollController implements ng.IComponentController {
     this.$scope.$on('$destroy', () => this.scrollableContainer.off(this.containerEvent));
   }
 
-  public constructor(private $timeout: ng.ITimeoutService) {}
+  public constructor(private $timeout: ITimeoutService) {}
 }
 
 @DirectiveFactory('$timeout')
-class AutoScrollDirective implements ng.IDirective {
+class AutoScrollDirective implements IDirective {
   public restrict = 'A';
   public controller: any = AutoScrollController;
   public controllerAs = '$ctrl';
@@ -66,7 +66,7 @@ class AutoScrollDirective implements ng.IDirective {
     scrollToTop: '=?',
   };
 
-  public link($scope: ng.IScope, $element: JQuery, $attrs: AutoScrollAttrs, ctrl: AutoScrollController) {
+  public link($scope: IScope, $element: JQuery, $attrs: AutoScrollAttrs, ctrl: AutoScrollController) {
     ctrl.$scope = $scope;
     ctrl.$element = $element;
     ctrl.$attrs = $attrs;

--- a/app/scripts/modules/core/src/presentation/navigation/pageNavigator.component.ts
+++ b/app/scripts/modules/core/src/presentation/navigation/pageNavigator.component.ts
@@ -1,12 +1,12 @@
-import {module} from 'angular';
-import {PageNavigationState, PAGE_NAVIGATION_STATE} from './pageNavigationState';
-import {throttle} from 'lodash';
-import {ScrollToService, SCROLL_TO_SERVICE} from 'core/utils/scrollTo/scrollTo.service';
-import {PAGE_SECTION_COMPONENT} from './pageSection.component';
-import {UUIDGenerator} from 'core/utils/uuid.service';
+import { IController, module } from 'angular';
+import { PageNavigationState, PAGE_NAVIGATION_STATE } from './pageNavigationState';
+import { throttle } from 'lodash';
+import { ScrollToService, SCROLL_TO_SERVICE } from 'core/utils/scrollTo/scrollTo.service';
+import { PAGE_SECTION_COMPONENT } from './pageSection.component';
+import { UUIDGenerator } from 'core/utils/uuid.service';
 import './pageNavigation.less';
 
-class PageNavigatorController implements ng.IComponentController {
+class PageNavigatorController implements IController {
   public scrollableContainer: string;
   private container: JQuery;
   private navigator: JQuery;

--- a/app/scripts/modules/core/src/presentation/navigation/pageSection.component.ts
+++ b/app/scripts/modules/core/src/presentation/navigation/pageSection.component.ts
@@ -1,5 +1,5 @@
-import {module} from 'angular';
-import {PageNavigationState, INavigationPage} from './pageNavigationState';
+import { IController, module } from 'angular';
+import { PageNavigationState, INavigationPage } from './pageNavigationState';
 
 interface IPageSectionOnChanges extends ng.IOnChangesObject {
   visible: ng.IChangesObject<boolean>;
@@ -7,7 +7,7 @@ interface IPageSectionOnChanges extends ng.IOnChangesObject {
   badge: ng.IChangesObject<string>;
 }
 
-class PageSectionController implements ng.IComponentController {
+class PageSectionController implements IController {
   public key: string;
   public label: string;
   public badge: string;

--- a/app/scripts/modules/core/src/search/infrastructure/infrastructureSearch.service.ts
+++ b/app/scripts/modules/core/src/search/infrastructure/infrastructureSearch.service.ts
@@ -45,7 +45,7 @@ export class InfrastructureSearcher {
         )
       })
       .subscribe((result: ISearchResults<ISearchResult>) => {
-        const tmp = result.results.reduce((categories: { [type: string]: ISearchResult[] }, entry: ISearchResult) => {
+        const tmp: {[type: string]: ISearchResult[]} = result.results.reduce((categories: { [type: string]: ISearchResult[] }, entry: ISearchResult) => {
           this.formatResult(entry.type, entry).then((name) => entry.displayName = name);
           entry.href = urlBuilderService.buildFromMetadata(entry);
           if (!categories[entry.type]) {

--- a/app/scripts/modules/core/src/serverGroup/configure/common/deployInitializer.component.ts
+++ b/app/scripts/modules/core/src/serverGroup/configure/common/deployInitializer.component.ts
@@ -1,4 +1,4 @@
-import { IComponentController, IComponentOptions, IPromise, module } from 'angular';
+import { IController, IComponentOptions, IPromise, module } from 'angular';
 
 import { groupBy, sortBy } from 'lodash';
 
@@ -27,7 +27,7 @@ export interface IParentState {
   loaded: boolean,
 }
 
-export class DeployInitializerController implements IComponentController {
+export class DeployInitializerController implements IController {
   public templates: IDeployTemplate[] = [];
 
   public application: Application;

--- a/app/scripts/modules/core/src/serverGroup/configure/common/serverGroupCommandBuilder.service.ts
+++ b/app/scripts/modules/core/src/serverGroup/configure/common/serverGroupCommandBuilder.service.ts
@@ -21,7 +21,7 @@ export interface IServerGroupCommandDirty {
   keyPair?: boolean;
   loadBalancers?: string[];
   region?: boolean;
-  securityGroups?: ISecurityGroup[];
+  securityGroups?: string[];
   subnetType?: boolean;
   vpcId?: boolean;
 }

--- a/app/scripts/modules/core/src/serverGroup/details/runningTasks.component.ts
+++ b/app/scripts/modules/core/src/serverGroup/details/runningTasks.component.ts
@@ -1,13 +1,13 @@
-import {module} from 'angular';
+import { IController, IComponentOptions, module } from 'angular';
 import { IServerGroup } from 'core/domain';
-import {Application} from 'core/application/application.model';
+import { Application } from 'core/application/application.model';
 
-class ServerGroupRunningTasksCtrl implements ng.IComponentController {
+class ServerGroupRunningTasksCtrl implements IController {
   public serverGroup: IServerGroup;
   public application: Application;
 }
 
-class ServerGroupRunningTasksComponent implements ng.IComponentOptions {
+class ServerGroupRunningTasksComponent implements IComponentOptions {
   public bindings: any = {
     serverGroup: '<',
     application: '<',

--- a/app/scripts/modules/core/src/serverGroup/details/scalingActivities/scalingActivities.controller.ts
+++ b/app/scripts/modules/core/src/serverGroup/details/scalingActivities/scalingActivities.controller.ts
@@ -1,8 +1,8 @@
+import { IController, module } from 'angular';
 import * as _ from 'lodash';
-import {module} from 'angular';
-import {IModalServiceInstance} from 'angular-ui-bootstrap';
+import { IModalServiceInstance } from 'angular-ui-bootstrap';
 
-import {SERVER_GROUP_READER, ServerGroupReader} from 'core/serverGroup/serverGroupReader.service';
+import { SERVER_GROUP_READER, ServerGroupReader } from 'core/serverGroup/serverGroupReader.service';
 import { IServerGroup } from 'core/domain';
 
 export interface IScalingActivitiesViewState {
@@ -31,7 +31,7 @@ export interface IRawScalingActivity {
   startTime: number;
 }
 
-export class ScalingActivitiesCtrl implements ng.IComponentController {
+export class ScalingActivitiesCtrl implements IController {
   public viewState: IScalingActivitiesViewState;
   public activities: IScalingEventSummary[] = [];
 

--- a/app/scripts/modules/core/src/serverGroup/details/scalingActivities/viewScalingActivitiesLink.component.ts
+++ b/app/scripts/modules/core/src/serverGroup/details/scalingActivities/viewScalingActivitiesLink.component.ts
@@ -1,8 +1,8 @@
-import {module} from 'angular';
-import {IModalService} from 'angular-ui-bootstrap';
-import {SCALING_ACTIVITIES_CTRL, ScalingActivitiesCtrl} from './scalingActivities.controller';
+import { IController, IComponentOptions, module } from 'angular';
+import { IModalService } from 'angular-ui-bootstrap';
+import { SCALING_ACTIVITIES_CTRL, ScalingActivitiesCtrl } from './scalingActivities.controller';
 
-class ViewScalingActivitiesLinkCtrl implements ng.IComponentController {
+class ViewScalingActivitiesLinkCtrl implements IController {
   public serverGroup: any;
 
   public constructor(private $uibModal: IModalService) { 'ngInject'; }
@@ -19,7 +19,7 @@ class ViewScalingActivitiesLinkCtrl implements ng.IComponentController {
   }
 }
 
-class ViewScalingActivitiesLink implements ng.IComponentOptions {
+class ViewScalingActivitiesLink implements IComponentOptions {
   public bindings: any = {
     serverGroup: '='
   };

--- a/app/scripts/modules/core/src/serverGroup/serverGroup.component.ts
+++ b/app/scripts/modules/core/src/serverGroup/serverGroup.component.ts
@@ -1,5 +1,5 @@
 import { has } from 'lodash';
-import { IComponentController, IComponentOptions, IFilterService, ITimeoutService, IScope, module } from 'angular';
+import { IController, IComponentOptions, IFilterService, ITimeoutService, IScope, module } from 'angular';
 import { StateService } from '@uirouter/angularjs';
 
 import { CLUSTER_FILTER_MODEL, ClusterFilterModel } from 'core/cluster/filter/clusterFilter.model';
@@ -22,7 +22,7 @@ export interface ServerGroupViewModel {
   images?: string;
 }
 
-export class ServerGroupController implements IComponentController {
+export class ServerGroupController implements IController {
   public cluster: string;
   public serverGroup: IServerGroup;
   public application: string;

--- a/app/scripts/modules/core/src/task/monitor/taskMonitor.builder.spec.ts
+++ b/app/scripts/modules/core/src/task/monitor/taskMonitor.builder.spec.ts
@@ -1,11 +1,12 @@
-import {mock} from 'angular';
+import { mock } from 'angular';
 import Spy = jasmine.Spy;
 
-import {API_SERVICE, Api} from 'core/api/api.service';
-import {TASK_MONITOR_BUILDER, TaskMonitorBuilder} from 'core/task/monitor/taskMonitor.builder';
-import {OrchestratedItemTransformer} from 'core/orchestratedItem/orchestratedItem.transformer';
-import {APPLICATION_MODEL_BUILDER, ApplicationModelBuilder} from 'core/application/applicationModel.builder';
-import {IModalServiceInstance} from 'angular-ui-bootstrap';
+import { API_SERVICE, Api } from 'core/api/api.service';
+import { ITask } from 'core/domain';
+import { TASK_MONITOR_BUILDER, TaskMonitorBuilder } from 'core/task/monitor/taskMonitor.builder';
+import { OrchestratedItemTransformer } from 'core/orchestratedItem/orchestratedItem.transformer';
+import { APPLICATION_MODEL_BUILDER, ApplicationModelBuilder } from 'core/application/applicationModel.builder';
+import { IModalServiceInstance } from 'angular-ui-bootstrap';
 
 describe('Service: taskMonitorBuilder', () => {
 
@@ -106,7 +107,7 @@ describe('Service: taskMonitorBuilder', () => {
 
     it('sets error when task fails while polling', () => {
       let completeCalled = false;
-      const task = { id: 'a', status: 'RUNNING' };
+      const task = { id: 'a', status: 'RUNNING' } as ITask;
       orchestratedItemTransformer.defineProperties(task);
 
       const operation = () => $q.when(task);

--- a/app/scripts/modules/core/src/task/platformHealthOverrideMessage.component.ts
+++ b/app/scripts/modules/core/src/task/platformHealthOverrideMessage.component.ts
@@ -1,11 +1,11 @@
-import { IComponentController, IComponentOptions, module } from 'angular';
+import { IController, IComponentOptions, module } from 'angular';
 import { get } from 'lodash';
 import * as moment from 'moment';
 
 import { Application } from 'core/application/application.model';
 import { IInstanceCounts, IStage, ITask, ITaskStep, ITimedItem } from 'core/domain';
 
-class PlatformHealthOverrideMessageController implements IComponentController {
+class PlatformHealthOverrideMessageController implements IController {
   public showMessage: boolean;
   public messageTemplate = require('./platformHealthOverrideMessage.html');
   private application: Application;

--- a/app/scripts/modules/core/src/task/task.read.service.ts
+++ b/app/scripts/modules/core/src/task/task.read.service.ts
@@ -1,6 +1,6 @@
-import {module} from 'angular';
-import {API_SERVICE, Api} from 'core/api/api.service';
-import {ORCHESTRATED_ITEM_TRANSFORMER, OrchestratedItemTransformer} from 'core/orchestratedItem/orchestratedItem.transformer';
+import { module } from 'angular';
+import { API_SERVICE, Api } from 'core/api/api.service';
+import { ORCHESTRATED_ITEM_TRANSFORMER, OrchestratedItemTransformer } from 'core/orchestratedItem/orchestratedItem.transformer';
 import { ITask } from 'core/domain';
 
 export class TaskReader {
@@ -46,7 +46,7 @@ export class TaskReader {
 
   public waitUntilTaskMatches(task: ITask, closure: (task: ITask) => boolean, failureClosure?: (task: ITask) => boolean,
                               interval = 1000): ng.IPromise<ITask> {
-    const deferred = this.$q.defer();
+    const deferred = this.$q.defer<ITask>();
     if (!task) {
       deferred.reject(null);
     } else if (closure(task)) {

--- a/app/scripts/modules/core/src/utils/clipboard/copyToClipboard.component.ts
+++ b/app/scripts/modules/core/src/utils/clipboard/copyToClipboard.component.ts
@@ -1,9 +1,9 @@
-import {IComponentController, IComponentOptions, IScope, ITimeoutService, module} from 'angular';
+import {IController, IComponentOptions, IScope, ITimeoutService, module} from 'angular';
 import * as Clipboard from 'clipboard';
 
 import './copyToClipboard.component.less';
 
-export class CopyToClipboardController implements IComponentController {
+export class CopyToClipboardController implements IController {
   public text: string;
   public toolTip: string;
   public tempToolTip: string;

--- a/app/scripts/modules/core/src/utils/renderIfFeature.component.ts
+++ b/app/scripts/modules/core/src/utils/renderIfFeature.component.ts
@@ -1,8 +1,8 @@
-import {module} from 'angular';
+import { IComponentOptions, module } from 'angular';
 
-import {SETTINGS} from '../config/settings';
+import { SETTINGS } from '../config/settings';
 
-class RenderIfFeatureController implements ng.IComponentController {
+class RenderIfFeatureController implements ng.IController {
   public feature: string;
   public featureEnabled = false;
 
@@ -11,7 +11,7 @@ class RenderIfFeatureController implements ng.IComponentController {
   }
 }
 
-class RenderIfFeatureComponent implements ng.IComponentOptions {
+class RenderIfFeatureComponent implements IComponentOptions {
   public bindings: any = {feature: '@'};
   public controller: any = RenderIfFeatureController;
   public transclude = true;

--- a/app/scripts/modules/core/src/utils/selectOnDblClick.directive.ts
+++ b/app/scripts/modules/core/src/utils/selectOnDblClick.directive.ts
@@ -1,8 +1,8 @@
 /** based on http://jsfiddle.net/epinapala/WdeTM/4/  **/
-import { IComponentOptions, IDirective, IScope, module } from 'angular';
+import { IController, IDirective, IScope, module } from 'angular';
 import { DirectiveFactory } from './tsDecorators/directiveFactoryDecorator';
 
-class DoubleClickController implements IComponentOptions {
+class DoubleClickController implements IController {
   public $element: JQuery;
   public $scope: IScope;
   public $attrs: any;

--- a/app/scripts/modules/docker/src/image/dockerImageAndTagSelector.component.ts
+++ b/app/scripts/modules/docker/src/image/dockerImageAndTagSelector.component.ts
@@ -1,4 +1,4 @@
-import { module } from 'angular';
+import { IChangesObject, IController, IOnChangesObject, module } from 'angular';
 import { isString, trim, uniq } from 'lodash';
 
 import { ACCOUNT_SERVICE, AccountService, IAccount, IFindImageParams } from '@spinnaker/core';
@@ -11,11 +11,11 @@ interface IViewState {
   imagesRefreshing: boolean;
 }
 
-export interface IOnDockerBindingsChanges extends ng.IOnChangesObject {
-  registry: ng.IChangesObject<string>;
+export interface IOnDockerBindingsChanges extends IOnChangesObject {
+  registry: IChangesObject<string>;
 }
 
-export class DockerImageAndTagSelectorController implements ng.IComponentController {
+export class DockerImageAndTagSelectorController implements IController {
 
   private viewState: IViewState = {
     imagesLoading: false,

--- a/app/scripts/modules/google/src/cache/cacheRefresh.component.ts
+++ b/app/scripts/modules/google/src/cache/cacheRefresh.component.ts
@@ -1,4 +1,4 @@
-import { IComponentController, IComponentOptions, module } from 'angular';
+import { IController, IComponentOptions, module } from 'angular';
 
 import {
   CACHE_INITIALIZER_SERVICE,
@@ -7,7 +7,7 @@ import {
   InfrastructureCacheService
 } from '@spinnaker/core';
 
-class GceCacheRefreshCtrl implements IComponentController {
+class GceCacheRefreshCtrl implements IController {
   public capitalizedKey: string;
   public depluralizedKey: string;
   public renderCompact: boolean;

--- a/app/scripts/modules/google/src/loadBalancer/configure/choice/gceLoadBalancerChoice.modal.ts
+++ b/app/scripts/modules/google/src/loadBalancer/configure/choice/gceLoadBalancerChoice.modal.ts
@@ -1,4 +1,4 @@
-import { module } from 'angular';
+import { IController, module } from 'angular';
 import { IModalInstanceService, IModalService } from 'angular-ui-bootstrap';
 import { find, map } from 'lodash';
 
@@ -9,7 +9,7 @@ import {
   IGceLoadBalancerToWizardMap
 } from './loadBalancerTypeToWizardMap.constant';
 
-class GceLoadBalancerChoiceCtrl implements ng.IComponentController {
+class GceLoadBalancerChoiceCtrl implements IController {
   public choices: string[];
   public choice = 'Network';
 

--- a/app/scripts/modules/google/src/loadBalancer/configure/common/addressSelector.component.ts
+++ b/app/scripts/modules/google/src/loadBalancer/configure/common/addressSelector.component.ts
@@ -1,7 +1,7 @@
-import {module, IComponentOptions, IComponentController} from 'angular';
+import {module, IComponentOptions, IController} from 'angular';
 import {IGceAddress} from 'google/address/address.reader';
 
-class GceAddressSelectorCtrl implements IComponentController {
+class GceAddressSelectorCtrl implements IController {
   public selectedAddress: IGceAddress;
   public addressList: IGceAddress[];
   public account: string;

--- a/app/scripts/modules/google/src/loadBalancer/configure/common/healthCheck.component.ts
+++ b/app/scripts/modules/google/src/loadBalancer/configure/common/healthCheck.component.ts
@@ -1,8 +1,8 @@
-import {get} from 'lodash';
-import {module} from 'angular';
-import {IGceHealthCheck} from 'google/domain/index';
+import { get } from 'lodash';
+import { IController, module } from 'angular';
+import { IGceHealthCheck } from 'google/domain/index';
 
-class HealthCheckCreateCtrl implements ng.IComponentController {
+class HealthCheckCreateCtrl implements IController {
   public healthCheck: IGceHealthCheck;
   public healthCheckPlaceholder: IGceHealthCheck;
   public healthChecksByAccountAndType: { [account: string]: { [healthCheckType: string]: IGceHealthCheck[] } };

--- a/app/scripts/modules/google/src/loadBalancer/configure/internal/gceCreateInternalLoadBalancer.controller.ts
+++ b/app/scripts/modules/google/src/loadBalancer/configure/internal/gceCreateInternalLoadBalancer.controller.ts
@@ -1,4 +1,4 @@
-import { module } from 'angular';
+import { IController, IScope, module } from 'angular';
 import { IModalInstanceService } from 'angular-ui-bootstrap';
 import { StateService } from '@uirouter/angularjs';
 import * as _ from 'lodash';
@@ -35,7 +35,7 @@ interface IListKeyedByAccount {
   [account: string]: string[];
 }
 
-interface IPrivateScope extends ng.IScope {
+interface IPrivateScope extends IScope {
   $$destroyed: boolean;
 }
 
@@ -58,7 +58,7 @@ class InternalLoadBalancer implements IGceLoadBalancer {
   constructor (public region: string) {}
 }
 
-class InternalLoadBalancerCtrl extends CommonGceLoadBalancerCtrl implements ng.IComponentController {
+class InternalLoadBalancerCtrl extends CommonGceLoadBalancerCtrl implements IController {
   public pages: any = {
     'location': require('./createLoadBalancerProperties.html'),
     'listener': require('./listener.html'),

--- a/app/scripts/modules/google/src/loadBalancer/configure/ssl/gceCreateSslLoadBalancer.controller.ts
+++ b/app/scripts/modules/google/src/loadBalancer/configure/ssl/gceCreateSslLoadBalancer.controller.ts
@@ -1,4 +1,4 @@
-import { module, IScope } from 'angular';
+import { module, IScope, IController } from 'angular';
 import { IModalInstanceService } from 'angular-ui-bootstrap';
 import { StateService } from '@uirouter/angularjs';
 import * as _ from 'lodash';
@@ -60,7 +60,7 @@ class SslLoadBalancer implements IGceLoadBalancer {
   constructor (public region = 'global') {}
 }
 
-class SslLoadBalancerCtrl extends CommonGceLoadBalancerCtrl implements ng.IComponentController {
+class SslLoadBalancerCtrl extends CommonGceLoadBalancerCtrl implements IController {
   public pages: any = {
     'location': require('./createLoadBalancerProperties.html'),
     'listener': require('./listener.html'),

--- a/app/scripts/modules/google/src/loadBalancer/details/deleteModal/deleteModal.controller.ts
+++ b/app/scripts/modules/google/src/loadBalancer/details/deleteModal/deleteModal.controller.ts
@@ -1,4 +1,4 @@
-import { module } from 'angular';
+import { IController, IPromise, module } from 'angular';
 import { IModalInstanceService } from 'angular-ui-bootstrap';
 
 import {
@@ -30,7 +30,7 @@ interface IGoogleLoadBalancerDeleteOperation extends ILoadBalancerDeleteCommand 
   loadBalancerType: string;
 }
 
-class DeleteLoadBalancerModalController implements ng.IComponentController {
+class DeleteLoadBalancerModalController implements IController {
   public verification: Verification = new Verification();
   public params: Params = new Params();
   public taskMonitor: any;
@@ -76,7 +76,7 @@ class DeleteLoadBalancerModalController implements ng.IComponentController {
     }
   }
 
-  private getSubmitMethod (): {(): ng.IPromise<any>} {
+  private getSubmitMethod (): {(): IPromise<any>} {
     if (this.gceHttpLoadBalancerUtils.isHttpLoadBalancer(this.loadBalancer)) {
       return () => {
         return this.gceHttpLoadBalancerWriter.deleteLoadBalancers(this.loadBalancer, this.application, this.params);

--- a/app/scripts/modules/google/src/serverGroup/configure/wizard/autoHealingPolicy/autoHealingPolicySelector.component.ts
+++ b/app/scripts/modules/google/src/serverGroup/configure/wizard/autoHealingPolicy/autoHealingPolicySelector.component.ts
@@ -1,8 +1,8 @@
-import {set} from 'lodash';
-import {module} from 'angular';
-import {IGceAutoHealingPolicy} from 'google/domain/autoHealingPolicy';
+import { IComponentOptions, IController, module } from 'angular';
+import { set } from 'lodash';
+import { IGceAutoHealingPolicy } from 'google/domain/autoHealingPolicy';
 
-class GceAutoHealingPolicySelector implements ng.IComponentController {
+class GceAutoHealingPolicySelector implements IController {
   public httpHealthChecks: string[];
   public autoHealingPolicy: IGceAutoHealingPolicy;
   public enabled: boolean;
@@ -38,7 +38,7 @@ class GceAutoHealingPolicySelector implements ng.IComponentController {
   }
 }
 
-class GceAutoHealingPolicySelectorComponent implements ng.IComponentOptions {
+class GceAutoHealingPolicySelectorComponent implements IComponentOptions {
   public bindings: any = {
     onHealthCheckRefresh: '&',
     setAutoHealingPolicy: '&',

--- a/app/scripts/modules/google/src/serverGroup/configure/wizard/loadBalancingPolicy/loadBalancingPolicySelector.component.ts
+++ b/app/scripts/modules/google/src/serverGroup/configure/wizard/loadBalancingPolicy/loadBalancingPolicySelector.component.ts
@@ -1,8 +1,8 @@
-import {set, get, has, without} from 'lodash';
-import {module} from 'angular';
+import { IComponentOptions, IController, module } from 'angular';
+import { set, get, has, without } from 'lodash';
 import './loadBalancingPolicySelector.component.less';
 
-class GceLoadBalancingPolicySelectorController implements ng.IComponentController {
+class GceLoadBalancingPolicySelectorController implements IController {
 
   public maxPort = 65535;
   public command: any;
@@ -78,7 +78,7 @@ class GceLoadBalancingPolicySelectorController implements ng.IComponentControlle
   }
 }
 
-class GceLoadBalancingPolicySelectorComponent implements ng.IComponentOptions {
+class GceLoadBalancingPolicySelectorComponent implements IComponentOptions {
   public bindings: any = {
     command: '='
   };

--- a/app/scripts/modules/google/src/serverGroup/details/autoHealingPolicy/addAutoHealingPolicyButton.component.ts
+++ b/app/scripts/modules/google/src/serverGroup/details/autoHealingPolicy/addAutoHealingPolicyButton.component.ts
@@ -1,9 +1,9 @@
-import { module } from 'angular';
+import { IController, IComponentOptions, module } from 'angular';
 import { IModalService } from 'angular-ui-bootstrap';
 
 import { Application, IServerGroup } from '@spinnaker/core';
 
-class GceAddAutoHealingPolicyButtonCtrl implements ng.IComponentController {
+class GceAddAutoHealingPolicyButtonCtrl implements IController {
   public application: Application;
   public serverGroup: IServerGroup;
 
@@ -23,7 +23,7 @@ class GceAddAutoHealingPolicyButtonCtrl implements ng.IComponentController {
   }
 }
 
-class GceAddAutoHealingPolicyButton implements ng.IComponentOptions {
+class GceAddAutoHealingPolicyButton implements IComponentOptions {
   public bindings: any = {
     application: '<',
     serverGroup: '<',

--- a/app/scripts/modules/google/src/serverGroup/details/autoHealingPolicy/autoHealingPolicy.component.ts
+++ b/app/scripts/modules/google/src/serverGroup/details/autoHealingPolicy/autoHealingPolicy.component.ts
@@ -1,11 +1,11 @@
-import { module } from 'angular';
+import { IController, IComponentOptions, module } from 'angular';
 import { IModalService } from 'angular-ui-bootstrap';
 
 import { Application, ConfirmationModalService } from '@spinnaker/core';
 
 import { IGceServerGroup } from 'google/domain/index';
 
-class GceAutoHealingPolicyDetailsCtrl implements ng.IComponentController {
+class GceAutoHealingPolicyDetailsCtrl implements IController {
   public serverGroup: IGceServerGroup;
   public application: Application;
 
@@ -44,7 +44,7 @@ class GceAutoHealingPolicyDetailsCtrl implements ng.IComponentController {
   }
 }
 
-class GceAutoHealingPolicyDetails implements ng.IComponentOptions {
+class GceAutoHealingPolicyDetails implements IComponentOptions {
   public bindings: any = {serverGroup: '<', application: '<'};
   public template = `
     <dt>

--- a/app/scripts/modules/google/src/serverGroup/details/autoHealingPolicy/modal/upsertAutoHealingPolicy.modal.controller.ts
+++ b/app/scripts/modules/google/src/serverGroup/details/autoHealingPolicy/modal/upsertAutoHealingPolicy.modal.controller.ts
@@ -1,5 +1,5 @@
 import { Application, TaskMonitor, TaskMonitorBuilder } from '@spinnaker/core';
-import { module } from 'angular';
+import { IController, module } from 'angular';
 import { IModalServiceInstance } from 'angular-ui-bootstrap';
 import { chain, cloneDeep, last } from 'lodash';
 
@@ -8,7 +8,7 @@ import { GCE_HEALTH_CHECK_READER, GceHealthCheckReader } from 'google/healthChec
 
 import './upsertAutoHealingPolicy.modal.less';
 
-class GceUpsertAutoHealingPolicyModalCtrl {
+class GceUpsertAutoHealingPolicyModalCtrl implements IController {
   public autoHealingPolicy: IGceAutoHealingPolicy;
   public taskMonitor: TaskMonitor;
   public httpHealthChecks: string[];

--- a/app/scripts/modules/kubernetes/container/lifecycleHook.component.ts
+++ b/app/scripts/modules/kubernetes/container/lifecycleHook.component.ts
@@ -1,4 +1,4 @@
-import {module} from 'angular';
+import { IComponentOptions, IController, module } from 'angular';
 
 interface IKubernetesHandler {
   type: 'EXEC' | 'HTTP';
@@ -23,7 +23,7 @@ interface IKeyValuePair {
   value: string;
 }
 
-class KubernetesLifecycleHookConfigurerCtrl implements ng.IComponentController {
+class KubernetesLifecycleHookConfigurerCtrl implements IController {
   public heading: string;
   public handler: IKubernetesHandler;
   public execActionCommandsViewValue: string;
@@ -95,7 +95,7 @@ class KubernetesLifecycleHookConfigurerCtrl implements ng.IComponentController {
   }
 }
 
-class KubernetesLifecycleHookConfigurer implements ng.IComponentOptions {
+class KubernetesLifecycleHookConfigurer implements IComponentOptions {
   public bindings: any = {
     heading: '@',
     handler: '<',

--- a/app/scripts/modules/kubernetes/container/securityContext/capabilitiesSelector.component.ts
+++ b/app/scripts/modules/kubernetes/container/securityContext/capabilitiesSelector.component.ts
@@ -1,5 +1,5 @@
-import {module} from 'angular';
-import {set, has} from 'lodash';
+import { IController, IComponentOptions, module } from 'angular';
+import { set, has } from 'lodash';
 
 interface ICapabilitiesSelectorField {
   label: string;
@@ -7,7 +7,7 @@ interface ICapabilitiesSelectorField {
   model: string;
 }
 
-class CapabilitiesSelector implements ng.IComponentController {
+class CapabilitiesSelector implements IController {
   public component: any;
   public fields: ICapabilitiesSelectorField[] = [
     {
@@ -35,7 +35,7 @@ class CapabilitiesSelector implements ng.IComponentController {
   }
 }
 
-class CapabilitiesSelectorComponent implements ng.IComponentOptions {
+class CapabilitiesSelectorComponent implements IComponentOptions {
   public bindings: any = {
     component: '=',
   };

--- a/app/scripts/modules/kubernetes/container/securityContext/seLinuxOptionsSelector.component.ts
+++ b/app/scripts/modules/kubernetes/container/securityContext/seLinuxOptionsSelector.component.ts
@@ -1,11 +1,11 @@
-import {module} from 'angular';
+import {IController, IComponentOptions, module} from 'angular';
 
 interface ISeLinuxField {
   label: string;
   model: string;
 }
 
-class SeLinuxOptions implements ng.IComponentController {
+class SeLinuxOptions implements IController {
   public component: any;
   public fields: ISeLinuxField[] = [
     {
@@ -27,7 +27,7 @@ class SeLinuxOptions implements ng.IComponentController {
   ];
 }
 
-class SeLinuxOptionsComponent implements ng.IComponentOptions {
+class SeLinuxOptionsComponent implements IComponentOptions {
   public bindings: any = {
     component: '=',
   };

--- a/app/scripts/modules/kubernetes/container/securityContext/securityContextSelector.component.ts
+++ b/app/scripts/modules/kubernetes/container/securityContext/securityContextSelector.component.ts
@@ -1,4 +1,4 @@
-import {module} from 'angular';
+import { IController, IComponentOptions, module} from 'angular';
 
 import './securityContextSelector.component.less';
 import {KUBERNETES_SE_LINUX_OPTIONS_SELECTOR} from './seLinuxOptionsSelector.component';
@@ -12,7 +12,7 @@ interface ISecurityContextField {
   columns?: number;
 }
 
-class SecurityContextSelector implements ng.IComponentController {
+class SecurityContextSelector implements IController {
   public component: any;
   public fields: ISecurityContextField[] = [
     {
@@ -40,7 +40,7 @@ class SecurityContextSelector implements ng.IComponentController {
   ];
 }
 
-class SecurityContextSelectorComponent implements ng.IComponentOptions {
+class SecurityContextSelectorComponent implements IComponentOptions {
   public bindings: any = {
     component: '='
   };

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "react-virtualized-select": "^3.1.0",
     "react2angular": "^1.1.3",
     "reflect-metadata": "^0.1.9",
-    "rxjs": "^5.1.0",
+    "rxjs": "^5.4.2",
     "select2-bootstrap-css": "git://github.com/t0m/select2-bootstrap-css.git#v1.3.1",
     "source-map": "^0.4.4",
     "source-sans-pro": "^2.0.10",
@@ -79,8 +79,8 @@
     "ui-select": "^0.19.6"
   },
   "devDependencies": {
-    "@types/angular": "1.6.16",
-    "@types/angular-mocks": "1.5.9",
+    "@types/angular": "1.6.26",
+    "@types/angular-mocks": "1.5.10",
     "@types/angular-ui-bootstrap": "^0.13.41",
     "@types/clipboard": "^1.5.33",
     "@types/d3": "^4.5.0",
@@ -147,7 +147,7 @@
     "tslint": "^5.5.0",
     "tslint-loader": "^3.4.3",
     "tslint-react": "^3.0.0",
-    "typescript": "^2.2.2",
+    "typescript": "~2.4.1",
     "url-loader": "^0.5.7",
     "webpack": "^2.5.1",
     "webpack-dev-server": "^2.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,13 @@
 # yarn lockfile v1
 
 
-"@types/angular-mocks@1.5.9", "@types/angular-mocks@^1.5.9":
+"@types/angular-mocks@1.5.10":
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/@types/angular-mocks/-/angular-mocks-1.5.10.tgz#bb3728bfc156a3bc35dfbfcc2d332e175284fba6"
+  dependencies:
+    "@types/angular" "*"
+
+"@types/angular-mocks@^1.5.9":
   version "1.5.9"
   resolved "https://registry.yarnpkg.com/@types/angular-mocks/-/angular-mocks-1.5.9.tgz#4d91bb71a5cfb000d02b02133bc98c20f57101fd"
   dependencies:
@@ -14,11 +20,9 @@
   dependencies:
     "@types/angular" "*"
 
-"@types/angular@*", "@types/angular@1.6.16", "@types/angular@^1.6.15", "@types/angular@^1.6.16":
-  version "1.6.16"
-  resolved "https://registry.yarnpkg.com/@types/angular/-/angular-1.6.16.tgz#f649ef28dd56311a7d8c10be19af879a2a3a9151"
-  dependencies:
-    "@types/jquery" "*"
+"@types/angular@*", "@types/angular@1.6.26", "@types/angular@^1.6.15", "@types/angular@^1.6.16":
+  version "1.6.26"
+  resolved "https://registry.yarnpkg.com/@types/angular/-/angular-1.6.26.tgz#a96cccef648de0bf7435f3b9bad13f2430719305"
 
 "@types/cheerio@*":
   version "0.22.1"
@@ -1574,13 +1578,13 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@2.9.x, commander@^2.5.0:
+commander@2.9.x:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
     graceful-readlink ">= 1.0.0"
 
-commander@^2.9.0:
+commander@^2.5.0, commander@^2.9.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
 
@@ -5364,9 +5368,9 @@ rx-lite@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
 
-rxjs@^5.1.0:
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.4.0.tgz#a7db14ab157f9d7aac6a56e655e7a3860d39bf26"
+rxjs@^5.4.2:
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.4.2.tgz#2a3236fcbf03df57bae06fd6972fd99e5c08fcf7"
   dependencies:
     symbol-observable "^1.0.1"
 
@@ -5971,9 +5975,9 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@^2.2.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.3.2.tgz#f0f045e196f69a72f06b25fd3bd39d01c3ce9984"
+typescript@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.4.1.tgz#c3ccb16ddaa0b2314de031e7e6fee89e5ba346bc"
 
 ua-parser-js@^0.7.9:
   version "0.7.12"


### PR DESCRIPTION
Supersedes #3910 

I cherry picked the commit by @jrsquared into master, updated `@types/angular` and `@types/angular-mocks`, removed the `$onInit()` methods, and fixed an error or two.  I also removed some more `ng.*` stuff.  

Seems to work on my machine, but it would be safest if ya'll pulled it down to check if it works with retina.

@jrsquared @icfantv @anotherchrisberry 