### PR TITLE
fix(provider/k8sv2): Move delete manifest form into component

### DIFF
--- a/app/scripts/modules/kubernetes/src/v2/manifest/delete/delete.controller.ts
+++ b/app/scripts/modules/kubernetes/src/v2/manifest/delete/delete.controller.ts
@@ -10,8 +10,9 @@ import {
   TaskMonitorBuilder
 } from '@spinnaker/core';
 import { IManifestCoordinates } from '../IManifestCoordinates';
+import { KUBERNETES_DELETE_MANIFEST_OPTIONS_FORM } from './deleteOptionsForm.component';
 
-interface IDeleteCommand {
+export interface IDeleteCommand {
   name: string;
   location: string;
   account: string;
@@ -19,7 +20,7 @@ interface IDeleteCommand {
   options: IDeleteOptions;
 }
 
-interface IDeleteOptions {
+export interface IDeleteOptions {
   gracePeriodSeconds?: number;
   cascading: boolean;
 }
@@ -81,5 +82,6 @@ export const KUBERNETES_MANIFEST_DELETE_CTRL = 'spinnaker.kubernetes.v2.manifest
 module(KUBERNETES_MANIFEST_DELETE_CTRL, [
   TASK_MONITOR_BUILDER,
   MANIFEST_WRITER,
+  KUBERNETES_DELETE_MANIFEST_OPTIONS_FORM,
 ])
   .controller('kubernetesV2ManifestDeleteCtrl', KubernetesManifestDeleteController);

--- a/app/scripts/modules/kubernetes/src/v2/manifest/delete/delete.html
+++ b/app/scripts/modules/kubernetes/src/v2/manifest/delete/delete.html
@@ -6,35 +6,7 @@
       <h3>Delete {{ctrl.command.name | robotToHuman}} in {{ctrl.command.location}}</h3>
     </div>
     <div class="modal-body confirmation-modal">
-      <div class="form-horizontal">
-        <div class="form-group form-inline">
-          <div class="col-md-3 sm-label-right">
-            Cascading
-            <help-field key="kubernetes.manifest.delete.cascading"></help-field>
-          </div>
-          <div class="col-md-3">
-            <div class="input-group">
-              <input type="checkbox"
-                     ng-model="ctrl.command.options.cascading"/>
-            </div>
-          </div>
-        </div>
-        <div class="form-group form-inline">
-          <div class="col-md-3 sm-label-right">
-            Grace Period
-            <help-field key="kubernetes.manifest.delete.gracePeriod"></help-field>
-          </div>
-          <div class="col-md-4">
-            <div class="input-group">
-              <input type="number"
-                     class="form-control input-sm highlight-pristine"
-                     ng-model="ctrl.command.options.gracePeriodSeconds"
-                     min="0"/>
-              <span class="input-group-addon">second<span ng-if="ctrl.command.options.gracePeriodSeconds !== 1">s</span></span>
-            </div>
-          </div>
-        </div>
-      </div>
+      <kubernetes-delete-manifest-options-form options="ctrl.command.options"></kubernetes-delete-manifest-options-form>
       <task-reason command="ctrl.command"></task-reason>
     </div>
     <div class="modal-footer">

--- a/app/scripts/modules/kubernetes/src/v2/manifest/delete/deleteOptionsForm.component.ts
+++ b/app/scripts/modules/kubernetes/src/v2/manifest/delete/deleteOptionsForm.component.ts
@@ -1,0 +1,49 @@
+import { IComponentOptions, IController, module } from 'angular';
+
+import { IDeleteOptions } from './delete.controller';
+
+class KubernetesDeleteManifestOptionsFormCtrl implements IController {
+  public options: IDeleteOptions;
+}
+
+class KubernetesDeletManifestOptionsFormComponent implements IComponentOptions {
+  public bindings: any = { options: '=' };
+  public controller: any = KubernetesDeleteManifestOptionsFormCtrl;
+  public controllerAs = 'ctrl';
+
+  public template = `
+    <div class="form-horizontal">
+      <div class="form-group form-inline">
+        <div class="col-md-3 sm-label-right">
+          Cascading
+          <help-field key="kubernetes.manifest.delete.cascading"></help-field>
+        </div>
+        <div class="col-md-3">
+          <div class="input-group">
+            <input type="checkbox"
+                  ng-model="ctrl.options.cascading"/>
+          </div>
+        </div>
+      </div>
+      <div class="form-group form-inline">
+        <div class="col-md-3 sm-label-right">
+          Grace Period
+          <help-field key="kubernetes.manifest.delete.gracePeriod"></help-field>
+        </div>
+        <div class="col-md-4">
+          <div class="input-group">
+            <input type="number"
+                  class="form-control input-sm highlight-pristine"
+                  ng-model="ctrl.options.gracePeriodSeconds"
+                  min="0"/>
+            <span class="input-group-addon">second<span ng-if="ctrl.options.gracePeriodSeconds !== 1">s</span></span>
+          </div>
+        </div>
+      </div>
+    </div>
+  `;
+}
+
+export const KUBERNETES_DELETE_MANIFEST_OPTIONS_FORM = 'spinnaker.kubernetes.v2.kubernetes.manifest.delete.options.component';
+module(KUBERNETES_DELETE_MANIFEST_OPTIONS_FORM, [])
+  .component('kubernetesDeleteManifestOptionsForm', new KubernetesDeletManifestOptionsFormComponent());


### PR DESCRIPTION
Moving this form into it's own component will allow it to be re-used in the 'Delete Manifest' pipeline stage.