### PR TITLE
fix(pipelines): do not save changes to pipeline config on execution run

### DIFF
--- a/app/scripts/modules/core/src/delivery/manualExecution/manualPipelineExecution.controller.js
+++ b/app/scripts/modules/core/src/delivery/manualExecution/manualPipelineExecution.controller.js
@@ -5,7 +5,6 @@ import _ from 'lodash';
 
 import { AUTHENTICATION_SERVICE } from 'core/authentication/authentication.service';
 import { PIPELINE_CONFIG_PROVIDER } from 'core/pipeline/config/pipelineConfigProvider';
-import { PIPELINE_CONFIG_SERVICE } from 'core/pipeline/config/services/pipelineConfig.service';
 
 import './manualPipelineExecution.less';
 
@@ -13,13 +12,11 @@ module.exports = angular.module('spinnaker.core.delivery.manualPipelineExecution
   require('angular-ui-bootstrap'),
   require('./inlinePropertyScope.filter'),
   PIPELINE_CONFIG_PROVIDER,
-  PIPELINE_CONFIG_SERVICE,
   require('../../notification/notification.service'),
   AUTHENTICATION_SERVICE
 ])
   .controller('ManualPipelineExecutionCtrl', function ($uibModalInstance, pipeline, application, pipelineConfig,
-                                                       notificationService, authenticationService,
-                                                       pipelineConfigService) {
+                                                       notificationService, authenticationService) {
 
     this.origPipeline = {};
 
@@ -129,10 +126,6 @@ module.exports = angular.module('spinnaker.core.delivery.manualPipelineExecution
 
     };
 
-    this.pipelineIsDirty = () => {
-      return !angular.equals(this.command.pipeline, this.origPipeline);
-    };
-
     this.execute = () => {
       let selectedTrigger = this.command.trigger || {},
           command = { trigger: selectedTrigger },
@@ -151,14 +144,7 @@ module.exports = angular.module('spinnaker.core.delivery.manualPipelineExecution
       if (pipeline.parameterConfig && pipeline.parameterConfig.length) {
         selectedTrigger.parameters = this.parameters;
       }
-
-      if (this.pipelineIsDirty()) {
-        pipelineConfigService.savePipeline(pipeline)
-          .then(() => $uibModalInstance.close(command) );
-      } else {
-        $uibModalInstance.close(command);
-      }
-
+      $uibModalInstance.close(command);
     };
 
     this.cancel = $uibModalInstance.dismiss;


### PR DESCRIPTION
I'm scratching my head on this one. I think the intent was: if a user set up a fast property or wanted to override some other field for a single execution, they'd want to carry that update through to subsequent executions.

That might be true in some cases, but it's causing a lot of confusion for teams that sometimes don't want to set a property and are deleting the property for their execution, and then it's gone for the next execution.

This behavior was very surprising to me. I couldn't even understand what the user was complaining about until I removed a property, ran the pipeline, then re-ran it and saw that the property was gone.