### PR TITLE
fix(dcos): Add DC/OS to the list of default providers

### DIFF
--- a/halconfig/settings.js
+++ b/halconfig/settings.js
@@ -65,7 +65,7 @@ var netflixMode = false;
 window.spinnakerSettings = {
   version: version,
   checkForUpdates: false,
-  defaultProviders: ['aws', 'gce', 'azure', 'cf', 'kubernetes', 'titus', 'openstack', 'oraclebmcs'],
+  defaultProviders: ['aws', 'gce', 'azure', 'cf', 'kubernetes', 'titus', 'openstack', 'oraclebmcs', 'dcos'],
   feedbackUrl: feedbackUrl,
   gateUrl: gateHost,
   bakeryDetailUrl: bakeryDetailUrl,


### PR DESCRIPTION
This was inadvertently left out of #4015.