### PR TITLE
fix(pipelines): refresh relative start time on interval

### DIFF
--- a/app/scripts/modules/core/src/delivery/status/executionStatus.html
+++ b/app/scripts/modules/core/src/delivery/status/executionStatus.html
@@ -41,7 +41,7 @@
         {{ ::$ctrl.execution | executionUser }}
       </li>
       <li title="{{ ::$ctrl.execution.startTime | timestamp }}">
-        {{ ::$ctrl.execution.startTime | relativeTime }}
+        {{ $ctrl.timestamp }}
       </li>
     </span>
     <li class="break-word" ng-repeat="parameter in ::$ctrl.parameters">


### PR DESCRIPTION
Fixes a somewhat recent regression where execution relative times stopped updating. Previously, they updated because we'd replace the entire execution and re-render it pretty frequently, but we're a little more selective with what we re-render now...