### PR TITLE
feat(core): allow pipeline parameters to be required

### DIFF
--- a/app/scripts/modules/core/src/delivery/manualExecution/manualPipelineExecution.controller.js
+++ b/app/scripts/modules/core/src/delivery/manualExecution/manualPipelineExecution.controller.js
@@ -17,8 +17,6 @@ module.exports = angular.module('spinnaker.core.delivery.manualPipelineExecution
   .controller('ManualPipelineExecutionCtrl', function ($uibModalInstance, pipeline, application, pipelineConfig,
                                                        notificationService, authenticationService) {
 
-    this.origPipeline = {};
-
     let applicationNotifications = [];
     let pipelineNotifications = [];
 
@@ -106,8 +104,6 @@ module.exports = angular.module('spinnaker.core.delivery.manualPipelineExecution
       pipelineNotifications = pipeline.notifications || [];
       synchronizeNotifications();
 
-      this.origPipeline = _.cloneDeep(pipeline); // make a copy to diff changes
-
       this.currentlyRunningExecutions = executions
         .filter((execution) => execution.pipelineConfigId === pipeline.id && execution.isActive);
       addTriggers();
@@ -118,6 +114,7 @@ module.exports = angular.module('spinnaker.core.delivery.manualPipelineExecution
 
       if (pipeline.parameterConfig && pipeline.parameterConfig.length) {
         this.parameters = {};
+        this.hasRequiredParameters = pipeline.parameterConfig.some(p => p.required);
         pipeline.parameterConfig.forEach((parameter) => {
           this.parameters[parameter.name] = parameter.default;
         });

--- a/app/scripts/modules/core/src/delivery/manualExecution/manualPipelineExecution.html
+++ b/app/scripts/modules/core/src/delivery/manualExecution/manualPipelineExecution.html
@@ -37,7 +37,7 @@
           <i class="fa fa-exclamation-triangle"></i>
           This pipeline is currently executing!
         </strong></p>
-        <div ng-repeat="execution in vm.currentlyRunningExecutions" class="pad-left">
+        <div ng-repeat="execution in vm.currentlyRunningExecutions | limitTo: 1" class="pad-left">
           <strong>Execution started: </strong>{{execution.startTime | timestamp }}
           <div>
             <strong>Current stage:</strong>
@@ -45,6 +45,13 @@
               {{stage.name}}
             </span>
           </div>
+        </div>
+        <div ng-if="vm.currentlyRunningExecutions.length > 1">
+          <em>
+            &hellip;and
+            {{vm.currentlyRunningExecutions.length - 1}}
+            other execution<span ng-if="vm.currentlyRunningExecutions.length > 2">s</span>
+          </em>
         </div>
       </div>
 
@@ -70,13 +77,17 @@
         <div class="form-group" ng-repeat="parameter in vm.command.pipeline.parameterConfig">
           <div class="col-md-4 sm-label-right break-word">
             <b>{{parameter.name}}</b>
+            <span ng-if="parameter.required">*</span>
             <help-field content="{{parameter.description}}" ng-if="parameter.description"></help-field>
           </div>
           <div class="col-md-6" ng-if="!parameter.hasOptions">
-            <input type="text" class="form-control input-sm" ng-model="vm.parameters[parameter.name]"/>
+            <input class="form-control input-sm"
+                   ng-model="vm.parameters[parameter.name]"
+                   ng-required="parameter.required"/>
           </div>
           <div class="col-md-6" ng-if="parameter.hasOptions">
             <ui-select ng-model="vm.parameters[parameter.name]"
+                       ng-required="parameter.required"
                        style="width:100%"
                        class="form-control input-sm">
               <ui-select-match>
@@ -87,6 +98,11 @@
               </ui-select-choices>
             </ui-select>
           </div>
+        </div>
+        <div class="form-group" ng-if="vm.hasRequiredParameters">
+          <div class="col-md-4 col-md-offset-4">
+            <em>* Required</em>
+
         </div>
       </div>
 

--- a/app/scripts/modules/core/src/pipeline/config/parameters/parameter.html
+++ b/app/scripts/modules/core/src/pipeline/config/parameters/parameter.html
@@ -24,18 +24,30 @@
         </div>
       </div>
 
-      <stage-config-field label="Description" help-key="pipeline.config.parameter.description">
+      <stage-config-field label="Required">
+        <div class="checkbox">
+          <label>
+            <input type="checkbox" ng-model="parameter.required" />
+          </label>
+        </div>
+      </stage-config-field>
+
+      <stage-config-field label="Description">
         <input type="text" required ng-model="parameter.description"
                class="form-control input-sm"/>
       </stage-config-field>
-      <stage-config-field label="Default Value" help-key="pipeline.config.parameter.default">
+      <stage-config-field label="Default Value">
         <input type="text" required ng-model="parameter.default"
                class="form-control input-sm"/>
       </stage-config-field>
-      <stage-config-field label="Show Options" help-key="pipeline.config.parameter.default">
-        <input type="checkbox" ng-model="parameter.hasOptions" ng-change="parameterCtrl.setupOptions(parameter)">
+      <stage-config-field label="Show Options">
+        <div class="checkbox">
+          <label>
+            <input type="checkbox" ng-model="parameter.hasOptions" ng-change="parameterCtrl.setupOptions(parameter)" />
+          </label>
+        </div>
       </stage-config-field>
-      <stage-config-field ng-if="parameter.hasOptions" label="Options" help-key="pipeline.config.parameter.description">
+      <stage-config-field ng-if="parameter.hasOptions" label="Options">
         <div ng-repeat="item in parameter.options" style="margin-bottom:5px">
           <input style="width:90%" class="col-md-4 form-control input-sm" ng-model="item.value" type="text"/>
           <button class="btn-link" ng-click="parameterCtrl.removeOption($index, parameter)">


### PR DESCRIPTION
Companion PR for https://github.com/spinnaker/gate/pull/479

Also fixing alignment of the options checkbox on the parameter config, and removing the help fields, since there's no help content associated with them.

Also only showing a single running execution in the warning that there are currently running executions. If there are multiple, it's hard to read and navigate the modal.