### PR TITLE
Bump package core to 0.0.363 and amazon to 0.0.189

### DIFF
--- a/app/scripts/modules/amazon/package.json
+++ b/app/scripts/modules/amazon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/amazon",
-  "version": "0.0.188",
+  "version": "0.0.189",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/core",
-  "version": "0.0.362",
+  "version": "0.0.363",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
### chore(core): Bump version to 0.0.363

8edcc221c45f4d3533ffe2056323688a4ae31e32 fix(core): show no results message on v2 search (#6982)
1bbd93664306eaea595a746ae664c64944559ed4 feat(core): allow dynamic resolution of docker insights URL (#6981)
84db0ef6c88ba6b234a4f06d7f2af91b2d84ee41 fix(cf): reorg build info details on server group detail and summary (#6983)
c48a0179a179524fe02cdda76fb0eedb3d25bfaa fix(core): Add expected artifacts to inheritable mptv2 collections (#6975)
a21e95e8da9f7d3ed8a83da708e353dee71cd8ef refactor(core): Reactified parameters for triggers (#6923)
e439d2c6bb703f6f5a6483be86fbaa4163445c64 feat(gcb): allow pre-artifacts-rewrite expected artifacts to be selected in gcb stage (#6948)
fc50576eb0ff54ed1dd0a1c8efbac08c074e42cc fix(executions): URI Encode pipeline names (#6971)
7007830742d30ee7ebc182321ce79d13a20ee8ff fix(server group): show a CI build link in server group.buildinfo (#6967)
a79edb09480e1b3665879802c2f0590418810598 feat(core): Enable manual execution of mptv2 pipelines (#6968)

### chore(amazon): Bump version to 0.0.189

b576fed4abd05f2cb60fc6bfbf410232679a5b8d refactor(amazon): de-angularize load balancer transformer (#6984)
1fcdf7c5451031c609865bbbf1a3e814802db00b fix(aws): add NLB info to target group help text (#6977)
52d89d6fb55af9402dbf23258837576e25435599 feat(cloudformation): support cfn tags (#6928)