### PR TITLE
fix(core): remove lazy datasource config on security groups, load bal…

### DIFF
--- a/app/scripts/modules/core/src/application/application.model.spec.ts
+++ b/app/scripts/modules/core/src/application/application.model.spec.ts
@@ -215,9 +215,6 @@ describe ('Application Model', function () {
         securityGroupsByApplicationName: any[] = [];
 
       configureApplication(serverGroups, loadBalancers, securityGroupsByApplicationName);
-      application.loadBalancers.activate();
-      application.refresh();
-      $scope.$digest();
       expect(application.defaultCredentials.gce).toBe('prod');
       expect(application.defaultRegions.gce).toBe('us-central-1');
     });
@@ -228,9 +225,6 @@ describe ('Application Model', function () {
         securityGroupsByApplicationName: any[] = [{ name: 'deck-test', provider: 'cf', accountName: 'test', region: 'us-south-7' }];
 
       configureApplication(serverGroups, loadBalancers, securityGroupsByApplicationName);
-      application.securityGroups.activate();
-      application.refresh();
-      $scope.$digest();
       expect(application.defaultCredentials.cf).toBe('test');
       expect(application.defaultRegions.cf).toBe('us-south-7');
     });
@@ -241,10 +235,6 @@ describe ('Application Model', function () {
         securityGroupsByApplicationName: any[] = [{ name: 'deck-test', provider: 'aws', accountName: 'test', region: 'us-east-1' }];
 
       configureApplication(serverGroups, loadBalancers, securityGroupsByApplicationName);
-      application.loadBalancers.activate();
-      application.securityGroups.activate();
-      application.refresh();
-      $scope.$digest();
       expect(application.defaultCredentials.aws).toBeUndefined();
       expect(application.defaultRegions.aws).toBeUndefined();
     });
@@ -255,11 +245,6 @@ describe ('Application Model', function () {
         securityGroupsByApplicationName: any[] = [{ name: 'deck-test', provider: 'aws', accountName: 'test', region: 'us-east-1' }];
 
       configureApplication(serverGroups, loadBalancers, securityGroupsByApplicationName);
-      application.loadBalancers.activate();
-      application.securityGroups.activate();
-      application.refresh();
-      $scope.$digest();
-
       expect(application.defaultCredentials.aws).toBeUndefined();
       expect(application.defaultRegions.aws).toBe('us-east-1');
     });
@@ -270,11 +255,6 @@ describe ('Application Model', function () {
         securityGroupsByApplicationName: any[] = [{ name: 'deck-test', provider: 'aws', accountName: 'test', region: 'us-west-1' }];
 
       configureApplication(serverGroups, loadBalancers, securityGroupsByApplicationName);
-      application.loadBalancers.activate();
-      application.securityGroups.activate();
-      application.refresh();
-      $scope.$digest();
-
       expect(application.defaultCredentials.aws).toBe('test');
       expect(application.defaultRegions.aws).toBeUndefined();
     });
