### PR TITLE
feat(moniker): Use server group moniker in multi-select

### DIFF
--- a/app/scripts/modules/core/src/cluster/filter/multiselect.model.js
+++ b/app/scripts/modules/core/src/cluster/filter/multiselect.model.js
@@ -152,6 +152,7 @@ module.exports = angular
           region: serverGroup.region,
           provider: serverGroup.type,
           name: serverGroup.name,
+          moniker: serverGroup.moniker,
         });
       }
       this.serverGroupsStream.next();


### PR DESCRIPTION
When using multi-select on the cluster view page, monikers are not carried through with the server group information. This PR will fix it. I'm not exactly sure why only certain fields are mapped through from the server group model. It seems like IServerGroup should be used here, but I think that is a separate issue.