### PR TITLE
fix(kubernetes): fix req. artifacts to bind selector in patch manifes…

### DIFF
--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/patchManifest/patchManifestConfig.html
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/patchManifest/patchManifestConfig.html
@@ -76,7 +76,7 @@
       command="ctrl.$scope.stage"
       ids-field="requiredArtifactIds"
       artifact-label="Req. Artifacts To Bind"
-      expected-artifacts="ctrl.expectedArtifacts"
+      expected-artifacts="ctrl.$scope.expectedArtifacts"
       help-field-key="kubernetes.manifest.requiredArtifactsToBind"
       show-icons="true"
     >


### PR DESCRIPTION
…t stage
Closes https://github.com/spinnaker/spinnaker/issues/4496

This has been broken for at least the last two releases, probably went undetected because requiring an artifact to bind in the patch stage is relatively rare? Will patch back to 1.13 and 1.14.

Before:
![OLRqbqoLLy8](https://user-images.githubusercontent.com/15936279/59054258-460d6900-8861-11e9-85e2-3810bd405707.png)

After:
![DsVgXv33Wjr](https://user-images.githubusercontent.com/15936279/59054207-2bd38b00-8861-11e9-8f36-57d5736500b2.png)
