### PR TITLE
feat(core): Enable manual execution of mptv2 pipelines

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/templates/v2/pipelineTemplateV2.service.ts
+++ b/app/scripts/modules/core/src/pipeline/config/templates/v2/pipelineTemplateV2.service.ts
@@ -3,6 +3,7 @@ import { hri as HumanReadableIds } from 'human-readable-ids';
 import { IPipeline, IPipelineTemplateConfigV2, IPipelineTemplateV2 } from 'core/domain';
 import { PipelineJSONService } from 'core/pipeline/config/services/pipelineJSON.service';
 import { UUIDGenerator } from 'core/utils';
+import { SETTINGS } from 'core/config';
 
 export class PipelineTemplateV2Service {
   public static createPipelineTemplate(pipeline: IPipeline, owner: string): IPipelineTemplateV2 {
@@ -52,6 +53,10 @@ export class PipelineTemplateV2Service {
   private static prefixSource(source = ''): string {
     const referencePrefix = 'spinnaker://';
     return source.startsWith(referencePrefix) ? source : `${referencePrefix}${source}`;
+  }
+
+  public static isConfigurable(pipelineConfig: IPipeline): boolean {
+    return SETTINGS.feature.managedPipelineTemplatesV2UI || !this.isV2PipelineConfig(pipelineConfig);
   }
 
   private static schema = 'v2';

--- a/app/scripts/modules/core/src/pipeline/executions/executionGroup/ExecutionGroup.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/executionGroup/ExecutionGroup.tsx
@@ -19,7 +19,6 @@ import { TriggersTag } from 'core/pipeline/triggers/TriggersTag';
 import { AccountTag } from 'core/account';
 import { ModalInjector, ReactInjector } from 'core/reactShims';
 import { PipelineTemplateV2Service } from 'core/pipeline';
-import { SETTINGS } from 'core/config';
 import { Spinner } from 'core/widgets/spinners/Spinner';
 
 import './executionGroup.less';
@@ -206,8 +205,7 @@ export class ExecutionGroup extends React.Component<IExecutionGroupProps, IExecu
     const pipelineDisabled = pipelineConfig && pipelineConfig.disabled;
     const pipelineDescription = pipelineConfig && pipelineConfig.description;
     const hasRunningExecutions = group.runningExecutions && group.runningExecutions.length > 0;
-    const hasMPTv2PipelineConfig = !!(pipelineConfig && PipelineTemplateV2Service.isV2PipelineConfig(pipelineConfig));
-    const mptv2Flag = SETTINGS.feature.managedPipelineTemplatesV2UI;
+    const isConfigurable = !pipelineConfig || PipelineTemplateV2Service.isConfigurable(pipelineConfig);
 
     const deploymentAccountLabels = without(this.state.deploymentAccounts || [], ...(group.targetAccounts || [])).map(
       (account: string) => <AccountTag key={account} account={account} />,
@@ -244,7 +242,7 @@ export class ExecutionGroup extends React.Component<IExecutionGroupProps, IExecu
         execution={execution}
         pipelineConfig={pipelineConfig}
         application={this.props.application}
-        onRerun={pipelineConfig && !hasMPTv2PipelineConfig ? this.rerunExecutionClicked : undefined}
+        onRerun={pipelineConfig && isConfigurable ? this.rerunExecutionClicked : undefined}
       />
     ));
 
@@ -297,23 +295,19 @@ export class ExecutionGroup extends React.Component<IExecutionGroupProps, IExecu
                     {pipelineConfig && <NextRunTag pipeline={pipelineConfig} />}
                     <ExecutionAction
                       handleClick={this.handleConfigureClicked}
-                      disabled={hasMPTv2PipelineConfig && !mptv2Flag}
-                      tooltipText={
-                        hasMPTv2PipelineConfig && !mptv2Flag
-                          ? PipelineTemplateV2Service.getUnsupportedCopy('Configuration')
-                          : ''
-                      }
+                      disabled={!isConfigurable}
+                      tooltipText={!isConfigurable ? PipelineTemplateV2Service.getUnsupportedCopy('Configuration') : ''}
                     >
                       <span className="glyphicon glyphicon-cog" />
                       {' Configure'}
                     </ExecutionAction>
                     {pipelineConfig && (
                       <ExecutionAction
-                        disabled={hasMPTv2PipelineConfig}
+                        disabled={!isConfigurable}
                         handleClick={this.handleTriggerClicked}
                         style={{ visibility: pipelineDisabled ? 'hidden' : 'visible' }}
                         tooltipText={
-                          hasMPTv2PipelineConfig ? PipelineTemplateV2Service.getUnsupportedCopy('Manual Execution') : ''
+                          !isConfigurable ? PipelineTemplateV2Service.getUnsupportedCopy('Manual Execution') : ''
                         }
                       >
                         {triggeringExecution ? (

--- a/app/scripts/modules/core/src/pipeline/manualExecution/manualPipelineExecution.controller.js
+++ b/app/scripts/modules/core/src/pipeline/manualExecution/manualPipelineExecution.controller.js
@@ -303,7 +303,7 @@ module.exports = angular
 
       if (!pipeline) {
         this.pipelineOptions = application.pipelineConfigs.data.filter(
-          c => !c.disabled && !PipelineTemplateV2Service.isV2PipelineConfig(c),
+          c => !c.disabled && PipelineTemplateV2Service.isConfigurable(c),
         );
       }
     },


### PR DESCRIPTION
This enables manual execution for templated v2 pipelines. This was fixed when configuration was addressed in this commit, https://github.com/spinnaker/deck/commit/90fb96c4bfbbb07b23c8c3072229e58aa6f68868#diff-a04c4d36f5303c52f54f0283a5e17c51 , while this PR enables interacting with UI elements for starting manual executions.

https://github.com/spinnaker/spinnaker/issues/4390

![image](https://user-images.githubusercontent.com/2623242/57532226-3e61af80-7309-11e9-8143-e3643ddeca95.png)


