### PR TITLE
feat: resolve provider version in instance state

### DIFF
--- a/app/scripts/modules/core/src/cloudProvider/versionedCloudProvider.service.spec.ts
+++ b/app/scripts/modules/core/src/cloudProvider/versionedCloudProvider.service.spec.ts
@@ -1,0 +1,138 @@
+import { mock, IRootScopeService, IScope } from 'angular';
+
+import { CLOUD_PROVIDER_REGISTRY } from './cloudProvider.registry';
+import { ACCOUNT_SERVICE } from 'core/account/account.service';
+import { VERSIONED_CLOUD_PROVIDER_SERVICE, VersionedCloudProviderService } from './versionedCloudProvider.service';
+import { APPLICATION_MODEL_BUILDER, ApplicationModelBuilder } from 'core/application';
+
+describe('Service: versionedCloudProviderService', () => {
+  let service: VersionedCloudProviderService, appBuilder: ApplicationModelBuilder, scope: IScope;
+
+  beforeEach((mock.module(
+    VERSIONED_CLOUD_PROVIDER_SERVICE,
+    APPLICATION_MODEL_BUILDER,
+    CLOUD_PROVIDER_REGISTRY,
+    ACCOUNT_SERVICE,
+  )));
+
+  beforeEach(
+    mock.inject(($rootScope: IRootScopeService,
+                 versionedCloudProviderService: VersionedCloudProviderService,
+                 applicationModelBuilder: ApplicationModelBuilder) => {
+      service = versionedCloudProviderService;
+      appBuilder = applicationModelBuilder;
+      scope = $rootScope.$new();
+    }
+  ));
+
+  describe('instance provider version disambiguation', () => {
+    beforeEach(() => {
+      (service as any).accounts = [
+        { name: 'v1-k8s-account', cloudProvider: 'kubernetes', providerVersion: 'v1' },
+        { name: 'v2-k8s-account', cloudProvider: 'kubernetes', providerVersion: 'v2' },
+        { name: 'appengine-account', cloudProvider: 'appengine', providerVersion: 'v1' },
+        { name: 'gce-account', cloudProvider: 'gce' },
+      ] as any[];
+    });
+
+    it('uses available accounts to determine provider version if possible', () => {
+      const app = appBuilder.createStandaloneApplication('myApp');
+
+      service.getInstanceProviderVersion('appengine', 'my-instance-id', app).then(providerVersion => {
+        expect(providerVersion).toEqual('v1');
+      });
+      service.getInstanceProviderVersion('gce', 'my-instance-id', app).then(providerVersion => {
+        expect(providerVersion).toEqual(null);
+      });
+
+      scope.$digest();
+    });
+
+    it('scrapes application server groups to determine provider version if possible', () => {
+      const app = appBuilder.createApplication('myApp', [
+        {
+          key: 'serverGroups',
+          data: [
+            {
+              name: 'myServerGroup',
+              account: 'v2-k8s-account',
+              cloudProvider: 'kubernetes',
+              instances: [
+                { id: 'my-instance-id' },
+              ],
+              serverGroups: [],
+            }
+          ]
+        },
+        {
+          key: 'loadBalancers',
+          data: [],
+        }
+      ]);
+
+      service.getInstanceProviderVersion('kubernetes', 'my-instance-id', app).then(providerVersion => {
+        expect(providerVersion).toEqual('v2');
+      });
+
+      scope.$digest();
+    });
+
+    it('scrapes application load balancers to determine provider version if possible', () => {
+      const app = appBuilder.createApplication('myApp', [
+        {
+          key: 'loadBalancers',
+          data: [
+            {
+              name: 'myLoadBalancer',
+              account: 'v2-k8s-account',
+              cloudProvider: 'kubernetes',
+              instances: [
+                { id: 'my-instance-id' },
+              ]
+            }
+          ]
+        },
+        {
+          key: 'serverGroups',
+          data: [],
+        },
+      ]);
+
+      service.getInstanceProviderVersion('kubernetes', 'my-instance-id', app).then(providerVersion => {
+        expect(providerVersion).toEqual('v2');
+      });
+
+      scope.$digest();
+    });
+
+    it('scrapes application load balancers\' server groups to determine provider version if possible', () => {
+      const app = appBuilder.createApplication('myApp', [
+        {
+          key: 'loadBalancers',
+          data: [
+            {
+              name: 'myLoadBalancer',
+              account: 'v2-k8s-account',
+              cloudProvider: 'kubernetes',
+              instances: [],
+              serverGroups: [{
+                isDisabled: true,
+                instances: [{ id: 'my-instance-id' }],
+              }],
+            }
+          ]
+        },
+        {
+          key: 'serverGroups',
+          data: [],
+        },
+      ]);
+
+      service.getInstanceProviderVersion('kubernetes', 'my-instance-id', app).then(providerVersion => {
+        expect(providerVersion).toEqual('v2');
+      });
+
+      scope.$digest();
+    });
+  });
+});

--- a/app/scripts/modules/core/src/cloudProvider/versionedCloudProvider.service.ts
+++ b/app/scripts/modules/core/src/cloudProvider/versionedCloudProvider.service.ts
@@ -1,10 +1,11 @@
-import { ILogService, module } from 'angular';
+import { ILogService, IPromise, IQService, module } from 'angular';
 import { map } from 'lodash';
 
 import { SETTINGS } from 'core/config/settings';
 import { AccountService, IAccountDetails } from 'core/account';
 import { CloudProviderRegistry } from 'core/cloudProvider';
