### PR TITLE
feat(gcb): allow pre-artifacts-rewrite expected artifacts to be selec…

### DIFF
--- a/app/scripts/modules/core/src/artifact/NgGenericArtifactDelegate.ts
+++ b/app/scripts/modules/core/src/artifact/NgGenericArtifactDelegate.ts
@@ -8,7 +8,7 @@ import { IArtifactAccount } from 'core/account';
 import { ExpectedArtifactSelectorViewControllerAngularDelegate } from './ExpectedArtifactSelectorViewControllerAngularDelegate';
 import { ArtifactTypePatterns } from './ArtifactTypes';
 
-const defaultExcludedArtifactTypes = [ArtifactTypePatterns.KUBERNETES, ArtifactTypePatterns.DOCKER_IMAGE];
+export const defaultExcludedArtifactTypes = [ArtifactTypePatterns.KUBERNETES, ArtifactTypePatterns.DOCKER_IMAGE];
 
 export class NgGenericArtifactDelegate
   extends ExpectedArtifactSelectorViewControllerAngularDelegate<IArtifactSource<IStage | IPipeline>>

--- a/app/scripts/modules/core/src/artifact/index.ts
+++ b/app/scripts/modules/core/src/artifact/index.ts
@@ -21,3 +21,4 @@ export * from './react/ExpectedArtifactEditor';
 export * from './react/ExpectedArtifactSourceSelector';
 export * from './react/ExpectedArtifactModal';
 export * from './react/StageArtifactSelector';
+export * from './react/PreRewriteStageArtifactSelector';

--- a/app/scripts/modules/core/src/artifact/react/PreRewriteStageArtifactSelector.spec.tsx
+++ b/app/scripts/modules/core/src/artifact/react/PreRewriteStageArtifactSelector.spec.tsx
@@ -1,0 +1,140 @@
+import * as React from 'react';
+import { mount } from 'enzyme';
+
+import {
+  AccountService,
+  ArtifactAccountSelector,
+  ExpectedArtifactEditor,
+  ExpectedArtifactSelector,
+  IArtifactAccount,
+  IPipeline,
+  IStage,
+  noop,
+} from '@spinnaker/core';
+
+import { PreRewriteStageArtifactSelector } from './PreRewriteStageArtifactSelector';
+
+describe('<PreRewriteStageArtifactSelector />', () => {
+  let pipeline: IPipeline;
+  let stage: IStage;
+  let component: any;
+  let promise: Promise<IArtifactAccount[]>;
+
+  beforeEach(() => {
+    promise = Promise.resolve([
+      {
+        name: 'github-account-1',
+        types: ['github/file'],
+      },
+      {
+        name: 'github-account-2',
+        types: ['github/file'],
+      },
+    ]);
+    spyOn(AccountService, 'getArtifactAccounts').and.callFake(() => promise);
+
+    stage = {
+      name: 'Google Cloud Build',
+      refId: '1',
+      requisiteStageRefIds: [],
+      type: 'googleCloudBuild',
+    };
+
+    pipeline = {
+      application: 'my-app',
+      expectedArtifacts: [
+        {
+          displayName: 'shy-newt-62',
+          defaultArtifact: {
+            id: '5aa6d7ef-2cbd-4384-973b-2d8e75cd69b8',
+            name: 'gcb.yml',
+            reference: 'https://api.github.com/repos/maggieneterval/spinnaker-kubernetes-demo/contents/gcb.yml',
+            type: 'github/file',
+            version: 'master',
+          },
+          id: '626ce062-6e60-498d-a562-289db3f7faf5',
+          matchArtifact: {
+            id: '863f61af-1d74-40ba-886b-27c985b5f6e7',
+            name: 'gcb.yml',
+            type: 'github/file',
+          },
+          usePriorArtifact: false,
+          useDefaultArtifact: true,
+        },
+      ],
+      id: '123',
+      index: 0,
+      keepWaitingPipelines: false,
+      limitConcurrent: true,
+      name: 'my-pipeline',
+      stages: [stage],
+      strategy: false,
+      triggers: [],
+      parameterConfig: [],
+    };
+  });
+
+  it('renders only an ExpectedArtifactSelector by default', () => {
+    component = mount(
+      <PreRewriteStageArtifactSelector
+        excludedArtifactTypes={[]}
+        selectedArtifactId={null}
+        pipeline={pipeline}
+        selectedArtifactAccount={null}
+        setArtifactAccount={noop}
+        setArtifactId={noop}
+        stage={stage}
+      />,
+    );
+    return promise
+      .then(() => component.update())
+      .then(() => {
+        expect(component.find(ExpectedArtifactSelector).length).toEqual(1);
+        expect(component.find(ArtifactAccountSelector).length).toEqual(0);
+        expect(component.find(ExpectedArtifactEditor).length).toEqual(0);
+      });
+  });
+
+  it('renders an ExpectedArtifactSelector and ArtifactAccountSelector when an expected artifact with more than one possible account is selected', () => {
+    component = mount(
+      <PreRewriteStageArtifactSelector
+        excludedArtifactTypes={[]}
+        selectedArtifactId="626ce062-6e60-498d-a562-289db3f7faf5"
+        pipeline={pipeline}
+        selectedArtifactAccount="github-account-2"
+        setArtifactAccount={noop}
+        setArtifactId={noop}
+        stage={stage}
+      />,
+    );
+    return promise
+      .then(() => component.update())
+      .then(() => {
+        expect(component.find(ExpectedArtifactSelector).length).toEqual(1);
+        expect(component.find(ArtifactAccountSelector).length).toEqual(1);
+        expect(component.find(ExpectedArtifactEditor).length).toEqual(0);
+      });
+  });
+
+  it('renders an ExpectedArtifactSelector and ExpectedArtifactEditor (which includes an ArtifactAccountSelector) when "Create new" is selected', () => {
+    component = mount(
+      <PreRewriteStageArtifactSelector
+        excludedArtifactTypes={[]}
+        selectedArtifactId={null}
+        pipeline={pipeline}
+        selectedArtifactAccount={null}
+        setArtifactAccount={noop}
+        setArtifactId={noop}
+        stage={stage}
+      />,
+    );
+    component.instance().onRequestCreateArtifact();
+    return promise
+      .then(() => component.update())
+      .then(() => {
+        expect(component.find(ExpectedArtifactSelector).length).toEqual(1);
+        expect(component.find(ArtifactAccountSelector).length).toEqual(1);
+        expect(component.find(ExpectedArtifactEditor).length).toEqual(1);
+      });
+  });
+});

