### PR TITLE
feat(tests): Add downloader to fetch pre-recorded network fixtures

### DIFF
--- a/test/functional/tools/FixtureService.ts
+++ b/test/functional/tools/FixtureService.ts
@@ -1,7 +1,54 @@
 import * as path from 'path';
+import * as url from 'url';
+import * as fs from 'fs';
+import { GCSFixtureDownloader } from './GCSFixtureDownloader';
 
 export class FixtureService {
-  constructor() {}
+  constructor(private sourceUri: string, private specsRoot: string) {}
+
+  private fetchFixture(toFile: string): Promise<any> {
+    const { protocol } = url.parse(this.sourceUri);
+    if (protocol === 'gs:') {
+      return GCSFixtureDownloader.download(this.sourceUri, this.specsRoot, toFile);
+    } else {
+      return Promise.reject(new Error(`unsupported fixture source uri: ${this.sourceUri}`));
+    }
+  }
+
+  public findMissingFixtures(): string[] {
+    const queue = [this.specsRoot];
+    const missingFixtures: string[] = [];
+    while (queue.length > 0) {
+      const dir = queue.shift();
+      const entries = fs.readdirSync(dir);
+      entries.forEach((entry: string) => {
+        const fullpath = path.join(dir, entry);
+        const stat = fs.lstatSync(fullpath);
+        if (stat.isDirectory() && !stat.isSymbolicLink()) {
+          queue.push(fullpath);
+        } else if (entry.endsWith('.spec.ts')) {
+          const fixtureFile = this.fixtureNameForTestPath(fullpath);
+          if (!entries.includes(fixtureFile)) {
+            missingFixtures.push(path.join(dir, fixtureFile));
+          }
+        }
+      });
+    }
+    return missingFixtures;
+  }
+
+  public downloadFixtures(fixturePaths: string[]): Promise<void> {
+    fixturePaths = fixturePaths.slice(0);
+    const downloadRemainingFixtures: () => Promise<any> = () => {
+      if (fixturePaths.length > 0) {
+        const fixturePath = fixturePaths.pop();
+        console.log('fetching fixture for ' + fixturePath);
+        return this.fetchFixture(fixturePath).then(downloadRemainingFixtures);
+      }
+      return Promise.resolve();
+    };
+    return downloadRemainingFixtures();
+  }
 
   public fixtureNameForTestPath(testpath: string) {
     const basename = path.basename(testpath);

--- a/test/functional/tools/GCSFixtureDownloader.ts
+++ b/test/functional/tools/GCSFixtureDownloader.ts
@@ -1,0 +1,29 @@
+import * as path from 'path';
+import { exec } from 'child_process';
+
+const GSUTIL_PROC_OPTS = {
+  timeout: 5000,
+  killSignal: 'SIGKILL',
+};
+
+export class GCSFixtureDownloader {
+  public static download(bucketPathUri: string, specsRootPath: string, absFixturePath: string) {
+    const relativeFixturePath = path.relative(specsRootPath, absFixturePath);
+    const fullBucketDownloadUri = [bucketPathUri, relativeFixturePath].join('/');
+    return new Promise((resolve, reject) => {
+      const command = ['gsutil', 'cp', fullBucketDownloadUri, absFixturePath];
+      const onExit = (err: Error) => {
+        if (err) {
+          reject(new Error(`failed to save file "${absFixturePath}" from source "${fullBucketDownloadUri}": ${err}`));
+        } else {
+          resolve();
+        }
+      };
+      const gsutilProc = exec(command.join(' '), GSUTIL_PROC_OPTS, onExit);
+      gsutilProc.stderr.on('data', data => {
+        process.stderr.write(data);
+      });
+      gsutilProc.stdout.on('data', _data => {});
+    });
+  }
+}


### PR DESCRIPTION
This adds a download utility that will download existing network fixtures to disk for any `.spec.ts` file that doesn't have a corresponding `.mountebank_fixture.json` file.  Support for GCS buckets is introduced here but adding support for other providers should be easy enough (for example if we decided in future to put network fixtures in git instead).

In a follow up commit I will add a publicly accessible bucket to serve up the fixtures and also introduce a script to automate all of this ceremony.