### PR TITLE
Bump package core to 0.0.371 and docker to 0.0.40 and amazon to 0.0.191

### DIFF
--- a/app/scripts/modules/amazon/package.json
+++ b/app/scripts/modules/amazon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/amazon",
-  "version": "0.0.190",
+  "version": "0.0.191",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/core",
-  "version": "0.0.370",
+  "version": "0.0.371",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/docker/package.json
+++ b/app/scripts/modules/docker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/docker",
-  "version": "0.0.39",
+  "version": "0.0.40",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
### chore(core): Bump version to 0.0.371

2268217b0f3cc8bf52be773a0d7e4ef3899bc621 feat(core): allow any json subtypes in API response (#7040)
b55e3b819c219ec75544c6753891b31ff92ee5d2 fix(core/amazon): validate target group healthcheck fields (#6962)
c9791e62d032ab06f5fe06ffc3f3c070a8e2fea9 fix(core): blur active element when rendering task monitor (#7034)
43fb8a0b6ed63f818ab0a65cf15b3590dd6b40f5 fix(core): unwrap font-awesome span from button label (#7032)
8982b34874cefc7e2862d05acb735e808b62703d fix(cf): server group header build links should precede images (#7027)
59b69b8968631712985b8d0c4285696adf416c9c fix(executions): Fixed missing account tags in standalone (#7036)
f3fd44cb512ce594733fba983ac0eb38db77b905 fix(artifact/helm): fix version list (#7030)
f1ca123fdbfe237fadb3f6054d2b6066f361b1e0 fix(chaos): Stack and detail are actually not required (#7028)
b505b5cc40ec50389e2740eee5c0df750bcd7c51 refactor(core): minor fixes to the refactored triggers (#7024)
9cf9a623d0b706bc242265564bbbb1101fb2ff8d fix(authz): Handle apps without execute permissions (#7017)
6390c71e38da44ad5395ec45a2b79506f1eac3f4 fix(kubernetes): Fix NPE in bake manifest details (#7022)

### chore(docker): Bump version to 0.0.40

bd7c5b6ac49d7aef2ca17bfd7c71c19999bc6712 fix(docker): Stop losing manually defined imageId (#7037)

### chore(amazon): Bump version to 0.0.191

b55e3b819c219ec75544c6753891b31ff92ee5d2 fix(core/amazon): validate target group healthcheck fields (#6962)
a2a3bbbf89724a45350e66ea54ab186b1463ed53 feat(amazon): remove s3 as store type option for baking (#7035)