### PR TITLE
Add core alias tsconfig

### DIFF
--- a/app/scripts/modules/amazon/tsconfig.json
+++ b/app/scripts/modules/amazon/tsconfig.json
@@ -9,10 +9,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "jsx": "react",
-    "lib": [
-      "es2016",
-      "dom"
-    ],
+    "lib": ["es2016", "dom"],
     "moduleResolution": "node",
     "module": "commonjs",
     "noEmitHelpers": false,
@@ -30,21 +27,14 @@
     "inlineSources": true,
     "strictNullChecks": false, // should really get to a place where we can turn this on
     "target": "es6",
-    "typeRoots": [
-      "../../../../node_modules/@types"
-    ],
+    "typeRoots": ["../../../../node_modules/@types"],
     "paths": {
       "@spinnaker/core": ["../../core/lib"],
+      "core/*": ["../../core/lib/*"],
       "amazon/*": ["*"],
       "amazon": ["."]
     }
   },
-  "include": [
-    "src/**/*.ts",
-    "src/**/*.tsx"
-  ],
-  "exclude": [
-    "./lib",
-    "**/*.spec.*"
-  ]
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["./lib", "**/*.spec.*"]
 }

--- a/app/scripts/modules/appengine/tsconfig.json
+++ b/app/scripts/modules/appengine/tsconfig.json
@@ -9,10 +9,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "jsx": "react",
-    "lib": [
-      "es2016",
-      "dom"
-    ],
+    "lib": ["es2016", "dom"],
     "moduleResolution": "node",
     "module": "commonjs",
     "noEmitHelpers": false,
@@ -30,21 +27,14 @@
     "inlineSources": true,
     "strictNullChecks": false, // should really get to a place where we can turn this on
     "target": "es6",
-    "typeRoots": [
-      "../../../../node_modules/@types"
-    ],
+    "typeRoots": ["../../../../node_modules/@types"],
     "paths": {
       "@spinnaker/core": ["../../core/lib"],
+      "core/*": ["../../core/lib/*"],
       "appengine/*": ["*"],
       "appengine": ["."]
     }
   },
-  "include": [
-    "src/**/*.ts",
-    "src/**/*.tsx"
-  ],
-  "exclude": [
-    "./lib",
-    "**/*.spec.*"
-  ]
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["./lib", "**/*.spec.*"]
 }

--- a/app/scripts/modules/cloudfoundry/tsconfig.json
+++ b/app/scripts/modules/cloudfoundry/tsconfig.json
@@ -30,6 +30,7 @@
     "typeRoots": ["../../../../node_modules/@types"],
     "paths": {
       "@spinnaker/core": ["../../core/lib"],
+      "core/*": ["../../core/lib/*"],
       "cloudfoundry/*": ["*"],
       "cloudfoundry": ["."]
     }

--- a/app/scripts/modules/docker/tsconfig.json
+++ b/app/scripts/modules/docker/tsconfig.json
@@ -9,10 +9,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "jsx": "react",
-    "lib": [
-      "es2016",
-      "dom"
-    ],
+    "lib": ["es2016", "dom"],
     "moduleResolution": "node",
     "module": "commonjs",
     "noEmitHelpers": false,
@@ -30,18 +27,12 @@
     "inlineSources": true,
     "strictNullChecks": false, // should really get to a place where we can turn this on
     "target": "es6",
-    "typeRoots": [
-      "../../../../node_modules/@types"
-    ],
+    "typeRoots": ["../../../../node_modules/@types"],
     "paths": {
-      "@spinnaker/core": ["../../core/lib"]
+      "@spinnaker/core": ["../../core/lib"],
+      "core/*": ["core/src/*"]
     }
   },
-  "files": [
-    "src/index.ts"
-  ],
-  "exclude": [
-    "./lib",
-    "**/*.spec.*"
-  ]
+  "files": ["src/index.ts"],
+  "exclude": ["./lib", "**/*.spec.*"]
 }

--- a/app/scripts/modules/ecs/tsconfig.json
+++ b/app/scripts/modules/ecs/tsconfig.json
@@ -30,6 +30,7 @@
     "typeRoots": ["../../../../node_modules/@types"],
     "paths": {
       "@spinnaker/core": ["../../core/lib"],
+      "core/*": ["../../core/lib/*"],
       "@spinnaker/amazon": ["../../amazon/lib"],
       "ecs/*": ["*"],
       "ecs": ["."]

--- a/app/scripts/modules/google/tsconfig.json
+++ b/app/scripts/modules/google/tsconfig.json
@@ -9,10 +9,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "jsx": "react",
-    "lib": [
-      "es2016",
-      "dom"
-    ],
+    "lib": ["es2016", "dom"],
     "moduleResolution": "node",
     "module": "commonjs",
     "noEmitHelpers": false,
@@ -30,21 +27,14 @@
     "inlineSources": true,
     "strictNullChecks": false,
     "target": "es6",
-    "typeRoots": [
-      "../../../../node_modules/@types"
-    ],
+    "typeRoots": ["../../../../node_modules/@types"],
     "paths": {
       "@spinnaker/core": ["../../core/lib"],
+      "core/*": ["../../core/lib/*"],
       "google/*": ["*"],
       "google": ["."]
     }
   },
