### PR TITLE
feat(artifacts): Allow preconfigured webhooks to produce artifacts

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/webhook/webhookStage.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/webhook/webhookStage.ts
@@ -160,6 +160,7 @@ module(WEBHOOK_STAGE, [])
             key: preconfiguredWebhook.type,
             alias: 'preconfiguredWebhook',
             addAliasToConfig: true,
+            producesArtifacts: true,
             restartable: true,
             controller: 'WebhookStageCtrl',
             controllerAs: '$ctrl',


### PR DESCRIPTION
Allow preconfigured webhooks to produce artifacts in deck. Previously preconfigured webhooks were not able to configure expected artifacts from deck. It appears this will enable that. I am not sure but I think this will work with orca as-is.

Everything else seems to be there for this to work?