### PR TITLE
fix(core) Keep correct stage in summary object for future operations

### DIFF
--- a/app/scripts/modules/core/src/pipeline/service/executions.transformer.service.ts
+++ b/app/scripts/modules/core/src/pipeline/service/executions.transformer.service.ts
@@ -437,6 +437,7 @@ export class ExecutionsTransformerService {
         if (summary.groupStages.length === 1) {
           // If there's only one stage, get rid of the group.
           const onlyStage = summary.groupStages[0];
+          summary = onlyStage;
           stageSummaries[index] = onlyStage;
           delete idToGroupIdMap[onlyStage.refId];
         } else if (summary.groupStages.length > 1) {


### PR DESCRIPTION
Keep the `summary` object with the correct stage as the `summary` object is used later on used ( [in here](https://github.com/spinnaker/deck/blob/master/app/scripts/modules/core/src/pipeline/service/executions.transformer.service.ts#L465) ) and without this, the `summary` object changes are discarded since it's changed an object which is not in the array anymore.