### PR TITLE
fix(kubernetes): replace all hyphens in annotation driven titles

### DIFF
--- a/app/scripts/modules/kubernetes/src/v2/manifest/annotationCustomSections.component.ts
+++ b/app/scripts/modules/kubernetes/src/v2/manifest/annotationCustomSections.component.ts
@@ -63,8 +63,8 @@ class KubernetesAnnotationCustomSections implements IController {
       content = this.$interpolate(content)({ ...this.resource });
     }
     return {
-      title: parsed.title.replace('-', ' ').trim(),
-      key: parsed.key.replace('-', ' ').trim(),
+      title: parsed.title.replace(/-/g, ' ').trim(),
+      key: parsed.key.replace(/-/g, ' ').trim(),
       content: parsed.isHtml ? this.sanitizeContent(content) : content,
       isHtml: parsed.isHtml,
     };


### PR DESCRIPTION
Before:

<img width="302" alt="screen shot 2018-08-13 at 11 09 26 am" src="https://user-images.githubusercontent.com/34253460/44040938-81256bfc-9eea-11e8-9cc8-2c5695dedc00.png">

After:

<img width="308" alt="screen shot 2018-08-13 at 11 09 48 am" src="https://user-images.githubusercontent.com/34253460/44040944-85c918ac-9eea-11e8-8c48-87daf814a920.png">
