### PR TITLE
fix(core/pipeline): Fix pipeline config - add stage that uses BaseProviderStageCtrl

### DIFF
--- a/app/scripts/modules/core/src/account/account.service.ts
+++ b/app/scripts/modules/core/src/account/account.service.ts
@@ -1,4 +1,4 @@
-import { chain, intersection, zipObject } from 'lodash';
+import { chain, intersection, zipObject, uniq } from 'lodash';
 import { ILogService, IPromise, IQResolveReject, IQService, module } from 'angular';
 import { Observable } from 'rxjs';
 
@@ -58,7 +58,7 @@ export class AccountService {
   }).publishReplay(1).refCount();
 
   public providers$ = this.accounts$.map((accounts: IAccountDetails[]) => {
-    const providersFromAccounts: string[] = Array.from(new Set(accounts.map((account: IAccount) => account.type)));
+    const providersFromAccounts: string[] = uniq(accounts.map(account => account.type));
     return intersection(providersFromAccounts, this.cloudProviderRegistry.listRegisteredProviders());
   });
 

--- a/app/scripts/modules/core/src/account/account.service.ts
+++ b/app/scripts/modules/core/src/account/account.service.ts
@@ -57,6 +57,11 @@ export class AccountService {
     return Observable.fromPromise<IAccountDetails[]>(promise);
   }).publishReplay(1).refCount();
 
+  public providers$ = this.accounts$.map((accounts: IAccountDetails[]) => {
+    const providersFromAccounts: string[] = Array.from(new Set(accounts.map((account: IAccount) => account.type)));
+    return intersection(providersFromAccounts, this.cloudProviderRegistry.listRegisteredProviders());
+  });
+
   constructor(private $log: ILogService,
               private $q: IQService,
               private cloudProviderRegistry: CloudProviderRegistry,
@@ -171,30 +176,24 @@ export class AccountService {
     });
   }
 
-  public listProviders(application: Application = null): IPromise<string[]> {
-    return this.listAllAccounts()
-      .then((accounts: IAccount[]) => {
-        const all: string[] = Array.from(new Set(accounts.map((account: IAccount) => account.type)));
-        const available: string[] = intersection(all, this.cloudProviderRegistry.listRegisteredProviders());
-        let result: string[];
-        if (application) {
-          if (application.attributes.cloudProviders.length) {
-            result = application.attributes.cloudProviders;
-          } else {
-            if (SETTINGS.defaultProviders) {
-              result = SETTINGS.defaultProviders;
-            } else {
-              result = available;
-            }
-          }
-
-          result = intersection(available, result);
+  public listProviders$(application: Application = null): Observable<string[]> {
+    return this.providers$
+      .map((available: string[]) => {
+        if (!application) {
+          return available;
+        } else if (application.attributes.cloudProviders.length) {
+          return intersection(available, application.attributes.cloudProviders);
+        } else if (SETTINGS.defaultProviders) {
+          return intersection(available, SETTINGS.defaultProviders)
         } else {
-          result = available;
+          return available;
         }
+      })
+      .map(results => results.sort());
+  }
 
-        return result.sort();
-      });
+  public listProviders(application: Application = null): IPromise<string[]> {
+    return this.$q.when(this.listProviders$(application).toPromise());
   }
 }
 

--- a/app/scripts/modules/core/src/cache/cacheInitializer.service.spec.ts
+++ b/app/scripts/modules/core/src/cache/cacheInitializer.service.spec.ts
@@ -87,6 +87,7 @@ describe('Service: cacheInitializer', function () {
       spyOn(securityGroupReader, 'getAllSecurityGroups').and.returnValue($q.when(keys.sg));
       spyOn(applicationReader, 'listApplications').and.returnValue($q.when(keys.app));
       spyOn(igorService, 'listMasters').and.returnValue($q.when(keys.bm));
+      spyOn(accountService, 'listProviders').and.returnValue($q.when([]));
     });
 
     it('should initialize the cache initializer with the initialization values', () => {

--- a/app/scripts/modules/core/src/pipeline/config/stages/baseProviderStage/baseProviderStage.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/baseProviderStage/baseProviderStage.js
@@ -22,7 +22,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.baseProviderStage
       stageProviders.push({cloudProvider: 'docker'});
     }
 
-    accountService.listProviders($scope.application).then(function (providers) {
+    accountService.listProviders$($scope.application).take(1).subscribe(function (providers) {
       $scope.viewState.loading = false;
       const availableProviders = [];
       stageProviders.forEach(sp => {


### PR DESCRIPTION
@jrsquared @ethanfrogers @lwander 

This (hopefully) fixes an issue when adding a stage to a pipeline.  It seems there was some `$q` trickery going previously, which was lost when wrapping a native promise as a `$q` promise `$q.when(observable$.toPromise())`.  I suspect this was due to the `$q` promise participating in the existing AngularJS digest cycle, while the wrapped promise was executing after an event loop tick.

This switches the `BaseProviderStageCtrl` to use an observable API which executes synchronously, when possible.