### PR TITLE
fix(core): show no results message on v2 search

### DIFF
--- a/app/scripts/modules/core/src/search/infrastructure/SearchV2.tsx
+++ b/app/scripts/modules/core/src/search/infrastructure/SearchV2.tsx
@@ -109,7 +109,7 @@ export class SearchV2 extends React.Component<{}, ISearchV2State> {
           if (!this.state.selectedTab) {
             this.selectTab(resultSets);
           }
-          this.setState({ resultSets });
+          this.setState({ resultSets, isSearching: !finishedSearching });
         },
         null,
         () => this.setState({ isSearching: false }),

--- a/app/scripts/modules/core/src/search/searchResult/SearchResults.tsx
+++ b/app/scripts/modules/core/src/search/searchResult/SearchResults.tsx
@@ -25,6 +25,12 @@ export interface ISearchResultsState {
   active: SearchResultType;
 }
 
+const NoResults = () => (
+  <div className="flex-grow vertical center middle">
+    <h3>No results found for the specified search query</h3>
+  </div>
+);
+
 export class SearchResults extends React.Component<ISearchResultsProps, ISearchResultsState> {
   public state = { active: null as any };
 
@@ -38,12 +44,14 @@ export class SearchResults extends React.Component<ISearchResultsProps, ISearchR
     const { resultSets, isSearching } = this.props;
     const { active } = this.state;
     const activeResultSet = active && resultSets.find(resultSet => resultSet.type === active);
+    const noResults = resultSets.every(r => r.status === SearchStatus.FINISHED && r.results.length === 0);
 
     return (
       <div className="search-results">
         <SearchResultTabs resultSets={resultSets} activeSearchResultType={active} />
         {activeResultSet && <SearchResultGrid resultSet={activeResultSet} />}
         {!activeResultSet && isSearching && <Searching />}
+        {noResults && !active && <NoResults />}
       </div>
     );
   }


### PR DESCRIPTION
1. We rarely set `isSearching`, but we should.
2. If the user does not click on one of the side tabs, and there are no matches for a search, they get stuck in the "fetching search results" screen forever.