### PR TITLE
fix(core/pipeline): stop searching stage context, being greedy about parentExecutions

### DIFF
--- a/app/scripts/modules/core/src/help/help.contents.ts
+++ b/app/scripts/modules/core/src/help/help.contents.ts
@@ -52,7 +52,6 @@ const helpContents: { [key: string]: string } = {
       <ul>
         <li>Name</li>
         <li>Trigger</li>
-        <li>Context - server groups, bakery results, etc.</li>
       </ul>`,
   'pipeline.config.triggers.respectQuietPeriod': `
       <p>The quiet period is a system operator designated period of time when automated pipelines and deploys should not run.</p>`,

--- a/app/scripts/modules/core/src/pipeline/filter/executionFilter.service.ts
+++ b/app/scripts/modules/core/src/pipeline/filter/executionFilter.service.ts
@@ -136,7 +136,6 @@ export class ExecutionFilterService {
     }
     const searchText = [execution.name];
     searchText.push(execution.id);
-    searchText.push(this.getValuesAsString(execution.appConfig));
     searchText.push(this.getValuesAsString(execution.trigger, ['parentExecution']));
 
     execution.searchField = searchText.join(' ').toLowerCase();

--- a/app/scripts/modules/core/src/pipeline/filter/executionFilter.service.ts
+++ b/app/scripts/modules/core/src/pipeline/filter/executionFilter.service.ts
@@ -137,10 +137,8 @@ export class ExecutionFilterService {
     const searchText = [execution.name];
     searchText.push(execution.id);
     searchText.push(this.getValuesAsString(execution.appConfig));
-    searchText.push(this.getValuesAsString(execution.trigger));
-    execution.stages.forEach(stage =>
-      searchText.push(this.getValuesAsString(stage.context, ['commits', 'jarDiffs', 'kato.tasks'])),
-    );
+    searchText.push(this.getValuesAsString(execution.trigger, ['parentExecution']));
+
     execution.searchField = searchText.join(' ').toLowerCase();
   }
 


### PR DESCRIPTION
Historically, we let folks to a text search on the name, id, trigger, and stage context of an execution. Later we stopped actually loading in full stage context data for un-expanded executions to improve some performance problems, but that had the side effect of making context search pretty weird and seemingly non-deterministic from a user point of view (due to not knowing whether a value would be available or left out of search).

Two changes:
- Stop giving people weird experiences trying to guess what's searchable and what's not by no longer searching in stage context. This leaves name, id, and all the trigger fields. There's some help text about what you can search for that has been updated too
- Fix an _awesome_ bug with `parentExecution` fields on triggers: we were trying to stringify all the fields (including nesting) on each trigger, but sometimes that includes a `parentExecution`. Because we didn't explicitly omit that field, we'd end up also making _every single value_ in the entire parent execution available for searching on the child. This has lead to some totally bizarre search results

In a perfect world with infinite time, it'd be nice to use a backend search that could do more advanced filtering and continue to let people search in stage context, but in the near-term I'm making the case that our current user confusion is worse than not being able to search in context at all.

