### PR TITLE
fix(titus): Default to 1 percent for container migrations vs 1 instance

### DIFF
--- a/app/scripts/modules/titus/src/migration/titusMigrationConfig.component.ts
+++ b/app/scripts/modules/titus/src/migration/titusMigrationConfig.component.ts
@@ -24,7 +24,7 @@ export class RollingPushStrategy implements IMigrationStrategyType {
   }
 
   public concurrentRelaunches = 1;
-  public concurrentRelaunchesAsPercentage = false;
+  public concurrentRelaunchesAsPercentage = true;
 
   public waitTime = 0;
 }


### PR DESCRIPTION
As requested by the titus folks.
