### PR TITLE
refactor(amazon): remove local storage caches: instance types, load balancers

### DIFF
--- a/app/scripts/modules/amazon/src/cache/cacheConfigurer.service.js
+++ b/app/scripts/modules/amazon/src/cache/cacheConfigurer.service.js
@@ -2,38 +2,25 @@
 
 const angular = require('angular');
 
-import {
-  ACCOUNT_SERVICE,
-  INSTANCE_TYPE_SERVICE,
-  LOAD_BALANCER_READ_SERVICE,
-  SUBNET_READ_SERVICE
-} from '@spinnaker/core';
-
 import { VPC_READ_SERVICE } from '../vpc/vpc.read.service';
 
 module.exports = angular.module('spinnaker.amazon.cache.initializer', [
-  ACCOUNT_SERVICE,
-  LOAD_BALANCER_READ_SERVICE,
-  INSTANCE_TYPE_SERVICE,
-  SUBNET_READ_SERVICE,
   VPC_READ_SERVICE,
 ])
-  .factory('awsCacheConfigurer', function ($q,
-                                         accountService, instanceTypeService,
-                                         subnetReader, vpcReader, loadBalancerReader) {
+  .factory('awsCacheConfigurer', function ($q, subnetReader, vpcReader) {
 
     let config = Object.create(null);
 
-    config.credentials = {
-      initializers: [ () => accountService.listAccounts('aws') ],
-    };
-
+    // cache no longer used; version incremented and retained to clear any existing caches
+    // remove this cache entry any time after June 2018
     config.instanceTypes = {
-      initializers: [ () => instanceTypeService.getAllTypesByRegion('aws') ],
+      version: 3
     };
 
+    // cache no longer used; version incremented and retained to clear any existing caches
+    // remove this cache entry any time after June 2018
     config.loadBalancers = {
-      initializers: [ () => loadBalancerReader.listLoadBalancers('aws') ],
+      version: 2,
     };
 
     config.subnets = {

--- a/app/scripts/modules/amazon/src/instance/awsInstanceType.service.js
+++ b/app/scripts/modules/amazon/src/instance/awsInstanceType.service.js
@@ -3,13 +3,12 @@
 const angular = require('angular');
 import _ from 'lodash';
 
-import { API_SERVICE, INFRASTRUCTURE_CACHE_SERVICE } from '@spinnaker/core';
+import { API_SERVICE } from '@spinnaker/core';
 
 module.exports = angular.module('spinnaker.amazon.instanceType.service', [
   API_SERVICE,
-  INFRASTRUCTURE_CACHE_SERVICE
 ])
-  .factory('awsInstanceTypeService', function ($http, $q, API, infrastructureCaches) {
+  .factory('awsInstanceTypeService', function ($http, $q, API) {
 
     var m4 = {
       type: 'm4',
@@ -168,21 +167,15 @@ module.exports = angular.module('spinnaker.amazon.instanceType.service', [
     }
 
     var getAllTypesByRegion = function getAllTypesByRegion() {
-      var cached = infrastructureCaches.get('instanceTypes').get('aws');
-      if (cached) {
-        return $q.when(cached);
-      }
       return API.one('instanceTypes').get()
         .then(function (types) {
-          var result = _.chain(types)
+          return _.chain(types)
             .map(function (type) {
               return { region: type.region, account: type.account, name: type.name, key: [type.region, type.account, type.name].join(':') };
             })
             .uniqBy('key')
             .groupBy('region')
             .value();
-          infrastructureCaches.get('instanceTypes').put('aws', result);
-          return result;
         });
     };
 

--- a/app/scripts/modules/amazon/src/instance/awsInstanceType.service.spec.js
+++ b/app/scripts/modules/amazon/src/instance/awsInstanceType.service.spec.js
@@ -14,7 +14,7 @@ describe('Service: InstanceType', function () {
   });
 
 
-  beforeEach(window.inject(function (_awsInstanceTypeService_, _$httpBackend_, _API_, infrastructureCaches) {
+  beforeEach(window.inject(function (_awsInstanceTypeService_, _$httpBackend_, _API_) {
     API = _API_;
     this.awsInstanceTypeService = _awsInstanceTypeService_;
     this.$httpBackend = _$httpBackend_;
@@ -36,10 +36,6 @@ describe('Service: InstanceType', function () {
       {account: 'test', region: 'us-east-1', name: 't2.loltiny', availabilityZone: 'us-east-1c'},
     ];
 
-    infrastructureCaches.createCache('instanceTypes', {});
-    if (infrastructureCaches.get('instanceTypes')) {
-      infrastructureCaches.get('instanceTypes').removeAll();
-    }
   }));
 
   afterEach(function () {

--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/loadBalancers/loadBalancerSelector.component.html
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/loadBalancers/loadBalancerSelector.component.html
@@ -85,17 +85,4 @@
     </div>
   </div>
 
-  <div class="form-group small" style="margin-top: 20px">
-    <div class="col-md-8 col-md-offset-4">
-      <p>
-        <span ng-if="$ctrl.refreshing"><span class="fa fa-refresh fa-spin"></span></span>
-        Load balancers
-        <span ng-if="!$ctrl.refreshing">last refreshed {{ $ctrl.refreshTime | timestamp }}</span>
-        <span ng-if="$ctrl.refreshing"> refreshing...</span>
-      </p>
-      <p>If you're not finding a target group or classic load balancer that was recently added,
-        <a href ng-click="$ctrl.refreshLoadBalancers()">click here</a> to refresh the list.
-      </p>
-    </div>
-  </div>
 </div>

--- a/app/scripts/modules/core/src/loadBalancer/loadBalancer.read.service.ts
+++ b/app/scripts/modules/core/src/loadBalancer/loadBalancer.read.service.ts
@@ -1,7 +1,6 @@
 import { IPromise, IQService, module } from 'angular';
 
 import { API_SERVICE, Api } from 'core/api/api.service';
-import { INFRASTRUCTURE_CACHE_SERVICE, InfrastructureCacheService } from 'core/cache/infrastructureCaches.service';
 import { NAMING_SERVICE, NamingService, IComponentName } from 'core/naming/naming.service';
 import { ILoadBalancer, ILoadBalancerSourceData } from 'core/domain';
 
@@ -19,7 +18,7 @@ export interface ILoadBalancersByAccount {
 export class LoadBalancerReader {
 
   public constructor(private $q: IQService, private API: Api, private namingService: NamingService,
-                     private loadBalancerTransformer: any, private infrastructureCaches: InfrastructureCacheService) {
+                     private loadBalancerTransformer: any) {
     'ngInject';
   }
 
@@ -37,7 +36,6 @@ export class LoadBalancerReader {
 
   public listLoadBalancers(cloudProvider: string): IPromise<ILoadBalancersByAccount[]> {
     return this.API.all('loadBalancers')
-      .useCache(this.infrastructureCaches.get('loadBalancers'))
       .withParams({ provider: cloudProvider })
       .getList();
   }
@@ -59,7 +57,6 @@ export const LOAD_BALANCER_READ_SERVICE = 'spinnaker.core.loadBalancer.read.serv
 
 module(LOAD_BALANCER_READ_SERVICE, [
   NAMING_SERVICE,
-  INFRASTRUCTURE_CACHE_SERVICE,
   require('./loadBalancer.transformer.js').name,
   API_SERVICE
 ]).service('loadBalancerReader', LoadBalancerReader);


### PR DESCRIPTION
I ran through this a bunch of times today, and I honestly don't think we get anything by keeping these items in local storage, aside from annoying users when the cache gets wiped out because we run out of space.

The endpoints in question load in around 2s for us (and I suspect we have more load balancers in AWS than most Spinnaker users), and they take up quite a bit of local storage space.

I don't think we can get rid of security groups yet, but maybe we can figure that out some day.

@jrsquared or @christopherthielen feel free to merge next week, or leave it for the following week.