### PR TITLE
fix(core/projects): Submit task against the 'spinnaker' application

### DIFF
--- a/app/scripts/modules/core/src/projects/service/ProjectWriter.ts
+++ b/app/scripts/modules/core/src/projects/service/ProjectWriter.ts
@@ -7,6 +7,7 @@ export class ProjectWriter {
   public static upsertProject(project: IProject): IPromise<ITask> {
     const descriptor = project.id ? 'Update' : 'Create';
     return TaskExecutor.executeTask({
+      application: 'spinnaker',
       job: [
         {
           type: 'upsertProject',
@@ -20,6 +21,7 @@ export class ProjectWriter {
 
   public static deleteProject(project: IProject): IPromise<ITask> {
     return TaskExecutor.executeTask({
+      application: 'spinnaker',
       job: [
         {
           type: 'deleteProject',


### PR DESCRIPTION
When orca is backed by SQL (not redis) there is a NOT NULL constraint on the `task.application` column.  We need to submit the task against some application. I've arbitrarily chosen 'spinnaker'.