### PR TITLE
fix(core/serverGroup): Make forced deploy template selection actually work

### DIFF
--- a/app/scripts/modules/core/src/serverGroup/configure/common/DeployInitializer.tsx
+++ b/app/scripts/modules/core/src/serverGroup/configure/common/DeployInitializer.tsx
@@ -41,8 +41,9 @@ export class DeployInitializer extends React.Component<IDeployInitializerProps, 
     const { viewState } = props.command;
     if (!viewState.disableNoTemplateSelection) {
       templates.push(this.noTemplate);
-      selectedTemplate = this.noTemplate;
     }
+
+    selectedTemplate = this.noTemplate;
 
     const serverGroups: IServerGroup[] = props.application
       .getDataSource('serverGroups')
@@ -64,8 +65,10 @@ export class DeployInitializer extends React.Component<IDeployInitializerProps, 
       });
     });
 
-    if (templates.length === 1) {
+    if (viewState.disableNoTemplateSelection && templates.length === 1) {
       selectedTemplate = templates[0];
+    } else if (!viewState.disableNoTemplateSelection && templates.length === 2) {
+      selectedTemplate = templates[1];
     }
 
     this.state = {
@@ -198,14 +201,13 @@ export class DeployInitializer extends React.Component<IDeployInitializerProps, 
             </form>
           </Modal.Body>
           <div className="modal-footer">
-            {selectedTemplate &&
-              (selectedTemplate.serverGroup || !command.viewState.disableNoTemplateSelection) && (
-                <button className="btn btn-primary" onClick={this.useTemplate}>
-                  {selectedTemplate.serverGroup && <span>Use this template</span>}
-                  {!selectedTemplate.serverGroup && <span>Continue without a template</span>}
-                  <span className="glyphicon glyphicon-chevron-right" />
-                </button>
-              )}
+            {(selectedTemplate.serverGroup || !command.viewState.disableNoTemplateSelection) && (
+              <button className="btn btn-primary" onClick={this.useTemplate}>
+                {selectedTemplate.serverGroup && <span>Use this template</span>}
+                {!selectedTemplate.serverGroup && <span>Continue without a template</span>}
+                <span className="glyphicon glyphicon-chevron-right" />
+              </button>
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
Turns out that the canary stage has historically told the deploy/clone dialog to force folks to select a server group template when adding a new canary/baseline pair (`disableNoTemplateSelection`). That used to work in angular-land, but when the relevant code got ported to the `DeployInitializer` component it broke. The underlying reason is that angular does a bunch of magic null-soaking that meant our controller code would happily evaluate derefs of the `selectedTemplate` object without it even existing. React is not nearly as happy to do that.

We already have a nicely setup `noTemplate` object that allows us to not worry about nulls, we just needed to actually use it for the canary stage case where you're forced to pick.