### PR TITLE
fix(amazon/loadBalancer): Support order property in listener actions

### DIFF
--- a/app/scripts/modules/amazon/src/domain/IAmazonLoadBalancer.ts
+++ b/app/scripts/modules/amazon/src/domain/IAmazonLoadBalancer.ts
@@ -56,6 +56,7 @@ export interface IAmazonApplicationLoadBalancer extends IAmazonLoadBalancer {
 
 export interface IListenerAction {
   authenticateOidcConfig?: IAuthenticateOidcActionConfig;
+  order?: number;
   targetGroupName?: string;
   type: IListenerActionType;
 }

--- a/app/scripts/modules/amazon/src/domain/IAmazonLoadBalancerSourceData.ts
+++ b/app/scripts/modules/amazon/src/domain/IAmazonLoadBalancerSourceData.ts
@@ -113,6 +113,7 @@ export interface IApplicationLoadBalancerListenerSourceData {
   defaultActions: Array<{
     targetGroupName: string;
     type: IListenerActionType;
+    order: number;
   }>;
   listenerArn: string;
   loadBalancerName: string;

--- a/app/scripts/modules/amazon/src/loadBalancer/details/loadBalancerDetails.controller.ts
+++ b/app/scripts/modules/amazon/src/loadBalancer/details/loadBalancerDetails.controller.ts
@@ -122,6 +122,13 @@ export class AwsLoadBalancerDetailsController implements IController {
                 }
 
                 this.listeners = [];
+
+                // Sort the actions by the order specified since amazon does not return them in order of order
+                elb.listeners.forEach(l => {
+                  l.defaultActions.sort((a, b) => a.order - b.order);
+                  l.rules.forEach(r => r.actions.sort((a, b) => a.order - b.order));
+                });
+
                 elb.listeners.forEach(listener => {
                   listener.rules.map(rule => {
                     let inMatch = [

--- a/app/scripts/modules/core/src/loadBalancer/loadBalancer.read.service.ts
+++ b/app/scripts/modules/core/src/loadBalancer/loadBalancer.read.service.ts
@@ -56,7 +56,6 @@ export class LoadBalancerReader {
       lb.stack = nameParts.stack;
       lb.detail = nameParts.freeFormDetails;
       lb.cloudProvider = lb.cloudProvider || lb.type || lb.provider;
-      lb.loadBalancerType = lb.loadBalancerType || 'classic';
       return lb;
     });
   }


### PR DESCRIPTION
Fixed an issue with out-of-order actions for a rule.
This also makes sure the `authenticate-oidc` action is first, fixing the broken authenticate action.