### PR TITLE
fix(tests): add anonymous /auth/user stub for all tests

### DIFF
--- a/test/functional/fixtures/anonymous_auth_response.mountebank_fixture.json
+++ b/test/functional/fixtures/anonymous_auth_response.mountebank_fixture.json
@@ -1,0 +1,55 @@
+{
+  "predicates": [
+    {
+      "caseSensitive": true,
+      "deepEquals": {
+        "method": "GET"
+      },
+      "keyCaseSensitive": true
+    },
+    {
+      "caseSensitive": true,
+      "deepEquals": {
+        "path": "/auth/user"
+      },
+      "keyCaseSensitive": true
+    },
+    {
+      "caseSensitive": true,
+      "deepEquals": {
+        "query": {}
+      },
+      "keyCaseSensitive": true
+    }
+  ],
+  "responses": [
+    {
+      "is": {
+        "statusCode": 200,
+        "headers": {
+          "Access-Control-Allow-Credentials": "true",
+          "Access-Control-Allow-Origin": "http://localhost:9000",
+          "Access-Control-Allow-Methods": "POST, GET, OPTIONS, DELETE, PUT, PATCH",
+          "Access-Control-Max-Age": "3600",
+          "Access-Control-Allow-Headers": "x-requested-with, content-type, authorization, X-RateLimit-App, X-Spinnaker-Priority",
+          "Access-Control-Expose-Headers": "X-AUTH-REDIRECT-URL",
+          "X-Application-Context": "gate:test,local:18084",
+          "X-SPINNAKER-REQUEST-ID": "2f863756-b8d4-4f48-8c60-e57de751c362",
+          "ETag": "\"03cf418cf00dd7ec96b2cb447fd951ffc\"",
+          "X-Content-Type-Options": "nosniff",
+          "X-XSS-Protection": "1; mode=block",
+          "Cache-Control": "no-cache, no-store, max-age=0, must-revalidate",
+          "Pragma": "no-cache",
+          "Expires": "0",
+          "X-Frame-Options": "DENY",
+          "Content-Type": "application/json;charset=UTF-8",
+          "Content-Length": 219,
+          "Date": "Tue, 15 Jan 2019 19:03:29 GMT",
+          "Connection": "close"
+        },
+        "body": "{\"accountNonExpired\":true,\"accountNonLocked\":true,\"allowedAccounts\":[],\"authorities\":[],\"credentialsNonExpired\":true,\"email\":\"anonymous\",\"enabled\":true,\"firstName\":null,\"lastName\":null,\"roles\":[],\"username\":\"anonymous\"}",
+        "_mode": "text"
+      }
+    }
+  ]
+}

