### PR TITLE
fix(core/instance): Make navigating to instance details work again post-React-rewrite

### DIFF
--- a/app/scripts/modules/core/src/instance/InstanceListBody.tsx
+++ b/app/scripts/modules/core/src/instance/InstanceListBody.tsx
@@ -170,7 +170,7 @@ export class InstanceListBody extends React.Component<IInstanceListBodyProps, II
     });
 
     return (
-      <tr key={instance.id} className={rowClass}>
+      <tr key={instance.id} data-instance-id={instance.id} className={rowClass}>
         {this.$state.params.multiselect && (
           <td className="no-hover">
             <input


### PR DESCRIPTION
Re-add the `data-instance-id` attr that was lost in #4733 so that clicking on instances in the details view works.

Separately, we should go back and set this up as an onClick handler on each row now that React is handling the event delegation (once we confirm there's no negative perf impact).