### PR TITLE
chore(deck): removed executionEngine flag and force cancel option

### DIFF
--- a/app/scripts/modules/core/src/cancelModal/cancel.html
+++ b/app/scripts/modules/core/src/cancelModal/cancel.html
@@ -15,23 +15,6 @@
         </div>
       </div>
       <task-reason command="params"></task-reason>
-      <div class="force-cancel" ng-if="params.forceable">
-        <div class="row">
-          <div class="col-md-3 sm-label-right">
-            <label for="force">Force</label>
-          </div>
-          <div class="col-md-7">
-            <input id="force" type="checkbox" ng-model="params.force">
-          </div>
-        </div>
-        <div class="row" ng-if="params.forceable && params.force">
-          <div class="col-md-push-3 col-md-7">
-            <div class="alert alert-info" role="alert">
-              <strong>Note:</strong> This option will force the pipeline to cancel. It should only be used if the task or pipeline hangs.
-            </div>
-          </div>
-        </div>
-      </div>
     </div>
     <div class="modal-footer">
       <button class="btn btn-default"

--- a/app/scripts/modules/core/src/cancelModal/cancelModal.service.ts
+++ b/app/scripts/modules/core/src/cancelModal/cancelModal.service.ts
@@ -6,7 +6,6 @@ export interface ICancelModalParams {
   body?: string;
   buttonText: string;
   cancelButtonText?: string;
-  forceable?: boolean;
   header: string;
   submitMethod: (reason: string, force?: boolean) => ng.IPromise<any>;
 }
@@ -14,8 +13,7 @@ export interface ICancelModalParams {
 export class CancelModalService {
 
   private defaults: Partial<ICancelModalParams> = {
-    cancelButtonText: 'Cancel',
-    forceable: false
+    cancelButtonText: 'Cancel'
   };
 
   public constructor(private $uibModal: IModalService, private $sce: ng.ISCEService) {}

--- a/app/scripts/modules/core/src/delivery/executionGroup/execution/Execution.tsx
+++ b/app/scripts/modules/core/src/delivery/executionGroup/execution/Execution.tsx
@@ -174,7 +174,6 @@ export class Execution extends React.Component<IExecutionProps, IExecutionState>
     cancelModalService.confirm({
       header: `Really stop execution of ${this.props.execution.name}?`,
       buttonText: `Stop running ${this.props.execution.name}`,
-      forceable: this.props.execution.executionEngine !== 'v1',
       body: hasDeployStage ? '<b>Note:</b> Any deployments that have begun will continue and need to be cleaned up manually.' : null,
       submitMethod: (reason, force) => executionService.cancelExecution(this.props.application, this.props.execution.id, force, reason)
     });

--- a/app/scripts/modules/core/src/domain/IExecution.ts
+++ b/app/scripts/modules/core/src/domain/IExecution.ts
@@ -13,7 +13,6 @@ export interface IExecution extends IOrchestratedItem {
   stageSummaries?: IExecutionStageSummary[];
   isStrategy?: boolean;
   name?: string;
-  executionEngine?: string;
   stringVal?: string;
   isComplete?: boolean;
   graphStatusHash?: string;

--- a/app/scripts/modules/core/src/domain/IPipeline.ts
+++ b/app/scripts/modules/core/src/domain/IPipeline.ts
@@ -4,7 +4,6 @@ import {ITrigger} from './ITrigger';
 export interface IPipeline {
   application: string;
   description?: string;
-  executionEngine: string;
   id: string;
   index: number;
   isNew?: boolean;

--- a/app/scripts/modules/core/src/pipeline/config/services/piplineConfig.service.spec.ts
+++ b/app/scripts/modules/core/src/pipeline/config/services/piplineConfig.service.spec.ts
@@ -38,7 +38,6 @@ describe('pipelineConfigService', () => {
       keepWaitingPipelines: false,
       strategy: false,
       parallel: true,
-      executionEngine: 'v2',
       triggers: [],
       stages: [],
       parameterConfig: null,

--- a/app/scripts/modules/core/src/pipeline/config/validation/pipelineConfig.validator.spec.ts
+++ b/app/scripts/modules/core/src/pipeline/config/validation/pipelineConfig.validator.spec.ts
@@ -54,7 +54,6 @@ describe('pipelineConfigValidator', () => {
       limitConcurrent: true,
       keepWaitingPipelines: true,
       parallel: true,
-      executionEngine: 'v2',
       stages: stages,
       triggers: triggers,
     };


### PR DESCRIPTION
The executionEngine field is redundant as there's only one now and we will hopefully never create a v4.

Force cancel does nothing as of v3.