### PR TITLE
feat(core/pipelines): allow user-friendly labels on pipeline parameters

### DIFF
--- a/app/scripts/modules/core/src/help/help.contents.ts
+++ b/app/scripts/modules/core/src/help/help.contents.ts
@@ -310,4 +310,7 @@ module(HELP_CONTENTS, [])
     'pipeline.config.webhook.canceledStatuses': 'Comma-separated list of strings that will be considered as CANCELED status.',
     'pipeline.config.webhook.terminalStatuses': 'Comma-separated list of strings that will be considered as TERMINAL status.',
     'pipeline.config.webhook.customHeaders': 'Key-value pairs to be sent as additional headers to the service.',
+    'pipeline.config.parameter.label': '(Optional): a label to display when users are triggering the pipeline manually',
+    'pipeline.config.parameter.description': `(Optional): if supplied, will be displayed to users as a tooltip
+        when triggering the pipeline manually. You can include HTML in this field.`,
   });

--- a/app/scripts/modules/core/src/pipeline/config/parameters/parameter.html
+++ b/app/scripts/modules/core/src/pipeline/config/parameters/parameter.html
@@ -32,7 +32,12 @@
         </div>
       </stage-config-field>
 
-      <stage-config-field label="Description">
+      <stage-config-field label="Label" help-key="pipeline.config.parameter.label">
+        <input type="text" ng-model="parameter.label"
+               class="form-control input-sm"/>
+      </stage-config-field>
+
+      <stage-config-field label="Description" help-key="pipeline.config.parameter.description">
         <input type="text" ng-model="parameter.description"
                class="form-control input-sm"/>
       </stage-config-field>
@@ -54,7 +59,7 @@
             <span class="glyphicon glyphicon-trash" uib-tooltip="Remove Option"></span><span class="sr-only">Remove Option</span>
           </button>
         </div>
-        <button class="btn btn-sm btn-default" ng-click="parameterCtrl.addOption(parameter)">
+        <button class="btn btn-sm btn-default add-new" ng-click="parameterCtrl.addOption(parameter)" style="margin-top: 10px">
           <span class="glyphicon glyphicon-plus-sign"></span> Add New Option
         </button>
       </stage-config-field>

--- a/app/scripts/modules/core/src/pipeline/manualExecution/manualPipelineExecution.html
+++ b/app/scripts/modules/core/src/pipeline/manualExecution/manualPipelineExecution.html
@@ -76,7 +76,7 @@
         <p class="manual-execution-parameters-description">This pipeline is parameterized. Please enter values for the parameters below.</p>
         <div class="form-group" ng-repeat="parameter in vm.command.pipeline.parameterConfig">
           <div class="col-md-4 sm-label-right break-word">
-            <b>{{parameter.name}}</b>
+            <b>{{parameter.label || parameter.name}}</b>
             <span ng-if="parameter.required">*</span>
             <help-field content="{{parameter.description}}" ng-if="parameter.description"></help-field>
           </div>


### PR DESCRIPTION
Parameters can be pretty unfriendly to end users, since we just display the name. This allows people to optionally include a label on the parameters.

<img width="865" alt="screen shot 2018-02-26 at 1 54 31 pm" src="https://user-images.githubusercontent.com/73450/36697739-d446e512-1afc-11e8-9a76-408665d12813.png">

<img width="589" alt="screen shot 2018-02-26 at 1 56 36 pm" src="https://user-images.githubusercontent.com/73450/36697767-e44921aa-1afc-11e8-861c-0c8ba839646f.png">
