### PR TITLE
fix(core): do not overhydrate executions

### DIFF
--- a/app/scripts/modules/core/src/pipeline/service/execution.service.ts
+++ b/app/scripts/modules/core/src/pipeline/service/execution.service.ts
@@ -523,6 +523,9 @@ export class ExecutionService {
     if (unhydrated.hydrator) {
       return unhydrated.hydrator;
     }
+    if (unhydrated.hydrated) {
+      return Promise.resolve(unhydrated);
+    }
     const executionHydrator = this.getExecution(unhydrated.id).then(hydrated => {
       this.transformExecution(application, hydrated);
       hydrated.stages.forEach(s => {


### PR DESCRIPTION
There are multiple ways an execution is hydrated (not just via the `hydrate` method). When we call the `hydrate` method, we should short-circuit out if it's already hydrated, rather than reload the execution.

This cuts down on the long loading indicators on execution stage tooltips.