### PR TITLE
feat(core/triggers): More relevant info when selecting execution

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/triggers/pipeline/pipelineTriggerOptions.directive.html
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/pipeline/pipelineTriggerOptions.directive.html
@@ -6,7 +6,7 @@
     </p>
   </div>
   <div class="col-md-6" ng-if="vm.viewState.loadError">Error loading executions!</div>
-  <div class="col-md-6" ng-if="!vm.viewState.executionsLoading">
+  <div class="col-md-7" ng-if="!vm.viewState.executionsLoading">
     <div ng-if="!vm.executions.length"><p class="form-control-static">No recent executions found</p></div>
     <ui-select class="form-control input-sm"
                ng-model="vm.viewState.selectedExecution"
@@ -14,14 +14,16 @@
                ng-if="vm.executions.length">
       <ui-select-match placeholder="Select...">
                 <span>
-                  {{$select.selected.buildTime | timestamp}}
+                  <execution-build-title execution="$select.selected" default-to-timestamp="true" ></execution-build-title>
                   <strong>({{$select.selected.status}})</strong>
                 </span>
       </ui-select-match>
       <ui-select-choices repeat="execution in vm.executions | anyFieldFilter: {status: $select.search}">
               <span>
-                {{execution.buildTime | timestamp}}
-                <strong>({{execution.status}})</strong>
+                <strong><execution-build-title execution="execution" default-to-timestamp="false" ></execution-build-title></strong>
+                {{execution.buildTime | timestamp}} ({{execution.status}})
+                <br />
+                <span ng-if="execution.buildInfo.scm">{{execution.buildInfo.scm[0].branch}} ({{execution.buildInfo.scm[0].sha1 | limitTo:6}}): {{execution.buildInfo.scm[0].message | limitTo:30}}<span ng-if="execution.buildInfo.scm[0].message.length > 30">…</span></span></span>
               </span>
       </ui-select-choices>
     </ui-select>

--- a/app/scripts/modules/core/src/pipeline/config/triggers/pipeline/pipelineTriggerOptions.directive.html
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/pipeline/pipelineTriggerOptions.directive.html
@@ -22,8 +22,7 @@
               <span>
                 <strong><execution-build-title execution="execution" default-to-timestamp="false" ></execution-build-title></strong>
                 {{execution.buildTime | timestamp}} ({{execution.status}})
-                <br />
-                <span ng-if="execution.buildInfo.scm">{{execution.buildInfo.scm[0].branch}} ({{execution.buildInfo.scm[0].sha1 | limitTo:6}}): {{execution.buildInfo.scm[0].message | limitTo:30}}<span ng-if="execution.buildInfo.scm[0].message.length > 30">…</span></span></span>
+                <span ng-if="execution.buildInfo.scm"><br />{{execution.buildInfo.scm[0].branch}} ({{execution.buildInfo.scm[0].sha1 | limitTo:6}}): {{execution.buildInfo.scm[0].message | limitTo:30}}<span ng-if="execution.buildInfo.scm[0].message.length > 30">…</span></span></span>
               </span>
       </ui-select-choices>
     </ui-select>

--- a/app/scripts/modules/core/src/pipeline/config/triggers/pipeline/pipelineTriggerOptions.directive.js
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/pipeline/pipelineTriggerOptions.directive.js
@@ -20,10 +20,11 @@ module.exports = angular
       scope: {}
     };
   })
