### PR TITLE
feat(core/presentation): Support inline radio buttons

### DIFF
--- a/app/scripts/modules/core/src/entityTag/EntityTagEditor.tsx
+++ b/app/scripts/modules/core/src/entityTag/EntityTagEditor.tsx
@@ -190,7 +190,7 @@ export class EntityTagEditor extends React.Component<IEntityTagEditorProps, IEnt
                       const option = ownerOptions.find(opt => opt.label === evt.target.value);
                       setFieldValue('ownerOption', option);
                     }}
-                    input={props => <RadioButtonInput {...props} options={ownerOptions.map(opt => opt.label)} />}
+                    input={props => <RadioButtonInput {...props} stringOptions={ownerOptions.map(opt => opt.label)} />}
                   />
                 )}
               </Modal.Body>

--- a/app/scripts/modules/core/src/presentation/main.less
+++ b/app/scripts/modules/core/src/presentation/main.less
@@ -1431,16 +1431,19 @@ body > .select2-container.open {
   }
 }
 
+.checkbox-inline + .checkbox-inline,
+.radio-inline + .radio-inline {
+  margin-left: 0 !important;
+}
+
 .checkbox-inline,
 .radio-inline {
-  input[type='checkbox'],
-  input[type='radio'] {
-    margin-left: -15px;
-  }
-  padding-left: 25px;
-  &:first-child {
-    padding-left: 15px;
-  }
+  margin-right: 15px;
+}
+
+.checkbox-inline:last-of-type,
+.radio-inline:last-of-type {
+  margin-right: 0;
 }
 
 ul.checkmap {


### PR DESCRIPTION
This PR changes the following things in `RadioButtonInput`:
- adds support for `inline` radio buttons.
- adds `stringOptions` prop instead of overloading `options` which previously took either an array of `Option` objects _or_ an array of `string`s (I'm open to feedback on this API change)
- switches from a `Set` of options to an array, so ordering can be applied.

I'd primarily like feedback from @anotherchrisberry  but he's OOO so I'm tagging Erik and Alan.

---

This PR also reverts tweaks to global bootstrap CSS that adjust margins and padding.

before: 
![Screen Shot 2019-06-03 at 6 22 18 PM](https://user-images.githubusercontent.com/2053478/58844560-8b952080-862c-11e9-91ad-480c947f28d1.png)

after:
![Screen Shot 2019-06-03 at 5 47 04 PM](https://user-images.githubusercontent.com/2053478/58844563-92bc2e80-862c-11e9-8b77-c4d0cc5319e1.png)


---

Finally, this adds support for wrapping of inline checkboxes and radio buttons using a margin hack.  This puts the margin between successive elements on the *right* of the element instead of the left.  This is to support wrapping of inline checkboxes and radios.

before:
![Screen Shot 2019-06-03 at 5 53 00 PM](https://user-images.githubusercontent.com/2053478/58844589-c39c6380-862c-11e9-8471-5449ab8f9054.png)

after:
![Screen Shot 2019-06-03 at 5 53 39 PM](https://user-images.githubusercontent.com/2053478/58844594-cc8d3500-862c-11e9-9c1f-5c7d2ccc2fe3.png)


cc: @Jammy-Louie I believe this component should allow you to drop this duplicate component:
https://github.com/spinnaker/deck/blob/de57adf09452e5a5ad3449b0ec2f552f27555092/app/scripts/modules/cloudfoundry/src/presentation/forms/inputs/CloudFoundryRadioButtonInput.tsx#L23-L57
