### PR TITLE
fix(core): get region for deployed link from multiple sources

### DIFF
--- a/app/scripts/modules/core/src/task/tasks.controller.js
+++ b/app/scripts/modules/core/src/task/tasks.controller.js
@@ -206,11 +206,12 @@ module.exports = angular
     };
 
     controller.getRegion = function(task) {
-      var deployedServerGroups = _.find(task.variables, function(variable) {
-        return variable.key === 'deploy.server.groups';
-      }).value;
-
-      return _.keys(deployedServerGroups)[0];
+      const regionVariable = (task.variables || []).find(variable => {
+        return (
+          ['deploy.server.groups', 'availabilityZones'].includes(variable.key) && Object.keys(variable.value).length
+        );
+      });
+      return regionVariable && Object.keys(regionVariable.value)[0];
     };
 
     controller.getProviderForServerGroupByTask = function(task) {


### PR DESCRIPTION
Sometimes a clone results in an empty variable for 'deploy.server.groups', so we create a bad link. We can look in this other random variable as a fallback to get the region.

If you want to see a lot of lodash, look at this controller.