### PR TITLE
refactor(artifacts): Deprecate kind field

### DIFF
--- a/app/scripts/modules/core/src/artifact/expectedArtifact.service.ts
+++ b/app/scripts/modules/core/src/artifact/expectedArtifact.service.ts
@@ -49,12 +49,10 @@ export class ExpectedArtifactService {
       useDefaultArtifact: false,
       matchArtifact: {
         id: UUIDGenerator.generateUuid(),
-        kind: 'custom',
         customKind: true,
       },
       defaultArtifact: {
         id: UUIDGenerator.generateUuid(),
-        kind: 'custom',
         customKind: true,
       },
     };

--- a/app/scripts/modules/core/src/artifact/react/ExpectedArtifactEditor.tsx
+++ b/app/scripts/modules/core/src/artifact/react/ExpectedArtifactEditor.tsx
@@ -88,7 +88,9 @@ export class ExpectedArtifactEditor extends React.Component<
   private onKindChange = (kind: IArtifactKindConfig) => {
     const expectedArtifact = cloneDeep(this.state.expectedArtifact);
     expectedArtifact.matchArtifact.type = kind.type;
-    expectedArtifact.matchArtifact.kind = kind.key;
+    // kind is deprecated; remove it from artifacts as they are updated
+    delete expectedArtifact.matchArtifact.kind;
+    expectedArtifact.matchArtifact.customKind = kind.customKind;
     const accounts = this.accountsForExpectedArtifact(expectedArtifact);
     this.setState({ expectedArtifact, account: accounts[0] });
   };

--- a/app/scripts/modules/core/src/artifact/react/ExpectedArtifactSelector.spec.tsx
+++ b/app/scripts/modules/core/src/artifact/react/ExpectedArtifactSelector.spec.tsx
@@ -6,9 +6,8 @@ import { IExpectedArtifact } from 'core/domain';
 
 import { ExpectedArtifactSelector } from './ExpectedArtifactSelector';
 
