### PR TITLE
feat(core): allow parameters to be hidden based on other params

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/parameters/parameter.html
+++ b/app/scripts/modules/core/src/pipeline/config/parameters/parameter.html
@@ -11,11 +11,18 @@
         </label>
         <div class="col-md-9">
           <div class="row">
-            <div class="col-md-6">
+            <div class="col-md-4">
               <input type="text" required ng-model="parameter.name"
                      class="form-control input-sm"/>
             </div>
-            <div class="col-md-1 col-md-offset-5">
+            <div class="col-md-2 sm-label-right">
+              <span class="label-text">Label <help-field key="pipeline.config.parameter.label"></help-field></span>
+            </div>
+            <div class="col-md-4">
+              <input type="text" ng-model="parameter.label"
+                     class="form-control input-sm"/>
+            </div>
+            <div class="col-md-1 col-md-offset-1">
               <button class="btn-link" ng-click="parameterCtrl.remove(parameter)">
                 <span class="glyphicon glyphicon-trash" uib-tooltip="Remove parameter"></span><span class="sr-only">Remove Parameter</span>
               </button>
@@ -30,11 +37,6 @@
             <input type="checkbox" ng-model="parameter.required" />
           </label>
         </div>
-      </stage-config-field>
-
-      <stage-config-field label="Label" help-key="pipeline.config.parameter.label">
-        <input type="text" ng-model="parameter.label"
-               class="form-control input-sm"/>
       </stage-config-field>
 
       <stage-config-field label="Description" help-key="pipeline.config.parameter.description">

--- a/app/scripts/modules/core/src/pipeline/manualExecution/manualPipelineExecution.html
+++ b/app/scripts/modules/core/src/pipeline/manualExecution/manualPipelineExecution.html
@@ -74,7 +74,7 @@
 
       <div ng-if="vm.command.pipeline.parameterConfig !== undefined && vm.command.pipeline.parameterConfig.length">
         <p class="manual-execution-parameters-description">This pipeline is parameterized. Please enter values for the parameters below.</p>
-        <div class="form-group" ng-repeat="parameter in vm.command.pipeline.parameterConfig">
+        <div class="form-group" ng-repeat="parameter in vm.command.pipeline.parameterConfig" ng-if="!vm.hiddenParameters.has(parameter.name)">
           <div class="col-md-4 sm-label-right break-word">
             <b>{{parameter.label || parameter.name}}</b>
             <span ng-if="parameter.required">*</span>
@@ -83,11 +83,13 @@
           <div class="col-md-6" ng-if="!parameter.hasOptions">
             <input class="form-control input-sm"
                    ng-model="vm.parameters[parameter.name]"
+                   ng-change="vm.updateParameters()"
                    ng-required="parameter.required"/>
           </div>
           <div class="col-md-6" ng-if="parameter.hasOptions">
             <ui-select ng-model="vm.parameters[parameter.name]"
                        ng-required="parameter.required"
+                       on-select="vm.updateParameters()"
                        style="width:100%"
                        class="form-control input-sm">
               <ui-select-match>

--- a/app/scripts/modules/core/src/utils/sandbox/eval.worker.ts
+++ b/app/scripts/modules/core/src/utils/sandbox/eval.worker.ts
@@ -1,0 +1,23 @@
+// tslint:disable:no-eval
+self.onmessage = (e: MessageEvent) => {
+  'use strict';
+  const ctx: Worker = self as any;
+  if (e.data.context && e.data.expression) {
+    let toEval = '';
+
+    Object.keys(e.data.context).forEach(k => {
+      toEval += `var ${k} = ${JSON.stringify(e.data.context[k])};\n`;
+    });
+    toEval += ` !!(${e.data.expression})`;
+    ctx.postMessage({
+      id: e.data.id,
+      result: eval(toEval)
+    });
+  } else {
+    ctx.postMessage({
+      id: e.data.id,
+      result: false,
+    });
+  }
+  return;
+};

--- a/app/scripts/modules/core/src/utils/sandbox/sandbox.evaluator.ts
+++ b/app/scripts/modules/core/src/utils/sandbox/sandbox.evaluator.ts
@@ -1,0 +1,28 @@
+import Evaluator = require('worker-loader!./eval.worker');
+
+let counter = 0;
+const resolves: {[key: number]: Function} = {};
+
+/**
+ * Allows evaluation of arbitrary JS expression, run within a supplied context
+ * @param {string} expression the expression to evaluate; the result will be coerced to a boolean, e.g.
+ *    "parameters.region === 'us-east-1'"
+ * @param context the context to be made available to the expression, e.g.
+ *   { parameters: { region: 'us-east-1' } }
+ * @return {Promise<boolean>}
+ */
+export const evaluate = (expression: string, context: any): Promise<boolean> => {
+  const evaluator = new Evaluator();
+  counter++;
+  const result = new Promise<boolean>((resolve) => {
+    resolves[counter] = resolve;
+  });
+
+  evaluator.postMessage({ id: counter, expression, context });
+  evaluator.addEventListener('message', (e: MessageEvent) => {
+    resolves[e.data.id](e.data.result === true);
+    delete resolves[e.data.id];
+  });
+
+  return result;
+};

