### PR TITLE
fix(titus/deploy): fix parameterized imageId fix

### DIFF
--- a/app/scripts/modules/titus/src/serverGroup/configure/wizard/pages/ServerGroupBasicSettings.tsx
+++ b/app/scripts/modules/titus/src/serverGroup/configure/wizard/pages/ServerGroupBasicSettings.tsx
@@ -61,7 +61,7 @@ class ServerGroupBasicSettingsImpl extends React.Component<
 
     this.state = {
       ...this.getStateFromProps(props),
-      showImageIdField: props.formik.values.imageId.includes('${'),
+      showImageIdField: values.imageId && values.imageId.includes('${'),
     };
   }
 


### PR DESCRIPTION
#5818 added a check for a parameterized `imageId`, but in many cases that field can be undefined.