### PR TITLE
feat(google): add inline artifact editor to google deploy stage

### DIFF
--- a/app/scripts/modules/core/src/artifact/ArtifactTypes.ts
+++ b/app/scripts/modules/core/src/artifact/ArtifactTypes.ts
@@ -5,6 +5,7 @@ export const ArtifactTypePatterns = {
   GCS_OBJECT: /gcs\/object/,
   GITHUB_FILE: /github\/file/,
   GITLAB_FILE: /gitlab\/file/,
+  GCE_MACHINE_IMAGE: /gce\/image/,
   KUBERNETES: /kubernetes\/.*/,
   S3_OBJECT: /s3\/object/,
 };

--- a/app/scripts/modules/core/src/artifact/ExpectedArtifactSelectorViewController.ts
+++ b/app/scripts/modules/core/src/artifact/ExpectedArtifactSelectorViewController.ts
@@ -7,7 +7,8 @@ export interface IExpectedArtifactSelectorViewControllerDelegate {
   getExpectedArtifactAccounts(): IArtifactAccount[];
   getSelectedAccount(): IArtifactAccount;
   getExpectedArtifactSources(): Array<IArtifactSource<any>>;
-  getExcludedArtifactTypes(): RegExp[];
+  getOfferedArtifactTypes?(): RegExp[];
+  getExcludedArtifactTypes?(): RegExp[];
   getSupportedArtifactKinds(): IArtifactKindConfig[];
   setSelectedExpectedArtifact(e: IExpectedArtifact): void;
   setSelectedArtifactAccount(a: IArtifactAccount): void;

--- a/app/scripts/modules/core/src/artifact/NgGCEImageArtifactDelegate.ts
+++ b/app/scripts/modules/core/src/artifact/NgGCEImageArtifactDelegate.ts
@@ -1,0 +1,81 @@
+import { IScope } from 'angular';
+import {
+  ExpectedArtifactService,
+  Registry,
+  IExpectedArtifact,
+  IArtifactAccount,
+  IArtifactKindConfig,
+  IArtifactSource,
+  IExpectedArtifactSelectorViewControllerDelegate,
+  IStage,
+  IPipeline,
+} from 'core';
+import { ArtifactTypePatterns } from './ArtifactTypes';
+
+type GCEImageArtifactSource = IArtifactSource<IStage | IPipeline>;
+
+const offeredArtifactTypes: RegExp[] = [ArtifactTypePatterns.GCE_MACHINE_IMAGE];
+
+export class NgGCEImageArtifactDelegate implements IExpectedArtifactSelectorViewControllerDelegate {
+  private sources: GCEImageArtifactSource[] = [];
+  // TODO(sbws): Add UI components for a gce/image expected artifact kind, currently user must define custom.
+  private kinds: IArtifactKindConfig[] = Registry.pipeline
+    .getArtifactKinds()
+    .filter((a: IArtifactKindConfig) => a.key === 'custom');
+  // This is always empty for GCE images.
+  private accounts: IArtifactAccount[] = [];
+
+  constructor(private $scope: IScope) {
+    const { viewState } = $scope.command;
+    this.sources = ExpectedArtifactService.sourcesForPipelineStage(viewState.pipeline, viewState.stage);
+    this.refreshExpectedArtifacts();
+  }
+
+  public getExpectedArtifacts(): IExpectedArtifact[] {
+    const { viewState } = this.$scope.command;
+    return ExpectedArtifactService.getExpectedArtifactsAvailableToStage(viewState.stage, viewState.pipeline);
+  }
+
+  public getSelectedExpectedArtifact(): IExpectedArtifact {
+    return (this.getExpectedArtifacts() || []).find(ea => ea.id === this.$scope.command.imageArtifactId);
+  }
+
+  public getExpectedArtifactAccounts(): IArtifactAccount[] {
+    return this.accounts;
+  }
+
+  public getSelectedAccount(): IArtifactAccount {
+    return null;
+  }
+
+  public getExpectedArtifactSources(): Array<IArtifactSource<any>> {
+    return this.sources;
+  }
+
+  public getOfferedArtifactTypes(): RegExp[] {
+    return offeredArtifactTypes;
+  }
+
+  public getSupportedArtifactKinds(): IArtifactKindConfig[] {
+    return this.kinds;
+  }
+
+  public setSelectedExpectedArtifact(e: IExpectedArtifact): void {
+    this.$scope.command.imageArtifactId = e.id;
+    this.$scope.gceImageArtifact.showCreateArtifactForm = false;
+    this.$scope.$apply();
+  }
+
+  public setSelectedArtifactAccount(_a: IArtifactAccount): void {
+    return;
+  }
+
+  public createArtifact(): void {
+    this.$scope.gceImageArtifact.showCreateArtifactForm = true;
+    this.$scope.$apply();
+  }
+
+  public refreshExpectedArtifacts(): void {
+    this.$scope.command.viewState.expectedArtifacts = this.getExpectedArtifacts();
+  }
+}

--- a/app/scripts/modules/core/src/artifact/index.ts
+++ b/app/scripts/modules/core/src/artifact/index.ts
@@ -10,3 +10,4 @@ export * from './react/ArtifactIconList';
 export * from './ArtifactTypes';
 export * from './ExpectedArtifactSelectorViewController';
 export * from './NgManifestArtifactDelegate';
+export * from './NgGCEImageArtifactDelegate';

--- a/app/scripts/modules/core/src/artifact/react/ExpectedArtifactEditor.tsx
+++ b/app/scripts/modules/core/src/artifact/react/ExpectedArtifactEditor.tsx
@@ -22,7 +22,8 @@ export interface IExpectedArtifactEditorProps {
   sources: IExpectedArtifactSourceOption[];
   accounts: IArtifactAccount[];
   onSave: (e: IExpectedArtifactEditorSaveEvent) => void;
-  showIcons: boolean;
+  showIcons?: boolean;
+  showAccounts?: boolean;
   className?: string;
 }
 
@@ -42,6 +43,11 @@ export class ExpectedArtifactEditor extends React.Component<
   IExpectedArtifactEditorProps,
   IExpectedArtifactEditorState
 > {
+  public static defaultProps = {
+    showIcons: true,
+    showAccounts: true,
+  };
+
   constructor(props: IExpectedArtifactEditorProps) {
     super(props);
     this.state = {
@@ -61,7 +67,7 @@ export class ExpectedArtifactEditor extends React.Component<
 
   private accountsForExpectedArtifact(expectedArtifact: IExpectedArtifact): IArtifactAccount[] {
     const artifact = ExpectedArtifactService.artifactFromExpected(expectedArtifact);
-    if (!artifact) {
+    if (!artifact || !this.props.accounts) {
       return [];
     }
     return this.props.accounts.filter(a => a.types.includes(artifact.type));
@@ -94,12 +100,13 @@ export class ExpectedArtifactEditor extends React.Component<
   };
 
   private availableKinds = () => {
-    const { kinds, accounts } = this.props;
+    const kinds = this.props.kinds || [];
+    const accounts = this.props.accounts || [];
     return kinds.filter(k => k.key === 'custom' || accounts.find(a => a.types.includes(k.type)));
   };
 
   public render() {
-    const { sources } = this.props;
+    const { sources, showIcons, showAccounts } = this.props;
     const { expectedArtifact, source, account } = this.state;
     const accounts = this.accountsForExpectedArtifact(expectedArtifact);
     const artifact = ExpectedArtifactService.artifactFromExpected(expectedArtifact);
@@ -111,12 +118,19 @@ export class ExpectedArtifactEditor extends React.Component<
         <StageConfigField label="Artifact Source" fieldColumns={8}>
           <ExpectedArtifactSourceSelector sources={sources} selected={source} onChange={this.onSourceChange} />
         </StageConfigField>
-        <StageConfigField label="Artifact Type" fieldColumns={8}>
-          <ExpectedArtifactKindSelector kinds={kinds} selected={kind} onChange={this.onKindChange} />
+        <StageConfigField label="Artifact Kind" fieldColumns={8}>
+          <ExpectedArtifactKindSelector
+            kinds={kinds}
+            selected={kind}
+            onChange={this.onKindChange}
+            showIcons={showIcons}
+          />
         </StageConfigField>
-        <StageConfigField label="Artifact Account" fieldColumns={8}>
-          <ArtifactAccountSelector accounts={accounts} selected={account} onChange={this.onAccountChange} />
-        </StageConfigField>
+        {showAccounts && (
+          <StageConfigField label="Artifact Account" fieldColumns={8}>
+            <ArtifactAccountSelector accounts={accounts} selected={account} onChange={this.onAccountChange} />
+          </StageConfigField>
+        )}
         {EditCmp && <EditCmp artifact={artifact} onChange={this.onArtifactEdit} labelColumns={3} fieldColumns={3} />}
         <StageConfigField label="" fieldColumns={8}>
           <button onClick={this.onSave} className="btn btn-block btn-primary btn-sm">
@@ -141,6 +155,7 @@ module(EXPECTED_ARTIFACT_EDITOR_COMPONENT_REACT, [
     'accounts',
     'onSave',
     'showIcons',
+    'showAccounts',
     'className',
   ]),
 );

--- a/app/scripts/modules/core/src/serverGroup/configure/common/serverGroupCommandBuilder.service.ts
+++ b/app/scripts/modules/core/src/serverGroup/configure/common/serverGroupCommandBuilder.service.ts
@@ -2,7 +2,7 @@ import { module } from 'angular';
 
 import { Application } from 'core/application/application.model';
 import { IMoniker } from 'core/naming/IMoniker';
-import { ILoadBalancer, ISecurityGroup, ISubnet, IEntityTags } from 'core/domain';
+import { ILoadBalancer, ISecurityGroup, ISubnet, IEntityTags, IPipeline, IStage } from 'core/domain';
 import { ICapacity } from 'core/serverGroup/serverGroupWriter.service';
 import { IDeploymentStrategy } from 'core/deploymentStrategy';
 import { ISecurityGroupsByAccountSourceData } from 'core/securityGroup/securityGroupReader.service';
@@ -53,6 +53,8 @@ export interface IServerGroupCommandViewState {
   useSimpleCapacity: boolean;
   usePreferredZones: boolean;
   mode: string;
+  pipeline?: IPipeline;
+  stage?: IStage;
 }
 
 export interface IServerGroupCommandBackingDataFiltered {
@@ -100,6 +102,7 @@ export interface IServerGroupCommand extends IServerGroupCommandResult {
   freeFormDetails?: string;
   healthCheckType: string;
   iamRole: string;
+  imageArtifactId?: string;
   instanceType: string;
   interestingHealthProviderNames: string[];
   loadBalancers: string[];

--- a/app/scripts/modules/google/src/serverGroup/configure/serverGroupCommandBuilder.service.js
+++ b/app/scripts/modules/google/src/serverGroup/configure/serverGroupCommandBuilder.service.js
@@ -485,6 +485,8 @@ module.exports = angular
 
         var expectedArtifacts = ExpectedArtifactService.getExpectedArtifactsAvailableToStage(currentStage, pipeline);
         var viewState = {
+          pipeline,
+          stage: currentStage,
           instanceProfile: asyncData.instanceProfile,
           disableImageSelection: true,
           expectedArtifacts: expectedArtifacts,

--- a/app/scripts/modules/google/src/serverGroup/configure/wizard/location/basicSettings.controller.js
+++ b/app/scripts/modules/google/src/serverGroup/configure/wizard/location/basicSettings.controller.js
@@ -3,7 +3,7 @@
 const angular = require('angular');
 import { Observable, Subject } from 'rxjs';
 
-import { IMAGE_READER } from '@spinnaker/core';
+import { IMAGE_READER, ExpectedArtifactSelectorViewController, NgGCEImageArtifactDelegate } from '@spinnaker/core';
 
 module.exports = angular
   .module('spinnaker.google.serverGroup.configure.wizard.basicSettings.controller', [
@@ -93,4 +93,11 @@ module.exports = angular
     };
 
     this.imageSources = ['artifact', 'priorStage'];
+
+    const gceImageDelegate = new NgGCEImageArtifactDelegate($scope);
+    $scope.gceImageArtifact = {
+      showCreateArtifactForm: false,
+      delegate: gceImageDelegate,
+      controller: new ExpectedArtifactSelectorViewController(gceImageDelegate),
+    };
   });

--- a/app/scripts/modules/google/src/serverGroup/configure/wizard/location/basicSettings.html
+++ b/app/scripts/modules/google/src/serverGroup/configure/wizard/location/basicSettings.html
@@ -58,13 +58,24 @@
                              image-sources="basicSettingsCtrl.imageSources"
                              help-field-key="gce.image.source">
       </image-source-selector>
-      <expected-artifact-selector ng-if="command.imageSource === 'artifact'"
-                                  command="command"
-                                  id="command.imageArtifactId"
-                                  expected-artifacts="command.viewState.expectedArtifacts"
-                                  help-field-key="gce.image.artifact"
-                                  show-icons="true">
-      </expected-artifact-selector>
+      <stage-config-field label="Expected Artifact" help-key="gce.image.artifact" field-columns="8" ng-if="command.imageSource === 'artifact'">
+        <expected-artifact-selector-react
+                                    expected-artifacts="command.viewState.expectedArtifacts"
+                                    selected="gceImageArtifact.delegate.getSelectedExpectedArtifact()"
+                                    on-change="gceImageArtifact.controller.onArtifactChange"
+                                    on-request-create="gceImageArtifact.controller.onRequestCreate"
+                                    offered-artifact-types="gceImageArtifact.delegate.getOfferedArtifactTypes()"
+                                    requesting-new="gceImageArtifact.showCreateArtifactForm"
+                                    >
+        </expected-artifact-selector-react>
+      </stage-config-field>
+      <expected-artifact-editor-react ng-if="gceImageArtifact.showCreateArtifactForm"
+                                      kinds="gceImageArtifact.delegate.getSupportedArtifactKinds()"
+                                      sources="gceImageArtifact.delegate.getExpectedArtifactSources()"
+                                      on-save="gceImageArtifact.controller.onArtifactCreated"
+                                      show-accounts="false"
+      >
+      </expected-artifact-editor-react>
     </div>
     <div class="form-group" ng-if="!command.viewState.disableImageSelection">
       <div class="col-md-3 sm-label-right">


### PR DESCRIPTION
This PR also limits the selectable artifacts to those with a `gce/image` type.

![2018-09-12_14-41-16](https://user-images.githubusercontent.com/34253460/45446087-05017300-b69a-11e8-9201-eb90a30d94f0.png)
