### PR TITLE
fix(bake): Allow null extended attributes in bake stages

### DIFF
--- a/app/scripts/modules/amazon/src/pipeline/stages/bake/bakeStage.html
+++ b/app/scripts/modules/amazon/src/pipeline/stages/bake/bakeStage.html
@@ -80,7 +80,7 @@
               <strong class="small">{{key}}</strong>
             </td>
             <td>
-              <input type="text" required ng-model="stage.extendedAttributes[key]" value="{{value}}"
+              <input type="text" ng-model="stage.extendedAttributes[key]" value="{{value}}"
                      class="form-control input-sm"/>
             </td>
             <td class="text-right">

--- a/app/scripts/modules/azure/pipeline/stages/bake/bakeStage.html
+++ b/app/scripts/modules/azure/pipeline/stages/bake/bakeStage.html
@@ -58,7 +58,7 @@
               <strong class="small">{{key}}</strong>
             </td>
             <td>
-              <input type="text" required ng-model="stage.extendedAttributes[key]" value="{{value}}"
+              <input type="text" ng-model="stage.extendedAttributes[key]" value="{{value}}"
                      class="form-control input-sm"/>
             </td>
             <td class="text-right">

--- a/app/scripts/modules/core/src/pipeline/config/stages/bake/modal/addExtendedAttribute.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/bake/modal/addExtendedAttribute.html
@@ -23,9 +23,7 @@
           <input type="text"
                  class="form-control input-sm "
                  ng-model="extendedAttribute.value"
-                 placeholder="enter an attribute value"
-                 required>
-          </input>
+                 placeholder="enter an attribute value">
         </div>
       </div>
     </div>

--- a/app/scripts/modules/google/src/pipeline/stages/bake/bakeStage.html
+++ b/app/scripts/modules/google/src/pipeline/stages/bake/bakeStage.html
@@ -76,7 +76,7 @@
             <strong class="small">{{key}}</strong>
           </td>
           <td>
-            <input type="text" required ng-model="stage.extendedAttributes[key]" value="{{value}}"
+            <input type="text" ng-model="stage.extendedAttributes[key]" value="{{value}}"
                    class="form-control input-sm"/>
           </td>
           <td class="text-right">

--- a/app/scripts/modules/openstack/src/pipeline/stages/bake/bakeStage.html
+++ b/app/scripts/modules/openstack/src/pipeline/stages/bake/bakeStage.html
@@ -65,7 +65,7 @@
               <strong class="small">{{key}}</strong>
             </td>
             <td>
-              <input type="text" required ng-model="stage.extendedAttributes[key]"
+              <input type="text" ng-model="stage.extendedAttributes[key]"
                      class="form-control input-sm"/>
             </td>
             <td class="text-right">


### PR DESCRIPTION
Many optional paramters are defaulted by various config files during bake stages; it is useful to be able to explicitly clear these values using extended attributes. In order to allow this, allow the value of an extended attribute to be empty.