### PR TITLE
Moved from validate to required/optional

### DIFF
--- a/app/scripts/modules/core/src/presentation/forms/validation/validators.ts
+++ b/app/scripts/modules/core/src/presentation/forms/validation/validators.ts
@@ -35,7 +35,7 @@ const oneOf = (list: any[], message?: string): IValidator => {
 const arrayNotEmpty = (message?: string): IValidator => {
   return (val: string | any[], label = THIS_FIELD) => {
     message = message || `${label} must contain at least one entry`;
-    return val && val.length && message;
+    return val && val.length < 1 && message;
   };
 };
 


### PR DESCRIPTION
First class support for `required` turns a bunch of `.validate([isRequired()])` into `.required()` which is more readable and natural.

First class support for `optional`:
```js
b.field('foo', 'Foo').optional([
  minValue(1003),
  maxValue(1005)
])
```
is probably be more ergonomic than any other way we try to do it through composition, like
```js
b.field('foo', 'Foo').validate([
  optional(minValue(1003)),
  optional(maxValue(1005))
])
```
or
```js
b.field('foo', 'Foo').validate([
  minValue(1003),
  maxValue(1005)
].map(optional))
```