### PR TITLE
fix(pipelines): show loading message while fetching version history

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/actions/pipelineConfigActions.html
+++ b/app/scripts/modules/core/src/pipeline/config/actions/pipelineConfigActions.html
@@ -12,8 +12,8 @@
 
     <li ng-if="pipeline.locked"><a href ng-click="pipelineConfigurerCtrl.editPipelineJson()">Show JSON</a></li>
     <li ng-if="!pipeline.locked"><a href ng-click="pipelineConfigurerCtrl.editPipelineJson()">Edit as JSON</a></li>
-
-    <li ng-if="viewState.hasHistory"><a href ng-click="pipelineConfigurerCtrl.showHistory()">Show Revision History</a></li>
-    <li ng-if="!viewState.hasHistory"><a class="disabled">No version history found</a></li>
+    <li ng-if="viewState.loadingHistory"><a class="disabled"><em>Loading History...</em></a></li>
+    <li ng-if="!viewState.loadingHistory && viewState.hasHistory"><a href ng-click="pipelineConfigurerCtrl.showHistory()">Show Revision History</a></li>
+    <li ng-if="!viewState.loadingHistory && !viewState.hasHistory"><a class="disabled">No version history found</a></li>
   </ul>
 </div>

--- a/app/scripts/modules/core/src/pipeline/config/pipelineConfigurer.js
+++ b/app/scripts/modules/core/src/pipeline/config/pipelineConfigurer.js
@@ -44,9 +44,9 @@ module.exports = angular.module('spinnaker.core.pipeline.config.pipelineConfigur
     pipelineConfigService.getHistory($scope.pipeline.id, 2).then(history => {
       if (history && history.length > 1) {
         $scope.viewState.hasHistory = true;
-        this.setViewState({ hasHistory: true });
+        this.setViewState({ hasHistory: true, loadingHistory: false });
       }
-    });
+    }).finally(() => this.setViewState({loadingHistory: false}));
 
     var configViewStateCache = viewStateCache.get('pipelineConfig');
 
@@ -59,6 +59,8 @@ module.exports = angular.module('spinnaker.core.pipeline.config.pipelineConfigur
       stageIndex: 0,
       loading: false,
     };
+
+    $scope.viewState.loadingHistory = true;
 
     let setOriginal = (pipeline) => {
       $scope.viewState.original = angular.toJson(pipeline);


### PR DESCRIPTION
A call that once took 100ms now takes up to a second or two sometimes (usually not, but sometimes it does), so it's confusing to users when they see "no version history".