--- a/app/scripts/modules/core/src/artifact/react/PreRewriteStageArtifactSelector.tsx
+++ b/app/scripts/modules/core/src/artifact/react/PreRewriteStageArtifactSelector.tsx
@@ -1,0 +1,206 @@
+import * as React from 'react';
+import { Observable, Subject } from 'rxjs';
+import { find, get } from 'lodash';
+
+import {
+  defaultExcludedArtifactTypes,
+  AccountService,
+  ArtifactAccountSelector,
+  ExpectedArtifactEditor,
+  ExpectedArtifactSelector,
+  ExpectedArtifactService,
+  IArtifactAccount,
+  IArtifactKindConfig,
+  IArtifactSource,
+  IExpectedArtifact,
+  IExpectedArtifactSourceOption,
+  IPipeline,
+  IStage,
+  Registry,
+  StageConfigField,
+} from '@spinnaker/core';
+
+interface IPreRewriteArtifactSelectorProps {
+  excludedArtifactTypes?: RegExp[];
+  selectedArtifactId: string;
+  pipeline: IPipeline;
+  selectedArtifactAccount: string;
+  setArtifactAccount: (accountName: string) => void;
+  setArtifactId: (expectedArtifactId: string) => void;
+  stage: IStage;
+  updatePipeline: (pipeline: IPipeline) => void;
+}
+
+interface IPreRewriteArtifactSelectorState {
+  accountsForArtifact: IArtifactAccount[];
+  allArtifactAccounts: IArtifactAccount[];
+  expectedArtifacts: IExpectedArtifact[];
+  showCreateArtifactForm: boolean;
+}
+
+export class PreRewriteStageArtifactSelector extends React.Component<
+  IPreRewriteArtifactSelectorProps,
+  IPreRewriteArtifactSelectorState
+> {
+  public static defaultProps: Partial<IPreRewriteArtifactSelectorProps> = {
+    excludedArtifactTypes: defaultExcludedArtifactTypes,
+  };
+  private destroy$ = new Subject();
+
+  public constructor(props: IPreRewriteArtifactSelectorProps) {
+    super(props);
+    this.state = {
+      accountsForArtifact: [],
+      allArtifactAccounts: [],
+      expectedArtifacts: ExpectedArtifactService.getExpectedArtifactsAvailableToStage(props.stage, props.pipeline),
+      showCreateArtifactForm: false,
+    };
+  }
+
+  public componentDidMount(): void {
+    this.fetchArtifactAccounts();
+  }
+
+  private fetchArtifactAccounts = (): void => {
+    Observable.fromPromise(AccountService.getArtifactAccounts())
+      .takeUntil(this.destroy$)
+      .subscribe((allArtifactAccounts: IArtifactAccount[]) => {
+        this.setState({
+          accountsForArtifact: this.getAccountsForArtifact(allArtifactAccounts, this.props.selectedArtifactId),
+          allArtifactAccounts,
+        });
+      });
+  };
+
+  private getAccountsForArtifact = (
+    allArtifactAccounts: IArtifactAccount[],
+    selectedArtifactId: string,
+  ): IArtifactAccount[] => {
+    const artifact = ExpectedArtifactService.artifactFromExpected(this.getSelectedExpectedArtifact(selectedArtifactId));
+    if (!artifact) {
+      return [];
+    }
+    return artifact.type === 'helm/chart'
+      ? allArtifactAccounts.filter(a => a.types.includes(artifact.type) && a.name === artifact.artifactAccount)
+      : allArtifactAccounts.filter(a => a.types.includes(artifact.type));
+  };
+
+  private getSelectedExpectedArtifact = (selectedArtifactId: string): IExpectedArtifact => {
+    return find(this.state.expectedArtifacts, artifact => artifact.id === selectedArtifactId);
+  };
+
+  private getSelectedArtifactAccount = (): IArtifactAccount => {
+    return find(this.state.allArtifactAccounts, account => account.name === this.props.selectedArtifactAccount);
+  };
+
+  private updateAccounts = (artifactId: string): void => {
+    const { selectedArtifactAccount, setArtifactAccount } = this.props;
+
+    const accountsForArtifact = this.getAccountsForArtifact(this.state.allArtifactAccounts, artifactId);
+    if (!selectedArtifactAccount || !accountsForArtifact.find(a => a.name === selectedArtifactAccount)) {
+      if (accountsForArtifact.length) {
+        setArtifactAccount(get(accountsForArtifact, [0, 'name']));
+      } else {
+        setArtifactAccount(null);
+      }
+    }
+    this.setState({
+      accountsForArtifact,
+    });
+  };
+
+  private onArtifactChange = (expectedArtifact: IExpectedArtifact) => {
+    this.props.setArtifactId(expectedArtifact.id);
+    this.setState({
+      showCreateArtifactForm: false,
+    });
+    this.updateAccounts(expectedArtifact.id);
+  };
+
+  private onRequestCreateArtifact = (): void => {
+    this.setState({
+      showCreateArtifactForm: true,
+    });
+  };
+
+  private showAccountSelect = (): boolean => {
+    return (
+      !this.state.showCreateArtifactForm &&
+      this.getSelectedExpectedArtifact(this.props.selectedArtifactId) != null &&
+      this.state.accountsForArtifact.length > 1
+    );
+  };
+
+  private getKinds = (): IArtifactKindConfig[] => {
+    return Registry.pipeline
+      .getMatchArtifactKinds()
+      .filter((a: IArtifactKindConfig) => !this.props.excludedArtifactTypes.find(t => t.test(a.type)));
+  };
+
+  private getSources = (): IExpectedArtifactSourceOption[] => {
+    return ExpectedArtifactService.sourcesForPipelineStage(
+      () => this.props.pipeline,
+      this.props.stage,
+    ) as IExpectedArtifactSourceOption[];
+  };
+
+  private saveCreatedArtifact = (event: {
+    expectedArtifact: IExpectedArtifact;
+    account: IArtifactAccount;
+    source: IArtifactSource<any>;
+  }) => {
+    ExpectedArtifactService.addArtifactTo(event.expectedArtifact, event.source.source);
+    this.props.updatePipeline(event.source.source);
+    this.updateAccounts(event.expectedArtifact.id);
+    this.props.setArtifactId(event.expectedArtifact.id);
+    this.props.setArtifactAccount(event.account.name);
+    this.setState({
+      expectedArtifacts: ExpectedArtifactService.getExpectedArtifactsAvailableToStage(
+        this.props.stage,
+        this.props.pipeline,
+      ),
+      showCreateArtifactForm: false,
+    });
+  };
+
+  public componentWillUnmount(): void {
+    this.destroy$.next();
+  }
+
+  public render() {
+    const { excludedArtifactTypes, selectedArtifactId, setArtifactAccount } = this.props;
+    const { accountsForArtifact, allArtifactAccounts, showCreateArtifactForm } = this.state;
+
+    return (
+      <>
+        <StageConfigField label="Artifact">
+          <ExpectedArtifactSelector
+            excludedArtifactTypes={excludedArtifactTypes}
+            expectedArtifacts={this.state.expectedArtifacts}
+            selected={this.getSelectedExpectedArtifact(selectedArtifactId)}
+            onChange={this.onArtifactChange}
+            onRequestCreate={this.onRequestCreateArtifact}
+            requestingNew={showCreateArtifactForm}
+          />
+        </StageConfigField>
+        {this.showAccountSelect() && (
+          <StageConfigField label="Artifact Account">
+            <ArtifactAccountSelector
+              accounts={accountsForArtifact}
+              selected={this.getSelectedArtifactAccount()}
+              onChange={(account: IArtifactAccount) => setArtifactAccount(account.name)}
+            />
+          </StageConfigField>
+        )}
+        {this.state.showCreateArtifactForm && (
+          <ExpectedArtifactEditor
+            accounts={allArtifactAccounts}
+            kinds={this.getKinds()}
+            onSave={this.saveCreatedArtifact}
+            sources={this.getSources()}
+          />
+        )}
+      </>
+    );
+  }
+}

