### PR TITLE
Bump package core to 0.0.382 and amazon to 0.0.199

### DIFF
--- a/app/scripts/modules/amazon/package.json
+++ b/app/scripts/modules/amazon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/amazon",
-  "version": "0.0.198",
+  "version": "0.0.199",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/core",
-  "version": "0.0.381",
+  "version": "0.0.382",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
### chore(core): Bump version to 0.0.382

51b8d2dab596db97ea9e6110cb6e2317ad97bb43 feat(trigger): Allow entry of explicit build number (#7176)
9eb04b48eb5d667f963e3496a23bbb7626047c8e fix(pipeline): Fixed stage config for faileventual (#7174)
40eb9394247966f51b1975bbbb069ebda8593a82 feat(core/task): UserVerification: Accept an 'account' prop. (#7173)
97c4aed44ea05672dcbdc2316cc857fb1f96c0dc refactor(core/serverGroup): Extract MinMaxDesiredChanges component (#7171)

### chore(amazon): Bump version to 0.0.199

97c4aed44ea05672dcbdc2316cc857fb1f96c0dc refactor(core/serverGroup): Extract MinMaxDesiredChanges component (#7171)


