### PR TITLE
feat(artifacts): Enable GCE deploy stage to deploy an artifact

### DIFF
--- a/app/scripts/modules/core/src/artifact/artifact.module.ts
+++ b/app/scripts/modules/core/src/artifact/artifact.module.ts
@@ -3,10 +3,12 @@ import { module } from 'angular';
 import { EXPECTED_ARTIFACT_SELECTOR_COMPONENT } from './expectedArtifactSelector.component';
 import { EXPECTED_ARTIFACT_SERVICE } from './expectedArtifact.service';
 import { EXPECTED_ARTIFACT_MULTI_SELECTOR_COMPONENT } from './expectedArtifactMultiSelector.component';
+import { IMAGE_SOURCE_SELECTOR_COMPONENT } from './imageSourceSelector.component';
 
 export const ARTIFACT_MODULE = 'spinnaker.core.artifact';
 module(ARTIFACT_MODULE, [
   EXPECTED_ARTIFACT_MULTI_SELECTOR_COMPONENT,
   EXPECTED_ARTIFACT_SELECTOR_COMPONENT,
   EXPECTED_ARTIFACT_SERVICE,
+  IMAGE_SOURCE_SELECTOR_COMPONENT
 ]);

--- a/app/scripts/modules/core/src/artifact/expectedArtifact.service.ts
+++ b/app/scripts/modules/core/src/artifact/expectedArtifact.service.ts
@@ -1,7 +1,7 @@
 import { copy, module } from 'angular';
 
 import { IArtifact, IExpectedArtifact, IPipeline, IStage } from 'core/domain';
