### PR TITLE
feat(gcb): accept gcb definition file as artifact

### DIFF
--- a/app/scripts/modules/core/src/artifact/expectedArtifact.service.ts
+++ b/app/scripts/modules/core/src/artifact/expectedArtifact.service.ts
@@ -1,3 +1,4 @@
+import { get } from 'lodash';
 import { PipelineConfigService } from 'core/pipeline';
 import { Registry } from 'core/registry';
 import {
@@ -38,7 +39,7 @@ export class ExpectedArtifactService {
     // is that we don't want to include an empty string in the artifact list, so omit any falsey values.
     return (stageContext: IExecutionContext) =>
       fields
-        .map(field => stageContext[field])
+        .map((field): string => get(stageContext, field))
         .filter(v => v)
         .reduce((array, value) => array.concat(value), []);
   }

--- a/app/scripts/modules/core/src/pipeline/config/stages/googleCloudBuild/GoogleCloudBuildStageForm.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/googleCloudBuild/GoogleCloudBuildStageForm.tsx
@@ -1,0 +1,129 @@
+import * as React from 'react';
+import Select, { Option } from 'react-select';
+import { get } from 'lodash';
+
+import {
+  ArtifactTypePatterns,
+  IArtifact,
+  IExpectedArtifact,
+  IFormikStageConfigInjectedProps,
+  RadioButtonInput,
+  SETTINGS,
+  StageArtifactSelector,
+  StageConfigField,
+  yamlDocumentsToString,
+  YamlEditor,
+} from '@spinnaker/core';
+
+export enum buildDefinitionSources {
+  ARTIFACT = 'artifact',
+  TEXT = 'text',
+}
+
+interface IGoogleCloudBuildStageFormProps {
+  googleCloudBuildAccounts: string[];
+}
+
+interface IGoogleCloudBuildStageFormState {
+  rawBuildDefinitionYaml: string;
+}
+
+export class GoogleCloudBuildStageForm extends React.Component<
+  IGoogleCloudBuildStageFormProps & IFormikStageConfigInjectedProps,
+  IGoogleCloudBuildStageFormState
+> {
+  public constructor(props: IGoogleCloudBuildStageFormProps & IFormikStageConfigInjectedProps) {
+    super(props);
+    const stage = props.formik.values;
+    this.state = {
+      rawBuildDefinitionYaml: stage.buildDefinition ? yamlDocumentsToString([stage.buildDefinition]) : '',
+    };
+  }
+
+  private onYamlChange = (rawYaml: string, yamlDocs: any): void => {
+    this.setState({ rawBuildDefinitionYaml: rawYaml });
+    const buildDefinition = Array.isArray(yamlDocs) && yamlDocs.length > 0 ? yamlDocs[0] : null;
+    this.props.formik.setFieldValue('buildDefinition', buildDefinition);
+  };
+
+  private onAccountChange = (accountOption: Option) => {
+    this.props.formik.setFieldValue('account', accountOption.value);
+  };
+
+  private getAccountOptions = (): Array<Option<string>> => {
+    return this.props.googleCloudBuildAccounts.map(account => ({
+      label: account,
+      value: account,
+    }));
+  };
+
+  private getSourceOptions = (): Array<Option<string>> => {
+    return [
+      { value: buildDefinitionSources.TEXT, label: 'Text' },
+      { value: buildDefinitionSources.ARTIFACT, label: 'Artifact' },
+    ];
+  };
+
+  private onSourceChange = (e: any) => {
+    this.props.formik.setFieldValue('buildDefinitionSource', e.target.value);
+  };
+
+  private onExpectedArtifactSelected = (expectedArtifact: IExpectedArtifact) => {
+    this.props.formik.setFieldValue('buildDefinitionArtifact.artifactId', expectedArtifact.id);
+    this.props.formik.setFieldValue('buildDefinitionArtifact.artifact', null);
+  };
+
+  private onArtifactEdited = (artifact: IArtifact) => {
+    this.props.formik.setFieldValue('buildDefinitionArtifact.artifact', artifact);
+    this.props.formik.setFieldValue('buildDefinitionArtifact.artifactId', null);
+  };
+
+  public render() {
+    const stage = this.props.formik.values;
+    return (
+      <>
+        <StageConfigField label="Account">
+          <Select
+            clearable={false}
+            onChange={this.onAccountChange}
+            options={this.getAccountOptions()}
+            value={this.props.formik.values.account}
+          />
+        </StageConfigField>
+        {SETTINGS.feature['artifactsRewrite'] && (
+          <StageConfigField label="Build Definition Source">
+            <RadioButtonInput
+              options={this.getSourceOptions()}
+              onChange={this.onSourceChange}
+              value={this.props.formik.values.buildDefinitionSource}
+            />
+          </StageConfigField>
+        )}
+        {this.props.formik.values.buildDefinitionSource === buildDefinitionSources.TEXT && (
+          <StageConfigField label="Build Definition">
+            <YamlEditor value={this.state.rawBuildDefinitionYaml} onChange={this.onYamlChange} />
+          </StageConfigField>
+        )}
+        {this.props.formik.values.buildDefinitionSource === buildDefinitionSources.ARTIFACT &&
+          SETTINGS.feature['artifactsRewrite'] && (
+            <StageConfigField label="Build Definition Artifact">
+              <StageArtifactSelector
+                pipeline={this.props.pipeline}
+                stage={stage}
+                expectedArtifactId={get(stage, 'buildDefinitionArtifact.artifactId')}
+                artifact={get(stage, 'buildDefinitionArtifact.artifact')}
+                onExpectedArtifactSelected={this.onExpectedArtifactSelected}
+                onArtifactEdited={this.onArtifactEdited}
+                excludedArtifactTypePatterns={[
+                  ArtifactTypePatterns.DOCKER_IMAGE,
+                  ArtifactTypePatterns.KUBERNETES,
+                  ArtifactTypePatterns.FRONT50_PIPELINE_TEMPLATE,
+                  ArtifactTypePatterns.EMBEDDED_BASE64,
+                ]}
+              />
+            </StageConfigField>
+          )}
+      </>
+    );
+  }
+}

--- a/app/scripts/modules/core/src/pipeline/config/stages/googleCloudBuild/googleCloudBuildStage.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/googleCloudBuild/googleCloudBuildStage.ts
@@ -1,9 +1,14 @@
-import { ExecutionArtifactTab } from 'core/artifact';
-import { ExecutionDetailsTasks } from 'core/pipeline';
-import { Registry } from 'core/registry';
+import {
+  ArtifactReferenceService,
+  ExecutionArtifactTab,
+  ExecutionDetailsTasks,
+  ExpectedArtifactService,
+  Registry,
+} from '@spinnaker/core';
 
 import { GoogleCloudBuildStageConfig } from './GoogleCloudBuildStageConfig';
 import { GoogleCloudBuildExecutionDetails } from './GoogleCloudBuildExecutionDetails';
+import { validate } from './googleCloudBuildValidators';
 
 Registry.pipeline.registerStage({
   label: 'Google Cloud Build',
@@ -12,5 +17,7 @@ Registry.pipeline.registerStage({
   producesArtifacts: true,
   component: GoogleCloudBuildStageConfig,
   executionDetailsSections: [GoogleCloudBuildExecutionDetails, ExecutionDetailsTasks, ExecutionArtifactTab],
-  validators: [{ type: 'requiredField', fieldName: 'account' }],
+  validateFn: validate,
+  artifactExtractor: ExpectedArtifactService.accumulateArtifacts(['buildDefinitionArtifact.artifactId']),
+  artifactRemover: ArtifactReferenceService.removeArtifactFromFields(['buildDefinitionArtifact.artifactId']),
 });

--- a/app/scripts/modules/core/src/pipeline/config/stages/googleCloudBuild/googleCloudBuildValidators.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/googleCloudBuild/googleCloudBuildValidators.ts
@@ -1,0 +1,7 @@
+import { buildValidators, IContextualValidator, IStage } from '@spinnaker/core';
+
+export const validate: IContextualValidator = (stage: IStage) => {
+  const validation = buildValidators(stage);
+  validation.field('account', 'Account').required();
+  return validation.result();
+};


### PR DESCRIPTION
- Allows GCB stage config to accept build definition as an artifact when `ARTIFACTS_REWRITE_ENABLED=true`. Otherwise, only accepts build definition as text and hides artifact selector. Accepting pre-rewrite artifacts in a React component without introducing Angular dependencies is non-trivial and will be addressed in a separate PR.
- Modifies function returned by `ExpectedArtifactService.accumulateArtifacts` to accept nested fields (i.e. `keyA.keyB`) in order to display consumed artifacts nested in context
- Refactors GCB stage to more closely adhere to new `FormikStageConfig` pattern and cancelable promise convention

Artifact defined inline:
![96ZABYr4DGX](https://user-images.githubusercontent.com/15936279/57248695-ff81e000-7010-11e9-825e-6529bb7fc368.png)

Artifact defined in pipeline config:
![5UFvcdFBPtm](https://user-images.githubusercontent.com/15936279/57248704-03adfd80-7011-11e9-96be-d37deb5265d9.png)

Consumed artifact (when artifact is defined in pipeline config):
![umKTphNGnn8](https://user-images.githubusercontent.com/15936279/57248759-348e3280-7011-11e9-9df1-e65808fef5b1.png)
