### PR TITLE
fix(core): Remove configure button and setup redirect for mptv2 pipeline

### DIFF
--- a/app/scripts/modules/core/src/domain/IExecution.ts
+++ b/app/scripts/modules/core/src/domain/IExecution.ts
@@ -3,6 +3,7 @@ import { IOrchestratedItem } from './IOrchestratedItem';
 import { IExecutionTrigger } from './IExecutionTrigger';
 import { IExecutionStage, IExecutionStageSummary } from './IExecutionStage';
 import { IAuthentication } from './IAuthentication';
+import { IPipeline } from './IPipeline';
 
 export interface IExecution extends IOrchestratedItem {
   appConfig?: any;
@@ -23,6 +24,7 @@ export interface IExecution extends IOrchestratedItem {
   isStrategy?: boolean;
   name?: string;
   pipelineConfigId?: string;
+  pipelineConfig?: IPipeline;
   searchField?: string;
   stageSummaries?: IExecutionStageSummary[]; // added by transformer
   stageWidth?: string; // added by transformer

--- a/app/scripts/modules/core/src/domain/IPipeline.ts
+++ b/app/scripts/modules/core/src/domain/IPipeline.ts
@@ -16,6 +16,7 @@ export interface IPipeline {
   limitConcurrent: boolean;
   name: string;
   respectQuietPeriod?: boolean;
+  schema?: string;
   stages: IStage[];
   strategy: boolean;
   triggers: ITrigger[];

--- a/app/scripts/modules/core/src/pipeline/config/CreatePipeline.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/CreatePipeline.tsx
@@ -5,6 +5,7 @@ import { Dropdown } from 'react-bootstrap';
 
 import { Application } from 'core/application';
 import { IPipeline } from 'core/domain';
+import { PipelineTemplateV2Service } from 'core/pipeline';
 import { ReactInjector } from 'core/reactShims';
 import { Tooltip } from 'core/presentation/Tooltip';
 
@@ -23,7 +24,7 @@ export class CreatePipeline extends React.Component<ICreatePipelineProps> {
     const { application } = this.props;
 
     const pipelineConfigs = get(application, 'pipelineConfigs.data', []).filter(
-      (pipelineConfig: IPipeline) => pipelineConfig.schema !== 'v2',
+      (pipelineConfig: IPipeline) => !PipelineTemplateV2Service.isV2PipelineConfig(pipelineConfig),
     );
     const hasPipelineConfigs = pipelineConfigs.length > 0;
 

--- a/app/scripts/modules/core/src/pipeline/config/CreatePipeline.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/CreatePipeline.tsx
@@ -4,6 +4,7 @@ import { get } from 'lodash';
 import { Dropdown } from 'react-bootstrap';
 
 import { Application } from 'core/application';
+import { IPipeline } from 'core/domain';
 import { ReactInjector } from 'core/reactShims';
 import { Tooltip } from 'core/presentation/Tooltip';
 
@@ -20,7 +21,12 @@ export class CreatePipeline extends React.Component<ICreatePipelineProps> {
 
   public render() {
     const { application } = this.props;
-    const hasPipelineConfigs = get(application, 'pipelineConfigs.data', []).length > 0;
+
+    const pipelineConfigs = get(application, 'pipelineConfigs.data', []).filter(
+      (pipelineConfig: IPipeline) => pipelineConfig.schema !== 'v2',
+    );
+    const hasPipelineConfigs = pipelineConfigs.length > 0;
+
     const hasStrategyConfigs = get(application, 'strategyConfigs.data', []).length > 0;
     const header = !(hasPipelineConfigs || hasStrategyConfigs) ? (
       <li className="dropdown-header" style={{ marginTop: 0 }}>
@@ -56,10 +62,9 @@ export class CreatePipeline extends React.Component<ICreatePipelineProps> {
         </Dropdown.Toggle>
         <Dropdown.Menu className="dropdown-menu">
           {header}
-          {hasPipelineConfigs &&
-            application.pipelineConfigs.data.map((pipeline: any) => (
-              <Pipeline key={pipeline.id} pipeline={pipeline} type="pipeline" />
-            ))}
+          {pipelineConfigs.map((pipeline: IPipeline) => (
+            <Pipeline key={pipeline.id} pipeline={pipeline} type="pipeline" />
+          ))}
           {hasStrategyConfigs &&
             application.strategyConfigs.data.map((pipeline: any) => (
               <Pipeline key={pipeline.id} pipeline={pipeline} type="strategy" />

--- a/app/scripts/modules/core/src/pipeline/config/actions/templateJson/ShowPipelineTemplateJsonModal.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/actions/templateJson/ShowPipelineTemplateJsonModal.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { IModalComponentProps, JsonEditor } from 'core/presentation';
 import { IPipeline, IPipelineTemplateV2 } from 'core/domain';
 import { CopyToClipboard, noop, JsonUtils } from 'core/utils';
-import { PipelineTemplateV2Service } from 'core/pipeline/config/templates/v2/pipelineTemplateV2.service';
+import { PipelineTemplateV2Service } from 'core/pipeline';
 
 import './ShowPipelineTemplateJsonModal.less';
 

--- a/app/scripts/modules/core/src/pipeline/config/pipelineConfig.controller.js
+++ b/app/scripts/modules/core/src/pipeline/config/pipelineConfig.controller.js
@@ -4,6 +4,7 @@ import _ from 'lodash';
 import { hri as HumanReadableIds } from 'human-readable-ids';
 
 import { PipelineTemplateReader } from './templates/PipelineTemplateReader';
+import { PipelineTemplateV2Service } from 'core/pipeline';
 
 const angular = require('angular');
 
@@ -25,7 +26,7 @@ module.exports = angular
       this.initialize = () => {
         this.pipelineConfig = _.find(app.pipelineConfigs.data, { id: $stateParams.pipelineId });
 
-        if (this.pipelineConfig && this.pipelineConfig.schema === 'v2') {
+        if (this.pipelineConfig && PipelineTemplateV2Service.isV2PipelineConfig(this.pipelineConfig)) {
           return $state.go('home.applications.application.pipelines.executions', null, { location: 'replace' });
         }
 

--- a/app/scripts/modules/core/src/pipeline/config/pipelineConfig.controller.js
+++ b/app/scripts/modules/core/src/pipeline/config/pipelineConfig.controller.js
@@ -11,9 +11,10 @@ module.exports = angular
   .module('spinnaker.core.pipeline.config.controller', [require('@uirouter/angularjs').default])
   .controller('PipelineConfigCtrl', [
     '$scope',
+    '$state',
     '$stateParams',
     'app',
-    function($scope, $stateParams, app) {
+    function($scope, $state, $stateParams, app) {
       this.application = app;
       this.state = {
         pipelinesLoaded: false,
@@ -23,6 +24,10 @@ module.exports = angular
 
       this.initialize = () => {
         this.pipelineConfig = _.find(app.pipelineConfigs.data, { id: $stateParams.pipelineId });
+
+        if (this.pipelineConfig && this.pipelineConfig.schema === 'v2') {
+          return $state.go('home.applications.application.pipelines.executions', null, { location: 'replace' });
+        }
 
         if (this.pipelineConfig && this.pipelineConfig.expectedArtifacts) {
           for (const artifact of this.pipelineConfig.expectedArtifacts) {

--- a/app/scripts/modules/core/src/pipeline/config/templates/v2/pipelineTemplateV2.service.ts
+++ b/app/scripts/modules/core/src/pipeline/config/templates/v2/pipelineTemplateV2.service.ts
@@ -22,4 +22,8 @@ export class PipelineTemplateV2Service {
       variables: [],
     };
   }
+
+  public static isV2PipelineConfig(pipelineConfig: IPipeline): boolean {
+    return pipelineConfig.schema === 'v2';
+  }
 }

--- a/app/scripts/modules/core/src/pipeline/details/SingleExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/details/SingleExecutionDetails.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { get } from 'lodash';
 import * as ReactGA from 'react-ga';
 import { Subscription } from 'rxjs';
 import { UISref } from '@uirouter/react';
@@ -132,6 +133,8 @@ export class SingleExecutionDetails extends React.Component<
     const defaultExecutionParams = { application: app.name, executionId: execution ? execution.id : '' };
     const executionParams = ReactInjector.$state.params.executionParams || defaultExecutionParams;
 
+    const isFromMPTV2Pipeline = (get(execution, 'pipelineConfig.schema', '') as string) === 'v2';
+
     return (
       <div style={{ width: '100%', paddingTop: 0 }}>
         {execution && (
@@ -160,21 +163,22 @@ export class SingleExecutionDetails extends React.Component<
                       <span> stage durations</span>
                     </label>
                   </div>
-                  <Tooltip value="Navigate to Pipeline Configuration">
-                    <UISref
-                      to="^.pipelineConfig"
-                      params={{ application: this.props.app.name, pipelineId: this.state.execution.pipelineConfigId }}
-                    >
-                      <button
-                        className="btn btn-sm btn-default"
-                        onClick={this.handleConfigureClicked}
-                        style={{ marginRight: '5px' }}
+                  {!isFromMPTV2Pipeline && (
+                    <Tooltip value="Navigate to Pipeline Configuration">
+                      <UISref
+                        to="^.pipelineConfig"
+                        params={{ application: this.props.app.name, pipelineId: this.state.execution.pipelineConfigId }}
                       >
-                        <span className="glyphicon glyphicon-cog" />
-                        <span className="visible-md-inline visible-lg-inline"> Configure</span>
-                      </button>
-                    </UISref>
-                  </Tooltip>
+                        <button
+                          className="btn btn-sm btn-default single-execution-details__configure"
+                          onClick={this.handleConfigureClicked}
+                        >
+                          <span className="glyphicon glyphicon-cog" />
+                          <span className="visible-md-inline visible-lg-inline"> Configure</span>
+                        </button>
+                      </UISref>
+                    </Tooltip>
+                  )}
                 </div>
               </div>
             </div>

--- a/app/scripts/modules/core/src/pipeline/details/SingleExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/details/SingleExecutionDetails.tsx
@@ -5,9 +5,10 @@ import { Subscription } from 'rxjs';
 import { UISref } from '@uirouter/react';
 
 import { Application } from 'core/application/application.model';
-import { IExecution } from 'core/domain';
+import { IExecution, IPipeline } from 'core/domain';
 import { Execution } from 'core/pipeline/executions/execution/Execution';
 import { IScheduler, SchedulerFactory } from 'core/scheduler';
+import { PipelineTemplateV2Service } from 'core/pipeline';
 import { ReactInjector, IStateChange } from 'core/reactShims';
 import { Tooltip } from 'core/presentation';
 import { ISortFilter } from 'core/filterModel';
@@ -132,8 +133,11 @@ export class SingleExecutionDetails extends React.Component<
 
     const defaultExecutionParams = { application: app.name, executionId: execution ? execution.id : '' };
     const executionParams = ReactInjector.$state.params.executionParams || defaultExecutionParams;
-
-    const isFromMPTV2Pipeline = (get(execution, 'pipelineConfig.schema', '') as string) === 'v2';
+    const isFromMPTV2Pipeline = PipelineTemplateV2Service.isV2PipelineConfig(get(
+      execution,
+      'pipelineConfig',
+      {},
+    ) as IPipeline);
 
     return (
       <div style={{ width: '100%', paddingTop: 0 }}>

--- a/app/scripts/modules/core/src/pipeline/details/singleExecutionDetails.less
+++ b/app/scripts/modules/core/src/pipeline/details/singleExecutionDetails.less
@@ -1,5 +1,3 @@
-.single-execution-details {
-  .checkbox {
-    padding: 0 1em;
-  }
+.single-execution-details__configure {
+  margin: 0 5px 0 1em;
 }

--- a/app/scripts/modules/core/src/pipeline/executions/executionGroup/ExecutionGroup.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/executionGroup/ExecutionGroup.tsx
@@ -55,6 +55,8 @@ export class ExecutionGroup extends React.Component<IExecutionGroupProps, IExecu
     const pipelineConfig = find(this.props.application.pipelineConfigs.data, {
       name: this.props.group.heading,
     }) as IPipeline;
+
+    const hasNonMPTV2PipelineConfig = pipelineConfig && pipelineConfig.schema !== 'v2';
     const sectionCacheKey = this.getSectionCacheKey();
 
     this.state = {
@@ -66,7 +68,7 @@ export class ExecutionGroup extends React.Component<IExecutionGroupProps, IExecu
         CollapsibleSectionStateCache.isExpanded(sectionCacheKey),
       poll: null,
       canTriggerPipelineManually: !!pipelineConfig,
-      canConfigure: !!(pipelineConfig || strategyConfig),
+      canConfigure: !!(hasNonMPTV2PipelineConfig || strategyConfig),
       showAccounts: ExecutionState.filterModel.asFilterModel.sortFilter.groupBy === 'name',
       pipelineConfig,
       showOverflowAccountTags: false,

--- a/app/scripts/modules/core/src/pipeline/executions/executionGroup/ExecutionGroup.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/executionGroup/ExecutionGroup.tsx
@@ -17,6 +17,7 @@ import { IRetryablePromise } from 'core/utils/retryablePromise';
 import { TriggersTag } from 'core/pipeline/triggers/TriggersTag';
 import { AccountTag } from 'core/account';
 import { ModalInjector, ReactInjector } from 'core/reactShims';
+import { PipelineTemplateV2Service } from 'core/pipeline';
 import { Spinner } from 'core/widgets/spinners/Spinner';
 
 import './executionGroup.less';
@@ -56,7 +57,7 @@ export class ExecutionGroup extends React.Component<IExecutionGroupProps, IExecu
       name: this.props.group.heading,
     }) as IPipeline;
 
-    const hasNonMPTV2PipelineConfig = pipelineConfig && pipelineConfig.schema !== 'v2';
+    const hasNonMPTV2PipelineConfig = pipelineConfig && !PipelineTemplateV2Service.isV2PipelineConfig(pipelineConfig);
     const sectionCacheKey = this.getSectionCacheKey();
 
     this.state = {

--- a/app/scripts/modules/core/src/pipeline/index.ts
+++ b/app/scripts/modules/core/src/pipeline/index.ts
@@ -5,6 +5,7 @@ export * from './config/stages/stageConstants';
 export * from './config/PipelineRegistry';
 export * from './config/stages/templates';
 export * from './config/services/PipelineConfigService';
+export * from './config/templates/v2/pipelineTemplateV2.service';
 export * from './config/triggers/ITriggerConfigProps';
 export * from './config/triggers/RunAsUser';
 export * from './config/validation/PipelineConfigValidator';

--- a/app/scripts/modules/core/src/pipeline/service/execution.service.ts
+++ b/app/scripts/modules/core/src/pipeline/service/execution.service.ts
@@ -104,8 +104,18 @@ export class ExecutionService {
     return API.one('pipelines', executionId)
       .get()
       .then((execution: IExecution) => {
+        const { application, name } = execution;
         execution.hydrated = true;
         this.cleanExecutionForDiffing(execution);
+        if (application && name) {
+          return API.one('applications', application, 'pipelineConfigs', name)
+            .get()
+            .then((pipelineConfig: IPipeline) => {
+              execution.pipelineConfig = pipelineConfig;
+              return execution;
+            })
+            .catch(() => execution);
+        }
         return execution;
       });
   }


### PR DESCRIPTION
https://github.com/spinnaker/spinnaker/issues/4056

Removes configure as an option for pipelines from mptv2 templates:
![image](https://user-images.githubusercontent.com/2623242/53834315-b0f48e80-3f58-11e9-8e47-d127bd65e1c8.png)

Removes mptv2 pipelines from the Configure menu in the "Pipelines" view:
![image](https://user-images.githubusercontent.com/2623242/53834347-bf42aa80-3f58-11e9-8dcd-b026c2d6de03.png)

Removes the configure button from the single execution view if a execution has a mptv2 pipeline config:
![image](https://user-images.githubusercontent.com/2623242/53834462-1183cb80-3f59-11e9-9043-3481cee7c1db.png)

Redirects to "Pipelines" view if user navigates to mptv2 pipeline config directly.


