### PR TITLE
fix(core): Fixed cluster scroll jump

### DIFF
--- a/app/scripts/modules/core/src/cluster/allClusters.html
+++ b/app/scripts/modules/core/src/cluster/allClusters.html
@@ -55,9 +55,13 @@
 </div>
 
 <!-- overflow-y is set to avoid flickering when scrollbars are set to always show (react virtualized thing) -->
+<div ng-if="!ctrl.initialized">
+  <loading-spinner size="medium"></loading-spinner>
+</div>
+
 <all-clusters-groupings
   class="content"
   app="ctrl.application"
-  initialized="ctrl.initialized"
   style="overflow-y: hidden"
+  initialized="ctrl.initialized"
 ></all-clusters-groupings>


### PR DESCRIPTION
Cluster page scrolls even when the user clicks on a cluster.

We set up scroll to specific server group if it is deep linked. this is set as a state in react. However it is never reset. As a result, even when the user clicks on a different server group, we update the route, but the state still has the previous server group set to scroll. So the page always scrolls to the previous server group. 
The current fix sets the ref as a state. This is because componentDidMount is called before the list component is loaded. So we need the ref and need to check when the component is updating and set it once the very first time to scroll. 
