### PR TITLE
fix(google): revert "select all zones by default when deploying a regional gce server group (#6751) (#6755)"

### DIFF
--- a/app/scripts/modules/google/src/serverGroup/configure/serverGroupConfiguration.service.js
+++ b/app/scripts/modules/google/src/serverGroup/configure/serverGroupConfiguration.service.js
@@ -340,7 +340,7 @@ module.exports = angular
       const regions = command.backingData.credentialsKeyedByAccount[command.credentials].regions;
       if (_.isArray(regions)) {
         filteredData.zones = _.find(regions, { name: command.region }).zones;
-        filteredData.automaticZones = filteredData.zones.slice().sort();
+        filteredData.truncatedZones = _.takeRight(filteredData.zones.sort(), 3);
       } else {
         // TODO(duftler): Remove this once we finish deprecating the old style regions/zones in clouddriver GCE credentials.
         filteredData.zones = regions[command.region];
@@ -572,8 +572,9 @@ module.exports = angular
 
       // Only include explicitly-selected firewalls in the body of the command.
       const xpnHostProject = getXpnHostProjectIfAny(command.network);
-      const decoratedSecurityGroups = _.map(command.securityGroups, sg =>
-        !sg.startsWith(xpnHostProject) ? xpnHostProject + sg : sg,
+      const decoratedSecurityGroups = _.map(
+        command.securityGroups,
+        sg => (!sg.startsWith(xpnHostProject) ? xpnHostProject + sg : sg),
       );
       command.securityGroups = _.difference(decoratedSecurityGroups, _.map(command.implicitSecurityGroups, 'id'));
 

--- a/app/scripts/modules/google/src/serverGroup/configure/wizard/zones/zoneSelector.directive.html
+++ b/app/scripts/modules/google/src/serverGroup/configure/wizard/zones/zoneSelector.directive.html
@@ -2,12 +2,10 @@
   <div class="col-md-3 sm-label-right">Zone</div>
   <div class="col-md-7" ng-if="!vm.command.region">(Select a region)</div>
   <div class="col-md-7">
-    <select
-      class="form-control input-sm"
+    <select class="form-control input-sm"
       ng-model="vm.command.zone"
       ng-options="zone for zone in vm.command.backingData.filtered.zones"
-      ng-required="!vm.command.regional"
-    >
+      ng-required="!vm.command.regional">
     </select>
   </div>
 </div>
@@ -19,13 +17,15 @@
       Server group will be available in:
     </p>
     <ul>
-      <li ng-repeat="zone in vm.command.backingData.filtered.automaticZones">
+      <li ng-repeat="zone in vm.command.backingData.filtered.truncatedZones">
         {{zone}}
       </li>
     </ul>
   </div>
   <div class="col-md-7" ng-if="vm.command.selectZones">
-    <ui-select multiple ng-model="vm.command.distributionPolicy.zones" class="form-control input-sm">
+    <ui-select multiple
+               ng-model="vm.command.distributionPolicy.zones"
+               class="form-control input-sm">
       <ui-select-match>{{ $item }}</ui-select-match>
       <ui-select-choices repeat="zone as zone in vm.command.backingData.filtered.zones">
         <span>{{ zone }}</span>

--- a/app/scripts/modules/google/src/serverGroup/serverGroup.transformer.js
+++ b/app/scripts/modules/google/src/serverGroup/serverGroup.transformer.js
@@ -27,7 +27,7 @@ module.exports = angular
     }
 
     function convertServerGroupCommandToDeployConfiguration(base) {
-      const automaticZones = base.backingData.filtered.automaticZones;
+      const truncatedZones = base.backingData.filtered.truncatedZones;
 
       // use defaults to avoid copying the backingData, which is huge and expensive to copy over
       const command = defaults({ backingData: [], viewState: [] }, base);
@@ -38,7 +38,7 @@ module.exports = angular
       command.disableTraffic = !command.enableTraffic;
       command.cloudProvider = 'gce';
       command.availabilityZones = {};
-      command.availabilityZones[command.region] = base.zone ? [base.zone] : automaticZones;
+      command.availabilityZones[command.region] = base.zone ? [base.zone] : truncatedZones;
       command.account = command.credentials;
       delete command.viewState;
       delete command.backingData;


### PR DESCRIPTION
Release-1.12.x version of https://github.com/spinnaker/deck/pull/6808

This reverts commit 63248626d8e416830b043fdc8db08d93e74e4bac.

In hindsight, Deck was already doing the right thing here. The platform, GCP,
chooses the zones if the user doesn't specify them. In some quick testing
through the GCP UI, MIGs in us-central1 always seem to get spread across
zones -b, -c, and -f and never end up on -a. So it was incorrect to show in
Deck that they might be placed on -a.