### PR TITLE
fix(webpack): fix svg rendering in devServer mode

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -63,7 +63,11 @@ function configure(IS_TEST) {
         {test: /\.js$/, use: ['happypack/loader?id=js'], exclude: /node_modules(?!\/clipboard)/},
         {test: /\.tsx?$/, use: ['happypack/loader?id=ts'], exclude: /node_modules/},
         {test: /\.json$/, loader: 'json-loader'},
-        {test: /\.(woff|otf|ttf|eot|png|gif|ico)(.*)?$/, use: 'file-loader'},
+        {
+          test: /\.(woff|woff2|otf|ttf|eot|png|gif|ico)$/,
+          loader: 'file-loader',
+          options: { name: '[name].[hash:5].[ext]'}
+        },
         {
           test: require.resolve('jquery'),
           use: [
@@ -72,9 +76,10 @@ function configure(IS_TEST) {
           ]
         },
         {
-          test: /\.svg(.*)?$/,
+          test: /\.svg$/,
           exclude: /\/app\/scripts\/modules\/core\/src\/widgets\/spinners/,
-          use: 'file-loader'
+          loader: 'file-loader',
+          options: { name: '[name].[hash:5].[ext]'}
         },
         {
           test: /\.svg(.*)?$/,


### PR DESCRIPTION
This might make sense to someone else.

This afternoon, we started noticing the cloud provider icons were not rendering when running the dev server. This might also be affecting OSS users (we have a custom build internally which consumes the modules).

I'm not sure why, but the first `file-loader` rule (#L66 in the current code) seemed to be catching and processing the SVG files, and outputting them as references to the files that were generated via #L75's rule, which resulted in invalid SVG files, and, thus, no images. Removing the `(.*)` from the regex fixed it.

I added naming patterns to the outputs to help trace this down and left it in because it's nice to know what the files are, e.g. `appengine.icon.d44e5.svg` instead of `4738441332bb5b89fbf1b32f390fd573.svg`.