### PR TITLE
fix(amazon/core): Sorting order of regions in bake stage + lint fix

### DIFF
--- a/app/scripts/modules/amazon/src/pipeline/stages/bake/awsBakeStage.js
+++ b/app/scripts/modules/amazon/src/pipeline/stages/bake/awsBakeStage.js
@@ -43,7 +43,7 @@ module.exports = angular
   })
   .controller('awsBakeStageCtrl', function($scope, $q, $uibModal) {
     $scope.stage.extendedAttributes = $scope.stage.extendedAttributes || {};
-    $scope.stage.regions = $scope.stage.regions || [];
+    $scope.stage.regions = ($scope.stage.regions && $scope.stage.regions.sort()) || [];
 
     if (!$scope.stage.user) {
       $scope.stage.user = AuthenticationService.getAuthenticatedUser().name;

--- a/app/scripts/modules/core/src/account/accountTag.less
+++ b/app/scripts/modules/core/src/account/accountTag.less
@@ -52,6 +52,6 @@
   }
 
   .account-tag {
-    border-top: 1px solid white;
+    border-top: 1px solid var(--color-white);
   }
 }


### PR DESCRIPTION
Regions in bake stage are sorted. Lint warnings fixed. 

Regions in bake stage configuration while setting up a pipeline is not sorted. Find Image stage however has it sorted. Sorted the list of regions. 
There was an additional lint warning for a color which is also fixed. 

![image](https://user-images.githubusercontent.com/2153660/52497684-8ac31500-2b8b-11e9-86c7-6d25f086bbe1.png)
