### PR TITLE
chore(core) fixed imports

### DIFF
--- a/app/scripts/modules/google/src/loadBalancer/configure/http/transformer.service.js
+++ b/app/scripts/modules/google/src/loadBalancer/configure/http/transformer.service.js
@@ -3,7 +3,7 @@
 const angular = require('angular');
 import * as _ from 'lodash';
 
-import { NameUtils } from 'core/naming';
+import { NameUtils } from '@spinnaker/core';
 
 import { sessionAffinityModelToViewMap, sessionAffinityViewToModelMap } from '../common/sessionAffinityNameMaps';
 

--- a/app/scripts/modules/openstack/src/serverGroup/configure/ServerGroupCommandBuilder.js
+++ b/app/scripts/modules/openstack/src/serverGroup/configure/ServerGroupCommandBuilder.js
@@ -4,7 +4,7 @@ import _ from 'lodash';
 
 const angular = require('angular');
 
-import { NameUtils } from 'core/naming';
+import { NameUtils } from '@spinnaker/core';
 
 import { OpenStackProviderSettings } from '../../openstack.settings';
 


### PR DESCRIPTION
webpack adds an alias for `@spinnaker/core` so that each module can be build separately and imported