### PR TITLE
feat(provider/kubernetes): hide artifact account selector when only one suitable account is available

### DIFF
--- a/app/scripts/modules/core/src/account/AccountService.ts
+++ b/app/scripts/modules/core/src/account/AccountService.ts
@@ -27,6 +27,11 @@ export interface IAccount {
   skin?: string;
 }
 
+export interface IArtifactAccount {
+  name: string;
+  types: string[];
+}
+
 export interface IAccountDetails extends IAccount {
   accountType: string;
   authorized: boolean;
@@ -93,7 +98,7 @@ export class AccountService {
     });
   }
 
-  public static getArtifactAccounts(): IPromise<IAccount[]> {
+  public static getArtifactAccounts(): IPromise<IArtifactAccount[]> {
     return API.one('artifacts')
       .one('credentials')
       .useCache()

--- a/app/scripts/modules/core/src/artifact/ArtifactIconService.ts
+++ b/app/scripts/modules/core/src/artifact/ArtifactIconService.ts
@@ -1,3 +1,5 @@
+import * as ArtifactTypes from './ArtifactTypes';
+
 const unknownArtifactPath = require('./icons/unknown-type-artifact.svg');
 
 interface IArtifactIcon {
@@ -25,11 +27,11 @@ export class ArtifactIconService {
   }
 }
 
-ArtifactIconService.registerType(/docker\/image/, require('./icons/docker-image-artifact.svg'));
-ArtifactIconService.registerType(/kubernetes\/.*/, require('./icons/kubernetes-artifact.svg'));
-ArtifactIconService.registerType(/embedded\/base64/, require('./icons/embedded-base64-artifact.svg'));
-ArtifactIconService.registerType(/gcs\/object/, require('./icons/gcs-file-artifact.svg'));
-ArtifactIconService.registerType(/github\/file/, require('./icons/github-file-artifact.svg'));
-ArtifactIconService.registerType(/gitlab\/file/, require('./icons/gitlab-file-artifact.svg'));
-ArtifactIconService.registerType(/bitbucket\/file/, require('./icons/bitbucket-file-artifact.svg'));
-ArtifactIconService.registerType(/s3\/object/, require('./icons/s3-object-artifact.svg'));
+ArtifactIconService.registerType(ArtifactTypes.DOCKER_IMAGE, require('./icons/docker-image-artifact.svg'));
+ArtifactIconService.registerType(ArtifactTypes.KUBERNETES, require('./icons/kubernetes-artifact.svg'));
+ArtifactIconService.registerType(ArtifactTypes.EMBEDDED_BASE64, require('./icons/embedded-base64-artifact.svg'));
+ArtifactIconService.registerType(ArtifactTypes.GCS_OBJECT, require('./icons/gcs-file-artifact.svg'));
+ArtifactIconService.registerType(ArtifactTypes.GITHUB_FILE, require('./icons/github-file-artifact.svg'));
+ArtifactIconService.registerType(ArtifactTypes.GITLAB_FILE, require('./icons/gitlab-file-artifact.svg'));
+ArtifactIconService.registerType(ArtifactTypes.BITBUCKET_FILE, require('./icons/bitbucket-file-artifact.svg'));
+ArtifactIconService.registerType(ArtifactTypes.S3_OBJECT, require('./icons/s3-object-artifact.svg'));

--- a/app/scripts/modules/core/src/artifact/ArtifactTypes.ts
+++ b/app/scripts/modules/core/src/artifact/ArtifactTypes.ts
@@ -1,0 +1,8 @@
+export const DOCKER_IMAGE = /docker\/image/;
+export const KUBERNETES = /kubernetes\/.*/;
+export const EMBEDDED_BASE64 = /embedded\/base64/;
+export const GCS_OBJECT = /gcs\/object/;
+export const GITHUB_FILE = /github\/file/;
+export const GITLAB_FILE = /gitlab\/file/;
+export const BITBUCKET_FILE = /bitbucket\/file/;
+export const S3_OBJECT = /s3\/object/;

--- a/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/bakeManifestConfig.controller.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/bakeManifestConfig.controller.ts
@@ -1,11 +1,11 @@
 import { IController, IScope } from 'angular';
 
-import { AccountService, ExpectedArtifactService, IAccount, IExpectedArtifact } from 'core';
+import { AccountService, ExpectedArtifactService, IArtifactAccount, IExpectedArtifact } from 'core';
 import { UUIDGenerator } from 'core/utils';
 
 export class BakeManifestConfigCtrl implements IController {
   public expectedArtifacts: IExpectedArtifact[];
-  public artifactAccounts: IAccount[];
+  public artifactAccounts: IArtifactAccount[];
   public templateRenderers = ['HELM2'];
 
   public static defaultInputArtifact(): any {


### PR DESCRIPTION
Hides the artifact account selector when the user only has one configured account for a given artifact's type.  Embedded artifacts provide the clearest example of this; the user is unable to configure their own embedded-account and so the account selector is never displayed for embedded/base64 artifacts. More generally if, for example, a user only has a single GCS artifact account configured then Deck will simply choose that account and won't provide a single-entry select box.

An artifact selected that only has one available account associated with its type:

<img width="471" alt="screen shot 2018-08-13 at 5 06 27 pm" src="https://user-images.githubusercontent.com/34253460/44058978-d92db1b4-9f1d-11e8-8d59-2d7b40a7b2cb.png">

An artifact selected that has two available accounts associated with its type:

<img width="466" alt="screen shot 2018-08-13 at 5 05 54 pm" src="https://user-images.githubusercontent.com/34253460/44058998-ebf103dc-9f1d-11e8-89d6-8fe5c63d7fbe.png">
