### PR TITLE
fix(core): fix refresh on execution patches; default option on judgment

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/executionWindows/ExecutionWindowActions.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/executionWindows/ExecutionWindowActions.tsx
@@ -49,11 +49,10 @@ export class ExecutionWindowActions extends React.Component<
   private finishWaiting(e: React.MouseEvent<HTMLElement>): void {
     const { confirmationModalService, executionService } = ReactInjector;
     (e.target as HTMLElement).blur(); // forces closing of the popover when the modal opens
-    const stage = this.props.stage,
-      executionId = this.props.execution.id;
+    const { application, execution, stage } = this.props;
 
-    const matcher = (execution: IExecution) => {
-      const match = execution.stages.find(test => test.id === stage.id);
+    const matcher = (updated: IExecution) => {
+      const match = updated.stages.find(test => test.id === stage.id);
       return match.status !== 'RUNNING';
     };
 
@@ -64,8 +63,9 @@ export class ExecutionWindowActions extends React.Component<
       body: stage.context.skipWindowText || `<p>${DEFAULT_SKIP_WINDOW_TEXT}</p>`,
       submitMethod: () => {
         return executionService
-          .patchExecution(executionId, stage.id, data)
-          .then(() => executionService.waitUntilExecutionMatches(executionId, matcher));
+          .patchExecution(execution.id, stage.id, data)
+          .then(() => executionService.waitUntilExecutionMatches(execution.id, matcher))
+          .then(updated => executionService.updateExecution(application, updated));
       },
     });
   }

--- a/app/scripts/modules/core/src/pipeline/config/stages/manualJudgment/ManualJudgmentApproval.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/manualJudgment/ManualJudgmentApproval.tsx
@@ -1,4 +1,3 @@
-import { IPromise } from 'angular';
 import * as React from 'react';
 import Select, { Option } from 'react-select';
 import 'react-select/dist/react-select.css';
@@ -37,24 +36,11 @@ export class ManualJudgmentApproval extends React.Component<
     };
   }
 
