### PR TITLE
feat(documentation): Custom help link

### DIFF
--- a/app/scripts/modules/core/src/config/settings.ts
+++ b/app/scripts/modules/core/src/config/settings.ts
@@ -1,5 +1,11 @@
 import { cloneDeep, merge } from 'lodash';
 
+export interface IAdditionalHelpLinks {
+  text: string;
+  url: string;
+  icon?: string;
+}
+
 export interface IProviderSettings {
   defaults: any;
   resetToOriginal?: () => void;
@@ -110,6 +116,7 @@ export interface ISpinnakerSettings {
     text?: string;
     url: string;
   };
+  additionalHelpLinks?: IAdditionalHelpLinks[];
   gateUrl: string;
   gitSources: string[];
   maxPipelineAgeDays: number;

--- a/app/scripts/modules/core/src/help/HelpMenu.tsx
+++ b/app/scripts/modules/core/src/help/HelpMenu.tsx
@@ -17,6 +17,22 @@ const Feedback = () =>
     </MenuItem>
   ) : null;
 
+const AdditionalHelpLinks = () =>
+  SETTINGS.additionalHelpLinks && SETTINGS.additionalHelpLinks.length ? (
+    <>
+      {SETTINGS.additionalHelpLinks.map((helpLink, i) => (
+        <MenuItem href={helpLink.url} key={i} target="_blank">
+          {helpLink.icon ? (
+            <span>
+              <i className={helpLink.icon} /> &nbsp;
+            </span>
+          ) : null}
+          {helpLink.text || `Additional Help`}
+        </MenuItem>
+      ))}
+    </>
+  ) : null;
+
 export const HelpMenu = () => {
   return (
     <li className="help-menu">
@@ -26,6 +42,7 @@ export const HelpMenu = () => {
         </Dropdown.Toggle>
         <Dropdown.Menu>
           <Feedback />
+          <AdditionalHelpLinks />
           <MenuItem href={DOCS_URL} target="_blank">
             Docs
           </MenuItem>
@@ -51,6 +68,7 @@ export const HelpMenu = () => {
         </Dropdown.Toggle>
         <Dropdown.Menu>
           <Feedback />
+          <AdditionalHelpLinks />
           <MenuItem href={DOCS_URL} target="_blank">
             Docs
           </MenuItem>


### PR DESCRIPTION
This enables Spinnaker administrators to add a custom help link. This link can provide organization specific examples / use cases for Spinnaker. 

<kbd> ![](https://cl.ly/22da8b256bbe/Image%202019-04-11%20at%207.32.21%20PM.png) </kbd>
