### PR TITLE
feat(pubsub): pubsub providers list pulled from settings

### DIFF
--- a/app/scripts/modules/core/src/config/settings.ts
+++ b/app/scripts/modules/core/src/config/settings.ts
@@ -78,6 +78,7 @@ export interface ISpinnakerSettings {
   providers?: {
     [key: string]: IProviderSettings; // allows custom providers not typed in here (good for testing too)
   };
+  pubsubProviders: string[];
   resetProvider: (provider: string) => () => void;
   resetToOriginal: () => void;
   searchVersion: 1 | 2;

--- a/app/scripts/modules/core/src/pipeline/config/triggers/pubsub/pubsub.trigger.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/pubsub/pubsub.trigger.ts
@@ -1,5 +1,7 @@
 import { IController, module } from 'angular';
 
+import { SETTINGS } from 'core/config/settings';
+
 import { PIPELINE_CONFIG_PROVIDER, PipelineConfigProvider } from 'core/pipeline/config/pipelineConfigProvider';
 import {
   PUBSUB_SUBSCRIPTION_SERVICE,
@@ -10,7 +12,7 @@ import {
 } from 'core/domain';
 
 class PubsubTriggerController implements IController {
-  public pubsubSystems = ['kafka', 'google'];
+  public pubsubSystems = SETTINGS.pubsubProviders || ['google', 'kafka'];
   public pubsubSubscriptions: string[];
   public subscriptionsLoaded = false;
 

--- a/settings.js
+++ b/settings.js
@@ -129,6 +129,7 @@ window.spinnakerSettings = {
   authEnabled: authEnabled,
   authTtl: 600000,
   gitSources: ['stash', 'github', 'bitbucket'],
+  pubsubProviders: ['google', 'kafka'],
   triggerTypes: ['git', 'pipeline', 'docker', 'cron', 'jenkins', 'travis', 'pubsub'],
   searchVersion: 1,
   feature: {


### PR DESCRIPTION
This should pull from settings.js if configured, and if not fall back to the old behavior. Is there anything else I need to do to pull the list of pubsub providers from deck settings?