### PR TITLE
fix(core): clear stage-specific fields when changing stage types

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/stage.module.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/stage.module.js
@@ -126,6 +126,12 @@ module.exports = angular
         $scope.stage.alias = stage.alias;
       }
       this.selectStage();
+      // clear stage-specific fields
+      Object.keys($scope.stage).forEach(k => {
+        if (!['requisiteStageRefIds', 'refId', 'isNew', 'name', 'type'].includes(k)) {
+          delete $scope.stage[k];
+        }
+      });
     };
 
     this.selectStage = function(newVal, oldVal) {


### PR DESCRIPTION
If a user adds a new stage, then scrolls through the different stage types, selecting one, then another, then another, old fields from each stage config rendering will accumulate in the stage JSON. It's easy enough to clear those fields out, so we should do that.