### PR TITLE
fix(amazon): Update default internalPort for CLBs to 80

### DIFF
--- a/app/scripts/modules/amazon/src/loadBalancer/configure/classic/Listeners.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/classic/Listeners.tsx
@@ -112,7 +112,7 @@ export class Listeners extends React.Component<IListenersProps, IListenersState>
       internalProtocol: 'HTTP',
       externalProtocol: 'HTTP',
       externalPort: 80,
-      internalPort: 0,
+      internalPort: 80,
     });
     this.updateListeners();
   };


### PR DESCRIPTION
No idea why we defaulted to 0 for the internal port, but this seems to fail silently somewhere in the backend, basically with a task completion that ends up with no listener created (probably because 0 isn't really a port).

80 seems more reasonable since we already default to HTTP anyways. This way if someone forgot to actually configure their desired internal port, at least they'll get a listener created to the wrong port instead of wondering why the listener didn't get created