### PR TITLE
refactor(core): limit calls to /credentials

### DIFF
--- a/app/scripts/modules/azure/loadBalancer/configure/createLoadBalancer.controller.spec.js
+++ b/app/scripts/modules/azure/loadBalancer/configure/createLoadBalancer.controller.spec.js
@@ -50,8 +50,7 @@ describe('Controller: azureCreateLoadBalancerCtrl', function () {
   it('makes the expected REST calls for data for a new loadbalancer', function() {
     $http.when('GET', API.baseUrl + '/networks').respond([]);
     $http.when('GET', API.baseUrl + '/securityGroups').respond({});
-    $http.when('GET', API.baseUrl + '/credentials').respond([]);
-    $http.when('GET', API.baseUrl + '/credentials/azure-test').respond([]);
+    $http.when('GET', API.baseUrl + '/credentials?expand=true').respond([]);
     $http.when('GET', API.baseUrl + '/subnets').respond([]);
 
     $http.flush();

--- a/app/scripts/modules/core/src/account/account.service.spec.ts
+++ b/app/scripts/modules/core/src/account/account.service.spec.ts
@@ -28,7 +28,7 @@ describe('Service: accountService', () => {
   afterEach(SETTINGS.resetToOriginal);
 
   it('should filter the list of accounts by provider when supplied', () => {
-    $http.expectGET(`${API.baseUrl}/credentials`).respond(200, [
+    $http.expectGET(`${API.baseUrl}/credentials?expand=true`).respond(200, [
       { name: 'test', type: 'aws' },
       { name: 'prod', type: 'aws' },
       { name: 'prod', type: 'gce' },
@@ -46,13 +46,10 @@ describe('Service: accountService', () => {
   describe('getAllAccountDetailsForProvider', () => {
 
     it('should return details for each account', function () {
-      $http.expectGET(API.baseUrl + '/credentials').respond(200, [
+      $http.expectGET(API.baseUrl + '/credentials?expand=true').respond(200, [
         { name: 'test', type: 'aws' },
         { name: 'prod', type: 'aws' },
       ]);
-
-      $http.expectGET(API.baseUrl + '/credentials/test').respond(200, { a: 1 });
-      $http.expectGET(API.baseUrl + '/credentials/prod').respond(200, { a: 2 });
 
       let details: any = null;
       accountService.getAllAccountDetailsForProvider('aws').then((results: any) => {
@@ -61,12 +58,12 @@ describe('Service: accountService', () => {
 
       $http.flush();
       expect(details.length).toBe(2);
-      expect(details[0].a).toBe(1);
-      expect(details[1].a).toBe(2);
+      expect(details[0].name).toBe('test');
+      expect(details[1].name).toBe('prod');
     });
 
     it('should fall back to an empty array if an exception occurs when listing accounts', () => {
-      $http.expectGET(`${API.baseUrl}/credentials`).respond(429, null);
+      $http.expectGET(`${API.baseUrl}/credentials?expand=true`).respond(429, null);
 
       let details: any[] = null;
       accountService.getAllAccountDetailsForProvider('aws').then((results: any[]) => {
@@ -77,24 +74,6 @@ describe('Service: accountService', () => {
       expect(details).toEqual([]);
     });
 
-    it('should fall back to an empty array if an exception occurs when getting details for an account', () => {
-      $http.expectGET(`${API.baseUrl}/credentials`).respond(200, [
-        { name: 'test', type: 'aws' },
-        { name: 'prod', type: 'aws' },
-      ]);
-
-      $http.expectGET(API.baseUrl + '/credentials/test').respond(500, null);
-      $http.expectGET(API.baseUrl + '/credentials/prod').respond(200, { a: 2 });
-
-      let details: any = null;
-      accountService.getAllAccountDetailsForProvider('aws').then((results: any) => {
-        details = results;
-      });
-
-      $http.flush();
-
-      expect(details).toEqual([]);
-    });
   });
 
   describe('listProviders', () => {
@@ -102,7 +81,7 @@ describe('Service: accountService', () => {
     let registeredProviders: string[];
     beforeEach(() => {
       registeredProviders = ['aws', 'gce', 'cf'];
-      $http.whenGET(`${API.baseUrl}/credentials`).respond(200,
+      $http.whenGET(`${API.baseUrl}/credentials?expand=true`).respond(200,
         [{ type: 'aws' }, { type: 'gce' }, { type: 'cf' }]
       );
 

--- a/app/scripts/modules/core/src/chaosMonkey/chaosMonkeyExceptions.component.spec.ts
+++ b/app/scripts/modules/core/src/chaosMonkey/chaosMonkeyExceptions.component.spec.ts
@@ -1,4 +1,4 @@
-import { mock, IComponentControllerService, IScope, IQService, IRootScopeService, IPromise } from 'angular';
+import { mock, IComponentControllerService, IScope, IQService, IRootScopeService } from 'angular';
 
 import { CHAOS_MONKEY_EXCEPTIONS_COMPONENT, ChaosMonkeyExceptionsController } from './chaosMonkeyExceptions.component';
 import { AccountService } from 'core/account/account.service';
@@ -40,16 +40,12 @@ describe('Controller: ChaosMonkeyExceptions', () => {
   describe('data initialization', () => {
 
     it('gets all accounts, then adds wildcard and regions per account to vm', () => {
-      const accounts = [ { name: 'prod' }, { name: 'test' } ];
-      const details: any = {
-        prod: { name: 'prod', regions: [ { name: 'us-east-1' }, { name: 'us-west-1' }] },
-        test: { name: 'test', regions: [ { name: 'us-west-2' }, { name: 'eu-west-1' }] }
-      };
+      const accounts: any = [
+        { name: 'prod', regions: [ { name: 'us-east-1' }, { name: 'us-west-1' }] },
+        { name: 'test', regions: [ { name: 'us-west-2' }, { name: 'eu-west-1' }] }
+      ];
 
       spyOn(accountService, 'listAccounts').and.returnValue($q.when(accounts));
-      spyOn(accountService, 'getAccountDetails').and.callFake((accountName: string): IPromise<any> => {
-        return $q.when(details[accountName]);
-      });
 
       initializeController(null);
       $ctrl.application =
@@ -59,7 +55,7 @@ describe('Controller: ChaosMonkeyExceptions', () => {
       $ctrl.$onInit();
       $scope.$digest();
 
-      expect($ctrl.accounts).toEqual([details.prod, details.test]);
+      expect($ctrl.accounts).toEqual([accounts[0], accounts[1]]);
       expect($ctrl.regionsByAccount).toEqual({
         prod: [ '*', 'us-east-1', 'us-west-1'],
         test: [ '*', 'us-west-2', 'eu-west-1']

--- a/package.json
+++ b/package.json
@@ -170,5 +170,8 @@
     "webpack": "3.8.1",
     "webpack-dev-server": "2.7.1",
     "webpack-node-externals": "^1.6.0"
+  },
+  "optionalDependencies": {
+    "fsevents": "^1.1.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2571,6 +2571,10 @@ detect-indent@^4.0.0:
   dependencies:
     repeating "^2.0.0"
 
+detect-libc@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
+
 detective@^4.3.1:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/detective/-/detective-4.5.0.tgz#6e5a8c6b26e6c7a254b1c6b6d7490d98ec91edd1"
@@ -3452,6 +3456,13 @@ fsevents@^1.0.0:
     nan "^2.3.0"
     node-pre-gyp "^0.6.29"
 
+fsevents@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.1.3.tgz#11f82318f5fe7bb2cd22965a108e9306208216d8"
+  dependencies:
+    nan "^2.3.0"
+    node-pre-gyp "^0.6.39"
+
 fstream-ignore@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/fstream-ignore/-/fstream-ignore-1.0.5.tgz#9c31dae34767018fe1d249b24dada67d092da105"
@@ -3697,7 +3708,7 @@ hash.js@^1.0.0, hash.js@^1.0.3:
   dependencies:
     inherits "^2.0.1"
 
-hawk@~3.1.3:
+hawk@3.1.3, hawk@~3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/hawk/-/hawk-3.1.3.tgz#078444bd7c1640b0fe540d2c9b73d59678e8e1c4"
   dependencies:
@@ -5076,6 +5087,22 @@ node-pre-gyp@^0.6.29:
     tar "^2.2.1"
     tar-pack "^3.4.0"
 
+node-pre-gyp@^0.6.39:
+  version "0.6.39"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz#c00e96860b23c0e1420ac7befc5044e1d78d8649"
+  dependencies:
+    detect-libc "^1.0.2"
+    hawk "3.1.3"
+    mkdirp "^0.5.1"
+    nopt "^4.0.1"
+    npmlog "^4.0.2"
+    rc "^1.1.7"
+    request "2.81.0"
+    rimraf "^2.6.1"
+    semver "^5.3.0"
+    tar "^2.2.1"
+    tar-pack "^3.4.0"
+
 nopt@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.1.tgz#d0d4685afd5415193c8c7505602d0d17cd64474d"
@@ -6408,7 +6435,7 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
-request@^2.72.0, request@^2.81.0:
+request@2.81.0, request@^2.72.0, request@^2.81.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
   dependencies:


### PR DESCRIPTION
Companion PR to spinnaker/gate#502 and spinnaker/clouddriver#2326

We have all the details in the list of credentials now, so we can stop calling it separately in the UI, and just maintain a local cache.