### PR TITLE
fix(core): blur active element when rendering task monitor

### DIFF
--- a/app/scripts/modules/core/src/task/monitor/TaskMonitor.ts
+++ b/app/scripts/modules/core/src/task/monitor/TaskMonitor.ts
@@ -80,6 +80,7 @@ export class TaskMonitor {
     this.task = null;
     this.error = false;
     this.errorMessage = null;
+    document.activeElement && (document.activeElement as HTMLElement).blur();
   }
 
   public setError(task?: ITask): void {

--- a/app/scripts/modules/core/src/task/monitor/taskMonitor.html
+++ b/app/scripts/modules/core/src/task/monitor/taskMonitor.html
@@ -11,7 +11,7 @@
     </div>
   </div>
   <div class="modal-footer" ng-if="!taskMonitor.error">
-    <button class="btn btn-primary" ng-click="taskMonitor.closeModal()" autofocus>Close</button>
+    <button class="btn btn-primary" ng-click="taskMonitor.closeModal()">Close</button>
   </div>
   <div class="modal-footer" ng-if="taskMonitor.error">
     <button class="btn btn-primary" ng-click="taskMonitor.tryToFix()">Go back and try to fix this</button>


### PR DESCRIPTION
When the task monitor first pops down, we should steal the focus so that the submit button that's underneath it no longer has focus. People keep pressing enter twice and submitting multiple duplicate tasks.