### PR TITLE
fix(core/application): Use relative import of ICluster

### DIFF
--- a/app/scripts/modules/core/src/application/application.model.ts
+++ b/app/scripts/modules/core/src/application/application.model.ts
@@ -3,7 +3,7 @@ import { map, union, uniq } from 'lodash';
 import { $log, $q } from 'ngimport';
 import { Observable, ReplaySubject, Subject, Subscription } from 'rxjs';
 
-import { ICluster } from 'core/domain';
+import { ICluster } from '../domain/ICluster';
 import { ApplicationDataSource, IDataSourceConfig, IFetchStatus } from './service/applicationDataSource';
 
 export class Application {


### PR DESCRIPTION
For some reason importing ICluster fro core/domain broke our downstream deck project
