### PR TITLE
feat(core): Call new manual execution endpoint behind a flag

### DIFF
--- a/app/scripts/modules/core/src/config/settings.ts
+++ b/app/scripts/modules/core/src/config/settings.ts
@@ -49,6 +49,7 @@ export interface IFeatures {
   travis?: boolean;
   managedServiceAccounts?: boolean;
   wercker?: boolean;
+  triggerViaEcho: boolean;
   [key: string]: any;
 }
 

--- a/app/scripts/modules/core/src/pipeline/config/services/PipelineConfigService.ts
+++ b/app/scripts/modules/core/src/pipeline/config/services/PipelineConfigService.ts
@@ -11,6 +11,9 @@ import { IPipeline } from 'core/domain/IPipeline';
 export interface ITriggerPipelineResponse {
   ref: string;
 }
+export interface IEchoTriggerPipelineResponse {
+  eventId: string;
+}
 export class PipelineConfigService {
   private static configViewStateCache = ViewStateCache.createCache('pipelineConfig', { version: 2 });
 
@@ -93,6 +96,23 @@ export class PipelineConfigService {
       .post()
       .then((result: ITriggerPipelineResponse) => {
         return result.ref.split('/').pop();
+      });
+  }
+
+  public static triggerPipelineViaEcho(
+    applicationName: string,
+    pipelineName: string,
+    body: any = {},
+  ): IPromise<string> {
+    body.user = AuthenticationService.getAuthenticatedUser().name;
+    return API.one('pipelines')
+      .one('v2')
+      .one(applicationName)
+      .one(pipelineName)
+      .data(body)
+      .post()
+      .then((result: IEchoTriggerPipelineResponse) => {
+        return result.eventId;
       });
   }
 

--- a/app/scripts/modules/core/src/pipeline/manualExecution/manualPipelineExecution.controller.js
+++ b/app/scripts/modules/core/src/pipeline/manualExecution/manualPipelineExecution.controller.js
@@ -224,6 +224,8 @@ module.exports = angular
       command.pipelineName = pipeline.name;
       selectedTrigger.type = 'manual';
       selectedTrigger.dryRun = this.command.dryRun;
+      // The description is not part of the trigger spec, so don't send it
+      delete selectedTrigger.description;
 
       if (pipeline.parameterConfig && pipeline.parameterConfig.length) {
         selectedTrigger.parameters = this.parameters;


### PR DESCRIPTION
A new endpoint that triggers manual executions via Echo has been added to Gate. Update Deck to send manual execution requests to this endpoint behind a flag that will default to off (until we are confident there
are no regressions).