### PR TITLE
fix(kubernetes): cherry-pick execution and link fixes from master into 1.11

### DIFF
--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/react/DeployStatus.tsx
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/react/DeployStatus.tsx
@@ -25,6 +25,7 @@ interface IStageManifest {
 
 export interface IDeployStatusState {
   subscriptions: IManifestSubscription[];
+  manifestIds: string[];
 }
 
 export class DeployStatus extends React.Component<IExecutionDetailsSectionProps, IDeployStatusState> {
@@ -32,32 +33,52 @@ export class DeployStatus extends React.Component<IExecutionDetailsSectionProps,
 
   constructor(props: IExecutionDetailsSectionProps) {
     super(props);
-    this.state = { subscriptions: [] };
+    this.state = { subscriptions: [], manifestIds: [] };
   }
 
   public componentDidMount() {
-    this.buildSubscriptions();
-  }
-
-  public componentDidUpdate() {
-    this.buildSubscriptions();
-  }
-
-  private buildSubscriptions() {
-    const subscriptions: IManifestSubscription[] = [];
-    const stageManifests = this.getStageManifests();
-    stageManifests.forEach(m => {
-      const subscription = this.subscribeToManifest(m);
-      if (subscription != null) {
-        subscriptions.push(subscription);
-      }
-    });
-    if (subscriptions.length > 0) {
-      this.setState({ subscriptions });
-    }
+    this.componentDidUpdate(this.props, this.state);
   }
 
   public componentWillUnmount() {
+    this.unsubscribeAll();
+  }
+
+  public componentDidUpdate(_prevProps: IExecutionDetailsSectionProps, prevState: IDeployStatusState) {
+    const manifests: IStageManifest[] = get(this.props.stage, ['context', 'outputs.manifests'], []).filter(m => !!m);
+    const manifestIds = manifests.map(m => this.manifestIdentifier(m)).sort();
+    if (prevState.manifestIds.join('') !== manifestIds.join('')) {
+      this.unsubscribeAll();
+      const subscriptions = manifests.map(manifest => {
+        const id = this.manifestIdentifier(manifest);
+        return {
+          id,
+          unsubscribe: this.subscribeToManifestUpdates(id, manifest),
+          manifest: this.stageManifestToIManifest(manifest, this.props.stage.context.account),
+        };
+      });
+      this.setState({ subscriptions, manifestIds });
+    }
+  }
+
+  private subscribeToManifestUpdates(id: string, manifest: IStageManifest): () => void {
+    const params = {
+      account: this.props.stage.context.account,
+      name: upperFirst(manifest.kind) + ' ' + manifest.metadata.name,
+      location: manifest.metadata.namespace == null ? '_' : manifest.metadata.namespace,
+    };
+    return KubernetesManifestService.subscribe(this.props.application, params, (updated: IManifest) => {
+      const idx = this.state.subscriptions.findIndex(sub => sub.id === id);
+      if (idx !== -1) {
+        const subscription = { ...this.state.subscriptions[idx], manifest: updated };
+        const subscriptions = [...this.state.subscriptions];
+        subscriptions[idx] = subscription;
+        this.setState({ subscriptions });
+      }
+    });
+  }
+
+  private unsubscribeAll() {
     this.state.subscriptions.forEach(({ unsubscribe }) => unsubscribe());
   }
 
@@ -67,19 +88,6 @@ export class DeployStatus extends React.Component<IExecutionDetailsSectionProps,
     const namespace = (manifest.metadata.namespace || '_').toLowerCase();
     const name = manifest.metadata.name.toLowerCase();
     return `${namespace} ${kind} ${name}`;
-  }
-
-  private findSubscriptionIndex({ id }: { id: string }): number {
-    return this.state.subscriptions.findIndex(sub => sub.id === id);
-  }
-
-  private manifestFullName(manifest: any): string {
-    return upperFirst(manifest.kind) + ' ' + manifest.metadata.name;
-  }
-
-  private getStageManifests(): IStageManifest[] {
-    const manifests: any[] = get(this.props, ['stage', 'context', 'outputs.manifests'], []);
-    return manifests.filter(m => !!m);
   }
 
   private stageManifestToIManifest(manifest: IStageManifest, account: string): IManifest {
@@ -96,42 +104,8 @@ export class DeployStatus extends React.Component<IExecutionDetailsSectionProps,
     };
   }
 
