### PR TITLE
fix(core): titus run jobs override all other providers (#6647)

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/baseProviderStage/baseProviderStage.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/baseProviderStage/baseProviderStage.html
@@ -1,8 +1,12 @@
 <div class="form-horizontal" ng-if="!viewState.loading">
   <stage-config-field label="Provider" ng-if="providers.length > 1">
-      <provider-selector providers="providers"
-                         component="stage" field="cloudProviderType"
-                         read-only="!stage.isNew"></provider-selector>
+    <provider-selector
+      providers="providers"
+      component="stage"
+      field="cloudProviderType"
+      read-only="!stage.isNew"
+    ></provider-selector>
   </stage-config-field>
   <div ng-include="providerStageDetailsUrl"></div>
+  <div class="react-stage-details"></div>
 </div>

--- a/app/scripts/modules/core/src/pipeline/config/stages/baseProviderStage/baseProviderStage.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/baseProviderStage/baseProviderStage.js
@@ -2,9 +2,13 @@
 
 const angular = require('angular');
 
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+
 import { AccountService } from 'core/account/AccountService';
 import { Registry } from 'core/registry';
 import { SETTINGS } from 'core/config/settings';
+import { StageConfigWrapper } from 'core/pipeline/config/stages/StageConfigWrapper';
 
 module.exports = angular
   .module('spinnaker.core.pipeline.stage.baseProviderStage', [])
@@ -49,13 +53,25 @@ module.exports = angular
         }
       });
 
+    let reactMounted = false;
     function loadProvider() {
       const stageProvider = (stageProviders || []).find(
         s => s.cloudProvider === stage.cloudProviderType || (s.providesFor || []).includes(stage.cloudProviderType),
       );
       if (stageProvider) {
         $scope.stage.type = stageProvider.key || $scope.stage.type;
-        $scope.providerStageDetailsUrl = stageProvider.templateUrl;
+        const el = document.querySelector('.react-stage-details');
+        if (reactMounted) {
+          ReactDOM.unmountComponentAtNode(el);
+        }
+        if (stageProvider.component) {
+          const props = $scope.reactPropsForBaseProviderStage;
+          props.component = stageProvider.component;
+          ReactDOM.render(React.createElement(StageConfigWrapper, props), el);
+        } else {
+          $scope.providerStageDetailsUrl = stageProvider.templateUrl;
+        }
+        reactMounted = !!stageProvider.component;
       }
     }
 

--- a/app/scripts/modules/core/src/pipeline/config/stages/stage.module.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/stage.module.js
@@ -73,8 +73,8 @@ module.exports = angular
       return stage.available
         ? 'Available'
         : requisiteStageRefIds.includes(stage.refId)
-          ? null
-          : 'Downstream dependencies (unavailable)';
+        ? null
+        : 'Downstream dependencies (unavailable)';
     };
 
     $scope.stageProducesArtifacts = function() {
@@ -184,24 +184,28 @@ module.exports = angular
             defaultsDeep($scope.stage, config.defaults);
           }
           if (config.useBaseProvider || config.provides) {
+            config.component = null;
             config.templateUrl = require('./baseProviderStage/baseProviderStage.html');
             config.controller = 'BaseProviderStageCtrl as baseProviderStageCtrl';
           }
           updateStageName(config, oldVal);
           applyConfigController(config, stageScope);
 
+          const props = {
+            application: $scope.application,
+            stageFieldUpdated: $scope.stageFieldUpdated,
+            updateStageField: changes => {
+              extend($scope.stage, changes);
+              $scope.stageFieldUpdated();
+            },
+            stage: $scope.stage,
+            component: config.component,
+            configuration: config.configuration,
+          };
+          if (config.useBaseProvider || config.provides) {
+            stageScope.reactPropsForBaseProviderStage = props;
+          }
           if (config.component) {
-            const props = {
-              application: $scope.application,
-              stageFieldUpdated: $scope.stageFieldUpdated,
-              updateStageField: changes => {
-                extend($scope.stage, changes);
-                $scope.stageFieldUpdated();
-              },
-              stage: $scope.stage,
-              component: config.component,
-              configuration: config.configuration,
-            };
             ReactDOM.render(React.createElement(StageConfigWrapper, props), stageDetailsNode);
           } else {
             const template = $templateCache.get(config.templateUrl);


### PR DESCRIPTION
Cherry-pick of https://github.com/spinnaker/deck/pull/6647

Since the Titus Run Job stage is written in React its provider config
includes a component field. stage.module.js responds to a component
field by rendering it into the DOM.

When multiple providers are available for a given stage (for example
with the Run Job stage) the baseProviderStage, an angular component, is
meant to be shown to the user for them to pick one.

Unfortunately the rendering of a React component from a provider config
short circuits the rendering of the baseProviderStage.

Resolving this first problem requires nulling out the `component` field
when baseProviderStage needs to be shown.

The follow-on issue is that baseProviderStage did not previously know
how to render react components. This meant that the user could pick a
Run Job stage, then choose the Titus provider, but they wouldn't see any
stage rendered.

The solution I've implemented is the fewest LOC change I could make - it
duplicates the rendering logic from `stage.module.js` into
baseProviderStage and threads the constructed props object from
stage.module.js down into the baseProviderStage.

The alternatives proposed were: 1. To try and split up baseProviderStage
or 2. Try to merge baseProviderStage into stage.module.js. I tried both
of these but didn't get either solution into a working state and ended
up with a huge mess of changed lines on my hands.