### PR TITLE
fix(core): update stage failure component when JSON changes

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/overrideFailure/overrideFailure.component.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/overrideFailure/overrideFailure.component.js
@@ -46,7 +46,7 @@ module.exports = angular.module('spinnaker.core.pipeline.stage.overrideFailure',
         this.viewState.failureOption = initValue;
       };
 
-      $scope.$watch(() => this.stage, this.initializeFailureOption);
+      $scope.$watch(() => this.stage, this.initializeFailureOption, true);
     },
   ],
 });


### PR DESCRIPTION
If the user edits the `failPipeline`, `continuePipeline`, or `completeOtherBranchesThenFail` fields via the Edit Stage as JSON modal, the changes are not reflected in the view until switching to another stage.

The bug occurs because, when we edit the stage as JSON, we assign the updated stage fields to the existing stage object, instead of replacing it completely.

This is not a new bug! It's been there since this feature was added almost three years ago. It just wasn't noticed because the logic we're hiding in this component is kinda nuts so nobody tried to manually edit it. Until this morning.