### PR TITLE
fix(core): load jQuery before Angular

### DIFF
--- a/app/scripts/app.ts
+++ b/app/scripts/app.ts
@@ -1,3 +1,4 @@
+require('jquery'); // ensures jQuery is loaded before Angular so Angular does not use jqlite
 import { module } from 'angular';
 
 import { CORE_MODULE } from '@spinnaker/core';


### PR DESCRIPTION
Deck depends on Angular elements being jQuery objects, unfortunately.