### PR TITLE
 feat(canary) - Add support for Baseline Offsets, bump @kayenta to 0.0.75

### DIFF
--- a/app/scripts/modules/canary/acaTask/acaTaskExecutionDetails.html
+++ b/app/scripts/modules/canary/acaTask/acaTaskExecutionDetails.html
@@ -203,6 +203,10 @@
           <div class="col-md-4 sm-label-right compact">Interval</div>
           <div class="col-md-6">{{canaryConfig.canaryAnalysisConfig.canaryAnalysisIntervalMins}} minutes</div>
         </div>
+        <div class="row" ng-if="!canaryConfig.canaryAnalysisConfig.baselineAnalysisOffsetInMins">
+          <div class="col-md-4 sm-label-right compact">Baseline Offset</div>
+          <div class="col-md-6">{{canaryConfig.canaryAnalysisConfig.baselineAnalysisOffsetInMins}}  minutes</div>
+        </div>
         <div class="row">
           <div class="col-md-4 sm-label-right compact">Notification Hours</div>
           <div class="col-md-6">{{canaryConfig.canaryAnalysisConfig.notificationHours.join(', ')}}</div>

--- a/app/scripts/modules/canary/canary.help.ts
+++ b/app/scripts/modules/canary/canary.help.ts
@@ -10,6 +10,8 @@ const helpContents: { [key: string]: string } = {
         <p>The <em>average</em> strategy takes the average of all the canary scores</p>`,
   'pipeline.config.canary.delayBeforeAnalysis':
     '<p>The number of minutes until the first ACA measurement interval begins.</p>',
+  'pipeline.config.canary.baselineAnalysisOffset':
+    '<p>The offset in minutes of baseline data collection from the beginning of canary analysis. Useful for comparing metrics pre-canary for relative comparison. This field accepts SpEL</p>',
   'pipeline.config.canary.notificationHours': '<p>Hours at which to send a notification (comma separated)</p>',
   'pipeline.config.canary.canaryInterval':
     '<p>The frequency at which a canary score is generated.  The recommended interval is at least 30 minutes.</p>',

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.4.1",
-    "@spinnaker/kayenta": "0.0.73",
+    "@spinnaker/kayenta": "0.0.75",
     "@spinnaker/styleguide": "^1.0.12",
     "@types/date-fns": "^2.6.0",
     "@types/memoize-one": "^3.1.1",


### PR DESCRIPTION
Currently canaries initiated from Orca must always have the same start/end time for all analysis scopes (baseline, canary, etc). This PR adds support for setting an offset value which will time shift the analysis allowing for comparing metrics against a pre-deployment baseline. This PR adds the required new components in deck-kayenta, as well as some new helper fields for enabling support of this new feature.

This PR depends on another PR to be merged and published first due to the dependecy bump of @spinnaker/kayenta to 0.0.75. This PR is required to be merged first: https://github.com/spinnaker/deck-kayenta/pull/422