### PR TITLE
fix(core/pipelines): force data refresh on pipeline creation

### DIFF
--- a/app/scripts/modules/core/src/pipeline/create/CreatePipelineModal.tsx
+++ b/app/scripts/modules/core/src/pipeline/create/CreatePipelineModal.tsx
@@ -154,7 +154,7 @@ export class CreatePipelineModal extends React.Component<ICreatePipelineModalPro
 
   private onSaveSuccess(config: Partial<IPipeline>): void {
     const application = this.props.application;
-    application.getDataSource('pipelineConfigs').refresh().then(() => {
+    application.getDataSource('pipelineConfigs').refresh(true).then(() => {
       const newPipeline = (config.strategy ?
                           (application.strategyConfigs.data as IPipeline[]) :
                            application.getDataSource('pipelineConfigs').data).find(_config => _config.name === config.name);


### PR DESCRIPTION
There's a potential race condition when saving a pipeline: if the data source is already loading when the pipeline save starts, the save success handler could try to refresh without doing anything. Then the user gets an error message that is slightly confusing, and most users will just try to re-save the pipeline, which won't work because it's already saved successfully.

This just forces a refresh of the configs to avoid that situation.