### PR TITLE
fix(core/amazon): avoid overflow on server group modal components

### DIFF
--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/ServerGroupCapacity.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/ServerGroupCapacity.tsx
@@ -37,7 +37,7 @@ class ServerGroupCapacityImpl extends React.Component<IServerGroupCapacityProps>
     const { setFieldValue, values } = this.props.formik;
 
     return (
-      <div className="clearfix">
+      <div className="container-fluid form-horizontal">
         <div className="row">
           <div className="col-md-12">
             <CapacitySelector command={values} setFieldValue={setFieldValue} MinMaxDesired={MinMaxDesired} />

--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/ServerGroupInstanceType.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/ServerGroupInstanceType.tsx
@@ -41,7 +41,7 @@ class ServerGroupInstanceTypeImpl extends React.Component<IServerGroupInstanceTy
 
     if (showTypeSelector && values) {
       return (
-        <div>
+        <div className="container-fluid form-horizontal">
           <InstanceArchetypeSelector
             command={values}
             onTypeChanged={this.instanceTypeChanged}

--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/ServerGroupLoadBalancers.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/ServerGroupLoadBalancers.tsx
@@ -252,7 +252,7 @@ class ServerGroupLoadBalancersImpl extends React.Component<
     }
 
     return (
-      <div className="row">
+      <div className="container-fluid form-horizontal">
         {targetGroupSection}
         {loadBalancersSection}
       </div>

--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/ServerGroupSecurityGroups.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/ServerGroupSecurityGroups.tsx
@@ -37,7 +37,7 @@ class ServerGroupSecurityGroupsImpl extends React.Component<IServerGroupSecurity
     const { values } = this.props.formik;
 
     return (
-      <div className="row">
+      <div className="container-fluid form-horizontal">
         <ServerGroupSecurityGroupsRemoved command={values} onClear={this.acknowledgeRemovedGroups} />
         <SecurityGroupSelector
           command={values}

--- a/app/scripts/modules/core/src/serverGroup/configure/common/instanceArchetypeDirective.html
+++ b/app/scripts/modules/core/src/serverGroup/configure/common/instanceArchetypeDirective.html
@@ -8,7 +8,7 @@
         <span is-visible="command.viewState.instanceProfile === instanceProfile.type"
               class="far fa-check-circle selected-indicator"></span>
     <div class="panel-heading">
-      <h4><span class="glyphicon glyphicon-{{instanceProfile.icon}}"></span><br/> {{instanceProfile.label}}</h4>
+      <h4><span class="glyphicon glyphicon-{{instanceProfile.icon}}"></span><div>{{instanceProfile.label}}</div></h4>
     </div>
   </button>
 </div>

--- a/app/scripts/modules/core/src/serverGroup/configure/common/v2instanceArchetype.directive.html
+++ b/app/scripts/modules/core/src/serverGroup/configure/common/v2instanceArchetype.directive.html
@@ -7,7 +7,7 @@
         <span is-visible="instanceArchetypeCtrl.command.viewState.instanceProfile === instanceProfile.type"
               class="far fa-check-circle selected-indicator"></span>
     <div class="panel-heading">
-      <h4><span class="glyphicon glyphicon-{{instanceProfile.icon}}"></span><br/> {{instanceProfile.label}}</h4>
+      <h4><span class="glyphicon glyphicon-{{instanceProfile.icon}}"></span><div>{{instanceProfile.label}}</div></h4>
     </div>
   </button>
 </div>


### PR DESCRIPTION
Fixes an obscure and kind of dumb Chrome-specific bug where, if a user enters a very long value in the `Image` field search box, the modal gets stuck over to the right. This happens because there are several component in the modal that are wider than the modal, but the `steps` div has `overflow-x: hidden`. When the super long entry goes into the search field, Chrome scrolls the content over to follow the cursor, but then leaves it pulled to the right:

<img width="895" alt="screen shot 2018-12-06 at 8 50 25 pm" src="https://user-images.githubusercontent.com/73450/49628677-764f7a00-f99a-11e8-8de5-692268516b01.png">


The trick is to make sure nothing actually blows over the width of the steps section by adding `container-fluid form-horizontal` classes to force the `form-group` divs to...look, there is a lot of Bootstrap and a lot of CSS happening in these modals. I barely understand why this fixes it.

Firefox and Safari handle this scenario correctly, FWIW.