### PR TITLE
feat(entitytags): Show replaced server group details in popover

### DIFF
--- a/app/scripts/modules/core/src/entityTag/entitySource.popover.html
+++ b/app/scripts/modules/core/src/entityTag/entitySource.popover.html
@@ -1,16 +1,29 @@
 <dl>
   <dt>{{$ctrl.executionType}}</dt>
   <dd>{{$ctrl.metadata.value.description}}</dd>
-  <div ng-if="$ctrl.execution">
+  <div ng-if="$ctrl.execution" style="margin-top: 10px">
     <dt>Triggered by</dt>
     <dd ng-if="$ctrl.metadata.value.user">{{$ctrl.metadata.value.user}}</dd>
     <dd ng-if="!$ctrl.metadata.value.user">{{$ctrl.execution.trigger.type}}</dd>
   </div>
-  <div ng-if="!$ctrl.execution && $ctrl.metadata.value.user">
+
+  <div ng-if="!$ctrl.execution && $ctrl.metadata.value.user" style="margin-top: 10px">
     <dt>User</dt>
     <dd>{{$ctrl.metadata.value.user}}</dd>
   </div>
-  <div ng-if="$ctrl.metadata.value.comments">
+
+  <div ng-if="$ctrl.metadata.value.previousServerGroup" style="margin-top: 10px">
+    <dt>Replaced</dt>
+    <dd>
+      {{$ctrl.metadata.value.previousServerGroup.name}}<br/>
+      {{$ctrl.metadata.value.previousServerGroup.imageName}}
+      <span ng-if="$ctrl.metadata.value.previousServerGroup.imageId !== $ctrl.metadata.value.previousServerGroup.imageName">
+        ({{$ctrl.metadata.value.previousServerGroup.imageId}})
+      </span>
+    </dd>
+  </div>
+
+  <div ng-if="$ctrl.metadata.value.comments" style="margin-top: 10px">
     <dt>Comments</dt>
     <dd ng-bind-html="$ctrl.comments"></dd>
   </div>


### PR DESCRIPTION
As of spinnaker/orca#1705, `orca` is now adding previous server group
details to the `spinnaker:metadata` tag.

These details include:
- previous server group name
- image name
- image id

![image](https://user-images.githubusercontent.com/388652/31700718-206e7566-b380-11e7-8189-72ea742c0c79.png)
