### PR TITLE
fix(google): differentiate among autohealing health check kinds

### DIFF
--- a/app/scripts/modules/google/src/domain/autoHealingPolicy.ts
+++ b/app/scripts/modules/google/src/domain/autoHealingPolicy.ts
@@ -1,5 +1,8 @@
+import { IGceHealthCheckKind } from 'google/domain/healthCheck';
+
 export interface IGceAutoHealingPolicy {
   healthCheck?: string;
+  healthCheckKind?: IGceHealthCheckKind;
   initialDelaySec?: number;
   maxUnavailable?: IMaxUnavailable;
 }

--- a/app/scripts/modules/google/src/domain/healthCheck.ts
+++ b/app/scripts/modules/google/src/domain/healthCheck.ts
@@ -8,4 +8,12 @@ export interface IGceHealthCheck {
   timeoutSec: number;
   unhealthyThreshold: number;
   healthyThreshold: number;
+  kind: IGceHealthCheckKind;
+  selfLink: string;
+}
+
+export enum IGceHealthCheckKind {
+  healthCheck = 'healthCheck',
+  httpHealthCheck = 'httpHealthCheck',
+  httpsHealthCheck = 'httpsHealthCheck',
 }

--- a/app/scripts/modules/google/src/healthCheck/healthCheckUtils.spec.ts
+++ b/app/scripts/modules/google/src/healthCheck/healthCheckUtils.spec.ts
@@ -1,0 +1,83 @@
+import { IGceHealthCheck, IGceHealthCheckKind } from 'google/domain';
+import {
+  parseHealthCheckUrl,
+  getHealthCheckOptions,
+  getDuplicateHealthCheckNames,
+} from 'google/healthCheck/healthCheckUtils';
+
+describe('Health check display utils', () => {
+  let healthChecks: IGceHealthCheck[];
+  beforeEach(() => {
+    healthChecks = getSampleHealthChecks();
+  });
+  describe('parseHealthCheckUrl', () => {
+    it('extracts name and kind from health check url', () => {
+      healthChecks.forEach(hc => {
+        expect(parseHealthCheckUrl(hc.selfLink)).toEqual({
+          healthCheckName: hc.name,
+          healthCheckKind: hc.kind,
+        });
+      });
+    });
+  });
+  describe('getHealthCheckOptions', () => {
+    it('adds appropriate displayName to each health check, including kind when name is duplicate', () => {
+      expect(getHealthCheckOptions(healthChecks).map(hc => hc.displayName)).toEqual([
+        'hello (healthCheck)',
+        'hello (httpsHealthCheck)',
+        'ping',
+      ]);
+    });
+  });
+  describe('getDuplicateHealthCheckNames', () => {
+    it('returns list of names that occur more than once in list of health checks', () => {
+      const duplicates = getDuplicateHealthCheckNames(healthChecks);
+      expect(duplicates.size).toEqual(1);
+      expect(duplicates.has('hello')).toBeTruthy();
+    });
+  });
+});
+
+function getSampleHealthChecks(): IGceHealthCheck[] {
+  return [
+    {
+      account: 'my-gce-account',
+      checkIntervalSec: 1,
+      healthCheckType: 'HTTP',
+      healthyThreshold: 1,
+      kind: IGceHealthCheckKind.healthCheck,
+      name: 'hello',
+      port: 8080,
+      requestPath: '/hello',
+      selfLink: 'https://www.googleapis.com/compute/beta/projects/my-project/global/healthChecks/hello',
+      timeoutSec: 1,
+      unhealthyThreshold: 1,
+    },
+    {
+      account: 'my-gce-account',
+      checkIntervalSec: 1,
+      healthCheckType: 'HTTPS',
+      healthyThreshold: 1,
+      kind: IGceHealthCheckKind.httpsHealthCheck,
+      name: 'hello',
+      port: 8080,
+      requestPath: '/hello',
+      selfLink: 'https://www.googleapis.com/compute/beta/projects/my-project/global/httpsHealthChecks/hello',
+      timeoutSec: 1,
+      unhealthyThreshold: 1,
+    },
+    {
+      account: 'my-gce-account',
+      checkIntervalSec: 1,
+      healthCheckType: 'HTTP',
+      healthyThreshold: 1,
+      kind: IGceHealthCheckKind.httpHealthCheck,
+      name: 'ping',
+      port: 8080,
+      requestPath: '/ping',
+      selfLink: 'https://www.googleapis.com/compute/beta/projects/my-project/global/httpHealthChecks/ping',
+      timeoutSec: 1,
+      unhealthyThreshold: 1,
+    },
+  ];
+}

