### PR TITLE
fix(bake/manifest): Preserve artifact account selection

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/bakeManifestConfig.controller.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/bakeManifestConfig.controller.ts
@@ -64,13 +64,9 @@ export class BakeManifestConfigCtrl implements IController {
       Object.assign(stage, defaultSelection);
     }
     this.ensureTemplateArtifact();
-    stage.inputArtifacts = stage.inputArtifacts.map((a: IArtifactAccountPair) => this.defaultInputArtifact(a));
     AccountService.getArtifactAccounts().then(accounts => {
       this.artifactAccounts = accounts;
-      stage.inputArtifacts.forEach((a: InputArtifact) => {
-        a.delegate.setAccounts(accounts);
-        a.controller.updateAccounts(a.delegate.getSelectedExpectedArtifact());
-      });
+      stage.inputArtifacts = stage.inputArtifacts.map((a: IArtifactAccountPair) => this.defaultInputArtifact(a));
     });
   }
 
@@ -120,6 +116,8 @@ export class BakeManifestConfigCtrl implements IController {
   public canShowAccountSelect(artifact: InputArtifact): boolean {
     return (
       artifact &&
+      artifact.delegate &&
+      artifact.controller &&
       !artifact.delegate.requestingNew &&
       (artifact.controller.accountsForArtifact.length > 1 && artifact.delegate.getSelectedExpectedArtifact() != null)
     );


### PR DESCRIPTION
This fixes a bug in Bake Manifest stage configuration. If the input artifacts have more than one account, UI shows the user a dropdown for selecting the desired account. However this selection is lost every time the user navigates to another screen/stage and comes back to Bake Manifest stage configuration, falling back always to the first artifact account shown in the dropdown.

![Screen Recording 2019-05-07 at 10 55 AM](https://user-images.githubusercontent.com/35276119/57314224-d3b93580-70b6-11e9-8ac3-4083519808a4.gif)

The bug is caused because `InputArtifact` objects are created before having the list of artifact accounts ready. This has the effect of clearing the selected account, and when the account list is initialized the selected account fallbacks to the first in the list.
