### PR TITLE
feat(core/overrideRegistry): Add react component decorators to enable UI overrides

### DIFF
--- a/app/scripts/modules/core/src/overrideRegistry/Overridable.tsx
+++ b/app/scripts/modules/core/src/overrideRegistry/Overridable.tsx
@@ -1,0 +1,144 @@
+import { Spinner } from 'core';
+import * as React from 'react';
+import { Subject, Observable } from 'rxjs';
+
+import { ReactInjector, AngularJSAdapter } from 'core/reactShims';
+import { IAccountDetails } from 'core/account';
+
+export interface IOverridableProps {
+  accountId?: string;
+}
+
+/**
+ * Enables this component to be overriden by some other component.
+ *
+ * This is a Class Decorator which should be applied to a React Component Class.
+ *
+ * When rendered, the component will first check if an overriding component is registered using the same key.
+ * If yes, the overriding component is rendered.
+ * If no, the decorated component itself is rendered.
+ *
+ * @Overridable('overrideKey')
+ * class MyCmp extends React.Component {
+ *   render() { return <h1>Overridable Component</h1> }
+ * }
+ *
+ * When using the component, just render it as usual:
+ * <MyCmp/>
+ *
+ * If the override is cloud provider specific, pass the accountId as a prop:
+ * <MyCmp accountId={accountId} />
+ */
+export function Overridable(key: string) {
+  return function <P extends IOverridableProps, T extends React.ComponentClass<P>> (targetComponent: T): T {
+    return overridableComponent(targetComponent, key)
+  }
+}
+
+/**
+ * A high order component which returns a delegating component.
+ * The component will delegate to the overriding component registered with OverrideRegistry or CloudProviderRegistry.
+ * If no override is registered, it delegates to the component being decorated.
+ *
+ * class MyCmp extends React.Component {
+ *   render() { return <h1>Overridable Component</h1>
+ * }
+ *
+ * export const MyOverridableCmp = overridableComponent(MyCmp);
+ */
+export function overridableComponent <P extends IOverridableProps, T extends React.ComponentClass<P>> (DefaultComponent: T, key: string): T {
+  class OverridableComponent extends React.Component<P, { Component: T }> {
+    private account$ = new Subject<string>();
+    private destroy$ = new Subject();
+
+    constructor(props: P) {
+      super(props);
+
+      const { accountService } = ReactInjector;
+
+      this.account$
+        .switchMap(accountId => {
+          if (accountId) {
+            return Observable.fromPromise(accountService.getAccountDetails(accountId));
+          }
+
+          return Observable.of(null);
+        })
+        .map((accountDetails: IAccountDetails) => this.getComponent(accountDetails))
+        .takeUntil(this.destroy$)
+        .subscribe((Component) => this.setState({ Component }));
+    }
+
+    public componentDidMount() {
+      this.account$.next(this.props.accountId);
+    }
+
+    public componentWillUnmount() {
+      this.destroy$.next();
+    }
+
+    public componentWillReceiveProps(nextProps: P) {
+      const { accountId } = nextProps;
+      if (this.props.accountId !== accountId) {
+        this.account$.next(accountId);
+      }
+    }
+
+    private getComponentFromCloudProvider(accountDetails: IAccountDetails): T {
+      const { cloudProvider, providerVersion } = accountDetails;
+      const { cloudProviderRegistry } = ReactInjector;
+      if (!cloudProvider) {
+        return null;
+      }
+
+      const CloudProviderComponentOverride = cloudProviderRegistry.getValue(cloudProvider, key, providerVersion);
+      if (CloudProviderComponentOverride) {
+        return CloudProviderComponentOverride as T;
+      }
+
+      const cloudProviderTemplateOverride = cloudProviderRegistry.getValue(cloudProvider, key + 'TemplateUrl', providerVersion);
+      if (cloudProviderTemplateOverride) {
+        const cloudProviderController = cloudProviderRegistry.getValue(cloudProvider, key + 'Controller', providerVersion);
+        const controllerAs = cloudProviderController && cloudProviderController.includes(' as ') ? undefined : 'ctrl';
+        const Component = (props: any) =>
+          <AngularJSAdapter {...props} templateUrl={cloudProviderTemplateOverride} controller={cloudProviderController} controllerAs={controllerAs}/>;
+
+        return Component as any as T;
+      }
+
+      return null;
+    }
+
+    private getComponentFromOverrideRegistry(): T {
+      const { overrideRegistry } = ReactInjector;
+
+      const ComponentOverride = overrideRegistry.getComponent(key);
+      if (ComponentOverride) {
+        return ComponentOverride as T;
+      }
+
+      const templateOverride: string = overrideRegistry.getTemplate(key, null);
+      if (templateOverride) {
+        const controllerOverride: string = overrideRegistry.getController(key, null);
+        const controllerAs = controllerOverride && controllerOverride.includes(' as ') ? undefined : 'ctrl';
+        const Component = (props: any) =>
+            <AngularJSAdapter {...props} templateUrl={templateOverride} controller={controllerOverride} controllerAs={controllerAs} />;
+
+        return Component as any as T;
+      }
+
+      return null;
+    }
+
+    private getComponent(accountDetails: IAccountDetails): T {
+      return this.getComponentFromCloudProvider(accountDetails || {} as any) || this.getComponentFromOverrideRegistry() || DefaultComponent;
+    }
+
+    public render() {
+      const Component = this.state && this.state.Component;
+      return Component ? <Component {...this.props} /> : <Spinner/>;
+    }
+  }
+
+  return OverridableComponent as any as T;
+}

