### PR TITLE
fix(kubernetes): specify monospace fonts to prevent cursor misalignment in ace editor

### DIFF
--- a/app/scripts/modules/kubernetes/src/v2/manifest/editor/editor.less
+++ b/app/scripts/modules/kubernetes/src/v2/manifest/editor/editor.less
@@ -1,10 +1,12 @@
+@import (reference) '~bootstrap/less/variables.less';
+
 .ace-editor {
   // TODO(dpeach): Deck's styles are overriding the ace editor's
   // font styles, so we have to set them here. Ideally
   // we wouldn't have to do this.
   div,
   span {
-    font-family: monospace;
+    font-family: @font-family-monospace;
   }
 
   > div.ace_gutter {


### PR DESCRIPTION
Closes https://github.com/spinnaker/spinnaker/issues/3807