### PR TITLE
Server Group Manager data source, states, and kubernetes details

### DIFF
--- a/app/scripts/modules/core/src/domain/index.ts
+++ b/app/scripts/modules/core/src/domain/index.ts
@@ -38,6 +38,7 @@ export * from './IRegionalCluster';
 
 export * from './ISecurityGroup';
 export * from './IServerGroup';
+export * from './IServerGroupManager';
 export * from './IStage';
 export * from './IStageContext';
 export * from './IStageOrTriggerTypeConfig';

--- a/app/scripts/modules/core/src/serverGroupManager/serverGroupManager.dataSource.ts
+++ b/app/scripts/modules/core/src/serverGroupManager/serverGroupManager.dataSource.ts
@@ -1,0 +1,28 @@
+import { IQService, module } from 'angular';
+
+import { Application, APPLICATION_DATA_SOURCE_REGISTRY, ApplicationDataSourceRegistry } from 'core/application';
+import { SERVER_GROUP_MANAGER_SERVICE, ServerGroupManagerService } from './serverGroupManager.service';
+import { IServerGroupManager } from 'core/domain/IServerGroupManager';
+
+export const SERVER_GROUP_MANAGER_DATA_SOURCE = 'spinnaker.core.serverGroupManager.dataSource';
+module(SERVER_GROUP_MANAGER_DATA_SOURCE, [
+  APPLICATION_DATA_SOURCE_REGISTRY,
+  SERVER_GROUP_MANAGER_SERVICE,
+]).run(($q: IQService,
+        applicationDataSourceRegistry: ApplicationDataSourceRegistry,
+        serverGroupManagerService: ServerGroupManagerService) => {
+  'ngInject';
+
+  const loader = (application: Application) =>
+    serverGroupManagerService.getServerGroupManagersForApplication(application.name);
+
+  const onLoad = (_application: Application, serverGroupManagers: IServerGroupManager[]) =>
+    $q.resolve(serverGroupManagers);
+
+  applicationDataSourceRegistry.registerDataSource({
+    key: 'serverGroupManagers',
+    visible: false,
+    onLoad,
+    loader,
+  });
+});

--- a/app/scripts/modules/core/src/serverGroupManager/serverGroupManager.dataSource.ts
+++ b/app/scripts/modules/core/src/serverGroupManager/serverGroupManager.dataSource.ts
@@ -22,7 +22,7 @@ module(SERVER_GROUP_MANAGER_DATA_SOURCE, [
   applicationDataSourceRegistry.registerDataSource({
     key: 'serverGroupManagers',
     visible: false,
-    onLoad,
     loader,
+    onLoad,
   });
 });

--- a/app/scripts/modules/core/src/serverGroupManager/serverGroupManager.module.ts
+++ b/app/scripts/modules/core/src/serverGroupManager/serverGroupManager.module.ts
@@ -2,9 +2,11 @@ import { module } from 'angular';
 
 import { SERVER_GROUP_MANAGER_DATA_SOURCE } from './serverGroupManager.dataSource';
 import { SERVER_GROUP_MANAGER_SERVICE } from './serverGroupManager.service';
+import { SERVER_GROUP_MANAGER_STATES } from './serverGroupManager.states';
 
 export const SERVER_GROUP_MANAGER_MODULE = 'spinnaker.core.serverGroupManager.module';
 module(SERVER_GROUP_MANAGER_MODULE, [
   SERVER_GROUP_MANAGER_DATA_SOURCE,
   SERVER_GROUP_MANAGER_SERVICE,
+  SERVER_GROUP_MANAGER_STATES,
 ]);

--- a/app/scripts/modules/core/src/serverGroupManager/serverGroupManager.module.ts
+++ b/app/scripts/modules/core/src/serverGroupManager/serverGroupManager.module.ts
@@ -1,8 +1,10 @@
 import { module } from 'angular';
 
+import { SERVER_GROUP_MANAGER_DATA_SOURCE } from './serverGroupManager.dataSource';
 import { SERVER_GROUP_MANAGER_SERVICE } from './serverGroupManager.service';
 
 export const SERVER_GROUP_MANAGER_MODULE = 'spinnaker.core.serverGroupManager.module';
 module(SERVER_GROUP_MANAGER_MODULE, [
+  SERVER_GROUP_MANAGER_DATA_SOURCE,
   SERVER_GROUP_MANAGER_SERVICE,
 ]);

