### PR TITLE
feat(provider/kubernetes): delineate default artifacts in executions

### DIFF
--- a/app/scripts/modules/core/src/domain/IExecutionTrigger.ts
+++ b/app/scripts/modules/core/src/domain/IExecutionTrigger.ts
@@ -1,5 +1,6 @@
 import { IExecution } from './IExecution';
 import { IArtifact } from './IArtifact';
+import { IExpectedArtifact } from './IExpectedArtifact';
 
 export interface IExecutionTrigger {
   buildInfo?: any;
@@ -13,4 +14,5 @@ export interface IExecutionTrigger {
   user: string;
   dryRun?: boolean;
   artifacts?: IArtifact[];
+  resolvedExpectedArtifacts?: IExpectedArtifact[];
 }

--- a/app/scripts/modules/core/src/pipeline/status/ArtifactList.tsx
+++ b/app/scripts/modules/core/src/pipeline/status/ArtifactList.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
-import { IArtifact } from 'core/domain';
+import { IArtifact, IExpectedArtifact } from 'core/domain';
 
 import './artifactList.less';
 
 export interface IArtifactListProps {
   artifacts: IArtifact[],
+  resolvedExpectedArtifacts?: IExpectedArtifact[]
 };
 
 export interface IArtifactListState {}
@@ -14,8 +15,11 @@ export class ArtifactList extends React.Component<IArtifactListProps, IArtifactL
     super(props);
   }
 
-  private tooltip(artifact: IArtifact): string {
+  private tooltip(artifact: IArtifact, isDefault: boolean): string {
     const tooltipEntries = [];
+    if (isDefault) {
+      tooltipEntries.push('Default Artifact');
+    }
     if (artifact.name) {
       tooltipEntries.push(`Name: ${artifact.name}`);
     }
@@ -32,16 +36,23 @@ export class ArtifactList extends React.Component<IArtifactListProps, IArtifactL
   }
 
   public render() {
-    const { artifacts } = this.props;
+    const { artifacts, resolvedExpectedArtifacts = [] } = this.props;
+    const defaultArtifactRefs = new Set();
+    resolvedExpectedArtifacts.forEach(rea => {
+      if (rea && rea.defaultArtifact && rea.defaultArtifact.reference) {
+        defaultArtifactRefs.add(rea.defaultArtifact.reference);
+      }
+    });
     if (!artifacts || artifacts.length === 0) {
       return null;
     }
     return (
       <ul className="trigger-details artifacts">
         {artifacts.map((artifact: IArtifact, i: number) => {
-          const { name, version, type } = artifact;
+          const { name, version, type, reference } = artifact;
+          const isDefault = defaultArtifactRefs.has(reference);
           return (
-            <li key={`${i}-${name}`} className="break-word" title={this.tooltip(artifact)}>
+            <li key={`${i}-${name}`} className="break-word" title={this.tooltip(artifact, isDefault)}>
               <dl>
                 <div>
                   <dt>
@@ -53,7 +64,7 @@ export class ArtifactList extends React.Component<IArtifactListProps, IArtifactL
                 </div>
                 <div>
                   <dt>
-                    Artifact
+                    Artifact{isDefault && '*'}
                   </dt>
                   <dd>
                     {name}

--- a/app/scripts/modules/core/src/pipeline/status/ExecutionStatus.tsx
+++ b/app/scripts/modules/core/src/pipeline/status/ExecutionStatus.tsx
@@ -109,6 +109,7 @@ export class ExecutionStatus extends React.Component<IExecutionStatusProps, IExe
   public render() {
     const { execution, showingDetails, standalone } = this.props;
     const artifacts: IArtifact[] = execution.trigger.artifacts;
+    const resolvedExpectedArtifacts = execution.trigger.resolvedExpectedArtifacts;
     return (
       <div className="execution-status-section">
         <span className={`trigger-type ${this.state.sortFilter.groupBy !== name ? 'subheading' : ''}`}>
@@ -133,7 +134,7 @@ export class ExecutionStatus extends React.Component<IExecutionStatusProps, IExe
           </span>
           {this.state.parameters.map((p) => <li key={p.key} className="break-word"><span className="parameter-key">{p.key}</span>: {p.value}</li>)}
         </ul>
-        <ArtifactList artifacts={artifacts} />
+        <ArtifactList artifacts={artifacts} resolvedExpectedArtifacts={resolvedExpectedArtifacts} />
         {!standalone && <a className="clickable" onClick={this.toggleDetails}><span className={`small glyphicon ${showingDetails ? 'glyphicon-chevron-down' : 'glyphicon-chevron-right'}`}/>Details</a>}
       </div>
     )


### PR DESCRIPTION
Adds an asterisk to indicate default artifacts used in an execution, and includes the phrase "Default Artifact" in the artifact's tooltip.

![asterisk](https://user-images.githubusercontent.com/34253460/36810911-1d47c86e-1c9a-11e8-9e0e-0c1e47e1e44a.png)
---
![tooltip](https://user-images.githubusercontent.com/34253460/36810913-1f697eda-1c9a-11e8-87de-7d6237f7f77c.png)

fixes https://github.com/spinnaker/spinnaker/issues/2329