### PR TITLE
fix(core): handle execution window expressions gracefully

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/executionWindows/executionWindows.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/executionWindows/executionWindows.html
@@ -1,10 +1,19 @@
 <div class="form-group">
   <div class="col-md-9 col-md-offset-1">
-    <div class="checkbox">
+    <div class="checkbox" ng-if="!stage.restrictExecutionDuringTimeWindow.includes('${')">
       <label>
-        <input type="checkbox" ng-checked="stage.restrictExecutionDuringTimeWindow" />
+        <input type="checkbox"
+               ng-false-value="undefined"
+               ng-model="stage.restrictExecutionDuringTimeWindow"/>
         <strong> Restrict execution to specific time windows</strong>
       </label>
+    </div>
+    <div class="row" ng-if="stage.restrictExecutionDuringTimeWindow.includes('${')" style="margin-top: 20px">
+      <strong> Restrict execution to specific time windows when this expression is true</strong>
+      <input type="text"
+             class="form-control input-sm"
+             ng-model="stage.restrictExecutionDuringTimeWindow"/>
+
     </div>
   </div>
 </div>


### PR DESCRIPTION
The recent change was meant to handle a case where this flag was set with a parameter, but unfortunately prevented the checkbox from functioning as a toggle in any other case.

This exposes the parameterized version if applicable. Not providing an easy way to set the parameter (users will still need to edit the JSON directly), but it at least exposes the parameterized field.

cc @archana-s 