### PR TITLE
feat(provider/kubernetes): Surface specially named annotations in details UI

### DIFF
--- a/app/scripts/modules/kubernetes/src/v2/instance/details/details.html
+++ b/app/scripts/modules/kubernetes/src/v2/instance/details/details.html
@@ -61,6 +61,8 @@
       </ul>
     </collapsible-section>
 
+    <kubernetes-annotation-custom-sections manifest="ctrl.instance.manifest" resource="ctrl.instance"></kubernetes-annotation-custom-sections>
+
     <collapsible-section heading="Events" expanded="true">
       <kubernetes-manifest-events manifest="ctrl.manifest"></kubernetes-manifest-events>
     </collapsible-section>

--- a/app/scripts/modules/kubernetes/src/v2/kubernetes.v2.module.ts
+++ b/app/scripts/modules/kubernetes/src/v2/kubernetes.v2.module.ts
@@ -39,6 +39,7 @@ import { KUBERNETES_SHOW_MANIFEST_YAML } from './manifest/showManifestYaml.compo
 import { KUBERNETES_SHOW_MANIFEST_DETAILS } from './manifest/showManifestDetails.component';
 import { KUBERNETES_V2_LOAD_BALANCER_TRANSFORMER } from './loadBalancer/transformer';
 import { KUBERNETES_V2_SECURITY_GROUP_TRANSFORMER } from './securityGroup/transformer';
+import { KUBERNETES_ANNOTATION_CUSTOM_SECTIONS } from './manifest/annotationCustomSections.component';
 
 // load all templates into the $templateCache
 const templates = require.context('kubernetes', true, /\.html$/);