-  private subscribeToManifest(manifest: IStageManifest): IManifestSubscription {
-    const { application, stage } = this.props;
-    const { account } = stage.context;
-    const { namespace: location } = manifest.metadata;
-    const name = this.manifestFullName(manifest);
-    const params = { account, location, name };
-    const id = this.manifestIdentifier(manifest);
-    if (location == null) {
-      params.location = '_';
-    }
-    if (this.findSubscriptionIndex({ id }) !== -1) {
-      return null;
-    }
-    const unsubscribe = KubernetesManifestService.subscribe(application, params, (updatedManifest: IManifest) => {
-      this.saveManifestSubscription({ id, unsubscribe, manifest: updatedManifest });
-    });
-    return {
-      id,
-      unsubscribe,
-      manifest: this.stageManifestToIManifest(manifest, account),
-    };
-  }
-
-  private saveManifestSubscription(subscription: IManifestSubscription) {
-    const idx = this.findSubscriptionIndex(subscription);
-    const subscriptions = [...this.state.subscriptions];
-    if (idx === -1) {
-      subscriptions.push(subscription);
-    } else {
-      subscriptions[idx] = subscription;
-    }
-    this.setState({ subscriptions });
-  }
-
   public render() {
-    const { name: sectionName, current: currentSection, application, stage } = this.props;
+    const { name: sectionName, current: currentSection, stage } = this.props;
     const manifests: IManifest[] = this.state.subscriptions.filter(sub => !!sub.manifest).map(sub => sub.manifest);
     return (
       <ExecutionDetailsSection name={sectionName} current={currentSection}>
@@ -142,7 +116,7 @@ export class DeployStatus extends React.Component<IExecutionDetailsSectionProps,
               <div className="well alert alert-info">
                 {manifests.map(manifest => {
                   const uid = manifest.manifest.metadata.uid || this.manifestIdentifier(manifest.manifest);
-                  return <ManifestStatus key={uid} manifest={manifest} application={application} stage={stage} />;
+                  return <ManifestStatus key={uid} manifest={manifest} stage={stage} />;
                 })}
               </div>
             </div>

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/react/ManifestDetailsLink.tsx
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/react/ManifestDetailsLink.tsx
@@ -1,15 +1,20 @@
 import * as React from 'react';
-import { IManifest, Application, ReactInjector, AccountService } from '@spinnaker/core';
+import { IManifest, ReactInjector, AccountService } from '@spinnaker/core';
 import { get, trim } from 'lodash';
+
+const UNMAPPED_K8S_RESOURCE_STATE_KEY = 'kubernetesResource';
 
 export interface IManifestDetailsProps {
   manifest: IManifest;
   linkName: string;
-  application: Application;
   accountId: string;
 }
 
-export class ManifestDetailsLink extends React.Component<IManifestDetailsProps> {
+export interface IManifestDetailsState {
+  url: string;
+}
+
+export class ManifestDetailsLink extends React.Component<IManifestDetailsProps, IManifestDetailsState> {
   private spinnakerKindStateMap: { [k: string]: string } = {
     // keys from clouddriver's KubernetesSpinnakerKindMap
     serverGroupManagers: 'serverGroupManager',
@@ -18,11 +23,14 @@ export class ManifestDetailsLink extends React.Component<IManifestDetailsProps> 
 
   constructor(props: IManifestDetailsProps) {
     super(props);
-    this.onClick = this.onClick.bind(this);
+    this.state = {
+      url: '',
+    };
+    this.loadUrl();
   }
 
   private canOpen(): boolean {
-    return !!this.props.manifest.manifest;
+    return !!this.props.manifest.manifest && !!this.state.url;
   }
 
   private spinnakerKindFromKubernetesKind(kind: string, kindMap: { [k: string]: string }) {
@@ -36,29 +44,39 @@ export class ManifestDetailsLink extends React.Component<IManifestDetailsProps> 
     );
   }
 
-  private openDetails(stateKey: string) {
-    const { $state } = ReactInjector;
-    const region = this.resourceRegion();
-    const params: { [k: string]: string } = { accountId: this.props.accountId, provider: 'kubernetes', region };
+  private getStateParams(stateKey: string): any {
     const kind = this.props.manifest.manifest.kind.toLowerCase();
-    params[stateKey] = `${kind} ${this.props.manifest.manifest.metadata.name}`;
-    $state.go(`home.applications.application.insight.clusters.${stateKey}`, params);
+    const name = this.props.manifest.manifest.metadata.name;
+    const region = this.resourceRegion();
+    const params: { [k: string]: string } = {
+      accountId: this.props.accountId,
+      provider: 'kubernetes',
+      region,
+      reg: region, // Filters the list of clusters on the Clusters screen to those in the same namespace
+      [stateKey]: `${kind} ${name}`,
+    };
+    if (!params.region && kind === 'namespace' && stateKey === UNMAPPED_K8S_RESOURCE_STATE_KEY) {
+      params.region = name;
+    }
+    return params;
   }
 
-  public onClick() {
+  private loadUrl() {
     const kind: string = get(this.props, ['manifest', 'manifest', 'kind'], '');
     const { accountId } = this.props;
     AccountService.getAccountDetails(accountId).then(account => {
       const spinnakerKind = this.spinnakerKindFromKubernetesKind(kind, account.spinnakerKindMap);
-      const stateKey = this.spinnakerKindStateMap[spinnakerKind] || 'kubernetesResource';
-      this.openDetails(stateKey);
+      const stateKey = this.spinnakerKindStateMap[spinnakerKind] || UNMAPPED_K8S_RESOURCE_STATE_KEY;
+      const params = this.getStateParams(stateKey);
+      const url = ReactInjector.$state.href(`home.applications.application.insight.clusters.${stateKey}`, params);
+      this.setState({ url });
     });
   }
 
   public render() {
     if (this.canOpen()) {
       return (
-        <a onClick={this.onClick} className="clickable">
+        <a href={this.state.url} className="clickable">
           {this.props.linkName}
         </a>
       );

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/react/ManifestStatus.tsx
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/react/ManifestStatus.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { IManifest, Application } from '@spinnaker/core';
+import { IManifest } from '@spinnaker/core';
 import { DeployManifestStatusPills } from './DeployStatusPills';
 import { ManifestYaml } from './ManifestYaml';
 import { ManifestDetailsLink } from './ManifestDetailsLink';
@@ -9,13 +9,12 @@ import './ManifestStatus.less';
 
 export interface IManifestStatusProps {
   manifest: IManifest;
-  application: Application;
   stage: any;
 }
 
 export class ManifestStatus extends React.Component<IManifestStatusProps> {
   public render() {
-    const { manifest, application, stage } = this.props;
+    const { manifest, stage } = this.props;
     const { account } = stage.context;
     return [
       <dl className="manifest-status" key="manifest-status">
@@ -28,7 +27,7 @@ export class ManifestStatus extends React.Component<IManifestStatusProps> {
       </dl>,
       <div className="manifest-support-links" key="manifest-support-links">
         <ManifestYaml manifest={manifest} linkName="YAML" />
-        <ManifestDetailsLink linkName="Details" manifest={manifest} application={application} accountId={account} />
+        <ManifestDetailsLink linkName="Details" manifest={manifest} accountId={account} />
       </div>,
       <div className="manifest-events pad-left" key="manifest-events">
         <ManifestEvents manifest={manifest} />


### PR DESCRIPTION
Commits:
fix(kubernetes): fix manifest update race condition (#6101)
fix(kubernetes): namespace details links in executions dont work (#6114)
fix(kubernetes): clicking execution details link filters clusters screen (#6120)