### PR TITLE
fix(core): do not edit live copy of pipeline configs

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/pipelineConfig.controller.js
+++ b/app/scripts/modules/core/src/pipeline/config/pipelineConfig.controller.js
@@ -35,6 +35,9 @@ module.exports = angular
           this.state.notFound = true;
         }
       }
+      if (this.pipelineConfig) {
+        this.pipelineConfig = _.cloneDeep(this.pipelineConfig);
+      }
     };
 
     if (!app.notFound) {


### PR DESCRIPTION
It's kind of nuts that, when you are editing a pipeline config, you're editing the actual data source data and not a copy.

This manifests when changing a pipeline config, navigating away (confirming you're leaving unsaved changes), then navigating back. If, for example, you removed a stage, that stage can still be missing when you navigate back if the pipeline configs have not refreshed yet.