### PR TITLE
 feat(kubernetes): validate text manifests when rollout strategies enabled

### DIFF
--- a/app/scripts/modules/core/src/config/settings.ts
+++ b/app/scripts/modules/core/src/config/settings.ts
@@ -51,7 +51,6 @@ export interface IFeatures {
   // whether stages affecting infrastructure (like "Create Load Balancer") should be enabled or not
   infrastructureStages?: boolean;
   jobs?: boolean;
-  kubernetesRolloutStrategies?: boolean;
   managedPipelineTemplatesV2UI?: boolean;
   managedServiceAccounts?: boolean;
   notifications?: boolean;

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifest.validator.ts
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifest.validator.ts
@@ -2,6 +2,10 @@ import { get, isEmpty } from 'lodash';
 
 import { IPipeline, IStage, IValidatorConfig, ICustomValidator } from '@spinnaker/core';
 
+import { strategyRedBlack } from 'kubernetes/v2/rolloutStrategy/redblack.strategy';
+
+const MAX_VERSION_HISTORY_ANNOTATION = 'strategy.spinnaker.io/max-version-history';
+
 export const deployManifestValidators = (): IValidatorConfig[] => {
   return [
     {
@@ -11,6 +15,20 @@ export const deployManifestValidators = (): IValidatorConfig[] => {
         const services = get(stage, 'trafficManagement.options.services', []);
         if (enabled && isEmpty(services)) {
           return `Select at least one <strong>Service</strong> to enable Spinnaker-managed rollout strategy options.`;
+        }
+        if (enabled && stage.source === 'text') {
+          const manifests = get(stage, 'manifests', []);
+          if (manifests.length !== 1 || get(manifests, [0, 'kind']) !== 'ReplicaSet') {
+            return 'Spinnaker can manage traffic for ReplicaSets only. Please enter exactly one ReplicaSet manifest or disable rollout strategies.';
+          }
+          const strategy = get(stage, 'trafficManagement.options.strategy');
+          const maxVersionHistory = parseInt(
+            get(manifests, [0, 'metadata', 'annotations', MAX_VERSION_HISTORY_ANNOTATION]),
+            10,
+          );
+          if (strategy === strategyRedBlack.key && maxVersionHistory < 2) {
+            return `The max version history specified in your manifest conflicts with the behavior of the Red/Black rollout strategy. Please update your <strong>${MAX_VERSION_HISTORY_ANNOTATION}</strong> annotation to a value greater than or equal to 2.`;
+          }
         }
         return null;
       },

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestConfig.html
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestConfig.html
@@ -130,7 +130,6 @@
       </expected-artifact-multi-selector>
     </div>
     <manifest-deployment-options
-      ng-if="ctrl.checkFeatureFlag('kubernetesRolloutStrategies')"
       accounts="ctrl.metadata.backingData.accounts"
       config="ctrl.$scope.stage.trafficManagement"
       on-config-change="ctrl.handleTrafficManagementConfigChange"

--- a/settings.js
+++ b/settings.js
@@ -22,7 +22,6 @@ var fiatEnabled = process.env.FIAT_ENABLED === 'true' ? true : false;
 var gremlinEnabled = process.env.GREMLIN_ENABLED === 'false' ? false : true;
 var iapRefresherEnabled = process.env.IAP_REFRESHER_ENABLED === 'true' ? true : false;
 var infrastructureEnabled = process.env.INFRA_ENABLED === 'true' ? true : false;
-var kubernetesRolloutStrategiesEnabled = process.env.KUBERNETES_ROLLOUT_STRATEGIES === 'true';
 var managedPipelineTemplatesV2UIEnabled = process.env.MANAGED_PIPELINE_TEMPLATES_V2_UI_ENABLED === 'true';
 var managedServiceAccountsEnabled = process.env.MANAGED_SERVICE_ACCOUNTS_ENABLED === 'true';
 var onDemandClusterThreshold = process.env.ON_DEMAND_CLUSTER_THRESHOLD || '350';
@@ -78,7 +77,6 @@ window.spinnakerSettings = {
     // whether stages affecting infrastructure (like "Create Load Balancer") should be enabled or not
     infrastructureStages: infrastructureEnabled,
     jobs: false,
-    kubernetesRolloutStrategies: kubernetesRolloutStrategiesEnabled,
     managedPipelineTemplatesV2UI: managedPipelineTemplatesV2UIEnabled,
     managedServiceAccounts: managedServiceAccountsEnabled,
     notifications: false,


### PR DESCRIPTION
- feat(kubernetes): validate text manifests when rollout strategies enabled
  - Display warning when [strategy.spinnaker.io/max-version-history](https://www.spinnaker.io/reference/providers/kubernetes-v2/#strategy) conflicts with behavior of selected strategy
  - Display warning when not (exactly) one ReplicaSet manifest is entered
- feat(kubernetes): remove rollout strategies feature flag
  - Now that Orca and Clouddriver support Kubernetes rollout strategies, it is safe to remove this feature flag