--- a/test/functional/tests/appengine/pipelines_list.spec.ts.mountebank_fixture.json
+++ b/test/functional/tests/appengine/pipelines_list.spec.ts.mountebank_fixture.json
@@ -7,61 +7,6 @@
         {
           "caseSensitive": true,
           "deepEquals": {
-            "method": "GET"
-          },
-          "keyCaseSensitive": true
-        },
-        {
-          "caseSensitive": true,
-          "deepEquals": {
-            "path": "/auth/user"
-          },
-          "keyCaseSensitive": true
-        },
-        {
-          "caseSensitive": true,
-          "deepEquals": {
-            "query": {}
-          },
-          "keyCaseSensitive": true
-        }
-      ],
-      "responses": [
-        {
-          "is": {
-            "statusCode": 200,
-            "headers": {
-              "Access-Control-Allow-Credentials": "true",
-              "Access-Control-Allow-Origin": "http://localhost:9000",
-              "Access-Control-Allow-Methods": "POST, GET, OPTIONS, DELETE, PUT, PATCH",
-              "Access-Control-Max-Age": "3600",
-              "Access-Control-Allow-Headers": "x-requested-with, content-type, authorization, X-RateLimit-App, X-Spinnaker-Priority",
-              "Access-Control-Expose-Headers": "X-AUTH-REDIRECT-URL",
-              "X-Application-Context": "gate:test,local:18084",
-              "X-SPINNAKER-REQUEST-ID": "2f863756-b8d4-4f48-8c60-e57de751c362",
-              "ETag": "\"03cf418cf00dd7ec96b2cb447fd951ffc\"",
-              "X-Content-Type-Options": "nosniff",
-              "X-XSS-Protection": "1; mode=block",
-              "Cache-Control": "no-cache, no-store, max-age=0, must-revalidate",
-              "Pragma": "no-cache",
-              "Expires": "0",
-              "X-Frame-Options": "DENY",
-              "Content-Type": "application/json;charset=UTF-8",
-              "Content-Length": 224,
-              "Date": "Tue, 15 Jan 2019 19:03:29 GMT",
-              "Connection": "close"
-            },
-            "body": "{\"accountNonExpired\":true,\"accountNonLocked\":true,\"allowedAccounts\":[\"gae\"],\"authorities\":[],\"credentialsNonExpired\":true,\"email\":\"anonymous\",\"enabled\":true,\"firstName\":null,\"lastName\":null,\"roles\":[],\"username\":\"anonymous\"}",
-            "_mode": "text"
-          }
-        }
-      ]
-    },
-    {
-      "predicates": [
-        {
-          "caseSensitive": true,
-          "deepEquals": {
             "method": "OPTIONS"
           },
           "keyCaseSensitive": true

--- a/test/functional/tests/core/applications_create_required_config_prevents_creation.spec.ts.mountebank_fixture.json
+++ b/test/functional/tests/core/applications_create_required_config_prevents_creation.spec.ts.mountebank_fixture.json
@@ -7,60 +7,6 @@
         {
           "caseSensitive": true,
           "deepEquals": {
-            "method": "GET"
-          },
-          "keyCaseSensitive": true
-        },
-        {
-          "caseSensitive": true,
-          "deepEquals": {
-            "path": "/auth/user"
-          },
-          "keyCaseSensitive": true
-        },
-        {
-          "caseSensitive": true,
-          "deepEquals": {
-            "query": {}
-          },
-          "keyCaseSensitive": true
-        }
-      ],
-      "responses": [
-        {
-          "is": {
-            "statusCode": 200,
-            "headers": {
-              "Access-Control-Allow-Credentials": "true",
-              "Access-Control-Allow-Origin": "http://localhost:9000",
-              "Access-Control-Allow-Methods": "POST, GET, OPTIONS, DELETE, PUT, PATCH",
-              "Access-Control-Max-Age": "3600",
-              "Access-Control-Allow-Headers": "x-requested-with, content-type, authorization, X-RateLimit-App, X-Spinnaker-Priority",
-              "Access-Control-Expose-Headers": "X-AUTH-REDIRECT-URL",
-              "X-Content-Type-Options": "nosniff",
-              "X-XSS-Protection": "1; mode=block",
-              "Cache-Control": "no-cache, no-store, max-age=0, must-revalidate",
-              "Pragma": "no-cache",
-              "Expires": "0",
-              "X-Frame-Options": "DENY",
-              "X-Application-Context": "gate:test,local:18084",
-              "X-SPINNAKER-REQUEST-ID": "ccefe8a8-d740-4ca8-8804-79e8e31fc983",
-              "Content-Type": "application/json;charset=UTF-8",
-              "Content-Length": 359,
-              "Date": "Thu, 04 Oct 2018 23:45:51 GMT",
-              "Connection": "close"
-            },
-            "body": "{\"accountNonExpired\":true,\"accountNonLocked\":true,\"allowedAccounts\":[\"kubernetes-v2-provider\",\"dockerhub\",\"gcr-docker-registry\",\"k8s-v2\",\"compute-engine\",\"gce\",\"gae\",\"deck-functional-tests\",\"appengine-heb-sun\"],\"authorities\":[],\"credentialsNonExpired\":true,\"email\":\"anonymous\",\"enabled\":true,\"firstName\":null,\"lastName\":null,\"roles\":[],\"username\":\"anonymous\"}",
-            "_mode": "text"
-          }
-        }
-      ]
-    },
-    {
-      "predicates": [
-        {
-          "caseSensitive": true,
-          "deepEquals": {
             "method": "OPTIONS"
           },
           "keyCaseSensitive": true

--- a/test/functional/tests/core/applications_create_takes_user_to_infra_page.spec.ts.mountebank_fixture.json
+++ b/test/functional/tests/core/applications_create_takes_user_to_infra_page.spec.ts.mountebank_fixture.json
@@ -7,60 +7,6 @@
         {
           "caseSensitive": true,
           "deepEquals": {
-            "method": "GET"
-          },
-          "keyCaseSensitive": true
-        },
-        {
-          "caseSensitive": true,
-          "deepEquals": {
-            "path": "/auth/user"
-          },
-          "keyCaseSensitive": true
-        },
-        {
-          "caseSensitive": true,
-          "deepEquals": {
-            "query": {}
-          },
-          "keyCaseSensitive": true
-        }
-      ],
-      "responses": [
-        {
-          "is": {
-            "statusCode": 200,
-            "headers": {
-              "Access-Control-Allow-Credentials": "true",
-              "Access-Control-Allow-Origin": "http://localhost:9000",
-              "Access-Control-Allow-Methods": "POST, GET, OPTIONS, DELETE, PUT, PATCH",
-              "Access-Control-Max-Age": "3600",
-              "Access-Control-Allow-Headers": "x-requested-with, content-type, authorization, X-RateLimit-App, X-Spinnaker-Priority",
-              "Access-Control-Expose-Headers": "X-AUTH-REDIRECT-URL",
-              "X-Content-Type-Options": "nosniff",
-              "X-XSS-Protection": "1; mode=block",
-              "Cache-Control": "no-cache, no-store, max-age=0, must-revalidate",
-              "Pragma": "no-cache",
-              "Expires": "0",
-              "X-Frame-Options": "DENY",
-              "X-Application-Context": "gate:test,local:18084",
-              "X-SPINNAKER-REQUEST-ID": "ccefe8a8-d740-4ca8-8804-79e8e31fc983",
-              "Content-Type": "application/json;charset=UTF-8",
-              "Content-Length": 359,
-              "Date": "Thu, 04 Oct 2018 23:45:51 GMT",
-              "Connection": "close"
-            },
-            "body": "{\"accountNonExpired\":true,\"accountNonLocked\":true,\"allowedAccounts\":[\"kubernetes-v2-provider\",\"dockerhub\",\"gcr-docker-registry\",\"k8s-v2\",\"compute-engine\",\"gce\",\"gae\",\"deck-functional-tests\",\"appengine-heb-sun\"],\"authorities\":[],\"credentialsNonExpired\":true,\"email\":\"anonymous\",\"enabled\":true,\"firstName\":null,\"lastName\":null,\"roles\":[],\"username\":\"anonymous\"}",
-            "_mode": "text"
-          }
-        }
-      ]
-    },
-    {
-      "predicates": [
-        {
-          "caseSensitive": true,
-          "deepEquals": {
             "method": "OPTIONS"
           },
           "keyCaseSensitive": true

--- a/test/functional/tests/core/applications_list.spec.ts.mountebank_fixture.json
+++ b/test/functional/tests/core/applications_list.spec.ts.mountebank_fixture.json
@@ -7,61 +7,6 @@
         {
           "caseSensitive": true,
           "deepEquals": {
-            "method": "GET"
-          },
-          "keyCaseSensitive": true
-        },
-        {
-          "caseSensitive": true,
-          "deepEquals": {
-            "path": "/auth/user"
-          },
-          "keyCaseSensitive": true
-        },
-        {
-          "caseSensitive": true,
-          "deepEquals": {
-            "query": {}
-          },
-          "keyCaseSensitive": true
-        }
-      ],
-      "responses": [
-        {
-          "is": {
-            "statusCode": 200,
-            "headers": {
-              "Access-Control-Allow-Credentials": "true",
-              "Access-Control-Allow-Origin": "http://localhost:9000",
-              "Access-Control-Allow-Methods": "POST, GET, OPTIONS, DELETE, PUT, PATCH",
-              "Access-Control-Max-Age": "3600",
-              "Access-Control-Allow-Headers": "x-requested-with, content-type, authorization, X-RateLimit-App, X-Spinnaker-Priority",
-              "Access-Control-Expose-Headers": "X-AUTH-REDIRECT-URL",
-              "X-Application-Context": "gate:test,local:18084",
-              "X-SPINNAKER-REQUEST-ID": "15362443-21b4-424a-94f6-88f99ce8138f",
-              "ETag": "\"03cf418cf00dd7ec96b2cb447fd951ffc\"",
-              "X-Content-Type-Options": "nosniff",
-              "X-XSS-Protection": "1; mode=block",
-              "Cache-Control": "no-cache, no-store, max-age=0, must-revalidate",
-              "Pragma": "no-cache",
-              "Expires": "0",
-              "X-Frame-Options": "DENY",
-              "Content-Type": "application/json;charset=UTF-8",
-              "Content-Length": 224,
-              "Date": "Tue, 15 Jan 2019 17:58:52 GMT",
-              "Connection": "close"
-            },
-            "body": "{\"accountNonExpired\":true,\"accountNonLocked\":true,\"allowedAccounts\":[\"gae\"],\"authorities\":[],\"credentialsNonExpired\":true,\"email\":\"anonymous\",\"enabled\":true,\"firstName\":null,\"lastName\":null,\"roles\":[],\"username\":\"anonymous\"}",
-            "_mode": "text"
-          }
-        }
-      ]
-    },
-    {
-      "predicates": [
-        {
-          "caseSensitive": true,
-          "deepEquals": {
             "method": "OPTIONS"
           },
           "keyCaseSensitive": true

--- a/test/functional/tests/core/home.spec.ts.mountebank_fixture.json
+++ b/test/functional/tests/core/home.spec.ts.mountebank_fixture.json
@@ -7,60 +7,6 @@
         {
           "caseSensitive": true,
           "deepEquals": {
-            "method": "GET"
-          },
-          "keyCaseSensitive": true
-        },
-        {
-          "caseSensitive": true,
-          "deepEquals": {
-            "path": "/auth/user"
-          },
-          "keyCaseSensitive": true
-        },
-        {
-          "caseSensitive": true,
-          "deepEquals": {
-            "query": {}
-          },
-          "keyCaseSensitive": true
-        }
-      ],
-      "responses": [
-        {
-          "is": {
-            "statusCode": 200,
-            "headers": {
-              "Access-Control-Allow-Credentials": "true",
-              "Access-Control-Allow-Origin": "http://localhost:9000",
-              "Access-Control-Allow-Methods": "POST, GET, OPTIONS, DELETE, PUT, PATCH",
-              "Access-Control-Max-Age": "3600",
-              "Access-Control-Allow-Headers": "x-requested-with, content-type, authorization, X-RateLimit-App, X-Spinnaker-Priority",
-              "Access-Control-Expose-Headers": "X-AUTH-REDIRECT-URL",
-              "X-Content-Type-Options": "nosniff",
-              "X-XSS-Protection": "1; mode=block",
-              "Cache-Control": "no-cache, no-store, max-age=0, must-revalidate",
-              "Pragma": "no-cache",
-              "Expires": "0",
-              "X-Frame-Options": "DENY",
-              "X-Application-Context": "gate:test,local:18084",
-              "X-SPINNAKER-REQUEST-ID": "262fe1fd-5245-40b3-bd5d-772f88a56fee",
-              "Content-Type": "application/json;charset=UTF-8",
-              "Content-Length": 359,
-              "Date": "Thu, 04 Oct 2018 23:45:44 GMT",
-              "Connection": "close"
-            },
-            "body": "{\"accountNonExpired\":true,\"accountNonLocked\":true,\"allowedAccounts\":[\"kubernetes-v2-provider\",\"dockerhub\",\"gcr-docker-registry\",\"k8s-v2\",\"compute-engine\",\"gce\",\"gae\",\"deck-functional-tests\",\"appengine-heb-sun\"],\"authorities\":[],\"credentialsNonExpired\":true,\"email\":\"anonymous\",\"enabled\":true,\"firstName\":null,\"lastName\":null,\"roles\":[],\"username\":\"anonymous\"}",
-            "_mode": "text"
-          }
-        }
-      ]
-    },
-    {
-      "predicates": [
-        {
-          "caseSensitive": true,
-          "deepEquals": {
             "method": "OPTIONS"
           },
           "keyCaseSensitive": true

--- a/test/functional/tests/google/clone.spec.ts.mountebank_fixture.json
+++ b/test/functional/tests/google/clone.spec.ts.mountebank_fixture.json
@@ -7,60 +7,6 @@
         {
           "caseSensitive": true,
           "deepEquals": {
-            "method": "GET"
-          },
-          "keyCaseSensitive": true
-        },
-        {
-          "caseSensitive": true,
-          "deepEquals": {
-            "path": "/auth/user"
-          },
-          "keyCaseSensitive": true
-        },
-        {
-          "caseSensitive": true,
-          "deepEquals": {
-            "query": {}
-          },
-          "keyCaseSensitive": true
-        }
-      ],
-      "responses": [
-        {
-          "is": {
-            "statusCode": 200,
-            "headers": {
-              "Access-Control-Allow-Credentials": "true",
-              "Access-Control-Allow-Origin": "http://localhost:9000",
-              "Access-Control-Allow-Methods": "POST, GET, OPTIONS, DELETE, PUT, PATCH",
-              "Access-Control-Max-Age": "3600",
-              "Access-Control-Allow-Headers": "x-requested-with, content-type, authorization, X-RateLimit-App, X-Spinnaker-Priority",
-              "Access-Control-Expose-Headers": "X-AUTH-REDIRECT-URL",
-              "X-Content-Type-Options": "nosniff",
-              "X-XSS-Protection": "1; mode=block",
-              "Cache-Control": "no-cache, no-store, max-age=0, must-revalidate",
-              "Pragma": "no-cache",
-              "Expires": "0",
-              "X-Frame-Options": "DENY",
-              "X-Application-Context": "gate:test,local:18084",
-              "X-SPINNAKER-REQUEST-ID": "ccefe8a8-d740-4ca8-8804-79e8e31fc983",
-              "Content-Type": "application/json;charset=UTF-8",
-              "Content-Length": 359,
-              "Date": "Thu, 04 Oct 2018 23:45:51 GMT",
-              "Connection": "close"
-            },
-            "body": "{\"accountNonExpired\":true,\"accountNonLocked\":true,\"allowedAccounts\":[\"kubernetes-v2-provider\",\"dockerhub\",\"gcr-docker-registry\",\"k8s-v2\",\"compute-engine\",\"gce\",\"gae\",\"deck-functional-tests\",\"appengine-heb-sun\"],\"authorities\":[],\"credentialsNonExpired\":true,\"email\":\"anonymous\",\"enabled\":true,\"firstName\":null,\"lastName\":null,\"roles\":[],\"username\":\"anonymous\"}",
-            "_mode": "text"
-          }
-        }
-      ]
-    },
-    {
-      "predicates": [
-        {
-          "caseSensitive": true,
-          "deepEquals": {
             "method": "OPTIONS"
           },
           "keyCaseSensitive": true

--- a/test/functional/tools/FixtureService.ts
+++ b/test/functional/tools/FixtureService.ts
@@ -11,4 +11,8 @@ export class FixtureService {
   public fixturePathForTestPath(testpath: string) {
     return path.join(path.dirname(testpath), this.fixtureNameForTestPath(testpath));
   }
+
+  public anonymousAuthFixturePath(): string {
+    return path.resolve(__dirname, '../fixtures/anonymous_auth_response.mountebank_fixture.json');
+  }
 }

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -75,7 +75,10 @@ const config = {
       if (flags['record-fixtures']) {
         return mountebankService.beginRecording();
       } else {
-        return mountebankService.createImposterFromFixtureFile(testRun.fixtureFile);
+        return mountebankService.createImposterFromFixtureFile(
+          testRun.fixtureFile,
+          fixtureService.anonymousAuthFixturePath(),
+        );
       }
     });
   },


### PR DESCRIPTION
Extract /auth/user stubbed response from all tests and put in a shared fixture file. This works around an issue where Deck in "dev mode" won't make this request and so recorded fixtures will be missing this stubbed response.  When the fixtures then get replayed with Deck in "production mode", the requests to /auth/user will 404 (since no response was recorded) and Deck will just hang on its loading screen. The test will fail for seemingly no good reason.