### PR TITLE
feat(core/utils): Add WorkerPool class to limit concurrency of promise based tasks

### DIFF
--- a/app/scripts/modules/core/src/utils/workerPool.spec.ts
+++ b/app/scripts/modules/core/src/utils/workerPool.spec.ts
@@ -1,0 +1,145 @@
+import { Task, WorkerPool } from './workerPool';
+
+const delay = (millis = 0) => new Promise<void>(resolve => setTimeout(resolve, millis));
+
+// Testing class to track running tasks
+class TaskTracker {
+  public runningTasks: number[] = [];
+
+  private start(id: number) {
+    this.runningTasks.push(id);
+  }
+
+  private stop(id: number) {
+    const { runningTasks } = this;
+    const idx = runningTasks.indexOf(id);
+    if (idx === -1) {
+      throw new Error(`Task ${id} not found in runningTasks ${JSON.stringify(runningTasks)}`);
+    }
+    runningTasks.splice(idx, 1);
+  }
+
+  public createTask(id: number, task: Task) {
+    return () => {
+      this.start(id);
+      const promise = task();
+      promise.then(() => this.stop(id), () => this.stop(id));
+      return promise;
+    };
+  }
+}
+
+describe('Worker pool', () => {
+  describe('.task()', () => {
+    it('registers a task and returns a promise that resolves to the task result', done => {
+      new WorkerPool(1)
+        .task(() => Promise.resolve(2))
+        .then(val => expect(val).toBe(2))
+        .then(done);
+    });
+
+    it('runs one task at a time when concurrency === 1', async done => {
+      const pool = new WorkerPool(1);
+      const tracker = new TaskTracker();
+
+      const promise1 = pool.task(tracker.createTask(1, () => delay().then(() => 'one')));
+      const promise2 = pool.task(tracker.createTask(2, () => delay().then(() => 'two')));
+      expect(tracker.runningTasks).toEqual([1]);
+
+      const result1 = await promise1;
+      expect(result1).toEqual('one');
+      expect(tracker.runningTasks).toEqual([2]);
+
+      const result2 = await promise2;
+      expect(result2).toEqual('two');
+      expect(tracker.runningTasks).toEqual([]);
+
+      done();
+    });
+
+    it('runs two tasks at a time when concurrency === 2', async done => {
+      const pool = new WorkerPool(2);
+      const tracker = new TaskTracker();
+
+      const promise1 = pool.task(tracker.createTask(1, () => delay().then(() => 'one')));
+      const promise2 = pool.task(tracker.createTask(2, () => delay().then(() => 'two')));
+      const promise3 = pool.task(tracker.createTask(3, () => delay().then(() => 'three')));
+      const promise4 = pool.task(tracker.createTask(4, () => delay().then(() => 'four')));
+
+      expect(tracker.runningTasks).toEqual([1, 2]);
+
+      const result1 = await promise1;
+      expect(result1).toEqual('one');
+      expect(tracker.runningTasks).toEqual([2, 3]);
+
+      const result2 = await promise2;
+      expect(result2).toEqual('two');
+      expect(tracker.runningTasks).toEqual([3, 4]);
+
+      const result3 = await promise3;
+      expect(result3).toEqual('three');
+      expect(tracker.runningTasks).toEqual([4]);
+
+      const result4 = await promise4;
+      expect(result4).toEqual('four');
+      expect(tracker.runningTasks).toEqual([]);
+
+      done();
+    });
+  });
+
+  describe('.cancelAll()', () => {
+    it('cancels running tasks and rejects their promises', async done => {
+      const pool = new WorkerPool(1);
+      const tracker = new TaskTracker();
+
+      const promise1 = pool.task(tracker.createTask(1, () => delay().then(() => 'one')));
+      const promise2 = pool.task(tracker.createTask(2, () => delay().then(() => 'two')));
+
+      const result1 = await promise1;
+      expect(result1).toEqual('one');
+
+      pool.cancelAll('cancel reason');
+      try {
+        const result2 = await promise2;
+        fail(`promise2 should have been rejected but was ${result2}`);
+      } catch (error) {
+        expect(error).toBe('cancel reason');
+        done();
+      }
+    });
+
+    it('cancels running AND pending tasks and rejects their promises', async done => {
+      const pool = new WorkerPool(1);
+      const tracker = new TaskTracker();
+
+      const promise1 = pool.task(tracker.createTask(1, () => delay().then(() => 'one')));
+      const promise2 = pool.task(tracker.createTask(2, () => delay().then(() => 'two')));
+      const promise3 = pool.task(tracker.createTask(2, () => delay().then(() => 'three')));
+
+      pool.cancelAll('cancel reason');
+
+      try {
+        const result1 = await promise1;
+        fail(`promise1 should have been rejected but was ${result1}`);
+      } catch (error) {
+        expect(error).toBe('cancel reason');
+      }
+
+      try {
+        const result2 = await promise2;
+        fail(`promise2 should have been rejected but was ${result2}`);
+      } catch (error) {
+        expect(error).toBe('cancel reason');
+      }
+
+      try {
+        const result3 = await promise3;
+        fail(`promise3 should have been rejected but was ${result3}`);
+      } catch (error) {
+        expect(error).toBe('cancel reason');
+        done();
+      }
+    });
+  });
+});

