### PR TITLE
Bump package core to 0.0.336 and amazon to 0.0.174

### DIFF
--- a/app/scripts/modules/amazon/package.json
+++ b/app/scripts/modules/amazon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/amazon",
-  "version": "0.0.173",
+  "version": "0.0.174",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/core",
-  "version": "0.0.335",
+  "version": "0.0.336",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
### chore(core): Bump version to 0.0.336

4d816b54a0dade16becd5c0fa8aa0a4abd9782ee fix(core/clipboard): correctly type CopyToClipboard's displayText prop (#6580)

### chore(amazon): Bump version to 0.0.174

ad7c582006a70648b20a1c7b6bb466fa62fb8b6c fix(aws): set redirectActionConfig on ALB rules (#6579)


