### PR TITLE
 feat(artifacts): Either string or artifact is sufficient for bake stage

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/pipelineConfig.module.js
+++ b/app/scripts/modules/core/src/pipeline/config/pipelineConfig.module.js
@@ -5,6 +5,7 @@ const angular = require('angular');
 import { CREATE_PIPELINE_COMPONENT } from './createPipeline.component';
 import { PIPELINE_GRAPH_COMPONENT } from './graph/pipeline.graph.component';
 import { REQUIRED_FIELD_VALIDATOR } from './validation/requiredField.validator';
+import { ANY_FIELD_REQUIRED_VALIDATOR } from './validation/anyFieldRequired.validator';
 import { SERVICE_ACCOUNT_ACCESS_VALIDATOR } from './validation/serviceAccountAccess.validator';
 import { STAGE_BEFORE_TYPE_VALIDATOR } from './validation/stageBeforeType.validator';
 import { STAGE_OR_TRIGGER_BEFORE_TYPE_VALIDATOR } from './validation/stageOrTriggerBeforeType.validator';
@@ -24,6 +25,7 @@ module.exports = angular.module('spinnaker.core.pipeline.config', [
   require('./pipelineConfigView.js').name,
   require('./pipelineConfigurer.js').name,
   REQUIRED_FIELD_VALIDATOR,
+  ANY_FIELD_REQUIRED_VALIDATOR,
   TARGET_IMPEDANCE_VALIDATOR,
   STAGE_OR_TRIGGER_BEFORE_TYPE_VALIDATOR,
   STAGE_BEFORE_TYPE_VALIDATOR,

--- a/app/scripts/modules/core/src/pipeline/config/validation/anyFieldRequired.validator.ts
+++ b/app/scripts/modules/core/src/pipeline/config/validation/anyFieldRequired.validator.ts
@@ -1,0 +1,47 @@
+import { module } from 'angular';
+import { map, some } from 'lodash';
+
+import { IPipeline, IStage, IStageOrTriggerTypeConfig, ITrigger } from 'core/domain';
+import { BaseRequiredFieldValidator, IRequiredField } from './baseRequiredField.validator';
+import { PIPELINE_CONFIG_VALIDATOR, PipelineConfigValidator } from './pipelineConfig.validator';
+import { IBaseRequiredFieldValidationConfig } from 'core/pipeline/config/validation/baseRequiredField.validator';
+
+export interface IMultiRequiredField extends IBaseRequiredFieldValidationConfig {
+  fields: IRequiredField[];
+}
+
+export type IAnyFieldRequiredValidationConfig = IBaseRequiredFieldValidationConfig & IMultiRequiredField;
+
+export class AnyFieldRequiredValidator extends BaseRequiredFieldValidator {
+  protected passesValidation(
+    pipeline: IPipeline,
+    stage: IStage | ITrigger,
+    validationConfig: IAnyFieldRequiredValidationConfig,
+  ): boolean {
+    return some(validationConfig.fields, (requiredField: IRequiredField) => {
+      return this.fieldIsValid(pipeline, stage, requiredField.fieldName);
+    });
+  }
+
+  protected validationMessage(
+    validationConfig: IAnyFieldRequiredValidationConfig,
+    config: IStageOrTriggerTypeConfig,
+  ): string {
+    let fieldString: string = map(validationConfig.fields, (requiredField: IRequiredField) =>
+      this.printableFieldLabel(requiredField),
+    ).join(', ');
+    return (
+      validationConfig.message ||
+      `At least one of the following fields must be supplied for ${
+        config.label
+      } stages: <strong>${fieldString}</strong>.`
+    );
+  }
+}
+
+export const ANY_FIELD_REQUIRED_VALIDATOR = 'spinnaker.core.pipeline.config.validation.anyFieldRequired';
+module(ANY_FIELD_REQUIRED_VALIDATOR, [PIPELINE_CONFIG_VALIDATOR])
+  .service('anyFieldRequiredValidator', AnyFieldRequiredValidator)
+  .run((pipelineConfigValidator: PipelineConfigValidator, anyFieldRequiredValidator: AnyFieldRequiredValidator) => {
+    pipelineConfigValidator.registerValidator('anyFieldRequired', anyFieldRequiredValidator);
+  });

--- a/app/scripts/modules/core/src/pipeline/config/validation/anyFieldRequired.validator.ts
+++ b/app/scripts/modules/core/src/pipeline/config/validation/anyFieldRequired.validator.ts
@@ -1,5 +1,4 @@
 import { module } from 'angular';
-import { map, some } from 'lodash';
 
 import { IPipeline, IStage, IStageOrTriggerTypeConfig, ITrigger } from 'core/domain';
 import { BaseRequiredFieldValidator, IRequiredField } from './baseRequiredField.validator';
@@ -18,7 +17,7 @@ export class AnyFieldRequiredValidator extends BaseRequiredFieldValidator {
     stage: IStage | ITrigger,
     validationConfig: IAnyFieldRequiredValidationConfig,
   ): boolean {
-    return some(validationConfig.fields, (requiredField: IRequiredField) => {
+    return validationConfig.fields.some((requiredField: IRequiredField) => {
       return this.fieldIsValid(pipeline, stage, requiredField.fieldName);
     });
   }
@@ -27,9 +26,9 @@ export class AnyFieldRequiredValidator extends BaseRequiredFieldValidator {
     validationConfig: IAnyFieldRequiredValidationConfig,
     config: IStageOrTriggerTypeConfig,
   ): string {
-    let fieldString: string = map(validationConfig.fields, (requiredField: IRequiredField) =>
-      this.printableFieldLabel(requiredField),
-    ).join(', ');
+    const fieldString: string = validationConfig.fields
+      .map((requiredField: IRequiredField) => this.printableFieldLabel(requiredField))
+      .join(', ');
     return (
       validationConfig.message ||
       `At least one of the following fields must be supplied for ${

--- a/app/scripts/modules/core/src/pipeline/config/validation/baseRequiredField.validator.ts
+++ b/app/scripts/modules/core/src/pipeline/config/validation/baseRequiredField.validator.ts
@@ -37,7 +37,7 @@ export abstract class BaseRequiredFieldValidator implements IStageOrTriggerValid
   ): string;
 
   protected printableFieldLabel(field: IRequiredField): string {
-    let fieldLabel: string = field.fieldLabel || field.fieldName;
+    const fieldLabel: string = field.fieldLabel || field.fieldName;
     return upperFirst(fieldLabel);
   }
 
@@ -49,8 +49,6 @@ export abstract class BaseRequiredFieldValidator implements IStageOrTriggerValid
     const fieldExists = has(stage, fieldName);
     const field: any = get(stage, fieldName);
 
-    return fieldExists && (field || field === 0) && !(field instanceof Array && field.length === 0);
+    return fieldExists && (field || field === 0) && !(Array.isArray(field) && field.length === 0);
   }
 }
-
-export const BASE_REQUIRED_FIELD_VALIDATOR = 'spinnaker.core.pipeline.config.validation.baseRequiredField';

--- a/app/scripts/modules/core/src/pipeline/config/validation/baseRequiredField.validator.ts
+++ b/app/scripts/modules/core/src/pipeline/config/validation/baseRequiredField.validator.ts
@@ -1,0 +1,56 @@
+import { get, has } from 'lodash';
+
+import { IPipeline, IStage, IStageOrTriggerTypeConfig, ITrigger } from 'core/domain';
+import { IStageOrTriggerValidator, IValidatorConfig } from './pipelineConfig.validator';
+
+export interface IRequiredField {
+  fieldName: string;
+  fieldLabel?: string;
+}
+
+export interface IBaseRequiredFieldValidationConfig extends IValidatorConfig {
+  message?: string;
+}
+
+export abstract class BaseRequiredFieldValidator implements IStageOrTriggerValidator {
+  public validate(
+    pipeline: IPipeline,
+    stage: IStage | ITrigger,
+    validationConfig: IBaseRequiredFieldValidationConfig,
+    config: IStageOrTriggerTypeConfig,
+  ): string {
+    if (!this.passesValidation(pipeline, stage, validationConfig)) {
+      return this.validationMessage(validationConfig, config);
+    }
+    return null;
+  }
+
+  protected abstract passesValidation(
+    pipeline: IPipeline,
+    stage: IStage | ITrigger,
+    validationConfig: IBaseRequiredFieldValidationConfig,
+  ): boolean;
+
+  protected abstract validationMessage(
+    validationConfig: IBaseRequiredFieldValidationConfig,
+    config: IStageOrTriggerTypeConfig,
+  ): string;
+
+  protected printableFieldLabel(field: IRequiredField): string {
+    let fieldLabel: string = field.fieldLabel || field.fieldName;
+    return fieldLabel.charAt(0).toUpperCase() + fieldLabel.substr(1);
+  }
+
+  protected fieldIsValid(pipeline: IPipeline, stage: IStage | ITrigger, fieldName: string): boolean {
+    if (pipeline.strategy === true && ['cluster', 'regions', 'zones', 'credentials'].includes(fieldName)) {
+      return true;
+    }
+
+    const fieldExists = has(stage, fieldName);
+    const field: any = get(stage, fieldName);
+
+    return fieldExists && (field || field === 0) && !(field instanceof Array && field.length === 0);
+  }
+}
+
+export const BASE_REQUIRED_FIELD_VALIDATOR = 'spinnaker.core.pipeline.config.validation.baseRequiredField';

--- a/app/scripts/modules/core/src/pipeline/config/validation/baseRequiredField.validator.ts
+++ b/app/scripts/modules/core/src/pipeline/config/validation/baseRequiredField.validator.ts
@@ -1,4 +1,4 @@
-import { get, has } from 'lodash';
+import { get, has, upperFirst } from 'lodash';
 
 import { IPipeline, IStage, IStageOrTriggerTypeConfig, ITrigger } from 'core/domain';
 import { IStageOrTriggerValidator, IValidatorConfig } from './pipelineConfig.validator';
@@ -38,7 +38,7 @@ export abstract class BaseRequiredFieldValidator implements IStageOrTriggerValid
 
   protected printableFieldLabel(field: IRequiredField): string {
     let fieldLabel: string = field.fieldLabel || field.fieldName;
-    return fieldLabel.charAt(0).toUpperCase() + fieldLabel.substr(1);
+    return upperFirst(fieldLabel);
   }
 
   protected fieldIsValid(pipeline: IPipeline, stage: IStage | ITrigger, fieldName: string): boolean {

--- a/app/scripts/modules/core/src/pipeline/config/validation/requiredField.validator.ts
+++ b/app/scripts/modules/core/src/pipeline/config/validation/requiredField.validator.ts
@@ -1,38 +1,18 @@
 import { module } from 'angular';
-import { get, has } from 'lodash';
 
 import { IPipeline, IStage, IStageOrTriggerTypeConfig, ITrigger } from 'core/domain';
-import {
-  IStageOrTriggerValidator,
-  IValidatorConfig,
-  PIPELINE_CONFIG_VALIDATOR,
-  PipelineConfigValidator,
-} from './pipelineConfig.validator';
+import { BaseRequiredFieldValidator, IRequiredField } from './baseRequiredField.validator';
+import { PIPELINE_CONFIG_VALIDATOR, PipelineConfigValidator } from './pipelineConfig.validator';
+import { IBaseRequiredFieldValidationConfig } from 'core/pipeline/config/validation/baseRequiredField.validator';
 
 export interface IRequiredField {
   fieldName: string;
   fieldLabel?: string;
 }
 
-export interface IBaseRequiredFieldValidationConfig extends IValidatorConfig {
-  message?: string;
-}
+export type IRequiredFieldValidationConfig = IBaseRequiredFieldValidationConfig & IRequiredField;
 
-export type IRequiredFieldValidationConfig = IRequiredField & IBaseRequiredFieldValidationConfig;
-
-export class RequiredFieldValidator implements IStageOrTriggerValidator {
-  public validate(
-    pipeline: IPipeline,
-    stage: IStage | ITrigger,
-    validationConfig: IRequiredFieldValidationConfig,
-    config: IStageOrTriggerTypeConfig,
-  ): string {
-    if (!this.passesValidation(pipeline, stage, validationConfig)) {
-      return this.validationMessage(validationConfig, config);
-    }
-    return null;
-  }
-
+export class RequiredFieldValidator extends BaseRequiredFieldValidator {
   protected passesValidation(
     pipeline: IPipeline,
     stage: IStage | ITrigger,
@@ -47,22 +27,6 @@ export class RequiredFieldValidator implements IStageOrTriggerValidator {
   ): string {
     let fieldLabel: string = this.printableFieldLabel(validationConfig);
     return validationConfig.message || `<strong>${fieldLabel}</strong> is a required field for ${config.label} stages.`;
-  }
-
-  protected printableFieldLabel(field: IRequiredField): string {
-    let fieldLabel: string = field.fieldLabel || field.fieldName;
-    return fieldLabel.charAt(0).toUpperCase() + fieldLabel.substr(1);
-  }
-
-  protected fieldIsValid(pipeline: IPipeline, stage: IStage | ITrigger, fieldName: string): boolean {
-    if (pipeline.strategy === true && ['cluster', 'regions', 'zones', 'credentials'].includes(fieldName)) {
-      return true;
-    }
-
-    const fieldExists = has(stage, fieldName);
-    const field: any = get(stage, fieldName);
-
-    return fieldExists && (field || field === 0) && !(field instanceof Array && field.length === 0);
   }
 }
 

--- a/app/scripts/modules/core/src/pipeline/config/validation/requiredField.validator.ts
+++ b/app/scripts/modules/core/src/pipeline/config/validation/requiredField.validator.ts
@@ -9,11 +9,16 @@ import {
   PipelineConfigValidator,
 } from './pipelineConfig.validator';
 
-export interface IRequiredFieldValidationConfig extends IValidatorConfig {
+export interface IRequiredField {
   fieldName: string;
   fieldLabel?: string;
+}
+
+export interface IBaseRequiredFieldValidationConfig extends IValidatorConfig {
   message?: string;
 }
+
+export type IRequiredFieldValidationConfig = IRequiredField & IBaseRequiredFieldValidationConfig;
 
 export class RequiredFieldValidator implements IStageOrTriggerValidator {
   public validate(
@@ -22,24 +27,42 @@ export class RequiredFieldValidator implements IStageOrTriggerValidator {
     validationConfig: IRequiredFieldValidationConfig,
     config: IStageOrTriggerTypeConfig,
   ): string {
-    if (
-      pipeline.strategy === true &&
-      ['cluster', 'regions', 'zones', 'credentials'].includes(validationConfig.fieldName)
-    ) {
-      return null;
-    }
-
-    let fieldLabel: string = validationConfig.fieldLabel || validationConfig.fieldName;
-    fieldLabel = fieldLabel.charAt(0).toUpperCase() + fieldLabel.substr(1);
-    const validationMessage =
-      validationConfig.message || `<strong>${fieldLabel}</strong> is a required field for ${config.label} stages.`;
-    const fieldExists = has(stage, validationConfig.fieldName);
-    const field: any = get(stage, validationConfig.fieldName);
-
-    if (!fieldExists || (!field && field !== 0) || (field instanceof Array && field.length === 0)) {
-      return validationMessage;
+    if (!this.passesValidation(pipeline, stage, validationConfig)) {
+      return this.validationMessage(validationConfig, config);
     }
     return null;
+  }
+
+  protected passesValidation(
+    pipeline: IPipeline,
+    stage: IStage | ITrigger,
+    validationConfig: IRequiredFieldValidationConfig,
+  ): boolean {
+    return this.fieldIsValid(pipeline, stage, validationConfig.fieldName);
+  }
+
+  protected validationMessage(
+    validationConfig: IRequiredFieldValidationConfig,
+    config: IStageOrTriggerTypeConfig,
+  ): string {
+    let fieldLabel: string = this.printableFieldLabel(validationConfig);
+    return validationConfig.message || `<strong>${fieldLabel}</strong> is a required field for ${config.label} stages.`;
+  }
+
+  protected printableFieldLabel(field: IRequiredField): string {
+    let fieldLabel: string = field.fieldLabel || field.fieldName;
+    return fieldLabel.charAt(0).toUpperCase() + fieldLabel.substr(1);
+  }
+
+  protected fieldIsValid(pipeline: IPipeline, stage: IStage | ITrigger, fieldName: string): boolean {
+    if (pipeline.strategy === true && ['cluster', 'regions', 'zones', 'credentials'].includes(fieldName)) {
+      return true;
+    }
+
+    const fieldExists = has(stage, fieldName);
+    const field: any = get(stage, fieldName);
+
+    return fieldExists && (field || field === 0) && !(field instanceof Array && field.length === 0);
   }
 }
 

--- a/app/scripts/modules/core/src/pipeline/config/validation/requiredField.validator.ts
+++ b/app/scripts/modules/core/src/pipeline/config/validation/requiredField.validator.ts
@@ -25,7 +25,7 @@ export class RequiredFieldValidator extends BaseRequiredFieldValidator {
     validationConfig: IRequiredFieldValidationConfig,
     config: IStageOrTriggerTypeConfig,
   ): string {
-    let fieldLabel: string = this.printableFieldLabel(validationConfig);
+    const fieldLabel: string = this.printableFieldLabel(validationConfig);
     return validationConfig.message || `<strong>${fieldLabel}</strong> is a required field for ${config.label} stages.`;
   }
 }

--- a/app/scripts/modules/google/src/pipeline/stages/bake/gceBakeStage.js
+++ b/app/scripts/modules/google/src/pipeline/stages/bake/gceBakeStage.js
@@ -35,7 +35,15 @@ module.exports = angular
       },
       producesArtifacts: true,
       defaultTimeoutMs: 60 * 60 * 1000, // 60 minutes
-      validators: [{ type: 'requiredField', fieldName: 'package' }],
+      validators: [
+        {
+          type: 'anyFieldRequired',
+          fields: [
+            { fieldName: 'package', fieldLabel: 'Package' },
+            { fieldName: 'packageArtifactIds', fieldLabel: 'Package Artifacts' },
+          ],
+        },
+      ],
       restartable: true,
     });
     artifactReferenceServiceProvider.registerReference('stage', () => [['packageArtifactIds']]);


### PR DESCRIPTION
Allow packages to be specified as either a string or a list of artifacts on the bake stage.  To implement this, create a new field validator that checks if at least one of a list of fields is non-null.