### PR TITLE
chore(cf): rename serviceName to serviceInstanceName

### DIFF
--- a/app/scripts/modules/cloudfoundry/src/pipeline/stages/deployService/CloudfoundryDeployServiceStageConfig.tsx
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/stages/deployService/CloudfoundryDeployServiceStageConfig.tsx
@@ -49,7 +49,7 @@ export class CloudfoundryDeployServiceStageConfig extends React.Component<
     props.stage.cloudProvider = 'cloudfoundry';
     props.stage.manifest = props.stage.manifest || {
       service: '',
-      serviceName: '',
+      serviceInstanceName: '',
       servicePlan: '',
       parameters: '',
       type: 'direct',
@@ -71,7 +71,7 @@ export class CloudfoundryDeployServiceStageConfig extends React.Component<
       case 'direct':
         this.props.stage.manifest = {
           service: '',
-          serviceName: '',
+          serviceInstanceName: '',
           servicePlan: '',
           type: 'direct',
         };
@@ -89,7 +89,7 @@ export class CloudfoundryDeployServiceStageConfig extends React.Component<
         this.props.stage.manifest = {
           credentials: '',
           routeServiceUrl: '',
-          serviceName: '',
+          serviceInstanceName: '',
           syslogDrainUrl: '',
           tags: [],
           type: 'userProvided',
@@ -147,7 +147,7 @@ export class CloudfoundryDeployServiceStageConfig extends React.Component<
     this.props.stage.credentials = credentials;
     this.props.stage.region = '';
     this.props.stage.manifest.service = '';
-    this.props.stage.manifest.serviceName = '';
+    this.props.stage.manifest.serviceInstanceName = '';
     this.props.stage.manifest.servicePlan = '';
     this.props.stageFieldUpdated();
     if (credentials) {
@@ -160,7 +160,7 @@ export class CloudfoundryDeployServiceStageConfig extends React.Component<
     this.setState({ region: region });
     this.props.stage.region = region;
     this.props.stage.manifest.service = '';
-    this.props.stage.manifest.serviceName = '';
+    this.props.stage.manifest.serviceInstanceName = '';
     this.props.stage.manifest.servicePlan = '';
     this.props.stageFieldUpdated();
     this.clearAndReloadServices();

--- a/app/scripts/modules/cloudfoundry/src/pipeline/stages/deployService/CreateServiceInstanceDirectInput.tsx
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/stages/deployService/CreateServiceInstanceDirectInput.tsx
@@ -16,7 +16,7 @@ interface ICreateServiceInstanceDirectInputProps {
 interface ICreateServiceInstanceDirectInputState {
   parameters?: string;
   service: string;
-  serviceName: string;
+  serviceInstanceName: string;
   servicePlan: string;
   tags?: string[];
 }
@@ -33,13 +33,13 @@ export class CreateServiceInstanceDirectInput extends React.Component<
     };
   }
 
-  private serviceNameUpdated = (event: React.ChangeEvent<HTMLInputElement>): void => {
-    const serviceName = event.target.value;
+  private serviceInstanceNameUpdated = (event: React.ChangeEvent<HTMLInputElement>): void => {
+    const serviceInstanceName = event.target.value;
     const { onChange, serviceInput } = this.props;
-    this.setState({ serviceName });
+    this.setState({ serviceInstanceName });
     onChange({
       ...serviceInput,
-      serviceName,
+      serviceInstanceName,
     } as ICloudFoundryServiceManifestSource);
   };
 
@@ -88,14 +88,19 @@ export class CreateServiceInstanceDirectInput extends React.Component<
 
   public render() {
     const { serviceInput, serviceNamesAndPlans } = this.props;
-    const { parameters, service, serviceName, servicePlan, tags } = serviceInput;
+    const { parameters, service, serviceInstanceName, servicePlan, tags } = serviceInput;
     const services = serviceNamesAndPlans.map(item => item.name);
     const serviceWithPlans = serviceNamesAndPlans.find(it => it.name === serviceInput.service);
     const servicePlans = serviceWithPlans ? serviceWithPlans.servicePlans.map((it: IServicePlan) => it.name) : [];
     return (
       <div>
-        <StageConfigField label="Service Name">
-          <TextInput type="text" className="form-control" onChange={this.serviceNameUpdated} value={serviceName} />
+        <StageConfigField label="Service Instance Name">
+          <TextInput
+            type="text"
+            className="form-control"
+            onChange={this.serviceInstanceNameUpdated}
+            value={serviceInstanceName}
+          />
         </StageConfigField>
         <StageConfigField label="Service">
           <ReactSelectInput clearable={false} onChange={this.serviceUpdated} value={service} stringOptions={services} />

--- a/app/scripts/modules/cloudfoundry/src/pipeline/stages/deployService/CreateUserProvidedInput.tsx
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/stages/deployService/CreateUserProvidedInput.tsx
@@ -11,7 +11,7 @@ interface ICreateServiceInstanceUserProvidedInputProps {
 }
 
 interface ICreateServiceInstanceUserProvidedInputState {
-  serviceName: string;
+  serviceInstanceName: string;
   tags?: string[];
   syslogDrainUrl?: string;
   credentials?: string;
@@ -28,13 +28,13 @@ export class CreateUserProvidedInput extends React.Component<
     this.state = { ...serviceInput };
   }
 
-  private serviceNameUpdated = (event: React.ChangeEvent<HTMLInputElement>): void => {
-    const serviceName = event.target.value;
+  private serviceInstanceNameUpdated = (event: React.ChangeEvent<HTMLInputElement>): void => {
+    const serviceInstanceName = event.target.value;
     const { onChange, serviceInput } = this.props;
-    this.setState({ serviceName });
+    this.setState({ serviceInstanceName });
     onChange({
       ...serviceInput,
-      serviceName,
+      serviceInstanceName,
     } as ICloudFoundryServiceManifestSource);
   };
 
@@ -78,11 +78,16 @@ export class CreateUserProvidedInput extends React.Component<
   };
 
   public render() {
-    const { serviceName, tags, syslogDrainUrl, credentials, routeServiceUrl } = this.state;
+    const { serviceInstanceName, tags, syslogDrainUrl, credentials, routeServiceUrl } = this.state;
     return (
       <>
-        <StageConfigField label="Service Name">
-          <TextInput type="text" className="form-control" onChange={this.serviceNameUpdated} value={serviceName} />
+        <StageConfigField label="Service Instance Name">
+          <TextInput
+            type="text"
+            className="form-control"
+            onChange={this.serviceInstanceNameUpdated}
+            value={serviceInstanceName}
+          />
         </StageConfigField>
         <StageConfigField label="Syslog Drain URL">
           <TextInput onChange={this.syslogDrainUrlUpdated} value={syslogDrainUrl} />

--- a/app/scripts/modules/cloudfoundry/src/pipeline/stages/deployService/cloudfoundryDeployServiceStage.module.ts
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/stages/deployService/cloudfoundryDeployServiceStage.module.ts
@@ -12,10 +12,10 @@ class CloudFoundryDeployServiceStageCtrl implements IController {
   }
 }
 
-const serviceNameValidatorConfig: IServiceFieldValidatorConfig = {
+const serviceInstanceNameValidatorConfig: IServiceFieldValidatorConfig = {
   type: 'requiredServiceField',
   serviceInputType: 'direct',
-  fieldName: 'serviceName',
+  fieldName: 'serviceInstanceName',
   preventSave: true,
 };
 
@@ -54,10 +54,10 @@ const referenceValidatorConfig: IServiceFieldValidatorConfig = {
   preventSave: true,
 };
 
-const userProvidedServiceNameValidatorConfig: IServiceFieldValidatorConfig = {
+const userProvidedServiceInstanceNameValidatorConfig: IServiceFieldValidatorConfig = {
   type: 'requiredServiceField',
   serviceInputType: 'userProvided',
-  fieldName: 'serviceName',
+  fieldName: 'serviceInstanceName',
   preventSave: true,
 };
 
@@ -83,13 +83,13 @@ module(CLOUD_FOUNDRY_DEPLOY_SERVICE_STAGE, [])
       validators: [
         { type: 'requiredField', fieldName: 'credentials', fieldLabel: 'account' },
         { type: 'requiredField', fieldName: 'region' },
-        serviceNameValidatorConfig,
+        serviceInstanceNameValidatorConfig,
         serviceValidatorConfig,
         servicePlanValidatorConfig,
         jsonValidatorConfig,
         accountValidatorConfig,
         referenceValidatorConfig,
-        userProvidedServiceNameValidatorConfig,
+        userProvidedServiceInstanceNameValidatorConfig,
         credentialsJsonValidatorConfig,
       ],
     });

--- a/app/scripts/modules/cloudfoundry/src/pipeline/stages/deployService/interfaces.ts
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/stages/deployService/interfaces.ts
@@ -1,7 +1,7 @@
 export interface ICloudfoundryServiceManifestDirectSource {
   parameters?: string;
   service: string;
-  serviceName: string;
+  serviceInstanceName: string;
   servicePlan: string;
   tags?: string[];
 }
@@ -14,7 +14,7 @@ export interface ICloudfoundryServiceManifestArtifactSource {
 export interface ICloudFoundryServiceUserProvidedSource {
   credentials?: string;
   routeServiceUrl: string;
-  serviceName: string;
+  serviceInstanceName: string;
   syslogDrainUrl?: string;
   tags?: string[];
 }

--- a/app/scripts/modules/cloudfoundry/src/pipeline/stages/destroyAsg/CloudfoundryDestroyAsgStageConfig.tsx
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/stages/destroyAsg/CloudfoundryDestroyAsgStageConfig.tsx
@@ -25,7 +25,7 @@ export interface ICloudfoundryDestroyAsgStageConfigState {
   pipeline: IPipeline;
   region: string;
   regions: IRegion[];
-  serviceName: string;
+  serviceInstanceName: string;
   target: string;
 }
 
@@ -44,7 +44,7 @@ export class CloudfoundryDestroyAsgStageConfig extends React.Component<
       pipeline: props.pipeline,
       region: props.stage.region,
       regions: [],
-      serviceName: props.stage.serviceName,
+      serviceInstanceName: props.stage.serviceInstanceName,
       target: props.stage.target,
     };
   }

--- a/app/scripts/modules/cloudfoundry/src/pipeline/stages/destroyService/CloudfoundryDestroyServiceStageConfig.tsx
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/stages/destroyService/CloudfoundryDestroyServiceStageConfig.tsx
@@ -10,7 +10,7 @@ export interface ICloudfoundryDestroyServiceStageConfigState {
   credentials: string;
   region: string;
   regions: IRegion[];
-  serviceName: string;
+  serviceInstanceName: string;
 }
 
 export class CloudfoundryDestroyServiceStageConfig extends React.Component<
@@ -26,7 +26,7 @@ export class CloudfoundryDestroyServiceStageConfig extends React.Component<
       credentials: props.stage.credentials,
       region: props.stage.region,
       regions: [],
-      serviceName: props.stage.serviceName,
+      serviceInstanceName: props.stage.serviceInstanceName,
     };
   }
 
@@ -63,10 +63,10 @@ export class CloudfoundryDestroyServiceStageConfig extends React.Component<
     this.props.stageFieldUpdated();
   };
 
-  private serviceNameUpdated = (event: React.ChangeEvent<HTMLInputElement>): void => {
-    const serviceName = event.target.value;
-    this.setState({ serviceName });
-    this.props.stage.serviceName = serviceName;
+  private serviceInstanceNameUpdated = (event: React.ChangeEvent<HTMLInputElement>): void => {
+    const serviceInstanceName = event.target.value;
+    this.setState({ serviceInstanceName });
+    this.props.stage.serviceInstanceName = serviceInstanceName;
     this.props.stageFieldUpdated();
   };
 
@@ -77,7 +77,7 @@ export class CloudfoundryDestroyServiceStageConfig extends React.Component<
 
   public render() {
     const { stage } = this.props;
-    const { credentials, region, serviceName, timeout } = stage;
+    const { credentials, region, serviceInstanceName, timeout } = stage;
     const { accounts, regions } = this.state;
     return (
       <div className="form-horizontal">
@@ -109,13 +109,13 @@ export class CloudfoundryDestroyServiceStageConfig extends React.Component<
             onChange={this.regionUpdated}
           />
         </StageConfigField>
-        <StageConfigField label="Service Name">
+        <StageConfigField label="Service Instance Name">
           <input
             type="text"
             className="form-control"
             required={true}
-            onChange={this.serviceNameUpdated}
-            value={serviceName}
+            onChange={this.serviceInstanceNameUpdated}
+            value={serviceInstanceName}
           />
         </StageConfigField>
         <StageConfigField label="Override Destroy Timeout (Seconds)" helpKey="cf.service.destroy.timeout">

--- a/app/scripts/modules/cloudfoundry/src/pipeline/stages/destroyService/cloudfoundryDestroyServiceStage.module.ts
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/stages/destroyService/cloudfoundryDestroyServiceStage.module.ts
@@ -25,7 +25,7 @@ module(CLOUD_FOUNDRY_DESTROY_SERVICE_STAGE, [])
       executionDetailsSections: [CloudfoundryDestroyServiceExecutionDetails, ExecutionDetailsTasks],
       validators: [
         { type: 'requiredField', fieldName: 'region' },
-        { type: 'requiredField', fieldName: 'serviceName', preventSave: true },
+        { type: 'requiredField', fieldName: 'serviceInstanceName', preventSave: true },
         { type: 'requiredField', fieldName: 'credentials', fieldLabel: 'account' },
       ],
     });


### PR DESCRIPTION
renaming `serviceName` to `serviceInstanceName` so it is clear that `serviceInstanceName` represents the new service instance and not the name of the Service