### PR TITLE
fix(core): do not cache getAllSecurityGroups API call

### DIFF
--- a/app/scripts/modules/core/src/securityGroup/securityGroupReader.service.ts
+++ b/app/scripts/modules/core/src/securityGroup/securityGroupReader.service.ts
@@ -288,7 +288,6 @@ export class SecurityGroupReader {
       return this.$q.resolve(cached);
     }
     return API.one('securityGroups')
-      .useCache()
       .get()
       .then((groupsByAccount: ISecurityGroupsByAccountSourceData) => {
         Object.keys(groupsByAccount).forEach(account => {


### PR DESCRIPTION
There is no reason to cache this call! We try to get the data out of local storage, but if it is not there (because the cache has expired or, more likely, been invalidated because it was missing something), we need to get new data from the server. If we always returned the first API call we made from the server, we're never going to get new data.

This is why, when you create a new server group, all security groups disappear from the page. The data source gets into a state where it keeps trying to reload the data, because it does not trust what it's getting back, but it just reloads the data from the HTTP cache.

Some work needs to be done still on the security group caching - it would be nice to remove the need for caching in local storage altogether - but this is a quick easy fix for a problem that has been around for some time?

@christopherthielen there is still an issue where the new security group details won't load if there is already a security group details panel open. I see the state change events fire to replace the current details with the new one, but then there is another state change event to replace it again with the old params. Maybe we can walk through it on Monday if you have time.