### PR TITLE
fix(*): Remove all self closing tags in AngularJS templates

### DIFF
--- a/app/scripts/modules/amazon/src/loadBalancer/details/loadBalancerDetails.html
+++ b/app/scripts/modules/amazon/src/loadBalancer/details/loadBalancerDetails.html
@@ -20,7 +20,7 @@
       </a>
     </div>
     <div class="header-text horizontal middle">
-      <i class="fa icon-sitemap"/>
+      <i class="fa icon-sitemap"></i>
       <h3 class="horizontal middle space-between flex-1" select-on-dbl-click>
         {{ctrl.loadBalancer.name}}
         <render-if-feature feature="entityTags">
@@ -149,7 +149,7 @@
             <div ng-repeat="action in listener.actions">
               <!-- authenticate-oidc -->
               <span ng-if="action.type === 'authenticate-oidc'">
-                <i class="fas fa-fw fa-user-lock"/>
+                <i class="fas fa-fw fa-user-lock"></i>
                 <a ng-if="ctrl.oidcConfigPath"
                   href="{{ctrl.oidcConfigPath}}{{action.authenticateOidcConfig.clientId}}" target="_blank">
                   {{action.authenticateOidcConfig.clientId}}
@@ -160,7 +160,7 @@
               </span>
               <!-- forward -->
               <span ng-if="action.targetGroupName && action.targetGroup">
-                <i class="fa fa-fw fa-crosshairs icon" aria-hidden="true"/>
+                <i class="fa fa-fw fa-crosshairs icon" aria-hidden="true"></i>
                 <a ui-sref="^.targetGroupDetails({region: action.targetGroup.region,
                               loadBalancerName: ctrl.loadBalancer.name,
                               accountId: action.targetGroup.account,
@@ -171,7 +171,7 @@
                 </a>
               </span>
               <span ng-if="action.targetGroupName && !action.targetGroup">
-                <i class="fa fa-fw fa-crosshairs icon" aria-hidden="true"/>
+                <i class="fa fa-fw fa-crosshairs icon" aria-hidden="true"></i>
                 {{action.targetGroupName}}
               </span>
             </div>

--- a/app/scripts/modules/amazon/src/securityGroup/configure/createSecurityGroupIngress.html
+++ b/app/scripts/modules/amazon/src/securityGroup/configure/createSecurityGroupIngress.html
@@ -4,7 +4,7 @@
         <div class="col-md-12" ng-if="state.removedRules.length">
           <div class="alert alert-warning">
             <p><i class="fa fa-exclamation-triangle"></i>
-              The following <firewall-label label="firewalls"/> could not be found in the selected account/region/VPC and were removed:
+              The following <firewall-label label="firewalls"></firewall-label> could not be found in the selected account/region/VPC and were removed:
             </p>
             <ul>
               <li ng-repeat="securityGroup in state.removedRules">{{securityGroup}}</li>
@@ -27,7 +27,7 @@
           <table class="table table-condensed packed">
             <thead>
             <tr>
-              <th style="width: 50%"><firewall-label label="Firewall"/></th>
+              <th style="width: 50%"><firewall-label label="Firewall"></firewall-label></th>
               <th style="width: 15%">Protocol</th>
               <th style="width: 15%">Start Port</th>
               <th style="width: 15%">End Port</th>
@@ -60,7 +60,7 @@
             <tr>
               <td colspan="5">
                 <button class="add-new col-md-12" ng-click="ctrl.addRule(securityGroup.securityGroupIngress)"><span
-                  class="glyphicon glyphicon-plus-sign"></span> Add new <firewall-label label="Firewall"/> Rule
+                  class="glyphicon glyphicon-plus-sign"></span> Add new <firewall-label label="Firewall"></firewall-label> Rule
                 </button>
               </td>
             </tr>
@@ -73,11 +73,11 @@
         <div class="col-md-12">
           <p>
             <span ng-if="state.refreshingSecurityGroups"><span class="fa fa-sync-alt fa-spin"></span></span>
-            <firewall-label label="Firewalls"/>
+            <firewall-label label="Firewalls"></firewall-label>
             <span ng-if="!state.refreshingSecurityGroups">last refreshed {{ state.refreshTime | timestamp }}</span>
             <span ng-if="state.refreshingSecurityGroups"> refreshing...</span>
           </p>
-          <p>If you're not finding a <firewall-label label="firewall"/> that was recently added,
+          <p>If you're not finding a <firewall-label label="firewall"></firewall-label> that was recently added,
             <a href ng-click="ctrl.refreshSecurityGroups()">click here</a> to refresh the list.
           </p>
         </div>

--- a/app/scripts/modules/amazon/src/securityGroup/configure/createSecurityGroupProperties.html
+++ b/app/scripts/modules/amazon/src/securityGroup/configure/createSecurityGroupProperties.html
@@ -2,7 +2,7 @@
     <div class="modal-body">
       <div class="form-group">
         <div class="col-md-12 well" ng-class="{'alert-danger': form.securityGroupName.$error.validateUnique, 'alert-info': !form.securityGroupName.$error.validateUnique}">
-          <strong>Your <firewall-label label="firewall"/> will be named:</strong>
+          <strong>Your <firewall-label label="firewall"></firewall-label> will be named:</strong>
           <span ng-bind="namePreview"></span>
           <help-field key="aws.securityGroup.name"></help-field>
           <input type="hidden" class="form-control input-sm"

--- a/app/scripts/modules/amazon/src/securityGroup/details/securityGroupDetail.html
+++ b/app/scripts/modules/amazon/src/securityGroup/details/securityGroupDetail.html
@@ -1,5 +1,5 @@
 <div class="text-center" ng-if="state.notFound">
-  <h3>Could not find <firewall-label label="firewall"/> {{group}}.</h3>
+  <h3>Could not find <firewall-label label="firewall"></firewall-label> {{group}}.</h3>
   <a ui-sref="home.infrastructure">Back to search results</a>
 </div>
 <div class="details-panel" ng-if="!state.notFound">
@@ -35,12 +35,12 @@
     <div class="actions">
       <div class="dropdown" uib-dropdown dropdown-append-to-body>
         <button type="button" class="btn btn-sm btn-primary dropdown-toggle" ng-disabled="disabled" uib-dropdown-toggle>
-          <firewall-label label="Firewall"/> Actions <span class="caret"></span>
+          <firewall-label label="Firewall"></firewall-label> Actions <span class="caret"></span>
         </button>
         <ul class="dropdown-menu" uib-dropdown-menu role="menu">
           <li><a href ng-click="ctrl.editInboundRules()">Edit Inbound Rules</a></li>
-          <li><a href ng-click="ctrl.deleteSecurityGroup()">Delete <firewall-label label="Firewall"/></a></li>
-          <li><a href ng-click="ctrl.cloneSecurityGroup()">Clone <firewall-label label="Firewall"/></a></li>
+          <li><a href ng-click="ctrl.deleteSecurityGroup()">Delete <firewall-label label="Firewall"></firewall-label></a></li>
+          <li><a href ng-click="ctrl.cloneSecurityGroup()">Clone <firewall-label label="Firewall"></firewall-label></a></li>
           <render-if-feature feature="entityTags">
             <add-entity-tag-links component="securityGroup"
                                   application="ctrl.application"
@@ -90,7 +90,7 @@
 
       <dl ng-class="insightCtrl.vm.filtersExpanded ? '' : 'dl-horizontal dl-medium'"
           ng-repeat="rule in securityGroupRules | orderBy: 'securityGroup.name' ">
-        <dt><firewall-label label="Firewall"/></dt>
+        <dt><firewall-label label="Firewall"></firewall-label></dt>
         <dd ng-if="rule.securityGroup.name">
           <a ui-sref="^.firewallDetails({name: rule.securityGroup.name, accountId: rule.securityGroup.accountName, region: rule.securityGroup.region, vpcId: rule.securityGroup.vpcId, provider: 'aws'})">
             <account-tag account="rule.securityGroup.accountName || rule.securityGroup.accountId" ng-if="rule.securityGroup.accountName !== securityGroup.accountName"></account-tag>

--- a/app/scripts/modules/amazon/src/serverGroup/details/securityGroup/editSecurityGroups.modal.html
+++ b/app/scripts/modules/amazon/src/serverGroup/details/securityGroup/editSecurityGroups.modal.html
@@ -3,7 +3,7 @@
   <form role="form" name="form">
     <modal-close dismiss="$dismiss()"></modal-close>
     <div class="modal-header">
-      <h3>Edit <firewall-label label="Firewalls"/> for {{$ctrl.serverGroup.name}}</h3>
+      <h3>Edit <firewall-label label="Firewalls"></firewall-label> for {{$ctrl.serverGroup.name}}</h3>
     </div>
     <div class="modal-body container-fluid form-horizontal">
       <div class="form-group">

