### PR TITLE
fix(core): fix alignment of copy-to-clipboard icon

### DIFF
--- a/app/scripts/modules/core/src/presentation/details.less
+++ b/app/scripts/modules/core/src/presentation/details.less
@@ -103,10 +103,9 @@
       word-break: break-all;
       padding: 15px 0;
       display: table;
-      .copy-to-clipboard .glyphicon{
+      .copy-to-clipboard .glyphicon {
         color: inherit;
         font-size: 150%;
-        padding-top: 10px;
       }
       .glyphicon, .icon {
         display: inline-block;


### PR DESCRIPTION
At some point, the icon got shifted down by 10px. This aligns it with the text.