### PR TITLE
Bump package core to 0.0.391 and amazon to 0.0.203

### DIFF
--- a/app/scripts/modules/amazon/package.json
+++ b/app/scripts/modules/amazon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/amazon",
-  "version": "0.0.202",
+  "version": "0.0.203",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/core",
-  "version": "0.0.390",
+  "version": "0.0.391",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
### chore(core): Bump version to 0.0.391

0e5e66a3fae50abddb98cb2d97036a32907ea811 feat(titus): Adding support for service job processes (#7186)
68ee670d5993c9649bd9cc1c6b312512132dcdac feat({core,amazon}/pipeline): add support per-OS AWS VM type choices (#7187)

### chore(amazon): Bump version to 0.0.203

68ee670d5993c9649bd9cc1c6b312512132dcdac feat({core,amazon}/pipeline): add support per-OS AWS VM type choices (#7187)


