### PR TITLE
fix(pipeline): fix invisible parameter when default is not in options

### DIFF
--- a/app/scripts/modules/core/src/pipeline/manualExecution/manualPipelineExecution.controller.js
+++ b/app/scripts/modules/core/src/pipeline/manualExecution/manualPipelineExecution.controller.js
@@ -158,6 +158,7 @@ module.exports = angular
       // Inject the default value into the options list if it is absent
       if (
         parameterConfig.default &&
+        parameterConfig.options &&
         !parameterConfig.options.some(option => option.value === parameterConfig.default)
       ) {
         parameterConfig.options.unshift({ value: parameterConfig.default });

--- a/app/scripts/modules/core/src/pipeline/manualExecution/manualPipelineExecution.controller.js
+++ b/app/scripts/modules/core/src/pipeline/manualExecution/manualPipelineExecution.controller.js
@@ -155,6 +155,13 @@ module.exports = angular
     };
 
     this.addParameter = parameterConfig => {
+      // Inject the default value into the options list if it is absent
+      if (
+        parameterConfig.default &&
+        !parameterConfig.options.some(option => option.value === parameterConfig.default)
+      ) {
+        parameterConfig.options.unshift({ value: parameterConfig.default });
+      }
       const { name } = parameterConfig;
       const parameters = trigger ? trigger.parameters : {};
       if (this.parameters[name] === undefined) {


### PR DESCRIPTION
When a pipeline is configured with a parameter that can be selected from an options list, yet the default value is not part of that options list, it looks as if nothing is selected by default.

In actuality, the default option is still selected (just not shown in the UI) and running the pipeline will result in running with the default value, even though that was not present to the user.

Additionally, if the user selects from one of the options, there is no way to select the pipeline's configured default.

This PR forces the default value to be part of the options list if it is absent.