### PR TITLE
fix(core): Projects calls interval increased to 3min from 30s

### DIFF
--- a/app/scripts/modules/core/src/projects/dashboard/dashboard.controller.js
+++ b/app/scripts/modules/core/src/projects/dashboard/dashboard.controller.js
@@ -126,8 +126,8 @@ module.exports = angular
         .value();
     };
 
-    let clusterScheduler = SchedulerFactory.createScheduler(),
-      executionScheduler = SchedulerFactory.createScheduler();
+    let clusterScheduler = SchedulerFactory.createScheduler(3 * 60 * 1000),
+      executionScheduler = SchedulerFactory.createScheduler(3 * 60 * 1000);
 
     let clusterLoader = clusterScheduler.subscribe(getClusters);
 


### PR DESCRIPTION
Increase scheduled re-fetch on clusters and executions in projects from 30s to 3min. 

There are some heavy projects set up at Netflix with multiple pipelines and clusters. This occasionally bombards clouddriver with requests especially if the tab is left open since it repeats the calls every 30s. In order to reduce these incidents, we decided to increase the interval for refetch from 30s to 3min. 