### PR TITLE
fix(kubernetes): clicking execution details link filters clusters screen

### DIFF
--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/react/DeployStatus.tsx
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/react/DeployStatus.tsx
@@ -105,7 +105,7 @@ export class DeployStatus extends React.Component<IExecutionDetailsSectionProps,
   }
 
   public render() {
-    const { name: sectionName, current: currentSection, application, stage } = this.props;
+    const { name: sectionName, current: currentSection, stage } = this.props;
     const manifests: IManifest[] = this.state.subscriptions.filter(sub => !!sub.manifest).map(sub => sub.manifest);
     return (
       <ExecutionDetailsSection name={sectionName} current={currentSection}>
@@ -116,7 +116,7 @@ export class DeployStatus extends React.Component<IExecutionDetailsSectionProps,
               <div className="well alert alert-info">
                 {manifests.map(manifest => {
                   const uid = manifest.manifest.metadata.uid || this.manifestIdentifier(manifest.manifest);
-                  return <ManifestStatus key={uid} manifest={manifest} application={application} stage={stage} />;
+                  return <ManifestStatus key={uid} manifest={manifest} stage={stage} />;
                 })}
               </div>
             </div>

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/react/ManifestStatus.tsx
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/react/ManifestStatus.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { IManifest, Application } from '@spinnaker/core';
+import { IManifest } from '@spinnaker/core';
 import { DeployManifestStatusPills } from './DeployStatusPills';
 import { ManifestYaml } from './ManifestYaml';
 import { ManifestDetailsLink } from './ManifestDetailsLink';
@@ -9,13 +9,12 @@ import './ManifestStatus.less';
 
 export interface IManifestStatusProps {
   manifest: IManifest;
-  application: Application;
   stage: any;
 }
 
 export class ManifestStatus extends React.Component<IManifestStatusProps> {
   public render() {
-    const { manifest, application, stage } = this.props;
+    const { manifest, stage } = this.props;
     const { account } = stage.context;
     return [
       <dl className="manifest-status" key="manifest-status">
@@ -28,7 +27,7 @@ export class ManifestStatus extends React.Component<IManifestStatusProps> {
       </dl>,
       <div className="manifest-support-links" key="manifest-support-links">
         <ManifestYaml manifest={manifest} linkName="YAML" />
-        <ManifestDetailsLink linkName="Details" manifest={manifest} application={application} accountId={account} />
+        <ManifestDetailsLink linkName="Details" manifest={manifest} accountId={account} />
       </div>,
       <div className="manifest-events pad-left" key="manifest-events">
         <ManifestEvents manifest={manifest} />


### PR DESCRIPTION
Fixes https://github.com/spinnaker/spinnaker/issues/3443

Before, clicking a Details link in an execution showed the clusters screen with all clusters shown.

![screen shot 2018-11-30 at 3 56 09 pm](https://user-images.githubusercontent.com/34253460/49314582-e94b8300-f4b8-11e8-8976-2cf39c8d8153.png)

After, clicking a Details link in an execution shows the clusters screen filtered to the namespace that the resource you clicked on belongs.

![screen shot 2018-11-30 at 3 55 14 pm](https://user-images.githubusercontent.com/34253460/49314588-ed77a080-f4b8-11e8-98c7-153ecc63ace1.png)
