### PR TITLE
fix(config) Remove invalid escape in regex

### DIFF
--- a/app/scripts/modules/core/src/application/modal/editApplication.html
+++ b/app/scripts/modules/core/src/application/modal/editApplication.html
@@ -76,7 +76,7 @@
                  class="form-control input-sm"
                  ng-model="editApp.applicationAttributes.repoSlug"
                  placeholder="Enter your source repository name (not the url)"
-                 pattern="^((?!\:\/\/).)*$"
+                 pattern="^((?!:\/\/).)*$"
                  name="repoSlug"/>
         </div>
       </div>

--- a/app/scripts/modules/core/src/application/modal/newapplication.html
+++ b/app/scripts/modules/core/src/application/modal/newapplication.html
@@ -81,7 +81,7 @@
                  class="form-control input-sm"
                  ng-model="newAppModal.application.repoSlug"
                  placeholder="Enter your source repository name (not the URL)"
-                 pattern="^((?!\:\/\/).)*$"
+                 pattern="^((?!:\/\/).)*$"
                  name="repoSlug"/>
         </div>
       </div>


### PR DESCRIPTION
Fixes the regex used to validate the Repo Name in app config; previous version would generate the following error:

```Pattern attribute value ^((?!\:\/\/).)*$ is not a valid regular expression: Uncaught SyntaxError: Invalid regular expression: /^((?!\:\/\/).)*$/: Invalid escape```