### PR TITLE
fix(core/executions): do not auto-refresh manual judgment stages

### DIFF
--- a/app/scripts/modules/core/src/application/nav/applicationNav.component.less
+++ b/app/scripts/modules/core/src/application/nav/applicationNav.component.less
@@ -41,7 +41,7 @@ application-nav, application-nav-secondary, .application-nav {
         border-bottom: 12px solid var(--color-alabaster);
         position: absolute;
         left: calc(~"50% - 12px");
-        bottom: -2px;
+        bottom: -3px;
       }
     }
   }

--- a/app/scripts/modules/core/src/pipeline/config/stages/manualJudgment/ManualJudgmentApproval.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/manualJudgment/ManualJudgmentApproval.tsx
@@ -46,7 +46,7 @@ export class ManualJudgmentApproval extends React.Component<IManualJudgmentAppro
   private judgmentMade(): void {
     // do not update the submitting state - the reload of the executions will clear it out; otherwise,
     // there is a flash on the screen when we go from submitting to not submitting to the buttons not being there.
-    this.props.application.getDataSource('executions').refresh();
+    this.props.application.activeState.refresh(true);
     this.setState({ submitting: false });
   }
 


### PR DESCRIPTION
If a pipeline is just waiting for a manual judgment to be made, there's no sense refreshing it every second.

Also making some clearly unrelated changes that can't be justified in the same PR