### PR TITLE
feat(provider/gce): Moniker support for GCE server groups

### DIFF
--- a/app/scripts/modules/core/src/cluster/cluster.service.ts
+++ b/app/scripts/modules/core/src/cluster/cluster.service.ts
@@ -273,6 +273,13 @@ export class ClusterService {
     const nameParts = NameUtils.parseServerGroupName(serverGroup.name);
     if (serverGroup.moniker) {
       Object.assign(serverGroup, serverGroup.moniker);
+      if (serverGroup.moniker.cluster == null && (serverGroup.moniker.stack || serverGroup.moniker.detail)) {
+        serverGroup.cluster = NameUtils.getClusterName(
+          serverGroup.moniker.app || nameParts.application,
+          serverGroup.stack,
+          serverGroup.detail,
+        );
+      }
     } else {
       serverGroup.app = nameParts.application;
       serverGroup.stack = nameParts.stack;

--- a/app/scripts/modules/core/src/cluster/cluster.service.ts
+++ b/app/scripts/modules/core/src/cluster/cluster.service.ts
@@ -273,13 +273,6 @@ export class ClusterService {
     const nameParts = NameUtils.parseServerGroupName(serverGroup.name);
     if (serverGroup.moniker) {
       Object.assign(serverGroup, serverGroup.moniker);
-      if (serverGroup.moniker.cluster == null && (serverGroup.moniker.stack || serverGroup.moniker.detail)) {
-        serverGroup.cluster = NameUtils.getClusterName(
-          serverGroup.moniker.app || nameParts.application,
-          serverGroup.stack,
-          serverGroup.detail,
-        );
-      }
     } else {
       serverGroup.app = nameParts.application;
       serverGroup.stack = nameParts.stack;

--- a/app/scripts/modules/google/src/serverGroup/configure/serverGroupCommandBuilder.service.js
+++ b/app/scripts/modules/google/src/serverGroup/configure/serverGroupCommandBuilder.service.js
@@ -3,7 +3,7 @@
 const angular = require('angular');
 import _ from 'lodash';
 
-import { AccountService, ExpectedArtifactService, INSTANCE_TYPE_SERVICE, NameUtils } from '@spinnaker/core';
+import { AccountService, ExpectedArtifactService, INSTANCE_TYPE_SERVICE } from '@spinnaker/core';
 import { GCEProviderSettings } from 'google/gce.settings';
 
 module.exports = angular
@@ -379,14 +379,14 @@ module.exports = angular
 
       function buildServerGroupCommandFromExisting(application, serverGroup, mode) {
         mode = mode || 'clone';
-        const serverGroupName = NameUtils.parseServerGroupName(serverGroup.name);
+        const moniker = serverGroup.moniker;
 
         const command = {
           application: application.name,
           autoscalingPolicy: _.cloneDeep(serverGroup.autoscalingPolicy),
           strategy: '',
-          stack: serverGroupName.stack,
-          freeFormDetails: serverGroupName.freeFormDetails,
+          stack: moniker.stack,
+          freeFormDetails: moniker.detail,
           credentials: serverGroup.account,
           loadBalancers: extractLoadBalancers(serverGroup.asg),
           loadBalancingPolicy: _.cloneDeep(serverGroup.loadBalancingPolicy),

--- a/app/scripts/modules/google/src/serverGroup/configure/serverGroupCommandBuilder.service.js
+++ b/app/scripts/modules/google/src/serverGroup/configure/serverGroupCommandBuilder.service.js
@@ -278,6 +278,11 @@ module.exports = angular
           if (command.labels['spinnaker-server-group']) {
             delete command.labels['spinnaker-server-group'];
           }
+
+          // Need to delete the sequence, otherwise it won't increment
+          if (command.labels['spinnaker-moniker-sequence']) {
+            delete command.labels['spinnaker-moniker-sequence'];
+          }
         }
       }
 

--- a/app/scripts/modules/google/src/serverGroup/configure/serverGroupCommandBuilder.service.js
+++ b/app/scripts/modules/google/src/serverGroup/configure/serverGroupCommandBuilder.service.js
@@ -244,6 +244,10 @@ module.exports = angular
             angular.extend(command.instanceMetadata, _.omit(metadataItems, gceServerGroupHiddenMetadataKeys));
           }
         }
+
+        if (command.labels['spinnaker-moniker-sequence']) {
+          delete command.labels['spinnaker-moniker-sequence'];
+        }
       }
 
       function getCustomUserDataKeys(customUserData) {


### PR DESCRIPTION
Makes Deck use moniker for GCE server groups. Depends on https://github.com/spinnaker/clouddriver/pull/3258