### PR TITLE
fix(pipelines): hit target for labels is off by 8px

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/graph/PipelineGraphNode.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/graph/PipelineGraphNode.tsx
@@ -136,13 +136,11 @@ export class PipelineGraphNode extends React.Component<IPipelineGraphNodeProps> 
 
     // Wrap all the label html in a foreignObject to make SVG happy
     GraphLabel = (
-      <foreignObject
-        width={maxLabelWidth}
-        height="34"
-        transform={`translate(${labelOffsetX}, ${node.leaf && !node.executionStage ? -8 : labelOffsetY * -1})`}
-      >
-        {GraphLabel}
-      </foreignObject>
+      <g transform={`translate(${labelOffsetX}, ${node.leaf && !node.executionStage ? -8 : labelOffsetY * -1})`}>
+        <foreignObject width={maxLabelWidth} height="34">
+          {GraphLabel}
+        </foreignObject>
+      </g>
     );
 
     let NodeContents = (


### PR DESCRIPTION
The transform applied to the foreignObject doesn't seem to translate the hit target. Wrapping the foreignObject in a group seems to do the job.

Before, an area of the label is not clickable:

![pipeline _graph_label_broke](https://user-images.githubusercontent.com/34253460/50836723-e51c4c00-1327-11e9-918f-87ad7cc0e0d5.gif)

After, the entire label is clickable as expected:

![pipeline _graph_label_fixed](https://user-images.githubusercontent.com/34253460/50836740-f49b9500-1327-11e9-88ee-bd84a81b8cb5.gif)

Fixes https://github.com/spinnaker/spinnaker/issues/3828#event-2060240398