### PR TITLE
fix(projects): Fixed project dashboard to application link

### DIFF
--- a/app/scripts/modules/core/src/projects/ProjectHeader.tsx
+++ b/app/scripts/modules/core/src/projects/ProjectHeader.tsx
@@ -113,7 +113,7 @@ export class ProjectHeader extends React.Component<IProjectHeaderProps, IProject
                     <MenuItem divider={true} />
                     {config.applications &&
                       config.applications.map(app => (
-                        <UISref key={app} to=".application" params={{ application: app }}>
+                        <UISref key={app} to=".application.insight.clusters" params={{ application: app }}>
                           <MenuItem onClick={closeDropdown}> {app} </MenuItem>
                         </UISref>
                       ))}


### PR DESCRIPTION
This fixes `Cannot transition to abstract state 'home.project.application'`.