### PR TITLE
fix(artifacts): Fix no expected artifacts message

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/producesArtifacts/producesArtifacts.component.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/producesArtifacts/producesArtifacts.component.ts
@@ -59,7 +59,7 @@ class ProducesArtifactsComponent implements IComponentOptions {
         expected-artifact="expectedArtifact"
         application="application">
       </expected-artifact>
-      <div class="row" ng-if="ctrl.hasExpectedArtifacts()">
+      <div class="row" ng-if="!ctrl.hasExpectedArtifacts()">
         <p class="col-md-12">
           You don't have any expected artifacts for {{ ctrl.stage.name }}.
         </p>


### PR DESCRIPTION
The "You don't have any expected artifacts" message currently shows
when there are in fact artifacts.

cherry pick 1.6