### PR TITLE
fix(core): Hide "Run as user" when using managed service accounts

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/triggers/BaseTrigger.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/BaseTrigger.tsx
@@ -52,7 +52,7 @@ export class BaseTrigger extends React.Component<IBaseTriggerConfigProps, IBaseT
     const { serviceAccounts } = this.state;
     return (
       <>
-        {SETTINGS.feature.fiatEnabled && serviceAccounts && (
+        {SETTINGS.feature.fiatEnabled && serviceAccounts && !SETTINGS.feature.managedServiceAccounts && (
           <div className="form-group">
             <RunAsUser
               serviceAccounts={serviceAccounts}


### PR DESCRIPTION
Regression introduced in #6970 while converting triggers to React
