### PR TITLE
refactor(core): de-angularize ApplicationModelBuilder, fix project ex…

### DIFF
--- a/app/scripts/modules/amazon/src/instance/details/instance.details.controller.spec.js
+++ b/app/scripts/modules/amazon/src/instance/details/instance.details.controller.spec.js
@@ -1,4 +1,4 @@
-import { APPLICATION_MODEL_BUILDER, InstanceReader } from '@spinnaker/core';
+import { ApplicationModelBuilder, InstanceReader } from '@spinnaker/core';
 
 describe('Controller: awsInstanceDetailsCtrl', function() {
   var controller;
@@ -6,10 +6,10 @@ describe('Controller: awsInstanceDetailsCtrl', function() {
   var $q;
   var application;
 
-  beforeEach(window.module(require('./instance.details.controller').name, APPLICATION_MODEL_BUILDER));
+  beforeEach(window.module(require('./instance.details.controller').name));
 
   beforeEach(
-    window.inject(function($rootScope, $controller, _$q_, applicationModelBuilder) {
+    window.inject(function($rootScope, $controller, _$q_) {
       scope = $rootScope.$new();
       $q = _$q_;
 
@@ -24,7 +24,7 @@ describe('Controller: awsInstanceDetailsCtrl', function() {
         });
       };
 
-      application = applicationModelBuilder.createApplicationForTests(
+      application = ApplicationModelBuilder.createApplicationForTests(
         'app',
         { key: 'loadBalancers', lazy: true },
         { key: 'serverGroups', lazy: true },

--- a/app/scripts/modules/amazon/src/loadBalancer/details/loadBalancerDetails.controller.spec.ts
+++ b/app/scripts/modules/amazon/src/loadBalancer/details/loadBalancerDetails.controller.spec.ts
@@ -1,7 +1,7 @@
 import { IControllerService, IRootScopeService, mock } from 'angular';
 import { StateService } from '@uirouter/core';
 
-import { APPLICATION_MODEL_BUILDER, ApplicationModelBuilder, ISubnet } from '@spinnaker/core';
+import { ApplicationModelBuilder, ISubnet } from '@spinnaker/core';
 
 import { AWS_LOAD_BALANCER_DETAILS_CTRL, AwsLoadBalancerDetailsController } from './loadBalancerDetails.controller';
 
@@ -17,28 +17,21 @@ describe('Controller: LoadBalancerDetailsCtrl', function() {
     vpcId: '1',
   };
 
-  beforeEach(mock.module(APPLICATION_MODEL_BUILDER, AWS_LOAD_BALANCER_DETAILS_CTRL));
+  beforeEach(mock.module(AWS_LOAD_BALANCER_DETAILS_CTRL));
 
   beforeEach(
-    mock.inject(
-      (
-        $controller: IControllerService,
-        $rootScope: IRootScopeService,
-        _$state_: StateService,
-        applicationModelBuilder: ApplicationModelBuilder,
-      ) => {
-        $scope = $rootScope.$new();
-        $state = _$state_;
-        const app = applicationModelBuilder.createApplicationForTests('app', { key: 'loadBalancers', lazy: true });
-        app.loadBalancers.data.push(loadBalancer);
-        controller = $controller(AwsLoadBalancerDetailsController, {
-          $scope,
-          loadBalancer,
-          app,
-          $state,
-        });
-      },
-    ),
+    mock.inject(($controller: IControllerService, $rootScope: IRootScopeService, _$state_: StateService) => {
+      $scope = $rootScope.$new();
+      $state = _$state_;
+      const app = ApplicationModelBuilder.createApplicationForTests('app', { key: 'loadBalancers', lazy: true });
+      app.loadBalancers.data.push(loadBalancer);
+      controller = $controller(AwsLoadBalancerDetailsController, {
+        $scope,
+        loadBalancer,
+        app,
+        $state,
+      });
+    }),
   );
 
   it('should have an instantiated controller', function() {

--- a/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupConfiguration.service.spec.ts
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupConfiguration.service.spec.ts
@@ -2,7 +2,6 @@ import { mock, IQService, IScope, IRootScopeService } from 'angular';
 
 import {
   AccountService,
-  APPLICATION_MODEL_BUILDER,
   ApplicationModelBuilder,
   CacheInitializerService,
   LoadBalancerReader,
@@ -23,10 +22,9 @@ describe('Service: awsServerGroupConfiguration', function() {
     awsInstanceTypeService: any,
     cacheInitializer: CacheInitializerService,
     loadBalancerReader: LoadBalancerReader,
-    applicationModelBuilder: ApplicationModelBuilder,
     $scope: IScope;
 
-  beforeEach(mock.module(APPLICATION_MODEL_BUILDER, AWS_SERVER_GROUP_CONFIGURATION_SERVICE));
+  beforeEach(mock.module(AWS_SERVER_GROUP_CONFIGURATION_SERVICE));
 
   beforeEach(
     mock.inject(function(
@@ -36,7 +34,6 @@ describe('Service: awsServerGroupConfiguration', function() {
       _awsInstanceTypeService_: any,
       _cacheInitializer_: CacheInitializerService,
       _loadBalancerReader_: LoadBalancerReader,
-      _applicationModelBuilder_: ApplicationModelBuilder,
       $rootScope: IRootScopeService,
     ) {
       service = _awsServerGroupConfigurationService_;
@@ -45,7 +42,6 @@ describe('Service: awsServerGroupConfiguration', function() {
       awsInstanceTypeService = _awsInstanceTypeService_;
       cacheInitializer = _cacheInitializer_;
       loadBalancerReader = _loadBalancerReader_;
-      applicationModelBuilder = _applicationModelBuilder_;
       $scope = $rootScope.$new();
 
       this.allLoadBalancers = [
@@ -108,7 +104,7 @@ describe('Service: awsServerGroupConfiguration', function() {
       } as any;
 
       service.configureCommand(
-        applicationModelBuilder.createApplicationForTests('name', { key: 'loadBalancers', lazy: true }),
+        ApplicationModelBuilder.createApplicationForTests('name', { key: 'loadBalancers', lazy: true }),
         command,
       );
       $scope.$digest();

--- a/app/scripts/modules/azure/instance/details/instance.details.controller.spec.js
+++ b/app/scripts/modules/azure/instance/details/instance.details.controller.spec.js
@@ -1,4 +1,4 @@
-import { APPLICATION_MODEL_BUILDER, InstanceReader } from '@spinnaker/core';
+import { ApplicationModelBuilder, InstanceReader } from '@spinnaker/core';
 
 describe('Controller: azureInstanceDetailsCtrl', function() {
   var controller;
@@ -6,14 +6,14 @@ describe('Controller: azureInstanceDetailsCtrl', function() {
   var $q;
   var application;
 
-  beforeEach(window.module(require('./instance.details.controller').name, APPLICATION_MODEL_BUILDER));
+  beforeEach(window.module(require('./instance.details.controller').name));
 
   beforeEach(
-    window.inject(function($rootScope, $controller, _$q_, applicationModelBuilder) {
+    window.inject(function($rootScope, $controller, _$q_) {
       scope = $rootScope.$new();
       $q = _$q_;
 
-      application = applicationModelBuilder.createApplicationForTests(
+      application = ApplicationModelBuilder.createApplicationForTests(
         'app',
         { key: 'loadBalancers', lazy: true },
         { key: 'serverGroups', lazy: true },

--- a/app/scripts/modules/azure/loadBalancer/configure/createLoadBalancer.controller.spec.js
+++ b/app/scripts/modules/azure/loadBalancer/configure/createLoadBalancer.controller.spec.js
@@ -1,17 +1,17 @@
 'use strict';
 
-import { API, APPLICATION_MODEL_BUILDER } from '@spinnaker/core';
+import { API, ApplicationModelBuilder } from '@spinnaker/core';
 
 describe('Controller: azureCreateLoadBalancerCtrl', function() {
   var $http;
 
   // load the controller's module
-  beforeEach(window.module(require('./createLoadBalancer.controller').name, APPLICATION_MODEL_BUILDER));
+  beforeEach(window.module(require('./createLoadBalancer.controller').name));
 
   // Initialize the controller and a mock scope
   beforeEach(
-    window.inject(function($controller, $rootScope, applicationModelBuilder) {
-      const app = applicationModelBuilder.createApplicationForTests('app', { key: 'loadBalancers', lazy: true });
+    window.inject(function($controller, $rootScope) {
+      const app = ApplicationModelBuilder.createApplicationForTests('app', { key: 'loadBalancers', lazy: true });
       this.$scope = $rootScope.$new();
       this.ctrl = $controller('azureCreateLoadBalancerCtrl', {
         $scope: this.$scope,

--- a/app/scripts/modules/azure/loadBalancer/details/loadBalancerDetail.controller.spec.js
+++ b/app/scripts/modules/azure/loadBalancer/details/loadBalancerDetail.controller.spec.js
@@ -1,4 +1,4 @@
-import { APPLICATION_MODEL_BUILDER } from '@spinnaker/core';
+import { ApplicationModelBuilder } from '@spinnaker/core';
 
 describe('Controller: azureLoadBalancerDetailsCtrl', function() {
   var controller;
@@ -12,13 +12,13 @@ describe('Controller: azureLoadBalancerDetailsCtrl', function() {
     vpcId: '1',
   };
 
-  beforeEach(window.module(require('./loadBalancerDetail.controller').name, APPLICATION_MODEL_BUILDER));
+  beforeEach(window.module(require('./loadBalancerDetail.controller').name));
 
   beforeEach(
-    window.inject(function($controller, $rootScope, _$state_, applicationModelBuilder) {
+    window.inject(function($controller, $rootScope, _$state_) {
       $scope = $rootScope.$new();
       $state = _$state_;
-      let app = applicationModelBuilder.createApplicationForTests('app', { key: 'loadBalancers', lazy: true });
+      let app = ApplicationModelBuilder.createApplicationForTests('app', { key: 'loadBalancers', lazy: true });
       app.loadBalancers.data.push(loadBalancer);
       controller = $controller('azureLoadBalancerDetailsCtrl', {
         $scope: $scope,

--- a/app/scripts/modules/cloudfoundry/src/presentation/widgets/accountRegionClusterSelector/AccountRegionClusterSelector.spec.tsx
+++ b/app/scripts/modules/cloudfoundry/src/presentation/widgets/accountRegionClusterSelector/AccountRegionClusterSelector.spec.tsx
@@ -4,7 +4,6 @@ import { mount, shallow } from 'enzyme';
 
 import {
   Application,
-  APPLICATION_MODEL_BUILDER,
   ApplicationModelBuilder,
   ApplicationDataSource,
   IMoniker,
@@ -31,11 +30,11 @@ describe('<AccountRegionClusterSelector />', () => {
     } as IServerGroup;
   }
 
-  beforeEach(mock.module(APPLICATION_MODEL_BUILDER, REACT_MODULE));
+  beforeEach(mock.module(REACT_MODULE));
   beforeEach(
-    mock.inject(($rootScope: IScope, applicationModelBuilder: ApplicationModelBuilder) => {
+    mock.inject(($rootScope: IScope) => {
       $scope = $rootScope.$new();
-      application = applicationModelBuilder.createApplicationForTests('app', {
+      application = ApplicationModelBuilder.createApplicationForTests('app', {
         key: 'serverGroups',
         loaded: true,
         data: [

--- a/app/scripts/modules/core/src/application/application.model.spec.ts
+++ b/app/scripts/modules/core/src/application/application.model.spec.ts
@@ -1,7 +1,7 @@
 import { mock } from 'angular';
 
 import { Application } from './application.model';
-import { APPLICATION_MODEL_BUILDER, ApplicationModelBuilder } from './applicationModel.builder';
+import { ApplicationModelBuilder } from './applicationModel.builder';
 import { ApplicationDataSourceRegistry } from './service/ApplicationDataSourceRegistry';
 import { LOAD_BALANCER_DATA_SOURCE } from 'core/loadBalancer/loadBalancer.dataSource';
 import { SecurityGroupReader } from 'core/securityGroup/securityGroupReader.service';
@@ -11,24 +11,16 @@ import { SECURITY_GROUP_DATA_SOURCE } from 'core/securityGroup/securityGroup.dat
 import { IEntityTag, IEntityTags, IServerGroup, IInstanceCounts, ILoadBalancer } from 'core/domain';
 
 describe('Application Model', function() {
-  let application: Application;
-  let securityGroupReader: SecurityGroupReader,
+  let application: Application,
+    securityGroupReader: SecurityGroupReader,
     loadBalancerReader: any,
     clusterService: any,
     $q: ng.IQService,
-    $scope: ng.IScope,
-    applicationModelBuilder: ApplicationModelBuilder;
+    $scope: ng.IScope;
 
   beforeEach(() => ApplicationDataSourceRegistry.clearDataSources());
 
-  beforeEach(
-    mock.module(
-      SECURITY_GROUP_DATA_SOURCE,
-      SERVER_GROUP_DATA_SOURCE,
-      LOAD_BALANCER_DATA_SOURCE,
-      APPLICATION_MODEL_BUILDER,
-    ),
-  );
+  beforeEach(mock.module(SECURITY_GROUP_DATA_SOURCE, SERVER_GROUP_DATA_SOURCE, LOAD_BALANCER_DATA_SOURCE));
 
   beforeEach(
     mock.inject(function(
@@ -37,14 +29,12 @@ describe('Application Model', function() {
       _$q_: ng.IQService,
       _loadBalancerReader_: any,
       $rootScope: any,
-      _applicationModelBuilder_: ApplicationModelBuilder,
     ) {
       securityGroupReader = _securityGroupReader_;
       clusterService = _clusterService_;
       loadBalancerReader = _loadBalancerReader_;
       $q = _$q_;
       $scope = $rootScope.$new();
-      applicationModelBuilder = _applicationModelBuilder_;
     }),
   );
 
@@ -61,7 +51,7 @@ describe('Application Model', function() {
     ) {
       return $q.when(groupsByName || []);
     });
-    application = applicationModelBuilder.createApplicationForTests(
+    application = ApplicationModelBuilder.createApplicationForTests(
       'app',
       ...ApplicationDataSourceRegistry.getDataSources(),
     );

--- a/app/scripts/modules/core/src/application/application.state.provider.ts
+++ b/app/scripts/modules/core/src/application/application.state.provider.ts
@@ -80,16 +80,15 @@ export class ApplicationStateProvider implements IServiceProvider {
       resolve: {
         app: [
           '$stateParams',
-          'applicationModelBuilder',
-          ($stateParams: StateParams, applicationModelBuilder: ApplicationModelBuilder) => {
+          ($stateParams: StateParams) => {
             return ApplicationReader.getApplication($stateParams.application, false)
               .then(
                 (app: Application): Application => {
                   InferredApplicationWarningService.checkIfInferredAndWarn(app);
-                  return app || applicationModelBuilder.createNotFoundApplication($stateParams.application);
+                  return app || ApplicationModelBuilder.createNotFoundApplication($stateParams.application);
                 },
               )
-              .catch(() => applicationModelBuilder.createNotFoundApplication($stateParams.application));
+              .catch(() => ApplicationModelBuilder.createNotFoundApplication($stateParams.application));
           },
         ],
       },

--- a/app/scripts/modules/core/src/application/applicationModel.builder.ts
+++ b/app/scripts/modules/core/src/application/applicationModel.builder.ts
@@ -1,6 +1,3 @@
-import { module } from 'angular';
-import { ROBOT_TO_HUMAN_FILTER } from 'core/presentation/robotToHumanFilter/robotToHuman.filter';
-import { OVERRIDE_REGISTRY } from 'core/overrideRegistry';
 import { SchedulerFactory } from 'core/scheduler/SchedulerFactory';
 import { Application } from './application.model';
 
@@ -8,28 +5,20 @@ import { IDataSourceConfig } from './service/applicationDataSource';
 
 export class ApplicationModelBuilder {
   /** This is mostly used in tests */
-  public createApplicationForTests(name: string, ...dataSources: IDataSourceConfig[]): Application {
+  public static createApplicationForTests(name: string, ...dataSources: IDataSourceConfig[]): Application {
     return new Application(name, SchedulerFactory.createScheduler(), dataSources);
   }
 
-  public createStandaloneApplication(name: string): Application {
+  public static createStandaloneApplication(name: string): Application {
     const application = new Application(name, SchedulerFactory.createScheduler(), []);
     application.isStandalone = true;
     return application;
   }
 
-  public createNotFoundApplication(name: string): Application {
+  public static createNotFoundApplication(name: string): Application {
     const config: IDataSourceConfig = { key: 'serverGroups', lazy: true };
     const application = new Application(name, SchedulerFactory.createScheduler(), [config]);
     application.notFound = true;
     return application;
   }
 }
-
-export const APPLICATION_MODEL_BUILDER = 'spinnaker.core.application.model.builder';
-
-module(APPLICATION_MODEL_BUILDER, [
-  ROBOT_TO_HUMAN_FILTER,
-  OVERRIDE_REGISTRY,
-  require('@uirouter/angularjs').default,
-]).service('applicationModelBuilder', ApplicationModelBuilder);

--- a/app/scripts/modules/core/src/application/config/dataSources/applicationDataSourceEditor.component.spec.ts
+++ b/app/scripts/modules/core/src/application/config/dataSources/applicationDataSourceEditor.component.spec.ts
@@ -1,13 +1,12 @@
 import { mock } from 'angular';
 
 import { Application } from 'core/application/application.model';
-import { APPLICATION_MODEL_BUILDER, ApplicationModelBuilder } from 'core/application/applicationModel.builder';
+import { ApplicationModelBuilder } from 'core/application/applicationModel.builder';
 import { APPLICATION_DATA_SOURCE_EDITOR, DataSourceEditorController } from './applicationDataSourceEditor.component';
 import { ApplicationWriter } from 'core/application/service/ApplicationWriter';
 
 describe('Component: Application Data Source Editor', () => {
-  let applicationModelBuilder: ApplicationModelBuilder,
-    application: Application,
+  let application: Application,
     $componentController: ng.IComponentControllerService,
     ctrl: DataSourceEditorController,
     $q: ng.IQService,
@@ -22,17 +21,15 @@ describe('Component: Application Data Source Editor', () => {
     ctrl.$onInit();
   };
 
-  beforeEach(mock.module(APPLICATION_DATA_SOURCE_EDITOR, APPLICATION_MODEL_BUILDER));
+  beforeEach(mock.module(APPLICATION_DATA_SOURCE_EDITOR));
 
   beforeEach(
     mock.inject(
       (
-        _applicationModelBuilder_: ApplicationModelBuilder,
         _$componentController_: ng.IComponentControllerService,
         _$q_: ng.IQService,
         $rootScope: ng.IRootScopeService,
       ) => {
-        applicationModelBuilder = _applicationModelBuilder_;
         $componentController = _$componentController_;
         $q = _$q_;
         $scope = $rootScope.$new();
@@ -41,7 +38,7 @@ describe('Component: Application Data Source Editor', () => {
   );
 
   beforeEach(() => {
-    application = applicationModelBuilder.createApplicationForTests(
+    application = ApplicationModelBuilder.createApplicationForTests(
       'app',
       {
         key: 'optionalSource',

--- a/app/scripts/modules/core/src/application/listExtractor/AppListExtractor.spec.ts
+++ b/app/scripts/modules/core/src/application/listExtractor/AppListExtractor.spec.ts
@@ -1,15 +1,12 @@
-import { mock } from 'angular';
 import { IInstance, IServerGroup } from 'core/domain';
 import { Application } from '../application.model';
-import { APPLICATION_MODEL_BUILDER, ApplicationModelBuilder } from '../applicationModel.builder';
+import { ApplicationModelBuilder } from '../applicationModel.builder';
 import { AppListExtractor } from './AppListExtractor';
 import { IMoniker } from 'core/naming/IMoniker';
 
 describe('AppListExtractor', function() {
-  let applicationModelBuilder: ApplicationModelBuilder;
-
   const buildApplication = (serverGroups: any[] = []): Application => {
-    const application: Application = applicationModelBuilder.createApplicationForTests('app', {
+    const application: Application = ApplicationModelBuilder.createApplicationForTests('app', {
       key: 'serverGroups',
       lazy: true,
     });
@@ -21,14 +18,6 @@ describe('AppListExtractor', function() {
     const { id, availabilityZone } = instance;
     return { id, availabilityZone };
   };
-
-  beforeEach(mock.module(APPLICATION_MODEL_BUILDER));
-
-  beforeEach(
-    mock.inject((_applicationModelBuilder_: ApplicationModelBuilder) => {
-      applicationModelBuilder = _applicationModelBuilder_;
-    }),
-  );
 
   describe('Get Monikers from a list of applications', function() {
     it('should return a filtered list of monikers', function() {

--- a/app/scripts/modules/core/src/application/service/InferredApplicationWarningService.spec.ts
+++ b/app/scripts/modules/core/src/application/service/InferredApplicationWarningService.spec.ts
@@ -1,32 +1,20 @@
-import { mock } from 'angular';
-
 import Spy = jasmine.Spy;
 
 import { NotifierService } from 'core/widgets/notifier/notifier.service';
 
 import { InferredApplicationWarningService } from './InferredApplicationWarningService';
 import { Application } from '../application.model';
-import { APPLICATION_MODEL_BUILDER, ApplicationModelBuilder } from '../applicationModel.builder';
+import { ApplicationModelBuilder } from '../applicationModel.builder';
 
 describe('Service: inferredApplicationWarning', () => {
-  let applicationModelBuilder: ApplicationModelBuilder;
-
-  beforeEach(mock.module(APPLICATION_MODEL_BUILDER));
-
-  beforeEach(
-    mock.inject((_applicationModelBuilder_: ApplicationModelBuilder) => {
-      applicationModelBuilder = _applicationModelBuilder_;
-    }),
-  );
-
   describe('checkIfInferredAndWarn', () => {
     let configuredApp: Application, inferredApp: Application;
 
     beforeEach(function() {
-      configuredApp = applicationModelBuilder.createApplicationForTests('myConfiguredApp');
+      configuredApp = ApplicationModelBuilder.createApplicationForTests('myConfiguredApp');
       configuredApp.attributes.email = 'email@email.email';
 
-      inferredApp = applicationModelBuilder.createNotFoundApplication('myInferredApp');
+      inferredApp = ApplicationModelBuilder.createNotFoundApplication('myInferredApp');
 
       InferredApplicationWarningService.resetViewedApplications();
       spyOn(NotifierService, 'publish');

--- a/app/scripts/modules/core/src/chaosMonkey/chaosMonkeyExceptions.component.spec.ts
+++ b/app/scripts/modules/core/src/chaosMonkey/chaosMonkeyExceptions.component.spec.ts
@@ -2,15 +2,14 @@ import { mock, IComponentControllerService, IScope, IQService, IRootScopeService
 
 import { CHAOS_MONKEY_EXCEPTIONS_COMPONENT, ChaosMonkeyExceptionsController } from './chaosMonkeyExceptions.component';
 import { AccountService } from 'core/account/AccountService';
-import { APPLICATION_MODEL_BUILDER, ApplicationModelBuilder } from 'core/application/applicationModel.builder';
+import { ApplicationModelBuilder } from 'core/application/applicationModel.builder';
 import { ChaosMonkeyConfig } from 'core/chaosMonkey/chaosMonkeyConfig.component';
 
 describe('Controller: ChaosMonkeyExceptions', () => {
   let $componentController: IComponentControllerService,
     $ctrl: ChaosMonkeyExceptionsController,
     $scope: IScope,
-    $q: IQService,
-    applicationBuilder: ApplicationModelBuilder;
+    $q: IQService;
 
   const initializeController = (data: any) => {
     $ctrl = $componentController(
@@ -20,20 +19,14 @@ describe('Controller: ChaosMonkeyExceptions', () => {
     ) as ChaosMonkeyExceptionsController;
   };
 
-  beforeEach(mock.module(APPLICATION_MODEL_BUILDER, CHAOS_MONKEY_EXCEPTIONS_COMPONENT));
+  beforeEach(mock.module(CHAOS_MONKEY_EXCEPTIONS_COMPONENT));
 
   beforeEach(
     mock.inject(
-      (
-        _$componentController_: IComponentControllerService,
-        _$q_: IQService,
-        $rootScope: IRootScopeService,
-        _applicationModelBuilder_: ApplicationModelBuilder,
-      ) => {
+      (_$componentController_: IComponentControllerService, _$q_: IQService, $rootScope: IRootScopeService) => {
         $scope = $rootScope.$new();
         $componentController = _$componentController_;
         $q = _$q_;
-        applicationBuilder = _applicationModelBuilder_;
       },
     ),
   );
@@ -48,7 +41,7 @@ describe('Controller: ChaosMonkeyExceptions', () => {
       spyOn(AccountService, 'listAllAccounts').and.returnValue($q.when(accounts));
 
       initializeController(null);
-      $ctrl.application = applicationBuilder.createApplicationForTests('app', {
+      $ctrl.application = ApplicationModelBuilder.createApplicationForTests('app', {
         key: 'serverGroups',
         loader: () => $q.resolve([]),
         onLoad: (_app, data) => $q.resolve(data),

--- a/app/scripts/modules/core/src/cloudProvider/providerSelection/providerSelection.service.spec.ts
+++ b/app/scripts/modules/core/src/cloudProvider/providerSelection/providerSelection.service.spec.ts
@@ -1,4 +1,4 @@
-import { APPLICATION_MODEL_BUILDER, ApplicationModelBuilder } from 'core/application/applicationModel.builder';
+import { ApplicationModelBuilder } from 'core/application/applicationModel.builder';
 import { Application } from 'core/application/application.model';
 import { mock, IQService, IScope, IRootScopeService } from 'angular';
 import { IModalService } from 'angular-ui-bootstrap';
@@ -25,14 +25,11 @@ function fakeAccount(provider: string): IAccountDetails {
 }
 
 describe('providerSelectionService: API', () => {
-  beforeEach(mock.module(APPLICATION_MODEL_BUILDER, PROVIDER_SELECTION_SERVICE, require('angular-ui-bootstrap')));
+  beforeEach(mock.module(PROVIDER_SELECTION_SERVICE, require('angular-ui-bootstrap')));
 
   // required to ensure registry provider is available
-  let $q: IQService,
-    $scope: IScope,
-    $modal: IModalService,
-    providerService: ProviderSelectionService,
-    applicationBuilder: ApplicationModelBuilder;
+  let $q: IQService, $scope: IScope, $modal: IModalService, providerService: ProviderSelectionService;
+
   beforeEach(
     mock.inject(
       (
@@ -40,13 +37,11 @@ describe('providerSelectionService: API', () => {
         $rootScope: IRootScopeService,
         _$uibModal_: IModalService,
         _providerSelectionService_: ProviderSelectionService,
-        _applicationModelBuilder_: ApplicationModelBuilder,
       ) => {
         $q = _$q_;
         $scope = $rootScope.$new();
         $modal = _$uibModal_;
         providerService = _providerSelectionService_;
-        applicationBuilder = _applicationModelBuilder_;
       },
     ),
   );
@@ -79,7 +74,7 @@ describe('providerSelectionService: API', () => {
     accounts = [];
     delete SETTINGS.defaultProvider;
 
-    application = applicationBuilder.createApplicationForTests('app');
+    application = ApplicationModelBuilder.createApplicationForTests('app');
     application.attributes = { cloudProviders: 'testProvider' };
 
     config = {

--- a/app/scripts/modules/core/src/cloudProvider/skin.service.spec.ts
+++ b/app/scripts/modules/core/src/cloudProvider/skin.service.spec.ts
@@ -1,16 +1,13 @@
 import { IQService, IRootScopeService, IScope, mock } from 'angular';
-import { APPLICATION_MODEL_BUILDER, ApplicationModelBuilder } from 'core/application';
+import { ApplicationModelBuilder } from 'core/application';
 
 import { SkinService } from './skin.service';
 
 describe('Service: SkinService', () => {
-  let appBuilder: ApplicationModelBuilder, scope: IScope, $q: IQService;
-
-  beforeEach(mock.module(APPLICATION_MODEL_BUILDER));
+  let scope: IScope, $q: IQService;
 
   beforeEach(
-    mock.inject(($rootScope: IRootScopeService, _$q_: IQService, applicationModelBuilder: ApplicationModelBuilder) => {
-      appBuilder = applicationModelBuilder;
+    mock.inject(($rootScope: IRootScopeService, _$q_: IQService) => {
       scope = $rootScope.$new();
       $q = _$q_;
     }),
@@ -29,7 +26,7 @@ describe('Service: SkinService', () => {
     });
 
     it('uses available accounts to determine skin if possible', () => {
-      const app = appBuilder.createStandaloneApplication('myApp');
+      const app = ApplicationModelBuilder.createStandaloneApplication('myApp');
 
       SkinService.getInstanceSkin('appengine', 'my-instance-id', app).then(skin => {
         expect(skin).toEqual('v1');
@@ -42,7 +39,7 @@ describe('Service: SkinService', () => {
     });
 
     it('scrapes application server groups to determine skin if possible', () => {
-      const app = appBuilder.createApplicationForTests(
+      const app = ApplicationModelBuilder.createApplicationForTests(
         'myApp',
         {
           key: 'serverGroups',
@@ -71,7 +68,7 @@ describe('Service: SkinService', () => {
     });
 
     it('scrapes application load balancers to determine skin if possible', () => {
-      const app = appBuilder.createApplicationForTests(
+      const app = ApplicationModelBuilder.createApplicationForTests(
         'myApp',
         {
           key: 'loadBalancers',
@@ -99,7 +96,7 @@ describe('Service: SkinService', () => {
     });
 
     it("scrapes application load balancers' server groups to determine skin if possible", () => {
-      const app = appBuilder.createApplicationForTests(
+      const app = ApplicationModelBuilder.createApplicationForTests(
         'myApp',
         {
           key: 'loadBalancers',

--- a/app/scripts/modules/core/src/cluster/cluster.service.spec.ts
+++ b/app/scripts/modules/core/src/cluster/cluster.service.spec.ts
@@ -2,7 +2,7 @@ import { IHttpBackendService, mock } from 'angular';
 import { find } from 'lodash';
 
 import * as State from 'core/state';
-import { APPLICATION_MODEL_BUILDER, ApplicationModelBuilder } from 'core/application/applicationModel.builder';
+import { ApplicationModelBuilder } from 'core/application/applicationModel.builder';
 import { IInstanceCounts, IServerGroup } from 'core/domain';
 import { Application } from 'core/application/application.model';
 
@@ -13,7 +13,7 @@ import { SETTINGS } from 'core/config/settings';
 const ClusterState = State.ClusterState;
 
 describe('Service: Cluster', function() {
-  beforeEach(mock.module(CLUSTER_SERVICE, APPLICATION_MODEL_BUILDER));
+  beforeEach(mock.module(CLUSTER_SERVICE));
 
   let clusterService: ClusterService;
   let $http: IHttpBackendService;
@@ -33,30 +33,24 @@ describe('Service: Cluster', function() {
   });
 
   beforeEach(
-    mock.inject(
-      (
-        $httpBackend: IHttpBackendService,
-        _clusterService_: ClusterService,
-        applicationModelBuilder: ApplicationModelBuilder,
-      ) => {
-        $http = $httpBackend;
-        clusterService = _clusterService_;
+    mock.inject(($httpBackend: IHttpBackendService, _clusterService_: ClusterService) => {
+      $http = $httpBackend;
+      clusterService = _clusterService_;
 
-        application = applicationModelBuilder.createApplicationForTests(
-          'app',
-          { key: 'serverGroups' },
-          { key: 'runningExecutions' },
-          { key: 'runningTasks' },
-        );
-        application.getDataSource('serverGroups').data = [
-          { name: 'the-target', account: 'not-the-target', region: 'us-east-1' },
-          { name: 'the-target', account: 'test', region: 'not-the-target' },
-          { name: 'the-target', account: 'test', region: 'us-east-1' },
-          { name: 'not-the-target', account: 'test', region: 'us-east-1' },
-          { name: 'the-source', account: 'test', region: 'us-east-1' },
-        ];
-      },
-    ),
+      application = ApplicationModelBuilder.createApplicationForTests(
+        'app',
+        { key: 'serverGroups' },
+        { key: 'runningExecutions' },
+        { key: 'runningTasks' },
+      );
+      application.getDataSource('serverGroups').data = [
+        { name: 'the-target', account: 'not-the-target', region: 'us-east-1' },
+        { name: 'the-target', account: 'test', region: 'not-the-target' },
+        { name: 'the-target', account: 'test', region: 'us-east-1' },
+        { name: 'not-the-target', account: 'test', region: 'us-east-1' },
+        { name: 'the-source', account: 'test', region: 'us-east-1' },
+      ];
+    }),
   );
 
   describe('lazy cluster fetching', () => {

--- a/app/scripts/modules/core/src/cluster/filter/ClusterFilterService.spec.ts
+++ b/app/scripts/modules/core/src/cluster/filter/ClusterFilterService.spec.ts
@@ -2,7 +2,7 @@ import { mock } from 'angular';
 import * as _ from 'lodash';
 import { CLUSTER_SERVICE } from 'core/cluster/cluster.service';
 import { Application } from 'core/application/application.model';
-import { APPLICATION_MODEL_BUILDER, ApplicationModelBuilder } from 'core/application/applicationModel.builder';
+import { ApplicationModelBuilder } from 'core/application/applicationModel.builder';
 import * as State from 'core/state';
 
 const ClusterState = State.ClusterState;
@@ -14,19 +14,12 @@ describe('Service: clusterFilterService', function() {
   let clusterService: any;
   let applicationJSON: any;
   let groupedJSON: any;
-  let applicationModelBuilder: ApplicationModelBuilder;
   let application: Application;
 
   beforeEach(function() {
-    mock.module(APPLICATION_MODEL_BUILDER, CLUSTER_SERVICE, require('./mockApplicationData').name, 'ui.router');
-    mock.inject(function(
-      _applicationJSON_: any,
-      _groupedJSON_: any,
-      _clusterService_: any,
-      _applicationModelBuilder_: ApplicationModelBuilder,
-    ) {
+    mock.module(CLUSTER_SERVICE, require('./mockApplicationData').name, 'ui.router');
+    mock.inject(function(_applicationJSON_: any, _groupedJSON_: any, _clusterService_: any) {
       clusterService = _clusterService_;
-      applicationModelBuilder = _applicationModelBuilder_;
 
       applicationJSON = _applicationJSON_;
       groupedJSON = _groupedJSON_;
@@ -35,7 +28,7 @@ describe('Service: clusterFilterService', function() {
     });
 
     this.buildApplication = (json: any) => {
-      const app = applicationModelBuilder.createApplicationForTests('app', { key: 'serverGroups', lazy: true });
+      const app = ApplicationModelBuilder.createApplicationForTests('app', { key: 'serverGroups', lazy: true });
       if (json.serverGroups) {
         app.getDataSource('serverGroups').data = _.cloneDeep(json.serverGroups.data);
       }

--- a/app/scripts/modules/core/src/instance/details/multipleInstances.controller.spec.js
+++ b/app/scripts/modules/core/src/instance/details/multipleInstances.controller.spec.js
@@ -1,4 +1,4 @@
-import { APPLICATION_MODEL_BUILDER } from 'core/application/applicationModel.builder';
+import { ApplicationModelBuilder } from 'core/application/applicationModel.builder';
 import * as State from 'core/state';
 
 describe('Controller: MultipleInstances', function() {
@@ -7,14 +7,14 @@ describe('Controller: MultipleInstances', function() {
 
   beforeEach(() => State.initialize());
 
-  beforeEach(window.module(require('./multipleInstances.controller').name, APPLICATION_MODEL_BUILDER));
+  beforeEach(window.module(require('./multipleInstances.controller').name));
 
   beforeEach(
-    window.inject(function($rootScope, $controller, _$q_, applicationModelBuilder) {
+    window.inject(function($rootScope, $controller) {
       scope = $rootScope.$new();
 
       this.createController = function(serverGroups) {
-        let application = applicationModelBuilder.createApplicationForTests('app', { key: 'serverGroups', lazy: true });
+        let application = ApplicationModelBuilder.createApplicationForTests('app', { key: 'serverGroups', lazy: true });
         application.serverGroups.data = serverGroups;
         application.serverGroups.loaded = true;
         this.application = application;

--- a/app/scripts/modules/core/src/instance/instance.states.ts
+++ b/app/scripts/modules/core/src/instance/instance.states.ts
@@ -91,9 +91,8 @@ module(INSTANCE_STATES, [APPLICATION_STATE_PROVIDER, STATE_CONFIG_PROVIDER]).con
           },
         ],
         app: [
-          'applicationModelBuilder',
-          (applicationModelBuilder: ApplicationModelBuilder): Application => {
-            return applicationModelBuilder.createStandaloneApplication('(standalone instance)');
+          (): Application => {
+            return ApplicationModelBuilder.createStandaloneApplication('(standalone instance)');
           },
         ],
         overrides: () => {

--- a/app/scripts/modules/core/src/instance/instance.write.service.spec.ts
+++ b/app/scripts/modules/core/src/instance/instance.write.service.spec.ts
@@ -2,7 +2,7 @@ import { mock } from 'angular';
 
 import { IMultiInstanceGroup, INSTANCE_WRITE_SERVICE, InstanceWriter } from 'core/instance/instance.write.service';
 import { Application } from 'core/application/application.model';
-import { APPLICATION_MODEL_BUILDER, ApplicationModelBuilder } from '../application/applicationModel.builder';
+import { ApplicationModelBuilder } from '../application/applicationModel.builder';
 import { IInstance, IServerGroup } from 'core/domain';
 import * as State from 'core/state';
 
@@ -10,26 +10,18 @@ import { ServerGroupReader } from '../serverGroup/serverGroupReader.service';
 import { IJob, ITaskCommand, TaskExecutor } from '../task/taskExecutor';
 
 describe('Service: instance writer', function() {
-  let service: InstanceWriter, $q: ng.IQService, $scope: ng.IScope, applicationModelBuilder: ApplicationModelBuilder;
+  let service: InstanceWriter, $q: ng.IQService, $scope: ng.IScope;
 
   beforeEach(() => State.initialize());
 
-  beforeEach(mock.module(INSTANCE_WRITE_SERVICE, APPLICATION_MODEL_BUILDER));
+  beforeEach(mock.module(INSTANCE_WRITE_SERVICE));
 
   beforeEach(
-    mock.inject(
-      (
-        instanceWriter: InstanceWriter,
-        _$q_: ng.IQService,
-        $rootScope: ng.IRootScopeService,
-        _applicationModelBuilder_: ApplicationModelBuilder,
-      ) => {
-        service = instanceWriter;
-        $q = _$q_;
-        $scope = $rootScope.$new();
-        applicationModelBuilder = _applicationModelBuilder_;
-      },
-    ),
+    mock.inject((instanceWriter: InstanceWriter, _$q_: ng.IQService, $rootScope: ng.IRootScopeService) => {
+      service = instanceWriter;
+      $q = _$q_;
+      $scope = $rootScope.$new();
+    }),
   );
 
   describe('terminate and decrement server group', () => {
@@ -51,7 +43,7 @@ describe('Service: instance writer', function() {
         zone: 'a',
         launchTime: 2,
       };
-      const application: Application = applicationModelBuilder.createApplicationForTests('app', {
+      const application: Application = ApplicationModelBuilder.createApplicationForTests('app', {
         key: 'serverGroups',
         lazy: true,
       });
@@ -111,7 +103,7 @@ describe('Service: instance writer', function() {
     });
 
     it('only sends jobs for groups with instances', () => {
-      const application: Application = applicationModelBuilder.createApplicationForTests('app');
+      const application: Application = ApplicationModelBuilder.createApplicationForTests('app');
       addInstance(serverGroupB, {
         name: 'i-234',
         id: 'i-234',
@@ -143,7 +135,7 @@ describe('Service: instance writer', function() {
     });
 
     it('includes additional job properties for terminate and shrink', () => {
-      const application: Application = applicationModelBuilder.createApplicationForTests('app');
+      const application: Application = ApplicationModelBuilder.createApplicationForTests('app');
       addInstance(serverGroupA, {
         name: 'i-234',
         id: 'i-234',
@@ -177,7 +169,7 @@ describe('Service: instance writer', function() {
     });
 
     it('includes a useful descriptor on terminate instances', () => {
-      const application: Application = applicationModelBuilder.createApplicationForTests('app');
+      const application: Application = ApplicationModelBuilder.createApplicationForTests('app');
       addInstance(serverGroupA, {
         name: 'i-123',
         id: 'i-123',
@@ -203,7 +195,7 @@ describe('Service: instance writer', function() {
     });
 
     it('includes a useful descriptor on reboot instances', function() {
-      const application: Application = applicationModelBuilder.createApplicationForTests('app');
+      const application: Application = ApplicationModelBuilder.createApplicationForTests('app');
       addInstance(serverGroupA, {
         name: 'i-123',
         id: 'i-123',
@@ -229,7 +221,7 @@ describe('Service: instance writer', function() {
     });
 
     it('includes a useful descriptor on disable in discovery', function() {
-      const application: Application = applicationModelBuilder.createApplicationForTests('app');
+      const application: Application = ApplicationModelBuilder.createApplicationForTests('app');
       addInstance(serverGroupA, {
         name: 'i-123',
         id: 'i-123',
@@ -255,7 +247,7 @@ describe('Service: instance writer', function() {
     });
 
     it('includes a useful descriptor on enable in discovery', function() {
-      const application: Application = applicationModelBuilder.createApplicationForTests('app');
+      const application: Application = ApplicationModelBuilder.createApplicationForTests('app');
       addInstance(serverGroupA, {
         name: 'i-123',
         id: 'i-123',

--- a/app/scripts/modules/core/src/loadBalancer/LoadBalancersTag.spec.tsx
+++ b/app/scripts/modules/core/src/loadBalancer/LoadBalancersTag.spec.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { ReactWrapper, mount } from 'enzyme';
 
 import { Application } from 'core/application/application.model';
-import { APPLICATION_MODEL_BUILDER, ApplicationModelBuilder } from 'core/application/applicationModel.builder';
+import { ApplicationModelBuilder } from 'core/application/applicationModel.builder';
 import { ILoadBalancersTagProps } from './LoadBalancersTagWrapper';
 import { LoadBalancersTag } from './LoadBalancersTag';
 import { IServerGroup } from 'core/domain';
@@ -15,13 +15,11 @@ describe('<LoadBalancersTag />', () => {
 
   let $q: IQService, $scope: IScope, application: Application, component: ReactWrapper<ILoadBalancersTagProps, any>;
 
-  beforeEach(mock.module(APPLICATION_MODEL_BUILDER));
-
   beforeEach(
-    mock.inject((_$q_: IQService, $rootScope: IScope, applicationModelBuilder: ApplicationModelBuilder) => {
+    mock.inject((_$q_: IQService, $rootScope: IScope) => {
       $q = _$q_;
       $scope = $rootScope.$new();
-      application = applicationModelBuilder.createApplicationForTests('app', {
+      application = ApplicationModelBuilder.createApplicationForTests('app', {
         key: 'loadBalancers',
         loader: () => $q.resolve(application.loadBalancers.data),
         onLoad: (_app, data) => $q.resolve(data),

--- a/app/scripts/modules/core/src/loadBalancer/filter/LoadBalancerFilterService.spec.ts
+++ b/app/scripts/modules/core/src/loadBalancer/filter/LoadBalancerFilterService.spec.ts
@@ -1,7 +1,5 @@
-import { mock } from 'angular';
-
 import { Application } from 'core/application/application.model';
-import { APPLICATION_MODEL_BUILDER, ApplicationModelBuilder } from 'core/application/applicationModel.builder';
+import { ApplicationModelBuilder } from 'core/application/applicationModel.builder';
 import { ILoadBalancer, IServerGroup, ILoadBalancerGroup } from 'core/domain';
 import { LoadBalancerState } from 'core/state';
 
@@ -9,18 +7,14 @@ import { LoadBalancerState } from 'core/state';
 describe('Service: loadBalancerFilterService', function() {
   const debounceTimeout = 30;
 
-  let app: Application, resultJson: any, modelBuilder: ApplicationModelBuilder;
+  let app: Application, resultJson: any;
 
   beforeEach(() => {
-    mock.module(APPLICATION_MODEL_BUILDER);
-    mock.inject(function(applicationModelBuilder: ApplicationModelBuilder) {
-      modelBuilder = applicationModelBuilder;
-    });
     LoadBalancerState.filterModel.asFilterModel.groups = [];
   });
 
   beforeEach(function() {
-    app = modelBuilder.createApplicationForTests('app', { key: 'loadBalancers', lazy: true });
+    app = ApplicationModelBuilder.createApplicationForTests('app', { key: 'loadBalancers', lazy: true });
     app.getDataSource('loadBalancers').data = [
       {
         name: 'elb-1',

--- a/app/scripts/modules/core/src/pagerDuty/PageModal.tsx
+++ b/app/scripts/modules/core/src/pagerDuty/PageModal.tsx
@@ -71,7 +71,7 @@ export class PageModal extends React.Component<IPageModalProps, IPageModalState>
 
   public sendPage = (): void => {
     const { applications, services } = this.props;
-    const defaultApp = new ApplicationModelBuilder().createStandaloneApplication('spinnaker');
+    const defaultApp = ApplicationModelBuilder.createStandaloneApplication('spinnaker');
     const ownerApp = applications && applications.length === 1 ? applications[0] : defaultApp;
 
     const taskMonitor = new TaskMonitor({

--- a/app/scripts/modules/core/src/pipeline/config/actions/delete/deletePipelineModal.controller.spec.js
+++ b/app/scripts/modules/core/src/pipeline/config/actions/delete/deletePipelineModal.controller.spec.js
@@ -1,15 +1,15 @@
-import { APPLICATION_MODEL_BUILDER } from 'core/application/applicationModel.builder';
+import { ApplicationModelBuilder } from 'core/application/applicationModel.builder';
 import { PipelineConfigService } from 'core/pipeline/config/services/PipelineConfigService';
 
 describe('Controller: deletePipelineModal', function() {
   const angular = require('angular');
 
-  beforeEach(window.module(require('./delete.module').name, APPLICATION_MODEL_BUILDER));
+  beforeEach(window.module(require('./delete.module').name));
   beforeEach(
-    window.inject(function($controller, $rootScope, $log, $q, $state, applicationModelBuilder) {
+    window.inject(function($controller, $rootScope, $log, $q, $state) {
       this.$rootScope = $rootScope;
       this.$q = $q;
-      this.application = applicationModelBuilder.createApplicationForTests('app', {
+      this.application = ApplicationModelBuilder.createApplicationForTests('app', {
         key: 'pipelineConfigs',
         lazy: true,
         loader: () => this.$q.when(this.application.pipelineConfigs.data),

--- a/app/scripts/modules/core/src/pipeline/config/actions/rename/renamePipelineModal.controller.spec.js
+++ b/app/scripts/modules/core/src/pipeline/config/actions/rename/renamePipelineModal.controller.spec.js
@@ -1,16 +1,16 @@
-import { APPLICATION_MODEL_BUILDER } from 'core/application/applicationModel.builder';
+import { ApplicationModelBuilder } from 'core/application/applicationModel.builder';
 import { PipelineConfigService } from 'core/pipeline/config/services/PipelineConfigService';
 
 describe('Controller: renamePipelineModal', function() {
   const angular = require('angular');
 
-  beforeEach(window.module(require('./rename.module').name, APPLICATION_MODEL_BUILDER));
+  beforeEach(window.module(require('./rename.module').name));
 
   beforeEach(
-    window.inject(function($controller, $rootScope, $log, $q, applicationModelBuilder) {
+    window.inject(function($controller, $rootScope, $log, $q) {
       this.$q = $q;
       this.$rootScope = $rootScope;
-      this.application = applicationModelBuilder.createApplicationForTests('app', {
+      this.application = ApplicationModelBuilder.createApplicationForTests('app', {
         key: 'pipelineConfigs',
         lazy: true,
         loader: () => this.$q.when(this.application.pipelineConfigs.data),

--- a/app/scripts/modules/core/src/pipeline/config/pipelineConfig.controller.spec.js
+++ b/app/scripts/modules/core/src/pipeline/config/pipelineConfig.controller.spec.js
@@ -1,22 +1,20 @@
-import { APPLICATION_MODEL_BUILDER } from 'core/application/applicationModel.builder';
+import { ApplicationModelBuilder } from 'core/application/applicationModel.builder';
 
 describe('Controller: PipelineConfigCtrl', function() {
   var controller;
   var scope;
-  var applicationModelBuilder;
 
-  beforeEach(window.module(require('./pipelineConfig.controller').name, APPLICATION_MODEL_BUILDER));
+  beforeEach(window.module(require('./pipelineConfig.controller').name));
 
   beforeEach(
-    window.inject(function($rootScope, $controller, _applicationModelBuilder_) {
+    window.inject(function($rootScope, $controller) {
       scope = $rootScope.$new();
       controller = $controller;
-      applicationModelBuilder = _applicationModelBuilder_;
     }),
   );
 
   it('should initialize immediately if pipeline configs are already present', function() {
-    const application = applicationModelBuilder.createApplicationForTests('app', {
+    const application = ApplicationModelBuilder.createApplicationForTests('app', {
       key: 'pipelineConfigs',
       lazy: true,
     });
@@ -35,7 +33,7 @@ describe('Controller: PipelineConfigCtrl', function() {
   });
 
   it('should wait until pipeline configs are loaded before initializing', function() {
-    const application = applicationModelBuilder.createApplicationForTests('app', {
+    const application = ApplicationModelBuilder.createApplicationForTests('app', {
       key: 'pipelineConfigs',
       lazy: true,
     });

--- a/app/scripts/modules/core/src/pipeline/config/templates/configurePipelineTemplateModal.controller.spec.ts
+++ b/app/scripts/modules/core/src/pipeline/config/templates/configurePipelineTemplateModal.controller.spec.ts
@@ -5,7 +5,7 @@ import {
   ConfigurePipelineTemplateModalController,
 } from './configurePipelineTemplateModal.controller';
 import { IVariable } from './inputs/variableInput.service';
-import { APPLICATION_MODEL_BUILDER, ApplicationModelBuilder } from 'core/application/applicationModel.builder';
+import { ApplicationModelBuilder } from 'core/application/applicationModel.builder';
 import { Application } from 'core/application/application.model';
 import { PIPELINE_TEMPLATE_MODULE } from './pipelineTemplate.module';
 import { PipelineTemplateReader } from './PipelineTemplateReader';
@@ -74,39 +74,32 @@ describe('Controller: ConfigurePipelineTemplateModalCtrl', () => {
     ],
   };
 
-  beforeEach(mock.module(APPLICATION_MODEL_BUILDER, CONFIGURE_PIPELINE_TEMPLATE_MODAL_CTRL, PIPELINE_TEMPLATE_MODULE));
+  beforeEach(mock.module(CONFIGURE_PIPELINE_TEMPLATE_MODAL_CTRL, PIPELINE_TEMPLATE_MODULE));
 
   beforeEach(() => {
-    mock.inject(
-      (
-        $controller: ng.IControllerService,
-        $rootScope: ng.IRootScopeService,
-        _$q_: IQService,
-        applicationModelBuilder: ApplicationModelBuilder,
-      ) => {
-        application = applicationModelBuilder.createStandaloneApplication('app');
-        $scope = $rootScope.$new();
-        $q = _$q_;
-        ctrl = $controller('ConfigurePipelineTemplateModalCtrl', {
-          $scope,
-          application,
-          $uibModalInstance: { close: $q.resolve(null) },
-          pipelineTemplateConfig: {
-            config: {
-              pipeline: {
-                name: 'My Managed Pipeline',
-                template: {
-                  source: 'spinnaker://myPipelineId',
-                },
+    mock.inject(($controller: ng.IControllerService, $rootScope: ng.IRootScopeService, _$q_: IQService) => {
+      application = ApplicationModelBuilder.createStandaloneApplication('app');
+      $scope = $rootScope.$new();
+      $q = _$q_;
+      ctrl = $controller('ConfigurePipelineTemplateModalCtrl', {
+        $scope,
+        application,
+        $uibModalInstance: { close: $q.resolve(null) },
+        pipelineTemplateConfig: {
+          config: {
+            pipeline: {
+              name: 'My Managed Pipeline',
+              template: {
+                source: 'spinnaker://myPipelineId',
               },
             },
           },
-          pipelineId: '1234',
-          executionId: null,
-          isNew: true,
-        }) as ConfigurePipelineTemplateModalController;
-      },
-    );
+        },
+        pipelineId: '1234',
+        executionId: null,
+        isNew: true,
+      }) as ConfigurePipelineTemplateModalController;
+    });
   });
 
   describe('data initialization', () => {

--- a/app/scripts/modules/core/src/pipeline/create/CreatePipelineModal.spec.tsx
+++ b/app/scripts/modules/core/src/pipeline/create/CreatePipelineModal.spec.tsx
@@ -5,7 +5,7 @@ import { shallow } from 'enzyme';
 import { CreatePipelineModal, ICreatePipelineModalProps } from './CreatePipelineModal';
 import { PipelineTemplateReader } from 'core/pipeline/config/templates/PipelineTemplateReader';
 import { Application } from 'core/application/application.model';
-import { APPLICATION_MODEL_BUILDER, ApplicationModelBuilder } from 'core/application/applicationModel.builder';
+import { ApplicationModelBuilder } from 'core/application/applicationModel.builder';
 import { IPipeline } from 'core/domain';
 import { SETTINGS } from 'core/config/settings';
 import { PipelineConfigService } from 'core/pipeline/config/services/PipelineConfigService';
@@ -19,14 +19,12 @@ xdescribe('CreatePipelineModal', () => {
   let initializeComponent: (configs?: Array<Partial<IPipeline>>) => void;
   let component: CreatePipelineModal;
 
-  beforeEach(mock.module(APPLICATION_MODEL_BUILDER));
-
   beforeEach(
-    mock.inject((_$q_: IQService, $rootScope: IScope, applicationModelBuilder: ApplicationModelBuilder) => {
+    mock.inject((_$q_: IQService, $rootScope: IScope) => {
       $q = _$q_;
       $scope = $rootScope.$new();
       initializeComponent = (configs = []) => {
-        application = applicationModelBuilder.createApplicationForTests(
+        application = ApplicationModelBuilder.createApplicationForTests(
           'app',
           {
             key: 'pipelineConfigs',

--- a/app/scripts/modules/core/src/pipeline/executions/Executions.spec.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/Executions.spec.tsx
@@ -4,10 +4,12 @@ import { set } from 'lodash';
 import { IScope, ITimeoutService, mock, noop } from 'angular';
 
 import { Application } from 'core/application';
-import { APPLICATION_MODEL_BUILDER, ApplicationModelBuilder } from 'core/application/applicationModel.builder';
+import { ApplicationModelBuilder } from 'core/application/applicationModel.builder';
 import { INSIGHT_FILTER_STATE_MODEL } from 'core/insight/insightFilterState.model';
 import { REACT_MODULE, ReactInjector } from 'core/reactShims';
+import { OVERRIDE_REGISTRY } from 'core/overrideRegistry';
 import { ScrollToService } from 'core/utils';
+import * as State from 'core/state';
 import { IExecutionsProps, IExecutionsState, Executions } from './Executions';
 
 describe('<Executions/>', () => {
@@ -31,12 +33,13 @@ describe('<Executions/>', () => {
     component = mount(<Executions app={application} />);
   }
 
-  beforeEach(mock.module(APPLICATION_MODEL_BUILDER, INSIGHT_FILTER_STATE_MODEL, REACT_MODULE));
+  beforeEach(mock.module(INSIGHT_FILTER_STATE_MODEL, REACT_MODULE, OVERRIDE_REGISTRY));
   beforeEach(
-    mock.inject((_$timeout_: ITimeoutService, $rootScope: IScope, applicationModelBuilder: ApplicationModelBuilder) => {
+    mock.inject((_$timeout_: ITimeoutService, $rootScope: IScope) => {
+      State.initialize();
       scope = $rootScope.$new();
       $timeout = _$timeout_;
-      application = applicationModelBuilder.createApplicationForTests(
+      application = ApplicationModelBuilder.createApplicationForTests(
         'app',
         { key: 'executions', lazy: true },
         { key: 'pipelineConfigs', lazy: true },
@@ -46,7 +49,6 @@ describe('<Executions/>', () => {
 
   it('should not set loading flag to false until executions and pipeline configs have been loaded', function() {
     initializeApplication();
-
     expect(component.state().loading).toBe(true);
     application.executions.dataUpdated();
     application.pipelineConfigs.dataUpdated();

--- a/app/scripts/modules/core/src/pipeline/pipeline.dataSource.spec.ts
+++ b/app/scripts/modules/core/src/pipeline/pipeline.dataSource.spec.ts
@@ -1,21 +1,17 @@
 import { IQProvider, mock } from 'angular';
 
 import { Application } from 'core/application/application.model';
-import { APPLICATION_MODEL_BUILDER, ApplicationModelBuilder } from 'core/application/applicationModel.builder';
+import { ApplicationModelBuilder } from 'core/application/applicationModel.builder';
 import { ApplicationDataSourceRegistry } from '../application/service/ApplicationDataSourceRegistry';
 import { EXECUTION_SERVICE } from './service/execution.service';
 import { PipelineConfigService } from 'core/pipeline/config/services/PipelineConfigService';
 
 describe('Pipeline Data Source', function() {
-  let application: Application,
-    executionService: any,
-    $scope: ng.IScope,
-    applicationModelBuilder: ApplicationModelBuilder,
-    $q: ng.IQService;
+  let application: Application, executionService: any, $scope: ng.IScope, $q: ng.IQService;
 
   beforeEach(() => ApplicationDataSourceRegistry.clearDataSources());
 
-  beforeEach(mock.module(require('./pipeline.dataSource').name, EXECUTION_SERVICE, APPLICATION_MODEL_BUILDER));
+  beforeEach(mock.module(require('./pipeline.dataSource').name, EXECUTION_SERVICE));
 
   // https://docs.angularjs.org/guide/migration#migrate1.5to1.6-ng-services-$q
   beforeEach(
@@ -25,22 +21,16 @@ describe('Pipeline Data Source', function() {
   );
 
   beforeEach(
-    mock.inject(function(
-      _executionService_: any,
-      _$q_: ng.IQService,
-      $rootScope: ng.IRootScopeService,
-      _applicationModelBuilder_: ApplicationModelBuilder,
-    ) {
+    mock.inject(function(_executionService_: any, _$q_: ng.IQService, $rootScope: ng.IRootScopeService) {
       $q = _$q_;
       $scope = $rootScope.$new();
       executionService = _executionService_;
-      applicationModelBuilder = _applicationModelBuilder_;
     }),
   );
 
   function configureApplication() {
     ApplicationDataSourceRegistry.registerDataSource({ key: 'serverGroups' });
-    application = applicationModelBuilder.createApplicationForTests(
+    application = ApplicationModelBuilder.createApplicationForTests(
       'app',
       ...ApplicationDataSourceRegistry.getDataSources(),
     );

--- a/app/scripts/modules/core/src/projects/dashboard/dashboard.controller.js
+++ b/app/scripts/modules/core/src/projects/dashboard/dashboard.controller.js
@@ -3,6 +3,7 @@
 const angular = require('angular');
 import _ from 'lodash';
 
+import { ApplicationModelBuilder } from 'core/application/applicationModel.builder';
 import { EXECUTION_SERVICE } from 'core/pipeline/service/execution.service';
 import { RecentHistoryService } from 'core/history/recentHistory.service';
 import { SchedulerFactory } from 'core/scheduler/SchedulerFactory';
@@ -28,6 +29,7 @@ module.exports = angular
     '$q',
     function($scope, $rootScope, projectConfiguration, executionService, regionFilterService, $q) {
       this.project = projectConfiguration;
+      this.application = ApplicationModelBuilder.createStandaloneApplication('project');
 
       // These templates are almost identical, but it doesn't look like you can pass in a directive easily as a tooltip so
       // here they are

--- a/app/scripts/modules/core/src/projects/dashboard/dashboard.html
+++ b/app/scripts/modules/core/src/projects/dashboard/dashboard.html
@@ -29,7 +29,11 @@
       <div class="horizontal center" ng-if="!vm.state.executions.loaded">
         <loading-spinner size="'small'"></loading-spinner>
       </div>
-      <project-pipeline ng-repeat="execution in vm.executions" execution="execution"></project-pipeline>
+      <project-pipeline
+        ng-repeat="execution in vm.executions"
+        execution="execution"
+        application="vm.application"
+      ></project-pipeline>
       <h4 ng-if="!vm.project.config.pipelineConfigs.length">No pipelines configured</h4>
       <h4 ng-if="vm.state.executions.error">There was a problem loading the executions for this project.</h4>
     </div>

--- a/app/scripts/modules/core/src/projects/dashboard/pipeline/projectPipeline.component.ts
+++ b/app/scripts/modules/core/src/projects/dashboard/pipeline/projectPipeline.component.ts
@@ -4,4 +4,7 @@ import { react2angular } from 'react2angular';
 import { ProjectPipeline } from './ProjectPipeline';
 
 export const PROJECT_PIPELINE_COMPONENT = 'spinnaker.core.projects.dashboard.pipelines.projectPipeline.component';
-module(PROJECT_PIPELINE_COMPONENT, []).component('projectPipeline', react2angular(ProjectPipeline, ['execution']));
+module(PROJECT_PIPELINE_COMPONENT, []).component(
+  'projectPipeline',
+  react2angular(ProjectPipeline, ['execution', 'application']),
+);

--- a/app/scripts/modules/core/src/reactShims/react.injector.ts
+++ b/app/scripts/modules/core/src/reactShims/react.injector.ts
@@ -3,7 +3,6 @@ import IInjectorService = angular.auto.IInjectorService;
 
 import { StateParams, StateService, UIRouter } from '@uirouter/core';
 
-import { ApplicationModelBuilder } from '../application/applicationModel.builder';
 import { CacheInitializerService } from '../cache/cacheInitializer.service';
 import { ConfirmationModalService } from '../confirmationModal/confirmationModal.service';
 import { ExecutionDetailsSectionService } from 'core/pipeline/details/executionDetailsSection.service';
@@ -45,7 +44,6 @@ export class CoreReactInject extends ReactInject {
   public get $rootScope() { return this.$injector.get('$rootScope') as IScope; }
   public get $stateParams() { return this.$injector.get('$stateParams') as StateParams; }
   public get $uiRouter() { return this.$injector.get('$uiRouter') as UIRouter; }
-  public get applicationModelBuilder() { return this.$injector.get('applicationModelBuilder') as ApplicationModelBuilder; }
   public get cacheInitializer() { return this.$injector.get('cacheInitializer') as CacheInitializerService; }
   public get confirmationModalService() { return this.$injector.get('confirmationModalService') as ConfirmationModalService; }
   public get executionDetailsSectionService() { return this.$injector.get('executionDetailsSectionService') as ExecutionDetailsSectionService; }

--- a/app/scripts/modules/core/src/securityGroup/securityGroup.states.ts
+++ b/app/scripts/modules/core/src/securityGroup/securityGroup.states.ts
@@ -6,7 +6,6 @@ import {
   APPLICATION_STATE_PROVIDER,
   ApplicationStateProvider,
   Application,
-  APPLICATION_MODEL_BUILDER,
   ApplicationModelBuilder,
 } from 'core/application';
 import { SkinService } from 'core/cloudProvider';
@@ -17,7 +16,7 @@ import { filterModelConfig } from './filter/SecurityGroupFilterModel';
 import { SecurityGroupDetails } from './SecurityGroupDetails';
 
 export const SECURITY_GROUP_STATES = 'spinnaker.core.securityGroup.states';
-module(SECURITY_GROUP_STATES, [APPLICATION_STATE_PROVIDER, STATE_CONFIG_PROVIDER, APPLICATION_MODEL_BUILDER]).config([
+module(SECURITY_GROUP_STATES, [APPLICATION_STATE_PROVIDER, STATE_CONFIG_PROVIDER]).config([
   'applicationStateProvider',
   'stateConfigProvider',
   (applicationStateProvider: ApplicationStateProvider, stateConfigProvider: StateConfigProvider) => {
@@ -126,16 +125,11 @@ module(SECURITY_GROUP_STATES, [APPLICATION_STATE_PROVIDER, STATE_CONFIG_PROVIDER
         app: [
           '$stateParams',
           'securityGroupReader',
-          'applicationModelBuilder',
-          (
-            $stateParams: StateParams,
-            securityGroupReader: SecurityGroupReader,
-            applicationModelBuilder: ApplicationModelBuilder,
-          ): ng.IPromise<Application> => {
+          ($stateParams: StateParams, securityGroupReader: SecurityGroupReader): ng.IPromise<Application> => {
             // we need the application to have a firewall index (so rules get attached and linked properly)
             // and its name should just be the name of the firewall (so cloning works as expected)
             return securityGroupReader.loadSecurityGroups().then(securityGroupsIndex => {
-              const application: Application = applicationModelBuilder.createStandaloneApplication($stateParams.name);
+              const application: Application = ApplicationModelBuilder.createStandaloneApplication($stateParams.name);
               application['securityGroupsIndex'] = securityGroupsIndex; // TODO: refactor the securityGroupsIndex out
               return application;
             });

--- a/app/scripts/modules/core/src/securityGroup/securityGroupReader.service.spec.ts
+++ b/app/scripts/modules/core/src/securityGroup/securityGroupReader.service.spec.ts
@@ -2,7 +2,7 @@ import { mock } from 'angular';
 
 import { API } from 'core/api/ApiService';
 import { Application } from 'core/application/application.model';
-import { APPLICATION_MODEL_BUILDER, ApplicationModelBuilder } from 'core/application/applicationModel.builder';
+import { ApplicationModelBuilder } from 'core/application/applicationModel.builder';
 import { InfrastructureCaches } from 'core/cache';
 import { ISecurityGroup } from 'core/domain';
 import { ISecurityGroupDetail, SECURITY_GROUP_READER, SecurityGroupReader } from './securityGroupReader.service';
@@ -12,26 +12,20 @@ import {
 } from './securityGroupTransformer.service';
 
 describe('Service: securityGroupReader', function() {
-  let $q: ng.IQService,
-    $http: ng.IHttpBackendService,
-    $scope: ng.IRootScopeService,
-    applicationModelBuilder: ApplicationModelBuilder,
-    reader: SecurityGroupReader;
+  let $q: ng.IQService, $http: ng.IHttpBackendService, $scope: ng.IRootScopeService, reader: SecurityGroupReader;
 
-  beforeEach(mock.module(APPLICATION_MODEL_BUILDER, SECURITY_GROUP_TRANSFORMER_SERVICE, SECURITY_GROUP_READER));
+  beforeEach(mock.module(SECURITY_GROUP_TRANSFORMER_SERVICE, SECURITY_GROUP_READER));
   beforeEach(
     mock.inject(function(
       _$q_: ng.IQService,
       $httpBackend: ng.IHttpBackendService,
       $rootScope: ng.IRootScopeService,
-      _applicationModelBuilder_: ApplicationModelBuilder,
       _providerServiceDelegate_: any,
       securityGroupTransformer: SecurityGroupTransformerService,
       _securityGroupReader_: SecurityGroupReader,
     ) {
       reader = _securityGroupReader_;
       $http = $httpBackend;
-      applicationModelBuilder = _applicationModelBuilder_;
       $q = _$q_;
       $scope = $rootScope.$new();
 
@@ -55,7 +49,7 @@ describe('Service: securityGroupReader', function() {
   it('attaches load balancer to firewall usages', function() {
     let data: any[] = null;
 
-    const application: Application = applicationModelBuilder.createApplicationForTests(
+    const application: Application = ApplicationModelBuilder.createApplicationForTests(
       'app',
       {
         key: 'securityGroups',
@@ -103,7 +97,7 @@ describe('Service: securityGroupReader', function() {
 
   it('adds firewall names across accounts, falling back to the ID if none found', function() {
     let details: ISecurityGroupDetail = null;
-    const application: Application = applicationModelBuilder.createApplicationForTests('app');
+    const application: Application = ApplicationModelBuilder.createApplicationForTests('app');
     application['securityGroupsIndex'] = {
       test: { 'us-east-1': { 'sg-2': { name: 'matched' } } },
       prod: { 'us-east-1': { 'sg-2': { name: 'matched-prod' } } },
@@ -134,7 +128,7 @@ describe('Service: securityGroupReader', function() {
 
   it('should clear cache, then reload firewalls and try again if a firewall is not found', function() {
     let data: ISecurityGroup[] = null;
-    const application: Application = applicationModelBuilder.createApplicationForTests(
+    const application: Application = ApplicationModelBuilder.createApplicationForTests(
       'app',
       {
         key: 'securityGroups',

--- a/app/scripts/modules/core/src/serverGroup/configure/common/deployInitializer.component.spec.ts
+++ b/app/scripts/modules/core/src/serverGroup/configure/common/deployInitializer.component.spec.ts
@@ -3,13 +3,10 @@ import {
   DeployInitializerController,
   DEPLOY_INITIALIZER_COMPONENT,
 } from 'core/serverGroup/configure/common/deployInitializer.component';
-import { Application, ApplicationModelBuilder, APPLICATION_MODEL_BUILDER } from 'core/application';
+import { Application, ApplicationModelBuilder } from 'core/application';
 
 describe('Component: deployInitializer', () => {
-  let ctrl: DeployInitializerController,
-    $componentController: IComponentControllerService,
-    applicationModelBuilder: ApplicationModelBuilder,
-    application: Application;
+  let ctrl: DeployInitializerController, $componentController: IComponentControllerService, application: Application;
 
   const initialize = () => {
     ctrl = $componentController(
@@ -20,20 +17,17 @@ describe('Component: deployInitializer', () => {
     ctrl.$onInit();
   };
 
-  beforeEach(mock.module(DEPLOY_INITIALIZER_COMPONENT, APPLICATION_MODEL_BUILDER));
+  beforeEach(mock.module(DEPLOY_INITIALIZER_COMPONENT));
 
   beforeEach(
-    mock.inject(
-      (_applicationModelBuilder_: ApplicationModelBuilder, _$componentController_: IComponentControllerService) => {
-        applicationModelBuilder = _applicationModelBuilder_;
-        $componentController = _$componentController_;
-      },
-    ),
+    mock.inject((_$componentController_: IComponentControllerService) => {
+      $componentController = _$componentController_;
+    }),
   );
 
   describe('template initialization', () => {
     it('creates separate template options for each account and region of a cluster', () => {
-      application = applicationModelBuilder.createApplicationForTests('app', { key: 'serverGroups', lazy: true });
+      application = ApplicationModelBuilder.createApplicationForTests('app', { key: 'serverGroups', lazy: true });
       application.getDataSource('serverGroups').data = [
         {
           name: 'sg1',

--- a/app/scripts/modules/core/src/serverGroup/details/multipleServerGroups.controller.spec.js
+++ b/app/scripts/modules/core/src/serverGroup/details/multipleServerGroups.controller.spec.js
@@ -1,4 +1,4 @@
-import { APPLICATION_MODEL_BUILDER } from 'core/application/applicationModel.builder';
+import { ApplicationModelBuilder } from 'core/application/applicationModel.builder';
 import { ClusterState } from 'core/state';
 import * as State from 'core/state';
 
@@ -6,17 +6,17 @@ describe('Controller: MultipleServerGroups', function() {
   var controller;
   var scope;
 
-  beforeEach(window.module(require('./multipleServerGroups.controller').name, APPLICATION_MODEL_BUILDER));
+  beforeEach(window.module(require('./multipleServerGroups.controller').name));
 
   beforeEach(() => State.initialize());
 
   beforeEach(
-    window.inject(function($rootScope, $controller, _$q_, applicationModelBuilder) {
+    window.inject(function($rootScope, $controller) {
       scope = $rootScope.$new();
       ClusterState.filterModel.sortFilter.multiselect = true;
 
       this.createController = function(serverGroups) {
-        let application = applicationModelBuilder.createApplicationForTests('app', { key: 'serverGroups', lazy: true });
+        let application = ApplicationModelBuilder.createApplicationForTests('app', { key: 'serverGroups', lazy: true });
         application.serverGroups.data = serverGroups;
         application.serverGroups.loaded = true;
         this.application = application;

--- a/app/scripts/modules/core/src/serverGroup/details/serverGroupWarningMessage.service.spec.ts
+++ b/app/scripts/modules/core/src/serverGroup/details/serverGroupWarningMessage.service.spec.ts
@@ -1,21 +1,13 @@
-import { mock } from 'angular';
 import { ServerGroupWarningMessageService } from './serverGroupWarningMessage.service';
-import { ApplicationModelBuilder, APPLICATION_MODEL_BUILDER } from 'core/application/applicationModel.builder';
+import { ApplicationModelBuilder } from 'core/application/applicationModel.builder';
 import { IServerGroup } from 'core/domain';
 import { Application } from 'core/application/application.model';
 import { IConfirmationModalParams } from 'core/confirmationModal/confirmationModal.service';
 
 describe('ServerGroupWarningMessageService', () => {
-  let applicationModelBuilder: ApplicationModelBuilder, app: Application, serverGroup: IServerGroup;
+  let app: Application, serverGroup: IServerGroup;
 
-  beforeEach(mock.module(APPLICATION_MODEL_BUILDER));
-
-  beforeEach(
-    mock.inject((_applicationModelBuilder_: ApplicationModelBuilder) => {
-      applicationModelBuilder = _applicationModelBuilder_;
-      app = applicationModelBuilder.createApplicationForTests('app');
-    }),
-  );
+  beforeEach(() => (app = ApplicationModelBuilder.createApplicationForTests('app')));
 
   describe('addDestroyWarningMessage', () => {
     it('leaves parameters unchanged when additional server groups exist in cluster', () => {

--- a/app/scripts/modules/core/src/serverGroup/serverGroupWriter.service.spec.ts
+++ b/app/scripts/modules/core/src/serverGroup/serverGroupWriter.service.spec.ts
@@ -8,7 +8,7 @@ import {
 } from './configure/common/serverGroupCommandBuilder.service';
 import { ITaskCommand } from 'core/task/taskExecutor';
 import { Application } from 'core/application/application.model';
-import { APPLICATION_MODEL_BUILDER, ApplicationModelBuilder } from 'core/application/applicationModel.builder';
+import { ApplicationModelBuilder } from 'core/application/applicationModel.builder';
 import { ApplicationDataSourceRegistry } from 'core/application/service/ApplicationDataSourceRegistry';
 
 interface IApplicationTask {
@@ -20,23 +20,18 @@ class TestApplication extends Application {
 }
 
 describe('serverGroupWriter', function() {
-  let $httpBackend: ng.IHttpBackendService,
-    applicationModelBuilder: ApplicationModelBuilder,
-    serverGroupTransformer: any,
-    serverGroupWriter: ServerGroupWriter;
+  let $httpBackend: ng.IHttpBackendService, serverGroupTransformer: any, serverGroupWriter: ServerGroupWriter;
 
-  beforeEach(mock.module(APPLICATION_MODEL_BUILDER, SERVER_GROUP_WRITER));
+  beforeEach(mock.module(SERVER_GROUP_WRITER));
 
   beforeEach(function() {
     mock.inject(function(
       _serverGroupWriter_: ServerGroupWriter,
       _$httpBackend_: ng.IHttpBackendService,
-      _applicationModelBuilder_: ApplicationModelBuilder,
       _serverGroupTransformer_: any,
     ) {
       serverGroupWriter = _serverGroupWriter_;
       $httpBackend = _$httpBackend_;
-      applicationModelBuilder = _applicationModelBuilder_;
       serverGroupTransformer = _serverGroupTransformer_;
     });
   });
@@ -64,7 +59,7 @@ describe('serverGroupWriter', function() {
         })
         .respond(200, { ref: '/1' });
 
-      const application: TestApplication = applicationModelBuilder.createApplicationForTests(
+      const application: TestApplication = ApplicationModelBuilder.createApplicationForTests(
         'app',
         ...ApplicationDataSourceRegistry.getDataSources(),
       ) as TestApplication;
@@ -81,7 +76,7 @@ describe('serverGroupWriter', function() {
 
     let command: IServerGroupCommand;
     beforeEach(() => {
-      const application: Application = applicationModelBuilder.createApplicationForTests(
+      const application: Application = ApplicationModelBuilder.createApplicationForTests(
         'app',
         ...ApplicationDataSourceRegistry.getDataSources(),
       );

--- a/app/scripts/modules/core/src/task/monitor/taskMonitor.spec.ts
+++ b/app/scripts/modules/core/src/task/monitor/taskMonitor.spec.ts
@@ -7,25 +7,16 @@ import { API } from 'core/api/ApiService';
 import { ITask } from 'core/domain';
 import { TaskMonitor } from './TaskMonitor';
 import { OrchestratedItemTransformer } from 'core/orchestratedItem/orchestratedItem.transformer';
-import { APPLICATION_MODEL_BUILDER, ApplicationModelBuilder } from 'core/application/applicationModel.builder';
+import { ApplicationModelBuilder } from 'core/application/applicationModel.builder';
 
 describe('TaskMonitor', () => {
-  let $scope: ng.IScope, $http: ng.IHttpBackendService, applicationModelBuilder: ApplicationModelBuilder;
-
-  beforeEach(mock.module(APPLICATION_MODEL_BUILDER));
+  let $scope: ng.IScope, $http: ng.IHttpBackendService;
 
   beforeEach(
-    mock.inject(
-      (
-        $rootScope: ng.IRootScopeService,
-        $httpBackend: ng.IHttpBackendService,
-        _applicationModelBuilder_: ApplicationModelBuilder,
-      ) => {
-        $scope = $rootScope.$new();
-        $http = $httpBackend;
-        applicationModelBuilder = _applicationModelBuilder_;
-      },
-    ),
+    mock.inject(($rootScope: ng.IRootScopeService, $httpBackend: ng.IHttpBackendService) => {
+      $scope = $rootScope.$new();
+      $http = $httpBackend;
+    }),
   );
 
   describe('task submit', () => {
@@ -36,7 +27,7 @@ describe('TaskMonitor', () => {
 
       const operation = () => $q.when(task);
       const monitor = new TaskMonitor({
-        application: applicationModelBuilder.createApplicationForTests('app', { key: 'runningTasks', lazy: true }),
+        application: ApplicationModelBuilder.createApplicationForTests('app', { key: 'runningTasks', lazy: true }),
         title: 'some task',
         modalInstance: { result: $q.defer().promise } as IModalServiceInstance,
         onTaskComplete: () => (completeCalled = true),
@@ -69,7 +60,7 @@ describe('TaskMonitor', () => {
       const task = { failureMessage: 'it failed' };
       const operation = () => $q.reject(task);
       const monitor = new TaskMonitor({
-        application: applicationModelBuilder.createApplicationForTests('app', { key: 'runningTasks', lazy: true }),
+        application: ApplicationModelBuilder.createApplicationForTests('app', { key: 'runningTasks', lazy: true }),
         title: 'a task',
         modalInstance: { result: $q.defer().promise } as IModalServiceInstance,
         onTaskComplete: () => (completeCalled = true),
@@ -93,7 +84,7 @@ describe('TaskMonitor', () => {
 
       const operation = () => $q.when(task);
       const monitor = new TaskMonitor({
-        application: applicationModelBuilder.createApplicationForTests('app', { key: 'runningTasks', lazy: true }),
+        application: ApplicationModelBuilder.createApplicationForTests('app', { key: 'runningTasks', lazy: true }),
         title: 'a task',
         modalInstance: { result: $q.defer().promise } as IModalServiceInstance,
         onTaskComplete: () => (completeCalled = true),

--- a/app/scripts/modules/core/src/task/task.dataSource.spec.ts
+++ b/app/scripts/modules/core/src/task/task.dataSource.spec.ts
@@ -1,28 +1,27 @@
 import { mock, IQService } from 'angular';
 
 import { Application } from 'core/application/application.model';
-import { APPLICATION_MODEL_BUILDER, ApplicationModelBuilder } from 'core/application/applicationModel.builder';
+import { ApplicationModelBuilder } from 'core/application/applicationModel.builder';
 import { ApplicationDataSourceRegistry } from '../application/service/ApplicationDataSourceRegistry';
 import { TaskReader } from 'core/task/task.read.service';
 
 describe('Task Data Source', function() {
-  let application: Application, $scope: any, applicationModelBuilder: ApplicationModelBuilder, $q: IQService;
+  let application: Application, $scope: any, $q: IQService;
 
   beforeEach(() => ApplicationDataSourceRegistry.clearDataSources());
 
-  beforeEach(mock.module(require('./task.dataSource').name, APPLICATION_MODEL_BUILDER));
+  beforeEach(mock.module(require('./task.dataSource').name));
 
   beforeEach(
-    mock.inject(function(_$q_: any, $rootScope: any, _applicationModelBuilder_: any) {
+    mock.inject(function(_$q_: any, $rootScope: any) {
       $q = _$q_;
       $scope = $rootScope.$new();
-      applicationModelBuilder = _applicationModelBuilder_;
     }),
   );
 
   function configureApplication() {
     ApplicationDataSourceRegistry.registerDataSource({ key: 'serverGroups' });
-    application = applicationModelBuilder.createApplicationForTests(
+    application = ApplicationModelBuilder.createApplicationForTests(
       'app',
       ...ApplicationDataSourceRegistry.getDataSources(),
     );

--- a/app/scripts/modules/core/src/task/tasks.controller.spec.js
+++ b/app/scripts/modules/core/src/task/tasks.controller.spec.js
@@ -1,4 +1,4 @@
-import { APPLICATION_MODEL_BUILDER } from 'core/application/applicationModel.builder';
+import { ApplicationModelBuilder } from 'core/application/applicationModel.builder';
 import { TaskWriter } from './task.write.service';
 
 describe('Controller: tasks', function() {
@@ -6,14 +6,14 @@ describe('Controller: tasks', function() {
   var scope;
   var $q;
 
-  beforeEach(window.module(require('./tasks.controller').name, APPLICATION_MODEL_BUILDER));
+  beforeEach(window.module(require('./tasks.controller').name));
 
   beforeEach(
-    window.inject(function($controller, $rootScope, _$q_, applicationModelBuilder) {
+    window.inject(function($controller, $rootScope, _$q_) {
       $q = _$q_;
 
       this.initializeController = tasks => {
-        let application = applicationModelBuilder.createApplicationForTests('app', { key: 'tasks', lazy: true });
+        let application = ApplicationModelBuilder.createApplicationForTests('app', { key: 'tasks', lazy: true });
         application.tasks.activate = angular.noop;
         application.tasks.data = tasks || [];
         application.tasks.loaded = true;

--- a/app/scripts/modules/google/src/loadBalancer/configure/network/createLoadBalancer.controller.spec.js
+++ b/app/scripts/modules/google/src/loadBalancer/configure/network/createLoadBalancer.controller.spec.js
@@ -1,20 +1,20 @@
 'use strict';
 
-import { APPLICATION_MODEL_BUILDER, ModalWizard } from '@spinnaker/core';
+import { ApplicationModelBuilder, ModalWizard } from '@spinnaker/core';
 
 describe('Controller: gceCreateLoadBalancerCtrl', function() {
   const angular = require('angular');
 
   // load the controller's module
   beforeEach(function() {
-    window.module(require('./createLoadBalancer.controller').name, APPLICATION_MODEL_BUILDER);
+    window.module(require('./createLoadBalancer.controller').name);
   });
 
   // Initialize the controller and a mock scope
   beforeEach(
-    window.inject(function($controller, $rootScope, applicationModelBuilder) {
+    window.inject(function($controller, $rootScope) {
       this.$scope = $rootScope.$new();
-      const app = applicationModelBuilder.createApplicationForTests('app', { key: 'loadBalancers', lazy: true });
+      const app = ApplicationModelBuilder.createApplicationForTests('app', { key: 'loadBalancers', lazy: true });
       this.ctrl = $controller('gceCreateLoadBalancerCtrl', {
         $scope: this.$scope,
         $uibModalInstance: { dismiss: angular.noop, result: { then: angular.noop } },

--- a/app/scripts/modules/google/src/loadBalancer/details/loadBalancerDetail.controller.spec.js
+++ b/app/scripts/modules/google/src/loadBalancer/details/loadBalancerDetail.controller.spec.js
@@ -1,4 +1,4 @@
-import { APPLICATION_MODEL_BUILDER } from '@spinnaker/core';
+import { ApplicationModelBuilder } from '@spinnaker/core';
 
 describe('Controller: LoadBalancerDetailsCtrl', function() {
   //NOTE: This is just a skeleton test to test DI.  Please add more tests.;
@@ -14,13 +14,13 @@ describe('Controller: LoadBalancerDetailsCtrl', function() {
     vpcId: '1',
   };
 
-  beforeEach(window.module(require('./loadBalancerDetail.controller').name, APPLICATION_MODEL_BUILDER));
+  beforeEach(window.module(require('./loadBalancerDetail.controller').name));
 
   beforeEach(
-    window.inject(function($controller, $rootScope, _$state_, applicationModelBuilder) {
+    window.inject(function($controller, $rootScope, _$state_) {
       $scope = $rootScope.$new();
       $state = _$state_;
-      const app = applicationModelBuilder.createApplicationForTests('app', { key: 'loadBalancers', lazy: true });
+      const app = ApplicationModelBuilder.createApplicationForTests('app', { key: 'loadBalancers', lazy: true });
       app.loadBalancers.data.push(loadBalancer);
       controller = $controller('gceLoadBalancerDetailsCtrl', {
         $scope: $scope,

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/ManifestCopier.spec.ts
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/ManifestCopier.spec.ts
@@ -1,19 +1,17 @@
 import { IQService, IScope, mock } from 'angular';
 
-import { ApplicationModelBuilder, Application, noop, APPLICATION_MODEL_BUILDER } from '@spinnaker/core';
+import { ApplicationModelBuilder, Application, noop } from '@spinnaker/core';
 import { ManifestCopier } from './ManifestCopier';
 
 describe('<ManifestCopier />', () => {
   let application: Application;
 
-  beforeEach(mock.module(APPLICATION_MODEL_BUILDER));
-
   beforeEach(
-    mock.inject(($q: IQService, $rootScope: IScope, applicationModelBuilder: ApplicationModelBuilder) => {
+    mock.inject(($q: IQService, $rootScope: IScope) => {
       const $scope = $rootScope.$new();
       // The application model implicitly depends on a bunch of Angular things, which is why
       // we need the Angular mock environment (even though we're testing a React component).
-      application = applicationModelBuilder.createApplicationForTests(
+      application = ApplicationModelBuilder.createApplicationForTests(
         'app',
         {
           key: 'serverGroups',

--- a/app/scripts/modules/openstack/src/loadBalancer/configure/wizard/upsert.controller.spec.js
+++ b/app/scripts/modules/openstack/src/loadBalancer/configure/wizard/upsert.controller.spec.js
@@ -2,18 +2,18 @@
 
 import _ from 'lodash';
 
-import { AccountService, LoadBalancerWriter, APPLICATION_MODEL_BUILDER } from '@spinnaker/core';
+import { AccountService, LoadBalancerWriter, ApplicationModelBuilder } from '@spinnaker/core';
 
 import { OpenStackProviderSettings } from '../../../openstack.settings';
 
 describe('Controller: openstackCreateLoadBalancerCtrl', function() {
   // load the controller's module
-  beforeEach(window.module(require('./upsert.controller').name, APPLICATION_MODEL_BUILDER));
+  beforeEach(window.module(require('./upsert.controller').name));
 
   // Initialize the controller and a mock scope
   var testSuite;
   beforeEach(
-    window.inject(function($controller, $rootScope, $q, applicationModelBuilder) {
+    window.inject(function($controller, $rootScope, $q) {
       testSuite = this;
 
       this.loadBalancerDefaults = {
@@ -102,7 +102,7 @@ describe('Controller: openstackCreateLoadBalancerCtrl', function() {
         result: $q.when(null),
       };
 
-      this.mockApplication = applicationModelBuilder.createApplicationForTests('app', {
+      this.mockApplication = ApplicationModelBuilder.createApplicationForTests('app', {
         key: 'loadBalancers',
         lazy: false,
         loader: () => $q.resolve(_.clone(this.testData.loadBalancerList)),

--- a/app/scripts/modules/openstack/src/securityGroup/configure/wizard/upsert.controller.spec.js
+++ b/app/scripts/modules/openstack/src/securityGroup/configure/wizard/upsert.controller.spec.js
@@ -1,17 +1,17 @@
-import { AccountService, APPLICATION_MODEL_BUILDER, SecurityGroupWriter } from '@spinnaker/core';
+import { AccountService, ApplicationModelBuilder, SecurityGroupWriter } from '@spinnaker/core';
 
 import { OpenStackProviderSettings } from '../../../openstack.settings';
 
 describe('Controller: openstackCreateSecurityGroupCtrl', function() {
   // load the controller's module
-  beforeEach(window.module(require('./upsert.controller').name, APPLICATION_MODEL_BUILDER));
+  beforeEach(window.module(require('./upsert.controller').name));
 
   afterEach(OpenStackProviderSettings.resetToOriginal);
 
   // Initialize the controller and a mock scope
   var testSuite;
   beforeEach(
-    window.inject(function($controller, $rootScope, $q, applicationModelBuilder) {
+    window.inject(function($controller, $rootScope, $q) {
       testSuite = this;
       OpenStackProviderSettings.defaults.account = 'account1';
 
@@ -65,7 +65,7 @@ describe('Controller: openstackCreateSecurityGroupCtrl', function() {
         close: jasmine.createSpy(),
         result: $q.when(null),
       };
-      let application = applicationModelBuilder.createApplicationForTests('app', {
+      let application = ApplicationModelBuilder.createApplicationForTests('app', {
         key: 'securityGroups',
         onLoad: angular.noop,
         loader: angular.noop,

--- a/app/scripts/modules/oracle/src/loadBalancer/configure/createLoadBalancer.controller.spec.ts
+++ b/app/scripts/modules/oracle/src/loadBalancer/configure/createLoadBalancer.controller.spec.ts
@@ -1,7 +1,7 @@
 import { IControllerService, IRootScopeService, IScope, mock, noop } from 'angular';
 import { StateService } from '@uirouter/core';
 
-import { API, APPLICATION_MODEL_BUILDER, ApplicationModelBuilder } from '@spinnaker/core';
+import { API, ApplicationModelBuilder } from '@spinnaker/core';
 
 import { ORACLE_LOAD_BALANCER_CREATE_CONTROLLER, OracleLoadBalancerController } from './createLoadBalancer.controller';
 import {
@@ -18,40 +18,33 @@ describe('Controller: oracleCreateLoadBalancerCtrl', function() {
   let $scope: IScope;
   let $state: StateService;
 
-  beforeEach(mock.module(APPLICATION_MODEL_BUILDER, ORACLE_LOAD_BALANCER_CREATE_CONTROLLER));
+  beforeEach(mock.module(ORACLE_LOAD_BALANCER_CREATE_CONTROLLER));
 
   // Initialize the controller and a mock scope
   beforeEach(
-    mock.inject(
-      (
-        $controller: IControllerService,
-        $rootScope: IRootScopeService,
-        _$state_: StateService,
-        applicationModelBuilder: ApplicationModelBuilder,
-      ) => {
-        $scope = $rootScope.$new();
-        $state = _$state_;
-        const application = applicationModelBuilder.createApplicationForTests('app', {
-          key: 'loadBalancers',
-          lazy: true,
-        });
+    mock.inject(($controller: IControllerService, $rootScope: IRootScopeService, _$state_: StateService) => {
+      $scope = $rootScope.$new();
+      $state = _$state_;
+      const application = ApplicationModelBuilder.createApplicationForTests('app', {
+        key: 'loadBalancers',
+        lazy: true,
+      });
 
-        const isNew = true;
-        controller = $controller(OracleLoadBalancerController, {
-          $scope,
-          $uibModalInstance: { dismiss: noop, result: { then: noop } },
-          loadBalancer,
-          application,
-          $state,
-          isNew,
-        });
-        controller.addBackendSet();
-        controller.addListener();
-        controller.addCert();
+      const isNew = true;
+      controller = $controller(OracleLoadBalancerController, {
+        $scope,
+        $uibModalInstance: { dismiss: noop, result: { then: noop } },
+        loadBalancer,
+        application,
+        $state,
+        isNew,
+      });
+      controller.addBackendSet();
+      controller.addListener();
+      controller.addCert();
 
-        controller.listeners[0].defaultBackendSetName = controller.backendSets[0].name;
-      },
-    ),
+      controller.listeners[0].defaultBackendSetName = controller.backendSets[0].name;
+    }),
   );
 
   beforeEach(

--- a/app/scripts/modules/oracle/src/loadBalancer/configure/createLoadBalancer.controller.ts
+++ b/app/scripts/modules/oracle/src/loadBalancer/configure/createLoadBalancer.controller.ts
@@ -498,5 +498,6 @@ export class OracleLoadBalancerController implements IController {
 export const ORACLE_LOAD_BALANCER_CREATE_CONTROLLER = 'spinnaker.oracle.loadBalancer.create.controller';
 module(ORACLE_LOAD_BALANCER_CREATE_CONTROLLER, [
   require('angular-ui-bootstrap'),
+  require('@uirouter/angularjs').default,
   ORACLE_LOAD_BALANCER_TRANSFORMER,
 ]).controller('oracleCreateLoadBalancerCtrl', OracleLoadBalancerController);

--- a/app/scripts/modules/oracle/src/loadBalancer/details/loadBalancerDetail.controller.spec.ts
+++ b/app/scripts/modules/oracle/src/loadBalancer/details/loadBalancerDetail.controller.spec.ts
@@ -5,7 +5,6 @@ import {
 import { IControllerService, IRootScopeService, IScope, mock } from 'angular';
 import { StateService } from '@uirouter/angularjs';
 import {
-  APPLICATION_MODEL_BUILDER,
   ApplicationModelBuilder,
   SECURITY_GROUP_READER,
   SecurityGroupReader,
@@ -34,7 +33,6 @@ describe('Controller: oracleLoadBalancerDetailCtrl', function() {
   beforeEach(
     mock.module(
       ORACLE_LOAD_BALANCER_DETAIL_CONTROLLER,
-      APPLICATION_MODEL_BUILDER,
       SECURITY_GROUP_READER,
       LOAD_BALANCER_READ_SERVICE,
       CONFIRMATION_MODAL_SERVICE,
@@ -50,11 +48,10 @@ describe('Controller: oracleLoadBalancerDetailCtrl', function() {
         _securityGroupReader_: SecurityGroupReader,
         _confirmationModalService_: ConfirmationModalService,
         _loadBalancerReader_: LoadBalancerReader,
-        applicationModelBuilder: ApplicationModelBuilder,
       ) => {
         $scope = $rootScope.$new();
         $state = _$state_;
-        const app = applicationModelBuilder.createApplicationForTests('app', { key: 'loadBalancers', lazy: true });
+        const app = ApplicationModelBuilder.createApplicationForTests('app', { key: 'loadBalancers', lazy: true });
         app.loadBalancers.data.push(loadBalancer);
         securityGroupReader = _securityGroupReader_;
         confirmationModalService = _confirmationModalService_;

--- a/app/scripts/modules/oracle/src/loadBalancer/details/loadBalancerDetail.controller.ts
+++ b/app/scripts/modules/oracle/src/loadBalancer/details/loadBalancerDetail.controller.ts
@@ -167,7 +167,7 @@ export class OracleLoadBalancerDetailController implements IController {
 }
 
 export const ORACLE_LOAD_BALANCER_DETAIL_CONTROLLER = 'spinnaker.oracle.loadBalancerDetail.controller';
-module(ORACLE_LOAD_BALANCER_DETAIL_CONTROLLER, [require('angular-ui-bootstrap')]).controller(
-  'oracleLoadBalancerDetailCtrl',
-  OracleLoadBalancerDetailController,
-);
+module(ORACLE_LOAD_BALANCER_DETAIL_CONTROLLER, [
+  require('@uirouter/angularjs').default,
+  require('angular-ui-bootstrap'),
+]).controller('oracleLoadBalancerDetailCtrl', OracleLoadBalancerDetailController);


### PR DESCRIPTION
…ecutions

This started as a few lines to fix execution hydration in the projects view. But it seemed easy enough to make the ApplicationModelBuilder not an Angular service, so here we are.