### PR TITLE
feat(runjob): capture output ui

### DIFF
--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/ManifestDeploymentOptions.tsx
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/ManifestDeploymentOptions.tsx
@@ -9,6 +9,7 @@ import { IAccountDetails, IDeploymentStrategy, StageConfigField } from '@spinnak
 
 import { ManifestKindSearchService } from 'kubernetes/v2/manifest/ManifestKindSearch';
 import { rolloutStrategies } from 'kubernetes/v2/rolloutStrategy';
+import { NamespaceSelector } from './NamespaceSelector';
 
 export interface ITrafficManagementConfig {
   enabled: boolean;
@@ -68,13 +69,6 @@ export class ManifestDeploymentOptions extends React.Component<
     });
   };
 
-  private getNamespaceOptions = (): Array<Option<string>> => {
-    const { accounts, selectedAccount } = this.props;
-    const selectedAccountDetails = find(accounts, a => a.name === selectedAccount);
-    const namespaces = get(selectedAccountDetails, 'namespaces', []);
-    return map(namespaces, n => ({ label: n, value: n }));
-  };
-
   private strategyOptionRenderer = (option: IDeploymentStrategy) => {
     return (
       <div className="body-regular">
@@ -128,11 +122,11 @@ export class ManifestDeploymentOptions extends React.Component<
         {config.enabled && (
           <>
             <StageConfigField fieldColumns={8} label="Service(s) Namespace">
-              <Select
-                clearable={false}
-                onChange={(option: Option<string>) => this.onConfigChange('options.namespace', option.value)}
-                options={this.getNamespaceOptions()}
-                value={config.options.namespace}
+              <NamespaceSelector
+                onChange={(namespace: string): void => this.onConfigChange('options.namespace', namespace)}
+                accounts={this.props.accounts}
+                selectedAccount={this.props.selectedAccount}
+                selectedNamespace={config.options.namespace}
               />
             </StageConfigField>
             <StageConfigField fieldColumns={8} label="Service(s)">

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/NamespaceSelector.tsx
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/NamespaceSelector.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import Select, { Creatable, Option } from 'react-select';
+import { get, find, map, includes } from 'lodash';
+import { IAccountDetails } from '@spinnaker/core';
+
+export interface INamespaceSelectorProps {
+  onChange: (namespace: string) => void;
+  accounts: IAccountDetails[];
+  selectedAccount: string;
+  selectedNamespace: string;
+  createable?: boolean;
+}
+
+export class NamespaceSelector extends React.Component<INamespaceSelectorProps> {
+  public defaultProps = { createable: false };
+
+  private getNamespaceOptions(): Array<Option<string>> {
+    const { accounts, selectedAccount } = this.props;
+    const selectedAccountDetails = find(accounts, a => a.name === selectedAccount);
+    const namespaces = get(selectedAccountDetails, 'namespaces', []);
+    const options = map(namespaces, n => ({ label: n, value: n }));
+    if (this.props.createable && !includes(namespaces, this.props.selectedNamespace)) {
+      options.push({ label: this.props.selectedNamespace, value: this.props.selectedNamespace });
+    }
+    return options;
+  }
+
+  public render() {
+    const componentProps = {
+      clearable: false,
+      options: this.getNamespaceOptions(),
+      value: this.props.selectedNamespace,
+      onChange: (option: Option) => this.props.onChange(option.value.toString()),
+    };
+    return <>{this.props.createable ? <Creatable {...componentProps} /> : <Select {...componentProps} />}</>;
+  }
+}


### PR DESCRIPTION
UI for v2 run job capture output. there are 2 options - logs and
artifact. setting to `logs` will set the `propertyFile` option to
trigger the runJob stage to read from the container logs. setting to
artifact will trigger the `ConsumeArtifactTask` to fetch and inject the
defined artifact.