### PR TITLE
feat(k8s): Exclude inline base 64 artifact editing in k8s manifest

### DIFF
--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestConfig.controller.ts
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestConfig.controller.ts
@@ -48,6 +48,7 @@ export class KubernetesV2DeployManifestConfigCtrl implements IController {
       ArtifactTypePatterns.DOCKER_IMAGE,
       ArtifactTypePatterns.KUBERNETES,
       ArtifactTypePatterns.FRONT50_PIPELINE_TEMPLATE,
+      ArtifactTypePatterns.EMBEDDED_BASE64,
     ];
 
     KubernetesManifestCommandBuilder.buildNewManifestCommand(


### PR DESCRIPTION
So that users aren't confused about whether they should put raw manifest text in "Text" source or in "Artifact" source of type base64.