### PR TITLE
fix(core/executions): make text on truncated params selectable

### DIFF
--- a/app/scripts/modules/core/src/pipeline/status/ExecutionParameters.tsx
+++ b/app/scripts/modules/core/src/pipeline/status/ExecutionParameters.tsx
@@ -16,11 +16,7 @@ export interface IDisplayableParameter {
   valueTruncated?: string;
 }
 
-interface IExecutionParametersState {
-  toggle: boolean;
-}
-
-export class ExecutionParameters extends React.Component<IExecutionParametersProps, IExecutionParametersState> {
+export class ExecutionParameters extends React.Component<IExecutionParametersProps> {
   constructor(props: IExecutionParametersProps) {
     super(props);
   }
@@ -29,7 +25,7 @@ export class ExecutionParameters extends React.Component<IExecutionParametersPro
     if (parameter.valueTruncated) {
       return () => {
         parameter.showTruncatedValue = !parameter.showTruncatedValue;
-        this.setState({ toggle: parameter.showTruncatedValue });
+        this.forceUpdate();
       };
     }
     return null;
@@ -60,13 +56,15 @@ export class ExecutionParameters extends React.Component<IExecutionParametersPro
               {c.map(p => (
                 <div key={p.key} className="an-execution-parameter">
                   <div className="parameter-key">{p.key}:</div>
-                  <div className="parameter-value" onClick={this.toggleParameterTruncation(p)}>
-                    {p.showTruncatedValue ? p.valueTruncated : p.value}
-                    {p.showTruncatedValue ? (
-                      <a>
-                        <span> View Full</span>
-                      </a>
-                    ) : null}
+                  <div className="parameter-value">
+                    <div className="vertical">
+                      <span>{p.showTruncatedValue ? p.valueTruncated : p.value}</span>
+                      {p.valueTruncated && (
+                        <button className="link truncate-toggle" onClick={this.toggleParameterTruncation(p)}>
+                          {p.showTruncatedValue ? ' Show more' : ' Show Less'}
+                        </button>
+                      )}
+                    </div>
                   </div>
                 </div>
               ))}

--- a/app/scripts/modules/core/src/pipeline/status/executionParameters.less
+++ b/app/scripts/modules/core/src/pipeline/status/executionParameters.less
@@ -33,4 +33,11 @@
   display: table-cell;
   padding: 1px;
   word-break: break-word;
+
+  .truncate-toggle {
+    padding: 0;
+    align-self: flex-start;
+    outline: none;
+    line-height: 30px;
+  }
 }


### PR DESCRIPTION
In the new parameter UI for executions, we truncate parameter values over a certain size. Turns out that the toggle for showing/hiding the truncated value was setup to fire when clicking _any part of the value_, not just the 'View Full' link, and that makes it hard/impossible to select text out of a long value (like a JSON object) to copy-paste.

This changes to an always-visible 'Show more' / 'Show less' toggle, and removes click handling on the text itself. I had to do some weird layout hacking with `line-height` to get the link to work, which as far as I can tell is caused by the table layout these parameters are using (the clickable area seems to get truncated by the table row element somehow).

In my heart of hearts I'd like to move to using flex layouts here as I think that would fix these weird layout problems, but don't really want to go down the rabbit hole right now.

Before:
<img width="700" alt="Screen Shot 2019-05-09 at 11 03 57 AM" src="https://user-images.githubusercontent.com/1850998/57475918-427ac800-724a-11e9-9cb1-972d3d159e5c.png">

After:
<img width="705" alt="Screen Shot 2019-05-09 at 11 05 13 AM" src="https://user-images.githubusercontent.com/1850998/57476025-8ff73500-724a-11e9-83a7-9d75eb9f1875.png">
