### PR TITLE
fix(provider/kubernetes): re-enable script stage for k8s v2

### DIFF
--- a/app/scripts/modules/kubernetes/src/v2/kubernetes.v2.module.ts
+++ b/app/scripts/modules/kubernetes/src/v2/kubernetes.v2.module.ts
@@ -133,7 +133,6 @@ module(KUBERNETES_V2_MODULE, [
       'runJob',
       'scaleDown',
       'scaleDownCluster',
-      'script',
       'shrinkCluster',
     ],
   });


### PR DESCRIPTION
In a v2-only application:

<img width="379" alt="screen shot 2018-06-08 at 9 20 48 am" src="https://user-images.githubusercontent.com/34253460/41160318-42f253c0-6afd-11e8-967f-6e916432ecfa.png">
