### PR TITLE
fix(kubernetes): Replace all periods in image name (#5711)

### DIFF
--- a/app/scripts/modules/kubernetes/src/serverGroup/configure/configuration.service.js
+++ b/app/scripts/modules/kubernetes/src/serverGroup/configure/configuration.service.js
@@ -95,7 +95,7 @@ module.exports = angular
         }
 
         return {
-          name: (image.repository || image.name.replace(/[.]/, '-'))
+          name: (image.repository || image.name.replace(/[.]/g, '-'))
             .replace(/_/g, '')
             .replace(/[\/ ]/g, '-')
             .toLowerCase(),


### PR DESCRIPTION
When generating an image name from the registry, we were only replacing the first period, which breaks for registries that have more than one period.