### PR TITLE
chore(Dockerfile): Use node:10 base image, do not use gradle to build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8
+FROM node:10
 
 COPY . deck/
 
@@ -6,7 +6,9 @@ WORKDIR deck
 
 RUN free -h && \
   docker/setup-apache2.sh && \
-  GRADLE_USER_HOME=cache ./gradlew build -PskipTests && \
+  npm i -g yarn && \
+  yarn && \
+  yarn build && \
   mkdir -p /opt/deck/html/ && \
   cp build/webpack/* /opt/deck/html/ && \
   cd .. && \


### PR DESCRIPTION
I was having some trouble getting deck to build inside a container with 4gb memory (side note: it takes 4gb of memory to build deck 😱).  

`gradle` launches `webpack` and then two VMs are running at the same time (the Java VM for gradle and v8 for webpack).  This used enough extra memory that the webpack build consistently failed.  

AFACT, gradle isn't necessary to build the deck image.  It was used to install node and yarn, then kick off the webpack build.  However, the `node:10` base image comes with node and npm preinstalled.   I believe installing `yarn` and invoking the webpack build via `yarn build` should produce the same results.