### PR TITLE
fix(amazon): filter app load balancer options by account/region in cl…

### DIFF
--- a/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupConfiguration.service.ts
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupConfiguration.service.ts
@@ -513,7 +513,8 @@ export class AwsServerGroupConfigurationService {
         .value();
     }
 
-    return command.backingData.appLoadBalancers || [];
+    const appLoadBalancers = command.backingData.appLoadBalancers || [];
+    return appLoadBalancers.filter(lb => lb.region === command.region && lb.account === command.credentials);
   }
 
   public getLoadBalancerNames(command: IAmazonServerGroupCommand): string[] {

--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/loadBalancers/loadBalancerSelector.component.html
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/loadBalancers/loadBalancerSelector.component.html
@@ -52,6 +52,9 @@
       <help-field key="aws.loadBalancer.loadBalancers"></help-field>
     </div>
     <div class="col-md-8">
+      <div class="form-control-static" ng-if="!$ctrl.command.backingData.filtered.loadBalancers.length">
+        No classic load balancers found in the selected account/region/VPC
+      </div>
       <ui-select ng-if="$ctrl.command.backingData.filtered.loadBalancers.length"
                  multiple
                  ng-model="$ctrl.command.loadBalancers"


### PR DESCRIPTION
…uster config

We still need to do some filtering for app-specific load balancers to make sure we're only presenting the user with options available in the account/region of the cluster.

Also adding the nice message we have for target groups to classic load balancers when no options are available.