### PR TITLE
fix(core/pipelines): rerender view when first stage is removed

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/pipelineConfigurer.js
+++ b/app/scripts/modules/core/src/pipeline/config/pipelineConfigurer.js
@@ -317,6 +317,9 @@ module.exports = angular.module('spinnaker.core.pipeline.config.pipelineConfigur
       if (stageIndex > 0) {
         this.setViewState({ stageIndex: $scope.viewState.stageIndex - 1 });
       }
+      if (stageIndex === $scope.viewState.stageIndex && stageIndex === 0) {
+        $scope.$broadcast('pipeline-json-edited');
+      }
       if (!$scope.renderablePipeline.stages.length) {
         this.navigateTo({section: 'triggers'});
       }


### PR DESCRIPTION
We typically change the `stageIndex` value, which triggers a re-render on the stage details when editing a pipeline and deleting a stage. 

If you delete the first stage, however, the details stick around, because we don't update the index. This just calls a broadcast so we do update the details.