### PR TITLE
fix(pipeline): fix invisible parameter when default is not in options

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/pipeline/pipelineStage.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/pipeline/pipelineStage.js
@@ -93,6 +93,11 @@ module.exports = angular
               $scope.stage.pipelineParameters = {};
             }
             $scope.pipelineParameters = config.parameterConfig;
+            $scope.pipelineParameters.forEach(parameterConfig => {
+              if (parameterConfig.default && parameterConfig.options && !parameterConfig.options.some(option => option.value === parameterConfig.default)) {
+                parameterConfig.options.unshift({ value: parameterConfig.default });
+              }
+            })
             $scope.userSuppliedParameters = $scope.stage.pipelineParameters;
 
             if ($scope.pipelineParameters) {

--- a/app/scripts/modules/core/src/pipeline/config/stages/pipeline/pipelineStage.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/pipeline/pipelineStage.js
@@ -94,10 +94,14 @@ module.exports = angular
             }
             $scope.pipelineParameters = config.parameterConfig;
             $scope.pipelineParameters.forEach(parameterConfig => {
-              if (parameterConfig.default && parameterConfig.options && !parameterConfig.options.some(option => option.value === parameterConfig.default)) {
+              if (
+                parameterConfig.default &&
+                parameterConfig.options &&
+                !parameterConfig.options.some(option => option.value === parameterConfig.default)
+              ) {
                 parameterConfig.options.unshift({ value: parameterConfig.default });
               }
-            })
+            });
             $scope.userSuppliedParameters = $scope.stage.pipelineParameters;
 
             if ($scope.pipelineParameters) {


### PR DESCRIPTION
In the pipeline stage's stage config, if a parameter has options and the parameter's default is not part of the options, it will be invisible.

This fix injects the default into the list of options and also fixes the invisibility (because it is an option, it no longer is invisible).