### PR TITLE
fix(amazon/loadBalancer): Fix AZ autobalance, subnet AZ default value, and isInternal checkbox

### DIFF
--- a/app/scripts/modules/amazon/src/loadBalancer/configure/common/LoadBalancerLocation.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/common/LoadBalancerLocation.tsx
@@ -380,7 +380,9 @@ export class LoadBalancerLocation extends React.Component<ILoadBalancerLocationP
                     <Field
                       name="isInternal"
                       onChange={this.internalFlagChanged}
-                      render={({ field }: FieldProps) => <input type="checkbox" checked={!!field.value} />}
+                      render={({ field: { value, ...field } }: FieldProps) => (
+                        <input type="checkbox" {...field} checked={!!value} />
+                      )}
                     />
                     Create an internal load balancer
                   </label>

--- a/app/scripts/modules/amazon/src/serverGroup/AvailabilityZoneSelector.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/AvailabilityZoneSelector.tsx
@@ -37,7 +37,8 @@ export class AvailabilityZoneSelector extends React.Component<
   }
 
   private setDefaultZones(props: IAvailabilityZoneSelectorProps) {
-    const { credentials, onChange, region, usePreferredZones } = props;
+    const { credentials, onChange, region } = props;
+    const { usePreferredZones } = this.state;
 
     AccountService.getAvailabilityZonesForAccountAndRegion('aws', credentials, region).then(preferredZones => {
       this.setState({ defaultZones: preferredZones });

--- a/app/scripts/modules/amazon/src/subnet/SubnetSelectInput.tsx
+++ b/app/scripts/modules/amazon/src/subnet/SubnetSelectInput.tsx
@@ -90,7 +90,7 @@ export class SubnetSelectInput extends React.Component<ISubnetSelectInputProps, 
   public applyDefaultSubnet() {
     const { value, onChange, subnets } = this.props;
     const defaultSubnetType = get(SETTINGS, 'providers.aws.defaults.subnetType');
-    const defaultSubnet = subnets.find(subnet => defaultSubnetType === subnet.purpose);
+    const defaultSubnet = subnets.find(subnet => defaultSubnetType === subnet.purpose) || subnets[0];
     if (!value && defaultSubnet) {
       onChange(createFakeReactSyntheticEvent({ name, value: defaultSubnet.purpose }));
     }


### PR DESCRIPTION
- When a new ALB was created, AZ autobalance mode was not saving the default AZs into the form state.
- When no default subnet is configured, the first subnet was selected in the UI, but not in the form state. 
- the isInternal checkbox was read-only