### PR TITLE
feat(core): Extend app name to be modified in custom builds of deck

### DIFF
--- a/app/scripts/modules/core/src/application/ApplicationName.tsx
+++ b/app/scripts/modules/core/src/application/ApplicationName.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+
+import { Application } from 'core/application';
+
+export interface IApplicationNameProps {
+  app: Application;
+}
+
+export class ApplicationName extends React.Component<IApplicationNameProps> {
+  public render() {
+    return <span className="application-name">{this.props.app.name}</span>;
+  }
+}

--- a/app/scripts/modules/core/src/application/ApplicationNameWrapper.tsx
+++ b/app/scripts/modules/core/src/application/ApplicationNameWrapper.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+
+import { Application } from 'core/application/application.model';
+import { ReactInjector } from 'core/reactShims';
+
+import { ApplicationName } from './ApplicationName';
+
+export interface IApplicationNameProps {
+  app: Application;
+}
+
+export class ApplicationNameWrapper extends React.Component<IApplicationNameProps> {
+  public render(): React.ReactElement<ApplicationNameWrapper> {
+    const { overrideRegistry } = ReactInjector;
+    const config = overrideRegistry.getComponent('applicationName');
+    const Title = config || ApplicationName;
+
+    return <Title {...this.props} />;
+  }
+}

--- a/app/scripts/modules/core/src/application/nav/ApplicationHeader.tsx
+++ b/app/scripts/modules/core/src/application/nav/ApplicationHeader.tsx
@@ -10,6 +10,7 @@ import { ThirdLevelNavigation } from './ThirdLevelNavigation';
 import { ApplicationDataSource } from '../service/applicationDataSource';
 import { ReactInjector } from 'core/reactShims';
 import { ApplicationIcon } from '../ApplicationIcon';
+import { ApplicationNameWrapper } from '../ApplicationNameWrapper';
 
 import './applicationNav.component.less';
 
@@ -133,7 +134,7 @@ export class ApplicationHeader extends React.Component<IApplicationHeaderProps, 
           <ApplicationIcon app={app} />
         </span>
         <span className="horizontal middle wrap">
-          <span className="application-name">{app.name}</span>
+          <ApplicationNameWrapper app={app} />
           <ApplicationRefresher app={app} />
         </span>
       </h2>


### PR DESCRIPTION
Ability to extend Application Name displayed in the navigation

Allowing Application Name component to be extended will help with adding a custom component at Netflix. The custom component can display all apps that belong to the team, link to teams page; almost similar to applications displayed within projects page. The benefit of having this directly on the application name itself is to ensure it is visible, discoverable and easy to hop between apps one owns. 