### PR TITLE
fix(provider/gce) Update max disk number for local-ssd to 8 from 4

### DIFF
--- a/app/scripts/modules/google/src/help/gce.help.ts
+++ b/app/scripts/modules/google/src/help/gce.help.ts
@@ -22,7 +22,7 @@ const helpContents: {[key: string]: string} = {
   'gce.instance.customMetadata.load-balancing-policy': 'This field is used to "remember" the load balancing policy this instance is associated with, even if it is deregistered.',
   'gce.instance.customMetadata.startup-script': 'This script will run automatically on every boot.',
   'gce.instance.storage': '<p>Storage options can be fully-configured on the <b>Advanced Settings</b> tab. These are just default settings. Please be aware of your Local SSD quotas as you provision VMs.</p>',
-  'gce.instance.storage.localSSD': '<p>Local SSD disks are always 375GB. All non shared-core instance types support attaching up to 4 Local SSD disks. Please be aware of your Local SSD quotas as you provision VMs.</p>',
+  'gce.instance.storage.localSSD': '<p>Local SSD disks are always 375GB. All non shared-core instance types support attaching up to 8 Local SSD disks. Please be aware of your Local SSD quotas as you provision VMs.</p>',
   'gce.instance.serviceAccount': '<p>Service accounts authenticate applications running on your virtual machine instances to other Google Cloud Platform services. Valid values are either "default" or the full email address of a custom service account.</p>',
   'gce.instance.authScopes': '<p>Service account scopes specify which Google Cloud Platform APIs your instances can authenticate with, and define the level of access that your instances have with those services. You can enter custom auth scopes by typing into the blank field.</p>',
   'gce.instance.authScopes.cloud-platform': '<p>The instances in this server group have full API access to all Google Cloud services.</p>',

--- a/app/scripts/modules/google/src/serverGroup/configure/wizard/advancedSettings/diskConfigurer.component.ts
+++ b/app/scripts/modules/google/src/serverGroup/configure/wizard/advancedSettings/diskConfigurer.component.ts
@@ -98,7 +98,7 @@ class GceDiskConfigurer implements IComponentOptions {
                ng-change="$ctrl.handleLocalSSDCountChange()"
                required
                min="0"
-               max="{{$ctrl.command.viewState.instanceTypeDetails.storage.localSSDSupported ? 4 : 0}}"
+               max="{{$ctrl.command.viewState.instanceTypeDetails.storage.localSSDSupported ? 8 : 0}}"
                ng-disabled="!$ctrl.command.viewState.instanceTypeDetails.storage.localSSDSupported"/>
       </div>
     </div>


### PR DESCRIPTION
New PR because I'm always going to fail at rebasing against deck correctly.

From: https://cloud.google.com/compute/docs/disks/local-ssd#create_local_ssd
"Each local SSD is 375 GB in size, but you can attach up to eight local SSD devices for 3 TB of total local SSD storage space per instance"

4 was the old limit

Closes spinnaker/spinnaker#1945

