### PR TITLE
fix(core): render reason as HTML in tasks view

### DIFF
--- a/app/scripts/modules/core/src/task/tasks.html
+++ b/app/scripts/modules/core/src/task/tasks.html
@@ -160,7 +160,7 @@
             </tr>
             <tr ng-if="tasks.isExpanded(task.id) && task.getValueFor('reason')" class="task-reason">
               <td colspan="9">
-                <strong>Reason:</strong> {{task.getValueFor('reason')}}
+                <strong>Reason:</strong> <span ng-bind-html="task.getValueFor('reason')"></span>
               </td>
             </tr>
             <tr ng-if="tasks.isExpanded(task.id)" ng-repeat-end>


### PR DESCRIPTION
We claim in the placeholder text of the `reason` field in the modals that HTML is okay, so maybe we should try rendering HTML...