### PR TITLE
refactor(aws): move certificate config to second line on elb/alb

### DIFF
--- a/app/scripts/modules/amazon/src/loadBalancer/configure/application/ALBListeners.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/application/ALBListeners.tsx
@@ -498,6 +498,7 @@ class ALBListenersImpl extends React.Component<IALBListenersProps, IALBListeners
                                 certificates={certificates}
                                 accountName={values.credentials}
                                 currentValue={certificate.name}
+                                app={this.props.app}
                                 onCertificateSelect={value => this.handleCertificateChanged(certificate, value)}
                               />
                             )}

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/classic/CreateClassicLoadBalancer.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/classic/CreateClassicLoadBalancer.tsx
@@ -241,7 +241,7 @@ export class CreateClassicLoadBalancer extends React.Component<
           loadBalancer={loadBalancer}
         />
         <SecurityGroups done={true} isNew={isNew} />
-        <Listeners done={true} />
+        <Listeners done={true} app={app} />
         <HealthCheck done={true} />
         <AdvancedSettings done={true} />
       </WizardModal>

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/common/AmazonCertificateSelectField.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/common/AmazonCertificateSelectField.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import Select, { Option } from 'react-select';
-import { Overridable } from '@spinnaker/core';
+import { Application, Overridable } from '@spinnaker/core';
 
 import { IAmazonCertificate } from 'amazon/domain';
 
@@ -9,18 +9,11 @@ export interface IAmazonCertificateSelectFieldProps {
   accountName: string;
   currentValue: string;
   onCertificateSelect: (certificateName: string) => void;
+  app: Application;
 }
 
 @Overridable('amazon.certificateSelectField')
 export class AmazonCertificateSelectField extends React.Component<IAmazonCertificateSelectFieldProps> {
-  public shouldComponentUpdate(nextProps: Readonly<IAmazonCertificateSelectFieldProps>): boolean {
-    return (
-      nextProps.currentValue !== this.props.currentValue ||
-      nextProps.accountName !== this.props.accountName ||
-      nextProps.certificates !== this.props.certificates
-    );
-  }
-
   public render() {
     const { certificates, accountName, onCertificateSelect, currentValue } = this.props;
     const certificatesForAccount = certificates[accountName] || [];
@@ -31,7 +24,7 @@ export class AmazonCertificateSelectField extends React.Component<IAmazonCertifi
       <Select
         className="input-sm"
         wrapperStyle={{ width: '100%' }}
-        clearable={false}
+        clearable={true}
         required={true}
         options={certificateOptions}
         onChange={(value: Option<string>) => onCertificateSelect(value.value)}

--- a/app/scripts/modules/core/src/presentation/main.less
+++ b/app/scripts/modules/core/src/presentation/main.less
@@ -12,6 +12,9 @@
 
 .Select-input {
   font-size: 12px;
+  input:invalid {
+    box-shadow: none;
+  }
 }
 
 .Select-placeholder {
@@ -1243,6 +1246,7 @@ select.input-sm {
 .Select.input-sm {
   display: flex;
   align-items: center;
+  padding-right: 0;
   .Select-control {
     display: flex;
     justify-content: space-between;
@@ -1256,6 +1260,11 @@ select.input-sm {
     left: 0;
     right: 0;
     width: unset;
+  }
+  .Select-clear-zone {
+    position: absolute;
+    right: 25px;
+    line-height: 30px;
   }
 }
 


### PR DESCRIPTION
Not a huge change, but better - certificate names are usually pretty long.

For ALBs, it's all basically CSS

**Classic Load Balancer**
_current_
<img width="639" alt="screen shot 2019-01-24 at 9 48 20 am" src="https://user-images.githubusercontent.com/73450/51698689-b953c400-1fbf-11e9-99d6-c5bd733dc8f7.png">

_PR_
<img width="643" alt="screen shot 2019-01-24 at 9 49 11 am" src="https://user-images.githubusercontent.com/73450/51698686-b953c400-1fbf-11e9-9e0e-032b8d523b67.png">

**Application Load Balancer**
_current_
<img width="630" alt="screen shot 2019-01-24 at 9 48 38 am" src="https://user-images.githubusercontent.com/73450/51698688-b953c400-1fbf-11e9-82e5-101c85e63b03.png">
_PR_
<img width="641" alt="screen shot 2019-01-24 at 9 48 49 am" src="https://user-images.githubusercontent.com/73450/51698687-b953c400-1fbf-11e9-92e5-23d99932eba1.png">
