### PR TITLE
provider(kubernetes): Hide min/max label in servergroup details when min is null-ish

### DIFF
--- a/app/scripts/modules/kubernetes/src/v2/serverGroup/details/details.html
+++ b/app/scripts/modules/kubernetes/src/v2/serverGroup/details/details.html
@@ -86,7 +86,12 @@
     </collapsible-section>
     <collapsible-section heading="Size" expanded="true">
       <dl class="dl-horizontal dl-flex"
-          ng-if="ctrl.serverGroup.capacity.min === ctrl.serverGroup.capacity.max">
+          ng-if="ctrl.serverGroup.capacity.min == null">
+        <dt>Current</dt>
+        <dd>{{ctrl.serverGroup.instances.length}}</dd>
+      </dl>
+      <dl class="dl-horizontal dl-flex"
+          ng-if="ctrl.serverGroup.capacity.min != null && ctrl.serverGroup.capacity.min === ctrl.serverGroup.capacity.max">
         <dt>Min/Max</dt>
         <dd>{{ctrl.serverGroup.capacity.min}}</dd>
         <dt>Current</dt>


### PR DESCRIPTION
Before:

![2018-08-15_10-02-43](https://user-images.githubusercontent.com/34253460/44152068-679854cc-a072-11e8-8d4e-5649a7a314bb.png)

After:

![2018-08-15_10-01-08](https://user-images.githubusercontent.com/34253460/44152028-4481c87e-a072-11e8-92ec-65a3d0b766e0.png)
