### PR TITLE
chore(amazon): Bump version to 0.0.192

### DIFF
--- a/app/scripts/modules/amazon/package.json
+++ b/app/scripts/modules/amazon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/amazon",
-  "version": "0.0.191",
+  "version": "0.0.192",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
### chore(amazon): Bump version to 0.0.192

e259625d239ba3246de3a06273236d4768cbfc2a fix(amazon): do not set target group errors to falsy values (#7050)


