### PR TITLE
perf(core): lazy load data for load balancers, security groups

### DIFF
--- a/app/scripts/modules/core/src/application/application.model.spec.ts
+++ b/app/scripts/modules/core/src/application/application.model.spec.ts
@@ -215,6 +215,9 @@ describe ('Application Model', function () {
         securityGroupsByApplicationName: any[] = [];
 
       configureApplication(serverGroups, loadBalancers, securityGroupsByApplicationName);
+      application.loadBalancers.activate();
+      application.refresh();
+      $scope.$digest();
       expect(application.defaultCredentials.gce).toBe('prod');
       expect(application.defaultRegions.gce).toBe('us-central-1');
     });
@@ -225,6 +228,9 @@ describe ('Application Model', function () {
         securityGroupsByApplicationName: any[] = [{ name: 'deck-test', provider: 'cf', accountName: 'test', region: 'us-south-7' }];
 
       configureApplication(serverGroups, loadBalancers, securityGroupsByApplicationName);
+      application.securityGroups.activate();
+      application.refresh();
+      $scope.$digest();
       expect(application.defaultCredentials.cf).toBe('test');
       expect(application.defaultRegions.cf).toBe('us-south-7');
     });
@@ -235,6 +241,10 @@ describe ('Application Model', function () {
         securityGroupsByApplicationName: any[] = [{ name: 'deck-test', provider: 'aws', accountName: 'test', region: 'us-east-1' }];
 
       configureApplication(serverGroups, loadBalancers, securityGroupsByApplicationName);
+      application.loadBalancers.activate();
+      application.securityGroups.activate();
+      application.refresh();
+      $scope.$digest();
       expect(application.defaultCredentials.aws).toBeUndefined();
       expect(application.defaultRegions.aws).toBeUndefined();
     });
@@ -245,6 +255,11 @@ describe ('Application Model', function () {
         securityGroupsByApplicationName: any[] = [{ name: 'deck-test', provider: 'aws', accountName: 'test', region: 'us-east-1' }];
 
       configureApplication(serverGroups, loadBalancers, securityGroupsByApplicationName);
+      application.loadBalancers.activate();
+      application.securityGroups.activate();
+      application.refresh();
+      $scope.$digest();
+
       expect(application.defaultCredentials.aws).toBeUndefined();
       expect(application.defaultRegions.aws).toBe('us-east-1');
     });
@@ -255,6 +270,11 @@ describe ('Application Model', function () {
         securityGroupsByApplicationName: any[] = [{ name: 'deck-test', provider: 'aws', accountName: 'test', region: 'us-west-1' }];
 
       configureApplication(serverGroups, loadBalancers, securityGroupsByApplicationName);
+      application.loadBalancers.activate();
+      application.securityGroups.activate();
+      application.refresh();
+      $scope.$digest();
+
       expect(application.defaultCredentials.aws).toBe('test');
       expect(application.defaultRegions.aws).toBeUndefined();
     });
