### PR TITLE
fix(core): use $timeout to handle change event in accountSelectField

### DIFF
--- a/app/scripts/modules/core/src/account/AccountSelectInput.tsx
+++ b/app/scripts/modules/core/src/account/AccountSelectInput.tsx
@@ -112,7 +112,11 @@ export class AccountSelectInput extends React.Component<IAccountSelectInputProps
             </option>
           ))}
 
-          {showSeparator && <option disabled={true}>---------------</option>}
+          {showSeparator && (
+            <option value="-" disabled={true}>
+              ---------------
+            </option>
+          )}
 
           {secondaryAccounts.map(account => (
             <option key={account} value={account}>
@@ -131,7 +135,7 @@ export class AccountSelectInput extends React.Component<IAccountSelectInputProps
     const showSeparator = primaryAccounts.length > 0 && secondaryAccounts.length > 0;
     const options: Option[] = primaryAccounts.map(a => ({ label: a, value: a }));
     if (showSeparator) {
-      options.push({ label: '---------------', value: '', disabled: true });
+      options.push({ label: '---------------', value: '-', disabled: true });
     }
     options.push(...secondaryAccounts.map(a => ({ label: a, value: a })));
     return (

--- a/app/scripts/modules/core/src/account/accountSelectField.component.ts
+++ b/app/scripts/modules/core/src/account/accountSelectField.component.ts
@@ -1,4 +1,4 @@
-import { IScope, module } from 'angular';
+import { ITimeoutService, module } from 'angular';
 import * as React from 'react';
 
 export const ACCOUNT_SELECT_COMPONENT = 'spinnaker.core.account.accountSelectField.component';
@@ -22,9 +22,9 @@ module(ACCOUNT_SELECT_COMPONENT, []).component('accountSelectField', {
     onChange: '&',
     readOnly: '=',
   },
-  controller: function($scope: IScope) {
+  controller: function($timeout: ITimeoutService) {
     this.handleSelectChanged = (event: React.ChangeEvent<HTMLInputElement>) => {
-      $scope.$apply(() => {
+      $timeout(() => {
         this.currentValue = this.component[this.field] = event.target.value;
         this.onChange && this.onChange();
       });


### PR DESCRIPTION
The find image stage in AWS is blowing up with a digest-in-progress error when the stage is first selected. This is happening because...React->Angular->React->Angular, I guess, and the easiest solution is to call the change handler in a `$timeout` block instead of an `$apply`.

Separate PR coming to address some other issues I found along the way.