### PR TITLE
fix(amazon): Fixed cloning security group across accounts

### DIFF
--- a/app/scripts/modules/amazon/src/securityGroup/clone/cloneSecurityGroup.controller.js
+++ b/app/scripts/modules/amazon/src/securityGroup/clone/cloneSecurityGroup.controller.js
@@ -78,6 +78,15 @@ module.exports = angular
       .value();
 
     vm.upsert = function() {
+      // <account-select-field> only updates securityGroup.credentials, but Orca looks at account* before looking at credentials
+      // Updating the rest of the attributes to send the correct (expected) account for all attributes
+      const { credentials } = $scope.securityGroup;
+      Object.assign($scope.securityGroup, {
+        account: credentials,
+        accountName: credentials,
+        accountId: credentials,
+      });
+
       vm.mixinUpsert('Clone');
     };
 


### PR DESCRIPTION
Cloning a security group gets the entire source security group object, then updates it with any modifications made in dialog. Unfortunately, "account" exists as multiple attributes:

- `account`
- `accountId`
- `accountName`
- `credentials`

and the `<account-select-field>` can only update a single attribute. To address this, we can copy the updated account to the rest of the fields.