### PR TITLE
fix(validation): Validator should pass checkParentTriggers through

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/validation/upstreamVersionProvided.validator.ts
+++ b/app/scripts/modules/core/src/pipeline/config/validation/upstreamVersionProvided.validator.ts
@@ -38,6 +38,7 @@ export class UpstreamVersionProvidedValidator implements IStageOrTriggerValidato
     const message = validator.getMessage(labels);
     const downstreamValidatorConfig: IStageOrTriggerBeforeTypeValidationConfig = {
       type: 'stageOrTriggerBeforeType',
+      checkParentTriggers: validator.checkParentTriggers,
       stageTypes,
       message,
     };


### PR DESCRIPTION
Created a new validator to check upstream for stages/triggers that provide version information for bakes (https://github.com/spinnaker/deck/pull/6328), but forgot to pass through the flag that also checks stages/triggers of parent pipeline triggers. Whoops!