### PR TITLE
feat(cf): add build info to server group

### DIFF
--- a/app/scripts/modules/cloudfoundry/src/domain/ICloudFoundryServerGroup.ts
+++ b/app/scripts/modules/cloudfoundry/src/domain/ICloudFoundryServerGroup.ts
@@ -16,6 +16,7 @@ export interface ICloudFoundryServerGroup extends IServerGroup {
   droplet?: ICloudFoundryDroplet;
   serviceInstances: ICloudFoundryServiceInstance[];
   env: ICloudFoundryEnvVar[];
+  ciBuild: ICloudFoundryBuildInfo;
 }
 
 export interface ICloudFoundryServiceInstance {
@@ -28,4 +29,11 @@ export interface ICloudFoundryServiceInstance {
 export interface ICloudFoundryEnvVar {
   key: string;
   value: string;
+}
+
+export interface ICloudFoundryBuildInfo {
+  jobName: string;
+  jobNumber: string;
+  jobUrl: string;
+  version: string;
 }

--- a/app/scripts/modules/cloudfoundry/src/serverGroup/details/sections/PackageSection.tsx
+++ b/app/scripts/modules/cloudfoundry/src/serverGroup/details/sections/PackageSection.tsx
@@ -16,6 +16,32 @@ export class PackageSection extends React.Component<ICloudFoundryServerGroupDeta
         {serverGroup.droplet && serverGroup.droplet.sourcePackage && (
           <CollapsibleSection heading="Package" defaultExpanded={true}>
             <dl className="dl-horizontal dl-flex">
+              {serverGroup.ciBuild && serverGroup.ciBuild.version && (
+                <div>
+                  <dt>Version</dt>
+                  <dd>{serverGroup.ciBuild.version}</dd>
+                </div>
+              )}
+              {serverGroup.ciBuild && serverGroup.ciBuild.jobName && (
+                <div>
+                  <dt>Job</dt>
+                  <dd>{serverGroup.ciBuild.jobName}</dd>
+                </div>
+              )}
+              {serverGroup.ciBuild && serverGroup.ciBuild.jobNumber && (
+                <div>
+                  <dt>Build</dt>
+                  {serverGroup.ciBuild.jobUrl ? (
+                    <dd>
+                      <a target="_blank" href={serverGroup.ciBuild.jobUrl}>
+                        {serverGroup.ciBuild.jobNumber}
+                      </a>
+                    </dd>
+                  ) : (
+                    <dd>{serverGroup.ciBuild.jobNumber}</dd>
+                  )}
+                </div>
+              )}
               <dt>Checksum</dt>
               <dd>{serverGroup.droplet.sourcePackage.checksum}</dd>
             </dl>


### PR DESCRIPTION
This is similar to how it is represented in the AWS impl. We could probably standardize the attributes across providers. I’m using “ciBuild” rather than “buildinfo” because CF already has a “buildinfo” that refers to creating the droplet with a build pack. In the view I prefer to incorporate the link with the build number rather than show it explicitly. There is not a lot of horizontal real estate in the detail side panels.

![Screen Shot 2019-04-30 at 11 07 10 AM](https://user-images.githubusercontent.com/2743/56976278-3602bb00-6b38-11e9-835e-a79e602c8ffb.png)
