### PR TITLE
refactor(core): alphabetize config, make onDemandClusterThreshold configurable

### DIFF
--- a/app/scripts/modules/core/src/cluster/cluster.service.ts
+++ b/app/scripts/modules/core/src/cluster/cluster.service.ts
@@ -9,6 +9,7 @@ import { FilterModelService } from 'core/filterModel';
 import { IArtifactExtractor, ICluster, IClusterSummary, IExecution, IExecutionStage, IServerGroup } from 'core/domain';
 import { ClusterState } from 'core/state';
 import { ProviderServiceDelegate } from 'core/cloudProvider';
+import { SETTINGS } from 'core/config/settings';
 
 import { taskMatcher } from './task.matcher';
 
@@ -31,7 +32,7 @@ export class ClusterService {
       const serverGroupLoader = API.one('applications')
         .one(application.name)
         .all('serverGroups');
-      dataSource.fetchOnDemand = clusters.length > ClusterService.ON_DEMAND_THRESHOLD;
+      dataSource.fetchOnDemand = clusters.length > SETTINGS.onDemandClusterThreshold;
       if (dataSource.fetchOnDemand) {
         dataSource.clusters = clusters;
         serverGroupLoader.withParams({

--- a/app/scripts/modules/core/src/config/settings.ts
+++ b/app/scripts/modules/core/src/config/settings.ts
@@ -16,15 +16,15 @@ export interface INotificationSettings {
     enabled: boolean;
   };
   hipchat: {
-    enabled: boolean;
     botName: string;
+    enabled: boolean;
   };
   sms: {
     enabled: boolean;
   };
   slack: {
-    enabled: boolean;
     botName: string;
+    enabled: boolean;
   };
   githubstatus: {
     enabled: boolean;
@@ -32,29 +32,28 @@ export interface INotificationSettings {
 }
 
 export interface IFeatures {
+  [key: string]: any;
   canary?: boolean;
+  chaosMonkey?: boolean;
+  dockerBake?: boolean;
   entityTags?: boolean;
   fiatEnabled?: boolean;
   iapRefresherEnabled?: boolean;
-  pipelines?: boolean;
-  notifications?: boolean;
-  clusterDiff?: boolean;
-  roscoMode?: boolean;
-  chaosMonkey?: boolean;
   // whether stages affecting infrastructure (like "Create Load Balancer") should be enabled or not
   infrastructureStages?: boolean;
   jobs?: boolean;
-  snapshots?: boolean;
-  dockerBake?: boolean;
-  pagerDuty?: boolean;
-  pipelineTemplates?: boolean;
-  versionedProviders?: boolean;
-  travis?: boolean;
   managedServiceAccounts?: boolean;
+  notifications?: boolean;
+  pagerDuty?: boolean;
+  pipelines?: boolean;
+  pipelineTemplates?: boolean;
   quietPeriod?: boolean;
-  wercker?: boolean;
+  roscoMode?: boolean;
+  snapshots?: boolean;
+  travis?: boolean;
   triggerViaEcho?: boolean;
-  [key: string]: any;
+  versionedProviders?: boolean;
+  wercker?: boolean;
 }
 
 export interface IDockerInsightSettings {
@@ -66,10 +65,10 @@ export interface ISpinnakerSettings {
   [key: string]: any;
 
   analytics: {
-    ga?: string;
     customConfig?: {
       siteSpeedSampleRate?: number;
     };
+    ga?: string;
   };
   authEnabled: boolean;
   authEndpoint: string;
@@ -98,9 +97,9 @@ export interface ISpinnakerSettings {
   };
   feature: IFeatures;
   feedback?: {
-    url: string;
-    text?: string;
     icon?: string;
+    text?: string;
+    url: string;
   };
   gateUrl: string;
   gitSources: string[];
@@ -108,8 +107,8 @@ export interface ISpinnakerSettings {
   notifications: INotificationSettings;
   pagerDuty?: {
     accountName?: string;
-    defaultSubject?: string;
     defaultDetails?: string;
+    defaultSubject?: string;
     required?: boolean;
   };
   pollSchedule: number;
@@ -117,12 +116,12 @@ export interface ISpinnakerSettings {
     [key: string]: IProviderSettings; // allows custom providers not typed in here (good for testing too)
   };
   pubsubProviders: string[];
+  quietPeriod: [string | number, string | number];
   resetProvider: (provider: string) => () => void;
   resetToOriginal: () => void;
   searchVersion: 1 | 2;
   triggerTypes: string[];
   useClassicFirewallLabels: boolean;
-  quietPeriod: [string | number, string | number];
 }
 
 export const SETTINGS: ISpinnakerSettings = (window as any).spinnakerSettings;

--- a/app/scripts/modules/core/src/config/settings.ts
+++ b/app/scripts/modules/core/src/config/settings.ts
@@ -105,6 +105,7 @@ export interface ISpinnakerSettings {
   gitSources: string[];
   maxPipelineAgeDays: number;
   notifications: INotificationSettings;
+  onDemandClusterThreshold: number;
   pagerDuty?: {
     accountName?: string;
     defaultDetails?: string;

--- a/halconfig/settings.js
+++ b/halconfig/settings.js
@@ -23,6 +23,7 @@ var jobsEnabled = '{%features.jobs%}' === 'true';
 var maxPipelineAgeDays = '{%maxPipelineAgeDays%}';
 var mineCanaryEnabled = '{%features.mineCanary%}' === 'true';
 var notificationsEnabled = '{%notifications.enabled%}' === 'true';
+var onDemandClusterThreshold = '{%onDemandClusterThreshold%}';
 var pipelineTemplatesEnabled = '{%features.pipelineTemplates%}' === 'true';
 var reduxLoggerEnabled = '{%canary.reduxLogger%}' === 'true';
 var showAllConfigsEnabled = '{%canary.showAllCanaryConfigs%}' === 'true';
@@ -165,6 +166,7 @@ window.spinnakerSettings = {
     },
     slack: slack,
   },
+  onDemandClusterThreshold: onDemandClusterThreshold,
   pagerDuty: {
     required: false,
   },

--- a/halconfig/settings.js
+++ b/halconfig/settings.js
@@ -1,34 +1,78 @@
 'use strict';
 
 var gateHost = '{%gate.baseUrl%}';
-var bakeryDetailUrl = gateHost + '/bakery/logs/{{context.region}}/{{context.status.resourceId}}';
-var authEndpoint = gateHost + '/auth/user';
-var authEnabled = '{%features.auth%}' === 'true';
-var chaosEnabled = '{%features.chaos%}' === 'true';
-var fiatEnabled = '{%features.fiat%}' === 'true';
-var iapRefresherEnabled = '{%features.iapRefresherEnabled}' === 'true';
-var jobsEnabled = '{%features.jobs%}' === 'true';
-var infrastructureStagesEnabled = '{%features.infrastructureStages%}' === 'true';
-var pipelineTemplatesEnabled = '{%features.pipelineTemplates%}' === 'true';
 var artifactsEnabled = '{%features.artifacts%}' === 'true';
-var travisEnabled = '{%features.travis%}' === 'true';
-var werckerEnabled = '{%features.wercker%}' === 'true';
-var mineCanaryEnabled = '{%features.mineCanary%}' === 'true';
-var reduxLoggerEnabled = '{%canary.reduxLogger%}' === 'true';
-var defaultMetricsAccountName = '{%canary.defaultMetricsAccount%}';
-var defaultStorageAccountName = '{%canary.defaultStorageAccount%}';
-var defaultCanaryJudge = '{%canary.defaultJudge%}';
-var defaultMetricsStore = '{%canary.defaultMetricsStore%}';
-var canaryStagesEnabled = '{%canary.stages%}' === 'true';
 var atlasWebComponentsUrl = '{%canary.atlasWebComponentsUrl%}';
-var templatesEnabled = '{%canary.templatesEnabled%}' === 'true';
-var showAllConfigsEnabled = '{%canary.showAllCanaryConfigs%}' === 'true';
+var authEnabled = '{%features.auth%}' === 'true';
+var authEndpoint = gateHost + '/auth/user';
+var bakeryDetailUrl = gateHost + '/bakery/logs/{{context.region}}/{{context.status.resourceId}}';
 var canaryFeatureDisabled = '{%canary.featureEnabled%}' !== 'true';
-var maxPipelineAgeDays = '{%maxPipelineAgeDays%}';
-var timezone = '{%timezone%}';
-var version = '{%version%}';
+var canaryStagesEnabled = '{%canary.stages%}' === 'true';
 var changelogGistId = '{%changelog.gist.id%}';
 var changelogGistName = '{%changelog.gist.name%}';
+var chaosEnabled = '{%features.chaos%}' === 'true';
+var defaultCanaryJudge = '{%canary.defaultJudge%}';
+var defaultMetricsStore = '{%canary.defaultMetricsStore%}';
+var defaultMetricsAccountName = '{%canary.defaultMetricsAccount%}';
+var defaultStorageAccountName = '{%canary.defaultStorageAccount%}';
+var entityTagsEnabled = false;
+var fiatEnabled = '{%features.fiat%}' === 'true';
+var iapRefresherEnabled = '{%features.iapRefresherEnabled}' === 'true';
+var infrastructureStagesEnabled = '{%features.infrastructureStages%}' === 'true';
+var jobsEnabled = '{%features.jobs%}' === 'true';
+var maxPipelineAgeDays = '{%maxPipelineAgeDays%}';
+var mineCanaryEnabled = '{%features.mineCanary%}' === 'true';
+var notificationsEnabled = '{%notifications.enabled%}' === 'true';
+var pipelineTemplatesEnabled = '{%features.pipelineTemplates%}' === 'true';
+var reduxLoggerEnabled = '{%canary.reduxLogger%}' === 'true';
+var showAllConfigsEnabled = '{%canary.showAllCanaryConfigs%}' === 'true';
+var slack = {
+  botName: '{%notifications.slack.botName%}',
+  enabled: '{%notifications.slack.enabled%}' === 'true',
+};
+var templatesEnabled = '{%canary.templatesEnabled%}' === 'true';
+var travisEnabled = '{%features.travis%}' === 'true';
+var timezone = '{%timezone%}';
+var version = '{%version%}';
+var werckerEnabled = '{%features.wercker%}' === 'true';
+
+// Cloud Providers
+var appengine = {
+  defaults: {
+    account: '{%appengine.default.account%}',
+    editLoadBalancerStageEnabled: '{%appengine.enabled%}' === 'true',
+  },
+};
+var aws = {
+  defaults: {
+    account: '{%aws.default.account%}',
+    iamRole: 'BaseIAMRole',
+    region: '{%aws.default.region%}',
+  },
+  defaultSecurityGroups: [],
+  loadBalancers: {
+    // if true, VPC load balancers will be created as internal load balancers if the selected subnet has a purpose
+    // tag that starts with "internal"
+    inferInternalFlagFromSubnet: false,
+  },
+  useAmiBlockDeviceMappings: false,
+};
+var azure = {
+  defaults: {
+    account: '{%azure.default.account%}',
+    region: '{%azure.default.region%}',
+  },
+};
+var dcos = {
+  defaults: {
+    account: '{%dcos.default.account%}',
+  },
+};
+var ecs = {
+  defaults: {
+    account: '{%ecs.default.account%}',
+  },
+};
 var gce = {
   defaults: {
     account: '{%google.default.account%}',
@@ -40,16 +84,10 @@ var gce = {
 var kubernetes = {
   defaults: {
     account: '{%kubernetes.default.account%}',
+    instanceLinkTemplate: '{{host}}/api/v1/proxy/namespaces/{{namespace}}/pods/{{name}}',
+    internalDNSNameTemplate: '{{name}}.{{namespace}}.svc.cluster.local',
     namespace: '{%kubernetes.default.namespace%}',
     proxy: '{%kubernetes.default.proxy%}',
-    internalDNSNameTemplate: '{{name}}.{{namespace}}.svc.cluster.local',
-    instanceLinkTemplate: '{{host}}/api/v1/proxy/namespaces/{{namespace}}/pods/{{name}}',
-  },
-};
-var appengine = {
-  defaults: {
-    account: '{%appengine.default.account%}',
-    editLoadBalancerStageEnabled: '{%appengine.enabled%}' === 'true',
   },
 };
 var openstack = {
@@ -58,102 +96,69 @@ var openstack = {
     region: '{%openstack.default.region%}',
   },
 };
-var azure = {
-  defaults: {
-    account: '{%azure.default.account%}',
-    region: '{%azure.default.region%}',
-  },
-};
 var oracle = {
   defaults: {
     account: '{%oracle.default.account%}',
     region: '{%oracle.default.region%}',
   },
 };
-var dcos = {
-  defaults: {
-    account: '{%dcos.default.account%}',
-  },
-};
-var aws = {
-  defaults: {
-    account: '{%aws.default.account%}',
-    region: '{%aws.default.region%}',
-    iamRole: 'BaseIAMRole',
-  },
-  defaultSecurityGroups: [],
-  loadBalancers: {
-    // if true, VPC load balancers will be created as internal load balancers if the selected subnet has a purpose
-    // tag that starts with "internal"
-    inferInternalFlagFromSubnet: false,
-  },
-  useAmiBlockDeviceMappings: false,
-};
-var ecs = {
-  defaults: {
-    account: '{%ecs.default.account%}',
-  },
-};
-var entityTagsEnabled = false;
-var netflixMode = false;
-var notificationsEnabled = '{%notifications.enabled%}' === 'true';
-var slack = {
-  enabled: '{%notifications.slack.enabled%}' === 'true',
-  botName: '{%notifications.slack.botName%}',
-};
 
 window.spinnakerSettings = {
-  version: version,
-  checkForUpdates: false,
-  defaultProviders: [
-    'aws',
-    'ecs',
-    'gce',
-    'azure',
-    'cloudfoundry',
-    'kubernetes',
-    'titus',
-    'openstack',
-    'oracle',
-    'dcos',
-  ],
-  gateUrl: gateHost,
-  bakeryDetailUrl: bakeryDetailUrl,
+  authEnabled: authEnabled,
   authEndpoint: authEndpoint,
-  pollSchedule: 30000,
-  defaultTimeZone: timezone, // see http://momentjs.com/timezone/docs/#/data-utilities/
-  defaultCategory: 'serverGroup',
-  defaultInstancePort: 80,
-  maxPipelineAgeDays: maxPipelineAgeDays,
-  providers: {
-    azure: azure,
-    aws: aws,
-    ecs: ecs,
-    gce: gce,
-    titus: {
-      defaults: {
-        account: 'titustestvpc',
-        region: 'us-east-1',
-        iamProfile: '{{application}}InstanceProfile',
-      },
-    },
-    openstack: openstack,
-    kubernetes: kubernetes,
-    appengine: appengine,
-    oracle: oracle,
-    dcos: dcos,
+  authTtl: 600000,
+  bakeryDetailUrl: bakeryDetailUrl,
+  canary: {
+    atlasWebComponentsUrl: atlasWebComponentsUrl,
+    defaultJudge: defaultCanaryJudge,
+    featureDisabled: canaryFeatureDisabled,
+    reduxLogger: reduxLoggerEnabled,
+    metricsAccountName: defaultMetricsAccountName,
+    metricStore: defaultMetricsStore,
+    showAllConfigs: showAllConfigsEnabled,
+    stagesEnabled: canaryStagesEnabled,
+    storageAccountName: defaultStorageAccountName,
+    templatesEnabled: templatesEnabled,
   },
   changelog: {
-    gistId: changelogGistId,
     fileName: changelogGistName,
+    gistId: changelogGistId,
   },
+  checkForUpdates: false,
+  defaultCategory: 'serverGroup',
+  defaultInstancePort: 80,
+  defaultProviders: ['aws', 'azure', 'dcos', 'ecs', 'gce', 'kubernetes', 'openstack', 'oracle', 'titus'],
+  defaultTimeZone: timezone, // see http://momentjs.com/timezone/docs/#/data-utilities/
+  feature: {
+    artifacts: artifactsEnabled,
+    canary: mineCanaryEnabled,
+    chaosMonkey: chaosEnabled,
+    entityTags: entityTagsEnabled,
+    fiatEnabled: fiatEnabled,
+    iapRefresherEnabled: iapRefresherEnabled,
+    infrastructureStages: infrastructureStagesEnabled,
+    jobs: jobsEnabled,
+    notifications: notificationsEnabled,
+    pagerDuty: false,
+    pipelines: true,
+    pipelineTemplates: pipelineTemplatesEnabled,
+    roscoMode: true,
+    snapshots: false,
+    travis: travisEnabled,
+    triggerViaEcho: true,
+    versionedProviders: true,
+    wercker: werckerEnabled,
+  },
+  gateUrl: gateHost,
+  gitSources: ['bitbucket', 'gitlab', 'github', 'stash'],
+  maxPipelineAgeDays: maxPipelineAgeDays,
   notifications: {
     email: {
       enabled: true,
     },
     hipchat: {
-      enabled: true,
       botName: 'Skynet T-800',
+      enabled: true,
     },
     sms: {
       enabled: true,
@@ -163,45 +168,26 @@ window.spinnakerSettings = {
   pagerDuty: {
     required: false,
   },
-  authEnabled: authEnabled,
-  authTtl: 600000,
-  gitSources: ['stash', 'github', 'bitbucket', 'gitlab'],
+  pollSchedule: 30000,
+  providers: {
+    appengine: appengine,
+    aws: aws,
+    azure: azure,
+    dcos: dcos,
+    ecs: ecs,
+    gce: gce,
+    kubernetes: kubernetes,
+    openstack: openstack,
+    oracle: oracle,
+    titus: {
+      defaults: {
+        account: 'titustestvpc',
+        iamProfile: '{{application}}InstanceProfile',
+        region: 'us-east-1',
+      },
+    },
+  },
   pubsubProviders: ['google'], // TODO(joonlim): Add amazon once it is confirmed that amazon pub/sub works.
-  triggerTypes: ['git', 'pipeline', 'docker', 'cron', 'jenkins', 'wercker', 'travis', 'pubsub', 'webhook'],
-  canary: {
-    reduxLogger: reduxLoggerEnabled,
-    metricsAccountName: defaultMetricsAccountName,
-    storageAccountName: defaultStorageAccountName,
-    defaultJudge: defaultCanaryJudge,
-    metricStore: defaultMetricsStore,
-    stagesEnabled: canaryStagesEnabled,
-    atlasWebComponentsUrl: atlasWebComponentsUrl,
-    templatesEnabled: templatesEnabled,
-    showAllConfigs: showAllConfigsEnabled,
-    featureDisabled: canaryFeatureDisabled,
-  },
-  feature: {
-    entityTags: entityTagsEnabled,
-    fiatEnabled: fiatEnabled,
-    iapRefresherEnabled: iapRefresherEnabled,
-    netflixMode: netflixMode,
-    chaosMonkey: chaosEnabled,
-    jobs: jobsEnabled,
-    pipelineTemplates: pipelineTemplatesEnabled,
-    notifications: notificationsEnabled,
-    artifacts: artifactsEnabled,
-    canary: mineCanaryEnabled,
-    infrastructureStages: infrastructureStagesEnabled,
-    pipelines: true,
-    fastProperty: true,
-    vpcMigrator: true,
-    pagerDuty: false,
-    clusterDiff: false,
-    roscoMode: true,
-    snapshots: false,
-    travis: travisEnabled,
-    triggerViaEcho: true,
-    wercker: werckerEnabled,
-    versionedProviders: true,
-  },
+  triggerTypes: ['cron', 'docker', 'git', 'jenkins', 'pipeline', 'pubsub', 'travis', 'webhook', 'wercker'],
+  version: version,
 };

--- a/settings.js
+++ b/settings.js
@@ -20,6 +20,7 @@ var fiatEnabled = process.env.FIAT_ENABLED === 'true' ? true : false;
 var iapRefresherEnabled = process.env.IAP_REFRESHER_ENABLED === 'true' ? true : false;
 var infrastructureEnabled = process.env.INFRA_ENABLED === 'true' ? true : false;
 var managedServiceAccountsEnabled = process.env.MANAGED_SERVICE_ACCOUNTS_ENABLED === 'true';
+var onDemandClusterThreshold = process.env.ON_DEMAND_CLUSTER_THRESHOLD || '350';
 var reduxLoggerEnabled = process.env.REDUX_LOGGER === 'true';
 var templatesEnabled = process.env.TEMPLATES_ENABLED === 'true';
 var triggerViaEcho = process.env.TRIGGER_VIA_ECHO !== 'false';
@@ -91,6 +92,7 @@ window.spinnakerSettings = {
       enabled: true,
     },
   },
+  onDemandClusterThreshold: Number(onDemandClusterThreshold),
   pollSchedule: 30000,
   providers: {
     appengine: {

--- a/settings.js
+++ b/settings.js
@@ -1,48 +1,101 @@
 'use strict';
 
-var gateHost = process.env.API_HOST || 'http://localhost:8084';
-var bakeryDetailUrl =
-  process.env.BAKERY_DETAIL_URL || gateHost + '/bakery/logs/{{context.region}}/{{context.status.resourceId}}';
-var authEndpoint = process.env.AUTH_ENDPOINT || gateHost + '/auth/user';
+var apiHost = process.env.API_HOST || 'http://localhost:8084';
+var artifactsEnabled = process.env.ARTIFACTS_ENABLED === 'true';
+var atlasWebComponentsUrl = process.env.ATLAS_WEB_COMPONENTS_URL;
+var authEndpoint = process.env.AUTH_ENDPOINT || apiHost + '/auth/user';
 var authEnabled = process.env.AUTH_ENABLED === 'false' ? false : true;
-var netflixMode = process.env.NETFLIX_MODE === 'true' ? true : false;
-var chaosEnabled = netflixMode || process.env.CHAOS_ENABLED === 'true' ? true : false;
+var bakeryDetailUrl =
+  process.env.BAKERY_DETAIL_URL || apiHost + '/bakery/logs/{{context.region}}/{{context.status.resourceId}}';
+var canaryAccount = process.env.CANARY_ACCOUNT || '';
+var canaryEnabled = process.env.CANARY_ENABLED === 'true';
+var canaryFeatureDisabled = process.env.CANARY_FEATURE_ENABLED !== 'true';
+var canaryStagesEnabled = process.env.CANARY_STAGES_ENABLED === 'true';
+var chaosEnabled = process.env.CHAOS_ENABLED === 'true' ? true : false;
+var debugEnabled = process.env.DEBUG_ENABLED === 'false' ? false : true;
+var defaultMetricStore = process.env.METRIC_STORE || 'atlas';
+var dryRunEnabled = process.env.DRYRUN_ENABLED === 'true' ? true : false;
+var entityTagsEnabled = process.env.ENTITY_TAGS_ENABLED === 'true' ? true : false;
 var fiatEnabled = process.env.FIAT_ENABLED === 'true' ? true : false;
 var iapRefresherEnabled = process.env.IAP_REFRESHER_ENABLED === 'true' ? true : false;
-var entityTagsEnabled = process.env.ENTITY_TAGS_ENABLED === 'true' ? true : false;
-var debugEnabled = process.env.DEBUG_ENABLED === 'false' ? false : true;
-var canaryEnabled = process.env.CANARY_ENABLED === 'true';
 var infrastructureEnabled = process.env.INFRA_ENABLED === 'true' ? true : false;
-var dryRunEnabled = process.env.DRYRUN_ENABLED === 'true' ? true : false;
-var reduxLoggerEnabled = process.env.REDUX_LOGGER === 'true';
-var defaultMetricStore = process.env.METRIC_STORE || 'atlas';
-var canaryStagesEnabled = process.env.CANARY_STAGES_ENABLED === 'true';
-var templatesEnabled = process.env.TEMPLATES_ENABLED === 'true';
-var atlasWebComponentsUrl = process.env.ATLAS_WEB_COMPONENTS_URL;
-var canaryAccount = process.env.CANARY_ACCOUNT || '';
-var canaryFeatureDisabled = process.env.CANARY_FEATURE_ENABLED !== 'true';
-var useClassicFirewallLabels = process.env.USE_CLASSIC_FIREWALL_LABELS === 'true';
-var artifactsEnabled = process.env.ARTIFACTS_ENABLED === 'true';
 var managedServiceAccountsEnabled = process.env.MANAGED_SERVICE_ACCOUNTS_ENABLED === 'true';
+var reduxLoggerEnabled = process.env.REDUX_LOGGER === 'true';
+var templatesEnabled = process.env.TEMPLATES_ENABLED === 'true';
 var triggerViaEcho = process.env.TRIGGER_VIA_ECHO !== 'false';
+var useClassicFirewallLabels = process.env.USE_CLASSIC_FIREWALL_LABELS === 'true';
 
 window.spinnakerSettings = {
+  authEnabled: authEnabled,
+  authEndpoint: authEndpoint,
+  authTtl: 600000,
+  bakeryDetailUrl: bakeryDetailUrl,
+  canary: {
+    atlasWebComponentsUrl: atlasWebComponentsUrl,
+    defaultJudge: 'NetflixACAJudge-v1.0',
+    featureDisabled: canaryFeatureDisabled,
+    metricsAccountName: canaryAccount,
+    metricStore: defaultMetricStore,
+    reduxLogger: reduxLoggerEnabled,
+    showAllConfigs: true,
+    stagesEnabled: canaryStagesEnabled,
+    storageAccountName: canaryAccount,
+    templatesEnabled: templatesEnabled,
+  },
   checkForUpdates: true,
   debugEnabled: debugEnabled,
-  defaultProviders: ['aws', 'gce', 'azure', 'cloudfoundry', 'kubernetes', 'dcos', 'openstack', 'oracle', 'ecs'],
-  gateUrl: gateHost,
-  bakeryDetailUrl: bakeryDetailUrl,
-  authEndpoint: authEndpoint,
-  pollSchedule: 30000,
-  maxPipelineAgeDays: 14,
-  defaultTimeZone: process.env.TIMEZONE || 'America/Los_Angeles', // see http://momentjs.com/timezone/docs/#/data-utilities/
   defaultCategory: 'serverGroup',
   defaultInstancePort: 80,
+  defaultProviders: ['aws', 'gce', 'azure', 'cloudfoundry', 'kubernetes', 'dcos', 'openstack', 'oracle', 'ecs'],
+  defaultTimeZone: process.env.TIMEZONE || 'America/Los_Angeles', // see http://momentjs.com/timezone/docs/#/data-utilities/
+  feature: {
+    artifacts: artifactsEnabled,
+    canary: canaryEnabled,
+    chaosMonkey: chaosEnabled,
+    dryRunEnabled: dryRunEnabled,
+    entityTags: entityTagsEnabled,
+    fiatEnabled: fiatEnabled,
+    iapRefresherEnabled: iapRefresherEnabled,
+    // whether stages affecting infrastructure (like "Create Load Balancer") should be enabled or not
+    infrastructureStages: infrastructureEnabled,
+    jobs: false,
+    managedServiceAccounts: managedServiceAccountsEnabled,
+    notifications: false,
+    pagerDuty: false,
+    pipelineTemplates: false,
+    pipelines: true,
+    quietPeriod: false,
+    roscoMode: false,
+    snapshots: false,
+    travis: false,
+    triggerViaEcho: triggerViaEcho,
+    versionedProviders: true,
+    wercker: false,
+  },
+  gateUrl: apiHost,
+  gitSources: ['stash', 'github', 'bitbucket', 'gitlab'],
+  maxPipelineAgeDays: 14,
+  notifications: {
+    email: {
+      enabled: true,
+    },
+    hipchat: {
+      botName: 'Skynet T-800',
+      enabled: true,
+    },
+    slack: {
+      botName: 'spinnakerbot',
+      enabled: true,
+    },
+    sms: {
+      enabled: true,
+    },
+  },
+  pollSchedule: 30000,
   providers: {
-    azure: {
+    appengine: {
       defaults: {
-        account: 'azure-test',
-        region: 'westus',
+        account: 'my-appengine-account',
       },
     },
     aws: {
@@ -53,27 +106,39 @@ window.spinnakerSettings = {
       },
       defaultSecurityGroups: [],
       loadBalancers: {
+        disableManualOidcDialog: false,
         // if true, VPC load balancers will be created as internal load balancers if the selected subnet has a purpose
         // tag that starts with "internal"
         inferInternalFlagFromSubnet: false,
-        disableManualOidcDialog: false,
       },
       useAmiBlockDeviceMappings: false,
+    },
+    azure: {
+      defaults: {
+        account: 'azure-test',
+        region: 'westus',
+      },
     },
     cloudfoundry: {
       defaults: {
         account: 'my-cloudfoundry-account',
       },
     },
+    dcos: {
+      defaults: {
+        account: 'my-dcos-account',
+      },
+    },
     ecs: {
       defaults: {
         account: 'test',
-        region: 'us-east-1',
         iamRole: 'BaseIAMRole',
+        region: 'us-east-1',
       },
       defaultSecurityGroups: [],
     },
     gce: {
+      associatePublicIpAddress: true,
       defaults: {
         account: 'my-google-account',
         instanceTypeStorage: {
@@ -81,8 +146,8 @@ window.spinnakerSettings = {
           defaultSettings: {
             disks: [
               {
-                type: 'pd-ssd',
                 sizeGb: 10,
+                type: 'pd-ssd',
               },
             ],
           },
@@ -92,20 +157,22 @@ window.spinnakerSettings = {
         region: 'us-central1',
         zone: 'us-central1-f',
       },
-      associatePublicIpAddress: true,
     },
-    titus: {
+    kubernetes: {
       defaults: {
-        account: 'titustestvpc',
-        region: 'us-east-1',
-        iamProfile: '{{application}}InstanceProfile',
+        account: 'my-kubernetes-account',
+        apiPrefix: 'api/v1/proxy/namespaces/kube-system/services/kubernetes-dashboard/#',
+        instanceLinkTemplate: '{{host}}/api/v1/proxy/namespaces/{{namespace}}/pods/{{name}}',
+        internalDNSNameTemplate: '{{name}}.{{namespace}}.svc.cluster.local',
+        namespace: 'default',
+        proxy: 'localhost:8001',
       },
     },
     oracle: {
       defaults: {
         account: 'DEFAULT',
-        region: 'us-phoenix-1',
         bakeryRegions: ['us-phoenix-1'],
+        region: 'us-phoenix-1',
       },
     },
     openstack: {
@@ -114,95 +181,23 @@ window.spinnakerSettings = {
         region: 'us-west-1',
       },
     },
-    kubernetes: {
+    titus: {
       defaults: {
-        account: 'my-kubernetes-account',
-        namespace: 'default',
-        proxy: 'localhost:8001',
-        internalDNSNameTemplate: '{{name}}.{{namespace}}.svc.cluster.local',
-        instanceLinkTemplate: '{{host}}/api/v1/proxy/namespaces/{{namespace}}/pods/{{name}}',
-        apiPrefix: 'api/v1/proxy/namespaces/kube-system/services/kubernetes-dashboard/#',
+        account: 'titustestvpc',
+        iamProfile: '{{application}}InstanceProfile',
+        region: 'us-east-1',
       },
-    },
-    dcos: {
-      defaults: {
-        account: 'my-dcos-account',
-      },
-    },
-    appengine: {
-      defaults: {
-        account: 'my-appengine-account',
-      },
-    },
-  },
-  whatsNew: {
-    gistId: '32526cd608db3d811b38',
-    fileName: 'news.md',
-  },
-  notifications: {
-    email: {
-      enabled: true,
-    },
-    hipchat: {
-      enabled: true,
-      botName: 'Skynet T-800',
-    },
-    sms: {
-      enabled: true,
-    },
-    slack: {
-      enabled: true,
-      botName: 'spinnakerbot',
     },
   },
   pagerDuty: {
     required: false,
   },
-  authEnabled: authEnabled,
-  authTtl: 600000,
-  gitSources: ['stash', 'github', 'bitbucket', 'gitlab'],
   pubsubProviders: ['google'], // TODO(joonlim): Add amazon once it is confirmed that amazon pub/sub works.
-  triggerTypes: ['git', 'pipeline', 'docker', 'cron', 'jenkins', 'wercker', 'travis', 'pubsub'],
   searchVersion: 1,
+  triggerTypes: ['cron', 'docker', 'git', 'jenkins', 'pipeline', 'pubsub', 'travis', 'wercker'],
   useClassicFirewallLabels: useClassicFirewallLabels,
-  canary: {
-    reduxLogger: reduxLoggerEnabled,
-    metricsAccountName: canaryAccount,
-    storageAccountName: canaryAccount,
-    defaultJudge: 'NetflixACAJudge-v1.0',
-    metricStore: defaultMetricStore,
-    stagesEnabled: canaryStagesEnabled,
-    atlasWebComponentsUrl: atlasWebComponentsUrl,
-    templatesEnabled: templatesEnabled,
-    showAllConfigs: true,
-    featureDisabled: canaryFeatureDisabled,
-  },
-  feature: {
-    artifacts: artifactsEnabled,
-    canary: canaryEnabled,
-    chaosMonkey: chaosEnabled,
-    clusterDiff: false,
-    dryRunEnabled: dryRunEnabled,
-    entityTags: entityTagsEnabled,
-    fastProperty: true,
-    fiatEnabled: fiatEnabled,
-    iapRefresherEnabled: iapRefresherEnabled,
-    // whether stages affecting infrastructure (like "Create Load Balancer") should be enabled or not
-    infrastructureStages: infrastructureEnabled,
-    jobs: false,
-    netflixMode: netflixMode,
-    notifications: false,
-    pagerDuty: false,
-    pipelineTemplates: false,
-    pipelines: true,
-    roscoMode: false,
-    snapshots: false,
-    triggerViaEcho: triggerViaEcho,
-    travis: false,
-    versionedProviders: true,
-    vpcMigrator: true,
-    wercker: false,
-    managedServiceAccounts: managedServiceAccountsEnabled,
-    quietPeriod: false,
+  whatsNew: {
+    fileName: 'news.md',
+    gistId: '32526cd608db3d811b38',
   },
 };


### PR DESCRIPTION
For https://github.com/spinnaker/spinnaker/issues/3699

The config alphabetization is a periodic refactor we (maybe just I) seem to do. I don't know if it's worth the hassle but I'm doing it anyway. Also clearing out some unused config flags/features: `vpcMigrator`, `netflixMode`, `fastProperty`, `clusterDiff`.