### PR TITLE
feat(provider/kubernetes): run job node selector

### DIFF
--- a/app/scripts/modules/kubernetes/src/pipeline/stages/runJob/configureJob.html
+++ b/app/scripts/modules/kubernetes/src/pipeline/stages/runJob/configureJob.html
@@ -58,6 +58,13 @@
       </div>
       <map-editor model="ctrl.stage.labels" add-button-label="Add Labels" labels-left="true">
       </map-editor>
+      
+      <div class="sm-label-left">
+        <b>Node Selector</b>
+      </div>
+      <map-editor model="ctrl.stage.nodeSelector" add-button-label="Add Node Selector" labels-left="true">
+      </map-editor>
+
     </v2-wizard-page>
 
     <div ng-repeat="container in ctrl.stage.containers">


### PR DESCRIPTION
add support for run job node selector. looks like clouddriver already
supports this so we just need to expose it via the UI

fixes spinnaker/spinnaker#2553