### PR TITLE
fix(kubernetes): show Deployment clusters in Find Artifacts from Reso…

### DIFF
--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/findArtifactsFromResource/findArtifactsFromResourceConfig.controller.ts
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/findArtifactsFromResource/findArtifactsFromResourceConfig.controller.ts
@@ -8,8 +8,8 @@ export class KubernetesV2FindArtifactsFromResourceConfigCtrl implements IControl
 
   public static $inject = ['$scope'];
   constructor(private $scope: IScope) {
+    this.application = this.$scope.$parent.application;
     if (this.$scope.stage.isNew) {
-      this.application = this.$scope.$parent.application;
       const defaultSelection: IManifestSelector = {
         location: '',
         account: '',


### PR DESCRIPTION
…urce stages

Closes secondary issue reported with https://github.com/spinnaker/spinnaker/issues/4205

- Previously, Deployment clusters were not available in the manifest selector cluster dropdown in Find Artifacts from Resource stages. This is because we were excluding any clusters of server groups with server group managers. I believe this is an artifact of previously only using the manifest selector component for traffic management stages, where Deployments are invalid.
- Makes sure the application is available on props of non-new Find Artifacts from Resource stages so that available clusters can be accurately derived when editing a stage.
- To do: refactor the bloated `ManifestSelector.tsx` into smaller, more manageable components, and add tests for each.