### PR TITLE
fix(core): remove blur handler on HoverablePopover

### DIFF
--- a/app/scripts/modules/core/src/presentation/HoverablePopover.tsx
+++ b/app/scripts/modules/core/src/presentation/HoverablePopover.tsx
@@ -156,7 +156,6 @@ export class HoverablePopover extends React.Component<IHoverablePopoverProps, IH
           <PopoverRenderer
             onMouseOver={this.handleMouseEvent}
             onMouseLeave={this.handleMouseEvent}
-            onBlur={this.handleMouseEvent}
             id={this.props.id}
             title={this.props.title}
             className={this.props.className}


### PR DESCRIPTION
If a popover includes two input elements, navigating between them causing the popover to close, which is surprising.