### PR TITLE
fix(core/presentation): Give WatchValue better typing, tolerate no children

### DIFF
--- a/app/scripts/modules/core/src/presentation/WatchValue.tsx
+++ b/app/scripts/modules/core/src/presentation/WatchValue.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 interface IWatchValueProps<T> {
   value: T;
   onChange: (newValue: T, oldValue: T) => void;
-  isEqual: (newValue: T, oldValue: T) => boolean;
+  isEqual?: (newValue: T, oldValue: T) => boolean;
 }
 
 interface IWatchValueState<T> {
@@ -36,6 +36,6 @@ export class WatchValue<T = any> extends React.Component<IWatchValueProps<T>, IW
   }
 
   public render() {
-    return this.props.children;
+    return this.props.children || null;
   }
 }


### PR DESCRIPTION
- `isEqual` is optional and ought to be typed as such
- Previously `render` would spit out `undefined`, which React finds displeasing