--- a/app/scripts/modules/google/src/healthCheck/healthCheckUtils.ts
+++ b/app/scripts/modules/google/src/healthCheck/healthCheckUtils.ts
@@ -1,0 +1,47 @@
+import { IGceHealthCheck, IGceHealthCheckKind } from 'google/domain';
+
+export interface IGceHealthCheckOption {
+  displayName: string;
+  kind: IGceHealthCheckKind;
+  name: string;
+  selfLink: string;
+}
+
+export function parseHealthCheckUrl(url: string): { healthCheckName: string; healthCheckKind: IGceHealthCheckKind } {
+  const healthCheckPathParts = url.split('/');
+  if (healthCheckPathParts.length < 2) {
+    throw new Error(`Health check url ${url} missing expected segments.`);
+  }
+  const healthCheckName = healthCheckPathParts[healthCheckPathParts.length - 1];
+  const healthCheckKind = healthCheckPathParts[healthCheckPathParts.length - 2].slice(0, -1);
+  return {
+    healthCheckName,
+    healthCheckKind: healthCheckKind as IGceHealthCheckKind,
+  };
+}
+
+export function getHealthCheckOptions(healthChecks: IGceHealthCheck[]): IGceHealthCheckOption[] {
+  const duplicateNames = getDuplicateHealthCheckNames(healthChecks);
+  return healthChecks.map(hc => {
+    const isNameDupe = duplicateNames.has(hc.name);
+    return {
+      displayName: isNameDupe ? `${hc.name} (${hc.kind})` : hc.name,
+      kind: hc.kind,
+      name: hc.name,
+      selfLink: hc.selfLink,
+    };
+  });
+}
+
+export function getDuplicateHealthCheckNames(healthChecks: IGceHealthCheck[]): Set<string> {
+  const allNames = new Set();
+  const duplicateNames = new Set();
+  healthChecks.forEach(hc => {
+    if (allNames.has(hc.name)) {
+      duplicateNames.add(hc.name);
+    } else {
+      allNames.add(hc.name);
+    }
+  });
+  return duplicateNames;
+}

--- a/app/scripts/modules/google/src/serverGroup/configure/serverGroupCommandBuilder.service.js
+++ b/app/scripts/modules/google/src/serverGroup/configure/serverGroupCommandBuilder.service.js
@@ -193,7 +193,7 @@ module.exports = angular
 
         if (autoHealingPolicyHealthCheck) {
           command.autoHealingPolicy = {
-            healthCheck: autoHealingPolicyHealthCheck,
+            healthCheck: healthCheckUrl,
             initialDelaySec: autoHealingPolicy.initialDelaySec,
           };
         }

