### PR TITLE
feat(titus): allow editing of existing disruption budget

### DIFF
--- a/app/scripts/modules/titus/src/domain/IJobDisruptionBudget.ts
+++ b/app/scripts/modules/titus/src/domain/IJobDisruptionBudget.ts
@@ -1,0 +1,19 @@
+export interface IJobTimeWindow {
+  days: string[];
+  hourlyTimeWindows: Array<{ startHour: number; endHour: number }>;
+  timeZone: string;
+}
+
+export interface IJobDisruptionBudget {
+  // policy options
+  availabilityPercentageLimit?: { percentageOfHealthyContainers: number }; // default
+  unhealthyTasksLimit?: { limitOfUnhealthyContainers: number };
+  selfManaged?: { relocationTimeMs: number };
+  relocationLimit?: { limit: number };
+
+  rateUnlimited?: boolean;
+  timeWindows: IJobTimeWindow[];
+  containerHealthProviders: Array<{ name: string }>;
+  ratePerInterval?: { intervalMs: number; limitPerInterval: number };
+  ratePercentagePerInterval?: { intervalMs: number; percentageLimitPerInterval: number };
+}

--- a/app/scripts/modules/titus/src/domain/ITitusServerGroup.ts
+++ b/app/scripts/modules/titus/src/domain/ITitusServerGroup.ts
@@ -1,9 +1,10 @@
 import { IAccountDetails, IServerGroup } from '@spinnaker/core';
 import { IScalingPolicyView } from '@spinnaker/amazon';
