### PR TITLE
fix(core): Build triggers: Properly render large number of jobs

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/triggers/baseBuild/BaseBuildTrigger.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/baseBuild/BaseBuildTrigger.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import Select, { Option } from 'react-select';
+import VirtualizedSelect from 'react-virtualized-select';
 import { Observable, Subject } from 'rxjs';
 
 import { BaseTrigger } from 'core/pipeline';
@@ -123,7 +124,7 @@ export class BaseBuildTrigger extends React.Component<IBaseBuildTriggerConfigPro
     return (
       <>
         {jobsLoaded && (
-          <Select
+          <VirtualizedSelect
             className="form-control input-sm"
             options={jobs.map(j => ({ label: j, value: j }))}
             placeholder={'Select a job...'}


### PR DESCRIPTION
The react Select component does not render a large number of jobs very well. In our environment it freezes the browser for ~30 seconds after every typed letter. VirtualizedSelect seems to handle this a lot better (instant response). For reference, our job list contains 43 791 elements.

PTAL @Jammy-Louie 