### PR TITLE
refactor(titus): generalize ConfigBin and export it

### DIFF
--- a/app/scripts/modules/amazon/src/serverGroup/details/sections/ScalingPoliciesDetailsSection.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/details/sections/ScalingPoliciesDetailsSection.tsx
@@ -2,48 +2,32 @@ import * as React from 'react';
 
 import { CollapsibleSection, Overridable, Tooltip } from '@spinnaker/core';
 
-import { IScalingProcess } from 'amazon/domain';
+import { IAmazonServerGroupView, IScalingProcess } from 'amazon/domain';
 import { AwsNgReact } from 'amazon/reactShims';
 import { AutoScalingProcessService } from '../scalingProcesses/AutoScalingProcessService';
 
 import { IAmazonServerGroupDetailsSectionProps } from './IAmazonServerGroupDetailsSectionProps';
 import { CreateScalingPolicyButton } from '../scalingPolicy/CreateScalingPolicyButton';
 
-export interface IScalingPoliciesDetailsSectionState {
-  scalingPoliciesDisabled: boolean;
-}
-
 @Overridable('aws.serverGroup.ScalingPoliciesDetailsSection')
-export class ScalingPoliciesDetailsSection extends React.Component<
-  IAmazonServerGroupDetailsSectionProps,
-  IScalingPoliciesDetailsSectionState
-> {
+export class ScalingPoliciesDetailsSection extends React.Component<IAmazonServerGroupDetailsSectionProps> {
   constructor(props: IAmazonServerGroupDetailsSectionProps) {
     super(props);
-
-    this.state = this.getState(props);
   }
 
-  private getState(props: IAmazonServerGroupDetailsSectionProps): IScalingPoliciesDetailsSectionState {
-    const { serverGroup } = props;
-
+  public static arePoliciesDisabled(serverGroup: IAmazonServerGroupView): boolean {
     const autoScalingProcesses: IScalingProcess[] = AutoScalingProcessService.normalizeScalingProcesses(serverGroup);
-    const scalingPoliciesDisabled =
+    return (
       serverGroup.scalingPolicies.length > 0 &&
       autoScalingProcesses
         .filter(p => !p.enabled)
-        .some(p => ['Launch', 'Terminate', 'AlarmNotification'].includes(p.name));
-
-    return { scalingPoliciesDisabled };
-  }
-
-  public componentWillReceiveProps(nextProps: IAmazonServerGroupDetailsSectionProps): void {
-    this.setState(this.getState(nextProps));
+        .some(p => ['Launch', 'Terminate', 'AlarmNotification'].includes(p.name))
+    );
   }
 
   public render(): JSX.Element {
     const { app, serverGroup } = this.props;
-    const { scalingPoliciesDisabled } = this.state;
+    const scalingPoliciesDisabled = ScalingPoliciesDetailsSection.arePoliciesDisabled(serverGroup);
 
     const { ScalingPolicySummary } = AwsNgReact;
 

--- a/app/scripts/modules/titus/src/index.ts
+++ b/app/scripts/modules/titus/src/index.ts
@@ -2,3 +2,5 @@ export { TITUS_MODULE } from './titus.module';
 
 export * from './titus.settings';
 export * from './reactShims';
+export * from './serverGroup/details/scalingPolicy/configBin/ConfigBinLink';
+export * from './serverGroup/details/scalingPolicy/configBin/configBin.reader';

--- a/app/scripts/modules/titus/src/serverGroup/details/scalingPolicy/configBin/ConfigBinLink.tsx
+++ b/app/scripts/modules/titus/src/serverGroup/details/scalingPolicy/configBin/ConfigBinLink.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
+import { Application, HelpField } from '@spinnaker/core';
+
 import { IClusterConfig } from './configBin.reader';
 import { ConfigBinModal } from './ConfigBinModal';
-import { Application, HelpField } from '@spinnaker/core';
+import { IMetricOption } from './metricOptions';
 
 export interface IConfigBinLinkProps {
   application: Application;
@@ -11,7 +13,7 @@ export interface IConfigBinLinkProps {
   region: string;
   env: string;
   configUpdated: () => void;
-  linkText?: string;
+  cannedMetrics: IMetricOption[];
 }
 
 export interface IConfigBinLinkState {
@@ -36,12 +38,11 @@ export class ConfigBinLink extends React.Component<IConfigBinLinkProps, IConfigB
   };
 
   public render() {
-    const { config, awsAccountId, env, region, clusterName, application } = this.props;
-    const linkText = this.props.linkText || 'Configure available metrics';
+    const { config, awsAccountId, env, region, clusterName, application, cannedMetrics } = this.props;
     return (
       <div>
         <a className="clickable" onClick={this.showModal}>
-          {linkText}
+          Configure available metrics
         </a>{' '}
         <HelpField id="titus.configBin.metrics" />
         {this.state.modalOpen && (
@@ -53,6 +54,7 @@ export class ConfigBinLink extends React.Component<IConfigBinLinkProps, IConfigB
             region={region}
             showCallback={this.hideModal}
             clusterName={clusterName}
+            cannedMetrics={cannedMetrics}
           />
         )}
       </div>

--- a/app/scripts/modules/titus/src/serverGroup/details/scalingPolicy/configBin/CustomMetric.tsx
+++ b/app/scripts/modules/titus/src/serverGroup/details/scalingPolicy/configBin/CustomMetric.tsx
@@ -8,18 +8,9 @@ export interface ICustomMetricProps {
   metricRemoved: (metric: IClusterConfigExpression) => void;
 }
 
-export interface ICustomMetricState {
-  name: string;
-  uri: string;
-}
-
-export class CustomMetric extends React.Component<ICustomMetricProps, ICustomMetricState> {
+export class CustomMetric extends React.Component<ICustomMetricProps> {
   constructor(props: ICustomMetricProps) {
     super(props);
-    this.state = {
-      name: props.metric.metricName,
-      uri: props.metric.atlasUri,
-    };
   }
 
   private metricNameUpdated = (e: React.ChangeEvent<HTMLInputElement>): void => {

--- a/app/scripts/modules/titus/src/serverGroup/details/scalingPolicy/configBin/configBin.reader.ts
+++ b/app/scripts/modules/titus/src/serverGroup/details/scalingPolicy/configBin/configBin.reader.ts
@@ -16,9 +16,7 @@ export interface IClusterConfig {
 }
 
 export class ConfigBinService {
-  public getConfig(clusterName: string): IPromise<IClusterConfig> {
+  public static getConfig(clusterName: string): IPromise<IClusterConfig> {
     return API.one('configbin', 'cloudwatch-forwarding', clusterName).get();
   }
 }
-
-export const configBinService = new ConfigBinService();

--- a/app/scripts/modules/titus/src/serverGroup/details/scalingPolicy/configBin/configBinLink.component.ts
+++ b/app/scripts/modules/titus/src/serverGroup/details/scalingPolicy/configBin/configBinLink.component.ts
@@ -14,5 +14,6 @@ module(CONFIG_BIN_LINK_COMPONENT, []).component(
     'region',
     'env',
     'configUpdated',
+    'cannedMetrics',
   ]),
 );

--- a/app/scripts/modules/titus/src/serverGroup/details/scalingPolicy/configBin/metricOptions.ts
+++ b/app/scripts/modules/titus/src/serverGroup/details/scalingPolicy/configBin/metricOptions.ts
@@ -1,73 +1,21 @@
 export interface IMetricOption {
-  name: string;
+  metricName: string;
+  metric: string;
   description: string;
   units: string;
-  idDimensions?: string[];
 }
 
-export interface IMetricOptionGroup {
-  category: string;
-  options: IMetricOption[];
-}
-
-export const metricOptions: IMetricOptionGroup[] = [
+export const titusMetricOptions: IMetricOption[] = [
   {
-    category: 'CPU',
-    options: [
-      {
-        name: 'cgroup.cpu.processingCapacity',
-        description: 'Amount of processing time requested for the container.',
-        units: 'seconds/second',
-      },
-      {
-        name: 'cgroup.cpu.processingTime',
-        description: 'Amount of time spent processing code in the container.',
-        units: 'seconds/second',
-      },
-      {
-        name: 'cgroup.cpu.shares',
-        description: 'Number of shares configured for the job. The Titus scheduler treats each CPU core as 100 shares.',
-        units: 'num shares',
-      },
-      {
-        name: 'cgroup.cpu.usageTime',
-        description: 'Amount of time spent processing code in the container in either the system or user category.',
-        units: 'seconds/second',
-        idDimensions: ['system', 'user'],
-      },
-    ],
+    metric: 'name,cgroup.cpu.processingTime,:eq,100,:mul,name,cgroup.cpu.processingCapacity,:eq,:div',
+    metricName: 'cgroup.cpu.utilization',
+    description: 'Average CPU Utilization',
+    units: 'percent',
   },
   {
-    category: 'Memory',
-    options: [
-      {
-        name: 'cgroup.mem.failures',
-        description: 'Counter indicating an allocation failure occurred.',
-        units: 'failures/second',
-      },
-      {
-        name: 'cgroup.mem.limit',
-        description: 'Memory limit for the cgroup.',
-        units: 'bytes',
-      },
-      {
-        name: 'cgroup.mem.used',
-        description: 'Memory usage for the cgroup.',
-        units: 'bytes',
-      },
-      {
-        name: 'cgroup.mem.pageFaults',
-        description: `Counter indicating the number of times that a process of the cgroup triggered a "page fault" and a
-     "major fault", respectively.`,
-        units: 'faults/second',
-        idDimensions: ['minor', 'major'],
-      },
-      {
-        name: 'cgroup.mem.processUsage',
-        description: 'Amount of memory used by processes running in the cgroup.',
-        units: 'bytes',
-        idDimensions: ['cache', 'rss', 'rss_huge', 'mapped_file'],
-      },
-    ],
+    metric: 'name,ipc.server.call,:eq,statistic,count,:eq,:and,:avg',
+    metricName: 'ipc.throughputAverage',
+    description: 'Average Throughput (RPS) per node',
+    units: 'requests',
   },
 ];

--- a/app/scripts/modules/titus/src/serverGroup/details/serverGroupDetails.html
+++ b/app/scripts/modules/titus/src/serverGroup/details/serverGroupDetails.html
@@ -179,6 +179,7 @@
           cluster-name="serverGroup.cluster"
           region="serverGroup.region"
           env="ctrl.env"
+          canned-metrics="titusMetricOptions"
           config="configBinData"
           config-updated="addConfigBinData"
         ></config-bin-link>

--- a/app/scripts/modules/titus/src/serverGroup/details/serverGroupDetails.titus.controller.js
+++ b/app/scripts/modules/titus/src/serverGroup/details/serverGroupDetails.titus.controller.js
@@ -18,11 +18,12 @@ import { TitusReactInjector } from 'titus/reactShims';
 
 import { SCALING_POLICY_MODULE } from './scalingPolicy/scalingPolicy.module';
 
-import { configBinService } from './scalingPolicy/configBin/configBin.reader';
+import { ConfigBinService } from './scalingPolicy/configBin/configBin.reader';
 import { CONFIG_BIN_LINK_COMPONENT } from './scalingPolicy/configBin/configBinLink.component';
 
 import { TitusCloneServerGroupModal } from '../configure/wizard/TitusCloneServerGroupModal';
 import { TITUS_SECURITY_GROUPS_DETAILS } from './titusSecurityGroups.component';
+import { titusMetricOptions } from './scalingPolicy/configBin/metricOptions';
 
 module.exports = angular
   .module('spinnaker.serverGroup.details.titus.controller', [
@@ -65,6 +66,7 @@ module.exports = angular
       this.application = app;
 
       $scope.gateUrl = SETTINGS.gateUrl;
+      $scope.titusMetricOptions = titusMetricOptions;
 
       $scope.state = {
         loading: true,
@@ -126,8 +128,7 @@ module.exports = angular
 
       $scope.addConfigBinData = () => {
         const cluster = NameUtils.parseServerGroupName($scope.serverGroup.name).cluster;
-        configBinService
-          .getConfig(cluster)
+        ConfigBinService.getConfig(cluster)
           .then(config => {
             $scope.configBinData = config;
           })


### PR DESCRIPTION
We're going to start using ConfigBin (an internal service at Netflix) to forward Atlas metrics to Cloudwatch for AWS clusters. Currently, we're only using it for Titus.

Some minor refactoring to remove state in a few places, and to simplify some of the code matching existing metrics with canned ones, those are the friends we made along the way.