### PR TITLE
feat(core): add ChecklistInput form component

### DIFF
--- a/app/scripts/modules/core/src/presentation/forms/inputs/ChecklistInput.tsx
+++ b/app/scripts/modules/core/src/presentation/forms/inputs/ChecklistInput.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+
+import { createFakeReactSyntheticEvent, orEmptyString, validationClassName } from './utils';
+import { IFormInputProps, OmitControlledInputPropsFrom } from '../interface';
+
+interface IChecklistInputProps extends IFormInputProps, OmitControlledInputPropsFrom<React.InputHTMLAttributes<any>> {
+  options: string[];
+}
+
+export class ChecklistInput extends React.Component<IChecklistInputProps> {
+  public render() {
+    const { value, validation, inputClassName, options, onChange, ...otherProps } = this.props;
+    const className = `${orEmptyString(inputClassName)} ${validationClassName(validation)}`;
+
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+      const selected = e.target.value;
+      let newValue = value.concat(selected);
+      if (value.includes(selected)) {
+        newValue = value.filter((v: string) => v !== selected);
+      }
+      onChange(createFakeReactSyntheticEvent({ value: newValue, name: e.target.name }));
+    };
+
+    return (
+      <div className="checklist">
+        {options.map(o => (
+          <div className="checkbox" key={o}>
+            <label>
+              <input
+                className={className}
+                type="checkbox"
+                value={o}
+                onChange={e => handleChange(e)}
+                checked={!!value.includes(o)}
+                {...otherProps}
+              />
+              {o}
+            </label>
+          </div>
+        ))}
+      </div>
+    );
+  }
+}

--- a/app/scripts/modules/core/src/presentation/forms/inputs/index.ts
+++ b/app/scripts/modules/core/src/presentation/forms/inputs/index.ts
@@ -1,4 +1,5 @@
 export * from './CheckboxInput';
+export * from './ChecklistInput';
 export * from './JsonEditor';
 export * from './NumberInput';
 export * from './RadioButtonInput';


### PR DESCRIPTION
Not sure if there is a better way to handle this.

I need a form input to handle toggling an array of strings, e.g. days of the week:
```
{
  days: ['Monday', 'Wednesday', 'Friday']
}
```

Usage:
```html
<FormikFormField
  name="days"
  label="Days"
  input={props => <ChecklistInput {...props} options={['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday']} />}
/>
```