### PR TITLE
fix(artifacts): Allow defaulting in execution artifact

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/findArtifactFromExecution/findArtifactFromExecution.controller.spec.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/findArtifactFromExecution/findArtifactFromExecution.controller.spec.ts
@@ -1,0 +1,111 @@
+'use strict';
+
+import { IScope, mock } from 'angular';
+import { FindArtifactFromExecutionCtrl } from 'core/pipeline/config/stages/findArtifactFromExecution/findArtifactFromExecution.controller';
+
+describe('Find Artifact From Execution Controller:', function() {
+  let ctrl: FindArtifactFromExecutionCtrl, $scope: IScope, initializeController: (stage: any) => void;
+
+  beforeEach(
+    mock.inject(($rootScope: IScope) => {
+      $scope = $rootScope.$new();
+      initializeController = (stage: any) => {
+        $scope = $rootScope.$new();
+        $scope.stage = stage;
+        ctrl = new FindArtifactFromExecutionCtrl($scope);
+      };
+    }),
+  );
+
+  it('properly initializes an empty stage', () => {
+    initializeController({});
+    const expectedArtifact = ctrl.stage.expectedArtifact;
+    const executionOptions: any = ctrl.stage.executionOptions;
+
+    expect(executionOptions).toBeDefined();
+
+    expect(expectedArtifact).toBeDefined();
+    expect(expectedArtifact.id).toBeDefined();
+    expect(expectedArtifact.displayName).toBeDefined();
+    expect(expectedArtifact.matchArtifact).toBeDefined();
+    expect(expectedArtifact.defaultArtifact).toBeDefined();
+    expect(expectedArtifact.useDefaultArtifact).toBeFalsy();
+  });
+
+  it('does not overwrite existing execution options', () => {
+    const existingExecutionOptions = {
+      successful: true,
+      terminal: true,
+    };
+    initializeController({
+      executionOptions: existingExecutionOptions,
+    });
+
+    const expectedArtifact = ctrl.stage.expectedArtifact;
+    const executionOptions: any = ctrl.stage.executionOptions;
+
+    expect(executionOptions).toBeDefined();
+    expect(executionOptions).toEqual(existingExecutionOptions);
+
+    expect(expectedArtifact).toBeDefined();
+    expect(expectedArtifact.id).toBeDefined();
+    expect(expectedArtifact.displayName).toBeDefined();
+    expect(expectedArtifact.matchArtifact).toBeDefined();
+    expect(expectedArtifact.defaultArtifact).toBeDefined();
+    expect(expectedArtifact.useDefaultArtifact).toBeFalsy();
+  });
+
+  it('adds missing fields to partly-initialized expected artifact', () => {
+    const existingExpectedArtifact = {
+      id: 'e3125b4d-6358-4fe2-a4c4-1379d1fe7d03',
+      matchArtifact: {
+        name: 'gcr.io/test',
+        type: 'docker/image',
+      },
+    };
+    initializeController({
+      expectedArtifact: existingExpectedArtifact,
+    });
+
+    const expectedArtifact: any = ctrl.stage.expectedArtifact;
+
+    expect(expectedArtifact).toBeDefined();
+    expect(expectedArtifact.id).toEqual(existingExpectedArtifact.id);
+    expect(expectedArtifact.displayName).toBeDefined();
+    expect(expectedArtifact.matchArtifact).toEqual(existingExpectedArtifact.matchArtifact);
+    expect(expectedArtifact.defaultArtifact).toBeDefined();
+    expect(expectedArtifact.useDefaultArtifact).toBeFalsy();
+  });
+
+  it('does not overwrite a fully-initialized expected artifact', () => {
+    const existingExpectedArtifact = {
+      id: '645f9710-1f93-4551-a73b-be1447c939bc',
+      displayName: 'my-artifact',
+      matchArtifact: {
+        id: '6b8c2ed5-3460-4d18-b122-8fbe28bc4c2b',
+        name: 'gcr.io/test',
+        type: 'docker/image',
+      },
+      defaultArtifact: {
+        id: 'febf5209-0469-4b46-9d4e-d1e99b4acf05',
+        name: 'gcr.io/other-test',
+        reference: 'gcr.io/other-test',
+        type: 'docker/image',
+      },
+      useDefaultArtifact: true,
+      usePriorArtifact: false,
+    };
+    initializeController({
+      expectedArtifact: existingExpectedArtifact,
+    });
+
+    const expectedArtifact: any = ctrl.stage.expectedArtifact;
+
+    expect(expectedArtifact).toBeDefined();
+    expect(expectedArtifact.id).toEqual(existingExpectedArtifact.id);
+    expect(expectedArtifact.displayName).toEqual(expectedArtifact.displayName);
+    expect(expectedArtifact.matchArtifact).toEqual(existingExpectedArtifact.matchArtifact);
+    expect(expectedArtifact.defaultArtifact).toEqual(existingExpectedArtifact.defaultArtifact);
+    expect(expectedArtifact.useDefaultArtifact).toBeTruthy();
+  });
+});

