### PR TITLE
feat(core): collapse execution group account tags if there are more than 2

### DIFF
--- a/app/scripts/modules/core/src/account/AccountTag.tsx
+++ b/app/scripts/modules/core/src/account/AccountTag.tsx
@@ -4,6 +4,7 @@ import { AccountService } from 'core/account/AccountService';
 
 export interface IAccountTagProps {
   account: string;
+  className?: string;
 }
 
 export interface IAccountTagState {
@@ -46,8 +47,12 @@ export class AccountTag extends React.Component<IAccountTagProps, IAccountTagSta
   }
 
   public render() {
-    const { account } = this.props;
+    const { account, className } = this.props;
     const { isProdAccount } = this.state;
-    return <span className={`account-tag account-tag-${isProdAccount ? 'prod' : 'notprod'}`}>{account}</span>;
+    return (
+      <span className={`account-tag account-tag-${isProdAccount ? 'prod' : 'notprod'} ${className || ''}`}>
+        {account}
+      </span>
+    );
   }
 }

--- a/app/scripts/modules/core/src/account/accountTag.less
+++ b/app/scripts/modules/core/src/account/accountTag.less
@@ -17,7 +17,8 @@
   }
 }
 
-.heading-tag {
+.heading-tag,
+.heading-tag-overflow-group {
   display: flex;
   .account-tag {
     font-size: 100%;
@@ -33,5 +34,24 @@
     .glyphicon {
       margin-right: 3px;
     }
+  }
+}
+
+.heading-tag-overflow-group {
+  pointer-events: none;
+  position: absolute;
+  display: flex;
+  flex-wrap: wrap;
+  top: 100%;
+  left: 0;
+  transition: opacity 0.2s linear;
+  opacity: 0;
+
+  &.shown {
+    opacity: 1;
+  }
+
+  .account-tag {
+    border-top: 1px solid white;
   }
 }


### PR DESCRIPTION
Having too many accounts utilized in a pipeline results in a messy execution group header:

![screen shot 2018-09-25 at 4 07 59 pm](https://user-images.githubusercontent.com/34253460/46040063-51f33980-c0dd-11e8-9a64-e3b1f523cc0e.png)

This PR hides account tags if there are more than 2 and provides an on-hover handler to show those that are hidden:

![multiple_account_tags_unroll](https://user-images.githubusercontent.com/34253460/46040156-8961e600-c0dd-11e8-97f0-e56e09811cce.gif)

It's not the prettiest thing in the world. Any objections to merging? Open to suggestions on the animation or layout.

Closes https://github.com/spinnaker/spinnaker/issues/3200