### PR TITLE
feat(*/instance): add moniker info + env to instance link templates

### DIFF
--- a/app/scripts/modules/amazon/src/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/amazon/src/instance/details/instance.details.controller.js
@@ -32,6 +32,8 @@ module.exports = angular
     instanceReader,
     instance,
     app,
+    moniker,
+    environment,
     $q,
     overrides,
   ) {
@@ -45,6 +47,8 @@ module.exports = angular
     };
 
     $scope.application = app;
+    $scope.moniker = moniker;
+    $scope.environment = environment;
 
     $scope.securityGroupsLabel = FirewallLabels.get('Firewalls');
 

--- a/app/scripts/modules/amazon/src/instance/details/instance.details.controller.spec.js
+++ b/app/scripts/modules/amazon/src/instance/details/instance.details.controller.spec.js
@@ -18,9 +18,11 @@ describe('Controller: awsInstanceDetailsCtrl', function() {
       this.createController = function(application, instance) {
         controller = $controller('awsInstanceDetailsCtrl', {
           $scope: scope,
-          instance: instance,
           app: application,
           overrides: {},
+          moniker: {},
+          environment: 'test',
+          instance,
         });
       };
 

--- a/app/scripts/modules/amazon/src/instance/details/instanceDetails.html
+++ b/app/scripts/modules/amazon/src/instance/details/instanceDetails.html
@@ -189,7 +189,7 @@
         </li>
       </ul>
     </collapsible-section>
-    <instance-links address="baseIpAddress" application="application" instance="instance"></instance-links>
+    <instance-links address="baseIpAddress" application="application" instance="instance" moniker="moniker" environment="environment"></instance-links>
   </div>
   <div class="content" ng-if="!state.loading && !instance">
     <div class="content-section">

--- a/app/scripts/modules/cloudfoundry/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/cloudfoundry/instance/details/instance.details.controller.js
@@ -29,6 +29,8 @@ module.exports = angular
     instanceReader,
     instance,
     app,
+    moniker,
+    environment,
   ) {
     // needed for standalone instances
     $scope.detailsTemplateUrl = CloudProviderRegistry.getValue('cf', 'instance.detailsTemplateUrl');
@@ -39,6 +41,8 @@ module.exports = angular
     };
 
     $scope.application = app;
+    $scope.moniker = moniker;
+    $scope.environment = environment;
 
     function extractHealthMetrics(instance, latest) {
       // do not backfill on standalone instances

--- a/app/scripts/modules/cloudfoundry/instance/details/instance.details.controller.spec.js
+++ b/app/scripts/modules/cloudfoundry/instance/details/instance.details.controller.spec.js
@@ -13,6 +13,8 @@ describe('Controller: cfInstanceDetailsCtrl', function() {
       controller = $controller('cfInstanceDetailsCtrl', {
         $scope: scope,
         instance: {},
+        moniker: {},
+        environment: 'test',
         app: { isStandalone: true },
       });
     }),

--- a/app/scripts/modules/cloudfoundry/instance/details/instanceDetails.html
+++ b/app/scripts/modules/cloudfoundry/instance/details/instanceDetails.html
@@ -137,7 +137,7 @@
         </li>
       </ul>
     </collapsible-section>
-    <instance-links address="baseIpAddress" application="application" instance="instance"></instance-links>
+    <instance-links address="baseIpAddress" application="application" instance="instance" moniker="moniker" environment="environment"></instance-links>
   </div>
   <div class="content" ng-if="!state.loading && !instance">
     <div class="content-section">

--- a/app/scripts/modules/core/src/instance/details/instanceLinks.component.js
+++ b/app/scripts/modules/core/src/instance/details/instanceLinks.component.js
@@ -12,6 +12,8 @@ module.exports = angular.module('spinnaker.core.instance.details.instanceLinks',
     address: '=',
     application: '=',
     instance: '=',
+    moniker: '=',
+    environment: '=',
   },
   templateUrl: require('./instanceLinks.component.html'),
   controller: function($interpolate) {
@@ -25,7 +27,12 @@ module.exports = angular.module('spinnaker.core.instance.details.instanceLinks',
         let url = link.path;
         // handle interpolated variables
         if (url.includes('{{')) {
-          url = $interpolate(url)(Object.assign({}, this.instance, { ipAddress: this.address }));
+          url = $interpolate(url)(
+            Object.assign({}, this.instance, this.moniker, {
+              ipAddress: this.address,
+              environment: this.environment,
+            }),
+          );
         }
         // handle relative paths
         if (!url.includes('//')) {

--- a/app/scripts/modules/ecs/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/ecs/instance/details/instance.details.controller.js
@@ -27,6 +27,8 @@ module.exports = angular
     instanceWriter,
     instance,
     app,
+    moniker,
+    environment,
     $q,
     overrides,
   ) {
@@ -40,6 +42,8 @@ module.exports = angular
     };
 
     $scope.application = app;
+    $scope.moniker = moniker;
+    $scope.environment = environment;
 
     const cloudProvider = 'ecs';
     const defaultRequestParams = { cloudProvider: cloudProvider };

--- a/app/scripts/modules/ecs/instance/details/instanceDetails.html
+++ b/app/scripts/modules/ecs/instance/details/instanceDetails.html
@@ -128,7 +128,7 @@
         </li>
       </ul>
     </collapsible-section>
-    <instance-links address="baseIpAddress" application="application" instance="instance"></instance-links>
+    <instance-links address="baseIpAddress" application="application" instance="instance" moniker="moniker" environment="environment"></instance-links>
   </div>
   <div class="content" ng-if="!state.loading && !instance">
     <div class="content-section">

--- a/app/scripts/modules/google/src/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/google/src/instance/details/instance.details.controller.js
@@ -33,6 +33,8 @@ module.exports = angular
     instanceReader,
     instance,
     app,
+    moniker,
+    environment,
     $q,
     gceHttpLoadBalancerUtils,
     gceXpnNamingService,
@@ -48,6 +50,8 @@ module.exports = angular
     };
 
     $scope.application = app;
+    $scope.moniker = moniker;
+    $scope.environment = environment;
 
     function extractHealthMetrics(instance, latest) {
       // do not backfill on standalone instances

--- a/app/scripts/modules/google/src/instance/details/instance.details.controller.spec.js
+++ b/app/scripts/modules/google/src/instance/details/instance.details.controller.spec.js
@@ -14,6 +14,8 @@ describe('Controller: gceInstanceDetailsCtrl', function() {
       controller = $controller('gceInstanceDetailsCtrl', {
         $scope: scope,
         instance: {},
+        moniker: {},
+        environment: 'test',
         app: { isStandalone: true },
       });
     }),

--- a/app/scripts/modules/google/src/instance/details/instanceDetails.html
+++ b/app/scripts/modules/google/src/instance/details/instanceDetails.html
@@ -213,7 +213,7 @@
         </li>
       </ul>
     </collapsible-section>
-    <instance-links address="baseIpAddress" application="application" instance="instance"></instance-links>
+    <instance-links address="baseIpAddress" application="application" instance="instance" moniker="moniker" environment="environment"></instance-links>
   </div>
   <div class="content" ng-if="!state.loading && !instance">
     <div class="content-section">

--- a/app/scripts/modules/kubernetes/src/instance/details/details.controller.js
+++ b/app/scripts/modules/kubernetes/src/instance/details/details.controller.js
@@ -29,6 +29,8 @@ module.exports = angular
     instanceReader,
     instance,
     app,
+    moniker,
+    environment,
     kubernetesProxyUiService,
     $q,
   ) {
@@ -41,6 +43,8 @@ module.exports = angular
     };
 
     this.application = app;
+    $scope.moniker = moniker;
+    $scope.environment = environment;
 
     this.uiLink = function uiLink() {
       return kubernetesProxyUiService.buildLink(

--- a/app/scripts/modules/kubernetes/src/instance/details/details.html
+++ b/app/scripts/modules/kubernetes/src/instance/details/details.html
@@ -141,7 +141,7 @@
         <console-output-link instance="instance"></console-output-link>
       </div>
     </collapsible-section>
-    <instance-links address="ctrl.baseIpAddress" application="ctrl.application" instance="instance"></instance-links>
+    <instance-links address="ctrl.baseIpAddress" application="ctrl.application" instance="instance" moniker="moniker" environment="environment"></instance-links>
   </div>
   <div class="content" ng-if="!state.loading && !instance">
     <div class="content-section">

--- a/app/scripts/modules/openstack/src/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/openstack/src/instance/details/instance.details.controller.js
@@ -30,6 +30,8 @@ module.exports = angular
     instanceReader,
     instance,
     app,
+    moniker,
+    environment,
     $q,
     overrides,
   ) {
@@ -45,6 +47,8 @@ module.exports = angular
     $scope.firewallsLabel = FirewallLabels.get('Firewalls');
 
     $scope.application = app;
+    $scope.moniker = moniker;
+    $scope.environment = environment;
 
     function extractHealthMetrics(instance, latest) {
       // do not backfill on standalone instances

--- a/app/scripts/modules/openstack/src/instance/details/instanceDetails.html
+++ b/app/scripts/modules/openstack/src/instance/details/instanceDetails.html
@@ -160,7 +160,7 @@
         </li>
       </ul>
     </collapsible-section>
-    <instance-links address="ctrl.baseIpAddress" application="ctrl.application" instance="instance"></instance-links>
+    <instance-links address="ctrl.baseIpAddress" application="ctrl.application" instance="instance" moniker="moniker" environment="environment"></instance-links>
   </div>
   <div class="content" ng-if="!state.loading && !instance">
     <div class="content-section">

--- a/app/scripts/modules/titus/src/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/titus/src/instance/details/instance.details.controller.js
@@ -33,6 +33,8 @@ module.exports = angular
     instanceReader,
     instance,
     app,
+    moniker,
+    environment,
     titusSecurityGroupReader,
   ) {
     // needed for standalone instances
@@ -45,6 +47,8 @@ module.exports = angular
     $scope.firewallsLabel = FirewallLabels.get('Firewalls');
 
     $scope.application = app;
+    $scope.moniker = moniker;
+    $scope.environment = environment;
     $scope.gateUrl = SETTINGS.gateUrl;
 
     function extractHealthMetrics(instance, latest) {

--- a/app/scripts/modules/titus/src/instance/details/instanceDetails.html
+++ b/app/scripts/modules/titus/src/instance/details/instanceDetails.html
@@ -169,7 +169,7 @@
           Logs in Titus UI</a></li>
       </ul>
     </collapsible-section>
-    <instance-links address="baseIpAddress" application="application" instance="instance"></instance-links>
+    <instance-links address="baseIpAddress" application="application" instance="instance" moniker="moniker" environment="environment"></instance-links>
   </div>
   <div class="content" ng-if="!state.loading && !instance">
     <div class="content-section">


### PR DESCRIPTION
So folks can use things like `{{stack}}` and `{{environment}}` when building links.

To the best of my knowledge I covered all the cloud providers that currently implement custom instance links — there are a few like Azure that didn't seem to use them at all. I kind of went around the existing angular data flow a bit in hopes of making things more amenable to reactification later, but I'm not particularly tied to it.