### PR TITLE
refactor(docker): Consolidate and clean up image selector functions

### DIFF
--- a/app/scripts/modules/docker/src/image/DockerImageAndTagSelector.tsx
+++ b/app/scripts/modules/docker/src/image/DockerImageAndTagSelector.tsx
@@ -5,6 +5,7 @@ import { groupBy, reduce, trim, uniq } from 'lodash';
 import { AccountService, HelpField, IAccount, IFindImageParams, Tooltip } from '@spinnaker/core';
 
 import { DockerImageReader, IDockerImage } from './DockerImageReader';
+import { DockerImageUtils, IDockerImageParts } from './DockerImageUtils';
 
 export interface IDockerImageAndTagChanges {
   account?: string;
@@ -12,10 +13,12 @@ export interface IDockerImageAndTagChanges {
   registry?: string;
   repository?: string;
   tag?: string;
+  imageId?: string;
 }
 
 export interface IDockerImageAndTagSelectorProps {
   specifyTagByRegex: boolean;
+  imageId: string;
   organization: string;
   registry: string;
   repository: string;
@@ -33,9 +36,7 @@ export interface IDockerImageAndTagSelectorState {
   imagesLoaded: boolean;
   imagesLoading: boolean;
   imagesRefreshing: boolean;
-  organizationMap: { [key: string]: string[] };
   organizationOptions: Array<Option<string>>;
-  repositoryMap: { [key: string]: string[] };
   repositoryOptions: Array<Option<string>>;
   tagOptions: Array<Option<string>>;
 }
@@ -50,11 +51,17 @@ export class DockerImageAndTagSelector extends React.Component<
     organization: '',
     registry: '',
     repository: '',
-    tag: '',
   };
 
   private images: IDockerImage[];
   private accounts: string[];
+
+  private registryMap: { [key: string]: string };
+  private accountMap: { [key: string]: string[] };
+  private newAccounts: string[];
+  private organizationMap: { [key: string]: string[] };
+  private repositoryMap: { [key: string]: string[] };
+  private organizations: string[];
 
   public constructor(props: IDockerImageAndTagSelectorProps) {
     super(props);
@@ -71,9 +78,7 @@ export class DockerImageAndTagSelector extends React.Component<
       imagesLoaded: false,
       imagesLoading: false,
       imagesRefreshing: false,
-      organizationMap: {},
       organizationOptions,
-      repositoryMap: {},
       repositoryOptions,
       tagOptions,
     };
@@ -150,18 +155,17 @@ export class DockerImageAndTagSelector extends React.Component<
     return [];
   }
 
