### PR TITLE
fix(core/pagerDuty): give appropriate app to PagerDutyWriter

### DIFF
--- a/app/scripts/modules/core/src/pagerDuty/PageModal.tsx
+++ b/app/scripts/modules/core/src/pagerDuty/PageModal.tsx
@@ -70,18 +70,23 @@ export class PageModal extends React.Component<IPageModalProps, IPageModalState>
   };
 
   public sendPage = (): void => {
+    const { applications, services } = this.props;
+    const defaultApp = new ApplicationModelBuilder().createStandaloneApplication('spinnaker');
+    const ownerApp = applications && applications.length === 1 ? applications[0] : defaultApp;
+
     const taskMonitor = new TaskMonitor({
-      application: new ApplicationModelBuilder().createStandaloneApplication('spinnaker'),
+      application: ownerApp,
       title: `Sending page to ${this.state.pageCount} policies`,
       modalInstance: TaskMonitor.modalInstanceEmulation(() => this.close()),
       onTaskComplete: () => this.props.closeCallback(true),
     });
 
     const submitMethod = () => {
-      const { applications, services } = this.props;
       const { subject, details } = this.state;
 
-      return PagerDutyWriter.sendPage(applications, services.map(s => s.integration_key), subject, { details });
+      return PagerDutyWriter.sendPage(applications, services.map(s => s.integration_key), subject, ownerApp, {
+        details,
+      });
     };
 
     taskMonitor.submit(submitMethod);

--- a/app/scripts/modules/core/src/pagerDuty/pagerDuty.write.service.ts
+++ b/app/scripts/modules/core/src/pagerDuty/pagerDuty.write.service.ts
@@ -21,6 +21,7 @@ export class PagerDutyWriter {
     applications: Application[],
     keys: string[],
     reason: string,
+    ownerApp: Application,
     details?: { [key: string]: any },
   ): IPromise<any> {
     const job = {
@@ -38,19 +39,15 @@ export class PagerDutyWriter {
     }
 
     const task = {
+      application: ownerApp,
       job: [job],
       description: 'Send Page',
     } as ITaskCommand;
-
-    // If only one application was passed in, assign ownership
-    if (applications && applications.length === 1) {
-      task.application = applications[0];
-    }
 
     return TaskExecutor.executeTask(task);
   }
 
   public static pageApplicationOwner(application: Application, reason: string, details?: string): IPromise<any> {
-    return this.sendPage([application], undefined, reason, { details });
+    return this.sendPage([application], undefined, reason, application, { details });
   }
 }


### PR DESCRIPTION
#6764 tried to make sure that `pageApplicationOwner` tasks always have an app attached to them (we now require them when using the SQL storage backend for Orca). Problem is, the actual task being passed to `TaskWriter` never got an application — just the `TaskMonitor` instance we were using to watch it. 

This does two things:
- Ensure that `PagerDutyWriter.sendPage` always has an app to tie to the task it submits
- Move the decision logic for which app to use out of `PagerDutyWriter` by asking for it explicitly in `sendPage`. We don't really have enough context inside that method to know which app out of the list of many, one, or none would be appropriate