### PR TITLE
refactor(stages): Wire up Pipeline validation to stage validateFn

### DIFF
--- a/app/scripts/modules/core/src/domain/IStageOrTriggerTypeConfig.ts
+++ b/app/scripts/modules/core/src/domain/IStageOrTriggerTypeConfig.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import { ITriggerTemplateComponentProps } from '../pipeline/manualExecution/TriggerTemplate';
 import { IValidatorConfig } from '../pipeline/config/validation/PipelineConfigValidator';
+import { IContextualValidator } from 'core/pipeline';
 
 export interface IStageOrTriggerTypeConfig {
   manualExecutionComponent?: React.ComponentType<ITriggerTemplateComponentProps>;
@@ -14,4 +15,5 @@ export interface IStageOrTriggerTypeConfig {
   component?: React.ComponentType;
   providesVersionForBake?: boolean;
   validators?: IValidatorConfig[];
+  validateFn?: IContextualValidator;
 }

--- a/app/scripts/modules/core/src/pipeline/config/stages/FormikStageConfig.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/FormikStageConfig.tsx
@@ -11,7 +11,10 @@ export interface IFormikStageConfigInjectedProps {
   formik: FormikProps<IStage>;
 }
 
-export type IContextualValidator = (values: IStage, context: any) => void | object | Promise<FormikErrors<IStage>>;
+export type IContextualValidator = (
+  values: IStage,
+  context: any,
+) => FormikErrors<IStage> | Promise<FormikErrors<IStage>>;
 
 export interface IFormikStageConfigProps {
   application: Application;


### PR DESCRIPTION
Wiring up the new Formik-style stages' `validate` functions to the pipeline validator.

The old `validators` will take precedence, but the expectation is to use either or and not both, so if a stage has a `validate` function, the old `validators` should be removed.