### PR TITLE
chore(tslint): Turn off picky member-ordering rule

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -31,7 +31,7 @@
     "max-classes-per-file": false,
     "max-line-length": false,
     "member-access": true,
-    "member-ordering": [true, "static-before-instance", "variables-before-functions"],
+    "member-ordering": false,
     "no-arg": true,
     "no-bitwise": true,
     "no-console": [true, "log", "warn", "debug", "info", "time", "timeEnd", "trace"],


### PR DESCRIPTION
I hate this rule.

We're likely going to want to change our linting over to `eslint` soon anyway.  TypeScript project is going to embrace eslint as the standard linter.

### From the **Linting** section of [the TypeScript roadmap](https://github.com/Microsoft/TypeScript/issues/29288)

> - Semantic rules in ESLint
> - - Parity with TSLint
> - - Speed & scalability
> - Editor integration for ESLint

> In a survey we ran in VS Code a few months back, the most frequent theme we heard from users was that the linting experience left much to be desired. Since part of our team is dedicated to editing experiences in JavaScript, our editor team set out to add support for both TSLint and ESLint. However, we noticed that there were a few architectural issues with the way TSLint rules operate that impacted performance. Fixing TSLint to operate more efficiently would require a different API which would break existing rules (unless an interop API was built like what wotan provides).

> Meanwhile, ESLint already has the more-performant architecture we're looking for from a linter. Additionally, different communities of users often have lint rules (e.g. rules for React Hooks or Vue) that are built for ESLint, but not TSLint.

> Given this, our editor team will be focusing on leveraging ESLint rather than duplicating work. For scenarios that ESLint currently doesn't cover (e.g. semantic linting or program-wide linting), we'll be working on sending contributions to bring ESLint's TypeScript support to parity with TSLint. As an initial testbed of how this works in practice, we'll be switching the TypeScript repository over to using ESLint, and sending any new rules upstream.