### PR TITLE
fix(core/modal): avoid throwing errors on modal $dismiss

### DIFF
--- a/app/scripts/modules/amazon/src/pipeline/stages/bake/awsBakeStage.js
+++ b/app/scripts/modules/amazon/src/pipeline/stages/bake/awsBakeStage.js
@@ -132,7 +132,7 @@ module.exports = angular.module('spinnaker.amazon.pipeline.stage.bakeStage', [
         }
       }).result.then(function(extendedAttribute) {
           $scope.stage.extendedAttributes[extendedAttribute.key] = extendedAttribute.value;
-      });
+      }).catch(() => {});
     };
 
     this.removeExtendedAttribute = function (key) {

--- a/app/scripts/modules/appengine/pipeline/stages/editLoadBalancer/appengineEditLoadBalancerStage.ts
+++ b/app/scripts/modules/appengine/pipeline/stages/editLoadBalancer/appengineEditLoadBalancerStage.ts
@@ -25,7 +25,7 @@ class AppengineEditLoadBalancerStageCtrl implements IController {
       }
     }).result.then((newLoadBalancer: ILoadBalancer) => {
       this.$scope.stage.loadBalancers.push(newLoadBalancer);
-    });
+    }).catch(() => {});
   }
 
   public editLoadBalancer(index: number) {
@@ -42,7 +42,7 @@ class AppengineEditLoadBalancerStageCtrl implements IController {
       }
     }).result.then((updatedLoadBalancer: ILoadBalancer) => {
       this.$scope.stage.loadBalancers[index] = updatedLoadBalancer;
-    });
+    }).catch(() => {});
   }
 
   public removeLoadBalancer(index: number): void {

--- a/app/scripts/modules/azure/pipeline/stages/bake/azureBakeStage.js
+++ b/app/scripts/modules/azure/pipeline/stages/bake/azureBakeStage.js
@@ -122,7 +122,7 @@ module.exports = angular.module('spinnaker.azure.pipeline.stage.bakeStage', [
         }
       }).result.then(function(extendedAttribute) {
           $scope.stage.extendedAttributes[extendedAttribute.key] = extendedAttribute.value;
-      });
+      }).catch(() => {});
     };
 
     this.removeExtendedAttribute = function (key) {

--- a/app/scripts/modules/canary/canary/canaryStage.js
+++ b/app/scripts/modules/canary/canary/canaryStage.js
@@ -412,7 +412,7 @@ module.exports = angular.module('spinnaker.canary.canaryStage', [
           cleanupClusterConfig(baselineCluster, 'baseline');
           cleanupClusterConfig(canaryCluster, 'canary');
           $scope.stage.clusterPairs.push({baseline: baselineCluster, canary: canaryCluster});
-        });
+        }).catch(() => {});
       });
     };
 
@@ -447,7 +447,7 @@ module.exports = angular.module('spinnaker.canary.canaryStage', [
         var stageCluster = awsServerGroupTransformer.convertServerGroupCommandToDeployConfiguration(command);
         cleanupClusterConfig(stageCluster, type);
         $scope.stage.clusterPairs[index][type.toLowerCase()] = stageCluster;
-      });
+      }).catch(() => {});
     };
 
     this.deleteClusterPair = function(index) {

--- a/app/scripts/modules/core/src/application/applications.component.ts
+++ b/app/scripts/modules/core/src/application/applications.component.ts
@@ -53,7 +53,7 @@ export class ApplicationsController implements IController {
             templateUrl: this.overrideRegistry.getTemplate('createApplicationModal', require('./modal/newapplication.html')),
             controller: this.overrideRegistry.getController('CreateApplicationModalCtrl'),
             controllerAs: 'newAppModal'
-          }).result.then((app) => this.routeToApplication(app));
+          }).result.then((app) => this.routeToApplication(app)).catch(() => {});
         }
       }
     ];

