### PR TITLE
chore(docker): Bump version to 0.0.27

### DIFF
--- a/app/scripts/modules/docker/package.json
+++ b/app/scripts/modules/docker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/docker",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
adc4be1196681daef5433b5b2d7a1c0c6d784c26 fix(docker): Make sure to preselect define type for image selector (#6188)
