### PR TITLE
fix(core): remove :focus styling on nav dropdowns

### DIFF
--- a/app/scripts/modules/core/src/application/nav/applicationNav.component.less
+++ b/app/scripts/modules/core/src/application/nav/applicationNav.component.less
@@ -54,7 +54,7 @@
     position: relative;
     box-shadow: 0 0 3px 1px var(--color-alto);
   }
-  .nav-item {
+  .nav-item, .dropdown-toggle {
     &:after {
       content: ' ';
       width: 0;
@@ -68,8 +68,7 @@
       z-index: 3;
       transition: border-bottom-color 200ms ease-in;
     }
-    &.active, &:focus, &:hover {
-      background-color: transparent;
+    &.active, &:hover {
       color: var(--color-primary);
       .badge {
         background-color: var(--color-primary);


### PR DESCRIPTION
If you use the browser navigation to move between pages, the top level nav items tend to retain focus, which makes it look like they are selected. Also, the caret was only showing on the dropdowns when they were in a :hover or :focus state due to a previous refactor (CSS is hard for some people).