### PR TITLE
fix(core): Fixed exception while configuring strategies

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/pipelineConfig.controller.js
+++ b/app/scripts/modules/core/src/pipeline/config/pipelineConfig.controller.js
@@ -26,7 +26,8 @@ module.exports = angular
 
       this.initialize = () => {
         this.pipelineConfig = _.find(app.pipelineConfigs.data, { id: $stateParams.pipelineId });
-        const isV2PipelineConfig = PipelineTemplateV2Service.isV2PipelineConfig(this.pipelineConfig);
+        const isV2PipelineConfig =
+          this.pipelineConfig && PipelineTemplateV2Service.isV2PipelineConfig(this.pipelineConfig);
 
         if (this.pipelineConfig && isV2PipelineConfig && !SETTINGS.feature.managedPipelineTemplatesV2UI) {
           return $state.go('home.applications.application.pipelines.executions', null, { location: 'replace' });


### PR DESCRIPTION
Strategies exist in `app.strategyConfigs` so `this.pipelineConfig` will be undefined `PipelineTemplateV2Service.isV2PipelineConfig` isn't protected against that.

Typescript probably would've caught this!