### PR TITLE
feat(rollback): Support wait before disable during an orchestrated rollback

### DIFF
--- a/app/scripts/modules/amazon/src/serverGroup/details/rollback/rollbackServerGroup.controller.js
+++ b/app/scripts/modules/amazon/src/serverGroup/details/rollback/rollbackServerGroup.controller.js
@@ -61,6 +61,7 @@ module.exports = angular
         rollbackServerGroupName: serverGroup.name,
         restoreServerGroupName: previousServerGroup ? previousServerGroup.name : undefined,
         targetHealthyRollbackPercentage: healthyPercent,
+        delayBeforeDisableSeconds: 0,
       },
     };
 

--- a/app/scripts/modules/amazon/src/serverGroup/details/rollback/rollbackServerGroup.html
+++ b/app/scripts/modules/amazon/src/serverGroup/details/rollback/rollbackServerGroup.html
@@ -46,6 +46,18 @@
 
       <div class="row">
         <div class="col-sm-11 col-sm-offset-1">
+          Wait
+          <input placeholder="0"
+                 min="0"
+                 type="number"
+                 ng-model="command.rollbackContext.delayBeforeDisableSeconds"
+                 class="form-control input-sm inline-number">
+          seconds before disabling <em>{{ ctrl.label(serverGroup) }}</em>.
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-sm-11 col-sm-offset-1">
           Consider rollback successful when
           <input type="number"
                  min="0"
@@ -76,7 +88,10 @@
                 instances to report as healthy
               </li>
             </li>
-            <li>Disable {{ serverGroup.name }}</li>
+            <li ng-if="command.rollbackContext.delayBeforeDisableSeconds > 0">
+              Wait {{ command.rollbackContext.delayBeforeDisableSeconds }} seconds
+            </li>
+            <li>Disable <em>{{ serverGroup.name }}</em></li>
             <li>Restore minimum capacity of <em>{{ command.rollbackContext.restoreServerGroupName || 'previous server group' }}</em> [
               <strong>min</strong>: {{ serverGroup.capacity.min }}
             ]</li>

--- a/app/scripts/modules/titus/src/serverGroup/details/rollback/rollbackServerGroup.controller.js
+++ b/app/scripts/modules/titus/src/serverGroup/details/rollback/rollbackServerGroup.controller.js
@@ -56,6 +56,7 @@ module.exports = angular
         rollbackServerGroupName: serverGroup.name,
         restoreServerGroupName: previousServerGroup ? previousServerGroup.name : undefined,
         targetHealthyRollbackPercentage: healthyPercent,
+        delayBeforeDisableSeconds: 0,
       },
     };
 

--- a/app/scripts/modules/titus/src/serverGroup/details/rollback/rollbackServerGroup.html
+++ b/app/scripts/modules/titus/src/serverGroup/details/rollback/rollbackServerGroup.html
@@ -43,6 +43,18 @@
 
       <div class="row">
         <div class="col-sm-11 col-sm-offset-1">
+          Wait
+          <input placeholder="0"
+                 min="0"
+                 type="number"
+                 ng-model="command.rollbackContext.delayBeforeDisableSeconds"
+                 class="form-control input-sm inline-number">
+          seconds before disabling <em>{{ ctrl.label(serverGroup) }}</em>.
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-sm-11 col-sm-offset-1">
           Consider rollback successful when
           <input type="number"
                  min="0"
@@ -96,7 +108,7 @@
                 instances to report as healthy
               </li>
             </li>
-            <li>Disable {{ serverGroup.name }}</li>
+            <li>Disable <em>{{ serverGroup.name }}</em></li>
             <li>Restore minimum capacity of <em>new server group</em> [
               <strong>min</strong>: {{ serverGroup.capacity.min }}
               ]</li>


### PR DESCRIPTION
We support this for a normal red/black and have been asked to also allow it during a rollback.

related to spinnaker/orca#2456
