### PR TITLE
chore(core): bump package to 0.0.368

### DIFF
--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/core",
-  "version": "0.0.367",
+  "version": "0.0.368",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
### chore(core): Bump version to 0.0.368

7639f803ab3d197d861aa4ac2c03062ea2b1f494 fix(core): provide formatLabel option for all trigger types (#7007)