### PR TITLE
fix(styles): fix icons under styleguide class

### DIFF
--- a/app/scripts/modules/core/src/forms/buttonBusyIndicator/buttonBusyIndicator.component.ts
+++ b/app/scripts/modules/core/src/forms/buttonBusyIndicator/buttonBusyIndicator.component.ts
@@ -3,7 +3,7 @@ import {IComponentOptions, module} from 'angular';
 import './buttonBusyIndicator.component.less';
 
 export class ButtonBusyIndicatorComponent implements IComponentOptions {
-  public template = `<span us-spinner="{color: '#ffffff', left: '3px', top: '10px', radius:3, width: 2, length: 3}"></span>`;
+  public template = `<i us-spinner="{color: '#ffffff', left: '3px', top: '10px', radius:3, width: 2, length: 3}"></i>`;
 }
 
 export const BUTTON_BUSY_INDICATOR_COMPONENT = 'spinnaker.core.forms.buttonBusyIndicator.component';

--- a/app/scripts/modules/core/src/help/HelpField.tsx
+++ b/app/scripts/modules/core/src/help/HelpField.tsx
@@ -68,7 +68,7 @@ export class HelpField extends React.Component<IHelpFieldProps, IState> {
     const { placement, label, expand } = this.props;
     const { contents } = this.state;
 
-    const icon = <span className="small glyphicon glyphicon-question-sign"/>;
+    const icon = <i className="small glyphicon glyphicon-question-sign"/>;
 
     const popover = (
       <HoverablePopover placement={placement} template={contents} onShow={this.onShow} onHide={this.onHide}>

--- a/app/scripts/modules/core/src/help/helpField.component.ts
+++ b/app/scripts/modules/core/src/help/helpField.component.ts
@@ -115,7 +115,7 @@ export class HelpFieldComponent implements IComponentOptions {
               popover-placement="{{$ctrl.contents.placement}}"
               popover-is-open="$ctrl.displayPopover"
               popover-trigger="'none'">
-        <span class="small glyphicon glyphicon-question-sign"></span>
+        <i class="small glyphicon glyphicon-question-sign"></i>
       </a>
     </div>
   `;

--- a/app/scripts/modules/core/src/modal/buttons/SubmitButton.tsx
+++ b/app/scripts/modules/core/src/modal/buttons/SubmitButton.tsx
@@ -21,7 +21,7 @@ export class SubmitButton extends React.Component<ISubmitButtonProps> {
         onClick={this.props.onClick}
       >
         { !this.props.submitting && (
-          <span className="fa fa-check-circle-o"/>
+          <i className="fa fa-check-circle-o"/>
         ) || (
           <ButtonBusyIndicator/>
         )}&nbsp;

--- a/app/scripts/modules/core/src/modal/buttons/submitButton.component.ts
+++ b/app/scripts/modules/core/src/modal/buttons/submitButton.component.ts
@@ -10,7 +10,7 @@ export class SubmitButtonComponent implements IComponentOptions {
   };
   public template = `
     <button class="btn btn-primary" ng-disabled="$ctrl.isDisabled" ng-click="$ctrl.onClick()">
-      <span ng-if="!$ctrl.submitting" class="fa fa-check-circle-o"></span>
+      <i ng-if="!$ctrl.submitting" class="fa fa-check-circle-o"></i>
       <button-busy-indicator ng-if="$ctrl.submitting"></button-busy-indicator>
       {{$ctrl.label || ($ctrl.isNew ? 'Create' : 'Update')}}
     </button>`;

--- a/app/scripts/modules/core/src/presentation/main.less
+++ b/app/scripts/modules/core/src/presentation/main.less
@@ -1046,7 +1046,7 @@ a.help-field {
   &:active, &:hover {
     opacity: 1;
   }
-  span {
+  span, i {
     top: 0;
     font-size: 70%;
   }


### PR DESCRIPTION
These components no longer render properly under `.styleguide` due to this rule:

https://github.com/spinnaker/deck/blob/master/app/scripts/modules/core/src/styleguide/src/styles/typography.css#L157-L159 

@anotherchrisberry 