### PR TITLE
chore(core): Bump version to 0.0.372

### DIFF
--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/core",
-  "version": "0.0.371",
+  "version": "0.0.372",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
### chore(core): Bump version to 0.0.372

a6838326fdb8d0879ac062cacd421801615b6760 fix(core): set runAsUser field correctly on triggers (#7048)
f0287a11ccf92ab902adb55de8664bcde43175bd fix(runJob/kubernetes): use explicit pod name (#7039)
fc1cd1be9a361aad29f55ec4b17943273bd862f9 fix(core): allow clearing of run as user field in triggers (#7045)
246637936d56234d84801a91733afb630c9cb0b4 refactor(core): reactify CRON trigger (#7020)


