### PR TITLE
fix(provider/kubernetes): v2 move backing data out of stage

### DIFF
--- a/app/scripts/modules/kubernetes/src/v2/manifest/edit/editManifestWizard.controller.ts
+++ b/app/scripts/modules/kubernetes/src/v2/manifest/edit/editManifestWizard.controller.ts
@@ -13,6 +13,7 @@ import {
 
 import {
   IKubernetesManifestCommand,
+  IKubernetesManifestCommandMetadata,
   KUBERNETES_MANIFEST_COMMAND_BUILDER,
   KubernetesManifestCommandBuilder
 } from '../manifestCommandBuilder.service';
@@ -24,6 +25,7 @@ class KubernetesEditManifestCtrl implements IController {
   };
   public taskMonitor: TaskMonitor;
   public command: IKubernetesManifestCommand;
+  public metadata: IKubernetesManifestCommandMetadata;
 
   constructor(sourceManifest: any,
               sourceMoniker: IMoniker,
@@ -35,7 +37,10 @@ class KubernetesEditManifestCtrl implements IController {
     'ngInject';
     this.kubernetesManifestCommandBuilder.buildNewManifestCommand(application, sourceManifest, sourceMoniker)
       .then((builtCommand) => {
-        this.command = builtCommand;
+        const { command, metadata } = builtCommand;
+        this.command = command;
+        this.metadata = metadata;
+
         this.initialize();
         this.state.loaded = true;
       });
@@ -46,7 +51,7 @@ class KubernetesEditManifestCtrl implements IController {
   }
 
   public submit(): void {
-    const command = this.kubernetesManifestCommandBuilder.copyAndCleanCommand(this.command);
+    const command = this.kubernetesManifestCommandBuilder.copyAndCleanCommand(this.metadata, this.command);
     const submitMethod = () => this.manifestWriter.deployManifest(command, this.application);
     this.taskMonitor.submit(submitMethod);
   }

--- a/app/scripts/modules/kubernetes/src/v2/manifest/manifestCommandBuilder.service.ts
+++ b/app/scripts/modules/kubernetes/src/v2/manifest/manifestCommandBuilder.service.ts
@@ -4,13 +4,21 @@ import { dump, load } from 'js-yaml'
 
 import { ACCOUNT_SERVICE, AccountService, Application, IMoniker } from '@spinnaker/core';
 
+export interface IKubernetesManifestCommandData {
+  command: IKubernetesManifestCommand;
+  metadata: IKubernetesManifestCommandMetadata;
+}
+
 export interface IKubernetesManifestCommand {
   account: string;
   cloudProvider: string;
   manifest: any;
-  manifestText: string;
   relationships: IKubernetesManifestSpinnakerRelationships;
   moniker: IMoniker;
+}
+
+export interface IKubernetesManifestCommandMetadata {
+  manifestText: string;
   backingData: any;
 }
 
@@ -38,22 +46,16 @@ export class KubernetesManifestCommandBuilder {
       return false;
     }
 
-    if (!command.manifestText) {
-      return false;
-    }
-
     return true;
   }
 
-  public copyAndCleanCommand(input: IKubernetesManifestCommand): IKubernetesManifestCommand {
+  public copyAndCleanCommand(metadata: IKubernetesManifestCommandMetadata, input: IKubernetesManifestCommand): IKubernetesManifestCommand {
     const command = copy(input);
-    command.manifest = load(command.manifestText);
-    delete command.manifestText;
-    delete command.backingData;
+    command.manifest = load(metadata.manifestText);
     return command;
   }
 
-  public buildNewManifestCommand(app: Application, sourceManifest?: any, sourceMoniker?: IMoniker): IPromise<IKubernetesManifestCommand> {
+  public buildNewManifestCommand(app: Application, sourceManifest?: any, sourceMoniker?: IMoniker): IPromise<IKubernetesManifestCommandData> {
     const dataToFetch = {
       accounts: this.accountService.getAllAccountDetailsForProvider('kubernetes', 'v2'),
     };
@@ -67,7 +69,7 @@ export class KubernetesManifestCommandBuilder {
         }
 
         const manifest = {};
-        const manifestText = sourceManifest == null ? '' : dump(sourceManifest);
+        const manifestText = !sourceManifest ? '' : dump(sourceManifest);
         const cloudProvider = 'kubernetes';
         const moniker = sourceMoniker || {
           app: app.name,
@@ -79,14 +81,18 @@ export class KubernetesManifestCommandBuilder {
         };
 
         return {
-          backingData,
-          cloudProvider,
-          manifest,
-          manifestText,
-          relationships,
-          moniker,
-          account,
-        } as IKubernetesManifestCommand;
+          command: {
+            cloudProvider,
+            manifest,
+            relationships,
+            moniker,
+            account,
+          },
+          metadata: {
+            backingData,
+            manifestText,
+          }
+        } as IKubernetesManifestCommandData;
       });
   }
 }

--- a/app/scripts/modules/kubernetes/src/v2/manifest/wizard/basicSettings.component.ts
+++ b/app/scripts/modules/kubernetes/src/v2/manifest/wizard/basicSettings.component.ts
@@ -1,13 +1,14 @@
 import { IComponentOptions, IController, module } from 'angular';
 
-import { IKubernetesManifestCommand } from '../manifestCommandBuilder.service';
+import { IKubernetesManifestCommand, IKubernetesManifestCommandMetadata } from '../manifestCommandBuilder.service';
 
 class KubernetesManifestBasicSettingsCtrl implements IController {
   public command: IKubernetesManifestCommand;
+  public metadata: IKubernetesManifestCommandMetadata;
 }
 
 class KubernetesManifestBasicSettingsComponent implements IComponentOptions {
-  public bindings: any = { command: '=' };
+  public bindings: any = { command: '=', metadata: '<' };
   public controller: any = KubernetesManifestBasicSettingsCtrl;
   public controllerAs = 'ctrl';
   public template = `
@@ -21,7 +22,7 @@ class KubernetesManifestBasicSettingsComponent implements IComponentOptions {
           <div class="col-md-7">
             <account-select-field component="ctrl.command"
                                   field="account"
-                                  accounts="ctrl.command.backingData.accounts"
+                                  accounts="ctrl.metadata.backingData.accounts"
                                   provider="'kubernetes'"></account-select-field>
           </div>
         </div>

--- a/app/scripts/modules/kubernetes/src/v2/manifest/wizard/manifestEntry.component.ts
+++ b/app/scripts/modules/kubernetes/src/v2/manifest/wizard/manifestEntry.component.ts
@@ -1,23 +1,24 @@
 import { IComponentOptions, IController, module } from 'angular';
 
-import { IKubernetesManifestCommand } from '../manifestCommandBuilder.service';
+import { IKubernetesManifestCommand, IKubernetesManifestCommandMetadata } from '../manifestCommandBuilder.service';
 
 import './manifestEntry.less'
 
 class KubernetesManifestCtrl implements IController {
   public command: IKubernetesManifestCommand;
+  public metadata: IKubernetesManifestCommandMetadata;
   public change: () => void;
 }
 
 class KubernetesManifestEntryComponent implements IComponentOptions {
-  public bindings: any = { command: '=', change: '&' };
+  public bindings: any = { command: '=', metadata: '=', change: '&' };
   public controller: any = KubernetesManifestCtrl;
   public controllerAs = 'ctrl';
   public template = `
     <div class="container-fluid form-horizontal">
       <ng-form name="manifest">
         <div class="form-group">
-          <textarea class="code form-control kubernetes-manifest-entry" ng-model="ctrl.command.manifestText" ng-change="ctrl.change()" rows="40"></textarea>
+          <textarea class="code form-control kubernetes-manifest-entry" ng-model="ctrl.metadata.manifestText" ng-change="ctrl.change()" rows="40"></textarea>
         </div>
       </ng-form>
     </div>

--- a/app/scripts/modules/kubernetes/src/v2/manifest/wizard/manifestWizard.controller.ts
+++ b/app/scripts/modules/kubernetes/src/v2/manifest/wizard/manifestWizard.controller.ts
@@ -11,7 +11,7 @@ import {
 } from '@spinnaker/core';
 
 import {
-  IKubernetesManifestCommand,
+  IKubernetesManifestCommand, IKubernetesManifestCommandMetadata,
   KUBERNETES_MANIFEST_COMMAND_BUILDER,
   KubernetesManifestCommandBuilder
 } from '../manifestCommandBuilder.service';
@@ -23,6 +23,7 @@ class KubernetesManifestWizardCtrl implements IController {
   };
   public taskMonitor: TaskMonitor;
   public command: IKubernetesManifestCommand;
+  public metadata: IKubernetesManifestCommandMetadata;
 
   constructor(private $uibModalInstance: IModalInstanceService,
               private application: Application,
@@ -32,7 +33,10 @@ class KubernetesManifestWizardCtrl implements IController {
     'ngInject';
     this.kubernetesManifestCommandBuilder.buildNewManifestCommand(application)
       .then((builtCommand) => {
-        this.command = builtCommand;
+        const { command, metadata } = builtCommand;
+        this.command = command;
+        this.metadata = metadata;
+
         this.initialize();
         this.state.loaded = true;
       });
@@ -43,7 +47,7 @@ class KubernetesManifestWizardCtrl implements IController {
   }
 
   public submit(): void {
-    const command = this.kubernetesManifestCommandBuilder.copyAndCleanCommand(this.command);
+    const command = this.kubernetesManifestCommandBuilder.copyAndCleanCommand(this.metadata, this.command);
     const submitMethod = () => this.manifestWriter.deployManifest(command, this.application);
     this.taskMonitor.submit(submitMethod);
   }

--- a/app/scripts/modules/kubernetes/src/v2/manifest/wizard/manifestWizard.html
+++ b/app/scripts/modules/kubernetes/src/v2/manifest/wizard/manifestWizard.html
@@ -8,10 +8,10 @@
                      task-monitor="ctrl.taskMonitor"
                      dismiss="$dismiss()">
       <v2-wizard-page key="basicSettings" label="Basic Settings" mark-complete-on-view="false">
-        <kubernetes-manifest-basic-settings command="ctrl.command"> </kubernetes-manifest-basic-settings>
+        <kubernetes-manifest-basic-settings command="ctrl.command" metadata="ctrl.metadata"> </kubernetes-manifest-basic-settings>
       </v2-wizard-page>
       <v2-wizard-page key="manifest" label="Manifest" mark-complete-on-view="false">
-        <kubernetes-manifest-entry command="ctrl.command"> </kubernetes-manifest-entry>
+        <kubernetes-manifest-entry command="ctrl.command" metadata="ctrl.metadata"> </kubernetes-manifest-entry>
       </v2-wizard-page>
     </v2-modal-wizard>
   </div>

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestConfig.controller.ts
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestConfig.controller.ts
@@ -2,32 +2,34 @@ import { IScope, IController } from 'angular';
 import { load } from 'js-yaml';
 
 import {
+  IKubernetesManifestCommandMetadata,
   KubernetesManifestCommandBuilder
 } from '../../../manifest/manifestCommandBuilder.service';
 
 export class KubernetesV2DeployManifestConfigCtrl implements IController {
-
   public state = {
     loaded: false,
   };
 
+  public metadata: IKubernetesManifestCommandMetadata;
+
   constructor(private $scope: IScope,
               private kubernetesManifestCommandBuilder: KubernetesManifestCommandBuilder) {
     'ngInject';
-    this.kubernetesManifestCommandBuilder.buildNewManifestCommand(this.$scope.application)
+    this.kubernetesManifestCommandBuilder.buildNewManifestCommand(this.$scope.application, this.$scope.stage.manifest, this.$scope.stage.moniker)
       .then((builtCommand) => {
-        this.$scope.stage.backingData = builtCommand.backingData;
         if (this.$scope.stage.isNew) {
-          Object.assign(this.$scope.stage, builtCommand);
+          Object.assign(this.$scope.stage, builtCommand.command);
         }
-        this.$scope.stage.manifest = load(this.$scope.stage.manifestText);
+
+        this.metadata = builtCommand.metadata;
         this.state.loaded = true;
       });
   }
 
   public change() {
     try {
-      this.$scope.stage.manifest = load(this.$scope.stage.manifestText);
+      this.$scope.stage.manifest = load(this.metadata.manifestText);
     } catch (e) {}
   }
 }

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestConfig.html
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestConfig.html
@@ -3,9 +3,9 @@
     <strong>Warning!</strong> This stage is under active development and is subject to change.
   </div>
   <v2-wizard-page key="basicSettings" label="Basic Settings" mark-complete-on-view="false">
-    <kubernetes-manifest-basic-settings command="ctrl.$scope.stage"> </kubernetes-manifest-basic-settings>
+    <kubernetes-manifest-basic-settings command="ctrl.$scope.stage" metadata="ctrl.metadata"> </kubernetes-manifest-basic-settings>
   </v2-wizard-page>
   <v2-wizard-page key="manifest" label="Manifest" mark-complete-on-view="false">
-    <kubernetes-manifest-entry command="ctrl.$scope.stage" change="ctrl.change()"> </kubernetes-manifest-entry>
+    <kubernetes-manifest-entry command="ctrl.$scope.stage" metadata="ctrl.metadata" change="ctrl.change()"> </kubernetes-manifest-entry>
   </v2-wizard-page>
 </div>

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestStage.ts
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestStage.ts
@@ -30,7 +30,7 @@ module(KUBERNETES_DEPLOY_MANIFEST_STAGE, [
       controllerAs: 'ctrl',
       validators: [
         { type: 'requiredField', fieldName: 'moniker.cluster', fieldLabel: 'Cluster' },
-        { type: 'requiredField', fieldName: 'manifestText', fieldLabel: 'Manifest' }
+        { type: 'requiredField', fieldName: 'manifest', fieldLabel: 'Manifest' }
       ],
     });
   }

--- a/app/scripts/modules/kubernetes/src/v2/serverGroup/serverGroupCommandBuilder.service.ts
+++ b/app/scripts/modules/kubernetes/src/v2/serverGroup/serverGroupCommandBuilder.service.ts
@@ -2,7 +2,7 @@ import { IPromise, module } from 'angular';
 
 import { Application } from '@spinnaker/core';
 import {
-  IKubernetesManifestCommand,
+  IKubernetesManifestCommandData,
   KUBERNETES_MANIFEST_COMMAND_BUILDER,
   KubernetesManifestCommandBuilder
 } from '../manifest/manifestCommandBuilder.service';
@@ -12,7 +12,7 @@ export class KubernetesV2ServerGroupCommandBuilder {
     'ngInject';
   }
 
-  public buildNewServerGroupCommand(app: Application): IPromise<IKubernetesManifestCommand> {
+  public buildNewServerGroupCommand(app: Application): IPromise<IKubernetesManifestCommandData> {
     return this.kubernetesManifestCommandBuilder.buildNewManifestCommand(app);
   }
 }


### PR DESCRIPTION
This way backingData & manifestText aren't stored in the pipeline definition. 

FYI @andrewbackes this might break any pipelines you've already created with this stage