### PR TITLE
chore(npmignore): remove yalc workaround for 'history' and 'changes'

### DIFF
--- a/app/scripts/modules/core/.npmignore
+++ b/app/scripts/modules/core/.npmignore
@@ -2,5 +2,3 @@ yalc.*
 .*
 tsconfig.json
 webpack.config.js
-!history
-!changes


### PR DESCRIPTION
See: https://github.com/whitecolor/yalc/pull/24
