### PR TITLE
feat(core): add markdown functionality to custom app banners

### DIFF
--- a/app/scripts/modules/core/src/application/config/customBanner/CustomBannerConfig.tsx
+++ b/app/scripts/modules/core/src/application/config/customBanner/CustomBannerConfig.tsx
@@ -9,6 +9,8 @@ import {
 } from 'core/application/config/customBanner/customBannerColors';
 
 import { noop } from 'core/utils';
+import { Markdown } from 'core/presentation/Markdown';
+import { HelpField } from 'core/help/HelpField';
 
 import './customBannerConfig.less';
 
@@ -180,6 +182,21 @@ export class CustomBannerConfig extends React.Component<ICustomBannerConfigProps
                       }}
                       value={banner.text}
                     />
+                    <div className="small text-right">
+                      Markdown is okay <HelpField id="markdown.examples" />
+                    </div>
+                    <div>
+                      <b>Preview</b>
+                      <div
+                        className="input-sm custom-banner-config-preview"
+                        style={{
+                          backgroundColor: banner.backgroundColor,
+                          color: banner.textColor,
+                        }}
+                      >
+                        <Markdown message={banner.text} />
+                      </div>
+                    </div>
                   </td>
                   <td>
                     <Select

--- a/app/scripts/modules/core/src/application/config/customBanner/customBannerConfig.less
+++ b/app/scripts/modules/core/src/application/config/customBanner/customBannerConfig.less
@@ -7,10 +7,15 @@
   margin-bottom: 10px;
 }
 
-.custom-banner-config-textarea {
+.custom-banner-config-textarea,
+.custom-banner-config-preview {
   resize: vertical;
   min-height: 50px;
   max-height: 150px;
+}
+
+.custom-banner-config-preview {
+  overflow-y: auto;
 }
 
 .custom-banner-config-color-option {

--- a/app/scripts/modules/core/src/header/customBanner/CustomBanner.tsx
+++ b/app/scripts/modules/core/src/header/customBanner/CustomBanner.tsx
@@ -3,6 +3,7 @@ import { get } from 'lodash';
 
 import { ICustomBannerConfig } from 'core/application/config/customBanner/CustomBannerConfig';
 import { ApplicationReader } from 'core/application/service/ApplicationReader';
+import { Markdown } from 'core/presentation/Markdown';
 import { ReactInjector } from 'core/reactShims';
 import { noop } from 'core/utils';
 
@@ -65,7 +66,7 @@ export class CustomBanner extends React.Component<{}, ICustomBannerState> {
           color: bannerConfig.textColor,
         }}
       >
-        {bannerConfig.text}
+        <Markdown message={bannerConfig.text} />
       </div>
     );
   }


### PR DESCRIPTION
- Based on the UI for Entity Tag editing, adds support for writing custom application banners in Markdown, allowing for formatted text and links.
- Example: ![appbannermarkdown](https://user-images.githubusercontent.com/15936279/54939498-22dc4a00-4eff-11e9-8b7e-5de46ae4fdc6.png)


