### PR TITLE
fix(ux): minor text revisions for server group enable modal

### DIFF
--- a/app/scripts/modules/amazon/src/serverGroup/details/AmazonServerGroupActions.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/details/AmazonServerGroupActions.tsx
@@ -149,7 +149,7 @@ export class AmazonServerGroupActions extends React.Component<IAmazonServerGroup
       header: 'Rolling back?',
       body: `Spinnaker provides an orchestrated rollback feature to carefully restore a different version of this
              server group. Do you want to use the orchestrated rollback?`,
-      buttonText: `Yes, let's start the orchestrated rollback`,
+      buttonText: `Yes, take me to the rollback settings modal`,
       cancelButtonText: 'No, I just want to enable the server group',
     };
 

--- a/app/scripts/modules/titus/src/serverGroup/details/serverGroupDetails.titus.controller.js
+++ b/app/scripts/modules/titus/src/serverGroup/details/serverGroupDetails.titus.controller.js
@@ -302,7 +302,7 @@ module.exports = angular
         header: 'Rolling back?',
         body: `Spinnaker provides an orchestrated rollback feature to carefully restore a different version of this
              server group. Do you want to use the orchestrated rollback?`,
-        buttonText: `Yes, let's start the orchestrated rollback`,
+        buttonText: `Yes, take me to the rollback settings modal`,
         cancelButtonText: 'No, I just want to enable the server group',
       };
 


### PR DESCRIPTION
revises some modal text to imply that another dialog box follows it.