### PR TITLE
refactor(*): use mask-image CSS for cloud provider logos

### DIFF
--- a/app/scripts/modules/amazon/src/logo/aws.logo.less
+++ b/app/scripts/modules/amazon/src/logo/aws.logo.less
@@ -1,6 +1,5 @@
 .cloud-provider-logo {
   .icon-aws {
-    background: url('aws.icon.svg') no-repeat 50% 50%;
-    background-size: cover;
+    mask-image: url('aws.icon.svg');
   }
 }

--- a/app/scripts/modules/appengine/src/logo/appengine.logo.less
+++ b/app/scripts/modules/appengine/src/logo/appengine.logo.less
@@ -1,6 +1,5 @@
 .cloud-provider-logo {
   .icon-appengine {
-    background: url('appengine.icon.svg') no-repeat 100% 100%;
-    background-size: cover;
+    mask-image: url('appengine.icon.svg');
   }
 }

--- a/app/scripts/modules/cloudfoundry/src/logo/cf.logo.less
+++ b/app/scripts/modules/cloudfoundry/src/logo/cf.logo.less
@@ -1,6 +1,5 @@
 .cloud-provider-logo {
   .icon-cloudfoundry {
-    background: url('cf.logo.svg') no-repeat 50% 50%;
-    background-size: cover;
+    mask-image: url('cf.logo.svg');
   }
 }

--- a/app/scripts/modules/core/src/cloudProvider/cloudProviderLogo.less
+++ b/app/scripts/modules/core/src/cloudProvider/cloudProviderLogo.less
@@ -4,16 +4,17 @@
   .icon {
     display: inline-block;
     vertical-align: sub;
-    -webkit-filter: invert(53%) sepia(100%) hue-rotate(50deg);
-    filter: invert(53%) sepia(100%) hue-rotate(50deg);
+    mask-repeat: no-repeat;
+    mask-position: 50% 50%;
+    mask-size: cover;
+    background-color: var(--color-success);
   }
 }
 
 .disabled {
   .cloud-provider-logo {
     .icon {
-      -webkit-filter: opacity(64%);
-      filter: opacity(64%);
+      background-color: var(--color-dovegray);
     }
   }
 }

--- a/app/scripts/modules/dcos/logo/dcos.logo.less
+++ b/app/scripts/modules/dcos/logo/dcos.logo.less
@@ -1,6 +1,5 @@
 cloud-provider-logo {
   .icon-dcos {
-    background: url('dcos.logo.svg') no-repeat 50% 50%;
-    background-size: cover;
+    mask-image: url('dcos.logo.svg');
   }
 }

--- a/app/scripts/modules/ecs/src/logo/ecs.logo.less
+++ b/app/scripts/modules/ecs/src/logo/ecs.logo.less
@@ -1,6 +1,5 @@
 .cloud-provider-logo {
   .icon-ecs {
-    background: url('ecs.icon.svg') no-repeat 50% 50%;
-    background-size: cover;
+    mask-image: url('ecs.icon.svg');
   }
 }

--- a/app/scripts/modules/google/src/logo/gce.logo.less
+++ b/app/scripts/modules/google/src/logo/gce.logo.less
@@ -1,6 +1,5 @@
 .cloud-provider-logo {
   .icon-gce {
-    background: url('gce.logo.svg') no-repeat 50% 50%;
-    background-size: cover;
+    mask-image: url('gce.logo.svg');
   }
 }

--- a/app/scripts/modules/kubernetes/src/logo/kubernetes.logo.less
+++ b/app/scripts/modules/kubernetes/src/logo/kubernetes.logo.less
@@ -1,6 +1,5 @@
 .cloud-provider-logo {
   .icon-kubernetes {
-    background: url('kubernetes.icon.svg') no-repeat 50% 50%;
-    background-size: cover;
+    mask-image: url('kubernetes.icon.svg');
   }
 }

--- a/app/scripts/modules/openstack/src/logo/openstack.logo.less
+++ b/app/scripts/modules/openstack/src/logo/openstack.logo.less
@@ -1,6 +1,5 @@
 .cloud-provider-logo {
   .icon-openstack {
-    background: url('openstack.logo.svg') no-repeat 50% 50%;
-    background-size: cover;
+    mask-image: url('openstack.logo.svg');
   }
 }

--- a/app/scripts/modules/titus/src/logo/titus.logo.less
+++ b/app/scripts/modules/titus/src/logo/titus.logo.less
@@ -1,6 +1,5 @@
 .cloud-provider-logo {
   .icon-titus {
-    background: url('titus.logo.svg') no-repeat 50% 50%;
-    background-size: cover;
+    mask-image: url('titus.logo.svg');
   }
 }


### PR DESCRIPTION
`mask-*` was not implemented by several of the major browsers a few years ago when the cloud provider logo work was first done. 

This meant we worked around it with some really clunky `filter` code to get the green color, which wasn't exactly the same as the other green color.

`mask-*` is now implemented in Safari, Edge, and Firefox, so...let's use it and get rid of the gross `filter` bits?