### PR TITLE
fix(amazon): do not mutate nested objects on clone server group command

### DIFF
--- a/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupConfiguration.service.ts
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupConfiguration.service.ts
@@ -147,9 +147,9 @@ export class AwsServerGroupConfigurationService {
       command.suspendedProcesses = command.suspendedProcesses || [];
       const processIndex = command.suspendedProcesses.indexOf(process);
       if (processIndex === -1) {
-        command.suspendedProcesses.push(process);
+        command.suspendedProcesses = command.suspendedProcesses.concat(process);
       } else {
-        command.suspendedProcesses.splice(processIndex, 1);
+        command.suspendedProcesses = command.suspendedProcesses.filter(p => p !== process);
       }
     };
 

--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/capacity/CapacitySelector.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/capacity/CapacitySelector.tsx
@@ -44,9 +44,7 @@ export class CapacitySelector extends React.Component<ICapacitySelectorProps> {
   private setMinMax(value: number) {
     const { command } = this.props;
     if (command.viewState.useSimpleCapacity) {
-      command.capacity.min = value;
-      command.capacity.max = value;
-      command.capacity.desired = value;
+      command.capacity = { min: value, max: value, desired: value };
       this.props.setFieldValue('useSourceCapacity', false);
       this.props.setFieldValue('capacity', command.capacity);
     }
@@ -61,6 +59,7 @@ export class CapacitySelector extends React.Component<ICapacitySelectorProps> {
   private capacityFieldChanged = (fieldName: 'min' | 'max' | 'desired', value: string) => {
     const { command, setFieldValue } = this.props;
     const num = Number.parseInt(value, 10);
+    command.capacity = { ...command.capacity };
     command.capacity[fieldName] = num;
     setFieldValue('capacity', command.capacity);
   };

--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/ServerGroupBasicSettings.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/ServerGroupBasicSettings.tsx
@@ -131,8 +131,9 @@ export class ServerGroupBasicSettings
   }
 
   private clientRequestsChanged = () => {
-    const { values } = this.props.formik;
+    const { values, setFieldValue } = this.props.formik;
     values.toggleSuspendedProcess(values, 'AddToLoadBalancer');
+    setFieldValue('suspendedProcesses', values.suspendedProcesses);
     this.setState({});
   };
 

--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/ServerGroupZones.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/ServerGroupZones.tsx
@@ -27,8 +27,9 @@ export class ServerGroupZones extends React.Component<IServerGroupZonesProps>
   };
 
   private rebalanceToggled = () => {
-    const { values } = this.props.formik;
+    const { values, setFieldValue } = this.props.formik;
     values.toggleSuspendedProcess(values, 'AZRebalance');
+    setFieldValue('suspendedProcesses', values.suspendedProcesses);
     this.setState({});
   };
 

--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/advancedSettings/ServerGroupAdvancedSettingsCommon.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/advancedSettings/ServerGroupAdvancedSettingsCommon.tsx
@@ -32,8 +32,9 @@ export class ServerGroupAdvancedSettingsCommon extends React.Component<IServerGr
   };
 
   private toggleSuspendedProcess = (process: string) => {
-    const { values } = this.props.formik;
+    const { values, setFieldValue } = this.props.formik;
     values.toggleSuspendedProcess(values, process);
+    setFieldValue('suspendedProcesses', values.suspendedProcesses);
     this.setState({});
   };
 


### PR DESCRIPTION
Formik does not seem to recognize a nested field value mutation as a mutation, so it won't set the `dirty` flag to true, which prevents form submission if only these values are changed.

There might be another one or two lurking in that modal but these are the obvious ones.