### PR TITLE
fix(provider/kubernetes): manifest.metadata.namespace can be null-ish

### DIFF
--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/react/DeployStatus.tsx
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/react/DeployStatus.tsx
@@ -63,7 +63,8 @@ export class DeployStatus extends React.Component<IExecutionDetailsSectionProps,
 
   private manifestIdentifier(manifest: IStageManifest) {
     const kind = manifest.kind.toLowerCase();
-    const namespace = manifest.metadata.namespace.toLowerCase();
+    // manifest.metadata.namespace doesn't exist if it's a namespace being deployed
+    const namespace = (manifest.metadata.namespace || '').toLowerCase();
     const name = manifest.metadata.name.toLowerCase();
     return `${namespace} ${kind} ${name}`;
   }


### PR DESCRIPTION
Before: exception thrown when deploying namespace manifest
After: no exception thrown when deploying namespace manifest