### PR TITLE
fix(build): Fix yarn lockfile

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -639,10 +639,10 @@
   dependencies:
     "@uirouter/core" "5.0.21"
 
-"@uirouter/core@5.0.1", "@uirouter/core@5.0.20", "@uirouter/core@5.0.21":
-  version "5.0.20"
-  resolved "https://registry.yarnpkg.com/@uirouter/core/-/core-5.0.20.tgz#9c27d8d14d50358040840fd00e9d38c36be1adc5"
-  integrity sha512-7MwtORbMF0UFCgMb+KcBAx+7EsYn/6sP5mEAjLNQq14AkHOJom5pPRE0N3nxduFbK3V2TXfsOX2UjtbkuXql+A==
+"@uirouter/core@5.0.1", "@uirouter/core@5.0.21":
+  version "5.0.21"
+  resolved "https://registry.yarnpkg.com/@uirouter/core/-/core-5.0.21.tgz#b6c4c311e9416a1e8ce76b072e042a60224d1b3a"
+  integrity sha512-QWHc0wT00qtYNkT0BXZaFNLLHZyux0qJjF8c2WklW5/Q0Z866NoJjJErEMWjQb/AR+olkR2NlfEEi8KTQU2OpA==
 
 "@uirouter/react-hybrid@0.3.6", "@uirouter/react-hybrid@^0.1.0":
   version "0.3.6"


### PR DESCRIPTION
It looks like the yarn lockfile wasn't properly updated after upgrading uirouter to 5.0.21; commit the update that is generated by running yarn on the current package.json.