### PR TITLE
feat(core): allow customization of manual judgment action labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ build/
 dist/
 lib/
 transpiled/
+app/scripts/modules/core/src/styleguide/src/public/
 
 # Test Results
 test-results.xml

--- a/app/scripts/modules/core/src/delivery/executionGroup/execution/Execution.tsx
+++ b/app/scripts/modules/core/src/delivery/executionGroup/execution/Execution.tsx
@@ -29,6 +29,7 @@ export interface IExecutionProps {
   standalone?: boolean;
   title?: string;
   dataSourceKey?: string;
+  showAccountLabels?: boolean;
 }
 
 export interface IExecutionState {
@@ -296,7 +297,8 @@ export class Execution extends React.Component<IExecutionProps, IExecutionState>
         <div className={`execution-overview group-by-${this.state.sortFilter.groupBy}`}>
           { this.props.title && (
             <h4 className="execution-name">
-             {this.props.title}
+              {this.props.showAccountLabels && accountLabels}
+              {this.props.title}
             </h4>
           )}
           { showExecutionName && (

--- a/app/scripts/modules/core/src/pipeline/config/stages/manualJudgment/ManualJudgmentApproval.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/manualJudgment/ManualJudgmentApproval.tsx
@@ -117,7 +117,7 @@ export class ManualJudgmentApproval extends React.Component<IManualJudgmentAppro
                 { this.isSubmitting('continue') && (
                   <ButtonBusyIndicator/>
                 )}
-                Continue
+                {stage.context.continueButtonLabel || 'Continue'}
               </button>
               <button
                 className="btn btn-danger"
@@ -127,7 +127,7 @@ export class ManualJudgmentApproval extends React.Component<IManualJudgmentAppro
                 { this.isSubmitting('stop') && (
                   <ButtonBusyIndicator/>
                 )}
-                Stop
+                {stage.context.stopButtonLabel || 'Stop'}
               </button>
             </div>
           </div>


### PR DESCRIPTION
Actually three things:
1. Allow "Stop" and "Continue" button labels to be customized
2. Allow execution account labels to be shown regardless of sort filter status
3. add the styleguide generated file to .gitignore