### PR TITLE
fix(*): fix account selection in findAmi, AWS ingress rule picker

### DIFF
--- a/app/scripts/modules/amazon/src/pipeline/stages/findAmi/awsFindAmiStage.js
+++ b/app/scripts/modules/amazon/src/pipeline/stages/findAmi/awsFindAmiStage.js
@@ -63,7 +63,6 @@ module.exports = angular
     if (angular.isUndefined(stage.onlyEnabled)) {
       stage.onlyEnabled = true;
     }
-
     if (!stage.credentials && $scope.application.defaultCredentials.aws) {
       stage.credentials = $scope.application.defaultCredentials.aws;
     }

--- a/app/scripts/modules/amazon/src/securityGroup/configure/ingressRuleGroupSelector.component.ts
+++ b/app/scripts/modules/amazon/src/securityGroup/configure/ingressRuleGroupSelector.component.ts
@@ -1,5 +1,5 @@
 import { IController, IComponentOptions, module } from 'angular';
-import { Subject } from 'rxjs';
+import { Subject, Subscription } from 'rxjs';
 import { get, intersection, uniq } from 'lodash';
 
 import { ISecurityGroupRule, ISecurityGroup, IVpc } from '@spinnaker/core';
@@ -31,6 +31,8 @@ class IngressRuleSelectorController implements IController {
   public coordinatesChanged: Subject<void>;
   public allSecurityGroupsUpdated: Subject<void>;
   public availableSecurityGroups: string[];
+  public coordinatesChangedListener: Subscription;
+  public securityGroupsUpdatedListener: Subscription;
 
   public infiniteScroll: IInfiniteScroll = {
     currentItems: 20,
@@ -74,11 +76,15 @@ class IngressRuleSelectorController implements IController {
 
   public $onInit(): void {
     this.setAvailableSecurityGroups();
+    this.coordinatesChangedListener = this.coordinatesChanged.subscribe(() => this.setAvailableSecurityGroups());
+    this.securityGroupsUpdatedListener = this.allSecurityGroupsUpdated.subscribe(() =>
+      this.setAvailableSecurityGroups(),
+    );
   }
 
   public $onDestroy() {
-    this.coordinatesChanged.unsubscribe();
-    this.allSecurityGroupsUpdated.unsubscribe();
+    this.coordinatesChangedListener.unsubscribe();
+    this.securityGroupsUpdatedListener.unsubscribe();
   }
 
   public setAvailableSecurityGroups(): void {

--- a/app/scripts/modules/core/src/application/application.model.ts
+++ b/app/scripts/modules/core/src/application/application.model.ts
@@ -238,9 +238,9 @@ export class Application {
       const vals = sources
         .map(ds => map(ds.data.filter(d => d[ds.providerField] === provider), ds[field]))
         .filter(v => v.length > 0);
-      const allRegions = union(...vals);
-      if (allRegions.length === 1) {
-        (results as any)[provider] = allRegions[0];
+      const allValues = union(...vals);
+      if (allValues.length === 1) {
+        (results as any)[provider] = allValues[0];
       }
     });
     return results;


### PR DESCRIPTION
When creating a Find Image stage, we throw away the account default because we don't set the accounts in the view on first render (they're set via the `listAccounts` callback). Easy fix is to just hide the picker until the accounts are there (which is the next cycle, basically immediately).

Also fixing a broken subscription thing that causes problems editing ingress rules for AWS.