### PR TITLE
feat(esc): Add support for task definition artifacts

### DIFF
--- a/app/scripts/modules/ecs/src/ecs.help.ts
+++ b/app/scripts/modules/ecs/src/ecs.help.ts
@@ -52,6 +52,16 @@ const helpContents: { [key: string]: string } = {
     '<p>The container\'s logging driver.  This directly maps to the <a href="https://docs.docker.com/config/containers/logging/configure/#configure-the-default-logging-driver"><b>--log-driver</b> Docker flag.</a></p>',
   'ecs.logOptions':
     '<p>A map of log options.  This directly maps with the <a href="https://docs.docker.com/config/containers/logging/log_tags/"><b>--log-opt</b> Docker flag  </a></p>',
+  'ecs.taskDefinition':
+    '<p>The source of the ECS Task Definition. Task Definition contents can either be entering manually via input fields or from a selected JSON file artifact. Artifact file contents should be structured as an ECS "RegisterTaskDefinition" request.</p>',
+  'ecs.taskDefinitionArtifact': '<p>The artifact containing the ECS Task Definition.</p>',
+  'ecs.containerMappings':
+    '<p>The list of expected containers within the Task Definition and which container image they should use. Containers in the Task Definition which are not specified here will be registered as appears in the artifact.</p>',
+  'ecs.containerMappingName':
+    '<p>The name of the container. Name should match the <a href="https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ContainerDefinition.html#ECS-Type-ContainerDefinition-name"><b>containerDefinition.name</b></a> field as it appears in the Task Definition.</p>',
+  'ecs.containerMappingImage': '<p>The container image the named container should run.</p>',
+  'ecs.loadBalancedContainer':
+    '<p>The container in the Task Definition that should receive traffic from the load balancer. Required if a load balancer target group has been specified.</p>',
   'ecs.tags': '<p>The tags to apply to the task definition and the service',
   'ecs.environmentVariables':
     '<p>The environment variable(s) your container are deployed with. SERVER_GROUP, CLOUD_STACK and CLOUD_DETAIL environment variables are used during deployment to identify the task and cannot be set here.</p>',

--- a/app/scripts/modules/ecs/src/ecs.help.ts
+++ b/app/scripts/modules/ecs/src/ecs.help.ts
@@ -56,7 +56,7 @@ const helpContents: { [key: string]: string } = {
     '<p>The source of the ECS Task Definition. Task Definition contents can either be entering manually via input fields or from a selected JSON file artifact. Artifact file contents should be structured as an ECS "RegisterTaskDefinition" request.</p>',
   'ecs.taskDefinitionArtifact': '<p>The artifact containing the ECS Task Definition.</p>',
   'ecs.containerMappings':
-    '<p>The list of expected containers within the Task Definition and which container image they should use. Containers in the Task Definition which are not specified here will be registered as appears in the artifact.</p>',
+    '<p>The list of expected containers within the Task Definition and which container image they should use. Containers in the Task Definition which are not specified here will be registered as they appear in the artifact.</p>',
   'ecs.containerMappingName':
     '<p>The name of the container. Name should match the <a href="https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ContainerDefinition.html#ECS-Type-ContainerDefinition-name"><b>containerDefinition.name</b></a> field as it appears in the Task Definition.</p>',
   'ecs.containerMappingImage': '<p>The container image the named container should run.</p>',

--- a/app/scripts/modules/ecs/src/ecs.module.ts
+++ b/app/scripts/modules/ecs/src/ecs.module.ts
@@ -16,6 +16,7 @@ import './ecs.help';
 import { COMMON_MODULE } from './common/common.module';
 import { ECS_SERVERGROUP_MODULE } from './serverGroup/serverGroup.module';
 import { ECS_SERVER_GROUP_LOGGING } from './serverGroup/configure/wizard/logging/logging.component';
+import { TASK_DEFINITION_REACT } from './serverGroup/configure/wizard/taskDefinition/TaskDefinition';
 
 import './logo/ecs.logo.less';
 
@@ -38,6 +39,7 @@ angular
     require('./serverGroup/configure/wizard/advancedSettings/advancedSettings.component').name,
     require('./serverGroup/configure/wizard/container/container.component').name,
     require('./serverGroup/configure/wizard/horizontalScaling/horizontalScaling.component').name,
+    TASK_DEFINITION_REACT,
     ECS_SERVER_GROUP_LOGGING,
     ECS_NETWORKING_SECTION,
     ECS_CLUSTER_READ_SERVICE,

--- a/app/scripts/modules/ecs/src/serverGroup/configure/serverGroupCommandBuilder.service.js
+++ b/app/scripts/modules/ecs/src/serverGroup/configure/serverGroupCommandBuilder.service.js
@@ -141,6 +141,8 @@ module.exports = angular
               healthCheckGracePeriodSeconds: '',
               placementConstraints: [],
               placementStrategyName: '',
+              taskDefinitionArtifact: {},
+              useTaskDefinitionArtifact: false,
               placementStrategySequence: [],
               serviceDiscoveryAssociations: [],
               ecsClusterName: '',
@@ -201,6 +203,8 @@ module.exports = angular
             existingPipelineCluster: true,
             dirty: {},
             contextImages: contextImages,
+            pipeline: pipeline,
+            currentStage: current,
           };
 
           var viewOverrides = {
@@ -224,9 +228,12 @@ module.exports = angular
         return $q.when({
           viewState: {
             requiresTemplateSelection: true,
+            // applies viewState overrides after template selection
             overrides: {
               viewState: {
                 contextImages: contextImages,
+                pipeline: pipeline,
+                currentStage: current,
               },
             },
           },
@@ -247,6 +254,7 @@ module.exports = angular
       function buildServerGroupCommandFromExisting(application, serverGroup, mode = 'clone') {
         var preferredZonesLoader = AccountService.getPreferredZonesByAccount('ecs');
 
+        // TODO: not set when called w/ existing template, might need to call buildUpdateServerGroupCommand?
         var serverGroupName = NameUtils.parseServerGroupName(serverGroup.asg.autoScalingGroupName);
 
         var asyncLoader = $q.all({
@@ -291,6 +299,11 @@ module.exports = angular
               .map(process => process.processName)
               .filter(name => !enabledProcesses.includes(name)),
             targetGroup: serverGroup.targetGroup,
+            taskDefinitionArtifact: {},
+            taskDefinitionArtifactAccount: '',
+            useTaskDefinitionArtifact: false,
+            containerMappings: [],
+            loadBalancedContainer: '',
             copySourceScalingPoliciesAndActions: true,
             viewState: {
               instanceProfile: asyncData.instanceProfile,

--- a/app/scripts/modules/ecs/src/serverGroup/configure/serverGroupConfiguration.service.ts
+++ b/app/scripts/modules/ecs/src/serverGroup/configure/serverGroupConfiguration.service.ts
@@ -5,7 +5,10 @@ import {
   AccountService,
   CACHE_INITIALIZER_SERVICE,
   IAccountDetails,
+  IArtifact,
   IDeploymentStrategy,
+  IPipeline,
+  IStage,
   IRegion,
   IServerGroupCommand,
   IServerGroupCommandBackingData,
@@ -59,6 +62,8 @@ export interface IEcsDockerImage extends IDockerImage {
 
 export interface IEcsServerGroupCommandViewState extends IServerGroupCommandViewState {
   contextImages: IEcsDockerImage[];
+  pipeline: IPipeline;
+  currentStage: IStage;
 }
 
 export interface IEcsServerGroupCommandBackingDataFiltered extends IServerGroupCommandBackingDataFiltered {
@@ -87,6 +92,16 @@ export interface IEcsServerGroupCommandBackingData extends IServerGroupCommandBa
   images: IEcsDockerImage[];
 }
 
+export interface IEcsTaskDefinitionArtifact {
+  artifact?: IArtifact;
+  artifactId?: string;
+}
+
+export interface IEcsContainerMapping {
+  containerName: string;
+  imageDescription: IEcsDockerImage;
+}
+
 export interface IEcsServerGroupCommand extends IServerGroupCommand {
   backingData: IEcsServerGroupCommandBackingData;
   targetHealthyDeployPercentage: number;
@@ -95,6 +110,10 @@ export interface IEcsServerGroupCommand extends IServerGroupCommand {
   placementStrategySequence: IPlacementStrategy[];
   imageDescription: IEcsDockerImage;
   viewState: IEcsServerGroupCommandViewState;
+  taskDefinitionArtifact: IEcsTaskDefinitionArtifact;
+  taskDefinitionArtifactAccount: string;
+  containerMappings: IEcsContainerMapping[];
+  loadBalancedContainer: string;
 
   subnetTypeChanged: (command: IEcsServerGroupCommand) => IServerGroupCommandResult;
   placementStrategyNameChanged: (command: IEcsServerGroupCommand) => IServerGroupCommandResult;
@@ -210,6 +229,7 @@ export class EcsServerGroupConfigurationService {
       .then((backingData: Partial<IEcsServerGroupCommandBackingData>) => {
         backingData.accounts = keys(backingData.credentialsKeyedByAccount);
         backingData.filtered = {} as IEcsServerGroupCommandBackingDataFiltered;
+
         if (cmd.viewState.contextImages) {
           backingData.images = backingData.images.concat(cmd.viewState.contextImages);
         }

--- a/app/scripts/modules/ecs/src/serverGroup/configure/wizard/CloneServerGroup.ecs.controller.js
+++ b/app/scripts/modules/ecs/src/serverGroup/configure/wizard/CloneServerGroup.ecs.controller.js
@@ -234,7 +234,11 @@ module.exports = angular
 
       // used by react components to update command fields in parent (angular) scope
       $scope.notifyAngular = function(commandKey, value) {
-        $scope.command[commandKey] = value;
+        if (commandKey == 'pipeline') {
+          $scope.command.viewState.pipeline = value;
+        } else {
+          $scope.command[commandKey] = value;
+        }
       };
 
       // used by react components to configure command for image queries

--- a/app/scripts/modules/ecs/src/serverGroup/configure/wizard/CloneServerGroup.ecs.controller.js
+++ b/app/scripts/modules/ecs/src/serverGroup/configure/wizard/CloneServerGroup.ecs.controller.js
@@ -8,6 +8,7 @@ import {
   SERVER_GROUP_WRITER,
   TaskMonitor,
   ModalWizard,
+  STAGE_ARTIFACT_SELECTOR_COMPONENT_REACT,
 } from '@spinnaker/core';
 
 import { ECS_SERVER_GROUP_CONFIGURATION_SERVICE } from '../serverGroupConfiguration.service';
@@ -25,6 +26,7 @@ module.exports = angular
     IAM_ROLE_READ_SERVICE,
     ECS_CLUSTER_READ_SERVICE,
     ECS_SECRET_READ_SERVICE,
+    STAGE_ARTIFACT_SELECTOR_COMPONENT_REACT,
   ])
   .controller('ecsCloneServerGroupCtrl', [
     '$scope',
@@ -80,6 +82,10 @@ module.exports = angular
         advancedSettings: overrideRegistry.getTemplate(
           'ecs.serverGroup.advancedSettings',
           require('./advancedSettings/advancedSettings.html'),
+        ),
+        taskDefinition: overrideRegistry.getTemplate(
+          'ecs.taskDefinition',
+          require('./taskDefinition/taskDefinition.html'),
         ),
       };
 
@@ -157,7 +163,7 @@ module.exports = angular
       });
 
       function configureCommand() {
-        ecsServerGroupConfigurationService.configureCommand(serverGroupCommand).then(function() {
+        ecsServerGroupConfigurationService.configureCommand($scope.command).then(function() {
           $scope.state.loaded = true;
           initializeCommand();
           initializeSelectOptions();
@@ -224,6 +230,16 @@ module.exports = angular
       this.templateSelected = () => {
         $scope.state.requiresTemplateSelection = false;
         configureCommand();
+      };
+
+      // used by react components to update command fields in parent (angular) scope
+      $scope.notifyAngular = function(commandKey, value) {
+        $scope.command[commandKey] = value;
+      };
+
+      // used by react components to configure command for image queries
+      $scope.configureCommand = function(query) {
+        return ecsServerGroupConfigurationService.configureCommand($scope.command, query);
       };
     },
   ]);

--- a/app/scripts/modules/ecs/src/serverGroup/configure/wizard/advancedSettings/advancedSettings.component.html
+++ b/app/scripts/modules/ecs/src/serverGroup/configure/wizard/advancedSettings/advancedSettings.component.html
@@ -38,26 +38,28 @@
     </div>
   </div>
 
-  <div class="form-group">
-    <div class="col-md-5 sm-label-right">
-      <b>Docker Image Credentials</b> <help-field key="ecs.dockerimagecredentials"></help-field>
-    </div>
-    <div class="col-md-7" ng-if="!$ctrl.command.backingData.filtered.secrets.length">
-      No account or region was selected, or no AWS Secrets Manager secrets are available in this account and region.
-    </div>
+  <div ng-if="!$ctrl.command.useTaskDefinitionArtifact">
+    <div class="form-group">
+      <div class="col-md-5 sm-label-right">
+        <b>Docker Image Credentials</b> <help-field key="ecs.dockerimagecredentials"></help-field>
+      </div>
+      <div class="col-md-7" ng-if="!$ctrl.command.backingData.filtered.secrets.length">
+        No account or region was selected, or no AWS Secrets Manager secrets are available in this account and region.
+      </div>
 
-    <div class="col-md-7" ng-if="$ctrl.command.backingData.filtered.secrets.length">
-      <ui-select
-        ng-model="$ctrl.command.dockerImageCredentialsSecret"
-        class="form-control input-sm"
-        required
-        on-select="$ctrl.fieldChanged()"
-      >
-        <ui-select-match>{{ $select.selected }}</ui-select-match>
-        <ui-select-choices repeat="secret in $ctrl.command.backingData.filtered.secrets | filter: $select.search">
-          <span ng-bind-html="secret"></span>
-        </ui-select-choices>
-      </ui-select>
+      <div class="col-md-7" ng-if="$ctrl.command.backingData.filtered.secrets.length">
+        <ui-select
+          ng-model="$ctrl.command.dockerImageCredentialsSecret"
+          class="form-control input-sm"
+          required
+          on-select="$ctrl.fieldChanged()"
+        >
+          <ui-select-match>{{ $select.selected }}</ui-select-match>
+          <ui-select-choices repeat="secret in $ctrl.command.backingData.filtered.secrets | filter: $select.search">
+            <span ng-bind-html="secret"></span>
+          </ui-select-choices>
+        </ui-select>
+      </div>
     </div>
   </div>
 
@@ -114,10 +116,10 @@
                 class="form-control input-sm"
                 ng-model="constraint.type"
                 ng-options="type for type in ['distinctInstance', 'memberOf']"
-              />
+              ></select>
             </td>
             <td>
-              <input type="text" class="form-control input-sm no-spel" ng-model="constraint.expression"/>
+              <input type="text" class="form-control input-sm no-spel" ng-model="constraint.expression" />
             </td>
             <td>
               <div class="form-control-static">
@@ -143,20 +145,22 @@
     </form>
   </div>
 
-  <div class="form-group">
-    <div class="sm-label-left">
-      <b>Docker labels (optional)</b>
-      <help-field key="ecs.dockerLabels"></help-field>
+  <div ng-if="!$ctrl.command.useTaskDefinitionArtifact">
+    <div class="form-group">
+      <div class="sm-label-left">
+        <b>Docker labels (optional)</b>
+        <help-field key="ecs.dockerLabels"></help-field>
+      </div>
+      <map-editor model="$ctrl.command.dockerLabels" allow-empty="true"></map-editor>
     </div>
-    <map-editor model="$ctrl.command.dockerLabels" allow-empty="true"></map-editor>
-  </div>
 
-  <div class="form-group">
-    <div class="sm-label-left">
-      <b>Environment Variables (optional)</b>
-      <help-field key="ecs.environmentVariables"></help-field>
+    <div class="form-group">
+      <div class="sm-label-left">
+        <b>Environment Variables (optional)</b>
+        <help-field key="ecs.environmentVariables"></help-field>
+      </div>
+      <map-editor model="$ctrl.command.environmentVariables" allow-empty="true"></map-editor>
     </div>
-    <map-editor model="$ctrl.command.environmentVariables" allow-empty="true"></map-editor>
   </div>
 
   <div class="form-group">
@@ -165,5 +169,16 @@
       <help-field key="ecs.tags"></help-field>
     </div>
     <map-editor model="$ctrl.command.tags" allow-empty="true"></map-editor>
+  </div>
+
+  <div ng-if="$ctrl.command.useTaskDefinitionArtifact" style="color:#666;">
+    <hr />
+    <p>
+      <em
+        ><strong>Docker Image Credentials, Docker labels</strong>, and <strong>Environment Variables</strong> cannot be
+        individually set when using a Task Definition artifact. Please include them in their respective container
+        definition in that file.
+      </em>
+    </p>
   </div>
 </div>

--- a/app/scripts/modules/ecs/src/serverGroup/configure/wizard/serverGroupWizard.html
+++ b/app/scripts/modules/ecs/src/serverGroup/configure/wizard/serverGroupWizard.html
@@ -13,15 +13,22 @@
       <v2-wizard-page key="networking" label="Networking" done="true">
         <ng-include src="pages.networking"></ng-include>
       </v2-wizard-page>
-      <v2-wizard-page key="container" label="Container" done="true">
-        <ng-include src="pages.container"></ng-include>
+      <v2-wizard-page key="taskDefinition" label="Task Definition" done="true">
+        <ng-include src="pages.taskDefinition"></ng-include>
       </v2-wizard-page>
+      <div ng-if="!command.useTaskDefinitionArtifact">
+        <v2-wizard-page key="container" label="Container" done="true">
+          <ng-include src="pages.container"></ng-include>
+        </v2-wizard-page>
+      </div>
       <v2-wizard-page key="horizontalScaling" label="Horizontal Scaling" done="true">
         <ng-include src="pages.horizontalScaling"></ng-include>
       </v2-wizard-page>
-      <v2-wizard-page key="logging" label="Logging" done="true">
-        <ng-include src="pages.logging"></ng-include>
-      </v2-wizard-page>
+      <div ng-if="!command.useTaskDefinitionArtifact">
+        <v2-wizard-page key="logging" label="Logging" done="true">
+          <ng-include src="pages.logging"></ng-include>
+        </v2-wizard-page>
+      </div>
       <v2-wizard-page key="serviceDiscovery" label="Service Discovery" done="true">
         <ng-include src="pages.serviceDiscovery"></ng-include>
       </v2-wizard-page>

--- a/app/scripts/modules/ecs/src/serverGroup/configure/wizard/taskDefinition/TaskDefinition.tsx
+++ b/app/scripts/modules/ecs/src/serverGroup/configure/wizard/taskDefinition/TaskDefinition.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { module, IPromise } from 'angular';
+import { concat, uniq } from 'lodash';
 import { react2angular } from 'react2angular';
 import {
   IEcsContainerMapping,
@@ -142,8 +143,14 @@ export class TaskDefinition extends React.Component<ITaskDefinitionProps, ITaskD
     this.setState({ containerMappings: currentMappings });
   };
 
-  // NoOp here, but required by StageArtifactSelectorDelegate.
-  private updatePipeline = (pipeline: IPipeline): void => {};
+  private updatePipeline = (pipeline: IPipeline): void => {
+    if (pipeline.expectedArtifacts && pipeline.expectedArtifacts.length > 0) {
+      const oldArtifacts = this.props.command.viewState.pipeline.expectedArtifacts;
+      const updatedArtifacts = concat(pipeline.expectedArtifacts, oldArtifacts);
+      pipeline.expectedArtifacts = uniq(updatedArtifacts);
+      this.props.notifyAngular('pipeline', pipeline);
+    }
+  };
 
   public render(): React.ReactElement<TaskDefinition> {
     const { command } = this.props;

--- a/app/scripts/modules/ecs/src/serverGroup/configure/wizard/taskDefinition/TaskDefinition.tsx
+++ b/app/scripts/modules/ecs/src/serverGroup/configure/wizard/taskDefinition/TaskDefinition.tsx
@@ -159,8 +159,13 @@ export class TaskDefinition extends React.Component<ITaskDefinitionProps, ITaskD
     const updateContainerMappingImage = this.updateContainerMappingImage;
 
     const dockerImages = this.state.dockerImages.map(function(image, index) {
+      let msg = '';
+      if (image.fromTrigger || image.fromContext) {
+        msg = image.fromTrigger ? '(TRIGGER) ' : '(FIND IMAGE RESULT) ';
+      }
       return (
         <option key={index} value={image.imageId}>
+          {msg}
           {image.imageId}
         </option>
       );

--- a/app/scripts/modules/ecs/src/serverGroup/configure/wizard/taskDefinition/TaskDefinition.tsx
+++ b/app/scripts/modules/ecs/src/serverGroup/configure/wizard/taskDefinition/TaskDefinition.tsx
@@ -1,0 +1,287 @@
+import * as React from 'react';
+import { module, IPromise } from 'angular';
+import { react2angular } from 'react2angular';
+import {
+  IEcsContainerMapping,
+  IEcsDockerImage,
+  IEcsServerGroupCommand,
+  IEcsTaskDefinitionArtifact,
+} from '../../serverGroupConfiguration.service';
+import {
+  ArtifactTypePatterns,
+  HelpField,
+  IArtifact,
+  IExpectedArtifact,
+  IPipeline,
+  StageArtifactSelectorDelegate,
+} from '@spinnaker/core';
+
+export interface ITaskDefinitionProps {
+  command: IEcsServerGroupCommand;
+  notifyAngular: (key: string, value: any) => void;
+  configureCommand: (query: string) => IPromise<void>;
+}
+
+interface ITaskDefinitionState {
+  taskDefArtifact: IEcsTaskDefinitionArtifact;
+  taskDefArtifactAccount: string;
+  containerMappings: IEcsContainerMapping[];
+  dockerImages: IEcsDockerImage[];
+  loadBalancedContainer: string;
+}
+
+export class TaskDefinition extends React.Component<ITaskDefinitionProps, ITaskDefinitionState> {
+  constructor(props: ITaskDefinitionProps) {
+    super(props);
+    const cmd = this.props.command;
+    let defaultContainer = '';
+    if (cmd.containerMappings && cmd.containerMappings.length > 0) {
+      defaultContainer = cmd.containerMappings[0].containerName;
+    }
+
+    this.state = {
+      taskDefArtifact: cmd.taskDefinitionArtifact,
+      containerMappings: cmd.containerMappings ? cmd.containerMappings : [],
+      dockerImages: cmd.backingData && cmd.backingData.filtered ? cmd.backingData.filtered.images : [],
+      loadBalancedContainer: cmd.loadBalancedContainer || defaultContainer,
+      taskDefArtifactAccount: cmd.taskDefinitionArtifactAccount,
+    };
+  }
+
+  public componentDidMount() {
+    this.props.configureCommand('1').then(() => {
+      this.setState({ dockerImages: this.props.command.backingData.filtered.images });
+    });
+  }
+
+  private getIdToImageMap = (): Map<string, IEcsDockerImage> => {
+    const imageIdToDescription = new Map<string, IEcsDockerImage>();
+    this.props.command.backingData.filtered.images.forEach(e => {
+      imageIdToDescription.set(e.imageId, e);
+    });
+
+    return imageIdToDescription;
+  };
+
+  private getEmptyImageDescription = (): IEcsDockerImage => {
+    return {
+      imageId: '',
+      message: '',
+      fromTrigger: false,
+      fromContext: false,
+      stageId: '',
+      imageLabelOrSha: '',
+      account: '',
+      registry: '',
+      repository: '',
+      tag: '',
+    };
+  };
+
+  private excludedArtifactTypePatterns = [
+    ArtifactTypePatterns.KUBERNETES,
+    ArtifactTypePatterns.DOCKER_IMAGE,
+    ArtifactTypePatterns.FRONT50_PIPELINE_TEMPLATE,
+    ArtifactTypePatterns.EMBEDDED_BASE64,
+  ];
+
+  private onExpectedArtifactSelected = (expectedArtifactId: string): void => {
+    const selectedArtifact = { artifactId: expectedArtifactId };
+    this.props.notifyAngular('taskDefinitionArtifact', selectedArtifact);
+    this.setState({ taskDefArtifact: selectedArtifact });
+  };
+
+  private onArtifactEdited = (artifact: IArtifact): void => {
+    const newArtifact = { artifact: artifact };
+    this.props.notifyAngular('taskDefinitionArtifact', newArtifact);
+    this.setState({ taskDefArtifact: newArtifact });
+  };
+
+  private setArtifactAccount = (accountName: string): void => {
+    this.props.notifyAngular('taskDefinitionArtifactAccount', accountName);
+    this.setState({ taskDefArtifactAccount: accountName });
+  };
+
+  private pushMapping = () => {
+    const conMaps = this.state.containerMappings;
+    conMaps.push({ containerName: '', imageDescription: this.getEmptyImageDescription() });
+    this.setState({ containerMappings: conMaps });
+  };
+
+  private updateContainerMappingName = (index: number, newName: string) => {
+    const currentMappings = this.state.containerMappings;
+    const targetMapping = currentMappings[index];
+    targetMapping.containerName = newName;
+    this.props.notifyAngular('containerMappings', currentMappings);
+    this.setState({ containerMappings: currentMappings });
+  };
+
+  private updateContainerMappingImage = (index: number, newImage: string) => {
+    const imageMap = this.getIdToImageMap();
+    let newImageDescription = imageMap.get(newImage);
+
+    if (!newImageDescription) {
+      newImageDescription = this.getEmptyImageDescription();
+    }
+    const currentMappings = this.state.containerMappings;
+    const targetMapping = currentMappings[index];
+    targetMapping.imageDescription = newImageDescription;
+    this.props.notifyAngular('containerMappings', currentMappings);
+    this.setState({ containerMappings: currentMappings });
+  };
+
+  private updateLoadBalancedContainer = (containerName: string) => {
+    this.props.notifyAngular('loadBalancedContainer', containerName);
+    this.setState({ loadBalancedContainer: containerName });
+  };
+
+  private removeMapping = (index: number) => {
+    const currentMappings = this.state.containerMappings;
+    currentMappings.splice(index, 1);
+    this.props.notifyAngular('containerMappings', currentMappings);
+    this.setState({ containerMappings: currentMappings });
+  };
+
+  // NoOp here, but required by StageArtifactSelectorDelegate.
+  private updatePipeline = (pipeline: IPipeline): void => {};
+
+  public render(): React.ReactElement<TaskDefinition> {
+    const { command } = this.props;
+    const removeMapping = this.removeMapping;
+    const updateContainerMappingName = this.updateContainerMappingName;
+    const updateContainerMappingImage = this.updateContainerMappingImage;
+
+    const dockerImages = this.state.dockerImages.map(function(image, index) {
+      return (
+        <option key={index} value={image.imageId}>
+          {image.imageId}
+        </option>
+      );
+    });
+
+    const mappingInputs = this.state.containerMappings.map(function(mapping, index) {
+      return (
+        <tr key={index}>
+          <td>
+            <input
+              className="form-control input-sm"
+              required={true}
+              placeholder="enter container name..."
+              value={mapping.containerName.toString()}
+              onChange={e => updateContainerMappingName(index, e.target.value)}
+            />
+          </td>
+          <td>
+            <select
+              className="form-control input-sm"
+              value={mapping.imageDescription.imageId}
+              required={true}
+              onChange={e => updateContainerMappingImage(index, e.target.value)}
+            >
+              <option value={''}>Select an image to use...</option>
+              {dockerImages}
+            </select>
+          </td>
+          <td>
+            <div className="form-control-static">
+              <a className="btn-link sm-label" onClick={() => removeMapping(index)}>
+                <span className="glyphicon glyphicon-trash" />
+                <span className="sr-only">Remove</span>
+              </a>
+            </div>
+          </td>
+        </tr>
+      );
+    });
+
+    const containerOptions = this.state.containerMappings.map(function(mapping, index) {
+      return (
+        <option key={index} value={mapping.containerName}>
+          {mapping.containerName}
+        </option>
+      );
+    });
+
+    return (
+      <div className="container-fluid form-horizontal">
+        <div className="form-group">
+          <div className="col-md-12">
+            <StageArtifactSelectorDelegate
+              artifact={this.state.taskDefArtifact.artifact}
+              excludedArtifactTypePatterns={this.excludedArtifactTypePatterns}
+              expectedArtifactId={this.state.taskDefArtifact.artifactId}
+              label="Artifact"
+              helpKey="ecs.taskDefinitionArtifact"
+              onExpectedArtifactSelected={(artifact: IExpectedArtifact) => this.onExpectedArtifactSelected(artifact.id)}
+              onArtifactEdited={this.onArtifactEdited}
+              pipeline={command.viewState.pipeline}
+              selectedArtifactId={this.state.taskDefArtifact.artifactId}
+              selectedArtifactAccount={this.state.taskDefArtifactAccount}
+              setArtifactAccount={this.setArtifactAccount}
+              setArtifactId={this.onExpectedArtifactSelected}
+              stage={command.viewState.currentStage}
+              updatePipeline={this.updatePipeline}
+            />
+          </div>
+        </div>
+        <div className="form-group">
+          <div className="col-md-3 sm-label-right">
+            <strong>Load balanced container</strong>
+            <HelpField id="ecs.loadBalancedContainer" />
+          </div>
+          <div className="col-md-9">
+            <select
+              className="form-control input-sm"
+              required={command.targetGroup ? true : false}
+              value={this.state.loadBalancedContainer}
+              onChange={e => this.updateLoadBalancedContainer(e.target.value)}
+            >
+              <option value={''}>{'Select a container for load balancer traffic...'}</option>
+              {containerOptions}
+            </select>
+          </div>
+        </div>
+        <div className="form-group">
+          <div className="sm-label-left">
+            <b>Container Mappings</b>
+            <HelpField id="ecs.containerMappings" />
+          </div>
+          <form name="ecsTaskDefinitionContainerMappings">
+            <table className="table table-condensed packed tags">
+              <thead>
+                <tr key="header">
+                  <th style={{ width: '30%' }}>
+                    Container name
+                    <HelpField id="ecs.containerMappingName" />
+                  </th>
+                  <th style={{ width: '70%' }}>
+                    Container image
+                    <HelpField id="ecs.containerMappingImage" />
+                  </th>
+                  <th />
+                </tr>
+              </thead>
+              <tbody>{mappingInputs}</tbody>
+              <tfoot>
+                <tr>
+                  <td colSpan={3}>
+                    <button className="btn btn-block btn-sm add-new" onClick={this.pushMapping}>
+                      <span className="glyphicon glyphicon-plus-sign" />
+                      Add New Container Mapping
+                    </button>
+                  </td>
+                </tr>
+              </tfoot>
+            </table>
+          </form>
+        </div>
+      </div>
+    );
+  }
+}
+
+export const TASK_DEFINITION_REACT = 'spinnaker.ecs.serverGroup.configure.wizard.taskDefinition.react';
+module(TASK_DEFINITION_REACT, []).component(
+  'taskDefinitionReact',
+  react2angular(TaskDefinition, ['command', 'notifyAngular', 'configureCommand']),
+);

--- a/app/scripts/modules/ecs/src/serverGroup/configure/wizard/taskDefinition/taskDefinition.html
+++ b/app/scripts/modules/ecs/src/serverGroup/configure/wizard/taskDefinition/taskDefinition.html
@@ -1,0 +1,44 @@
+<div class="clearfix">
+  <div class="row">
+    <div class="col-md-12">
+      <div class="container-fluid form-horizontal">
+        <div class="form-group">
+          <div class="col-md-4 sm-label-right">
+            <b>Task Definition source</b>
+            <help-field key="ecs.taskDefinition"></help-field>
+          </div>
+          <div class="col-md-2 radio">
+            <label>
+              <input
+                type="radio"
+                ng-model="command.useTaskDefinitionArtifact"
+                ng-value="false"
+                id="taskDefinitionSourceInputs"
+              />
+              Inputs
+            </label>
+          </div>
+          <div class="col-md-1 radio">
+            <label>
+              <input
+                type="radio"
+                ng-model="command.useTaskDefinitionArtifact"
+                ng-value="true"
+                id="taskDefinitionSourceArtifact"
+              />
+              Artifact
+            </label>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-12" ng-if="command.useTaskDefinitionArtifact">
+      <hr />
+      <task-definition-react
+        command="command"
+        notify-angular="notifyAngular"
+        configure-command="configureCommand"
+      ></task-definition-react>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
Add support for deploying an ECS Task Definition as an artifact.

* Implements https://github.com/spinnaker/spinnaker/issues/4070
* Fixes https://github.com/spinnaker/spinnaker/issues/3341

This feature allows Task Definition attributes, including multiple containers, to be defined in an artifact (JSON file) and used in conjunction with pipeline images and other server group settings to deploy to ECS.

### New UI

![image](https://user-images.githubusercontent.com/34254888/60322315-fee03880-9933-11e9-804c-c724c45aefcc.png)