@@ -282,6 +302,11 @@ describe ('Application Model', function () {
         securityGroupsByApplicationName: any[] = [{ name: 'deck-test', provider: 'aws', accountName: 'test', region: 'us-west-2' }];
 
       configureApplication(serverGroups, loadBalancers, securityGroupsByApplicationName);
+      application.loadBalancers.activate();
+      application.securityGroups.activate();
+      application.refresh();
+      $scope.$digest();
+
       expect(application.defaultCredentials.aws).toBe('test');
       expect(application.defaultRegions.aws).toBe('us-west-2');
       expect(application.defaultCredentials.gce).toBe('gce-test');

--- a/app/scripts/modules/core/src/application/service/application.read.service.spec.ts
+++ b/app/scripts/modules/core/src/application/service/application.read.service.spec.ts
@@ -79,15 +79,11 @@ describe('Service: applicationReader', function () {
       loadApplication();
       expect(application.attributes.dataSources).toBeUndefined();
       expect((<Spy>clusterService.loadServerGroups).calls.count()).toBe(1);
-      expect((<Spy>securityGroupReader.getApplicationSecurityGroups).calls.count()).toBe(1);
-      expect(loadBalancerReader.loadLoadBalancers.calls.count()).toBe(1);
     });
 
     it ('loads all data sources if disabled dataSource attribute is an empty array', function () {
       loadApplication({ enabled: [], disabled: [] });
       expect((<Spy>clusterService.loadServerGroups).calls.count()).toBe(1);
-      expect((<Spy>securityGroupReader.getApplicationSecurityGroups).calls.count()).toBe(1);
-      expect(loadBalancerReader.loadLoadBalancers.calls.count()).toBe(1);
     });
 
     it ('only loads configured dataSources if attribute is non-empty', function () {

--- a/app/scripts/modules/core/src/loadBalancer/LoadBalancers.tsx
+++ b/app/scripts/modules/core/src/loadBalancer/LoadBalancers.tsx
@@ -47,12 +47,15 @@ export class LoadBalancers extends React.Component<ILoadBalancersProps, ILoadBal
     this.groupsUpdatedListener = loadBalancerFilterService.groupsUpdatedStream.subscribe(() => this.groupsUpdated());
     loadBalancerFilterModel.asFilterModel.activate();
     this.loadBalancersRefreshUnsubscribe = app.getDataSource('loadBalancers').onRefresh(null, () => this.updateLoadBalancerGroups());
+    app.loadBalancers.activate();
     app.setActiveState(app.loadBalancers);
     this.updateLoadBalancerGroups();
   }
 
   public componentWillUnmount(): void {
-    this.props.app.setActiveState();
+    const { app } = this.props;
+    app.setActiveState();
+    app.loadBalancers.deactivate();
     this.groupsUpdatedListener.unsubscribe();
     this.loadBalancersRefreshUnsubscribe();
   }

--- a/app/scripts/modules/core/src/loadBalancer/loadBalancer.dataSource.ts
+++ b/app/scripts/modules/core/src/loadBalancer/loadBalancer.dataSource.ts
@@ -27,6 +27,7 @@ module(LOAD_BALANCER_DATA_SOURCE, [
   applicationDataSourceRegistry.registerDataSource({
     key: 'loadBalancers',
     optional: true,
+    lazy: true,
     loader: loadLoadBalancers,
     onLoad: addLoadBalancers,
     afterLoad: addTags,

--- a/app/scripts/modules/core/src/securityGroup/AllSecurityGroupsCtrl.js
+++ b/app/scripts/modules/core/src/securityGroup/AllSecurityGroupsCtrl.js
@@ -37,10 +37,12 @@ module.exports = angular.module('spinnaker.core.securityGroup.all.controller', [
 
       app.setActiveState(app.securityGroups);
       $scope.$on('$destroy', () => {
+        app.securityGroups.deactivate();
         app.setActiveState();
         groupsUpdatedSubscription.unsubscribe();
       });
 
+      app.securityGroups.activate();
       app.securityGroups.ready().then(() => updateSecurityGroups());
 
       app.securityGroups.onRefresh($scope, handleRefresh);

--- a/app/scripts/modules/core/src/securityGroup/securityGroup.dataSource.ts
+++ b/app/scripts/modules/core/src/securityGroup/securityGroup.dataSource.ts
@@ -31,6 +31,7 @@ module(SECURITY_GROUP_DATA_SOURCE, [
     applicationDataSourceRegistry.registerDataSource({
       key: 'securityGroups',
       optional: true,
+      lazy: true,
       loader: loadSecurityGroups,
       onLoad: addSecurityGroups,
       afterLoad: addTags,


### PR DESCRIPTION
People don't frequently visit these pages, so most of the background fetching is a waste of time/resources.

I considered doing the same thing to the clusters tab, but that felt sluggish, as that and the pipelines tab are the two most frequently visited tabs.