### PR TITLE
Alternative application view in the clusters tab

### DIFF
--- a/app/scripts/modules/core/src/cluster/ClusterPod.tsx
+++ b/app/scripts/modules/core/src/cluster/ClusterPod.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
+import * as classNames from 'classnames';
 import { BindAll } from 'lodash-decorators';
 import { orderBy } from 'lodash';
 
-import { ReactInjector } from 'core/reactShims';
+import { ReactInjector, NgReact } from 'core/reactShims';
 import { ServerGroup } from 'core/serverGroup/ServerGroup';
 import { Application } from 'core/application';
 import { EntityNotifications } from 'core/entityTag/notifications/EntityNotifications';
@@ -70,7 +71,9 @@ export class ClusterPod extends React.Component<IClusterPodProps, IClusterPodSta
   }
 
   private renderSubGroup(subgroup: IServerGroupSubgroup) {
+    const { AccountTag } = NgReact;
     const { grouping, application, sortFilter } = this.props;
+    const applicationView = sortFilter.applicationView;
     const hasMoniker = subgroup.serverGroups.every((sg) => { return !!sg.moniker });
     let iteratee;
     if (hasMoniker) {
@@ -81,10 +84,17 @@ export class ClusterPod extends React.Component<IClusterPodProps, IClusterPodSta
 
     const sortedServerGroups = orderBy(subgroup.serverGroups, [iteratee], ['desc']);
 
+
+
     return (
-      <div className="pod-subgroup" key={subgroup.key}>
+      <div className={classNames('pod-subgroup', { 'pod-warning': subgroup.warning, 'pod-error': subgroup.error })} key={subgroup.key}>
         <h6 className="sticky-header-2 subgroup-title">
-          {subgroup.heading}
+          {applicationView && <div>
+            <AccountTag account={subgroup.heading} />&nbsp;
+            {subgroup.warning && <span className="pill warn"><span className="glyphicon glyphicon-warning-sign"/>&nbsp;&nbsp;{subgroup.warning}</span>}
+            {subgroup.error && <span className="pill danger"><span className="glyphicon glyphicon-alert"/>&nbsp;&nbsp;{subgroup.error}</span>}
+          </div>}
+          {!applicationView && subgroup.heading}
 
           <EntityNotifications
             entity={subgroup}
@@ -96,18 +106,19 @@ export class ClusterPod extends React.Component<IClusterPodProps, IClusterPodSta
             onUpdate={application.serverGroups.refresh}
           />
         </h6>
-
-        {grouping.cluster.category === 'serverGroup' && sortedServerGroups.map((serverGroup: IServerGroup) => (
-          <ServerGroup
-            key={serverGroup.name}
-            serverGroup={serverGroup}
-            cluster={serverGroup.cluster}
-            application={application}
-            sortFilter={sortFilter}
-            hasDiscovery={grouping.hasDiscovery}
-            hasLoadBalancers={grouping.hasLoadBalancers}
-          />
-        ))}
+        <div className={classNames({ 'horizontal wrap': applicationView })}>
+          {grouping.cluster.category === 'serverGroup' && sortedServerGroups.map((serverGroup: IServerGroup) => (
+            <ServerGroup
+              key={serverGroup.name}
+              serverGroup={serverGroup}
+              cluster={serverGroup.cluster}
+              application={application}
+              sortFilter={sortFilter}
+              hasDiscovery={grouping.hasDiscovery}
+              hasLoadBalancers={grouping.hasLoadBalancers}
+            />
+          ))}
+        </div>
       </div>
     )
   }

--- a/app/scripts/modules/core/src/cluster/ClusterPodTitleWrapper.tsx
+++ b/app/scripts/modules/core/src/cluster/ClusterPodTitleWrapper.tsx
@@ -10,6 +10,7 @@ export interface IClusterPodTitleProps {
   grouping: IClusterSubgroup;
   application: Application;
   parentHeading: string;
+  sortFilter: any;
 }
 
 @BindAll()

--- a/app/scripts/modules/core/src/cluster/DefaultClusterPodTitle.tsx
+++ b/app/scripts/modules/core/src/cluster/DefaultClusterPodTitle.tsx
@@ -11,13 +11,13 @@ export class DefaultClusterPodTitle extends React.Component<IClusterPodTitleProp
 
   public render(): React.ReactElement<DefaultClusterPodTitle> {
     const { AccountTag } = NgReact;
-    const { grouping, application, parentHeading } = this.props;
+    const { grouping, application, parentHeading, sortFilter } = this.props;
 
     return (
       <div className="rollup-title-cell">
-        <div className="heading-tag">
+        {!sortFilter.applicationView && <div className="heading-tag">
           <AccountTag account={parentHeading} />
-        </div>
+        </div>}
 
         <div className="pod-center">
           <div>

--- a/app/scripts/modules/core/src/cluster/allClusters.html
+++ b/app/scripts/modules/core/src/cluster/allClusters.html
@@ -14,22 +14,32 @@
         </button>
       </div>
       <div class="form-group">
-        <label class="checkbox">Show </label>
         <div class="checkbox">
           <label>
             <input type="checkbox"
-                   ng-model="sortFilter.showAllInstances"
+                   ng-model="sortFilter.applicationView"
                    ng-change="ctrl.updateClusterGroups()"/>
-            Instances
+            Application view
           </label>
         </div>
-        <div class="checkbox" is-visible="sortFilter.showAllInstances">
-          <label>
-            <input type="checkbox"
-                   ng-model="sortFilter.listInstances"
-                   ng-change="ctrl.updateClusterGroups()"/>
-            with details
-          </label>
+        <div class="form-group" ng-if="!sortFilter.applicationView">
+          <label class="checkbox">Show </label>
+          <div class="checkbox">
+            <label>
+              <input type="checkbox"
+                     ng-model="sortFilter.showAllInstances"
+                     ng-change="ctrl.updateClusterGroups()"/>
+              Instances
+            </label>
+          </div>
+          <div class="checkbox" is-visible="sortFilter.showAllInstances">
+            <label>
+              <input type="checkbox"
+                     ng-model="sortFilter.listInstances"
+                     ng-change="ctrl.updateClusterGroups()"/>
+              with details
+            </label>
+          </div>
         </div>
       </div>
     </div>

--- a/app/scripts/modules/core/src/cluster/filter/clusterFilter.model.ts
+++ b/app/scripts/modules/core/src/cluster/filter/clusterFilter.model.ts
@@ -23,6 +23,7 @@ export const filterModelConfig: IFilterConfig[] = [
   { model: 'instanceSort', displayOption: true, type: 'sortKey', defaultValue: 'launchTime' },
   { model: 'multiselect', displayOption: true, type: 'boolean', },
   { model: 'clusters', type: 'trueKeyObject' },
+  { model: 'applicationView', displayOption: true, type: 'boolean', },
 ];
 
 export class ClusterFilterModel {

--- a/app/scripts/modules/core/src/cluster/rollups.less
+++ b/app/scripts/modules/core/src/cluster/rollups.less
@@ -407,6 +407,22 @@ running-tasks-tag {
         padding: 5px 1px;
       }
     }
+    &.pod-error {
+      margin-top: 10px;
+      padding-bottom: 10px;
+      background-color: var(--color-danger-light);
+      h6 {
+        background-color: var(--color-danger-light);
+      }
+    }
+    &.pod-warning {
+      margin-top: 10px;
+      padding-bottom: 10px;
+      background-color: var(--color-alert-light);
+      h6 {
+        background-color: var(--color-alert-light);
+      }
+    }
   }
   h5, h6 {
     font-weight: 600;

--- a/app/scripts/modules/core/src/serverGroup/serverGroup.less
+++ b/app/scripts/modules/core/src/serverGroup/serverGroup.less
@@ -9,3 +9,17 @@
     }
   }
 }
