### PR TITLE
System import is deprecated dont use it why are you still using it please stop

### DIFF
--- a/app/scripts/modules/amazon/tsconfig.json
+++ b/app/scripts/modules/amazon/tsconfig.json
@@ -11,7 +11,7 @@
     "jsx": "react",
     "lib": ["es2016", "dom"],
     "moduleResolution": "node",
-    "module": "commonjs",
+    "module": "esnext",
     "noEmitHelpers": false,
     "noImplicitAny": true,
     "noImplicitReturns": true,

--- a/app/scripts/modules/appengine/tsconfig.json
+++ b/app/scripts/modules/appengine/tsconfig.json
@@ -11,7 +11,7 @@
     "jsx": "react",
     "lib": ["es2016", "dom"],
     "moduleResolution": "node",
-    "module": "commonjs",
+    "module": "esnext",
     "noEmitHelpers": false,
     "noImplicitAny": true,
     "noImplicitReturns": true,

--- a/app/scripts/modules/cloudfoundry/tsconfig.json
+++ b/app/scripts/modules/cloudfoundry/tsconfig.json
@@ -11,7 +11,7 @@
     "jsx": "react",
     "lib": ["es2016", "dom"],
     "moduleResolution": "node",
-    "module": "commonjs",
+    "module": "esnext",
     "noEmitHelpers": false,
     "noImplicitAny": true,
     "noImplicitReturns": true,

--- a/app/scripts/modules/core/src/bootstrap/uiRouterVisualizer.toggle.ts
+++ b/app/scripts/modules/core/src/bootstrap/uiRouterVisualizer.toggle.ts
@@ -1,4 +1,3 @@
-declare const System: any;
 import { UIRouter, Transition, Glob, UIRouterPlugin } from '@uirouter/core';
 
 import { bootstrapModule } from './bootstrap.module';
@@ -23,7 +22,7 @@ bootstrapModule.run(($uiRouter: UIRouter) => {
       .filter(state => collapseGlobs.some(glob => glob.matches(state.name)));
     collapsedStates.forEach(state => ((state.$$state() as any)._collapsed = true));
 
-    return System.import('@uirouter/visualizer')
+    return import('@uirouter/visualizer')
       .then((vis: any) => (VisualizerPlugin = vis.Visualizer))
       .then(createVisualizer);
   };

--- a/app/scripts/modules/core/tsconfig.json
+++ b/app/scripts/modules/core/tsconfig.json
@@ -9,12 +9,9 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "jsx": "react",
-    "lib": [
-      "es2016",
-      "dom"
-    ],
+    "lib": ["es2016", "dom"],
     "moduleResolution": "node",
-    "module": "commonjs",
+    "module": "esnext",
     "noEmitHelpers": false,
     "noImplicitAny": true,
     "noImplicitReturns": true,
@@ -30,21 +27,13 @@
     "inlineSources": true,
     "strictNullChecks": false, // should really get to a place where we can turn this on
     "target": "es6",
-    "typeRoots": [
-      "../../../../node_modules/@types"
-    ],
+    "typeRoots": ["../../../../node_modules/@types"],
     "paths": {
       "@spinnaker/core": ["."],
       "core/*": ["*"],
       "core": ["."]
     }
   },
-  "include": [
-    "src/**/*.ts",
-    "src/**/*.tsx"
-  ],
-  "exclude": [
-    "./lib",
-    "**/*.spec.*"
-  ]
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["./lib", "**/*.spec.*"]
 }

--- a/app/scripts/modules/docker/tsconfig.json
+++ b/app/scripts/modules/docker/tsconfig.json
@@ -11,7 +11,7 @@
     "jsx": "react",
     "lib": ["es2016", "dom"],
     "moduleResolution": "node",
-    "module": "commonjs",
+    "module": "esnext",
     "noEmitHelpers": false,
     "noImplicitAny": true,
     "noImplicitReturns": true,

--- a/app/scripts/modules/ecs/tsconfig.json
+++ b/app/scripts/modules/ecs/tsconfig.json
@@ -11,7 +11,7 @@
     "jsx": "react",
     "lib": ["es2016", "dom"],
     "moduleResolution": "node",
