### PR TITLE
fix(core/pipeline): un-shadow parameter

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/waitForCondition/SkipConditionWait.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/waitForCondition/SkipConditionWait.tsx
@@ -21,8 +21,8 @@ const skipRemainingWait = (
 ): void => {
   const { confirmationModalService, executionService } = ReactInjector;
   (event.target as HTMLElement).blur(); // forces closing of the popover when the modal opens
-  const matcher = (execution: IExecution) => {
-    const match = execution.stages.find(test => test.id === stage.id);
+  const matcher = ({ stages }: IExecution) => {
+    const match = stages.find(test => test.id === stage.id);
     return match.status !== 'RUNNING';
   };
 


### PR DESCRIPTION
Turns out this is a warning that gets printed in the middle of the build output until it hits master, and then we run in production mode and it blows up.