### PR TITLE
feat(artifacts): Support Jenkins stages emitting artifacts

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/jenkins/jenkinsStage.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/jenkins/jenkinsStage.js
@@ -16,6 +16,7 @@ module.exports = angular
       restartable: true,
       controller: 'JenkinsStageCtrl',
       controllerAs: 'jenkinsStageCtrl',
+      producesArtifacts: true,
       templateUrl: require('./jenkinsStage.html'),
       executionDetailsUrl: require('./jenkinsExecutionDetails.html'),
       executionLabelComponent: JenkinsExecutionLabel,


### PR DESCRIPTION
Deck support for https://github.com/spinnaker/spinnaker/issues/2643

It would be logical to only show the artifact specification section if the user has specified a value for `stage.propertyFile`, but I don't know how to do that.