--- a/app/scripts/modules/core/src/pipeline/config/stages/common/IStageConfigProps.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/common/IStageConfigProps.ts
@@ -9,4 +9,7 @@ export interface IStageConfigProps {
   stageFieldUpdated: () => void;
   updateStage: (changes: { [key: string]: any }) => void;
   updateStageField: (changes: { [key: string]: any }) => void;
+  // Added to enable inline artifact editing from React stages
+  // todo(mneterval): remove after pre-rewrite artifacts are deprecated
+  updatePipeline: (changes: { [key: string]: any }) => void;
 }

--- a/app/scripts/modules/core/src/pipeline/config/stages/googleCloudBuild/GoogleCloudBuildStageConfig.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/googleCloudBuild/GoogleCloudBuildStageConfig.tsx
@@ -22,8 +22,10 @@ export class GoogleCloudBuildStageConfig extends React.Component<IStageConfigPro
     };
     const { stage: initialStageConfig } = props;
     const stage = cloneDeep(initialStageConfig);
-    if (initialStageConfig.isNew) {
+    if (!stage.application) {
       stage.application = props.application.name;
+    }
+    if (!stage.buildDefinitionSource) {
       stage.buildDefinitionSource = buildDefinitionSources.TEXT;
     }
     // Intentionally initializing the stage config only once in the constructor
@@ -35,7 +37,7 @@ export class GoogleCloudBuildStageConfig extends React.Component<IStageConfigPro
     this.fetchGoogleCloudBuildAccounts();
   };
 
