### PR TITLE
fix(core): provide formatLabel option for all trigger types

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/triggers/concourse/ConcourseTriggerTemplate.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/concourse/ConcourseTriggerTemplate.tsx
@@ -17,6 +17,8 @@ export class ConcourseTriggerTemplate extends React.Component<ITriggerTemplateCo
     );
   };
 
+  public static formatLabel = BaseBuildTriggerTemplate.formatLabel;
+
   public render() {
     return (
       <BaseBuildTriggerTemplate

--- a/app/scripts/modules/core/src/pipeline/config/triggers/jenkins/JenkinsTriggerTemplate.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/jenkins/JenkinsTriggerTemplate.tsx
@@ -5,6 +5,8 @@ import { BuildServiceType } from 'core/ci';
 import { ITriggerTemplateComponentProps } from 'core/pipeline/manualExecution/TriggerTemplate';
 
 export class JenkinsTriggerTemplate extends React.Component<ITriggerTemplateComponentProps> {
+  public static formatLabel = BaseBuildTriggerTemplate.formatLabel;
+
   public render() {
     return <BaseBuildTriggerTemplate {...this.props} buildTriggerType={BuildServiceType.Jenkins} />;
   }

--- a/app/scripts/modules/core/src/pipeline/config/triggers/pipeline/PipelineTrigger.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/pipeline/PipelineTrigger.tsx
@@ -115,7 +115,7 @@ export class PipelineTrigger extends React.Component<IPipelineTriggerConfigProps
                 <Select
                   className="form-control input-sm"
                   onChange={(option: Option<string>) => this.onUpdateTrigger({ pipeline: option.value })}
-                  options={pipelines.map(p => ({ label: p.id, value: p.id }))}
+                  options={pipelines.map(p => ({ label: p.name, value: p.id }))}
                   placeholder={'Select a pipeline...'}
                   value={pipeline}
                 />

--- a/app/scripts/modules/core/src/pipeline/config/triggers/travis/TravisTriggerTemplate.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/travis/TravisTriggerTemplate.tsx
@@ -5,6 +5,8 @@ import { BuildServiceType } from 'core/ci';
 import { ITriggerTemplateComponentProps } from 'core/pipeline/manualExecution/TriggerTemplate';
 
 export class TravisTriggerTemplate extends React.Component<ITriggerTemplateComponentProps> {
+  public static formatLabel = BaseBuildTriggerTemplate.formatLabel;
+
   public render() {
     return <BaseBuildTriggerTemplate {...this.props} buildTriggerType={BuildServiceType.Travis} />;
   }

--- a/app/scripts/modules/core/src/pipeline/config/triggers/wercker/WerckerTriggerTemplate.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/wercker/WerckerTriggerTemplate.tsx
@@ -5,6 +5,8 @@ import { BuildServiceType } from 'core/ci';
 import { ITriggerTemplateComponentProps } from 'core/pipeline/manualExecution/TriggerTemplate';
 
 export class WerckerTriggerTemplate extends React.Component<ITriggerTemplateComponentProps> {
+  public static formatLabel = BaseBuildTriggerTemplate.formatLabel;
+
   public render() {
     return <BaseBuildTriggerTemplate {...this.props} buildTriggerType={BuildServiceType.Wercker} />;
   }


### PR DESCRIPTION
This was kind of lost in the refactor to favor composition over inheritance.

It's worth considering a refactor of this functionality when we convert the manualPipelineExecution modal itself to React; this is a tactical fix to allow existing code to continue functioning.

Also fixing the label on the pipeline stage.