### PR TITLE
fix(docker): fix binding of `handleRefreshImages` method #3514

### DIFF
--- a/app/scripts/modules/docker/src/image/DockerImageAndTagSelector.tsx
+++ b/app/scripts/modules/docker/src/image/DockerImageAndTagSelector.tsx
@@ -252,9 +252,9 @@ export class DockerImageAndTagSelector extends React.Component<
       });
   }
 
-  public handleRefreshImages(): void {
+  public handleRefreshImages = (): void => {
     this.refreshImages(this.props);
-  }
+  };
 
   public refreshImages(props: IDockerImageAndTagSelectorProps): void {
     this.initializeImages(props, true);


### PR DESCRIPTION
Per [this issue](https://github.com/spinnaker/spinnaker/issues/3514), refreshing Docker images was failing with the following error due to unbound method:

![console output](https://user-images.githubusercontent.com/3867275/47562889-5307c880-d920-11e8-908f-8a12725333dd.png)

