### PR TITLE
fix(core): provide key for repeating param JSX elements

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/pipeline/PipelineParametersExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/pipeline/PipelineParametersExecutionDetails.tsx
@@ -20,10 +20,10 @@ export function PipelineParametersExecutionDetails(props: IExecutionDetailsSecti
             {Object.keys(parameters)
               .sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()))
               .map(key => (
-                <>
+                <React.Fragment key={key}>
                   <dt>{key}</dt>
                   <dd>{parameters[key]}</dd>
-                </>
+                </React.Fragment>
               ))}
           </dl>
         </div>


### PR DESCRIPTION
React gets a little whiny about repeating nodes without keys.