### PR TITLE
fix(provider/openstack): Subnet list now updates on region change

### DIFF
--- a/app/scripts/modules/openstack/src/serverGroup/configure/wizard/location/ServerGroupBasicSettings.controller.js
+++ b/app/scripts/modules/openstack/src/serverGroup/configure/wizard/location/ServerGroupBasicSettings.controller.js
@@ -39,6 +39,11 @@ module.exports = angular.module('spinnaker.serverGroup.configure.openstack.basic
       $scope.subnetFilter.region = $scope.command.region;
     });
 
+    $scope.$watch('command.region', function(region) {
+      $scope.subnetFilter.account = $scope.command.credentials;
+      $scope.subnetFilter.region = region;
+    });
+
     $scope.$watch('basicSettings.$valid', function(newVal) {
       if (newVal) {
         v2modalWizardService.markClean('location');


### PR DESCRIPTION
Previously, when changing the region when creating a new openstack server group the subnet list did not update. This is because there wasn't a watch on the region changing. This has now been fixed.