### PR TITLE
chore(core): Bump version to 0.0.367

### DIFF
--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/core",
-  "version": "0.0.366",
+  "version": "0.0.367",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
### chore(core): Bump version to 0.0.367

cfb2a51e906c1b2cf50280413fab4db06ba8ef05 fix(core): do not validate pipeline configs before initialization (#7003)


