### PR TITLE
fix(core): allow auto-navigation on single search result in V2

### DIFF
--- a/app/scripts/modules/core/src/search/infrastructure/SearchV2.tsx
+++ b/app/scripts/modules/core/src/search/infrastructure/SearchV2.tsx
@@ -94,6 +94,17 @@ export class SearchV2 extends React.Component<{}, ISearchV2State> {
       .takeUntil(this.destroy$)
       .subscribe(
         resultSets => {
+          // auto-navigation only happens via shortcut links, and we only do it if there is exactly one result, e.g
+          // when searching for an instance ID
+          const autoNavigate = window.location.href.endsWith('route=true');
+          const finishedSearching = resultSets.map(r => r.status).every(s => s === SearchStatus.FINISHED);
+          if (finishedSearching && autoNavigate) {
+            const allResults = resultSets.reduce((acc, rs) => acc.concat(rs.results), []);
+            if (allResults.length === 1) {
+              window.location.href = allResults[0].href;
+              return;
+            }
+          }
           if (!this.state.selectedTab) {
             this.selectTab(resultSets);
           }


### PR DESCRIPTION
We have some internal Apache rewrite rules that change the Spinnaker URL from, e.g. `http://spinnaker?i-123456789` to `http://spinnaker/#/search?key=i-123456789&route=true`. 

We use this to quickly navigate (fine, navigate with fewer clicks) to an instance in the UI. It was a sneaky feature in the V1 search that we didn't implement in the V2 search. This adds it for V2.