### PR TITLE
feat(core): allow setting params via query string on manual execution

### DIFF
--- a/app/scripts/modules/core/src/navigation/urlParser.ts
+++ b/app/scripts/modules/core/src/navigation/urlParser.ts
@@ -9,10 +9,6 @@ export interface IQueryParams {
 }
 
 export class UrlParser {
-  public static parseLocationHash(hash = ''): string {
-    return hash.indexOf('?') <= 1 ? '' : hash.substring(hash.indexOf('?') + 1);
-  }
-
   /**
    * Parses an escaped url query string into key-value pairs.
    * @returns {Object.<string,boolean|Array>}

--- a/app/scripts/modules/core/src/pipeline/executions/Executions.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/Executions.tsx
@@ -62,25 +62,6 @@ export class Executions extends React.Component<IExecutionsProps, IExecutionsSta
     };
   }
 
-  public componentWillMount(): void {
-    const { app } = this.props;
-    if (ExecutionState.filterModel.mostRecentApplication !== app.name) {
-      ExecutionState.filterModel.asFilterModel.groups = [];
-      ExecutionState.filterModel.mostRecentApplication = app.name;
-    }
-
-    if (app.notFound) {
-      return;
-    }
-    app.setActiveState(app.executions);
-    app.executions.activate();
-    app.pipelineConfigs.activate();
-    this.activeRefresher = SchedulerFactory.createScheduler(5000);
-    this.activeRefresher.subscribe(() => {
-      app.getDataSource('runningExecutions').refresh();
-    });
-  }
-
   private clearFilters = (): void => {
     ExecutionFilterService.clearFilters();
     this.updateExecutionGroups(true);
@@ -219,12 +200,28 @@ export class Executions extends React.Component<IExecutionsProps, IExecutionsSta
   }
 
   public componentDidMount(): void {
+    const { app } = this.props;
+    if (ExecutionState.filterModel.mostRecentApplication !== app.name) {
+      ExecutionState.filterModel.asFilterModel.groups = [];
+      ExecutionState.filterModel.mostRecentApplication = app.name;
+    }
+
+    if (app.notFound) {
+      return;
+    }
+    app.setActiveState(app.executions);
+    app.executions.activate();
+    app.pipelineConfigs.activate();
+    this.activeRefresher = SchedulerFactory.createScheduler(5000);
+    this.activeRefresher.subscribe(() => {
+      app.getDataSource('runningExecutions').refresh();
+    });
+
     this.groupsUpdatedSubscription = ExecutionFilterService.groupsUpdatedStream.subscribe(() => this.groupsUpdated());
     this.locationChangeUnsubscribe = ReactInjector.$uiRouter.transitionService.onSuccess({}, t =>
       this.handleTransitionSuccess(t),
     );
 
-    const { app } = this.props;
     this.executionsRefreshUnsubscribe = app.executions.onRefresh(
       null,
       () => {

--- a/app/scripts/modules/core/src/pipeline/manualExecution/manualPipelineExecution.controller.js
+++ b/app/scripts/modules/core/src/pipeline/manualExecution/manualPipelineExecution.controller.js
@@ -6,6 +6,7 @@ import _ from 'lodash';
 import { AuthenticationService } from 'core/authentication';
 import { Registry } from 'core/registry';
 import { SETTINGS } from 'core/config/settings';
+import { UrlParser } from 'core/navigation';
 import { AppNotificationsService } from 'core/notification/AppNotificationsService';
 import { PipelineTemplateReader } from 'core/pipeline/config/templates/PipelineTemplateReader';
 
@@ -168,6 +169,8 @@ module.exports = angular
     };
 
     this.addParameter = parameterConfig => {
+      const [, queryString] = window.location.href.split('?');
+      const queryParams = UrlParser.parseQueryString(queryString);
       // Inject the default value into the options list if it is absent
       if (
         parameterConfig.default &&
@@ -178,6 +181,9 @@ module.exports = angular
       }
       const { name } = parameterConfig;
       const parameters = trigger ? trigger.parameters : {};
+      if (queryParams[name]) {
+        this.parameters[name] = queryParams[name];
+      }
       if (this.parameters[name] === undefined) {
         this.parameters[name] = parameters[name] !== undefined ? parameters[name] : parameterConfig.default;
       }


### PR DESCRIPTION
We have some users taking advantage of the deep linking ability to start a manual execution. They would like the ability to specify values for the parameters in the query string, e.g.
```
executions?startManualExecution=myPipeline&pipelineParam1=foo
```

I was going to rewrite this component in React, but...there's a lot going on in this component, so will for sure do it later.