### PR TITLE
feat(webhooks): preconfigured webhook params

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/webhook/webhookExecutionDetails.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/webhook/webhookExecutionDetails.html
@@ -16,6 +16,13 @@
           <dd>{{ctrl.stage.context.statusEndpoint}}</dd>
         </dl>
       </div>
+      <div class="col-md-12" ng-if="ctrl.stage.context.parameterValues">
+        <h5>Parameters</h5>
+        <dl class="dl-narrow dl-horizontal">
+          <dt ng-repeat-start="(key, val) in ctrl.stage.context.parameterValues">{{key}}</dt>
+          <dd ng-repeat-end>{{val}}</dd>
+        </dl>
+      </div>
     </div>
     <stage-failure-message stage="ctrl.stage" is-failed="ctrl.stage.isFailed" message="ctrl.getException(stage) || ctrl.failureMessage"></stage-failure-message>
     <div class="well alert-info" ng-if="ctrl.stage.context.progressMessage || ctrl.stage.status">

--- a/app/scripts/modules/core/src/pipeline/config/stages/webhook/webhookStage.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/webhook/webhookStage.html
@@ -13,6 +13,18 @@
       </ui-select-choices>
     </ui-select>
   </stage-config-field>
+  <stage-config-field label="Parameters"
+                      ng-if="$ctrl.parameters.length">
+    <div class="form-group" ng-repeat="parameter in $ctrl.parameters | orderBy:'name'">
+      <div class="col-md-3 sm-label-right">
+        <b class="break-word">{{ parameter.label }}</b>
+        <help-field content="{{parameter.description}}" ng-if="parameter.description"></help-field>
+      </div>
+      <div class="col-md-5">
+        <input ng-model="$ctrl.stage.parameterValues[parameter.name]" type="text" class="form-control input-sm"/>
+      </div>
+    </div>
+  </stage-config-field>
   <stage-config-field label="Payload"
                       help-key="pipeline.config.webhook.payload"
                       ng-if="$ctrl.stage.method !== 'GET' && $ctrl.stage.method !== 'HEAD' && $ctrl.displayField('payload')">


### PR DESCRIPTION
adds support for preconfigured webhook parameters. these parameters can
be set in orca's config and are then exposed to users. instead of
expecting users to fillout an entire payload, these parameters can be
used to expose the important parts and abstract the other configuration
away.

related orca pr: spinnaker/orca#1887

@anotherchrisberry @ajordens PTAL

### Configuration
![image](https://user-images.githubusercontent.com/3324110/34992739-1b6d324c-fa9c-11e7-8e2a-c2ee58baaa9f.png)

### Execution
![image](https://user-images.githubusercontent.com/3324110/34992755-2a3b156e-fa9c-11e7-90bc-69aee678d8a2.png)
