### PR TITLE
feat(artifacts): infer kind from type if kind is not available

### DIFF
--- a/app/scripts/modules/core/src/artifact/expectedArtifact.service.spec.ts
+++ b/app/scripts/modules/core/src/artifact/expectedArtifact.service.spec.ts
@@ -1,0 +1,47 @@
+import { noop } from 'lodash';
+import { ExpectedArtifactService } from './expectedArtifact.service';
+import { IArtifact } from 'core/domain';
+import { Registry } from 'core';
+
+describe('ExpectedArtifactService', () => {
+  describe('getKind()', () => {
+    it('returns the kind stored on an artifact', () => {
+      const expectedKind = 'foo';
+      const artifact: IArtifact = {
+        kind: expectedKind,
+        id: 'artifact-id',
+      };
+      const kind = ExpectedArtifactService.getKind(artifact);
+      expect(kind).toEqual(expectedKind);
+    });
+
+    it('infers kind from type if no explicit kind is stored on the artifact', () => {
+      const expectedKind = 'my-custom-kind';
+      Registry.pipeline.registerArtifactKind({
+        label: 'foo',
+        type: 'my-custom-type',
+        description: 'foo',
+        key: expectedKind,
+        isDefault: false,
+        isMatch: false,
+        template: '',
+        controller: noop,
+      });
+      const artifact: IArtifact = {
+        id: 'artifact-id',
+        type: 'my-custom-type',
+      };
+      const kind = ExpectedArtifactService.getKind(artifact);
+      expect(kind).toEqual(expectedKind);
+    });
+
+    it('returns null kind if neither kind nor type are stored on artifact', () => {
+      const expectedKind: string = null;
+      const artifact: IArtifact = {
+        id: 'artifact-id',
+      };
+      const kind = ExpectedArtifactService.getKind(artifact);
+      expect(kind).toEqual(expectedKind);
+    });
+  });
+});

--- a/app/scripts/modules/core/src/artifact/expectedArtifact.service.ts
+++ b/app/scripts/modules/core/src/artifact/expectedArtifact.service.ts
@@ -88,4 +88,21 @@ export class ExpectedArtifactService {
       .forEach(s => sources.push(s));
     return sources;
   }
+
+  public static getKind(artifact: IArtifact): string {
+    if (artifact != null) {
+      if (artifact.kind) {
+        return artifact.kind;
+      } else {
+        const artifactType = artifact.type;
+        const inferredKindConfig = Registry.pipeline.getArtifactKinds().find(k => {
+          return k.type === artifactType;
+        });
+        if (inferredKindConfig != null) {
+          return inferredKindConfig.key;
+        }
+      }
+    }
+    return null;
+  }
 }

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/artifact.component.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/artifact.component.ts
@@ -11,7 +11,7 @@ import {
 } from 'angular';
 import { IArtifact, IArtifactKindConfig } from 'core/domain';
 import { Registry } from 'core/registry';
-import { AccountService, ArtifactIconService, IArtifactAccount } from 'core';
+import { AccountService, ArtifactIconService, ExpectedArtifactService, IArtifactAccount } from 'core';
 
 class ArtifactCtrl implements IController {
   public artifact: IArtifact;
@@ -81,7 +81,7 @@ class ArtifactCtrl implements IController {
   }
 
   public loadArtifactKind(): void {
-    const { kind } = this.artifact;
+    const kind = ExpectedArtifactService.getKind(this.artifact) || 'custom';
     if (!kind) {
       return;
     }

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/expectedArtifact.component.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/expectedArtifact.component.ts
@@ -1,5 +1,6 @@
 import { IAttributes, IComponentController, IComponentOptions, module } from 'angular';
 
+import { ExpectedArtifactService } from 'core';
 import { IExpectedArtifact } from 'core/domain';
 import { Registry } from 'core/registry';
 
@@ -20,14 +21,15 @@ class ExpectedArtifactController implements IComponentController {
       expectedArtifact: { useDefaultArtifact, defaultArtifact, matchArtifact },
     } = this;
     if (useDefaultArtifact && defaultArtifact.type == null) {
-      const defaultKey = 'default.' + matchArtifact.kind;
+      const matchKind = ExpectedArtifactService.getKind(matchArtifact);
+      const defaultKey = 'default.' + matchKind;
       const defaultKindConfig = Registry.pipeline.getArtifactKinds().find(kind => kind.key === defaultKey);
       if (defaultKindConfig) {
         defaultArtifact.type = defaultKindConfig.type;
         defaultArtifact.kind = defaultKindConfig.key;
       } else {
         defaultArtifact.type = matchArtifact.type;
-        defaultArtifact.kind = matchArtifact.kind;
+        defaultArtifact.kind = matchKind;
       }
     }
   }


### PR DESCRIPTION
Fixes https://github.com/spinnaker/spinnaker/issues/3491

This PR makes Deck a bit more resilient when an artifact doesn't include a kind string.

Previously, if an artifact did not have a kind:

![screen shot 2018-10-23 at 12 13 40 pm](https://user-images.githubusercontent.com/34253460/47374917-18522600-d6bd-11e8-8432-e1cb6a932082.png)

Now when kind is missing rely on the type, or failing that, assume kind is "custom":

![screen shot 2018-10-23 at 12 02 20 pm](https://user-images.githubusercontent.com/34253460/47374929-1daf7080-d6bd-11e8-91a4-f44bbd23e8da.png)

The kind select remains outlined in red since I didn't want a UI component to silently modify the artifact's data, but at least the user is still able to modify the content of the artifact.