@@ -88,6 +89,7 @@ module(KUBERNETES_V2_MODULE, [
   KUBERNETES_MANIFEST_EVENTS,
   KUBERNETES_SHOW_MANIFEST_YAML,
   KUBERNETES_SHOW_MANIFEST_DETAILS,
+  KUBERNETES_ANNOTATION_CUSTOM_SECTIONS,
 ]).config((cloudProviderRegistryProvider: CloudProviderRegistry) => {
   cloudProviderRegistryProvider.registerProvider('kubernetes', {
     name: 'Kubernetes',

--- a/app/scripts/modules/kubernetes/src/v2/loadBalancer/details/details.html
+++ b/app/scripts/modules/kubernetes/src/v2/loadBalancer/details/details.html
@@ -73,6 +73,8 @@
       <health-counts class="pull-left" container="ctrl.loadBalancer.instanceCounts"></health-counts>
     </collapsible-section>
 
+    <kubernetes-annotation-custom-sections manifest="ctrl.loadBalancer.manifest" resource="ctrl.loadBalancer"></kubernetes-annotation-custom-sections>
+
     <collapsible-section heading="Events" expanded="true">
       <kubernetes-manifest-events manifest="ctrl.manifest"></kubernetes-manifest-events>
     </collapsible-section>

--- a/app/scripts/modules/kubernetes/src/v2/manifest/annotationCustomSections.component.ts
+++ b/app/scripts/modules/kubernetes/src/v2/manifest/annotationCustomSections.component.ts
@@ -1,0 +1,110 @@
+import { IComponentOptions, IController, ISCEService, IInterpolateService, module } from 'angular';
+import { get, partition } from 'lodash';
+import * as DOMPurify from 'dompurify';
+
+interface IAnnotationsMap {
+  [key: string]: string;
+}
+
+interface ICustomSection {
+  title: string;
+  key: string;
+  isHtml: boolean;
+  content: string;
+}
+
+interface ICustomSectionMap {
+  [key: string]: ICustomSection[];
+}
+
+class KubernetesAnnotationCustomSections implements IController {
+  private resource: any;
+  public manifest: any;
+  public customSections: ICustomSectionMap;
+
+  constructor(private $sce: ISCEService, private $interpolate: IInterpolateService) {
+    const annotations: IAnnotationsMap = get(this, ['manifest', 'metadata', 'annotations']);
+    if (annotations == null) {
+      return;
+    }
+    this.populateCustomSections(annotations);
+  }
+
+  private populateCustomSections(annotations: IAnnotationsMap) {
+    const customSections: ICustomSectionMap = Object.keys(annotations).reduce(
+      (memo: ICustomSectionMap, annotationKey: string) => {
+        const entry = this.annotationToEntry(annotations[annotationKey], annotationKey);
+        if (entry != null && entry.title) {
+          memo[entry.title] = memo[entry.title] || [];
+          memo[entry.title].push(entry);
+        }
+        return memo;
+      },
+      {},
+    );
+    // Sort section contents such that text entries appear before HTML entries.
+    this.customSections = Object.keys(customSections).reduce((memo: ICustomSectionMap, sectionTitle: string) => {
+      const entriesHtmlText = partition(customSections[sectionTitle], section => section.isHtml);
+      memo[sectionTitle] = entriesHtmlText[1].concat(entriesHtmlText[0]);
+      return memo;
+    }, {});
+  }
+
+  private annotationToEntry(content: string, annotationKey: string): ICustomSection {
+    const parsed = this.parseAnnotationKey(annotationKey);
+    if (parsed == null) {
+      return null;
+    }
+    if (this.resource && content.includes('{{')) {
+      content = this.$interpolate(content)({ ...this.resource });
+    }
+    return {
+      title: parsed.title.replace('-', ' ').trim(),
+      key: parsed.key.replace('-', ' ').trim(),
+      content: parsed.isHtml ? this.sanitizeContent(content) : content,
+      isHtml: parsed.isHtml,
+    };
+  }
+
+  private parseAnnotationKey(annotationKey: string): { title: string; key: string; isHtml: boolean } {
+    const keyParts = /([^.]+)\.details\.(html\.)?spinnaker\.io(?:\/(.*))?/.exec(annotationKey);
+    if (keyParts == null || keyParts.length !== 4) {
+      return null;
+    }
+    return {
+      title: keyParts[1] || '',
+      key: keyParts[3] || '',
+      isHtml: !!keyParts[2],
+    };
+  }
+
+  private sanitizeContent(unsanitized: string): any {
+    const sanitized = DOMPurify.sanitize(unsanitized, {
+      ADD_ATTR: ['target'],
+    });
+    return this.$sce.trustAsHtml(sanitized);
+  }
+}
+
+class KubernetesAnnotationCustomSectionsComponent implements IComponentOptions {
+  public bindings: any = { manifest: '<', resource: '<' };
+  public controller: any = ['$sce', '$interpolate', KubernetesAnnotationCustomSections];
+  public controllerAs = 'ctrl';
+  public template = `
+    <collapsible-section expanded="true" ng-if="ctrl.manifest" ng-repeat="(section, entries) in ctrl.customSections" heading="{{ section }}">
+      <div ng-repeat="entry in entries">
+        <div ng-if="entry.isHtml" ng-bind-html="entry.content"></div>
+        <div ng-if="!entry.isHtml">
+          <span ng-if="entry.key" style="font-weight:bold">{{ entry.key }}</span>
+          <span>{{ entry.content }}</span>
+        </div>
+      </div>
+    </collapsible-section>
+  `;
+}
+
+export const KUBERNETES_ANNOTATION_CUSTOM_SECTIONS = 'spinnaker.kubernetes.v2.manifest.annotation.custom.sections';
+module(KUBERNETES_ANNOTATION_CUSTOM_SECTIONS, []).component(
+  'kubernetesAnnotationCustomSections',
+  new KubernetesAnnotationCustomSectionsComponent(),
+);

--- a/app/scripts/modules/kubernetes/src/v2/securityGroup/details/details.html
+++ b/app/scripts/modules/kubernetes/src/v2/securityGroup/details/details.html
@@ -56,6 +56,8 @@
       </dl>
     </collapsible-section>
 
+    <kubernetes-annotation-custom-sections manifest="ctrl.securityGroup.manifest" resource="ctrl.securityGroup"></kubernetes-annotation-custom-sections>
+
     <collapsible-section heading="Labels" expanded="true">
       <kubernetes-manifest-labels manifest="ctrl.securityGroup.manifest"></kubernetes-manifest-labels>
     </collapsible-section>

--- a/app/scripts/modules/kubernetes/src/v2/serverGroup/details/details.html
+++ b/app/scripts/modules/kubernetes/src/v2/serverGroup/details/details.html
@@ -75,6 +75,9 @@
         </dd>
       </dl>
     </collapsible-section>
+
+    <kubernetes-annotation-custom-sections manifest="ctrl.serverGroup.manifest" resource="ctrl.serverGroup"></kubernetes-annotation-custom-sections>
+
     <collapsible-section heading="Events" expanded="true">
       <kubernetes-manifest-events manifest="ctrl.manifest"></kubernetes-manifest-events>
     </collapsible-section>

--- a/app/scripts/modules/kubernetes/src/v2/serverGroupManager/details/details.html
+++ b/app/scripts/modules/kubernetes/src/v2/serverGroupManager/details/details.html
@@ -97,6 +97,8 @@
       </ul>
     </collapsible-section>
 
+    <kubernetes-annotation-custom-sections manifest="ctrl.serverGroupManager.manifest" resource="ctrl.serverGroupManager"></kubernetes-annotation-custom-sections>
+
     <collapsible-section heading="Events" expanded="true">
       <kubernetes-manifest-events manifest="ctrl.manifest"></kubernetes-manifest-events>
     </collapsible-section>


### PR DESCRIPTION
Annotations on k8s resources with a key matching `(section-title).details.(html)?.spinnaker.io/(key-name)` will be used to populate a section in the details panel for that resource.

Hyphens in the section title and key name are replaced with spaces.

The content of the annotation is interpolated using the resource (ala instance links) so that information can be dynamically set with `{{ }}` template literals.

Finally, prior to reaching the DOM, the content is pushed through DOMPurify.sanitize.

Fixes https://github.com/spinnaker/spinnaker/issues/2529 and, by extension, provides support for https://github.com/spinnaker/spinnaker/issues/2528

<img width="219" alt="screen shot 2018-04-17 at 1 59 07 pm" src="https://user-images.githubusercontent.com/34253460/38887695-8f83b514-4247-11e8-9ac2-b8a5a1161abb.png">
