### PR TITLE
feat(kubernetes): new deployment representation in cluster view

### DIFF
--- a/app/scripts/modules/core/src/cluster/ClusterPod.tsx
+++ b/app/scripts/modules/core/src/cluster/ClusterPod.tsx
@@ -10,6 +10,7 @@ import { Tooltip } from 'core/presentation';
 import { IClusterSubgroup, IServerGroupSubgroup } from './filter/ClusterFilterService';
 import { ISortFilter } from 'core/filterModel';
 import { ClusterPodTitleWrapper } from 'core/cluster/ClusterPodTitleWrapper';
+import { ServerGroupManager } from 'core/serverGroupManager/ServerGroupManager';
 
 export interface IClusterPodProps {
   grouping: IClusterSubgroup;
@@ -93,6 +94,16 @@ export class ClusterPod extends React.Component<IClusterPodProps, IClusterPodSta
             onUpdate={() => application.serverGroups.refresh()}
           />
         </h6>
+
+        {(subgroup.serverGroupManagers || []).map(manager => (
+          <ServerGroupManager
+            key={manager.key}
+            manager={manager}
+            grouping={grouping}
+            application={application}
+            sortFilter={sortFilter}
+          />
+        ))}
 
         {grouping.cluster.category === 'serverGroup' &&
           sortedServerGroups.map((serverGroup: IServerGroup) => (

--- a/app/scripts/modules/core/src/cluster/filter/ClusterFilterService.ts
+++ b/app/scripts/modules/core/src/cluster/filter/ClusterFilterService.ts
@@ -1,4 +1,4 @@
-import { each, forOwn, groupBy, sortBy } from 'lodash';
+import { each, forOwn, groupBy, sortBy, partition } from 'lodash';
 import { Debounce } from 'lodash-decorators';
 import { $log } from 'ngimport';
 import { Subject } from 'rxjs';
@@ -31,12 +31,21 @@ export interface IClusterSubgroup extends IParentGrouping {
   entityTags: IEntityTags;
 }
 
+// TODO(dpeach): should this be IRegionSubgroup?
 export interface IServerGroupSubgroup {
   heading: string;
   key: string;
   category: string;
   serverGroups: IServerGroup[];
+  serverGroupManagers?: IServerGroupManagerSubgroup[];
   entityTags: IEntityTags;
+}
+
+export interface IServerGroupManagerSubgroup {
+  heading: string;
+  key: string;
+  category: string;
+  serverGroups: IServerGroup[];
 }
 
 export type Grouping = IClusterGroup | IClusterSubgroup | IServerGroupSubgroup;
@@ -76,12 +85,29 @@ export class ClusterFilterService {
             regionGroups: IServerGroupSubgroup[] = [];
 
           forOwn(regionGroupings, (regionGroup: IServerGroup[], region: string) => {
+            const [managed, standalone] = partition(
+                regionGroup,
+                group => group.serverGroupManagers && group.serverGroupManagers.length,
+              ),
+              serverGroupManagers: IServerGroupManagerSubgroup[] = [],
+              managerGroupings = groupBy(managed, sg => sg.serverGroupManagers[0].name);
+
+            forOwn(managerGroupings, (managerGroup: IServerGroup[], manager: string) => {
+              serverGroupManagers.push({
+                heading: manager,
+                key: manager,
+                category: 'serverGroupManager',
+                serverGroups: managerGroup,
+              });
+            });
+
             regionGroups.push({
               heading: region,
               category,
-              serverGroups: regionGroup,
+              serverGroups: standalone,
               key: `${region}:${category}`,
               entityTags: (regionGroup[0].clusterEntityTags || []).find(t => t.entityRef['region'] === region),
+              ...(serverGroupManagers.length ? { serverGroupManagers } : {}),
             });
           });
 

--- a/app/scripts/modules/core/src/cluster/rollups.less
+++ b/app/scripts/modules/core/src/cluster/rollups.less
@@ -378,6 +378,11 @@ running-tasks-tag {
     &:hover {
       border-color: var(--color-accent-g1);
     }
+
+    &.managed {
+      margin: 5px;
+      border-style: dashed;
+    }
   }
   .permalinks {
     font-size: 80%;

--- a/app/scripts/modules/core/src/domain/IServerGroup.ts
+++ b/app/scripts/modules/core/src/domain/IServerGroup.ts
@@ -46,6 +46,7 @@ export interface IServerGroup {
   runningTasks?: ITask[];
   searchField?: string;
   securityGroups?: string[];
+  serverGroupManagers?: Array<{ account: string; location: string; name: string }>;
   stack?: string;
   stringVal?: string;
   subnetType?: string;

--- a/app/scripts/modules/core/src/serverGroup/ServerGroup.tsx
+++ b/app/scripts/modules/core/src/serverGroup/ServerGroup.tsx
@@ -34,6 +34,7 @@ export interface IServerGroupProps {
   sortFilter: ISortFilter;
   hasLoadBalancers: boolean;
   hasDiscovery: boolean;
+  hasManager?: boolean;
 }
 
 export interface IServerGroupState {
@@ -159,7 +160,7 @@ export class ServerGroup extends React.Component<IServerGroupProps, IServerGroup
 
   public render() {
     const { instances, images, jenkins, docker, isSelected, isMultiSelected } = this.state;
-    const { serverGroup, application, sortFilter, hasDiscovery, hasLoadBalancers } = this.props;
+    const { serverGroup, application, sortFilter, hasDiscovery, hasLoadBalancers, hasManager } = this.props;
     const { account, region, name } = serverGroup;
     const { showAllInstances, listInstances } = sortFilter;
     const key = ScrollToService.toDomId(['serverGroup', account, region, name].join('-'));
@@ -171,6 +172,7 @@ export class ServerGroup extends React.Component<IServerGroupProps, IServerGroup
       'clickable-row': true,
       disabled: serverGroup.isDisabled,
       active: isSelected,
+      managed: hasManager,
     });
 
     return (

--- a/app/scripts/modules/core/src/serverGroup/ServerGroupHeader.tsx
+++ b/app/scripts/modules/core/src/serverGroup/ServerGroupHeader.tsx
@@ -10,7 +10,6 @@ import { HealthCounts } from 'core/healthCounts';
 import { NameUtils } from 'core/naming';
 import { CloudProviderLogo } from 'core/cloudProvider';
 import { LoadBalancersTagWrapper } from 'core/loadBalancer';
-import { ServerGroupManagerTag } from 'core/serverGroupManager/ServerGroupManagerTag';
 import { ISortFilter } from 'core/filterModel';
 import { Overridable } from 'core/overrideRegistry';
 
@@ -126,13 +125,6 @@ export class RunningTasks extends React.Component<IServerGroupHeaderProps> {
   }
 }
 
-export class ServerGroupManager extends React.Component<IServerGroupHeaderProps> {
-  public render() {
-    const { application, serverGroup } = this.props;
-    return <ServerGroupManagerTag application={application} serverGroup={serverGroup} />;
-  }
-}
-
 @Overridable('serverGroups.pod.header')
 export class ServerGroupHeader extends React.Component<IServerGroupHeaderProps> {
   public render() {
@@ -150,7 +142,6 @@ export class ServerGroupHeader extends React.Component<IServerGroupHeaderProps> 
         <div className="flex-container-h baseline flex-pull-right">
           <RunningTasks {...props} />
           <LoadBalancers {...props} />
-          <ServerGroupManager {...props} />
           <Health {...props} />
         </div>
       </div>

--- a/app/scripts/modules/core/src/serverGroupManager/ServerGroupManager.tsx
+++ b/app/scripts/modules/core/src/serverGroupManager/ServerGroupManager.tsx
@@ -1,0 +1,110 @@
+import * as React from 'react';
+import * as classNames from 'classnames';
+import { orderBy } from 'lodash';
+
+import {
+  Application,
+  IClusterSubgroup,
+  IInstanceCounts,
+  IServerGroup,
+  IServerGroupManagerSubgroup,
+  ISortFilter,
+  ReactInjector,
+  ServerGroup,
+} from 'core';
+import { ServerGroupManagerHeading } from './ServerGroupManagerHeading';
+
+interface IServerGroupManagerProps {
+  manager: IServerGroupManagerSubgroup;
+  grouping: IClusterSubgroup;
+  application: Application;
+  sortFilter: ISortFilter;
+}
+
+export class ServerGroupManager extends React.Component<IServerGroupManagerProps> {
+  private isSelected = (): boolean => {
+    const { manager } = this.props;
+    const [serverGroup] = manager.serverGroups;
+    const params = {
+      accountId: serverGroup.account,
+      region: serverGroup.region,
+      provider: serverGroup.cloudProvider,
+      serverGroupManager: manager.heading,
+    };
+    return ReactInjector.$state.includes('**.serverGroupManager', params);
+  };
+
+  private handleClick = (e: React.MouseEvent<HTMLElement>): void => {
+    const { manager } = this.props;
+    const [serverGroup] = manager.serverGroups;
+    const nextState = ReactInjector.$state.current.name.endsWith('.clusters')
+      ? '.serverGroupManager'
+      : '^.serverGroupManager';
+
+    e.preventDefault();
+    e.stopPropagation();
+    ReactInjector.$state.go(nextState, {
+      accountId: serverGroup.account,
+      region: serverGroup.region,
+      provider: serverGroup.cloudProvider,
+      serverGroupManager: manager.heading,
+    });
+  };
+
+  private buildHealthCounts = (): IInstanceCounts => {
+    const {
+      manager: { serverGroups },
+    } = this.props;
+    const pick = (key: keyof IInstanceCounts) => (total: number, serverGroup: IServerGroup): number =>
+      total + serverGroup.instanceCounts[key];
+
+    return {
+      up: serverGroups.reduce(pick('up'), 0),
+      down: serverGroups.reduce(pick('down'), 0),
+      starting: serverGroups.reduce(pick('starting'), 0),
+      succeeded: serverGroups.reduce(pick('succeeded'), 0),
+      failed: serverGroups.reduce(pick('failed'), 0),
+      unknown: serverGroups.reduce(pick('unknown'), 0),
+      outOfService: serverGroups.reduce(pick('outOfService'), 0),
+    };
+  };
+
+  public render() {
+    const { manager, application, sortFilter, grouping } = this.props;
+    const [serverGroup] = manager.serverGroups;
+    const classes = {
+      active: this.isSelected(),
+      clickable: true,
+      'clickable-row': true,
+      'rollup-details': true,
+    };
+    const sortedServerGroups = orderBy(
+      manager.serverGroups,
+      [manager.serverGroups.every(sg => !!sg.moniker) ? 'moniker.sequence' : 'name'],
+      ['desc'],
+    );
+
+    return (
+      <div className={classNames(classes)}>
+        <ServerGroupManagerHeading
+          onClick={this.handleClick}
+          health={this.buildHealthCounts()}
+          provider={serverGroup.type}
+        />
+
+        {sortedServerGroups.map((sg: IServerGroup) => (
+          <ServerGroup
+            key={sg.name}
+            serverGroup={sg}
+            cluster={sg.cluster}
+            application={application}
+            sortFilter={sortFilter}
+            hasDiscovery={grouping.hasDiscovery}
+            hasLoadBalancers={grouping.hasLoadBalancers}
+            hasManager={true}
+          />
+        ))}
+      </div>
+    );
+  }
+}

--- a/app/scripts/modules/core/src/serverGroupManager/ServerGroupManagerHeading.tsx
+++ b/app/scripts/modules/core/src/serverGroupManager/ServerGroupManagerHeading.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+
+import { CloudProviderLogo, HealthCounts, IInstanceCounts } from 'core';
+
+export interface IServerGroupManagerHeadingProps {
+  health: IInstanceCounts;
+  provider: string;
+  onClick(event: React.MouseEvent<HTMLElement>): void;
+}
+
+export const ServerGroupManagerHeading = ({ onClick, health, provider }: IServerGroupManagerHeadingProps) => {
+  return (
+    <div className={`flex-container-h baseline server-group-title sticky-header-3`} onClick={onClick}>
+      <div className="flex-container-h baseline section-title">
+        <CloudProviderLogo provider={provider} height="16px" width="16px" />
+      </div>
+      <div className="flex-container-h baseline flex-pull-right">
+        <HealthCounts container={health} />
+      </div>
+    </div>
+  );
+};

--- a/app/scripts/modules/kubernetes/src/v2/serverGroup/serverGroupTransformer.service.ts
+++ b/app/scripts/modules/kubernetes/src/v2/serverGroup/serverGroupTransformer.service.ts
@@ -1,17 +1,20 @@
 import { IPromise, IQService, module } from 'angular';
+import { IKubernetesServerGroup } from 'kubernetes';
 
 export class KubernetesV2ServerGroupTransformer {
   constructor(private $q: IQService) {
     'ngInject';
   }
 
-  public normalizeServerGroup(serverGroup: any): IPromise<any> {
+  public normalizeServerGroup(serverGroup: IKubernetesServerGroup): IPromise<IKubernetesServerGroup> {
+    // TODO(dpeach): this isn't great, but we need to assume it's a deployment so that we can click
+    // into the details panel.
+    serverGroup.serverGroupManagers.forEach(manager => (manager.name = `deployment ${manager.name}`));
     return this.$q.when(serverGroup);
   }
 }
 
 export const KUBERNETES_V2_SERVER_GROUP_TRANSFORMER = 'spinnaker.kubernetes.v2.serverGroup.transformer.service';
-
 module(KUBERNETES_V2_SERVER_GROUP_TRANSFORMER, []).service(
   'kubernetesV2ServerGroupTransformer',
   KubernetesV2ServerGroupTransformer,


### PR DESCRIPTION
![new_deployments](https://user-images.githubusercontent.com/13868700/44155210-b1995834-a07a-11e8-9018-953267e0c20f.png)

Clicking the top of the grouping opens the deployment details on the left side.

When selected, looks like this:
![selected_deployment](https://user-images.githubusercontent.com/13868700/44155283-e13889e8-a07a-11e8-8585-e94031958fcf.png)