--- a/app/scripts/modules/appengine/src/helpContents/appengineHelpContents.ts
+++ b/app/scripts/modules/appengine/src/helpContents/appengineHelpContents.ts
@@ -9,7 +9,7 @@ const helpContents = [
   {
     key: 'appengine.serverGroup.git.repositoryUrl',
     value: `The full URL to the git repository containing the source files for this deployment,
-              including protocol. For example, <b>https://github.com/spinnaker/deck.git<b/>`,
+              including protocol. For example, <b>https://github.com/spinnaker/deck.git</b>`,
   },
   {
     key: 'appengine.serverGroup.gitCredentialType',

--- a/app/scripts/modules/appengine/src/loadBalancer/details/details.html
+++ b/app/scripts/modules/appengine/src/loadBalancer/details/details.html
@@ -19,7 +19,7 @@
       </a>
     </div>
     <div class="header-text horizontal middle">
-      <i class="fa icon-sitemap"/>
+      <i class="fa icon-sitemap"></i>
       <h3 class="horizontal middle space-between flex-1" select-on-dbl-click>
         {{ctrl.loadBalancer.name}}
       </h3>

--- a/app/scripts/modules/azure/loadBalancer/configure/healthCheck.html
+++ b/app/scripts/modules/azure/loadBalancer/configure/healthCheck.html
@@ -35,7 +35,7 @@
       <div class="form-group">
         <div class="col-md-6 sm-label-right">
           <b>Interval</b>
-          <help-field key="loadBalancer.probes.probeInterval" />
+          <help-field key="loadBalancer.probes.probeInterval"></help-field>
         </div>
         <div class="col-md-4">
           <input class="form-control input-sm" type="number" min="0" ng-model="loadBalancer.probes[0].probeInterval" />
@@ -44,7 +44,7 @@
       <div class="form-group">
         <div class="col-md-6 sm-label-right">
           <b>Unhealthy Threshold</b>
-          <help-field key="loadBalancer.probes.unhealthyThreshold" />
+          <help-field key="loadBalancer.probes.unhealthyThreshold"></help-field>
         </div>
         <div class="col-md-4">
           <input class="form-control input-sm" type="number" min="0" ng-model="loadBalancer.probes[0].unhealthyThreshold" />
@@ -53,7 +53,7 @@
       <div class="form-group">
         <div class="col-md-6 sm-label-right">
           <b>Timeout</b>
-          <help-field key="loadBalancer.probes.timeout" />
+          <help-field key="loadBalancer.probes.timeout"></help-field>
         </div>
         <div class="col-md-4">
           <input class="form-control input-sm" type="number" min="0" ng-model="loadBalancer.probes[0].timeout" />

--- a/app/scripts/modules/azure/loadBalancer/details/loadBalancerDetail.html
+++ b/app/scripts/modules/azure/loadBalancer/details/loadBalancerDetail.html
@@ -20,7 +20,7 @@
       </a>
     </div>
     <div class="header-text horizontal middle">
-      <i class="fa icon-sitemap"/>
+      <i class="fa icon-sitemap"></i>
       <h3 class="horizontal middle space-between flex-1" select-on-dbl-click>
         {{loadBalancer.name}}
       </h3>

--- a/app/scripts/modules/azure/securityGroup/configure/createSecurityGroupIngress.html
+++ b/app/scripts/modules/azure/securityGroup/configure/createSecurityGroupIngress.html
@@ -49,7 +49,7 @@
   <div class="form-group small" style="margin-top: 20px">
     <div class="col-md-12">
       <button class="add-new col-md-12" ng-click="ctrl.addRule(securityGroup.securityRules)"><span
-        class="glyphicon glyphicon-plus-sign"></span> Add new <firewall-label label="Firewall"/> Rule
+        class="glyphicon glyphicon-plus-sign"></span> Add new <firewall-label label="Firewall"></firewall-label> Rule
       </button>
     </div>
   </div>

--- a/app/scripts/modules/azure/securityGroup/configure/createSecurityGroupProperties.html
+++ b/app/scripts/modules/azure/securityGroup/configure/createSecurityGroupProperties.html
@@ -1,7 +1,7 @@
 <div class="modal-body">
   <div class="form-group">
     <div class="col-md-12 well" ng-class="{'alert-danger': form.securityGroupName.$error.validateUnique, 'alert-info': !form.securityGroupName.$error.validateUnique}">
-      <strong>Your <firewall-label label="firewall"/> will be named:</strong>
+      <strong>Your <firewall-label label="firewall"></firewall-label> will be named:</strong>
       <span ng-bind="namePreview"></span>
     </div>
   </div>

--- a/app/scripts/modules/azure/securityGroup/details/securityGroupDetail.html
+++ b/app/scripts/modules/azure/securityGroup/details/securityGroupDetail.html
@@ -18,12 +18,12 @@
     <div class="actions">
       <div class="dropdown" uib-dropdown dropdown-append-to-body>
         <button type="button" class="btn btn-sm btn-primary dropdown-toggle" ng-disabled="disabled" uib-dropdown-toggle>
-          <firewall-label label="Firewall"/> Actions <span class="caret"></span>
+          <firewall-label label="Firewall"></firewall-label> Actions <span class="caret"></span>
         </button>
         <ul class="dropdown-menu" uib-dropdown-menu role="menu">
-          <li><a href ng-click="ctrl.deleteSecurityGroup()">Delete <firewall-label label="Firewall"/></a></li>
+          <li><a href ng-click="ctrl.deleteSecurityGroup()">Delete <firewall-label label="Firewall"></firewall-label></a></li>
           <li><a href ng-click="ctrl.editInboundRules()">Edit Inbound Rules</a></li>
-          <li><a href ng-click="ctrl.cloneSecurityGroup()">Clone <firewall-label label="Firewall"/></a></li>
+          <li><a href ng-click="ctrl.cloneSecurityGroup()">Clone <firewall-label label="Firewall"></firewall-label></a></li>
         </ul>
       </div>
     </div>

--- a/app/scripts/modules/azure/serverGroup/configure/wizard/advancedSettings/advancedSettingsSelector.directive.html
+++ b/app/scripts/modules/azure/serverGroup/configure/wizard/advancedSettings/advancedSettingsSelector.directive.html
@@ -8,14 +8,14 @@
     <div class="form-group">
       <div class="col-xs-4 sm-label-right">
         <b>Custom Data</b>
-        <help-field key="azure.serverGroup.customData" />
+        <help-field key="azure.serverGroup.customData"></help-field>
       </div>
       <div class="col-md-7"><input type="text" class="form-control input-sm" ng-model="adv.command.osConfig.customData" /></div>
     </div>
     <div class="form-group">
       <div class="col-md-4 sm-label-right">
         <b>Custom Script</b>
-        <help-field key="azure.serverGroup.scriptLocation" />
+        <help-field key="azure.serverGroup.scriptLocation"></help-field>
       </div>
       <div class="col-md-7">
         <input type="text" class="form-control input-sm" ng-model="adv.command.customScriptsSettings.fileUris" />
@@ -24,7 +24,7 @@
     <div class="form-group">
       <div class="col-md-4 sm-label-right">
         <b>Command To Execute</b>
-        <help-field key="azure.serverGroup.commandToExecute" />
+        <help-field key="azure.serverGroup.commandToExecute"></help-field>
       </div>
       <div class="col-md-7">
         <input type="text" class="form-control input-sm" ng-model="adv.command.customScriptsSettings.commandToExecute" />

--- a/app/scripts/modules/azure/serverGroup/configure/wizard/securityGroup/serverGroupSecurityGroupsSelector.directive.html
+++ b/app/scripts/modules/azure/serverGroup/configure/wizard/securityGroup/serverGroupSecurityGroupsSelector.directive.html
@@ -1,7 +1,7 @@
 <h5 class="text-center" ng-if="!command.viewState.securityGroupsConfigured">Please select an account and region.</h5>
 <div ng-if="command.viewState.securityGroupsConfigured"  ng-controller="azureServerGroupSecurityGroupsCtrl as securityGroupCtrl">
   <div class="form-group">
-    <div class="col-md-3 sm-label-right"><b><firewall-label label="Firewalls"/></b></div>
+    <div class="col-md-3 sm-label-right"><b><firewall-label label="Firewalls"></firewall-label></b></div>
     <div class="col-md-7">
       <ui-select ng-model="command.selectedSecurityGroup" class="form-control input-sm" on-select="securityGroupCtrl.securityGroupChanged($item)">
         <ui-select-match placeholder="select a {{firewallLabel}}">{{$select.selected.id}}</ui-select-match>
@@ -16,11 +16,11 @@
     <div class="col-md-9 col-md-offset-3">
       <p>
         <span ng-if="refreshing"><span class="fa fa-sync-alt fa-spin"></span></span>
-        <firewall-label label="Firewalls"/>
+        <firewall-label label="Firewalls"></firewall-label>
         <span ng-if="!refreshing">last refreshed {{ getSecurityGroupRefreshTime() | timestamp }}</span>
         <span ng-if="refreshing"> refreshing...</span>
       </p>
-      <p>If you're not finding a <firewall-label label="firewall"/> that was recently added,
+      <p>If you're not finding a <firewall-label label="firewall"></firewall-label> that was recently added,
         <a href ng-click="refreshSecurityGroups()">click here</a> to refresh the list.
       </p>
     </div>

--- a/app/scripts/modules/cloudfoundry/src/instance/details/cloudFoundryInstanceDetails.html
+++ b/app/scripts/modules/cloudfoundry/src/instance/details/cloudFoundryInstanceDetails.html
@@ -5,4 +5,4 @@
   instance-id-not-found="instanceIdNotFound"
   instance-writer="instanceWriter"
   loading="loading"
-  ng-style="{ display: 'flex', width: '100%' }"/>
+  ng-style="{ display: 'flex', width: '100%' }"></cf-instance-details>

--- a/app/scripts/modules/cloudfoundry/src/loadBalancer/details/cloudFoundryLoadBalancerDetails.html
+++ b/app/scripts/modules/cloudfoundry/src/loadBalancer/details/cloudFoundryLoadBalancerDetails.html
@@ -4,4 +4,4 @@
   load-balancer="loadBalancer"
   load-balancer-not-found="loadBalancerNotFound"
   loading="loading"
-  ng-style="{ display: 'flex', width: '100%' }"/>
+  ng-style="{ display: 'flex', width: '100%' }"></cf-load-balancer-details>

--- a/app/scripts/modules/cloudfoundry/src/pipeline/stages/deployService/cloudfoundryDeployServiceStage.html
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/stages/deployService/cloudfoundryDeployServiceStage.html
@@ -1,1 +1,1 @@
-<cf-deploy-service-stage stage="stage" stage-field-updated="stageFieldUpdated" />
+<cf-deploy-service-stage stage="stage" stage-field-updated="stageFieldUpdated"></cf-deploy-service-stage>

--- a/app/scripts/modules/cloudfoundry/src/pipeline/stages/destroyAsg/cloudfoundryDestroyAsgStage.html
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/stages/destroyAsg/cloudfoundryDestroyAsgStage.html
@@ -1,1 +1,1 @@
-<cf-destroy-asg-stage application="application" pipeline="pipeline" stage="stage" stage-field-updated="stageFieldUpdated" />
+<cf-destroy-asg-stage application="application" pipeline="pipeline" stage="stage" stage-field-updated="stageFieldUpdated"></cf-destroy-asg-stage>

--- a/app/scripts/modules/cloudfoundry/src/pipeline/stages/destroyService/cloudfoundryDestroyServiceStage.html
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/stages/destroyService/cloudfoundryDestroyServiceStage.html
@@ -1,1 +1,1 @@
-<cf-destroy-service-stage stage="stage" stage-field-updated="stageFieldUpdated" />
+<cf-destroy-service-stage stage="stage" stage-field-updated="stageFieldUpdated"></cf-destroy-service-stage>

--- a/app/scripts/modules/cloudfoundry/src/pipeline/stages/disableAsg/cloudfoundryDisableAsgStage.html
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/stages/disableAsg/cloudfoundryDisableAsgStage.html
@@ -1,1 +1,1 @@
-<cf-disable-asg-stage application="application" pipeline="pipeline" stage="stage" stage-field-updated="stageFieldUpdated" />
+<cf-disable-asg-stage application="application" pipeline="pipeline" stage="stage" stage-field-updated="stageFieldUpdated"></cf-disable-asg-stage>

--- a/app/scripts/modules/cloudfoundry/src/pipeline/stages/enableAsg/cloudfoundryEnableAsgStage.html
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/stages/enableAsg/cloudfoundryEnableAsgStage.html
@@ -1,1 +1,1 @@
-<cf-enable-asg-stage application="application" pipeline="pipeline" stage="stage" stage-field-updated="stageFieldUpdated" />
+<cf-enable-asg-stage application="application" pipeline="pipeline" stage="stage" stage-field-updated="stageFieldUpdated"></cf-enable-asg-stage>

--- a/app/scripts/modules/cloudfoundry/src/pipeline/stages/resizeAsg/cloudfoundryResizeAsgStage.html
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/stages/resizeAsg/cloudfoundryResizeAsgStage.html
@@ -1,1 +1,1 @@
-<cf-resize-asg-stage application="application" pipeline="pipeline" stage="stage" stage-field-updated="stageFieldUpdated" />
+<cf-resize-asg-stage application="application" pipeline="pipeline" stage="stage" stage-field-updated="stageFieldUpdated"></cf-resize-asg-stage>

--- a/app/scripts/modules/cloudfoundry/src/pipeline/stages/rollbackCluster/cloudfoundryRollbackClusterStage.html
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/stages/rollbackCluster/cloudfoundryRollbackClusterStage.html
@@ -1,1 +1,1 @@
-<cf-rollback-cluster-stage application="application" pipeline="pipeline" stage="stage" stage-field-updated="stageFieldUpdated" />
+<cf-rollback-cluster-stage application="application" pipeline="pipeline" stage="stage" stage-field-updated="stageFieldUpdated"></cf-rollback-cluster-stage>

--- a/app/scripts/modules/core/src/application/config/applicationCacheManagement.directive.html
+++ b/app/scripts/modules/core/src/application/config/applicationCacheManagement.directive.html
@@ -29,7 +29,7 @@
   </div>
 </div>
 <div class="row" ng-if="vm.hasCache('securityGroups')">
-  <div class="col-md-3 col-md-offset-1"><firewall-label label="Firewalls"/></div>
+  <div class="col-md-3 col-md-offset-1"><firewall-label label="Firewalls"></firewall-label></div>
   <div class="col-md-3">{{vm.getCacheInfo('securityGroups').ageMax | timestamp}}</div>
   <div class="col-md-1 text-center">
     <a href ng-click="vm.refreshCache('securityGroups')">

--- a/app/scripts/modules/core/src/application/config/applicationNotifications.directive.html
+++ b/app/scripts/modules/core/src/application/config/applicationNotifications.directive.html
@@ -1,2 +1,2 @@
 <p>You can edit notification settings for this application</p>
-<notification-list notifications="vm.notifications" level="application" application="vm.application.name"/>
+<notification-list notifications="vm.notifications" level="application" application="vm.application.name"></notification-list>

--- a/app/scripts/modules/core/src/application/config/deleteApplicationSection.directive.html
+++ b/app/scripts/modules/core/src/application/config/deleteApplicationSection.directive.html
@@ -1,6 +1,6 @@
 <p ng-if="!vm.hasServerGroups">
   Deleting the application only removes the associated metadata around the application.
-  It will <strong>not</strong> delete any <firewall-label label="firewalls"/>, load balancers, or pipeline configurations you
+  It will <strong>not</strong> delete any <firewall-label label="firewalls"></firewall-label>, load balancers, or pipeline configurations you
   may have created.
 </p>
 

--- a/app/scripts/modules/core/src/cluster/filter/clusterFilter.component.html
+++ b/app/scripts/modules/core/src/cluster/filter/clusterFilter.component.html
@@ -163,8 +163,7 @@
       <label-filter
         labels-map="$ctrl.labelsMap"
         label-filters="$ctrl.labelFilters"
-        update-label-filters="$ctrl.onLabelFiltersChange"
-      />
+        update-label-filters="$ctrl.onLabelFiltersChange"></label-filter>
     </filter-section>
 
   </div>

--- a/app/scripts/modules/core/src/pipeline/config/stages/bake/bakeStageChooseOs.component.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/bake/bakeStageChooseOs.component.html
@@ -12,5 +12,5 @@
   <input type="radio"
          ng-model="$ctrl.model"
          ng-value="baseOsOption.id"/>
-  {{$ctrl.getBaseOsDescription(baseOsOption)}} <help-field content="{{$ctrl.getBaseOsDetailedDescription(baseOsOption)}}" />
+  {{$ctrl.getBaseOsDescription(baseOsOption)}} <help-field content="{{$ctrl.getBaseOsDetailedDescription(baseOsOption)}}"></help-field>
 </label>

--- a/app/scripts/modules/core/src/pipeline/config/stages/core/stageConfigField/stageConfigField.directive.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/core/stageConfigField/stageConfigField.directive.html
@@ -1,9 +1,9 @@
 <div class="form-group">
   <label class="col-md-3 sm-label-right">
-    <span class="label-text" ng-bind="vm.label"/>
-    <help-field key="{{vm.helpKey}}" expand="vm.helpKeyExpand"/>
+    <span class="label-text" ng-bind="vm.label"></span>
+    <help-field key="{{vm.helpKey}}" expand="vm.helpKeyExpand"></help-field>
   </label>
   <div class="col-md-{{vm.fieldColumns}}">
-    <ng-transclude/>
+    <ng-transclude></ng-transclude>
   </div>
 </div>

--- a/app/scripts/modules/core/src/pipeline/config/stages/executionWindows/executionWindows.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/executionWindows/executionWindows.html
@@ -160,7 +160,7 @@
                 rows="4"
                 placeholder="Default text: '{{executionWindowsCtrl.defaultSkipWindowText}}' (HTML is okay)"
                 style="margin-top: 5px"
-                ng-model="stage.skipWindowText"/>
+                ng-model="stage.skipWindowText"></textarea>
     </div>
   </div>
 

--- a/app/scripts/modules/core/src/pipeline/config/stages/jenkins/jenkinsStage.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/jenkins/jenkinsStage.html
@@ -76,8 +76,8 @@
           <input ng-if="!useDefaultParameters[parameter.name]" type="checkbox" class="input-sm" ng-model="userSuppliedParameters[parameter.name]" ng-change="updateParam(parameter.name)"/>
         </div>
         <div ng-switch-when="TextParameterDefinition">
-          <textarea disabled ng-if="useDefaultParameters[parameter.name]" class="form-control input-sm" ng-model="parameter.defaultValue" style="max-width: 100%"/>
-          <textarea ng-if="!useDefaultParameters[parameter.name]" class="form-control input-sm" ng-model="userSuppliedParameters[parameter.name]" ng-change="updateParam(parameter.name)" style="max-width: 100%"/>
+          <textarea disabled ng-if="useDefaultParameters[parameter.name]" class="form-control input-sm" ng-model="parameter.defaultValue" style="max-width: 100%"></textarea>
+          <textarea ng-if="!useDefaultParameters[parameter.name]" class="form-control input-sm" ng-model="userSuppliedParameters[parameter.name]" ng-change="updateParam(parameter.name)" style="max-width: 100%"></textarea>
         </div>
         <div ng-switch-when="ChoiceParameterDefinition">
           <ui-select class="form-control input-sm" ng-if="!useDefaultParameters[parameter.name]" ng-model="userSuppliedParameters[parameter.name]">
@@ -125,7 +125,7 @@
                  ng-model="viewState.markUnstableAsSuccessful"
                  ng-change="jenkinsStageCtrl.markUnstableChanged()"
                  ng-value="false"/> fail the stage
-          <help-field key="pipeline.config.jenkins.markUnstableAsSuccessful.false"/>
+          <help-field key="pipeline.config.jenkins.markUnstableAsSuccessful.false"></help-field>
         </label>
       </div>
       <div class="radio">
@@ -134,7 +134,7 @@
                  ng-model="viewState.markUnstableAsSuccessful"
                  ng-change="jenkinsStageCtrl.markUnstableChanged()"
                  ng-value="true"/> consider stage successful
-          <help-field key="pipeline.config.jenkins.markUnstableAsSuccessful.true"/>
+          <help-field key="pipeline.config.jenkins.markUnstableAsSuccessful.true"></help-field>
         </label>
       </div>
 

--- a/app/scripts/modules/core/src/pipeline/config/stages/overrideFailure/overrideFailure.component.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/overrideFailure/overrideFailure.component.html
@@ -8,7 +8,7 @@
                ng-model="$ctrl.viewState.failureOption"
                ng-change="$ctrl.failureOptionChanged()"
                value="fail"/> halt the entire pipeline
-        <help-field key="pipeline.config.haltPipelineOnFailure"/>
+        <help-field key="pipeline.config.haltPipelineOnFailure"></help-field>
       </label>
     </div>
     <div class="radio">
@@ -18,7 +18,7 @@
                ng-model="$ctrl.viewState.failureOption"
                ng-change="$ctrl.failureOptionChanged()"
                value="stop"/> halt this branch of the pipeline
-        <help-field key="pipeline.config.haltBranchOnFailure"/>
+        <help-field key="pipeline.config.haltBranchOnFailure"></help-field>
       </label>
     </div>
     <div class="radio">
@@ -28,7 +28,7 @@
                ng-model="$ctrl.viewState.failureOption"
                ng-change="$ctrl.failureOptionChanged()"
                value="faileventual"/> halt this branch and fail the pipeline once other branches complete
-        <help-field key="pipeline.config.haltBranchOnFailureFailPipeline"/>
+        <help-field key="pipeline.config.haltBranchOnFailureFailPipeline"></help-field>
       </label>
     </div>
     <div class="radio">
@@ -38,7 +38,7 @@
                ng-model="$ctrl.viewState.failureOption"
                ng-change="$ctrl.failureOptionChanged()"
                value="ignore"/> ignore the failure
-        <help-field key="pipeline.config.ignoreFailure"/>
+        <help-field key="pipeline.config.ignoreFailure"></help-field>
       </label>
     </div>
   </div>

--- a/app/scripts/modules/core/src/pipeline/config/stages/script/scriptStage.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/script/scriptStage.html
@@ -17,7 +17,7 @@
   </stage-config-field>
   <stage-config-field label="Command" help-key="pipeline.config.script.command">
     <textarea class="form-control input-sm" required
-              ng-model="stage.command"/>
+              ng-model="stage.command"></textarea>
   </stage-config-field>
   <stage-config-field label="Output File" help-key="pipeline.config.script.propertyFile">
     <input type="text" class="form-control input-sm"

--- a/app/scripts/modules/core/src/pipeline/config/stages/travis/travisStage.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/travis/travisStage.html
@@ -109,7 +109,7 @@
                  ng-model="$ctrl.viewState.markUnstableAsSuccessful"
                  ng-change="$ctrl.markUnstableChanged()"
                  ng-value="false"/> fail the stage
-          <help-field key="pipeline.config.travis.markUnstableAsSuccessful.false"/>
+          <help-field key="pipeline.config.travis.markUnstableAsSuccessful.false"></help-field>
         </label>
       </div>
       <div class="radio">
@@ -118,7 +118,7 @@
                  ng-model="$ctrl.viewState.markUnstableAsSuccessful"
                  ng-change="$ctrl.markUnstableChanged()"
                  ng-value="true"/> consider stage successful
-          <help-field key="pipeline.config.travis.markUnstableAsSuccessful.true"/>
+          <help-field key="pipeline.config.travis.markUnstableAsSuccessful.true"></help-field>
         </label>
       </div>
     </div>

--- a/app/scripts/modules/core/src/pipeline/config/stages/webhook/webhookStage.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/webhook/webhookStage.html
@@ -34,7 +34,7 @@
     <textarea class="code form-control flex-fill"
               rows="5"
               ng-model="$ctrl.command.payloadJSON"
-              ng-change="$ctrl.updatePayload()"/>
+              ng-change="$ctrl.updatePayload()"></textarea>
 
       <div class="form-group row slide-in" ng-if="$ctrl.command.invalid">
         <div class="col-sm-9 col-sm-offset-3 error-message">

--- a/app/scripts/modules/core/src/pipeline/config/stages/wercker/werckerStage.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/wercker/werckerStage.html
@@ -24,7 +24,7 @@
       </a>
     </div>
   </div>
-  
+
   <div class="form-group">
     <label class="col-md-2 col-md-offset-1 sm-label-right">Application</label>
     <div class="col-md-6">
@@ -55,7 +55,7 @@
       </a>
     </div>
   </div>
-  
+
   <div class="form-group">
     <label class="col-md-2 col-md-offset-1 sm-label-right">Pipeline</label>
     <div class="col-md-6">
@@ -86,7 +86,7 @@
       </a>
     </div>
   </div>
- 
+
   <stage-config-field label="Wait for results" help-key="wercker.waitForCompletion">
     <input type="checkbox" class="input-sm" name="waitForCompletion"
            ng-model="$ctrl.viewState.waitForCompletion"
@@ -102,7 +102,7 @@
                  ng-model="$ctrl.viewState.markUnstableAsSuccessful"
                  ng-change="$ctrl.markUnstableChanged()"
                  ng-value="false"/> fail the stage
-          <help-field key="pipeline.config.wercker.markUnstableAsSuccessful.false"/>
+          <help-field key="pipeline.config.wercker.markUnstableAsSuccessful.false"></help-field>
         </label>
       </div>
       <div class="radio">
@@ -111,7 +111,7 @@
                  ng-model="$ctrl.viewState.markUnstableAsSuccessful"
                  ng-change="$ctrl.markUnstableChanged()"
                  ng-value="true"/> consider stage successful
-          <help-field key="pipeline.config.wercker.markUnstableAsSuccessful.true"/>
+          <help-field key="pipeline.config.wercker.markUnstableAsSuccessful.true"></help-field>
         </label>
       </div>
 

--- a/app/scripts/modules/core/src/pipeline/config/triggers/trigger.html
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/trigger.html
@@ -32,7 +32,7 @@
         <div class="form-group" ng-if="pipeline.expectedArtifacts.length">
           <div class="col-md-10">
             <div class="form-group">
-              <label class=" col-md-3 sm-label-right">Artifact Constraints<help-field key="pipeline.config.expectedArtifact"/></label>
+              <label class=" col-md-3 sm-label-right">Artifact Constraints<help-field key="pipeline.config.expectedArtifact"></help-field></label>
               <div class="col-md-9">
                 <ui-select ng-if="pipeline.expectedArtifacts.length"
                            multiple

--- a/app/scripts/modules/core/src/pipeline/manualExecution/manualPipelineExecution.html
+++ b/app/scripts/modules/core/src/pipeline/manualExecution/manualPipelineExecution.html
@@ -69,7 +69,7 @@
             </select>
           </div>
         </div>
-        <trigger-template component="vm.triggerComponent" command="vm.command"/>
+        <trigger-template component="vm.triggerComponent" command="vm.command"></trigger-template>
       </div>
 
       <div ng-if="vm.command.pipeline.parameterConfig !== undefined && vm.command.pipeline.parameterConfig.length">
@@ -126,7 +126,7 @@
         </div>
       </div>
 
-      <stage-manual-components ng-if="vm.stageComponents" command="vm.command" components="vm.stageComponents" />
+      <stage-manual-components ng-if="vm.stageComponents" command="vm.command" components="vm.stageComponents"></stage-manual-components>
 
       <div class="form-group">
         <label class="col-md-4 sm-label-right">Notifications</label>

--- a/app/scripts/modules/core/src/securityGroup/all.html
+++ b/app/scripts/modules/core/src/securityGroup/all.html
@@ -23,7 +23,7 @@
       <button class="btn btn-sm btn-default" ng-click="ctrl.createSecurityGroup()">
         <span class="glyphicon glyphicon-plus-sign visible-lg-inline"></span>
         <span class="glyphicon glyphicon-plus-sign visible-md-inline visible-sm-inline" uib-tooltip="Create {{firewallLabel}}"></span>
-        <span class="visible-lg-inline">Create <firewall-label label="Firewall"/></span>
+        <span class="visible-lg-inline">Create <firewall-label label="Firewall"></firewall-label></span>
       </button>
     </div>
   </div>

--- a/app/scripts/modules/core/src/securityGroup/groupings.html
+++ b/app/scripts/modules/core/src/securityGroup/groupings.html
@@ -6,7 +6,7 @@
                         parent-heading="group.heading"></security-group-pod>
   </div>
   <div ng-if="groups.length === 0">
-    <h4 class="text-center">No <firewall-label label="firewalls"/> match the filters you've selected.</h4>
+    <h4 class="text-center">No <firewall-label label="firewalls"></firewall-label> match the filters you've selected.</h4>
   </div>
 </div>
 <div ng-if="!ctrl.initialized" class="horizontal center spinner-container">

--- a/app/scripts/modules/core/src/securityGroup/securityGroup.html
+++ b/app/scripts/modules/core/src/securityGroup/securityGroup.html
@@ -42,7 +42,7 @@
             ui-sref-active="active"
             ng-click="$event.stopPropagation()"
         >
-          <i class="fa icon-sitemap"/> {{loadBalancer.name}}
+          <i class="fa icon-sitemap"></i> {{loadBalancer.name}}
         </a>
       </div>
     </div>

--- a/app/scripts/modules/dcos/help/dcos.help.ts
+++ b/app/scripts/modules/dcos/help/dcos.help.ts
@@ -2,7 +2,7 @@ import { HelpContentsRegistry } from '@spinnaker/core';
 
 const helpContents: { [key: string]: string } = {
   'dcos.loadBalancer.group':
-    '<p>(Optional) The DC/OS group under which the application should live.</p><p> It can be a hierarchical path, delimited by backslashes.<p/><p>This will often be referred to as <b>Region</b> in Spinnaker.</p>',
+    '<p>(Optional) The DC/OS group under which the application should live.</p><p> It can be a hierarchical path, delimited by backslashes.<p></p><p>This will often be referred to as <b>Region</b> in Spinnaker.</p>',
   'dcos.loadBalancer.cpus': '(Required) Amount of CPUs used for the load balancer (default: 2).',
   'dcos.loadBalancer.mem': '(Required) Amount of memory used for the load balancer (default: 1024).',
   'dcos.loadBalancer.instances': '(Required) Number of instances of the load balancer to be deployed (default: 1).',
@@ -23,7 +23,7 @@ const helpContents: { [key: string]: string } = {
   'dcos.serverGroup.region':
     '(Required) One of the core naming components of a cluster, used to create logical groupings with DCOS (using Marathon groups) of applications (default: "default").',
   'dcos.serverGroup.group':
-    '(Optional) The DC/OS group under which the application should live.<p> It can be a hierarchical path, delimited by backslashes.<p/>',
+    '(Optional) The DC/OS group under which the application should live.<p> It can be a hierarchical path, delimited by backslashes.</p>',
   'dcos.serverGroup.stack':
     '(Optional) One of the core naming components of a cluster, used to create vertical stacks of dependent services for integration testing.',
   'dcos.serverGroup.freeFormDetails':

--- a/app/scripts/modules/dcos/loadBalancer/details/details.html
+++ b/app/scripts/modules/dcos/loadBalancer/details/details.html
@@ -19,7 +19,7 @@
       </a>
     </div>
     <div class="header-text horizontal middle">
-      <i class="fa icon-sitemap"/>
+      <i class="fa icon-sitemap"></i>
       <h3 class="horizontal middle space-between flex-1" select-on-dbl-click>
         {{loadBalancer.name}}
       </h3>

--- a/app/scripts/modules/dcos/serverGroup/configure/wizard/optional.html
+++ b/app/scripts/modules/dcos/serverGroup/configure/wizard/optional.html
@@ -14,7 +14,7 @@
           Fetch URIs
           <help-field key="dcos.serverGroup.uris"></help-field>
         </div>
-        <div class="col-md-7"><textarea class="form-control input-sm" name="fetch" ng-model="command.viewModel.fetch" ng-pattern='ctrl.fetchPattern'/></div>
+        <div class="col-md-7"><textarea class="form-control input-sm" name="fetch" ng-model="command.viewModel.fetch" ng-pattern='ctrl.fetchPattern'></textarea></div>
       </div>
       <div class="form-group row slide-in" ng-if="optional.fetch.$error.pattern">
         <div class="col-sm-9 col-sm-offset-2 error-message">

--- a/app/scripts/modules/ecs/src/serverGroup/details/serverGroupDetails.html
+++ b/app/scripts/modules/ecs/src/serverGroup/details/serverGroupDetails.html
@@ -213,7 +213,7 @@
     <collapsible-section heading="Server Group Logs">
       <ul>
         <li>
-          <view-events-link server-group="ctrl.serverGroup" />
+          <view-events-link server-group="ctrl.serverGroup"></view-events-link>
         </li>
       </ul>
     </collapsible-section>

--- a/app/scripts/modules/google/src/loadBalancer/configure/common/healthCheck.component.html
+++ b/app/scripts/modules/google/src/loadBalancer/configure/common/healthCheck.component.html
@@ -92,7 +92,7 @@
 
     <div class="form-group">
       <div class="col-md-4 sm-label-right">
-        <b>Timeout</b><help-field key="loadBalancer.advancedSettings.healthTimeout"/>
+        <b>Timeout</b><help-field key="loadBalancer.advancedSettings.healthTimeout"></help-field>
       </div>
       <div class="col-md-4">
         <input class="form-control input-sm"
@@ -106,7 +106,7 @@
 
     <div class="form-group">
       <div class="col-md-4 sm-label-right">
-        <b>Interval</b><help-field key="gce.loadBalancer.advancedSettings.healthInterval"/>
+        <b>Interval</b><help-field key="gce.loadBalancer.advancedSettings.healthInterval"></help-field>
       </div>
       <div class="col-md-4">
         <input class="form-control input-sm"
@@ -120,7 +120,7 @@
 
     <div class="form-group">
       <div class="col-md-4 sm-label-right">
-        <b>Healthy Threshold</b><help-field key="gce.loadBalancer.advancedSettings.healthyThreshold"/>
+        <b>Healthy Threshold</b><help-field key="gce.loadBalancer.advancedSettings.healthyThreshold"></help-field>
       </div>
       <div class="col-md-4">
         <input class="form-control input-sm"
@@ -134,7 +134,7 @@
 
     <div class="form-group">
       <div class="col-md-4 sm-label-right">
-        <b>Unhealthy Threshold</b><help-field key="gce.loadBalancer.advancedSettings.unhealthyThreshold"/>
+        <b>Unhealthy Threshold</b><help-field key="gce.loadBalancer.advancedSettings.unhealthyThreshold"></help-field>
       </div>
       <div class="col-md-4">
         <input class="form-control input-sm"

--- a/app/scripts/modules/google/src/loadBalancer/configure/http/healthCheck/healthCheck.component.html
+++ b/app/scripts/modules/google/src/loadBalancer/configure/http/healthCheck/healthCheck.component.html
@@ -95,7 +95,7 @@
 
     <div class="form-group">
       <div class="col-md-4 sm-label-right">
-        <b>Timeout</b><help-field key="loadBalancer.advancedSettings.healthTimeout"/>
+        <b>Timeout</b><help-field key="loadBalancer.advancedSettings.healthTimeout"></help-field>
       </div>
       <div class="col-md-4">
         <input class="form-control input-sm"
@@ -109,7 +109,7 @@
 
     <div class="form-group">
       <div class="col-md-4 sm-label-right">
-        <b>Interval</b><help-field key="gce.loadBalancer.advancedSettings.healthInterval"/>
+        <b>Interval</b><help-field key="gce.loadBalancer.advancedSettings.healthInterval"></help-field>
       </div>
       <div class="col-md-4">
         <input class="form-control input-sm"
@@ -123,7 +123,7 @@
 
     <div class="form-group">
       <div class="col-md-4 sm-label-right">
-        <b>Healthy Threshold</b><help-field key="gce.loadBalancer.advancedSettings.healthyThreshold"/>
+        <b>Healthy Threshold</b><help-field key="gce.loadBalancer.advancedSettings.healthyThreshold"></help-field>
       </div>
       <div class="col-md-4">
         <input class="form-control input-sm"
@@ -137,7 +137,7 @@
 
     <div class="form-group">
       <div class="col-md-4 sm-label-right">
-        <b>Unhealthy Threshold</b><help-field key="gce.loadBalancer.advancedSettings.unhealthyThreshold"/>
+        <b>Unhealthy Threshold</b><help-field key="gce.loadBalancer.advancedSettings.unhealthyThreshold"></help-field>
       </div>
       <div class="col-md-4">
         <input class="form-control input-sm"

--- a/app/scripts/modules/google/src/loadBalancer/configure/network/advancedSettings.html
+++ b/app/scripts/modules/google/src/loadBalancer/configure/network/advancedSettings.html
@@ -3,7 +3,7 @@
 
     <div class="form-group">
       <div class="col-md-6 sm-label-right">
-        <b>Timeout</b><help-field key="loadBalancer.advancedSettings.healthTimeout"/>
+        <b>Timeout</b><help-field key="loadBalancer.advancedSettings.healthTimeout"></help-field>
       </div>
       <div class="col-md-4">
         <input class="form-control input-sm" type="number" min="0" ng-model="loadBalancer.healthTimeout"/>
@@ -12,7 +12,7 @@
 
     <div class="form-group">
       <div class="col-md-6 sm-label-right">
-        <b>Interval</b><help-field key="gce.loadBalancer.advancedSettings.healthInterval"/>
+        <b>Interval</b><help-field key="gce.loadBalancer.advancedSettings.healthInterval"></help-field>
       </div>
       <div class="col-md-4">
         <input class="form-control input-sm" type="number" min="0" ng-model="loadBalancer.healthInterval"/>
@@ -21,7 +21,7 @@
 
     <div class="form-group">
       <div class="col-md-6 sm-label-right">
-        <b>Healthy Threshold</b><help-field key="gce.loadBalancer.advancedSettings.healthyThreshold"/>
+        <b>Healthy Threshold</b><help-field key="gce.loadBalancer.advancedSettings.healthyThreshold"></help-field>
       </div>
       <div class="col-md-4">
         <input class="form-control input-sm" type="number" min="0" ng-model="loadBalancer.healthyThreshold"/>
@@ -30,7 +30,7 @@
 
     <div class="form-group">
       <div class="col-md-6 sm-label-right">
-        <b>Unhealthy Threshold</b><help-field key="gce.loadBalancer.advancedSettings.unhealthyThreshold"/>
+        <b>Unhealthy Threshold</b><help-field key="gce.loadBalancer.advancedSettings.unhealthyThreshold"></help-field>
       </div>
       <div class="col-md-4">
         <input class="form-control input-sm" type="number" min="0" ng-model="loadBalancer.unhealthyThreshold"/>

--- a/app/scripts/modules/google/src/securityGroup/configure/createSecurityGroupIngress.html
+++ b/app/scripts/modules/google/src/securityGroup/configure/createSecurityGroupIngress.html
@@ -3,7 +3,7 @@
       <div class="col-md-12" ng-if="state.removedRules.length">
         <div class="alert alert-warning">
           <p><i class="fa fa-exclamation-triangle"></i>
-            The following <firewall-label label="firewalls"/> could not be found in the selected account/region/VPC and were removed:
+            The following <firewall-label label="firewalls"></firewall-label> could not be found in the selected account/region/VPC and were removed:
           </p>
           <ul>
             <li ng-repeat="securityGroup in state.removedRules">{{securityGroup}}</li>

--- a/app/scripts/modules/google/src/securityGroup/configure/createSecurityGroupProperties.html
+++ b/app/scripts/modules/google/src/securityGroup/configure/createSecurityGroupProperties.html
@@ -2,7 +2,7 @@
     <div class="modal-body">
       <div class="form-group">
         <div class="col-md-12 well" ng-class="{'alert-danger': form.securityGroupName.$error.validateUnique, 'alert-info': !form.securityGroupName.$error.validateUnique}">
-          <strong>Your <firewall-label label="firewall"/> will be named:</strong>
+          <strong>Your <firewall-label label="firewall"></firewall-label> will be named:</strong>
           <span ng-bind="namePreview"></span>
           <input type="hidden" class="form-control input-sm"
                  ng-model="securityGroup.name"

--- a/app/scripts/modules/google/src/securityGroup/details/securityGroupDetail.html
+++ b/app/scripts/modules/google/src/securityGroup/details/securityGroupDetail.html
@@ -32,12 +32,12 @@
     <div class="actions">
       <div ng-if="!securityGroup.id.includes('/')" class="dropdown" uib-dropdown dropdown-append-to-body>
         <button type="button" class="btn btn-sm btn-primary dropdown-toggle" uib-dropdown-toggle>
-          <firewall-label label="Firewall"/> Actions <span class="caret"></span>
+          <firewall-label label="Firewall"></firewall-label> Actions <span class="caret"></span>
         </button>
         <ul class="dropdown-menu" uib-dropdown-menu role="menu">
           <li><a href ng-click="ctrl.editInboundRules()">Edit Inbound Rules</a></li>
-          <li><a href ng-click="ctrl.deleteSecurityGroup()">Delete <firewall-label label="Firewall"/></a></li>
-          <li><a href ng-click="ctrl.cloneSecurityGroup()">Clone <firewall-label label="Firewall"/></a></li>
+          <li><a href ng-click="ctrl.deleteSecurityGroup()">Delete <firewall-label label="Firewall"></firewall-label></a></li>
+          <li><a href ng-click="ctrl.cloneSecurityGroup()">Clone <firewall-label label="Firewall"></firewall-label></a></li>
           <render-if-feature feature="entityTags">
             <add-entity-tag-links component="securityGroup"
                                   application="ctrl.application"
@@ -48,12 +48,12 @@
       </div>
       <div ng-if="securityGroup.id.includes('/')" class="dropdown" uib-dropdown dropdown-append-to-body>
         <button type="button" class="btn btn-sm btn-primary dropdown-toggle" uib-dropdown-toggle>
-          <firewall-label label="Firewall"/> Actions <span class="caret"></span>
+          <firewall-label label="Firewall"></firewall-label> Actions <span class="caret"></span>
         </button>
         <ul uib-tooltip="You cannot modify shared VPC host project firewall rules." class="dropdown-menu" uib-dropdown-menu role="menu">
           <li class="disabled"><a>Edit Inbound Rules</a></li>
-          <li class="disabled"><a>Delete <firewall-label label="Firewall"/></a></li>
-          <li class="disabled"><a>Clone <firewall-label label="Firewall"/></a></li>
+          <li class="disabled"><a>Delete <firewall-label label="Firewall"></firewall-label></a></li>
+          <li class="disabled"><a>Clone <firewall-label label="Firewall"></firewall-label></a></li>
         </ul>
       </div>
     </div>

--- a/app/scripts/modules/google/src/serverGroup/configure/wizard/securityGroups/securityGroupSelector.directive.html
+++ b/app/scripts/modules/google/src/serverGroup/configure/wizard/securityGroups/securityGroupSelector.directive.html
@@ -1,5 +1,5 @@
 <div class="form-group">
-  <div class="col-md-3 sm-label-right"><b><firewall-label label="Firewalls"/></b></div>
+  <div class="col-md-3 sm-label-right"><b><firewall-label label="Firewalls"></firewall-label></b></div>
   <div class="col-md-9">
     <ui-select ng-if="vm.command.backingData.filtered.securityGroups.length"
                multiple
@@ -21,14 +21,14 @@
 <div class="form-group small" style="margin-top: 20px">
   <div class="col-md-9 col-md-offset-3 checkbox">
     <p>
-      <label><input type="checkbox" ng-model="vm.command.viewState.listImplicitSecurityGroups"/> Show Implicit <firewall-label label="Firewalls"/> </label>
+      <label><input type="checkbox" ng-model="vm.command.viewState.listImplicitSecurityGroups"/> Show Implicit <firewall-label label="Firewalls"></firewall-label> </label>
       <help-field key="gce.serverGroup.securityGroups.implicit"></help-field>
     </p>
   </div>
 </div>
 
 <div class="form-group" ng-if="vm.command.viewState.listImplicitSecurityGroups">
-  <div class="col-md-3 sm-label-right"><b>Implicit <firewall-label label="Firewalls"/></b></div>
+  <div class="col-md-3 sm-label-right"><b>Implicit <firewall-label label="Firewalls"></firewall-label></b></div>
   <div class="col-md-9">
     <ul ng-if="vm.command.implicitSecurityGroups.length" style="margin-top: 10px; list-style-type: none">
       <li ng-repeat="securityGroup in vm.command.implicitSecurityGroups">{{securityGroup.name}}</li>
@@ -43,11 +43,11 @@
   <div class="col-md-9 col-md-offset-3">
     <p>
       <span ng-if="refreshing"><span class="fa fa-sync-alt fa-spin"></span></span>
-      <firewall-label label="Firewalls"/>
+      <firewall-label label="Firewalls"></firewall-label>
       <span ng-if="!refreshing">last refreshed {{ vm.getSecurityGroupRefreshTime() | timestamp }}</span>
       <span ng-if="refreshing"> refreshing...</span>
     </p>
-    <p>If you're not finding a <firewall-label label="firewall"/> that was recently added,
+    <p>If you're not finding a <firewall-label label="firewall"></firewall-label> that was recently added,
       <a href ng-click="vm.refreshSecurityGroups()">click here</a> to refresh the list.
     </p>
   </div>

--- a/app/scripts/modules/google/src/serverGroup/configure/wizard/securityGroups/securityGroupsRemoved.directive.html
+++ b/app/scripts/modules/google/src/serverGroup/configure/wizard/securityGroups/securityGroupsRemoved.directive.html
@@ -1,7 +1,7 @@
 <div class="col-md-12" ng-if="vm.command.viewState.dirty.securityGroups">
   <div class="alert alert-warning">
     <p><i class="fa fa-exclamation-triangle"></i>
-      The following <firewall-label label="firewalls"/> could not be found in the selected account/network and were removed:
+      The following <firewall-label label="firewalls"></firewall-label> could not be found in the selected account/network and were removed:
     </p>
     <ul>
       <li ng-repeat="securityGroup in vm.command.viewState.dirty.securityGroups">{{securityGroup}}</li>

--- a/app/scripts/modules/kubernetes/src/instance/details/details.html
+++ b/app/scripts/modules/kubernetes/src/instance/details/details.html
@@ -130,7 +130,7 @@
     </collapsible-section>
     <collapsible-section heading="Events">
       <div ng-if="instance.events && instance.events.length > 0">
-        <kubernetes-event ng-repeat="event in instance.events" event="event"/>
+        <kubernetes-event ng-repeat="event in instance.events" event="event"></kubernetes-event>
       </div>
       <div ng-if="!(instance.events && instance.events.length > 0)">
         No events.

--- a/app/scripts/modules/kubernetes/src/loadBalancer/details/details.html
+++ b/app/scripts/modules/kubernetes/src/loadBalancer/details/details.html
@@ -19,7 +19,7 @@
       </a>
     </div>
     <div class="header-text horizontal middle">
-      <i class="fa icon-sitemap"/>
+      <i class="fa icon-sitemap"></i>
       <h3 class="horizontal middle space-between flex-1" select-on-dbl-click>
         {{loadBalancer.name}}
       </h3>

--- a/app/scripts/modules/kubernetes/src/securityGroup/configure/wizard/basicSettings.html
+++ b/app/scripts/modules/kubernetes/src/securityGroup/configure/wizard/basicSettings.html
@@ -5,7 +5,7 @@
   <div class="modal-body" ng-if="state.accountsLoaded">
     <div class="form-group">
       <div class="col-md-12 well" ng-class="{'alert-danger': form.securityGroupName.$error.validateUnique, 'alert-info': !form.securityGroupName.$error.validateUnique}">
-        <strong>Your <firewall-label label="firewall"/> will be named:</strong>
+        <strong>Your <firewall-label label="firewall"></firewall-label> will be named:</strong>
         <span>{{ctrl.getName()}}</span>
           <!-- Angular does not seem to run length validation on hidden inputs, hence the text + display:none -->
         <input type="text"

--- a/app/scripts/modules/kubernetes/src/securityGroup/details/details.html
+++ b/app/scripts/modules/kubernetes/src/securityGroup/details/details.html
@@ -18,11 +18,11 @@
     <div class="actions">
       <div class="dropdown" uib-dropdown dropdown-append-to-body>
         <button type="button" class="btn btn-sm btn-primary dropdown-toggle" ng-disabled="disabled" uib-dropdown-toggle>
-          <firewall-label label="Firewall"/> Actions <span class="caret"></span>
+          <firewall-label label="Firewall"></firewall-label> Actions <span class="caret"></span>
         </button>
         <ul class="dropdown-menu" uib-dropdown-menu role="menu">
-          <li><a href ng-click="ctrl.deleteSecurityGroup()">Delete <firewall-label label="Firewall"/></a></li>
-          <li><a href ng-click="ctrl.editSecurityGroup()">Edit <firewall-label label="Firewall"/></a></li>
+          <li><a href ng-click="ctrl.deleteSecurityGroup()">Delete <firewall-label label="Firewall"></firewall-label></a></li>
+          <li><a href ng-click="ctrl.editSecurityGroup()">Edit <firewall-label label="Firewall"></firewall-label></a></li>
         </ul>
       </div>
     </div>

--- a/app/scripts/modules/kubernetes/src/serverGroup/details/details.html
+++ b/app/scripts/modules/kubernetes/src/serverGroup/details/details.html
@@ -191,7 +191,7 @@
     </collapsible-section>
     <collapsible-section heading="Events">
       <div ng-if="serverGroup.events && serverGroup.events.length > 0">
-        <kubernetes-event ng-repeat="event in serverGroup.events" event="event"/>
+        <kubernetes-event ng-repeat="event in serverGroup.events" event="event"></kubernetes-event>
       </div>
       <div ng-if="!(serverGroup.events && serverGroup.events.length > 0)">
         No events.

--- a/app/scripts/modules/kubernetes/src/v2/securityGroup/details/details.html
+++ b/app/scripts/modules/kubernetes/src/v2/securityGroup/details/details.html
@@ -43,14 +43,14 @@
       <div class="actions">
         <div class="dropdown" uib-dropdown dropdown-append-to-body>
           <button type="button" class="btn btn-sm btn-primary dropdown-toggle" uib-dropdown-toggle>
-            <firewall-label label="{{ctrl.securityGroup.kind | robotToHuman}}"/> Actions <span class="caret"></span>
+            <firewall-label label="{{ctrl.securityGroup.kind | robotToHuman}}"></firewall-label> Actions <span class="caret"></span>
           </button>
           <ul class="dropdown-menu" uib-dropdown-menu role="menu">
             <li>
-              <a href ng-click="ctrl.deleteSecurityGroup()">Delete <firewall-label label="Firewall"/></a>
+              <a href ng-click="ctrl.deleteSecurityGroup()">Delete <firewall-label label="Firewall"></firewall-label></a>
             </li>
             <li>
-              <a href ng-click="ctrl.editSecurityGroup()">Edit <firewall-label label="Firewall"/></a>
+              <a href ng-click="ctrl.editSecurityGroup()">Edit <firewall-label label="Firewall"></firewall-label></a>
             </li>
           <render-if-feature feature="entityTags">
             <add-entity-tag-links component="ctrl.securityGroup"

--- a/app/scripts/modules/kubernetes/src/v2/serverGroupManager/details/details.html
+++ b/app/scripts/modules/kubernetes/src/v2/serverGroupManager/details/details.html
@@ -77,7 +77,7 @@
                                   application="ctrl.app"
                                   entity-type="serverGroupManager"
                                   owner-options="ctrl.entityTagTargets"
-                                  on-update="ctrl.app.serverGroupManagers.refresh()" />
+                                  on-update="ctrl.app.serverGroupManagers.refresh()"></add-entity-tag-links>
           </render-if-feature>
         </ul>
       </div>

--- a/app/scripts/modules/openstack/src/loadBalancer/details/details.html
+++ b/app/scripts/modules/openstack/src/loadBalancer/details/details.html
@@ -19,7 +19,7 @@
       </a>
     </div>
     <div class="header-text horizontal middle">
-      <i class="fa icon-sitemap"/>
+      <i class="fa icon-sitemap"></i>
       <h3 class="horizontal middle space-between flex-1" select-on-dbl-click>
         {{loadBalancer.name}}
       </h3>

--- a/app/scripts/modules/openstack/src/securityGroup/configure/wizard/basicSettings.html
+++ b/app/scripts/modules/openstack/src/securityGroup/configure/wizard/basicSettings.html
@@ -5,7 +5,7 @@
   <div class="modal-body" ng-if="state.accountsLoaded">
     <div class="form-group">
       <div class="col-md-12 well" ng-if="isNew" ng-class="{'alert-danger': form.securityGroupName.$error.validateUnique, 'alert-info': !form.securityGroupName.$error.validateUnique}">
-        <strong>Your <firewall-label label="firewall"/> will be named:</strong>
+        <strong>Your <firewall-label label="firewall"></firewall-label> will be named:</strong>
         <span>{{ctrl.getName()}}</span>
           <!-- Angular does not seem to run length validation on hidden inputs, hence the text + display:none -->
         <input type="text"

--- a/app/scripts/modules/openstack/src/securityGroup/configure/wizard/rules.html
+++ b/app/scripts/modules/openstack/src/securityGroup/configure/wizard/rules.html
@@ -110,11 +110,11 @@
     <div class="col-md-12">
         <p>
             <span ng-if="state.refreshingSecurityGroups"><span class="fa fa-sync-alt fa-spin"></span></span>
-            <firewall-label label="Firewalls"/>
+            <firewall-label label="Firewalls"></firewall-label>
             <span ng-if="!state.refreshingSecurityGroups">last refreshed {{ rulesController.getSecurityGroupRefreshTime() | timestamp }}</span>
             <span ng-if="state.refreshingSecurityGroups"> refreshing...</span>
         </p>
-        <p>If you're not finding a <firewall-label label="firewall"/> that was recently added,
+        <p>If you're not finding a <firewall-label label="firewall"></firewall-label> that was recently added,
             <a href ng-click="rulesController.refreshSecurityGroups()">click here</a> to refresh the list.
         </p>
     </div>

--- a/app/scripts/modules/openstack/src/securityGroup/details/details.html
+++ b/app/scripts/modules/openstack/src/securityGroup/details/details.html
@@ -18,11 +18,11 @@
     <div class="actions">
       <div class="dropdown" uib-dropdown dropdown-append-to-body>
         <button type="button" class="btn btn-sm btn-primary dropdown-toggle" ng-disabled="disabled" uib-dropdown-toggle>
-          <firewall-label label="Firewall"/> Actions <span class="caret"></span>
+          <firewall-label label="Firewall"></firewall-label> Actions <span class="caret"></span>
         </button>
         <ul class="dropdown-menu" uib-dropdown-menu role="menu">
-          <li><a href ng-click="ctrl.editSecurityGroup()">Edit <firewall-label label="Firewall"/></a></li>
-          <li><a href ng-click="ctrl.deleteSecurityGroup()">Delete <firewall-label label="Firewall"/></a></li>
+          <li><a href ng-click="ctrl.editSecurityGroup()">Edit <firewall-label label="Firewall"></firewall-label></a></li>
+          <li><a href ng-click="ctrl.deleteSecurityGroup()">Delete <firewall-label label="Firewall"></firewall-label></a></li>
         </ul>
       </div>
     </div>
@@ -60,7 +60,7 @@
 
           <dl ng-class="insightCtrl.vm.filtersExpanded ? '' : 'dl-horizontal dl-medium'"
               ng-repeat="rule in securityGroup.securityGroupRules | orderBy: 'securityGroup.name' ">
-            <dt><firewall-label label="Firewall"/></dt>
+            <dt><firewall-label label="Firewall"></firewall-label></dt>
             <dd ng-if="rule.securityGroup.name">
                   <a ui-sref="^.firewallDetails({name: rule.securityGroup.name, accountId: rule.securityGroup.accountName, region: rule.securityGroup.region, vpcId: rule.securityGroup.vpcId, provider: 'openstack'})">
                       <account-tag account="rule.securityGroup.accountName || rule.securityGroup.accountId" ng-if="rule.securityGroup.accountName !== securityGroup.accountName"></account-tag>

--- a/app/scripts/modules/oracle/src/loadBalancer/details/loadBalancerDetail.html
+++ b/app/scripts/modules/oracle/src/loadBalancer/details/loadBalancerDetail.html
@@ -20,7 +20,7 @@
       </a>
     </div>
     <div class="header-text horizontal middle">
-      <i class="fa icon-sitemap"/>
+      <i class="fa icon-sitemap"></i>
       <h3 class="horizontal middle space-between flex-1" select-on-dbl-click>
         {{loadBalancer.name}}
       </h3>

--- a/app/scripts/modules/oracle/src/pipeline/stages/bake/bakeStage.html
+++ b/app/scripts/modules/oracle/src/pipeline/stages/bake/bakeStage.html
@@ -24,7 +24,7 @@
                        ng-model="stage.baseOs"
                        ng-value="baseImage.id"/>
                 {{bakeStageCtrl.getBaseOsDescription(baseImage)}}
-                <help-field content="{{baseImage.detailedDescription}}"/>
+                <help-field content="{{baseImage.detailedDescription}}"></help-field>
             </label>
         </div>
     </stage-config-field>

--- a/app/scripts/modules/oracle/src/securityGroup/configure/createSecurityGroup.html
+++ b/app/scripts/modules/oracle/src/securityGroup/configure/createSecurityGroup.html
@@ -4,8 +4,8 @@
   <div class="container-fluid">
     <div class="col-md-12 well">
       <h4>Notice</h4>
-      <p>We don't currently support the ability to create <firewall-label label="firewalls"/> for Oracle Cloud from Spinnaker.</p>
-      <p>You can use the Oracle Cloud console to create and manage Security Lists to provide a virtual <firewall-label label="firewall"/> for an instance.</p>
+      <p>We don't currently support the ability to create <firewall-label label="firewalls"></firewall-label> for Oracle Cloud from Spinnaker.</p>
+      <p>You can use the Oracle Cloud console to create and manage Security Lists to provide a virtual <firewall-label label="firewall"></firewall-label> for an instance.</p>
     </div>
   </div>
   <div class="modal-footer">

--- a/app/scripts/modules/oracle/src/serverGroup/configure/wizard/network/networkSettings.html
+++ b/app/scripts/modules/oracle/src/serverGroup/configure/wizard/network/networkSettings.html
@@ -8,6 +8,6 @@
         <textarea class="form-control input-sm"
                   name="sshAuthorizedKeys"
                   placeholder="Enter the public SSH key for the default user on the instance."
-                  ng-model="command.sshAuthorizedKeys" />
+                  ng-model="command.sshAuthorizedKeys"></textarea>
     </div>
 </div>


### PR DESCRIPTION
Self closing tags are invalid HTML except for a few specific tags, i.e., `<br/>`, `<input/>`, etc.  In some cases markup following a self closed tag will be embedded inside the self closed tag.  i.e., 
```
<i class="fa fa-spin"/> 
<h1>hello</h1>
```
is parsed as 
```<i class="fa fa-spin>
<h1>hello</h1>
</i>
```
AngularJS code relies on the browser html parser, and so we shouldn't use self-closed tags in AngularJS code.

Reference: https://github.com/angular/angular.js/issues/1953#issuecomment-13135021

This issue manifest as oddly placed icons when I changed typescript module type from `commonjs` to `esnext` in #6445 (and I have no idea why that would alter the behavior)
![screen shot 2019-01-28 at 3 52 36 pm](https://user-images.githubusercontent.com/2053478/51884455-2e1a5b80-233c-11e9-9f24-2698b6b11a84.png)
