### PR TITLE
Bump package core to 0.0.377 and docker to 0.0.42 and amazon to 0.0.194

### DIFF
--- a/app/scripts/modules/amazon/package.json
+++ b/app/scripts/modules/amazon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/amazon",
-  "version": "0.0.193",
+  "version": "0.0.194",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/core",
-  "version": "0.0.376",
+  "version": "0.0.377",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/docker/package.json
+++ b/app/scripts/modules/docker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/docker",
-  "version": "0.0.41",
+  "version": "0.0.42",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
### chore(core): Bump version to 0.0.377

d5425b45b9692ccc989cacbde469343fd9919227 refactor(core): virtualize execution rendering (#7140)
342087cf996b2bcadb991e7086552b29509e7e4b feat(core): allow users to override pipeline graph positions (#7141)
fb58d70ddf8f14f2b2ca128505e6b255557ee583 fix(core): do not send a cloud provider on v2 search calls (#7142)
5d6d9aad3ee09afd70614aa821e48927a6920e50 chore(core): clarify clone stage help text (#7131)
745f0a16ac689209ff44fe2bc6839317476034a6 fix(core): Display latest template in pipeline template list (#7145)
456172b52d41fb7e014a8ac7344d9476687bbe27 fix(webhooks): addresses issue 3450 - introduce a delay before polling webhook (#7144)
7238d1de6ebef092c1c25d1851d9524593c63f8b feat(core): Enable new artifacts workflow in bakeManifest (#7138)
45e5aa348ab7138b3b2a078c457c218bc129869c feat(artifacts): find multiple artifacts from single execution (#7139)
dae73dad404ba35715217c147ba82bc33fe3a5c3 fix(core): provide key for repeating param JSX elements (#7136)
bbc1d06598b5edc40fb59fd3ff448db4717a3a29 fix(core): filter falsy error messages from errors object on tasks (#7135)
47828080e629cf9c16ebfb510f1d316dfc332c9e refactor(core): Reactify overrideTimeout (#7126)
0a3bd68babe3b3a9c7b44da27e461b15f2abeb07 feat(core/presentation): Always call onBlur in Checklist to "mark as touched" (#7134)
cdd6f2379859d3c2b13bac59aa470c08b391a865 chore(package): Just Update Prettier™
7e464a9a7d56326c57d027b96d4e567af9e5db3f fix(amazon): Support SpEL in advanced capacity (#7124)
08e950634131cd5fdd0f37cbcea68386d0a662a0 chore(deck): Update to Typescript 3.4
fa515dc7462b2ffaad51ca81f9faa71215b449db fix(core): do not stretch provider logos in selection modal (#7128)

### chore(docker): Bump version to 0.0.42

83580106cd707a5a4de244f117d0a249e39ec5af fix(docker): Allow auto-switch to manual entry when refreshing images (#7120)

### chore(amazon): Bump version to 0.0.194

cdd6f2379859d3c2b13bac59aa470c08b391a865 chore(package): Just Update Prettier™
7e464a9a7d56326c57d027b96d4e567af9e5db3f fix(amazon): Support SpEL in advanced capacity (#7124)
08e950634131cd5fdd0f37cbcea68386d0a662a0 chore(deck): Update to Typescript 3.4


