### PR TITLE
fix(core): only escape escaped JSON in execution status params

### DIFF
--- a/app/scripts/modules/core/src/pipeline/status/ExecutionStatus.tsx
+++ b/app/scripts/modules/core/src/pipeline/status/ExecutionStatus.tsx
@@ -105,9 +105,19 @@ export class ExecutionStatus extends React.Component<IExecutionStatusProps, IExe
     this.props.toggleDetails();
   };
 
+  // A more friendly render for escaped JSON string parameters, e.g.
+  // { \"key\" : \"value\" } will be rendered as {"key": "value"}
+  // All other values will be rendered normally.
   private unescapeIfJSON = (value: any): any => {
     try {
-      return JSON.parse(value);
+      if (value && value.toString().match(/\\"/)) {
+        const parsed = JSON.parse(value);
+        const parsedParsed = JSON.parse(parsed);
+        if (typeof parsedParsed === 'object') {
+          return parsed;
+        }
+      }
+      return value;
     } catch {
       return value;
     }


### PR DESCRIPTION
I think the comment in the code explains it? I don't know if there's a cleaner or more elegant way to do this.