### PR TITLE
fix(amazon): Added AWS/ApplicationELB namespace to cloudwatch namespaces

### DIFF
--- a/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/upsert/alarm/namespaces.ts
+++ b/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/upsert/alarm/namespaces.ts
@@ -1,4 +1,5 @@
 export const NAMESPACES = [
+  'AWS/ApplicationELB',
   'AWS/AutoScaling',
   'AWS/Billing',
   'AWS/CloudFront',


### PR DESCRIPTION
Added AWS/ApplicationELB namespace to the list of cloudwatch namespaces.