### PR TITLE
feat(provider/kubernetes): runJob context images

### DIFF
--- a/app/scripts/modules/kubernetes/src/pipeline/stages/runJob/runJobStage.html
+++ b/app/scripts/modules/kubernetes/src/pipeline/stages/runJob/runJobStage.html
@@ -18,6 +18,20 @@
     </namespace-select-field>
   </stage-config-field>
 
+  <stage-config-field label="Image">
+    <ui-select name="containerSelect" ng-model="ctrl.stage.container" class="form-control input-sm" required>
+        <ui-select-match>{{ ctrl.stage.container.imageDescription | kubernetesImageId }}</ui-select-match>
+        <ui-select-choices
+          repeat="container in ctrl.containers | orderBy: 'imageDescription.imageId'"
+          group-by="ctrl.groupByRegistry"
+          refresh-delay="0"
+          ui-disable-choice="container.message"
+          refresh="ctrl.searchImages($select.search)">
+          <span ng-bind-html="container.imageDescription | kubernetesImageId | highlight: $select.search"></span>
+        </ui-select-choices>
+      </ui-select>
+  </stage-config-field>
+
   <stage-config-field label="Container Name">
     <div>
       <input type="text" class="form-control input-sm" ng-model="ctrl.stage.container.name">
@@ -38,45 +52,7 @@
         </select>
     </div>
   </stage-config-field>
-
-  <stage-config-field label="Image">
-    <div class="form-group" ng-if="ctrl.hasDockerPipelineTriggers()">
-      <div>
-        <label class="sm-label">
-          Resolve from Trigger
-        </label>
-        <input type="checkbox"
-               style="margin-left: 20px"
-               ng-model="ctrl.stage.container.imageDescription.fromTrigger"/>
-      </div>
-    </div>
-    <div ng-if="!ctrl.stage.container.imageDescription.fromTrigger">
-      <docker-image-and-tag-selector
-        specify-tag-by-regex="false"
-        account="ctrl.stage.container.imageDescription.account"
-        organization="ctrl.stage.container.imageDescription.organization"
-        registry="ctrl.stage.container.imageDescription.registry"
-        repository="ctrl.stage.container.imageDescription.repository"
-        tag="ctrl.stage.container.imageDescription.tag"
-        show-registry="true"
-        on-change="ctrl.onChange"></docker-image-and-tag-selector>
-    </div>
-    <div ng-if="ctrl.stage.container.imageDescription.fromTrigger" class="form-group">
-        <div class="sm-label-right col-md-3">
-        Trigger
-        </div>
-        <div class="col-md-9">
-          <ui-select ng-model="ctrl.container"
-                    class="form-control input-sm"
-                    ng-change="ctrl.updateContainerImage()" required>
-            <ui-select-match>{{ctrl.container}}</ui-select-match>
-            <ui-select-choices repeat="image in ctrl.triggerImages() | filter: $select.search | orderBy">
-              <span ng-bind-html="image | highlight: $select.search"></span>
-            </ui-select-choices>
-          </ui-select>
-        </div>
-    </div>
-  </stage-config-field>
+  
   <stage-config-field label="Commands" help-key="kubernetes.containers.command">
     <kubernetes-container-commands commands="ctrl.stage.container.command">
     </kubernetes-container-commands>

--- a/app/scripts/modules/kubernetes/src/presentation/imageId.filter.ts
+++ b/app/scripts/modules/kubernetes/src/presentation/imageId.filter.ts
@@ -1,0 +1,37 @@
+import { module } from 'angular';
+
+export interface IDockerImage {
+  fromFindImage: boolean;
+  fromBake: boolean;
+  repository: string;
+  tag: string;
+  registry: string;
+  cluster: string;
+  pattern: string;
+  fromTrigger: boolean;
+}
+
+export function imageId(image: IDockerImage): string {
+  if (image.fromFindImage) {
+    return `${image.cluster} ${image.pattern}`;
+  } else if (image.fromBake) {
+    return `${image.repository} (Baked during execution)`;
+  } else if (image.fromTrigger && !image.tag) {
+    return `${image.registry}/${image.repository} (Tag resolved at runtime)`;
+  } else {
+    if (image.registry) {
+      return `${image.registry}/${image.repository}:${image.tag}`;
+    } else {
+      return `${image.repository}:${image.tag}`;
+    }
+  }
+}
+
+export function imageIdFilter() {
+  return imageId;
+}
+
+export const KUBERNETES_IMAGE_ID_FILTER = 'spinnaker.kubernetes.presentation.imageId.filter';
+module(KUBERNETES_IMAGE_ID_FILTER, [])
+  .filter('kubernetesImageId', imageIdFilter);
+


### PR DESCRIPTION
add support for using images found from context in the runJob stage. i
refactored the `Resolve from Trigger` checkbox, and included Context and
Trigger images in the same dropdown to bring it more in line with the
Server Group configuration.

spinnaker/spinnaker#1961
spinnaker/spinnaker#1960

@danielpeach can I get some early feedback on this? I had to copy a bunch of code over from the Server Group module. I feel like there may be a better way to handle that, I just don't know what it is.