### PR TITLE
fix(core): hide jenkins failure message when controller not initialized

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/jenkins/jenkinsExecutionDetails.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/jenkins/jenkinsExecutionDetails.html
@@ -65,7 +65,7 @@
       </div>
     </div>
 
-    <stage-failure-message stage="stage" is-failed="stage.isFailed" message="ctrl.getException(stage) || failureMessage"></stage-failure-message>
+    <stage-failure-message stage="stage" ng-if="stage.isFailed" message="ctrl.getException(stage) || failureMessage"></stage-failure-message>
   </div>
 
   <div class="step-section-details" ng-if="detailsSection === 'taskStatus'">


### PR DESCRIPTION
The Jenkins stage error message is constructed after the initial template rendering, so there's a single render call that triggers the `no-reason` warning, but it's not valid and just adding noise.