### PR TITLE
feat(webhook): override webhook timeout

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/webhook/webhookStage.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/webhook/webhookStage.ts
@@ -149,6 +149,7 @@ module(WEBHOOK_STAGE, [JSON_UTILITY_SERVICE, PIPELINE_CONFIG_PROVIDER])
       controllerAs: '$ctrl',
       templateUrl: require('./webhookStage.html'),
       executionDetailsUrl: require('./webhookExecutionDetails.html'),
+      defaultTimeoutMs: 60 * 60 * 1000, // 1 hour
       validators: [{ type: 'requiredField', fieldName: 'url' }, { type: 'requiredField', fieldName: 'method' }],
     });
   })


### PR DESCRIPTION
Maybe your webhook is polling for results and takes longer than 1 hour to complete. Let's surface the timeout for this case so you can override it.