### PR TITLE
fix(core): omit moniker when caching security groups

### DIFF
--- a/app/scripts/modules/amazon/src/loadBalancer/configure/classic/createClassicLoadBalancer.controller.spec.ts
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/classic/createClassicLoadBalancer.controller.spec.ts
@@ -73,6 +73,7 @@ describe('Controller: awsCreateClassicLoadBalancerCtrl', () => {
   afterEach(AWSProviderSettings.resetToOriginal);
 
   it('requires health check path for HTTP/S', () => {
+    spyOn(securityGroupReader, 'getAllSecurityGroups').and.returnValue($q.when([]));
     initialize();
     const loadBalancer = {
       healthCheckProtocol: 'HTTP'
@@ -94,6 +95,7 @@ describe('Controller: awsCreateClassicLoadBalancerCtrl', () => {
   });
 
   it('includes SSL Certificate field when any listener is HTTPS or SSL', () => {
+    spyOn(securityGroupReader, 'getAllSecurityGroups').and.returnValue($q.when([]));
     initialize();
     const loadBalancer = {
       listeners: [],
@@ -125,6 +127,7 @@ describe('Controller: awsCreateClassicLoadBalancerCtrl', () => {
 
   describe('prependForwardSlash', () => {
     beforeEach(() => {
+      spyOn(securityGroupReader, 'getAllSecurityGroups').and.returnValue($q.when([]));
       initialize();
     });
     it('should add the leading slash if it is NOT present', () => {
@@ -151,6 +154,7 @@ describe('Controller: awsCreateClassicLoadBalancerCtrl', () => {
   describe('isInternal flag', () => {
     it('should remove the flag and set a state value if inferInternalFlagFromSubnet is true', () => {
       AWSProviderSettings.loadBalancers.inferInternalFlagFromSubnet = true;
+      spyOn(securityGroupReader, 'getAllSecurityGroups').and.returnValue($q.when([]));
       initialize();
 
       expect(controller.loadBalancerCommand.isInternal).toBe(undefined);
@@ -158,6 +162,7 @@ describe('Controller: awsCreateClassicLoadBalancerCtrl', () => {
     });
 
     it('should set the flag based on purpose when subnet is updated', () => {
+      spyOn(securityGroupReader, 'getAllSecurityGroups').and.returnValue($q.when([]));
       initialize();
 
       controller.subnets = [
@@ -179,6 +184,7 @@ describe('Controller: awsCreateClassicLoadBalancerCtrl', () => {
     });
 
     it('should leave the flag once it has been toggled', () => {
+      spyOn(securityGroupReader, 'getAllSecurityGroups').and.returnValue($q.when([]));
       initialize();
 
       controller.subnets = [
@@ -204,6 +210,7 @@ describe('Controller: awsCreateClassicLoadBalancerCtrl', () => {
 
     it('should leave the flag and not set a state value if inferInternalFlagFromSubnet is false or not defined', () => {
       AWSProviderSettings.loadBalancers.inferInternalFlagFromSubnet = true;
+      spyOn(securityGroupReader, 'getAllSecurityGroups').and.returnValue($q.when([]));
 
       initialize();
       expect(controller.loadBalancerCommand.isInternal).toBe(undefined);

--- a/app/scripts/modules/core/src/securityGroup/securityGroupReader.service.spec.ts
+++ b/app/scripts/modules/core/src/securityGroup/securityGroupReader.service.spec.ts
@@ -9,6 +9,7 @@ import {
 import { ISecurityGroup } from 'core/domain';
 import { APPLICATION_MODEL_BUILDER, ApplicationModelBuilder } from 'core/application/applicationModel.builder';
 import { Application } from 'core/application/application.model';
+import { InfrastructureCacheService } from 'core';
 
 describe('Service: securityGroupReader', function () {
 
@@ -28,6 +29,7 @@ describe('Service: securityGroupReader', function () {
                           _applicationModelBuilder_: ApplicationModelBuilder,
                           _providerServiceDelegate_: any,
                           securityGroupTransformer: SecurityGroupTransformerService,
+                          infrastructureCaches: InfrastructureCacheService,
                           _securityGroupReader_: SecurityGroupReader) {
       reader = _securityGroupReader_;
       $http = $httpBackend;
@@ -35,6 +37,12 @@ describe('Service: securityGroupReader', function () {
       applicationModelBuilder = _applicationModelBuilder_;
       $q = _$q_;
       $scope = $rootScope.$new();
+
+      const cacheStub: any = {
+          get: () => null,
+          put: () => {},
+      };
+      spyOn(infrastructureCaches, 'get').and.returnValue(cacheStub);
 
       spyOn(securityGroupTransformer, 'normalizeSecurityGroup')
         .and

--- a/app/scripts/modules/core/src/securityGroup/securityGroupReader.service.ts
+++ b/app/scripts/modules/core/src/securityGroup/securityGroupReader.service.ts
@@ -12,6 +12,7 @@ import { SETTINGS } from 'core/config/settings';
 import { SEARCH_SERVICE, SearchService, ISearchResults } from 'core/search/search.service';
 import { ISecurityGroupSearchResult } from './securityGroupSearchResultType';
 import { ProviderServiceDelegate, PROVIDER_SERVICE_DELEGATE } from 'core/cloudProvider/providerService.delegate';
+import { IMoniker } from 'core/naming/IMoniker';
 
 export interface ISecurityGroupsByAccount {
   [account: string]: {
@@ -61,6 +62,7 @@ export interface ISecurityGroupSummary {
   id: string;
   name: string;
   vpcId: string;
+  moniker?: IMoniker;
 }
 
 export interface ISecurityGroupsByAccountSourceData {
@@ -286,7 +288,27 @@ export class SecurityGroupReader {
   }
 
   public getAllSecurityGroups(): IPromise<ISecurityGroupsByAccountSourceData> {
-    return this.API.one('securityGroups').useCache(this.infrastructureCaches.get('securityGroups')).get();
+    // Because these are cached in local storage, we unfortunately need to remove the moniker, as it triples the size
+    // of the object being stored, which blows out our LS quota for a sufficiently large footprint
+    const cache = this.infrastructureCaches.get('securityGroups');
+    const cached = cache.get('allGroups');
+    if (cached) {
+      return this.$q.resolve(cached);
+    }
+    return this.API.one('securityGroups').useCache().get()
+      .then((groupsByAccount: ISecurityGroupsByAccountSourceData) => {
+          Object.keys(groupsByAccount).forEach(account => {
+            Object.keys(groupsByAccount[account]).forEach(provider => {
+              Object.keys(groupsByAccount[account][provider]).forEach(region => {
+                groupsByAccount[account][provider][region].forEach(group => {
+                  delete group.moniker;
+                })
+              })
+            })
+          });
+        cache.put('allGroups', groupsByAccount);
+        return groupsByAccount;
+      });
   }
 
   public getApplicationSecurityGroup(application: Application,


### PR DESCRIPTION
The moniker roughly triples the size of the cached security group in local storage.

In most installations, this is probably not a big deal, but Netflix has a large footprint in the cloud, and we're seeing security groups taking > 3 MB of local storage space, resulting in frequent cache quota overflows, which results in local storage clearing, which is...not great.

As far as I can tell, nothing is reading the moniker data for security groups from this data source, so this should not be a problem.

We need to reconsider our strategy for storing security groups in local storage, but in the interim, this is needed.

FYI @lwander @andrewbackes 