### PR TITLE
feat(amazon): show certificate upload/expiration when selected for lo…

### DIFF
--- a/app/scripts/modules/amazon/src/loadBalancer/configure/common/AmazonCertificateSelectField.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/common/AmazonCertificateSelectField.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import Select, { Option } from 'react-select';
-import { Application, Overridable } from '@spinnaker/core';
+import { Application, Overridable, timestamp, relativeTime } from '@spinnaker/core';
 
 import { IAmazonCertificate } from 'amazon/domain';
 
@@ -20,16 +20,27 @@ export class AmazonCertificateSelectField extends React.Component<IAmazonCertifi
     const certificateOptions = certificatesForAccount.map(cert => {
       return { label: cert.serverCertificateName, value: cert.serverCertificateName };
     });
+    const currentCert = certificatesForAccount.find(c => c.serverCertificateName === currentValue);
     return (
-      <Select
-        className="input-sm"
-        wrapperStyle={{ width: '100%' }}
-        clearable={true}
-        required={true}
-        options={certificateOptions}
-        onChange={(value: Option<string>) => onCertificateSelect(value.value)}
-        value={currentValue}
-      />
+      <div style={{ width: '100%' }}>
+        <Select
+          className="input-sm"
+          wrapperStyle={{ width: '100%' }}
+          clearable={true}
+          required={true}
+          options={certificateOptions}
+          onChange={(value: Option<string>) => onCertificateSelect(value.value)}
+          value={currentValue}
+        />
+        {currentCert && (
+          <div className="small sp-margin-xs-top sp-margin-m-bottom sp-margin-m-left">
+            <div>
+              Uploaded {relativeTime(currentCert.uploadDate)} ({timestamp(currentCert.uploadDate)})
+            </div>
+            <b>Expires {relativeTime(currentCert.expiration)}</b> ({timestamp(currentCert.expiration)})
+          </div>
+        )}
+      </div>
     );
   }
 }

--- a/app/scripts/modules/core/src/certificates/certificate.read.service.ts
+++ b/app/scripts/modules/core/src/certificates/certificate.read.service.ts
@@ -7,6 +7,7 @@ export interface ICertificate {
   path: string;
   serverCertificateId: string;
   serverCertificateName: string;
+  uploadDate: number;
 }
 
 export class CertificateReader {


### PR DESCRIPTION
…ad balancers

If there are multiple certificates with very long and very similar names, once selected, the name can be cut off, making it hard for users to have confidence that they've selected the right one.

This PR adds some helpful metadata when a certificate has been selected.
<img width="585" alt="Screen Shot 2019-03-20 at 9 31 06 PM" src="https://user-images.githubusercontent.com/73450/54733649-e784f880-4b57-11e9-8c55-680f655342b4.png">

