### PR TITLE
feat(core): Version account lookup

### DIFF
--- a/app/scripts/modules/core/src/account/account.service.ts
+++ b/app/scripts/modules/core/src/account/account.service.ts
@@ -21,6 +21,7 @@ export interface IAccount {
   name: string;
   requiredGroupMembership: string[];
   type: string;
+  providerVersion?: string;
 }
 
 export interface IAccountDetails extends IAccount {
@@ -34,7 +35,6 @@ export interface IAccountDetails extends IAccount {
   primaryAccount: boolean;
   regions: IRegion[];
   namespaces?: string[];
-  providerVersion?: string;
 }
 
 export interface IAggregatedAccounts {
@@ -83,8 +83,8 @@ export class AccountService {
       .get();
   }
 
-  public getAllAccountDetailsForProvider(provider: string): ng.IPromise<IAccountDetails[]> {
-    return this.listAccounts(provider)
+  public getAllAccountDetailsForProvider(provider: string, providerVersion: string = null): ng.IPromise<IAccountDetails[]> {
+    return this.listAccounts(provider, providerVersion)
       .then((accounts: IAccount[]) => this.$q.all(accounts.map((account: IAccount) => this.getAccountDetails(account.name))))
       .catch((error: any) => {
         this.$log.warn(`Failed to load accounts for provider "${provider}"; exception:`, error);
@@ -166,11 +166,14 @@ export class AccountService {
       });
   }
 
-  public listAccounts(provider: string = null): ng.IPromise<IAccount[]> {
-
+  public listAccounts(provider: string = null, providerVersion: string = null): ng.IPromise<IAccount[]> {
     let result: ng.IPromise<IAccount[]> = this.API.one('credentials').useCache().get();
     if (provider) {
-      result = result.then((accounts: IAccount[]) => accounts.filter((account: IAccount) => account.type === provider));
+      result = result.then((accounts) => accounts.filter((account) => account.type === provider));
+    }
+
+    if (providerVersion) {
+      result = result.then((accounts) => accounts.filter((account) => account.providerVersion === providerVersion));
     }
 
     return result;

--- a/app/scripts/modules/kubernetes/cluster/configure/CommandBuilder.js
+++ b/app/scripts/modules/kubernetes/cluster/configure/CommandBuilder.js
@@ -12,7 +12,7 @@ module.exports = angular.module('spinnaker.kubernetes.clusterCommandBuilder.serv
 ])
   .factory('kubernetesClusterCommandBuilder', function (accountService) {
     function attemptToSetValidAccount(application, defaultAccount, command) {
-      return accountService.listAccounts('kubernetes').then(function(kubernetesAccounts) {
+      return accountService.listAccounts('kubernetes', 'v1').then(function(kubernetesAccounts) {
         var kubernetesAccountNames = _.map(kubernetesAccounts, 'name');
         var firstKubernetesAccount = null;
 

--- a/app/scripts/modules/kubernetes/serverGroup/configure/configuration.service.js
+++ b/app/scripts/modules/kubernetes/serverGroup/configure/configuration.service.js
@@ -43,7 +43,7 @@ module.exports = angular.module('spinnaker.serverGroup.configure.kubernetes.conf
       }
 
       return $q.all({
-        accounts: accountService.listAccounts('kubernetes'),
+        accounts: accountService.listAccounts('kubernetes', 'v1'),
         loadBalancers: loadBalancerReader.listLoadBalancers('kubernetes'),
         allImages: imagesPromise
       }).then(function(backingData) {


### PR DESCRIPTION
All accounts should be reporting `providerVersion` now, since the account interface returns `v1` by default: https://github.com/spinnaker/clouddriver/blob/master/clouddriver-security/src/main/groovy/com/netflix/spinnaker/clouddriver/security/AccountCredentials.java#L72

Even if they don't, as long as the provider ignores the version no change in behavior should happen.