### PR TITLE
feat(kubernetes): add expression evaluation options to bake and deplo…

### DIFF
--- a/app/scripts/modules/core/src/help/help.contents.ts
+++ b/app/scripts/modules/core/src/help/help.contents.ts
@@ -253,6 +253,8 @@ const helpContents: { [key: string]: string } = {
       <p>For example, if the user selects "rollback" from this list of options, that branch can be activated by using the expression:
         <samp class="small">execution.stages[n].context.judgmentInput=="rollback"</samp></p>`,
   'pipeline.config.bake.manifest.expectedArtifact': '<p>This is the template you want to render.</p>',
+  'pipeline.config.bake.manifest.overrideExpressionEvaluation':
+    '<p>Explicitly evaluate SpEL expressions in overrides just prior to manifest baking. Can be paired with the "Skip SpEL evaluation" option in the Deploy Manifest stage when baking a third-party manifest artifact with expressions not meant for Spinnaker to evaluate as SpEL.</p>',
   'pipeline.config.haltPipelineOnFailure':
     'Immediately halts execution of all running stages and fails the entire execution.',
   'pipeline.config.haltBranchOnFailure':

--- a/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/bakeManifestConfig.controller.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/bakeManifestConfig.controller.ts
@@ -58,6 +58,7 @@ export class BakeManifestConfigCtrl implements IController {
           },
         ],
         inputArtifacts: [this.defaultInputArtifact()],
+        evaluateOverrideExpressions: false,
       };
 
       Object.assign(stage, defaultSelection);

--- a/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/bakeManifestConfig.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/bakeManifestConfig.html
@@ -123,5 +123,17 @@
     <stage-config-field label="Overrides" field-columns="6">
       <map-editor model="ctrl.$scope.stage.overrides" add-button-label="Add override"></map-editor>
     </stage-config-field>
+
+    <stage-config-field
+      help-key="pipeline.config.bake.manifest.overrideExpressionEvaluation"
+      label="Expression Evaluation"
+    >
+      <div class="checkbox">
+        <label>
+          <input type="checkbox" ng-model="ctrl.$scope.stage.evaluateOverrideExpressions" />
+          Evaluate SpEL expressions in overrides at bake time
+        </label>
+      </div>
+    </stage-config-field>
   </div>
 </div>

--- a/app/scripts/modules/kubernetes/src/help/kubernetes.help.ts
+++ b/app/scripts/modules/kubernetes/src/help/kubernetes.help.ts
@@ -206,6 +206,8 @@ const helpContents: { [key: string]: string } = {
     'The artifact that is to be applied to the Kubernetes account for this stage.  The artifact should represent a valid Kubernetes manifest.',
   'kubernetes.manifest.requiredArtifactsToBind':
     'These artifacts must be present in the context for this stage to successfully complete. Artifacts specified will be <a href="https://www.spinnaker.io/reference/artifacts/in-kubernetes-v2/#binding-artifacts-in-manifests" target="_blank">bound to the deployed manifest.</a>',
+  'kubernetes.manifest.skipExpressionEvaluation':
+    '<p>Skip SpEL expression evaluation of the manifest artifact in this stage. Can be paired with the "Evaluate SpEL expressions in overrides at bake time" option in the Bake Manifest stage when baking a third-party manifest artifact with expressions not meant for Spinnaker to evaluate as SpEL.</p>',
   'kubernetes.manifest.undoRollout.revisionsBack': `
       <p>How many revisions to rollback from the current active revision. This is not a hard-coded revision to rollout.</p>
       <p>For example: If you specify "1", and this stage executes, the prior revision will be active upon success.</p>

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestConfig.controller.ts
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestConfig.controller.ts
@@ -56,6 +56,7 @@ export class KubernetesV2DeployManifestConfigCtrl implements IController {
         defaults(stage, builtCommand.command, {
           manifestArtifactAccount: '',
           source: this.textSource,
+          skipExpressionEvaluation: false,
         });
       }
       this.metadata = builtCommand.metadata;

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestConfig.html
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestConfig.html
@@ -41,6 +41,18 @@
         >
         </stage-artifact-selector-react>
       </stage-config-field>
+      <stage-config-field
+        help-key="kubernetes.manifest.skipExpressionEvaluation"
+        label="Expression Evaluation"
+        ng-if="ctrl.$scope.stage.source === ctrl.artifactSource"
+      >
+        <div class="checkbox">
+          <label>
+            <input type="checkbox" ng-model="ctrl.$scope.stage.skipExpressionEvaluation" />
+            Skip SpEL expression evaluation
+          </label>
+        </div>
+      </stage-config-field>
       <hr />
       <stage-config-field
         label="Req. Artifacts to Bind"
@@ -89,6 +101,18 @@
         on-save="ctrl.manifestArtifactController.onArtifactCreated"
       >
       </expected-artifact-editor-react>
+      <stage-config-field
+        help-key="kubernetes.manifest.skipExpressionEvaluation"
+        label="Expression Evaluation"
+        ng-if="ctrl.$scope.stage.source === ctrl.artifactSource"
+      >
+        <div class="checkbox">
+          <label>
+            <input type="checkbox" ng-model="ctrl.$scope.stage.skipExpressionEvaluation" />
+            Skip SpEL expression evaluation
+          </label>
+        </div>
+      </stage-config-field>
       <hr />
       <expected-artifact-multi-selector
         command="ctrl.$scope.stage"


### PR DESCRIPTION
…y manifest stages

Corresponding Orca PR: https://github.com/spinnaker/orca/pull/2761

The primary purpose of this change is to prevent Deploy Manifest stage failure for users attempting to deploy third-party Helm manifests that include `${}`-wrapped expressions, while allowing SpEL overrides to be explicitly evaluated just prior to baking. These options should probably be deprecated when expression evaluation is refactored in Spinnaker (see this [proposal](https://github.com/spinnaker/spinnaker/issues/3500)).

- Adds `evaluateOverrideExpressions` option to Bake Manifest stage. This defaults to false. When it is set to true, SpEL expressions evaluation of manifest overrides will occur during the Bake stage.
- Adds `skipExpressionEvaluation` option to Deploy Manifest stage for manifest artifacts. This defaults to false. When it is set to true, SpEL expression of the manifest artifact will not occur during the Deploy stage.
- Important caveat: Orca attempts to evaluate expressions in the entire pipeline context multiple times in logic that does not belong to these stages (for example, [here](https://github.com/spinnaker/orca/blob/master/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/OperationsController.groovy#L167)). Therefore, there will still be "failed to evaluate" warnings for all `${}`-wrapped expressions not intended for Spinnaker.

Related issues:
- https://github.com/spinnaker/spinnaker/issues/2809
- https://github.com/spinnaker/spinnaker/issues/3028
- https://github.com/spinnaker/spinnaker/issues/3939
- https://github.com/spinnaker/spinnaker/issues/4109
- https://github.com/spinnaker/spinnaker/issues/3644
- https://github.com/spinnaker/spinnaker/issues/3335

Before:
![2kX9K7zFvuJ](https://user-images.githubusercontent.com/15936279/54393281-26124300-4680-11e9-9fec-dd9f9c492dda.png)

After:
![2N55McgwoEf](https://user-images.githubusercontent.com/15936279/54393295-2d395100-4680-11e9-84eb-ee212fcb6d77.png)

