### PR TITLE
feat(core): allow custom warning when users skip an execution window

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/executionWindows/ExecutionWindowActions.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/executionWindows/ExecutionWindowActions.tsx
@@ -26,6 +26,8 @@ export interface IExecutionWindowWhitelistEntry {
   endMin: number;
 }
 
+export const DEFAULT_SKIP_WINDOW_TEXT = 'The pipeline will proceed immediately, continuing to the next step in the stage.';
+
 @BindAll()
 export class ExecutionWindowActions extends React.Component<IExecutionWindowActionsProps, IExecutionWindowActionsState> {
   constructor(props: IExecutionWindowActionsProps) {
@@ -55,7 +57,7 @@ export class ExecutionWindowActions extends React.Component<IExecutionWindowActi
     confirmationModalService.confirm({
       header: 'Really skip execution window?',
       buttonText: 'Skip',
-      body: '<p>The pipeline will proceed immediately, continuing to the next step in the stage.</p>',
+      body: stage.context.skipWindowText || `<p>${DEFAULT_SKIP_WINDOW_TEXT}</p>`,
       submitMethod: () => {
         return executionService.patchExecution(executionId, stage.id, data)
           .then(() => executionService.waitUntilExecutionMatches(executionId, matcher));

--- a/app/scripts/modules/core/src/pipeline/config/stages/executionWindows/executionWindows.controller.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/executionWindows/executionWindows.controller.js
@@ -5,6 +5,7 @@ import { Subject } from 'rxjs';
 
 import { EXECUTION_WINDOW_ATLAS_GRAPH } from './atlasGraph.component';
 import { EXECUTION_WINDOWS_DAY_PICKER } from './executionWindowDayPicker.component';
+import { DEFAULT_SKIP_WINDOW_TEXT } from './ExecutionWindowActions';
 
 module.exports = angular.module('spinnaker.core.pipeline.stage.executionWindows.controller', [
   require('core/utils/timePicker.service.js').name,
@@ -14,6 +15,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.executionWindows.
   .controller('ExecutionWindowsCtrl', function($scope, timePickerService) {
 
     this.windowsUpdatedStream = new Subject();
+    this.enableCustomSkipWindowText = false;
 
     $scope.hours = timePickerService.getHours();
     $scope.minutes = timePickerService.getMinutes();
@@ -144,6 +146,9 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.executionWindows.
         left: (hour.key / 24 * 100) + '%',
       });
     });
+
+    this.enableCustomSkipWindowText = !!$scope.stage.skipWindowText;
+    this.defaultSkipWindowText = DEFAULT_SKIP_WINDOW_TEXT;
 
     $scope.$watch('stage.restrictedExecutionWindow.whitelist', this.updateTimelineWindows, true);
     $scope.$watch('stage.restrictExecutionDuringTimeWindow', this.toggleWindowRestriction);

--- a/app/scripts/modules/core/src/pipeline/config/stages/executionWindows/executionWindows.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/executionWindows/executionWindows.html
@@ -146,6 +146,24 @@
       </div>
     </div>
   </div>
+  <div class="form-group">
+    <div class="col-md-10 col-md-offset-1">
+      <div class="checkbox">
+        <label>
+          <input type="checkbox" ng-model="executionWindowsCtrl.enableCustomSkipWindowText"/>
+          <strong> Show custom warning when users skip execution window</strong>
+        </label>
+      </div>
+    </div>
+    <div class="col-md-10 col-md-offset-1 checkbox-padding" ng-if="executionWindowsCtrl.enableCustomSkipWindowText">
+      <textarea class="form-control"
+                rows="4"
+                placeholder="Default text: '{{executionWindowsCtrl.defaultSkipWindowText}}' (HTML is okay)"
+                style="margin-top: 5px"
+                ng-model="stage.skipWindowText"/>
+    </div>
+  </div>
+
   <execution-window-atlas-graph stage="stage"
                                 windows="timelineWindows"
                                 windows-updated="executionWindowsCtrl.windowsUpdatedStream"></execution-window-atlas-graph>

--- a/app/scripts/modules/core/src/pipeline/config/stages/templates/index.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/templates/index.ts
@@ -1,3 +1,4 @@
 export const PipelineTemplates = {
   addExtendedAttributes: require('core/pipeline/config/stages/bake/modal/addExtendedAttribute.html'),
+  manualExecutionHandler: require('core/pipeline/manualExecution/manualPipelineExecution.html'),
 };


### PR DESCRIPTION
We have some users who want to make it much more explicit what will happen when an execution window is skipped, e.g. **This will cause the deployment to proceed outside normal business hours. Are you sure you want to do this?**

Seems like a reasonable ask.