### PR TITLE
chore(core): fix warning about renderability of <g>

### DIFF
--- a/app/scripts/modules/core/src/presentation/HoverablePopover.tsx
+++ b/app/scripts/modules/core/src/presentation/HoverablePopover.tsx
@@ -144,7 +144,7 @@ export class HoverablePopover extends React.Component<IHoverablePopoverProps, IH
     );
 
     return (
-      <g
+      <div
         style={{ display: 'inline' }}
         onMouseEnter={this.handleMouseEvent}
         onMouseLeave={this.handleMouseEvent}
@@ -170,7 +170,7 @@ export class HoverablePopover extends React.Component<IHoverablePopoverProps, IH
             {popoverContent}
           </PopoverOffset>
         </Overlay>
-      </g>
+      </div>
     );
   }
 }


### PR DESCRIPTION
Just a tiny change to fix this annoying warning in the console. Maybe I'm missing something, but I don't see any reason this has to be a `<g>`. Seems to work the same with a `<div>`.

![image](https://user-images.githubusercontent.com/1697736/52612384-0ef8ef00-2e4f-11e9-81f6-f6d06ad70c42.png)
