### PR TITLE
feat(core/pipelines): allow triggering of execution via deep link

### DIFF
--- a/app/scripts/modules/core/src/pipeline/pipeline.states.ts
+++ b/app/scripts/modules/core/src/pipeline/pipeline.states.ts
@@ -63,7 +63,7 @@ module(PIPELINE_STATES, [
 
   const executions: INestedState = {
     name: 'executions',
-    url: `?${stateConfigProvider.paramsToQuery(filterModelConfig)}`,
+    url: `?startManualExecution&${stateConfigProvider.paramsToQuery(filterModelConfig)}`,
     views: {
       'pipelines': { component: Executions, $type: 'react' },
     },


### PR DESCRIPTION
We've had a few folks ask for this functionality in the past - provide a way to invoke the manual execution modal from a deep link.