### PR TITLE
feat(core/modal): Silence all rejection warning in console when ui-bootstrap modals are closed/cancelled.

### DIFF
--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/core",
-  "version": "0.0.91",
+  "version": "0.0.92",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/core/src/utils/uibModalRejections.ts
+++ b/app/scripts/modules/core/src/utils/uibModalRejections.ts
@@ -1,0 +1,17 @@
+import { module } from 'angular';
+import { IModalInstanceService, IModalService } from 'angular-ui-bootstrap';
+
+export const UIB_MODAL_REJECTIONS = 'spinnaker.core.utils.uibModalRejections';
+const mod = module(UIB_MODAL_REJECTIONS, []);
+
+// Avoid "Possibly unhandled rejection" in console when closing a uibModal
+mod.decorator('$uibModal', function($delegate: IModalService) {
+  const realOpen = $delegate.open;
+  $delegate.open = function() {
+    const modalInstance: IModalInstanceService = realOpen.apply(this, arguments);
+    modalInstance.result.catch(() => {});
+    return modalInstance;
+  };
+  return $delegate;
+});
+

--- a/app/scripts/modules/core/src/utils/utils.module.js
+++ b/app/scripts/modules/core/src/utils/utils.module.js
@@ -4,6 +4,7 @@ import { RENDER_IF_FEATURE } from './renderIfFeature.component';
 import { COPY_TO_CLIPBOARD_COMPONENT } from './clipboard/copyToClipboard.component';
 import { TIME_FORMATTERS } from './timeFormatters';
 import { SELECT_ON_DOUBLE_CLICK_DIRECTIVE } from 'core/utils/selectOnDblClick.directive';
+import { UIB_MODAL_REJECTIONS } from './uibModalRejections';
 
 const angular = require('angular');
 
@@ -15,6 +16,7 @@ module.exports = angular.module('spinnaker.utils', [
   SELECT_ON_DOUBLE_CLICK_DIRECTIVE,
   require('./infiniteScroll.directive.js').name,
   RENDER_IF_FEATURE,
+  UIB_MODAL_REJECTIONS,
   require('./waypoints/waypoint.directive').name,
   require('./waypoints/waypointContainer.directive').name,
 ]);


### PR DESCRIPTION
This still allows the `.result` to be chained off from the calling code, such as:

```
$uibmodal.open({ ... }).result.then(onConfirm, onCancel)
```