--- a/app/scripts/modules/core/src/application/config/applicationAttributes.directive.js
+++ b/app/scripts/modules/core/src/application/config/applicationAttributes.directive.js
@@ -86,6 +86,6 @@ module.exports = angular
           this.application.attributes = newAttributes;
           setHealthMessage();
           setPermissions();
-        });
+        }).catch(() => {});
     };
   });

--- a/app/scripts/modules/core/src/application/config/applicationAttributes.directive.spec.js
+++ b/app/scripts/modules/core/src/application/config/applicationAttributes.directive.spec.js
@@ -34,13 +34,16 @@ describe('Controller: Config', function () {
 
     it('should copy attributes when edit application is successful', function() {
       var newAttributes = { foo: 'bar' };
-      spyOn($uibModal, 'open').and.returnValue({
+      const modalStub = {
         result: {
           then: function(method) {
             method(newAttributes);
-          }
+            return modalStub.result;
+          },
+          catch: () => {}
         }
-      });
+      };
+      spyOn($uibModal, 'open').and.returnValue(modalStub);
 
       configController.editApplication();
       expect(application.attributes).toBe(newAttributes);

--- a/app/scripts/modules/core/src/application/config/links/applicationLinks.component.js
+++ b/app/scripts/modules/core/src/application/config/links/applicationLinks.component.js
@@ -88,7 +88,7 @@ module.exports = angular
         }).result.then(newSections => {
           this.sections = newSections;
           this.configChanged();
-        });
+        }).catch(() => {});
       };
 
       this.sortOptions = {

--- a/app/scripts/modules/core/src/delivery/executionGroup/ExecutionGroup.tsx
+++ b/app/scripts/modules/core/src/delivery/executionGroup/ExecutionGroup.tsx
@@ -113,7 +113,7 @@ export class ExecutionGroup extends React.Component<IExecutionGroupProps, IExecu
         application: () => this.props.application,
         currentlyRunningExecutions: () => this.props.group.runningExecutions,
       }
-    }).result.then((command) => this.startPipeline(command));
+    }).result.then((command) => this.startPipeline(command)).catch(() => {});
   }
 
   public componentDidMount(): void {

--- a/app/scripts/modules/core/src/delivery/executions/executions.controller.js
+++ b/app/scripts/modules/core/src/delivery/executions/executions.controller.js
@@ -174,6 +174,6 @@ module.exports = angular.module('spinnaker.core.delivery.executions.controller',
           pipeline: () => null,
           application: () => this.application,
         }
-      }).result.then(startPipeline);
+      }).result.then(startPipeline).catch(() => {});
     };
   });

--- a/app/scripts/modules/core/src/modal/dismiss.decorator.ts
+++ b/app/scripts/modules/core/src/modal/dismiss.decorator.ts
@@ -1,0 +1,24 @@
+import { module } from 'angular';
+import IProvideService = angular.auto.IProvideService;
+
+import { IModalStackService } from 'angular-ui-bootstrap';
+
+export const DISMISS_DECORATOR = 'spinnaker.core.modal.dismiss.decorator';
+module(DISMISS_DECORATOR, [])
+  .config(($provide: IProvideService) => {
+    // Prevents an error from escaping when the user dismisses a modal created via the ReactInjector
+    // (error looks like: "Possibly unhandled rejection: undefined undefined")
+    $provide.decorator('$uibModalStack', ($delegate: IModalStackService) => {
+      const originalDismiss: Function = $delegate.dismiss;
+      $delegate.dismiss = (...args: any[]) => {
+        originalDismiss.apply(this, args);
+        const [ modalInstance ] = args;
+        if (modalInstance && modalInstance.result) {
+          modalInstance.result
+            .catch(() => {});
+        }
+      };
+
+      return $delegate;
+    });
+  });

--- a/app/scripts/modules/core/src/modal/modal.module.js
+++ b/app/scripts/modules/core/src/modal/modal.module.js
@@ -2,10 +2,11 @@
 
 const angular = require('angular');
 
