### PR TITLE
fix(pipelines): Fix polling for manual execution

### DIFF
--- a/app/scripts/modules/core/src/pipeline/executions/executionGroup/ExecutionGroup.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/executionGroup/ExecutionGroup.tsx
@@ -103,7 +103,11 @@ export class ExecutionGroup extends React.Component<IExecutionGroupProps, IExecu
         monitor.then(() => this.setState({ triggeringExecution: false }));
         this.setState({ poll: monitor });
       },
-      () => this.setState({ triggeringExecution: false }));
+      () => {
+        const monitor = this.props.application.executions.refresh();
+        monitor.then(() => this.setState({ triggeringExecution: false }));
+        this.setState({ poll: monitor });
+      });
   }
 
   public triggerPipeline(): void {

--- a/app/scripts/modules/core/src/pipeline/service/execution.service.ts
+++ b/app/scripts/modules/core/src/pipeline/service/execution.service.ts
@@ -182,18 +182,15 @@ export class ExecutionService {
     }
 
     public waitUntilNewTriggeredPipelineAppears(application: Application, triggeredPipelineId: string): IPromise<any> {
-      return this.getRunningExecutions(application.name).then((executions: IExecution[]) => {
-        const match = executions.find((execution) => execution.id === triggeredPipelineId);
+      return this.getExecution(triggeredPipelineId).then(() => {
         const deferred = this.$q.defer();
-        if (match) {
-          application.executions.refresh().then(deferred.resolve);
-          return deferred.promise;
-        } else {
-          return this.$timeout(() => {
-            return this.waitUntilNewTriggeredPipelineAppears(application, triggeredPipelineId);
-          }, 1000);
-        }
-      });
+        application.executions.refresh().then(deferred.resolve);
+        return deferred.promise;
+      }).catch(() => {
+        return this.$timeout(() => {
+          return this.waitUntilNewTriggeredPipelineAppears(application, triggeredPipelineId);
+        }, 1000);
+      })
     }
 
     private waitUntilPipelineIsCancelled(application: Application, executionId: string): IPromise<any> {


### PR DESCRIPTION
Refresh pipeline executions when a manual execution fails, so the
failure is surfaced in the UI. Update polling for executions to look
for the specific execution, rather than looking for all running executions
and filtering in JavaScript.  This fixes a bug leading to infinite
polling if the execution ended up in a non-running status before the
first poll.