### PR TITLE
fix(amazon/deploy): Make source capacity work again, other misc. fixes

### DIFF
--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/capacity/CapacitySelector.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/capacity/CapacitySelector.tsx
@@ -12,12 +12,12 @@ export interface ICapacitySelectorProps {
 }
 
 export class CapacitySelector extends React.Component<ICapacitySelectorProps> {
-  public preferSourceCapacityOptions = [
-    { label: 'fail the stage', value: undefined },
+  private preferSourceCapacityOptions = [
+    { label: 'fail the stage', value: false },
     { label: 'use fallback values', value: true },
   ];
 
-  public useSourceCapacityUpdated(event: React.ChangeEvent<HTMLInputElement>): void {
+  private useSourceCapacityUpdated = (event: React.ChangeEvent<HTMLInputElement>): void => {
     const value = event.target.value === 'true';
     const { command } = this.props;
     this.props.setFieldValue('useSourceCapacity', value);
@@ -27,9 +27,9 @@ export class CapacitySelector extends React.Component<ICapacitySelectorProps> {
       this.props.setFieldValue('preferSourceCapacity', undefined);
     }
     this.setState({});
-  }
+  };
 
-  public setSimpleCapacity(simpleCapacity: boolean) {
+  private setSimpleCapacity(simpleCapacity: boolean) {
     const { command } = this.props;
     command.viewState.useSimpleCapacity = simpleCapacity;
     this.props.setFieldValue('useSourceCapacity', false);
@@ -37,12 +37,12 @@ export class CapacitySelector extends React.Component<ICapacitySelectorProps> {
     this.setState({});
   }
 
-  public simpleInstancesChanged = (event: React.ChangeEvent<HTMLInputElement>) => {
+  private simpleInstancesChanged = (event: React.ChangeEvent<HTMLInputElement>) => {
     const value = Number.parseInt(event.target.value, 10);
     this.setMinMax(value);
   };
 
-  public setMinMax(value: number) {
+  private setMinMax(value: number) {
     const { command } = this.props;
     if (command.viewState.useSimpleCapacity) {
       command.capacity.min = value;
@@ -54,10 +54,10 @@ export class CapacitySelector extends React.Component<ICapacitySelectorProps> {
     this.setState({});
   }
 
-  public preferSourceCapacityChanged(option: Option<boolean>) {
-    this.props.setFieldValue('preferSourceCapacity', option.value);
+  private preferSourceCapacityChanged = (option: Option<boolean>) => {
+    this.props.setFieldValue('preferSourceCapacity', option.value ? true : undefined);
     this.setState({});
-  }
+  };
 
   private capacityFieldChanged = (fieldName: 'min' | 'max' | 'desired', value: string) => {
     const { command, setFieldValue } = this.props;
@@ -96,6 +96,7 @@ export class CapacitySelector extends React.Component<ICapacitySelectorProps> {
                     <input
                       type="radio"
                       checked={command.useSourceCapacity}
+                      value="true"
                       id="useSourceCapacityTrue"
                       onChange={this.useSourceCapacityUpdated}
                     />
@@ -108,7 +109,7 @@ export class CapacitySelector extends React.Component<ICapacitySelectorProps> {
                     <div>
                       If no current server group is found,
                       <Select
-                        value={command.preferSourceCapacity}
+                        value={!!command.preferSourceCapacity}
                         options={this.preferSourceCapacityOptions}
                         onChange={this.preferSourceCapacityChanged}
                       />
@@ -126,7 +127,8 @@ export class CapacitySelector extends React.Component<ICapacitySelectorProps> {
                   <label>
                     <input
                       type="radio"
-                      checked={command.useSourceCapacity}
+                      checked={!command.useSourceCapacity}
+                      value="false"
                       id="useSourceCapacityFalse"
                       onChange={this.useSourceCapacityUpdated}
                     />

--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/ServerGroupBasicSettings.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/ServerGroupBasicSettings.tsx
@@ -15,6 +15,7 @@ import {
   TetheredSelect,
   IServerGroup,
   TaskReason,
+  Spinner,
 } from '@spinnaker/core';
 
 import { AwsNgReact } from 'amazon/reactShims';
@@ -100,7 +101,7 @@ class ServerGroupBasicSettingsImpl extends React.Component<
         values.backingData.packageImages = values.backingData.filtered.images;
         this.setState({ images });
       });
-    if (!values.amiName) {
+    if (!values.viewState.disableImageSelection && !values.amiName) {
       this.searchImages('');
     }
   }
@@ -110,7 +111,12 @@ class ServerGroupBasicSettingsImpl extends React.Component<
 
     const images = [
       {
-        message: `<loading-spinner size="'nano'"></loading-spinner> Finding results matching "${q}"...`,
+        message: (
+          <div>
+            <Spinner size="small" />
+            {`Finding results matching "${q}"...`}
+          </div>
+        ),
       },
     ];
     this.setState({ images });
@@ -190,7 +196,7 @@ class ServerGroupBasicSettingsImpl extends React.Component<
         'Only dot(.), underscore(_), and dash(-) special characters are allowed in the Detail field.';
     }
 
-    if (!values.amiName) {
+    if (!values.viewState.disableImageSelection && !values.amiName) {
       errors.amiName = 'Image required.';
     }
 

--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/ServerGroupSecurityGroups.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/ServerGroupSecurityGroups.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { FormikProps } from 'formik';
 
-import { IWizardPageProps, wizardPage } from '@spinnaker/core';
+import { IWizardPageProps, wizardPage, FirewallLabels } from '@spinnaker/core';
 
 import { SecurityGroupSelector } from '../securityGroups/SecurityGroupSelector';
 import { IAmazonServerGroupCommand } from '../../serverGroupConfiguration.service';
@@ -13,7 +13,9 @@ class ServerGroupSecurityGroupsImpl extends React.Component<
   IWizardPageProps & FormikProps<IAmazonServerGroupCommand>,
   IServerGroupSecurityGroupsState
 > {
-  public static LABEL = 'Security Groups';
+  public static get LABEL() {
+    return FirewallLabels.get('Firewalls');
+  }
 
   public validate(values: IAmazonServerGroupCommand): { [key: string]: string } {
     const errors: { [key: string]: string } = {};


### PR DESCRIPTION
Some more fun fixes:

- The radio buttons to select whether to copy source capacity or use new capacity settings were not working for several reasons (both options were checking the same condition, no `value` was specified for either, and there was a missing arrow binding for the `onChange` callback).
- The header/nav label was hard coded to `Security Groups` rather than using `FirewallLabels`.
- When `disableImageSelection` was set, the wizard could never be submitted/completed because `amiName` wasn't present and we were validating for it's existence all the time.
- The `preferSourceCapacity` setting was missing an arrow binding, and also showed the select field as empty/not selected when it was set to the default, rather than showing the actual default.
- The loading spinner + text for the image search select box was an angular HTML string that didn't work anymore.

I also went in and switched some things to `private` just for fun.