### PR TITLE
chore(amazon/instance): Promote the recommended high-memory family to r5

### DIFF
--- a/app/scripts/modules/amazon/src/instance/awsInstanceType.service.js
+++ b/app/scripts/modules/amazon/src/instance/awsInstanceType.service.js
@@ -96,13 +96,13 @@ module.exports = angular
       ],
     };
 
-    var r4 = {
-      type: 'r4',
+    var r5 = {
+      type: 'r5',
       description:
-        'r4 instances are optimized for memory-intensive applications and have the lowest cost per GiB of RAM among Amazon EC2 instance types.',
+        'r5 instances are optimized for memory-intensive applications and have the lowest cost per GiB of RAM among Amazon EC2 instance types.',
       instanceTypes: [
         {
-          name: 'r4.large',
+          name: 'r5.large',
           label: 'Large',
           cpu: 2,
           memory: 15.25,
@@ -110,7 +110,7 @@ module.exports = angular
           costFactor: 1,
         },
         {
-          name: 'r4.xlarge',
+          name: 'r5.xlarge',
           label: 'XLarge',
           cpu: 4,
           memory: 30.5,
@@ -118,7 +118,7 @@ module.exports = angular
           costFactor: 2,
         },
         {
-          name: 'r4.2xlarge',
+          name: 'r5.2xlarge',
           label: '2XLarge',
           cpu: 8,
           memory: 61,
@@ -126,7 +126,7 @@ module.exports = angular
           costFactor: 2,
         },
         {
-          name: 'r4.4xlarge',
+          name: 'r5.4xlarge',
           label: '4XLarge',
           cpu: 16,
           memory: 122,
@@ -146,7 +146,7 @@ module.exports = angular
       {
         type: 'memory',
         label: 'High Memory',
-        families: [r4],
+        families: [r5],
         icon: 'hdd',
       },
       {
@@ -252,9 +252,9 @@ module.exports = angular
 
     let families = {
       paravirtual: ['c1', 'c3', 'hi1', 'hs1', 'm1', 'm2', 'm3', 't1'],
-      hvm: ['c3', 'c4', 'd2', 'i2', 'g2', 'm3', 'm4', 'm5', 'p2', 'r3', 't2', 'x1'],
-      vpcOnly: ['c4', 'm4', 'm5', 't2', 'x1'],
-      ebsOptimized: ['c4', 'd2', 'f1', 'g3', 'i3', 'm4', 'm5', 'p2', 'r4', 'x1'],
+      hvm: ['c3', 'c4', 'd2', 'i2', 'g2', 'm3', 'm4', 'm5', 'p2', 'r3', 'r4', 'r5', 't2', 'x1'],
+      vpcOnly: ['c4', 'm4', 'm5', 'r4', 'r5', 't2', 'x1'],
+      ebsOptimized: ['c4', 'd2', 'f1', 'g3', 'i3', 'm4', 'm5', 'p2', 'r4', 'r5', 'x1'],
     };
 
     function filterInstanceTypes(instanceTypes, virtualizationType, vpcOnly) {


### PR DESCRIPTION
The usual periodic upgrade to cheaper, faster stuff. No machine stats changed.

I also added `r4` as vpc-only and HVM-only, seems it was missed.