### PR TITLE
chore(styleguide): fix styleguide config paths

### DIFF
--- a/app/scripts/modules/core/src/styleguide/src/styles/postcss.config.js
+++ b/app/scripts/modules/core/src/styleguide/src/styles/postcss.config.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 module.exports = {
   plugins: {
     'postcss-import': {},
@@ -6,9 +8,9 @@ module.exports = {
     'postcss-scopeit': {scopeName: 'styleguide'},
     'postcss-style-guide': {
       project: 'Spinnaker',
-      dest: './app/scripts/modules/core/src/styleguide/public/styleguide.html',
+      dest: path.join(__dirname, '..', '..', 'src', 'public', 'styleguide.html'),
       showCode: false,
-      themePath: './app/scripts/modules/core/src/styleguide/src/styleguide-template/'
+      themePath: path.join(__dirname, '..', '..', 'src', 'styleguide-template')
     },
     'cssnano': {}
   }


### PR DESCRIPTION
The relative path wasn't working so great for the core library, in that it was preventing it from being built.

Seems like a great case for the old `path` hammer.