### PR TITLE
fix(kubernetes): add k8s kind in artifact icon list

### DIFF
--- a/app/scripts/modules/core/src/artifact/ArtifactTypes.ts
+++ b/app/scripts/modules/core/src/artifact/ArtifactTypes.ts
@@ -6,7 +6,7 @@ export const ArtifactTypePatterns = {
   GITHUB_FILE: /github\/file/,
   GITLAB_FILE: /gitlab\/file/,
   GCE_MACHINE_IMAGE: /gce\/image/,
-  KUBERNETES: /kubernetes\/.*/,
+  KUBERNETES: /kubernetes\/(.*)/,
   S3_OBJECT: /s3\/object/,
   HELM_CHART: /helm\/chart/,
 };

--- a/app/scripts/modules/core/src/artifact/react/ArtifactIconList.tsx
+++ b/app/scripts/modules/core/src/artifact/react/ArtifactIconList.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
+import { isString } from 'lodash';
 import { IArtifact } from 'core/domain';
-import { ArtifactIconService } from 'core/artifact';
+import { ArtifactIconService, ArtifactTypePatterns } from 'core/artifact';
 
 export interface IArtifactIconListProps {
   artifacts: IArtifact[];
@@ -9,13 +10,23 @@ export interface IArtifactIconListProps {
 export const ArtifactIconList = (props: IArtifactIconListProps): any => {
   return props.artifacts.map((artifact, i) => {
     const { location, reference, type } = artifact;
+    let { name } = artifact;
     const iconPath = ArtifactIconService.getPath(type);
     const key = `${location || ''}${type || ''}${reference || ''}` || String(i);
+    let title = type;
+    if (isString(type) && type.length > 0) {
+      const k8sKindMatch = type.match(ArtifactTypePatterns.KUBERNETES);
+      if (k8sKindMatch != null && k8sKindMatch[1].length > 0) {
+        const kind = k8sKindMatch[1].substr(0, 1).toUpperCase() + k8sKindMatch[1].substr(1);
+        name = `${kind} ${name}`;
+        title = name;
+      }
+    }
     return (
-      <div key={key} className="artifact-list-item" title={artifact.type}>
+      <div key={key} className="artifact-list-item" title={title}>
         {iconPath && <img className="artifact-list-item-icon" width="20" height="20" src={iconPath} />}
         <span className="artifact-list-item-name">
-          {artifact.name}
+          {name}
           {artifact.version && <span> - {artifact.version}</span>}
         </span>
       </div>


### PR DESCRIPTION
Fixes https://github.com/spinnaker/spinnaker/issues/3567

K8s kind now appears in list alongside artifact name:

<img width="429" alt="screen shot 2018-11-06 at 3 45 37 pm" src="https://user-images.githubusercontent.com/34253460/48092682-5716ce80-e1db-11e8-954a-562e8cb539d5.png">
