### PR TITLE
refactor(core): expose clusterService in react injector

### DIFF
--- a/app/scripts/modules/core/src/reactShims/react.injector.ts
+++ b/app/scripts/modules/core/src/reactShims/react.injector.ts
@@ -4,9 +4,11 @@ import IInjectorService = angular.auto.IInjectorService;
 import { StateParams, StateService, UIRouter } from '@uirouter/core';
 
 import { CacheInitializerService } from '../cache/cacheInitializer.service';
+import { ClusterService } from '../cluster/cluster.service';
 import { ConfirmationModalService } from '../confirmationModal/confirmationModal.service';
 import { ExecutionDetailsSectionService } from 'core/pipeline/details/executionDetailsSection.service';
 import { ExecutionService } from '../pipeline/service/execution.service';
+import { ImageReader } from 'core/image/image.reader';
 import { InfrastructureSearchService } from '../search/infrastructure/infrastructureSearch.service';
 import { InsightFilterStateModel } from '../insight/insightFilterState.model';
 import { InstanceTypeService, InstanceWriter } from 'core/instance';
@@ -16,9 +18,8 @@ import { PageTitleService } from 'core/pageTitle';
 import { ProviderServiceDelegate } from '../cloudProvider/providerService.delegate';
 import { SecurityGroupReader } from '../securityGroup/securityGroupReader.service';
 import { ServerGroupWriter } from '../serverGroup/serverGroupWriter.service';
-import { ImageReader } from 'core/image/image.reader';
-import { StateEvents } from './state.events';
 import { SkinSelectionService } from '../cloudProvider/skinSelection/skinSelection.service';
+import { StateEvents } from './state.events';
 
 export abstract class ReactInject {
   protected $injector: IInjectorService;
@@ -45,6 +46,7 @@ export class CoreReactInject extends ReactInject {
   public get $uiRouter() { return this.$injector.get('$uiRouter') as UIRouter; }
   public get cacheInitializer() { return this.$injector.get('cacheInitializer') as CacheInitializerService; }
   public get confirmationModalService() { return this.$injector.get('confirmationModalService') as ConfirmationModalService; }
+  public get clusterService() { return this.$injector.get('clusterService') as ClusterService; }
   public get executionDetailsSectionService() { return this.$injector.get('executionDetailsSectionService') as ExecutionDetailsSectionService; }
   public get executionService() { return this.$injector.get('executionService') as ExecutionService; }
   public get imageReader() { return this.$injector.get('imageReader') as ImageReader; }

--- a/app/scripts/modules/core/src/serverGroup/serverGroup.transformer.js
+++ b/app/scripts/modules/core/src/serverGroup/serverGroup.transformer.js
@@ -44,25 +44,9 @@ module.exports = angular
         return service ? service.convertServerGroupCommandToDeployConfiguration(base) : null;
       }
 
-      // strips out Angular bits (see angular.js#toJsonReplacer), as well as executions and running tasks
-      function jsonReplacer(key, value) {
-        var val = value;
-
-        if (typeof key === 'string' && key.charAt(0) === '$' && key.charAt(1) === '$') {
-          val = undefined;
-        }
-
-        if (key === 'executions' || key === 'runningTasks') {
-          val = undefined;
-        }
-
-        return val;
-      }
-
       return {
-        normalizeServerGroup: normalizeServerGroup,
-        convertServerGroupCommandToDeployConfiguration: convertServerGroupCommandToDeployConfiguration,
-        jsonReplacer: jsonReplacer,
+        normalizeServerGroup,
+        convertServerGroupCommandToDeployConfiguration,
       };
     },
   ]);


### PR DESCRIPTION
Making `clusterService` available (we use it in our internal build) to React; also fixing import order for performance, and removing an unused method in an entirely unrelated service