### PR TITLE
fix(tests): functional test runner needs imports converted to requires

### DIFF
--- a/test/functional/run.js
+++ b/test/functional/run.js
@@ -1,9 +1,11 @@
 #!/usr/bin/env node
 
+const process = require('process');
+process.env.TS_NODE_COMPILER_OPTIONS = '{"module":"commonjs"}';
+
 require('ts-node/register');
 
 const path = require('path');
-const process = require('process');
 const minimist = require('minimist');
 const { TestRunner } = require('./tools/TestRunner');
 


### PR DESCRIPTION
The functional test runner code is executed by node.js. Since `import` statements aren't yet supported in node we need to tell the typescript compiler to convert them to `require()` calls instead.

Prior to this change the functional tests fail with the following error:

```javascript
(function (exports, require, module, __filename, __dirname) { import * as process from 'process';
                                                              ^^^^^^

SyntaxError: Unexpected token import
    at createScript (vm.js:80:10)
    at Object.runInThisContext (vm.js:139:10)
    at Module._compile (module.js:617:28)
    at Module.m._compile (/Users/sbws/dev/spinnaker/deck/node_modules/ts-node/src/index.ts:439:23)
    at Module._extensions..js (module.js:664:10)
    at Object.require.extensions.(anonymous function) [as .ts] (/Users/sbws/dev/spinnaker/deck/node_modules/ts-node/src/index.ts:442:12)
    at Module.load (module.js:566:32)
    at tryModuleLoad (module.js:506:12)
    at Function.Module._load (module.js:498:3)
    at Module.require (module.js:597:17)
```