### PR TITLE
fix(core/executions): tweak padding on status glyph

### DIFF
--- a/app/scripts/modules/core/src/delivery/details/executionDetails.less
+++ b/app/scripts/modules/core/src/delivery/details/executionDetails.less
@@ -120,6 +120,9 @@
 
   .stage-details {
     .stage-details-heading {
+      .status-glyph {
+        margin-right: 3px;
+      }
       text-transform: uppercase;
       margin-top: 0;
       h4 {


### PR DESCRIPTION
Small CSS adjustment. There used to be a whitespace character between the glyph and the heading text in the Angular days.