### PR TITLE
feat(kubernetes/v2): Adds ClipboardText component to ease getting information from labels in UI

### DIFF
--- a/app/scripts/modules/core/src/utils/ClipboardText.less
+++ b/app/scripts/modules/core/src/utils/ClipboardText.less
@@ -1,0 +1,14 @@
+.clipboard-btn {
+  border-width: 0;
+  background-color: transparent;
+  color: var(--color-dovegray);
+  display: inline-block;
+}
+.clipboard-btn:hover {
+  background-color: transparent;
+}
+&.copy-to-clipboard-sm {
+  .clipboard-btn {
+    margin-bottom: 3px;
+  }
+}

--- a/app/scripts/modules/core/src/utils/ClipboardText.spec.tsx
+++ b/app/scripts/modules/core/src/utils/ClipboardText.spec.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import { mount } from 'enzyme';
+
+import { ClipboardText } from './ClipboardText';
+
+describe('<ClipboardText />', () => {
+  it('renders an input with the text value', () => {
+    const wrapper = mount(<ClipboardText text="Rebel Girl" />);
+    const input = wrapper.find('input');
+    expect(input.get(0).props.value).toEqual('Rebel Girl');
+  });
+});

--- a/app/scripts/modules/core/src/utils/ClipboardText.tsx
+++ b/app/scripts/modules/core/src/utils/ClipboardText.tsx
@@ -1,0 +1,115 @@
+import * as React from 'react';
+import { OverlayTrigger, Tooltip } from 'react-bootstrap';
+
+import './ClipboardText.less';
+
+export interface IClipboardTextProps {
+  text: string;
+}
+
+/**
+ * Places text in an invisible input field so we can auto-focus and select the text
+ * then copy it to the clipboard onClick. Used in labels found in components like
+ * ManifestStatus to make it easier to grab data from the UI.
+ *
+ * This component mimics utils/clipboard/copyToClipboard.component.ts but
+ * since the text is placed in an invisible input its very easy to select
+ * if the copy fails.
+ */
+export class ClipboardText extends React.Component<IClipboardTextProps> {
+  public state = {
+    tooltipCopy: false,
+    inputWidth: 'auto',
+  };
+
+  private textRef: React.RefObject<HTMLInputElement> = React.createRef();
+  private hiddenRef: React.RefObject<HTMLSpanElement> = React.createRef();
+
+  private inputStyle = {
+    borderWidth: '0px',
+    display: 'inline-block',
+    backgroundColor: 'transparent',
+  };
+
+  private hiddenStyle = {
+    position: 'absolute' as 'absolute',
+    height: 0,
+    overflow: 'hidden',
+    whiteSpace: 'pre' as 'pre',
+  };
+
+  /**
+   * We need to play some games to get the correct width of the container
+   * input element but grabbing the offsetWidth of a hidden span containing
+   * the same value text as the input.
+   */
+  public componentDidMount() {
+    const hiddenNode = this.hiddenRef.current;
+    this.setState({ inputWidth: hiddenNode.offsetWidth + 3 });
+  }
+
+  /**
+   * Focuses on the input element and attempts to copy to the clipboard.
+   * Also updates state.tooltipCopy with a success/fail message, which is
+   * reset after 3s. The selection is immediately blur'd so you shouldn't
+   * see much of it during the copy.
+   */
+  public handleClick = (e: React.SyntheticEvent) => {
+    e.preventDefault();
+    const { text } = this.props;
+    const node: HTMLInputElement = this.textRef.current;
+    node.focus();
+    node.select();
+
+    try {
+      document.execCommand('copy');
+      node.blur();
+      this.setState({ tooltipCopy: `Copied ${text}` });
+      window.setTimeout(this.resetToolTip, 3000);
+    } catch (e) {
+      this.setState({ tooltipCopy: "Couldn't copy!" });
+    }
+  };
+
+  public resetToolTip = () => {
+    this.setState({ tooltipCopy: false });
+  };
+
+  public render() {
+    const { text } = this.props;
+    const { inputWidth, tooltipCopy } = this.state;
+
+    const copy = tooltipCopy || `Copy ${text}`;
+    const tooltip = <Tooltip id={`clipboardText-${text.replace(' ', '-')}`}>{copy}</Tooltip>;
+
+    const updatedStyle = {
+      ...this.inputStyle,
+      width: inputWidth,
+    };
+
+    return (
+      <React.Fragment>
+        <span ref={this.hiddenRef} style={this.hiddenStyle}>
+          {text}
+        </span>
+        <input
+          onChange={e => e} // no-op to prevent warnings
+          ref={this.textRef}
+          value={text}
+          type="text"
+          style={updatedStyle}
+        />
+        <OverlayTrigger placement="top" overlay={tooltip}>
+          <button
+            onClick={this.handleClick}
+            className="btn btn-xs btn-default clipboard-btn"
+            uib-tooltip={`Copy ${text}`}
+            aria-label="Copy to clipboard"
+          >
+            <span className="glyphicon glyphicon-copy" />
+          </button>
+        </OverlayTrigger>
+      </React.Fragment>
+    );
+  }
+}

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/react/ManifestStatus.tsx
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/react/ManifestStatus.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
-import { IManifest } from '@spinnaker/core';
+import { ClipboardText } from 'core/utils/ClipboardText';
 import { DeployManifestStatusPills } from './DeployStatusPills';
-import { ManifestYaml } from './ManifestYaml';
+import { IManifest } from '@spinnaker/core';
 import { ManifestDetailsLink } from './ManifestDetailsLink';
 import { ManifestEvents } from './ManifestEvents';
+import { ManifestYaml } from './ManifestYaml';
 
 import './ManifestStatus.less';
 
@@ -20,7 +21,7 @@ export class ManifestStatus extends React.Component<IManifestStatusProps> {
       <dl className="manifest-status" key="manifest-status">
         <dt>{manifest.manifest.kind}</dt>
         <dd>
-          {manifest.manifest.metadata.name}
+          <ClipboardText text={manifest.manifest.metadata.name} />
           &nbsp;
           <DeployManifestStatusPills manifest={manifest} />
         </dd>


### PR DESCRIPTION
features:

- Adds `ClipboardText` component to be used in text-labels to make it easy to copy/paste information directly from the UI. (Is a React version of existing Angular component).
- When you click on a label that uses the component, it will be auto-selected and the text will be copied to your clipboard automatically.
- Example: https://cl.ly/493c95d5c56f

![copywidgetthing](https://user-images.githubusercontent.com/215030/51572283-eb0b4480-1e72-11e9-8e12-0c104265bc95.gif)


fixes:

Issue in which it is difficult to double-click to select text labels (this is probably due to the use of dictionary lists in the rendered HTML).

![](https://d2ddoduugvun08.cloudfront.net/items/3624032Y0b2j12092j0t/Screen%20Recording%202018-12-19%20at%2005.06%20PM.gif?X-CloudApp-Visitor-Id=2880687&v=46115b52)