### PR TITLE
fix(moniker): Arrange cluster by moniker.cluster if available

### DIFF
--- a/app/scripts/modules/core/src/cluster/cluster.service.ts
+++ b/app/scripts/modules/core/src/cluster/cluster.service.ts
@@ -213,10 +213,14 @@ export class ClusterService {
 
   private addNameParts(serverGroup: IServerGroup): void {
     const nameParts = this.namingService.parseServerGroupName(serverGroup.name);
-    serverGroup.app = nameParts.application;
-    serverGroup.stack = nameParts.stack;
-    serverGroup.detail = nameParts.freeFormDetails;
-    serverGroup.cluster = nameParts.cluster;
+    if (serverGroup.moniker) {
+      Object.assign(serverGroup, serverGroup.moniker);
+    } else {
+      serverGroup.app = nameParts.application;
+      serverGroup.stack = nameParts.stack;
+      serverGroup.detail = nameParts.freeFormDetails;
+      serverGroup.cluster = nameParts.cluster;
+    }
     serverGroup.category = 'serverGroup';
   }
 


### PR DESCRIPTION
After serverGroups are fetched from Clouddriver, `addNameParts()` runs:
https://github.com/spinnaker/deck/blob/master/app/scripts/modules/core/src/cluster/cluster.service.ts#L40

The original behavior was to fetch server groups from Clouddriver. Then overwrite app/stack/detail by re-deriving them via the `NamingService` in Deck. The `NamingService` uses the Frigga conventions. In the case of the Kubernetes V2 provider, it was really messing things up. In particular the cluster view was never organized correctly. All server groups for all providers fetched from clouddriver should now have a moniker, I added a check just as an extra precaution.

I think that in the long run we will probably want to just rely on the moniker to determine app/stack/detail, but we can address that in another iteration.