### PR TITLE
test(openstack): Fix some openstack load balancer update tests

### DIFF
--- a/app/scripts/modules/openstack/src/loadBalancer/configure/wizard/upsert.controller.js
+++ b/app/scripts/modules/openstack/src/loadBalancer/configure/wizard/upsert.controller.js
@@ -122,7 +122,7 @@ module.exports = angular
     }
 
     function updateLoadBalancerNames() {
-      var account = $scope.loadBalancer.credentials;
+      var account = $scope.loadBalancer.credentials || $scope.loadBalancer.account;
 
       const accountLoadBalancersByRegion = {};
       application

--- a/app/scripts/modules/openstack/src/loadBalancer/configure/wizard/upsert.controller.spec.js
+++ b/app/scripts/modules/openstack/src/loadBalancer/configure/wizard/upsert.controller.spec.js
@@ -105,7 +105,8 @@ describe('Controller: openstackCreateLoadBalancerCtrl', function() {
       this.mockApplication = applicationModelBuilder.createApplication('app', {
         key: 'loadBalancers',
         lazy: false,
-        data: this.testData.loadBalancerList,
+        loader: () => $q.resolve(_.clone(this.testData.loadBalancerList)),
+        onLoad: (_app, data) => $q.resolve(data),
       });
       spyOn(this.mockApplication.loadBalancers, 'refresh').and.callThrough();
       this.mockApplication.loadBalancers.onNextRefresh = jasmine
@@ -233,6 +234,7 @@ describe('Controller: openstackCreateLoadBalancerCtrl', function() {
             beforeEach(function() {
               this.$scope.loadBalancer.account = 'account2';
               this.ctrl.accountUpdated();
+              this.$scope.$digest();
             });
 
             it('- updates the list of load balancer names', function() {


### PR DESCRIPTION
These tests were passing the test data to the service and the service was mutating the data.
Because of this, the expect calls were always true (the test wouldn't fail no matter what data you tested against)