### PR TITLE
feat(core): add utility to calculate time to next open window

### DIFF
--- a/app/scripts/modules/core/src/domain/IExecutionWindow.ts
+++ b/app/scripts/modules/core/src/domain/IExecutionWindow.ts
@@ -1,0 +1,11 @@
+export interface IExecutionWindow {
+  whitelist: ITimeWindow[];
+  days?: number[];
+}
+
+export interface ITimeWindow {
+  startHour: number;
+  startMin: number;
+  endHour: number;
+  endMin: number;
+}

--- a/app/scripts/modules/core/src/domain/index.ts
+++ b/app/scripts/modules/core/src/domain/index.ts
@@ -15,6 +15,7 @@ export * from './IEntityTags';
 export * from './IExecution';
 export * from './IExecutionStage';
 export * from './IExecutionTrigger';
+export * from './IExecutionWindow';
 export * from './IExpectedArtifact'
 
 export * from './IHealth';

--- a/app/scripts/modules/core/src/utils/executionWindowUtils.spec.ts
+++ b/app/scripts/modules/core/src/utils/executionWindowUtils.spec.ts
@@ -1,0 +1,136 @@
+import { SETTINGS } from 'core/config/settings';
+import { ITimeWindow } from 'core/domain';
+import { getMinutesToNextWindow } from './executionWindowUtils';
+
+// Tue Feb 13 2018 12:000 GMT
+const now = 1518523200000;
+
+describe('getMinutesToNextWindow', () => {
+
+  let whitelist: ITimeWindow[];
+  let days: number[] = [];
+
+  const getMinutes = () => getMinutesToNextWindow({ whitelist, days }, now);
+
+  beforeEach(() => {
+    SETTINGS.defaultTimeZone = 'Etc/GMT+0';
+    days = [];
+  });
+
+  afterEach(SETTINGS.resetToOriginal);
+
+  describe('in the window', () => {
+    it('handles a window that starts right now and the window is < 1 hour', () => {
+      whitelist = [{
+        startMin: 0,
+        startHour: 12,
+        endMin: 2,
+        endHour: 12
+      }];
+      expect(getMinutes()).toBe(0);
+    });
+    it('handles a window that starts right now and the window is > 1 hour', () => {
+      whitelist = [{
+        startMin: 0,
+        startHour: 12,
+        endMin: 2,
+        endHour: 13
+      }];
+      expect(getMinutes()).toBe(0);
+    });
+    it('handles the last hour of a window', () => {
+      whitelist = [{
+        startMin: 0,
+        startHour: 11,
+        endMin: 1,
+        endHour: 12
+      }];
+      expect(getMinutes()).toBe(0);
+    });
+    it('handles wrapping windows', () => {
+      whitelist = [{
+        startMin: 0,
+        startHour: 23,
+        endMin: 1,
+        endHour: 12
+      }];
+      expect(getMinutes()).toBe(0);
+    });
+    it('considers multiple whitelist entries', () => {
+      whitelist = [
+        {
+          startMin: 0,
+          startHour: 11,
+          endMin: 1,
+          endHour: 11
+        },
+        {
+          startMin: 45,
+          startHour: 11,
+          endMin: 1,
+          endHour: 12
+        }
+      ];
+    });
+    it('considers day of the week', () => {
+      days.push(2);
+      whitelist = [{
+        startMin: 0,
+        startHour: 11,
+        endMin: 1,
+        endHour: 12
+      }];
+      expect(getMinutes()).toBe(0);
+    });
+  });
+
+  describe('outside the window', () => {
+    it('returns 1 if a window starts in one minute', () => {
+      whitelist = [{
+        startMin: 1,
+        startHour: 12,
+        endMin: 2,
+        endHour: 12
+      }];
+      expect(getMinutes()).toBe(1);
+    });
+    it('returns 60 if a window starts in one hour', () => {
+      whitelist = [{
+        startMin: 0,
+        startHour: 13,
+        endMin: 0,
+        endHour: 14
+      }];
+      expect(getMinutes()).toBe(60);
+    });
+    it('rolls over to the next day if there are no windows coming up today', () => {
+      whitelist = [{
+        startMin: 0,
+        startHour: 1,
+        endMin: 0,
+        endHour: 2
+      }];
+      expect(getMinutes()).toBe(60 * 13);
+    });
+    it('rolls over to Thursday if it is the first available day', () => {
+      whitelist = [{
+        startMin: 0,
+        startHour: 12,
+        endMin: 2,
+        endHour: 12
+      }];
+      days = [ 4 ];
+      expect(getMinutes()).toBe(2 * 24 * 60);
+    });
+    it('rolls over to next week if Monday is the only available day', () => {
+      whitelist = [{
+        startMin: 0,
+        startHour: 12,
+        endMin: 2,
+        endHour: 12
+      }];
+      days = [ 1 ];
+      expect(getMinutes()).toBe(6 * 24 * 60);
+    });
+  });
+});

