### PR TITLE
refactor(core): use non-deprecated tasks endpoint for app tasks

### DIFF
--- a/app/scripts/modules/core/src/serverGroup/serverGroupWriter.service.spec.ts
+++ b/app/scripts/modules/core/src/serverGroup/serverGroupWriter.service.spec.ts
@@ -58,7 +58,7 @@ describe('serverGroupWriter', function() {
     function postTask(serverGroupCommand: IServerGroupCommand): ITaskCommand {
       let submitted: ITaskCommand = {};
       $httpBackend
-        .expectPOST(`${API.baseUrl}/applications/app/tasks`, (body: string) => {
+        .expectPOST(`${API.baseUrl}/tasks`, (body: string) => {
           submitted = JSON.parse(body) as ITaskCommand;
           return true;
         })

--- a/app/scripts/modules/core/src/task/task.write.service.spec.ts
+++ b/app/scripts/modules/core/src/task/task.write.service.spec.ts
@@ -22,15 +22,14 @@ describe('Service: TaskWriter', () => {
   describe('cancelling task', () => {
     it('should wait until task is canceled, then resolve', () => {
       const taskId = 'abc';
-      const cancelUrl = [API.baseUrl, 'applications', 'deck', 'tasks', taskId, 'cancel'].join('/');
+      const cancelUrl = [API.baseUrl, 'tasks', taskId, 'cancel'].join('/');
       const checkUrl = [API.baseUrl, 'tasks', taskId].join('/');
-      const application = 'deck';
       let completed = false;
 
       $httpBackend.expectPUT(cancelUrl).respond(200, []);
       $httpBackend.expectGET(checkUrl).respond(200, { id: taskId });
 
-      TaskWriter.cancelTask(application, taskId).then(() => (completed = true));
+      TaskWriter.cancelTask(taskId).then(() => (completed = true));
       $httpBackend.flush();
       expect(completed).toBe(false);
 

--- a/app/scripts/modules/core/src/task/task.write.service.ts
+++ b/app/scripts/modules/core/src/task/task.write.service.ts
@@ -11,14 +11,11 @@ export interface ITaskCreateResult {
 
 export class TaskWriter {
   public static postTaskCommand(taskCommand: ITaskCommand): IPromise<ITaskCreateResult> {
-    return API.one('applications', taskCommand.application || taskCommand.project)
-      .all('tasks')
-      .post(taskCommand);
+    return API.all('tasks').post(taskCommand);
   }
 
-  public static cancelTask(applicationName: string, taskId: string): IPromise<void> {
-    return API.one('applications', applicationName)
-      .all('tasks')
+  public static cancelTask(taskId: string): IPromise<void> {
+    return API.all('tasks')
       .one(taskId, 'cancel')
       .put()
       .then(() =>

--- a/app/scripts/modules/core/src/task/tasks.controller.js
+++ b/app/scripts/modules/core/src/task/tasks.controller.js
@@ -147,7 +147,7 @@ module.exports = angular
           return task.id === taskId;
         })[0];
         var submitMethod = function() {
-          return TaskWriter.cancelTask(application.name, taskId).then(() => application.tasks.refresh());
+          return TaskWriter.cancelTask(taskId).then(() => application.tasks.refresh());
         };
 
         confirmationModalService.confirm({


### PR DESCRIPTION
These endpoints were [just recently deprecated](https://github.com/spinnaker/gate/commit/4c06144025c0a0b264f88002e1ebeab302e88518), so we should start using the new, application-agnostic endpoints for these operations.