### PR TITLE
feat(provider/kubernetes): support envFrom

### DIFF
--- a/app/scripts/modules/kubernetes/src/container/configurer.directive.html
+++ b/app/scripts/modules/kubernetes/src/container/configurer.directive.html
@@ -103,6 +103,13 @@
       <kubernetes-container-environment-variables env-vars="container.envVars">
       </kubernetes-container-environment-variables>
     </div>
+    <div class="form-group">
+      <div class="sm-label-left">
+        <b>Environment From</b>
+      </div>
+      <kubernetes-container-environment-from env-from="container.envFrom">
+      </kubernetes-container-environment-from>
+    </div>
   </collapsible-section>
 
   <collapsible-section heading="Resources" expanded="false" subsection="true">

--- a/app/scripts/modules/kubernetes/src/container/configurer.directive.js
+++ b/app/scripts/modules/kubernetes/src/container/configurer.directive.js
@@ -2,10 +2,12 @@
 
 const angular = require('angular');
 
-import {KUBERNETES_LIFECYCLE_HOOK_CONFIGURER} from './lifecycleHook.component';
+import { KUBERNETES_LIFECYCLE_HOOK_CONFIGURER } from './lifecycleHook.component';
+import { KUBERNETES_CONTAINER_ENVIRONMENT_FROM } from './environmentFrom.component';
 
 module.exports = angular.module('spinnaker.kubernetes.container.configurer.directive', [
   KUBERNETES_LIFECYCLE_HOOK_CONFIGURER,
+  KUBERNETES_CONTAINER_ENVIRONMENT_FROM,
 ]).directive('kubernetesContainerConfigurer', function () {
     return {
       restrict: 'E',

--- a/app/scripts/modules/kubernetes/src/container/environmentFrom.component.html
+++ b/app/scripts/modules/kubernetes/src/container/environmentFrom.component.html
@@ -1,0 +1,78 @@
+<table class="table table-condensed" style="border-top: 2px solid white; margin-bottom: 0px;">
+  <tbody>
+  <tr ng-repeat="envFrom in $ctrl.envFrom">
+    <td>
+      <div class="form-group">
+        <div class="col-md-3 sm-label-right">
+          Prefix
+        </div>
+        <div class="col-md-3">
+          <input class="form-control input input-sm" type="text" ng-model="envFrom.prefix">
+        </div>
+        <div class="col-md-2 col-md-offset-1">
+          <button class="btn btn-sm btn-default" ng-click="$ctrl.removeEnvFrom($index)">
+            <span class="glyphicon glyphicon-trash visible-lg-inline"></span>
+            <span>Remove</span>
+          </button>
+        </div>
+      </div>
+      <div class="form-group">
+        <div class="col-md-3 sm-label-right">
+          Source
+        </div>
+        <div class="col-md-3">
+          <select class="form-control input-sm"
+                  ng-model="$ctrl.envFromSourceTypes[$index]"
+                  ng-change="$ctrl.updateEnvFrom($index)"
+                  ng-options="sourceType for sourceType in $ctrl.sourceTypes"></select>
+        </div>
+      </div>
+      <div ng-switch on="$ctrl.envFromSourceTypes[$index]">
+        <div class="form-group" ng-switch-when="Config Map">
+          <div class="col-md-3 sm-label-right">
+            Map Name
+          </div>
+          <div class="col-md-3">
+            <input class="form-control input input-sm"
+                   type="text"
+                   ng-model="envFrom.configMapRef.name">
+          </div>
+          <div class="col-md-1 sm-label-right">
+            Optional
+          </div>
+          <div class="col-md-3">
+            <input type="checkbox"
+                   style="margin-top: 10px; margin-left: 8px;"
+                   ng-model="envFrom.configMapRef.optional"/>
+          </div>
+        </div>
+        <div class="form-group" ng-switch-when="Secret">
+          <div class="col-md-3 sm-label-right">
+            Secret Name
+          </div>
+          <div class="col-md-3">
+            <input class="form-control input input-sm"
+                   type="text"
+                   ng-model="envFrom.secretRef.name">
+          </div>
+          <div class="col-md-1 sm-label-right">
+            Optional
+          </div>
+          <div class="col-md-3">
+            <input type="checkbox"
+                   style="margin-top: 10px; margin-left: 8px;"
+                   ng-model="envFrom.secretRef.optional"/>
+          </div>
+        </div>
+      </div>
+    </td>
+  </tr>
+  <tr>
+    <td colspan="3">
+      <button class="add-new btn btn-block btn-sm" ng-click="$ctrl.addEnvFrom()" style="margin-bottom: 0px;"><span
+        class="glyphicon glyphicon-plus-sign"></span> Add Environment From
+      </button>
+    </td>
+  </tr>
+  </tbody>
+</table>

--- a/app/scripts/modules/kubernetes/src/container/environmentFrom.component.ts
+++ b/app/scripts/modules/kubernetes/src/container/environmentFrom.component.ts
@@ -1,0 +1,81 @@
+import { IComponentOptions, IController, module } from 'angular';
+
+interface IKubernetesEnvironmentFrom {
+  prefix: string;
+  configMapRef?: IKubernetesConfigMapRef;
+  secretRef?: IKubernetesSecretRef;
+}
+
+interface IKubernetesConfigMapRef {
+  name: string;
+  optional: boolean;
+}
+
+interface IKubernetesSecretRef {
+  name: string;
+  optional: boolean;
+}
+
+const CONFIGMAP_TYPE = 'Config Map';
+const SECRET_TYPE = 'Secret';
+const DEFAULT_ENVFROM_TYPE = CONFIGMAP_TYPE;
+
+class KubernetesEnvironmentFromCtrl implements IController {
+  public envFrom: IKubernetesEnvironmentFrom[];
+  public envFromSourceTypes: string[];
+  public sourceTypes: string[] = [CONFIGMAP_TYPE, SECRET_TYPE];
+
+  public $onInit(): void {
+    if (!this.envFrom ) {
+      this.envFrom = [];
+    }
+    this.mapEnvFromSourceTypes();
+  }
+
+  public mapEnvFromSourceTypes(): void {
+    this.envFromSourceTypes = this.envFrom
+      .map((envFrom) => {
+        if (envFrom.configMapRef) {
+          return CONFIGMAP_TYPE;
+        } else {
+          return SECRET_TYPE;
+        }
+      });
+  }
+
+  public removeEnvFrom(index: number): void {
+    this.envFrom.splice(index, 1);
+    this.envFromSourceTypes.splice(index, 1);
+  }
+
+  public addEnvFrom(): void {
+    this.envFrom.push({ prefix: '' });
+    this.envFromSourceTypes.push(DEFAULT_ENVFROM_TYPE);
+  }
+
+  public updateEnvFrom(index: number): void {
+    const envFrom = this.envFrom[index];
+    const sourceType = this.envFromSourceTypes[index];
+    switch (sourceType) {
+      case CONFIGMAP_TYPE:
+        delete envFrom.secretRef;
+        break;
+      case SECRET_TYPE:
+        delete envFrom.configMapRef;
+        break;
+    }
+  }
+}
+
+class KubernetesContainerEnvironmentFrom implements IComponentOptions {
+  public bindings: any = {
+    envFrom: '<'
+  };
+  public templateUrl = require('./environmentFrom.component.html');
+  public controller: any = KubernetesEnvironmentFromCtrl;
+}
+
+export const KUBERNETES_CONTAINER_ENVIRONMENT_FROM = 'spinnaker.kubernetes.container.environmentFrom.component';
+module(KUBERNETES_CONTAINER_ENVIRONMENT_FROM, [])
+  .component('kubernetesContainerEnvironmentFrom', new KubernetesContainerEnvironmentFrom());
+

--- a/app/scripts/modules/kubernetes/src/pipeline/stages/runJob/configureJob.controller.js
+++ b/app/scripts/modules/kubernetes/src/pipeline/stages/runJob/configureJob.controller.js
@@ -2,6 +2,7 @@
 
 const angular = require('angular');
 import { KUBERNETES_LIFECYCLE_HOOK_CONFIGURER } from 'kubernetes/container/lifecycleHook.component';
+import { KUBERNETES_CONTAINER_ENVIRONMENT_FROM } from 'kubernetes/container/environmentFrom.component';
 
 module.exports = angular.module('spinnaker.kubernetes.pipeline.stage.runJobStage.configure', [
   require('kubernetes/container/commands.component.js').name,
@@ -11,7 +12,8 @@ module.exports = angular.module('spinnaker.kubernetes.pipeline.stage.runJobStage
   require('kubernetes/container/ports.component.js').name,
   require('kubernetes/container/resources.component.js').name,
   require('kubernetes/container/probe.directive.js').name,
-  KUBERNETES_LIFECYCLE_HOOK_CONFIGURER
+  KUBERNETES_LIFECYCLE_HOOK_CONFIGURER,
+  KUBERNETES_CONTAINER_ENVIRONMENT_FROM,
 ])
   .controller('kubernetesConfigureJobController', function($scope, $uibModalInstance, accountService, kubernetesImageReader, pipelineConfigService, $filter,
                                                            stage, pipeline) {
@@ -114,6 +116,7 @@ module.exports = angular.module('spinnaker.kubernetes.pipeline.stage.runJobStage
             livenessProbe: null,
             readinessProbe: null,
             envVars: [],
+            envFrom: [],
             command: [],
             args: [],
             volumeMounts: [],

--- a/app/scripts/modules/kubernetes/src/pipeline/stages/runJob/configureJob.html
+++ b/app/scripts/modules/kubernetes/src/pipeline/stages/runJob/configureJob.html
@@ -100,6 +100,12 @@
           </div>
           <kubernetes-container-environment-variables env-vars="container.envVars">
           </kubernetes-container-environment-variables>
+
+          <div class="sm-label-left">
+            <b>Environment From</b>
+          </div>
+          <kubernetes-container-environment-from env-from="container.envFrom">
+          </kubernetes-container-environment-from>
         </collapsible-section>
 
         <collapsible-section heading="Volumes" expanded="false" subsection="true">

--- a/app/scripts/modules/kubernetes/src/serverGroup/configure/configuration.service.js
+++ b/app/scripts/modules/kubernetes/src/serverGroup/configure/configuration.service.js
@@ -117,6 +117,7 @@ module.exports = angular.module('spinnaker.serverGroup.configure.kubernetes.conf
           livenessProbe: null,
           readinessProbe: null,
           envVars: [],
+          envFrom: [],
           command: [],
           args: [],
           volumeMounts: [],


### PR DESCRIPTION
add support for envFrom pod option. this option allows users to specify
a config map of secret to use for environment variables.

![image](https://user-images.githubusercontent.com/3324110/33738747-f4730a0a-db5f-11e7-91a2-8de3266443be.png)

@danielpeach PTAL!

spinnaker/spinnaker#2120