### PR TITLE
fix(core/pipeline): fix type mismatch in pipeline trigger, broken webhook trigger

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/triggers/BaseTrigger.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/BaseTrigger.tsx
@@ -27,7 +27,7 @@ export class BaseTrigger extends React.Component<IBaseTriggerConfigProps, IBaseT
     };
   }
 
-  public componentDidMount(): void {
+  public componentDidMount() {
     if (SETTINGS.feature.fiatEnabled) {
       Observable.fromPromise(ServiceAccountReader.getServiceAccounts())
         .takeUntil(this.destroy$)
@@ -35,7 +35,7 @@ export class BaseTrigger extends React.Component<IBaseTriggerConfigProps, IBaseT
     }
   }
 
-  public componentWillUnmount(): void {
+  public componentWillUnmount() {
     this.destroy$.next();
   }
 

--- a/app/scripts/modules/core/src/pipeline/config/triggers/webhook/WebhookTrigger.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/webhook/WebhookTrigger.tsx
@@ -13,11 +13,7 @@ export interface IWebhookTriggerProps {
 }
 
 export class WebhookTrigger extends React.Component<IWebhookTriggerProps> {
-  constructor(props: IWebhookTriggerProps) {
-    super(props);
-  }
-
-  private WebhookTriggerContents() {
+  private WebhookTriggerContents = () => {
     const { trigger } = this.props;
     const { source, type } = trigger;
     const p = trigger.payloadConstraints || {};
@@ -61,7 +57,7 @@ export class WebhookTrigger extends React.Component<IWebhookTriggerProps> {
         </div>
       </>
     );
-  }
+  };
 
   private onUpdateTrigger = (update: any) => {
     this.props.triggerUpdated &&


### PR DESCRIPTION
few fixes for the new react-powered pipeline and webhook triggers:

- the status chcecklist for for pipeline triggers wasn't transforming the `Set`s coming from `Checklist` to arrays, which got masked by the fact that the `onUpdateTrigger` method is typed with `any`. End result was that once a status was changed the underlying JSON was malformed and made the trigger component un-renderable on the next navigation to the same view
- fixed up some minor things in `PipelineTrigger` like not triggering the `destroy$` subject on unmount and not using the pre-existing `status` list if one existed
- webhook triggers were un-renderable in all cases due to using a standard instance method instead of an arrow function