### PR TITLE
chore(scripts): Improve publish safety, add assert_clean_master.sh and build_order.sh

### DIFF
--- a/app/scripts/modules/assert_clean_master.sh
+++ b/app/scripts/modules/assert_clean_master.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Runs this script from the 'deck/app/scripts/modules' directory
+cd `dirname $0`;
+
+# Assert that we are on the 'master' branch
+# (a local branch that tracks decks 'master' branch)
+CURRENTBRANCH=`git symbolic-ref --short HEAD`
+TRACKING=`git rev-parse --abbrev-ref --symbolic-full-name @{u}`
+
+if [ $? -ne 0 ] ; then
+  echo "You must be on 'master' (a branch tracking the upstream Deck 'master' branch)."
+  echo
+  echo "The current branch '${CURRENTBRANCH}' is not tracking any remote."
+  exit -1
+fi
+
+REMOTE=`echo ${TRACKING} | sed -e 's/[/].*//'`
+BRANCH=`echo ${TRACKING} | sed -e 's/[^/]*[/]//'`
+REMOTE_URL=`git remote get-url ${REMOTE}`
+DECK_HTTPS="https://github.com/spinnaker/deck.git"
+DECK_GIT="git@github.com:spinnaker/deck.git"
+
+if [ "x${REMOTE_URL}" != "x${DECK_HTTPS}" ] && [ "x${REMOTE_URL}" != "x${DECK_GIT}" ] ; then
+  echo "You must be on 'master' (a branch tracking the upstream Deck 'master' branch)."
+  echo
+  echo "The current branch '${CURRENTBRANCH}' is tracking '${TRACKING}'."
+  echo "However, the remote '${REMOTE}' has a URL of '${REMOTE_URL}'."
+  echo "The tracked remote should be either '${DECK_HTTPS}' or '${DECK_GIT}'."
+  exit -1
+fi
+
+if [ "x${BRANCH}" != "xmaster" ] ; then
+  echo "You must be on 'master' (a branch tracking the upstream Deck 'master' branch)."
+  echo
+  echo "The current branch '${CURRENTBRANCH}' is tracking '${TRACKING}'."
+  exit -1
+fi
+
+# Assert that the local branch is "clean" so we don't publish any uncommitted code
+DIRTY_COMMITS=`git status --porcelain`;
+if [ "x${DIRTY_COMMITS}" != "x" ] ; then
+  echo "Your working copy is not clean (you have uncommited changes)."
+  echo
+  echo "Please stash these changes before publishing using 'git stash'.";
+  echo
+  git status --porcelain
+  exit -1;
+fi
+
+# Get the latest information from the remote
+git fetch ${REMOTE}
+
+STATUS=`git status -sb --porcelain`
+if [[ ${STATUS} =~ [Bb]ehind ]] ; then
+  echo "Your local branch is behind the upstream branch '${TRACKING}'."
+  echo
+  echo "The upstream branch has additional commits that would not be included in the published package."
+  echo "Run 'git pull' to update your local branch."
+  echo
+  git status -sb
+  exit -1
+fi
+
+if [[ ${STATUS} =~ [Aa]head ]] ; then
+  echo "Your local branch is ahead of the upstream branch '${TRACKING}'."
+  echo
+  echo "Your local branch has additional commits that are not reflected in the upstream branch."
+  echo "Add your commits to the upstream branch by creating a pull request."
+  echo
+  git status -sb
+  exit -1
+fi

--- a/app/scripts/modules/build_order.sh
+++ b/app/scripts/modules/build_order.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+cd `dirname $0`
+MODULES=$*;
+
+TUPLES=""
+for MODULE in $MODULES ; do
+  # hard coding known deps for now because the package.json files don't yet contain the package's dependencies
+  case "$MODULE" in
+      amazon) DEPS="core" ;;
+      appengine) DEPS="core" ;;
+      cloudfoundry) DEPS="core" ;;
+      core) DEPS="core" ;;
+      docker) DEPS="core" ;;
+      ecs) DEPS="amazon core" ;;
+      google) DEPS="core" ;;
+      kubernetes) DEPS="core" ;;
+      openstack) DEPS="core" ;;
+      oracle) DEPS="core" ;;
+      titus) DEPS="amazon docker core" ;;
+      *)
+        echo "Unknown module: ${MODULE}"
+        exit -1;
+        ;;
+  esac
+
+  for DEP in $DEPS ; do
+    TUPLES="${TUPLES} ${DEP} ${MODULE}"
+  done
+done
+
+echo $TUPLES | tsort

--- a/app/scripts/modules/publish.sh
+++ b/app/scripts/modules/publish.sh
@@ -1,59 +1,130 @@
 #!/bin/bash
