### PR TITLE
fix(amazon/loadBalancers): Show target group sticky status appropriately

### DIFF
--- a/app/scripts/modules/amazon/src/loadBalancer/configure/application/TargetGroups.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/application/TargetGroups.tsx
@@ -339,7 +339,7 @@ class TargetGroupsImpl extends React.Component<ITargetGroupsProps & IWizardPageP
                             <label className="checkbox-inline" style={{ paddingTop: '2px' }}>
                               <input
                                 type="checkbox"
-                                value={targetGroup.attributes.stickinessEnabled ? 'true' : 'false'}
+                                checked={targetGroup.attributes.stickinessEnabled}
                                 onChange={(event) => this.targetGroupFieldChanged(index, 'attributes.stickinessEnabled', event.target.checked)}
                               />
                                 {' '}<label>Sticky</label><HelpField id="aws.targetGroup.attributes.stickinessEnabled"/>


### PR DESCRIPTION
@tomaslin FYI