### PR TITLE
chore(travis): parallelize module build tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,19 +17,8 @@ jobs:
     - stage: tests
       name: run tests for deck
       script: gradle/buildViaTravis.sh
-
-    # these modules have a specific build order because of dependancies
-    - name: build the core, amazon, ecs, and titus module
-      script: gradle/buildModules.sh core amazon ecs titus
-
-    # these modules do not depend on anything besides "core".
-    # Let's group together just to take advantage of travis's parallel job limit (5) to speed up builds
-    - name: build the core, appengine, and cloudfoundry module
-      script: gradle/buildModules.sh core appengine cloudfoundry
-    - name: build the core, google, and kubernetes module
-      script: gradle/buildModules.sh core google kubernetes
-    - name: build the core, docker, and openstack module
-      script: gradle/buildModules.sh core docker openstack
+    - name: build the all module libs
+      script: gradle/buildModules.sh
 
 before_cache: gradle/prepCaches.sh
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,34 @@ before_install:
 - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.5.1
 - sh -e /etc/init.d/xvfb start
 install: gradle/installViaTravis.sh
-script:
-  - gradle/buildViaTravis.sh
-  - gradle/buildModules.sh
+
+jobs:
+  include:
+    - stage: tests
+      name: run tests for deck
+      script: gradle/buildViaTravis.sh
+    # there's no need to build "core" since it's being built by each other module as a dependancy
+    # - name: build the "core" module
+    #   script: gradle/buildModules.sh core
+    - name: build the "amazon" module
+      script: gradle/buildModules.sh core amazon
+    - name: build the "ecs" module
+      script: gradle/buildModules.sh core amazon ecs
+    - name: build the "titus" module
+      script: gradle/buildModules.sh core amazon titus
+    - name: build the "appengine" module
+      script: gradle/buildModules.sh core appengine
+    - name: build the "cloudfoundry" module
+      script: gradle/buildModules.sh core cloudfoundry
+    - name: build the "docker" module
+      script: gradle/buildModules.sh core docker
+    - name: build the "google" module
+      script: gradle/buildModules.sh core google
+    - name: build the "kubernetes" module
+      script: gradle/buildModules.sh core kubernetes
+    - name: build the "openstack" module
+      script: gradle/buildModules.sh core openstack
+
 before_cache: gradle/prepCaches.sh
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,27 +17,19 @@ jobs:
     - stage: tests
       name: run tests for deck
       script: gradle/buildViaTravis.sh
-    # there's no need to build "core" since it's being built by each other module as a dependancy
-    # - name: build the "core" module
-    #   script: gradle/buildModules.sh core
-    - name: build the "amazon" module
-      script: gradle/buildModules.sh core amazon
-    - name: build the "ecs" module
-      script: gradle/buildModules.sh core amazon ecs
-    - name: build the "titus" module
-      script: gradle/buildModules.sh core amazon titus
-    - name: build the "appengine" module
-      script: gradle/buildModules.sh core appengine
-    - name: build the "cloudfoundry" module
-      script: gradle/buildModules.sh core cloudfoundry
-    - name: build the "docker" module
-      script: gradle/buildModules.sh core docker
-    - name: build the "google" module
-      script: gradle/buildModules.sh core google
-    - name: build the "kubernetes" module
-      script: gradle/buildModules.sh core kubernetes
-    - name: build the "openstack" module
-      script: gradle/buildModules.sh core openstack
+
+    # these modules have a specific build order because of dependancies
+    - name: build the core, amazon, ecs, and titus module
+      script: gradle/buildModules.sh core amazon ecs titus
+
+    # these modules do not depend on anything besides "core".
+    # Let's group together just to take advantage of travis's parallel job limit (5) to speed up builds
+    - name: build the core, appengine, and cloudfoundry module
+      script: gradle/buildModules.sh core appengine cloudfoundry
+    - name: build the core, google, and kubernetes module
+      script: gradle/buildModules.sh core google kubernetes
+    - name: build the core, docker, and openstack module
+      script: gradle/buildModules.sh core docker openstack
 
 before_cache: gradle/prepCaches.sh
 cache:


### PR DESCRIPTION
This will build all the modules in parallel like:

<kbd>![](https://cl.ly/401b67525f40/Screen%20Recording%202018-09-18%20at%2001.54.gif)</kbd>

which will help reduce the time that travis takes to test.
- prior to #5750 being merged it took ~8 mins
- after #5750  was merged in, it took: ~11 mins
- with this PR, it now takes: ~6 mins. 😱 🎉 

> note: travis is usually limited to building 5 parallel jobs at a time, so we'll use that to our advantage and stack in the module builds.

> note: the build of "core" module is duplicated because each cloud provider's module requires the core module to be built.