### PR TITLE
fix(authz): Handle apps without execute permissions

### DIFF
--- a/app/scripts/modules/core/src/application/config/applicationAttributes.directive.js
+++ b/app/scripts/modules/core/src/application/config/applicationAttributes.directive.js
@@ -59,6 +59,13 @@ module.exports = angular
           (permissions.READ || []).forEach(role => {
             permissionsMap.set(role, 'read');
           });
+          (permissions.EXECUTE || []).forEach(role => {
+            if (permissionsMap.has(role)) {
+              permissionsMap.set(role, permissionsMap.get(role) + ', execute');
+            } else {
+              permissionsMap.set(role, 'execute');
+            }
+          });
           (permissions.WRITE || []).forEach(role => {
             if (permissionsMap.has(role)) {
               permissionsMap.set(role, permissionsMap.get(role) + ', write');

--- a/app/scripts/modules/core/src/application/modal/PermissionsConfigurer.spec.tsx
+++ b/app/scripts/modules/core/src/application/modal/PermissionsConfigurer.spec.tsx
@@ -42,6 +42,24 @@ describe('PermissionsConfigurer', () => {
     });
   });
 
+  it('supports old READ/WRITE permissions by adding EXECUTE implicitly', () => {
+    const component = createComponent({
+      permissions: {
+        READ: ['my-team'],
+        WRITE: ['my-team'],
+      } as IPermissions,
+      requiredGroupMembership: null,
+      onPermissionsChange: () => null,
+    });
+
+    expect(component.state.permissionRows).toEqual([
+      {
+        group: 'my-team',
+        access: 'READ,EXECUTE,WRITE',
+      },
+    ]);
+  });
+
   it(`populates the 'roleOptions' list with a user's roles minus the roles already used in the permissions object`, () => {
     const component = createComponent({
       permissions: { READ: ['groupA', 'groupB'], EXECUTE: ['groupB'], WRITE: ['groupB'] },

--- a/app/scripts/modules/core/src/application/modal/PermissionsConfigurer.spec.tsx
+++ b/app/scripts/modules/core/src/application/modal/PermissionsConfigurer.spec.tsx
@@ -42,24 +42,6 @@ describe('PermissionsConfigurer', () => {
     });
   });
 
-  it('supports old READ/WRITE permissions by adding EXECUTE implicitly', () => {
-    const component = createComponent({
-      permissions: {
-        READ: ['my-team'],
-        WRITE: ['my-team'],
-      } as IPermissions,
-      requiredGroupMembership: null,
-      onPermissionsChange: () => null,
-    });
-
-    expect(component.state.permissionRows).toEqual([
-      {
-        group: 'my-team',
-        access: 'READ,EXECUTE,WRITE',
-      },
-    ]);
-  });
-
   it(`populates the 'roleOptions' list with a user's roles minus the roles already used in the permissions object`, () => {
     const component = createComponent({
       permissions: { READ: ['groupA', 'groupB'], EXECUTE: ['groupB'], WRITE: ['groupB'] },

--- a/app/scripts/modules/core/src/application/modal/PermissionsConfigurer.tsx
+++ b/app/scripts/modules/core/src/application/modal/PermissionsConfigurer.tsx
@@ -35,7 +35,7 @@ export class PermissionsConfigurer extends React.Component<IPermissionsConfigure
     { value: 'READ,EXECUTE', label: 'Read and execute' },
     { value: 'READ,EXECUTE,WRITE', label: 'Read, execute, write' },
   ];
-  private static legacyAccessTypes: Option[] = [{ value: 'READ,WRITE', label: 'Read, and write' }];
+  private static legacyAccessTypes: Option[] = [{ value: 'READ,WRITE', label: 'Read and write' }];
 
   constructor(props: IPermissionsConfigurerProps) {
     super(props);
@@ -192,9 +192,10 @@ export class PermissionsConfigurer extends React.Component<IPermissionsConfigure
     return (
       <div className="permissions-configurer">
         {this.state.permissionRows.map((row, i) => {
-          const permissionTypeLabel = []
-            .concat(PermissionsConfigurer.accessTypes, PermissionsConfigurer.legacyAccessTypes)
-            .find(type => type.value === row.access).label;
+          const permissionTypeLabel = [
+            ...PermissionsConfigurer.accessTypes,
+            ...PermissionsConfigurer.legacyAccessTypes,
+          ].find(type => type.value === row.access).label;
           return (
             <div key={row.group || i} className="permissions-row clearfix">
               <div className="col-md-5 permissions-group">

--- a/app/scripts/modules/core/src/application/modal/PermissionsConfigurer.tsx
+++ b/app/scripts/modules/core/src/application/modal/PermissionsConfigurer.tsx
@@ -61,26 +61,35 @@ export class PermissionsConfigurer extends React.Component<IPermissionsConfigure
       return permissionRows;
     }
 
-    permissions.READ.forEach(group => {
-      permissionRows.push({ group, access: 'READ' });
-    });
+    permissions.READ &&
+      permissions.READ.forEach(group => {
+        permissionRows.push({ group, access: 'READ' });
+      });
 
-    permissions.EXECUTE.forEach(group => {
-      const matchingRow = permissionRows.find(row => row.group === group);
-      if (matchingRow) {
-        matchingRow.access += ',EXECUTE';
-      } else {
-        permissionRows.push({ group, access: 'EXECUTE' });
-      }
-    });
+    permissions.EXECUTE &&
+      permissions.EXECUTE.forEach(group => {
+        const matchingRow = permissionRows.find(row => row.group === group);
+        if (matchingRow) {
+          matchingRow.access += ',EXECUTE';
+        } else {
+          permissionRows.push({ group, access: 'EXECUTE' });
+        }
+      });
 
-    permissions.WRITE.forEach(group => {
-      const matchingRow = permissionRows.find(row => row.group === group);
-      if (matchingRow) {
-        matchingRow.access += ',WRITE';
-      } else {
-        // WRITE only permissions aren't supported in the UI, but they could be.
-        permissionRows.push({ group, access: 'WRITE' });
+    permissions.WRITE &&
+      permissions.WRITE.forEach(group => {
+        const matchingRow = permissionRows.find(row => row.group === group);
+        if (matchingRow) {
+          matchingRow.access += ',WRITE';
+        } else {
+          // WRITE only permissions aren't supported in the UI, but they could be.
+          permissionRows.push({ group, access: 'WRITE' });
+        }
+      });
+
+    permissionRows.forEach(row => {
+      if (row.access === 'READ,WRITE') {
+        row.access = 'READ,EXECUTE,WRITE';
       }
     });
 

--- a/app/scripts/modules/core/src/application/modal/PermissionsConfigurer.tsx
+++ b/app/scripts/modules/core/src/application/modal/PermissionsConfigurer.tsx
@@ -35,6 +35,7 @@ export class PermissionsConfigurer extends React.Component<IPermissionsConfigure
     { value: 'READ,EXECUTE', label: 'Read and execute' },
     { value: 'READ,EXECUTE,WRITE', label: 'Read, execute, write' },
   ];
+  private static legacyAccessTypes: Option[] = [{ value: 'READ,WRITE', label: 'Read, and write' }];
 
   constructor(props: IPermissionsConfigurerProps) {
     super(props);
@@ -86,12 +87,6 @@ export class PermissionsConfigurer extends React.Component<IPermissionsConfigure
           permissionRows.push({ group, access: 'WRITE' });
         }
       });
-
-    permissionRows.forEach(row => {
-      if (row.access === 'READ,WRITE') {
-        row.access = 'READ,EXECUTE,WRITE';
-      }
-    });
 
     return permissionRows;
   }
@@ -197,8 +192,9 @@ export class PermissionsConfigurer extends React.Component<IPermissionsConfigure
     return (
       <div className="permissions-configurer">
         {this.state.permissionRows.map((row, i) => {
-          const permissionTypeLabel = PermissionsConfigurer.accessTypes.find(type => type.value === row.access).label;
-
+          const permissionTypeLabel = []
+            .concat(PermissionsConfigurer.accessTypes, PermissionsConfigurer.legacyAccessTypes)
+            .find(type => type.value === row.access).label;
           return (
             <div key={row.group || i} className="permissions-row clearfix">
               <div className="col-md-5 permissions-group">


### PR DESCRIPTION
PermissionsConfigurer always assumed apps had EXECUTE permissions set
which is not true for applications created before EXECUTE was a thing.

A more detailed description is here: https://github.com/spinnaker/deck/pull/7015#issue-279537064

Thanks @jervi !!