### PR TITLE
fix(pipelines): guard against missing info on deploy stage

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/deploy/deployExecutionDetails.controller.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/deploy/deployExecutionDetails.controller.js
@@ -91,10 +91,10 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.deploy.details.co
         const serverGroupName = context['deploy.server.groups'][context.source.region][0];
         serverGroupReader.getServerGroup(context.application, context.account, context.source.region, serverGroupName)
           .then(serverGroup => {
-            if (serverGroup.buildInfo.jenkins) {
+            if (_.has(serverGroup, 'buildInfo.jenkins')) {
               $scope.changeConfig.buildInfo.jenkins = serverGroup.buildInfo.jenkins;
             }
-          });
+          }).catch(() => {});
       }
     };
 


### PR DESCRIPTION
Adding a couple of checks to avoid some exceptions when 
a) the server group has been destroyed
b) the server group has no `buildInfo`