--- a/app/scripts/modules/core/src/utils/executionWindowUtils.ts
+++ b/app/scripts/modules/core/src/utils/executionWindowUtils.ts
@@ -1,0 +1,63 @@
+import { SETTINGS } from 'core/config/settings';
+import { IExecutionWindow } from 'core/domain';
+import * as moment from 'moment';
+
+// current time is just there for testing
+export function getMinutesToNextWindow(window: IExecutionWindow, currentTime = Date.now()): number {
+  const tz = SETTINGS.defaultTimeZone;
+  const now = moment.tz(currentTime, tz).toObject();
+  const today = moment.tz(currentTime, tz).day();
+  const days = (window.days || []).slice().sort((a, b) => a - b);
+  // can this even run today? if not, reset "now" to midnight
+  // this is a cheat on days - we are not considering the actual days of the week
+  const todayIsValid = !days.length || days.includes(today);
+
+  const minutesToNextOpening = window.whitelist.map(w => {
+    if (todayIsValid) {
+      // window < 1hr and in the same hour, e.g. 12:00 to 12:45
+      if (w.startHour === w.endHour && w.startMin <= now.minutes && w.endMin > now.minutes) {
+        return 0;
+      }
+      // in the first hour of the window
+      if (w.startHour !== w.endHour && w.startHour === now.hours && w.startMin <= now.minutes) {
+        return 0;
+      }
+      // in the last hour of the window
+      if (w.startHour !== w.endHour && w.endHour === now.hours && w.endMin > now.minutes) {
+        return 0;
+      }
+      // wrapping window, e.g. 22:00 to 5:00
+      if (w.startHour > w.endHour) {
+        if (w.startHour < now.hours) {
+          return 0;
+        }
+        if (w.endHour > now.hours) {
+          return 0;
+        }
+      }
+      // not a wrapping window, e.g. 9:45 to 15:00
+      if (w.startHour < now.hours && w.endHour > now.hours) {
+        return 0;
+      }
+    }
+    // not in the window
+    let hourOffset = 0;
+    // next day?
+    if (!todayIsValid || w.startHour < now.hours || (w.startHour === now.hours && w.startMin < now.minutes)) {
+      if (days.length) {
+        const lastDay = days[days.length - 1];
+        const firstDay = days[0];
+        if (lastDay <= today) {
+          hourOffset = (7 - today + firstDay) * 24;
+        } else {
+          hourOffset = (days.find(d => d > today) - today) * 24;
+        }
+      } else {
+        hourOffset = 24;
+      }
+    }
+    return (hourOffset + w.startHour - now.hours) * 60 + w.startMin - now.minutes;
+  });
+
+  return Math.min(...minutesToNextOpening);
+}


### PR DESCRIPTION
Should allow us to figure out when a stage with a given execution window restriction will run. 

Not actually using it right now but thinking we could add it to the popover that allows users to skip the execution window, similar to how we do wait stages.

I wrote this for some internal features but figured it makes more sense to keep it in the core module.

(based on [similar logic in Orca](https://github.com/spinnaker/orca/blob/master/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/RestrictExecutionDuringTimeWindow.java))