### PR TITLE
fix(amazon): copy EBS volumes when explicitly cloning an ASG

### DIFF
--- a/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupCommandBuilder.service.js
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupCommandBuilder.service.js
@@ -233,7 +233,7 @@ module.exports = angular.module('spinnaker.amazon.serverGroupCommandBuilder.serv
           tags: Object.assign({}, serverGroup.tags, existingTags),
           targetGroups: serverGroup.targetGroups,
           useAmiBlockDeviceMappings: useAmiBlockDeviceMappings,
-          copySourceCustomBlockDeviceMappings: false, // default to using block device mappings from current instance type
+          copySourceCustomBlockDeviceMappings: mode === 'clone', // default to using block device mappings if not cloning
           viewState: {
             instanceProfile: asyncData.instanceProfile,
             useAllImageSelection: false,


### PR DESCRIPTION
When cloning an existing ASG, the expectation is the user should not have to go to the Advanced Settings section and change anything. Right now, if the user has custom EBS mappings, those will _not_ be copied over when cloning unless the user goes and selects the correct option, which is a big surprise.