### PR TITLE
fix(core): fix submenu alignment, sync running badges

### DIFF
--- a/app/scripts/modules/core/src/application/nav/DataSourceEntry.tsx
+++ b/app/scripts/modules/core/src/application/nav/DataSourceEntry.tsx
@@ -1,0 +1,81 @@
+import * as React from 'react';
+import { Subscription } from 'rxjs';
+
+import { Application, ApplicationDataSource } from 'core/application';
+import { IEntityTags } from 'core/domain';
+import { DataSourceNotifications } from 'core/entityTag/notifications/DataSourceNotifications';
+
+import { NavIcon } from './NavIcon';
+
+export interface IDataSourceEntryProps {
+  application: Application;
+  dataSource?: ApplicationDataSource;
+  hideIcon?: boolean;
+}
+
+export interface IDataSourceEntryState {
+  runningCount?: number;
+  tags?: IEntityTags[];
+}
+
+export class DataSourceEntry extends React.Component<IDataSourceEntryProps, IDataSourceEntryState> {
+
+  private runningCountSubscription: Subscription;
+  private entityTagsSubscription: Subscription;
+
+  constructor(props: IDataSourceEntryProps) {
+    super(props);
+    this.state = this.getState(props);
+  }
+
+  public componentDidMount() {
+    this.configureSubscriptions(this.props);
+  }
+
+  public componentWillReceiveProps(nextProps: IDataSourceEntryProps) {
+    this.setState(this.getState(nextProps));
+    this.clearSubscriptions();
+    this.configureSubscriptions(nextProps);
+  }
+
+  private configureSubscriptions(props: IDataSourceEntryProps) {
+    const { dataSource, application } = props;
+    if (dataSource.badge && application.getDataSource(dataSource.badge)) {
+      const badgeSource = application.getDataSource(dataSource.badge);
+      this.runningCountSubscription = badgeSource.refresh$
+        .subscribe(() => this.setState({ runningCount: badgeSource.data.length }));
+    }
+    this.entityTagsSubscription = dataSource.refresh$
+      .subscribe(() => this.setState({ tags: dataSource.alerts }));
+  }
+
+  private getState(props: IDataSourceEntryProps): IDataSourceEntryState {
+    const { dataSource, application } = props;
+    return {
+      tags: dataSource.alerts || [],
+      runningCount: dataSource && dataSource.badge ? application.getDataSource(dataSource.badge).data.length : 0,
+    };
+  }
+
+  private clearSubscriptions(): void {
+    this.runningCountSubscription && this.runningCountSubscription.unsubscribe();
+    this.entityTagsSubscription.unsubscribe();
+  }
+
+  public componentWillUnmount() {
+    this.clearSubscriptions();
+  }
+
+  public render() {
+    const { dataSource, application, hideIcon } = this.props;
+    const { tags, runningCount } = this.state;
+    return (
+      <>
+        {!hideIcon && <NavIcon icon={dataSource.icon}/>}
+        {' ' + dataSource.label}
+        {runningCount > 0 && <span className="badge badge-running-count">{runningCount}</span>}
+        <DataSourceNotifications tags={tags} application={application} tabName={dataSource.label}/>
+      </>
+    );
+  }
+}

--- a/app/scripts/modules/core/src/application/nav/ThirdLevelNavigation.tsx
+++ b/app/scripts/modules/core/src/application/nav/ThirdLevelNavigation.tsx
@@ -1,12 +1,11 @@
 import * as React from 'react';
 import { UIRouterContext } from '@uirouter/react-hybrid';
 import { UISref, UISrefActive } from '@uirouter/react';
-import { NavIcon } from 'core/application/nav/NavIcon';
 import { BindAll } from 'lodash-decorators';
 
 import { Application } from 'core/application';
-import { DataSourceNotifications } from 'core/entityTag/notifications/DataSourceNotifications';
 import { IDataSourceCategory } from './ApplicationHeader';
+import { DataSourceEntry } from './DataSourceEntry';
 
 export interface IThirdLevelNavigationProps {
   category: IDataSourceCategory;
@@ -26,26 +25,17 @@ export class ThirdLevelNavigation extends React.Component<IThirdLevelNavigationP
       <div className="container application-header application-nav hidden-xs">
         <div className="third-level-nav horizontal middle">
         <h3>{category.label}</h3>
-        <div className="nav-section horizontal middle">
-          {category.dataSources.map(dataSource => (
-            <UISrefActive class="active" key={dataSource.key}>
-              <UISref to={dataSource.sref}>
-                <a className="nav-item horizontal middle">
-
-                  <NavIcon icon={dataSource.icon}/>
-
-                  {' ' + dataSource.label}
-
-                  <DataSourceNotifications tags={dataSource.alerts} application={application} tabName={category.label}/>
-
-                  {dataSource.badge && application.getDataSource(dataSource.badge).data.length > 0 &&
-                    <span className="badge badge-running-count">{application.getDataSource(dataSource.badge).data.length}</span>}
-
-                </a>
-              </UISref>
-            </UISrefActive>
-          ))}
-        </div>
+          <div className="nav-section horizontal middle">
+            {category.dataSources.map(dataSource => (
+              <UISrefActive class="active" key={dataSource.key}>
+                <UISref to={dataSource.sref}>
+                  <a className="nav-item horizontal middle">
+                    <DataSourceEntry application={application} dataSource={dataSource}/>
+                  </a>
+                </UISref>
+              </UISrefActive>
+            ))}
+          </div>
         </div>
       </div>
     );

--- a/app/scripts/modules/core/src/application/nav/applicationNav.component.less
+++ b/app/scripts/modules/core/src/application/nav/applicationNav.component.less
@@ -92,6 +92,7 @@
       margin-top: -10px;
     }
     .nav-menu-item {
+      display: flex;
       color: var(--color-primary);
       font-size: 14px;
       padding: 5px 15px;
@@ -109,13 +110,6 @@
     font-weight: 600;
   }
   .nav-item {
-    &[disabled] {
-      cursor: none;
-      opacity: 1;
-      a {
-        cursor: default;
-      }
-    }
     a {
       &:hover, &:focus, &:active {
         text-decoration: none;
@@ -130,11 +124,9 @@
       font-size: 16px;
       padding: 15px;
     }
-    &:focus {
-      outline: none;
-    }
-    &:hover {
-      text-decoration: none;
+    &:focus, &:hover {
+      outline: none !important;
+      text-decoration: none !important;
     }
   }
   .nav-item-icon {
@@ -184,6 +176,9 @@
       color: var(--color-primary);
       border-bottom-color: var(--color-primary);
       transition: border-bottom-color 200ms ease-in, color 200ms ease-in;
+      .badge {
+        background-color: var(--color-primary);
+      }
     }
   }
 }


### PR DESCRIPTION
* Fixing the CSS in the menu items (bootstrap has a pretty specific CSS selector setting the display to `block`, overriding the `flex` we are trying to get via `horizontal`)
* forcing the menus to close when the active category is set to this menu, getting rid of the disabled approach to close the menu because, when mousing between an active (i.e. disabled) menu and another one, the mouseEnter event does not fire on the adjacent one, so its menu does not display. I don't know why, I just spent three hours trying to figure it out and this is where we are and, well, this makes as much sense as the original approach.
* pushing the logic for the single-source (i.e. dropdown menu items, third-level navigation entries) data synchronization to its own component, since they are not synchronizing at all. Users haven't noticed it (or haven't said anything about it), but I would like to get ahead of this one.