### PR TITLE
fix(core): Server group details could not be opened

### DIFF
--- a/app/scripts/modules/amazon/src/loadBalancer/loadBalancer.transformer.ts
+++ b/app/scripts/modules/amazon/src/loadBalancer/loadBalancer.transformer.ts
@@ -83,6 +83,8 @@ export class AwsLoadBalancerTransformer {
     serverGroups.forEach(serverGroup => {
       serverGroup.account = serverGroup.account || container.account;
       serverGroup.region = serverGroup.region || container.region;
+      serverGroup.cloudProvider = serverGroup.cloudProvider || container.cloudProvider;
+
       if (serverGroup.detachedInstances) {
         serverGroup.detachedInstances = (serverGroup.detachedInstances as any).map((instanceId: string) => {
           return { id: instanceId } as IInstance;
@@ -121,8 +123,9 @@ export class AwsLoadBalancerTransformer {
 
       tg.serverGroups = tg.serverGroups.map(serverGroup => {
         const account = accounts.find(x => x.name === serverGroup.account);
-        const cloudProvider = serverGroup.cloudProvider || (account && account.cloudProvider);
+        const cloudProvider = (account && account.cloudProvider) || serverGroup.cloudProvider;
 
+        serverGroup.cloudProvider = cloudProvider;
         serverGroup.instances.forEach(instance => {
           instance.cloudProvider = cloudProvider;
           instance.provider = cloudProvider;


### PR DESCRIPTION
Fixed passing the cloud provider correctly to server groups so their details can render from the load balancer page.

https://github.com/spinnaker/deck/commit/060ad9cc0eed5cf389d2923436f02911a2a25b6a#diff-0051f567bb321bdd6ec4d5e2652f82f1 This introduced a bug where the details of the server groups could not be accessed because they are missing the provider value during state transition. 
This is fixed by passing the cloud provider to the server groups. This will still keep the instance provider intact as it is hydrated with the provider information. 