### PR TITLE
fix(core): handle challengeDestructiveActions being undefined in API response

### DIFF
--- a/app/scripts/modules/core/src/account/AccountTag.tsx
+++ b/app/scripts/modules/core/src/account/AccountTag.tsx
@@ -36,7 +36,7 @@ export class AccountTag extends React.Component<IAccountTagProps, IAccountTagSta
     const { cache } = AccountTag;
     if (!cache.hasOwnProperty(account)) {
       cache[account] = ReactInjector.accountService.challengeDestructiveActions(account)
-        .then(result => cache[account] = result);
+        .then(result => cache[account] = !!result);
     }
 
     const cachedVal: boolean | IPromise<boolean> = cache[account];


### PR DESCRIPTION
If a provider returns a response without a challengeDestructiveActions field then that value is cached as `undefined`.  The `typeof` check on line 44 will then assume that the cache is holding a Promise (since the value isn't a bool) and attempt to call `.then` on undefined.

Before (appengine provider):

![account_tag](https://user-images.githubusercontent.com/34253460/35745428-3efc8f1e-0811-11e8-8def-e9897a2dfb7d.png)

After: no error.