### PR TITLE
fix(webpack): remove API_HOST

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -175,7 +175,6 @@ function configure(IS_TEST) {
 
     config.plugins.push(...[
       new webpack.EnvironmentPlugin({
-        API_HOST: 'https://api-prestaging.spinnaker.mgmt.netflix.net',
         ENTITY_TAGS_ENABLED: 'true',
         FIAT_ENABLED: 'false',
         INFRA_STAGES: 'false',


### PR DESCRIPTION
@anotherchrisberry let me know if I'm doing this wrong, but it seems like adding API_HOST there forces the default settings.js to use netflix's internal API_HOST as opposed to localhost:8084