### PR TITLE
fix(appengine/google/kubernetes): change logo background colors to of…

### DIFF
--- a/app/scripts/modules/appengine/src/logo/appengine.logo.less
+++ b/app/scripts/modules/appengine/src/logo/appengine.logo.less
@@ -1,5 +1,6 @@
 .cloud-provider-logo {
   .icon-appengine {
     mask-image: url('appengine.icon.svg');
+    background-color: #4285f4;
   }
 }

--- a/app/scripts/modules/google/src/logo/gce.logo.less
+++ b/app/scripts/modules/google/src/logo/gce.logo.less
@@ -1,5 +1,6 @@
 .cloud-provider-logo {
   .icon-gce {
     mask-image: url('gce.logo.svg');
+    background-color: #4285f4;
   }
 }

--- a/app/scripts/modules/kubernetes/src/logo/kubernetes.logo.less
+++ b/app/scripts/modules/kubernetes/src/logo/kubernetes.logo.less
@@ -1,5 +1,6 @@
 .cloud-provider-logo {
   .icon-kubernetes {
     mask-image: url('kubernetes.icon.svg');
+    background-color: #326ce5;
   }
 }


### PR DESCRIPTION
…ficial brand colors

Currently, we set the background color of all Cloud Provider logos to Spinnaker's `color-success` green color [here](https://github.com/spinnaker/deck/blob/master/app/scripts/modules/core/src/cloudProvider/cloudProviderLogo.less#L10).

This overrides the GAE, GCE, and Kubernetes logo background colors to match fill colors from [official Google SVG files](https://cloud.google.com/icons/). Probably not worth making color variables for these since they are not part of the Spinnaker color palette.
