### PR TITLE
refactor(core): remove unused applicationMap code from ApplicationReader

### DIFF
--- a/app/scripts/modules/core/src/application/service/ApplicationReader.ts
+++ b/app/scripts/modules/core/src/application/service/ApplicationReader.ts
@@ -25,20 +25,10 @@ export interface IApplicationSummary {
 }
 
 export class ApplicationReader {
-  private static applicationMap: Map<string, IApplicationSummary> = new Map<string, IApplicationSummary>();
-
-  public static listApplications(populateMap = false): IPromise<IApplicationSummary[]> {
+  public static listApplications(): IPromise<IApplicationSummary[]> {
     return API.all('applications')
       .useCache()
-      .getList()
-      .then((applications: IApplicationSummary[]) => {
-        if (populateMap) {
-          const tmpMap: Map<string, IApplicationSummary> = new Map<string, IApplicationSummary>();
-          applications.forEach((application: IApplicationSummary) => tmpMap.set(application.name, application));
-          this.applicationMap = tmpMap;
-        }
-        return applications;
-      });
+      .getList();
   }
 
   public static getApplication(name: string, expand = true): IPromise<Application> {
@@ -54,10 +44,6 @@ export class ApplicationReader {
         application.refresh();
         return application;
       });
-  }
-
-  public static getApplicationMap(): Map<string, IApplicationSummary> {
-    return this.applicationMap;
   }
 
   private static splitAttributes(attributes: any, fields: string[]) {

--- a/app/scripts/modules/core/src/cluster/clusterSearchResultType.tsx
+++ b/app/scripts/modules/core/src/cluster/clusterSearchResultType.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { uniqBy } from 'lodash';
 import { Observable } from 'rxjs';
 
-import { ApplicationReader, IApplicationSummary } from 'core/application';
 import { IQueryParams, urlBuilderRegistry } from 'core/navigation';
 import { ReactInjector } from 'core/reactShims';
 import { IServerGroupSearchResult } from 'core/serverGroup/serverGroupSearchResultType';
@@ -10,7 +9,6 @@ import { IServerGroupSearchResult } from 'core/serverGroup/serverGroupSearchResu
 import {
   searchResultTypeRegistry,
   AccountCell,
-  BasicCell,
   HrefCell,
   ISearchColumn,
   DefaultSearchResultTab,
@@ -29,7 +27,6 @@ export interface IClusterSearchResult extends ISearchResult {
   account: string;
   application: string;
   cluster: string;
-  email?: string;
   stack: string;
 }
 
@@ -42,7 +39,6 @@ class ClustersSearchResultType extends SearchResultType<IClusterSearchResult> {
   private cols: { [key: string]: ISearchColumn } = {
     CLUSTER: { key: 'cluster', label: 'Name' },
     ACCOUNT: { key: 'account' },
-    EMAIL: { key: 'email' },
   };
 
   public TabComponent = DefaultSearchResultTab;
@@ -51,7 +47,6 @@ class ClustersSearchResultType extends SearchResultType<IClusterSearchResult> {
     <TableHeader>
       <HeaderCell col={this.cols.CLUSTER} />
       <HeaderCell col={this.cols.ACCOUNT} />
-      <HeaderCell col={this.cols.EMAIL} />
     </TableHeader>
   );
 
@@ -66,7 +61,6 @@ class ClustersSearchResultType extends SearchResultType<IClusterSearchResult> {
           <TableRow key={itemKeyFn(item)}>
             <HrefCell item={item} col={this.cols.CLUSTER} />
             <AccountCell item={item} col={this.cols.ACCOUNT} />
-            <BasicCell item={item} col={this.cols.EMAIL} />
           </TableRow>
         ))}
       </TableBody>
@@ -88,8 +82,6 @@ class ClustersSearchResultType extends SearchResultType<IClusterSearchResult> {
     _params: IQueryParams,
     otherResults: Observable<ISearchResultSet>,
   ): Observable<ISearchResults<IClusterSearchResult>> {
-    const applications: Map<string, IApplicationSummary> = ApplicationReader.getApplicationMap();
-
     return otherResults
       .filter(resultSet => resultSet.type.id === 'serverGroups')
       .first()
@@ -102,12 +94,7 @@ class ClustersSearchResultType extends SearchResultType<IClusterSearchResult> {
         const serverGroups = results as IServerGroupSearchResult[];
         const searchResults = serverGroups.map(sg => this.makeSearchResult(sg));
         const clusters: IClusterSearchResult[] = uniqBy(searchResults, sg => `${sg.account}-${sg.cluster}`);
-        const clusterResults = clusters.map(cluster => {
-          const app = applications.get(cluster.application);
-          return { ...cluster, email: app && app.email };
-        });
-
-        return { results: clusterResults };
+        return { results: clusters };
       });
   }
 


### PR DESCRIPTION
We are never calling `listApplications` with the `populateMap` parameter, so...let's just remove it. It's there to populate an email field in cluster search results, but there was a regression at some point in the past year that stopped it from being populated and nobody noticed.