### PR TITLE
feat(provider/kubernetes): split kubernetes pod logs by container #3360

### DIFF
--- a/app/scripts/modules/core/src/instance/InstanceReader.ts
+++ b/app/scripts/modules/core/src/instance/InstanceReader.ts
@@ -3,6 +3,11 @@ import { API } from 'core/api/ApiService';
 import { IInstance } from 'core/domain';
 
 export interface IInstanceConsoleOutput {
+  output: string | IInstanceMultiOutputLog[];
+}
+
+export interface IInstanceMultiOutputLog {
+  name: string;
   output: string;
 }
 

--- a/app/scripts/modules/core/src/instance/details/console/consoleOutput.modal.controller.js
+++ b/app/scripts/modules/core/src/instance/details/console/consoleOutput.modal.controller.js
@@ -6,23 +6,37 @@ const angular = require('angular');
 
 module.exports = angular
   .module('spinnaker.core.instance.details.console.controller', [])
-  .controller('ConsoleOutputCtrl', function($scope, $uibModalInstance, instance) {
+  .controller('ConsoleOutputCtrl', function($scope, $uibModalInstance, instance, usesMultiOutput) {
     const instanceId = instance.instanceId || instance.id;
     $scope.vm = {
       loading: true,
       instanceId: instanceId,
+      usesMultiOutput,
     };
 
-    InstanceReader.getConsoleOutput(instance.account, instance.region, instanceId, instance.provider).then(
-      function(response) {
-        $scope.vm.consoleOutput = response.output;
-        $scope.vm.loading = false;
-      },
-      function(exception) {
-        $scope.vm.exception = exception;
-        $scope.vm.loading = false;
-      },
-    );
+    $scope.fetchLogs = isInitialFetch => {
+      $scope.vm.loading = true;
+      $scope.vm.exception = null;
+      InstanceReader.getConsoleOutput(instance.account, instance.region, instanceId, instance.provider).then(
+        function(response) {
+          $scope.vm.consoleOutput = response.output;
+          $scope.vm.loading = false;
+
+          if ($scope.vm.usesMultiOutput) {
+            $scope.selectLog = function(log) {
+              $scope.vm.selectedLog = log;
+            };
+            if (isInitialFetch) {
+              $scope.selectLog($scope.vm.consoleOutput[0]);
+            }
+          }
+        },
+        function(exception) {
+          $scope.vm.exception = exception;
+          $scope.vm.loading = false;
+        },
+      );
+    };
 
     $scope.close = $uibModalInstance.dismiss;
 
@@ -30,4 +44,6 @@ module.exports = angular
       const console = document.getElementById('console-output');
       console.scrollTop = console.scrollHeight;
     };
+
+    $scope.fetchLogs(true);
   });

--- a/app/scripts/modules/core/src/instance/details/console/consoleOutput.modal.html
+++ b/app/scripts/modules/core/src/instance/details/console/consoleOutput.modal.html
@@ -9,7 +9,26 @@
         <div class="horizontal center middle spinner-container" ng-if="vm.loading">
           <loading-spinner size="'small'"></loading-spinner>
         </div>
-        <pre style="font-size:75%;" ng-if="vm.consoleOutput">{{vm.consoleOutput}}</pre>
+        <div ng-if="vm.usesMultiOutput && !vm.loading && vm.consoleOutput.length">
+          <ul class="tabs-basic console-output-tabs">
+            <li
+              class="console-output-tab"
+              ng-class="{'selected': log.name === vm.selectedLog.name}"
+              ng-click="selectLog(log)"
+              ng-repeat="log in vm.consoleOutput"
+            >
+              {{log.name}}
+            </li>
+          </ul>
+          <pre class="body-small" ng-if="vm.selectedLog">
+            {{vm.selectedLog.output}}
+          </pre>
+        </div>
+        <div ng-if="!vm.usesMultiOutput && !vm.loading && vm.consoleOutput">
+          <pre class="body-small" ng-if="vm.consoleOutput">
+            {{vm.consoleOutput}}
+          </pre>
+        </div>
         <div ng-if="vm.exception">
           <p>An error occurred trying to load console output. Please try again later.</p>
           <p>Exception:</p>
@@ -19,6 +38,7 @@
     </div>
   </div>
   <div class="modal-footer">
+    <button class="btn btn-link" ng-if="vm.consoleOutput" ng-click="fetchLogs(false)">Refresh</button>
     <button class="btn btn-link" ng-if="vm.consoleOutput" ng-click="jumpToEnd()">Scroll to End</button>
     <button class="btn btn-primary" ng-click="close()">Close</button>
   </div>

--- a/app/scripts/modules/core/src/instance/details/console/consoleOutput.modal.less
+++ b/app/scripts/modules/core/src/instance/details/console/consoleOutput.modal.less
@@ -1,0 +1,13 @@
+.console-output-tabs {
+  list-style: none;
+  overflow-x: scroll;
+  padding: 0 20px;
+}
+
+.console-output-tab {
+  min-width: 50px;
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/app/scripts/modules/core/src/instance/details/console/consoleOutputLink.directive.js
+++ b/app/scripts/modules/core/src/instance/details/console/consoleOutputLink.directive.js
@@ -4,6 +4,8 @@ const angular = require('angular');
 
 import { InstanceTemplates } from 'core/instance/templates';
 
+import './consoleOutput.modal.less';
+
 module.exports = angular
   .module('spinnaker.core.instance.details.console.link', [
     require('angular-ui-bootstrap'),
@@ -17,10 +19,12 @@ module.exports = angular
       bindToController: {
         instance: '=',
         text: '=?',
+        usesMultiOutput: '=?',
       },
       controllerAs: 'vm',
       controller: function($uibModal) {
         this.text = this.text || 'Console Output (Raw)';
+        this.usesMultiOutput = this.usesMultiOutput || false;
         this.showConsoleOutput = function() {
           $uibModal.open({
             templateUrl: InstanceTemplates.consoleOutputModal,
@@ -28,6 +32,7 @@ module.exports = angular
             size: 'lg modal-fullscreen',
             resolve: {
               instance: () => this.instance,
+              usesMultiOutput: () => this.usesMultiOutput,
             },
           });
         };

--- a/app/scripts/modules/kubernetes/src/instance/details/details.html
+++ b/app/scripts/modules/kubernetes/src/instance/details/details.html
@@ -138,7 +138,7 @@
     </collapsible-section>
     <collapsible-section heading="Logs" expanded="true">
       <div>
-        <console-output-link instance="instance"></console-output-link>
+        <console-output-link instance="instance" uses-multi-output="true"></console-output-link>
       </div>
     </collapsible-section>
     <instance-links address="ctrl.baseIpAddress" application="ctrl.application" instance="instance" moniker="moniker" environment="environment"></instance-links>

--- a/app/scripts/modules/kubernetes/src/v2/instance/details/details.html
+++ b/app/scripts/modules/kubernetes/src/v2/instance/details/details.html
@@ -56,7 +56,7 @@
         <dt>QOS Class</dt>
         <dd><kubernetes-manifest-qos manifest="ctrl.instance.manifest"></kubernetes-manifest-qos></dd>
         <dt>Logs</dt>
-        <dd><console-output-link instance="ctrl.consoleOutputInstance"></console-output-link></dd>
+        <dd><console-output-link instance="ctrl.consoleOutputInstance" uses-multi-output="true"></console-output-link></dd>
       </dl>
     </collapsible-section>
     <collapsible-section heading="Status" expanded="true">


### PR DESCRIPTION
Closes [issue #3360](https://github.com/spinnaker/spinnaker/issues/3360)

Updates kubernetes instance logs and job logs to be divided into tabs by container. Adds refresh functionality to instance logs:

![spinnaker-k8s-log-screengrab](https://user-images.githubusercontent.com/15936279/46477175-08c77780-c7b8-11e8-9990-f635ef21ec55.png)


cc @danielpeach @lwander 

