### PR TITLE
feat(provider/kubernetes): namespace deployManifest

### DIFF
--- a/app/scripts/modules/kubernetes/src/v2/manifest/wizard/BasicSettings.tsx
+++ b/app/scripts/modules/kubernetes/src/v2/manifest/wizard/BasicSettings.tsx
@@ -19,7 +19,7 @@ export function ManifestBasicSettings({
   selectedAccount,
 }: IManifestBasicSettingsProps) {
   return (
-    <div className="container-fluid form-horizontal">
+    <div className="form-horizontal">
       <div className="form-group">
         <div className="col-md-3 sm-label-right">
           Account <HelpField id="kubernetes.manifest.account" />


### PR DESCRIPTION
adds fields for namespaceOverride to allow users to define the namespace
their manifests are deployed into (particularly for manifests baked from
Helm charts).


## Default - no override
![image](https://user-images.githubusercontent.com/3324110/57882557-fa334b00-77f1-11e9-8b7e-a35e4deeb401.png)

## Namespace override enabled
![image](https://user-images.githubusercontent.com/3324110/57882577-08816700-77f2-11e9-9296-408e155b44ad.png)


## Override enabled w/ SpEL expression
![image](https://user-images.githubusercontent.com/3324110/57882609-1f27be00-77f2-11e9-8872-df734c6c8fae.png)
