### PR TITLE
feat(core): show pipeline stage durations by default

### DIFF
--- a/app/scripts/modules/core/src/pipeline/filter/ExecutionFilterModel.ts
+++ b/app/scripts/modules/core/src/pipeline/filter/ExecutionFilterModel.ts
@@ -136,7 +136,7 @@ export class ExecutionFilterModel {
     key = key || this.mostRecentApplication || GLOBAL_CACHE_KEY;
     const cachedApp = this.configViewStateCache.get(key) || {};
     const cachedGlobal = this.configViewStateCache.get(GLOBAL_CACHE_KEY) || {};
-    const defaults = { count: 2, groupBy: 'name', showDurations: false };
+    const defaults = { count: 2, groupBy: 'name', showDurations: true };
     this.configViewStateCache.touch(key); // prevents cache from expiring just because it hasn't been changed
     return extend(defaults, cachedApp, { showDurations: cachedGlobal.showDurations });
   }


### PR DESCRIPTION
These durations are so nice, we should just show them by default.

We already have a GA event on the toggle of the show stage durations checkbox, so we'll track the usage of the feature at Netflix over the next month or two. If nobody seems to be turning off the durations, we'll remove the checkbox and behavior altogether unless there are objections.