### PR TITLE
fix(tests): give anonymous auth fixture to mountebank

### DIFF
--- a/test/functional/README.md
+++ b/test/functional/README.md
@@ -25,6 +25,9 @@ The options available for the runner script are as follows:
                        running Gate server.
 --record-fixtures      Boolean. Record network fixtures for later replay.
                        Requires a running Spinnaker deployment.
+--serve-fixture        Boolean. Serve a pre-recorded network fixture in place
+                       of a running Gate server. Used during development to
+                       allow debugging of fixture responses.
 --gate-port            (only used when recording fixtures) Port on which a
                        real Gate server is currently running. The imposter
                        recording a test's network fixture will proxy requests

--- a/test/functional/run.js
+++ b/test/functional/run.js
@@ -115,7 +115,7 @@ Options:
                        running Gate server.
 --record-fixtures      Boolean. Record network fixtures for later replay.
                        Requires a running Spinnaker deployment.
---serve-fixture        Boolean. Serve a pre-recorded network fixtures in place
+--serve-fixture        Boolean. Serve a pre-recorded network fixture in place
                        of a running Gate server. Used during development to
                        allow debugging of fixture responses.
 --gate-port            (only used when recording fixtures) Port on which a

--- a/test/functional/tools/TestRunner.ts
+++ b/test/functional/tools/TestRunner.ts
@@ -83,7 +83,10 @@ export class TestRunner {
     const fixturePath = this.fixtureService.fixturePathForTestPath(testpath);
     Promise.all(this.launchReadinessPromises)
       .then(() => {
-        return this.mountebankService.createImposterFromFixtureFile(fixturePath);
+        return this.mountebankService.createImposterFromFixtureFile(
+          fixturePath,
+          this.fixtureService.anonymousAuthFixturePath(),
+        );
       })
       .catch(err => {
         console.error(`error serving fixture: ${err}`);


### PR DESCRIPTION
Deck's nightly functional tests are currently failing.  I added a new feature flag to the test runner that lets a developer serve a single fixture file so they can click around Deck and confirm whether the fixture returns expected data.  At the same time as adding the feature I also updated the signature of the `createImposterFromFixtureFile` method to expect an auth fixture to be passed as well so that responses from the `/auth/user` endpoint can be mocked with data independent of a test fixture.  I forgot to update the new feature flag's usage of the `createImposterFromFixtureFile` method to match the updated function signature.