### PR TITLE
fix(core/entityTag): Use pipeline.id for pipeline entity tag's `entityId` value

### DIFF
--- a/app/scripts/modules/core/src/entityTag/EntityTagsReader.ts
+++ b/app/scripts/modules/core/src/entityTag/EntityTagsReader.ts
@@ -105,7 +105,7 @@ export class EntityTagsReader {
     const allTags = application.getDataSource('entityTags').data;
     const pipelineTags: IEntityTags[] = allTags.filter(t => t.entityRef.entityType === 'pipeline');
     application.getDataSource('pipelineConfigs').data.forEach((pipeline: IPipeline) => {
-      pipeline.entityTags = pipelineTags.find(t => t.entityRef.entityId === pipeline.name);
+      pipeline.entityTags = pipelineTags.find(t => t.entityRef.entityId === pipeline.id);
     });
   }
 

--- a/app/scripts/modules/core/src/entityTag/clusterTargetBuilder.ts
+++ b/app/scripts/modules/core/src/entityTag/clusterTargetBuilder.ts
@@ -1,5 +1,4 @@
 import { IServerGroup, IServerGroupManager } from 'core/domain';
-// import { NameUtils } from 'core/naming';
 
 import { IOwnerOption } from './EntityTagEditor';
 


### PR DESCRIPTION
Relates to #5498

A pipeline can be be renamed.  Seems like we should use the `pipeline.id` as the entity tag's `entityId` value instead of the `name`.

@nvndnl  PTAL