### PR TITLE
chore(amazon): Bump version to 0.0.132

### DIFF
--- a/app/scripts/modules/amazon/package.json
+++ b/app/scripts/modules/amazon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/amazon",
-  "version": "0.0.131",
+  "version": "0.0.132",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
aa204d4e35a2073c4301f5510ee956801b03dbf3 fix(amazon/deploy): Fix clearing invalid security groups (#5948)
