### PR TITLE
chore(core): bump package to 0.0.54

### DIFF
--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/core",
-  "version": "0.0.53",
+  "version": "0.0.54",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
* fix(core): Fix deploy template selection when one server group and no template selection is disabled
* style(core/styleguide) Cataloging Spinnaker styles in to a style guide
* refactor(core + canary): move shared canary components back to canary module
* fix(core): do not overwrite target percentages on rolling red/black
* chore(deck): removed executionEngine flag and force cancel option
* feat(pipeline_templates): adds link to template json