### PR TITLE
chore(package): prepare -> prepublishOnly for everything

### DIFF
--- a/app/scripts/modules/amazon/package.json
+++ b/app/scripts/modules/amazon/package.json
@@ -6,6 +6,6 @@
   "scripts": {
     "clean": "../../../../node_modules/rimraf/bin.js lib",
     "lib": "npm run clean && ../../../../node_modules/typescript/bin/tsc && node ../../../../node_modules/webpack/bin/webpack.js",
-    "prepare": "npm run lib"
+    "prepublishOnly": "npm run lib"
   }
 }

--- a/app/scripts/modules/appengine/package.json
+++ b/app/scripts/modules/appengine/package.json
@@ -6,6 +6,6 @@
   "scripts": {
     "clean": "../../../../node_modules/rimraf/bin.js lib",
     "lib": "npm run clean && ../../../../node_modules/typescript/bin/tsc && node ../../../../node_modules/webpack/bin/webpack.js",
-    "prepare": "npm run lib"
+    "prepublishOnly": "npm run lib"
   }
 }

--- a/app/scripts/modules/cloudfoundry/package.json
+++ b/app/scripts/modules/cloudfoundry/package.json
@@ -6,6 +6,6 @@
   "scripts": {
     "clean": "../../../../node_modules/rimraf/bin.js lib",
     "lib": "npm run clean && ../../../../node_modules/typescript/bin/tsc && node ../../../../node_modules/webpack/bin/webpack.js",
-    "prepare": "npm run lib"
+    "prepublishOnly": "npm run lib"
   }
 }

--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -6,6 +6,6 @@
   "scripts": {
     "clean": "../../../../node_modules/rimraf/bin.js lib",
     "lib": "npm run clean && ../../../../node_modules/typescript/bin/tsc && node ../../../../node_modules/webpack/bin/webpack.js",
-    "prepare": "npm run lib"
+    "prepublishOnly": "npm run lib"
   }
 }

--- a/app/scripts/modules/docker/package.json
+++ b/app/scripts/modules/docker/package.json
@@ -6,6 +6,6 @@
   "scripts": {
     "clean": "../../../../node_modules/rimraf/bin.js lib",
     "lib": "npm run clean && ../../../../node_modules/typescript/bin/tsc && node ../../../../node_modules/webpack/bin/webpack.js",
-    "prepare": "npm run lib"
+    "prepublishOnly": "npm run lib"
   }
 }

--- a/app/scripts/modules/ecs/package.json
+++ b/app/scripts/modules/ecs/package.json
@@ -6,6 +6,6 @@
   "scripts": {
     "clean": "../../../../node_modules/rimraf/bin.js lib",
     "lib": "npm run clean && ../../../../node_modules/typescript/bin/tsc && node ../../../../node_modules/webpack/bin/webpack.js",
-    "prepare": "npm run lib"
+    "prepublishOnly": "npm run lib"
   }
 }

--- a/app/scripts/modules/google/package.json
+++ b/app/scripts/modules/google/package.json
@@ -6,6 +6,6 @@
   "scripts": {
     "clean": "../../../../node_modules/rimraf/bin.js lib",
     "lib": "npm run clean && ../../../../node_modules/typescript/bin/tsc && node ../../../../node_modules/webpack/bin/webpack.js",
-    "prepare": "npm run lib"
+    "prepublishOnly": "npm run lib"
   }
 }

--- a/app/scripts/modules/kubernetes/package.json
+++ b/app/scripts/modules/kubernetes/package.json
@@ -6,6 +6,6 @@
   "scripts": {
     "clean": "../../../../node_modules/rimraf/bin.js lib",
     "lib": "npm run clean && ../../../../node_modules/typescript/bin/tsc && node ../../../../node_modules/webpack/bin/webpack.js",
-    "prepare": "npm run lib"
+    "prepublishOnly": "npm run lib"
   }
 }

--- a/app/scripts/modules/openstack/package.json
+++ b/app/scripts/modules/openstack/package.json
@@ -6,6 +6,6 @@
   "scripts": {
     "clean": "../../../../node_modules/rimraf/bin.js lib",
     "lib": "npm run clean && ../../../../node_modules/typescript/bin/tsc && node ../../../../node_modules/webpack/bin/webpack.js",
-    "prepare": "npm run lib"
+    "prepublishOnly": "npm run lib"
   }
 }

--- a/app/scripts/modules/oracle/package.json
+++ b/app/scripts/modules/oracle/package.json
@@ -6,6 +6,6 @@
   "scripts": {
     "clean": "../../../../node_modules/rimraf/bin.js lib",
     "lib": "npm run clean && ../../../../node_modules/typescript/bin/tsc && node ../../../../node_modules/webpack/bin/webpack.js",
-    "prepare": "npm run lib"
+    "prepublishOnly": "npm run lib"
   }
 }

--- a/app/scripts/modules/titus/package.json
+++ b/app/scripts/modules/titus/package.json
@@ -6,6 +6,6 @@
   "scripts": {
     "clean": "../../../../node_modules/rimraf/bin.js lib",
     "lib": "npm run clean && ../../../../node_modules/typescript/bin/tsc && node ../../../../node_modules/webpack/bin/webpack.js",
-    "prepare": "npm run lib"
+    "prepublishOnly": "npm run lib"
   }
 }


### PR DESCRIPTION
As far as I can tell we don't rely on the behavior of `prepare` (which also gets triggered on `install` in addition to `publish`). This just updates us to a more use-case appropriate `prepublishOnly` script across all packages.

An added side-benefit of this is a more convenient experience for those of us that use [`yalc`](https://github.com/whitecolor/yalc).