### PR TITLE
fix(amazon): Fix empty security group dropdown due to nulled vpcId

### DIFF
--- a/app/scripts/modules/amazon/src/securityGroup/configure/configSecurityGroup.mixin.controller.js
+++ b/app/scripts/modules/amazon/src/securityGroup/configure/configSecurityGroup.mixin.controller.js
@@ -169,7 +169,7 @@ module.exports = angular
         }
       }
 
-      const match = (available || []).find(vpc => vpc.label === $scope.securityGroup.vpcName);
+      const match = (available || []).find(vpc => vpc.ids.includes($scope.securityGroup.vpcId));
       $scope.securityGroup.vpcId = match ? match.ids[0] : null;
       this.vpcUpdated();
     };


### PR DESCRIPTION
Since we filter security groups by vpcId, we end up filtering **all security groups** from the dropdown because the `vpcId` gets nulled when `vpcName` is missing from a `$scope.securityGroup`.