### PR TITLE
feat(pipeline_templates) Allow Pipelines to Inherit Pipeline Template Parameters

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/templates/configurePipelineTemplateModal.controller.ts
+++ b/app/scripts/modules/core/src/pipeline/config/templates/configurePipelineTemplateModal.controller.ts
@@ -28,6 +28,7 @@ export interface IState {
   loadingError: boolean;
   noVariables: boolean;
   planErrors: IPipelineTemplatePlanError[];
+  inheritTemplateParameters: boolean;
 }
 
 @BindAll()
@@ -35,7 +36,7 @@ export class ConfigurePipelineTemplateModalController implements IController {
   public pipelineName: string;
   public variableMetadataGroups: IVariableMetadataGroup[];
   public variables: IVariable[];
-  public state: IState = { loading: true, error: false, planErrors: null, loadingError: false, noVariables: false };
+  public state: IState = { loading: true, error: false, planErrors: null, loadingError: false, noVariables: false, inheritTemplateParameters: true };
   private template: IPipelineTemplate;
   private source: string;
 
@@ -110,6 +111,9 @@ export class ConfigurePipelineTemplateModalController implements IController {
           pipelineConfigId: this.pipelineId,
           template: { source: this.source },
           variables: this.transformVariablesForPipelinePlan(),
+        },
+        configuration: {
+          inherit: this.state.inheritTemplateParameters ? ['parameters'] : [],
         },
       },
     };

--- a/app/scripts/modules/core/src/pipeline/config/templates/configurePipelineTemplateModal.html
+++ b/app/scripts/modules/core/src/pipeline/config/templates/configurePipelineTemplateModal.html
@@ -26,6 +26,9 @@
   <div ng-if="ctrl.state.noVariables && !ctrl.state.error" class="alert alert-info">
     <p>This template has no variables to configure.</p>
   </div>
+  <div ng-if="!ctrl.state.error" class="alert alert-info">
+    Inherit Template Parameters:<input type="checkbox" ng-model="ctrl.state.inheritTemplateParameters">
+  </div>
   <div class="modal-footer" ng-if="!ctrl.state.loading">
     <button ng-if="!ctrl.isNew && !ctrl.state.noVariables" class="btn btn-default" ng-click="ctrl.cancel()">Cancel</button>
     <button ng-if="ctrl.state.noVariables" class="btn btn-default" ng-click="ctrl.submit()">Dismiss</button>

--- a/app/scripts/modules/core/src/pipeline/config/templates/pipelineTemplate.service.ts
+++ b/app/scripts/modules/core/src/pipeline/config/templates/pipelineTemplate.service.ts
@@ -52,6 +52,9 @@ export interface IPipelineTemplateConfig extends Partial<IPipeline> {
         source: string;
       };
       variables?: { [key: string]: any };
+    },
+    configuration?: {
+      inherit?: string[];
     };
   };
 }

--- a/app/scripts/modules/core/src/pipeline/create/CreatePipelineModal.tsx
+++ b/app/scripts/modules/core/src/pipeline/create/CreatePipelineModal.tsx
@@ -36,6 +36,7 @@ export interface ICreatePipelineModalState {
   loadingTemplateFromSource: boolean;
   loadingTemplateFromSourceError: boolean;
   templateSourceUrl: string;
+  inheritTemplateParameters: boolean;
 }
 
 export interface ICreatePipelineCommand {
@@ -103,6 +104,7 @@ export class CreatePipelineModal extends React.Component<ICreatePipelineModalPro
       loadingTemplateFromSource: false,
       loadingTemplateFromSourceError: false,
       templateSourceUrl: '',
+      inheritTemplateParameters: true,
     };
   }
 


### PR DESCRIPTION
Currently, if you specify a pipeline template with parameters and then try to create a template with it in deck, the parameters are not inherited and have to be recreated by hand in the new pipeline. This behavior works as expected with roer / cli / API.
![template-inherit](https://user-images.githubusercontent.com/121679/39030672-6973f776-4431-11e8-804b-ac8b09284fca.gif)
