### PR TITLE
chore(amazon): Bump version to 0.0.190

### DIFF
--- a/app/scripts/modules/amazon/package.json
+++ b/app/scripts/modules/amazon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/amazon",
-  "version": "0.0.189",
+  "version": "0.0.190",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
### chore(amazon): Bump version to 0.0.190

e06039b98d9e4ae96b2c8849daae17c077b16237 fix(amazon): explicitly import d3 for scaling policy graphs (#6989)
