### PR TITLE
 refactor(artifacts): Remove explicit references to kind from artifacts

### DIFF
--- a/app/scripts/modules/core/src/artifact/expectedArtifact.service.spec.ts
+++ b/app/scripts/modules/core/src/artifact/expectedArtifact.service.spec.ts
@@ -1,47 +1,101 @@
 import { noop } from 'lodash';
 import { ExpectedArtifactService } from './expectedArtifact.service';
-import { IArtifact } from 'core/domain';
+import { IArtifact, IArtifactKindConfig } from 'core/domain';
 import { Registry } from 'core/registry';
 
 describe('ExpectedArtifactService', () => {
-  describe('getKind()', () => {
+  describe('getKindConfig()', () => {
+    const baseKindConfig = {
+      label: '',
+      description: '',
+      isDefault: false,
+      isMatch: false,
+      template: '',
+      controller: noop,
+    };
+    const kindConfigs: IArtifactKindConfig[] = [
+      {
+        type: 'foo-type',
+        key: 'foo',
+        isMatch: true,
+      },
+      {
+        type: 'foo-type',
+        key: 'foo-default',
+        isDefault: true,
+      },
+      {
+        type: 'bar-type',
+        key: 'bar',
+        isMatch: true,
+      },
+      {
+        type: 'bar-type',
+        key: 'bar-default',
+        isDefault: true,
+      },
+    ].map(k => ({ ...baseKindConfig, ...k }));
+    const defaultKindConfig = {
+      ...baseKindConfig,
+      key: 'custom',
+      isMatch: true,
+      isDefault: true,
+    };
+    beforeAll(() => {
+      kindConfigs.forEach(kindConfig => Registry.pipeline.registerArtifactKind(kindConfig));
+      Registry.pipeline.registerDefaultArtifactKind(defaultKindConfig);
+    });
+
     it('returns the kind stored on an artifact', () => {
-      const expectedKind = 'foo';
       const artifact: IArtifact = {
-        kind: expectedKind,
+        kind: 'foo',
         id: 'artifact-id',
       };
-      const kind = ExpectedArtifactService.getKind(artifact);
-      expect(kind).toEqual(expectedKind);
+      const kindConfig = ExpectedArtifactService.getKindConfig(artifact, false);
+      expect(kindConfig).toEqual(kindConfigs[0]);
+    });
+
+    it('returns the kind stored on an artifact regardless of default setting', () => {
+      const artifact: IArtifact = {
+        kind: 'foo',
+        id: 'artifact-id',
+      };
+      const kindConfig = ExpectedArtifactService.getKindConfig(artifact, true);
+      expect(kindConfig).toEqual(kindConfigs[0]);
     });
 
     it('infers kind from type if no explicit kind is stored on the artifact', () => {
-      const expectedKind = 'my-custom-kind';
-      Registry.pipeline.registerArtifactKind({
-        label: 'foo',
-        type: 'my-custom-type',
-        description: 'foo',
-        key: expectedKind,
-        isDefault: false,
-        isMatch: false,
-        template: '',
-        controller: noop,
-      });
       const artifact: IArtifact = {
         id: 'artifact-id',
-        type: 'my-custom-type',
+        type: 'bar-type',
       };
-      const kind = ExpectedArtifactService.getKind(artifact);
-      expect(kind).toEqual(expectedKind);
+      const kindConfig = ExpectedArtifactService.getKindConfig(artifact, false);
+      expect(kindConfig).toEqual(kindConfigs[2]);
     });
 
-    it('returns null kind if neither kind nor type are stored on artifact', () => {
-      const expectedKind: string = null;
+    it('infers kind from type if no explicit kind is stored on the artifact when isDefault is true', () => {
+      const artifact: IArtifact = {
+        id: 'artifact-id',
+        type: 'bar-type',
+      };
+      const kindConfig = ExpectedArtifactService.getKindConfig(artifact, true);
+      expect(kindConfig).toEqual(kindConfigs[3]);
+    });
+
+    it('returns the default kind if neither kind nor type are stored on artifact', () => {
       const artifact: IArtifact = {
         id: 'artifact-id',
       };
-      const kind = ExpectedArtifactService.getKind(artifact);
-      expect(kind).toEqual(expectedKind);
+      const kindConfig = ExpectedArtifactService.getKindConfig(artifact, false);
+      expect(kindConfig).toEqual(defaultKindConfig);
+    });
+
+    it('returns the default kind if neither kind nor type are stored on artifact when isDefault is true', () => {
+      const artifact: IArtifact = {
+        id: 'artifact-id',
+      };
+      const kindConfig = ExpectedArtifactService.getKindConfig(artifact, true);
+      expect(kindConfig).toEqual(defaultKindConfig);
     });
   });
 });

--- a/app/scripts/modules/core/src/artifact/react/ExpectedArtifactEditor.tsx
+++ b/app/scripts/modules/core/src/artifact/react/ExpectedArtifactEditor.tsx
@@ -59,7 +59,9 @@ export class ExpectedArtifactEditor extends React.Component<
   constructor(props: IExpectedArtifactEditorProps) {
     super(props);
     this.state = {
-      expectedArtifact: props.default ? cloneDeep(props.default) : ExpectedArtifactService.createEmptyArtifact(null),
+      expectedArtifact: props.default
+        ? cloneDeep(props.default)
+        : ExpectedArtifactService.createEmptyArtifact('custom'),
       source: props.sources[0],
       account: null,
     };
@@ -123,7 +125,7 @@ export class ExpectedArtifactEditor extends React.Component<
     const accounts = this.accountsForExpectedArtifact(expectedArtifact);
     const artifact = ExpectedArtifactService.artifactFromExpected(expectedArtifact);
     const kinds = this.availableKinds().sort((a, b) => a.label.localeCompare(b.label));
-    const kind = artifact ? kinds.find(k => k.key === artifact.kind) : null;
+    const kind = ExpectedArtifactService.getKindConfig(artifact, false);
     const EditCmp = kind && kind.editCmp;
     return (
       <>

--- a/app/scripts/modules/core/src/pipeline/config/PipelineRegistry.ts
+++ b/app/scripts/modules/core/src/pipeline/config/PipelineRegistry.ts
@@ -24,6 +24,7 @@ export class PipelineRegistry {
   private stageTypes: IStageTypeConfig[] = [];
   private transformers: ITransformer[] = [];
   private artifactKinds: IArtifactKindConfig[] = [];
+  private defaultArtifactKind: IArtifactKindConfig;
 
   constructor() {
     this.getStageConfig = memoize(this.getStageConfig.bind(this), (stage: IStage) =>
@@ -83,6 +84,11 @@ export class PipelineRegistry {
     this.artifactKinds.push(artifactKindConfig);
   }
 
+  public registerDefaultArtifactKind(artifactKindConfig: IArtifactKindConfig): void {
+    this.defaultArtifactKind = artifactKindConfig;
+    this.registerArtifactKind(artifactKindConfig);
+  }
+
   public getExecutionTransformers(): ITransformer[] {
     return this.transformers;
   }
@@ -97,6 +103,10 @@ export class PipelineRegistry {
 
   public getArtifactKinds(): IArtifactKindConfig[] {
     return cloneDeep(this.artifactKinds);
+  }
+
+  public getDefaultArtifactKind(): IArtifactKindConfig {
+    return cloneDeep(this.defaultArtifactKind);
   }
 
   private getCloudProvidersForStage(

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/artifact.component.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/artifact.component.ts
@@ -83,21 +83,11 @@ class ArtifactCtrl implements IController {
   }
 
   public loadArtifactKind(): void {
-    const kind = ExpectedArtifactService.getKind(this.artifact) || 'custom';
-    if (!kind) {
-      return;
-    }
-    const artifactKindConfig = this.options.filter(function(config) {
-      return config.key === kind;
-    });
-
-    if (artifactKindConfig.length) {
-      const config = artifactKindConfig[0];
-      this.description = config.description;
-      this.renderArtifactConfigTemplate(config);
-      this.selectedLabel = config.label;
-      this.selectedIcon = ArtifactIconService.getPath(config.type);
-    }
+    const config = ExpectedArtifactService.getKindConfig(this.artifact, this.isDefault);
+    this.description = config.description;
+    this.renderArtifactConfigTemplate(config);
+    this.selectedLabel = config.label;
+    this.selectedIcon = ArtifactIconService.getPath(config.type);
   }
 
   public artifactIconPath(artifact: IArtifact) {

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/custom/custom.artifact.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/custom/custom.artifact.ts
@@ -13,7 +13,7 @@ class CustomArtifactController implements IController {
 export const CUSTOM_ARTIFACT = 'spinnaker.core.pipeline.trigger.custom.artifact';
 module(CUSTOM_ARTIFACT, [])
   .config(() => {
-    Registry.pipeline.registerArtifactKind({
+    Registry.pipeline.registerDefaultArtifactKind({
       label: 'Custom',
       description: 'A custom-defined artifact.',
       key: 'custom',

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/expectedArtifact.component.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/expectedArtifact.component.ts
@@ -2,7 +2,6 @@ import { IAttributes, IComponentController, IComponentOptions, module } from 'an
 
 import { ExpectedArtifactService } from 'core/artifact';
 import { IExpectedArtifact } from 'core/domain';
-import { Registry } from 'core/registry';
 
 class ExpectedArtifactController implements IComponentController {
   public expectedArtifact: IExpectedArtifact;
@@ -21,16 +20,9 @@ class ExpectedArtifactController implements IComponentController {
       expectedArtifact: { useDefaultArtifact, defaultArtifact, matchArtifact },
     } = this;
     if (useDefaultArtifact && defaultArtifact.type == null) {
-      const matchKind = ExpectedArtifactService.getKind(matchArtifact);
-      const defaultKey = 'default.' + matchKind;
-      const defaultKindConfig = Registry.pipeline.getArtifactKinds().find(kind => kind.key === defaultKey);
-      if (defaultKindConfig) {
-        defaultArtifact.type = defaultKindConfig.type;
-        defaultArtifact.kind = defaultKindConfig.key;
-      } else {
-        defaultArtifact.type = matchArtifact.type;
-        defaultArtifact.kind = matchKind;
-      }
+      const defaultKindConfig = ExpectedArtifactService.getKindConfig(matchArtifact, true);
+      defaultArtifact.type = defaultKindConfig.type || matchArtifact.type;
+      defaultArtifact.kind = defaultKindConfig.key;
     }
   }
 }


### PR DESCRIPTION
These commits consolidate all access to `artifact.kind` into the `getKindConfig` function.  This will make it easier to change the logic for inferring kind to no longer depend on `kind` being set.