### PR TITLE
feat(kubernetes): use inline artifact editor for deploy manifest artifact

### DIFF
--- a/app/scripts/modules/core/src/artifact/ExpectedArtifactSelectorViewController.ts
+++ b/app/scripts/modules/core/src/artifact/ExpectedArtifactSelectorViewController.ts
@@ -1,0 +1,65 @@
+import { IExpectedArtifact, IArtifactAccount, IArtifactSource, IArtifactKindConfig } from 'core';
+import { ExpectedArtifactService } from './expectedArtifact.service';
+
+export interface IExpectedArtifactSelectorViewControllerDelegate {
+  getExpectedArtifacts(): IExpectedArtifact[];
+  getSelectedExpectedArtifact(): IExpectedArtifact;
+  getExpectedArtifactAccounts(): IArtifactAccount[];
+  getSelectedAccount(): IArtifactAccount;
+  getExpectedArtifactSources(): Array<IArtifactSource<any>>;
+  getExcludedArtifactTypes(): RegExp[];
+  getSupportedArtifactKinds(): IArtifactKindConfig[];
+  setSelectedExpectedArtifact(e: IExpectedArtifact): void;
+  setSelectedArtifactAccount(a: IArtifactAccount): void;
+  createArtifact(): void;
+  refreshExpectedArtifacts(): void;
+}
+
+export class ExpectedArtifactSelectorViewController {
+  public accountsForArtifact: IArtifactAccount[];
+
+  constructor(private delegate: IExpectedArtifactSelectorViewControllerDelegate) {}
+
+  public updateAccounts = (expectedArtifact: IExpectedArtifact) => {
+    if (expectedArtifact == null) {
+      this.accountsForArtifact = [];
+    } else {
+      const artifact = ExpectedArtifactService.artifactFromExpected(expectedArtifact);
+      const allAccounts = this.delegate.getExpectedArtifactAccounts();
+      this.accountsForArtifact = allAccounts.filter(a => a.types.includes(artifact.type));
+      const selected = this.delegate.getSelectedAccount();
+      if (!selected || !this.accountsForArtifact.find(a => a.name === selected.name)) {
+        if (this.accountsForArtifact.length) {
+          this.delegate.setSelectedArtifactAccount(this.accountsForArtifact[0]);
+        } else {
+          this.delegate.setSelectedArtifactAccount(null);
+        }
+      }
+    }
+  };
+
+  public onArtifactChange = (expectedArtifact: IExpectedArtifact) => {
+    this.delegate.setSelectedExpectedArtifact(expectedArtifact);
+    this.updateAccounts(expectedArtifact);
+  };
+
+  public onArtifactCreated = (event: {
+    expectedArtifact: IExpectedArtifact;
+    account: IArtifactAccount;
+    source: IArtifactSource<any>;
+  }) => {
+    ExpectedArtifactService.addArtifactTo(event.expectedArtifact, event.source.source);
+    this.delegate.refreshExpectedArtifacts();
+    this.updateAccounts(event.expectedArtifact);
+    this.delegate.setSelectedExpectedArtifact(event.expectedArtifact);
+    this.delegate.setSelectedArtifactAccount(event.account);
+  };
+
+  public onRequestCreate = () => {
+    this.delegate.createArtifact();
+  };
+
+  public onAccountChange = (account: IArtifactAccount) => {
+    this.delegate.setSelectedArtifactAccount(account);
+  };
+}

--- a/app/scripts/modules/core/src/artifact/index.ts
+++ b/app/scripts/modules/core/src/artifact/index.ts
@@ -8,3 +8,4 @@ export * from './imageSourceSelector.component';
 export * from './react/ExecutionArtifactTab';
 export * from './react/ArtifactIconList';
 export * from './ArtifactTypes';
