### PR TITLE
fix(titus): consider platformHealthOnly flag when setting budget health

### DIFF
--- a/app/scripts/modules/titus/src/serverGroup/configure/serverGroupConfiguration.service.ts
+++ b/app/scripts/modules/titus/src/serverGroup/configure/serverGroupConfiguration.service.ts
@@ -1,10 +1,11 @@
 import { IPromise, module } from 'angular';
-import { chain, flatten, intersection, xor } from 'lodash';
+import { chain, flatten, intersection, xor, cloneDeep } from 'lodash';
 import { $q } from 'ngimport';
 import { Subject } from 'rxjs';
 
 import {
   AccountService,
+  Application,
   IServerGroupCommand,
   IServerGroupCommandViewState,
   IDeploymentStrategy,
@@ -57,6 +58,14 @@ export const defaultJobDisruptionBudget: IJobDisruptionBudget = {
       timeZone: 'PST',
     },
   ],
+};
+
+export const getDefaultJobDisruptionBudgetForApp = (application: Application): IJobDisruptionBudget => {
+  const budget = cloneDeep(defaultJobDisruptionBudget);
+  if (application.attributes && application.attributes.platformHealthOnly) {
+    budget.containerHealthProviders = [];
+  }
+  return budget;
 };
 
 export type Constraint = 'ExclusiveHost' | 'UniqueHost' | 'ZoneBalance';

