### PR TITLE
feat(core): allow skipped stages to be omitted from the execution graph

### DIFF
--- a/app/scripts/modules/core/src/domain/IExecution.ts
+++ b/app/scripts/modules/core/src/domain/IExecution.ts
@@ -21,12 +21,12 @@ export interface IExecution extends IOrchestratedItem {
   pipelineConfigId?: string;
   searchField?: string;
   stageSummaries?: IExecutionStageSummary[]; // added by transformer
-  stageWidth?: string; // added by transformer
   stages: IExecutionStage[];
   stringVal?: string;
   trigger: IExecutionTrigger;
   user: string;
   fromTemplate?: boolean;
+  hideSkippedStages?: boolean;
 }
 
 export interface IExecutionGroup {

--- a/app/scripts/modules/core/src/pipeline/config/triggers/triggers.html
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/triggers.html
@@ -80,4 +80,13 @@
       </div>
     </div>
   </page-section>
+  <page-section key="skippedStages" label="Skipped Stages">
+    <div class="checkbox">
+      <label>
+        <input type="checkbox"
+               ng-model="pipeline.hideSkippedStages"/>
+        If conditional stages are skipped, do not show them in the pipeline graph
+      </label>
+    </div>
+  </page-section>
 </page-navigator>


### PR DESCRIPTION
If you end up skipping a bunch of stages, you can have a pretty sparse graph, e.g.
<img width="988" alt="screen shot 2018-03-01 at 10 19 06 am" src="https://user-images.githubusercontent.com/73450/36862213-fdc20288-1d3a-11e8-9c34-2450edf04db9.png">

With this change, we can omit those stages if they are not relevant:
<img width="986" alt="screen shot 2018-03-01 at 10 19 24 am" src="https://user-images.githubusercontent.com/73450/36862228-0e9ef07a-1d3b-11e8-8449-4d31b3e3e300.png">
