### PR TITLE
chore(core): Bump version to 0.0.384

### DIFF
--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/core",
-  "version": "0.0.383",
+  "version": "0.0.384",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
### chore(core): Bump version to 0.0.384

ecb2dd17aea1958e78089ed58f18a19ed502998f feat(gce): Support new artifact model for deploy SG (#7178)
c93b4d0130011aa6be927c3ce9760faf1a9e5890 fix(executions): Clarify why executions are NOT_STARTED (#7183)
1f3882b87a76d0e8db57d4172f7a62b65ae76d17 fix(core/pipeline): Change 'pipelines' state to redirect to the default child 'executions' ... instead of having an abstract state

