### PR TITLE
fix(kubernetes): fix discrepancy between orca deploy stage model and …

### DIFF
--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestConfig.controller.ts
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestConfig.controller.ts
@@ -91,8 +91,8 @@ export class KubernetesV2DeployManifestConfigCtrl implements IController {
   public onRequiredArtifactsChanged = (bindings: IManifestBindArtifact[]) => {
     this.$scope.$applyAsync(() => {
       this.$scope.bindings = bindings;
-      this.$scope.stage.requiredArtifactIds = bindings.filter((b: IManifestBindArtifact) => b.expectedArtifactId);
-      this.$scope.stage.requiredArtifacts = bindings.filter((b: IManifestBindArtifact) => b.artifact);
+      this.$scope.stage.requiredArtifactIds = bindings.filter(b => b.expectedArtifactId).map(b => b.expectedArtifactId);
+      this.$scope.stage.requiredArtifacts = bindings.filter(b => b.artifact);
     });
   };
 


### PR DESCRIPTION
…artifacts rewrite stage model

Orca expects `requiredArtifactIds` to be a list of strings ([source](https://github.com/spinnaker/orca/blob/master/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/manifest/DeployManifestContext.java#L37)), which is what Deck sends when the artifacts rewrite flag is off.

Before:

![before1](https://user-images.githubusercontent.com/15936279/56678612-23e4d080-6691-11e9-82eb-a6ab1c014ce7.png)

![before2](https://user-images.githubusercontent.com/15936279/56678629-2cd5a200-6691-11e9-8036-196102da3839.png)

![before3](https://user-images.githubusercontent.com/15936279/56678647-36f7a080-6691-11e9-99fa-ffa6620b194a.png)

After:

![after1](https://user-images.githubusercontent.com/15936279/56678944-dc127900-6691-11e9-8354-7ce81e31dc3a.png)

![after2](https://user-images.githubusercontent.com/15936279/56678960-e59be100-6691-11e9-93a0-b4a4317d5393.png)