-  private fetchGoogleCloudBuildAccounts = () => {
+  private fetchGoogleCloudBuildAccounts = (): void => {
     Observable.fromPromise(IgorService.getGcbAccounts())
       .takeUntil(this.destroy$)
       .subscribe((googleCloudBuildAccounts: string[]) => {
@@ -55,7 +57,11 @@ export class GoogleCloudBuildStageConfig extends React.Component<IStageConfigPro
         onChange={this.props.updateStage}
         validate={validate}
         render={props => (
-          <GoogleCloudBuildStageForm {...props} googleCloudBuildAccounts={this.state.googleCloudBuildAccounts} />
+          <GoogleCloudBuildStageForm
+            {...props}
+            googleCloudBuildAccounts={this.state.googleCloudBuildAccounts}
+            updatePipeline={this.props.updatePipeline}
+          />
         )}
       />
     );

--- a/app/scripts/modules/core/src/pipeline/config/stages/stage.module.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/stage.module.js
@@ -217,6 +217,11 @@ module.exports = angular
                 extend($scope.stage, changes);
                 $scope.stageFieldUpdated();
               },
+              // Added to enable inline artifact editing from React stages
+              // todo(mneterval): remove after pre-rewrite artifacts are deprecated
+              updatePipeline: changes => {
+                extend($scope.$parent.pipeline, changes);
+              },
               pipeline: $scope.pipeline,
               stage: $scope.stage,
               component: config.component,


### PR DESCRIPTION
…ted in gcb stage

- Abstracts pre-rewrite artifact selection and inline creation into new React component, `PreRewriteStageArtifactSelector`. In order to avoid introducing angular dependencies to this component, expose `updatePipeline` prop to React stage components. Saving an artifact inline needs to add it to the parent pipeline's list of `expectedArtifacts`. This approach feels "bad" so if anyone has a more elegant solution please let me know. (:cry:) Existing components handle this by mutating `$scope.parent.pipeline` directly via angular delegates/controllers. 
- We will be able to remove `updatePipeline` once we deprecate pre-rewrite artifact handling. In the meantime, it will unblock us from removing the angular artifact delegates and controllers as dependencies from all Kubernetes stages that handle artifacts.

![xBnbHHZHy4A](https://user-images.githubusercontent.com/15936279/57390214-d20c7200-7189-11e9-8056-034410b2a6d9.png)

![RcipPGWcRiu](https://user-images.githubusercontent.com/15936279/57544480-72e36480-7325-11e9-9e5c-e56cc4fd1dd3.png)

