### PR TITLE
fix(provider/kubernetes): fix runjob trigger image

### DIFF
--- a/app/scripts/modules/kubernetes/src/pipeline/stages/runJob/configureJob.controller.js
+++ b/app/scripts/modules/kubernetes/src/pipeline/stages/runJob/configureJob.controller.js
@@ -62,6 +62,12 @@ module.exports = angular.module('spinnaker.kubernetes.pipeline.stage.runJobStage
       };
     }).filter(image => !!image);
 
+    this.triggerImages = this.pipeline.triggers.filter(trigger => trigger.type === 'docker')
+      .map(image => {
+        image.fromTrigger = true;
+        return image;
+      });
+
     this.searchImages = (query) => {
       kubernetesImageReader.findImages({
         provider: 'dockerRegistry',
@@ -69,11 +75,8 @@ module.exports = angular.module('spinnaker.kubernetes.pipeline.stage.runJobStage
         q: query
       }).then((data) => {
 
-        if (this.pipeline.triggers) {
-          data = data.concat(this.pipeline.triggers.map((image) => {
-            image.fromTrigger = true;
-            return image;
-          }));
+        if (this.triggerImages) {
+          data = data.concat(this.triggerImages);
         }
 
         if (this.contextImages) {


### PR DESCRIPTION
when populating the list of triggering images, if you had a trigger of
any other type (ex `cron`), the container list bomb. this only allows
triggers of type `docker` to be considered.

@danielpeach PTAL