### PR TITLE
fix(provider/openstack): Properly set the attributes of a strtegy pipeline

### DIFF
--- a/app/scripts/modules/openstack/src/serverGroup/configure/serverGroupConfiguration.service.js
+++ b/app/scripts/modules/openstack/src/serverGroup/configure/serverGroupConfiguration.service.js
@@ -49,9 +49,9 @@ module.exports = angular
             securityGroups: securityGroupReader.getAllSecurityGroups(),
             loadBalancers: loadBalancerReader.loadLoadBalancers(application.name),
             userDataTypes: $q.when(angular.copy(userDataTypes)),
+            accounts: AccountService.listAccounts('openstack'),
           })
           .then(function(backingData) {
-            backingData.accounts = _.keys(backingData.credentialsKeyedByAccount);
             backingData.filtered = {};
             command.backingData = backingData;
             backingData.filtered.securityGroups = getRegionalSecurityGroups(command);

--- a/app/scripts/modules/openstack/src/serverGroup/serverGroup.transformer.js
+++ b/app/scripts/modules/openstack/src/serverGroup/serverGroup.transformer.js
@@ -52,6 +52,8 @@ module.exports = angular
           userData: base.userData,
           serverGroupParameters: params,
           strategy: base.strategy,
+          strategyPipeline: base.strategyPipeline,
+          strategyApplication: base.strategyApplication,
         };
 
         if (base.viewState.mode === 'clone' && base.source) {


### PR DESCRIPTION
The openstack clouddriver in Deck does not properly set the ID of a strategy pipeline when used as a custom step in a deploy pipeline.

This makes Orca fail the lookup of the strategy pipeline when executing the deployment. The pull request is aimed at properly setting the required attributes.