### PR TITLE
fix(core/dataSources): make child sources always honor their parents' disabled state

### DIFF
--- a/app/scripts/modules/core/src/application/service/ApplicationReader.ts
+++ b/app/scripts/modules/core/src/application/service/ApplicationReader.ts
@@ -82,8 +82,8 @@ export class ApplicationReader {
     }
     allDataSources.filter(ds => ds.requiresDataSource).forEach(ds => {
       const parent = allDataSources.find(p => p.key === ds.requiresDataSource);
-      if (parent && parent.disabled) {
-        this.setDataSourceDisabled(ds, application, true);
+      if (parent) {
+        this.setDataSourceDisabled(ds, application, parent.disabled);
       }
     });
   }


### PR DESCRIPTION
Turns out that historically we've updated the `disabled` flags on child data sources when their parent is disabled, but _not_ when they're enabled. The only reason it got noticed was because there's some child sources that populate nav items which were not updating without a refresh, but it's nice to do the right thing I suppose.