### PR TITLE
fix(appengine): selectedProvider received as null when Create Server Group btn clicked

### DIFF
--- a/app/scripts/modules/appengine/src/serverGroup/configure/serverGroupCommandBuilder.service.ts
+++ b/app/scripts/modules/appengine/src/serverGroup/configure/serverGroupCommandBuilder.service.ts
@@ -99,9 +99,12 @@ export class AppengineServerGroupCommandBuilder {
 
   public buildNewServerGroupCommand(
     app: Application,
-    selectedProvider = 'appengine',
+    selectedProvider: string,
     mode = 'create',
   ): IPromise<IAppengineServerGroupCommand> {
+    if (selectedProvider == null) {
+      selectedProvider = 'appengine';
+    }
     const dataToFetch = {
       accounts: AccountService.getAllAccountDetailsForProvider('appengine'),
       storageAccounts: StorageAccountReader.getStorageAccounts(),


### PR DESCRIPTION
Before:

![appengine_broken](https://user-images.githubusercontent.com/34253460/47677320-29a3a280-db95-11e8-9c81-a5fe1815f7a6.gif)


After:

![appengine_fixed](https://user-images.githubusercontent.com/34253460/47677334-2f998380-db95-11e8-87d4-a47407d07086.gif)
