### PR TITLE
fix(amazon): remove listener certs when switching to HTTP

### DIFF
--- a/app/scripts/modules/amazon/src/loadBalancer/configure/application/ALBListeners.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/application/ALBListeners.tsx
@@ -126,6 +126,7 @@ class ALBListenersImpl extends React.Component<
     }
     if (listener.protocol === 'HTTP') {
       listener.port = 80;
+      listener.certificates.length = 0;
     }
     this.updateListeners();
   }


### PR DESCRIPTION
Fixes a minor bug where switching a listener from HTTP -> HTTPS -> HTTP leaves the certificate field in place.