### PR TITLE
chore(core): Bump version to 0.0.352

### DIFF
--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/core",
-  "version": "0.0.351",
+  "version": "0.0.352",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
### chore(core): Bump version to 0.0.352

0a5fd58ed76c894f9a8b0ab7027bd07e0dfc43ce refactor(*): remove cache-clearing calls that do not do anything (#6861)
a084b74ccffb3781eb8b534e8e6799d841c3ea28 fix(core): do not assume READ and WRITE are set on app permissions attribute (#6862)
0333b67defc62ae77cf5e48096ce7ea4715c1a5b fix(stage): remove pipeline filter for findArtifactFromExecution (#6858)