### PR TITLE
feat(gitlab) - Add gitlab as a gitSource and allow gitSources to be configured via settings.js

### DIFF
--- a/app/scripts/modules/core/src/application/modal/createApplication.modal.controller.js
+++ b/app/scripts/modules/core/src/application/modal/createApplication.modal.controller.js
@@ -42,7 +42,7 @@ module.exports = angular
       permissionsInvalid: false,
     };
     this.data = {
-
+      gitSources: SETTINGS.gitSources || ['stash', 'github', 'bitbucket', 'gitlab']
     };
     this.application = {
       cloudProviders: [],

--- a/app/scripts/modules/core/src/application/modal/editApplication.controller.modal.js
+++ b/app/scripts/modules/core/src/application/modal/editApplication.controller.modal.js
@@ -4,6 +4,7 @@ import _ from 'lodash';
 import {ACCOUNT_SERVICE} from 'core/account/account.service';
 import {APPLICATION_WRITE_SERVICE} from 'core/application/service/application.write.service';
 import {TASK_READ_SERVICE} from 'core/task/task.read.service';
+import {SETTINGS} from 'core/config/settings';
 
 const angular = require('angular');
 
@@ -17,7 +18,9 @@ module.exports = angular
   .controller('EditApplicationController', function ($scope, $window, $state, $uibModalInstance, application, applicationWriter,
                                                      accountService, taskReader) {
     var vm = this;
-    this.data = {};
+    this.data = {
+      gitSources: SETTINGS.gitSources || ['stash', 'github', 'bitbucket', 'gitlab']
+    };
     this.state = {
       submitting: false,
       permissionsInvalid: false,
@@ -121,4 +124,3 @@ module.exports = angular
 
     return vm;
   });
-

--- a/app/scripts/modules/core/src/application/modal/editApplication.html
+++ b/app/scripts/modules/core/src/application/modal/editApplication.html
@@ -19,7 +19,7 @@
         <div class="col-sm-9">
           <input type="email"
                  name="email"
-                 ng-class="{'ng-invalid ng-dirty':newAppModal.emailErrorMsg.length > 0 }"
+                 ng-class="{'ng-invalid ng-dirty':editApp.emailErrorMsg.length > 0 }"
                  class="form-control input-sm "
                  data-purpose="application-email"
                  ng-model="editApp.applicationAttributes.email"
@@ -55,7 +55,7 @@
         <div class="col-sm-9">
           <select
             class="form-control input-sm"
-            ng-options="repoType for repoType in ['stash', 'github', 'bitbucket']"
+            ng-options="repoType for repoType in editApp.data.gitSources"
             ng-model="editApp.applicationAttributes.repoType">
             <option value="">Select Repo Type</option>
           </select>

--- a/app/scripts/modules/core/src/application/modal/newapplication.html
+++ b/app/scripts/modules/core/src/application/modal/newapplication.html
@@ -59,7 +59,7 @@
         <div class="col-sm-9">
           <select
             class="form-control input-sm"
-            ng-options="repoType for repoType in ['stash', 'github', 'bitbucket']"
+            ng-options="repoType for repoType in newAppModal.data.gitSources"
             ng-model="newAppModal.application.repoType">
             <option value="">Select Repo Type</option>
           </select>

--- a/app/scripts/modules/core/src/pipeline/config/triggers/git/git.trigger.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/git/git.trigger.ts
@@ -10,7 +10,7 @@ class GitTriggerController implements IController {
 
   public fiatEnabled: boolean = SETTINGS.feature.fiatEnabled;
   public serviceAccounts: string[] = [];
-  public gitTriggerTypes = SETTINGS.gitSources || ['stash', 'github', 'bitbucket'];
+  public gitTriggerTypes = SETTINGS.gitSources || ['stash', 'github', 'bitbucket', 'gitlab'];
   public displayText: any = {
     'pipeline.config.git.project': {
       'bitbucket': 'Team or User',


### PR DESCRIPTION
Gitlab scm support was added to igor in spinnaker/spinnaker#2047 .This extends that addition to deck.

This also allows the gitSources to be overridden in configuration via settings.js/settings-local.js.
