### PR TITLE
 refactor(core): Remove triggerViaEcho feature flag

### DIFF
--- a/app/scripts/modules/core/src/config/settings.ts
+++ b/app/scripts/modules/core/src/config/settings.ts
@@ -55,7 +55,6 @@ export interface IFeatures {
   roscoMode?: boolean;
   snapshots?: boolean;
   travis?: boolean;
-  triggerViaEcho?: boolean;
   versionedProviders?: boolean;
   wercker?: boolean;
 }

--- a/app/scripts/modules/core/src/pipeline/config/services/PipelineConfigService.ts
+++ b/app/scripts/modules/core/src/pipeline/config/services/PipelineConfigService.ts
@@ -8,7 +8,7 @@ import { ViewStateCache } from 'core/cache';
 import { IStage } from 'core/domain/IStage';
 import { IPipeline } from 'core/domain/IPipeline';
 
-export interface IEchoTriggerPipelineResponse {
+export interface ITriggerPipelineResponse {
   eventId: string;
 }
 export class PipelineConfigService {
@@ -98,11 +98,7 @@ export class PipelineConfigService {
       .put();
   }
 
-  public static triggerPipelineViaEcho(
-    applicationName: string,
-    pipelineName: string,
-    body: any = {},
-  ): IPromise<string> {
+  public static triggerPipeline(applicationName: string, pipelineName: string, body: any = {}): IPromise<string> {
     body.user = AuthenticationService.getAuthenticatedUser().name;
     return API.one('pipelines')
       .one('v2')
@@ -110,7 +106,7 @@ export class PipelineConfigService {
       .one(encodeURIComponent(pipelineName))
       .data(body)
       .post()
-      .then((result: IEchoTriggerPipelineResponse) => {
+      .then((result: ITriggerPipelineResponse) => {
         return result.eventId;
       });
   }

--- a/app/scripts/modules/core/src/pipeline/config/services/PipelineConfigService.ts
+++ b/app/scripts/modules/core/src/pipeline/config/services/PipelineConfigService.ts
@@ -8,9 +8,6 @@ import { ViewStateCache } from 'core/cache';
 import { IStage } from 'core/domain/IStage';
 import { IPipeline } from 'core/domain/IPipeline';
 
-export interface ITriggerPipelineResponse {
-  ref: string;
-}
 export interface IEchoTriggerPipelineResponse {
   eventId: string;
 }
@@ -101,18 +98,6 @@ export class PipelineConfigService {
       .put();
   }
 
-  public static triggerPipeline(applicationName: string, pipelineName: string, body: any = {}): IPromise<string> {
-    body.user = AuthenticationService.getAuthenticatedUser().name;
-    return API.one('pipelines')
-      .one(applicationName)
-      .one(encodeURIComponent(pipelineName))
-      .data(body)
-      .post()
-      .then((result: ITriggerPipelineResponse) => {
-        return result.ref.split('/').pop();
-      });
-  }
-
   public static triggerPipelineViaEcho(
     applicationName: string,
     pipelineName: string,
@@ -170,17 +155,6 @@ export class PipelineConfigService {
       });
     }
     return uniq(upstreamStages);
-  }
-
-  public static startAdHocPipeline(body: any): IPromise<string> {
-    body.user = AuthenticationService.getAuthenticatedUser().name;
-    return API.one('pipelines')
-      .one('start')
-      .data(body)
-      .post()
-      .then((result: ITriggerPipelineResponse) => {
-        return result.ref.split('/').pop();
-      });
   }
 
   private static sortPipelines(pipelines: IPipeline[]): IPromise<IPipeline[]> {

--- a/app/scripts/modules/core/src/pipeline/service/execution.service.spec.ts
+++ b/app/scripts/modules/core/src/pipeline/service/execution.service.spec.ts
@@ -449,7 +449,7 @@ describe('Service: executionService', () => {
     });
   });
 
-  describe('waitUntilPipelineAppearsForEventId', () => {
+  describe('waitUntilTriggeredPipelineAppears', () => {
     const applicationName = 'deck';
     const application: Application = { name: applicationName, executions: { refresh: () => $q.when(null) } } as any;
     const eventId = 'abc';
@@ -461,7 +461,7 @@ describe('Service: executionService', () => {
 
       $httpBackend.expectGET(url).respond(200, [execution]);
 
-      executionService.waitUntilPipelineAppearsForEventId(application, eventId).promise.then(() => (succeeded = true));
+      executionService.waitUntilTriggeredPipelineAppears(application, eventId).promise.then(() => (succeeded = true));
 
       expect(succeeded).toBe(false);
 
@@ -474,7 +474,7 @@ describe('Service: executionService', () => {
 
       $httpBackend.expectGET(url).respond(200, []);
 
-      executionService.waitUntilPipelineAppearsForEventId(application, eventId).promise.then(() => (succeeded = true));
+      executionService.waitUntilTriggeredPipelineAppears(application, eventId).promise.then(() => (succeeded = true));
 
       expect(succeeded).toBe(false);
 
@@ -487,7 +487,7 @@ describe('Service: executionService', () => {
 
       $httpBackend.expectGET(url).respond(200, []);
 
-      executionService.waitUntilPipelineAppearsForEventId(application, eventId).promise.then(() => (succeeded = true));
+      executionService.waitUntilTriggeredPipelineAppears(application, eventId).promise.then(() => (succeeded = true));
 
       expect(succeeded).toBe(false);
 

--- a/app/scripts/modules/core/src/pipeline/service/execution.service.spec.ts
+++ b/app/scripts/modules/core/src/pipeline/service/execution.service.spec.ts
@@ -449,19 +449,19 @@ describe('Service: executionService', () => {
     });
   });
 
-  describe('waitUntilNewTriggeredPipelineAppears', () => {
-    const application: Application = { name: 'deck', executions: { refresh: () => $q.when(null) } } as any;
-    const executionId = 'abc';
-    const url = [SETTINGS.gateUrl, 'pipelines', executionId].join('/');
+  describe('waitUntilPipelineAppearsForEventId', () => {
+    const applicationName = 'deck';
+    const application: Application = { name: applicationName, executions: { refresh: () => $q.when(null) } } as any;
+    const eventId = 'abc';
+    const url = [SETTINGS.gateUrl, 'applications', 'deck', 'executions', 'search'].join('/') + '?eventId=abc';
+    const execution: any = {}; // Stub execution
 
     it('resolves when the pipeline exists', () => {
       let succeeded = false;
 
-      $httpBackend.expectGET(url).respond(200, {});
+      $httpBackend.expectGET(url).respond(200, [execution]);
 
-      executionService
-        .waitUntilNewTriggeredPipelineAppears(application, executionId)
-        .promise.then(() => (succeeded = true));
+      executionService.waitUntilPipelineAppearsForEventId(application, eventId).promise.then(() => (succeeded = true));
 
       expect(succeeded).toBe(false);
 
@@ -472,11 +472,9 @@ describe('Service: executionService', () => {
     it('does not resolve when the pipeline does not exist', () => {
       let succeeded = false;
 
-      $httpBackend.expectGET(url).respond(404, {});
+      $httpBackend.expectGET(url).respond(200, []);
 
-      executionService
-        .waitUntilNewTriggeredPipelineAppears(application, executionId)
-        .promise.then(() => (succeeded = true));
+      executionService.waitUntilPipelineAppearsForEventId(application, eventId).promise.then(() => (succeeded = true));
 
       expect(succeeded).toBe(false);
 
@@ -487,11 +485,9 @@ describe('Service: executionService', () => {
     it('resolves when the pipeline exists on a later poll', () => {
       let succeeded = false;
 
-      $httpBackend.expectGET(url).respond(404, {});
+      $httpBackend.expectGET(url).respond(200, []);
 
-      executionService
-        .waitUntilNewTriggeredPipelineAppears(application, executionId)
-        .promise.then(() => (succeeded = true));
+      executionService.waitUntilPipelineAppearsForEventId(application, eventId).promise.then(() => (succeeded = true));
 
       expect(succeeded).toBe(false);
 
@@ -500,7 +496,7 @@ describe('Service: executionService', () => {
       expect(succeeded).toBe(false);
 
       // return success on the second GET request
-      $httpBackend.expectGET(url).respond(200, {});
+      $httpBackend.expectGET(url).respond(200, [execution]);
       timeout.flush();
       $httpBackend.flush();
 

--- a/app/scripts/modules/core/src/pipeline/service/execution.service.ts
+++ b/app/scripts/modules/core/src/pipeline/service/execution.service.ts
@@ -250,14 +250,6 @@ export class ExecutionService {
     return retryablePromise(closure);
   }
 
-  public waitUntilNewTriggeredPipelineAppears(
-    application: Application,
-    triggeredPipelineId: string,
-  ): IRetryablePromise<any> {
-    const closure = () => this.getExecution(triggeredPipelineId).then(() => application.executions.refresh());
-    return retryablePromise(closure);
-  }
-
   private waitUntilPipelineIsCancelled(application: Application, executionId: string): IPromise<any> {
     return this.waitUntilExecutionMatches(executionId, (execution: IExecution) => execution.status === 'CANCELED').then(
       () => application.executions.refresh(),

--- a/app/scripts/modules/core/src/pipeline/service/execution.service.ts
+++ b/app/scripts/modules/core/src/pipeline/service/execution.service.ts
@@ -239,16 +239,9 @@ export class ExecutionService {
 
   public startAndMonitorPipeline(app: Application, pipeline: string, trigger: any): IPromise<IRetryablePromise<void>> {
     const { executionService } = ReactInjector;
-    let triggerFunction: (app: string, pipeline: string, trigger: any) => IPromise<string>;
-    let monitorFunction: (id: string) => IRetryablePromise<any>;
-    if (SETTINGS.feature.triggerViaEcho) {
-      triggerFunction = PipelineConfigService.triggerPipelineViaEcho.bind(PipelineConfigService);
-      monitorFunction = eventId => executionService.waitUntilPipelineAppearsForEventId(app, eventId);
-    } else {
-      triggerFunction = PipelineConfigService.triggerPipeline.bind(PipelineConfigService);
-      monitorFunction = newPipelineId => executionService.waitUntilNewTriggeredPipelineAppears(app, newPipelineId);
-    }
-    return triggerFunction(app.name, pipeline, trigger).then(triggerResult => monitorFunction(triggerResult));
+    return PipelineConfigService.triggerPipelineViaEcho(app.name, pipeline, trigger).then(triggerResult =>
+      executionService.waitUntilPipelineAppearsForEventId(app, triggerResult),
+    );
   }
 
   public waitUntilPipelineAppearsForEventId(application: Application, eventId: string): IRetryablePromise<any> {

--- a/app/scripts/modules/core/src/pipeline/service/execution.service.ts
+++ b/app/scripts/modules/core/src/pipeline/service/execution.service.ts
@@ -239,12 +239,12 @@ export class ExecutionService {
 
   public startAndMonitorPipeline(app: Application, pipeline: string, trigger: any): IPromise<IRetryablePromise<void>> {
     const { executionService } = ReactInjector;
-    return PipelineConfigService.triggerPipelineViaEcho(app.name, pipeline, trigger).then(triggerResult =>
-      executionService.waitUntilPipelineAppearsForEventId(app, triggerResult),
+    return PipelineConfigService.triggerPipeline(app.name, pipeline, trigger).then(triggerResult =>
+      executionService.waitUntilTriggeredPipelineAppears(app, triggerResult),
     );
   }
 
-  public waitUntilPipelineAppearsForEventId(application: Application, eventId: string): IRetryablePromise<any> {
+  public waitUntilTriggeredPipelineAppears(application: Application, eventId: string): IRetryablePromise<any> {
     const closure = () =>
       this.getExecutionByEventId(application.name, eventId).then(() => application.executions.refresh());
     return retryablePromise(closure);

--- a/halconfig/settings.js
+++ b/halconfig/settings.js
@@ -172,7 +172,6 @@ window.spinnakerSettings = {
     roscoMode: true,
     snapshots: false,
     travis: travisEnabled,
-    triggerViaEcho: true,
     versionedProviders: true,
     wercker: werckerEnabled,
   },

--- a/settings.js
+++ b/settings.js
@@ -27,7 +27,6 @@ var managedServiceAccountsEnabled = process.env.MANAGED_SERVICE_ACCOUNTS_ENABLED
 var onDemandClusterThreshold = process.env.ON_DEMAND_CLUSTER_THRESHOLD || '350';
 var reduxLoggerEnabled = process.env.REDUX_LOGGER === 'true';
 var templatesEnabled = process.env.TEMPLATES_ENABLED === 'true';
-var triggerViaEcho = process.env.TRIGGER_VIA_ECHO !== 'false';
 var useClassicFirewallLabels = process.env.USE_CLASSIC_FIREWALL_LABELS === 'true';
 
 window.spinnakerSettings = {
@@ -88,7 +87,6 @@ window.spinnakerSettings = {
     roscoMode: false,
     snapshots: false,
     travis: false,
-    triggerViaEcho: triggerViaEcho,
     versionedProviders: true,
     wercker: false,
   },


### PR DESCRIPTION
* refactor(core): Remove triggerViaEcho feature flag
   
  This flag was introduced in 1.11 and was enabled by default in 1.12; there have been no reports of any issues, so remove the flag.

* refactor(core): Remove unused functions
    
  Also convert the test of waitUntilNewTriggeredPipelineAppears into a test of waitUntilPipelineAppearsForEventId, as it looks like I didn't add a test to that function when I wrote it.

* refactor(core): Rename echo-specific triggering functions
    
  Now that the triggerViaEcho feature flag has been removed, rename the functions that were specific to the echo workflow to have more generic names.

