### PR TITLE
refactor(runJob/kubernetes): refactor exec details

### DIFF
--- a/app/scripts/modules/core/src/manifest/IManifestSubscription.ts
+++ b/app/scripts/modules/core/src/manifest/IManifestSubscription.ts
@@ -1,0 +1,7 @@
+import { IManifest } from 'core/domain';
+
+export interface IManifestSubscription {
+  id: string;
+  unsubscribe: () => void;
+  manifest: IManifest;
+}

--- a/app/scripts/modules/core/src/manifest/ManifestService.ts
+++ b/app/scripts/modules/core/src/manifest/ManifestService.ts
@@ -1,0 +1,57 @@
+import { Application, IManifest } from '@spinnaker/core';
+import { ManifestReader } from './ManifestReader';
+
+export interface IManifestContainer {
+  manifest: IManifest;
+}
+
+export interface IStageManifest {
+  kind: string;
+  apiVersion: string;
+  metadata: {
+    namespace: string;
+    name: string;
+  };
+}
+
+export interface IManifestParams {
+  account: string;
+  location: string;
+  name: string;
+}
+
+export type IManifestCallback = (manifest: IManifest) => void;
+
+export class ManifestService {
+  public static makeManifestRefresher(
+    app: Application,
+    params: IManifestParams,
+    container: IManifestContainer,
+  ): () => void {
+    const onUpdate = (manifest: IManifest) => {
+      container.manifest = manifest || container.manifest;
+    };
+    return ManifestService.subscribe(app, params, onUpdate);
+  }
+
+  public static subscribe(app: Application, params: IManifestParams, fn: IManifestCallback): () => void {
+    ManifestService.updateManifest(params, fn);
+    return app.onRefresh(null, () => ManifestService.updateManifest(params, fn));
+  }
+
+  private static updateManifest(params: IManifestParams, fn: IManifestCallback) {
+    ManifestReader.getManifest(params.account, params.location, params.name).then(manifest => fn(manifest));
+  }
+
+  public static manifestIdentifier(manifest: IStageManifest) {
+    const kind = manifest.kind.toLowerCase();
+    // manifest.metadata.namespace doesn't exist if it's a namespace being deployed
+    const namespace = (manifest.metadata.namespace || '_').toLowerCase();
+    const name = manifest.metadata.name.toLowerCase();
+    const apiVersion = (manifest.apiVersion || '_').toLowerCase();
+    // assuming this identifier is opaque and not parsed anywhere. Including the
+    // apiVersion will prevent collisions with CRD kinds without having any visible
+    // effect elsewhere
+    return `${namespace} ${kind} ${apiVersion} ${name}`;
+  }
+}

--- a/app/scripts/modules/core/src/manifest/index.ts
+++ b/app/scripts/modules/core/src/manifest/index.ts
@@ -1,2 +1,6 @@
 export * from './ManifestWriter';
 export * from './ManifestReader';
+export * from './stage/JobStageExecutionLogs';
+export * from './IManifestSubscription';
+export * from './ManifestService';
+export * from './stage/JobManifestPodLogs';

--- a/app/scripts/modules/core/src/manifest/stage/JobManifestPodLogs.tsx
+++ b/app/scripts/modules/core/src/manifest/stage/JobManifestPodLogs.tsx
@@ -1,13 +1,11 @@
 import * as React from 'react';
 import { Modal, Button } from 'react-bootstrap';
 import * as classNames from 'classnames';
-import {
-  IManifest,
-  IManifestEvent,
-  InstanceReader,
-  IInstanceConsoleOutput,
-  IInstanceMultiOutputLog,
-} from '@spinnaker/core';
+
+import { InstanceReader, IInstanceConsoleOutput, IInstanceMultiOutputLog } from 'core/instance/InstanceReader';
+
+import { IManifestEvent, IManifest } from 'core/domain/IManifest';
+
 import { get, trim, bindAll } from 'lodash';
 
 // IJobManifestPodLogs is the data needed to get logs

