### PR TITLE
fix(core): avoid in sync race condition when saving pipelines

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/pipelineConfigurer.js
+++ b/app/scripts/modules/core/src/pipeline/config/pipelineConfigurer.js
@@ -390,11 +390,12 @@ module.exports = angular
 
     this.savePipeline = () => {
       this.setViewState({ saving: true });
-      PipelineConfigService.savePipeline($scope.pipeline)
+      const toSave = _.cloneDeep($scope.pipeline);
+      PipelineConfigService.savePipeline(toSave)
         .then(() => $scope.application.pipelineConfigs.refresh(true))
         .then(
           () => {
-            setOriginal($scope.pipeline);
+            setOriginal(toSave);
             markDirty();
             this.setViewState({ saving: false });
           },


### PR DESCRIPTION
If you click the "Save" button on a pipeline, then make changes to the config while the pipeline is still saving, those changes will not be tracked in the current state of the pipeline config, so you won't see the Save button again unless you make an additional change - and the revert button will do the wrong thing.

This is a very old bug. I considered converting the Angular here to React, but...it's 500+ lines of Angular.