### PR TITLE
chore(core): bump package to 0.0.45

### DIFF
--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/core",
-  "version": "0.0.44",
+  "version": "0.0.45",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/core/webpack.config.js
+++ b/app/scripts/modules/core/webpack.config.js
@@ -10,7 +10,6 @@ const exclusionPattern = /(node_modules|\.\.\/deck)/;
 
 module.exports = {
   context: basePath,
-  devtool: 'source-map',
   entry: {
     lib: path.join(__dirname, 'src', 'index.ts'),
   },
@@ -138,7 +137,7 @@ module.exports = {
       mangle: false,
       beautify: true,
       comments: true,
-      sourceMap: true,
+      sourceMap: false,
     }),
     new HappyPack({
       id: 'lib-html',


### PR DESCRIPTION
fix(canary): show exception on STOPPED; extract deploy stages
fix(core): avoid double-load of execution, treat FAILED_CONTINUE as isFailed