--- a/app/scripts/modules/core/src/manifest/stage/JobStageExecutionLogs.tsx
+++ b/app/scripts/modules/core/src/manifest/stage/JobStageExecutionLogs.tsx
@@ -1,0 +1,99 @@
+import * as React from 'react';
+
+import { IManifestSubscription } from '../IManifestSubscription';
+import { IStageManifest, ManifestService } from '../ManifestService';
+import { JobManifestPodLogs } from './JobManifestPodLogs';
+import { IManifest } from 'core/domain/IManifest';
+
+import { get } from 'lodash';
+import { Application } from 'core/application';
+
+interface IJobStageExecutionLogsProps {
+  manifest: IStageManifest;
+  deployedName: string;
+  account: string;
+  application: Application;
+}
+
+interface IJobStageExecutionLogsState {
+  subscription: IManifestSubscription;
+  manifestId: string;
+}
+
+export class JobStageExecutionLogs extends React.Component<IJobStageExecutionLogsProps, IJobStageExecutionLogsState> {
+  public state = {
+    subscription: { id: '', unsubscribe: () => {}, manifest: {} } as IManifestSubscription,
+    manifestId: '',
+  };
+
+  public componentDidMount() {
+    this.componentDidUpdate(this.props, this.state);
+  }
+
+  public componentWillMount() {
+    this.unsubscribe();
+  }
+
+  private unsubscribe() {
+    this.state.subscription && this.state.subscription.unsubscribe && this.state.subscription.unsubscribe();
+  }
+
+  public componentDidUpdate(_prevPropds: IJobStageExecutionLogsProps, prevState: IJobStageExecutionLogsState) {
+    const { manifest } = this.props;
+    const manifestId = ManifestService.manifestIdentifier(manifest);
+    if (prevState.manifestId === manifestId) {
+      return;
+    }
+    this.refreshSubscription(manifestId, manifest);
+  }
+
+  private refreshSubscription(manifestId: string, manifest: IStageManifest) {
+    const subscription = {
+      id: manifestId,
+      manifest: this.stageManifestToIManifest(manifest, this.props.deployedName, this.props.account),
+      unsubscribe: this.subscribeToManifestUpdates(manifest),
+    };
+    this.setState({ subscription, manifestId });
+  }
+
+  private subscribeToManifestUpdates(manifest: IStageManifest): () => void {
+    const params = {
+      account: this.props.account,
+      name: this.props.deployedName,
+      location: manifest.metadata.namespace == null ? '_' : manifest.metadata.namespace,
+    };
+    return ManifestService.subscribe(this.props.application, params, (updated: IManifest) => {
+      const subscription = { ...this.state.subscription, manifest: updated };
+      this.setState({ subscription });
+    });
+  }
+
+  private stageManifestToIManifest(manifest: IStageManifest, deployedName: string, account: string): IManifest {
+    const namespace = get(manifest, ['metadata', 'namespace'], '');
+
+    return {
+      name: deployedName,
+      moniker: null,
+      account,
+      cloudProvider: 'kubernetes',
+      location: namespace,
+      manifest,
+      status: {},
+      artifacts: [],
+      events: [],
+    };
+  }
+
+  public render() {
+    const { manifest } = this.state.subscription;
+    let event: any = null;
+    if (manifest && manifest.events) {
+      event = manifest.events.find((e: any) => e.message.startsWith('Created pod'));
+    }
+    if (!manifest || !event) {
+      return <div>No Console Output</div>;
+    }
+
+    return <JobManifestPodLogs manifest={manifest} manifestEvent={event} linkName="Console Output" />;
+  }
+}

--- a/app/scripts/modules/core/src/pipeline/config/stages/preconfiguredJob/PreconfiguredJobExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/preconfiguredJob/PreconfiguredJobExecutionDetails.tsx
@@ -7,37 +7,63 @@ import {
   StageFailureMessage,
 } from 'core/pipeline';
 import { IPreconfiguredJobParameter } from './preconfiguredJobStage';
