### PR TITLE
Bump package core to 0.0.390 and amazon to 0.0.202 and titus to 0.0.104

### DIFF
--- a/app/scripts/modules/amazon/package.json
+++ b/app/scripts/modules/amazon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/amazon",
-  "version": "0.0.201",
+  "version": "0.0.202",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/core",
-  "version": "0.0.389",
+  "version": "0.0.390",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/titus/package.json
+++ b/app/scripts/modules/titus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/titus",
-  "version": "0.0.103",
+  "version": "0.0.104",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
### chore(core): Bump version to 0.0.390

768c2109ab2d5ddb98a1d521fb74b5e508a3ee07 fix(executions): Correctly populate trigger when rerunning an execution (#7205)
f340b0268c1c85aae96c54acee77aa39ef9770d6 feat(google): support stateful MIG operations (#7196)

### chore(amazon): Bump version to 0.0.202

bf68118738ed4dcfd2f8c9e61f8247bcccba2918 refactor(amazon): allow custom CLB config when ejecting from a wizard (#7206)

### chore(titus): Bump version to 0.0.104

a468de458f784bc3e23b340acf053871d2d35678 fix(spel): Fix exceptions when account is an expression (#7168)


