### PR TITLE
fix(provider/kubernetes): fix instance dereg lb

### DIFF
--- a/app/scripts/modules/kubernetes/src/instance/details/details.controller.js
+++ b/app/scripts/modules/kubernetes/src/instance/details/details.controller.js
@@ -206,7 +206,7 @@ module.exports = angular.module('spinnaker.instance.detail.kubernetes.controller
       };
 
       var submitMethod = function () {
-        return instanceWriter.registerInstanceWithLoadBalancer(instance, app, { interestingHealthProviderNames: ['Kubernetes'] } );
+        return instanceWriter.registerInstanceWithLoadBalancer(instance, app, { interestingHealthProviderNames: ['Kubernetes'], namespace: instance.region || instance.namespace } );
       };
 
       confirmationModalService.confirm({
@@ -221,14 +221,14 @@ module.exports = angular.module('spinnaker.instance.detail.kubernetes.controller
     this.deregisterInstanceFromLoadBalancer = function deregisterInstanceFromLoadBalancer() {
       var instance = $scope.instance;
       var loadBalancerNames = instance.loadBalancers.join(' and ');
-
+      
       var taskMonitor = {
         application: app,
         title: 'Deregistering ' + instance.name + ' from ' + loadBalancerNames
       };
 
       var submitMethod = function () {
-        return instanceWriter.deregisterInstanceFromLoadBalancer(instance, app, { interestingHealthProviderNames: ['Kubernetes'] } );
+        return instanceWriter.deregisterInstanceFromLoadBalancer(instance, app, { interestingHealthProviderNames: ['Kubernetes'], namespace: instance.region || instance.namespace } );
       };
 
       confirmationModalService.confirm({


### PR DESCRIPTION
deregister and register from/to LB actions werent working due to a
missing namespace.

fixes spinnaker/spinnaker#2340

@lwander @danielpeach i'll cherry pick this over into the 1.6.x branch once merged.