### PR TITLE
fix(style): Upgrade bootstrap to avoid XSS vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "angular-ui-sortable": "^0.17.0",
     "angular2react": "^3.0.2",
     "babel-preset-env": "^1.6.1",
-    "bootstrap": "3.3.7",
+    "bootstrap": "3.4.0",
     "cachefactory": "^3.0.0",
     "classname": "^0.0.0",
     "clipboard": "^1.5.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2591,6 +2591,11 @@ bootstrap@3.3.7:
   resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-3.3.7.tgz#5a389394549f23330875a3b150656574f8a9eb71"
   integrity sha1-WjiTlFSfIzMIdaOxUGVldPip63E=
 
+bootstrap@3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-3.4.0.tgz#f8d77540dd3062283d2ae7687e21c1e691961640"
+  integrity sha512-F1yTDO9OHKH0xjl03DsOe8Nu1OWBIeAugGMhy3UTIYDdbbIPesQIhCEbj+HEr6wqlwweGAlP8F3OBC6kEuhFuw==
+
 boundary-cells@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/boundary-cells/-/boundary-cells-2.0.1.tgz#e905a8d1419cf47cb36be3dbf525db5e24de0042"


### PR DESCRIPTION
Bootstrap 3.3.7 was found to have three XSS vulnerabilities. 

Bootstrap released a patch 3.4.0 which fixes these issues and does not include any new features or updates to existing ones which will break our styles. I ran a quick test on all our pages and found them to look exactly the same.

Reference:  https://blog.getbootstrap.com/2018/12/13/bootstrap-3-4-0/ 
If you are still worried: https://github.com/twbs/bootstrap/pull/27288 