### PR TITLE
fix(ecs): Disable artifact selection outside of pipelines

### DIFF
--- a/app/scripts/modules/ecs/src/serverGroup/configure/wizard/taskDefinition/taskDefinition.html
+++ b/app/scripts/modules/ecs/src/serverGroup/configure/wizard/taskDefinition/taskDefinition.html
@@ -24,14 +24,14 @@
                 type="radio"
                 ng-model="command.useTaskDefinitionArtifact"
                 ng-value="true"
-                ng-disabled="command.viewState.mode == 'create'"
+                ng-disabled="command.viewState.mode === 'create'"
                 id="taskDefinitionSourceArtifact"
               />
               Artifact
             </label>
           </div>
         </div>
-        <div ng-if="command.viewState.mode == 'create'" style="color:#666;">
+        <div ng-if="command.viewState.mode === 'create'" class="color-text-caption">
           <hr />
           <span><em>Artifacts not supported outside of pipelines.</em></span>
         </div>

--- a/app/scripts/modules/ecs/src/serverGroup/configure/wizard/taskDefinition/taskDefinition.html
+++ b/app/scripts/modules/ecs/src/serverGroup/configure/wizard/taskDefinition/taskDefinition.html
@@ -24,11 +24,16 @@
                 type="radio"
                 ng-model="command.useTaskDefinitionArtifact"
                 ng-value="true"
+                ng-disabled="command.viewState.mode == 'create'"
                 id="taskDefinitionSourceArtifact"
               />
               Artifact
             </label>
           </div>
+        </div>
+        <div ng-if="command.viewState.mode == 'create'" style="color:#666;">
+          <hr />
+          <span><em>Artifacts not supported outside of pipelines.</em></span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Disables artifact selection when creating an ECS server group outside of a pipeline (since pipeline "expected artifacts" are needed for them to work). 

### New UI msg
![artifacts_disabled_msg](https://user-images.githubusercontent.com/34254888/60470280-c632ae80-9c14-11e9-96f3-4ed8a0ab49d1.PNG)
