### PR TITLE
feat(roles): Add execute permission type to create new application.

### DIFF
--- a/app/scripts/modules/core/src/application/modal/PermissionsConfigurer.spec.tsx
+++ b/app/scripts/modules/core/src/application/modal/PermissionsConfigurer.spec.tsx
@@ -37,13 +37,14 @@ describe('PermissionsConfigurer', () => {
 
     expect(permissions).toEqual({
       READ: ['groupA', 'groupB'],
+      EXECUTE: ['groupA', 'groupB'],
       WRITE: ['groupA', 'groupB'],
     });
   });
 
   it(`populates the 'roleOptions' list with a user's roles minus the roles already used in the permissions object`, () => {
     const component = createComponent({
-      permissions: { READ: ['groupA', 'groupB'], WRITE: ['groupB'] },
+      permissions: { READ: ['groupA', 'groupB'], EXECUTE: ['groupB'], WRITE: ['groupB'] },
       requiredGroupMembership: null,
       onPermissionsChange: () => null,
     });


### PR DESCRIPTION
Applications can now have a new permission type called execute along with read and write. The application creation via the UI ensures that execute always implies read access and write always includes execute (and read).


Part of spinnaker/spinnaker#3554