### PR TITLE
feat(kubernetes) remove upper limit for CPU Target on resize

### DIFF
--- a/app/scripts/modules/kubernetes/src/serverGroup/details/resize/resize.html
+++ b/app/scripts/modules/kubernetes/src/serverGroup/details/resize/resize.html
@@ -70,8 +70,7 @@
                      class="form-control input-sm"
                      name="details"
                      ng-model="command.scalingPolicy.cpuUtilization.target"
-                     min="0"
-                     max="100"/>
+                     min="0"/>
               <span class="input-group-addon">%</span>
             </div>
           </div>


### PR DESCRIPTION
Current utilization is based on requested CPU, so it can be larger than 100%