### PR TITLE
fix(core): make imports relative on AccountSelectInput, RegionSelectI…

### DIFF
--- a/app/scripts/modules/core/src/account/AccountSelectInput.tsx
+++ b/app/scripts/modules/core/src/account/AccountSelectInput.tsx
@@ -4,7 +4,7 @@ import { flatten, isEqual, map, uniq, xor } from 'lodash';
 import Select, { Option } from 'react-select';
 
 import { createFakeReactSyntheticEvent } from 'core/presentation/forms/inputs/utils';
-import { IFormInputProps } from 'core/presentation';
+import { IFormInputProps } from '../presentation';
 
 import { AccountService, IAccount } from './AccountService';
 

--- a/app/scripts/modules/core/src/region/RegionSelectInput.tsx
+++ b/app/scripts/modules/core/src/region/RegionSelectInput.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { IRegion } from 'core/account/AccountService';
-import { IFormInputProps } from 'core/presentation';
+import { IFormInputProps } from '../presentation';
 
 export interface IRegionSelectInputProps extends IFormInputProps {
   account: string;


### PR DESCRIPTION
All of this has happened before, all of this will happen again. I spent half an hour of looking for a cleaner solution to this issue but did not find one.

**The issue**
You cannot use these components outside the core repository if you try to add any props that are declared in `IFormInputProps`. The TS compiler doesn't flatten out the interface definitions for the `I*Props`, leaving them in the `.d.ts` files as:
```
import { IFormInputProps } from 'core/presentation';
export interface IAccountSelectInputProps extends IFormInputProps {
    accounts: IAccount[] | string[];
    provider: string;
    readOnly?: boolean;
    renderFilterableSelectThreshold?: number;
}
```
When using the library in a separate project, e.g. our internal build, the TS compiler doesn't know how to follow `core/presentation`, so it throws an error. It does not throw an error on the initial build (or when using the field in other modules in this repo, e.g. provider modules, because we have `paths` declared in the `tsconfig.json` to resolve `core/*` correctly.

This might become a much bigger and more obvious problem when we split provider modules out into separate repos or however we end up doing it. For now, this is what we do, I guess.

