### PR TITLE
fix(amazon/deploy): Use the right text for submit btn when cloning

### DIFF
--- a/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupCommandBuilder.service.js
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupCommandBuilder.service.js
@@ -263,6 +263,7 @@ module.exports = angular
             useSimpleCapacity: serverGroup.asg.minSize === serverGroup.asg.maxSize,
             usePreferredZones: usePreferredZones,
             mode: mode,
+            submitButtonLabel: getSubmitButtonLabel(mode),
             isNew: false,
             dirty: {},
           },


### PR DESCRIPTION
It seems this particular command builder was missed when adding `submitButtonLabel` to everything.