### PR TITLE
fix(core): recompute cluster pod heights on filter changes

### DIFF
--- a/app/scripts/modules/core/src/instance/details/InstanceDetails.tsx
+++ b/app/scripts/modules/core/src/instance/details/InstanceDetails.tsx
@@ -67,7 +67,11 @@ export class InstanceDetails extends React.Component<IInstanceDetailsProps, IIns
   public render() {
     const { accountId, moniker, environment, loading } = this.state;
     if (loading) {
-      return <Spinner />;
+      return (
+        <div className="full-width text-center">
+          <Spinner size="medium" message=" " />
+        </div>
+      );
     }
 
     return <InstanceDetailsCmp {...this.props} accountId={accountId} moniker={moniker} environment={environment} />;


### PR DESCRIPTION
I no longer understand what the `keyMapper` is supposed to be doing in the React Virtualized List. The `List` element does not seem to take those keys into consideration when re-rendering its rows, so when the underlying data has changed (because the filters have changed, for example), it seems to leave the row heights alone for any rows currently rendered on the screen. As soon as the user scrolls the list at all, however, the correct heights are applied, so I'm really not sure what to think of it.

This workaround is simple: reset the measurer cache whenever the filters change. I don't care for it, but maybe it's fine.

@erikmunson PTAL when you have a chance. You can test out the existing behavior in our clusters view of Orca by toggling the test account filter on and off.

This other change (to the instance details) is totally unrelated but gets rid of the vertical blinds effect that flashes when the instance details panel is loading.