### PR TITLE
fix(chaos): Stack and detail are actually not required

### DIFF
--- a/app/scripts/modules/core/src/chaosMonkey/chaosMonkeyExceptions.component.html
+++ b/app/scripts/modules/core/src/chaosMonkey/chaosMonkeyExceptions.component.html
@@ -42,7 +42,6 @@
               class="form-control input-sm"
               ng-model="exception.stack"
               ng-change="$ctrl.updateConfig()"
-              required
             />
           </td>
           <td>
@@ -51,7 +50,6 @@
               class="form-control input-sm"
               ng-model="exception.detail"
               ng-change="$ctrl.updateConfig()"
-              required
             />
           </td>
           <td>


### PR DESCRIPTION
For example, one may actually want to enable chaos monkey on all other clusters except for the stack-less cluster.