### PR TITLE
fix(webpack): Fixes issue where jquery-ui was not correctly loaded by webpack

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -127,6 +127,10 @@ function configure(IS_TEST) {
             { loader: 'expose-loader?jQuery' },
           ],
         },
+        {
+          test: /ui-sortable/,
+          use: ['imports-loader?$UI=jquery-ui/ui/widgets/sortable']
+        }
       ],
     },
     watch: IS_TEST,


### PR DESCRIPTION
# Background 

In the Pipelines view (`#/applications/{appname}/executions/configure/{guid}`) there is a JavaScript error related to [angular-ui/ui-sortable](https://github.com/angular-ui/ui-sortable/issues/518) on page load:

```
angular.js:14525 TypeError: element.sortable is not a function
    at init (sortable.js:531)
    at initIfEnabled (sortable.js:539)
    at Object.link (sortable.js:550)
    at angular.js:1346
    at angular.js:10420
    at At (angular.js:10426)
    at f (angular.js:9815)
    at a (angular.js:9055)
    at f (angular.js:9809)
    at angular.js:10154 "<div ng-model="pipeline.parameterConfig" ui-sortable="parametersCtrl.sortOptions" class="ng-pristine ng-untouched ng-valid ng-isolate-scope">"
```

Which breaks drag/drop of Parameters, etc.

## Fix

As per https://github.com/angular-ui/ui-sortable/issues/518 adding the following to `webpack.common.js` and recompiling fixes the issue and re-enables drag/drop:

```javascript
{
     test: /ui-sortable/,
     use: ['imports-loader?$UI=jquery-ui/ui/widgets/sortable']
}
```