### PR TITLE
fix(amazon): explicitly import d3 for scaling policy graphs

### DIFF
--- a/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/chart/metricAlarmChart.component.js
+++ b/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/chart/metricAlarmChart.component.js
@@ -3,6 +3,8 @@
 const angular = require('angular');
 import _ from 'lodash';
 import { Subject } from 'rxjs';
+// we need to explicitly import d3 because n3-charts depends on it being in the global namespace
+import 'd3';
 
 import { CloudMetricsReader } from '@spinnaker/core';
 


### PR DESCRIPTION
I mean...I guess it was being imported by something else at some point?