### PR TITLE
chore(core): bump package to 0.0.150

### DIFF
--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/core",
-  "version": "0.0.149",
+  "version": "0.0.150",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
* fix(core/canary): don't die if the `monitorCanary` synthetic stage is not present
* feat(pubsub): pubsub providers list pulled from settings