### PR TITLE
Call new manual execution endpoint in Executions.tsx

### DIFF
--- a/app/scripts/modules/core/src/pipeline/executions/Executions.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/Executions.tsx
@@ -18,10 +18,10 @@ import { ExecutionFilters } from 'core/pipeline/filter/ExecutionFilters';
 import { ExecutionFilterService } from 'core/pipeline/filter/executionFilter.service';
 import { ExecutionGroups } from './executionGroup/ExecutionGroups';
 import { FilterTags, IFilterTag, ISortFilter } from 'core/filterModel';
-import { PipelineConfigService } from 'core/pipeline/config/services/PipelineConfigService';
 import { Spinner } from 'core/widgets/spinners/Spinner';
 import { ExecutionState } from 'core/state';
 import { ScrollToService } from 'core/utils';
+import { IRetryablePromise } from 'core/utils/retryablePromise';
 import { SchedulerFactory } from 'core/scheduler';
 
 import './executions.less';
@@ -34,6 +34,7 @@ export interface IExecutionsState {
   initializationError?: boolean;
   filtersExpanded: boolean;
   loading: boolean;
+  poll: IRetryablePromise<any>;
   sortFilter: ISortFilter;
   tags: IFilterTag[];
   triggeringExecution: boolean;
@@ -54,6 +55,7 @@ export class Executions extends React.Component<IExecutionsProps, IExecutionsSta
     this.state = {
       filtersExpanded: this.insightFilterStateModel.filtersExpanded,
       loading: true,
+      poll: null,
       sortFilter: ExecutionState.filterModel.asFilterModel.sortFilter,
       tags: [],
       triggeringExecution: false,
@@ -140,16 +142,16 @@ export class Executions extends React.Component<IExecutionsProps, IExecutionsSta
   };
 
   private startPipeline(command: IPipelineCommand): IPromise<void> {
+    const { executionService } = ReactInjector;
     this.setState({ triggeringExecution: true });
-    return PipelineConfigService.triggerPipeline(this.props.app.name, command.pipelineName, command.trigger).then(
-      (newPipelineId: string) => {
-        const monitor = ReactInjector.executionService.waitUntilNewTriggeredPipelineAppears(
-          this.props.app,
-          newPipelineId,
-        );
+    return executionService.startAndMonitorPipeline(this.props.app, command.pipelineName, command.trigger).then(
+      monitor => {
+        this.setState({ poll: monitor });
         monitor.promise.then(() => this.setState({ triggeringExecution: false }));
       },
-      () => this.setState({ triggeringExecution: false }),
+      () => {
+        this.setState({ triggeringExecution: false });
+      },
     );
   }
 
@@ -265,6 +267,7 @@ export class Executions extends React.Component<IExecutionsProps, IExecutionsSta
     this.groupsUpdatedSubscription.unsubscribe();
     this.locationChangeUnsubscribe();
     this.activeRefresher && this.activeRefresher.unsubscribe();
+    this.state.poll && this.state.poll.cancel();
   }
 
   private showFilters = (): void => {

--- a/app/scripts/modules/core/src/pipeline/service/execution.service.ts
+++ b/app/scripts/modules/core/src/pipeline/service/execution.service.ts
@@ -16,6 +16,8 @@ import { ISortFilter } from 'core/filterModel';
 import { ExecutionState } from 'core/state';
 import { Error } from 'tslint/lib/error';
 import { IRetryablePromise, retryablePromise } from 'core/utils/retryablePromise';
+import { ReactInjector } from 'core/reactShims';
+import { PipelineConfigService } from 'core/pipeline/config/services/PipelineConfigService';
 
 export class ExecutionService {
   public get activeStatuses(): string[] {
@@ -225,6 +227,20 @@ export class ExecutionService {
         });
       }
     }
+  }
+
+  public startAndMonitorPipeline(app: Application, pipeline: string, trigger: any): IPromise<IRetryablePromise<void>> {
+    const { executionService } = ReactInjector;
+    let triggerFunction: (app: string, pipeline: string, trigger: any) => IPromise<string>;
+    let monitorFunction: (id: string) => IRetryablePromise<any>;
+    if (SETTINGS.feature.triggerViaEcho) {
+      triggerFunction = PipelineConfigService.triggerPipelineViaEcho.bind(PipelineConfigService);
+      monitorFunction = eventId => executionService.waitUntilPipelineAppearsForEventId(app, eventId);
+    } else {
+      triggerFunction = PipelineConfigService.triggerPipeline.bind(PipelineConfigService);
+      monitorFunction = newPipelineId => executionService.waitUntilNewTriggeredPipelineAppears(app, newPipelineId);
+    }
+    return triggerFunction(app.name, pipeline, trigger).then(triggerResult => monitorFunction(triggerResult));
   }
 
   public waitUntilPipelineAppearsForEventId(application: Application, eventId: string): IRetryablePromise<any> {

--- a/settings.js
+++ b/settings.js
@@ -24,6 +24,7 @@ var canaryFeatureDisabled = process.env.CANARY_FEATURE_ENABLED !== 'true';
 var useClassicFirewallLabels = process.env.USE_CLASSIC_FIREWALL_LABELS === 'true';
 var artifactsEnabled = process.env.ARTIFACTS_ENABLED === 'true';
 var managedServiceAccountsEnabled = process.env.MANAGED_SERVICE_ACCOUNTS_ENABLED === 'true';
+var triggerViaEcho = process.env.TRIGGER_VIA_ECHO === 'true';
 
 window.spinnakerSettings = {
   checkForUpdates: true,
@@ -197,6 +198,7 @@ window.spinnakerSettings = {
     pipelines: true,
     roscoMode: false,
     snapshots: false,
+    triggerViaEcho: triggerViaEcho,
     travis: false,
     versionedProviders: true,
     vpcMigrator: true,


### PR DESCRIPTION
feat(core): Call new manual execution endpoint in Executions.tsx

Update Executions.tsx to call the new manual execution endpoint.
This change also does the following:
  * Handles cancelling polling when Executions.tsx unmounts, which was not handled before
  * Refactors some of the common manual triggering logic out of the react components and into a service

feat(core): Add triggerViaEcho to settings.js
