### PR TITLE
fix(kubernetes): fix saving of kubernetes yaml patches #3433

### DIFF
--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/patchManifest/patchManifestConfig.controller.ts
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/patchManifest/patchManifestConfig.controller.ts
@@ -1,5 +1,6 @@
 import { IController, IScope } from 'angular';
 import { get, defaults } from 'lodash';
+import { dump } from 'js-yaml';
 import { ExpectedArtifactSelectorViewController, NgManifestArtifactDelegate } from '@spinnaker/core';
 import { IPatchOptions, MergeStrategy } from './patchOptionsForm.component';
 import {
@@ -16,12 +17,19 @@ export class KubernetesV2PatchManifestConfigCtrl implements IController {
   public textSource = 'text';
   public artifactSource = 'artifact';
   public sources = [this.textSource, this.artifactSource];
+  public rawPatchBody: string;
 
   private manifestArtifactDelegate: NgManifestArtifactDelegate;
   private manifestArtifactController: ExpectedArtifactSelectorViewController;
 
   constructor(private $scope: IScope) {
     'ngInject';
+
+    try {
+      this.rawPatchBody = $scope.stage.patchBody ? dump($scope.stage.patchBody) : null;
+    } catch (e) {
+      this.rawPatchBody = null;
+    }
 
     const defaultOptions: IPatchOptions = {
       mergeStrategy: MergeStrategy.strategic,
@@ -58,7 +66,8 @@ export class KubernetesV2PatchManifestConfigCtrl implements IController {
     });
   }
 
-  public handleYamlChange = (patchBody: any): void => {
+  public handleYamlChange = (rawPatchBody: string, patchBody: any): void => {
+    this.rawPatchBody = rawPatchBody;
     this.$scope.stage.patchBody = patchBody;
     // Called from a React component.
     this.$scope.$applyAsync();

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/patchManifest/patchManifestConfig.html
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/patchManifest/patchManifestConfig.html
@@ -25,7 +25,7 @@
     <yaml-editor
       ng-if="stage.source === ctrl.textSource"
       on-change="ctrl.handleYamlChange"
-      value="stage.patchBody">
+      value="ctrl.rawPatchBody">
     </yaml-editor>
     <stage-config-field label="Expected Artifact" help-key="kubernetes.manifest.expectedArtifact" field-columns="8" ng-if="ctrl.$scope.stage.source === ctrl.artifactSource">
       <expected-artifact-selector-react


### PR DESCRIPTION
I created a new issue separate from the Kubernetes JSON patch issue since I think this is an unrelated problem. We need to save the `patchBody` on the stage as a plain object so it can be serialized to JSON, but currently we are saving the raw YAML string, which causes CloudDriver to throw an error when the pipeline is run.