### PR TITLE
fix(core/securityGroups): ensure security groups view renders when ready

### DIFF
--- a/app/scripts/modules/core/src/securityGroup/AllSecurityGroupsCtrl.js
+++ b/app/scripts/modules/core/src/securityGroup/AllSecurityGroupsCtrl.js
@@ -41,6 +41,7 @@ module.exports = angular.module('spinnaker.core.securityGroup.all.controller', [
       });
 
       app.securityGroups.onRefresh($scope, () => updateSecurityGroups());
+      app.securityGroups.ready().then(() => updateSecurityGroups());
 
     };
 


### PR DESCRIPTION
There's a race condition where the security groups view sometimes does not render when switching between tabs - it gets stuck in the "loading" state.

I won't pretend to understand why this fixes the problem. It, uh, just does.