### PR TITLE
feat(CI/Jenkins): Add parameter type checking/mapped elements to Jenkins task UI.

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/jenkins/jenkinsStage.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/jenkins/jenkinsStage.html
@@ -65,9 +65,38 @@
         <b class="break-word">{{parameter.name}}</b>
         <help-field content="{{parameter.description}}" ng-if="parameter.description"></help-field>
       </div>
-      <div class="col-md-5">
-        <input disabled ng-if="useDefaultParameters[parameter.name]" type="text" class="form-control input-sm" value="{{parameter.defaultValue}}"/>
-        <input ng-if="!useDefaultParameters[parameter.name]" type="text" class="form-control input-sm" ng-model="userSuppliedParameters[parameter.name]" ng-change="updateParam(parameter.name)"/>
+      <div class="col-md-5" ng-switch on="parameter.type">
+        <div ng-switch-when="PasswordParameterDefinition">
+          <!-- Passwords do not expose their defaults, for obvious reasons, so we can skip this -->
+          <input ng-if="!useDefaultParameters[parameter.name]" type="password" class="form-control input-sm" ng-model="userSuppliedParameters[parameter.name]" ng-change="updateParam(parameter.name)"/>
+        </div>
+        <div ng-switch-when="BooleanParameterDefinition">
+          <input disabled ng-if="useDefaultParameters[parameter.name] && parameter.defaultValue == 'true'" type="checkbox" class="input-sm" checked/>
+          <input disabled ng-if="useDefaultParameters[parameter.name] && parameter.defaultValue == 'false'" type="checkbox" class="input-sm"/>
+          <input ng-if="!useDefaultParameters[parameter.name]" type="checkbox" class="input-sm" ng-model="userSuppliedParameters[parameter.name]" ng-change="updateParam(parameter.name)"/>
+        </div>
+        <div ng-switch-when="TextParameterDefinition">
+          <textarea disabled ng-if="useDefaultParameters[parameter.name]" class="form-control input-sm" ng-model="parameter.defaultValue" style="max-width: 100%"/>
+          <textarea ng-if="!useDefaultParameters[parameter.name]" class="form-control input-sm" ng-model="userSuppliedParameters[parameter.name]" ng-change="updateParam(parameter.name)" style="max-width: 100%"/>
+        </div>
+        <div ng-switch-when="ChoiceParameterDefinition">
+          <ui-select class="form-control input-sm" ng-if="!useDefaultParameters[parameter.name]" ng-model="userSuppliedParameters[parameter.name]">
+            <ui-select-match placeholder="Select a choice...">{{$select.selected}}</ui-select-match>
+            <ui-select-choices repeat="choice in parameter.choices | filter: $select.search">
+              <span ng-bind-html="choice | highlight: $select.search"></span>
+            </ui-select-choices>
+          </ui-select>
+          <ui-select class="form-control input-sm" ng-disabled="useDefaultParameters[parameter.name]" search-enabled="false" ng-if="useDefaultParameters[parameter.name]" ng-model="parameter.defaultValue">
+            <ui-select-match placeholder="Select a choice...">{{$select.selected}}</ui-select-match>
+            <ui-select-choices repeat="choice in parameter.choices | filter: $select.search">
+              <span ng-bind-html="choice | highlight: $select.search"></span>
+            </ui-select-choices>
+          </ui-select>
+        </div>
+        <div ng-switch-default>
+          <input disabled ng-if="useDefaultParameters[parameter.name]" type="text" class="form-control input-sm" value="{{parameter.defaultValue}}"/>
+          <input ng-if="!useDefaultParameters[parameter.name]" type="text" class="form-control input-sm" ng-model="userSuppliedParameters[parameter.name]" ng-change="updateParam(parameter.name)"/>
+        </div>
       </div>
       <div class="checkbox col-md-4" ng-if="parameter.defaultValue!==null">
         <label>


### PR DESCRIPTION
Changes were made to the Jenkins task UI used by Deck to support
specific parameter types already provided by Igor. The default was left as
input:text to keep the functionality for unknown/unspecified parameter types.

Recommendations/changes welcome.

[https://github.com/spinnaker/spinnaker/issues/1872](Issue)