### PR TITLE
fix(ecs): Set viewState.mode when creating server group for pipeline

### DIFF
--- a/app/scripts/modules/ecs/src/serverGroup/configure/serverGroupCommandBuilder.service.js
+++ b/app/scripts/modules/ecs/src/serverGroup/configure/serverGroupCommandBuilder.service.js
@@ -231,6 +231,7 @@ module.exports = angular
             // applies viewState overrides after template selection
             overrides: {
               viewState: {
+                mode: 'editPipeline',
                 contextImages: contextImages,
                 pipeline: pipeline,
                 currentStage: current,


### PR DESCRIPTION
Currently, creating an ECS server group within the `deploy` stage of a pipeline results in server group creation happening immediately, but then it FAILS to join the pipeline (it's visible in the 'Clusters' screen but not within the `deploy` stage originally being edited). 

This is b/c the view state "mode" is not set when building a server group for a pipeline, resulting in "create" behavior vs. "editPipeline" behavior. 

This change sets the mode to "editPipeline", which adds the server group to the deploy stage being edited and executes creation on pipeline deployment (same behavior as when adding a server group to the stage via JSON).

