### PR TITLE
chore(amazon): bump package to 0.0.58

### DIFF
--- a/app/scripts/modules/amazon/package.json
+++ b/app/scripts/modules/amazon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/amazon",
-  "version": "0.0.57",
+  "version": "0.0.58",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
* fix(amazon): Default `copySourceCustomBlockDeviceMappings` to false
* fix(amazon): fresh new spinners