### PR TITLE
fix(core): use relative imports for ReactSelectInput

### DIFF
--- a/app/scripts/modules/core/src/presentation/forms/inputs/ReactSelectInput.tsx
+++ b/app/scripts/modules/core/src/presentation/forms/inputs/ReactSelectInput.tsx
@@ -1,11 +1,13 @@
 import * as React from 'react';
 import Select, { Option, ReactSelectProps } from 'react-select';
 
-import { OmitControlledInputPropsFrom, StringsAsOptions, TetheredSelect } from 'core/presentation';
 import { noop } from 'core/utils';
 
+import { StringsAsOptions } from './StringsAsOptions';
+import { TetheredSelect } from '../../TetheredSelect';
+
 import { createFakeReactSyntheticEvent, isStringArray, orEmptyString } from './utils';
-import { IFormInputProps } from '../interface';
+import { IFormInputProps, OmitControlledInputPropsFrom } from '../interface';
 
 interface IReactSelectInputProps extends IFormInputProps, OmitControlledInputPropsFrom<ReactSelectProps> {
   stringOptions?: string[];


### PR DESCRIPTION
I tried three or four different libraries that are supposed to transform `.d.ts` file imports from path aliases to relative paths, but couldn't get any of them to work. Maybe because of our weird "node modules at the top, tsconfig and webpack config at the bottom" setup? I don't know, but I gave up and felt sad about it.