### PR TITLE
feat(artifacts): show artifact type as icon in execution summary

### DIFF
--- a/app/scripts/modules/core/src/pipeline/status/ArtifactList.spec.tsx
+++ b/app/scripts/modules/core/src/pipeline/status/ArtifactList.spec.tsx
@@ -40,7 +40,7 @@ describe('<ArtifactList/>', () => {
     expect(component.find('ul.trigger-details.artifacts').length).toEqual(1);
   });
 
-  it("renders an artifact's type and name", function() {
+  it("renders an artifact's name", function() {
     const artifacts: IArtifact[] = [
       {
         id: 'abcd',
@@ -54,12 +54,9 @@ describe('<ArtifactList/>', () => {
     const dt = li.find('dt');
     const dd = li.find('dd');
     expect(li.length).toEqual(1);
-    expect(dt.length).toEqual(2);
-    expect(dd.length).toEqual(2);
-    expect(dt.at(0).text()).toEqual('Type');
-    expect(dd.at(0).text()).toEqual(ARTIFACT_TYPE);
-    expect(dt.at(1).text()).toEqual('Artifact');
-    expect(dd.at(1).text()).toEqual(ARTIFACT_NAME);
+    expect(dt.length).toEqual(1);
+    expect(dd.length).toEqual(1);
+    expect(dd.at(0).text()).toEqual(ARTIFACT_NAME);
   });
 
   it('does not render artifacts without a type and name', function() {
@@ -101,11 +98,11 @@ describe('<ArtifactList/>', () => {
     const resolvedExpectedArtifacts = artifacts.map(a => ({ boundArtifact: a } as IExpectedArtifact));
     component = shallow(<ArtifactList artifacts={artifacts} resolvedExpectedArtifacts={resolvedExpectedArtifacts} />);
     const li = component.find('li');
-    expect(li.find('dd').length).toEqual(3);
+    expect(li.find('dd').length).toEqual(2);
     expect(
       li
         .find('dd')
-        .at(2)
+        .at(1)
         .text(),
     ).toEqual(version);
   });

--- a/app/scripts/modules/core/src/pipeline/status/ArtifactList.tsx
+++ b/app/scripts/modules/core/src/pipeline/status/ArtifactList.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { IArtifact, IExpectedArtifact } from 'core/domain';
+import { ArtifactIconService } from 'core';
 
 import './artifactList.less';
 
@@ -66,11 +67,9 @@ export class ArtifactList extends React.Component<IArtifactListProps, IArtifactL
             <li key={`${i}-${name}`} className="break-word" title={this.tooltip(artifact, isDefault)}>
               <dl>
                 <div>
-                  <dt>Type</dt>
-                  <dd>{type}</dd>
-                </div>
-                <div>
-                  <dt>Artifact{isDefault && '*'}</dt>
+                  <dt>
+                    <img className="artifact-icon" src={ArtifactIconService.getPath(type)} width="18" height="18" />
+                  </dt>
                   <dd>{name}</dd>
                 </div>
                 {version && (

--- a/app/scripts/modules/core/src/pipeline/status/artifactList.less
+++ b/app/scripts/modules/core/src/pipeline/status/artifactList.less
@@ -9,20 +9,26 @@
       text-overflow: ellipsis;
       overflow: hidden;
       font-size: inherit;
-      height: 12px;
+      height: 18px;
+      line-height: 18px;
     }
 
     dl {
       margin: 0;
     }
 
-    dd, dt {
+    dd,
+    dt {
       display: inline;
     }
 
     dt {
       font-weight: normal;
       padding: 0 4px 0 0;
+    }
+
+    .artifact-icon {
+      padding-right: 4px;
     }
   }
 }


### PR DESCRIPTION
<img width="275" alt="screen shot 2018-05-17 at 12 42 00 pm" src="https://user-images.githubusercontent.com/34253460/40191524-cc3a7bec-59cf-11e8-8523-e88ab25a3b42.png">

<img width="225" alt="screen shot 2018-05-17 at 12 42 17 pm" src="https://user-images.githubusercontent.com/34253460/40191525-cc5b7b8a-59cf-11e8-9f73-ea03ea60998e.png">
