### PR TITLE
refactor(core): rename Security Groups to Firewalls

### DIFF
--- a/app/scripts/modules/amazon/src/help/amazon.help.ts
+++ b/app/scripts/modules/amazon/src/help/amazon.help.ts
@@ -76,11 +76,11 @@ const helpContents: { [key: string]: string } = {
   'aws.serverGroup.traffic': `<p>Enables the "AddToLoadBalancer" scaling process, which is used by Spinnaker and discovery services to determine if the server group is enabled.</p>
      <p>Will be automatically enabled when any non "custom" deployment strategy is selected.</p>`,
   'aws.securityGroup.vpc': `
-    <p>The VPC to which this security group will apply.</p>
+    <p>The VPC to which this {{firewall}} will apply.</p>
     <p>If you wish to use VPC but are unsure which VPC to use, the most common one is "Main".</p>
     <p>If you do not wish to use VPC, select "None".</p>`,
   'aws.securityGroup.name':
-    '<p>The security group name is formed by combining the application name, the <b>Stack</b> field, and the <b>Detail</b> field.</p>',
+    '<p>The {{firewall}} name is formed by combining the application name, the <b>Stack</b> field, and the <b>Detail</b> field.</p>',
   'aws.scalingPolicy.search.restricted': `<p>Resets dimensions to "AutoScalingGroupName: {name of the ASG}" and provides
         a simpler, combined input for the namespace and metric name fields.</p>`,
   'aws.scalingPolicy.search.all': `

--- a/app/scripts/modules/amazon/src/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/amazon/src/instance/details/instance.details.controller.js
@@ -9,6 +9,7 @@ import {
   INSTANCE_READ_SERVICE,
   RECENT_HISTORY_SERVICE,
   SETTINGS,
+  FirewallLabels,
 } from '@spinnaker/core';
 
 import { AMAZON_INSTANCE_WRITE_SERVICE } from 'amazon/instance/amazon.instance.write.service';
@@ -46,6 +47,8 @@ module.exports = angular
     };
 
     $scope.application = app;
+
+    $scope.securityGroupsLabel = FirewallLabels.get('Firewalls');
 
     function extractHealthMetrics(instance, latest) {
       // do not backfill on standalone instances

--- a/app/scripts/modules/amazon/src/instance/details/instanceDetails.html
+++ b/app/scripts/modules/amazon/src/instance/details/instanceDetails.html
@@ -166,10 +166,10 @@
         </dd>
       </dl>
     </collapsible-section>
-    <collapsible-section heading="Security Groups">
+    <collapsible-section heading="{{securityGroupsLabel}}">
         <ul>
           <li ng-repeat="securityGroup in instance.securityGroups | orderBy:'groupName'">
-            <a ui-sref="^.securityGroupDetails({name:securityGroup.groupName, accountId: instance.account, region: instance.region, vpcId: instance.vpcId, provider: instance.provider})">
+            <a ui-sref="^.firewallDetails({name:securityGroup.groupName, accountId: instance.account, region: instance.region, vpcId: instance.vpcId, provider: instance.provider})">
               {{securityGroup.groupName}} ({{securityGroup.groupId}})
             </a>
           </li>

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/common/SecurityGroups.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/common/SecurityGroups.tsx
@@ -14,6 +14,7 @@ import {
   Spinner,
   timestamp,
   wizardPage,
+  FirewallLabels,
 } from '@spinnaker/core';
 
 import { AWSProviderSettings } from 'amazon/aws.settings';
@@ -32,7 +33,9 @@ class SecurityGroupsImpl extends React.Component<
   IWizardPageProps & FormikProps<IAmazonClassicLoadBalancerUpsertCommand>,
   ISecurityGroupsState
 > {
-  public static LABEL = 'Security Groups';
+  public static get LABEL() {
+    return FirewallLabels.get('Firewalls');
+  }
 
   private destroy$ = new Subject();
 
@@ -183,8 +186,8 @@ class SecurityGroupsImpl extends React.Component<
                 <div className="alert alert-warning">
                   <p>
                     <i className="fa fa-exclamation-triangle" />
-                    The following security groups could not be found in the selected account/region/VPC and were
-                    removed:
+                    The following {FirewallLabels.get('firewalls')} could not be found in the selected
+                    account/region/VPC and were removed:
                   </p>
                   <ul>{removed.map(sg => <li key={sg}>{sg}</li>)}</ul>
                   <p className="text-right">
@@ -197,7 +200,7 @@ class SecurityGroupsImpl extends React.Component<
             </div>
           )}
           <div className="form-group">
-            <div className="col-md-3 sm-label-right">Security Groups</div>
+            <div className="col-md-3 sm-label-right">{FirewallLabels.get('Firewalls')}</div>
             <div className="col-md-9">
               {!loaded && (
                 <div style={{ paddingTop: '13px' }}>
@@ -225,12 +228,12 @@ class SecurityGroupsImpl extends React.Component<
                     <span className="fa fa-sync-alt fa-spin" />{' '}
                   </span>
                 )}
-                Security groups
+                {FirewallLabels.get('Firewalls')}
                 {!refreshing && <span> last refreshed {timestamp(refreshTime)}</span>}
                 {refreshing && <span> refreshing...</span>}
               </p>
               <p>
-                If you're not finding a security group that was recently added,{' '}
+                If you're not finding a {FirewallLabels.get('firewall')} that was recently added,{' '}
                 <a className="clickable" onClick={this.refreshSecurityGroups}>
                   click here
                 </a>{' '}

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/common/createAmazonLoadBalancer.controller.ts
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/common/createAmazonLoadBalancer.controller.ts
@@ -20,6 +20,7 @@ import {
   SubnetReader,
   TaskMonitorBuilder,
   TaskMonitor,
+  FirewallLabels,
 } from '@spinnaker/core';
 
 import { AmazonCertificateReader, IAmazonCertificate } from 'amazon/certificates/amazon.certificate.read.service';
@@ -247,7 +248,7 @@ export abstract class CreateAmazonLoadBalancerCtrl {
       });
       this.loadBalancerCommand.securityGroups = uniq(existingNames);
       if (this.viewState.removedSecurityGroups.length) {
-        this.v2modalWizardService.markDirty('Security Groups');
+        this.v2modalWizardService.markDirty(FirewallLabels.get('Firewalls'));
       }
     } else {
       this.clearSecurityGroups();
@@ -437,11 +438,11 @@ export abstract class CreateAmazonLoadBalancerCtrl {
       this.availabilityZones = this.subnets
         .find(o => o.purpose === this.loadBalancerCommand.subnetType)
         .availabilityZones.sort();
-      this.v2modalWizardService.includePage('Security Groups');
+      this.v2modalWizardService.includePage(FirewallLabels.get('Firewalls'));
     } else {
       this.updateAvailabilityZones();
       this.loadBalancerCommand.vpcId = null;
-      this.v2modalWizardService.excludePage('Security Groups');
+      this.v2modalWizardService.excludePage(FirewallLabels.get('Firewalls'));
     }
   }
 

--- a/app/scripts/modules/amazon/src/loadBalancer/details/loadBalancerDetails.controller.ts
+++ b/app/scripts/modules/amazon/src/loadBalancer/details/loadBalancerDetails.controller.ts
@@ -17,6 +17,7 @@ import {
   SecurityGroupReader,
   SUBNET_READ_SERVICE,
   SubnetReader,
+  FirewallLabels,
 } from '@spinnaker/core';
 
 import {
@@ -45,6 +46,7 @@ export class AwsLoadBalancerDetailsController implements IController {
   public securityGroups: ISecurityGroup[];
   public ipAddressTypeDescription: string;
   public state = { loading: true };
+  public firewallsLabel = FirewallLabels.get('Firewalls');
 
   constructor(
     private $scope: IScope,

--- a/app/scripts/modules/amazon/src/loadBalancer/details/loadBalancerDetails.html
+++ b/app/scripts/modules/amazon/src/loadBalancer/details/loadBalancerDetails.html
@@ -151,10 +151,10 @@
         </dd>
       </dl>
     </collapsible-section>
-    <collapsible-section heading="Security Groups">
+    <collapsible-section heading="{{ctrl.firewallsLabel}}">
       <ul>
         <li ng-repeat="securityGroup in ctrl.securityGroups | orderBy:'name'">
-          <a ui-sref="^.securityGroupDetails({name:securityGroup.name, accountId: ctrl.loadBalancer.account, region: ctrl.loadBalancer.region, vpcId: ctrl.loadBalancer.vpcId, provider: ctrl.loadBalancer.provider})">
+          <a ui-sref="^.firewallDetails({name:securityGroup.name, accountId: ctrl.loadBalancer.account, region: ctrl.loadBalancer.region, vpcId: ctrl.loadBalancer.vpcId, provider: ctrl.loadBalancer.provider})">
             {{securityGroup.name}} ({{securityGroup.id}})
           </a>
         </li>

--- a/app/scripts/modules/amazon/src/securityGroup/clone/cloneSecurityGroup.controller.js
+++ b/app/scripts/modules/amazon/src/securityGroup/clone/cloneSecurityGroup.controller.js
@@ -3,7 +3,7 @@
 const angular = require('angular');
 import _ from 'lodash';
 
-import { AccountService } from '@spinnaker/core';
+import { AccountService, FirewallLabels } from '@spinnaker/core';
 
 import { VPC_READ_SERVICE } from 'amazon/vpc/vpc.read.service';
 
@@ -20,6 +20,8 @@ module.exports = angular
     application,
   ) {
     var vm = this;
+
+    vm.firewallLabel = FirewallLabels.get('Firewall');
 
     $scope.pages = {
       location: require('../configure/createSecurityGroupProperties.html'),

--- a/app/scripts/modules/amazon/src/securityGroup/clone/cloneSecurityGroup.html
+++ b/app/scripts/modules/amazon/src/securityGroup/clone/cloneSecurityGroup.html
@@ -1,4 +1,4 @@
-<v2-modal-wizard heading="Clone Security Group" task-monitor="taskMonitor" dismiss="$dismiss()">
+<v2-modal-wizard heading="Clone {{ctrl.firewallLabel}}" task-monitor="taskMonitor" dismiss="$dismiss()">
   <v2-wizard-page key="Location" label="Location">
     <ng-include src="pages.location"></ng-include>
   </v2-wizard-page>

--- a/app/scripts/modules/amazon/src/securityGroup/configure/CreateSecurityGroup.controller.spec.js
+++ b/app/scripts/modules/amazon/src/securityGroup/configure/CreateSecurityGroup.controller.spec.js
@@ -114,12 +114,12 @@ describe('Controller: CreateSecurityGroup', function() {
       }),
     );
 
-    it('initializes with no security groups available for ingress permissions', function() {
+    it('initializes with no firewalls available for ingress permissions', function() {
       this.initializeCtrl();
       expect(this.$scope.availableSecurityGroups.length).toBe(0);
     });
 
-    it('sets up available security groups once an account and region are selected', function() {
+    it('sets up available firewalls once an account and region are selected', function() {
       this.initializeCtrl();
       this.$scope.securityGroup.credentials = 'prod';
       this.ctrl.accountUpdated();
@@ -179,7 +179,7 @@ describe('Controller: CreateSecurityGroup', function() {
       expect(this.$scope.securityGroup.vpcId).toBe('vpc2-te');
     });
 
-    describe('security group removal', function() {
+    describe('firewall removal', function() {
       beforeEach(function() {
         spyOn(this.v2modalWizardService, 'markDirty').and.returnValue(null);
         this.initializeCtrl();

--- a/app/scripts/modules/amazon/src/securityGroup/configure/CreateSecurityGroupCtrl.js
+++ b/app/scripts/modules/amazon/src/securityGroup/configure/CreateSecurityGroupCtrl.js
@@ -2,7 +2,7 @@
 
 const angular = require('angular');
 
-import { CACHE_INITIALIZER_SERVICE } from '@spinnaker/core';
+import { CACHE_INITIALIZER_SERVICE, FirewallLabels } from '@spinnaker/core';
 
 module.exports = angular
   .module('spinnaker.amazon.securityGroup.create.controller', [
@@ -24,6 +24,8 @@ module.exports = angular
     };
 
     var ctrl = this;
+
+    ctrl.translate = FirewallLabels.get;
 
     angular.extend(
       this,

--- a/app/scripts/modules/amazon/src/securityGroup/configure/EditSecurityGroupCtrl.js
+++ b/app/scripts/modules/amazon/src/securityGroup/configure/EditSecurityGroupCtrl.js
@@ -3,7 +3,7 @@
 const angular = require('angular');
 import _ from 'lodash';
 
-import { SECURITY_GROUP_WRITER, TASK_MONITOR_BUILDER } from '@spinnaker/core';
+import { SECURITY_GROUP_WRITER, TASK_MONITOR_BUILDER, FirewallLabels } from '@spinnaker/core';
 
 module.exports = angular
   .module('spinnaker.amazon.securityGroup.edit.controller', [
@@ -48,7 +48,7 @@ module.exports = angular
 
     $scope.taskMonitor = taskMonitorBuilder.buildTaskMonitor({
       application: application,
-      title: 'Updating your security group',
+      title: `Updating your ${FirewallLabels.get('firewall')}`,
       modalInstance: $uibModalInstance,
       onTaskComplete: () => application.securityGroups.refresh(),
     });

--- a/app/scripts/modules/amazon/src/securityGroup/configure/configSecurityGroup.mixin.controller.js
+++ b/app/scripts/modules/amazon/src/securityGroup/configure/configSecurityGroup.mixin.controller.js
@@ -11,6 +11,7 @@ import {
   SECURITY_GROUP_READER,
   SECURITY_GROUP_WRITER,
   TASK_MONITOR_BUILDER,
+  FirewallLabels,
   V2_MODAL_WIZARD_SERVICE,
 } from '@spinnaker/core';
 
@@ -74,10 +75,10 @@ module.exports = angular
         vpcId: $scope.securityGroup.vpcId,
         provider: 'aws',
       };
-      if (!$state.includes('**.securityGroupDetails')) {
-        $state.go('.securityGroupDetails', newStateParams);
+      if (!$state.includes('**.firewallDetails')) {
+        $state.go('.firewallDetails', newStateParams);
       } else {
-        $state.go('^.securityGroupDetails', newStateParams);
+        $state.go('^.firewallDetails', newStateParams);
       }
     }
 
@@ -88,7 +89,7 @@ module.exports = angular
 
     $scope.taskMonitor = taskMonitorBuilder.buildTaskMonitor({
       application: application,
-      title: 'Creating your security group',
+      title: `Creating your ${FirewallLabels.get('firewall')}`,
       modalInstance: $uibModalInstance,
       onTaskComplete: onTaskComplete,
     });

--- a/app/scripts/modules/amazon/src/securityGroup/configure/createSecurityGroup.html
+++ b/app/scripts/modules/amazon/src/securityGroup/configure/createSecurityGroup.html
@@ -1,5 +1,5 @@
 <ng-form role="form" name="form" novalidate>
-  <v2-modal-wizard heading="Create New Security Group" task-monitor="taskMonitor" dismiss="$dismiss()">
+  <v2-modal-wizard heading="Create New {{ctrl.translate('Firewall')" task-monitor="taskMonitor" dismiss="$dismiss()">
     <v2-wizard-page key="Location" label="Location">
       <ng-include src="pages.location"></ng-include>
     </v2-wizard-page>

--- a/app/scripts/modules/amazon/src/securityGroup/configure/createSecurityGroupIngress.html
+++ b/app/scripts/modules/amazon/src/securityGroup/configure/createSecurityGroupIngress.html
@@ -4,7 +4,7 @@
         <div class="col-md-12" ng-if="state.removedRules.length">
           <div class="alert alert-warning">
             <p><i class="fa fa-exclamation-triangle"></i>
-              The following security groups could not be found in the selected account/region/VPC and were removed:
+              The following <firewall-label label="firewalls"/> could not be found in the selected account/region/VPC and were removed:
             </p>
             <ul>
               <li ng-repeat="securityGroup in state.removedRules">{{securityGroup}}</li>
@@ -27,7 +27,7 @@
           <table class="table table-condensed packed">
             <thead>
             <tr>
-              <th style="width: 50%">Security Group</th>
+              <th style="width: 50%"><firewall-label label="Firewall"/></th>
               <th style="width: 15%">Protocol</th>
               <th style="width: 15%">Start Port</th>
               <th style="width: 15%">End Port</th>
@@ -60,7 +60,7 @@
             <tr>
               <td colspan="5">
                 <button class="add-new col-md-12" ng-click="ctrl.addRule(securityGroup.securityGroupIngress)"><span
-                  class="glyphicon glyphicon-plus-sign"></span> Add new Security Group Rule
+                  class="glyphicon glyphicon-plus-sign"></span> Add new <firewall-label label="Firewall"/> Rule
                 </button>
               </td>
             </tr>
@@ -73,11 +73,11 @@
         <div class="col-md-12">
           <p>
             <span ng-if="state.refreshingSecurityGroups"><span class="fa fa-sync-alt fa-spin"></span></span>
-            Security groups
+            <firewall-label label="Firewalls"/>
             <span ng-if="!state.refreshingSecurityGroups">last refreshed {{ state.refreshTime | timestamp }}</span>
             <span ng-if="state.refreshingSecurityGroups"> refreshing...</span>
           </p>
-          <p>If you're not finding a security group that was recently added,
+          <p>If you're not finding a <firewall-label label="firewall"/> that was recently added,
             <a href ng-click="ctrl.refreshSecurityGroups()">click here</a> to refresh the list.
           </p>
         </div>

--- a/app/scripts/modules/amazon/src/securityGroup/configure/createSecurityGroupProperties.html
+++ b/app/scripts/modules/amazon/src/securityGroup/configure/createSecurityGroupProperties.html
@@ -2,7 +2,7 @@
     <div class="modal-body">
       <div class="form-group">
         <div class="col-md-12 well" ng-class="{'alert-danger': form.securityGroupName.$error.validateUnique, 'alert-info': !form.securityGroupName.$error.validateUnique}">
-          <strong>Your security group will be named:</strong>
+          <strong>Your <firewall-label label="firewall"/> will be named:</strong>
           <span ng-bind="namePreview"></span>
           <help-field key="aws.securityGroup.name"></help-field>
           <input type="hidden" class="form-control input-sm"
@@ -13,7 +13,7 @@
                  ng-pattern="ctrl.namePattern"
                  trigger-validation="securityGroup.subnet"
                  required/>
-          <validation-error ng-if="form.securityGroupName.$error.validateUnique && securityGroup.credentials" message="A security group named '{{namePreview}}' already exists in one or more of the selected regions"></validation-error>
+          <validation-error ng-if="form.securityGroupName.$error.validateUnique && securityGroup.credentials" message="A {{ctrl.translate('firewall')}} named '{{namePreview}}' already exists in one or more of the selected regions"></validation-error>
           <validation-error ng-if="form.securityGroupName.$error.pattern" message="Name must match {{ctrl.getCurrentNamePattern().toString()}}"></validation-error>
         </div>
       </div>

--- a/app/scripts/modules/amazon/src/securityGroup/details/securityGroupDetail.controller.js
+++ b/app/scripts/modules/amazon/src/securityGroup/details/securityGroupDetail.controller.js
@@ -9,6 +9,7 @@ import {
   RECENT_HISTORY_SERVICE,
   SECURITY_GROUP_READER,
   SECURITY_GROUP_WRITER,
+  FirewallLabels,
 } from '@spinnaker/core';
 
 module.exports = angular
@@ -34,6 +35,7 @@ module.exports = angular
     this.application = app;
     const application = app;
     const securityGroup = resolvedSecurityGroup;
+    this.firewallLabel = FirewallLabels.get('Firewall');
 
     // needed for standalone instances
     $scope.detailsTemplateUrl = CloudProviderRegistry.getValue('aws', 'securityGroup.detailsTemplateUrl');
@@ -200,13 +202,14 @@ module.exports = angular
         applicationName: application.name,
         taskMonitorConfig: taskMonitor,
         submitMethod: submitMethod,
-        retryBody:
-          '<div><p>Retry deleting the security group and revoke any dependent ingress rules?</p><p>Any instance or load balancer associations will have to removed manually.</p></div>',
+        retryBody: `<div><p>Retry deleting the ${FirewallLabels.get(
+          'firewall',
+        )} and revoke any dependent ingress rules?</p><p>Any instance or load balancer associations will have to removed manually.</p></div>`,
       });
     };
 
     if (app.isStandalone) {
-      // we still want the edit to refresh the security group details when the modal closes
+      // we still want the edit to refresh the firewall details when the modal closes
       app.securityGroups = {
         refresh: extractSecurityGroup,
       };

--- a/app/scripts/modules/amazon/src/securityGroup/details/securityGroupDetail.html
+++ b/app/scripts/modules/amazon/src/securityGroup/details/securityGroupDetail.html
@@ -1,5 +1,5 @@
 <div class="text-center" ng-if="state.notFound">
-  <h3>Could not find security group {{group}}.</h3>
+  <h3>Could not find <firewall-label label="firewall"/> {{group}}.</h3>
   <a ui-sref="home.infrastructure">Back to search results</a>
 </div>
 <div class="details-panel" ng-if="!state.notFound">
@@ -35,12 +35,12 @@
     <div class="actions">
       <div class="dropdown" uib-dropdown dropdown-append-to-body>
         <button type="button" class="btn btn-sm btn-primary dropdown-toggle" ng-disabled="disabled" uib-dropdown-toggle>
-          Security Group Actions <span class="caret"></span>
+          <firewall-label label="Firewall"/> Actions <span class="caret"></span>
         </button>
         <ul class="dropdown-menu" uib-dropdown-menu role="menu">
           <li><a href ng-click="ctrl.editInboundRules()">Edit Inbound Rules</a></li>
-          <li><a href ng-click="ctrl.deleteSecurityGroup()">Delete Security Group</a></li>
-          <li><a href ng-click="ctrl.cloneSecurityGroup()">Clone Security Group</a></li>
+          <li><a href ng-click="ctrl.deleteSecurityGroup()">Delete <firewall-label label="Firewall"/></a></li>
+          <li><a href ng-click="ctrl.cloneSecurityGroup()">Clone <firewall-label label="Firewall"/></a></li>
           <render-if-feature feature="entityTags">
             <add-entity-tag-links component="securityGroup"
                                   application="ctrl.application"
@@ -52,7 +52,7 @@
     </div>
   </div>
   <div class="content" ng-if="!state.loading">
-    <collapsible-section heading="Security Group Details" expanded="true">
+    <collapsible-section heading="{{ctrl.firewallLabel}} Details" expanded="true">
       <dl class="dl-horizontal dl-medium">
         <dt>ID</dt>
         <dd>{{securityGroup.id}}</dd>
@@ -79,14 +79,14 @@
         </dd>
       </dl>
     </collapsible-section>
-    <collapsible-section heading="Security Group Rules ({{securityGroupRules.length || 0}})" expanded="{{securityGroupRules.length > 0}}">
+    <collapsible-section heading="{{ctrl.firewallLabel}} Rules ({{securityGroupRules.length || 0}})" expanded="{{securityGroupRules.length > 0}}">
       <div ng-if="!securityGroupRules.length">None</div>
 
       <dl ng-class="insightCtrl.vm.filtersExpanded ? '' : 'dl-horizontal dl-medium'"
           ng-repeat="rule in securityGroupRules | orderBy: 'securityGroup.name' ">
-        <dt>Security Group</dt>
+        <dt><firewall-label label="Firewall"/></dt>
         <dd ng-if="rule.securityGroup.name">
-          <a ui-sref="^.securityGroupDetails({name: rule.securityGroup.name, accountId: rule.securityGroup.accountName, region: rule.securityGroup.region, vpcId: rule.securityGroup.vpcId, provider: 'aws'})">
+          <a ui-sref="^.firewallDetails({name: rule.securityGroup.name, accountId: rule.securityGroup.accountName, region: rule.securityGroup.region, vpcId: rule.securityGroup.vpcId, provider: 'aws'})">
             <account-tag account="rule.securityGroup.accountName || rule.securityGroup.accountId" ng-if="rule.securityGroup.accountName !== securityGroup.accountName"></account-tag>
             {{rule.securityGroup.name}} ({{rule.securityGroup.id}})
           </a>

--- a/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupConfiguration.service.spec.ts
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupConfiguration.service.spec.ts
@@ -120,7 +120,7 @@ describe('Service: awsServerGroupConfiguration', function() {
       expect(command.dirty).toBeUndefined();
     });
 
-    it('attempts to reload security groups if some are not found on initialization, but does not set dirty flag', function() {
+    it('attempts to reload firewalls if some are not found on initialization, but does not set dirty flag', function() {
       spyOn(AccountService, 'getCredentialsKeyedByAccount').and.returnValue($q.when([]));
       const getAllSecurityGroupsSpy = spyOn(securityGroupReader, 'getAllSecurityGroups').and.returnValue($q.when([]));
       spyOn(loadBalancerReader, 'listLoadBalancers').and.returnValue($q.when(this.allLoadBalancers));
@@ -307,14 +307,14 @@ describe('Service: awsServerGroupConfiguration', function() {
       };
     });
 
-    it('matches existing security groups based on name - no VPC', function() {
+    it('matches existing firewalls based on name - no VPC', function() {
       this.command.region = 'us-east-1';
       const result = service.configureSecurityGroupOptions(this.command);
       expect(this.command.securityGroups).toEqual(['sg-1c', 'sg-2c']);
       expect(result).toEqual({ dirty: {} });
     });
 
-    it('matches existing security groups based on name - VPC', function() {
+    it('matches existing firewalls based on name - VPC', function() {
       this.command.vpcId = 'vpc-1';
       const result = service.configureSecurityGroupOptions(this.command);
       expect(this.command.securityGroups).toEqual(['sg-1va', 'sg-2va']);
@@ -329,7 +329,7 @@ describe('Service: awsServerGroupConfiguration', function() {
       expect(result).toEqual({ dirty: {} });
     });
 
-    it('sets dirty all unmatched security groups - no VPC', function() {
+    it('sets dirty all unmatched firewalls - no VPC', function() {
       this.command.securityGroups.push('sg-3a');
       this.command.region = 'us-east-1';
       const result = service.configureSecurityGroupOptions(this.command);
@@ -337,7 +337,7 @@ describe('Service: awsServerGroupConfiguration', function() {
       expect(result).toEqual({ dirty: { securityGroups: ['sg3'] } });
     });
 
-    it('sets dirty all unmatched security groups - VPC', function() {
+    it('sets dirty all unmatched firewalls - VPC', function() {
       this.command.securityGroups.push('sg-3a');
       this.command.vpcId = 'vpc-2';
       const result = service.configureSecurityGroupOptions(this.command);

--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/CloneServerGroup.aws.controller.js
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/CloneServerGroup.aws.controller.js
@@ -8,6 +8,7 @@ import {
   SERVER_GROUP_WRITER,
   TASK_MONITOR_BUILDER,
   V2_MODAL_WIZARD_SERVICE,
+  FirewallLabels,
 } from '@spinnaker/core';
 
 import { AWS_SERVER_GROUP_CONFIGURATION_SERVICE } from 'amazon/serverGroup/configure/serverGroupConfiguration.service';
@@ -68,6 +69,8 @@ module.exports = angular
 
     $scope.title = title;
 
+    $scope.firewallsLabel = FirewallLabels.get('Firewalls');
+
     $scope.applicationName = application.name;
     $scope.application = application;
 
@@ -82,7 +85,7 @@ module.exports = angular
       copied: [
         'account, region, subnet, cluster name (stack, details)',
         'load balancers',
-        'security groups',
+        FirewallLabels.get('firewalls'),
         'instance type',
         'all fields on the Advanced Settings page',
       ],

--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/securityGroups/securityGroupSelector.directive.html
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/securityGroups/securityGroupSelector.directive.html
@@ -1,6 +1,6 @@
 <div class="form-group">
   <div class="col-md-3 sm-label-right" ng-if="!vm.hideLabel">
-    <b>Security Groups</b>
+    <b><firewall-label label="Firewalls"/></b>
     <help-field key="{{vm.helpKey}}"></help-field>
   </div>
   <div class="col-md-9">
@@ -23,11 +23,11 @@
   <div class="col-md-{{vm.hideLabel ? 12 : 9}} col-md-offset-{{vm.hideLabel ? 0 : 3}}">
     <p>
       <span ng-if="vm.refreshing"><span class="fa fa-sync-alt fa-spin"></span></span>
-      Security groups
+      <firewall-label label="Firewalls"/>
       <span ng-if="!vm.refreshing">last refreshed {{ vm.refreshTime | timestamp }}</span>
       <span ng-if="vm.refreshing"> refreshing...</span>
     </p>
-    <p>If you're not finding a security group that was recently added,
+    <p>If you're not finding a <firewall-label label="firewall"/> that was recently added,
       <a href ng-click="vm.refreshSecurityGroups()">click here</a> to refresh the list.
     </p>
   </div>

--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/securityGroups/securityGroupsRemoved.component.html
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/securityGroups/securityGroupsRemoved.component.html
@@ -1,7 +1,7 @@
 <div class="col-md-12" ng-if="$ctrl.command.viewState.dirty.securityGroups || $ctrl.removed.length">
   <div class="alert alert-warning">
     <p><i class="fa fa-exclamation-triangle"></i>
-      The following security groups could not be found in the selected account/region/VPC and were removed:
+      The following <firewall-label label="firewalls"/> could not be found in the selected account/region/VPC and were removed:
     </p>
     <ul>
       <li ng-repeat="securityGroup in $ctrl.command.viewState.dirty.securityGroups">{{securityGroup}}</li>

--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/serverGroupWizard.html
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/serverGroupWizard.html
@@ -13,7 +13,7 @@
       <v2-wizard-page key="load-balancers" label="Load Balancers" done="true">
         <ng-include src="pages.loadBalancers"></ng-include>
       </v2-wizard-page>
-      <v2-wizard-page key="security-groups" label="Security Groups" done="true">
+      <v2-wizard-page key="security-groups" label="{{firewallsLabel}}" done="true">
         <ng-include src="pages.securityGroups"></ng-include>
       </v2-wizard-page>
       <v2-wizard-page key="instance-type" label="Instance Type" mark-complete-on-view="false">

--- a/app/scripts/modules/amazon/src/serverGroup/details/sections/SecurityGroupsDetailsSection.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/details/sections/SecurityGroupsDetailsSection.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { chain, find, sortBy } from 'lodash';
 import { UISref } from '@uirouter/react';
 
-import { CollapsibleSection, ISecurityGroup, ModalInjector } from '@spinnaker/core';
+import { CollapsibleSection, ISecurityGroup, ModalInjector, FirewallLabels } from '@spinnaker/core';
 
 import { IAmazonServerGroupDetailsSectionProps } from './IAmazonServerGroupDetailsSectionProps';
 
@@ -59,12 +59,12 @@ export class SecurityGroupsDetailsSection extends React.Component<
     const { securityGroups } = this.state;
 
     return (
-      <CollapsibleSection heading="Security Groups">
+      <CollapsibleSection heading={FirewallLabels.get('Firewalls')}>
         <ul>
           {sortBy(securityGroups, 'name').map(securityGroup => (
             <li key={securityGroup.name}>
               <UISref
-                to="^.securityGroupDetails"
+                to="^.firewallDetails"
                 params={{
                   name: securityGroup.name,
                   accountId: securityGroup.accountName,
@@ -82,7 +82,7 @@ export class SecurityGroupsDetailsSection extends React.Component<
         </ul>
         {serverGroup.vpcId && (
           <a className="clickable" onClick={this.updateSecurityGroups}>
-            Edit Security Groups
+            Edit {FirewallLabels.get('Firewalls')}
           </a>
         )}
       </CollapsibleSection>

--- a/app/scripts/modules/amazon/src/serverGroup/details/securityGroup/editSecurityGroups.modal.controller.js
+++ b/app/scripts/modules/amazon/src/serverGroup/details/securityGroup/editSecurityGroups.modal.controller.js
@@ -3,7 +3,13 @@
 const angular = require('angular');
 import _ from 'lodash';
 
-import { SECURITY_GROUP_READER, SERVER_GROUP_WRITER, TASK_EXECUTOR, TASK_MONITOR_BUILDER } from '@spinnaker/core';
+import {
+  SECURITY_GROUP_READER,
+  SERVER_GROUP_WRITER,
+  TASK_EXECUTOR,
+  TASK_MONITOR_BUILDER,
+  FirewallLabels,
+} from '@spinnaker/core';
 
 module.exports = angular
   .module('spinnaker.amazon.serverGroup.details.securityGroup.editSecurityGroups.modal.controller', [
@@ -65,7 +71,7 @@ module.exports = angular
 
     this.taskMonitor = taskMonitorBuilder.buildTaskMonitor({
       application: application,
-      title: 'Update Security Groups for ' + serverGroup.name,
+      title: `Update ${FirewallLabels.get('Firewalls')} for ${serverGroup.name}`,
       modalInstance: $uibModalInstance,
       onTaskComplete: () => application.serverGroups.refresh(),
     });

--- a/app/scripts/modules/amazon/src/serverGroup/details/securityGroup/editSecurityGroups.modal.html
+++ b/app/scripts/modules/amazon/src/serverGroup/details/securityGroup/editSecurityGroups.modal.html
@@ -3,7 +3,7 @@
   <form role="form" name="form">
     <modal-close dismiss="$dismiss()"></modal-close>
     <div class="modal-header">
-      <h3>Edit Security Groups for {{$ctrl.serverGroup.name}}</h3>
+      <h3>Edit <firewall-label label="Firewalls"/> for {{$ctrl.serverGroup.name}}</h3>
     </div>
     <div class="modal-body container-fluid form-horizontal">
       <div class="form-group">

--- a/app/scripts/modules/amazon/src/validation/applicationName.validator.ts
+++ b/app/scripts/modules/amazon/src/validation/applicationName.validator.ts
@@ -1,6 +1,11 @@
 import { module } from 'angular';
 
-import { APPLICATION_NAME_VALIDATOR, IApplicationNameValidator, ApplicationNameValidator } from '@spinnaker/core';
+import {
+  APPLICATION_NAME_VALIDATOR,
+  FirewallLabels,
+  IApplicationNameValidator,
+  ApplicationNameValidator,
+} from '@spinnaker/core';
 import { AWSProviderSettings } from '../aws.settings';
 
 class AmazonApplicationNameValidator implements IApplicationNameValidator {
@@ -15,8 +20,8 @@ class AmazonApplicationNameValidator implements IApplicationNameValidator {
     const lockoutDate = AWSProviderSettings.classicLaunchLockout;
     if (lockoutDate && lockoutDate < new Date().getTime()) {
       warnings.push(
-        'New applications deployed to AWS are restricted to VPC; you cannot create server groups, ' +
-          'load balancers, or security groups in EC2 Classic.',
+        `New applications deployed to AWS are restricted to VPC; you cannot create server groups, ' +
+          'load balancers, or ${FirewallLabels.get('firewalls')} in EC2 Classic.`,
       );
     }
   }
