### PR TITLE
fix(kubernetes): fix runjob stage init

### DIFF
--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/runJob/KubernetesV2RunJobStageConfig.tsx
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/runJob/KubernetesV2RunJobStageConfig.tsx
@@ -27,6 +27,14 @@ export class KubernetesV2RunJobStageConfig extends React.Component<IStageConfigP
     credentials: [],
   };
 
+  constructor(props: IStageConfigProps) {
+    super(props);
+    const { stage, application } = this.props;
+    if (!stage.application) {
+      stage.application = application.name;
+    }
+  }
+
   public outputOptions = [
     { label: 'None', value: 'none' },
     { label: 'Logs', value: 'propertyFile' },


### PR DESCRIPTION
fix stage initialization by setting the stage's application config if it
doesn't exist. this field is required to be set for the stage to work.
initially i had assumed the that BasicSettings component would configure
it.