### PR TITLE
fix(google): fix autohealing health checks in deploy stages

### DIFF
--- a/app/scripts/modules/google/src/domain/autoHealingPolicy.ts
+++ b/app/scripts/modules/google/src/domain/autoHealingPolicy.ts
@@ -1,8 +1,9 @@
 import { IGceHealthCheckKind } from 'google/domain/healthCheck';
 
 export interface IGceAutoHealingPolicy {
-  healthCheck?: string;
-  healthCheckKind?: IGceHealthCheckKind;
+  healthCheck?: string; // received from server as health check URL, but posted as health check name
+  healthCheckKind?: IGceHealthCheckKind; // used by Clouddriver to disambiguate health checks
+  healthCheckUrl?: string; // used by Deck as unique ID
   initialDelaySec?: number;
   maxUnavailable?: IMaxUnavailable;
 }

--- a/app/scripts/modules/google/src/serverGroup/configure/serverGroupCommandBuilder.service.js
+++ b/app/scripts/modules/google/src/serverGroup/configure/serverGroupCommandBuilder.service.js
@@ -5,6 +5,7 @@ import _ from 'lodash';
 
 import { AccountService, ExpectedArtifactService, INSTANCE_TYPE_SERVICE } from '@spinnaker/core';
 import { GCEProviderSettings } from 'google/gce.settings';
