### PR TITLE
 feat(core/amazon): add a visual indicator to infra managed by Keel

### DIFF
--- a/app/scripts/modules/amazon/src/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/amazon/src/instance/details/instance.details.controller.js
@@ -10,6 +10,7 @@ import {
   RecentHistoryService,
   SETTINGS,
   FirewallLabels,
+  MANAGED_RESOURCE_DETAILS_INDICATOR,
 } from '@spinnaker/core';
 
 import { AMAZON_INSTANCE_WRITE_SERVICE } from 'amazon/instance/amazon.instance.write.service';
@@ -21,11 +22,11 @@ module.exports = angular
     AMAZON_INSTANCE_WRITE_SERVICE,
     require('../../vpc/vpcTag.directive').name,
     CONFIRMATION_MODAL_SERVICE,
+    MANAGED_RESOURCE_DETAILS_INDICATOR,
   ])
   .controller('awsInstanceDetailsCtrl', [
     '$scope',
     '$state',
-    '$uibModal',
     'amazonInstanceWriter',
     'confirmationModalService',
     'instance',
@@ -37,7 +38,6 @@ module.exports = angular
     function(
       $scope,
       $state,
-      $uibModal,
       amazonInstanceWriter,
       confirmationModalService,
       instance,

--- a/app/scripts/modules/amazon/src/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/amazon/src/instance/details/instance.details.controller.js
@@ -10,7 +10,6 @@ import {
   RecentHistoryService,
   SETTINGS,
   FirewallLabels,
-  MANAGED_RESOURCE_DETAILS_INDICATOR,
 } from '@spinnaker/core';
 
 import { AMAZON_INSTANCE_WRITE_SERVICE } from 'amazon/instance/amazon.instance.write.service';
@@ -22,7 +21,6 @@ module.exports = angular
     AMAZON_INSTANCE_WRITE_SERVICE,
     require('../../vpc/vpcTag.directive').name,
     CONFIRMATION_MODAL_SERVICE,
-    MANAGED_RESOURCE_DETAILS_INDICATOR,
   ])
   .controller('awsInstanceDetailsCtrl', [
     '$scope',

--- a/app/scripts/modules/amazon/src/instance/details/instanceDetails.html
+++ b/app/scripts/modules/amazon/src/instance/details/instanceDetails.html
@@ -92,6 +92,11 @@
       </div>
     </div>
   </div>
+  <managed-resource-details-indicator
+    ng-if="!state.loading && instance.serverGroup && instance.serverGroup.clusterEntityTags"
+    entity-tags="instance.serverGroup.clusterEntityTags"
+  >
+  </managed-resource-details-indicator>
   <div class="content" ng-if="!state.loading && instance">
     <collapsible-section heading="Instance Information" expanded="true">
       <dl class="dl-horizontal dl-flex">
@@ -116,9 +121,13 @@
           >
         </dd>
         <dt ng-if="instance.serverGroup">VPC</dt>
-        <dd ng-if="instance.serverGroup"><vpc-tag vpc-id="instance.vpcId"></vpc-tag></dd>
+        <dd ng-if="instance.serverGroup">
+          <vpc-tag vpc-id="instance.vpcId"></vpc-tag>
+        </dd>
         <dt ng-if="instance.subnetId">Subnet</dt>
-        <dd ng-if="instance.subnetId"><subnet-tag subnet-id="instance.subnetId"></subnet-tag></dd>
+        <dd ng-if="instance.subnetId">
+          <subnet-tag subnet-id="instance.subnetId"></subnet-tag>
+        </dd>
         <dt ng-if="instance.imageId">Image ID</dt>
         <dd ng-if="instance.imageId">{{instance.imageId}}</dd>
       </dl>

--- a/app/scripts/modules/amazon/src/instance/details/instanceDetails.html
+++ b/app/scripts/modules/amazon/src/instance/details/instanceDetails.html
@@ -92,11 +92,6 @@
       </div>
     </div>
   </div>
-  <managed-resource-details-indicator
-    ng-if="!state.loading && instance.serverGroup && instance.serverGroup.clusterEntityTags"
-    entity-tags="instance.serverGroup.clusterEntityTags"
-  >
-  </managed-resource-details-indicator>
   <div class="content" ng-if="!state.loading && instance">
     <collapsible-section heading="Instance Information" expanded="true">
       <dl class="dl-horizontal dl-flex">

--- a/app/scripts/modules/amazon/src/loadBalancer/details/loadBalancerDetails.controller.ts
+++ b/app/scripts/modules/amazon/src/loadBalancer/details/loadBalancerDetails.controller.ts
@@ -16,6 +16,7 @@ import {
   SecurityGroupReader,
   SubnetReader,
   FirewallLabels,
+  MANAGED_RESOURCE_DETAILS_INDICATOR,
 } from '@spinnaker/core';
 
 import {
@@ -234,4 +235,5 @@ module(AWS_LOAD_BALANCER_DETAILS_CTRL, [
   LOAD_BALANCER_ACTIONS,
   LOAD_BALANCER_READ_SERVICE,
   CONFIRMATION_MODAL_SERVICE,
+  MANAGED_RESOURCE_DETAILS_INDICATOR,
 ]).controller('awsLoadBalancerDetailsCtrl', AwsLoadBalancerDetailsController);

--- a/app/scripts/modules/amazon/src/loadBalancer/details/loadBalancerDetails.html
+++ b/app/scripts/modules/amazon/src/loadBalancer/details/loadBalancerDetails.html
@@ -58,6 +58,11 @@
       </div>
     </div>
   </div>
+  <managed-resource-details-indicator
+    ng-if="!ctrl.state.loading && ctrl.loadBalancer.entityTags"
+    entity-tags="ctrl.loadBalancer.entityTags"
+  >
+  </managed-resource-details-indicator>
   <div ng-if="!ctrl.state.loading" class="content">
     <collapsible-section heading="Load Balancer Details" expanded="true">
       <dl class="dl-horizontal dl-flex">
@@ -68,7 +73,9 @@
           <account-tag account="ctrl.loadBalancer.account" pad="right"></account-tag> {{ctrl.loadBalancer.region}}
         </dd>
         <dt>VPC</dt>
-        <dd><vpc-tag vpc-id="ctrl.loadBalancer.elb.vpcId"></vpc-tag></dd>
+        <dd>
+          <vpc-tag vpc-id="ctrl.loadBalancer.elb.vpcId"></vpc-tag>
+        </dd>
         <dt>Subnet</dt>
         <dd>{{ctrl.getFirstSubnetPurpose(ctrl.loadBalancer.subnetDetails)}}</dd>
         <dt ng-if="ctrl.ipAddressTypeDescription">Type</dt>

--- a/app/scripts/modules/amazon/src/loadBalancer/details/loadBalancerDetails.html
+++ b/app/scripts/modules/amazon/src/loadBalancer/details/loadBalancerDetails.html
@@ -60,7 +60,7 @@
   </div>
   <managed-resource-details-indicator
     ng-if="!ctrl.state.loading && ctrl.loadBalancer.entityTags"
-    entity-tags="ctrl.loadBalancer.entityTags"
+    entity-tags="[ctrl.loadBalancer.entityTags]"
   >
   </managed-resource-details-indicator>
   <div ng-if="!ctrl.state.loading" class="content">

--- a/app/scripts/modules/amazon/src/loadBalancer/details/targetGroupDetails.controller.ts
+++ b/app/scripts/modules/amazon/src/loadBalancer/details/targetGroupDetails.controller.ts
@@ -1,7 +1,7 @@
 import { IController, IPromise, IQService, IScope, module } from 'angular';
 import { StateService } from '@uirouter/angularjs';
 
-import { Application, ILoadBalancer } from '@spinnaker/core';
+import { Application, ILoadBalancer, MANAGED_RESOURCE_DETAILS_INDICATOR } from '@spinnaker/core';
 
 import { IAmazonApplicationLoadBalancer, ITargetGroup } from 'amazon/domain/IAmazonLoadBalancer';
 
@@ -87,7 +87,7 @@ export class AwsTargetGroupDetailsController implements IController {
 }
 
 export const AWS_TARGET_GROUP_DETAILS_CTRL = 'spinnaker.amazon.loadBalancer.details.targetGroupDetails.controller';
-module(AWS_TARGET_GROUP_DETAILS_CTRL, [require('@uirouter/angularjs').default]).controller(
-  'awsTargetGroupDetailsCtrl',
-  AwsTargetGroupDetailsController,
-);
+module(AWS_TARGET_GROUP_DETAILS_CTRL, [
+  require('@uirouter/angularjs').default,
+  MANAGED_RESOURCE_DETAILS_INDICATOR,
+]).controller('awsTargetGroupDetailsCtrl', AwsTargetGroupDetailsController);

--- a/app/scripts/modules/amazon/src/loadBalancer/details/targetGroupDetails.html
+++ b/app/scripts/modules/amazon/src/loadBalancer/details/targetGroupDetails.html
@@ -22,42 +22,21 @@
         {{ctrl.targetGroup.name}}
       </h3>
     </div>
-    <div>
-      <div class="actions">
-        <div class="dropdown" uib-dropdown dropdown-append-to-body>
-          <button
-            type="button"
-            class="btn btn-sm btn-primary dropdown-toggle"
-            style="visibility: hidden"
-            disabled
-            uib-dropdown-toggle
-          >
-            Target Group Actions <span class="caret"></span>
-          </button>
-          <ul class="dropdown-menu" uib-dropdown-menu role="menu">
-            <li><a href ng-click="ctrl.editLoadBalancer()">Edit Target Group</a></li>
-            <li ng-if="!ctrl.loadBalancer.instances.length">
-              <a href ng-click="ctrl.deleteLoadBalancer()">Delete Target Group</a>
-            </li>
-            <li
-              ng-if="ctrl.loadBalancer.instances.length"
-              class="disabled"
-              uib-tooltip="You must detach all instances before you can delete this load balancer."
-            >
-              <a href ng-click="ctrl.deleteLoadBalancer()">Delete Target Group</a>
-            </li>
-          </ul>
-        </div>
-      </div>
-    </div>
   </div>
+  <managed-resource-details-indicator
+    ng-if="!ctrl.state.loading && ctrl.loadBalancer.entityTags"
+    entity-tags="ctrl.loadBalancer.entityTags"
+  >
+  </managed-resource-details-indicator>
   <div ng-if="!ctrl.state.loading" class="content">
     <collapsible-section heading="Target Group Details" expanded="true">
       <dl class="dl-horizontal dl-flex">
         <dt>In</dt>
         <dd><account-tag account="ctrl.targetGroup.account" pad="right"></account-tag> {{ctrl.targetGroup.region}}</dd>
         <dt>VPC</dt>
-        <dd><vpc-tag vpc-id="ctrl.targetGroup.vpcId"></vpc-tag></dd>
+        <dd>
+          <vpc-tag vpc-id="ctrl.targetGroup.vpcId"></vpc-tag>
+        </dd>
         <dt>Protocol</dt>
         <dd>{{ctrl.targetGroup.protocol}}</dd>
         <dt>Port</dt>

--- a/app/scripts/modules/amazon/src/loadBalancer/details/targetGroupDetails.html
+++ b/app/scripts/modules/amazon/src/loadBalancer/details/targetGroupDetails.html
@@ -25,7 +25,7 @@
   </div>
   <managed-resource-details-indicator
     ng-if="!ctrl.state.loading && ctrl.loadBalancer.entityTags"
-    entity-tags="ctrl.loadBalancer.entityTags"
+    entity-tags="[ctrl.loadBalancer.entityTags]"
   >
   </managed-resource-details-indicator>
   <div ng-if="!ctrl.state.loading" class="content">

--- a/app/scripts/modules/amazon/src/securityGroup/details/securityGroupDetail.controller.js
+++ b/app/scripts/modules/amazon/src/securityGroup/details/securityGroupDetail.controller.js
@@ -10,6 +10,7 @@ import {
   SECURITY_GROUP_READER,
   SecurityGroupWriter,
   FirewallLabels,
+  MANAGED_RESOURCE_DETAILS_INDICATOR,
 } from '@spinnaker/core';
 
 import { VpcReader } from '../../vpc/VpcReader';
@@ -20,6 +21,7 @@ module.exports = angular
     SECURITY_GROUP_READER,
     CONFIRMATION_MODAL_SERVICE,
     require('../clone/cloneSecurityGroup.controller').name,
+    MANAGED_RESOURCE_DETAILS_INDICATOR,
   ])
   .controller('awsSecurityGroupDetailsCtrl', [
     '$scope',

--- a/app/scripts/modules/amazon/src/securityGroup/details/securityGroupDetail.html
+++ b/app/scripts/modules/amazon/src/securityGroup/details/securityGroupDetail.html
@@ -56,7 +56,7 @@
   </div>
   <managed-resource-details-indicator
     ng-if="!state.loading && securityGroup.entityTags"
-    entity-tags="securityGroup.entityTags"
+    entity-tags="[securityGroup.entityTags]"
   >
   </managed-resource-details-indicator>
   <div class="content" ng-if="!state.loading">

--- a/app/scripts/modules/amazon/src/securityGroup/details/securityGroupDetail.html
+++ b/app/scripts/modules/amazon/src/securityGroup/details/securityGroupDetail.html
@@ -54,17 +54,26 @@
       </div>
     </div>
   </div>
+  <managed-resource-details-indicator
+    ng-if="!state.loading && securityGroup.entityTags"
+    entity-tags="securityGroup.entityTags"
+  >
+  </managed-resource-details-indicator>
   <div class="content" ng-if="!state.loading">
     <collapsible-section heading="{{ctrl.firewallLabel}} Details" expanded="true">
       <dl class="dl-horizontal dl-medium">
         <dt>ID</dt>
         <dd>{{securityGroup.id}}</dd>
         <dt>Account</dt>
-        <dd><account-tag account="securityGroup.accountName"></account-tag></dd>
+        <dd>
+          <account-tag account="securityGroup.accountName"></account-tag>
+        </dd>
         <dt>Region</dt>
         <dd>{{securityGroup.region}}</dd>
         <dt>VPC</dt>
-        <dd><vpc-tag vpc-id="securityGroup.vpcId"></vpc-tag></dd>
+        <dd>
+          <vpc-tag vpc-id="securityGroup.vpcId"></vpc-tag>
+        </dd>
         <dt>Description</dt>
         <dd>{{securityGroup.description}}</dd>
       </dl>
@@ -102,7 +111,9 @@
         ng-class="insightCtrl.vm.filtersExpanded ? '' : 'dl-horizontal dl-medium'"
         ng-repeat="rule in securityGroupRules | orderBy: 'securityGroup.name' "
       >
-        <dt><firewall-label label="Firewall"></firewall-label></dt>
+        <dt>
+          <firewall-label label="Firewall"></firewall-label>
+        </dt>
         <dd ng-if="rule.securityGroup.name">
           <a
             ui-sref="^.firewallDetails({name: rule.securityGroup.name, accountId: rule.securityGroup.accountName, region: rule.securityGroup.region, vpcId: rule.securityGroup.vpcId, provider: 'aws'})"

--- a/app/scripts/modules/core/src/index.ts
+++ b/app/scripts/modules/core/src/index.ts
@@ -44,6 +44,8 @@ export * from './loadBalancer';
 
 export * from './modal';
 
+export * from './managed';
+
 export * from './manifest';
 
 export * from './naming';

--- a/app/scripts/modules/core/src/managed/ManagedResourceDetailsIndicator.less
+++ b/app/scripts/modules/core/src/managed/ManagedResourceDetailsIndicator.less
@@ -1,0 +1,4 @@
+.ManagedResourceDetailsIndicator > .icon {
+  text-shadow: 0px 1px 4px rgba(0, 0, 0, 0.5);
+  padding-right: 5px;
+}

--- a/app/scripts/modules/core/src/managed/ManagedResourceDetailsIndicator.tsx
+++ b/app/scripts/modules/core/src/managed/ManagedResourceDetailsIndicator.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { get } from 'lodash';
+
+import { IEntityTags } from 'core/domain';
+
+export const MANAGED_BY_SPINNAKER_TAG_NAME = 'spinnaker_ui_notice:managed_by_spinnaker';
+
+export interface IManagedResourceDetailsIndicatorProps {
+  entityTags: IEntityTags[] | IEntityTags;
+}
+
+export const ManagedResourceDetailsIndicator = ({ entityTags }: IManagedResourceDetailsIndicatorProps) => {
+  const normalizedTags = Array.isArray(entityTags) ? entityTags : [entityTags];
+  const isManaged =
+    get(normalizedTags, 'length') &&
+    normalizedTags.some(({ tags }) => tags.some(({ name }) => name === MANAGED_BY_SPINNAKER_TAG_NAME));
+
+  if (!isManaged) {
+    return null;
+  }
+  return <div className="band band-info">Managed Declaratively 🌈</div>;
+};

--- a/app/scripts/modules/core/src/managed/ManagedResourceDetailsIndicator.tsx
+++ b/app/scripts/modules/core/src/managed/ManagedResourceDetailsIndicator.tsx
@@ -2,21 +2,40 @@ import * as React from 'react';
 import { get } from 'lodash';
 
 import { IEntityTags } from 'core/domain';
+import { HoverablePopover } from 'core/presentation';
+
+import './ManagedResourceDetailsIndicator.less';
 
 export const MANAGED_BY_SPINNAKER_TAG_NAME = 'spinnaker_ui_notice:managed_by_spinnaker';
 
 export interface IManagedResourceDetailsIndicatorProps {
-  entityTags: IEntityTags[] | IEntityTags;
+  entityTags: IEntityTags[];
 }
 
 export const ManagedResourceDetailsIndicator = ({ entityTags }: IManagedResourceDetailsIndicatorProps) => {
-  const normalizedTags = Array.isArray(entityTags) ? entityTags : [entityTags];
   const isManaged =
-    get(normalizedTags, 'length') &&
-    normalizedTags.some(({ tags }) => tags.some(({ name }) => name === MANAGED_BY_SPINNAKER_TAG_NAME));
+    get(entityTags, 'length') &&
+    entityTags.some(({ tags }) => tags.some(({ name }) => name === MANAGED_BY_SPINNAKER_TAG_NAME));
 
   if (!isManaged) {
     return null;
   }
-  return <div className="band band-info">Managed Declaratively 🌈</div>;
+
+  const helpText = (
+    <>
+      <p>
+        <b>Spinnaker is continuously managing this resource.</b>
+      </p>
+      <p>Changes made in the UI will be stomped in favor of the existing declarative configuration.</p>
+    </>
+  );
+
+  return (
+    <HoverablePopover template={helpText} placement="left">
+      <div className="band band-info ManagedResourceDetailsIndicator">
+        <span className="icon">🌈</span>
+        Managed by Spinnaker
+      </div>
+    </HoverablePopover>
+  );
 };

--- a/app/scripts/modules/core/src/managed/index.ts
+++ b/app/scripts/modules/core/src/managed/index.ts
@@ -1,0 +1,2 @@
+export * from './ManagedResourceDetailsIndicator';
+export * from './managedResourceDetailsIndicator.component';

--- a/app/scripts/modules/core/src/managed/managedResourceDetailsIndicator.component.ts
+++ b/app/scripts/modules/core/src/managed/managedResourceDetailsIndicator.component.ts
@@ -3,7 +3,7 @@ import { react2angular } from 'react2angular';
 
 import { ManagedResourceDetailsIndicator } from './ManagedResourceDetailsIndicator';
 
-export const MANAGED_RESOURCE_DETAILS_INDICATOR = 'spinnaker.amazon.managed.resourceDetailsIndicator.component';
+export const MANAGED_RESOURCE_DETAILS_INDICATOR = 'spinnaker.core.managed.resourceDetailsIndicator.component';
 module(MANAGED_RESOURCE_DETAILS_INDICATOR, []).component(
   'managedResourceDetailsIndicator',
   react2angular(ManagedResourceDetailsIndicator, ['entityTags']),

--- a/app/scripts/modules/core/src/managed/managedResourceDetailsIndicator.component.ts
+++ b/app/scripts/modules/core/src/managed/managedResourceDetailsIndicator.component.ts
@@ -1,0 +1,10 @@
+import { module } from 'angular';
+import { react2angular } from 'react2angular';
+
+import { ManagedResourceDetailsIndicator } from './ManagedResourceDetailsIndicator';
+
+export const MANAGED_RESOURCE_DETAILS_INDICATOR = 'spinnaker.amazon.managed.resourceDetailsIndicator.component';
+module(MANAGED_RESOURCE_DETAILS_INDICATOR, []).component(
+  'managedResourceDetailsIndicator',
+  react2angular(ManagedResourceDetailsIndicator, ['entityTags']),
+);

--- a/app/scripts/modules/core/src/serverGroup/details/ServerGroupDetails.tsx
+++ b/app/scripts/modules/core/src/serverGroup/details/ServerGroupDetails.tsx
@@ -4,6 +4,7 @@ import { Subject } from 'rxjs';
 
 import { CloudProviderLogo } from 'core/cloudProvider/CloudProviderLogo';
 import { EntityNotifications } from 'core/entityTag/notifications/EntityNotifications';
+import { ManagedResourceDetailsIndicator } from 'core/managed';
 import { IServerGroup } from 'core/domain';
 import { ReactInjector } from 'core/reactShims';
 import { SETTINGS } from 'core/config/settings';
@@ -121,6 +122,7 @@ export class ServerGroupDetails extends React.Component<IServerGroupDetailsProps
         {serverGroup && serverGroup.isDisabled && (
           <div className="band band-info">Disabled {timestamp(serverGroup.disabledDate)}</div>
         )}
+        {!loading && <ManagedResourceDetailsIndicator entityTags={serverGroup.clusterEntityTags} />}
         {!loading && (
           <div className="content">
             <RunningTasks serverGroup={serverGroup} application={app} />


### PR DESCRIPTION
The first PR for bringing [keel](http://github.com/spinnaker/keel) into the UI — this is a quick (largely experimental) attempt at indicating resources are managed. Currently applies to clusters, load balancers/target groups, and security groups.

Right now this is implemented via entity tags, but may change in the future. I'm not particularly tied to any of the specifics (including new directory structures, etc.).

<img width="743" alt="Screen Shot 2019-06-27 at 9 13 23 PM" src="https://user-images.githubusercontent.com/1850998/60316893-75276f80-9921-11e9-8d34-56395fefa0f5.png">

