### PR TITLE
feat(amazon/serverGroup): warn that scaling policies will not work when capacity is pinned

### DIFF
--- a/app/scripts/modules/amazon/src/serverGroup/details/resize/resizeCapacity.component.html
+++ b/app/scripts/modules/amazon/src/serverGroup/details/resize/resizeCapacity.component.html
@@ -48,17 +48,6 @@
                                  min="{{$ctrl.command.min}}"
                                  max="{{$ctrl.command.max}}"/></div>
   </div>
-
-  <div class="row" ng-if="$ctrl.command.min == $ctrl.command.max && $ctrl.serverGroup.scalingPolicies.length > 0">
-    <div class="col-md-7 col-md-offset-3">
-      <div class="well-compact alert alert-warning">
-        <b>Warning</b>: this server group has
-        <span ng-if="$ctrl.serverGroup.scalingPolicies.length == 1">a scaling policy.</span>
-        <span ng-if="$ctrl.serverGroup.scalingPolicies.length > 1">scaling policies.</span>
-        Scaling policies will not take effect when <b>Min</b> is the same as <b>Max</b>.
-      </div>
-    </div>
-  </div>
 </div>
 <div ng-if="!$ctrl.command.advancedMode">
   <div class="form-group">
@@ -95,15 +84,20 @@
         instances
     </div>
   </div>
-  <div class="row" ng-if="$ctrl.command.min == $ctrl.command.max && $ctrl.serverGroup.scalingPolicies.length > 0">
-    <div class="col-md-7 col-md-offset-3">
-      <div class="well-compact alert alert-warning">
-        <b>Warning</b>: this server group has
-        <span ng-if="$ctrl.serverGroup.scalingPolicies.length == 1">a scaling policy.</span>
-        <span ng-if="$ctrl.serverGroup.scalingPolicies.length > 1">scaling policies.</span>
+</div>
+<div class="row" ng-if="$ctrl.command.min == $ctrl.command.max && $ctrl.serverGroup.scalingPolicies.length > 0">
+  <div class="col-md-7 col-md-offset-3">
+    <div class="well-compact alert alert-warning">
+      <b>Warning</b>: this server group has
+      <span ng-if="$ctrl.serverGroup.scalingPolicies.length == 1">a scaling policy.</span>
+      <span ng-if="$ctrl.serverGroup.scalingPolicies.length > 1">scaling policies.</span>
+      <span ng-if="!$ctrl.command.advancedMode">
         Scaling policies will not take effect in Simple Mode.
         Switch to <a href ng-click="$ctrl.command.advancedMode = true">Advanced Mode</a>.
-      </div>
+      </span>
+      <span ng-if="$ctrl.command.advancedMode">
+        Scaling policies will not take effect when <b>Min</b> is the same as <b>Max</b>.
+      </span>
     </div>
   </div>
 </div>

--- a/app/scripts/modules/amazon/src/serverGroup/details/resize/resizeCapacity.component.html
+++ b/app/scripts/modules/amazon/src/serverGroup/details/resize/resizeCapacity.component.html
@@ -49,6 +49,16 @@
                                  max="{{$ctrl.command.max}}"/></div>
   </div>
 
+  <div class="row" ng-if="$ctrl.command.min == $ctrl.command.max && $ctrl.serverGroup.scalingPolicies.length > 0">
+    <div class="col-md-7 col-md-offset-3">
+      <div class="well-compact alert alert-warning">
+        <b>Warning</b>: this server group has
+        <span ng-if="$ctrl.serverGroup.scalingPolicies.length == 1">a scaling policy.</span>
+        <span ng-if="$ctrl.serverGroup.scalingPolicies.length > 1">scaling policies.</span>
+        Scaling policies will not take effect when <b>Min</b> is the same as <b>Max</b>.
+      </div>
+    </div>
+  </div>
 </div>
 <div ng-if="!$ctrl.command.advancedMode">
   <div class="form-group">
@@ -83,6 +93,17 @@
                required
                style="width: 60px"/>
         instances
+    </div>
+  </div>
+  <div class="row" ng-if="$ctrl.command.min == $ctrl.command.max && $ctrl.serverGroup.scalingPolicies.length > 0">
+    <div class="col-md-7 col-md-offset-3">
+      <div class="well-compact alert alert-warning">
+        <b>Warning</b>: this server group has
+        <span ng-if="$ctrl.serverGroup.scalingPolicies.length == 1">a scaling policy.</span>
+        <span ng-if="$ctrl.serverGroup.scalingPolicies.length > 1">scaling policies.</span>
+        Scaling policies will not take effect in Simple Mode.
+        Switch to <a href ng-click="$ctrl.command.advancedMode = true">Advanced Mode</a>.
+      </div>
     </div>
   </div>
 </div>

--- a/app/scripts/modules/amazon/src/serverGroup/details/resize/resizeCapacity.component.ts
+++ b/app/scripts/modules/amazon/src/serverGroup/details/resize/resizeCapacity.component.ts
@@ -3,7 +3,8 @@ import { IComponentOptions, module } from 'angular';
 const resizeCapacityComponent: IComponentOptions = {
   bindings: {
     command: '=',
-    currentSize: '='
+    currentSize: '=',
+    serverGroup: '='
   },
   templateUrl: require('./resizeCapacity.component.html'),
   controller: () => {}

--- a/app/scripts/modules/amazon/src/serverGroup/details/resize/resizeServerGroup.html
+++ b/app/scripts/modules/amazon/src/serverGroup/details/resize/resizeServerGroup.html
@@ -7,7 +7,8 @@
     </div>
     <div class="modal-body confirmation-modal">
       <div class="form-horizontal">
-        <aws-resize-capacity command="command" current-size="currentSize"></aws-resize-capacity>
+        <aws-resize-capacity command="command" current-size="currentSize" server-group="serverGroup"></aws-resize-capacity>
+        
       </div>
       <div class="row">
         <div class="col-sm-10 col-sm-offset-1">


### PR DESCRIPTION
For the majority of use cases, pinning capacity at a fixed size while a scaling policy is in effect is not a desirable state, and will lead to the appearance of the scaling policy 'not working'. This adds a yellow warning section below the capacity resize inputs when the chosen capacity range would result in scaling policies becoming ineffective.