### PR TITLE
fix(aws): provide help explanation when load balancer delete is disabled

### DIFF
--- a/app/scripts/modules/amazon/src/loadBalancer/details/LoadBalancerActions.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/details/LoadBalancerActions.tsx
@@ -2,7 +2,15 @@ import * as React from 'react';
 import { Dropdown } from 'react-bootstrap';
 import { get } from 'lodash';
 
-import { Application, ApplicationReader, LoadBalancerWriter, SETTINGS, NgReact, ReactInjector } from '@spinnaker/core';
+import {
+  Application,
+  ApplicationReader,
+  LoadBalancerWriter,
+  SETTINGS,
+  NgReact,
+  ReactInjector,
+  HelpField,
+} from '@spinnaker/core';
 
 import { IAmazonLoadBalancer, IAmazonLoadBalancerDeleteCommand } from 'amazon/domain';
 
@@ -121,12 +129,10 @@ export class LoadBalancerActions extends React.Component<ILoadBalancerActionsPro
               </li>
             )}
             {loadBalancer.instances.length > 0 && (
-              <li
-                className="disabled"
-                uib-tooltip="You must detach all instances before you can delete this load balancer."
-              >
+              <li className="disabled">
                 <a className="clickable" onClick={this.deleteLoadBalancer}>
-                  Delete Load Balancer
+                  Delete Load Balancer{' '}
+                  <HelpField content="You must detach all instances before you can delete this load balancer." />
                 </a>
               </li>
             )}


### PR DESCRIPTION
FYI `uib-tooltip` does not do what you want it to do on React components.