### PR TITLE
fix(titus): send serverGroupName when terminating instances

### DIFF
--- a/app/scripts/modules/titus/src/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/titus/src/instance/details/instance.details.controller.js
@@ -171,7 +171,7 @@ module.exports = angular
         var submitMethod = function() {
           let params = { cloudProvider: 'titus' };
           if (instance.serverGroup) {
-            params.managedInstanceGroupName = instance.serverGroup;
+            params.serverGroupName = instance.serverGroup;
           }
           return instanceWriter.terminateInstance(instance, app, params);
         };


### PR DESCRIPTION
Something changed somewhere in Orca or Clouddriver that is causing grief terminating Titus instances when we send `managedInstanceGroupName` instead of `serverGroupName`