### PR TITLE
feat(kubernetes): filter artifact types that dont make sense for a manifest

### DIFF
--- a/app/scripts/modules/core/src/artifact/ArtifactIconService.ts
+++ b/app/scripts/modules/core/src/artifact/ArtifactIconService.ts
@@ -1,4 +1,4 @@
-import * as ArtifactTypes from './ArtifactTypes';
+import { ArtifactTypePatterns } from './ArtifactTypes';
 
 const unknownArtifactPath = require('./icons/unknown-type-artifact.svg');
 
@@ -27,11 +27,11 @@ export class ArtifactIconService {
   }
 }
 
-ArtifactIconService.registerType(ArtifactTypes.DOCKER_IMAGE, require('./icons/docker-image-artifact.svg'));
-ArtifactIconService.registerType(ArtifactTypes.KUBERNETES, require('./icons/kubernetes-artifact.svg'));
-ArtifactIconService.registerType(ArtifactTypes.EMBEDDED_BASE64, require('./icons/embedded-base64-artifact.svg'));
-ArtifactIconService.registerType(ArtifactTypes.GCS_OBJECT, require('./icons/gcs-file-artifact.svg'));
-ArtifactIconService.registerType(ArtifactTypes.GITHUB_FILE, require('./icons/github-file-artifact.svg'));
-ArtifactIconService.registerType(ArtifactTypes.GITLAB_FILE, require('./icons/gitlab-file-artifact.svg'));
-ArtifactIconService.registerType(ArtifactTypes.BITBUCKET_FILE, require('./icons/bitbucket-file-artifact.svg'));
-ArtifactIconService.registerType(ArtifactTypes.S3_OBJECT, require('./icons/s3-object-artifact.svg'));
+ArtifactIconService.registerType(ArtifactTypePatterns.DOCKER_IMAGE, require('./icons/docker-image-artifact.svg'));
+ArtifactIconService.registerType(ArtifactTypePatterns.KUBERNETES, require('./icons/kubernetes-artifact.svg'));
+ArtifactIconService.registerType(ArtifactTypePatterns.EMBEDDED_BASE64, require('./icons/embedded-base64-artifact.svg'));
+ArtifactIconService.registerType(ArtifactTypePatterns.GCS_OBJECT, require('./icons/gcs-file-artifact.svg'));
+ArtifactIconService.registerType(ArtifactTypePatterns.GITHUB_FILE, require('./icons/github-file-artifact.svg'));
+ArtifactIconService.registerType(ArtifactTypePatterns.GITLAB_FILE, require('./icons/gitlab-file-artifact.svg'));
+ArtifactIconService.registerType(ArtifactTypePatterns.BITBUCKET_FILE, require('./icons/bitbucket-file-artifact.svg'));
+ArtifactIconService.registerType(ArtifactTypePatterns.S3_OBJECT, require('./icons/s3-object-artifact.svg'));

--- a/app/scripts/modules/core/src/artifact/ArtifactTypes.ts
+++ b/app/scripts/modules/core/src/artifact/ArtifactTypes.ts
@@ -1,8 +1,10 @@
-export const DOCKER_IMAGE = /docker\/image/;
-export const KUBERNETES = /kubernetes\/.*/;
-export const EMBEDDED_BASE64 = /embedded\/base64/;
-export const GCS_OBJECT = /gcs\/object/;
-export const GITHUB_FILE = /github\/file/;
-export const GITLAB_FILE = /gitlab\/file/;
-export const BITBUCKET_FILE = /bitbucket\/file/;
-export const S3_OBJECT = /s3\/object/;
+export const ArtifactTypePatterns = {
+  BITBUCKET_FILE: /bitbucket\/file/,
+  DOCKER_IMAGE: /docker\/image/,
+  EMBEDDED_BASE64: /embedded\/base64/,
+  GCS_OBJECT: /gcs\/object/,
+  GITHUB_FILE: /github\/file/,
+  GITLAB_FILE: /gitlab\/file/,
+  KUBERNETES: /kubernetes\/.*/,
+  S3_OBJECT: /s3\/object/,
+};

--- a/app/scripts/modules/core/src/artifact/index.ts
+++ b/app/scripts/modules/core/src/artifact/index.ts
@@ -7,3 +7,4 @@ export * from './expectedArtifact.service';
 export * from './imageSourceSelector.component';
 export * from './react/ExecutionArtifactTab';
 export * from './react/ArtifactIconList';
+export * from './ArtifactTypes';

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestConfig.controller.ts
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestConfig.controller.ts
@@ -7,7 +7,7 @@ import {
   KubernetesManifestCommandBuilder,
 } from '../../../manifest/manifestCommandBuilder.service';
 
-import { ExpectedArtifactService, IExpectedArtifact } from '@spinnaker/core';
+import { ExpectedArtifactService, IExpectedArtifact, ArtifactTypePatterns } from '@spinnaker/core';
 
 export class KubernetesV2DeployManifestConfigCtrl implements IController {
   public state = {
@@ -18,6 +18,7 @@ export class KubernetesV2DeployManifestConfigCtrl implements IController {
   public textSource = 'text';
   public artifactSource = 'artifact';
   public sources = [this.textSource, this.artifactSource];
+  public excludedManifestArtifactPatterns = [ArtifactTypePatterns.KUBERNETES, ArtifactTypePatterns.DOCKER_IMAGE];
 
   public expectedArtifacts: IExpectedArtifact[];
 

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestConfig.html
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestConfig.html
@@ -33,6 +33,7 @@
                                 accounts="ctrl.metadata.backingData.artifactAccounts"
                                 expected-artifacts="ctrl.expectedArtifacts"
                                 help-field-key="kubernetes.manifest.expectedArtifact"
+                                exclude-artifact-type-patterns="ctrl.excludedManifestArtifactPatterns"
                                 show-icons="true">
     </expected-artifact-selector>
     <hr>


### PR DESCRIPTION
Before, a user could select a docker image as manifest source:

![2018-08-15_16-36-40](https://user-images.githubusercontent.com/34253460/44171880-794ff300-a0a9-11e8-9325-356e161d80f4.png)

After, the manifest dropdown is prevented from showing docker images or kubernetes resources as possible manifest sources:

![2018-08-15_16-35-24](https://user-images.githubusercontent.com/34253460/44171911-8cfb5980-a0a9-11e8-83a0-afa876d76686.png)

Closes https://github.com/spinnaker/spinnaker/issues/3198