### PR TITLE
feat(provider/appengine): Enable flex deployments from image url

### DIFF
--- a/app/scripts/modules/appengine/appengine.settings.ts
+++ b/app/scripts/modules/appengine/appengine.settings.ts
@@ -4,6 +4,7 @@ export interface IAppengineProviderSettings extends IProviderSettings {
   defaults: {
     account?: string;
     editLoadBalancerStageEnabled?: boolean;
+    containerImageUrlDeployments?: boolean;
   };
 }
 

--- a/app/scripts/modules/appengine/helpContents/appengineHelpContents.ts
+++ b/app/scripts/modules/appengine/helpContents/appengineHelpContents.ts
@@ -46,6 +46,14 @@ module(APPENGINE_HELP_CONTENTS_REGISTRY, [HELP_CONTENTS_REGISTRY])
                 <p>If this is a pipeline stage, you can use Spinnaker Pipeline Expressions here.</p>`,
       },
       {
+        key: 'appengine.serverGroup.configFilesRequired',
+        value: `<p>The contents of an App Engine config file (e.g., an <code>app.yaml</code> or
+                <code>cron.yaml</code> file).</p>
+                <p>An <code>app.yaml</code> file is required and must have <code>runtime: custom</code> in
+                order to deploy successfully.</p>
+                <p>If this is a pipeline stage, you can use Spinnaker Pipeline Expressions here.</p>`,
+      },
+      {
         key: 'appengine.serverGroup.matchBranchOnRegex',
         value: `(Optional) A Jenkins trigger may produce details from multiple repositories and branches.
                 Spinnaker will use the regex specified here to help resolve a branch for the deployment.
@@ -60,6 +68,11 @@ module(APPENGINE_HELP_CONTENTS_REGISTRY, [HELP_CONTENTS_REGISTRY])
         value: `If selected, the previously running server group in this server group\'s <b>service</b>
                 (Spinnaker load balancer) will be stopped. This option will be respected only if this server group will
                 be receiving all traffic and the previous server group is using manual scaling.`,
