### PR TITLE
feat(provider/kubernetes): add dns policy

### DIFF
--- a/app/scripts/modules/kubernetes/help/kubernetes.help.ts
+++ b/app/scripts/modules/kubernetes/help/kubernetes.help.ts
@@ -100,6 +100,10 @@ const helpContents: {[key: string]: string} = {
   'kubernetes.service.externalIps': `
       IP addresses for which nodes in the cluster also accept traffic. This is not managed by Kubernetes and the
       responsibility of the user to configure.`,
+  'kubernetes.pod.dnsPolicy':`
+      <p>Set DNS policy for containers within the pod.</p>
+      <p>Defaults to <b>ClusterFirst</b>.</p>
+      <p>To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to <b>ClusterFirstWithHostNet</b>.</p>`,
   'kubernetes.pod.volume': `
       <p>A storage volume to be mounted and shared by containers in this pod. The lifecycle depends on the volume type selected.</p>
       <p><b>CONFIGMAP</b>: Intended to act as a reference to multiple properties files. Similar to the /etc directory, and the files within, on a Linux computer.</p>

--- a/app/scripts/modules/kubernetes/pipeline/stages/runJob/runJobStage.html
+++ b/app/scripts/modules/kubernetes/pipeline/stages/runJob/runJobStage.html
@@ -30,6 +30,15 @@
     </div>
   </stage-config-field>
 
+  <stage-config-field label="DNS Policy">
+    <div>
+        <select class="form-control input-sm"
+                ng-model="ctrl.stage.dnsPolicy"
+                ng-options="option for option in ctrl.policies">
+        </select>
+    </div>
+  </stage-config-field>
+
   <stage-config-field label="Image">
     <div class="form-group" ng-if="ctrl.hasDockerPipelineTriggers()">
       <div>

--- a/app/scripts/modules/kubernetes/pipeline/stages/runJob/runJobStage.js
+++ b/app/scripts/modules/kubernetes/pipeline/stages/runJob/runJobStage.js
@@ -39,6 +39,8 @@ module.exports = angular.module('spinnaker.kubernetes.pipeline.stage.runJobStage
     this.pipeline = $scope.pipeline;
     this.container = null;
 
+    this.policies = ['ClusterFirst', 'Default', 'ClusterFirstWithHostNet'];
+
     const buildImageDescriptor = (image) => {
       let descriptor = `${image.account}/${image.repository}`;
       if (image.tag) {
@@ -55,6 +57,9 @@ module.exports = angular.module('spinnaker.kubernetes.pipeline.stage.runJobStage
       _.set(this.stage, 'container.imageDescription.fromTrigger', false);
     }
 
+    if (!this.stage.dnsPolicy) {
+      this.stage.dnsPolicy = 'ClusterFirst';
+    }
 
     if (this.stage.container.imageDescription.fromTrigger === true) {
       this.container = buildImageDescriptor(this.stage.container.imageDescription);

--- a/app/scripts/modules/kubernetes/serverGroup/configure/configure.kubernetes.module.js
+++ b/app/scripts/modules/kubernetes/serverGroup/configure/configure.kubernetes.module.js
@@ -6,6 +6,7 @@ module.exports = angular.module('spinnaker.serverGroup.configure.kubernetes', [
   require('./configuration.service.js'),
   require('./CommandBuilder.js'),
   require('./wizard/BasicSettings.controller.js'),
+  require('./wizard/advancedSettings.controller.js'),
   require('./wizard/Clone.controller.js'),
   require('./wizard/loadBalancers.controller.js'),
   require('./wizard/volumes.controller.js'),

--- a/app/scripts/modules/kubernetes/serverGroup/configure/wizard/advancedSettings.controller.js
+++ b/app/scripts/modules/kubernetes/serverGroup/configure/wizard/advancedSettings.controller.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const angular = require('angular');
+
+module.exports = angular.module('spinnaker.serverGroup.configure.kubernetes.advancedSettings', [])
+  .controller('kubernetesServerGroupAdvancedSettingsController', function($scope) {
+
+    if (!$scope.command.dnsPolicy) {
+      $scope.command.dnsPolicy = 'ClusterFirst';
+    }
+
+    this.policies = ['ClusterFirst', 'Default', 'ClusterFirstWithHostNet'];
+  });

--- a/app/scripts/modules/kubernetes/serverGroup/configure/wizard/advancedSettings.html
+++ b/app/scripts/modules/kubernetes/serverGroup/configure/wizard/advancedSettings.html
@@ -1,5 +1,19 @@
-<ng-form name="advancedSettings">
+<ng-form name="advancedSettings" ng-controller="kubernetesServerGroupAdvancedSettingsController as advancedController">
   <div class="form-group form-horizontal">
+
+
+     <div class="form-group">
+      <div class="col-md-4 sm-label-right">
+        DNS Policy
+        <help-field key="kubernetes.pod.dnsPolicy"></help-field>
+      </div>
+      <div class="col-md-7">
+        <select class="form-control input-sm"
+                ng-model="command.dnsPolicy"
+                ng-options="option for option in advancedController.policies">
+        </select>
+      </div>
+    </div>
 
     <div class="form-group">
       <div class="col-md-4 sm-label-right">


### PR DESCRIPTION
adds support for dns policy on server groups and run job stages.

https://kubernetes.io/docs/api-reference/v1.7/#pod-v1-core

Corresponding Clouddriver PR: spinnaker/clouddriver#1800

@danielpeach PTAL