-import {V2_MODAL_WIZARD_COMPONENT} from './wizard/v2modalWizard.component';
-import {V2_MODAL_WIZARD_SERVICE} from './wizard/v2modalWizard.service';
-import {MODAL_CLOSE_COMPONENT} from './buttons/modalClose.component';
-import {SUBMIT_BUTTON_COMPONENT} from './buttons/submitButton.component';
+import { DISMISS_DECORATOR } from './dismiss.decorator';
+import { V2_MODAL_WIZARD_COMPONENT } from './wizard/v2modalWizard.component';
+import { V2_MODAL_WIZARD_SERVICE } from './wizard/v2modalWizard.service';
+import { MODAL_CLOSE_COMPONENT } from './buttons/modalClose.component';
+import { SUBMIT_BUTTON_COMPONENT } from './buttons/submitButton.component';
 
 import './modals.less';
 
@@ -15,6 +16,7 @@ module.exports = angular
     require('./modalPage.directive.js').name,
     require('./wizard/wizardSubFormValidation.service').name,
     require('./closeable/closeable.modal.controller').name,
+    DISMISS_DECORATOR,
     MODAL_CLOSE_COMPONENT,
     SUBMIT_BUTTON_COMPONENT,
     V2_MODAL_WIZARD_SERVICE,

--- a/app/scripts/modules/core/src/notification/notificationList.directive.js
+++ b/app/scripts/modules/core/src/notification/notificationList.directive.js
@@ -6,135 +6,135 @@ require('./notificationList.directive.html');
 require('./modal/editNotification.html');
 
 module.exports = angular.module('spinnaker.core.notifications.notificationList', [])
