### PR TITLE
feat(core/search): Show search results as they arrive -- do not wait for all to complete

### DIFF
--- a/app/scripts/modules/core/src/account/AccountTag.tsx
+++ b/app/scripts/modules/core/src/account/AccountTag.tsx
@@ -1,3 +1,33 @@
+import * as React from 'react';
+import { BindAll } from 'lodash-decorators';
+import { ReactInjector } from 'core/reactShims';
+
 export interface IAccountTagProps {
   account: string;
+}
+
+export interface IAccountTagState {
+  isProdAccount: boolean;
+}
+
+@BindAll()
+export class AccountTag extends React.Component<IAccountTagProps, IAccountTagState> {
+  public state = { isProdAccount: false };
+
+  constructor(props: IAccountTagProps) {
+    super(props);
+
+    ReactInjector.accountService.challengeDestructiveActions(props.account)
+      .then(isProdAccount => this.setState({ isProdAccount }));
+  }
+
+  public render() {
+    const { account } = this.props;
+    const { isProdAccount } = this.state;
+    return (
+      <span className={`account-tag account-tag-${isProdAccount ? 'prod' : 'notprod'}`}>
+        {account}
+      </span>
+    );
+  }
 }

--- a/app/scripts/modules/core/src/application/applicationSearchResultType.tsx
+++ b/app/scripts/modules/core/src/application/applicationSearchResultType.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import {
   AccountCell, BasicCell, HrefCell, searchResultTypeRegistry, ISearchResult, ISearchResultType,
-  SearchResultTabComponent, SearchResultsHeaderComponent, SearchResultsDataComponent, DefaultSearchResultTab,
+  SearchResultsHeaderComponent, SearchResultsDataComponent, DefaultSearchResultTab,
   HeaderCell, TableBody, TableHeader, TableRow, ISearchColumn,
 } from 'core/search';
 
@@ -37,10 +37,6 @@ const itemKeyFn = (item: IApplicationSearchResult) => item.application;
 const itemSortFn = (a: IApplicationSearchResult, b: IApplicationSearchResult) =>
   a.application.localeCompare(b.application);
 
