### PR TITLE
fix(core): support failed health status style

### DIFF
--- a/app/scripts/modules/core/src/cluster/rollups.less
+++ b/app/scripts/modules/core/src/cluster/rollups.less
@@ -90,7 +90,7 @@ table.instances {
     &.health-status-Up {
       background-color: var(--color-success-light);
     }
-    &.health-status-Down {
+    &.health-status-Down, &.health-status-Failed {
       background-color: var(--color-danger);
     }
     &.health-status-OutOfService {
@@ -119,7 +119,7 @@ table.instances {
       &.health-status-Up {
         background-color: var(--color-success);
       }
-      &.health-status-Down {
+      &.health-status-Down, &.health-status-Failed {
         background-color: var(--color-danger);
       }
       &.health-status-OutOfService {


### PR DESCRIPTION
add support for `health-status-Failed`. previously, instances in a
`Failed` state were getting the `Up` styling which is misleading.

Fixes spinnaker/spinnaker#2059