### PR TITLE
feat(core/search): Add health counts to server groups search results

### DIFF
--- a/app/scripts/modules/core/src/search/searchResult/Renderers.tsx
+++ b/app/scripts/modules/core/src/search/searchResult/Renderers.tsx
@@ -2,6 +2,9 @@ import * as React from 'react';
 import { startCase, kebabCase } from 'lodash';
 
 import { NgReact } from 'core/reactShims';
+import { Spinner } from 'core/widgets';
+import { IInstanceCounts } from 'core/domain';
+import { HealthCounts } from 'core/healthCounts';
 
 export interface ISearchColumn {
   key: string;
@@ -101,6 +104,28 @@ export class AccountCell extends React.Component<ICellRendererProps> {
         {accounts.map((account: string) => (
           <AccountTag key={account} account={account}/>
         ))}
+      </div>
+    );
+  }
+}
+
+export class HealthCountsCell extends React.Component<ICellRendererProps> {
+  private cellContent(instanceCounts: IInstanceCounts) {
+    switch (instanceCounts) {
+      case undefined:
+        return <Spinner size="small"/>;
+      case null:
+        return <span className="error">error</span>;
+      default:
+        return <HealthCounts container={instanceCounts}/>;
+    }
+  }
+
+  public render() {
+    const { item, col } = this.props;
+    return (
+      <div className={colClass(col.key)}>
+        {this.cellContent(item[col.key])}
       </div>
     );
   }

--- a/app/scripts/modules/core/src/search/searchResult/Renderers.tsx
+++ b/app/scripts/modules/core/src/search/searchResult/Renderers.tsx
@@ -115,7 +115,7 @@ export class HealthCountsCell extends React.Component<ICellRendererProps> {
       case undefined:
         return <Spinner size="small"/>;
       case null:
-        return <span className="error">error</span>;
+        return <span>?</span>;
       default:
         return <HealthCounts container={instanceCounts}/>;
     }

--- a/app/scripts/modules/core/src/search/searchResult/SearchResultGrid.tsx
+++ b/app/scripts/modules/core/src/search/searchResult/SearchResultGrid.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { BindAll } from 'lodash-decorators';
+import { kebabCase } from 'lodash';
 
 import { ISearchResultType } from './searchResultsType.registry';
 import { SearchStatus } from './SearchResults';
@@ -44,7 +45,7 @@ export class SearchResultGrid extends React.Component<ISearchResultGridProps> {
 
         return (
           <div className="search-result-grid flex-fill" style={{ height: 'initial' }}>
-            <div className={`table table-search-results table-search-results-${searchResultsType.id}`}>
+            <div className={`table table-search-results table-search-results-${kebabCase(searchResultsType.id)}`}>
               <SearchResultsHeader type={searchResultsType} />
               <SearchResultsData type={searchResultsType} results={searchResults} />
             </div>

--- a/app/scripts/modules/core/src/search/searchResult/searchResultsType.registry.ts
+++ b/app/scripts/modules/core/src/search/searchResult/searchResultsType.registry.ts
@@ -7,7 +7,7 @@ export interface IResultDisplayFormatter {
 
 export type SearchResultTabComponent = React.ComponentType<ISearchResultTabProps>;
 export type SearchResultsHeaderComponent = React.ComponentType<{ type: ISearchResultType }>;
-export type SearchResultsDataComponent = React.ComponentType<{ type: ISearchResultType, results: any[] }>;
+export type SearchResultsDataComponent<T = any> = React.ComponentType<{ type: ISearchResultType, results: T[] }>;
 
 export interface ISearchResultType {
   /** The unique key for the type, i.e., 'applications', 'serverGroup' */

--- a/app/scripts/modules/core/src/serverGroup/serverGroup.less
+++ b/app/scripts/modules/core/src/serverGroup/serverGroup.less
@@ -1,7 +1,11 @@
-.table-search-results-server-group {
+.table-search-results-server-groups {
   .table-header, .table-row {
     .col-server-group {
       width: 300px;
+    }
+
+    .col-instance-counts .instance-health-counts {
+      float: none;
     }
   }
 }

--- a/app/scripts/modules/core/src/serverGroup/serverGroupSearchResultType.tsx
+++ b/app/scripts/modules/core/src/serverGroup/serverGroupSearchResultType.tsx
@@ -1,10 +1,16 @@
 import * as React from 'react';
+import { Observable, Subject, BehaviorSubject } from 'rxjs';
 
 import {
-  AccountCell, BasicCell, HrefCell, searchResultTypeRegistry, ISearchColumn, ISearchResultType,
+  AccountCell, BasicCell, HrefCell, HealthCountsCell, searchResultTypeRegistry, ISearchColumn, ISearchResultType,
   SearchResultTabComponent, SearchResultsHeaderComponent, SearchResultsDataComponent, DefaultSearchResultTab,
   ISearchResult, HeaderCell, TableBody, TableHeader, TableRow,
 } from 'core/search';
+
+import { ReactInjector } from 'core/reactShims';
+import { IServerGroup, IInstanceCounts } from 'core/domain';
+
+import './serverGroup.less';
 
 export interface IServerGroupSearchResult extends ISearchResult {
   account: string;
@@ -17,17 +23,19 @@ export interface IServerGroupSearchResult extends ISearchResult {
   serverGroup: string;
   stack: string;
   url: string;
+  instanceCounts: IInstanceCounts;
 }
 
 const cols: { [key: string]: ISearchColumn } = {
   SERVERGROUP: { key: 'serverGroup', label: 'Name' },
   ACCOUNT: { key: 'account' },
   REGION: { key: 'region' },
-  EMAIL: { key: 'email' }
+  EMAIL: { key: 'email' },
+  HEALTH: { key: 'instanceCounts', label: 'Health' },
 };
 
 const iconClass = 'fa fa-th-large';
-const displayName = 'Security Groups';
+const displayName = 'Server Groups';
 
 const itemKeyFn = (item: IServerGroupSearchResult) =>
   [item.serverGroup, item.account, item.region].join('|');
@@ -46,10 +54,11 @@ const SearchResultsHeader: SearchResultsHeaderComponent = () => (
     <HeaderCell col={cols.ACCOUNT}/>
     <HeaderCell col={cols.REGION}/>
     <HeaderCell col={cols.EMAIL}/>
+    <HeaderCell col={cols.HEALTH}/>
   </TableHeader>
 );
 
-const SearchResultsData: SearchResultsDataComponent = ({ results }) => (
+const SearchResultsData: SearchResultsDataComponent<IServerGroupSearchResult> = ({ results }) => (
   <TableBody>
     {results.slice().sort(itemSortFn).map(item => (
       <TableRow key={itemKeyFn(item)}>
@@ -57,10 +66,111 @@ const SearchResultsData: SearchResultsDataComponent = ({ results }) => (
         <AccountCell item={item} col={cols.ACCOUNT} />
         <BasicCell item={item} col={cols.REGION} />
         <BasicCell item={item} col={cols.EMAIL} />
+        <HealthCountsCell item={item} col={cols.HEALTH} />
       </TableRow>
     ))}
   </TableBody>
 );
+
+interface IServerGroupDataProps {
+  type: ISearchResultType;
+  results: IServerGroupSearchResult[],
+}
+
+interface IServerGroupDataState {
+  serverGroups: IServerGroupSearchResult[],
+}
+
+interface IServerGroupTuple {
+  toFetch: IServerGroupSearchResult;
+  fetched: IServerGroup;
+}
+
+const makeServerGroupTuples = (sgToFetch: IServerGroupSearchResult[], fetched: IServerGroup[]): IServerGroupTuple[] => {
+  const findFetchedValue = (toFetch: IServerGroupSearchResult) => fetched.find(sg => sg.name === toFetch.serverGroup);
+  return sgToFetch.map(toFetch => ({ toFetch, fetched: findFetchedValue(toFetch) }));
+};
+
+const fetchServerGroups = (toFetch: IServerGroupSearchResult[]) => {
+  const fetchPromise = ReactInjector.API.one('serverGroups')
+    .withParams({ serverGroupNames: toFetch.map(sg => `${sg.account}:${sg.region}:${sg.serverGroup}`) })
+    .get()
+    .then((fetched: IServerGroup[]) => makeServerGroupTuples(toFetch, fetched));
+
+  return Observable.fromPromise(fetchPromise);
+};
+
+/**
+ * Wraps a server group search results component and augments with health/instance counts
+ *
+ * The /search endpoints do not return instance counts.
+ * This component waits until it is rendered, then starts fetching instance counts and mutating the search results.
+ */
+const AddHealthCounts = (Component: SearchResultsDataComponent<IServerGroupSearchResult>): SearchResultsDataComponent<IServerGroupSearchResult> => {
+  return class FetchHealthCounts extends React.Component<IServerGroupDataProps, IServerGroupDataState> {
+    public state = { serverGroups: [] } as any;
+    private results$ = new BehaviorSubject<IServerGroupSearchResult[]>([]);
+    private stop$ = new Subject();
+
+    constructor(props: any) {
+      super(props);
+
+      const failedFetch = (failedFetches: IServerGroupSearchResult[]) =>
+        Observable.of(failedFetches.map(toFetch => ({ toFetch, fetched: { instanceCounts: null } })));
+
+      // fetch a batch of server groups.
+      const processBatch = (batch: IServerGroupSearchResult[]) => {
+        return fetchServerGroups(batch).catch((err: { status: number }) => {
+          // In case of 404 during batch fetch, fall back to individual fetch
+          if (err.status === 404) {
+            // retry, but fetch each servergroup individually
+            return Observable.from(batch).flatMap(sg => {
+              return fetchServerGroups([sg]).catch(() => failedFetch([sg]))
+            });
+          }
+
+          return Observable.of(failedFetch(batch))
+        });
+      };
+
+      this.results$.flatMap((searchResults: IServerGroupSearchResult[]) => {
+        return Observable.from(searchResults)
+          .filter(result => result.instanceCounts === undefined)
+          // Serially fetch instance counts in batches of 25
+          .bufferCount(25)
+          .concatMap(processBatch);
+      })
+      .takeUntil(this.stop$)
+      .subscribe((tuples: IServerGroupTuple[]) => {
+        tuples.forEach(result => result.toFetch.instanceCounts = result.fetched.instanceCounts);
+        this.setState({ serverGroups: this.results$.value.slice() });
+      });
+    }
+
+    private applyServerGroups(serverGroups: IServerGroupSearchResult[]) {
+      serverGroups = serverGroups.sort(itemSortFn);
+      this.results$.next(serverGroups);
+      this.setState({ serverGroups })
+    }
+
+    public componentDidMount() {
+      this.applyServerGroups(this.props.results);
+    }
+
+    public componentWillReceiveProps(nextProps: IServerGroupDataProps) {
+      this.applyServerGroups(nextProps.results);
+    }
+
+    public componentWillUnmount() {
+      this.stop$.next();
+      this.stop$.complete();
+    }
+
+    public render() {
+      return <Component type={this.props.type} results={this.state.serverGroups} />
+    }
+  }
+};
 
 const serverGroupSearchResultType: ISearchResultType = {
   id: 'serverGroups',
@@ -71,7 +181,7 @@ const serverGroupSearchResultType: ISearchResultType = {
   components: {
     SearchResultTab,
     SearchResultsHeader,
-    SearchResultsData,
+    SearchResultsData: AddHealthCounts(SearchResultsData),
   },
 };
 

--- a/app/scripts/modules/core/src/serverGroup/serverGroupSearchResultType.tsx
+++ b/app/scripts/modules/core/src/serverGroup/serverGroupSearchResultType.tsx
@@ -127,7 +127,7 @@ const AddHealthCounts = (Component: SearchResultsDataComponent<IServerGroupSearc
           // In case of 404 during batch fetch, fall back to individual fetch
           if (err.status === 404) {
             // retry, but fetch each servergroup individually
-            return Observable.from(batch).flatMap(sg => {
+            return Observable.from(batch).mergeMap(sg => {
               return fetchServerGroups([sg]).catch(() => failedFetch([sg]))
             });
           }
@@ -136,7 +136,7 @@ const AddHealthCounts = (Component: SearchResultsDataComponent<IServerGroupSearc
         });
       };
 
-      this.results$.flatMap((searchResults: IServerGroupSearchResult[]) => {
+      this.results$.mergeMap((searchResults: IServerGroupSearchResult[]) => {
         return Observable.from(searchResults)
           .filter(result => result.instanceCounts === undefined)
           // Serially fetch instance counts in batches of 25


### PR DESCRIPTION
This PR fetches server group health counts when the server groups tab is selected.  The server groups are fetched in batches (of 25).  While fetching, a `<Spinner size="small" />` is shown in the Health column for each server group.