-import { IJobDisruptionBudget } from '../serverGroup/configure/serverGroupConfiguration.service';
+import { IJobDisruptionBudget } from './IJobDisruptionBudget';
 import { ITitusPolicy } from './ITitusScalingPolicy';
 
 export interface ITitusServerGroup extends IServerGroup {
+  id?: string;
   disruptionBudget?: IJobDisruptionBudget;
   migrationPolicy?: { type: string };
   image?: ITitusImage;

--- a/app/scripts/modules/titus/src/domain/index.ts
+++ b/app/scripts/modules/titus/src/domain/index.ts
@@ -1,3 +1,4 @@
+export * from './IJobDisruptionBudget';
 export * from './ITitusCredentials';
 export * from './ITitusScalingPolicy';
 export * from './ITitusServerGroup';

--- a/app/scripts/modules/titus/src/serverGroup/configure/serverGroupConfiguration.service.ts
+++ b/app/scripts/modules/titus/src/serverGroup/configure/serverGroupConfiguration.service.ts
@@ -27,6 +27,8 @@ import {
   VpcReader,
 } from '@spinnaker/amazon';
 
+import { IJobDisruptionBudget } from 'titus/domain';
+
 export interface ITitusServerGroupCommandBackingData extends IServerGroupCommandBackingData {
   accounts: string[];
   vpcs: IVpc[];
@@ -37,26 +39,6 @@ export interface ITitusServerGroupCommandViewState extends IServerGroupCommandVi
   regionChangedStream: Subject<{}>;
   groupsRemovedStream: Subject<{}>;
   dirty: IAmazonServerGroupCommandDirty;
-}
-
-export interface IJobTimeWindow {
-  days: string[];
-  hourlyTimeWindows: Array<{ startHour: number; endHour: number }>;
-  timeZone: string;
-}
-
-export interface IJobDisruptionBudget {
-  // policy options
-  availabilityPercentageLimit?: { percentageOfHealthyContainers: number }; // default
-  unhealthyTasksLimit?: { limitOfUnhealthyContainers: number };
-  selfManaged?: { relocationTimeMs: number };
-  relocationLimit?: { limit: number };
-
-  rateUnlimited?: boolean;
-  timeWindows: IJobTimeWindow[];
-  containerHealthProviders: Array<{ name: string }>;
-  ratePerInterval?: { intervalMs: number; limitPerInterval: number };
-  ratePercentagePerInterval?: { intervalMs: number; percentageLimitPerInterval: number };
 }
 
 export const defaultJobDisruptionBudget: IJobDisruptionBudget = {

--- a/app/scripts/modules/titus/src/serverGroup/configure/wizard/pages/disruptionBudget/JobDisruptionBudget.tsx
+++ b/app/scripts/modules/titus/src/serverGroup/configure/wizard/pages/disruptionBudget/JobDisruptionBudget.tsx
@@ -14,11 +14,9 @@ import {
 
 import { WindowPicker } from './WindowPicker';
 
-import {
-  ITitusServerGroupCommand,
-  defaultJobDisruptionBudget,
-  IJobDisruptionBudget,
-} from '../../../serverGroupConfiguration.service';
+import { ITitusServerGroupCommand, defaultJobDisruptionBudget } from '../../../serverGroupConfiguration.service';
+
+import { IJobDisruptionBudget } from 'titus/domain';
 
 import { rateOptions } from './RateOptions';
 

--- a/app/scripts/modules/titus/src/serverGroup/configure/wizard/pages/disruptionBudget/WindowPicker.tsx
+++ b/app/scripts/modules/titus/src/serverGroup/configure/wizard/pages/disruptionBudget/WindowPicker.tsx
@@ -4,7 +4,8 @@ import { get } from 'lodash';
 
 import { FormikFormField, ChecklistInput, NumberInput, HelpField, ReactSelectInput } from '@spinnaker/core';
 
-import { IJobTimeWindow, ITitusServerGroupCommand } from '../../../serverGroupConfiguration.service';
+import { ITitusServerGroupCommand } from '../../../serverGroupConfiguration.service';
+import { IJobTimeWindow } from 'titus/domain';
 
 export interface IWindowPickerProps {
   formik: FormikProps<ITitusServerGroupCommand>;

--- a/app/scripts/modules/titus/src/serverGroup/details/disruptionBudget/DisruptionBudgetSection.tsx
+++ b/app/scripts/modules/titus/src/serverGroup/details/disruptionBudget/DisruptionBudgetSection.tsx
@@ -5,15 +5,17 @@ import { react2angular } from 'react2angular';
 import * as prettyMilliseconds from 'pretty-ms';
 
 import { IServerGroupDetailsSectionProps, HelpField } from '@spinnaker/core';
+import { TitusReactInjector } from 'titus';
 
-import { defaultJobDisruptionBudget, IJobDisruptionBudget } from '../configure/serverGroupConfiguration.service';
-import { policyOptions } from '../configure/wizard/pages/disruptionBudget/PolicyOptions';
-import { rateOptions } from '../configure/wizard/pages/disruptionBudget/RateOptions';
+import { defaultJobDisruptionBudget, ITitusServerGroupCommand } from '../../configure/serverGroupConfiguration.service';
+import { policyOptions } from '../../configure/wizard/pages/disruptionBudget/PolicyOptions';
+import { rateOptions } from '../../configure/wizard/pages/disruptionBudget/RateOptions';
 import {
   IFieldOption,
   DisruptionBudgetDescription,
-} from '../configure/wizard/pages/disruptionBudget/JobDisruptionBudget';
-import { ITitusServerGroup } from 'titus/domain';
+} from '../../configure/wizard/pages/disruptionBudget/JobDisruptionBudget';
+import { ITitusServerGroup, IJobDisruptionBudget } from '../../../domain';
+import { EditDisruptionBudgetModal } from './EditDisruptionBudgetModal';
 
 export class DisruptionBudgetSection extends React.Component<IServerGroupDetailsSectionProps> {
   private SectionHeading = ({
@@ -172,6 +174,15 @@ export class DisruptionBudgetSection extends React.Component<IServerGroupDetails
     );
   };
 
+  private editBudget = (): void => {
+    const { app, serverGroup } = this.props;
+    TitusReactInjector.titusServerGroupCommandBuilder
+      .buildServerGroupCommandFromExisting(app, serverGroup)
+      .then((command: ITitusServerGroupCommand) => {
+        EditDisruptionBudgetModal.show({ command, application: app, serverGroup });
+      });
+  };
+
   public render() {
     const { Policy, SectionHeading, Rate, TimeWindows } = this;
     const serverGroup: ITitusServerGroup = this.props.serverGroup;
@@ -192,6 +203,11 @@ export class DisruptionBudgetSection extends React.Component<IServerGroupDetails
           <Rate budget={budget} />
         </div>
         <TimeWindows budget={budget} />
+        <div className="sp-margin-l-top">
+          <a className="clickable" onClick={this.editBudget}>
+            Edit Disruption Budget
+          </a>
+        </div>
       </>
     );
   }

--- a/app/scripts/modules/titus/src/serverGroup/details/disruptionBudget/EditDisruptionBudgetModal.tsx
+++ b/app/scripts/modules/titus/src/serverGroup/details/disruptionBudget/EditDisruptionBudgetModal.tsx
@@ -1,0 +1,96 @@
+import * as React from 'react';
+import { Modal } from 'react-bootstrap';
+import { Formik } from 'formik';
+
+import {
+  Application,
+  TaskMonitor,
+  IJob,
+  IModalComponentProps,
+  ModalClose,
+  SubmitButton,
+  NgReact,
+  ReactModal,
+  TaskExecutor,
+} from '@spinnaker/core';
+
+import { JobDisruptionBudget } from '../../configure/wizard/pages/disruptionBudget/JobDisruptionBudget';
+import { ITitusServerGroupCommand } from '../../configure/serverGroupConfiguration.service';
+import { ITitusServerGroup } from 'titus/domain';
+
+export interface IEditDisruptionBudgetModalProps extends IModalComponentProps {
+  application: Application;
+  command: ITitusServerGroupCommand;
+  serverGroup: ITitusServerGroup;
+}
+
+export class EditDisruptionBudgetModal extends React.Component<IEditDisruptionBudgetModalProps> {
+  public static show(props: IEditDisruptionBudgetModalProps): Promise<void> {
+    return ReactModal.show(EditDisruptionBudgetModal, props);
+  }
+
+  private submit(values: ITitusServerGroupCommand, taskMonitor: TaskMonitor): void {
+    const { application, serverGroup } = this.props;
+    const job: IJob = {
+      type: 'upsertDisruptionBudget',
+      cloudProvider: 'titus',
+      credentials: serverGroup.account,
+      region: serverGroup.region,
+      jobId: serverGroup.id,
+      disruptionBudget: values.disruptionBudget,
+    };
+
+    taskMonitor.submit(() =>
+      TaskExecutor.executeTask({
+        job: [job],
+        application,
+        description: `Update Disruption Budget for ${serverGroup.name}`,
+      }),
+    );
+  }
+
+  public render() {
+    const { application, command, dismissModal } = this.props;
+    const { TaskMonitorWrapper } = NgReact;
+    const taskMonitor = new TaskMonitor({
+      application,
+      title: 'Updating Job Disruption Budget',
+      modalInstance: TaskMonitor.modalInstanceEmulation(() => dismissModal()),
+      onTaskComplete: () => application.serverGroups.refresh(),
+    });
+
+    return (
+      <>
+        <TaskMonitorWrapper monitor={taskMonitor} />
+        <Formik<ITitusServerGroupCommand>
+          initialValues={command}
+          isInitialValid={true}
+          onSubmit={(values: ITitusServerGroupCommand) => this.submit(values, taskMonitor)}
+          render={formik => (
+            <>
+              <Modal.Header>
+                <h3>Update Disruption Budget</h3>
+              </Modal.Header>
+              <ModalClose dismiss={dismissModal} />
+              <Modal.Body>
+                <JobDisruptionBudget formik={formik} />
+              </Modal.Body>
+              <Modal.Footer>
+                <button className="btn btn-default" onClick={dismissModal} type="button">
+                  Cancel
+                </button>
+                <SubmitButton
+                  onClick={() => this.submit(formik.values, taskMonitor)}
+                  isDisabled={!formik.isValid}
+                  isFormSubmit={true}
+                  submitting={false}
+                  label="Update Budget"
+                />
+              </Modal.Footer>
+            </>
+          )}
+        />
+      </>
+    );
+  }
+}

--- a/app/scripts/modules/titus/src/serverGroup/details/serverGroupDetails.titus.controller.js
+++ b/app/scripts/modules/titus/src/serverGroup/details/serverGroupDetails.titus.controller.js
@@ -15,7 +15,7 @@ import {
 
 import { TitusReactInjector } from 'titus/reactShims';
 
-import { DISRUPTION_BUDGET_DETAILS_SECTION } from './DisruptionBudgetSection';
+import { DISRUPTION_BUDGET_DETAILS_SECTION } from './disruptionBudget/DisruptionBudgetSection';
 
 import { SCALING_POLICY_MODULE } from './scalingPolicy/scalingPolicy.module';
 


### PR DESCRIPTION
Not exciting, fortunately. Reusing the budget editor from the create/clone modal to allow editing of existing disruption budgets.