### PR TITLE
fix(core): fix path to entity source pipeline

### DIFF
--- a/app/scripts/modules/core/src/entityTag/entitySource.component.ts
+++ b/app/scripts/modules/core/src/entityTag/entitySource.component.ts
@@ -48,7 +48,6 @@ class EntitySourceCtrl implements IController {
 export class EntitySourceComponent implements ng.IComponentOptions {
   public bindings: any = {
     metadata: '<',
-    relativePath: '<?',
   };
   public controller: any = EntitySourceCtrl;
   public template = `


### PR DESCRIPTION
Seems to be fallout from the es6 work last week. There is a default value set for this class field; however, it's getting overwritten to `null` by Angular, even though it is optional.

We don't actually ever set this value, so the fix is straightforward.