### PR TITLE
feat(kuberntes): v2 runJob

### DIFF
--- a/app/scripts/modules/kubernetes/src/v2/kubernetes.v2.module.ts
+++ b/app/scripts/modules/kubernetes/src/v2/kubernetes.v2.module.ts
@@ -3,6 +3,7 @@ import { module } from 'angular';
 import { CloudProviderRegistry, STAGE_ARTIFACT_SELECTOR_COMPONENT_REACT, YAML_EDITOR_COMPONENT } from '@spinnaker/core';
 
 import '../logo/kubernetes.logo.less';
+
 import { KUBERNETES_MANIFEST_BASIC_SETTINGS } from './manifest/wizard/basicSettings.component';
 import { KUBERNETES_MANIFEST_DELETE_CTRL } from './manifest/delete/delete.controller';
 import { KUBERNETES_MANIFEST_SCALE_CTRL } from './manifest/scale/scale.controller';
@@ -41,6 +42,8 @@ import { JSON_EDITOR_COMPONENT } from './manifest/editor/json/jsonEditor.compone
 import { ManifestWizard } from 'kubernetes/v2/manifest/wizard/ManifestWizard';
 import { KUBERNETES_ENABLE_MANIFEST_STAGE } from 'kubernetes/v2/pipelines/stages/traffic/enableManifest.stage';
 import { KUBERNETES_DISABLE_MANIFEST_STAGE } from 'kubernetes/v2/pipelines/stages/traffic/disableManifest.stage';
+import { KUBERNETES_V2_RUN_JOB_STAGE } from 'kubernetes/v2/pipelines/stages/runJob/runJobStage';
+
 import './pipelines/validation/manifestSelector.validator';
 
 // load all templates into the $templateCache
