### PR TITLE
fix(provider/openstack): Subnet Selector shows correct subnet

### DIFF
--- a/app/scripts/modules/openstack/subnet/subnetSelectField.directive.js
+++ b/app/scripts/modules/openstack/subnet/subnetSelectField.directive.js
@@ -30,7 +30,7 @@ module.exports = angular.module('spinnaker.openstack.subnet.subnetSelectField.di
           label: 'Subnet',
           labelColumnSize: 3,
           valueColumnSize: 7,
-          options: [],
+          options: [{label: scope.model, value: scope.model}],
           filter: {},
           backingCache: 'subnets',
 


### PR DESCRIPTION
Before, the Subnet selector in the server group details always defaulted to the first subnet choice. Now the subnet is properly populated from the server group details.