### PR TITLE
fix(package): Widen package.json engines fields

### DIFF
--- a/gradle/installViaTravis.sh
+++ b/gradle/installViaTravis.sh
@@ -2,7 +2,7 @@
 # This script will build the project.
 
 if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
-  NODE_JS_VERSION=`node -e 'console.log(require("./package.json").engines.node)'`;
+  NODE_JS_VERSION=`node -e 'console.log(require("./package.json").engines.node.replace(/[^\d\.]/g, ""))'`;
   echo -e "Installing/activating nodejs v$NODE_JS_VERSION"
 
   # http://austinpray.com/ops/2015/09/20/change-travis-node-version.html

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
     "registry": "http://artifacts.netflix.com/api/npm/npm-local"
   },
   "engines": {
-    "node": "7.0.0",
-    "npm": "5.3.0",
-    "yarn": "0.27.5"
+    "node": ">=7.0.0",
+    "npm": ">=5.3.0",
+    "yarn": ">=0.27.5"
   },
   "scripts": {
     "clean": "rimraf .awcache .happypack build node_modules transpiled",


### PR DESCRIPTION
`yarn install` fails with yarn 1.0+ which enforces the `engines` fields

@icfantv @anotherchrisberry @jrsquared 