### PR TITLE
chore(amazon): Bump version to 0.0.146

### DIFF
--- a/app/scripts/modules/amazon/package.json
+++ b/app/scripts/modules/amazon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/amazon",
-  "version": "0.0.145",
+  "version": "0.0.146",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
2c15170f9cc61638a38b34cf180b17543ffcfd0d fix(aws): really properly sort instance types (#6191)
75d7e334a08a232a57567ce54bcf01ff7a66a2b1 fix(aws): sort instance type options in server group modal (#6190)