### PR TITLE
fix(core/search): Get rid of useless prompt, hide 'Recently Viewed' header if no history

### DIFF
--- a/app/scripts/modules/core/src/search/infrastructure/SearchResultPods.tsx
+++ b/app/scripts/modules/core/src/search/infrastructure/SearchResultPods.tsx
@@ -33,7 +33,7 @@ export class SearchResultPods extends React.Component<ISearchResultPodsProps> {
     const projects: ISearchResultPodData = results.find(x => x.category === 'projects');
     const otherCategories: ISearchResultPodData[] = results.filter(x => x.category !== 'projects')
       .sort((a, b) => a.category.localeCompare(b.category));
-    
+
     return (
       <div className="infrastructure-section container">
         <div className="recent-items">

--- a/app/scripts/modules/core/src/search/infrastructure/SearchResultPods.tsx
+++ b/app/scripts/modules/core/src/search/infrastructure/SearchResultPods.tsx
@@ -25,10 +25,15 @@ export interface ISearchResultPodsProps {
 export class SearchResultPods extends React.Component<ISearchResultPodsProps> {
   public render() {
     const { results } = this.props;
+
+    if (!results.length) {
+      return null;
+    }
+
     const projects: ISearchResultPodData = results.find(x => x.category === 'projects');
     const otherCategories: ISearchResultPodData[] = results.filter(x => x.category !== 'projects')
       .sort((a, b) => a.category.localeCompare(b.category));
-
+    
     return (
       <div className="infrastructure-section container">
         <div className="recent-items">

--- a/app/scripts/modules/core/src/search/infrastructure/SearchV2.tsx
+++ b/app/scripts/modules/core/src/search/infrastructure/SearchV2.tsx
@@ -155,7 +155,6 @@ export class SearchV2 extends React.Component<{}, ISearchV2State> {
         <div className="container flex-fill" style={{ overflowY: 'auto' }}>
           {!hasSearchQuery && (
             <div>
-              <h3 style={{ textAlign: 'center' }}>Please enter a search query to get started</h3>
               <RecentlyViewedItems Component={SearchResultPods}/>
             </div>
           )}

--- a/app/scripts/modules/core/src/search/searchResult/SearchResultGrid.tsx
+++ b/app/scripts/modules/core/src/search/searchResult/SearchResultGrid.tsx
@@ -10,12 +10,6 @@ export interface ISearchResultGridProps {
   resultSet: ISearchResultSet;
 }
 
-const NoQuery = () => (
-  <div className="flex-grow vertical center middle">
-    <h2>Please enter a search query to get started</h2>
-  </div>
-);
-
 export const Searching = () => (
   <div className="flex-grow vertical center middle">
     <Spinner size="large" message="Fetching search results ..."/>
@@ -57,7 +51,7 @@ export class SearchResultGrid extends React.Component<ISearchResultGridProps> {
     switch (status) {
       case SearchStatus.INITIAL:
       case undefined:
-        return <NoQuery/>;
+        return null;
 
       case SearchStatus.ERROR:
         return <FetchError resultSet={resultSet}/>;


### PR DESCRIPTION
Couple of things:

1) I got rid of the "Please enter a search query to get started" text, because it was kind of useless and mostly just added visual noise.

2) Now when there's no recent history, we won't show the awkwardly orphaned "Recently Viewed" header above... nothing at all.