### PR TITLE
feat(provider/amazon): Show NLBs in the Load Balancer screen and allow NLB target groups to be selected when deploying

### DIFF
--- a/app/scripts/modules/amazon/src/loadBalancer/AmazonLoadBalancerClusterContainer.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/AmazonLoadBalancerClusterContainer.tsx
@@ -11,7 +11,7 @@ export class AmazonLoadBalancerClusterContainer extends React.Component<ILoadBal
   public render(): React.ReactElement<AmazonLoadBalancerClusterContainer> {
     const { loadBalancer, showInstances, showServerGroups } = this.props;
 
-    if (loadBalancer.loadBalancerType === 'application') {
+    if (loadBalancer.loadBalancerType !== 'classic') {
       const alb = loadBalancer as IAmazonApplicationLoadBalancer
       const TargetGroups = alb.targetGroups.map(targetGroup => {
         return (

--- a/app/scripts/modules/amazon/src/loadBalancer/amazonLoadBalancerDataUtils.ts
+++ b/app/scripts/modules/amazon/src/loadBalancer/amazonLoadBalancerDataUtils.ts
@@ -30,7 +30,7 @@ export class AmazonLoadBalancerDataUtils {
 
   public static populateTargetGroups(application: Application, serverGroup: IAmazonServerGroup): IPromise<ITargetGroup[]> {
     return application.getDataSource('loadBalancers').ready().then(() => {
-      const loadBalancers: IAmazonApplicationLoadBalancer[] = application.getDataSource('loadBalancers').data.filter((lb) => lb.loadBalancerType === 'application') as IAmazonApplicationLoadBalancer[];
+      const loadBalancers: IAmazonApplicationLoadBalancer[] = application.getDataSource('loadBalancers').data.filter((lb) => lb.loadBalancerType === 'application' || lb.loadBalancerType === 'network') as IAmazonApplicationLoadBalancer[];
       const targetGroups = serverGroup.targetGroups.map((targetGroupName: string) => {
         const allTargetGroups = flatten(loadBalancers.map((lb) => lb.targetGroups || []));
         const targetGroup = allTargetGroups.find((tg) => tg.name === targetGroupName);

--- a/app/scripts/modules/amazon/src/loadBalancer/details/loadBalancerDetails.controller.ts
+++ b/app/scripts/modules/amazon/src/loadBalancer/details/loadBalancerDetails.controller.ts
@@ -143,7 +143,9 @@ export class AwsLoadBalancerDetailsController implements IController {
           this.loadBalancer.elb.vpcId = this.loadBalancer.elb.vpcId || this.loadBalancer.elb.vpcid;
           this.loadBalancer.account = this.loadBalancerFromParams.accountId;
 
-          if ((details[0] as IApplicationLoadBalancerSourceData).loadBalancerType === 'application') {
+          const sourceData = (details[0] as IApplicationLoadBalancerSourceData);
+          if (sourceData.loadBalancerType === 'application' || sourceData.loadBalancerType === 'network') {
+            // Transform listener data
             const elb = details[0] as IApplicationLoadBalancerSourceData;
             if (elb.listeners && elb.listeners.length) {
               this.elbProtocol = 'http:';

--- a/app/scripts/modules/amazon/src/loadBalancer/details/loadBalancerDetails.html
+++ b/app/scripts/modules/amazon/src/loadBalancer/details/loadBalancerDetails.html
@@ -39,7 +39,7 @@
       </h3>
     </div>
     <div>
-      <div class="actions">
+      <div class="actions" ng-if="ctrl.loadBalancer.loadBalancerType !== 'network'">
         <div class="dropdown" uib-dropdown dropdown-append-to-body>
           <button type="button" class="btn btn-sm btn-primary dropdown-toggle" uib-dropdown-toggle>
             Load Balancer Actions <span class="caret"></span>
@@ -72,6 +72,8 @@
         <dd><vpc-tag vpc-id="ctrl.loadBalancer.elb.vpcId"></vpc-tag></dd>
         <dt>Subnet</dt>
         <dd>{{ctrl.getFirstSubnetPurpose(ctrl.loadBalancer.subnetDetails)}}</dd>
+        <dt ng-if="ctrl.ipAddressTypeDescription">Type</dt>
+        <dd ng-if="ctrl.ipAddressTypeDescription">{{ctrl.loadBalancer.loadBalancerType}}</dd>
         <dt ng-if="ctrl.ipAddressTypeDescription">IP Type</dt>
         <dd ng-if="ctrl.ipAddressTypeDescription">{{ctrl.ipAddressTypeDescription}}</dd>
       </dl>

--- a/app/scripts/modules/core/src/loadBalancer/LoadBalancerPod.tsx
+++ b/app/scripts/modules/core/src/loadBalancer/LoadBalancerPod.tsx
@@ -43,7 +43,7 @@ export class LoadBalancerPod extends React.Component<ILoadBalancerPodProps> {
             </div>
             <div className="pod-center">
               <div>
-                <span className="icon icon-elb"/> {grouping.heading}
+                {grouping.heading}
               </div>
             </div>
           </div>


### PR DESCRIPTION
NLBs are live in AWS (and already cached in Clouddriver). This does not allow CRUD of NLBs, but it will allow you to see the existence of them in deck and select those already existing target groups in a deploy configuration.