### PR TITLE
fix(core): avoid scrollbars in cluster pod header

### DIFF
--- a/app/scripts/modules/core/src/cluster/DefaultClusterPodTitle.tsx
+++ b/app/scripts/modules/core/src/cluster/DefaultClusterPodTitle.tsx
@@ -18,7 +18,7 @@ export class DefaultClusterPodTitle extends React.Component<IClusterPodTitleProp
           <AccountTag account={parentHeading} />
         </div>
 
-        <div className="pod-center">
+        <div className="pod-center horizontal space-between center flex-1">
           <div>
             <span className="glyphicon glyphicon-th"/>
             {' ' + grouping.heading}

--- a/app/scripts/modules/core/src/cluster/rollups.less
+++ b/app/scripts/modules/core/src/cluster/rollups.less
@@ -7,7 +7,7 @@
   }
   .server-group-title {
     input {
-      margin-right: 3px;
+      margin: 0 5px 3px 0;
     }
   }
 }
@@ -190,10 +190,7 @@ table.instances {
   font-size: 16px;
   color: var(--color-primary);
   .pod-center {
-    flex: 1 1 auto;
     min-width: 0;
-    display: flex;
-    justify-content: space-between;
     background-color: var(--color-accent-g2);
     padding: 0 10px;
     border-right: 1px solid var(--color-alabaster);
@@ -345,7 +342,7 @@ running-tasks-tag {
   padding: 0;
 
   .section-title {
-    min-height: 24px;
+    margin-bottom: 3px;
     span {
       font-size: 13px;
     }
@@ -368,6 +365,7 @@ running-tasks-tag {
   }
   .pod-subgroup {
     h6 {
+      display: flex;
       text-transform: uppercase;
       margin: 0;
       padding: 10px 10px 5px;
@@ -493,6 +491,10 @@ running-tasks-tag {
   .server-group-sequence {
     text-transform: uppercase;
     font-weight: 600;
+    margin-left: 2px;
+  }
+  .build-link {
+    margin-left: 3px;
   }
   .server-group-title, .subgroup-title {
     padding: 5px 10px 2px;

--- a/app/scripts/modules/core/src/entityTag/notifications/notifications.less
+++ b/app/scripts/modules/core/src/entityTag/notifications/notifications.less
@@ -66,13 +66,12 @@
 }
 
 .entity-notifications {
-  display: inline-block;
-  position: relative;
+  display: flex;
 
   .tag-marker {
     display: inline-block;
     margin-left: 5px;
-    font-size: 14px;
+    font-size: 15px;
 
     &.inverse {
       .fa {

--- a/app/scripts/modules/core/src/serverGroup/ServerGroup.tsx
+++ b/app/scripts/modules/core/src/serverGroup/ServerGroup.tsx
@@ -196,7 +196,7 @@ export class ServerGroup extends React.Component<IServerGroupProps, IServerGroup
       'sticky-header-3': this.headerIsSticky(),
     });
 
-    const col1ClassName = `col-md-${images ? 9 : 8 } col-sm-6 section-title`;
+    const col1ClassName = `col-md-${images ? 9 : 8 } col-sm-6 section-title horizontal bottom`;
     const col2ClassName = `col-md-${images ? 3 : 4 } col-sm-6 text-right`;
 
     return (
@@ -212,7 +212,7 @@ export class ServerGroup extends React.Component<IServerGroupProps, IServerGroup
 
                   <span className="server-group-sequence"> {this.state.serverGroupSequence}</span>
                   {(hasJenkins || hasImages) && <span>: </span>}
-                  {hasJenkins && <a href={jenkins.href} target="_blank">Build: #{jenkins.number}</a>}
+                  {hasJenkins && <a className="build-link" href={jenkins.href} target="_blank">Build: #{jenkins.number}</a>}
                   {hasImages && <span>{images}</span>}
 
                   <EntityNotifications


### PR DESCRIPTION
I was pretty sure I had fixed this a couple of weeks ago by shrinking the font size of the `tag-marker` class but I hadn't, so now I'm converting a bunch of the header contents to flexbox using the style guide.