### PR TITLE
fix(provider/kubernetes) - manifests can be provided now through artifacts

### DIFF
--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestStage.ts
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestStage.ts
@@ -30,8 +30,7 @@ module(KUBERNETES_DEPLOY_MANIFEST_STAGE, [
       executionDetailsUrl: require('./deployManifestExecutionDetails.html'),
       executionConfigSections: ['deployStatus', 'taskStatus'],
       validators: [
-        { type: 'requiredField', fieldName: 'moniker.cluster', fieldLabel: 'Cluster' },
-        { type: 'requiredField', fieldName: 'manifest', fieldLabel: 'Manifest' }
+        { type: 'requiredField', fieldName: 'moniker.cluster', fieldLabel: 'Cluster' }
       ],
     });
   }


### PR DESCRIPTION
Manifests can be provider through artifacts so this field is now optional.