### PR TITLE
fix(deck): Change RunJob stage to check for logs in HTML

### DIFF
--- a/app/scripts/modules/kubernetes/src/pipeline/stages/runJob/runJobExecutionDetails.controller.js
+++ b/app/scripts/modules/kubernetes/src/pipeline/stages/runJob/runJobExecutionDetails.controller.js
@@ -16,7 +16,6 @@ module.exports = angular
     $uibModal,
   ) {
     $scope.configSections = ['runJobConfig', 'taskStatus'];
-    $scope.hasLogs = has($scope.stage, 'context.jobStatus.logs');
     $scope.executionId = $stateParams.executionId;
 
     // if the stage is pre-multi-containers

--- a/app/scripts/modules/kubernetes/src/pipeline/stages/runJob/runJobExecutionDetails.html
+++ b/app/scripts/modules/kubernetes/src/pipeline/stages/runJob/runJobExecutionDetails.html
@@ -17,8 +17,8 @@
               {{[container.imageDescription.repository, execution.trigger.tag].join(':')}}
             </dd>
           </span>
-          <dt ng-if="hasLogs">Logs</dt>
-          <dd ng-if="hasLogs">
+          <dt ng-if="stage.context.jobStatus.logs">Logs</dt>
+          <dd ng-if="stage.context.jobStatus.logs">
             <dl><a href="" ng-click="displayLogs()">Console Output (Raw)</a></dl>
           </dd>
         </dl>


### PR DESCRIPTION
To fix https://github.com/spinnaker/spinnaker/issues/2869

Checks to see if a RunJob pipeline stage has output logs in the HTML with Angular, rather than in the controller.
The HTML will poll for changes in the logs all the time, and will update without any refreshing, and displays at all times