### PR TITLE
fix(kubernetes): manifest editor load time

### DIFF
--- a/app/scripts/modules/kubernetes/src/v2/manifest/manifestCommandBuilder.service.ts
+++ b/app/scripts/modules/kubernetes/src/v2/manifest/manifestCommandBuilder.service.ts
@@ -1,5 +1,8 @@
 import { cloneDeep } from 'lodash';
 import { dump, loadAll } from 'js-yaml';
+import { $q } from 'ngimport';
+import { IPromise } from 'angular';
+
 import { AccountService, Application, IMoniker } from '@spinnaker/core';
 
 export interface IKubernetesManifestCommandData {
@@ -60,13 +63,15 @@ export class KubernetesManifestCommandBuilder {
     app: Application,
     sourceManifest?: any,
     sourceMoniker?: IMoniker,
-  ): Promise<IKubernetesManifestCommandData> {
-    const dataToFetch = [
-      AccountService.getAllAccountDetailsForProvider('kubernetes', 'v2'),
-      AccountService.getArtifactAccounts(),
-    ];
+  ): IPromise<IKubernetesManifestCommandData> {
+    const dataToFetch = {
+      accounts: AccountService.getAllAccountDetailsForProvider('kubernetes', 'v2'),
+      artifactAccounts: AccountService.getArtifactAccounts(),
+    };
 
-    return Promise.all(dataToFetch).then(([accounts, artifactAccounts]) => {
+    // TODO(dpeach): if no callers of this method are Angular controllers,
+    // $q.all may be safely replaced with Promise.all.
+    return $q.all(dataToFetch).then(({ accounts, artifactAccounts }) => {
       const backingData = {
         accounts,
         artifactAccounts,


### PR DESCRIPTION
Native JS promises aren't hooked into Angular's event cycle - i.e., Angular doesn't notice when these promises resolve, and doesn't know to update the view.

Closes https://github.com/spinnaker/spinnaker/issues/3164