--- a/app/scripts/modules/core/src/utils/sandbox/worker.d.ts
+++ b/app/scripts/modules/core/src/utils/sandbox/worker.d.ts
@@ -1,0 +1,6 @@
+declare module "worker-loader!*" {
+  class WebpackWorker extends Worker {
+    constructor();
+  }
+  export = WebpackWorker;
+}

--- a/package.json
+++ b/package.json
@@ -80,7 +80,8 @@
     "source-sans-pro": "^2.0.10",
     "spel2js": "^0.2.1",
     "spin.js": "git://github.com/fgnass/spin.js.git#2.3.1",
-    "ui-select": "^0.19.6"
+    "ui-select": "^0.19.6",
+    "worker-loader": "^1.1.1"
   },
   "devDependencies": {
     "@types/angular": "1.6.26",
@@ -116,7 +117,7 @@
     "angulartics-google-analytics": "^0.2.0",
     "autoprefixer": "^7.1.2",
     "babel-core": "^6.21.1",
-    "babel-loader": "^7.1.2",
+    "babel-loader": "^7.1.3",
     "babel-plugin-angularjs-annotate": "^0.8.0",
     "cache-loader": "^1.1.0",
     "css-loader": "^0.28.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "experimentalDecorators": true,
     "jsx": "react",
     "lib": [
+      "webworker",
       "es2016",
       "dom"
     ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -586,6 +586,10 @@ ajv-keywords@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-2.1.1.tgz#617997fc5f60576894c435f940d819e135b80762"
 
+ajv-keywords@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.1.0.tgz#ac2b27939c543e95d2c06e7f7f5c27be4aa543be"
+
 ajv@^4.7.0, ajv@^4.9.1:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.8.tgz#82ffb02b29e662ae53bdc20af15947706739c536"
@@ -601,6 +605,14 @@ ajv@^5.0.0, ajv@^5.1.5:
     fast-deep-equal "^1.0.0"
     json-schema-traverse "^0.3.0"
     json-stable-stringify "^1.0.1"
+
+ajv@^6.1.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.2.0.tgz#afac295bbaa0152449e522742e4547c1ae9328d2"
+  dependencies:
+    fast-deep-equal "^1.0.0"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.3.0"
 
 align-text@^0.1.1, align-text@^0.1.3:
   version "0.1.4"
@@ -1111,9 +1123,9 @@ babel-helpers@^6.24.1:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
-babel-loader@^7.1.2:
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-7.1.2.tgz#f6cbe122710f1aa2af4d881c6d5b54358ca24126"
+babel-loader@^7.1.3:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-7.1.3.tgz#ff5b440da716e9153abb946251a9ab7670037b16"
   dependencies:
     find-cache-dir "^1.0.0"
     loader-utils "^1.0.2"
@@ -3578,6 +3590,10 @@ fast-deep-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz#96256a3bc975595eb36d82e9929d060d893439ff"
 
+fast-json-stable-stringify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
+
 fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
@@ -5347,7 +5363,7 @@ loader-utils@^0.2.16, loader-utils@^0.2.5, loader-utils@~0.2.6:
     json5 "^0.5.0"
     object-assign "^4.0.1"
 
-loader-utils@^1.0.2, loader-utils@^1.1.0:
+loader-utils@^1.0.0, loader-utils@^1.0.2, loader-utils@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.1.0.tgz#c98aef488bcceda2ffb5e2de646d6a754429f5cd"
   dependencies:
@@ -7761,6 +7777,13 @@ schema-utils@^0.3.0:
   dependencies:
     ajv "^5.0.0"
 
+schema-utils@^0.4.0:
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-0.4.5.tgz#21836f0608aac17b78f9e3e24daff14a5ca13a3e"
+  dependencies:
+    ajv "^6.1.0"
+    ajv-keywords "^3.1.0"
+
 schema-utils@^0.4.2:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-0.4.3.tgz#e2a594d3395834d5e15da22b48be13517859458e"
@@ -9053,6 +9076,13 @@ wordwrap@~0.0.2:
 wordwrap@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
+
+worker-loader@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/worker-loader/-/worker-loader-1.1.1.tgz#920d74ddac6816fc635392653ed8b4af1929fd92"
+  dependencies:
+    loader-utils "^1.0.0"
+    schema-utils "^0.4.0"
 
 wrap-ansi@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
This might be a terrible idea, I don't know.

We've seen scenarios where folks have a lot of parameters in their pipelines, but some of those parameters are only applicable if other parameters are set, or if the trigger is a specific job. This would let them hide those parameters from the user starting the pipeline by adding a simple expression to the parameter's config.

Example: there are a lot of parameters for this pipeline that only make sense when the Regional Steps field has a non-zero value.
<img width="594" alt="screen shot 2018-03-01 at 8 30 15 pm" src="https://user-images.githubusercontent.com/73450/36883988-c9a40494-1d92-11e8-83cd-1b89085d3eb7.png">

By setting the `conditional` on those fields to `parameters.numberOfRegions !== '0'`, I can hide those fields and present a more intuitive experience for the user:
<img width="591" alt="screen shot 2018-03-01 at 8 29 48 pm" src="https://user-images.githubusercontent.com/73450/36883973-a2d4a17a-1d92-11e8-8142-49b59e6de4ad.png">

To guard against completely arbitrary script execution, we push the evaluation into a web worker, and always return a boolean. 

I'm not exposing this field in the UI - I would like to experiment with it and try to poke holes in this before making it broadly available.
