### PR TITLE
fix(aca): listing accounts from all providers

### DIFF
--- a/app/scripts/modules/canary/acaTask/acaTaskStage.js
+++ b/app/scripts/modules/canary/acaTask/acaTaskStage.js
@@ -59,16 +59,24 @@ module.exports = angular.module('spinnaker.canary.acaTaskStage', [
         : $scope.stage.canary.watchers //if it is not an array it is probably a SpEL
       : '';
 
-    accountService.getUniqueAttributeForAllAccounts('aws', 'regions')
-      .then( (regions) => {
-        $scope.regions = regions.sort();
+    var applicationProviders = $scope.application.attributes.cloudProviders;
+    if (applicationProviders.length === 0) {
+      applicationProviders[0] = 'aws'; // default to aws if no providers are set
+    }
+
+    $scope.accounts = new Array();
+    for (var i = 0; i < applicationProviders.length; i++) {
+      accountService.listAccounts(applicationProviders[i]).then(function(accounts) {
+        accountService.getUniqueAttributeForAllAccounts(applicationProviders[i], 'regions')
+        .then( (regions) => {
+          $scope.regions = regions.sort();
+        });
+
+      for (var j = 0; j < accounts.length; j++) {
+        $scope.accounts.push(accounts[j]);
+      }
       });
-
-
-    accountService.listAccounts('aws').then(function(accounts) {
-      $scope.accounts = accounts;
-    });
-
+    }
 
     //TODO: Extract to be reusable with canaryStage [zkt]
     this.updateWatchersList = () => {


### PR DESCRIPTION
This change is related to the issue filed [#2083](https://github.com/spinnaker/spinnaker/issues/2083), essentially that only AWS accounts are listed during ACA Task creation.

This change allows accounts to be picked from all configured (chosen during application creation) providers. If no providers are chosen, it defaults to pick AWS accounts. 