### PR TITLE
fix(core-package): Add explicit do-not-ignores to .npmignore so yalc doesn't exclude them

### DIFF
--- a/app/scripts/modules/core/.npmignore
+++ b/app/scripts/modules/core/.npmignore
@@ -2,4 +2,5 @@ yalc.*
 .*
 tsconfig.json
 webpack.config.js
-
+!history
+!changes


### PR DESCRIPTION
Yalc ignores a certain set of files like LICENSE or HISTORY (I'm not sure why) and this PR explicitly unignores them.

See: https://github.com/whitecolor/yalc/issues/8