### PR TITLE
fix(core): do not automatically inject parameterConfig on pipelines

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/parameters/Parameters.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/parameters/Parameters.tsx
@@ -76,7 +76,7 @@ export class Parameters extends React.Component<IParametersProps, IParametersSta
           togglePins={this.togglePins}
           removeParameter={this.removeParameter}
           updateParameter={this.updateParameter}
-          isMultiple={parameters.length > 1}
+          isMultiple={parameters && parameters.length > 1}
           onSortEnd={this.handleSortEnd}
           lockAxis={'y'}
           useDragHandle={true}

--- a/app/scripts/modules/core/src/pipeline/config/triggers/triggers.directive.js
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/triggers.directive.js
@@ -75,9 +75,6 @@ module.exports = angular
 
       this.checkFeatureFlag = flag => !!SETTINGS.feature[flag];
 
-      //Call back function for full controlled react component
-      $scope.pipeline.parameterConfig = $scope.pipeline.parameterConfig || [];
-
       $scope.addParameter = () => {
         if (!$scope.pipeline.parameterConfig) {
           $scope.pipeline.parameterConfig = [];


### PR DESCRIPTION
Pipelines created before https://github.com/spinnaker/deck/pull/6923 was deployed will not have `parameterConfig` unless the user has added parameters.

We don't really need to add the empty `parameterConfig` array to the pipeline. Doing so changes the JSON, which makes the pipeline dirty, which shows a revert button, which throws an error when clicked.

There's already a guard in place on the `addParameter` which will initialize the field. That's all we really need AFAICT.