### PR TITLE
fix(artifacts): ensure fieldColumns is not undefined in expected artifact select

### DIFF
--- a/app/scripts/modules/core/src/artifact/expectedArtifactSelector.component.ts
+++ b/app/scripts/modules/core/src/artifact/expectedArtifactSelector.component.ts
@@ -16,6 +16,10 @@ class ExpectedArtifactSelectorCtrl implements IController {
   public showIcons: boolean;
   public fieldColumns: number;
 
+  public $onInit() {
+    this.fieldColumns = this.fieldColumns || 8;
+  }
+
   public iconPath(expected: IExpectedArtifact): string {
     const artifact = expected && (expected.matchArtifact || expected.defaultArtifact);
     if (artifact == null) {


### PR DESCRIPTION
I accidentally broke this with my previous appengine change.

Broken:
<img width="715" alt="screen shot 2018-05-18 at 1 32 20 pm" src="https://user-images.githubusercontent.com/34253460/40249089-f2a2dd1c-5a9f-11e8-9878-b6aa22322b29.png">

Fixed:
<img width="672" alt="screen shot 2018-05-18 at 1 32 57 pm" src="https://user-images.githubusercontent.com/34253460/40249119-06e1ec82-5aa0-11e8-8d3b-ef5ed797c04f.png">
