### PR TITLE
fix(eslint): enable es2017 parsing to allow trailing commas in function declaration arguments

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -37,6 +37,7 @@
     "no-empty-pattern": 0
   },
   "parserOptions": {
+    "ecmaVersion": 8,
     "sourceType": "module"
   },
   "env": {


### PR DESCRIPTION
Prettier is adding trailing commas to multi line functions declarations, i.e:

```js
function(
  foo,
  bar,
) {
 // function body
}
``` 

eslint is puking on the `bar,` trailing comma.  Updating the eslint parser to support ES2017 features fixes the parse errors.