### PR TITLE
feat(core): compress AWS security groups before caching

### DIFF
--- a/app/scripts/modules/amazon/src/securityGroup/securityGroup.transformer.js
+++ b/app/scripts/modules/amazon/src/securityGroup/securityGroup.transformer.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const angular = require('angular');
+import { groupBy } from 'lodash';
 
 import { VpcReader } from '../vpc/VpcReader';
 
@@ -20,7 +21,28 @@ module.exports = angular
       };
     }
 
+    function compress(securityGroups) {
+      const grouped = groupBy(securityGroups, 'vpcId');
+      Object.keys(grouped).forEach(vpcId => {
+        grouped[vpcId] = grouped[vpcId].map(g => [g.name, g.id]);
+      });
+      return grouped;
+    }
+
+    function decompress(groupedGroups) {
+      const flattened = [];
+      Object.keys(groupedGroups).forEach(vpcId => {
+        groupedGroups[vpcId].forEach(g => {
+          flattened.push({ name: g[0], id: g[1], vpcId });
+        });
+      });
+      return flattened;
+    }
+
     return {
-      normalizeSecurityGroup: normalizeSecurityGroup,
+      normalizeSecurityGroup,
+      compress,
+      decompress,
+      supportsCompression: true,
     };
   });

--- a/app/scripts/modules/core/src/cache/infrastructureCacheConfig.ts
+++ b/app/scripts/modules/core/src/cache/infrastructureCacheConfig.ts
@@ -17,7 +17,7 @@ export interface IInfrastructureCacheConfig {
 
 export const INFRASTRUCTURE_CACHE_CONFIG: IInfrastructureCacheConfig = {
   securityGroups: {
-    version: 2, // increment to force refresh of cache on next page load - can be added to any cache
+    version: 3, // increment to force refresh of cache on next page load - can be added to any cache
   },
   healthChecks: {
     version: 2,


### PR DESCRIPTION
We ran into Safari' local storage limit (5 MB) trying to put the security groups cache in there. The changes here reduce the size of what we're putting into local storage by doing a couple of things:
* adding an additional level of grouping to each region (vpcId), so we don't have to store its value repeatedly
* storing the objects as a two-string tuple ([name, id]) instead of an object, so we don't have to store `"name":` and `"id":` repeatedly
This reduces the stored value size by about half. Compression adds about 10-30ms; decompression adds 10-30ms, too. I played around with actual compression algorithms, and was seeing ~90% size reduction, but I was also seeing 250+ms on both compression and decompression, so that's a non-starter IMO.

This is probably the last band-aid we want to put on the underlying problem, which is we fetch all the security groups (aka firewalls) in the world and cache them. We do this so we can quickly convert group IDs (e.g. `sg-123456789`) to names for display, and also so we don't repeatedly hit Gate to get a list of all security groups for when users are editing ingress rules or creating something (load balancer, server group) and adding security groups to it. The underlying problem is going to take a fair amount of work, I think...