+PACKAGEDIRS=$*
+
+# Run this script from the 'deck/app/scripts/modules' directory
+cd `dirname $0`
+
+# Show help text if no modules were specified
 if [ "$1" == "" ] ; then
-  echo "Bump versions in package.json and (optionally) publish deck modules";
-  echo "$0 <module1> <module2>";
-  exit
+  echo "Bump versions in package.json and (optionally) publish deck modules"
+  echo "$0 <module1> <module2>"
+  exit 1
 fi
 
-CWD=`pwd`;
+# Check for clean master
+echo "Deck package publisher ---> Checking that you are on the 'master' branch and are up to date with the remote..."
+./assert_clean_master.sh || exit 2
 
-for i in $* ; do
-  if [ ! -d $i ] ; then
-    echo "$CWD/$i does not exist";
-    exit;
+# Check that all modules (cli arguments) exist
+echo "Deck package publisher ---> Checking that all packages (${PACKAGEDIRS}) exist..."
+CWD=`pwd`
+for DIR in ${PACKAGEDIRS} ; do
+  if [ ! -e ${DIR}/package.json ] ; then
+    echo "$CWD/${DIR}/package.json does not exist"
+    exit 3
   fi
 done
 
-CURRENTBRANCH=`git branch | grep \* | cut -d ' ' -f2`;
-if [ "$CURRENTBRANCH" == "master" ] ; then
-  echo "";
-  read -p "Create new branch for package bumps? (y/n) " -n 1 -r
-  echo "";
-  if [ "$REPLY" == "y" ] ; then
-    COUNT=;
-    while git show-ref --verify --quiet refs/heads/package-bump$COUNT ; do
-      let COUNT=COUNT+1;
-    done
-    git checkout -b package-bump$COUNT;
+# Switch to a new bump-package<n> branch
+echo "Deck package publisher ---> Creating a new branch for package bumps..."
+COUNT=
+while git show-ref --verify --quiet refs/heads/bump-package$COUNT ; do
+  let COUNT=COUNT+1
+done
+git checkout -b bump-package$COUNT
+TEMPORARYBRANCH=`git branch | grep \* | cut -d ' ' -f2`
+echo "Deck package publisher ---> Created and switched to temporary branch '${TEMPORARYBRANCH}'..."
+
+# Run yarn
+echo "Deck package publisher ---> Updating to latest dependencies..."
+pushd ../../../
+yarn
+popd
+
+# Determine upstream dependencies and proper build order
+echo "Deck package publisher ---> Preparing to publish ${PACKAGEDIRS}..."
+BUILDORDER=`./build_order.sh ${PACKAGEDIRS}`
+echo "Deck package publisher ---> Package build order:"
+echo "${BUILDORDER}"
+echo
+
+PUBLISHBRANCH="";
+# Loop over packages to build and either a) Build and Publish to NPM or b) Build only
+for DIR in ${BUILDORDER} ; do
+  # Check if the current package to build is in PACKAGEDIRS (if so, publish it)
+  if echo ${PACKAGEDIRS} | grep -F -q -w "${DIR}" ; then
+    echo "Deck package publisher ---> Preparing to publish '${DIR}'..."
+
+    echo "Deck package publisher ---> Creating changelog for '${DIR}'..."
+    COMMITS=`echo "" && echo "" && ./show_unpublished_commits.sh ${DIR}`
+    pushd ${DIR} > /dev/null
+    echo "${COMMITS}"
+
+    PACKAGE=`node -e 'console.log(JSON.parse(require("fs").readFileSync("package.json")).name)'`
+
+    echo "Deck package publisher ---> Bumping version for '${PACKAGE}'..."
+    npm version patch --no-git-tag-version
+    VERSION=`node -e 'console.log(JSON.parse(require("fs").readFileSync("package.json")).version)'`
+
+    echo "Deck package publisher ---> Commiting version bump of '${PACKAGE}' to ${VERSION}..."
+    git commit -m "chore(${DIR}): Bump version to ${VERSION}${COMMITS}" package.json
+
+    if [ "x${PUBLISHBRANCH}" == "x" ] ; then
+      PUBLISHBRANCH="bump-package-${DIR}-to-${VERSION}"
+    else
+      PUBLISHBRANCH="${PUBLISHBRANCH}-and-${DIR}-to-${VERSION}"
+    fi
+    echo "Deck package publisher ---> Updated publish branch to ${PUBLISHBRANCH}"
+
+    echo
+    read -t 1 -n 10000 discard
+    read -p "Ready to build and publish version ${VERSION} of '${PACKAGE}' to npm? (y/n) " -n 1 -r
+    echo
+    if [ "$REPLY" == "y" ] ; then
+      echo "Deck package publisher ---> Publishing ${PACKAGE}..."
+      npm publish
+    else
+      echo "Deck package publisher ---> Building (but NOT publishing) ${PACKAGE}..."
+      yarn prepublishOnly
+    fi
+  else
+    echo "Deck package publisher ---> Building (but not publishing) upstream dependency '${DIR}'..."
+    pushd ${DIR} > /dev/null
+    yarn prepublishOnly
   fi
