### PR TITLE
fix(tests): looking for app links sometimes fails because page isnt ready

### DIFF
--- a/test/functional/tests/core/pages/ApplicationsListPage.ts
+++ b/test/functional/tests/core/pages/ApplicationsListPage.ts
@@ -40,11 +40,12 @@ export class ApplicationsListPage extends Page {
   }
 
   public applicationsLinks(): Client<RawResult<Element>>[] & RawResult<Element>[] {
+    this.awaitLocator(ApplicationsListPage.locators.applicationLinks);
     return browser.$$(ApplicationsListPage.locators.applicationLinks);
   }
 
   public applicationLinkWithLabel(label: string): Client<RawResult<Element>> {
-    const links = browser.$$(ApplicationsListPage.locators.applicationLinks);
+    const links = this.applicationsLinks();
     const labelLink = links.find(link => link.getText().includes(label));
     return labelLink;
   }


### PR DESCRIPTION
Nightly builds fail sometimes because this locator is used immediately after the browser is opened by the test runner and sometimes the app list hasn't loaded in yet.