### PR TITLE
chore(core): Bump version to 0.0.348

### DIFF
--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/core",
-  "version": "0.0.347",
+  "version": "0.0.348",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
### chore(core): Bump version to 0.0.348

ad8d504863f654a659dc7c82b97b1c1b7a61a7e0 feat(core): provide link when task/stage fails due to traffic guards (#6772)
d819cf3740f9341f66aee9c8cfa40eb01c404054 fix(core): make chaos monkey opt-in for new apps (#6766)


