### PR TITLE
fix(kubernetes): hide manifest artifact selector in text mode

### DIFF
--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestConfig.html
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestConfig.html
@@ -33,6 +33,7 @@
     <hr ng-if="stage.source === ctrl.textSource" />
     <div ng-if="ctrl.checkFeatureFlag('artifactsRewrite')">
       <stage-config-field
+        ng-if="stage.source === ctrl.artifactSource"
         label="Manifest Artifact"
         help-field-key="kubernetes.manifest.expectedArtifact"
         field-columns="8"


### PR DESCRIPTION
When the artifacts rewrite feature flag is enabled, we should hide the manifest artifact selector in text mode and only show the YAML editor.

Before:
![before](https://user-images.githubusercontent.com/15936279/56614249-9fd60e80-65e6-11e9-967b-1ad28caad2fa.png)

After:
![after](https://user-images.githubusercontent.com/15936279/56614255-a4022c00-65e6-11e9-9272-424a26ffc40c.png)

