### PR TITLE
fix(core): re-enable filter on (none) for stack/detail

### DIFF
--- a/app/scripts/modules/core/src/filterModel/filter.model.service.js
+++ b/app/scripts/modules/core/src/filterModel/filter.model.service.js
@@ -50,7 +50,8 @@ module.exports = angular
         if (isFilterable(model.sortFilter.stack)) {
           var checkedStacks = getCheckValues(model.sortFilter.stack);
           if (checkedStacks.includes('(none)')) {
-            checkedStacks.push('');
+            checkedStacks.push(''); // TODO: remove when moniker is source of truth for naming
+            checkedStacks.push(null);
           }
           return _.includes(checkedStacks, target.stack);
         } else {
@@ -64,7 +65,8 @@ module.exports = angular
         if (isFilterable(model.sortFilter.detail)) {
           var checkedDetails = getCheckValues(model.sortFilter.detail);
           if (checkedDetails.includes('(none)')) {
-            checkedDetails.push('');
+            checkedDetails.push(''); // TODO: remove when moniker is source of truth for naming
+            checkedDetails.push(null);
           }
           return _.includes(checkedDetails, target.detail);
         } else {


### PR DESCRIPTION
Fixing a regression from https://github.com/spinnaker/deck/pull/4369

Previously, `stack` and `detail` would be set to empty strings if they were not present. Since they're `null` in the case of monikers, the `(none)` filters won't work.

cc @andrewbackes 