### PR TITLE
fix(core): fix manual judgment render, active execution refresh

### DIFF
--- a/app/scripts/modules/core/src/pipeline/executions/execution/ExecutionMarker.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/execution/ExecutionMarker.tsx
@@ -105,11 +105,15 @@ export class ExecutionMarker extends React.Component<IExecutionMarkerProps, IExe
           </TooltipComponent>
         );
       } else {
-        const loadingTooltip = (<Tooltip id={stage.id}><Spinner size="small"/></Tooltip>);
+        const loadingTooltip = (
+          <Tooltip id={stage.id}>
+            <Spinner size="small" />
+          </Tooltip>
+        );
         return (
           <span onMouseEnter={this.hydrate}>
             <OverlayTrigger placement="top" overlay={loadingTooltip}>
-              {this.props.children}
+              {stageContents}
             </OverlayTrigger>
           </span>
         );


### PR DESCRIPTION
The first commit fixes a dumb thing I did copy/pasting something, and I don't want to talk about it.

The second commit fixes a few things I noticed:
* Orca doesn't always return the execution JSON in exactly the same order, so our `stringVal` check often unnecessarily replaces the execution or stages within the execution
* the active refresher code in the Execution component does not consider the case where an execution gets replaced by the execution service and the props have changed

The `TODO` comment still stands - this is a mess, and I am guessing it doesn't need to be now, as most of the code on this page is not Angular. Once we get the performance changes in around lazy loading, I will tackle refactoring this.