### PR TITLE
fix(titus): display security groups in details when firewalls feature…

### DIFF
--- a/app/scripts/modules/titus/src/domain/ITitusScalingPolicy.ts
+++ b/app/scripts/modules/titus/src/domain/ITitusScalingPolicy.ts
@@ -1,0 +1,5 @@
+import { IScalingPolicy, ITargetTrackingConfiguration } from '@spinnaker/amazon';
+
+export interface ITitusPolicy extends IScalingPolicy {
+  targetPolicyDescriptor?: ITargetTrackingConfiguration;
+}

--- a/app/scripts/modules/titus/src/domain/ITitusServerGroup.ts
+++ b/app/scripts/modules/titus/src/domain/ITitusServerGroup.ts
@@ -1,0 +1,20 @@
+import { IAccountDetails, IServerGroup } from '@spinnaker/core';
+import { IScalingPolicyView } from '@spinnaker/amazon';
+import { ITitusPolicy } from './ITitusScalingPolicy';
+
+export interface ITitusServerGroup extends IServerGroup {
+  image?: ITitusImage;
+  scalingPolicies?: ITitusPolicy[];
+  targetGroups?: string[];
+}
+
+export interface ITitusImage {
+  dockerImageDigest: string;
+  dockerImageName: string;
+  dockerImageVersion: string;
+}
+
+export interface ITitusServerGroupView extends ITitusServerGroup {
+  accountDetails?: IAccountDetails;
+  scalingPolicies: IScalingPolicyView[];
+}

--- a/app/scripts/modules/titus/src/domain/index.ts
+++ b/app/scripts/modules/titus/src/domain/index.ts
@@ -1,1 +1,3 @@
 export * from './ITitusCredentials';
+export * from './ITitusScalingPolicy';
+export * from './ITitusServerGroup';

--- a/app/scripts/modules/titus/src/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/titus/src/instance/details/instance.details.controller.js
@@ -33,7 +33,6 @@ module.exports = angular
     app,
     moniker,
     environment,
