### PR TITLE
feature(core): allow custom tooltip, modal body on Cancel Execution

### DIFF
--- a/app/scripts/modules/core/src/presentation/main.less
+++ b/app/scripts/modules/core/src/presentation/main.less
@@ -524,6 +524,9 @@ dl {
 
 .tooltip-inner {
   overflow-wrap: break-word;
+  p:last-child {
+    margin-bottom: 0;
+  }
 }
 
 .tooltip-table {


### PR DESCRIPTION
We use the Execution component in our internal build to roll out property changes. When those executions are cancelled, we have custom code in Orca that will revert any changes that the execution has made so far.

This rollback behavior is not obvious to users - it's inconsistent with how pipelines in Spinnaker work on other changes. We don't want to _not_ perform the rollback, but we do want to let users know that it will happen if they cancel the execution, so we want to customize the tooltip on the cancel button, and add some body text to the confirmation modal when they choose to cancel.