### PR TITLE
Bump package kubernetes to 0.0.21 and google to 0.0.5

### DIFF
--- a/app/scripts/modules/google/package.json
+++ b/app/scripts/modules/google/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/google",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/kubernetes/package.json
+++ b/app/scripts/modules/kubernetes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/kubernetes",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
### chore(kubernetes): Bump version to 0.0.21

27d8a12c6e133ba0a25d874535f3c77da431113e chore(eslint): Fix lint errors
a8c174925f64045f70c11b2bfc11fe1fdd558660 chore(package): Just Update Prettier™
9eccc0f19d3f5aa5a55354d0c9344bb79a9c77bc refactor(artifacts): Generalize artifact delegate for reuse (#6495)
6c54b61d443907c396055d0f8e1bd2df9ab58405 fix(kubernetes): do not override `location` and `replicas` in new Scale Manifest stage
a35088ab28cc3b25c9e6731f6fb70bf7d0e14ef0 chore(webpack): Switch to TerserPlugin.  Split bundles into ~5mb chunks
54157f2e6787e6a12fa0e67ccbc138a903f72a40 fix(kubernetes/serverGroup): Remove module.exports assignment in typescript file
5c49dd2ab3c4226295a7e8041c25dabdbeee6a2c chore(typescript): Switch module from 'commonjs' to 'esnext' to emit raw dynamic 'import()'
0451046c241b450ae4b05df0b67b61758c16acce chore(package): Add .npmignore to all packages
d53836b695f3527f8ee9da86e86f30c08bdcc303 refactor(kubernetes/modal): Refactor kubernetes modals to use WizardPage component
dba26d8225841a9c8512f0aeebc1ba2741fbf96f feat(kubernetes/v2): Converts CopyToClipboard to React Component (#6451)
6f608a0ab43616eb130c7417e560bc3df780f335 fix(*): Remove all self closing tags in AngularJS templates Reference: https://github.com/angular/angular.js/issues/1953#issuecomment-13135021
65c26016557740ebce758cc14ec13ca30de72d0f fix(kubernetes): post strategic patch body as object
51a8542bd3ed9a31c0d4dfd8895fe0929aa44462 fix(kubernetes): fix account selection by handling null values passed to ManifestSelector.isExpression
35be1f0872f5958514c920ee97510d36484e33eb refactor(*): Don't use js or ts file extension in require()
a02a5e19f057423dcdefde85e292330009f1d72e chore(k8s): clean up imports (#6430)
fa18bdccbcfc0a553df2cb6ab72173215da11920 feat(kubernetes/v2): Adds CopyToClipboard component to ease getting text from UI (#6419)
98a85e9b40eb728b25fadfe67fb57cceb0c88aac chore(*): bump @types/enzyme@3.1.15, @types/jasmine@3.3.7, enzyme@3.8.0, enzyme-adapter-react-16@1.7.1, karma@4.0.0, karma-jasmine@2.0.1, karma-webpack@3.0.5, typescript@^3.2.4, jasmine-core@3.3.0 - disable jasmine 3.0's random test order by default feature
93f1209b105e46f423125e879784ab007e6cda25 fix(appengine/google/kubernetes): change logo background colors to official brand colors (#6347)
e802c4515726e74f0f2157bde292fc43a6b46271 fix(*): allow modal to stay open on auto-close (#6329)
6fee54da853652d8124669563f3c553e51346f1d fix(kubernetes): specify monospace fonts to prevent cursor misalignment in ace editor
86baac96af19a15b1339cd5f1856ee1e78d9d800 refactor(*): use mask-image CSS for cloud provider logos (#6280)

### chore(google): Bump version to 0.0.5

a8c174925f64045f70c11b2bfc11fe1fdd558660 chore(package): Just Update Prettier™
a35088ab28cc3b25c9e6731f6fb70bf7d0e14ef0 chore(webpack): Switch to TerserPlugin.  Split bundles into ~5mb chunks
5c49dd2ab3c4226295a7e8041c25dabdbeee6a2c chore(typescript): Switch module from 'commonjs' to 'esnext' to emit raw dynamic 'import()'
0451046c241b450ae4b05df0b67b61758c16acce chore(package): Add .npmignore to all packages
d09a9103b3ae434a25f88b4ff78cf8bb02e987f9 feat(google): Add support for accelerators when deploying VMs (#6467)
6f608a0ab43616eb130c7417e560bc3df780f335 fix(*): Remove all self closing tags in AngularJS templates Reference: https://github.com/angular/angular.js/issues/1953#issuecomment-13135021
35be1f0872f5958514c920ee97510d36484e33eb refactor(*): Don't use js or ts file extension in require()
87013c652a9ef1bab148981f7e8a0d7742b7a2e6 config(google): Update GCE's base URL to the new domain (#6401)
9f90ebd8c96b4fcc70b93b7f3d741d4d44bd2c3d fix(google): safe healthcheck lookups when cloning server group
b920442a948329e2e0bfc0af4dbcf276d8aa3485 fix(google): differentiate among autohealing health check kinds
786862b28efad1864e17fcca231625a001028dac fix(google): fix autohealing clone logic
93f1209b105e46f423125e879784ab007e6cda25 fix(appengine/google/kubernetes): change logo background colors to official brand colors (#6347)
e802c4515726e74f0f2157bde292fc43a6b46271 fix(*): allow modal to stay open on auto-close (#6329)
d4127fa451e4f7149d10aad00dc3169f65f23ff9 fix(google): prevent parent server group from overwriting null clone autohealing policies
86baac96af19a15b1339cd5f1856ee1e78d9d800 refactor(*): use mask-image CSS for cloud provider logos (#6280)
3afbd0001ad934ef9febe87579cc3fe81bd5f3f8 fix(bake): Allow null extended attributes in bake stages (#6256)
6b8188bb54ea2e70987841079a8aff7debd8bd66 chore(*): Add core alias to module tsconfigs


