### PR TITLE
fix(loadBalancer): Use correct provider for titus server groups/instances

### DIFF
--- a/app/scripts/modules/amazon/src/loadBalancer/TargetGroup.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/TargetGroup.tsx
@@ -22,9 +22,8 @@ export class TargetGroup extends React.Component<ITargetGroupProps> {
     const ServerGroups = orderBy(targetGroup.serverGroups, ['isDisabled', 'name'], ['asc', 'desc']).map(serverGroup => (
       <LoadBalancerServerGroup
         key={serverGroup.name}
-        account={targetGroup.account}
-        region={targetGroup.region}
-        cloudProvider={targetGroup.cloudProvider}
+        account={serverGroup.account}
+        region={serverGroup.region}
         serverGroup={serverGroup}
         showInstances={showInstances}
       />

--- a/app/scripts/modules/amazon/src/loadBalancer/details/targetGroupDetails.html
+++ b/app/scripts/modules/amazon/src/loadBalancer/details/targetGroupDetails.html
@@ -91,7 +91,7 @@
               <a ui-sref="^.serverGroup({region: serverGroup.region,
                                           accountId: serverGroup.account,
                                           serverGroup: serverGroup.name,
-                                          provider: 'aws'})">
+                                          provider: serverGroup.cloudProvider})">
               {{serverGroup.name}}
               </a>
             </li>