--- a/app/scripts/modules/core/src/utils/workerPool.ts
+++ b/app/scripts/modules/core/src/utils/workerPool.ts
@@ -1,0 +1,68 @@
+import { isUndefined, without } from 'lodash';
+
+export type Task<T = any> = () => Promise<T>;
+
+class Worker<T> {
+  public workerPromise: Promise<T>;
+  private resolve: (resolvedValue: T) => void;
+  private reject: (error: any) => void;
+
+  constructor(private task: Task<T>) {
+    this.workerPromise = new Promise<T>((resolve, reject) => Object.assign(this, { resolve, reject }));
+  }
+
+  public run(): Promise<T> {
+    const taskPromise = this.task();
+    taskPromise.then(this.resolve, this.reject);
+    return taskPromise;
+  }
+
+  public cancel(reason?: any) {
+    this.reject(isUndefined(reason) ? 'Cancelled' : reason);
+  }
+}
+
+export class WorkerPool<T = any> {
+  private queuedTasks: Array<Worker<T>> = [];
+  private runningTasks: Array<Worker<T>> = [];
+  constructor(private concurrency: number) {}
+
+  public task(task: Task<T>): Promise<T> {
+    const worker = new Worker(task);
+
+    this.queuedTasks.push(worker);
+    this.flush();
+
+    return worker.workerPromise;
+  }
+
+  public cancelAll(reason?: any) {
+    []
+      .concat(this.runningTasks)
+      .concat(this.queuedTasks)
+      .forEach(task => task.cancel(reason));
+    this.runningTasks = [];
+    this.queuedTasks = [];
+  }
+
+  private flush() {
+    const { queuedTasks, runningTasks } = this;
+
+    if (queuedTasks.length && runningTasks.length < this.concurrency) {
+      this.runTask(queuedTasks.shift());
+    }
+  }
+
+  private completeTask(worker: Worker<T>) {
+    this.runningTasks = without(this.runningTasks, worker);
+    this.flush();
+  }
+
+  private runTask(worker: Worker<T>) {
+    this.runningTasks.push(worker);
+    const done = () => {
+      return this.completeTask(worker);
+    };
+    worker.run().then(done, done);
+  }
+}

--- a/app/scripts/modules/core/src/utils/workerPool.ts
+++ b/app/scripts/modules/core/src/utils/workerPool.ts
@@ -60,9 +60,7 @@ export class WorkerPool<T = any> {
 
   private runTask(worker: Worker<T>) {
     this.runningTasks.push(worker);
-    const done = () => {
-      return this.completeTask(worker);
-    };
+    const done = () => this.completeTask(worker);
     worker.run().then(done, done);
   }
 }


### PR DESCRIPTION
@anotherchrisberry I generalized your worker pool code into a util class.  We can integrate this into the FP code some other day.

TLDR: 

```
const pool = new WorkerPool(2); // limit to 2 concurrent workers
pool.task(() => api.doStuff(1)).then(handleSuccess, handleFailure);
pool.task(() => api.doStuff(2)).then(handleSuccess, handleFailure);
pool.task(() => api.doStuff(3)).then(handleSuccess, handleFailure);
pool.task(() => api.doStuff(4)).then(handleSuccess, handleFailure);
```

And streaming via Rx https://stackblitz.com/edit/rxjs-workerpool?file=index.ts :

```ts
import { of } from 'rxjs'; 
import { map, mergeMap, combineLatest } from 'rxjs/operators';
import { WorkerPool } from './workerPool';

const delay = (millis = 0) => new Promise<void>(resolve => setTimeout(resolve, millis));
const randomDelay = (maxDelay: number) => delay(Math.floor(Math.random() * maxDelay));

const pool = new WorkerPool(2);

const source = of(1, 2, 3, 4, 5, 6, 7, 8, 9).pipe(
  map(x => `application${x}`),
  map(x => () => randomDelay(5000).then(() => `Hello ${x}!`)),
  mergeMap(task => pool.task(task)),
);

source.subscribe(x => console.log(x));
```