### PR TITLE
chore(dependencies): bump deck-kayenta to 0.0.63

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@fortawesome/fontawesome-free-webfonts": "^1.0.9",
-    "@spinnaker/kayenta": "0.0.57",
+    "@spinnaker/kayenta": "0.0.63",
     "@spinnaker/styleguide": "^1.0.0",
     "@types/react-tether": "^0.5.3",
     "@uirouter/react-hybrid": "0.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -81,9 +81,10 @@
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
 
-"@spinnaker/kayenta@0.0.57":
-  version "0.0.57"
-  resolved "https://registry.yarnpkg.com/@spinnaker/kayenta/-/kayenta-0.0.57.tgz#b47afe604aed479364d7efa54d3d7a8092959fd6"
+"@spinnaker/kayenta@0.0.63":
+  version "0.0.63"
+  resolved "https://registry.yarnpkg.com/@spinnaker/kayenta/-/kayenta-0.0.63.tgz#09448a2fc7c5c68463bdee50d3352bc80cd5b4b0"
+  integrity sha512-bDWVCoLuH6zOJ+EXvn4Y/pjqYEAi1zKEjN+PQorF0szmIqJlP9sndrpVKaYUqja5BqE76usQK5Me/X3eX8meSw==
   dependencies:
     "@fortawesome/fontawesome-free-webfonts" "^1.0.4"
     "@types/plotly.js" "^1.28.12"


### PR DESCRIPTION
Cherry-pick of https://github.com/spinnaker/deck/pull/5949 into 1.10 branch.

Fixes https://github.com/spinnaker/spinnaker/issues/3190