### PR TITLE
fix(provider/gce): Fix credential account handling in svg wizard.

### DIFF
--- a/app/scripts/modules/google/src/serverGroup/configure/serverGroupCommandBuilder.service.js
+++ b/app/scripts/modules/google/src/serverGroup/configure/serverGroupCommandBuilder.service.js
@@ -263,18 +263,12 @@ module.exports = angular.module('spinnaker.gce.serverGroupCommandBuilder.service
     function attemptToSetValidCredentials(application, defaultCredentials, command) {
       return accountService.listAccounts('gce').then(function(gceAccounts) {
         var gceAccountNames = _.map(gceAccounts, 'name');
-        var firstGCEAccount = null;
-
-        if (application.accounts.length) {
-          firstGCEAccount = _.find(application.accounts, function (applicationAccount) {
-            return gceAccountNames.includes(applicationAccount);
-          });
-        }
+        var firstGCEAccount = gceAccountNames[0];
 
         var defaultCredentialsAreValid = defaultCredentials && gceAccountNames.includes(defaultCredentials);
 
         command.credentials =
-          defaultCredentialsAreValid ? defaultCredentials : (firstGCEAccount ? firstGCEAccount : 'my-account-name');
+          defaultCredentialsAreValid ? defaultCredentials : (firstGCEAccount || 'my-account-name');
       });
     }
 


### PR DESCRIPTION
Removes 'application accounts' handling for a simpler and straightforward approach. Fixes an issue where infrastructure needs to be present for regions/networks/subnets etc to be populated in the server group from the credentials.

Dan typed this change on my keyboard.