### PR TITLE
fix(core/presentation): change warning class to match class applied…

### DIFF
--- a/app/scripts/modules/core/src/application/modal/validation/applicationNameValidationMessages.component.ts
+++ b/app/scripts/modules/core/src/application/modal/validation/applicationNameValidationMessages.component.ts
@@ -23,7 +23,7 @@ class ApplicationNameValidationMessagesComponent implements ng.IComponentOptions
   public controller: any = ApplicationNameValidationMessagesController;
   public template = `
     <div class="form-group row slide-in" ng-if="$ctrl.messages.warnings.length">
-      <div class="col-sm-9 col-sm-offset-3 warn-message" ng-repeat="warning in $ctrl.messages.warnings">
+      <div class="col-sm-9 col-sm-offset-3 warning-message" ng-repeat="warning in $ctrl.messages.warnings">
         <cloud-provider-logo provider="warning.cloudProvider" height="'16px'" width="'16px'"></cloud-provider-logo>
         {{warning.message}}
       </div>

--- a/app/scripts/modules/core/src/application/modal/validation/applicationNameValidationMessages.directive.html
+++ b/app/scripts/modules/core/src/application/modal/validation/applicationNameValidationMessages.directive.html
@@ -1,5 +1,5 @@
 <div class="form-group row slide-in" ng-if="vm.warnings.length">
-  <div class="col-sm-9 col-sm-offset-3 warn-message" ng-repeat="warning in vm.warnings">
+  <div class="col-sm-9 col-sm-offset-3 warning-message" ng-repeat="warning in vm.warnings">
     <cloud-provider-logo provider="warning.cloudProvider" height="'16px'" width="'16px'"></cloud-provider-logo>
     {{warning.message}}
   </div>

--- a/app/scripts/modules/core/src/presentation/main.less
+++ b/app/scripts/modules/core/src/presentation/main.less
@@ -879,7 +879,7 @@ select:invalid {
   color: var(--color-danger);
 }
 
-.warn-message {
+.warning-message {
   text-align: left;
   display: block;
   font-weight: 600;


### PR DESCRIPTION
…by ValidationMessage component

Change class `warn-message` to `warning-message` to match class name applied by `ValidationMessage` component of type `warning`: https://github.com/spinnaker/deck/blob/master/app/scripts/modules/core/src/validation/ValidationMessage.tsx#L9

Needed so warnings are styled appropriately with incoming deck-kayenta changes to filter template editing.
