### PR TITLE
feat(kubernetes): allow multi-manifest for rollout strategies

### DIFF
--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifest.validator.ts
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifest.validator.ts
@@ -20,12 +20,13 @@ export const deployManifestValidators = (): IValidatorConfig[] => {
         }
         if (enabled && stage.source === 'text') {
           const manifests = get(stage, 'manifests', []);
-          if (manifests.length !== 1 || get(manifests, [0, 'kind']) !== 'ReplicaSet') {
-            return 'Spinnaker can manage traffic for ReplicaSets only. Please enter exactly one ReplicaSet manifest or disable rollout strategies.';
+          const replicaSetManifests = manifests.filter(m => m.kind === 'ReplicaSet');
+          if (replicaSetManifests.length !== 1) {
+            return 'Spinnaker can manage traffic for one ReplicaSet only. Please enter one ReplicaSet manifest or disable rollout strategies.';
           }
           const strategy = get(stage, 'trafficManagement.options.strategy');
           const maxVersionHistory = parseInt(
-            get(manifests, [0, 'metadata', 'annotations', MAX_VERSION_HISTORY_ANNOTATION]),
+            get(replicaSetManifests, [0, 'metadata', 'annotations', MAX_VERSION_HISTORY_ANNOTATION]),
             10,
           );
           if (strategy === strategyRedBlack.key && maxVersionHistory < 2) {


### PR DESCRIPTION
Closes https://github.com/spinnaker/spinnaker/issues/4446

- Removes validation preventing multi-manifests to be deployed as part of a Spinnaker-coordinated rollout strategy. Still expects exactly one ReplicaSet, but now permits other resources to be deployed alongside the ReplicaSet. (Also, the designated Service must still be deployed prior to the rollout.)

Related PRs:
Clouddriver: https://github.com/spinnaker/clouddriver/pull/3874
Orca: spinnaker/orca#3034

Example (ReplicaSet + ConfigMap):

![oL7q72jBxaA](https://user-images.githubusercontent.com/15936279/61147326-1974ee80-a4aa-11e9-8d87-33f30901d2b6.png)
