### PR TITLE
fix(core/account): Fixed AccountSelectField missing state initialization

### DIFF
--- a/app/scripts/modules/core/src/account/AccountSelectField.tsx
+++ b/app/scripts/modules/core/src/account/AccountSelectField.tsx
@@ -86,6 +86,10 @@ export class AccountSelectField extends React.Component<IAccountSelectFieldProps
     });
   };
 
+  public componentDidMount() {
+    this.groupAccounts(this.props.accounts);
+  }
+
   public componentWillReceiveProps(nextProps: IAccountSelectFieldProps) {
     if (!isEqual(nextProps.accounts, this.props.accounts)) {
       this.groupAccounts(nextProps.accounts);


### PR DESCRIPTION
Dropdowns were empty since `componentWillReceiveProps` is not called on mount and `props.account` never change after that so `groupAccounts` never has a chance to map them into `state`.