### PR TITLE
fix(provider/kubernetes): artifact tab columns compressed in small windows

### DIFF
--- a/app/scripts/modules/core/src/artifact/react/ExecutionArtifactTab.tsx
+++ b/app/scripts/modules/core/src/artifact/react/ExecutionArtifactTab.tsx
@@ -48,13 +48,13 @@ export class ExecutionArtifactTab extends React.Component<IExecutionDetailsSecti
     return (
       <ExecutionDetailsSection name={this.props.name} current={this.props.current}>
         <div className="row execution-artifacts">
-          <div className="col-md-6 artifact-list-container">
+          <div className="col-sm-6 artifact-list-container">
             <h5>Consumed Artifacts</h5>
             <div>
               <ArtifactIconList artifacts={consumedArtifacts} />
             </div>
           </div>
-          <div className="col-md-6 artifact-list-container">
+          <div className="col-sm-6 artifact-list-container">
             <h5>Produced Artifacts</h5>
             <div>
               <ArtifactIconList artifacts={producedArtifacts} />


### PR DESCRIPTION
Before:

<img width="567" alt="screen shot 2018-05-30 at 12 02 02 pm" src="https://user-images.githubusercontent.com/34253460/40732444-4f5cd3e0-6401-11e8-84ba-90e37f1d8dc3.png">

After:

<img width="569" alt="screen shot 2018-05-30 at 12 01 39 pm" src="https://user-images.githubusercontent.com/34253460/40732453-535b7528-6401-11e8-8764-7c02944d643f.png">
