### PR TITLE
fix(provider/kubernetes): Change FileSystem to Filesystem

### DIFF
--- a/app/scripts/modules/kubernetes/src/container/securityContext/securityContextSelector.component.ts
+++ b/app/scripts/modules/kubernetes/src/container/securityContext/securityContextSelector.component.ts
@@ -29,7 +29,7 @@ class SecurityContextSelector implements IController {
     },
     {
       label: 'Read Only Root Filesystem',
-      model: 'readOnlyRootFileSystem',
+      model: 'readOnlyRootFilesystem',
       type: 'checkbox',
     },
     {


### PR DESCRIPTION

This addresses issue: #2993. The problem is that deck pushes `FileSystem` and cloud driver expects `Filesystem`. This causes the pod yamls to not be updated and thus the deployed state to not reflect state as displayed in deck.