### PR TITLE
Bump package core to 0.0.373 and docker to 0.0.41 and titus to 0.0.98

### DIFF
--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/core",
-  "version": "0.0.372",
+  "version": "0.0.373",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/docker/package.json
+++ b/app/scripts/modules/docker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/docker",
-  "version": "0.0.40",
+  "version": "0.0.41",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/titus/package.json
+++ b/app/scripts/modules/titus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/titus",
-  "version": "0.0.97",
+  "version": "0.0.98",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
### chore(core): Bump version to 0.0.373

89e4e78505ed8760214389eea683ad929c7a5a9f fix(runJob/kubernetes): reliably display logs (#7060)
50f23fcca731ebbc3bf9a25805223632ea8a3364 refactor(core): allow checklist component to accept objects as a prop (#7058)
0eaae9a8e938a5ec3387ca471051417eda25cb61 refactor(core): expose clusterService in react injector (#7043)
8dd1417ed18557e2b37fceb820b6255bab4e1d1e fix(core): Build triggers: Properly render large number of jobs (#7056)
497523348967d2d8c84dc6f6a1c57b7ae895e1be fix(artifacts/helm): support regex/spel in version (#7033)

### chore(docker): Bump version to 0.0.41

59259a91cee44f88d2559b2728a889919a635853 fix(docker): Fixed imageId parsing and digest support (#7053)

### chore(titus): Bump version to 0.0.98

50f23fcca731ebbc3bf9a25805223632ea8a3364 refactor(core): allow checklist component to accept objects as a prop (#7058)
59259a91cee44f88d2559b2728a889919a635853 fix(docker): Fixed imageId parsing and digest support (#7053)


