### PR TITLE
fix(amazon): use arrow functions in server group modal

### DIFF
--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/AmazonCloneServerGroupModal.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/AmazonCloneServerGroupModal.tsx
@@ -85,12 +85,12 @@ export class AmazonCloneServerGroupModal extends React.Component<
     this.configureCommand();
   };
 
-  private onTaskComplete() {
+  private onTaskComplete = () => {
     this.props.application.serverGroups.refresh();
     this.props.application.serverGroups.onNextRefresh(null, this.onApplicationRefresh);
-  }
+  };
 
-  protected onApplicationRefresh(): void {
+  protected onApplicationRefresh = (): void => {
     if (this._isUnmounted) {
       return;
     }
@@ -123,7 +123,7 @@ export class AmazonCloneServerGroupModal extends React.Component<
         ReactInjector.$state.go(transitionTo, newStateParams);
       }
     }
-  }
+  };
 
   private initializeCommand = () => {
     const { command } = this.props;


### PR DESCRIPTION
These methods are referenced in a way that `this` gets bound differently, resulting in a "Unknown Error" + "Operation Succeeded" message combo that is a little confusing for users.