### PR TITLE
chore(core): Bump core to 0.0.246

### DIFF
--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/core",
-  "version": "0.0.245",
+  "version": "0.0.246",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
Bumping core to 0.0.246.

Includes fix for scrolling to bottom in clusters page. 