### PR TITLE
fix(core): Add expected artifacts to inheritable mptv2 collections

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/templates/v2/configurePipelineTemplateModalV2.controller.ts
+++ b/app/scripts/modules/core/src/pipeline/config/templates/v2/configurePipelineTemplateModalV2.controller.ts
@@ -30,6 +30,7 @@ export interface IState {
   inheritTemplateParameters: boolean;
   inheritTemplateTriggers: boolean;
   inheritTemplateNotifications: boolean;
+  inheritTemplateExpectedArtifacts: boolean;
 }
 // Logic lifted from ConfigurePipelineTemplateModalController and slightly refactored to support MPTV2.
 // TODO: Once MPTV1 is fully migrated, delete ConfigurePipelineTemplateModalController.
@@ -46,6 +47,7 @@ export class ConfigurePipelineTemplateModalV2Controller implements IController {
     inheritTemplateParameters: true,
     inheritTemplateTriggers: true,
     inheritTemplateNotifications: true,
+    inheritTemplateExpectedArtifacts: true,
   };
   private template: IPipelineTemplate;
   private source: string;
@@ -80,6 +82,7 @@ export class ConfigurePipelineTemplateModalV2Controller implements IController {
     this.state.inheritTemplateNotifications = !excluded.includes('notifications');
     this.state.inheritTemplateParameters = !excluded.includes('parameters');
     this.state.inheritTemplateTriggers = !excluded.includes('triggers');
+    this.state.inheritTemplateExpectedArtifacts = !excluded.includes('expectedArtifacts');
 
     this.pipelineName = name;
     this.source = template.reference;
@@ -111,14 +114,20 @@ export class ConfigurePipelineTemplateModalV2Controller implements IController {
 
     return PipelineTemplateReader.getPipelinePlan(config)
       .then(plan => {
-        const { parameterConfig, notifications, triggers } = plan;
-        const { inheritTemplateParameters, inheritTemplateNotifications, inheritTemplateTriggers } = this.state;
+        const { parameterConfig, notifications, triggers, expectedArtifacts } = plan;
+        const {
+          inheritTemplateParameters,
+          inheritTemplateNotifications,
+          inheritTemplateTriggers,
+          inheritTemplateExpectedArtifacts,
+        } = this.state;
 
         const configWithInheritedValues = {
           ...config,
           ...(inheritTemplateParameters && parameterConfig ? { parameterConfig } : {}),
           ...(inheritTemplateNotifications && notifications ? { notifications } : {}),
           ...(inheritTemplateTriggers && triggers ? { triggers } : {}),
+          ...(inheritTemplateExpectedArtifacts && expectedArtifacts ? { expectedArtifacts } : {}),
         };
 
         this.$uibModalInstance.close({ plan, config: configWithInheritedValues });
@@ -135,7 +144,12 @@ export class ConfigurePipelineTemplateModalV2Controller implements IController {
   public buildConfig(): IPipelineTemplateConfigV2 {
     const {
       application: { name: appName },
-      state: { inheritTemplateNotifications, inheritTemplateParameters, inheritTemplateTriggers },
+      state: {
+        inheritTemplateNotifications,
+        inheritTemplateParameters,
+        inheritTemplateTriggers,
+        inheritTemplateExpectedArtifacts,
+      },
       pipelineName,
       pipelineTemplateConfig,
       source,
@@ -145,10 +159,12 @@ export class ConfigurePipelineTemplateModalV2Controller implements IController {
       ...(inheritTemplateParameters ? [] : ['parameters']),
       ...(inheritTemplateNotifications ? [] : ['notifications']),
       ...(inheritTemplateTriggers ? [] : ['triggers']),
+      ...(inheritTemplateExpectedArtifacts ? [] : ['expectedArtifacts']),
     ];
 
     return {
       ...(pipelineTemplateConfig || {}),
+      type: 'templatedPipeline',
       name: pipelineName,
       application: appName,
       variables: this.transformVariablesForPipelinePlan(),

--- a/app/scripts/modules/core/src/pipeline/config/templates/v2/configurePipelineTemplateModalV2.html
+++ b/app/scripts/modules/core/src/pipeline/config/templates/v2/configurePipelineTemplateModalV2.html
@@ -34,6 +34,7 @@
   </div>
   <div ng-if="!ctrl.state.error" class="alert alert-info">
     <strong>Inherit the following configuration from the template</strong>
+    <p><input type="checkbox" ng-model="ctrl.state.inheritTemplateExpectedArtifacts" /> Expected Artifacts</p>
     <p><input type="checkbox" ng-model="ctrl.state.inheritTemplateNotifications" /> Notifications</p>
     <p><input type="checkbox" ng-model="ctrl.state.inheritTemplateParameters" /> Parameters</p>
     <p><input type="checkbox" ng-model="ctrl.state.inheritTemplateTriggers" /> Triggers</p>


### PR DESCRIPTION
This is a small fix to add Expected Artifacts to the list of items that can be selectively inherited from a template.

![image](https://user-images.githubusercontent.com/2623242/57620099-c3d99f80-7555-11e9-8d0e-87cf63ba8599.png)
