### PR TITLE
fix(ecs): Remove unused cacheInitializer injection

### DIFF
--- a/app/scripts/modules/ecs/src/serverGroup/configure/serverGroupConfiguration.service.ts
+++ b/app/scripts/modules/ecs/src/serverGroup/configure/serverGroupConfiguration.service.ts
@@ -86,7 +86,6 @@ export class EcsServerGroupConfigurationService {
 
   public static $inject = [
     '$q',
-    'cacheInitializer',
     'loadBalancerReader',
     'serverGroupCommandRegistry',
     'iamRoleReader',


### PR DESCRIPTION
This fixes the ECS server group modal.  Currently it won't load because the $inject list and the constructor list don't match up, leading to the wrong types being injected.