### PR TITLE
chore(amazon): bump package to 0.0.55

### DIFF
--- a/app/scripts/modules/amazon/package.json
+++ b/app/scripts/modules/amazon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/amazon",
-  "version": "0.0.54",
+  "version": "0.0.55",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
* fix(amazon): omit spinnaker metadata tags when cloning server groups