### PR TITLE
feat(core): provide simple general purpose event bus

### DIFF
--- a/app/scripts/modules/core/src/delivery/details/StageFailureMessage.tsx
+++ b/app/scripts/modules/core/src/delivery/details/StageFailureMessage.tsx
@@ -1,14 +1,16 @@
 import * as React from 'react';
 
-import { IExecutionStage, ITaskStep } from 'core/domain';
+import { get } from 'lodash';
 
-import { robotToHuman } from 'core/presentation/robotToHumanFilter/robotToHuman.filter';
 import { UISref } from '@uirouter/react';
 import { UIRouterContext } from '@uirouter/react-hybrid';
 
-import { ReactInjector } from 'core';
+import { IExecutionStage, ITaskStep } from 'core/domain';
 
-import { get } from 'lodash';
+import { robotToHuman } from 'core/presentation/robotToHumanFilter/robotToHuman.filter';
+import { EventBus } from 'core/event/EventBus';
+
+import { ReactInjector } from 'core';
 
 export interface IStageFailureMessageProps {
   message?: string;
@@ -120,6 +122,8 @@ export class StageFailureMessage extends React.Component<IStageFailureMessagePro
           </div>
         );
       }
+
+      EventBus.publish('stage-failure-message:no-reason', { params: Object.assign({}, ReactInjector.$state.params) });
     }
 
     return null;

--- a/app/scripts/modules/core/src/event/EventBus.spec.ts
+++ b/app/scripts/modules/core/src/event/EventBus.spec.ts
@@ -1,0 +1,16 @@
+import { EventBus } from './EventBus';
+
+describe('EventBus', () => {
+  describe('observe', () => {
+    it('only picks up messages with the specified key', () => {
+      const results = [];
+      const subscription = EventBus.observe<number>('z').subscribe(n => results.push(n));
+      EventBus.publish('a', 1);
+      EventBus.publish('z', 2);
+      EventBus.publish('b', 3);
+      EventBus.publish('z', 4);
+      expect(results).toEqual([2, 4]);
+      subscription.unsubscribe();
+    });
+  });
+});

--- a/app/scripts/modules/core/src/event/EventBus.ts
+++ b/app/scripts/modules/core/src/event/EventBus.ts
@@ -1,0 +1,32 @@
+import { Observable, Subject } from 'rxjs';
+
+export interface IEventMessage {
+  key: string;
+  payload: any;
+}
+
+/**
+ * Simple message bus, allowing events to be picked up across disparate components
+ */
+export class EventBus {
+
+  private static message$: Subject<IEventMessage> = new Subject<IEventMessage>();
+
+  /**
+   * Creates a new observable of all future message payloads published with the specified key
+   * @param {string} key
+   * @return {Observable<any>}
+   */
+  public static observe<T>(key: string): Observable<T> {
+    return this.message$.filter(m => m.key === key).map(m => m.payload);
+  }
+
+  /**
+   * Publishes a message with the supplied payload for any observer to pick up
+   * @param {string} key
+   * @param payload
+   */
+  public static publish(key: string, payload: any): void {
+    this.message$.next({ key, payload });
+  }
+}

--- a/app/scripts/modules/core/src/index.ts
+++ b/app/scripts/modules/core/src/index.ts
@@ -21,6 +21,8 @@ export * from './entityTag';
 // is found by the TS compiler, but not at runtime)
 export * from './entityTag/notifications/EntityNotifications';
 
+export * from './event/EventBus';
+
 export * from './filterModel';
 
 export * from './healthCounts';


### PR DESCRIPTION
We are going to use this internally to track when users see what was formerly a low-value error message ("No reason provided") and figure out what actual error message could be surfaced.