### PR TITLE
refactor(core/forms): Save 19kb in deck bundle by not using 'util' package

### DIFF
--- a/app/scripts/modules/core/src/forms/mapEditor/MapEditor.tsx
+++ b/app/scripts/modules/core/src/forms/mapEditor/MapEditor.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { isString } from 'util';
+import { isString } from 'lodash';
 
 export interface IMapPair {
   key: string;


### PR DESCRIPTION
I found this import from `'util'` but it should be from `'lodash'`.  This is the only place `util` was being used.