### PR TITLE
feat(cf/serverGroup): Use discriminator 'type' field to improve type checking

### DIFF
--- a/app/scripts/modules/cloudfoundry/src/serverGroup/configure/serverGroupCommandBuilder.service.cf.ts
+++ b/app/scripts/modules/cloudfoundry/src/serverGroup/configure/serverGroupCommandBuilder.service.cf.ts
@@ -93,9 +93,8 @@ export class CloudFoundryServerGroupCommandBuilder {
         routes: serverGroup.loadBalancers,
         environment: CloudFoundryServerGroupCommandBuilder.envVarsFromObject(serverGroup.env),
         services: (serverGroup.serviceInstances || []).map(serviceInstance => serviceInstance.name),
-        reference: '',
-        account: '',
-        pattern: '',
+        healthCheckType: '',
+        healthCheckHttpEndpoint: '',
       };
       command.region = serverGroup.region;
       command.stack = serverGroup.stack;

--- a/app/scripts/modules/cloudfoundry/src/serverGroup/configure/serverGroupConfigurationModel.cf.ts
+++ b/app/scripts/modules/cloudfoundry/src/serverGroup/configure/serverGroupConfigurationModel.cf.ts
@@ -12,11 +12,13 @@ export interface ICloudFoundryCreateServerGroupCommand extends IServerGroupComma
 }
 
 export interface ICloudFoundryArtifactSource {
+  type: 'artifact';
   reference: string;
   account: string;
 }
 
 export interface ICloudFoundryPackageSource {
+  type: 'package';
   clusterName: string;
   serverGroupName: string;
   account: string;
@@ -24,16 +26,18 @@ export interface ICloudFoundryPackageSource {
 }
 
 export interface ICloudFoundryTriggerSource {
+  type: 'trigger';
   pattern: string;
   account: string; // optional: used in the event that retrieving an artifact from a trigger source requires auth
 }
 
-export type ICloudFoundryBinarySource = { type: string } & (
+export type ICloudFoundryBinarySource =
   | ICloudFoundryArtifactSource
   | ICloudFoundryPackageSource
-  | ICloudFoundryTriggerSource);
+  | ICloudFoundryTriggerSource;
 
 export interface ICloudFoundryManifestDirectSource {
+  type: 'direct';
   memory: string;
   diskQuota: string;
   instances: number;
@@ -46,19 +50,21 @@ export interface ICloudFoundryManifestDirectSource {
 }
 
 export interface ICloudFoundryManifestArtifactSource {
+  type: 'artifact';
   reference: string;
   account: string;
 }
 
 export interface ICloudFoundryManifestTriggerSource {
+  type: 'trigger';
   pattern: string;
   account: string; // optional: used in the event that retrieving a manifest from a trigger source requires auth
 }
 
-export type ICloudFoundryManifestSource = { type: string } & (
+export type ICloudFoundryManifestSource =
   | ICloudFoundryManifestDirectSource
   | ICloudFoundryManifestTriggerSource
-  | ICloudFoundryManifestArtifactSource);
+  | ICloudFoundryManifestArtifactSource;
 
 export interface ICloudFoundryDeployConfiguration {
   account: string;


### PR DESCRIPTION
Discriminated union types:  https://www.typescriptlang.org/docs/handbook/advanced-types.html#discriminated-unions

I ran into this while refactoring the modals in #6348.  You can improve type checking by adding a discriminator to each interface in the union type.  Then, TypeScript can tell which one of the union types is present based on the value of the discriminator.

@Jammy-Louie PTAL...  if you like it I'll merge when you say so.