### PR TITLE
fix(provider/cf): Default clone stage to start on creation

### DIFF
--- a/app/scripts/modules/cloudfoundry/src/serverGroup/configure/serverGroupCommandBuilder.service.cf.ts
+++ b/app/scripts/modules/cloudfoundry/src/serverGroup/configure/serverGroupCommandBuilder.service.cf.ts
@@ -153,7 +153,7 @@ export class CloudFoundryServerGroupCommandBuilder {
       command.freeFormDetails = stage.freeFormDetails || command.freeFormDetails;
       command.maxRemainingAsgs = stage.maxRemainingAsgs;
       command.region = stage.region;
-      command.startApplication = stage.startApplication;
+      command.startApplication = stage.startApplication === undefined || stage.startApplication;
       command.stack = stage.stack || command.stack;
       command.strategy = stage.strategy;
       command.target = stage.target;


### PR DESCRIPTION
This is consistent with the Deploy operation and the Clone server group action which both start on creation by default.