### PR TITLE
chore(core): Bump version to 0.0.347

### DIFF
--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/core",
-  "version": "0.0.346",
+  "version": "0.0.347",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
### chore(core): Bump version to 0.0.347

65fbb679c66251db38e3db0ed62ce7f0c559ef1f fix(core): send application when paging via PagerDuty (#6764)


