### PR TITLE
fix(core): count down remaining time in wait stage details

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/wait/WaitExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/wait/WaitExecutionDetails.tsx
@@ -7,7 +7,7 @@ import { SkipWait } from './SkipWait';
 export function WaitExecutionDetails(props: IExecutionDetailsSectionProps) {
   return (
     <ExecutionDetailsSection name={props.name} current={props.current}>
-      <SkipWait application={props.application} execution={props.execution} stage={props.stage} />
+      <SkipWait application={props.application} execution={props.execution} stage={props.stage} autoRefresh={true}/>
       <StageFailureMessage stage={props.stage} message={props.stage.failureMessage} />
       <StageExecutionLogs stage={props.stage} />
     </ExecutionDetailsSection>


### PR DESCRIPTION
Basically restoring all the code I deleted yesterday when I was sure it wasn't needed. Turns out it is needed, as we don't re-mount the stage details, just re-render (I forgot how React works).

Since the popover re-mounts all the time, we still need to render it immediately, so I've just added an `autoRefresh` prop to the component.