### PR TITLE
fix(core): do not load GA script if not configured

### DIFF
--- a/app/index.deck
+++ b/app/index.deck
@@ -175,11 +175,15 @@
   </script>
 
   <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
+    window.addEventListener('load', () => {
+      const settings = window.spinnakerSettings;
+      if (settings && (settings.analytics.ga || settings.analytics.customConfig) {
+        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+          m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+      }
+    });
   </script>
 
   <!-- Actually injects our application -->

--- a/app/scripts/modules/core/src/analytics/analytics.service.js
+++ b/app/scripts/modules/core/src/analytics/analytics.service.js
@@ -7,12 +7,13 @@ const angular = require('angular');
 module.exports = angular
   .module('spinnaker.core.analytics.service', [require('angulartics'), require('angulartics-google-analytics')])
   .run(function($window) {
-    if (SETTINGS.analytics.ga) {
+    if (SETTINGS.analytics.ga || SETTINGS.analytics.customConfig) {
+      $window.addEventListener('load', () => {
         if (SETTINGS.analytics.customConfig) {
-            $window.ga('create', SETTINGS.analytics.ga, SETTINGS.analytics.customConfig);
+          $window.ga('create', SETTINGS.analytics.ga, SETTINGS.analytics.customConfig);
+        } else {
+          $window.ga('create', SETTINGS.analytics.ga, 'auto');
         }
-        else {
-            $window.ga('create', SETTINGS.analytics.ga, 'auto');
-        }
+      });
     }
   });


### PR DESCRIPTION
Not that this is the biggest contributor to slow load times for Deck, but...might as well not load the Google Analytics script if it's not going to be used?