### PR TITLE
Bump package core to 0.0.362 and titus to 0.0.96

### DIFF
--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/core",
-  "version": "0.0.361",
+  "version": "0.0.362",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/titus/package.json
+++ b/app/scripts/modules/titus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/titus",
-  "version": "0.0.95",
+  "version": "0.0.96",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
### chore(core): Bump version to 0.0.362

6d151c042e125e0de9f87da8eb5f373e9e3eed89 feat(stages): Support SpEL autocompletion for Evaluate Variables stage editor (#6958)
b74c8555f625c68ea0be7194d2c404db18f3264f fix(core/presentation): Handle non-string inputs to Markdown component using .toString() (#6960)
c931524e74b424282651f972f0e8841c17a316d4 fix(core/executions): make text on truncated params selectable (#6959)
3d7c79475835252ca456f515458f46b9fa7228ba fix(artifacts): Allow defaulting in execution artifact (#6961)
60ced4ad2f84cff5536631c196d88ce4e03b2639 feat(stages): Add Concourse stage (#6957)

### chore(titus): Bump version to 0.0.96

cdd46e00b217e2010aba1dbec9d956ed64cd9227 fix(titus): consider platformHealthOnly flag when setting budget health (#6963)