### PR TITLE
fix(core): extract target accounts from config

### DIFF
--- a/app/scripts/modules/core/src/pipeline/filter/executionFilter.service.ts
+++ b/app/scripts/modules/core/src/pipeline/filter/executionFilter.service.ts
@@ -180,6 +180,9 @@ export class ExecutionFilterService {
   }
 
   private extractAccounts(config: IPipeline): string[] {
+    if (!config) {
+      return [];
+    }
     const configAccounts: string[] = [];
     (config.stages || []).forEach(stage => {
       const stageConfig = this.pipelineConfig.getStageConfig(stage);
@@ -225,6 +228,7 @@ export class ExecutionFilterService {
           config: config || null,
           executions: groupExecutions,
           runningExecutions: groupExecutions.filter((execution: IExecution) => execution.isActive),
+          targetAccounts: this.extractAccounts(config),
           fromTemplate: config.type === 'templatedPipeline',
         });
       });


### PR DESCRIPTION
Huh, who would have guessed we are only looking at the pipeline config to get the target accounts (the tags on the beginning of the execution group header) if there are no executions.

Since the executions are not going to provide that data now (unless one happens to be running), we should really get that data from the configs.

We still want to keep to `accountExtractor` field on the stage configs (and all that associated data), as it's used in our internal fast property pipelines views, but long-term, we should move this data extraction to Orca.