### PR TITLE
chore(core): Bump version to 0.0.364

### DIFF
--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/core",
-  "version": "0.0.363",
+  "version": "0.0.364",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
### chore(core): Bump version to 0.0.364

f44e2e8f93c3a509765633c4ab1e79694d7c2177 fix(titus): Shimming the execution logs for preconfigured jobs (#6972)