### PR TITLE
fix(core): make react-select CSS resets more specific

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/manualJudgment/ManualJudgmentApproval.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/manualJudgment/ManualJudgmentApproval.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import Select, { Option } from 'react-select';
-import 'react-select/dist/react-select.css';
 
 import { IExecution, IExecutionStage } from 'core/domain';
 import { Application } from 'core/application/application.model';

--- a/app/scripts/modules/core/src/presentation/main.less
+++ b/app/scripts/modules/core/src/presentation/main.less
@@ -4,27 +4,29 @@
 @fixed-header-z-index: 1030;
 
 /* Resets for React select */
-.Select--multi .Select-multi-value-wrapper,
-.Select-control,
-.Select-input {
-  height: 30px;
-}
-
-.Select-input {
-  font-size: 12px;
-  input:invalid {
-    box-shadow: none;
+html {
+  .Select--multi .Select-multi-value-wrapper,
+  .Select-control,
+  .Select-input {
+    height: 30px;
   }
-}
 
-.Select-placeholder {
-  line-height: 30px;
-  height: inherit;
-}
+  .Select-input {
+    font-size: 12px;
+    input:invalid {
+      box-shadow: none;
+    }
+  }
 
-.Select-placeholder,
-.Select--single > .Select-control .Select-value {
-  line-height: 30px;
+  .Select-placeholder {
+    line-height: 30px;
+    height: inherit;
+  }
+
+  .Select-placeholder,
+  .Select--single > .Select-control .Select-value {
+    line-height: 30px;
+  }
 }
 
 .form-field-loading {


### PR DESCRIPTION
Making these CSS rules a little more specific than the defaults. Right now, the library build is bundling the CSS in a different order than specified, so these CSS rules are not being applied in custom builds utilizing the libraries.