### PR TITLE
fix(build): remove default env vars

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -175,10 +175,6 @@ function configure(IS_TEST) {
 
     config.plugins.push(...[
       new webpack.EnvironmentPlugin({
-        ENTITY_TAGS_ENABLED: 'true',
-        FIAT_ENABLED: 'false',
-        INFRA_STAGES: 'false',
-        TIMEZONE: 'America/Los_Angeles',
         NODE_ENV: 'development',
       }),
       new webpack.optimize.CommonsChunkPlugin({name: 'vendor', filename: 'vendor.bundle.js'}),


### PR DESCRIPTION
Related to this: https://github.com/spinnaker/deck/pull/4469 having these env vars breaks the default settings.js since it always prefers to read from the user's environment than what's set in settings.js

@jtk54 FYI