### PR TITLE
fix(core/pipeline): make cancelmodal take markdown for body

### DIFF
--- a/app/scripts/modules/core/src/cancelModal/CancelModal.tsx
+++ b/app/scripts/modules/core/src/cancelModal/CancelModal.tsx
@@ -4,7 +4,7 @@ import { Field, FieldProps, Form, Formik } from 'formik';
 import { IPromise } from 'angular';
 
 import { SubmitButton, ModalClose } from 'core/modal';
-import { ReactModal } from 'core/presentation';
+import { ReactModal, Markdown } from 'core/presentation';
 
 export interface ICancelModalProps {
   body?: string;
@@ -72,7 +72,7 @@ export class CancelModal extends React.Component<ICancelModalProps, ICancelModal
         initialValues={{}}
         onSubmit={this.submitConfirmation}
         render={() => {
-          const wrappedBody = body ? <div>{body}</div> : null;
+          const wrappedBody = body ? <Markdown message={body} /> : null;
 
           return (
             <Form className="form-horizontal">

--- a/app/scripts/modules/core/src/pipeline/executions/execution/Execution.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/execution/Execution.tsx
@@ -157,7 +157,7 @@ export class Execution extends React.Component<IExecutionProps, IExecutionState>
       buttonText: `Stop running ${execution.name}`,
       body:
         hasDeployStage && !cancelConfirmationText
-          ? '<b>Note:</b> Any deployments that have begun will continue and need to be cleaned up manually.'
+          ? '*Note:* Any deployments that have begun will continue and need to be cleaned up manually.'
           : cancelConfirmationText,
       submitMethod: (reason, force) => executionService.cancelExecution(application, execution.id, force, reason),
     });


### PR DESCRIPTION
Markdown makes it safer and easier to format body in the modal (which currently html escapes)
Fixes this:

![image](https://user-images.githubusercontent.com/9469228/54066741-6427e680-41ea-11e9-9869-a9e897444c91.png)
