### PR TITLE
fix(amazon/loadBalancers): Remove cert and ssl policies when submitting http listener

### DIFF
--- a/app/scripts/modules/amazon/src/loadBalancer/configure/application/CreateApplicationLoadBalancer.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/application/CreateApplicationLoadBalancer.tsx
@@ -84,6 +84,10 @@ export class CreateApplicationLoadBalancer extends React.Component<ICreateApplic
   private formatListeners(command: IAmazonApplicationLoadBalancerUpsertCommand): IPromise<void> {
     return ReactInjector.accountService.getAccountDetails(command.credentials).then((account) => {
       command.listeners.forEach((listener) => {
+        if (listener.protocol === 'HTTP') {
+          delete listener.sslPolicy;
+          listener.certificates = [];
+        }
         listener.certificates.forEach((certificate) => {
           certificate.certificateArn = this.certificateIdAsARN(account.accountId, certificate.name,
           command.region, certificate.type || this.certificateTypes[0]);


### PR DESCRIPTION
Updating a listener to switch from `HTTPS` to `HTTP` would cause the AWS API to fail because the  `certificates` and `sslPolicy` fields are still provided.


