### PR TITLE
fix(core): handle running execution fetch failure

### DIFF
--- a/app/scripts/modules/core/src/delivery/executionGroup/execution/Execution.tsx
+++ b/app/scripts/modules/core/src/delivery/executionGroup/execution/Execution.tsx
@@ -185,7 +185,7 @@ export class Execution extends React.Component<IExecutionProps, IExecutionState>
             executionService.removeCompletedExecutionsFromRunningData(application);
           }
           refreshing = false;
-        });
+        }).catch(() => refreshing = false);
       });
     }
   }


### PR DESCRIPTION
If the `get` call fails, an exception will be thrown, but the execution will never try to refresh again, which can cause confusion.