### PR TITLE
fix(artifact): hide artifact account selector when deploying manifest from inline text

### DIFF
--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestConfig.controller.ts
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestConfig.controller.ts
@@ -46,6 +46,7 @@ export class KubernetesV2DeployManifestConfigCtrl implements IController {
 
   public canShowAccountSelect() {
     return (
+      this.$scope.stage.source === this.artifactSource &&
       !this.$scope.showCreateArtifactForm &&
       (this.manifestArtifactController.accountsForArtifact.length > 1 &&
         this.manifestArtifactDelegate.getSelectedExpectedArtifact() != null)


### PR DESCRIPTION
Before: Artifact account select incorrectly appears when manifest source is set to 'text'

After: Artifact account select does not appear unless manifest source is set to 'artifact'