### PR TITLE
perf(core/executions): consider pipeline filters when fetching execut…

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/pipelineConfigurer.js
+++ b/app/scripts/modules/core/src/pipeline/config/pipelineConfigurer.js
@@ -373,7 +373,7 @@ module.exports = angular.module('spinnaker.core.pipeline.config.pipelineConfigur
     };
 
     this.getPipelineExecutions = () => {
-      executionService.getExecutionsForConfigIds($scope.pipeline.application, $scope.pipeline.id, 5)
+      executionService.getExecutionsForConfigIds($scope.pipeline.application, [$scope.pipeline.id], 5)
         .then(executions => {
           executions.forEach(execution => executionsTransformer.addBuildInfo(execution));
           $scope.pipelineExecutions = executions;

--- a/app/scripts/modules/core/src/pipeline/config/triggers/pipeline/pipelineTriggerOptions.directive.js
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/pipeline/pipelineTriggerOptions.directive.js
@@ -54,7 +54,7 @@ module.exports = angular
         return;
       }
       this.viewState.executionsLoading = true;
-      executionService.getExecutions(command.trigger.application, {statuses: []})
+      executionService.getExecutions(command.trigger.application)
         .then(executionLoadSuccess, executionLoadFailure);
     };
 

--- a/app/scripts/modules/core/src/pipeline/executions/execution/Execution.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/execution/Execution.tsx
@@ -181,7 +181,11 @@ export class Execution extends React.Component<IExecutionProps, IExecutionState>
         executionService.getExecution(execution.id).then((updated: IExecution) => {
           if (this.mounted) {
             const dataSource = application.getDataSource(this.props.dataSourceKey);
-            executionService.updateExecution(application, updated, dataSource);
+            // if we are already in the middle of a refresh, leave the running execution alone,
+            // lest we trigger a dataUpdated event and clear the reloadingForFilters flag
+            if (!this.props.application.executions.reloadingForFilters) {
+              executionService.updateExecution(application, updated, dataSource);
+            }
             executionService.removeCompletedExecutionsFromRunningData(application);
           }
           refreshing = false;

--- a/app/scripts/modules/core/src/pipeline/filter/ExecutionFilters.tsx
+++ b/app/scripts/modules/core/src/pipeline/filter/ExecutionFilters.tsx
@@ -78,13 +78,13 @@ export class ExecutionFilters extends React.Component<IExecutionFiltersProps, IE
   private refreshExecutions(): void {
     ReactInjector.executionFilterModel.asFilterModel.applyParamsToUrl();
     this.props.application.executions.reloadingForFilters = true;
-    this.props.application.executions.refresh();
+    this.props.application.executions.refresh(true);
   }
 
   private clearFilters(): void {
     ReactGA.event({ category: 'Pipelines', action: `Filter: clear all (side nav)` });
     ReactInjector.executionFilterService.clearFilters();
-    ReactInjector.executionFilterService.updateExecutionGroups(this.props.application);
+    this.refreshExecutions();
   }
 
   private getPipelineNames(): string[] {
@@ -188,7 +188,7 @@ export class ExecutionFilters extends React.Component<IExecutionFiltersProps, IE
                 <Pipelines
                   names={pipelineNames}
                   dragEnabled={pipelineReorderEnabled}
-                  update={this.updateExecutionGroups}
+                  update={this.refreshExecutions}
                   onSortEnd={this.handleSortEnd}
                 />
                 { pipelineNames.length && (

--- a/app/scripts/modules/core/src/pipeline/manualExecution/manualPipelineExecution.html
+++ b/app/scripts/modules/core/src/pipeline/manualExecution/manualPipelineExecution.html
@@ -102,7 +102,7 @@
         <div class="form-group" ng-if="vm.hasRequiredParameters">
           <div class="col-md-4 col-md-offset-4">
             <em>* Required</em>
-
+          </div>
         </div>
       </div>
 

--- a/app/scripts/modules/core/src/pipeline/pipeline.dataSource.js
+++ b/app/scripts/modules/core/src/pipeline/pipeline.dataSource.js
@@ -21,7 +21,7 @@ module.exports = angular
     };
 
     let loadExecutions = (application) => {
-      return executionService.getExecutions(application.name);
+      return executionService.getExecutions(application.name, application);
     };
 
     let loadPipelineConfigs = (application) => {


### PR DESCRIPTION
…ions

For applications with a very large list of pipeline executions, it's really cumbersome to view the history for a single pipeline beyond a couple of executions because Deck always fetches all the executions for the entire application. We already have an endpoint to retrieve executions by pipeline config ids, so we can use that to expedite retrieval.

The code is a little messy (we have to fetch the pipeline configs first, then correlate names to ids), but it's not bad, and ends up feeling a lot snappier. The only downside is there are more calls being made to the backend for smaller applications, too. But in my limited testing, this feels negligible on smaller apps.

There's also a fix in here for data source refresh. Right now, performing multiple `refresh(true)` calls on a data source will not necessarily result in the last one in being applied. This is especially noticeable on the executions as you toggle filters on and off. The fix is hacky because we're in a weird hybrid state between promises and observables in the data sources; nonetheless, it's functional and will be rewritten someday with `switchMap` and the world will be a better place.

@ajordens FYI
@jrsquared PTAL