### PR TITLE
fix(core): conditionally show/label parameters section of execution bar

### DIFF
--- a/app/scripts/modules/core/src/pipeline/executions/execution/execution.less
+++ b/app/scripts/modules/core/src/pipeline/executions/execution/execution.less
@@ -127,6 +127,6 @@ execution-details-section-nav {
   }
 }
 
-.execution-details-button {
-  margin-top: 6px;
+.execution-parameters-button {
+  margin-bottom: 6px;
 }

--- a/app/scripts/modules/core/src/pipeline/status/ExecutionParameters.spec.tsx
+++ b/app/scripts/modules/core/src/pipeline/status/ExecutionParameters.spec.tsx
@@ -4,8 +4,7 @@ import { mock } from 'angular';
 
 import { REACT_MODULE } from 'core/reactShims';
 
-import { IExecutionParametersProps, ExecutionParameters } from './ExecutionParameters';
-import { IDisplayableParameter } from 'core/pipeline';
+import { IExecutionParametersProps, ExecutionParameters, IDisplayableParameter } from './ExecutionParameters';
 
 describe('<ExecutionParameters/>', () => {
   let component: ShallowWrapper<IExecutionParametersProps>;

--- a/app/scripts/modules/core/src/pipeline/status/ExecutionParameters.tsx
+++ b/app/scripts/modules/core/src/pipeline/status/ExecutionParameters.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
 
-import { IDisplayableParameter } from 'core/pipeline';
-
 import './executionStatus.less';
 import './executionParameters.less';
 
@@ -9,6 +7,13 @@ export interface IExecutionParametersProps {
   shouldShowAllParams: boolean;
   displayableParameters: IDisplayableParameter[];
   pinnedDisplayableParameters: IDisplayableParameter[];
+}
+
+export interface IDisplayableParameter {
+  key: string;
+  value: string;
+  showTruncatedValue?: boolean;
+  valueTruncated?: string;
 }
 
 interface IExecutionParametersState {

--- a/app/scripts/modules/core/src/pipeline/status/ExecutionStatus.tsx
+++ b/app/scripts/modules/core/src/pipeline/status/ExecutionStatus.tsx
@@ -19,7 +19,6 @@ import './executionStatus.less';
 export interface IExecutionStatusProps {
   execution: IExecution;
   showingDetails: boolean;
-  showingParams: boolean;
   standalone: boolean;
 }
 

--- a/app/scripts/modules/core/src/pipeline/status/ParametersAndArtifacts.tsx
+++ b/app/scripts/modules/core/src/pipeline/status/ParametersAndArtifacts.tsx
@@ -1,0 +1,153 @@
+import * as React from 'react';
+import { keyBy, truncate } from 'lodash';
+import memoizeOne from 'memoize-one';
+
+import { IExecution, IPipeline } from 'core/domain';
+import { SETTINGS } from 'core/config/settings';
+
+import { ExecutionParameters, IDisplayableParameter } from './ExecutionParameters';
+import { ResolvedArtifactList } from './ResolvedArtifactList';
+
+export interface IParametersAndArtifactsProps {
+  execution: IExecution;
+  pipelineConfig: IPipeline;
+  expandParamsOnInit: boolean;
+}
+
+export interface IParametersAndArtifactsState {
+  showingParams: boolean;
+}
+
+export class ParametersAndArtifacts extends React.Component<
+  IParametersAndArtifactsProps,
+  IParametersAndArtifactsState
+> {
+  constructor(props: IParametersAndArtifactsProps) {
+    super(props);
+    this.state = {
+      showingParams: props.expandParamsOnInit,
+    };
+  }
+
+  private toggleParams = (): void => {
+    const { showingParams } = this.state;
+    this.setState({ showingParams: !showingParams });
+  };
+
+  private getDisplayableParameters = memoizeOne(
+    (
+      execution: IExecution,
+      pipelineConfig: IPipeline,
+    ): { displayableParameters: IDisplayableParameter[]; pinnedDisplayableParameters: IDisplayableParameter[] } => {
+      // these are internal parameters that are not useful to end users
+      const strategyExclusions = [
+        'parentPipelineId',
+        'strategy',
+        'parentStageId',
+        'deploymentDetails',
+        'cloudProvider',
+      ];
+
+      const truncateLength = 200;
+
+      const isParamDisplayable = (paramKey: string) =>
+        execution.isStrategy ? !strategyExclusions.includes(paramKey) : true;
+
+      const displayableParameters: IDisplayableParameter[] = Object.keys(
+        (execution.trigger && execution.trigger.parameters) || {},
+      )
+        .filter(isParamDisplayable)
+        .sort()
+        .map((key: string) => {
+          const value = JSON.stringify(execution.trigger.parameters[key]);
+          const showTruncatedValue = value.length > truncateLength;
+          let valueTruncated;
+          if (showTruncatedValue) {
+            valueTruncated = truncate(value, { length: truncateLength });
+          }
+          return { key, value, valueTruncated, showTruncatedValue };
+        });
+
+      let pinnedDisplayableParameters: IDisplayableParameter[] = [];
+
+      if (pipelineConfig) {
+        const paramConfigIndexByName = keyBy(pipelineConfig.parameterConfig, 'name');
+        const isParamPinned = (param: IDisplayableParameter): boolean =>
+          paramConfigIndexByName[param.key] && paramConfigIndexByName[param.key].pinned; // an older execution's parameter might be missing from a newer pipelineConfig.parameterConfig
+
+        pinnedDisplayableParameters = displayableParameters.filter(isParamPinned);
+      }
+
+      return { displayableParameters, pinnedDisplayableParameters };
+    },
+  );
+
+  private getLabel(displayableParameters: IDisplayableParameter[]): string {
+    const { execution } = this.props;
+    const { trigger } = execution;
+    const { resolvedExpectedArtifacts } = trigger;
+
+    const showParameters = displayableParameters.length > 0;
+    const showArtifacts = resolvedExpectedArtifacts.length > 0;
+
+    if (showParameters && showArtifacts) {
+      return `Parameters/Artifacts (${displayableParameters.length}/${resolvedExpectedArtifacts.length})`;
+    }
+    if (showParameters) {
+      return `Parameters (${displayableParameters.length})`;
+    }
+    return `Artifacts (${resolvedExpectedArtifacts.length})`;
+  }
+
+  public render() {
+    const { execution, pipelineConfig } = this.props;
+    const { showingParams } = this.state;
+
+    const { displayableParameters, pinnedDisplayableParameters } = this.getDisplayableParameters(
+      execution,
+      pipelineConfig,
+    );
+
+    const { trigger } = execution;
+    const { artifacts, resolvedExpectedArtifacts } = trigger;
+
+    const parametersAndArtifactsExpanded =
+      showingParams ||
+      (displayableParameters.length === pinnedDisplayableParameters.length && !resolvedExpectedArtifacts.length);
+
+    if (!displayableParameters.length && !resolvedExpectedArtifacts.length) {
+      return null;
+    }
+
+    const label = this.getLabel(displayableParameters);
+
+    return (
+      <>
+        <div className="execution-parameters-button">
+          <a className="clickable" onClick={this.toggleParams}>
+            <span
+              className={`small glyphicon ${
+                parametersAndArtifactsExpanded ? 'glyphicon-chevron-down' : 'glyphicon-chevron-right'
+              }`}
+            />
+            {parametersAndArtifactsExpanded ? '' : 'View All '}
+            {label}
+          </a>
+        </div>
+        <ExecutionParameters
+          shouldShowAllParams={showingParams}
+          displayableParameters={displayableParameters}
+          pinnedDisplayableParameters={pinnedDisplayableParameters}
+        />
+
+        {SETTINGS.feature.artifacts && (
+          <ResolvedArtifactList
+            artifacts={artifacts}
+            resolvedExpectedArtifacts={resolvedExpectedArtifacts}
+            showingExpandedArtifacts={showingParams}
+          />
+        )}
+      </>
+    );
+  }
+}


### PR DESCRIPTION
Hides the parameters/artifacts section if no parameters or artifacts are present:

_Current_
<img width="192" alt="Screen Shot 2019-04-18 at 2 27 30 PM" src="https://user-images.githubusercontent.com/73450/56392385-328d3c80-61e6-11e9-807f-84e7f03d907e.png">
_PR_
<img width="193" alt="Screen Shot 2019-04-18 at 2 26 30 PM" src="https://user-images.githubusercontent.com/73450/56392386-3325d300-61e6-11e9-88e9-9c77ac69d0ab.png">

Also changing the label: if there are no artifacts, just show "parameters"; if there are no parameters, just show "artifacts":

_Current_
<img width="187" alt="Screen Shot 2019-04-18 at 2 27 48 PM" src="https://user-images.githubusercontent.com/73450/56392407-39b44a80-61e6-11e9-8cc2-741c2d37e23f.png">
_PR_
<img width="186" alt="Screen Shot 2019-04-18 at 2 27 55 PM" src="https://user-images.githubusercontent.com/73450/56392409-3a4ce100-61e6-11e9-876e-1c5efbf074ec.png">
