### PR TITLE
fix(amazon/cloudfoundry/core): SPEL support for capacity in cluster configuration

### DIFF
--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/capacity/CapacitySelector.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/capacity/CapacitySelector.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Select, { Option } from 'react-select';
 
-import { HelpField, IServerGroupCommand } from '@spinnaker/core';
+import { HelpField, IServerGroupCommand, SpelNumberInput } from '@spinnaker/core';
 import { IMinMaxDesiredProps } from './MinMaxDesired';
 
 export interface ICapacitySelectorProps {
@@ -36,12 +36,11 @@ export class CapacitySelector extends React.Component<ICapacitySelectorProps> {
     this.setState({});
   }
 
-  private simpleInstancesChanged = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const value = Number.parseInt(event.target.value, 10);
+  private simpleInstancesChanged = (value: number | string) => {
     this.setMinMax(value);
   };
 
-  private setMinMax(value: number) {
+  private setMinMax(value: number | string) {
     const { command } = this.props;
     if (command.viewState.useSimpleCapacity) {
       command.capacity = { min: value, max: value, desired: value };
@@ -168,15 +167,8 @@ export class CapacitySelector extends React.Component<ICapacitySelectorProps> {
         </div>
         <div className="form-group">
           <div className="col-md-3 sm-label-right">Number of Instances</div>
-          <div className="col-md-2">
-            <input
-              type="number"
-              onChange={this.simpleInstancesChanged}
-              className="form-control input-sm"
-              value={command.capacity.desired}
-              min={0}
-              required={true}
-            />
+          <div className="col-md-8">
+            <SpelNumberInput value={command.capacity.desired} min={0} onChange={this.simpleInstancesChanged} />
           </div>
         </div>
       </div>

--- a/app/scripts/modules/amazon/src/serverGroup/details/resize/AmazonResizeServerGroupModal.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/details/resize/AmazonResizeServerGroupModal.tsx
@@ -55,8 +55,8 @@ export interface IResizeJob extends IServerGroupJob {
 
 interface IChangedField {
   field: keyof ICapacity;
-  prevValue: number;
-  value: number;
+  prevValue: number | string;
+  value: number | string;
 }
 
 export class AmazonResizeServerGroupModal extends React.Component<

--- a/app/scripts/modules/cloudfoundry/src/serverGroup/details/resize/CloudFoundryResizeServerGroupModal.tsx
+++ b/app/scripts/modules/cloudfoundry/src/serverGroup/details/resize/CloudFoundryResizeServerGroupModal.tsx
@@ -31,7 +31,7 @@ export interface ICloudFoundryResizeServerGroupModalState {
 }
 
 export interface ICloudFoundryResizeServerGroupValues {
-  desired: number;
+  desired: number | string;
   diskQuota?: number;
   memory?: number;
   reason?: string;

--- a/app/scripts/modules/core/src/serverGroup/serverGroupWriter.service.ts
+++ b/app/scripts/modules/core/src/serverGroup/serverGroupWriter.service.ts
@@ -8,9 +8,9 @@ import { IMoniker, NameUtils } from 'core/naming';
 import { IJob, TaskExecutor } from 'core/task/taskExecutor';
 
 export interface ICapacity {
-  desired: number;
-  max: number;
-  min: number;
+  desired: number | string;
+  max: number | string;
+  min: number | string;
 }
 
 export interface IServerGroupJob extends IJob {

--- a/app/scripts/modules/core/src/widgets/index.ts
+++ b/app/scripts/modules/core/src/widgets/index.ts
@@ -7,3 +7,4 @@ export * from './Spinner';
 export * from './spinners/Spinner';
 export * from './ScopeClusterSelector';
 export * from './tags';
+export * from './spelText/SpelNumberInput';

--- a/app/scripts/modules/core/src/widgets/spelText/SpelNumberInput.tsx
+++ b/app/scripts/modules/core/src/widgets/spelText/SpelNumberInput.tsx
@@ -50,10 +50,11 @@ export class SpelNumberInput extends React.Component<INumberInputProps, INumberI
     const { expressionActive, glowing } = this.state;
     const { value, min, max } = this.props;
     return (
-      <div className="navbar-form" style={{ padding: 0 }}>
+      <div className="navbar-form" style={{ padding: 0, margin: 0 }}>
         <div className={`button-input ${expressionActive ? 'text' : 'number'}${glowing ? ' focus' : ''}`}>
           <span className="btn-group btn-group-xs" role="group">
             <button
+              type="button"
               className={`btn btn-default ${expressionActive ? '' : 'active'}`}
               onClick={() => this.setExpressionActive(false)}
               onFocus={() => this.setGlow(true)}
@@ -64,6 +65,7 @@ export class SpelNumberInput extends React.Component<INumberInputProps, INumberI
               </Tooltip>
             </button>
             <button
+              type="button"
               className={`btn btn-default ${expressionActive ? 'active' : ''}`}
               onClick={() => this.setExpressionActive(true)}
               onFocus={() => this.setGlow(true)}


### PR DESCRIPTION
Support SPEL input and display for simple capacity in cluster configuration.

Some of the netflix users are setting an expression for capacity. Today, if someone sets the capacity as an expression and tried to edit something else in the cluster configuration, we ask them to enter a number for the capacity and override their expression. This change fixes that by supporting toggle between spel and number input.