### PR TITLE
fix(core): Validators for script stage

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/script/scriptStage.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/script/scriptStage.html
@@ -13,11 +13,11 @@
            ng-model="stage.repoBranch"/>
   </stage-config-field>
   <stage-config-field label="Script Path" help-key="pipeline.config.script.path">
-    <input type="text" class="form-control input-sm"
+    <input type="text" class="form-control input-sm" required
            ng-model="stage.scriptPath"/>
   </stage-config-field>
   <stage-config-field label="Command" help-key="pipeline.config.script.command">
-    <textarea class="form-control input-sm"
+    <textarea class="form-control input-sm" required
               ng-model="stage.command"/>
   </stage-config-field>
   <stage-config-field label="Output File" help-key="pipeline.config.script.propertyFile">

--- a/app/scripts/modules/core/src/pipeline/config/stages/script/scriptStage.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/script/scriptStage.ts
@@ -21,6 +21,7 @@ module(SCRIPT_STAGE, [])
       templateUrl: require('./scriptStage.html'),
       executionDetailsSections: [ScriptExecutionDetails, ExecutionDetailsTasks],
       strategy: true,
+      validators: [{ type: 'requiredField', fieldName: 'command' }, { type: 'requiredField', fieldName: 'scriptPath' }],
     });
   })
   .controller('ScriptStageCtrl', function($scope: IScope, stage: IStage) {

--- a/app/scripts/modules/core/src/presentation/main.less
+++ b/app/scripts/modules/core/src/presentation/main.less
@@ -799,6 +799,7 @@ select:invalid {
     &.ng-dirty,
     &.ng-invalid-validate-min,
     &.ng-invalid-validate-max,
+    &.ng-invalid-required,
     &.highlight-pristine {
       border-color: var(--color-danger);
       .box-shadow(inset 0 1px 1px rgba(0, 0, 0, 0.075)); // Redeclare so transitions work


### PR DESCRIPTION
Made script path and command required in script stage.

When setting up a pipeline, if there is a script stage, the user needs to type in both script path and command. Made these fields required and added validators so the stage shows red to indicate its not fully set up. 