### PR TITLE
feat(core): increase visibility of hover on clickable pods

### DIFF
--- a/app/scripts/modules/amazon/src/loadBalancer/TargetGroup.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/TargetGroup.tsx
@@ -42,7 +42,7 @@ export class TargetGroup extends React.Component<ITargetGroupProps> {
       <div className="target-group-container container-fluid no-padding">
         <UISrefActive class="active">
           <UISref to=".targetGroupDetails" params={params}>
-            <div className={`clickable clickable-row row no-margin-top target-group-header`}>
+            <div className={`clickable clickable-row row no-margin-y target-group-header`}>
               <div className="col-md-8 target-group-title">{targetGroup.name}</div>
               <div className="col-md-4 text-right">
                 <HealthCounts container={targetGroup.instanceCounts} />

--- a/app/scripts/modules/amazon/src/loadBalancer/targetGroup.less
+++ b/app/scripts/modules/amazon/src/loadBalancer/targetGroup.less
@@ -9,9 +9,8 @@
 
 .cluster-container {
   .target-group-container {
-    margin-top: 5px;
+    margin-top: 3px;
     &:not(:first-child) {
-      margin-top: 3px;
       padding-top: 5px;
     }
   }
@@ -28,12 +27,13 @@
       margin-top: -1px;
     }
   }
-  .no-margin-top {
+  .no-margin-y {
     margin-top: -1px !important;
+    margin-bottom: 0 !important;
   }
 
-  >div {
-    >.text-right {
+  > div {
+    > .text-right {
       padding-right: 10px;
       font-weight: 600;
     }

--- a/app/scripts/modules/core/src/cluster/rollups.less
+++ b/app/scripts/modules/core/src/cluster/rollups.less
@@ -367,13 +367,17 @@ running-tasks-tag {
   .clickable-row {
     background-color: var(--color-white);
     border: 1px solid var(--color-alto);
-    margin: 5px 15px 0;
+    margin: 5px 15px 3px;
+    position: relative;
+    z-index: 1;
     &.active {
       border-color: var(--color-accent-g1);
       background-color: var(--color-accent-g3);
     }
     &:hover {
       border-color: var(--color-accent-g1);
+      box-shadow: 0 0 4px 2px var(--color-accent-g1);
+      z-index: 2;
     }
 
     &.managed {

--- a/app/scripts/modules/core/src/loadBalancer/LoadBalancerServerGroup.tsx
+++ b/app/scripts/modules/core/src/loadBalancer/LoadBalancerServerGroup.tsx
@@ -45,7 +45,7 @@ export class LoadBalancerServerGroup extends React.Component<
     const className = classNames({
       clickable: true,
       'clickable-row': true,
-      'no-margin-top': true,
+      'no-margin-y': true,
       disabled: serverGroup.isDisabled,
     });
 

--- a/app/scripts/modules/core/src/loadBalancer/loadBalancerPod.less
+++ b/app/scripts/modules/core/src/loadBalancer/loadBalancerPod.less
@@ -1,11 +1,12 @@
-@import (reference) "~core/presentation/less/imports/commonImports.less";
+@import (reference) '~core/presentation/less/imports/commonImports.less';
 
 .load-balancer-pod {
   .cluster-container {
     padding: 3px 15px;
     &.disabled {
       opacity: 0.4;
-      &:active, &:hover {
+      &:active,
+      &:hover {
         opacity: 0.7;
       }
     }
@@ -17,14 +18,14 @@
     .pod-subgroup {
       h6 {
         padding-bottom: 10px;
-        background: rgba(0,0,0,0);
+        background: rgba(0, 0, 0, 0);
       }
     }
   }
   .load-balancer-header {
     overflow: hidden;
     background-color: var(--color-alabaster);
-    padding: 8px 20px 0 20px;
+    padding: 8px 20px 3px 20px;
     .health-counts {
       .instance-health-counts {
         margin-top: -2px;
@@ -32,7 +33,7 @@
     }
   }
   .load-balancer {
-    >.cluster-container {
+    > .cluster-container {
       padding-top: 0;
     }
   }


### PR DESCRIPTION
We have an extremely minimal affordance to indicate a user can click on a server group, load balancer, or security group - just a color change of the border from gray to blue:

_Server group (first one hovered)_
<img width="727" alt="screen shot 2018-12-05 at 10 45 13 pm" src="https://user-images.githubusercontent.com/73450/49566465-8ce4cb00-f8df-11e8-959d-27fdc40770d9.png">

_Load balancer_
<img width="711" alt="screen shot 2018-12-05 at 10 45 23 pm" src="https://user-images.githubusercontent.com/73450/49566542-ccabb280-f8df-11e8-824f-6b03634d01d4.png">


_Target group within a load balancer_
<img width="708" alt="screen shot 2018-12-05 at 10 45 30 pm" src="https://user-images.githubusercontent.com/73450/49566456-86565380-f8df-11e8-9e94-616973b281ab.png">


This is not the ultimate solution to discoverability that these things are clickable, but it's surely better than what we currently have?

_Server group_
<img width="708" alt="screen shot 2018-12-05 at 10 43 33 pm" src="https://user-images.githubusercontent.com/73450/49566373-3ecfc780-f8df-11e8-8956-877e9e306749.png">

_Load balancer_
<img width="710" alt="screen shot 2018-12-05 at 10 44 14 pm" src="https://user-images.githubusercontent.com/73450/49566413-5eff8680-f8df-11e8-92a4-087df8e1562b.png">

_Target group_
<img width="705" alt="screen shot 2018-12-05 at 10 44 22 pm" src="https://user-images.githubusercontent.com/73450/49566409-5ad36900-f8df-11e8-9fd4-928f7a170f26.png">
