### PR TITLE
feat(artifacts): Re-use artifacts when re-running a pipeline

### DIFF
--- a/app/scripts/modules/core/src/pipeline/manualExecution/manualPipelineExecution.controller.js
+++ b/app/scripts/modules/core/src/pipeline/manualExecution/manualPipelineExecution.controller.js
@@ -13,12 +13,14 @@ import { PipelineTemplateV2Service } from 'core/pipeline';
 
 import { STAGE_MANUAL_COMPONENTS } from './stageManualComponents.component';
 import { TRIGGER_TEMPLATE } from './triggerTemplate.component';
+import { ARTIFACT_LIST } from '../status/artifactList.component';
 
 import './manualPipelineExecution.less';
 
 module.exports = angular
   .module('spinnaker.core.pipeline.manualPipelineExecution.controller', [
     require('angular-ui-bootstrap'),
+    ARTIFACT_LIST,
     TRIGGER_TEMPLATE,
     STAGE_MANUAL_COMPONENTS,
   ])
@@ -107,15 +109,20 @@ module.exports = angular
           trigger.type = this.triggers[0].type;
         }
 
-        const suppliedTriggerCanBeInvoked =
+        const suppliedTriggerHasManualComponent =
           trigger && Registry.pipeline.hasManualExecutionComponentForTriggerType(trigger.type);
