### PR TITLE
fix(core/projects): restore refresh icon, set app name on init

### DIFF
--- a/app/scripts/modules/core/src/projects/project.controller.js
+++ b/app/scripts/modules/core/src/projects/project.controller.js
@@ -8,7 +8,7 @@ import './project.less';
 module.exports = angular.module('spinnaker.core.projects.project.controller', [
   require('./configure/configureProject.modal.controller.js').name,
 ])
-  .controller('ProjectCtrl', function ($scope, $uibModal, $timeout, $state, projectConfiguration) {
+  .controller('ProjectCtrl', function ($scope, $uibModal, $timeout, $state, $stateParams, projectConfiguration) {
 
     this.project = projectConfiguration;
 
@@ -29,7 +29,7 @@ module.exports = angular.module('spinnaker.core.projects.project.controller', [
     let initialize = () => {
       projectConfiguration.config.applications = projectConfiguration.config.applications || [];
 
-      let selectedApplication = null;
+      let selectedApplication = $stateParams.application;
 
       // $stateParams is scoped to parent state, so if an application is selected, it will not be visible
       $scope.$on('$stateChangeSuccess', (event, toState, toParams) => {

--- a/app/scripts/modules/core/src/projects/project.less
+++ b/app/scripts/modules/core/src/projects/project.less
@@ -38,8 +38,12 @@
         margin-top: 0;
         min-width: 20px;
         margin-right: 0;
-        .application-name, .fa {
+        .application-name, .fa-window-maximize {
           display: none;
+        }
+        .refresher {
+          margin-top: 0;
+          padding-top: 5px;
         }
         a {
           margin-right: 0;


### PR DESCRIPTION
We lost the refresh icon when we changed it from bootstrap to font awesome.

The initial application setting broke (I think) when we upgraded ui-router at some point (looks like we were relying on the stateChangeSuccess event previously).