+import { JobStageExecutionLogs } from 'core/manifest/stage/JobStageExecutionLogs';
+import { get } from 'lodash';
 
-export function PreconfiguredJobExecutionDetails(props: IExecutionDetailsSectionProps) {
-  const { stage, name, current } = props;
+export class PreconfiguredJobExecutionDetails extends React.Component<IExecutionDetailsSectionProps> {
+  public static title = 'preconfiguredJobConfig';
 
-  const parameters =
-    stage.context.preconfiguredJobParameters && stage.context.parameters ? (
-      <div>
-        <dl className="dl-horizontal">
-          {stage.context.preconfiguredJobParameters.map((parameter: IPreconfiguredJobParameter) => (
-            <React.Fragment>
-              <dt>{parameter.label}</dt>
-              <dd>{stage.context.parameters[parameter.name]}</dd>
-            </React.Fragment>
-          ))}
-        </dl>
-      </div>
-    ) : (
-      <div>No details provided.</div>
+  private executionLogsComponent(cloudProvider: string) {
+    const { stage } = this.props;
+
+    if (cloudProvider === 'kubernetes') {
+      const manifest = get(stage, ['context', 'manifest'], null);
+      const namespace = get(manifest, ['metadata', 'namespace']);
+      const deployedJobs = get(this.props.stage, ['context', 'deploy.jobs']);
+      const deployedName = get(deployedJobs, namespace, [])[0] || '';
+      return (
+        <div className="well">
+          <JobStageExecutionLogs
+            manifest={manifest}
+            deployedName={deployedName}
+            account={this.props.stage.context.account}
+            application={this.props.application}
+          />
+        </div>
+      );
+    }
+
+    return <StageExecutionLogs stage={stage} />;
+  }
+
+  public render() {
+    const { stage, name, current } = this.props;
+    const { cloudProvider } = stage.context;
+
+    const parameters =
+      stage.context.preconfiguredJobParameters && stage.context.parameters ? (
+        <div>
+          <dl className="dl-horizontal">
+            {stage.context.preconfiguredJobParameters.map((parameter: IPreconfiguredJobParameter) => (
+              <React.Fragment>
+                <dt>{parameter.label}</dt>
+                <dd>{stage.context.parameters[parameter.name]}</dd>
+              </React.Fragment>
+            ))}
+          </dl>
+        </div>
+      ) : (
+        <div>No details provided.</div>
+      );
+
+    const logsComponent = this.executionLogsComponent(cloudProvider);
+
+    return (
+      <ExecutionDetailsSection name={name} current={current}>
+        {parameters}
+        <StageFailureMessage stage={stage} message={stage.failureMessage} />
+        {logsComponent}
+      </ExecutionDetailsSection>
     );
-
-  return (
-    <ExecutionDetailsSection name={name} current={current}>
-      {parameters}
-      <StageFailureMessage stage={stage} message={stage.failureMessage} />
-      <StageExecutionLogs stage={stage} />
-    </ExecutionDetailsSection>
-  );
-}
-
-// TODO: refactor this to not use namespace
-// eslint-disable-next-line
-export namespace PreconfiguredJobExecutionDetails {
-  export const title = 'preconfiguredJobConfig';
+  }
 }

--- a/app/scripts/modules/core/src/pipeline/details/StageExecutionLogs.tsx
+++ b/app/scripts/modules/core/src/pipeline/details/StageExecutionLogs.tsx
@@ -2,46 +2,21 @@ import * as React from 'react';
 import { get } from 'lodash';
 
 import { IStage } from 'core/domain';
-import { ReactModal } from 'core/presentation';
-
-import { LogsModal, ILogsModalProps } from './LogsModal';
 
 export interface IStageExecutionLogsProps {
   stage: IStage;
 }
 
 export class StageExecutionLogs extends React.Component<IStageExecutionLogsProps> {
-  public isExternalLink = false;
-
-  constructor(props: any) {
-    super(props);
-    // titus jobs present a link to an external system for logs
-    // kubernetes jobs store logs in the execution context (for better, or for worse)
-    this.isExternalLink = get<string>(this.props.stage, 'context.execution.logs') !== undefined;
-  }
-
-  public showModal = () => {
-    ReactModal.show(
-      LogsModal,
-      {
-        logs: get<string>(this.props.stage, 'context.jobStatus.logs'),
-      } as ILogsModalProps,
-      { dialogClassName: 'modal-lg modal-fullscreen' },
-    );
-  };
-
   public render() {
     const logs = get<string>(this.props.stage, 'context.execution.logs');
     return (
       <div className="row">
         <div className="col-md-12">
           <div className="well alert alert-info">
-            {this.isExternalLink && (
-              <a target="_blank" href={logs}>
-                View Execution Logs
-              </a>
-            )}
-            {!this.isExternalLink && <a onClick={this.showModal}>View Execution Logs</a>}
+            <a target="_blank" href={logs}>
+              View Execution Logs
+            </a>
           </div>
         </div>
       </div>

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/react/ManifestEvents.tsx
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/react/ManifestEvents.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { get } from 'lodash';
 import { DateTime } from 'luxon';
-import { IManifest, IManifestEvent, relativeTime } from '@spinnaker/core';
-import { JobManifestPodLogs } from './JobManifestPodLogs';
+import { IManifest, IManifestEvent, relativeTime, JobManifestPodLogs } from '@spinnaker/core';
 
 export interface IManifestEventsProps {
   manifest: IManifest;

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/runJob/RunJobExecutionDetails.tsx
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/runJob/RunJobExecutionDetails.tsx
@@ -1,77 +1,20 @@
 import * as React from 'react';
 import { get } from 'lodash';
 
-import { IExecutionDetailsSectionProps, ExecutionDetailsSection, AccountTag, IManifest } from '@spinnaker/core';
-
-import { JobManifestPodLogs } from '../deployManifest/react/JobManifestPodLogs';
-
-import { KubernetesManifestService, IStageManifest } from 'kubernetes/v2/manifest/manifest.service';
-
-import { IManifestSubscription } from '../deployManifest/react/DeployStatus';
+import {
+  IExecutionDetailsSectionProps,
+  ExecutionDetailsSection,
+  AccountTag,
+  JobStageExecutionLogs,
+  IStageManifest,
+} from '@spinnaker/core';
 
 interface IStageDeployedJobs {
   [namespace: string]: string[];
 }
 
-interface IRunJobExecutionDetailsState {
-  subscription: IManifestSubscription;
-  manifestId: string;
-}
-
-export class RunJobExecutionDetails extends React.Component<
-  IExecutionDetailsSectionProps,
-  IRunJobExecutionDetailsState
-> {
+export class RunJobExecutionDetails extends React.Component<IExecutionDetailsSectionProps> {
   public static title = 'runJobConfig';
-  public state = {
-    subscription: { id: '', unsubscribe: () => {}, manifest: {} } as IManifestSubscription,
-    manifestId: '',
-  };
-
-  public componentDidMount() {
-    this.componentDidUpdate(this.props, this.state);
-  }
-
-  public componentWillUnmount() {
-    this.unsubscribe();
-  }
-
-  public componentDidUpdate(_prevProps: IExecutionDetailsSectionProps, prevState: IRunJobExecutionDetailsState) {
-    const manifest: IStageManifest = get(this.props.stage, ['context', 'manifest']);
-    const manifestId = KubernetesManifestService.manifestIdentifier(manifest);
-    if (prevState.manifestId !== manifestId) {
-      this.unsubscribe();
-      const subscription = {
-        id: manifestId,
-        unsubscribe: this.subscribeToManifestUpdates(manifest),
-        manifest: this.stageManifestToIManifest(
-          manifest,
-          get(this.props.stage, ['context', 'deploy.jobs'], {}),
-          this.props.stage.context.account,
-        ),
-      };
-      this.setState({
-        subscription,
-        manifestId,
-      });
-    }
-  }
-
-  private unsubscribe() {
-    this.state.subscription && this.state.subscription.unsubscribe && this.state.subscription.unsubscribe();
-  }
-
-  private subscribeToManifestUpdates(manifest: IStageManifest): () => void {
-    const params = {
-      account: this.props.stage.context.account,
-      name: this.extractDeployedJobName(manifest, get(this.props.stage, ['context', 'deploy.jobs'], {})),
-      location: manifest.metadata.namespace == null ? '_' : manifest.metadata.namespace,
-    };
-    return KubernetesManifestService.subscribe(this.props.application, params, (updated: IManifest) => {
-      const subscription = { ...this.state.subscription, manifest: updated };
-      this.setState({ subscription });
-    });
-  }
 
   private extractDeployedJobName(manifest: IStageManifest, deployedJobs: IStageDeployedJobs): string {
     const namespace = get(manifest, ['metadata', 'namespace'], '');
@@ -79,35 +22,13 @@ export class RunJobExecutionDetails extends React.Component<
     return jobNames.length > 0 ? jobNames[0] : '';
   }
 
-  private stageManifestToIManifest(
-    manifest: IStageManifest,
-    deployedJobs: IStageDeployedJobs,
-    account: string,
-  ): IManifest {
-    const namespace = get(manifest, ['metadata', 'namespace'], '');
-    const name = this.extractDeployedJobName(manifest, deployedJobs);
-
-    return {
-      name,
-      moniker: null,
-      account,
-      cloudProvider: 'kubernetes',
-      location: namespace,
-      manifest,
-      status: {},
-      artifacts: [],
-      events: [],
-    };
-  }
-
   public render() {
     const { stage, name, current } = this.props;
     const { context } = stage;
-    const manifest = get(this.state, ['subscription', 'manifest'], null);
-    let event: any = null;
-    if (manifest && manifest.events) {
-      event = manifest.events.find((e: any) => e.message.startsWith('Created pod'));
-    }
+
+    const { manifest } = context;
+    const deployedName = this.extractDeployedJobName(manifest, get(context, ['deploy.jobs']));
+
     return (
       <ExecutionDetailsSection name={name} current={current}>
         <div className="row">
@@ -117,19 +38,23 @@ export class RunJobExecutionDetails extends React.Component<
               <dd>
                 <AccountTag account={context.account} />
               </dd>
+              {stage.context.jobStatus && stage.context.jobStatus.location && (
+                <span>
+                  <dt>Namespace</dt>
+                  <dd>{stage.context.jobStatus.location}</dd>
+                </span>
+              )}
+              <dt>Logs</dt>
+              <dd>
+                <JobStageExecutionLogs
+                  manifest={manifest}
+                  deployedName={deployedName}
+                  account={this.props.stage.context.account}
+                  application={this.props.application}
+                />
+              </dd>
             </dl>
-            {stage.context.jobStatus && stage.context.jobStatus.location && (
-              <dl className="dl-narrow dl-horizontal">
-                <dt>Namespace</dt>
-                <dd>{stage.context.jobStatus.location}</dd>
-              </dl>
-            )}
           </div>
-          {manifest && event && (
-            <div className="col-md-9 well">
-              <JobManifestPodLogs manifest={manifest} manifestEvent={event} linkName="Console Output (Raw)" />
-            </div>
-          )}
         </div>
       </ExecutionDetailsSection>
     );


### PR DESCRIPTION
refactor some of the manifest components into the core module and use
those instead of the kubernetes specific ones. doing this because
`StageExecutionLogs` in the `core` module needs to use
`JobManifestPodLogs`.