### PR TITLE
fix(core/executions): do not overwrite hydrated executions

### DIFF
--- a/app/scripts/modules/core/src/pipeline/executions/execution/ExecutionMarker.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/execution/ExecutionMarker.tsx
@@ -46,7 +46,7 @@ export class ExecutionMarker extends React.Component<IExecutionMarkerProps, IExe
   private hydrate = (): void => {
     const { execution, application } = this.props;
     ReactInjector.executionService.hydrate(application, execution).then(() => {
-      if (this.mounted) {
+      if (this.mounted && !this.state.hydrated) {
         this.setState({ hydrated: true });
       }
     });

--- a/app/scripts/modules/core/src/pipeline/service/execution.service.ts
+++ b/app/scripts/modules/core/src/pipeline/service/execution.service.ts
@@ -428,6 +428,10 @@ export class ExecutionService {
   }
 
   public synchronizeExecution(current: IExecution, updated: IExecution): void {
+    // don't dehydrate!
+    if (!updated.hydrated && current.hydrated) {
+      return;
+    }
     const hydrationFlagChanged = !current.hydrated && updated.hydrated;
     (updated.stageSummaries || []).forEach((updatedSummary, idx) => {
       const currentSummary = current.stageSummaries[idx];


### PR DESCRIPTION
Prevents replacement of a hydrated execution's stages with ones that are not hydrated.

This is the last bug we'll encounter due to the hydration code.

cc @danielpeach 