### PR TITLE
refactor(core): use running executions to refresh in-place executions

### DIFF
--- a/app/scripts/modules/core/src/pipeline/executions/Executions.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/Executions.tsx
@@ -1,5 +1,6 @@
 import { IPromise } from 'angular';
 import { CreatePipelineButton } from 'core/pipeline/create/CreatePipelineButton';
+import { IScheduler } from 'core/scheduler/scheduler.factory';
 import * as React from 'react';
 import * as ReactGA from 'react-ga';
 import { Transition } from '@uirouter/core';
@@ -41,6 +42,7 @@ export class Executions extends React.Component<IExecutionsProps, IExecutionsSta
   private groupsUpdatedSubscription: Subscription;
   private locationChangeUnsubscribe: Function;
   private insightFilterStateModel = ReactInjector.insightFilterStateModel;
+  private activeRefresher: IScheduler;
 
   private filterCountOptions = [1, 2, 5, 10, 20, 30, 40, 50];
 
@@ -69,6 +71,10 @@ export class Executions extends React.Component<IExecutionsProps, IExecutionsSta
     app.setActiveState(app.executions);
     app.executions.activate();
     app.pipelineConfigs.activate();
+    this.activeRefresher = ReactInjector.schedulerFactory.createScheduler(5000);
+    this.activeRefresher.subscribe(() => {
+      app.getDataSource('runningExecutions').refresh();
+    });
   }
 
   private clearFilters(): void {
@@ -260,6 +266,7 @@ export class Executions extends React.Component<IExecutionsProps, IExecutionsSta
     this.executionsRefreshUnsubscribe();
     this.groupsUpdatedSubscription.unsubscribe();
     this.locationChangeUnsubscribe();
+    this.activeRefresher && this.activeRefresher.unsubscribe();
   }
 
   private showFilters(): void {

--- a/app/scripts/modules/core/src/pipeline/service/execution.service.ts
+++ b/app/scripts/modules/core/src/pipeline/service/execution.service.ts
@@ -415,6 +415,13 @@ export class ExecutionService {
         application.executions.data.push(re);
       }
     });
+    application.executions.data.forEach((execution: IExecution) => {
+      if (execution.isActive && application.runningExecutions.data.every((e: IExecution) => e.id !== execution.id)) {
+        this.getExecution(execution.id).then(updatedExecution => {
+          this.updateExecution(application, updatedExecution);
+        });
+      }
+    });
     if (updated && !application.executions.reloadingForFilters) {
       application.executions.dataUpdated();
     }


### PR DESCRIPTION
Instead of worrying about the execution refresh from the `Execution` component itself, let's just refresh the running executions every 5000ms when we're on the executions view and let them get merged in as they are, anyway.

It's not *as* immediate as the per-second refresh, but it's a lot less chatty on the network, it's sufficiently responsive (average latency of active execution data should be ~2.5s, assuming data changes every second for an execution, which...it doesn't), and it's a lot easier to reason about the code this way.