### PR TITLE
fix(core): Actually default to using new manual trigger endpoint

### DIFF
--- a/halconfig/settings.js
+++ b/halconfig/settings.js
@@ -200,6 +200,7 @@ window.spinnakerSettings = {
     roscoMode: true,
     snapshots: false,
     travis: travisEnabled,
+    triggerViaEcho: true,
     wercker: werckerEnabled,
     versionedProviders: true,
   },


### PR DESCRIPTION
The last change to default to using the new manual trigger endpoint
only affected users running a localgit setup; to default to enabled
for halyard users, we need to change this file.

To turn off the settings, users can add the following to
settings-local.js:
window.spinnakerSettings.feature.triggerViaEcho = false;