### PR TITLE
fix(core/pipelines): force refresh pipeline configs after save completes

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/pipelineConfigurer.js
+++ b/app/scripts/modules/core/src/pipeline/config/pipelineConfigurer.js
@@ -356,7 +356,7 @@ module.exports = angular.module('spinnaker.core.pipeline.config.pipelineConfigur
     this.savePipeline = () => {
       this.setViewState({ saving: true });
       pipelineConfigService.savePipeline($scope.pipeline)
-        .then(() => $scope.application.pipelineConfigs.refresh())
+        .then(() => $scope.application.pipelineConfigs.refresh(true))
         .then(
           () => {
             setOriginal($scope.pipeline);


### PR DESCRIPTION
Avoids a race condition that can happen if the save completes while the pipeline configs are refreshing, and the user immediately goes back to the executions view to run the pipeline.