+export * from './ExpectedArtifactSelectorViewController';

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestArtifactDelegate.ts
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestArtifactDelegate.ts
@@ -1,0 +1,96 @@
+import { IScope } from 'angular';
+import {
+  ExpectedArtifactService,
+  Registry,
+  IExpectedArtifact,
+  IArtifactAccount,
+  IArtifactKindConfig,
+  IArtifactSource,
+  IExpectedArtifactSelectorViewControllerDelegate,
+  IStage,
+  IPipeline,
+} from '@spinnaker/core';
+
+type ManifestArtifactSource = IArtifactSource<IStage | IPipeline>;
+
+export class DeployManifestArtifactDelegate implements IExpectedArtifactSelectorViewControllerDelegate {
+  private sources: ManifestArtifactSource[];
+  private kinds: IArtifactKindConfig[];
+  private accounts: IArtifactAccount[];
+
+  constructor(private $scope: IScope, private excludedArtifactTypes: RegExp[]) {
+    this.sources = ExpectedArtifactService.sourcesForPipelineStage(this.$scope.$parent.pipeline, this.$scope.stage);
+    this.kinds = Registry.pipeline
+      .getArtifactKinds()
+      .filter(a => a.isMatch)
+      .filter(a => !this.getExcludedArtifactTypes().find(t => t.test(a.type)));
+    this.refreshExpectedArtifacts();
+  }
+
+  public getExcludedArtifactTypes = (): RegExp[] => {
+    return this.excludedArtifactTypes;
+  };
+
+  public getExpectedArtifacts = (): IExpectedArtifact[] => {
+    return ExpectedArtifactService.getExpectedArtifactsAvailableToStage(
+      this.$scope.stage,
+      this.$scope.$parent.pipeline,
+    );
+  };
+
+  public getSelectedExpectedArtifact = (): IExpectedArtifact => {
+    const id = this.$scope.stage.manifestArtifactId;
+    if (id == null) {
+      return null;
+    }
+    return this.getExpectedArtifacts().find(ea => ea.id === id);
+  };
+
+  public getExpectedArtifactAccounts = (): IArtifactAccount[] => {
+    return this.accounts;
+  };
+
+  public getSelectedAccount = (): IArtifactAccount => {
+    const accountName = this.$scope.stage.manifestArtifactAccount;
+    if (accountName == null) {
+      return null;
+    }
+    return this.getExpectedArtifactAccounts().find(a => a.name === accountName);
+  };
+
+  public getExpectedArtifactSources = (): ManifestArtifactSource[] => {
+    return this.sources;
+  };
+
+  public getSupportedArtifactKinds = (): IArtifactKindConfig[] => {
+    return this.kinds;
+  };
+
+  public setAccounts = (accounts: IArtifactAccount[]) => {
+    this.accounts = [...accounts];
+  };
+
+  public setSelectedExpectedArtifact = (expectedArtifact: IExpectedArtifact) => {
+    this.$scope.showCreateArtifactForm = false;
+    this.$scope.stage.manifestArtifactId = expectedArtifact.id;
+    this.$scope.$apply();
+  };
+
+  public setSelectedArtifactAccount(account: IArtifactAccount) {
+    if (account) {
+      this.$scope.stage.manifestArtifactAccount = account.name;
+    } else {
+      this.$scope.stage.manifestArtifactAccount = '';
+    }
+    this.$scope.$apply();
+  }
+
+  public createArtifact() {
+    this.$scope.showCreateArtifactForm = true;
+    this.$scope.$apply();
+  }
+
+  public refreshExpectedArtifacts() {
+    this.$scope.expectedArtifacts = this.getExpectedArtifacts();
+  }
+}

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestConfig.html
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestConfig.html
@@ -25,21 +25,37 @@
     <kubernetes-manifest-entry ng-if="ctrl.$scope.stage.source === ctrl.textSource"
                                command="ctrl.$scope.stage">
     </kubernetes-manifest-entry>
-    <expected-artifact-selector ng-if="ctrl.$scope.stage.source === ctrl.artifactSource"
-                                command="ctrl.$scope.stage"
-                                id="ctrl.$scope.stage.manifestArtifactId"
-                                account="ctrl.$scope.stage.manifestArtifactAccount"
-                                accounts="ctrl.metadata.backingData.artifactAccounts"
-                                expected-artifacts="ctrl.expectedArtifacts"
-                                help-field-key="kubernetes.manifest.expectedArtifact"
-                                excluded-artifact-types="ctrl.excludedManifestArtifactPatterns"
-                                show-icons="true">
-    </expected-artifact-selector>
+    <stage-config-field label="Expected Artifact" help-key="kubernetes.manifest.expectedArtifact" field-columns="8">
+      <expected-artifact-selector-react ng-if="ctrl.$scope.stage.source === ctrl.artifactSource"
+                                  expected-artifacts="ctrl.$scope.expectedArtifacts"
+                                  selected="ctrl.manifestArtifactDelegate.getSelectedExpectedArtifact()"
+                                  on-change="ctrl.manifestArtifactController.onArtifactChange"
+                                  on-request-create="ctrl.manifestArtifactController.onRequestCreate"
+                                  excluded-artifact-types="ctrl.manifestArtifactDelegate.getExcludedArtifactTypes()"
+                                  requesting-new="ctrl.$scope.showCreateArtifactForm"
+                                  >
+      </expected-artifact-selector-react>
+    </stage-config-field>
+    <stage-config-field label="Artifact Account" field-columns="8" ng-if="ctrl.canShowAccountSelect()">
+      <artifact-account-selector-react
+        accounts="ctrl.manifestArtifactController.accountsForArtifact"
+        selected="ctrl.manifestArtifactDelegate.getSelectedAccount()"
+        on-change="ctrl.manifestArtifactController.onAccountChange"
+        >
+      </artifact-account-selector-react>
+    </stage-config-field>
+    <expected-artifact-editor-react ng-if="ctrl.$scope.showCreateArtifactForm"
+                                    kinds="ctrl.manifestArtifactDelegate.getSupportedArtifactKinds()"
+                                    sources="ctrl.manifestArtifactDelegate.getExpectedArtifactSources()"
+                                    accounts="ctrl.manifestArtifactDelegate.getExpectedArtifactAccounts()"
+                                    on-save="ctrl.manifestArtifactController.onArtifactCreated"
+    >
+    </expected-artifact-editor-react>
     <hr>
     <expected-artifact-multi-selector command="ctrl.$scope.stage"
                                       ids-field="requiredArtifactIds"
                                       artifact-label="Req. Artifacts To Bind"
-                                      expected-artifacts="ctrl.expectedArtifacts"
+                                      expected-artifacts="ctrl.$scope.expectedArtifacts"
                                       help-field-key="kubernetes.manifest.requiredArtifactsToBind"
                                       show-icons="true">
     </expected-artifact-multi-selector>


### PR DESCRIPTION
This PR enables a user to define an expected artifact while in-situ on the Deploy Manifest stage configuration screen. This pulls together the previous merges for https://github.com/spinnaker/spinnaker/issues/2921

I'm not particularly happy with the amount of code that's needed for a stage to utilize the inline editor. At the moment adding support to a new stage will involve writing a delegate class that meets the `IExpectedArtifactSelectorViewControllerDelegate` interface. In this PR it's an extra 100 lines of code that's specific to the deploy manifest stage. I'm still looking for ways to reduce this burden but there's no reason to hold back the functionality while I think about that. Suggestions welcome here.