### PR TITLE
fix(artifact/helm): fix version list

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/helm/HelmArtifactEditor.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/helm/HelmArtifactEditor.tsx
@@ -54,7 +54,7 @@ class HelmEditor extends React.Component<IArtifactEditorProps, IHelmArtifactEdit
             value={artifact.name || ''}
             onChange={(e: Option) => {
               this.onChange(e, 'name');
-              this.onNameChange();
+              this.onNameChange(e.value.toString());
             }}
             clearable={false}
           />
@@ -80,8 +80,8 @@ class HelmEditor extends React.Component<IArtifactEditorProps, IHelmArtifactEdit
     this.props.onChange(clone);
   };
 
-  private onNameChange = () => {
-    ArtifactService.getArtifactVersions(TYPE, this.props.account.name, this.props.artifact.name).then(versions => {
+  private onNameChange = (chartName: string) => {
+    ArtifactService.getArtifactVersions(TYPE, this.props.account.name, chartName).then(versions => {
       this.setState({ versions });
     });
   };


### PR DESCRIPTION
helm chart versions weren't being listed properly because the chart name
was being pulled from the previous value. so, the list of versions you
got back were for a previously selected chart name instead of the newly
selected chart name.