### PR TITLE
fix(kubernetes): Fix NPE in bake manifest details

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/BakeManifestDetailsTab.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/BakeManifestDetailsTab.tsx
@@ -12,7 +12,7 @@ export class BakeManifestDetailsTab extends React.Component<IExecutionDetailsSec
   public static title = 'bakedManifest';
 
   public render() {
-    const bakedArtifacts: IArtifact[] = this.props.stage.context.artifacts.filter(
+    const bakedArtifacts: IArtifact[] = (this.props.stage.context.artifacts || []).filter(
       (a: IArtifact) => a.type === 'embedded/base64',
     );
     return (


### PR DESCRIPTION
If the bake manifest stage doesn't output any artifacts, the stage fails to render due to an NPE. This is probably rare as you'd generally want at least one artifact, but still worth fixing.