### PR TITLE
refactor(stages): Adding StageConfigWrapper for cleaner StageConfigs

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/StageConfigWrapper.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/StageConfigWrapper.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { IStageConfigProps } from 'core/pipeline';
 
 export interface IStageConfigWrapperProps extends IStageConfigProps {
-  component: typeof React.Component;
+  component: React.ComponentType<any>;
 }
 
 /* This wrapper component exists so that StageConfig components don't have to manually

--- a/app/scripts/modules/core/src/pipeline/config/stages/StageConfigWrapper.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/StageConfigWrapper.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+
+import { IStageConfigProps } from 'core/pipeline';
+
+export interface IStageConfigWrapperProps extends IStageConfigProps {
+  component: typeof React.Component;
+}
+
+/* This wrapper component exists so that StageConfig components don't have to manually
+ * call this.forceUpdate() after updating a stage field. The only reason it is currently
+ * needed is because the stage config object is managed in angular, above the render root.
+ * When it is eventually migrated to react, it will simply be part of the state of some
+ * parent component and this wrapper can be removed.
+ */
+
+export class StageConfigWrapper extends React.Component<IStageConfigWrapperProps> {
+  public render() {
+    const { component: StageConfig, updateStageField, ...otherProps } = this.props;
+    return (
+      <StageConfig
+        updateStageField={(changes: { [key: string]: any }) => {
+          updateStageField(changes);
+          this.forceUpdate();
+        }}
+        {...otherProps}
+      />
+    );
+  }
+}

--- a/app/scripts/modules/core/src/pipeline/config/stages/core/IStageConfigProps.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/core/IStageConfigProps.ts
@@ -5,5 +5,5 @@ export interface IStageConfigProps {
   application: Application;
   stage: IStage;
   stageFieldUpdated: () => void;
-  updateStageField: (changes: any) => void;
+  updateStageField: (changes: { [key: string]: any }) => void;
 }

--- a/app/scripts/modules/core/src/pipeline/config/stages/core/IStageConfigProps.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/core/IStageConfigProps.ts
@@ -5,4 +5,5 @@ export interface IStageConfigProps {
   application: Application;
   stage: IStage;
   stageFieldUpdated: () => void;
+  updateStageField: (changes: any) => void;
 }

--- a/app/scripts/modules/core/src/pipeline/config/stages/evaluateVariables/EvaluateVariablesStageConfig.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/evaluateVariables/EvaluateVariablesStageConfig.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { map, set } from 'lodash';
+import { map } from 'lodash';
 
 import { IStageConfigProps, StageConfigField } from 'core/pipeline';
 import { MapEditor } from 'core/forms';
@@ -14,14 +14,8 @@ export class EvaluateVariablesStageConfig extends React.Component<IStageConfigPr
     return map(variables, (value, key): IEvaluatedVariable => ({ key, value }));
   }
 
-  private stageFieldChanged = (fieldIndex: string, value: { [key: string]: string }) => {
-    set(this.props.stage, fieldIndex, this.expand(value));
-    this.props.stageFieldUpdated();
-    this.forceUpdate();
-  };
-
   private mapChanged = (key: string, values: { [key: string]: string }) => {
-    this.stageFieldChanged(key, values);
+    this.props.updateStageField({ [key]: this.expand(values) });
   };
 
   public render() {

--- a/app/scripts/modules/core/src/pipeline/config/stages/stage.module.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/stage.module.js
@@ -13,7 +13,6 @@ import { EDIT_STAGE_JSON_CONTROLLER } from './core/editStageJson.controller';
 import { STAGE_NAME } from './StageName';
 import { PipelineConfigService } from 'core/pipeline/config/services/PipelineConfigService';
 import { Registry } from 'core/registry';
-import { wrapStageConfig } from './wrapStageConfig';
 import { StageConfigWrapper } from './StageConfigWrapper';
 
 module.exports = angular

--- a/app/scripts/modules/core/src/pipeline/config/stages/stage.module.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/stage.module.js
@@ -3,7 +3,7 @@
 const angular = require('angular');
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { defaultsDeep } from 'lodash';
+import { defaultsDeep, extend } from 'lodash';
 
 import { AccountService } from 'core/account/AccountService';
 import { API } from 'core/api';
@@ -13,6 +13,8 @@ import { EDIT_STAGE_JSON_CONTROLLER } from './core/editStageJson.controller';
 import { STAGE_NAME } from './StageName';
 import { PipelineConfigService } from 'core/pipeline/config/services/PipelineConfigService';
 import { Registry } from 'core/registry';
+import { wrapStageConfig } from './wrapStageConfig';
+import { StageConfigWrapper } from './StageConfigWrapper';
 
 module.exports = angular
   .module('spinnaker.core.pipeline.config.stage', [
@@ -190,13 +192,17 @@ module.exports = angular
           applyConfigController(config, stageScope);
 
           if (config.component) {
-            const StageConfig = config.component;
             const props = {
               application: $scope.application,
               stageFieldUpdated: $scope.stageFieldUpdated,
+              updateStageField: changes => {
+                extend($scope.stage, changes);
+                $scope.stageFieldUpdated();
+              },
               stage: $scope.stage,
+              component: config.component,
             };
-            ReactDOM.render(React.createElement(StageConfig, props), stageDetailsNode);
+            ReactDOM.render(React.createElement(StageConfigWrapper, props), stageDetailsNode);
           } else {
             const template = $templateCache.get(config.templateUrl);
             const templateBody = $compile(template)(stageScope);


### PR DESCRIPTION
When stage fields are updated, instead of mutating props directly and force updating, `StageConfig` components should actually invoke a callback with the changes.

Before:
```
this.props.stage.variables = variables;
this.props.stageFieldUpdated();
this.forceUpdate();
```

After
```
this.props.updateStageField({variables});
```

`StageConfigWrapper` exists purely to perform the `this.forceUpdate()` because we wouldn't want all the `StageConfig` components to have to make that call (or even be aware of it). The reason the force update is needed is because `$scope.stage` is updated above the render root. Once that can be encapsulated in the state of some parent component (when we migrate it from angular to react), the force update and the wrapper component should no longer be needed.