-        if (suppliedTriggerCanBeInvoked) {
+        if (suppliedTriggerHasManualComponent) {
           Registry.pipeline
             .getManualExecutionComponentForTriggerType(trigger.type)
             .formatLabel(trigger)
             .then(label => (trigger.description = label));
+          // If the trigger has a manual component, we don't want to also explicitly
+          // send along the artifacts from the last run, as the manual component will
+          // populate enough information (ex: build number, docker tag) to re-inflate
+          // these on a subsequent run.
+          trigger.artifacts = [];
         }
-        this.command.trigger = suppliedTriggerCanBeInvoked ? trigger : _.head(this.triggers);
+        this.command.trigger = trigger || _.head(this.triggers);
       };
 
       const updatePipelinePlan = pipeline => {

--- a/app/scripts/modules/core/src/pipeline/manualExecution/manualPipelineExecution.html
+++ b/app/scripts/modules/core/src/pipeline/manualExecution/manualPipelineExecution.html
@@ -157,6 +157,13 @@
         components="vm.stageComponents"
       ></stage-manual-components>
 
+      <div class="form-group" ng-if="vm.command.trigger.artifacts.length > 0">
+        <label class="col-md-4 sm-label-right">Artifacts</label>
+        <div class="col-md-8">
+          <artifact-list artifacts="vm.command.trigger.artifacts" />
+        </div>
+      </div>
+
       <div class="form-group">
         <label class="col-md-4 sm-label-right">Notifications</label>
         <div class="col-md-8">

--- a/app/scripts/modules/core/src/pipeline/pipeline.module.ts
+++ b/app/scripts/modules/core/src/pipeline/pipeline.module.ts
@@ -39,6 +39,7 @@ import { STAGE_FAILURE_MESSAGE_COMPONENT } from './details/stageFailureMessage.c
 import { STEP_EXECUTION_DETAILS_COMPONENT } from './details/stepExecutionDetails.component';
 import { STAGE_SUMMARY_COMPONENT } from './details/stageSummary.component';
 import { PRODUCES_ARTIFACTS } from './config/stages/producesArtifacts/producesArtifacts.component';
+import { ARTIFACT_LIST } from './status/artifactList.component';
 
 import './pipeline.less';
 import 'angular-ui-sortable';
@@ -58,6 +59,7 @@ module(PIPELINE_MODULE, [
   STAGE_SUMMARY_COMPONENT,
 
   require('./pipeline.dataSource').name,
+  ARTIFACT_LIST,
   PIPELINE_STATES,
   require('./config/pipelineConfig.module').name,
   COPY_STAGE_MODAL_CONTROLLER,

--- a/app/scripts/modules/core/src/pipeline/status/Artifact.spec.tsx
+++ b/app/scripts/modules/core/src/pipeline/status/Artifact.spec.tsx
@@ -2,15 +2,17 @@ import * as React from 'react';
 import { ShallowWrapper, shallow } from 'enzyme';
 import { mock } from 'angular';
 import { REACT_MODULE } from 'core/reactShims';
+
 import { IArtifact } from 'core/domain';
-import { Artifact, IArtifactProps, IArtifactState } from './Artifact';
+
+import { Artifact, IArtifactProps } from './Artifact';
 
 const ARTIFACT_TYPE = 'docker/image';
 const ARTIFACT_NAME = 'example.com/container';
 const ARTIFACT_REFERENCE = 'docker.io/example.com/container:latest';
 
 describe('<Artifact/>', () => {
-  let component: ShallowWrapper<IArtifactProps, IArtifactState>;
+  let component: ShallowWrapper<IArtifactProps>;
 
   beforeEach(mock.module(REACT_MODULE));
   beforeEach(mock.inject(() => {})); // Angular is lazy.

--- a/app/scripts/modules/core/src/pipeline/status/Artifact.spec.tsx
+++ b/app/scripts/modules/core/src/pipeline/status/Artifact.spec.tsx
@@ -1,0 +1,78 @@
+import * as React from 'react';
+import { ShallowWrapper, shallow } from 'enzyme';
+import { mock } from 'angular';
+import { REACT_MODULE } from 'core/reactShims';
+import { IArtifact } from 'core/domain';
+import { Artifact, IArtifactProps, IArtifactState } from './Artifact';
+
+const ARTIFACT_TYPE = 'docker/image';
+const ARTIFACT_NAME = 'example.com/container';
+const ARTIFACT_REFERENCE = 'docker.io/example.com/container:latest';
+
+describe('<Artifact/>', () => {
+  let component: ShallowWrapper<IArtifactProps, IArtifactState>;
+
+  beforeEach(mock.module(REACT_MODULE));
+  beforeEach(mock.inject(() => {})); // Angular is lazy.
+
+  it("renders an artifact's name", function() {
+    const artifact: IArtifact = {
+      id: 'abcd',
+      type: ARTIFACT_TYPE,
+      name: ARTIFACT_NAME,
+    };
+    component = shallow(<Artifact artifact={artifact} />);
+    const dl = component.find('dl');
+    const dt = dl.find('dt');
+    const dd = dl.find('dd');
+    expect(dl.length).toEqual(1);
+    expect(dt.length).toEqual(1);
+    expect(dd.length).toEqual(1);
+    expect(dd.at(0).text()).toEqual(ARTIFACT_NAME);
+  });
+
+  it('renders an artifact version if present', function() {
+    const version = 'v001';
+    const artifact: IArtifact = {
+      id: 'abcd',
+      type: ARTIFACT_TYPE,
+      name: ARTIFACT_NAME,
+      version,
+    };
+    component = shallow(<Artifact artifact={artifact} />);
+    const dl = component.find('dl');
+    const dt = dl.find('dt');
+    const dd = dl.find('dd');
+    expect(dl.length).toEqual(1);
+    expect(dt.length).toEqual(2);
+    expect(dd.length).toEqual(2);
+    expect(dd.at(1).text()).toEqual(version);
+  });
+
+  it('includes the artifact reference in the tootip', function() {
+    const artifact: IArtifact = {
+      id: 'abcd',
+      type: ARTIFACT_TYPE,
+      name: ARTIFACT_NAME,
+      reference: ARTIFACT_REFERENCE,
+    };
+    component = shallow(<Artifact artifact={artifact} />);
+    const dl = component.find('dl');
+    expect(dl.length).toEqual(1);
+    const title = dl.at(0).prop('title');
+    expect(title).toMatch('Reference: ' + ARTIFACT_REFERENCE);
+  });
+
+  it('does not include a reference in the tooltip if none is specified', function() {
+    const artifact: IArtifact = {
+      id: 'abcd',
+      type: ARTIFACT_TYPE,
+      name: ARTIFACT_NAME,
+    };
+    component = shallow(<Artifact artifact={artifact} />);
+    const dl = component.find('dl');
+    expect(dl.length).toEqual(1);
+    const title = dl.at(0).prop('title');
+    expect(title).not.toMatch('Reference: ');
+  });
+});

--- a/app/scripts/modules/core/src/pipeline/status/Artifact.tsx
+++ b/app/scripts/modules/core/src/pipeline/status/Artifact.tsx
@@ -11,13 +11,7 @@ export interface IArtifactProps {
   sequence?: number;
 }
 
-export interface IArtifactState {}
-
-export class Artifact extends React.Component<IArtifactProps, IArtifactState> {
-  constructor(props: IArtifactProps) {
-    super(props);
-  }
-
+export class Artifact extends React.Component<IArtifactProps> {
   private tooltip(artifact: IArtifact, isDefault: boolean): string {
     const tooltipEntries = [];
     if (isDefault) {

--- a/app/scripts/modules/core/src/pipeline/status/Artifact.tsx
+++ b/app/scripts/modules/core/src/pipeline/status/Artifact.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react';
+
+import { IArtifact } from 'core/domain';
+import { ArtifactIconService } from 'core/artifact';
+
+import './artifact.less';
+
+export interface IArtifactProps {
+  artifact: IArtifact;
+  isDefault?: boolean;
+  sequence?: number;
+}
+
+export interface IArtifactState {}
+
+export class Artifact extends React.Component<IArtifactProps, IArtifactState> {
+  constructor(props: IArtifactProps) {
+    super(props);
+  }
+
+  private tooltip(artifact: IArtifact, isDefault: boolean): string {
+    const tooltipEntries = [];
+    if (isDefault) {
+      tooltipEntries.push('Default Artifact');
+    }
+    if (artifact.name) {
+      tooltipEntries.push(`Name: ${artifact.name}`);
+    }
+    if (artifact.type) {
+      tooltipEntries.push(`Type: ${artifact.type}`);
+    }
+    if (artifact.version) {
+      tooltipEntries.push(`Version: ${artifact.version}`);
+    }
+    if (artifact.reference) {
+      tooltipEntries.push(`Reference: ${artifact.reference}`);
+    }
+    return tooltipEntries.join('\n');
+  }
+
+  public render() {
+    const { artifact, isDefault } = this.props;
+    const { name, version, type } = artifact;
+
+    return (
+      <div className="artifact-details">
+        <dl title={this.tooltip(artifact, isDefault)}>
+          <div>
+            <dt>
+              {ArtifactIconService.getPath(type) ? (
+                <img className="artifact-icon" src={ArtifactIconService.getPath(type)} width="18" height="18" />
+              ) : (
+                <span>{type}</span>
+              )}
+            </dt>
+            <dd>{name}</dd>
+          </div>
+          {version && (
+            <div>
+              <dt>Version</dt>
+              <dd>{version}</dd>
+            </div>
+          )}
+        </dl>
+      </div>
+    );
+  }
+}

--- a/app/scripts/modules/core/src/pipeline/status/ArtifactList.spec.tsx
+++ b/app/scripts/modules/core/src/pipeline/status/ArtifactList.spec.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import { ShallowWrapper, shallow } from 'enzyme';
+import { mock } from 'angular';
+import { REACT_MODULE } from 'core/reactShims';
+import { IArtifact } from 'core/domain';
+import { Artifact } from './Artifact';
+import { ArtifactList, IArtifactListProps, IArtifactListState } from './ArtifactList';
+
+const ARTIFACT_TYPE = 'docker/image';
+const ARTIFACT_NAME = 'example.com/container';
+
+describe('<ArtifactList/>', () => {
+  let component: ShallowWrapper<IArtifactListProps, IArtifactListState>;
+
+  beforeEach(mock.module(REACT_MODULE));
+  beforeEach(mock.inject(() => {})); // Angular is lazy.
+
+  it('renders null when null artifacts are passed in', function() {
+    const artifacts: IArtifact[] = null;
+    component = shallow(<ArtifactList artifacts={artifacts} />);
+    expect(component.get(0)).toEqual(null);
+  });
+
+  it('renders null when 0 artifacts are passed in', function() {
+    const artifacts: IArtifact[] = [];
+    component = shallow(<ArtifactList artifacts={artifacts} />);
+    expect(component.get(0)).toEqual(null);
+  });
+
+  it('renders a list when artifacts are passed in', function() {
+    const artifacts: IArtifact[] = [
+      {
+        id: 'abcd',
+        type: ARTIFACT_TYPE,
+        name: ARTIFACT_NAME,
+      },
+      {
+        id: 'defg',
+        type: ARTIFACT_TYPE,
+        name: ARTIFACT_NAME,
+      },
+    ];
+    component = shallow(<ArtifactList artifacts={artifacts} />);
+    expect(component.find(Artifact).length).toEqual(2);
+  });
+});

--- a/app/scripts/modules/core/src/pipeline/status/ArtifactList.spec.tsx
+++ b/app/scripts/modules/core/src/pipeline/status/ArtifactList.spec.tsx
@@ -2,15 +2,17 @@ import * as React from 'react';
 import { ShallowWrapper, shallow } from 'enzyme';
 import { mock } from 'angular';
 import { REACT_MODULE } from 'core/reactShims';
+
 import { IArtifact } from 'core/domain';
+
 import { Artifact } from './Artifact';
-import { ArtifactList, IArtifactListProps, IArtifactListState } from './ArtifactList';
+import { ArtifactList, IArtifactListProps } from './ArtifactList';
 
 const ARTIFACT_TYPE = 'docker/image';
 const ARTIFACT_NAME = 'example.com/container';
 
 describe('<ArtifactList/>', () => {
-  let component: ShallowWrapper<IArtifactListProps, IArtifactListState>;
+  let component: ShallowWrapper<IArtifactListProps>;
 
   beforeEach(mock.module(REACT_MODULE));
   beforeEach(mock.inject(() => {})); // Angular is lazy.

--- a/app/scripts/modules/core/src/pipeline/status/ArtifactList.tsx
+++ b/app/scripts/modules/core/src/pipeline/status/ArtifactList.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+
+import { IArtifact } from 'core/domain';
+
+import './artifactList.less';
+import { Artifact } from 'core/pipeline/status/Artifact';
+
+export interface IArtifactListProps {
+  artifacts: IArtifact[];
+}
+
+export interface IArtifactListState {}
+
+export class ArtifactList extends React.Component<IArtifactListProps, IArtifactListState> {
+  constructor(props: IArtifactListProps) {
+    super(props);
+  }
+
+  public render() {
+    let { artifacts } = this.props;
+
+    artifacts = artifacts || [];
+    if (artifacts.length === 0) {
+      return null;
+    }
+
+    return (
+      <div className="artifact-list">
+        <ul>
+          {artifacts.map((artifact: IArtifact, i: number) => {
+            return (
+              <li key={`${i}-${name}`} className="break-word">
+                <Artifact artifact={artifact} />
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    );
+  }
+}

--- a/app/scripts/modules/core/src/pipeline/status/ArtifactList.tsx
+++ b/app/scripts/modules/core/src/pipeline/status/ArtifactList.tsx
@@ -1,21 +1,15 @@
 import * as React from 'react';
 
 import { IArtifact } from 'core/domain';
+import { Artifact } from 'core/pipeline/status/Artifact';
 
 import './artifactList.less';
-import { Artifact } from 'core/pipeline/status/Artifact';
 
 export interface IArtifactListProps {
   artifacts: IArtifact[];
 }
 
-export interface IArtifactListState {}
-
-export class ArtifactList extends React.Component<IArtifactListProps, IArtifactListState> {
-  constructor(props: IArtifactListProps) {
-    super(props);
-  }
-
+export class ArtifactList extends React.Component<IArtifactListProps> {
   public render() {
     let { artifacts } = this.props;
 

--- a/app/scripts/modules/core/src/pipeline/status/ExecutionStatus.tsx
+++ b/app/scripts/modules/core/src/pipeline/status/ExecutionStatus.tsx
@@ -15,7 +15,7 @@ import { SETTINGS } from 'core/config/settings';
 import { buildDisplayName } from '../executionBuild/buildDisplayName.filter';
 import { ExecutionBuildLink } from '../executionBuild/ExecutionBuildLink';
 import { ExecutionUserStatus } from './ExecutionUserStatus';
-import { ArtifactList } from './ArtifactList';
+import { ResolvedArtifactList } from './ResolvedArtifactList';
 
 import './executionStatus.less';
 
@@ -136,7 +136,7 @@ export class ExecutionStatus extends React.Component<IExecutionStatusProps, IExe
           ))}
         </ul>
         {SETTINGS.feature.artifacts && (
-          <ArtifactList artifacts={artifacts} resolvedExpectedArtifacts={resolvedExpectedArtifacts} />
+          <ResolvedArtifactList artifacts={artifacts} resolvedExpectedArtifacts={resolvedExpectedArtifacts} />
         )}
         {!standalone && (
           <a className="clickable" onClick={this.toggleDetails}>

--- a/app/scripts/modules/core/src/pipeline/status/ResolvedArtifactList.spec.tsx
+++ b/app/scripts/modules/core/src/pipeline/status/ResolvedArtifactList.spec.tsx
@@ -4,6 +4,7 @@ import { mock } from 'angular';
 import { REACT_MODULE } from 'core/reactShims';
 import { IArtifact, IExpectedArtifact } from 'core/domain';
 import { ResolvedArtifactList, IResolvedArtifactListProps, IResolvedArtifactListState } from './ResolvedArtifactList';
+import { Artifact } from 'core/pipeline/status/Artifact';
 
 const ARTIFACT_TYPE = 'docker/image';
 const ARTIFACT_NAME = 'example.com/container';
@@ -41,31 +42,10 @@ describe('<ResolvedArtifactList/>', () => {
     component = shallow(
       <ResolvedArtifactList artifacts={artifacts} resolvedExpectedArtifacts={resolvedExpectedArtifacts} />,
     );
-    expect(component.find('ul.trigger-details.artifacts').length).toEqual(1);
+    expect(component.find(Artifact).length).toEqual(1);
   });
 
-  it("renders an artifact's name", function() {
-    const artifacts: IArtifact[] = [
-      {
-        id: 'abcd',
-        type: ARTIFACT_TYPE,
-        name: ARTIFACT_NAME,
-      },
-    ];
-    const resolvedExpectedArtifacts = artifacts.map(a => ({ boundArtifact: a } as IExpectedArtifact));
-    component = shallow(
-      <ResolvedArtifactList artifacts={artifacts} resolvedExpectedArtifacts={resolvedExpectedArtifacts} />,
-    );
-    const li = component.find('li');
-    const dt = li.find('dt');
-    const dd = li.find('dd');
-    expect(li.length).toEqual(1);
-    expect(dt.length).toEqual(1);
-    expect(dd.length).toEqual(1);
-    expect(dd.at(0).text()).toEqual(ARTIFACT_NAME);
-  });
-
-  it('does not render artifacts without a type and name', function() {
+  it('does not render an artifact without a type and name', function() {
     const singleArtifact: IArtifact[] = [
       {
         id: 'abcd',
@@ -76,7 +56,9 @@ describe('<ResolvedArtifactList/>', () => {
       <ResolvedArtifactList artifacts={singleArtifact} resolvedExpectedArtifacts={resolvedExpectedArtifacts} />,
     );
     expect(component.get(0)).toEqual(null);
+  });
 
+  it('renders an artifacts that does have a type and name', function() {
     const artifacts: IArtifact[] = [
       {
         id: 'abcd',
@@ -87,32 +69,11 @@ describe('<ResolvedArtifactList/>', () => {
         name: ARTIFACT_NAME,
       },
     ];
-    component = shallow(<ResolvedArtifactList artifacts={artifacts} />);
-    expect(component.find('ul.trigger-details.artifacts').length).toEqual(1);
-  });
-
-  it('renders an artifact version if present', function() {
-    const version = 'v001';
-    const artifacts: IArtifact[] = [
-      {
-        id: 'abcd',
-        type: ARTIFACT_TYPE,
-        name: ARTIFACT_NAME,
-        version,
-      },
-    ];
     const resolvedExpectedArtifacts = artifacts.map(a => ({ boundArtifact: a } as IExpectedArtifact));
     component = shallow(
       <ResolvedArtifactList artifacts={artifacts} resolvedExpectedArtifacts={resolvedExpectedArtifacts} />,
     );
-    const li = component.find('li');
-    expect(li.find('dd').length).toEqual(2);
-    expect(
-      li
-        .find('dd')
-        .at(1)
-        .text(),
-    ).toEqual(version);
+    expect(component.find(Artifact).length).toEqual(1);
   });
 
   it('does not render artifacts for which there is no expected artifact in the pipeline', function() {

--- a/app/scripts/modules/core/src/pipeline/status/ResolvedArtifactList.spec.tsx
+++ b/app/scripts/modules/core/src/pipeline/status/ResolvedArtifactList.spec.tsx
@@ -3,27 +3,29 @@ import { ShallowWrapper, shallow } from 'enzyme';
 import { mock } from 'angular';
 import { REACT_MODULE } from 'core/reactShims';
 import { IArtifact, IExpectedArtifact } from 'core/domain';
-import { ArtifactList, IArtifactListProps, IArtifactListState } from './ArtifactList';
+import { ResolvedArtifactList, IResolvedArtifactListProps, IResolvedArtifactListState } from './ResolvedArtifactList';
 
 const ARTIFACT_TYPE = 'docker/image';
 const ARTIFACT_NAME = 'example.com/container';
 
-describe('<ArtifactList/>', () => {
-  let component: ShallowWrapper<IArtifactListProps, IArtifactListState>;
+describe('<ResolvedArtifactList/>', () => {
+  let component: ShallowWrapper<IResolvedArtifactListProps, IResolvedArtifactListState>;
 
   beforeEach(mock.module(REACT_MODULE));
   beforeEach(mock.inject(() => {})); // Angular is lazy.
 
   it('renders null when null artifacts are passed in', function() {
     const artifacts: IArtifact[] = null;
-    component = shallow(<ArtifactList artifacts={artifacts} />);
+    component = shallow(<ResolvedArtifactList artifacts={artifacts} />);
     expect(component.get(0)).toEqual(null);
   });
 
   it('renders null when 0 artifacts are passed in', function() {
     const artifacts: IArtifact[] = [];
     const resolvedExpectedArtifacts = artifacts.map(a => ({ boundArtifact: a } as IExpectedArtifact));
-    component = shallow(<ArtifactList artifacts={artifacts} resolvedExpectedArtifacts={resolvedExpectedArtifacts} />);
+    component = shallow(
+      <ResolvedArtifactList artifacts={artifacts} resolvedExpectedArtifacts={resolvedExpectedArtifacts} />,
+    );
     expect(component.get(0)).toEqual(null);
   });
 
@@ -36,7 +38,9 @@ describe('<ArtifactList/>', () => {
       },
     ];
     const resolvedExpectedArtifacts = artifacts.map(a => ({ boundArtifact: a } as IExpectedArtifact));
-    component = shallow(<ArtifactList artifacts={artifacts} resolvedExpectedArtifacts={resolvedExpectedArtifacts} />);
+    component = shallow(
+      <ResolvedArtifactList artifacts={artifacts} resolvedExpectedArtifacts={resolvedExpectedArtifacts} />,
+    );
     expect(component.find('ul.trigger-details.artifacts').length).toEqual(1);
   });
 
@@ -49,7 +53,9 @@ describe('<ArtifactList/>', () => {
       },
     ];
     const resolvedExpectedArtifacts = artifacts.map(a => ({ boundArtifact: a } as IExpectedArtifact));
-    component = shallow(<ArtifactList artifacts={artifacts} resolvedExpectedArtifacts={resolvedExpectedArtifacts} />);
+    component = shallow(
+      <ResolvedArtifactList artifacts={artifacts} resolvedExpectedArtifacts={resolvedExpectedArtifacts} />,
+    );
     const li = component.find('li');
     const dt = li.find('dt');
     const dd = li.find('dd');
@@ -67,7 +73,7 @@ describe('<ArtifactList/>', () => {
     ];
     const resolvedExpectedArtifacts = singleArtifact.map(a => ({ boundArtifact: a } as IExpectedArtifact));
     component = shallow(
-      <ArtifactList artifacts={singleArtifact} resolvedExpectedArtifacts={resolvedExpectedArtifacts} />,
+      <ResolvedArtifactList artifacts={singleArtifact} resolvedExpectedArtifacts={resolvedExpectedArtifacts} />,
     );
     expect(component.get(0)).toEqual(null);
 
@@ -81,7 +87,7 @@ describe('<ArtifactList/>', () => {
         name: ARTIFACT_NAME,
       },
     ];
-    component = shallow(<ArtifactList artifacts={artifacts} />);
+    component = shallow(<ResolvedArtifactList artifacts={artifacts} />);
     expect(component.find('ul.trigger-details.artifacts').length).toEqual(1);
   });
 
@@ -96,7 +102,9 @@ describe('<ArtifactList/>', () => {
       },
     ];
     const resolvedExpectedArtifacts = artifacts.map(a => ({ boundArtifact: a } as IExpectedArtifact));
-    component = shallow(<ArtifactList artifacts={artifacts} resolvedExpectedArtifacts={resolvedExpectedArtifacts} />);
+    component = shallow(
+      <ResolvedArtifactList artifacts={artifacts} resolvedExpectedArtifacts={resolvedExpectedArtifacts} />,
+    );
     const li = component.find('li');
     expect(li.find('dd').length).toEqual(2);
     expect(
@@ -115,7 +123,7 @@ describe('<ArtifactList/>', () => {
         name: ARTIFACT_NAME,
       },
     ];
-    component = shallow(<ArtifactList artifacts={artifacts} />);
+    component = shallow(<ResolvedArtifactList artifacts={artifacts} />);
     const li = component.find('li');
     expect(li.text()).toMatch(/1.*artifact.*not.*consumed/);
   });

--- a/app/scripts/modules/core/src/pipeline/status/ResolvedArtifactList.spec.tsx
+++ b/app/scripts/modules/core/src/pipeline/status/ResolvedArtifactList.spec.tsx
@@ -2,15 +2,17 @@ import * as React from 'react';
 import { ShallowWrapper, shallow } from 'enzyme';
 import { mock } from 'angular';
 import { REACT_MODULE } from 'core/reactShims';
+
 import { IArtifact, IExpectedArtifact } from 'core/domain';
-import { ResolvedArtifactList, IResolvedArtifactListProps, IResolvedArtifactListState } from './ResolvedArtifactList';
 import { Artifact } from 'core/pipeline/status/Artifact';
+
+import { ResolvedArtifactList, IResolvedArtifactListProps } from './ResolvedArtifactList';
 
 const ARTIFACT_TYPE = 'docker/image';
 const ARTIFACT_NAME = 'example.com/container';
 
 describe('<ResolvedArtifactList/>', () => {
-  let component: ShallowWrapper<IResolvedArtifactListProps, IResolvedArtifactListState>;
+  let component: ShallowWrapper<IResolvedArtifactListProps>;
 
   beforeEach(mock.module(REACT_MODULE));
   beforeEach(mock.inject(() => {})); // Angular is lazy.

--- a/app/scripts/modules/core/src/pipeline/status/ResolvedArtifactList.tsx
+++ b/app/scripts/modules/core/src/pipeline/status/ResolvedArtifactList.tsx
@@ -5,15 +5,15 @@ import { ArtifactIconService } from 'core/artifact';
 
 import './artifactList.less';
 
-export interface IArtifactListProps {
+export interface IResolvedArtifactListProps {
   artifacts: IArtifact[];
   resolvedExpectedArtifacts?: IExpectedArtifact[];
 }
 
-export interface IArtifactListState {}
+export interface IResolvedArtifactListState {}
 
-export class ArtifactList extends React.Component<IArtifactListProps, IArtifactListState> {
-  constructor(props: IArtifactListProps) {
+export class ResolvedArtifactList extends React.Component<IResolvedArtifactListProps, IResolvedArtifactListState> {
+  constructor(props: IResolvedArtifactListProps) {
     super(props);
   }
 

--- a/app/scripts/modules/core/src/pipeline/status/ResolvedArtifactList.tsx
+++ b/app/scripts/modules/core/src/pipeline/status/ResolvedArtifactList.tsx
@@ -1,22 +1,16 @@
 import * as React from 'react';
 
 import { IArtifact, IExpectedArtifact } from 'core/domain';
+import { Artifact } from 'core/pipeline/status/Artifact';
 
 import './artifactList.less';
-import { Artifact } from 'core/pipeline/status/Artifact';
 
 export interface IResolvedArtifactListProps {
   artifacts: IArtifact[];
   resolvedExpectedArtifacts?: IExpectedArtifact[];
 }
 
-export interface IResolvedArtifactListState {}
-
-export class ResolvedArtifactList extends React.Component<IResolvedArtifactListProps, IResolvedArtifactListState> {
-  constructor(props: IResolvedArtifactListProps) {
-    super(props);
-  }
-
+export class ResolvedArtifactList extends React.Component<IResolvedArtifactListProps> {
   public render() {
     let { artifacts, resolvedExpectedArtifacts } = this.props;
 

--- a/app/scripts/modules/core/src/pipeline/status/ResolvedArtifactList.tsx
+++ b/app/scripts/modules/core/src/pipeline/status/ResolvedArtifactList.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 
 import { IArtifact, IExpectedArtifact } from 'core/domain';
-import { ArtifactIconService } from 'core/artifact';
 
 import './artifactList.less';
+import { Artifact } from 'core/pipeline/status/Artifact';
 
 export interface IResolvedArtifactListProps {
   artifacts: IArtifact[];
@@ -15,26 +15,6 @@ export interface IResolvedArtifactListState {}
 export class ResolvedArtifactList extends React.Component<IResolvedArtifactListProps, IResolvedArtifactListState> {
   constructor(props: IResolvedArtifactListProps) {
     super(props);
-  }
-
-  private tooltip(artifact: IArtifact, isDefault: boolean): string {
-    const tooltipEntries = [];
-    if (isDefault) {
-      tooltipEntries.push('Default Artifact');
-    }
-    if (artifact.name) {
-      tooltipEntries.push(`Name: ${artifact.name}`);
-    }
-    if (artifact.type) {
-      tooltipEntries.push(`Type: ${artifact.type}`);
-    }
-    if (artifact.version) {
-      tooltipEntries.push(`Version: ${artifact.version}`);
-    }
-    if (artifact.reference) {
-      tooltipEntries.push(`Reference: ${artifact.reference}`);
-    }
-    return tooltipEntries.join('\n');
   }
 
   public render() {
@@ -60,39 +40,24 @@ export class ResolvedArtifactList extends React.Component<IResolvedArtifactListP
     }
 
     return (
-      <ul className="trigger-details artifacts">
-        {decoratedExpectedArtifacts.map((artifact: IArtifact, i: number) => {
-          const { name, version, type, reference } = artifact;
-          const isDefault = defaultArtifactRefs.has(reference);
-          return (
-            <li key={`${i}-${name}`} className="break-word" title={this.tooltip(artifact, isDefault)}>
-              <dl>
-                <div>
-                  <dt>
-                    {ArtifactIconService.getPath(type) ? (
-                      <img className="artifact-icon" src={ArtifactIconService.getPath(type)} width="18" height="18" />
-                    ) : (
-                      <span>{type}</span>
-                    )}
-                  </dt>
-                  <dd>{name}</dd>
-                </div>
-                {version && (
-                  <div>
-                    <dt>Version</dt>
-                    <dd>{version}</dd>
-                  </div>
-                )}
-              </dl>
+      <div className="artifact-list">
+        <ul>
+          {decoratedExpectedArtifacts.map((artifact: IArtifact, i: number) => {
+            const { reference } = artifact;
+            const isDefault = defaultArtifactRefs.has(reference);
+            return (
+              <li key={`${i}-${name}`} className="break-word">
+                <Artifact artifact={artifact} isDefault={isDefault} />
+              </li>
+            );
+          })}
+          {decoratedArtifacts.length > decoratedExpectedArtifacts.length && (
+            <li key="extraneous-artifacts">
+              {decoratedArtifacts.length - decoratedExpectedArtifacts.length} received artifacts were not consumed
             </li>
-          );
-        })}
-        {decoratedArtifacts.length > decoratedExpectedArtifacts.length && (
-          <li key="extraneous-artifacts">
-            {decoratedArtifacts.length - decoratedExpectedArtifacts.length} received artifacts were not consumed
-          </li>
-        )}
-      </ul>
+          )}
+        </ul>
+      </div>
     );
   }
 }

--- a/app/scripts/modules/core/src/pipeline/status/artifact.less
+++ b/app/scripts/modules/core/src/pipeline/status/artifact.less
@@ -1,0 +1,28 @@
+.artifact-details {
+  div {
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    font-size: inherit;
+    height: 18px;
+    line-height: 18px;
+  }
+
+  dl {
+    margin: 0;
+  }
+
+  dd,
+  dt {
+    display: inline;
+  }
+
+  dt {
+    font-weight: normal;
+    padding: 0 4px 0 0;
+  }
+
+  .artifact-icon {
+    padding-right: 4px;
+  }
+}

--- a/app/scripts/modules/core/src/pipeline/status/artifactList.component.ts
+++ b/app/scripts/modules/core/src/pipeline/status/artifactList.component.ts
@@ -1,0 +1,7 @@
+import { module } from 'angular';
+import { react2angular } from 'react2angular';
+
+import { ArtifactList } from './ArtifactList';
+
+export const ARTIFACT_LIST = 'spinnaker.core.pipeline.status.artifactList';
+module(ARTIFACT_LIST, []).component('artifactList', react2angular(ArtifactList, ['artifacts']));

--- a/app/scripts/modules/core/src/pipeline/status/artifactList.less
+++ b/app/scripts/modules/core/src/pipeline/status/artifactList.less
@@ -1,34 +1,10 @@
-.execution-status-section {
-  ul.trigger-details.artifacts {
-    li {
-      margin-bottom: 4px;
-    }
+.artifact-list {
+  ul {
+    padding: 0;
+  }
 
-    div {
-      white-space: nowrap;
-      text-overflow: ellipsis;
-      overflow: hidden;
-      font-size: inherit;
-      height: 18px;
-      line-height: 18px;
-    }
-
-    dl {
-      margin: 0;
-    }
-
-    dd,
-    dt {
-      display: inline;
-    }
-
-    dt {
-      font-weight: normal;
-      padding: 0 4px 0 0;
-    }
-
-    .artifact-icon {
-      padding-right: 4px;
-    }
+  li {
+    list-style: none;
+    margin-bottom: 4px;
   }
 }


### PR DESCRIPTION
Closes spinnaker/spinnaker#3748

* refactor(artifacts): Rename `ArtifactList` to `ResolvedArtifactList`
 This component is specific to a list of resolved artifacts, and requires the pipeline's expected artifacts as input. Rename it to free up ArtifactList for a more generic list of artifacts.

* refactor(artifacts): Create a react component for an artifact list
    
  The logic for rendering a single artifact is currently embedded in `ResolveArtifactList`; pull this into its own component so it can be reused and create a new `ArtifactList` component that generically displays a list of artifacts, without expected artifact logic.

* feat(artifacts): Re-use artifacts when re-running a pipeline
    
  The manual execution widget does not currently support injecting artifacts into a pipeline. This means that pipelines that depend on artifacts cannot be manually started; support this workflow for the re-run pipeline case by re-sending the same artifacts as the initial run. These will show up as a read-only list of artifacts in the Confirm Execution dialog.