### PR TITLE
fix(pipeline): Fixed missing inherited triggers/parameters/artifacts

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/templates/configurePipelineTemplateModal.controller.ts
+++ b/app/scripts/modules/core/src/pipeline/config/templates/configurePipelineTemplateModal.controller.ts
@@ -94,7 +94,14 @@ export class ConfigurePipelineTemplateModalController implements IController {
     const config = this.buildConfig();
     return PipelineTemplateReader.getPipelinePlan(config)
       .then(plan => {
-        this.$uibModalInstance.close({ plan, config });
+        const { parameterConfig, expectedArtifacts, triggers } = plan;
+        const inherited = {
+          ...config,
+          ...(this.state.inheritTemplateParameters && parameterConfig ? { parameterConfig } : {}),
+          ...(this.state.inheritTemplateExpectedArtifacts && expectedArtifacts ? { expectedArtifacts } : {}),
+          ...(this.state.inheritTemplateTriggers && triggers ? { triggers } : {}),
+        };
+        this.$uibModalInstance.close({ plan, config: inherited });
       })
       .catch((response: IHttpPromiseCallbackArg<IPipelineTemplatePlanResponse>) => {
         Object.assign(this.state, { loading: false, error: true, planErrors: response.data && response.data.errors });


### PR DESCRIPTION
When inheriting triggers, pipelines, or expected artifacts from a Managed Pipeline Template, the inherited attributes were not copied over from the plan to the pipeline config that gets rendered.

This change copies them selectively, based on the desired inheritance.