### PR TITLE
fix(core): Fix dismissal of new server group template modal

### DIFF
--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/templateSelection/templateSelection.html
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/templateSelection/templateSelection.html
@@ -2,5 +2,6 @@
                     command="command"
                     application="application"
                     parent-state="state"
+                    dismiss="ctrl.cancel()"
                     template-selection-text="ctrl.templateSelectionText"
                     on-template-selected="ctrl.templateSelected()"></deploy-initializer>

--- a/app/scripts/modules/azure/serverGroup/configure/wizard/templateSelection.html
+++ b/app/scripts/modules/azure/serverGroup/configure/wizard/templateSelection.html
@@ -2,5 +2,6 @@
                     command="command"
                     application="application"
                     parent-state="state"
+                    dismiss="ctrl.cancel()"
                     template-selection-text="ctrl.templateSelectionText"
                     on-template-selected="ctrl.templateSelected()"></deploy-initializer>

--- a/app/scripts/modules/cloudfoundry/serverGroup/configure/wizard/templateSelection.html
+++ b/app/scripts/modules/cloudfoundry/serverGroup/configure/wizard/templateSelection.html
@@ -2,4 +2,5 @@
                     command="command"
                     application="application"
                     parent-state="state"
+                    dismiss="ctrl.cancel()"
                     on-template-selected="ctrl.templateSelected()"></deploy-initializer>

--- a/app/scripts/modules/core/src/serverGroup/configure/common/deployInitializer.component.html
+++ b/app/scripts/modules/core/src/serverGroup/configure/common/deployInitializer.component.html
@@ -1,5 +1,5 @@
 <div modal-page>
-  <modal-close dismiss="$dismiss()"></modal-close>
+  <modal-close dismiss="$ctrl.dismiss()"></modal-close>
   <div ng-if="$ctrl.parentState.loaded">
     <div class="modal-header">
       <h3>Template Selection</h3>

--- a/app/scripts/modules/core/src/serverGroup/configure/common/deployInitializer.component.ts
+++ b/app/scripts/modules/core/src/serverGroup/configure/common/deployInitializer.component.ts
@@ -32,6 +32,7 @@ export class DeployInitializerController implements IController {
 
   public application: Application;
   public command: any;
+  public dismiss: () => void;
   public onTemplateSelected: () => void;
   public selectedTemplate: IDeployTemplate;
   public cloudProvider: string;
@@ -119,6 +120,7 @@ const component: IComponentOptions = {
     application: '<',
     cloudProvider: '@',
     command: '<',
+    dismiss: '&',
     onTemplateSelected: '&',
     parentState: '<',
     templateSelectionText: '<',

--- a/app/scripts/modules/dcos/serverGroup/configure/wizard/templateSelection.html
+++ b/app/scripts/modules/dcos/serverGroup/configure/wizard/templateSelection.html
@@ -2,5 +2,6 @@
                      command="command"
                      application="application"
                      parent-state="state"
+                     dismiss="ctrl.cancel()"
                      template-selection-text="ctrl.templateSelectionText"
                      on-template-selected="ctrl.templateSelected()"></deploy-initializer>

--- a/app/scripts/modules/ecs/serverGroup/configure/wizard/templateSelection/templateSelection.html
+++ b/app/scripts/modules/ecs/serverGroup/configure/wizard/templateSelection/templateSelection.html
@@ -2,5 +2,6 @@
                     command="command"
                     application="application"
                     parent-state="state"
+                    dismiss="ctrl.cancel()"
                     template-selection-text="ctrl.templateSelectionText"
                     on-template-selected="ctrl.templateSelected()"></deploy-initializer>

--- a/app/scripts/modules/google/src/serverGroup/configure/wizard/templateSelection/templateSelection.html
+++ b/app/scripts/modules/google/src/serverGroup/configure/wizard/templateSelection/templateSelection.html
@@ -2,5 +2,6 @@
                     command="command"
                     application="application"
                     parent-state="state"
+                    dismiss="ctrl.cancel()"
                     template-selection-text="ctrl.templateSelectionText"
                     on-template-selected="ctrl.templateSelected()"></deploy-initializer>

--- a/app/scripts/modules/kubernetes/src/serverGroup/configure/wizard/templateSelection.html
+++ b/app/scripts/modules/kubernetes/src/serverGroup/configure/wizard/templateSelection.html
@@ -2,5 +2,6 @@
                     command="command"
                     application="application"
                     parent-state="state"
+                    dismiss="ctrl.cancel()"
                     template-selection-text="ctrl.templateSelectionText"
                     on-template-selected="ctrl.templateSelected()"></deploy-initializer>

--- a/app/scripts/modules/openstack/src/serverGroup/configure/wizard/templateSelection.html
+++ b/app/scripts/modules/openstack/src/serverGroup/configure/wizard/templateSelection.html
@@ -2,5 +2,6 @@
                     command="command"
                     application="application"
                     parent-state="state"
+                    dismiss="ctrl.cancel()"
                     template-selection-text="ctrl.templateSelectionText"
                     on-template-selected="ctrl.templateSelected()"></deploy-initializer>

--- a/app/scripts/modules/oracle/serverGroup/configure/wizard/templateSelection/templateSelection.html
+++ b/app/scripts/modules/oracle/serverGroup/configure/wizard/templateSelection/templateSelection.html
@@ -2,5 +2,6 @@
                     command="command"
                     application="application"
                     parent-state="state"
+                    dismiss="ctrl.cancel()"
                     template-selection-text="ctrl.templateSelectionText"
                     on-template-selected="ctrl.templateSelected()"></deploy-initializer>


### PR DESCRIPTION
The template selection modal that appears when adding a new server
group in a 'Deploy' stage should dismiss when clicking the 'x'.