### PR TITLE
fix(core): improve pipeline graph mouse event handling for Chrome 67

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/graph/PipelineGraphNode.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/graph/PipelineGraphNode.tsx
@@ -92,7 +92,6 @@ export class PipelineGraphNode extends React.Component<IPipelineGraphNodeProps> 
             r={nodeRadius}
             className={circleClassName}
             fillOpacity={!node.isActive && node.executionStage ? 0.4 : 1}
-            onClick={this.handleClick}
           />
         )}
 
@@ -106,7 +105,6 @@ export class PipelineGraphNode extends React.Component<IPipelineGraphNodeProps> 
               className={circleClassName}
               height={nodeRadius * 2}
               width={nodeRadius}
-              onClick={this.handleClick}
             />
           )}
       </g>
@@ -121,40 +119,20 @@ export class PipelineGraphNode extends React.Component<IPipelineGraphNodeProps> 
       );
     }
 
-    // Add the group popover to the circle if the node is representative of a group
-    // Only executions have a 'stage' property
-    if (node.stage && node.stage.type === 'group') {
-      GraphNode = (
-        <GroupExecutionPopover stage={node.stage} subStageClicked={this.subStageClicked}>
-          {GraphNode}
-        </GroupExecutionPopover>
-      );
-    }
-
     // Render the label differently if there is a custom label component
     let GraphLabel = node.labelComponent ? (
       <div
         className={`execution-stage-label ${!isGroup ? 'clickable' : 'stage-group'} ${(
           node.status || ''
         ).toLowerCase()}`}
-        onClick={this.handleClick}
       >
         <LabelComponent stage={node.stage} />
       </div>
     ) : (
-      <div className={`label-body node ${!isGroup ? 'clickable' : ''}`} onClick={this.handleClick}>
+      <div className={`label-body node ${!isGroup ? 'clickable' : ''}`}>
         <a>{node.name}</a>
       </div>
     );
-
-    // Add the group popover to the label if the node is representative of a group
-    if (node.stage && node.stage.type === 'group') {
-      GraphLabel = (
-        <GroupExecutionPopover stage={node.stage} subStageClicked={this.subStageClicked}>
-          {GraphLabel}
-        </GroupExecutionPopover>
-      );
-    }
 
     // Wrap all the label html in a foreignObject to make SVG happy
     GraphLabel = (
@@ -167,10 +145,29 @@ export class PipelineGraphNode extends React.Component<IPipelineGraphNodeProps> 
       </foreignObject>
     );
 
-    return (
-      <g onMouseEnter={this.highlight} onMouseLeave={this.removeHighlight} style={{ pointerEvents: 'all' }}>
+    let NodeContents = (
+      <>
         {GraphNode}
         {GraphLabel}
+      </>
+    );
+
+    if (node.stage && node.stage.type === 'group') {
+      NodeContents = (
+        <GroupExecutionPopover stage={node.stage} subStageClicked={this.subStageClicked} width={maxLabelWidth}>
+          {NodeContents}
+        </GroupExecutionPopover>
+      );
+    }
+
+    return (
+      <g
+        onMouseEnter={this.highlight}
+        onMouseLeave={this.removeHighlight}
+        onClick={this.handleClick}
+        style={{ cursor: 'pointer', pointerEvents: 'all' }}
+      >
+        {NodeContents}
       </g>
     );
   }

--- a/app/scripts/modules/core/src/pipeline/config/stages/group/GroupExecutionLabel.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/group/GroupExecutionLabel.tsx
@@ -14,6 +14,7 @@ export interface IGroupExecutionLabelProps {
   execution: IExecution;
   application: Application;
   executionMarker: boolean;
+  width?: number;
 }
 
 export class GroupExecutionLabel extends React.Component<IGroupExecutionLabelProps> {
@@ -23,14 +24,14 @@ export class GroupExecutionLabel extends React.Component<IGroupExecutionLabelPro
   };
 
   public render() {
-    const { stage } = this.props;
+    const { stage, width } = this.props;
 
     if (!this.props.executionMarker) {
       return <ExecutionBarLabel {...this.props} />;
     }
 
     return (
-      <GroupExecutionPopover stage={stage} subStageClicked={this.subStageClicked}>
+      <GroupExecutionPopover stage={stage} subStageClicked={this.subStageClicked} width={width}>
         {this.props.children}
       </GroupExecutionPopover>
     );

--- a/app/scripts/modules/core/src/pipeline/config/stages/group/GroupExecutionPopover.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/group/GroupExecutionPopover.tsx
@@ -7,6 +7,7 @@ import './groupStage.less';
 
 export interface IGroupExecutionPopoverProps {
   stage: IExecutionStageSummary;
+  width: number;
   subStageClicked?: (groupStage: IExecutionStageSummary, stage: IExecutionStageSummary) => void;
 }
 
@@ -54,10 +55,10 @@ export class GroupExecutionPopover extends React.Component<IGroupExecutionPopove
   };
 
   public render() {
-    const { stage } = this.props;
+    const { stage, width } = this.props;
 
     const template = (
-      <div>
+      <div style={{ minWidth: width - 30 + 'px' }}>
         <div className="group-name">{stage.name.toUpperCase()}</div>
         <ul className="group-execution-label-list">
           {stage.groupStages.map(s => (


### PR DESCRIPTION
Improve the handling of clicking and hovering on stages in the pipeline graph in Chrome 67 (`foreignObject` creates its own stacking context) by consolidating the click/mouseEnter/mouseLeave events on the parent `<g>` element.

Small tweaks to the grouped stage menu, forcing it to be a bit wider because react-bootstrap does not support composite placement (i.e. `bottom left`), and the menu now appears in the middle of the entire node + label, which can be a lot wider than needed because, well, laying out this graph is complicated.

Closes https://github.com/spinnaker/spinnaker/issues/2850