### PR TITLE
fix(core): properly update execution permalink on location change

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/graph/PipelineGraph.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/graph/PipelineGraph.tsx
@@ -378,16 +378,16 @@ export class PipelineGraph extends React.Component<IPipelineGraphProps, IPipelin
   }
 
   private resetLinks(props: IPipelineGraphProps, node: IPipelineGraphNode): void {
-    const { execution, viewState } = props;
+    const { activeStageId, section, stageIndex } = props.viewState;
     if (props.execution) {
       // executions view
-      node.isActive = viewState.activeStageId === node.index && viewState.executionId === execution.id;
+      node.isActive = activeStageId === node.index;
     } else {
       // pipeline config view
       if (node.section === 'triggers') {
-        node.isActive = viewState.section === node.section;
+        node.isActive = section === node.section;
       } else {
-        node.isActive = viewState.stageIndex === node.index && viewState.section === 'stage';
+        node.isActive = stageIndex === node.index && section === 'stage';
       }
     }
     node.isHighlighted = false;

--- a/app/scripts/modules/core/src/pipeline/config/graph/pipelineGraph.service.ts
+++ b/app/scripts/modules/core/src/pipeline/config/graph/pipelineGraph.service.ts
@@ -5,7 +5,6 @@ export interface IExecutionViewState {
   activeSubStageId: number;
   canConfigure: boolean;
   canTriggerPipelineManually: boolean;
-  executionId: string;
   section?: string;
   stageIndex?: number;
 }
@@ -49,7 +48,6 @@ export interface IPipelineGraphNode {
   warnings?: { messages: string[] };
 
   // Execution node parameters
-  executionId?: string;
   executionStage?: boolean;
   hasNotStarted?: boolean;
   labelComponent?: React.ComponentType<{ stage: IExecutionStageSummary }>;
@@ -68,14 +66,13 @@ export class PipelineGraphService {
       const node: IPipelineGraphNode = {
         childLinks: [],
         children: [],
-        executionId: execution.id,
         executionStage: true,
         extraLabelLines: stage.extraLabelLines ? stage.extraLabelLines(stage) : 0,
         graphRowOverride: stage.graphRowOverride || 0,
         hasNotStarted: stage.hasNotStarted,
         id: stage.refId,
         index: idx,
-        isActive: viewState.activeStageId === stage.index && viewState.executionId === execution.id,
+        isActive: viewState.activeStageId === stage.index,
         isHighlighted: false,
         labelComponent: stage.labelComponent,
         masterStage: stage.masterStage,

--- a/app/scripts/modules/core/src/pipeline/executions/execution/Execution.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/execution/Execution.tsx
@@ -6,7 +6,6 @@ import { Subscription } from 'rxjs';
 import * as classNames from 'classnames';
 
 import { Application } from 'core/application/application.model';
-import { CopyToClipboard } from 'core/utils';
 import { StageExecutionDetails } from 'core/pipeline/details/StageExecutionDetails';
 import { ExecutionStatus } from 'core/pipeline/status/ExecutionStatus';
 import { ParametersAndArtifacts } from 'core/pipeline/status/ParametersAndArtifacts';
@@ -25,6 +24,7 @@ import { ExecutionMarker } from './ExecutionMarker';
 import { PipelineGraph } from 'core/pipeline/config/graph/PipelineGraph';
 import { Tooltip } from 'core/presentation/Tooltip';
 import { CancelModal } from 'core/cancelModal/CancelModal';
+import { ExecutionPermalink } from './ExecutionPermalink';
 
 import './execution.less';
 
@@ -257,10 +257,6 @@ export class Execution extends React.Component<IExecutionProps, IExecutionState>
     ReactGA.event({ category: 'Pipeline', action: 'Execution source clicked' });
   };
 
-  private handlePermalinkClick = (): void => {
-    ReactGA.event({ category: 'Pipeline', action: 'Permalink clicked' });
-  };
-
   private handleToggleDetails = (): void => {
     ReactGA.event({ category: 'Pipeline', action: 'Execution details toggled (Details link)' });
     this.toggleDetails();
@@ -440,10 +436,7 @@ export class Execution extends React.Component<IExecutionProps, IExecutionState>
                   Source
                 </a>
                 {' | '}
-                <a onClick={this.handlePermalinkClick} href={this.getUrl()}>
-                  Permalink
-                </a>
-                <CopyToClipboard text={this.getUrl()} toolTip="Copy permalink to clipboard" />
+                <ExecutionPermalink standalone={standalone} />
               </div>
             </div>
           </div>

--- a/app/scripts/modules/core/src/pipeline/executions/execution/ExecutionPermalink.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/execution/ExecutionPermalink.tsx
@@ -1,0 +1,39 @@
+import { CopyToClipboard } from 'core/utils';
+import { ReactInjector } from 'core/reactShims';
+import * as React from 'react';
+import * as ReactGA from 'react-ga';
+
+export interface IExecutionPermalinkProps {
+  standalone: boolean;
+}
+
+export const ExecutionPermalink = ({ standalone }: IExecutionPermalinkProps) => {
+  const [url, setUrl] = React.useState(location.href);
+
+  React.useEffect(() => {
+    const subscription = ReactInjector.stateEvents.locationChangeSuccess.subscribe(() => {
+      const newUrl = location.href;
+      if (url !== newUrl) {
+        if (!standalone) {
+          setUrl(newUrl);
+        } else {
+          setUrl(newUrl.replace('/executions', '/executions/details'));
+        }
+      }
+    });
+    return () => subscription.unsubscribe();
+  }, []);
+
+  const handlePermalinkClick = (): void => {
+    ReactGA.event({ category: 'Pipeline', action: 'Permalink clicked' });
+  };
+
+  return (
+    <>
+      <a onClick={handlePermalinkClick} href={url}>
+        Permalink
+      </a>
+      <CopyToClipboard text={url} toolTip="Copy permalink to clipboard" />
+    </>
+  );
+};

--- a/app/scripts/modules/core/src/reactShims/state.events.ts
+++ b/app/scripts/modules/core/src/reactShims/state.events.ts
@@ -11,6 +11,7 @@ export interface IStateChange {
 
 export class StateEvents {
   public stateChangeSuccess: Subject<IStateChange> = new Subject<IStateChange>();
+  public locationChangeSuccess: Subject<string> = new Subject<string>();
 
   public static $inject = ['$rootScope'];
   constructor(private $rootScope: IRootScopeService) {
@@ -23,7 +24,10 @@ export class StateEvents {
     ) => {
       this.stateChangeSuccess.next({ to, toParams, from, fromParams });
     };
+    const onLocationChangeSuccess = (_event: IAngularEvent, newUrl: string) => this.locationChangeSuccess.next(newUrl);
+
     this.$rootScope.$on('$stateChangeSuccess', onChangeSuccess);
+    this.$rootScope.$on('$locationChangeSuccess', onLocationChangeSuccess);
   }
 }
 


### PR DESCRIPTION
It looks like the `$stateChangeSuccess` event fires before the browser's location has been updated, so we're always behind a cycle when rendering the permalinks for executions.

Moved into a separate component because `<Execution>` is already pretty pretty big.

EDIT: I added a second commit to cut down on the re-render calls. What we are doing currently is kind of nuts and unnecessary and results in ~8 calls to `render` for each displayed execution every time a user clicks on a stage to toggle details or switch to a different execution.