### PR TITLE
fix(projects): restore project header width to 100%

### DIFF
--- a/app/scripts/modules/core/src/projects/dashboard/cluster/projectCluster.less
+++ b/app/scripts/modules/core/src/projects/dashboard/cluster/projectCluster.less
@@ -1,6 +1,11 @@
 @import (reference) "~core/presentation/less/imports/commonImports.less";
 
 project-cluster {
+  .rollup-summary {
+    .container-fluid {
+      width: 100%;
+    }
+  }
   .cluster-name {
     display: inline-block;
     margin-right: 10px;


### PR DESCRIPTION
I broke this all the way back in https://github.com/spinnaker/deck/pull/4127