### PR TITLE
fix(executions): Clarify why executions are NOT_STARTED

### DIFF
--- a/app/scripts/modules/core/src/domain/IExecution.ts
+++ b/app/scripts/modules/core/src/domain/IExecution.ts
@@ -22,6 +22,7 @@ export interface IExecution extends IOrchestratedItem {
   id: string;
   isComplete?: boolean;
   isStrategy?: boolean;
+  limitConcurrent?: boolean;
   name?: string;
   pipelineConfigId?: string;
   pipelineConfig?: IPipeline;

--- a/app/scripts/modules/core/src/pipeline/executions/execution/Execution.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/execution/Execution.tsx
@@ -360,7 +360,7 @@ export class Execution extends React.PureComponent<IExecutionProps, IExecutionSt
                     >
                       <a>RUNNING</a>
                     </UISref>{' '}
-                    executions
+                    executions)
                   </>
                 )}
               </span>

--- a/app/scripts/modules/core/src/pipeline/executions/execution/Execution.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/execution/Execution.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import * as ReactGA from 'react-ga';
+import { UISref } from '@uirouter/react';
 import { isEqual } from 'lodash';
 import { $location } from 'ngimport';
 import { Subscription } from 'rxjs';
@@ -294,6 +295,7 @@ export class Execution extends React.PureComponent<IExecutionProps, IExecutionSt
       pipelineConfig,
     } = this.props;
     const { pipelinesUrl, restartDetails, showingDetails, sortFilter, viewState } = this.state;
+    const { $state } = ReactInjector;
 
     const accountLabels = this.props.execution.deploymentTargets.map(account => (
       <AccountTag key={account} account={account} />
@@ -348,6 +350,19 @@ export class Execution extends React.PureComponent<IExecutionProps, IExecutionSt
               Status:{' '}
               <span className={`status execution-status execution-status-${execution.status.toLowerCase()}`}>
                 {execution.status}
+                {execution.status === 'NOT_STARTED' && execution.limitConcurrent && (
+                  <>
+                    {' '}
+                    waiting on{' '}
+                    <UISref
+                      to={`${$state.current.name.endsWith('.execution') ? '^' : ''}.^.executions`}
+                      params={{ pipeline: execution.name, status: 'RUNNING' }}
+                    >
+                      <a>RUNNING</a>
+                    </UISref>{' '}
+                    executions
+                  </>
+                )}
               </span>
               {execution.cancellationReason && (
                 <Tooltip value={execution.cancellationReason}>

--- a/app/scripts/modules/core/src/pipeline/executions/execution/Execution.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/execution/Execution.tsx
@@ -352,7 +352,7 @@ export class Execution extends React.PureComponent<IExecutionProps, IExecutionSt
                 {execution.status}
                 {execution.status === 'NOT_STARTED' && execution.limitConcurrent && (
                   <>
-                    {' '}
+                    {' ('}
                     waiting on{' '}
                     <UISref
                       to={`${$state.current.name.endsWith('.execution') ? '^' : ''}.^.executions`}


### PR DESCRIPTION
Users are sometimes confused why their executions are "stuck" in `NOT_STARTED` state and it's usually because there is a `RUNNING` execution and the pipeline is configured with concurrent executions disabled (the default).

This change just explains it better when `limitConcurrent` is `true`. As a bonus, clicking `RUNNING` also links to executions filtered to running executions of the pipeline in question (there should only be one): 
<img width="163" alt="aquachpy_·_Pipeline_Executions" src="https://user-images.githubusercontent.com/1633736/60620427-07030280-9d90-11e9-8225-5cc22eeb04d4.png">
