### PR TITLE
fix(core/pipeline): Fix rendering of pipeline graphs after tslint --fix

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/graph/pipelineGraph.service.ts
+++ b/app/scripts/modules/core/src/pipeline/config/graph/pipelineGraph.service.ts
@@ -115,6 +115,7 @@ export class PipelineGraphService {
 
     pipeline.stages.forEach(function(stage: IExecutionStageSummary, idx: number) {
       const warnings = pipelineValidations.stages.find((e: any) => e.stage === stage);
+      const parentIds = (stage.requisiteStageRefIds || []).slice();
       const node: IPipelineGraphNode = {
         childLinks: [],
         children: [],
@@ -124,7 +125,7 @@ export class PipelineGraphService {
         isActive: viewState.stageIndex === idx && viewState.section === 'stage',
         isHighlighted: false,
         name: stage.name || '[new stage]',
-        parentIds: { ...[], ...(stage.requisiteStageRefIds || []) },
+        parentIds,
         parentLinks: [],
         parents: [],
         root: false,


### PR DESCRIPTION
fixes:
```
Uncaught TypeError: node.parentIds.push is not a function
    at eval (pipelineGraph.service.ts:89)
    at Array.forEach (<anonymous>)
    at Function.generateConfigGraph (pipelineGraph.service.ts:68)
    at ConstructorWrapper.createNodes (PipelineGraph.tsx:133)
    at ConstructorWrapper.applyPhasesAndLink (PipelineGraph.tsx:145)
    at ConstructorWrapper.updateGraph (PipelineGraph.tsx:418)
    at ConstructorWrapper.componentDidMount (PipelineGraph.tsx:468)
    at commitLifeCycles (react-dom.development.js:8770)
    at commitAllLifeCycles (react-dom.development.js:9946)
    at HTMLUnknownElement.callCallback (react-dom.development.js:542)
```