### PR TITLE
fix(core): do not overdo showing the auth modal

### DIFF
--- a/app/scripts/modules/core/src/authentication/AuthenticationInitializer.ts
+++ b/app/scripts/modules/core/src/authentication/AuthenticationInitializer.ts
@@ -1,4 +1,5 @@
 import { Observable, Subscription } from 'rxjs';
+import { IHttpPromiseCallbackArg } from 'angular';
 import { $location, $rootScope, $http } from 'ngimport';
 
 import { LoggedOutModal } from 'core/authentication/LoggedOutModal';
@@ -19,7 +20,7 @@ export class AuthenticationInitializer {
   private static checkForReauthentication(): void {
     $http
       .get(SETTINGS.authEndpoint)
-      .then((response: ng.IHttpPromiseCallbackArg<IAuthResponse>) => {
+      .then((response: IHttpPromiseCallbackArg<IAuthResponse>) => {
         if (response.data.username) {
           AuthenticationService.setAuthenticatedUser({
             name: response.data.username,
@@ -58,7 +59,7 @@ export class AuthenticationInitializer {
     $rootScope.authenticating = true;
     $http
       .get(SETTINGS.authEndpoint)
-      .then((response: ng.IHttpPromiseCallbackArg<IAuthResponse>) => {
+      .then((response: IHttpPromiseCallbackArg<IAuthResponse>) => {
         if (response.data.username) {
           AuthenticationService.setAuthenticatedUser({
             name: response.data.username,
@@ -75,9 +76,10 @@ export class AuthenticationInitializer {
 
   public static reauthenticateUser(): void {
     if (!this.userLoggedOut) {
+      this.userLoggedOut = true;
       $http
         .get(SETTINGS.authEndpoint)
-        .then((response: ng.IHttpPromiseCallbackArg<IAuthResponse>) => {
+        .then((response: IHttpPromiseCallbackArg<IAuthResponse>) => {
           if (response.data.username) {
             AuthenticationService.setAuthenticatedUser({
               name: response.data.username,
@@ -85,6 +87,7 @@ export class AuthenticationInitializer {
               roles: response.data.roles,
             });
             $rootScope.authenticating = false;
+            this.userLoggedOut = false;
           } else {
             this.loginNotification();
           }


### PR DESCRIPTION
If the network interceptor fails on a bunch of calls that are stacked up, the logged out modal will pop up for each one, which happens when there is a network connection issue (e.g. VPN reconnection) during an app refresh. I've seen the modal pop up 10 or 11 times, which renders the background black (and also results in 10 or 11 re-authentication attempts when navigating away from, then back to, the logged out page).

This...fixes that.