### PR TITLE
refactor(google): Refactor config fields to use consistent directive

### DIFF
--- a/app/scripts/modules/core/src/artifact/expectedArtifactMultiSelector.component.ts
+++ b/app/scripts/modules/core/src/artifact/expectedArtifactMultiSelector.component.ts
@@ -22,21 +22,16 @@ class ExpectedArtifactMultiSelectorComponent implements IComponentOptions {
   public template = `
       <render-if-feature feature="artifacts">
         <ng-form name="artifacts">
-          <div class="col-md-12">
-            <div class="form-group">
-              <label class="col-md-3 sm-label-right">{{ctrl.artifactLabel}} <help-field key="{{ctrl.helpFieldKey}}"/></label>
-              <div class="col-md-9">
-                <ui-select multiple
-                           ng-model="ctrl.command[ctrl.idsField]"
-                           class="form-control input-sm">
-                  <ui-select-match>{{ $item | summarizeExpectedArtifact }}</ui-select-match>
-                  <ui-select-choices repeat="expected.id as expected in ctrl.expectedArtifacts">
-                    <span>{{ expected | summarizeExpectedArtifact }}</span>
-                  </ui-select-choices>
-                </ui-select>
-              </div>
-            </div>
-          </div>
+          <stage-config-field label="{{ctrl.artifactLabel}}" help-key="{{ctrl.helpFieldKey}}">
+            <ui-select multiple
+                       ng-model="ctrl.command[ctrl.idsField]"
+                       class="form-control input-sm">
+              <ui-select-match>{{ $item | summarizeExpectedArtifact }}</ui-select-match>
+              <ui-select-choices repeat="expected.id as expected in ctrl.expectedArtifacts">
+                <span>{{ expected | summarizeExpectedArtifact }}</span>
+              </ui-select-choices>
+            </ui-select>
+          </stage-config-field>
         </ng-form>
       </render-if-feature>
   `;

--- a/app/scripts/modules/core/src/artifact/expectedArtifactSelector.component.ts
+++ b/app/scripts/modules/core/src/artifact/expectedArtifactSelector.component.ts
@@ -30,33 +30,28 @@ class ExpectedArtifactSelectorComponent implements IComponentOptions {
   public controllerAs = 'ctrl';
   public template = `
     <render-if-feature feature="artifacts">
-        <ng-form name="artifact">
-          <div class="form-group">
-            <label class="col-md-3 sm-label-right">Expected Artifact <help-field key="{{ ctrl.helpFieldKey }}"/></label>
-            <div class="col-md-7">
-              <ui-select ng-model="ctrl.id"
-                         class="form-control input-sm" required>
-                <ui-select-match>{{ $select.selected | summarizeExpectedArtifact }}</ui-select-match>
-                <ui-select-choices repeat="expected.id as expected in ctrl.expectedArtifacts">
-                  <span>{{ expected | summarizeExpectedArtifact }}</span>
-                </ui-select-choices>
-              </ui-select>
-            </div>
-          </div>
-          <div ng-if="ctrl.account !== undefined" class="form-group">
-            <label class="col-md-3 sm-label-right">Artifact Account</label>
-            <div class="col-md-7">
-              <ui-select ng-model="ctrl.account"
-                         class="form-control input-sm">
-                <ui-select-match>{{ $select.selected.name }}</ui-select-match>
-                <ui-select-choices repeat="account.name as account in ctrl.accounts">
-                  <span>{{ account.name }}</span>
-                </ui-select-choices>
-              </ui-select>
-            </div>
-          </div>
-        </ng-form>
-    </render-if-feature>
+      <ng-form name="artifact">
+        <stage-config-field label="Expected Artifact" help-key="{{ctrl.helpFieldKey}}">
+          <ui-select ng-model="ctrl.id"
+                     class="form-control input-sm" required>
+            <ui-select-match>{{ $select.selected | summarizeExpectedArtifact }}</ui-select-match>
+            <ui-select-choices repeat="expected.id as expected in ctrl.expectedArtifacts">
+               <span>{{ expected | summarizeExpectedArtifact }}</span>
+            </ui-select-choices>
+          </ui-select>
+        </stage-config-field>
+        <stage-config-field ng-if="ctrl.account !== undefined"
+                            label="Artifact Account">
+          <ui-select ng-model="ctrl.account"
+                     class="form-control input-sm">
+            <ui-select-match>{{ $select.selected.name }}</ui-select-match>
+            <ui-select-choices repeat="account.name as account in ctrl.accounts">
+              <span>{{ account.name }}</span>
+            </ui-select-choices>
+          </ui-select>
+        </stage-config-field>
+      </ng-form>
+     </render-if-feature>
   `;
 }
 

--- a/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/bakeManifestConfig.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/bakeManifestConfig.html
@@ -2,76 +2,64 @@
   <div class="alert alert-warning">
     <strong>Warning!</strong> This stage is under active development and is subject to change.
   </div>
-  <h4>Template Renderer</h4>
-  <div class="form-group">
-    <div class="col-md-3 sm-label-right">
-      Render Engine
-      <help-field key="pipeline.config.bake.manifest.templateRenderer"></help-field>
-    </div>
-    <div class="col-md-3">
+
+  <div class="container-fluid form-horizontal">
+    <h4>Template Renderer</h4>
+    <stage-config-field label="Render Engine"
+                        help-key="pipeline.config.bake.manifest.templateRenderer"
+                        field-columns="3">
       <select class="form-control input-sm"
               ng-model="ctrl.$scope.stage.templateRenderer">
         <option ng-repeat="renderer in ctrl.templateRenderers"
                 value="{{renderer}}"
                 ng-selected="ctrl.$scope.stage.templateRenderer === renderer">{{renderer}}</option>
       </select>
-    </div>
-  </div>
-  <div class="form-group">
-    <div class="col-md-3 sm-label-right">
-      Name
-    </div>
-    <div class="col-md-3">
+    </stage-config-field>
+    <stage-config-field label="Name" field-columns="3">
       <input type="text" class="form-control input-sm"
              ng-model="ctrl.$scope.stage.outputName"
              ng-change="ctrl.outputNameChange()">
       </input>
-    </div>
-  </div>
+    </stage-config-field>
 
-  <h4>Template Artifact</h4>
-  <expected-artifact-selector command="ctrl.$scope.stage"
-                              id="ctrl.$scope.stage.inputArtifacts[0].id"
-                              account="ctrl.$scope.stage.inputArtifacts[0].account"
-                              accounts="ctrl.artifactAccounts"
-                              expected-artifacts="ctrl.expectedArtifacts"
-                              help-field-key="pipeline.config.bake.manifest.expectedArtifact">
-  </expected-artifact-selector>
+    <h4>Template Artifact</h4>
+    <expected-artifact-selector command="ctrl.$scope.stage"
+                                id="ctrl.$scope.stage.inputArtifacts[0].id"
+                                account="ctrl.$scope.stage.inputArtifacts[0].account"
+                                accounts="ctrl.artifactAccounts"
+                                expected-artifacts="ctrl.expectedArtifacts"
+                                help-field-key="pipeline.config.bake.manifest.expectedArtifact">
+    </expected-artifact-selector>
 
-  <h4>Overrides</h4>
-  <div class="row form-group" ng-if="ctrl.hasValueArtifacts()" ng-repeat="artifact in ctrl.$scope.stage.inputArtifacts.slice(1)">
-    <div class="col-md-offset-1 col-md-9">
-      <expected-artifact-selector command="ctrl.$scope.stage"
-                                  id="artifact.id"
-                                  account="artifact.account"
-                                  accounts="ctrl.artifactAccounts"
-                                  expected-artifacts="ctrl.expectedArtifacts">
-      </expected-artifact-selector>
-    </div>
-    <div class="col-md-1">
-      <div class="form-control-static">
-        <a href ng-click="ctrl.removeInputArtifact($index + 1)">
-          <span class="glyphicon glyphicon-trash"></span>
-          <span class="sr-only">Remove field</span>
-        </a>
+    <h4>Overrides</h4>
+    <div class="row form-group" ng-if="ctrl.hasValueArtifacts()" ng-repeat="artifact in ctrl.$scope.stage.inputArtifacts.slice(1)">
+      <div class="col-md-offset-1 col-md-9">
+        <expected-artifact-selector command="ctrl.$scope.stage"
+                                    id="artifact.id"
+                                    account="artifact.account"
+                                    accounts="ctrl.artifactAccounts"
+                                    expected-artifacts="ctrl.expectedArtifacts">
+        </expected-artifact-selector>
+      </div>
+      <div class="col-md-1">
+        <div class="form-control-static">
+          <a href ng-click="ctrl.removeInputArtifact($index + 1)">
+            <span class="glyphicon glyphicon-trash"></span>
+            <span class="sr-only">Remove field</span>
+          </a>
+        </div>
       </div>
     </div>
-  </div>
-  <div class="row form-group">
-    <div class="col-md-offset-3 col-md-7">
+
+    <stage-config-field field-columns="8">
       <button class="btn btn-block btn-sm add-new" ng-click="ctrl.addInputArtifact()">
         <span class="glyphicon glyphicon-plus-sign"></span>
         Add value artifact
       </button>
-    </div>
-  </div>
+    </stage-config-field>
 
-  <div class="form-group">
-    <div class="col-md-3 sm-label-right">
-      Overrides
-    </div>
-    <div class="col-md-6">
+    <stage-config-field label="Overrides" field-columns="6">
       <map-editor model="ctrl.$scope.stage.overrides" add-button-label="Add override"></map-editor>
-    </div>
+    </stage-config-field>
   </div>
 </div>

--- a/app/scripts/modules/kubernetes/src/v2/manifest/wizard/basicSettings.component.ts
+++ b/app/scripts/modules/kubernetes/src/v2/manifest/wizard/basicSettings.component.ts
@@ -12,34 +12,21 @@ class KubernetesManifestBasicSettingsComponent implements IComponentOptions {
   public controller: any = KubernetesManifestBasicSettingsCtrl;
   public controllerAs = 'ctrl';
   public template = `
-    <div class="container-fluid form-horizontal">
       <ng-form name="basicSettings">
-        <div class="form-group">
-          <div class="col-md-3 sm-label-right">
-            Account *
-            <help-field key="kubernetes.manifest.account"></help-field>
-          </div>
-          <div class="col-md-7">
-            <account-select-field component="ctrl.command"
-                                  field="account"
-                                  accounts="ctrl.metadata.backingData.accounts"
-                                  provider="'kubernetes'"></account-select-field>
-          </div>
-        </div>
-
-        <div class="form-group">
-          <div class="col-md-3 sm-label-right">
-            Application *
-            <help-field key="kubernetes.manifest.application"></help-field>
-          </div>
-          <div class="col-md-7"><input readonly="true"
-                                       type="text"
-                                       class="form-control input-sm"
-                                       name="application"
-                                       ng-model="ctrl.command.moniker.app"/></div>
-        </div>
+        <stage-config-field label="Account *" help-key="kubernetes.manifest.account">
+          <account-select-field component="ctrl.command"
+                                field="account"
+                                accounts="ctrl.metadata.backingData.accounts"
+                                provider="'kubernetes'"></account-select-field>
+        </stage-config-field>
+        <stage-config-field label="Application *" help-key="kubernetes.manifest.application">
+          <input readonly="true"
+                 type="text"
+                 class="form-control input-sm"
+                 name="application"
+                 ng-model="ctrl.command.moniker.app"/>
+        </stage-config-field>
       </ng-form>
-    </div>
   `;
 }
 

--- a/app/scripts/modules/kubernetes/src/v2/manifest/wizard/manifestEntry.component.ts
+++ b/app/scripts/modules/kubernetes/src/v2/manifest/wizard/manifestEntry.component.ts
@@ -15,14 +15,12 @@ class KubernetesManifestEntryComponent implements IComponentOptions {
   public controller: any = KubernetesManifestCtrl;
   public controllerAs = 'ctrl';
   public template = `
-    <div class="container-fluid form-horizontal">
       <ng-form name="manifest">
         <div class="form-group" ng-class="{ 'kubernetes-manifest-error': ctrl.metadata.yamlError }">
           <div style="" class="kubernetes-manifest-yaml-error-message">Invalid YAML</div>
           <textarea class="code form-control kubernetes-manifest-entry" ng-model="ctrl.metadata.manifestText" ng-change="ctrl.change()" rows="40"></textarea>
         </div>
       </ng-form>
-    </div>
   `;
 }
 

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestConfig.html
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestConfig.html
@@ -3,56 +3,43 @@
     <strong>Warning!</strong> This stage is under active development and is subject to change.
   </div>
 
-  <h4>Basic Settings</h4>
-  <kubernetes-manifest-basic-settings command="ctrl.$scope.stage"
-                                      metadata="ctrl.metadata">
-  </kubernetes-manifest-basic-settings>
-
-  <h4>Manifest Configuration</h4>
   <div class="container-fluid form-horizontal">
+    <h4>Basic Settings</h4>
+    <kubernetes-manifest-basic-settings command="ctrl.$scope.stage"
+                                        metadata="ctrl.metadata">
+    </kubernetes-manifest-basic-settings>
+
+    <h4>Manifest Configuration</h4>
     <ng-form name="kubernetesManifestSource">
-      <div class="form-group form-inline">
-        <div class="col-md-3 sm-label-right">
-          Manifest Source
-          <help-field key="kubernetes.manifest.source"></help-field>
-        </div>
-        <div class="col-md-4">
-          <label class="sm-label-right">
-            <input type="radio" ng-model="ctrl.$scope.stage.source" value="{{ctrl.textSource}}">
-            {{ ctrl.textSource | robotToHuman }}
-          </label><br/>
-          <label class="sm-label-right">
-            <input type="radio" ng-model="ctrl.$scope.stage.source" value="{{ctrl.artifactSource}}">
-            {{ ctrl.artifactSource | robotToHuman }}
-          </label>
-        </div>
-      </div>
+      <stage-config-field label="Manifest Source" help-key="kubernetes.manifest.source">
+        <label class="sm-label-right">
+          <input type="radio" ng-model="ctrl.$scope.stage.source" value="{{ctrl.textSource}}">
+          {{ ctrl.textSource | robotToHuman }}
+        </label><br/>
+        <label class="sm-label-right">
+          <input type="radio" ng-model="ctrl.$scope.stage.source" value="{{ctrl.artifactSource}}">
+          {{ ctrl.artifactSource | robotToHuman }}
+        </label>
+      </stage-config-field>
     </ng-form>
-  </div>
-
-  <hr>
-
-  <kubernetes-manifest-entry ng-if="ctrl.$scope.stage.source === ctrl.textSource"
-                             command="ctrl.$scope.stage"
-                             metadata="ctrl.metadata" change="ctrl.change()">
-  </kubernetes-manifest-entry>
-
-  <div class="container-fluid form-horizontal" ng-if="ctrl.$scope.stage.source === ctrl.artifactSource">
-    <expected-artifact-selector command="ctrl.$scope.stage"
+    <kubernetes-manifest-entry ng-if="ctrl.$scope.stage.source === ctrl.textSource"
+                               command="ctrl.$scope.stage"
+                               metadata="ctrl.metadata" change="ctrl.change()">
+    </kubernetes-manifest-entry>
+    <expected-artifact-selector ng-if="ctrl.$scope.stage.source === ctrl.artifactSource"
+                                command="ctrl.$scope.stage"
                                 id="ctrl.$scope.stage.manifestArtifactId"
                                 account="ctrl.$scope.stage.manifestArtifactAccount"
                                 accounts="ctrl.metadata.backingData.artifactAccounts"
                                 expected-artifacts="ctrl.expectedArtifacts"
                                 help-field-key="kubernetes.manifest.expectedArtifact">
     </expected-artifact-selector>
+    <hr>
+    <expected-artifact-multi-selector command="ctrl.$scope.stage"
+                                      ids-field="requiredArtifactIds"
+                                      artifact-label="Req. Artifacts To Bind"
+                                      expected-artifacts="ctrl.expectedArtifacts"
+                                      help-field-key="kubernetes.manifest.requiredArtifactsToBind">
+    </expected-artifact-multi-selector>
   </div>
-
-  <hr>
-
-  <expected-artifact-multi-selector command="ctrl.$scope.stage"
-                                    ids-field="requiredArtifactIds"
-                                    artifact-label="Req. Artifacts To Bind"
-                                    expected-artifacts="ctrl.expectedArtifacts"
-                                    help-field-key="kubernetes.manifest.requiredArtifactsToBind">
-  </expected-artifact-multi-selector>
 </div>


### PR DESCRIPTION
* Make artifact components more re-usable by being more consistent about which tags should be handled by the parent form and which should be embedded in the component.  In particular, push ` <div class="container-fluid form-horizontal">` to the top of each form rather than repeating in each component.
* Replace boiler-plate form layout code with `stage-config-field` directive