### PR TITLE
feat(core): allow custom warning when users skip wait stage

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/wait/SkipWait.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/wait/SkipWait.tsx
@@ -5,6 +5,7 @@ import { Application } from 'core/application/application.model';
 import { ReactInjector } from 'core/reactShims';
 import { duration } from 'core/utils/timeFormatters';
 import { OrchestratedItemRunningTime } from 'core/pipeline/executions/execution/OrchestratedItemRunningTime';
+import { DEFAULT_SKIP_WAIT_TEXT } from './waitStage';
 
 export interface ISkipWaitProps {
   execution: IExecution;
@@ -43,7 +44,7 @@ export class SkipWait extends React.Component<ISkipWaitProps, ISkipWaitState> {
     confirmationModalService.confirm({
       header: 'Really skip wait?',
       buttonText: 'Skip',
-      body: '<p>The pipeline will proceed immediately, marking this stage completed.</p>',
+      body: stage.context.skipWaitText || DEFAULT_SKIP_WAIT_TEXT,
       submitMethod: () => {
         return executionService.patchExecution(this.props.execution.id, stage.id, data)
           .then(() => executionService.waitUntilExecutionMatches(this.props.execution.id, matcher));

--- a/app/scripts/modules/core/src/pipeline/config/stages/wait/waitStage.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/wait/waitStage.html
@@ -2,4 +2,21 @@
   <stage-config-field label="Wait Time (seconds)" field-columns="6">
     <number-input model="stage.waitTime"></number-input>
   </stage-config-field>
+  <div class="form-group">
+    <div class="col-md-8 col-md-offset-3">
+      <div class="checkbox">
+        <label>
+          <input type="checkbox" ng-model="ctrl.enableCustomSkipWaitText"/>
+          <span> Show custom warning when users skip wait</span>
+        </label>
+      </div>
+    </div>
+    <div class="col-md-8 col-md-offset-3 checkbox-padding" ng-if="ctrl.enableCustomSkipWaitText">
+        <textarea class="form-control"
+                  rows="4"
+                  placeholder="Default text: '{{ctrl.defaultSkipWaitText}}' (HTML is okay)"
+                  style="margin-top: 5px"
+                  ng-model="stage.skipWaitText"/>
+    </div>
+  </div>
 </div>

--- a/app/scripts/modules/core/src/pipeline/config/stages/wait/waitStage.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/wait/waitStage.ts
@@ -9,6 +9,8 @@ import { WaitExecutionLabel } from './WaitExecutionLabel';
 
 export const WAIT_STAGE = 'spinnaker.core.pipeline.stage.waitStage';
 
+export const DEFAULT_SKIP_WAIT_TEXT = 'The pipeline will proceed immediately, marking this stage completed.';
+
 module(WAIT_STAGE, [
   PIPELINE_CONFIG_PROVIDER,
 ])
@@ -22,9 +24,13 @@ module(WAIT_STAGE, [
       executionLabelComponent: WaitExecutionLabel,
       useCustomTooltip: true,
       strategy: true,
-      controller: 'WaitStageCtrl',
+      controller: 'WaitStageCtrl as ctrl',
       validators: [
         { type: 'requiredField', fieldName: 'waitTime' },
       ],
     });
-  }).controller('WaitStageCtrl', (stage: IStage) => stage.waitTime = stage.waitTime || 30);
+  }).controller('WaitStageCtrl', function (stage: IStage) {
+    stage.waitTime = stage.waitTime || 30;
+    stage.enableCustomSkipWaitText = !!stage.skipWaitText;
+    this.defaultSkipWaitText = DEFAULT_SKIP_WAIT_TEXT;
+  });


### PR DESCRIPTION
We did something similar for execution window skipping; this applies the same pattern to wait stages.