### PR TITLE
fix(aws): really properly sort instance types

### DIFF
--- a/app/scripts/modules/amazon/src/instance/awsInstanceType.service.js
+++ b/app/scripts/modules/amazon/src/instance/awsInstanceType.service.js
@@ -192,12 +192,8 @@ module.exports = angular
       var type1 = o1.split('.'),
         type2 = o2.split('.');
 
-      if (type1.length !== 2 || type2.length !== 2) {
-        return 0;
-      }
-
-      let [family1, class1] = type1;
-      let [family2, class2] = type2;
+      let [family1, class1 = ''] = type1;
+      let [family2, class2 = ''] = type2;
 
       if (family1 !== family2) {
         if (family1 > family2) {

--- a/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupConfiguration.service.ts
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupConfiguration.service.ts
@@ -323,7 +323,7 @@ export class AwsServerGroupConfigurationService {
         result.dirty.instanceType = command.instanceType;
         command.instanceType = null;
       }
-      command.backingData.filtered.instanceTypes = filtered.sort();
+      command.backingData.filtered.instanceTypes = filtered;
     } else {
       command.backingData.filtered.instanceTypes = [];
     }


### PR DESCRIPTION
Turns out we have this great new instance type showing up, `p3dn`.