### PR TITLE
feat(titus): show disruption budget in job details panel

### DIFF
--- a/app/scripts/modules/titus/src/domain/ITitusServerGroup.ts
+++ b/app/scripts/modules/titus/src/domain/ITitusServerGroup.ts
@@ -1,8 +1,11 @@
 import { IAccountDetails, IServerGroup } from '@spinnaker/core';
 import { IScalingPolicyView } from '@spinnaker/amazon';
+import { IJobDisruptionBudget } from '../serverGroup/configure/serverGroupConfiguration.service';
 import { ITitusPolicy } from './ITitusScalingPolicy';
 
 export interface ITitusServerGroup extends IServerGroup {
+  disruptionBudget?: IJobDisruptionBudget;
+  migrationPolicy?: { type: string };
   image?: ITitusImage;
   scalingPolicies?: ITitusPolicy[];
   targetGroups?: string[];

--- a/app/scripts/modules/titus/src/help/titus.help.ts
+++ b/app/scripts/modules/titus/src/help/titus.help.ts
@@ -72,6 +72,15 @@ const helpContents: { [key: string]: string } = {
       initiated the cooldown is calculated as part of the desired capacity for the next scale out. The intention is to
       continuously (but not excessively) scale out.</p>
   `,
+  'titus.disruptionbudget.description': `
+    <p>
+      The Job Disruption Budget is part of the job descriptor, and defines the behavior of how containers of the
+      job can be relocated.{' '}
+      <a href="http://manuals.test.netflix.net/view/titus-docs/mkdocs/master/disruption_budget/" target="_blank">
+        Read the full documentation
+      </a>
+    </p>
+  `,
 };
 
 Object.keys(helpContents).forEach(key => HelpContentsRegistry.register(key, helpContents[key]));

--- a/app/scripts/modules/titus/src/serverGroup/configure/wizard/pages/disruptionBudget/JobDisruptionBudget.tsx
+++ b/app/scripts/modules/titus/src/serverGroup/configure/wizard/pages/disruptionBudget/JobDisruptionBudget.tsx
@@ -43,6 +43,16 @@ export interface IFieldOptionComponentProps {
   isDisabled: boolean;
 }
 
+export const DisruptionBudgetDescription = () => (
+  <p>
+    The Job Disruption Budget is part of the job descriptor, and defines the behavior of how containers of the job can
+    be relocated.{' '}
+    <a href="http://manuals.test.netflix.net/view/titus-docs/mkdocs/master/disruption_budget/" target="_blank">
+      Read the full documentation
+    </a>
+  </p>
+);
+
 export class JobDisruptionBudget extends React.Component<IJobDisruptionBudgetProps, IJobDisruptionBudgetState> {
   private timeWindowOptions: IFieldOption[] = [
     {
@@ -141,13 +151,7 @@ export class JobDisruptionBudget extends React.Component<IJobDisruptionBudgetPro
     return (
       <LayoutProvider value={ResponsiveFieldLayout}>
         <div className="form-horizontal sp-margin-l-xaxis">
-          <p>
-            The Job Disruption Budget is part of the job descriptor, and defines the behavior of how containers of the
-            job can be relocated.{' '}
-            <a href="http://manuals.test.netflix.net/view/titus-docs/mkdocs/master/disruption_budget/" target="_blank">
-              Read the full documentation
-            </a>
-          </p>
+          <DisruptionBudgetDescription />
 
           <FormikFormField
             name="usingDefault"

--- a/app/scripts/modules/titus/src/serverGroup/details/DisruptionBudgetSection.tsx
+++ b/app/scripts/modules/titus/src/serverGroup/details/DisruptionBudgetSection.tsx
@@ -1,0 +1,203 @@
+import * as React from 'react';
+import { isEqual, cloneDeep } from 'lodash';
+const angular = require('angular');
+import { react2angular } from 'react2angular';
+
+import { IServerGroupDetailsSectionProps, duration, HelpField } from '@spinnaker/core';
+
+import { defaultJobDisruptionBudget, IJobDisruptionBudget } from '../configure/serverGroupConfiguration.service';
+import { policyOptions } from '../configure/wizard/pages/disruptionBudget/PolicyOptions';
+import { rateOptions } from '../configure/wizard/pages/disruptionBudget/RateOptions';
+import {
+  IFieldOption,
+  DisruptionBudgetDescription,
+} from '../configure/wizard/pages/disruptionBudget/JobDisruptionBudget';
+import { ITitusServerGroup } from 'titus/domain';
+
+export class DisruptionBudgetSection extends React.Component<IServerGroupDetailsSectionProps> {
+  private SectionHeading = ({
+    budget,
+    options,
+    label,
+  }: {
+    budget: IJobDisruptionBudget;
+    options: IFieldOption[];
+    label: string;
+  }): JSX.Element => {
+    const selected = options.find(o => !!budget[o.field]);
+    if (!selected) {
+      return null;
+    }
+    return (
+      <div>
+        <div className="bold">{label}</div>
+        {selected.label} <HelpField content={selected.description} />
+      </div>
+    );
+  };
+
+  private Policy = ({ budget }: { budget: IJobDisruptionBudget }): JSX.Element => {
+    const { ParentheticalDuration } = this;
+    if (budget.availabilityPercentageLimit) {
+      return (
+        <div>
+          <div className="bold">Percentage of Healthy Containers</div>
+          {budget.availabilityPercentageLimit.percentageOfHealthyContainers} percent
+        </div>
+      );
+    }
+    if (budget.relocationLimit) {
+      return (
+        <div>
+          <div className="bold">Limit</div>
+          {budget.relocationLimit.limit} task{budget.relocationLimit.limit !== 1 && 's'}
+        </div>
+      );
+    }
+    if (budget.unhealthyTasksLimit) {
+      return (
+        <div>
+          <div className="bold">Limit of Unhealthy Containers</div>
+          {budget.unhealthyTasksLimit.limitOfUnhealthyContainers} container
+          {budget.unhealthyTasksLimit.limitOfUnhealthyContainers !== 1 && 's'}
+        </div>
+      );
+    }
+    if (budget.selfManaged) {
+      return (
+        <div>
+          <div className="bold">Relocation Time</div>
+          {budget.selfManaged.relocationTimeMs > 0 && (
+            <ParentheticalDuration durationMs={budget.selfManaged.relocationTimeMs} />
+          )}
+          {budget.selfManaged.relocationTimeMs === 0 && '0 ms (immediate)'}
+        </div>
+      );
+    }
+    return null;
+  };
+
+  // it's bad enough that we make users enter these values as milliseconds; let's not make them translate it
+  private ParentheticalDuration = ({ durationMs }: { durationMs: number }) => (
+    <span>
+      {durationMs} ms
+      {durationMs > 1000 && ` (${duration(durationMs)})`}
+    </span>
+  );
+
+  private Rate = ({ budget }: { budget: IJobDisruptionBudget }): JSX.Element => {
+    const { ParentheticalDuration } = this;
+    if (budget.ratePerInterval) {
+      return (
+        <>
+          <div>
+            <div className="bold">Interval</div>
+            <ParentheticalDuration durationMs={budget.ratePerInterval.intervalMs} />
+          </div>
+          <div>
+            <div className="bold">Limit</div>
+            {budget.ratePerInterval.limitPerInterval} task{budget.ratePerInterval.limitPerInterval !== 1 && 's'}
+          </div>
+        </>
+      );
+    }
+    if (budget.ratePercentagePerInterval) {
+      return (
+        <>
+          <div>
+            <div className="bold">Interval</div>
+            <ParentheticalDuration durationMs={budget.ratePercentagePerInterval.intervalMs} />
+          </div>
+          <div>
+            <div className="bold">Percentage per Interval</div>
+            {budget.ratePercentagePerInterval.percentageLimitPerInterval} percent
+          </div>
+        </>
+      );
+    }
+    return null;
+  };
+
+  // given a collection of days, e.g. ['Monday', 'Tuesday', 'Wednesday', 'Saturday'], return 'Mon-Wed, Sat'
+  private groupedDays = (days: string[]): string => {
+    const allDays = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
+    const sortedDays = days.sort((d1, d2) => allDays.indexOf(d1) - allDays.indexOf(d2));
+    const groups: string[] = [];
+    const currentGroup: string[] = [];
+    allDays.slice(allDays.indexOf(sortedDays[0])).forEach(d => {
+      if (sortedDays.includes(d)) {
+        currentGroup.push(d);
+      } else {
+        if (currentGroup.length) {
+          groups.push(this.toDayRangeString(currentGroup));
+          currentGroup.length = 0;
+        }
+      }
+    });
+    if (currentGroup.length) {
+      groups.push(this.toDayRangeString(currentGroup));
+    }
+    return groups.join(', ');
+  };
+
+  private toDayRangeString(days: string[]) {
+    if (!days.length) {
+      return null;
+    }
+    if (days.length === 1) {
+      return days[0].substr(0, 3);
+    }
+    return `${days[0].substr(0, 3)}-${days[days.length - 1].substr(0, 3)}`;
+  }
+
+  private TimeWindows = ({ budget }: { budget: IJobDisruptionBudget }): JSX.Element => {
+    const { groupedDays } = this;
+    const hasWindows = budget.timeWindows && budget.timeWindows.length > 0;
+    return (
+      <>
+        <div className="bold">When can disruption occur?</div>
+        <div>
+          {hasWindows &&
+            budget.timeWindows.map((tw1, i1) => {
+              return tw1.hourlyTimeWindows.map((tw2, i2) => (
+                <div key={`${i1}.${i2}`}>
+                  {groupedDays(tw1.days)}, {tw2.startHour}:00 - {tw2.endHour}:00 {tw1.timeZone}
+                </div>
+              ));
+            })}
+          {!hasWindows && 'Any time'}
+        </div>
+      </>
+    );
+  };
+
+  public render() {
+    const { Policy, SectionHeading, Rate, TimeWindows } = this;
+    const serverGroup: ITitusServerGroup = this.props.serverGroup;
+    const hasDefaultMigrationPolicy =
+      !serverGroup.migrationPolicy || serverGroup.migrationPolicy.type === 'SystemDefault';
+    const budget = serverGroup.disruptionBudget || cloneDeep(defaultJobDisruptionBudget);
+    const usingDefault = !hasDefaultMigrationPolicy && isEqual(budget, defaultJobDisruptionBudget);
+    return (
+      <>
+        <DisruptionBudgetDescription />
+        {usingDefault && <div>(default policy)</div>}
+        <div className="bottom-border">
+          <SectionHeading budget={budget} options={policyOptions} label="Policy" />
+          <Policy budget={budget} />
+        </div>
+        <div className="bottom-border">
+          <SectionHeading budget={budget} options={rateOptions} label="Rate" />
+          <Rate budget={budget} />
+        </div>
+        <TimeWindows budget={budget} />
+      </>
+    );
+  }
+}
+
+export const DISRUPTION_BUDGET_DETAILS_SECTION = 'spinnaker.titus.disruptionbudget.section';
+
+angular
+  .module(DISRUPTION_BUDGET_DETAILS_SECTION, [])
+  .component('titusDisruptionBudgetSection', react2angular(DisruptionBudgetSection, ['serverGroup', 'app']));

--- a/app/scripts/modules/titus/src/serverGroup/details/serverGroupDetails.html
+++ b/app/scripts/modules/titus/src/serverGroup/details/serverGroupDetails.html
@@ -183,6 +183,12 @@
         ></config-bin-link>
       </div>
     </collapsible-section>
+    <collapsible-section heading="Job Disruption Budget">
+      <titus-disruption-budget-section
+        app="ctrl.application"
+        server-group="serverGroup"
+      ></titus-disruption-budget-section>
+    </collapsible-section>
     <collapsible-section heading="Job Attributes">
       <div ng-if="!serverGroup.labels">No job attributes associated with this server group</div>
       <dl ng-if="labels">

--- a/app/scripts/modules/titus/src/serverGroup/details/serverGroupDetails.titus.controller.js
+++ b/app/scripts/modules/titus/src/serverGroup/details/serverGroupDetails.titus.controller.js
@@ -15,6 +15,8 @@ import {
 
 import { TitusReactInjector } from 'titus/reactShims';
 
+import { DISRUPTION_BUDGET_DETAILS_SECTION } from './DisruptionBudgetSection';
+
 import { SCALING_POLICY_MODULE } from './scalingPolicy/scalingPolicy.module';
 
 import { TitusCloneServerGroupModal } from '../configure/wizard/TitusCloneServerGroupModal';
@@ -25,6 +27,7 @@ module.exports = angular
     require('@uirouter/angularjs').default,
     require('../configure/ServerGroupCommandBuilder').name,
     CONFIRMATION_MODAL_SERVICE,
+    DISRUPTION_BUDGET_DETAILS_SECTION,
     SERVER_GROUP_WRITER,
     require('./resize/resizeServerGroup.controller').name,
     require('./rollback/rollbackServerGroup.controller').name,


### PR DESCRIPTION
I'm not going to convert the entire Titus server group details panel to React, but I will at least make this component not-Angular...