### PR TITLE
feat(core/pipeline): Expose "Override stage timeout" UI for Pipeline Stage

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/pipeline/pipelineStage.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/pipeline/pipelineStage.js
@@ -18,6 +18,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.pipelineStage', [
       controllerAs: 'pipelineStageCtrl',
       templateUrl: require('./pipelineStage.html'),
       executionDetailsUrl: require('./pipelineExecutionDetails.html'),
+      defaultTimeoutMs: 12 * 60 * 60 * 1000, // 12 hours
       validators: [
         { type: 'requiredField', fieldName: 'pipeline', },
       ],


### PR DESCRIPTION
The UI for overriding stage timeouts was not enabled for the Pipeline Stage.  Some pipelines may take longer than 12 hrs to run, so users should be allowed to choose the timeout.

![screen shot 2017-12-08 at 6 52 40 pm](https://user-images.githubusercontent.com/2053478/33791930-1e71d3f6-dc49-11e7-8455-da1ffcda0b8f.png)
