### PR TITLE
feat(provider/kubernetes): trim runJob logs from executions until explicitly requested

### DIFF
--- a/app/scripts/modules/core/src/pipeline/service/execution.service.spec.ts
+++ b/app/scripts/modules/core/src/pipeline/service/execution.service.spec.ts
@@ -158,7 +158,7 @@ describe('Service: executionService', () => {
           SETTINGS.gateUrl,
           'applications',
           'deck',
-          'pipelines?limit=3',
+          'pipelines?limit=3&expand=false',
         ].join('/');
 
       $httpBackend.expectGET(url).respond(200, []);
@@ -182,7 +182,7 @@ describe('Service: executionService', () => {
         SETTINGS.gateUrl,
         'applications',
         'deck',
-        'pipelines?limit=3',
+        'pipelines?limit=3&expand=false',
       ].join('/');
 
       $httpBackend.expectGET(url).respond(429, []);

--- a/app/scripts/modules/kubernetes/src/pipeline/stages/runJob/runJobExecutionDetails.html
+++ b/app/scripts/modules/kubernetes/src/pipeline/stages/runJob/runJobExecutionDetails.html
@@ -17,8 +17,8 @@
               {{[container.imageDescription.repository, execution.trigger.tag].join(':')}}
             </dd>
           </span>
-          <dt ng-if="stage.context.jobStatus.logs">Logs</dt>
-          <dd ng-if="stage.context.jobStatus.logs">
+          <dt ng-if="hasLogs">Logs</dt>
+          <dd ng-if="hasLogs">
             <dl><a href="" ng-click="displayLogs()">Console Output (Raw)</a></dl>
           </dd>
         </dl>

--- a/app/scripts/modules/kubernetes/src/pipeline/stages/runJob/runJobLogs.html
+++ b/app/scripts/modules/kubernetes/src/pipeline/stages/runJob/runJobLogs.html
@@ -5,7 +5,8 @@
   </div>
   <form role="form">
     <div class="modal-body">
-      <pre>{{logs}}</pre>
+      <loading-spinner size="'large'" ng-if="loading"></loading-spinner>
+      <pre ng-if="!loading">{{logs}}</pre>
     </div>
     <div class="modal-footer">
       <button class="btn btn-primary" ng-click="$close()">Close</button>


### PR DESCRIPTION
Run Jobs that generate a large amount of log output can dramatically slow down loading of the pipeline executions screen in deck.

This PR sends an `expand` query param when fetching executions history and, by default, sets it not to fetch logs.  Fetching console output is now done when the user clicks on the `Console Output` link in the RubJob stage details.

see related PRs for gate https://github.com/spinnaker/gate/pull/515 and orca https://github.com/spinnaker/orca/pull/2061

Here's what a loading runJob log looks like:

![load_console_output](https://user-images.githubusercontent.com/34253460/37543587-71f3f144-2938-11e8-8395-6715c0f61ee0.gif)
