### PR TITLE
fix(core): consistent button sizing in details panels

### DIFF
--- a/app/scripts/modules/core/src/presentation/details.less
+++ b/app/scripts/modules/core/src/presentation/details.less
@@ -66,7 +66,7 @@
     flex-flow: row wrap;
 
     margin: 0 -4px;
-    .dropdown {
+    .btn-sm {
       margin: 4px;
     }
   }


### PR DESCRIPTION
We have some details panels with buttons and dropdowns.

<img width="315" alt="screen shot 2018-02-01 at 2 04 20 pm" src="https://user-images.githubusercontent.com/73450/35705956-dfa49538-0758-11e8-900a-dcda7ac70bd8.png">

The dropdowns have `btn-sm` in them, so...