### PR TITLE
fix(provider/azure): Enable strategy for azure

### DIFF
--- a/app/scripts/modules/azure/serverGroup/serverGroup.transformer.js
+++ b/app/scripts/modules/azure/serverGroup/serverGroup.transformer.js
@@ -33,6 +33,7 @@ module.exports = angular
         cloudProvider: command.selectedProvider,
         application: command.application,
         stack: command.stack,
+        strategy: command.strategy,
         detail: command.freeFormDetails,
         freeFormDetails: command.freeFormDetails,
         account: command.credentials,


### PR DESCRIPTION
Background:
Currently orca doesn't process job according by new strategy after choosed new strategy like highlander for azure. The root cause is that deck doesn't memory the new strategy and pass to orca.

Fix:
So update the deck code to memory new strategy and then the memoried new strategy would be passed to orca.