### PR TITLE
fix(executions): URI Encode pipeline names

### DIFF
--- a/app/scripts/modules/core/src/pipeline/service/execution.service.ts
+++ b/app/scripts/modules/core/src/pipeline/service/execution.service.ts
@@ -108,7 +108,7 @@ export class ExecutionService {
         execution.hydrated = true;
         this.cleanExecutionForDiffing(execution);
         if (application && name) {
-          return API.one('applications', application, 'pipelineConfigs', name)
+          return API.one('applications', application, 'pipelineConfigs', encodeURIComponent(name))
             .get()
             .then((pipelineConfig: IPipeline) => {
               execution.pipelineConfig = pipelineConfig;


### PR DESCRIPTION
Some people (I won't mention who), don't like bracket so we need to encode them or Gate will blow up.