### PR TITLE
fix(core): rename canary score component

### DIFF
--- a/app/scripts/modules/core/src/canary/canaryScores.component.ts
+++ b/app/scripts/modules/core/src/canary/canaryScores.component.ts
@@ -5,4 +5,4 @@ import { CanaryScores } from './CanaryScores';
 
 export const CANARY_SCORES_CONFIG_COMPONENT = 'spinnaker.core.canaryScores.component';
 module(CANARY_SCORES_CONFIG_COMPONENT, [])
-  .component('canaryScores', react2angular(CanaryScores, ['onChange', 'successfulHelpFieldId', 'successfulLabel', 'successfulScore', 'unhealthyHelpFieldId', 'unhealthyLabel', 'unhealthyScore']));
+  .component('kayentaCanaryScores', react2angular(CanaryScores, ['onChange', 'successfulHelpFieldId', 'successfulLabel', 'successfulScore', 'unhealthyHelpFieldId', 'unhealthyLabel', 'unhealthyScore']));


### PR DESCRIPTION
There's a directive naming collision with our internal build, so renaming this for now to get a fix out.

cc @danielpeach 