### PR TITLE
fix(executions): Fixed stage does not open when clicked

### DIFF
--- a/app/scripts/modules/core/src/pipeline/executions/execution/Execution.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/execution/Execution.tsx
@@ -63,7 +63,7 @@ export class Execution extends React.Component<IExecutionProps, IExecutionState>
     const initialViewState = {
       activeStageId: Number($stateParams.stage),
       activeSubStageId: Number($stateParams.subStage),
-      executionId: execution.id,
+      executionId: $stateParams.executionId,
       canTriggerPipelineManually: false,
       canConfigure: false,
     };


### PR DESCRIPTION
This fixes the bug where clicking the stage of another execution does not open that execution's details and display the details of the clicked stage.

Based on the following usage, it seems like `viewState.executionId` is meant to track against the global router state (which execution, if any, is expanded):
https://github.com/spinnaker/deck/blob/d09a9103b3ae434a25f88b4ff78cf8bb02e987f9/app/scripts/modules/core/src/pipeline/executions/execution/Execution.tsx#L89

If the `viewState` is initialized to the component's execution ID and not `$stateParams.executionId`, the following condition fails:
https://github.com/spinnaker/deck/blob/d09a9103b3ae434a25f88b4ff78cf8bb02e987f9/app/scripts/modules/core/src/pipeline/executions/execution/Execution.tsx#L90-L95
 and prevents `showingDetails` from being recomputed (and thus we don't show the details).