+      },
+      {
+        key: 'appengine.serverGroup.containerImageUrl',
+        value: `The full URL to the container image to use for deployment. The URL must be one of the valid GCR hostnames,
+                for example <b>gcr.io/my-project/image:tag</b>`,
       },
       {
         key: 'appengine.loadBalancer.shardBy.cookie',

--- a/app/scripts/modules/appengine/serverGroup/configure/serverGroupCommandBuilder.service.ts
+++ b/app/scripts/modules/appengine/serverGroup/configure/serverGroupCommandBuilder.service.ts
@@ -52,12 +52,14 @@ export interface IAppengineServerGroupCommand {
   fromArtifact: boolean;
   expectedArtifactId: string;
   sourceType: string;
+  containerImageUrl?: string;
 }
 
 export enum AppengineSourceType {
   GCS = 'gcs',
   GIT = 'git',
-  ARTIFACT = 'artifact'
+  ARTIFACT = 'artifact',
+  CONTAINER_IMAGE = 'containerImage',
 }
 
 interface IViewState {

--- a/app/scripts/modules/appengine/serverGroup/configure/wizard/basicSettings.controller.ts
+++ b/app/scripts/modules/appengine/serverGroup/configure/wizard/basicSettings.controller.ts
@@ -2,7 +2,7 @@ import { copy, extend, IController, IControllerService, IScope, module } from 'a
 import { StateService } from '@uirouter/angularjs';
 import { set } from 'lodash';
 
-import { IArtifact, IExpectedArtifact, NamingService } from '@spinnaker/core';
+import { IArtifact, IExpectedArtifact, NamingService, SETTINGS } from '@spinnaker/core';
 
 import { GitCredentialType, IAppengineAccount } from 'appengine/domain/index';
 import { AppengineSourceType, IAppengineServerGroupCommand } from '../serverGroupCommandBuilder.service';
@@ -12,6 +12,7 @@ interface IAppengineBasicSettingsScope extends IScope {
 }
 
 class AppengineServerGroupBasicSettingsCtrl implements IController {
+  public containerImageUrlEnabled = SETTINGS.providers.appengine.defaults.containerImageUrlDeployments;
 
   constructor(public $scope: IAppengineBasicSettingsScope,
               $state: StateService,
@@ -39,6 +40,10 @@ class AppengineServerGroupBasicSettingsCtrl implements IController {
 
   public isGcsSource(): boolean {
     return this.$scope.command.sourceType === AppengineSourceType.GCS;
+  }
+
+  public isContainerImageSource(): boolean {
+    return this.$scope.command.sourceType === AppengineSourceType.CONTAINER_IMAGE;
   }
 
   // TODO(jtk54): this is a copy of core code, please dedup using expected-artifact-selector component

--- a/app/scripts/modules/appengine/serverGroup/configure/wizard/basicSettings.html
+++ b/app/scripts/modules/appengine/serverGroup/configure/wizard/basicSettings.html
@@ -66,14 +66,21 @@
           <label>
             <input type="radio"
                    ng-model="command.sourceType"
-                   value="gcs"> GCS
+                   value="gcs" /> GCS
           </label>
         </div>
         <div class="radio radio-inline">
           <label>
             <input type="radio"
                    ng-model="command.sourceType"
-                   value="git"> Git
+                   value="git" /> Git
+          </label>
+        </div>
+        <div class="radio radio-inline" ng-if="basicSettingsCtrl.containerImageUrlEnabled">
+          <label>
+            <input type="radio"
+                   ng-model="command.sourceType"
+                   value="containerImage" /> Container Image
           </label>
         </div>
       </div>
@@ -197,6 +204,21 @@
           <a href ng-click="basicSettingsCtrl.toggleResolveViaTrigger()">Click for text input</a>
         </span>
         </div>
+      </div>
+    </div>
+
+    <div ng-if="basicSettingsCtrl.isContainerImageSource()">
+      <div class="form-group">
+        <div class="col-md-3 sm-label-right">
+          Image URL
+          <help-field key="appengine.serverGroup.containerImageUrl"></help-field>
+        </div>
+        <div class="col-md-7">
+          <input type="text"
+            required
+            class="form-control input-sm"
+            name="containerImageUrl"
+            ng-model="command.containerImageUrl"/></div>
       </div>
     </div>
 

--- a/app/scripts/modules/appengine/serverGroup/configure/wizard/configFiles.component.ts
+++ b/app/scripts/modules/appengine/serverGroup/configure/wizard/configFiles.component.ts
@@ -1,7 +1,8 @@
 import { IController, module } from 'angular';
+import { AppengineSourceType } from '../serverGroupCommandBuilder.service';
 
 class AppengineConfigFileConfigurerCtrl implements IController {
-  public command: {configFiles: string[]};
+  public command: {configFiles: string[], sourceType: string};
 
   public $onInit(): void {
     if (!this.command.configFiles) {
@@ -26,6 +27,10 @@ class AppengineConfigFileConfigurerCtrl implements IController {
       event.target.selectionStart += 2;
     }
   }
+
+  public isContainerImageSource(): boolean {
+    return this.command.sourceType === AppengineSourceType.CONTAINER_IMAGE;
+  }
 }
 
 class AppengineConfigFileConfigurerComponent implements ng.IComponentOptions {
@@ -33,7 +38,7 @@ class AppengineConfigFileConfigurerComponent implements ng.IComponentOptions {
   public controller: any = AppengineConfigFileConfigurerCtrl;
   public template = `
     <div class="form-horizontal container-fluid">
-      <div class="form-group">
+      <div class="form-group" ng-if="!$ctrl.isContainerImageSource()">
         <div class="col-md-3 sm-label-right">
           Application Root
           <help-field class="help-field-absolute" key="appengine.serverGroup.applicationDirectoryRoot"></help-field>
@@ -45,7 +50,7 @@ class AppengineConfigFileConfigurerComponent implements ng.IComponentOptions {
                  ng-model="$ctrl.command.applicationDirectoryRoot"/></div>
       </div>
 
-      <div class="form-group">
+      <div class="form-group" ng-if="!$ctrl.isContainerImageSource()">
         <div class="col-md-3 sm-label-right">
           Config Filepaths <help-field key="appengine.serverGroup.configFilepaths"></help-field>
         </div>
@@ -62,7 +67,13 @@ class AppengineConfigFileConfigurerComponent implements ng.IComponentOptions {
 
       <div class="form-group">
         <div class="col-md-3 sm-label-right">
-          Config Files <help-field key="appengine.serverGroup.configFiles"></help-field>
+          Config Files
+          <span ng-if="!$ctrl.isContainerImageSource()">
+            <help-field key="appengine.serverGroup.configFiles"></help-field>
+          </span>
+          <span ng-if="$ctrl.isContainerImageSource()">
+            <help-field key="appengine.serverGroup.configFilesRequired"></help-field>
+          </span>
         </div>
         <div ng-repeat="configFile in $ctrl.command.configFiles track by $index" >
           <div class="col-md-7" ng-class="{'col-md-offset-3': $index > 0}" style="margin-top: 5px;">

--- a/app/scripts/modules/appengine/serverGroup/transformer.ts
+++ b/app/scripts/modules/appengine/serverGroup/transformer.ts
@@ -35,6 +35,7 @@ export class AppengineDeployDescription {
   public fromArtifact: boolean;
   public sourceType: string;
   public storageAccountName?: string;
+  public containerImageUrl?: string;
 
   constructor(command: IAppengineServerGroupCommand) {
     this.credentials = command.credentials;
@@ -62,6 +63,7 @@ export class AppengineDeployDescription {
     this.fromArtifact = command.fromArtifact;
     this.sourceType = command.sourceType;
     this.storageAccountName = command.storageAccountName;
+    this.containerImageUrl = command.containerImageUrl;
   }
 }
 

--- a/settings.js
+++ b/settings.js
@@ -101,7 +101,8 @@ window.spinnakerSettings = {
     appengine: {
       defaults: {
         account: 'my-appengine-account',
-      }
+        containerImageUrlDeployments: false,
+      },
     }
   },
   whatsNew: {


### PR DESCRIPTION
Currently feature flagged behind `providers.appengine.defaults.containerImageUrlDeployments`

![appengine_flex](https://user-images.githubusercontent.com/34253460/34267590-72e10734-e64b-11e7-8087-3082b494f1cb.png)