### PR TITLE
fix(core/reactShims): Add catch block to reactShims state.go() calls

### DIFF
--- a/app/scripts/modules/core/src/reactShims/react.injector.ts
+++ b/app/scripts/modules/core/src/reactShims/react.injector.ts
@@ -133,8 +133,9 @@ export class CoreReactInject extends ReactInject {
       const deferred = $q.defer();
       const promise = Object.create(deferred);
       promise.promise.transition = null;
+      promise.promise.catch(() => {});
       $rootScope.$applyAsync(() => {
-        promise.transition = originalGo.apply(this, args).then((r: any) => { promise.resolve(r); });
+        promise.transition = originalGo.apply(this, args).then(promise.resolve, promise.reject);
       });
       return promise.promise;
     };


### PR DESCRIPTION
Hoping this will silence some of those `state.go()` "transition aborted" messages.

![screen shot 2018-01-02 at 1 27 38 pm](https://user-images.githubusercontent.com/2053478/34500730-d71da620-efc0-11e7-829c-538b26de6182.png)
