### PR TITLE
refactor(core): lazy load execution details

### DIFF
--- a/app/scripts/modules/canary/acaTask/acaTaskStage.transformer.js
+++ b/app/scripts/modules/canary/acaTask/acaTaskStage.transformer.js
@@ -12,7 +12,7 @@ module.exports = angular.module('spinnaker.canary.acaTask.transformer', []).serv
 
   this.transform = function(application, execution) {
     execution.stages.forEach(function(stage) {
-      if (stage.type === 'acaTask') {
+      if (stage.type === 'acaTask' && execution.hydrated) {
         OrchestratedItemTransformer.defineProperties(stage);
         stage.exceptions = [];
 

--- a/app/scripts/modules/core/src/domain/IExecution.ts
+++ b/app/scripts/modules/core/src/domain/IExecution.ts
@@ -27,6 +27,8 @@ export interface IExecution extends IOrchestratedItem {
   trigger: IExecutionTrigger;
   user: string;
   fromTemplate?: boolean;
+  hydrated?: boolean;
+  hydrator?: Promise<IExecution>;
 }
 
 export interface IExecutionGroup {

--- a/app/scripts/modules/core/src/pipeline/config/graph/PipelineGraph.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/graph/PipelineGraph.tsx
@@ -6,6 +6,7 @@ import { BindAll, Debounce, Throttle } from 'lodash-decorators';
 import { clone, find, flatten, forOwn, groupBy, max, maxBy, sortBy, sum, sumBy, uniq } from 'lodash';
 import { Subscription } from 'rxjs';
 
+import { Application } from 'core/application';
 import { IExecution, IPipeline } from 'core/domain';
 import { IPipelineValidationResults } from 'core/pipeline/config/validation/pipelineConfig.validator';
 import { ReactInjector } from 'core/reactShims';
@@ -24,6 +25,7 @@ import './pipelineGraph.less';
 
 export interface IPipelineGraphProps {
   execution?: IExecution;
+  application?: Application;
   onNodeClick: (node: IPipelineGraphNode, subIndex?: number) => void;
   pipeline?: IPipeline;
   shouldValidate?: boolean;
@@ -40,6 +42,7 @@ export interface IPipelineGraphState {
   nodeRadius: number;
   phaseCount: number;
   rowHeights: number[];
+  hydrated: boolean;
 }
 
 @BindAll()
@@ -55,6 +58,7 @@ export class PipelineGraph extends React.Component<IPipelineGraphProps, IPipelin
     nodeRadius: this.defaultNodeRadius,
     phaseCount: 0,
     rowHeights: [],
+    hydrated: false,
   };
   private element: JQuery;
   private graphStatusHash: string;
@@ -65,15 +69,17 @@ export class PipelineGraph extends React.Component<IPipelineGraphProps, IPipelin
   private rowPadding = 20;
   private validationSubscription: Subscription;
   private windowResize = this.handleWindowResize.bind(this);
+  private mounted = false;
 
   constructor(props: IPipelineGraphProps) {
     super(props);
-    this.state = this.defaultState;
+    const { execution } = props;
+    this.state = { ...this.defaultState, ...{ hydrated: execution && execution.hydrated } };
 
     // HACK: This is needed to update the node states in the graph based on the stage states.
     //       Once the execution itself changes based on stage status, this can be removed.
-    if (this.props.execution) {
-      this.graphStatusHash = this.props.execution.graphStatusHash;
+    if (execution) {
+      this.graphStatusHash = execution.graphStatusHash;
     }
   }
 
@@ -396,6 +402,14 @@ export class PipelineGraph extends React.Component<IPipelineGraphProps, IPipelin
 
   public componentDidMount() {
     window.addEventListener('resize', this.windowResize);
+    this.mounted = true;
+    if (!this.state.hydrated && this.props.execution) {
+      ReactInjector.executionService.hydrate(this.props.application, this.props.execution).then(() => {
+        if (this.mounted) {
+          this.setState({ hydrated: true });
+        }
+      });
+    }
     this.validationSubscription = ReactInjector.pipelineConfigValidator.subscribe(validations => {
       this.pipelineValidations = validations;
       this.updateGraph(this.props);
@@ -445,6 +459,7 @@ export class PipelineGraph extends React.Component<IPipelineGraphProps, IPipelin
   }
 
   public componentWillUnmount() {
+    this.mounted = false;
     this.validationSubscription.unsubscribe();
     window.removeEventListener('resize', this.windowResize);
   }

--- a/app/scripts/modules/core/src/pipeline/config/stages/core/ExecutionBarLabel.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/core/ExecutionBarLabel.tsx
@@ -1,16 +1,53 @@
 import * as React from 'react';
+import { BindAll } from 'lodash-decorators';
 import { OverlayTrigger, Tooltip } from 'react-bootstrap';
 
 import { IExecutionStageLabelComponentProps } from 'core/domain';
 import { ExecutionWindowActions } from 'core/pipeline/config/stages/executionWindows/ExecutionWindowActions';
 import { HoverablePopover } from 'core/presentation/HoverablePopover';
 import { ReactInjector } from 'core/reactShims';
+import { Spinner } from 'core/widgets';
 
 export interface IExecutionBarLabelProps extends IExecutionStageLabelComponentProps {
   tooltip?: JSX.Element;
 }
 
-export class ExecutionBarLabel extends React.Component<IExecutionBarLabelProps> {
+export interface IExecutionBarLabelState {
+  hydrated: boolean;
+}
+
+@BindAll()
+export class ExecutionBarLabel extends React.Component<IExecutionBarLabelProps, IExecutionBarLabelState> {
+
+  private mounted = false;
+
+  constructor(props: IExecutionBarLabelProps) {
+    super(props);
+    this.state = {
+      hydrated: props.execution && props.execution.hydrated
+    };
+  }
+
+  private hydrate(): void {
+    const { execution, application } = this.props;
+    if (!execution) {
+      return;
+    }
+    ReactInjector.executionService.hydrate(application, execution).then(() => {
+      if (this.mounted) {
+        this.setState({ hydrated: true });
+      }
+    });
+  }
+
+  public componentDidMount() {
+    this.mounted = true;
+  }
+
+  public componentWillUnmount() {
+    this.mounted = false;
+  }
+
   public render() {
     const { stage, application, execution, executionMarker } = this.props;
     const inSuspendedExecutionWindow = stage.inSuspendedExecutionWindow;
@@ -28,6 +65,16 @@ export class ExecutionBarLabel extends React.Component<IExecutionBarLabelProps> 
     }
     if (executionMarker) {
       const LabelComponent = stage.labelComponent;
+      if (LabelComponent !== ExecutionBarLabel && !this.state.hydrated) {
+        const loadingTooltip = (<Tooltip id={stage.id}><Spinner size="small"/></Tooltip>);
+        return (
+          <span onMouseEnter={this.hydrate}>
+            <OverlayTrigger placement="top" overlay={loadingTooltip}>
+              {this.props.children}
+            </OverlayTrigger>
+          </span>
+        );
+      }
       const tooltip = (
         <Tooltip id={stage.id}>
           <LabelComponent application={application} execution={execution} stage={stage} />

--- a/app/scripts/modules/core/src/pipeline/executions/execution/Execution.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/execution/Execution.tsx
@@ -409,7 +409,7 @@ export class Execution extends React.Component<IExecutionProps, IExecutionState>
         </div>
         {showingDetails && (
           <div className="execution-graph">
-            <PipelineGraph execution={execution} onNodeClick={this.handleNodeClick} viewState={viewState} />
+            <PipelineGraph execution={execution} application={application} onNodeClick={this.handleNodeClick} viewState={viewState} />
           </div>
         )}
         {showingDetails && (

--- a/app/scripts/modules/core/src/pipeline/executions/executionGroup/ExecutionGroup.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/executionGroup/ExecutionGroup.tsx
@@ -300,6 +300,6 @@ export class ExecutionGroup extends React.Component<IExecutionGroupProps, IExecu
   }
 
   private getDeploymentAccounts(): string[] {
-    return uniq(flatten<string>(this.props.group.executions.map((e: IExecution) => e.deploymentTargets))).sort();
+    return uniq(flatten<string>(this.props.group.executions.map((e: IExecution) => e.deploymentTargets))).sort().filter(a => !!a);
   }
 }


### PR DESCRIPTION
The amount of data we return from the `application/{app}/pipelines` call is often very heavy and rarely needs to be. We don't need `context`, or `outputs`, or `tasks` on stages unless we hover over certain stage types or we expand the execution to look at the graph or stage details.

There will be a subsequent PR to Orca to remove those fields when `expand=false` is sent. For now, we are simulating that by removing them after the response comes back. The idea is to run this for a day or two in production, find out if we missed anything, then actually remove the fields from the Orca payload once we're satisfied we are handling everything in Deck correctly.

There are two cases I'm assuming we need the full stage context to render tooltips for the pipeline stages in the execution bar: if there is a custom tooltip (manual judgment when it's awaiting judgment, running wait stages), or if there is a custom label (bake, canary, Jenkins stages). When the user first hovers on one of those stages, we'll fetch the execution details and add them to the execution's stages.

We also need the context for the pipeline graph and stage details.

I'm sure there's a more RxJS way of doing this. I went with a Promise because that's my comfort zone but happy to make this more Rx-y if someone thinks that's a better way to handle it and provides guidance.