### PR TITLE
refactor(titus): Moving constraints from lists to maps

### DIFF
--- a/app/scripts/modules/titus/src/serverGroup/configure/ServerGroupCommandBuilder.js
+++ b/app/scripts/modules/titus/src/serverGroup/configure/ServerGroupCommandBuilder.js
@@ -2,6 +2,7 @@
 
 const angular = require('angular');
 
+import { set } from 'lodash';
 import { NameUtils } from '@spinnaker/core';
 import { TitusProviderSettings } from '../../titus.settings';
 
@@ -48,8 +49,10 @@ module.exports = angular
           cloudProvider: 'titus',
           selectedProvider: 'titus',
           iamProfile: defaultIamProfile,
-          softConstraints: [],
-          hardConstraints: [],
+          constraints: {
+            hard: {},
+            soft: {},
+          },
           viewState: {
             useSimpleCapacity: true,
             usePreferredZones: true,
@@ -99,8 +102,10 @@ module.exports = angular
           capacityGroup: serverGroup.capacityGroup,
           migrationPolicy: serverGroup.migrationPolicy ? serverGroup.migrationPolicy : { type: 'systemDefault' },
           securityGroups: serverGroup.securityGroups || [],
-          hardConstraints: serverGroup.hardConstraints || [],
-          softConstraints: serverGroup.softConstraints || [],
+          constraints: {
+            hard: (serverGroup.constraints && serverGroup.constraints.hard) || {},
+            soft: (serverGroup.constraints && serverGroup.constraints.soft) || {},
+          },
           inService: serverGroup.disabled ? false : true,
           source: {
             account: serverGroup.account,
@@ -168,8 +173,21 @@ module.exports = angular
 
         return asyncLoader.then(function(asyncData) {
           var command = asyncData.command;
-          command.hardConstraints = command.hardConstraints || [];
-          command.softConstraints = command.softConstraints || [];
+
+          command.constraints = {
+            hard:
+              (originalCluster.constraints && originalCluster.constraints.hard) ||
+              (originalCluster.hardConstraints &&
+                originalCluster.hardConstraints.reduce((a, c) => set(a, c, 'true'), {})) ||
+              {},
+            soft:
+              (originalCluster.constarints && originalCluster.constarints.soft) ||
+              (originalCluster.softConstraints &&
+                originalCluster.softConstraints.reduce((a, c) => set(a, c, 'true'), {})) ||
+              {},
+          };
+          delete pipelineCluster.hardConstraints;
+          delete pipelineCluster.softConstraints;
 
           var viewState = {
             disableImageSelection: true,

--- a/app/scripts/modules/titus/src/serverGroup/configure/ServerGroupCommandBuilder.js
+++ b/app/scripts/modules/titus/src/serverGroup/configure/ServerGroupCommandBuilder.js
@@ -181,7 +181,7 @@ module.exports = angular
                 originalCluster.hardConstraints.reduce((a, c) => set(a, c, 'true'), {})) ||
               {},
             soft:
-              (originalCluster.constarints && originalCluster.constarints.soft) ||
+              (originalCluster.constraints && originalCluster.constraints.soft) ||
               (originalCluster.softConstraints &&
                 originalCluster.softConstraints.reduce((a, c) => set(a, c, 'true'), {})) ||
               {},

--- a/app/scripts/modules/titus/src/serverGroup/configure/serverGroupConfiguration.service.ts
+++ b/app/scripts/modules/titus/src/serverGroup/configure/serverGroupConfiguration.service.ts
@@ -68,7 +68,6 @@ export const getDefaultJobDisruptionBudgetForApp = (application: Application): I
   return budget;
 };
 
-export type Constraint = 'ExclusiveHost' | 'UniqueHost' | 'ZoneBalance';
 export interface ITitusServerGroupCommand extends IServerGroupCommand {
   cluster?: ICluster;
   disruptionBudget?: IJobDisruptionBudget;
@@ -104,8 +103,10 @@ export interface ITitusServerGroupCommand extends IServerGroupCommand {
   migrationPolicy: {
     type: string;
   };
-  softConstraints: Constraint[];
-  hardConstraints: Constraint[];
+  constraints: {
+    hard: { [key: string]: string };
+    soft: { [key: string]: string };
+  };
 }
 
 export class TitusServerGroupConfigurationService {


### PR DESCRIPTION
Moving deck over to maps so we can get quickly get rid of the lists (because it's not possible to represent a map as a list).

API already supports the map based constraints:
- currently returns both
- for operations, the `constraints` map (if present) will take precedence over the old lists, so we're safe to send only maps
- pipelines cluster configs will be transformed from lists to maps upon editing the cluster

