### PR TITLE
fix(artifacts): hide artifact editor when source of manifest is text

### DIFF
--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestConfig.html
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestConfig.html
@@ -49,7 +49,7 @@
         >
       </artifact-account-selector-react>
     </stage-config-field>
-    <expected-artifact-editor-react ng-if="ctrl.$scope.showCreateArtifactForm"
+    <expected-artifact-editor-react ng-if="stage.source === ctrl.artifactSource && ctrl.$scope.showCreateArtifactForm"
                                     kinds="ctrl.manifestArtifactDelegate.getSupportedArtifactKinds()"
                                     sources="ctrl.manifestArtifactDelegate.getExpectedArtifactSources()"
                                     accounts="ctrl.manifestArtifactDelegate.getExpectedArtifactAccounts()"


### PR DESCRIPTION
Fixes https://github.com/spinnaker/spinnaker/issues/3529

Before:

![manifest_source_artifact_to_text](https://user-images.githubusercontent.com/34253460/47747601-178e3680-dc5f-11e8-839e-a4e20f2a5c0f.gif)

-----

After:

![manifest_source_artifact_to_text_fixed](https://user-images.githubusercontent.com/34253460/47747603-1a892700-dc5f-11e8-86b4-b1341acf0425.gif)
