### PR TITLE
feat(provider/cf): option to define timeouts for service creation/destroy

### DIFF
--- a/app/scripts/modules/cloudfoundry/src/help/cloudfoundry.help.ts
+++ b/app/scripts/modules/cloudfoundry/src/help/cloudfoundry.help.ts
@@ -1,12 +1,16 @@
 import { HelpContentsRegistry } from '@spinnaker/core';
 
 const helpContents: { [key: string]: string } = {
+  'cf.service.deploy.timeout':
+    '(Optional) <b>Override Deploy Timeout</b> is the maximum amount of time allowed for service deployment before Spinnaker reports a timeout error (default: 450 seconds). If a timeout error is reported by Spinnaker, the request may still be processed and a service may still be created.',
+  'cf.service.destroy.timeout':
+    '(Optional) <b>Override Destroy Timeout</b> is the maximum amount of time allowed for service destruction before Spinnaker reports a timeout error (default: 450 seconds). If a timeout error is reported by Spinnaker, the request may still be processed and the service may be deleted.',
   'cf.serverGroup.stack':
     '(Optional) <b>Stack</b> is one of the core naming components of a cluster, used to create vertical stacks of dependent services for integration testing.',
   'cf.serverGroup.detail':
     '(Optional) <b>Detail</b> is a string of free-form alphanumeric characters and hyphens to describe any other variables.',
   'cf.serverGroup.startApplication':
-    '<b>Start on creation</b> is a boolean value that determines if the server group is started upon creation. Default value is <code>true</code>',
+    '<b>Start on creation</b> is a boolean value that determines if the server group is started upon creation. Default value is <code>true</code>.',
   'cf.serverGroup.routes':
     '(Optional) <b>Route</b> is a URI in the form of <code>some.host.some.domain[:9999][/some/path]</code> (port and path are optional). The domain has to be a valid domain in the CloudFoundry Org (Region) that this server group runs in.',
   'cf.artifact.package': `<p>This option allows you to create a new server group from an existing Droplet. You can use this to relocate an existing Cloud Foundry application from one space to another or to launch a clone of an application with different root filesystem or resource settings.</p>`,

--- a/app/scripts/modules/cloudfoundry/src/pipeline/stages/deployService/CloudfoundryDeployServiceStageConfig.tsx
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/stages/deployService/CloudfoundryDeployServiceStageConfig.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+
 import {
   AccountSelectField,
   AccountService,
@@ -185,9 +186,14 @@ export class CloudfoundryDeployServiceStageConfig extends React.Component<
     this.props.stageFieldUpdated();
   };
 
+  private timeoutUpdated = (event: React.ChangeEvent<HTMLInputElement>): void => {
+    this.props.stage.timeout = event.target.value;
+    this.props.stageFieldUpdated();
+  };
+
   public render() {
     const { stage } = this.props;
-    const { credentials, parameters, service, serviceName, servicePlan, tags } = stage;
+    const { credentials, parameters, service, serviceName, servicePlan, tags, timeout } = stage;
     const { accounts, newTag, regions, servicePlans, services } = this.state;
     return (
       <div className="form-horizontal cloudfoundry-deploy-service-stage">
@@ -287,6 +293,9 @@ export class CloudfoundryDeployServiceStageConfig extends React.Component<
         </StageConfigField>
         <StageConfigField label="Parameters">
           <textarea className="form-control" onChange={this.parametersUpdated} value={parameters} />
+        </StageConfigField>
+        <StageConfigField label="Override Deploy Timeout (Seconds)" helpKey="cf.service.deploy.timeout">
+          <input type="number" className="form-control" onChange={this.timeoutUpdated} value={timeout} />
         </StageConfigField>
       </div>
     );

--- a/app/scripts/modules/cloudfoundry/src/pipeline/stages/destroyService/CloudfoundryDestroyServiceStageConfig.tsx
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/stages/destroyService/CloudfoundryDestroyServiceStageConfig.tsx
@@ -75,9 +75,14 @@ export class CloudfoundryDestroyServiceStageConfig extends React.Component<
     this.props.stageFieldUpdated();
   };
 
+  private timeoutUpdated = (event: React.ChangeEvent<HTMLInputElement>): void => {
+    this.props.stage.timeout = event.target.value;
+    this.props.stageFieldUpdated();
+  };
+
   public render() {
     const { stage } = this.props;
-    const { credentials, serviceName } = stage;
+    const { credentials, serviceName, timeout } = stage;
     const { accounts, regions } = this.state;
     return (
       <div className="form-horizontal">
@@ -107,6 +112,9 @@ export class CloudfoundryDestroyServiceStageConfig extends React.Component<
             onChange={this.serviceNameUpdated}
             value={serviceName}
           />
+        </StageConfigField>
+        <StageConfigField label="Override Destroy Timeout (Seconds)" helpKey="cf.service.destroy.timeout">
+          <input type="number" className="form-control" onChange={this.timeoutUpdated} value={timeout} />
         </StageConfigField>
       </div>
     );


### PR DESCRIPTION
add an option to override the time out setting when deploying or destroying services in pipeline stages.

spinnaker/spinnaker#3637