### PR TITLE
feat(core): include address in context for instance links

### DIFF
--- a/app/scripts/modules/core/src/application/config/links/applicationLinks.component.html
+++ b/app/scripts/modules/core/src/application/config/links/applicationLinks.component.html
@@ -1,7 +1,18 @@
 <div class="row">
   <div class="col-md-9">
-    <p class="panel-description">Links appear in the instance details panel and provide a shortcut to common features,
-      such as logs, health, etc.</p>
+    <p>
+      Links appear in the instance details panel and provide a shortcut to common features,
+      such as logs, health, etc.
+    </p>
+    <p>
+      Links paths are templates - you can customize them using a number of field attributes available on the instance.
+    </p>
+    <p>
+      <a href="https://www.spinnaker.io/guides/user/instance-links/#customizing-application-links" target="_blank">
+        Check out the guide
+      </a>
+      for examples and to see what fields are available for your cloud provider.
+    </p>
   </div>
   <div class="col-md-3 text-right">
     <button class="btn btn-sm btn-default" ng-click="$ctrl.editJson()">

--- a/app/scripts/modules/core/src/instance/details/instanceLinks.component.js
+++ b/app/scripts/modules/core/src/instance/details/instanceLinks.component.js
@@ -25,7 +25,7 @@ module.exports = angular
           let url = link.path;
           // handle interpolated variables
           if (url.includes('{{')) {
-            url = $interpolate(url)(this.instance);
+            url = $interpolate(url)(Object.assign({}, this.instance, {ipAddress: this.address}));
           }
           // handle relative paths
           if (!url.includes('//')) {


### PR DESCRIPTION
Allows users to configure HTTPS-specific links to instances when required, e.g. `https://{{ipAddress}}:7002/something`, without having to specify `privateIpAddress` or `publicDnsName`.

Also adding a link to the guide on spinnaker.io to help folks with self-service on this feature.