### PR TITLE
fix(kubernetes): Fix copy from infrastructure link

### DIFF
--- a/app/scripts/modules/kubernetes/src/v2/manifest/wizard/manifestEntry.component.ts
+++ b/app/scripts/modules/kubernetes/src/v2/manifest/wizard/manifestEntry.component.ts
@@ -22,6 +22,8 @@ class KubernetesManifestCtrl implements IController {
     this.rawManifest = yamlDocumentsToString(this.manifests);
   };
 
+  public $onChanges = () => this.$onInit();
+
   public handleChange = (rawManifest: string, manifests: any): void => {
     this.rawManifest = rawManifest;
     this.command.manifests = manifests;


### PR DESCRIPTION
The 'copy from running infrastructure' link in the 'Deploy Manifest' stage is not currently updating the view (but is correctly updating the stage data).  I believe it's just due to a missing `$onChange` handler.