### PR TITLE
fix(aws): do not hardcode amiName when adding pipeline cluster

### DIFF
--- a/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupCommandBuilder.service.js
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupCommandBuilder.service.js
@@ -314,7 +314,7 @@ module.exports = angular
           command.viewState.imageId = serverGroup.launchConfig.imageId;
         }
 
-        if (serverGroup.image && serverGroup.image.name) {
+        if (mode === 'clone' && serverGroup.image && serverGroup.image.name) {
           command.amiName = serverGroup.image.name;
         }
 


### PR DESCRIPTION
We should only be setting the `amiName` field if we're cloning a cluster, not if we're configuring it for a pipeline.

Fixes a minor regression from a couple of weeks ago.