### PR TITLE
feat(provider/kubernetes): Enable annotations, labels and secrets for security groups (aka ingress resources) (spinnaker/spinnaker#2000)

### DIFF
--- a/app/scripts/modules/kubernetes/help/kubernetes.help.ts
+++ b/app/scripts/modules/kubernetes/help/kubernetes.help.ts
@@ -127,6 +127,8 @@ const helpContents: {[key: string]: string} = {
   'kubernetes.ingress.rules.host': 'The fully qualified domain name of a network host. Any traffic routed to this host matches this rule. May not be an IP address, or contain port information.',
   'kubernetes.ingress.rules.path': 'POSIX regex (IEE Std 1003.1) matched against the path of an incoming request.',
   'kubernetes.ingress.rules.port': 'The port on the specifed load balancer to route traffic to.',
+  'kubernetes.ingress.tls.host': 'The fully qualified domain name of a network host. Any traffic routed to this host can be secured with TLS. May not be an IP address, or contain port information.',
+  'kubernetes.ingress.tls.secret': '(Optional) Name of the Kubernetes secret that will be used to secure TLS connections to the security group. Note that Spinnaker will not create any secrets, they are assumed to exist.',
 };
 
 export const KUBERNETES_HELP = 'spinnaker.kubernetes.help.contents';

--- a/app/scripts/modules/kubernetes/securityGroup/configure/configure.kubernetes.module.js
+++ b/app/scripts/modules/kubernetes/securityGroup/configure/configure.kubernetes.module.js
@@ -5,5 +5,6 @@ const angular = require('angular');
 module.exports = angular.module('spinnaker.securityGroup.configure.kubernetes', [
   require('./wizard/backend.controller.js').name,
   require('./wizard/rules.controller.js').name,
+  require('./wizard/tls.controller.js').name,
   require('./wizard/upsert.controller.js').name,
 ]);

--- a/app/scripts/modules/kubernetes/securityGroup/configure/wizard/advancedSettings.html
+++ b/app/scripts/modules/kubernetes/securityGroup/configure/wizard/advancedSettings.html
@@ -1,0 +1,8 @@
+<form class="container-fluid form-horizontal" name="advancedSettings">
+  <div class="col-md-12">
+    <map-editor model="securityGroup.annotations" label="Annotations" add-button-label="Add Annotations" labels-left="true"></map-editor>
+  </div>
+  <div class="col-md-12">
+    <map-editor model="securityGroup.labels" label="Labels" add-button-label="Add Labels" labels-left="true"></map-editor>
+  </div>
+</form>

--- a/app/scripts/modules/kubernetes/securityGroup/configure/wizard/createWizard.html
+++ b/app/scripts/modules/kubernetes/securityGroup/configure/wizard/createWizard.html
@@ -8,6 +8,12 @@
   <v2-wizard-page key="rules" label="Rules">
     <ng-include src="pages.rules"></ng-include>
   </v2-wizard-page>
+  <v2-wizard-page key="tls" label="TLS">
+    <ng-include src="pages.tls"></ng-include>
+  </v2-wizard-page>
+  <v2-wizard-page key="Advanced Settings" label="Advanced Settings">
+    <ng-include src="pages.advancedSettings"></ng-include>
+  </v2-wizard-page>
 </v2-modal-wizard>
 <div class="modal-footer">
   <button ng-disabled="taskMonitor.submitting" class="btn btn-default"

--- a/app/scripts/modules/kubernetes/securityGroup/configure/wizard/editWizard.html
+++ b/app/scripts/modules/kubernetes/securityGroup/configure/wizard/editWizard.html
@@ -8,6 +8,12 @@
   <v2-wizard-page key="rules" label="Rules">
     <ng-include src="pages.rules"></ng-include>
   </v2-wizard-page>
+  <v2-wizard-page key="tls" label="TLS">
+    <ng-include src="pages.tls"></ng-include>
+  </v2-wizard-page>
+  <v2-wizard-page key="Advanced Settings" label="Advanced Settings">
+    <ng-include src="pages.advancedSettings"></ng-include>
+  </v2-wizard-page>
 </v2-modal-wizard>
 <div class="modal-footer">
   <button ng-disabled="taskMonitor.submitting" class="btn btn-default"

--- a/app/scripts/modules/kubernetes/securityGroup/configure/wizard/tls.controller.js
+++ b/app/scripts/modules/kubernetes/securityGroup/configure/wizard/tls.controller.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const angular = require('angular');
+
+module.exports = angular.module('spinnaker.securityGroup.configure.kubernetes.tls', [
+    require('../../transformer.js').name,
+])
+  .controller('kubernetesSecurityGroupTLSController', function($scope, kubernetesSecurityGroupTransformer) {
+    this.addTLSEntry = function() {
+      $scope.securityGroup.tls.push(kubernetesSecurityGroupTransformer.constructNewIngressTLS());
+    };
+
+    this.removeTLSEntry = function(i) {
+      $scope.securityGroup.tls.splice(i, 1);
+    };
+  });

--- a/app/scripts/modules/kubernetes/securityGroup/configure/wizard/tls.html
+++ b/app/scripts/modules/kubernetes/securityGroup/configure/wizard/tls.html
@@ -1,0 +1,34 @@
+<form ng-controller="kubernetesSecurityGroupTLSController as tlsController" class="container-fluid form-horizontal" name="rules">
+  <div class="col-md-12">
+    <div ng-repeat="tls in securityGroup.tls">
+      <hr ng-if="$index > 0">
+      <div class="form-group">
+        <div class="col-md-3 sm-label-right">
+          Host
+          <help-field key="kubernetes.ingress.tls.host"></help-field>
+        </div>
+        <div class="col-md-6">
+          <input type="text" class="form-control input-sm" name="details" ng-model="tls.hosts"/>
+        </div>
+        <div class="col-md-1">
+          <button class="btn btn-sm btn-default" ng-click="tlsController.removeTLSEntry($index)">
+             <span class="glyphicon glyphicon-trash visible-lg-inline"></span>
+             <span class="visible-lg-inline"> Remove Entry</span>
+          </button>
+        </div>
+      </div>
+      <div class="form-group">
+        <div class="col-md-3 sm-label-right">
+          Secret
+          <help-field key="kubernetes.ingress.tls.secret"></help-field>
+        </div>
+        <div class="col-md-6">
+          <input type="text" class="form-control input-sm" name="details" ng-model="tls.secretName"/>
+        </div>
+      </div>
+    </div>
+    <button class="add-new btn btn-block btn-sm" ng-click="tlsController.addTLSEntry()"><span
+      class="glyphicon glyphicon-plus-sign"></span> Add New TLS Entry
+    </button>
+  </div>
+</form>

--- a/app/scripts/modules/kubernetes/securityGroup/configure/wizard/upsert.controller.js
+++ b/app/scripts/modules/kubernetes/securityGroup/configure/wizard/upsert.controller.js
@@ -34,6 +34,8 @@ module.exports = angular.module('spinnaker.securityGroup.kubernetes.create.contr
       basicSettings: require('./basicSettings.html'),
       backend: require('./backend.html'),
       rules: require('./rules.html'),
+      tls: require('./tls.html'),
+      advancedSettings: require('./advancedSettings.html'),
     };
 
     $scope.state = {
@@ -181,6 +183,14 @@ module.exports = angular.module('spinnaker.securityGroup.kubernetes.create.contr
             cloudProvider: 'kubernetes',
             region: $scope.securityGroup.namespace,
           };
+
+          // Change TLS hosts from string to array for Clouddriver (if it isn't already an array)
+          for (let idx in $scope.securityGroup.tls) {
+            if (!Array.isArray($scope.securityGroup.tls[idx].hosts)) {
+              $scope.securityGroup.tls[idx].hosts = [$scope.securityGroup.tls[idx].hosts];
+            }
+          }
+
           return securityGroupWriter.upsertSecurityGroup($scope.securityGroup, application, descriptor, params);
         }
       );