+
+.server-group.application-view {
+  .cluster-container {
+    width: 200px;
+    height: 100px;
+    .vertical {
+      height: 100%;
+    }
+    .instance-health-counts {
+      float: none;
+      padding-left: 0;
+    }
+  }
+}


### PR DESCRIPTION
Adds a new, alternative way of looking at the clusters. In the new "Application view", the clusters are primarily sorted by cluster name instead of environment. It will also display a warning if more than one server group is active at the same time in the same region.

Please let me know what you think, I'm open to suggestions!

![skjermbilde 2018-01-15 kl 10 24 45](https://user-images.githubusercontent.com/155558/34936189-b83d6ee6-f9e0-11e7-8d0d-01f69178ea38.png)

![skjermbilde 2018-01-15 kl 10 24 23](https://user-images.githubusercontent.com/155558/34936191-be9b209e-f9e0-11e7-965d-943618a1f40c.png)

![skjermbilde 2018-01-15 kl 10 25 38](https://user-images.githubusercontent.com/155558/34936200-c54153aa-f9e0-11e7-96cd-7cfe84d3f2db.png)

![skjermbilde 2018-01-15 kl 10 37 18](https://user-images.githubusercontent.com/155558/34936201-c5651812-f9e0-11e7-85f1-d1d24cccc5f3.png)

Tip: it might be easier to read the PR if you [ignore whitespace](https://github.com/spinnaker/deck/pull/4667/files?w=1).