### PR TITLE
fix(provider/azure): Fix the account list can't show when "Create Server Group" in cluster page 

### DIFF
--- a/app/scripts/modules/azure/serverGroup/configure/serverGroupCommandBuilder.service.js
+++ b/app/scripts/modules/azure/serverGroup/configure/serverGroupCommandBuilder.service.js
@@ -12,8 +12,8 @@ module.exports = angular
 
       var imageLoader = azureImageReader.findImages({ provider: 'azure' });
 
-      var defaultCredentials = defaults.account || application.defaultCredentials;
-      var defaultRegion = defaults.region || application.defaultRegion;
+      var defaultCredentials = defaults.account || application.defaultCredentials.azure;
+      var defaultRegion = defaults.region || application.defaultRegions.azure;
 
       return $q
         .all({


### PR DESCRIPTION
Root cause: In **serverGroupCommandBuilder.service**, the `defaultCredentials` and `defaultRegion` are not set to correct value. So that the "credential" property passed to **accountSelectField.directive.js** is a Map instead of a string. And calling `includes` function on the Map cause the error which prevent the account list show