### PR TITLE
feat(core): Indicate templated pipelines

### DIFF
--- a/app/scripts/modules/core/src/domain/IExecution.ts
+++ b/app/scripts/modules/core/src/domain/IExecution.ts
@@ -25,6 +25,7 @@ export interface IExecution extends IOrchestratedItem {
   stringVal?: string;
   trigger: IExecutionTrigger;
   user: string;
+  fromTemplate?: boolean;
 }
 
 export interface IExecutionGroup {
@@ -33,5 +34,5 @@ export interface IExecutionGroup {
   heading: string;
   runningExecutions?: IExecution[];
   targetAccounts?: string[];
+  fromTemplate?: boolean;
 }
-

--- a/app/scripts/modules/core/src/domain/IPipeline.ts
+++ b/app/scripts/modules/core/src/domain/IPipeline.ts
@@ -19,6 +19,7 @@ export interface IPipeline {
   parameterConfig: IParameter[];
   disabled?: boolean;
   expectedArtifacts?: IExpectedArtifact[];
+  type?: string;
 }
 
 export interface IParameter {

--- a/app/scripts/modules/core/src/pipeline/executions/execution/Execution.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/execution/Execution.tsx
@@ -289,12 +289,14 @@ export class Execution extends React.Component<IExecutionProps, IExecutionState>
           { this.props.title && (
             <h4 className="execution-name">
               {this.props.showAccountLabels && accountLabels}
+              {this.props.execution.fromTemplate && <i className="from-template fa fa-table" title="Template Pipeline" />}
               {this.props.title}
             </h4>
           )}
           { showExecutionName && (
             <h4 className="execution-name">
               {accountLabels}
+              {this.props.execution.fromTemplate && <i className="from-template fa fa-table" title="Template Pipeline" />}
               {this.props.execution.name}
             </h4>
           )}

--- a/app/scripts/modules/core/src/pipeline/executions/executionGroup/ExecutionGroup.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/executionGroup/ExecutionGroup.tsx
@@ -185,6 +185,7 @@ export class ExecutionGroup extends React.Component<IExecutionGroupProps, IExecu
                   {groupTargetAccountLabels}
                 </div>
                 <h4 className="execution-group-title">
+                  {group.fromTemplate && <i className="from-template fa fa-table" title="Template Pipeline" />}
                   {group.heading}
                   {pipelineDescription && <span> <Tooltip value={pipelineDescription}><span className="glyphicon glyphicon-info-sign"/></Tooltip></span>}
                   {pipelineDisabled && <span> (disabled)</span>}

--- a/app/scripts/modules/core/src/pipeline/executions/executions.less
+++ b/app/scripts/modules/core/src/pipeline/executions/executions.less
@@ -41,6 +41,10 @@
   .form-group > * {
     margin-right: 3px;
   }
+  .fa.from-template {
+    font-size: 1.25rem;
+    padding-right: 0.4rem;
+  }
 }
 
 .executions {

--- a/app/scripts/modules/core/src/pipeline/filter/executionFilter.service.ts
+++ b/app/scripts/modules/core/src/pipeline/filter/executionFilter.service.ts
@@ -168,6 +168,13 @@ export class ExecutionFilterService {
       executions = executions.concat(groupedExecutions.sort((a, b) => this.executionSorter(a, b)));
     });
 
+    executions.forEach((execution: IExecution) => {
+      const config: IPipeline = find<IPipeline>(application.pipelineConfigs.data, { id: execution.pipelineConfigId });
+      if (config != null && config.type === 'templatedPipeline') {
+        execution.fromTemplate = true;
+      }
+    });
+
     if (this.executionFilterModel.asFilterModel.sortFilter.groupBy === 'name') {
       const executionGroups = groupBy(executions, 'name');
       forOwn(executionGroups, (groupExecutions, key) => {
@@ -179,6 +186,7 @@ export class ExecutionFilterService {
           config: config || null,
           executions: groupExecutions,
           runningExecutions: groupExecutions.filter((execution: IExecution) => execution.isActive),
+          fromTemplate: config.type === 'templatedPipeline',
         });
       });
       this.addEmptyPipelines(groups, application);


### PR DESCRIPTION
Add a small table icon to the group header / execution title of pipelines that are based on templates.

Open to suggestions on better icon choice.

![templated_pipeline_name](https://user-images.githubusercontent.com/34253460/35413271-e8aaa5bc-01ec-11e8-92f5-5802ed34bfeb.png)

![templated_pipeline_group](https://user-images.githubusercontent.com/34253460/35413273-eae507dc-01ec-11e8-8e48-c58c7498272a.png)

Includes a tooltip on hover:

![screenshot from 2018-01-25 16-30-34](https://user-images.githubusercontent.com/34253460/35413430-62a3be94-01ed-11e8-8db3-9cdd7a89895a.png)
