### PR TITLE
fix(search): add default method value

### DIFF
--- a/app/scripts/modules/core/src/application/ApplicationPostSearchResultSearcher.ts
+++ b/app/scripts/modules/core/src/application/ApplicationPostSearchResultSearcher.ts
@@ -15,7 +15,7 @@ export class ApplicationPostSearchResultSearcher implements IPostSearchResultSea
 
   constructor(private $state: StateService, private applicationReader: ApplicationReader) {}
 
-  public getPostSearchResults(inputs: IServerGroupSearchResult[]): IPromise<ISearchResultSet[]> {
+  public getPostSearchResults(inputs: IServerGroupSearchResult[] = []): IPromise<ISearchResultSet[]> {
 
     const names: Set<string> = new Set<string>(inputs.map((result: IServerGroupSearchResult) => result.application));
     return this.applicationReader.listApplications(true).then((apps: IApplicationSummary[]) => {

--- a/app/scripts/modules/core/src/cluster/ClusterPostSearchResultSearcher.ts
+++ b/app/scripts/modules/core/src/cluster/ClusterPostSearchResultSearcher.ts
@@ -18,7 +18,7 @@ export class ClusterPostSearchResultSearcher implements IPostSearchResultSearche
   constructor(private $q: IQService, private $state: StateService) {
   }
 
-  public getPostSearchResults(inputs: IServerGroupSearchResult[]): IPromise<ISearchResultSet[]> {
+  public getPostSearchResults(inputs: IServerGroupSearchResult[] = []): IPromise<ISearchResultSet[]> {
 
     const clusters: IClusterSearchResult[] = inputs.map((serverGroup: IServerGroupSearchResult) => {
       const { account, application, cluster, detail, region, stack } = serverGroup;


### PR DESCRIPTION
* add default method value for post search result searchers so that it
can intelligently process search result map lookups that don't exist.
this is currently an artifact of region searching such that too many
search results are found and they're culled in clouddriver so that only
instance results come back.  we need to change the way the results are
returned for the new search to perhaps limit the search results to, say,
_n per type rather than _n total_.  need to have a think about
this.