--- a/app/scripts/modules/titus/src/serverGroup/configure/wizard/TitusCloneServerGroupModal.tsx
+++ b/app/scripts/modules/titus/src/serverGroup/configure/wizard/TitusCloneServerGroupModal.tsx
@@ -19,7 +19,7 @@ import {
 import { ServerGroupCapacity, ServerGroupLoadBalancers, ServerGroupSecurityGroups } from '@spinnaker/amazon';
 import { JobDisruptionBudget } from './pages/disruptionBudget/JobDisruptionBudget';
 
-import { ITitusServerGroupCommand, defaultJobDisruptionBudget } from '../serverGroupConfiguration.service';
+import { ITitusServerGroupCommand, getDefaultJobDisruptionBudgetForApp } from '../serverGroupConfiguration.service';
 import { TitusReactInjector } from '../../../reactShims';
 
 import { ServerGroupBasicSettings, ServerGroupResources, ServerGroupParameters } from './pages';
@@ -143,7 +143,7 @@ export class TitusCloneServerGroupModal extends React.Component<
     if (command.disruptionBudget.timeWindows && !command.disruptionBudget.timeWindows.length) {
       delete command.disruptionBudget.timeWindows;
     }
-    if (isEqual(defaultJobDisruptionBudget, command.disruptionBudget)) {
+    if (isEqual(getDefaultJobDisruptionBudgetForApp(this.props.application), command.disruptionBudget)) {
       toSubmit = { ...command, disruptionBudget: undefined };
     }
     if (forPipelineConfig) {
@@ -266,7 +266,7 @@ export class TitusCloneServerGroupModal extends React.Component<
               label="Job Disruption Budget"
               wizard={wizard}
               order={nextIdx()}
-              render={({ innerRef }) => <JobDisruptionBudget ref={innerRef} formik={formik} />}
+              render={({ innerRef }) => <JobDisruptionBudget ref={innerRef} formik={formik} app={application} />}
             />
 
             <WizardPage

--- a/app/scripts/modules/titus/src/serverGroup/configure/wizard/pages/disruptionBudget/JobDisruptionBudget.tsx
+++ b/app/scripts/modules/titus/src/serverGroup/configure/wizard/pages/disruptionBudget/JobDisruptionBudget.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { FormikProps } from 'formik';
 import { Option } from 'react-select';
-import { cloneDeep, isEqual, get } from 'lodash';
+import { isEqual, get } from 'lodash';
 
 import {
+  Application,
   FormikFormField,
   CheckboxInput,
   HelpField,
@@ -14,7 +15,11 @@ import {
 
 import { WindowPicker } from './WindowPicker';
 
-import { ITitusServerGroupCommand, defaultJobDisruptionBudget } from '../../../serverGroupConfiguration.service';
+import {
+  ITitusServerGroupCommand,
+  defaultJobDisruptionBudget,
+  getDefaultJobDisruptionBudgetForApp,
+} from '../../../serverGroupConfiguration.service';
 
 import { IJobDisruptionBudget } from 'titus/domain';
 
@@ -24,6 +29,7 @@ import { policyOptions } from './PolicyOptions';
 
 export interface IJobDisruptionBudgetProps {
   formik: FormikProps<ITitusServerGroupCommand>;
+  app: Application;
 }
 
 export interface IJobDisruptionBudgetState {
@@ -71,7 +77,7 @@ export class JobDisruptionBudget extends React.Component<IJobDisruptionBudgetPro
     super(props);
     const { disruptionBudget } = props.formik.values;
     this.state = {
-      usingDefault: !disruptionBudget || isEqual(disruptionBudget, defaultJobDisruptionBudget),
+      usingDefault: !disruptionBudget || isEqual(disruptionBudget, getDefaultJobDisruptionBudgetForApp(props.app)),
     };
     if (this.state.usingDefault) {
       this.setToDefaultBudget();
@@ -79,7 +85,7 @@ export class JobDisruptionBudget extends React.Component<IJobDisruptionBudgetPro
   }
 
   private setToDefaultBudget(): void {
-    this.props.formik.setFieldValue('disruptionBudget', cloneDeep(defaultJobDisruptionBudget));
+    this.props.formik.setFieldValue('disruptionBudget', getDefaultJobDisruptionBudgetForApp(this.props.app));
   }
 
   private toggleUseDefault = (): void => {
@@ -132,7 +138,7 @@ export class JobDisruptionBudget extends React.Component<IJobDisruptionBudgetPro
 
   public render() {
     const { usingDefault } = this.state;
-    const budget = this.props.formik.values.disruptionBudget || defaultJobDisruptionBudget;
+    const budget = this.props.formik.values.disruptionBudget || getDefaultJobDisruptionBudgetForApp(this.props.app);
 
     const policyType = this.getSelectionFromFields(policyOptions);
     const PolicyFields = policyType.fieldComponent;

--- a/app/scripts/modules/titus/src/serverGroup/details/disruptionBudget/DisruptionBudgetSection.tsx
+++ b/app/scripts/modules/titus/src/serverGroup/details/disruptionBudget/DisruptionBudgetSection.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { isEqual, cloneDeep } from 'lodash';
+import { isEqual } from 'lodash';
 const angular = require('angular');
 import { react2angular } from 'react2angular';
 import * as prettyMilliseconds from 'pretty-ms';
@@ -7,7 +7,10 @@ import * as prettyMilliseconds from 'pretty-ms';
 import { IServerGroupDetailsSectionProps, HelpField } from '@spinnaker/core';
 import { TitusReactInjector } from 'titus/reactShims';
 
-import { defaultJobDisruptionBudget, ITitusServerGroupCommand } from '../../configure/serverGroupConfiguration.service';
+import {
+  getDefaultJobDisruptionBudgetForApp,
+  ITitusServerGroupCommand,
+} from '../../configure/serverGroupConfiguration.service';
 import { policyOptions } from '../../configure/wizard/pages/disruptionBudget/PolicyOptions';
 import { rateOptions } from '../../configure/wizard/pages/disruptionBudget/RateOptions';
 import {
@@ -188,8 +191,9 @@ export class DisruptionBudgetSection extends React.Component<IServerGroupDetails
     const serverGroup: ITitusServerGroup = this.props.serverGroup;
     const hasDefaultMigrationPolicy =
       !serverGroup.migrationPolicy || serverGroup.migrationPolicy.type === 'SystemDefault';
-    const budget = serverGroup.disruptionBudget || cloneDeep(defaultJobDisruptionBudget);
-    const usingDefault = !hasDefaultMigrationPolicy && isEqual(budget, defaultJobDisruptionBudget);
+    const defaultBudget = getDefaultJobDisruptionBudgetForApp(this.props.app);
+    const budget = serverGroup.disruptionBudget || defaultBudget;
+    const usingDefault = !hasDefaultMigrationPolicy && isEqual(budget, defaultBudget);
     return (
       <>
         <DisruptionBudgetDescription />

--- a/app/scripts/modules/titus/src/serverGroup/details/disruptionBudget/EditDisruptionBudgetModal.tsx
+++ b/app/scripts/modules/titus/src/serverGroup/details/disruptionBudget/EditDisruptionBudgetModal.tsx
@@ -73,7 +73,7 @@ export class EditDisruptionBudgetModal extends React.Component<IEditDisruptionBu
               </Modal.Header>
               <ModalClose dismiss={dismissModal} />
               <Modal.Body>
-                <JobDisruptionBudget formik={formik} />
+                <JobDisruptionBudget formik={formik} app={application} />
               </Modal.Body>
               <Modal.Footer>
                 <button className="btn btn-default" onClick={dismissModal} type="button">


### PR DESCRIPTION
We need to conditionally set the `containerHealthProviders` based on the `platformHealthOnly` flag on the application attributes.