### PR TITLE
fix(titus): fix alignment of migration config fields

### DIFF
--- a/app/scripts/modules/titus/src/migration/titusMigrationConfig.component.less
+++ b/app/scripts/modules/titus/src/migration/titusMigrationConfig.component.less
@@ -51,8 +51,11 @@ titus-migration-config {
   }
 
   .config-field {
-    display: inline-block;
     margin-right: 10px;
+  }
+
+  .ui-select-placeholder {
+    display: inline;
   }
 
   .migration-config-pipeline {


### PR DESCRIPTION
On certain screen resolutions, the "Wait [x] seconds between updates" line will appear to the right of the line above it when toggling the batch size dropdown. Also, the batch size dropdown causes grief when it's open because it tries to render as a block level element, so we should force it to display inline.