### PR TITLE
feat(core): Support a date constraint on trigger parameters

### DIFF
--- a/app/scripts/modules/core/src/pipeline/manualExecution/manualPipelineExecution.controller.js
+++ b/app/scripts/modules/core/src/pipeline/manualExecution/manualPipelineExecution.controller.js
@@ -259,6 +259,19 @@ module.exports = angular
       return this.command.pipeline.stages.filter(stage => stage.type === stageType);
     };
 
+    this.dateOptions = {
+      dateDisabled: false,
+      showWeeks: false,
+      minDate: new Date(),
+      startingDay: 1,
+    };
+
+    this.dateOpened = {};
+
+    this.openDate = parameterName => {
+      this.dateOpened[parameterName] = true;
+    };
+
     /**
      * Initialization
      */

--- a/app/scripts/modules/core/src/pipeline/manualExecution/manualPipelineExecution.html
+++ b/app/scripts/modules/core/src/pipeline/manualExecution/manualPipelineExecution.html
@@ -80,7 +80,25 @@
             <span ng-if="parameter.required">*</span>
             <help-field content="{{parameter.description}}" ng-if="parameter.description"></help-field>
           </div>
-          <div class="col-md-6" ng-if="!parameter.hasOptions">
+          <div class="col-md-6" ng-if="!parameter.hasOptions && parameter.constraint === 'date'">
+            <p class="input-group">
+              <input type="text"
+                class="form-control input-sm"
+                uib-datepicker-popup
+                datepicker-append-to-body="true"
+                ng-model="parameter.model"
+                ng-change="vm.parameters[parameter.name] = parameter.model.toISOString().slice(0,10); vm.updateParameters();"
+                is-open="vm.dateOpened[parameter.name]"
+                datepicker-options="vm.dateOptions"
+                ng-required="true"
+                close-text="Close"
+              />
+              <span class="input-group-btn">
+                <button type="button" style="padding: 4px 8px;" class="btn btn-default" ng-click="vm.openDate(parameter.name)"><i class="glyphicon glyphicon-calendar"></i></button>
+              </span>
+            </p>
+          </div>
+          <div class="col-md-6" ng-if="!parameter.hasOptions && !parameter.constraint">
             <input class="form-control input-sm"
                    ng-model="vm.parameters[parameter.name]"
                    ng-change="vm.updateParameters()"

--- a/app/scripts/modules/core/src/pipeline/manualExecution/manualPipelineExecution.less
+++ b/app/scripts/modules/core/src/pipeline/manualExecution/manualPipelineExecution.less
@@ -10,3 +10,7 @@
     padding-left: 20px;
   }
 }
+
+.uib-datepicker-popup.dropdown-menu {
+  z-index: var(--layer-critical);
+}


### PR DESCRIPTION
Support a date picker for trigger parameters.

If the parameter has `"constraint": "date"` in the parameter config in the pipeline JSON, then when manually triggering the pipeline, the input for the parameter will only accept a valid date string and will have a date picker.

Currently no UI to actually pick the constraint type, JSON only feature right now.

<img width="647" alt="screen shot 2018-10-29 at 11 24 28 am" src="https://user-images.githubusercontent.com/56971/47673691-9bb6c000-db72-11e8-9c05-4bc0b5a540e5.png">

@asher FYI