### PR TITLE
fix(pipelines): correctly rerender when editing JSON

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/pipelineConfigurer.js
+++ b/app/scripts/modules/core/src/pipeline/config/pipelineConfigurer.js
@@ -173,7 +173,7 @@ module.exports = angular.module('spinnaker.core.pipeline.config.pipelineConfigur
         controllerAs: '$ctrl',
         size: 'lg modal-fullscreen',
         resolve: {
-          pipeline: () => $scope.pipeline,
+          pipeline: () => $scope.renderablePipeline,
         }
       }).result.then(() => {
         $scope.$broadcast('pipeline-json-edited');


### PR DESCRIPTION
I will not explain why this fixes the pipeline config rendering when using the "Edit as JSON" feature, nor will I explain why it's currently broken. Also, I will not confirm this change doesn't have any surprising side effect on templated pipelines.