### PR TITLE
chore(core): update banner spec

### DIFF
--- a/app/scripts/modules/core/src/header/customBanner/CustomBanner.spec.tsx
+++ b/app/scripts/modules/core/src/header/customBanner/CustomBanner.spec.tsx
@@ -33,13 +33,13 @@ describe('<CustomBanner />', () => {
       it('updates state appropriately when no enabled banner found on app attributes', () => {
         expect(wrapper.state('bannerConfig')).toBeNull();
         application.attributes.customBanners = null;
-        wrapper.instance().updateBannerConfig(application);
+        wrapper.instance().updateBannerConfig(application.attributes);
         expect(wrapper.state('bannerConfig')).toBeNull();
       });
       it('updates state appropriately when enabled banner found on app attributes', () => {
         expect(wrapper.state('bannerConfig')).toBeNull();
         application.attributes.customBanners = bannerConfigs;
-        wrapper.instance().updateBannerConfig(application);
+        wrapper.instance().updateBannerConfig(application.attributes);
         expect(wrapper.state('bannerConfig')).toEqual(bannerConfigs[0]);
       });
     });


### PR DESCRIPTION
Travis builds are failing because this test has been failing since [this PR](https://github.com/spinnaker/deck/pull/6512/files) updated the banner component to use `getApplicationAttributes` rather than `getApplication`