### PR TITLE
Bump package core to 0.0.380 and docker to 0.0.43 and amazon to 0.0.198 and titus to 0.0.100

### DIFF
--- a/app/scripts/modules/amazon/package.json
+++ b/app/scripts/modules/amazon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/amazon",
-  "version": "0.0.197",
+  "version": "0.0.198",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/core",
-  "version": "0.0.379",
+  "version": "0.0.380",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/docker/package.json
+++ b/app/scripts/modules/docker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/docker",
-  "version": "0.0.42",
+  "version": "0.0.43",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/titus/package.json
+++ b/app/scripts/modules/titus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/titus",
-  "version": "0.0.99",
+  "version": "0.0.100",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
### chore(core): Bump version to 0.0.380

2fd1aa97195cc1bf8c26447a3d144e6d6192021f  feat(core/amazon): add a visual indicator to infra managed by Keel (#7161)

### chore(docker): Bump version to 0.0.43

e08e36f58edc81ee3143a08a57834bfd6c420d6f feat(docker): allow extra inline help on tag selector (#7143)

### chore(amazon): Bump version to 0.0.198

2fd1aa97195cc1bf8c26447a3d144e6d6192021f  feat(core/amazon): add a visual indicator to infra managed by Keel (#7161)

### chore(titus): Bump version to 0.0.100

422be22d3a6563eeab280afc0c4b9176fe6d9705 fix(titus): allow security group in cluster config by name (#7160)
cdd6f2379859d3c2b13bac59aa470c08b391a865 chore(package): Just Update Prettier™


