### PR TITLE
fix(core): avoid excessive rerender on popovers with templates

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/wait/SkipWait.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/wait/SkipWait.tsx
@@ -10,7 +10,6 @@ export interface ISkipWaitProps {
   execution: IExecution;
   stage: IExecutionStage;
   application: Application;
-  autoRefresh?: boolean;
 }
 
 export interface ISkipWaitState {
@@ -53,19 +52,15 @@ export class SkipWait extends React.Component<ISkipWaitProps, ISkipWaitState> {
   };
 
   public componentWillReceiveProps() {
-    this.runningTime && this.runningTime.checkStatus();
+    this.runningTime.checkStatus();
   }
 
   public componentDidMount() {
-    if (this.props.autoRefresh) {
-      this.runningTime = new OrchestratedItemRunningTime(this.props.stage, (time: number) => this.setRemainingWait(time));
-    } else {
-      this.setRemainingWait(Date.now() - this.props.stage.startTime);
-    }
+    this.runningTime = new OrchestratedItemRunningTime(this.props.stage, (time: number) => this.setRemainingWait(time));
   }
 
   public componentWillUnmount() {
-    this.runningTime && this.runningTime.reset();
+    this.runningTime.reset();
   }
 
   public render() {
@@ -97,3 +92,4 @@ export class SkipWait extends React.Component<ISkipWaitProps, ISkipWaitState> {
     )
   }
 }
+

--- a/app/scripts/modules/core/src/pipeline/config/stages/wait/WaitExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/wait/WaitExecutionDetails.tsx
@@ -7,12 +7,12 @@ import { SkipWait } from './SkipWait';
 export function WaitExecutionDetails(props: IExecutionDetailsSectionProps) {
   return (
     <ExecutionDetailsSection name={props.name} current={props.current}>
-      <SkipWait application={props.application} execution={props.execution} stage={props.stage} autoRefresh={true}/>
+      <SkipWait application={props.application} execution={props.execution} stage={props.stage}/>
       <StageFailureMessage stage={props.stage} message={props.stage.failureMessage} />
       <StageExecutionLogs stage={props.stage} />
     </ExecutionDetailsSection>
   );
-};
+}
 
 export namespace WaitExecutionDetails {
   export const title = 'waitConfig';

--- a/app/scripts/modules/core/src/presentation/HoverablePopover.tsx
+++ b/app/scripts/modules/core/src/presentation/HoverablePopover.tsx
@@ -141,7 +141,9 @@ export class HoverablePopover extends React.Component<IHoverablePopoverProps, IH
     const { Component, template, placement, container, hOffsetPercent, id, title, className } = this.props;
     const { popoverIsOpen, animation, placementOverride } = this.state;
 
-    const PopoverContentsComponent: React.ComponentType<IHoverablePopoverContentsProps> = Component ? Component : () => template;
+    const popoverContent: JSX.Element = Component ?
+      <Component {...this.props} hidePopover={() => this.hidePopoverEvents$.next()}/> :
+      template;
 
     return (
       <g onMouseEnter={this.handleMouseEvent} onMouseLeave={this.handleMouseEvent} ref={this.refCallback}>
@@ -157,7 +159,7 @@ export class HoverablePopover extends React.Component<IHoverablePopoverProps, IH
             title={title}
             className={className}
           >
-            <PopoverContentsComponent {...this.props} hidePopover={() => this.hidePopoverEvents$.next()}/>
+            {popoverContent}
           </PopoverOffset>
         </Overlay>
       </g>


### PR DESCRIPTION
The arrow function causes a lot of unneeded re-renders when a template is passed in instead of a Component.

The rest of the PR just reverts changes made to the wait stage components to work around the underlying issue...