### PR TITLE
feat(core/notification): Add a quick one-off slack channel affordance

### DIFF
--- a/app/scripts/modules/core/src/notification/modal/editNotification.controller.modal.js
+++ b/app/scripts/modules/core/src/notification/modal/editNotification.controller.modal.js
@@ -6,6 +6,8 @@ const angular = require('angular');
 
 require('./editNotification.html');
 
+import './editNotification.less';
+
 module.exports = angular
   .module('spinnaker.core.notification.modal.editNotification.modal.controller', [])
   .controller('EditNotificationController', function ($scope, $uibModalInstance, notification, level, stageType) {

--- a/app/scripts/modules/core/src/notification/modal/editNotification.less
+++ b/app/scripts/modules/core/src/notification/modal/editNotification.less
@@ -1,0 +1,13 @@
+.slack-channel-form-control {
+  .slack-channel-annotation {
+    display: block;
+    position: absolute;
+    top: 5px;
+    left: 25px;
+    color: var(--color-concrete);
+  }
+
+  .form-control {
+    padding-left: 22px;
+  }
+}

--- a/app/scripts/modules/core/src/notification/modal/editNotification.less
+++ b/app/scripts/modules/core/src/notification/modal/editNotification.less
@@ -1,6 +1,5 @@
 .slack-channel-form-control {
   .slack-channel-annotation {
-    display: block;
     position: absolute;
     top: 5px;
     left: 25px;

--- a/app/scripts/modules/core/src/notification/types/slack/additionalFields.html
+++ b/app/scripts/modules/core/src/notification/types/slack/additionalFields.html
@@ -1,7 +1,7 @@
 <div class="form-group row">
   <div class="col-sm-3 sm-label-right">Slack Channel</div>
   <div class="col-sm-9 slack-channel-form-control">
-    <span class="slack-channel-annotation">#</span>
+    <div class="slack-channel-annotation">#</div>
     <input name="Slack"
            class="form-control input-sm"
            ng-model="vm.notification.address"

--- a/app/scripts/modules/core/src/notification/types/slack/additionalFields.html
+++ b/app/scripts/modules/core/src/notification/types/slack/additionalFields.html
@@ -1,8 +1,9 @@
 <div class="form-group row">
   <div class="col-sm-3 sm-label-right">Slack Channel</div>
-  <div class="col-sm-9">
+  <div class="col-sm-9 slack-channel-form-control">
+    <span class="slack-channel-annotation">#</span>
     <input name="Slack"
-           class="form-control input-sm "
+           class="form-control input-sm"
            ng-model="vm.notification.address"
            placeholder="enter a Slack channel"
            required />


### PR DESCRIPTION
We wanted to add a little `#` channel indicator in the common Slack notification input we use across the UI. I've intentionally done it in a less-than-reusable way since I'd like to get inputs with before/after annotations into the style guide shortly and didn't want to duplicate work.