### PR TITLE
style(core/cluster): Fixed active state color for server group

### DIFF
--- a/app/scripts/modules/core/src/cluster/rollups.less
+++ b/app/scripts/modules/core/src/cluster/rollups.less
@@ -354,7 +354,7 @@ running-tasks-tag {
     margin: 5px 15px 0;
     &.active {
       border-color: var(--color-accent-g1);
-      background-color: var(--color-alabaster);
+      background-color: var(--color-accent-g3);
     }
     &:hover {
       border-color: var(--color-accent-g1);
@@ -400,9 +400,9 @@ running-tasks-tag {
       }
       &.active {
         border-color: var(--color-accent-g1);
-        background-color: var(--color-alabaster);
+        background-color: var(--color-accent-g3);
         .server-group-title {
-          background-color: var(--color-alabaster);
+          background-color: var(--color-accent-g3);
         }
       }
     }


### PR DESCRIPTION
Broke the background color for active server group. Fixed it to use a shade of blue from the style guide. 