### PR TITLE
Bump package core to 0.0.388 and amazon to 0.0.201

### DIFF
--- a/app/scripts/modules/amazon/package.json
+++ b/app/scripts/modules/amazon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/amazon",
-  "version": "0.0.200",
+  "version": "0.0.201",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/core",
-  "version": "0.0.387",
+  "version": "0.0.388",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
### chore(core): Bump version to 0.0.388

5d2f3075ea15472e5bdc163515934ad35f753055 fix(core): correctly compute pipeline graph scroll position (#7198)

### chore(amazon): Bump version to 0.0.201

829da5a98886a6c5d2cb17cbddcca20c75b118c0 feat(amazon): allow custom help message on scaling policy selection modal (#7199)
7a218bc8d1e54037f9dfd5fd81b9d6d6af3b010f fix(amazon): Disallow enable instance in a disabled server group (#7197)


