### PR TITLE
feat(mptv2): add list screen for pipeline templates

### DIFF
--- a/app/scripts/modules/core/src/domain/IPipelineTemplateV2.ts
+++ b/app/scripts/modules/core/src/domain/IPipelineTemplateV2.ts
@@ -8,6 +8,9 @@ export interface IPipelineTemplateV2 {
   protect: boolean;
   schema: string;
   variables: IVariableMetadataV2[];
+  version?: string;
+  updateTs?: string;
+  digest?: string;
 }
 
 interface IPipelineTemplateMetadataV2 {

--- a/app/scripts/modules/core/src/header/SpinnakerHeader.tsx
+++ b/app/scripts/modules/core/src/header/SpinnakerHeader.tsx
@@ -5,6 +5,7 @@ import { UIRouterContext } from '@uirouter/react-hybrid';
 import { NgReact } from 'core/reactShims';
 import { GlobalSearch } from 'core/search/global/GlobalSearch';
 import { HelpMenu } from 'core/help/HelpMenu';
+import { SETTINGS } from 'core/config';
 
 import './SpinnakerHeader.css';
 
@@ -35,6 +36,16 @@ export class SpinnakerHeader extends React.Component<{}, ISpinnakerHeaderState> 
 
   public render(): React.ReactElement<SpinnakerHeader> {
     const { UserMenu, WhatsNew } = NgReact;
+
+    const mptv2Button = (
+      <li key="navPipelineTemplates">
+        <UISrefActive class="active">
+          <UISref to="home.pipeline-templates">
+            <a>Pipeline Templates</a>
+          </UISref>
+        </UISrefActive>
+      </li>
+    );
 
     return (
       <nav className="container spinnaker-header" role="navigation" aria-label="Main Menu">
@@ -72,8 +83,8 @@ export class SpinnakerHeader extends React.Component<{}, ISpinnakerHeaderState> 
                   </UISref>
                 </UISrefActive>
               </li>
+              {SETTINGS.feature.managedPipelineTemplatesV2UI ? mptv2Button : null}
             </ul>
-
             <ul className="nav nav-items">
               <UserMenu />
               <GlobalSearch />

--- a/app/scripts/modules/core/src/pipeline/config/actions/templateJson/ShowPipelineTemplateJsonModal.spec.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/actions/templateJson/ShowPipelineTemplateJsonModal.spec.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { mount } from 'enzyme';
 
-import { IPipeline } from 'core/domain';
+import { IPipeline, IPipelineTemplateV2 } from 'core/domain';
+import { PipelineTemplateV2Service } from 'core/pipeline/config/templates/v2/pipelineTemplateV2.service';
 import { ShowPipelineTemplateJsonModal } from './ShowPipelineTemplateJsonModal';
 
 describe('<ShowPipelineTemplateJsonModal />', () => {
@@ -12,27 +13,21 @@ describe('<ShowPipelineTemplateJsonModal />', () => {
     stages: [{ name: 'Find Image from Cluster', refId: '1', requisiteStageRefIds: [], type: 'findImage' }],
   };
 
-  it('renders a pipeline object in a template json string', () => {
-    const wrapper = mount(<ShowPipelineTemplateJsonModal pipeline={mockPipeline as IPipeline} />);
-    const templateStr = wrapper.find('JsonEditor').prop('value');
-    const template = JSON.parse(templateStr as string);
-    expect(template.pipeline).toEqual(mockPipeline);
-  });
+  const mockTemplate: IPipelineTemplateV2 = PipelineTemplateV2Service.createPipelineTemplate(
+    mockPipeline as IPipeline,
+    'example@example.com',
+  );
 
   it('dismisses modal with close button', () => {
     const dismissModal = jasmine.createSpy('dismissModal');
-    const wrapper = mount(
-      <ShowPipelineTemplateJsonModal pipeline={mockPipeline as IPipeline} dismissModal={dismissModal} />,
-    );
+    const wrapper = mount(<ShowPipelineTemplateJsonModal template={mockTemplate} dismissModal={dismissModal} />);
     const button = wrapper.find('button').filterWhere(n => n.text() === 'Close');
     button.simulate('click');
     expect(dismissModal).toHaveBeenCalled();
   });
 
   it('updates template json with user input', () => {
-    const wrapper = mount(
-      <ShowPipelineTemplateJsonModal pipeline={mockPipeline as IPipeline} ownerEmail="example@example.com" />,
-    );
+    const wrapper = mount(<ShowPipelineTemplateJsonModal template={mockTemplate} />);
     const simulateInputChange = (id: string, value: string) =>
       wrapper.find(id).simulate('change', { target: { value } });
 

--- a/app/scripts/modules/core/src/pipeline/config/pipelineConfigurer.js
+++ b/app/scripts/modules/core/src/pipeline/config/pipelineConfigurer.js
@@ -15,6 +15,7 @@ import { PipelineConfigService } from 'core/pipeline/config/services/PipelineCon
 import { ExecutionsTransformer } from 'core/pipeline/service/ExecutionsTransformer';
 import { EditPipelineJsonModal } from 'core/pipeline/config/actions/pipelineJson/EditPipelineJsonModal';
 import { ShowPipelineTemplateJsonModal } from 'core/pipeline/config/actions/templateJson/ShowPipelineTemplateJsonModal';
+import { PipelineTemplateV2Service } from 'core/pipeline';
 
 module.exports = angular
   .module('spinnaker.core.pipeline.config.pipelineConfigurer', [OVERRIDE_REGISTRY, EXECUTION_BUILD_TITLE])
@@ -214,11 +215,10 @@ module.exports = angular
 
       this.exportPipelineTemplate = () => {
         const modalProps = { dialogClassName: 'modal-lg modal-fullscreen' };
-        ReactModal.show(
-          ShowPipelineTemplateJsonModal,
-          { ownerEmail: _.get($scope, 'application.attributes.email', ''), pipeline: $scope.pipeline },
-          modalProps,
-        );
+        const pipeline = $scope.pipeline;
+        const ownerEmail = _.get($scope, 'application.attributes.email', '');
+        const template = PipelineTemplateV2Service.createPipelineTemplate(pipeline, ownerEmail);
+        ReactModal.show(ShowPipelineTemplateJsonModal, { template }, modalProps);
       };
 
       // Disabling a pipeline also just toggles the disabled flag - it does not save any pending changes

--- a/app/scripts/modules/core/src/pipeline/config/templates/PipelineTemplateReader.ts
+++ b/app/scripts/modules/core/src/pipeline/config/templates/PipelineTemplateReader.ts
@@ -3,6 +3,7 @@ import { $q } from 'ngimport';
 import { flatten } from 'lodash';
 import { API } from 'core/api/ApiService';
 import { IPipeline } from 'core/domain/IPipeline';
+import { IPipelineTemplateV2 } from 'core/domain/IPipelineTemplateV2';
 
 export interface IPipelineTemplate {
   id: string;
@@ -110,6 +111,14 @@ export class PipelineTemplateReader {
       .then(templates => {
         templates.forEach(template => (template.selfLink = `spinnaker://${template.id}`));
         return templates;
+      });
+  }
+
+  public static getV2PipelineTemplateList(): IPromise<IPipelineTemplateV2[]> {
+    return API.one('pipelineTemplates')
+      .get()
+      .then((templates: IPipelineTemplateV2[]) => {
+        return templates.filter(({ schema }) => schema === 'v2');
       });
   }
 }

--- a/app/scripts/modules/core/src/pipeline/config/templates/v2/PipelineTemplatesV2.less
+++ b/app/scripts/modules/core/src/pipeline/config/templates/v2/PipelineTemplatesV2.less
@@ -1,0 +1,13 @@
+.pipeline-templates-error-banner {
+  margin: 1em 0;
+
+  i.fa-exclamation-triangle {
+    padding-right: 8px;
+  }
+}
+
+.pipeline-template-actions {
+  button.link {
+    padding: 0;
+  }
+}

--- a/app/scripts/modules/core/src/pipeline/config/templates/v2/PipelineTemplatesV2.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/templates/v2/PipelineTemplatesV2.tsx
@@ -1,0 +1,128 @@
+import * as React from 'react';
+import { DateTime } from 'luxon';
+import { get } from 'lodash';
+import { IPipelineTemplateV2 } from 'core/domain/IPipelineTemplateV2';
+import { ReactModal } from 'core/presentation';
+import {
+  ShowPipelineTemplateJsonModal,
+  IShowPipelineTemplateJsonModalProps,
+} from 'core/pipeline/config/actions/templateJson/ShowPipelineTemplateJsonModal';
+import { PipelineTemplateReader } from '../PipelineTemplateReader';
+
+import './PipelineTemplatesV2.less';
+
+export interface IPipelineTemplatesV2State {
+  templates: IPipelineTemplateV2[];
+  fetchError: string;
+}
+
+export const PipelineTemplatesV2Error = (props: { message: string }) => {
+  return (
+    <div className="pipeline-templates-error-banner horizontal middle center heading-4">
+      <i className="fa fa-exclamation-triangle" />
+      <span>{props.message}</span>
+    </div>
+  );
+};
+
+export class PipelineTemplatesV2 extends React.Component<{}, IPipelineTemplatesV2State> {
+  constructor(props: {}) {
+    super(props);
+    this.state = { templates: [], fetchError: null };
+  }
+
+  public componentDidMount() {
+    this.fetchTemplates();
+  }
+
+  private fetchTemplates = () => {
+    const templatesPromise = PipelineTemplateReader.getV2PipelineTemplateList();
+    templatesPromise.then(
+      templates => {
+        this.setState({ templates });
+      },
+      err => {
+        const message: string = get(err, 'data.message') || get(err, 'message') || 'Unknown error.';
+        this.setState({ fetchError: message });
+      },
+    );
+  };
+
+  private idForTemplate = (template: IPipelineTemplateV2) => {
+    const { id, version = '', digest = '' } = template;
+    return `${id}:${version}:${digest}`;
+  };
+
+  private getUpdateTimeForTemplate = (template: IPipelineTemplateV2) => {
+    const millis = Number.parseInt(template.updateTs, 10);
+    if (isNaN(millis)) {
+      return '';
+    }
+    const dt = DateTime.fromMillis(millis);
+    return dt.toLocaleString(DateTime.DATETIME_SHORT);
+  };
+
+  private showTemplateJson = (template: IPipelineTemplateV2) => {
+    const props = {
+      template,
+      editable: false,
+      modalHeading: 'View Pipeline Template',
+      descriptionText: 'The JSON below contains the metadata, variables and pipeline definition for this template.',
+    };
+    ReactModal.show<IShowPipelineTemplateJsonModalProps>(ShowPipelineTemplateJsonModal, props, {
+      dialogClassName: 'modal-lg modal-fullscreen',
+    });
+  };
+
+  public render() {
+    return (
+      <>
+        <div className="infrastructure">
+          <div className="infrastructure-section search-header">
+            <div className="container">
+              <h2 className="header-section">
+                <span className="search-label">Pipeline Templates</span>
+              </h2>
+            </div>
+          </div>
+          <div className="infrastructure-section">
+            <div className="container">
+              {this.state.fetchError && (
+                <PipelineTemplatesV2Error
+                  message={`There was an error fetching pipeline templates: ${this.state.fetchError}`}
+                />
+              )}
+              <table className="table">
+                <thead>
+                  <tr>
+                    <th>Name</th>
+                    <th>Owner</th>
+                    <th>Updated</th>
+                    <th>Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {(this.state.templates || []).map(template => {
+                    const { metadata } = template;
+                    return (
+                      <tr key={this.idForTemplate(template)}>
+                        <td>{metadata.name || '-'}</td>
+                        <td>{metadata.owner || '-'}</td>
+                        <td>{this.getUpdateTimeForTemplate(template) || '-'}</td>
+                        <td className="pipeline-template-actions">
+                          <button className="link" onClick={() => this.showTemplateJson(template)}>
+                            View
+                          </button>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </>
+    );
+  }
+}

--- a/app/scripts/modules/core/src/pipeline/config/templates/v2/pipelineTemplateV2.states.ts
+++ b/app/scripts/modules/core/src/pipeline/config/templates/v2/pipelineTemplateV2.states.ts
@@ -1,0 +1,30 @@
+import { module } from 'angular';
+import { SETTINGS } from 'core/config';
+import { INestedState, STATE_CONFIG_PROVIDER, StateConfigProvider } from 'core/navigation';
+import { PipelineTemplatesV2 } from './PipelineTemplatesV2';
+
+export const PIPELINE_TEMPLATES_V2_STATES_CONFIG = 'spinnaker.core.pipeline.templates.v2.states.config';
+
+module(PIPELINE_TEMPLATES_V2_STATES_CONFIG, [STATE_CONFIG_PROVIDER]).config([
+  'stateConfigProvider',
+  (stateConfigProvider: StateConfigProvider) => {
+    const pipelineTemplatesList: INestedState = {
+      name: 'pipeline-templates',
+      url: '/pipeline-templates',
+      views: {
+        'main@': {
+          component: PipelineTemplatesV2,
+          $type: 'react',
+        },
+      },
+      data: {
+        pageTitleMain: {
+          label: 'Pipeline Templates',
+        },
+      },
+    };
+    if (SETTINGS.feature.managedPipelineTemplatesV2UI) {
+      stateConfigProvider.addToRootState(pipelineTemplatesList);
+    }
+  },
+]);

--- a/app/scripts/modules/core/src/pipeline/pipeline.module.ts
+++ b/app/scripts/modules/core/src/pipeline/pipeline.module.ts
@@ -43,6 +43,7 @@ import { STEP_EXECUTION_DETAILS_COMPONENT } from './details/stepExecutionDetails
 import { STAGE_SUMMARY_COMPONENT } from './details/stageSummary.component';
 import { PRODUCES_ARTIFACTS } from './config/stages/producesArtifacts/producesArtifacts.component';
 import { ARTIFACT_LIST } from './status/artifactList.component';
+import { PIPELINE_TEMPLATES_V2_STATES_CONFIG } from './config/templates/v2/pipelineTemplateV2.states';
 
 import './pipeline.less';
 import 'angular-ui-sortable';
@@ -103,4 +104,5 @@ module(PIPELINE_MODULE, [
   require('./config/preconditions/preconditions.module').name,
   require('./config/preconditions/types/clusterSize/clusterSize.precondition.type.module').name,
   require('./config/preconditions/types/expression/expression.precondition.type.module').name,
+  PIPELINE_TEMPLATES_V2_STATES_CONFIG,
 ]);


### PR DESCRIPTION
Fixes https://github.com/spinnaker/spinnaker/issues/3888

![Screen Shot 2019-03-20 at 10 28 44 AM](https://user-images.githubusercontent.com/34253460/54696136-abbf4400-4b01-11e9-9aa3-3d7a48c62cbe.png)

Note: There are two duplicate-looking templates in this screenshot. This is working correctly and is just a side effect of spin's current implementation of template versioning.

- Adds template list screen that allows user to View the JSON of all of their saved templates
- Adds `#/pipeline-templates` route to get to the list screen (behind feature flag)
- Adds button in top nav to get to the list screen (behind feature flag)

I'm not opinionated about the location of the entrypoint (nav button at top of Deck) or the chosen URL (`#/pipeline-templates`). Happy to change these if anyone has suggestions for better placement or naming.