### PR TITLE
bug(provider/openstack) - Interface network and security groups are o…

### DIFF
--- a/app/scripts/modules/openstack/src/loadBalancer/configure/wizard/interface.html
+++ b/app/scripts/modules/openstack/src/loadBalancer/configure/wizard/interface.html
@@ -4,6 +4,7 @@
       model="loadBalancer.networkId"
       help-key="openstack.loadBalancer.network"
       read-only="!isNew"
+      allow-no-selection="true"
       filter="{ account: loadBalancer.account }">
     </network-select-field>
 
@@ -11,7 +12,7 @@
       label="Security Groups"
       cache="allSecurityGroups"
       refresh-cache="updateSecurityGroups"
-      required="true"
+      required="false"
       model="loadBalancer.securityGroups">
     </os-cache-backed-multi-select-field>
   </div>


### PR DESCRIPTION
…ptional.

Assigning a FIP and security groups to a load balancer is an optional configuration in Openstack.
Changes are dependent on  https://github.com/spinnaker/clouddriver/pull/2154
