### PR TITLE
fix(pipelines): add validator to webhook stage "method" field

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/webhook/webhookStage.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/webhook/webhookStage.ts
@@ -126,6 +126,7 @@ module(WEBHOOK_STAGE, [
     executionDetailsUrl: require('./webhookExecutionDetails.html'),
     validators: [
       {type: 'requiredField', fieldName: 'url'},
+      {type: 'requiredField', fieldName: 'method'}
     ]
   });
 }).run((pipelineConfig: PipelineConfigProvider, API: Api) => {


### PR DESCRIPTION
It's not _really_ required, but it's confusing that it'll default to a `POST` on the backend, so let's strongly suggest users enter something.