### PR TITLE
fix(executions): fix header alignment

### DIFF
--- a/app/scripts/modules/core/src/delivery/executions/executions.html
+++ b/app/scripts/modules/core/src/delivery/executions/executions.html
@@ -42,7 +42,7 @@
       <div class="pull-right">
         <create-new application="$ctrl.application"></create-new>
       </div>
-      <form class="form-inline execution-filters">
+      <form class="form-inline" style="margin-bottom: 5px">
         <div class="form-group" ng-if="$ctrl.filter.groupBy" style="margin-right: 20px">
           <a class="btn btn-xs btn-default" href
              analytics-on="click"


### PR DESCRIPTION
No need for `execution-filters` - it's being used for the side filters and this is confusing (and causing misalignment of the entries in the top header).