### PR TITLE
fix(core): do not flag pipelines dirty on initial save

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/pipelineConfigurer.js
+++ b/app/scripts/modules/core/src/pipeline/config/pipelineConfigurer.js
@@ -388,6 +388,7 @@ module.exports = angular
         .then(() => $scope.application.pipelineConfigs.refresh(true))
         .then(
           () => {
+            $scope.viewState.hasHistory = true;
             setOriginal(toSave);
             markDirty();
             this.setViewState({ saving: false });

--- a/app/scripts/modules/core/src/pipeline/config/services/PipelineConfigService.spec.ts
+++ b/app/scripts/modules/core/src/pipeline/config/services/PipelineConfigService.spec.ts
@@ -62,18 +62,22 @@ describe('PipelineConfigService', () => {
         ],
       });
 
-      $http.expectPOST(API.baseUrl + '/pipelines').respond(200, '');
+      $http
+        .expectPOST(API.baseUrl + '/pipelines', (requestString: string) => {
+          const request = JSON.parse(requestString) as IPipeline;
+          return (
+            request.stages[0].name === 'explicit name' &&
+            !request.stages[1].name &&
+            !request.stages[2].name &&
+            request.stages.every(s => !s.isNew)
+          );
+        })
+        .respond(200, '');
 
       PipelineConfigService.savePipeline(pipeline);
       $scope.$digest();
-
-      expect(pipeline.stages[0].name).toBe('explicit name');
-      expect(pipeline.stages[1].name).toBeUndefined();
-      expect(pipeline.stages[2].name).toBeUndefined();
-
-      expect(pipeline.stages[0].isNew).toBeUndefined();
-      expect(pipeline.stages[1].isNew).toBeUndefined();
-      expect(pipeline.stages[2].isNew).toBeUndefined();
+      $http.flush();
+      $http.verifyNoOutstandingRequest();
     });
   });
 

--- a/app/scripts/modules/core/src/pipeline/config/services/PipelineConfigService.ts
+++ b/app/scripts/modules/core/src/pipeline/config/services/PipelineConfigService.ts
@@ -1,5 +1,5 @@
 import { IPromise } from 'angular';
-import { sortBy, uniq } from 'lodash';
+import { sortBy, uniq, cloneDeep } from 'lodash';
 import { $q } from 'ngimport';
 
 import { API } from 'core/api/ApiService';
@@ -57,7 +57,8 @@ export class PipelineConfigService {
       .remove();
   }
 
-  public static savePipeline(pipeline: IPipeline): IPromise<void> {
+  public static savePipeline(toSave: IPipeline): IPromise<void> {
+    const pipeline = cloneDeep(toSave);
     delete pipeline.isNew;
     pipeline.name = pipeline.name.trim();
     if (Array.isArray(pipeline.stages)) {


### PR DESCRIPTION
When it's brand new, there are `isNew` flags on the pipeline and its stages. These get removed by the `savePipeline` method, which is a surprise!

It's better to make a deep copy of the config in the save method, and remove the fields from there.

Also toggling the `hasHistory` flag after a successful save.