### PR TITLE
fix(core): Fix deploy template selection when one server group and no template selection is disabled

### DIFF
--- a/app/scripts/modules/core/src/serverGroup/configure/common/deployInitializer.component.ts
+++ b/app/scripts/modules/core/src/serverGroup/configure/common/deployInitializer.component.ts
@@ -68,6 +68,7 @@ export class DeployInitializerController implements IController {
     });
 
     if (this.templates.length === 1) {
+      this.selectedTemplate = this.templates[0];
       this.useTemplate();
     }
   }


### PR DESCRIPTION
When `viewState.disableNoTemplateSelection` is not set, `selectedTemplate` never gets set. If there is only one template, this control assumes that single template is already selected.



...
This took me way too long to figure out.