### PR TITLE
fix(judgement): Adding stage refId as component key to bust residual state

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/manualJudgment/ManualJudgmentExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/manualJudgment/ManualJudgmentExecutionDetails.tsx
@@ -48,7 +48,7 @@ export class ManualJudgmentExecutionDetails extends React.Component<
           {stage.context.judgmentInput && <dt>Input</dt>}
           {stage.context.judgmentInput && <dd>{robotToHuman(stage.context.judgmentInput)}</dd>}
         </dl>
-        <ManualJudgmentApproval application={application} execution={execution} stage={stage} />
+        <ManualJudgmentApproval key={stage.refId} application={application} execution={execution} stage={stage} />
         {stage.context.judgmentInput && <StageFailureMessage stage={stage} message={stage.failureMessage} />}
       </ExecutionDetailsSection>
     );


### PR DESCRIPTION
If a manual judgement is clicked and the user clicks to another Manual Judgement stage before the request completes, the new stage will show the `Continue` (or `Stop`) button as still pending, and it will remain pending even after the request completes.

This is because the `ManualJudgementApproval` component's `submitting` state remains true when switching to another `Manual Judgement` stage.

A simple `key={stage.refId}` fixes this as it tells React that the component instance shouldn't be shared between the two stages.