### PR TITLE
feat(core/pipeline): Make CreatePipelineModal overridable

### DIFF
--- a/app/scripts/modules/core/src/application/applicationModel.builder.ts
+++ b/app/scripts/modules/core/src/application/applicationModel.builder.ts
@@ -1,6 +1,7 @@
 import { module } from 'angular';
 
 import { ROBOT_TO_HUMAN_FILTER } from 'core/presentation/robotToHumanFilter/robotToHuman.filter';
+import { OVERRIDE_REGISTRY } from 'core/overrideRegistry';
 import { SchedulerFactory } from 'core/scheduler/SchedulerFactory';
 import { Application } from './application.model';
 
@@ -45,7 +46,8 @@ export class ApplicationModelBuilder {
 
 export const APPLICATION_MODEL_BUILDER = 'spinnaker.core.application.model.builder';
 
-module(APPLICATION_MODEL_BUILDER, [ROBOT_TO_HUMAN_FILTER, require('@uirouter/angularjs').default]).service(
-  'applicationModelBuilder',
-  ApplicationModelBuilder,
-);
+module(APPLICATION_MODEL_BUILDER, [
+  ROBOT_TO_HUMAN_FILTER,
+  OVERRIDE_REGISTRY,
+  require('@uirouter/angularjs').default,
+]).service('applicationModelBuilder', ApplicationModelBuilder);

--- a/app/scripts/modules/core/src/pipeline/create/CreatePipelineModal.spec.tsx
+++ b/app/scripts/modules/core/src/pipeline/create/CreatePipelineModal.spec.tsx
@@ -48,7 +48,8 @@ describe('CreatePipelineModal', () => {
           pipelineSavedCallback: (): void => null,
         };
 
-        component = shallow(<CreatePipelineModal {...props} />).instance() as CreatePipelineModal;
+        const RealCreatePipelineModal = (CreatePipelineModal as any).OriginalComponent as React.ComponentType<any>;
+        component = shallow(<RealCreatePipelineModal {...props} />).instance() as CreatePipelineModal;
       };
     }),
   );

--- a/app/scripts/modules/core/src/pipeline/create/CreatePipelineModal.tsx
+++ b/app/scripts/modules/core/src/pipeline/create/CreatePipelineModal.tsx
@@ -6,6 +6,7 @@ import { $log } from 'ngimport';
 import { IHttpPromiseCallbackArg } from 'angular';
 import { cloneDeep, get, uniqBy } from 'lodash';
 
+import { Overridable } from 'core/overrideRegistry';
 import { Application } from 'core/application/application.model';
 import { IPipeline } from 'core/domain/IPipeline';
 import { SubmitButton } from 'core/modal/buttons/SubmitButton';
@@ -59,6 +60,7 @@ export interface ICreatePipelineModalProps {
   pipelineSavedCallback: (pipelineId: string) => void;
 }
 
+@Overridable('core.pipeline.CreatePipelineModal')
 export class CreatePipelineModal extends React.Component<ICreatePipelineModalProps, ICreatePipelineModalState> {
   constructor(props: ICreatePipelineModalProps) {
     super(props);


### PR DESCRIPTION
For schibsted: support override of `CreatePipelineModal`

to override:

```js
@Overrides('core.pipeline.CreatePipelineModal')
export class MyCreatePipelineModal extends React.Component {
  render() {
    return <Modal
         ... ... ...
  }
}
```

@jrsquared @amanya 