### PR TITLE
fix(settings): add gitlab git source by default

### DIFF
--- a/halconfig/settings.js
+++ b/halconfig/settings.js
@@ -152,7 +152,7 @@ window.spinnakerSettings = {
   },
   authEnabled: authEnabled,
   authTtl: 600000,
-  gitSources: ['stash', 'github', 'bitbucket'],
+  gitSources: ['stash', 'github', 'bitbucket', 'gitlab'],
   pubsubProviders: ['google'], // TODO(joonlim): Add amazon once it is confirmed that amazon pub/sub works.
   triggerTypes: ['git', 'pipeline', 'docker', 'cron', 'jenkins', 'travis', 'pubsub', 'webhook'],
   canary: {

--- a/settings.js
+++ b/settings.js
@@ -152,7 +152,7 @@ window.spinnakerSettings = {
   },
   authEnabled: authEnabled,
   authTtl: 600000,
-  gitSources: ['stash', 'github', 'bitbucket'],
+  gitSources: ['stash', 'github', 'bitbucket', 'gitlab'],
   pubsubProviders: ['google'], // TODO(joonlim): Add amazon once it is confirmed that amazon pub/sub works.
   triggerTypes: ['git', 'pipeline', 'docker', 'cron', 'jenkins', 'travis', 'pubsub'],
   searchVersion: 1,


### PR DESCRIPTION
adds gitlab as a default git source. spinnaker/deck#4657 added the ability to override
this via `settings-local.js`. it seems like the default should be all available git sources
with the ability to pare down as necessary.

@anotherchrisberry @danielpeach PTAL!
