### PR TITLE
refactor(amazon): make cluster selection optional

### DIFF
--- a/app/scripts/modules/core/src/widgets/accountRegionClusterSelector.component.html
+++ b/app/scripts/modules/core/src/widgets/accountRegionClusterSelector.component.html
@@ -27,11 +27,13 @@
     include-select-all-button="true">
   </checklist>
 </stage-config-field>
-<stage-config-field label="Cluster" help-key="pipeline.config.findAmi.cluster">
-  <cluster-selector
-    clusters="vm.clusterList"
-    model="vm.component[vm.clusterField]"
-    toggled="vm.clusterSelectInputToggled(isToggled)"
-    on-change="vm.clusterChanged(clusterName)">
-  </cluster-selector>
-</stage-config-field>
+<div ng-if="vm.showClusterSelect">
+  <stage-config-field label="Cluster" help-key="pipeline.config.findAmi.cluster">
+    <cluster-selector
+      clusters="vm.clusterList"
+      model="vm.component[vm.clusterField]"
+      toggled="vm.clusterSelectInputToggled(isToggled)"
+      on-change="vm.clusterChanged(clusterName)">
+    </cluster-selector>
+  </stage-config-field>
+</div>

--- a/app/scripts/modules/core/src/widgets/accountRegionClusterSelector.component.js
+++ b/app/scripts/modules/core/src/widgets/accountRegionClusterSelector.component.js
@@ -22,6 +22,7 @@ module.exports = angular
         showAllRegions: '=?',
         onAccountUpdate: '&?',
         disableRegionSelect: '=?',
+        showClusterSelect: '=?',
       },
       templateUrl: require('./accountRegionClusterSelector.component.html'),
       controllerAs: 'vm',
@@ -29,6 +30,11 @@ module.exports = angular
         this.clusterField = this.clusterField || 'cluster';
 
         let vm = this;
+
+        if (vm.showClusterSelect === undefined) {
+          vm.showClusterSelect = true;
+        }
+
         let showAllRegions = vm.showAllRegions || false;
 
         let isTextInputForClusterFiled;


### PR DESCRIPTION
The upcoming CloudFormation stage needs to select the account and region
where the CloudFormation template is deployed, but not the clusters.

This patch makes the cluster selection optional, defaulting to true
(show the cluster selection) which is the current behaviour.