### PR TITLE
fix(amazon/loadBalancer): Show region and account when deleting a load balancer

### DIFF
--- a/app/scripts/modules/amazon/src/loadBalancer/details/loadBalancerDetails.controller.ts
+++ b/app/scripts/modules/amazon/src/loadBalancer/details/loadBalancerDetails.controller.ts
@@ -132,7 +132,7 @@ export class AwsLoadBalancerDetailsController implements IController {
     const submitMethod = () => this.loadBalancerWriter.deleteLoadBalancer(command, this.app);
 
     this.confirmationModalService.confirm({
-      header: `Really delete ${this.loadBalancerFromParams.name}?`,
+      header: `Really delete ${this.loadBalancerFromParams.name} in ${this.loadBalancerFromParams.region}: ${this.loadBalancerFromParams.accountId}?`,
       buttonText: `Delete ${this.loadBalancerFromParams.name}`,
       provider: 'aws',
       account: this.loadBalancerFromParams.accountId,


### PR DESCRIPTION
<img width="605" alt="screen shot 2018-01-18 at 2 09 16 pm" src="https://user-images.githubusercontent.com/56971/35123966-3264447c-fc59-11e7-8d28-a9d1da032746.png">
