### PR TITLE
chore(core): bump version to 0.0.300

### DIFF
--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/core",
-  "version": "0.0.299",
+  "version": "0.0.300",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
Bump version of core to avail new exported FormikApplicationsPicker.

This new version include the following commits: 
https://github.com/spinnaker/deck/commit/e6cb682e8e6bf2df545373fcd74ba564a92ee5ce
https://github.com/spinnaker/deck/commit/2729fde6f31b2d2e53c9335a03b77c5c8a1e7bc6

