### PR TITLE
fix(webhooks): addresses issue 3450 - introduce a delay before polling webhook

### DIFF
--- a/app/scripts/modules/core/src/help/help.contents.ts
+++ b/app/scripts/modules/core/src/help/help.contents.ts
@@ -412,6 +412,10 @@ const helpContents: { [key: string]: string } = {
     "Pick the status url from the JSON returned by the webhook's response call.",
   'pipeline.config.webhook.statusUrlJsonPath':
     "JSON path to the status url in the webhook's response JSON. (i.e. <samp>$.buildInfo.url</samp>)",
+  'pipeline.config.webhook.retryStatusCodes':
+    'Normally, webhook stage only retries on 429 and 5xx status codes. <br>You can specify additional status codes here that will cause the monitor to retry (e.g. <samp>404, 418</samp>)',
+  'pipeline.config.webhook.waitBeforeMonitor':
+    'Optional delay (in seconds) to wait before starting to poll the endpoint for monitoring status',
   'pipeline.config.webhook.statusJsonPath':
     "JSON path to the status information in the webhook's response JSON. (e.g. <samp>$.buildInfo.status</samp>)",
   'pipeline.config.webhook.progressJsonPath':

--- a/app/scripts/modules/core/src/help/help.contents.ts
+++ b/app/scripts/modules/core/src/help/help.contents.ts
@@ -413,7 +413,7 @@ const helpContents: { [key: string]: string } = {
   'pipeline.config.webhook.statusUrlJsonPath':
     "JSON path to the status url in the webhook's response JSON. (i.e. <samp>$.buildInfo.url</samp>)",
   'pipeline.config.webhook.retryStatusCodes':
-    'Normally, webhook stage only retries on 429 and 5xx status codes. <br>You can specify additional status codes here that will cause the monitor to retry (e.g. <samp>404, 418</samp>)',
+    'Normally, webhook stages only retry on 429 and 5xx status codes. <br>You can specify additional status codes here that will cause the monitor to retry (e.g. <samp>404, 418</samp>)',
   'pipeline.config.webhook.waitBeforeMonitor':
     'Optional delay (in seconds) to wait before starting to poll the endpoint for monitoring status',
   'pipeline.config.webhook.statusJsonPath':

--- a/app/scripts/modules/core/src/pipeline/config/stages/webhook/webhookStage.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/webhook/webhookStage.html
@@ -158,6 +158,25 @@
       </div>
     </div>
     <stage-config-field
+      label="Delay before monitoring"
+      help-key="pipeline.config.webhook.waitBeforeMonitor"
+      ng-if="$ctrl.displayField('waitBeforeMonitor')"
+    >
+      <input type="text" class="form-control input-sm" ng-model="$ctrl.stage.waitBeforeMonitor" />
+    </stage-config-field>
+    <stage-config-field
+      label="Retry HTTP Statuses"
+      help-key="pipeline.config.webhook.retryStatusCodes"
+      ng-if="$ctrl.displayField('retryStatusCodes')"
+    >
+      <input
+        type="text"
+        class="form-control input-sm"
+        ng-model="$ctrl.viewState.retryStatusCodes"
+        ng-change="$ctrl.retryCodesChanged()"
+      />
+    </stage-config-field>
+    <stage-config-field
       label="Status JsonPath"
       help-key="pipeline.config.webhook.statusJsonPath"
       ng-if="$ctrl.displayField('statusJsonPath')"

--- a/app/scripts/modules/core/src/pipeline/config/stages/webhook/webhookStage.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/webhook/webhookStage.ts
@@ -9,6 +9,7 @@ export interface IWebhookStageViewState {
   waitForCompletion?: boolean;
   statusUrlResolution: string;
   failFastStatusCodes: string;
+  retryStatusCodes: string;
 }
 
 export interface IWebhookStageCommand {
@@ -56,6 +57,7 @@ export class WebhookStage implements IController {
       waitForCompletion: this.stage.waitForCompletion || false,
       statusUrlResolution: this.stage.statusUrlResolution || 'getMethod',
       failFastStatusCodes: this.stage.failFastStatusCodes ? this.stage.failFastStatusCodes.join() : '',
+      retryStatusCodes: this.stage.retryStatusCodes ? this.stage.retryStatusCodes.join() : '',
     };
 
     this.command = {
@@ -72,6 +74,7 @@ export class WebhookStage implements IController {
         stageConfig.configuration.waitForCompletion || this.viewState.waitForCompletion;
       this.parameters = stageConfig.configuration.parameters || [];
       this.viewState.failFastStatusCodes = this.stage.failFastStatusCodes ? this.stage.failFastStatusCodes.join() : '';
+      this.viewState.retryStatusCodes = this.stage.retryStatusCodes ? this.stage.retryStatusCodes.join() : '';
     }
 
     if (this.parameters.length && !this.stage.parameterValues) {
@@ -108,6 +111,12 @@ export class WebhookStage implements IController {
     const failFastCodes = this.viewState.failFastStatusCodes.split(',').map(x => x.trim());
 
     this.stage.failFastStatusCodes = failFastCodes.map(x => parseInt(x, 10)).filter(x => !isNaN(x));
+  }
+
+  public retryCodesChanged(): void {
+    const retryCodes = this.viewState.retryStatusCodes.split(',').map(x => x.trim());
+
+    this.stage.retryStatusCodes = retryCodes.map(x => parseInt(x, 10)).filter(x => !isNaN(x));
   }
 
   public customHeaderCount(): number {


### PR DESCRIPTION
Add additional parameters to the monitored webhook to allow:
* waiting some number of seconds before polling starts
* retrying on specific HTTP status codes

see https://github.com/spinnaker/spinnaker/issues/3450

orca counterpart (https://github.com/spinnaker/orca/pull/2984)

