### PR TITLE
fix(pipeline): Fix target impedance validator for clone server gro…

### DIFF
--- a/app/scripts/modules/cloudfoundry/src/pipeline/config/validation/cfTargetImpedance.validator.ts
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/config/validation/cfTargetImpedance.validator.ts
@@ -42,7 +42,7 @@ export class CfTargetImpedanceValidator implements IStageOrTriggerValidator {
           });
         } else if (
           toTest.type === 'cloneServerGroup' &&
-          toTest.targetCluster === stage.cluster &&
+          NameUtils.getClusterName(toTest.application, toTest.stack, toTest.freeFormDetails) === stage.cluster &&
           toTest.region === region
         ) {
           regionFound = true;

--- a/app/scripts/modules/core/src/pipeline/config/validation/targetImpedance.validator.ts
+++ b/app/scripts/modules/core/src/pipeline/config/validation/targetImpedance.validator.ts
@@ -42,7 +42,8 @@ export class TargetImpedanceValidator implements IStageOrTriggerValidator {
           });
         } else if (
           toTest.type === 'cloneServerGroup' &&
-          toTest['targetCluster'] === stage['cluster'] &&
+          NameUtils.getClusterName(toTest['application'], toTest['stack'], toTest['freeFormDetails']) ===
+            stage['cluster'] &&
           toTest['region'] === region
         ) {
           regionFound = true;


### PR DESCRIPTION
Previously, the comparison logic tested against clone server group's target cluster and not its _destination_.

Validation worked when the server group created at the end of clone operation had the same stack and detail as the source, but failed otherwise.

![image](https://user-images.githubusercontent.com/1697736/55267354-a1aeeb00-524f-11e9-9877-3bdd0c65fe9b.png)
