### PR TITLE
fix(triggers): Add pipeline name to search request

### DIFF
--- a/app/scripts/modules/core/src/pipeline/service/execution.service.spec.ts
+++ b/app/scripts/modules/core/src/pipeline/service/execution.service.spec.ts
@@ -451,9 +451,12 @@ describe('Service: executionService', () => {
 
   describe('waitUntilTriggeredPipelineAppears', () => {
     const applicationName = 'deck';
+    const pipelineName = 'pipeline';
     const application: Application = { name: applicationName, executions: { refresh: () => $q.when(null) } } as any;
     const eventId = 'abc';
-    const url = [SETTINGS.gateUrl, 'applications', 'deck', 'executions', 'search'].join('/') + '?eventId=abc';
+    const url =
+      [SETTINGS.gateUrl, 'applications', 'deck', 'executions', 'search'].join('/') +
+      '?eventId=abc&pipelineName=pipeline';
     const execution: any = {}; // Stub execution
 
     it('resolves when the pipeline exists', () => {
@@ -461,7 +464,9 @@ describe('Service: executionService', () => {
 
       $httpBackend.expectGET(url).respond(200, [execution]);
 
-      executionService.waitUntilTriggeredPipelineAppears(application, eventId).promise.then(() => (succeeded = true));
+      executionService
+        .waitUntilTriggeredPipelineAppears(application, pipelineName, eventId)
+        .promise.then(() => (succeeded = true));
 
       expect(succeeded).toBe(false);
 
@@ -474,7 +479,9 @@ describe('Service: executionService', () => {
 
       $httpBackend.expectGET(url).respond(200, []);
 
-      executionService.waitUntilTriggeredPipelineAppears(application, eventId).promise.then(() => (succeeded = true));
+      executionService
+        .waitUntilTriggeredPipelineAppears(application, pipelineName, eventId)
+        .promise.then(() => (succeeded = true));
 
       expect(succeeded).toBe(false);
 
@@ -487,7 +494,9 @@ describe('Service: executionService', () => {
 
       $httpBackend.expectGET(url).respond(200, []);
 
-      executionService.waitUntilTriggeredPipelineAppears(application, eventId).promise.then(() => (succeeded = true));
+      executionService
+        .waitUntilTriggeredPipelineAppears(application, pipelineName, eventId)
+        .promise.then(() => (succeeded = true));
 
       expect(succeeded).toBe(false);
 

--- a/app/scripts/modules/core/src/pipeline/service/execution.service.ts
+++ b/app/scripts/modules/core/src/pipeline/service/execution.service.ts
@@ -120,9 +120,9 @@ export class ExecutionService {
       });
   }
 
-  public getExecutionByEventId(application: string, eventId: string): IPromise<IExecution> {
+  public getExecutionByEventId(application: string, pipelineName: string, eventId: string): IPromise<IExecution> {
     return API.all('applications', application, 'executions', 'search')
-      .get({ eventId })
+      .get({ pipelineName, eventId })
       .then((data: IExecution[]) => {
         if (data.length > 0) {
           const execution = data[0];
@@ -240,13 +240,17 @@ export class ExecutionService {
   public startAndMonitorPipeline(app: Application, pipeline: string, trigger: any): IPromise<IRetryablePromise<void>> {
     const { executionService } = ReactInjector;
     return PipelineConfigService.triggerPipeline(app.name, pipeline, trigger).then(triggerResult =>
-      executionService.waitUntilTriggeredPipelineAppears(app, triggerResult),
+      executionService.waitUntilTriggeredPipelineAppears(app, pipeline, triggerResult),
     );
   }
 
-  public waitUntilTriggeredPipelineAppears(application: Application, eventId: string): IRetryablePromise<any> {
+  public waitUntilTriggeredPipelineAppears(
+    application: Application,
+    pipelineName: string,
+    eventId: string,
+  ): IRetryablePromise<any> {
     const closure = () =>
-      this.getExecutionByEventId(application.name, eventId).then(() => application.executions.refresh());
+      this.getExecutionByEventId(application.name, pipelineName, eventId).then(() => application.executions.refresh());
     return retryablePromise(closure);
   }
 


### PR DESCRIPTION
When searching for a manually started pipeline by eventId, we should also pass in the pipeline name to reduce the amount of data returned from the persistence store.