### PR TITLE
feat(provider/amazon): Rollback support for PREVIOUS_IMAGE strategy

### DIFF
--- a/app/scripts/modules/amazon/src/serverGroup/details/rollback/rollbackServerGroup.controller.js
+++ b/app/scripts/modules/amazon/src/serverGroup/details/rollback/rollbackServerGroup.controller.js
@@ -2,6 +2,7 @@
 
 const angular = require('angular');
 
+import { get } from 'lodash';
 import { SERVER_GROUP_WRITER, TASK_MONITOR_BUILDER } from '@spinnaker/core';
 
 module.exports = angular.module('spinnaker.amazon.serverGroup.details.rollback.controller', [
@@ -18,6 +19,28 @@ module.exports = angular.module('spinnaker.amazon.serverGroup.details.rollback.c
 
       var desired = serverGroup.capacity.desired;
 
+      var rollbackType = 'EXPLICIT';
+
+      if (allServerGroups.length === 0 && serverGroup.entityTags) {
+        const previousServerGroup = get(serverGroup, 'entityTags.creationMetadata.value.previousServerGroup');
+        if (previousServerGroup) {
+          rollbackType = 'PREVIOUS_IMAGE';
+          $scope.previousServerGroup = {
+            name: previousServerGroup.name,
+            imageName: previousServerGroup.imageName
+          };
+
+          if (previousServerGroup.imageId && previousServerGroup.imageId !== previousServerGroup.imageName) {
+            $scope.previousServerGroup.imageId = previousServerGroup.imageId;
+          }
+
+          const buildNumber = get(previousServerGroup, 'buildInfo.jenkins.number');
+          if (buildNumber) {
+            $scope.previousServerGroup.buildNumber = buildNumber;
+          }
+        }
+      }
+
       if (desired < 10) {
         var healthyPercent = 100;
       } else if (desired < 20) {
@@ -28,7 +51,7 @@ module.exports = angular.module('spinnaker.amazon.serverGroup.details.rollback.c
       }
 
       $scope.command = {
-        rollbackType: 'EXPLICIT',
+        rollbackType: rollbackType,
         rollbackContext: {
           rollbackServerGroupName: serverGroup.name,
           targetHealthyRollbackPercentage: healthyPercent
@@ -51,6 +74,11 @@ module.exports = angular.module('spinnaker.amazon.serverGroup.details.rollback.c
         var command = $scope.command;
         if (!$scope.verification.verified) {
           return false;
+        }
+
+        if (rollbackType === 'PREVIOUS_IMAGE') {
+          // no need to validate when using an explicit image
+          return true;
         }
 
         return command.rollbackContext.restoreServerGroupName !== undefined;

--- a/app/scripts/modules/amazon/src/serverGroup/details/rollback/rollbackServerGroup.html
+++ b/app/scripts/modules/amazon/src/serverGroup/details/rollback/rollbackServerGroup.html
@@ -10,13 +10,25 @@
         <div class="col-sm-3 sm-label-right">
           Restore to
         </div>
-        <div class="col-sm-6">
-          <ui-select ng-model="command.rollbackContext.restoreServerGroupName" class="form-control input-sm">
+        <div class="col-sm-8">
+          <ui-select ng-model="command.rollbackContext.restoreServerGroupName"
+                     class="form-control input-sm"
+                     ng-if="command.rollbackType === 'EXPLICIT'">
             <ui-select-match placeholder="Select...">{{ctrl.label($select.selected)}}</ui-select-match>
             <ui-select-choices group-by="ctrl.group" repeat="serverGroup.name as serverGroup in allServerGroups">
               <span ng-bind-html="ctrl.label(serverGroup)"></span>
             </ui-select-choices>
           </ui-select>
+          <div ng-if="command.rollbackType === 'PREVIOUS_IMAGE'" style="margin-top: 5px">
+            {{ previousServerGroup.name }} <span class="small">(no longer deployed)</span><br/>
+            <span class="small">
+              <strong>Image</strong>: {{ previousServerGroup.imageName}}
+              <span ng-if="previousServerGroup.imageId">({{ previousServerGroup.imageId }})</span><br/>
+            </span>
+            <span class="small" ng-if="previousServerGroup.buildNumber">
+              <strong>Build</strong> #{{ previousServerGroup.buildNumber }}
+            </span>
+          </div>
         </div>
       </div>
 
@@ -52,7 +64,7 @@
           Rollback Operations
         </div>
       </div>
-      <div class="row">
+      <div class="row" ng-if="command.rollbackType === 'EXPLICIT'">
         <div class="col-sm-11 col-sm-offset-1">
           <ol>
             <li>Enable <em>{{ command.rollbackContext.restoreServerGroupName || 'previous server group' }}</em></li>
@@ -70,6 +82,29 @@
             <li>Restore minimum capacity of <em>{{ command.rollbackContext.restoreServerGroupName || 'previous server group' }}</em> [
               <strong>min</strong>: {{ serverGroup.capacity.min }}
             ]</li>
+          </ol>
+          <p>
+            This rollback will affect server groups in {{ serverGroup.account }} ({{ serverGroup.region }}).
+          </p>
+        </div>
+      </div>
+      <div class="row" ng-if="command.rollbackType === 'PREVIOUS_IMAGE'">
+        <div class="col-sm-11 col-sm-offset-1">
+          <ol>
+            <li>Deploy <em>{{ previousServerGroup.imageId }}</em> [
+              <strong>min</strong>: {{serverGroup.capacity.desired}},
+              <strong>max</strong>: {{ serverGroup.capacity.max }},
+              <strong>desired</strong>: {{ serverGroup.capacity.desired }}
+              ]<br/>(minimum capacity pinned at {{serverGroup.capacity.desired}} to prevent autoscaling down during deploy)
+              <li ng-if="command.rollbackContext.targetHealthyRollbackPercentage < 100">
+                Wait for at least {{minHealthy(command.rollbackContext.targetHealthyRollbackPercentage)}}
+                instances to report as healthy
+              </li>
+            </li>
+            <li>Disable {{ serverGroup.name }}</li>
+            <li>Restore minimum capacity of <em>new server group</em> [
+              <strong>min</strong>: {{ serverGroup.capacity.min }}
+              ]</li>
           </ol>
           <p>
             This rollback will affect server groups in {{ serverGroup.account }} ({{ serverGroup.region }}).


### PR DESCRIPTION
Rolling back to a previous image is available iff:
- a `spinnaker:metadata` entity tag exists with `previousServerGroup`
details
- there are no other server groups in the cluster/region

![image](https://user-images.githubusercontent.com/388652/31796402-3084acae-b4de-11e7-8fd7-06cd537748f7.png)
