### PR TITLE
fix(trigger): Fix react trigger components don't receive prop updates

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/triggers/trigger.directive.js
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/trigger.directive.js
@@ -114,9 +114,18 @@ module.exports = angular
             if (config.component) {
               // react
               const TriggerConfig = config.component;
-              const props = { fieldUpdated: $scope.fieldUpdated, trigger: $scope.trigger };
+              const renderTrigger = props =>
+                ReactDOM.render(React.createElement(TriggerConfig, props), triggerBodyNode);
 
-              ReactDOM.render(React.createElement(TriggerConfig, props), triggerBodyNode);
+              const props = {
+                fieldUpdated: () => {
+                  $scope.fieldUpdated();
+                  renderTrigger(props);
+                },
+                trigger: $scope.trigger,
+              };
+
+              renderTrigger(props);
             } else if (config.templateUrl) {
               // angular
               const template = $templateCache.get(config.templateUrl);


### PR DESCRIPTION
Currently React trigger components don't receive prop updates when `ITriggerConfigProps#fieldUpdated` is called.