### PR TITLE
fix(aws): sort instance type options in server group modal

### DIFF
--- a/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupConfiguration.service.ts
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupConfiguration.service.ts
@@ -323,7 +323,7 @@ export class AwsServerGroupConfigurationService {
         result.dirty.instanceType = command.instanceType;
         command.instanceType = null;
       }
-      command.backingData.filtered.instanceTypes = filtered;
+      command.backingData.filtered.instanceTypes = filtered.sort();
     } else {
       command.backingData.filtered.instanceTypes = [];
     }


### PR DESCRIPTION
I kind of can't believe this hasn't come up before, but the instance type options are just in some random order.