### PR TITLE
perf(google): improve performance of GCE image selection

### DIFF
--- a/app/scripts/modules/google/src/image/ImageSelect.tsx
+++ b/app/scripts/modules/google/src/image/ImageSelect.tsx
@@ -1,0 +1,61 @@
+import { module } from 'angular';
+
+import { chain } from 'lodash';
+import * as React from 'react';
+import { Async, AutocompleteResult, Option } from 'react-select';
+import { react2angular } from 'react2angular';
+
+interface IImage {
+  imageName: string;
+}
+
+interface IImageSelectProps {
+  availableImages: IImage[];
+  selectedImage: string;
+  selectImage: (image: string, target?: any) => void;
+  target?: any;
+}
+
+export class ImageSelect extends React.Component<IImageSelectProps> {
+  private loadOptions = (inputValue: string): Promise<AutocompleteResult<string>> => {
+    return new Promise(resolve => {
+      if (!inputValue || inputValue.length < 3) {
+        resolve({
+          options: [],
+          complete: false,
+        });
+      } else {
+        const filteredOptions = chain(this.props.availableImages)
+          .filter(i => i.imageName.toLowerCase().includes(inputValue))
+          .take(20)
+          .map(i => ({ value: i.imageName, label: i.imageName }))
+          .value();
+        resolve({
+          options: filteredOptions,
+          complete: false,
+        });
+      }
+    });
+  };
+
+  public render() {
+    return (
+      <Async
+        cache={null}
+        clearable={false}
+        ignoreAccents={false}
+        loadOptions={this.loadOptions}
+        onChange={(selected: Option<string>) => this.props.selectImage(selected.value, this.props.target)}
+        placeholder="Type at least 3 characters to search for an image..."
+        searchPromptText="Type at least 3 characters to search for an image..."
+        value={{ value: this.props.selectedImage, label: this.props.selectedImage }}
+      />
+    );
+  }
+}
+
+export const GCE_IMAGE_SELECT = 'spinnaker.gce.imageSelect';
+module(GCE_IMAGE_SELECT, []).component(
+  'gceImageSelect',
+  react2angular(ImageSelect, ['availableImages', 'selectedImage', 'selectImage', 'target']),
+);

--- a/app/scripts/modules/google/src/serverGroup/configure/serverGroup.configure.gce.module.js
+++ b/app/scripts/modules/google/src/serverGroup/configure/serverGroup.configure.gce.module.js
@@ -8,6 +8,7 @@ import { GCE_CACHE_REFRESH } from 'google/cache/cacheRefresh.component';
 import { GCE_CUSTOM_INSTANCE_CONFIGURER } from './wizard/customInstance/customInstanceConfigurer.component';
 import { GCE_DISK_CONFIGURER } from './wizard/advancedSettings/diskConfigurer.component';
 import { GCE_ACCELERATOR_CONFIGURER } from './wizard/advancedSettings/acceleratorConfigurer.component';
