### PR TITLE
fix(core/nav): use 'undefined' instead of 'null' for empty select value

### DIFF
--- a/app/scripts/modules/core/src/application/nav/TinyHeader.tsx
+++ b/app/scripts/modules/core/src/application/nav/TinyHeader.tsx
@@ -57,7 +57,7 @@ export class TinyHeader extends React.Component<ITinyHeaderProps> {
       .concat(secondaryCategories)
       .find(c => c.dataSources.some(ds => $state.includes(appState + ds.sref)));
     if (!categoryMatch) {
-      return null;
+      return undefined;
     }
     return categoryMatch.dataSources.find(ds => $state.includes(appState + ds.sref)).key;
   }


### PR DESCRIPTION
Fixes:
```
warning.js:33 Warning: `value` prop on `select` should not be null. Consider using an empty string to clear the component or `undefined` for uncontrolled components.
    in select (created by TinyHeader)
    in div (created by TinyHeader)
    in TinyHeader (created by ApplicationHeader)
    in div (created by ApplicationHeader)
    in div (created by ApplicationHeader)
    in div (created by ApplicationHeader)
    in ApplicationHeader (created by ApplicationComponent)
    in div (created by ApplicationComponent)
    in ApplicationComponent (created by BindResolvesToProps)
    in BindResolvesToProps (created by UIView)
    in UIView (created by ReactUIView)
    in UIRouterContextComponent (created by ReactUIView)
    in ReactUIView
```