### PR TITLE
fix(core/projects): remove duplicative home.projects.project.** substates

### DIFF
--- a/app/scripts/modules/core/src/projects/projects.states.ts
+++ b/app/scripts/modules/core/src/projects/projects.states.ts
@@ -89,7 +89,6 @@ module(PROJECTS_STATES_CONFIG, [
         label: 'Projects',
       },
     },
-    children: [project],
   };
 
   stateConfigProvider.addToRootState(allProjects);


### PR DESCRIPTION
The projects states are under `home.project.**`, but were also duplicated underneath `home.projects.project.**`.
The second set of states are not used, AFAICT

This is a baby step.  More steps to come, I hope.