### PR TITLE
feat(core) add a help menu with links to docs and community

### DIFF
--- a/app/scripts/modules/core/src/header/SpinnakerHeader.tsx
+++ b/app/scripts/modules/core/src/header/SpinnakerHeader.tsx
@@ -5,6 +5,7 @@ import { UIRouterContext } from '@uirouter/react-hybrid';
 
 import { NgReact } from 'core/reactShims';
 import { GlobalSearch } from 'core/search/global/GlobalSearch';
+import { HelpMenu } from 'core/help/HelpMenu';
 
 import './SpinnakerHeader.css';
 
@@ -82,6 +83,7 @@ export class SpinnakerHeader extends React.Component<{}, ISpinnakerHeaderState> 
               <UserMenu />
               <GlobalSearch />
               <WhatsNew />
+              <HelpMenu />
             </ul>
           </div>
         }

--- a/app/scripts/modules/core/src/help/HelpMenu.less
+++ b/app/scripts/modules/core/src/help/HelpMenu.less
@@ -1,0 +1,32 @@
+.help-menu {
+  border: 0;
+
+  .dropdown-toggle,
+  .dropdown-toggle:active {
+    border: 0;
+    font-size: 14px;
+    font-weight: 200;
+    margin: 0;
+    border: 0;
+    background: transparent;
+    border-radius: 0;
+    color: var(--color-white);
+
+    .caret {
+      margin-left: 3px;
+    }
+  }
+
+  .dropdown.open {
+    .dropdown-toggle {
+      background-color: transparent;
+      text-decoration: none;
+      color: var(--color-white);
+      box-shadow: none;
+    }
+  }
+
+  .dropdown-menu {
+    border: 0;
+  }
+}

--- a/app/scripts/modules/core/src/help/HelpMenu.tsx
+++ b/app/scripts/modules/core/src/help/HelpMenu.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import { Dropdown, MenuItem, Glyphicon } from 'react-bootstrap';
+
+import './HelpMenu.less';
+
+const DOCS_URL = 'https://spinnaker.io/docs';
+const COMMUNITY_URL = 'https://spinnaker.io/community';
+
+export const HelpMenu = () => {
+  return (
+    <li className="help-menu">
+      <Dropdown id="help-menu-dropdown" pullRight={true}>
+        <Dropdown.Toggle className="hidden-lg" noCaret={true}>
+          <Glyphicon glyph="question-sign" />
+        </Dropdown.Toggle>
+        <Dropdown.Menu>
+          <MenuItem href={DOCS_URL} target="_blank">
+            Docs
+          </MenuItem>
+          <MenuItem divider={true} />
+          <MenuItem href={COMMUNITY_URL} target="_blank">
+            Community Resources
+          </MenuItem>
+        </Dropdown.Menu>
+      </Dropdown>
+
+      <Dropdown id="help-menu-dropdown-large" pullRight={true}>
+        <Dropdown.Toggle className="hidden-xs hidden-sm hidden-md">
+          Help
+        </Dropdown.Toggle>
+        <Dropdown.Menu>
+          <MenuItem href={DOCS_URL} target="_blank">
+            Docs
+          </MenuItem>
+          <MenuItem href={COMMUNITY_URL} target="_blank">
+            Community Resources
+          </MenuItem>
+        </Dropdown.Menu>
+      </Dropdown>
+    </li>
+  );
+};


### PR DESCRIPTION
This PR adds a help menu in the app's header, to the right of the Search and, if present, the What's New button:

![help_lg](https://user-images.githubusercontent.com/34253460/36566755-5f1b4aba-17f2-11e8-99a9-659ace45a0a1.png)
![help_sm](https://user-images.githubusercontent.com/34253460/36566786-78bea0a2-17f2-11e8-8aeb-07f3c882c75d.png)
![help_menu_lg](https://user-images.githubusercontent.com/34253460/36566797-869e125c-17f2-11e8-8fcc-08030c3d80cd.png)
![help_menu_sm](https://user-images.githubusercontent.com/34253460/36566799-88adec34-17f2-11e8-8ccc-9e3ebd3ad65e.png)

These screenshots show help without the optional Auth menu and What's New button:
![help_lg_no_auth_no_whats_new](https://user-images.githubusercontent.com/34253460/36566805-8b876b42-17f2-11e8-9fdd-892b562489f8.png)
![help_menu_sm_no_auth_no_whats_new](https://user-images.githubusercontent.com/34253460/36566807-8d171a70-17f2-11e8-9a85-21a0bf2b50a5.png)
