### PR TITLE
Bump package core to 0.0.361 and titus to 0.0.95

### DIFF
--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/core",
-  "version": "0.0.360",
+  "version": "0.0.361",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/titus/package.json
+++ b/app/scripts/modules/titus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/titus",
-  "version": "0.0.94",
+  "version": "0.0.95",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
### chore(core): Bump version to 0.0.361

61c4afa03fd275f094925c64853af2851d15c563 fix(core): use new ProviderSelectionService everywhere (#6953)

### chore(titus): Bump version to 0.0.95

bbcbd7363b860f12f624a1a6b1f0b2c2d70f0050 fix(titus): import TitusReactInjector from subdirectory (#6952)
