### PR TITLE
fix(kubernetes): fix account selection by handling null values passed…

### DIFF
--- a/app/scripts/modules/kubernetes/src/v2/manifest/selector/ManifestSelector.tsx
+++ b/app/scripts/modules/kubernetes/src/v2/manifest/selector/ManifestSelector.tsx
@@ -221,7 +221,7 @@ export class ManifestSelector extends React.Component<IManifestSelectorProps, IM
     this.setStateAndUpdateStage({ selector: this.state.selector });
   };
 
-  private isExpression = (value = ''): boolean => value.includes('${');
+  private isExpression = (value: string): boolean => (typeof value === 'string' ? value.includes('${') : false);
 
   private search = (kind: string, namespace: string, account: string): IPromise<string[]> => {
     if (this.isExpression(account)) {


### PR DESCRIPTION
… to ManifestSelector.isExpression

Resolves https://github.com/spinnaker/spinnaker/issues/3872

 `isExpression` was choking when `value` was null because default params only reset `undefined` or missing values.