### PR TITLE
fix(core): omit exception message on stopped manual judgment stages

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/manualJudgment/ManualJudgmentExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/manualJudgment/ManualJudgmentExecutionDetails.tsx
@@ -43,7 +43,7 @@ export class ManualJudgmentExecutionDetails extends React.Component<IExecutionDe
 
         </dl>
         <ManualJudgmentApproval application={application} execution={execution} stage={stage}/>
-        <StageFailureMessage stage={stage} message={stage.failureMessage} />
+        {stage.context.judgmentInput && <StageFailureMessage stage={stage} message={stage.failureMessage} />}
       </ExecutionDetailsSection>
     )
   }


### PR DESCRIPTION
Fixes a regression from a couple of weeks ago, where a misleading exception on a manual judgment stage always appears when the user halts the stage.