### PR TITLE
 feat(kubernetes): add dynamic target selection to patch manifest stage

### DIFF
--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deleteManifest/DeleteManifestStageConfig.tsx
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deleteManifest/DeleteManifestStageConfig.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { defaultsDeep } from 'lodash';
+import { defaults } from 'lodash';
 
 import { Application, IStage, IStageConfigProps } from '@spinnaker/core';
 
@@ -16,18 +16,16 @@ export interface IKubernetesManifestStageConfigProps extends IStageConfigProps {
 
 export class DeleteManifestStageConfig extends React.Component<IKubernetesManifestStageConfigProps> {
   public componentDidMount = (): void => {
-    defaultsDeep(this.props.stage, {
+    defaults(this.props.stage, {
       app: this.props.application.name,
       cloudProvider: 'kubernetes',
-      kinds: [],
-      labelSelectors: {
-        selectors: [],
-      },
-      options: {
+    });
+    if (this.props.stage.isNew) {
+      this.props.stage.options = {
         gracePeriodSeconds: null,
         cascading: true,
-      },
-    });
+      };
+    }
     this.props.stageFieldUpdated();
   };
 

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/patchManifest/patchManifestConfig.controller.ts
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/patchManifest/patchManifestConfig.controller.ts
@@ -45,6 +45,10 @@ export class KubernetesV2PatchManifestConfigCtrl implements IController {
       this.$scope.stage.options = defaultOptions;
     }
 
+    if (!this.$scope.stage.app) {
+      this.$scope.stage.app = this.$scope.application.name;
+    }
+
     this.setRawPatchBody(this.getMergeStrategy());
 
     this.manifestArtifactDelegate = new NgGenericArtifactDelegate($scope, 'manifest');

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/patchManifest/patchManifestConfig.html
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/patchManifest/patchManifestConfig.html
@@ -3,6 +3,8 @@
     <h4>Resource to Patch</h4>
     <div class="horizontal-rule"></div>
     <kubernetes-manifest-selector
+      application="ctrl.$scope.application"
+      modes='["static", "dynamic"]'
       on-change="ctrl.handleManifestSelectorChange"
       selector="ctrl.$scope.stage"
     ></kubernetes-manifest-selector>

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/patchManifest/patchManifestStage.ts
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/patchManifest/patchManifestStage.ts
@@ -12,6 +12,7 @@ import { KubernetesV2PatchManifestConfigCtrl } from '../patchManifest/patchManif
 import { KUBERNETES_PATCH_MANIFEST_OPTIONS_FORM } from './patchOptionsForm.component';
 import { KUBERNETES_MANIFEST_SELECTOR } from 'kubernetes/v2/manifest/selector/selector.component';
 import { DeployStatus } from '../deployManifest/react/DeployStatus';
+import { trafficValidators } from '../traffic/validators';
 
 export const KUBERNETES_PATCH_MANIFEST_STAGE = 'spinnaker.kubernetes.v2.pipeline.stage.patchManifestStage';
 
@@ -33,11 +34,7 @@ module(KUBERNETES_PATCH_MANIFEST_STAGE, [KUBERNETES_PATCH_MANIFEST_OPTIONS_FORM,
         executionDetailsSections: [PatchStatus, ExecutionDetailsTasks, ExecutionArtifactTab],
         producesArtifacts: true,
         defaultTimeoutMs: 30 * 60 * 1000, // 30 minutes
-        validators: [
-          { type: 'requiredField', fieldName: 'location', fieldLabel: 'Namespace' },
-          { type: 'requiredField', fieldName: 'account', fieldLabel: 'Account' },
-          { type: 'manifestSelector' },
-        ],
+        validators: trafficValidators(KUBERNETES_PATCH_MANIFEST_STAGE),
         artifactExtractor: ExpectedArtifactService.accumulateArtifacts(['manifestArtifactId', 'requiredArtifactIds']),
         artifactRemover: ArtifactReferenceService.removeArtifactFromFields([
           'manifestArtifactId',


### PR DESCRIPTION
Follow-up to https://github.com/spinnaker/deck/pull/6628
Closes https://github.com/spinnaker/spinnaker/issues/3829
- Adds UI support for dynamic target selection in Patch Manifest stage
- In separate commit, fixes defaults for Delete Manifest stage

Corresponding Orca PR: https://github.com/spinnaker/orca/pull/2688

![kzm6mydncrq 1](https://user-images.githubusercontent.com/15936279/53656476-576f2580-3c21-11e9-8167-cc87849ee494.png)
