### PR TITLE
fix(amazon/deploy): Edit deployment cluster button did not work

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/deploy/deployStage.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/deploy/deployStage.js
@@ -138,24 +138,23 @@ module.exports = angular
             .then(command => {
               if (config.CloneServerGroupModal) {
                 // react
-                config.CloneServerGroupModal.show({ title, application, command });
+                return config.CloneServerGroupModal.show({ title, application, command });
               } else {
                 // angular
-                $uibModal
-                  .open({
-                    templateUrl: config.cloneServerGroupTemplateUrl,
-                    controller: `${config.cloneServerGroupController} as ctrl`,
-                    size: 'lg',
-                    resolve: {
-                      title: () => title,
-                      application: () => application,
-                      serverGroupCommand: () => command,
-                    },
-                  })
-                  .result.then(handleResult)
-                  .catch(() => {});
+                return $uibModal.open({
+                  templateUrl: config.cloneServerGroupTemplateUrl,
+                  controller: `${config.cloneServerGroupController} as ctrl`,
+                  size: 'lg',
+                  resolve: {
+                    title: () => title,
+                    application: () => application,
+                    serverGroupCommand: () => command,
+                  },
+                }).result;
               }
-            });
+            })
+            .then(handleResult)
+            .catch(() => {});
         });
     };
 
@@ -179,21 +178,20 @@ module.exports = angular
             return providerConfig.serverGroup.CloneServerGroupModal.show({ title, application, command });
           } else {
             // angular
-            return $uibModal
-              .open({
-                templateUrl: providerConfig.serverGroup.cloneServerGroupTemplateUrl,
-                controller: `${providerConfig.serverGroup.cloneServerGroupController} as ctrl`,
-                size: 'lg',
-                resolve: {
-                  title: () => title,
-                  application: () => application,
-                  serverGroupCommand: () => command,
-                },
-              })
-              .result.then(handleResult)
-              .catch(() => {});
+            return $uibModal.open({
+              templateUrl: providerConfig.serverGroup.cloneServerGroupTemplateUrl,
+              controller: `${providerConfig.serverGroup.cloneServerGroupController} as ctrl`,
+              size: 'lg',
+              resolve: {
+                title: () => title,
+                application: () => application,
+                serverGroupCommand: () => command,
+              },
+            }).result;
           }
-        });
+        })
+        .then(handleResult)
+        .catch(() => {});
     };
 
     this.copyCluster = function(index) {


### PR DESCRIPTION
Nothing happened when pressing the edit icon, apart for the following console error being printed: "Error: One of component or template or templateUrl options is required".
You should of course just enter the correct configuration values immediately, but some people are not perfect and do mistakes. This commit will make those people happy, because the edit button once again works.