### PR TITLE
Manually filter out removed artifact IDs from stages

### DIFF
--- a/app/scripts/modules/core/src/artifact/expectedArtifact.service.ts
+++ b/app/scripts/modules/core/src/artifact/expectedArtifact.service.ts
@@ -1,4 +1,5 @@
 import { copy, module } from 'angular';
+import { isString } from 'lodash';
 
 import { IArtifact, IExpectedArtifact, IPipeline, IStage } from 'core/domain';
 import { PIPELINE_CONFIG_SERVICE, PipelineConfigService } from 'core/pipeline/config/services/pipelineConfig.service';
@@ -27,8 +28,10 @@ export class ExpectedArtifactService {
 }
 
 export function summarizeExpectedArtifact() {
-  return function (expected: IExpectedArtifact): string {
-    if (!expected) {
+  return function (expected: (IExpectedArtifact|string)): string {
+    // `expected` is a string only if an expected artifact has been deleted
+    // and a stale uuid still exists as a reference somewhere
+    if (!expected || isString(expected)) {
       return '';
     }
 

--- a/app/scripts/modules/core/src/pipeline/config/triggers/triggers.directive.js
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/triggers.directive.js
@@ -50,9 +50,35 @@ module.exports = angular.module('spinnaker.core.pipeline.config.trigger.triggers
         return;
       }
 
-      pipeline.triggers
-        .forEach(t => t.expectedArtifactIds = t.expectedArtifactIds
-          .filter(eid => expectedArtifact.id !== eid));
+      pipeline.triggers.forEach(t => {
+        if (t.expectedArtifactIds) {
+          t.expectedArtifactIds = t.expectedArtifactIds.filter(id => id !== expectedArtifact.id);
+        }
+      });
+
+      if (!pipeline.stages || pipeline.stages.length === 0) {
+        return;
+      }
+
+      pipeline.stages.forEach(stage => {
+        if (stage.manifestArtifactId && stage.manifestArtifactId === expectedArtifact.id) {
+          delete stage.manifestArtifactId;
+        }
+        if (stage.requiredArtifactIds && stage.requiredArtifactIds.length > 0) {
+          stage.requiredArtifactIds = stage.requiredArtifactIds.filter(id => id !== expectedArtifact.id);
+        }
+        if (stage.clusters && stage.clusters.length > 0) {
+          stage.clusters.forEach(cluster => {
+            if (cluster.imageArtifactId === expectedArtifact.id) {
+              delete cluster.imageArtifactId;
+
+              if (cluster.imageSource === 'artifact') {
+                delete cluster.imageSource;
+              }
+            }
+          });
+        }
+      });
     };
 
     this.addArtifact = () => {


### PR DESCRIPTION
When an expected artifact is deleted any references to it continue to live on in stages' JSON.
When the UI attempts to render artifact info based on those references it's unable to find the correlating artifact objects (since they're deleted) and so surfaces the error to the DOM in odd ways.

See https://github.com/spinnaker/spinnaker/issues/2562

This is a crummy fix because it hard-codes the locations of all the places artifacts might live in the `removeExpectedArtifact` method.  It will need to be updated every time we add a new field on a stage that will store reference to an artifact.  I'm not sure what we could do as a better fix for this though.  Ideas welcome.