### PR TITLE
refactor(search): Update BasicCell to allow children

### DIFF
--- a/app/scripts/modules/core/src/search/searchResult/Renderers.tsx
+++ b/app/scripts/modules/core/src/search/searchResult/Renderers.tsx
@@ -52,8 +52,8 @@ export interface ICellRendererProps {
 
 export class BasicCell extends React.Component<ICellRendererProps> {
   public render() {
-    const { item, col, defaultValue } = this.props;
-    return <div className={colClass(col.key)}>{item[col.key] || defaultValue}</div>;
+    const { item, col, defaultValue, children } = this.props;
+    return <div className={colClass(col.key)}>{children || item[col.key] || defaultValue}</div>;
   }
 }
 


### PR DESCRIPTION
So we can compose cells with children instead of just text.

Don't think this calls for an entirely separate component (i.e. `CellWithChildren` or `ContainerCell`), does it?