### PR TITLE
fix(core): allow overflow on details panel for menus

### DIFF
--- a/app/scripts/modules/core/src/insight/insight.less
+++ b/app/scripts/modules/core/src/insight/insight.less
@@ -7,6 +7,7 @@ insight-layout {
     overflow-x: hidden;
 
     .content {
+      overflow-x: hidden;
       overflow-y: auto;
     }
   }

--- a/app/scripts/modules/core/src/presentation/main.less
+++ b/app/scripts/modules/core/src/presentation/main.less
@@ -117,8 +117,7 @@ html {
   }
   .filters-content, .nav-content, .details-panel, .main-content {
     width: 100%;
-    overflow-y: auto;
-    overflow-x: hidden;
+    overflow-x: visible;
 
     display: flex;
     flex-direction: column;
@@ -133,6 +132,7 @@ html {
     }
   }
   .filters-content {
+    overflow-x: hidden;
     @media (min-width: 708px) and (max-width: 992px) {
       font-size: 90%;
       h3 {

--- a/app/scripts/modules/core/src/styleguide/public/styleguide.html
+++ b/app/scripts/modules/core/src/styleguide/public/styleguide.html
@@ -1154,11 +1154,11 @@ The content section does  not have a box around it.</li>
                   <p>Controlling the number of layers a page has with z-index selectors.
 Use the following selectors to get the specific layer. This eliminates the need to
 manually set z-index that can be difficult to track.</p>
-<pre><code><span class="hljs-number">1</span>. <span class="hljs-class">.layer-critical</span>    gives you <span class="hljs-tag">a</span> zindex of <span class="hljs-number">10000</span>
-<span class="hljs-number">2</span>. <span class="hljs-class">.layer-high</span>        gives you <span class="hljs-tag">a</span> zindex of <span class="hljs-number">9000</span>
-<span class="hljs-number">3</span>. <span class="hljs-class">.layer-medium</span>      gives you  <span class="hljs-tag">a</span> zindex of  <span class="hljs-number">8000</span>
-<span class="hljs-number">4</span>. <span class="hljs-class">.layer-low</span>         gives you <span class="hljs-tag">a</span> zindex of <span class="hljs-number">7000</span>
-<span class="hljs-number">5</span>. <span class="hljs-class">.layer-backdrop</span>    gives you <span class="hljs-tag">a</span> zindex of <span class="hljs-number">6000</span>
+<pre><code><span class="hljs-number">1</span>. <span class="hljs-class">.layer-critical</span> or <span class="hljs-function"><span class="hljs-title">var</span><span class="hljs-params">(--layer-critical)</span></span>    gives you <span class="hljs-tag">a</span> zindex of <span class="hljs-number">10000</span>
+<span class="hljs-number">2</span>. <span class="hljs-class">.layer-high</span> or <span class="hljs-function"><span class="hljs-title">var</span><span class="hljs-params">(--layer-high)</span></span>            gives you <span class="hljs-tag">a</span> zindex of <span class="hljs-number">9000</span>
+<span class="hljs-number">3</span>. <span class="hljs-class">.layer-medium</span> or <span class="hljs-function"><span class="hljs-title">var</span><span class="hljs-params">(--layer-medium)</span></span>        gives you  <span class="hljs-tag">a</span> zindex of  <span class="hljs-number">8000</span>
+<span class="hljs-number">4</span>. <span class="hljs-class">.layer-low</span> or <span class="hljs-function"><span class="hljs-title">var</span><span class="hljs-params">(--layer-low)</span></span>              gives you <span class="hljs-tag">a</span> zindex of <span class="hljs-number">7000</span>
+<span class="hljs-number">5</span>. <span class="hljs-class">.layer-backdrop</span> or <span class="hljs-function"><span class="hljs-title">var</span><span class="hljs-params">(--layer-backdrop)</span></span>    gives you <span class="hljs-tag">a</span> zindex of <span class="hljs-number">6000</span>
 </code></pre>
               
               </div>


### PR DESCRIPTION
It's CSS so it'll probably screw something else up but we can deal with that when we find it.

(This probably only affects Netflix, unless someone else has customized the header for the AWS server group panel and added another menu)

Before:
<img width="244" alt="screen shot 2018-02-13 at 4 39 53 pm" src="https://user-images.githubusercontent.com/73450/36182054-91eecc4a-10dc-11e8-9326-0ed7a421ad82.png">

After:
<img width="333" alt="screen shot 2018-02-13 at 4 41 40 pm" src="https://user-images.githubusercontent.com/73450/36182101-cedddd26-10dc-11e8-891a-276e0e8ab6cb.png">
