### PR TITLE
feat(kubernetes): include server group manager name in clickable clusters box

### DIFF
--- a/app/scripts/modules/core/src/serverGroupManager/ServerGroupManager.tsx
+++ b/app/scripts/modules/core/src/serverGroupManager/ServerGroupManager.tsx
@@ -65,7 +65,7 @@ export class ServerGroupManager extends React.Component<IServerGroupManagerProps
   };
 
   public render() {
-    const { application, sortFilter, grouping, serverGroups } = this.props;
+    const { application, sortFilter, grouping, serverGroups, manager } = this.props;
     const classes = {
       active: this.isSelected(),
       clickable: true,
@@ -79,6 +79,7 @@ export class ServerGroupManager extends React.Component<IServerGroupManagerProps
           onClick={this.handleClick}
           health={this.buildHealthCounts()}
           provider={serverGroups[0].type}
+          heading={manager}
         />
 
         {serverGroups.map((sg: IServerGroup) => (

--- a/app/scripts/modules/core/src/serverGroupManager/ServerGroupManagerHeading.tsx
+++ b/app/scripts/modules/core/src/serverGroupManager/ServerGroupManagerHeading.tsx
@@ -5,14 +5,16 @@ import { CloudProviderLogo, HealthCounts, IInstanceCounts } from 'core';
 export interface IServerGroupManagerHeadingProps {
   health: IInstanceCounts;
   provider: string;
+  heading: string;
   onClick(event: React.MouseEvent<HTMLElement>): void;
 }
 
-export const ServerGroupManagerHeading = ({ onClick, health, provider }: IServerGroupManagerHeadingProps) => {
+export const ServerGroupManagerHeading = ({ onClick, health, provider, heading }: IServerGroupManagerHeadingProps) => {
   return (
     <div className={`flex-container-h baseline server-group-title`} onClick={onClick}>
       <div className="flex-container-h baseline section-title">
         <CloudProviderLogo provider={provider} height="16px" width="16px" />
+        {heading}
       </div>
       <div className="flex-container-h baseline flex-pull-right">
         <HealthCounts container={health} />


### PR DESCRIPTION
Fixes https://github.com/spinnaker/spinnaker/issues/3516

Before:

![screen shot 2018-11-02 at 5 10 49 pm](https://user-images.githubusercontent.com/34253460/47940809-4821da80-dec2-11e8-94e6-0603b9cfb812.png)

After:

![screen shot 2018-11-02 at 5 04 22 pm](https://user-images.githubusercontent.com/34253460/47940618-91255f00-dec1-11e8-9488-247a5512f6fd.png)

Open to suggestions of a better way to indicate clickability. The duplication definitely isn't ideal.