@@ -36,7 +41,9 @@ class AmazonApplicationNameValidator implements IApplicationNameValidator {
     }
     if (name.length > 240) {
       if (name.length >= 248) {
-        warnings.push('You will not be able to include a stack or detail field for clusters or security groups.');
+        warnings.push(
+          `You will not be able to include a stack or detail field for clusters or ${FirewallLabels.get('firewalls')}.`,
+        );
       } else {
         const remaining = 248 - name.length;
         warnings.push(`If you plan to include a stack or detail field for clusters, you will only

--- a/app/scripts/modules/azure/loadBalancer/details/loadBalancerDetail.controller.js
+++ b/app/scripts/modules/azure/loadBalancer/details/loadBalancerDetail.controller.js
@@ -8,6 +8,7 @@ import {
   LOAD_BALANCER_READ_SERVICE,
   LOAD_BALANCER_WRITE_SERVICE,
   SECURITY_GROUP_READER,
+  FirewallLabels,
 } from '@spinnaker/core';
 
 module.exports = angular
@@ -34,6 +35,8 @@ module.exports = angular
     $scope.state = {
       loading: true,
     };
+
+    $scope.firewallsLabel = FirewallLabels.get('Firewalls');
 
     function extractLoadBalancer() {
       $scope.loadBalancer = app.loadBalancers.data.filter(function(test) {

--- a/app/scripts/modules/azure/loadBalancer/details/loadBalancerDetail.html
+++ b/app/scripts/modules/azure/loadBalancer/details/loadBalancerDetail.html
@@ -92,10 +92,10 @@
         </dd>
       </dl>
     </collapsible-section>
-    <collapsible-section heading="Security Groups">
+    <collapsible-section heading="{{firewallsLabel}}">
       <ul>
         <li ng-repeat="securityGroup in securityGroups | orderBy:'name'">
-          <a ui-sref="^.securityGroupDetails({name:securityGroup.name, accountId: loadBalancer.account, region: loadBalancer.region, vpcId: loadBalancer.vpcId, provider: loadBalancer.provider})">
+          <a ui-sref="^.firewallDetails({name:securityGroup.name, accountId: loadBalancer.account, region: loadBalancer.region, vpcId: loadBalancer.vpcId, provider: loadBalancer.provider})">
             {{securityGroup.name}} ({{securityGroup.id}})
           </a>
         </li>

--- a/app/scripts/modules/azure/securityGroup/clone/cloneSecurityGroup.controller.js
+++ b/app/scripts/modules/azure/securityGroup/clone/cloneSecurityGroup.controller.js
@@ -3,7 +3,7 @@
 const angular = require('angular');
 import _ from 'lodash';
 
-import { AccountService, TASK_MONITOR_BUILDER } from '@spinnaker/core';
+import { AccountService, TASK_MONITOR_BUILDER, FirewallLabels } from '@spinnaker/core';
 
 module.exports = angular
   .module('spinnaker.azure.securityGroup.clone.controller', [
@@ -22,6 +22,8 @@ module.exports = angular
     application,
   ) {
     var ctrl = this;
+
+    $scope.firewallLabel = FirewallLabels.get('Firewall');
 
     $scope.pages = {
       location: require('../configure/createSecurityGroupProperties.html'),
@@ -65,7 +67,7 @@ module.exports = angular
 
     $scope.taskMonitor = taskMonitorBuilder.buildTaskMonitor({
       application: application,
-      title: 'Updating your security group',
+      title: `Updating your ${FirewallLabels.get('firewall')}`,
       modalInstance: $uibModalInstance,
       onTaskComplete: onTaskComplete,
     });
@@ -103,10 +105,10 @@ module.exports = angular
         region: $scope.securityGroup.region,
         provider: 'azure',
       };
-      if (!$state.includes('**.securityGroupDetails')) {
-        $state.go('.securityGroupDetails', newStateParams);
+      if (!$state.includes('**.firewallDetails')) {
+        $state.go('.firewallDetails', newStateParams);
       } else {
-        $state.go('^.securityGroupDetails', newStateParams);
+        $state.go('^.firewallDetails', newStateParams);
       }
     }
 

--- a/app/scripts/modules/azure/securityGroup/clone/cloneSecurityGroup.html
+++ b/app/scripts/modules/azure/securityGroup/clone/cloneSecurityGroup.html
@@ -1,5 +1,5 @@
 
-<v2-modal-wizard heading="Clone Security Group">
+<v2-modal-wizard heading="Clone {{firewallLabel}}">
   <v2-wizard-page key="Location" label="Location">
     <ng-include src="pages.location"></ng-include>
   </v2-wizard-page>

--- a/app/scripts/modules/azure/securityGroup/configure/CreateSecurityGroup.controller.spec.js
+++ b/app/scripts/modules/azure/securityGroup/configure/CreateSecurityGroup.controller.spec.js
@@ -72,7 +72,7 @@ describe('Controller: Azure.CreateSecurityGroup', function() {
       }),
     );
 
-    it('initializes with no security groups available for ingress permissions', function() {
+    it('initializes with no firewalls available for ingress permissions', function() {
       this.initializeCtrl();
       expect(this.$scope.securityGroup.securityRules.length).toBe(0);
     });

--- a/app/scripts/modules/azure/securityGroup/configure/CreateSecurityGroupCtrl.js
+++ b/app/scripts/modules/azure/securityGroup/configure/CreateSecurityGroupCtrl.js
@@ -2,7 +2,7 @@
 
 const angular = require('angular');
 
-import { AccountService, TASK_MONITOR_BUILDER } from '@spinnaker/core';
+import { AccountService, TASK_MONITOR_BUILDER, FirewallLabels } from '@spinnaker/core';
 
 module.exports = angular
   .module('spinnaker.azure.securityGroup.create.controller', [
@@ -25,6 +25,8 @@ module.exports = angular
       location: require('./createSecurityGroupProperties.html'),
       ingress: require('./createSecurityGroupIngress.html'),
     };
+
+    $scope.firewallLabel = FirewallLabels.get('Firewall');
 
     var ctrl = this;
     $scope.isNew = true;
@@ -57,10 +59,10 @@ module.exports = angular
         region: $scope.securityGroup.regions[0],
         provider: 'azure',
       };
-      if (!$state.includes('**.securityGroupDetails')) {
-        $state.go('.securityGroupDetails', newStateParams);
+      if (!$state.includes('**.firewallDetails')) {
+        $state.go('.firewallDetails', newStateParams);
       } else {
-        $state.go('^.securityGroupDetails', newStateParams);
+        $state.go('^.firewallDetails', newStateParams);
       }
     }
 
@@ -71,7 +73,7 @@ module.exports = angular
 
     $scope.taskMonitor = taskMonitorBuilder.buildTaskMonitor({
       application: application,
-      title: 'Creating your security group',
+      title: `Creating your ${FirewallLabels.get('firewall')}`,
       modalInstance: $uibModalInstance,
       onTaskComplete: onTaskComplete,
     });

--- a/app/scripts/modules/azure/securityGroup/configure/EditSecurityGroupCtrl.js
+++ b/app/scripts/modules/azure/securityGroup/configure/EditSecurityGroupCtrl.js
@@ -4,6 +4,7 @@ const angular = require('angular');
 
 import {
   CACHE_INITIALIZER_SERVICE,
+  FirewallLabels,
   InfrastructureCaches,
   SECURITY_GROUP_READER,
   TASK_MONITOR_BUILDER,
@@ -48,7 +49,7 @@ module.exports = angular
 
     $scope.taskMonitor = taskMonitorBuilder.buildTaskMonitor({
       application: application,
-      title: 'Updating your security group',
+      title: `Updating your ${FirewallLabels.get('firewall')}`,
       modalInstance: $uibModalInstance,
       onTaskComplete: onTaskComplete,
     });
@@ -105,10 +106,10 @@ module.exports = angular
         region: $scope.securityGroup.region,
         provider: 'azure',
       };
-      if (!$state.includes('**.securityGroupDetails')) {
-        $state.go('.securityGroupDetails', newStateParams);
+      if (!$state.includes('**.firewallDetails')) {
+        $state.go('.firewallDetails', newStateParams);
       } else {
-        $state.go('^.securityGroupDetails', newStateParams);
+        $state.go('^.firewallDetails', newStateParams);
       }
     }
 

--- a/app/scripts/modules/azure/securityGroup/configure/configSecurityGroup.mixin.controller.js
+++ b/app/scripts/modules/azure/securityGroup/configure/configSecurityGroup.mixin.controller.js
@@ -4,6 +4,7 @@ const angular = require('angular');
 import _ from 'lodash';
 
 import { AccountService, SECURITY_GROUP_READER, SECURITY_GROUP_WRITER, TASK_MONITOR_BUILDER } from '@spinnaker/core';
+import { FirewallLabels } from 'root/app/scripts/modules/core/src';
 
 module.exports = angular
   .module('spinnaker.azure.securityGroup.baseConfig.controller', [
@@ -55,10 +56,10 @@ module.exports = angular
         vpcId: $scope.securityGroup.vpcId,
         provider: 'azure',
       };
-      if (!$state.includes('**.securityGroupDetails')) {
-        $state.go('.securityGroupDetails', newStateParams);
+      if (!$state.includes('**.firewallDetails')) {
+        $state.go('.firewallDetails', newStateParams);
       } else {
-        $state.go('^.securityGroupDetails', newStateParams);
+        $state.go('^.firewallDetails', newStateParams);
       }
     }
 
@@ -69,7 +70,7 @@ module.exports = angular
 
     $scope.taskMonitor = taskMonitorBuilder.buildTaskMonitor({
       application: application,
-      title: 'Creating your security group',
+      title: `Creating your ${FirewallLabels.get('firewall')}`,
       modalInstance: $uibModalInstance,
       onTaskComplete: onTaskComplete,
     });

--- a/app/scripts/modules/azure/securityGroup/configure/createSecurityGroup.html
+++ b/app/scripts/modules/azure/securityGroup/configure/createSecurityGroup.html
@@ -1,5 +1,5 @@
 <form name="form" class="form-horizontal" novalidate validate-on-submit>
-  <v2-modal-wizard heading="Create New Security Group" task-monitor="taskMonitor" dismiss="$dismiss()">
+  <v2-modal-wizard heading="Create New {{firewallLabel}}" task-monitor="taskMonitor" dismiss="$dismiss()">
     <v2-wizard-page key="Location" label="Location">
       <ng-include src="pages.location"></ng-include>
     </v2-wizard-page>

--- a/app/scripts/modules/azure/securityGroup/configure/createSecurityGroupIngress.html
+++ b/app/scripts/modules/azure/securityGroup/configure/createSecurityGroupIngress.html
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="col-md-12">
       <p class="info">
-      <span class="glyphicon glyphicon-info-sign"></span> Source/Destination address prefixes can only be edited through the Azure Portal. 
+      <span class="glyphicon glyphicon-info-sign"></span> Source/Destination address prefixes can only be edited through the Azure Portal.
       </p>
     </div>
   </div>
@@ -14,8 +14,8 @@
             <tr>
               <th style="width: 21%">Protocol</th>
               <th style="width: 32%">Start Port<help-field key="azure.securityGroup.ingress.startPort"></help-field></th>
-              <th style="width: 32%">End Port<help-field key="azure.securityGroup.ingress.endPort"></help-field></th> 
-              <th style width=15%>Actions<help-field key="azure.securityGroup.ingress.actions"></help-field></th>                 
+              <th style="width: 32%">End Port<help-field key="azure.securityGroup.ingress.endPort"></help-field></th>
+              <th style width=15%>Actions<help-field key="azure.securityGroup.ingress.actions"></help-field></th>
             </tr>
           </thead>
           <tbody>
@@ -35,7 +35,7 @@
                 <a class="btn-link sm-label"
                   ng-click="ctrl.moveDown(securityGroup.securityRules, $index)"><span
                   class="glyphicon glyphicon-arrow-down"></span>
-                </a>            
+                </a>
                 <a class="btn-link sm-label"
                   ng-click="ctrl.removeRule(securityGroup.securityRules, $index)"><span
                   class="glyphicon glyphicon-trash"></span>
@@ -44,12 +44,12 @@
             </tr>
           </tbody>
         </table>
-      </div>    
-    </div>                      
+      </div>
+    </div>
   <div class="form-group small" style="margin-top: 20px">
     <div class="col-md-12">
       <button class="add-new col-md-12" ng-click="ctrl.addRule(securityGroup.securityRules)"><span
-        class="glyphicon glyphicon-plus-sign"></span> Add new Security Group Rule
+        class="glyphicon glyphicon-plus-sign"></span> Add new <firewall-label label="Firewall"/> Rule
       </button>
     </div>
   </div>

--- a/app/scripts/modules/azure/securityGroup/configure/createSecurityGroupProperties.html
+++ b/app/scripts/modules/azure/securityGroup/configure/createSecurityGroupProperties.html
@@ -1,18 +1,8 @@
 <div class="modal-body">
   <div class="form-group">
     <div class="col-md-12 well" ng-class="{'alert-danger': form.securityGroupName.$error.validateUnique, 'alert-info': !form.securityGroupName.$error.validateUnique}">
-      <strong>Your security group will be named:</strong>
+      <strong>Your <firewall-label label="firewall"/> will be named:</strong>
       <span ng-bind="namePreview"></span>
-<!--           <input type="hidden" class="form-control input-sm"
-              ng-model="securityGroup.name"
-              validate-unique="existingSecurityGroupNames"
-              validate-ignore-case="true"
-              name="securityGroupName"
-              ng-pattern="ctrl.namePattern"
-              trigger-validation="securityGroup.subnet"
-              required/>
-      <validation-error ng-if="form.securityGroupName.$error.validateUnique && securityGroup.credentials" message="A security group named '{{namePreview}}' already exists in one or more of the selected regions"></validation-error>
-      <validation-error ng-if="form.securityGroupName.$error.pattern" message="Name must match {{ctrl.getCurrentNamePattern().toString()}}"></validation-error> -->
     </div>
   </div>
   <div class="form-group">

--- a/app/scripts/modules/azure/securityGroup/details/securityGroupDetail.controller.js
+++ b/app/scripts/modules/azure/securityGroup/details/securityGroupDetail.controller.js
@@ -3,7 +3,7 @@
 const angular = require('angular');
 import _ from 'lodash';
 
-import { CONFIRMATION_MODAL_SERVICE, SECURITY_GROUP_READER } from '@spinnaker/core';
+import { CONFIRMATION_MODAL_SERVICE, SECURITY_GROUP_READER, FirewallLabels } from '@spinnaker/core';
 
 module.exports = angular
   .module('spinnaker.azure.securityGroup.azure.details.controller', [
@@ -29,6 +29,8 @@ module.exports = angular
     $scope.state = {
       loading: true,
     };
+
+    $scope.firewallLabel = FirewallLabels.get('Firewall');
 
     function extractSecurityGroup() {
       return securityGroupReader
@@ -128,7 +130,7 @@ module.exports = angular
     };
 
     if (app.isStandalone) {
-      // we still want the edit to refresh the security group details when the modal closes
+      // we still want the edit to refresh the firewall details when the modal closes
       app.securityGroups = {
         refresh: extractSecurityGroup,
       };

--- a/app/scripts/modules/azure/securityGroup/details/securityGroupDetail.html
+++ b/app/scripts/modules/azure/securityGroup/details/securityGroupDetail.html
@@ -18,18 +18,18 @@
     <div class="actions">
       <div class="dropdown" uib-dropdown dropdown-append-to-body>
         <button type="button" class="btn btn-sm btn-primary dropdown-toggle" ng-disabled="disabled" uib-dropdown-toggle>
-          Security Group Actions <span class="caret"></span>
+          <firewall-label label="Firewall"/> Actions <span class="caret"></span>
         </button>
         <ul class="dropdown-menu" uib-dropdown-menu role="menu">
-          <li><a href ng-click="ctrl.deleteSecurityGroup()">Delete Security Group</a></li>
+          <li><a href ng-click="ctrl.deleteSecurityGroup()">Delete <firewall-label label="Firewall"/></a></li>
           <li><a href ng-click="ctrl.editInboundRules()">Edit Inbound Rules</a></li>
-          <li><a href ng-click="ctrl.cloneSecurityGroup()">Clone Security Group</a></li>
+          <li><a href ng-click="ctrl.cloneSecurityGroup()">Clone <firewall-label label="Firewall"/></a></li>
         </ul>
       </div>
     </div>
   </div>
   <div class="content" ng-if="!state.loading">
-    <collapsible-section heading="Security Group Details" expanded="true">
+    <collapsible-section heading="{{firewallLabel}} Details" expanded="true">
       <dl class="dl-horizontal dl-medium">
         <dt>ID</dt>
         <dd>{{securityGroup.id}}</dd>
@@ -37,8 +37,6 @@
         <dd><account-tag account="securityGroup.accountName"></account-tag></dd>
         <dt>Region</dt>
         <dd>{{securityGroup.region}}</dd>
-<!--         <dt>VPC:</dt>
-        <dd><vpc-tag vpc-id="securityGroup.vpcId"></vpc-tag></dd> -->
         <dt>Description:</dt>
         <dd>{{securityGroup.description}}</dd>
       </dl>

--- a/app/scripts/modules/azure/securityGroup/securityGroup.write.service.js
+++ b/app/scripts/modules/azure/securityGroup/securityGroup.write.service.js
@@ -3,7 +3,7 @@
 const angular = require('angular');
 import _ from 'lodash';
 
-import { InfrastructureCaches, TASK_EXECUTOR } from '@spinnaker/core';
+import { InfrastructureCaches, TASK_EXECUTOR, FirewallLabels } from '@spinnaker/core';
 
 module.exports = angular
   .module('spinnaker.azure.securityGroup.write.service', [require('@uirouter/angularjs').default, TASK_EXECUTOR])
@@ -17,7 +17,7 @@ module.exports = angular
       var operation = taskExecutor.executeTask({
         job: [params],
         application: application,
-        description: descriptor + ' Security Group: ' + name,
+        description: `${descriptor} ${FirewallLabels.get('Firewall')}: ${name}`,
       });
 
       InfrastructureCaches.clearCache('securityGroup');
@@ -36,7 +36,7 @@ module.exports = angular
       var operation = taskExecutor.executeTask({
         job: [params],
         application: application,
-        description: 'Delete Security Group: ' + securityGroup.name,
+        description: `Delete ${FirewallLabels.get('Firewalls')}: ${securityGroup.name}`,
       });
 
       InfrastructureCaches.clearCache('securityGroup');

--- a/app/scripts/modules/azure/serverGroup/configure/serverGroupConfiguration.service.spec.js
+++ b/app/scripts/modules/azure/serverGroup/configure/serverGroupConfiguration.service.spec.js
@@ -109,7 +109,7 @@ describe('Service: azureServerGroupConfiguration', function() {
       };
     });
 
-    it('finds matching security groups and assigns them to the filtered list the first time', function() {
+    it('finds matching firewalls and assigns them to the filtered list the first time', function() {
       this.command.region = 'westus';
       var expected = this.allSecurityGroups.azurecred1['westus'];
 
@@ -120,7 +120,7 @@ describe('Service: azureServerGroupConfiguration', function() {
       expect(this.command.viewState.securityGroupConfigured).toBeTrue;
     });
 
-    it('finds matcing security groups, sets dirty flag for subsequent time', function() {
+    it('finds matching firewalls, sets dirty flag for subsequent time', function() {
       this.command.region = 'eastus';
       this.command.backingData.filtered.securityGroups = this.allSecurityGroups.azurecred1['westus'];
       var expected = this.allSecurityGroups.azurecred1['eastus'];
@@ -153,7 +153,7 @@ describe('Service: azureServerGroupConfiguration', function() {
       expect(this.command.viewState.securityGroupConfigured).toBeTrue;
     });
 
-    it('returns no security groups if none match', function() {
+    it('returns no firewalls if none match', function() {
       this.command.region = 'eastasia';
       this.command.backingData.filtered.securityGroups = this.allSecurityGroups.azurecred1['westus'];
 

--- a/app/scripts/modules/azure/serverGroup/configure/wizard/CloneServerGroup.azure.controller.js
+++ b/app/scripts/modules/azure/serverGroup/configure/wizard/CloneServerGroup.azure.controller.js
@@ -2,7 +2,7 @@
 
 const angular = require('angular');
 
-import { SERVER_GROUP_WRITER, TASK_MONITOR_BUILDER, V2_MODAL_WIZARD_SERVICE } from '@spinnaker/core';
+import { SERVER_GROUP_WRITER, TASK_MONITOR_BUILDER, V2_MODAL_WIZARD_SERVICE, FirewallLabels } from '@spinnaker/core';
 
 module.exports = angular
   .module('spinnaker.azure.cloneServerGroup.controller', [
@@ -35,6 +35,8 @@ module.exports = angular
       advancedSettings: require('./advancedSettings/advancedSettings.html'),
     };
 
+    $scope.firewallsLabel = FirewallLabels.get('Firewalls');
+
     $scope.title = title;
 
     $scope.applicationName = application.name;
@@ -50,7 +52,7 @@ module.exports = angular
       copied: [
         'account, region, subnet, cluster name (stack, details)',
         'load balancers',
-        'security groups',
+        FirewallLabels.get('firewalls'),
         'instance type',
         'all fields on the Advanced Settings page',
       ],

--- a/app/scripts/modules/azure/serverGroup/configure/wizard/securityGroup/serverGroupSecurityGroupsSelector.directive.html
+++ b/app/scripts/modules/azure/serverGroup/configure/wizard/securityGroup/serverGroupSecurityGroupsSelector.directive.html
@@ -1,10 +1,10 @@
 <h5 class="text-center" ng-if="!command.viewState.securityGroupsConfigured">Please select an account and region.</h5>
 <div ng-if="command.viewState.securityGroupsConfigured"  ng-controller="azureServerGroupSecurityGroupsCtrl as securityGroupCtrl">
   <div class="form-group">
-    <div class="col-md-3 sm-label-right"><b>Security Groups</b></div>
+    <div class="col-md-3 sm-label-right"><b><firewall-label label="Firewalls"/></b></div>
     <div class="col-md-7">
       <ui-select ng-model="command.selectedSecurityGroup" class="form-control input-sm" on-select="securityGroupCtrl.securityGroupChanged($item)">
-        <ui-select-match placeholder="select a security group">{{$select.selected.id}}</ui-select-match>
+        <ui-select-match placeholder="select a {{firewallLabel}}">{{$select.selected.id}}</ui-select-match>
         <ui-select-choices repeat="securityGroup in command.backingData.filtered.securityGroups | anyFieldFilter: {name: $select.search, id: $select.search}">
           <span ng-bind-html="securityGroup.id | highlight: $select.search"></span>
         </ui-select-choices>
@@ -16,11 +16,11 @@
     <div class="col-md-9 col-md-offset-3">
       <p>
         <span ng-if="refreshing"><span class="fa fa-sync-alt fa-spin"></span></span>
-        Security groups
+        <firewall-label label="Firewalls"/>
         <span ng-if="!refreshing">last refreshed {{ getSecurityGroupRefreshTime() | timestamp }}</span>
         <span ng-if="refreshing"> refreshing...</span>
       </p>
-      <p>If you're not finding a security group that was recently added,
+      <p>If you're not finding a <firewall-label label="firewall"/> that was recently added,
         <a href ng-click="refreshSecurityGroups()">click here</a> to refresh the list.
       </p>
     </div>

--- a/app/scripts/modules/azure/serverGroup/configure/wizard/securityGroup/serverGroupSecurityGroupsSelector.directive.js
+++ b/app/scripts/modules/azure/serverGroup/configure/wizard/securityGroup/serverGroupSecurityGroupsSelector.directive.js
@@ -2,7 +2,7 @@
 
 const angular = require('angular');
 
-import { InfrastructureCaches } from '@spinnaker/core';
+import { FirewallLabels, InfrastructureCaches } from '@spinnaker/core';
 
 module.exports = angular
   .module('spinnaker.azure.serverGroup.configure.securityGroupSelector.directive', [])
@@ -14,6 +14,8 @@ module.exports = angular
       },
       templateUrl: require('./serverGroupSecurityGroupsSelector.directive.html'),
       link: function(scope) {
+        scope.firewallLabel = FirewallLabels.get('firewall');
+
         scope.getSecurityGroupRefreshTime = function() {
           return InfrastructureCaches.get('securityGroups').getStats().ageMax;
         };

--- a/app/scripts/modules/azure/serverGroup/configure/wizard/serverGroupWizard.html
+++ b/app/scripts/modules/azure/serverGroup/configure/wizard/serverGroupWizard.html
@@ -20,7 +20,7 @@
         <v2-wizard-page key="network-settings" label="Network Settings" mark-complete-on-view="false">
           <ng-include src="pages.networkSettings"></ng-include>
         </v2-wizard-page>
-        <v2-wizard-page key="security-groups" label="Security Groups" mark-complete-on-view="false" done="true">
+        <v2-wizard-page key="security-groups" label="{{firewallsLabel}}" mark-complete-on-view="false" done="true">
           <ng-include src="pages.securityGroups"></ng-include>
         </v2-wizard-page>
         <v2-wizard-page key="advanced-settings" label="Advanced Settings" mark-complete-on-view="false" done="true">

--- a/app/scripts/modules/azure/serverGroup/details/serverGroupDetails.azure.controller.js
+++ b/app/scripts/modules/azure/serverGroup/details/serverGroupDetails.azure.controller.js
@@ -8,6 +8,7 @@ import {
   SERVER_GROUP_READER,
   SERVER_GROUP_WARNING_MESSAGE_SERVICE,
   SERVER_GROUP_WRITER,
+  FirewallLabels,
 } from '@spinnaker/core';
 
 require('../configure/serverGroup.configure.azure.module.js');
@@ -37,6 +38,8 @@ module.exports = angular
     $scope.state = {
       loading: true,
     };
+
+    $scope.firewallsLabel = FirewallLabels.get('Firewalls');
 
     this.application = app;
 

--- a/app/scripts/modules/azure/serverGroup/details/serverGroupDetails.html
+++ b/app/scripts/modules/azure/serverGroup/details/serverGroupDetails.html
@@ -89,7 +89,7 @@
       </dl>
     </collapsible-section>
 
-    <collapsible-section heading="Security Groups">
+    <collapsible-section heading="{{firewallsLabel}}">
       <dl class="dl-horizontal dl-flex">
         <dt>Name</dt>
         <dd>{{serverGroup.securityGroupName}}</dd>

--- a/app/scripts/modules/cloudfoundry/instance/details/instanceDetails.html
+++ b/app/scripts/modules/cloudfoundry/instance/details/instanceDetails.html
@@ -105,10 +105,10 @@
         <dd ng-if="instance.externalIpAddress"><a href="http://{{instance.externalIpAddress}}" target="_blank">{{instance.externalIpAddress}}</a></dd>
       </dl>
     </collapsible-section>
-    <collapsible-section heading="Security Groups">
+    <collapsible-section heading="Firewalls">
         <ul>
           <li ng-repeat="securityGroup in instance.securityGroups | orderBy:'groupName'">
-            <a ui-sref="^.securityGroupDetails({name:securityGroup.groupName, accountId: instance.account, region: 'global', provider: instance.provider})">
+            <a ui-sref="^.firewallDetails({name:securityGroup.groupName, accountId: instance.account, region: 'global', provider: instance.provider})">
               {{securityGroup.groupName}}
             </a>
           </li>

--- a/app/scripts/modules/cloudfoundry/securityGroup/details/SecurityGroupDetailsCtrl.js
+++ b/app/scripts/modules/cloudfoundry/securityGroup/details/SecurityGroupDetailsCtrl.js
@@ -56,7 +56,7 @@ module.exports = angular
     });
 
     if (app.isStandalone) {
-      // we still want the edit to refresh the security group details when the modal closes
+      // we still want the edit to refresh the firewall details when the modal closes
       app.securityGroups = {
         refresh: extractSecurityGroup,
       };

--- a/app/scripts/modules/cloudfoundry/securityGroup/details/securityGroupDetails.html
+++ b/app/scripts/modules/cloudfoundry/securityGroup/details/securityGroupDetails.html
@@ -17,7 +17,7 @@
     </div>
   </div>
   <div class="content" ng-if="!state.loading">
-    <collapsible-section heading="Security Group Details" expanded="true">
+    <collapsible-section heading="Firewall Details" expanded="true">
       <dl class="dl-horizontal dl-medium">
         <dt>ID</dt>
         <dd>{{securityGroup.id}}</dd>

--- a/app/scripts/modules/cloudfoundry/serverGroup/configure/serverGroupConfiguration.service.js
+++ b/app/scripts/modules/cloudfoundry/serverGroup/configure/serverGroupConfiguration.service.js
@@ -34,7 +34,7 @@ module.exports = angular
           configureImages(command);
 
           if (command.securityGroups && command.securityGroups.length) {
-            // Verify all security groups are accounted for; otherwise, try refreshing security groups cache.
+            // Verify all firewalls are accounted for; otherwise, try refreshing firewalls cache.
             var securityGroupIds = _.map(getSecurityGroups(command), 'id');
             if (_.intersection(command.securityGroups, securityGroupIds).length < command.securityGroups.length) {
               securityGroupReloader = refreshSecurityGroups(command, true);
@@ -119,17 +119,17 @@ module.exports = angular
         }
       }
 
-      // Only include explicit security group options in the pulldown list.
+      // Only include explicit firewall options in the pulldown list.
       command.backingData.filtered.securityGroups = _.filter(newSecurityGroups, function(securityGroup) {
         return !_.isEmpty(securityGroup.targetTags);
       });
 
-      // Identify implicit security groups so they can be optionally listed in a read-only state.
+      // Identify implicit firewalls so they can be optionally listed in a read-only state.
       command.implicitSecurityGroups = _.filter(newSecurityGroups, function(securityGroup) {
         return _.isEmpty(securityGroup.targetTags);
       });
 
-      // Only include explicitly-selected security groups in the body of the command.
+      // Only include explicitly-selected firewalls in the body of the command.
       command.securityGroups = _.difference(command.securityGroups, _.map(command.implicitSecurityGroups, 'id'));
 
       return results;

--- a/app/scripts/modules/cloudfoundry/serverGroup/details/serverGroupDetails.html
+++ b/app/scripts/modules/cloudfoundry/serverGroup/details/serverGroupDetails.html
@@ -111,10 +111,10 @@
         <dd>{{ctrl.getNetwork()}}</dd>
       </dl>
     </collapsible-section>
-    <collapsible-section heading="Security Groups">
+    <collapsible-section heading="Firewalls">
       <ul>
         <li ng-repeat="securityGroup in securityGroups | orderBy:'name'">
-          <a ui-sref="^.securityGroupDetails({name: securityGroup.name, accountId: securityGroup.accountName, region: serverGroup.region, provider: serverGroup.type})">
+          <a ui-sref="^.firewallDetails({name: securityGroup.name, accountId: securityGroup.accountName, region: serverGroup.region, provider: serverGroup.type})">
             {{securityGroup.name}}
           </a>
         </li>

--- a/app/scripts/modules/core/src/application/application.model.spec.ts
+++ b/app/scripts/modules/core/src/application/application.model.spec.ts
@@ -228,7 +228,7 @@ describe('Application Model', function() {
       expect(application.defaultRegions.gce).toBe('us-central-1');
     });
 
-    it('sets default credentials and region from security group', function() {
+    it('sets default credentials and region from firewall', function() {
       const serverGroups: any[] = [],
         loadBalancers: ILoadBalancer[] = [],
         securityGroupsByApplicationName: any[] = [

--- a/app/scripts/modules/core/src/application/application.state.provider.ts
+++ b/app/scripts/modules/core/src/application/application.state.provider.ts
@@ -55,7 +55,7 @@ export class ApplicationStateProvider implements IServiceProvider {
   /**
    * Adds an inspector view to all insight states. Adding an insight detail state makes that view available to all
    * parent insight views, so, for example, adding the load balancer details state makes it available to cluster,
-   * security group, and load balancer insight parent states
+   * firewall, and load balancer insight parent states
    * @param state
    */
   public addInsightDetailState(state: INestedState): void {

--- a/app/scripts/modules/core/src/application/config/applicationCacheManagement.directive.html
+++ b/app/scripts/modules/core/src/application/config/applicationCacheManagement.directive.html
@@ -29,7 +29,7 @@
   </div>
 </div>
 <div class="row" ng-if="vm.hasCache('securityGroups')">
-  <div class="col-md-3 col-md-offset-1">Security Groups</div>
+  <div class="col-md-3 col-md-offset-1"><firewall-label label="Firewalls"/></div>
   <div class="col-md-3">{{vm.getCacheInfo('securityGroups').ageMax | timestamp}}</div>
   <div class="col-md-1 text-center">
     <a href ng-click="vm.refreshCache('securityGroups')">

--- a/app/scripts/modules/core/src/application/config/deleteApplicationSection.directive.html
+++ b/app/scripts/modules/core/src/application/config/deleteApplicationSection.directive.html
@@ -1,6 +1,6 @@
 <p ng-if="!vm.hasServerGroups">
   Deleting the application only removes the associated metadata around the application.
-  It will <strong>not</strong> delete any security groups, load balancers, or pipeline configurations you
+  It will <strong>not</strong> delete any <firewall-label label="firewalls"/>, load balancers, or pipeline configurations you
   may have created.
 </p>
 

--- a/app/scripts/modules/core/src/application/service/applicationDataSource.ts
+++ b/app/scripts/modules/core/src/application/service/applicationDataSource.ts
@@ -5,6 +5,7 @@ import { Subject, Subscription } from 'rxjs';
 
 import { Application } from '../application.model';
 import { IEntityTags } from 'core/domain/IEntityTags';
+import { FirewallLabels } from 'core/securityGroup/label/FirewallLabels';
 
 export interface IDataSourceConfig {
   /**
@@ -285,6 +286,7 @@ export class ApplicationDataSource implements IDataSourceConfig {
     if (!config.label && this.$filter) {
       this.label = this.$filter('robotToHuman')(config.key);
     }
+    this.label = FirewallLabels.get(this.label);
 
     if (!config.activeState && this.sref) {
       this.activeState = '**' + this.sref + '.**';

--- a/app/scripts/modules/core/src/config/settings.ts
+++ b/app/scripts/modules/core/src/config/settings.ts
@@ -67,6 +67,7 @@ export interface ISpinnakerSettings {
   defaultInstancePort: number;
   defaultProviders: string[];
   defaultTimeZone: string; // see http://momentjs.com/timezone/docs/#/data-utilities/
+  dockerInsights: IDockerInsightSettings;
   entityTags?: {
     maxUrlLength?: number;
   };
@@ -95,7 +96,7 @@ export interface ISpinnakerSettings {
   resetToOriginal: () => void;
   searchVersion: 1 | 2;
   triggerTypes: string[];
-  dockerInsights: IDockerInsightSettings;
+  useClassicFirewallLabels: boolean;
 }
 
 export const SETTINGS: ISpinnakerSettings = (window as any).spinnakerSettings;

--- a/app/scripts/modules/core/src/core.module.ts
+++ b/app/scripts/modules/core/src/core.module.ts
@@ -58,6 +58,9 @@ import { SERVERGROUP_MODULE } from './serverGroup/serverGroup.module';
 import { SERVER_GROUP_MANAGER_MODULE } from './serverGroupManager/serverGroupManager.module';
 import { STYLEGUIDE_MODULE } from './styleguide/styleguide.module';
 import { SUBNET_MODULE } from './subnet/subnet.module';
+
+import { FIREWALL_LABEL_COMPONENT } from 'core/securityGroup/label/firewallLabel.component';
+
 import { WHATS_NEW_MODULE } from './whatsNew/whatsNew.module';
 import { WIDGETS_MODULE } from './widgets/widgets.module';
 
@@ -98,6 +101,7 @@ module(CORE_MODULE, [
 
   ENTITY_TAGS_MODULE,
 
+  FIREWALL_LABEL_COMPONENT,
   require('./forms/forms.module').name,
 
   HEALTH_COUNTS_MODULE,
@@ -130,6 +134,7 @@ module(CORE_MODULE, [
   require('./securityGroup/securityGroup.module').name,
   SERVERGROUP_MODULE,
   SERVER_GROUP_MANAGER_MODULE,
+  STYLEGUIDE_MODULE,
   SUBNET_MODULE,
 
   require('./task/task.module').name,
@@ -140,7 +145,6 @@ module(CORE_MODULE, [
   WIDGETS_MODULE,
 
   require('./validation/validation.module').name,
-  STYLEGUIDE_MODULE,
 ]).run(() => {
   // initialize all the stateful services
   State.initialize();

--- a/app/scripts/modules/core/src/entityTag/entityTags.help.ts
+++ b/app/scripts/modules/core/src/entityTag/entityTags.help.ts
@@ -23,13 +23,13 @@ const helpContents: any[] = [
   },
   {
     key: 'entityTags.securityGroup.notice',
-    contents: `<p>Notices provide additional context for a security group. When present, an info icon
-      <i class="notification fa fa-flag"></i> will be displayed in the security groups view next to the security group.</p>`,
+    contents: `<p>Notices provide additional context for a {{firewall}}. When present, an info icon
+      <i class="notification fa fa-flag"></i> will be displayed in the {{firewalls}} view next to the {{firewall}}.</p>`,
   },
   {
     key: 'entityTags.securityGroup.alert',
-    contents: `<p>Alerts indicate an issue with a security group. When present, an alert icon
-      <i class="notification fa fa-exclamation-triangle"></i> will be displayed in the security groups view next to the security group.</p>`,
+    contents: `<p>Alerts indicate an issue with a {{firewall}}. When present, an alert icon
+      <i class="notification fa fa-exclamation-triangle"></i> will be displayed in the {{firewall}} view next to the {{firewall}}.</p>`,
   },
 ];
 

--- a/app/scripts/modules/core/src/help/help.contents.ts
+++ b/app/scripts/modules/core/src/help/help.contents.ts
@@ -37,16 +37,15 @@ const helpContents: { [key: string]: string } = {
       </ul>
       <p>You can search for multiple words or word fragments. For instance, to find all load balancers in a prod stack with "canary" in the details, enter <samp>prod canary</samp>.</p>`,
   'securityGroup.search': `
-      Quickly filter the displayed security groups by the following fields:
+      Filter by the following fields:
       <ul>
         <li>VPC (prefixed, e.g. <samp>vpc:main</samp>)
-        <li>Security Group Name</li>
+        <li>Name</li>
         <li>Server Group Name</li>
         <li>Load Balancer Name</li>
         <li>Region</li>
         <li>Account</li>
-      </ul>
-      <p>You can search for multiple words or word fragments. For instance, to find all security groups in a prod stack with "canary" in the details, enter <samp>prod canary</samp>.</p>`,
+      </ul>`,
   'executions.search': `
       Quickly filter the displayed executions by the following fields:
       <ul>

--- a/app/scripts/modules/core/src/help/helpContents.registry.ts
+++ b/app/scripts/modules/core/src/help/helpContents.registry.ts
@@ -1,3 +1,5 @@
+import { FirewallLabels } from 'core/securityGroup/label';
+
 export class HelpContentsRegistry {
   private static helpFields: Map<string, string> = new Map<string, string>();
   private static overrides: Set<string> = new Set<string>();
@@ -8,7 +10,12 @@ export class HelpContentsRegistry {
    * @returns the configured help value, or null
    */
   public static getHelpField(key: string): string {
-    return this.helpFields.get(key) || null;
+    let contents = this.helpFields.get(key);
+    if (contents) {
+      // TODO: remove this if the FirewallLabels feature ever goes away
+      contents = contents.replace(/{{(.+?)}}/g, (_ignored, match) => FirewallLabels.get(match));
+    }
+    return contents || null;
   }
 
   /**

--- a/app/scripts/modules/core/src/history/recentHistory.service.ts
+++ b/app/scripts/modules/core/src/history/recentHistory.service.ts
@@ -37,6 +37,14 @@ export class RecentHistoryService {
 
   public getItems(type: any): IRecentHistoryEntry[] {
     const replacements: ICacheEntryStateMigrator[] = [
+      {
+        state: 'securityGroup',
+        replacement: 'firewall',
+      },
+      {
+        state: 'securityGroupDetails',
+        replacement: 'firewallDetails',
+      },
       // example: replace "application.executions" with "application.pipelines.executions"
       // {
       //   state: 'application.executions',

--- a/app/scripts/modules/core/src/navigation/state.provider.ts
+++ b/app/scripts/modules/core/src/navigation/state.provider.ts
@@ -69,7 +69,7 @@ export class StateConfigProvider implements IServiceProvider {
    * @param base, e.g. "/applications/{application}"
    * @param replacement, e.g. "/applications/{application}/clusters"
    */
-  public addRewriteRule(base: string, replacement: string) {
+  public addRewriteRule(base: string | RegExp, replacement: string | Function) {
     this.$urlRouterProvider.when(base, replacement);
   }
 

--- a/app/scripts/modules/core/src/navigation/urlBuilder.service.ts
+++ b/app/scripts/modules/core/src/navigation/urlBuilder.service.ts
@@ -217,7 +217,7 @@ class ProjectsUrlBuilder implements IUrlBuilder {
 
 class SecurityGroupsUrlBuilder implements IUrlBuilder {
   public build(input: IUrlBuilderInput, $state: StateService) {
-    const href: string = $state.href('home.securityGroupDetails', {
+    const href: string = $state.href('home.firewallDetails', {
       accountId: input.account,
       region: input.region,
       name: input.name,

--- a/app/scripts/modules/core/src/search/infrastructure/infrastructure.controller.js
+++ b/app/scripts/modules/core/src/search/infrastructure/infrastructure.controller.js
@@ -4,6 +4,7 @@ import _ from 'lodash';
 
 const angular = require('angular');
 
+import { FirewallLabels } from 'core/securityGroup/label';
 import { SEARCH_RANK_FILTER } from '../searchRank.filter';
 import { CACHE_INITIALIZER_SERVICE } from 'core/cache/cacheInitializer.service';
 import { OVERRIDE_REGISTRY } from 'core/overrideRegistry/override.registry';
@@ -45,6 +46,8 @@ module.exports = angular
     $state,
   ) {
     var search = infrastructureSearchService.getSearcher();
+
+    $scope.firewallsLabel = FirewallLabels.get('firewalls');
 
     $scope.categories = [];
     $scope.projects = [];

--- a/app/scripts/modules/core/src/search/infrastructure/infrastructure.html
+++ b/app/scripts/modules/core/src/search/infrastructure/infrastructure.html
@@ -6,7 +6,7 @@
         <span class="search-label">Search</span>
         <input type="search"
                class="form-control input-lg"
-               placeholder="projects, applications, clusters, load balancers, server groups, security groups"
+               placeholder="projects, applications, clusters, load balancers, server groups, {{firewallsLabel}}"
                autofocus
                ng-model-options="{ updateOn: 'default blur', debounce: { 'default': 300, 'blur': 0 } }"
                ng-model="query"/>

--- a/app/scripts/modules/core/src/search/widgets/Search.tsx
+++ b/app/scripts/modules/core/src/search/widgets/Search.tsx
@@ -6,6 +6,7 @@ import { Key, ITag, TagList } from 'core/widgets';
 import { IFilterType, SearchFilterTypeRegistry } from './SearchFilterTypeRegistry';
 import { Filters, IFiltersLayout } from './Filters';
 import { Filter } from './Filter';
+import { FirewallLabels } from 'core';
 
 import './search.less';
 
@@ -321,7 +322,9 @@ export class Search extends React.Component<ISearchProps, ISearchState> {
               ref={this.refCallback}
               autoFocus={true}
               className="search__input-control"
-              placeholder="projects, applications, clusters, load balancers, server groups, security groups"
+              placeholder={`projects, applications, clusters, load balancers, server groups, ${FirewallLabels.get(
+                'firewalls',
+              )}`}
               onBlur={this.handleBlur}
               onChange={this.handleChange}
               onFocus={this.handleFocus}

--- a/app/scripts/modules/core/src/securityGroup/AllSecurityGroupsCtrl.js
+++ b/app/scripts/modules/core/src/securityGroup/AllSecurityGroupsCtrl.js
@@ -6,6 +6,7 @@ import { CloudProviderRegistry } from 'core/cloudProvider';
 import { SKIN_SELECTION_SERVICE } from 'core/cloudProvider/skinSelection/skinSelection.service';
 import { PROVIDER_SELECTION_SERVICE } from 'core/cloudProvider/providerSelection/providerSelection.service';
 import { SETTINGS } from 'core/config/settings';
+import { FirewallLabels } from './label/FirewallLabels';
 import { SecurityGroupState } from 'core/state';
 
 const angular = require('angular');
@@ -48,6 +49,7 @@ module.exports = angular
     };
 
     this.groupingsTemplate = require('./groupings.html');
+    this.firewallLabel = FirewallLabels.get('Firewall');
 
     let updateSecurityGroups = () => {
       $scope.$evalAsync(() => {

--- a/app/scripts/modules/core/src/securityGroup/SecurityGroupDetails.tsx
+++ b/app/scripts/modules/core/src/securityGroup/SecurityGroupDetails.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import { Overridable, IOverridableProps } from 'core/overrideRegistry';
+import { FirewallLabels } from 'core/securityGroup/label/FirewallLabels';
 
 export interface ISecurityGroupDetailsProps extends IOverridableProps {}
 
 @Overridable('securityGroup.details')
 export class SecurityGroupDetails extends React.Component<ISecurityGroupDetailsProps> {
   public render() {
-    return <h3>Security Group Details</h3>;
+    return <h3>{FirewallLabels.get('Firewalls')} Details</h3>;
   }
 }

--- a/app/scripts/modules/core/src/securityGroup/all.html
+++ b/app/scripts/modules/core/src/securityGroup/all.html
@@ -22,8 +22,8 @@
     <div class="application-actions">
       <button class="btn btn-sm btn-default" ng-click="ctrl.createSecurityGroup()">
         <span class="glyphicon glyphicon-plus-sign visible-lg-inline"></span>
-        <span class="glyphicon glyphicon-plus-sign visible-md-inline visible-sm-inline" uib-tooltip="Create Security Group"></span>
-        <span class="visible-lg-inline">Create Security Group</span>
+        <span class="glyphicon glyphicon-plus-sign visible-md-inline visible-sm-inline" uib-tooltip="Create {{firewallLabel}}"></span>
+        <span class="visible-lg-inline">Create <firewall-label label="Firewall"/></span>
       </button>
     </div>
   </div>

--- a/app/scripts/modules/core/src/securityGroup/filter/SecurityGroupFilterService.spec.js
+++ b/app/scripts/modules/core/src/securityGroup/filter/SecurityGroupFilterService.spec.js
@@ -27,7 +27,7 @@ describe('Service: securityGroupFilterService', function() {
     State.SecurityGroupState.filterModel.asFilterModel.clearFilters();
   });
 
-  describe('Updating the security group group', function() {
+  describe('Updating the firewall group', function() {
     it('no filter: should be transformed', function() {
       var expected = [
         {

--- a/app/scripts/modules/core/src/securityGroup/groupings.html
+++ b/app/scripts/modules/core/src/securityGroup/groupings.html
@@ -6,7 +6,7 @@
                         parent-heading="group.heading"></security-group-pod>
   </div>
   <div ng-if="groups.length === 0">
-    <h4 class="text-center">No security groups match the filters you've selected.</h4>
+    <h4 class="text-center">No <firewall-label label="firewalls"/> match the filters you've selected.</h4>
   </div>
 </div>
 <div ng-if="!ctrl.initialized" class="horizontal center spinner-container">

--- a/app/scripts/modules/core/src/securityGroup/index.ts
+++ b/app/scripts/modules/core/src/securityGroup/index.ts
@@ -1,2 +1,3 @@
 export * from './securityGroupReader.service';
 export * from './securityGroupWriter.service';
+export * from './label/FirewallLabels';

--- a/app/scripts/modules/core/src/securityGroup/label/FirewallLabels.ts
+++ b/app/scripts/modules/core/src/securityGroup/label/FirewallLabels.ts
@@ -1,0 +1,26 @@
+import { SETTINGS } from 'core/config/settings';
+
+export class FirewallLabels {
+  private static labels: Map<string, string> = new Map<string, string>();
+
+  /**
+   * Returns the overridden label, or the label if no override is registered
+   */
+  public static get(label: string): string {
+    return this.labels.get(label) || label;
+  }
+
+  /**
+   * Adds a label to the registry.
+   */
+  public static register(label: string, translation: string): void {
+    this.labels.set(label, translation);
+  }
+}
+
+if (SETTINGS.useClassicFirewallLabels) {
+  FirewallLabels.register('firewall', 'security group');
+  FirewallLabels.register('firewalls', 'security groups');
+  FirewallLabels.register('Firewall', 'Security Group');
+  FirewallLabels.register('Firewalls', 'Security Groups');
+}

--- a/app/scripts/modules/core/src/securityGroup/label/firewallLabel.component.ts
+++ b/app/scripts/modules/core/src/securityGroup/label/firewallLabel.component.ts
@@ -1,0 +1,20 @@
+import { IComponentController, module } from 'angular';
+import { FirewallLabels } from './FirewallLabels';
+
+class LabelCtrl implements IComponentController {
+  public value: string;
+  private label: string;
+
+  public $onInit() {
+    this.value = FirewallLabels.get(this.label);
+  }
+}
+
+export const FIREWALL_LABEL_COMPONENT = 'spinnaker.core.firewall.label.component';
+module(FIREWALL_LABEL_COMPONENT, []).component('firewallLabel', {
+  bindings: {
+    label: '@',
+  },
+  controller: LabelCtrl,
+  template: `<span>{{$ctrl.value}}</span>`,
+});

--- a/app/scripts/modules/core/src/securityGroup/label/index.ts
+++ b/app/scripts/modules/core/src/securityGroup/label/index.ts
@@ -1,0 +1,1 @@
+export * from './FirewallLabels';

--- a/app/scripts/modules/core/src/securityGroup/securityGroup.dataSource.ts
+++ b/app/scripts/modules/core/src/securityGroup/securityGroup.dataSource.ts
@@ -35,8 +35,9 @@ module(SECURITY_GROUP_DATA_SOURCE, [
 
     applicationDataSourceRegistry.registerDataSource({
       key: 'securityGroups',
+      label: 'Firewalls',
       category: INFRASTRUCTURE_KEY,
-      sref: '.insight.securityGroups',
+      sref: '.insight.firewalls',
       optional: true,
       icon: 'fa fa-xs fa-fw fa-lock',
       loader: loadSecurityGroups,

--- a/app/scripts/modules/core/src/securityGroup/securityGroup.html
+++ b/app/scripts/modules/core/src/securityGroup/securityGroup.html
@@ -1,5 +1,5 @@
 <div class="pod-subgroup clickable clickable-row clearfix"
-     ui-sref=".securityGroupDetails(srefParams)"
+     ui-sref=".firewallDetails(srefParams)"
      ui-sref-active="active">
   <h6 class="sticky-header-2 horizontal middle">
     <span class="glyphicon glyphicon-transfer"></span>&nbsp;

--- a/app/scripts/modules/core/src/securityGroup/securityGroupReader.service.spec.ts
+++ b/app/scripts/modules/core/src/securityGroup/securityGroupReader.service.spec.ts
@@ -52,7 +52,7 @@ describe('Service: securityGroupReader', function() {
     }),
   );
 
-  it('attaches load balancer to security group usages', function() {
+  it('attaches load balancer to firewall usages', function() {
     let data: any[] = null;
 
     const application: Application = applicationModelBuilder.createApplication(
@@ -98,7 +98,7 @@ describe('Service: securityGroupReader', function() {
     expect(group.usages.loadBalancers[0]).toEqual({ name: application.getDataSource('loadBalancers').data[0].name });
   });
 
-  it('adds security group names across accounts, falling back to the ID if none found', function() {
+  it('adds firewall names across accounts, falling back to the ID if none found', function() {
     let details: ISecurityGroupDetail = null;
     const application: Application = applicationModelBuilder.createApplication('app');
     application['securityGroupsIndex'] = {
@@ -129,7 +129,7 @@ describe('Service: securityGroupReader', function() {
     expect(details.securityGroupRules[2].securityGroup.inferredName).toBeFalsy();
   });
 
-  it('should clear cache, then reload security groups and try again if a security group is not found', function() {
+  it('should clear cache, then reload firewalls and try again if a firewall is not found', function() {
     let data: ISecurityGroup[] = null;
     const application: Application = applicationModelBuilder.createApplication(
       'app',

--- a/app/scripts/modules/core/src/securityGroup/securityGroupReader.service.ts
+++ b/app/scripts/modules/core/src/securityGroup/securityGroupReader.service.ts
@@ -141,7 +141,7 @@ export class SecurityGroupReader {
             }
             securityGroups.push(securityGroup);
           } catch (e) {
-            this.$log.warn('could not attach security group to load balancer:', loadBalancer.name, securityGroupId, e);
+            this.$log.warn('could not attach firewall to load balancer:', loadBalancer.name, securityGroupId, e);
             notFoundCaught = true;
           }
         });
@@ -163,7 +163,7 @@ export class SecurityGroupReader {
         SecurityGroupReader.attachUsageFields(match);
         securityGroups.push(match);
       } catch (e) {
-        this.$log.warn('could not initialize application security group:', securityGroup);
+        this.$log.warn('could not initialize application firewall:', securityGroup);
         notFoundCaught = true;
       }
     });
@@ -193,7 +193,7 @@ export class SecurityGroupReader {
             }
             securityGroups.push(securityGroup);
           } catch (e) {
-            this.$log.warn('could not attach security group to server group:', serverGroup.name, securityGroupId);
+            this.$log.warn('could not attach firewall to server group:', serverGroup.name, securityGroupId);
             notFoundCaught = true;
           }
         });
@@ -240,7 +240,7 @@ export class SecurityGroupReader {
         data = nameBasedGroups.securityGroups;
       }
     } else {
-      // filter down to empty (name-based only) security groups - we will repopulate usages
+      // filter down to empty (name-based only) firewalls - we will repopulate usages
       data = application
         .getDataSource('securityGroups')
         .data.filter(
@@ -263,7 +263,7 @@ export class SecurityGroupReader {
 
     data = uniq(data);
     if (notFoundCaught && retryIfNotFound) {
-      this.$log.warn('Clearing security group cache and trying again...');
+      this.$log.warn('Clearing firewall cache and trying again...');
       return this.clearCacheAndRetryAttachingSecurityGroups(application, nameBasedSecurityGroups);
     } else {
       data.forEach((sg: ISecurityGroup) => this.addNamePartsToSecurityGroup(sg));
@@ -421,7 +421,7 @@ export class SecurityGroupReader {
       .then((searchResults: ISearchResults<ISecurityGroupSearchResult>) => {
         let result: ISecurityGroup[] = [];
         if (!searchResults || !searchResults.results) {
-          this.$log.warn('WARNING: Gate security group endpoint appears to be down.');
+          this.$log.warn('WARNING: Gate firewall endpoint appears to be down.');
         } else {
           result = filter(searchResults.results, { application: applicationName });
         }

--- a/app/scripts/modules/core/src/securityGroup/securityGroupSearchResultType.tsx
+++ b/app/scripts/modules/core/src/securityGroup/securityGroupSearchResultType.tsx
@@ -1,3 +1,4 @@
+import { FirewallLabels } from 'core/securityGroup/label';
 import * as React from 'react';
 
 import {
@@ -32,7 +33,7 @@ export interface ISecurityGroupSearchResult extends ISearchResult {
 class SecurityGroupsSearchResultType extends SearchResultType<ISecurityGroupSearchResult> {
   public id = 'securityGroups';
   public order = 6;
-  public displayName = 'Security Groups';
+  public displayName = FirewallLabels.get('Firewalls');
   public iconClass = 'fa fa-exchange-alt';
 
   private cols: { [key: string]: ISearchColumn } = {

--- a/app/scripts/modules/core/src/securityGroup/securityGroupWriter.service.ts
+++ b/app/scripts/modules/core/src/securityGroup/securityGroupWriter.service.ts
@@ -3,6 +3,7 @@ import { IPromise, module } from 'angular';
 import { Application } from 'core/application/application.model';
 import { InfrastructureCaches } from 'core/cache/infrastructureCaches';
 import { ISecurityGroup, ITask } from 'core/domain';
+import { FirewallLabels } from 'core/securityGroup/label';
 
 import { IJob, TASK_EXECUTOR, TaskExecutor } from 'core/task/taskExecutor';
 
@@ -29,7 +30,7 @@ export class SecurityGroupWriter {
     const operation: IPromise<ITask> = this.taskExecutor.executeTask({
       job: [params],
       application,
-      description: `Delete Security Group: ${securityGroup.name}`,
+      description: `Delete ${FirewallLabels.get('Firewall')}: ${securityGroup.name}`,
     });
     InfrastructureCaches.clearCache('securityGroups');
 
@@ -49,7 +50,7 @@ export class SecurityGroupWriter {
     const operation: IPromise<ITask> = this.taskExecutor.executeTask({
       job: [job],
       application,
-      description: `${description} Security Group: ${securityGroup.name}`,
+      description: `${description} ${FirewallLabels.get('Firewall')}: ${securityGroup.name}`,
     });
 
     InfrastructureCaches.clearCache('securityGroups');

--- a/app/scripts/modules/core/src/serverGroup/serverGroupWriter.service.ts
+++ b/app/scripts/modules/core/src/serverGroup/serverGroupWriter.service.ts
@@ -2,6 +2,7 @@ import { module } from 'angular';
 
 import { Application } from 'core/application/application.model';
 import { ISecurityGroup, IServerGroup, ITask } from 'core/domain';
+import { FirewallLabels } from 'core/securityGroup/label';
 import { IServerGroupCommand } from './configure/common/serverGroupCommandBuilder.service';
 import { IMoniker, NameUtils } from 'core/naming';
 import { IJob, TASK_EXECUTOR, TaskExecutor } from 'core/task/taskExecutor';
@@ -170,7 +171,7 @@ export class ServerGroupWriter {
     return this.taskExecutor.executeTask({
       job: [job],
       application,
-      description: `Update security groups for ${serverGroup.name}`,
+      description: `Update ${FirewallLabels.get('firewalls')} for ${serverGroup.name}`,
     });
   }
 }

--- a/app/scripts/modules/ecs/serverGroup/details/serverGroupDetails.ecs.controller.js
+++ b/app/scripts/modules/ecs/serverGroup/details/serverGroupDetails.ecs.controller.js
@@ -2,6 +2,7 @@
 
 const angular = require('angular');
 import { chain, filter, find, has, isEmpty } from 'lodash';
+import { FirewallLabels } from 'root/app/scripts/modules/core/src';
 
 import { ECS_SERVER_GROUP_TRANSFORMER } from '../serverGroup.transformer';
 
@@ -45,6 +46,8 @@ module.exports = angular
     this.state = {
       loading: true,
     };
+
+    this.firewallsLabel = FirewallLabels.get('Firewalls');
 
     this.application = app;
 

--- a/app/scripts/modules/ecs/serverGroup/details/serverGroupDetails.html
+++ b/app/scripts/modules/ecs/serverGroup/details/serverGroupDetails.html
@@ -146,7 +146,7 @@
         </dd>
       </dl>
     </collapsible-section>
-    <collapsible-section heading="Security Groups" expanded="false">
+    <collapsible-section heading="{{ctrl.firewallsLabel}}" expanded="false">
       <ul>
         <li ng-repeat="securityGroup in ctrl.serverGroup.securityGroups">
           {{securityGroup}}

--- a/app/scripts/modules/google/src/help/gce.help.ts
+++ b/app/scripts/modules/google/src/help/gce.help.ts
@@ -126,7 +126,7 @@ const helpContents: { [key: string]: string } = {
   'gce.serverGroup.securityGroups.implicit':
     'Firewall rules with no target tags defined will permit incoming connections that match the ingress rules to all instances in the network.',
   'gce.serverGroup.securityGroups.targetTags':
-    'This security group will be associated with this server group only if a target tag is selected.',
+    'This {{firewall}} rule will be associated with this server group only if a target tag is selected.',
   'gce.serverGroup.autoscaling.targetCPUUsage':
     'Autoscaling adds or removes VMs in the group to maintain this level of CPU usage on each VM.',
   'gce.serverGroup.autoscaling.targetHTTPLoadBalancingUsage':

--- a/app/scripts/modules/google/src/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/google/src/instance/details/instance.details.controller.js
@@ -12,6 +12,7 @@ import {
 } from '@spinnaker/core';
 
 import { GCE_HTTP_LOAD_BALANCER_UTILS } from 'google/loadBalancer/httpLoadBalancerUtils.service';
+import { FirewallLabels } from 'root/app/scripts/modules/core/src';
 
 module.exports = angular
   .module('spinnaker.instance.detail.gce.controller', [
@@ -40,6 +41,8 @@ module.exports = angular
   ) {
     // needed for standalone instances
     $scope.detailsTemplateUrl = CloudProviderRegistry.getValue('gce', 'instance.detailsTemplateUrl');
+
+    $scope.firewallsLabel = FirewallLabels.get('Firewalls');
 
     $scope.state = {
       loading: true,

--- a/app/scripts/modules/google/src/instance/details/instanceDetails.html
+++ b/app/scripts/modules/google/src/instance/details/instanceDetails.html
@@ -145,10 +145,10 @@
         </dd>
       </dl>
     </collapsible-section>
-    <collapsible-section heading="Security Groups">
+    <collapsible-section heading="{{firewallsLabel}}">
         <ul>
           <li ng-repeat="securityGroup in instance.securityGroups | orderBy:'groupName'">
-            <a ui-sref="^.securityGroupDetails({name:securityGroup.groupName, accountId: instance.account, region: 'global', provider: instance.provider})">
+            <a ui-sref="^.firewallDetails({name:securityGroup.groupName, accountId: instance.account, region: 'global', provider: instance.provider})">
               {{securityGroup.groupName}}
             </a>
           </li>

--- a/app/scripts/modules/google/src/securityGroup/clone/cloneSecurityGroup.controller.js
+++ b/app/scripts/modules/google/src/securityGroup/clone/cloneSecurityGroup.controller.js
@@ -3,7 +3,7 @@
 const angular = require('angular');
 import _ from 'lodash';
 
-import { AccountService } from '@spinnaker/core';
+import { AccountService, FirewallLabels } from '@spinnaker/core';
 
 module.exports = angular
   .module('spinnaker.google.securityGroup.clone.controller', [
@@ -24,6 +24,8 @@ module.exports = angular
       sourceFilters: require('../configure/createSecurityGroupSourceFilters.html'),
       ingress: require('../configure/createSecurityGroupIngress.html'),
     };
+
+    $scope.firewallLabel = FirewallLabels.get('Firewall');
 
     angular.extend(
       this,

--- a/app/scripts/modules/google/src/securityGroup/clone/cloneSecurityGroup.html
+++ b/app/scripts/modules/google/src/securityGroup/clone/cloneSecurityGroup.html
@@ -1,5 +1,5 @@
 <ng-form name="form" novalidate class="gce-security-group-wizard">
-  <v2-modal-wizard heading="Clone Security Group" task-monitor="taskMonitor" dismiss="$dismiss()">
+  <v2-modal-wizard heading="Clone {{firewallLabel}}" task-monitor="taskMonitor" dismiss="$dismiss()">
     <v2-wizard-page key="Location" label="Location">
       <ng-include src="pages.location"></ng-include>
     </v2-wizard-page>

--- a/app/scripts/modules/google/src/securityGroup/configure/ConfigSecurityGroupMixin.controller.js
+++ b/app/scripts/modules/google/src/securityGroup/configure/ConfigSecurityGroupMixin.controller.js
@@ -4,6 +4,7 @@ const angular = require('angular');
 import _ from 'lodash';
 
 import {
+  FirewallLabels,
   NETWORK_READ_SERVICE,
   SECURITY_GROUP_READER,
   SECURITY_GROUP_WRITER,
@@ -138,10 +139,10 @@ module.exports = angular
         vpcId: $scope.securityGroup.vpcId,
         provider: 'gce',
       };
-      if (!$state.includes('**.securityGroupDetails')) {
-        $state.go('.securityGroupDetails', newStateParams);
+      if (!$state.includes('**.firewallDetails')) {
+        $state.go('.firewallDetails', newStateParams);
       } else {
-        $state.go('^.securityGroupDetails', newStateParams);
+        $state.go('^.firewallDetails', newStateParams);
       }
     }
 
@@ -152,7 +153,7 @@ module.exports = angular
 
     $scope.taskMonitor = taskMonitorBuilder.buildTaskMonitor({
       application: application,
-      title: 'Creating your security group',
+      title: `Creating your ${FirewallLabels.get('firewall')}`,
       modalInstance: $uibModalInstance,
       onTaskComplete: onTaskComplete,
     });

--- a/app/scripts/modules/google/src/securityGroup/configure/createSecurityGroup.controller.js
+++ b/app/scripts/modules/google/src/securityGroup/configure/createSecurityGroup.controller.js
@@ -2,7 +2,7 @@
 
 const angular = require('angular');
 
-import { AccountService, InfrastructureCaches } from '@spinnaker/core';
+import { AccountService, FirewallLabels, InfrastructureCaches } from '@spinnaker/core';
 
 module.exports = angular
   .module('spinnaker.gce.securityGroup.create.controller', [require('@uirouter/angularjs').default])

--- a/app/scripts/modules/google/src/securityGroup/configure/createSecurityGroup.html
+++ b/app/scripts/modules/google/src/securityGroup/configure/createSecurityGroup.html
@@ -1,5 +1,5 @@
 <ng-form role="form" name="form" novalidate class="gce-security-group-wizard">
-  <v2-modal-wizard heading="Create New Security Group" task-monitor="taskMonitor" dismiss="$dismiss()">
+  <v2-modal-wizard heading="Create New {{firewallLabel}}" task-monitor="taskMonitor" dismiss="$dismiss()">
     <v2-wizard-page key="Location" label="Location">
       <ng-include src="pages.location"></ng-include>
     </v2-wizard-page>

--- a/app/scripts/modules/google/src/securityGroup/configure/createSecurityGroupIngress.html
+++ b/app/scripts/modules/google/src/securityGroup/configure/createSecurityGroupIngress.html
@@ -3,7 +3,7 @@
       <div class="col-md-12" ng-if="state.removedRules.length">
         <div class="alert alert-warning">
           <p><i class="fa fa-exclamation-triangle"></i>
-            The following security groups could not be found in the selected account/region/VPC and were removed:
+            The following <firewall-label label="firewalls"/> could not be found in the selected account/region/VPC and were removed:
           </p>
           <ul>
             <li ng-repeat="securityGroup in state.removedRules">{{securityGroup}}</li>

--- a/app/scripts/modules/google/src/securityGroup/configure/createSecurityGroupProperties.html
+++ b/app/scripts/modules/google/src/securityGroup/configure/createSecurityGroupProperties.html
@@ -2,7 +2,7 @@
     <div class="modal-body">
       <div class="form-group">
         <div class="col-md-12 well" ng-class="{'alert-danger': form.securityGroupName.$error.validateUnique, 'alert-info': !form.securityGroupName.$error.validateUnique}">
-          <strong>Your security group will be named:</strong>
+          <strong>Your <firewall-label label="firewall"/> will be named:</strong>
           <span ng-bind="namePreview"></span>
           <input type="hidden" class="form-control input-sm"
                  ng-model="securityGroup.name"
@@ -12,7 +12,7 @@
                  ng-pattern="ctrl.namePattern"
                  trigger-validation="securityGroup.subnet"
                  required/>
-          <validation-error ng-if="form.securityGroupName.$error.validateUnique && securityGroup.credentials" message="There is already a security group in {{securityGroup.credentials}} with that name."></validation-error>
+          <validation-error ng-if="form.securityGroupName.$error.validateUnique && securityGroup.credentials" message="There is already a {{firewallLabel}} in {{securityGroup.credentials}} with that name."></validation-error>
           <validation-error ng-if="form.securityGroupName.$error.pattern" message="Name can only contain letters, numbers, and dashes(-)."></validation-error>
         </div>
       </div>

--- a/app/scripts/modules/google/src/securityGroup/configure/editSecurityGroup.controller.js
+++ b/app/scripts/modules/google/src/securityGroup/configure/editSecurityGroup.controller.js
@@ -2,7 +2,7 @@
 
 const angular = require('angular');
 
-import { InfrastructureCaches, SECURITY_GROUP_WRITER, TASK_MONITOR_BUILDER } from '@spinnaker/core';
+import { FirewallLabels, InfrastructureCaches, SECURITY_GROUP_WRITER, TASK_MONITOR_BUILDER } from '@spinnaker/core';
 
 module.exports = angular
   .module('spinnaker.google.securityGroup.edit.controller', [
@@ -47,7 +47,7 @@ module.exports = angular
 
     $scope.taskMonitor = taskMonitorBuilder.buildTaskMonitor({
       application: application,
-      title: 'Updating your security group',
+      title: `Updating your ${FirewallLabels.get('firewall')}`,
       modalInstance: $uibModalInstance,
       onTaskComplete: () => application.securityGroups.refresh(),
     });

--- a/app/scripts/modules/google/src/securityGroup/details/securityGroupDetail.controller.js
+++ b/app/scripts/modules/google/src/securityGroup/details/securityGroupDetail.controller.js
@@ -7,6 +7,7 @@ import {
   AccountService,
   CloudProviderRegistry,
   CONFIRMATION_MODAL_SERVICE,
+  FirewallLabels,
   SECURITY_GROUP_READER,
   SECURITY_GROUP_WRITER,
 } from '@spinnaker/core';
@@ -44,6 +45,8 @@ module.exports = angular
       standalone: app.isStandalone,
     };
 
+    $scope.firewallLabel = FirewallLabels.get('Firewall');
+
     function extractSecurityGroup() {
       return securityGroupReader
         .getSecurityGroupDetails(
@@ -69,7 +72,7 @@ module.exports = angular
             );
             $scope.securityGroup = angular.extend(_.cloneDeep(applicationSecurityGroup), $scope.securityGroup);
 
-            // These come back from the global security group endpoint as '[tag-a, tag-b]'
+            // These come back from the global firewall endpoint as '[tag-a, tag-b]'
             if (typeof $scope.securityGroup.targetTags === 'string') {
               let targetTags = $scope.securityGroup.targetTags;
               $scope.securityGroup.targetTags = targetTags.substring(1, targetTags.length - 1).split(', ');
@@ -226,7 +229,7 @@ module.exports = angular
     };
 
     if (app.isStandalone) {
-      // we still want the edit to refresh the security group details when the modal closes
+      // we still want the edit to refresh the firewall details when the modal closes
       app.securityGroups = {
         refresh: extractSecurityGroup,
       };

--- a/app/scripts/modules/google/src/securityGroup/details/securityGroupDetail.html
+++ b/app/scripts/modules/google/src/securityGroup/details/securityGroupDetail.html
@@ -32,12 +32,12 @@
     <div class="actions">
       <div ng-if="!securityGroup.id.includes('/')" class="dropdown" uib-dropdown dropdown-append-to-body>
         <button type="button" class="btn btn-sm btn-primary dropdown-toggle" uib-dropdown-toggle>
-          Security Group Actions <span class="caret"></span>
+          <firewall-label label="Firewall"/> Actions <span class="caret"></span>
         </button>
         <ul class="dropdown-menu" uib-dropdown-menu role="menu">
           <li><a href ng-click="ctrl.editInboundRules()">Edit Inbound Rules</a></li>
-          <li><a href ng-click="ctrl.deleteSecurityGroup()">Delete Security Group</a></li>
-          <li><a href ng-click="ctrl.cloneSecurityGroup()">Clone Security Group</a></li>
+          <li><a href ng-click="ctrl.deleteSecurityGroup()">Delete <firewall-label label="Firewall"/></a></li>
+          <li><a href ng-click="ctrl.cloneSecurityGroup()">Clone <firewall-label label="Firewall"/></a></li>
           <render-if-feature feature="entityTags">
             <add-entity-tag-links component="securityGroup"
                                   application="ctrl.application"
@@ -48,18 +48,18 @@
       </div>
       <div ng-if="securityGroup.id.includes('/')" class="dropdown" uib-dropdown dropdown-append-to-body>
         <button type="button" class="btn btn-sm btn-primary dropdown-toggle" uib-dropdown-toggle>
-          Security Group Actions <span class="caret"></span>
+          <firewall-label label="Firewall"/> Actions <span class="caret"></span>
         </button>
         <ul uib-tooltip="You cannot modify shared VPC host project firewall rules." class="dropdown-menu" uib-dropdown-menu role="menu">
           <li class="disabled"><a>Edit Inbound Rules</a></li>
-          <li class="disabled"><a>Delete Security Group</a></li>
-          <li class="disabled"><a>Clone Security Group</a></li>
+          <li class="disabled"><a>Delete <firewall-label label="Firewall"/></a></li>
+          <li class="disabled"><a>Clone <firewall-label label="Firewall"/></a></li>
         </ul>
       </div>
     </div>
   </div>
   <div class="content" ng-if="!state.loading">
-    <collapsible-section heading="Security Group Details" expanded="true">
+    <collapsible-section heading="{{firewallLabel}} Details" expanded="true">
       <dl class="dl-horizontal dl-medium">
         <dt>ID</dt>
         <dd>{{securityGroup.id}}</dd>

--- a/app/scripts/modules/google/src/securityGroup/securityGroupHelpText.service.ts
+++ b/app/scripts/modules/google/src/securityGroup/securityGroupHelpText.service.ts
@@ -1,7 +1,7 @@
 import { module } from 'angular';
 import { get, has } from 'lodash';
 
-import { Application, IServerGroup } from '@spinnaker/core';
+import { Application, FirewallLabels, IServerGroup } from '@spinnaker/core';
 
 export class GceSecurityGroupHelpTextService {
   private serverGroupsIndexedByTag: Map<string, Set<string>>;
@@ -25,10 +25,12 @@ export class GceSecurityGroupHelpTextService {
         text = null;
         break;
       case 1:
-        text = `This ${tagType} tag associates this security group with the server group <em>${serverGroups[0]}</em>.`;
+        text = `This ${tagType} tag associates this ${FirewallLabels.get('firewall')} with the server group <em>${
+          serverGroups[0]
+        }</em>.`;
         break;
       default:
-        text = `This ${tagType} tag associates this security group with the server groups
+        text = `This ${tagType} tag associates this ${FirewallLabels.get('firewall')} with the server groups
                 ${serverGroups.map(serverGroup => `<em>${serverGroup}</em>`).join(', ')}.`;
         break;
     }

--- a/app/scripts/modules/google/src/serverGroup/configure/serverGroupConfiguration.service.js
+++ b/app/scripts/modules/google/src/serverGroup/configure/serverGroupConfiguration.service.js
@@ -116,7 +116,7 @@ module.exports = angular
             }
           }
           if (command.securityGroups && command.securityGroups.length) {
-            // Verify all security groups are accounted for; otherwise, try refreshing security groups cache.
+            // Verify all firewalls are accounted for; otherwise, try refreshing firewalls cache.
             var securityGroupIds = _.map(getSecurityGroups(command), 'id');
             if (_.intersection(command.securityGroups, securityGroupIds).length < command.securityGroups.length) {
               securityGroupReloader = refreshSecurityGroups(command, true);
@@ -563,17 +563,17 @@ module.exports = angular
         }
       }
 
-      // Only include explicit security group options in the pulldown list.
+      // Only include explicit firewall options in the pulldown list.
       command.backingData.filtered.securityGroups = _.filter(newSecurityGroups, function(securityGroup) {
         return !_.isEmpty(securityGroup.targetTags);
       });
 
-      // Identify implicit security groups so they can be optionally listed in a read-only state.
+      // Identify implicit firewalls so they can be optionally listed in a read-only state.
       command.implicitSecurityGroups = _.filter(newSecurityGroups, function(securityGroup) {
         return _.isEmpty(securityGroup.targetTags);
       });
 
-      // Only include explicitly-selected security groups in the body of the command.
+      // Only include explicitly-selected firewalls in the body of the command.
       var xpnHostProject = getXpnHostProjectIfAny(command.network);
       var decoratedSecurityGroups = _.map(
         command.securityGroups,

--- a/app/scripts/modules/google/src/serverGroup/configure/wizard/cloneServerGroup.gce.controller.js
+++ b/app/scripts/modules/google/src/serverGroup/configure/wizard/cloneServerGroup.gce.controller.js
@@ -3,7 +3,7 @@
 const angular = require('angular');
 import _ from 'lodash';
 
-import { INSTANCE_TYPE_SERVICE } from '@spinnaker/core';
+import { FirewallLabels, INSTANCE_TYPE_SERVICE } from '@spinnaker/core';
 
 module.exports = angular
   .module('spinnaker.serverGroup.configure.gce.cloneServerGroup', [
@@ -44,6 +44,8 @@ module.exports = angular
       advancedSettings: require('./advancedSettings/advancedSettings.html'),
     };
 
+    $scope.firewallsLabel = FirewallLabels.get('Firewalls');
+
     $scope.title = title;
 
     $scope.applicationName = application.name;
@@ -60,7 +62,7 @@ module.exports = angular
       copied: [
         'account, region, subnet, cluster name (stack, details)',
         'load balancers',
-        'security groups',
+        FirewallLabels.get('firewalls'),
         'instance type',
         'all fields on the Advanced Settings page',
       ],

--- a/app/scripts/modules/google/src/serverGroup/configure/wizard/securityGroups/securityGroupSelector.directive.html
+++ b/app/scripts/modules/google/src/serverGroup/configure/wizard/securityGroups/securityGroupSelector.directive.html
@@ -1,5 +1,5 @@
 <div class="form-group">
-  <div class="col-md-3 sm-label-right"><b>Security Groups</b></div>
+  <div class="col-md-3 sm-label-right"><b><firewall-label label="Firewalls"/></b></div>
   <div class="col-md-9">
     <ui-select ng-if="vm.command.backingData.filtered.securityGroups.length"
                multiple
@@ -21,14 +21,14 @@
 <div class="form-group small" style="margin-top: 20px">
   <div class="col-md-9 col-md-offset-3 checkbox">
     <p>
-      <label><input type="checkbox" ng-model="vm.command.viewState.listImplicitSecurityGroups"/> Show Implicit Security Groups </label>
+      <label><input type="checkbox" ng-model="vm.command.viewState.listImplicitSecurityGroups"/> Show Implicit <firewall-label label="Firewalls"/> </label>
       <help-field key="gce.serverGroup.securityGroups.implicit"></help-field>
     </p>
   </div>
 </div>
 
 <div class="form-group" ng-if="vm.command.viewState.listImplicitSecurityGroups">
-  <div class="col-md-3 sm-label-right"><b>Implicit Security Groups</b></div>
+  <div class="col-md-3 sm-label-right"><b>Implicit <firewall-label label="Firewalls"/></b></div>
   <div class="col-md-9">
     <ul ng-if="vm.command.implicitSecurityGroups.length" style="margin-top: 10px; list-style-type: none">
       <li ng-repeat="securityGroup in vm.command.implicitSecurityGroups">{{securityGroup.name}}</li>
@@ -43,11 +43,11 @@
   <div class="col-md-9 col-md-offset-3">
     <p>
       <span ng-if="refreshing"><span class="fa fa-sync-alt fa-spin"></span></span>
-      Security groups
+      <firewall-label label="Firewalls"/>
       <span ng-if="!refreshing">last refreshed {{ vm.getSecurityGroupRefreshTime() | timestamp }}</span>
       <span ng-if="refreshing"> refreshing...</span>
     </p>
-    <p>If you're not finding a security group that was recently added,
+    <p>If you're not finding a <firewall-label label="firewall"/> that was recently added,
       <a href ng-click="vm.refreshSecurityGroups()">click here</a> to refresh the list.
     </p>
   </div>

--- a/app/scripts/modules/google/src/serverGroup/configure/wizard/securityGroups/securityGroupsRemoved.directive.html
+++ b/app/scripts/modules/google/src/serverGroup/configure/wizard/securityGroups/securityGroupsRemoved.directive.html
@@ -1,7 +1,7 @@
 <div class="col-md-12" ng-if="vm.command.viewState.dirty.securityGroups">
   <div class="alert alert-warning">
     <p><i class="fa fa-exclamation-triangle"></i>
-      The following security groups could not be found in the selected account/network and were removed:
+      The following <firewall-label label="firewalls"/> could not be found in the selected account/network and were removed:
     </p>
     <ul>
       <li ng-repeat="securityGroup in vm.command.viewState.dirty.securityGroups">{{securityGroup}}</li>

--- a/app/scripts/modules/google/src/serverGroup/configure/wizard/securityGroups/tagManager.service.js
+++ b/app/scripts/modules/google/src/serverGroup/configure/wizard/securityGroups/tagManager.service.js
@@ -4,6 +4,8 @@ import _ from 'lodash';
 
 const angular = require('angular');
 
+import { FirewallLabels } from '@spinnaker/core';
+
 module.exports = angular.module('spinnaker.deck.gce.tagManager.service', []).factory('gceTagManager', function() {
   let resetKeys = ['command', 'securityGroups', 'securityGroupObjectsKeyedByTag', 'securityGroupObjectsKeyedById'];
 
@@ -183,7 +185,9 @@ module.exports = angular.module('spinnaker.deck.gce.tagManager.service', []).fac
     let groups = _.get(this, ['securityGroupObjectsKeyedByTag', tagName]),
       groupIds = groups ? groups.filter(sg => sg.network === this.command.network).map(sg => sg.id) : [];
 
-    return `This tag associates this server group with security group${groupIds.length > 1 ? 's' : ''}
+    return `This tag associates this server group with ${
+      groupIds.length > 1 ? FirewallLabels.get('firewalls') : FirewallLabels.get('firewall')
+    }
               <em>${groupIds.join(', ')}</em>.`;
   };
 

--- a/app/scripts/modules/google/src/serverGroup/configure/wizard/serverGroupWizard.html
+++ b/app/scripts/modules/google/src/serverGroup/configure/wizard/serverGroupWizard.html
@@ -13,7 +13,7 @@
       <v2-wizard-page key="load-balancers" label="Load Balancers" mark-complete-on-view="false">
         <ng-include src="pages.loadBalancers"></ng-include>
       </v2-wizard-page>
-      <v2-wizard-page key="security-groups" label="Security Groups" done="true">
+      <v2-wizard-page key="security-groups" label="{{firewallsLabel}}" done="true">
         <ng-include src="pages.securityGroups"></ng-include>
       </v2-wizard-page>
       <v2-wizard-page key="instance-type" label="Instance Type" mark-complete-on-view="false">

--- a/app/scripts/modules/google/src/serverGroup/details/serverGroupDetails.gce.controller.js
+++ b/app/scripts/modules/google/src/serverGroup/details/serverGroupDetails.gce.controller.js
@@ -16,6 +16,7 @@ import {
 require('../configure/serverGroup.configure.gce.module.js');
 
 import './serverGroupDetails.less';
+import { FirewallLabels } from 'root/app/scripts/modules/core/src';
 
 module.exports = angular
   .module('spinnaker.serverGroup.details.gce.controller', [
@@ -51,6 +52,8 @@ module.exports = angular
     this.state = {
       loading: true,
     };
+
+    this.firewallsLabel = FirewallLabels.get('Firewalls');
 
     this.application = app;
 

--- a/app/scripts/modules/google/src/serverGroup/details/serverGroupDetails.html
+++ b/app/scripts/modules/google/src/serverGroup/details/serverGroupDetails.html
@@ -169,10 +169,10 @@
         <dd ng-if="!ctrl.serverGroup.startupScript">[none]</dd>
       </dl>
     </collapsible-section>
-    <collapsible-section heading="Security Groups">
+    <collapsible-section heading="{{ctrl.firewallsLabel}}">
       <ul>
         <li ng-repeat="securityGroup in ctrl.securityGroups | orderBy:'name'">
-          <a ui-sref="^.securityGroupDetails({name: securityGroup.name, accountId: securityGroup.accountName, region: 'global', provider: ctrl.serverGroup.type})">
+          <a ui-sref="^.firewallDetails({name: securityGroup.name, accountId: securityGroup.accountName, region: 'global', provider: ctrl.serverGroup.type})">
             {{securityGroup.name}}
           </a>
         </li>

--- a/app/scripts/modules/google/src/validation/applicationName.validator.js
+++ b/app/scripts/modules/google/src/validation/applicationName.validator.js
@@ -2,7 +2,7 @@
 
 const angular = require('angular');
 
-import { APPLICATION_NAME_VALIDATOR } from '@spinnaker/core';
+import { APPLICATION_NAME_VALIDATOR, FirewallLabels } from '@spinnaker/core';
 
 module.exports = angular
   .module('spinnaker.gce.validation.applicationName', [APPLICATION_NAME_VALIDATOR])
@@ -72,12 +72,15 @@ module.exports = angular
       if (name.length > maxResourceNameLength - 12) {
         if (name.length >= maxResourceNameLength - 2) {
           warnings.push(
-            'With separators ("-"), you will not be able to include a stack and detail field for ' +
-              'Google security groups.',
+            `With separators ("-"), you will not be able to include a stack and detail field for Google ${FirewallLabels.get(
+              'firewalls',
+            )}.`,
           );
         } else {
           let remaining = maxResourceNameLength - 2 - name.length;
-          warnings.push(`If you plan to include a stack or detail field for Google security groups, you will only
+          warnings.push(`If you plan to include a stack or detail field for Google ${FirewallLabels.get(
+            'firewalls',
+          )}, you will only
             have ~${remaining} characters to do so.`);
         }
       }

--- a/app/scripts/modules/kubernetes/src/help/kubernetes.help.ts
+++ b/app/scripts/modules/kubernetes/src/help/kubernetes.help.ts
@@ -167,7 +167,7 @@ const helpContents: { [key: string]: string } = {
   'kubernetes.ingress.tls.host':
     'The fully qualified domain name of a network host. Any traffic routed to this host can be secured with TLS. May not be an IP address, or contain port information.',
   'kubernetes.ingress.tls.secret':
-    '(Optional) Name of the Kubernetes secret that will be used to secure TLS connections to the security group. Note that Spinnaker will not create any secrets, they are assumed to exist.',
+    '(Optional) Name of the Kubernetes secret that will be used to secure TLS connections to the {{firewall}}. Note that Spinnaker will not create any secrets, they are assumed to exist.',
   'kubernetes.manifest.account': `
       <p>A Spinnaker account corresponds to a physical Kubernetes cluster. If you are unsure which account to use, talk to your Spinnaker admin.</p>
   `,

--- a/app/scripts/modules/kubernetes/src/securityGroup/configure/wizard/basicSettings.html
+++ b/app/scripts/modules/kubernetes/src/securityGroup/configure/wizard/basicSettings.html
@@ -5,7 +5,7 @@
   <div class="modal-body" ng-if="state.accountsLoaded">
     <div class="form-group">
       <div class="col-md-12 well" ng-class="{'alert-danger': form.securityGroupName.$error.validateUnique, 'alert-info': !form.securityGroupName.$error.validateUnique}">
-        <strong>Your security group will be named:</strong>
+        <strong>Your <firewall-label label="firewall"/> will be named:</strong>
         <span>{{ctrl.getName()}}</span>
           <!-- Angular does not seem to run length validation on hidden inputs, hence the text + display:none -->
         <input type="text"
@@ -16,7 +16,7 @@
                validate-unique="existingSecurityGroupNames"
                validate-ignore-case="true"
                name="securityGroupName"/>
-        <validation-error ng-if="form.securityGroupName.$error.validateUnique" message="There is already a security group in {{securityGroup.account}} with that name."></validation-error>
+        <validation-error ng-if="form.securityGroupName.$error.validateUnique" message="There is already a {{firewallLabelLc}} in {{securityGroup.account}} with that name."></validation-error>
       </div>
     </div>
     <div ng-show="isNew">
@@ -59,7 +59,7 @@
       </div>
       <div class="form-group">
         <div class="col-md-9 col-md-offset-3" ng-if="form.securityGroupName.$error.maxlength">
-          <validation-error message="Security Group name can only be 24 characters."></validation-error>
+          <validation-error message="{{firewallLabel}} name can only be 24 characters."></validation-error>
         </div>
       </div>
     </div>

--- a/app/scripts/modules/kubernetes/src/securityGroup/configure/wizard/createWizard.html
+++ b/app/scripts/modules/kubernetes/src/securityGroup/configure/wizard/createWizard.html
@@ -1,4 +1,4 @@
-<v2-modal-wizard heading="Create New Security Group" task-monitor="taskMonitor" dismiss="$dismiss()">
+<v2-modal-wizard heading="Create New {{firewallLabel}}" task-monitor="taskMonitor" dismiss="$dismiss()">
   <v2-wizard-page key="basic-settings" label="Basic Settings">
     <ng-include src="pages.basicSettings"></ng-include>
   </v2-wizard-page>

--- a/app/scripts/modules/kubernetes/src/securityGroup/configure/wizard/editWizard.html
+++ b/app/scripts/modules/kubernetes/src/securityGroup/configure/wizard/editWizard.html
@@ -1,4 +1,4 @@
-<v2-modal-wizard heading="Edit Security Group" task-monitor="taskMonitor" dismiss="$dismiss()">
+<v2-modal-wizard heading="Edit {{firewallLabel}}" task-monitor="taskMonitor" dismiss="$dismiss()">
   <v2-wizard-page key="basic-settings" label="Basic Settings">
     <ng-include src="pages.basicSettings"></ng-include>
   </v2-wizard-page>

--- a/app/scripts/modules/kubernetes/src/securityGroup/configure/wizard/upsert.controller.js
+++ b/app/scripts/modules/kubernetes/src/securityGroup/configure/wizard/upsert.controller.js
@@ -4,6 +4,7 @@ const angular = require('angular');
 
 import {
   AccountService,
+  FirewallLabels,
   LOAD_BALANCER_READ_SERVICE,
   SECURITY_GROUP_READER,
   SECURITY_GROUP_WRITER,
@@ -37,6 +38,9 @@ module.exports = angular
     taskMonitorBuilder,
   ) {
     var ctrl = this;
+    $scope.firewallLabel = FirewallLabels.get('Firewall');
+    $scope.firewallLabelLc = FirewallLabels.get('firewall');
+
     $scope.isNew = !securityGroup.edit;
     $scope.securityGroup = securityGroup;
 
@@ -66,10 +70,10 @@ module.exports = angular
         namespace: $scope.securityGroup.namespace,
         provider: 'kubernetes',
       };
-      if (!$state.includes('**.securityGroupDetails')) {
-        $state.go('.securityGroupDetails', newStateParams);
+      if (!$state.includes('**.firewallDetails')) {
+        $state.go('.firewallDetails', newStateParams);
       } else {
-        $state.go('^.securityGroupDetails', newStateParams);
+        $state.go('^.firewallDetails', newStateParams);
       }
     }
 
@@ -80,7 +84,7 @@ module.exports = angular
 
     $scope.taskMonitor = taskMonitorBuilder.buildTaskMonitor({
       application: application,
-      title: ($scope.isNew ? 'Creating ' : 'Updating ') + 'your security group',
+      title: `${$scope.isNew ? 'Creating ' : 'Updating '} your ${FirewallLabels.get('firewall')}`,
       modalInstance: $uibModalInstance,
       onTaskComplete: onTaskComplete,
     });

--- a/app/scripts/modules/kubernetes/src/securityGroup/details/details.controller.js
+++ b/app/scripts/modules/kubernetes/src/securityGroup/details/details.controller.js
@@ -10,6 +10,7 @@ import {
   SECURITY_GROUP_WRITER,
   ServerGroupTemplates,
 } from '@spinnaker/core';
+import { FirewallLabels } from 'root/app/scripts/modules/core/src';
 
 module.exports = angular
   .module('spinnaker.securityGroup.kubernetes.details.controller', [
@@ -33,6 +34,8 @@ module.exports = angular
 
     // needed for standalone instances
     $scope.detailsTemplateUrl = CloudProviderRegistry.getValue('kubernetes', 'securityGroup.detailsTemplateUrl');
+
+    $scope.firewallLabel = FirewallLabels.get('Firewall');
 
     $scope.state = {
       loading: true,

--- a/app/scripts/modules/kubernetes/src/securityGroup/details/details.html
+++ b/app/scripts/modules/kubernetes/src/securityGroup/details/details.html
@@ -18,17 +18,17 @@
     <div class="actions">
       <div class="dropdown" uib-dropdown dropdown-append-to-body>
         <button type="button" class="btn btn-sm btn-primary dropdown-toggle" ng-disabled="disabled" uib-dropdown-toggle>
-          Security Group Actions <span class="caret"></span>
+          <firewall-label label="Firewall"/> Actions <span class="caret"></span>
         </button>
         <ul class="dropdown-menu" uib-dropdown-menu role="menu">
-          <li><a href ng-click="ctrl.deleteSecurityGroup()">Delete Security Group</a></li>
-          <li><a href ng-click="ctrl.editSecurityGroup()">Edit Security Group</a></li>
+          <li><a href ng-click="ctrl.deleteSecurityGroup()">Delete <firewall-label label="Firewall"/></a></li>
+          <li><a href ng-click="ctrl.editSecurityGroup()">Edit <firewall-label label="Firewall"/></a></li>
         </ul>
       </div>
     </div>
   </div>
   <div class="content" ng-if="!state.loading">
-    <collapsible-section heading="Security Group Details" expanded="true">
+    <collapsible-section heading="{{firewallLabel}} Details" expanded="true">
       <dl class="dl-horizontal dl-medium">
         <dt>ID</dt>
         <dd>{{securityGroup.id}}</dd>

--- a/app/scripts/modules/kubernetes/src/serverGroup/configure/wizard/Clone.controller.js
+++ b/app/scripts/modules/kubernetes/src/serverGroup/configure/wizard/Clone.controller.js
@@ -2,7 +2,7 @@
 
 const angular = require('angular');
 
-import { SERVER_GROUP_WRITER, TASK_MONITOR_BUILDER, V2_MODAL_WIZARD_SERVICE } from '@spinnaker/core';
+import { FirewallLabels, SERVER_GROUP_WRITER, TASK_MONITOR_BUILDER, V2_MODAL_WIZARD_SERVICE } from '@spinnaker/core';
 
 module.exports = angular
   .module('spinnaker.serverGroup.configure.kubernetes.clone', [
@@ -54,7 +54,7 @@ module.exports = angular
       copied: [
         'account, namespace, cluster name (stack, details)',
         'load balancers',
-        'security groups',
+        FirewallLabels.get('firewalls'),
         'container configuration',
       ],
       notCopied: [],

--- a/app/scripts/modules/kubernetes/src/v2/securityGroup/details/details.html
+++ b/app/scripts/modules/kubernetes/src/v2/securityGroup/details/details.html
@@ -28,14 +28,14 @@
       <div class="actions">
         <div class="dropdown" uib-dropdown dropdown-append-to-body>
           <button type="button" class="btn btn-sm btn-primary dropdown-toggle" uib-dropdown-toggle>
-            Security Group Actions <span class="caret"></span>
+            <firewall-label label="Firewall"/> Actions <span class="caret"></span>
           </button>
           <ul class="dropdown-menu" uib-dropdown-menu role="menu">
             <li>
-              <a href ng-click="ctrl.deleteSecurityGroup()">Delete Security Group</a>
+              <a href ng-click="ctrl.deleteSecurityGroup()">Delete <firewall-label label="Firewall"/></a>
             </li>
             <li>
-              <a href ng-click="ctrl.editSecurityGroup()">Edit Security Group</a>
+              <a href ng-click="ctrl.editSecurityGroup()">Edit <firewall-label label="Firewall"/></a>
             </li>
           </ul>
         </div>

--- a/app/scripts/modules/openstack/src/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/openstack/src/instance/details/instance.details.controller.js
@@ -11,6 +11,7 @@ import {
   RECENT_HISTORY_SERVICE,
   SETTINGS,
 } from '@spinnaker/core';
+import { FirewallLabels } from 'root/app/scripts/modules/core/src';
 
 module.exports = angular
   .module('spinnaker.instance.detail.openstack.controller', [
@@ -42,6 +43,8 @@ module.exports = angular
       standalone: app.isStandalone,
       instancePort: _.get(app, 'attributes.instancePort') || SETTINGS.defaultInstancePort || 80,
     };
+
+    $scope.firewallsLabel = FirewallLabels.get('Firewalls');
 
     $scope.application = app;
 

--- a/app/scripts/modules/openstack/src/instance/details/instanceDetails.html
+++ b/app/scripts/modules/openstack/src/instance/details/instanceDetails.html
@@ -137,10 +137,10 @@
         </dd>
       </dl>
     </collapsible-section>
-    <collapsible-section heading="Security Groups">
+    <collapsible-section heading="{{firewallsLabel}}">
         <ul>
           <li ng-repeat="securityGroup in instance.securityGroups | orderBy:'groupName'">
-            <a ui-sref="^.securityGroupDetails({name:securityGroup.groupName, accountId: instance.account, region: instance.region, vpcId: instance.vpcId, provider: instance.provider})">
+            <a ui-sref="^.firewallDetails({name:securityGroup.groupName, accountId: instance.account, region: instance.region, vpcId: instance.vpcId, provider: instance.provider})">
               {{securityGroup.groupName}} ({{securityGroup.groupId}})
             </a>
           </li>

--- a/app/scripts/modules/openstack/src/loadBalancer/configure/wizard/interface.html
+++ b/app/scripts/modules/openstack/src/loadBalancer/configure/wizard/interface.html
@@ -9,7 +9,7 @@
     </network-select-field>
 
     <os-cache-backed-multi-select-field
-      label="Security Groups"
+      label="{{firewallsLabel}}"
       cache="allSecurityGroups"
       refresh-cache="updateSecurityGroups"
       required="false"

--- a/app/scripts/modules/openstack/src/loadBalancer/configure/wizard/upsert.controller.js
+++ b/app/scripts/modules/openstack/src/loadBalancer/configure/wizard/upsert.controller.js
@@ -11,6 +11,7 @@ import {
 } from '@spinnaker/core';
 
 import '../../loadBalancer.less';
+import { FirewallLabels } from 'root/app/scripts/modules/core/src';
 
 module.exports = angular
   .module('spinnaker.loadBalancer.openstack.create.controller', [
@@ -52,6 +53,8 @@ module.exports = angular
       accountsLoaded: false,
       submitting: false,
     };
+
+    $scope.firewallsLabel = FirewallLabels.get('Firewalls');
 
     $scope.subnetFilter = {};
 

--- a/app/scripts/modules/openstack/src/securityGroup/configure/wizard/basicSettings.html
+++ b/app/scripts/modules/openstack/src/securityGroup/configure/wizard/basicSettings.html
@@ -5,7 +5,7 @@
   <div class="modal-body" ng-if="state.accountsLoaded">
     <div class="form-group">
       <div class="col-md-12 well" ng-if="isNew" ng-class="{'alert-danger': form.securityGroupName.$error.validateUnique, 'alert-info': !form.securityGroupName.$error.validateUnique}">
-        <strong>Your security group will be named:</strong>
+        <strong>Your <firewall-label label="firewall"/> will be named:</strong>
         <span>{{ctrl.getName()}}</span>
           <!-- Angular does not seem to run length validation on hidden inputs, hence the text + display:none -->
         <input type="text"
@@ -16,7 +16,7 @@
                validate-unique="existingSecurityGroupNames"
                validate-ignore-case="true"
                name="securityGroupName"/>
-        <validation-error ng-if="form.securityGroupName.$error.validateUnique" message="There is already a security group in {{securityGroup.account}} with that name."></validation-error>
+        <validation-error ng-if="form.securityGroupName.$error.validateUnique" message="There is already a {{firewallLabelLc}} in {{securityGroup.account}} with that name."></validation-error>
       </div>
     </div>
       <div class="form-group">

--- a/app/scripts/modules/openstack/src/securityGroup/configure/wizard/createWizard.html
+++ b/app/scripts/modules/openstack/src/securityGroup/configure/wizard/createWizard.html
@@ -1,5 +1,5 @@
 <ng-form role="form" name="form" novalidate>
-    <v2-modal-wizard heading="Create New Security Group" task-monitor="taskMonitor" dismiss="$dismiss()">
+    <v2-modal-wizard heading="Create New {{firewallLabel}}" task-monitor="taskMonitor" dismiss="$dismiss()">
       <v2-wizard-page key="basic-settings" label="Basic Settings">
         <ng-include src="pages.basicSettings"></ng-include>
       </v2-wizard-page>

--- a/app/scripts/modules/openstack/src/securityGroup/configure/wizard/rules.controller.js
+++ b/app/scripts/modules/openstack/src/securityGroup/configure/wizard/rules.controller.js
@@ -2,7 +2,7 @@
 
 const angular = require('angular');
 
-import { InfrastructureCaches, SECURITY_GROUP_READER } from '@spinnaker/core';
+import { FirewallLabels, InfrastructureCaches, SECURITY_GROUP_READER } from '@spinnaker/core';
 
 module.exports = angular
   .module('spinnaker.securityGroup.configure.openstack.ports', [
@@ -55,7 +55,7 @@ module.exports = angular
         // Add self referencial option at the start of avaibleSecurityGroup Collection
         // Only do need this on create as an edit has itself in the list already.
         if ($scope.securityGroup.edit === undefined) {
-          $scope.prependSecurityGroupOption({ id: 'SELF', name: 'This Security Group (Self)' });
+          $scope.prependSecurityGroupOption({ id: 'SELF', name: `This ${FirewallLabels.get('Firewall')} (Self)` });
         }
 
         // Add CIDR at the start of avaibleSecurityGroup Collection

--- a/app/scripts/modules/openstack/src/securityGroup/configure/wizard/rules.html
+++ b/app/scripts/modules/openstack/src/securityGroup/configure/wizard/rules.html
@@ -7,7 +7,7 @@
           <th style="width: 15%">Protocol</th>
           <th style="width: 12%" uib-tooltip="From Port is used for TCP and UDP, Type is used for ICMP.">From Port/Type</th>
           <th style="width: 12%" uib-tooltip="To Port is used for TCP and UDP, Code is used for ICMP.">To Port/Code</th>
-          <th style="width: 20%" uib-tooltip="Remote value can either be a security group or a CIDR.">Remote</th>
+          <th style="width: 20%" uib-tooltip="Remote value can either be a {{firewallLabelLc}} or a CIDR.">Remote</th>
           <th style="width: 15%">CIDR</th>
           <th></th>
         </tr>
@@ -110,11 +110,11 @@
     <div class="col-md-12">
         <p>
             <span ng-if="state.refreshingSecurityGroups"><span class="fa fa-sync-alt fa-spin"></span></span>
-            Security groups
+            <firewall-label label="Firewalls"/>
             <span ng-if="!state.refreshingSecurityGroups">last refreshed {{ rulesController.getSecurityGroupRefreshTime() | timestamp }}</span>
             <span ng-if="state.refreshingSecurityGroups"> refreshing...</span>
         </p>
-        <p>If you're not finding a security group that was recently added,
+        <p>If you're not finding a <firewall-label label="firewall"/> that was recently added,
             <a href ng-click="rulesController.refreshSecurityGroups()">click here</a> to refresh the list.
         </p>
     </div>

--- a/app/scripts/modules/openstack/src/securityGroup/configure/wizard/upsert.controller.js
+++ b/app/scripts/modules/openstack/src/securityGroup/configure/wizard/upsert.controller.js
@@ -4,6 +4,7 @@ const angular = require('angular');
 
 import {
   AccountService,
+  FirewallLabels,
   NameUtils,
   SECURITY_GROUP_READER,
   SECURITY_GROUP_WRITER,
@@ -32,6 +33,8 @@ module.exports = angular
     taskMonitorBuilder,
   ) {
     var ctrl = this;
+    $scope.firewallLabel = FirewallLabels.get('Firewall');
+    $scope.firewallLabelLc = FirewallLabels.get('firewall');
     $scope.isNew = !securityGroup.edit;
     $scope.securityGroup = securityGroup;
 
@@ -58,10 +61,10 @@ module.exports = angular
         namespace: $scope.securityGroup.namespace,
         provider: 'openstack',
       };
-      if (!$state.includes('**.securityGroupDetails')) {
-        $state.go('.securityGroupDetails', newStateParams);
+      if (!$state.includes('**.firewallDetails')) {
+        $state.go('.firewallDetails', newStateParams);
       } else {
-        $state.go('^.securityGroupDetails', newStateParams);
+        $state.go('^.firewallDetails', newStateParams);
       }
     }
 
@@ -72,7 +75,7 @@ module.exports = angular
 
     $scope.taskMonitor = taskMonitorBuilder.buildTaskMonitor({
       application: application,
-      title: ($scope.isNew ? 'Creating ' : 'Updating ') + 'your security group',
+      title: `${$scope.isNew ? 'Creating ' : 'Updating '} your ${FirewallLabels.get('firewall')}`,
       modalInstance: $uibModalInstance,
       onTaskComplete: onTaskComplete,
     });

--- a/app/scripts/modules/openstack/src/securityGroup/configure/wizard/upsert.controller.spec.js
+++ b/app/scripts/modules/openstack/src/securityGroup/configure/wizard/upsert.controller.spec.js
@@ -160,7 +160,7 @@ describe('Controller: openstackCreateSecurityGroupCtrl', function() {
           this.$scope.$digest();
         });
 
-        it('- updates the list of security Group names', function() {
+        it('- updates the list of firewall names', function() {
           expect(this.$scope.state.securityGroupNamesLoaded).toBeTruthy();
           expect(this.$scope.existingSecurityGroupNames).toEqual(
             _.map(_.filter(this.testData.loadSecurityGroups, { account: 'account1' }), function(lb) {
@@ -205,7 +205,7 @@ describe('Controller: openstackCreateSecurityGroupCtrl', function() {
                   this.taskCompletionCallback();
                 });
 
-                it('- refreshes the security groups', function() {
+                it('- refreshes the firewalls', function() {
                   expect(this.mockApplication.securityGroups.refresh).toHaveBeenCalled();
                 });
 
@@ -218,7 +218,7 @@ describe('Controller: openstackCreateSecurityGroupCtrl', function() {
                     this.$scope.$$destroyed = false;
                   });
 
-                  describe('& security Groups are refreshed', function() {
+                  describe('& firewalls are refreshed', function() {
                     beforeEach(function() {
                       this.applicationRefreshCallback();
                     });
@@ -282,7 +282,7 @@ describe('Controller: openstackCreateSecurityGroupCtrl', function() {
 
         this.applicationRefreshCallback();
         expect(this.mockModal.close).toHaveBeenCalled();
-        expect(this.mockState.go).toHaveBeenCalledWith('^.securityGroupDetails', {
+        expect(this.mockState.go).toHaveBeenCalledWith('^.firewallDetails', {
           name: this.$scope.securityGroup.name,
           accountId: this.$scope.securityGroup.account,
           namespace: undefined,

--- a/app/scripts/modules/openstack/src/securityGroup/details/details.controller.js
+++ b/app/scripts/modules/openstack/src/securityGroup/details/details.controller.js
@@ -6,6 +6,7 @@ import _ from 'lodash';
 import {
   CloudProviderRegistry,
   CONFIRMATION_MODAL_SERVICE,
+  FirewallLabels,
   SECURITY_GROUP_READER,
   SECURITY_GROUP_WRITER,
 } from '@spinnaker/core';
@@ -32,6 +33,8 @@ module.exports = angular
 
     // needed for standalone instances
     $scope.detailsTemplateUrl = CloudProviderRegistry.getValue('openstack', 'securityGroup.detailsTemplateUrl');
+
+    $scope.firewallLabel = FirewallLabels.get('Firewall');
 
     $scope.state = {
       loading: true,
@@ -120,7 +123,7 @@ module.exports = angular
     };
 
     if (app.isStandalone) {
-      // we still want the edit to refresh the security group details when the modal closes
+      // we still want the edit to refresh the firewall details when the modal closes
       app.securityGroups = {
         refresh: extractSecurityGroup,
       };

--- a/app/scripts/modules/openstack/src/securityGroup/details/details.controller.spec.js
+++ b/app/scripts/modules/openstack/src/securityGroup/details/details.controller.spec.js
@@ -75,7 +75,7 @@ describe('Controller: openstackSecurityGroupDetailsController', function() {
       });
     });
 
-    it('security group for edit', function() {
+    it('firewall for edit', function() {
       expect(this.mockSecurityGroupReader.getSecurityGroupDetails).toHaveBeenCalledWith(
         this.mockApplication,
         this.editSecurityGroup.accountId,
@@ -86,7 +86,7 @@ describe('Controller: openstackSecurityGroupDetailsController', function() {
       );
     });
 
-    describe('security group object should get set.', function() {
+    describe('firewall object should get set.', function() {
       beforeEach(function() {
         var securityGroup = this.editSecurityGroup;
         var details = {
@@ -98,7 +98,7 @@ describe('Controller: openstackSecurityGroupDetailsController', function() {
         this.$scope.$digest();
       });
 
-      it('should set security group region', function() {
+      it('should set firewall region', function() {
         expect(this.$scope.state.loading).toEqual(false);
       });
     });

--- a/app/scripts/modules/openstack/src/securityGroup/details/details.html
+++ b/app/scripts/modules/openstack/src/securityGroup/details/details.html
@@ -18,17 +18,17 @@
     <div class="actions">
       <div class="dropdown" uib-dropdown dropdown-append-to-body>
         <button type="button" class="btn btn-sm btn-primary dropdown-toggle" ng-disabled="disabled" uib-dropdown-toggle>
-          Security Group Actions <span class="caret"></span>
+          <firewall-label label="Firewall"/> Actions <span class="caret"></span>
         </button>
         <ul class="dropdown-menu" uib-dropdown-menu role="menu">
-          <li><a href ng-click="ctrl.editSecurityGroup()">Edit Security Group</a></li>
-          <li><a href ng-click="ctrl.deleteSecurityGroup()">Delete Security Group</a></li>
+          <li><a href ng-click="ctrl.editSecurityGroup()">Edit <firewall-label label="Firewall"/></a></li>
+          <li><a href ng-click="ctrl.deleteSecurityGroup()">Delete <firewall-label label="Firewall"/></a></li>
         </ul>
       </div>
     </div>
   </div>
   <div class="content" ng-if="!state.loading">
-    <collapsible-section heading="Security Group Details" expanded="true">
+    <collapsible-section heading="{{firewallLabel}} Details" expanded="true">
       <dl class="dl-horizontal dl-medium">
         <dt>ID</dt>
         <dd>{{securityGroup.id}}</dd>
@@ -55,14 +55,14 @@
         </dd>
       </dl>
     </collapsible-section>
-    <collapsible-section heading="Security Group Rules ({{securityGroup.securityGroupRules.length || 0}})" expanded="{{!!securityGroup.securityGroupRules.length}}">
+    <collapsible-section heading="{{firewallLabel}} Rules ({{securityGroup.securityGroupRules.length || 0}})" expanded="{{!!securityGroup.securityGroupRules.length}}">
           <div ng-if="!securityGroup.securityGroupRules.length">None</div>
 
           <dl ng-class="insightCtrl.vm.filtersExpanded ? '' : 'dl-horizontal dl-medium'"
               ng-repeat="rule in securityGroup.securityGroupRules | orderBy: 'securityGroup.name' ">
-            <dt>Security Group</dt>
+            <dt><firewall-label label="Firewall"/></dt>
             <dd ng-if="rule.securityGroup.name">
-                  <a ui-sref="^.securityGroupDetails({name: rule.securityGroup.name, accountId: rule.securityGroup.accountName, region: rule.securityGroup.region, vpcId: rule.securityGroup.vpcId, provider: 'openstack'})">
+                  <a ui-sref="^.firewallDetails({name: rule.securityGroup.name, accountId: rule.securityGroup.accountName, region: rule.securityGroup.region, vpcId: rule.securityGroup.vpcId, provider: 'openstack'})">
                       <account-tag account="rule.securityGroup.accountName || rule.securityGroup.accountId" ng-if="rule.securityGroup.accountName !== securityGroup.accountName"></account-tag>
                     {{rule.securityGroup.name}} ({{rule.securityGroup.id}})
                 </a>

--- a/app/scripts/modules/openstack/src/serverGroup/configure/wizard/Clone.controller.js
+++ b/app/scripts/modules/openstack/src/serverGroup/configure/wizard/Clone.controller.js
@@ -2,7 +2,7 @@
 
 const angular = require('angular');
 
-import { SERVER_GROUP_WRITER, TASK_MONITOR_BUILDER, V2_MODAL_WIZARD_SERVICE } from '@spinnaker/core';
+import { FirewallLabels, SERVER_GROUP_WRITER, TASK_MONITOR_BUILDER, V2_MODAL_WIZARD_SERVICE } from '@spinnaker/core';
 
 module.exports = angular
   .module('spinnaker.openstack.serverGroup.configure.clone', [
@@ -51,7 +51,7 @@ module.exports = angular
       copied: [
         'account, namespace, cluster name (stack, details)',
         'load balancers',
-        'security groups',
+        FirewallLabels.get('firewalls'),
         'container configuration',
       ],
       notCopied: [],

--- a/app/scripts/modules/openstack/src/serverGroup/configure/wizard/access/AccessSettings.controller.js
+++ b/app/scripts/modules/openstack/src/serverGroup/configure/wizard/access/AccessSettings.controller.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import { FirewallLabels } from '@spinnaker/core';
+
 const angular = require('angular');
 
 module.exports = angular
@@ -15,6 +17,8 @@ module.exports = angular
     networkReader,
     v2modalWizardService,
   ) {
+    $scope.firewallsLabel = FirewallLabels.get('Firewalls');
+
     // Loads all load balancers in the current application, region, and account
     $scope.updateLoadBalancers = function() {
       var filter = {
@@ -31,7 +35,7 @@ module.exports = angular
 
     $scope.$watch('command.associatePublicIpAddress', resetFloatingNetworkIp);
 
-    // Loads all security groups in the current region and account
+    // Loads all firewalls in the current region and account
     $scope.updateSecurityGroups = function() {
       $scope.allSecurityGroups = getSecurityGroups();
     };

--- a/app/scripts/modules/openstack/src/serverGroup/configure/wizard/access/accessSettings.html
+++ b/app/scripts/modules/openstack/src/serverGroup/configure/wizard/access/accessSettings.html
@@ -26,7 +26,7 @@
       </os-cache-backed-multi-select-field>
 
       <os-cache-backed-multi-select-field
-        label="Security Groups"
+        label="{{firewallsLabel}}"
         cache="allSecurityGroups"
         refresh-cache="updateSecurityGroups"
         required="true"

--- a/app/scripts/modules/openstack/src/serverGroup/details/serverGroupDetails.html
+++ b/app/scripts/modules/openstack/src/serverGroup/details/serverGroupDetails.html
@@ -141,10 +141,10 @@
         <dd><a target=_blank href="{{ctrl.buildJenkinsLink()}}">{{ctrl.buildJenkinsLink()}}</a></dd>
       </dl>
     </collapsible-section>
-    <collapsible-section heading="Security Groups">
+    <collapsible-section heading="{{ctrl.firewallsLabel}}">
       <ul>
         <li ng-repeat="securityGroup in securityGroups | orderBy:'name'">
-          <a ui-sref="^.securityGroupDetails({name: securityGroup.name, accountId: securityGroup.accountName, region: ctrl.serverGroup.region, vpcId: ctrl.serverGroup.vpcId, provider: ctrl.serverGroup.type})">
+          <a ui-sref="^.firewallDetails({name: securityGroup.name, accountId: securityGroup.accountName, region: ctrl.serverGroup.region, vpcId: ctrl.serverGroup.vpcId, provider: ctrl.serverGroup.type})">
             {{securityGroup.name}} ({{securityGroup.id}})
           </a>
         </li>

--- a/app/scripts/modules/openstack/src/serverGroup/details/serverGroupDetails.openstack.controller.js
+++ b/app/scripts/modules/openstack/src/serverGroup/details/serverGroupDetails.openstack.controller.js
@@ -6,6 +6,7 @@ import _ from 'lodash';
 import {
   AccountService,
   CONFIRMATION_MODAL_SERVICE,
+  FirewallLabels,
   OVERRIDE_REGISTRY,
   SECURITY_GROUP_READER,
   SERVER_GROUP_READER,
@@ -49,6 +50,8 @@ module.exports = angular
     this.state = {
       loading: true,
     };
+
+    this.firewallsLabel = FirewallLabels.get('Firewalls');
 
     this.application = app;
 
@@ -316,7 +319,7 @@ module.exports = angular
         var accountIndex = allSecurityGroups[serverGroup.account] || {};
         var regionSecurityGroups = accountIndex[serverGroup.region] || {};
         $scope.securityGroups = _.map(serverGroup.launchConfig.securityGroups, sgId => {
-          //TODO(jcwest): remove this once the back-end sends correctly formatted security group IDs
+          //TODO(jcwest): remove this once the back-end sends correctly formatted firewall IDs
           if (new RegExp("^\\[u'").test(sgId)) {
             sgId = sgId.split("'")[1];
           }

--- a/app/scripts/modules/openstack/src/validation/applicationName.validator.js
+++ b/app/scripts/modules/openstack/src/validation/applicationName.validator.js
@@ -2,7 +2,7 @@
 
 const angular = require('angular');
 
-import { APPLICATION_NAME_VALIDATOR } from '@spinnaker/core';
+import { APPLICATION_NAME_VALIDATOR, FirewallLabels } from '@spinnaker/core';
 
 module.exports = angular
   .module('spinnaker.openstack.validation.applicationName', [APPLICATION_NAME_VALIDATOR])
@@ -21,7 +21,11 @@ module.exports = angular
       }
       if (name.length > 240) {
         if (name.length >= 248) {
-          warnings.push('You will not be able to include a stack or detail field for clusters or security groups.');
+          warnings.push(
+            `You will not be able to include a stack or detail field for clusters or ${FirewallLabels.get(
+              'firewalls',
+            )}.`,
+          );
         } else {
           let remaining = 248 - name.length;
           warnings.push(`If you plan to include a stack or detail field for clusters, you will only

--- a/app/scripts/modules/oracle/oraclebmcs.module.js
+++ b/app/scripts/modules/oracle/oraclebmcs.module.js
@@ -33,7 +33,7 @@ module.exports = angular
     require('./image/image.reader.js').name,
     // Instances
     require('./instance/details/instance.details.controller.js').name,
-    // Security Groups
+    // Firewalls
     require('./securityGroup/securityGroup.reader.js').name,
     require('./securityGroup/securityGroup.transformer.js').name,
     require('./securityGroup/configure/createSecurityGroup.controller.js').name,

--- a/app/scripts/modules/oracle/securityGroup/configure/createSecurityGroup.controller.js
+++ b/app/scripts/modules/oracle/securityGroup/configure/createSecurityGroup.controller.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import { FirewallLabels } from 'root/app/scripts/modules/core/src';
+
 const angular = require('angular');
 
 module.exports = angular
@@ -8,4 +10,5 @@ module.exports = angular
     this.cancel = () => {
       $uibModalInstance.dismiss();
     };
+    $scope.firewallLabel = FirewallLabels.get('Firewall');
   });

--- a/app/scripts/modules/oracle/securityGroup/configure/createSecurityGroup.html
+++ b/app/scripts/modules/oracle/securityGroup/configure/createSecurityGroup.html
@@ -1,11 +1,11 @@
 <ng-form role="form" name="form" novalidate>
-  <v2-modal-wizard heading="Create New Oracle BMC Security Group" dismiss="$dismiss()">
+  <v2-modal-wizard heading="Create New Oracle BMC {{firewallLabel}}" dismiss="$dismiss()">
   </v2-modal-wizard>
   <div class="container-fluid">
     <div class="col-md-12 well">
       <h4>Notice</h4>
-      <p>We don't currently support the ability to create security groups for Oracle BMCS.</p>
-      <p>You can use the BMCS console to create and manage your Security Groups.</p>
+      <p>We don't currently support the ability to create <firewall-label label="firewalls"/> for Oracle BMCS.</p>
+      <p>You can use the BMCS console to create and manage your <firewall-label label="Firewalls"/>.</p>
     </div>
   </div>
   <div class="modal-footer">

--- a/app/scripts/modules/oracle/serverGroup/configure/wizard/cloneServerGroup.controller.js
+++ b/app/scripts/modules/oracle/serverGroup/configure/wizard/cloneServerGroup.controller.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const angular = require('angular');
+import { FirewallLabels } from '@spinnaker/core';
 
 module.exports = angular
   .module('spinnaker.oraclebmcs.serverGroup.configure.cloneServerGroup', [require('@uirouter/angularjs').default])
@@ -37,7 +38,7 @@ module.exports = angular
       copied: [
         'account, region, subnet, cluster name (stack, details)',
         'load balancers',
-        'security groups',
+        FirewallLabels.get('firewalls'),
         'instance type',
         'all fields on the Advanced Settings page',
       ],

--- a/app/scripts/modules/titus/src/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/titus/src/instance/details/instance.details.controller.js
@@ -7,6 +7,7 @@ import {
   AccountService,
   CloudProviderRegistry,
   CONFIRMATION_MODAL_SERVICE,
+  FirewallLabels,
   INSTANCE_READ_SERVICE,
   INSTANCE_WRITE_SERVICE,
   RECENT_HISTORY_SERVICE,
@@ -43,6 +44,7 @@ module.exports = angular
       loading: true,
       standalone: app.isStandalone,
     };
+    $scope.firewallsLabel = FirewallLabels.get('Firewalls');
 
     $scope.application = app;
     $scope.gateUrl = SETTINGS.gateUrl;

--- a/app/scripts/modules/titus/src/instance/details/instanceDetails.html
+++ b/app/scripts/modules/titus/src/instance/details/instanceDetails.html
@@ -139,11 +139,11 @@
         <dd>{{instance.placement.host}}</dd>
       </dl>
     </collapsible-section>
-    <collapsible-section heading="Security Groups">
+    <collapsible-section heading="{{firewallsLabel}}">
       <ul>
         <li ng-repeat="securityGroup in securityGroups | orderBy:'name'">
           <a
-            ui-sref="^.securityGroupDetails({name: securityGroup.name, accountId: securityGroup.account, region: instance.region, vpcId: securityGroup.vpcId, provider: 'aws'})">
+            ui-sref="^.firewallDetails({name: securityGroup.name, accountId: securityGroup.account, region: instance.region, vpcId: securityGroup.vpcId, provider: 'aws'})">
             {{securityGroup.name}} ({{securityGroup.id}})
           </a>
         </li>

--- a/app/scripts/modules/titus/src/pipeline/stages/runJob/RunJobExecutionDetails.tsx
+++ b/app/scripts/modules/titus/src/pipeline/stages/runJob/RunJobExecutionDetails.tsx
@@ -6,7 +6,6 @@ import {
   AccountTag,
   ExecutionDetailsSection,
   IExecutionDetailsSectionProps,
-  IExecutionDetailsComponentProps,
   StageFailureMessage,
 } from '@spinnaker/core';
 
@@ -14,16 +13,14 @@ export interface IRunJobExecutionDetailsState {
   titusUiEndpoint?: string;
 }
 
-export interface IRunJobExecutionDetailsProps extends IExecutionDetailsComponentProps, IExecutionDetailsSectionProps {}
-
 export class RunJobExecutionDetails extends React.Component<
-  IRunJobExecutionDetailsProps,
+  IExecutionDetailsSectionProps,
   IRunJobExecutionDetailsState
 > {
   public static title = 'runJobConfig';
   private mounted = false;
 
-  constructor(props: IRunJobExecutionDetailsProps) {
+  constructor(props: IExecutionDetailsSectionProps) {
     super(props);
     this.state = {};
   }

--- a/app/scripts/modules/titus/src/pipeline/stages/runJob/runJobStage.html
+++ b/app/scripts/modules/titus/src/pipeline/stages/runJob/runJobStage.html
@@ -85,9 +85,9 @@
              ng-model="stage.cluster.iamProfile"/>
     </stage-config-field>
 
-    <stage-config-field label="Security Groups" help-key="titus.job.securityGroups">
+    <stage-config-field label="{{firewallsLabel}}" help-key="titus.job.securityGroups">
       <div ng-if="!stage.credentials || !stage.cluster.region">
-        Account and region must be selected before security groups can be added
+        Account and region must be selected before <firewall-label label="firewalls"/> can be added
       </div>
       <titus-security-group-picker ng-if="runJobCtrl.loaded && stage.credentials && stage.cluster.region"
                                    command="stage"

--- a/app/scripts/modules/titus/src/pipeline/stages/runJob/titusRunJobStage.js
+++ b/app/scripts/modules/titus/src/pipeline/stages/runJob/titusRunJobStage.js
@@ -3,7 +3,7 @@
 const angular = require('angular');
 import { Subject } from 'rxjs';
 
-import { AccountService, ExecutionDetailsTasks } from '@spinnaker/core';
+import { AccountService, ExecutionDetailsTasks, FirewallLabels } from '@spinnaker/core';
 import { RunJobExecutionDetails } from './RunJobExecutionDetails';
 
 module.exports = angular
@@ -33,6 +33,7 @@ module.exports = angular
   .controller('titusRunJobStageCtrl', function($scope, $q) {
     let stage = $scope.stage;
     let vm = this;
+    $scope.firewallsLabel = FirewallLabels.get('Firewalls');
 
     if (!stage.cluster) {
       stage.cluster = {};

--- a/app/scripts/modules/titus/src/serverGroup/configure/wizard/CloneServerGroup.titus.controller.js
+++ b/app/scripts/modules/titus/src/serverGroup/configure/wizard/CloneServerGroup.titus.controller.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const angular = require('angular');
+import { FirewallLabels } from '@spinnaker/core';
+
 import { TITUS_SECURITY_GROUP_PICKER } from '../../../securityGroup/securityGroupPicker.component';
 import { TITUS_LOAD_BALANCER_SELECTOR } from '../../../loadBalancers/loadBalancerSelector.component';
 
@@ -32,6 +34,8 @@ module.exports = angular
       securityGroups: require('./securityGroups.html'),
       parameters: require('./parameters.html'),
     };
+
+    $scope.firewallsLabel = FirewallLabels.get('Firewalls');
 
     $scope.title = title;
     $scope.applicationName = application.name;

--- a/app/scripts/modules/titus/src/serverGroup/configure/wizard/serverGroupWizard.html
+++ b/app/scripts/modules/titus/src/serverGroup/configure/wizard/serverGroupWizard.html
@@ -19,7 +19,7 @@
       <v2-wizard-page key="loadBalancers" label="Load Balancers" mandatory="false">
         <ng-include src="pages.loadBalancers"></ng-include>
       </v2-wizard-page>
-      <v2-wizard-page key="securityGroups" label="Security Groups" mandatory="false">
+      <v2-wizard-page key="securityGroups" label="{{firewallsLabel}}" mandatory="false">
         <ng-include src="pages.securityGroups"></ng-include>
       </v2-wizard-page>
       <v2-wizard-page key="parameters" label="Advanced Settings" mandatory="false">

--- a/app/scripts/modules/titus/src/serverGroup/details/serverGroupDetails.html
+++ b/app/scripts/modules/titus/src/serverGroup/details/serverGroupDetails.html
@@ -152,11 +152,11 @@
         <dd>{{serverGroup.resources.gpu}}</dd>
       </dl>
     </collapsible-section>
-    <collapsible-section heading="Security Groups">
+    <collapsible-section heading="{{firewallsLabel}}">
       <ul>
         <li ng-repeat="securityGroup in securityGroups | orderBy:'name'">
           <a
-            ui-sref="^.securityGroupDetails({name: securityGroup.name, accountId: securityGroup.account, region: serverGroup.placement.region, vpcId: securityGroup.vpcId, provider: 'aws'})">
+            ui-sref="^.firewallDetails({name: securityGroup.name, accountId: securityGroup.account, region: serverGroup.placement.region, vpcId: securityGroup.vpcId, provider: 'aws'})">
             {{securityGroup.name}} ({{securityGroup.id}})
           </a>
         </li>

--- a/app/scripts/modules/titus/src/serverGroup/details/serverGroupDetails.titus.controller.js
+++ b/app/scripts/modules/titus/src/serverGroup/details/serverGroupDetails.titus.controller.js
@@ -7,6 +7,7 @@ import {
   AccountService,
   ClusterTargetBuilder,
   CONFIRMATION_MODAL_SERVICE,
+  FirewallLabels,
   NameUtils,
   SERVER_GROUP_READER,
   SERVER_GROUP_WARNING_MESSAGE_SERVICE,
@@ -51,6 +52,8 @@ module.exports = angular
   ) {
     let application = app;
     this.application = app;
+
+    $scope.firewallsLabel = FirewallLabels.get('Firewalls');
 
     $scope.gateUrl = SETTINGS.gateUrl;
 

--- a/app/scripts/modules/titus/src/validation/applicationName.validator.ts
+++ b/app/scripts/modules/titus/src/validation/applicationName.validator.ts
@@ -1,6 +1,11 @@
 import { module } from 'angular';
 
-import { APPLICATION_NAME_VALIDATOR, ApplicationNameValidator, IApplicationNameValidator } from '@spinnaker/core';
+import {
+  APPLICATION_NAME_VALIDATOR,
+  ApplicationNameValidator,
+  FirewallLabels,
+  IApplicationNameValidator,
+} from '@spinnaker/core';
 
 class TitusApplicationNameValidator implements IApplicationNameValidator {
   private validateSpecialCharacters(name: string, errors: string[]): void {
@@ -17,7 +22,9 @@ class TitusApplicationNameValidator implements IApplicationNameValidator {
     }
     if (name.length > 240) {
       if (name.length >= 248) {
-        warnings.push('You will not be able to include a stack or detail field for clusters or security groups.');
+        warnings.push(
+          `You will not be able to include a stack or detail field for clusters or ${FirewallLabels.get('firewalls')}.`,
+        );
       } else {
         const remaining = 248 - name.length;
         warnings.push(`If you plan to include a stack or detail field for clusters, you will only

--- a/settings.js
+++ b/settings.js
@@ -21,6 +21,7 @@ var templatesEnabled = process.env.TEMPLATES_ENABLED === 'true';
 var atlasWebComponentsUrl = process.env.ATLAS_WEB_COMPONENTS_URL;
 var canaryAccount = process.env.CANARY_ACCOUNT || '';
 var canaryFeatureDisabled = process.env.CANARY_FEATURE_ENABLED !== 'true';
+var useClassicFirewallLabels = process.env.USE_CLASSIC_FIREWALL_LABELS === 'true';
 
 window.spinnakerSettings = {
   checkForUpdates: true,
@@ -155,6 +156,7 @@ window.spinnakerSettings = {
   pubsubProviders: ['google'], // TODO(joonlim): Add amazon once it is confirmed that amazon pub/sub works.
   triggerTypes: ['git', 'pipeline', 'docker', 'cron', 'jenkins', 'travis', 'pubsub'],
   searchVersion: 1,
+  useClassicFirewallLabels: useClassicFirewallLabels,
   canary: {
     reduxLogger: reduxLoggerEnabled,
     metricsAccountName: canaryAccount,


### PR DESCRIPTION
Some people think "Security Groups" is a little too cloud provider specific, so, like we did with "server groups", we are migrating to a more abstract term: "Firewalls".

If this will be confusing to some folks, it can be toggled back to the legacy term of "Security Groups" via a field in the settings (`useClassicFirewallLabels`).