### PR TITLE
chore(artifacts): de-angularize artifact reference service

### DIFF
--- a/app/scripts/modules/core/src/artifact/ArtifactReferenceService.spec.ts
+++ b/app/scripts/modules/core/src/artifact/ArtifactReferenceService.spec.ts
@@ -1,4 +1,4 @@
-import { ArtifactReferenceServiceProvider } from './ArtifactReferenceService';
+import { ArtifactReferenceService } from './ArtifactReferenceService';
 
 const stage = (mixin: any) => ({
   name: 'name',
@@ -9,26 +9,24 @@ const stage = (mixin: any) => ({
 });
 
 describe('ArtifactReferenceService', () => {
-  let svc: ArtifactReferenceServiceProvider;
-
   beforeEach(() => {
-    svc = new ArtifactReferenceServiceProvider();
+    ArtifactReferenceService.deregisterAll();
   });
 
   describe('removeReferenceFromStages', () => {
     it('deletes reference from stage', () => {
       const stages = [stage({ foo: 'bar' })];
       const refs = () => [['foo']];
-      svc.registerReference('stage', refs);
-      svc.removeReferenceFromStages('bar', stages);
+      ArtifactReferenceService.registerReference('stage', refs);
+      ArtifactReferenceService.removeReferenceFromStages('bar', stages);
       expect(stages[0].foo).toBe(undefined);
     });
 
     it('deletes multiple references from a stage if registered to do so', () => {
       const stages = [stage({ deployedManifest: 'foo', requiredArtifactIds: 'foo' })];
       const refs = () => [['deployedManifest'], ['requiredArtifactIds']];
-      svc.registerReference('stage', refs);
-      svc.removeReferenceFromStages('foo', stages);
+      ArtifactReferenceService.registerReference('stage', refs);
+      ArtifactReferenceService.removeReferenceFromStages('foo', stages);
       expect(stages[0].deployedManifest).toBe(undefined);
       expect(stages[0].requiredArtifactIds).toBe(undefined);
     });
@@ -36,8 +34,8 @@ describe('ArtifactReferenceService', () => {
     it('doesnt delete reference from stage if reference doesnt match', () => {
       const stages = [stage({ foo: 'ref1' }), stage({ foo: 'ref2' })];
       const refs = () => [['foo']];
-      svc.registerReference('stage', refs);
-      svc.removeReferenceFromStages('ref1', stages);
+      ArtifactReferenceService.registerReference('stage', refs);
+      ArtifactReferenceService.removeReferenceFromStages('ref1', stages);
       expect(stages[0].foo).toBe(undefined);
       expect(stages[1].foo).toBe('ref2');
     });
@@ -45,24 +43,24 @@ describe('ArtifactReferenceService', () => {
     it('doesnt delete reference if reference doesnt exist', () => {
       const stages = [stage({ foo: 'ref1' })];
       const refs = () => [['foo', 'bar']];
-      svc.registerReference('stage', refs);
-      svc.removeReferenceFromStages('ref1', stages);
+      ArtifactReferenceService.registerReference('stage', refs);
+      ArtifactReferenceService.removeReferenceFromStages('ref1', stages);
       expect(stages[0].foo).toBe('ref1');
     });
 
     it('deletes nested references', () => {
       const stages = [stage({ foo: [{ baz: 'ref1' }] })];
       const refs = () => [['foo', 0, 'baz']];
-      svc.registerReference('stage', refs);
-      svc.removeReferenceFromStages('ref1', stages);
+      ArtifactReferenceService.registerReference('stage', refs);
+      ArtifactReferenceService.removeReferenceFromStages('ref1', stages);
       expect(stages[0].foo[0].baz).toBe(undefined);
     });
 
     it('doesnt delete nested references if reference doesnt match', () => {
       const stages = [stage({ foo: [{ baz: 'ref1' }] }), stage({ foo: [{ baz: 'ref2' }] })];
       const refs = () => [['foo', 0, 'baz']];
-      svc.registerReference('stage', refs);
-      svc.removeReferenceFromStages('ref1', stages);
+      ArtifactReferenceService.registerReference('stage', refs);
+      ArtifactReferenceService.removeReferenceFromStages('ref1', stages);
       expect(stages[0].foo[0].baz).toBe(undefined);
       expect(stages[1].foo[0].baz).toBe('ref2');
     });
@@ -70,8 +68,8 @@ describe('ArtifactReferenceService', () => {
     it('splices nested reference from array', () => {
       const stages = [stage({ path: { to: { reference: ['ref1', 'ref2', 'ref3'] } } })];
       const refs = () => [['path', 'to', 'reference', 1]];
-      svc.registerReference('stage', refs);
-      svc.removeReferenceFromStages('ref2', stages);
+      ArtifactReferenceService.registerReference('stage', refs);
+      ArtifactReferenceService.removeReferenceFromStages('ref2', stages);
       expect(stages[0].path.to.reference.length).toBe(2);
       expect(stages[0].path.to.reference[0]).toBe('ref1');
       expect(stages[0].path.to.reference[1]).toBe('ref3');
@@ -80,8 +78,8 @@ describe('ArtifactReferenceService', () => {
     it('doesnt splice nested reference from array if reference doesnt match', () => {
       const stages = [stage({ path: { to: { reference: ['ref1', 'ref2', 'ref3'] } } })];
       const refs = () => [['path', 'to', 'reference', 1]];
-      svc.registerReference('stage', refs);
-      svc.removeReferenceFromStages('not found reference', stages);
+      ArtifactReferenceService.registerReference('stage', refs);
+      ArtifactReferenceService.removeReferenceFromStages('not found reference', stages);
       expect(stages[0].path.to.reference.length).toBe(3);
       expect(stages[0].path.to.reference[0]).toBe('ref1');
       expect(stages[0].path.to.reference[1]).toBe('ref2');
@@ -91,8 +89,8 @@ describe('ArtifactReferenceService', () => {
     it('splices nested reference from array when only the path to the array is given', () => {
       const stages = [stage({ path: { to: { reference: ['ref1', 'ref2', 'ref3'] } } })];
       const refs = () => [['path', 'to', 'reference']];
-      svc.registerReference('stage', refs);
-      svc.removeReferenceFromStages('ref2', stages);
+      ArtifactReferenceService.registerReference('stage', refs);
+      ArtifactReferenceService.removeReferenceFromStages('ref2', stages);
       expect(stages[0].path.to.reference.length).toBe(2);
       expect(stages[0].path.to.reference[0]).toBe('ref1');
       expect(stages[0].path.to.reference[1]).toBe('ref3');

--- a/app/scripts/modules/core/src/artifact/ArtifactReferenceService.ts
+++ b/app/scripts/modules/core/src/artifact/ArtifactReferenceService.ts
@@ -1,4 +1,3 @@
-import { module } from 'angular';
 import { IStage } from 'core/domain';
 import { isEmpty, get } from 'lodash';
 
@@ -11,20 +10,16 @@ interface IReference {
   walker: IWalker;
 }
 
-export class ArtifactReferenceServiceProvider {
-  private references: IReference[] = [];
+export class ArtifactReferenceService {
+  private static references: IReference[] = [];
 
-  public $get() {
-    return this;
+  public static registerReference(category: SupportedStage, walker: IWalker) {
+    ArtifactReferenceService.references.push({ category, walker });
   }
 
-  public registerReference(category: SupportedStage, walker: any) {
-    this.references.push({ category, walker });
-  }
-
-  public removeReferenceFromStages(reference: string, stages: IStage[]) {
+  public static removeReferenceFromStages(reference: string, stages: IStage[]) {
     (stages || []).forEach(stage => {
-      this.references.forEach(ref => {
+      ArtifactReferenceService.references.forEach(ref => {
         const paths: Array<Array<string | number>> = ref.walker(stage).filter(path => !isEmpty(path));
         paths.map(p => p.slice(0)).forEach(path => {
           let tail = path.pop();
@@ -48,7 +43,8 @@ export class ArtifactReferenceServiceProvider {
       });
     });
   }
-}
 
-export const ARTIFACT_REFERENCE_SERVICE_PROVIDER = 'spinnaker.core.artifacts.referenceServiceProvider';
-module(ARTIFACT_REFERENCE_SERVICE_PROVIDER, []).provider('artifactReferenceService', ArtifactReferenceServiceProvider);
+  public static deregisterAll() {
+    ArtifactReferenceService.references = [];
+  }
+}

--- a/app/scripts/modules/core/src/artifact/expectedArtifactMultiSelector.component.ts
+++ b/app/scripts/modules/core/src/artifact/expectedArtifactMultiSelector.component.ts
@@ -13,7 +13,7 @@ class ExpectedArtifactMultiSelectorCtrl implements IController {
   public showIcons: boolean;
 
   public iconPath(expected: IExpectedArtifact): string {
-    const artifact = expected.matchArtifact || expected.defaultArtifact;
+    const artifact = expected && (expected.matchArtifact || expected.defaultArtifact);
     if (artifact == null) {
       return '';
     }

--- a/app/scripts/modules/core/src/artifact/expectedArtifactSelector.component.ts
+++ b/app/scripts/modules/core/src/artifact/expectedArtifactSelector.component.ts
@@ -16,7 +16,7 @@ class ExpectedArtifactSelectorCtrl implements IController {
   public showIcons: boolean;
 
   public iconPath(expected: IExpectedArtifact): string {
-    const artifact = expected.matchArtifact || expected.defaultArtifact;
+    const artifact = expected && (expected.matchArtifact || expected.defaultArtifact);
     if (artifact == null) {
       return '';
     }

--- a/app/scripts/modules/core/src/pipeline/config/stages/producesArtifacts/producesArtifacts.component.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/producesArtifacts/producesArtifacts.component.ts
@@ -2,18 +2,11 @@ import { IComponentOptions, IController, module } from 'angular';
 
 import { UUIDGenerator } from 'core/utils/uuid.service';
 import { IStage, IExpectedArtifact, IPipeline } from 'core';
-import {
-  ArtifactReferenceServiceProvider,
-  ARTIFACT_REFERENCE_SERVICE_PROVIDER,
-} from 'core/artifact/ArtifactReferenceService';
+import { ArtifactReferenceService } from 'core/artifact/ArtifactReferenceService';
 
 class ProducesArtifactsCtrl implements IController {
   public stage: IStage;
   public pipeline: IPipeline;
-
-  constructor(private artifactReferenceService: ArtifactReferenceServiceProvider) {
-    'nginject';
-  }
 
   public hasExpectedArtifacts(): boolean {
     return this.stage && this.stage.expectedArtifacts instanceof Array && this.stage.expectedArtifacts.length > 0;
@@ -26,7 +19,7 @@ class ProducesArtifactsCtrl implements IController {
 
     stage.expectedArtifacts = stage.expectedArtifacts.filter((a: IExpectedArtifact) => a.id !== expectedArtifact.id);
 
-    this.artifactReferenceService.removeReferenceFromStages(expectedArtifact.id, this.pipeline.stages);
+    ArtifactReferenceService.removeReferenceFromStages(expectedArtifact.id, this.pipeline.stages);
   };
 
   private defaultArtifact() {
@@ -56,7 +49,7 @@ class ProducesArtifactsComponent implements IComponentOptions {
     pipeline: '=',
   };
   public controllerAs = 'ctrl';
-  public controller = ['artifactReferenceService', ProducesArtifactsCtrl];
+  public controller = ProducesArtifactsCtrl;
   public template = `
     <div class="container-fluid form-horizontal">
       <expected-artifact
@@ -83,7 +76,4 @@ class ProducesArtifactsComponent implements IComponentOptions {
 }
 
 export const PRODUCES_ARTIFACTS = 'spinnaker.core.pipeline.stage.producesArtifacts';
-module(PRODUCES_ARTIFACTS, [ARTIFACT_REFERENCE_SERVICE_PROVIDER]).component(
-  'producesArtifacts',
-  new ProducesArtifactsComponent(),
-);
+module(PRODUCES_ARTIFACTS, []).component('producesArtifacts', new ProducesArtifactsComponent());

--- a/app/scripts/modules/core/src/pipeline/config/triggers/triggers.directive.js
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/triggers.directive.js
@@ -1,13 +1,13 @@
 'use strict';
 
-import { ARTIFACT_REFERENCE_SERVICE_PROVIDER } from 'core/artifact/ArtifactReferenceService';
+import { ArtifactReferenceService } from 'core/artifact/ArtifactReferenceService';
 import { UUIDGenerator } from 'core/utils/uuid.service';
 import { Registry } from 'core/registry';
 
 const angular = require('angular');
 
 module.exports = angular
-  .module('spinnaker.core.pipeline.config.trigger.triggersDirective', [ARTIFACT_REFERENCE_SERVICE_PROVIDER])
+  .module('spinnaker.core.pipeline.config.trigger.triggersDirective', [])
   .directive('triggers', function() {
     return {
       restrict: 'E',
@@ -20,7 +20,7 @@ module.exports = angular
       templateUrl: require('./triggers.html'),
     };
   })
-  .controller('triggersCtrl', function($scope, artifactReferenceService) {
+  .controller('triggersCtrl', function($scope) {
     this.addTrigger = function() {
       var triggerTypes = Registry.pipeline.getTriggerTypes(),
         newTrigger = { enabled: true };
@@ -55,7 +55,7 @@ module.exports = angular
         }
       });
 
-      artifactReferenceService.removeReferenceFromStages(expectedArtifact.id, pipeline.stages);
+      ArtifactReferenceService.removeReferenceFromStages(expectedArtifact.id, pipeline.stages);
     };
 
     this.addArtifact = () => {

--- a/app/scripts/modules/google/src/pipeline/stages/bake/gceBakeStage.js
+++ b/app/scripts/modules/google/src/pipeline/stages/bake/gceBakeStage.js
@@ -4,7 +4,7 @@ const angular = require('angular');
 import _ from 'lodash';
 
 import {
-  ARTIFACT_REFERENCE_SERVICE_PROVIDER,
+  ArtifactReferenceService,
   AuthenticationService,
   BakeExecutionLabel,
   BAKERY_SERVICE,
@@ -16,11 +16,10 @@ import {
 
 module.exports = angular
   .module('spinnaker.gce.pipeline.stage..bakeStage', [
-    ARTIFACT_REFERENCE_SERVICE_PROVIDER,
     require('./bakeExecutionDetails.controller.js').name,
     BAKERY_SERVICE,
   ])
-  .config(function(artifactReferenceServiceProvider) {
+  .config(function() {
     Registry.pipeline.registerStage({
       provides: 'bake',
       cloudProvider: 'gce',
@@ -45,7 +44,7 @@ module.exports = angular
       ],
       restartable: true,
     });
-    artifactReferenceServiceProvider.registerReference('stage', () => [['packageArtifactIds']]);
+    ArtifactReferenceService.registerReference('stage', () => [['packageArtifactIds']]);
   })
   .controller('gceBakeStageCtrl', function($scope, bakeryService, $q, $uibModal) {
     $scope.stage.extendedAttributes = $scope.stage.extendedAttributes || {};

--- a/app/scripts/modules/google/src/pipeline/stages/cloneServerGroup/gceCloneServerGroupStage.js
+++ b/app/scripts/modules/google/src/pipeline/stages/cloneServerGroup/gceCloneServerGroupStage.js
@@ -3,17 +3,11 @@
 const angular = require('angular');
 import _ from 'lodash';
 
-import {
-  AccountService,
-  ARTIFACT_REFERENCE_SERVICE_PROVIDER,
-  NameUtils,
-  Registry,
-  StageConstants,
-} from '@spinnaker/core';
+import { AccountService, ArtifactReferenceService, NameUtils, Registry, StageConstants } from '@spinnaker/core';
 
 module.exports = angular
-  .module('spinnaker.gce.pipeline.stage..cloneServerGroupStage', [ARTIFACT_REFERENCE_SERVICE_PROVIDER])
-  .config(function(artifactReferenceServiceProvider) {
+  .module('spinnaker.gce.pipeline.stage..cloneServerGroupStage', [])
+  .config(function() {
     Registry.pipeline.registerStage({
       provides: 'cloneServerGroup',
       cloudProvider: 'gce',
@@ -27,7 +21,7 @@ module.exports = angular
       ],
     });
 
-    artifactReferenceServiceProvider.registerReference('stage', obj => {
+    ArtifactReferenceService.registerReference('stage', obj => {
       const paths = [];
       if (obj.type === 'deploy' && Array.isArray(obj.clusters)) {
         obj.clusters.forEach((cluster, i) => {

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestStage.ts
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestStage.ts
@@ -1,6 +1,6 @@
 import { module } from 'angular';
 
-import { ArtifactReferenceServiceProvider, Registry, SETTINGS } from '@spinnaker/core';
+import { ArtifactReferenceService, Registry, SETTINGS } from '@spinnaker/core';
 
 import { KubernetesV2DeployManifestConfigCtrl } from './deployManifestConfig.controller';
 import { KUBERNETES_MANIFEST_COMMAND_BUILDER } from '../../../manifest/manifestCommandBuilder.service';
@@ -14,7 +14,7 @@ module(KUBERNETES_DEPLOY_MANIFEST_STAGE, [
   KUBERNETES_DEPLOY_MANIFEST_DEPLOY_STATUS_MANIFEST_SUMMARY,
   KUBERNETES_EXECUTION_ARTIFACT_TAB,
 ])
-  .config((artifactReferenceServiceProvider: ArtifactReferenceServiceProvider) => {
+  .config(() => {
     // Todo: replace feature flag with proper versioned provider mechanism once available.
     if (SETTINGS.feature.versionedProviders) {
       Registry.pipeline.registerStage({
@@ -32,10 +32,7 @@ module(KUBERNETES_DEPLOY_MANIFEST_STAGE, [
         validators: [],
       });
 
-      artifactReferenceServiceProvider.registerReference('stage', () => [
-        ['manifestArtifactId'],
-        ['requiredArtifactIds'],
-      ]);
+      ArtifactReferenceService.registerReference('stage', () => [['manifestArtifactId'], ['requiredArtifactIds']]);
     }
   })
   .controller('KubernetesV2DeployManifestConfigCtrl', KubernetesV2DeployManifestConfigCtrl);


### PR DESCRIPTION
Adds artifact reference removal to the bakeManifest stage for the `expectedArtifacts` and `inputArtifacts` fields.

In the below image an artifact has been removed from the Expected Artifacts section of the config screen & that removal continues to be correctly reflected in the GCE deploy stage:

<img width="557" alt="screen shot 2018-05-18 at 11 47 12 am" src="https://user-images.githubusercontent.com/34253460/40244737-aca8d824-5a91-11e8-8ad7-5e802e134291.png">

And here an artifact has been removed from a config screen and is correctly reflected in the bake manifest stage:

<img width="732" alt="screen shot 2018-05-18 at 11 48 26 am" src="https://user-images.githubusercontent.com/34253460/40244738-acb35290-5a91-11e8-9f0f-aaac2e73922c.png">