### PR TITLE
fix(core): ensure filter tag removal removes tags from filter

### DIFF
--- a/app/scripts/modules/core/src/filterModel/IFilterModel.ts
+++ b/app/scripts/modules/core/src/filterModel/IFilterModel.ts
@@ -13,37 +13,41 @@ export interface IFilterConfig {
   array?: boolean;
 }
 
+export interface ITrueKeyModel {
+  [key: string]: boolean;
+}
+
 // The sortFilter objects are generated, so leaving all fields as required
 // In addition, there should technically be a few different ISortFilter
 // sub-interfaces (Clusters, Pipeline, Load Balancer, etc)
 // but I want to delete all this stuff in favor of router params eventually
 // anyway, so keeping the interface consolidated for now.
 export interface ISortFilter {
-  account: { [key: string]: boolean };
-  availabilityZone: { [key: string]: boolean };
+  account: ITrueKeyModel;
+  availabilityZone: ITrueKeyModel;
   category: { [key: string]: any };
   clusters: { [key: string]: any };
   count: number;
-  detail: { [key: string]: boolean };
+  detail: ITrueKeyModel;
   filter: string;
   groupBy: string;
   instanceSort: string;
-  instanceType: { [key: string]: boolean };
-  labels: { [key: string]: boolean };
+  instanceType: ITrueKeyModel;
+  labels: ITrueKeyModel;
   listInstances: boolean;
   maxInstances: number;
   minInstances: number;
   multiselect: boolean;
-  pipeline: { [key: string]: boolean };
-  providerType: { [key: string]: boolean };
-  region: { [key: string]: boolean };
+  pipeline: ITrueKeyModel;
+  providerType: ITrueKeyModel;
+  region: ITrueKeyModel;
   showAllInstances: boolean;
   showInstances: boolean;
   showLoadBalancers: boolean;
   showServerGroups: boolean;
   showDurations: boolean;
-  stack: { [key: string]: boolean };
-  status: { [key: string]: boolean };
+  stack: ITrueKeyModel;
+  status: ITrueKeyModel;
 }
 
 export interface IFilterModel {


### PR DESCRIPTION
Scenario: a user on the executions view filters to only show executions from one or two pipelines. They then expand one of the pipelines. This causes the `sortFilter` value to be set to a new object, but the filter tags are not regenerated, so the `clear` method on the filter tag is holding on to a stale reference. If the user tries to clear the tag by clicking the little (x) on it, nothing happens.

If someone wants to dig deeper to understand why the sort filter model is regenerating its model, but not the tags, go for it! This is a safe change, but might not be addressing some other underlying issue.