### PR TITLE
fix(provider/kubernetes): fix destroy multiple

### DIFF
--- a/app/scripts/modules/kubernetes/src/serverGroup/paramsMixin.js
+++ b/app/scripts/modules/kubernetes/src/serverGroup/paramsMixin.js
@@ -8,21 +8,21 @@ module.exports = angular
 
     function destroyServerGroup(serverGroup) {
       return {
-        namespace: serverGroup.namespace,
+        namespace: serverGroup.region || serverGroup.namespace,
         interestingHealthProviderNames: ['KubernetesService']
       };
     }
 
     function enableServerGroup(serverGroup) {
       return {
-          namespace: serverGroup.region,
+          namespace: serverGroup.region || serverGroup.namespace,
           interestingHealthProviderNames: ['KubernetesService']
       };
     }
 
     function disableServerGroup(serverGroup) {
       return {
-          namespace: serverGroup.region,
+          namespace: serverGroup.region || serverGroup.namespace,
           interestingHealthProviderNames: ['KubernetesService']
       };
     }


### PR DESCRIPTION
when destroying multiple servergroups, the namespace key wasn't being
populated properly. `serverGroup.region` is the correct key to use for
namespace.

ping @danielpeach or @lwander 

Fixes spinnaker/spinnaker#2027
