### PR TITLE
fix(trigger): add webhook to triggerTypes

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -235,6 +235,7 @@ window.spinnakerSettings = {
     'pipeline',
     'pubsub',
     'travis',
+    'webhook',
     'wercker',
   ],
   useClassicFirewallLabels: useClassicFirewallLabels,


### PR DESCRIPTION
`webhook` was missing from `triggerTypes` in `settings.js` (patched file) whereas [it was available in `halconfig/settings.js`](https://github.com/spinnaker/deck/blob/efcec9696f70153ea09c4b0763ee15466a40c563/halconfig/settings.js#L239). this brings parity (for `triggerTypes`) between these two configuration files.

for deployments without `halyard`, without this in `triggerTypes`, one cannot define `webhook` triggers in deck UI. even the ones which are already defined wouldn't be rendered properly.