### PR TITLE
fix(core): navigate to failed stage with message if possible on detai…

### DIFF
--- a/app/scripts/modules/core/src/pipeline/executions/execution/Execution.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/execution/Execution.tsx
@@ -114,7 +114,10 @@ export class Execution extends React.Component<IExecutionProps, IExecutionState>
 
   public toggleDetails = (stageIndex?: number, subIndex?: number): void => {
     const { executionService } = ReactInjector;
-    executionService.toggleDetails(this.props.execution, stageIndex, subIndex);
+    const { execution, application } = this.props;
+    executionService.hydrate(application, execution).then(() => {
+      executionService.toggleDetails(execution, stageIndex, subIndex);
+    });
   };
 
   public getUrl(): string {

--- a/app/scripts/modules/core/src/pipeline/service/ExecutionsTransformer.ts
+++ b/app/scripts/modules/core/src/pipeline/service/ExecutionsTransformer.ts
@@ -274,6 +274,9 @@ export class ExecutionsTransformer {
     if (steps.find(s => s.isFailed)) {
       summary.firstActiveStage = steps.findIndex(s => s.isFailed);
     }
+    if (steps.find(s => s.isFailed && !!s.failureMessage)) {
+      summary.firstActiveStage = steps.findIndex(s => s.isFailed && !!s.failureMessage);
+    }
   }
 
   public static transformExecution(application: Application, execution: IExecution): void {


### PR DESCRIPTION
…ls toggle

There are some garbage stages in the execution, and when a user clicks on a failed stage, we automatically bring them to the first failed stage, which is often one of these trash stages, e.g. "Deploy".

If we hydrate the execution, we can grab the first stage with a legitimate failure message, and show that one on click.