### PR TITLE
fix(core): correct category on recently viewed analytics events

### DIFF
--- a/app/scripts/modules/core/src/search/infrastructure/RecentlyViewedItems.tsx
+++ b/app/scripts/modules/core/src/search/infrastructure/RecentlyViewedItems.tsx
@@ -11,9 +11,9 @@ import { ISearchResult, ISearchResultPodData, SearchResultPods } from './SearchR
 
 export interface IChildComponentProps {
   results: ISearchResultPodData[];
-  onResultClick: (categoryName: string) => void;
   onRemoveItem?: (categoryName: string, itemId: string) => void;
   onRemoveProject?: (projectId: string) => void;
+  onResultClick: (categoryName: string) => void;
 }
 
 export interface IRecentlyViewedItemsProps {
@@ -86,7 +86,7 @@ export class RecentlyViewedItems extends React.Component<IRecentlyViewedItemsPro
   }
 
   private handleResultClick(categoryName: string): void {
-    ReactGA.event({ category: 'Global Search', action: `Recent item selected from ${categoryName}` });
+    ReactGA.event({ category: 'Primary Search', action: `Recent item selected from ${categoryName}` });
   }
 
   public render() {
@@ -97,8 +97,8 @@ export class RecentlyViewedItems extends React.Component<IRecentlyViewedItemsPro
         <Component
           results={this.state.recentItems}
           onRemoveItem={this.handleRemoveItem}
-          onResultClick={this.handleResultClick}
           onRemoveProject={this.handleRemoveProject}
+          onResultClick={this.handleResultClick}
         />
        ) : (
         // Once RecentlyViewedItems is no longer rendered as part of any angular
@@ -106,8 +106,8 @@ export class RecentlyViewedItems extends React.Component<IRecentlyViewedItemsPro
         <SearchResultPods
           results={this.state.recentItems}
           onRemoveItem={this.handleRemoveItem}
-          onResultClick={this.handleResultClick}
           onRemoveProject={this.handleRemoveProject}
+          onResultClick={this.handleResultClick}
         />
        )
     );

--- a/app/scripts/modules/core/src/search/infrastructure/search.infrastructure.module.js
+++ b/app/scripts/modules/core/src/search/infrastructure/search.infrastructure.module.js
@@ -5,7 +5,6 @@ import { RECENTLY_VIEWED_ITEMS_COMPONENT } from './recentlyViewedItems.component
 import { SEARCH_COMPONENT } from '../widgets/search.component';
 import { SEARCH_INFRASTRUCTURE_V2_CONTROLLER } from './infrastructureSearchV2.component';
 import { SEARCH_RESULT_COMPONENT } from './searchResult.component';
-import { SEARCH_RESULT_PODS_COMPONENT } from './searchResultPods.component';
 
 import './infrastructure.less';
 
@@ -17,5 +16,4 @@ module(SEARCH_INFRASTRUCTURE, [
   SEARCH_COMPONENT,
   SEARCH_INFRASTRUCTURE_V2_CONTROLLER,
   SEARCH_RESULT_COMPONENT,
-  SEARCH_RESULT_PODS_COMPONENT,
 ]);

--- a/app/scripts/modules/core/src/search/infrastructure/searchResultPods.component.ts
+++ b/app/scripts/modules/core/src/search/infrastructure/searchResultPods.component.ts
@@ -1,6 +1,0 @@
-import { module } from 'angular';
-import { react2angular } from 'react2angular';
-import { SearchResultPods } from './SearchResultPods';
-
-export const SEARCH_RESULT_PODS_COMPONENT = 'spinnaker.core.search.infrastructure.searchResultPods.component';
-module(SEARCH_RESULT_PODS_COMPONENT, []).component('searchResultPods', react2angular(SearchResultPods, ['results']));


### PR DESCRIPTION
Also removing the `searchResultPods` angular component - I cannot find any matches for `search-result-pods` in the codebase.

Tested this with both v1 and v2 search versions.