### PR TITLE
chore(imports): don't use alias for core imports

### DIFF
--- a/app/scripts/modules/core/src/bootstrap/spinnaker.component.ts
+++ b/app/scripts/modules/core/src/bootstrap/spinnaker.component.ts
@@ -2,7 +2,7 @@ import { IController } from 'angular';
 
 import { bootstrapModule } from './bootstrap.module';
 import { OverrideRegistry } from 'core/overrideRegistry';
-import { IFeatures, SETTINGS } from '@spinnaker/core';
+import { IFeatures, SETTINGS } from 'core/config/settings';
 
 const template = `
   <div class="spinnaker-container">

--- a/app/scripts/modules/core/src/delivery/create/TemplateDescription.tsx
+++ b/app/scripts/modules/core/src/delivery/create/TemplateDescription.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { NgReact } from '@spinnaker/core';
+import { NgReact } from 'core/reactShims/ngReact';
 import { IPipelineTemplate } from 'core/pipeline/config/templates/pipelineTemplate.service';
 
 import './TemplateDescription.less';

--- a/app/scripts/modules/core/src/deploymentStrategy/strategies/rollingredblack/rollingredblack.strategy.ts
+++ b/app/scripts/modules/core/src/deploymentStrategy/strategies/rollingredblack/rollingredblack.strategy.ts
@@ -1,4 +1,4 @@
-import {DeploymentStrategyRegistry} from '@spinnaker/core';
+import {DeploymentStrategyRegistry} from 'core/deploymentStrategy/deploymentStrategy.registry';
 
 DeploymentStrategyRegistry.registerStrategy({
   label: 'Rolling Red/Black (Experimental)',

--- a/app/scripts/modules/core/src/instance/details/console/consoleOutputLink.directive.js
+++ b/app/scripts/modules/core/src/instance/details/console/consoleOutputLink.directive.js
@@ -2,7 +2,7 @@
 
 const angular = require('angular');
 
-import { InstanceTemplates } from '@spinnaker/core';
+import {InstanceTemplates} from 'core/instance/templates';
 
 module.exports = angular
   .module('spinnaker.core.instance.details.console.link', [
@@ -19,7 +19,7 @@ module.exports = angular
         text: '=?'
       },
       controllerAs: 'vm',
-      controller: function($uibModal) {
+      controller: function ($uibModal) {
         this.text = this.text || 'Console Output (Raw)';
         this.showConsoleOutput = function () {
           $uibModal.open({

--- a/app/scripts/modules/core/src/navigation/urlBuilder.registry.ts
+++ b/app/scripts/modules/core/src/navigation/urlBuilder.registry.ts
@@ -1,4 +1,4 @@
-import { IUrlBuilder } from '@spinnaker/core';
+import { IUrlBuilder } from './urlBuilder.service';
 
 export class UrlBuilderRegistry {
   private builders: { [key: string]: IUrlBuilder} = {};

--- a/app/scripts/modules/core/src/pipeline/config/stages/script/scriptExecutionDetails.controller.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/script/scriptExecutionDetails.controller.ts
@@ -3,7 +3,8 @@ import { get } from 'lodash';
 import { StateParams } from '@uirouter/core';
 
 import { BaseExecutionDetailsCtrl, IExecutionDetailsScope } from '../core/baseExecutionDetails.controller';
-import { ExecutionDetailsSectionService, IStage } from '@spinnaker/core';
+import { IStage } from 'core/domain/IStage';
+import { ExecutionDetailsSectionService } from 'core/delivery/details/executionDetailsSection.service';
 
 export class ScriptExecutionDetailsCtrl extends BaseExecutionDetailsCtrl {
 

--- a/app/scripts/modules/core/src/pipeline/config/templates/Variable.spec.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/templates/Variable.spec.tsx
@@ -2,8 +2,9 @@ import { mock } from 'angular';
 import * as React from 'react';
 import { mount, ReactWrapper } from 'enzyme';
 
-import { HELP_CONTENTS, HELP_CONTENTS_REGISTRY, REACT_MODULE } from '@spinnaker/core';
-
+import { REACT_MODULE } from 'core/reactShims/react.module';
+import { HELP_CONTENTS } from 'core/help/help.contents';
+import { HELP_CONTENTS_REGISTRY } from 'core/help/helpContents.registry';
 import { PIPELINE_TEMPLATE_MODULE } from './pipelineTemplate.module';
 import { Variable } from './Variable';
 import { IVariableError, IVariableProps } from './inputs/variableInput.service';

--- a/app/scripts/modules/core/src/search/externalSearch.registry.ts
+++ b/app/scripts/modules/core/src/search/externalSearch.registry.ts
@@ -1,8 +1,11 @@
 import { IPromise } from 'angular';
 import { $q, $log } from 'ngimport';
 
-import { ISearchResult, ISearchResultFormatter, IUrlBuilder, urlBuilderRegistry } from '@spinnaker/core';
+import { urlBuilderRegistry } from 'core/navigation/urlBuilder.registry';
+import { IUrlBuilder } from 'core/navigation/urlBuilder.service';
 import { searchResultFormatterRegistry } from './searchResult/searchResultFormatter.registry';
+import { ISearchResult } from './search.service';
+import { ISearchResultFormatter } from './searchResult/searchResultFormatter.registry';
 
 /**
  * External search registry entries add a section to the infrastructure search


### PR DESCRIPTION
* for files already in the core module, modify the imports to not import
from `@spinnaker/core`.  rather, favor importing from their `core/` or
relative path.
