### PR TITLE
OS load balancer network and sg bugfixes

### DIFF
--- a/app/scripts/modules/openstack/common/cacheBackedMultiSelect.template.html
+++ b/app/scripts/modules/openstack/common/cacheBackedMultiSelect.template.html
@@ -10,7 +10,7 @@
     </ui-select>
   </div>
   <div class="col-md-1 sm-label-left">
-    <a href="" ng-click="forceRefreshCache()" uib-tooltip-template="refreshTooltipTemplate">
+    <a href="" ng-click="forceRefreshCache()">
       <span class="fa fa-refresh" ng-class="{'fa-spin':cache.loading}"></span>
     </a>
   </div>

--- a/app/scripts/modules/openstack/loadBalancer/configure/wizard/interface.html
+++ b/app/scripts/modules/openstack/loadBalancer/configure/wizard/interface.html
@@ -1,11 +1,18 @@
 <ng-form class="container-fluid form-horizontal" name="interfaceForm">
   <div class="modal-body">
-    <network-select-field model="loadBalancer.networkId" help-key="openstack.loadBalancer.network" read-only="!isNew"></network-select-field>
+    <network-select-field
+      model="loadBalancer.networkId"
+      help-key="openstack.loadBalancer.network"
+      read-only="!isNew"
+      filter="{ account: loadBalancer.account }">
+    </network-select-field>
 
-    <os-cache-backed-multi-select-field label="Security Groups"
-                                            cache="allSecurityGroups"
-                                            refresh-cache="updateSecurityGroups"
-                                            required="true"
-                                            model="loadBalancer.securityGroups"></os-cache-backed-multi-select-field>
+    <os-cache-backed-multi-select-field
+      label="Security Groups"
+      cache="allSecurityGroups"
+      refresh-cache="updateSecurityGroups"
+      required="true"
+      model="loadBalancer.securityGroups">
+    </os-cache-backed-multi-select-field>
   </div>
 </ng-form>

--- a/app/scripts/modules/openstack/loadBalancer/configure/wizard/upsert.controller.js
+++ b/app/scripts/modules/openstack/loadBalancer/configure/wizard/upsert.controller.js
@@ -58,6 +58,7 @@ module.exports = angular.module('spinnaker.loadBalancer.openstack.create.control
     $scope.allSecurityGroups = [];
     $scope.$watch('loadBalancer.account', updateSecurityGroups);
     $scope.$watch('loadBalancer.region', updateSecurityGroups);
+    $scope.updateSecurityGroups = updateSecurityGroups;
     updateSecurityGroups();
 
     // initialize controller
@@ -158,6 +159,9 @@ module.exports = angular.module('spinnaker.loadBalancer.openstack.create.control
     this.accountUpdated = function() {
       ctrl.updateName();
       $scope.subnetFilter = {type: 'openstack', account: $scope.loadBalancer.account, region: $scope.loadBalancer.region};
+      if ($scope.loadBalancer) {
+        $scope.loadBalancer.securityGroups = [];
+      }
       updateLoadBalancerNames();
     };
 

--- a/app/scripts/modules/openstack/network/networkSelectField.directive.js
+++ b/app/scripts/modules/openstack/network/networkSelectField.directive.js
@@ -51,10 +51,12 @@ module.exports = angular.module('spinnaker.openstack.network.networkSelectField.
               scope.onChange({network: newValue});
             }
           }
-
         });
 
-        scope.$watch('filter', function() { scope.$broadcast('updateOptions'); });
+        scope.$watch('filter', function() {
+          scope.$broadcast('onValueChanged');
+          scope.updateOptions();
+        });
       }
     };
 });


### PR DESCRIPTION
fix(provider/openstack): Fixed network so it is filtered by account for load balancer creation.
fix(provider/openstack): Fixed network so it refreshes when a new account is selected.
fix(provider/openstack): Fixed network so it resets to default when a new account is selected and the selected network becomes invalid.
fix(provider/openstack): Fixed security groups so it clears and refreshes when a new account is selected.
fix(provider/openstack): Fixed security groups refresh button.
fix(provider/openstack): Removed security group refresh tooltip that wasn't showing any data.