### PR TITLE
fix(pipeline): Correctly handle saving pipeline templates

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/pipelineConfigurer.js
+++ b/app/scripts/modules/core/src/pipeline/config/pipelineConfigurer.js
@@ -305,7 +305,7 @@ module.exports = angular
       $scope.$applyAsync(() => {
         $scope.renderablePipeline = _.clone($scope.renderablePipeline);
         // need to ensure references are maintained
-        if ($scope.plan) {
+        if ($scope.isTemplatedPipeline) {
           $scope.plan = $scope.renderablePipeline;
         } else {
           $scope.pipeline = $scope.renderablePipeline;


### PR DESCRIPTION
If a templated pipeline, save the template configuration, not the rendered pipeline.