### PR TITLE
feat(gcb): add gcb-specific execution details tab

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/googleCloudBuild/GoogleCloudBuildExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/googleCloudBuild/GoogleCloudBuildExecutionDetails.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import { capitalize, get } from 'lodash';
+
+import { IExecutionDetailsSectionProps, ExecutionDetailsSection } from 'core/pipeline';
+
+export class GoogleCloudBuildExecutionDetails extends React.Component<IExecutionDetailsSectionProps> {
+  public static title = 'googleCloudBuildStatus';
+
+  public render() {
+    const { current, name, stage } = this.props;
+    const logUrl: string = get(stage, 'context.buildInfo.logUrl');
+    const status: string = get(stage, 'context.buildInfo.status');
+
+    return (
+      <ExecutionDetailsSection name={name} current={current}>
+        <div className="row">
+          <div className="col-md-6">
+            {status && (
+              <div className="row">
+                <div className="col-md-6">
+                  <strong>Status:</strong>
+                </div>
+                <div className="col-md-6">{capitalize(status)}</div>
+              </div>
+            )}
+            {logUrl && (
+              <div className="row">
+                <div className="col-md-6">
+                  <strong>Details:</strong>
+                </div>
+                <div className="col-md-6">
+                  <a href={logUrl} target="_blank">
+                    Build Logs
+                  </a>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </ExecutionDetailsSection>
+    );
+  }
+}

--- a/app/scripts/modules/core/src/pipeline/config/stages/googleCloudBuild/googleCloudBuildStage.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/googleCloudBuild/googleCloudBuildStage.ts
@@ -3,6 +3,7 @@ import { ExecutionDetailsTasks } from 'core/pipeline';
 import { Registry } from 'core/registry';
 
 import { GoogleCloudBuildStageConfig } from './GoogleCloudBuildStageConfig';
+import { GoogleCloudBuildExecutionDetails } from './GoogleCloudBuildExecutionDetails';
 
 Registry.pipeline.registerStage({
   label: 'Google Cloud Build',
@@ -10,6 +11,6 @@ Registry.pipeline.registerStage({
   key: 'googleCloudBuild',
   producesArtifacts: true,
   component: GoogleCloudBuildStageConfig,
-  executionDetailsSections: [ExecutionDetailsTasks, ExecutionArtifactTab],
+  executionDetailsSections: [GoogleCloudBuildExecutionDetails, ExecutionDetailsTasks, ExecutionArtifactTab],
   validators: [{ type: 'requiredField', fieldName: 'account' }],
 });


### PR DESCRIPTION
Adds GCB stage execution details tab with current status and link to logs.

![E34dMvevAoA](https://user-images.githubusercontent.com/15936279/57041821-2a46ef80-6c31-11e9-81c1-a80a7f1b654f.png)