-  private provideJudgment(judgmentDecision: string): IPromise<void> {
+  private provideJudgment(judgmentDecision: string): void {
+    const { application, execution, stage } = this.props;
     const judgmentInput: string = this.state.judgmentInput ? this.state.judgmentInput.value : null;
     this.setState({ submitting: true, error: false, judgmentDecision });
-    return ReactInjector.manualJudgmentService
-      .provideJudgment(this.props.execution, this.props.stage, judgmentDecision, judgmentInput)
-      .then(() => this.judgmentMade())
-      .catch(() => this.judgmentFailure());
-  }
-
-  private judgmentMade(): void {
-    // do not update the submitting state - the reload of the executions will clear it out; otherwise,
-    // there is a flash on the screen when we go from submitting to not submitting to the buttons not being there.
-    this.props.application.activeState.refresh(true);
-    this.setState({ submitting: false });
-  }
-
-  private judgmentFailure(): void {
-    this.setState({ submitting: false, error: true });
+    ReactInjector.manualJudgmentService.provideJudgment(application, execution, stage, judgmentDecision, judgmentInput);
   }
 
   private isSubmitting(decision: string): boolean {
@@ -118,7 +104,11 @@ export class ManualJudgmentApproval extends React.Component<
             <div className="action-buttons">
               <button
                 className="btn btn-primary"
-                disabled={this.state.submitting || stage.context.judgmentStatus}
+                disabled={
+                  this.state.submitting ||
+                  stage.context.judgmentStatus ||
+                  (options.length && !this.state.judgmentInput.value)
+                }
                 onClick={this.handleContinueClick}
               >
                 {this.isSubmitting('continue') && <ButtonBusyIndicator />}
@@ -127,7 +117,11 @@ export class ManualJudgmentApproval extends React.Component<
               <button
                 className="btn btn-danger"
                 onClick={this.handleStopClick}
-                disabled={this.state.submitting || stage.context.judgmentStatus}
+                disabled={
+                  this.state.submitting ||
+                  stage.context.judgmentStatus ||
+                  (options.length && !this.state.judgmentInput.value)
+                }
               >
                 {this.isSubmitting('stop') && <ButtonBusyIndicator />}
                 {stage.context.stopButtonLabel || 'Stop'}

--- a/app/scripts/modules/core/src/pipeline/config/stages/manualJudgment/manualJudgment.service.spec.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/manualJudgment/manualJudgment.service.spec.ts
@@ -45,8 +45,9 @@ describe('Service: manualJudgment', () => {
 
       $http.expectPATCH(requestUrl).respond(200, '');
       spyOn(executionService, 'waitUntilExecutionMatches').and.returnValue(deferred.promise);
+      spyOn(executionService, 'updateExecution').and.stub();
 
-      service.provideJudgment(execution, stage, 'continue').then(() => (succeeded = true));
+      service.provideJudgment(null, execution, stage, 'continue').then(() => (succeeded = true));
 
       $http.flush();
       expect(succeeded).toBe(false);
@@ -66,7 +67,7 @@ describe('Service: manualJudgment', () => {
       $http.expectPATCH(requestUrl).respond(200, '');
       spyOn(executionService, 'waitUntilExecutionMatches').and.returnValue(deferred.promise);
 
-      service.provideJudgment(execution, stage, 'continue').then(() => (succeeded = true), () => (failed = true));
+      service.provideJudgment(null, execution, stage, 'continue').then(() => (succeeded = true), () => (failed = true));
 
       $http.flush();
       expect(succeeded).toBe(false);
@@ -86,7 +87,7 @@ describe('Service: manualJudgment', () => {
 
       $http.expectPATCH(requestUrl).respond(503, '');
 
-      service.provideJudgment(execution, stage, 'continue').then(() => (succeeded = true), () => (failed = true));
+      service.provideJudgment(null, execution, stage, 'continue').then(() => (succeeded = true), () => (failed = true));
 
       $http.flush();
       expect(succeeded).toBe(false);

--- a/app/scripts/modules/core/src/pipeline/config/stages/wait/SkipWait.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/wait/SkipWait.tsx
@@ -34,7 +34,7 @@ export class SkipWait extends React.Component<ISkipWaitProps, ISkipWaitState> {
   private skipRemainingWait = (e: React.MouseEvent<HTMLElement>): void => {
     const { confirmationModalService, executionService } = ReactInjector;
     (e.target as HTMLElement).blur(); // forces closing of the popover when the modal opens
-    const stage = this.props.stage;
+    const { stage, application } = this.props;
     const matcher = (execution: IExecution) => {
       const match = execution.stages.find(test => test.id === stage.id);
       return match.status !== 'RUNNING';
@@ -48,7 +48,8 @@ export class SkipWait extends React.Component<ISkipWaitProps, ISkipWaitState> {
       submitMethod: () => {
         return executionService
           .patchExecution(this.props.execution.id, stage.id, data)
-          .then(() => executionService.waitUntilExecutionMatches(this.props.execution.id, matcher));
+          .then(() => executionService.waitUntilExecutionMatches(this.props.execution.id, matcher))
+          .then(updated => executionService.updateExecution(application, updated));
       },
     });
   };

--- a/app/scripts/modules/core/src/pipeline/service/execution.service.ts
+++ b/app/scripts/modules/core/src/pipeline/service/execution.service.ts
@@ -450,7 +450,7 @@ export class ExecutionService {
       }
     });
     current.stringVal = updated.stringVal;
-    current.hydrated = updated.hydrated;
+    current.hydrated = current.hydrated || updated.hydrated;
     current.graphStatusHash = this.calculateGraphStatusHash(current);
   }
 

--- a/app/scripts/modules/core/src/securityGroup/filter/SecurityGroupFilterService.ts
+++ b/app/scripts/modules/core/src/securityGroup/filter/SecurityGroupFilterService.ts
@@ -1,4 +1,3 @@
-import { module } from 'angular';
 import { chain, find, forOwn, groupBy, map, sortBy } from 'lodash';
 import { Subject } from 'rxjs';
 import { BindAll } from 'lodash-decorators';


### PR DESCRIPTION
The actions that can be taken on manual judgment, wait, and execution window stages do not update the execution itself, instead relying on the data source refresh cycle to update the stages, which can take a little while. This changes that behavior to update the execution when the change has been detected.

Also, we potentially reset the `hydrated` flag when we synchronize the execution, which we shouldn't do if it was previously hydrated. This is a problem when the execution is hydrated and then completes, as we'll reset the flag.

This is frankly more fallout and confusion due to the way we are trying to optimize refreshes via in-place updates of the executions, rather than replacing them completely, and in theory this stuff goes away when we get the rest of the executions view (specifically the execution details, I think) moved over to React from Angular.

The last bit prevents users from submitting a manual judgment with an option until they've selected one.