### PR TITLE
fix(core/pipeline): Don't fail when checking Force Rebake without a trigger

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/bake/ManualExecutionBake.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/bake/ManualExecutionBake.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { get } from 'lodash';
+import { get, set } from 'lodash';
 
 import { HelpField } from 'core/help/HelpField';
 import { ITriggerTemplateComponentProps } from 'core/pipeline/manualExecution/TriggerTemplate';
@@ -8,7 +8,7 @@ export class ManualExecutionBake extends React.Component<ITriggerTemplateCompone
   private handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const target = event.target;
     const checked = target.checked;
-    this.props.command.trigger.rebake = checked;
+    set(this.props.command, 'trigger.rebake', checked);
     this.setState({});
   };
 


### PR DESCRIPTION
We were relying on `ng-model`'s deep property setting to add a `trigger` object if it didn't already exist. Since the manual execution controller is already setup to handle us doing it this way I'm not gonna go in and muck with it.