### PR TITLE
fix(artifacts): remove stage references to removed artifacts in artifacts rewrite mode

### DIFF
--- a/app/scripts/modules/core/src/artifact/ArtifactReferenceService.spec.ts
+++ b/app/scripts/modules/core/src/artifact/ArtifactReferenceService.spec.ts
@@ -23,22 +23,29 @@ describe('ArtifactReferenceService', () => {
       registerTestStage(['foo']);
       const stages = [stage({ type: 'testStage', foo: 'bar' })];
       ArtifactReferenceService.removeReferenceFromStages('bar', stages);
-      expect(stages[0].foo).toBe(undefined);
+      expect(stages[0].foo).toBe(null);
     });
 
     it('deletes multiple references from a stage if registered to do so', () => {
       registerTestStage(['deployedManifest', 'requiredArtifactIds']);
       const stages = [stage({ type: 'testStage', deployedManifest: 'foo', requiredArtifactIds: 'foo' })];
       ArtifactReferenceService.removeReferenceFromStages('foo', stages);
-      expect(stages[0].deployedManifest).toBe(undefined);
-      expect(stages[0].requiredArtifactIds).toBe(undefined);
+      expect(stages[0].deployedManifest).toBe(null);
+      expect(stages[0].requiredArtifactIds).toBe(null);
+    });
+
+    it('handles nested references', () => {
+      registerTestStage(['foo.bar']);
+      const stages = [stage({ type: 'testStage', foo: { bar: 'baz' } })];
+      ArtifactReferenceService.removeReferenceFromStages('baz', stages);
+      expect(stages[0].foo.bar).toBe(null);
     });
 
     it('doesnt delete reference from stage if reference doesnt match', () => {
       registerTestStage(['foo']);
       const stages = [stage({ type: 'testStage', foo: 'ref1' }), stage({ type: 'testStage', foo: 'ref2' })];
       ArtifactReferenceService.removeReferenceFromStages('ref1', stages);
-      expect(stages[0].foo).toBe(undefined);
+      expect(stages[0].foo).toBe(null);
       expect(stages[1].foo).toBe('ref2');
     });
 

--- a/app/scripts/modules/core/src/artifact/ArtifactReferenceService.ts
+++ b/app/scripts/modules/core/src/artifact/ArtifactReferenceService.ts
@@ -1,5 +1,5 @@
 import { IStage } from 'core/domain';
-import { get, noop } from 'lodash';
+import { get, noop, set } from 'lodash';
 import { Registry } from 'core/registry';
 
 export class ArtifactReferenceService {
@@ -12,10 +12,11 @@ export class ArtifactReferenceService {
   }
 
   public static removeArtifactFromField(field: string, obj: { [key: string]: string | string[] }, artifactId: string) {
-    if (Array.isArray(obj[field])) {
-      obj[field] = (obj[field] as string[]).filter((a: string) => a !== artifactId);
-    } else if (obj[field] === artifactId) {
-      delete obj[field];
+    const reference = get(obj, field);
+    if (Array.isArray(reference)) {
+      set(obj, field, reference.filter((a: string) => a !== artifactId));
+    } else if (reference === artifactId) {
+      set(obj, field, null);
     }
   }
 

--- a/app/scripts/modules/core/src/pipeline/config/triggers/trigger.directive.js
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/trigger.directive.js
@@ -6,6 +6,7 @@ import * as ReactDOM from 'react-dom';
 import { Registry } from 'core/registry';
 import { SETTINGS } from 'core/config/settings';
 import { TRIGGER_ARTIFACT_CONSTRAINT_SELECTOR_REACT } from './artifacts';
+import { ArtifactReferenceService } from '../../../artifact';
 
 const angular = require('angular');
 
@@ -19,6 +20,7 @@ const removeUnusedExpectedArtifacts = function(pipeline) {
         delete pipeline.expectedArtifacts;
       }
     }
+    ArtifactReferenceService.removeReferenceFromStages(artifact.id, pipeline.stages);
   });
 };
 


### PR DESCRIPTION
fix(artifacts): remove stage references to removed artifacts in artifacts rewrite mode

- Adds call to `ArtifactReferenceService.removeReferenceFromStages` to post-artifacts-rewrite logic for trigger/artifact deletion.

feat(artifacts): support nested artifact references in ArtifactReferenceService

- Allow `ArtifactReferenceService.removeArtifactFromFields` to specify nested references to artifacts (i.e. `keyA.keyB`) by replacing direct lookups with `_.get` and `_.set`. This cleanest way to do this was replacing the `delete` logic with a `._set` to null, so updated tests accordingly.