### PR TITLE
fix(provider/kubernetes): exclude manifest stages from v1

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/pipelineConfigProvider.ts
+++ b/app/scripts/modules/core/src/pipeline/config/pipelineConfigProvider.ts
@@ -136,7 +136,6 @@ export class PipelineConfigProvider implements IServiceProvider {
       return configurableStageTypes;
     }
     configurableStageTypes.forEach(type => type.cloudProviders = this.getCloudProvidersForStage(type, allStageTypes, accounts));
-    // remove stage types where all given provider accounts are explicitly excluded by that type
     configurableStageTypes = configurableStageTypes.filter(type => {
       return !accounts.every(a => {
         const p = this.cloudProviderRegistryProvider.getProvider(a.cloudProvider, a.providerVersion);

--- a/app/scripts/modules/kubernetes/src/v1/kubernetes.v1.module.ts
+++ b/app/scripts/modules/kubernetes/src/v1/kubernetes.v1.module.ts
@@ -102,6 +102,13 @@ module(KUBERNETES_V1_MODULE, [
         configurationService: 'kubernetesServerGroupConfigurationService',
         paramsMixin: 'kubernetesServerGroupParamsMixin',
       },
+      unsupportedStageTypes: [
+        'scaleManifest',
+        'deployManifest',
+        'deleteManifest',
+        'undoRolloutManifest',
+        'findArtifactsFromResource',
+      ],
     });
   });
 


### PR DESCRIPTION
Stages available in an application configured only with a V1 Provider, Before & After:

![before_fix](https://user-images.githubusercontent.com/34253460/36287646-23783c7a-1284-11e8-96a4-021b4abb493e.png) ![after_fix](https://user-images.githubusercontent.com/34253460/36287648-25cfca4c-1284-11e8-804e-f7d9e88628ff.png)
