### PR TITLE
Bump package core to 0.0.366 and titus to 0.0.97

### DIFF
--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/core",
-  "version": "0.0.365",
+  "version": "0.0.366",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/titus/package.json
+++ b/app/scripts/modules/titus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/titus",
-  "version": "0.0.96",
+  "version": "0.0.97",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
### chore(core): Bump version to 0.0.366

4c06d10d70bc53008aaeeee1ae7441c36bfcf485 feat(titus): Render run job output file as YAML (#6992)
b888ff581c718da3dda9d3274b20c706184f5aff fix(core): filter empty URL parts in ApiService, do not next scheduler on unsubscribe (#7000)

### chore(titus): Bump version to 0.0.97

4c06d10d70bc53008aaeeee1ae7441c36bfcf485 feat(titus): Render run job output file as YAML (#6992)