### PR TITLE
fix(google): Remove image region validation from find image stage

### DIFF
--- a/app/scripts/modules/google/src/pipeline/stages/findImageFromTags/gceFindImageFromTagsStage.js
+++ b/app/scripts/modules/google/src/pipeline/stages/findImageFromTags/gceFindImageFromTagsStage.js
@@ -13,11 +13,7 @@ module.exports = angular
       templateUrl: require('./findImageFromTagsStage.html'),
       executionDetailsUrl: require('./findImageFromTagsExecutionDetails.html'),
       executionConfigSections: ['findImageConfig', 'taskStatus'],
-      validators: [
-        { type: 'requiredField', fieldName: 'packageName' },
-        { type: 'requiredField', fieldName: 'regions' },
-        { type: 'requiredField', fieldName: 'tags' },
-      ],
+      validators: [{ type: 'requiredField', fieldName: 'packageName' }, { type: 'requiredField', fieldName: 'tags' }],
     });
   })
   .controller('gceFindImageFromTagsStageCtrl', function($scope) {


### PR DESCRIPTION
GCE images aren't associated with a region, so there is no field to enter one in the UI. We should remove the validation that warns that a region has not been selected.