### PR TITLE
feat(provider/ecs): Add option to associate public IP address

### DIFF
--- a/app/scripts/modules/ecs/src/ecs.help.ts
+++ b/app/scripts/modules/ecs/src/ecs.help.ts
@@ -30,6 +30,7 @@ const helpContents: { [key: string]: string } = {
     '<p>A predefined MetricAlarm and Autoscaling policy with an Action must exist.</p><p>There is a delay in MetricAlarm recognizing the Autoscaling policy.</p>',
   'ecs.healthgraceperiod':
     '<p>How long a container will be kept alive despite the load balancer health checks, in seconds.</p>',
+  'ecs.publicip': '<p>Assign a public IP address to each task.</p>',
   'ecs.networkMode':
     '<p>awsvpc is the only networking mode that allows you to use Elastic Network Interfaces (ENI).  The default value converts to Bridge on Linux, and NAT on Windows.</p>',
   'ecs.subnet': '<p>The subnet group on which your server group will be deployed.</p>',

--- a/app/scripts/modules/ecs/src/serverGroup/configure/wizard/networking/networkingSelector.component.html
+++ b/app/scripts/modules/ecs/src/serverGroup/configure/wizard/networking/networkingSelector.component.html
@@ -57,6 +57,26 @@
     </div>
   </div>
 
+  <div ng-if="$ctrl.command.networkMode == 'awsvpc'">
+    <div class="form-group">
+      <div class="col-md-4 sm-label-right">
+        <b>Associate Public IP Address</b> <help-field key="ecs.publicip"></help-field>
+      </div>
+      <div class="col-md-1 radio">
+        <label>
+          <input type="radio" ng-model="$ctrl.command.associatePublicIpAddress" ng-value="true" id="associatePublicIpAddressTrue"/>
+          Yes
+        </label>
+      </div>
+      <div class="col-md-1 radio">
+        <label>
+          <input type="radio" ng-model="$ctrl.command.associatePublicIpAddress" ng-value="false" id="associatePublicIpAddressFalse"/>
+          No
+        </label>
+      </div>
+    </div>
+  </div>
+
   <div class="col-md-12" ng-if="$ctrl.command.viewState.dirty.targetGroup">
     <div class="alert alert-warning">
       <p><i class="fa fa-exclamation-triangle"></i>


### PR DESCRIPTION
Configuration for public IP address option ("Associate Public IP Address") when using VPC mode in ECS server groups

Clouddriver-side change is here: https://github.com/spinnaker/clouddriver/pull/2908

![public-ip-addr](https://user-images.githubusercontent.com/484245/44614251-e6643680-a7d5-11e8-84fd-9bc66044d0e8.png)