--- a/app/scripts/modules/amazon/src/loadBalancer/loadBalancer.transformer.ts
+++ b/app/scripts/modules/amazon/src/loadBalancer/loadBalancer.transformer.ts
@@ -122,6 +122,12 @@ export class AwsLoadBalancerTransformer {
       tg.serverGroups = tg.serverGroups.map(serverGroup => {
         const account = accounts.find(x => x.name === serverGroup.account);
         const cloudProvider = serverGroup.cloudProvider || (account && account.cloudProvider);
+
+        serverGroup.instances.forEach(instance => {
+          instance.cloudProvider = cloudProvider;
+          instance.provider = cloudProvider;
+        });
+
         return { ...serverGroup, cloudProvider };
       });
 

--- a/app/scripts/modules/core/src/instance/Instances.tsx
+++ b/app/scripts/modules/core/src/instance/Instances.tsx
@@ -8,7 +8,6 @@ import { Instance } from './Instance';
 export interface IInstancesProps {
   instances: IInstance[];
   highlight?: string;
-  cloudProvider?: string;
 }
 
 export interface IInstancesState {
@@ -72,7 +71,7 @@ class InstancesInternal extends React.Component<IInstancesInternalProps, IInstan
 
   private handleInstanceClicked = (instance: IInstance) => {
     const { router, uiview } = this.props;
-    const params = { instanceId: instance.id, provider: instance.provider || this.props.cloudProvider };
+    const params = { instanceId: instance.id, provider: instance.cloudProvider || instance.provider };
     const options = { relative: uiview.context };
 
     router.stateService.go('.instanceDetails', params, options);

--- a/app/scripts/modules/core/src/loadBalancer/LoadBalancerClusterContainer.tsx
+++ b/app/scripts/modules/core/src/loadBalancer/LoadBalancerClusterContainer.tsx
@@ -31,9 +31,8 @@ export class LoadBalancerClusterContainer extends React.Component<ILoadBalancerC
     const ServerGroups = orderBy(serverGroups, ['isDisabled', 'name'], ['asc', 'desc']).map(serverGroup => (
       <LoadBalancerServerGroup
         key={serverGroup.name}
-        account={loadBalancer.account}
-        region={loadBalancer.region}
-        cloudProvider={loadBalancer.cloudProvider}
+        account={serverGroup.account}
+        region={serverGroup.region}
         serverGroup={serverGroup}
         showInstances={showInstances}
       />
@@ -44,11 +43,7 @@ export class LoadBalancerClusterContainer extends React.Component<ILoadBalancerC
         {showServerGroups && ServerGroups}
         {!showServerGroups &&
           showInstances && (
-            <LoadBalancerInstances
-              cloudProvider={loadBalancer.cloudProvider}
-              serverGroups={loadBalancer.serverGroups}
-              instances={loadBalancer.instances}
-            />
+            <LoadBalancerInstances serverGroups={loadBalancer.serverGroups} instances={loadBalancer.instances} />
           )}
       </div>
     );

--- a/app/scripts/modules/core/src/loadBalancer/LoadBalancerInstances.tsx
+++ b/app/scripts/modules/core/src/loadBalancer/LoadBalancerInstances.tsx
@@ -9,7 +9,6 @@ import { ClusterState } from 'core/state';
 export interface ILoadBalancerInstancesProps {
   serverGroups: IServerGroup[];
   instances: IInstance[];
-  cloudProvider?: string;
 }
 
 export interface ILoadBalancerInstancesState {
@@ -41,7 +40,7 @@ export class LoadBalancerInstances extends React.Component<ILoadBalancerInstance
   public render(): React.ReactElement<LoadBalancerInstances> {
     return (
       <div className="instance-list">
-        <Instances cloudProvider={this.props.cloudProvider} instances={this.state.instances} />
+        <Instances instances={this.state.instances} />
       </div>
     );
   }

--- a/app/scripts/modules/core/src/loadBalancer/LoadBalancerServerGroup.tsx
+++ b/app/scripts/modules/core/src/loadBalancer/LoadBalancerServerGroup.tsx
@@ -10,7 +10,6 @@ import { HealthCounts } from 'core/healthCounts/HealthCounts';
 import { Instances } from 'core/instance/Instances';
 
 export interface ILoadBalancerServerGroupProps {
-  cloudProvider: string;
   region: string;
   account: string;
   serverGroup: IServerGroup;
@@ -41,7 +40,7 @@ export class LoadBalancerServerGroup extends React.Component<
   }
 
   public render(): React.ReactElement<LoadBalancerServerGroup> {
-    const { cloudProvider, serverGroup, showInstances, account, region } = this.props;
+    const { serverGroup, showInstances, account, region } = this.props;
 
     const className = classNames({
       clickable: true,
@@ -54,7 +53,7 @@ export class LoadBalancerServerGroup extends React.Component<
       region: serverGroup.region || region,
       accountId: serverGroup.account || account,
       serverGroup: serverGroup.name,
-      provider: serverGroup.cloudProvider || cloudProvider,
+      provider: serverGroup.cloudProvider,
     };
 
     return (
@@ -64,7 +63,8 @@ export class LoadBalancerServerGroup extends React.Component<
             <div className="server-group-title container-fluid no-padding">
               <div className="row">
                 <div className="col-md-8">
-                  <CloudProviderLogo provider={cloudProvider} height={'14px'} width={'14px'} /> {serverGroup.name}
+                  <CloudProviderLogo provider={serverGroup.cloudProvider} height={'14px'} width={'14px'} />{' '}
+                  {serverGroup.name}
                 </div>
                 <div className="col-md-4 text-right">
                   <HealthCounts container={serverGroup.instanceCounts} />
@@ -73,7 +73,7 @@ export class LoadBalancerServerGroup extends React.Component<
             </div>
             {showInstances && (
               <div className="instance-list">
-                <Instances cloudProvider={this.props.cloudProvider} instances={this.state.instances} />
+                <Instances instances={this.state.instances} />
               </div>
             )}
           </div>


### PR DESCRIPTION
The fact that there can be Titus server groups/instances underneath AWS load balancers in the hierarchy breaks some of the assumptions we originally made when building the LB view for AWS. This led to an end state where we tried to represent Titus entities using our Amazon components, which made the instance details pane make no sense (even though it rendered without issue).

I chose to patch this up by hydrating the provider onto instances when we get the provider for each server group, and switching things that were pulling providers off of target groups to use the server group instead (in places where the logic is scoped to a given server group). A couple of things that came to mind:

- It feels like it'd be nice to tack the provider onto the server group when it comes back from `/loadBalancers`, but hydrating on the client via the account is not horrible if done right.

- I started hydrating instances because we expect a provider to get tacked onto instances throughout the rest of the instance-related components (in fact the clusters view has never given `<Instances />` a separate `cloudProvider` prop), and it feels like relying on a parent association to get a provider is asking for trouble.