### PR TITLE
fix(amazon): Default `copySourceCustomBlockDeviceMappings` to false

### DIFF
--- a/app/scripts/modules/amazon/src/pipeline/stages/cloneServerGroup/awsCloneServerGroupStage.js
+++ b/app/scripts/modules/amazon/src/pipeline/stages/cloneServerGroup/awsCloneServerGroupStage.js
@@ -51,9 +51,8 @@ module.exports = angular.module('spinnaker.amazon.pipeline.stage.cloneServerGrou
     }
 
     if (stage.isNew) {
-      let useAmiBlockDeviceMappings = _.get($scope, 'application.attributes.providerSettings.aws.useAmiBlockDeviceMappings', false);
-      stage.useAmiBlockDeviceMappings = useAmiBlockDeviceMappings;
-      stage.copySourceCustomBlockDeviceMappings = !useAmiBlockDeviceMappings;
+      stage.useAmiBlockDeviceMappings = _.get($scope, 'application.attributes.providerSettings.aws.useAmiBlockDeviceMappings', false);
+      stage.copySourceCustomBlockDeviceMappings = false; // default to using block device mappings from current instance type
     }
 
     this.targetClusterUpdated = () => {

--- a/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupCommandBuilder.service.js
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupCommandBuilder.service.js
@@ -73,7 +73,7 @@ module.exports = angular.module('spinnaker.amazon.serverGroupCommandBuilder.serv
             spotPrice: '',
             tags: {},
             useAmiBlockDeviceMappings: useAmiBlockDeviceMappings,
-            copySourceCustomBlockDeviceMappings: !useAmiBlockDeviceMappings,
+            copySourceCustomBlockDeviceMappings: false, // default to using block device mappings from current instance type
             viewState: {
               instanceProfile: 'custom',
               useAllImageSelection: false,
@@ -233,7 +233,7 @@ module.exports = angular.module('spinnaker.amazon.serverGroupCommandBuilder.serv
           tags: Object.assign({}, serverGroup.tags, existingTags),
           targetGroups: serverGroup.targetGroups,
           useAmiBlockDeviceMappings: useAmiBlockDeviceMappings,
-          copySourceCustomBlockDeviceMappings: !useAmiBlockDeviceMappings,
+          copySourceCustomBlockDeviceMappings: false, // default to using block device mappings from current instance type
           viewState: {
             instanceProfile: asyncData.instanceProfile,
             useAllImageSelection: false,


### PR DESCRIPTION
This only affects new clone / deploy stages and is targeted at
better supporting instance types that are not yet natively supported
by `clouddriver`.

An edge case exists when a server group is created with the
default block device mappings for "unknown" instance types.

Subsequent clones of this server group will carry forward this
set of block device mappings even after support for the new instance
type has been added to `clouddriver`.