--- a/app/scripts/modules/kubernetes/securityGroup/details/details.controller.js
+++ b/app/scripts/modules/kubernetes/securityGroup/details/details.controller.js
@@ -43,6 +43,12 @@ module.exports = angular.module('spinnaker.securityGroup.kubernetes.details.cont
           autoClose();
         } else {
           $scope.securityGroup = details;
+
+          // Change TLS hosts from array to string for the UI
+          for (let idx in $scope.securityGroup.tls) {
+            const tls = $scope.securityGroup.tls[idx];
+            tls.hosts = tls.hosts[0];
+          }
         }
       },
         autoClose

--- a/app/scripts/modules/kubernetes/securityGroup/details/details.html
+++ b/app/scripts/modules/kubernetes/securityGroup/details/details.html
@@ -75,11 +75,34 @@
         No rules created
       </dl>
     </collapsible-section>
+    <collapsible-section heading="TLS">
+      <dl ng-class="insightCtrl.vm.filtersExpanded ? '' : 'dl-horizontal dl-medium'"
+          ng-repeat="tls in securityGroup.ingress.spec.tls"
+          ng-if="securityGroup.ingress.spec.tls.length">
+        <dt>Host</dt>
+        <dd>{{tls.hosts[0]}}</dd>
+      </dl>
+      <dl ng-if="!securityGroup.ingress.spec.tls.length">
+        No TLS entries created
+      </dl>
+    </collapsible-section>
     <collapsible-section heading="Status">
       <dl ng-class="insightCtrl.vm.filtersExpanded ? '' : 'dl-horizontal dl-medium'"
           ng-repeat="ingress in securityGroup.ingress.status.loadBalancer.ingress">
         <dt>IP</dt>
         <dd>{{ingress.ip}}</dd>
