### PR TITLE
feat(core): better handle stage removal

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/pipelineConfigurer.js
+++ b/app/scripts/modules/core/src/pipeline/config/pipelineConfigurer.js
@@ -339,7 +339,12 @@ module.exports = angular
       $scope.renderablePipeline.stages.splice(stageIndex, 1);
       $scope.renderablePipeline.stages.forEach(test => {
         if (stage.refId && test.requisiteStageRefIds) {
-          test.requisiteStageRefIds = _.without(test.requisiteStageRefIds, stage.refId);
+          if (test.requisiteStageRefIds.includes(stage.refId)) {
+            test.requisiteStageRefIds = test.requisiteStageRefIds.filter(id => id !== stage.refId);
+            if (!test.requisiteStageRefIds.length) {
+              test.requisiteStageRefIds = [...stage.requisiteStageRefIds];
+            }
+          }
         }
       });
       if (stageIndex > 0) {


### PR DESCRIPTION
When a user deletes a downstream stage, it gets really ugly when there are no additional downstream stages, because it becomes an orphaned branch of the pipeline, sad:

An open question is: if a stage depends on two stages, and you remove one of the stages, should it now depend on the stages the removed stage depended on? With this PR, it won't - it'll only attach if its only upstream stage was the removed one.