### PR TITLE
fix(core): titus run jobs override all other providers

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/baseProviderStage/baseProviderStage.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/baseProviderStage/baseProviderStage.html
@@ -8,4 +8,5 @@
     ></provider-selector>
   </stage-config-field>
   <div ng-include="providerStageDetailsUrl"></div>
+  <div class="react-stage-details"></div>
 </div>

--- a/app/scripts/modules/core/src/pipeline/config/stages/baseProviderStage/baseProviderStage.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/baseProviderStage/baseProviderStage.js
@@ -2,9 +2,13 @@
 
 const angular = require('angular');
 
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+
 import { AccountService } from 'core/account/AccountService';
 import { Registry } from 'core/registry';
 import { SETTINGS } from 'core/config/settings';
+import { StageConfigWrapper } from 'core/pipeline/config/stages/StageConfigWrapper';
 
 module.exports = angular
   .module('spinnaker.core.pipeline.stage.baseProviderStage', [])
@@ -52,13 +56,25 @@ module.exports = angular
           }
         });
 
+      let reactMounted = false;
       function loadProvider() {
         const stageProvider = (stageProviders || []).find(
           s => s.cloudProvider === stage.cloudProviderType || (s.providesFor || []).includes(stage.cloudProviderType),
         );
         if (stageProvider) {
           $scope.stage.type = stageProvider.key || $scope.stage.type;
-          $scope.providerStageDetailsUrl = stageProvider.templateUrl;
+          const el = document.querySelector('.react-stage-details');
+          if (reactMounted) {
+            ReactDOM.unmountComponentAtNode(el);
+          }
+          if (stageProvider.component) {
+            const props = $scope.reactPropsForBaseProviderStage;
+            props.component = stageProvider.component;
+            ReactDOM.render(React.createElement(StageConfigWrapper, props), el);
+          } else {
+            $scope.providerStageDetailsUrl = stageProvider.templateUrl;
+          }
+          reactMounted = !!stageProvider.component;
         }
       }
 

--- a/app/scripts/modules/core/src/pipeline/config/stages/stage.module.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/stage.module.js
@@ -200,24 +200,28 @@ module.exports = angular
               defaultsDeep($scope.stage, config.defaults);
             }
             if (config.useBaseProvider || config.provides) {
+              config.component = null;
               config.templateUrl = require('./baseProviderStage/baseProviderStage.html');
               config.controller = 'BaseProviderStageCtrl as baseProviderStageCtrl';
             }
             updateStageName(config, oldVal);
             applyConfigController(config, stageScope);
 
+            const props = {
+              application: $scope.application,
+              stageFieldUpdated: $scope.stageFieldUpdated,
+              updateStageField: changes => {
+                extend($scope.stage, changes);
+                $scope.stageFieldUpdated();
+              },
+              stage: $scope.stage,
+              component: config.component,
+              configuration: config.configuration,
+            };
+            if (config.useBaseProvider || config.provides) {
+              stageScope.reactPropsForBaseProviderStage = props;
+            }
             if (config.component) {
-              const props = {
-                application: $scope.application,
-                stageFieldUpdated: $scope.stageFieldUpdated,
-                updateStageField: changes => {
-                  extend($scope.stage, changes);
-                  $scope.stageFieldUpdated();
-                },
-                stage: $scope.stage,
-                component: config.component,
-                configuration: config.configuration,
-              };
               ReactDOM.render(React.createElement(StageConfigWrapper, props), stageDetailsNode);
             } else {
               const template = $templateCache.get(config.templateUrl);


### PR DESCRIPTION
See https://github.com/spinnaker/spinnaker/issues/3879 for full context on this patch but here's a quick summary:

Since the Titus Run Job stage is written in React its provider config
includes a `component` field. `stage.module.js` responds to a component
field by rendering it straight into the DOM.

When multiple providers are available for a given stage the
`baseProviderStage`, an angular component, is meant to be shown to
the user for them to pick which provider to use.

Unfortunately `stage.module.js`'s rendering of a React component short
circuits the rendering of the `baseProviderStage`. The user never gets presented
with the option to choose a different provider.

Resolving this first problem requires nulling out the `component` field
when baseProviderStage needs to be shown.

The follow-on issue is that baseProviderStage did not previously know
how to render react components like the Titus Run Job stage. This meant
that the user could pick a Run Job stage, then choose the Titus provider,
but they wouldn't see any stage rendered.

So, the solution I've implemented is the fewest LOC change I could make - it
duplicates the rendering logic from `stage.module.js` into
`baseProviderStage` and threads the constructed props object from
`stage.module.js` down into the `baseProviderStage`.

The alternatives proposed were: 1, To try and split up baseProviderStage
and 2, Try to blend the features from `baseProviderStage` into `stage.module.js`.
I tried both of these but didn't get either solution into a working state. And in both
cases I ended up with a huge mess of changed lines on my hands. So I've opted
for the smallest change possible instead and just forced it to work. If there's a better
way I'd love to see someone else contribute it but mostly I just want to see this issue
fixed ASAP in 1.12 and before 1.13 gets cut.

@anotherchrisberry @christopherthielen PTAL if you can.

### Screenshot Before This Change:

The user doesn't get to choose a provider for their Run Job stage; Titus is always shown.

![screen shot 2019-03-06 at 11 03 55 am](https://user-images.githubusercontent.com/34253460/53895236-8f9aad80-3fff-11e9-8563-2fdb633265c7.png)


### Screenshot After This Change:

The user can choose a provider for the Run Job stage:

![screen shot 2019-03-06 at 10 46 04 am](https://user-images.githubusercontent.com/34253460/53895415-05067e00-4000-11e9-8087-a2ac3b4cdc2a.png)

The baseProviderStage is able to render the React Titus Run Job stage:

![screen shot 2019-03-06 at 10 45 56 am](https://user-images.githubusercontent.com/34253460/53895440-0fc11300-4000-11e9-8918-cf3ee060461f.png)