### PR TITLE
fix(moniker) - adds filter to only retrieve target cluster for clone aws cluster stage

### DIFF
--- a/app/scripts/modules/amazon/src/pipeline/stages/cloneServerGroup/awsCloneServerGroupStage.js
+++ b/app/scripts/modules/amazon/src/pipeline/stages/cloneServerGroup/awsCloneServerGroupStage.js
@@ -60,7 +60,8 @@ module.exports = angular.module('spinnaker.amazon.pipeline.stage.cloneServerGrou
 
     this.targetClusterUpdated = () => {
       if (stage.targetCluster) {
-        let moniker = _.first(appListExtractorService.getMonikers([$scope.application]));
+        const filterByCluster = (serverGroup) => serverGroup.moniker.cluster === stage.targetCluster;
+        let moniker = _.first(appListExtractorService.getMonikers([$scope.application], filterByCluster));
         stage.stack = moniker.stack;
         stage.freeFormDetails = moniker.detail;
       } else {

--- a/app/scripts/modules/core/src/application/listExtractor/listExtractor.service.spec.ts
+++ b/app/scripts/modules/core/src/application/listExtractor/listExtractor.service.spec.ts
@@ -36,6 +36,21 @@ describe('appListExtractorService', function () {
   );
 
   describe('Get Monikers from a list of applications', function () {
+
+      it('should return a filtered list of monikers', function () {
+        let moniker: IMoniker = {
+          cluster: 'test-cluster',
+          application: 'test-application'
+        };
+        const filterByCluster = (serverGroup:IServerGroup) => serverGroup.moniker.cluster === 'test-cluster'
+        const applicationA: Application = buildApplication([ {moniker: moniker} ]);
+        const applicationB: Application = buildApplication();
+
+        const result = service.getMonikers([applicationA, applicationB], filterByCluster);
+        expect(result.length).toEqual(1);
+        expect(result).toEqual([moniker]);
+      });
+
       it('should get a empty list for one application w/ no monikers', function () {
         const application: Application = buildApplication([ {stack: 'prod'}, {stack: 'test'} ]);
         const result = service.getMonikers([application]);

--- a/app/scripts/modules/core/src/application/listExtractor/listExtractor.service.ts
+++ b/app/scripts/modules/core/src/application/listExtractor/listExtractor.service.ts
@@ -16,8 +16,9 @@ const defaultFilter = () => true;
 
 export class AppListExtractor {
 
-  public getMonikers(applications: Application[]): IMoniker[] {
+  public getMonikers(applications: Application[],  filter: IServerGroupFilter = defaultFilter): IMoniker[] {
     const allMonikers: IMoniker[][] = applications.map(a => a.getDataSource('serverGroups').data
+      .filter(filter)
       .map((serverGroup: IServerGroup) => serverGroup.moniker));
     return compact(flatten(allMonikers));
   }


### PR DESCRIPTION
This fix adds a filter to only retrieve the target cluster moniker.  Previously it returned all monikers and it just grabbed the first one.