### PR TITLE
fix(core/modal): Deep merge `errors` object

### DIFF
--- a/app/scripts/modules/core/src/modal/wizard/WizardModal.tsx
+++ b/app/scripts/modules/core/src/modal/wizard/WizardModal.tsx
@@ -155,7 +155,7 @@ export class WizardModal<T = {}> extends React.Component<IWizardModalProps<T>, I
     return mergedErrors;
   };
 
-  private revalidate = () => this.formikRef.current.getFormikBag().validateForm();
+  private revalidate = () => this.formikRef.current && this.formikRef.current.getFormikBag().validateForm();
 
   private setWaiting = (section: string, isWaiting: boolean): void => {
     const waiting = new Set(this.state.waiting);

--- a/app/scripts/modules/core/src/modal/wizard/WizardModal.tsx
+++ b/app/scripts/modules/core/src/modal/wizard/WizardModal.tsx
@@ -2,8 +2,9 @@ import * as React from 'react';
 import * as classNames from 'classnames';
 import { Formik, Form, FormikValues } from 'formik';
 import { Modal } from 'react-bootstrap';
+import { merge } from 'lodash';
 
-import { TaskMonitor } from 'core';
+import { TaskMonitor } from 'core/task';
 import { IModalComponentProps, Tooltip } from 'core/presentation';
 import { NgReact } from 'core/reactShims';
 import { Spinner } from 'core/widgets';
@@ -149,9 +150,9 @@ export class WizardModal<T = {}> extends React.Component<IWizardModalProps<T>, I
       errors.push(pageErrors);
     });
     errors.push(this.props.validate(values));
-    const flattenedErrors = Object.assign({}, ...errors);
-    this.setState({ pageErrors: newPageErrors, formInvalid: Object.keys(flattenedErrors).length > 0 });
-    return flattenedErrors;
+    const mergedErrors = errors.reduce((mergeTarget, errorObj) => merge(mergeTarget, errorObj), {});
+    this.setState({ pageErrors: newPageErrors, formInvalid: Object.keys(mergedErrors).length > 0 });
+    return mergedErrors;
   };
 
   private revalidate = () => this.formikRef.current.getFormikBag().validateForm();


### PR DESCRIPTION
The errors object in Formik 1.x mirrors the shape of the form data.  This means idiomatic formik will set things like `errors.object.array[0] = 'This is the error message'`.

If wizard page 1 adds `errors.object.array[0] = 'error message'` and page 2 adds `errors.object.textfield = 'a different error'`, using a simple `Object.assign` will clobber `errors.object` and lose the errors from page 1.

Additionally, now that errors objects are deep objects, you cannot do `Object.keys(errors).map(key => errors[key])` to get a list of error messages.  Thus, the `flattenErrors` method which flattens errors to an object, i.e. from:

```js
errors = {
  object: {
    array: [
      'error message'
    ],
    textfield: 'a different error',
  }
};
```

to:

```js
{
  'errors.object.array[0]': 'error message',
  'errors.object.textfield': 'a different error',
}
```