### PR TITLE
fix(kubernetes): defaults can be passed in as null

### DIFF
--- a/app/scripts/modules/kubernetes/src/serverGroup/configure/CommandBuilder.js
+++ b/app/scripts/modules/kubernetes/src/serverGroup/configure/CommandBuilder.js
@@ -7,7 +7,10 @@ module.exports = angular
     require('../../cluster/cluster.kubernetes.module.js').name,
   ])
   .factory('kubernetesServerGroupCommandBuilder', function($q, kubernetesClusterCommandBuilder) {
-    function buildNewServerGroupCommand(application, defaults = {}) {
+    function buildNewServerGroupCommand(application, defaults) {
+      if (defaults == null) {
+        defaults = {};
+      }
       var command = kubernetesClusterCommandBuilder.buildNewClusterCommand(application, defaults);
       command.targetSize = 1;
 


### PR DESCRIPTION
I think this fixes https://github.com/spinnaker/spinnaker/issues/3544 and https://github.com/spinnaker/spinnaker/issues/3559