### PR TITLE
fix(pubsub): Filter displayed list of Pub/Sub Subscription Names by Pub/Sub System Type.

### DIFF
--- a/app/scripts/modules/core/src/domain/IPubsubSubscription.ts
+++ b/app/scripts/modules/core/src/domain/IPubsubSubscription.ts
@@ -1,0 +1,4 @@
+export interface IPubsubSubscription {
+  pubsubSystem: string;
+  subscriptionName: string;
+}

--- a/app/scripts/modules/core/src/domain/index.ts
+++ b/app/scripts/modules/core/src/domain/index.ts
@@ -35,6 +35,7 @@ export * from './IOrchestratedItem';
 
 export * from './IPipeline';
 export * from './IProject';
+export * from './IPubsubSubscription';
 
 export * from './IRegionalCluster';
 

--- a/app/scripts/modules/core/src/pipeline/config/triggers/pubsub/pubsub.trigger.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/pubsub/pubsub.trigger.ts
@@ -1,14 +1,18 @@
 import { IController, module } from 'angular';
 
-import { SETTINGS } from 'core/config/settings';
-
-import { PIPELINE_CONFIG_PROVIDER, PipelineConfigProvider } from 'core/pipeline/config/pipelineConfigProvider';
-import { PUBSUB_SUBSCRIPTION_SERVICE, PubsubSubscriptionService } from 'core/pubsub';
-import { IPubsubTrigger } from 'core/domain';
-import { ServiceAccountService } from 'core';
+import {
+  IPubsubSubscription,
+  IPubsubTrigger,
+  PIPELINE_CONFIG_PROVIDER,
+  PipelineConfigProvider,
+  PUBSUB_SUBSCRIPTION_SERVICE,
+  PubsubSubscriptionService,
+  ServiceAccountService,
+  SETTINGS,
+} from '@spinnaker/core';
 
 class PubsubTriggerController implements IController {
-  public pubsubSystems = SETTINGS.pubsubProviders || ['google']; // TODO: Add amazon once it is confirmed that amazon pub/sub works.
+  public pubsubSystems = SETTINGS.pubsubProviders || ['google']; // TODO(joonlim): Add amazon once it is confirmed that amazon pub/sub works.
   private pubsubSubscriptions: IPubsubSubscription[];
   public filteredPubsubSubscriptions: string[];
   public subscriptionsLoaded = false;

--- a/app/scripts/modules/core/src/pipeline/config/triggers/pubsub/pubsub.trigger.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/pubsub/pubsub.trigger.ts
@@ -8,8 +8,9 @@ import { IPubsubTrigger } from 'core/domain';
 import { ServiceAccountService } from 'core';
 
 class PubsubTriggerController implements IController {
-  public pubsubSystems = SETTINGS.pubsubProviders || ['google', 'kafka'];
-  public pubsubSubscriptions: string[];
+  public pubsubSystems = SETTINGS.pubsubProviders || ['google']; // TODO: Add amazon once it is confirmed that amazon pub/sub works.
+  private pubsubSubscriptions: IPubsubSubscription[];
+  public filteredPubsubSubscriptions: string[];
   public subscriptionsLoaded = false;
   public serviceAccounts: string[];
 
@@ -21,14 +22,28 @@ class PubsubTriggerController implements IController {
     'ngInject';
 
     this.subscriptionsLoaded = false;
+    this.refreshPubsubSubscriptions();
+    this.serviceAccountService.getServiceAccounts().then(accounts => {
+      this.serviceAccounts = accounts || [];
+    });
+  }
+
+  // If we ever need a refresh button in pubsubTrigger.html, call this function.
+  public refreshPubsubSubscriptions(): void {
     this.pubsubSubscriptionService
       .getPubsubSubscriptions()
       .then(subscriptions => (this.pubsubSubscriptions = subscriptions))
       .catch(() => (this.pubsubSubscriptions = []))
-      .finally(() => (this.subscriptionsLoaded = true));
-    this.serviceAccountService.getServiceAccounts().then(accounts => {
-      this.serviceAccounts = accounts || [];
-    });
+      .finally(() => {
+        this.subscriptionsLoaded = true;
+        this.updateFilteredPubsubSubscriptions();
+      });
+  }
+
+  public updateFilteredPubsubSubscriptions(): void {
+    this.filteredPubsubSubscriptions = this.pubsubSubscriptions
+      .filter(subscription => subscription.pubsubSystem === this.trigger.pubsubSystem)
+      .map(subscription => subscription.subscriptionName);
   }
 }
 

--- a/app/scripts/modules/core/src/pipeline/config/triggers/pubsub/pubsubTrigger.html
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/pubsub/pubsubTrigger.html
@@ -6,7 +6,8 @@
     <div class="col-md-6">
       <select class="form-control input-sm"
               ng-options="pubsubSystem for pubsubSystem in vm.pubsubSystems"
-              ng-model="vm.trigger.pubsubSystem">
+              ng-model="vm.trigger.pubsubSystem"
+              ng-change="vm.updateFilteredPubsubSubscriptions()">
         <option value="">Select Pub/Sub System</option>
       </select>
     </div>
@@ -18,7 +19,7 @@
     </div>
     <div class="col-md-6">
       <select class="form-control input-sm"
-              ng-options="pubsubSystem for pubsubSystem in vm.pubsubSubscriptions"
+              ng-options="subscription for subscription in vm.filteredPubsubSubscriptions"
               ng-model="vm.trigger.subscriptionName">
         <option value="">Select Pub/Sub Subscription</option>
       </select>

--- a/app/scripts/modules/core/src/pubsub/pubsubSubscription.service.ts
+++ b/app/scripts/modules/core/src/pubsub/pubsubSubscription.service.ts
@@ -1,9 +1,10 @@
 import { module, IPromise } from 'angular';
 
 import { API } from 'core/api/ApiService';
+import { IPubsubSubscription } from 'core/domain';
 
 export class PubsubSubscriptionService {
-  public getPubsubSubscriptions(): IPromise<string[]> {
+  public getPubsubSubscriptions(): IPromise<IPubsubSubscription[]> {
     return API.one('pubsub')
       .one('subscriptions')
       .get();

--- a/app/scripts/modules/core/src/pubsub/pubsubSubscription.service.ts
+++ b/app/scripts/modules/core/src/pubsub/pubsubSubscription.service.ts
@@ -1,7 +1,6 @@
 import { module, IPromise } from 'angular';
 
-import { API } from 'core/api/ApiService';
-import { IPubsubSubscription } from 'core/domain';
+import { API, IPubsubSubscription } from '@spinnaker/core';
 
 export class PubsubSubscriptionService {
   public getPubsubSubscriptions(): IPromise<IPubsubSubscription[]> {

--- a/halconfig/settings.js
+++ b/halconfig/settings.js
@@ -2,13 +2,13 @@
 
 var feedbackUrl = '';
 var gateHost = '{%gate.baseUrl%}';
-var bakeryDetailUrl = (gateHost + '/bakery/logs/{{context.region}}/{{context.status.resourceId}}');
-var authEndpoint = (gateHost + '/auth/user');
+var bakeryDetailUrl = gateHost + '/bakery/logs/{{context.region}}/{{context.status.resourceId}}';
+var authEndpoint = gateHost + '/auth/user';
 var authEnabled = '{%features.auth%}' === 'true';
 var chaosEnabled = '{%features.chaos%}' === 'true';
 var fiatEnabled = '{%features.fiat%}' === 'true';
 var jobsEnabled = '{%features.jobs%}' === 'true';
-var infrastructureStagesEnabled = "{%features.infrastructureStages%}" === "true";
+var infrastructureStagesEnabled = '{%features.infrastructureStages%}' === 'true';
 var pipelineTemplatesEnabled = '{%features.pipelineTemplates%}' === 'true';
 var artifactsEnabled = '{%features.artifacts%}' === 'true';
 var mineCanaryEnabled = '{%features.mineCanary%}' === 'true';
@@ -31,7 +31,7 @@ var gce = {
   defaults: {
     account: '{%google.default.account%}',
     region: '{%google.default.region%}',
-    zone: '{%google.default.zone%}'
+    zone: '{%google.default.zone%}',
   },
   associatePublicIpAddress: true,
 };
@@ -42,49 +42,49 @@ var kubernetes = {
     proxy: '{%kubernetes.default.proxy%}',
     internalDNSNameTemplate: '{{name}}.{{namespace}}.svc.cluster.local',
     instanceLinkTemplate: '{{host}}/api/v1/proxy/namespaces/{{namespace}}/pods/{{name}}',
-  }
+  },
 };
 var appengine = {
   defaults: {
     account: '{%appengine.default.account%}',
     editLoadBalancerStageEnabled: '{%appengine.enabled%}' === 'true',
     containerImageUrlDeployments: appengineContainerImageUrlDeploymentsEnabled,
-  }
+  },
 };
 var openstack = {
   defaults: {
     account: '{%openstack.default.account%}',
-    region: '{%openstack.default.region%}'
-  }
+    region: '{%openstack.default.region%}',
+  },
 };
 var azure = {
   defaults: {
     account: '{%azure.default.account%}',
-    region: '{%azure.default.region%}'
-  }
+    region: '{%azure.default.region%}',
+  },
 };
 var oraclebmcs = {
   defaults: {
     account: '{%oraclebmcs.default.account%}',
-    region: '{%oraclebmcs.default.region%}'
-  }
+    region: '{%oraclebmcs.default.region%}',
+  },
 };
 var dcos = {
   defaults: {
-    account: '{%dcos.default.account%}'
-  }
+    account: '{%dcos.default.account%}',
+  },
 };
 var ecs = {
   defaults: {
-    account: '{%ecs.default.account%}'
-  }
+    account: '{%ecs.default.account%}',
+  },
 };
 var entityTagsEnabled = false;
 var netflixMode = false;
 var notificationsEnabled = '{%notifications.enabled%}' === 'true';
 var slack = {
   enabled: '{%notifications.slack.enabled%}' === 'true',
-  botName: '{%notifications.slack.botName%}'
+  botName: '{%notifications.slack.botName%}',
 };
 
 window.spinnakerSettings = {
@@ -128,7 +128,7 @@ window.spinnakerSettings = {
     kubernetes: kubernetes,
     appengine: appengine,
     oraclebmcs: oraclebmcs,
-    dcos: dcos
+    dcos: dcos,
   },
   changelog: {
     gistId: changelogGistId,
@@ -140,19 +140,20 @@ window.spinnakerSettings = {
     },
     hipchat: {
       enabled: true,
-      botName: 'Skynet T-800'
+      botName: 'Skynet T-800',
     },
     sms: {
       enabled: true,
     },
-    slack: slack
+    slack: slack,
   },
   pagerDuty: {
-    required: false
+    required: false,
   },
   authEnabled: authEnabled,
   authTtl: 600000,
   gitSources: ['stash', 'github', 'bitbucket'],
+  pubsubProviders: ['google'], // TODO(joonlim): Add amazon once it is confirmed that amazon pub/sub works.
   triggerTypes: ['git', 'pipeline', 'docker', 'cron', 'jenkins', 'travis', 'pubsub', 'webhook'],
   canary: {
     reduxLogger: reduxLoggerEnabled,

--- a/settings.js
+++ b/settings.js
@@ -152,7 +152,7 @@ window.spinnakerSettings = {
   authEnabled: authEnabled,
   authTtl: 600000,
   gitSources: ['stash', 'github', 'bitbucket'],
-  pubsubProviders: ['google'], // TODO: Add amazon once it is confirmed that amazon pub/sub works.
+  pubsubProviders: ['google'], // TODO(joonlim): Add amazon once it is confirmed that amazon pub/sub works.
   triggerTypes: ['git', 'pipeline', 'docker', 'cron', 'jenkins', 'travis', 'pubsub'],
   searchVersion: 1,
   canary: {

--- a/settings.js
+++ b/settings.js
@@ -139,7 +139,7 @@ window.spinnakerSettings = {
   authEnabled: authEnabled,
   authTtl: 600000,
   gitSources: ['stash', 'github', 'bitbucket'],
-  pubsubProviders: ['google', 'kafka'],
+  pubsubProviders: ['google'], // TODO: Add amazon once it is confirmed that amazon pub/sub works.
   triggerTypes: ['git', 'pipeline', 'docker', 'cron', 'jenkins', 'travis', 'pubsub'],
   searchVersion: 1,
   canary: {


### PR DESCRIPTION
* Part of a bug fix to display only Pub/Sub subscription names of subscriptions associated with a given Pub/Sub system type (e.g., 'google').
* This fix also touches echo and gate.
* This PR also removes 'kafka' from list of Pub/Sub System Types in settings.js and pubsub.trigger.ts as it is not being used.
* We have opted out of adding a button to refresh the cached list of subscriptions because @danielpeach deemed it an unlikely use case.