### PR TITLE
fix(core/css): be explicit on which file we're importing

### DIFF
--- a/app/scripts/modules/core/src/core.module.ts
+++ b/app/scripts/modules/core/src/core.module.ts
@@ -22,7 +22,7 @@ import { UI_ROUTER_REACT_HYBRID } from '@uirouter/react-hybrid';
 // use require instead of import to ensure insertion order is preserved
 require('Select2/select2.css');
 require('select2-bootstrap-css/select2-bootstrap.css');
-import 'source-sans-pro';
+import 'source-sans-pro/source-sans-pro.css';
 import { RECENT_HISTORY_SERVICE } from 'core/history';
 require('root/app/fonts/spinnaker/icons.css');
 


### PR DESCRIPTION
in the module `source-sans-pro@2.0.10` `packageJson.main` is specified to be `source-sans-pro.css`, however this is dropped in following versions. Here's a screenshot of available versions:
![](https://cl.ly/25ade4705d72/Screen%20Shot%202019-02-15%20at%2011.26.44.png)

To address this, let's directly reference the file which should help prevent build issues when upgrading and also with importing `@spinnaker/core` as a module in deck extensions since the current package.json specifies `"source-sans-pro": "^2.0.10",` which allows using the `2.45.0 (latest)` version.
