### PR TITLE
fix(appengine): add server group button broken

### DIFF
--- a/app/scripts/modules/appengine/src/serverGroup/configure/serverGroupCommandBuilder.service.ts
+++ b/app/scripts/modules/appengine/src/serverGroup/configure/serverGroupCommandBuilder.service.ts
@@ -141,20 +141,20 @@ export class AppengineServerGroupCommandBuilder {
   public buildNewServerGroupCommandForPipeline(
     _stage: IStage,
     pipeline: IPipeline,
-  ): {
+  ): IPromise<{
     backingData: {
       triggerOptions: Array<IAppengineGitTrigger | IAppengineJenkinsTrigger>;
       expectedArtifacts: IExpectedArtifact[];
     };
-  } {
+  }> {
     // We can't copy server group configuration for App Engine, and can't build the full command here because we don't have
     // access to the application.
-    return {
+    return this.$q.when({
       backingData: {
         triggerOptions: AppengineServerGroupCommandBuilder.getTriggerOptions(pipeline),
         expectedArtifacts: AppengineServerGroupCommandBuilder.getExpectedArtifacts(pipeline),
       },
-    };
+    });
   }
 
   public buildServerGroupCommandFromPipeline(


### PR DESCRIPTION
It looks as though deployStage now expects `buildNewServerGroupCommandForPipeline` to return a promise, and the other providers are doing so, but that appengine was missed.

Needs to be cherry-picked into 1.9.

Before, when clicking Add Server Group, no modal appears and the following error is shown in console:

![2018-08-16_14-40-09](https://user-images.githubusercontent.com/34253460/44228084-5e8d8500-a162-11e8-8334-98495a98a00c.png)

After, the exception doesn't appear and the server group modal is shown.