### PR TITLE
fix(core/amazon): wrap spinner size in quotes

### DIFF
--- a/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/chart/metricAlarmChart.component.html
+++ b/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/chart/metricAlarmChart.component.html
@@ -2,7 +2,7 @@
   <h5 class="text-center">
     <span ng-if="$ctrl.chartData.noData">No data available</span>
     <span ng-if="$ctrl.chartData.loading">
-      <loading-spinner size="small" message="loading..."></loading-spinner>
+      <loading-spinner size="'medium'"></loading-spinner>
     </span>
   </h5>
 </div>

--- a/app/scripts/modules/core/src/pipeline/config/stages/executionWindows/atlasGraph.component.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/executionWindows/atlasGraph.component.ts
@@ -316,7 +316,7 @@ class AtlasGraphComponent implements ng.IComponentOptions {
           <div class="no-data-overlay" ng-if="$ctrl.chartData.loading || $ctrl.chartData.noData">
             <h5 class="text-center">
               <span ng-if="$ctrl.chartData.loading">
-                <loading-spinner size="'small'" message="'loading...'"></loading-spinner>
+                <loading-spinner size="'medium'"></loading-spinner>
               </span>
             </h5>
           </div>


### PR DESCRIPTION
The size and message attributes need to be wrapped in single quotes when used in as an Angular component.

Also changing these two to size medium, which includes the the "loading..." message and centers the loading bar.

@archana-s what do you think about center-aligning the small loader?