### PR TITLE
feat(artifacts): filter set of available artifact kinds by configured artifact accounts

### DIFF
--- a/app/scripts/modules/core/src/domain/IArtifactKindConfig.ts
+++ b/app/scripts/modules/core/src/domain/IArtifactKindConfig.ts
@@ -5,6 +5,7 @@ export interface IArtifactKindConfig {
   key: string;
   isDefault: boolean;
   isMatch: boolean;
+  isPubliclyAccessible?: boolean;
   template: string;
   controller: Function;
   controllerAs?: string;

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/docker/defaultDocker.artifact.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/docker/defaultDocker.artifact.ts
@@ -32,6 +32,7 @@ module(DEFAULT_DOCKER_ARTIFACT, []).config(() => {
     type: 'docker/image',
     isDefault: true,
     isMatch: false,
+    isPubliclyAccessible: true,
     description: 'A Docker image to be deployed.',
     key: 'default.docker',
     controller: function(artifact: IArtifact) {

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/docker/docker.artifact.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/docker/docker.artifact.ts
@@ -10,6 +10,8 @@ module(DOCKER_ARTIFACT, []).config(() => {
     type: 'docker/image',
     isDefault: false,
     isMatch: true,
+    // docker hub image artifacts can be bound to manifests without an associated artifact-account
+    isPubliclyAccessible: true,
     description: 'A Docker image to be deployed.',
     key: 'docker',
     controller: function(artifact: IArtifact) {


### PR DESCRIPTION
Before, all artifact kinds are available regardless of which artifact accounts have been configured:

![2018-08-14_16-31-39](https://user-images.githubusercontent.com/34253460/44116854-a23e205e-9fdf-11e8-9145-e307a07c34d0.png)

After, only the artifact kinds matching the set of configured accounts are available. In the below screenshot I only have a GCS credential configured. Base64 and Custom artifacts are credential-less and Docker artifacts are publicly accessible from docker hub:

![2018-08-15_12-47-30](https://user-images.githubusercontent.com/34253460/44160755-747b4700-a089-11e8-8fec-aa4a528c12fb.png)
