### PR TITLE
feat(core/executions): allow pipeline rerun with same parameters

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/pipelineConfigurer.js
+++ b/app/scripts/modules/core/src/pipeline/config/pipelineConfigurer.js
@@ -378,7 +378,7 @@ module.exports = angular.module('spinnaker.core.pipeline.config.pipelineConfigur
     };
 
     this.getPipelineExecutions = () => {
-      executionService.getExecutionsForConfigIds($scope.pipeline.application, [$scope.pipeline.id], 5)
+      executionService.getExecutionsForConfigIds($scope.pipeline.id, { limit: 5, transform: true, application: $scope.pipeline.application})
         .then(executions => {
           executions.forEach(execution => executionsTransformer.addBuildInfo(execution));
           $scope.pipelineExecutions = executions;

--- a/app/scripts/modules/core/src/pipeline/config/triggers/jenkins/jenkinsTriggerOptions.directive.js
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/jenkins/jenkinsTriggerOptions.directive.js
@@ -24,7 +24,8 @@ module.exports = angular
       this.builds = builds.filter((build) => !build.building && build.result === 'SUCCESS')
         .sort((a, b) => b.number - a.number);
       if (this.builds.length) {
-        let defaultSelection = this.builds[0];
+        // default to what is supplied by the trigger if possible; otherwise, use the latest
+        let defaultSelection = this.builds.find(b => b.number === this.command.trigger.buildNumber) || this.builds[0];
         this.viewState.selectedBuild = defaultSelection;
         this.updateSelectedBuild(defaultSelection);
       }
@@ -45,8 +46,12 @@ module.exports = angular
       this.viewState = {
         buildsLoading: true,
         loadError: false,
-        selectedBuild: null,
+        selectedBuild: command.trigger.buildNumber,
       };
+
+      if (command.trigger.buildNumber) {
+        this.updateSelectedBuild(command.trigger.buildInfo);
+      }
 
       // do not re-initialize if the trigger has changed to some other type
       if (command.trigger.type !== 'jenkins') {

--- a/app/scripts/modules/core/src/pipeline/config/triggers/jenkins/jenkinsTriggerOptions.directive.spec.js
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/jenkins/jenkinsTriggerOptions.directive.spec.js
@@ -48,7 +48,7 @@ describe('Jenkins Trigger: JenkinsTriggerOptionsCtrl', function() {
     expect(ctrl.viewState.buildsLoading).toBe(false);
     expect(ctrl.viewState.loadError).toBe(false);
     expect(ctrl.builds).toEqual(builds);
-    expect(ctrl.viewState.selectedBuild).toBe(null);
+    expect(ctrl.viewState.selectedBuild).toBeUndefined();
   });
 
   it('sets build to first one available when returned on initialization', function () {
@@ -74,7 +74,7 @@ describe('Jenkins Trigger: JenkinsTriggerOptionsCtrl', function() {
     expect(ctrl.viewState.buildsLoading).toBe(false);
     expect(ctrl.viewState.loadError).toBe(true);
     expect(ctrl.builds).toBeUndefined();
-    expect(ctrl.viewState.selectedBuild).toBe(null);
+    expect(ctrl.viewState.selectedBuild).toBeUndefined();
     expect(command.extraFields.buildNumber).toBeUndefined();
   });
 

--- a/app/scripts/modules/core/src/pipeline/config/triggers/pipeline/pipelineTrigger.module.js
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/pipeline/pipelineTrigger.module.js
@@ -32,16 +32,21 @@ module.exports = angular.module('spinnaker.core.pipeline.config.trigger.pipeline
     return {
       formatLabel: (trigger) => {
 
+        // if this is a re-run, the trigger info will be on the parentExecution; otherwise, check the trigger itself
+        // (normalization occurs in the pipelineTriggerOptions component, but that renders after this method is called)
+        const application = _.get(trigger, 'parentExecution.application', trigger.application);
+        const pipelineConfigId = _.get(trigger, 'parentExecution.pipelineConfigId', trigger.pipeline);
+
         let loadSuccess = (pipelines) => {
-          let pipeline = pipelines.find((config) => config.id === trigger.pipeline);
-          return pipeline ? `(Pipeline) ${trigger.application}: ${pipeline.name}` : '[pipeline not found]';
+          let pipeline = pipelines.find((config) => config.id === pipelineConfigId);
+          return pipeline ? `(Pipeline) ${application}: ${pipeline.name}` : '[pipeline not found]';
         };
 
         let loadFailure = () => {
-          return `[could not load pipelines for '${trigger.application}']`;
+          return `[could not load pipelines for '${application}']`;
         };
 
-        return pipelineConfigService.getPipelinesForApplication(trigger.application)
+        return pipelineConfigService.getPipelinesForApplication(application)
           .then(loadSuccess, loadFailure);
       },
       selectorTemplate: require('./selectorTemplate.html'),

--- a/app/scripts/modules/core/src/pipeline/config/triggers/pipeline/pipelineTriggerOptions.directive.spec.js
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/pipeline/pipelineTriggerOptions.directive.spec.js
@@ -40,7 +40,7 @@ describe('Pipeline Trigger: PipelineTriggerOptionsCtrl', function() {
 
   it('loads executions on initialization, setting state flags', function () {
     let executions = [];
-    spyOn(executionService, 'getExecutions').and.returnValue($q.when(executions));
+    spyOn(executionService, 'getExecutionsForConfigIds').and.returnValue($q.when(executions));
 
     this.initialize();
     expect(ctrl.viewState.executionsLoading).toBe(true);
@@ -53,25 +53,24 @@ describe('Pipeline Trigger: PipelineTriggerOptionsCtrl', function() {
 
   it('sets execution to first one available when returned on initialization', function () {
     let executions = [
-      { pipelineConfigId: 'b', buildTime: 1, id: 'b-1', application: 'a' },
       { pipelineConfigId: 'b', buildTime: 3, id: 'b-3', application: 'a' },
-      { pipelineConfigId: 'c', buildTime: 2, id: 'c-2', application: 'a' },
+      { pipelineConfigId: 'b', buildTime: 1, id: 'b-1', application: 'a' },
     ];
-    spyOn(executionService, 'getExecutions').and.returnValue($q.when(executions));
+    spyOn(executionService, 'getExecutionsForConfigIds').and.returnValue($q.when(executions));
 
     this.initialize();
     expect(ctrl.viewState.executionsLoading).toBe(true);
     $scope.$digest();
     expect(ctrl.viewState.executionsLoading).toBe(false);
     expect(ctrl.viewState.loadError).toBe(false);
-    expect(ctrl.executions).toEqual([executions[1], executions[0]]);
-    expect(ctrl.viewState.selectedExecution).toBe(executions[1]);
+    expect(ctrl.executions).toEqual([executions[0], executions[1]]);
+    expect(ctrl.viewState.selectedExecution).toBe(executions[0]);
     expect(command.extraFields.parentPipelineId).toBe('b-3');
     expect(command.extraFields.parentPipelineApplication).toBe('a');
   });
 
   it('sets flags when execution load fails', function () {
-    spyOn(executionService, 'getExecutions').and.returnValue($q.reject('does not matter'));
+    spyOn(executionService, 'getExecutionsForConfigIds').and.returnValue($q.reject('does not matter'));
 
     this.initialize();
     expect(ctrl.viewState.executionsLoading).toBe(true);
@@ -89,12 +88,12 @@ describe('Pipeline Trigger: PipelineTriggerOptionsCtrl', function() {
         secondExecution = { pipelineConfigId: 'c', buildTime: 3, id: 'c-3', application: 'b' },
         secondTrigger = { type: 'pipeline', application: 'b', pipeline: 'c'};
 
-    spyOn(executionService, 'getExecutions').and.callFake((application) => {
+    spyOn(executionService, 'getExecutionsForConfigIds').and.callFake((configIds) => {
       let executions = [];
-      if (application === 'a') {
+      if (configIds[0] === 'b') {
         executions = [firstExecution];
       }
-      if (application === 'b') {
+      if (configIds[0] === 'c') {
         executions = [secondExecution];
       }
       return $q.when(executions);

--- a/app/scripts/modules/core/src/pipeline/config/triggers/travis/travisTriggerOptions.component.spec.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/travis/travisTriggerOptions.component.spec.ts
@@ -60,7 +60,7 @@ describe('Travis Trigger: TravisTriggerOptionsCtrl', () => {
     expect(controller.viewState.buildsLoading).toBe(false);
     expect(controller.viewState.loadError).toBe(false);
     expect(controller.builds).toEqual(builds);
-    expect(controller.viewState.selectedBuild).toBe(null);
+    expect(controller.viewState.selectedBuild).toBeUndefined();
   });
 
   it('sets build to first one available when returned on initialization', function () {
@@ -86,7 +86,7 @@ describe('Travis Trigger: TravisTriggerOptionsCtrl', () => {
     expect(controller.viewState.buildsLoading).toBe(false);
     expect(controller.viewState.loadError).toBe(true);
     expect(controller.builds).toBeUndefined();
-    expect(controller.viewState.selectedBuild).toBe(null);
+    expect(controller.viewState.selectedBuild).toBeUndefined();
     expect(command.extraFields.buildNumber).toBeUndefined();
   });
 

--- a/app/scripts/modules/core/src/pipeline/config/triggers/travis/travisTriggerOptions.component.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/travis/travisTriggerOptions.component.ts
@@ -23,7 +23,7 @@ export class TravisTriggerOptionsController {
     this.viewState = {
       buildsLoading: true,
       loadError: false,
-      selectedBuild: null,
+      selectedBuild: this.command.trigger.buildNumber,
     };
 
     this.$scope.$watch(() => this.command.trigger, () => this.initialize());
@@ -34,7 +34,8 @@ export class TravisTriggerOptionsController {
       .filter((build) => !build.building && build.result === 'SUCCESS')
       .sort((a, b) => b.number - a.number);
     if (this.builds.length) {
-      const defaultSelection = this.builds[0];
+      // default to what is supplied by the trigger if possible; otherwise, use the latest
+      const defaultSelection = this.builds.find(b => b === this.command.trigger.buildNumber) || this.builds[0];
       this.viewState.selectedBuild = defaultSelection;
       this.updateSelectedBuild(defaultSelection);
     }

--- a/app/scripts/modules/core/src/pipeline/executions/Executions.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/Executions.tsx
@@ -152,6 +152,7 @@ export class Executions extends React.Component<IExecutionsProps, IExecutionsSta
       controller: 'ManualPipelineExecutionCtrl as vm',
       resolve: {
         pipeline: () => pipeline,
+        trigger: () => null as any,
         application: () => this.props.app,
       }
     }).result

--- a/app/scripts/modules/core/src/pipeline/executions/execution/Execution.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/execution/Execution.tsx
@@ -9,7 +9,7 @@ import * as classNames from 'classnames';
 import { Application } from 'core/application/application.model';
 import { StageExecutionDetails } from 'core/pipeline/details/StageExecutionDetails';
 import { ExecutionStatus } from 'core/pipeline/status/ExecutionStatus';
-import { IExecution , IRestartDetails } from 'core/domain';
+import { IExecution, IRestartDetails } from 'core/domain';
 import { IExecutionViewState, IPipelineGraphNode } from 'core/pipeline/config/graph/pipelineGraph.service';
 import { IScheduler } from 'core/scheduler/scheduler.factory';
 import { OrchestratedItemRunningTime } from './OrchestratedItemRunningTime';
@@ -34,6 +34,7 @@ export interface IExecutionProps {
   title?: string | JSX.Element;
   dataSourceKey?: string;
   showAccountLabels?: boolean;
+  onRerun?: (execution: IExecution) => void;
 }
 
 export interface IExecutionState {
@@ -224,28 +225,29 @@ export class Execution extends React.Component<IExecutionProps, IExecutionState>
     ReactGA.event({ category: 'Pipeline', action: 'Execution source clicked (no stages found)' });
   }
 
-  private handlePauseClick(event: React.MouseEvent<HTMLElement>): void {
+  private handlePauseClick(): void {
     ReactGA.event({ category: 'Pipeline', action: 'Execution pause clicked' });
     this.pauseExecution();
-    event.stopPropagation();
   }
 
-  private handleResumeClick(event: React.MouseEvent<HTMLElement>): void {
+  private handleResumeClick(): void {
     ReactGA.event({ category: 'Pipeline', action: 'Execution resume clicked' });
     this.resumeExecution();
-    event.stopPropagation();
   }
 
-  private handleDeleteClick(event: React.MouseEvent<HTMLElement>): void {
+  private handleDeleteClick(): void {
     ReactGA.event({ category: 'Pipeline', action: 'Execution delete clicked' });
     this.deleteExecution();
-    event.stopPropagation();
   }
 
-  private handleCancelClick(event: React.MouseEvent<HTMLElement>): void {
+  private handleCancelClick(): void {
     ReactGA.event({ category: 'Pipeline', action: 'Execution cancel clicked' });
     this.cancelExecution();
-    event.stopPropagation();
+  }
+
+  private handleRerunClick(): void {
+    ReactGA.event({ category: 'Pipeline', action: 'Execution rerun clicked' });
+    this.props.onRerun(this.props.execution);
   }
 
   private handleSourceClick(): void {
@@ -336,30 +338,39 @@ export class Execution extends React.Component<IExecutionProps, IExecutionState>
           <div className="execution-actions">
             { execution.isRunning && (
               <Tooltip value="Pause execution">
-                <a className="clickable" onClick={this.handlePauseClick}>
-                  <span className="glyphicon glyphicon-pause"/>
-                </a>
+                <button className="link" onClick={this.handlePauseClick}>
+                  <i className="fa fa-pause"/>
+                </button>
               </Tooltip>
             )}
             { execution.isPaused && (
               <Tooltip value="Resume execution">
-                <a className="clickable" onClick={this.handleResumeClick}>
-                  <span className="glyphicon glyphicon-play"/>
-                </a>
+                <button className="link" onClick={this.handleResumeClick}>
+                  <i className="fa fa-play"/>
+                </button>
               </Tooltip>
             )}
             { !execution.isActive && (
-              <Tooltip value="Delete execution">
-                <a className="clickable" onClick={this.handleDeleteClick}>
-                  <span className="glyphicon glyphicon-trash"/>
-                </a>
-              </Tooltip>
+              <span>
+                {this.props.onRerun && (
+                  <Tooltip value="Re-run execution with same parameters">
+                    <button className="link" onClick={this.handleRerunClick}>
+                      <i className="fa fa-repeat"/>
+                    </button>
+                  </Tooltip>
+                )}
+                <Tooltip value="Delete execution">
+                  <button className="link" onClick={this.handleDeleteClick}>
+                    <span className="glyphicon glyphicon-trash"/>
+                  </button>
+                </Tooltip>
+              </span>
             )}
             { execution.isActive && (
               <Tooltip value="Cancel execution">
-                <a className="clickable" onClick={this.handleCancelClick}>
-                  <span className="glyphicon glyphicon-remove-circle"/>
-                </a>
+                <button className="link" onClick={this.handleCancelClick}>
+                  <i className="fa fa-times-circle-o"/>
+                </button>
               </Tooltip>
             )}
           </div>

--- a/app/scripts/modules/core/src/pipeline/executions/execution/execution.less
+++ b/app/scripts/modules/core/src/pipeline/executions/execution/execution.less
@@ -62,13 +62,12 @@
   vertical-align: top;
   padding-top: 20px;
   margin-left: 6px;
-  .glyphicon-remove-circle {
+  .fa-times-circle-o {
     color: var(--color-danger);
   }
 
-  a {
-    text-decoration: none;
-
+  button.link {
+    padding: 2px 3px 0;
     &:first-child {
       padding-right: 5px;
     }

--- a/app/scripts/modules/core/src/pipeline/manualExecution/manualPipelineExecution.controller.spec.js
+++ b/app/scripts/modules/core/src/pipeline/manualExecution/manualPipelineExecution.controller.spec.js
@@ -20,6 +20,7 @@ describe('Controller: ManualPipelineExecution', function () {
         pipeline: pipeline,
         pipelineConfig: pipelineConfig,
         $uibModalInstance: modalInstance || {},
+        trigger: null,
         notificationService: this.notificationService,
       });
     };

--- a/app/scripts/modules/docker/src/pipeline/trigger/dockerTriggerOptions.directive.js
+++ b/app/scripts/modules/docker/src/pipeline/trigger/dockerTriggerOptions.directive.js
@@ -34,7 +34,8 @@ module.exports = angular
     let tagLoadSuccess = (tags) => {
       this.tags = tags;
       if (this.tags.length) {
-        let defaultSelection = this.tags[0];
+        // default to what is supplied by the trigger if possible; otherwise, use the latest
+        let defaultSelection = this.tags.find(t => t === this.command.trigger.tag) || this.tags[0];
         this.viewState.selectedTag = defaultSelection;
         this.updateSelectedTag(defaultSelection);
       }


### PR DESCRIPTION
Adds an icon next to completed executions, allowing users to trigger a re-run of the pipeline with the same parameters (and build, for Jenkins).

<img width="595" alt="screen shot 2018-02-19 at 3 09 56 pm" src="https://user-images.githubusercontent.com/73450/36400640-044341aa-1587-11e8-97a1-0f957b2d7683.png">