### PR TITLE
fix(provider/kubernetes): Show warnings for dashes in app names

### DIFF
--- a/app/scripts/modules/kubernetes/src/validation/applicationName.validator.js
+++ b/app/scripts/modules/kubernetes/src/validation/applicationName.validator.js
@@ -10,11 +10,16 @@ module.exports = angular
   ])
   .factory('kubernetesApplicationNameValidator', function () {
 
-    function validateSpecialCharacters(name, errors) {
-      let pattern = /^([a-zA-Z][a-zA-Z0-9]*)?$/;
-      if (!pattern.test(name)) {
-        errors.push('The application name must begin with a letter and must contain only letters or digits. No ' +
-          'special characters are allowed.');
+    function validateSpecialCharacters(name, warnings, errors) {
+      const alphanumPattern = /^([a-zA-Z][a-zA-Z0-9]*)?$/;
+      if (!alphanumPattern.test(name)) {
+        const alphanumWithDashPattern = /^([a-zA-Z][a-zA-Z0-9-]*)?$/;
+        if (alphanumWithDashPattern.test(name)) {
+          warnings.push('Dashes should only be used in application names when using the Kubernetes v2 provider.');
+        } else {
+          errors.push('The application name must begin with a letter and must contain only letters or digits. ' +
+              'No special characters are allowed.');
+        }
       }
     }
 
@@ -50,7 +55,7 @@ module.exports = angular
           errors = [];
 
       if (name && name.length) {
-        validateSpecialCharacters(name, errors);
+        validateSpecialCharacters(name, warnings, errors);
         validateLength(name, warnings, errors);
       }
 


### PR DESCRIPTION
Dashes in application names are allowed for applications created by the Kubernetes v2 provider using moniker annotations.

Users should be allowed to create applications containing dashes when using the Kubernetes provider, but be warned that such names should only be used for v2.

In particular, this is important in order to be able to create the application in deck and then provision templated pipelines using roer.

![kubernetes-application-name](https://user-images.githubusercontent.com/252950/36813640-833a1286-1cd5-11e8-88f0-83a924890aac.png)
