### PR TITLE
Execution fixes

### DIFF
--- a/app/scripts/modules/core/src/pipeline/filter/ExecutionFilterModel.ts
+++ b/app/scripts/modules/core/src/pipeline/filter/ExecutionFilterModel.ts
@@ -77,7 +77,7 @@ export class ExecutionFilterModel {
     $rootScope.$on(
       '$stateChangeSuccess',
       (_event, toState: Ng1StateDeclaration, toParams: StateParams, fromState: Ng1StateDeclaration) => {
-        if (this.movingToExecutionsState(toState)) {
+        if (this.movingToExecutionsState(toState) && !toParams.pipeline) {
           this.mostRecentApplication = toParams.application;
           this.assignViewStateFromCache();
         }

--- a/app/scripts/modules/core/src/pipeline/service/execution.service.ts
+++ b/app/scripts/modules/core/src/pipeline/service/execution.service.ts
@@ -428,6 +428,7 @@ export class ExecutionService {
   }
 
   public synchronizeExecution(current: IExecution, updated: IExecution): void {
+    const hydrationFlagChanged = !current.hydrated && updated.hydrated;
     (updated.stageSummaries || []).forEach((updatedSummary, idx) => {
       const currentSummary = current.stageSummaries[idx];
       if (!currentSummary) {
@@ -436,7 +437,7 @@ export class ExecutionService {
         // if the stage is active, update it in place if it has changed to save Angular
         // from removing, then re-rendering every DOM node
         // also, don't dehydrate
-        if ((updatedSummary.isActive || currentSummary.isActive) && (!current.hydrated || updated.hydrated)) {
+        if (updatedSummary.isActive || currentSummary.isActive || hydrationFlagChanged) {
           if (this.stringify(currentSummary) !== this.stringify(updatedSummary)) {
             Object.assign(currentSummary, updatedSummary);
           }


### PR DESCRIPTION
The first one makes sure we don't override the execution filter state on route changes if the filter state is not actually cached.

The second one makes sure we try to synchronize the execution details whenever the execution is hydrated.