### PR TITLE
feat(core): add ability to search clusters by labels

### DIFF
--- a/app/scripts/modules/core/src/cluster/filter/ClusterFilterService.spec.ts
+++ b/app/scripts/modules/core/src/cluster/filter/ClusterFilterService.spec.ts
@@ -497,6 +497,79 @@ describe('Service: clusterFilterService', function() {
     });
   });
 
+  describe('filter by label', function() {
+    it('should filter by label key and value as exact, case-sensitive matches', function(done) {
+      ClusterState.filterModel.asFilterModel.sortFilter.filter = 'labels:source=prod';
+      const expected: any = _.filter(groupedJSON, {
+        subgroups: [
+          {
+            subgroups: [
+              {
+                serverGroups: [
+                  {
+                    labels: {
+                      source: 'prod',
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+      ClusterState.filterService.updateClusterGroups(application);
+      setTimeout(() => {
+        expect(ClusterState.filterModel.asFilterModel.groups).toEqual(expected);
+        done();
+      }, debounceTimeout);
+    });
+
+    it('should not match on partial value', function(done) {
+      ClusterState.filterModel.asFilterModel.sortFilter.filter = 'labels:source=pro';
+      ClusterState.filterService.updateClusterGroups(application);
+      setTimeout(() => {
+        expect(ClusterState.filterModel.asFilterModel.groups).toEqual([]);
+        done();
+      }, debounceTimeout);
+    });
+
+    it('should not match on case-insensitive value', function(done) {
+      ClusterState.filterModel.asFilterModel.sortFilter.filter = 'labels:source=Prod';
+      ClusterState.filterService.updateClusterGroups(application);
+      setTimeout(() => {
+        expect(ClusterState.filterModel.asFilterModel.groups).toEqual([]);
+        done();
+      }, debounceTimeout);
+    });
+
+    it('should perform an AND match on comma separated list, ignoring spaces', function(done) {
+      ClusterState.filterModel.asFilterModel.sortFilter.filter = 'labels: source=prod, app=spinnaker';
+      const expected: any = _.filter(groupedJSON, {
+        subgroups: [
+          {
+            subgroups: [
+              {
+                serverGroups: [
+                  {
+                    labels: {
+                      app: 'spinnaker',
+                      source: 'prod',
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+      ClusterState.filterService.updateClusterGroups(application);
+      setTimeout(() => {
+        expect(ClusterState.filterModel.asFilterModel.groups).toEqual(expected);
+        done();
+      }, debounceTimeout);
+    });
+  });
+
   describe('multiInstance filtering', function() {
     beforeEach(function() {
       this.navigationSynced = false;

--- a/app/scripts/modules/core/src/cluster/filter/mockApplicationData.js
+++ b/app/scripts/modules/core/src/cluster/filter/mockApplicationData.js
@@ -21,6 +21,10 @@ module.exports = angular
           instanceType: 'm3.medium',
           vpcName: '',
           category: 'serverGroup',
+          labels: {
+            app: 'spinnaker',
+            source: 'prod',
+          },
         },
         {
           cluster: 'in-us-west-1-only',
@@ -34,6 +38,9 @@ module.exports = angular
           instanceType: 'm3.large',
           vpcName: 'Main',
           category: 'serverGroup',
+          labels: {
+            app: 'spinnaker',
+          },
         },
       ],
     },
@@ -73,6 +80,10 @@ module.exports = angular
                     outOfService: 0,
                   },
                   isDisabled: true,
+                  labels: {
+                    app: 'spinnaker',
+                    source: 'prod',
+                  },
                   type: 'gce',
                   instanceType: 'm3.medium',
                   vpcName: '',
@@ -117,6 +128,9 @@ module.exports = angular
                     outOfService: 0,
                   },
                   isDisabled: false,
+                  labels: {
+                    app: 'spinnaker',
+                  },
                   type: 'aws',
                   instanceType: 'm3.large',
                   vpcName: 'Main',

--- a/app/scripts/modules/core/src/domain/IServerGroup.ts
+++ b/app/scripts/modules/core/src/domain/IServerGroup.ts
@@ -34,6 +34,7 @@ export interface IServerGroup {
   instances: IInstance[];
   instanceType?: string;
   isDisabled?: boolean;
+  labels?: { [key: string]: string };
   launchConfig?: any;
   loadBalancers?: string[];
   name: string;

--- a/app/scripts/modules/core/src/help/help.contents.ts
+++ b/app/scripts/modules/core/src/help/help.contents.ts
@@ -21,6 +21,7 @@ const helpContents: { [key: string]: string } = {
         <li>Account</li>
         <li>Load Balancer Name</li>
         <li>Instance ID</li>
+        <li>Labels (comma-separated list of key-value pairs that must all apply to entity, e.g. <samp>labels:app=spinnaker, source=prod</samp>)</li>
       </ul>
       <p>You can search for multiple words or word fragments. For instance, to find all server groups in a prod stack with "canary" in the details, enter <samp>prod canary</samp>.</p>
       <p>To find a particular instance, enter the instance ID. Only the containing server group will be displayed, and the instance


### PR DESCRIPTION
Adding label search functionality as a separate PR from label filter functionality as the latter is a bit messier (#3238)

![a0bd8221-3a10-4d85-a1b1-49c2da51989d](https://user-images.githubusercontent.com/15936279/50183255-7f681180-02df-11e9-8168-b7ef01187a62.gif)

