### PR TITLE
fix(core/executions): Disable text selection when re-ordering pipelines

### DIFF
--- a/app/scripts/modules/core/src/pipeline/filter/ExecutionFilters.tsx
+++ b/app/scripts/modules/core/src/pipeline/filter/ExecutionFilters.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import * as ReactGA from 'react-ga';
 import { get, isEmpty, orderBy, uniq } from 'lodash';
 import { Debounce } from 'lodash-decorators';
+import * as classnames from 'classnames';
 import { SortableContainer, SortableElement, SortableHandle, arrayMove, SortEnd } from 'react-sortable-hoc';
 import { Subscription } from 'rxjs';
 
@@ -290,7 +291,7 @@ const FilterCheckbox = (props: {
 
 const Pipeline = SortableElement(
   (props: { tag: IFilterTag; pipeline: string; dragEnabled: boolean; update: () => void }) => (
-    <div className="checkbox sortable">
+    <div className={classnames('checkbox sortable', { 'disable-user-select': props.dragEnabled })}>
       <div>
         <label>
           {props.dragEnabled && <DragHandle />}

--- a/app/scripts/modules/core/src/pipeline/filter/executionFilters.less
+++ b/app/scripts/modules/core/src/pipeline/filter/executionFilters.less
@@ -1,4 +1,5 @@
-execution-filters, .execution-filters {
+execution-filters,
+.execution-filters {
   width: 100%;
   display: flex;
   .sortable {
@@ -8,6 +9,9 @@ execution-filters, .execution-filters {
       margin-right: 3px;
       opacity: 0.7;
       font-size: 80%;
+    }
+    &.disable-user-select {
+      user-select: none;
     }
   }
 }


### PR DESCRIPTION
When re-ordering pipelines in the filter sidebar, it can get kinda wonky if you accidentally make the browser think you're selecting text. If you manage to click + drag just right, sometimes it even thinks you're trying to drag a multi-line text selection for copy-pasting.

This switches off text selection when entering re-ordering mode for strategies and normal pipelines. Outside re-ordering mode you can still select the pipeline names to copy-paste, if that's something you're into.