### PR TITLE
fix(core): Show all app selections when creating a pipeline from mptv2

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/templates/v2/PipelineTemplatesV2.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/templates/v2/PipelineTemplatesV2.tsx
@@ -6,7 +6,7 @@ import { Subscription } from 'rxjs';
 import { UISref } from '@uirouter/react';
 
 import { PipelineTemplateV2Service } from './pipelineTemplateV2.service';
-import CreatePipelineFromTemplate from './CreatePipelineFromTemplate';
+import { CreatePipelineFromTemplate } from './createPipelineFromTemplate';
 import { IPipelineTemplateV2 } from 'core/domain/IPipelineTemplateV2';
 import { ShowPipelineTemplateJsonModal } from 'core/pipeline/config/actions/templateJson/ShowPipelineTemplateJsonModal';
 import { ReactInjector, IStateChange } from 'core/reactShims';

--- a/app/scripts/modules/core/src/pipeline/config/templates/v2/createPipelineFromTemplate/CreatePipelineFromTemplate.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/templates/v2/createPipelineFromTemplate/CreatePipelineFromTemplate.tsx
@@ -4,14 +4,16 @@ import { Option } from 'react-select';
 import { Observable, Subject } from 'rxjs';
 
 import { Application, ApplicationReader, IApplicationSummary } from 'core/application';
-import ApplicationSelector from './ApplicationSelector';
+import ApplicationSelector from '../ApplicationSelector';
 import { CreatePipelineModal } from 'core/pipeline';
 import { IPipelineTemplateV2 } from 'core/domain/IPipelineTemplateV2';
 import { ReactInjector } from 'core/reactShims';
 import { Spinner } from 'core/widgets/spinners/Spinner';
 import { SubmitButton } from 'core/modal/buttons/SubmitButton';
 
-export interface ICreatePipelineFromTemplateProps {
+import './createPipelineFromTemplate.less';
+
+interface ICreatePipelineFromTemplateProps {
   closeModalCallback: () => void;
   template: IPipelineTemplateV2;
 }
@@ -26,7 +28,7 @@ interface ICreatePipelineFromTemplateState {
   submitting: boolean;
 }
 
-export default class CreatePipelineFromTemplate extends React.Component<
+export class CreatePipelineFromTemplate extends React.Component<
   ICreatePipelineFromTemplateProps,
   ICreatePipelineFromTemplateState
 > {
@@ -128,7 +130,7 @@ export default class CreatePipelineFromTemplate extends React.Component<
     }
 
     return (
-      <Modal show={true} onHide={closeModalCallback}>
+      <Modal show={true} onHide={closeModalCallback} className="create-pipeline-from-template-modal">
         <Modal.Header closeButton={true}>
           <Modal.Title>Select An Application</Modal.Title>
         </Modal.Header>

--- a/app/scripts/modules/core/src/pipeline/config/templates/v2/createPipelineFromTemplate/createPipelineFromTemplate.less
+++ b/app/scripts/modules/core/src/pipeline/config/templates/v2/createPipelineFromTemplate/createPipelineFromTemplate.less
@@ -1,0 +1,3 @@
+.create-pipeline-from-template-modal .modal-content {
+  overflow: visible;
+}

--- a/app/scripts/modules/core/src/pipeline/config/templates/v2/createPipelineFromTemplate/index.ts
+++ b/app/scripts/modules/core/src/pipeline/config/templates/v2/createPipelineFromTemplate/index.ts
@@ -1,0 +1,1 @@
+export * from './CreatePipelineFromTemplate';


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2623242/56681671-d91a8700-6697-11e9-8fa7-cb1857d2eabd.png)
Before this fix, the application select box would get clipped at the bottom of the modal and not show "samplek8"