### PR TITLE
feat(aws): Support rollback of a disabled server group

### DIFF
--- a/app/scripts/modules/amazon/src/serverGroup/details/rollback/rollbackServerGroup.controller.js
+++ b/app/scripts/modules/amazon/src/serverGroup/details/rollback/rollbackServerGroup.controller.js
@@ -11,7 +11,9 @@ module.exports = angular.module('spinnaker.amazon.serverGroup.details.rollback.c
     ])
     .controller('awsRollbackServerGroupCtrl', function ($scope, $uibModalInstance, serverGroupWriter,
                                                         taskMonitorBuilder,
-                                                        application, serverGroup, disabledServerGroups, allServerGroups) {
+                                                        application,
+                                                        serverGroup, previousServerGroup,
+                                                        disabledServerGroups, allServerGroups) {
       $scope.serverGroup = serverGroup;
       $scope.disabledServerGroups = disabledServerGroups.sort((a, b) => b.name.localeCompare(a.name));
       $scope.allServerGroups = allServerGroups.sort((a, b) => b.name.localeCompare(a.name));
@@ -54,6 +56,7 @@ module.exports = angular.module('spinnaker.amazon.serverGroup.details.rollback.c
         rollbackType: rollbackType,
         rollbackContext: {
           rollbackServerGroupName: serverGroup.name,
+          restoreServerGroupName: previousServerGroup ? previousServerGroup.name : undefined,
           targetHealthyRollbackPercentage: healthyPercent
         }
       };

--- a/app/scripts/modules/amazon/src/serverGroup/details/rollback/rollbackServerGroup.html
+++ b/app/scripts/modules/amazon/src/serverGroup/details/rollback/rollbackServerGroup.html
@@ -10,7 +10,7 @@
         <div class="col-sm-3 sm-label-right">
           Restore to
         </div>
-        <div class="col-sm-8">
+        <div class="col-md-7">
           <ui-select ng-model="command.rollbackContext.restoreServerGroupName"
                      class="form-control input-sm"
                      ng-if="command.rollbackType === 'EXPLICIT'">
@@ -42,9 +42,7 @@
         </div>
       </div>
 
-      <div class="row">
-        <task-reason command="command"></task-reason>
-      </div>
+      <task-reason command="command"></task-reason>
 
       <div class="row">
         <div class="col-sm-11 col-sm-offset-1">


### PR DESCRIPTION
A disabled server group can be rolled back iff at least one enabled
server group exists in the same cluster.

The largest enabled server group in the cluster will will be selected as
the rollback source.

depends on spinnaker/clouddriver#2455
