### PR TITLE
feat(pipelines): allow JSON editing of individual stages

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/core/editStageJson.controller.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/core/editStageJson.controller.ts
@@ -1,0 +1,50 @@
+import { module, IController } from 'angular';
+import { IModalServiceInstance } from 'angular-ui-bootstrap';
+
+import { cloneDeepWith } from 'lodash';
+
+import { IStage } from 'core/domain';
+import { JsonUtilityService } from 'core/utils/json/json.utility.service';
+
+export class EditStageJsonController implements IController {
+
+  public stageJSON: string;
+  public isInvalid = false;
+  public errorMessage: string = null;
+
+  private immutableFields = ['$$hashKey', 'refId', 'requisiteStageRefIds'];
+
+  constructor(private $uibModalInstance: IModalServiceInstance,
+              private jsonUtilityService: JsonUtilityService,
+              private stage: IStage) {
+    'ngInject';
+    const copy = cloneDeepWith<IStage>(stage, (value: any) => {
+      if (value && value.$$hashKey) {
+        delete value.$$hashKey;
+      }
+      return undefined; // required for clone operation and typescript happiness
+    });
+    this.immutableFields.forEach(k => delete copy[k]);
+    this.stageJSON = this.jsonUtilityService.makeSortedStringFromObject(copy);
+  }
+
+  public updateStage(): void {
+    try {
+      const parsed = JSON.parse(this.stageJSON);
+      Object.keys(this.stage)
+        .filter(k => !this.immutableFields.includes(k))
+        .forEach(k => delete this.stage[k]);
+      Object.assign(this.stage, parsed);
+      this.$uibModalInstance.close();
+    } catch (e) {
+      this.isInvalid = true;
+      this.errorMessage = e.message;
+    }
+  }
+
+}
+
+export const EDIT_STAGE_JSON_CONTROLLER = 'spinnaker.core.pipeline.config.stages.core.editStageJson.controller';
+module(EDIT_STAGE_JSON_CONTROLLER, [
+  require('angular-ui-bootstrap')
+]).controller('editStageJsonCtrl', EditStageJsonController);

--- a/app/scripts/modules/core/src/pipeline/config/stages/core/editStageJson.modal.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/core/editStageJson.modal.html
@@ -1,0 +1,41 @@
+<div modal-page class="flex-fill">
+  <modal-close dismiss="$dismiss()"></modal-close>
+  <div class="modal-header">
+    <h3>Edit Stage JSON</h3>
+  </div>
+  <div class="modal-body flex-fill">
+    <div class="row">
+      <div class="col-md-12">
+        <p>
+          The JSON below represents the stage configuration in its persisted state.
+        </p>
+      </div>
+    </div>
+    <form name="form" class="form-horizontal flex-fill">
+      <div class="form-group flex-fill">
+        <textarea class="code form-control flex-fill" ng-model="$ctrl.stageJSON"></textarea>
+      </div>
+    </form>
+    <div class="row">
+      <div class="col-md-12">
+        <p>
+          <strong>Note:</strong> Clicking "Update Stage" below will not save your changes to the server - it only
+          updates the configuration within the browser, so you'll want to verify your changes and click "Save Changes"
+          when you're ready.
+        </p>
+      </div>
+    </div>
+    <div class="form-group row slide-in" ng-if="$ctrl.isInvalid">
+      <div class="col-sm-9 col-sm-offset-3 error-message">
+        Error: {{$ctrl.errorMessage}}
+      </div>
+    </div>
+  </div>
+  <div class="modal-footer">
+    <button class="btn btn-default" ng-click="$dismiss()">Cancel</button>
+    <button class="btn btn-primary"
+            ng-click="$ctrl.updateStage()">
+      <span class="fa fa-check-circle-o"></span> Update Stage
+    </button>
+  </div>
+</div>

--- a/app/scripts/modules/core/src/pipeline/config/stages/stage.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/stage.html
@@ -46,8 +46,11 @@
       </stage-config-field>
     </div>
     <div class="col-md-2 text-right">
-      <button type="button" class="btn btn-sm btn-default" ng-click="pipelineConfigurerCtrl.removeStage(stage)">
+      <button type="button" class="btn btn-sm btn-default" ng-click="pipelineConfigurerCtrl.removeStage(stage)" style="margin-bottom: 5px">
         <span class="glyphicon glyphicon-trash" uib-tooltip="Remove stage"></span> Remove stage
