### PR TITLE
fix(core/cluster): Vertically align icons and make them the same size

### DIFF
--- a/app/scripts/modules/core/src/cluster/rollups.less
+++ b/app/scripts/modules/core/src/cluster/rollups.less
@@ -330,6 +330,15 @@ running-tasks-tag {
   }
 }
 
+.server-group-manager-tag {
+  .badge-counter {
+    margin-top: -5px;
+    height: 19px;
+    .fa-server {
+      padding: 1px 0;
+    }
+  }
+}
 
 .rollup-details {
   background-color: var(--color-alabaster);


### PR DESCRIPTION
My OCD was hurting

Before:
<img width="699" alt="skjermbilde 2018-02-02 kl 13 13 13" src="https://user-images.githubusercontent.com/155558/35736570-ccac1aac-0828-11e8-85dc-76c5052abd02.png">

After:
<img width="696" alt="skjermbilde 2018-02-02 kl 14 45 37" src="https://user-images.githubusercontent.com/155558/35736571-ccc44b72-0828-11e8-911f-ac944531b3a6.png">
