### PR TITLE
fix(amazon): provide better error message when bake stage fails

### DIFF
--- a/app/scripts/modules/amazon/src/pipeline/stages/bake/bakeExecutionDetails.controller.js
+++ b/app/scripts/modules/amazon/src/pipeline/stages/bake/bakeExecutionDetails.controller.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const angular = require('angular');
+import { get } from 'lodash';
 
 import { SETTINGS } from '@spinnaker/core';
 
@@ -17,6 +18,7 @@ module.exports = angular.module('spinnaker.amazon.pipeline.stage.bake.executionD
       $scope.provider = $scope.stage.context.cloudProviderType || 'aws';
       $scope.roscoMode = SETTINGS.feature.roscoMode;
       $scope.bakeryDetailUrl = $interpolate(SETTINGS.bakeryDetailUrl);
+      $scope.bakeFailedNoError = get($scope.stage, 'context.status.result') === 'FAILURE' && !$scope.stage.failureMessage;
     };
 
     let initialize = () => executionDetailsSectionService.synchronizeSection($scope.configSections, initialized);

--- a/app/scripts/modules/amazon/src/pipeline/stages/bake/bakeExecutionDetails.html
+++ b/app/scripts/modules/amazon/src/pipeline/stages/bake/bakeExecutionDetails.html
@@ -33,7 +33,7 @@
         </dl>
       </div>
     </div>
-    <stage-failure-message stage="stage" message="stage.failureMessage"></stage-failure-message>
+    <stage-failure-message stage="stage" message="stage.failureMessage" ng-if="stage.failureMessage"></stage-failure-message>
 
     <div class="row" ng-if="stage.context.region && stage.context.status.resourceId">
       <div class="col-md-12">
@@ -44,9 +44,9 @@
             <div select-on-dbl-click>{{stage.context.imageName}}</div>
             <div>({{stage.context.ami}})</div>
           </div>
-          <a target="_blank" href="{{ bakeryDetailUrl(stage) }}">
-            View Bakery Details
-          </a>
+          <span ng-if="bakeFailedNoError">Bake failed. </span>
+          <a target="_blank" href="{{ bakeryDetailUrl(stage) }}">View Bakery Details</a>
+          <span ng-if="bakeFailedNoError"> for more info.</span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Not a lot going on here, just omitting the `<stage-failure-message>` tag if there's no message and directing the user more explicitly to the bakery logs.