### PR TITLE
fix(core/search): Fix faceted search without any `q` query param

### DIFF
--- a/app/scripts/modules/core/src/search/infrastructure/infrastructureSearchV2.service.ts
+++ b/app/scripts/modules/core/src/search/infrastructure/infrastructureSearchV2.service.ts
@@ -53,7 +53,7 @@ export class InfrastructureSearchServiceV2 {
     };
 
     return Observable.from(types)
-      .mergeMap(type => {
+      .mergeMap((type: SearchResultType) => {
         return type
           .search(params, otherResults$)
           .map((searchResults: ISearchResults<any>) => makeResultSet(searchResults, type))

--- a/app/scripts/modules/core/src/search/search.service.ts
+++ b/app/scripts/modules/core/src/search/search.service.ts
@@ -11,6 +11,7 @@ export interface ISearchParams {
   platform?: string;
   pageNumber?: number;
   pageSize?: number;
+  allowShortQuery?: 'true' | undefined;
 }
 
 export interface ISearchResults<T extends ISearchResult> {

--- a/app/scripts/modules/core/src/search/searchResult/searchResultType.ts
+++ b/app/scripts/modules/core/src/search/searchResult/searchResultType.ts
@@ -41,8 +41,15 @@ export abstract class SearchResultType<T extends ISearchResult = ISearchResult> 
 
   /** Override this method as necessary */
   public search(params: ISearchParams, _otherResults?: Observable<ISearchResultSet>): Observable<ISearchResults<T>> {
-    const { key, ...otherParams } = params;
-    const searchParams = { ...otherParams, q: key, type: this.id };
+    const { cloudProvider, key, ...otherParams } = params;
+    const searchParams = { ...otherParams, q: key, cloudProvider, type: this.id };
+
+    // If filters other than 'q' (e.g., stack) are passed,
+    // tell clouddriver not to require at least 3 characters
+    if (Object.keys(otherParams).length > 0) {
+      searchParams.allowShortQuery = 'true';
+    }
+
     return Observable.fromPromise(SearchService.search(searchParams));
   }
 }


### PR DESCRIPTION
See https://github.com/spinnaker/gate/blob/f38b1525135070bef6ca525ea8e261f60c39ef97/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/SearchController.groovy#L42-L45