### PR TITLE
fix(core): Display template inherited items (mptv2) as read only

### DIFF
--- a/app/scripts/modules/core/src/domain/IPipeline.ts
+++ b/app/scripts/modules/core/src/domain/IPipeline.ts
@@ -3,7 +3,7 @@ import { ITrigger } from './ITrigger';
 import { IExpectedArtifact } from 'core/domain/IExpectedArtifact';
 import { IEntityTags } from './IEntityTags';
 
-interface INotification {
+interface INotification extends ITemplateInheritable {
   type: string;
   address: string;
   when: string[];
@@ -37,7 +37,7 @@ export interface IPipeline {
   type?: string;
 }
 
-export interface IParameter {
+export interface IParameter extends ITemplateInheritable {
   name: string;
   description: string;
   default: string;
@@ -71,4 +71,8 @@ export interface IPipelineRef {
   application: String;
   name: String;
   id?: String;
+}
+
+export interface ITemplateInheritable {
+  inherited?: boolean;
 }

--- a/app/scripts/modules/core/src/domain/ITrigger.ts
+++ b/app/scripts/modules/core/src/domain/ITrigger.ts
@@ -1,6 +1,6 @@
-import { IExecution } from 'core/domain';
+import { IExecution, ITemplateInheritable } from 'core/domain';
 
-export interface ITrigger {
+export interface ITrigger extends ITemplateInheritable {
   enabled: boolean;
   rebake?: boolean;
   user?: string;

--- a/app/scripts/modules/core/src/notification/notificationList.directive.html
+++ b/app/scripts/modules/core/src/notification/notificationList.directive.html
@@ -25,24 +25,32 @@
         </tr>
       </thead>
       <tbody>
-        <tr ng-repeat="notification in notifications">
+        <tr ng-repeat="notification in notifications" ng-class="{'templated-pipeline-item': notification.inherited}">
           <td>
-            {{notification.type|notificationType}}
+            {{ notification.type | notificationType }}
           </td>
           <td>
-            {{notification|notificationDetails}}
+            {{ notification | notificationDetails }}
           </td>
           <td>
-            <div ng-repeat="when in notification.when">{{when|notificationWhen:level:parent.type}}</div>
+            <div ng-repeat="when in notification.when">{{ when | notificationWhen: level:parent.type }}</div>
           </td>
           <td>
-            <a class="btn btn-xs btn-link" href ng-click="notificationListCtrl.editNotification(notification)">Edit</a>
+            <a
+              class="btn btn-xs btn-link"
+              href
+              ng-click="notificationListCtrl.editNotification(notification)"
+              ng-if="!notification.inherited"
+              >Edit</a
+            >
             <a
               class="btn btn-xs btn-link pad-left"
               href
               ng-click="notificationListCtrl.removeNotification(notification)"
+              ng-if="!notification.inherited"
               >Remove</a
             >
+            <span class="btn btn-xs pad-left" ng-if="notification.inherited">Inherited from template</span>
           </td>
         </tr>
       </tbody>

--- a/app/scripts/modules/core/src/pipeline/config/parameters/Parameter.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/parameters/Parameter.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as classNames from 'classnames';
 
 import { HelpField } from 'core/help';
 import { Tooltip } from 'core/presentation';
@@ -14,6 +15,7 @@ export interface IParameter {
   default: string;
   hasOptions: boolean;
   options: IParameterOption[];
+  inherited: boolean;
 }
 
 export interface IParameterOption {
@@ -89,7 +91,18 @@ export class Parameter extends React.Component<IParameterProps> {
   };
 
   public render(): JSX.Element {
-    const { name, label, required, pinned, description, hasOptions, options, isMultiple, removeParameter } = this.props;
+    const {
+      name,
+      label,
+      required,
+      pinned,
+      description,
+      hasOptions,
+      options,
+      isMultiple,
+      removeParameter,
+      inherited,
+    } = this.props;
 
     const {
       addOption,
@@ -107,113 +120,124 @@ export class Parameter extends React.Component<IParameterProps> {
       <div className="parameter-config">
         <div className="row">
           <div className="col-md-12">
-            <div className="form-horizontal panel-pipeline-phase">
-              <div className="row name-field">
-                <div className="col-md-1">{isMultiple && <DragHandler />}</div>
-                <label className="col-md-2 sm-label-right">
-                  <span className="label-text">Name</span>
-                </label>
-                <div className="col-md-9">
-                  <div className="row">
-                    <div className="col-md-4">
-                      <input
-                        className="form-control input-sm"
-                        type="text"
-                        required={true}
-                        value={name}
-                        onChange={handleNameChange}
-                      />
-                    </div>
-                    <div className="col-md-2 sm-label-right">
-                      <span className="label-text">Label </span>
-                      <HelpField id="pipeline.config.parameter.label" />
-                    </div>
-                    <div className="col-md-4">
-                      <input className="form-control input-sm" type="text" value={label} onChange={handleLabelChange} />
-                    </div>
-                    <div className="col-md-1 col-md-offset-1">
-                      <Tooltip value="Remove parameter">
-                        <button className="btn btn-link glyphicon glyphicon-trash" onClick={removeParameter} />
-                      </Tooltip>
+            <fieldset disabled={inherited} className={classNames({ 'templated-pipeline-item': inherited })}>
+              <div className="form-horizontal panel-pipeline-phase">
+                <div className="row name-field">
+                  <div className="col-md-1">{isMultiple && <DragHandler />}</div>
+                  <label className="col-md-2 sm-label-right">
+                    <span className="label-text">Name</span>
+                  </label>
+                  <div className="col-md-9">
+                    <div className="row">
+                      <div className="col-md-4">
+                        <input
+                          className="form-control input-sm"
+                          type="text"
+                          required={true}
+                          value={name}
+                          onChange={handleNameChange}
+                        />
+                      </div>
+                      <div className="col-md-2 sm-label-right">
+                        <span className="label-text">Label </span>
+                        <HelpField id="pipeline.config.parameter.label" />
+                      </div>
+                      <div className="col-md-4">
+                        <input
+                          className="form-control input-sm"
+                          type="text"
+                          value={label}
+                          onChange={handleLabelChange}
+                        />
+                      </div>
+                      {!inherited && (
+                        <div className="col-md-1 col-md-offset-1">
+                          <Tooltip value="Remove parameter">
+                            <button className="btn btn-link glyphicon glyphicon-trash" onClick={removeParameter} />
+                          </Tooltip>
+                        </div>
+                      )}
                     </div>
                   </div>
                 </div>
-              </div>
 
-              <StageConfigField label="Required">
-                <div className="checkbox">
-                  <label>
-                    <input type="checkbox" checked={required} onChange={handleRequiredChange} />
-                  </label>
-                </div>
-              </StageConfigField>
-              <StageConfigField label="Pin Parameter" helpKey="pipeline.config.parameter.pinned">
-                <div className="checkbox">
-                  <label>
-                    <input type="checkbox" checked={pinned} onChange={handlePinnedChange} />
-                  </label>
-                </div>
-              </StageConfigField>
-
-              <StageConfigField label="Description" helpKey="pipeline.config.parameter.description">
-                <input
-                  className="form-control input-sm"
-                  type="text"
-                  value={description}
-                  onChange={handleDescriptionChange}
-                />
-              </StageConfigField>
-
-              <StageConfigField label="Default Value">
-                <input
-                  className="form-control input-sm"
-                  type="text"
-                  value={this.props.default}
-                  onChange={handleDefaultChange}
-                />
-              </StageConfigField>
-
-              <StageConfigField label="Show Options">
-                <div className="checkbox">
-                  <label>
-                    <input type="checkbox" checked={hasOptions} onChange={handleHasOptionChange} />
-                  </label>
-                </div>
-              </StageConfigField>
-
-              {hasOptions && (
-                <StageConfigField label="Options">
-                  {options.map(function(option: IParameterOption, index: number) {
-                    return (
-                      <div key={index} style={{ marginBottom: '5px' }}>
-                        <input
-                          className="col-md-4 form-control input-sm"
-                          style={{ width: '90%' }}
-                          type="text"
-                          value={option.value}
-                          onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
-                            handleOptionChange(index, event.target.value)
-                          }
-                        />
-                        <Tooltip value="Remove parameter">
-                          <button
-                            className="btn btn-link glyphicon glyphicon-trash"
-                            onClick={() => removeOption(index)}
-                          />
-                        </Tooltip>
-                      </div>
-                    );
-                  })}
-                  <button
-                    className="btn btn-sm btn-default add-new"
-                    onClick={() => addOption()}
-                    style={{ marginTop: '10px' }}
-                  >
-                    <span className="glyphicon glyphicon-plus-sign" /> Add New Option
-                  </button>
+                <StageConfigField label="Required">
+                  <div className="checkbox">
+                    <label>
+                      <input type="checkbox" checked={required} onChange={handleRequiredChange} />
+                    </label>
+                  </div>
                 </StageConfigField>
-              )}
-            </div>
+                <StageConfigField label="Pin Parameter" helpKey="pipeline.config.parameter.pinned">
+                  <div className="checkbox">
+                    <label>
+                      <input type="checkbox" checked={pinned} onChange={handlePinnedChange} />
+                    </label>
+                  </div>
+                </StageConfigField>
+
+                <StageConfigField label="Description" helpKey="pipeline.config.parameter.description">
+                  <input
+                    className="form-control input-sm"
+                    type="text"
+                    value={description}
+                    onChange={handleDescriptionChange}
+                  />
+                </StageConfigField>
+
+                <StageConfigField label="Default Value">
+                  <input
+                    className="form-control input-sm"
+                    type="text"
+                    value={this.props.default}
+                    onChange={handleDefaultChange}
+                  />
+                </StageConfigField>
+
+                <StageConfigField label="Show Options">
+                  <div className="checkbox">
+                    <label>
+                      <input type="checkbox" checked={hasOptions} onChange={handleHasOptionChange} />
+                    </label>
+                  </div>
+                </StageConfigField>
+
+                {hasOptions && (
+                  <StageConfigField label="Options">
+                    {options.map(function(option: IParameterOption, index: number) {
+                      return (
+                        <div key={index} style={{ marginBottom: '5px' }}>
+                          <input
+                            className="col-md-4 form-control input-sm"
+                            style={{ width: '90%' }}
+                            type="text"
+                            value={option.value}
+                            onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+                              handleOptionChange(index, event.target.value)
+                            }
+                          />
+                          {!inherited && (
+                            <Tooltip value="Remove parameter">
+                              <button
+                                className="btn btn-link glyphicon glyphicon-trash"
+                                onClick={() => removeOption(index)}
+                              />
+                            </Tooltip>
+                          )}
+                        </div>
+                      );
+                    })}
+                    <button
+                      className="btn btn-sm btn-default add-new"
+                      onClick={() => addOption()}
+                      style={{ marginTop: '10px' }}
+                    >
+                      <span className="glyphicon glyphicon-plus-sign" /> Add New Option
+                    </button>
+                  </StageConfigField>
+                )}
+              </div>
+            </fieldset>
           </div>
         </div>
       </div>

--- a/app/scripts/modules/core/src/pipeline/config/parameters/Parameters.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/parameters/Parameters.tsx
@@ -37,9 +37,11 @@ export class Parameters extends React.Component<IParametersProps, IParametersSta
   private togglePins = (): void => {
     const parameters = this.props.parameters.slice(0);
     const { allParametersPinned } = this.state;
-    parameters.forEach(param => {
-      param.pinned = !allParametersPinned;
-    });
+    parameters
+      .filter(param => !param.inherited)
+      .forEach(param => {
+        param.pinned = !allParametersPinned;
+      });
     this.props.updateAllParameters(parameters);
     this.setPinAllParametersState();
   };

--- a/app/scripts/modules/core/src/pipeline/config/pipelineConfig.controller.js
+++ b/app/scripts/modules/core/src/pipeline/config/pipelineConfig.controller.js
@@ -55,9 +55,14 @@ module.exports = angular
             this.pipelineConfig.isNew = true;
           }
 
-          if (!this.pipelineConfig.isNew) {
+          if (!this.pipelineConfig.isNew || isV2PipelineConfig) {
             return PipelineTemplateReader.getPipelinePlan(this.pipelineConfig, $stateParams.executionId)
-              .then(plan => (this.pipelinePlan = plan))
+              .then(plan => {
+                if (isV2PipelineConfig) {
+                  PipelineTemplateV2Service.inheritedKeys.forEach(key => (this.pipelineConfig[key] = plan[key] || []));
+                }
+                this.pipelinePlan = plan;
+              })
               .catch(error => {
                 this.templateError = error;
                 this.pipelineConfig.isNew = true;

--- a/app/scripts/modules/core/src/pipeline/config/pipelineConfig.less
+++ b/app/scripts/modules/core/src/pipeline/config/pipelineConfig.less
@@ -310,3 +310,12 @@ parameter,
     }
   }
 }
+
+.templated-pipeline-item {
+  pointer-events: none;
+  opacity: 0.75;
+}
+
+.templated-pipeline-item__status {
+  pointer-events: auto;
+}

--- a/app/scripts/modules/core/src/pipeline/config/services/PipelineConfigService.ts
+++ b/app/scripts/modules/core/src/pipeline/config/services/PipelineConfigService.ts
@@ -4,9 +4,11 @@ import { $q } from 'ngimport';
 
 import { API } from 'core/api/ApiService';
 import { AuthenticationService } from 'core/authentication/AuthenticationService';
+import { PipelineTemplateV2Service } from 'core/pipeline';
 import { ViewStateCache } from 'core/cache';
 import { IStage } from 'core/domain/IStage';
 import { IPipeline } from 'core/domain/IPipeline';
+import { SETTINGS } from 'core/config';
 
 export interface ITriggerPipelineResponse {
   eventId: string;
@@ -56,7 +58,7 @@ export class PipelineConfigService {
   }
 
   public static savePipeline(toSave: IPipeline): IPromise<void> {
-    const pipeline = cloneDeep(toSave);
+    let pipeline = cloneDeep(toSave);
     delete pipeline.isNew;
     pipeline.name = pipeline.name.trim();
     if (Array.isArray(pipeline.stages)) {
@@ -67,6 +69,10 @@ export class PipelineConfigService {
         }
       });
     }
+    if (SETTINGS.feature.managedPipelineTemplatesV2UI && PipelineTemplateV2Service.isV2PipelineConfig(pipeline)) {
+      pipeline = PipelineTemplateV2Service.filterInheritedConfig(pipeline) as IPipeline;
+    }
+
     return API.one(pipeline.strategy ? 'strategies' : 'pipelines')
       .data(pipeline)
       .post();

--- a/app/scripts/modules/core/src/pipeline/config/templates/v2/configurePipelineTemplateModalV2.html
+++ b/app/scripts/modules/core/src/pipeline/config/templates/v2/configurePipelineTemplateModalV2.html
@@ -34,7 +34,6 @@
   </div>
   <div ng-if="!ctrl.state.error" class="alert alert-info">
     <strong>Inherit the following configuration from the template</strong>
-    <p><input type="checkbox" ng-model="ctrl.state.inheritTemplateExpectedArtifacts" /> Expected Artifacts</p>
     <p><input type="checkbox" ng-model="ctrl.state.inheritTemplateNotifications" /> Notifications</p>
     <p><input type="checkbox" ng-model="ctrl.state.inheritTemplateParameters" /> Parameters</p>
     <p><input type="checkbox" ng-model="ctrl.state.inheritTemplateTriggers" /> Triggers</p>

--- a/app/scripts/modules/core/src/pipeline/config/templates/v2/pipelineTemplateV2.service.ts
+++ b/app/scripts/modules/core/src/pipeline/config/templates/v2/pipelineTemplateV2.service.ts
@@ -1,9 +1,16 @@
 import { hri as HumanReadableIds } from 'human-readable-ids';
 
-import { IPipeline, IPipelineTemplateConfigV2, IPipelineTemplateV2 } from 'core/domain';
+import { IPipeline, IPipelineTemplateConfigV2, IPipelineTemplateV2, ITemplateInheritable } from 'core/domain';
 import { PipelineJSONService } from 'core/pipeline/config/services/pipelineJSON.service';
 import { UUIDGenerator } from 'core/utils';
 import { SETTINGS } from 'core/config';
+
+enum InheritedItem {
+  Triggers = 'triggers',
+  Notifications = 'notifications',
+  ParameterConfig = 'parameterConfig',
+  ExpectedArtifacts = 'expectedArtifacts',
+}
 
 export class PipelineTemplateV2Service {
   public static createPipelineTemplate(pipeline: IPipeline, owner: string): IPipelineTemplateV2 {
@@ -59,5 +66,24 @@ export class PipelineTemplateV2Service {
     return SETTINGS.feature.managedPipelineTemplatesV2UI || !this.isV2PipelineConfig(pipelineConfig);
   }
 
+  public static filterInheritedConfig(pipelineConfig: Partial<IPipeline>) {
+    PipelineTemplateV2Service.inheritedKeys.forEach(key => {
+      if (Array.isArray(pipelineConfig[key])) {
+        const configCollection = pipelineConfig[key];
+        pipelineConfig[key] = (configCollection as ITemplateInheritable[]).filter(
+          item => !item.inherited,
+        ) as typeof configCollection;
+      }
+    });
+    return pipelineConfig;
+  }
+
   private static schema = 'v2';
+
+  public static inheritedKeys: Set<InheritedItem> = new Set([
+    InheritedItem.Triggers,
+    InheritedItem.Notifications,
+    InheritedItem.ParameterConfig,
+    InheritedItem.ExpectedArtifacts,
+  ]);
 }

--- a/app/scripts/modules/core/src/pipeline/config/triggers/trigger.html
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/trigger.html
@@ -1,102 +1,111 @@
 <div class="row">
   <div class="col-md-12">
-    <div class="form-horizontal panel-pipeline-phase">
-      <div class="form-group row">
-        <div class="col-md-10">
-          <div class="row">
-            <label class="col-md-3 sm-label-right">Type</label>
-            <div class="col-md-9">
-              <select
-                class="input-sm"
-                ng-change="triggerCtrl.loadTrigger()"
-                ng-options="option.key as option.label for option in options"
-                ng-model="trigger.type"
-              >
-                <option value="">Select...</option>
-              </select>
-              {{description}}
+    <fieldset ng-disabled="trigger.inherited" ng-class="{'templated-pipeline-item': trigger.inherited}">
+      <div class="form-horizontal panel-pipeline-phase">
+        <div class="form-group row">
+          <div class="col-md-10">
+            <div class="row">
+              <label class="col-md-3 sm-label-right">Type</label>
+              <div class="col-md-9">
+                <select
+                  class="input-sm"
+                  ng-change="triggerCtrl.loadTrigger()"
+                  ng-options="option.key as option.label for option in options"
+                  ng-model="trigger.type"
+                >
+                  <option value="">Select...</option>
+                </select>
+                {{ description }}
+              </div>
             </div>
           </div>
-        </div>
-        <div class="col-md-2 text-right">
-          <button class="btn btn-sm btn-default" ng-click="triggerCtrl.removeTrigger(trigger)">
-            <span class="glyphicon glyphicon-trash" uib-tooltip="Remove trigger"></span>
-            <span class="visible-xl-inline">Remove trigger</span>
-          </button>
-        </div>
-      </div>
-      <div class="form-group">
-        <div class="col-md-10">
-          <div class="trigger-body"></div>
-        </div>
-      </div>
-      <div
-        class="form-group"
-        ng-if="!triggerCtrl.checkFeatureFlag('artifactsRewrite') && triggerCtrl.checkFeatureFlag('artifacts') && pipeline.expectedArtifacts.length > 0"
-      >
-        <div class="col-md-10">
-          <div class="form-group">
-            <label class="col-md-3 sm-label-right"
-              >Artifact Constraints<help-field key="pipeline.config.expectedArtifact"></help-field
-            ></label>
-            <div class="col-md-9">
-              <ui-select
-                ng-if="pipeline.expectedArtifacts.length"
-                multiple
-                ng-model="trigger.expectedArtifactIds"
-                class="form-control input-sm"
-              >
-                <ui-select-match>{{ $item.displayName }}</ui-select-match>
-                <ui-select-choices repeat="expected.id as expected in pipeline.expectedArtifacts">
-                  <span>{{ expected.displayName }}</span>
-                </ui-select-choices>
-              </ui-select>
-            </div>
+          <div class="col-md-2 text-right" ng-if="!trigger.inherited">
+            <button class="btn btn-sm btn-default" ng-click="triggerCtrl.removeTrigger(trigger)">
+              <span class="glyphicon glyphicon-trash" uib-tooltip="Remove trigger"></span>
+              <span class="visible-xl-inline">Remove trigger</span>
+            </button>
+          </div>
+          <div class="col-md-2 text-right" ng-if="trigger.inherited">
+            <span class="templated-pipeline-item__status btn btn-sm btn-default">
+              <i class="from-template fa fa-table" title="From template" uib-tooltip="From Template"></i>
+              <span class="visible-xl-inline">From Template</span>
+            </span>
           </div>
         </div>
-      </div>
-      <render-if-feature feature="artifactsRewrite">
         <div class="form-group">
+          <div class="col-md-10">
+            <div class="trigger-body"></div>
+          </div>
+        </div>
+        <div
+          class="form-group"
+          ng-if="!triggerCtrl.checkFeatureFlag('artifactsRewrite') && triggerCtrl.checkFeatureFlag('artifacts') && pipeline.expectedArtifacts.length > 0"
+        >
           <div class="col-md-10">
             <div class="form-group">
               <label class="col-md-3 sm-label-right"
                 >Artifact Constraints<help-field key="pipeline.config.expectedArtifact"></help-field
               ></label>
-              <div class="col-md-9 row">
-                <trigger-artifact-constraint-selector-react
-                  pipeline="pipeline"
-                  trigger="trigger"
-                  selected="trigger.expectedArtifactIds"
-                  on-define-expected-artifact="triggerCtrl.defineExpectedArtifact"
-                  on-change-selected="triggerCtrl.changeExpectedArtifacts"
-                ></trigger-artifact-constraint-selector-react>
+              <div class="col-md-9">
+                <ui-select
+                  ng-if="pipeline.expectedArtifacts.length"
+                  multiple
+                  ng-model="trigger.expectedArtifactIds"
+                  class="form-control input-sm"
+                  ng-disabled="trigger.inherited"
+                >
+                  <ui-select-match>{{ $item.displayName }}</ui-select-match>
+                  <ui-select-choices repeat="expected.id as expected in pipeline.expectedArtifacts">
+                    <span>{{ expected.displayName }}</span>
+                  </ui-select-choices>
+                </ui-select>
               </div>
             </div>
           </div>
         </div>
-      </render-if-feature>
-      <div class="form-group" ng-if="trigger.type && !triggerCtrl.disableAutoTriggering.includes(trigger.type)">
-        <div class="col-md-10">
-          <div class="row">
-            <div class="col-md-9 col-md-offset-3 checkbox">
-              <label><input type="checkbox" ng-model="trigger.enabled" ng-value="true" /> Trigger Enabled</label>
+        <render-if-feature feature="artifactsRewrite">
+          <div class="form-group">
+            <div class="col-md-10">
+              <div class="form-group">
+                <label class="col-md-3 sm-label-right"
+                  >Artifact Constraints<help-field key="pipeline.config.expectedArtifact"></help-field
+                ></label>
+                <div class="col-md-9 row">
+                  <trigger-artifact-constraint-selector-react
+                    pipeline="pipeline"
+                    trigger="trigger"
+                    selected="trigger.expectedArtifactIds"
+                    on-define-expected-artifact="(triggerCtrl.defineExpectedArtifact)"
+                    on-change-selected="(triggerCtrl.changeExpectedArtifacts)"
+                  ></trigger-artifact-constraint-selector-react>
+                </div>
+              </div>
+            </div>
+          </div>
+        </render-if-feature>
+        <div class="form-group" ng-if="trigger.type && !triggerCtrl.disableAutoTriggering.includes(trigger.type)">
+          <div class="col-md-10">
+            <div class="row">
+              <div class="col-md-9 col-md-offset-3 checkbox">
+                <label><input type="checkbox" ng-model="trigger.enabled" ng-value="true" /> Trigger Enabled</label>
+              </div>
             </div>
           </div>
         </div>
-      </div>
-      <div class="form-group" ng-if="trigger.type && triggerCtrl.disableAutoTriggering.includes(trigger.type)">
-        <div class="col-md-10 col-md-offset-1">
-          <div class="row">
-            <div class="col-md-8 col-md-offset-3">
-              <div class="alert alert-warning">
-                Automatic triggering is disabled for this trigger type. You can still use this as a trigger to supply
-                data to downstream stages, but will need to manually execute this pipeline.
+        <div class="form-group" ng-if="trigger.type && triggerCtrl.disableAutoTriggering.includes(trigger.type)">
+          <div class="col-md-10 col-md-offset-1">
+            <div class="row">
+              <div class="col-md-8 col-md-offset-3">
+                <div class="alert alert-warning">
+                  Automatic triggering is disabled for this trigger type. You can still use this as a trigger to supply
+                  data to downstream stages, but will need to manually execute this pipeline.
+                </div>
               </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
+    </fieldset>
     <div class="stage-details">
       <div class="row">
         <div class="stage-body"></div>


### PR DESCRIPTION
MPTv1 saved inherited items (notifications, triggers, parameters) directly to the pipeline config which allowed them to be displayed while configuring in deck. MPTv2 pipelines saved in spin do not save them to the pipeline config and instead rely on them being inherited during the plan phase. This PR renders items inherited from the plan and marks them as read only since they cannot be edited or deleted directly through the pipeline config.

https://github.com/spinnaker/spinnaker/issues/4451

Inherited Trigger
![image](https://user-images.githubusercontent.com/2623242/59228232-51d09680-8ba5-11e9-8f82-6db97fb420f9.png)

Inherited Notification
![image](https://user-images.githubusercontent.com/2623242/59228325-7d538100-8ba5-11e9-9b31-71c83046c65e.png)

Inherited Parameter
![image](https://user-images.githubusercontent.com/2623242/59228410-be4b9580-8ba5-11e9-8164-924371e4e71d.png)

