### PR TITLE
fix(aws): set redirectActionConfig on ALB rules

### DIFF
--- a/app/scripts/modules/amazon/src/domain/IAmazonLoadBalancer.ts
+++ b/app/scripts/modules/amazon/src/domain/IAmazonLoadBalancer.ts
@@ -78,7 +78,8 @@ export interface IRedirectActionConfig {
 export interface IListenerAction {
   authenticateOidcConfig?: IAuthenticateOidcActionConfig;
   order?: number;
-  redirectActionConfig?: IRedirectActionConfig;
+  redirectActionConfig?: IRedirectActionConfig; // writes
+  redirectConfig?: IRedirectActionConfig; // reads
   targetGroupName?: string;
   type: IListenerActionType;
 }

--- a/app/scripts/modules/amazon/src/domain/IAmazonLoadBalancerSourceData.ts
+++ b/app/scripts/modules/amazon/src/domain/IAmazonLoadBalancerSourceData.ts
@@ -1,8 +1,8 @@
 import { ILoadBalancerSourceData } from '@spinnaker/core';
 
-import { NLBListenerProtocol } from 'amazon/domain';
+import { IListenerAction, NLBListenerProtocol } from 'amazon/domain';
 
-import { IListenerActionType, IListenerRule } from './IAmazonLoadBalancer';
+import { IListenerRule } from './IAmazonLoadBalancer';
 
 export interface IAmazonContainerServerGroupSourceData {
   detachedInstances: string[];
@@ -112,11 +112,7 @@ export interface IApplicationLoadBalancerCertificateSourceData {
 
 export interface IApplicationLoadBalancerListenerSourceData {
   certificates?: IApplicationLoadBalancerCertificateSourceData[];
-  defaultActions: Array<{
-    targetGroupName: string;
-    type: IListenerActionType;
-    order: number;
-  }>;
+  defaultActions: IListenerAction[];
   listenerArn: string;
   loadBalancerName: string;
   port: number;

--- a/app/scripts/modules/amazon/src/loadBalancer/loadBalancer.transformer.ts
+++ b/app/scripts/modules/amazon/src/loadBalancer/loadBalancer.transformer.ts
@@ -310,6 +310,7 @@ export class AwsLoadBalancerTransformer {
             if (action.targetGroupName) {
               action.targetGroupName = action.targetGroupName.replace(`${applicationName}-`, '');
             }
+            action.redirectActionConfig = action.redirectConfig;
           });
 
           // Remove the default rule because it already exists in defaultActions
@@ -319,6 +320,7 @@ export class AwsLoadBalancerTransformer {
               if (action.targetGroupName) {
                 action.targetGroupName = action.targetGroupName.replace(`${applicationName}-`, '');
               }
+              action.redirectActionConfig = action.redirectConfig;
             });
             rule.conditions = rule.conditions || [];
           });


### PR DESCRIPTION
Minor inconsistency between the commands Clouddriver wants and the models AWS returns.

@jrsquared if people are not scripting against this part of the API, it would be good to convert Clouddriver to just use `redirectConfig` instead of `redirectActionConfig` and then undo most of these changes, unless there's a reason to have both, in which case, I am so proud of my code.