+      </dl>
+    </collapsible-section>
+    <collapsible-section heading="Annotations" ng-if="securityGroup.ingress.metadata.annotations">
+      <dl class="dl-horizontal dl-flex">
+        <kubernetes-key-value-details map="securityGroup.ingress.metadata.annotations">
+        </kubernetes-key-value-details>
+      </dl>
+    </collapsible-section>
+    <collapsible-section heading="Labels" ng-if="securityGroup.ingress.metadata.labels">
+      <dl class="dl-horizontal dl-flex">
+        <kubernetes-key-value-details map="securityGroup.ingress.metadata.labels">
+        </kubernetes-key-value-details>
       </dl>
     </collapsible-section>
   </div>

--- a/app/scripts/modules/kubernetes/securityGroup/transformer.js
+++ b/app/scripts/modules/kubernetes/securityGroup/transformer.js
@@ -25,6 +25,7 @@ module.exports = angular.module('spinnaker.kubernetes.securityGroup.transformer'
         },
 
         rules: [],
+        tls: [],
       };
     }
 
@@ -49,10 +50,18 @@ module.exports = angular.module('spinnaker.kubernetes.securityGroup.transformer'
       };
     }
 
+    function constructNewIngressTLS() {
+      return {
+        hosts : [],
+        secretName: '',
+      };
+    }
+
     return {
       normalizeSecurityGroup: normalizeSecurityGroup,
       constructNewSecurityGroupTemplate: constructNewSecurityGroupTemplate,
       constructNewIngressRule: constructNewIngressRule,
       constructNewIngressPath: constructNewIngressPath,
+      constructNewIngressTLS: constructNewIngressTLS,
     };
   });


### PR DESCRIPTION
This enables the setting of annotations, labels and TLS secrets on k8s Security groups (aka ingress resources) from the UI.

It is one of 2 PR's that fix spinnaker/spinnaker#2000 (the other being spinnaker/clouddriver#2005)