### PR TITLE
fix(provider/kubernetes): fix envvar deletion

### DIFF
--- a/app/scripts/modules/kubernetes/src/container/environmentVariables.component.js
+++ b/app/scripts/modules/kubernetes/src/container/environmentVariables.component.js
@@ -30,7 +30,7 @@ module.exports = angular.module('spinnaker.deck.kubernetes.environmentVariables.
 
       this.removeEnvVar = function(index) {
         this.envVars.splice(index, 1);
-        this.envVarsSourceTypes(index, 1);
+        this.envVarsSourceTypes.splice(index, 1);
       };
 
       this.addEnvVar = function() {


### PR DESCRIPTION
fixes a problem where deleting an environment variable would cause other
environemnt variable types to get messed up.

Fixes spinnaker/spinnaker#1866

ping @danielpeach 