### PR TITLE
fix(amazon): Fixed similar image finder so concat happens

### DIFF
--- a/app/scripts/modules/amazon/src/serverGroup/configure/AmazonImageSelectInput.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/AmazonImageSelectInput.tsx
@@ -98,7 +98,7 @@ export class AmazonImageSelectInput extends React.Component<IAmazonImageSelector
       }
 
       return this.searchForImages(this.buildQueryForSimilarImages(image.imageName)).then(similarImages => {
-        if (!similarImages.find(img => img.imageName !== image.imageName)) {
+        if (!similarImages.find(img => img.imageName === image.imageName)) {
           // findImages has a limit of 1000 and may not always include the current image, which is confusing
           return similarImages.concat(image);
         }


### PR DESCRIPTION
`find` always succeeded at the first element so we never `concat`ed