### PR TITLE
fix(core/deploymentStrategy): Fix rolling red/black NPE

### DIFF
--- a/app/scripts/modules/core/src/deploymentStrategy/strategies/rollingredblack/AdditionalFields.tsx
+++ b/app/scripts/modules/core/src/deploymentStrategy/strategies/rollingredblack/AdditionalFields.tsx
@@ -47,11 +47,12 @@ export class AdditionalFields extends React.Component<IRollingRedBlackStrategyAd
   public render() {
     const { NumberList } = NgReact;
     const { command } = this.props;
+    const rollbackOnFailure = command.rollback && command.rollback.onFailure;
     return (
       <div className="form-group">
         <div className="col-md-12 checkbox" style={{ marginTop: 0 }}>
           <label>
-            <input type="checkbox" checked={command.rollback.onFailure} onChange={this.rollbackOnFailureChange} />
+            <input type="checkbox" checked={rollbackOnFailure} onChange={this.rollbackOnFailureChange} />
             Rollback to previous server group if deployment fails <HelpField id="strategy.rollingRedBlack.rollback" />
           </label>
         </div>


### PR DESCRIPTION
fixes error when selecting rolling red/black without selecting a previous strategy
@ajordens 
```
console.js:35 TypeError: Cannot read property 'onFailure' of undefined
    at exports.AdditionalFields.render (AdditionalFields.tsx:54)
    at li (react-dom.production.min.js:163)
    at si (react-dom.production.min.js:162)
    at pi (react-dom.production.min.js:171)
    at Ui (react-dom.production.min.js:202)
    at qi (react-dom.production.min.js:203)
    at Pa (react-dom.production.min.js:218)
    at Ea (react-dom.production.min.js:217)
    at La (react-dom.production.min.js:232)
    at An (react-dom.production.min.js:85)
    at HTMLDocument.o (raven.js:377)
```