### PR TITLE
feat(pipeline): Support `runAsUser` for implicit pipeline triggers

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/triggers/pipeline/pipelineTrigger.html
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/pipeline/pipelineTrigger.html
@@ -56,4 +56,11 @@
       <checklist items="statusOptions" model="trigger.status" inline="true"></checklist>
     </div>
   </div>
+
+  <div class="form-group" ng-if="pipelineTriggerCtrl.fiatEnabled">
+    <run-as-user-selector service-accounts="pipelineTriggerCtrl.serviceAccounts"
+                          component="trigger"
+                          field="runAsUser">
+    </run-as-user-selector>
+  </div>
 </div>

--- a/app/scripts/modules/core/src/pipeline/config/triggers/pipeline/pipelineTrigger.module.js
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/pipeline/pipelineTrigger.module.js
@@ -3,10 +3,12 @@
 import _ from 'lodash';
 const angular = require('angular');
 
+import { ServiceAccountReader } from 'core/serviceAccount/ServiceAccountReader';
 import { ApplicationReader } from 'core/application/service/ApplicationReader';
 import { PipelineConfigService } from 'core/pipeline/config/services/PipelineConfigService';
 import { PipelineTriggerTemplate } from './PipelineTriggerTemplate';
 import { Registry } from 'core/registry';
+import { SETTINGS } from 'core/config/settings';
 
 module.exports = angular
   .module('spinnaker.core.pipeline.config.trigger.pipeline', [require('../trigger.directive.js').name])
@@ -23,6 +25,11 @@ module.exports = angular
   })
   .controller('pipelineTriggerCtrl', function($scope, trigger) {
     $scope.trigger = trigger;
+
+    this.fiatEnabled = SETTINGS.feature.fiatEnabled;
+    ServiceAccountReader.getServiceAccounts().then(accounts => {
+      this.serviceAccounts = accounts || [];
+    });
 
     if (!$scope.trigger.application) {
       $scope.trigger.application = $scope.application.name;


### PR DESCRIPTION
Previously these pipelines inherited the authentication context of their
parent pipeline.

spinnaker/orca#2295 has altered this behavior.
