### PR TITLE
fix(core): do not try to parse/unescape execution status parameters

### DIFF
--- a/app/scripts/modules/core/src/pipeline/status/ExecutionStatus.tsx
+++ b/app/scripts/modules/core/src/pipeline/status/ExecutionStatus.tsx
@@ -105,14 +105,6 @@ export class ExecutionStatus extends React.Component<IExecutionStatusProps, IExe
     this.props.toggleDetails();
   };
 
-  private unescapeIfJSON = (value: any): any => {
-    try {
-      return JSON.parse(value);
-    } catch {
-      return value;
-    }
-  };
-
   public render() {
     const { execution, showingDetails, standalone } = this.props;
     const { trigger } = execution;
@@ -139,7 +131,7 @@ export class ExecutionStatus extends React.Component<IExecutionStatusProps, IExe
           </li>
           {this.state.parameters.map(p => (
             <li key={p.key} className="break-word">
-              <span className="parameter-key">{p.key}</span>: {this.unescapeIfJSON(p.value)}
+              <span className="parameter-key">{p.key}</span>: {p.value}
             </li>
           ))}
         </ul>


### PR DESCRIPTION
The code as-is breaks whenever a parameter looks JSON-y, e.g. `"[1, 2]"` or `"{key: 3}"`, and the hoops we're jumping through to unescape in the case a user has sent escaped JSON in as a parameter are not worth working around.