### PR TITLE
feat(stage): manual judgement continue button moved to right

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/manualJudgment/ManualJudgmentApproval.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/manualJudgment/ManualJudgmentApproval.tsx
@@ -101,18 +101,6 @@ export class ManualJudgmentApproval extends React.Component<
             )}
             <div className="action-buttons">
               <button
-                className="btn btn-primary"
-                disabled={
-                  this.state.submitting ||
-                  stage.context.judgmentStatus ||
-                  (options.length && !this.state.judgmentInput.value)
-                }
-                onClick={this.handleContinueClick}
-              >
-                {this.isSubmitting('continue') && <ButtonBusyIndicator />}
-                {stage.context.continueButtonLabel || 'Continue'}
-              </button>
-              <button
                 className="btn btn-danger"
                 onClick={this.handleStopClick}
                 disabled={
@@ -123,6 +111,18 @@ export class ManualJudgmentApproval extends React.Component<
               >
                 {this.isSubmitting('stop') && <ButtonBusyIndicator />}
                 {stage.context.stopButtonLabel || 'Stop'}
+              </button>
+              <button
+                className="btn btn-primary"
+                disabled={
+                  this.state.submitting ||
+                  stage.context.judgmentStatus ||
+                  (options.length && !this.state.judgmentInput.value)
+                }
+                onClick={this.handleContinueClick}
+              >
+                {this.isSubmitting('continue') && <ButtonBusyIndicator />}
+                {stage.context.continueButtonLabel || 'Continue'}
               </button>
             </div>
           </div>


### PR DESCRIPTION
Resolves https://github.com/spinnaker/spinnaker/issues/3371

Before, the continue button appears on the left.

![screen shot 2019-01-02 at 10 45 39 am](https://user-images.githubusercontent.com/34253460/50599387-f377ed00-0e7b-11e9-90d5-6c51f8bc6df9.png)

After, it's on the right.

![screen shot 2019-01-02 at 10 46 18 am](https://user-images.githubusercontent.com/34253460/50599391-f672dd80-0e7b-11e9-9a25-28c5cd1ad5b3.png)
