### PR TITLE
fix(core): Don't use '@spinnaker/core' imports inside core package

### DIFF
--- a/app/scripts/modules/core/src/pagerDuty/pagerDuty.read.service.spec.ts
+++ b/app/scripts/modules/core/src/pagerDuty/pagerDuty.read.service.spec.ts
@@ -1,6 +1,6 @@
 import { IHttpBackendService, mock } from 'angular';
 
-import { Api, API_SERVICE } from '@spinnaker/core';
+import { Api, API_SERVICE } from 'core/api/api.service';
 
 import { IPagerDutyService, PagerDutyReader } from './pagerDuty.read.service';
 

--- a/app/scripts/modules/core/src/pagerDuty/pagerDuty.read.service.ts
+++ b/app/scripts/modules/core/src/pagerDuty/pagerDuty.read.service.ts
@@ -1,7 +1,7 @@
 import { module } from 'angular';
 import { Observable } from 'rxjs';
 
-import { Api, API_SERVICE } from '@spinnaker/core';
+import { Api, API_SERVICE } from 'core/api/api.service';
 
 export interface IPagerDutyService {
   id: string;

--- a/app/scripts/modules/core/src/pagerDuty/pagerDutySelectField.component.ts
+++ b/app/scripts/modules/core/src/pagerDuty/pagerDutySelectField.component.ts
@@ -1,6 +1,6 @@
 import { IComponentController, IComponentOptions, module } from 'angular';
 
-import { SchedulerFactory } from '@spinnaker/core';
+import { SchedulerFactory } from 'core/scheduler/scheduler.factory';
 
 import { IPagerDutyService, PAGER_DUTY_READ_SERVICE, PagerDutyReader } from './pagerDuty.read.service';
 

--- a/app/scripts/modules/core/src/serverGroupManager/serverGroupManager.service.ts
+++ b/app/scripts/modules/core/src/serverGroupManager/serverGroupManager.service.ts
@@ -1,6 +1,6 @@
 import { module, IPromise } from 'angular';
 
-import { API_SERVICE, Api } from '@spinnaker/core';
+import { API_SERVICE, Api } from 'core/api/api.service';
 
 import { IServerGroupManager } from 'core/domain/IServerGroupManager';
 


### PR DESCRIPTION
A few imports referencing `@spinnaker/core` made their way into the core package itself. This doesn't cause problems in the majority of cases (which _I think_ is due to having an alias setup in the webpack config). When using `npm link`/`yarn link` to work on projects that import `@spinnaker/core`, though, webpack fails to resolve any imports for `@spinnaker/core` that live inside the core package. In general we should be importing things internal to core using the `core/*` alias or relative imports anyway, so this does a simple swap on the import references.

cc @jrsquared @danielpeach since both of you touched these.