### PR TITLE
fix(pipeline/deploy): Fixed missing tab by reevaluating scope later

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/deploy/deployExecutionDetails.controller.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/deploy/deployExecutionDetails.controller.js
@@ -37,16 +37,23 @@ module.exports = angular
       return result;
     }
 
-    if ($scope.stage.context) {
-      if (
-        ($scope.stage.context.commits && $scope.stage.context.commits.length > 0) ||
-        !areJarDiffsEmpty($scope.stage.context.jarDiffs)
-      ) {
-        $scope.configSections.push('changes');
+    function evaluateSections() {
+      $scope.configSections = ['deploymentConfig', 'taskStatus', 'artifactStatus'];
+
+      if ($scope.stage.context) {
+        if (
+          ($scope.stage.context.commits && $scope.stage.context.commits.length > 0) ||
+          !areJarDiffsEmpty($scope.stage.context.jarDiffs)
+        ) {
+          $scope.configSections.push('changes');
+        }
       }
     }
 
+    evaluateSections();
+
     let initialized = () => {
+      evaluateSections();
       $scope.detailsSection = $stateParams.details;
 
       var context = $scope.stage.context || {},


### PR DESCRIPTION
Given a pipeline execution with a `Bake` and `Deploy` stage (which has `Changes` to show):

1. Click the `Deploy` stage to show its details, see that the `Changes` section appears
2. Click the `Bake` stage to show its details
3. Click back to the `Deploy` stage to show it's details, the `Changes` section is now missing

The evaluation of whether or not to to display the "changes" tab is happening too early. Works fine if the `Deploy` is the first stage to be detailed, but if we're transitioning from another stage, the evaluation of what sections to display (which I've now refactored into `evaluateSections`) is evaluating while scope still contains the old stage and doesn't get to run after the scope is updated with the new stage.

Adding another evaluation within `initialized` lets it operate on the correct stage.