### PR TITLE
Rejigger wizard modal and wizard wizard page to use render props

### DIFF
--- a/app/scripts/modules/amazon/src/loadBalancer/configure/application/ALBAdvancedSettings.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/application/ALBAdvancedSettings.tsx
@@ -1,19 +1,8 @@
 import * as React from 'react';
-import { FormikErrors } from 'formik';
 
-import { FormikFormField, CheckboxInput, NumberInput, HelpField, IWizardPageProps, wizardPage } from '@spinnaker/core';
+import { FormikFormField, CheckboxInput, NumberInput, HelpField } from '@spinnaker/core';
 
-import { IAmazonApplicationLoadBalancerUpsertCommand } from 'amazon/domain';
-
-export type IALBAdvancedSettingsProps = IWizardPageProps<IAmazonApplicationLoadBalancerUpsertCommand>;
-
-class ALBAdvancedSettingsImpl extends React.Component<IALBAdvancedSettingsProps> {
-  public static LABEL = 'Advanced Settings';
-
-  public validate(): FormikErrors<IAmazonApplicationLoadBalancerUpsertCommand> {
-    return {};
-  }
-
+export class ALBAdvancedSettings extends React.Component {
   public render() {
     return (
       <div>
@@ -34,5 +23,3 @@ class ALBAdvancedSettingsImpl extends React.Component<IALBAdvancedSettingsProps>
     );
   }
 }
-
-export const ALBAdvancedSettings = wizardPage(ALBAdvancedSettingsImpl);

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/application/ALBListeners.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/application/ALBListeners.tsx
@@ -2,17 +2,16 @@ import * as React from 'react';
 import { $q } from 'ngimport';
 import { SortableContainer, SortableElement, SortableHandle, arrayMove, SortEnd } from 'react-sortable-hoc';
 import { difference, flatten, get, uniq } from 'lodash';
-import { FormikErrors } from 'formik';
+import { FormikErrors, FormikProps } from 'formik';
 
 import {
   Application,
   CustomLabels,
   HelpField,
-  IWizardPageProps,
+  IWizardPageComponent,
   ReactInjector,
   Tooltip,
   ValidationMessage,
-  wizardPage,
 } from '@spinnaker/core';
 
 import { AWSProviderSettings } from 'amazon/aws.settings';
@@ -66,12 +65,13 @@ const defaultAuthAction = {
   type: 'authenticate-oidc',
 } as IListenerAction;
 
-export interface IALBListenersProps extends IWizardPageProps<IAmazonApplicationLoadBalancerUpsertCommand> {
+export interface IALBListenersProps {
   app: Application;
+  formik: FormikProps<IAmazonApplicationLoadBalancerUpsertCommand>;
 }
 
-class ALBListenersImpl extends React.Component<IALBListenersProps, IALBListenersState> {
-  public static LABEL = 'Listeners';
+export class ALBListeners extends React.Component<IALBListenersProps, IALBListenersState>
+  implements IWizardPageComponent<IAmazonApplicationLoadBalancerUpsertCommand> {
   public protocols = ['HTTP', 'HTTPS'];
 
   private initialActionsWithAuth: Set<IListenerAction[]> = new Set();
@@ -866,5 +866,3 @@ const Rules = SortableContainer((props: IRulesProps) => (
     </tr>
   </tbody>
 ));
-
-export const ALBListeners = wizardPage(ALBListenersImpl);

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/application/TargetGroups.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/application/TargetGroups.tsx
@@ -1,22 +1,22 @@
 import * as React from 'react';
 import { filter, flatten, get, groupBy, set, uniq } from 'lodash';
-import { FormikErrors } from 'formik';
+import { FormikErrors, FormikProps } from 'formik';
 import { Observable, Subject } from 'rxjs';
 
 import {
   Application,
   HelpField,
-  IWizardPageProps,
+  IWizardPageComponent,
   SpInput,
   ValidationMessage,
   spelNumberCheck,
-  wizardPage,
 } from '@spinnaker/core';
 
 import { IAmazonApplicationLoadBalancer, IAmazonApplicationLoadBalancerUpsertCommand } from 'amazon/domain';
 
-export interface ITargetGroupsProps extends IWizardPageProps<IAmazonApplicationLoadBalancerUpsertCommand> {
+export interface ITargetGroupsProps {
   app: Application;
+  formik: FormikProps<IAmazonApplicationLoadBalancerUpsertCommand>;
   isNew: boolean;
   loadBalancer: IAmazonApplicationLoadBalancer;
 }
@@ -26,9 +26,8 @@ export interface ITargetGroupsState {
   oldTargetGroupCount: number;
 }
 
-class TargetGroupsImpl extends React.Component<ITargetGroupsProps, ITargetGroupsState> {
-  public static LABEL = 'Target Groups';
-
+export class TargetGroups extends React.Component<ITargetGroupsProps, ITargetGroupsState>
+  implements IWizardPageComponent<IAmazonApplicationLoadBalancerUpsertCommand> {
   public protocols = ['HTTP', 'HTTPS'];
   public targetTypes = ['instance', 'ip'];
   private destroy$ = new Subject();
@@ -139,7 +138,9 @@ class TargetGroupsImpl extends React.Component<ITargetGroupsProps, ITargetGroups
           }
         });
 
-        this.setState({ existingTargetGroupNames: targetGroupsByAccountAndRegion }, this.props.revalidate);
+        this.setState({ existingTargetGroupNames: targetGroupsByAccountAndRegion }, () =>
+          this.props.formik.validateForm(),
+        );
       });
   }
 
@@ -488,5 +489,3 @@ class TargetGroupsImpl extends React.Component<ITargetGroupsProps, ITargetGroups
     );
   }
 }
-
-export const TargetGroups = wizardPage(TargetGroupsImpl);

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/classic/AdvancedSettings.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/classic/AdvancedSettings.tsx
@@ -1,21 +1,17 @@
 import * as React from 'react';
-import { FormikErrors } from 'formik';
+import { FormikProps } from 'formik';
 
-import { Validation, FormikFormField, NumberInput, HelpField, IWizardPageProps, wizardPage } from '@spinnaker/core';
+import { Validation, FormikFormField, NumberInput, HelpField } from '@spinnaker/core';
 
 import { IAmazonClassicLoadBalancerUpsertCommand } from 'amazon/domain';
 
 import './AdvancedSettings.css';
 
-export type IAdvancedSettingsProps = IWizardPageProps<IAmazonClassicLoadBalancerUpsertCommand>;
+export interface IAdvancedSettingsProps {
+  formik: FormikProps<IAmazonClassicLoadBalancerUpsertCommand>;
+}
 
