### PR TITLE
feat(core): allow any json subtypes in API response

### DIFF
--- a/app/scripts/modules/core/src/api/ApiService.spec.ts
+++ b/app/scripts/modules/core/src/api/ApiService.spec.ts
@@ -70,6 +70,22 @@ describe('API Service', function() {
       expect(rejected).toBe(true);
     });
 
+    it('application/foo+json is fine', () => {
+      spyOn(AuthenticationInitializer, 'reauthenticateUser').and.callFake(noop);
+      $httpBackend
+        .expectGET(`${baseUrl}/bad`)
+        .respond(200, '{"good":"job"}', { 'content-type': 'application/foo+json' });
+
+      let rejected = false;
+      API.one('bad')
+        .get()
+        .then(noop, () => (rejected = true));
+
+      $httpBackend.flush();
+      expect((AuthenticationInitializer.reauthenticateUser as Spy).calls.count()).toBe(0);
+      expect(rejected).toBe(false);
+    });
+
     it('string responses starting with <html should trigger a reauthentication request and reject', function() {
       spyOn(AuthenticationInitializer, 'reauthenticateUser').and.callFake(noop);
       $httpBackend.expectGET(`${baseUrl}/fine`).respond(200, 'this is fine');

--- a/app/scripts/modules/core/src/api/ApiService.ts
+++ b/app/scripts/modules/core/src/api/ApiService.ts
@@ -41,7 +41,7 @@ export class API {
     return $q((resolve, reject) => {
       const contentType = result.headers('content-type');
       if (contentType) {
-        const isJson = contentType.includes('application/json');
+        const isJson = contentType.match(/application\/(.+\+)?json/); // e.g application/json, application/hal+json
         const isZeroLengthHtml = contentType.includes('text/html') && result.data === '';
         const isZeroLengthText = contentType.includes('text/plain') && result.data === '';
         if (!(isJson || isZeroLengthHtml || isZeroLengthText)) {


### PR DESCRIPTION
We have some internal endpoints we are proxying that return `application/hal+json`, which means we can't use API right now without, uh, this change or some change like this. Also there is not enough regex in the codebase.