### PR TITLE
fix(executions): Correctly populate trigger when rerunning an execution

### DIFF
--- a/app/scripts/modules/core/src/pipeline/manualExecution/manualPipelineExecution.controller.js
+++ b/app/scripts/modules/core/src/pipeline/manualExecution/manualPipelineExecution.controller.js
@@ -122,7 +122,18 @@ module.exports = angular
           // these on a subsequent run.
           trigger.artifacts = [];
         }
-        this.command.trigger = trigger || _.head(this.triggers);
+        if (trigger) {
+          // Find the pipeline.trigger that matches trigger (the trigger from the execution being re-run)
+          this.command.trigger = this.triggers.find(t =>
+            Object.keys(t)
+              .filter(k => k !== 'description')
+              .every(k => t[k] === trigger[k]),
+          );
+          // If we found a match, rehydrate it with everything from trigger, otherwise just default back to setting it to trigger
+          this.command.trigger = this.command.trigger ? Object.assign(this.command.trigger, trigger) : trigger;
+        } else {
+          this.command.trigger = _.head(this.triggers);
+        }
       };
 
       const updatePipelinePlan = pipeline => {


### PR DESCRIPTION
When a user tries to re-run an execution, `command.trigger` is set to the trigger of the execution being re-run, however since Angular's `select` is checking for referential equality, it doesn't match anything in the list of options (`pipeline.trigger`) so the user is left with an empty select.

This fix attempts to match the execution to a `pipeline.trigger`(already copied into `this.triggers`) then hydrates it with everything from the trigger of the execution (so that other things like buildNumber do not get reset).