### PR TITLE
fix(core/clusters): prevent scroll reset on instance clicks; better n…

### DIFF
--- a/app/scripts/modules/core/src/instance/InstanceListBody.tsx
+++ b/app/scripts/modules/core/src/instance/InstanceListBody.tsx
@@ -47,7 +47,7 @@ export class InstanceListBody extends React.Component<IInstanceListBodyProps, II
       .takeUntil(this.destroy$)
       .subscribe(() => {
         this.setState({
-          activeInstanceId: this.$state.params.activeInstanceId,
+          activeInstanceId: this.$state.params.instanceId,
           multiselect: this.$state.params.multiselect,
         });
       });

--- a/app/scripts/modules/core/src/instance/Instances.tsx
+++ b/app/scripts/modules/core/src/instance/Instances.tsx
@@ -71,7 +71,9 @@ export class Instances extends React.Component<IInstancesProps, IInstancesState>
 
   private partitionInstances(): IInstance[][] {
     const partitions: IInstance[][] = [];
-    const instances = (this.props.instances || []).sort((a, b) => a.launchTime - b.launchTime);
+    const instances = (this.props.instances || []).sort(
+      (a, b) => a.launchTime - b.launchTime || a.id.localeCompare(b.id),
+    );
     if (!instances.length) {
       return partitions;
     }


### PR DESCRIPTION
…o rows messaging

Easy to explain: 
* better message when no rows are shown on the clusters view. If there are no server groups in the app, say that. If it's in fetch on demand mode and no clusters are selected, say nothing.
* correctly highlight selected rows in the detailed (i.e. full row per instance) view
* sort instances by launch time, but fall back to id if the launch times are the same

Harder to explain part: on the clusters view, if you have very large clusters, i.e. clusters that have enough instances to span multiple lines per server group, clicking around on instances can cause the scroll position to get reset. This happens because we are way too aggressively clearing the cell cache, which is basically a computed store of heights for each cluster pod. If the virtualized list has already rendered a big cluster pod above, when you click on an instance below, the height gets reset to 177px, even if it was, say, 500px. So the scroll bar jumps back up.

Instead of caching by row index, we can cache by the number of instances in the normal view, and the number of instances per cluster pod in the detailed view (which should account for multiple load balancers causing varying heights of instances). I think this is going to work >99% of the time. It is definitely 95% better than what's happening now.

The cluster key is a sorted grouping of number of number of instances per subgroup, e.g. `1; 5, 5` would indicate two subgroups (regions), one with a single server group with one instance, another with two server groups, each with five instances. For detailed views, this is prefixed with the cluster name, e.g. `myapp-cluster: 1; 5, 5`.