### PR TITLE
feat(kubernetes): show images in server group details

### DIFF
--- a/app/scripts/modules/kubernetes/src/v2/kubernetes.v2.module.ts
+++ b/app/scripts/modules/kubernetes/src/v2/kubernetes.v2.module.ts
@@ -38,6 +38,7 @@ import { KUBERNETES_V2_SECURITY_GROUP_TRANSFORMER } from './securityGroup/transf
 import { KUBERNETES_ANNOTATION_CUSTOM_SECTIONS } from './manifest/annotationCustomSections.component';
 import { KUBERNETES_V2_RESOURCE_STATES } from './resources/resources.state';
 import { KUBERNETES_COPY_FROM_TEMPLATE_BUTTON } from './pipelines/stages/deployManifest/CopyFromTemplateButton';
+import { KUBERNETES_MANIFEST_IMAGE_DETAILS } from 'kubernetes/v2/manifest/manifestImageDetails.component';
 import { YAML_EDITOR_COMPONENT } from './manifest/yaml/yamlEditor.component';
 import { ManifestWizard } from 'kubernetes/v2/manifest/wizard/ManifestWizard';
 
@@ -86,6 +87,7 @@ module(KUBERNETES_V2_MODULE, [
   KUBERNETES_MANIFEST_RESOURCES,
   KUBERNETES_MANIFEST_QOS,
   KUBERNETES_ANNOTATION_CUSTOM_SECTIONS,
+  KUBERNETES_MANIFEST_IMAGE_DETAILS,
   KUBERNETES_V2_RESOURCE_STATES,
   YAML_EDITOR_COMPONENT,
 ]).config(() => {

--- a/app/scripts/modules/kubernetes/src/v2/manifest/ManifestImageDetails.spec.tsx
+++ b/app/scripts/modules/kubernetes/src/v2/manifest/ManifestImageDetails.spec.tsx
@@ -1,0 +1,75 @@
+import * as React from 'react';
+import { mount } from 'enzyme';
+import { load } from 'js-yaml';
+import { ManifestImageDetails } from 'kubernetes/v2/manifest/ManifestImageDetails';
+
+describe('<ManifestImageDetails />', () => {
+  it('renders image names', () => {
+    const manifest = `
+      apiVersion: extensions/v1beta1
+      kind: Deployment
+      spec:
+        template:
+          spec:
+            containers:
+              - image: 'nginx:1.9.9'
+                imagePullPolicy: IfNotPresent
+                name: nginx`;
+    const wrapper = component(manifest);
+    const li = wrapper.find('li').at(0);
+    expect(li.text().trim()).toEqual('nginx:1.9.9');
+  });
+
+  it('separates `containers` and `initContainers` if both are present', () => {
+    let manifest = `
+      apiVersion: extensions/v1beta1
+      kind: Deployment
+      spec:
+        template:
+          spec:
+            containers:
+              - image: 'nginx:1.9.9'
+                imagePullPolicy: IfNotPresent
+                name: nginx`;
+    let wrapper = component(manifest);
+    expect(wrapper.html()).not.toContain('Init Containers');
+    expect(wrapper.html()).not.toContain('Containers');
+
+    manifest = `
+      apiVersion: extensions/v1beta1
+      kind: Deployment
+      spec:
+        template:
+          spec:
+            containers:
+              - image: 'nginx:1.9.9'
+                imagePullPolicy: IfNotPresent
+                name: nginx
+            initContainers:
+              - command:
+                  - echo
+                  - helloworld
+                image: busybox
+                name: init-deployment`;
+    wrapper = component(manifest);
+    expect(wrapper.html()).toContain('Init Containers');
+    expect(wrapper.html()).toContain('Containers');
+  });
+
+  it('appends `:latest` to an image without a tag or digest', () => {
+    const manifest = `
+      apiVersion: extensions/v1beta1
+      kind: Deployment
+      spec:
+        template:
+          spec:
+            containers:
+              - image: busybox
+                imagePullPolicy: IfNotPresent
+                name: busybox`;
+    const wrapper = component(manifest);
+    const li = wrapper.find('li').at(0);
+    expect(li.text().trim()).toEqual('busybox:latest');
+  });
+});
+const component = (manifest: string) => mount(<ManifestImageDetails manifest={load(manifest)} /> as any);

--- a/app/scripts/modules/kubernetes/src/v2/manifest/ManifestImageDetails.tsx
+++ b/app/scripts/modules/kubernetes/src/v2/manifest/ManifestImageDetails.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+import { has, sortBy } from 'lodash';
+
+import { HelpField } from '@spinnaker/core';
+
+export interface IContainer {
+  name: string;
+  image: string;
+}
+
+export interface IManifestImageDetailsProps {
+  manifest: {
+    spec: {
+      template: {
+        spec: {
+          containers: IContainer;
+          initContainers: IContainer;
+        };
+      };
+    };
+  };
+}
+
+// From https://github.com/docker/distribution/blob/master/docs/spec/api.md
+// if an image doesn't have a colon, it doesn't have a tag or digest.
+const normalizeImage = (image: string): string => {
+  if (image && image.includes(':')) {
+    return image;
+  }
+  return `${image}:latest`;
+};
+
+export const ManifestImageDetails = ({ manifest }: IManifestImageDetailsProps) => {
+  if (!has(manifest, 'spec.template.spec')) {
+    // Could still be loading the manifest in a parent component.
+    return null;
+  }
+  const containers = sortBy(manifest.spec.template.spec.containers || [], ['image']);
+  const initContainers = sortBy(manifest.spec.template.spec.initContainers || [], ['image']);
+  const hasBothContainerTypes = containers.length > 0 && initContainers.length > 0;
+  if (containers.length === 0 && initContainers.length === 0) {
+    // Not sure if this could happen
+    return <span>No images.</span>;
+  }
+
+  return (
+    <ul>
+      {hasBothContainerTypes && <strong>Containers</strong>}
+      {containers.map(container => (
+        <li key={container.image} title={normalizeImage(container.image)} className="break-word">
+          {normalizeImage(container.image)}{' '}
+          <HelpField content={`This is container <strong>${container.name}</strong>'s image.`} />
+        </li>
+      ))}
+      {hasBothContainerTypes && <strong>Init Containers</strong>}
+      {initContainers.map(container => (
+        <li key={container.image} className="break-word" title={normalizeImage(container.image)}>
+          {normalizeImage(container.image)}{' '}
+          <HelpField content={`This is init container <strong>${container.name}</strong>'s image.`} />
+        </li>
+      ))}
+    </ul>
+  );
+};

--- a/app/scripts/modules/kubernetes/src/v2/manifest/manifestImageDetails.component.ts
+++ b/app/scripts/modules/kubernetes/src/v2/manifest/manifestImageDetails.component.ts
@@ -1,0 +1,9 @@
+import { module } from 'angular';
+import { react2angular } from 'react2angular';
+import { ManifestImageDetails } from 'kubernetes/v2/manifest/ManifestImageDetails';
+
+export const KUBERNETES_MANIFEST_IMAGE_DETAILS = 'spinnaker.kubernetes.v2.manifestImageDetails.component';
+module(KUBERNETES_MANIFEST_IMAGE_DETAILS, []).component(
+  'kubernetesManifestImageDetails',
+  react2angular(ManifestImageDetails, ['manifest']),
+);

--- a/app/scripts/modules/kubernetes/src/v2/serverGroup/details/details.html
+++ b/app/scripts/modules/kubernetes/src/v2/serverGroup/details/details.html
@@ -78,6 +78,10 @@
 
     <kubernetes-annotation-custom-sections manifest="ctrl.serverGroup.manifest" resource="ctrl.serverGroup"></kubernetes-annotation-custom-sections>
 
+    <collapsible-section heading="Images" expanded="true">
+      <kubernetes-manifest-image-details manifest="ctrl.serverGroup.manifest"></kubernetes-manifest-image-details>
+    </collapsible-section>
+
     <collapsible-section heading="Events" expanded="true">
       <kubernetes-manifest-events manifest="ctrl.manifest"></kubernetes-manifest-events>
     </collapsible-section>


### PR DESCRIPTION
Closes https://github.com/spinnaker/spinnaker/issues/3263

<img width="337" alt="screen shot 2018-09-21 at 2 34 11 pm" src="https://user-images.githubusercontent.com/13868700/45899996-674e2800-bdac-11e8-8224-a3fa1c8df678.png">

Tooltip shows which container or init container the image is running on:
<img width="429" alt="screen shot 2018-09-21 at 2 34 05 pm" src="https://user-images.githubusercontent.com/13868700/45900003-6ddc9f80-bdac-11e8-8b4c-70c28b230e00.png">


@Rigdon is this what you're looking for?