--- a/app/scripts/modules/core/src/serverGroupManager/serverGroupManager.service.ts
+++ b/app/scripts/modules/core/src/serverGroupManager/serverGroupManager.service.ts
@@ -4,7 +4,7 @@ import { API_SERVICE, Api } from '@spinnaker/core';
 
 import { IServerGroupManager } from 'core/domain/IServerGroupManager';
 
-class ServerGroupManagerService {
+export class ServerGroupManagerService {
   constructor(private API: Api) {
     'ngInject';
   }

--- a/app/scripts/modules/core/src/serverGroupManager/serverGroupManager.states.ts
+++ b/app/scripts/modules/core/src/serverGroupManager/serverGroupManager.states.ts
@@ -1,0 +1,53 @@
+import { ITemplateCacheService, module } from 'angular';
+import { StateParams } from '@uirouter/angularjs';
+
+import { APPLICATION_STATE_PROVIDER, ApplicationStateProvider } from 'core/application';
+import { INestedState } from 'core/navigation';
+import { VersionedCloudProviderService } from 'core/cloudProvider';
+
+export const SERVER_GROUP_MANAGER_STATES = 'spinnaker.core.serverGroupManager.states';
+module(SERVER_GROUP_MANAGER_STATES, [APPLICATION_STATE_PROVIDER])
+  .config((applicationStateProvider: ApplicationStateProvider) => {
+    const serverGroupManagerDetails: INestedState = {
+      name: 'serverGroupManager',
+      url: '/serverGroupManagerDetails/:provider/:accountId/:region/:serverGroupManager',
+      views: {
+        'detail@../insight': {
+          templateProvider: ['$templateCache', '$stateParams', 'versionedCloudProviderService',
+            ($templateCache: ITemplateCacheService,
+             $stateParams: StateParams,
+             versionedCloudProviderService: VersionedCloudProviderService) => {
+              return $templateCache.get(versionedCloudProviderService.getValue($stateParams.provider, $stateParams.accountId, 'serverGroupManager.detailsTemplateUrl'));
+            }],
+          controllerProvider: ['$stateParams', 'versionedCloudProviderService',
+            ($stateParams: StateParams,
+             versionedCloudProviderService: VersionedCloudProviderService) => {
+              return versionedCloudProviderService.getValue($stateParams.provider, $stateParams.accountId, 'serverGroupManager.detailsController');
+            }],
+          controllerAs: 'ctrl'
+        }
+      },
+      resolve: {
+        serverGroup: ['$stateParams', ($stateParams: StateParams) => {
+          return {
+            name: $stateParams.serverGroup,
+            accountId: $stateParams.accountId,
+            region: $stateParams.region,
+          };
+        }]
+      },
+      data: {
+        pageTitleDetails: {
+          title: 'Server Group Manager Details',
+          nameParam: 'serverGroupManager',
+          accountParam: 'accountId',
+          regionParam: 'region'
+        },
+        history: {
+          type: 'serverGroupManagers',
+        },
+      }
+    };
+
+    applicationStateProvider.addInsightDetailState(serverGroupManagerDetails);
+  });

--- a/app/scripts/modules/core/src/serverGroupManager/serverGroupManager.states.ts
+++ b/app/scripts/modules/core/src/serverGroupManager/serverGroupManager.states.ts
@@ -28,9 +28,9 @@ module(SERVER_GROUP_MANAGER_STATES, [APPLICATION_STATE_PROVIDER])
         }
       },
       resolve: {
-        serverGroup: ['$stateParams', ($stateParams: StateParams) => {
+        serverGroupManager: ['$stateParams', ($stateParams: StateParams) => {
           return {
-            name: $stateParams.serverGroup,
+            name: $stateParams.serverGroupManager,
             accountId: $stateParams.accountId,
             region: $stateParams.region,
           };

--- a/app/scripts/modules/kubernetes/src/v2/kubernetes.v2.module.ts
+++ b/app/scripts/modules/kubernetes/src/v2/kubernetes.v2.module.ts
@@ -51,6 +51,9 @@ module(KUBERNETES_V2_MODULE, [
         detailsTemplateUrl: require('./serverGroup/details/details.html'),
         detailsController: 'kubernetesV2ServerGroupDetailsCtrl',
       },
+      serverGroupManager: {
+        
+      },
       loadBalancer: {
         detailsTemplateUrl: require('./loadBalancer/details/details.html'),
         detailsController: 'kubernetesV2LoadBalancerDetailsCtrl',

--- a/app/scripts/modules/kubernetes/src/v2/kubernetes.v2.module.ts
+++ b/app/scripts/modules/kubernetes/src/v2/kubernetes.v2.module.ts
@@ -14,6 +14,7 @@ import { KUBERNETES_V2_SERVER_GROUP_TRANSFORMER } from './serverGroup/serverGrou
 import { KUBERNETES_V2_SERVER_GROUP_DETAILS_CTRL } from './serverGroup/details/details.controller';
 import { KUBERNETES_V2_SERVER_GROUP_RESIZE_CTRL } from './serverGroup/details/resize/resize.controller';
 import { KUBERNETES_V2_SERVER_GROUP_COMMAND_BUILDER } from './serverGroup/serverGroupCommandBuilder.service';
+import { KUBERNETES_V2_SERVER_GROUP_MANAGER_DETAILS_CTRL } from './serverGroupManager/details/details.controller';
 
 // load all templates into the $templateCache
 const templates = require.context('kubernetes', true, /\.html$/);
@@ -28,9 +29,11 @@ module(KUBERNETES_V2_MODULE, [
   KUBERNETES_V2_INSTANCE_DETAILS_CTRL,
   KUBERNETES_V2_LOAD_BALANCER_DETAILS_CTRL,
   KUBERNETES_V2_SERVER_GROUP_COMMAND_BUILDER,
-  KUBERNETES_V2_SERVER_GROUP_TRANSFORMER,
   KUBERNETES_V2_SERVER_GROUP_DETAILS_CTRL,
+  KUBERNETES_V2_SERVER_GROUP_TRANSFORMER,
+  KUBERNETES_V2_SERVER_GROUP_MANAGER_DETAILS_CTRL,
   KUBERNETES_V2_SERVER_GROUP_RESIZE_CTRL,
+  KUBERNETES_V2_SERVER_GROUP_MANAGER_DETAILS_CTRL,
   KUBERNETES_MANIFEST_BASIC_SETTINGS,
   KUBERNETES_MANIFEST_COMMAND_BUILDER,
   KUBERNETES_MANIFEST_CTRL,
@@ -52,7 +55,8 @@ module(KUBERNETES_V2_MODULE, [
         detailsController: 'kubernetesV2ServerGroupDetailsCtrl',
       },
       serverGroupManager: {
-        
+        detailsTemplateUrl: require('./serverGroupManager/details/details.html'),
+        detailsController: 'kubernetesV2ServerGroupManagerDetailsCtrl',
       },
       loadBalancer: {
         detailsTemplateUrl: require('./loadBalancer/details/details.html'),

--- a/app/scripts/modules/kubernetes/src/v2/serverGroupManager/details/details.controller.ts
+++ b/app/scripts/modules/kubernetes/src/v2/serverGroupManager/details/details.controller.ts
@@ -1,0 +1,32 @@
+import { IController, module } from 'angular';
+
+import { IServerGroupManager, Application } from '@spinnaker/core';
+
+interface IServerGroupManagerFromStateParams {
+  accountId: string;
+  region: string;
+  name: string;
+}
+
+class KubernetesServerGroupManagerDetailsController implements IController {
+  public serverGroupManager: IServerGroupManager;
+
+  constructor(serverGroupManager: IServerGroupManagerFromStateParams,
+              public app: Application) {
+    'ngInject';
+    this.app.ready()
+      .then(() => this.extractServerGroupManager(serverGroupManager));
+  }
+
+  private extractServerGroupManager(stateParams: IServerGroupManagerFromStateParams): void {
+    this.serverGroupManager = this.app.getDataSource('serverGroupManagers').data.find((manager: IServerGroupManager) =>
+      manager.name === stateParams.name
+        && manager.region === stateParams.region
+        && manager.account === stateParams.accountId
+    );
+  }
+}
+
+export const KUBERNETES_V2_SERVER_GROUP_MANAGER_DETAILS_CTRL = 'spinnaker.kubernetes.v2.serverGroupManager.details.controller';
+module(KUBERNETES_V2_SERVER_GROUP_MANAGER_DETAILS_CTRL, [])
+  .controller('kubernetesV2ServerGroupManagerDetailsCtrl', KubernetesServerGroupManagerDetailsController)

--- a/app/scripts/modules/kubernetes/src/v2/serverGroupManager/details/details.html
+++ b/app/scripts/modules/kubernetes/src/v2/serverGroupManager/details/details.html
@@ -1,0 +1,3 @@
+<pre>
+  {{ctrl.serverGroupManager}}
+</pre>


### PR DESCRIPTION
`#/applications/{app}/clusters/serverGroupManagerDetails/{provider}/{account}/{region}/{serverGroupManagerName}` now opens the server group manager details panel.