### PR TITLE
fix(provider/cf): Make expected artifacts selectable as clone manifests

### DIFF
--- a/app/scripts/modules/cloudfoundry/src/serverGroup/configure/serverGroupCommandBuilder.service.cf.ts
+++ b/app/scripts/modules/cloudfoundry/src/serverGroup/configure/serverGroupCommandBuilder.service.cf.ts
@@ -159,6 +159,13 @@ export class CloudFoundryServerGroupCommandBuilder {
       command.target = stage.target;
       command.targetCluster = stage.targetCluster;
       command.manifest = stage.manifest || command.manifest;
+
+      command.viewState = {
+        ...command.viewState,
+        pipeline,
+        stage,
+      };
+
       return command;
     });
   }


### PR DESCRIPTION
The clone dialog needs to have pipeline and stage state so that it can look up available expected artifacts at this point in the pipeline's execution.

cc / @ciberkleid

![image](https://user-images.githubusercontent.com/1697736/55373387-90bdde00-54ca-11e9-8274-23c93a412249.png)
