### PR TITLE
feat(provider/kubernetes): runJob multi container

### DIFF
--- a/app/scripts/modules/kubernetes/src/pipeline/stages/runJob/configureJob.controller.js
+++ b/app/scripts/modules/kubernetes/src/pipeline/stages/runJob/configureJob.controller.js
@@ -19,6 +19,7 @@ module.exports = angular.module('spinnaker.kubernetes.pipeline.stage.runJobStage
     this.stage = stage;
     this.pipeline = pipeline;
     this.policies = ['ClusterFirst', 'Default', 'ClusterFirstWithHostNet'];
+    this.pullPolicies = ['IFNOTPRESENT', 'ALWAYS', 'NEVER'];
 
     accountService.getUniqueAttributeForAllAccounts('kubernetes', 'namespaces')
       .then((namespaces) => {
@@ -29,11 +30,6 @@ module.exports = angular.module('spinnaker.kubernetes.pipeline.stage.runJobStage
       .then((accounts) => {
         this.accounts = accounts;
       });
-
-
-    if (!_.has(this.stage, 'container.name')) {
-      _.set(this.stage, 'container.name', 'job');
-    }
 
     if (!this.stage.dnsPolicy) {
       this.stage.dnsPolicy = 'ClusterFirst';
@@ -138,18 +134,18 @@ module.exports = angular.module('spinnaker.kubernetes.pipeline.stage.runJobStage
       }
     };
 
-    this.setPostStartHandler = (handler) => {
-      if (!this.stage.container.lifecycle) {
-        this.stage.container.lifecycle = {};
+    this.setPostStartHandler = (index, handler) => {
+      if (!this.stage.containers[index].lifecycle) {
+        this.stage.containers[index].lifecycle = {};
       }
-      this.stage.container.lifecycle.postStart = handler;
+      this.stage.containers[index].lifecycle.postStart = handler;
     };
 
-    this.setPreStopHandler = (handler) => {
-      if (!this.stage.container.lifecycle) {
-        this.stage.container.lifecycle = {};
+    this.setPreStopHandler = (index, handler) => {
+      if (!this.stage.containers[index].lifecycle) {
+        this.stage.containers[index].lifecycle = {};
       }
-      this.stage.container.lifecycle.preStop = handler;
+      this.stage.containers[index].lifecycle.preStop = handler;
     };
 
     this.submit = () => {

--- a/app/scripts/modules/kubernetes/src/pipeline/stages/runJob/configureJob.html
+++ b/app/scripts/modules/kubernetes/src/pipeline/stages/runJob/configureJob.html
@@ -1,7 +1,7 @@
 <form name="form" class="container-fluid form-horizontal" style="padding: 0;">
   <v2-modal-wizard heading="Configure Run Job"
                    dismiss="ctrl.cancel">
-    <v2-wizard-page label="Basic Settings" mark-complete-on-view="false">
+    <v2-wizard-page key="basic" label="Basic Settings" mark-complete-on-view="false">
       <stage-config-field label="Account">
         <account-select-field component="ctrl.stage"
                               field="account"
@@ -9,7 +9,7 @@
                               accounts="ctrl.accounts">
         </account-select-field>
       </stage-config-field>
-    
+
       <stage-config-field label="Namespace" help-key="kubernetes.namespace">
         <namespace-select-field component="ctrl.stage"
                                 field="namespace"
@@ -19,12 +19,10 @@
                                 namespaces="ctrl.namespaces">
         </namespace-select-field>
       </stage-config-field>
-    </v2-wizard-page>
 
-    <v2-wizard-page label="Container" done="true">
       <stage-config-field label="Image">
-        <ui-select name="containerSelect" ng-model="ctrl.stage.container" class="form-control input-sm" required>
-          <ui-select-match>{{ ctrl.stage.container.imageDescription | kubernetesImageId }}</ui-select-match>
+        <ui-select multiple name="containerSelect" ng-model="ctrl.stage.containers" class="form-control input-sm" required>
+          <ui-select-match>{{ $item.imageDescription | kubernetesImageId }}</ui-select-match>
           <ui-select-choices
             repeat="container in ctrl.containers | orderBy: 'imageDescription.imageId'"
             group-by="ctrl.groupByRegistry"
@@ -35,74 +33,9 @@
           </ui-select-choices>
         </ui-select>
       </stage-config-field>
-
-      <stage-config-field label="Container Name">
-        <div>
-          <input type="text" class="form-control input-sm" ng-model="ctrl.stage.container.name">
-        </div>
-      </stage-config-field>
-      
-      <collapsible-section heading="Basic Settings" expanded="true" subsection="true">
-        <div class="sm-label-left">
-          <b>Commands</b>
-        </div>
-        <kubernetes-container-commands commands="ctrl.stage.container.command">
-        </kubernetes-container-commands>
-        
-        <div class="sm-label-left">
-          <b>Args</b>
-        </div>
-        <kubernetes-container-arguments args="ctrl.stage.container.args">
-        </kubernetes-container-arguments>
-      
-        <div class="sm-label-left">
-          <b>Environment Variables</b>
-        </div>
-        <kubernetes-container-environment-variables env-vars="ctrl.stage.container.envVars">
-        </kubernetes-container-environment-variables>
-      </collapsible-section>
-
-      <collapsible-section heading="Volumes" expanded="false" subsection="true">
-        <kubernetes-container-volumes volume-sources="ctrl.stage.volumeSources" volume-mounts="ctrl.stage.container.volumeMounts">
-        </kubernetes-container-volumes>
-      </collapsible-section>
-
-      <collapsible-section heading="Ports" expanded="false" subsection="true">
-        <kubernetes-container-ports ports="ctrl.stage.container.ports">
-        </kubernetes-container-ports>
-      </collapsible-section>
-
-      <collapsible-section heading="Probes" expanded="false" subsection="true">
-        <kubernetes-container-probe container="ctrl.stage.container" command="$ctrl" probetype="'readinessProbe'" heading="'Readiness'">
-        </kubernetes-container-probe>
-        <hr>
-        <kubernetes-container-probe container="ctrl.stage.container" command="$ctrl" probetype="'livenessProbe'" heading="'Liveness'">
-        </kubernetes-container-probe>
-      </collapsible-section>
-
-      <collapsible-section heading="Resources" expanded="false" subsection="true">
-        <kubernetes-container-resources container="ctrl.stage.container">
-        </kubernetes-container-resources>
-      </collapsible-section>
-
-      <collapsible-section heading="Security Context" expanded="false" subsection="true">
-        <kubernetes-security-context-selector component="ctrl.stage.container">
-        </kubernetes-security-context-selector>
-      </collapsible-section>
-
-      <collapsible-section heading="Lifecycle Hooks" expanded="false" subsection="true">
-        <kubernetes-lifecycle-hook-configurer on-handler-change="ctrl.setPostStartHandler(handler)"
-                                              handler="ctrl.stage.container.lifecycle.postStart">
-        PostStart <help-field key="kubernetes.containers.lifecycle.postStart"></help-field>
-        </kubernetes-lifecycle-hook-configurer>
-        <kubernetes-lifecycle-hook-configurer on-handler-change="ctrl.setPreStopHandler(handler)"
-                                              handler="ctrl.stage.container.lifecycle.preStop">
-        PreStop <help-field key="kubernetes.containers.lifecycle.preStop"></help-field>
-        </kubernetes-lifecycle-hook-configurer>
-      </collapsible-section>
     </v2-wizard-page>
 
-    <v2-wizard-page label="Advanced Settings" done="true">
+    <v2-wizard-page key="advanced" label="Advanced Settings" done="true">
       <stage-config-field label="DNS Policy">
         <select class="form-control input-sm"
                 ng-model="ctrl.stage.dnsPolicy"
@@ -119,16 +52,100 @@
       </div>
       <map-editor model="ctrl.stage.annotations" add-button-label="Add Annotations" labels-left="true">
       </map-editor>
-  
+
       <div class="sm-label-left">
         <b>Pod Labels</b>
       </div>
       <map-editor model="ctrl.stage.labels" add-button-label="Add Labels" labels-left="true">
       </map-editor>
     </v2-wizard-page>
+
+    <div ng-repeat="container in ctrl.stage.containers">
+      <v2-wizard-page key="container-{{$index}}" label="Container" done="true">
+        <div style="padding-bottom: 10px">
+          <stage-config-field label="Name">
+            <div>
+              <input type="text" class="form-control input-sm" ng-model="container.name">
+            </div>
+          </stage-config-field>
+
+          <stage-config-field label="Registry" help-key="kubernetes.containers.registry">
+            <p class="form-control-static">{{container.imageDescription.registry}}</p>
+          </stage-config-field>
+
+          <stage-config-field label="Pull Policy" help-key="kubernetes.containers.pullpolicy">
+            <select class="form-control input-sm" ng-model="container.imagePullPolicy">
+              <option ng-repeat="type in ctrl.pullPolicies" value="{{type}}"
+                      ng-selected="container.imagePullPolicy === type">{{type}}</option>
+            </select>
+          </stage-config-field>
+        </div>
+        <collapsible-section heading="Basic Settings" expanded="true" subsection="true">
+          <div class="sm-label-left">
+            <b>Commands</b>
+            <help-field key="kubernetes.containers.command"></help-field>
+          </div>
+          <kubernetes-container-commands commands="container.command">
+          </kubernetes-container-commands>
+
+          <div class="sm-label-left">
+            <b>Args</b>
+            <help-field key="kubernetes.containers.args"></help-field>
+          </div>
+          <kubernetes-container-arguments args="container.args">
+          </kubernetes-container-arguments>
+
+          <div class="sm-label-left">
+            <b>Environment Variables</b>
+          </div>
+          <kubernetes-container-environment-variables env-vars="container.envVars">
+          </kubernetes-container-environment-variables>
+        </collapsible-section>
+
+        <collapsible-section heading="Volumes" expanded="false" subsection="true">
+          <kubernetes-container-volumes volume-sources="ctrl.stage.volumeSources" volume-mounts="container.volumeMounts">
+          </kubernetes-container-volumes>
+        </collapsible-section>
+
+        <collapsible-section heading="Ports" expanded="false" subsection="true">
+          <kubernetes-container-ports ports="container.ports">
+          </kubernetes-container-ports>
+        </collapsible-section>
+
+        <collapsible-section heading="Probes" expanded="false" subsection="true">
+          <kubernetes-container-probe container="container" command="ctrl" probetype="'readinessProbe'" heading="'Readiness'">
+          </kubernetes-container-probe>
+          <hr>
+          <kubernetes-container-probe container="container" command="ctrl" probetype="'livenessProbe'" heading="'Liveness'">
+          </kubernetes-container-probe>
+        </collapsible-section>
+
+        <collapsible-section heading="Resources" expanded="false" subsection="true">
+          <kubernetes-container-resources container="container">
+          </kubernetes-container-resources>
+        </collapsible-section>
+
+        <collapsible-section heading="Security Context" expanded="false" subsection="true">
+          <kubernetes-security-context-selector component="container">
+          </kubernetes-security-context-selector>
+        </collapsible-section>
+
+        <collapsible-section heading="Lifecycle Hooks" expanded="false" subsection="true">
+          <kubernetes-lifecycle-hook-configurer on-handler-change="ctrl.setPostStartHandler($index, handler)"
+                                                handler="container.lifecycle.postStart">
+          PostStart <help-field key="kubernetes.containers.lifecycle.postStart"></help-field>
+          </kubernetes-lifecycle-hook-configurer>
+          <kubernetes-lifecycle-hook-configurer on-handler-change="ctrl.setPreStopHandler($index, handler)"
+                                                handler="container.lifecycle.preStop">
+          PreStop <help-field key="kubernetes.containers.lifecycle.preStop"></help-field>
+          </kubernetes-lifecycle-hook-configurer>
+        </collapsible-section>
+      </v2-wizard-page>
+    </div>
+
   </v2-modal-wizard>
   <div class="modal-footer">
     <button class="btn btn-default btn-cancel" ng-click="ctrl.cancel()">Cancel</button>
     <submit-button on-click="ctrl.submit()"></submit-button>
-  </div>  
+  </div>
 </form>

--- a/app/scripts/modules/kubernetes/src/pipeline/stages/runJob/runJobStage.html
+++ b/app/scripts/modules/kubernetes/src/pipeline/stages/runJob/runJobStage.html
@@ -17,7 +17,9 @@
         {{ ctrl.stage.namespace }}
       </td>
       <td>
-        {{ ctrl.stage.container.imageDescription | kubernetesImageId }}
+        <div ng-repeat="container in ctrl.stage.containers">
+          {{ container.imageDescription | kubernetesImageId }}
+        </div>
       </td>
       <td class="condensed-actions text-center">
         <a class="btn btn-sm btn-link" href ng-click="ctrl.configureJob()">

--- a/app/scripts/modules/kubernetes/src/pipeline/stages/runJob/runJobStage.js
+++ b/app/scripts/modules/kubernetes/src/pipeline/stages/runJob/runJobStage.js
@@ -36,6 +36,12 @@ module.exports = angular.module('spinnaker.kubernetes.pipeline.stage.runJobStage
     this.stage.cloudProvider = 'kubernetes';
     this.stage.application = $scope.application.name;
 
+
+    if (this.stage.container && !this.stage.containers) {
+      this.stage.containers = [this.stage.container];
+      delete this.stage.container;
+    }
+
     this.configureJob = () => {
       return $uibModal.open({
         templateUrl: require('./configureJob.html'),


### PR DESCRIPTION
adds support for running jobs with multiple containers. will convert
existing `container` usage to `containers`

spinnaker/spinnaker#1961

@danielpeach PTAL. for real this time. this is the final round of run job work.