### PR TITLE
fix(core): allow grouping by time on cancelled executions

### DIFF
--- a/app/scripts/modules/core/src/domain/IExecution.ts
+++ b/app/scripts/modules/core/src/domain/IExecution.ts
@@ -6,6 +6,7 @@ export interface IExecution extends IOrchestratedItem {
   appConfig?: any;
   application: string;
   buildInfo?: any;
+  buildTime?: number;
   canceledBy?: string;
   cancellationReason?: string;
   context?: { [key: string]: any };

--- a/app/scripts/modules/core/src/pipeline/filter/executionFilter.service.ts
+++ b/app/scripts/modules/core/src/pipeline/filter/executionFilter.service.ts
@@ -36,7 +36,10 @@ export class ExecutionFilterService {
   }
 
   private groupByTimeBoundary(executions: IExecution[]): {[boundaryName: string]: IExecution[]} {
-    return groupBy(executions, (execution) => boundaries.find((boundary) => moment(execution.startTime).isAfter(boundary.after())).name);
+    return groupBy(executions, (execution) =>
+      boundaries.find((boundary) =>
+        // executions that were cancelled before ever starting will not have a startTime, just a buildTime
+        moment(execution.startTime || execution.buildTime).isAfter(boundary.after())).name);
   }
 
   @Debounce(25)


### PR DESCRIPTION
Ran into this today, looking at executions that were cancelled due to concurrent execution configuration.