-fi
-CURRENTBRANCH=`git branch | grep \* | cut -d ' ' -f2`;
 
-for i in $* ; do
-  COMMITS=`echo "" && echo "" && ./show_unpublished_commits.sh $i`;
-  pushd $i > /dev/null;
-  npm version patch --no-git-tag-version;
-  VERSION=`node -e 'console.log(JSON.parse(require("fs").readFileSync("package.json")).version)'`;
-  PACKAGE=`node -e 'console.log(JSON.parse(require("fs").readFileSync("package.json")).name)'`;
-
-  git commit -m "chore($i): Bump version to ${VERSION}${COMMITS}" package.json
-
-  echo "";
-  read -p "Publish ${PACKAGE}? (y/n) " -n 1 -r
-  echo "";
-  if [ "$REPLY" == "y" ] ; then
-    npm publish;
-  fi
-
-  popd > /dev/null;
+  popd > /dev/null
 done
 
+# Create a branch with the package bump versions in it
+# Github will use this as the PR title
+echo "Deck package publisher ---> Creating publish branch '${PUBLISHBRANCH}'..."
+git co -b ${PUBLISHBRANCH} || exit 4
+echo "Deck package publisher ---> Deleting temporary branch '${TEMPORARYBRANCH}'..."
+git branch -D ${TEMPORARYBRANCH} || exit 5
 
-if [ "$CURRENTBRANCH" != "master" ] ; then
-  echo "";
-  read -p "Push current branch ${CURRENTBRANCH} to 'origin'? (y/n) " -n 1 -r
-  echo "";
-  if [ "$REPLY" == "y" ] ; then
-    git push --set-upstream origin $CURRENTBRANCH;
+echo
+read -t 1 -n 10000 discard
+read -p "Ready to push branch ${PUBLISHBRANCH} to 'origin'? (y/n) " -n 1 -r
+echo
+if [ "$REPLY" == "y" ] ; then
+  echo "Deck package publisher ---> Pushing ${PUBLISHBRANCH} to 'origin'..."
+  # https://dwmkerr.com/a-portable-and-magic-free-way-to-open-pull-requests-from-the-command-line/
+  # Push to origin, grabbing the output but then echoing it back.
+  PUSHOUTPUT=`git push origin -u ${PUBLISHBRANCH} 2>&1`
+  echo "${PUSHOUTPUT}"
+
+  # If there's anything which starts with http, it's a good guess it'll be a
+  # link to GitHub/GitLab/Whatever. So open it.
+  LINK=$(echo "${PUSHOUTPUT}" | grep -o 'http.*' | sed -e 's/[[:space:]]*$//')
+  if [ "x${LINK}" != "x" ] && which python > /dev/null ; then
+    echo "Deck package publisher ---> Creating pull request at: ${LINK}..."
+    python -mwebbrowser "${LINK}"
   fi
 fi
+
+echo "Deck package publisher ---> Switching back to 'master'..."
+git co master
+
+echo "Deck package publisher ---> Deleting pull request branch ${PUBLISHBRANCH}..."
+git branch -D ${PUBLISHBRANCH}

--- a/app/scripts/modules/show_dirty_modules.sh
+++ b/app/scripts/modules/show_dirty_modules.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # Reports if any modules are dirty, and what commits have been made since the last package.json commit
+cd `dirname $0`;
 
 for PKGJSON in `ls */package.json` ; do
   MODULE=`dirname $PKGJSON`;

--- a/app/scripts/modules/show_unpublished_commits.sh
+++ b/app/scripts/modules/show_unpublished_commits.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+cd `dirname $0`
 
 MODULE=$1;
 if [ "$MODULE" == "" ] ; then


### PR DESCRIPTION
This PR improves the safety of the deck publish script: `/deck/app/scripts/modules/publish.sh`.

Improvements:

- Asserts that you are on master, do not have a dirty working copy, and are not ahead or behind of upstream
- Updated dependencies (`yarn`) before building packages
- Builds all dependent packages, i.e., before publishing `titus`, it will build `docker`, `amazon`, and `core`
- Automatically builds dependent packages (and/or multiple published packages) in the correct order
- Provides a PR title that includes the packages being published and their new versions
- Automatically opens a browser to the "create pull request" screen
- Allows the scripts to be invoked using an absolute path `./app/scripts/module/publish.sh core`
- Supports "dry run" mode by answering "no" to the "publish to npm?" questions

To use, invoke the script and provide a list of modules to publish.

```
./publish.sh titus core amazon
```