### PR TITLE
fix(core/clipboard): correctly type CopyToClipboard's displayText prop

### DIFF
--- a/app/scripts/modules/core/src/utils/clipboard/CopyToClipboard.tsx
+++ b/app/scripts/modules/core/src/utils/clipboard/CopyToClipboard.tsx
@@ -6,7 +6,7 @@ import './CopyToClipboard.less';
 
 export interface ICopyToClipboardProps {
   analyticsLabel?: string;
-  displayText: boolean;
+  displayText?: boolean;
   text: string;
   toolTip: string;
 }


### PR DESCRIPTION
`displayText` is optional and defaults to `false`, let's make the interface reflect reality.