### PR TITLE
feat(core): Adding null check to protect against undefined config

### DIFF
--- a/app/scripts/modules/core/src/pipeline/filter/executionFilter.service.ts
+++ b/app/scripts/modules/core/src/pipeline/filter/executionFilter.service.ts
@@ -221,7 +221,7 @@ export class ExecutionFilterService {
           executions: groupExecutions,
           runningExecutions: groupExecutions.filter((execution: IExecution) => execution.isActive),
           targetAccounts: this.extractAccounts(config),
-          fromTemplate: config.type === 'templatedPipeline',
+          fromTemplate: (config && config.type === 'templatedPipeline') || false,
         });
       });
       this.addEmptyPipelines(groups, application);


### PR DESCRIPTION
If config is allowed to be null (and looks like it is), seems reasonable that if there is no type, then it's not from a templated pipeline so `fromTemplate` should be false.