### PR TITLE
fix(core): Fixed DeploymentStrategySelector not updating strategy

### DIFF
--- a/app/scripts/modules/core/src/deploymentStrategy/DeploymentStrategySelector.tsx
+++ b/app/scripts/modules/core/src/deploymentStrategy/DeploymentStrategySelector.tsx
@@ -64,7 +64,9 @@ export class DeploymentStrategySelector extends React.Component<
         newStrategy.initializationMethod(command);
       }
     }
-
+    // Usage of the angular <deployment-strategy-selector> do not have an onStrategyChange and simply expect command.strategy to be updated
+    // This was previously done by <ui-select ng-model="$ctrl.command.strategy">
+    command.strategy = strategy;
     if (onStrategyChange && newStrategy) {
       onStrategyChange(command, newStrategy);
     }


### PR DESCRIPTION
If `onStrategyChange` is not used, the new strategy doesn't go anywhere.

This used to be done by `<ui-select ng-model="$ctrl.command.strategy">`.