### PR TITLE
fix(google): revert "select all zones by default when deploying a regional gce server group (#6751)"

### DIFF
--- a/app/scripts/modules/google/src/serverGroup/configure/serverGroupConfiguration.service.js
+++ b/app/scripts/modules/google/src/serverGroup/configure/serverGroupConfiguration.service.js
@@ -369,7 +369,7 @@ module.exports = angular
         const regions = command.backingData.credentialsKeyedByAccount[command.credentials].regions;
         if (_.isArray(regions)) {
           filteredData.zones = _.find(regions, { name: command.region }).zones;
-          filteredData.automaticZones = filteredData.zones.slice().sort();
+          filteredData.truncatedZones = _.takeRight(filteredData.zones.sort(), 3);
         } else {
           // TODO(duftler): Remove this once we finish deprecating the old style regions/zones in clouddriver GCE credentials.
           filteredData.zones = regions[command.region];

--- a/app/scripts/modules/google/src/serverGroup/configure/wizard/zones/zoneSelector.directive.html
+++ b/app/scripts/modules/google/src/serverGroup/configure/wizard/zones/zoneSelector.directive.html
@@ -19,7 +19,7 @@
       Server group will be available in:
     </p>
     <ul>
-      <li ng-repeat="zone in vm.command.backingData.filtered.automaticZones">
+      <li ng-repeat="zone in vm.command.backingData.filtered.truncatedZones">
         {{zone}}
       </li>
     </ul>

--- a/app/scripts/modules/google/src/serverGroup/serverGroup.transformer.js
+++ b/app/scripts/modules/google/src/serverGroup/serverGroup.transformer.js
@@ -29,7 +29,7 @@ module.exports = angular
       }
 
       function convertServerGroupCommandToDeployConfiguration(base) {
-        const automaticZones = base.backingData.filtered.automaticZones;
+        const truncatedZones = base.backingData.filtered.truncatedZones;
 
         // use defaults to avoid copying the backingData, which is huge and expensive to copy over
         const command = defaults({ backingData: [], viewState: [] }, base);
@@ -40,7 +40,7 @@ module.exports = angular
         command.disableTraffic = !command.enableTraffic;
         command.cloudProvider = 'gce';
         command.availabilityZones = {};
-        command.availabilityZones[command.region] = base.zone ? [base.zone] : automaticZones;
+        command.availabilityZones[command.region] = base.zone ? [base.zone] : truncatedZones;
         command.account = command.credentials;
         delete command.viewState;
         delete command.backingData;


### PR DESCRIPTION
This reverts commit ad2e2227442aa2e7abf85bf1a82ef7a5f51b1445.

In hindsight, Deck was already doing the right thing here. The platform, GCP, chooses the zones if the user doesn't specify them.  In some quick testing through the GCP UI, MIGs in us-central1 always seem to get spread across zones -b, -c, and -f and never end up on -a.  So it was incorrect to show in Deck that they might be placed on -a.

Closes https://github.com/spinnaker/spinnaker/issues/4071