### PR TITLE
fix(amazon/deploy): Do not destroy SpEL based load balancers in deploy config

### DIFF
--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/loadBalancers/loadBalancerSelector.component.html
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/loadBalancers/loadBalancerSelector.component.html
@@ -26,7 +26,7 @@
                  ng-model="$ctrl.command.targetGroups"
                  class="form-control input-sm">
         <ui-select-match>{{$item}}</ui-select-match>
-        <ui-select-choices repeat="targetGroup in $ctrl.command.backingData.filtered.targetGroups | filter: $select.search">
+        <ui-select-choices repeat="targetGroup in $ctrl.command.backingData.filtered.targetGroups.concat($ctrl.command.spelTargetGroups) | filter: $select.search">
           <span ng-bind-html="targetGroup | highlight: $select.search"></span>
         </ui-select-choices>
       </ui-select>
@@ -57,7 +57,7 @@
                  ng-model="$ctrl.command.loadBalancers"
                  class="form-control input-sm">
         <ui-select-match>{{$item}}</ui-select-match>
-        <ui-select-choices repeat="loadBalancer in $ctrl.command.backingData.filtered.loadBalancers | filter: $select.search">
+        <ui-select-choices repeat="loadBalancer in $ctrl.command.backingData.filtered.loadBalancers.concat($ctrl.command.spelLoadBalancers) | filter: $select.search">
           <span ng-bind-html="loadBalancer | highlight: $select.search"></span>
         </ui-select-choices>
       </ui-select>

--- a/app/scripts/modules/core/src/serverGroup/configure/common/serverGroupCommandBuilder.service.ts
+++ b/app/scripts/modules/core/src/serverGroup/configure/common/serverGroupCommandBuilder.service.ts
@@ -98,6 +98,7 @@ export interface IServerGroupCommand extends IServerGroupCommandResult {
   };
   stack?: string;
   moniker?: IMoniker;
+  spelLoadBalancers: string[];
   strategy: string;
   subnetType: string;
   suspendedProcesses: string[];


### PR DESCRIPTION
If someone has added a SpEL based load balancer or target group to a deploy config, then goes to edit that deploy config in the UI, it will remove them because they don't string match existing ones.

This basically trusts load balancers or target groups that have a `${` in them as being 'valid' so it will not remove them.