-    "module": "commonjs",
+    "module": "esnext",
     "noEmitHelpers": false,
     "noImplicitAny": true,
     "noImplicitReturns": true,

--- a/app/scripts/modules/google/tsconfig.json
+++ b/app/scripts/modules/google/tsconfig.json
@@ -11,7 +11,7 @@
     "jsx": "react",
     "lib": ["es2016", "dom"],
     "moduleResolution": "node",
-    "module": "commonjs",
+    "module": "esnext",
     "noEmitHelpers": false,
     "noImplicitAny": true,
     "noImplicitReturns": true,

--- a/app/scripts/modules/kubernetes/tsconfig.json
+++ b/app/scripts/modules/kubernetes/tsconfig.json
@@ -11,7 +11,7 @@
     "jsx": "react",
     "lib": ["es2017", "dom"],
     "moduleResolution": "node",
-    "module": "commonjs",
+    "module": "esnext",
     "noEmitHelpers": false,
     "noImplicitAny": true,
     "noImplicitReturns": true,

--- a/app/scripts/modules/openstack/tsconfig.json
+++ b/app/scripts/modules/openstack/tsconfig.json
@@ -11,7 +11,7 @@
     "jsx": "react",
     "lib": ["es2016", "dom"],
     "moduleResolution": "node",
-    "module": "commonjs",
+    "module": "esnext",
     "noEmitHelpers": false,
     "noImplicitAny": true,
     "noImplicitReturns": true,

--- a/app/scripts/modules/oracle/tsconfig.json
+++ b/app/scripts/modules/oracle/tsconfig.json
@@ -11,7 +11,7 @@
     "jsx": "react",
     "lib": ["es2016", "dom"],
     "moduleResolution": "node",
-    "module": "commonjs",
+    "module": "esnext",
     "noEmitHelpers": false,
     "noImplicitAny": true,
     "noImplicitReturns": true,

--- a/app/scripts/modules/titus/tsconfig.json
+++ b/app/scripts/modules/titus/tsconfig.json
@@ -11,7 +11,7 @@
     "jsx": "react",
     "lib": ["es2016", "dom"],
     "moduleResolution": "node",
