### PR TITLE
feat(preconfiguredJob): logs for k8s jobs

### DIFF
--- a/app/scripts/modules/core/src/pipeline/details/LogsModal.tsx
+++ b/app/scripts/modules/core/src/pipeline/details/LogsModal.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 
-import { IModalComponentProps } from '@spinnaker/core';
+import { IModalComponentProps } from 'core/presentation';
 
-export interface IRunJobLogsModalProps extends IModalComponentProps {
+export interface ILogsModalProps extends IModalComponentProps {
   logs: string;
 }
 
-export class RunJobLogsModal extends React.Component<IRunJobLogsModalProps> {
-  constructor(props: IRunJobLogsModalProps) {
+export class LogsModal extends React.Component<ILogsModalProps> {
+  constructor(props: ILogsModalProps) {
     super(props);
   }
 

--- a/app/scripts/modules/core/src/pipeline/details/StageExecutionLogs.tsx
+++ b/app/scripts/modules/core/src/pipeline/details/StageExecutionLogs.tsx
@@ -2,22 +2,49 @@ import * as React from 'react';
 import { get } from 'lodash';
 
 import { IStage } from 'core/domain';
+import { ReactModal } from 'core/presentation';
 
-export const StageExecutionLogs = (props: { stage: IStage }): JSX.Element => {
-  const logs = get<string>(props.stage, 'context.execution.logs');
-  if (!logs) {
-    return null;
+import { LogsModal, ILogsModalProps } from './LogsModal';
+
+export interface IStageExecutionLogsProps {
+  stage: IStage;
+}
+
+export class StageExecutionLogs extends React.Component<IStageExecutionLogsProps> {
+  public isExternalLink = false;
+
+  constructor(props: any) {
+    super(props);
+    // titus jobs present a link to an external system for logs
+    // kubernetes jobs store logs in the execution context (for better, or for worse)
+    this.isExternalLink = get<string>(this.props.stage, 'context.execution.logs') !== undefined;
   }
 
-  return (
-    <div className="row">
-      <div className="col-md-12">
-        <div className="well alert alert-info">
-          <a target="_blank" href={logs}>
-            View Execution Logs
-          </a>
+  public showModal = () => {
+    ReactModal.show(
+      LogsModal,
+      {
+        logs: get<string>(this.props.stage, 'context.jobStatus.logs'),
+      } as ILogsModalProps,
+      { dialogClassName: 'modal-lg modal-fullscreen' },
+    );
+  };
+
+  public render() {
+    const logs = get<string>(this.props.stage, 'context.execution.logs');
+    return (
+      <div className="row">
+        <div className="col-md-12">
+          <div className="well alert alert-info">
+            {this.isExternalLink && (
+              <a target="_blank" href={logs}>
+                View Execution Logs
+              </a>
+            )}
+            {!this.isExternalLink && <a onClick={this.showModal}>View Execution Logs</a>}
+          </div>
         </div>
       </div>
-    </div>
-  );
-};
+    );
+  }
+}

--- a/app/scripts/modules/core/src/pipeline/details/index.ts
+++ b/app/scripts/modules/core/src/pipeline/details/index.ts
@@ -2,3 +2,4 @@ export * from './executionDetailsSection.service';
 export * from './ExecutionDetailsSectionNav';
 export * from './StageExecutionLogs';
 export * from './StageFailureMessage';
+export * from './LogsModal';

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/runJob/RunJobExecutionDetails.tsx
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/runJob/RunJobExecutionDetails.tsx
@@ -1,14 +1,14 @@
 import * as React from 'react';
 import { get } from 'lodash';
 
-import { RunJobLogsModal, IRunJobLogsModalProps } from './RunJobLogsModal';
-
 import {
   IExecutionDetailsSectionProps,
   ExecutionDetailsSection,
   AccountTag,
   ReactModal,
   ReactInjector,
+  LogsModal,
+  ILogsModalProps,
 } from '@spinnaker/core';
 
 export class RunJobExecutionDetails extends React.Component<IExecutionDetailsSectionProps> {
@@ -25,10 +25,10 @@ export class RunJobExecutionDetails extends React.Component<IExecutionDetailsSec
 
       const modalProps = { dialogClassName: 'modal-lg modal-fullscreen' };
       ReactModal.show(
-        RunJobLogsModal,
+        LogsModal,
         {
           logs: get(fullStage, 'context.jobStatus.logs', 'No log output found.'),
-        } as IRunJobLogsModalProps,
+        } as ILogsModalProps,
         modalProps,
       );
     });


### PR DESCRIPTION
supports logs for preconfigured kubernetes jobs. titus jobs only link
out to extenal systems for their logs. for kubernetes, logs are stored
in the execution context and can be displayed directly.

## Execution Details
![image](https://user-images.githubusercontent.com/3324110/55981432-a9fe2180-5c64-11e9-98e0-cc53548f42df.png)


## Log display
![image](https://user-images.githubusercontent.com/3324110/55981453-b6827a00-5c64-11e9-9564-a47bea5e37eb.png)
