### PR TITLE
fix(canary): Fix moniker for baseline/canary clusters

### DIFF
--- a/app/scripts/modules/amazon/package.json
+++ b/app/scripts/modules/amazon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/amazon",
-  "version": "0.0.46",
+  "version": "0.0.47",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupConfiguration.service.ts
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupConfiguration.service.ts
@@ -9,7 +9,6 @@ import {
   CacheInitializerService,
   IAccountDetails,
   IDeploymentStrategy,
-  IMoniker,
   IRegion,
   ISecurityGroup,
   IServerGroupCommand,
@@ -572,14 +571,7 @@ export class AwsServerGroupConfigurationService {
       };
 
       command.clusterChanged = (): void => {
-        const appName = command.application;
-        const moniker: IMoniker = {
-          app: appName,
-          stack: command.stack,
-          detail: command.freeFormDetails,
-          cluster: this.namingService.getClusterName(appName, command.stack, command.freeFormDetails)
-        };
-        command.moniker = moniker;
+        command.moniker = this.namingService.getMoniker(command.application, command.stack, command.freeFormDetails);
       };
 
       command.credentialsChanged = (): IServerGroupCommandResult => {

--- a/app/scripts/modules/canary/canary/canaryStage.js
+++ b/app/scripts/modules/canary/canary/canaryStage.js
@@ -148,6 +148,7 @@ module.exports = angular.module('spinnaker.canary.canaryStage', [
                                            namingService, providerSelectionService,
                                            authenticationService, cloudProviderRegistry,
                                            serverGroupCommandBuilder, awsServerGroupTransformer, accountService, appListExtractorService) {
+    'ngInject';
 
     $scope.isExpression = function(value) {
       return isString(value) && value.includes('${');
@@ -364,6 +365,7 @@ module.exports = angular.module('spinnaker.canary.canaryStage', [
         cluster.freeFormDetails += '-';
       }
       cluster.freeFormDetails += type.toLowerCase();
+      cluster.moniker = namingService.getMoniker(cluster.application, cluster.stack, cluster.freeFormDetails);
     }
 
     function configureServerGroupCommandForEditing(command) {

--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/core",
-  "version": "0.0.93",
+  "version": "0.0.94",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/core/src/naming/naming.service.ts
+++ b/app/scripts/modules/core/src/naming/naming.service.ts
@@ -1,5 +1,6 @@
 import { module } from 'angular';
 import { padStart, isNil } from 'lodash';
+import { IMoniker } from './IMoniker';
 
 export interface IComponentName {
   application: string;
@@ -99,6 +100,11 @@ export class NamingService {
 
   public parseSecurityGroupName(securityGroupName: string): IComponentName {
     return this.parseLoadBalancerName(securityGroupName);
+  }
+
+  public getMoniker(app: string, stack: string, detail: string): IMoniker {
+    const cluster = this.getClusterName(app, stack, detail);
+    return { app, stack, detail, cluster };
   }
 }
 


### PR DESCRIPTION
The `moniker` objects for the `*-baseline` and `*-canary` clusters were not being updated properly after editing the canary cluster configuration.

@anotherchrisberry @jrsquared @asher @cfieber