### PR TITLE
fix(core): use small loader instead of nano on task monitor

### DIFF
--- a/app/scripts/modules/core/src/task/monitor/taskMonitorStatus.component.js
+++ b/app/scripts/modules/core/src/task/monitor/taskMonitorStatus.component.js
@@ -16,7 +16,7 @@ module.exports = angular
           </li>
         </ul>
         <ul class="task task-progress task-progress-running" ng-if="$ctrl.monitor.task.isActive">
-          <li><loading-spinner size="'nano'"></loading-spinner></li>
+          <li><loading-spinner size="'small'"></loading-spinner></li>
         </ul>
         <ul class="task task-progress task-progress-refresh" ng-if="$ctrl.monitor.task.isCompleted">
           <li>


### PR DESCRIPTION
This loader sits on its own line, so should be three bars, not one