### PR TITLE
fix(versionCheck): swallow exception if version.json fetch fails

### DIFF
--- a/app/scripts/modules/core/src/config/versionCheck.service.ts
+++ b/app/scripts/modules/core/src/config/versionCheck.service.ts
@@ -35,7 +35,7 @@ class VersionCheckService {
 
   private checkVersion(): void {
     const url = `/version.json?_=${Date.now()}`;
-    this.$http.get(url).then((resp) => this.versionRetrieved(resp));
+    this.$http.get(url).then((resp) => this.versionRetrieved(resp)).catch(() => {});
   }
 
   private versionRetrieved(response: any): void {


### PR DESCRIPTION
Using the much more efficient empty arrow function in lieu of the bulky `noop` that some people prefer