### PR TITLE
fix(aws/serverGroups): always show AWS sever group settings

### DIFF
--- a/app/scripts/modules/amazon/src/serverGroup/details/sections/AdvancedSettingsDetailsSection.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/details/sections/AdvancedSettingsDetailsSection.tsx
@@ -21,30 +21,26 @@ export class AdvancedSettingsDetailsSection extends React.Component<IAmazonServe
 
     const asg = serverGroup.asg;
 
-    if (serverGroup.buildInfo && serverGroup.buildInfo.jenkins) {
-      return (
-        <CollapsibleSection heading="Advanced Settings">
-          <dl className="horizontal-when-filters-collapsed">
-            <dt>Cooldown</dt>
-            <dd>{asg.defaultCooldown} seconds</dd>
-            {asg.enabledMetrics.length > 0 && [
-              <dt key={'t-metrics'}>Enabled Metrics</dt>,
-              <dd key={'d-metrics'}>{asg.enabledMetrics.map(m => m.metric).join(', ')}</dd>,
-            ]}
-            <dt>Health Check Type</dt>
-            <dd>{asg.healthCheckType}</dd>
-            <dt>Grace Period</dt>
-            <dd>{asg.healthCheckGracePeriod} seconds</dd>
-            <dt>Termination Policies</dt>
-            <dd>{asg.terminationPolicies.join(', ')}</dd>
-          </dl>
-          <a className="clickable" onClick={this.editAdvancedSettings}>
-            Edit Advanced Settings
-          </a>
-        </CollapsibleSection>
-      );
-    }
-
-    return null;
+    return (
+      <CollapsibleSection heading="Advanced Settings">
+        <dl className="horizontal-when-filters-collapsed">
+          <dt>Cooldown</dt>
+          <dd>{asg.defaultCooldown} seconds</dd>
+          {asg.enabledMetrics.length > 0 && [
+            <dt key={'t-metrics'}>Enabled Metrics</dt>,
+            <dd key={'d-metrics'}>{asg.enabledMetrics.map(m => m.metric).join(', ')}</dd>,
+          ]}
+          <dt>Health Check Type</dt>
+          <dd>{asg.healthCheckType}</dd>
+          <dt>Grace Period</dt>
+          <dd>{asg.healthCheckGracePeriod} seconds</dd>
+          <dt>Termination Policies</dt>
+          <dd>{asg.terminationPolicies.join(', ')}</dd>
+        </dl>
+        <a className="clickable" onClick={this.editAdvancedSettings}>
+          Edit Advanced Settings
+        </a>
+      </CollapsibleSection>
+    );
   }
 }


### PR DESCRIPTION
I think this was disabled by accident. I don't see anything in the advanced settings to force it to be only enabled when `buildInfo` and `jenkins` properties exist