### PR TITLE
feat(core): Warning message about invalid job params

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/jenkins/jenkinsStage.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/jenkins/jenkinsStage.html
@@ -170,6 +170,20 @@
         </label>
       </div>
     </div>
+    <div ng-if="invalidParameters.length" class="horizontal center sp-margin-l-top" style="width: 100%">
+      <div class="alert alert-danger vertical">
+        <p>
+          <i class="fa fa-exclamation-triangle"></i>
+          The following parameters are not accepted by the jenkins job but are still set in the stage configuration:
+        </p>
+        <ul>
+          <li ng-repeat="paramName in invalidParameters">
+            {{paramName}}
+          </li>
+        </ul>
+        <button class="self-right passive" ng-click="jenkinsStageCtrl.removeInvalidParameters()">Remove all</button>
+      </div>
+    </div>
   </div>
 
   <stage-config-field label="Wait for results" help-key="jenkins.waitForCompletion">

--- a/app/scripts/modules/core/src/pipeline/config/stages/jenkins/jenkinsStage.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/jenkins/jenkinsStage.js
@@ -105,6 +105,7 @@ module.exports = angular
       function updateJobConfig() {
         let stage = $scope.stage,
           view = $scope.viewState;
+
         if (stage && stage.master && stage.job && !view.masterIsParameterized && !view.jobIsParameterized) {
           IgorService.getJobConfig($scope.stage.master, $scope.stage.job).then(config => {
             config = config || {};
@@ -114,6 +115,14 @@ module.exports = angular
             $scope.jobParams = config.parameterDefinitionList;
             $scope.userSuppliedParameters = $scope.stage.parameters;
             $scope.useDefaultParameters = {};
+
+            if ($scope.jobParams) {
+              const acceptedJobParameters = $scope.jobParams.map(param => param.name);
+              $scope.invalidParameters = Object.keys($scope.userSuppliedParameters).filter(
+                paramName => !acceptedJobParameters.includes(paramName),
+              );
+            }
+
             let params = $scope.jobParams || [];
             params.forEach(property => {
               if (!(property.name in $scope.stage.parameters) && property.defaultValue !== null) {
@@ -134,6 +143,15 @@ module.exports = angular
         } else if ($scope.userSuppliedParameters[parameter]) {
           $scope.stage.parameters[parameter] = $scope.userSuppliedParameters[parameter];
         }
+      };
+
+      this.removeInvalidParameters = function() {
+        $scope.invalidParameters.forEach(param => {
+          if ($scope.stage.parameters[param] !== 'undefined') {
+            delete $scope.stage.parameters[param];
+          }
+        });
+        $scope.invalidParameters = [];
       };
 
       initializeMasters();


### PR DESCRIPTION
Parameters not accepted by a jenkins job are highlighted in a jenkins stage.

The stage config can end up having parameters that are no longer needed/accepted by the jenkins job. This is similar to https://github.com/spinnaker/deck/pull/6668. 

![image](https://user-images.githubusercontent.com/2153660/54164023-535cb800-4418-11e9-9d16-57d93acd2719.png)


