### PR TITLE
chore(search): move enabled filters

### DIFF
--- a/app/scripts/modules/amazon/src/aws.module.ts
+++ b/app/scripts/modules/amazon/src/aws.module.ts
@@ -1,6 +1,6 @@
 import { module } from 'angular';
 
-import { CLOUD_PROVIDER_REGISTRY, CloudProviderRegistry, DeploymentStrategyRegistry, SearchFilterTypeRegistry } from '@spinnaker/core';
+import { CLOUD_PROVIDER_REGISTRY, CloudProviderRegistry, DeploymentStrategyRegistry } from '@spinnaker/core';
 
 import { AWS_LOAD_BALANCER_MODULE } from './loadBalancer/loadBalancer.module';
 import { AWS_REACT_MODULE } from './reactShims/aws.react.module';
@@ -114,9 +114,6 @@ module(AMAZON_MODULE, [
       templateUrl: require('./applicationProviderFields/awsFields.html'),
     },
   });
-}).run(() => {
-  SearchFilterTypeRegistry.register({key: 'account', modifier: 'acct', text: 'Account'});
-  SearchFilterTypeRegistry.register({key: 'region', modifier: 'reg', text: 'Region'});
 });
 
 DeploymentStrategyRegistry.registerProvider('aws', ['custom', 'redblack', 'rollingpush', 'rollingredblack']);

--- a/app/scripts/modules/core/src/search/widgets/search.component.ts
+++ b/app/scripts/modules/core/src/search/widgets/search.component.ts
@@ -8,6 +8,8 @@ export const SEARCH_COMPONENT = 'spinnaker.core.search.component';
 module(SEARCH_COMPONENT, [])
   .component('tagSearch', react2angular(Search, ['query', 'onChange']))
   .run(() => {
+    SearchFilterTypeRegistry.register({ key: 'account', modifier: 'acct', text: 'Account' });
+    SearchFilterTypeRegistry.register({ key: 'region', modifier: 'reg', text: 'Region' });
     SearchFilterTypeRegistry.register({ key: 'stack', modifier: 'stack', text: 'Stack' });
     SearchFilterTypeRegistry.register({ key: 'type', modifier: 'type', text: 'Type' });
   });


### PR DESCRIPTION
* basically all cloud providers have the current set of filter types so
there's no reason to tie it to the aws module.  also, because the
new page will ultimately be feature flagged due to the necessary
back-end clouddriver work (i.e., `KeyParser` implementation).
