### PR TITLE
fix(core): allow side filters to be collapsed

### DIFF
--- a/app/scripts/modules/core/src/insight/insightFilter.component.html
+++ b/app/scripts/modules/core/src/insight/insightFilter.component.html
@@ -9,7 +9,7 @@
 
 <a href
    class="btn btn-xs btn-default pull-right unpin"
-   ng-click="$ctrl.insightFilterStateModel.pinFilters(!$ctrl.insightFilterStateModel.filtersPinned)"
+   ng-click="$ctrl.insightFilterStateModel.pinFilters(false)"
    ng-show="$ctrl.insightFilterStateModel.filtersExpanded">
   <i class="fa fa-backward" uib-tooltip="Hide filters"></i>
 </a>

--- a/app/scripts/modules/core/src/presentation/main.less
+++ b/app/scripts/modules/core/src/presentation/main.less
@@ -248,7 +248,7 @@ html {
       width: 390px;
     }
     @media(min-width: 1400px) {
-      width: 540px;
+      width: 530px;
     }
   }
   .nav-content {


### PR DESCRIPTION
This has probably been broken for a really long time but nobody uses it?