### PR TITLE
refactor(core): remove navigation from stage config details

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/deploy/deployStage.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/deploy/deployStage.html
@@ -18,7 +18,7 @@
       <tbody ui-sortable="deployStageCtrl.clusterSortOptions" ng-model="stage.clusters">
       <tr ng-repeat="cluster in stage.clusters">
         <td class="handle"><span class="glyphicon glyphicon-resize-vertical"></span></td>
-        <td if-multiple-providers class="text-center">
+        <td if-multiple-providers>
           <cloud-provider-logo provider="cluster.cloudProvider || cluster.provider || cluster.providerType || 'aws'"
                                width="'20px'" height="'20px'" show-tooltip="true"></cloud-provider-logo>
         </td>

--- a/app/scripts/modules/core/src/pipeline/config/stages/stage.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/stage.html
@@ -56,7 +56,7 @@
       </button>
     </div>
   </div>
-  <page-navigator scrollable-container="[ui-view]" ng-show="stage.type">
+  <page-navigator scrollable-container="[ui-view]" ng-show="stage.type" hide-navigation="true">
     <page-section key="stage" label="{{label}} Configuration">
       <div class="stage-details"></div>
     </page-section>

--- a/app/scripts/modules/core/src/presentation/navigation/pageNavigator.component.ts
+++ b/app/scripts/modules/core/src/presentation/navigation/pageNavigator.component.ts
@@ -14,6 +14,7 @@ class PageNavigatorController implements IController {
   private navigator: JQuery;
   private id: string;
   private deepLinkParam: string;
+  public hideNavigation = false;
 
   private getEventKey(): string {
     return `scroll.pageNavigation.${this.id}`;
@@ -27,7 +28,7 @@ class PageNavigatorController implements IController {
     this.id = UUIDGenerator.generateUuid();
     PageNavigationState.reset();
     this.container = this.$element.closest(this.scrollableContainer);
-    if (isFunction(this.container.bind)) {
+    if (isFunction(this.container.bind) && !this.hideNavigation) {
       this.container.bind(this.getEventKey(), throttle(() => this.handleScroll(), 20));
     }
     this.navigator = this.$element.find('.page-navigation');
@@ -37,7 +38,7 @@ class PageNavigatorController implements IController {
   }
 
   public $onDestroy(): void {
-    if (isFunction(this.container.unbind)) {
+    if (isFunction(this.container.unbind) && !this.hideNavigation) {
       this.container.unbind(this.getEventKey());
     }
   }
@@ -94,12 +95,13 @@ class PageNavigatorComponent implements ng.IComponentOptions {
   public bindings: any = {
     scrollableContainer: '@',
     deepLinkParam: '@?',
+    hideNavigation: '<?',
   };
   public controller: any = PageNavigatorController;
   public transclude = true;
   public template = `
     <div class="row">
-      <div class="col-md-3 hidden-sm hidden-xs">
+      <div class="col-md-3 hidden-sm hidden-xs" ng-show="!$ctrl.hideNavigation">
         <ul class="page-navigation">
           <li ng-repeat="page in $ctrl.pageNavigationState.pages"
               data-page-navigation-link="{{page.key}}"
@@ -112,7 +114,7 @@ class PageNavigatorComponent implements ng.IComponentOptions {
           </li>
         </ul>
       </div>
-      <div class="col-md-9 col-sm-12">
+      <div class="col-md-{{$ctrl.hideNavigation ? 12 : 9}} col-sm-12">
         <div class="sections" ng-transclude></div>
       </div>
     </div>


### PR DESCRIPTION
The stage config view could use more love than this, but, for now, let's remove the navigation bits on the left side. Most people don't notice they are even there, and I suspect nobody finds them actually useful?

With the side nav removed, we end up with a lot more space for clusters in the deploy stage, and expressions on conditional stages:
<img width="1159" alt="screen shot 2019-02-11 at 5 01 02 pm" src="https://user-images.githubusercontent.com/73450/52604296-29b36f80-2e1f-11e9-8334-ab72919eefe4.png">
