### PR TITLE
chore(amazon): Bump version to 0.0.196

### DIFF
--- a/app/scripts/modules/amazon/package.json
+++ b/app/scripts/modules/amazon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/amazon",
-  "version": "0.0.195",
+  "version": "0.0.196",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
### chore(amazon): Bump version to 0.0.196

f790fdf69c86146d0eca0a3f1648654c5fe2dcb6 fix(amazon): attach instanceId as id field on standalone instance details (#7156)
b53ac89ddebe0a73ee23c6c3f45764bea33dd418 feat(cfn/changesets): Introduce support for CFN changesets (#7071)


