### PR TITLE
fix(provider/kubernetes): initContianers exiting

### DIFF
--- a/app/scripts/modules/kubernetes/src/serverGroup/configure/configuration.service.js
+++ b/app/scripts/modules/kubernetes/src/serverGroup/configure/configuration.service.js
@@ -14,7 +14,6 @@ module.exports = angular.module('spinnaker.serverGroup.configure.kubernetes.conf
   .factory('kubernetesServerGroupConfigurationService', function($q, accountService, kubernetesImageReader,
                                                                  loadBalancerReader, cacheInitializer) {
     function configureCommand(application, command, query = '') {
-
       // this ensures we get the images we need when cloning or copying a server group template.
       const containers = command.containers.concat(command.initContainers || []);
       let queries = containers
@@ -189,7 +188,7 @@ module.exports = angular.module('spinnaker.serverGroup.configure.kubernetes.conf
         result.dirty.containers = invalidContainers;
       }
 
-      const [ validInitContainers, invalidInitContainers ] = getValidContainers(command, command.initContainers);
+      const [ validInitContainers, invalidInitContainers ] = getValidContainers(command, command.initContainers || []);
       command.initContainers = validInitContainers;
       if (invalidInitContainers.length > 0) {
         result.dirty.initContainers = invalidInitContainers;

--- a/app/scripts/modules/kubernetes/src/serverGroup/configure/wizard/basicSettings.html
+++ b/app/scripts/modules/kubernetes/src/serverGroup/configure/wizard/basicSettings.html
@@ -78,7 +78,7 @@
     <help-field key="kubernetes.serverGroup.initContainers"></help-field>
     </div>
     <div class="col-md-9">
-      <ui-select multiple name="initContainerSelect" ng-model="command.initContainers" class="form-control input-sm" required>
+      <ui-select multiple name="initContainerSelect" ng-model="command.initContainers" class="form-control input-sm">
         <ui-select-match>{{$item.imageDescription.imageId}}</ui-select-match>
         <ui-select-choices
           repeat="container in command.backingData.filtered.containers | orderBy:'imageDescription.imageId'"


### PR DESCRIPTION
fix an issue where i was calling forEach on an undefined property. if
the property doesn't exist, it will just pass an empty set. also,
iniContainers are not required.

ping @danielpeach 

fyi @andrewbackes @kevinawoo 
