### PR TITLE
fix(runjob): Fixing security group matching by name

### DIFF
--- a/app/scripts/modules/titus/src/pipeline/stages/runJob/TitusSecurityGroupPicker.tsx
+++ b/app/scripts/modules/titus/src/pipeline/stages/runJob/TitusSecurityGroupPicker.tsx
@@ -105,7 +105,7 @@ export class TitusSecurityGroupPicker extends React.Component<
         return match ? match.name : groupId;
       });
 
-      const matchedGroups: ISecurityGroup[] = groupsToEdit
+      const matchedGroups: ISecurityGroup[] = oldGroupNames
         .map((groupId: string) => {
           const securityGroup: any = availableGroups.find(o => o.id === groupId || o.name === groupId);
           return securityGroup ? securityGroup.name : null;


### PR DESCRIPTION
Looks like this was also 99% there but using the wrong variable made mapping IDs to names then back to IDs in the new account/region not work.