### PR TITLE
fix(core/canary): don't die if the `monitorCanary` synthetic stage is missing

### DIFF
--- a/app/scripts/modules/canary/canary/canaryStage.transformer.js
+++ b/app/scripts/modules/canary/canary/canaryStage.transformer.js
@@ -133,12 +133,17 @@ module.exports = angular.module('spinnaker.canary.transformer', [])
             $log.warn('No deployment parent found for canary stage in execution:', execution.id);
             return;
           }
+
           var monitorStage = _.find(execution.stages, {
             type: 'monitorCanary',
             context: {
               canaryStageId: stage.id,
             }
           });
+          if (!monitorStage) {
+            $log.warn('No monitorCanary stage found for canary stage in execution:', execution.id);
+            return;
+          }
 
           const deployStages = execution.stages.filter(s =>
             s.parentStageId === deployParent.id && ['deploy', 'createServerGroup'].includes(s.type));
@@ -179,7 +184,7 @@ module.exports = angular.module('spinnaker.canary.transformer', [])
             status = 'SKIPPED';
           }
           var canaryStatus = stage.context.canary.status;
-          if (canaryStatus && status !== 'CANCELED') {
+          if (canaryStatus && !['CANCELED', 'STOPPED'].includes(status)) {
             if (canaryStatus.status === 'LAUNCHED' || monitorStage.status === 'RUNNING') {
               status = 'RUNNING';
             }


### PR DESCRIPTION
@anotherchrisberry PTAL

The other option is to do

```
monitorStage = { context: {} };
```
and let the rest of the code run using the mock stage