### PR TITLE
fix(core): correctly build permalinks for executions

### DIFF
--- a/app/scripts/modules/core/src/pipeline/executions/execution/ExecutionPermalink.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/execution/ExecutionPermalink.tsx
@@ -8,17 +8,14 @@ export interface IExecutionPermalinkProps {
 }
 
 export const ExecutionPermalink = ({ standalone }: IExecutionPermalinkProps) => {
-  const [url, setUrl] = React.useState(location.href);
+  const asPermalink = (link: string) => (standalone ? link : link.replace('/executions', '/executions/details'));
+
+  const [url, setUrl] = React.useState(asPermalink(location.href));
 
   React.useEffect(() => {
-    const subscription = ReactInjector.stateEvents.locationChangeSuccess.subscribe(() => {
-      const newUrl = location.href;
+    const subscription = ReactInjector.stateEvents.locationChangeSuccess.subscribe(newUrl => {
       if (url !== newUrl) {
-        if (!standalone) {
-          setUrl(newUrl);
-        } else {
-          setUrl(newUrl.replace('/executions', '/executions/details'));
-        }
+        setUrl(asPermalink(newUrl));
       }
     });
     return () => subscription.unsubscribe();


### PR DESCRIPTION
Kinda derped this one by not handling the initial case where the details render right away on a hydrated execution.