### PR TITLE
feat(amazon): Support passing a capacity constraint during resize

### DIFF
--- a/app/scripts/modules/amazon/src/help/amazon.help.ts
+++ b/app/scripts/modules/amazon/src/help/amazon.help.ts
@@ -95,7 +95,11 @@ const helpContents: {[key: string]: string} = {
   'aws.targetGroup.attributes.deregistrationDelay': 'The amount of time for Elastic Load Balancing to wait before changing the state of a deregistering target from draining to unused. The range is 0-3600 seconds. The default value is 300 seconds.',
   'aws.targetGroup.attributes.stickinessEnabled': ' Indicates whether sticky sessions are enabled.',
   'aws.targetGroup.attributes.stickinessType': 'The type of sticky sessions. The only current possible value is <code>lb_cookie</code>.',
-  'aws.targetGroup.attributes.stickinessDuration': 'The time period, in seconds, during which requests from a client should be routed to the same target. After this time period expires, the load balancer-generated cookie is considered stale. The range is 1 second to 1 week (604800 seconds). The default value is 1 day (86400 seconds).'
+  'aws.targetGroup.attributes.stickinessDuration': 'The time period, in seconds, during which requests from a client should be routed to the same target. After this time period expires, the load balancer-generated cookie is considered stale. The range is 1 second to 1 week (604800 seconds). The default value is 1 day (86400 seconds).',
+  'aws.serverGroup.capacityConstraint': `
+      <p>Ensures that the capacity of this server group has not changed in the background (i.e. due to autoscaling activity).</p>
+      <p>If the capacity has changed, this resize operation will be rejected.</p>`,
+
 };
 
 export const AMAZON_HELP = 'spinnaker.amazon.help.contents';

--- a/app/scripts/modules/amazon/src/serverGroup/details/resize/resizeServerGroup.controller.js
+++ b/app/scripts/modules/amazon/src/serverGroup/details/resize/resizeServerGroup.controller.js
@@ -26,6 +26,13 @@ module.exports = angular.module('spinnaker.amazon.serverGroup.details.resize.con
 
     $scope.command = angular.copy($scope.currentSize);
     $scope.command.advancedMode = serverGroup.asg.minSize !== serverGroup.asg.maxSize;
+    $scope.command.constraints = {
+      capacity: {
+        min: serverGroup.asg.minSize,
+        max: serverGroup.asg.maxSize,
+        desired: serverGroup.asg.desiredCapacity
+      }
+    };
 
     if (application && application.attributes) {
       if (application.attributes.platformHealthOnlyShowOverride && application.attributes.platformHealthOnly) {
@@ -34,6 +41,20 @@ module.exports = angular.module('spinnaker.amazon.serverGroup.details.resize.con
 
       $scope.command.platformHealthOnlyShowOverride = application.attributes.platformHealthOnlyShowOverride;
     }
+
+    this.toggleCapacityConstraint = function () {
+      if ($scope.command.constraints.capacity) {
+        $scope.command.constraints = {};
+      } else {
+        $scope.command.constraints = {
+          capacity: {
+            min: serverGroup.asg.minSize,
+            max: serverGroup.asg.maxSize,
+            desired: serverGroup.asg.desiredCapacity
+          }
+        };
+      }
+    };
 
     this.isValid = function () {
       var command = $scope.command;
@@ -63,6 +84,7 @@ module.exports = angular.module('spinnaker.amazon.serverGroup.details.resize.con
       var submitMethod = function() {
         return serverGroupWriter.resizeServerGroup(serverGroup, application, {
           capacity: capacity,
+          constraints: $scope.command.constraints,
           interestingHealthProviderNames: $scope.command.interestingHealthProviderNames,
           reason: $scope.command.reason,
         });

--- a/app/scripts/modules/amazon/src/serverGroup/details/resize/resizeServerGroup.html
+++ b/app/scripts/modules/amazon/src/serverGroup/details/resize/resizeServerGroup.html
@@ -9,16 +9,26 @@
       <div class="form-horizontal">
         <aws-resize-capacity command="command" current-size="currentSize"></aws-resize-capacity>
       </div>
-      <div class="row" ng-if="command.platformHealthOnlyShowOverride">
+      <div class="row">
         <div class="col-sm-10 col-sm-offset-1">
-          <platform-health-override command="command"
-                                    platform-health-type="'Amazon'"
-                                    show-help-details="true">
-          </platform-health-override>
+          <div class="checkbox">
+            <label>
+              <input type="checkbox"
+                     ng-checked="command.constraints.capacity"
+                     ng-click="ctrl.toggleCapacityConstraint()"/>
+              Enforce Capacity Constraint
+            </label>
+            <help-field key="aws.serverGroup.capacityConstraint"></help-field>
+          </div>
+          <div ng-if="command.platformHealthOnlyShowOverride">
+            <platform-health-override command="command"
+                                      platform-health-type="'Amazon'"
+                                      show-help-details="true">
+            </platform-health-override>
+          </div>
         </div>
       </div>
       <task-reason command="command"></task-reason>
-
     </div>
     <aws-footer action="ctrl.resize()"
                 cancel="ctrl.cancel()"


### PR DESCRIPTION
`clouddriver` can enforce that capacity of the server group being
resized has not changed in the background.

This addresses situations where autoscaling has occurred in the
background and subsequently been "undone" by a concurrent resize operation.

![image](https://user-images.githubusercontent.com/388652/33403229-5b85cc16-d514-11e7-8d7d-1f1c1ced21c5.png)

![image](https://user-images.githubusercontent.com/388652/33403248-75dcdf50-d514-11e7-9531-3f8a62806286.png)
