### PR TITLE
refactor(core): export ExecutionsTransformer in core module

### DIFF
--- a/app/scripts/modules/core/src/pipeline/index.ts
+++ b/app/scripts/modules/core/src/pipeline/index.ts
@@ -16,3 +16,4 @@ export * from './executions/execution/Execution';
 export * from './filter/ExecutionFilterModel';
 export * from './manualExecution/TriggerTemplate';
 export * from './service/execution.service';
+export * from './service/ExecutionsTransformer';


### PR DESCRIPTION
We use this thing internally. Well, we used to use `executionService.transformExecution` but I refactored that out, since it was just delegating to the same method in ExecutionsTransformer, so here we are.