### PR TITLE
fix(core/help): Allow target="_blank" in links in help popover

### DIFF
--- a/app/scripts/modules/core/src/help/HelpField.tsx
+++ b/app/scripts/modules/core/src/help/HelpField.tsx
@@ -45,8 +45,9 @@ export class HelpField extends React.Component<IHelpFieldProps, IState> {
       contentString = this.helpContentsRegistry.getHelpField(id) || this.helpContents[id] || fallback;
     }
 
+    const config = { ADD_ATTR: ['target'] }; // allow: target="_blank"
     return {
-      contents: <div dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(contentString) }}/>,
+      contents: <div dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(contentString, config) }}/>,
     }
   }
 


### PR DESCRIPTION
Allow links such as `<a target="_blank" href="http://blah.com">Blah</a>` to open in a new window