@@ -302,11 +282,6 @@ describe ('Application Model', function () {
         securityGroupsByApplicationName: any[] = [{ name: 'deck-test', provider: 'aws', accountName: 'test', region: 'us-west-2' }];
 
       configureApplication(serverGroups, loadBalancers, securityGroupsByApplicationName);
-      application.loadBalancers.activate();
-      application.securityGroups.activate();
-      application.refresh();
-      $scope.$digest();
-
       expect(application.defaultCredentials.aws).toBe('test');
       expect(application.defaultRegions.aws).toBe('us-west-2');
       expect(application.defaultCredentials.gce).toBe('gce-test');

--- a/app/scripts/modules/core/src/application/service/application.read.service.spec.ts
+++ b/app/scripts/modules/core/src/application/service/application.read.service.spec.ts
@@ -79,11 +79,15 @@ describe('Service: applicationReader', function () {
       loadApplication();
       expect(application.attributes.dataSources).toBeUndefined();
       expect((<Spy>clusterService.loadServerGroups).calls.count()).toBe(1);
+      expect((<Spy>securityGroupReader.getApplicationSecurityGroups).calls.count()).toBe(1);
+      expect(loadBalancerReader.loadLoadBalancers.calls.count()).toBe(1);
     });
 
     it ('loads all data sources if disabled dataSource attribute is an empty array', function () {
       loadApplication({ enabled: [], disabled: [] });
       expect((<Spy>clusterService.loadServerGroups).calls.count()).toBe(1);
+      expect((<Spy>securityGroupReader.getApplicationSecurityGroups).calls.count()).toBe(1);
+      expect(loadBalancerReader.loadLoadBalancers.calls.count()).toBe(1);
     });
 
     it ('only loads configured dataSources if attribute is non-empty', function () {

--- a/app/scripts/modules/core/src/loadBalancer/LoadBalancers.tsx
+++ b/app/scripts/modules/core/src/loadBalancer/LoadBalancers.tsx
@@ -47,15 +47,11 @@ export class LoadBalancers extends React.Component<ILoadBalancersProps, ILoadBal
     this.groupsUpdatedListener = loadBalancerFilterService.groupsUpdatedStream.subscribe(() => this.groupsUpdated());
     loadBalancerFilterModel.asFilterModel.activate();
     this.loadBalancersRefreshUnsubscribe = app.getDataSource('loadBalancers').onRefresh(null, () => this.updateLoadBalancerGroups());
-    app.loadBalancers.activate();
     app.setActiveState(app.loadBalancers);
     this.updateLoadBalancerGroups();
   }
 
   public componentWillUnmount(): void {
-    const { app } = this.props;
-    app.setActiveState();
-    app.loadBalancers.deactivate();
     this.groupsUpdatedListener.unsubscribe();
     this.loadBalancersRefreshUnsubscribe();
   }

--- a/app/scripts/modules/core/src/loadBalancer/loadBalancer.dataSource.ts
+++ b/app/scripts/modules/core/src/loadBalancer/loadBalancer.dataSource.ts
@@ -27,7 +27,6 @@ module(LOAD_BALANCER_DATA_SOURCE, [
   applicationDataSourceRegistry.registerDataSource({
     key: 'loadBalancers',
     optional: true,
-    lazy: true,
     loader: loadLoadBalancers,
     onLoad: addLoadBalancers,
     afterLoad: addTags,

--- a/app/scripts/modules/core/src/pipeline/triggers/NextRunTag.tsx
+++ b/app/scripts/modules/core/src/pipeline/triggers/NextRunTag.tsx
@@ -27,7 +27,8 @@ export class NextRunTag extends React.Component<INextRunTagProps, INextRunTagSta
 
   private updateSchedule(): INextRunTagState {
     if (this.props.pipeline) {
-      const crons = (this.props.pipeline.triggers || []).filter(t => t.type === 'cron' && t.enabled) as ICronTrigger[];
+      const crons = (this.props.pipeline.triggers || [])
+        .filter((t: ICronTrigger) => t.type === 'cron' && t.enabled && t.cronExpression) as ICronTrigger[];
       const nextTimes: number[] = [];
       crons.forEach(cron => {
         const parts = cron.cronExpression.split(' ');

--- a/app/scripts/modules/core/src/securityGroup/AllSecurityGroupsCtrl.js
+++ b/app/scripts/modules/core/src/securityGroup/AllSecurityGroupsCtrl.js
@@ -37,12 +37,10 @@ module.exports = angular.module('spinnaker.core.securityGroup.all.controller', [
 
       app.setActiveState(app.securityGroups);
       $scope.$on('$destroy', () => {
-        app.securityGroups.deactivate();
         app.setActiveState();
         groupsUpdatedSubscription.unsubscribe();
       });
 
-      app.securityGroups.activate();
       app.securityGroups.ready().then(() => updateSecurityGroups());
 
       app.securityGroups.onRefresh($scope, handleRefresh);

--- a/app/scripts/modules/core/src/securityGroup/securityGroup.dataSource.ts
+++ b/app/scripts/modules/core/src/securityGroup/securityGroup.dataSource.ts
@@ -31,7 +31,6 @@ module(SECURITY_GROUP_DATA_SOURCE, [
     applicationDataSourceRegistry.registerDataSource({
       key: 'securityGroups',
       optional: true,
-      lazy: true,
       loader: loadSecurityGroups,
       onLoad: addSecurityGroups,
       afterLoad: addTags,


### PR DESCRIPTION
…ancers

Turns out we kind of need that data to render the load balancers tags on the cluster pod, as well as the security groups on the server group details.

Rollback of https://github.com/spinnaker/deck/pull/4661