@@ -93,6 +96,7 @@ module(KUBERNETES_V2_MODULE, [
   KUBERNETES_ENABLE_MANIFEST_STAGE,
   KUBERNETES_DISABLE_MANIFEST_STAGE,
   STAGE_ARTIFACT_SELECTOR_COMPONENT_REACT,
+  KUBERNETES_V2_RUN_JOB_STAGE,
 ]).config(() => {
   CloudProviderRegistry.registerProvider('kubernetes', {
     name: 'Kubernetes',

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/runJob/KubernetesV2RunJobStageConfig.tsx
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/runJob/KubernetesV2RunJobStageConfig.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react';
+
+import { IStageConfigProps, AccountService, YamlEditor, yamlDocumentsToString, IAccount } from '@spinnaker/core';
+
+import { ManifestBasicSettings } from 'kubernetes/v2/manifest/wizard/BasicSettings';
+
+export interface IKubernetesRunJobStageConfigState {
+  credentials: IAccount[];
+  rawManifest?: string;
+}
+
+export class KubernetesV2RunJobStageConfig extends React.Component<IStageConfigProps> {
+  public state: IKubernetesRunJobStageConfigState = {
+    credentials: [],
+  };
+
+  public accountChanged = (account: string) => {
+    this.props.updateStageField({
+      credentails: account,
+      account: account,
+    });
+  };
+
+  public handleRawManifestChange = (rawManifest: string, manifests: any) => {
+    if (manifests) {
+      this.props.updateStageField({ manifest: manifests[0] });
+    }
+    this.setState({ rawManifest });
+  };
+
+  public initRawManifest() {
+    const { stage } = this.props;
+    if (stage.manifest) {
+      this.setState({ rawManifest: yamlDocumentsToString([stage.manifest]) });
+    }
+  }
+
+  public componentDidMount() {
+    this.props.updateStageField({ cloudProvider: 'kubernetes' });
+    AccountService.getAllAccountDetailsForProvider('kubernetes', 'v2').then((accounts: any) => {
+      this.setState({ credentials: accounts });
+    });
+    this.initRawManifest();
+  }
+
+  public render() {
+    const { application, stage } = this.props;
+
+    return (
+      <div className="container-fluid form-horizontal">
+        <h4>Basic Settings</h4>
+        <ManifestBasicSettings
+          app={application}
+          selectedAccount={stage.account || ''}
+          accounts={this.state.credentials}
+          onAccountSelect={(selectedAccount: string) => this.accountChanged(selectedAccount)}
+        />
+        <h4>Manifest Configuration</h4>
+        <YamlEditor value={this.state.rawManifest} onChange={this.handleRawManifestChange} />
+      </div>
+    );
+  }
+}

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/runJob/RunJobExecutionDetails.tsx
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/runJob/RunJobExecutionDetails.tsx
@@ -1,0 +1,72 @@
+import * as React from 'react';
+import { get } from 'lodash';
+
+import { RunJobLogsModal, IRunJobLogsModalProps } from './RunJobLogsModal';
+
+import {
+  IExecutionDetailsSectionProps,
+  ExecutionDetailsSection,
+  AccountTag,
+  ReactModal,
+  ReactInjector,
+} from '@spinnaker/core';
+
+export class RunJobExecutionDetails extends React.Component<IExecutionDetailsSectionProps> {
+  public static title = 'runJobConfig';
+
+  public showLogsModal = (_event: any): void => {
+    const { stage, execution } = this.props;
+    const { executionService } = ReactInjector;
+    executionService.getExecution(execution.id).then((fullExecution: any) => {
+      const fullStage = fullExecution.stages.find((s: any) => s.id === stage.id);
+      if (!fullStage) {
+        return;
+      }
+
+      const modalProps = { dialogClassName: 'modal-lg modal-fullscreen' };
+      ReactModal.show(
+        RunJobLogsModal,
+        {
+          logs: get(fullStage, 'context.jobStatus.logs', 'No log output found.'),
+        } as IRunJobLogsModalProps,
+        modalProps,
+      );
+    });
+  };
+
+  public render() {
+    const { stage, name, current } = this.props;
+    const { context } = stage;
+
+    return (
+      <ExecutionDetailsSection name={name} current={current}>
+        <div className="row">
+          <div className="col-md-9">
+            <dl className="dl-narrow dl-horizontal">
+              <dt>Account</dt>
+              <dd>
+                <AccountTag account={context.account} />
+              </dd>
+            </dl>
+            {stage.context.jobStatus && stage.context.jobStatus.location && (
+              <dl className="dl-narrow dl-horizontal">
+                <dt>Namespace</dt>
+                <dd>{stage.context.jobStatus.location}</dd>
+              </dl>
+            )}
+          </div>
+          {stage.context.jobStatus && stage.context.jobStatus.logs && (
+            <div className="col-md-9">
+              <dl className="dl-narrow dl-horizontal">
+                <dt>Logs</dt>
+                <dd>
+                  <a onClick={this.showLogsModal}>Console Output (Raw)</a>
+                </dd>
+              </dl>
+            </div>
+          )}
+        </div>
+      </ExecutionDetailsSection>
+    );
+  }
+}

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/runJob/RunJobLogsModal.tsx
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/runJob/RunJobLogsModal.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+
+import { IModalComponentProps } from '@spinnaker/core';
+
+export interface IRunJobLogsModalProps extends IModalComponentProps {
+  logs: string;
+}
+
+export class RunJobLogsModal extends React.Component<IRunJobLogsModalProps> {
+  constructor(props: IRunJobLogsModalProps) {
+    super(props);
+  }
+
+  public render() {
+    const { dismissModal } = this.props;
+    return (
+      <div className="flex-fill">
+        <div className="modal-header">
+          <h3>Execution Logs</h3>
+        </div>
+        <div className="modal-body flex-fill">
+          <pre className="body-small flex-fill">{this.props.logs || ''}</pre>
+        </div>
+        <div className="modal-footer">
+          <button className="btn btn-default" onClick={dismissModal}>
+            Close
+          </button>
+        </div>
+      </div>
+    );
+  }
+}

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/runJob/runJobStage.ts
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/runJob/runJobStage.ts
@@ -1,0 +1,51 @@
+import { module } from 'angular';
+
+import {
+  Registry,
+  ExecutionDetailsTasks,
+  IPipeline,
+  IStage,
+  IValidatorConfig,
+  IStageOrTriggerTypeConfig,
+  ICustomValidator,
+} from '@spinnaker/core';
+
+import { KubernetesV2RunJobStageConfig } from './KubernetesV2RunJobStageConfig';
+import { RunJobExecutionDetails } from './RunJobExecutionDetails';
+
+export const KUBERNETES_V2_RUN_JOB_STAGE = 'spinnaker.kubernetes.v2.pipeline.stage.runJob';
+
+module(KUBERNETES_V2_RUN_JOB_STAGE, [])
+  .config(() => {
+    Registry.pipeline.registerStage({
+      label: 'Run Job (Manifest)',
+      description: 'Run a Kubernetes Job mainfest yaml/json file.',
+      key: 'runJobManifest',
+      alias: 'runJob',
+      addAliasToConfig: true,
+      cloudProvider: 'kubernetes',
+      component: KubernetesV2RunJobStageConfig,
+      executionDetailsSections: [ExecutionDetailsTasks, RunJobExecutionDetails],
+      defaultTimeoutMs: 30 * 60 * 1000,
+      validators: [
+        {
+          type: 'custom',
+          validate: (
+            _pipeline: IPipeline,
+            stage: IStage,
+            _validator: IValidatorConfig,
+            _config: IStageOrTriggerTypeConfig,
+          ): string => {
+            if (!stage.manifest || !stage.manifest.kind) {
+              return '';
+            }
+            if (stage.manifest.kind !== 'Job') {
+              return 'Run Job (Manifest) only accepts manifest of kind Job.';
+            }
+            return '';
+          },
+        } as ICustomValidator,
+      ],
+    });
+  })
+  .controller('KubernetesV2RunJobStageConfig', KubernetesV2RunJobStageConfig);


### PR DESCRIPTION
UI support for the V2 Run Job stage

This is just the basics of the stage. I'll be adding support for artifacts in future revisions. I'm not sure what we want to put in the execution details besides account and namespace but we could add more later.

## Execution Details
![image](https://user-images.githubusercontent.com/3324110/55879987-d1be8e00-5b6d-11e9-8176-938c9dbfd80d.png)

## Log output
![image](https://user-images.githubusercontent.com/3324110/55880013-df741380-5b6d-11e9-9201-b6477d700a15.png)


## Stage configuration
![image](https://user-images.githubusercontent.com/3324110/55880043-eac73f00-5b6d-11e9-9dcd-31fd77e7230e.png)
