### PR TITLE
Scoped import instead of direct

### DIFF
--- a/app/scripts/modules/kubernetes/src/v2/manifest/showManifestDetails.component.ts
+++ b/app/scripts/modules/kubernetes/src/v2/manifest/showManifestDetails.component.ts
@@ -1,6 +1,6 @@
 import { module, IComponentOptions, IController } from 'angular';
 import { trim } from 'lodash';
-import { ReactInjector } from 'core/reactShims';
+import { ReactInjector } from '@spinnaker/core';
 
 const supportedKinds = ['deployment', 'replicaset'];
 


### PR DESCRIPTION
Import fix for a recently added change. The import the way it was written works fine when running under yarn directly, but errors out if you try to build kubernetes as a module.