### PR TITLE
fix(provider/appengine): dont throw error when git credentials are missing

### DIFF
--- a/app/scripts/modules/appengine/serverGroup/configure/wizard/basicSettings.controller.ts
+++ b/app/scripts/modules/appengine/serverGroup/configure/wizard/basicSettings.controller.ts
@@ -72,7 +72,7 @@ class AppengineServerGroupBasicSettingsCtrl implements IController {
   public onAccountChange(): void {
     const account = this.findAccountInBackingData();
     if (account) {
-      this.$scope.command.gitCredentialType = account.supportedGitCredentialTypes[0];
+      this.$scope.command.gitCredentialType = this.getSupportedGitCredentialTypes()[0];
       this.$scope.command.region = account.region;
     } else {
       this.$scope.command.gitCredentialType = 'NONE';
@@ -82,7 +82,7 @@ class AppengineServerGroupBasicSettingsCtrl implements IController {
 
   public getSupportedGitCredentialTypes(): GitCredentialType[] {
     const account = this.findAccountInBackingData();
-    if (account) {
+    if (account && account.supportedGitCredentialsTypes) {
       return account.supportedGitCredentialTypes;
     } else {
       return ['NONE'];


### PR DESCRIPTION
I don't understand why this and https://github.com/spinnaker/deck/pull/4766 are suddenly needed in the appengine provider.  It feels like some API response changed format dramatically but I've tried bisecting back a bit in the commit histories of deck/gate/orca/clouddriver but can't find where this issue was introduced.  Nonetheless, this PR works around the issue of account git credentials being undefined in appengine.

#### Before:
Console error when adding server group:
![git_error](https://user-images.githubusercontent.com/34253460/35748354-c25232ce-081b-11e8-9528-927c0c1d39a3.png)

Missing account dropdown in basicSettings screen:
![missing_account_dropdown](https://user-images.githubusercontent.com/34253460/35748357-c417b610-081b-11e8-9ca7-010387753f82.png)

#### After:
Error removed and account dropdown appears correctly.