### PR TITLE
chore(core): bump package to 0.0.53

### DIFF
--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/core",
-  "version": "0.0.52",
+  "version": "0.0.53",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
fix(core/utils): Fix task running duration when longer than 31 days
fix(core): add createServerGroup to list of candidate running stages
fix(core): rename canary score component