### PR TITLE
feat(core): omit unsupported cloud provider data from clusters

### DIFF
--- a/app/scripts/modules/core/src/cluster/cluster.service.ts
+++ b/app/scripts/modules/core/src/cluster/cluster.service.ts
@@ -24,6 +24,8 @@ export class ClusterService {
     'ngInject';
   }
 
+  // Retrieves and normalizes all server groups. If a server group for an unsupported cloud provider (i.e. one that does
+  // not have a server group transformer) is encountered, it will be omitted from the result.
   public loadServerGroups(application: Application): IPromise<IServerGroup[]> {
     return this.getClusters(application.name).then((clusters: IClusterSummary[]) => {
       const dataSource = application.getDataSource('serverGroups');
@@ -40,7 +42,8 @@ export class ClusterService {
       return serverGroupLoader.getList().then((serverGroups: IServerGroup[]) => {
         serverGroups.forEach(sg => this.addHealthStatusCheck(sg));
         serverGroups.forEach(sg => this.addNameParts(sg));
-        return this.$q.all(serverGroups.map(sg => this.serverGroupTransformer.normalizeServerGroup(sg, application)));
+        return this.$q.all(serverGroups.map(sg => this.serverGroupTransformer.normalizeServerGroup(sg, application)))
+          .then(normalized => normalized.filter(Boolean));
       });
     });
   }

--- a/app/scripts/modules/core/src/serverGroup/serverGroup.transformer.js
+++ b/app/scripts/modules/core/src/serverGroup/serverGroup.transformer.js
@@ -25,9 +25,12 @@ module.exports = angular.module('spinnaker.core.serverGroup.transformer', [
     }
 
     function normalizeServerGroupForProviderVersion(serverGroup, application, providerVersion) {
-      return providerServiceDelegate
-        .getDelegate(serverGroup.provider || serverGroup.type, 'serverGroup.transformer', providerVersion)
-        .normalizeServerGroup(serverGroup, application);
+      const transformer = providerServiceDelegate
+        .getDelegate(serverGroup.provider || serverGroup.type, 'serverGroup.transformer', providerVersion);
+      if (!transformer) {
+        return null;
+      }
+      return transformer.normalizeServerGroup(serverGroup, application);
     }
 
     function convertServerGroupCommandToDeployConfiguration(base) {


### PR DESCRIPTION
If a server group is part of a cloud provider that is not configured, no cluster data ends up being loaded for any application that includes server groups in that provider, which seems wrong (it implies there are no server groups at all). It's probably better to just strip out the unsupported server groups.

We see this frequently during local development on the OSS codebase for applications that have a mix of AWS and Titus.