### PR TITLE
feat(provider/kubernetes): generic details view for unmapped resources

### DIFF
--- a/app/scripts/modules/kubernetes/src/v2/kubernetes.v2.module.ts
+++ b/app/scripts/modules/kubernetes/src/v2/kubernetes.v2.module.ts
@@ -37,6 +37,7 @@ import { KUBERNETES_MULTI_MANIFEST_SELECTOR } from './manifest/selector/multiSel
 import { KUBERNETES_V2_LOAD_BALANCER_TRANSFORMER } from './loadBalancer/transformer';
 import { KUBERNETES_V2_SECURITY_GROUP_TRANSFORMER } from './securityGroup/transformer';
 import { KUBERNETES_ANNOTATION_CUSTOM_SECTIONS } from './manifest/annotationCustomSections.component';
+import { KUBERNETES_V2_RESOURCE_STATES } from './resources/resources.state';
 
 // load all templates into the $templateCache
 const templates = require.context('kubernetes', true, /\.html$/);
@@ -83,6 +84,7 @@ module(KUBERNETES_V2_MODULE, [
   KUBERNETES_MANIFEST_ANNOTATIONS,
   KUBERNETES_MANIFEST_EVENTS,
   KUBERNETES_ANNOTATION_CUSTOM_SECTIONS,
+  KUBERNETES_V2_RESOURCE_STATES,
 ]).config(() => {
   CloudProviderRegistry.registerProvider('kubernetes', {
     name: 'Kubernetes',

--- a/app/scripts/modules/kubernetes/src/v2/manifest/ManifestAnnotations.tsx
+++ b/app/scripts/modules/kubernetes/src/v2/manifest/ManifestAnnotations.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import { get, keys } from 'lodash';
+
+export interface IManifestAnnotationsMap {
+  [key: string]: string;
+}
+
+export interface IManifestAnnotationsProps {
+  manifest?: {
+    metadata?: {
+      annotations?: IManifestAnnotationsMap;
+    };
+  };
+}
+
+export class ManifestAnnotations extends React.Component<IManifestAnnotationsProps> {
+  private ignoreAnnotations = ['kubectl.kubernetes.io/last-applied-configuration'];
+
+  public render() {
+    const annotations: IManifestAnnotationsMap = get(this.props, ['manifest', 'metadata', 'annotations'], {});
+    const annotationKeys = keys(annotations).filter(k => !this.ignoreAnnotations.includes(k));
+    return (
+      <div className="vertical left">
+        {annotationKeys.map(key => (
+          <div className="info" key={key}>
+            <code>
+              {key}: {annotations[key]}
+            </code>
+          </div>
+        ))}
+      </div>
+    );
+  }
+}

--- a/app/scripts/modules/kubernetes/src/v2/manifest/ManifestLabels.tsx
+++ b/app/scripts/modules/kubernetes/src/v2/manifest/ManifestLabels.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { get, keys } from 'lodash';
+
+import './manifestLabels.less';
+
+export interface IManifestLabelsMap {
+  [key: string]: string;
+}
+
+export interface IManifestLabelsProps {
+  manifest?: {
+    metadata?: {
+      labels?: IManifestLabelsMap;
+    };
+  };
+}
+
+export class ManifestLabels extends React.Component<IManifestLabelsProps> {
+  public render() {
+    const labels: IManifestLabelsMap = get(this.props, ['manifest', 'metadata', 'labels'], {});
+    return (
+      <div className="horizontal wrap">
+        {keys(labels).map(key => (
+          <div key={key} className="manifest-label sp-badge info">
+            {key}: {labels[key]}
+          </div>
+        ))}
+      </div>
+    );
+  }
+}

--- a/app/scripts/modules/kubernetes/src/v2/manifest/manifestAnnotations.component.ts
+++ b/app/scripts/modules/kubernetes/src/v2/manifest/manifestAnnotations.component.ts
@@ -1,35 +1,9 @@
-import { IComponentOptions, IController, module } from 'angular';
-
-class KubernetesManifestAnnotations implements IController {
-  public manifest: any;
-  private ignoreAnnotations = ['kubectl.kubernetes.io/last-applied-configuration'];
-
-  public isValidKey(k: string): boolean {
-    return this.ignoreAnnotations.indexOf(k) === -1;
-  }
-
-  constructor() {
-    'ngInject';
-  }
-}
-
-class KubernetesManifestAnnotationsComponent implements IComponentOptions {
-  public bindings: any = { manifest: '<' };
-  public controller: any = KubernetesManifestAnnotations;
-  public controllerAs = 'ctrl';
-  public template = `
-    <div class="vertical left">
-      <div class="info" ng-repeat="(k, v) in ctrl.manifest.metadata.annotations" ng-if="ctrl.isValidKey(k)">
-        <code>
-          {{k}}: {{v}}
-        </code>
-      </div>
-    </div>
-  `;
-}
+import { module } from 'angular';
+import { react2angular } from 'react2angular';
+import { ManifestAnnotations } from './ManifestAnnotations';
 
 export const KUBERNETES_MANIFEST_ANNOTATIONS = 'spinnaker.kubernetes.v2.manifest.annotations';
 module(KUBERNETES_MANIFEST_ANNOTATIONS, []).component(
   'kubernetesManifestAnnotations',
-  new KubernetesManifestAnnotationsComponent(),
+  react2angular(ManifestAnnotations, ['manifest']),
 );

--- a/app/scripts/modules/kubernetes/src/v2/manifest/manifestLabels.component.ts
+++ b/app/scripts/modules/kubernetes/src/v2/manifest/manifestLabels.component.ts
@@ -1,27 +1,9 @@
-import { IComponentOptions, IController, module } from 'angular';
-
-import './manifestLabels.less';
-
-class KubernetesManifestLabels implements IController {
-  public manifest: any;
-
-  constructor() {
-    'ngInject';
-  }
-}
-
-class KubernetesManifestLabelsComponent implements IComponentOptions {
-  public bindings: any = { manifest: '<' };
-  public controller: any = KubernetesManifestLabels;
-  public controllerAs = 'ctrl';
-  public template = `
-    <div class="horizontal wrap">
-      <div class="manifest-label sp-badge info" ng-repeat="(k, v) in ctrl.manifest.metadata.labels">
-        {{k}}: {{v}}
-      </div>
-    </div>
-  `;
-}
+import { module } from 'angular';
+import { react2angular } from 'react2angular';
+import { ManifestLabels } from './ManifestLabels';
 
 export const KUBERNETES_MANIFEST_LABELS = 'spinnaker.kubernetes.v2.manifest.labels';
-module(KUBERNETES_MANIFEST_LABELS, []).component('kubernetesManifestLabels', new KubernetesManifestLabelsComponent());
+module(KUBERNETES_MANIFEST_LABELS, []).component(
+  'kubernetesManifestLabels',
+  react2angular(ManifestLabels, ['manifest']),
+);

--- a/app/scripts/modules/kubernetes/src/v2/manifest/status/ManifestCondition.tsx
+++ b/app/scripts/modules/kubernetes/src/v2/manifest/status/ManifestCondition.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+
+export interface IKubernetesManifestCondition {
+  status: string;
+  type: string;
+  lastTransitionTime: string;
+  message: string;
+}
+
+export interface IKubernetesManifestConditionProps {
+  condition: IKubernetesManifestCondition;
+}
+
+export class ManifestCondition extends React.Component<IKubernetesManifestConditionProps> {
+  public render() {
+    const { condition } = this.props;
+    return [
+      <span key="properties">
+        {condition.status === 'True' && <span style={{ marginRight: '3px' }} className="glyphicon glyphicon-Normal" />}
+        {condition.status === 'False' && <span style={{ marginRight: '3px' }} className="glyphicon glyphicon-Warn" />}
+        {condition.status === 'Unknown' && <span style={{ marginRight: '3px' }}>?</span>}
+        <b style={{ marginRight: '3px' }}>{condition.type}</b>
+        <i>{condition.lastTransitionTime}</i>
+      </span>,
+      <div key="message">{condition.message}</div>,
+    ];
+  }
+}

--- a/app/scripts/modules/kubernetes/src/v2/manifest/status/condition.component.ts
+++ b/app/scripts/modules/kubernetes/src/v2/manifest/status/condition.component.ts
@@ -1,29 +1,9 @@
-import { IComponentOptions, IController, module } from 'angular';
-
-class KubernetesManifestConditionCtrl implements IController {
-  public condition: any;
-}
-
-class KubernetesManifestConditionComponent implements IComponentOptions {
-  public bindings: any = { condition: '<' };
-  public controller: any = KubernetesManifestConditionCtrl;
-  public controllerAs = 'ctrl';
-  public template = `
-      <span>
-        <span ng-if="ctrl.condition.status === 'True'" class="glyphicon glyphicon-Normal"></span>
-        <span ng-if="ctrl.condition.status === 'False'" class="glyphicon glyphicon-Warn"></span>
-        <span ng-if="ctrl.condition.status === 'Unknown'"> ? </span>
-        <b>{{ctrl.condition.type}}</b>
-        <i>{{ctrl.condition.lastTransitionTime}}</i>
-      </span>
-      <div>
-        {{ctrl.condition.message}}
-      </div>
-  `;
-}
+import { module } from 'angular';
+import { react2angular } from 'react2angular';
+import { ManifestCondition } from './ManifestCondition';
 
 export const KUBERNETES_MANIFEST_CONDITION = 'spinnaker.kubernetes.v2.manifest.condition.component';
 module(KUBERNETES_MANIFEST_CONDITION, []).component(
   'kubernetesManifestCondition',
-  new KubernetesManifestConditionComponent(),
+  react2angular(ManifestCondition, ['condition']),
 );

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/react/ManifestDetailsLink.tsx
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/react/ManifestDetailsLink.tsx
@@ -9,8 +9,6 @@ export interface IManifestDetailsProps {
   accountId: string;
 }
 
-const supportedKinds = ['deployment', 'replicaset'];
-
 export class ManifestDetailsLink extends React.Component<IManifestDetailsProps> {
   constructor(props: IManifestDetailsProps) {
     super(props);
@@ -18,13 +16,7 @@ export class ManifestDetailsLink extends React.Component<IManifestDetailsProps> 
   }
 
   private canOpen(): boolean {
-    return !!(
-      this.props.manifest.manifest &&
-      this.props.manifest.manifest.kind &&
-      this.props.manifest.manifest.metadata &&
-      this.props.manifest.manifest.metadata.annotations &&
-      supportedKinds.includes(this.props.manifest.manifest.kind.toLowerCase())
-    );
+    return !!this.props.manifest.manifest;
   }
 
   public openDetails() {
@@ -33,6 +25,8 @@ export class ManifestDetailsLink extends React.Component<IManifestDetailsProps> 
       this.openDeploymentDetails();
     } else if (kind === 'replicaset') {
       this.openReplicaSetDetails();
+    } else {
+      this.openGenericResourceDetails();
     }
   }
 
@@ -59,6 +53,14 @@ export class ManifestDetailsLink extends React.Component<IManifestDetailsProps> 
     const params = this.buildParams(annotations);
     params.serverGroup = `replicaSet ${annotations.name}-${annotations.version}`;
     $state.go('home.applications.application.insight.clusters.serverGroup', params);
+  }
+
+  private openGenericResourceDetails() {
+    const { $state } = ReactInjector;
+    const annotations = this.extractAnnotations(this.props.manifest.manifest.metadata.annotations);
+    const params = this.buildParams(annotations);
+    params.kubernetesResource = `${this.props.manifest.manifest.kind} ${this.props.manifest.manifest.metadata.name}`;
+    $state.go('home.applications.application.insight.clusters.kubernetesResource', params);
   }
 
   private stripQuotes(str: string): string {

--- a/app/scripts/modules/kubernetes/src/v2/resources/ResourceDetails.tsx
+++ b/app/scripts/modules/kubernetes/src/v2/resources/ResourceDetails.tsx
@@ -1,0 +1,121 @@
+import * as React from 'react';
+import * as moment from 'moment';
+import { get } from 'lodash';
+import { UISref } from '@uirouter/react';
+import { IManifest, Spinner, CloudProviderLogo, CollapsibleSection, AccountTag, timestamp } from '@spinnaker/core';
+import { KubernetesManifestService } from '../manifest/manifest.service';
+import { ManifestEvents } from 'kubernetes/v2/pipelines/stages/deployManifest/react/ManifestEvents';
+import { ManifestLabels } from 'kubernetes/v2/manifest/ManifestLabels';
+import { ManifestAnnotations } from 'kubernetes/v2/manifest/ManifestAnnotations';
+import { ManifestCondition } from 'kubernetes/v2/manifest/status/ManifestCondition';
+
+export interface IKubernetesResourceDetailsProps {
+  app: any;
+  kubernetesResource: any;
+}
+
+export interface IKubernetesResourceDetailsState {
+  manifest?: IManifest;
+  loading: boolean;
+}
+
+export class KubernetesResourceDetails extends React.Component<
+  IKubernetesResourceDetailsProps,
+  IKubernetesResourceDetailsState
+> {
+  private unsubscribeManifest?: () => void;
+
+  constructor(props: IKubernetesResourceDetailsProps) {
+    super(props);
+    this.state = {
+      loading: true,
+      manifest: null,
+    };
+  }
+
+  public componentDidMount() {
+    const { kubernetesResource } = this.props;
+    const params = {
+      account: kubernetesResource.accountId,
+      location: kubernetesResource.region,
+      name: kubernetesResource.kubernetesResource,
+    };
+    this.unsubscribeManifest = KubernetesManifestService.subscribe(this.props.app, params, manifest => {
+      if (this.unsubscribeManifest != null) {
+        this.setState({ manifest, loading: false });
+      }
+    });
+  }
+
+  public componentWillUnmount() {
+    if (this.unsubscribeManifest) {
+      this.unsubscribeManifest();
+      this.unsubscribeManifest = null;
+    }
+  }
+
+  public render() {
+    const { manifest } = this.state;
+    const metadata = get(manifest, ['manifest', 'metadata'], null);
+    const creationUnixMs = get(metadata, 'creationTimestamp') && moment(metadata.creationTimestamp).valueOf();
+    return (
+      <div className="details-panel">
+        <div className="header">
+          <div className="close-button">
+            <a className="btn btn-link">
+              <UISref to="^">
+                <span className="glyphicon glyphicon-remove" />
+              </UISref>
+            </a>
+          </div>
+          {this.state.loading ? (
+            <div className="horizontal center middle">
+              <Spinner size="small" />
+            </div>
+          ) : (
+            <div className="header-text horizontal middle">
+              <CloudProviderLogo provider="kubernetes" height="36px" width="36px" />
+              <h3 className="horizontal middle space-between flex-1">{get(metadata, ['name'], '')}</h3>
+            </div>
+          )}
+        </div>
+        {!this.state.loading && (
+          <div className="content">
+            <CollapsibleSection heading="Information">
+              <dl className="dl-horizontal dl-flex">
+                <dt>Created</dt>
+                <dd>{timestamp(creationUnixMs)}</dd>
+                <dt>Account</dt>
+                <dd>
+                  <AccountTag account={get(manifest, ['account'], '')} />
+                </dd>
+                <dt>Namespace</dt>
+                <dd>{get(metadata, ['namespace'], '')}</dd>
+                <dt>Kind</dt>
+                <dd>{get(manifest, ['manifest', 'kind'], '')}</dd>
+              </dl>
+            </CollapsibleSection>
+            <CollapsibleSection key="status" heading="status" defaultExpanded={true}>
+              <ul>
+                {get(manifest, ['manifest', 'status', 'conditions'], []).map(condition => (
+                  <li key={condition.type + condition.lastTransitionTime} style={{ marginBottom: '10px' }}>
+                    <ManifestCondition condition={condition} />
+                  </li>
+                ))}
+              </ul>
+            </CollapsibleSection>
+            <CollapsibleSection key="events" heading="events" defaultExpanded={true}>
+              <ManifestEvents manifest={manifest} />
+            </CollapsibleSection>
+            <CollapsibleSection key="labels" heading="labels" defaultExpanded={true}>
+              <ManifestLabels manifest={get(manifest, ['manifest'], {})} />
+            </CollapsibleSection>
+            <CollapsibleSection key="annotations" heading="annotations" defaultExpanded={true}>
+              <ManifestAnnotations manifest={get(manifest, ['manifest'], {})} />
+            </CollapsibleSection>
+          </div>
+        )}
+      </div>
+    );
+  }
+}

--- a/app/scripts/modules/kubernetes/src/v2/resources/resources.state.ts
+++ b/app/scripts/modules/kubernetes/src/v2/resources/resources.state.ts
@@ -1,0 +1,44 @@
+import { module } from 'angular';
+import { APPLICATION_STATE_PROVIDER, ApplicationStateProvider } from 'core/application';
+import { INestedState } from 'core/navigation';
+import { KubernetesResourceDetails } from './ResourceDetails';
+
+export interface IKubernetesResourceStateParams {
+  provider: string;
+  accountId: string;
+  region: string;
+  kubernetesResource: string;
+}
+
+export const KUBERNETES_V2_RESOURCE_STATES = 'spinnaker.core.kubernetesResource.states';
+module(KUBERNETES_V2_RESOURCE_STATES, [APPLICATION_STATE_PROVIDER]).config(
+  (applicationStateProvider: ApplicationStateProvider) => {
+    const kubernetesResourceDetails: INestedState = {
+      name: 'kubernetesResource',
+      url: '/manifest/:provider/:accountId/:region/:kubernetesResource',
+      views: {
+        'detail@../insight': {
+          component: KubernetesResourceDetails,
+          $type: 'react',
+        },
+      },
+      resolve: {
+        accountId: ['$stateParams', ($stateParams: IKubernetesResourceStateParams) => $stateParams.accountId],
+        kubernetesResource: ['$stateParams', ($stateParams: IKubernetesResourceStateParams) => $stateParams],
+      },
+      data: {
+        pageTitleDetails: {
+          title: 'Generic Kubernetes Resource Details',
+          nameParam: 'kubernetesResource',
+          accountParam: 'accountId',
+          regionParam: 'region',
+        },
+        history: {
+          type: 'kubernetesResource',
+        },
+      },
+    };
+
+    applicationStateProvider.addInsightDetailState(kubernetesResourceDetails);
+  },
+);


### PR DESCRIPTION
An "unmapped resource" is one that doesn't map cleanly to Spinnaker's notion of server groups / firewalls / load balancers.  A k8s ConfigMap is an example of this.

Fixes https://github.com/spinnaker/spinnaker/issues/2586
Fixes https://github.com/spinnaker/spinnaker/issues/2327

This PR adds a k8s-specific URL that matches the pattern `/applications/:appId/clusters/manifest/:provider/:accountId/:region/:kind%20:name`.  I haven't leveraged the Override registry here because I don't think any of the other providers have the same need as kubernetes re: unmappable resources.

ConfigMap example:

<img width="218" alt="screen shot 2018-06-18 at 1 17 33 pm" src="https://user-images.githubusercontent.com/34253460/41551697-a68c1e66-72fa-11e8-8827-8445a462f362.png">

For comparison's sake, here's how a pod renders with the existing k8s instance details view vs. the generic resource details view:

<img width="216" alt="screen shot 2018-06-18 at 1 18 34 pm" src="https://user-images.githubusercontent.com/34253460/41551761-d60876c6-72fa-11e8-8039-b33d375d46c1.png"><img width="217" alt="screen shot 2018-06-18 at 1 18 19 pm" src="https://user-images.githubusercontent.com/34253460/41551765-dabd0c40-72fa-11e8-96d7-ced46b3fe38a.png">
