### PR TITLE
fix(core): avoid overflow on Applications actions menu

### DIFF
--- a/app/scripts/modules/core/src/application/search/Applications.tsx
+++ b/app/scripts/modules/core/src/application/search/Applications.tsx
@@ -143,7 +143,7 @@ export class Applications extends React.Component<{}, IApplicationsState> {
     return (
       <div className="infrastructure">
         <div className="infrastructure-section search-header">
-          <div className="container" style={{ overflowY: 'auto' }}>
+          <div className="container">
             <h2 className="header-section">
               <span className="search-label">Applications</span>
               <input
@@ -161,7 +161,7 @@ export class Applications extends React.Component<{}, IApplicationsState> {
           </div>
         </div>
 
-        <div className="container">
+        <div className="infrastructure-section container">
           {!applications && <LoadingSpinner/>}
 
           {applications && applications.length === 0 && (

--- a/app/scripts/modules/core/src/insight/InsightMenu.tsx
+++ b/app/scripts/modules/core/src/insight/InsightMenu.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { IScope } from 'angular';
 import { BindAll } from 'lodash-decorators';
-import { ButtonToolbar, DropdownButton, MenuItem } from 'react-bootstrap';
+import { DropdownButton, MenuItem } from 'react-bootstrap';
 import { StateService } from '@uirouter/core';
 import { IModalService } from 'angular-ui-bootstrap';
 
@@ -91,13 +91,11 @@ export class InsightMenu extends React.Component<IInsightMenuProps, IInsightMenu
       <span>Refresh all caches</span>;
 
     return (
-      <ButtonToolbar bsSize="small">
-        <DropdownButton pullRight={true} title="Actions" id="insight-menu">
-          {createApp && <MenuItem href="javascript:void(0)" onClick={this.createApplication}>Create Application</MenuItem>}
-          {createProject && <MenuItem href="javascript:void(0)" onClick={this.createProject}>Create Project</MenuItem>}
-          {refreshCaches && <MenuItem href="javascript:void(0)" onClick={this.refreshAllCaches}>{refreshMarkup}</MenuItem>}
-        </DropdownButton>
-      </ButtonToolbar>
+      <DropdownButton pullRight={true} title="Actions" id="insight-menu">
+        {createApp && <MenuItem href="javascript:void(0)" onClick={this.createApplication}>Create Application</MenuItem>}
+        {createProject && <MenuItem href="javascript:void(0)" onClick={this.createProject}>Create Project</MenuItem>}
+        {refreshCaches && <MenuItem href="javascript:void(0)" onClick={this.refreshAllCaches}>{refreshMarkup}</MenuItem>}
+      </DropdownButton>
     )
   };
 }


### PR DESCRIPTION
Fixes this:
<img width="341" alt="screen shot 2018-03-21 at 11 39 44 pm" src="https://user-images.githubusercontent.com/73450/37755067-2ca30d46-2d61-11e8-802a-b54e2b627ade.png">

Also makes the application list scrollable if needed. I think some users have long descriptions, so the table gets very long, and they cannot get to the pagination controls.