### PR TITLE
feat(core): add getApplicationAttributes method

### DIFF
--- a/app/scripts/modules/core/src/application/service/ApplicationReader.ts
+++ b/app/scripts/modules/core/src/application/service/ApplicationReader.ts
@@ -31,6 +31,16 @@ export class ApplicationReader {
       .getList();
   }
 
+  public static getApplicationAttributes(name: string): IPromise<any> {
+    return API.one('applications', name)
+      .withParams({ expand: false })
+      .get()
+      .then((fromServer: Application) => {
+        this.splitAttributes(fromServer.attributes, ['accounts', 'cloudProviders']);
+        return fromServer.attributes;
+      });
+  }
+
   public static getApplication(name: string, expand = true): IPromise<Application> {
     return API.one('applications', name)
       .withParams({ expand: expand })

--- a/app/scripts/modules/core/src/header/customBanner/CustomBanner.tsx
+++ b/app/scripts/modules/core/src/header/customBanner/CustomBanner.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { get } from 'lodash';
 
 import { ICustomBannerConfig } from 'core/application/config/customBanner/CustomBannerConfig';
-import { Application } from 'core/application/application.model';
 import { ApplicationReader } from 'core/application/service/ApplicationReader';
 import { ReactInjector } from 'core/reactShims';
 import { noop } from 'core/utils';
@@ -35,18 +34,18 @@ export class CustomBanner extends React.Component<{}, ICustomBannerState> {
         applicationName,
         bannerConfig: null,
       });
-      if (applicationName != null) {
-        ApplicationReader.getApplication(applicationName)
-          .then((app: Application) => {
-            this.updateBannerConfig(app);
+      if (applicationName) {
+        ApplicationReader.getApplicationAttributes(applicationName)
+          .then((attributes: any) => {
+            this.updateBannerConfig(attributes);
           })
           .catch(noop);
       }
     }
   }
 
-  public updateBannerConfig(application: Application): void {
-    const bannerConfigs: ICustomBannerConfig[] = get(application, 'attributes.customBanners') || [];
+  public updateBannerConfig(attributes: any): void {
+    const bannerConfigs: ICustomBannerConfig[] = get(attributes, 'customBanners') || [];
     const bannerConfig = bannerConfigs.find(config => config.enabled) || null;
     this.setState({
       bannerConfig,


### PR DESCRIPTION
Calling `.getApplication` spawns an entire application object, complete with refreshing data sources and all kinds of other things that may not be expected.

@maggieneterval I added this method for something completely unrelated (on our internal build) and saw this was a good place to use it in OSS. It prevents a double loading of server groups and other always-active data sources when switching applications.