### PR TITLE
fix(core): shrink tag marker to fit better in cluster header

### DIFF
--- a/app/scripts/modules/core/src/entityTag/notifications/notifications.less
+++ b/app/scripts/modules/core/src/entityTag/notifications/notifications.less
@@ -72,7 +72,7 @@
   .tag-marker {
     display: inline-block;
     margin-left: 5px;
-    font-size: 15px;
+    font-size: 14px;
 
     &.inverse {
       .fa {


### PR DESCRIPTION
People with scroll bars always enabled see this on clusters with alerts:
<img width="442" alt="screen shot 2018-02-02 at 12 34 24 pm" src="https://user-images.githubusercontent.com/73450/35753661-72efbc34-0815-11e8-9be8-6f124d903169.png">

I fought this for a while and this seemed like the least harmful fix.