### PR TITLE
fix(provider/kubernetes): namespace manifests should be fetched with location of "_"

### DIFF
--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/react/DeployStatus.tsx
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/react/DeployStatus.tsx
@@ -64,7 +64,7 @@ export class DeployStatus extends React.Component<IExecutionDetailsSectionProps,
   private manifestIdentifier(manifest: IStageManifest) {
     const kind = manifest.kind.toLowerCase();
     // manifest.metadata.namespace doesn't exist if it's a namespace being deployed
-    const namespace = (manifest.metadata.namespace || '').toLowerCase();
+    const namespace = (manifest.metadata.namespace || '_').toLowerCase();
     const name = manifest.metadata.name.toLowerCase();
     return `${namespace} ${kind} ${name}`;
   }
@@ -103,6 +103,9 @@ export class DeployStatus extends React.Component<IExecutionDetailsSectionProps,
     const name = this.manifestFullName(manifest);
     const params = { account, location, name };
     const id = this.manifestIdentifier(manifest);
+    if (location == null) {
+      params.location = '_';
+    }
     if (this.findSubscriptionIndex({ id }) !== -1) {
       return null;
     }


### PR DESCRIPTION
Before:

Namespace manifest deploy status 404'd, always rendered with fallback view:

<img width="239" alt="screen shot 2018-05-31 at 10 23 22 am" src="https://user-images.githubusercontent.com/34253460/40787917-bf1a7460-64bc-11e8-8824-b69fcf420dbf.png">

After:

Namespace manifest deploy state requested successfully, rendered with status pills:

<img width="269" alt="screen shot 2018-05-31 at 10 22 51 am" src="https://user-images.githubusercontent.com/34253460/40787933-cc8f050c-64bc-11e8-867f-759756b42604.png">
