### PR TITLE
fix(docker): Stop losing manually defined imageId

### DIFF
--- a/app/scripts/modules/docker/src/image/DockerImageAndTagSelector.tsx
+++ b/app/scripts/modules/docker/src/image/DockerImageAndTagSelector.tsx
@@ -291,7 +291,12 @@ export class DockerImageAndTagSelector extends React.Component<
       }
       newState.switchedManualWarning = `Could not find ${missingFields.join(' or ')}, switched to manual entry`;
     } else if (!imageId || !imageId.includes('${')) {
-      this.synchronizeChanges({ organization, repository, tag, digest: this.props.digest }, registry);
+      this.synchronizeChanges(
+        this.state.defineManually
+          ? DockerImageUtils.splitImageId(imageId)
+          : { organization, repository, tag, digest: this.props.digest },
+        registry,
+      );
     }
 
     this.setState(newState);


### PR DESCRIPTION
We were losing manually defined imageId on refreshes because didn't properly handle the `defineManually` case.

Basically we only call `synchronizeChanges` with the parts (org, repo, tag/digest), but when we're defining the imageId manually, we end up generating an `undefined` imageId because tag was undefined.

**tl;dr**
For the defineManually case, we just needed to parse imageId into `IDockerImageParts` before passing it into `synchronizeChanges`