### PR TITLE
Revert "feat(build): add cache bust for builds"

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,7 +30,7 @@ function configure(env, webpackOpts) {
     },
     output: {
       path: path.join(__dirname, 'build', 'webpack', process.env.SPINNAKER_ENV || ''),
-      filename: `[name]${IS_PRODUCTION ? '.[chunkhash]' : ''}.js`,
+      filename: '[name].js',
     },
     devtool: IS_PRODUCTION ? 'source-map' : 'eval',
     optimization: {


### PR DESCRIPTION
Reverts spinnaker/deck#5479

See https://github.com/spinnaker/spinnaker/issues/2942

This is more complicated than I thought. The problem is that it adds a hash to `settings.js` that Halyard can't know about beforehand. I can't see a way to prevent `settings.js` from receiving a hash.

Maybe someone with more Webpack knowledge (@christopherthielen ) can think of a solution?