### PR TITLE
feat(jenkins): Add artifact status tab to Jenkins execution details

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/jenkins/jenkinsExecutionDetails.controller.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/jenkins/jenkinsExecutionDetails.controller.js
@@ -9,7 +9,7 @@ module.exports = angular
     '$stateParams',
     'executionDetailsSectionService',
     function($scope, $stateParams, executionDetailsSectionService) {
-      $scope.configSections = ['jenkinsConfig', 'taskStatus'];
+      $scope.configSections = ['jenkinsConfig', 'taskStatus', 'artifactStatus'];
 
       let initialized = () => {
         $scope.detailsSection = $stateParams.details;

--- a/app/scripts/modules/core/src/pipeline/config/stages/jenkins/jenkinsExecutionDetails.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/jenkins/jenkinsExecutionDetails.html
@@ -76,4 +76,7 @@
       <execution-step-details item="stage"></execution-step-details>
     </div>
   </div>
+  <div class="step-section-details" ng-if="detailsSection === 'artifactStatus'">
+    <execution-artifact-tab stage="stage" execution="execution"></execution-artifact-tab>
+  </div>
 </div>


### PR DESCRIPTION
The Jenkins stage is now able to produce artifacts, so show them in the execution details.

Back-end changes are in spinnaker/orca#2723 though this can still be merged first; it will just show an empty artifact tab in the Jenkins execution history until people can actually use artifacts.