### PR TITLE
fix(core/pipeline): Only list decorated artifacts

### DIFF
--- a/app/scripts/modules/core/src/pipeline/status/ArtifactList.spec.tsx
+++ b/app/scripts/modules/core/src/pipeline/status/ArtifactList.spec.tsx
@@ -15,7 +15,7 @@ describe('<ArtifactList/>', () => {
   beforeEach(mock.inject(() => {})); // Angular is lazy.
 
   it('renders null when null artifacts are passed in', function() {
-    const artifacts: IArtifact[] = [];
+    const artifacts: IArtifact[] = null;
     component = shallow(<ArtifactList artifacts={artifacts} />);
     expect(component.get(0)).toEqual(null);
   });
@@ -57,6 +57,29 @@ describe('<ArtifactList/>', () => {
     expect(dd.at(0).text()).toEqual(ARTIFACT_TYPE);
     expect(dt.at(1).text()).toEqual('Artifact');
     expect(dd.at(1).text()).toEqual(ARTIFACT_NAME);
+  });
+
+  it('does not render artifacts without a type and name', function() {
+    const singleArtifact: IArtifact[] = [
+      {
+        id: 'abcd',
+      },
+    ];
+    component = shallow(<ArtifactList artifacts={singleArtifact} />);
+    expect(component.get(0)).toEqual(null);
+
+    const artifacts: IArtifact[] = [
+      {
+        id: 'abcd',
+      },
+      {
+        id: 'abcd2',
+        type: ARTIFACT_TYPE,
+        name: ARTIFACT_NAME,
+      },
+    ];
+    component = shallow(<ArtifactList artifacts={artifacts} />);
+    expect(component.find('ul.trigger-details.artifacts').length).toEqual(1);
   });
 
   it('renders an artifact version if present', function() {

--- a/app/scripts/modules/core/src/pipeline/status/ArtifactList.tsx
+++ b/app/scripts/modules/core/src/pipeline/status/ArtifactList.tsx
@@ -37,15 +37,19 @@ export class ArtifactList extends React.Component<IArtifactListProps, IArtifactL
 
   public render() {
     const { artifacts, resolvedExpectedArtifacts = [] } = this.props;
+
     const defaultArtifactRefs = new Set();
     resolvedExpectedArtifacts.forEach(rea => {
       if (rea && rea.defaultArtifact && rea.defaultArtifact.reference) {
         defaultArtifactRefs.add(rea.defaultArtifact.reference);
       }
     });
-    if (!artifacts || artifacts.length === 0) {
+    const decoratedArtifacts = artifacts && artifacts.filter(({ name, type }) => name && type);
+
+    if (!decoratedArtifacts || decoratedArtifacts.length === 0) {
       return null;
     }
+
     return (
       <ul className="trigger-details artifacts">
         {artifacts.map((artifact: IArtifact, i: number) => {


### PR DESCRIPTION
We've been running into an issue at Netflix where Igor is not configured to decorate artifacts, but Orca is [adding artifact data to manual executions](https://github.com/spinnaker/orca/commit/b1f1686672a5f65bf452779f6d2ee7b49cc51aca). This results in a bunch of artifacts on execution objects without a `type` or `name`, which the current `ArtifactList` just dumps on the screen:

<img width="708" alt="undecorated-artifacts" src="https://user-images.githubusercontent.com/1850998/39211574-e921b1ec-47c0-11e8-97f1-be5d7e47a9ca.png">

In general, artifacts that don't have a `type` or `name` are relatively useless from Deck's perspective (hence the decoration that Igor does). This change just omits any undecorated artifacts.