### PR TITLE
fix(core/execution) fix type error when configuring declarative pipelines

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/pipelineConfigurer.js
+++ b/app/scripts/modules/core/src/pipeline/config/pipelineConfigurer.js
@@ -431,7 +431,7 @@ module.exports = angular
 
     this.getPipelineExecutions = () => {
       executionService
-        .getExecutionsForConfigIds($scope.pipeline.id, {
+        .getExecutionsForConfigIds([$scope.pipeline.id], {
           limit: 5,
           transform: true,
           application: $scope.pipeline.application,


### PR DESCRIPTION
This fixes a `TypeError: (pipelineConfigIds || []).join is not a function` error I'm having when accessing configuration for any declarative pipeline.

Not sure if this is the way to solve it so PTAL