### PR TITLE
fix(core): render remaining wait on wait stage popover

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/wait/SkipWait.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/wait/SkipWait.tsx
@@ -4,7 +4,6 @@ import { IExecution, IExecutionStage } from 'core/domain';
 import { Application } from 'core/application/application.model';
 import { ReactInjector } from 'core/reactShims';
 import { duration } from 'core/utils/timeFormatters';
-import { OrchestratedItemRunningTime } from 'core/pipeline/executions/execution/OrchestratedItemRunningTime';
 
 export interface ISkipWaitProps {
   execution: IExecution;
@@ -17,7 +16,6 @@ export interface ISkipWaitState {
 }
 
 export class SkipWait extends React.Component<ISkipWaitProps, ISkipWaitState> {
-  private runningTime: OrchestratedItemRunningTime;
 
   constructor(props: ISkipWaitProps) {
     super(props);
@@ -51,16 +49,8 @@ export class SkipWait extends React.Component<ISkipWaitProps, ISkipWaitState> {
     });
   };
 
-  public componentWillReceiveProps() {
-    this.runningTime.checkStatus();
-  }
-
   public componentDidMount() {
-    this.runningTime = new OrchestratedItemRunningTime(this.props.stage, (time: number) => this.setRemainingWait(time));
-  }
-
-  public componentWillUnmount() {
-    this.runningTime.reset();
+    this.setRemainingWait(Date.now() - this.props.stage.startTime);
   }
 
   public render() {


### PR DESCRIPTION
I'm not sure what is causing this, but the popover label for the wait stage (when it is running) re-mounts at least once a second, so the `OrchestratedItemRunningTime` object never gets a chance to set the remaining time field, so it's never rendered.

The frequent remounting is an interesting and potentially bigger problem, but I'm not sure why that is happening.