-const SearchResultTab: SearchResultTabComponent = ({ ...props }) => (
-  <DefaultSearchResultTab {...props} iconClass={iconClass} label={displayName} />
-);
-
 const SearchResultsHeader: SearchResultsHeaderComponent = () => (
   <TableHeader>
     <HeaderCell col={cols.APPLICATION}/>
@@ -68,7 +64,7 @@ const applicationSearchResultType: ISearchResultType = {
   iconClass,
   displayFormatter: (searchResult: IApplicationSearchResult) => searchResult.application,
   components: {
-    SearchResultTab,
+    SearchResultTab: DefaultSearchResultTab,
     SearchResultsHeader,
     SearchResultsData,
   },

--- a/app/scripts/modules/core/src/cluster/ClusterPostSearchResultSearcher.ts
+++ b/app/scripts/modules/core/src/cluster/ClusterPostSearchResultSearcher.ts
@@ -1,18 +1,14 @@
-import { uniqBy } from 'lodash';
 import { IPromise, IQService } from 'angular';
 import { StateService } from '@uirouter/angularjs';
+import { uniqBy } from 'lodash';
 
-import { urlBuilderRegistry } from 'core/navigation/urlBuilder.registry';
-import {
-  ISearchResultType,
-  searchResultTypeRegistry
-} from 'core/search/searchResult/searchResultsType.registry';
-import { ISearchResultSet } from 'core/search/infrastructure/infrastructureSearch.service';
+import { urlBuilderRegistry } from 'core/navigation';
+import { IPostSearchResultSearcher, ISearchResultSet, ISearchResultType, searchResultTypeRegistry } from 'core/search';
 import { IServerGroupSearchResult } from 'core/serverGroup/serverGroupSearchResultType';
-import { IClusterSearchResult } from './clusterSearchResultType';
-import { IPostSearchResultSearcher } from 'core/search/searchResult/PostSearchResultSearcherRegistry';
 
-export class ClusterPostSearchResultSearcher implements IPostSearchResultSearcher<IServerGroupSearchResult> {
+import { IClusterSearchResult } from './clusterSearchResultType';
+
+export class ClusterPostSearchResultSearcher implements IPostSearchResultSearcher {
   private TYPE_ID = 'clusters';
   constructor(private $q: IQService, private $state: StateService) {}
 
@@ -25,13 +21,15 @@ export class ClusterPostSearchResultSearcher implements IPostSearchResultSearche
     return { account, application, cluster, provider, stack, displayName: cluster, href, type };
   }
 
-  public getPostSearchResults(inputs: IServerGroupSearchResult[] = []): IPromise<ISearchResultSet[]> {
+  public getPostSearchResults(resultSet: ISearchResultSet<IServerGroupSearchResult>): IPromise<ISearchResultSet> {
+    const inputs = resultSet.results;
     const type: ISearchResultType = searchResultTypeRegistry.get(this.TYPE_ID);
 
     // create cluster search results based on the server group search results
     const clusters = inputs.map(input => this.makeSearchResult(input));
     const results: IClusterSearchResult[] = uniqBy(clusters, sg => `${sg.account}-${sg.cluster}`);
 
-    return this.$q.when([{ type, results }]);
+    const { status, error } = resultSet;
+    return this.$q.when({ status, error, type, results });
   }
 }

--- a/app/scripts/modules/core/src/cluster/DefaultClusterPodTitle.tsx
+++ b/app/scripts/modules/core/src/cluster/DefaultClusterPodTitle.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { BindAll } from 'lodash-decorators';
 
-import { NgReact } from 'core/reactShims';
+import { AccountTag } from 'core/account';
 import { EntityNotifications } from 'core/entityTag/notifications/EntityNotifications';
 import { HealthCounts } from 'core/healthCounts';
 import { IClusterPodTitleProps } from './ClusterPodTitleWrapper';
@@ -10,7 +10,6 @@ import { IClusterPodTitleProps } from './ClusterPodTitleWrapper';
 export class DefaultClusterPodTitle extends React.Component<IClusterPodTitleProps> {
 
   public render(): React.ReactElement<DefaultClusterPodTitle> {
-    const { AccountTag } = NgReact;
     const { grouping, application, parentHeading } = this.props;
 
     return (

--- a/app/scripts/modules/core/src/cluster/clusterSearchResultType.tsx
+++ b/app/scripts/modules/core/src/cluster/clusterSearchResultType.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import {
   searchResultTypeRegistry, AccountCell, BasicCell, HrefCell, ISearchColumn, ISearchResultType,
-  SearchResultTabComponent, SearchResultsHeaderComponent, SearchResultsDataComponent, DefaultSearchResultTab,
+  SearchResultsHeaderComponent, SearchResultsDataComponent, DefaultSearchResultTab,
   HeaderCell, TableBody, TableHeader, TableRow, ISearchResult,
 } from 'core/search';
 
@@ -23,13 +23,9 @@ const cols: { [key: string]: ISearchColumn } = {
 const iconClass = 'fa fa-th';
 const displayName = 'Clusters';
 
-const itemKeyFn = (item: IClusterSearchResult) => item.cluster;
+const itemKeyFn = (item: IClusterSearchResult) => `${item.account}-${item.cluster}`;
 const itemSortFn = (a: IClusterSearchResult, b: IClusterSearchResult) =>
   a.cluster.localeCompare(b.cluster);
-
-const SearchResultTab: SearchResultTabComponent = ({ ...props }) => (
-  <DefaultSearchResultTab {...props} iconClass={iconClass} label={displayName} />
-);
 
 const SearchResultsHeader: SearchResultsHeaderComponent = () => (
   <TableHeader>
@@ -58,7 +54,7 @@ const clustersSearchResultType: ISearchResultType = {
   displayName,
   displayFormatter: (searchResult: IClusterSearchResult) => searchResult.cluster,
   components: {
-    SearchResultTab,
+    SearchResultTab: DefaultSearchResultTab,
     SearchResultsHeader,
     SearchResultsData,
   },

--- a/app/scripts/modules/core/src/entityTag/notifications/EntityName.tsx
+++ b/app/scripts/modules/core/src/entityTag/notifications/EntityName.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { IEntityTags } from 'core/domain';
-import { NgReact } from 'core/reactShims';
+import { AccountTag } from 'core/account';
 
 export interface IEntityNameProps {
   tag: IEntityTags;
@@ -11,7 +11,6 @@ export interface IEntityNameProps {
 export class EntityName extends React.Component<IEntityNameProps> {
   public render() {
     const entityRef = this.props.tag.entityRef;
-    const { AccountTag } = NgReact;
     if (!entityRef.account && !entityRef.region) {
       return null;
     }

--- a/app/scripts/modules/core/src/instance/instanceSearchResultType.tsx
+++ b/app/scripts/modules/core/src/instance/instanceSearchResultType.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 
 import {
-  AccountCell, BasicCell, HrefCell, searchResultTypeRegistry, SearchFilterTypeRegistry,
-  SearchResultTabComponent, SearchResultsHeaderComponent, SearchResultsDataComponent, DefaultSearchResultTab,
+  AccountCell, BasicCell, HrefCell, searchResultTypeRegistry,
+  SearchResultsHeaderComponent, SearchResultsDataComponent, DefaultSearchResultTab,
   ISearchResultType, ISearchResult, HeaderCell, TableBody, TableHeader, TableRow, ISearchColumn,
 } from 'core/search';
 
@@ -33,10 +33,6 @@ const itemKeyFn = (item: IInstanceSearchResult) => item.instanceId;
 const itemSortFn = (a: IInstanceSearchResult, b: IInstanceSearchResult) =>
   a.instanceId.localeCompare(b.instanceId);
 
-const SearchResultTab: SearchResultTabComponent = ({ ...props }) => (
-  <DefaultSearchResultTab {...props} iconClass={iconClass} label={displayName} />
-);
-
 const SearchResultsHeader: SearchResultsHeaderComponent = () => (
   <TableHeader>
     <HeaderCell col={cols.INSTANCE}/>
@@ -64,14 +60,13 @@ const instancesSearchResultType: ISearchResultType = {
   order: 4,
   iconClass,
   displayName,
-  requiredSearchFields: [SearchFilterTypeRegistry.KEYWORD_FILTER.key],
 
   displayFormatter: (searchResult: IInstanceSearchResult) => {
     const serverGroup = searchResult.serverGroup || 'standalone instance';
     return `${searchResult.instanceId} (${serverGroup} - ${searchResult.region})`;
   },
   components: {
-    SearchResultTab,
+    SearchResultTab: DefaultSearchResultTab,
     SearchResultsHeader,
     SearchResultsData,
   },

--- a/app/scripts/modules/core/src/loadBalancer/LoadBalancerPod.tsx
+++ b/app/scripts/modules/core/src/loadBalancer/LoadBalancerPod.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { NgReact } from 'core/reactShims';
+import { AccountTag } from 'core/account';
 import { Application } from 'core/application/application.model';
 import { ILoadBalancerGroup } from 'core/domain';
 import { LoadBalancer } from './LoadBalancer';
@@ -18,7 +18,6 @@ export interface ILoadBalancerPodProps {
 export class LoadBalancerPod extends React.Component<ILoadBalancerPodProps> {
   public render(): React.ReactElement<LoadBalancerPod> {
     const { grouping, application, parentHeading, showServerGroups, showInstances } = this.props;
-    const { AccountTag } = NgReact;
     const subgroups = grouping.subgroups.map((subgroup) => (
       <LoadBalancer
         key={subgroup.heading}

--- a/app/scripts/modules/core/src/loadBalancer/loadBalancerSearchResultType.tsx
+++ b/app/scripts/modules/core/src/loadBalancer/loadBalancerSearchResultType.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import {
   AccountCell, BasicCell, HrefCell, searchResultTypeRegistry, ISearchColumn, ISearchResultType,
-  SearchResultTabComponent, SearchResultsHeaderComponent, SearchResultsDataComponent, DefaultSearchResultTab,
+  SearchResultsHeaderComponent, SearchResultsDataComponent, DefaultSearchResultTab,
   ISearchResult, HeaderCell, TableBody, TableHeader, TableRow,
 } from 'core/search';
 
@@ -39,10 +39,6 @@ const itemSortFn = (a: ILoadBalancerSearchResult, b: ILoadBalancerSearchResult) 
   return order !== 0 ? order : a.region.localeCompare(b.region);
 };
 
-const SearchResultTab: SearchResultTabComponent = ({ ...props }) => (
-  <DefaultSearchResultTab {...props} iconClass={iconClass} label={displayName} />
-);
-
 const SearchResultsHeader: SearchResultsHeaderComponent = () => (
   <TableHeader>
     <HeaderCell col={cols.LOADBALANCER}/>
@@ -76,7 +72,7 @@ const loadBalancersSearchResultType: ISearchResultType = {
     return `${name} (${searchResult.region})`;
   },
   components: {
-    SearchResultTab,
+    SearchResultTab: DefaultSearchResultTab,
     SearchResultsHeader,
     SearchResultsData,
   },

--- a/app/scripts/modules/core/src/pipeline/config/stages/cloneServerGroup/CloneServerGroupExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/cloneServerGroup/CloneServerGroupExecutionDetails.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { find, get } from 'lodash';
 
-import { NgReact, ReactInjector } from 'core/reactShims';
+import { AccountTag } from 'core/account';
+import { ReactInjector } from 'core/reactShims';
 import { StageFailureMessage } from 'core/pipeline/details';
 import { ExecutionDetailsSection, IExecutionDetailsSectionProps } from '../core';
 
@@ -73,7 +74,6 @@ export class CloneServerGroupExecutionDetails extends React.Component<IExecution
   }
 
   public render() {
-    const { AccountTag } = NgReact;
     const { deployResults } = this.state;
     const { stage, current, name } = this.props;
     const specifiedCapacity = !stage.context.useSourceCapacity && stage.context.capacity;

--- a/app/scripts/modules/core/src/pipeline/config/stages/core/AsgActionExecutionDetailsSection.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/core/AsgActionExecutionDetailsSection.tsx
@@ -2,10 +2,9 @@ import * as React from 'react';
 
 import { StageExecutionLogs, StageFailureMessage } from 'core/pipeline/details';
 import { ExecutionDetailsSection, IExecutionDetailsSectionProps } from '../core';
-import { NgReact } from 'core/reactShims';
+import { AccountTag } from 'core/account';
 
 export function AsgActionExecutionDetailsSection(props: IExecutionDetailsSectionProps & { action: string }) {
-  const { AccountTag } = NgReact;
   const { action, stage } = props;
   return (
     <ExecutionDetailsSection name={props.name} current={props.current}>

--- a/app/scripts/modules/core/src/pipeline/config/stages/disableCluster/DisableClusterExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/disableCluster/DisableClusterExecutionDetails.tsx
@@ -1,12 +1,11 @@
 import * as React from 'react';
 
 import { ExecutionDetailsSection, IExecutionDetailsSectionProps } from 'core/pipeline/config/stages/core';
-import { NgReact } from 'core/reactShims';
+import { AccountTag } from 'core/account';
 import { StageExecutionLogs, StageFailureMessage } from 'core/pipeline/details';
 import { ServerGroupStageContext } from '../core/ServerGroupStageContext';
 
 export function DisableClusterExecutionDetails(props: IExecutionDetailsSectionProps) {
-  const { AccountTag } = NgReact;
   const { stage } = props;
   return (
     <ExecutionDetailsSection name={props.name} current={props.current}>

--- a/app/scripts/modules/core/src/pipeline/config/stages/findAmi/FindAmiExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/findAmi/FindAmiExecutionDetails.tsx
@@ -1,13 +1,12 @@
 import * as React from 'react';
 
 import { ExecutionDetailsSection, IExecutionDetailsSectionProps } from 'core/pipeline/config/stages/core';
-import { NgReact } from 'core/reactShims';
+import { AccountTag } from 'core/account';
 import { StageFailureMessage } from 'core/pipeline/details';
 
 import { IFindAmiStageContext } from './findAmiStage';
 
 export function FindAmiExecutionDetails(props: IExecutionDetailsSectionProps) {
-  const { AccountTag } = NgReact;
   const { stage } = props;
   const regions = stage.context && stage.context.regions && stage.context.regions.join(', ');
   return (

--- a/app/scripts/modules/core/src/pipeline/config/stages/rollbackCluster/RollbackClusterExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/rollbackCluster/RollbackClusterExecutionDetails.tsx
@@ -2,11 +2,10 @@ import * as React from 'react';
 
 import { ExecutionDetailsSection, IExecutionDetailsSectionProps } from 'core/pipeline/config/stages/core';
 import { HelpField } from 'core/help/HelpField';
-import { NgReact } from 'core/reactShims';
+import { AccountTag } from 'core/account';
 import { StageExecutionLogs, StageFailureMessage } from 'core/pipeline/details';
 
 export function RollbackClusterExecutionDetails(props: IExecutionDetailsSectionProps) {
-  const { AccountTag } = NgReact;
   const { stage } = props;
 
   const imagesToRestore = stage.context.imagesToRestore && stage.context.imagesToRestore.map((entry: any) => {

--- a/app/scripts/modules/core/src/pipeline/config/stages/scaleDownCluster/ScaleDownClusterExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/scaleDownCluster/ScaleDownClusterExecutionDetails.tsx
@@ -1,12 +1,11 @@
 import * as React from 'react';
 
 import { ExecutionDetailsSection, IExecutionDetailsSectionProps } from 'core/pipeline/config/stages/core';
-import { NgReact } from 'core/reactShims';
+import { AccountTag } from 'core/account';
 import { StageExecutionLogs, StageFailureMessage } from 'core/pipeline/details';
 import { ServerGroupStageContext } from '../core/ServerGroupStageContext';
 
 export function ScaleDownClusterExecutionDetails(props: IExecutionDetailsSectionProps) {
-  const { AccountTag } = NgReact;
   const { stage } = props;
   return (
     <ExecutionDetailsSection name={props.name} current={props.current}>

--- a/app/scripts/modules/core/src/pipeline/config/stages/shrinkCluster/ShrinkClusterExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/shrinkCluster/ShrinkClusterExecutionDetails.tsx
@@ -1,12 +1,11 @@
 import * as React from 'react';
 
 import { ExecutionDetailsSection, IExecutionDetailsSectionProps } from 'core/pipeline/config/stages/core';
-import { NgReact } from 'core/reactShims';
+import { AccountTag } from 'core/account';
 import { StageExecutionLogs, StageFailureMessage } from 'core/pipeline/details';
 import { ServerGroupStageContext } from '../core/ServerGroupStageContext';
 
 export function ShrinkClusterExecutionDetails(props: IExecutionDetailsSectionProps) {
-  const { AccountTag } = NgReact;
   const { stage } = props;
   return (
     <ExecutionDetailsSection name={props.name} current={props.current}>

--- a/app/scripts/modules/core/src/pipeline/executions/execution/Execution.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/execution/Execution.tsx
@@ -14,6 +14,7 @@ import { IExecutionViewState, IPipelineGraphNode } from 'core/pipeline/config/gr
 import { IScheduler } from 'core/scheduler/scheduler.factory';
 import { OrchestratedItemRunningTime } from './OrchestratedItemRunningTime';
 import { SETTINGS } from 'core/config/settings';
+import { AccountTag } from 'core/account';
 import { NgReact, ReactInjector } from 'core/reactShims';
 import { duration, timestamp } from 'core/utils/timeFormatters';
 
@@ -255,7 +256,7 @@ export class Execution extends React.Component<IExecutionProps, IExecutionState>
   }
 
   public render() {
-    const { AccountTag, CopyToClipboard } = NgReact;
+    const { CopyToClipboard } = NgReact;
     const accountLabels = this.props.execution.deploymentTargets.map((account) => (
       <AccountTag key={account} account={account}/>
     ));

--- a/app/scripts/modules/core/src/pipeline/executions/executionGroup/ExecutionGroup.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/executionGroup/ExecutionGroup.tsx
@@ -12,7 +12,8 @@ import { IExecution, IExecutionGroup, IPipeline, IPipelineCommand } from 'core/d
 import { NextRunTag } from 'core/pipeline/triggers/NextRunTag';
 import { Tooltip } from 'core/presentation/Tooltip';
 import { TriggersTag } from 'core/pipeline/triggers/TriggersTag';
-import { NgReact, ReactInjector } from 'core/reactShims';
+import { AccountTag } from 'core/account';
+import { ReactInjector } from 'core/reactShims';
 import { Spinner } from 'core/widgets/spinners/Spinner'
 
 import './executionGroup.less';
@@ -162,7 +163,6 @@ export class ExecutionGroup extends React.Component<IExecutionGroupProps, IExecu
   }
 
   public render(): React.ReactElement<ExecutionGroup> {
-    const { AccountTag } = NgReact;
     const group = this.props.group;
     const pipelineConfig = this.state.pipelineConfig;
     const pipelineDisabled = pipelineConfig && pipelineConfig.disabled;

--- a/app/scripts/modules/core/src/projects/projectSearchResultType.tsx
+++ b/app/scripts/modules/core/src/projects/projectSearchResultType.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import {
   searchResultTypeRegistry, BasicCell, HrefCell, ISearchResult, HeaderCell, ISearchResultType,
-  SearchResultTabComponent, SearchResultsHeaderComponent, SearchResultsDataComponent, DefaultSearchResultTab,
+  SearchResultsHeaderComponent, SearchResultsDataComponent, DefaultSearchResultTab,
   TableBody, TableHeader, TableRow, ISearchColumn,
 } from 'core/search';
 import { IProjectConfig } from 'core/domain';
@@ -37,10 +37,6 @@ const itemKeyFn = (item: IProjectSearchResult) => item.id;
 const itemSortFn = (a: IProjectSearchResult, b: IProjectSearchResult) =>
   a.name.localeCompare(b.name);
 
-const SearchResultTab: SearchResultTabComponent = ({ ...props }) => (
-  <DefaultSearchResultTab {...props} iconClass={iconClass} label={displayName} />
-);
-
 const SearchResultsHeader: SearchResultsHeaderComponent = () => (
   <TableHeader>
     <HeaderCell col={cols.NAME}/>
@@ -72,7 +68,7 @@ const projectsSearchResultType: ISearchResultType = {
     return project + applications;
   },
   components: {
-    SearchResultTab,
+    SearchResultTab: DefaultSearchResultTab,
     SearchResultsHeader,
     SearchResultsData,
   },

--- a/app/scripts/modules/core/src/reactShims/ngReact.ts
+++ b/app/scripts/modules/core/src/reactShims/ngReact.ts
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { angular2react } from 'angular2react';
 import IInjectorService = angular.auto.IInjectorService;
 import { AccountSelectFieldWrapperComponent } from '../account/accountSelectFieldWrapper.component';
-import { AccountTagComponent } from '../account/accountTag.component';
 import { AddEntityTagLinksWrapperComponent } from 'core/entityTag/addEntityTagLinks.component';
 import { ApplicationNavComponent } from 'core/application/nav/applicationNav.component';
 import { ApplicationNavSecondaryComponent } from 'core/application/nav/applicationNavSecondary.component';
@@ -11,7 +10,6 @@ import { ButtonBusyIndicatorComponent } from '../forms/buttonBusyIndicator/butto
 import { CopyToClipboardComponent } from '../utils/clipboard/copyToClipboard.component';
 import { DiffViewProps } from '../pipeline/config/actions/history/DiffView';
 import { HelpFieldWrapperComponent } from '../help/helpField.component';
-import { IAccountTagProps } from '../account/AccountTag';
 import { IApplicationNavProps } from 'core/application/nav/ApplicationNav';
 import { IApplicationNavSecondaryProps } from 'core/application/nav/ApplicationNavSecondary';
 import { IButtonBusyIndicatorProps } from '../forms/buttonBusyIndicator/ButtonBusyIndicator';
@@ -39,7 +37,6 @@ export class NgReactInjector extends ReactInject {
 
   // Reactified components
   public AccountSelectField: React.ComponentClass<IAccountSelectFieldProps>                   = angular2react('accountSelectFieldWrapper', new AccountSelectFieldWrapperComponent(), this.$injectorProxy) as any;
-  public AccountTag: React.ComponentClass<IAccountTagProps>                                   = angular2react('accountTag', new AccountTagComponent(), this.$injectorProxy) as any;
   public AddEntityTagLinks: React.ComponentClass<IAddEntityTagLinksProps>                     = angular2react('addEntityTagLinksWrapper', new AddEntityTagLinksWrapperComponent(), this.$injectorProxy) as any;
   public ApplicationNav: React.ComponentClass<IApplicationNavProps>                           = angular2react('applicationNav', new ApplicationNavComponent(), this.$injectorProxy) as any;
   public ApplicationNavSecondary: React.ComponentClass<IApplicationNavSecondaryProps>         = angular2react('applicationNavSecondary', new ApplicationNavSecondaryComponent(), this.$injectorProxy) as any;

--- a/app/scripts/modules/core/src/search/externalSearch.registry.ts
+++ b/app/scripts/modules/core/src/search/externalSearch.registry.ts
@@ -1,11 +1,15 @@
 import { IPromise } from 'angular';
-import { $q, $log } from 'ngimport';
+import { Observable } from 'rxjs';
+import { intersection, isUndefined } from 'lodash';
 
-import { urlBuilderRegistry } from 'core/navigation/urlBuilder.registry';
-import { IUrlBuilder } from 'core/navigation/urlBuilder.service';
+import { IQueryParams, IUrlBuilder, urlBuilderRegistry } from 'core/navigation';
+
 import { searchResultTypeRegistry } from './searchResult/searchResultsType.registry';
 import { ISearchResult } from './search.service';
 import { ISearchResultType } from './searchResult/searchResultsType.registry';
+import { ISearchResultSet } from './infrastructure/infrastructureSearch.service';
+import { SearchFilterTypeRegistry } from './widgets/SearchFilterTypeRegistry';
+import { SearchStatus } from './searchResult/SearchResults';
 
 /**
  * External search registry entries add a section to the infrastructure search
@@ -13,9 +17,9 @@ import { ISearchResultType } from './searchResult/searchResultsType.registry';
 export interface IExternalSearchConfig {
 
   /**
-   * Provides the display text of the search entry. Can include HTML
+   * The Search Result Type for this external search (registered in SearchResultTypeRegistry).
    */
-  searchResultType: ISearchResultType;
+  type: ISearchResultType;
 
   /**
    * Method to fetch search results
@@ -30,22 +34,47 @@ export interface IExternalSearchConfig {
 }
 
 export class ExternalSearchRegistry {
-  private registry: {[key: string]: IExternalSearchConfig} = {};
+  private registry: IExternalSearchConfig[] = [];
 
-  public register(searchConfig: IExternalSearchConfig) {
-    const type = searchConfig.searchResultType;
-    searchResultTypeRegistry.register(type);
-    urlBuilderRegistry.register(type.id, searchConfig.urlBuilder);
-    this.registry[type.id] = searchConfig;
+  public getAll(): IExternalSearchConfig[] {
+    return this.registry;
   }
 
-  public search(query: string): IPromise<ISearchResult[]> {
-    return $q.all(Object.keys(this.registry).map(k => this.registry[k].search(query)))
-      .then((searchResults: ISearchResult[][]) => [].concat.apply([], searchResults))
-      .catch((e) => {
-        $log.warn('External search error:', e);
-        return [];
+  public register(searchConfig: IExternalSearchConfig) {
+    const type = searchConfig.type;
+    searchResultTypeRegistry.register(type);
+    urlBuilderRegistry.register(type.id, searchConfig.urlBuilder);
+    this.registry.push(searchConfig);
+  }
+
+  public search(queryParams: IQueryParams): Observable<ISearchResultSet> {
+    const query = queryParams.q as string;
+
+    // Returns true if the result object's values matches all the parameter values
+    // Only accounts for parameters which are registered in SearchFilterTypeRegistry
+    const matchesAllFilterKeys = (result: ISearchResult, params: IQueryParams) => {
+      const filterKeys: string[] = intersection(SearchFilterTypeRegistry.getRegisteredFilterKeys(), Object.keys(params));
+      return filterKeys.every(filterKey => {
+        const resultVal: string = (result as any)[filterKey];
+        return isUndefined(resultVal) || resultVal === params[filterKey];
       });
+    };
+
+    return Observable.from(this.registry).mergeMap(config => {
+      const { type } = config;
+
+      if (!queryParams.q) {
+        return Observable.of({ type, results: [], status: SearchStatus.NO_RESULTS });
+      }
+
+      return Observable.fromPromise(config.search(query))
+        // Perform additional client-side filtering of results after fetch completes
+        .map(results => results.filter(result => matchesAllFilterKeys(result, queryParams)))
+        .map(results => ({ type, results, status: SearchStatus.FINISHED }))
+        .catch(error => {
+          return Observable.of({ error, type, results: [], status: SearchStatus.ERROR });
+        });
+    });
   }
 }
 

--- a/app/scripts/modules/core/src/search/infrastructure/SearchResult.tsx
+++ b/app/scripts/modules/core/src/search/infrastructure/SearchResult.tsx
@@ -1,7 +1,7 @@
 import * as DOMPurify from 'dompurify';
 import * as React from 'react';
 
-import { NgReact } from 'core/reactShims';
+import { AccountTag } from 'core/account';
 import { IRecentHistoryEntry } from 'core/history';
 
 export interface ISearchResultProps {
@@ -10,7 +10,6 @@ export interface ISearchResultProps {
 
 export class SearchResult extends React.Component<ISearchResultProps> {
   public render() {
-    const { AccountTag } = NgReact;
     const { item } = this.props;
     const params = item.params || {};
     const account = item.account || params.account || params.accountId || params.accountName;

--- a/app/scripts/modules/core/src/search/infrastructure/SearchV2.tsx
+++ b/app/scripts/modules/core/src/search/infrastructure/SearchV2.tsx
@@ -149,7 +149,8 @@ export class SearchV2 extends React.Component<{}, ISearchV2State> {
   }
 
   public handleFilterChange(filters: ITag[]) {
-    const newParams = filters.reduce((params, filter) => ({ ...params, [filter.key]:  filter.text }), {});
+    const blankApiParams = API_PARAMS.reduce((acc, key) => ({ ...acc, [key]: undefined }), {});
+    const newParams = filters.reduce((params, filter) => ({ ...params, [filter.key]:  filter.text }), blankApiParams);
     this.$state.go('.', newParams, { location: 'replace' });
   }
 

--- a/app/scripts/modules/core/src/search/infrastructure/infrastructure.states.ts
+++ b/app/scripts/modules/core/src/search/infrastructure/infrastructure.states.ts
@@ -13,13 +13,13 @@ module(INFRASTRUCTURE_STATES, [
     name: 'search',
     url: '/search?q&key&tab&name&account&region&stack',
     params: {
-      account: { dynamic: true, inherit: false, value: null },
-      key:     { dynamic: true, inherit: false, value: null },
-      name:    { dynamic: true, inherit: false, value: null },
-      q:       { dynamic: true, inherit: false, value: null },
-      region:  { dynamic: true, inherit: false, value: null },
-      stack:   { dynamic: true, inherit: false, value: null },
-      tab:     { dynamic: true, inherit: true,  value: 'applications' },
+      account: { dynamic: true, value: null },
+      key:     { dynamic: true, value: null },
+      name:    { dynamic: true, value: null },
+      q:       { dynamic: true, value: null },
+      region:  { dynamic: true, value: null },
+      stack:   { dynamic: true, value: null },
+      tab:     { dynamic: true, value: 'applications' },
     },
     views: {
       'main@': {

--- a/app/scripts/modules/core/src/search/infrastructure/infrastructure.states.ts
+++ b/app/scripts/modules/core/src/search/infrastructure/infrastructure.states.ts
@@ -14,12 +14,12 @@ module(INFRASTRUCTURE_STATES, [
     url: '/search?q&key&tab&name&account&region&stack',
     params: {
       account: { dynamic: true, inherit: false, value: null },
-      key: { dynamic: true, inherit: false, value: null },
-      name: { dynamic: true, inherit: false, value: null },
-      q: { dynamic: true, inherit: false, value: null },
-      region: { dynamic: true, inherit: false, value: null },
-      stack: { dynamic: true, inherit: false, value: null },
-      tab: { dynamic: true, inherit: true, value: null },
+      key:     { dynamic: true, inherit: false, value: null },
+      name:    { dynamic: true, inherit: false, value: null },
+      q:       { dynamic: true, inherit: false, value: null },
+      region:  { dynamic: true, inherit: false, value: null },
+      stack:   { dynamic: true, inherit: false, value: null },
+      tab:     { dynamic: true, inherit: true,  value: 'applications' },
     },
     views: {
       'main@': {

--- a/app/scripts/modules/core/src/search/infrastructure/search.infrastructure.module.js
+++ b/app/scripts/modules/core/src/search/infrastructure/search.infrastructure.module.js
@@ -4,7 +4,6 @@ import { PROJECT_SUMMARY_POD_COMPONENT } from './projectSummaryPod.component';
 import { RECENTLY_VIEWED_ITEMS_COMPONENT } from './recentlyViewedItems.component';
 import { SEARCH_COMPONENT } from '../widgets/search.component';
 import { SEARCH_INFRASTRUCTURE_V2_CONTROLLER } from './infrastructureSearchV2.component';
-import { SEARCH_RESULTS_COMPONENT } from '../searchResult/searchResults.component';
 import { SEARCH_RESULT_COMPONENT } from './searchResult.component';
 import { SEARCH_RESULT_PODS_COMPONENT } from './searchResultPods.component';
 
@@ -17,7 +16,6 @@ module(SEARCH_INFRASTRUCTURE, [
   RECENTLY_VIEWED_ITEMS_COMPONENT,
   SEARCH_COMPONENT,
   SEARCH_INFRASTRUCTURE_V2_CONTROLLER,
-  SEARCH_RESULTS_COMPONENT,
   SEARCH_RESULT_COMPONENT,
   SEARCH_RESULT_PODS_COMPONENT,
 ]);

--- a/app/scripts/modules/core/src/search/searchResult/DefaultSearchResultTab.tsx
+++ b/app/scripts/modules/core/src/search/searchResult/DefaultSearchResultTab.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import * as classNames from 'classnames';
 
 import { Spinner } from 'core/widgets';
 import { Tooltip } from 'core/presentation';
@@ -22,12 +21,6 @@ export class DefaultSearchResultTab extends React.Component<ISearchResultTabProp
     const resultsCount = results.length;
     const countLabel = resultsCount < SearchService.DEFAULT_PAGE_SIZE ? `${resultsCount}` : `${resultsCount}+`;
 
-    const className = classNames({
-      'search-group': true,
-      'search-group--focus': isActive,
-      'search-group--blur': !isActive,
-    });
-
     const Badge = () => {
       switch (status) {
         case SearchStatus.SEARCHING:
@@ -49,11 +42,13 @@ export class DefaultSearchResultTab extends React.Component<ISearchResultTabProp
       }
     };
 
+    const focusOrBlurClass = isActive ? 'search-group--focus' : 'search-group--blur';
+
     return (
-      <div className={className}>
-        <span className={`search-group-icon ${iconClass}`}/>
-        <div className="search-group-name">{type.displayName}</div>
-        <Badge/>
+      <div className={`flex-container-h baseline search-group ${focusOrBlurClass}`}>
+        <span className={`flex-nogrow search-group-icon ${iconClass}`}/>
+        <div className="flex-grow search-group-name">{type.displayName}</div>
+        <div className="flex-nogrow"><Badge/></div>
       </div>
     );
   }

--- a/app/scripts/modules/core/src/search/searchResult/DefaultSearchResultTab.tsx
+++ b/app/scripts/modules/core/src/search/searchResult/DefaultSearchResultTab.tsx
@@ -1,43 +1,59 @@
 import * as React from 'react';
 import * as classNames from 'classnames';
-import { BindAll } from 'lodash-decorators';
 
-import { SearchService } from 'core/search/search.service';
-import { ISearchResultType } from 'core';
+import { Spinner } from 'core/widgets';
+import { Tooltip } from 'core/presentation';
+
+import { SearchService } from '../search.service';
+import { ISearchResultSet } from '../infrastructure/infrastructureSearch.service';
+import { SearchStatus } from './SearchResults';
 
 export interface ISearchResultTabProps {
-  type: ISearchResultType;
-  resultsCount: number;
+  resultSet: ISearchResultSet;
   isActive: boolean;
-  onClick: (group: ISearchResultType) => void;
-  iconClass?: string;
-  label?: string;
 }
 
-@BindAll()
 export class DefaultSearchResultTab extends React.Component<ISearchResultTabProps> {
-  private handleClick(): void {
-    const { type, resultsCount, onClick } = this.props;
-    resultsCount && onClick && onClick(type);
-  }
-
   public render() {
-    const { isActive, type, resultsCount } = this.props;
+    const { isActive, resultSet } = this.props;
+    const { type, results, status, error } = resultSet;
+
     const iconClass = type.iconClass;
+    const resultsCount = results.length;
     const countLabel = resultsCount < SearchService.DEFAULT_PAGE_SIZE ? `${resultsCount}` : `${resultsCount}+`;
 
     const className = classNames({
       'search-group': true,
       'search-group--focus': isActive,
       'search-group--blur': !isActive,
-      'faded': resultsCount === 0
     });
 
+    const Badge = () => {
+      switch (status) {
+        case SearchStatus.SEARCHING:
+          return <Spinner size="small"/>;
+
+        case SearchStatus.ERROR:
+          return (
+            <Tooltip value={error && error.toString()}>
+              <i className="fa fa-exclamation-triangle"/>
+            </Tooltip>
+          );
+
+        default:
+          if (results.length) {
+            return <div className="badge">{countLabel}</div>;
+          }
+
+          return <div className="badge faded">{countLabel}</div>
+      }
+    };
+
     return (
-      <div className={className} onClick={this.handleClick}>
+      <div className={className}>
         <span className={`search-group-icon ${iconClass}`}/>
         <div className="search-group-name">{type.displayName}</div>
-        <div className="badge">{countLabel}</div>
+        <Badge/>
       </div>
     );
   }

--- a/app/scripts/modules/core/src/search/searchResult/PostSearchResultSearcherRegistry.ts
+++ b/app/scripts/modules/core/src/search/searchResult/PostSearchResultSearcherRegistry.ts
@@ -1,10 +1,9 @@
 import { IPromise } from 'angular';
 
 import { ISearchResultSet } from '../infrastructure/infrastructureSearch.service';
-import { ISearchResult } from '../search.service';
 
-export interface IPostSearchResultSearcher<T extends ISearchResult> {
-  getPostSearchResults: (inputs: T[]) => IPromise<ISearchResultSet[]>
+export interface IPostSearchResultSearcher {
+  getPostSearchResults: (sourceData: ISearchResultSet) => IPromise<ISearchResultSet>
 }
 
 export interface ITypeMapping {
@@ -13,20 +12,17 @@ export interface ITypeMapping {
 }
 
 export class SearchResultSearcherRegistry {
-
-  private searcherRegistry: Map<string, IPostSearchResultSearcher<ISearchResult>> =
-    new Map<string, IPostSearchResultSearcher<ISearchResult>>();
-
+  private searcherRegistry: Map<string, IPostSearchResultSearcher> = new Map<string, IPostSearchResultSearcher>();
   private typeMappingRegistry: Map<string, string> = new Map<string, string>();
 
-  public register<T extends ISearchResult>(sourceType: string,
-                                           targetType: string,
-                                           searcher: IPostSearchResultSearcher<T>): void {
+  public register(sourceType: string,
+                  targetType: string,
+                  searcher: IPostSearchResultSearcher): void {
     this.searcherRegistry.set(sourceType, searcher);
     this.typeMappingRegistry.set(sourceType, targetType);
   }
 
-  public getPostResultSearcher<T extends ISearchResult>(type: string): IPostSearchResultSearcher<T> {
+  public getPostResultSearcher(type: string): IPostSearchResultSearcher {
     return this.searcherRegistry.get(type);
   }
 

--- a/app/scripts/modules/core/src/search/searchResult/Renderers.tsx
+++ b/app/scripts/modules/core/src/search/searchResult/Renderers.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { startCase, kebabCase } from 'lodash';
 
-import { NgReact } from 'core/reactShims';
+import { AccountTag } from 'core/account';
 import { Spinner } from 'core/widgets';
 import { IInstanceCounts } from 'core/domain';
 import { HealthCounts } from 'core/healthCounts';
@@ -90,7 +90,6 @@ export class HrefCell extends React.Component<ICellRendererProps> {
 
 export class AccountCell extends React.Component<ICellRendererProps> {
   public render() {
-    const { AccountTag } = NgReact;
     const { item, col } = this.props;
 
     const value: string | string[] = item[col.key];

--- a/app/scripts/modules/core/src/search/searchResult/SearchResultTabs.tsx
+++ b/app/scripts/modules/core/src/search/searchResult/SearchResultTabs.tsx
@@ -1,36 +1,32 @@
 import * as React from 'react';
-import { BindAll } from 'lodash-decorators';
+import { UISref } from '@uirouter/react';
+import { UIRouterContext } from '@uirouter/react-hybrid';
 
-import { ISearchResultData } from 'core/search/searchResult/SearchResults';
 import { ISearchResultType } from './searchResultsType.registry';
+import { ISearchResultSet } from '../infrastructure/infrastructureSearch.service';
 
 export interface ISearchResultTabsProps {
-  searchResultData: ISearchResultData[]
+  resultSets: ISearchResultSet[]
   activeSearchResultType: ISearchResultType;
-  onClick?: (group: ISearchResultType) => void;
 }
 
-@BindAll()
+@UIRouterContext
 export class SearchResultTabs extends React.Component<ISearchResultTabsProps> {
-  private handleClick(type: ISearchResultType) {
-    this.props.onClick && this.props.onClick(type);
-  }
-
   public render(): React.ReactElement<SearchResultTabs> {
-    const { searchResultData, activeSearchResultType } = this.props;
+    const { activeSearchResultType } = this.props;
+    const resultSets = this.props.resultSets.slice().sort((a, b) => a.type.order - b.type.order);
 
     return (
       <div className="search-groups">
-        {searchResultData.map(({ type, results }) => {
+        {resultSets.map(resultSet => {
+          const { type } = resultSet;
           const { SearchResultTab } = type.components;
+          const active = type === activeSearchResultType;
+
           return (
-            <SearchResultTab
-              key={type.id}
-              type={type}
-              resultsCount={results.length}
-              isActive={type === activeSearchResultType}
-              onClick={this.handleClick}
-            />
+            <UISref key={type.id} to="." params={{ tab: type.id }}>
+              <a><SearchResultTab resultSet={resultSet} isActive={active} /></a>
+            </UISref>
           );
         })}
       </div>

--- a/app/scripts/modules/core/src/search/searchResult/SearchResultTabs.tsx
+++ b/app/scripts/modules/core/src/search/searchResult/SearchResultTabs.tsx
@@ -17,7 +17,7 @@ export class SearchResultTabs extends React.Component<ISearchResultTabsProps> {
     const resultSets = this.props.resultSets.slice().sort((a, b) => a.type.order - b.type.order);
 
     return (
-      <div className="search-groups">
+      <ul className="search-groups nostyle">
         {resultSets.map(resultSet => {
           const { type } = resultSet;
           const { SearchResultTab } = type.components;
@@ -25,11 +25,11 @@ export class SearchResultTabs extends React.Component<ISearchResultTabsProps> {
 
           return (
             <UISref key={type.id} to="." params={{ tab: type.id }}>
-              <a><SearchResultTab resultSet={resultSet} isActive={active} /></a>
+              <li><SearchResultTab resultSet={resultSet} isActive={active} /></li>
             </UISref>
           );
         })}
-      </div>
+      </ul>
     );
   }
 }

--- a/app/scripts/modules/core/src/search/searchResult/searchResults.component.ts
+++ b/app/scripts/modules/core/src/search/searchResult/searchResults.component.ts
@@ -1,8 +1,0 @@
-import { module } from 'angular';
-import { react2angular } from 'react2angular';
-
-import { SearchResults } from './SearchResults';
-
-export const SEARCH_RESULTS_COMPONENT = 'spinnaker.core.search.results.component';
-module(SEARCH_RESULTS_COMPONENT, [])
-  .component('searchResults', react2angular(SearchResults, ['searchStatus', 'searchResultTypes', 'searchResultCategories', 'searchResultProjects']));

--- a/app/scripts/modules/core/src/search/searchResult/searchResults.less
+++ b/app/scripts/modules/core/src/search/searchResult/searchResults.less
@@ -4,6 +4,9 @@
 @import "~core/search/searchResult/baseTable.less";
 
 .search-results {
+  .faded {
+    opacity: 0.2;
+  }
 
   display: flex;
   margin-top: 10px;
@@ -16,17 +19,15 @@
     width: 275px;
 
     .search-group {
+      > * {
+        flex: 0 0 auto;
+      }
 
       align-items: baseline;
       .clickable();
       display: flex;
       padding: 10px;
       margin-bottom: 1px;
-
-      &.faded {
-        opacity: 0.2;
-        cursor: not-allowed;
-      }
 
       .search-group-icon {
         background-color: var(--color-primary);
@@ -43,10 +44,13 @@
 
       .search-group-name {
         color: var(--color-primary);
-        flex: 1 0 auto;
+        flex: 1 1 auto;
         font-size: 110%;
         font-weight: 600;
         text-transform: uppercase;
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
       }
 
       .badge {

--- a/app/scripts/modules/core/src/search/searchResult/searchResults.less
+++ b/app/scripts/modules/core/src/search/searchResult/searchResults.less
@@ -19,13 +19,7 @@
     width: 275px;
 
     .search-group {
-      > * {
-        flex: 0 0 auto;
-      }
-
-      align-items: baseline;
       .clickable();
-      display: flex;
       padding: 10px;
       margin-bottom: 1px;
 
@@ -44,7 +38,6 @@
 
       .search-group-name {
         color: var(--color-primary);
-        flex: 1 1 auto;
         font-size: 110%;
         font-weight: 600;
         text-transform: uppercase;
@@ -69,6 +62,7 @@
       &:hover {
         background-color: var(--color-accent-g2);
         transition: all 0.15s ease-in-out;
+
         &.faded {
           background-color: var(--color-alabaster);
         }
@@ -77,8 +71,6 @@
   }
 
   .search-result-grid {
-
-    flex: 1 0 auto;
     padding-left: 15px;
 
     .small {

--- a/app/scripts/modules/core/src/search/searchResult/searchResultsType.registry.ts
+++ b/app/scripts/modules/core/src/search/searchResult/searchResultsType.registry.ts
@@ -1,4 +1,4 @@
-import { ISearchResult } from 'core/search';
+import { ISearchResult } from '../search.service';
 import { ISearchResultTabProps } from './DefaultSearchResultTab';
 
 export interface IResultDisplayFormatter {

--- a/app/scripts/modules/core/src/search/widgets/Search.tsx
+++ b/app/scripts/modules/core/src/search/widgets/Search.tsx
@@ -2,14 +2,14 @@ import * as React from 'react';
 import * as classNames from 'classnames';
 import { BindAll } from 'lodash-decorators';
 
-import { Key } from 'core/widgets/Keys';
-import { ITag } from 'core/widgets/tags/Tag';
-import { TagList } from 'core/widgets/tags/TagList';
-import { Filters, IFiltersLayout } from './Filters';
+import { Key, ITag, TagList } from 'core/widgets';
+
 import { IFilterType, SearchFilterTypeRegistry } from './SearchFilterTypeRegistry';
+import { Filters, IFiltersLayout } from './Filters';
+import { Filter } from './Filter';
 
 import './search.less';
-import { Filter } from 'core';
+
 
 export interface ISearchProps {
   params: { [key: string]: any };
@@ -85,10 +85,6 @@ export class Search extends React.Component<ISearchProps, ISearchState> {
       .map(key => ({ key, text: params[key] }));
 
     return tagsToKeep.concat(tagsToAdd);
-  }
-
-  private isTagAlreadyPresent(tag: ITag): boolean {
-    return this.state.tags.some((t: ITag) => t.key === tag.key && t.text === tag.text);
   }
 
   private isLongEnoughIfKeyword(tag: ITag): boolean {
@@ -217,8 +213,8 @@ export class Search extends React.Component<ISearchProps, ISearchState> {
 
   private handleFilterSelection(filter?: IFilterType): void {
     const tag = this.buildTagFromInputString(filter);
-    if (tag && !this.isTagAlreadyPresent(tag) && this.isLongEnoughIfKeyword(tag)) {
-      const tags: ITag[] = this.state.tags.concat(tag);
+    if (tag && this.isLongEnoughIfKeyword(tag)) {
+      const tags: ITag[] = this.state.tags.filter(x => x.key !== tag.key).concat(tag);
       this.setState({
         activeFilter: SearchFilterTypeRegistry.KEYWORD_FILTER,
         isOpen: false,

--- a/app/scripts/modules/core/src/securityGroup/securityGroupSearchResultType.tsx
+++ b/app/scripts/modules/core/src/securityGroup/securityGroupSearchResultType.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import {
   AccountCell, BasicCell, HrefCell, searchResultTypeRegistry, ISearchColumn, ISearchResultType,
-  SearchResultTabComponent, SearchResultsHeaderComponent, SearchResultsDataComponent, DefaultSearchResultTab,
+  SearchResultsHeaderComponent, SearchResultsDataComponent, DefaultSearchResultTab,
   ISearchResult, HeaderCell, TableBody, TableHeader, TableRow,
 } from 'core/search';
 
@@ -35,10 +35,6 @@ const itemSortFn = (a: ISecurityGroupSearchResult, b: ISecurityGroupSearchResult
   return order !== 0 ? order : a.region.localeCompare(b.region);
 };
 
-const SearchResultTab: SearchResultTabComponent = ({ ...props }) => (
-  <DefaultSearchResultTab {...props} iconClass={iconClass} label={displayName} />
-);
-
 const SearchResultsHeader: SearchResultsHeaderComponent = () => (
   <TableHeader>
     <HeaderCell col={cols.NAME}/>
@@ -66,7 +62,7 @@ const securityGroupsSearchResultType: ISearchResultType = {
   order: 6,
   displayFormatter: (searchResult: ISecurityGroupSearchResult) => `${searchResult.name} (${searchResult.region})`,
   components: {
-    SearchResultTab,
+    SearchResultTab: DefaultSearchResultTab,
     SearchResultsHeader,
     SearchResultsData,
   },

--- a/app/scripts/modules/core/src/serverGroup/serverGroupSearchResultType.tsx
+++ b/app/scripts/modules/core/src/serverGroup/serverGroupSearchResultType.tsx
@@ -1,14 +1,13 @@
 import * as React from 'react';
 import { Observable, Subject, BehaviorSubject } from 'rxjs';
 
-import {
-  AccountCell, BasicCell, HrefCell, HealthCountsCell, searchResultTypeRegistry, ISearchColumn, ISearchResultType,
-  SearchResultTabComponent, SearchResultsHeaderComponent, SearchResultsDataComponent, DefaultSearchResultTab,
-  ISearchResult, HeaderCell, TableBody, TableHeader, TableRow,
-} from 'core/search';
-
 import { ReactInjector } from 'core/reactShims';
 import { IServerGroup, IInstanceCounts } from 'core/domain';
+import {
+  AccountCell, BasicCell, HrefCell, HealthCountsCell, searchResultTypeRegistry, ISearchColumn, ISearchResultType,
+  SearchResultsHeaderComponent, SearchResultsDataComponent, DefaultSearchResultTab,
+  ISearchResult, HeaderCell, TableBody, TableHeader, TableRow,
+} from 'core/search';
 
 import './serverGroup.less';
 
@@ -43,10 +42,6 @@ const itemSortFn = (a: IServerGroupSearchResult, b: IServerGroupSearchResult) =>
   const order = a.serverGroup.localeCompare(b.serverGroup);
   return order !== 0 ? order : a.region.localeCompare(b.region);
 };
-
-const SearchResultTab: SearchResultTabComponent = ({ ...props }) => (
-  <DefaultSearchResultTab {...props} iconClass={iconClass} label={displayName} />
-);
 
 const SearchResultsHeader: SearchResultsHeaderComponent = () => (
   <TableHeader>
@@ -167,12 +162,12 @@ const AddHealthCounts = (Component: SearchResultsDataComponent<IServerGroupSearc
 
 const serverGroupSearchResultType: ISearchResultType = {
   id: 'serverGroups',
-  order: 6,
+  order: 3,
   iconClass,
   displayName,
   displayFormatter: (searchResult: IServerGroupSearchResult) => `${searchResult.serverGroup} (${searchResult.region})`,
   components: {
-    SearchResultTab,
+    SearchResultTab: DefaultSearchResultTab,
     SearchResultsHeader,
     SearchResultsData: AddHealthCounts(SearchResultsData),
   },

--- a/app/scripts/modules/core/src/widgets/cluster/ClusterMatches.tsx
+++ b/app/scripts/modules/core/src/widgets/cluster/ClusterMatches.tsx
@@ -1,19 +1,18 @@
 import * as React from 'react';
 import { IClusterMatch } from './clusterMatches.component';
-import { NgReact } from 'core/reactShims/ngReact';
+import { AccountTag } from 'core/account';
 
 export interface IClusterMatchesProps {
   matches: IClusterMatch[]
 }
 
 export class ClusterMatches extends React.Component<IClusterMatchesProps> {
-
   public render() {
     const { matches } = this.props;
-    const { AccountTag } = NgReact;
     if (!matches || !matches.length) {
-      return (<div>(no matches)</div>);
+      return <div>(no matches)</div>;
     }
+
     return (
       <ul className="nostyle">
         {matches.map((match: IClusterMatch, index: number) => (

--- a/app/scripts/modules/core/src/widgets/tags/TagList.tsx
+++ b/app/scripts/modules/core/src/widgets/tags/TagList.tsx
@@ -18,7 +18,6 @@ export interface ITagListProps {
 
 @BindAll()
 export class TagList extends React.Component<ITagListProps> {
-
   public static defaultProps: Partial<ITagListProps> = {
     onBlur: () => {},
     onDelete: () => {},
@@ -107,25 +106,23 @@ export class TagList extends React.Component<ITagListProps> {
     }
   }
 
-  private generateTagElement(tag: ITag): JSX.Element {
-    return (
-      <Tag
-        key={[tag.key, tag.text].join('|')}
-        tag={tag}
-        onBlur={this.handleBlur}
-        onCreate={this.handleCreate}
-        onDelete={this.handleDelete}
-        onFocus={this.handleFocus}
-        onKeyUp={this.handleKeyUp}
-      />
-    );
-  }
-
   public render(): React.ReactElement<TagList> {
+    const tags = this.props.tags || [];
 
-    const tags = (this.props.tags || []).map((tag: ITag) => this.generateTagElement(tag));
     return (
-      <div className="tag-list">{tags}</div>
+      <div className="tag-list">
+        {tags.map(tag => (
+          <Tag
+            key={[tag.key, tag.text].join('|')}
+            tag={tag}
+            onBlur={this.handleBlur}
+            onCreate={this.handleCreate}
+            onDelete={this.handleDelete}
+            onFocus={this.handleFocus}
+            onKeyUp={this.handleKeyUp}
+          />
+        ))}
+      </div>
     );
   }
 }


### PR DESCRIPTION
Also:
- Refactored the search fetching to RxJS
- Refactored search types to reference the `DefaultSearchResultTab` directly
- Track current tab as a URL parameter

Housekeeping TODOs:
- Consolidate internal/external/derived search types and getInternalSearchResultTypesForParams, etc
- Fix application search (do not derive from servergroups)

Feature TODOs:
- Sorting
- Elastic Search
  - instance type search
  - etc
