### PR TITLE
fix(aws/loadbalancer): ensure timeout < interval

### DIFF
--- a/app/scripts/modules/amazon/src/loadBalancer/configure/classic/advancedSettings.html
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/classic/advancedSettings.html
@@ -3,16 +3,24 @@
 
     <div class="form-group">
       <div class="col-md-6 sm-label-right">
-        <b>Timeout</b><help-field key="ctrl.loadBalancerCommand.advancedSettings.healthTimeout"/>
+        <b>Timeout</b><help-field key="loadBalancer.advancedSettings.healthTimeout"/>
       </div>
       <div class="col-md-4">
-        <input class="form-control input-sm" type="number" min="0" ng-model="ctrl.loadBalancerCommand.healthTimeout"/>
+        <input class="form-control input-sm"
+               type="number"
+               name="healthTimeout"
+               min="0"
+               ng-max="ctrl.loadBalancerCommand.healthInterval - 1"
+               ng-model="ctrl.loadBalancerCommand.healthTimeout"/>
+      </div>
+      <div class="col-md-12 col-md-offset-6" ng-if="form.healthTimeout.$error.max">
+        <validation-error message="The health timeout must be less than the health interval."></validation-error>
       </div>
     </div>
 
     <div class="form-group">
       <div class="col-md-6 sm-label-right">
-        <b>Interval</b><help-field key="ctrl.loadBalancerCommand.advancedSettings.healthInterval"/>
+        <b>Interval</b><help-field key="loadBalancer.advancedSettings.healthInterval"/>
       </div>
       <div class="col-md-4">
         <input class="form-control input-sm" type="number" min="0" ng-model="ctrl.loadBalancerCommand.healthInterval"/>
@@ -21,7 +29,7 @@
 
     <div class="form-group">
       <div class="col-md-6 sm-label-right">
-        <b>Healthy Threshold</b><help-field key="ctrl.loadBalancerCommand.advancedSettings.healthyThreshold"/>
+        <b>Healthy Threshold</b><help-field key="loadBalancer.advancedSettings.healthyThreshold"/>
       </div>
       <div class="col-md-4">
         <input class="form-control input-sm" type="number" min="0" ng-model="ctrl.loadBalancerCommand.healthyThreshold"/>
@@ -30,7 +38,7 @@
 
     <div class="form-group">
       <div class="col-md-6 sm-label-right">
-        <b>Unhealthy Threshold</b><help-field key="ctrl.loadBalancerCommand.advancedSettings.unhealthyThreshold"/>
+        <b>Unhealthy Threshold</b><help-field key="loadBalancer.advancedSettings.unhealthyThreshold"/>
       </div>
       <div class="col-md-4">
         <input class="form-control input-sm" type="number" min="0" ng-model="ctrl.loadBalancerCommand.unhealthyThreshold"/>

--- a/app/scripts/modules/core/src/help/help.contents.ts
+++ b/app/scripts/modules/core/src/help/help.contents.ts
@@ -77,8 +77,8 @@ module(HELP_CONTENTS, [])
         <p>If you want to start from scratch, select "None".</p>
         <p>You can always edit the cluster configuration after you've created it.</p>`,
 
-    'loadBalancer.advancedSettings.healthTimeout': '<p>Configures the timeout, in seconds, for reaching the healthCheck target.</p><p> Default: <b>5</b></p>',
-    'loadBalancer.advancedSettings.healthInterval': '<p>Configures the interval, in seconds, between ELB health checks.</p><p>Default: <b>10</b></p>',
+    'loadBalancer.advancedSettings.healthTimeout': '<p>Configures the timeout, in seconds, for reaching the healthCheck target.  Must be less than the interval.</p><p> Default: <b>5</b></p>',
+    'loadBalancer.advancedSettings.healthInterval': '<p>Configures the interval, in seconds, between ELB health checks.  Must be greater than the timeout.</p><p>Default: <b>10</b></p>',
     'loadBalancer.advancedSettings.healthyThreshold': '<p>Configures the number of healthy observations before reinstituting an instance into the ELB’s traffic rotation.</p><p>Default: <b>10</b></p>',
     'loadBalancer.advancedSettings.unhealthyThreshold': '<p>Configures the number of unhealthy observations before deservicing an instance from the ELB.</p><p>Default: <b>2</b></p>',
     'pipeline.config.resizeAsg.action': `


### PR DESCRIPTION
* add an error check and message around ensuring the load balancer
health timeout is less than the health interval.
* updated help bubble text to include field value requirements for timeout and interval.
* fix broken help bubbles for classic ELB advanced settings.