### PR TITLE
feat(core): console output jump to end

### DIFF
--- a/app/scripts/modules/core/src/instance/details/console/consoleOutput.modal.controller.js
+++ b/app/scripts/modules/core/src/instance/details/console/consoleOutput.modal.controller.js
@@ -26,5 +26,10 @@ module.exports = angular.module('spinnaker.core.instance.details.console.control
     );
 
     $scope.close = $uibModalInstance.dismiss;
+    
+    $scope.jumpToEnd = () => {
+      const console = document.getElementById("console-output");
+      console.scrollTop = console.scrollHeight;
+    };
 
   });

--- a/app/scripts/modules/core/src/instance/details/console/consoleOutput.modal.html
+++ b/app/scripts/modules/core/src/instance/details/console/consoleOutput.modal.html
@@ -1,15 +1,15 @@
-<div modal-page>
+<div class="flex-fill" modal-page>
   <modal-close dismiss="$dismiss()"></modal-close>
   <div class="modal-header">
     <h3>Console Output: {{vm.instanceId}}</h3>
   </div>
-  <div class="modal-body">
+  <div id="console-output" class="modal-body">
     <div class="row">
       <div class="col-md-12">
         <div class="horizontal center middle spinner-container" ng-if="vm.loading">
           <loading-spinner size="'small'"></loading-spinner>
         </div>
-        <pre style="font-size:75%" ng-if="vm.consoleOutput">{{vm.consoleOutput}}</pre>
+        <pre style="font-size:75%;" ng-if="vm.consoleOutput">{{vm.consoleOutput}}</pre>
         <div ng-if="vm.exception">
           <p>An error occurred trying to load console output. Please try again later.</p>
           <p>Exception:</p>
@@ -19,6 +19,7 @@
     </div>
   </div>
   <div class="modal-footer">
+    <button class="btn btn-link" ng-if="vm.consoleOutput" ng-click="jumpToEnd()">Scroll to End</button>
     <button class="btn btn-primary" ng-click="close()">Close</button>
   </div>
 </div>

--- a/app/scripts/modules/core/src/instance/details/console/consoleOutputLink.directive.js
+++ b/app/scripts/modules/core/src/instance/details/console/consoleOutputLink.directive.js
@@ -25,7 +25,7 @@ module.exports = angular
           $uibModal.open({
             templateUrl: InstanceTemplates.consoleOutputModal,
             controller: 'ConsoleOutputCtrl as ctrl',
-            size: 'lg',
+            size: 'lg modal-fullscreen',
             resolve: {
               instance: () => this.instance
             }


### PR DESCRIPTION
constrain modal height and add shortcut to end of the output by jumping
`pre` content to end.

@anotherchrisberry PTAL. I pulled the `800px` from the changes modal so it's not _totally_ arbitrary.