### PR TITLE
fix(core/canary): do not transform lazy canaries; smarter stage hydration

### DIFF
--- a/app/scripts/modules/canary/canary/canaryStage.transformer.js
+++ b/app/scripts/modules/canary/canary/canaryStage.transformer.js
@@ -124,6 +124,10 @@ module.exports = angular.module('spinnaker.canary.transformer', []).service('can
 
   this.transform = function(application, execution) {
     var syntheticStagesToAdd = [];
+    if (!execution.hydrated) {
+      // don't bother trying to transform if it isn't hydrated
+      return;
+    }
     execution.stages.forEach(function(stage) {
       if (stage.type === 'canary') {
         OrchestratedItemTransformer.defineProperties(stage);

--- a/app/scripts/modules/core/src/pipeline/service/execution.service.spec.ts
+++ b/app/scripts/modules/core/src/pipeline/service/execution.service.spec.ts
@@ -361,7 +361,7 @@ describe('Service: executionService', () => {
       ];
       const updatedStages = [
         { id: 'a', status: 'COMPLETED' },
-        { id: 'b', status: 'RUNNING', newField: 'x' },
+        { id: 'b', status: 'RUNNING', newField: 'x', isActive: true },
         { id: 'c', status: 'RUNNING' },
         { id: 'd', status: 'NOT_STARTED' },
       ];
@@ -370,12 +370,14 @@ describe('Service: executionService', () => {
         stringVal: 'ac',
         stageSummaries: originalStages.slice(),
         graphStatusHash: 'COMPLETED:RUNNING:RUNNING:NOT_STARTED',
+        hydrated: false,
       };
       const updated = {
         id: 1,
         stringVal: 'ab',
         stageSummaries: updatedStages.slice(),
         graphStatusHash: 'COMPLETED:RUNNING:RUNNING:NOT_STARTED',
+        hydrated: false,
       };
       const execs: IExecution[] = [updated] as any;
       application.executions.data = [original];

--- a/app/scripts/modules/core/src/pipeline/service/execution.service.ts
+++ b/app/scripts/modules/core/src/pipeline/service/execution.service.ts
@@ -440,12 +440,9 @@ export class ExecutionService {
       if (!currentSummary) {
         current.stageSummaries.push(updatedSummary);
       } else {
-        // if the stage was not already completed, update it in place if it has changed to save Angular
+        // if the stage is active, update it in place if it has changed to save Angular
         // from removing, then re-rendering every DOM node
-        if (
-          (!updatedSummary.isCompleted || !currentSummary.isCompleted) &&
-          (!updatedSummary.hasNotStarted || !currentSummary.hasNotStarted)
-        ) {
+        if (updatedSummary.isActive || currentSummary.isActive) {
           if (this.stringify(currentSummary) !== this.stringify(updatedSummary)) {
             Object.assign(currentSummary, updatedSummary);
           }
@@ -453,6 +450,7 @@ export class ExecutionService {
       }
     });
     current.stringVal = updated.stringVal;
+    current.hydrated = updated.hydrated;
     current.graphStatusHash = this.calculateGraphStatusHash(current);
   }
 
@@ -502,13 +500,9 @@ export class ExecutionService {
       hydrated.stages.forEach(s => {
         const toHydrate = unhydrated.stages.find(s2 => s2.id === s.id);
         if (toHydrate) {
-          Object.assign(toHydrate, s);
-        }
-      });
-      hydrated.stageSummaries.forEach(s => {
-        const toHydrate = unhydrated.stageSummaries.find(s2 => s2.id === s.id);
-        if (toHydrate) {
-          Object.assign(toHydrate, s);
+          toHydrate.context = s.context;
+          toHydrate.outputs = s.outputs;
+          toHydrate.tasks = s.tasks;
         }
       });
       unhydrated.hydrated = true;


### PR DESCRIPTION
Turns out it is better to only hydrate the parts that get hydrated.

Also, better to not try to transform a canary stage with no context.

Finally, better to leave stages alone on a synchronize if they are not and were not active, e.g. if they were in a FAILED_CONTINUE state.

