### PR TITLE
feat(core): server group manager button on server group pod

### DIFF
--- a/app/scripts/modules/core/src/domain/IServerGroupManager.ts
+++ b/app/scripts/modules/core/src/domain/IServerGroupManager.ts
@@ -2,6 +2,7 @@ import { IMoniker } from 'core/naming';
 
 export interface IServerGroupManager {
   account: string;
+  cloudProvider: string;
   moniker: IMoniker;
   name: string;
   region: string;

--- a/app/scripts/modules/core/src/index.ts
+++ b/app/scripts/modules/core/src/index.ts
@@ -58,6 +58,7 @@ export * from './scheduler';
 export * from './search';
 export * from './securityGroup';
 export * from './serverGroup';
+export * from './serverGroupManager';
 export * from './serviceAccount';
 export * from './storage';
 export * from './subnet';

--- a/app/scripts/modules/core/src/serverGroup/ServerGroup.tsx
+++ b/app/scripts/modules/core/src/serverGroup/ServerGroup.tsx
@@ -15,6 +15,7 @@ import { NamingService } from 'core/naming';
 import { NgReact, ReactInjector } from 'core/reactShims';
 import { Instances } from 'core/instance/Instances';
 import { ScrollToService } from 'core/utils';
+import { ServerGroupManagerTag } from 'core/serverGroupManager/ServerGroupManagerTag';
 
 export interface JenkinsViewModel {
   number: number;
@@ -236,6 +237,7 @@ export class ServerGroup extends React.Component<IServerGroupProps, IServerGroup
                   )}
 
                   {hasLoadBalancer && <LoadBalancersTagWrapper application={application} serverGroup={serverGroup}/>}
+                  <ServerGroupManagerTag application={application} serverGroup={serverGroup}/>
                 </div>
               </div>
             </div>

--- a/app/scripts/modules/core/src/serverGroupManager/ServerGroupManagerTag.tsx
+++ b/app/scripts/modules/core/src/serverGroupManager/ServerGroupManagerTag.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import { BindAll } from 'lodash-decorators';
+
+import { Application } from 'core/application';
+import { IServerGroupManager, IServerGroup } from 'core/domain';
+import { ReactInjector } from 'core/reactShims';
+import { Tooltip } from 'core/presentation/Tooltip';
+import { IServerGroupManagerStateParams } from 'core/serverGroupManager';
+
+export interface IServerGroupManagerTagProps {
+  application: Application;
+  serverGroup: IServerGroup;
+}
+
+@BindAll()
+export class ServerGroupManagerTag extends React.Component<IServerGroupManagerTagProps> {
+  public render() {
+    const serverGroupManager = this.extractServerGroupManager();
+    if (!serverGroupManager) {
+      return null;
+    }
+
+    return (
+      <Tooltip value={`Server Group Manager: ${serverGroupManager.name}`}>
+        <span onClick={this.openDetails} className="fa fa-server"/>
+      </Tooltip>
+    );
+  }
+
+  private extractServerGroupManager(): IServerGroupManager {
+    const { application, serverGroup } = this.props;
+    return application.getDataSource('serverGroupManagers').data.find((manager: IServerGroupManager) =>
+      manager.serverGroups.some(group =>
+        serverGroup.name === group.name
+          && serverGroup.region === manager.region
+          && serverGroup.account === manager.account
+      )
+    );
+  }
+
+  private openDetails(event: React.MouseEvent<HTMLElement>): void {
+    event.preventDefault();
+    const { $state } = ReactInjector;
+    const nextState = $state.current.name.endsWith('.clusters') ? '.serverGroupManager' : '^.serverGroupManager';
+    $state.go(nextState, this.buildStateParams());
+  }
+
+  private buildStateParams(): IServerGroupManagerStateParams {
+    const serverGroupManager = this.extractServerGroupManager();
+    return {
+      accountId: serverGroupManager.account,
+      region: serverGroupManager.region,
+      provider: serverGroupManager.cloudProvider,
+      serverGroupManager: serverGroupManager.name,
+    };
+  }
+}

--- a/app/scripts/modules/core/src/serverGroupManager/index.ts
+++ b/app/scripts/modules/core/src/serverGroupManager/index.ts
@@ -1,0 +1,4 @@
+export * from './serverGroupManager.dataSource';
+export * from './serverGroupManager.states';
+export * from './serverGroupManager.service';
+export * from './ServerGroupManagerTag';

--- a/app/scripts/modules/core/src/serverGroupManager/serverGroupManager.states.ts
+++ b/app/scripts/modules/core/src/serverGroupManager/serverGroupManager.states.ts
@@ -5,6 +5,13 @@ import { APPLICATION_STATE_PROVIDER, ApplicationStateProvider } from 'core/appli
 import { INestedState } from 'core/navigation';
 import { VersionedCloudProviderService } from 'core/cloudProvider';
 
+export interface IServerGroupManagerStateParams {
+  provider: string;
+  accountId: string;
+  region: string;
+  serverGroupManager: string;
+}
+
 export const SERVER_GROUP_MANAGER_STATES = 'spinnaker.core.serverGroupManager.states';
 module(SERVER_GROUP_MANAGER_STATES, [APPLICATION_STATE_PROVIDER])
   .config((applicationStateProvider: ApplicationStateProvider) => {
@@ -28,13 +35,7 @@ module(SERVER_GROUP_MANAGER_STATES, [APPLICATION_STATE_PROVIDER])
         }
       },
       resolve: {
-        serverGroupManager: ['$stateParams', ($stateParams: StateParams) => {
-          return {
-            name: $stateParams.serverGroupManager,
-            accountId: $stateParams.accountId,
-            region: $stateParams.region,
-          };
-        }]
+        serverGroupManager: ['$stateParams', ($stateParams: IServerGroupManagerStateParams) => $stateParams]
       },
       data: {
         pageTitleDetails: {

--- a/app/scripts/modules/kubernetes/src/v2/serverGroupManager/details/details.controller.ts
+++ b/app/scripts/modules/kubernetes/src/v2/serverGroupManager/details/details.controller.ts
@@ -1,26 +1,20 @@
 import { IController, module } from 'angular';
 
-import { IServerGroupManager, Application } from '@spinnaker/core';
-
-interface IServerGroupManagerFromStateParams {
-  accountId: string;
-  region: string;
-  name: string;
-}
+import { IServerGroupManager, IServerGroupManagerStateParams, Application } from '@spinnaker/core';
 
 class KubernetesServerGroupManagerDetailsController implements IController {
   public serverGroupManager: IServerGroupManager;
 
-  constructor(serverGroupManager: IServerGroupManagerFromStateParams,
+  constructor(serverGroupManager: IServerGroupManagerStateParams,
               public app: Application) {
     'ngInject';
     this.app.ready()
       .then(() => this.extractServerGroupManager(serverGroupManager));
   }
 
-  private extractServerGroupManager(stateParams: IServerGroupManagerFromStateParams): void {
+  private extractServerGroupManager(stateParams: IServerGroupManagerStateParams): void {
     this.serverGroupManager = this.app.getDataSource('serverGroupManagers').data.find((manager: IServerGroupManager) =>
-      manager.name === stateParams.name
+      manager.name === stateParams.serverGroupManager
         && manager.region === stateParams.region
         && manager.account === stateParams.accountId
     );


### PR DESCRIPTION
Not worrying about styling yet because we haven't decided on an icon and this will only be visible to V2 Kubernetes users.

![server_group_manager_icon](https://user-images.githubusercontent.com/13868700/32743074-67a07318-c879-11e7-9f19-db89ffded635.png)
