### PR TITLE
fix(core): avoid flickering scrollbars in clusters view

### DIFF
--- a/app/scripts/modules/core/src/cluster/allClusters.html
+++ b/app/scripts/modules/core/src/cluster/allClusters.html
@@ -57,8 +57,10 @@
   <h4 class="text-center">There was an error loading the clusters for this application. We'll try again shortly.</h4>
 </div>
 
+<!-- overflow-y is set to avoid flickering when scrollbars are set to always show (react virtualized thing) -->
 <all-clusters-groupings
   class="content"
   app="ctrl.application"
   initialized="ctrl.initialized"
+  style="overflow-y: hidden"
 ></all-clusters-groupings>


### PR DESCRIPTION
Only noticeable when users have their scrollbars set to always show and they toggle some filters in the clusters view, going from a view where the cluster groupings are too tall to where they are not.

See https://github.com/bvaughn/react-virtualized/issues/773