### PR TITLE
fix(amazon/loadBalancer): Fix load balancer VPC selection

### DIFF
--- a/app/scripts/modules/amazon/src/loadBalancer/configure/common/LoadBalancerLocation.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/common/LoadBalancerLocation.tsx
@@ -160,6 +160,7 @@ class LoadBalancerLocationImpl extends React.Component<ILoadBalancerLocationProp
       return chain(subnets)
         .filter({ account: credentials, region })
         .reject({ target: 'ec2' })
+        .reject({ purpose: null })
         .value();
     });
   }

--- a/app/scripts/modules/amazon/src/loadBalancer/loadBalancer.transformer.ts
+++ b/app/scripts/modules/amazon/src/loadBalancer/loadBalancer.transformer.ts
@@ -466,7 +466,7 @@ export class AwsLoadBalancerTransformer {
       defaultSubnetType = AWSProviderSettings.defaults.subnetType;
     return {
       availabilityZones: undefined,
-      name: undefined,
+      name: '',
       stack: '',
       detail: '',
       loadBalancerType: 'classic',
@@ -505,7 +505,7 @@ export class AwsLoadBalancerTransformer {
       defaultSubnetType = AWSProviderSettings.defaults.subnetType,
       defaultTargetGroupName = `targetgroup`;
     return {
-      name: undefined,
+      name: '',
       availabilityZones: undefined,
       stack: '',
       detail: '',
@@ -562,7 +562,7 @@ export class AwsLoadBalancerTransformer {
       defaultSubnetType = AWSProviderSettings.defaults.subnetType,
       defaultTargetGroupName = `targetgroup`;
     return {
-      name: undefined,
+      name: '',
       availabilityZones: undefined,
       stack: '',
       detail: '',

--- a/app/scripts/modules/amazon/src/serverGroup/AvailabilityZoneSelector.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/AvailabilityZoneSelector.tsx
@@ -41,9 +41,10 @@ export class AvailabilityZoneSelector extends React.Component<
   private setDefaultZones(props: IAvailabilityZoneSelectorProps) {
     const { credentials, onChange, region } = props;
 
-    AccountService.getAvailabilityZonesForAccountAndRegion('aws', credentials, region).then(
-      preferredZones => preferredZones && onChange(preferredZones.slice()),
-    );
+    AccountService.getAvailabilityZonesForAccountAndRegion('aws', credentials, region).then(preferredZones => {
+      this.setState({ defaultZones: preferredZones });
+      return preferredZones && onChange(preferredZones.slice());
+    });
   }
 
   private handleUsePreferredZonesChanged = (event: React.ChangeEvent<HTMLSelectElement>): void => {

--- a/app/scripts/modules/amazon/src/subnet/subnetSelectField.component.ts
+++ b/app/scripts/modules/amazon/src/subnet/subnetSelectField.component.ts
@@ -53,7 +53,7 @@ class SubnetSelectFieldController implements IController {
     this.activeSubnets = subnets.filter(s => !s.deprecated);
     this.deprecatedSubnets = subnets.filter(s => s.deprecated);
     if (subnets.length) {
-      if (!this.component[this.field] && !this.readOnly) {
+      if (this.component[this.field] === null && !this.readOnly) {
         this.component[this.field] = subnets[0].purpose;
         if (this.onChange) {
           this.onChange();


### PR DESCRIPTION
This should fix spinnaker/spinnaker#3242 and is similar to #6108 with added fix to AvailabilityZoneSelector similar to #6074.

Fix to release-1.10.x, similar to #6115 