### PR TITLE
style(provider/google): Fix react-style dropdown z-index in Instance Type Configurer

### DIFF
--- a/app/scripts/modules/google/src/serverGroup/details/serverGroupDetails.gce.controller.js
+++ b/app/scripts/modules/google/src/serverGroup/details/serverGroupDetails.gce.controller.js
@@ -15,6 +15,8 @@ import {
 
 require('../configure/serverGroup.configure.gce.module.js');
 
+import './serverGroupDetails.less';
+
 module.exports = angular.module('spinnaker.serverGroup.details.gce.controller', [
   require('@uirouter/angularjs').default,
   require('../configure/serverGroupCommandBuilder.service.js').name,

--- a/app/scripts/modules/google/src/serverGroup/details/serverGroupDetails.less
+++ b/app/scripts/modules/google/src/serverGroup/details/serverGroupDetails.less
@@ -1,0 +1,3 @@
+gce-custom-instance-configurer .Select-menu-outer {
+  z-index: 4;
+}


### PR DESCRIPTION
Prior to this change the menus for Cores and Memory (Gb) would appear underneath the wizard's sticky headers, blocking options somewhat.

Before:

![dropdown_before](https://user-images.githubusercontent.com/34253460/34421450-4edd0314-ebdd-11e7-8139-95b206e07478.jpg)

After:

![dropdown_after](https://user-images.githubusercontent.com/34253460/34421455-54904a1e-ebdd-11e7-9644-f458d0adbdfd.jpg)
