### PR TITLE
fix(core): fix execution rendering on lazy executions

### DIFF
--- a/app/scripts/modules/core/src/pipeline/details/StageExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/details/StageExecutionDetails.tsx
@@ -141,7 +141,7 @@ export class StageExecutionDetails extends React.Component<IStageExecutionDetail
     }
 
     const stateStage = parseInt($stateParams.stage, 10);
-    const stateSubStage = parseInt($stateParams.subStage, 10);
+    const stateSubStage = $stateParams.subStage !== undefined ? parseInt($stateParams.subStage, 10) : undefined;
     const { stage, subStage } = this.validateStageExists(summaries, stateStage, stateSubStage);
     if (stage !== stateStage || subStage !== stateSubStage) {
       $state.go('.', { stage, subStage }, { location: 'replace' });

--- a/app/scripts/modules/core/src/pipeline/service/execution.service.ts
+++ b/app/scripts/modules/core/src/pipeline/service/execution.service.ts
@@ -502,9 +502,13 @@ export class ExecutionService {
       hydrated.stages.forEach(s => {
         const toHydrate = unhydrated.stages.find(s2 => s2.id === s.id);
         if (toHydrate) {
-          toHydrate.context = s.context;
-          toHydrate.outputs = s.outputs;
-          toHydrate.tasks = s.tasks;
+          Object.assign(toHydrate, s);
+        }
+      });
+      hydrated.stageSummaries.forEach(s => {
+        const toHydrate = unhydrated.stageSummaries.find(s2 => s2.id === s.id);
+        if (toHydrate) {
+          Object.assign(toHydrate, s);
         }
       });
       unhydrated.hydrated = true;


### PR DESCRIPTION
Pushing the execution hydrate call up to the Execution component itself instead of the graph component, and preventing the details from being shown at all until the execution is hydrated. It's a lot easier to reason about things in the graph and execution details if you always assume it's hydrated.

Also avoiding an unnecessary `setState` call on the `viewState` field, since it was getting called a lot and causes a lot of pain on the pipeline graph.

And...using `Object.assign` to hydrate the stages and stage summaries instead of a handful of explicit assignments.