### PR TITLE
fix(bakery/oracle): use read-only text field for bake region

### DIFF
--- a/app/scripts/modules/oracle/src/pipeline/stages/bake/bakeStage.html
+++ b/app/scripts/modules/oracle/src/pipeline/stages/bake/bakeStage.html
@@ -13,12 +13,8 @@
     </stage-config-field>
 
     <stage-config-field label="Region" help-key="oracle.pipeline.config.bake.regions">
-        <region-select-field component="stage"
-                             field="region"
-                             account="stage.accountName"
-                             regions="regions"
-                             provider="'oracle'">
-        </region-select-field>
+        <input type="text" class="form-control input-sm" ng-readonly="true"
+               ng-model="stage.region"/>
     </stage-config-field>
 
     <stage-config-field label="Base Image" , help-key="oracle.pipeline.config.bake.baseOsOption">
@@ -45,8 +41,7 @@
     <stage-config-field label="Rebake" help-key="execution.forceRebake">
         <div class="checkbox" style="margin-bottom: 0">
             <label>
-                <input type="checkbox" ng-model="stage.rebake">
-                </input>
+                <input type="checkbox" ng-model="stage.rebake"/>
                 Rebake image without regard to the status of any existing bake
             </label>
         </div>
@@ -55,7 +50,7 @@
         <div class="col-md-9 col-md-offset-1">
             <div class="checkbox">
                 <label>
-                    <input type="checkbox" ng-model="stage.showAdvancedOptions">
+                    <input type="checkbox" ng-model="stage.showAdvancedOptions"/>
                     <strong>Show Advanced Options</strong>
                 </label>
             </div>
@@ -77,5 +72,4 @@
             </label>
         </stage-config-field>
     </div>
-</div>
 </div>

--- a/app/scripts/modules/oracle/src/pipeline/stages/bake/ociBakeStage.js
+++ b/app/scripts/modules/oracle/src/pipeline/stages/bake/ociBakeStage.js
@@ -2,16 +2,7 @@
 
 const angular = require('angular');
 
-import _ from 'lodash';
-
-import {
-  AccountService,
-  AuthenticationService,
-  BakeryReader,
-  NetworkReader,
-  Registry,
-  SubnetReader,
-} from '@spinnaker/core';
+import { AccountService, AuthenticationService, BakeryReader, Registry } from '@spinnaker/core';
 
 module.exports = angular
   .module('spinnaker.oracle.pipeline.stage.bakeStage', [require('./bakeExecutionDetails.controller.js').name])
@@ -79,8 +70,10 @@ module.exports = angular
 
         if ($scope.stage.accountName) {
           AccountService.getRegionsForAccount($scope.stage.accountName).then(function(regions) {
-            $scope.regions = regions;
-            $scope.stage.region = $scope.regions[0].name;
+            if (Array.isArray(regions) && regions.length != 0) {
+              // there is exactly one region per account
+              $scope.stage.region = regions[0].name;
+            }
           });
         }
 
@@ -94,8 +87,10 @@ module.exports = angular
 
     this.accountUpdated = function() {
       AccountService.getRegionsForAccount($scope.stage.accountName).then(function(regions) {
-        $scope.regions = regions;
-        $scope.stage.region = $scope.regions[0].name;
+        if (Array.isArray(regions) && regions.length != 0) {
+          // there is exactly one region per account
+          $scope.stage.region = regions[0].name;
+        }
       });
     };
 


### PR DESCRIPTION
Use read-only text field for region instead of select field in Oracle Bake Configuration.  Note that in oracle provider, there is only one region per account.