-    .directive('notificationList', function () {
-        return {
-            restrict: 'E',
-            scope: {
-                application: '=',
-                level: '@',
-                notifications: '=',
-                parent: '='
-            },
-            templateUrl: require('./notificationList.directive.html'),
-            controller: 'NotificationListCtrl',
-            controllerAs: 'notificationListCtrl'
-        };
-    })
-    .controller('NotificationListCtrl', function ($scope, $uibModal, notificationService) {
+  .directive('notificationList', function () {
+    return {
+      restrict: 'E',
+      scope: {
+        application: '=',
+        level: '@',
+        notifications: '=',
+        parent: '='
+      },
+      templateUrl: require('./notificationList.directive.html'),
+      controller: 'NotificationListCtrl',
+      controllerAs: 'notificationListCtrl'
+    };
+  })
+  .controller('NotificationListCtrl', function ($scope, $uibModal, notificationService) {
 
-        var vm = this;
+    var vm = this;
 
-        vm.revertNotificationChanges = function () {
+    vm.revertNotificationChanges = function () {
 
-            /*
-                we currently store application level notifications in front50 as an map indexed by type
-                {
-                     "application": "ayuda",
-                     "hipchat": [ { ... } ],
-                     "email": [ { ... } ]
-                }
-                the code below unwraps it into a table friendly format and the saveNotifications code will
-                write it back into the right format.
-
-                We will change the format in front50 when we rewrite notifications to use CQL so this tranformation
-                is no longer needed
-             */
-
-            notificationService.getNotificationsForApplication($scope.application).then(function (notifications) {
-                $scope.notifications = _.filter(_.flatten(_.map(['email', 'sms', 'hipchat', 'slack'],
-                    function (type) {
-                        if (notifications[type]) {
-                            return _.map(notifications[type], function (entry) {
-                                    return _.extend(entry, {type: type});
-                                }
-                            );
-                        }
-                    }
-                )), function (allow) {
-                    return allow !== undefined && allow.level === 'application';
-                });
-                vm.isNotificationsDirty = false;
-            });
-        };
-
-        if ($scope.level === 'application') {
-            vm.revertNotificationChanges();
-        }
-
-        vm.saveNotifications = function () {
-            var toSaveNotifications = {};
-            toSaveNotifications.application = $scope.application;
-
-            _.each($scope.notifications, function (notification) {
-                if (toSaveNotifications[notification.type] === undefined) {
-                    toSaveNotifications[notification.type] = [];
-                }
-                toSaveNotifications[notification.type].push(notification);
-            });
-
-            notificationService.saveNotificationsForApplication($scope.application, toSaveNotifications).then(function () {
-                vm.revertNotificationChanges();
-            });
-
-        };
-
-        vm.editNotification = function (notification) {
-            var modalInstance = $uibModal.open({
-                templateUrl: require('./modal/editNotification.html'),
-                controller: 'EditNotificationController',
-                controllerAs: 'editNotification',
-                resolve: {
-                    notification: function () {
-                        return notification;
-                    },
-                    level: function() {
-                        return $scope.level;
-                    },
-                    stageType: function() {
-                        if ($scope.parent) {
-                          return $scope.parent.type;
-                        } else {
-                          return null;
-                        }
-                    }
-                }
-            });
-
-            modalInstance.result.then(function (newNotification) {
-                if (!notification) {
-                    $scope.notifications.push(newNotification);
-                } else {
-                    $scope.notifications[$scope.notifications.indexOf(notification)] = newNotification;
-                }
-                vm.isNotificationsDirty = true;
-            });
-
-        };
-
-        vm.addNotification = function () {
-            if ($scope.parent && !$scope.parent.notifications) {
-                $scope.parent.notifications = [];
-            }
-            vm.editNotification(undefined);
-        };
-
-        vm.removeNotification = function (notification) {
-            $scope.notifications = $scope.notifications.filter(function (el) {
-                    return el !== notification;
-                }
-            );
-            if (!$scope.notifications.length) {
-              delete $scope.notifications;
-            }
-            vm.isNotificationsDirty = true;
-        };
-
-        vm.manageStateOnToggle = function () {
-          if (!$scope.parent.sendNotifications) {
-            delete $scope.notifications;
+      /*
+          we currently store application level notifications in front50 as a map indexed by type
+          {
+               "application": "ayuda",
+               "hipchat": [ { ... } ],
+               "email": [ { ... } ]
           }
-        };
+          the code below unwraps it into a table friendly format and the saveNotifications code will
+          write it back into the right format.
 
-        return vm;
+          We will change the format in front50 when we rewrite notifications to use CQL so this transformation
+          is no longer needed
+       */
 
-    });
+      notificationService.getNotificationsForApplication($scope.application).then(function (notifications) {
+        $scope.notifications = _.filter(_.flatten(_.map(['email', 'sms', 'hipchat', 'slack'],
+          function (type) {
+            if (notifications[type]) {
+              return _.map(notifications[type], function (entry) {
+                  return _.extend(entry, {type: type});
+                }
+              );
+            }
+          }
+        )), function (allow) {
+          return allow !== undefined && allow.level === 'application';
+        });
+        vm.isNotificationsDirty = false;
+      });
+    };
+
+    if ($scope.level === 'application') {
+      vm.revertNotificationChanges();
+    }
+
+    vm.saveNotifications = function () {
+      var toSaveNotifications = {};
+      toSaveNotifications.application = $scope.application;
+
+      _.each($scope.notifications, function (notification) {
+        if (toSaveNotifications[notification.type] === undefined) {
+          toSaveNotifications[notification.type] = [];
+        }
+        toSaveNotifications[notification.type].push(notification);
+      });
+
+      notificationService.saveNotificationsForApplication($scope.application, toSaveNotifications).then(function () {
+        vm.revertNotificationChanges();
+      });
+
+    };
+
+    vm.editNotification = function (notification) {
+      var modalInstance = $uibModal.open({
+        templateUrl: require('./modal/editNotification.html'),
+        controller: 'EditNotificationController',
+        controllerAs: 'editNotification',
+        resolve: {
+          notification: function () {
+            return notification;
+          },
+          level: function () {
+            return $scope.level;
+          },
+          stageType: function () {
+            if ($scope.parent) {
+              return $scope.parent.type;
+            } else {
+              return null;
+            }
+          }
+        }
+      });
+
+      modalInstance.result.then((newNotification) => {
+        if (!notification) {
+          $scope.notifications.push(newNotification);
+        } else {
+          $scope.notifications[$scope.notifications.indexOf(notification)] = newNotification;
+        }
+        vm.isNotificationsDirty = true;
+      }).catch(() => {});
+
+    };
+
+    vm.addNotification = function () {
+      if ($scope.parent && !$scope.parent.notifications) {
+        $scope.parent.notifications = [];
+      }
+      vm.editNotification(undefined);
+    };
+
+    vm.removeNotification = function (notification) {
+      $scope.notifications = $scope.notifications.filter(function (el) {
+          return el !== notification;
+        }
+      );
+      if (!$scope.notifications.length) {
+        delete $scope.notifications;
+      }
+      vm.isNotificationsDirty = true;
+    };
+
+    vm.manageStateOnToggle = function () {
+      if (!$scope.parent.sendNotifications) {
+        delete $scope.notifications;
+      }
+    };
+
+    return vm;
+
+  });

--- a/app/scripts/modules/core/src/pipeline/config/pipelineConfigurer.js
+++ b/app/scripts/modules/core/src/pipeline/config/pipelineConfigurer.js
@@ -116,7 +116,7 @@ module.exports = angular.module('spinnaker.core.pipeline.config.pipelineConfigur
           application: () => $scope.application,
           forStrategyConfig: () => $scope.pipeline.strategy,
         }
-      }).result.then(stageTemplate => ctrl.addStage(stageTemplate));
+      }).result.then(stageTemplate => ctrl.addStage(stageTemplate)).catch(() => {});
     };
 
     var ctrl = this;
