### PR TITLE
fix(provider/google): cloning server group doesnt correctly copy disk info

### DIFF
--- a/app/scripts/modules/google/src/serverGroup/configure/wizard/cloneServerGroup.gce.controller.js
+++ b/app/scripts/modules/google/src/serverGroup/configure/wizard/cloneServerGroup.gce.controller.js
@@ -150,7 +150,7 @@ module.exports = angular
       $scope.$watch('command.region', createResultProcessor($scope.command.regionChanged));
       $scope.$watch('command.network', createResultProcessor($scope.command.networkChanged));
       $scope.$watch('command.zone', createResultProcessor($scope.command.zoneChanged));
-      $scope.$watch('command.viewState.instanceTypeDetails', updateStorageSettingsFromInstanceType(), true);
+      $scope.$watch('command.viewState.instanceTypeDetails', updateStorageSettingsFromInstanceType());
       $scope.$watch(
         'command.viewState.customInstance',
         () => {


### PR DESCRIPTION
Previously the clone modal wouldn't pick up disks when copying a server group.  Or, more accurately, it would pick them up and then immediately overwrite them with the instance type's default.

After this change a custom disk size correctly shows up in the clone modal:

<img width="458" alt="screen shot 2018-08-01 at 9 54 42 am" src="https://user-images.githubusercontent.com/34253460/43525903-f8ff30e6-9570-11e8-8975-2bae96c7d0ea.png">