### PR TITLE
fix(docker): disable manual execution until tag selected

### DIFF
--- a/app/scripts/modules/docker/src/pipeline/trigger/dockerTriggerOptions.directive.html
+++ b/app/scripts/modules/docker/src/pipeline/trigger/dockerTriggerOptions.directive.html
@@ -5,6 +5,8 @@
       <span class="fa fa-cog fa-spin"></span>
     </p>
   </div>
+  <!-- prevent form submission while tags are loading -->
+  <input type="hidden" ng-required="vm.viewState.tagsLoading" ng-model="vm.viewState.selectedTag" />
   <div class="col-md-6" ng-if="vm.viewState.loadError">Error loading tags!</div>
   <div class="col-md-6" ng-if="!vm.viewState.tagsLoading">
     <div ng-if="!vm.tags.length"><p class="form-control-static">No tags found</p></div>

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -133,6 +133,7 @@ function configure(IS_TEST) {
     devServer: IS_TEST ? {
       stats: 'errors-only',
     } : {
+      disableHostCheck: true,
       port: process.env.DECK_PORT || 9000,
       host: process.env.DECK_HOST || 'localhost',
       https: process.env.DECK_HTTPS === 'true',


### PR DESCRIPTION
We've had a few users click the "Run" button before the tags have loaded, which starts the pipeline without any tag.