-  "include": [
-    "src/**/*.ts",
-    "src/**/*.tsx"
-  ],
-  "exclude": [
-    "./lib",
-    "**/*.spec.*"
-  ]
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["./lib", "**/*.spec.*"]
 }

--- a/app/scripts/modules/kubernetes/tsconfig.json
+++ b/app/scripts/modules/kubernetes/tsconfig.json
@@ -30,6 +30,7 @@
     "typeRoots": ["../../../../node_modules/@types"],
     "paths": {
       "@spinnaker/core": ["../../core/lib"],
+      "core/*": ["../../core/lib/*"],
       "kubernetes/*": ["*"],
       "kubernetes": ["."]
     }

--- a/app/scripts/modules/openstack/tsconfig.json
+++ b/app/scripts/modules/openstack/tsconfig.json
@@ -9,10 +9,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "jsx": "react",
-    "lib": [
-      "es2016",
-      "dom"
-    ],
+    "lib": ["es2016", "dom"],
     "moduleResolution": "node",
     "module": "commonjs",
     "noEmitHelpers": false,
@@ -30,19 +27,12 @@
     "inlineSources": true,
     "strictNullChecks": false, // should really get to a place where we can turn this on
     "target": "es6",
-    "typeRoots": [
-      "../../../../node_modules/@types"
-    ],
+    "typeRoots": ["../../../../node_modules/@types"],
     "paths": {
-      "@spinnaker/core": ["../../core/lib"]
+      "@spinnaker/core": ["../../core/lib"],
+      "core/*": ["core/src/*"]
     }
   },
-  "include": [
-    "src/**/*.ts",
-    "src/**/*.tsx"
-  ],
-  "exclude": [
-    "./lib",
-    "**/*.spec.*"
-  ]
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["./lib", "**/*.spec.*"]
 }

--- a/app/scripts/modules/oracle/tsconfig.json
+++ b/app/scripts/modules/oracle/tsconfig.json
@@ -30,6 +30,7 @@
     "typeRoots": ["../../../../node_modules/@types"],
     "paths": {
       "@spinnaker/core": ["../../core/lib"],
+      "core/*": ["../../core/lib/*"],
       "oracle/*": ["*"],
       "oracle": ["."]
     }

