### PR TITLE
fix(provider/kubernetes): Remove patch manifest stage v1 provider

### DIFF
--- a/app/scripts/modules/kubernetes/src/v1/kubernetes.v1.module.ts
+++ b/app/scripts/modules/kubernetes/src/v1/kubernetes.v1.module.ts
@@ -108,6 +108,7 @@ module(KUBERNETES_V1_MODULE, [
       'undoRolloutManifest',
       'findArtifactsFromResource',
       'bakeManifest',
+      'patchManifest',
     ],
   });
 });


### PR DESCRIPTION
Looks like this was accidentally applied to both v1 and v2, rather than just v2.