-const artifact = (kind: string, type: string): IExpectedArtifact => {
+const artifact = (type: string): IExpectedArtifact => {
   const ea = ExpectedArtifactService.createEmptyArtifact();
-  ea.matchArtifact.kind = kind;
   ea.matchArtifact.customKind = false;
   ea.matchArtifact.type = type;
   return ea;
@@ -17,7 +16,7 @@ const artifact = (kind: string, type: string): IExpectedArtifact => {
 describe('<ExpectedArtifactSelector/>', () => {
   describe('filtering offered artifact types', () => {
     it('only includes those artifacts with type matching a single offeredArtifactTypes regex', () => {
-      const artifacts = [artifact('GCS', 'gcs/object'), artifact('Docker', 'docker/image')];
+      const artifacts = [artifact('gcs/object'), artifact('docker/image')];
       const sel = mount(
         <ExpectedArtifactSelector
           expectedArtifacts={artifacts}
@@ -31,11 +30,7 @@ describe('<ExpectedArtifactSelector/>', () => {
     });
 
     it('only includes those artifacts whose type matches any of the regexes in the offeredArtifactTypes array', () => {
-      const artifacts = [
-        artifact('GCS', 'gcs/object'),
-        artifact('FooBar', 'foo/bar'),
-        artifact('Docker', 'docker/image'),
-      ];
+      const artifacts = [artifact('gcs/object'), artifact('foo/bar'), artifact('docker/image')];
       const sel = mount(
         <ExpectedArtifactSelector
           expectedArtifacts={artifacts}
@@ -52,7 +47,7 @@ describe('<ExpectedArtifactSelector/>', () => {
 
   describe('excluding artifact types', () => {
     it('excludes single artifact types defined by regex', () => {
-      const artifacts = [artifact('GCS', 'gcs/object'), artifact('Docker', 'docker/image')];
+      const artifacts = [artifact('gcs/object'), artifact('docker/image')];
       const sel = mount(
         <ExpectedArtifactSelector
           expectedArtifacts={artifacts}
@@ -66,11 +61,7 @@ describe('<ExpectedArtifactSelector/>', () => {
     });
 
     it('excludes multiple artifact types defined by regex', () => {
-      const artifacts = [
-        artifact('GCS', 'gcs/object'),
-        artifact('GCS', 'gcs/bucket'),
-        artifact('Docker', 'docker/image'),
-      ];
+      const artifacts = [artifact('gcs/object'), artifact('gcs/bucket'), artifact('docker/image')];
       const sel = mount(
         <ExpectedArtifactSelector
           expectedArtifacts={artifacts}
@@ -84,7 +75,7 @@ describe('<ExpectedArtifactSelector/>', () => {
     });
 
     it('excludes multiple artifact types defined by multiples regexes', () => {
-      const artifacts = [artifact('GCS', 'gcs/object'), artifact('Docker', 'docker/image')];
+      const artifacts = [artifact('gcs/object'), artifact('docker/image')];
       const sel = mount(
         <ExpectedArtifactSelector
           expectedArtifacts={artifacts}
@@ -99,7 +90,7 @@ describe('<ExpectedArtifactSelector/>', () => {
 
   describe('creating a new artifact', () => {
     it('provides an option to create a new artifact when an onRequestCreate prop is given', () => {
-      const artifacts = [artifact('GCS', 'gcs/object')];
+      const artifacts = [artifact('gcs/object')];
       const sel = mount(
         <ExpectedArtifactSelector expectedArtifacts={artifacts} onChange={_ea => {}} onRequestCreate={() => {}} />,
       );
@@ -108,7 +99,7 @@ describe('<ExpectedArtifactSelector/>', () => {
     });
 
     it('doesnt provide an option to create a new artifact when an onRequestCreate prop is not given', () => {
-      const artifacts = [artifact('GCS', 'gcs/object')];
+      const artifacts = [artifact('gcs/object')];
       const sel = mount(<ExpectedArtifactSelector expectedArtifacts={artifacts} onChange={_ea => {}} />);
       const options = sel.find('TetheredSelect').prop('options') as any[];
       expect(options.length).toBe(1);

--- a/app/scripts/modules/core/src/artifact/react/ExpectedArtifactSelector.tsx
+++ b/app/scripts/modules/core/src/artifact/react/ExpectedArtifactSelector.tsx
@@ -38,7 +38,7 @@ export class ExpectedArtifactSelector extends React.Component<IExpectedArtifactS
     showIcons: true,
   };
 
-  private summarizeExpectedArtifact = summarizeExpectedArtifact(['kind', 'id']);
+  private summarizeExpectedArtifact = summarizeExpectedArtifact(['kind', 'id', 'customKind']);
 
   private renderOption = (e: IExpectedArtifactSelectorOption) => {
     if (!e.expectedArtifact && !e.requestingNew) {

--- a/app/scripts/modules/core/src/artifact/summarizeExpectedArtifact.ts
+++ b/app/scripts/modules/core/src/artifact/summarizeExpectedArtifact.ts
@@ -1,7 +1,7 @@
 import { module } from 'angular';
 import { IArtifact, IExpectedArtifact } from 'core/domain';
 
-export function summarizeExpectedArtifact(excludeKeys = ['kind']) {
+export function summarizeExpectedArtifact(excludeKeys = ['customKind', 'kind']) {
   return function(expected: IExpectedArtifact): string {
     if (!expected) {
       return '';

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/artifact.component.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/artifact.component.ts
@@ -69,7 +69,7 @@ class ArtifactCtrl implements IController {
     let options = this.options;
     if (this.artifactAccounts) {
       options = options.filter(o => {
-        const isCustomArtifact = o.type == null;
+        const isCustomArtifact = o.customKind;
         const isPublic = !!o.isPubliclyAccessible;
         const hasCredential = this.artifactAccounts.find(a => a.types.includes(o.type));
         return isCustomArtifact || isPublic || hasCredential;
@@ -87,7 +87,8 @@ class ArtifactCtrl implements IController {
   }
 
   public onKindChange(artifactKind: IArtifactKindConfig): void {
-    this.artifact.kind = artifactKind.key;
+    // kind is deprecated; remove it from artifacts as they are updated
+    delete this.artifact.kind;
     this.artifact.customKind = artifactKind.customKind;
     this.renderArtifactConfigTemplate(artifactKind);
   }

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/expectedArtifact.component.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/expectedArtifact.component.ts
@@ -22,7 +22,8 @@ class ExpectedArtifactController implements IComponentController {
     if (useDefaultArtifact && defaultArtifact.type == null) {
       const defaultKindConfig = ExpectedArtifactService.getKindConfig(matchArtifact, true);
       defaultArtifact.type = defaultKindConfig.type || matchArtifact.type;
-      defaultArtifact.kind = defaultKindConfig.key;
+      // kind is deprecated; remove it from artifacts as they are updated
+      delete defaultArtifact.kind;
       defaultArtifact.customKind = defaultKindConfig.customKind;
     }
   }


### PR DESCRIPTION
Replace all places where we write the kind field of artifacts with writing the customKind field. Delete artifact.kind any time we're updating customKind, as we want customKind alone to control whether to show the custom editing form once the artifact has this field.