### PR TITLE
feat(core): skip stage button

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/core/executionSummary.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/core/executionSummary.html
@@ -2,7 +2,7 @@
   <h5 class="execution-details-title">
     Stage details: {{stageSummary.name || stageSummary.type }}
 
-    <div ng-if="(!stage.isRunning && !stage.isCompleted) && $ctrl.isRestartable(stage)" uib-dropdown class="btn-group pull-right">
+    <div ng-if="$ctrl.isRestartable(stage) || $ctrl.canManuallySkip()" uib-dropdown class="btn-group pull-right">
       <button type="button"
               class="btn btn-default btn-sm dropdown-toggle"
               analytics-on="click"
@@ -13,16 +13,33 @@
         <span class="caret"></span>
       </button>
       <ul class="dropdown-menu" uib-dropdown-menu uib-dropdown-append-to-body="true" role="menu">
-        <li><a href ng-controller="RestartStageCtrl as restartCtrl"
-               analytics-on="click"
-               analytics-category="Pipeline"
-               analytics-event="Execution restart clicked"
-               ng-click="restartCtrl.restart()">Restart {{ stageSummary.name }}</a></li>
+        <li ng-if="$ctrl.isRestartable(stage)">
+          <a
+             href
+             ng-controller="RestartStageCtrl as restartCtrl"
+             analytics-on="click"
+             analytics-category="Pipeline"
+             analytics-event="Execution restart clicked"
+             ng-click="restartCtrl.restart()">Restart {{ stageSummary.name }}</a>
+        </li>
+        <li ng-if="$ctrl.canManuallySkip()">
+          <a
+            href
+            analytics-on="click"
+            analytics-category="Pipeline"
+            analytics-event="Stage skip clicked"
+            ng-click="$ctrl.openManualSkipStageModal()">Skip {{ $ctrl.getTopLevelStage().name }}</a>
+        </li>
       </ul>
     </div>
   </h5>
   <h6 class="duration">Duration: {{stageSummary.runningTimeInMs | duration}}</h6>
   <h6 ng-if="stage.context.restartDetails">Restarted by {{stage.context.restartDetails.restartedBy}} &mdash; {{stage.context.restartDetails.restartTime | timestamp}}</h6>
+  <h6 ng-if="$ctrl.getTopLevelStage().context.manualSkip" uib-tooltip="{{$ctrl.getTopLevelStage().context.reason}}">
+    Manually skipped by {{$ctrl.getTopLevelStage().lastModified.user}}
+    &mdash;
+    {{$ctrl.getTopLevelStage().lastModified.lastModifiedTime | timestamp}}
+  </h6>
 
   <table class="table">
     <thead>

--- a/app/scripts/modules/core/src/pipeline/details/stageSummary.component.ts
+++ b/app/scripts/modules/core/src/pipeline/details/stageSummary.component.ts
@@ -5,6 +5,7 @@ import { HtmlRenderer, Parser } from 'commonmark';
 import { Application } from 'core/application';
 import { IExecution, IExecutionStage, IExecutionStageSummary, IStage } from 'core/domain';
 import { Registry } from 'core/registry';
+import { ConfirmationModalService, ExecutionService } from 'core';
 
 export class StageSummaryController implements IController {
   public application: Application;
@@ -16,7 +17,13 @@ export class StageSummaryController implements IController {
   private parser: Parser = new Parser();
   private renderer: HtmlRenderer = new HtmlRenderer();
 
-  constructor(private $scope: IScope, private $stateParams: StateParams, private $state: StateService) {
+  constructor(
+    private $scope: IScope,
+    private $stateParams: StateParams,
+    private $state: StateService,
+    private confirmationModalService: ConfirmationModalService,
+    private executionService: ExecutionService,
+  ) {
     'ngInject';
   }
 
@@ -63,6 +70,10 @@ export class StageSummaryController implements IController {
   }
 
   public isRestartable(stage?: IStage): boolean {
+    if (stage.isRunning || stage.isCompleted) {
+      return false;
+    }
+
     const stageConfig = Registry.pipeline.getStageConfig(stage);
     if (!stageConfig || stage.isRestarting === true) {
       return false;
@@ -74,6 +85,50 @@ export class StageSummaryController implements IController {
     }
 
     return stageConfig.restartable || false;
+  }
+
+  public canManuallySkip(): boolean {
+    const topLevelStage = this.getTopLevelStage();
+    return this.stage.isRunning && topLevelStage && topLevelStage.context.canManuallySkip;
+  }
+
+  public getTopLevelStage(): IExecutionStage {
+    let parentStageId = this.stage.parentStageId,
+      topLevelStage: IExecutionStage = this.stage;
+    while (parentStageId) {
+      topLevelStage = this.execution.stages.find(stage => stage.id === parentStageId);
+      parentStageId = topLevelStage.parentStageId;
+    }
+    return topLevelStage;
+  }
+
+  public openManualSkipStageModal(): void {
+    const topLevelStage = this.getTopLevelStage();
+    this.confirmationModalService.confirm({
+      header: 'Really skip this stage?',
+      buttonText: 'Skip',
+      askForReason: true,
+      submitJustWithReason: true,
+      body: `
+        <div class="alert alert-warning">
+          <b>Warning:</b> Skipping this stage may have unpredictable results.
+          <ul>
+            <li>Mutating changes initiated by this stage will continue and will need to be cleaned up manually.</li>
+            <li>Downstream stages that depend on the outputs of this stage may fail or behave unexpectedly.</li>
+          </ul>
+        </div>
+      `,
+      submitMethod: (reason: string) =>
+        this.executionService
+          .patchExecution(this.execution.id, topLevelStage.id, { manualSkip: true, reason })
+          .then(() =>
+            this.executionService.waitUntilExecutionMatches(this.execution.id, execution => {
+              const updatedStage = execution.stages.find(stage => stage.id === topLevelStage.id);
+              return updatedStage && updatedStage.status === 'SKIPPED';
+            }),
+          )
+          .then(updated => this.executionService.updateExecution(this.application, updated)),
+    });
   }
 
   public toggleDetails(index: number): void {


### PR DESCRIPTION
Corresponds to https://github.com/spinnaker/orca/pull/2445

Deploy stages can't be skipped - just using deploy as an example.

Button:
![skip_deploy](https://user-images.githubusercontent.com/13868700/46552074-874f1280-c8a7-11e8-8fdb-0aaa506f2aba.png)
Modal:
![skip_deploy_modal](https://user-images.githubusercontent.com/13868700/46552072-874f1280-c8a7-11e8-9cfc-f3a2f4865ae1.png)
After skipping a stage:
![skip_deploy_tooltip](https://user-images.githubusercontent.com/13868700/46552073-874f1280-c8a7-11e8-932f-5e7af8142178.png)
