### PR TITLE
fix(core): Display latest template in pipeline template list

### DIFF
--- a/app/scripts/modules/core/src/domain/IPipelineTemplateV2.ts
+++ b/app/scripts/modules/core/src/domain/IPipelineTemplateV2.ts
@@ -11,6 +11,7 @@ export interface IPipelineTemplateV2 {
   version?: string;
   updateTs?: string;
   digest?: string;
+  tag?: string;
 }
 
 interface IPipelineTemplateMetadataV2 {

--- a/app/scripts/modules/core/src/pipeline/config/templates/PipelineTemplateReader.ts
+++ b/app/scripts/modules/core/src/pipeline/config/templates/PipelineTemplateReader.ts
@@ -146,7 +146,10 @@ export class PipelineTemplateReader {
     return API.one('pipelineTemplates')
       .get()
       .then((templates: IPipelineTemplateV2[]) => {
-        return templates.filter(({ schema }) => schema === 'v2');
+        return templates.filter(
+          ({ digest, schema, tag }) =>
+            schema === 'v2' && tag === PipelineTemplateV2Service.defaultTag && typeof digest === 'undefined',
+        );
       });
   }
 }

--- a/app/scripts/modules/core/src/pipeline/config/templates/v2/pipelineTemplateV2.service.ts
+++ b/app/scripts/modules/core/src/pipeline/config/templates/v2/pipelineTemplateV2.service.ts
@@ -77,6 +77,7 @@ export class PipelineTemplateV2Service {
   }
 
   private static schema = 'v2';
+  public static defaultTag = 'latest';
 
   public static inheritedKeys: Set<InheritedItem> = new Set([
     InheritedItem.Triggers,

--- a/app/scripts/modules/core/src/pipeline/create/CreatePipelineModal.tsx
+++ b/app/scripts/modules/core/src/pipeline/create/CreatePipelineModal.tsx
@@ -166,7 +166,9 @@ export class CreatePipelineModal extends React.Component<ICreatePipelineModalPro
     const config = {
       ...pipelineConfig,
       ...(preselectedTemplate
-        ? PipelineTemplateV2Service.getPipelineTemplateConfigV2(preselectedTemplate.id)
+        ? PipelineTemplateV2Service.getPipelineTemplateConfigV2(
+            `${preselectedTemplate.id}:${PipelineTemplateV2Service.defaultTag}`,
+          )
         : PipelineTemplateReader.getPipelineTemplateConfig({
             name: command.name,
             application: application.name,


### PR DESCRIPTION
https://github.com/spinnaker/spinnaker/issues/4561

![image](https://user-images.githubusercontent.com/2623242/60065113-b543e380-96d0-11e9-9f2d-6d75841407e3.png)

When templates are saved, they create 3 versions in front50. The first version represents the template addressed by id, the second version is the template addressed by the "latest" tag, and the third version is the template addressed by its content (digest). 

Displaying three versions in the UI was causing confusion as to which version was which. This change displays solely the `latest` version. The `latest` version allows a pipeline to automatically receive updates when a new version is published. Pinning to a version can be done through Spin CLI.