### PR TITLE
feat(core): allow users to override pipeline graph positions

### DIFF
--- a/app/scripts/modules/core/src/domain/IExecutionStage.ts
+++ b/app/scripts/modules/core/src/domain/IExecutionStage.ts
@@ -59,6 +59,7 @@ export interface IExecutionStageSummary extends IOrchestratedItem {
   endTime: number;
   extraLabelLines?: (stage: IExecutionStageSummary) => number;
   firstActiveStage?: number;
+  graphRowOverride?: number;
   group?: string;
   groupStages?: IExecutionStageSummary[];
   id: string;

--- a/app/scripts/modules/core/src/pipeline/config/graph/PipelineGraph.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/graph/PipelineGraph.tsx
@@ -194,6 +194,7 @@ export class PipelineGraph extends React.Component<IPipelineGraphProps, IPipelin
             }
             return 0;
           },
+          (node: IPipelineGraphNode) => (node.graphRowOverride ? node.graphRowOverride : 1000),
           // same highest parent, prefer farthest last node
           (node: IPipelineGraphNode) => 1 - node.lastPhase,
           // same highest parent, prefer fewer terminal children if any

--- a/app/scripts/modules/core/src/pipeline/config/graph/pipelineGraph.service.ts
+++ b/app/scripts/modules/core/src/pipeline/config/graph/pipelineGraph.service.ts
@@ -32,6 +32,7 @@ export interface IPipelineGraphNode {
   parents: IPipelineGraphNode[];
   placeholder?: boolean;
   root?: boolean;
+  graphRowOverride?: number;
   row?: number; // Added after the fact in PipelineGraphDirective
   x?: number; // Added after the fact in PipelineGraphDirective
   y?: number; // Added after the fact in PipelineGraphDirective
@@ -70,6 +71,7 @@ export class PipelineGraphService {
         executionId: execution.id,
         executionStage: true,
         extraLabelLines: stage.extraLabelLines ? stage.extraLabelLines(stage) : 0,
+        graphRowOverride: stage.graphRowOverride || 0,
         hasNotStarted: stage.hasNotStarted,
         id: stage.refId,
         index: idx,
@@ -120,6 +122,7 @@ export class PipelineGraphService {
       const node: IPipelineGraphNode = {
         childLinks: [],
         children: [],
+        graphRowOverride: stage.graphRowOverride || 0,
         hasWarnings: !!warnings,
         id: stage.refId,
         index: idx,

--- a/app/scripts/modules/core/src/pipeline/service/ExecutionsTransformer.ts
+++ b/app/scripts/modules/core/src/pipeline/service/ExecutionsTransformer.ts
@@ -360,6 +360,7 @@ export class ExecutionsTransformer {
           group: context.group,
           id: stage.id,
           index: undefined,
+          graphRowOverride: context.graphRowOverride || 0,
           masterStage: stage,
           name: stage.name,
           refId: stage.refId,


### PR DESCRIPTION
We've had a few requests over the years from users who want more control in the rendering of the pipeline graph. We work very hard to minimize a) the overlapping lines and b) the length of the lines.

Sometimes users want to override this. This PR provide that ability by adding another field to the stage JSON.

Not sure about the field name (does `graphRowOverride` make any sense) or about how to document this. I feel like it should be documented beyond "in the code" and "tribal knowledge". Feelings?