### PR TITLE
chore(core): Bump version to 0.0.317

### DIFF
--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/core",
-  "version": "0.0.316",
+  "version": "0.0.317",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
5be1a825f85d30359596e4e38bbf41bf145f7833 fix(core): fix filtering on no details in clusters view (#6423)
abe1eea2164a5dbae04f3755273e35a46bdb185f Revert "chore(uiSelect): Remove decorators for uiSelectMultiple which we no longer use, AFAICT"