### PR TITLE
refactor(core/presentation): Switch from a separate IControlledInputProps `field` object prop to spread props

### DIFF
--- a/app/scripts/modules/core/src/presentation/forms/FormField.tsx
+++ b/app/scripts/modules/core/src/presentation/forms/FormField.tsx
@@ -114,7 +114,7 @@ export class FormField extends React.Component<IFormFieldProps, IFormFieldState>
       removeValidator: this.removeValidator,
     };
 
-    const inputElement = renderContent(input, { field: controlledInputProps, validation: validationProps });
+    const inputElement = renderContent(input, { ...controlledInputProps, validation: validationProps });
 
     return (
       <WatchValue onChange={x => this.value$.next(x)} value={value}>

--- a/app/scripts/modules/core/src/presentation/forms/FormikFormField.tsx
+++ b/app/scripts/modules/core/src/presentation/forms/FormikFormField.tsx
@@ -95,7 +95,7 @@ export class FormikFormFieldImpl<T = any>
 
     const fieldLayoutPropsWithoutInput: IFieldLayoutPropsWithoutInput = { label, help, required, actions };
 
-    const render = (props: FieldProps<any>) => {
+    const renderField = (props: FieldProps<any>) => {
       const { field } = props;
 
       const validationProps: IValidationProps = {
@@ -106,7 +106,7 @@ export class FormikFormFieldImpl<T = any>
         removeValidator: this.removeValidator,
       };
 
-      const inputElement = renderContent(input, { field, validation: validationProps });
+      const inputElement = renderContent(input, { ...field, validation: validationProps });
 
       return (
         <WatchValue onChange={onChange} value={field.value}>
@@ -118,10 +118,10 @@ export class FormikFormFieldImpl<T = any>
     const validator = createFieldValidator(label, required, [].concat(validate).concat(internalValidators));
 
     if (this.props.fastField) {
-      return <FastField name={name} validate={validator} render={render} />;
+      return <FastField name={name} validate={validator} render={renderField} />;
     }
 
-    return <Field name={name} validate={validator} render={render} />;
+    return <Field name={name} validate={validator} render={renderField} />;
   }
 }
 

--- a/app/scripts/modules/core/src/presentation/forms/inputs/CheckboxInput.tsx
+++ b/app/scripts/modules/core/src/presentation/forms/inputs/CheckboxInput.tsx
@@ -1,23 +1,22 @@
 import * as React from 'react';
 
 import { orEmptyString, validationClassName } from './utils';
-import { IFormInputProps } from '../interface';
+import { IFormInputProps, OmitControlledInputPropsFrom } from '../interface';
 
-interface ICheckBoxInputProps extends IFormInputProps, React.InputHTMLAttributes<any> {
+interface ICheckBoxInputProps extends IFormInputProps, OmitControlledInputPropsFrom<React.InputHTMLAttributes<any>> {
   inputClassName?: string;
   text?: React.ReactNode;
 }
 
 export class CheckboxInput extends React.Component<ICheckBoxInputProps> {
   public render() {
-    const { field, validation, inputClassName, text, ...otherProps } = this.props;
-    const { value, ...fieldProps } = field;
+    const { value, validation, inputClassName, text, ...otherProps } = this.props;
     const className = `CheckboxInput ${orEmptyString(inputClassName)} ${validationClassName(validation)}`;
 
     return (
       <div className="checkbox">
         <label>
-          <input className={className} type="checkbox" checked={!!value} {...fieldProps} {...otherProps} />
+          <input className={className} type="checkbox" checked={!!value} {...otherProps} />
           {text}
         </label>
       </div>

--- a/app/scripts/modules/core/src/presentation/forms/inputs/NumberInput.tsx
+++ b/app/scripts/modules/core/src/presentation/forms/inputs/NumberInput.tsx
@@ -3,11 +3,11 @@ import memoizeOne from 'memoize-one';
 
 import { orEmptyString, validationClassName } from './utils';
 import { composeValidators, Validation, Validator } from '../Validation';
-import { IFormInputProps } from '../interface';
+import { IFormInputProps, OmitControlledInputPropsFrom } from '../interface';
 
 import './NumberInput.css';
 
-interface INumberInputProps extends IFormInputProps, React.InputHTMLAttributes<any> {
+interface INumberInputProps extends IFormInputProps, OmitControlledInputPropsFrom<React.InputHTMLAttributes<any>> {
   inputClassName?: string;
 }
 
@@ -32,9 +32,8 @@ export class NumberInput extends React.Component<INumberInputProps> {
   }
 
   public render() {
-    const { field, validation, inputClassName, ...otherProps } = this.props;
-    const fieldProps = { ...field, value: orEmptyString(field.value) };
+    const { value, validation, inputClassName, ...otherProps } = this.props;
     const className = `NumberInput form-control ${orEmptyString(inputClassName)} ${validationClassName(validation)}`;
-    return <input className={className} type="number" {...fieldProps} {...otherProps} />;
+    return <input className={className} type="number" value={orEmptyString(value)} {...otherProps} />;
   }
 }

--- a/app/scripts/modules/core/src/presentation/forms/inputs/RadioButtonInput.tsx
+++ b/app/scripts/modules/core/src/presentation/forms/inputs/RadioButtonInput.tsx
@@ -1,22 +1,20 @@
 import * as React from 'react';
 import { Option } from 'react-select';
 
-import { Markdown, StringsAsOptions } from 'core/presentation';
+import { Markdown, OmitControlledInputPropsFrom, StringsAsOptions } from 'core/presentation';
 
 import { isStringArray, orEmptyString, validationClassName } from './utils';
-
 import { IFormInputProps } from '../interface';
 
-interface IRadioButtonInputProps extends IFormInputProps, React.TextareaHTMLAttributes<any> {
+interface IRadioButtonInputProps
+  extends IFormInputProps,
+    OmitControlledInputPropsFrom<React.TextareaHTMLAttributes<any>> {
   options: Array<string | Option<string | number>>;
   inputClassName?: string;
 }
 
 export const RadioButtonInput = (props: IRadioButtonInputProps) => {
-  const { field, validation, inputClassName, options } = props;
-  const { value, onBlur, onChange, name } = field;
-
-  const fieldProps = { name, onChange, onBlur };
+  const { value, validation, inputClassName, options, ...otherProps } = props;
   const className = `RadioButtonInput radio ${orEmptyString(inputClassName)} ${validationClassName(validation)}`;
 
   const RadioButtonsElement = ({ opts }: { opts: Array<Option<string>> }) => (
@@ -24,7 +22,7 @@ export const RadioButtonInput = (props: IRadioButtonInputProps) => {
       {opts.map(option => (
         <div key={option.label} className={className}>
           <label>
-            <input type="radio" {...fieldProps} value={option.value} checked={option.value === value} />
+            <input type="radio" {...otherProps} value={option.value} checked={option.value === value} />
             <span className="marked">
               <Markdown message={option.label} />
             </span>

--- a/app/scripts/modules/core/src/presentation/forms/inputs/SelectInput.tsx
+++ b/app/scripts/modules/core/src/presentation/forms/inputs/SelectInput.tsx
@@ -1,24 +1,23 @@
 import * as React from 'react';
 import { Option } from 'react-select';
 
-import { StringsAsOptions } from 'core/presentation';
+import { OmitControlledInputPropsFrom, StringsAsOptions } from 'core/presentation';
 
 import { isStringArray, orEmptyString, validationClassName } from './utils';
 import { IFormInputProps } from '../interface';
 
-interface ISelectInputProps extends IFormInputProps, React.InputHTMLAttributes<any> {
+interface ISelectInputProps extends IFormInputProps, OmitControlledInputPropsFrom<React.InputHTMLAttributes<any>> {
   inputClassName?: string;
   options: Array<string | Option<string>>;
 }
 
 export class SelectInput extends React.Component<ISelectInputProps> {
   public render() {
-    const { field, validation, options, inputClassName, ...otherProps } = this.props;
-    const fieldProps = { ...field, value: orEmptyString(field.value) };
+    const { value, validation, options, inputClassName, ...otherProps } = this.props;
     const className = `SelectInput form-control ${orEmptyString(inputClassName)} ${validationClassName(validation)}`;
 
     const SelectElement = ({ opts }: { opts: Array<Option<string>> }) => (
-      <select className={className} {...fieldProps} {...otherProps}>
+      <select className={className} value={orEmptyString(value)} {...otherProps}>
         {opts.map(option => (
           <option key={option.value} value={option.value}>
             {option.label}

--- a/app/scripts/modules/core/src/presentation/forms/inputs/TextAreaInput.tsx
+++ b/app/scripts/modules/core/src/presentation/forms/inputs/TextAreaInput.tsx
@@ -1,18 +1,16 @@
 import * as React from 'react';
 
 import { orEmptyString, validationClassName } from './utils';
-import { IFormInputProps } from '../interface';
+import { IFormInputProps, OmitControlledInputPropsFrom } from '../interface';
 
-interface ITextAreaInputProps extends IFormInputProps, React.TextareaHTMLAttributes<any> {
+interface ITextAreaInputProps extends IFormInputProps, OmitControlledInputPropsFrom<React.TextareaHTMLAttributes<any>> {
   inputClassName?: string;
 }
 
 export class TextAreaInput extends React.Component<ITextAreaInputProps> {
   public render() {
-    const { field, validation, inputClassName, ...otherProps } = this.props;
-    const fieldProps = { ...field, value: orEmptyString(field.value) };
+    const { value, validation, inputClassName, ...otherProps } = this.props;
     const className = `TextAreaInput form-control ${orEmptyString(inputClassName)} ${validationClassName(validation)}`;
-
-    return <textarea className={className} autoComplete="off" {...fieldProps} {...otherProps} />;
+    return <textarea className={className} autoComplete="off" value={orEmptyString(value)} {...otherProps} />;
   }
 }

--- a/app/scripts/modules/core/src/presentation/forms/inputs/TextInput.tsx
+++ b/app/scripts/modules/core/src/presentation/forms/inputs/TextInput.tsx
@@ -1,18 +1,16 @@
 import * as React from 'react';
 
 import { orEmptyString, validationClassName } from './utils';
-import { IFormInputProps } from '../interface';
+import { IFormInputProps, OmitControlledInputPropsFrom } from '../interface';
 
-interface ITextInputProps extends IFormInputProps, React.InputHTMLAttributes<any> {
+interface ITextInputProps extends IFormInputProps, OmitControlledInputPropsFrom<React.InputHTMLAttributes<any>> {
   inputClassName?: string;
 }
 
 export class TextInput extends React.Component<ITextInputProps> {
   public render() {
-    const { field, validation, inputClassName, ...otherProps } = this.props;
-    const fieldProps = { ...field, value: orEmptyString(field.value) };
+    const { value, validation, inputClassName, ...otherProps } = this.props;
     const className = `TextInput form-control ${orEmptyString(inputClassName)} ${validationClassName(validation)}`;
-
-    return <input className={className} type="text" autoComplete="off" {...fieldProps} {...otherProps} />;
+    return <input className={className} type="text" autoComplete="off" value={orEmptyString(value)} {...otherProps} />;
   }
 }

--- a/app/scripts/modules/core/src/presentation/forms/inputs/expression/ExpressionInput.tsx
+++ b/app/scripts/modules/core/src/presentation/forms/inputs/expression/ExpressionInput.tsx
@@ -15,15 +15,14 @@ export class ExpressionInput extends React.Component<IExpressionInputProps> {
   public static defaultProps = { context: {}, placeholder: '' };
 
   public componentDidUpdate(prevProps: IExpressionInputProps) {
-    const { context, field } = this.props;
-    if (field.value !== prevProps.field.value || !isEqual(context, prevProps.context)) {
-      const expressionChange = evaluateExpression(context, field.value);
+    const { context, value } = this.props;
+    if (value !== prevProps.value || !isEqual(context, prevProps.context)) {
+      const expressionChange = evaluateExpression(context, value);
       this.props.onExpressionChange(expressionChange);
     }
   }
 
   public render(): JSX.Element {
-    const { field, placeholder, validation } = this.props;
-    return <TextInput autoComplete="off" field={field} placeholder={placeholder} validation={validation} />;
+    return <TextInput autoComplete="off" {...this.props} />;
   }
 }

--- a/app/scripts/modules/core/src/presentation/forms/inputs/utils.ts
+++ b/app/scripts/modules/core/src/presentation/forms/inputs/utils.ts
@@ -6,6 +6,7 @@ import { IValidationProps } from '../interface';
 export const orEmptyString = (val: any) => (isUndefined(val) ? '' : val);
 
 export const validationClassName = (validation: IValidationProps) => {
+  validation = validation || {};
   return classNames({
     'ng-dirty': !!validation.touched,
     'ng-invalid': validation.validationStatus === 'error',

--- a/app/scripts/modules/core/src/presentation/forms/interface.ts
+++ b/app/scripts/modules/core/src/presentation/forms/interface.ts
@@ -17,13 +17,19 @@ export interface IFieldLayoutProps extends IFieldLayoutPropsWithoutInput {
   input: React.ReactNode;
 }
 
-/** These props are used by controlled components, such as <input> or Input components like TextInput */
+/**
+ * These props are used by controlled components, such as <input> or Input components like TextInput
+ * The typings reference the typings supplied by formik FieldProps
+ */
 export interface IControlledInputProps {
   value: FieldProps['field']['value'];
   onChange: FieldProps['field']['onChange'];
   onBlur: FieldProps['field']['onBlur'];
   name: FieldProps['field']['name'];
 }
+
+export type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
+export type OmitControlledInputPropsFrom<T> = Omit<T, keyof IControlledInputProps>;
 
 /** These props are used by Input components, such as TextInput */
 export interface IValidationProps {
@@ -35,9 +41,8 @@ export interface IValidationProps {
 }
 
 /** These props are used by Input components, such as TextInput */
-export interface IFormInputProps {
-  field: IControlledInputProps;
-  validation: IValidationProps;
+export interface IFormInputProps extends Partial<IControlledInputProps> {
+  validation?: IValidationProps;
   inputClassName?: string;
 }
 

--- a/app/scripts/modules/core/src/projects/configure/FormikApplicationsPicker.tsx
+++ b/app/scripts/modules/core/src/projects/configure/FormikApplicationsPicker.tsx
@@ -36,7 +36,7 @@ export class FormikApplicationsPicker extends React.Component<IFormikApplication
       const appClassName = 'body-small zombie-label flex-1 sp-padding-xs-yaxis sp-padding-s-xaxis sp-margin-xs-yaxis';
       const isError = props.validation.validationStatus === 'error';
       // When there is an error, render a disabled TextInput with failed validation, else render the weird box ui
-      return isError ? <TextInput disabled={true} {...props} /> : <p className={appClassName}>{props.field.value}</p>;
+      return isError ? <TextInput disabled={true} {...props} /> : <p className={appClassName}>{props.value}</p>;
     };
 
     return (


### PR DESCRIPTION
from: `<TextInput field={{ name, onChange, onBlur, value }} />`
to: `<TextInput name={name} onChange={onChange} onBlur={onBlur} value={value} />`