-    titusSecurityGroupReader,
   ) {
     // needed for standalone instances
     $scope.detailsTemplateUrl = CloudProviderRegistry.getValue('titus', 'instance.detailsTemplateUrl');
@@ -80,6 +79,7 @@ module.exports = angular
       app.serverGroups.data.some(function(serverGroup) {
         return serverGroup.instances.some(function(possibleInstance) {
           if (possibleInstance.id === instance.instanceId) {
+            $scope.serverGroup = serverGroup;
             instanceSummary = possibleInstance;
             loadBalancers = serverGroup.loadBalancers;
             account = serverGroup.account;
@@ -109,18 +109,6 @@ module.exports = angular
             $scope.instance.loadBalancers = loadBalancers;
             $scope.baseIpAddress = $scope.instance.placement.containerIp || $scope.instance.placement.host;
             $scope.instance.externalIpAddress = $scope.instance.placement.host;
-            if (instanceDetails.securityGroups) {
-              $scope.securityGroups = _.chain(instanceDetails.securityGroups)
-                .map(function(securityGroup) {
-                  return titusSecurityGroupReader.resolveIndexedSecurityGroup(
-                    app['securityGroupsIndex'],
-                    extraData,
-                    securityGroup.groupId,
-                  );
-                })
-                .compact()
-                .value();
-            }
             getBastionAddressForAccount(accountDetails, region);
             $scope.instance.titusUiEndpoint = this.titusUiEndpoint;
           }, autoClose);

--- a/app/scripts/modules/titus/src/instance/details/instanceDetails.html
+++ b/app/scripts/modules/titus/src/instance/details/instanceDetails.html
@@ -139,16 +139,7 @@
         <dd>{{instance.placement.host}}</dd>
       </dl>
     </collapsible-section>
-    <collapsible-section heading="{{firewallsLabel}}">
-      <ul>
-        <li ng-repeat="securityGroup in securityGroups | orderBy:'name'">
-          <a
-            ui-sref="^.firewallDetails({name: securityGroup.name, accountId: securityGroup.account, region: instance.region, vpcId: securityGroup.vpcId, provider: 'aws'})">
-            {{securityGroup.name}} ({{securityGroup.id}})
-          </a>
-        </li>
-      </ul>
-    </collapsible-section>
+    <titus-security-groups app="application" server-group="serverGroup" class="collapsible-section" style="display: block"></titus-security-groups>
     <!--<collapsible-section heading="Resources">
       <dl class="dl-horizontal dl-flex">
         <dt>CPU(s)</dt>

--- a/app/scripts/modules/titus/src/reactShims/titus.react.injector.ts
+++ b/app/scripts/modules/titus/src/reactShims/titus.react.injector.ts
@@ -7,6 +7,7 @@ export class TitusReactInject extends ReactInject {
   public get titusServerGroupTransformer() { return this.$injector.get('titusServerGroupTransformer') as any; }
   public get titusServerGroupCommandBuilder() { return this.$injector.get('titusServerGroupCommandBuilder') as any; }
   public get titusServerGroupConfigurationService() { return this.$injector.get('titusServerGroupConfigurationService') as any; }
+  public get titusSecurityGroupReader() { return this.$injector.get('titusSecurityGroupReader') as any; }
 
   public initialize($injector: IInjectorService) {
     this.$injector = $injector;

--- a/app/scripts/modules/titus/src/serverGroup/details/TitusSecurityGroups.tsx
+++ b/app/scripts/modules/titus/src/serverGroup/details/TitusSecurityGroups.tsx
@@ -1,0 +1,113 @@
+import * as React from 'react';
+import { sortBy } from 'lodash';
+
+import { UISref } from '@uirouter/react';
+import { UIRouterContextComponent } from '@uirouter/react-hybrid';
+
+import {
+  AccountService,
+  Application,
+  CollapsibleSection,
+  ISecurityGroup,
+  FirewallLabels,
+  ReactInjector,
+} from '@spinnaker/core';
+
+import { TitusReactInjector } from 'titus/reactShims';
+import { ITitusServerGroupView } from 'titus/domain';
+
+export interface ITitusServerGroupDetailsSectionProps {
+  app: Application;
+  serverGroup: ITitusServerGroupView;
+}
+
+export interface ISecurityGroupsDetailsSectionState {
+  securityGroups?: ISecurityGroup[];
+}
+
+export class TitusSecurityGroupsDetailsSection extends React.Component<
+  ITitusServerGroupDetailsSectionProps,
+  ISecurityGroupsDetailsSectionState
+> {
+  constructor(props: ITitusServerGroupDetailsSectionProps) {
+    super(props);
+    this.state = {};
+  }
+
+  public componentDidMount() {
+    this.configureSecurityGroups(this.props);
+  }
+
+  private configureSecurityGroups(props: ITitusServerGroupDetailsSectionProps): void {
+    const { app, serverGroup } = props;
+    const { region } = serverGroup;
+    if (app.securityGroupsIndex && serverGroup.accountDetails) {
+      const securityGroups = serverGroup.securityGroups.map(sgId =>
+        TitusReactInjector.titusSecurityGroupReader.resolveIndexedSecurityGroup(
+          app.securityGroupsIndex,
+          { account: serverGroup.accountDetails.awsAccount, region },
+          sgId,
+        ),
+      );
+      this.setState({ securityGroups });
+    } else {
+      AccountService.listAllAccounts('titus').then(accounts => {
+        const titusAccount = accounts.find(a => a.name === serverGroup.account);
+        if (titusAccount && titusAccount.awsAccount) {
+          ReactInjector.securityGroupReader.getAllSecurityGroups().then(allSecurityGroups => {
+            const regionalGroups = allSecurityGroups[titusAccount.awsAccount]['aws'][region];
+            const securityGroups = serverGroup.securityGroups
+              .map(sgId => regionalGroups.find(rg => rg.id === sgId))
+              .filter(g => g)
+              .map(sg => ({
+                account: titusAccount.awsAccount,
+                name: sg.name,
+                id: sg.id,
+                vpcId: sg.vpcId,
+              }));
+            this.setState({ securityGroups });
+          });
+        }
+      });
+    }
+  }
+
+  public componentWillReceiveProps(nextProps: ITitusServerGroupDetailsSectionProps): void {
+    this.configureSecurityGroups(nextProps);
+  }
+
+  public render(): JSX.Element {
+    const { serverGroup } = this.props;
+    const { securityGroups } = this.state;
+    // prevent a reflow of the details panel when the security groups actually load by rendering a placeholder
+    const initializing = !securityGroups && (serverGroup.securityGroups || []).length;
+
+    return (
+      <CollapsibleSection heading={FirewallLabels.get('Firewalls')} outerDivClassName="">
+        <ul>
+          {initializing && serverGroup.securityGroups.map(sgId => <li key={sgId}>...</li>)}
+          <UIRouterContextComponent>
+            {sortBy(securityGroups, 'name').map(securityGroup => (
+              <li key={securityGroup.name}>
+                <UISref
+                  to="^.firewallDetails"
+                  params={{
+                    name: securityGroup.name,
+                    accountId: securityGroup.account,
+                    region: serverGroup.region,
+                    vpcId: securityGroup.vpcId,
+                    provider: 'aws',
+                  }}
+                >
+                  <a>
+                    {securityGroup.name} ({securityGroup.id})
+                  </a>
+                </UISref>
+              </li>
+            ))}
+          </UIRouterContextComponent>
+        </ul>
+      </CollapsibleSection>
+    );
+  }
+}

--- a/app/scripts/modules/titus/src/serverGroup/details/scalingPolicy/scalingPolicySummary.component.ts
+++ b/app/scripts/modules/titus/src/serverGroup/details/scalingPolicy/scalingPolicySummary.component.ts
@@ -2,11 +2,7 @@ import { IController, IComponentOptions, module } from 'angular';
 
 import { Application, IServerGroup } from '@spinnaker/core';
 
-import { IScalingPolicy, ITargetTrackingConfiguration } from '@spinnaker/amazon';
-
-interface ITitusPolicy extends IScalingPolicy {
-  targetPolicyDescriptor?: ITargetTrackingConfiguration;
-}
+import { ITitusPolicy } from 'titus/domain';
 
 class ScalingPolicyDetailsSummaryController implements IController {
   public templateUrl: string;

--- a/app/scripts/modules/titus/src/serverGroup/details/serverGroupDetails.html
+++ b/app/scripts/modules/titus/src/serverGroup/details/serverGroupDetails.html
@@ -152,16 +152,8 @@
         <dd>{{serverGroup.resources.gpu}}</dd>
       </dl>
     </collapsible-section>
-    <collapsible-section heading="{{firewallsLabel}}">
-      <ul>
-        <li ng-repeat="securityGroup in securityGroups | orderBy:'name'">
-          <a
-            ui-sref="^.firewallDetails({name: securityGroup.name, accountId: securityGroup.account, region: serverGroup.placement.region, vpcId: securityGroup.vpcId, provider: 'aws'})">
-            {{securityGroup.name}} ({{securityGroup.id}})
-          </a>
-        </li>
-      </ul>
-    </collapsible-section>
+
+    <titus-security-groups app="ctrl.application" server-group="serverGroup" class="collapsible-section" style="display: block"></titus-security-groups>
 
     <collapsible-section heading="Scaling Policies" ng-if="ctrl.scalingPoliciesEnabled">
       <titus-scaling-policy-summary

--- a/app/scripts/modules/titus/src/serverGroup/details/serverGroupDetails.titus.controller.js
+++ b/app/scripts/modules/titus/src/serverGroup/details/serverGroupDetails.titus.controller.js
@@ -7,7 +7,6 @@ import {
   AccountService,
   ClusterTargetBuilder,
   CONFIRMATION_MODAL_SERVICE,
-  FirewallLabels,
   NameUtils,
   ServerGroupReader,
   ServerGroupWarningMessageService,
@@ -23,10 +22,10 @@ import { configBinService } from './scalingPolicy/configBin/configBin.reader';
 import { CONFIG_BIN_LINK_COMPONENT } from './scalingPolicy/configBin/configBinLink.component';
 
 import { TitusCloneServerGroupModal } from '../configure/wizard/TitusCloneServerGroupModal';
+import { TITUS_SECURITY_GROUPS_DETAILS } from './titusSecurityGroups.component';
 
 module.exports = angular
   .module('spinnaker.serverGroup.details.titus.controller', [
-    require('../../securityGroup/securityGroup.read.service').name,
     require('@uirouter/angularjs').default,
     require('../configure/ServerGroupCommandBuilder.js').name,
     CONFIG_BIN_LINK_COMPONENT,
@@ -35,6 +34,7 @@ module.exports = angular
     require('./resize/resizeServerGroup.controller').name,
     require('./rollback/rollbackServerGroup.controller').name,
     SCALING_POLICY_MODULE,
+    TITUS_SECURITY_GROUPS_DETAILS,
   ])
   .controller('titusServerGroupDetailsCtrl', function(
     $scope,
@@ -48,12 +48,9 @@ module.exports = angular
     confirmationModalService,
     serverGroupWriter,
     awsServerGroupTransformer,
-    titusSecurityGroupReader,
   ) {
     let application = app;
     this.application = app;
-
-    $scope.firewallsLabel = FirewallLabels.get('Firewalls');
 
     $scope.gateUrl = SETTINGS.gateUrl;
 
@@ -108,18 +105,6 @@ module.exports = angular
         transformScalingPolicies(details);
 
         if (!_.isEmpty($scope.serverGroup)) {
-          if (details.securityGroups) {
-            $scope.securityGroups = _.chain(details.securityGroups)
-              .map(function(id) {
-                return titusSecurityGroupReader.resolveIndexedSecurityGroup(
-                  application['securityGroupsIndex'],
-                  details,
-                  id,
-                );
-              })
-              .compact()
-              .value();
-          }
           configureEntityTagTargets();
         } else {
           autoClose();

--- a/app/scripts/modules/titus/src/serverGroup/details/titusSecurityGroups.component.ts
+++ b/app/scripts/modules/titus/src/serverGroup/details/titusSecurityGroups.component.ts
@@ -1,0 +1,10 @@
+import { module } from 'angular';
+import { react2angular } from 'react2angular';
+
+import { TitusSecurityGroupsDetailsSection } from './TitusSecurityGroups';
+
+export const TITUS_SECURITY_GROUPS_DETAILS = 'spinnaker.titus.serverGroup.details.securityGroups.component';
+module(TITUS_SECURITY_GROUPS_DETAILS, []).component(
+  'titusSecurityGroups',
+  react2angular(TitusSecurityGroupsDetailsSection, ['app', 'serverGroup']),
+);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,7 +41,10 @@
       "oracle": ["oracle/src"],
       "@spinnaker/cloudfoundry": ["cloudfoundry/src"],
       "cloudfoundry/*": ["cloudfoundry/src/*"],
-      "cloudfoundry/": ["cloudfoundry/src"]
+      "cloudfoundry/": ["cloudfoundry/src"],
+      "@spinnaker/titus": ["titus/src"],
+      "titus/*": ["titus/src/*"],
+      "titus/": ["titus/src"]
     },
     "pretty": true,
     "removeComments": true,


### PR DESCRIPTION
… is disabled

The changes let Titus jobs and tasks display their security groups when the application has disabled the security groups feature (currently, a bunch of NPEs are thrown).