### PR TITLE
feat(templates): add Save button to export pipeline template json modal

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/actions/templateJson/ShowPipelineTemplateJsonModal.less
+++ b/app/scripts/modules/core/src/pipeline/config/actions/templateJson/ShowPipelineTemplateJsonModal.less
@@ -1,3 +1,11 @@
 .show-pipeline-template-json-modal__copy {
   margin-bottom: 5px;
 }
+
+.show-pipeline-template-json-modal__save-error {
+  color: var(--color-danger);
+}
+
+.show-pipeline-template-json-modal__saving-spinner {
+  justify-content: center;
+}

--- a/app/scripts/modules/core/src/pipeline/config/templates/PipelineTemplateWriter.ts
+++ b/app/scripts/modules/core/src/pipeline/config/templates/PipelineTemplateWriter.ts
@@ -1,0 +1,16 @@
+import { IPromise } from 'angular';
+import { $q } from 'ngimport';
+import { API } from 'core/api/ApiService';
+import { IPipelineTemplateV2 } from 'core/domain/IPipelineTemplateV2';
+
+export class PipelineTemplateWriter {
+  public static savePipelineTemplateV2(template: IPipelineTemplateV2): IPromise<any> {
+    return $q((resolve, reject) => {
+      API.one('v2')
+        .one('pipelineTemplates')
+        .one('create')
+        .post(template)
+        .then(resolve, reject);
+    });
+  }
+}

--- a/app/scripts/modules/core/src/pipeline/config/templates/v2/pipelineTemplateV2.service.ts
+++ b/app/scripts/modules/core/src/pipeline/config/templates/v2/pipelineTemplateV2.service.ts
@@ -30,4 +30,9 @@ export class PipelineTemplateV2Service {
   public static getUnsupportedCopy(task: string): string {
     return `${task} of templated v2 pipelines through the UI is unsupported. Use Spin CLI instead.`;
   }
+
+  public static idForTemplate(template: { id: string; digest?: string }): string {
+    const { id, digest = '' } = template;
+    return `${id}:${digest}`;
+  }
 }

--- a/app/scripts/modules/core/src/pipeline/config/templates/v2/pipelineTemplateV2.states.ts
+++ b/app/scripts/modules/core/src/pipeline/config/templates/v2/pipelineTemplateV2.states.ts
@@ -8,6 +8,16 @@ export const PIPELINE_TEMPLATES_V2_STATES_CONFIG = 'spinnaker.core.pipeline.temp
 module(PIPELINE_TEMPLATES_V2_STATES_CONFIG, [STATE_CONFIG_PROVIDER]).config([
   'stateConfigProvider',
   (stateConfigProvider: StateConfigProvider) => {
+    const pipelineTemplateDetail: INestedState = {
+      name: 'pipeline-templates-detail',
+      url: '/:templateId',
+      data: {
+        pageTitleMain: {
+          label: 'Pipeline Templates',
+        },
+      },
+    };
+
     const pipelineTemplatesList: INestedState = {
       name: 'pipeline-templates',
       url: '/pipeline-templates',
@@ -22,7 +32,9 @@ module(PIPELINE_TEMPLATES_V2_STATES_CONFIG, [STATE_CONFIG_PROVIDER]).config([
           label: 'Pipeline Templates',
         },
       },
+      children: [pipelineTemplateDetail],
     };
+
     if (SETTINGS.feature.managedPipelineTemplatesV2UI) {
       stateConfigProvider.addToRootState(pipelineTemplatesList);
     }


### PR DESCRIPTION
Fixes https://github.com/spinnaker/spinnaker/issues/4190

Adds a button to save a template directly from the pipeline export modal. Clicking the button saves the template and redirects the user to the templates screen where they can see their new template.

![mpt_save](https://user-images.githubusercontent.com/34253460/55094037-f30e7d00-508b-11e9-8282-68f4771a86b3.gif)
