### PR TITLE
chore(deps): Update lodash-decorators to 4.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "jquery-ui": "~1.10.5",
     "js-yaml": "^3.8.3",
     "lodash": "^4.16.1",
-    "lodash-decorators": "^4.3.1",
+    "lodash-decorators": "^4.4.1",
     "moment-timezone": "^0.4.0",
     "n3-charts": "^2.0.18",
     "ngimport": "^0.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4083,8 +4083,8 @@ locate-path@^2.0.0:
     path-exists "^3.0.0"
 
 lodash-decorators@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/lodash-decorators/-/lodash-decorators-4.3.1.tgz#500d9b230a42df850a7bb289d822cdab57198584"
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/lodash-decorators/-/lodash-decorators-4.4.1.tgz#0ad906da7e53eb8f739fd964ade99b6bddeaab76"
   dependencies:
     tslib "^1.6.1"
 


### PR DESCRIPTION
In prep for switch from `@autoBindMethods` to `@BindAll`
