### PR TITLE
fix(core): remove "0" from filter list when no pipelines present

### DIFF
--- a/app/scripts/modules/core/src/pipeline/create/CreatePipelineButton.tsx
+++ b/app/scripts/modules/core/src/pipeline/create/CreatePipelineButton.tsx
@@ -10,6 +10,7 @@ import { CreatePipelineModal } from './CreatePipelineModal';
 
 export interface ICreatePipelineButtonProps {
   application: Application;
+  asLink?: boolean;
 }
 
 export interface ICreatePipelineButtonState {
@@ -45,6 +46,25 @@ export class CreatePipelineButton extends React.Component<ICreatePipelineButtonP
   };
 
   public render() {
+    const modal = (
+      <CreatePipelineModal
+        show={this.state.showCreatePipelineModal}
+        showCallback={this.showCallBack}
+        pipelineSavedCallback={this.goToPipelineConfig}
+        application={this.props.application}
+      />
+    );
+    if (this.props.asLink) {
+      return (
+        <a
+          className="clickable"
+          onClick={this.createPipeline}
+        >
+          Configure a new pipeline
+          {modal}
+        </a>
+      );
+    }
     return (
       <button
         className="btn btn-sm btn-default"
@@ -56,12 +76,7 @@ export class CreatePipelineButton extends React.Component<ICreatePipelineButtonP
           <span className="glyphicon glyphicon-plus-sign hidden-xl-inline"/>
         </Tooltip>
         <span className="visible-xl-inline"> Create</span>
-        <CreatePipelineModal
-          show={this.state.showCreatePipelineModal}
-          showCallback={this.showCallBack}
-          pipelineSavedCallback={this.goToPipelineConfig}
-          application={this.props.application}
-        />
+        {modal}
       </button>
     )
   }

--- a/app/scripts/modules/core/src/pipeline/executions/Executions.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/Executions.tsx
@@ -1,4 +1,5 @@
 import { IPromise } from 'angular';
+import { CreatePipelineButton } from 'core/pipeline/create/CreatePipelineButton';
 import * as React from 'react';
 import * as ReactGA from 'react-ga';
 import { Transition } from '@uirouter/core';
@@ -250,6 +251,14 @@ export class Executions extends React.Component<IExecutionsProps, IExecutionsSta
     const hasPipelines = !!(get(app, 'executions.data', []).length || get(app, 'pipelineConfigs.data', []).length);
 
     if (!app.notFound) {
+      if (!hasPipelines) {
+        return (
+          <div className="text-center full-width">
+            <h3>No pipelines configured for this application.</h3>
+            <h4><CreatePipelineButton application={app} asLink={true}/></h4>
+          </div>
+        );
+      }
       return (
         <div className="executions-section">
           <div className={`insight ${filtersExpanded ? 'filters-expanded' : 'filters-collapsed'}`}>

--- a/app/scripts/modules/core/src/pipeline/filter/ExecutionFilters.tsx
+++ b/app/scripts/modules/core/src/pipeline/filter/ExecutionFilters.tsx
@@ -191,7 +191,7 @@ export class ExecutionFilters extends React.Component<IExecutionFiltersProps, IE
                   update={this.refreshExecutions}
                   onSortEnd={this.handleSortEnd}
                 />
-                { pipelineNames.length && (
+                { pipelineNames.length > 0 && (
                   <div>
                     { !pipelineReorderEnabled && (
                       <a


### PR DESCRIPTION
Making it much more explicit you need to create a new pipeline config to do anything useful with the executions view.

Current:
<img width="851" alt="screen shot 2018-01-04 at 10 21 06 am" src="https://user-images.githubusercontent.com/73450/34578277-30b405f2-f139-11e7-8154-51299ac04427.png">


PR:
<img width="860" alt="screen shot 2018-01-04 at 10 21 15 am" src="https://user-images.githubusercontent.com/73450/34578286-35375caa-f139-11e7-8460-fe9e0369b96e.png">

 Closes https://github.com/spinnaker/spinnaker/issues/2223