### PR TITLE
fix(amazon): properly assign credentials when editing load balancers

### DIFF
--- a/app/scripts/modules/amazon/src/loadBalancer/loadBalancer.transformer.ts
+++ b/app/scripts/modules/amazon/src/loadBalancer/loadBalancer.transformer.ts
@@ -134,7 +134,7 @@ export class AwsLoadBalancerTransformer {
       isInternal: loadBalancer.isInternal,
       region: loadBalancer.region,
       cloudProvider: loadBalancer.cloudProvider,
-      credentials: loadBalancer.credentials,
+      credentials: loadBalancer.credentials || loadBalancer.account,
       listeners: loadBalancer.listeners,
       loadBalancerType: 'classic',
       name: loadBalancer.name,


### PR DESCRIPTION
`credentials` is there for the upsert load balancer stage, but not when editing an existing load balancer.