### PR TITLE
fix(core): filter empty URL parts in ApiService, do not next schedule…

### DIFF
--- a/app/scripts/modules/core/src/api/ApiService.ts
+++ b/app/scripts/modules/core/src/api/ApiService.ts
@@ -3,6 +3,7 @@ import { $q, $http } from 'ngimport';
 import { AuthenticationInitializer } from '../authentication/AuthenticationInitializer';
 import { SETTINGS } from 'core/config/settings';
 import { ICache } from 'core/cache';
+import { isNil } from 'lodash';
 
 export interface IRequestBuilder {
   config?: IRequestConfig;
@@ -166,7 +167,9 @@ export class API {
       method: '',
       url: this.baseUrl,
     };
-    urls.forEach((url: string) => (config.url = `${config.url}/${url.toString().replace(/^\/+/, '')}`));
+    urls
+      .filter(i => !isNil(i))
+      .forEach((url: string) => (config.url = `${config.url}/${url.toString().replace(/^\/+/, '')}`));
 
     return this.baseReturn(config);
   }

--- a/app/scripts/modules/core/src/scheduler/SchedulerFactory.ts
+++ b/app/scripts/modules/core/src/scheduler/SchedulerFactory.ts
@@ -82,7 +82,6 @@ export class SchedulerFactory {
       unsubscribe: () => {
         suspended = true;
         if (scheduler) {
-          scheduler.next(false);
           scheduler.unsubscribe();
         }
         scheduler = null;


### PR DESCRIPTION
…r on unsubscribe

Two classes of bugs we've been seeing a lot lately, sort of related sometimes:
1. trying to call `toString` on a null or undefined object is not great
2. calling `next` on the scheduler when unsubscribing is almost certainly(?!) not the right behavior