### PR TITLE
refactor(core/amazon): allow custom load balancer creation flow

### DIFF
--- a/app/scripts/modules/amazon/src/loadBalancer/configure/AmazonLoadBalancerChoiceModal.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/AmazonLoadBalancerChoiceModal.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { Button, Modal } from 'react-bootstrap';
 
-import { ILoadBalancerModalProps, ModalClose, ReactModal, noop } from '@spinnaker/core';
+import { ILoadBalancerModalProps, ModalClose, ReactModal, noop, ReactInjector } from '@spinnaker/core';
 
-import { IAmazonLoadBalancerConfig, LoadBalancerTypes } from './LoadBalancerTypes';
+import { IAmazonLoadBalancerConfig, LoadBalancerTypes, ICloseableLoadBalancerModal } from './LoadBalancerTypes';
 
 export interface IAmazonLoadBalancerChoiceModalState {
   choices: IAmazonLoadBalancerConfig[];
@@ -38,10 +38,18 @@ export class AmazonLoadBalancerChoiceModal extends React.Component<
     this.setState({ selectedChoice: choice });
   }
 
+  private getSelectedChoiceComponent(): ICloseableLoadBalancerModal {
+    const selected = this.state.selectedChoice;
+    const override = ReactInjector.overrideRegistry.getComponent(
+      `amazon.loadBalancer.create.component.${selected.type}`,
+    ) as ICloseableLoadBalancerModal;
+    return override || selected.component;
+  }
+
   private choose = (): void => {
     const { children, ...loadBalancerProps } = this.props;
     this.close();
-    this.state.selectedChoice.component
+    this.getSelectedChoiceComponent()
       .show(loadBalancerProps)
       .then(loadBalancer => {
         this.props.closeModal(loadBalancer);

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/LoadBalancerTypes.ts
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/LoadBalancerTypes.ts
@@ -6,14 +6,16 @@ import { CreateApplicationLoadBalancer } from './application/CreateApplicationLo
 import { CreateClassicLoadBalancer } from './classic/CreateClassicLoadBalancer';
 import { CreateNetworkLoadBalancer } from './network/CreateNetworkLoadBalancer';
 
+export interface ICloseableLoadBalancerModal extends React.ComponentClass<ILoadBalancerModalProps> {
+  show: (props: ILoadBalancerModalProps) => Promise<IAmazonLoadBalancerUpsertCommand>;
+}
+
 export interface IAmazonLoadBalancerConfig {
   type: string;
   label: string;
   sublabel: string;
   description: string;
-  component: React.ComponentClass<ILoadBalancerModalProps> & {
-    show: (props: ILoadBalancerModalProps) => Promise<IAmazonLoadBalancerUpsertCommand>;
-  };
+  component: ICloseableLoadBalancerModal;
 }
 
 export const LoadBalancerTypes: IAmazonLoadBalancerConfig[] = [

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/application/CreateApplicationLoadBalancer.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/application/CreateApplicationLoadBalancer.tsx
@@ -59,7 +59,9 @@ export class CreateApplicationLoadBalancer extends React.Component<
   constructor(props: ICreateApplicationLoadBalancerProps) {
     super(props);
 
-    const loadBalancerCommand = props.loadBalancer
+    const loadBalancerCommand = props.command
+      ? (props.command as IAmazonApplicationLoadBalancerUpsertCommand) // ejecting from a wizard
+      : props.loadBalancer
       ? AwsReactInjector.awsLoadBalancerTransformer.convertApplicationLoadBalancerForEditing(props.loadBalancer)
       : AwsReactInjector.awsLoadBalancerTransformer.constructNewApplicationLoadBalancerTemplate(props.app);
 

--- a/app/scripts/modules/amazon/src/loadBalancer/index.ts
+++ b/app/scripts/modules/amazon/src/loadBalancer/index.ts
@@ -5,3 +5,4 @@ export * from './loadBalancer.transformer';
 export * from './TargetGroup';
 export * from './TargetGroupDetails';
 export * from './configure/common/AmazonCertificateSelectField';
+export * from './configure/LoadBalancerTypes';

--- a/app/scripts/modules/amazon/src/loadBalancer/loadBalancer.transformer.ts
+++ b/app/scripts/modules/amazon/src/loadBalancer/loadBalancer.transformer.ts
@@ -1,4 +1,13 @@
-import { AccountService, Application, IHealth, IInstance, IServerGroup, IVpc, NameUtils } from '@spinnaker/core';
+import {
+  AccountService,
+  Application,
+  IHealth,
+  IInstance,
+  IServerGroup,
+  IVpc,
+  NameUtils,
+  SETTINGS,
+} from '@spinnaker/core';
 import { AWSProviderSettings } from 'amazon/aws.settings';
 import {
   IALBListenerCertificate,
@@ -511,6 +520,7 @@ export class AwsLoadBalancerTransformer {
     const defaultCredentials = application.defaultCredentials.aws || AWSProviderSettings.defaults.account,
       defaultRegion = application.defaultRegions.aws || AWSProviderSettings.defaults.region,
       defaultSubnetType = AWSProviderSettings.defaults.subnetType,
+      defaultPort = application.attributes.instancePort || SETTINGS.defaultInstancePort,
       defaultTargetGroupName = `targetgroup`;
     return {
       name: '',
@@ -530,7 +540,7 @@ export class AwsLoadBalancerTransformer {
         {
           name: defaultTargetGroupName,
           protocol: 'HTTP',
-          port: 7001,
+          port: defaultPort,
           targetType: 'instance',
           healthCheckProtocol: 'HTTP',
           healthCheckPort: 'traffic-port',

--- a/app/scripts/modules/core/src/domain/ISubnet.ts
+++ b/app/scripts/modules/core/src/domain/ISubnet.ts
@@ -8,5 +8,6 @@ export interface ISubnet {
   label: string;
   purpose: string;
   deprecated: boolean;
+  target?: string;
   vpcId?: string;
 }

--- a/app/scripts/modules/core/src/loadBalancer/CreateLoadBalancerButton.tsx
+++ b/app/scripts/modules/core/src/loadBalancer/CreateLoadBalancerButton.tsx
@@ -13,6 +13,7 @@ export interface ILoadBalancerModalProps extends IModalComponentProps {
   app: Application;
   forPipelineConfig?: boolean;
   loadBalancer: ILoadBalancer;
+  command?: ILoadBalancerUpsertCommand; // optional, when ejecting from a wizard
   closeModal?(loadBalancerCommand: ILoadBalancerUpsertCommand): void; // provided by ReactModal
   dismissModal?(rejectReason?: any): void; // provided by ReactModal
 }

--- a/app/scripts/modules/core/src/presentation/forms/inputs/NumberInput.tsx
+++ b/app/scripts/modules/core/src/presentation/forms/inputs/NumberInput.tsx
@@ -24,11 +24,11 @@ export class NumberInput extends React.Component<INumberInputProps> {
   };
 
   public componentDidMount() {
-    this.props.validation.addValidator(this.validator);
+    this.props.validation && this.props.validation.addValidator(this.validator);
   }
 
   public componentWillUnmount() {
-    this.props.validation.removeValidator(this.validator);
+    this.props.validation && this.props.validation.removeValidator(this.validator);
   }
 
   public render() {


### PR DESCRIPTION
Working on a custom, wizard-driven flow for creating ALBs. It's very much tailored to Netflix for now, but will revisit it once we're happy with the flow.

These are the pieces that seem necessary to allow overriding (and ejecting from the wizard back into the default modal).