### PR TITLE
chore(*): bump packages for de-angularized help contents

### DIFF
--- a/app/scripts/modules/amazon/package.json
+++ b/app/scripts/modules/amazon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/amazon",
-  "version": "0.0.90",
+  "version": "0.0.91",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/core",
-  "version": "0.0.195",
+  "version": "0.0.196",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/kubernetes/package.json
+++ b/app/scripts/modules/kubernetes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/kubernetes",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/titus/package.json
+++ b/app/scripts/modules/titus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/titus",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
*spinnaker/core*
* fix(core): allow auto-navigation on single search result in V2
* fix(core): ExecutionBuildTitle sometimes gets an undefined execution
* refactor(*): de-angularize help contents/registry

*amazon/titus/kubernetes*
* de-angularize help contents/registry