### PR TITLE
chore(build): Use newer base image for deck build

### DIFF
--- a/cloudbuild-tagged.yaml
+++ b/cloudbuild-tagged.yaml
@@ -1,5 +1,5 @@
 steps:
-- name: 'java:8'
+- name: 'openjdk:8-stretch'
   env: ["GRADLE_USER_HOME=cache"]
   entrypoint: "bash"
   args: [ "-c", "./gradlew build -PskipTests"]

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,5 +1,5 @@
 steps:
-- name: 'java:8'
+- name: 'openjdk:8-stretch'
   env: ["GRADLE_USER_HOME=cache"]
   entrypoint: "bash"
   args: [ "-c", "./gradlew build -PskipTests"]


### PR DESCRIPTION
The 'java' docker repo has been deprecated and not maintained since the end of 2016 in favor of the 'openjdk' repo.

The old ones were using openjdk as well, so that's not a change, just the repo.  This also makes the base debian image more modern (stretch instead of jesse).

The particular issue this fixes is that deck wasn't building on debian stretch after node was upgraded.