### PR TITLE
feat(provider/kubernetes): link to resources next to YAML in deploy pipeline

### DIFF
--- a/app/scripts/modules/kubernetes/src/v2/kubernetes.v2.module.ts
+++ b/app/scripts/modules/kubernetes/src/v2/kubernetes.v2.module.ts
@@ -35,6 +35,7 @@ import { KUBERNETES_MANIFEST_LABELS } from './manifest/manifestLabels.component'
 import { KUBERNETES_MANIFEST_ANNOTATIONS } from './manifest/manifestAnnotations.component';
 import { KUBERNETES_MULTI_MANIFEST_SELECTOR } from './manifest/selector/multiSelector.component';
 import { KUBERNETES_SHOW_MANIFEST_YAML } from './manifest/showManifestYaml.component';
+import { KUBERNETES_SHOW_MANIFEST_DETAILS } from './manifest/showManifestDetails.component';
 
 // load all templates into the $templateCache
 const templates = require.context('kubernetes', true, /\.html$/);
@@ -80,6 +81,7 @@ module(KUBERNETES_V2_MODULE, [
   KUBERNETES_MANIFEST_LABELS,
   KUBERNETES_MANIFEST_ANNOTATIONS,
   KUBERNETES_SHOW_MANIFEST_YAML,
+  KUBERNETES_SHOW_MANIFEST_DETAILS,
 ]).config((cloudProviderRegistryProvider: CloudProviderRegistry) => {
     cloudProviderRegistryProvider.registerProvider('kubernetes', {
       name: 'Kubernetes',

--- a/app/scripts/modules/kubernetes/src/v2/manifest/showManifestDetails.component.ts
+++ b/app/scripts/modules/kubernetes/src/v2/manifest/showManifestDetails.component.ts
@@ -1,0 +1,80 @@
+import { module, IComponentOptions, IController } from 'angular';
+import { trim } from 'lodash';
+import { ReactInjector } from 'core/reactShims';
+
+const supportedKinds = ['deployment', 'replicaset'];
+
+class KubernetesShowManifestDetails implements IController {
+  public manifest: any;
+  public accountId: string;
+
+  public canOpen(): boolean {
+    return !!(
+      this.manifest &&
+      this.manifest.kind &&
+      this.manifest.metadata &&
+      this.manifest.metadata.annotations &&
+      supportedKinds.includes(this.manifest.kind.toLowerCase())
+    );
+  }
+
+  public openDetails() {
+    const kind = this.manifest.kind.toLowerCase();
+    if (kind === 'deployment') {
+      this.openDeploymentDetails();
+    } else if (kind === 'replicaset') {
+      this.openReplicaSetDetails();
+    }
+  }
+
+  private buildParams(annotations: any): any {
+    return {
+      accountId: this.accountId,
+      provider: 'kubernetes',
+      application: annotations.application,
+      region: annotations.region,
+    };
+  }
+
+  private openDeploymentDetails() {
+    const { $state } = ReactInjector;
+    const annotations = this.extractAnnotations(this.manifest.metadata.annotations);
+    const params = this.buildParams(annotations);
+    params.serverGroupManager = `deployment ${annotations.name}`;
+    $state.go('home.applications.application.insight.clusters.serverGroupManager', params);
+  }
+
+  private openReplicaSetDetails() {
+    const { $state } = ReactInjector;
+    const annotations = this.extractAnnotations(this.manifest.metadata.annotations);
+    const params = this.buildParams(annotations);
+    params.serverGroup = `replicaSet ${annotations.name}-${annotations.version}`;
+    $state.go('home.applications.application.insight.clusters.serverGroup', params);
+  }
+
+  private stripQuotes(str: string): string {
+    return trim(str, '"');
+  }
+
+  private extractAnnotations(annotations?: any): any {
+    return {
+      application: this.stripQuotes(annotations['moniker.spinnaker.io/application']),
+      region: this.stripQuotes(annotations['artifact.spinnaker.io/location']),
+      name: this.stripQuotes(annotations['artifact.spinnaker.io/name']),
+      version: this.stripQuotes(annotations['artifact.spinnaker.io/version']),
+    };
+  }
+}
+
+class KubernetesShowManifestDetailsComponent implements IComponentOptions {
+  public bindings: any = { manifest: '<', linkName: '<', accountId: '<' };
+  public controller: any = KubernetesShowManifestDetails;
+  public controllerAs = 'ctrl';
+  public template = trim(`
+    <a href ng-if='ctrl.canOpen()' ng-click='ctrl.openDetails()'>{{ctrl.linkName}}</a>
+  `);
+}
+
+export const KUBERNETES_SHOW_MANIFEST_DETAILS = 'spinnaker.kubernetes.v2.manifest.showDetails';
+module(KUBERNETES_SHOW_MANIFEST_DETAILS, [])
+  .component('kubernetesShowManifestDetails', new KubernetesShowManifestDetailsComponent());

--- a/app/scripts/modules/kubernetes/src/v2/manifest/showManifestYaml.component.ts
+++ b/app/scripts/modules/kubernetes/src/v2/manifest/showManifestYaml.component.ts
@@ -1,5 +1,6 @@
 import { copy, IComponentOptions, IController, IRootScopeService, module } from 'angular';
 import { IModalService } from 'angular-ui-bootstrap';
+import { trim } from 'lodash';
 import { dump } from 'js-yaml';
 
 class KubernetesShowManifestYaml implements IController {
@@ -30,9 +31,9 @@ class KubernetesShowManifestYamlComponent implements IComponentOptions {
   public bindings: any = { manifest: '<', linkName: '<' };
   public controller: any = KubernetesShowManifestYaml;
   public controllerAs = 'ctrl';
-  public template = `
+  public template = trim(`
     <a href ng-click='ctrl.openYaml()'>{{ctrl.linkName}}</a>
-  `;
+  `);
 }
 
 export const KUBERNETES_SHOW_MANIFEST_YAML = 'spinnaker.kubernetes.v2.manifest.showYaml';

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestExecutionDetails.html
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestExecutionDetails.html
@@ -7,7 +7,10 @@
       <div class="col-md-12">
         <div class="well alert alert-info">
           <dl ng-repeat="manifest in stage.context['outputs.manifests']">
-            <kubernetes-show-manifest-yaml manifest="manifest" link-name="manifest.kind + ' ' + manifest.metadata.name + ' YAML'"></kubernetes-show-manifest-yaml>
+            {{manifest.kind}} {{manifest.metadata.name}}<br />
+            <kubernetes-show-manifest-yaml manifest="manifest" link-name="'YAML'"></kubernetes-show-manifest-yaml>
+            &nbsp;&nbsp;&nbsp;&nbsp;
+            <kubernetes-show-manifest-details manifest="manifest" account-id="stage.context.account" link-name="'Details'"></kubernetes-show-manifest-details>
           </dl>
         </div>
       </div>

--- a/app/scripts/modules/kubernetes/src/v2/serverGroup/details/details.controller.ts
+++ b/app/scripts/modules/kubernetes/src/v2/serverGroup/details/details.controller.ts
@@ -48,7 +48,7 @@ class KubernetesServerGroupDetailsController implements IController {
 
   private ownerReferences(): [any] {
     const manifest = this.serverGroup.manifest;
-    if (manifest !== null && manifest.hasOwnProperty('metadata')
+    if (manifest != null && manifest.hasOwnProperty('metadata')
       && manifest.metadata.hasOwnProperty('ownerReferences')
       && Array.isArray(manifest.metadata.ownerReferences)) {
       return manifest.metadata.ownerReferences;

--- a/app/scripts/modules/kubernetes/src/v2/serverGroupManager/details/details.controller.ts
+++ b/app/scripts/modules/kubernetes/src/v2/serverGroupManager/details/details.controller.ts
@@ -63,7 +63,7 @@ class KubernetesServerGroupManagerDetailsController implements IController {
   }
 
   public canUndoRolloutServerGroupManager(): boolean {
-    return this.serverGroupManager.serverGroups && this.serverGroupManager.serverGroups.length > 0;
+    return this.serverGroupManager && this.serverGroupManager.serverGroups && this.serverGroupManager.serverGroups.length > 0;
   }
 
   public undoRolloutServerGroupManager(): void {


### PR DESCRIPTION
This is a first pass at https://github.com/spinnaker/spinnaker/issues/2327

Deployments and ReplicaSets now get linked from deploy pipelines to their respective details panels in the clusters view.

From here:

![q8mg0vvphtz](https://user-images.githubusercontent.com/34253460/36910286-492ca88a-1e0e-11e8-854c-d97465e5ff68.png)



To here:

![ff9vfltnop2](https://user-images.githubusercontent.com/34253460/36910290-4b11c964-1e0e-11e8-9941-6800c57b8b6b.png)

