### PR TITLE
fix(aca): listing accounts from all configured providers

### DIFF
--- a/app/scripts/modules/canary/acaTask/acaTaskStage.js
+++ b/app/scripts/modules/canary/acaTask/acaTaskStage.js
@@ -67,13 +67,12 @@ module.exports = angular.module('spinnaker.canary.acaTaskStage', [
       applicationProviders[0] = 'aws'; // default to AWS if no provider is set
     }
 
-    applicationProviders.forEach(p => accountService.listAccounts(p)
-      .then(a => $scope.accounts = $scope.accounts.concat(a))
-    );
-
-    applicationProviders.forEach(p => accountService.getUniqueAttributeForAllAccounts(p, 'regions')
-      .then(r=> $scope.regions = $scope.regions.concat(r))
-    );
+    applicationProviders.forEach(p => {
+      accountService.listAccounts(p)
+        .then(a => $scope.accounts = $scope.accounts.concat(a));
+      accountService.getUniqueAttributeForAllAccounts(p, 'regions')
+        ..then(r=> $scope.regions = $scope.regions.concat(r));
+    });
 
     //TODO: Extract to be reusable with canaryStage [zkt]
     this.updateWatchersList = () => {

--- a/app/scripts/modules/canary/acaTask/acaTaskStage.js
+++ b/app/scripts/modules/canary/acaTask/acaTaskStage.js
@@ -59,28 +59,21 @@ module.exports = angular.module('spinnaker.canary.acaTaskStage', [
         : $scope.stage.canary.watchers //if it is not an array it is probably a SpEL
       : '';
 
-    var applicationProviders = $scope.application.attributes.cloudProviders;
-    $scope.accounts = new Array();
-    $scope.regions = new Array();
+    let applicationProviders = $scope.application.attributes.cloudProviders;
+    $scope.accounts = [];
+    $scope.regions = [];
 
     if (applicationProviders.length === 0) {
       applicationProviders[0] = 'aws'; // default to AWS if no provider is set
     }
 
-    for (var i = 0; i < applicationProviders.length; i++) {
-      if (applicationProviders[i] === 'aws') {
-        accountService.getUniqueAttributeForAllAccounts(applicationProviders[i], 'regions')
-        .then((regions) => {
-          $scope.regions = regions.sort();
-        });
-      }
+    applicationProviders.forEach(p => accountService.listAccounts(p)
+      .then(a => $scope.accounts = $scope.accounts.concat(a))
+    );
 
-      accountService.listAccounts(applicationProviders[i]).then(function(accounts) {
-        for (var j = 0; j < accounts.length; j++) {
-          $scope.accounts.push(accounts[j]);
-        }
-      });
-    }
+    applicationProviders.forEach(p => accountService.getUniqueAttributeForAllAccounts(p, 'regions')
+      .then(r=> $scope.regions = $scope.regions.concat(r))
+    );
 
     //TODO: Extract to be reusable with canaryStage [zkt]
     this.updateWatchersList = () => {

--- a/app/scripts/modules/canary/acaTask/acaTaskStage.js
+++ b/app/scripts/modules/canary/acaTask/acaTaskStage.js
@@ -59,16 +59,28 @@ module.exports = angular.module('spinnaker.canary.acaTaskStage', [
         : $scope.stage.canary.watchers //if it is not an array it is probably a SpEL
       : '';
 
-    accountService.getUniqueAttributeForAllAccounts('aws', 'regions')
-      .then( (regions) => {
-        $scope.regions = regions.sort();
+    var applicationProviders = $scope.application.attributes.cloudProviders;
+    $scope.accounts = new Array();
+    $scope.regions = new Array();
+
+    if (applicationProviders.length === 0) {
+      applicationProviders[0] = 'aws'; // default to AWS if no provider is set
+    }
+
+    for (var i = 0; i < applicationProviders.length; i++) {
+      if (applicationProviders[i] === 'aws') {
+        accountService.getUniqueAttributeForAllAccounts(applicationProviders[i], 'regions')
+        .then((regions) => {
+          $scope.regions = regions.sort();
+        });
+      }
+
+      accountService.listAccounts(applicationProviders[i]).then(function(accounts) {
+        for (var j = 0; j < accounts.length; j++) {
+          $scope.accounts.push(accounts[j]);
+        }
       });
-
-
-    accountService.listAccounts('aws').then(function(accounts) {
-      $scope.accounts = accounts;
-    });
-
+    }
 
     //TODO: Extract to be reusable with canaryStage [zkt]
     this.updateWatchersList = () => {


### PR DESCRIPTION
*Title*
Picking Accounts from all Providers during ACA Task Creation

*Description*
This patch allows accounts of all configured providers to be listed during creation of an ACA task. Currently, only AWS accounts are listed in the drop down.

This essentially fixes the issue filed at [#2083](https://github.com/spinnaker/spinnaker/issues/2083)

*Environment*
I am running Spinnaker on AWS to deploy into AWS and Kubernetes.

*Cloud Provider*
AWS and Kubernetes

*Fix Area*
Pipeline Templates, Canary

*Testing*
I have tested these changes and ensured successful ACA task runs having set AWS & Kubernetes as cloud providers.
