### PR TITLE
fix(core/modal): Import IModalComponentProps relatively 

### DIFF
--- a/app/scripts/modules/core/src/modal/wizard/WizardModal.tsx
+++ b/app/scripts/modules/core/src/modal/wizard/WizardModal.tsx
@@ -4,10 +4,10 @@ import { Modal } from 'react-bootstrap';
 import { without, merge } from 'lodash';
 
 import { TaskMonitor } from 'core/task';
-import { IModalComponentProps } from 'core/presentation';
 import { NgReact } from 'core/reactShims';
 import { Spinner } from 'core/widgets';
 
+import { IModalComponentProps } from '../../presentation/ReactModal';
 import { ModalClose } from '../buttons/ModalClose';
 import { SubmitButton } from '../buttons/SubmitButton';
 import { WizardPage } from './WizardPage';


### PR DESCRIPTION
instead of from `core` so downstream projects don't need a `core` alias in tsconfig

This fixes a problem in our custom build where `IWizardModalProps` extends `IModalComponentProps` but `IModalComponentProps` could not be found.  This was because in the downstream project, TypeScript tries to resolve the `extends IModalComponentProps` clause through the `import { IModalComponentProps from 'core/presentation'`.  However, the downstream project's tsconfig.json isn't configured with a `"paths": { "core": "......" }`.  Typescript can't find the interface and gives up.  There is no error because we tell typescript not to check libraries via `skipLibCheck: true`