### PR TITLE
fix(provider/kubernetes): Fix label wording

### DIFF
--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestConfig.html
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestConfig.html
@@ -49,7 +49,7 @@
 
   <expected-artifact-multi-selector command="ctrl.$scope.stage"
                                     ids-field="requiredArtifactIds"
-                                    artifact-label="Required artifacts to deploy"
+                                    artifact-label="Required artifacts to bind"
                                     expected-artifacts="ctrl.expectedArtifacts">
   </expected-artifact-multi-selector>
 </div>


### PR DESCRIPTION
Artifacts are "bound", not "deployed"
