### PR TITLE
chore(core): bump package to 0.0.100

### DIFF
--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/core",
-  "version": "0.0.99",
+  "version": "0.0.100",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/core/src/event/EventBus.spec.ts
+++ b/app/scripts/modules/core/src/event/EventBus.spec.ts
@@ -3,7 +3,7 @@ import { EventBus } from './EventBus';
 describe('EventBus', () => {
   describe('observe', () => {
     it('only picks up messages with the specified key', () => {
-      const results = [];
+      const results: number[] = [];
       const subscription = EventBus.observe<number>('z').subscribe(n => results.push(n));
       EventBus.publish('a', 1);
       EventBus.publish('z', 2);


### PR DESCRIPTION
* fix(canary): fix syntax in acaTask stage
* fix(core): Link to failed stage had incorrect name
* fix(core): Favor using `stageId` when building links to failed stages
* fix(core): Fix a few more undefined errors from execution details controller
* feat(core): provide simple general purpose event bus