### PR TITLE
fix(stage): remove pipeline filter for findArtifactFromExecution

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/findArtifactFromExecution/findArtifactFromExecution.controller.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/findArtifactFromExecution/findArtifactFromExecution.controller.ts
@@ -60,7 +60,7 @@ export class FindArtifactFromExecutionCtrl implements IController {
     this.state.pipelinesLoaded = false;
     if (this.stage.application) {
       PipelineConfigService.getPipelinesForApplication(this.stage.application).then(ps => {
-        this.state.pipelines = ps.filter(p => p.id !== this.$scope.pipeline.id);
+        this.state.pipelines = ps;
         this.state.pipelinesLoaded = true;
       });
     }


### PR DESCRIPTION
The 'Find Artifact From Execution' stage has always filtered out the current stage when populating the pipeline choice dropdown in the UI. This places an unnecessary restriction on using artifacts from the current pipeline. An example use case for this is to pull a baseline artifact from the previous execution of the pipeline for ACA. This change removes the filter, allowing the current pipeline to be selected in the UI.