### PR TITLE
fix(google): fix autohealing clone logic

### DIFF
--- a/app/scripts/modules/google/src/serverGroup/configure/wizard/cloneServerGroup.gce.controller.js
+++ b/app/scripts/modules/google/src/serverGroup/configure/wizard/cloneServerGroup.gce.controller.js
@@ -391,7 +391,7 @@ module.exports = angular
     this.onEnableAutoHealingChange = function() {
       // Prevent empty auto-healing policies from being overwritten by those of their ancestors
       $scope.command.overwriteAncestorAutoHealingPolicy =
-        $scope.command.stack === 'clone' &&
+        $scope.command.viewState.mode === 'clone' &&
         $scope.command.autoHealingPolicy != null &&
         $scope.command.enableAutoHealing === false;
     };


### PR DESCRIPTION
When testing this fix, my stack was also named 'clone' so I somehow confused this with the correct check on viewState mode. :see_no_evil: 
Will patch into 1.10 and 1.11 as well.