### PR TITLE
chore(artifacts): de-angularize expected artifact service

### DIFF
--- a/app/scripts/modules/core/src/artifact/artifact.module.ts
+++ b/app/scripts/modules/core/src/artifact/artifact.module.ts
@@ -1,7 +1,7 @@
 import { module } from 'angular';
 
 import { EXPECTED_ARTIFACT_SELECTOR_COMPONENT } from './expectedArtifactSelector.component';
-import { EXPECTED_ARTIFACT_SERVICE } from './expectedArtifact.service';
+import { SUMMARIZE_EXPECTED_ARTIFACT_FILTER } from './summarizeExpectedArtifact';
 import { EXPECTED_ARTIFACT_MULTI_SELECTOR_COMPONENT } from './expectedArtifactMultiSelector.component';
 import { IMAGE_SOURCE_SELECTOR_COMPONENT } from './imageSourceSelector.component';
 
@@ -9,6 +9,6 @@ export const ARTIFACT_MODULE = 'spinnaker.core.artifact';
 module(ARTIFACT_MODULE, [
   EXPECTED_ARTIFACT_MULTI_SELECTOR_COMPONENT,
   EXPECTED_ARTIFACT_SELECTOR_COMPONENT,
-  EXPECTED_ARTIFACT_SERVICE,
+  SUMMARIZE_EXPECTED_ARTIFACT_FILTER,
   IMAGE_SOURCE_SELECTOR_COMPONENT,
 ]);

--- a/app/scripts/modules/core/src/artifact/expectedArtifact.service.ts
+++ b/app/scripts/modules/core/src/artifact/expectedArtifact.service.ts
@@ -1,10 +1,8 @@
-import { copy, module } from 'angular';
-
-import { IArtifact, IExpectedArtifact, IPipeline, IStage } from 'core/domain';
 import { PipelineConfigService } from 'core/pipeline/config/services/PipelineConfigService';
