### PR TITLE
fix(core/pipeline): Fix corner case where masterStage was not set

### DIFF
--- a/app/scripts/modules/core/src/delivery/service/executions.transformer.service.ts
+++ b/app/scripts/modules/core/src/delivery/service/executions.transformer.service.ts
@@ -392,7 +392,9 @@ export class ExecutionsTransformerService {
     }, [] as IExecutionStageSummary[]);
 
     stageSummaries.forEach((summary) => {
-      if (summary.type === 'group' && summary.groupStages.length > 1) {
+      if (summary.type === 'group' && summary.groupStages.length === 1 && !summary.masterStage) {
+        summary.masterStage = summary.groupStages[0].masterStage;
+      } else if (summary.type === 'group' && summary.groupStages.length > 1) {
         const subComments: string[] = [];
         // Find the earliest startTime and latest endTime
         summary.groupStages.forEach((subStage) => {


### PR DESCRIPTION
In a few cases, where a group only contains one groupStage, the masterStage can be undefined. This will lead to a Deck crash when rendering the executions page. Fixed by copying the masterStage from the groupStage.
@jrsquared PTAL