### PR TITLE
fix(pipeline/executionStatus): "details" link hidden by scrollbar.

### DIFF
--- a/app/scripts/modules/core/src/pipeline/status/executionStatus.less
+++ b/app/scripts/modules/core/src/pipeline/status/executionStatus.less
@@ -1,7 +1,7 @@
 .execution-status-section {
   display: inline-block;
   width: 180px;
-  overflow-y: hidden;
+  overflow: hidden;
   font-size: 0.8em;
   line-height: 12px;
   .status {


### PR DESCRIPTION
If the div showing execution status is too long on the X axis, the scrollbar will appear. That scrollbar, in conjunction with the `overflow-y: hidden` results in the "detail" link being impossible to click on.

<kbd>![56130276-b9db7580-5f84-11e9-91d3-8066fe5806de](https://user-images.githubusercontent.com/1613036/56131798-c366dc80-5f88-11e9-8c82-1d445c4dd44c.png)</kbd>

