### PR TITLE
fix(core): Prevent cluster saved state filter overrides

### DIFF
--- a/app/scripts/modules/core/src/filterModel/FilterModelService.ts
+++ b/app/scripts/modules/core/src/filterModel/FilterModelService.ts
@@ -155,8 +155,15 @@ export class FilterModelService {
 
     filterModel.hasSavedState = toParams => {
       const application = toParams.application;
+      const serverGroup = toParams.serverGroup;
+
+      const savedStateForApplication = filterModel.savedState[application];
+
       return (
-        filterModel.savedState[application] !== undefined && filterModel.savedState[application].params !== undefined
+        savedStateForApplication !== undefined &&
+        savedStateForApplication.params !== undefined &&
+        (!serverGroup ||
+          (savedStateForApplication.params.serverGroup && savedStateForApplication.params.serverGroup === serverGroup))
       );
     };
 


### PR DESCRIPTION
Clusters page filtered the page based on previously stored server group. 

As a result, if the user clicks on a different server group from the executions view, they would still land in the saved filter state. Clusters' saved state records the params applied for an application and whenever the user revisits the clusters page, it applies these params from saved state. This works well until we change the serverGroup for the same application. Since we didn't check against server group value changes in the new params vs saved state, we were always reverting back to the saved state. 

Fixed this behavior for serverGroup names. There are other filters like region/acct but I don't believe we deep link to just those filters.