### PR TITLE
feat(provider/kubernetes): Configurable apiPrefix for K8s

### DIFF
--- a/app/scripts/modules/kubernetes/src/kubernetes.settings.ts
+++ b/app/scripts/modules/kubernetes/src/kubernetes.settings.ts
@@ -8,6 +8,7 @@ export interface IKubernetesProviderSettings extends IProviderSettings {
     internalDNSNameTemplate?: string;
     instanceLinkTemplate?: string;
     rrb?: boolean
+    apiPrefix?: string;
   };
 }
 

--- a/app/scripts/modules/kubernetes/src/proxy/ui.service.js
+++ b/app/scripts/modules/kubernetes/src/proxy/ui.service.js
@@ -6,8 +6,6 @@ import {KubernetesProviderSettings} from '../kubernetes.settings';
 
 module.exports = angular.module('spinnaker.proxy.kubernetes.ui.service', [])
   .factory('kubernetesProxyUiService', function($interpolate) {
-    let apiPrefix = 'api/v1/proxy/namespaces/kube-system/services/kubernetes-dashboard/#';
-
     function getHost(accountName) {
       let host = KubernetesProviderSettings.defaults.proxy;
       let account = KubernetesProviderSettings[accountName];
@@ -20,6 +18,11 @@ module.exports = angular.module('spinnaker.proxy.kubernetes.ui.service', [])
     }
 
     function buildLink(accountName, kind, namespace, serverGroupName) {
+      let apiPrefix = KubernetesProviderSettings.defaults.apiPrefix;
+      if ((apiPrefix == null) || (apiPrefix === "")) {
+        apiPrefix = 'api/v1/proxy/namespaces/kube-system/services/kubernetes-dashboard/#';
+      }
+  
       let host = getHost(accountName);
       if (!host.startsWith('http://') && !host.startsWith('https://')) {
         host = 'http://' + host;

--- a/settings.js
+++ b/settings.js
@@ -90,6 +90,7 @@ window.spinnakerSettings = {
         proxy: 'localhost:8001',
         internalDNSNameTemplate: '{{name}}.{{namespace}}.svc.cluster.local',
         instanceLinkTemplate: '{{host}}/api/v1/proxy/namespaces/{{namespace}}/pods/{{name}}',
+        apiPrefix: 'api/v1/proxy/namespaces/kube-system/services/kubernetes-dashboard/#',
       },
     },
     dcos: {


### PR DESCRIPTION
Not all Kubernetes systems have the same apiPrefix, so let it be configurable
like the instanceLinkTemplate.  Defaults to existing hard-coded apiPrefix value for backwards compatibility.
