### PR TITLE
fix(kubernetes): do not override `location` and `replicas` in new Sca…

### DIFF
--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/scaleManifest/scaleManifestConfig.controller.ts
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/scaleManifest/scaleManifestConfig.controller.ts
@@ -1,4 +1,5 @@
 import { IController, IScope } from 'angular';
+import { defaults } from 'lodash';
 
 import { IManifestSelector } from 'kubernetes/v2/manifest/selector/IManifestSelector';
 import { Application } from '@spinnaker/core';
@@ -14,12 +15,12 @@ export class KubernetesV2ScaleManifestConfigCtrl implements IController {
         location: '',
         account: '',
       };
-      Object.assign(this.$scope.stage, defaultSelection);
+      defaults(this.$scope.stage, defaultSelection);
       const defaultOptions: any = {
         replicas: null,
         app: this.application.name,
       };
-      Object.assign(this.$scope.stage, defaultOptions);
+      defaults(this.$scope.stage, defaultOptions);
       this.$scope.stage.cloudProvider = 'kubernetes';
     }
   }


### PR DESCRIPTION
…le Manifest stage

Closes https://github.com/spinnaker/spinnaker/issues/3949

We do not remove the `isNew` field from a stage [until the pipeline is saved](https://github.com/spinnaker/deck/blob/master/app/scripts/modules/core/src/pipeline/config/services/PipelineConfigService.ts#L66), so previously we were overwriting fields on the Scale Manifest stage each time the form re-rendered when clicking back and forth among other stages and the new Scale Manifest stage. This switches `Object.assign` --> `_.defaults` so non-undefined values are not overwritten.