### PR TITLE
fix(aws): clarify all ports/protocols on IP range ingress

### DIFF
--- a/app/scripts/modules/amazon/src/securityGroup/details/securityGroupDetail.html
+++ b/app/scripts/modules/amazon/src/securityGroup/details/securityGroupDetail.html
@@ -75,7 +75,13 @@
         <dd>{{ipRangeRule.address}}</dd>
         <dt>Port Ranges</dt>
         <dd ng-repeat="rule in ipRangeRule.rules">
-          {{rule.protocol}}: {{rule.startPort}} &rarr; {{rule.endPort}}
+          <span ng-if="rule.protocol === '-1'">
+            All ports and protocols
+            <div ng-if="ipRangeRule.rules.length > 1"><em>Additional port ranges are specified, but redundant:</em></div>
+          </span>
+          <span ng-if="rule.protocol !== '-1'">
+            {{rule.protocol}}: {{rule.startPort}} &rarr; {{rule.endPort}}
+          </span>
         </dd>
       </dl>
     </collapsible-section>


### PR DESCRIPTION
In an IP range rule, you can specify the protocol as `-1` and AWS will treat it as a wildcard, allowing traffic from all ports and all ranges. 

This is not super clear in the UI:
<img width="184" alt="screen shot 2018-12-18 at 10 06 06 pm" src="https://user-images.githubusercontent.com/73450/50201996-421c7780-0311-11e9-9d0c-9f2493c22669.png">

This is more clear:
<img width="280" alt="screen shot 2018-12-18 at 10 06 43 pm" src="https://user-images.githubusercontent.com/73450/50202004-48aaef00-0311-11e9-85c7-2666e2a9073e.png">
