### PR TITLE
feature(cf): server group details creation timestamp links to pipeline

### DIFF
--- a/app/scripts/modules/cloudfoundry/src/domain/ICloudFoundryServerGroup.ts
+++ b/app/scripts/modules/cloudfoundry/src/domain/ICloudFoundryServerGroup.ts
@@ -18,6 +18,7 @@ export interface ICloudFoundryServerGroup extends IServerGroup {
   env: ICloudFoundryEnvVar[];
   ciBuild: ICloudFoundryBuildInfo;
   appArtifact: ICloudFoundryArtifactInfo;
+  pipelineId: String;
 }
 
 export interface ICloudFoundryServiceInstance {

--- a/app/scripts/modules/cloudfoundry/src/serverGroup/details/sections/ServerGroupInformationSection.tsx
+++ b/app/scripts/modules/cloudfoundry/src/serverGroup/details/sections/ServerGroupInformationSection.tsx
@@ -16,7 +16,15 @@ export class ServerGroupInformationSection extends React.Component<ICloudFoundry
       <CollapsibleSection heading="Server Group Information" defaultExpanded={true}>
         <dl className="dl-horizontal dl-flex">
           <dt>Created</dt>
-          <dd>{timestamp(serverGroup.createdTime)}</dd>
+          {serverGroup.pipelineId ? (
+            <dd>
+              <a target="_blank" href={'/#/applications/' + serverGroup.app + '/executions/' + serverGroup.pipelineId}>
+                {timestamp(serverGroup.createdTime)}
+              </a>
+            </dd>
+          ) : (
+            <dd>{timestamp(serverGroup.createdTime)}</dd>
+          )}
           <dt>Account</dt>
           <dd>
             <AccountTag account={serverGroup.account} />


### PR DESCRIPTION
If a server group is created by a pipeline, sometimes it would be nice to know which one did it. If a server group was created by a pipeline, the timestamp will now become a link to it.
