### PR TITLE
fix(core/instance): Show instance id not found message in details panel

### DIFF
--- a/app/scripts/modules/core/src/instance/details/InstanceDetailsPane.tsx
+++ b/app/scripts/modules/core/src/instance/details/InstanceDetailsPane.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { ReactInjector } from 'core/reactShims';
+import { UISref } from '@uirouter/react';
+
+export const InstanceDetailsPane = (props: { children: React.ReactNode }) => {
+  const isStandalone = ReactInjector.$uiRouter.globals.current.name === 'instanceDetails';
+
+  return (
+    <div className="details-panel">
+      <div className="header">
+        <div className="close-button">
+          <UISref to={isStandalone ? 'home.infrastructure' : '^'}>
+            <a className="btn btn-link">
+              <span className="glyphicon glyphicon-remove" />
+            </a>
+          </UISref>
+        </div>
+        {props.children}
+      </div>
+    </div>
+  );
+};

--- a/app/scripts/modules/core/src/instance/details/index.ts
+++ b/app/scripts/modules/core/src/instance/details/index.ts
@@ -1,0 +1,2 @@
+export * from './InstanceDetails';
+export * from './InstanceDetailsPane';

--- a/app/scripts/modules/core/src/instance/index.ts
+++ b/app/scripts/modules/core/src/instance/index.ts
@@ -1,4 +1,5 @@
 export * from './InstanceReader';
+export * from './details';
 export * from './instance.write.service';
 export * from './instanceType.service';
 export * from './templates';


### PR DESCRIPTION
- Extracted `InstanceDetailsPane` component
- Export react components from index
- Sort some things

Fixes this issue:

<img width="1144" alt="screen shot 2019-01-23 at 8 49 42 pm" src="https://user-images.githubusercontent.com/2053478/51655225-87574900-1f50-11e9-9043-71e64f9dde8c.png">

Before:

![instance not found - before](https://user-images.githubusercontent.com/2053478/51655483-c33ede00-1f51-11e9-8747-f510a27e01d7.gif)


After:

![instance not found - after](https://user-images.githubusercontent.com/2053478/51655337-15333400-1f51-11e9-9a30-e113bc952b4c.gif)


