### PR TITLE
fix(core): fix instance details sorting

### DIFF
--- a/app/scripts/modules/core/src/cluster/allClusters.controller.js
+++ b/app/scripts/modules/core/src/cluster/allClusters.controller.js
@@ -97,6 +97,11 @@ module.exports = angular
       updateClusterGroups();
     };
 
+    this.syncUrlAndUpdateClusterGroups = () => {
+      ClusterState.filterModel.applyParamsToUrl();
+      this.updateClusterGroups();
+    };
+
     this.clearFilters = function() {
       ClusterState.filterService.clearFilters();
       updateClusterGroups();

--- a/app/scripts/modules/core/src/cluster/allClusters.html
+++ b/app/scripts/modules/core/src/cluster/allClusters.html
@@ -16,7 +16,7 @@
           <label>
             <input type="checkbox"
                    ng-model="sortFilter.showAllInstances"
-                   ng-change="ctrl.updateClusterGroups()"/>
+                   ng-change="ctrl.syncUrlAndUpdateClusterGroups()"/>
             Instances
           </label>
         </div>
@@ -24,7 +24,7 @@
           <label>
             <input type="checkbox"
                    ng-model="sortFilter.listInstances"
-                   ng-change="ctrl.updateClusterGroups()"/>
+                   ng-change="ctrl.syncUrlAndUpdateClusterGroups()"/>
             with details
           </label>
         </div>

--- a/app/scripts/modules/core/src/serverGroup/ServerGroup.tsx
+++ b/app/scripts/modules/core/src/serverGroup/ServerGroup.tsx
@@ -204,7 +204,6 @@ export class ServerGroup extends React.Component<IServerGroupProps, IServerGroup
                     hasLoadBalancers={hasLoadBalancers}
                     instances={instances}
                     serverGroup={serverGroup}
-                    sortFilter={sortFilter}
                   />
                 </div>
               ) : (


### PR DESCRIPTION
Instance sorting has been broken for...a while? Also, toggling the checkboxes on the clusters header do not cause the URL to change.

It would be nice to get away from the whole `sortFilter` thing, and use `$state` as the data source for these things. We'll get there eventually.