-  .controller('PipelineTriggerOptionsCtrl', function ($scope, executionService) {
+  .controller('PipelineTriggerOptionsCtrl', function ($scope, executionService, executionsTransformer) {
     let executionLoadSuccess = (executions) => {
       this.executions = executions;
       if (this.executions.length) {
+        this.executions.forEach(execution => executionsTransformer.addBuildInfo(execution));
         // default to what is supplied by the trigger if possible; otherwise, use the latest
         let defaultSelection = this.executions.find(e => e.id === this.command.trigger.parentPipelineId) || this.executions[0];
         this.viewState.selectedExecution = defaultSelection;

--- a/app/scripts/modules/core/src/pipeline/config/triggers/pipeline/pipelineTriggerOptions.directive.spec.js
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/pipeline/pipelineTriggerOptions.directive.spec.js
@@ -2,7 +2,7 @@
 
 describe('Pipeline Trigger: PipelineTriggerOptionsCtrl', function() {
 
-  var $scope, executionService, ctrl, $q, command;
+  var $scope, executionService, executionsTransformer, ctrl, $q, command;
 
   beforeEach(
     window.module(
@@ -16,9 +16,10 @@ describe('Pipeline Trigger: PipelineTriggerOptionsCtrl', function() {
       $qProvider.errorOnUnhandledRejections(false);
   }));
 
-  beforeEach(window.inject(function($rootScope, _executionService_, $controller, _$q_) {
+  beforeEach(window.inject(function($rootScope, _executionService_, _executionsTransformer_, $controller, _$q_) {
     $scope = $rootScope.$new();
     executionService = _executionService_;
+    executionsTransformer = _executionsTransformer_;
     $q = _$q_;
 
     command = {
@@ -32,6 +33,7 @@ describe('Pipeline Trigger: PipelineTriggerOptionsCtrl', function() {
     this.initialize = function() {
       ctrl = $controller('PipelineTriggerOptionsCtrl', {
         executionService: executionService,
+        executionsTransformer: executionsTransformer,
         $scope: $scope,
       }, { command: command });
       ctrl.$onInit();
@@ -41,6 +43,7 @@ describe('Pipeline Trigger: PipelineTriggerOptionsCtrl', function() {
   it('loads executions on initialization, setting state flags', function () {
     let executions = [];
     spyOn(executionService, 'getExecutionsForConfigIds').and.returnValue($q.when(executions));
+    spyOn(executionsTransformer, "addBuildInfo");
 
     this.initialize();
     expect(ctrl.viewState.executionsLoading).toBe(true);
@@ -57,6 +60,7 @@ describe('Pipeline Trigger: PipelineTriggerOptionsCtrl', function() {
       { pipelineConfigId: 'b', buildTime: 1, id: 'b-1', application: 'a' },
     ];
     spyOn(executionService, 'getExecutionsForConfigIds').and.returnValue($q.when(executions));
+    spyOn(executionsTransformer, "addBuildInfo");
 
     this.initialize();
     expect(ctrl.viewState.executionsLoading).toBe(true);
@@ -71,6 +75,7 @@ describe('Pipeline Trigger: PipelineTriggerOptionsCtrl', function() {
 
   it('sets flags when execution load fails', function () {
     spyOn(executionService, 'getExecutionsForConfigIds').and.returnValue($q.reject('does not matter'));
+    spyOn(executionsTransformer, "addBuildInfo");
 
     this.initialize();
     expect(ctrl.viewState.executionsLoading).toBe(true);
@@ -98,6 +103,7 @@ describe('Pipeline Trigger: PipelineTriggerOptionsCtrl', function() {
       }
       return $q.when(executions);
     });
+    spyOn(executionsTransformer, "addBuildInfo");
 
     this.initialize();
     $scope.$digest();

--- a/app/scripts/modules/core/src/pipeline/config/triggers/pipeline/pipelineTriggerOptions.directive.spec.js
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/pipeline/pipelineTriggerOptions.directive.spec.js
@@ -43,7 +43,7 @@ describe('Pipeline Trigger: PipelineTriggerOptionsCtrl', function() {
   it('loads executions on initialization, setting state flags', function () {
     let executions = [];
     spyOn(executionService, 'getExecutionsForConfigIds').and.returnValue($q.when(executions));
-    spyOn(executionsTransformer, "addBuildInfo");
+    spyOn(executionsTransformer, 'addBuildInfo');
 
     this.initialize();
     expect(ctrl.viewState.executionsLoading).toBe(true);
@@ -60,7 +60,7 @@ describe('Pipeline Trigger: PipelineTriggerOptionsCtrl', function() {
       { pipelineConfigId: 'b', buildTime: 1, id: 'b-1', application: 'a' },
     ];
     spyOn(executionService, 'getExecutionsForConfigIds').and.returnValue($q.when(executions));
-    spyOn(executionsTransformer, "addBuildInfo");
+    spyOn(executionsTransformer, 'addBuildInfo');
 
     this.initialize();
     expect(ctrl.viewState.executionsLoading).toBe(true);
@@ -75,7 +75,7 @@ describe('Pipeline Trigger: PipelineTriggerOptionsCtrl', function() {
 
   it('sets flags when execution load fails', function () {
     spyOn(executionService, 'getExecutionsForConfigIds').and.returnValue($q.reject('does not matter'));
-    spyOn(executionsTransformer, "addBuildInfo");
+    spyOn(executionsTransformer, 'addBuildInfo');
 
     this.initialize();
     expect(ctrl.viewState.executionsLoading).toBe(true);


### PR DESCRIPTION
When selecting an execution for a pipeline triggered pipeline, it's hard to differentiate between the executions, as they are only displayed as a date/time and the execution status.
This PR adds some more information, if present. It works as long as the `scm` property of the trigger is set.
I'll probably do the same for the build triggers later.
![image](https://user-images.githubusercontent.com/155558/37213960-d9428d5e-23b3-11e8-9d53-8e2cda771865.png)
![image 1](https://user-images.githubusercontent.com/155558/37213959-d929beaa-23b3-11e8-8cdd-6c51defc6f1a.png)