### PR TITLE
fix(core/presentation): Add padding to filter sidebar as a scrolling affordance

### DIFF
--- a/app/scripts/modules/core/src/presentation/main.less
+++ b/app/scripts/modules/core/src/presentation/main.less
@@ -179,6 +179,9 @@ html {
       .dl-narrow;
     }
     .nav {
+      .content {
+        padding-bottom: 20px;
+      }
       .content, .heading {
         margin-left: 0;
         width: inherit;


### PR DESCRIPTION
Currently when you scroll to the bottom of the filter sidebar it's not entirely obvious you've reached the end. This adds a little bit of padding to the bottom of the inner content element as an affordance.

cc @archana-s 