### PR TITLE
Bump package core to 0.0.341 and amazon to 0.0.178

### DIFF
--- a/app/scripts/modules/amazon/package.json
+++ b/app/scripts/modules/amazon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/amazon",
-  "version": "0.0.177",
+  "version": "0.0.178",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/core",
-  "version": "0.0.340",
+  "version": "0.0.341",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
### chore(core): Bump version to 0.0.341

69a2d56c5d026679530b3cb59d51ae0ca5edd606 fix(artifacts): lookup of artifact id with incorrect string (#6622)
10153213b2bdabbf5fb166863c6bb28eb5b398a6 fix(projects): config state was stale after update (#6464)
c0f6b24ec35e5e9eb438791a2eaf0b540af2830e chore(angularjs): Move $inject annotation above hoisted functions (#6621)
a6a6b7394a4d09ee646a452a804d23bdf7134616 fix(gremlin): Check for fetched data from API (#6553)
d828a53e55919c16a8cea82af404c05bad081066 chore(angularjs): Explicitly annotate directive controllers

### chore(amazon): Bump version to 0.0.178

ea0808f57121e108072a664bed445b186820d03e fix(amazon/loadBalancer): Fix AZ autobalance, subnet AZ default value, and isInternal checkbox (#6623)


