### PR TITLE
refactor(stages): FormikStageConfig to provide Formik for StageConfigs

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/FormikStageConfig.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/FormikStageConfig.tsx
@@ -3,21 +3,7 @@ import { Formik, FormikProps, FormikErrors } from 'formik';
 
 import { IStage, IPipeline } from 'core/domain';
 import { Application } from 'core/application';
-import { LayoutProvider, ResponsiveFieldLayout } from 'core/presentation';
-
-export interface IEffectProps {
-  formik: FormikProps<IStage>;
-  onChange(values: any): void;
-}
-
-class Effect extends React.Component<IEffectProps> {
-  public componentDidUpdate() {
-    this.props.onChange && this.props.onChange(this.props.formik.values);
-  }
-  public render(): null {
-    return null;
-  }
-}
+import { LayoutProvider, ResponsiveFieldLayout, WatchValue } from 'core/presentation';
 
 export interface IFormikStageConfigInjectedProps {
   application: Application;
@@ -36,9 +22,9 @@ export interface IFormikStageConfigProps {
   onChange?: (values: IStage) => void;
 }
 
-export type IFormikValidator = (values: IStage) => void | object | Promise<FormikErrors<IStage>>;
+export type IStageValidator = (values: IStage) => void | object | Promise<FormikErrors<IStage>>;
 
-const decorate = (validate: IContextualValidator, props: IFormikStageConfigProps): IFormikValidator => {
+const decorate = (validate: IContextualValidator, props: IFormikStageConfigProps): IStageValidator => {
   const { application, pipeline } = props;
   return (values: IStage) => validate(values, { application, pipeline });
 };
@@ -53,7 +39,7 @@ export class FormikStageConfig extends React.Component<IFormikStageConfigProps> 
         onSubmit={() => {}}
         render={formik => (
           <LayoutProvider value={ResponsiveFieldLayout}>
-            <Effect formik={formik} onChange={onChange} />
+            <WatchValue onChange={onChange} value={formik.values} />
             {render({ application, pipeline, formik })}
           </LayoutProvider>
         )}

--- a/app/scripts/modules/core/src/pipeline/config/stages/FormikStageConfig.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/FormikStageConfig.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import { Formik, FormikProps, FormikErrors } from 'formik';
+
+import { IStage, IPipeline } from 'core/domain';
+import { Application } from 'core/application';
+import { LayoutProvider, ResponsiveFieldLayout } from 'core/presentation';
+
+export interface IEffectProps {
+  formik: FormikProps<IStage>;
+  onChange(values: any): void;
+}
+
+class Effect extends React.Component<IEffectProps> {
+  public componentDidUpdate() {
+    this.props.onChange && this.props.onChange(this.props.formik.values);
+  }
+  public render(): null {
+    return null;
+  }
+}
+
+export interface IFormikStageConfigInjectedProps {
+  application: Application;
+  pipeline: IPipeline;
+  formik: FormikProps<IStage>;
+}
+
+export type IContextualValidator = (values: IStage, context: any) => void | object | Promise<FormikErrors<IStage>>;
+
+export interface IFormikStageConfigProps {
+  application: Application;
+  stage: IStage;
+  pipeline: IPipeline;
+  validate?: IContextualValidator;
+  render: (props: IFormikStageConfigInjectedProps) => React.ReactNode;
+  onChange?: (values: IStage) => void;
+}
+
+export type IFormikValidator = (values: IStage) => void | object | Promise<FormikErrors<IStage>>;
+
+const decorate = (validate: IContextualValidator, props: IFormikStageConfigProps): IFormikValidator => {
+  const { application, pipeline } = props;
+  return (values: IStage) => validate(values, { application, pipeline });
+};
+
+export class FormikStageConfig extends React.Component<IFormikStageConfigProps> {
+  public render() {
+    const { render, onChange, stage, validate, application, pipeline } = this.props;
+    return (
+      <Formik<IStage>
+        validate={validate && decorate(validate, this.props)}
+        initialValues={stage}
+        onSubmit={() => {}}
+        render={formik => (
+          <LayoutProvider value={ResponsiveFieldLayout}>
+            <Effect formik={formik} onChange={onChange} />
+            {render({ application, pipeline, formik })}
+          </LayoutProvider>
+        )}
+      />
+    );
+  }
+}

--- a/app/scripts/modules/core/src/pipeline/config/stages/StageConfigWrapper.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/StageConfigWrapper.tsx
@@ -18,6 +18,7 @@ export class StageConfigWrapper extends React.Component<IStageConfigWrapperProps
     const { component: StageConfig, updateStageField, ...otherProps } = this.props;
     return (
       <StageConfig
+        updateStage={updateStageField}
         updateStageField={(changes: { [key: string]: any }) => {
           updateStageField(changes);
           this.forceUpdate();

--- a/app/scripts/modules/core/src/pipeline/config/stages/common/IStageConfigProps.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/common/IStageConfigProps.ts
@@ -7,5 +7,6 @@ export interface IStageConfigProps {
   pipeline: IPipeline;
   configuration?: any;
   stageFieldUpdated: () => void;
+  updateStage: (changes: { [key: string]: any }) => void;
   updateStageField: (changes: { [key: string]: any }) => void;
 }

--- a/app/scripts/modules/core/src/pipeline/index.ts
+++ b/app/scripts/modules/core/src/pipeline/index.ts
@@ -15,3 +15,4 @@ export * from './executions/execution/Execution';
 export * from './filter/ExecutionFilterModel';
 export * from './manualExecution/TriggerTemplate';
 export * from './service/execution.service';
+export * from './config/stages/FormikStageConfig';

--- a/app/scripts/modules/core/src/presentation/forms/layouts/ResponsiveFieldLayout.tsx
+++ b/app/scripts/modules/core/src/presentation/forms/layouts/ResponsiveFieldLayout.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+import * as classNames from 'classnames';
+
+import { HelpContextProvider } from 'core/help';
+
+import { IFieldLayoutProps } from '../interface';
+
+import '../forms.less';
+
+export class ResponsiveFieldLayout extends React.Component<IFieldLayoutProps> {
+  public render() {
+    const { label, help, input, actions, validationMessage, validationStatus } = this.props;
+    const showLabel = !!label || !!help;
+
+    const helpUnder = false;
+
+    return (
+      <HelpContextProvider value={helpUnder}>
+        <div className="sp-formItem">
+          <div className="sp-formItem__left">
+            {showLabel && (
+              <div className="sp-formLabel">
+                {label} {!helpUnder && help}
+              </div>
+            )}
+          </div>
+          <div className="sp-formItem__right">
+            <div className="sp-form">
+              <span className="field">
+                {input} {actions}
+              </span>
+            </div>
+            {helpUnder && help && <div className="description">{help}</div>}
+            {validationMessage && (
+              <div
+                className={classNames('messageContainer', {
+                  errorMessage: validationStatus === 'error',
+                  warningMessage: validationStatus === 'warning',
+                  previewMessage: validationStatus === 'message',
+                })}
+              >
+                <i />
+                <div className="message">{validationMessage}</div>
+              </div>
+            )}
+          </div>
+        </div>
+      </HelpContextProvider>
+    );
+  }
+}

--- a/app/scripts/modules/core/src/presentation/forms/layouts/index.ts
+++ b/app/scripts/modules/core/src/presentation/forms/layouts/index.ts
@@ -1,2 +1,3 @@
 export * from './StandardFieldLayout';
 export * from './LayoutContext';
+export * from './ResponsiveFieldLayout';


### PR DESCRIPTION
The goal is to ultimately make stage configs simpler, more composable and have less boilerplate, something like:
```
        <FormikFormField name="x" label="X" input={props => <TextInput {...props} />} />  
        <FormikFormField name="y" label="Y" input={props => <AccountSelectInput {...props} />} />  
        <FormikFormField name="z" label="Z" input={props => <RegionSelectInput {...props} />} />  
```

This means:
- Using `<FormikFormFields>` so that 1) form state can be managed by Formik and 2) layout is handled by `FieldLayout`s
- `Formik` for stages should be wired up in a consistent way
- `FieldLayout` inherited via context so that it doesn't have to be explicitly wired up

`<FormikStageConfig>` handles the latter 2 so that those details don't need to be part of every single stage.
Instead stage configs can simply focus on:
- Mapping `Input`s (simple or complex) to form fields
- UI state but not form state (i.e. "show advanced options")
- Validation

And in practice probably look something more like:
```
const ConfigureSomethingStage = stageConfigProps => (
  <FormikStageConfig {...stageConfigProps} onChange={stageConfigProps.updateStage} validate={validate} 
    render={({ application, pipeline, formik }) => (
      <div className="form-horizontal">
        <FormikFormField name="x" label="X" input={props => <TextInput {...props} />} />  
        <FormikFormField name="y" label="Y" input={props => <TextInput {...props} />} />  
        <FormikFormField name="z" label="Z" input={props => <TextInput {...props} />} />  
      </div>
    )}
  />
)
```

A better example might be the following works in progress of actual stages using `<FormikStageConfig>`:
- [Script stage](https://github.com/alanmquach/deck/commit/1b528c498e95846f91b98ffdc8551bd0dfb5b290)
- [Titus run job stage](https://github.com/alanmquach/deck/commit/6d03a2ff75dce35f1b1f322019cae9d40329e33e)

TODO:
- [ ] Still need to somehow wire up the the pipeline validation (the one that turns the stage nodes red) to use the new form-level `validate()`.