### PR TITLE
feat(core): Map/Unmap SGs and LBs as pipeline stages

### DIFF
--- a/app/scripts/modules/core/src/instance/instance.write.service.ts
+++ b/app/scripts/modules/core/src/instance/instance.write.service.ts
@@ -154,6 +154,34 @@ export class InstanceWriter {
     });
   }
 
+  public mapLoadBalancers(serverGroup: IServerGroup, application: Application, params: any = {}): IPromise<ITask> {
+    params.type = 'mapLoadBalancers';
+    params.name = [serverGroup.name];
+    params.loadBalancerNames = serverGroup.loadBalancers;
+    params.region = serverGroup.region;
+    params.credentials = serverGroup.account;
+    params.cloudProvider = serverGroup.cloudProvider;
+    return TaskExecutor.executeTask({
+      job: [params],
+      application,
+      description: `Map load balancers for server group: ${serverGroup.name}`,
+    });
+  }
+
+  public unmapLoadBalancers(serverGroup: IServerGroup, application: Application, params: any = {}): IPromise<ITask> {
+    params.type = 'unmapLoadBalancers';
+    params.name = [serverGroup.name];
+    params.loadBalancerNames = serverGroup.loadBalancers;
+    params.region = serverGroup.region;
+    params.credentials = serverGroup.account;
+    params.cloudProvider = serverGroup.cloudProvider;
+    return TaskExecutor.executeTask({
+      job: [params],
+      application,
+      description: `Unmap load balancers for server group: ${serverGroup.name}`,
+    });
+  }
+
   public enableInstancesInDiscovery(instanceGroups: IMultiInstanceGroup[], application: Application): IPromise<ITask> {
     return this.executeMultiInstanceTask(
       instanceGroups,

--- a/app/scripts/modules/core/src/pipeline/config/stages/mapLoadBalancers/MapLoadBalancersExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/mapLoadBalancers/MapLoadBalancersExecutionDetails.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+
+import { ExecutionDetailsSection, IExecutionDetailsSectionProps, StageFailureMessage } from 'core/pipeline';
+import { AccountTag } from 'core/account';
+
+export function MapLoadBalancersExecutionDetails(props: IExecutionDetailsSectionProps) {
+  const { stage } = props;
+  return (
+    <ExecutionDetailsSection name={props.name} current={props.current}>
+      <div className="row">
+        <div className="col-md-9">
+          <dl className="dl-narrow dl-horizontal">
+            <dt>Account</dt>
+            <dd>
+              <AccountTag account={stage.context.credentials} />
+            </dd>
+            <dt>Region</dt>
+            <dd>{stage.context.region}</dd>
+          </dl>
+        </div>
+      </div>
+      <StageFailureMessage stage={props.stage} message={props.stage.failureMessage} />
+    </ExecutionDetailsSection>
+  );
+}
+
+export namespace MapLoadBalancersExecutionDetails {
+  export const title = 'MapLoadBalancersConfig';
+}

--- a/app/scripts/modules/core/src/pipeline/config/stages/mapLoadBalancers/mapLoadBalancersStage.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/mapLoadBalancers/mapLoadBalancersStage.ts
@@ -1,0 +1,18 @@
+import { module } from 'angular';
+
+import { Registry } from 'core/registry';
+import { ExecutionDetailsTasks } from '../core';
+import { MapLoadBalancersExecutionDetails } from './MapLoadBalancersExecutionDetails';
+
+export const MAP_LOAD_BALANCERS_STAGE = 'spinnaker.core.pipeline.stage.mapLoadBalancers';
+
+module(MAP_LOAD_BALANCERS_STAGE, []).config(() => {
+  Registry.pipeline.registerStage({
+    executionDetailsSections: [MapLoadBalancersExecutionDetails, ExecutionDetailsTasks],
+    useBaseProvider: true,
+    key: 'mapLoadBalancers',
+    label: 'Map Load Balancers',
+    description: 'Map load balancers',
+    strategy: true,
+  });
+});

--- a/app/scripts/modules/core/src/pipeline/config/stages/unmapLoadBalancers/UnmapLoadBalancersExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/unmapLoadBalancers/UnmapLoadBalancersExecutionDetails.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+
+import { ExecutionDetailsSection, IExecutionDetailsSectionProps, StageFailureMessage } from 'core/pipeline';
+import { AccountTag } from 'core/account';
+
+export function UnmapLoadBalancersExecutionDetails(props: IExecutionDetailsSectionProps) {
+  const { stage } = props;
+  return (
+    <ExecutionDetailsSection name={props.name} current={props.current}>
+      <div className="row">
+        <div className="col-md-9">
+          <dl className="dl-narrow dl-horizontal">
+            <dt>Account</dt>
+            <dd>
+              <AccountTag account={stage.context.credentials} />
+            </dd>
+            <dt>Region</dt>
+            <dd>{stage.context.region}</dd>
+          </dl>
+        </div>
+      </div>
+      <StageFailureMessage stage={props.stage} message={props.stage.failureMessage} />
+    </ExecutionDetailsSection>
+  );
+}
+
+export namespace UnmapLoadBalancersExecutionDetails {
+  export const title = 'UnmapLoadBalancersConfig';
+}

--- a/app/scripts/modules/core/src/pipeline/config/stages/unmapLoadBalancers/unmapLoadBalancersStage.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/unmapLoadBalancers/unmapLoadBalancersStage.ts
@@ -1,0 +1,18 @@
+import { module } from 'angular';
+
+import { Registry } from 'core/registry';
+import { ExecutionDetailsTasks } from '../core';
+import { UnmapLoadBalancersExecutionDetails } from './UnmapLoadBalancersExecutionDetails';
+
+export const UNMAP_LOAD_BALANCERS_STAGE = 'spinnaker.core.pipeline.stage.unmapLoadBalancers';
+
+module(UNMAP_LOAD_BALANCERS_STAGE, []).config(() => {
+  Registry.pipeline.registerStage({
+    executionDetailsSections: [UnmapLoadBalancersExecutionDetails, ExecutionDetailsTasks],
+    useBaseProvider: true,
+    key: 'unmapLoadBalancers',
+    label: 'Unmap Load Balancers',
+    description: 'Unmap load balancers',
+    strategy: true,
+  });
+});

--- a/app/scripts/modules/core/src/pipeline/pipeline.module.ts
+++ b/app/scripts/modules/core/src/pipeline/pipeline.module.ts
@@ -18,6 +18,8 @@ import { FIND_AMI_STAGE } from './config/stages/findAmi/findAmiStage';
 import { FIND_ARTIFACT_FROM_EXECUTION_STAGE } from './config/stages/findArtifactFromExecution/findArtifactFromExecutionStage';
 import { GROUP_STAGE_MODULE } from './config/stages/group/groupStage.module';
 import { MANUAL_JUDGMENT_STAGE_MODULE } from './config/stages/manualJudgment/manualJudgmentStage.module';
+import { MAP_LOAD_BALANCERS_STAGE } from './config/stages/mapLoadBalancers/mapLoadBalancersStage';
+import { UNMAP_LOAD_BALANCERS_STAGE } from './config/stages/unmapLoadBalancers/unmapLoadBalancersStage';
 import { RESIZE_ASG_STAGE } from './config/stages/resizeAsg/resizeAsgStage';
 import { SCALE_DOWN_CLUSTER_STAGE } from './config/stages/scaleDownCluster/scaleDownClusterStage';
 import { SCRIPT_STAGE } from './config/stages/script/scriptStage';
@@ -85,6 +87,8 @@ module(PIPELINE_MODULE, [
   require('./config/stages/findImageFromTags/findImageFromTagsStage.module').name,
   require('./config/stages/jenkins/jenkinsStage.module').name,
   MANUAL_JUDGMENT_STAGE_MODULE,
+  MAP_LOAD_BALANCERS_STAGE,
+  UNMAP_LOAD_BALANCERS_STAGE,
   require('./config/stages/tagImage/tagImageStage.module').name,
   require('./config/stages/pipeline/pipelineStage.module').name,
   PRODUCES_ARTIFACTS,


### PR DESCRIPTION
Add pipeline stages for mapping and unmapping load balancers to core in preparation for a cloud-specific implementation in a forthcoming PR.