### PR TITLE
fix(provider/openstack): Region Selector shows correct region

### DIFF
--- a/app/scripts/modules/openstack/src/serverGroup/configure/wizard/location/ServerGroupBasicSettings.controller.js
+++ b/app/scripts/modules/openstack/src/serverGroup/configure/wizard/location/ServerGroupBasicSettings.controller.js
@@ -25,6 +25,10 @@ module.exports = angular.module('spinnaker.serverGroup.configure.openstack.basic
       region: $scope.command.region
     };
 
+    $scope.regionFilter = {
+      account: $scope.command.account,
+    };
+
     this.onRegionChanged = function(region) {
       $scope.command.region = region;
       $scope.subnetFilter.region = region;

--- a/app/scripts/modules/openstack/src/serverGroup/configure/wizard/location/basicSettings.html
+++ b/app/scripts/modules/openstack/src/serverGroup/configure/wizard/location/basicSettings.html
@@ -47,7 +47,7 @@
           <account-select-field read-only="command.viewState.readOnlyFields.credentials" component="command" field="credentials" accounts="command.backingData.accounts" provider="'openstack'"></account-select-field>
         </div>
       </div>
-      <os-region-select-field account="command.credentials" value="command.region" on-change="basicSettingsCtrl.onRegionChanged(region)"read-only="command.viewState.readOnlyFields.region"></os-region-select-field>
+      <os-region-select-field account="command.credentials" model="command.region" help-key="openstack.serverGroup.region" read-only="command.viewState.readOnlyFields.region" filter="regionFilter"></os-region-select-field>
       <div class="form-group">
         <div class="col-md-3 sm-label-right">
           Stack


### PR DESCRIPTION
Before, the Region selector in the server group details always defaulted to the first region choice. Now the region is properly populated from the server group details.
