### PR TITLE
refactor(core/application): Begin migration of Application Data Sources to Rx streams

### DIFF
--- a/app/scripts/modules/core/src/application/application.model.spec.ts
+++ b/app/scripts/modules/core/src/application/application.model.spec.ts
@@ -74,11 +74,8 @@ describe('Application Model', function() {
       ApplicationDataSourceRegistry.registerDataSource({
         key: 'lazySource',
         lazy: true,
-        loader: () => {
-          application.getDataSource('lazySource').data = ['a'];
-          return $q.when(null);
-        },
-        onLoad: () => $q.when(null),
+        loader: () => $q.resolve(['a']),
+        onLoad: (_app, data) => $q.resolve(data),
       });
     });
 

--- a/app/scripts/modules/core/src/application/application.model.ts
+++ b/app/scripts/modules/core/src/application/application.model.ts
@@ -2,8 +2,8 @@ import { IPromise, IScope } from 'angular';
 import { map, union, uniq } from 'lodash';
 import { $log, $q } from 'ngimport';
 import { Observable, ReplaySubject, Subject, Subscription } from 'rxjs';
-import { ICluster } from 'core/domain';
 
+import { ICluster } from 'core/domain';
 import { ApplicationDataSource, IDataSourceConfig, IFetchStatus } from './service/applicationDataSource';
 
 export class Application {
@@ -105,14 +105,16 @@ export class Application {
     const FETCHING_STATUS = statuses.some(({ status }) => status === 'FETCHING') ? 'FETCHING' : undefined;
     const FETCHED_STATUS = statuses.some(({ status }) => status === 'FETCHED') ? 'FETCHED' : undefined;
 
-    const rolledUpStatus: IFetchStatus['status'] = ERROR_STATUS || FETCHING_STATUS || FETCHED_STATUS;
+    const rolledUpStatus: IFetchStatus['status'] =
+      ERROR_STATUS || FETCHING_STATUS || FETCHED_STATUS || 'NOT_INITIALIZED';
 
     const allFetched = statuses.every(({ status }) => status === 'FETCHED');
-    const lastFetch = statuses.reduce((latest, status) => Math.max(latest, status.lastFetchTimestamp || 0), 0);
+    const lastFetch = statuses.reduce((latest, status) => Math.max(latest, status.lastRefresh || 0), 0);
 
     return {
       status: rolledUpStatus,
-      lastFetchTimestamp: allFetched ? lastFetch : this.lastRefresh,
+      lastRefresh: allFetched ? lastFetch : this.lastRefresh,
+      data: undefined,
     };
   }
 

--- a/app/scripts/modules/core/src/application/application.model.ts
+++ b/app/scripts/modules/core/src/application/application.model.ts
@@ -1,9 +1,10 @@
-import { ILogService, IPromise, IQService, IScope } from 'angular';
+import { IPromise, IScope } from 'angular';
 import { map, union, uniq } from 'lodash';
-import { Subject, Subscription } from 'rxjs';
+import { $log, $q } from 'ngimport';
+import { Observable, ReplaySubject, Subject, Subscription } from 'rxjs';
+import { ICluster } from 'core/domain';
 
-import { ApplicationDataSource } from './service/applicationDataSource';
-import { ICluster } from '../domain/ICluster';
+import { ApplicationDataSource, IDataSourceConfig, IFetchStatus } from './service/applicationDataSource';
 
 export class Application {
   [k: string]: any;
@@ -80,21 +81,46 @@ export class Application {
    */
   public activeState: ApplicationDataSource = null;
 
-  // Since active state changes don't use $scope, we can just make the Subject public
+  public activeDataSource$ = new ReplaySubject<ApplicationDataSource>(1);
+  /** @deprecated use activeDataSource$ */
   public activeStateChangeStream: Subject<any> = new Subject();
 
   private refreshStream: Subject<any> = new Subject();
-
   private refreshFailureStream: Subject<any> = new Subject();
+
+  // Stream of fetch status
+  public status$: Observable<IFetchStatus>;
 
   private dataLoader: Subscription;
 
-  constructor(
-    private applicationName: string,
-    private scheduler: any,
-    private $q: IQService,
-    private $log: ILogService,
-  ) {}
+  constructor(private applicationName: string, private scheduler: any, dataSourceConfigs: IDataSourceConfig[]) {
+    dataSourceConfigs.forEach(config => this.addDataSource(config));
+    this.status$ = Observable.combineLatest(this.dataSources.map(ds => ds.status$)).map(statuses =>
+      this.getDerivedApplicationStatus(statuses),
+    );
+  }
+
+  private getDerivedApplicationStatus(statuses: IFetchStatus[]): IFetchStatus {
+    const ERROR_STATUS = statuses.some(({ status }) => status === 'ERROR') ? 'ERROR' : undefined;
+    const FETCHING_STATUS = statuses.some(({ status }) => status === 'FETCHING') ? 'FETCHING' : undefined;
+    const FETCHED_STATUS = statuses.some(({ status }) => status === 'FETCHED') ? 'FETCHED' : undefined;
+
+    const rolledUpStatus: IFetchStatus['status'] = ERROR_STATUS || FETCHING_STATUS || FETCHED_STATUS;
+
+    const allFetched = statuses.every(({ status }) => status === 'FETCHED');
+    const lastFetch = statuses.reduce((latest, status) => Math.max(latest, status.lastFetchTimestamp || 0), 0);
+
+    return {
+      status: rolledUpStatus,
+      lastFetchTimestamp: allFetched ? lastFetch : this.lastRefresh,
+    };
+  }
+
+  private addDataSource(config: IDataSourceConfig) {
+    const dataSource = new ApplicationDataSource(config, this);
+    this.dataSources.push(dataSource);
+    this[config.key] = dataSource;
+  }
 
   /**
    * Returns a data source based on its key. Data sources can be accessed on the application directly via the key,
@@ -115,7 +141,7 @@ export class Application {
   public refresh(forceRefresh?: boolean): IPromise<any> {
     // refresh hidden data sources but do not consider their results when determining when the refresh completes
     this.dataSources.filter(ds => !ds.visible).forEach(ds => ds.refresh(forceRefresh));
-    return this.$q
+    return $q
       .all(this.dataSources.filter(ds => ds.visible).map(source => source.refresh(forceRefresh)))
       .then(() => this.applicationLoadSuccess(), error => this.applicationLoadError(error));
   }
@@ -127,7 +153,7 @@ export class Application {
    * not useful - it's only useful to watch the promise itself
    */
   public ready(): IPromise<any> {
-    return this.$q.all(
+    return $q.all(
       this.dataSources.filter(ds => ds.onLoad !== undefined && ds.visible).map(dataSource => dataSource.ready()),
     );
   }
@@ -171,15 +197,16 @@ export class Application {
     this.scheduler.unsubscribe();
   }
 
-  public setActiveState(state: ApplicationDataSource = null): void {
-    if (this.activeState !== state) {
-      this.activeState = state;
+  public setActiveState(dataSource: ApplicationDataSource = null): void {
+    if (this.activeState !== dataSource) {
+      this.activeState = dataSource;
+      this.activeDataSource$.next(dataSource);
       this.activeStateChangeStream.next(null);
     }
   }
 
   private applicationLoadError(err: Error): void {
-    this.$log.error(err, 'Failed to load application, will retry on next scheduler execution.');
+    $log.error(err, 'Failed to load application, will retry on next scheduler execution.');
     this.refreshFailureStream.next(err);
   }
 

--- a/app/scripts/modules/core/src/application/applicationModel.builder.ts
+++ b/app/scripts/modules/core/src/application/applicationModel.builder.ts
@@ -1,5 +1,4 @@
 import { module } from 'angular';
-
 import { ROBOT_TO_HUMAN_FILTER } from 'core/presentation/robotToHumanFilter/robotToHuman.filter';
 import { OVERRIDE_REGISTRY } from 'core/overrideRegistry';
 import { SchedulerFactory } from 'core/scheduler/SchedulerFactory';

--- a/app/scripts/modules/core/src/application/applicationModel.builder.ts
+++ b/app/scripts/modules/core/src/application/applicationModel.builder.ts
@@ -5,39 +5,25 @@ import { OVERRIDE_REGISTRY } from 'core/overrideRegistry';
 import { SchedulerFactory } from 'core/scheduler/SchedulerFactory';
 import { Application } from './application.model';
 
-import { ApplicationDataSource, IDataSourceConfig } from './service/applicationDataSource';
+import { IDataSourceConfig } from './service/applicationDataSource';
 
 export class ApplicationModelBuilder {
-  constructor(private $log: ng.ILogService, private $q: ng.IQService, private $filter: any) {
-    'ngInject';
-  }
-
-  /**
-   * This is mostly used in tests
-   */
+  /** This is mostly used in tests */
   public createApplicationForTests(name: string, ...dataSources: IDataSourceConfig[]): Application {
-    const application = new Application(name, SchedulerFactory.createScheduler(), this.$q, this.$log);
-    dataSources.forEach(ds => this.addDataSource(ds, application));
-    return application;
+    return new Application(name, SchedulerFactory.createScheduler(), dataSources);
   }
 
   public createStandaloneApplication(name: string): Application {
-    const application = new Application(name, SchedulerFactory.createScheduler(), this.$q, this.$log);
+    const application = new Application(name, SchedulerFactory.createScheduler(), []);
     application.isStandalone = true;
     return application;
   }
 
   public createNotFoundApplication(name: string): Application {
-    const application = new Application(name, SchedulerFactory.createScheduler(), this.$q, this.$log);
-    this.addDataSource({ key: 'serverGroups', lazy: true }, application);
+    const config: IDataSourceConfig = { key: 'serverGroups', lazy: true };
+    const application = new Application(name, SchedulerFactory.createScheduler(), [config]);
     application.notFound = true;
     return application;
-  }
-
-  private addDataSource(config: IDataSourceConfig, application: Application): void {
-    const source = new ApplicationDataSource(config, application, this.$q, this.$log, this.$filter);
-    application.dataSources.push(source);
-    application[config.key] = source;
   }
 }
 

--- a/app/scripts/modules/core/src/application/nav/ApplicationRefresher.tsx
+++ b/app/scripts/modules/core/src/application/nav/ApplicationRefresher.tsx
@@ -54,7 +54,7 @@ export class ApplicationRefresher extends React.Component<IApplicationRefresherP
     if (fetchStatus.status === 'FETCHING') {
       this.setState({ refreshing: true });
     } else if (fetchStatus.status === 'FETCHED') {
-      this.setState({ refreshing: false, lastRefresh: fetchStatus.lastFetchTimestamp });
+      this.setState({ refreshing: false, lastRefresh: fetchStatus.lastRefresh });
     } else {
       this.setState({ refreshing: false });
     }

--- a/app/scripts/modules/core/src/application/nav/ApplicationRefresher.tsx
+++ b/app/scripts/modules/core/src/application/nav/ApplicationRefresher.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { Subscription } from 'rxjs';
+import { Observable, Subject } from 'rxjs';
 
-import { Application } from 'core/application';
+import { Application, ApplicationDataSource, IFetchStatus } from 'core/application';
 import { Refresher } from 'core/presentation/refresher/Refresher';
 
 export interface IApplicationRefresherProps {
@@ -14,66 +14,53 @@ export interface IApplicationRefresherState {
 }
 
 export class ApplicationRefresher extends React.Component<IApplicationRefresherProps, IApplicationRefresherState> {
-  private activeStateRefreshUnsubscribe: () => void;
-  private activeStateChangeSubscription: Subscription;
-  private stopListeningToAppRefresh: Function;
+  private app$ = new Subject<Application>();
+  private destroy$ = new Subject();
+
+  public state = {
+    refreshing: false,
+    lastRefresh: 0,
+  };
 
   constructor(props: IApplicationRefresherProps) {
     super(props);
-    this.configureApplicationEventListeners(props.app);
-    this.state = Object.assign(this.parseRefreshState(props));
-  }
 
-  private resetActiveStateRefreshStream(props: IApplicationRefresherProps): void {
-    if (this.activeStateRefreshUnsubscribe) {
-      this.activeStateRefreshUnsubscribe();
-    }
-    const activeState = props.app.activeState || props.app;
-    this.activeStateRefreshUnsubscribe = activeState.onRefresh(null, () => {
-      this.setState(this.parseRefreshState(props));
-    });
+    this.app$
+      .filter(app => !!app)
+      .distinctUntilChanged()
+      // follow the data source from the active tab
+      .switchMap(app => app.activeDataSource$)
+      .startWith(null)
+      .mergeMap((dataSource: ApplicationDataSource) => {
+        // If there is no active data source (e.g., on config tab), use the application's status.
+        const fetchStatus$: Observable<IFetchStatus> = (dataSource && dataSource.status$) || props.app.status$;
+        return fetchStatus$.filter(fetchStatus => ['FETCHING', 'FETCHED', 'ERROR'].includes(fetchStatus.status));
+      })
+      .takeUntil(this.destroy$)
+      .subscribe(fetchStatus => this.update(fetchStatus));
+
+    this.app$.next(props.app);
   }
 
   public componentWillReceiveProps(nextProps: IApplicationRefresherProps) {
-    this.configureApplicationEventListeners(nextProps.app);
+    this.app$.next(nextProps.app);
   }
 
-  private configureApplicationEventListeners(app: Application): void {
-    app.ready().then(() => this.setState(this.parseRefreshState(this.props)));
-    this.clearApplicationListeners();
-    this.activeStateChangeSubscription = app.activeStateChangeStream.subscribe(() => {
-      this.resetActiveStateRefreshStream(this.props);
-      this.setState(this.parseRefreshState(this.props));
-    });
-    this.stopListeningToAppRefresh = app.onRefresh(null, () => {
-      this.setState(this.parseRefreshState(this.props));
-    });
+  public componentWillUnmount() {
+    this.destroy$.next();
   }
 
-  private clearApplicationListeners(): void {
-    if (this.activeStateChangeSubscription) {
-      this.activeStateChangeSubscription.unsubscribe();
-    }
-    if (this.stopListeningToAppRefresh) {
-      this.stopListeningToAppRefresh();
+  private update(fetchStatus: IFetchStatus): void {
+    if (fetchStatus.status === 'FETCHING') {
+      this.setState({ refreshing: true });
+    } else if (fetchStatus.status === 'FETCHED') {
+      this.setState({ refreshing: false, lastRefresh: fetchStatus.lastFetchTimestamp });
+    } else {
+      this.setState({ refreshing: false });
     }
   }
 
-  private parseRefreshState(props: IApplicationRefresherProps): IApplicationRefresherState {
-    const activeState = props.app.activeState || props.app;
-    return {
-      lastRefresh: activeState.lastRefresh,
-      refreshing: activeState.loading,
-    };
-  }
-
-  public componentWillUnmount(): void {
-    this.clearApplicationListeners();
-  }
-
-  public handleRefresh = (): void => {
-    // Force set refreshing to true since we are forcing the refresh
-    this.setState({ refreshing: true });
+  private handleRefresh = (): void => {
     this.props.app.refresh(true);
   };
 

--- a/app/scripts/modules/core/src/application/service/applicationDataSource.ts
+++ b/app/scripts/modules/core/src/application/service/applicationDataSource.ts
@@ -1,13 +1,13 @@
 import { IPromise, IScope } from 'angular';
+import { get } from 'lodash';
+import { $log, $q } from 'ngimport';
+import { BehaviorSubject, Observable, Subject } from 'rxjs';
 
 import { IEntityTags } from 'core/domain';
 import { robotToHuman } from 'core/presentation';
 import { ReactInjector } from 'core/reactShims';
 import { FirewallLabels } from 'core/securityGroup';
 import { toIPromise } from 'core/utils';
-import { get } from 'lodash';
-import { $log, $q } from 'ngimport';
-import { BehaviorSubject, Observable, Subject } from 'rxjs';
 
 import { Application } from '../application.model';
 

--- a/app/scripts/modules/core/src/application/service/applicationDataSource.ts
+++ b/app/scripts/modules/core/src/application/service/applicationDataSource.ts
@@ -1,19 +1,21 @@
-import { IDeferred, IPromise, IScope } from 'angular';
-import { $q, $log } from 'ngimport';
-import { get } from 'lodash';
-import { BehaviorSubject, Observable, Subject } from 'rxjs';
+import { IPromise, IScope } from 'angular';
 
 import { IEntityTags } from 'core/domain';
 import { robotToHuman } from 'core/presentation';
 import { ReactInjector } from 'core/reactShims';
 import { FirewallLabels } from 'core/securityGroup';
+import { toIPromise } from 'core/utils';
+import { get } from 'lodash';
+import { $log, $q } from 'ngimport';
+import { BehaviorSubject, Observable, Subject } from 'rxjs';
 
 import { Application } from '../application.model';
 
 export interface IFetchStatus {
   status: 'NOT_INITIALIZED' | 'FETCHING' | 'FETCHED' | 'ERROR';
   error?: any;
-  lastFetchTimestamp?: number;
+  lastRefresh: number;
+  data: any;
 }
 
 export interface IDataSourceConfig {
@@ -252,60 +254,75 @@ export class ApplicationDataSource implements IDataSourceConfig {
 
   /**
    * A timestamp indicating the last time the data source was successfully refreshed
+   * @deprecated use the streams
    */
   public lastRefresh: number;
 
-  public refresh$: Subject<void> = new Subject();
-  public refreshFailure$: Subject<any> = new Subject();
+  /** This subject is used to cancel the internal subscription */
+  private destroy$ = new Subject<void>();
+
+  /** This subject is used to trigger a new fetch */
+  private fetchRequest$ = new Subject<void>();
 
   /**
-   * Simple counter used to track the most recent refresh call to avoid data stomping
-   * when multiple force refresh calls occur
-   * (will go away when we switch from Promises to Observables)
+   * Stream of IFetchStatus.
+   * Updated when the status and/or data changes.
+   * Starts with NOT_INITIALIZED
    */
-  private currentLoadCall = 0;
+  public status$ = new BehaviorSubject<IFetchStatus>({
+    status: 'NOT_INITIALIZED',
+    lastRefresh: 0,
+    error: null,
+    data: this.data,
+  });
+
+  /** BehaviorSubject of data changes, starts by emitting the current value */
+  public data$ = new BehaviorSubject<any>(this.data);
 
   /**
-   * Dumb queue to fire when the most recent refresh call finishes
-   * (will go away when we switch from Promises to Observables)
+   * Stream of data changes
+   * @deprecated use data$.skip(1) instead
    */
-  private refreshQueue: Array<IDeferred<void>> = [];
+  public refresh$: Observable<any> = this.data$.skip(1);
 
-  public data$ = new BehaviorSubject<any>(null);
+  /** Stream of failed IFetchStatus */
+  private refreshFailure$ = this.status$.skip(1).filter(({ status }) => status === 'ERROR');
 
-  // Stream of fetch status
-  public status$ = new BehaviorSubject<IFetchStatus>({ status: 'NOT_INITIALIZED' });
-
-  // Stream of fetch failures
-  private failures$ = this.status$
-    .skip(1)
-    .filter(({ status }) => status === 'ERROR')
-    .map(({ error }) => error);
-
-  // Stream that throws fetch failures.
-  // Any failure will throw and complete this stream with the error
-  private throwFailures$ = this.failures$.map(error => {
+  /** Stream that throws fetch failures. */
+  private throwFailures$ = this.refreshFailure$.map(({ error }) => {
     throw error;
   });
+
+  /** A stream that either emits the next data change, or throws */
+  private nextRefresh$ = Observable.merge(this.data$.skip(1), this.throwFailures$).take(1);
 
   /**
    * Called when a method mutates some item in the data source's data, e.g. when a running execution is updated
    * independent of the execution data source's refresh cycle
    */
-  public dataUpdated(): void {
+  public dataUpdated(data?: any | undefined): void {
     if (this.loaded) {
-      this.data$.next(this.data);
-      this.refresh$.next(null);
+      this.updateData(data !== undefined ? data : this.data);
     }
+  }
+
+  /** Applies status and status flags */
+  private statusUpdated(fetchStatus: IFetchStatus) {
+    const { status } = fetchStatus;
+
+    this.status = fetchStatus;
+    this.loaded = status === 'FETCHED' || this.loaded;
+    this.loading = status === 'FETCHING';
+    this.loadFailure = status === 'ERROR';
+    this.lastRefresh = fetchStatus.lastRefresh;
+
+    this.debug(`status: ${fetchStatus.status}`);
   }
 
   constructor(config: IDataSourceConfig, private application: Application) {
     Object.assign(this, config);
 
-    if (!config.label) {
-      this.label = robotToHuman(config.key);
-    }
-    this.label = FirewallLabels.get(this.label);
+    this.label = FirewallLabels.get(config.label || robotToHuman(config.key));
 
     if (!config.activeState && this.sref) {
       this.activeState = '**' + this.sref + '.**';
@@ -315,6 +332,39 @@ export class ApplicationDataSource implements IDataSourceConfig {
       ReactInjector.$uiRouter.transitionService.onSuccess({ entering: this.activeState }, () => this.activate());
       ReactInjector.$uiRouter.transitionService.onSuccess({ exiting: this.activeState }, () => this.deactivate());
     }
+
+    const fetchStream$ = this.fetchRequest$
+      .do(() => this.debug('fetch requested...'))
+      .switchMap(() => {
+        return Observable.fromPromise(this.loader(this.application))
+          .mergeMap(data => this.onLoad(this.application, data))
+          .map(data => ({ status: 'FETCHED', lastRefresh: Date.now(), data }))
+          .catch(error => Observable.of({ status: 'ERROR', lastRefresh: this.lastRefresh, data: this.data, error }))
+          .startWith({ status: 'FETCHING', lastRefresh: this.lastRefresh, data: this.data });
+      })
+      .startWith(this.status$.value)
+      .takeUntil(this.destroy$) as Observable<IFetchStatus>;
+
+    // Some data sources expect other data sources to exist on the application
+    // Wait one tick before processing the stream so all data sources are registered
+    const nextTick$ = Observable.fromPromise($q.resolve());
+
+    fetchStream$.withLatestFrom(nextTick$).subscribe(([fetchStatus, _void]) => {
+      // Update mutable flags
+      this.statusUpdated(fetchStatus);
+
+      if (fetchStatus.status === 'FETCHED') {
+        this.updateData(fetchStatus.data);
+        this.afterLoad && this.afterLoad(this.application);
+        this.addAlerts();
+      }
+
+      this.status$.next(fetchStatus);
+    });
+  }
+
+  public destroy() {
+    this.destroy$.next();
   }
 
   /**
@@ -323,13 +373,11 @@ export class ApplicationDataSource implements IDataSourceConfig {
    * @param $scope the controller scope of the calling method. If the $scope is destroyed, the subscription is disposed.
    *        If you pass in null for the $scope, you are responsible for unsubscribing when your component unmounts.
    * @param callback the method to call the next time the data source refreshes
-   * @param failureMethod (optional) a method to call if the data source refresh fails
+   * @param onError (optional) a method to call if the data source refresh fails
    * @return a method to call to unsubscribe
    */
-  public onNextRefresh($scope: IScope, callback: any, failureMethod?: any): () => void {
-    const subscription = Observable.merge(this.data$.skip(1), this.throwFailures$)
-      .take(1)
-      .subscribe(data => callback(data), error => failureMethod && failureMethod(error));
+  public onNextRefresh($scope: IScope, callback: (data?: any) => void, onError?: (err?: any) => void): () => void {
+    const subscription = this.nextRefresh$.subscribe(data => callback(data), error => onError && onError(error));
 
     $scope && $scope.$on('$destroy', () => subscription.unsubscribe());
     return () => subscription.unsubscribe();
@@ -342,12 +390,12 @@ export class ApplicationDataSource implements IDataSourceConfig {
    * @param $scope the controller scope of the calling method. If the $scope is destroyed, the subscription is disposed.
    *        If you pass in null for the $scope, you are responsible for unsubscribing when your component unmounts.
    * @param callback the method to call the next time the data source refreshes
-   * @param failureMethod (optional) a method to call if the data source refresh fails
+   * @param onError (optional) a method to call if the data source refresh fails
    * @return a method to call to unsubscribe
    */
-  public onRefresh($scope: IScope, callback: any, failureMethod?: any): () => void {
-    const failures$ = this.failures$.mergeMap(error => {
-      failureMethod && failureMethod(error);
+  public onRefresh($scope: IScope, callback: (data?: any) => void, onError?: (err?: any) => void): () => void {
+    const failures$ = this.refreshFailure$.mergeMap(({ error }) => {
+      onError && onError(error);
       return Observable.empty();
     });
 
@@ -369,17 +417,24 @@ export class ApplicationDataSource implements IDataSourceConfig {
    *
    * @returns {IPromise<T>}
    */
-  public ready(): IPromise<void> {
+  public ready(): IPromise<any> {
     if (this.disabled || this.loaded || (this.lazy && !this.active)) {
-      return $q.resolve();
+      return $q.resolve(this.data);
     }
 
-    const readyPromise = Observable.merge(this.data$.filter(data => !!data), this.throwFailures$)
-      .take(1)
-      .toPromise();
+    return toIPromise(this.nextRefresh$);
+  }
 
-    // normalize as IPromise
-    return $q.resolve(readyPromise);
+  /**
+   * Sets the "active" flag to true and, if the data source has not been loaded, immediately calls "refresh()"
+   */
+  public activate(): void {
+    if (!this.active) {
+      this.active = true;
+      if (!this.loaded) {
+        this.refresh();
+      }
+    }
   }
 
   /**
@@ -387,6 +442,12 @@ export class ApplicationDataSource implements IDataSourceConfig {
    */
   public deactivate(): void {
     this.active = false;
+  }
+
+  private updateData(data: any) {
+    this.data = data || [];
+    this.data$.next(this.data);
+    this.debug(`this.data = ${JSON.stringify(this.data)}`);
   }
 
   /**
@@ -405,82 +466,23 @@ export class ApplicationDataSource implements IDataSourceConfig {
    * @param forceRefresh
    * @returns {any}
    */
-  public refresh(forceRefresh?: boolean): IPromise<void> {
-    const deferred = $q.defer<void>();
-    this.refreshQueue.push(deferred);
-    if (!this.loader || this.disabled) {
-      this.data.length = 0;
-      this.loading = false;
-      this.loaded = true;
-      return $q.when(null);
-    }
-    if (this.lazy && !this.active) {
-      this.data.length = 0;
+  public refresh(forceRefresh?: boolean): IPromise<any> {
+    this.debug(`refresh(${forceRefresh})`);
+    if (!this.loader || this.disabled || (this.lazy && !this.active)) {
       this.loaded = false;
-      return $q.when(null);
+      this.updateData([]);
+      return $q.resolve(this.data);
     }
+
+    const promise = toIPromise(this.data$.skip(1).take(1));
+
     if (this.loading && !forceRefresh) {
       $log.info(`${this.key} still loading, skipping refresh`);
-      return $q.when(null);
+    } else {
+      this.fetchRequest$.next();
     }
 
-    this.status$.next({ status: 'FETCHING' });
-    this.loading = true;
-
-    this.currentLoadCall += 1;
-    const loadCall = this.currentLoadCall;
-    this.loader(this.application)
-      .then(result => {
-        if (loadCall < this.currentLoadCall) {
-          // discard, more recent call has come in
-          // TODO: this will all be cleaner with Observables
-          $log.debug(`Discarding load #${loadCall} for ${this.key} - current is #${this.currentLoadCall}`);
-          return;
-        }
-        this.onLoad(this.application, result).then(data => {
-          if (data) {
-            this.data = data;
-            this.data$.next(data);
-          }
-          this.loaded = true;
-          this.loading = false;
-          this.loadFailure = false;
-          this.lastRefresh = Date.now();
-          this.status$.next({ status: 'FETCHED', lastFetchTimestamp: this.lastRefresh });
-          if (this.afterLoad) {
-            this.afterLoad(this.application);
-          }
-          this.addAlerts();
-          this.dataUpdated();
-        });
-        this.refreshQueue.forEach(d => d.resolve());
-        this.refreshQueue.length = 0;
-      })
-      .catch(rejection => {
-        if (loadCall === this.currentLoadCall) {
-          this.status$.next({ status: 'ERROR', error: rejection });
-          $log.warn(`Error retrieving ${this.key}`, rejection);
-          this.loading = false;
-          this.loadFailure = true;
-          this.refreshFailure$.next(rejection);
-          // resolve, don't reject - the refreshFailureStream and loadFailure flags signal the rejection
-          this.refreshQueue.forEach(d => d.resolve(rejection));
-          this.refreshQueue.length = 0;
-        }
-      });
-    return deferred.promise;
-  }
-
-  /**
-   * Sets the "active" flag to true and, if the data source has not been loaded, immediately calls "refresh()"
-   */
-  public activate(): void {
-    if (!this.active) {
-      this.active = true;
-      if (!this.loaded) {
-        this.refresh();
-      }
-    }
+    return promise;
   }
 
   private addAlerts(): void {
@@ -490,5 +492,10 @@ export class ApplicationDataSource implements IDataSourceConfig {
         .filter((d: any) => get(d, 'entityTags.alerts.length', 0))
         .map((d: any) => d['entityTags'] as IEntityTags);
     }
+  }
+
+  private debug(_message: string) {
+    // tslint:disable-next-line
+    // console.log(`DEBUG ${this.application.name}.${this.key}: ${_message}`);
   }
 }

--- a/app/scripts/modules/core/src/pipeline/config/actions/delete/deletePipelineModal.controller.spec.js
+++ b/app/scripts/modules/core/src/pipeline/config/actions/delete/deletePipelineModal.controller.spec.js
@@ -7,12 +7,13 @@ describe('Controller: deletePipelineModal', function() {
   beforeEach(window.module(require('./delete.module.js').name, APPLICATION_MODEL_BUILDER));
   beforeEach(
     window.inject(function($controller, $rootScope, $log, $q, $state, applicationModelBuilder) {
+      this.$rootScope = $rootScope;
       this.$q = $q;
       this.application = applicationModelBuilder.createApplicationForTests('app', {
         key: 'pipelineConfigs',
         lazy: true,
-        loader: () => this.$q.when(null),
-        onLoad: () => this.$q.when(null),
+        loader: () => this.$q.when(this.application.pipelineConfigs.data),
+        onLoad: (_app, data) => this.$q.when(data),
       });
       this.initializeController = function(pipeline) {
         this.$state = $state;
@@ -40,6 +41,8 @@ describe('Controller: deletePipelineModal', function() {
       ];
 
       this.application.pipelineConfigs.activate();
+      this.$rootScope.$digest();
+
       this.application.pipelineConfigs.data = [this.pipelines[0], this.pipelines[1], this.pipelines[2]];
       this.initializeController(this.pipelines[1]);
     });

--- a/app/scripts/modules/core/src/pipeline/config/actions/rename/renamePipelineModal.controller.spec.js
+++ b/app/scripts/modules/core/src/pipeline/config/actions/rename/renamePipelineModal.controller.spec.js
@@ -9,11 +9,12 @@ describe('Controller: renamePipelineModal', function() {
   beforeEach(
     window.inject(function($controller, $rootScope, $log, $q, applicationModelBuilder) {
       this.$q = $q;
+      this.$rootScope = $rootScope;
       this.application = applicationModelBuilder.createApplicationForTests('app', {
         key: 'pipelineConfigs',
         lazy: true,
-        loader: () => this.$q.when(null),
-        onLoad: () => this.$q.when(null),
+        loader: () => this.$q.when(this.application.pipelineConfigs.data),
+        onLoad: (_app, data) => this.$q.when(data),
       });
       this.initializeController = function(pipeline) {
         this.$scope = $rootScope.$new();
@@ -34,6 +35,7 @@ describe('Controller: renamePipelineModal', function() {
     this.pipelines = [{ name: 'a' }, { name: 'b' }, { name: 'c' }];
 
     this.application.pipelineConfigs.activate();
+    this.$rootScope.$digest();
     this.application.pipelineConfigs.data = [this.pipelines[0], this.pipelines[1], this.pipelines[2]];
     this.initializeController(this.pipelines[1]);
   });

--- a/app/scripts/modules/core/src/pipeline/create/CreatePipelineModal.spec.tsx
+++ b/app/scripts/modules/core/src/pipeline/create/CreatePipelineModal.spec.tsx
@@ -31,14 +31,14 @@ xdescribe('CreatePipelineModal', () => {
           {
             key: 'pipelineConfigs',
             lazy: true,
-            loader: () => $q.when(null),
-            onLoad: () => $q.when(null),
+            loader: () => $q.resolve(application.pipelineConfigs.data),
+            onLoad: (_app, data) => $q.resolve(data),
           },
           {
             key: 'strategyConfigs',
             lazy: true,
-            loader: () => $q.when(null),
-            onLoad: () => $q.when(null),
+            loader: () => $q.resolve(application.strategyConfigs.data),
+            onLoad: (_app, data) => $q.resolve(data),
           },
         );
         application.pipelineConfigs.data = configs;

--- a/app/scripts/modules/core/src/task/task.dataSource.spec.ts
+++ b/app/scripts/modules/core/src/task/task.dataSource.spec.ts
@@ -45,7 +45,7 @@ describe('Task Data Source', function() {
     });
 
     it('sets appropriate flags when task load fails', function() {
-      spyOn(TaskReader, 'getTasks').and.returnValue($q.reject(null));
+      spyOn(TaskReader, 'getTasks').and.callFake(() => $q.reject(null));
       configureApplication();
       expect(application.getDataSource('tasks').loaded).toBe(false);
       expect(application.getDataSource('tasks').loading).toBe(false);
@@ -79,7 +79,7 @@ describe('Task Data Source', function() {
     });
 
     it('sets appropriate flags when task reload fails; subscriber is responsible for error checking', function() {
-      spyOn(TaskReader, 'getTasks').and.returnValue($q.reject(null));
+      spyOn(TaskReader, 'getTasks').and.callFake(() => $q.reject(null));
       let errorsHandled = 0,
         successesHandled = 0;
       configureApplication();

--- a/app/scripts/modules/core/src/utils/index.ts
+++ b/app/scripts/modules/core/src/utils/index.ts
@@ -1,9 +1,9 @@
 ///<reference path="./classnames.d.ts" />
-///<reference path="./q.d.ts" />
 
 export * from './debug';
 export * from './json/JsonUtils';
 export * from './noop';
+export * from './q';
 export * from './scrollTo/scrollTo.service';
 export * from './timeFormatters';
 export * from './uuid.service';

--- a/app/scripts/modules/core/src/utils/q.ts
+++ b/app/scripts/modules/core/src/utils/q.ts
@@ -1,0 +1,12 @@
+///<reference path="./q.d.ts" />
+
+import { IPromise } from 'angular';
+import { $q } from 'ngimport';
+import { Observable } from 'rxjs';
+
+export function toIPromise<T>(source: Observable<T>): IPromise<T> {
+  return $q((resolve, reject) => {
+    let value: any;
+    source.subscribe((x: T) => (value = x), (err: any) => reject(err), () => resolve(value));
+  });
+}

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -67,7 +67,6 @@ module.exports = function(config) {
     // possible values: LOG_DISABLE || LOG_ERROR || LOG_WARN || LOG_INFO || LOG_DEBUG
     logLevel: config.DEBUG,
 
-    // jUnit Report output
     reporters: ['super-dots', 'mocha'],
     mochaReporter: {
       output: 'minimal',


### PR DESCRIPTION
## applicationDataSource:

- Add two streams: one for raw `data$` and one for fetch `status$`
- Refactor onRefresh and onNextRefresh to use the streams
- use `nginject`

In some future refactor, I intend to replace the promise based refresh() method and nuke the mutable status flags (`loading`/`loaded`/etc).

## ApplicationReader and applicationModel.builder:

- Removed addDataSources (moved to Application constructor)

## application.model:

- Derive application fetch `status$` stream from individual DataSource `status$` streams
- Require Data Source configs earlier (as a constructor parameter) for more predicable lifecycle

## ApplicationRefresher

- Utilize new streams api