### PR TITLE
fix(kubernetes): properly detect if autoscaler is attached to server groups

### DIFF
--- a/app/scripts/modules/kubernetes/src/serverGroup/details/details.html
+++ b/app/scripts/modules/kubernetes/src/serverGroup/details/details.html
@@ -111,13 +111,13 @@
     </collapsible-section>
     <collapsible-section heading="Replicas" expanded="true">
       <dl class="dl-horizontal dl-flex">
-        <div ng-show="serverGroup.autoscalerStatus === null">
+        <div ng-show="!serverGroup.autoscalerStatus">
           <dt>Current</dt>
           <dd>{{serverGroup.instances.length}}</dd>
           <dt>Desired</dt>
           <dd>{{serverGroup.capacity.desired}}</dd>
         </div>
-        <div ng-show="serverGroup.autoscalerStatus !== null">
+        <div ng-show="serverGroup.autoscalerStatus">
           <dt>Min</dt>
           <dd>{{serverGroup.deployDescription.capacity.min}}</dd>
           <dt>Max</dt>
@@ -129,10 +129,10 @@
     </collapsible-section>
     <collapsible-section heading="Horizontal Pod Autoscaling" expanded="true">
       <dl class="dl-horizontal dl-flex">
-        <div ng-show="serverGroup.autoscalerStatus === null">
+        <div ng-show="!serverGroup.autoscalerStatus">
           No autoscaler found.
         </div>
-        <div ng-show="serverGroup.autoscalerStatus !== null">
+        <div ng-show="serverGroup.autoscalerStatus">
           <dt>Desired</dt>
           <dd>{{serverGroup.autoscalerStatus.desiredReplicas}}</dd>
           <dt>Target CPU</dt>
@@ -191,7 +191,7 @@
     </collapsible-section>
     <collapsible-section heading="Events">
       <div ng-if="serverGroup.events && serverGroup.events.length > 0">
-        <kubernetes-event ng-repeat="event in serverGroup.events" event="event"></kubernetes-event>
+        <kubernetes-event ng-repeat="event in serverGroup.events" event="event"/>
       </div>
       <div ng-if="!(serverGroup.events && serverGroup.events.length > 0)">
         No events.

--- a/app/scripts/modules/kubernetes/src/serverGroup/details/details.html
+++ b/app/scripts/modules/kubernetes/src/serverGroup/details/details.html
@@ -191,7 +191,7 @@
     </collapsible-section>
     <collapsible-section heading="Events">
       <div ng-if="serverGroup.events && serverGroup.events.length > 0">
-        <kubernetes-event ng-repeat="event in serverGroup.events" event="event"/>
+        <kubernetes-event ng-repeat="event in serverGroup.events" event="event"></kubernetes-event>
       </div>
       <div ng-if="!(serverGroup.events && serverGroup.events.length > 0)">
         No events.

--- a/app/scripts/modules/kubernetes/src/serverGroup/details/resize/resize.html
+++ b/app/scripts/modules/kubernetes/src/serverGroup/details/resize/resize.html
@@ -5,7 +5,7 @@
     <div class="modal-header">
       <h3>Resize {{serverGroup.name}}</h3>
     </div>
-    <div class="modal-body confirmation-modal" ng-if="serverGroup.autoscalerStatus !== null">
+    <div class="modal-body confirmation-modal" ng-if="serverGroup.autoscalerStatus">
       <div class="form-horizontal">
         <div class="form-group form-inline">
           <div class="col-md-3 col-md-offset-3">Min</div>
@@ -86,7 +86,7 @@
       </div>
       <task-reason command="command"></task-reason>
     </div>
-    <div class="modal-body confirmation-modal" ng-if="serverGroup.autoscalerStatus === null">
+    <div class="modal-body confirmation-modal" ng-if="!serverGroup.autoscalerStatus">
       <div class="form-horizontal">
         <div class="form-group form-inline">
           <div class="col-md-3 sm-label-right">


### PR DESCRIPTION
`serverGroup.autoscaler` comes as `undefined` in angular scope when there's no autoscaler attached to a server group, thus wrong modals were shown to users.

@christopherthielen @maggieneterval - feel free to test it with Kubernetes V2. I've tested it with Kubernetes V1 and now everyone is happy that the Resize feature can be used again.