+import { IPipeline, IStage, IExpectedArtifact } from 'core/domain';
 
 export class ExpectedArtifactService {
-  public getExpectedArtifactsAvailableToStage(stage: IStage, pipeline: IPipeline): IExpectedArtifact[] {
+  public static getExpectedArtifactsAvailableToStage(stage: IStage, pipeline: IPipeline): IExpectedArtifact[] {
     let result = pipeline.expectedArtifacts || [];
     PipelineConfigService.getAllUpstreamDependencies(pipeline, stage).forEach(s => {
       const expectedArtifact = (s as any).expectedArtifact;
@@ -20,23 +18,3 @@ export class ExpectedArtifactService {
     return result;
   }
 }
-
-export function summarizeExpectedArtifact() {
-  return function(expected: IExpectedArtifact): string {
-    if (!expected) {
-      return '';
-    }
-
-    const artifact = copy(expected.matchArtifact);
-    return Object.keys(artifact)
-      .filter((k: keyof IArtifact) => artifact[k])
-      .filter(k => k !== 'kind')
-      .map((k: keyof IArtifact) => `${k}: ${artifact[k]}`)
-      .join(', ');
-  };
-}
-
-export const EXPECTED_ARTIFACT_SERVICE = 'spinnaker.core.artifacts.expected.service';
-module(EXPECTED_ARTIFACT_SERVICE, [])
-  .filter('summarizeExpectedArtifact', summarizeExpectedArtifact)
-  .service('expectedArtifactService', ExpectedArtifactService);

--- a/app/scripts/modules/core/src/artifact/expectedArtifactMultiSelector.component.ts
+++ b/app/scripts/modules/core/src/artifact/expectedArtifactMultiSelector.component.ts
@@ -1,7 +1,5 @@
 import { IComponentOptions, IController, module } from 'angular';
-
 import { IExpectedArtifact } from 'core/domain';
-import { EXPECTED_ARTIFACT_SERVICE, ExpectedArtifactService } from './expectedArtifact.service';
 import { ArtifactIconService } from './ArtifactIconService';
 
 import './artifactSelector.less';
@@ -13,10 +11,6 @@ class ExpectedArtifactMultiSelectorCtrl implements IController {
   public expectedArtifacts: IExpectedArtifact[];
   public helpFieldKey: string;
   public showIcons: boolean;
-
-  constructor(public expectedArtifactService: ExpectedArtifactService) {
-    'ngInject';
-  }
 
   public iconPath(expected: IExpectedArtifact): string {
     const artifact = expected.matchArtifact || expected.defaultArtifact;
@@ -61,7 +55,7 @@ class ExpectedArtifactMultiSelectorComponent implements IComponentOptions {
 }
 
 export const EXPECTED_ARTIFACT_MULTI_SELECTOR_COMPONENT = 'spinnaker.core.artifacts.expected.multiSelector';
-module(EXPECTED_ARTIFACT_MULTI_SELECTOR_COMPONENT, [EXPECTED_ARTIFACT_SERVICE]).component(
+module(EXPECTED_ARTIFACT_MULTI_SELECTOR_COMPONENT, []).component(
   'expectedArtifactMultiSelector',
   new ExpectedArtifactMultiSelectorComponent(),
 );

--- a/app/scripts/modules/core/src/artifact/expectedArtifactSelector.component.ts
+++ b/app/scripts/modules/core/src/artifact/expectedArtifactSelector.component.ts
@@ -2,7 +2,6 @@ import { IComponentOptions, IController, module } from 'angular';
 
 import { IExpectedArtifact } from 'core/domain';
 import { IAccount } from 'core/account';
-import { EXPECTED_ARTIFACT_SERVICE, ExpectedArtifactService } from './expectedArtifact.service';
 import { ArtifactIconService } from './ArtifactIconService';
 
 import './artifactSelector.less';
@@ -15,10 +14,6 @@ class ExpectedArtifactSelectorCtrl implements IController {
   public expectedArtifacts: IExpectedArtifact[];
   public helpFieldKey: string;
   public showIcons: boolean;
-
-  constructor(public expectedArtifactService: ExpectedArtifactService) {
-    'ngInject';
-  }
 
   public iconPath(expected: IExpectedArtifact): string {
     const artifact = expected.matchArtifact || expected.defaultArtifact;
@@ -73,7 +68,7 @@ class ExpectedArtifactSelectorComponent implements IComponentOptions {
 }
 
 export const EXPECTED_ARTIFACT_SELECTOR_COMPONENT = 'spinnaker.core.artifacts.expected.selector';
-module(EXPECTED_ARTIFACT_SELECTOR_COMPONENT, [EXPECTED_ARTIFACT_SERVICE]).component(
+module(EXPECTED_ARTIFACT_SELECTOR_COMPONENT, []).component(
   'expectedArtifactSelector',
   new ExpectedArtifactSelectorComponent(),
 );

--- a/app/scripts/modules/core/src/artifact/summarizeExpectedArtifact.ts
+++ b/app/scripts/modules/core/src/artifact/summarizeExpectedArtifact.ts
@@ -1,0 +1,20 @@
+import { copy, module } from 'angular';
+import { IArtifact, IExpectedArtifact } from 'core/domain';
+
+export function summarizeExpectedArtifact() {
+  return function(expected: IExpectedArtifact): string {
+    if (!expected) {
+      return '';
+    }
+
+    const artifact = copy(expected.matchArtifact);
+    return Object.keys(artifact)
+      .filter((k: keyof IArtifact) => artifact[k])
+      .filter(k => k !== 'kind')
+      .map((k: keyof IArtifact) => `${k}: ${artifact[k]}`)
+      .join(', ');
+  };
+}
+
+export const SUMMARIZE_EXPECTED_ARTIFACT_FILTER = 'spinnaker.core.artifacts.expected.service';
+module(SUMMARIZE_EXPECTED_ARTIFACT_FILTER, []).filter('summarizeExpectedArtifact', summarizeExpectedArtifact);

--- a/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/bakeManifestConfig.controller.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/bakeManifestConfig.controller.ts
@@ -11,26 +11,28 @@ export class BakeManifestConfigCtrl implements IController {
   public static defaultInputArtifact(): any {
     return {
       id: '',
-      account: ''
-    }
+      account: '',
+    };
   }
 
-  constructor(public $scope: IScope, expectedArtifactService: ExpectedArtifactService) {
+  constructor(public $scope: IScope) {
     'ngInject';
     if (this.$scope.stage.isNew) {
       const defaultSelection = {
         templateRenderer: 'HELM2',
-        expectedArtifacts: [{
-          matchArtifact: {
-            type: 'embedded/base64',
-            kind: 'base64',
-            name: ''
+        expectedArtifacts: [
+          {
+            matchArtifact: {
+              type: 'embedded/base64',
+              kind: 'base64',
+              name: '',
+            },
+            id: UUIDGenerator.generateUuid(),
+            defaultArtifact: {},
+            useDefaultArtifact: false,
           },
-          id: UUIDGenerator.generateUuid(),
-          defaultArtifact: {},
-          useDefaultArtifact: false,
-        }],
-        inputArtifacts: [ BakeManifestConfigCtrl.defaultInputArtifact() ]
+        ],
+        inputArtifacts: [BakeManifestConfigCtrl.defaultInputArtifact()],
       };
 
       Object.assign(this.$scope.stage, defaultSelection);
@@ -40,7 +42,7 @@ export class BakeManifestConfigCtrl implements IController {
       this.artifactAccounts = accounts;
     });
 
-    this.expectedArtifacts = expectedArtifactService.getExpectedArtifactsAvailableToStage(
+    this.expectedArtifacts = ExpectedArtifactService.getExpectedArtifactsAvailableToStage(
       this.$scope.stage,
       this.$scope.$parent.pipeline,
     );
@@ -48,7 +50,7 @@ export class BakeManifestConfigCtrl implements IController {
 
   public hasValueArtifacts(): boolean {
     if (!this.$scope.stage.inputArtifacts) {
-      this.$scope.stage.inputArtifacts = [ BakeManifestConfigCtrl.defaultInputArtifact() ];
+      this.$scope.stage.inputArtifacts = [BakeManifestConfigCtrl.defaultInputArtifact()];
     }
 
     return this.$scope.stage.inputArtifacts.length > 1;
@@ -58,22 +60,22 @@ export class BakeManifestConfigCtrl implements IController {
     // First artifact is special -- the UI depends on it existing. If someone edited the json to remove it,
     // this at least fixes the UI.
     if (!this.$scope.stage.inputArtifacts) {
-      this.$scope.stage.inputArtifacts = [ BakeManifestConfigCtrl.defaultInputArtifact() ];
+      this.$scope.stage.inputArtifacts = [BakeManifestConfigCtrl.defaultInputArtifact()];
     }
 
-    this.$scope.stage.inputArtifacts.push(BakeManifestConfigCtrl.defaultInputArtifact())
+    this.$scope.stage.inputArtifacts.push(BakeManifestConfigCtrl.defaultInputArtifact());
   }
 
   public removeInputArtifact(i: number) {
     if (!this.$scope.stage.inputArtifacts) {
-      this.$scope.stage.inputArtifacts = [ BakeManifestConfigCtrl.defaultInputArtifact() ];
+      this.$scope.stage.inputArtifacts = [BakeManifestConfigCtrl.defaultInputArtifact()];
     }
 
     if (i <= 0) {
       return;
     }
 
-    this.$scope.stage.inputArtifacts.splice(i, 1)
+    this.$scope.stage.inputArtifacts.splice(i, 1);
   }
 
   public outputNameChange() {

--- a/app/scripts/modules/google/src/pipeline/stages/bake/gceBakeStage.js
+++ b/app/scripts/modules/google/src/pipeline/stages/bake/gceBakeStage.js
@@ -8,7 +8,7 @@ import {
   AuthenticationService,
   BakeExecutionLabel,
   BAKERY_SERVICE,
-  EXPECTED_ARTIFACT_SERVICE,
+  ExpectedArtifactService,
   PipelineTemplates,
   Registry,
   SETTINGS,
@@ -19,7 +19,6 @@ module.exports = angular
     ARTIFACT_REFERENCE_SERVICE_PROVIDER,
     require('./bakeExecutionDetails.controller.js').name,
     BAKERY_SERVICE,
-    EXPECTED_ARTIFACT_SERVICE,
   ])
   .config(function(artifactReferenceServiceProvider) {
     Registry.pipeline.registerStage({
@@ -48,7 +47,7 @@ module.exports = angular
     });
     artifactReferenceServiceProvider.registerReference('stage', () => [['packageArtifactIds']]);
   })
-  .controller('gceBakeStageCtrl', function($scope, bakeryService, $q, $uibModal, expectedArtifactService) {
+  .controller('gceBakeStageCtrl', function($scope, bakeryService, $q, $uibModal) {
     $scope.stage.extendedAttributes = $scope.stage.extendedAttributes || {};
     $scope.stage.region = 'global';
 
@@ -70,7 +69,7 @@ module.exports = angular
         .all({
           baseOsOptions: bakeryService.getBaseOsOptions('gce'),
           baseLabelOptions: bakeryService.getBaseLabelOptions(),
-          expectedArtifacts: expectedArtifactService.getExpectedArtifactsAvailableToStage(
+          expectedArtifacts: ExpectedArtifactService.getExpectedArtifactsAvailableToStage(
             $scope.stage,
             $scope.pipeline,
           ),

--- a/app/scripts/modules/google/src/serverGroup/configure/serverGroupCommandBuilder.service.js
+++ b/app/scripts/modules/google/src/serverGroup/configure/serverGroupCommandBuilder.service.js
@@ -3,12 +3,11 @@
 const angular = require('angular');
 import _ from 'lodash';
 
-import { AccountService, EXPECTED_ARTIFACT_SERVICE, INSTANCE_TYPE_SERVICE, NameUtils } from '@spinnaker/core';
+import { AccountService, ExpectedArtifactService, INSTANCE_TYPE_SERVICE, NameUtils } from '@spinnaker/core';
 import { GCEProviderSettings } from 'google/gce.settings';
 
 module.exports = angular
   .module('spinnaker.gce.serverGroupCommandBuilder.service', [
-    EXPECTED_ARTIFACT_SERVICE,
     INSTANCE_TYPE_SERVICE,
     require('google/common/xpnNaming.gce.service.js').name,
     require('./../../instance/custom/customInstanceBuilder.gce.service.js').name,
@@ -16,7 +15,6 @@ module.exports = angular
   ])
   .factory('gceServerGroupCommandBuilder', function(
     $q,
-    expectedArtifactService,
     instanceTypeService,
     gceCustomInstanceBuilderService,
     gceServerGroupHiddenMetadataKeys,
@@ -362,7 +360,7 @@ module.exports = angular
 
     // Only used to prepare view requiring template selecting
     function buildNewServerGroupCommandForPipeline(currentStage, pipeline) {
-      var expectedArtifacts = expectedArtifactService.getExpectedArtifactsAvailableToStage(currentStage, pipeline);
+      var expectedArtifacts = ExpectedArtifactService.getExpectedArtifactsAvailableToStage(currentStage, pipeline);
       return $q.when({
         viewState: {
           expectedArtifacts: expectedArtifacts,
@@ -485,7 +483,7 @@ module.exports = angular
       return asyncLoader.then(function(asyncData) {
         var command = asyncData.command;
 
-        var expectedArtifacts = expectedArtifactService.getExpectedArtifactsAvailableToStage(currentStage, pipeline);
+        var expectedArtifacts = ExpectedArtifactService.getExpectedArtifactsAvailableToStage(currentStage, pipeline);
         var viewState = {
           instanceProfile: asyncData.instanceProfile,
           disableImageSelection: true,

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestConfig.controller.spec.ts
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestConfig.controller.spec.ts
@@ -32,7 +32,6 @@ describe('KubernetesV2DeployManifestConfigCtrl', function() {
   let stage: any;
   let scope: any;
   let cmdBuilder: any;
-  let artSvc: any;
 
   beforeEach(function() {
     metadata = {};
@@ -49,14 +48,11 @@ describe('KubernetesV2DeployManifestConfigCtrl', function() {
     cmdBuilder = {
       buildNewManifestCommand: () => builtCmdPromise,
     };
-    artSvc = {
-      getExpectedArtifactsAvailableToStage: (): any[] => [],
-    };
   });
 
   describe('change', function() {
     it('normalizes yaml doc with a single manifest into an array', function(done) {
-      const ctrl = new Controller(scope, cmdBuilder, artSvc);
+      const ctrl = new Controller(scope, cmdBuilder);
       builtCmdPromise.then(() => {
         ctrl.metadata.manifestText = basicManifest;
         ctrl.change();
@@ -68,7 +64,7 @@ describe('KubernetesV2DeployManifestConfigCtrl', function() {
     });
 
     it('normalizes a yaml doc with a single manifest in an array into a flat array', function(done) {
-      const ctrl = new Controller(scope, cmdBuilder, artSvc);
+      const ctrl = new Controller(scope, cmdBuilder);
       builtCmdPromise.then(() => {
         ctrl.metadata.manifestText = singleManifestArray;
         ctrl.change();
@@ -80,7 +76,7 @@ describe('KubernetesV2DeployManifestConfigCtrl', function() {
     });
 
     it('normalizes a yaml doc with multiple manifest entries in an array into a flat array', function(done) {
-      const ctrl = new Controller(scope, cmdBuilder, artSvc);
+      const ctrl = new Controller(scope, cmdBuilder);
       builtCmdPromise.then(() => {
         ctrl.metadata.manifestText = multipleManifestArray;
         ctrl.change();
@@ -93,7 +89,7 @@ describe('KubernetesV2DeployManifestConfigCtrl', function() {
     });
 
     it('normalizes a yaml doc with multiple manifest documents into a flat array', function(done) {
-      const ctrl = new Controller(scope, cmdBuilder, artSvc);
+      const ctrl = new Controller(scope, cmdBuilder);
       builtCmdPromise.then(() => {
         ctrl.metadata.manifestText = multipleManifestDocuments;
         ctrl.change();

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestConfig.controller.ts
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestConfig.controller.ts
@@ -20,11 +20,7 @@ export class KubernetesV2DeployManifestConfigCtrl implements IController {
 
   public expectedArtifacts: IExpectedArtifact[];
 
-  constructor(
-    private $scope: IScope,
-    private kubernetesManifestCommandBuilder: KubernetesManifestCommandBuilder,
-    private expectedArtifactService: ExpectedArtifactService,
-  ) {
+  constructor(private $scope: IScope, private kubernetesManifestCommandBuilder: KubernetesManifestCommandBuilder) {
     'ngInject';
     this.kubernetesManifestCommandBuilder
       .buildNewManifestCommand(
@@ -46,7 +42,7 @@ export class KubernetesV2DeployManifestConfigCtrl implements IController {
         this.state.loaded = true;
       });
 
-    this.expectedArtifacts = this.expectedArtifactService.getExpectedArtifactsAvailableToStage(
+    this.expectedArtifacts = ExpectedArtifactService.getExpectedArtifactsAvailableToStage(
       $scope.stage,
       $scope.$parent.pipeline,
     );


### PR DESCRIPTION
expected artifact selector continues to work in k8s deploy manifest stage:

<img width="705" alt="screen shot 2018-05-18 at 8 50 52 am" src="https://user-images.githubusercontent.com/34253460/40235742-2c002334-5a79-11e8-83f4-486340cf7775.png">


expected artifact multi-selector continues to work in gce bake stage:

<img width="705" alt="screen shot 2018-05-18 at 8 46 59 am" src="https://user-images.githubusercontent.com/34253460/40235743-2c0a4ef4-5a79-11e8-8675-274043eb02c7.png">

Both of those also use the artifact summarize filter that was moved to its own angular module file.