### PR TITLE
fix(artifacts): Fix SpEL text input used in React components

### DIFF
--- a/app/scripts/modules/core/src/widgets/spelText/SpelText.tsx
+++ b/app/scripts/modules/core/src/widgets/spelText/SpelText.tsx
@@ -44,20 +44,20 @@ export class SpelText extends React.Component<ISpelTextProps, ISpelTextState> {
     this.renderSuggestions();
   }
 
-  public componentDidUpdate() {
-    this.renderSuggestions();
+  public componentDidUpdate(_: Readonly<ISpelTextProps>, prevState: Readonly<ISpelTextState>): void {
+    if (prevState.textcompleteConfig !== this.state.textcompleteConfig) {
+      this.renderSuggestions();
+    }
   }
 
   private renderSuggestions() {
     const input = $(this.spelInputRef.current);
-    if (!input.attr('contenteditable')) {
-      input.attr('contenteditable', 'true');
-      input.textcomplete(this.state.textcompleteConfig, {
-        maxCount: 1000,
-        zIndex: 9000,
-        dropdownClassName: 'dropdown-menu textcomplete-dropdown spel-dropdown',
-      });
-    }
+    input.attr('contenteditable', 'true');
+    input.textcomplete(this.state.textcompleteConfig, {
+      maxCount: 1000,
+      zIndex: 9000,
+      dropdownClassName: 'dropdown-menu textcomplete-dropdown spel-dropdown',
+    });
   }
 
   public render() {


### PR DESCRIPTION
Fixes SpEL inputs for artifact selectors in React-based components.

![image](https://user-images.githubusercontent.com/1697736/54559870-084e2200-498f-11e9-8f99-013e56575f9d.png)