--- a/app/scripts/modules/titus/tsconfig.json
+++ b/app/scripts/modules/titus/tsconfig.json
@@ -30,6 +30,7 @@
     "typeRoots": ["../../../../node_modules/@types"],
     "paths": {
       "@spinnaker/core": ["../../core/lib"],
+      "core/*": ["../../core/lib/*"],
       "@spinnaker/docker": ["../../docker/lib"],
       "@spinnaker/amazon": ["../../amazon/lib"],
       "titus/*": ["*"],


### PR DESCRIPTION
I made some changes in core and tried building all the downstream modules using `gradle/buildModules.sh`.  Typescript complains that it doesn't understand the props being passed to the component from `core` when running `npm run lib` from `amazon` module (for example).

## Errors during npm run lib:

```
src/loadBalancer/configure/common/LoadBalancerLocation.tsx:346:19 - error TS2339: Property 'value' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<AccountSelectInput> & Readonly<{ children?: ReactNode; }> & Readonly<IAccountSelectInputProps>'.

346                   value={values.credentials}
                      ~~~~~~~~~~~~~~~~~~~~~~~~~~

src/loadBalancer/configure/common/LoadBalancerLocation.tsx:347:29 - error TS7006: Parameter 'evt' implicitly has an 'any' type.

347                   onChange={evt => this.accountUpdated(evt.target.value)}
                                ~~~

src/serverGroup/configure/wizard/pages/ServerGroupBasicSettings.tsx:320:15 - error TS2339: Property 'value' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<AccountSelectInput> & Readonly<{ children?: ReactNode; }> & Readonly<IAccountSelectInputProps>'.

320               value={values.credentials}
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~

src/serverGroup/configure/wizard/pages/ServerGroupBasicSettings.tsx:321:25 - error TS7006: Parameter 'evt' implicitly has an 'any' type.

321               onChange={evt => this.accountUpdated(evt.target.value)}
                            ~~~
```

## traceResolution before change

When I checked the module resolution details using `../../../../node_modules/.bin/tsc --traceResolution > resolution.txt` I found that the `core` alias was being followed from `AccountSelectInput.d.ts` and ended up unresolved:


```
======== Resolving module 'core/presentation' from '/redacted/spinnaker/deck/app/scripts/modules/core/lib/account/AccountSelectInput.d.ts'. ========
Explicitly specified module resolution kind: 'NodeJs'.
'baseUrl' option is set to '/redacted/spinnaker/deck/app/scripts/modules/amazon/src', using this value to resolve non-relative module name 'core/presentation'.
'paths' option is specified, looking for a pattern to match module name 'core/presentation'.
Resolving module name 'core/presentation' relative to base url '/redacted/spinnaker/deck/app/scripts/modules/amazon/src' - '/redacted/spinnaker/deck/app/scripts/modules/amazon/src/core/presentation
'.
Loading module as file / folder, candidate module location '/redacted/spinnaker/deck/app/scripts/modules/amazon/src/core/presentation', target file type 'TypeScript'.
Loading module 'core/presentation' from 'node_modules' folder, target file type 'TypeScript'.
Directory '/redacted/spinnaker/deck/app/scripts/modules/core/lib/account/node_modules' does not exist, skipping all lookups in it.
Directory '/redacted/spinnaker/deck/app/scripts/modules/core/lib/node_modules' does not exist, skipping all lookups in it.
Directory '/redacted/spinnaker/deck/app/scripts/modules/core/node_modules/@types' does not exist, skipping all lookups in it.
Directory '/redacted/spinnaker/deck/app/scripts/modules/node_modules' does not exist, skipping all lookups in it.
Directory '/redacted/spinnaker/deck/app/scripts/node_modules' does not exist, skipping all lookups in it.
Directory '/redacted/spinnaker/deck/app/node_modules' does not exist, skipping all lookups in it.
Directory '/redacted/spinnaker/node_modules' does not exist, skipping all lookups in it.
Directory '/redacted/node_modules' does not exist, skipping all lookups in it.
Directory '/Users/cthielen/node_modules/@types' does not exist, skipping all lookups in it.
Directory '/Users/node_modules' does not exist, skipping all lookups in it.
Directory '/node_modules' does not exist, skipping all lookups in it.
'baseUrl' option is set to '/redacted/spinnaker/deck/app/scripts/modules/amazon/src', using this value to resolve non-relative module name 'core/presentation'.
'paths' option is specified, looking for a pattern to match module name 'core/presentation'.
Resolving module name 'core/presentation' relative to base url '/redacted/spinnaker/deck/app/scripts/modules/amazon/src' - '/redacted/spinnaker/deck/app/scripts/modules/amazon/src/core/presentation
'.
Loading module as file / folder, candidate module location '/redacted/spinnaker/deck/app/scripts/modules/amazon/src/core/presentation', target file type 'JavaScript'.
Loading module 'core/presentation' from 'node_modules' folder, target file type 'JavaScript'.
Directory '/redacted/spinnaker/deck/app/scripts/modules/core/lib/account/node_modules' does not exist, skipping all lookups in it.
Directory '/redacted/spinnaker/deck/app/scripts/modules/core/lib/node_modules' does not exist, skipping all lookups in it.
Directory '/redacted/spinnaker/deck/app/scripts/modules/node_modules' does not exist, skipping all lookups in it.
Directory '/redacted/spinnaker/deck/app/scripts/node_modules' does not exist, skipping all lookups in it.
Directory '/redacted/spinnaker/deck/app/node_modules' does not exist, skipping all lookups in it.
Directory '/redacted/spinnaker/node_modules' does not exist, skipping all lookups in it.
Directory '/redacted/node_modules' does not exist, skipping all lookups in it.
Directory '/Users/node_modules' does not exist, skipping all lookups in it.
Directory '/node_modules' does not exist, skipping all lookups in it.
======== Module name 'core/presentation' was not resolved. ========
```
Note that the last line says `was not resolved`.  🤔 

## traceResolution after change

After adding the `core` alias to `modules/amazon/tsconfig.json` `paths` array, the alias is now resolved from `../../core/lib/....`.
I'm not sure if this is the right solution or not, but it seemed to get me out of the current jam.

```
======== Resolving module 'core/presentation' from '/redacted/spinnaker/deck/app/scripts/modules/core/lib/account/AccountSelectInput.d.ts'. ========
Explicitly specified module resolution kind: 'NodeJs'.
'baseUrl' option is set to '/redacted/spinnaker/deck/app/scripts/modules/amazon/src', using this value to resolve non-relative module name 'core/presentation'.
'paths' option is specified, looking for a pattern to match module name 'core/presentation'.
Module name 'core/presentation', matched pattern 'core/*'.
Trying substitution '../../core/lib/*', candidate module location: '../../core/lib/presentation'.
Loading module as file / folder, candidate module location '/redacted/spinnaker/deck/app/scripts/modules/core/lib/presentation', target file type 'TypeScript'.
File '/redacted/spinnaker/deck/app/scripts/modules/core/lib/presentation.ts' does not exist.
File '/redacted/spinnaker/deck/app/scripts/modules/core/lib/presentation.tsx' does not exist.
File '/redacted/spinnaker/deck/app/scripts/modules/core/lib/presentation.d.ts' does not exist.
File '/redacted/spinnaker/deck/app/scripts/modules/core/lib/presentation/package.json' does not exist.
File '/redacted/spinnaker/deck/app/scripts/modules/core/lib/presentation/index.ts' does not exist.
File '/redacted/spinnaker/deck/app/scripts/modules/core/lib/presentation/index.tsx' does not exist.
File '/redacted/spinnaker/deck/app/scripts/modules/core/lib/presentation/index.d.ts' exist - use it as a name resolution result.
======== Module name 'core/presentation' was successfully resolved to '/redacted/spinnaker/deck/app/scripts/modules/core/lib/presentation/index.d.ts'. ========
```


