### PR TITLE
fix(provider/kubernetes): exclude stages when k8s v2 is the only provider

### DIFF
--- a/app/scripts/modules/core/src/account/account.service.ts
+++ b/app/scripts/modules/core/src/account/account.service.ts
@@ -161,6 +161,14 @@ export class AccountService {
       .then((accounts) => accounts.filter((account) => account.authorized !== false));
   }
 
+  public applicationAccounts(application: Application = null): Promise<IAccountDetails[]> {
+    return Promise.all([this.listProviders(application), this.listAccounts()]).then(([providers, accounts]) => {
+      return providers.reduce((memo, p) => {
+        return memo.concat(accounts.filter(acc => acc.cloudProvider === p));
+      }, [] as IAccountDetails[]);
+    });
+  }
+
   public listProviders(application: Application = null): IPromise<string[]> {
     return this.listAllAccounts()
       .then((accounts: IAccount[]) => {

--- a/app/scripts/modules/core/src/domain/IStageTypeConfig.ts
+++ b/app/scripts/modules/core/src/domain/IStageTypeConfig.ts
@@ -15,6 +15,7 @@ export interface IStageTypeConfig extends IStageOrTriggerTypeConfig {
   configuration?: any;
   defaultTimeoutMs?: number;
   disableNotifications?: boolean;
+  excludedCloudProviders?: { cloudProvider: string; providerVersion: string; }[];
   executionConfigSections?: string[]; // angular only
   executionDetailsSections?: IExecutionDetailsSection[]; // react only
   executionDetailsUrl?: string; // angular only

--- a/app/scripts/modules/core/src/pipeline/config/stages/deploy/deployStage.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/deploy/deployStage.js
@@ -17,6 +17,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.deployStage', [
       strategyDescription: 'Deploys the image specified',
       key: 'deploy',
       alias: 'createServerGroup',
+      excludedCloudProviders: [{ cloudProvider: 'kubernetes', providerVersion: 'v2' }],
       templateUrl: require('./deployStage.html'),
       executionDetailsUrl: require('./deployExecutionDetails.html'),
       controller: 'DeployStageCtrl',

--- a/app/scripts/modules/core/src/pipeline/config/stages/stage.module.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/stage.module.js
@@ -52,9 +52,9 @@ module.exports = angular.module('spinnaker.core.pipeline.config.stage', [
       selectedStageType: null,
     };
 
-    accountService.listProviders($scope.application).then((providers) => {
-      $scope.options.stageTypes = pipelineConfig.getConfigurableStageTypes(providers);
-      $scope.showProviders = providers.length > 1;
+    accountService.applicationAccounts($scope.application).then(accounts => {
+      $scope.options.stageTypes = pipelineConfig.getConfigurableStageTypes(accounts);
+      $scope.showProviders = new Set(accounts.map(a => a.cloudProvider)).size > 1;
     });
 
     if ($scope.pipeline.strategy) {


### PR DESCRIPTION
~Providers are passed around as strings when assessing whether stages support them or not.  Both the kubernetes v1 and the kubernetes v2 provider share a provider string of `kubernetes`.  Therefore the stage filtering assumes that any stage supported by v1 is also supported by v2 but this is not the case.~

~This workaround allows a field to be added to a stage that lists specific provider versions that it doesn't support.  After the initial set of stages is filtered via provider strings, a second round of filtering is performed to remove any stage where the set of accounts for this application are entirely excluded by the stage's type.~

~This solution doesn't feel quite right but I can't see a way past this problem without a large refactor such that everywhere we pass a provider string we also pass around a version.  Maybe that would be a better solution though.  Open to ideas here.~

Fixed.

#### Before: (A Deploy stage appears in an app with only a k8s v2 account configured)

![before](https://user-images.githubusercontent.com/34253460/36002446-376b2378-0cf8-11e8-8218-c58725aca041.png)

#### After: (The Deploy stage is filtered out because its excludedCloudProviders field includes k8s v2)

![after](https://user-images.githubusercontent.com/34253460/36002466-4686c5f6-0cf8-11e8-9418-a77d1c4477c8.png)

https://github.com/spinnaker/spinnaker/issues/2277