### PR TITLE
feat(runjob): capture output ui

### DIFF
--- a/app/scripts/modules/kubernetes/src/help/kubernetes.help.ts
+++ b/app/scripts/modules/kubernetes/src/help/kubernetes.help.ts
@@ -225,6 +225,9 @@ const helpContents: { [key: string]: string } = {
     <p><b>json</b>: <a href="https://tools.ietf.org/html/rfc6902" target="_blank">JSON Patch, RFC 6902</a></p>
     <p><b>merge</b>: <a href="https://tools.ietf.org/html/rfc7386" target="_blank">JSON Merge Patch, RFC 7386</a></p>
   `,
+  'kubernetes.runJob.captureSource':
+    'Source from which to capture Job output. Captured output will be available in the pipeline context for use in downstream stages.',
+  'kubernetes.runJob.captureSource.containerName': `Use logs from this container to capture output data.`,
 };
 
 Object.keys(helpContents).forEach(key => HelpContentsRegistry.register(key, helpContents[key]));


### PR DESCRIPTION
UI for v2 run job capture output. there are 2 options - logs and
artifact. setting to `logs` will set the `propertyFile` option to
trigger the runJob stage to read from the container logs. setting to
artifact will trigger the `ConsumeArtifactTask` to fetch and inject the
defined artifact.

## Output selection (logs)
![image](https://user-images.githubusercontent.com/3324110/57638490-e088ce00-757b-11e9-9a66-1cf0fa08afe1.png)


## Output selection (artifact)
![image](https://user-images.githubusercontent.com/3324110/57638543-fa2a1580-757b-11e9-8d37-220ec06102b5.png)

## Output selection (none)
![image](https://user-images.githubusercontent.com/3324110/57638592-1928a780-757c-11e9-9819-1e29b939a102.png)
