### PR TITLE
style(core): Fixed a bad spinner

### DIFF
--- a/app/scripts/modules/core/src/pipeline/executions/executionGroup/ExecutionGroup.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/executionGroup/ExecutionGroup.tsx
@@ -218,7 +218,10 @@ export class ExecutionGroup extends React.Component<IExecutionGroupProps, IExecu
                       <h4 style={{ visibility: pipelineDisabled ? 'hidden' : 'visible' }}>
                         <a className="btn btn-xs btn-link" onClick={this.handleTriggerClicked}>
                           { this.state.triggeringExecution ?
-                            <span><Spinner size="nano" /> Starting Manual Execution&hellip;</span> :
+                            <div className="horizontal middle inline-spinner">
+                              <Spinner size="nano" />
+                              <span>{' '}Starting Manual Execution</span>
+                            </div> :
                             <span><span className="glyphicon glyphicon-play"/> Start Manual Execution</span>
                           }
                         </a>

--- a/app/scripts/modules/core/src/pipeline/executions/executionGroup/executionGroup.less
+++ b/app/scripts/modules/core/src/pipeline/executions/executionGroup/executionGroup.less
@@ -30,6 +30,9 @@
     height: 36px;
     flex: 0 0 auto;
   }
+  .inline-spinner .load {
+    margin: 2px 2px 0 0;
+  }
   a {
     font-weight: 600;
   }


### PR DESCRIPTION
Spinner that shows up next to "Start manual execution" link button in the executions page was off. Fixed it. 