### PR TITLE
feat(core): display unescaped JSON if pipeline parameter input was JSON

### DIFF
--- a/app/scripts/modules/core/src/pipeline/status/ExecutionStatus.tsx
+++ b/app/scripts/modules/core/src/pipeline/status/ExecutionStatus.tsx
@@ -105,6 +105,14 @@ export class ExecutionStatus extends React.Component<IExecutionStatusProps, IExe
     this.props.toggleDetails();
   };
 
+  private unescapeIfJSON = (value: any): any => {
+    try {
+      return JSON.parse(value);
+    } catch {
+      return value;
+    }
+  };
+
   public render() {
     const { execution, showingDetails, standalone } = this.props;
     const { trigger } = execution;
@@ -131,7 +139,7 @@ export class ExecutionStatus extends React.Component<IExecutionStatusProps, IExe
           </li>
           {this.state.parameters.map(p => (
             <li key={p.key} className="break-word">
-              <span className="parameter-key">{p.key}</span>: {p.value}
+              <span className="parameter-key">{p.key}</span>: {this.unescapeIfJSON(p.value)}
             </li>
           ))}
         </ul>


### PR DESCRIPTION
a user requested that we display the `ExecutionStatus` parameter value as an unescaped JSON if the input was an unescaped JSON. Having an escaped JSON is causing issues with another tool from the user that parses parameters from the `ExecutionStatus`

spinnaker/spinnaker#3976