### PR TITLE
feat(travis): set custom parameters using the UI

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/travis/modal/addParameter.controller.modal.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/travis/modal/addParameter.controller.modal.ts
@@ -1,0 +1,16 @@
+import { IController, module } from 'angular';
+import { IModalInstanceService } from 'angular-ui-bootstrap';
+
+export class TravisStageAddParameter implements IController {
+  constructor (private $scope: ng.IScope, private $uibModalInstance: IModalInstanceService) { 'ngInject'; }
+
+  public submit(): void {
+    this.$uibModalInstance.close(this.$scope.parameter);
+  }
+}
+
+export const TRAVIS_STAGE_ADD_PARAMETER_MODAL_CONTROLLER = 'spinnaker.core.pipeline.stage.travis.modal.addParameter';
+
+module(TRAVIS_STAGE_ADD_PARAMETER_MODAL_CONTROLLER,
+       [],
+).controller('TravisStageAddParameterCtrl', TravisStageAddParameter);

--- a/app/scripts/modules/core/src/pipeline/config/stages/travis/modal/addParameter.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/travis/modal/addParameter.html
@@ -1,0 +1,44 @@
+<div modal-page>
+  <modal-close dismiss="$dismiss()"></modal-close>
+  <div class="modal-header">
+    <h3 data-purpose="modal-header">Add Parameter</h3>
+  </div>
+
+  <form role="form" class="container-fluid" novalidate name="addParameterForm">
+    <div class="modal-body">
+      <div class="form-group row">
+        <div class="col-sm-3 sm-label-right">Key</div>
+        <div class="col-sm-9">
+          <input type="text"
+                 class="form-control input-sm"
+                 ng-model="parameter.key"
+                 placeholder="enter a parameter key"
+                 required>
+          </input>
+        </div>
+      </div>
+      <div class="form-group row">
+        <div class="col-sm-3 sm-label-right">Value</div>
+        <div class="col-sm-9">
+          <input type="text"
+                 class="form-control input-sm"
+                 ng-model="parameter.value"
+                 placeholder="enter a parameter value"
+                 required>
+          </input>
+        </div>
+      </div>
+    </div>
+
+    <div class="modal-footer">
+      <a href class="btn btn-default" ng-click="$dismiss()">Cancel</a>
+      <button type="submit"
+              class="btn btn-primary"
+              data-purpose="submit"
+              ng-click="ctrl.submit()"
+              ng-disabled="addParameterForm.$invalid">
+        <span class="fa fa-check-circle-o"></span> Add
+      </button>
+    </div>
+  </form>
+</div>

--- a/app/scripts/modules/core/src/pipeline/config/stages/travis/travisStage.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/travis/travisStage.html
@@ -57,28 +57,44 @@
   <stage-config-field label="Property File" help-key="pipeline.config.travis.propertyFile">
     <input type="text" class="form-control input-sm" ng-model="$ctrl.stage.propertyFile"/>
   </stage-config-field>
-  <div class="well well-sm clearfix ng-scope col-md-offset-1 col-md-10" ng-if="$ctrl.jobParams.length">
-    <h4 class="text-left">Job Parameters</h4>
-    <div class="form-group" ng-repeat="parameter in $ctrl.jobParams | orderBy:'name' ">
-      <div class="col-md-3 sm-label-right">
-        <b class="break-word">{{parameter.name}}</b>
-        <help-field content="{{parameter.description}}" ng-if="parameter.description"></help-field>
-      </div>
-      <div class="col-md-5">
-        <input disabled ng-if="$ctrl.useDefaultParameters[parameter.name]" type="text"
-               class="form-control input-sm" value="{{parameter.defaultValue}}"/>
-        <input ng-if="!$ctrl.useDefaultParameters[parameter.name]" type="text" class="form-control input-sm"
-               ng-model="$ctrl.userSuppliedParameters[parameter.name]"
-               ng-change="$ctrl.updateParam(parameter.name)"/>
-      </div>
-      <div class="checkbox col-md-4" ng-if="parameter.defaultValue!==null">
-        <label>
-          <input type="checkbox" ng-model="$ctrl.useDefaultParameters[parameter.name]"
-                 ng-change="$ctrl.updateParam(parameter.name)">Use default
-        </label>
+
+
+  <stage-config-field label="Parameters" help-key="pipeline.config.travis.parameters">
+    <table class="table table-condensed packed" ng-if="$ctrl.stage.parameters">
+      <thead>
+        <tr>
+          <th style="width:40%">Key</th>
+          <th style="width:60%">Value</th>
+          <th class="text-right">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr ng-repeat="(key, value) in $ctrl.stage.parameters">
+          <td>
+            <strong class="small">{{key}}</strong>
+          </td>
+          <td>
+            <input type="text" required ng-model="$ctrl.stage.parameters[key]"
+                   class="form-control input-sm"/>
+          </td>
+          <td class="text-center">
+            <a href ng-click="$ctrl.removeParameter(key)">
+              <span class="glyphicon glyphicon-trash"></span>
+              <span class="sr-only">Remove</span>
+            </a>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <div class="row">
+      <div class="col-md-12">
+        <button class="btn btn-block btn-sm add-new" ng-click="$ctrl.addParameter()">
+          <span class="glyphicon glyphicon-plus-sign"></span> Add Parameter
+        </button>
       </div>
     </div>
-  </div>
+  </stage-config-field>
+
   <stage-config-field label="Wait for results" help-key="travis.waitForCompletion">
     <input type="checkbox" class="input-sm" name="waitForCompletion"
            ng-model="$ctrl.viewState.waitForCompletion"

--- a/app/scripts/modules/core/src/pipeline/config/stages/travis/travisStage.module.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/travis/travisStage.module.ts
@@ -5,6 +5,7 @@ import { IGOR_SERVICE } from 'core/ci/igor.service';
 import { STAGE_CORE_MODULE } from '../core/stage.core.module';
 import { TIME_FORMATTERS } from 'core/utils/timeFormatters';
 import { TRAVIS_EXECUTION_DETAILS_CONTROLLER } from './travisExecutionDetails.controller';
+import { TRAVIS_STAGE_ADD_PARAMETER_MODAL_CONTROLLER  } from './modal/addParameter.controller.modal';
 
 export const TRAVIS_STAGE_MODULE = 'spinnaker.core.pipeline.stage.travis';
 module(TRAVIS_STAGE_MODULE, [
@@ -14,4 +15,5 @@ module(TRAVIS_STAGE_MODULE, [
   TIME_FORMATTERS,
   IGOR_SERVICE,
   TRAVIS_EXECUTION_DETAILS_CONTROLLER,
+  TRAVIS_STAGE_ADD_PARAMETER_MODAL_CONTROLLER,
 ]);


### PR DESCRIPTION
Also, we remove the visualization of parameters already defined in the `.travis.yml` because they are always taken into account, if some user-defined parameter overrides some parameter the former will be used.

This is how it looks:

![image](https://user-images.githubusercontent.com/4490611/34164482-f390471e-e4d9-11e7-96e8-83adaa2874f0.png)
