### PR TITLE
fix(core): Remove bashisms from start.sh

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,18 +1,18 @@
-#!/bin/bash
+#!/bin/sh
 
 CURRENT_VERSION=$(node -v)
 
 # Process engines format like { "node": ">=7.0.0" }
 DESIRED_VERSION=$(node -e "console.log(require('./package.json').engines.node.replace(/[^0-9.]/g, ''))");
 
-if [[ $CURRENT_VERSION != "v$DESIRED_VERSION" ]]; then
-  if [[ -f $HOME/.nvm/nvm.sh ]]; then
+if [ $CURRENT_VERSION != "v$DESIRED_VERSION" ]; then
+  if [ -f $HOME/.nvm/nvm.sh ]; then
     echo "Node is currently $CURRENT_VERSION. Activating $DESIRED_VERSION using nvm..."
     . $HOME/.nvm/nvm.sh
     echo "Using $DESIRED_VERSION...";
     nvm use $DESIRED_VERSION
 
-    if [[ $? != 0 ]]; then
+    if [ $? != 0 ]; then
       echo "Installing node $DESIRED_VERSION..."
       nvm install $DESIRED_VERSION
     fi


### PR DESCRIPTION
It's explicitly started using `sh` in `package.json`, so it should not use bash (although it has `#!/bin/bash`).

The alternative is to change `package.json` to use `bash` instead, but since this script has no need for an advanced shell, just use POSIX shell features.

This makes `yarn run start` work on systems where `sh` is not bash, where it previously failed with the error message

> ./start.sh: 8: ./start.sh: [[: not found