### PR TITLE
fix(pipelines): always show running executions and keep count in sync

### DIFF
--- a/app/scripts/modules/core/src/delivery/delivery.dataSource.js
+++ b/app/scripts/modules/core/src/delivery/delivery.dataSource.js
@@ -17,7 +17,7 @@ module.exports = angular
   .run(function($q, applicationDataSourceRegistry, executionService, pipelineConfigService, clusterService) {
 
     let addExecutions = (application, executions) => {
-      executionService.transformExecutions(application, executions);
+      executionService.transformExecutions(application, executions, application.executions.data);
       return $q.when(executionService.addExecutionsToApplication(application, executions));
     };
 
@@ -47,7 +47,12 @@ module.exports = angular
 
     let runningExecutionsLoaded = (application) => {
       clusterService.addExecutionsToServerGroups(application);
+      executionService.mergeRunningExecutionsIntoExecutions(application);
       application.getDataSource('serverGroups').dataUpdated();
+    };
+
+    let executionsLoaded = (application) => {
+      executionService.removeCompletedExecutionsFromRunningData(application);
     };
 
     if (SETTINGS.feature.pipelines !== false) {
@@ -61,6 +66,7 @@ module.exports = angular
         activeState: '**.pipelines.**',
         loader: loadExecutions,
         onLoad: addExecutions,
+        afterLoad: executionsLoaded,
         lazy: true,
         badge: 'runningExecutions',
         description: 'Orchestrated deployment management'

--- a/app/scripts/modules/core/src/delivery/executionGroup/execution/Execution.tsx
+++ b/app/scripts/modules/core/src/delivery/executionGroup/execution/Execution.tsx
@@ -90,6 +90,7 @@ export class Execution extends React.Component<IExecutionProps, IExecutionState>
           if (this.mounted) {
             const dataSource = application.getDataSource(this.props.dataSourceKey);
             executionService.updateExecution(application, updated, dataSource);
+            executionService.removeCompletedExecutionsFromRunningData(application);
           }
           refreshing = false;
         });

--- a/app/scripts/modules/core/src/delivery/filter/executionFilter.service.spec.ts
+++ b/app/scripts/modules/core/src/delivery/filter/executionFilter.service.spec.ts
@@ -1,13 +1,10 @@
 import {mock} from 'angular';
 
-import {Application} from 'core/application/application.model';
 import {APPLICATION_MODEL_BUILDER, ApplicationModelBuilder} from 'core/application/applicationModel.builder';
 import {EXECUTION_FILTER_MODEL, ExecutionFilterModel} from 'core/delivery/filter/executionFilter.model';
 import {EXECUTION_FILTER_SERVICE, ExecutionFilterService} from './executionFilter.service';
-import {IExecution} from 'core/domain/IExecution';
 
 describe('Service: executionFilterService', function () {
-  const debounceTimeout = 30;
 
   let modelBuilder: ApplicationModelBuilder;
   let service: ExecutionFilterService;
@@ -44,43 +41,4 @@ describe('Service: executionFilterService', function () {
     });
   });
 
-  describe('Updating execution groups', function () {
-
-    it('limits executions per pipeline', function (done) {
-      const application: Application = modelBuilder.createApplication('app', {key: 'executions', lazy: true}, {key: 'pipelineConfigs', lazy: true});
-      application.getDataSource('executions').data = [
-        { pipelineConfigId: '1', name: 'pipeline 1', endTime: 1, stages: [] },
-        { pipelineConfigId: '1', name: 'pipeline 1', endTime: 2, stages: [] },
-        { pipelineConfigId: '1', name: 'pipeline 1', endTime: 3, stages: [] },
-        { pipelineConfigId: '2', name: 'pipeline 2', endTime: 1, stages: [] },
-      ];
-      application.getDataSource('pipelineConfigs').data = [
-        { name: 'pipeline 1', pipelineConfigId: '1' },
-        { name: 'pipeline 2', pipelineConfigId: '2' },
-      ];
-
-      model.asFilterModel.sortFilter.count = 2;
-      model.asFilterModel.sortFilter.groupBy = 'none';
-
-      service.updateExecutionGroups(application);
-
-      setTimeout(() => {
-        expect(model.asFilterModel.groups.length).toBe(1);
-        expect(model.asFilterModel.groups[0].executions.length).toBe(3);
-        expect(model.asFilterModel.groups[0].executions.filter((ex: IExecution) => ex.pipelineConfigId === '1').length).toBe(2);
-        expect(model.asFilterModel.groups[0].executions.filter((ex: IExecution) => ex.pipelineConfigId === '2').length).toBe(1);
-
-        model.asFilterModel.sortFilter.groupBy = 'name';
-        service.updateExecutionGroups(application);
-
-        setTimeout(() => {
-          expect(model.asFilterModel.groups.length).toBe(2);
-          expect(model.asFilterModel.groups[0].executions.length).toBe(2);
-          expect(model.asFilterModel.groups[1].executions.length).toBe(1);
-          done();
-        }, debounceTimeout);
-      }, debounceTimeout)
-    });
-
-  });
 });

--- a/app/scripts/modules/core/src/delivery/filter/executionFilter.service.ts
+++ b/app/scripts/modules/core/src/delivery/filter/executionFilter.service.ts
@@ -149,10 +149,9 @@ export class ExecutionFilterService {
 
   private groupExecutions(filteredExecutions: IExecution[], application: Application): IExecutionGroup[] {
     const groups: IExecutionGroup[] = [];
-    // limit based on sortFilter.count
     let executions: IExecution[] = [];
     forOwn(groupBy(filteredExecutions, 'name'), (groupedExecutions) => {
-      executions = executions.concat(groupedExecutions.sort((a, b) => this.executionSorter(a, b)).slice(0, this.executionFilterModel.asFilterModel.sortFilter.count));
+      executions = executions.concat(groupedExecutions.sort((a, b) => this.executionSorter(a, b)));
     });
 
     if (this.executionFilterModel.asFilterModel.sortFilter.groupBy === 'name') {


### PR DESCRIPTION
This addresses a source of confusion for users who see a discrepancy between the running executions badge counter and the badge counters on individual pipelines due to a couple of things:

1. There are two data sources in play: one to get the overall count (`runningExecutions`), another to get the executions for each pipeline (`executions`), and they are both loaded asynchronously, so they often won't reflect the same data.
2. The `executions` data source has a limit based on a UI control that determines how many pipelines it loads. If one pipeline has five active executions going, but the UI control is set to "2", the user will only see "2" in the badge on that pipeline and wonder where the other three running executions are.

With this change, the numbers should always make sense, except when the user has applied side filters, but even then, it should be fairly obvious what's happening. Even if the user has the UI control set to "1", all running executions will be visible (up to 30 per pipeline - if there are more than 30 active executions for a single pipeline, the user has much bigger problems).

In a simple world, this would be a simple problem, but, due to the sheer size of the execution data and the number of moving parts in the UI, the pipeline loading/rendering/syncing code is incredibly complex and extremely optimized. I've considered about a dozen edge cases, but guessing there are a few more that will surface once this is in production.

@christopherthielen PTAL