### PR TITLE
fix(core): Backward compatibility for old application permissions

### DIFF
--- a/app/scripts/modules/core/src/application/config/applicationAttributes.directive.js
+++ b/app/scripts/modules/core/src/application/config/applicationAttributes.directive.js
@@ -59,6 +59,13 @@ module.exports = angular
           (permissions.READ || []).forEach(role => {
             permissionsMap.set(role, 'read');
           });
+          (permissions.EXECUTE || []).forEach(role => {
+            if (permissionsMap.has(role)) {
+              permissionsMap.set(role, permissionsMap.get(role) + ', execute');
+            } else {
+              permissionsMap.set(role, 'execute');
+            }
+          });
           (permissions.WRITE || []).forEach(role => {
             if (permissionsMap.has(role)) {
               permissionsMap.set(role, permissionsMap.get(role) + ', write');

--- a/app/scripts/modules/core/src/application/modal/PermissionsConfigurer.spec.tsx
+++ b/app/scripts/modules/core/src/application/modal/PermissionsConfigurer.spec.tsx
@@ -42,6 +42,24 @@ describe('PermissionsConfigurer', () => {
     });
   });
 
+  it('supports old READ/WRITE permissions by adding EXECUTE implicitly', () => {
+    const component = createComponent({
+      permissions: {
+        READ: ['my-team'],
+        WRITE: ['my-team'],
+      } as IPermissions,
+      requiredGroupMembership: null,
+      onPermissionsChange: () => null,
+    });
+
+    expect(component.state.permissionRows).toEqual([
+      {
+        group: 'my-team',
+        access: 'READ,EXECUTE,WRITE',
+      },
+    ]);
+  });
+
   it(`populates the 'roleOptions' list with a user's roles minus the roles already used in the permissions object`, () => {
     const component = createComponent({
       permissions: { READ: ['groupA', 'groupB'], EXECUTE: ['groupB'], WRITE: ['groupB'] },

--- a/app/scripts/modules/core/src/application/modal/PermissionsConfigurer.tsx
+++ b/app/scripts/modules/core/src/application/modal/PermissionsConfigurer.tsx
@@ -61,26 +61,35 @@ export class PermissionsConfigurer extends React.Component<IPermissionsConfigure
       return permissionRows;
     }
 
-    permissions.READ.forEach(group => {
-      permissionRows.push({ group, access: 'READ' });
-    });
+    permissions.READ &&
+      permissions.READ.forEach(group => {
+        permissionRows.push({ group, access: 'READ' });
+      });
 
-    permissions.EXECUTE.forEach(group => {
-      const matchingRow = permissionRows.find(row => row.group === group);
-      if (matchingRow) {
-        matchingRow.access += ',EXECUTE';
-      } else {
-        permissionRows.push({ group, access: 'EXECUTE' });
-      }
-    });
+    permissions.EXECUTE &&
+      permissions.EXECUTE.forEach(group => {
+        const matchingRow = permissionRows.find(row => row.group === group);
+        if (matchingRow) {
+          matchingRow.access += ',EXECUTE';
+        } else {
+          permissionRows.push({ group, access: 'EXECUTE' });
+        }
+      });
 
-    permissions.WRITE.forEach(group => {
-      const matchingRow = permissionRows.find(row => row.group === group);
-      if (matchingRow) {
-        matchingRow.access += ',WRITE';
-      } else {
-        // WRITE only permissions aren't supported in the UI, but they could be.
-        permissionRows.push({ group, access: 'WRITE' });
+    permissions.WRITE &&
+      permissions.WRITE.forEach(group => {
+        const matchingRow = permissionRows.find(row => row.group === group);
+        if (matchingRow) {
+          matchingRow.access += ',WRITE';
+        } else {
+          // WRITE only permissions aren't supported in the UI, but they could be.
+          permissionRows.push({ group, access: 'WRITE' });
+        }
+      });
+
+    permissionRows.forEach(row => {
+      if (row.access === 'READ,WRITE') {
+        row.access = 'READ,EXECUTE,WRITE';
       }
     });
 


### PR DESCRIPTION
Applications saved before #6901 and spinnaker/fiat#373 does not have EXECUTE permission set, and in some cases this breaks Deck. This commit fixes so that the old READ/WRITE permission is converted to a READ/EXECUTE/WRITE permission.
Also adds EXECUTE support to the applicationAttributes-ng-directive.

When this PR is merged, Deck will support old style permissions without EXECUTE, and the next time one saves the application, EXECUTE will be added (if the old permissions were READ/WRITE).

Current behaviour:

Application saved with read/write:
![image](https://user-images.githubusercontent.com/155558/57862132-2651ca80-77f8-11e9-9daa-804ec2ecc2bc.png)
And the permissions are set as follows in the application definition:
```json
        "permissions": {
            "READ": [
                "spt-delivery-team"
            ],
            "WRITE": [
                "spt-delivery-team"
            ]
        }
```

When opening the edit modal, the rendering fails and Permissions are not displayed at all:
![image](https://user-images.githubusercontent.com/155558/57862385-8e081580-77f8-11e9-9d8b-b765cda71642.png)

The stacktrace:
```
[Error] TypeError: undefined is not an object (evaluating 'permissions.EXECUTE.forEach')
	getPermissionRows (PermissionsConfigurer.tsx:48)
	getState (PermissionsConfigurer.tsx:36)
	PermissionsConfigurer (PermissionsConfigurer.tsx:26)
	constructClassInstance (react-dom.development.js:11361)
	updateClassComponent (react-dom.development.js:14687)
	performUnitOfWork (react-dom.development.js:19312)
	workLoop (react-dom.development.js:19352)
	callCallback (react-dom.development.js:149)
	dispatchEvent
	invokeGuardedCallbackDev (react-dom.development.js:199)
	invokeGuardedCallback (react-dom.development.js:256)
	replayUnitOfWork (react-dom.development.js:18578)
	renderRoot (react-dom.development.js:19468)
	performWorkOnRoot (react-dom.development.js:20342)
	performWork (react-dom.development.js:20254)
	performSyncWork (react-dom.development.js:20228)
	requestWork (react-dom.development.js:20097)
	scheduleWork (react-dom.development.js:19911)
	scheduleRootUpdate (react-dom.development.js:20572)
	render (react-dom.development.js:20953)
	(anonym funksjon) (react-dom.development.js:21090)
	legacyRenderSubtreeIntoContainer (react-dom.development.js:21086)
	render (index.js:60)
	$onChanges (index.js:28)
	(anonym funksjon) (angular.js:10022)
	forEach (angular.js:426)
	nodeLinkFn (angular.js:10018)
	compositeLinkFn (angular.js:9311)
	compositeLinkFn (angular.js:9314)
	compositeLinkFn (angular.js:9314)
	publicLinkFn (angular.js:9176)
	ngTranscludePostLink (angular.js:33349)
	invokeLinkFn (angular.js:10682)
	nodeLinkFn (angular.js:10071)
	compositeLinkFn (angular.js:9311)
	publicLinkFn (angular.js:9176)
	ngIfWatchAction (angular.js:28487)
	$digest (angular.js:18543)
	$apply (angular.js:18903)
	(anonym funksjon) (angular.js:27961)
	dispatch (jquery.js:5233)
```

FYI @dibyom 