### PR TITLE
fix(core/api): normalize API request urls

### DIFF
--- a/app/scripts/modules/core/src/api/ApiService.spec.ts
+++ b/app/scripts/modules/core/src/api/ApiService.spec.ts
@@ -11,13 +11,46 @@ describe('API Service', function() {
   beforeEach(
     mock.inject(function(_$httpBackend_: ng.IHttpBackendService) {
       $httpBackend = _$httpBackend_;
-      baseUrl = SETTINGS.gateUrl;
+      baseUrl = API.baseUrl;
     }),
   );
 
   afterEach(function() {
+    SETTINGS.resetToOriginal();
     $httpBackend.verifyNoOutstandingExpectation();
     $httpBackend.verifyNoOutstandingRequest();
+  });
+
+  describe('ensure api requests generate normalized urls', function() {
+    let expected: ng.IRequestConfig;
+    beforeEach(() => {
+      expected = {
+        method: '',
+        url: '',
+      };
+    });
+
+    it('trims leading slashes from urls', function() {
+      const result = API.one('/foo');
+      expected.url = `${baseUrl}/foo`;
+      expect(result.config).toEqual(expected);
+    });
+
+    it('trims repeated leading slashes from urls', function() {
+      const result = API.one('/////foo');
+      expected.url = `${baseUrl}/foo`;
+      expect(result.config).toEqual(expected);
+    });
+
+    it('trims trailing slashes from baseUrl', function() {
+      SETTINGS.gateUrl = 'http://localhost/';
+      expect(API.baseUrl).toEqual('http://localhost');
+    });
+
+    it('trims repeated trailing slashes from baseUrl', function() {
+      SETTINGS.gateUrl = 'http://localhost/////';
+      expect(API.baseUrl).toEqual('http://localhost');
+    });
   });
 
   describe('validate response content-type header', function() {

--- a/app/scripts/modules/core/src/api/ApiService.ts
+++ b/app/scripts/modules/core/src/api/ApiService.ts
@@ -164,9 +164,9 @@ export class API {
   private static init(urls: string[]) {
     const config: IRequestConfig = {
       method: '',
-      url: SETTINGS.gateUrl,
+      url: this.baseUrl,
     };
-    urls.forEach((url: string) => (config.url = `${config.url}/${url}`));
+    urls.forEach((url: string) => (config.url = `${config.url}/${url.toString().replace(/^\/+/, '')}`));
 
     return this.baseReturn(config);
   }
@@ -180,6 +180,6 @@ export class API {
   }
 
   public static get baseUrl(): string {
-    return SETTINGS.gateUrl;
+    return SETTINGS.gateUrl.replace(/\/+$/, '');
   }
 }


### PR DESCRIPTION
This only handles the case of a consumer of ApiService requesting with a leading
slash character. Full uri normalization may be a useful thing to add to handle
a request containing directory traversal characters but I don't suspect we have
any of those whereas the double-slash case is pretty easy to accidentally do
