### PR TITLE
fix(core): only use <g> for popovers in within SVGs

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/graph/PipelineGraphNode.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/graph/PipelineGraphNode.tsx
@@ -152,7 +152,12 @@ export class PipelineGraphNode extends React.Component<IPipelineGraphNodeProps> 
 
     if (node.stage && node.stage.type === 'group') {
       NodeContents = (
-        <GroupExecutionPopover stage={node.stage} subStageClicked={this.subStageClicked} width={maxLabelWidth}>
+        <GroupExecutionPopover
+          stage={node.stage}
+          subStageClicked={this.subStageClicked}
+          width={maxLabelWidth}
+          svgMode={true}
+        >
           {NodeContents}
         </GroupExecutionPopover>
       );

--- a/app/scripts/modules/core/src/pipeline/config/stages/group/GroupExecutionPopover.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/group/GroupExecutionPopover.tsx
@@ -9,6 +9,7 @@ export interface IGroupExecutionPopoverProps {
   stage: IExecutionStageSummary;
   width: number;
   subStageClicked?: (groupStage: IExecutionStageSummary, stage: IExecutionStageSummary) => void;
+  svgMode?: boolean;
 }
 
 export interface IGroupedStageListItemProps {
@@ -55,7 +56,7 @@ export class GroupExecutionPopover extends React.Component<IGroupExecutionPopove
   };
 
   public render() {
-    const { stage, width } = this.props;
+    const { stage, width, svgMode } = this.props;
 
     const template = (
       <div style={{ minWidth: width - 30 + 'px' }}>
@@ -69,7 +70,13 @@ export class GroupExecutionPopover extends React.Component<IGroupExecutionPopove
     );
 
     return (
-      <HoverablePopover className="group-stages-list-popover" delayHide={50} placement="bottom" template={template}>
+      <HoverablePopover
+        className="group-stages-list-popover"
+        svgMode={svgMode}
+        delayHide={50}
+        placement="bottom"
+        template={template}
+      >
         {this.props.children}
       </HoverablePopover>
     );


### PR DESCRIPTION
The <g> tag is necessary within the execution graph (it's used by grouped stages, which happens via pipeline templates), but React barks about it outside <svg> tags.

cc @jkschneider @jrsquared @christopherthielen 