### PR TITLE
fix(core): remove access modifier from local variable in versionSelector

### DIFF
--- a/app/scripts/modules/core/src/cloudProvider/versionSelection/versionSelector.component.ts
+++ b/app/scripts/modules/core/src/cloudProvider/versionSelection/versionSelector.component.ts
@@ -8,7 +8,7 @@ import { CLOUD_PROVIDER_REGISTRY } from 'core/cloudProvider/cloudProvider.regist
 export class VersionSelectorCtrl implements IController {
   public command: any =  { version: '' };
 
-  constructor(private versionOptions: string[],
+  constructor(public versionOptions: string[],
               private $uibModalInstance: IModalInstanceService) {
     'ngInject';
 


### PR DESCRIPTION
TS complains (fairly) that this field shouldn't be private. It is used in the template, so just making it public here.