### PR TITLE
fix(provider/kubernetes): clicking load balancer doesnt always show correct details view

### DIFF
--- a/app/scripts/modules/kubernetes/src/v2/loadBalancer/details/details.controller.ts
+++ b/app/scripts/modules/kubernetes/src/v2/loadBalancer/details/details.controller.ts
@@ -65,7 +65,11 @@ class KubernetesLoadBalancerDetailsController implements IController {
 
   private extractLoadBalancer(): void {
     const rawLoadBalancer = this.app.getDataSource('loadBalancers').data.find((test: ILoadBalancer) => {
-      return test.name === this.loadBalancerFromParams.name && test.account === this.loadBalancerFromParams.accountId;
+      return (
+        test.name === this.loadBalancerFromParams.name &&
+        test.account === this.loadBalancerFromParams.accountId &&
+        test.region === this.loadBalancerFromParams.region
+      );
     });
 
     if (rawLoadBalancer) {


### PR DESCRIPTION
fixes https://github.com/spinnaker/spinnaker/issues/2709

Multiple k8s Services can share a name and account ID if they're in different namespaces.  Adding namespace to the set of matched fields finds the precise Service that was clicked on by the user.

No visual change; clicking on a k8s LB entry now shows details for that LB every time.