### PR TITLE
chore(kubernetes): Bump version to 0.0.23

### DIFF
--- a/app/scripts/modules/kubernetes/package.json
+++ b/app/scripts/modules/kubernetes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/kubernetes",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
89e4e78505ed8760214389eea683ad929c7a5a9f fix(runJob/kubernetes): reliably display logs (#7060)
f0287a11ccf92ab902adb55de8664bcde43175bd fix(runJob/kubernetes): use explicit pod name (#7039)
3fd183ef3aa86808cc9cdb3b6ef09821acc8ac35 fix(kubernetes): fix runjob stage init (#7029)
4f4c32be1fef051a2299ecd7a90e2a1107bdc5cb feat(provider/kubernetes): namespace deployManifest (#7016)
8e97d5925b1cc1781d1651ae0acdc681175c3edb refactor(kubernetes): namespace selector component (#7012)
53cb42296a5dbbff15a96232ea4010d72b81ace2 refactor(kubernetes): convert deploy manifest stage to react (#7002)
0194821ef32b3d93e5a1df55ac5cb74200a34160 feat(runjob): capture output ui (#6978)