### PR TITLE
refactor(formik): Use TSX generics to render Formik components

### DIFF
--- a/app/scripts/modules/amazon/src/loadBalancer/configure/application/ConfigureOidcConfigModal.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/application/ConfigureOidcConfigModal.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Modal } from 'react-bootstrap';
-import { Formik, Field, Form, FormikErrors, FormikProps } from 'formik';
+import { Formik, Field, Form, FormikErrors } from 'formik';
 
 import { ModalClose, ReactModal, SubmitButton, noop } from '@spinnaker/core';
 
@@ -89,11 +89,11 @@ export class ConfigureOidcConfigModal extends React.Component<
 
     return (
       <div>
-        <Formik
+        <Formik<{}, IAuthenticateOidcActionConfig>
           initialValues={initialValues}
           onSubmit={this.submit}
           validate={this.validate}
-          render={(props: FormikProps<IAuthenticateOidcActionConfig>) => (
+          render={({ isValid }) => (
             <Form className="form-horizontal">
               <ModalClose dismiss={this.close} />
               <Modal.Header>
@@ -171,7 +171,7 @@ export class ConfigureOidcConfigModal extends React.Component<
                 <button className="btn btn-default" onClick={this.close} type="button">
                   Cancel
                 </button>
-                <SubmitButton isDisabled={!props.isValid} submitting={false} isFormSubmit={true} label={submitLabel} />
+                <SubmitButton isDisabled={!isValid} submitting={false} isFormSubmit={true} label={submitLabel} />
               </Modal.Footer>
             </Form>
           )}

--- a/app/scripts/modules/core/src/entityTag/EntityTagEditor.tsx
+++ b/app/scripts/modules/core/src/entityTag/EntityTagEditor.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Field, FieldProps, Form, Formik, FormikErrors, FormikProps } from 'formik';
+import { Field, FieldProps, Form, Formik, FormikErrors } from 'formik';
 import { Modal } from 'react-bootstrap';
 
 import {
@@ -153,11 +153,11 @@ export class EntityTagEditor extends React.Component<IEntityTagEditorProps, IEnt
       <div>
         <TaskMonitorWrapper monitor={this.state.taskMonitor} />
 
-        <Formik
+        <Formik<{}, IEntityTagEditorValues>
           initialValues={initialValues}
           onSubmit={this.upsertTag}
           validate={this.validate}
-          render={(props: FormikProps<IEntityTagEditorValues>) => (
+          render={({ isValid, values }) => (
             <Form className="form-horizontal">
               <Modal.Header>
                 <h3>
@@ -185,13 +185,13 @@ export class EntityTagEditor extends React.Component<IEntityTagEditorProps, IEnt
                         </div>
                       </div>
                     </div>
-                    {props.values.message && (
+                    {values.message && (
                       <div className="form-group preview">
                         <div className="col-md-3 sm-label-right">
                           <strong>Preview</strong>
                         </div>
                         <div className="col-md-9">
-                          <Markdown message={props.values.message} />
+                          <Markdown message={values.message} />
                         </div>
                       </div>
                     )}
@@ -214,7 +214,7 @@ export class EntityTagEditor extends React.Component<IEntityTagEditorProps, IEnt
                                     name="ownerIndex"
                                     type="radio"
                                     value={index}
-                                    checked={index === Number(props.values.ownerIndex)}
+                                    checked={index === Number(values.ownerIndex)}
                                   />
                                   <span className="marked">
                                     <Markdown message={option.label} />
@@ -233,7 +233,7 @@ export class EntityTagEditor extends React.Component<IEntityTagEditorProps, IEnt
                   Cancel
                 </button>
                 <SubmitButton
-                  isDisabled={!props.isValid || isSubmitting}
+                  isDisabled={!isValid || isSubmitting}
                   submitting={isSubmitting}
                   isFormSubmit={true}
                   label={submitLabel}

--- a/app/scripts/modules/core/src/modal/wizard/WizardModal.tsx
+++ b/app/scripts/modules/core/src/modal/wizard/WizardModal.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as classNames from 'classnames';
-import { Formik, Form, FormikProps, FormikValues } from 'formik';
+import { Formik, Form, FormikValues } from 'formik';
 import { Modal } from 'react-bootstrap';
 
 import { TaskMonitor } from 'core';
@@ -20,10 +20,10 @@ export interface IWizardPageData {
   validate: IWizardPageValidate;
 }
 
-export interface IWizardModalProps extends IModalComponentProps {
+export interface IWizardModalProps<T> extends IModalComponentProps {
   heading: string;
   hideSections?: Set<string>;
-  initialValues: FormikValues;
+  initialValues: T;
   loading?: boolean;
   submitButtonLabel: string;
   taskMonitor: TaskMonitor;
@@ -41,11 +41,11 @@ export interface IWizardModalState {
   waiting: Set<string>;
 }
 
-export class WizardModal<T extends FormikValues> extends React.Component<IWizardModalProps, IWizardModalState> {
+export class WizardModal<T extends FormikValues> extends React.Component<IWizardModalProps<T>, IWizardModalState> {
   private pages: { [label: string]: IWizardPageData } = {};
   private stepsElement: HTMLDivElement;
 
-  constructor(props: IWizardModalProps) {
+  constructor(props: IWizardModalProps<T>) {
     super(props);
 
     this.state = {
@@ -160,7 +160,7 @@ export class WizardModal<T extends FormikValues> extends React.Component<IWizard
     this.setState({ waiting });
   };
 
-  public render(): React.ReactElement<WizardModal<T>> {
+  public render() {
     const { heading, hideSections, initialValues, loading, submitButtonLabel, taskMonitor } = this.props;
     const { currentPage, dirtyPages, pageErrors, formInvalid, pages, waiting } = this.state;
     const { TaskMonitorWrapper } = NgReact;
@@ -172,11 +172,11 @@ export class WizardModal<T extends FormikValues> extends React.Component<IWizard
     return (
       <>
         {taskMonitor && <TaskMonitorWrapper monitor={taskMonitor} />}
-        <Formik
+        <Formik<{}, T>
           initialValues={initialValues}
           onSubmit={this.props.closeModal}
           validate={this.validate}
-          render={(props: FormikProps<T>) => (
+          render={props => (
             <Form className="form-horizontal">
               <ModalClose dismiss={this.props.dismissModal} />
               <Modal.Header>{heading && <h3>{heading}</h3>}</Modal.Header>

--- a/app/scripts/modules/core/src/presentation/forms/README.md
+++ b/app/scripts/modules/core/src/presentation/forms/README.md
@@ -7,16 +7,16 @@ The most common input is the native `<input/>` component, but these may also be 
 
 ### Examples:
 
-* Text Input `<input type="text" />`
-* Text Area `<textarea/>`
-* Integer Input `<input type="number"/>`
-* Select/Dropdown `<select><option/></select>`
-* Radio button group
-* Checkbox `<input type="checkbox"/>`
-* Typeahead -- custom component
-* Expressions -- custom component
-* Key/Value pairs -- custom component
-  * i.e., “Tags” in Advanced Deploy Settings
+- Text Input `<input type="text" />`
+- Text Area `<textarea/>`
+- Integer Input `<input type="number"/>`
+- Select/Dropdown `<select><option/></select>`
+- Radio button group
+- Checkbox `<input type="checkbox"/>`
+- Typeahead -- custom component
+- Expressions -- custom component
+- Key/Value pairs -- custom component
+  - i.e., “Tags” in Advanced Deploy Settings
 
 ## Layouts
 
@@ -26,14 +26,14 @@ The layout is also typically responsible for implementing any responsive behavio
 
 The components that a Layout manages are:
 
-* Input Field
-* Label
-* Help widget (i.e., popover)
-* Required indicator
-* Action Icons (trash, etc)
-* Validation
-  * Internal (built into component, I.e., date picker, expressions)
-  * External
+- Input Field
+- Label
+- Help widget (i.e., popover)
+- Required indicator
+- Action Icons (trash, etc)
+- Validation
+  - Internal (built into component, I.e., date picker, expressions)
+  - External
 
 ### Example Layout:
 
@@ -95,15 +95,16 @@ Field components wrap a controlled input component.
 However, a Formik wrapper is added to Field components, as a static `Formik` property.
 
 ```js
-<Formik
+<Formik<{}, IChronosTimelineConfig>
   initialValues={initialValues}
   validate={this.validate}
-  render={(formik: FormikProps<IChronosTimelineConfig>) => (
+  render={(formik) => (
     <TextField.Formik
       formik={formik}
       name="timelineName"
       label="Timeline Name"
     />
+  )}
 />
 ```
 


### PR DESCRIPTION
Typescript 2.9 added support for rendering components with generic type parameters.
By switching to this style, the `values` and `errors` can be destructured in the render function, and the types are inferred.

```ts
<Component<ConcreteType> />
```