-class AdvancedSettingsImpl extends React.Component<IAdvancedSettingsProps> {
-  public static LABEL = 'Advanced Settings';
-
-  public validate(): FormikErrors<IAmazonClassicLoadBalancerUpsertCommand> {
-    return {};
-  }
-
+export class AdvancedSettings extends React.Component<IAdvancedSettingsProps> {
   public render() {
     const { values } = this.props.formik;
     return (
@@ -72,5 +68,3 @@ class AdvancedSettingsImpl extends React.Component<IAdvancedSettingsProps> {
     );
   }
 }
-
-export const AdvancedSettings = wizardPage(AdvancedSettingsImpl);

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/classic/HealthCheck.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/classic/HealthCheck.tsx
@@ -1,19 +1,15 @@
 import * as React from 'react';
-import { FormikErrors } from 'formik';
+import { FormikProps } from 'formik';
 
-import { FormikFormField, SelectInput, TextInput, NumberInput, IWizardPageProps, wizardPage } from '@spinnaker/core';
+import { FormikFormField, SelectInput, TextInput, NumberInput } from '@spinnaker/core';
 
 import { IAmazonClassicLoadBalancerUpsertCommand } from 'amazon/domain';
 
-export type IHealthCheckProps = IWizardPageProps<IAmazonClassicLoadBalancerUpsertCommand>;
+export interface IHealthCheckProps {
+  formik: FormikProps<IAmazonClassicLoadBalancerUpsertCommand>;
+}
 
-class HealthCheckImpl extends React.Component<IHealthCheckProps> {
-  public static LABEL = 'Health Check';
-
-  public validate() {
-    return {} as FormikErrors<IAmazonClassicLoadBalancerUpsertCommand>;
-  }
-
+export class HealthCheck extends React.Component<IHealthCheckProps> {
   public requiresHealthCheckPath(): boolean {
     const { values } = this.props.formik;
     return values.healthCheckProtocol && values.healthCheckProtocol.indexOf('HTTP') === 0;
@@ -72,5 +68,3 @@ class HealthCheckImpl extends React.Component<IHealthCheckProps> {
     );
   }
 }
-
-export const HealthCheck = wizardPage(HealthCheckImpl);

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/classic/Listeners.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/classic/Listeners.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { get } from 'lodash';
-import { FormikErrors } from 'formik';
+import { FormikProps } from 'formik';
 
-import { Application, IWizardPageProps, wizardPage } from '@spinnaker/core';
+import { Application } from '@spinnaker/core';
 
 import { AWSProviderSettings } from 'amazon/aws.settings';
 import {
@@ -16,7 +16,8 @@ import { AmazonCertificateSelectField } from '../common/AmazonCertificateSelectF
 
 import './Listeners.less';
 
-export interface IListenersProps extends IWizardPageProps<IAmazonClassicLoadBalancerUpsertCommand> {
+export interface IListenersProps {
+  formik: FormikProps<IAmazonClassicLoadBalancerUpsertCommand>;
   app: Application;
 }
 
@@ -24,8 +25,7 @@ export interface IListenersState {
   certificates: { [accountId: number]: IAmazonCertificate[] };
 }
 
-class ListenersImpl extends React.Component<IListenersProps, IListenersState> {
-  public static LABEL = 'Listeners';
+export class Listeners extends React.Component<IListenersProps, IListenersState> {
   public protocols = ['HTTP', 'HTTPS', 'TCP', 'SSL'];
   public secureProtocols = ['HTTPS', 'SSL'];
   private certificateTypes = get(AWSProviderSettings, 'loadBalancers.certificateTypes', ['iam', 'acm']);
@@ -33,10 +33,6 @@ class ListenersImpl extends React.Component<IListenersProps, IListenersState> {
   public state: IListenersState = {
     certificates: [],
   };
-
-  public validate() {
-    return {} as FormikErrors<IAmazonClassicLoadBalancerUpsertCommand>;
-  }
 
   public componentDidMount(): void {
     this.loadCertificates();
@@ -271,5 +267,3 @@ class ListenersImpl extends React.Component<IListenersProps, IListenersState> {
     );
   }
 }
-
-export const Listeners = wizardPage(ListenersImpl);

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/common/LoadBalancerLocation.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/common/LoadBalancerLocation.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as classNames from 'classnames';
 import { IPromise } from 'angular';
 import { chain, isNil, uniq, groupBy } from 'lodash';
-import { Field, FormikErrors, FieldProps } from 'formik';
+import { Field, FormikErrors, FieldProps, FormikProps } from 'formik';
 import { Observable, Subject } from 'rxjs';
 
 import {
@@ -14,13 +14,12 @@ import {
   IMoniker,
   IRegion,
   ISubnet,
-  IWizardPageProps,
+  IWizardPageComponent,
   NameUtils,
   RegionSelectField,
   Spinner,
   SubnetReader,
   ValidationMessage,
-  wizardPage,
 } from '@spinnaker/core';
 
 import { AWSProviderSettings } from 'amazon/aws.settings';
@@ -36,8 +35,9 @@ export interface ISubnetOption {
   vpcIds: string[];
 }
 
-export interface ILoadBalancerLocationProps extends IWizardPageProps<IAmazonLoadBalancerUpsertCommand> {
+export interface ILoadBalancerLocationProps {
   app: Application;
+  formik: FormikProps<IAmazonLoadBalancerUpsertCommand>;
   forPipelineConfig?: boolean;
   isNew?: boolean;
   loadBalancer?: IAmazonLoadBalancer;
@@ -53,9 +53,8 @@ export interface ILoadBalancerLocationState {
   subnets: ISubnetOption[];
 }
 
-class LoadBalancerLocationImpl extends React.Component<ILoadBalancerLocationProps, ILoadBalancerLocationState> {
-  public static LABEL = 'Location';
-
+export class LoadBalancerLocation extends React.Component<ILoadBalancerLocationProps, ILoadBalancerLocationState>
+  implements IWizardPageComponent<IAmazonLoadBalancerUpsertCommand> {
   public state: ILoadBalancerLocationState = {
     accounts: undefined,
     availabilityZones: [],
@@ -395,5 +394,3 @@ class LoadBalancerLocationImpl extends React.Component<ILoadBalancerLocationProp
     );
   }
 }
-
-export const LoadBalancerLocation = wizardPage(LoadBalancerLocationImpl);

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/network/NLBAdvancedSettings.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/network/NLBAdvancedSettings.tsx
@@ -1,20 +1,15 @@
 import * as React from 'react';
-import { Field, FormikErrors } from 'formik';
+import { Field, FormikProps } from 'formik';
 
-import { HelpField, IWizardPageProps, wizardPage } from '@spinnaker/core';
+import { HelpField } from '@spinnaker/core';
 
 import { IAmazonNetworkLoadBalancerUpsertCommand } from 'amazon/domain';
 
-export type INLBAdvancedSettingsProps = IWizardPageProps<IAmazonNetworkLoadBalancerUpsertCommand>;
+export interface INLBAdvancedSettingsProps {
+  formik: FormikProps<IAmazonNetworkLoadBalancerUpsertCommand>;
+}
 
-class NLBAdvancedSettingsImpl extends React.Component<INLBAdvancedSettingsProps> {
-  public static LABEL = 'Advanced Settings';
-
-  public validate() {
-    const errors = {} as FormikErrors<IAmazonNetworkLoadBalancerUpsertCommand>;
-    return errors;
-  }
-
+export class NLBAdvancedSettings extends React.Component<INLBAdvancedSettingsProps> {
   public render() {
     const { values } = this.props.formik;
     return (
@@ -32,5 +27,3 @@ class NLBAdvancedSettingsImpl extends React.Component<INLBAdvancedSettingsProps>
     );
   }
 }
-
-export const NLBAdvancedSettings = wizardPage(NLBAdvancedSettingsImpl);

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/network/NLBListeners.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/network/NLBListeners.tsx
@@ -1,14 +1,17 @@
 import * as React from 'react';
 import { difference, flatten, uniq } from 'lodash';
 
-import { IWizardPageProps, ValidationMessage, wizardPage } from '@spinnaker/core';
+import { ValidationMessage, IWizardPageComponent } from '@spinnaker/core';
 
 import { NLBListenerProtocol, IListenerDescription, IAmazonNetworkLoadBalancerUpsertCommand } from 'amazon/domain';
+import { FormikProps } from 'formik';
 
-export type INLBListenersProps = IWizardPageProps<IAmazonNetworkLoadBalancerUpsertCommand>;
+export interface INLBListenersProps {
+  formik: FormikProps<IAmazonNetworkLoadBalancerUpsertCommand>;
+}
 
-class NLBListenersImpl extends React.Component<INLBListenersProps> {
-  public static LABEL = 'Listeners';
+export class NLBListeners extends React.Component<INLBListenersProps>
+  implements IWizardPageComponent<IAmazonNetworkLoadBalancerUpsertCommand> {
   public protocols = ['TCP'];
 
   private getAllTargetGroupsFromListeners(listeners: IListenerDescription[]): string[] {
@@ -191,5 +194,3 @@ class NLBListenersImpl extends React.Component<INLBListenersProps> {
     );
   }
 }
-
-export const NLBListeners = wizardPage(NLBListenersImpl);

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/network/TargetGroups.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/network/TargetGroups.tsx
@@ -1,22 +1,22 @@
 import * as React from 'react';
 import { filter, flatten, get, groupBy, set, uniq } from 'lodash';
-import { FormikErrors } from 'formik';
+import { FormikErrors, FormikProps } from 'formik';
 import { Observable, Subject } from 'rxjs';
 
 import {
   Application,
   HelpField,
-  IWizardPageProps,
+  IWizardPageComponent,
   spelNumberCheck,
   SpInput,
   ValidationMessage,
-  wizardPage,
 } from '@spinnaker/core';
 
 import { IAmazonApplicationLoadBalancer, IAmazonNetworkLoadBalancerUpsertCommand } from 'amazon/domain';
 
-export interface ITargetGroupsProps extends IWizardPageProps<IAmazonNetworkLoadBalancerUpsertCommand> {
+export interface ITargetGroupsProps {
   app: Application;
+  formik: FormikProps<IAmazonNetworkLoadBalancerUpsertCommand>;
   isNew: boolean;
   loadBalancer: IAmazonApplicationLoadBalancer;
 }
@@ -26,9 +26,8 @@ export interface ITargetGroupsState {
   oldTargetGroupCount: number;
 }
 
-class TargetGroupsImpl extends React.Component<ITargetGroupsProps, ITargetGroupsState> {
-  public static LABEL = 'Target Groups';
-
+export class TargetGroups extends React.Component<ITargetGroupsProps, ITargetGroupsState>
+  implements IWizardPageComponent<IAmazonNetworkLoadBalancerUpsertCommand> {
   public protocols = ['TCP'];
   public healthProtocols = ['TCP', 'HTTP', 'HTTPS'];
   public targetTypes = ['instance', 'ip'];
@@ -132,7 +131,9 @@ class TargetGroupsImpl extends React.Component<ITargetGroupsProps, ITargetGroups
           }
         });
 
-        this.setState({ existingTargetGroupNames: targetGroupsByAccountAndRegion }, this.props.revalidate);
+        this.setState({ existingTargetGroupNames: targetGroupsByAccountAndRegion }, () =>
+          this.props.formik.validateForm(),
+        );
       });
   }
 
@@ -417,5 +418,3 @@ class TargetGroupsImpl extends React.Component<ITargetGroupsProps, ITargetGroups
     );
   }
 }
-
-export const TargetGroups = wizardPage(TargetGroupsImpl);

--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/AmazonCloneServerGroupModal.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/AmazonCloneServerGroupModal.tsx
@@ -1,17 +1,17 @@
 import * as React from 'react';
 import { get } from 'lodash';
-import { FormikErrors, FormikValues } from 'formik';
 
 import {
   Application,
-  IStage,
-  ReactInjector,
-  TaskMonitor,
-  WizardModal,
   FirewallLabels,
   IModalComponentProps,
-  noop,
+  IStage,
+  ReactInjector,
   ReactModal,
+  TaskMonitor,
+  WizardModal,
+  WizardPage,
+  noop,
 } from '@spinnaker/core';
 
 import { AwsReactInjector } from 'amazon/reactShims';
@@ -159,11 +159,6 @@ export class AmazonCloneServerGroupModal extends React.Component<
     }
   };
 
-  private validate = (_values: FormikValues): FormikErrors<IAmazonServerGroupCommand> => {
-    const errors = {} as FormikErrors<IAmazonServerGroupCommand>;
-    return errors;
-  };
-
   public render() {
     const { application, command, dismissModal, title } = this.props;
     const { loaded, taskMonitor, requiresTemplateSelection } = this.state;
@@ -188,16 +183,61 @@ export class AmazonCloneServerGroupModal extends React.Component<
         dismissModal={dismissModal}
         closeModal={this.submit}
         submitButtonLabel={command.viewState.submitButtonLabel}
-        validate={this.validate}
-      >
-        <ServerGroupBasicSettings app={application} done={true} />
-        <ServerGroupLoadBalancers done={true} />
-        <ServerGroupSecurityGroups done={true} />
-        <ServerGroupInstanceType done={true} />
-        <ServerGroupCapacity done={true} />
-        <ServerGroupZones done={true} />
-        <ServerGroupAdvancedSettings app={application} done={true} />
-      </WizardModal>
+        render={({ formik, nextIdx, wizard }) => (
+          <>
+            <WizardPage
+              label="Basic Settings"
+              wizard={wizard}
+              order={nextIdx()}
+              render={({ innerRef }) => <ServerGroupBasicSettings ref={innerRef} formik={formik} app={application} />}
+            />
+
+            <WizardPage
+              label="Load Balancers"
+              wizard={wizard}
+              order={nextIdx()}
+              render={({ innerRef }) => <ServerGroupLoadBalancers ref={innerRef} formik={formik} />}
+            />
+
+            <WizardPage
+              label={FirewallLabels.get('Firewalls')}
+              wizard={wizard}
+              order={nextIdx()}
+              render={({ innerRef }) => <ServerGroupSecurityGroups ref={innerRef} formik={formik} />}
+            />
+
+            <WizardPage
+              label="Instance Type"
+              wizard={wizard}
+              order={nextIdx()}
+              render={({ innerRef }) => <ServerGroupInstanceType ref={innerRef} formik={formik} />}
+            />
+
+            <WizardPage
+              label="Capacity"
+              wizard={wizard}
+              order={nextIdx()}
+              render={({ innerRef }) => <ServerGroupCapacity ref={innerRef} formik={formik} />}
+            />
+
+            <WizardPage
+              label="Availability Zones"
+              wizard={wizard}
+              order={nextIdx()}
+              render={({ innerRef }) => <ServerGroupZones ref={innerRef} formik={formik} />}
+            />
+
+            <WizardPage
+              label="Advanced Settings"
+              wizard={wizard}
+              order={nextIdx()}
+              render={({ innerRef }) => (
+                <ServerGroupAdvancedSettings ref={innerRef} formik={formik} app={application} />
+              )}
+            />
+          </>
+        )}
+      />
     );
   }
 }

--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/ServerGroupBasicSettings.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/ServerGroupBasicSettings.tsx
@@ -1,18 +1,17 @@
 import * as React from 'react';
 import * as DOMPurify from 'dompurify';
-import { Field } from 'formik';
+import { Field, FormikProps } from 'formik';
 
 import {
   AccountSelectInput,
   DeploymentStrategySelector,
   HelpField,
-  IWizardPageProps,
-  wizardPage,
   NameUtils,
   RegionSelectField,
   Application,
   ReactInjector,
   IServerGroup,
+  IWizardPageComponent,
   TaskReason,
 } from '@spinnaker/core';
 
@@ -28,8 +27,9 @@ const isStackPattern = (stack: string) =>
 const isDetailPattern = (detail: string) =>
   !isExpressionLanguage(detail) ? /^([a-zA-Z_0-9._${}-]*(\${.+})*)*$/.test(detail) : true;
 
-export interface IServerGroupBasicSettingsProps extends IWizardPageProps<IAmazonServerGroupCommand> {
+export interface IServerGroupBasicSettingsProps {
   app: Application;
+  formik: FormikProps<IAmazonServerGroupCommand>;
 }
 
 export interface IServerGroupBasicSettingsState {
@@ -40,12 +40,9 @@ export interface IServerGroupBasicSettingsState {
   showPreviewAsWarning: boolean;
 }
 
-class ServerGroupBasicSettingsImpl extends React.Component<
-  IServerGroupBasicSettingsProps,
-  IServerGroupBasicSettingsState
-> {
-  public static LABEL = 'Basic Settings';
-
+export class ServerGroupBasicSettings
+  extends React.Component<IServerGroupBasicSettingsProps, IServerGroupBasicSettingsState>
+  implements IWizardPageComponent<IAmazonServerGroupCommand> {
   constructor(props: IServerGroupBasicSettingsProps) {
     super(props);
     const {
@@ -372,5 +369,3 @@ class ServerGroupBasicSettingsImpl extends React.Component<
     );
   }
 }
-
-export const ServerGroupBasicSettings = wizardPage(ServerGroupBasicSettingsImpl);

--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/ServerGroupCapacity.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/ServerGroupCapacity.tsx
@@ -1,19 +1,19 @@
 import * as React from 'react';
-import { Field } from 'formik';
+import { Field, FormikProps } from 'formik';
 
-import { IServerGroupCommand, IWizardPageProps, wizardPage } from '@spinnaker/core';
+import { IServerGroupCommand, IWizardPageComponent } from '@spinnaker/core';
 
 import { CapacitySelector } from '../capacity/CapacitySelector';
 import { MinMaxDesired } from '../capacity/MinMaxDesired';
 import { IAmazonServerGroupCommand } from '../../serverGroupConfiguration.service';
 
-export interface IServerGroupCapacityProps extends IWizardPageProps<IServerGroupCommand> {
+export interface IServerGroupCapacityProps {
+  formik: FormikProps<IServerGroupCommand>;
   hideTargetHealthyDeployPercentage?: boolean;
 }
 
-class ServerGroupCapacityImpl extends React.Component<IServerGroupCapacityProps> {
-  public static LABEL = 'Capacity';
-
+export class ServerGroupCapacity extends React.Component<IServerGroupCapacityProps>
+  implements IWizardPageComponent<IAmazonServerGroupCommand> {
   public validate(values: IServerGroupCommand): { [key: string]: string } {
     const errors: { [key: string]: string } = {};
 
@@ -67,5 +67,3 @@ class ServerGroupCapacityImpl extends React.Component<IServerGroupCapacityProps>
     );
   }
 }
-
-export const ServerGroupCapacity = wizardPage(ServerGroupCapacityImpl);

--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/ServerGroupInstanceType.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/ServerGroupInstanceType.tsx
@@ -1,15 +1,16 @@
 import * as React from 'react';
-import { FormikErrors } from 'formik';
+import { FormikErrors, FormikProps } from 'formik';
 
-import { IWizardPageProps, wizardPage, NgReact } from '@spinnaker/core';
+import { IWizardPageComponent, NgReact } from '@spinnaker/core';
 
 import { IAmazonServerGroupCommand } from '../../serverGroupConfiguration.service';
 
-export type IServerGroupInstanceTypeProps = IWizardPageProps<IAmazonServerGroupCommand>;
+export interface IServerGroupInstanceTypeProps {
+  formik: FormikProps<IAmazonServerGroupCommand>;
+}
 
-class ServerGroupInstanceTypeImpl extends React.Component<IServerGroupInstanceTypeProps> {
-  public static LABEL = 'Instance Type';
-
+export class ServerGroupInstanceType extends React.Component<IServerGroupInstanceTypeProps>
+  implements IWizardPageComponent<IAmazonServerGroupCommand> {
   public validate(values: IAmazonServerGroupCommand) {
     const errors: FormikErrors<IAmazonServerGroupCommand> = {};
 
@@ -60,5 +61,3 @@ class ServerGroupInstanceTypeImpl extends React.Component<IServerGroupInstanceTy
     return <h5 className="text-center">Please select an image.</h5>;
   }
 }
-
-export const ServerGroupInstanceType = wizardPage(ServerGroupInstanceTypeImpl);

--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/ServerGroupLoadBalancers.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/ServerGroupLoadBalancers.tsx
@@ -1,13 +1,15 @@
 import * as React from 'react';
 import { Option } from 'react-select';
+import { FormikProps } from 'formik';
 
-import { IWizardPageProps, wizardPage, HelpField, TetheredSelect, ReactInjector } from '@spinnaker/core';
+import { HelpField, IWizardPageComponent, TetheredSelect, ReactInjector } from '@spinnaker/core';
 
 import { IAmazonServerGroupCommand } from '../../serverGroupConfiguration.service';
 
-export interface IServerGroupLoadBalancersProps extends IWizardPageProps<IAmazonServerGroupCommand> {
+export interface IServerGroupLoadBalancersProps {
   hideLoadBalancers?: boolean;
   hideTargetGroups?: boolean;
+  formik: FormikProps<IAmazonServerGroupCommand>;
 }
 
 export interface IServerGroupLoadBalancersState {
@@ -20,22 +22,17 @@ const stringToOption = (value: string): Option<string> => {
   return { value, label: value };
 };
 
-class ServerGroupLoadBalancersImpl extends React.Component<
-  IServerGroupLoadBalancersProps,
-  IServerGroupLoadBalancersState
-> {
-  public static LABEL = 'Load Balancers';
-
+export class ServerGroupLoadBalancers
+  extends React.Component<IServerGroupLoadBalancersProps, IServerGroupLoadBalancersState>
+  implements IWizardPageComponent<IAmazonServerGroupCommand> {
   public state = {
     refreshing: false,
     refreshed: false,
     showVpcLoadBalancers: false,
   };
 
-  public validate(_values: IAmazonServerGroupCommand) {
+  public validate(values: IAmazonServerGroupCommand) {
     const errors = {} as any;
-    // TODO: check if this is correct, or if we should use the 'values' argument
-    const { values } = this.props.formik;
 
     if (values.viewState.dirty.targetGroups) {
       errors.targetGroups = 'You must confirm the removed target groups.';
@@ -64,7 +61,7 @@ class ServerGroupLoadBalancersImpl extends React.Component<
 
   public clearWarnings(key: 'loadBalancers' | 'targetGroups'): void {
     this.props.formik.values.viewState.dirty[key] = null;
-    this.props.revalidate();
+    this.props.formik.validateForm();
   }
 
   private targetGroupsChanged = (options: Array<Option<string>>) => {
@@ -259,5 +256,3 @@ class ServerGroupLoadBalancersImpl extends React.Component<
     );
   }
 }
-
-export const ServerGroupLoadBalancers = wizardPage(ServerGroupLoadBalancersImpl);

--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/ServerGroupSecurityGroups.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/ServerGroupSecurityGroups.tsx
@@ -1,18 +1,17 @@
 import * as React from 'react';
-
-import { IWizardPageProps, wizardPage, FirewallLabels } from '@spinnaker/core';
+import { FormikProps } from 'formik';
+import { IWizardPageComponent } from '@spinnaker/core';
 
 import { SecurityGroupSelector } from '../securityGroups/SecurityGroupSelector';
 import { IAmazonServerGroupCommand } from '../../serverGroupConfiguration.service';
 import { ServerGroupSecurityGroupsRemoved } from '../securityGroups/ServerGroupSecurityGroupsRemoved';
 
-export type IServerGroupSecurityGroupsProps = IWizardPageProps<IAmazonServerGroupCommand>;
+export interface IServerGroupSecurityGroupsProps {
+  formik: FormikProps<IAmazonServerGroupCommand>;
+}
 
-class ServerGroupSecurityGroupsImpl extends React.Component<IServerGroupSecurityGroupsProps> {
-  public static get LABEL() {
-    return FirewallLabels.get('Firewalls');
-  }
-
+export class ServerGroupSecurityGroups extends React.Component<IServerGroupSecurityGroupsProps>
+  implements IWizardPageComponent<IAmazonServerGroupCommand> {
   public validate(values: IAmazonServerGroupCommand) {
     const errors = {} as any;
 
@@ -49,5 +48,3 @@ class ServerGroupSecurityGroupsImpl extends React.Component<IServerGroupSecurity
     );
   }
 }
-
-export const ServerGroupSecurityGroups = wizardPage(ServerGroupSecurityGroupsImpl);

--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/ServerGroupZones.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/ServerGroupZones.tsx
@@ -1,15 +1,16 @@
 import * as React from 'react';
-
-import { IWizardPageProps, wizardPage } from '@spinnaker/core';
+import { FormikProps } from 'formik';
+import { IWizardPageComponent } from '@spinnaker/core';
 
 import { IAmazonServerGroupCommand } from '../../serverGroupConfiguration.service';
 import { AvailabilityZoneSelector } from '../../../AvailabilityZoneSelector';
 
-export type IServerGroupZonesProps = IWizardPageProps<IAmazonServerGroupCommand>;
+export interface IServerGroupZonesProps {
+  formik: FormikProps<IAmazonServerGroupCommand>;
+}
 
-class ServerGroupZonesImpl extends React.Component<IServerGroupZonesProps> {
-  public static LABEL = 'Availability Zones';
-
+export class ServerGroupZones extends React.Component<IServerGroupZonesProps>
+  implements IWizardPageComponent<IAmazonServerGroupCommand> {
   public validate(values: IAmazonServerGroupCommand) {
     const errors = {} as any;
 
@@ -62,5 +63,3 @@ class ServerGroupZonesImpl extends React.Component<IServerGroupZonesProps> {
     );
   }
 }
-
-export const ServerGroupZones = wizardPage(ServerGroupZonesImpl);

--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/advancedSettings/ServerGroupAdvancedSettings.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/advancedSettings/ServerGroupAdvancedSettings.tsx
@@ -1,29 +1,29 @@
 import * as React from 'react';
-import { FormikErrors } from 'formik';
+import { FormikProps } from 'formik';
 
-import { IWizardPageProps, wizardPage, Application } from '@spinnaker/core';
+import { Application, IWizardPageComponent } from '@spinnaker/core';
 
 import { IAmazonServerGroupCommand } from 'amazon/serverGroup/configure/serverGroupConfiguration.service';
 import { ServerGroupAdvancedSettingsInner } from './ServerGroupAdvancedSettingsInner';
 
-export interface IServerGroupAdvancedSettingsProps extends IWizardPageProps<IAmazonServerGroupCommand> {
+export interface IServerGroupAdvancedSettingsProps {
   app: Application;
+  formik: FormikProps<IAmazonServerGroupCommand>;
 }
 
-class ServerGroupAdvancedSettingsImpl extends React.Component<IServerGroupAdvancedSettingsProps> {
-  public static LABEL = 'Advanced Settings';
+export class ServerGroupAdvancedSettings extends React.Component<IServerGroupAdvancedSettingsProps>
+  implements IWizardPageComponent<IAmazonServerGroupCommand> {
   private ref: any = React.createRef();
 
-  public validate = (values: IAmazonServerGroupCommand) => {
+  public validate(values: IAmazonServerGroupCommand) {
     if (this.ref && this.ref.current) {
       return this.ref.current.validate(values);
     }
-    return {} as FormikErrors<IAmazonServerGroupCommand>;
-  };
+    return {};
+  }
 
   public render() {
-    return <ServerGroupAdvancedSettingsInner {...this.props} ref={this.ref} />;
+    const { app, formik } = this.props;
+    return <ServerGroupAdvancedSettingsInner formik={formik} app={app} ref={this.ref} />;
   }
 }
-
-export const ServerGroupAdvancedSettings = wizardPage(ServerGroupAdvancedSettingsImpl);

--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/advancedSettings/ServerGroupAdvancedSettingsInner.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/advancedSettings/ServerGroupAdvancedSettingsInner.tsx
@@ -1,14 +1,15 @@
 import * as React from 'react';
 import { FormikErrors } from 'formik';
 
-import { Overridable } from '@spinnaker/core';
+import { IWizardPageComponent, Overridable } from '@spinnaker/core';
 
 import { IAmazonServerGroupCommand } from 'amazon/serverGroup/configure/serverGroupConfiguration.service';
 import { ServerGroupAdvancedSettingsCommon } from './ServerGroupAdvancedSettingsCommon';
 import { IServerGroupAdvancedSettingsProps } from './ServerGroupAdvancedSettings';
 
 @Overridable('aws.serverGroup.advancedSettings')
-export class ServerGroupAdvancedSettingsInner extends React.Component<IServerGroupAdvancedSettingsProps> {
+export class ServerGroupAdvancedSettingsInner extends React.Component<IServerGroupAdvancedSettingsProps>
+  implements IWizardPageComponent<IAmazonServerGroupCommand> {
   private validators = new Map();
 
   public validate = (values: IAmazonServerGroupCommand) => {
@@ -31,6 +32,7 @@ export class ServerGroupAdvancedSettingsInner extends React.Component<IServerGro
   };
 
   public render() {
-    return <ServerGroupAdvancedSettingsCommon {...this.props} ref={this.handleRef as any} />;
+    const { formik, app } = this.props;
+    return <ServerGroupAdvancedSettingsCommon formik={formik} app={app} ref={this.handleRef as any} />;
   }
 }

--- a/app/scripts/modules/cloudfoundry/src/common/wizard/sections/cfDisclaimer.cf.tsx
+++ b/app/scripts/modules/cloudfoundry/src/common/wizard/sections/cfDisclaimer.cf.tsx
@@ -1,18 +1,6 @@
 import * as React from 'react';
 
-import { FormikErrors } from 'formik';
-
-import { wizardPage, IWizardPageProps, IJob } from '@spinnaker/core';
-
-export type IDisclaimerProps = IWizardPageProps<IJob>;
-
-class CfDisclaimerWizardPage extends React.Component<IDisclaimerProps> {
-  public static LABEL = 'Disclaimer';
-
-  public validate(_values: IDisclaimerProps) {
-    return {} as FormikErrors<IDisclaimerProps>;
-  }
-
+export class CfDisclaimerPage extends React.Component {
   public render() {
     return (
       <div className="row">
@@ -33,5 +21,3 @@ class CfDisclaimerWizardPage extends React.Component<IDisclaimerProps> {
     );
   }
 }
-
-export const CfDisclaimerPage = wizardPage(CfDisclaimerWizardPage);

--- a/app/scripts/modules/cloudfoundry/src/loadBalancer/configure/cloudFoundryLoadBalancerCreateModal.tsx
+++ b/app/scripts/modules/cloudfoundry/src/loadBalancer/configure/cloudFoundryLoadBalancerCreateModal.tsx
@@ -3,13 +3,13 @@ import { IDeferred } from 'angular';
 import * as React from 'react';
 
 import { IModalServiceInstance } from 'angular-ui-bootstrap';
-import { FormikErrors } from 'formik';
 import { cloneDeep } from 'lodash';
 import { $q } from 'ngimport';
 
 import {
   ILoadBalancerModalProps,
   WizardModal,
+  WizardPage,
   TaskMonitor,
   LoadBalancerWriter,
   ReactModal,
@@ -118,14 +118,9 @@ export class CloudFoundryLoadBalancerCreateModal extends React.Component<
     this.setState({ taskMonitor });
   };
 
-  private validate = (): FormikErrors<ICloudFoundryLoadBalancerUpsertCommand> => {
-    return {} as FormikErrors<ICloudFoundryLoadBalancerUpsertCommand>;
-  };
-
   public render() {
     const { app, forPipelineConfig } = this.props;
     const { isNew, loadBalancerCommand, taskMonitor } = this.state;
-    const hideSections = new Set<string>();
 
     return (
       <WizardModal<ICloudFoundryLoadBalancerUpsertCommand>
@@ -135,11 +130,17 @@ export class CloudFoundryLoadBalancerCreateModal extends React.Component<
         dismissModal={this.dismiss}
         closeModal={this.submit}
         submitButtonLabel={forPipelineConfig ? (isNew ? 'Add' : 'Done') : isNew ? 'Create' : 'Update'}
-        validate={this.validate}
-        hideSections={hideSections}
-      >
-        <LoadBalancerDetails app={app} isNew={isNew} />
-      </WizardModal>
+        render={({ formik, nextIdx, wizard }) => (
+          <>
+            <WizardPage
+              label="Details"
+              wizard={wizard}
+              order={nextIdx()}
+              render={({ innerRef }) => <LoadBalancerDetails ref={innerRef} formik={formik} app={app} isNew={isNew} />}
+            />
+          </>
+        )}
+      />
     );
   }
 }

--- a/app/scripts/modules/cloudfoundry/src/loadBalancer/configure/cloudFoundryNoLoadBalancerModal.tsx
+++ b/app/scripts/modules/cloudfoundry/src/loadBalancer/configure/cloudFoundryNoLoadBalancerModal.tsx
@@ -2,7 +2,7 @@ import { IDeferred } from 'angular';
 
 import * as React from 'react';
 
-import { ILoadBalancerModalProps, WizardModal, ReactModal, noop } from '@spinnaker/core';
+import { ILoadBalancerModalProps, WizardModal, WizardPage, ReactModal, noop } from '@spinnaker/core';
 import { ICloudFoundryLoadBalancerUpsertCommand } from 'cloudfoundry/domain/ICloudFoundryLoadBalancer';
 import { NoLoadBalancerDetails } from 'cloudfoundry/loadBalancer/configure/noLoadBalancer';
 import { CfDisclaimerPage } from 'cloudfoundry/common/wizard/sections/cfDisclaimer.cf';
@@ -69,11 +69,24 @@ export class CloudFoundryNoLoadBalancerModal extends React.Component<
         dismissModal={this.props.dismissModal}
         closeModal={this.submit}
         submitButtonLabel={'Ok'}
-        validate={noop}
-      >
-        <NoLoadBalancerDetails />
-        <CfDisclaimerPage />
-      </WizardModal>
+        render={({ nextIdx, wizard }) => (
+          <>
+            <WizardPage
+              label="Message"
+              wizard={wizard}
+              order={nextIdx()}
+              render={({ innerRef }) => <NoLoadBalancerDetails ref={innerRef} />}
+            />
+
+            <WizardPage
+              label="Disclaimer"
+              wizard={wizard}
+              order={nextIdx()}
+              render={({ innerRef }) => <CfDisclaimerPage ref={innerRef} />}
+            />
+          </>
+        )}
+      />
     );
   }
 }

--- a/app/scripts/modules/cloudfoundry/src/loadBalancer/configure/loadBalancerDetails.tsx
+++ b/app/scripts/modules/cloudfoundry/src/loadBalancer/configure/loadBalancerDetails.tsx
@@ -2,15 +2,16 @@ import * as React from 'react';
 
 import Select, { Option } from 'react-select';
 
-import { FormikErrors } from 'formik';
+import { FormikErrors, FormikProps } from 'formik';
 
-import { AccountService, Application, IAccount, IWizardPageProps, wizardPage, IRegion } from '@spinnaker/core';
+import { AccountService, Application, IAccount, IRegion, IWizardPageComponent } from '@spinnaker/core';
 
 import { ICloudFoundryAccount, ICloudFoundryDomain, ICloudFoundryLoadBalancerUpsertCommand } from 'cloudfoundry/domain';
 import { RouteDomainSelectField } from 'cloudfoundry/routeDomains';
 
-export interface ILoadBalancerDetailsProps extends IWizardPageProps<ICloudFoundryLoadBalancerUpsertCommand> {
+export interface ILoadBalancerDetailsProps {
   app: Application;
+  formik: FormikProps<ICloudFoundryLoadBalancerUpsertCommand>;
   isNew?: boolean;
 }
 
@@ -22,9 +23,8 @@ export interface ILoadBalancerDetailsState {
   regions: IRegion[];
 }
 
-class LoadBalancerDetailsImpl extends React.Component<ILoadBalancerDetailsProps, ILoadBalancerDetailsState> {
-  public static LABEL = 'Details';
-
+export class LoadBalancerDetails extends React.Component<ILoadBalancerDetailsProps, ILoadBalancerDetailsState>
+  implements IWizardPageComponent<ICloudFoundryLoadBalancerUpsertCommand> {
   public state: ILoadBalancerDetailsState = {
     accounts: undefined,
     availabilityZones: [],
@@ -215,5 +215,3 @@ class LoadBalancerDetailsImpl extends React.Component<ILoadBalancerDetailsProps,
     );
   }
 }
-
-export const LoadBalancerDetails = wizardPage(LoadBalancerDetailsImpl);

--- a/app/scripts/modules/cloudfoundry/src/loadBalancer/configure/noLoadBalancer.tsx
+++ b/app/scripts/modules/cloudfoundry/src/loadBalancer/configure/noLoadBalancer.tsx
@@ -1,20 +1,6 @@
 import * as React from 'react';
 
-import { FormikErrors } from 'formik';
-
-import { wizardPage, IWizardPageProps } from '@spinnaker/core';
-
-import { ICloudFoundryLoadBalancerUpsertCommand } from 'cloudfoundry/domain';
-
-export type INoLoadBalancerDetailsProps = IWizardPageProps<ICloudFoundryLoadBalancerUpsertCommand>;
-
-class NoLoadBalancerDetailsImpl extends React.Component<INoLoadBalancerDetailsProps> {
-  public static LABEL = 'Message';
-
-  public validate(_values: INoLoadBalancerDetailsProps) {
-    return {} as FormikErrors<INoLoadBalancerDetailsProps>;
-  }
-
+export class NoLoadBalancerDetails extends React.Component {
   public render() {
     return (
       <div className="row">
@@ -40,5 +26,3 @@ class NoLoadBalancerDetailsImpl extends React.Component<INoLoadBalancerDetailsPr
     );
   }
 }
-
-export const NoLoadBalancerDetails = wizardPage(NoLoadBalancerDetailsImpl);

--- a/app/scripts/modules/cloudfoundry/src/presentation/forms/serverGroup/Services.tsx
+++ b/app/scripts/modules/cloudfoundry/src/presentation/forms/serverGroup/Services.tsx
@@ -5,9 +5,7 @@ import { FormikFormField, TextInput } from '@spinnaker/core';
 
 import { ICloudFoundryCreateServerGroupCommand } from 'cloudfoundry/serverGroup/configure/serverGroupConfigurationModel.cf';
 
-export interface IServicesProps {}
-
-export class Services extends React.Component<IServicesProps> {
+export class Services extends React.Component {
   public render() {
     return (
       <div>

--- a/app/scripts/modules/cloudfoundry/src/serverGroup/configure/serverGroupCommandBuilder.service.cf.ts
+++ b/app/scripts/modules/cloudfoundry/src/serverGroup/configure/serverGroupCommandBuilder.service.cf.ts
@@ -93,8 +93,8 @@ export class CloudFoundryServerGroupCommandBuilder {
         routes: serverGroup.loadBalancers,
         environment: CloudFoundryServerGroupCommandBuilder.envVarsFromObject(serverGroup.env),
         services: (serverGroup.serviceInstances || []).map(serviceInstance => serviceInstance.name),
-        healthCheckType: '',
         healthCheckHttpEndpoint: '',
+        healthCheckType: '',
       };
       command.region = serverGroup.region;
       command.stack = serverGroup.stack;

--- a/app/scripts/modules/cloudfoundry/src/serverGroup/configure/wizard/sections/artifactSettings/ArtifactPackage.tsx
+++ b/app/scripts/modules/cloudfoundry/src/serverGroup/configure/wizard/sections/artifactSettings/ArtifactPackage.tsx
@@ -1,14 +1,6 @@
 import * as React from 'react';
 
-import {
-  AccountService,
-  FormikFormField,
-  IAccount,
-  IAccountDetails,
-  IRegion,
-  IWizardPageProps,
-  ReactSelectInput,
-} from '@spinnaker/core';
+import { AccountService, FormikFormField, IAccount, IAccountDetails, IRegion, ReactSelectInput } from '@spinnaker/core';
 
 import {
   ICloudFoundryCreateServerGroupCommand,
@@ -18,8 +10,8 @@ import { ICloudFoundryCluster, ICloudFoundryServerGroup } from 'cloudfoundry/dom
 import { CloudFoundryImageReader } from 'cloudfoundry/image/image.reader.cf';
 import { FormikProps } from 'formik';
 
-export interface IArtifactPackageProps extends IWizardPageProps<ICloudFoundryCreateServerGroupCommand> {
-  formik: FormikProps<any>;
+export interface IArtifactPackageProps {
+  formik: FormikProps<ICloudFoundryCreateServerGroupCommand>;
 }
 
 export interface IArtifactPackageState {

--- a/app/scripts/modules/cloudfoundry/src/serverGroup/configure/wizard/sections/artifactSettings/ArtifactSelection.tsx
+++ b/app/scripts/modules/cloudfoundry/src/serverGroup/configure/wizard/sections/artifactSettings/ArtifactSelection.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react';
 
-import { FormikFormField, IWizardPageProps, ReactSelectInput, TextInput } from '@spinnaker/core';
+import { FormikFormField, ReactSelectInput, TextInput } from '@spinnaker/core';
 
-import { ICloudFoundryCreateServerGroupCommand } from 'cloudfoundry/serverGroup/configure/serverGroupConfigurationModel.cf';
 import { IArtifactAccount } from 'core/index';
 
-export interface IArtifactSelectionProps extends IWizardPageProps<ICloudFoundryCreateServerGroupCommand> {
+export interface IArtifactSelectionProps {
   artifactAccounts: IArtifactAccount[];
 }
 

--- a/app/scripts/modules/cloudfoundry/src/serverGroup/configure/wizard/sections/artifactSettings/ArtifactSettings.cf.tsx
+++ b/app/scripts/modules/cloudfoundry/src/serverGroup/configure/wizard/sections/artifactSettings/ArtifactSettings.cf.tsx
@@ -2,25 +2,24 @@ import * as React from 'react';
 
 import { Option } from 'react-select';
 
-import { FormikFormField, IArtifactAccount, IWizardPageProps, wizardPage } from '@spinnaker/core';
+import { FormikFormField, IArtifactAccount } from '@spinnaker/core';
 
 import { ICloudFoundryCreateServerGroupCommand } from 'cloudfoundry/serverGroup/configure//serverGroupConfigurationModel.cf';
 import { ArtifactSelection } from 'cloudfoundry/serverGroup/configure/wizard/sections/artifactSettings/ArtifactSelection';
 import { ArtifactTrigger } from 'cloudfoundry/serverGroup/configure/wizard/sections/artifactSettings/ArtifactTrigger';
 import { CloudFoundryRadioButtonInput } from 'cloudfoundry/presentation/forms/inputs/CloudFoundryRadioButtonInput';
 import { ArtifactPackage } from 'cloudfoundry/serverGroup/configure/wizard/sections/artifactSettings/ArtifactPackage';
+import { FormikProps } from 'formik';
 
-export interface ICloudFoundryCreateServerGroupArtifactSettingsProps
-  extends IWizardPageProps<ICloudFoundryCreateServerGroupCommand> {
+export interface ICloudFoundryCreateServerGroupArtifactSettingsProps {
   artifactAccounts: IArtifactAccount[];
   artifact?: any;
+  formik: FormikProps<ICloudFoundryCreateServerGroupCommand>;
 }
 
-class ArtifactSettingsImpl extends React.Component<ICloudFoundryCreateServerGroupArtifactSettingsProps> {
-  public static get LABEL() {
-    return 'Artifact';
-  }
-
+export class CloudFoundryServerGroupArtifactSettings extends React.Component<
+  ICloudFoundryCreateServerGroupArtifactSettingsProps
+> {
   private artifactTypeUpdated = (type: string): void => {
     switch (type) {
       case 'package':
@@ -86,10 +85,4 @@ class ArtifactSettingsImpl extends React.Component<ICloudFoundryCreateServerGrou
       </div>
     );
   }
-
-  public validate(_values: ICloudFoundryCreateServerGroupArtifactSettingsProps) {
-    return {};
-  }
 }
-
-export const CloudFoundryServerGroupArtifactSettings = wizardPage(ArtifactSettingsImpl);

--- a/app/scripts/modules/cloudfoundry/src/serverGroup/configure/wizard/sections/artifactSettings/ArtifactTrigger.tsx
+++ b/app/scripts/modules/cloudfoundry/src/serverGroup/configure/wizard/sections/artifactSettings/ArtifactTrigger.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react';
 
-import { FormikFormField, HelpField, IWizardPageProps, ReactSelectInput, TextInput } from '@spinnaker/core';
+import { FormikFormField, HelpField, ReactSelectInput, TextInput } from '@spinnaker/core';
 
-import { ICloudFoundryCreateServerGroupCommand } from 'cloudfoundry/serverGroup/configure/serverGroupConfigurationModel.cf';
 import { IArtifactAccount } from 'core/index';
 
-export interface IArtifactTriggerProps extends IWizardPageProps<ICloudFoundryCreateServerGroupCommand> {
+export interface IArtifactTriggerProps {
   artifactAccounts: IArtifactAccount[];
 }
 

--- a/app/scripts/modules/cloudfoundry/src/serverGroup/configure/wizard/sections/artifactSettings/ConstantArtifactSettings.cf.tsx
+++ b/app/scripts/modules/cloudfoundry/src/serverGroup/configure/wizard/sections/artifactSettings/ConstantArtifactSettings.cf.tsx
@@ -1,22 +1,17 @@
 import * as React from 'react';
 
-import { IWizardPageProps, wizardPage } from '@spinnaker/core';
-
 import { ICloudFoundryCreateServerGroupCommand } from 'cloudfoundry/serverGroup/configure/serverGroupConfigurationModel.cf';
 import { ICloudFoundryServerGroup } from 'cloudfoundry/domain';
+import { FormikProps } from 'formik';
 
-export interface ICloudFoundryCloneServerGroupProps extends IWizardPageProps<ICloudFoundryCreateServerGroupCommand> {
+export interface ICloudFoundryCloneServerGroupProps {
+  formik: FormikProps<ICloudFoundryCreateServerGroupCommand>;
   serverGroup: ICloudFoundryServerGroup;
 }
 
-class ArtifactSettingsImpl extends React.Component<ICloudFoundryCloneServerGroupProps> {
-  public static get LABEL() {
-    return 'Artifact';
-  }
-
-  public static validate(_values: any): any {
-    return {};
-  }
+export class CloudFoundryServerGroupConstantArtifactSettings extends React.Component<
+  ICloudFoundryCloneServerGroupProps
+> {
   constructor(props: ICloudFoundryCloneServerGroupProps) {
     super(props);
     const { serverGroup } = props;
@@ -62,10 +57,4 @@ class ArtifactSettingsImpl extends React.Component<ICloudFoundryCloneServerGroup
       </div>
     );
   }
-
-  public validate(_values: any): any {
-    return {};
-  }
 }
-
-export const CloudFoundryServerGroupConstantArtifactSettings = wizardPage(ArtifactSettingsImpl);

--- a/app/scripts/modules/cloudfoundry/src/serverGroup/configure/wizard/sections/basicSettings/BasicSettings.cf.tsx
+++ b/app/scripts/modules/cloudfoundry/src/serverGroup/configure/wizard/sections/basicSettings/BasicSettings.cf.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { FormikErrors } from 'formik';
+import { FormikErrors, FormikProps } from 'formik';
 
 import {
   AccountService,
@@ -8,8 +8,7 @@ import {
   FormikFormField,
   IAccount,
   IRegion,
-  IWizardPageProps,
-  wizardPage,
+  IWizardPageComponent,
   HelpField,
   ReactSelectInput,
   TextInput,
@@ -20,7 +19,9 @@ import { CloudFoundryDeploymentStrategySelector } from 'cloudfoundry/deploymentS
 
 import 'cloudfoundry/common/cloudFoundry.less';
 
-export type ICloudFoundryServerGroupBasicSettingsProps = IWizardPageProps<ICloudFoundryCreateServerGroupCommand>;
+export interface ICloudFoundryServerGroupBasicSettingsProps {
+  formik: FormikProps<ICloudFoundryCreateServerGroupCommand>;
+}
 
 export interface ICloudFoundryServerGroupLocationSettingsState {
   account: string;
@@ -28,14 +29,9 @@ export interface ICloudFoundryServerGroupLocationSettingsState {
   regions: IRegion[];
 }
 
-class BasicSettingsImpl extends React.Component<
-  ICloudFoundryServerGroupBasicSettingsProps,
-  ICloudFoundryServerGroupLocationSettingsState
-> {
-  public static get LABEL() {
-    return 'Basic Settings';
-  }
-
+export class CloudFoundryServerGroupBasicSettings
+  extends React.Component<ICloudFoundryServerGroupBasicSettingsProps, ICloudFoundryServerGroupLocationSettingsState>
+  implements IWizardPageComponent<ICloudFoundryCreateServerGroupCommand> {
   public state: ICloudFoundryServerGroupLocationSettingsState = {
     account: '',
     accounts: [],
@@ -160,5 +156,3 @@ class BasicSettingsImpl extends React.Component<
     return errors;
   }
 }
-
-export const CloudFoundryServerGroupBasicSettings = wizardPage(BasicSettingsImpl);

--- a/app/scripts/modules/cloudfoundry/src/serverGroup/configure/wizard/sections/configurationSettings/ConfigurationSettings.cf.tsx
+++ b/app/scripts/modules/cloudfoundry/src/serverGroup/configure/wizard/sections/configurationSettings/ConfigurationSettings.cf.tsx
@@ -6,10 +6,9 @@ import {
   FormikFormField,
   HelpField,
   IArtifactAccount,
-  IWizardPageProps,
+  IWizardPageComponent,
   ReactSelectInput,
   TextInput,
-  wizardPage,
 } from '@spinnaker/core';
 
 import {
@@ -27,16 +26,17 @@ import {
   Routes,
   Services,
 } from 'cloudfoundry/presentation';
+import { FormikProps } from 'formik';
 
-export interface ICloudFoundryServerGroupConfigurationSettingsProps
-  extends IWizardPageProps<ICloudFoundryCreateServerGroupCommand> {
+export interface ICloudFoundryServerGroupConfigurationSettingsProps {
   artifactAccounts: IArtifactAccount[];
+  formik: FormikProps<ICloudFoundryCreateServerGroupCommand>;
   manifest?: any;
 }
 
-class ConfigurationSettingsImpl extends React.Component<ICloudFoundryServerGroupConfigurationSettingsProps> {
-  public static LABEL = 'Configuration';
-
+export class CloudFoundryServerGroupConfigurationSettings
+  extends React.Component<ICloudFoundryServerGroupConfigurationSettingsProps>
+  implements IWizardPageComponent<ICloudFoundryCreateServerGroupCommand> {
   private manifestTypeUpdated = (type: string): void => {
     switch (type) {
       case 'artifact':
@@ -213,7 +213,7 @@ class ConfigurationSettingsImpl extends React.Component<ICloudFoundryServerGroup
     );
   }
 
-  public validate(values: ICloudFoundryServerGroupConfigurationSettingsProps) {
+  public validate(values: ICloudFoundryCreateServerGroupCommand) {
     const errors = {} as any;
     const isStorageSize = (value: string) => /\d+[MG]/.test(value);
     if (values.manifest.type === 'direct') {
@@ -270,5 +270,3 @@ class ConfigurationSettingsImpl extends React.Component<ICloudFoundryServerGroup
     return errors;
   }
 }
-
-export const CloudFoundryServerGroupConfigurationSettings = wizardPage(ConfigurationSettingsImpl);

--- a/app/scripts/modules/core/src/modal/wizard/WizardStepLabel.tsx
+++ b/app/scripts/modules/core/src/modal/wizard/WizardStepLabel.tsx
@@ -1,71 +1,64 @@
 import * as React from 'react';
 import { isArray, isString, isObject } from 'lodash';
-import * as classNames from 'classnames';
 
 import { Tooltip } from 'core/presentation';
 
-import { IWizardPageData } from './WizardModal';
+import { WizardPage } from './WizardPage';
 
-interface IWizardStepLabelProps<T> {
+interface IWizardStepLabelProps {
   current: boolean;
-  dirty: boolean;
-  errors: { [key: string]: string };
-  pageState: IWizardPageData<T>;
-  onClick: (pageState: IWizardPageData<T>) => void;
-  waiting: boolean;
+  onClick: (page: WizardPage<any>) => void;
+  page: WizardPage<any>;
 }
 
-export class WizardStepLabel<T> extends React.Component<IWizardStepLabelProps<T>> {
-  private flattenErrors(errors: any) {
-    const traverse = (obj: any, path: string, flattenedErrors: { [key: string]: any }): any => {
-      if (isArray(obj)) {
-        obj.forEach((elem, idx) => traverse(elem, `${path}[${idx}]`, flattenedErrors));
-      } else if (isString(obj)) {
-        flattenedErrors[path] = obj;
-      } else if (isObject(obj)) {
-        Object.keys(obj).forEach(key => traverse(obj[key], `${path}.${key}`, flattenedErrors));
-      }
+const flattenErrors = (errors: any) => {
+  const traverse = (obj: any, path: string, flattenedErrors: { [key: string]: any }): any => {
+    if (isArray(obj)) {
+      obj.forEach((elem, idx) => traverse(elem, `${path}[${idx}]`, flattenedErrors));
+    } else if (isString(obj)) {
+      flattenedErrors[path] = obj;
+    } else if (isObject(obj)) {
+      Object.keys(obj).forEach(key => traverse(obj[key], `${path}.${key}`, flattenedErrors));
+    }
 
-      return flattenedErrors;
-    };
+    return flattenedErrors;
+  };
 
-    return traverse(errors, 'errors', {});
-  }
+  return traverse(errors, 'errors', {});
+};
 
+export class WizardStepLabel extends React.Component<IWizardStepLabelProps> {
   public render() {
-    const { current, dirty, errors, onClick, pageState, waiting } = this.props;
+    const { current, page, onClick } = this.props;
+    const { errors, status } = page.state;
+    const { label } = page.props;
 
-    const className = classNames({
-      default: !pageState.props.done,
-      dirty: dirty || !!errors,
-      current,
-      done: pageState.props.done,
-      waiting,
-    });
+    const flattenedErrors: { [field: string]: string } = flattenErrors(errors);
+    const hasErrors = !!Object.keys(flattenedErrors).length;
+    const className = `${WizardPage.getStatusClass(status)} ${current ? 'current' : ''}`;
 
-    const label = (
+    const pageLabel = (
       <li className={className}>
-        <a className="clickable" onClick={() => onClick(pageState)}>
-          {pageState.label}
+        <a className="clickable" onClick={() => onClick(page)}>
+          {label}
         </a>
       </li>
     );
 
-    const flattenedErrors = this.flattenErrors(errors);
-    const errorKeys = Object.keys(flattenedErrors);
-    if (errorKeys.length) {
-      const Errors = (
-        <span>
-          {errorKeys.map(key => (
-            <span key={key}>
-              {flattenedErrors[key]} <br />
-            </span>
-          ))}
-        </span>
-      );
-
-      return <Tooltip template={Errors}>{label}</Tooltip>;
+    if (!hasErrors) {
+      return pageLabel;
     }
-    return label;
+
+    const Errors = (
+      <span>
+        {Object.keys(flattenedErrors).map(key => (
+          <span key={key}>
+            {flattenedErrors[key]} <br />
+          </span>
+        ))}
+      </span>
+    );
+
+    return <Tooltip template={Errors}>{pageLabel}</Tooltip>;
   }
 }

--- a/app/scripts/modules/core/src/projects/configure/Applications.tsx
+++ b/app/scripts/modules/core/src/projects/configure/Applications.tsx
@@ -1,19 +1,18 @@
 import * as React from 'react';
-import { FormikErrors, getIn } from 'formik';
+import { FormikErrors, getIn, FormikProps } from 'formik';
 import { isEqual } from 'lodash';
 
 import { IProject, IProjectPipeline } from 'core/domain';
-import { IWizardPageProps, wizardPage } from 'core/modal';
+import { IWizardPageComponent } from 'core/modal';
 import { FormikApplicationsPicker } from 'core/projects/configure/FormikApplicationsPicker';
 
-export interface IApplicationsProps extends IWizardPageProps<IProject> {
+export interface IApplicationsProps {
+  formik: FormikProps<IProject>;
   allApplications: string[];
   onApplicationsChanged: (applications: string[]) => void;
 }
 
-class ApplicationsImpl extends React.Component<IApplicationsProps> {
-  public static LABEL = 'Applications';
-
+export class Applications extends React.Component<IApplicationsProps> implements IWizardPageComponent<IProject> {
   public validate(project: IProject): FormikErrors<IProject> {
     const configuredApps = (project.config && project.config.applications) || [];
     const getApplicationError = (app: string) =>
@@ -61,5 +60,3 @@ class ApplicationsImpl extends React.Component<IApplicationsProps> {
     );
   }
 }
-
-export const Applications = wizardPage(ApplicationsImpl);

--- a/app/scripts/modules/core/src/projects/configure/Clusters.tsx
+++ b/app/scripts/modules/core/src/projects/configure/Clusters.tsx
@@ -3,19 +3,17 @@ import { FieldArray, FormikErrors, FormikProps, getIn } from 'formik';
 
 import { IAccount } from 'core/account';
 import { IProject, IProjectCluster } from 'core/domain';
-import { IWizardPageProps, wizardPage } from 'core/modal';
+import { IWizardPageComponent } from 'core/modal';
 import { FormikFormField, ReactSelectInput, TextInput } from 'core/presentation';
 import { NgReact } from 'core/reactShims';
 
 import { FormikApplicationsPicker } from './FormikApplicationsPicker';
 
-export interface IClustersProps extends IWizardPageProps<IProject> {
+export interface IClustersProps {
   accounts: IAccount[];
 }
 
-class ClustersImpl extends React.Component<IClustersProps> {
-  public static LABEL = 'Clusters';
-
+export class Clusters extends React.Component<IClustersProps> implements IWizardPageComponent<IProject> {
   public validate = (value: IProject): FormikErrors<IProject> => {
     const applications = value.config.applications || [];
     if (value.config.clusters && value.config.clusters.length) {
@@ -155,5 +153,3 @@ class ClustersImpl extends React.Component<IClustersProps> {
     );
   }
 }
-
-export const Clusters = wizardPage(ClustersImpl);

--- a/app/scripts/modules/core/src/projects/configure/Pipelines.tsx
+++ b/app/scripts/modules/core/src/projects/configure/Pipelines.tsx
@@ -4,18 +4,16 @@ import { FieldArray, FormikErrors, getIn } from 'formik';
 import { FormikFormField, ReactSelectInput, StringsAsOptions } from 'core/presentation';
 import { Spinner } from 'core/widgets';
 import { IPipeline, IProject, IProjectPipeline } from 'core/domain';
-import { IWizardPageProps, wizardPage } from 'core/modal';
+import { IWizardPageComponent } from 'core/modal';
 
-export interface IPipelinesProps extends IWizardPageProps<{}> {
+export interface IPipelinesProps {
   appsPipelines: {
     [appName: string]: IPipeline[];
   };
 }
 
-class PipelinesImpl extends React.Component<IPipelinesProps> {
-  public static LABEL = 'Pipelines';
-
-  public validate = (value: IProject): FormikErrors<IProject> | void => {
+export class Pipelines extends React.Component<IPipelinesProps> implements IWizardPageComponent<IProject> {
+  public validate = (value: IProject): FormikErrors<IProject> => {
     const projectApplications = (value.config && value.config.applications) || [];
     const { appsPipelines } = this.props;
 
@@ -136,5 +134,3 @@ class PipelinesImpl extends React.Component<IPipelinesProps> {
     );
   }
 }
-
-export const Pipelines = wizardPage(PipelinesImpl);

--- a/app/scripts/modules/core/src/projects/configure/ProjectAttributes.tsx
+++ b/app/scripts/modules/core/src/projects/configure/ProjectAttributes.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
-import { FormikErrors } from 'formik';
+import { FormikErrors, FormikProps } from 'formik';
+
 import { IProject } from 'core/domain';
-import { IWizardPageProps, wizardPage } from 'core/modal';
+import { IWizardPageComponent } from 'core/modal';
 import { FormField, FormikFormField, TextInput } from 'core/presentation';
 
-export interface IProjectAttributesProps extends IWizardPageProps<IProject> {
-  onDelete?: Function;
+export interface IProjectAttributesProps {
   allProjects: IProject[];
+  formik: FormikProps<IProject>;
+  onDelete?: Function;
 }
 
 interface IProjectAttributesState {
@@ -14,9 +16,8 @@ interface IProjectAttributesState {
   projectNameForDeletion: string;
 }
 
-class ProjectAttributesImpl extends React.Component<IProjectAttributesProps, IProjectAttributesState> {
-  public static LABEL = 'Project Attributes';
-
+export class ProjectAttributes extends React.Component<IProjectAttributesProps, IProjectAttributesState>
+  implements IWizardPageComponent<IProject> {
   public state = {
     showProjectDeleteForm: false,
     projectNameForDeletion: null as string,
@@ -128,5 +129,3 @@ class ProjectAttributesImpl extends React.Component<IProjectAttributesProps, IPr
     );
   }
 }
-
-export const ProjectAttributes = wizardPage(ProjectAttributesImpl);

--- a/app/scripts/modules/kubernetes/src/v2/manifest/wizard/BasicSettings.tsx
+++ b/app/scripts/modules/kubernetes/src/v2/manifest/wizard/BasicSettings.tsx
@@ -1,25 +1,20 @@
 import * as React from 'react';
-import { FormikErrors } from 'formik';
+import { FormikProps } from 'formik';
 
-import { AccountSelectInput, HelpField, IWizardPageProps, wizardPage, Application } from '@spinnaker/core';
+import { AccountSelectInput, HelpField, Application } from '@spinnaker/core';
 
 import { IKubernetesManifestCommandData } from 'kubernetes/v2/manifest/manifestCommandBuilder.service';
 
-export interface IManifestBasicSettingsProps extends IWizardPageProps<IKubernetesManifestCommandData> {
+export interface IManifestBasicSettingsProps {
   app: Application;
+  formik: FormikProps<IKubernetesManifestCommandData>;
 }
 
-class ManifestBasicSettingsImpl extends React.Component<IManifestBasicSettingsProps> {
-  public static LABEL = 'Basic Settings';
-
+export class ManifestBasicSettings extends React.Component<IManifestBasicSettingsProps> {
   private accountUpdated = (account: string): void => {
     const { formik } = this.props;
     formik.values.command.account = account;
     formik.setFieldValue('account', account);
-  };
-
-  public validate = (_formik: IKubernetesManifestCommandData) => {
-    return {} as FormikErrors<IKubernetesManifestCommandData>;
   };
 
   public render() {
@@ -55,5 +50,3 @@ class ManifestBasicSettingsImpl extends React.Component<IManifestBasicSettingsPr
     );
   }
 }
-
-export const ManifestBasicSettings = wizardPage(ManifestBasicSettingsImpl);

--- a/app/scripts/modules/kubernetes/src/v2/manifest/wizard/ManifestEntry.tsx
+++ b/app/scripts/modules/kubernetes/src/v2/manifest/wizard/ManifestEntry.tsx
@@ -1,23 +1,22 @@
 import * as React from 'react';
-import { FormikErrors } from 'formik';
+import { FormikProps } from 'formik';
 import { dump } from 'js-yaml';
 
-import { IWizardPageProps, wizardPage, Application } from '@spinnaker/core';
+import { Application } from '@spinnaker/core';
 
 import { YamlEditor } from 'kubernetes/v2/manifest/editor/yaml/YamlEditor';
 import { IKubernetesManifestCommandData } from 'kubernetes/v2/manifest/manifestCommandBuilder.service';
 
-export interface IManifestBasicSettingsProps extends IWizardPageProps<IKubernetesManifestCommandData> {
+export interface IManifestBasicSettingsProps {
   app: Application;
+  formik: FormikProps<IKubernetesManifestCommandData>;
 }
 
 export interface IManifestBasicSettingsState {
   rawManifest: string;
 }
 
-class ManifestEntryImpl extends React.Component<IManifestBasicSettingsProps, IManifestBasicSettingsState> {
-  public static LABEL = 'Manifest';
-
+export class ManifestEntry extends React.Component<IManifestBasicSettingsProps, IManifestBasicSettingsState> {
   constructor(props: IManifestBasicSettingsProps) {
     super(props);
 
@@ -33,18 +32,8 @@ class ManifestEntryImpl extends React.Component<IManifestBasicSettingsProps, IMa
     }
   }
 
-  public validate = (_values: IKubernetesManifestCommandData) => {
-    return {} as FormikErrors<IKubernetesManifestCommandData>;
-  };
-
   private handleChange = (rawManifest: string, manifest: any) => {
-    const { values } = this.props.formik;
-    if (!values.command.manifests) {
-      values.command.manifests = [];
-    }
-    if (manifest) {
-      values.command.manifests = Array.isArray(manifest) ? manifest : [manifest];
-    }
+    this.props.formik.setFieldValue('command.manifests', [].concat(manifest).filter(x => !!x));
     this.setState({ rawManifest });
   };
 
@@ -52,5 +41,3 @@ class ManifestEntryImpl extends React.Component<IManifestBasicSettingsProps, IMa
     return <YamlEditor value={this.state.rawManifest} onChange={this.handleChange} />;
   }
 }
-
-export const ManifestEntry = wizardPage(ManifestEntryImpl);

--- a/app/scripts/modules/kubernetes/src/v2/manifest/wizard/ManifestWizard.tsx
+++ b/app/scripts/modules/kubernetes/src/v2/manifest/wizard/ManifestWizard.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
-import { FormikErrors, FormikValues } from 'formik';
 
 import {
   Application,
   TaskMonitor,
   WizardModal,
+  WizardPage,
   IModalComponentProps,
   noop,
   ReactModal,
@@ -68,11 +68,6 @@ export class ManifestWizard extends React.Component<IKubernetesManifestModalProp
     this.state.taskMonitor.submit(submitMethod);
   };
 
-  private validate = (_values: FormikValues): FormikErrors<IKubernetesManifestCommandData> => {
-    const errors = {} as FormikErrors<IKubernetesManifestCommandData>;
-    return errors;
-  };
-
   public render() {
     const { application, dismissModal, isNew } = this.props;
     const { loaded, taskMonitor, command } = this.state;
@@ -86,11 +81,24 @@ export class ManifestWizard extends React.Component<IKubernetesManifestModalProp
         dismissModal={dismissModal}
         closeModal={this.submit}
         submitButtonLabel={isNew ? 'Create' : 'Edit'}
-        validate={this.validate}
-      >
-        <ManifestBasicSettings done={true} app={application} />
-        <ManifestEntry done={true} app={application} />
-      </WizardModal>
+        render={({ formik, nextIdx, wizard }) => (
+          <>
+            <WizardPage
+              label="Basic Settings"
+              wizard={wizard}
+              order={nextIdx()}
+              render={({ innerRef }) => <ManifestBasicSettings ref={innerRef} formik={formik} app={application} />}
+            />
+
+            <WizardPage
+              label="Manifest"
+              wizard={wizard}
+              order={nextIdx()}
+              render={({ innerRef }) => <ManifestEntry ref={innerRef} formik={formik} app={application} />}
+            />
+          </>
+        )}
+      />
     );
   }
 }

--- a/app/scripts/modules/titus/src/serverGroup/configure/wizard/pages/ServerGroupBasicSettings.tsx
+++ b/app/scripts/modules/titus/src/serverGroup/configure/wizard/pages/ServerGroupBasicSettings.tsx
@@ -1,16 +1,15 @@
 import * as React from 'react';
-import { Field, FormikErrors } from 'formik';
+import { Field, FormikErrors, FormikProps } from 'formik';
 
 import {
   DeploymentStrategySelector,
   HelpField,
-  IWizardPageProps,
-  wizardPage,
   NameUtils,
   RegionSelectField,
   Application,
   ReactInjector,
   IServerGroup,
+  IWizardPageComponent,
   AccountSelectInput,
   AccountTag,
 } from '@spinnaker/core';
@@ -25,8 +24,9 @@ const isStackPattern = (stack: string) =>
 const isDetailPattern = (detail: string) =>
   isNotExpressionLanguage(detail) ? /^([a-zA-Z_0-9._$-{}\\\^~]*(\${.+})*)*$/.test(detail) : true;
 
-export interface IServerGroupBasicSettingsProps extends IWizardPageProps<ITitusServerGroupCommand> {
+export interface IServerGroupBasicSettingsProps {
   app: Application;
+  formik: FormikProps<ITitusServerGroupCommand>;
 }
 
 export interface IServerGroupBasicSettingsState {
@@ -36,12 +36,9 @@ export interface IServerGroupBasicSettingsState {
   showPreviewAsWarning: boolean;
 }
 
-class ServerGroupBasicSettingsImpl extends React.Component<
-  IServerGroupBasicSettingsProps,
-  IServerGroupBasicSettingsState
-> {
-  public static LABEL = 'Basic Settings';
-
+export class ServerGroupBasicSettings
+  extends React.Component<IServerGroupBasicSettingsProps, IServerGroupBasicSettingsState>
+  implements IWizardPageComponent<ITitusServerGroupCommand> {
   constructor(props: IServerGroupBasicSettingsProps) {
     super(props);
 
@@ -333,5 +330,3 @@ class ServerGroupBasicSettingsImpl extends React.Component<
     );
   }
 }
-
-export const ServerGroupBasicSettings = wizardPage(ServerGroupBasicSettingsImpl);

--- a/app/scripts/modules/titus/src/serverGroup/configure/wizard/pages/ServerGroupParameters.tsx
+++ b/app/scripts/modules/titus/src/serverGroup/configure/wizard/pages/ServerGroupParameters.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react';
-import { Field } from 'formik';
+import { Field, FormikProps } from 'formik';
 import Select, { Option } from 'react-select';
 
 import {
-  IWizardPageProps,
-  wizardPage,
   HelpField,
+  IWizardPageComponent,
   AccountTag,
   MapEditor,
   PlatformHealthOverride,
@@ -14,8 +13,9 @@ import {
 
 import { ITitusServerGroupCommand, Constraint } from '../../../configure/serverGroupConfiguration.service';
 
-export interface IServerGroupParametersProps extends IWizardPageProps<ITitusServerGroupCommand> {
+export interface IServerGroupParametersProps {
   app: Application;
+  formik: FormikProps<ITitusServerGroupCommand>;
 }
 
 export interface IServerGroupParametersState {
@@ -34,9 +34,8 @@ const migrationPolicyOptions = [
   { label: 'Self Managed', value: 'selfManaged' },
 ];
 
-class ServerGroupParametersImpl extends React.Component<IServerGroupParametersProps, IServerGroupParametersState> {
-  public static LABEL = 'Advanced Settings';
-
+export class ServerGroupParameters extends React.Component<IServerGroupParametersProps, IServerGroupParametersState>
+  implements IWizardPageComponent<ITitusServerGroupCommand> {
   private duplicateKeys: { [name: string]: boolean } = {};
 
   constructor(props: IServerGroupParametersProps) {
@@ -211,5 +210,3 @@ class ServerGroupParametersImpl extends React.Component<IServerGroupParametersPr
     );
   }
 }
-
-export const ServerGroupParameters = wizardPage(ServerGroupParametersImpl);

--- a/app/scripts/modules/titus/src/serverGroup/configure/wizard/pages/ServerGroupResources.tsx
+++ b/app/scripts/modules/titus/src/serverGroup/configure/wizard/pages/ServerGroupResources.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import Select, { Option } from 'react-select';
 
-import { IWizardPageProps, wizardPage, HelpField } from '@spinnaker/core';
+import { HelpField, IWizardPageComponent } from '@spinnaker/core';
 
 import { ITitusServerGroupCommand } from '../../../configure/serverGroupConfiguration.service';
+import { FormikProps } from 'formik';
 
 const mountPermOptions = [
   { label: 'Read and Write', value: 'RW' },
@@ -11,11 +12,12 @@ const mountPermOptions = [
   { label: 'Write Only', value: 'WO' },
 ];
 
-export type IServerGroupResourcesProps = IWizardPageProps<ITitusServerGroupCommand>;
+export interface IServerGroupResourcesProps {
+  formik: FormikProps<ITitusServerGroupCommand>;
+}
 
-class ServerGroupResourcesImpl extends React.Component<IServerGroupResourcesProps> {
-  public static LABEL = 'Resources';
-
+export class ServerGroupResources extends React.Component<IServerGroupResourcesProps>
+  implements IWizardPageComponent<ITitusServerGroupCommand> {
   public validate(values: ITitusServerGroupCommand) {
     const errors = {} as any;
 
@@ -203,5 +205,3 @@ class ServerGroupResourcesImpl extends React.Component<IServerGroupResourcesProp
     );
   }
 }
-
-export const ServerGroupResources = wizardPage(ServerGroupResourcesImpl);


### PR DESCRIPTION
The goal of this refactor is to 

a) minimize wizard modal magic 
b) allow more flexibility with how Wizard Page components can be rendered



This PR is split into multiple commits:

- refactor(core/modal): Rewrite wizard modal to use render props
  - Move label from wrapped component to WizardPage prop
  - Expose 'formik' as a separate prop in the render prop callback
  - Access wrapped component validate() function using 'innerRef'
  - Remove wizardPage() HOC
  - Remove hideSections prop
- refactor(core/projects): Migrate to wizardmodal render props
- refactor(amazon/modal): Refactor amazon modals to use new WizardPage component
- refactor(cloudfoundry/modal): Refactor cloudfoundry modals to use WizardPage component
- refactor(kubernetes/modal): Refactor kubernetes modals to use WizardPage component
- refactor(titus/modal): Refactor titus modals to use WizardPage component


Pros: Render props make the data flow more obvious
Cons: This is waaaaaay more verbose than the HOC