-  private getTags(repositoryMap: { [key: string]: string[] }, repository: string) {
-    let tag = this.props.tag;
+  private getTags(tag: string, repositoryMap: { [key: string]: string[] }, repository: string) {
     let tags: string[] = [];
     if (this.props.specifyTagByRegex) {
       if (tag && trim(tag) === '') {
-        tag = '';
+        tag = undefined;
       }
     } else {
       if (repositoryMap) {
         tags = repositoryMap[repository] || [];
         if (!tags.includes(tag) && tag && !tag.includes('${')) {
-          tag = '';
+          tag = undefined;
         }
       }
     }
@@ -170,12 +174,45 @@ export class DockerImageAndTagSelector extends React.Component<
   }
 
   public componentWillReceiveProps(nextProps: IDockerImageAndTagSelectorProps) {
-    if (!this.images || ['account', 'showRegistry'].some(key => (this.props as any)[key] !== (nextProps as any)[key])) {
+    if (
+      !this.images ||
+      ['account', 'showRegistry'].some(
+        (key: keyof IDockerImageAndTagSelectorProps) => this.props[key] !== nextProps[key],
+      )
+    ) {
       this.refreshImages(nextProps);
     } else if (
-      ['organization', 'registry', 'repository'].some(key => (this.props as any)[key] !== (nextProps as any)[key])
+      ['organization', 'registry', 'repository'].some(
+        (key: keyof IDockerImageAndTagSelectorProps) => this.props[key] !== nextProps[key],
+      )
     ) {
       this.updateThings(nextProps);
+    }
+  }
+
+  private synchronizeChanges(values: IDockerImageParts, registry: string) {
+    const { organization, repository, tag } = values;
+    if (this.props.onChange) {
+      const imageId = DockerImageUtils.generateImageId({ organization, repository, tag });
+      const changes: IDockerImageAndTagChanges = {};
+      if (tag !== this.props.tag) {
+        changes.tag = tag;
+      }
+      if (imageId !== this.props.imageId) {
+        changes.imageId = imageId;
+      }
+      if (organization !== this.props.organization) {
+        changes.organization = organization;
+      }
+      if (registry !== this.props.registry) {
+        changes.registry = registry;
+      }
+      if (repository !== this.props.repository) {
+        changes.repository = repository;
+      }
+      if (Object.keys(changes).length > 0) {
+        this.props.onChange(changes);
+      }
     }
   }
 
@@ -183,41 +220,30 @@ export class DockerImageAndTagSelector extends React.Component<
     let { organization, registry, repository } = props;
     const { account, showRegistry } = props;
 
-    const registryMap = this.getRegistryMap(this.images);
-    const accountMap = this.getAccountMap(this.images);
-    const newAccounts = this.accounts || Object.keys(accountMap);
-
-    const organizationMap = this.getOrganizationMap(this.images);
-    const repositoryMap = this.getRepositoryMap(this.images);
-    const organizations = this.getOrganizationsList(accountMap);
-
     organization =
-      !organizations.includes(organization) && organization && !organization.includes('${') ? '' : organization;
+      !this.organizations.includes(organization) && organization && !organization.includes('${') ? '' : organization;
 
     if (showRegistry) {
-      registry = registryMap[account];
+      registry = this.registryMap[account];
     }
 
-    const repositories = this.getRepositoryList(organizationMap, organization, registry);
+    const repositories = this.getRepositoryList(this.organizationMap, organization, registry);
 
     if (!repositories.includes(repository) && repository && !repository.includes('${')) {
       repository = '';
     }
 
-    const { tag, tags } = this.getTags(repositoryMap, repository);
-    if (this.props.onChange) {
-      this.props.onChange({ organization, registry, repository, tag });
-    }
+    const { tag, tags } = this.getTags(props.tag, this.repositoryMap, repository);
+
+    this.synchronizeChanges({ organization, repository, tag }, registry);
 
     this.setState({
-      accountOptions: newAccounts.sort().map(a => ({ label: a, value: a })), // def internal state
-      organizationOptions: organizations
+      accountOptions: this.newAccounts.sort().map(a => ({ label: a, value: a })),
+      organizationOptions: this.organizations
         .filter(o => o)
         .sort()
         .map(o => ({ label: o, value: o })),
-      imagesLoaded: true, // def internal state
-      organizationMap,
-      repositoryMap,
+      imagesLoaded: true,
       repositoryOptions: repositories.sort().map(r => ({ label: r, value: r })),
       tagOptions: tags.sort().map(t => ({ label: t, value: t })),
     });
@@ -242,6 +268,13 @@ export class DockerImageAndTagSelector extends React.Component<
     DockerImageReader.findImages(imageConfig)
       .then((images: IDockerImage[]) => {
         this.images = images;
+        this.registryMap = this.getRegistryMap(this.images);
+        this.accountMap = this.getAccountMap(this.images);
+        this.newAccounts = this.accounts || Object.keys(this.accountMap);
+
+        this.organizationMap = this.getOrganizationMap(this.images);
+        this.repositoryMap = this.getRepositoryMap(this.images);
+        this.organizations = this.getOrganizationsList(this.accountMap);
         this.updateThings(props);
       })
       .finally(() => {
@@ -284,13 +317,22 @@ export class DockerImageAndTagSelector extends React.Component<
   }
 
   private valueChanged(name: string, value: string) {
-    this.props.onChange && this.props.onChange({ [name]: value });
+    const changes = { [name]: value };
+    if (['organization', 'repository', 'tag'].some(n => n === name)) {
+      // values are parts of the image
+      const { organization, repository, tag } = this.props;
+      const imageParts = { ...{ organization, repository, tag }, ...changes };
+      const imageId = DockerImageUtils.generateImageId(imageParts);
+      changes.imageId = imageId;
+    }
+    this.props.onChange && this.props.onChange(changes);
   }
 
   public render() {
     const {
       account,
       fieldClass,
+      imageId,
       labelClass,
       organization,
       repository,
@@ -307,115 +349,141 @@ export class DockerImageAndTagSelector extends React.Component<
       tagOptions,
     } = this.state;
 
+    if (imageId && imageId.includes('${')) {
+      return (
+        <div className="form-group">
+          <div className={`sm-label-right ${labelClass}`}>Image ID</div>
+          <div className={fieldClass}>
+            <input
+              className="form-control input-sm"
+              value={imageId}
+              onChange={e => this.valueChanged('imageId', e.target.value)}
+            />
+          </div>
+        </div>
+      );
+    }
+
+    const Registry = showRegistry ? (
+      <div className="form-group">
+        <div className={`sm-label-right ${labelClass}`}>Registry Name</div>
+        <div className={fieldClass}>
+          <Select
+            value={account}
+            disabled={imagesRefreshing}
+            onChange={(o: Option<string>) => this.valueChanged('account', o ? o.value : '')}
+            options={accountOptions}
+            isLoading={imagesRefreshing}
+          />
+        </div>
+        <div className="col-md-1 text-center">
+          <Tooltip value={imagesRefreshing ? 'Images refreshing' : 'Refresh images list'}>
+            <a className="clickable" onClick={this.handleRefreshImages}>
+              <span className={`fa fa-sync-alt ${imagesRefreshing ? 'fa-spin' : ''}`} />
+            </a>
+          </Tooltip>
+        </div>
+      </div>
+    ) : null;
+
+    const Organization = (
+      <div className="form-group">
+        <div className={`sm-label-right ${labelClass}`}>Organization</div>
+        <div className={fieldClass}>
+          {organization.includes('${') ? (
+            <input
+              disabled={imagesRefreshing}
+              className="form-control input-sm"
+              value={organization}
+              onChange={e => this.valueChanged('organization', e.target.value)}
+            />
+          ) : (
+            <Select
+              value={organization}
+              disabled={imagesRefreshing}
+              onChange={(o: Option<string>) => this.valueChanged('organization', (o && o.value) || '')}
+              placeholder="No organization"
+              options={organizationOptions}
+              isLoading={imagesRefreshing}
+            />
+          )}
+        </div>
+      </div>
+    );
+
+    const Image = (
+      <div className="form-group">
+        <div className={`sm-label-right ${labelClass}`}>Image</div>
+        <div className={fieldClass}>
+          {repository.includes('${') ? (
+            <input
+              className="form-control input-sm"
+              disabled={imagesRefreshing}
+              value={repository}
+              onChange={e => this.valueChanged('repository', e.target.value)}
+            />
+          ) : (
+            <Select
+              value={repository}
+              disabled={imagesRefreshing}
+              onChange={(o: Option<string>) => this.valueChanged('repository', (o && o.value) || '')}
+              options={repositoryOptions}
+              required={true}
+              isLoading={imagesRefreshing}
+            />
+          )}
+        </div>
+      </div>
+    );
+
+    const Tag = specifyTagByRegex ? (
+      <div className="form-group">
+        <div className={`sm-label-right ${labelClass}`}>
+          Tag <HelpField id="pipeline.config.docker.trigger.tag" />
+        </div>
+        <div className={fieldClass}>
+          <input
+            type="text"
+            className="form-control input-sm"
+            value={tag || ''}
+            disabled={imagesRefreshing || !repository}
+            onChange={e => this.valueChanged('tag', e.target.value)}
+          />
+        </div>
+      </div>
+    ) : (
+      <div className="form-group">
+        <div className={`sm-label-right ${labelClass}`}>Tag</div>
+        <div className={fieldClass}>
+          {tag && tag.includes('${') ? (
+            <input
+              className="form-control input-sm"
+              disabled={imagesRefreshing}
+              value={tag || ''}
+              onChange={e => this.valueChanged('tag', e.target.value)}
+              required={true}
+            />
+          ) : (
+            <Select
+              value={tag || ''}
+              disabled={imagesRefreshing || !repository}
+              isLoading={imagesLoading}
+              onChange={(o: Option<string>) => this.valueChanged('tag', o ? o.value : undefined)}
+              options={tagOptions}
+              placeholder="No tag"
+              required={true}
+            />
+          )}
+        </div>
+      </div>
+    );
+
     return (
       <>
-        {showRegistry && (
-          <div className="form-group">
-            <div className={`sm-label-right ${labelClass}`}>Registry Name</div>
-            <div className={fieldClass}>
-              <Select
-                value={account}
-                disabled={imagesRefreshing}
-                onChange={(o: Option<string>) => this.valueChanged('account', o.value)}
-                options={accountOptions}
-                isLoading={imagesRefreshing}
-              />
-            </div>
-            <div className="col-md-1 text-center">
-              <Tooltip value={imagesRefreshing ? 'Images refreshing' : 'Refresh images list'}>
-                <a className="clickable" onClick={this.handleRefreshImages}>
-                  <span className={`fa fa-sync-alt ${imagesRefreshing ? 'fa-spin' : ''}`} />
-                </a>
-              </Tooltip>
-            </div>
-          </div>
-        )}
-        <div className="form-group">
-          <div className={`sm-label-right ${labelClass}`}>Organization</div>
-          <div className={fieldClass}>
-            {organization.includes('${') ? (
-              <input
-                disabled={imagesRefreshing}
-                className="form-control input-sm"
-                value={organization}
-                onChange={e => this.valueChanged('organization', e.target.value)}
-              />
-            ) : (
-              <Select
-                value={organization}
-                disabled={imagesRefreshing}
-                onChange={(o: Option<string>) => this.valueChanged('organization', (o && o.value) || '')}
-                placeholder="No organization"
-                options={organizationOptions}
-                isLoading={imagesRefreshing}
-              />
-            )}
-          </div>
-        </div>
-        <div className="form-group">
-          <div className={`sm-label-right ${labelClass}`}>Image</div>
-          <div className={fieldClass}>
-            {repository.includes('${') ? (
-              <input
-                className="form-control input-sm"
-                disabled={imagesRefreshing}
-                value={repository}
-                onChange={e => this.valueChanged('repository', e.target.value)}
-              />
-            ) : (
-              <Select
-                value={repository}
-                disabled={imagesRefreshing}
-                onChange={(o: Option<string>) => this.valueChanged('repository', (o && o.value) || '')}
-                options={repositoryOptions}
-                required={true}
-                isLoading={imagesRefreshing}
-              />
-            )}
-          </div>
-        </div>
-        {specifyTagByRegex && (
-          <div className="form-group">
-            <div className={`sm-label-right ${labelClass}`}>
-              Tag <HelpField id="pipeline.config.docker.trigger.tag" />
-            </div>
-            <div className={fieldClass}>
-              <input
-                type="text"
-                className="form-control input-sm"
-                value={tag}
-                disabled={imagesRefreshing || !repository}
-                onChange={e => this.valueChanged('tag', e.target.value)}
-              />
-            </div>
-          </div>
-        )}
-        {!specifyTagByRegex && (
-          <div className="form-group">
-            <div className={`sm-label-right ${labelClass}`}>Tag</div>
-            <div className={fieldClass}>
-              {tag.includes('${') ? (
-                <input
-                  className="form-control input-sm"
-                  disabled={imagesRefreshing}
-                  value={tag}
-                  onChange={e => this.valueChanged('tag', e.target.value)}
-                  required={true}
-                />
-              ) : (
-                <Select
-                  value={tag}
-                  disabled={imagesRefreshing || !repository}
-                  isLoading={imagesLoading}
-                  onChange={(o: Option<string>) => this.valueChanged('tag', o.value)}
-                  options={tagOptions}
-                  placeholder="No tag"
-                  required={true}
-                />
-              )}
-            </div>
-          </div>
-        )}
+        {Registry}
+        {Organization}
+        {Image}
+        {Tag}
       </>
     );
   }

--- a/app/scripts/modules/docker/src/image/DockerImageUtils.ts
+++ b/app/scripts/modules/docker/src/image/DockerImageUtils.ts
@@ -15,4 +15,12 @@ export class DockerImageUtils {
 
     return { organization, repository, tag };
   }
+
+  public static generateImageId(parts: IDockerImageParts): string {
+    if (!parts.repository || !parts.tag) {
+      return undefined;
+    }
+
+    return `${parts.repository}:${parts.tag}`;
+  }
 }

--- a/app/scripts/modules/docker/src/image/DockerImageUtils.ts
+++ b/app/scripts/modules/docker/src/image/DockerImageUtils.ts
@@ -2,6 +2,7 @@ export interface IDockerImageParts {
   organization: string;
   repository: string;
   tag?: string;
+  digest?: string;
 }
 
 export class DockerImageUtils {
@@ -11,16 +12,26 @@ export class DockerImageUtils {
     const organization = parts.length > 1 ? parts.shift() : '';
     const rest = parts.shift().split(':');
     const repository = organization.length > 0 ? `${organization}/${rest.shift()}` : rest.shift();
-    const tag = rest.shift();
 
-    return { organization, repository, tag };
+    const lookup = rest.shift();
+    let tag: string;
+    let digest: string;
+    if (lookup) {
+      if (lookup.startsWith('sha256:')) {
+        digest = lookup;
+      } else {
+        tag = lookup;
+      }
+    }
+
+    return { organization, repository, digest, tag };
   }
 
   public static generateImageId(parts: IDockerImageParts): string {
-    if (!parts.repository || !parts.tag) {
+    if (!parts.repository || !(parts.digest || parts.tag)) {
       return undefined;
     }
 
-    return `${parts.repository}:${parts.tag}`;
+    return `${parts.repository}:${parts.digest ? parts.digest : parts.tag}`;
   }
 }

--- a/app/scripts/modules/docker/src/pipeline/trigger/DockerTriggerConfig.tsx
+++ b/app/scripts/modules/docker/src/pipeline/trigger/DockerTriggerConfig.tsx
@@ -53,6 +53,7 @@ export class DockerTriggerConfig extends React.Component<IDockerTriggerConfigPro
           tag={trigger.tag}
           showRegistry={true}
           onChange={this.dockerChanged}
+          showDigest={false}
         />
 
         {fiatEnabled && (

--- a/app/scripts/modules/docker/src/pipeline/trigger/DockerTriggerConfig.tsx
+++ b/app/scripts/modules/docker/src/pipeline/trigger/DockerTriggerConfig.tsx
@@ -26,7 +26,9 @@ export class DockerTriggerConfig extends React.Component<IDockerTriggerConfigPro
   }
 
   private dockerChanged = (changes: IDockerImageAndTagChanges) => {
-    Object.assign(this.props.trigger, changes);
+    // Trigger doesn't use imageId.
+    const { imageId, ...rest } = changes;
+    Object.assign(this.props.trigger, rest);
     this.props.fieldUpdated();
     this.setState({});
   };
@@ -44,11 +46,11 @@ export class DockerTriggerConfig extends React.Component<IDockerTriggerConfigPro
       <div className="form-horizontal">
         <DockerImageAndTagSelector
           specifyTagByRegex={true}
-          account={trigger.account || ''}
-          organization={trigger.organization || ''}
-          registry={trigger.registry || ''}
-          repository={trigger.repository || ''}
-          tag={trigger.tag || ''}
+          account={trigger.account}
+          organization={trigger.organization}
+          registry={trigger.registry}
+          repository={trigger.repository}
+          tag={trigger.tag}
           showRegistry={true}
           onChange={this.dockerChanged}
         />

--- a/app/scripts/modules/titus/src/pipeline/stages/runJob/TitusRunJobStageConfig.tsx
+++ b/app/scripts/modules/titus/src/pipeline/stages/runJob/TitusRunJobStageConfig.tsx
@@ -184,6 +184,7 @@ export class TitusRunJobStageConfig extends React.Component<IStageConfigProps, I
         <DockerImageAndTagSelector
           specifyTagByRegex={false}
           account={stage.credentials}
+          digest={stage.digest}
           imageId={stage.cluster.imageId}
           organization={stage.organization}
           registry={stage.registry}

--- a/app/scripts/modules/titus/src/serverGroup/configure/ServerGroupCommandBuilder.js
+++ b/app/scripts/modules/titus/src/serverGroup/configure/ServerGroupCommandBuilder.js
@@ -56,6 +56,7 @@ module.exports = angular
         securityGroups: [],
         imageId: defaults.imageId,
         migrationPolicy: { type: 'systemDefault' },
+        digest: '',
         organization: '',
         tag: '',
         registry: '',
@@ -124,6 +125,7 @@ module.exports = angular
         },
         organization: '',
         tag: '',
+        digest: '',
         registry: '',
         repository: '',
       };

--- a/app/scripts/modules/titus/src/serverGroup/configure/serverGroupConfiguration.service.ts
+++ b/app/scripts/modules/titus/src/serverGroup/configure/serverGroupConfiguration.service.ts
@@ -47,7 +47,8 @@ export interface ITitusServerGroupCommand extends IServerGroupCommand {
   imageId: string;
   organization: string;
   repository: string;
-  tag: string;
+  tag?: string;
+  digest?: string;
   image: string;
   inService: boolean;
   resources: {

--- a/app/scripts/modules/titus/src/serverGroup/configure/wizard/pages/ServerGroupBasicSettings.tsx
+++ b/app/scripts/modules/titus/src/serverGroup/configure/wizard/pages/ServerGroupBasicSettings.tsx
@@ -47,7 +47,8 @@ class ServerGroupBasicSettingsImpl extends React.Component<
 
     const { values, setFieldValue } = this.props.formik;
     if (values.imageId && !values.imageId.includes('${')) {
-      const { organization, repository, tag } = DockerImageUtils.splitImageId(values.imageId);
+      const { digest, organization, repository, tag } = DockerImageUtils.splitImageId(values.imageId);
+      setFieldValue('digest', digest);
       setFieldValue('organization', organization);
       setFieldValue('repository', repository);
       setFieldValue('tag', tag);
@@ -247,6 +248,7 @@ class ServerGroupBasicSettingsImpl extends React.Component<
           <DockerImageAndTagSelector
             specifyTagByRegex={false}
             account={values.credentials}
+            digest={values.digest}
             imageId={values.imageId}
             organization={values.organization}
             registry={values.registry}


### PR DESCRIPTION
Be smarter about when we update docker image selector backing data, and consolidate the imageId generation into the control itself.