### PR TITLE
fix(core): remove tooltip if needed when unmounting instances

### DIFF
--- a/app/scripts/modules/core/src/instance/Instance.tsx
+++ b/app/scripts/modules/core/src/instance/Instance.tsx
@@ -13,20 +13,27 @@ export interface IInstanceProps {
 
 @BindAll()
 export class Instance extends React.Component<IInstanceProps> {
+  private $tooltipElement: JQuery = null;
+
   private handleClick(event: React.MouseEvent<any>) {
     event.preventDefault();
     this.props.onInstanceClicked(this.props.instance);
   }
 
   public onMouseOver(event: React.MouseEvent<any>) {
-    $(event.target)
-      .tooltip({ animation: false, container: 'body' } as JQueryUI.TooltipOptions)
-      .tooltip('show');
+    this.$tooltipElement = $(event.target);
+    this.$tooltipElement.tooltip({ animation: false, container: 'body' } as JQueryUI.TooltipOptions).tooltip('show');
   }
 
   public shouldComponentUpdate(nextProps: IInstanceProps) {
     const checkProps: Array<keyof IInstanceProps> = ['instance', 'active', 'highlight'];
     return checkProps.some(key => this.props[key] !== nextProps[key]);
+  }
+
+  public componentWillUnmount() {
+    if (this.$tooltipElement) {
+      this.$tooltipElement.tooltip('destroy');
+    }
   }
 
   public render() {


### PR DESCRIPTION
If a user is hovering over an instance chiclet when the instance is removed from the view, the tooltip will stick around. In the Angular world, the tooltip would be removed automatically because the Angular/jQuery lifecycles were somewhat coordinated, IIRC, but that's not the case with React + jQuery.

A different solution would be to apply the tooltips in a less 2007-era way, but we'd need to get a tooltip solution that does an append-to-body type thing, which wasn't well supported by React before 16.3, as far as I know, and...this is fine for now.