### PR TITLE
feat(core): enable highlighting of invalid pristine fields

### DIFF
--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/serverGroupWizard.html
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/serverGroupWizard.html
@@ -5,7 +5,7 @@
   <div ng-if="!state.loaded" style="height: 200px" class="horizontal center middle">
     <loading-spinner size="'small'"></loading-spinner>
   </div>
-  <div ng-if="!state.requiresTemplateSelection">
+  <div ng-if="!state.requiresTemplateSelection" ng-class="{'highlight-pristine' : command.viewState.mode === 'editPipeline'}">
     <v2-modal-wizard ng-show="state.loaded" heading="{{title}}" task-monitor="taskMonitor" dismiss="$dismiss()">
       <v2-wizard-page key="location" label="Basic Settings" mark-complete-on-view="false">
         <ng-include src="pages.basicSettings"></ng-include>

--- a/app/scripts/modules/core/src/presentation/main.less
+++ b/app/scripts/modules/core/src/presentation/main.less
@@ -735,6 +735,18 @@ tfoot .add-new {
   }
 }
 
+.highlight-pristine {
+  .ng-invalid {
+    border-color: var(--color-danger);
+    .box-shadow(inset 0 1px 1px rgba(0, 0, 0, .075)); // Redeclare so transitions work
+    &:focus {
+      border-color: var(--color-danger);
+      @shadow: inset 0 1px 1px rgba(0, 0, 0, .075), 0 0 6px var(--color-danger-light);
+      .box-shadow(@shadow);
+    }
+  }
+}
+
 .table {
   &.packed {
     margin-bottom: 0;


### PR DESCRIPTION
Ran into a confusing case where there were invalid fields in a cluster config, but no fields were highlighted because the user was editing the cluster and hadn't touched the fields, which is a little confusing.