### PR TITLE
fix(core/search): dont throw when SETTINGS.defaultProviders is null-ish

### DIFF
--- a/app/scripts/modules/core/src/search/infrastructure/infrastructureSearchV2.service.ts
+++ b/app/scripts/modules/core/src/search/infrastructure/infrastructureSearchV2.service.ts
@@ -25,7 +25,10 @@ export class InfrastructureSearchServiceV2 {
       return Observable.from(this.EMPTY_RESULTS);
     }
 
-    const params = { ...apiParams, cloudProvider: SETTINGS.defaultProviders[0] };
+    const params = { ...apiParams };
+    if (SETTINGS.defaultProviders && SETTINGS.defaultProviders.length > 0) {
+      params.cloudProvider = SETTINGS.defaultProviders[0];
+    }
     const types = searchResultTypeRegistry.getAll();
     const otherResults$ = new Subject<ISearchResultSet>();
 


### PR DESCRIPTION
When deck's settings have been overridden such that `SETTINGS.defaultProviders` is null or undefined, bad things happen:

![2018-03-29_11-11-14](https://user-images.githubusercontent.com/34253460/38096867-f41e3770-3341-11e8-9fd5-799c8effae57.png)

fixes https://github.com/spinnaker/spinnaker/issues/2561