### PR TITLE
fix(canary): show exception on STOPPED; extract deploy stages

### DIFF
--- a/app/scripts/modules/canary/canary/canaryStage.transformer.js
+++ b/app/scripts/modules/canary/canary/canaryStage.transformer.js
@@ -141,10 +141,8 @@ module.exports = angular.module('spinnaker.canary.transformer', [
             }
           });
 
-          var deployStages = _.filter(execution.stages, {
-            type: 'deploy',
-            parentStageId: deployParent.id,
-          });
+          const deployStages = execution.stages.filter(s =>
+            s.parentStageId === deployParent.id && ['deploy', 'createServerGroup'].includes(s.type));
 
           if (getException(monitorStage)) {
             stage.exceptions.push('Monitor Canary failure: ' + getException(monitorStage));

--- a/app/scripts/modules/core/src/orchestratedItem/orchestratedItem.transformer.ts
+++ b/app/scripts/modules/core/src/orchestratedItem/orchestratedItem.transformer.ts
@@ -46,20 +46,19 @@ export class OrchestratedItemTransformer {
         get: (): string => this.getGeneralException(item) || this.getOrchestrationException(item) || null
       },
       isCompleted: {
-        get: (): boolean => item.status === 'SUCCEEDED' || item.status === 'SKIPPED'
+        get: (): boolean => ['SUCCEEDED', 'SKIPPED'].includes(item.status)
       },
       isRunning: {
         get: (): boolean => item.status === 'RUNNING'
       },
       isFailed: {
-        get: (): boolean => item.status === 'TERMINAL' || item.status === 'FAILED_CONTINUE'
+        get: (): boolean => ['TERMINAL', 'FAILED_CONTINUE', 'STOPPED'].includes(item.status)
       },
       isStopped: {
         get: (): boolean => item.status === 'STOPPED'
       },
       isActive: {
-        get: (): boolean => item.status === 'RUNNING' || item.status === 'SUSPENDED' ||
-                            item.status === 'NOT_STARTED' || item.status === 'PAUSED'
+        get: (): boolean => ['RUNNING', 'SUSPENDED', 'NOT_STARTED', 'PAUSED'].includes(item.status)
       },
       hasNotStarted: {
         get: (): boolean => item.status === 'NOT_STARTED'


### PR DESCRIPTION
At some point, `deploy` became `createServerGroup`, resulting is us losing a fair amount of context (task status, exceptions).

This fixes that, and also treats `STOPPED` as a failed state, since it is a failed state.