### PR TITLE
feat(pipeline_templates): Display "Force Rebake" checkbox for MPT

### DIFF
--- a/app/scripts/modules/core/src/pipeline/manualExecution/manualPipelineExecution.controller.js
+++ b/app/scripts/modules/core/src/pipeline/manualExecution/manualPipelineExecution.controller.js
@@ -132,6 +132,17 @@ module.exports = angular
       const pipeline = this.command.pipeline,
         executions = application.executions.data || [];
 
+      if (
+        pipeline.type === 'templatedPipeline' &&
+        executions.length > 0 &&
+        (pipeline.stages === undefined || pipeline.stages.length === 0)
+      ) {
+        const previousSuccessfulExecution = executions.find(e => e.stages.length > 0);
+        if (previousSuccessfulExecution) {
+          pipeline.stages = previousSuccessfulExecution.stages;
+        }
+      }
+
       pipelineNotifications = pipeline.notifications || [];
       synchronizeNotifications();
 

--- a/app/scripts/modules/core/src/pipeline/manualExecution/manualPipelineExecution.controller.js
+++ b/app/scripts/modules/core/src/pipeline/manualExecution/manualPipelineExecution.controller.js
@@ -7,6 +7,7 @@ import { AuthenticationService } from 'core/authentication';
 import { Registry } from 'core/registry';
 import { SETTINGS } from 'core/config/settings';
 import { AppNotificationsService } from 'core/notification/AppNotificationsService';
+import { PipelineTemplateReader } from 'core/pipeline/config/templates/PipelineTemplateReader';
 
 import { STAGE_MANUAL_COMPONENTS } from './stageManualComponents.component';
 import { TRIGGER_TEMPLATE } from './triggerTemplate.component';
@@ -109,6 +110,21 @@ module.exports = angular
       this.command.trigger = suppliedTriggerCanBeInvoked ? trigger : _.head(this.triggers);
     };
 
+    const updatePipelinePlan = pipeline => {
+      if (pipeline.type === 'templatedPipeline' && (pipeline.stages === undefined || pipeline.stages.length === 0)) {
+        PipelineTemplateReader.getPipelinePlan(pipeline)
+          .then(plan => (this.stageComponents = getManualExecutionComponents(plan.stages)))
+          .catch(() => getManualExecutionComponents(pipeline.stages));
+      } else {
+        this.stageComponents = getManualExecutionComponents(pipeline.stages);
+      }
+    };
+
+    const getManualExecutionComponents = stages => {
+      const additionalComponents = stages.map(stage => Registry.pipeline.getManualExecutionComponentForStage(stage));
+      return _.uniq(_.compact(additionalComponents));
+    };
+
     /**
      * Controller API
      */
@@ -132,17 +148,6 @@ module.exports = angular
       const pipeline = this.command.pipeline,
         executions = application.executions.data || [];
 
-      if (
-        pipeline.type === 'templatedPipeline' &&
-        executions.length > 0 &&
-        (pipeline.stages === undefined || pipeline.stages.length === 0)
-      ) {
-        const previousSuccessfulExecution = executions.find(e => e.stages.length > 0);
-        if (previousSuccessfulExecution) {
-          pipeline.stages = previousSuccessfulExecution.stages;
-        }
-      }
-
       pipelineNotifications = pipeline.notifications || [];
       synchronizeNotifications();
 
@@ -152,10 +157,7 @@ module.exports = angular
       addTriggers();
       this.triggerUpdated();
 
-      const additionalComponents = pipeline.stages.map(stage =>
-        Registry.pipeline.getManualExecutionComponentForStage(stage),
-      );
-      this.stageComponents = _.uniq(_.compact(additionalComponents));
+      updatePipelinePlan(pipeline);
 
       if (pipeline.parameterConfig && pipeline.parameterConfig.length) {
         this.parameters = {};


### PR DESCRIPTION
When manually executing templated pipelines, the "Force Rebake" checkbox is missing, even though the pipeline contains a bake stage. Templated pipelines do not contain any stages before runtime, so the bake stage is never asked to inject its custom logic into the manual execution modal.

This is a simple 90/10-solution that just ~~iterates through previous executions, finds the previous execution that actually ran, and naïvely copies the~~ plans a new execution and adds the stages to the pipeline, so that the bake stage magic is executed.
It might result in false positives or negatives if you are changing the pipeline template, but as the main structure of a pipeline rarely changes and the fact that there are no bad consequences of displaying a "Force Rebake" checkbox when there is no bake stage, I think this is good enough.