### PR TITLE
chore(docker): Bump version to 0.0.30

### DIFF
--- a/app/scripts/modules/docker/package.json
+++ b/app/scripts/modules/docker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/docker",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
ecb9fe87476d87f0d175e2a2b53d92a5f000fe9a fix(docker): Show the tag not found warning more smarterly (#6354)
