### PR TITLE
refactor(trigger): pull link and or text from ITrigger

### DIFF
--- a/app/scripts/modules/core/src/domain/IExecutionTrigger.ts
+++ b/app/scripts/modules/core/src/domain/IExecutionTrigger.ts
@@ -15,4 +15,6 @@ export interface IExecutionTrigger {
   dryRun?: boolean;
   artifacts?: IArtifact[];
   resolvedExpectedArtifacts?: IExpectedArtifact[];
+  link?: string;
+  linkText?: string;
 }

--- a/app/scripts/modules/core/src/pipeline/executionBuild/ExecutionBuildLink.tsx
+++ b/app/scripts/modules/core/src/pipeline/executionBuild/ExecutionBuildLink.tsx
@@ -40,18 +40,52 @@ export class ExecutionBuildLink extends React.Component<IExecutionBuildLinkProps
               {trigger.parentExecution.name}
             </a>
           )}
-        {this.props.execution.buildInfo &&
-          this.props.execution.buildInfo.number && (
-            <a
-              className="execution-build-number clickable"
-              onClick={this.handleBuildInfoClick}
-              href={this.props.execution.buildInfo.url}
-              target="_blank"
-            >
-              <span className="build-label">Build</span> #{this.props.execution.buildInfo.number}
-            </a>
-          )}
+        {this.getBuildLink()}
       </span>
     );
   }
+
+  private getBuildText(execution: IExecution) {
+    if (execution.trigger.linkText) {
+      return <span className="build-label">{execution.trigger.linkText}</span>;
+    } else {
+      return (
+        <>
+          <span className="build-label">Build</span> #{execution.buildInfo.number}
+        </>
+      );
+    }
+  }
+
+  private getBuildLink = () => {
+    const { execution } = this.props;
+
+    if (
+      !(execution.trigger.linkText && execution.trigger.link) &&
+      !(execution.buildInfo && execution.buildInfo.number)
+    ) {
+      return null;
+    }
+
+    if (execution.trigger.linkText && !(execution.trigger.link || execution.buildInfo.url)) {
+      // If supplying link text, must supply either link or url
+      return null;
+    }
+
+    if (execution.trigger.link && !(execution.trigger.linkText || execution.buildInfo.number)) {
+      // If supplying link, must supply either link text or build number
+      return null;
+    }
+
+    return (
+      <a
+        className="execution-build-number clickable"
+        onClick={this.handleBuildInfoClick}
+        href={execution.trigger.link ? execution.trigger.link : execution.buildInfo.url}
+        target="_blank"
+      >
+        {this.getBuildText(execution)}
+      </a>
+    );
+  };
 }


### PR DESCRIPTION
Trigger object can contain (optionally) a `link` and/or `linkText`. If that exists, use that for display purposes