### PR TITLE
fix(pipeline_template): Cast numeric variable types during plan

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/templates/configurePipelineTemplateModal.controller.ts
+++ b/app/scripts/modules/core/src/pipeline/config/templates/configurePipelineTemplateModal.controller.ts
@@ -119,6 +119,10 @@ export class ConfigurePipelineTemplateModalController implements IController {
       .map(v => {
         if (v.type === 'object') {
           v.value = load(v.value);
+        } else if (v.type === 'int') {
+          return [v.name, parseInt(v.value, 10)];
+        } else if (v.type === 'float') {
+          return [v.name, parseFloat(v.value)];
         }
         return [v.name, v.value];
       })


### PR DESCRIPTION
Sending int/float variables as strings cause validation errors on the server side.