### PR TITLE
fix(core): restore pod header widths to fill container

### DIFF
--- a/app/scripts/modules/core/src/loadBalancer/LoadBalancerPod.tsx
+++ b/app/scripts/modules/core/src/loadBalancer/LoadBalancerPod.tsx
@@ -36,7 +36,7 @@ export class LoadBalancerPod extends React.Component<ILoadBalancerPodProps> {
             <div className="heading-tag">
               <AccountTag account={parentHeading}/>
             </div>
-            <div className="pod-center">
+            <div className="pod-center horizontal space-between center flex-1">
               <div>
                 {grouping.heading}
               </div>

--- a/app/scripts/modules/core/src/projects/dashboard/cluster/projectCluster.directive.html
+++ b/app/scripts/modules/core/src/projects/dashboard/cluster/projectCluster.directive.html
@@ -5,7 +5,7 @@
         <div class="col-md-12">
           <div class="rollup-title-cell">
             <collapsible-account-tag account="{{vm.cluster.account}}" state="vm.state"></collapsible-account-tag>
-            <div class="pod-center">
+            <div class="pod-center horizontal space-between center flex-1">
               <span class="cluster-name">{{vm.clusterLabel}}</span>
             </div>
             <span class="cluster-health">

--- a/app/scripts/modules/core/src/securityGroup/securityGroupPod.html
+++ b/app/scripts/modules/core/src/securityGroup/securityGroupPod.html
@@ -4,7 +4,7 @@
       <div class="heading-tag">
         <account-tag account="parentHeading"></account-tag>
       </div>
-      <div class="pod-center">
+      <div class="pod-center horizontal space-between center flex-1">
         <div>
           <span class="glyphicon glyphicon-transfer"></span>
           {{grouping.heading}}


### PR DESCRIPTION
Missed these yesterday when scanning the codebase as part of https://github.com/spinnaker/deck/pull/4836