### PR TITLE
feat(artifacts): find multiple artifacts from single execution

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/findArtifactFromExecution/FindArtifactFromExecutionExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/findArtifactFromExecution/FindArtifactFromExecutionExecutionDetails.tsx
@@ -8,32 +8,36 @@ import {
 } from 'core/pipeline';
 import { JsonUtils } from 'core/utils';
 
-export function FindArtifactFromExecutionExecutionDetails(props: IExecutionDetailsSectionProps) {
-  const { stage } = props;
+export class FindArtifactFromExecutionExecutionDetails extends React.Component<IExecutionDetailsSectionProps> {
+  public static title = 'artifactDetails';
+  public render() {
+    const { current, name, stage } = this.props;
 
-  return (
-    <ExecutionDetailsSection name={props.name} current={props.current}>
-      <div className="row">
-        <div className="col-md-9">
-          <dl className="dl-narrow dl-horizontal">
-            <dt>Match Artifact</dt>
-            <dd>{JsonUtils.makeSortedStringFromObject(stage.context.expectedArtifact.matchArtifact)}</dd>
-            {stage.context.expectedArtifact.useDefaultArtifact && <dt>Default Artifact</dt>}
-            {stage.context.expectedArtifact.useDefaultArtifact && (
-              <dd>{JsonUtils.makeSortedStringFromObject(stage.context.expectedArtifact.defaultArtifact)}</dd>
-            )}
-          </dl>
+    // Prior versions of this stage accepted only one expected artifact.
+    const expectedArtifacts = Array.isArray(stage.context.expectedArtifacts)
+      ? stage.context.expectedArtifacts
+      : [stage.context.expectedArtifact];
+
+    return (
+      <ExecutionDetailsSection name={name} current={current}>
+        <div className="row">
+          {expectedArtifacts.map(expectedArtifact => (
+            <div key={expectedArtifact.id}>
+              <h5>{expectedArtifact.displayName}</h5>
+              <div>Match Artifact</div>
+              <pre>{JsonUtils.makeSortedStringFromObject(expectedArtifact.matchArtifact)}</pre>
+              {expectedArtifact.useDefaultArtifact && (
+                <>
+                  <div>Default Artifact</div>
+                  <pre>{JsonUtils.makeSortedStringFromObject(expectedArtifact.defaultArtifact)}</pre>
+                </>
+              )}
+            </div>
+          ))}
         </div>
-      </div>
-
-      <StageFailureMessage stage={stage} message={stage.outputs.exception} />
-      <StageExecutionLogs stage={stage} />
-    </ExecutionDetailsSection>
-  );
-}
-
-// TODO: refactor this to not use namespace
-// eslint-disable-next-line
-export namespace FindArtifactFromExecutionExecutionDetails {
-  export const title = 'findArtifactFromExecutionConfig';
+        <StageFailureMessage stage={stage} message={stage.outputs.exception} />
+        <StageExecutionLogs stage={stage} />
+      </ExecutionDetailsSection>
+    );
+  }
 }

--- a/app/scripts/modules/core/src/pipeline/config/stages/findArtifactFromExecution/findArtifactFromExecution.controller.spec.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/findArtifactFromExecution/findArtifactFromExecution.controller.spec.ts
@@ -19,7 +19,7 @@ describe('Find Artifact From Execution Controller:', function() {
 
   it('properly initializes an empty stage', () => {
     initializeController({});
-    const expectedArtifact = ctrl.stage.expectedArtifact;
+    const expectedArtifact = ctrl.stage.expectedArtifacts[0];
     const executionOptions: any = ctrl.stage.executionOptions;
 
     expect(executionOptions).toBeDefined();
@@ -41,7 +41,7 @@ describe('Find Artifact From Execution Controller:', function() {
       executionOptions: existingExecutionOptions,
     });
 
-    const expectedArtifact = ctrl.stage.expectedArtifact;
+    const expectedArtifact = ctrl.stage.expectedArtifacts[0];
     const executionOptions: any = ctrl.stage.executionOptions;
 
     expect(executionOptions).toBeDefined();
@@ -67,7 +67,7 @@ describe('Find Artifact From Execution Controller:', function() {
       expectedArtifact: existingExpectedArtifact,
     });
 
-    const expectedArtifact: any = ctrl.stage.expectedArtifact;
+    const expectedArtifact: any = ctrl.stage.expectedArtifacts[0];
 
     expect(expectedArtifact).toBeDefined();
     expect(expectedArtifact.id).toEqual(existingExpectedArtifact.id);
@@ -99,7 +99,7 @@ describe('Find Artifact From Execution Controller:', function() {
       expectedArtifact: existingExpectedArtifact,
     });
 
-    const expectedArtifact: any = ctrl.stage.expectedArtifact;
+    const expectedArtifact: any = ctrl.stage.expectedArtifacts[0];
 
     expect(expectedArtifact).toBeDefined();
     expect(expectedArtifact.id).toEqual(existingExpectedArtifact.id);

--- a/app/scripts/modules/core/src/pipeline/config/stages/findArtifactFromExecution/findArtifactFromExecutionConfig.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/findArtifactFromExecution/findArtifactFromExecutionConfig.html
@@ -41,6 +41,18 @@
       <label> <input type="checkbox" ng-model="ctrl.stage.executionOptions.running" /> that are still running </label>
     </div>
   </div>
-  <h4>Match Artifact</h4>
-  <expected-artifact expected-artifact="ctrl.stage.expectedArtifact"></expected-artifact>
+  <h4>Match Artifacts</h4>
+  <expected-artifact
+    ng-repeat="artifact in ctrl.stage.expectedArtifacts"
+    context="ctrl.stage"
+    expected-artifact="artifact"
+    remove-expected-artifact="ctrl.removeExpectedArtifact"
+  />
+  <div class="row">
+    <div class="col-md-12">
+      <button class="btn btn-block btn-add-trigger add-new" ng-click="ctrl.addExpectedArtifact()">
+        <span class="glyphicon glyphicon-plus-sign"></span> Add Artifact
+      </button>
+    </div>
+  </div>
 </div>

--- a/app/scripts/modules/core/src/pipeline/config/stages/findArtifactFromExecution/findArtifactFromExecutionStage.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/findArtifactFromExecution/findArtifactFromExecutionStage.ts
@@ -14,8 +14,8 @@ module(FIND_ARTIFACT_FROM_EXECUTION_STAGE, [])
   .config(() => {
     if (SETTINGS.feature.artifacts) {
       Registry.pipeline.registerStage({
-        label: 'Find Artifact From Execution',
-        description: 'Find and bind an artifact from another execution',
+        label: 'Find Artifacts From Execution',
+        description: 'Find and bind artifacts from another execution',
         key: 'findArtifactFromExecution',
         templateUrl: require('./findArtifactFromExecutionConfig.html'),
         controller: 'findArtifactFromExecutionCtrl',


### PR DESCRIPTION
Closes https://github.com/spinnaker/spinnaker/issues/4354
Orca PR: https://github.com/spinnaker/orca/pull/3006

- Enables the selection of multiple artifacts in the Find Artifact from Execution stage.
- Makes minor UI changes to Find Artifact execution details tab.

Before:
![before](https://user-images.githubusercontent.com/15936279/59952075-f7f38a80-9448-11e9-90be-494f13c6a6cd.png)

After:
![after](https://user-images.githubusercontent.com/15936279/59952077-fcb83e80-9448-11e9-8058-6d6fb4acc8a6.png)

