### PR TITLE
fix(amazon): attach instanceId as id field on standalone instance det…

### DIFF
--- a/app/scripts/modules/amazon/src/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/amazon/src/instance/details/instance.details.controller.js
@@ -91,7 +91,7 @@ module.exports = angular
         var instanceSummary, loadBalancers, targetGroups, account, region, vpcId;
         if (!app.serverGroups) {
           // standalone instance
-          instanceSummary = {};
+          instanceSummary = { id: instance.instanceId }; // terminate call expects `id` to be populated
           loadBalancers = [];
           targetGroups = [];
           account = instance.account;


### PR DESCRIPTION
…ails

The instance writer expects the `id` field to be populated, which isn't happening on standalone instances right now.
