### PR TITLE
fix(core): eagerly fetch more than one cluster grouping pod

### DIFF
--- a/app/scripts/modules/core/src/cluster/AllClustersGroupings.tsx
+++ b/app/scripts/modules/core/src/cluster/AllClustersGroupings.tsx
@@ -120,7 +120,7 @@ export class AllClustersGroupings extends React.Component<IAllClustersGroupingsP
             rowHeight={this.cellCache.rowHeight}
             rowRenderer={this.renderRow}
             noRowsRenderer={this.noRowsRender}
-            overscanRowCount={1}
+            overscanRowCount={3}
             containerStyle={{ overflow: 'visible' }}
           />}
       </AutoSizer>


### PR DESCRIPTION
I had optimized this for the wrong scenario (absolute worst case), which negatively affects 99.9% of the actual real world scenarios.