### PR TITLE
feat(amazon): make root volume size configurable on bake stage

### DIFF
--- a/app/scripts/modules/amazon/src/aws.settings.ts
+++ b/app/scripts/modules/amazon/src/aws.settings.ts
@@ -24,6 +24,7 @@ export interface IAWSProviderSettings extends IProviderSettings {
   metrics?: {
     customNamespaces?: string[];
   };
+  minRootVolumeSize?: number;
 }
 
 export const AWSProviderSettings: IAWSProviderSettings = <IAWSProviderSettings>SETTINGS.providers.aws || { defaults: {} };

--- a/app/scripts/modules/amazon/src/pipeline/stages/bake/awsBakeStage.js
+++ b/app/scripts/modules/amazon/src/pipeline/stages/bake/awsBakeStage.js
@@ -3,6 +3,8 @@
 const angular = require('angular');
 import _ from 'lodash';
 
+import { AWSProviderSettings } from 'amazon/aws.settings';
+
 import {
   PipelineTemplates,
   BakeExecutionLabel,
@@ -52,6 +54,8 @@ module.exports = angular.module('spinnaker.amazon.pipeline.stage.bakeStage', [
 
     $scope.viewState = {
       loading: true,
+      roscoMode: SETTINGS.feature.roscoMode,
+      minRootVolumeSize: AWSProviderSettings.minRootVolumeSize,
     };
 
     function initialize() {
@@ -91,7 +95,6 @@ module.exports = angular.module('spinnaker.amazon.pipeline.stage.bakeStage', [
         if (!$scope.stage.baseLabel && $scope.baseLabelOptions && $scope.baseLabelOptions.length) {
           $scope.stage.baseLabel = $scope.baseLabelOptions[0];
         }
-        $scope.viewState.roscoMode = SETTINGS.feature.roscoMode;
         $scope.showAdvancedOptions = showAdvanced();
         $scope.viewState.loading = false;
       });
@@ -108,7 +111,7 @@ module.exports = angular.module('spinnaker.amazon.pipeline.stage.bakeStage', [
     function showAdvanced() {
       const stg = $scope.stage;
       return !!(stg.templateFileName || (stg.extendedAttributes && _.size(stg.extendedAttributes) > 0) ||
-        stg.varFileName || stg.baseName || stg.baseAmi || stg.amiName || stg.amiSuffix);
+        stg.varFileName || stg.baseName || stg.baseAmi || stg.amiName || stg.amiSuffix || stg.rootVolumeSize);
     }
 
     this.addExtendedAttribute = function() {

--- a/app/scripts/modules/amazon/src/pipeline/stages/bake/bakeStage.html
+++ b/app/scripts/modules/amazon/src/pipeline/stages/bake/bakeStage.html
@@ -106,6 +106,14 @@
         <input type="text" class="form-control input-sm"
                ng-model="stage.varFileName"/>
       </stage-config-field>
+      <stage-config-field label="Root Volume Size"
+                          ng-if="viewState.minRootVolumeSize">
+        <input type="number"
+               class="form-control input-sm"
+               style="width: 80px; display: inline-block"
+               ng-min="viewState.minRootVolumeSize"
+               ng-model="stage.rootVolumeSize"/> GB <span class="small">(minimum: {{viewState.minRootVolumeSize}})</span>
+      </stage-config-field>
       <stage-config-field label="Base Name">
         <input type="text" class="form-control input-sm"
                ng-model="stage.baseName"/>


### PR DESCRIPTION
This is supported by the Netflix internal bakery only right now.