### PR TITLE
feat(runJob/kubernetes): render external link

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/preconfiguredJob/PreconfiguredJobExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/preconfiguredJob/PreconfiguredJobExecutionDetails.tsx
@@ -21,6 +21,7 @@ export class PreconfiguredJobExecutionDetails extends React.Component<IExecution
       const namespace = get(manifest, ['metadata', 'namespace']);
       const deployedJobs = get(this.props.stage, ['context', 'deploy.jobs']);
       const deployedName = get(deployedJobs, namespace, [])[0] || '';
+      const externalLink = get<string>(this.props.stage, ['context', 'execution', 'logs']);
       return (
         <div className="well">
           <JobStageExecutionLogs
@@ -28,6 +29,7 @@ export class PreconfiguredJobExecutionDetails extends React.Component<IExecution
             deployedName={deployedName}
             account={this.props.stage.context.account}
             application={this.props.application}
+            externalLink={externalLink}
           />
         </div>
       );

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/runJob/RunJobExecutionDetails.tsx
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/runJob/RunJobExecutionDetails.tsx
@@ -28,6 +28,7 @@ export class RunJobExecutionDetails extends React.Component<IExecutionDetailsSec
 
     const { manifest } = context;
     const deployedName = this.extractDeployedJobName(manifest, get(context, ['deploy.jobs']));
+    const externalLink = get<string>(stage, ['context', 'execution', 'logs']);
 
     return (
       <ExecutionDetailsSection name={name} current={current}>
@@ -51,6 +52,7 @@ export class RunJobExecutionDetails extends React.Component<IExecutionDetailsSec
                   deployedName={deployedName}
                   account={this.props.stage.context.account}
                   application={this.props.application}
+                  externalLink={externalLink}
                 />
               </dd>
             </dl>


### PR DESCRIPTION
if `context.execution.logs` is present (pulled from manifest annotation
`jobs.spinnaker.io/logs`), render the content as a link, templated with
manifest data.

Depends on spinnaker/orca#2893.