### PR TITLE
fix(core/pipelines): do not show no pipelines message while initializing

### DIFF
--- a/app/scripts/modules/core/src/pipeline/executions/Executions.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/Executions.tsx
@@ -46,17 +46,7 @@ export class Executions extends React.Component<IExecutionsProps, IExecutionsSta
   constructor(props: IExecutionsProps) {
     super(props);
 
-    const { app } = props;
     const { executionFilterModel } = ReactInjector;
-    if (executionFilterModel.mostRecentApplication !== app.name) {
-      executionFilterModel.asFilterModel.groups = [];
-      executionFilterModel.mostRecentApplication = app.name;
-    }
-
-    if (app.notFound) { return; }
-
-    app.setActiveState(app.executions);
-
     this.state = {
       filtersExpanded: this.insightFilterStateModel.filtersExpanded,
       loading: true,
@@ -65,6 +55,18 @@ export class Executions extends React.Component<IExecutionsProps, IExecutionsSta
       triggeringExecution: false,
     };
 
+  }
+
+  public componentWillMount(): void {
+    const { app } = this.props;
+    const { executionFilterModel } = ReactInjector;
+    if (executionFilterModel.mostRecentApplication !== app.name) {
+      executionFilterModel.asFilterModel.groups = [];
+      executionFilterModel.mostRecentApplication = app.name;
+    }
+
+    if (app.notFound) { return; }
+    app.setActiveState(app.executions);
     app.executions.activate();
     app.pipelineConfigs.activate();
   }
@@ -251,7 +253,7 @@ export class Executions extends React.Component<IExecutionsProps, IExecutionsSta
     const hasPipelines = !!(get(app, 'executions.data', []).length || get(app, 'pipelineConfigs.data', []).length);
 
     if (!app.notFound) {
-      if (!hasPipelines) {
+      if (!hasPipelines && !loading) {
         return (
           <div className="text-center full-width">
             <h3>No pipelines configured for this application.</h3>


### PR DESCRIPTION
Also moving some logic into the `componentWillMount` method to get rid of a React warning about calling `setState` in a constructor.