### PR TITLE
fix(core): read displayTimestampsInUserLocalTime off SETTINGS.feature

### DIFF
--- a/app/scripts/modules/core/src/config/settings.ts
+++ b/app/scripts/modules/core/src/config/settings.ts
@@ -35,6 +35,7 @@ export interface IFeatures {
   [key: string]: any;
   canary?: boolean;
   chaosMonkey?: boolean;
+  displayTimestampsInUserLocalTime?: boolean;
   dockerBake?: boolean;
   entityTags?: boolean;
   fiatEnabled?: boolean;
@@ -86,7 +87,6 @@ export interface ISpinnakerSettings {
   defaultProviders: string[];
   defaultTimeZone: string; // see http://momentjs.com/timezone/docs/#/data-utilities/
   dockerInsights: IDockerInsightSettings;
-  displayTimestampsInUserLocalTime: boolean;
   entityTags?: {
     maxUrlLength?: number;
   };

--- a/app/scripts/modules/core/src/utils/timeFormatters.spec.ts
+++ b/app/scripts/modules/core/src/utils/timeFormatters.spec.ts
@@ -62,7 +62,7 @@ describe('Filter: timeFormatters', function() {
         expect(filter(1445707299020)).toBe('2015-10-24 17:21:39 GMT');
       });
       it('returns formatted date in user local time when valid value is provided', function() {
-        SETTINGS.displayTimestampsInUserLocalTime = true;
+        SETTINGS.feature.displayTimestampsInUserLocalTime = true;
         spyOn(moment.tz, 'guess').and.callFake(function() {
           return 'Asia/Tokyo'; // +09:00
         });

--- a/app/scripts/modules/core/src/utils/timeFormatters.ts
+++ b/app/scripts/modules/core/src/utils/timeFormatters.ts
@@ -29,7 +29,7 @@ export function timestamp(input: any) {
   if (!isInputValid(input)) {
     return '-';
   }
-  const tz = SETTINGS.displayTimestampsInUserLocalTime ? moment.tz.guess() : SETTINGS.defaultTimeZone;
+  const tz = SETTINGS.feature.displayTimestampsInUserLocalTime ? moment.tz.guess() : SETTINGS.defaultTimeZone;
   const thisMoment = moment.tz(parseInt(input, 10), tz);
   return thisMoment.isValid() ? thisMoment.format('YYYY-MM-DD HH:mm:ss z') : '-';
 }


### PR DESCRIPTION
[This](https://github.com/spinnaker/deck/pull/6362) PR added the `displayTimestampsInUserLocalTime` feature flag to `SETTINGS.feature` in `settings.js` and `halconfig/settings.js` but tried to read it off of `SETTINGS` directly. This change makes sure that it is read off of `SETTINGS.feature` everywhere.