### PR TITLE
feat(build): add cachebust query param to scripts in index.html

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -150,6 +150,7 @@ function configure(env, webpackOpts) {
         template: './app/index.deck',
         favicon: process.env.NODE_ENV === 'production' ? 'app/prod-favicon.ico' : 'app/dev-favicon.ico',
         inject: true,
+        hash: IS_PRODUCTION,
       }),
     ],
     devServer: {


### PR DESCRIPTION
Injects the script tags with a query param to help browsers figure out if they can load the script from cache or not:

```
<script type="text/javascript" src="settings.js?60126dc51605e31ce42c"></script>
<script type="text/javascript" src="settings-local.js?60126dc51605e31ce42c"></script>
<script type="text/javascript" src="vendors~app.js?60126dc51605e31ce42c"></script>
<script type="text/javascript" src="app.js?60126dc51605e31ce42c"></script>
```