--- a/app/scripts/modules/core/src/overrideRegistry/Overrides.tsx
+++ b/app/scripts/modules/core/src/overrideRegistry/Overrides.tsx
@@ -1,0 +1,65 @@
+import * as React from 'react';
+
+import { CloudProviderRegistry } from 'core/cloudProvider';
+import { OverrideRegistry } from 'core/overrideRegistry';
+
+/**
+ * Registers a component as a replacement for some other component.
+ *
+ * This is a Class Decorator which should be applied to a React Component Class.
+ * The component class will be used instead of the OverridableComponent with the same key.
+ *
+ * If an (optional) cloudProvider is specified, the component override takes effect only for that cloud provider.
+ * If an (optional) cloudProviderVersion is specified, the component override takes effect only for a specific version of that cloud provider.
+ *
+ * @Overrides('overrideKey', "aws", "v2")
+ * class MyOverridingCmp extends React.Component {
+ *   render() { return <h1>Overridden component</h1> }
+ * }
+ */
+export function Overrides(key: string, cloudProvider?: string, cloudProviderVersion?: string) {
+  return function <P, T extends React.ComponentClass<P>> (targetComponent: T): void {
+    overrideRegistrationQueue.register(targetComponent, key, cloudProvider, cloudProviderVersion);
+  }
+}
+
+/**
+ * This queues OverrideComponent registration until the registries are ready.
+ */
+export class RegistrationQueue {
+  private queue: Function[] = [];
+
+  private overrideRegistry: OverrideRegistry;
+  private cloudProviderRegistry: CloudProviderRegistry;
+
+  public setRegistries(overrideRegistry: OverrideRegistry, cloudProviderRegistry: CloudProviderRegistry) {
+    this.overrideRegistry = overrideRegistry;
+    this.cloudProviderRegistry = cloudProviderRegistry;
+
+    this.flush();
+  }
+
+  public register(component: React.ComponentType, key: string, cloudProvider?: string, cloudProviderVersion?: string) {
+    this.queue.push(() => {
+      if (!cloudProvider) {
+        this.overrideRegistry.overrideComponent(key, component);
+      } else {
+        this.cloudProviderRegistry.overrideValue(cloudProvider, key, component, cloudProviderVersion);
+      }
+    });
+
+    this.flush();
+  }
+
+  private flush() {
+    if (!this.overrideRegistry || !this.cloudProviderRegistry) {
+      return;
+    }
+
+    while (this.queue.length) {
+      this.queue.splice(0, 1)[0]();
+    }
+  }
+}
+
+export const overrideRegistrationQueue = new RegistrationQueue();

--- a/app/scripts/modules/core/src/overrideRegistry/index.ts
+++ b/app/scripts/modules/core/src/overrideRegistry/index.ts
@@ -1,1 +1,3 @@
 export * from './override.registry';
+export * from './Overridable';
+export * from './Overrides';

--- a/app/scripts/modules/core/src/overrideRegistry/override.registry.ts
+++ b/app/scripts/modules/core/src/overrideRegistry/override.registry.ts
@@ -1,16 +1,20 @@
 import { module } from 'angular';
 import * as React from 'react';
 
+import { CloudProviderRegistry } from 'core/cloudProvider';
+
+import { overrideRegistrationQueue } from './Overrides';
+
 export class OverrideRegistry {
   private templateOverrides: Map<string, string> = new Map();
-  private componentOverrides: Map<string, React.ComponentClass> = new Map();
+  private componentOverrides: Map<string, React.ComponentType> = new Map();
   private controllerOverrides: Map<string, string> = new Map();
 
   public overrideTemplate(key: string, val: string) {
     this.templateOverrides.set(key, val);
   }
 
-  public overrideComponent(key: string, val: React.ComponentClass) {
+  public overrideComponent(key: string, val: React.ComponentType) {
     this.componentOverrides.set(key, val);
   }
 
@@ -23,13 +27,18 @@ export class OverrideRegistry {
   }
 
   public getComponent<T>(key: string) {
-    return this.componentOverrides.get(key) as React.ComponentClass<T>;
+    return this.componentOverrides.get(key) as React.ComponentType<T>;
   }
 
-  public getController(key: string) {
-    return this.controllerOverrides.get(key) || key;
+  public getController(key: string, defaultVal: string = key) {
+    return this.controllerOverrides.get(key) || defaultVal;
   }
 }
 
 export const OVERRIDE_REGISTRY = 'spinnaker.core.override.registry';
-module(OVERRIDE_REGISTRY, []).service('overrideRegistry', OverrideRegistry);
+module(OVERRIDE_REGISTRY, [])
+  .service('overrideRegistry', OverrideRegistry)
+  .run((overrideRegistry: OverrideRegistry, cloudProviderRegistry: CloudProviderRegistry) => {
+    'ngInject';
+    overrideRegistrationQueue.setRegistries(overrideRegistry, cloudProviderRegistry);
+  });


### PR DESCRIPTION
feat(core/reactShims): Add templateUrl support to AngularJSAdapter react component

Migrate ServerGroupDetails and ApplicationIcon to use @Overridable() decorator.
