### PR TITLE
feat(amazon): Cluster dialog - only preload load balancers associated with app

### DIFF
--- a/app/scripts/modules/amazon/src/domain/IAmazonLoadBalancerSourceData.ts
+++ b/app/scripts/modules/amazon/src/domain/IAmazonLoadBalancerSourceData.ts
@@ -98,6 +98,7 @@ export interface IAmazonTargetGroupSourceData {
   serverGroups: IAmazonTargetGroupServerGroupSourceData[];
   targetGroupArn: string;
   targetGroupName: string;
+  targetType: string;
   type: string;
   unhealthyThresholdCount: number;
   vpcId: string;

--- a/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupConfiguration.service.spec.ts
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupConfiguration.service.spec.ts
@@ -2,7 +2,8 @@ import { mock, IQService, IScope, IRootScopeService } from 'angular';
 
 import {
   AccountService,
-  Application,
+  APPLICATION_MODEL_BUILDER,
+  ApplicationModelBuilder,
   CacheInitializerService,
   LoadBalancerReader,
   SecurityGroupReader,
@@ -24,9 +25,10 @@ describe('Service: awsServerGroupConfiguration', function() {
     subnetReader: SubnetReader,
     keyPairsReader: KeyPairsReader,
     loadBalancerReader: LoadBalancerReader,
+    applicationModelBuilder: ApplicationModelBuilder,
     $scope: IScope;
 
-  beforeEach(mock.module(AWS_SERVER_GROUP_CONFIGURATION_SERVICE));
+  beforeEach(mock.module(APPLICATION_MODEL_BUILDER, AWS_SERVER_GROUP_CONFIGURATION_SERVICE));
 
   beforeEach(
     mock.inject(function(
@@ -38,6 +40,7 @@ describe('Service: awsServerGroupConfiguration', function() {
       _subnetReader_: SubnetReader,
       _keyPairsReader_: KeyPairsReader,
       _loadBalancerReader_: LoadBalancerReader,
+      _applicationModelBuilder_: ApplicationModelBuilder,
       $rootScope: IRootScopeService,
     ) {
       service = _awsServerGroupConfigurationService_;
@@ -48,6 +51,7 @@ describe('Service: awsServerGroupConfiguration', function() {
       subnetReader = _subnetReader_;
       keyPairsReader = _keyPairsReader_;
       loadBalancerReader = _loadBalancerReader_;
+      applicationModelBuilder = _applicationModelBuilder_;
       $scope = $rootScope.$new();
 
       this.allLoadBalancers = [
@@ -111,12 +115,15 @@ describe('Service: awsServerGroupConfiguration', function() {
         },
       } as any;
 
-      service.configureCommand({} as Application, command);
+      service.configureCommand(
+        applicationModelBuilder.createApplication('name', { key: 'loadBalancers', lazy: true }),
+        command,
+      );
       $scope.$digest();
 
       expect(cacheInitializer.refreshCache).toHaveBeenCalledWith('loadBalancers');
       expect(refreshCacheSpy.calls.count()).toBe(1);
-      expect(listLoadBalancersSpy.calls.count()).toBe(2);
+      expect(listLoadBalancersSpy.calls.count()).toBe(1);
       expect(command.dirty).toBeUndefined();
     });
 
@@ -141,7 +148,10 @@ describe('Service: awsServerGroupConfiguration', function() {
         },
       } as any;
 
-      service.configureCommand({} as Application, command);
+      service.configureCommand(
+        applicationModelBuilder.createApplication('name', { key: 'loadBalancers', lazy: true }),
+        command,
+      );
       $scope.$digest();
       $scope.$digest();
 
@@ -177,7 +187,10 @@ describe('Service: awsServerGroupConfiguration', function() {
         },
       } as any;
 
-      service.configureCommand({} as Application, command);
+      service.configureCommand(
+        applicationModelBuilder.createApplication('name', { key: 'loadBalancers', lazy: true }),
+        command,
+      );
       $scope.$digest();
 
       expect(cacheInitializer.refreshCache).toHaveBeenCalledWith('instanceTypes');

--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/CloneServerGroup.aws.controller.spec.js
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/CloneServerGroup.aws.controller.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import { AccountService } from '@spinnaker/core';
+import { APPLICATION_MODEL_BUILDER, AccountService } from '@spinnaker/core';
 
 /*
  This is more of an integration test between awsServerGroupConfigurationService and awsCloneServerGroupCtrl.
@@ -11,7 +11,7 @@ describe('Controller: awsCloneServerGroup', function() {
   const AccountServiceFixture = require('../AccountServiceFixtures.js');
   const securityGroupReaderFixture = require('./SecurityGroupServiceFixtures.js');
 
-  beforeEach(window.module(require('./CloneServerGroup.aws.controller.js').name));
+  beforeEach(window.module(require('./CloneServerGroup.aws.controller.js').name, APPLICATION_MODEL_BUILDER));
 
   beforeEach(function() {
     window.inject(function(
@@ -29,6 +29,7 @@ describe('Controller: awsCloneServerGroup', function() {
       subnetReader,
       keyPairsReader,
       loadBalancerReader,
+      applicationModelBuilder,
     ) {
       this.$scope = $rootScope.$new();
       this.serverGroupWriter = serverGroupWriter;
@@ -42,6 +43,7 @@ describe('Controller: awsCloneServerGroup', function() {
       this.subnetReader = subnetReader;
       this.keyPairsReader = keyPairsReader;
       this.loadBalancerReader = loadBalancerReader;
+      this.applicationModelBuilder = applicationModelBuilder;
       this.$q = $q;
     });
 
@@ -116,7 +118,7 @@ describe('Controller: awsCloneServerGroup', function() {
           awsServerGroupConfigurationService: this.awsServerGroupConfigurationService,
           taskMonitorBuilder: this.taskMonitorBuilder,
           serverGroupCommand: serverGroupCommand,
-          application: { name: 'x' },
+          application: this.applicationModelBuilder.createApplication('x', { key: 'loadBalancers', lazy: true }),
           title: 'n/a',
         });
       });
@@ -236,7 +238,7 @@ describe('Controller: awsCloneServerGroup', function() {
           v2modalWizardService: this.v2modalWizardService,
           taskMonitorBuilder: this.taskMonitorBuilder,
           serverGroupCommand: serverGroupCommand,
-          application: { name: 'x' },
+          application: this.applicationModelBuilder.createApplication('x', { key: 'loadBalancers', lazy: true }),
           title: 'n/a',
         });
       });
@@ -418,7 +420,7 @@ describe('Controller: awsCloneServerGroup', function() {
           v2modalWizardService: this.v2modalWizardService,
           taskMonitorBuilder: this.taskMonitorBuilder,
           serverGroupCommand: serverGroup,
-          application: { name: 'x' },
+          application: this.applicationModelBuilder.createApplication('x', { key: 'loadBalancers', lazy: true }),
           title: 'n/a',
         });
       });

--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/loadBalancers/loadBalancerSelector.component.html
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/loadBalancers/loadBalancerSelector.component.html
@@ -84,5 +84,20 @@
       </div>
     </div>
   </div>
+  <div ng-if="!$ctrl.refreshed" class="form-group small" style="margin-top: 20px">
+    <div class="col-md-8 col-md-offset-4">
+      <p ng-if="$ctrl.refreshing">
+        <span class="fa fa-sync-alt fa-spin" />
+        <span> refreshing...</span>
+      </p>
+      <p ng-if="!$ctrl.refreshing">
+        If you are looking for a load balancer or target group from a different application, <br/>
+        <a class="clickable" ng-click="$ctrl.refreshLoadBalancers()">
+          click here
+        </a>
+        to load all load balancers.
+      </p>
+    </div>
+  </div>
 
 </div>

--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/loadBalancers/loadBalancerSelector.component.ts
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/loadBalancers/loadBalancerSelector.component.ts
@@ -1,7 +1,5 @@
 import { IController, IComponentOptions, module } from 'angular';
 
-import { InfrastructureCaches } from '@spinnaker/core';
-
 import {
   AWS_SERVER_GROUP_CONFIGURATION_SERVICE,
   AwsServerGroupConfigurationService,
@@ -10,24 +8,18 @@ import {
 class LoadBalancerSelectorController implements IController {
   public command: any;
 
-  public refreshTime: number;
+  public refreshed: boolean;
   public refreshing = false;
 
   constructor(private awsServerGroupConfigurationService: AwsServerGroupConfigurationService) {
     'ngInject';
-
-    this.setLoadBalancerRefreshTime();
-  }
-
-  public setLoadBalancerRefreshTime(): void {
-    this.refreshTime = InfrastructureCaches.get('loadBalancers').getStats().ageMax;
   }
 
   public refreshLoadBalancers(): void {
     this.refreshing = true;
     this.awsServerGroupConfigurationService.refreshLoadBalancers(this.command).then(() => {
       this.refreshing = false;
-      this.setLoadBalancerRefreshTime();
+      this.refreshed = true;
     });
   }
 }


### PR DESCRIPTION
99% of the time people are using load balancers from their own app. Sometimes the entire load balancer list can take a long time to come back, and the experience isn't great when the list is huge, so default to only load balancers from the specific app, but provide a way to load all of them on demand.

![screen shot 2018-05-08 at 4 06 13 pm](https://user-images.githubusercontent.com/56971/39787345-c5387080-52d9-11e8-9108-cc6621cf231e.png)
![screen shot 2018-05-08 at 4 06 18 pm](https://user-images.githubusercontent.com/56971/39787347-c8763b2e-52d9-11e8-9d9a-97df6fe75d2d.png)
