### PR TITLE
chore(provider/appengine): use expected-artifact-selector in place of copy-paste

### DIFF
--- a/app/scripts/modules/appengine/src/serverGroup/configure/wizard/basicSettings.controller.ts
+++ b/app/scripts/modules/appengine/src/serverGroup/configure/wizard/basicSettings.controller.ts
@@ -1,8 +1,8 @@
-import { copy, extend, IController, IControllerService, IScope, module } from 'angular';
+import { extend, IController, IControllerService, IScope, module } from 'angular';
 import { StateService } from '@uirouter/angularjs';
 import { set } from 'lodash';
 
-import { IArtifact, IExpectedArtifact, SETTINGS } from '@spinnaker/core';
+import { SETTINGS } from '@spinnaker/core';
 
 import { GitCredentialType, IAppengineAccount } from 'appengine/domain/index';
 import { AppengineSourceType, IAppengineServerGroupCommand } from '../serverGroupCommandBuilder.service';
@@ -47,19 +47,6 @@ class AppengineServerGroupBasicSettingsCtrl implements IController {
 
   public isContainerImageSource(): boolean {
     return this.$scope.command.sourceType === AppengineSourceType.CONTAINER_IMAGE;
-  }
-
-  // TODO(jtk54): this is a copy of core code, please dedup using expected-artifact-selector component
-  public summarizeExpectedArtifact(expected: IExpectedArtifact): string {
-    if (!expected) {
-      return '';
-    }
-
-    const artifact = copy(expected.matchArtifact);
-    return Object.keys(artifact)
-      .filter((k: keyof IArtifact) => artifact[k])
-      .map((k: keyof IArtifact) => `${k}: ${artifact[k]}`)
-      .join(', ');
   }
 
   public toggleResolveViaTrigger(): void {

--- a/app/scripts/modules/appengine/src/serverGroup/configure/wizard/basicSettings.html
+++ b/app/scripts/modules/appengine/src/serverGroup/configure/wizard/basicSettings.html
@@ -118,18 +118,13 @@
         </div>
       </div>
 
-      <div class="form-group" ng-if="command.fromArtifact">
-        <label class=" col-md-3 sm-label-right">Expected Artifact</label>
-        <div class="col-md-7">
-          <ui-select ng-model="command.expectedArtifactId"
-                     class="form-control input-sm">
-            <ui-select-match>{{ basicSettingsCtrl.summarizeExpectedArtifact($select.selected) }}</ui-select-match>
-            <ui-select-choices repeat="expected.id as expected in command.backingData.expectedArtifacts">
-              <span>{{ basicSettingsCtrl.summarizeExpectedArtifact(expected) }}</span>
-            </ui-select-choices>
-          </ui-select>
-        </div>
-      </div>
+      <expected-artifact-selector ng-if="command.fromArtifact"
+                                  command="command"
+                                  id="command.expectedArtifactId"
+                                  expected-artifacts="command.backingData.expectedArtifacts"
+                                  show-icons="true"
+                                  field-columns="7">
+      </expected-artifact-selector>
 
       <div class="form-group" ng-if="!command.fromArtifact">
         <div class="col-md-3 sm-label-right">
@@ -228,18 +223,13 @@
         </div>
       </div>
 
-      <div class="form-group" ng-if="command.fromArtifact">
-        <label class=" col-md-3 sm-label-right">Expected Artifact</label>
-        <div class="col-md-7">
-          <ui-select ng-model="command.expectedArtifactId"
-                     class="form-control input-sm">
-            <ui-select-match>{{ basicSettingsCtrl.summarizeExpectedArtifact($select.selected) }}</ui-select-match>
-            <ui-select-choices repeat="expected.id as expected in command.backingData.expectedArtifacts">
-              <span>{{ basicSettingsCtrl.summarizeExpectedArtifact(expected) }}</span>
-            </ui-select-choices>
-          </ui-select>
-        </div>
-      </div>
+      <expected-artifact-selector ng-if="command.fromArtifact"
+                                  command="command"
+                                  id="command.expectedArtifactId"
+                                  expected-artifacts="command.backingData.expectedArtifacts"
+                                  show-icons="true"
+                                  field-columns="7">
+      </expected-artifact-selector>
 
       <div class="form-group" ng-if="!command.fromArtifact">
         <div class="col-md-3 sm-label-right">

--- a/app/scripts/modules/core/src/artifact/expectedArtifactSelector.component.ts
+++ b/app/scripts/modules/core/src/artifact/expectedArtifactSelector.component.ts
@@ -14,6 +14,7 @@ class ExpectedArtifactSelectorCtrl implements IController {
   public expectedArtifacts: IExpectedArtifact[];
   public helpFieldKey: string;
   public showIcons: boolean;
+  public fieldColumns: number;
 
   public iconPath(expected: IExpectedArtifact): string {
     const artifact = expected && (expected.matchArtifact || expected.defaultArtifact);
@@ -33,13 +34,14 @@ class ExpectedArtifactSelectorComponent implements IComponentOptions {
     accounts: '<',
     helpFieldKey: '@',
     showIcons: '<',
+    fieldColumns: '@',
   };
   public controller: any = ExpectedArtifactSelectorCtrl;
   public controllerAs = 'ctrl';
   public template = `
     <render-if-feature feature="artifacts">
       <ng-form name="artifact">
-        <stage-config-field label="Expected Artifact" help-key="{{ctrl.helpFieldKey}}">
+        <stage-config-field label="Expected Artifact" help-key="{{ctrl.helpFieldKey}}" field-columns="{{ ctrl.fieldColumns }}">
           <ui-select ng-model="ctrl.id"
                      class="form-control input-sm expected-artifact-selector" required>
             <ui-select-match>
@@ -53,7 +55,8 @@ class ExpectedArtifactSelectorComponent implements IComponentOptions {
           </ui-select>
         </stage-config-field>
         <stage-config-field ng-if="ctrl.account !== undefined"
-                            label="Artifact Account">
+                            label="Artifact Account"
+                            fieldColumns="{{ ctrl.fieldColumns }}">
           <ui-select ng-model="ctrl.account"
                      class="form-control input-sm">
             <ui-select-match>{{ $select.selected.name }}</ui-select-match>


### PR DESCRIPTION
Following up on a `todo()` from a while ago.  Here's how the expected artifect selector looks in the appengine server group wizard:

<img width="543" alt="screen shot 2018-05-18 at 1 05 59 pm" src="https://user-images.githubusercontent.com/34253460/40248132-df26feec-5a9c-11e8-876b-00485f987897.png">

and I tested a deployment using the container image from the selector:

<img width="1092" alt="screen shot 2018-05-18 at 1 03 30 pm" src="https://user-images.githubusercontent.com/34253460/40248165-03966362-5a9d-11e8-9772-0271e79801f1.png">
