### PR TITLE
fix(core): clear cluster height cache when resizing window

### DIFF
--- a/app/scripts/modules/core/src/cluster/AllClustersGroupings.tsx
+++ b/app/scripts/modules/core/src/cluster/AllClustersGroupings.tsx
@@ -68,7 +68,12 @@ export class AllClustersGroupings extends React.Component<IAllClustersGroupingsP
     };
   }
 
+  private handleWindowResize = () => {
+    this.cellCache.clearAll();
+  };
+
   public componentDidMount() {
+    window.addEventListener('resize', this.handleWindowResize);
     const onGroupsChanged = (groups: IClusterGroup[]) => {
       this.setState(
         { groups: groups.reduce((a, b) => a.concat(b.subgroups), []) },
@@ -90,6 +95,7 @@ export class AllClustersGroupings extends React.Component<IAllClustersGroupingsP
   }
 
   public componentWillUnmount() {
+    window.removeEventListener('resize', this.handleWindowResize);
     this.groupsSubscription.unsubscribe();
     this.unwatchSortFilter();
   }


### PR DESCRIPTION
If you resize your window width, you can end up with some rows and parts of your clusters cut off. This prevents that.