### PR TITLE
fix(core/pipeline): Show errors in time window stage execution details

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/executionWindows/executionWindowsDetails.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/executionWindows/executionWindowsDetails.html
@@ -3,6 +3,7 @@
   <execution-details-section-nav sections="configSections"></execution-details-section-nav>
   <div class="step-section-details" ng-if="detailsSection === 'windowConfig'">
     <execution-window-actions application="application" execution="execution" stage="stage"></execution-window-actions>
+    <stage-failure-message stage="stage" message="stage.failureMessage"></stage-failure-message>
   </div>
 
   <div class="step-section-details" ng-if="detailsSection === 'taskStatus'">


### PR DESCRIPTION
If an execution window fails, the reason is not displayed to the user. This PR fixes that.