### PR TITLE
fix(core): Fix polling cancellation on manual trigger

### DIFF
--- a/app/scripts/modules/core/src/pipeline/executions/Executions.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/Executions.tsx
@@ -147,7 +147,7 @@ export class Executions extends React.Component<IExecutionsProps, IExecutionsSta
           this.props.app,
           newPipelineId,
         );
-        monitor.then(() => this.setState({ triggeringExecution: false }));
+        monitor.promise.then(() => this.setState({ triggeringExecution: false }));
       },
       () => this.setState({ triggeringExecution: false }),
     );

--- a/app/scripts/modules/core/src/pipeline/service/execution.service.spec.ts
+++ b/app/scripts/modules/core/src/pipeline/service/execution.service.spec.ts
@@ -459,7 +459,9 @@ describe('Service: executionService', () => {
 
       $httpBackend.expectGET(url).respond(200, {});
 
-      executionService.waitUntilNewTriggeredPipelineAppears(application, executionId).then(() => (succeeded = true));
+      executionService
+        .waitUntilNewTriggeredPipelineAppears(application, executionId)
+        .promise.then(() => (succeeded = true));
 
       expect(succeeded).toBe(false);
 
@@ -472,7 +474,9 @@ describe('Service: executionService', () => {
 
       $httpBackend.expectGET(url).respond(404, {});
 
-      executionService.waitUntilNewTriggeredPipelineAppears(application, executionId).then(() => (succeeded = true));
+      executionService
+        .waitUntilNewTriggeredPipelineAppears(application, executionId)
+        .promise.then(() => (succeeded = true));
 
       expect(succeeded).toBe(false);
 
@@ -485,7 +489,9 @@ describe('Service: executionService', () => {
 
       $httpBackend.expectGET(url).respond(404, {});
 
-      executionService.waitUntilNewTriggeredPipelineAppears(application, executionId).then(() => (succeeded = true));
+      executionService
+        .waitUntilNewTriggeredPipelineAppears(application, executionId)
+        .promise.then(() => (succeeded = true));
 
       expect(succeeded).toBe(false);
 

--- a/app/scripts/modules/core/src/utils/retryablePromise.ts
+++ b/app/scripts/modules/core/src/utils/retryablePromise.ts
@@ -1,4 +1,5 @@
 import { IPromise } from 'angular';
+import { $timeout } from 'ngimport';
 
 export interface IRetryablePromise<T> {
   cancel: () => void;
@@ -12,14 +13,14 @@ export const retryablePromise: <T>(closure: () => IPromise<T>, interval?: number
   let currentTimeout: IPromise<T>;
   const retryPromise: () => IPromise<T> = () =>
     closure().catch(() => {
-      currentTimeout = this.$timeout(retryPromise, interval);
+      currentTimeout = $timeout(retryPromise, interval);
       return currentTimeout;
     });
 
   const promise = retryPromise();
   const cancel = () => {
     if (currentTimeout) {
-      this.$timeout.cancel(currentTimeout);
+      $timeout.cancel(currentTimeout);
     }
   };
   return { promise, cancel };

--- a/app/scripts/modules/core/src/utils/retryablePromise.ts
+++ b/app/scripts/modules/core/src/utils/retryablePromise.ts
@@ -1,0 +1,26 @@
+import { IPromise } from 'angular';
+
+export interface IRetryablePromise<T> {
+  cancel: () => void;
+  promise: IPromise<T>;
+}
+
+export const retryablePromise: <T>(closure: () => IPromise<T>, interval?: number) => IRetryablePromise<T> = <T>(
+  closure: () => IPromise<T>,
+  interval = 1000,
+) => {
+  let currentTimeout: IPromise<T>;
+  const retryPromise: () => IPromise<T> = () =>
+    closure().catch(() => {
+      currentTimeout = this.$timeout(retryPromise, interval);
+      return currentTimeout;
+    });
+
+  const promise = retryPromise();
+  const cancel = () => {
+    if (currentTimeout) {
+      this.$timeout.cancel(currentTimeout);
+    }
+  };
+  return { promise, cancel };
+};


### PR DESCRIPTION
The current logic for cancelling polling for an execucution is broken; in particular, if the API call to get an execution returns an error the polling will continue even after navigating away and unmounting the component.