### PR TITLE
fix(provider/gce): Fix search endpoint calls.

### DIFF
--- a/app/scripts/modules/google/src/address/address.reader.ts
+++ b/app/scripts/modules/google/src/address/address.reader.ts
@@ -40,7 +40,7 @@ class GceAddressReader {
       return this.listAddresses(null /* region */).then(addresses => addresses.filter(address => address.region === region));
     } else {
       return this.searchService
-        .search<IAddressSearchResults>({ q: '', type: 'addresses' }, this.infrastructureCaches.get('addresses'))
+        .search<IAddressSearchResults>({ q: '***', type: 'addresses' }, this.infrastructureCaches.get('addresses'))
         .then((searchResults: ISearchResults<IAddressSearchResults>) => {
           if (searchResults && searchResults.results) {
             return searchResults.results

--- a/app/scripts/modules/google/src/backendService/backendService.reader.js
+++ b/app/scripts/modules/google/src/backendService/backendService.reader.js
@@ -14,7 +14,11 @@ module.exports = angular.module('spinnaker.deck.gce.backendService.reader.servic
       if (kind) {
         return listBackendServices()
           .then(([services]) => {
-            return services.results.filter((service) => service.kind === kind);
+            if (services) {
+              let results = services.results || [];
+              return results.filter((service) => service.kind === kind);
+            }
+            return [];
           });
       } else {
         return API

--- a/app/scripts/modules/google/src/certificate/certificate.reader.ts
+++ b/app/scripts/modules/google/src/certificate/certificate.reader.ts
@@ -20,7 +20,7 @@ export class GceCertificateReader {
 
   public listCertificates(): IPromise<IGceCertificate[]> {
     return this.searchService
-      .search<IGceCertificate>({ q: '', type: 'sslCertificates' }, this.infrastructureCaches.get('certificates'))
+      .search<IGceCertificate>({ q: '***', type: 'sslCertificates' }, this.infrastructureCaches.get('certificates'))
       .then((searchResults: ISearchResults<IGceCertificate>) => {
         if (searchResults && searchResults.results) {
           return searchResults.results.filter(certificate => certificate.provider === 'gce');

--- a/app/scripts/modules/google/src/healthCheck/healthCheck.read.service.ts
+++ b/app/scripts/modules/google/src/healthCheck/healthCheck.read.service.ts
@@ -28,7 +28,7 @@ export class GceHealthCheckReader {
       return this.listHealthChecks().then(healthChecks => healthChecks.filter(healthCheck => healthCheck.healthCheckType === type));
     } else {
       return this.searchService
-        .search({ q: '', type: 'healthChecks' }, this.infrastructureCaches.get('healthChecks'))
+        .search({ q: '***', type: 'healthChecks' }, this.infrastructureCaches.get('healthChecks'))
         .then((searchResults: ISearchResults<IHealthCheckSearchResults>) => {
           if (searchResults && searchResults.results) {
             const healthChecks = searchResults.results.filter(result => result.provider === 'gce')


### PR DESCRIPTION
We previously used /search to query the infrastructure caches and
suggest several types of components in the UI. There was a recently
added constraint that requires /search queries to provide a string
`>=` length 3, which broke our cache queries. This change is a temporary
fix/workaround to fix the contract breakage.