### PR TITLE
fix(core): ensure stage comments are in string format

### DIFF
--- a/app/scripts/modules/core/src/pipeline/details/stageSummary.component.ts
+++ b/app/scripts/modules/core/src/pipeline/details/stageSummary.component.ts
@@ -52,7 +52,8 @@ export class StageSummaryController implements IController {
   }
 
   public getComments(): string {
-    const parsed = this.parser.parse(this.stageSummary.comments);
+    // cast comments field to string in case it is set to a number via SpEL
+    const parsed = this.parser.parse(this.stageSummary.comments + '');
     return this.renderer.render(parsed);
   }
 


### PR DESCRIPTION
I don't know who would ever set the comment to a number via SpEL, but if they did, it would cause a lot of exceptions to be thrown.