### PR TITLE
fix(provider/kubernetes): add error message when manifest yaml isn't valid

### DIFF
--- a/app/scripts/modules/kubernetes/src/v2/manifest/manifestCommandBuilder.service.ts
+++ b/app/scripts/modules/kubernetes/src/v2/manifest/manifestCommandBuilder.service.ts
@@ -23,6 +23,7 @@ export interface IKubernetesManifestCommand {
 
 export interface IKubernetesManifestCommandMetadata {
   manifestText: string;
+  yamlError: boolean;
   backingData: any;
 }
 

--- a/app/scripts/modules/kubernetes/src/v2/manifest/wizard/manifestEntry.component.ts
+++ b/app/scripts/modules/kubernetes/src/v2/manifest/wizard/manifestEntry.component.ts
@@ -2,7 +2,7 @@ import { IComponentOptions, IController, module } from 'angular';
 
 import { IKubernetesManifestCommand, IKubernetesManifestCommandMetadata } from '../manifestCommandBuilder.service';
 
-import './manifestEntry.less'
+import './manifestEntry.less';
 
 class KubernetesManifestCtrl implements IController {
   public command: IKubernetesManifestCommand;
@@ -17,7 +17,8 @@ class KubernetesManifestEntryComponent implements IComponentOptions {
   public template = `
     <div class="container-fluid form-horizontal">
       <ng-form name="manifest">
-        <div class="form-group">
+        <div class="form-group" ng-class="{ 'kubernetes-manifest-error': ctrl.metadata.yamlError }">
+          <div style="" class="kubernetes-manifest-yaml-error-message">Invalid YAML</div>
           <textarea class="code form-control kubernetes-manifest-entry" ng-model="ctrl.metadata.manifestText" ng-change="ctrl.change()" rows="40"></textarea>
         </div>
       </ng-form>

--- a/app/scripts/modules/kubernetes/src/v2/manifest/wizard/manifestEntry.less
+++ b/app/scripts/modules/kubernetes/src/v2/manifest/wizard/manifestEntry.less
@@ -1,3 +1,24 @@
 .kubernetes-manifest-entry {
-  resize: vertical
+  resize: vertical;
+}
+
+.kubernetes-manifest-yaml-error-message {
+  display: none;
+}
+
+.kubernetes-manifest-error {
+  .kubernetes-manifest-yaml-error-message {
+    display: block;
+    position: absolute;
+    width: 200px;
+    padding: 0.2em 1em;
+    left: 50%;
+    margin-left: calc(-100px + -0.5em);
+    background: red;
+    color: white;
+  }
+
+  .kubernetes-manifest-entry {
+    background: rgb(255, 220, 220);
+  }
 }

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestConfig.controller.ts
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestConfig.controller.ts
@@ -42,8 +42,11 @@ export class KubernetesV2DeployManifestConfigCtrl implements IController {
   }
 
   public change() {
+    this.$scope.ctrl.metadata.yamlError = false;
     try {
       this.$scope.stage.manifest = load(this.metadata.manifestText);
-    } catch (e) {}
+    } catch (e) {
+      this.$scope.ctrl.metadata.yamlError = true;
+    }
   }
 }


### PR DESCRIPTION
![931a5aa2-e668-4879-9273-2f3efa7173e6](https://user-images.githubusercontent.com/34253460/35584291-8ebcd3c0-05c2-11e8-84a8-4b4de683a309.gif)

A small change to add an indicator when entered manifest YAML isn't valid.