### PR TITLE
fix(amazon): better style of react-select for certificates

### DIFF
--- a/app/scripts/modules/amazon/src/loadBalancer/configure/application/ALBListeners.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/application/ALBListeners.tsx
@@ -499,6 +499,7 @@ class ALBListenersImpl extends React.Component<IALBListenersProps, IALBListeners
                             </select>
                             {this.showCertificateSelect(certificate) && (
                               <Select
+                                className="input-sm"
                                 wrapperStyle={{ width: '100%' }}
                                 clearable={false}
                                 required={true}

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/classic/Listeners.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/classic/Listeners.tsx
@@ -59,7 +59,6 @@ class ListenersImpl extends React.Component<IListenersProps, IListenersState> {
   private showCertificateSelect(listener: IClassicListenerDescription): boolean {
     return (
       listener.sslCertificateType === 'iam' &&
-      this.secureProtocols.includes(listener.externalProtocol) &&
       this.state.certificates &&
       Object.keys(this.state.certificates).length > 0
     );

--- a/app/scripts/modules/core/src/presentation/main.less
+++ b/app/scripts/modules/core/src/presentation/main.less
@@ -1240,6 +1240,25 @@ select.input-sm {
   padding-right: 0;
 }
 
+.Select.input-sm {
+  display: flex;
+  align-items: center;
+  .Select-control {
+    display: flex;
+    justify-content: space-between;
+    .Select-value,
+    .Select-arrow-zone {
+      line-height: 30px;
+    }
+  }
+  .Select-menu-outer {
+    margin: -1px 10px 0;
+    left: 0;
+    right: 0;
+    width: unset;
+  }
+}
+
 .select-placeholder {
   display: inline-block;
   padding-left: 14px;


### PR DESCRIPTION
Makes the `input-sm` class behave more nicely with react-select

**Current:**
<img width="601" alt="screen shot 2019-01-17 at 9 35 24 am" src="https://user-images.githubusercontent.com/73450/51337361-c01c8d00-1a3b-11e9-8b2e-1ec03bc38287.png">

**PR:**
<img width="574" alt="screen shot 2019-01-17 at 9 58 00 am" src="https://user-images.githubusercontent.com/73450/51338386-85682400-1a3e-11e9-8e5e-3049a3b6eee3.png">
