### PR TITLE
fix(provider/azure): Fail to run pipeline at WaitForUpInstance task

### DIFF
--- a/app/scripts/modules/azure/serverGroup/serverGroup.transformer.js
+++ b/app/scripts/modules/azure/serverGroup/serverGroup.transformer.js
@@ -74,8 +74,8 @@ module.exports = angular
         vnet: command.vnet,
         vnetResourceGroup: command.selectedVnet.resourceGroup,
         subnet: command.subnet,
+        useSourceCapacity: false,
         capacity: {
-          useSourceCapacity: false,
           min: command.sku.capacity,
           max: command.sku.capacity,
         },


### PR DESCRIPTION
Background:
Currenly, it failed to run pipeline at WaitForUpInstance task and threw exception "Cannot cast object 'false' with class 'java.lang.Boolean' to class 'java.lang.Integer'". After investigated, I found the root cause is that orca will convert the capacity object to Map<String,Integer> but the azure code in deck would pass the property "useSourceCapacity" which is boolean value type under capacity object so that it failed. After checked, the property "useSourceCapacity" shouldn't be setted up under capacity object like other providers. And this property is unused in azure clouddriver.

Fix:
So I submitted this PR to remove the property "useSourceCapacity" from capacity object and add to outer layer of capacity under stage data.