### PR TITLE
fix(core): add margin between collapsed execution group headers

### DIFF
--- a/app/scripts/modules/core/src/delivery/executionGroup/executionGroup.less
+++ b/app/scripts/modules/core/src/delivery/executionGroup/executionGroup.less
@@ -107,4 +107,5 @@
 
 .execution-group {
   display: block;
+  margin-bottom: 5px;
 }


### PR DESCRIPTION
Fixes a minor regression from the conversion of sticky headers to CSS-only, adding a little gap between the headers on the executions view when they are collapsed.

**Current**
<img width="1072" alt="screen shot 2017-07-21 at 10 52 35 am" src="https://user-images.githubusercontent.com/73450/28475889-e98b4b4a-6e02-11e7-8120-2f5f76e31116.png">

**PR**
<img width="1071" alt="screen shot 2017-07-21 at 10 52 20 am" src="https://user-images.githubusercontent.com/73450/28475905-f106b332-6e02-11e7-9dd4-81dd7dbc1524.png">