-    "module": "commonjs",
+    "module": "esnext",
     "noEmitHelpers": false,
     "noImplicitAny": true,
     "noImplicitReturns": true,

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,7 +1,7 @@
 {
-    "purpose": "This file is used to support Microsoft Visual Studio Code users. See http://blogs.msdn.com/b/vscode/archive/2015/07/06/vs-code-es6.aspx for more details.",
-    "compilerOptions": {
-        "target": "ES6",
-        "module": "commonjs"
-    }
+  "purpose": "This file is used to support Microsoft Visual Studio Code users. See http://blogs.msdn.com/b/vscode/archive/2015/07/06/vs-code-es6.aspx for more details.",
+  "compilerOptions": {
+    "target": "ES6",
+    "module": "esnext"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@types/react-tether": "^0.5.3",
     "@uirouter/react-hybrid": "0.3.9",
     "@uirouter/rx": "0.4.5",
-    "@uirouter/visualizer": "6.0.2",
+    "@uirouter/visualizer": "^7.0.0",
     "Select2": "git://github.com/select2/select2.git#3.4.8",
     "angular": "1.6.10",
     "angular-cron-gen": "0.0.21",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "jsx": "react",
     "lib": ["es2017", "dom"],
     "moduleResolution": "node",
-    "module": "commonjs",
+    "module": "esnext",
     "noEmitHelpers": false,
     "noImplicitAny": true,
     "noImplicitReturns": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -730,15 +730,14 @@
     rollup-plugin-uglify "^1.0.2"
     rollup-plugin-visualizer "^0.2.1"
 
-"@uirouter/visualizer@6.0.2":
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/@uirouter/visualizer/-/visualizer-6.0.2.tgz#88813ba534d1f33674d90c2a5627a88f06c8f0c7"
-  integrity sha512-eeWF2rr5aIEW446LjOIYmU3CuVayuwYFJNxk8anr4NLfKSUy6qPhH6j5lpA59h9GhsDthRoGhHOTqlqftyYjcw==
+"@uirouter/visualizer@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@uirouter/visualizer/-/visualizer-7.0.0.tgz#84a728c5d082b5e2bde0c9e67d5e4b213fdb90f2"
+  integrity sha512-2XoZ3Xlj9ax/XF/gUgVLilA8q24M0WUVSJamr1kvBdcSQ1QDxWV162+NmGY9y92oVugxCIba7RZhn2x9GhKseA==
   dependencies:
-    d3-hierarchy "^1.1.6"
-    d3-interpolate "^1.2.0"
-    file-loader "^1.1.11"
-    preact "^8.2.9"
+    d3-hierarchy "^1.1.8"
+    d3-interpolate "^1.3.2"
+    preact "~8.4.2"
 
 "JSV@>= 4.0.x":
   version "4.0.2"
@@ -4455,10 +4454,10 @@ d3-hierarchy@^1.0.3:
   resolved "https://registry.yarnpkg.com/d3-hierarchy/-/d3-hierarchy-1.1.5.tgz#a1c845c42f84a206bcf1c01c01098ea4ddaa7a26"
   integrity sha1-ochFxC+Eoga88cAcAQmOpN2qeiY=
 
-d3-hierarchy@^1.1.6:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/d3-hierarchy/-/d3-hierarchy-1.1.6.tgz#842c1372090f870b7ea013ebae5c0c8d9f56229c"
-  integrity sha512-nn4bhBnwWnMSoZgkBXD7vRyZ0xVUsNMQRKytWYHhP1I4qHw+qzApCTgSQTZqMdf4XXZbTMqA59hFusga+THA/g==
+d3-hierarchy@^1.1.8:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/d3-hierarchy/-/d3-hierarchy-1.1.8.tgz#7a6317bd3ed24e324641b6f1e76e978836b008cc"
+  integrity sha512-L+GHMSZNwTpiq4rt9GEsNcpLa4M96lXMR8M/nMG9p5hBE0jy6C+3hWtyZMenPQdwla249iJy7Nx0uKt3n+u9+w==
 
 d3-interpolate@1:
   version "1.1.4"
@@ -4474,10 +4473,10 @@ d3-interpolate@^1.1.3:
   dependencies:
     d3-color "1"
 
-d3-interpolate@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-1.2.0.tgz#40d81bd8e959ff021c5ea7545bc79b8d22331c41"
-  integrity sha512-zLvTk8CREPFfc/2XglPQriAsXkzoRDAyBzndtKJWrZmHw7kmOWHNS11e40kPTd/oGk8P5mFJW5uBbcFQ+ybxyA==
+d3-interpolate@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-1.3.2.tgz#417d3ebdeb4bc4efcc8fd4361c55e4040211fd68"
+  integrity sha512-NlNKGopqaz9qM1PXh9gBF1KSCVh+jSFErrSlD/4hybwoNX/gt1d8CDbDW+3i+5UOHhjC6s6nMvRxcuoMVNgL2w==
   dependencies:
     d3-color "1"
 
@@ -12590,10 +12589,10 @@ preact@^7.2.0:
   resolved "https://registry.yarnpkg.com/preact/-/preact-7.2.1.tgz#159e1892f614985e49eb0a96fd6e6d8bdf8bbcc5"
   integrity sha1-FZ4YkvYUmF5J6wqW/W5ti9+LvMU=
 
-preact@^8.2.9:
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/preact/-/preact-8.3.0.tgz#eef16418bc351a44015b62c447722132ce5c36eb"
-  integrity sha512-yhP68bOZMWaNjfKig0xeL59H9TRShxCoLEUVnvKXfSqLK67EDYev7GVgAhKHmATK/HpnGw6SjSooVvEJgeAUDQ==
+preact@~8.4.2:
+  version "8.4.2"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-8.4.2.tgz#1263b974a17d1ea80b66590e41ef786ced5d6a23"
+  integrity sha512-TsINETWiisfB6RTk0wh3/mvxbGRvx+ljeBccZ4Z6MPFKgu/KFGyf2Bmw3Z/jlXhL5JlNKY6QAbA9PVyzIy9//A==
 
 prelude-ls@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
This was two full days of yak shaving just to remove the `System.` from `System.import()` 🙄 