### PR TITLE
fix(artifacts): use default artifact kind before match artifact kind

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/expectedArtifact.component.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/expectedArtifact.component.ts
@@ -1,6 +1,7 @@
 import { IAttributes, IComponentController, IComponentOptions, module } from 'angular';
 
 import { IExpectedArtifact } from 'core/domain';
+import { Registry } from 'core/registry';
 
 class ExpectedArtifactController implements IComponentController {
   public expectedArtifact: IExpectedArtifact;
@@ -19,8 +20,15 @@ class ExpectedArtifactController implements IComponentController {
       expectedArtifact: { useDefaultArtifact, defaultArtifact, matchArtifact },
     } = this;
     if (useDefaultArtifact && defaultArtifact.type == null) {
-      defaultArtifact.type = matchArtifact.type;
-      defaultArtifact.kind = matchArtifact.kind;
+      const defaultKey = 'default.' + matchArtifact.kind;
+      const defaultKindConfig = Registry.pipeline.getArtifactKinds().find(kind => kind.key === defaultKey);
+      if (defaultKindConfig) {
+        defaultArtifact.type = defaultKindConfig.type;
+        defaultArtifact.kind = defaultKindConfig.key;
+      } else {
+        defaultArtifact.type = matchArtifact.type;
+        defaultArtifact.kind = matchArtifact.kind;
+      }
     }
   }
 }


### PR DESCRIPTION
No real change in the UI so no screenshots included but my previous PR to automatically choose a default artifact's kind from a match artifact completely broke default artifact behaviour.  This PR looks for a default artifact equivalent to the existing match artifact and uses that if available.  Previously I just copied the match artifact's type and kind, which meant that any logic specific to the default artifact type was completely skipped, effectively breaking default artifacts.