### PR TITLE
feat(moniker) - adding monikers to the deploy stage

### DIFF
--- a/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupCommandBuilder.service.js
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupCommandBuilder.service.js
@@ -45,7 +45,7 @@ module.exports = angular.module('spinnaker.amazon.serverGroupCommandBuilder.serv
           var useAmiBlockDeviceMappings = applicationAwsSettings.useAmiBlockDeviceMappings || false;
 
           var command = {
-            application: application.name,
+            application: application,
             credentials: defaultCredentials,
             region: defaultRegion,
             strategy: '',
@@ -189,7 +189,7 @@ module.exports = angular.module('spinnaker.amazon.serverGroupCommandBuilder.serv
         var useAmiBlockDeviceMappings = applicationAwsSettings.useAmiBlockDeviceMappings || false;
 
         var command = {
-          application: application.name,
+          application: application,
           strategy: '',
           stack: serverGroupName.stack,
           freeFormDetails: serverGroupName.freeFormDetails,

--- a/app/scripts/modules/core/src/serverGroup/configure/common/serverGroupCommandBuilder.service.ts
+++ b/app/scripts/modules/core/src/serverGroup/configure/common/serverGroupCommandBuilder.service.ts
@@ -1,6 +1,7 @@
 import {module} from 'angular';
 
 import { Application } from 'core/application/application.model';
+import { IMoniker } from 'core/naming/IMoniker';
 import { ILoadBalancer, ISecurityGroup, ISubnet, IEntityTags } from 'core/domain';
 import { ICapacity } from 'core/serverGroup/serverGroupWriter.service';
 import { IDeploymentStrategy } from 'core/deploymentStrategy';
@@ -95,6 +96,7 @@ export interface IServerGroupCommand extends IServerGroupCommandResult {
     asgName: string;
   };
   stack?: string;
+  moniker?: IMoniker;
   strategy: string;
   subnetType: string;
   suspendedProcesses: string[];


### PR DESCRIPTION
This feature adds monikers to the amazon deploy stage.  One line of note is regarding the stringify of the application object below.  This is because the model (IServerGroupCommand) expecting an Application object but at runtime a string is given (see screenshot below).  So to avoid a compilation error, we stringify.  Not sure if there is a better approach.

![image](https://user-images.githubusercontent.com/69049/31580230-60729cd4-b0fe-11e7-85bd-b25d6edaa7ca.png)
