### PR TITLE
refactor(core): handle TS issue with interface extension

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/core/ExecutionDetailsSection.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/core/ExecutionDetailsSection.tsx
@@ -1,9 +1,20 @@
 import * as React from 'react';
-import { IExecutionDetailsComponentProps } from 'core/domain';
 
-export interface IExecutionDetailsSectionProps
-  extends IExecutionDetailsComponentProps,
-    IExecutionDetailsSectionWrapperProps {}
+import { Application } from 'core/application/application.model';
+import { IExecution } from 'core/domain/IExecution';
+import { IExecutionStage } from 'core/domain/IExecutionStage';
+import { IExecutionDetailsSection } from 'core/domain/IStageTypeConfig';
+
+export interface IExecutionDetailsSectionProps extends IExecutionDetailsSectionWrapperProps {
+  // NOTE: these are the fields from IExecutionDetailsComponentProps, but TS is not behaving in the library build,
+  // and does not recognize fields in a separate interface that this one extends when they are in a separate file, so
+  // we are copying them here
+  application: Application;
+  detailsSections: IExecutionDetailsSection[];
+  execution: IExecution;
+  provider: string;
+  stage: IExecutionStage;
+}
 
 export interface IExecutionDetailsSectionWrapperProps {
   children?: any;


### PR DESCRIPTION
This is very annoying and I have tried a bunch of different things to try to work around it.

This is repeatable, so may be something we need to figure out eventually if we continue to extend multiple interfaces that reside in different files, and then try to use those interfaces in other libraries.

For now, I'm putting a big fat comment in place.