### PR TITLE
fix(kubernetes): allow text input for replicas in `Scale (Manifest)` stage

### DIFF
--- a/app/scripts/modules/kubernetes/src/v2/manifest/scale/scaleSettingsForm.component.ts
+++ b/app/scripts/modules/kubernetes/src/v2/manifest/scale/scaleSettingsForm.component.ts
@@ -10,7 +10,7 @@ const kubernetesScaleManifestSettingsFormComponent: IComponentOptions = {
           Replicas
         </div>
         <div class="col-md-4">
-          <input type="number"
+          <input type="text"
                  class="form-control input-sm highlight-pristine"
                  ng-model="ctrl.settings.replicas"
                  min="0"/>


### PR DESCRIPTION
Currently the deck UI forces numeric input for replicas in the `Scale (Manifest)` stage. This prohibits configuring the stage to accept SpEL. Changed the input type to text, built and tested in our production cluster.
