### PR TITLE
fix(core): fix auto-navigation on route=true searches

### DIFF
--- a/app/scripts/modules/core/src/search/infrastructure/SearchV2.tsx
+++ b/app/scripts/modules/core/src/search/infrastructure/SearchV2.tsx
@@ -66,6 +66,9 @@ export class SearchV2 extends React.Component<{}, ISearchV2State> {
   }
 
   public componentDidMount() {
+    // auto-navigation only happens via shortcut links, and we only do it if there is exactly one result, e.g
+    // when searching for an instance ID
+    const autoNavigate = window.location.href.endsWith('route=true');
     this.$uiRouter.globals.params$
       .map(stateParams => this.getApiFilterParams(stateParams))
       .do((params: IQueryParams) => this.setState({ params }))
@@ -95,9 +98,6 @@ export class SearchV2 extends React.Component<{}, ISearchV2State> {
       .takeUntil(this.destroy$)
       .subscribe(
         resultSets => {
-          // auto-navigation only happens via shortcut links, and we only do it if there is exactly one result, e.g
-          // when searching for an instance ID
-          const autoNavigate = window.location.href.endsWith('route=true');
           const finishedSearching = resultSets.map(r => r.status).every(s => s === SearchStatus.FINISHED);
           if (finishedSearching && autoNavigate) {
             const allResults = resultSets.reduce((acc, rs) => acc.concat(rs.results), []);


### PR DESCRIPTION
This has only been working when the auto-navigable thing was the last search result to return, I think, because we'll change the URL to the tab with the search results first, which loses the `route=true` query param.