### PR TITLE
perf(core): Support loading an application with `?expand=false`

### DIFF
--- a/app/scripts/modules/core/src/application/application.state.provider.ts
+++ b/app/scripts/modules/core/src/application/application.state.provider.ts
@@ -93,7 +93,7 @@ export class ApplicationStateProvider implements IServiceProvider {
             applicationModelBuilder: ApplicationModelBuilder,
           ) => {
             return applicationReader
-              .getApplication($stateParams.application)
+              .getApplication($stateParams.application, false)
               .then((app: Application): Application => {
                 inferredApplicationWarningService.checkIfInferredAndWarn(app);
                 return app || applicationModelBuilder.createNotFoundApplication($stateParams.application);

--- a/app/scripts/modules/core/src/application/service/application.read.service.spec.ts
+++ b/app/scripts/modules/core/src/application/service/application.read.service.spec.ts
@@ -65,7 +65,11 @@ describe('Service: applicationReader', function() {
       if (dataSources !== undefined) {
         response.attributes['dataSources'] = dataSources;
       }
-      spyOn(API, 'one').and.returnValue({ get: () => $q.when(response) });
+      spyOn(API, 'one').and.returnValue({
+        withParams: () => {
+          return { get: () => $q.when(response) };
+        },
+      });
       spyOn(securityGroupReader, 'loadSecurityGroupsByApplicationName').and.returnValue($q.when([]));
       spyOn(loadBalancerReader, 'loadLoadBalancers').and.returnValue($q.when([]));
       spyOn(clusterService, 'loadServerGroups').and.returnValue($q.when([]));

--- a/app/scripts/modules/core/src/application/service/application.read.service.ts
+++ b/app/scripts/modules/core/src/application/service/application.read.service.ts
@@ -59,8 +59,9 @@ export class ApplicationReader {
       });
   }
 
-  public getApplication(name: string): IPromise<Application> {
+  public getApplication(name: string, expand = true): IPromise<Application> {
     return API.one('applications', name)
+      .withParams({ expand: expand })
       .get()
       .then((fromServer: Application) => {
         const application: Application = new Application(


### PR DESCRIPTION
Significant improvement in load time for situations where you _do not_
need cluster, server group and load balancer names.