@@ -163,7 +163,7 @@ module.exports = angular.module('spinnaker.core.pipeline.config.pipelineConfigur
       }).result.then(() => {
           setOriginal($scope.pipeline);
           markDirty();
-        });
+        }).catch(() => {});
     };
 
     this.editPipelineJson = () => {
@@ -178,7 +178,7 @@ module.exports = angular.module('spinnaker.core.pipeline.config.pipelineConfigur
       }).result.then(() => {
         $scope.$broadcast('pipeline-json-edited');
         this.updatePipeline();
-      });
+      }).catch(() => {});
     };
 
     // Enabling a pipeline simply toggles the disabled flag - it does not save any pending changes
@@ -189,7 +189,7 @@ module.exports = angular.module('spinnaker.core.pipeline.config.pipelineConfigur
         resolve: {
           pipeline: () => getOriginal()
         }
-      }).result.then(() => disableToggled(false));
+      }).result.then(() => disableToggled(false)).catch(() => {});
     };
 
     // Disabling a pipeline also just toggles the disabled flag - it does not save any pending changes
@@ -200,7 +200,7 @@ module.exports = angular.module('spinnaker.core.pipeline.config.pipelineConfigur
         resolve: {
           pipeline: () => getOriginal()
         }
-      }).result.then(() => disableToggled(true));
+      }).result.then(() => disableToggled(true)).catch(() => {});
     };
 
     function disableToggled(isDisabled) {
@@ -218,9 +218,7 @@ module.exports = angular.module('spinnaker.core.pipeline.config.pipelineConfigur
         resolve: {
           pipeline: () => $scope.pipeline
         }
-      }).result.then(function() {
-        setOriginal($scope.pipeline);
-      });
+      }).result.then(() => setOriginal($scope.pipeline)).catch(() => {});
     };
 
     this.unlockPipeline = () => {
@@ -233,7 +231,7 @@ module.exports = angular.module('spinnaker.core.pipeline.config.pipelineConfigur
       }).result.then(function () {
         delete $scope.pipeline.locked;
         setOriginal($scope.pipeline);
-      });
+      }).catch(() => {});
     };
 
     this.showHistory = () => {
@@ -249,7 +247,7 @@ module.exports = angular.module('spinnaker.core.pipeline.config.pipelineConfigur
       }).result.then(newConfig => {
         $scope.pipeline = newConfig;
         this.savePipeline();
-      });
+      }).catch(() => {});
     };
 
     // Poor react setState
