### PR TITLE
fix(kubernetes): hide expected artifact label when manifest source is text

### DIFF
--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestConfig.html
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestConfig.html
@@ -25,8 +25,8 @@
     <kubernetes-manifest-entry ng-if="ctrl.$scope.stage.source === ctrl.textSource"
                                command="ctrl.$scope.stage">
     </kubernetes-manifest-entry>
-    <stage-config-field label="Expected Artifact" help-key="kubernetes.manifest.expectedArtifact" field-columns="8">
-      <expected-artifact-selector-react ng-if="ctrl.$scope.stage.source === ctrl.artifactSource"
+    <stage-config-field label="Expected Artifact" help-key="kubernetes.manifest.expectedArtifact" field-columns="8" ng-if="ctrl.$scope.stage.source === ctrl.artifactSource">
+      <expected-artifact-selector-react
                                   expected-artifacts="ctrl.$scope.expectedArtifacts"
                                   selected="ctrl.manifestArtifactDelegate.getSelectedExpectedArtifact()"
                                   on-change="ctrl.manifestArtifactController.onArtifactChange"

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/patchManifest/patchManifestConfig.html
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/patchManifest/patchManifestConfig.html
@@ -31,8 +31,8 @@
       on-change="ctrl.handleYamlChange"
       value="stage.patchBody">
     </yaml-editor>
-    <stage-config-field label="Expected Artifact" help-key="kubernetes.manifest.expectedArtifact" field-columns="8">
-      <expected-artifact-selector-react ng-if="ctrl.$scope.stage.source === ctrl.artifactSource"
+    <stage-config-field label="Expected Artifact" help-key="kubernetes.manifest.expectedArtifact" field-columns="8" ng-if="ctrl.$scope.stage.source === ctrl.artifactSource">
+      <expected-artifact-selector-react
                                   expected-artifacts="ctrl.$scope.expectedArtifacts"
                                   selected="ctrl.manifestArtifactDelegate.getSelectedExpectedArtifact()"
                                   on-change="ctrl.manifestArtifactController.onArtifactChange"


### PR DESCRIPTION
Before:

An errant "Expected Artifacts" label would appear beneath the YAML editor.

<img width="285" alt="screen shot 2018-09-10 at 12 48 59 pm" src="https://user-images.githubusercontent.com/34253460/45311725-f9764680-b4f7-11e8-97c2-7243545f314b.png">

After:

The label no longer appears.