### PR TITLE
chore(amazon): bump package to 0.0.28

### DIFF
--- a/app/scripts/modules/amazon/package.json
+++ b/app/scripts/modules/amazon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/amazon",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
Not sure what's going on, but running `npm publish` did not run the `prepare` script - just pushed what was already there to npm.

What I'm saying is this is the same as version 0.0.27 except it actually contains the changes that are in the src directory of 27, just not in the build lib.js artifact.

Something strange is going on. Not sure if it's just me...