@@ -339,6 +337,7 @@ module.exports = angular.module('spinnaker.core.pipeline.config.pipelineConfigur
         delete $scope.pipeline.isNew;
         $scope.renderablePipeline = plan;
       })
+      .catch(() => {})
       .finally(() => this.setViewState({ loading: false }));
     };
 

--- a/app/scripts/modules/core/src/pipeline/config/preconditions/preconditionList.directive.js
+++ b/app/scripts/modules/core/src/pipeline/config/preconditions/preconditionList.directive.js
@@ -51,7 +51,7 @@ module.exports = angular.module('spinnaker.core.pipeline.config.preconditions.pr
             $scope.preconditions[$scope.preconditions.indexOf(precondition)] = newPrecondition;
           }
           vm.isPreconditionsDirty = true;
-        });
+        }).catch(() => {});
       };
 
       vm.addPrecondition = function (strategy) {

--- a/app/scripts/modules/core/src/pipeline/config/stages/createLoadBalancer/createLoadBalancerStage.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/createLoadBalancer/createLoadBalancerStage.js
@@ -48,7 +48,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.createLoadBalance
           }
         }).result.then(function(newLoadBalancer) {
           $scope.stage.loadBalancers.push(newLoadBalancer);
-        });
+        }).catch(() => {});
 
       });
     };
@@ -69,7 +69,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.createLoadBalance
           }
         }).result.then(function(updatedLoadBalancer) {
           $scope.stage.loadBalancers[index] = updatedLoadBalancer;
-        });
+        }).catch(() => {});
 
       });
     };

--- a/app/scripts/modules/core/src/pipeline/config/stages/deploy/deployStage.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/deploy/deployStage.js
@@ -119,7 +119,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.deployStage', [
             var stageCluster = serverGroupTransformer.convertServerGroupCommandToDeployConfiguration(command);
             delete stageCluster.credentials;
             $scope.stage.clusters.push(stageCluster);
-          });
+          }).catch(() => {});
       });
     };
 
@@ -145,7 +145,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.deployStage', [
           var stageCluster = serverGroupTransformer.convertServerGroupCommandToDeployConfiguration(command);
           delete stageCluster.credentials;
           $scope.stage.clusters[index] = stageCluster;
-        });
+        }).catch(() => {});
     };
 
     this.copyCluster = function(index) {

--- a/app/scripts/modules/core/src/pipeline/config/stages/manualJudgment/manualJudgmentStage.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/manualJudgment/manualJudgmentStage.js
@@ -69,7 +69,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.manualJudgmentSta
         } else {
           $scope.stage.notifications[$scope.stage.notifications.indexOf(notification)] = newNotification;
         }
-      });
+      }).catch(() => {});
 
     };
 

--- a/app/scripts/modules/core/src/pipeline/config/stages/stage.module.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/stage.module.js
@@ -103,7 +103,7 @@ module.exports = angular.module('spinnaker.core.pipeline.config.stage', [
         }
       }).result.then(() => {
         $scope.$broadcast('pipeline-json-edited');
-      });
+      }).catch(() => {});
     };
 
     this.selectStageType = stage => {

--- a/app/scripts/modules/core/src/pipeline/config/stages/webhook/webhookStage.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/webhook/webhookStage.ts
@@ -100,7 +100,7 @@ export class WebhookStage implements IController {
       controllerAs: 'addCustomHeader',
     }).result.then((customHeader: ICustomHeader) => {
       this.stage.customHeaders[customHeader.key] = customHeader.value;
-    });
+    }).catch(() => {});
   }
 
   public displayField(field: string): boolean {

--- a/app/scripts/modules/core/src/projects/project.controller.js
+++ b/app/scripts/modules/core/src/projects/project.controller.js
@@ -97,7 +97,7 @@ module.exports = angular.module('spinnaker.core.projects.project.controller', [
               $state.go($state.current, {}, {reload: true});
             }
           }
-      });
+      }).catch(() => {});
     };
 
   });

