### PR TITLE
feat(runJob): Adding support for preconfigured run job stages

### DIFF
--- a/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupConfiguration.service.ts
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupConfiguration.service.ts
@@ -241,6 +241,15 @@ export class AwsServerGroupConfigurationService {
             loadBalancerReloader = this.refreshLoadBalancers(cmd, true);
           }
         }
+
+        if (cmd.targetGroups && cmd.targetGroups.length) {
+          // verify all target groups are accounted for; otherwise, try refreshing load balancers cache
+          const targetGroupNames = this.getTargetGroupNames(cmd);
+          if (intersection(targetGroupNames, cmd.targetGroups).length < cmd.targetGroups.length) {
+            loadBalancerReloader = this.refreshLoadBalancers(cmd, true);
+          }
+        }
+
         if (cmd.securityGroups && cmd.securityGroups.length) {
           const regionalSecurityGroupIds = map(this.getRegionalSecurityGroups(cmd), 'id');
           if (intersection(cmd.securityGroups, regionalSecurityGroupIds).length < cmd.securityGroups.length) {

--- a/app/scripts/modules/core/src/pipeline/config/stages/core/IStageConfigProps.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/core/IStageConfigProps.ts
@@ -4,7 +4,7 @@ import { IStage } from 'core/domain';
 export interface IStageConfigProps {
   application: Application;
   stage: IStage;
-  configuration: any;
+  configuration?: any;
   stageFieldUpdated: () => void;
   updateStageField: (changes: { [key: string]: any }) => void;
 }

--- a/app/scripts/modules/core/src/pipeline/config/stages/core/IStageConfigProps.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/core/IStageConfigProps.ts
@@ -4,6 +4,7 @@ import { IStage } from 'core/domain';
 export interface IStageConfigProps {
   application: Application;
   stage: IStage;
+  configuration: any;
   stageFieldUpdated: () => void;
   updateStageField: (changes: { [key: string]: any }) => void;
 }

--- a/app/scripts/modules/core/src/pipeline/config/stages/preconfiguredJob/PreconfiguredJobExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/preconfiguredJob/PreconfiguredJobExecutionDetails.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+
+import {
+  IExecutionDetailsSectionProps,
+  ExecutionDetailsSection,
+  StageExecutionLogs,
+  StageFailureMessage,
+} from 'core/pipeline';
+
+export function PreconfiguredJobExecutionDetails(props: IExecutionDetailsSectionProps) {
+  const { stage, name, current } = props;
+
+  return (
+    <ExecutionDetailsSection name={name} current={current}>
+      <StageFailureMessage stage={stage} message={stage.failureMessage} />
+      <StageExecutionLogs stage={stage} />
+    </ExecutionDetailsSection>
+  );
+}
+
+export namespace PreconfiguredJobExecutionDetails {
+  export const title = 'preconfiguredJobConfig';
+}

--- a/app/scripts/modules/core/src/pipeline/config/stages/preconfiguredJob/PreconfiguredJobStageConfig.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/preconfiguredJob/PreconfiguredJobStageConfig.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import { set } from 'lodash';
+
+import { IStageConfigProps, StageConfigField } from 'core/pipeline';
+import { IPreconfiguredJobParameter } from './preconfiguredJobStage';
+
+export class PreconfiguredJobStageConfig extends React.Component<IStageConfigProps> {
+  private parameterFieldChanged = (fieldIndex: string, value: any) => {
+    set(this.props.stage, `parameters.${fieldIndex}`, value);
+    this.props.stageFieldUpdated();
+    this.forceUpdate();
+  };
+
+  public render() {
+    const {
+      stage: { parameters = {} },
+      configuration,
+    } = this.props;
+
+    return (
+      <div className="form-horizontal">
+        {configuration.parameters.map((parameter: IPreconfiguredJobParameter) => (
+          <StageConfigField label={parameter.label}>
+            <input
+              type="text"
+              className="form-control input-sm"
+              value={parameters[parameter.name]}
+              onChange={e => this.parameterFieldChanged(parameter.name, e.target.value)}
+            />
+          </StageConfigField>
+        ))}
+      </div>
+    );
+  }
+}

--- a/app/scripts/modules/core/src/pipeline/config/stages/preconfiguredJob/preconfiguredJobStage.module.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/preconfiguredJob/preconfiguredJobStage.module.ts
@@ -1,8 +1,8 @@
 import { module } from 'angular';
 
-import { PRECONFIGUREDJOB_STAGE } from './preconfiguredJobStage';
-import { STAGE_CORE_MODULE } from '../core/stage.core.module';
 import { TIME_FORMATTERS } from 'core/utils/timeFormatters';
+import { STAGE_CORE_MODULE } from '../core/stage.core.module';
+import { PRECONFIGUREDJOB_STAGE } from './preconfiguredJobStage';
 
 export const PRECONFIGUREDJOB_STAGE_MODULE = 'spinnaker.core.pipeline.stage.preconfiguredjob';
 module(PRECONFIGUREDJOB_STAGE_MODULE, [

--- a/app/scripts/modules/core/src/pipeline/config/stages/preconfiguredJob/preconfiguredJobStage.module.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/preconfiguredJob/preconfiguredJobStage.module.ts
@@ -1,0 +1,13 @@
+import { module } from 'angular';
+
+import { PRECONFIGUREDJOB_STAGE } from './preconfiguredJobStage';
+import { STAGE_CORE_MODULE } from '../core/stage.core.module';
+import { TIME_FORMATTERS } from 'core/utils/timeFormatters';
+
+export const PRECONFIGUREDJOB_STAGE_MODULE = 'spinnaker.core.pipeline.stage.preconfiguredjob';
+module(PRECONFIGUREDJOB_STAGE_MODULE, [
+  PRECONFIGUREDJOB_STAGE,
+  require('../stage.module.js').name,
+  STAGE_CORE_MODULE,
+  TIME_FORMATTERS,
+]);

--- a/app/scripts/modules/core/src/pipeline/config/stages/preconfiguredJob/preconfiguredJobStage.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/preconfiguredJob/preconfiguredJobStage.ts
@@ -1,0 +1,49 @@
+import { module } from 'angular';
+
+import { API } from 'core/api/ApiService';
+import { Registry } from 'core/registry';
+
+import { ExecutionDetailsTasks } from '../core';
+import { PreconfiguredJobExecutionDetails } from './PreconfiguredJobExecutionDetails';
+import { PreconfiguredJobStageConfig } from './PreconfiguredJobStageConfig';
+
+export interface IPreconfiguredJobParameter {
+  name: string;
+  label: string;
+  description?: string;
+  type: string;
+  defaultValue?: string;
+}
+
+interface IPreconfiguredJob {
+  type: string;
+  label: string;
+  noUserConfigurableFields: boolean;
+  description?: string;
+  waitForCompletion?: boolean;
+  parameters?: IPreconfiguredJobParameter[];
+}
+
+export const PRECONFIGUREDJOB_STAGE = 'spinnaker.core.pipeline.stage.preconfiguredJobStage';
+
+module(PRECONFIGUREDJOB_STAGE, []).run(() => {
+  API.one('jobs')
+    .all('preconfigured')
+    .getList()
+    .then((preconfiguredJobs: IPreconfiguredJob[]) => {
+      preconfiguredJobs.forEach((preconfiguredJob: IPreconfiguredJob) => {
+        const { label, description, type, waitForCompletion, parameters } = preconfiguredJob;
+        Registry.pipeline.registerStage({
+          label,
+          description,
+          key: type,
+          component: PreconfiguredJobStageConfig,
+          executionDetailsSections: [PreconfiguredJobExecutionDetails, ExecutionDetailsTasks],
+          configuration: {
+            waitForCompletion,
+            parameters,
+          },
+        });
+      });
+    });
+});

--- a/app/scripts/modules/core/src/pipeline/config/stages/preconfiguredJob/preconfiguredJobStage.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/preconfiguredJob/preconfiguredJobStage.ts
@@ -31,7 +31,7 @@ module(PRECONFIGUREDJOB_STAGE, []).run(() => {
     .all('preconfigured')
     .getList()
     .then((preconfiguredJobs: IPreconfiguredJob[]) => {
-      preconfiguredJobs.forEach((preconfiguredJob: IPreconfiguredJob) => {
+      preconfiguredJobs.forEach(preconfiguredJob => {
         const { label, description, type, waitForCompletion, parameters } = preconfiguredJob;
         Registry.pipeline.registerStage({
           label,

--- a/app/scripts/modules/core/src/pipeline/config/stages/stage.module.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/stage.module.js
@@ -200,6 +200,7 @@ module.exports = angular
               },
               stage: $scope.stage,
               component: config.component,
+              configuration: config.configuration,
             };
             ReactDOM.render(React.createElement(StageConfigWrapper, props), stageDetailsNode);
           } else {

--- a/app/scripts/modules/core/src/pipeline/pipeline.module.ts
+++ b/app/scripts/modules/core/src/pipeline/pipeline.module.ts
@@ -28,6 +28,8 @@ import { WERCKER_STAGE_MODULE } from './config/stages/wercker/werckerStage.modul
 import { UNMATCHED_STAGE_TYPE_STAGE } from './config/stages/unmatchedStageTypeStage/unmatchedStageTypeStage';
 import './config/stages/wait/waitStage';
 import './config/stages/evaluateVariables/evaluateVariablesStage';
+import './config/stages/preconfiguredJob/preconfiguredJobStage';
+import { PRECONFIGUREDJOB_STAGE_MODULE } from './config/stages/preconfiguredJob/preconfiguredJobStage.module';
 import { WEBHOOK_STAGE_MODULE } from './config/stages/webhook/webhookStage.module';
 import { PIPELINE_STATES } from './pipeline.states';
 import { BUILD_DISPLAY_NAME_FILTER } from './executionBuild/buildDisplayName.filter';
@@ -61,6 +63,7 @@ module(PIPELINE_MODULE, [
   GROUP_STAGE_MODULE,
   TRAVIS_STAGE_MODULE,
   WERCKER_STAGE_MODULE,
+  PRECONFIGUREDJOB_STAGE_MODULE,
   WEBHOOK_STAGE_MODULE,
   UNMATCHED_STAGE_TYPE_STAGE,
   require('./config/stages/bake/bakeStage.module').name,


### PR DESCRIPTION
Mostly driven by server data. Titus execution logs will need to be placed at `stage.context.execution.logs` for the Execution Details to properly link out to it though.