### PR TITLE
fix(amazon): allow deletion of scaling policies without alarms

### DIFF
--- a/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/alarmBasedSummary.component.html
+++ b/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/alarmBasedSummary.component.html
@@ -1,4 +1,5 @@
 <span class="label label-default">{{ $ctrl.policy.policyType | robotToHuman | uppercase }}</span>
+
 <div ng-repeat="alarm in $ctrl.policy.alarms track by $index">
   <div
     uib-popover-template="$ctrl.popoverTemplate"
@@ -16,14 +17,19 @@
       {{ alarm.evaluationPeriods }} consecutive periods of {{ alarm.period }} seconds
     </div>
   </div>
-  <div class="actions text-right">
-    <button class="btn btn-xs btn-link" ng-click="$ctrl.editPolicy()">
-      <span class="glyphicon glyphicon-cog" uib-tooltip="Edit policy"></span>
-      <span class="sr-only">Edit policy</span>
-    </button>
-    <button class="btn btn-xs btn-link" ng-click="$ctrl.deletePolicy()">
-      <span class="glyphicon glyphicon-trash" uib-tooltip="Delete policy"></span>
-      <span class="sr-only">Delete policy</span>
-    </button>
-  </div>
+</div>
+
+<div ng-if="!$ctrl.policy.alarms.length">
+  <em>No alarms configured for this policy &mdash; it's safe to delete.</em>
+</div>
+
+<div class="actions text-right">
+  <button class="btn btn-xs btn-link" ng-click="$ctrl.editPolicy()" ng-if="$ctrl.policy.alarms.length">
+    <span class="glyphicon glyphicon-cog" uib-tooltip="Edit policy"></span>
+    <span class="sr-only">Edit policy</span>
+  </button>
+  <button class="btn btn-xs btn-link" ng-click="$ctrl.deletePolicy()">
+    <span class="glyphicon glyphicon-trash" uib-tooltip="Delete policy"></span>
+    <span class="sr-only">Delete policy</span>
+  </button>
 </div>

--- a/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/alarmBasedSummary.component.js
+++ b/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/alarmBasedSummary.component.js
@@ -54,7 +54,7 @@ module.exports = angular
           confirmationModalService.confirm({
             header: 'Really delete ' + this.policy.policyName + '?',
             buttonText: 'Delete scaling policy',
-            account: this.serverGroup.account,
+            account: this.policy.alarms.length ? this.serverGroup.account : null, // don't confirm if it's a junk policy
             provider: 'aws',
             taskMonitorConfig: taskMonitor,
             submitMethod: submitMethod,

--- a/app/scripts/modules/titus/src/help/titus.help.ts
+++ b/app/scripts/modules/titus/src/help/titus.help.ts
@@ -45,16 +45,6 @@ const helpContents: { [key: string]: string } = {
     'AWS Security Groups to assign to this service. Security groups are set only if <samp>Allocate IP?</samp> has been selected and are assigned to the Titus AWS Elastic Network Interface.',
   'titus.job.capacityGroup': 'Capacity Group will default to application name if not specified.',
   'titus.job.securityGroups': 'AWS Security Groups to assign to this job',
-  'titus.configBin.metrics': `
-      <p>Metrics must be forwarded from Atlas to Cloudwatch in order to use them in scaling policies. Metrics can be
-        forwarded via
-        the <a href="http://insight-docs.prod.netflix.net/atlas/autoscaling/#sending-custom-metrics" target="_blank">
-          Atlas Java Client
-        </a>, or via ConfigBin, which can be configured here.
-      <p>Additional information on metrics below can be found
-        in <a href="http://insight-docs.prod.netflix.net/glossary/cgroup-system/" target="_blank">the documentation</a>.
-      </p>
-  `,
   'titus.autoscaling.cooldown': `
       <p>The amount of time, in seconds, after a scaling activity completes where previous trigger-related scaling
         activities can influence future scaling events.</p>


### PR DESCRIPTION
You can't edit a policy with no alarm, so we might as well let you delete it. There's a slightly bigger question around why policies get into this state, but that's beyond the scope of Deck. In short, it happens when there is an error in Clouddriver copying a scaling policy: we create the new policy first, then we create the alarms; if something fails when creating the alarms (e.g. the Clouddriver instance gets terminated), we can end up here. This happens rarely but is something we should address.

Also removing an unused help field entry that has moved to our internal build.