### PR TITLE
fix(core/spel): Truncate spel autocomplete values to 90 chars

### DIFF
--- a/app/scripts/modules/core/src/widgets/spelText/spelAutocomplete.service.js
+++ b/app/scripts/modules/core/src/widgets/spelText/spelAutocomplete.service.js
@@ -121,9 +121,9 @@ module.exports = angular
     const leafTemplateFn = stage => {
       return `${
         stage.leaf
-      } <span class="glyphicon glyphicon-triangle-right spel-value-separator"></span> <span class="marker value">${
+      } <span class="glyphicon glyphicon-triangle-right spel-value-separator"></span> <span class="marker value" title="${
         stage.value
-      }</span>`;
+      }">${stage.value.length > 90 ? `${stage.value.slice(0, 90)}...` : stage.value}</span>`;
     };
 
     let addExecutionForAutocomplete = (pipeline, textcompleteConfig) => {


### PR DESCRIPTION
Turns out sometimes the values on spel autocomplete options can be _really_ long. I explicitly didn't want to invest any time into touching the old CSS that currently styles these dropdowns as it's done via `jquery-textcomplete` and I anticipate its days are numbered. So instead I changed the template string and added a `title` tooltip 🤷‍♂️ .

Because this is set at 90 characters I suspect folks will rarely ever run into it, but at least things won't look broken when there's a 500+ character value.