### PR TITLE
fix(provider/cf): Rectify scaling ASGs

### DIFF
--- a/app/scripts/modules/cloudfoundry/src/pipeline/stages/resizeAsg/CloudfoundryResizeAsgStageConfig.tsx
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/stages/resizeAsg/CloudfoundryResizeAsgStageConfig.tsx
@@ -3,6 +3,7 @@ import {
   AccountService,
   Application,
   IAccount,
+  ICapacity,
   IPipeline,
   IRegion,
   IStageConfigProps,
@@ -19,14 +20,14 @@ export interface ICloudfoundryResizeAsgStageConfigState {
   accounts: IAccount[];
   action?: string;
   application: Application;
-  capacity?: any;
+  capacity?: Partial<ICapacity>;
   cloudProvider?: string;
   cloudProviderType?: string;
   credentials: string;
-  diskInMb?: number;
+  diskQuota?: number;
   instanceCount?: number;
   interestingHealthProviderNames?: string[];
-  memoryInMb?: number;
+  memory?: number;
   pipeline: IPipeline;
   region?: string;
   regions: IRegion[];
@@ -50,15 +51,17 @@ export class CloudfoundryResizeAsgStageConfig extends React.Component<
     ) {
       interestingHealthProviderNames = ['Cloud Foundry'];
     }
+    props.stage.capacity = props.stage.capacity || {};
+    props.stage.capacity.desired = props.stage.capacity.desired || 1;
     const initStage = {
       action: 'scale_exact',
-      capacity: props.stage.capacity || {},
+      capacity: props.stage.capacity,
       cloudProvider: 'cloudfoundry',
       cloudProviderType: props.stage.cloudProvider,
-      diskInMb: props.stage.diskInMb || 1024,
+      diskQuota: props.stage.diskQuota || 1024,
       instanceCount: props.stage.instanceCount || 1,
       interestingHealthProviderNames: interestingHealthProviderNames,
-      memoryInMb: props.stage.memoryInMb || 1024,
+      memory: props.stage.memory || 1024,
       target: props.stage.target,
     };
     Object.assign(props.stage, initStage);
@@ -97,21 +100,23 @@ export class CloudfoundryResizeAsgStageConfig extends React.Component<
   private instanceCountUpdated = (event: React.ChangeEvent<HTMLInputElement>): void => {
     const instanceCount = parseInt(event.target.value, 10);
     this.setState({ instanceCount: instanceCount });
-    this.props.stage.instanceCount = instanceCount;
+    this.props.stage.capacity.desired = instanceCount;
+    this.props.stage.capacity.min = instanceCount;
+    this.props.stage.capacity.max = instanceCount;
     this.props.stageFieldUpdated();
   };
 
-  private memoryInMbUpdated = (event: React.ChangeEvent<HTMLInputElement>): void => {
-    const memoryInMb = parseInt(event.target.value, 10);
-    this.setState({ memoryInMb: memoryInMb });
-    this.props.stage.memoryInMb = memoryInMb;
+  private memoryUpdated = (event: React.ChangeEvent<HTMLInputElement>): void => {
+    const memory = parseInt(event.target.value, 10);
+    this.setState({ memory: memory });
+    this.props.stage.memory = memory;
     this.props.stageFieldUpdated();
   };
 
-  private diskInMbUpdated = (event: React.ChangeEvent<HTMLInputElement>): void => {
-    const diskInMb = parseInt(event.target.value, 10);
-    this.setState({ diskInMb: diskInMb });
-    this.props.stage.diskInMb = diskInMb;
+  private diskQuotaUpdated = (event: React.ChangeEvent<HTMLInputElement>): void => {
+    const diskQuota = parseInt(event.target.value, 10);
+    this.setState({ diskQuota: diskQuota });
+    this.props.stage.diskQuota = diskQuota;
     this.props.stageFieldUpdated();
   };
 
@@ -124,7 +129,10 @@ export class CloudfoundryResizeAsgStageConfig extends React.Component<
   public render() {
     const { accounts, application, pipeline, resizeLabel, resizeMessage } = this.state;
     const { stage } = this.props;
-    const { diskInMb, instanceCount, memoryInMb, target } = this.props.stage;
+    const { capacity, target } = this.props.stage;
+    const diskQuota = this.props.stage.diskQuota;
+    const instanceCount = capacity.desired;
+    const memory = this.props.stage.memory;
     const { AccountRegionClusterSelector, TargetSelect } = NgReact;
     return (
       <div className="cloudfoundry-resize-asg-stage form-horizontal">
@@ -162,18 +170,18 @@ export class CloudfoundryResizeAsgStageConfig extends React.Component<
             <div className="col-md-3">
               <input
                 type="number"
-                key="memoryInMb"
-                onChange={this.memoryInMbUpdated}
-                value={memoryInMb}
+                key="memory"
+                onChange={this.memoryUpdated}
+                value={memory}
                 className="form-control input-sm"
               />
             </div>
             <div className="col-md-3">
               <input
                 type="number"
-                key="diskInMb"
-                onChange={this.diskInMbUpdated}
-                value={diskInMb}
+                key="diskQuota"
+                onChange={this.diskQuotaUpdated}
+                value={diskQuota}
                 className="form-control input-sm"
               />
             </div>

--- a/app/scripts/modules/cloudfoundry/src/pipeline/stages/resizeAsg/cloudfoundryResizeAsgStage.module.ts
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/stages/resizeAsg/cloudfoundryResizeAsgStage.module.ts
@@ -17,19 +17,22 @@ module(CLOUD_FOUNDRY_RESIZE_ASG_STAGE, [])
   .config(function() {
     const instanceCountValidator: IInstanceFieldSizeValidationConfig = {
       type: 'cfInstanceSizeField',
-      fieldName: 'instanceCount',
+      fieldName: 'capacity.desired',
+      fieldLabel: 'Instances',
       min: 0,
       preventSave: true,
     };
     const memoryValidator: IInstanceFieldSizeValidationConfig = {
       type: 'cfInstanceSizeField',
-      fieldName: 'memoryInMb',
+      fieldName: 'memory',
+      fieldLabel: 'Mem Mb',
       min: 256,
       preventSave: true,
     };
     const diskValidator: IInstanceFieldSizeValidationConfig = {
       type: 'cfInstanceSizeField',
-      fieldName: 'diskInMb',
+      fieldName: 'diskQuota',
+      fieldLabel: 'Disk Mb',
       min: 256,
       preventSave: true,
     };

--- a/app/scripts/modules/cloudfoundry/src/serverGroup/details/resize/resizeCapacity.html
+++ b/app/scripts/modules/cloudfoundry/src/serverGroup/details/resize/resizeCapacity.html
@@ -18,12 +18,12 @@
     </div>
     <div class="col-md-4"><input type="number"
                                  class="form-control input-sm"
-                                 ng-model="currentSize.memInMb"
+                                 ng-model="currentSize.memory"
                                  readonly/>
     </div>
     <div class="col-md-4"><input type="number"
                                  class="form-control input-sm"
-                                 ng-model="currentSize.diskInMb"
+                                 ng-model="currentSize.diskQuota"
                                  readonly/>
     </div>
   </div>
@@ -37,13 +37,13 @@
     /></div>
     <div class="col-md-4"><input type="number"
                                  class="form-control input-sm"
-                                 ng-model="command.memInMb"
+                                 ng-model="command.memory"
                                  required
                                  min="32"
     /></div>
     <div class="col-md-4"><input type="number"
                                  class="form-control input-sm"
-                                 ng-model="command.diskInMb"
+                                 ng-model="command.diskQuota"
                                  required
                                  min="32"
     /></div>

--- a/app/scripts/modules/cloudfoundry/src/serverGroup/details/resize/resizeServerGroup.controller.ts
+++ b/app/scripts/modules/cloudfoundry/src/serverGroup/details/resize/resizeServerGroup.controller.ts
@@ -6,14 +6,22 @@ import { IController, IScope, module } from 'angular';
 
 import { IModalInstanceService } from 'angular-ui-bootstrap';
 
-import { Application, SERVER_GROUP_WRITER, ServerGroupWriter, TaskMonitor, IServerGroupJob } from '@spinnaker/core';
+import {
+  Application,
+  SERVER_GROUP_WRITER,
+  ServerGroupWriter,
+  TaskMonitor,
+  IServerGroupJob,
+  ICapacity,
+} from '@spinnaker/core';
 
 import { ICloudFoundryServerGroup } from 'cloudfoundry/domain';
 
 interface ICloudFoundryResizeServerGroupCommand extends IServerGroupJob {
+  capacity?: Partial<ICapacity>;
+  diskQuota?: number;
   instanceCount?: number;
-  memoryInMb?: number;
-  diskInMb?: number;
+  memory?: number;
   serverGroupName: string;
   reason?: string;
 }
@@ -39,8 +47,8 @@ class CloudfoundryResizeServerGroupCtrl implements IController {
     this.$scope.application = this.application;
     this.$scope.currentSize = {
       instanceCount: this.serverGroup.instances.length,
-      memInMb: this.serverGroup.memory,
-      diskInMb: this.serverGroup.diskQuota,
+      memory: this.serverGroup.memory,
+      diskQuota: this.serverGroup.diskQuota,
     };
     this.$scope.command = angular.copy(this.$scope.currentSize);
     this.taskMonitor = new TaskMonitor({
@@ -52,15 +60,14 @@ class CloudfoundryResizeServerGroupCtrl implements IController {
 
   public submit(): void {
     const command: ICloudFoundryResizeServerGroupCommand = {
-      instanceCount: this.$scope.command.instanceCount,
-      memoryInMb: this.$scope.command.memInMb,
-      diskInMb: this.$scope.command.diskInMb,
       serverGroupName: this.serverGroup.name,
       capacity: {
         min: this.$scope.command.instanceCount,
         max: this.$scope.command.instanceCount,
         desired: this.$scope.command.instanceCount,
       },
+      diskQuota: this.$scope.command.diskQuota,
+      memory: this.$scope.command.memory,
       reason: this.$scope.command.reason,
     };
 


### PR DESCRIPTION
Now CF uses the Capacity struct in clouddriver to handle the case of
scaling-down ASGs to 0 instances, so CF's implementation in deck
must also use it.

spinnaker/spinnaker#3670