### PR TITLE
feat(core/presentation): Support validation when fields are touched

### DIFF
--- a/app/scripts/modules/core/src/modal/wizard/WizardModal.tsx
+++ b/app/scripts/modules/core/src/modal/wizard/WizardModal.tsx
@@ -21,6 +21,7 @@ export interface IWizardPageData<T> {
 }
 
 export interface IWizardModalProps<T> extends IModalComponentProps {
+  formClassName?: string;
   heading: string;
   hideSections?: Set<string>;
   initialValues: T;
@@ -161,7 +162,7 @@ export class WizardModal<T = {}> extends React.Component<IWizardModalProps<T>, I
   };
 
   public render() {
-    const { heading, hideSections, initialValues, loading, submitButtonLabel, taskMonitor } = this.props;
+    const { formClassName, heading, hideSections, initialValues, loading, submitButtonLabel, taskMonitor } = this.props;
     const { currentPage, dirtyPages, pageErrors, formInvalid, pages, waiting } = this.state;
     const { TaskMonitorWrapper } = NgReact;
 
@@ -177,7 +178,7 @@ export class WizardModal<T = {}> extends React.Component<IWizardModalProps<T>, I
           onSubmit={this.props.closeModal}
           validate={this.validate}
           render={formik => (
-            <Form className="form-horizontal">
+            <Form className={`form-horizontal ${formClassName}`}>
               <ModalClose dismiss={this.props.dismissModal} />
               <Modal.Header>{heading && <h3>{heading}</h3>}</Modal.Header>
               <Modal.Body>

--- a/app/scripts/modules/core/src/presentation/forms/fields/TextField.tsx
+++ b/app/scripts/modules/core/src/presentation/forms/fields/TextField.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as classNames from 'classnames';
 
 import { BasicLayout } from '../layouts';
 import { formikField, IFormikField } from './formikField';
@@ -10,14 +11,26 @@ export class TextField extends React.Component<ITextFieldProps> {
   public static defaultProps: Partial<IFieldProps> = { FieldLayout: BasicLayout };
 
   public render() {
-    const { label, help, error, warning, preview, actions, ...rest } = this.props;
-    const { FieldLayout, value, onChange, required, ...inputProps } = rest;
+    const { label, help, touched, error, warning, preview, actions, ...rest } = this.props;
+    const { FieldLayout, value, onChange, onBlur, required, ...inputProps } = rest;
+
+    const className = classNames({
+      'form-control': true,
+      'ng-dirty': !!touched,
+      'ng-invalid': !!error,
+    });
 
     const input = (
-      <input value={value} onChange={evt => onChange(evt.target.value)} className="form-control" {...inputProps} />
+      <input
+        value={value}
+        onChange={evt => onChange && onChange(evt.target.value)}
+        onBlur={evt => onBlur && onBlur(evt)}
+        className={className}
+        {...inputProps}
+      />
     );
 
-    const layoutProps: IFieldLayoutProps = { input, label, help, error, warning, preview, actions, required };
+    const layoutProps: IFieldLayoutProps = { input, label, help, error, warning, preview, actions, touched, required };
     return <FieldLayout {...layoutProps} />;
   }
 }

--- a/app/scripts/modules/core/src/presentation/forms/fields/formikField.tsx
+++ b/app/scripts/modules/core/src/presentation/forms/fields/formikField.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { FormikProps } from 'formik';
 import { IFieldProps, IFormikFieldProps, Omit } from '../interface';
 
 export type IFormikField<P extends IFieldProps<T>, T = string> = React.ComponentType<
@@ -10,12 +11,15 @@ export function formikField<P extends IFieldProps<T>, T = string>(
 ): IFormikField<P, T> {
   return (props: any) => {
     const { formik, name, ...rest } = props;
+    const formikProps: FormikProps<any> = formik;
 
     return (
       <FieldComponent
-        value={formik.values[name]}
-        error={formik.errors[name]}
-        onChange={(val: T) => formik.setFieldValue(name, val)}
+        value={formikProps.values[name]}
+        error={formikProps.errors[name]}
+        touched={formikProps.touched[name]}
+        onChange={(val: T) => formikProps.setFieldValue(name, val)}
+        onBlur={() => formikProps.setFieldTouched(name, true)}
         {...rest}
       />
     );

--- a/app/scripts/modules/core/src/presentation/forms/interface.ts
+++ b/app/scripts/modules/core/src/presentation/forms/interface.ts
@@ -14,6 +14,7 @@ export interface IFieldLayoutProps extends IFieldLayoutPropsWithoutInput {
 
 export interface IValidationProps {
   error?: string | JSX.Element;
+  touched?: boolean;
   warning?: string | JSX.Element;
   preview?: string | JSX.Element;
 }

--- a/app/scripts/modules/core/src/presentation/forms/layouts/BasicLayout.tsx
+++ b/app/scripts/modules/core/src/presentation/forms/layouts/BasicLayout.tsx
@@ -5,18 +5,21 @@ import { ValidationMessage } from 'core/validation';
 
 export class BasicLayout extends React.Component<IFieldLayoutProps> {
   public render() {
-    const { label, help, input, actions, error, warning, preview } = this.props;
+    const { label, help, input, actions, touched, error, warning, preview } = this.props;
 
     const renderMessage = (message: string | JSX.Element, type: IValidationMessageProps['type']) =>
       typeof message === 'string' ? <ValidationMessage type={type} message={message} /> : message;
 
-    const validation = renderMessage(error, 'error') || renderMessage(warning, 'warning') || preview;
+    const validation = touched && (renderMessage(error, 'error') || renderMessage(warning, 'warning'));
+    const showLabel = !!label || !!help;
 
     return (
       <div className="flex-container-h baseline margin-between-lg">
-        <div className="sm-label-right" style={{ minWidth: '120px' }}>
-          {label} {help}
-        </div>
+        {showLabel && (
+          <div className="sm-label-right" style={{ minWidth: '120px' }}>
+            {label} {help}
+          </div>
+        )}
 
         <div className="flex-grow">
           <div className="flex-container-v">
@@ -24,7 +27,7 @@ export class BasicLayout extends React.Component<IFieldLayoutProps> {
               {input} {actions}
             </div>
 
-            {validation}
+            {validation || preview}
           </div>
         </div>
       </div>


### PR DESCRIPTION
 (…and some other things)

WizardModal: support formClassName prop
TextField: Only show validation errors when field is touched
BasicLayout: Support input field with no label
formikField/TextField: support touched prop and set touched from onBlur
