### PR TITLE
feat(aws): show ALB listener redirect info in details

### DIFF
--- a/app/scripts/modules/amazon/src/loadBalancer/details/loadBalancerDetails.html
+++ b/app/scripts/modules/amazon/src/loadBalancer/details/loadBalancerDetails.html
@@ -163,6 +163,25 @@
         </div>
         <div class="listener-targets">
           <div ng-repeat="action in listener.actions">
+            <!-- redirect -->
+            <span ng-if="action.type === 'redirect'">
+              <span ng-if="action.redirectConfig.protocol !== listener.protocol">
+                {{action.redirectConfig.protocol}}:
+              </span>
+              <span ng-if="action.redirectConfig.host !== '#{host}'">
+                {{action.redirectConfig.host}}
+              </span>
+              <span ng-if="action.redirectConfig.port !== '#{port}'">
+                {{action.redirectConfig.port}}
+              </span>
+              <span ng-if="action.redirectConfig.path !== '/#{path}'">
+                {{action.redirectConfig.path}}
+              </span>
+              <span ng-if="action.redirectConfig.query !== '#{query}'">
+                ?{{action.redirectConfig.query}}
+              </span>
+              ({{action.redirectConfig.statusCode}})
+            </span>
             <!-- authenticate-oidc -->
             <span ng-if="action.type === 'authenticate-oidc'">
               <i class="fas fa-fw fa-user-lock"></i>


### PR DESCRIPTION
Users have to edit the load balancer right now to see details on a redirect action, no good.

Before:
<img width="229" alt="Screen Shot 2019-04-29 at 9 09 50 AM" src="https://user-images.githubusercontent.com/73450/56910100-96bdc500-6a5e-11e9-89bb-b2db779d4792.png">

After:
<img width="257" alt="Screen Shot 2019-04-29 at 9 09 28 AM" src="https://user-images.githubusercontent.com/73450/56910107-9ae9e280-6a5e-11e9-8a27-882b4dc222e2.png">
