### PR TITLE
fix(appengine): older apps that dont have cloudProviders field dont select correct serverGroup modal

### DIFF
--- a/halconfig/settings.js
+++ b/halconfig/settings.js
@@ -139,6 +139,7 @@ window.spinnakerSettings = {
   defaultCategory: 'serverGroup',
   defaultInstancePort: 80,
   defaultProviders: [
+    'appengine',
     'aws',
     'azure',
     'cloudfoundry',

--- a/settings.js
+++ b/settings.js
@@ -49,7 +49,18 @@ window.spinnakerSettings = {
   debugEnabled: debugEnabled,
   defaultCategory: 'serverGroup',
   defaultInstancePort: 80,
-  defaultProviders: ['aws', 'gce', 'azure', 'cloudfoundry', 'kubernetes', 'dcos', 'openstack', 'oracle', 'ecs'],
+  defaultProviders: [
+    'appengine',
+    'aws',
+    'azure',
+    'cloudfoundry',
+    'dcos',
+    'ecs',
+    'gce',
+    'kubernetes',
+    'openstack',
+    'oracle',
+  ],
   defaultTimeZone: process.env.TIMEZONE || 'America/Los_Angeles', // see http://momentjs.com/timezone/docs/#/data-utilities/
   feature: {
     artifacts: artifactsEnabled,


### PR DESCRIPTION
If an application does not include a `cloudProviders` string in its JSON then certain UI features will fall back to the set of `defaultProviders` defined in the settings object when determining whether that application includes specific providers. If `"appengine"` is missing from the list of default providers then older appengine applications that don't include the `cloudProviders` field can end up showing AWS modals by mistake.