### PR TITLE
refactor(serviceAccounts): Use an interface for service accounts.

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/triggers/git/git.trigger.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/git/git.trigger.ts
@@ -5,10 +5,11 @@ import { SETTINGS } from 'core/config/settings';
 import { IGitTrigger } from 'core/domain/ITrigger';
 import { Registry } from 'core/registry';
 import { ServiceAccountReader } from 'core/serviceAccount/ServiceAccountReader';
+import { IServiceAccount } from 'core';
 
 class GitTriggerController implements IController {
   public fiatEnabled: boolean = SETTINGS.feature.fiatEnabled;
-  public serviceAccounts: string[] = [];
+  public serviceAccounts: IServiceAccount[] = [];
   public gitTriggerTypes = SETTINGS.gitSources || ['stash', 'github', 'bitbucket', 'gitlab'];
   public displayText: any = {
     'pipeline.config.git.project': {

--- a/app/scripts/modules/core/src/pipeline/config/triggers/pubsub/pubsub.trigger.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/pubsub/pubsub.trigger.ts
@@ -5,13 +5,14 @@ import { PubsubSubscriptionReader } from 'core/pubsub';
 import { Registry } from 'core/registry';
 import { ServiceAccountReader } from 'core/serviceAccount';
 import { SETTINGS } from 'core/config/settings';
+import { IServiceAccount } from 'core';
 
 class PubsubTriggerController implements IController {
   public pubsubSystems = SETTINGS.pubsubProviders || ['google']; // TODO(joonlim): Add amazon once it is confirmed that amazon pub/sub works.
   private pubsubSubscriptions: IPubsubSubscription[];
   public filteredPubsubSubscriptions: string[];
   public subscriptionsLoaded = false;
-  public serviceAccounts: string[];
+  public serviceAccounts: IServiceAccount[];
 
   constructor(public trigger: IPubsubTrigger) {
     'ngInject';

--- a/app/scripts/modules/core/src/pipeline/config/triggers/runAsUserSelector.component.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/runAsUserSelector.component.ts
@@ -14,7 +14,7 @@ class RunAsUserSelectorComponent implements ng.IComponentOptions {
     <div class="col-md-9">
       <select
         class="form-control input-sm"
-        ng-options="svcAcct for svcAcct in $ctrl.serviceAccounts"
+        ng-options="svcAcct.name  as svcAcct.name for svcAcct in $ctrl.serviceAccounts"
         ng-model="$ctrl.component[$ctrl.field]">
         <option value="">Select Run As User</option>
       </select>

--- a/app/scripts/modules/core/src/pipeline/config/triggers/travis/travisTrigger.module.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/travis/travisTrigger.module.ts
@@ -7,6 +7,7 @@ import { IBuildTrigger } from 'core/domain/ITrigger';
 import { SETTINGS } from 'core/config/settings';
 
 import { TravisTriggerTemplate } from './TravisTriggerTemplate';
+import { IServiceAccount } from 'core';
 
 export interface ITravisTriggerViewState {
   mastersLoaded: boolean;
@@ -22,7 +23,7 @@ export class TravisTrigger implements IController {
   public filterLimit = 100;
   private filterThreshold = 500;
   public fiatEnabled: boolean;
-  public serviceAccounts: string[];
+  public serviceAccounts: IServiceAccount[];
 
   constructor($scope: IScope, public trigger: IBuildTrigger) {
     'ngInject';

--- a/app/scripts/modules/core/src/pipeline/config/triggers/webhook/webhook.trigger.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/webhook/webhook.trigger.ts
@@ -4,10 +4,11 @@ import { IWebhookTrigger } from 'core/domain';
 import { Registry } from 'core/registry';
 import { ServiceAccountReader } from 'core/serviceAccount/ServiceAccountReader';
 import { SETTINGS } from 'core/config/settings';
+import { IServiceAccount } from 'core';
 
 class WebhookTriggerController implements IController {
   public fiatEnabled: boolean;
-  public serviceAccounts: string[];
+  public serviceAccounts: IServiceAccount[];
 
   constructor(public trigger: IWebhookTrigger) {
     'ngInject';

--- a/app/scripts/modules/core/src/pipeline/config/validation/pipelineConfig.validator.spec.ts
+++ b/app/scripts/modules/core/src/pipeline/config/validation/pipelineConfig.validator.spec.ts
@@ -861,7 +861,9 @@ describe('pipelineConfigValidator', () => {
         return buildStageTypeConfig();
       });
 
-      spyOn(ServiceAccountReader, 'getServiceAccounts').and.returnValue($q.resolve(['my-account']));
+      spyOn(ServiceAccountReader, 'getServiceAccounts').and.returnValue(
+        $q.resolve([{ name: 'my-account', roles: ['abc'] }]),
+      );
     });
 
     it('calls service account access validator', () => {

--- a/app/scripts/modules/core/src/pipeline/config/validation/serviceAccountAccess.validator.ts
+++ b/app/scripts/modules/core/src/pipeline/config/validation/serviceAccountAccess.validator.ts
@@ -3,6 +3,7 @@ import { IPipeline, IStage, IStageOrTriggerTypeConfig } from 'core/domain';
 import { ServiceAccountReader } from 'core/serviceAccount/ServiceAccountReader';
 
 import { IStageOrTriggerValidator, IValidatorConfig, PipelineConfigValidator } from './PipelineConfigValidator';
+import { IServiceAccount } from 'core';
 
 export interface ITriggerWithServiceAccount extends IStage {
   runAsUser: string;
@@ -20,8 +21,8 @@ export class ServiceAccountAccessValidator implements IStageOrTriggerValidator {
     _config: IStageOrTriggerTypeConfig,
   ): ng.IPromise<string> {
     if (SETTINGS.feature.fiatEnabled) {
-      return ServiceAccountReader.getServiceAccounts().then((serviceAccounts: string[]) => {
-        if (stage.runAsUser && !serviceAccounts.includes(stage.runAsUser)) {
+      return ServiceAccountReader.getServiceAccounts().then((serviceAccounts: IServiceAccount[]) => {
+        if (stage.runAsUser && !serviceAccounts.map(s => s.name).includes(stage.runAsUser)) {
           return validator.message;
         } else {
           return null;

--- a/app/scripts/modules/core/src/serviceAccount/ServiceAccountReader.ts
+++ b/app/scripts/modules/core/src/serviceAccount/ServiceAccountReader.ts
@@ -5,8 +5,13 @@ import { $q } from 'ngimport';
 import { API } from 'core/api/ApiService';
 import { SETTINGS } from 'core/config/settings';
 
+export interface IServiceAccount {
+  name: string;
+  memberOf: string[];
+}
+
 export class ServiceAccountReader {
-  public static getServiceAccounts(): IPromise<string[]> {
+  public static getServiceAccounts(): IPromise<IServiceAccount[]> {
     if (!SETTINGS.feature.fiatEnabled) {
       return $q.resolve([]);
     } else {


### PR DESCRIPTION
The Gate API now returns the entire service account instead of just the roles.
This will eventually allow users to select roles for their pipelines.

Depends on spinnaker/gate/pull/573
