### PR TITLE
fix(core): fix flickering render of stage labels on hydration

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/common/ExecutionBarLabel.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/common/ExecutionBarLabel.tsx
@@ -27,8 +27,13 @@ export class ExecutionBarLabel extends React.Component<IExecutionBarLabelProps, 
   }
 
   private hydrate = (): void => {
-    const { execution, application } = this.props;
-    if (!execution) {
+    const { stage, application, execution } = this.props;
+    const { suspendedStageTypes } = stage;
+    const suspendedTypesNeedingHydration = ['restrictExecutionDuringTimeWindow', 'waitForCondition'];
+    const requiresHydration =
+      stage.labelComponent !== ExecutionBarLabel ||
+      suspendedTypesNeedingHydration.some(s => suspendedStageTypes.has(s));
+    if (!requiresHydration || !execution || execution.hydrated) {
       return;
     }
     ReactInjector.executionService.hydrate(application, execution).then(() => {
@@ -46,61 +51,50 @@ export class ExecutionBarLabel extends React.Component<IExecutionBarLabelProps, 
     this.mounted = false;
   }
 
-  public render() {
-    const { stage, application, execution, executionMarker } = this.props;
-    const { suspendedStageTypes } = stage;
-    if (suspendedStageTypes.has('restrictExecutionDuringTimeWindow') && executionMarker) {
-      const executionWindowStage = stage.stages.find(s => s.type === 'restrictExecutionDuringTimeWindow');
-      const template = (
-        <div>
-          <div>
-            <b>{stage.name}</b> (waiting for execution window)
-          </div>
-          <ExecutionWindowActions application={application} execution={execution} stage={executionWindowStage} />
-        </div>
-      );
-      return <HoverablePopover template={template}>{this.props.children}</HoverablePopover>;
-    } else if (suspendedStageTypes.has('waitForCondition') && executionMarker) {
-      const waitForConditionStage = stage.stages.find(s => s.type === 'waitForCondition');
-      const template = (
-        <div>
-          <p>
-            <b>{stage.name}</b> (waiting until conditions are met)
-          </p>
-          Conditions:
-          <SkipConditionWait application={application} execution={execution} stage={waitForConditionStage} />
-        </div>
-      );
-      return <HoverablePopover template={template}>{this.props.children}</HoverablePopover>;
-    }
-    if (executionMarker) {
-      const LabelComponent = stage.labelComponent;
-      if (LabelComponent !== ExecutionBarLabel && !this.state.hydrated) {
-        const loadingTooltip = (
-          <Tooltip id={stage.id}>
-            <Spinner size="small" />
-          </Tooltip>
-        );
-        return (
-          <span onMouseEnter={this.hydrate}>
-            <OverlayTrigger placement="top" overlay={loadingTooltip}>
-              {this.props.children}
-            </OverlayTrigger>
-          </span>
-        );
-      }
-      const tooltip = (
-        <Tooltip id={stage.id}>
-          <LabelComponent application={application} execution={execution} stage={stage} />
-        </Tooltip>
-      );
-      return (
-        <OverlayTrigger placement="top" overlay={tooltip}>
-          {this.props.children}
-        </OverlayTrigger>
-      );
-    }
+  private DefaultLabel = () => {
+    const { stage, application, execution } = this.props;
+    const LabelComponent = stage.labelComponent;
+    const tooltip = (
+      <Tooltip id={stage.id}>
+        <LabelComponent application={application} execution={execution} stage={stage} />
+      </Tooltip>
+    );
+    return (
+      <OverlayTrigger placement="top" overlay={tooltip}>
+        {this.props.children}
+      </OverlayTrigger>
+    );
+  };
 
+  private getExecutionWindowTemplate = () => {
+    const { stage, application, execution } = this.props;
+    const executionWindowStage = stage.stages.find(s => s.type === 'restrictExecutionDuringTimeWindow');
+    return (
+      <div>
+        <div>
+          <b>{stage.name}</b> (waiting for execution window)
+        </div>
+        <ExecutionWindowActions application={application} execution={execution} stage={executionWindowStage} />
+      </div>
+    );
+  };
+
+  private getWaitForConditionTemplate = () => {
+    const { stage, application, execution } = this.props;
+    const waitForConditionStage = stage.stages.find(s => s.type === 'waitForCondition');
+    return (
+      <div>
+        <p>
+          <b>{stage.name}</b> (waiting until conditions are met)
+        </p>
+        Conditions:
+        <SkipConditionWait application={application} execution={execution} stage={waitForConditionStage} />
+      </div>
+    );
+  };
+
+  private getRenderableStageName(): string {
+    const { stage } = this.props;
     let stageName = stage.name ? stage.name : stage.type;
     const params = ReactInjector.$uiRouter.globals.params;
     if (stage.type === 'group' && stage.groupStages && stage.index === Number(params.stage)) {
@@ -112,6 +106,37 @@ export class ExecutionBarLabel extends React.Component<IExecutionBarLabelProps, 
         }
       }
     }
-    return <span>{stageName}</span>;
+    return stageName;
+  }
+
+  public render() {
+    const { stage, execution, executionMarker } = this.props;
+    const { suspendedStageTypes } = stage;
+    const { getExecutionWindowTemplate, getWaitForConditionTemplate, DefaultLabel } = this;
+    if (executionMarker) {
+      const suspendedTypesNeedingHydration = ['restrictExecutionDuringTimeWindow', 'waitForCondition'];
+      const requiresHydration =
+        stage.labelComponent !== ExecutionBarLabel ||
+        suspendedTypesNeedingHydration.some(s => suspendedStageTypes.has(s));
+      let template: JSX.Element = null;
+      if (requiresHydration && !execution.hydrated) {
+        template = <Spinner size="small" />;
+      } else if (suspendedStageTypes.has('restrictExecutionDuringTimeWindow')) {
+        template = getExecutionWindowTemplate();
+      } else if (suspendedStageTypes.has('waitForCondition')) {
+        template = getWaitForConditionTemplate();
+      }
+      if (template) {
+        return (
+          <span onMouseEnter={this.hydrate}>
+            <HoverablePopover template={template}>{this.props.children}</HoverablePopover>
+          </span>
+        );
+      } else {
+        return <DefaultLabel />;
+      }
+    }
+
+    return <span>{this.getRenderableStageName()}</span>;
   }
 }

--- a/app/scripts/modules/core/src/pipeline/config/stages/concourse/concourseStage.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/concourse/concourseStage.ts
@@ -12,7 +12,6 @@ Registry.pipeline.registerStage({
   },
   component: ConcourseStageConfig,
   executionDetailsSections: [ConcourseExecutionDetails],
-  useCustomTooltip: true,
   strategy: true,
   validators: [
     { type: 'requiredField', fieldName: 'master' },

--- a/app/scripts/modules/core/src/pipeline/config/stages/entityTags/applyEntityTagsStage.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/entityTags/applyEntityTagsStage.ts
@@ -13,7 +13,6 @@ Registry.pipeline.registerStage({
   },
   component: ApplyEntityTagsStageConfig,
   executionDetailsSections: [ApplyEntityTagsExecutionDetails, ExecutionDetailsTasks],
-  useCustomTooltip: true,
   strategy: true,
   validators: [{ type: 'requiredField', fieldName: 'entityRef.entityType' }],
 });

--- a/app/scripts/modules/core/src/pipeline/config/stages/evaluateVariables/evaluateVariablesStage.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/evaluateVariables/evaluateVariablesStage.ts
@@ -14,7 +14,6 @@ Registry.pipeline.registerStage({
   },
   component: EvaluateVariablesStageConfig,
   executionDetailsSections: [EvaluateVariablesExecutionDetails, ExecutionDetailsTasks],
-  useCustomTooltip: true,
   strategy: true,
   validators: [{ type: 'requiredField', fieldName: 'variables' }],
 });

--- a/app/scripts/modules/core/src/presentation/HoverablePopover.tsx
+++ b/app/scripts/modules/core/src/presentation/HoverablePopover.tsx
@@ -165,6 +165,7 @@ export class HoverablePopover extends React.Component<IHoverablePopoverProps, IH
           placement={placementOverride || placement}
           target={this.targetRef.current}
           container={container}
+          shouldUpdatePosition={true}
         >
           <PopoverOffset
             ref={this.rendererRefCallback}


### PR DESCRIPTION
You know the annoying thing where you hover over a stage and you get a loading indicator in a tooltip, and then it just goes away, and you have to mouse out and then back over the stage to see the label? This fixes that.