### PR TITLE
fix(bake/manifest): fix passing namespace in helm bakery

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/bakeManifestConfig.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/bakeManifestConfig.html
@@ -23,7 +23,7 @@
     </stage-config-field>
     <stage-config-field label="Namespace" field-columns="3">
       <input type="text" class="form-control input-sm"
-             ng-model="ctrl.$scope.stage.properties.namespace">
+             ng-model="ctrl.$scope.stage.namespace">
       </input>
     </stage-config-field>
 


### PR DESCRIPTION
Use namespace parameter in pipeline instead properties.namespace

Cherry-picked: https://github.com/spinnaker/deck/commit/83c819a69f1b42239a15ebd3d3cc0b691ae272a7