### PR TITLE
Security groups standalone missing vpcName

### DIFF
--- a/app/scripts/modules/amazon/src/securityGroup/configure/configSecurityGroup.mixin.controller.js
+++ b/app/scripts/modules/amazon/src/securityGroup/configure/configSecurityGroup.mixin.controller.js
@@ -169,6 +169,8 @@ module.exports = angular
         }
       }
 
+      // When cloning a security group, if a user chooses a different account to clone to, but wants to retain the same VPC in this new account, it was not possible.
+      // We matched the vpc ids from one account to another but they are never the same. In order to ensure that users still retain their VPC choice, irrespective of the account, we switched to using vpc names instead of vpc ids
       const match = (available || []).find(vpc => vpc.label === $scope.securityGroup.vpcName);
       $scope.securityGroup.vpcId = match ? match.ids[0] : null;
       this.vpcUpdated();

--- a/app/scripts/modules/amazon/src/securityGroup/details/securityGroupDetail.controller.js
+++ b/app/scripts/modules/amazon/src/securityGroup/details/securityGroupDetail.controller.js
@@ -12,6 +12,8 @@ import {
   FirewallLabels,
 } from '@spinnaker/core';
 
+import { VpcReader } from '../../vpc/VpcReader';
+
 module.exports = angular
   .module('spinnaker.amazon.securityGroup.details.controller', [
     require('@uirouter/angularjs').default,
@@ -51,6 +53,12 @@ module.exports = angular
           securityGroup.vpcId,
           securityGroup.name,
         )
+        .then(function(details) {
+          return VpcReader.getVpcName(details.vpcId).then(name => {
+            details.vpcName = name;
+            return details;
+          });
+        })
         .then(function(details) {
           $scope.state.loading = false;
 


### PR DESCRIPTION
Matching was switched to use `vpcName` instead of `vpcId` so that we can perform cross account matching (names will be the same whereas ids would differ).

Looks like `vpcName` was missing from the securityGroup in the **standalone** security groups view. This caused the match logic to set the `vpcId` to null, which is then later used to filter the list of security groups to populate into the dropdown (we default to only showing security groups in the matching vpc, with the option to select from other accounts).

Since nothing would match against null, we ended up filtering out all groups so there would be nothing to select from. This fix allows the matching and subsequent filtering to work properly again.