### PR TITLE
fix(chaos): do not let user save invalid chaos monkey config

### DIFF
--- a/app/scripts/modules/core/src/application/config/footer/configSectionFooter.component.html
+++ b/app/scripts/modules/core/src/application/config/footer/configSectionFooter.component.html
@@ -10,7 +10,12 @@
     </button>
   </div>
   <div class="col-md-9 text-right">
-    <button class="btn btn-primary" ng-if="$ctrl.viewState.isDirty" ng-click="$ctrl.save()">
+    <button
+      class="btn btn-primary"
+      ng-if="$ctrl.viewState.isDirty"
+      ng-click="$ctrl.save()"
+      ng-disabled="$ctrl.saveDisabled"
+    >
       <span ng-if="!$ctrl.viewState.saving"> <span class="far fa-check-circle"></span> Save Changes </span>
       <span ng-if="$ctrl.viewState.saving" class="pulsing">
         <span class="fa fa-cog fa-spin"></span> Saving&hellip;

--- a/app/scripts/modules/core/src/application/config/footer/configSectionFooter.component.ts
+++ b/app/scripts/modules/core/src/application/config/footer/configSectionFooter.component.ts
@@ -19,6 +19,7 @@ export class ConfigSectionFooterController implements IController {
   public application: Application;
   public config: any;
   public configField: string;
+  public saveDisabled: boolean;
 
   public revert(): void {
     copy(this.viewState.originalConfig, this.config);
@@ -60,6 +61,7 @@ const configSectionFooterComponent: IComponentOptions = {
     configField: '@',
     revert: '&?',
     afterSave: '&?',
+    saveDisabled: '<',
   },
   controller: ConfigSectionFooterController,
   templateUrl: require('./configSectionFooter.component.html'),

--- a/app/scripts/modules/core/src/chaosMonkey/chaosMonkeyConfig.component.html
+++ b/app/scripts/modules/core/src/chaosMonkey/chaosMonkeyConfig.component.html
@@ -1,4 +1,4 @@
-<div class="form-inline" ng-if="$ctrl.chaosEnabled">
+<form name="form" class="form-inline" ng-if="$ctrl.chaosEnabled">
   <div class="chaos-enabled">
     <label class="checkbox-inline">
       <input type="checkbox" ng-model="$ctrl.config.enabled" ng-change="$ctrl.configChanged()" />
@@ -71,5 +71,6 @@
     config="$ctrl.config"
     view-state="$ctrl.viewState"
     config-field="chaosMonkey"
+    save-disabled="form.$invalid"
   ></config-section-footer>
-</div>
+</form>


### PR DESCRIPTION
If a user types an invalid value into a numeric field, the field will be marked invalid (and have a red outline) but can still be saved. This just prevents that.