### PR TITLE
feat(kubernetes): use kind mapping to determine details view

### DIFF
--- a/app/scripts/modules/core/src/account/AccountService.ts
+++ b/app/scripts/modules/core/src/account/AccountService.ts
@@ -39,6 +39,7 @@ export interface IAccountDetails extends IAccount {
   primaryAccount: boolean;
   regions: IRegion[];
   namespaces?: string[];
+  spinnakerKindMap?: { [k: string]: string };
 }
 
 export interface IAggregatedAccounts {

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/react/ManifestDetailsLink.tsx
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/react/ManifestDetailsLink.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { IManifest, Application, ReactInjector } from '@spinnaker/core';
-import { trim } from 'lodash';
+import { IManifest, Application, ReactInjector, AccountService } from '@spinnaker/core';
+import { get, trim } from 'lodash';
 
 export interface IManifestDetailsProps {
   manifest: IManifest;
@@ -10,76 +10,55 @@ export interface IManifestDetailsProps {
 }
 
 export class ManifestDetailsLink extends React.Component<IManifestDetailsProps> {
+  private spinnakerKindStateMap: { [k: string]: string } = {
+    // keys from clouddriver's KubernetesSpinnakerKindMap
+    serverGroupManagers: 'serverGroupManager',
+    serverGroups: 'serverGroup',
+  };
+
   constructor(props: IManifestDetailsProps) {
     super(props);
-    this.openDetails = this.openDetails.bind(this);
+    this.onClick = this.onClick.bind(this);
   }
 
   private canOpen(): boolean {
     return !!this.props.manifest.manifest;
   }
 
-  public openDetails() {
+  private spinnakerKindFromKubernetesKind(kind: string, kindMap: { [k: string]: string }) {
+    const foundKind = Object.keys(kindMap).find(k => k.toLowerCase() === kind.toLowerCase());
+    return kindMap[foundKind];
+  }
+
+  private resourceRegion(): string {
+    return trim(
+      get(this.props, ['manifest', 'manifest', 'metadata', 'annotations', 'artifact.spinnaker.io/location'], ''),
+    );
+  }
+
+  private openDetails(stateKey: string) {
+    const { $state } = ReactInjector;
+    const region = this.resourceRegion();
+    const params: { [k: string]: string } = { accountId: this.props.accountId, provider: 'kubernetes', region };
     const kind = this.props.manifest.manifest.kind.toLowerCase();
-    if (kind === 'deployment') {
-      this.openDeploymentDetails();
-    } else if (kind === 'replicaset') {
-      this.openReplicaSetDetails();
-    } else {
-      this.openGenericResourceDetails();
-    }
+    params[stateKey] = `${kind} ${this.props.manifest.manifest.metadata.name}`;
+    $state.go(`home.applications.application.insight.clusters.${stateKey}`, params);
   }
 
-  private buildParams(annotations: any): any {
-    return {
-      accountId: this.props.accountId,
-      provider: 'kubernetes',
-      application: annotations.application,
-      region: annotations.region,
-    };
-  }
-
-  private openDeploymentDetails() {
-    const { $state } = ReactInjector;
-    const annotations = this.extractAnnotations(this.props.manifest.manifest.metadata.annotations);
-    const params = this.buildParams(annotations);
-    params.serverGroupManager = `deployment ${annotations.name}`;
-    $state.go('home.applications.application.insight.clusters.serverGroupManager', params);
-  }
-
-  private openReplicaSetDetails() {
-    const { $state } = ReactInjector;
-    const annotations = this.extractAnnotations(this.props.manifest.manifest.metadata.annotations);
-    const params = this.buildParams(annotations);
-    params.serverGroup = `replicaSet ${annotations.name}-${annotations.version}`;
-    $state.go('home.applications.application.insight.clusters.serverGroup', params);
-  }
-
-  private openGenericResourceDetails() {
-    const { $state } = ReactInjector;
-    const annotations = this.extractAnnotations(this.props.manifest.manifest.metadata.annotations);
-    const params = this.buildParams(annotations);
-    params.kubernetesResource = `${this.props.manifest.manifest.kind} ${this.props.manifest.manifest.metadata.name}`;
-    $state.go('home.applications.application.insight.clusters.kubernetesResource', params);
-  }
-
-  private stripQuotes(str: string): string {
-    return trim(str, '"');
-  }
-
-  private extractAnnotations(annotations?: any): any {
-    return {
-      application: this.stripQuotes(annotations['moniker.spinnaker.io/application']),
-      region: this.stripQuotes(annotations['artifact.spinnaker.io/location']),
-      name: this.stripQuotes(annotations['artifact.spinnaker.io/name']),
-      version: this.stripQuotes(annotations['artifact.spinnaker.io/version']),
-    };
+  public onClick() {
+    const kind: string = get(this.props, ['manifest', 'manifest', 'kind'], '');
+    const { accountId } = this.props;
+    AccountService.getAccountDetails(accountId).then(account => {
+      const spinnakerKind = this.spinnakerKindFromKubernetesKind(kind, account.spinnakerKindMap);
+      const stateKey = this.spinnakerKindStateMap[spinnakerKind] || 'kubernetesResource';
+      this.openDetails(stateKey);
+    });
   }
 
   public render() {
     if (this.canOpen()) {
       return (
-        <a onClick={this.openDetails} className="clickable">
+        <a onClick={this.onClick} className="clickable">
           {this.props.linkName}
         </a>
       );


### PR DESCRIPTION
Use the kubernetes->spinnaker kind mappings from https://github.com/spinnaker/clouddriver/pull/2722 to route users to a resource's details view.