### PR TITLE
fix(artifacts): Creating new expected artifact doesn't save first time

### DIFF
--- a/app/scripts/modules/core/src/artifact/NgAppEngineDeployArtifactDelegate.ts
+++ b/app/scripts/modules/core/src/artifact/NgAppEngineDeployArtifactDelegate.ts
@@ -18,7 +18,7 @@ export class NgAppEngineDeployArtifactDelegate
   constructor(protected $scope: IScope, protected offeredArtifactTypes: RegExp[] = null) {
     super($scope);
     const { viewState } = $scope.command;
-    this.sources = ExpectedArtifactService.sourcesForPipelineStage(viewState.pipeline, viewState.stage);
+    this.sources = ExpectedArtifactService.sourcesForPipelineStage(() => viewState.pipeline, viewState.stage);
     this.kinds = Registry.pipeline.getArtifactKinds().filter((a: IArtifactKindConfig) => {
       return a.isMatch && (a.key === 'custom' || offeredArtifactTypes.find(oat => oat.test(a.type)));
     });

--- a/app/scripts/modules/core/src/artifact/NgBakeManifestArtifactDelegate.ts
+++ b/app/scripts/modules/core/src/artifact/NgBakeManifestArtifactDelegate.ts
@@ -20,7 +20,10 @@ export class NgBakeManifestArtifactDelegate
   constructor(private artifact: { $scope: IScope; id: string; account: string }) {
     super(artifact.$scope);
     this.refreshExpectedArtifacts();
-    this.sources = ExpectedArtifactService.sourcesForPipelineStage(this.$scope.$parent.pipeline, this.$scope.stage);
+    this.sources = ExpectedArtifactService.sourcesForPipelineStage(
+      () => this.$scope.$parent.pipeline,
+      this.$scope.stage,
+    );
     this.kinds = Registry.pipeline.getArtifactKinds().filter(a => a.isMatch);
   }
 

--- a/app/scripts/modules/core/src/artifact/NgGCEImageArtifactDelegate.ts
+++ b/app/scripts/modules/core/src/artifact/NgGCEImageArtifactDelegate.ts
@@ -26,7 +26,7 @@ export class NgGCEImageArtifactDelegate
   constructor(protected $scope: IScope) {
     super($scope);
     const { viewState } = $scope.command;
-    this.sources = ExpectedArtifactService.sourcesForPipelineStage(viewState.pipeline, viewState.stage);
+    this.sources = ExpectedArtifactService.sourcesForPipelineStage(() => viewState.pipeline, viewState.stage);
     this.refreshExpectedArtifacts();
   }
 

--- a/app/scripts/modules/core/src/artifact/NgManifestArtifactDelegate.ts
+++ b/app/scripts/modules/core/src/artifact/NgManifestArtifactDelegate.ts
@@ -20,7 +20,10 @@ export class NgManifestArtifactDelegate
   implements IExpectedArtifactSelectorViewControllerDelegate {
   constructor(protected $scope: IScope, private excludedArtifactTypes = defaultExcludedArtifactTypes) {
     super($scope);
-    this.sources = ExpectedArtifactService.sourcesForPipelineStage(this.$scope.$parent.pipeline, this.$scope.stage);
+    this.sources = ExpectedArtifactService.sourcesForPipelineStage(
+      () => this.$scope.$parent.pipeline,
+      this.$scope.stage,
+    );
     this.kinds = Registry.pipeline
       .getArtifactKinds()
       .filter((a: IArtifactKindConfig) => a.isMatch)

--- a/app/scripts/modules/core/src/artifact/expectedArtifact.service.ts
+++ b/app/scripts/modules/core/src/artifact/expectedArtifact.service.ts
@@ -70,12 +70,19 @@ export class ExpectedArtifactService {
   }
 
   public static sourcesForPipelineStage(
-    pipeline: IPipeline,
+    pipelineGetter: () => IPipeline,
     stage: IStage,
   ): Array<IArtifactSource<IPipeline | IStage>> {
     type ArtifactSource = IArtifactSource<IPipeline | IStage>;
-    const sources: ArtifactSource[] = [{ source: pipeline, label: 'Pipeline Trigger' }];
-    PipelineConfigService.getAllUpstreamDependencies(pipeline, stage)
+    const sources: ArtifactSource[] = [
+      {
+        get source() {
+          return pipelineGetter();
+        },
+        label: 'Pipeline Trigger',
+      },
+    ];
+    PipelineConfigService.getAllUpstreamDependencies(pipelineGetter(), stage)
       .filter(s => Registry.pipeline.getStageConfig(s).producesArtifacts)
       .map(s => ({ source: s, label: 'Stage (' + s.name + ')' }))
       .forEach(s => sources.push(s));


### PR DESCRIPTION
## Before:

![before_reference_fix](https://user-images.githubusercontent.com/34253460/45901188-1d674100-bdb0-11e8-93a6-3e3539f5b9e0.gif)

Notice that the newly-created expected artifact did not end up being selected in the select box. It likewise never ends up in the pipeline JSON. Very confusing. The manifest's artifact ID in the JSON *is* correctly set, however. Re-attempting the creation of the artifact always succeeds, so first creation is broken but second creation is fine.

## After:

![after_reference_fix](https://user-images.githubusercontent.com/34253460/45901194-20fac800-bdb0-11e8-87a8-31821117d166.gif)

Now the newly-created expected artifact does end up in the select box.

What's happening in the Before image is that the Pipeline which receives the new expected artifact is a stale reference that the view is no longer rendering. `$scope.$parent` is replaced at some point during the deploy stage's lifecycle, at which point the reference `$scope.$parent.pipeline` is also replaced, but I cannot find exactly when it is changing.

The workaround here is to delay resolving the pipeline's reference until the moment when the expected artifact is attached to it.