### PR TITLE
feat(amazon): remove s3 as store type option for baking

### DIFF
--- a/app/scripts/modules/amazon/src/pipeline/stages/bake/awsBakeStage.js
+++ b/app/scripts/modules/amazon/src/pipeline/stages/bake/awsBakeStage.js
@@ -65,7 +65,7 @@ module.exports = angular
           baseOsOptions: BakeryReader.getBaseOsOptions('aws'),
           baseLabelOptions: BakeryReader.getBaseLabelOptions(),
           vmTypes: ['hvm', 'pv'],
-          storeTypes: ['ebs', 's3', 'docker'],
+          storeTypes: ['ebs', 'docker'],
         }).then(function(results) {
           $scope.regions = results.regions;
           $scope.vmTypes = results.vmTypes;


### PR DESCRIPTION
Pretty sure this code path is only exercised at Netflix, and we don't support s3-backed AMI baking any more.