-import { PipelineConfigService } from 'core';
+import { PIPELINE_CONFIG_SERVICE, PipelineConfigService } from 'core/pipeline/config/services/pipelineConfig.service';
 
 export class ExpectedArtifactService {
   constructor(private pipelineConfigService: PipelineConfigService) {
@@ -42,8 +42,7 @@ export function summarizeExpectedArtifact() {
 }
 
 export const EXPECTED_ARTIFACT_SERVICE = 'spinnaker.core.artifacts.expected.service';
-module(EXPECTED_ARTIFACT_SERVICE , [])
-  .filter('summarizeExpectedArtifact', summarizeExpectedArtifact)
+module(EXPECTED_ARTIFACT_SERVICE , [
+  PIPELINE_CONFIG_SERVICE
+]).filter('summarizeExpectedArtifact', summarizeExpectedArtifact)
   .service('expectedArtifactService', ExpectedArtifactService);
-
-

--- a/app/scripts/modules/core/src/artifact/expectedArtifactSelector.component.ts
+++ b/app/scripts/modules/core/src/artifact/expectedArtifactSelector.component.ts
@@ -36,7 +36,7 @@ class ExpectedArtifactSelectorComponent implements IComponentOptions {
               </ui-select>
             </div>
           </div>
-          <div ng-if="ctrl.account-field" class="form-group">
+          <div ng-if="ctrl.accountField" class="form-group">
             <label class="col-md-3 sm-label-right">Artifact Account</label>
             <div class="col-md-7">
               <ui-select ng-model="ctrl.command[ctrl.accountField]"

--- a/app/scripts/modules/core/src/artifact/expectedArtifactSelector.component.ts
+++ b/app/scripts/modules/core/src/artifact/expectedArtifactSelector.component.ts
@@ -23,13 +23,12 @@ class ExpectedArtifactSelectorComponent implements IComponentOptions {
   public controllerAs = 'ctrl';
   public template = `
     <render-if-feature feature="artifacts">
-      <div class="container-fluid form-horizontal">
         <ng-form name="artifact">
           <div class="form-group">
             <label class="col-md-3 sm-label-right">Expected Artifact <help-field key="{{ ctrl.helpFieldKey }}"/></label>
             <div class="col-md-7">
               <ui-select ng-model="ctrl.command[ctrl.idField]"
-                         class="form-control input-sm">
+                         class="form-control input-sm" required>
                 <ui-select-match>{{ $select.selected | summarizeExpectedArtifact }}</ui-select-match>
                 <ui-select-choices repeat="expected.id as expected in ctrl.expectedArtifacts">
                   <span>{{ expected | summarizeExpectedArtifact }}</span>
@@ -37,7 +36,7 @@ class ExpectedArtifactSelectorComponent implements IComponentOptions {
               </ui-select>
             </div>
           </div>
-          <div class="form-group">
+          <div ng-if="ctrl.account-field" class="form-group">
             <label class="col-md-3 sm-label-right">Artifact Account</label>
             <div class="col-md-7">
               <ui-select ng-model="ctrl.command[ctrl.accountField]"
@@ -50,7 +49,6 @@ class ExpectedArtifactSelectorComponent implements IComponentOptions {
             </div>
           </div>
         </ng-form>
-      </div>
     </render-if-feature>
   `;
 }

--- a/app/scripts/modules/core/src/artifact/imageSourceSelector.component.ts
+++ b/app/scripts/modules/core/src/artifact/imageSourceSelector.component.ts
@@ -1,31 +1,7 @@
-/*
- * Copyright 2018 Google, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License")
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-import { IComponentOptions, IController, module } from 'angular';
-
-class ImageSourceSelectorCtrl implements IController {
-  public command: any;
-  public imageSources: string;
-  public helpFieldKey: string;
-  public idField: string;
-}
+import { IComponentOptions, module } from 'angular';
 
 class ImageSourceSelectorComponent implements IComponentOptions {
   public bindings: any = { command: '=', imageSources: '<', helpFieldKey: '@', idField: '@' };
-  public controller: any = ImageSourceSelectorCtrl;
   public controllerAs = 'ctrl';
   public template = `
     <render-if-feature feature="artifacts">

--- a/app/scripts/modules/core/src/artifact/imageSourceSelector.component.ts
+++ b/app/scripts/modules/core/src/artifact/imageSourceSelector.component.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { IComponentOptions, IController, module } from 'angular';
+
+class ImageSourceSelectorCtrl implements IController {
+  public command: any;
+  public imageSources: string;
+  public helpFieldKey: string;
+  public idField: string;
+}
+
+class ImageSourceSelectorComponent implements IComponentOptions {
+  public bindings: any = { command: '=', imageSources: '<', helpFieldKey: '@', idField: '@' };
+  public controller: any = ImageSourceSelectorCtrl;
+  public controllerAs = 'ctrl';
+  public template = `
+    <render-if-feature feature="artifacts">
+      <div class="form-group">
+        <div class="col-md-3 sm-label-right">
+          Image Source
+          <help-field key="{{ ctrl.helpFieldKey }}"></help-field>
+        </div>
+        <div class="col-md-9">
+          <div class="radio" ng-repeat="imageSource in ctrl.imageSources">
+            <label>
+              <input type="radio" ng-model="ctrl.command[ctrl.idField]" value="{{ imageSource }}">
+              {{ imageSource | robotToHuman }}
+            </label>
+          </div>
+        </div>
+      </div>
+    </render-if-feature>
+  `;
+}
+
+export const IMAGE_SOURCE_SELECTOR_COMPONENT = 'spinnaker.core.artifacts.expected.image.selector';
+module(IMAGE_SOURCE_SELECTOR_COMPONENT, [
+]).component('imageSourceSelector', new ImageSourceSelectorComponent());

--- a/app/scripts/modules/core/src/artifact/index.ts
+++ b/app/scripts/modules/core/src/artifact/index.ts
@@ -1,2 +1,3 @@
 export * from './expectedArtifactSelector.component';
 export * from './expectedArtifact.service';
+export * from './imageSourceSelector.component';

--- a/app/scripts/modules/core/src/cluster/cluster.service.ts
+++ b/app/scripts/modules/core/src/cluster/cluster.service.ts
@@ -176,6 +176,10 @@ export class ClusterService {
     });
   }
 
+  public isDeployingArtifact(cluster: ICluster): boolean {
+    return (cluster.imageSource === 'artifact');
+  }
+
   private getClusters(application: string): IPromise<IClusterSummary[]> {
     return this.API.one('applications').one(application).one('clusters').get().then((clustersMap: {[account: string]: string[]}) => {
       const clusters: IClusterSummary[] = [];

--- a/app/scripts/modules/core/src/cluster/cluster.service.ts
+++ b/app/scripts/modules/core/src/cluster/cluster.service.ts
@@ -177,7 +177,7 @@ export class ClusterService {
   }
 
   public isDeployingArtifact(cluster: ICluster): boolean {
-    return (cluster.imageSource === 'artifact');
+    return cluster.imageSource === 'artifact';
   }
 
   private getClusters(application: string): IPromise<IClusterSummary[]> {

--- a/app/scripts/modules/core/src/domain/ICluster.ts
+++ b/app/scripts/modules/core/src/domain/ICluster.ts
@@ -9,6 +9,7 @@ export interface IClusterSummary {
 export interface ICluster extends IClusterSummary {
   category: string;
   cloudProvider: string;
+  imageSource?: string;
   instanceCounts?: IInstanceCounts;
   serverGroups: IServerGroup[];
 }

--- a/app/scripts/modules/core/src/pipeline/config/stages/deploy/deployStage.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/deploy/deployStage.js
@@ -12,7 +12,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.deployStage', [
   SERVER_GROUP_COMMAND_BUILDER_SERVICE,
   CLUSTER_SERVICE,
 ])
-  .config(function ($injector, pipelineConfigProvider, cloudProviderRegistryProvider, clusterServiceProvider) {
+  .config(function (pipelineConfigProvider, cloudProviderRegistryProvider, clusterServiceProvider) {
     pipelineConfigProvider.registerStage({
       label: 'Deploy',
       description: 'Deploys the previously baked or found image',

--- a/app/scripts/modules/core/src/pipeline/config/stages/deploy/deployStage.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/deploy/deployStage.js
@@ -33,6 +33,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.deployStage', [
             }
             return stage.clusters.every(cluster =>
               cloudProviderRegistryProvider.$get().getValue(cluster.provider, 'serverGroup.skipUpstreamStageCheck')
+              || cluster.imageSource === 'artifact'
             );
           }
         },

--- a/app/scripts/modules/core/src/pipeline/config/stages/deploy/deployStage.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/deploy/deployStage.js
@@ -1,5 +1,6 @@
 'use strict';
 
+import {CLUSTER_SERVICE} from 'core/cluster/cluster.service';
 import {CLOUD_PROVIDER_REGISTRY} from 'core/cloudProvider/cloudProvider.registry';
 import {SERVER_GROUP_COMMAND_BUILDER_SERVICE} from 'core/serverGroup/configure/common/serverGroupCommandBuilder.service';
 import {StageConstants} from 'core/pipeline/config/stages/stageConstants';
@@ -9,8 +10,9 @@ const angular = require('angular');
 module.exports = angular.module('spinnaker.core.pipeline.stage.deployStage', [
   CLOUD_PROVIDER_REGISTRY,
   SERVER_GROUP_COMMAND_BUILDER_SERVICE,
+  CLUSTER_SERVICE,
 ])
-  .config(function (pipelineConfigProvider, cloudProviderRegistryProvider) {
+  .config(function ($injector, pipelineConfigProvider, cloudProviderRegistryProvider, clusterServiceProvider) {
     pipelineConfigProvider.registerStage({
       label: 'Deploy',
       description: 'Deploys the previously baked or found image',
@@ -27,15 +29,10 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.deployStage', [
           type: 'stageBeforeType',
           stageTypes: ['bake', 'findAmi', 'findImage', 'findImageFromTags'],
           message: 'You must have a Bake or Find Image stage before any deploy stage.',
-          skipValidation: (pipeline, stage) => {
-            if (!stage.clusters || !stage.clusters.length) {
-              return true;
-            }
-            return stage.clusters.every(cluster =>
-              cloudProviderRegistryProvider.$get().getValue(cluster.provider, 'serverGroup.skipUpstreamStageCheck')
-              || cluster.imageSource === 'artifact'
-            );
-          }
+          skipValidation: (pipeline, stage) => (stage.clusters || []).every(cluster =>
+            cloudProviderRegistryProvider.$get().getValue(cluster.provider, 'serverGroup.skipUpstreamStageCheck')
+            || clusterServiceProvider.$get().isDeployingArtifact(cluster)
+          )
         },
       ],
       accountExtractor: (stage) => (stage.context.clusters || []).map(c => c.account),

--- a/app/scripts/modules/core/src/serverGroup/configure/common/deployInitializer.component.ts
+++ b/app/scripts/modules/core/src/serverGroup/configure/common/deployInitializer.component.ts
@@ -87,7 +87,7 @@ export class DeployInitializerController implements IController {
     viewState.submitButtonLabel = 'Add';
     viewState.hideClusterNamePreview = baseCommand.viewState.hideClusterNamePreview || false;
     viewState.templatingEnabled = true;
-    
+
     Object.assign(command, baseCommand.viewState.overrides || {});
     Object.assign(baseCommand, command);
   }

--- a/app/scripts/modules/core/src/serverGroup/configure/common/deployInitializer.component.ts
+++ b/app/scripts/modules/core/src/serverGroup/configure/common/deployInitializer.component.ts
@@ -77,7 +77,6 @@ export class DeployInitializerController implements IController {
   private applyCommandToScope(command: any) {
     const { viewState } = command;
     const baseCommand = this.command;
-
     viewState.disableImageSelection = true;
     viewState.showImageSourceSelector = true;
     viewState.disableStrategySelection = baseCommand.viewState.disableStrategySelection || false;
@@ -87,7 +86,6 @@ export class DeployInitializerController implements IController {
     viewState.submitButtonLabel = 'Add';
     viewState.hideClusterNamePreview = baseCommand.viewState.hideClusterNamePreview || false;
     viewState.templatingEnabled = true;
-
     Object.assign(command, baseCommand.viewState.overrides || {});
     Object.assign(baseCommand, command);
   }

--- a/app/scripts/modules/core/src/serverGroup/configure/common/deployInitializer.component.ts
+++ b/app/scripts/modules/core/src/serverGroup/configure/common/deployInitializer.component.ts
@@ -77,13 +77,17 @@ export class DeployInitializerController implements IController {
   private applyCommandToScope(command: any) {
     const { viewState } = command;
     const baseCommand = this.command;
+
     viewState.disableImageSelection = true;
+    viewState.showImageSourceSelector = true;
     viewState.disableStrategySelection = baseCommand.viewState.disableStrategySelection || false;
+    viewState.expectedArtifacts = baseCommand.viewState.expectedArtifacts || [];
     viewState.imageId = null;
     viewState.readOnlyFields = baseCommand.viewState.readOnlyFields || {};
     viewState.submitButtonLabel = 'Add';
     viewState.hideClusterNamePreview = baseCommand.viewState.hideClusterNamePreview || false;
     viewState.templatingEnabled = true;
+    
     Object.assign(command, baseCommand.viewState.overrides || {});
     Object.assign(baseCommand, command);
   }

--- a/app/scripts/modules/core/src/serverGroup/configure/common/serverGroupCommandBuilder.service.ts
+++ b/app/scripts/modules/core/src/serverGroup/configure/common/serverGroupCommandBuilder.service.ts
@@ -36,6 +36,7 @@ export interface IServerGroupCommandViewState {
   disableImageSelection: boolean;
   imageId?: string;
   instanceProfile: string;
+  showImageSourceSelector: true;
   useAllImageSelection: boolean;
   useSimpleCapacity: boolean;
   usePreferredZones: boolean;

--- a/app/scripts/modules/google/src/help/gce.help.ts
+++ b/app/scripts/modules/google/src/help/gce.help.ts
@@ -16,7 +16,7 @@ const helpContents: {[key: string]: string} = {
   'gce.image.artifact': 'The artifact that is to be deployed to this cluster.  The artifact should represent a deployable image.',
   'gce.image.source': `
       <p>Where the image to deploy is read from.</p>
-            <p>
+      <p>
         <b>Artifact:</b> Deploy an artifact that was supplied/created upstream. The expected artifact must be referenced here, and will be bound at runtime.
       </p>
       <p>

--- a/app/scripts/modules/google/src/help/gce.help.ts
+++ b/app/scripts/modules/google/src/help/gce.help.ts
@@ -13,6 +13,16 @@ const helpContents: {[key: string]: string} = {
       and can be configured within the server group creation dialogue under <b>Port Name Mapping</b>.`,
   'gce.httpLoadBalancer.pathRule.paths': 'For example, <b>/path</b> in <b>example.com/path</b>',
   'gce.httpLoadBalancer.port': 'HTTP requests can be load balanced based on port 80 or port 8080. HTTPS requests can be load balanced on port 443.',
+  'gce.image.artifact': 'The artifact that is to be deployed to this cluster.  The artifact should represent a deployable image.',
+  'gce.image.source': `
+      <p>Where the image to deploy is read from.</p>
+            <p>
+        <b>Artifact:</b> Deploy an artifact that was supplied/created upstream. The expected artifact must be referenced here, and will be bound at runtime.
+      </p>
+      <p>
+        <b>Prior Stage:</b> Deploy the result of the most recent Bake or Find Image stage.
+      </p>
+  `,
   'gce.instance.customInstance.cores': '<ul><li>Above 1, vCPU count must be even.</li><li>Zones that support Haswell and Ivy Bridge processors can support custom machine types up to 32 vCPUs.</li><li>Zones that support Sandy Bridge processors can support up to 16 vCPUs.</li></ul>',
   'gce.instance.customInstance.memory': '<ul><li>Memory per vCPU must be between .9 GB and 6.5 GB.</li><li>Total memory must be a multiple of 256 MB.</li></ul>',
   'gce.instance.customMetadata.instance-template': 'The instance template used to configure this instance.',

--- a/app/scripts/modules/google/src/pipeline/stages/bake/gceBakeStage.js
+++ b/app/scripts/modules/google/src/pipeline/stages/bake/gceBakeStage.js
@@ -28,6 +28,7 @@ module.exports = angular.module('spinnaker.gce.pipeline.stage..bakeStage', [
       extraLabelLines: (stage) => {
         return stage.masterStage.context.allPreviouslyBaked || stage.masterStage.context.somePreviouslyBaked ? 1 : 0;
       },
+      producesArtifacts: true,
       defaultTimeoutMs: 60 * 60 * 1000, // 60 minutes
       validators: [
         { type: 'requiredField', fieldName: 'package', },

--- a/app/scripts/modules/google/src/serverGroup/configure/wizard/location/basicSettings.controller.js
+++ b/app/scripts/modules/google/src/serverGroup/configure/wizard/location/basicSettings.controller.js
@@ -97,4 +97,8 @@ module.exports = angular.module('spinnaker.google.serverGroup.configure.wizard.b
       }
     };
 
+    this.imageSources = [
+      'artifact',
+      'priorStage'
+    ];
   });

--- a/app/scripts/modules/google/src/serverGroup/configure/wizard/location/basicSettings.html
+++ b/app/scripts/modules/google/src/serverGroup/configure/wizard/location/basicSettings.html
@@ -52,6 +52,19 @@
         <span>Detail can only contain letters, numbers, and dashes(-).</span>
       </div>
     </div>
+    <div ng-if="command.viewState.showImageSourceSelector">
+      <image-source-selector command="command"
+                             id-field="imageSource"
+                             image-sources="basicSettingsCtrl.imageSources"
+                             help-field-key="gce.image.source">
+      </image-source-selector>
+      <expected-artifact-selector ng-if="command.imageSource === 'artifact'"
+                                  command="command"
+                                  id-field="imageArtifactId"
+                                  expected-artifacts="command.viewState.expectedArtifacts"
+                                  help-field-key="gce.image.artifact">
+      </expected-artifact-selector>
+    </div>
     <div class="form-group" ng-if="!command.viewState.disableImageSelection">
       <div class="col-md-3 sm-label-right">
         Image

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestConfig.html
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestConfig.html
@@ -37,14 +37,16 @@
                              metadata="ctrl.metadata" change="ctrl.change()">
   </kubernetes-manifest-entry>
 
-  <expected-artifact-selector ng-if="ctrl.$scope.stage.source === ctrl.artifactSource"
-                              command="ctrl.$scope.stage"
-                              id-field="manifestArtifactId"
-                              account-field="manifestArtifactAccount"
-                              accounts="ctrl.metadata.backingData.artifactAccounts"
-                              expected-artifacts="ctrl.expectedArtifacts"
-                              help-field-key="kubernetes.manifest.expectedArtifact">
-  </expected-artifact-selector>
+  <div class="container-fluid form-horizontal">
+    <expected-artifact-selector ng-if="ctrl.$scope.stage.source === ctrl.artifactSource"
+                                command="ctrl.$scope.stage"
+                                id-field="manifestArtifactId"
+                                account-field="manifestArtifactAccount"
+                                accounts="ctrl.metadata.backingData.artifactAccounts"
+                                expected-artifacts="ctrl.expectedArtifacts"
+                                help-field-key="kubernetes.manifest.expectedArtifact">
+    </expected-artifact-selector>
+  </div>
 
   <hr>
 

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestConfig.html
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestConfig.html
@@ -37,9 +37,8 @@
                              metadata="ctrl.metadata" change="ctrl.change()">
   </kubernetes-manifest-entry>
 
-  <div class="container-fluid form-horizontal">
-    <expected-artifact-selector ng-if="ctrl.$scope.stage.source === ctrl.artifactSource"
-                                command="ctrl.$scope.stage"
+  <div class="container-fluid form-horizontal" ng-if="ctrl.$scope.stage.source === ctrl.artifactSource">
+    <expected-artifact-selector command="ctrl.$scope.stage"
                                 id-field="manifestArtifactId"
                                 account-field="manifestArtifactAccount"
                                 accounts="ctrl.metadata.backingData.artifactAccounts"


### PR DESCRIPTION
The deploy stage for the GCE provider now gives the option of deploying a specified upstream artifact rather than deploying the result of the most recent Bake or Find Artifact stage.