### PR TITLE
fix(core/pipeline): Make script stage "Path" field not required

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/script/scriptStage.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/script/scriptStage.html
@@ -13,8 +13,7 @@
            ng-model="stage.repoBranch"/>
   </stage-config-field>
   <stage-config-field label="Script Path" help-key="pipeline.config.script.path">
-    <input type="text" class="form-control input-sm" required
-           ng-model="stage.scriptPath"/>
+    <input type="text" class="form-control input-sm" ng-model="stage.scriptPath"/>
   </stage-config-field>
   <stage-config-field label="Command" help-key="pipeline.config.script.command">
     <textarea class="form-control input-sm" required

--- a/app/scripts/modules/core/src/pipeline/config/stages/script/scriptStage.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/script/scriptStage.ts
@@ -21,7 +21,7 @@ module(SCRIPT_STAGE, [])
       templateUrl: require('./scriptStage.html'),
       executionDetailsSections: [ScriptExecutionDetails, ExecutionDetailsTasks],
       strategy: true,
-      validators: [{ type: 'requiredField', fieldName: 'command' }, { type: 'requiredField', fieldName: 'scriptPath' }],
+      validators: [{ type: 'requiredField', fieldName: 'command' }],
     });
   })
   .controller('ScriptStageCtrl', function($scope: IScope, stage: IStage) {


### PR DESCRIPTION
When no path is specified, the script stage finds the script command in the root of the git repository.  Path is only required if the script is found elsewhere.