### PR TITLE
fix(artifacts): Fix artifact tab in execution history

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/StageName.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/StageName.tsx
@@ -37,6 +37,6 @@ export const StageName: React.SFC<IStageNameProps> = props => {
   return <span>{nameFromRefId(props.stages, props.refId)}</span>;
 };
 
-export const STAGE_NAME = 'spinnaker.core.artifact.artifactTab.component';
+export const STAGE_NAME = 'spinnaker.core.artifact.stageName.component';
 
 module(STAGE_NAME, []).component('stageName', react2angular(StageName, ['stages', 'refId']));


### PR DESCRIPTION
The artifact tab in the execution history is broken due to a duplicate angular module name.