### PR TITLE
fix(core): reduce starting instance animations

### DIFF
--- a/app/scripts/modules/core/src/cluster/rollups.less
+++ b/app/scripts/modules/core/src/cluster/rollups.less
@@ -78,6 +78,15 @@ table.instances {
   td:first-child, th:first-child {
     padding-left: 0;
   }
+  .instance-group {
+    display: inline-block;
+  }
+  .instance-group-Starting {
+    .pulsing(1.0);
+    &:hover {
+      animation: none;
+    }
+  }
   a.instance {
     margin: 0;
     display: inline-block;
@@ -103,7 +112,6 @@ table.instances {
 
     &.health-status-Starting {
       background-color: var(--color-accent-g1);
-      .pulsing(1.0);
     }
 
     &:hover, &.active, &.highlighted {

--- a/app/scripts/modules/core/src/presentation/main.less
+++ b/app/scripts/modules/core/src/presentation/main.less
@@ -401,10 +401,6 @@ html {
   }
 }
 
-.glyphicon-Starting-triangle {
-  .pulsing(1.0);
-}
-
 .glyphicon-Failed-triangle {
   &:before {
     content: "\2717";


### PR DESCRIPTION
We ran into an unusual application whose steady state is all instances being in a "starting" state. 

This would be fine if the application didn't have thousands of instances, but it does. So, right now, the browser is forced to animate thousands of nodes on the page in a constant cycle.

This PR addresses this by grouping the instances into a separate div and animating that div.