### PR TITLE
fix(core): do not validate pipeline configs before initialization

### DIFF
--- a/app/scripts/modules/core/src/projects/configure/Applications.tsx
+++ b/app/scripts/modules/core/src/projects/configure/Applications.tsx
@@ -9,7 +9,6 @@ import { FormikApplicationsPicker } from 'core/projects/configure/FormikApplicat
 export interface IApplicationsProps {
   formik: FormikProps<IProject>;
   allApplications: string[];
-  onApplicationsChanged: (applications: string[]) => void;
 }
 
 export class Applications extends React.Component<IApplicationsProps> implements IWizardPageComponent<IProject> {
@@ -30,17 +29,11 @@ export class Applications extends React.Component<IApplicationsProps> implements
     } as any;
   }
 
-  public componentDidMount() {
-    const apps = getIn(this.props.formik.values, 'config.applications', []);
-    this.props.onApplicationsChanged && this.props.onApplicationsChanged(apps);
-  }
-
   public componentDidUpdate(prevProps: IApplicationsProps) {
     const prevApps = getIn(prevProps.formik.values, 'config.applications', []);
     const nextApps = getIn(this.props.formik.values, 'config.applications', []);
 
     if (!isEqual(prevApps, nextApps)) {
-      this.props.onApplicationsChanged && this.props.onApplicationsChanged(nextApps);
       // Remove any pipelines associated with the applications removed.
       const existingPipelineConfigs: IProjectPipeline[] = getIn(this.props.formik.values, 'config.pipelineConfigs', []);
       const newPipelineConfigs = existingPipelineConfigs.filter(({ application }) => nextApps.includes(application));

--- a/app/scripts/modules/core/src/projects/configure/ConfigureProjectModal.tsx
+++ b/app/scripts/modules/core/src/projects/configure/ConfigureProjectModal.tsx
@@ -27,7 +27,6 @@ export interface IConfigureProjectModalState {
   allAccounts: IAccount[];
   allProjects: IProject[];
   allApplications: IApplicationSummary[];
-  configuredApps: string[];
   loading: boolean;
   taskMonitor?: TaskMonitor;
 }
@@ -43,7 +42,6 @@ export class ConfigureProjectModal extends React.Component<IConfigureProjectModa
     allAccounts: [],
     allProjects: [],
     allApplications: [],
-    configuredApps: [],
   };
 
   public static show(props?: IConfigureProjectModalProps): Promise<any> {
@@ -67,14 +65,8 @@ export class ConfigureProjectModal extends React.Component<IConfigureProjectModa
     return ReactModal.show(ConfigureProjectModal, projectProps, modalProps);
   }
 
-  private handleApplicationsChanged = (configuredApps: string[]) => {
-    this.setState({ configuredApps });
-  };
-
   public componentDidMount() {
-    const { projectConfiguration } = this.props;
-    const configuredApps = (projectConfiguration && projectConfiguration.config.applications) || [];
-    Promise.all([this.initialFetch()]).then(() => this.setState({ loading: false, configuredApps }));
+    this.initialFetch().then(() => this.setState({ loading: false }));
   }
 
   private submit = (project: IProject) => {
@@ -146,14 +138,7 @@ export class ConfigureProjectModal extends React.Component<IConfigureProjectModa
               label="Applications"
               wizard={wizard}
               order={nextIdx()}
-              render={({ innerRef }) => (
-                <Applications
-                  ref={innerRef}
-                  formik={formik}
-                  allApplications={appNames}
-                  onApplicationsChanged={this.handleApplicationsChanged}
-                />
-              )}
+              render={({ innerRef }) => <Applications ref={innerRef} formik={formik} allApplications={appNames} />}
             />
 
             <WizardPage


### PR DESCRIPTION
The `validate` method gets called immediately, so all the pipeline configs on an existing project (when editing) appear with a red outline.

Minor refactor to prevent validation until the pipeline configs are all initialized.

I'm sure there's an RxJS way to do this, too.