### PR TITLE
fix(provider/kubernetes): delete action broken for all but server groups

### DIFF
--- a/app/scripts/modules/kubernetes/src/v2/instance/details/details.controller.ts
+++ b/app/scripts/modules/kubernetes/src/v2/instance/details/details.controller.ts
@@ -70,7 +70,8 @@ class KubernetesInstanceDetailsController implements IController {
           namespace: this.instance.namespace,
           account: this.instance.account,
         },
-        application: this.app
+        application: this.app,
+        manifestController: () => null,
       }
     });
   }

--- a/app/scripts/modules/kubernetes/src/v2/loadBalancer/details/details.controller.ts
+++ b/app/scripts/modules/kubernetes/src/v2/loadBalancer/details/details.controller.ts
@@ -40,7 +40,8 @@ class KubernetesLoadBalancerDetailsController implements IController {
           namespace: this.loadBalancerFromParams.region,
           account: this.loadBalancerFromParams.accountId,
         },
-        application: this.app
+        application: this.app,
+        manifestController: () => null,
       }
     });
   }

--- a/app/scripts/modules/kubernetes/src/v2/securityGroup/details/details.controller.ts
+++ b/app/scripts/modules/kubernetes/src/v2/securityGroup/details/details.controller.ts
@@ -39,7 +39,8 @@ class KubernetesSecurityGroupDetailsController implements IController {
           namespace: this.securityGroupFromParams.region,
           account: this.securityGroupFromParams.accountId,
         },
-        application: this.app
+        application: this.app,
+        manifestController: () => null,
       }
     });
   }

--- a/app/scripts/modules/kubernetes/src/v2/serverGroupManager/details/details.controller.ts
+++ b/app/scripts/modules/kubernetes/src/v2/serverGroupManager/details/details.controller.ts
@@ -130,7 +130,8 @@ class KubernetesServerGroupManagerDetailsController implements IController {
           namespace: this.serverGroupManager.namespace,
           account: this.serverGroupManager.account
         },
-        application: this.app
+        application: this.app,
+        manifestController: () => null,
       }
     });
   }


### PR DESCRIPTION
`manifestController` is now a required, injected dependency of `kubernetesV2ManifestDeleteCtrl` but this isn't caught by type-checking because uibModal resolves the deps at runtime.  No-op needs to be provided for all users of that controller: loadBalancer details, instance details, security group details, and server group manager details.

Before fix, delete modal doesn't appear and error appears in console:

![before_fix](https://user-images.githubusercontent.com/34253460/36441986-461fc1f0-1642-11e8-8c27-93d910a6827e.png)

After fix, delete modal correctly appears:

![after_fix](https://user-images.githubusercontent.com/34253460/36441990-4b3877f4-1642-11e8-950b-ab703dd71d1e.png)
