### PR TITLE
fix(amazon+titus/serverGroup): Revert custom sort logic no longer needed with react-select

### DIFF
--- a/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupConfiguration.service.ts
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupConfiguration.service.ts
@@ -472,14 +472,6 @@ export class AwsServerGroupConfigurationService {
       }
     }
     command.backingData.filtered.securityGroups = newRegionalSecurityGroups.sort((a, b) => {
-      if (command.securityGroups && !isExpression) {
-        if (command.securityGroups.includes(a.id)) {
-          return -1;
-        }
-        if (command.securityGroups.includes(b.id)) {
-          return 1;
-        }
-      }
       return a.name.localeCompare(b.name);
     });
     return result;

--- a/app/scripts/modules/titus/src/pipeline/stages/runJob/TitusSecurityGroupPicker.tsx
+++ b/app/scripts/modules/titus/src/pipeline/stages/runJob/TitusSecurityGroupPicker.tsx
@@ -118,15 +118,7 @@ export class TitusSecurityGroupPicker extends React.Component<
       groupsToEdit = matchedGroups.map(g => g.id);
       this.props.onChange(groupsToEdit);
     }
-    availableGroups = availableGroups.sort((a, b) => {
-      if (groupsToEdit.includes(a.id)) {
-        return -1;
-      }
-      if (groupsToEdit.includes(b.id)) {
-        return 1;
-      }
-      return a.name.localeCompare(b.name);
-    });
+    availableGroups = availableGroups.sort((a, b) => a.name.localeCompare(b.name));
     this.setState({ availableGroups, loaded: true, removedGroups });
   }
 


### PR DESCRIPTION
Two tests for serverGroupConfiguration service started failing because the expected sort order was different (perhaps due to a chrome update to `sort()` api?).  I found the original PR that introduced this sorting #2937 and it seems to introduced due to a requirement of ui-select.  React-select doesn't have the same data requirements, so sorting in this way is no longer necessary. 


