### PR TITLE
feat(core/angular): Improve error message when angular module dep is undefined

### DIFF
--- a/app/scripts/modules/core/src/index.ts
+++ b/app/scripts/modules/core/src/index.ts
@@ -1,3 +1,5 @@
+import './utils/failedToInstantiateModule';
+
 export * from './account';
 export * from './api';
 export * from './application';

--- a/app/scripts/modules/core/src/utils/failedToInstantiateModule.ts
+++ b/app/scripts/modules/core/src/utils/failedToInstantiateModule.ts
@@ -1,0 +1,13 @@
+import * as angular from 'angular';
+import { IModule } from 'angular';
+
+// Improve errors/stack traces related to:
+// `Error: [ng:areq] Argument 'module' is not a function, got undefined`
+const realModule = angular.module;
+(angular as any).module = function(name: string, requires?: string[], configFn?: Function): IModule {
+  if (requires && requires.some(dep => !dep)) {
+    const deps = requires.map(r => typeof r === 'string' ? `'${r}'` : `${r}`).join(', ');
+    throw new Error(`Got falsey dependency whilst registering angular module '${name}': [${deps}]`);
+  }
+  return realModule(name, requires, configFn);
+};

--- a/app/scripts/modules/core/src/utils/index.ts
+++ b/app/scripts/modules/core/src/utils/index.ts
@@ -1,4 +1,6 @@
 ///<reference path="./classnames.d.ts" />
+///<reference path="./q.d.ts" />
+
 export * from './debug';
 export * from './json/json.utility.service';
 export * from './noop';

--- a/app/scripts/modules/core/src/utils/q.d.ts
+++ b/app/scripts/modules/core/src/utils/q.d.ts
@@ -1,0 +1,9 @@
+import { IQService, IPromise } from '@types/angular';
+
+// add an overload for normalizing a regular Promise into an angular IPromise
+declare module '@types/angular' {
+  interface IQService {
+    when<T>(promise: Promise<T>): IPromise<T>;
+    resolve<T>(promise: Promise<T>): IPromise<T>;
+  }
+}


### PR DESCRIPTION
Also add typescript overload to $q for normalizing a real promise into a fake angularjs promise.

fixes typings of :
`const stringPromise = $q.when(Promise.resolve('foo'))`

before, stringPromise was an `IPromise<Promise<string>>`
now, it will be an `IPromise<string>`