--- a/app/scripts/modules/core/src/pipeline/config/stages/findArtifactFromExecution/findArtifactFromExecutionConfig.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/findArtifactFromExecution/findArtifactFromExecutionConfig.html
@@ -42,5 +42,5 @@
     </div>
   </div>
   <h4>Match Artifact</h4>
-  <artifact is-match artifact="ctrl.stage.expectedArtifact.matchArtifact"></artifact>
+  <expected-artifact expected-artifact="ctrl.stage.expectedArtifact"></expected-artifact>
 </div>

--- a/app/scripts/modules/core/src/pipeline/config/stages/findArtifactFromExecution/findArtifactFromExecutionStage.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/findArtifactFromExecution/findArtifactFromExecutionStage.ts
@@ -6,6 +6,7 @@ import { SETTINGS } from 'core/config/settings';
 import { ExecutionDetailsTasks } from '../common';
 import { FindArtifactFromExecutionCtrl } from '../findArtifactFromExecution/findArtifactFromExecution.controller';
 import { FindArtifactFromExecutionExecutionDetails } from '../findArtifactFromExecution/FindArtifactFromExecutionExecutionDetails';
+import { ExecutionArtifactTab } from 'core/artifact/react/ExecutionArtifactTab';
 
 export const FIND_ARTIFACT_FROM_EXECUTION_STAGE = 'spinnaker.core.pipeline.stage.findArtifactStage';
 
@@ -19,7 +20,11 @@ module(FIND_ARTIFACT_FROM_EXECUTION_STAGE, [])
         templateUrl: require('./findArtifactFromExecutionConfig.html'),
         controller: 'findArtifactFromExecutionCtrl',
         controllerAs: 'ctrl',
-        executionDetailsSections: [FindArtifactFromExecutionExecutionDetails, ExecutionDetailsTasks],
+        executionDetailsSections: [
+          FindArtifactFromExecutionExecutionDetails,
+          ExecutionDetailsTasks,
+          ExecutionArtifactTab,
+        ],
         validators: [
           { type: 'requiredField', fieldName: 'pipeline', fieldLabel: 'Pipeline' },
           { type: 'requiredField', fieldName: 'application', fieldLabel: 'Application' },

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/expectedArtifact.component.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/expectedArtifact.component.ts
@@ -43,7 +43,7 @@ const expectedArtifactComponent: IComponentOptions = {
           Match against
           <help-field key="pipeline.config.expectedArtifact.matchArtifact"/>
         </div>
-        <div class="col-md-2 col-md-offset-7">
+        <div class="col-md-2 col-md-offset-7" ng-if="ctrl.removeExpectedArtifact">
           <button class="btn btn-sm btn-default" ng-click="ctrl.removeExpectedArtifact(ctrl.context, ctrl.expectedArtifact)">
             <span class="glyphicon glyphicon-trash" uib-tooltip="Remove expected artifact"/>
             <span class="visible-xl-inline">Remove artifact</span>


### PR DESCRIPTION
Fixes spinnaker/spinnaker#4344.  (This will also require a small change to orca a the orca task does not support looking up a default artifact.)

Find artifact from execution doesn't use the full expected artifact component, which means users can't assign a name or use a default artifact. Upgrade it to the full expected artifact component so
it gets these features.

Also fix the field defaulting; currently the fields will reset if you navigate away and back to the stage before saving.

Also add the "Artifact Status" tab to this stage so it's easier to see the artifact that was bound.