### PR TITLE
fix(k8s): Fix deploy manifest

### DIFF
--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/ManifestBindArtifactsSelector.tsx
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/ManifestBindArtifactsSelector.tsx
@@ -48,7 +48,7 @@ export class ManifestBindArtifactsSelector extends React.Component<IManifestBind
               pipeline={pipeline}
               stage={stage}
               expectedArtifactId={binding && binding.expectedArtifactId}
-              artifact={binding && binding.artifact}
+              artifact={!!binding && binding.artifact}
               onArtifactEdited={(artifact: IArtifact) => this.onChangeBinding(i, { artifact: artifact })}
               onExpectedArtifactSelected={(expectedArtifact: IExpectedArtifact) =>
                 this.onChangeBinding(i, { expectedArtifactId: expectedArtifact.id })

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestConfig.controller.ts
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestConfig.controller.ts
@@ -42,7 +42,7 @@ export class KubernetesV2DeployManifestConfigCtrl implements IController {
     const stage = this.$scope.stage;
     this.$scope.bindings = (stage.requiredArtifactIds || [])
       .map((id: string) => ({ expectedArtifactId: id }))
-      .concat((stage.requiredArtifacts || []).map((artifact: IArtifact) => ({ artifact: artifact })));
+      .concat(stage.requiredArtifacts || []);
 
     this.$scope.excludedManifestArtifactTypes = [
       ArtifactTypePatterns.DOCKER_IMAGE,


### PR DESCRIPTION
In 1.13, the K8S deploy manifest stage displays the new artifacts UI when the feature flag is enabled. When loading a pipeline defined in this way, artifacts were incorrectly nested one layer too deep.

Also fixed Promise treatment of the React components related to this.

![image](https://user-images.githubusercontent.com/1697736/55931190-3d464100-5bea-11e9-9f3b-4884b47a5d9c.png)

See https://github.com/spinnaker/orca/pull/2830 for more details on the JSON structure changes we introduced into 1.13.