### PR TITLE
fix(core): Max remaining ASG should honor value being removed

### DIFF
--- a/app/scripts/modules/core/src/deploymentStrategy/strategies/redblack/redblack.strategy.ts
+++ b/app/scripts/modules/core/src/deploymentStrategy/strategies/redblack/redblack.strategy.ts
@@ -28,7 +28,7 @@ DeploymentStrategyRegistry.registerStrategy({
       rollback: {
         onFailure: false,
       },
-      maxRemainingAsgs: 2,
+      maxRemainingAsgs: !command.strategy ? 2 : command.maxRemainingAsgs,
       delayBeforeDisableSec: 0,
       delayBeforeScaleDownSec: 0,
       scaleDown: false,


### PR DESCRIPTION
maxRemainingAsgs use default placeholder value of 2 even if it is manually removed.

Scenario: A user configures a deploy stage with redblack and creates a cluster. This has a default maxRemainingAsg value of 2 by default. Now the user removes the maxRemainingAsgs from the pipeline JSON and saves the config. When the user gets to the cluster configuration in the UI, the maxRemainingAsg is set to 2 even though the value has been removed. This is incorrect because now the number of remaining ASGs is infinite and not 2 because it is not set. 
In this solution, I read if the strategy has already been set to determine if its a first time cluster config or existing cluster config. Based on that, it chooses whether to show the default values or not. This solution is easier than passing down if the cluster is in "create" or "edit" mode. 
