### PR TITLE
fix(aws): filter out subnets with no purpose

### DIFF
--- a/app/scripts/modules/core/src/subnet/subnet.read.service.ts
+++ b/app/scripts/modules/core/src/subnet/subnet.read.service.ts
@@ -18,7 +18,7 @@ export class SubnetReader {
             subnet.label += ' (deprecated)';
           }
         });
-        return subnets;
+        return subnets.filter(s => s.label);
       });
   }
 


### PR DESCRIPTION
If there is no purpose field, we cannot render these subnets, which means we cannot render the VPC subnet select field, which means we cannot clone a server group in an account/region with any subnets without a purpose.