### PR TITLE
feat(core/presentation): Add "success" type to ValidationMessage

### DIFF
--- a/app/scripts/modules/core/src/presentation/main.less
+++ b/app/scripts/modules/core/src/presentation/main.less
@@ -888,6 +888,13 @@ select:invalid {
   color: var(--color-danger);
 }
 
+.success-message {
+  text-align: left;
+  display: block;
+  font-weight: 600;
+  color: var(--color-success);
+}
+
 .warning-message {
   text-align: left;
   display: block;

--- a/app/scripts/modules/core/src/validation/ValidationMessage.tsx
+++ b/app/scripts/modules/core/src/validation/ValidationMessage.tsx
@@ -2,11 +2,27 @@ import * as React from 'react';
 
 export interface IValidationMessageProps {
   message: React.ReactNode;
-  type: 'error' | 'warning' | 'message';
+  type: 'success' | 'error' | 'warning' | 'message' | 'none';
+  // default: true
+  showIcon?: boolean;
 }
 
-export const ValidationMessage = (props: IValidationMessageProps) => (
-  <div className={`${props.type}-message`}>
-    <span className="fa fa-exclamation-circle" /> {props.message}
-  </div>
-);
+const iconClassName = {
+  success: 'far fa-check-circle',
+  error: 'fa fa-exclamation-circle',
+  warning: 'fa fa-exclamation-circle',
+  message: 'icon-view-1',
+  none: '',
+};
+
+export const ValidationMessage = (props: IValidationMessageProps) => {
+  const divClassName = `${props.type}-message`;
+  const showIcon = props.showIcon === undefined ? true : props.showIcon;
+  const spanClassName = (showIcon && iconClassName[props.type]) || '';
+
+  return (
+    <div className={divClassName}>
+      <span className={spanClassName} /> {props.message}
+    </div>
+  );
+};


### PR DESCRIPTION
### Adds `success` status
```        <ValidationMessage message="The quick brown fox jumps over lazy dog" type="success" />```
![Screen Shot 2019-06-04 at 10 37 03 AM](https://user-images.githubusercontent.com/2053478/58900812-ba56d980-86b4-11e9-8170-34ac7530553f.png)

### Adds `none` status

![Screen Shot 2019-06-04 at 10 44 46 AM](https://user-images.githubusercontent.com/2053478/58901301-cc854780-86b5-11e9-8249-ac538641afcc.png)

This status is unstyled

### Adds icon to `message` status
```        <ValidationMessage message="The quick brown fox jumps over lazy dog" type="message" />```
![Screen Shot 2019-06-04 at 10 42 55 AM](https://user-images.githubusercontent.com/2053478/58901198-892ad900-86b5-11e9-909a-ed93a6ab3db4.png)

This icon comes from the forms mockups greg comstock designed.  Note that we intend to style the `message` status further in the future, according to mockups.


### Support showing/hiding the icon
```        <ValidationMessage message="The quick brown fox jumps over lazy dog" type="error" />```
![Screen Shot 2019-06-04 at 10 34 38 AM](https://user-images.githubusercontent.com/2053478/58900673-75cb3e00-86b4-11e9-8d8a-318e697d1234.png)


```        <ValidationMessage message="The quick brown fox jumps over lazy dog" type="error" showIcon={false}/>```
![Screen Shot 2019-06-04 at 10 34 52 AM](https://user-images.githubusercontent.com/2053478/58900661-6c41d600-86b4-11e9-81c0-56c31fa726a8.png)
