### PR TITLE
fix(core): update webhook stage scope on stage change

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/webhook/webhookExecutionDetails.controller.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/webhook/webhookExecutionDetails.controller.ts
@@ -18,12 +18,12 @@ export class WebhookExecutionDetailsCtrl implements IController {
               private executionDetailsSectionService: ExecutionDetailsSectionService,
               private $scope: IScope) {
     'ngInject';
-    this.stage = this.$scope.stage;
     this.initialize();
     this.$scope.$on('$stateChangeSuccess', () => this.initialize());
   }
 
   public initialized(): void {
+    this.stage = this.$scope.stage;
     this.detailsSection = get<string>(this.$stateParams, 'details', '');
     this.failureMessage = this.getFailureMessage();
     this.progressMessage = this.getProgressMessage();


### PR DESCRIPTION
We need to update the stage on the controller when the state changes; otherwise, clicking on the execution graph between two stages will not update the execution details fully.