### PR TITLE
fix(core): avoid double-load of execution, treat F_C as isFailed

### DIFF
--- a/app/scripts/modules/core/src/delivery/details/singleExecutionDetails.component.ts
+++ b/app/scripts/modules/core/src/delivery/details/singleExecutionDetails.component.ts
@@ -92,19 +92,18 @@ class SingleExecutionDetailsController {
   }
 
   public $onInit() {
-    this.executionScheduler = this.schedulerFactory.createScheduler(5000);
-    this.executionLoader = this.executionScheduler.subscribe(() => this.getExecution());
-
     this.getExecution();
   }
 
   public $onDestroy() {
-    this.executionScheduler.unsubscribe();
-    this.executionLoader.unsubscribe();
+    if (this.executionScheduler) {
+      this.executionScheduler.unsubscribe();
+      this.executionLoader.unsubscribe();
+    }
   }
 
   private getExecution() {
-    const { executionService, executionScheduler, executionLoader, $state } = this;
+    const { executionService, $state } = this;
 
     if (this.app.notFound) {
       return;
@@ -114,9 +113,9 @@ class SingleExecutionDetailsController {
       this.execution = this.execution || execution;
       executionService.transformExecution(this.app, execution);
       executionService.synchronizeExecution(this.execution, execution);
-      if (!execution.isActive) {
-        executionScheduler.unsubscribe();
-        executionLoader.unsubscribe();
+      if (execution.isActive) {
+        this.executionScheduler = this.schedulerFactory.createScheduler(5000);
+        this.executionLoader = this.executionScheduler.subscribe(() => this.getExecution());
       }
     }, () => {
       this.execution = null;

--- a/app/scripts/modules/core/src/orchestratedItem/orchestratedItem.transformer.ts
+++ b/app/scripts/modules/core/src/orchestratedItem/orchestratedItem.transformer.ts
@@ -52,7 +52,7 @@ export class OrchestratedItemTransformer {
         get: (): boolean => item.status === 'RUNNING'
       },
       isFailed: {
-        get: (): boolean => item.status === 'TERMINAL'
+        get: (): boolean => item.status === 'TERMINAL' || item.status === 'FAILED_CONTINUE'
       },
       isStopped: {
         get: (): boolean => item.status === 'STOPPED'


### PR DESCRIPTION
A couple of small things I noticed investigating other issues:
* we should consider the `FAILED_CONTINUE` status when computing the `isFailed` property
* the single execution details loads the execution twice when it loads