### PR TITLE
feat(provider/cf): add deploy and delete service pipeline stages

### DIFF
--- a/app/scripts/modules/cloudfoundry/src/cf.module.ts
+++ b/app/scripts/modules/cloudfoundry/src/cf.module.ts
@@ -20,6 +20,7 @@ import './logo/cf.logo.less';
 import { CloudFoundryNoLoadBalancerModal } from './loadBalancer/configure/cloudFoundryNoLoadBalancerModal';
 import 'cloudfoundry/pipeline/config/validation/instanceSize.validator';
 import 'cloudfoundry/pipeline/config/validation/cfTargetImpedance.validator';
+import 'cloudfoundry/pipeline/config/validation/validServiceParameterJson.validator';
 
 // load all templates into the $templateCache
 const templates = require.context('./', true, /\.html$/);
@@ -42,6 +43,8 @@ module(CLOUD_FOUNDRY_MODULE, [
   require('./pipeline/stages/destroyAsg/cloudfoundryDestroyAsgStage.js').name,
   require('./pipeline/stages/resizeAsg/cloudfoundryResizeAsgStage.js').name,
   require('./pipeline/stages/rollbackCluster/cloudfoundryRollbackClusterStage.js').name,
+  require('./pipeline/stages/deployService/cloudfoundryDeployServiceStage.js').name,
+  require('./pipeline/stages/deleteService/cloudfoundryDeleteServiceStage.js').name,
 ]).config(() => {
   CloudProviderRegistry.registerProvider('cloudfoundry', {
     name: 'Cloud Foundry',

--- a/app/scripts/modules/cloudfoundry/src/pipeline/config/validation/validServiceParameterJson.validator.ts
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/config/validation/validServiceParameterJson.validator.ts
@@ -1,0 +1,57 @@
+import { get, has, upperFirst } from 'lodash';
+
+import {
+  IPipeline,
+  IStage,
+  IStageOrTriggerValidator,
+  ITrigger,
+  IValidatorConfig,
+  PipelineConfigValidator,
+} from '@spinnaker/core';
+
+export interface IServiceParameterJsonValidationConfig extends IValidatorConfig {
+  fieldName: string;
+  fieldLabel?: string;
+  message?: string;
+}
+
+export class ServiceParameterJsonFieldValidator implements IStageOrTriggerValidator {
+  public validate(
+    _pipeline: IPipeline,
+    stage: IStage | ITrigger,
+    validationConfig: IServiceParameterJsonValidationConfig,
+  ): string {
+    if (!this.fieldIsValid(stage, validationConfig)) {
+      return this.validationMessage(validationConfig);
+    }
+    return null;
+  }
+
+  private validationMessage(validationConfig: IServiceParameterJsonValidationConfig): string {
+    const fieldLabel: string = this.printableFieldLabel(validationConfig);
+    return validationConfig.message || `<strong>${fieldLabel}</strong> should be a valid JSON string.`;
+  }
+
+  private printableFieldLabel(config: IServiceParameterJsonValidationConfig): string {
+    const fieldLabel: string = config.fieldLabel || config.fieldName;
+    return upperFirst(fieldLabel);
+  }
+
+  private fieldIsValid(stage: IStage | ITrigger, config: IServiceParameterJsonValidationConfig): boolean {
+    const fieldExists = has(stage, config.fieldName);
+    const field: any = get(stage, config.fieldName);
+
+    if (!fieldExists || !field) {
+      return true;
+    }
+
+    try {
+      JSON.parse(field);
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+}
+
+PipelineConfigValidator.registerValidator('validServiceParameterJson', new ServiceParameterJsonFieldValidator());

--- a/app/scripts/modules/cloudfoundry/src/pipeline/stages/deleteService/cloudfoundryDeleteServiceStage.js
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/stages/deleteService/cloudfoundryDeleteServiceStage.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const angular = require('angular');
+
+import { AccountService, Registry } from '@spinnaker/core';
+
+module.exports = angular
+  .module('spinnaker.cloudfoundry.pipeline.stage.deleteServiceStage', [])
+  .config(function() {
+    Registry.pipeline.registerStage({
+      provides: 'deleteService',
+      cloudProvider: 'cloudfoundry',
+      templateUrl: require('./deleteServiceStage.html'),
+      executionStepLabelUrl: require('./deleteServiceStepLabel.html'),
+      accountExtractor: stage => [stage.context.credentials],
+      configAccountExtractor: stage => [stage.credentials],
+      validators: [
+        { type: 'requiredField', fieldName: 'action' },
+        { type: 'requiredField', fieldName: 'region' },
+        { type: 'requiredField', fieldName: 'serviceName', preventSave: true },
+        { type: 'requiredField', fieldName: 'credentials', fieldLabel: 'account' },
+      ],
+    });
+  })
+  .controller('CloudfoundryDeleteServiceStageCtrl', function($scope) {
+    let stage = $scope.stage;
+    stage.action = 'deleteService';
+    $scope.state = {
+      accounts: false,
+      regionsLoaded: false,
+    };
+    AccountService.listAccounts('cloudfoundry').then(function(accounts) {
+      $scope.accounts = accounts;
+      $scope.state.accounts = true;
+    });
+
+    AccountService.getRegionsForAccount($scope.stage.credentials).then(function(regions) {
+      $scope.regions = regions;
+    });
+
+    stage.cloudProvider = 'cloudfoundry';
+
+    $scope.onAccountChange = () => {
+      $scope.stage.service = null;
+      $scope.serviceNamesAndPlans = [];
+
+      AccountService.getRegionsForAccount($scope.stage.credentials).then(function(regions) {
+        $scope.regions = regions;
+      });
+    };
+  });

--- a/app/scripts/modules/cloudfoundry/src/pipeline/stages/deleteService/deleteServiceStage.html
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/stages/deleteService/deleteServiceStage.html
@@ -1,0 +1,22 @@
+<div ng-controller="CloudfoundryDeleteServiceStageCtrl as ctrl" class="form-horizontal">
+  <stage-config-field label="Account">
+    <account-select-field component="stage"
+                          field="credentials"
+                          provider="cloudfoundry"
+                          on-change="onAccountChange()"
+                          accounts="accounts">
+    </account-select-field>
+  </stage-config-field>
+  <region-select-field label-columns="3"
+                       component="stage"
+                       field="region"
+                       account="stage.credentials"
+                       provider="cloudfoundry"
+                       regions="regions">
+  </region-select-field>
+  <stage-config-field label="Service Name">
+    <input type="text"
+           required
+           ng-model="stage.serviceName"/>
+  </stage-config-field>
+</div>

--- a/app/scripts/modules/cloudfoundry/src/pipeline/stages/deleteService/deleteServiceStepLabel.html
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/stages/deleteService/deleteServiceStepLabel.html
@@ -1,0 +1,3 @@
+<span class="task-label">
+  Delete Service: {{step.context.serviceName}}
+</span>

--- a/app/scripts/modules/cloudfoundry/src/pipeline/stages/deployService/cloudfoundryDeployServiceStage.js
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/stages/deployService/cloudfoundryDeployServiceStage.js
@@ -1,0 +1,97 @@
+'use strict';
+
+const angular = require('angular');
+
+import { includes } from 'lodash';
+
+import { AccountService, Registry, ServicesReader } from '@spinnaker/core';
+
+import './cloudfoundryDeployServiceStage.less';
+
+module.exports = angular
+  .module('spinnaker.cloudfoundry.pipeline.stage.deployServiceStage', [])
+  .config(function() {
+    Registry.pipeline.registerStage({
+      provides: 'deployService',
+      cloudProvider: 'cloudfoundry',
+      templateUrl: require('./deployServiceStage.html'),
+      executionStepLabelUrl: require('./deployServiceStepLabel.html'),
+      accountExtractor: stage => [stage.context.credentials],
+      configAccountExtractor: stage => [stage.credentials],
+      validators: [
+        { type: 'requiredField', fieldName: 'action' },
+        { type: 'requiredField', fieldName: 'region' },
+        { type: 'requiredField', fieldName: 'service' },
+        { type: 'requiredField', fieldName: 'servicePlan', preventSave: true },
+        { type: 'requiredField', fieldName: 'serviceName', preventSave: true },
+        { type: 'requiredField', fieldName: 'credentials', fieldLabel: 'account' },
+        { type: 'validServiceParameterJson', fieldName: 'parameters', preventSave: true },
+      ],
+    });
+  })
+  .controller('CloudfoundryDeployServiceStageCtrl', function($scope) {
+    let stage = $scope.stage;
+    stage.action = 'deployService';
+    stage.tags = stage.tags || [];
+
+    $scope.state = {
+      accounts: false,
+      regionsLoaded: false,
+    };
+    $scope.tagName = '';
+
+    AccountService.listAccounts('cloudfoundry').then(function(accounts) {
+      $scope.accounts = accounts;
+      $scope.state.accounts = true;
+    });
+
+    AccountService.getRegionsForAccount($scope.stage.credentials).then(function(regions) {
+      $scope.regions = regions;
+    });
+
+    if ($scope.stage.credentials) {
+      ServicesReader.getServices($scope.stage.credentials).then(function(services) {
+        $scope.serviceNamesAndPlans = services;
+        $scope.services = services.map(function(item) {
+          return item.name;
+        });
+        let service = $scope.serviceNamesAndPlans.find(it => it.name === $scope.stage.service) || { servicePlans: [] };
+        $scope.servicePlans = service.servicePlans.map(it => it.name);
+      });
+    }
+
+    stage.cloudProvider = 'cloudfoundry';
+    $scope.onAccountChange = () => {
+      $scope.stage.service = null;
+      $scope.serviceNamesAndPlans = [];
+
+      AccountService.getRegionsForAccount($scope.stage.credentials).then(function(regions) {
+        $scope.regions = regions;
+      });
+
+      ServicesReader.getServices($scope.stage.credentials).then(function(services) {
+        $scope.serviceNamesAndPlans = services;
+        $scope.services = services.map(function(item) {
+          return item.name;
+        });
+        $scope.onServiceChange();
+      });
+    };
+
+    $scope.onServiceChange = () => {
+      $scope.stage.servicePlan = null;
+      let service = $scope.serviceNamesAndPlans.find(it => it.name === $scope.stage.service) || { servicePlans: [] };
+      $scope.servicePlans = service.servicePlans.map(it => it.name);
+    };
+
+    $scope.addTag = () => {
+      if (!includes(stage.tags, $scope.stage.newTag)) {
+        $scope.stage.tags.push($scope.stage.newTag);
+      }
+      $scope.stage.newTag = '';
+    };
+
+    $scope.deleteTag = function(index) {
+      $scope.stage.tags.splice(index, 1);
+    };
+  });

--- a/app/scripts/modules/cloudfoundry/src/pipeline/stages/deployService/cloudfoundryDeployServiceStage.less
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/stages/deployService/cloudfoundryDeployServiceStage.less
@@ -1,0 +1,8 @@
+.cloudfoundry-deploy-service-stage {
+  .badge {
+    .close {
+      margin-left: 0.25rem;
+      font-size: 100%;
+    }
+  }
+}

--- a/app/scripts/modules/cloudfoundry/src/pipeline/stages/deployService/deployServiceStage.html
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/stages/deployService/deployServiceStage.html
@@ -1,0 +1,52 @@
+<div ng-controller="CloudfoundryDeployServiceStageCtrl as ctrl" class="form-horizontal cloudfoundry-deploy-service-stage">
+  <stage-config-field label="Account">
+    <account-select-field component="stage"
+                          field="credentials"
+                          provider="cloudfoundry"
+                          on-change="onAccountChange()"
+                          accounts="accounts">
+    </account-select-field>
+  </stage-config-field>
+  <region-select-field label-columns="3"
+                       component="stage"
+                       field="region"
+                       account="stage.credentials"
+                       provider="cloudfoundry"
+                       regions="regions">
+  </region-select-field>
+  <stage-config-field label="Service">
+    <select class="form-control input-sm"
+            required
+            ng-change="onServiceChange()"
+            ng-model="stage.service"
+            ng-options="serv for serv in services">
+    </select>
+  </stage-config-field>
+  <stage-config-field label="Service Plan">
+    <select class="form-control input-sm"
+            required
+            ng-model="stage.servicePlan"
+            ng-options="plan for plan in servicePlans">
+    </select>
+  </stage-config-field>
+  <stage-config-field label="Service Name">
+    <input type="text"
+           required
+           ng-model="stage.serviceName"/>
+  </stage-config-field>
+  <stage-config-field label="Tags">
+     <input type="text" name="newTag" ng-model="stage.newTag" />
+     <button class="btn btn-default btn-xs" ng-disabled="!stage.newTag" ng-click="addTag()">Add Tag</button>
+    <div>
+      <span class="badge badge-pill" ng-repeat="tag in stage.tags">
+        {{tag}}
+        <button type="button" class="close small" aria-label="Close" ng-click="deleteTag($index)">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </span>
+    </div>
+  </stage-config-field>
+  <stage-config-field label="Parameters">
+    <textarea class="form-control" rows="5" ng-model="stage.parameters"/>
+  </stage-config-field>
+</div>

--- a/app/scripts/modules/cloudfoundry/src/pipeline/stages/deployService/deployServiceStepLabel.html
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/stages/deployService/deployServiceStepLabel.html
@@ -1,0 +1,4 @@
+<span class="task-label">
+  Deploy Service:
+  ({{step.context.region}})
+</span>

--- a/app/scripts/modules/core/src/domain/IService.ts
+++ b/app/scripts/modules/core/src/domain/IService.ts
@@ -1,0 +1,8 @@
+export interface IService {
+  name: string;
+  servicePlans: IServicePlan[];
+}
+
+export interface IServicePlan {
+  name: string;
+}

--- a/app/scripts/modules/core/src/domain/index.ts
+++ b/app/scripts/modules/core/src/domain/index.ts
@@ -46,6 +46,7 @@ export * from './IRegionalCluster';
 export * from './ISecurityGroup';
 export * from './IServerGroup';
 export * from './IServerGroupManager';
+export * from './IService';
 export * from './ISnapshot';
 export * from './IStage';
 export * from './IStageContext';

--- a/app/scripts/modules/core/src/index.ts
+++ b/app/scripts/modules/core/src/index.ts
@@ -71,6 +71,7 @@ export * from './securityGroup';
 export * from './serverGroup';
 export * from './serverGroupManager';
 export * from './serviceAccount';
+export * from './services';
 export * from './state';
 export * from './storage';
 export * from './subnet';

--- a/app/scripts/modules/core/src/pipeline/config/stages/deleteService/DeleteServiceExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/deleteService/DeleteServiceExecutionDetails.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+
+import { ExecutionDetailsSection, IExecutionDetailsSectionProps } from 'core/pipeline/config/stages/core';
+import { AccountTag } from 'core/account';
+import { StageFailureMessage } from 'core/pipeline/details';
+
+export function DeleteServiceExecutionDetails(props: IExecutionDetailsSectionProps) {
+  const { stage } = props;
+  return (
+    <ExecutionDetailsSection name={props.name} current={props.current}>
+      <div className="row">
+        <div className="col-md-9">
+          <dl className="dl-narrow dl-horizontal">
+            <dt>Account</dt>
+            <dd>
+              <AccountTag account={stage.context.credentials} />
+            </dd>
+            <dt>Region</dt>
+            <dd>{stage.context.region}</dd>
+          </dl>
+        </div>
+      </div>
+      <StageFailureMessage stage={props.stage} message={props.stage.failureMessage} />
+    </ExecutionDetailsSection>
+  );
+}
+
+export namespace DeleteServiceExecutionDetails {
+  export const title = 'deleteServiceConfig';
+}

--- a/app/scripts/modules/core/src/pipeline/config/stages/deleteService/deleteServiceStage.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/deleteService/deleteServiceStage.ts
@@ -1,0 +1,18 @@
+import { module } from 'angular';
+
+import { Registry } from 'core/registry';
+import { ExecutionDetailsTasks } from '../core';
+import { DeleteServiceExecutionDetails } from './DeleteServiceExecutionDetails';
+
+export const DELETE_SERVICE_STAGE = 'spinnaker.core.pipeline.stage.deleteService';
+
+module(DELETE_SERVICE_STAGE, []).config(() => {
+  Registry.pipeline.registerStage({
+    executionDetailsSections: [DeleteServiceExecutionDetails, ExecutionDetailsTasks],
+    useBaseProvider: true,
+    key: 'deleteService',
+    label: 'Delete Service',
+    description: 'Deletes a service',
+    strategy: true,
+  });
+});

--- a/app/scripts/modules/core/src/pipeline/config/stages/deployService/DeployServiceExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/deployService/DeployServiceExecutionDetails.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+
+import { ExecutionDetailsSection, IExecutionDetailsSectionProps } from 'core/pipeline/config/stages/core';
+import { AccountTag } from 'core/account';
+import { StageFailureMessage } from 'core/pipeline/details';
+
+export function DeployServiceExecutionDetails(props: IExecutionDetailsSectionProps) {
+  const { stage } = props;
+  return (
+    <ExecutionDetailsSection name={props.name} current={props.current}>
+      <div className="row">
+        <div className="col-md-9">
+          <dl className="dl-narrow dl-horizontal">
+            <dt>Account</dt>
+            <dd>
+              <AccountTag account={stage.context.credentials} />
+            </dd>
+            <dt>Region</dt>
+            <dd>{stage.context.region}</dd>
+          </dl>
+        </div>
+      </div>
+      <StageFailureMessage stage={props.stage} message={props.stage.failureMessage} />
+    </ExecutionDetailsSection>
+  );
+}
+
+export namespace DeployServiceExecutionDetails {
+  export const title = 'deployServiceConfig';
+}

--- a/app/scripts/modules/core/src/pipeline/config/stages/deployService/deployServiceStage.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/deployService/deployServiceStage.ts
@@ -1,0 +1,18 @@
+import { module } from 'angular';
+
+import { Registry } from 'core/registry';
+import { ExecutionDetailsTasks } from '../core';
+import { DeployServiceExecutionDetails } from './DeployServiceExecutionDetails';
+
+export const DEPLOY_SERVICE_STAGE = 'spinnaker.core.pipeline.stage.deployService';
+
+module(DEPLOY_SERVICE_STAGE, []).config(() => {
+  Registry.pipeline.registerStage({
+    executionDetailsSections: [DeployServiceExecutionDetails, ExecutionDetailsTasks],
+    useBaseProvider: true,
+    key: 'deployService',
+    label: 'Deploy Service',
+    description: 'Deploy a service',
+    strategy: true,
+  });
+});

--- a/app/scripts/modules/core/src/pipeline/pipeline.module.ts
+++ b/app/scripts/modules/core/src/pipeline/pipeline.module.ts
@@ -5,6 +5,8 @@ import { BAKE_MANIFEST_STAGE } from './config/stages/bakeManifest/bakeManifestSt
 import { CHECK_PRECONDITIONS_STAGE_MODULE } from './config/stages/checkPreconditions/checkPreconditionsStage.module';
 import { CLONE_SERVER_GROUP_STAGE } from './config/stages/cloneServerGroup/cloneServerGroupStage.module';
 import { COPY_STAGE_MODAL_CONTROLLER } from './config/copyStage/copyStage.modal.controller';
+import { DEPLOY_SERVICE_STAGE } from './config/stages/deployService/deployServiceStage';
+import { DELETE_SERVICE_STAGE } from './config/stages/deleteService/deleteServiceStage';
 import { CREATE_LOAD_BALANCER_STAGE } from './config/stages/createLoadBalancer/createLoadBalancerStage.module';
 import { DESTROY_ASG_STAGE } from './config/stages/destroyAsg/destroyAsgStage';
 import { DISABLE_ASG_STAGE_MODULE } from './config/stages/disableAsg/disableAsgStage.module';
@@ -66,6 +68,8 @@ module(PIPELINE_MODULE, [
   CLONE_SERVER_GROUP_STAGE,
   STAGE_CORE_MODULE,
   require('./config/stages/deploy/deployStage.module').name,
+  DEPLOY_SERVICE_STAGE,
+  DELETE_SERVICE_STAGE,
   DESTROY_ASG_STAGE,
   DISABLE_ASG_STAGE_MODULE,
   DISABLE_CLUSTER_STAGE,

--- a/app/scripts/modules/core/src/services/ServicesReader.ts
+++ b/app/scripts/modules/core/src/services/ServicesReader.ts
@@ -1,0 +1,15 @@
+import { IPromise } from 'angular';
+import { API } from 'core/api/ApiService';
+import { IService } from 'core/domain';
+
+export class ServicesReader {
+  public static getServices(account: string): IPromise<IService[]> {
+    return API.one('servicebroker')
+      .one(account)
+      .all('services')
+      .withParams({
+        cloudProvider: 'cloudfoundry',
+      })
+      .getList();
+  }
+}

--- a/app/scripts/modules/core/src/services/index.ts
+++ b/app/scripts/modules/core/src/services/index.ts
@@ -1,0 +1,1 @@
+export * from './ServicesReader';


### PR DESCRIPTION
This contains the necessary pipeline stages to support deploy and delete Open Service Broker services. Aside from Cloud Foundry, Kubernetes also provides a service catalog that presents an aggregate view of Open Service Broker services and allows for deploying, deleting, and binding those services.

More detail on our reasoning around OSB service provisioning [here](https://docs.google.com/document/d/1cEkB2SdgrUNg1biNjHPd5H0WNv9IJSt1IDfSu4mKfc0/edit?usp=sharing)