### PR TITLE
fix(provider/aws): Pre-populate spot price field with ancestor value …

### DIFF
--- a/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupCommandBuilder.service.js
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupCommandBuilder.service.js
@@ -70,7 +70,7 @@ module.exports = angular.module('spinnaker.amazon.serverGroupCommandBuilder.serv
             keyPair: keyPair,
             suspendedProcesses: [],
             securityGroups: [],
-            spotPrice: null,
+            spotPrice: '',
             tags: {},
             useAmiBlockDeviceMappings: useAmiBlockDeviceMappings,
             copySourceCustomBlockDeviceMappings: !useAmiBlockDeviceMappings,
@@ -210,7 +210,6 @@ module.exports = angular.module('spinnaker.amazon.serverGroupCommandBuilder.serv
           targetHealthyDeployPercentage: 100,
           availabilityZones: zones,
           selectedProvider: 'aws',
-          spotPrice: null,
           source: {
             account: serverGroup.account,
             region: serverGroup.region,
@@ -268,6 +267,7 @@ module.exports = angular.module('spinnaker.amazon.serverGroupCommandBuilder.serv
             ramdiskId: serverGroup.launchConfig.ramdiskId,
             instanceMonitoring: serverGroup.launchConfig.instanceMonitoring.enabled,
             ebsOptimized: serverGroup.launchConfig.ebsOptimized,
+            spotPrice: serverGroup.launchConfig.spotPrice,
           });
           if (serverGroup.launchConfig.userData) {
             command.base64UserData = serverGroup.launchConfig.userData;

--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/advancedSettings/advancedSettings.component.html
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/advancedSettings/advancedSettings.component.html
@@ -110,8 +110,7 @@
     </div>
     <div class="col-md-2"><input type="text"
                                  class="form-control input-sm"
-                                 ng-model="$ctrl.command.spotPrice"
-                                 ng-change="$ctrl.spotPriceChanged()"/></div>
+                                 ng-model="$ctrl.command.spotPrice"/></div>
   </div>
   <div class="form-group">
     <div class="col-md-5 sm-label-right"><b>AMI Block Device Mappings</b></div>

--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/advancedSettings/advancedSettings.component.js
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/advancedSettings/advancedSettings.component.js
@@ -24,13 +24,5 @@ module.exports = angular
       };
 
       this.disableSpotPricing = AWSProviderSettings.disableSpotPricing;
-
-      this.spotPriceChanged = () => {
-        // AWS returns an error if spot price is empty string
-        // so let's turn it into null
-        if (this.command.spotPrice === '') {
-          this.command.spotPrice = null;
-        }
-      };
     }
   });


### PR DESCRIPTION
…on clone. Send '' instead of null when no spot price is requested.