+import { GCE_IMAGE_SELECT } from '../../image/ImageSelect';
 
 module.exports = angular.module('spinnaker.serverGroup.configure.gce', [
   require('../../autoscalingPolicy/components/basicSettings/basicSettings.component').name,
@@ -19,6 +20,7 @@ module.exports = angular.module('spinnaker.serverGroup.configure.gce', [
   GCE_CUSTOM_INSTANCE_CONFIGURER,
   GCE_DISK_CONFIGURER,
   GCE_ACCELERATOR_CONFIGURER,
+  GCE_IMAGE_SELECT,
   require('../serverGroup.transformer').name,
   require('./serverGroupConfiguration.service').name,
   require('./wizard/advancedSettings/advancedSettingsSelector.directive').name,

--- a/app/scripts/modules/google/src/serverGroup/configure/serverGroupCommandBuilder.service.js
+++ b/app/scripts/modules/google/src/serverGroup/configure/serverGroupCommandBuilder.service.js
@@ -368,7 +368,6 @@ module.exports = angular
           viewState: {
             instanceProfile: 'custom',
             allImageSelection: null,
-            useAllImageSelection: false,
             useSimpleCapacity: true,
             usePreferredZones: true,
             listImplicitSecurityGroups: false,
@@ -449,7 +448,6 @@ module.exports = angular
           },
           viewState: {
             allImageSelection: null,
-            useAllImageSelection: false,
             useSimpleCapacity: !serverGroup.autoscalingPolicy,
             usePreferredZones: false,
             listImplicitSecurityGroups: false,

--- a/app/scripts/modules/google/src/serverGroup/configure/wizard/cloneServerGroup.gce.controller.js
+++ b/app/scripts/modules/google/src/serverGroup/configure/wizard/cloneServerGroup.gce.controller.js
@@ -138,15 +138,6 @@ module.exports = angular
         gceServerGroupConfigurationService
           .configureCommand(application, serverGroupCommand)
           .then(function() {
-            const mode = serverGroupCommand.viewState.mode;
-            if (mode === 'clone' || mode === 'create') {
-              if (
-                !serverGroupCommand.backingData.packageImages ||
-                !serverGroupCommand.backingData.packageImages.length
-              ) {
-                serverGroupCommand.viewState.useAllImageSelection = true;
-              }
-            }
             $scope.state.loaded = true;
             initializeSelectOptions();
             initializeWatches();

--- a/app/scripts/modules/google/src/serverGroup/configure/wizard/location/basicSettings.controller.js
+++ b/app/scripts/modules/google/src/serverGroup/configure/wizard/location/basicSettings.controller.js
@@ -41,15 +41,17 @@ module.exports = angular
       const imageSearchResultsStream = new Subject();
       imageSearchResultsStream.switchMap(fetchImagesForAccount).subscribe(images => {
         $scope.command.backingData.allImages = images;
-        $scope.command.backingData.packageImages = images;
       });
 
       this.accountUpdated = () => {
         imageSearchResultsStream.next();
       };
 
-      this.enableAllImageSearch = () => {
-        $scope.command.viewState.useAllImageSelection = true;
+      this.selectImage = image => {
+        // called from a React component
+        $scope.$apply(() => {
+          $scope.command.image = image;
+        });
       };
 
       angular.extend(

--- a/app/scripts/modules/google/src/serverGroup/configure/wizard/location/basicSettings.html
+++ b/app/scripts/modules/google/src/serverGroup/configure/wizard/location/basicSettings.html
@@ -114,29 +114,12 @@
         Image
         <help-field key="gce.serverGroup.imageName"></help-field>
       </div>
-      <div class="col-md-9" ng-if="command.viewState.useAllImageSelection">
-        <ui-select ng-model="command.image" class="form-control input-sm" required>
-          <ui-select-match placeholder="Search for an image..."
-            >{{$select.selected.imageName || 'Search for an image...'}}</ui-select-match
-          >
-          <ui-select-choices
-            repeat="result.imageName as result in command.backingData.allImages | filter: { imageName: $select.search }"
-          >
-            <span ng-bind-html="result.imageName | highlight: $select.search"></span>
-          </ui-select-choices>
-        </ui-select>
-      </div>
-      <div class="col-md-9" ng-if="!command.viewState.useAllImageSelection">
-        <ui-select class="form-control input-sm" required ng-model="command.image">
-          <ui-select-match placeholder="Pick an image">{{$select.selected.imageName}}</ui-select-match>
-          <ui-select-choices
-            repeat="image.imageName as image in command.backingData.allImages | filter: { imageName: $select.search }"
-          >
-            <span ng-bind-html="image.imageName | highlight: $select.search"></span>
-          </ui-select-choices>
-        </ui-select>
-        <a href ng-click="basicSettingsCtrl.enableAllImageSearch()">Search All Images</a
-        ><help-field key="aws.serverGroup.allImages"></help-field>
+      <div class="col-md-7">
+        <gce-image-select
+          available-images="command.backingData.allImages"
+          selected-image="command.image"
+          select-image="basicSettingsCtrl.selectImage"
+        />
       </div>
     </div>
     <div class="form-group">


### PR DESCRIPTION
Closes https://github.com/spinnaker/spinnaker/issues/4510

- The problem that this PR is trying to solve is a very slow or totally unresponsive server group modal UI for users with tens of thousands of images per account.
- Replaces Angular `ui-select` component with new React `ImageSelect` component, which uses an `Async` dropdown from the `react-select` library with several custom performance enhancements: 1) Only loads options when three or more characters have been typed 2) Only loads the first 20 matches for a given search string. (I also tested `react-virtualized`, but with tens of thousands of images the virtualization seemed ineffective.)
- Removes all the logic for toggling between searching all images and images that contain the current application's name. Since we are already making one fetch for all an account's images, we should not also make a separate fetch for a subset of those images.

Before (can't really get a good gif with ~25k images because the UI freezes for about ten seconds):
:sob: 

After:
![b0f3b0f3-1236-4ddf-9c75-4384e1d75cb4](https://user-images.githubusercontent.com/15936279/60995882-7f823a00-a321-11e9-97d8-3d046be6322a.gif)


