### PR TITLE
fix(core/pipeline): Don't fail when checking Force Rebake without a trigger

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/bake/ManualExecutionBake.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/bake/ManualExecutionBake.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { get } from 'lodash';
+import { get, set } from 'lodash';
 
 import { HelpField } from 'core/help/HelpField';
 import { ITriggerTemplateComponentProps } from 'core/pipeline/manualExecution/TriggerTemplate';
@@ -8,7 +8,7 @@ export class ManualExecutionBake extends React.Component<ITriggerTemplateCompone
   private handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const target = event.target;
     const checked = target.checked;
-    this.props.command.trigger.rebake = checked;
+    set(this.props.command, 'trigger.rebake', checked);
     this.setState({});
   };
 


### PR DESCRIPTION
Cherry-picked commit ab83c704e9a43439d85be084706810028b505c69 from master so it can get into 1.8.x sooner than later.  This bug is preventing "force rebake" options from working in several scenarios in 1.8.x.

ref. https://github.com/spinnaker/spinnaker/issues/3079