### PR TITLE
fix(core/pipeline) Check to see if restrictedExecutionWindow exists

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/executionWindows/executionWindows.controller.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/executionWindows/executionWindows.controller.js
@@ -121,7 +121,9 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.executionWindows.
           $scope.stage.restrictedExecutionWindow.jitter.skipManual = true;
         }
       } else {
-        delete $scope.stage.restrictedExecutionWindow.jitter;
+        if ($scope.stage.restrictedExecutionWindow) {
+          delete $scope.stage.restrictedExecutionWindow.jitter;
+        }
       }
     };
 


### PR DESCRIPTION
# Background

In the Pipeline configuration screen (`#/applications/{app name}/executions/configure/{guid}`) when clicking on "Manual Judgement" in the Deploy panel the following `TypeError` is triggered:

```
TypeError: Cannot convert undefined or null to object
    at toggleWindowJitter (executionWindows.controller.js:124)
    at Scope.$digest (angular.js:17999)
    at Scope.$apply (angular.js:18269)
    at done (angular.js:12387)
    at completeRequest (angular.js:12613)
    at XMLHttpRequest.requestLoaded (angular.js:12541) undefined
```

## Fix

This PR adds a small check to make sure `$scope.stage.restrictedExecutionWindow` exists before trying to `delete` its properties.