### PR TITLE
feat(titus): show disruption duration in readable format

### DIFF
--- a/app/scripts/modules/titus/src/serverGroup/details/DisruptionBudgetSection.tsx
+++ b/app/scripts/modules/titus/src/serverGroup/details/DisruptionBudgetSection.tsx
@@ -2,8 +2,9 @@ import * as React from 'react';
 import { isEqual, cloneDeep } from 'lodash';
 const angular = require('angular');
 import { react2angular } from 'react2angular';
+import * as prettyMilliseconds from 'pretty-ms';
 
-import { IServerGroupDetailsSectionProps, duration, HelpField } from '@spinnaker/core';
+import { IServerGroupDetailsSectionProps, HelpField } from '@spinnaker/core';
 
 import { defaultJobDisruptionBudget, IJobDisruptionBudget } from '../configure/serverGroupConfiguration.service';
 import { policyOptions } from '../configure/wizard/pages/disruptionBudget/PolicyOptions';
@@ -81,7 +82,7 @@ export class DisruptionBudgetSection extends React.Component<IServerGroupDetails
   private ParentheticalDuration = ({ durationMs }: { durationMs: number }) => (
     <span>
       {durationMs} ms
-      {durationMs > 1000 && ` (${duration(durationMs)})`}
+      {durationMs > 1000 && ` (${prettyMilliseconds(durationMs)})`}
     </span>
   );
 

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "memoize-one": "^4.0.2",
     "n3-charts": "^2.0.18",
     "ngimport": "^0.6.0",
+    "pretty-ms": "^5.0.0",
     "prop-types": "15.6.1",
     "react": "~16.8.0",
     "react-ace": "^6.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10611,6 +10611,11 @@ parse-json@^4.0.0:
     error-ex "^1.3.1"
     json-parse-better-errors "^1.0.1"
 
+parse-ms@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/parse-ms/-/parse-ms-2.1.0.tgz#348565a753d4391fa524029956b172cb7753097d"
+  integrity sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==
+
 parse-passwd@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
@@ -11337,6 +11342,13 @@ pretty-error@^2.0.2:
   dependencies:
     renderkid "^2.0.1"
     utila "~0.4"
+
+pretty-ms@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/pretty-ms/-/pretty-ms-5.0.0.tgz#6133a8f55804b208e4728f6aa7bf01085e951e24"
+  integrity sha512-94VRYjL9k33RzfKiGokPBPpsmloBYSf5Ri+Pq19zlsEcUKFob+admeXr5eFDRuPjFmEOcjJvPGdillYOJyvZ7Q==
+  dependencies:
+    parse-ms "^2.1.0"
 
 pretty-quick@^1.10.0:
   version "1.10.0"


### PR DESCRIPTION
Instead of, e.g. "02:24:48", show "2h 24m 48s".

I'm wary of bringing in yet another library, but this thing is trivially small (3.3kb, including its one dependency), so not that wary.