### PR TITLE
fix(pipeline): Fixed missing MPT icon for pipelines with no executions

### DIFF
--- a/app/scripts/modules/core/src/pipeline/filter/executionFilter.service.ts
+++ b/app/scripts/modules/core/src/pipeline/filter/executionFilter.service.ts
@@ -155,6 +155,7 @@ export class ExecutionFilterService {
           config,
           executions: [],
           targetAccounts: this.extractAccounts(config),
+          fromTemplate: (config && config.type === 'templatedPipeline') || false,
         }),
       );
     } else {
@@ -166,6 +167,7 @@ export class ExecutionFilterService {
             config,
             executions: [],
             targetAccounts: this.extractAccounts(config),
+            fromTemplate: (config && config.type === 'templatedPipeline') || false,
           });
         });
     }


### PR DESCRIPTION
Seems like one `fromTemplate` attribute was just forgotten about in `addEmptyPipelines`, which the [ExecutionGroup](https://github.com/alanmquach/deck/blob/master/app/scripts/modules/core/src/pipeline/executions/executionGroup/ExecutionGroup.tsx) component relies on to add the icon for pipelines based on Managed Pipeline Templates.