### PR TITLE
fix(provider/azure): subnet is null after select same loadbalancer

### DIFF
--- a/app/scripts/modules/azure/serverGroup/configure/wizard/loadBalancers/serverGroupLoadBalancersSelector.directive.html
+++ b/app/scripts/modules/azure/serverGroup/configure/wizard/loadBalancers/serverGroupLoadBalancersSelector.directive.html
@@ -3,7 +3,7 @@
   <div class="form-group">
     <div class="col-md-3 sm-label-right"><b>Load Balancers</b></div>
     <div class="col-md-7">
-      <ui-select required ng-model="command.loadBalancerName" class="form-control input-sm" on-select="loadBalancerCtrl.loadBalancerChanged($item)">
+      <ui-select required ng-model="command.loadBalancerName" class="form-control input-sm" ng-change="loadBalancerCtrl.loadBalancerChanged($select.selected)">
         <ui-select-match placeholder="select a loadBalancer">{{$select.selected}}</ui-select-match>
         <ui-select-choices repeat="loadBalancer in command.loadBalancers | filter: $select.search">
           <span ng-bind-html="loadBalancer | highlight: $select.search"></span>


### PR DESCRIPTION
Currently it sets subnet as null as default value in drop down list after select same loadbalancer.
So update the logic to not change subnet after select same loadbalancer.