### PR TITLE
fix(core): correctly compute pipeline graph scroll position

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/graph/PipelineGraph.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/graph/PipelineGraph.tsx
@@ -96,7 +96,7 @@ export class PipelineGraph extends React.Component<IPipelineGraphProps, IPipelin
     // track and save the graph scroll position for executions so it doesn't get reset to
     // zero every second due to repaint.
     if (this.props.execution) {
-      PipelineGraphService.xScrollOffset[this.props.execution.id] = e.deltaX;
+      PipelineGraphService.xScrollOffset[this.props.execution.id] = (e.target as HTMLElement).parentElement.scrollLeft;
     }
   };
 

--- a/app/scripts/modules/core/src/pipeline/details/SingleExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/details/SingleExecutionDetails.tsx
@@ -14,6 +14,7 @@ import { ReactInjector, IStateChange } from 'core/reactShims';
 import { Tooltip } from 'core/presentation';
 import { ISortFilter } from 'core/filterModel';
 import { ExecutionState } from 'core/state';
+import { ExecutionsTransformer } from '../service/ExecutionsTransformer';
 
 import './singleExecutionDetails.less';
 
@@ -65,7 +66,7 @@ export class SingleExecutionDetails extends React.Component<
 
     executionService.getExecution($state.params.executionId).then(
       execution => {
-        executionService.transformExecution(app, execution);
+        ExecutionsTransformer.transformExecution(app, execution);
         if (execution.isActive && !this.executionScheduler) {
           this.executionScheduler = SchedulerFactory.createScheduler(5000);
           this.executionLoader = this.executionScheduler.subscribe(() => this.getExecution());

--- a/app/scripts/modules/core/src/pipeline/service/ExecutionsTransformer.ts
+++ b/app/scripts/modules/core/src/pipeline/service/ExecutionsTransformer.ts
@@ -322,6 +322,19 @@ export class ExecutionsTransformer {
 
     OrchestratedItemTransformer.defineProperties(execution);
     this.processStageSummaries(execution);
+    execution.graphStatusHash = ExecutionsTransformer.calculateGraphStatusHash(execution);
+  }
+
+  private static calculateGraphStatusHash(execution: IExecution): string {
+    return (execution.stageSummaries || [])
+      .map(stage => {
+        const stageConfig = Registry.pipeline.getStageConfig(stage);
+        if (stageConfig && stageConfig.extraLabelLines) {
+          return [stageConfig.extraLabelLines(stage), stage.status].join('-');
+        }
+        return stage.status;
+      })
+      .join(':');
   }
 
   private static calculateRunningTime(stage: IExecutionStageSummary): () => number {


### PR DESCRIPTION
The `graphStatusHash` is pretty cheap to calculate (especially cheap compared to everything else we do in the transformer) and pretty important for knowing whether to update anything in the pipeline graph. So...let's make sure we set it.

The scroll tracking we're doing right now doesn't really work, it turns out, because `deltaX` only represents the difference in the X position between wheel events. It's usually a very small number, and can be negative. It had worked historically because, well, because the graph never updated and people didn't seem to notice.