### PR TITLE
fix(core): enable new traffic guards by default

### DIFF
--- a/app/scripts/modules/core/src/application/config/trafficGuard/trafficGuardConfig.component.ts
+++ b/app/scripts/modules/core/src/application/config/trafficGuard/trafficGuardConfig.component.ts
@@ -7,11 +7,15 @@ import { CLUSTER_MATCHES_COMPONENT, IClusterMatch } from 'core/widgets/cluster/c
 import './trafficGuardConfig.help';
 import { ClusterMatcher, IClusterMatchRule } from 'core/cluster/ClusterRuleMatcher';
 
+export interface ITrafficGuardRule extends IClusterMatchRule {
+  enabled: boolean;
+}
+
 export class TrafficGuardConfigController {
   public application: Application;
   public locationsByAccount: { [account: string]: string[] };
   public accounts: IAccountDetails[] = [];
-  public config: IClusterMatchRule[];
+  public config: ITrafficGuardRule[];
   public initializing = true;
   public clusterMatches: IClusterMatch[][] = [];
 
@@ -74,7 +78,7 @@ export class TrafficGuardConfigController {
   }
 
   public addGuard(): void {
-    this.config.push({ account: null, location: null, stack: null, detail: null });
+    this.config.push({ enabled: true, account: null, location: null, stack: null, detail: null });
     this.configChanged();
   }
 


### PR DESCRIPTION
Most people add new traffic guards with the intention of them guarding traffic.