### PR TITLE
fix(amazon/loadBalancer): Restore the "security group removed" warning when switching regions

### DIFF
--- a/app/scripts/modules/amazon/src/loadBalancer/configure/common/SecurityGroups.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/common/SecurityGroups.tsx
@@ -119,7 +119,7 @@ class SecurityGroupsImpl extends React.Component<ISecurityGroupsProps, ISecurity
           if (matches.length) {
             existingNames.push(matches[0].name);
           } else {
-            if (defaultSecurityGroups.includes(securityGroup)) {
+            if (!defaultSecurityGroups.includes(securityGroup)) {
               newRemoved.push(securityGroup);
             }
           }


### PR DESCRIPTION
this logic was accidentally reversed during a prior refactor