### PR TITLE
perf(google): avoid unnecessary fetching and filtering of gce images

### DIFF
--- a/app/scripts/modules/google/src/serverGroup/configure/serverGroupConfiguration.service.js
+++ b/app/scripts/modules/google/src/serverGroup/configure/serverGroupConfiguration.service.js
@@ -90,7 +90,7 @@ module.exports = angular
         } else {
           imageLoader = command.viewState.imageId
             ? loadImagesFromImageName(command)
-            : loadImagesFromApplicationName(application, command.selectedProvider);
+            : loadImagesFromApplicationName(application, command.selectedProvider, command.credentials);
         }
 
         return $q
@@ -101,7 +101,7 @@ module.exports = angular
             subnets: SubnetReader.listSubnetsByProvider('gce'),
             loadBalancers: loadBalancerReader.listLoadBalancers('gce'),
             packageImages: imageLoader,
-            allImages: loadAllImages(),
+            allImages: loadAllImages(command.credentials),
             instanceTypes: gceInstanceTypeService.getAllTypesByRegion(),
             persistentDiskTypes: $q.when(angular.copy(persistentDiskTypes)),
             authScopes: $q.when(angular.copy(authScopes)),
@@ -153,16 +153,18 @@ module.exports = angular
           });
       }
 
-      function loadImagesFromApplicationName(application, provider) {
+      function loadImagesFromApplicationName(application, provider, account) {
         return gceImageReader.findImages({
+          account: account,
           provider: provider,
           q: application.name.replace(/_/g, '[_\\-]') + '*',
         });
       }
 
       // Used to populate the image selection dropdowns in the persistent disk configurer.
-      function loadAllImages() {
+      function loadAllImages(account) {
         return gceImageReader.findImages({
+          account: account,
           provider: 'gce',
           q: '*',
         });
@@ -181,6 +183,7 @@ module.exports = angular
         }
 
         return gceImageReader.findImages({
+          account: command.credentials,
           provider: command.selectedProvider,
           q: packageBase + '*',
         });

--- a/app/scripts/modules/google/src/serverGroup/configure/wizard/advancedSettings/diskConfigurer.component.ts
+++ b/app/scripts/modules/google/src/serverGroup/configure/wizard/advancedSettings/diskConfigurer.component.ts
@@ -159,7 +159,7 @@ const gceDiskConfigurer: IComponentOptions = {
                            class="form-control input-sm"
                            required>
                   <ui-select-match placeholder="Select an image...">{{$select.selected.imageName || 'Select an image...'}}</ui-select-match>
-                  <ui-select-choices repeat="image.imageName as image in $ctrl.command.backingData.allImages | filter: { account: $ctrl.command.credentials } | orderBy: 'imageName'">
+                  <ui-select-choices repeat="image.imageName as image in $ctrl.command.backingData.allImages | filter: { imageName: $select.search }">
                     <span ng-bind-html="image.imageName | highlight: $select.search"></span>
                   </ui-select-choices>
                 </ui-select>

--- a/app/scripts/modules/google/src/serverGroup/configure/wizard/location/basicSettings.html
+++ b/app/scripts/modules/google/src/serverGroup/configure/wizard/location/basicSettings.html
@@ -10,6 +10,7 @@
           field="credentials"
           accounts="command.backingData.accounts"
           provider="'gce'"
+          on-change="basicSettingsCtrl.accountUpdated()"
         ></account-select-field>
       </div>
     </div>
@@ -124,12 +125,8 @@
             >{{$select.selected.imageName || 'Search for an image...'}}</ui-select-match
           >
           <ui-select-choices
-            repeat="result.imageName as result in command.backingData.filtered.images | filter: { account: command.credentials } | orderBy: 'imageName'"
-            refresh="basicSettingsCtrl.searchImages($select.search)"
-            ui-disable-choice="result.message"
-            reset-search-input="false"
+            repeat="result.imageName as result in command.backingData.allImages | filter: { imageName: $select.search }"
           >
-            <span ng-bind-html="result.message"></span>
             <span ng-bind-html="result.imageName | highlight: $select.search"></span>
           </ui-select-choices>
         </ui-select>
@@ -138,7 +135,7 @@
         <ui-select class="form-control input-sm" required ng-model="command.image">
           <ui-select-match placeholder="Pick an image">{{$select.selected.imageName}}</ui-select-match>
           <ui-select-choices
-            repeat="image.imageName as image in command.backingData.filtered.images | filter: { imageName: $select.search } | orderBy: '-imageName'"
+            repeat="image.imageName as image in command.backingData.allImages | filter: { imageName: $select.search }"
           >
             <span ng-bind-html="image.imageName | highlight: $select.search"></span>
           </ui-select-choices>


### PR DESCRIPTION
Addresses https://github.com/spinnaker/spinnaker/issues/4510

- [perf] Removes unnecessary client-side alphabetization of image names: Clouddriver already alphabetizes image results [here](https://github.com/spinnaker/clouddriver/blob/master/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/controllers/GoogleNamedImageLookupController.java#L118).
- [perf] Removes client-side filtration of images by account; adds account as image request parameter.
- [ux enhancement] Filters options by search text in image select dropdowns rather than only highlighting the matching text without actually removing non-matching options.
- [perf] Since we have already fetched all available account images to populate the persistent disk configuration, do not re-fetch images for Basic Settings component. Also do not re-fetch images as user types a search query; rely on client-side filtration only.

Upcoming work: server-side performance enhancements