### PR TITLE
fix(amazon): consider all target group names when creating new ones

### DIFF
--- a/app/scripts/modules/amazon/src/loadBalancer/configure/application/TargetGroups.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/application/TargetGroups.tsx
@@ -126,7 +126,7 @@ export class TargetGroups extends React.Component<ITargetGroupsProps, ITargetGro
       .takeUntil(this.destroy$)
       .subscribe(() => {
         app.getDataSource('loadBalancers').data.forEach((lb: IAmazonApplicationLoadBalancer) => {
-          if (lb.loadBalancerType === 'application') {
+          if (lb.loadBalancerType !== 'classic') {
             if (!loadBalancer || lb.name !== loadBalancer.name) {
               lb.targetGroups.forEach(targetGroup => {
                 targetGroupsByAccountAndRegion[lb.account] = targetGroupsByAccountAndRegion[lb.account] || {};

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/network/TargetGroups.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/network/TargetGroups.tsx
@@ -126,7 +126,7 @@ export class TargetGroups extends React.Component<ITargetGroupsProps, ITargetGro
       .takeUntil(this.destroy$)
       .subscribe(() => {
         app.getDataSource('loadBalancers').data.forEach((lb: IAmazonApplicationLoadBalancer) => {
-          if (lb.loadBalancerType === 'network') {
+          if (lb.loadBalancerType !== 'classic') {
             if (!loadBalancer || lb.name !== loadBalancer.name) {
               lb.targetGroups.forEach(targetGroup => {
                 targetGroupsByAccountAndRegion[lb.account] = targetGroupsByAccountAndRegion[lb.account] || {};


### PR DESCRIPTION
Turns out target groups are just target groups, and not specific to an NLB or ALB, so the names need to be unique across the two.