### PR TITLE
fix(artifacts): only show question mark icon for custom artifacts

### DIFF
--- a/app/scripts/modules/core/src/artifact/ArtifactIconService.ts
+++ b/app/scripts/modules/core/src/artifact/ArtifactIconService.ts
@@ -13,9 +13,13 @@ export class ArtifactIconService {
   }
 
   public static getPath(type: string) {
+    if (type == null) {
+      return unknownArtifactPath;
+    }
+
     const icon = ArtifactIconService.icons.find(entry => entry.type.test(type));
     if (icon === undefined) {
-      return unknownArtifactPath;
+      return null;
     }
     return icon.path;
   }

--- a/app/scripts/modules/core/src/artifact/expectedArtifactMultiSelector.component.ts
+++ b/app/scripts/modules/core/src/artifact/expectedArtifactMultiSelector.component.ts
@@ -40,11 +40,21 @@ class ExpectedArtifactMultiSelectorComponent implements IComponentOptions {
                        ng-model="ctrl.command[ctrl.idsField]"
                        class="form-control input-sm expected-artifact-multi-selector">
               <ui-select-match>
-                <img ng-if="ctrl.showIcons" width="16" height="16" class="artifact-icon" ng-src="{{ ctrl.iconPath($item) }}" />
+                <img
+                  ng-if="ctrl.showIcons && ctrl.iconPath($item)"
+                  width="16"
+                  height="16"
+                  class="artifact-icon"
+                  ng-src="{{ ctrl.iconPath($item) }}" />
                 {{ $item | summarizeExpectedArtifact }}
               </ui-select-match>
               <ui-select-choices repeat="expected.id as expected in ctrl.expectedArtifacts">
-                <img ng-if="ctrl.showIcons" width="16" height="16" class="artifact-icon" ng-src="{{ ctrl.iconPath(expected) }}" />
+                <img
+                  ng-if="ctrl.showIcons && ctrl.iconPath(expected)"
+                  width="16"
+                  height="16"
+                  class="artifact-icon"
+                  ng-src="{{ ctrl.iconPath(expected) }}" />
                 <span>{{ expected | summarizeExpectedArtifact }}</span>
               </ui-select-choices>
             </ui-select>

--- a/app/scripts/modules/core/src/artifact/expectedArtifactSelector.component.ts
+++ b/app/scripts/modules/core/src/artifact/expectedArtifactSelector.component.ts
@@ -49,11 +49,21 @@ class ExpectedArtifactSelectorComponent implements IComponentOptions {
           <ui-select ng-model="ctrl.id"
                      class="form-control input-sm expected-artifact-selector" required>
             <ui-select-match>
-              <img ng-if="ctrl.showIcons" width="16" height="16" class="artifact-icon" ng-src="{{ ctrl.iconPath($select.selected) }}" />
+              <img
+                ng-if="ctrl.showIcons && ctrl.iconPath($select.selected)"
+                width="16"
+                height="16"
+                class="artifact-icon"
+                ng-src="{{ ctrl.iconPath($select.selected) }}" />
               {{ $select.selected | summarizeExpectedArtifact }}
             </ui-select-match>
             <ui-select-choices repeat="expected.id as expected in ctrl.expectedArtifacts">
-              <img ng-if="ctrl.showIcons" width="16" height="16" class="artifact-icon" ng-src="{{ ctrl.iconPath(expected) }}" />
+              <img
+                ng-if="ctrl.showIcons && ctrl.iconPath(expected)"
+                width="16"
+                height="16"
+                class="artifact-icon"
+                ng-src="{{ ctrl.iconPath(expected) }}" />
               <span>{{ expected | summarizeExpectedArtifact }}</span>
             </ui-select-choices>
           </ui-select>

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/artifact.component.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/artifact.component.ts
@@ -97,11 +97,11 @@ class ArtifactComponent implements IComponentOptions {
                ng-model="ctrl.artifact.kind"
                on-select="ctrl.loadArtifactKind()">
       <ui-select-match>
-        <img width="20" height="20" ng-src="{{ ctrl.selectedIcon }}" />
+        <img width="20" height="20" ng-if="ctrl.selectedIcon" ng-src="{{ ctrl.selectedIcon }}" />
         {{ ctrl.selectedLabel }}
       </ui-select-match>
       <ui-select-choices repeat="option.key as option in ctrl.getOptions() | filter: { label: $select.search }">
-        <img width="20" height="20" ng-src="{{ ctrl.artifactIconPath(option) }}" />
+        <img width="20" height="20" ng-if="ctrl.artifactIconPath(option)" ng-src="{{ ctrl.artifactIconPath(option) }}" />
         <span>{{ option.label }}</span>
       </ui-select-choices>
     </ui-select>

--- a/app/scripts/modules/core/src/pipeline/status/ArtifactList.tsx
+++ b/app/scripts/modules/core/src/pipeline/status/ArtifactList.tsx
@@ -68,7 +68,11 @@ export class ArtifactList extends React.Component<IArtifactListProps, IArtifactL
               <dl>
                 <div>
                   <dt>
-                    <img className="artifact-icon" src={ArtifactIconService.getPath(type)} width="18" height="18" />
+                    {ArtifactIconService.getPath(type) ? (
+                      <img className="artifact-icon" src={ArtifactIconService.getPath(type)} width="18" height="18" />
+                    ) : (
+                      <span>{type}</span>
+                    )}
                   </dt>
                   <dd>{name}</dd>
                 </div>


### PR DESCRIPTION
i.e., if a configured artifact type doesn't have an icon, don't show a question mark.
