### PR TITLE
fix(core): sort global search results by ranking

### DIFF
--- a/app/scripts/modules/core/src/search/global/GlobalSearch.tsx
+++ b/app/scripts/modules/core/src/search/global/GlobalSearch.tsx
@@ -71,7 +71,7 @@ export class GlobalSearch extends React.Component<{}, IGlobalSearchState> {
           .filter(({ results }) => results.length)
           .map(category => ({
             ...category,
-            results: searchRank(category.results).slice(0, 5),
+            results: searchRank(category.results, category.query).slice(0, 5),
           }))
           .sort((a, b) => a.type.order - b.type.order),
       )

--- a/app/scripts/modules/core/src/search/infrastructure/infrastructureSearch.service.ts
+++ b/app/scripts/modules/core/src/search/infrastructure/infrastructureSearch.service.ts
@@ -14,6 +14,7 @@ export interface ISearchResultSet<T extends ISearchResult = ISearchResult> {
   results: T[];
   status: SearchStatus;
   error?: any;
+  query?: string;
 }
 
 export interface IProviderResultFormatter {

--- a/app/scripts/modules/core/src/search/infrastructure/infrastructureSearchV2.service.ts
+++ b/app/scripts/modules/core/src/search/infrastructure/infrastructureSearchV2.service.ts
@@ -44,7 +44,8 @@ export class InfrastructureSearchServiceV2 {
     const makeResultSet = (searchResults: ISearchResults<any>, type: SearchResultType): ISearchResultSet => {
       // Add URLs to each search result
       const results = searchResults.results.map(result => addComputedAttributes(result, type));
-      return { type, results, status: SearchStatus.FINISHED };
+      const query: string = apiParams.key as string;
+      return { type, results, status: SearchStatus.FINISHED, query };
     };
 
     const emitErrorResultSet = (error: any, type: SearchResultType): Observable<ISearchResultSet> => {


### PR DESCRIPTION
Code already exists to sort global search results based on the proximity of the query term to the display names of the search results, we just aren't triggering it without sending the query to it. This results in some queries not showing an exact match, which is annoying.