### PR TITLE
fix(core/account): Return empty array if no preferred zones are found in a region

### DIFF
--- a/app/scripts/modules/core/src/account/AccountService.ts
+++ b/app/scripts/modules/core/src/account/AccountService.ts
@@ -126,7 +126,7 @@ export class AccountService {
     region: string,
   ): IPromise<string[]> {
     return this.getPreferredZonesByAccount(provider).then(
-      (result: IAccountZone) => (result[account] ? result[account][region] : []),
+      (result: IAccountZone) => (result[account] && result[account][region]) || [],
     );
   }
 


### PR DESCRIPTION
In load balancer, select an account and region.  Then select a new account that doesn't exist in the same region.  The preferred zones will be returned as undefined.  This manifests as this stack trace, and the create load balancer dialog crashes: 

<img width="577" alt="screen shot 2019-01-05 at 2 08 39 pm" src="https://user-images.githubusercontent.com/2053478/50729723-8ff7f480-10f3-11e9-85a1-3a71c63c97bf.png">
