### PR TITLE
fix(core): avoid rendering wizard pages before they have registered

### DIFF
--- a/app/scripts/modules/core/src/modal/wizard/WizardModal.tsx
+++ b/app/scripts/modules/core/src/modal/wizard/WizardModal.tsx
@@ -166,7 +166,7 @@ export class WizardModal<T extends FormikValues> extends React.Component<IWizard
     const { currentPage, dirtyPages, errorPages, formInvalid, pages, waiting } = this.state;
     const { TaskMonitorWrapper } = NgReact;
 
-    const pagesToShow = pages.filter((page) => !hideSections.has(page));
+    const pagesToShow = pages.filter((page) => !hideSections.has(page) && this.pages[page]);
 
     const submitting = taskMonitor && taskMonitor.submitting;
 


### PR DESCRIPTION
Not sure if this broke with the React 16 upgrade or ??? but the `this.pages` array is only populated by the `onMount` call, so it is empty the first time through, and a bunch of NPEs get thrown and the modal doesn't open and people can't edit the load balancers.