### PR TITLE
fix(docker): fix binding of `handleRefreshImages` method #3514

### DIFF
--- a/app/scripts/modules/docker/src/image/DockerImageAndTagSelector.tsx
+++ b/app/scripts/modules/docker/src/image/DockerImageAndTagSelector.tsx
@@ -246,9 +246,9 @@ export class DockerImageAndTagSelector extends React.Component<
       });
   }
 
-  public handleRefreshImages(): void {
+  public handleRefreshImages = (): void => {
     this.refreshImages(this.props);
-  }
+  };
 
   public refreshImages(props: IDockerImageAndTagSelectorProps): void {
     this.initializeImages(props, true);


### PR DESCRIPTION
Cherry-pick of https://github.com/spinnaker/deck/pull/5902 into 1.10 per request from https://github.com/spinnaker/deck/pull/5902#issuecomment-436238264