### PR TITLE
feat(titus): Surface env and resources for runjob stage

### DIFF
--- a/app/scripts/modules/titus/src/pipeline/stages/runJob/RunJobExecutionDetails.tsx
+++ b/app/scripts/modules/titus/src/pipeline/stages/runJob/RunJobExecutionDetails.tsx
@@ -51,8 +51,10 @@ export class RunJobExecutionDetails extends React.Component<
     const { titusUiEndpoint } = this.state;
     const { context } = stage;
     const { cluster } = context;
+    const { resources, env } = cluster;
     const jobId = cluster ? get(context['deploy.jobs'], cluster.region, [])[0] : null;
     const taskId = get(context, 'jobStatus.completionDetails.taskId');
+
     return (
       <ExecutionDetailsSection name={name} current={current}>
         <div className="row">
@@ -94,9 +96,38 @@ export class RunJobExecutionDetails extends React.Component<
                   </dd>
                 </>
               )}
+              {resources && Object.keys(resources) && (
+                <>
+                  <dt>Resources</dt>
+                  <dd>
+                    <ul className="nostyle">
+                      {Object.keys(resources).map(key => (
+                        <li>
+                          {key}: {resources[key]}
+                        </li>
+                      ))}
+                    </ul>
+                  </dd>
+                </>
+              )}
             </dl>
           </div>
         </div>
+        {env && Object.keys(env) && (
+          <div className="row">
+            <div className="col-md-12">
+              <h5 style={{ marginBottom: 0, paddingBottom: '5px' }}>Environment Variables</h5>
+              <dl>
+                {Object.keys(env).map(key => (
+                  <>
+                    <dt>{key}</dt>
+                    <dd>{env[key]}</dd>
+                  </>
+                ))}
+              </dl>
+            </div>
+          </div>
+        )}
         {context.propertyFileContents && (
           <div className="row">
             <div className="col-md-12">
@@ -123,6 +154,7 @@ export class RunJobExecutionDetails extends React.Component<
           stage={stage}
           message={stage.failureMessage || get(context, 'completionDetails.message')}
         />
+
         {taskId && (
           <div className="row">
             <div className="col-md-12">


### PR DESCRIPTION
RunJob stage in execution now surfaces resources and env vars.

RunJob stage allows a user to configure resources and env vars. However during an execution, these are not provided for context, especially if it fails because of this config. 
