### PR TITLE
fix(kubernetes): duplicate 'replicas' label in scale manifest stage

### DIFF
--- a/app/scripts/modules/kubernetes/src/v2/manifest/scale/scaleSettingsForm.component.ts
+++ b/app/scripts/modules/kubernetes/src/v2/manifest/scale/scaleSettingsForm.component.ts
@@ -15,7 +15,6 @@ class KubernetesScaleManifestSettingsFormComponent implements IComponentOptions 
                   class="form-control input-sm highlight-pristine"
                   ng-model="ctrl.settings.replicas"
                   min="0"/>
-            <span class="input-group-addon">replica<span ng-if="ctrl.settings.replicas !== 1">s</span></span>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Before:

<img width="430" alt="screen shot 2018-08-13 at 11 35 07 am" src="https://user-images.githubusercontent.com/34253460/44041976-191e444a-9eed-11e8-9c14-27b47b2e9f0c.png">

After:

<img width="395" alt="screen shot 2018-08-13 at 11 34 36 am" src="https://user-images.githubusercontent.com/34253460/44041980-1d681a44-9eed-11e8-9111-b16f8bb023c6.png">

Closes https://github.com/spinnaker/spinnaker/issues/3169