### PR TITLE
fix(titus): send cloudProvider as a string to ConfigBinLink

### DIFF
--- a/app/scripts/modules/titus/src/serverGroup/details/serverGroupDetails.html
+++ b/app/scripts/modules/titus/src/serverGroup/details/serverGroupDetails.html
@@ -179,7 +179,7 @@
           cluster-name="serverGroup.cluster"
           region="serverGroup.region"
           env="ctrl.env"
-          cloud-provider="titus"
+          cloud-provider="'titus'"
         ></config-bin-link>
       </div>
     </collapsible-section>


### PR DESCRIPTION
angular2react makes it an object ref, derpity derp