### PR TITLE
chore(provider/kubernetes): tighten deploy manifest details view

### DIFF
--- a/app/scripts/modules/kubernetes/src/v2/manifest/showManifestDetails.component.ts
+++ b/app/scripts/modules/kubernetes/src/v2/manifest/showManifestDetails.component.ts
@@ -97,7 +97,11 @@ class KubernetesShowManifestDetailsComponent implements IComponentOptions {
   public controllerAs = 'ctrl';
   public template = trim(`
     <a href ng-if='ctrl.canOpen()' ng-click='ctrl.openDetails()'>{{ctrl.linkName}}</a>
-    <kubernetes-manifest-events manifest="ctrl.manifest"></kubernetes-manifest-events>
+    </br>
+    </br>
+    <div class="pad-left">
+      <kubernetes-manifest-events manifest="ctrl.manifest"></kubernetes-manifest-events>
+    </div>
   `);
 }
 

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestExecutionDetails.html
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestExecutionDetails.html
@@ -7,9 +7,8 @@
       <div class="col-md-12">
         <div class="well alert alert-info">
           <dl ng-repeat="manifest in stage.context['outputs.manifests']">
-            {{manifest.kind}} {{manifest.metadata.name}}<br />
+            <b>{{manifest.kind}}</b> {{manifest.metadata.name}}:
             <kubernetes-show-manifest-yaml manifest="manifest" link-name="'YAML'"></kubernetes-show-manifest-yaml>
-            &nbsp;&nbsp;&nbsp;&nbsp;
             <kubernetes-show-manifest-details application="application" manifest-contents="manifest" account-id="stage.context.account" link-name="'Details'"></kubernetes-show-manifest-details>
           </dl>
         </div>


### PR DESCRIPTION
Totally subjective, but though we could make some changes while testing the new force cache refresh:

Before:
![zr118i6tbgh](https://user-images.githubusercontent.com/4874941/39066883-abc37426-44a4-11e8-9052-1233bd0e8670.png)


After:
![zcj1jg2ecsb](https://user-images.githubusercontent.com/4874941/39066884-aff2f8dc-44a4-11e8-8883-2211d40f6127.png)
