### PR TITLE
Bump package core to 0.0.360 and amazon to 0.0.188 and titus to 0.0.94

### DIFF
--- a/app/scripts/modules/amazon/package.json
+++ b/app/scripts/modules/amazon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/amazon",
-  "version": "0.0.187",
+  "version": "0.0.188",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/core",
-  "version": "0.0.359",
+  "version": "0.0.360",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/titus/package.json
+++ b/app/scripts/modules/titus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/titus",
-  "version": "0.0.93",
+  "version": "0.0.94",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
### chore(core): Bump version to 0.0.360

954506ac56629b416441455ad1bb91929df19860 feat(core): compress AWS security groups before caching (#6947)
67baf43add977faded5eabb1e01b454acbdd1bce refactor(core): convert providerSelection modal to React (#6936)
1ada02195c197978e714126bf867121971ec7ccb feat(kubernetes): expose rendered helm template in execution details (#6943)
edee9effaf06ea096e98b5b65eed0d945d2bb76c fix(artifacts): remove stage references to removed artifacts in artifacts rewrite mode (#6939)

### chore(amazon): Bump version to 0.0.188

954506ac56629b416441455ad1bb91929df19860 feat(core): compress AWS security groups before caching (#6947)

### chore(titus): Bump version to 0.0.94

016be9e269700ec78d5f809c60c6d43665183254 feat(titus): allow editing of existing disruption budget (#6950)
67baf43add977faded5eabb1e01b454acbdd1bce refactor(core): convert providerSelection modal to React (#6936)