+      </button>
+      <button type="button" class="btn btn-sm btn-default" ng-click="stageConfigCtrl.editStageJson(stage)">
+        <i class="fa fa-cog"></i> Edit stage as JSON
       </button>
     </div>
   </div>

--- a/app/scripts/modules/core/src/pipeline/config/stages/stage.module.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/stage.module.js
@@ -2,18 +2,20 @@
 
 const angular = require('angular');
 
-import {ACCOUNT_SERVICE} from 'core/account/account.service';
-import {API_SERVICE} from 'core/api/api.service';
-import {BASE_EXECUTION_DETAILS_CTRL} from './core/baseExecutionDetails.controller';
-import {CONFIRMATION_MODAL_SERVICE} from 'core/confirmationModal/confirmationModal.service';
-import {PIPELINE_CONFIG_PROVIDER} from 'core/pipeline/config/pipelineConfigProvider';
-import {PIPELINE_CONFIG_SERVICE} from 'core/pipeline/config/services/pipelineConfig.service';
-import {PIPELINE_BAKE_STAGE_CHOOSE_OS} from 'core/pipeline/config/stages/bake/bakeStageChooseOs.component';
+import { ACCOUNT_SERVICE } from 'core/account/account.service';
+import { API_SERVICE } from 'core/api/api.service';
+import { BASE_EXECUTION_DETAILS_CTRL } from './core/baseExecutionDetails.controller';
+import { CONFIRMATION_MODAL_SERVICE } from 'core/confirmationModal/confirmationModal.service';
+import { EDIT_STAGE_JSON_CONTROLLER } from './core/editStageJson.controller';
+import { PIPELINE_CONFIG_PROVIDER } from 'core/pipeline/config/pipelineConfigProvider';
+import { PIPELINE_CONFIG_SERVICE } from 'core/pipeline/config/services/pipelineConfig.service';
+import { PIPELINE_BAKE_STAGE_CHOOSE_OS } from 'core/pipeline/config/stages/bake/bakeStageChooseOs.component';
 
 module.exports = angular.module('spinnaker.core.pipeline.config.stage', [
   ACCOUNT_SERVICE,
   API_SERVICE,
   BASE_EXECUTION_DETAILS_CTRL,
+  EDIT_STAGE_JSON_CONTROLLER,
   PIPELINE_CONFIG_PROVIDER,
   PIPELINE_CONFIG_SERVICE,
   require('./overrideTimeout/overrideTimeout.directive.js'),
@@ -40,7 +42,7 @@ module.exports = angular.module('spinnaker.core.pipeline.config.stage', [
       }
     };
   })
-  .controller('StageConfigCtrl', function($scope, $element, $compile, $controller, $templateCache,
+  .controller('StageConfigCtrl', function($scope, $element, $compile, $controller, $templateCache, $uibModal,
                                           pipelineConfigService, pipelineConfig, accountService) {
 
     var lastStageScope;
@@ -88,6 +90,19 @@ module.exports = angular.module('spinnaker.core.pipeline.config.stage', [
             refId: stage.refId,
           });
         }
+      });
+    };
+
+    this.editStageJson = () => {
+      $uibModal.open({
+        size: 'lg modal-fullscreen',
+        templateUrl: require('./core/editStageJson.modal.html'),
+        controller: 'editStageJsonCtrl as $ctrl',
+        resolve: {
+          stage: () => $scope.stage
+        }
+      }).result.then(() => {
+        $scope.$broadcast('pipeline-json-edited');
       });
     };
 


### PR DESCRIPTION
![edit-stage-json-2](https://user-images.githubusercontent.com/73450/29998663-205ff738-8fe6-11e7-9ff7-4bfc3335d473.gif)

We frequently tell folks to edit the pipeline JSON to access features that aren't exposed via the UI. This is cumbersome on a sufficiently large pipeline.

This PR does not deal with locked pipelines - wanted to get opinions on if this a good idea or not. If we like it, I'll add read-only functionality for locked pipelines.

We also still need to come up with an approach to handle expressions in non-text fields, something that's long overdue.