### PR TITLE
feat(artifacts): add react implementations of artifact editors

### DIFF
--- a/app/scripts/modules/core/src/domain/IArtifactEditorProps.ts
+++ b/app/scripts/modules/core/src/domain/IArtifactEditorProps.ts
@@ -1,0 +1,8 @@
+import { IArtifact } from 'core';
+
+export interface IArtifactEditorProps {
+  artifact: IArtifact;
+  onChange: (a: IArtifact) => void;
+  labelColumns: number;
+  fieldColumns: number;
+}

--- a/app/scripts/modules/core/src/domain/IArtifactKindConfig.ts
+++ b/app/scripts/modules/core/src/domain/IArtifactKindConfig.ts
@@ -1,3 +1,6 @@
+import { Component, SFC } from 'react';
+import { IArtifactEditorProps } from 'core/domain';
+
 export interface IArtifactKindConfig {
   label: string;
   type?: string;
@@ -6,6 +9,7 @@ export interface IArtifactKindConfig {
   isDefault: boolean;
   isMatch: boolean;
   isPubliclyAccessible?: boolean;
+  editCmp?: Component<IArtifactEditorProps> | SFC<IArtifactEditorProps>;
   template: string;
   controller: Function;
   controllerAs?: string;

--- a/app/scripts/modules/core/src/domain/index.ts
+++ b/app/scripts/modules/core/src/domain/index.ts
@@ -1,5 +1,6 @@
 export * from './IAppNotification';
 export * from './IArtifact';
+export * from './IArtifactEditorProps';
 export * from './IArtifactExtractor';
 export * from './IArtifactKindConfig';
 

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/base64/Base64ArtifactEditor.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/base64/Base64ArtifactEditor.tsx
@@ -1,0 +1,3 @@
+import { singleFieldArtifactEditor } from '../singleFieldArtifactEditor';
+
+export const Base64ArtifactEditor = singleFieldArtifactEditor('name', 'Name', 'base64-artifact', '');

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/base64/base64.artifact.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/base64/base64.artifact.ts
@@ -2,6 +2,7 @@ import { module } from 'angular';
 
 import { IArtifact } from 'core/domain/IArtifact';
 import { Registry } from 'core/registry';
+import { Base64ArtifactEditor } from './Base64ArtifactEditor';
 
 import './base64.artifact.less';
 
@@ -20,6 +21,7 @@ module(BASE64_ARTIFACT, []).config(() => {
       this.artifact.type = 'embedded/base64';
     },
     controllerAs: 'ctrl',
+    editCmp: Base64ArtifactEditor,
     template: `
 <div class="col-md-12">
   <div class="form-group row">

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/bitbucket/BitbucketArtifactEditor.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/bitbucket/BitbucketArtifactEditor.tsx
@@ -1,0 +1,8 @@
+import { singleFieldArtifactEditor } from '../singleFieldArtifactEditor';
+
+export const BitbucketArtifactEditor = singleFieldArtifactEditor(
+  'name',
+  'File path',
+  'manifests/frontend.yaml',
+  'pipeline.config.expectedArtifact.git.name',
+);

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/bitbucket/bitbucket.artifact.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/bitbucket/bitbucket.artifact.ts
@@ -2,6 +2,7 @@ import { module } from 'angular';
 
 import { IArtifact } from 'core/domain/IArtifact';
 import { Registry } from 'core/registry';
+import { BitbucketArtifactEditor } from './BitbucketArtifactEditor';
 
 export const BITBUCKET_ARTIFACT = 'spinnaker.core.pipeline.trigger.bitbucket.artifact';
 module(BITBUCKET_ARTIFACT, []).config(() => {
@@ -18,6 +19,7 @@ module(BITBUCKET_ARTIFACT, []).config(() => {
       this.artifact.type = 'bitbucket/file';
     },
     controllerAs: 'ctrl',
+    editCmp: BitbucketArtifactEditor,
     template: `
 <div class="col-md-12">
   <div class="form-group row">

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/custom/CustomArtifactEditor.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/custom/CustomArtifactEditor.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import { isFinite } from 'lodash';
+import { IArtifact, IArtifactEditorProps } from 'core/domain';
+
+export const CustomArtifactEditor = (props: IArtifactEditorProps) => {
+  const labelColumns = isFinite(props.labelColumns) ? props.labelColumns : 2;
+  const fieldColumns = isFinite(props.fieldColumns) ? props.fieldColumns : 8;
+  const labelClassName = 'col-md-' + labelColumns;
+  const fieldClassName = 'col-md-' + fieldColumns;
+  const input = (field: keyof IArtifact) => (
+    <input
+      type="text"
+      className="form-control input-sm"
+      value={props.artifact[field] || ''}
+      onChange={e => props.onChange({ ...props.artifact, [field]: e.target.value })}
+    />
+  );
+  return (
+    <div className="col-md-12">
+      <div className="form-group row">
+        <label className={labelClassName + ' sm-label-right'}>Type</label>
+        <div className="col-md-3">{input('type')}</div>
+        <label className={'col-md-2 sm-label-right'}>Name</label>
+        <div className="col-md-3">{input('name')}</div>
+      </div>
+      <div className="form-group row">
+        <label className={labelClassName + ' sm-label-right'}>Version</label>
+        <div className="col-md-3">{input('version')}</div>
+        <label className={'col-md-2 sm-label-right'}>Location</label>
+        <div className="col-md-3">{input('location')}</div>
+      </div>
+      <div className="form-group row">
+        <label className={labelClassName + ' sm-label-right'}>Reference</label>
+        <div className={fieldClassName}>{input('reference')}</div>
+      </div>
+    </div>
+  );
+};

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/custom/custom.artifact.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/custom/custom.artifact.ts
@@ -2,6 +2,7 @@ import { IController, module } from 'angular';
 
 import { IArtifact } from 'core/domain/IArtifact';
 import { Registry } from 'core/registry';
+import { CustomArtifactEditor } from './CustomArtifactEditor';
 
 class CustomArtifactController implements IController {
   constructor(public artifact: IArtifact) {
@@ -23,6 +24,7 @@ module(CUSTOM_ARTIFACT, [])
         this.artifact = artifact;
       },
       controllerAs: 'ctrl',
+      editCmp: CustomArtifactEditor,
       template: `
 <div class="col-md-12">
   <div class="form-group row">

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/docker/DockerArtifactEditor.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/docker/DockerArtifactEditor.tsx
@@ -1,0 +1,8 @@
+import { singleFieldArtifactEditor } from '../singleFieldArtifactEditor';
+
+export const DockerArtifactEditor = singleFieldArtifactEditor(
+  'name',
+  'Docker image',
+  'gcr.io/project/image',
+  'pipeline.config.expectedArtifact.docker.name',
+);

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/docker/docker.artifact.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/docker/docker.artifact.ts
@@ -2,6 +2,7 @@ import { module } from 'angular';
 
 import { IArtifact } from 'core/domain/IArtifact';
 import { Registry } from 'core/registry';
+import { DockerArtifactEditor } from './DockerArtifactEditor';
 
 export const DOCKER_ARTIFACT = 'spinnaker.core.pipeline.trigger.artifact.docker';
 module(DOCKER_ARTIFACT, []).config(() => {
@@ -20,6 +21,7 @@ module(DOCKER_ARTIFACT, []).config(() => {
       this.artifact.type = 'docker/image';
     },
     controllerAs: 'ctrl',
+    editCmp: DockerArtifactEditor,
     template: `
 <div class="col-md-12">
   <div class="form-group row">

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/gcs/GcsArtifactEditor.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/gcs/GcsArtifactEditor.tsx
@@ -1,0 +1,8 @@
+import { singleFieldArtifactEditor } from '../singleFieldArtifactEditor';
+
+export const GcsArtifactEditor = singleFieldArtifactEditor(
+  'name',
+  'Object path',
+  'gs://bucket/path/to/file',
+  'pipeline.config.expectedArtifact.gcs.name',
+);

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/gcs/gcs.artifact.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/gcs/gcs.artifact.ts
@@ -2,6 +2,7 @@ import { module } from 'angular';
 
 import { IArtifact } from 'core/domain/IArtifact';
 import { Registry } from 'core/registry';
+import { GcsArtifactEditor } from './GcsArtifactEditor';
 
 export const GCS_ARTIFACT = 'spinnaker.core.pipeline.trigger.gcs.artifact';
 module(GCS_ARTIFACT, []).config(() => {
@@ -18,6 +19,7 @@ module(GCS_ARTIFACT, []).config(() => {
       this.artifact.type = 'gcs/object';
     },
     controllerAs: 'ctrl',
+    editCmp: GcsArtifactEditor,
     template: `
 <div class="col-md-12">
   <div class="form-group row">

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/github/GithubArtifactEditor.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/github/GithubArtifactEditor.tsx
@@ -1,0 +1,8 @@
+import { singleFieldArtifactEditor } from '../singleFieldArtifactEditor';
+
+export const GithubArtifactEditor = singleFieldArtifactEditor(
+  'name',
+  'File path',
+  'manifests/frontend.yaml',
+  'pipeline.config.expectedArtifact.git.name',
+);

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/github/github.artifact.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/github/github.artifact.ts
@@ -2,6 +2,7 @@ import { module } from 'angular';
 
 import { IArtifact } from 'core/domain/IArtifact';
 import { Registry } from 'core/registry';
+import { GithubArtifactEditor } from './GithubArtifactEditor';
 
 export const GITHUB_ARTIFACT = 'spinnaker.core.pipeline.trigger.github.artifact';
 module(GITHUB_ARTIFACT, []).config(() => {
@@ -18,6 +19,7 @@ module(GITHUB_ARTIFACT, []).config(() => {
       this.artifact.type = 'github/file';
     },
     controllerAs: 'ctrl',
+    editCmp: GithubArtifactEditor,
     template: `
 <div class="col-md-12">
   <div class="form-group row">

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/gitlab/GitlabArtifactEditor.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/gitlab/GitlabArtifactEditor.tsx
@@ -1,0 +1,8 @@
+import { singleFieldArtifactEditor } from '../singleFieldArtifactEditor';
+
+export const GitlabArtifactEditor = singleFieldArtifactEditor(
+  'name',
+  'File path',
+  'manifests/frontend.yaml',
+  'pipeline.config.expectedArtifact.git.name',
+);

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/gitlab/gitlab.artifact.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/gitlab/gitlab.artifact.ts
@@ -2,6 +2,7 @@ import { module } from 'angular';
 
 import { IArtifact } from 'core/domain/IArtifact';
 import { Registry } from 'core/registry';
+import { GitlabArtifactEditor } from './GitlabArtifactEditor';
 
 export const GITLAB_ARTIFACT = 'spinnaker.core.pipeline.trigger.gitlab.artifact';
 module(GITLAB_ARTIFACT, []).config(() => {
@@ -18,6 +19,7 @@ module(GITLAB_ARTIFACT, []).config(() => {
       this.artifact.type = 'gitlab/file';
     },
     controllerAs: 'ctrl',
+    editCmp: GitlabArtifactEditor,
     template: `
 <div class="col-md-12">
   <div class="form-group row">

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/s3/S3ArtifactEditor.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/s3/S3ArtifactEditor.tsx
@@ -1,0 +1,8 @@
+import { singleFieldArtifactEditor } from '../singleFieldArtifactEditor';
+
+export const S3ArtifactEditor = singleFieldArtifactEditor(
+  'name',
+  'Object path',
+  's3://bucket/path/to/file',
+  'pipeline.config.expectedArtifact.s3.name',
+);

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/s3/s3.artifact.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/s3/s3.artifact.ts
@@ -2,6 +2,7 @@ import { module } from 'angular';
 
 import { IArtifact } from 'core/domain/IArtifact';
 import { Registry } from 'core/registry';
+import { S3ArtifactEditor } from './S3ArtifactEditor';
 
 export const S3_ARTIFACT = 'spinnaker.core.pipeline.trigger.s3.artifact';
 module(S3_ARTIFACT, []).config(() => {
@@ -18,6 +19,7 @@ module(S3_ARTIFACT, []).config(() => {
       this.artifact.type = 's3/object';
     },
     controllerAs: 'ctrl',
+    editCmp: S3ArtifactEditor,
     template: `
 <div class="col-md-12">
   <div class="form-group row">

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/singleFieldArtifactEditor.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/singleFieldArtifactEditor.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import { isFinite } from 'lodash';
+import { HelpField } from 'core';
+import { IArtifactEditorProps, IArtifact } from 'core/domain';
+
+export const singleFieldArtifactEditor = (
+  fieldKey: keyof IArtifact,
+  label: string,
+  placeholder: string,
+  helpTextKey: string,
+) => {
+  return (props: IArtifactEditorProps) => {
+    const labelColumns = isFinite(props.labelColumns) ? props.labelColumns : 2;
+    const fieldColumns = isFinite(props.fieldColumns) ? props.fieldColumns : 8;
+    const labelClassName = 'col-md-' + labelColumns;
+    const fieldClassName = 'col-md-' + fieldColumns;
+    return (
+      <div className="col-md-12">
+        <div className="form-group row">
+          <label className={labelClassName + ' sm-label-right'}>
+            {label}
+            {helpTextKey && <HelpField id={helpTextKey} />}
+          </label>
+          <div className={fieldClassName}>
+            <input
+              type="text"
+              placeholder={placeholder}
+              className="form-control input-sm"
+              value={props.artifact[fieldKey] || ''}
+              onChange={e => {
+                const clone = { ...props.artifact };
+                clone[fieldKey] = e.target.value;
+                props.onChange(clone);
+              }}
+            />
+          </div>
+        </div>
+      </div>
+    );
+  };
+};


### PR DESCRIPTION
Part 2 of many towards https://github.com/spinnaker/spinnaker/issues/2921

This adds react components for editing each artifact type. Improved type safety over html template strings and they're a bit more fungible for use in different places.

These aren't used yet. I'm breaking up a larger set of diffs into individual PRs. The next in this series adds a manifest artifact editor that makes use of these.