### PR TITLE
Bump package core to 0.0.379 and amazon to 0.0.197

### DIFF
--- a/app/scripts/modules/amazon/package.json
+++ b/app/scripts/modules/amazon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/amazon",
-  "version": "0.0.196",
+  "version": "0.0.197",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/core",
-  "version": "0.0.378",
+  "version": "0.0.379",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
### chore(core): Bump version to 0.0.379

973bd5c0d643f9437c17a512e95fb88307cb5444 fix(core/pipeline): When a pipeline or jenkins parameter is no longer accepted by the job/pipeline, show the parameter value (in addition to the name) in the warning message. (#7149)
8d929f06670e27055f488c282c13aa929578eccc fix(core): fix alignment on cards in card choices (#7158)

### chore(amazon): Bump version to 0.0.197

8d929f06670e27055f488c282c13aa929578eccc fix(core): fix alignment on cards in card choices (#7158)


