### PR TITLE
fix(provider/gce): Fix call to list backends

### DIFF
--- a/app/scripts/modules/google/src/address/address.reader.ts
+++ b/app/scripts/modules/google/src/address/address.reader.ts
@@ -40,7 +40,7 @@ class GceAddressReader {
       return this.listAddresses(null /* region */).then(addresses => addresses.filter(address => address.region === region));
     } else {
       return this.searchService
-        .search<IAddressSearchResults>({ q: '***', type: 'addresses' }, this.infrastructureCaches.get('addresses'))
+        .search<IAddressSearchResults>({ q: '', type: 'addresses', allowShortQuery: 'true' }, this.infrastructureCaches.get('addresses'))
         .then((searchResults: ISearchResults<IAddressSearchResults>) => {
           if (searchResults && searchResults.results) {
             return searchResults.results

--- a/app/scripts/modules/google/src/backendService/backendService.reader.js
+++ b/app/scripts/modules/google/src/backendService/backendService.reader.js
@@ -24,7 +24,7 @@ module.exports = angular.module('spinnaker.deck.gce.backendService.reader.servic
         return API
           .all('search')
           .useCache(infrastructureCaches.get('backendServices'))
-          .getList({q:'', type: 'backendServices'});
+          .getList({q:'', type: 'backendServices', allowShortQuery: 'true'});
       }
     }
 

--- a/app/scripts/modules/google/src/certificate/certificate.reader.ts
+++ b/app/scripts/modules/google/src/certificate/certificate.reader.ts
@@ -20,7 +20,7 @@ export class GceCertificateReader {
 
   public listCertificates(): IPromise<IGceCertificate[]> {
     return this.searchService
-      .search<IGceCertificate>({ q: '***', type: 'sslCertificates' }, this.infrastructureCaches.get('certificates'))
+      .search<IGceCertificate>({ q: '', type: 'sslCertificates', allowShortQuery: 'true' }, this.infrastructureCaches.get('certificates'))
       .then((searchResults: ISearchResults<IGceCertificate>) => {
         if (searchResults && searchResults.results) {
           return searchResults.results.filter(certificate => certificate.provider === 'gce');

--- a/app/scripts/modules/google/src/healthCheck/healthCheck.read.service.ts
+++ b/app/scripts/modules/google/src/healthCheck/healthCheck.read.service.ts
@@ -28,7 +28,7 @@ export class GceHealthCheckReader {
       return this.listHealthChecks().then(healthChecks => healthChecks.filter(healthCheck => healthCheck.healthCheckType === type));
     } else {
       return this.searchService
-        .search({ q: '***', type: 'healthChecks' }, this.infrastructureCaches.get('healthChecks'))
+        .search({ q: '', type: 'healthChecks', allowShortQuery: 'true' }, this.infrastructureCaches.get('healthChecks'))
         .then((searchResults: ISearchResults<IHealthCheckSearchResults>) => {
           if (searchResults && searchResults.results) {
             const healthChecks = searchResults.results.filter(result => result.provider === 'gce')


### PR DESCRIPTION
The call to get current backends is returning no results
as the query string needs to be at least 3 characters. Use the
allowShortQuery parameter to override this behavior.