### PR TITLE
 fix(provider/azure): Region can't be selected while creating loadbalancer with only one region

### DIFF
--- a/app/scripts/modules/azure/loadBalancer/configure/createLoadBalancer.controller.js
+++ b/app/scripts/modules/azure/loadBalancer/configure/createLoadBalancer.controller.js
@@ -28,6 +28,8 @@ module.exports = angular
     function($scope, $uibModalInstance, $state, azureLoadBalancerTransformer, application, loadBalancer, isNew) {
       var ctrl = this;
 
+      $scope.regions = [];
+
       $scope.pages = {
         location: require('./createLoadBalancerProperties.html'),
         listeners: require('./listeners.html'),

--- a/app/scripts/modules/azure/loadBalancer/loadBalancer.transformer.js
+++ b/app/scripts/modules/azure/loadBalancer/loadBalancer.transformer.js
@@ -68,7 +68,7 @@ module.exports = angular
 
       function constructNewLoadBalancerTemplate(application) {
         var defaultCredentials = application.defaultCredentials.azure || AzureProviderSettings.defaults.account,
-          defaultRegion = application.defaultRegion || AzureProviderSettings.defaults.region;
+          defaultRegion = application.defaultRegions.azure || AzureProviderSettings.defaults.region;
         return {
           stack: '',
           detail: 'frontend',

--- a/app/scripts/modules/azure/securityGroup/configure/CreateSecurityGroupCtrl.js
+++ b/app/scripts/modules/azure/securityGroup/configure/CreateSecurityGroupCtrl.js
@@ -25,6 +25,8 @@ module.exports = angular
         ingress: require('./createSecurityGroupIngress.html'),
       };
 
+      $scope.regions = [];
+
       $scope.firewallLabel = FirewallLabels.get('Firewall');
 
       var ctrl = this;


### PR DESCRIPTION
Background:
Currenly, when there is only one region, creating load balancer wizard failed to load region.