### PR TITLE
fix(core/presentation): make detail dropdowns not visually crop

### DIFF
--- a/app/scripts/modules/core/src/presentation/main.less
+++ b/app/scripts/modules/core/src/presentation/main.less
@@ -303,6 +303,7 @@ html {
     }
     react-ui-view-adapter {
       width: 100%;
+      overflow-x: visible !important;
     }
   }
   .nav-content {


### PR DESCRIPTION
detail view will be reconsidered soon as part of larger infrastructure view redesigns. For now, this just lets the dropdowns not get cropped. 

![screen shot 2019-01-11 at 4 04 04 pm](https://user-images.githubusercontent.com/3046463/51065586-94705180-15ba-11e9-920e-692666e2bd0c.png)
