### PR TITLE
fix(core): sort stage matches by label, then description

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/pipelineConfig.less
+++ b/app/scripts/modules/core/src/pipeline/config/pipelineConfig.less
@@ -28,6 +28,11 @@
 }
 
 .stage-choice {
+  .ui-select-highlight {
+    text-decoration: underline;
+  }
+}
+.stage-choice-heading {
   display: flex;
   strong {
     flex: 1 1 auto;

--- a/app/scripts/modules/core/src/pipeline/config/stages/stage.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/stage.html
@@ -16,16 +16,18 @@
           <ui-select-match>
             <strong>{{$select.selected.label}}</strong>
           </ui-select-match>
-          <ui-select-choices repeat="option.key as option in options.stageTypes | filter: $select.search">
+          <ui-select-choices repeat="option.key as option in options.stageTypes | stageTypeMatch: $select.search">
             <div class="stage-choice">
-              <strong>{{option.label}}</strong>
-              <span class="available-providers" ng-if="showProviders">
-                <cloud-provider-logo ng-repeat="provider in option.cloudProviders"
-                                     provider="provider"
-                                     height="'12px'" width="'12px'" show-tooltip="true"></cloud-provider-logo>
-              </span>
+              <div class="stage-choice-heading">
+                <strong ng-bind-html="option.label | highlight: $select.search"></strong>
+                <span class="available-providers" ng-if="showProviders">
+                  <cloud-provider-logo ng-repeat="provider in option.cloudProviders"
+                                       provider="provider"
+                                       height="'12px'" width="'12px'" show-tooltip="true"></cloud-provider-logo>
+                </span>
+              </div>
+              <div ng-bind-html="option.description | highlight: $select.search"></div>
             </div>
-            <div ng-bind-html="option.description"></div>
           </ui-select-choices>
         </ui-select>
       </stage-config-field>

--- a/app/scripts/modules/core/src/pipeline/config/stages/stage.module.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/stage.module.js
@@ -274,4 +274,27 @@ module.exports = angular
         submitMethod: restartStage,
       });
     };
+  })
+  .filter('stageTypeMatch', () => {
+    return (stageTypes, search) => {
+      const q = search.toLowerCase();
+      return stageTypes
+        .filter(s => s.label.toLowerCase().includes(q) || s.description.toLowerCase().includes(q))
+        .sort((a, b) => {
+          const aLabel = a.label.toLowerCase();
+          const bLabel = b.label.toLowerCase();
+          const aDescription = a.description.toLowerCase();
+          const bDescription = b.description.toLowerCase();
+          if (aLabel.includes(q) && !bLabel.includes(q)) {
+            return -1;
+          }
+          if (!aLabel.includes(q) && bLabel.includes(q)) {
+            return 1;
+          }
+          if (aLabel.includes(q) && bLabel.includes(q)) {
+            return aLabel.indexOf(q) - bLabel.indexOf(q);
+          }
+          return aDescription.indexOf(q) - bDescription.indexOf(q);
+        });
+    };
   });


### PR DESCRIPTION
The sort and filtering on the stage type picker is really bad, and it's getting worse as new stages are added:

**Bad matches**
<img width="373" alt="screen shot 2018-11-29 at 10 10 30 pm" src="https://user-images.githubusercontent.com/73450/49271718-b4412100-f423-11e8-9b5d-5c2bba125349.png">
Stages are matched based on any field in the stage config; apparently, some of these have a "wa" in them somewhere.

**Bad order**
<img width="377" alt="screen shot 2018-11-29 at 10 10 08 pm" src="https://user-images.githubusercontent.com/73450/49271805-084c0580-f424-11e8-85ae-181859afb03a.png">
The matches remain in alphabetical order, even if you type the name of a stage that exists.

**PR**
Instead, sort by label first, then description, and sort based on proximity of search text within those fields. Also, highlight it, so people can see quickly why it's matched:
<img width="374" alt="screen shot 2018-11-29 at 10 09 29 pm" src="https://user-images.githubusercontent.com/73450/49271875-58c36300-f424-11e8-881d-4b78a473ae3d.png">

Sorry for the Angular. I told myself I'd never touch anything Angular and not rewrite it to React, but this is a big one to bite off.