### PR TITLE
fix(core): attach instance ID tooltip to body

### DIFF
--- a/app/scripts/modules/core/src/instance/Instance.tsx
+++ b/app/scripts/modules/core/src/instance/Instance.tsx
@@ -20,7 +20,7 @@ export class Instance extends React.Component<IInstanceProps> {
 
   public onMouseOver(event: React.MouseEvent<any>) {
     $(event.target)
-      .tooltip({ animation: false } as JQueryUI.TooltipOptions)
+      .tooltip({ animation: false, container: 'body' } as JQueryUI.TooltipOptions)
       .tooltip('show');
   }
 


### PR DESCRIPTION
Prevents the tooltip from appearing under the instance chiclet, or from being cut off by the side of the container.