+import { parseHealthCheckUrl } from 'google/healthCheck/healthCheckUtils';
 
 module.exports = angular
   .module('spinnaker.gce.serverGroupCommandBuilder.service', [
@@ -194,14 +195,18 @@ module.exports = angular
       }
 
       function populateAutoHealingPolicy(serverGroup, command) {
-        if (serverGroup.autoHealingPolicy) {
-          let autoHealingPolicy = serverGroup.autoHealingPolicy;
-          const healthCheckUrl = autoHealingPolicy.healthCheck;
-          const autoHealingPolicyHealthCheck = healthCheckUrl ? _.last(healthCheckUrl.split('/')) : null;
+        const autoHealingPolicy = serverGroup.autoHealingPolicy;
+        if (autoHealingPolicy) {
+          const healthCheckUrl = autoHealingPolicy.healthCheckUrl
+            ? autoHealingPolicy.healthCheckUrl
+            : autoHealingPolicy.healthCheck;
 
-          if (autoHealingPolicyHealthCheck) {
+          if (healthCheckUrl) {
+            const { healthCheckName, healthCheckKind } = parseHealthCheckUrl(healthCheckUrl);
             command.autoHealingPolicy = {
-              healthCheck: healthCheckUrl,
+              healthCheck: healthCheckName,
+              healthCheckKind: healthCheckKind,
+              healthCheckUrl: healthCheckUrl,
               initialDelaySec: autoHealingPolicy.initialDelaySec,
             };
           }

--- a/app/scripts/modules/google/src/serverGroup/configure/serverGroupConfiguration.service.js
+++ b/app/scripts/modules/google/src/serverGroup/configure/serverGroupConfiguration.service.js
@@ -139,7 +139,7 @@ module.exports = angular
               if (
                 !_.chain(healthChecks)
                   .map('selfLink')
-                  .includes(command.autoHealingPolicy.healthCheck)
+                  .includes(command.autoHealingPolicy.healthCheckUrl)
                   .value()
               ) {
                 healthCheckReloader = refreshHealthChecks(command, true);
@@ -406,7 +406,7 @@ module.exports = angular
           _.has(command, 'autoHealingPolicy.healthCheck') &&
           !_.chain(filteredData.healthChecks)
             .map('selfLink')
-            .includes(command.autoHealingPolicy.healthCheck)
+            .includes(command.autoHealingPolicy.healthCheckUrl)
             .value()
         ) {
           delete command.autoHealingPolicy.healthCheck;

--- a/app/scripts/modules/google/src/serverGroup/configure/wizard/autoHealingPolicy/autoHealingPolicySelector.component.html
+++ b/app/scripts/modules/google/src/serverGroup/configure/wizard/autoHealingPolicy/autoHealingPolicySelector.component.html
@@ -3,7 +3,12 @@
     <b>Health Check</b>
   </div>
   <div class="col-md-6">
-    <ui-select ng-model="$ctrl.autoHealingPolicy.healthCheck" class="form-control input-sm" required>
+    <ui-select
+      ng-model="$ctrl.autoHealingPolicy.healthCheckUrl"
+      on-select="$ctrl.onHealthCheckChange($item, $model)"
+      class="form-control input-sm"
+      required
+    >
       <ui-select-match placeholder="Select...">{{ $select.selected.displayName }}</ui-select-match>
       <ui-select-choices
         repeat="healthCheck.selfLink as healthCheck in $ctrl.healthChecks | orderBy: 'displayName' | filter: { displayName: $select.search }"

--- a/app/scripts/modules/google/src/serverGroup/configure/wizard/autoHealingPolicy/autoHealingPolicySelector.component.ts
+++ b/app/scripts/modules/google/src/serverGroup/configure/wizard/autoHealingPolicy/autoHealingPolicySelector.component.ts
@@ -1,6 +1,7 @@
 import { IComponentOptions, IController, module } from 'angular';
 import { set } from 'lodash';
 import { IGceAutoHealingPolicy } from 'google/domain/autoHealingPolicy';
+import { IGceHealthCheckOption, parseHealthCheckUrl } from 'google/healthCheck/healthCheckUtils';
 
 class GceAutoHealingPolicySelector implements IController {
   public healthChecks: string[];
@@ -34,6 +35,14 @@ class GceAutoHealingPolicySelector implements IController {
     } else {
       const toDeleteKey = selectedMetric === 'percent' ? 'fixed' : 'percent';
       set(this.autoHealingPolicy, ['maxUnavailable', toDeleteKey], undefined);
+    }
+  }
+
+  public onHealthCheckChange(_healthCheck: IGceHealthCheckOption, healthCheckUrl: string) {
+    if (healthCheckUrl) {
+      const { healthCheckName, healthCheckKind } = parseHealthCheckUrl(healthCheckUrl);
+      this.autoHealingPolicy.healthCheck = healthCheckName;
+      this.autoHealingPolicy.healthCheckKind = healthCheckKind;
     }
   }
 }

--- a/app/scripts/modules/google/src/serverGroup/configure/wizard/cloneServerGroup.gce.controller.js
+++ b/app/scripts/modules/google/src/serverGroup/configure/wizard/cloneServerGroup.gce.controller.js
@@ -5,8 +5,6 @@ import _ from 'lodash';
 
 import { FirewallLabels, INSTANCE_TYPE_SERVICE, ModalWizard, TaskMonitor } from '@spinnaker/core';
 
-import { parseHealthCheckUrl } from 'google/healthCheck/healthCheckUtils';
-
 module.exports = angular
   .module('spinnaker.serverGroup.configure.gce.cloneServerGroup', [
     require('@uirouter/angularjs').default,
@@ -393,13 +391,6 @@ module.exports = angular
           return $uibModalInstance.close($scope.command);
         }
 
-        const healthCheckUrl = _.get($scope.command, 'autoHealingPolicy.healthCheck');
-        if (healthCheckUrl) {
-          const { healthCheckName, healthCheckKind } = parseHealthCheckUrl(healthCheckUrl);
-          $scope.command.autoHealingPolicy.healthCheck = healthCheckName;
-          $scope.command.autoHealingPolicy.healthCheckKind = healthCheckKind;
-        }
-
         $scope.taskMonitor.submit(function() {
           const promise = serverGroupWriter.cloneServerGroup(angular.copy($scope.command), application);
 
@@ -409,10 +400,6 @@ module.exports = angular
           $scope.command.tags = origTags;
           $scope.command.loadBalancers = origLoadBalancers;
           $scope.command.securityGroups = gceTagManager.inferSecurityGroupIdsFromTags($scope.command.tags);
-
-          if (healthCheckUrl) {
-            $scope.command.autoHealingPolicy.healthCheck = healthCheckUrl;
-          }
 
           return promise;
         });

--- a/app/scripts/modules/google/src/serverGroup/details/autoHealingPolicy/modal/upsertAutoHealingPolicy.modal.controller.ts
+++ b/app/scripts/modules/google/src/serverGroup/details/autoHealingPolicy/modal/upsertAutoHealingPolicy.modal.controller.ts
@@ -6,7 +6,7 @@ import { Application, TaskMonitor } from '@spinnaker/core';
 
 import { IGceAutoHealingPolicy, IGceServerGroup } from 'google/domain/index';
 import { GCE_HEALTH_CHECK_READER, GceHealthCheckReader } from 'google/healthCheck/healthCheck.read.service';
-import { getHealthCheckOptions, IGceHealthCheckOption, parseHealthCheckUrl } from 'google/healthCheck/healthCheckUtils';
+import { getHealthCheckOptions, IGceHealthCheckOption } from 'google/healthCheck/healthCheckUtils';
 
 import './upsertAutoHealingPolicy.modal.less';
 
@@ -37,9 +37,6 @@ class GceUpsertAutoHealingPolicyModalCtrl implements IController {
 
   public submit(): void {
     const submitMethod = () => {
-      const { healthCheckName, healthCheckKind } = parseHealthCheckUrl(this.autoHealingPolicy.healthCheck);
-      this.autoHealingPolicy.healthCheck = healthCheckName;
-      this.autoHealingPolicy.healthCheckKind = healthCheckKind;
       return this.gceAutoscalingPolicyWriter.upsertAutoHealingPolicy(
         this.application,
         this.serverGroup,


### PR DESCRIPTION
Closes https://github.com/spinnaker/spinnaker/issues/4221

We made the following fixes to Deck and Clouddriver to disambiguate health checks of the same name by also specifying the health check kind:
Deck: https://github.com/spinnaker/deck/pull/6382
Clouddriver: https://github.com/spinnaker/clouddriver/pull/3282

This fix worked by using the health check's URL as a unique ID, and extracting the health check's name and kind from the URL prior to submit. However, this only worked for ad-hoc create and clone operations, not the deploy stage, where the field is bound to the stage model. To resolve this, I added an onSelect handler to the health check dropdown that will update the health check's name and kind based on the selected health check URL. Confusingly, Deck receives a server group's `autoHealingPolicy.healthCheck` as the health check URL, but Clouddriver is expecting to receive a payload with `autoHealingPolicy.healthCheck` as the health check name, so to cover the two cases of building the command for stage editing (based on the stage model) and building the command for ad-hoc operations (based on what we receive from the server), we need to check if we have a `healthCheckUrl` field (only true for stages), and otherwise assume that the `healthCheck` is the URL.

Note that if users have worked around this bug by manually editing the deploy stage JSON such that `healthCheck` corresponds to the health check name rather than the URL, they can update these stages to work as expected by adding a `healthCheckUrl` field.