### PR TITLE
style(amazon): fix load balancer label alignment in server groups modal

### DIFF
--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/ServerGroupLoadBalancers.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/ServerGroupLoadBalancers.tsx
@@ -120,11 +120,11 @@ class ServerGroupLoadBalancersImpl extends React.Component<
             </div>
           )}
           <div className="form-group">
-            <div className="col-md-3 sm-label-right">
+            <div className="col-md-4 sm-label-right">
               <b>Target Groups </b>
               <HelpField id="aws.loadBalancer.targetGroups" />
             </div>
-            <div className="col-md-8">
+            <div className="col-md-7">
               {targetGroupOptions.length === 0 && (
                 <div className="form-control-static">No target groups found in the selected account/region/VPC</div>
               )}
@@ -181,7 +181,7 @@ class ServerGroupLoadBalancersImpl extends React.Component<
               <b>Classic Load Balancers </b>
               <HelpField id="aws.loadBalancer.loadBalancers" />
             </div>
-            <div className="col-md-8">
+            <div className="col-md-7">
               {loadBalancerOptions.length === 0 && (
                 <div className="form-control-static">No load balancers found in the selected account/region/VPC</div>
               )}


### PR DESCRIPTION
I don't want to brag, but I am very good at design.

**Current:**
<img width="643" alt="screen shot 2018-12-03 at 8 28 52 am" src="https://user-images.githubusercontent.com/73450/49387037-b4684780-f6d5-11e8-8e54-8690d50684ae.png">
<img width="642" alt="screen shot 2018-12-03 at 8 28 42 am" src="https://user-images.githubusercontent.com/73450/49387038-b4684780-f6d5-11e8-8249-4a5f6ef56db5.png">

**PR:**
<img width="644" alt="screen shot 2018-12-03 at 8 29 19 am" src="https://user-images.githubusercontent.com/73450/49387035-b3cfb100-f6d5-11e8-997e-19fe4dbaef92.png">
<img width="642" alt="screen shot 2018-12-03 at 8 29 07 am" src="https://user-images.githubusercontent.com/73450/49387036-b4684780-f6d5-11e8-9176-a06788a71f7a.png">
