### PR TITLE
fix(provider/cf): populate red/black strategy additional fields

### DIFF
--- a/app/scripts/modules/cloudfoundry/src/serverGroup/configure/serverGroupCommandBuilder.service.cf.ts
+++ b/app/scripts/modules/cloudfoundry/src/serverGroup/configure/serverGroupCommandBuilder.service.cf.ts
@@ -126,8 +126,11 @@ export class CloudFoundryServerGroupCommandBuilder {
     return this.buildNewServerGroupCommand(application, { mode: 'editPipeline' }).then(app => {
       app.credentials = originalCluster.account;
       app.artifact = originalCluster.artifact;
+      app.delayBeforeDisableSec = originalCluster.delayBeforeDisableSec;
       app.manifest = originalCluster.manifest;
+      app.maxRemainingAsgs = originalCluster.maxRemainingAsgs;
       app.region = originalCluster.region;
+      app.rollback = originalCluster.rollback;
       app.strategy = originalCluster.strategy;
       app.startApplication = originalCluster.startApplication;
       if (originalCluster.stack) {

--- a/app/scripts/modules/cloudfoundry/src/serverGroup/configure/serverGroupConfigurationModel.cf.ts
+++ b/app/scripts/modules/cloudfoundry/src/serverGroup/configure/serverGroupConfigurationModel.cf.ts
@@ -4,7 +4,10 @@ import { ICloudFoundryCluster, ICloudFoundryEnvVar } from 'cloudfoundry/domain';
 
 export interface ICloudFoundryCreateServerGroupCommand extends IServerGroupCommand {
   artifact: ICloudFoundryBinarySource;
+  delayBeforeDisableSec?: number;
   manifest: ICloudFoundryManifestSource;
+  maxRemainingAsgs?: number;
+  rollback?: boolean;
   startApplication: boolean;
 }
 
@@ -59,8 +62,11 @@ export interface ICloudFoundryDeployConfiguration {
   account: string;
   application: string;
   artifact: ICloudFoundryBinarySource;
+  delayBeforeDisableSec?: number;
   manifest: ICloudFoundryManifestSource;
+  maxRemainingAsgs?: number;
   region: string;
+  rollback?: boolean;
   stack?: string;
   freeFormDetails?: string;
   strategy?: string;


### PR DESCRIPTION
populate the red/black additional fields with the previously saved values from the pipeline stages.