### PR TITLE
feat(core): add application-specific custom banners

### DIFF
--- a/app/scripts/modules/core/src/application/config/applicationConfig.controller.js
+++ b/app/scripts/modules/core/src/application/config/applicationConfig.controller.js
@@ -1,7 +1,10 @@
+import { cloneDeep } from 'lodash';
+
 import { APPLICATION_DATA_SOURCE_EDITOR } from './dataSources/applicationDataSourceEditor.component';
 import { CHAOS_MONKEY_CONFIG_COMPONENT } from 'core/chaosMonkey/chaosMonkeyConfig.component';
 import { TRAFFIC_GUARD_CONFIG_COMPONENT } from './trafficGuard/trafficGuardConfig.component';
 import { SETTINGS } from 'core/config/settings';
+import { ApplicationWriter } from 'core/application/service/ApplicationWriter';
 
 const angular = require('angular');
 
@@ -18,7 +21,7 @@ module.exports = angular
     TRAFFIC_GUARD_CONFIG_COMPONENT,
     require('./links/applicationLinks.component').name,
   ])
-  .controller('ApplicationConfigController', function($state, app) {
+  .controller('ApplicationConfigController', function($state, app, $scope) {
     this.application = app;
     this.isDataSourceEnabled = key => app.dataSources.some(ds => ds.key === key && ds.disabled === false);
     this.feature = SETTINGS.feature;
@@ -28,4 +31,27 @@ module.exports = angular
       this.application.attributes.instancePort =
         this.application.attributes.instancePort || SETTINGS.defaultInstancePort || null;
     }
+    this.bannerConfigProps = {
+      isSaving: false,
+      saveError: false,
+    };
+    this.updateBannerConfigs = bannerConfigs => {
+      const applicationAttributes = cloneDeep(this.application.attributes);
+      applicationAttributes.customBanners = bannerConfigs;
+      $scope.$applyAsync(() => {
+        this.bannerConfigProps.isSaving = true;
+        this.bannerConfigProps.saveError = false;
+      });
+      ApplicationWriter.updateApplication(applicationAttributes)
+        .then(() => {
+          $scope.$applyAsync(() => {
+            this.bannerConfigProps.isSaving = false;
+            this.application.attributes = applicationAttributes;
+          });
+        })
+        .catch(() => {
+          this.bannerConfigProps.isSaving = false;
+          this.bannerConfigProps.saveError = true;
+        });
+    };
   });

--- a/app/scripts/modules/core/src/application/config/applicationConfig.view.html
+++ b/app/scripts/modules/core/src/application/config/applicationConfig.view.html
@@ -24,6 +24,15 @@
     <page-section key="snapshot" label="Serialize Application" visible="config.feature.snapshots">
       <application-snapshot-section application="config.application"></application-snapshot-section>
     </page-section>
+    <page-section key="banner" label="Custom Banners">
+      <custom-banner-config
+        banner-configs="config.application.attributes.customBanners"
+        is-saving="config.bannerConfigProps.isSaving"
+        save-error="config.bannerConfigProps.saveError"
+        update-banner-configs="config.updateBannerConfigs"
+      >
+      </custom-banner-config>
+    </page-section>
     <page-section key="delete" label="Delete Application">
       <delete-application-section application="config.application"></delete-application-section>
     </page-section>

--- a/app/scripts/modules/core/src/application/config/customBanner/CustomBannerConfig.spec.tsx
+++ b/app/scripts/modules/core/src/application/config/customBanner/CustomBannerConfig.spec.tsx
@@ -1,0 +1,83 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+
+import { noop } from 'core/utils';
+
+import { CustomBannerConfig, ICustomBannerConfig } from './CustomBannerConfig';
+
+describe('<CustomBannerConfig />', () => {
+  let bannerConfigs: ICustomBannerConfig[];
+  let wrapper: any;
+
+  beforeEach(() => {
+    bannerConfigs = getTestBannerConfigs();
+    wrapper = shallow(
+      <CustomBannerConfig
+        bannerConfigs={bannerConfigs}
+        isSaving={false}
+        saveError={false}
+        updateBannerConfigs={noop}
+      />,
+    );
+  });
+
+  describe('view', () => {
+    it('renders a row for each banner config', () => {
+      expect(wrapper.find('.custom-banner-config-row').length).toEqual(bannerConfigs.length);
+    });
+    it('renders an "add" button', () => {
+      expect(wrapper.find('.add-new').length).toEqual(1);
+    });
+  });
+
+  describe('functionality', () => {
+    it('update banner config', () => {
+      expect(wrapper.state('bannerConfigsEditing')).toEqual(bannerConfigs);
+      wrapper
+        .find('input[type="checkbox"]')
+        .at(1)
+        .simulate('change', { target: { checked: true } });
+      const updatedConfigs = [
+        {
+          ...bannerConfigs[0],
+          enabled: false,
+        },
+        {
+          ...bannerConfigs[1],
+          enabled: true,
+        },
+      ];
+      expect(wrapper.state('bannerConfigsEditing')).toEqual(updatedConfigs);
+    });
+    it('add banner config', () => {
+      expect(wrapper.state('bannerConfigsEditing').length).toEqual(2);
+      wrapper.find('.add-new').simulate('click');
+      expect(wrapper.state('bannerConfigsEditing').length).toEqual(3);
+    });
+    it('remove banner config', () => {
+      expect(wrapper.state('bannerConfigsEditing').length).toEqual(2);
+      wrapper
+        .find('.custom-banner-config-remove')
+        .at(1)
+        .simulate('click');
+      expect(wrapper.state('bannerConfigsEditing').length).toEqual(1);
+    });
+  });
+});
+
+export function getTestBannerConfigs(): ICustomBannerConfig[] {
+  return [
+    {
+      backgroundColor: 'var(--color-alert)',
+      enabled: true,
+      text: 'Warning: currently in maintenance mode',
+      textColor: 'var(--color-text-on-dark)',
+    },
+    {
+      backgroundColor: 'var(--color-alert)',
+      enabled: false,
+      text: 'Warning: currently in production freeze',
+      textColor: 'var(--color-text-on-dark)',
+    },
+  ];
+}

--- a/app/scripts/modules/core/src/application/config/customBanner/CustomBannerConfig.tsx
+++ b/app/scripts/modules/core/src/application/config/customBanner/CustomBannerConfig.tsx
@@ -1,0 +1,230 @@
+import * as React from 'react';
+import { isEqual } from 'lodash';
+import Select, { Option } from 'react-select';
+
+import { ConfigSectionFooter } from 'core/application/config/footer/ConfigSectionFooter';
+import {
+  bannerBackgroundColorOptions,
+  bannerTextColorOptions,
+} from 'core/application/config/customBanner/customBannerColors';
+
+import { noop } from 'core/utils';
+
+import './customBannerConfig.less';
+
+export interface ICustomBannerConfig {
+  backgroundColor: string;
+  enabled: boolean;
+  text: string;
+  textColor: string;
+}
+
+export interface ICustomBannerConfigProps {
+  bannerConfigs: ICustomBannerConfig[];
+  isSaving: boolean;
+  saveError: boolean;
+  updateBannerConfigs: (bannerConfigs: ICustomBannerConfig[]) => void;
+}
+
+export interface ICustomBannerConfigState {
+  bannerConfigsEditing: ICustomBannerConfig[];
+}
+
+export class CustomBannerConfig extends React.Component<ICustomBannerConfigProps, ICustomBannerConfigState> {
+  public static defaultProps: Partial<ICustomBannerConfigProps> = {
+    bannerConfigs: [],
+    isSaving: false,
+    saveError: false,
+    updateBannerConfigs: noop,
+  };
+
+  constructor(props: ICustomBannerConfigProps) {
+    super(props);
+    this.state = {
+      bannerConfigsEditing: props.bannerConfigs,
+    };
+  }
+
+  private onEnabledChange = (idx: number, isChecked: boolean) => {
+    this.setState({
+      bannerConfigsEditing: this.state.bannerConfigsEditing.map((config, i) => {
+        if (i === idx) {
+          return {
+            ...config,
+            enabled: isChecked,
+          };
+        }
+        // Only one config can be enabled
+        return {
+          ...config,
+          enabled: isChecked ? false : config.enabled,
+        };
+      }),
+    });
+  };
+
+  private onTextChange = (idx: number, text: string) => {
+    this.setState({
+      bannerConfigsEditing: this.state.bannerConfigsEditing.map((config, i) => {
+        if (i === idx) {
+          return {
+            ...config,
+            text,
+          };
+        }
+        return config;
+      }),
+    });
+  };
+
+  private onTextColorChange = (idx: number, option: Option<string>) => {
+    this.setState({
+      bannerConfigsEditing: this.state.bannerConfigsEditing.map((config, i) => {
+        if (i === idx) {
+          return {
+            ...config,
+            textColor: option.value,
+          };
+        }
+        return config;
+      }),
+    });
+  };
+
+  private onBackgroundColorChange = (idx: number, option: Option<string>) => {
+    this.setState({
+      bannerConfigsEditing: this.state.bannerConfigsEditing.map((config, i) => {
+        if (i === idx) {
+          return {
+            ...config,
+            backgroundColor: option.value,
+          };
+        }
+        return config;
+      }),
+    });
+  };
+
+  private addBanner = (): void => {
+    this.setState({
+      bannerConfigsEditing: this.state.bannerConfigsEditing.concat([
+        {
+          backgroundColor: 'var(--color-alert)',
+          enabled: false,
+          text: 'Your custom banner text',
+          textColor: 'var(--color-text-on-dark)',
+        } as ICustomBannerConfig,
+      ]),
+    });
+  };
+
+  private removeBanner = (idx: number): void => {
+    this.setState({
+      bannerConfigsEditing: this.state.bannerConfigsEditing.filter((_config, i) => i !== idx),
+    });
+  };
+
+  private isDirty = (): boolean => {
+    return !isEqual(this.props.bannerConfigs, this.state.bannerConfigsEditing);
+  };
+
+  private onRevertClicked = (): void => {
+    this.setState({
+      bannerConfigsEditing: this.props.bannerConfigs,
+    });
+  };
+
+  private onSaveClicked = (): void => {
+    this.props.updateBannerConfigs(this.state.bannerConfigsEditing);
+  };
+
+  private colorOptionRenderer = (option: Option<string>): JSX.Element => {
+    return <div className="custom-banner-config-color-option" style={{ backgroundColor: option.value }} />;
+  };
+
+  public render() {
+    return (
+      <div className="custom-banner-config-container">
+        <div className="custom-banner-config-description">
+          Custom Banners allow you to specify application-specific headers that will appear above the main Spinnaker
+          navigation bar.
+        </div>
+        <div className="col-md-10 col-md-offset-1">
+          <table className="table table-condensed">
+            <thead>
+              <tr>
+                <th className="text-center">Enabled</th>
+                <th>Text</th>
+                <th className="custom-banner-config-color-option-column">Text Color</th>
+                <th className="custom-banner-config-color-option-column">Background</th>
+                <th />
+              </tr>
+            </thead>
+            <tbody>
+              {this.state.bannerConfigsEditing.map((banner, idx) => (
+                <tr key={idx} className="custom-banner-config-row">
+                  <td className="text-center">
+                    <input
+                      checked={banner.enabled}
+                      onChange={(e: React.ChangeEvent<HTMLInputElement>) => this.onEnabledChange(idx, e.target.checked)}
+                      type="checkbox"
+                    />
+                  </td>
+                  <td>
+                    <textarea
+                      className="form-control input-sm custom-banner-config-textarea"
+                      onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => this.onTextChange(idx, e.target.value)}
+                      style={{
+                        backgroundColor: banner.backgroundColor,
+                        color: banner.textColor,
+                      }}
+                      value={banner.text}
+                    />
+                  </td>
+                  <td>
+                    <Select
+                      clearable={false}
+                      options={bannerTextColorOptions}
+                      onChange={(option: Option<string>) => this.onTextColorChange(idx, option)}
+                      optionRenderer={this.colorOptionRenderer}
+                      value={banner.textColor}
+                      valueRenderer={this.colorOptionRenderer}
+                    />
+                  </td>
+                  <td>
+                    <Select
+                      clearable={false}
+                      options={bannerBackgroundColorOptions}
+                      onChange={(option: Option<string>) => this.onBackgroundColorChange(idx, option)}
+                      optionRenderer={this.colorOptionRenderer}
+                      value={banner.backgroundColor}
+                      valueRenderer={this.colorOptionRenderer}
+                    />
+                  </td>
+                  <td>
+                    <button className="link custom-banner-config-remove" onClick={() => this.removeBanner(idx)}>
+                      <span className="glyphicon glyphicon-trash" />
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <div className="col-md-10 col-md-offset-1">
+          <button className="btn btn-block add-new" onClick={this.addBanner}>
+            <span className="glyphicon glyphicon-plus-sign" /> Add banner
+          </button>
+        </div>
+        <ConfigSectionFooter
+          isDirty={this.isDirty()}
+          isValid={true}
+          isSaving={this.props.isSaving}
+          saveError={false}
+          onRevertClicked={this.onRevertClicked}
+          onSaveClicked={this.onSaveClicked}
+        />
+      </div>
+    );
+  }
+}

--- a/app/scripts/modules/core/src/application/config/customBanner/customBannerColors.ts
+++ b/app/scripts/modules/core/src/application/config/customBanner/customBannerColors.ts
@@ -1,0 +1,71 @@
+import { Option } from 'react-select';
+
+export const bannerBackgroundColorOptions: Array<Option<string>> = [
+  {
+    label: 'danger',
+    value: 'var(--color-danger)',
+  },
+  {
+    label: 'danger-light',
+    value: 'var(--color-danger-light)',
+  },
+  {
+    label: 'alert',
+    value: 'var(--color-alert)',
+  },
+  {
+    label: 'alert-light',
+    value: 'var(--color-alert-light)',
+  },
+  {
+    label: 'warning',
+    value: 'var(--color-warning)',
+  },
+  {
+    label: 'warning-light',
+    value: 'var(--color-warning-light)',
+  },
+  {
+    label: 'success',
+    value: 'var(--color-success)',
+  },
+  {
+    label: 'success-light',
+    value: 'var(--color-success-light)',
+  },
+  {
+    label: 'accessory',
+    value: 'var(--color-accessory)',
+  },
+  {
+    label: 'accessory-light',
+    value: 'var(--color-accessory-light)',
+  },
+];
+
+export const bannerTextColorOptions: Array<Option<string>> = [
+  {
+    label: 'text-primary',
+    value: 'var(--color-text-primary)',
+  },
+  {
+    label: 'text-secondary',
+    value: 'var(--color-text-secondary)',
+  },
+  {
+    label: 'text-accent',
+    value: 'var(--color-text-accent)',
+  },
+  {
+    label: 'text-caption',
+    value: 'var(--color-text-caption)',
+  },
+  {
+    label: 'text-link',
+    value: 'var(--color-text-link)',
+  },
+  {
+    label: 'text-on-dark',
+    value: 'var(--color-text-on-dark)',
+  },
+];

--- a/app/scripts/modules/core/src/application/config/customBanner/customBannerConfig.component.ts
+++ b/app/scripts/modules/core/src/application/config/customBanner/customBannerConfig.component.ts
@@ -1,0 +1,10 @@
+import { module } from 'angular';
+import { react2angular } from 'react2angular';
+
+import { CustomBannerConfig } from './CustomBannerConfig';
+
+export const CUSTOM_BANNER_CONFIG = 'spinnaker.kubernetes.core.bannerConfig.component';
+module(CUSTOM_BANNER_CONFIG, []).component(
+  'customBannerConfig',
+  react2angular(CustomBannerConfig, ['bannerConfigs', 'isSaving', 'saveError', 'updateBannerConfigs']),
+);

--- a/app/scripts/modules/core/src/application/config/customBanner/customBannerConfig.less
+++ b/app/scripts/modules/core/src/application/config/customBanner/customBannerConfig.less
@@ -1,0 +1,27 @@
+.custom-banner-config-container {
+  display: flex;
+  flex-direction: column;
+}
+
+.custom-banner-config-description {
+  margin-bottom: 10px;
+}
+
+.custom-banner-config-textarea {
+  resize: vertical;
+  min-height: 50px;
+  max-height: 150px;
+}
+
+.custom-banner-config-color-option {
+  height: 20px;
+  border: 1px solid var(--color-alto);
+}
+
+.Select-value .custom-banner-config-color-option {
+  margin: 4px 12px 4px 4px;
+}
+
+.custom-banner-config-color-option-column {
+  width: 15%;
+}

--- a/app/scripts/modules/core/src/bootstrap/bootstrap.module.ts
+++ b/app/scripts/modules/core/src/bootstrap/bootstrap.module.ts
@@ -3,6 +3,11 @@ import { IModule, module } from 'angular';
 import { OVERRIDE_REGISTRY } from 'core/overrideRegistry/override.registry';
 
 import { SPINNAKER_HEADER } from 'core/header/spinnakerHeader.component';
+import { CUSTOM_BANNER } from 'core/header/customBanner/customBanner.component';
 
 export const APPLICATION_BOOTSTRAP_MODULE = 'spinnaker.core.applicationBootstrap';
-export const bootstrapModule = module(APPLICATION_BOOTSTRAP_MODULE, [OVERRIDE_REGISTRY, SPINNAKER_HEADER]) as IModule;
+export const bootstrapModule = module(APPLICATION_BOOTSTRAP_MODULE, [
+  OVERRIDE_REGISTRY,
+  SPINNAKER_HEADER,
+  CUSTOM_BANNER,
+]) as IModule;

--- a/app/scripts/modules/core/src/bootstrap/customBanner.html
+++ b/app/scripts/modules/core/src/bootstrap/customBanner.html
@@ -1,0 +1,1 @@
+<custom-banner></custom-banner>

--- a/app/scripts/modules/core/src/bootstrap/spinnaker.component.ts
+++ b/app/scripts/modules/core/src/bootstrap/spinnaker.component.ts
@@ -13,6 +13,7 @@ const template = `
       <loading-spinner size="'medium'"></loading-spinner>
     </div>
     <div class="navbar-inverse grid-header">
+      <custom-banner></custom-banner>
       <div ng-include="$ctrl.spinnakerHeaderTemplate"></div>
     </div>
 

--- a/app/scripts/modules/core/src/core.module.ts
+++ b/app/scripts/modules/core/src/core.module.ts
@@ -34,6 +34,7 @@ import { ARTIFACT_MODULE } from './artifact/artifact.module';
 import { AUTHENTICATION_MODULE } from './authentication/authentication.module';
 import { CLOUD_PROVIDER_MODULE } from './cloudProvider/cloudProvider.module';
 import { CLUSTER_MODULE } from './cluster/cluster.module';
+import { CUSTOM_BANNER_CONFIG } from './application/config/customBanner/customBannerConfig.component';
 
 import { DEBUG_WINDOW } from './utils/consoleDebug';
 import { DEPLOYMENT_STRATEGY_MODULE } from './deploymentStrategy/deploymentStrategy.module';
@@ -92,6 +93,7 @@ module(CORE_MODULE, [
 
   CLOUD_PROVIDER_MODULE,
   CLUSTER_MODULE,
+  CUSTOM_BANNER_CONFIG,
 
   DEBUG_WINDOW,
   DEPLOYMENT_STRATEGY_MODULE,

--- a/app/scripts/modules/core/src/header/customBanner/CustomBanner.less
+++ b/app/scripts/modules/core/src/header/customBanner/CustomBanner.less
@@ -1,0 +1,9 @@
+.custom-banner {
+  height: 30px;
+  line-height: 30px;
+  overflow: hidden;
+  padding: 0 10px;
+  text-align: center;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/app/scripts/modules/core/src/header/customBanner/CustomBanner.spec.tsx
+++ b/app/scripts/modules/core/src/header/customBanner/CustomBanner.spec.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+
+import { Application } from 'core/application/application.model';
+import { ICustomBannerConfig } from 'core/application/config/customBanner/CustomBannerConfig';
+import { getTestBannerConfigs } from 'core/application/config/customBanner/CustomBannerConfig.spec';
+
+import { CustomBanner } from './CustomBanner';
+
+describe('<CustomBanner />', () => {
+  let application: Application;
+  let wrapper: any;
+  let bannerConfigs: ICustomBannerConfig[];
+
+  beforeEach(() => {
+    application = new Application('my-app', null, []);
+    wrapper = shallow(<CustomBanner />);
+    bannerConfigs = getTestBannerConfigs();
+  });
+
+  describe('view', () => {
+    it('renders no banner by default', () => {
+      expect(wrapper.state('bannerConfig')).toBeNull();
+      expect(wrapper.find('.custom-banner').length).toEqual(0);
+    });
+
+    it('renders banner when appropriate', () => {
+      wrapper.setState({ bannerConfig: bannerConfigs[0] });
+      expect(wrapper.find('.custom-banner').length).toEqual(1);
+    });
+
+    describe('functionality', () => {
+      it('updates state appropriately when no enabled banner found on app attributes', () => {
+        expect(wrapper.state('bannerConfig')).toBeNull();
+        application.attributes.customBanners = null;
+        wrapper.instance().updateBannerConfig(application);
+        expect(wrapper.state('bannerConfig')).toBeNull();
+      });
+      it('updates state appropriately when enabled banner found on app attributes', () => {
+        expect(wrapper.state('bannerConfig')).toBeNull();
+        application.attributes.customBanners = bannerConfigs;
+        wrapper.instance().updateBannerConfig(application);
+        expect(wrapper.state('bannerConfig')).toEqual(bannerConfigs[0]);
+      });
+    });
+  });
+});

--- a/app/scripts/modules/core/src/header/customBanner/CustomBanner.tsx
+++ b/app/scripts/modules/core/src/header/customBanner/CustomBanner.tsx
@@ -1,0 +1,77 @@
+import * as React from 'react';
+import { get } from 'lodash';
+
+import { ICustomBannerConfig } from 'core/application/config/customBanner/CustomBannerConfig';
+import { Application } from 'core/application/application.model';
+import { ApplicationReader } from 'core/application/service/ApplicationReader';
+import { ReactInjector } from 'core/reactShims';
+import { noop } from 'core/utils';
+
+import './CustomBanner.less';
+
+export interface ICustomBannerState {
+  applicationName: string;
+  bannerConfig: ICustomBannerConfig;
+}
+
+export class CustomBanner extends React.Component<{}, ICustomBannerState> {
+  private locationChangeUnsubscribe: Function;
+
+  public state = {
+    applicationName: null,
+    bannerConfig: null,
+  } as ICustomBannerState;
+
+  public componentDidMount(): void {
+    this.locationChangeUnsubscribe = ReactInjector.$uiRouter.transitionService.onSuccess({}, () =>
+      this.updateApplication(),
+    );
+  }
+
+  private updateApplication(): void {
+    const applicationName: string = get(ReactInjector, '$stateParams.application');
+    if (applicationName !== this.state.applicationName) {
+      this.setState({
+        applicationName,
+        bannerConfig: null,
+      });
+      if (applicationName != null) {
+        ApplicationReader.getApplication(applicationName)
+          .then((app: Application) => {
+            this.updateBannerConfig(app);
+          })
+          .catch(noop);
+      }
+    }
+  }
+
+  public updateBannerConfig(application: Application): void {
+    const bannerConfigs: ICustomBannerConfig[] = get(application, 'attributes.customBanners') || [];
+    const bannerConfig = bannerConfigs.find(config => config.enabled) || null;
+    this.setState({
+      bannerConfig,
+    });
+  }
+
+  public render(): React.ReactElement<CustomBanner> {
+    const { bannerConfig } = this.state;
+    if (bannerConfig == null) {
+      return null;
+    }
+    return (
+      <div
+        className="custom-banner"
+        style={{
+          background: bannerConfig.backgroundColor,
+          color: bannerConfig.textColor,
+        }}
+      >
+        {bannerConfig.text}
+      </div>
+    );
+  }
+
+  public componentWillUnmount(): void {
+    this.locationChangeUnsubscribe();
+  }
+}

--- a/app/scripts/modules/core/src/header/customBanner/customBanner.component.ts
+++ b/app/scripts/modules/core/src/header/customBanner/customBanner.component.ts
@@ -1,0 +1,7 @@
+import { module } from 'angular';
+import { react2angular } from 'react2angular';
+
+import { CustomBanner } from './CustomBanner';
+
+export const CUSTOM_BANNER = 'spinnaker.core.banner.component';
+module(CUSTOM_BANNER, []).component('customBanner', react2angular(CustomBanner));


### PR DESCRIPTION
Let me know if you all have any thoughts on making the custom banners more or less configurable -- the specific use case this was requested for was putting up production freeze or maintenance alerts on specific applications.

![b5455002-3461-4792-b8f9-c8e06eae1b1f](https://user-images.githubusercontent.com/15936279/52237459-9070e000-2897-11e9-92b3-9469514e627c.gif)

