### PR TITLE
Bump package core to 0.0.338 and docker to 0.0.35 and amazon to 0.0.176 and titus to 0.0.76

### DIFF
--- a/app/scripts/modules/amazon/package.json
+++ b/app/scripts/modules/amazon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/amazon",
-  "version": "0.0.175",
+  "version": "0.0.176",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/core",
-  "version": "0.0.337",
+  "version": "0.0.338",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/docker/package.json
+++ b/app/scripts/modules/docker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/docker",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/titus/package.json
+++ b/app/scripts/modules/titus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/titus",
-  "version": "0.0.75",
+  "version": "0.0.76",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
### chore(core): Bump version to 0.0.338

7d5fc346bca54c5d53f9eb46d823cd993c102058 chore(prettier): Just Use Prettier™ (#6600)
64fb4892ee3e7114eccb8f6acc9d84ae652f1af3 fix(html): Fix various invalid HTML (#6597)
39f6858797af81265a6de1aa0735c33b9c35bd30 fix(core/diffs): Fix misnamed tempate field
5cf6c79da63404bb7238291d38bb7f5cfd10c26b chore(prettier): Just Use Prettier™
3ffa4fb7498df815014d61071e8588f0b34bf8b9 chore(angularjs): Do not use .component('foo', new Foo())
14bf52b2da88555cbab3bca7ae33062cf32d7625 feat(gremlin): Per feedback review within gate, change the Gate gremlin endpoint prefix from "gremlin" to "integrations/gremlin" (#6591)

### chore(docker): Bump version to 0.0.35

7d5fc346bca54c5d53f9eb46d823cd993c102058 chore(prettier): Just Use Prettier™ (#6600)
64fb4892ee3e7114eccb8f6acc9d84ae652f1af3 fix(html): Fix various invalid HTML (#6597)

### chore(amazon): Bump version to 0.0.176

7d5fc346bca54c5d53f9eb46d823cd993c102058 chore(prettier): Just Use Prettier™ (#6600)
04bb4a01c2d988aab5b5b8ae6e3aadbc59214898 fix(html): Fix various invalid HTML (#6599)
64fb4892ee3e7114eccb8f6acc9d84ae652f1af3 fix(html): Fix various invalid HTML (#6597)
5cf6c79da63404bb7238291d38bb7f5cfd10c26b chore(prettier): Just Use Prettier™
3ffa4fb7498df815014d61071e8588f0b34bf8b9 chore(angularjs): Do not use .component('foo', new Foo())

### chore(titus): Bump version to 0.0.76

7d5fc346bca54c5d53f9eb46d823cd993c102058 chore(prettier): Just Use Prettier™ (#6600)
04bb4a01c2d988aab5b5b8ae6e3aadbc59214898 fix(html): Fix various invalid HTML (#6599)
5cf6c79da63404bb7238291d38bb7f5cfd10c26b chore(prettier): Just Use Prettier™
3ffa4fb7498df815014d61071e8588f0b34bf8b9 chore(angularjs): Do not use .component('foo', new Foo())