-import { IDeckRootScope } from 'core/domain';
+import { IDeckRootScope, ILoadBalancer, IServerGroup } from 'core/domain';
+import { Application } from 'core/application';
 
 export class VersionedCloudProviderService {
 
@@ -12,6 +13,7 @@ export class VersionedCloudProviderService {
 
   constructor(private $rootScope: IDeckRootScope,
               private $log: ILogService,
+              private $q: IQService,
               private accountService: AccountService,
               private cloudProviderRegistry: CloudProviderRegistry) {
     'ngInject';
@@ -22,6 +24,50 @@ export class VersionedCloudProviderService {
     return (account && account.providerVersion)
       ? this.cloudProviderRegistry.getValue(cloudProvider, key, account.providerVersion)
       : this.cloudProviderRegistry.getValue(cloudProvider, key);
+  }
+
+  public getInstanceProviderVersion(cloudProvider: string, instanceId: string, app: Application): IPromise<string> {
+    const providerVersions = this.accounts.reduce(
+      (versions, account) => {
+        if (account.cloudProvider === cloudProvider && !!account.providerVersion) {
+          versions.add(account.providerVersion);
+        }
+        return versions;
+      },
+      new Set<string>(),
+    );
+
+    if (providerVersions.size === 0) {
+      // Rely on the cloudProviderRegistry to return the default provider implementation.
+      return this.$q.resolve(null);
+    } else if (providerVersions.size === 1) {
+      return this.$q.resolve(Array.from(providerVersions)[0]);
+    }
+
+    return app.ready().then(() => {
+      for (const serverGroup of (app.getDataSource('serverGroups').data as IServerGroup[])) {
+        if (serverGroup.cloudProvider === cloudProvider && (serverGroup.instances || []).some(instance => instance.id === instanceId)) {
+          return this.mapAccountToProviderVersion(serverGroup.account);
+        }
+      }
+      for (const loadBalancer of (app.getDataSource('loadBalancers').data as ILoadBalancer[])) {
+        if (loadBalancer.cloudProvider === cloudProvider) {
+          if ((loadBalancer.instances || []).some(instance => instance.id === instanceId)) {
+            return this.mapAccountToProviderVersion(loadBalancer.account);
+          }
+          // Hit a crazy Babel bug - can't return from a nested for...of loop.
+          for (let i = 0; i < (loadBalancer.serverGroups || []).length; i++) {
+            const serverGroup = loadBalancer.serverGroups[i];
+            if (serverGroup.isDisabled
+                && serverGroup.instances
+                && (serverGroup.instances || []).some(instance => instance.id === instanceId)) {
+              return this.mapAccountToProviderVersion(loadBalancer.account);
+            }
+          }
+        }
+      }
+      return null;
+    });
   }
 
   public initializeAccounts(): void {
@@ -37,6 +83,11 @@ export class VersionedCloudProviderService {
     }).finally(() => {
       this.$rootScope.accountsLoading = false;
     });
+  }
+
+  private mapAccountToProviderVersion(accountName: string): string {
+    const account = this.accounts.find(a => a.name === accountName);
+    return account ? account.providerVersion : null;
   }
 }
 

--- a/app/scripts/modules/core/src/instance/instance.states.ts
+++ b/app/scripts/modules/core/src/instance/instance.states.ts
@@ -8,6 +8,7 @@ import { INestedState, STATE_CONFIG_PROVIDER, StateConfigProvider } from 'core/n
 import { StateParams } from '@uirouter/angularjs';
 import { Application } from 'core/application/application.model';
 import { ApplicationModelBuilder } from '../application/applicationModel.builder';
+import { VersionedCloudProviderService } from 'core/cloudProvider';
 
 export const INSTANCE_STATES = 'spinnaker.core.instance.states';
 module(INSTANCE_STATES, [
@@ -20,16 +21,24 @@ module(INSTANCE_STATES, [
     url: '/instanceDetails/:provider/:instanceId',
     views: {
       'detail@../insight': {
-        templateProvider: ['$templateCache', '$stateParams', 'cloudProviderRegistry',
+        templateProvider: ['$templateCache', '$stateParams', 'cloudProviderRegistry', 'versionedCloudProviderService', 'app',
           ($templateCache: ng.ITemplateCacheService,
            $stateParams: StateParams,
-           cloudProviderRegistry: CloudProviderRegistry) => {
-            return $templateCache.get(cloudProviderRegistry.getValue($stateParams.provider, 'instance.detailsTemplateUrl'));
+           cloudProviderRegistry: CloudProviderRegistry,
+           versionedCloudProviderService: VersionedCloudProviderService,
+           app: Application) => {
+            return versionedCloudProviderService.getInstanceProviderVersion($stateParams.provider, $stateParams.instanceId, app).then(providerVersion =>
+              $templateCache.get(cloudProviderRegistry.getValue($stateParams.provider, 'instance.detailsTemplateUrl', providerVersion))
+            );
         }],
-        controllerProvider: ['$stateParams', 'cloudProviderRegistry',
+        controllerProvider: ['$stateParams', 'cloudProviderRegistry', 'versionedCloudProviderService', 'app',
           ($stateParams: StateParams,
-           cloudProviderRegistry: CloudProviderRegistry) => {
-            return cloudProviderRegistry.getValue($stateParams.provider, 'instance.detailsController');
+           cloudProviderRegistry: CloudProviderRegistry,
+           versionedCloudProviderService,
+           app: Application) => {
+            return versionedCloudProviderService.getInstanceProviderVersion($stateParams.provider, $stateParams.instanceId, app).then(providerVersion =>
+              cloudProviderRegistry.getValue($stateParams.provider, 'instance.detailsController', providerVersion)
+            );
         }],
         controllerAs: 'ctrl'
       }


### PR DESCRIPTION
Allows the correct instance detail controller & template to be resolved from the instance state definition.

Basically reproduces the logic inside most of the instance details controllers for resolving an instance's account from instance id + cloud provider.

Shouldn't do anything different if your provider only has one version.