### PR TITLE
chore(titus): Bump version to 0.0.89

### DIFF
--- a/app/scripts/modules/titus/package.json
+++ b/app/scripts/modules/titus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/titus",
-  "version": "0.0.88",
+  "version": "0.0.89",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
### chore(titus): Bump version to 0.0.89

9a622f0edea428a5582aa17ba8b42be1a454d4c9 fix(titus): correctly render JSON objects in run job details (#6872)


