### PR TITLE
fix(cf): server group header build links should precede images

### DIFF
--- a/app/scripts/modules/core/src/serverGroup/ServerGroupHeader.tsx
+++ b/app/scripts/modules/core/src/serverGroup/ServerGroupHeader.tsx
@@ -131,7 +131,6 @@ export class SequenceAndBuildAndImages extends React.Component<IServerGroupHeade
             {docker.image}:{docker.tag || docker.digest}
           </a>
         )}
-        {!!images && <ImageList {...this.props} />}
         {(!!ciBuild || !!appArtifact) && (
           <span>
             {!!appArtifact.version && <span> ({appArtifact.version})</span>}
@@ -142,6 +141,7 @@ export class SequenceAndBuildAndImages extends React.Component<IServerGroupHeade
             )}
           </span>
         )}
+        {!!images && <ImageList {...this.props} />}
       </div>
     );
   }


### PR DESCRIPTION
In the (currently unlikely) event that images and build info are both available, the images should not be first.
