### PR TITLE
fix(titus): use arrow function to avoid bad this binding in callback

### DIFF
--- a/app/scripts/modules/titus/src/serverGroup/configure/wizard/TitusCloneServerGroupModal.tsx
+++ b/app/scripts/modules/titus/src/serverGroup/configure/wizard/TitusCloneServerGroupModal.tsx
@@ -79,12 +79,12 @@ export class TitusCloneServerGroupModal extends React.Component<
     this.configureCommand();
   };
 
-  private onTaskComplete() {
+  private onTaskComplete = () => {
     this.props.application.serverGroups.refresh();
     this.props.application.serverGroups.onNextRefresh(null, this.onApplicationRefresh);
-  }
+  };
 
-  protected onApplicationRefresh(): void {
+  protected onApplicationRefresh = (): void => {
     if (this._isUnmounted) {
       return;
     }
@@ -117,7 +117,7 @@ export class TitusCloneServerGroupModal extends React.Component<
         ReactInjector.$state.go(transitionTo, newStateParams);
       }
     }
-  }
+  };
 
   private configureCommand = () => {
     const { command } = this.props;


### PR DESCRIPTION
We send `onTaskComplete` to the task monitor as a plain old function, so when the task completes, `this` is not what we want `this` to be.