--- a/app/scripts/modules/core/src/projects/projects.controller.js
+++ b/app/scripts/modules/core/src/projects/projects.controller.js
@@ -48,7 +48,7 @@ module.exports = angular.module('spinnaker.projects.controller', [
             resolve: {
               projectConfig: () => { return {}; },
             }
-          }).result.then(routeToProject);
+          }).result.then(routeToProject).catch(() => {});
         }
       }
     ];

--- a/app/scripts/modules/core/src/search/infrastructure/infrastructure.controller.js
+++ b/app/scripts/modules/core/src/search/infrastructure/infrastructure.controller.js
@@ -126,7 +126,7 @@ module.exports = angular.module('spinnaker.search.infrastructure.controller', [
         resolve: {
           projectConfig: () => { return {}; },
         }
-      }).result.then(routeToProject);
+      }).result.then(routeToProject).catch(() => {});
     };
 
     function routeToProject(project) {
@@ -143,7 +143,7 @@ module.exports = angular.module('spinnaker.search.infrastructure.controller', [
         templateUrl: overrideRegistry.getTemplate('createApplicationModal', require('../../application/modal/newapplication.html')),
         controller: overrideRegistry.getController('CreateApplicationModalCtrl'),
         controllerAs: 'newAppModal'
-      }).result.then(routeToApplication);
+      }).result.then(routeToApplication).catch(() => {});
     };
 
     function routeToApplication(app) {

--- a/app/scripts/modules/core/src/search/infrastructure/infrastructureV2.controller.ts
+++ b/app/scripts/modules/core/src/search/infrastructure/infrastructureV2.controller.ts
@@ -148,7 +148,7 @@ export class InfrastructureV2Ctrl implements IController {
           return {};
         },
       }
-    }).result.then(this.routeToProject);
+    }).result.then(this.routeToProject).catch(() => {});
   };
 
   private routeToProject(project: IProject) {
@@ -161,7 +161,7 @@ export class InfrastructureV2Ctrl implements IController {
       templateUrl: this.overrideRegistry.getTemplate('createApplicationModal', require('../../application/modal/newapplication.html')),
       controller: this.overrideRegistry.getController('CreateApplicationModalCtrl'),
       controllerAs: 'newAppModal'
-    }).result.then(this.routeToApplication);
+    }).result.then(this.routeToApplication).catch(() => {});
   };
 
   private routeToApplication(app: Application) {

--- a/app/scripts/modules/google/src/pipeline/stages/bake/gceBakeStage.js
+++ b/app/scripts/modules/google/src/pipeline/stages/bake/gceBakeStage.js
@@ -105,7 +105,7 @@ module.exports = angular.module('spinnaker.gce.pipeline.stage..bakeStage', [
         }
       }).result.then(function(extendedAttribute) {
           $scope.stage.extendedAttributes[extendedAttribute.key] = extendedAttribute.value;
-      });
+      }).catch(() => {});
     };
 
     this.removeExtendedAttribute = function (key) {

--- a/app/scripts/modules/openstack/pipeline/stages/bake/openstackBakeStage.js
+++ b/app/scripts/modules/openstack/pipeline/stages/bake/openstackBakeStage.js
@@ -115,7 +115,7 @@ module.exports = angular.module('spinnaker.openstack.pipeline.stage.bakeStage', 
         }
       }).result.then(function(extendedAttribute) {
           $scope.stage.extendedAttributes[extendedAttribute.key] = extendedAttribute.value;
-      });
+      }).catch(() => {});
     };
 
     this.removeExtendedAttribute = function(key) {


### PR DESCRIPTION
With the changes from [this PR](https://github.com/spinnaker/deck/commit/64d385fab6ec93f71208b5888bbcf3f8b52c537e), we need to provide a catch if we are doing anything with the `result` of a modal being opened.

The decorator is in place to catch dismiss calls from `ReactInjector`d modals, e.g. clicking "Create Load Balancer", then dismissing the modal. Not sure why that always triggers the exception, but it does.