### PR TITLE
feat(core): allow min/max on NumberSpelInput, zero wait on Wait Stage

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/wait/WaitStageConfig.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/wait/WaitStageConfig.tsx
@@ -19,7 +19,8 @@ export class WaitStageConfig extends React.Component<IStageConfigProps, IWaitSta
     state: IWaitStageConfigState,
   ): IWaitStageConfigState {
     const { stage } = props;
-    if (!stage.waitTime) {
+    const { waitTime } = stage;
+    if (waitTime === undefined || (!Number.isNaN(waitTime) && waitTime < 0)) {
       stage.waitTime = 30;
     }
     return {
@@ -35,7 +36,8 @@ export class WaitStageConfig extends React.Component<IStageConfigProps, IWaitSta
   }
 
   private getState(stage: IStage): IWaitStageConfigState {
-    if (!stage.waitTime) {
+    const { waitTime } = stage;
+    if (waitTime === undefined || (!Number.isNaN(waitTime) && waitTime < 0)) {
       stage.waitTime = 30;
     }
     return {
@@ -72,7 +74,7 @@ export class WaitStageConfig extends React.Component<IStageConfigProps, IWaitSta
       <div className="form-horizontal">
         <StageConfigField label="Wait time (seconds)" fieldColumns={6}>
           <div>
-            <SpelNumberInput value={waitTime} onChange={this.updateWaitTime} />
+            <SpelNumberInput value={waitTime} min={0} onChange={this.updateWaitTime} />
           </div>
         </StageConfigField>
         <div className="form-group">

--- a/app/scripts/modules/core/src/widgets/spelText/SpelNumberInput.tsx
+++ b/app/scripts/modules/core/src/widgets/spelText/SpelNumberInput.tsx
@@ -5,6 +5,8 @@ import { Tooltip } from 'core/presentation';
 export interface INumberInputProps {
   value: number | string;
   onChange: (value: number | string) => void;
+  min?: number;
+  max?: number;
 }
 
 export interface INumberInputState {
@@ -46,7 +48,7 @@ export class SpelNumberInput extends React.Component<INumberInputProps, INumberI
 
   public render() {
     const { expressionActive, glowing } = this.state;
-    const { value } = this.props;
+    const { value, min, max } = this.props;
     return (
       <div className="navbar-form" style={{ padding: 0 }}>
         <div className={`button-input ${expressionActive ? 'text' : 'number'}${glowing ? ' focus' : ''}`}>
@@ -79,6 +81,8 @@ export class SpelNumberInput extends React.Component<INumberInputProps, INumberI
             type={expressionActive ? 'text' : 'number'}
             className="form-control borderless"
             value={value}
+            min={min}
+            max={max}
             onChange={this.valueChanged}
             onFocus={() => this.setGlow(true)}
             onBlur={() => this.setGlow(false)}


### PR DESCRIPTION
This is a hot feature that a lot of people have been asking for this year, the ability to have a zero second wait stage.

Also adding min/max to the `<NumberSpelInput>`, another hot feature our end users have been asking for.