### PR TITLE
fix(kubernetes): console output broken for instances

### DIFF
--- a/app/scripts/modules/kubernetes/src/v2/instance/details/IKubernetesInstance.ts
+++ b/app/scripts/modules/kubernetes/src/v2/instance/details/IKubernetesInstance.ts
@@ -3,6 +3,7 @@ import { IInstance, IMoniker } from '@spinnaker/core';
 export interface IKubernetesInstance extends IInstance {
   kind: string;
   name: string;
+  humanReadableName: string;
   displayName: string;
   apiVersion: string;
   manifest: any;

--- a/app/scripts/modules/kubernetes/src/v2/instance/details/details.controller.ts
+++ b/app/scripts/modules/kubernetes/src/v2/instance/details/details.controller.ts
@@ -25,10 +25,18 @@ interface InstanceManager {
   instances: IKubernetesInstance[];
 }
 
+interface IConsoleOutputInstance {
+  account: string;
+  region: string;
+  id: string;
+  provider: string;
+}
+
 class KubernetesInstanceDetailsController implements IController {
   public state = { loading: true };
   public instance: IKubernetesInstance;
   public manifest: IManifest;
+  public consoleOutputInstance: IConsoleOutputInstance;
 
   constructor(
     instance: InstanceFromStateParams,
@@ -44,6 +52,12 @@ class KubernetesInstanceDetailsController implements IController {
       .then(() => this.retrieveInstance(instance))
       .then(instanceDetails => {
         this.instance = instanceDetails;
+        this.consoleOutputInstance = {
+          account: instanceDetails.account,
+          region: instanceDetails.region,
+          id: instanceDetails.humanReadableName,
+          provider: instanceDetails.provider,
+        };
 
         const unsubscribe = KubernetesManifestService.makeManifestRefresher(
           this.app,

--- a/app/scripts/modules/kubernetes/src/v2/instance/details/details.html
+++ b/app/scripts/modules/kubernetes/src/v2/instance/details/details.html
@@ -77,7 +77,7 @@
 
     <collapsible-section heading="Logs" expanded="true">
       <div>
-        <console-output-link instance="ctrl.instance"></console-output-link>
+        <console-output-link instance="ctrl.consoleOutputInstance"></console-output-link>
       </div>
     </collapsible-section>
   </div>


### PR DESCRIPTION
Console Output API for k8s v2 relies on the humanReadableName (previously returned as ID for k8s instances) which was no longer being passed since https://github.com/spinnaker/deck/pull/5506

Before:

<img width="922" alt="screen shot 2018-07-09 at 1 03 03 pm" src="https://user-images.githubusercontent.com/34253460/42464950-a53e52e8-8378-11e8-9073-ded075690ec3.png">

After:

<img width="926" alt="screen shot 2018-07-09 at 1 02 28 pm" src="https://user-images.githubusercontent.com/34253460/42464959-abfdc26c-8378-11e8-872c-b680660bc80e.png">