--- a/app/scripts/modules/google/src/serverGroup/configure/serverGroupConfiguration.service.js
+++ b/app/scripts/modules/google/src/serverGroup/configure/serverGroupConfiguration.service.js
@@ -14,6 +14,7 @@ import {
 
 import { GCEProviderSettings } from 'google/gce.settings';
 import { GCE_HEALTH_CHECK_READER } from 'google/healthCheck/healthCheck.read.service';
+import { getHealthCheckOptions } from 'google/healthCheck/healthCheckUtils';
 import { GCE_HTTP_LOAD_BALANCER_UTILS } from 'google/loadBalancer/httpLoadBalancerUtils.service';
 import { LOAD_BALANCER_SET_TRANSFORMER } from 'google/loadBalancer/loadBalancer.setTransformer';
 
@@ -133,6 +134,7 @@ module.exports = angular
             const healthChecks = getHealthChecks(command);
             if (
               !_.chain(healthChecks)
+                .map('selfLink')
                 .includes(command.autoHealingPolicy.healthCheck)
                 .value()
             ) {
@@ -357,10 +359,8 @@ module.exports = angular
     }
 
     function getHealthChecks(command) {
-      return _.chain(command.backingData.healthChecks)
-        .filter({ account: command.credentials })
-        .map('name')
-        .value();
+      const matchingHealthChecks = _.filter(command.backingData.healthChecks, { account: command.credentials });
+      return getHealthCheckOptions(matchingHealthChecks);
     }
 
     function configureHealthChecks(command) {
@@ -376,6 +376,7 @@ module.exports = angular
       if (
         _.has(command, 'autoHealingPolicy.healthCheck') &&
         !_.chain(filteredData.healthChecks)
+          .map('selfLink')
           .includes(command.autoHealingPolicy.healthCheck)
           .value()
       ) {

--- a/app/scripts/modules/google/src/serverGroup/configure/wizard/autoHealingPolicy/autoHealingPolicySelector.component.html
+++ b/app/scripts/modules/google/src/serverGroup/configure/wizard/autoHealingPolicy/autoHealingPolicySelector.component.html
@@ -4,9 +4,9 @@
   </div>
   <div class="col-md-6">
     <ui-select ng-model="$ctrl.autoHealingPolicy.healthCheck" class="form-control input-sm" required>
-      <ui-select-match placeholder="Select...">{{$select.selected}}</ui-select-match>
-      <ui-select-choices repeat="healthCheck in $ctrl.healthChecks | filter: $select.search">
-        <span ng-bind-html="healthCheck | highlight: $select.search"></span>
+      <ui-select-match placeholder="Select...">{{$select.selected.displayName}}</ui-select-match>
+      <ui-select-choices repeat="healthCheck.selfLink as healthCheck in $ctrl.healthChecks | orderBy: 'displayName' | filter: { displayName: $select.search }">
+        <span ng-bind-html="healthCheck.displayName | highlight: $select.search"></span>
       </ui-select-choices>
     </ui-select>
   </div>

--- a/app/scripts/modules/google/src/serverGroup/configure/wizard/cloneServerGroup.gce.controller.js
+++ b/app/scripts/modules/google/src/serverGroup/configure/wizard/cloneServerGroup.gce.controller.js
@@ -5,6 +5,8 @@ import _ from 'lodash';
 
 import { FirewallLabels, INSTANCE_TYPE_SERVICE, ModalWizard, TaskMonitor } from '@spinnaker/core';
 
+import { parseHealthCheckUrl } from 'google/healthCheck/healthCheckUtils';
+
 module.exports = angular
   .module('spinnaker.serverGroup.configure.gce.cloneServerGroup', [
     require('@uirouter/angularjs').default,
@@ -370,6 +372,14 @@ module.exports = angular
       if ($scope.command.viewState.mode === 'editPipeline' || $scope.command.viewState.mode === 'createPipeline') {
         return $uibModalInstance.close($scope.command);
       }
+
+      const healthCheckUrl = $scope.command.autoHealingPolicy.healthCheck;
+      if (healthCheckUrl) {
+        const { healthCheckName, healthCheckKind } = parseHealthCheckUrl(healthCheckUrl);
+        $scope.command.autoHealingPolicy.healthCheck = healthCheckName;
+        $scope.command.autoHealingPolicy.healthCheckKind = healthCheckKind;
+      }
+
       $scope.taskMonitor.submit(function() {
         const promise = serverGroupWriter.cloneServerGroup(angular.copy($scope.command), application);
 
@@ -379,6 +389,7 @@ module.exports = angular
         $scope.command.tags = origTags;
         $scope.command.loadBalancers = origLoadBalancers;
         $scope.command.securityGroups = gceTagManager.inferSecurityGroupIdsFromTags($scope.command.tags);
+        $scope.command.autoHealingPolicy.healthCheck = healthCheckUrl;
 
         return promise;
       });


### PR DESCRIPTION
Previously, we specified autohealing health checks by name, which is not guaranteed to be a unique key because it is possible to have up to three health checks with the same name (one of each kind: `healthCheck`, `httpHealthCheck`, and `httpsHealthCheck`). This can lead to [this Angular error](https://code.angularjs.org/1.6.4/docs/error/ngRepeat/dupes?p0=healthCheck%20in%20$select.items&p1=string:routing-test-hc&p2=routing-test-hc), which prevents the autohealing health check dropdown from working.

This changes the display logic to key on the health check URL, which can be parsed to infer its name and kind. Additionally, health checks will now be displayed alphabetically, and duplicated names will now be displayed along with their kinds. Corresponding Clouddriver PR: https://github.com/spinnaker/clouddriver/pull/3282

![h7qw2e5vtup](https://user-images.githubusercontent.com/15936279/51280873-d4ff0f00-19ae-11e9-9c0d-2ca9774787e2.png)