### PR TITLE
fix(docker): Fix subscription leak in DockerTriggerTemplate

### DIFF
--- a/app/scripts/modules/docker/src/pipeline/trigger/DockerTriggerTemplate.tsx
+++ b/app/scripts/modules/docker/src/pipeline/trigger/DockerTriggerTemplate.tsx
@@ -117,19 +117,22 @@ export class DockerTriggerTemplate extends React.Component<
     const { command } = this.props;
     command.triggerInvalid = true;
 
+    // These fields will be added to the trigger when the form is submitted
+    command.extraFields = {};
+
+    if (this.subscription) {
+      this.subscription.unsubscribe();
+    }
+
+    // cancel search stream if trigger has changed to some other type
+    if (command.trigger.type !== 'docker') {
+      return;
+    }
+
     this.subscription = this.queryStream
       .debounceTime(250)
       .switchMap(this.handleQuery)
       .subscribe(this.tagLoadSuccess, this.tagLoadFailure);
-
-    // These fields will be added to the trigger when the form is submitted
-    command.extraFields = {};
-
-    // cancel search stream if trigger has changed to some other type
-    if (command.trigger.type !== 'docker') {
-      this.subscription.unsubscribe();
-      return;
-    }
 
     this.searchTags();
   };
@@ -142,6 +145,12 @@ export class DockerTriggerTemplate extends React.Component<
 
   public componentDidMount() {
     this.initialize();
+  }
+
+  public componentWillUnmount() {
+    if (this.subscription) {
+      this.subscription.unsubscribe();
+    }
   }
 
   private searchTags = (query = '') => {


### PR DESCRIPTION
## WHAT

This pull request changes `initialize` function and added `componentWillUnmount` function to make sure the subscription unsubscribed properly.

## WHY

I found an issue that `Manual Execution` modal sent duplicate HTTP request to "/images/tags" endpoint.

For example, if you click `Start Manual Execution` button, select a pipeline, 1 OPTION method and 1 GET method request, it's **fine**:

<kbd><img width="1151" alt="1" src="https://user-images.githubusercontent.com/20374/56544754-58cd2680-65b0-11e9-8343-6bed0a519c4c.png"></kbd>

<kbd><img width="1153" alt="2" src="https://user-images.githubusercontent.com/20374/56544762-5ff43480-65b0-11e9-87f3-ef6fe6ba956f.png"></kbd>

<kbd><img width="1150" alt="3" src="https://user-images.githubusercontent.com/20374/56544768-6387bb80-65b0-11e9-8b91-fcc9fd5860bc.png"></kbd>

---

**But** if you select another pipeline, 2 same GET requests will be sent... :

<kbd><img width="1151" alt="4" src="https://user-images.githubusercontent.com/20374/56544959-ef99e300-65b0-11e9-963c-48a6ec7244f1.png"></kbd>


And if you repeat select pipelines, the number of duplicate HTTP requests will be increased... 

<kbd><img width="1151" alt="5" src="https://user-images.githubusercontent.com/20374/56544974-f9234b00-65b0-11e9-9c3a-61612eeff132.png"></kbd>


---

It seems that is caused by `subscription` leak in `DockerTriggerTemplate`.
This pull request is for fixing it.


