### PR TITLE
fix(core): filter falsy error messages from errors object on tasks

### DIFF
--- a/app/scripts/modules/core/src/orchestratedItem/orchestratedItem.transformer.ts
+++ b/app/scripts/modules/core/src/orchestratedItem/orchestratedItem.transformer.ts
@@ -1,5 +1,6 @@
 import { distanceInWords } from 'date-fns';
 import { $log } from 'ngimport';
+import { get } from 'lodash';
 
 import { IOrchestratedItem, IOrchestratedItemVariable, ITask, ITaskStep } from 'core/domain';
 import { ReactInjector } from 'core/reactShims';
@@ -161,8 +162,9 @@ export class OrchestratedItemTransformer {
   private static getGeneralException(task: ITask): string {
     const generalException: any = task.getValueFor('exception');
     if (generalException) {
-      if (generalException.details && generalException.details.errors && generalException.details.errors.length) {
-        return generalException.details.errors.join(', ');
+      const errors = get(generalException, 'details.errors', []).filter(m => !!m);
+      if (errors.length) {
+        return errors.join(', ');
       }
       if (generalException.details && generalException.details.error) {
         return generalException.details.error;


### PR DESCRIPTION
Worth digging into the backend, but we ran into an internal error that resulted in `"errors": [null]`, so we should filter those out and surface the `"error"` field, if it's present.