### PR TITLE
Simplify filtering logic

### DIFF
--- a/app/scripts/modules/core/src/cluster/cluster.service.spec.ts
+++ b/app/scripts/modules/core/src/cluster/cluster.service.spec.ts
@@ -1,6 +1,7 @@
 import { IHttpBackendService, mock } from 'angular';
 import { find } from 'lodash';
 
+import { REACT_MODULE } from 'core/reactShims';
 import * as State from 'core/state';
 import { ApplicationModelBuilder } from 'core/application/applicationModel.builder';
 import { IInstanceCounts, IServerGroup } from 'core/domain';
@@ -13,7 +14,7 @@ import { SETTINGS } from 'core/config/settings';
 const ClusterState = State.ClusterState;
 
 describe('Service: Cluster', function() {
-  beforeEach(mock.module(CLUSTER_SERVICE));
+  beforeEach(mock.module(CLUSTER_SERVICE, REACT_MODULE));
 
   let clusterService: ClusterService;
   let $http: IHttpBackendService;
@@ -27,10 +28,6 @@ describe('Service: Cluster', function() {
       },
     };
   }
-
-  beforeEach(() => {
-    State.initialize();
-  });
 
   beforeEach(
     mock.inject(($httpBackend: IHttpBackendService, _clusterService_: ClusterService) => {
@@ -52,6 +49,8 @@ describe('Service: Cluster', function() {
       ];
     }),
   );
+
+  beforeEach(() => State.initialize());
 
   describe('lazy cluster fetching', () => {
     it('switches to lazy cluster fetching if there are more than the on demand threshold for clusters', () => {

--- a/app/scripts/modules/core/src/cluster/filter/ClusterFilterModel.ts
+++ b/app/scripts/modules/core/src/cluster/filter/ClusterFilterModel.ts
@@ -30,7 +30,7 @@ export class ClusterFilterModel {
 
   constructor() {
     this.asFilterModel = FilterModelService.configureFilterModel(this as any, filterModelConfig);
-    FilterModelService.registerSaveAndRestoreRouterHooks(this.asFilterModel, '**.application.insight.clusters');
+    FilterModelService.registerRouterHooks(this.asFilterModel, '**.application.insight.clusters');
     this.asFilterModel.activate();
   }
 }

--- a/app/scripts/modules/core/src/cluster/filter/ClusterFilterModel.ts
+++ b/app/scripts/modules/core/src/cluster/filter/ClusterFilterModel.ts
@@ -1,8 +1,4 @@
-import { Ng1StateDeclaration, StateParams } from '@uirouter/angularjs';
-import { $rootScope } from 'ngimport';
-
 import { FilterModelService, IFilterConfig, IFilterModel } from 'core/filterModel';
-import { UrlParser } from 'core/navigation/urlParser';
 
 export const filterModelConfig: IFilterConfig[] = [
   { model: 'filter', param: 'q', clearValue: '', type: 'string', filterLabel: 'search' },
@@ -30,93 +26,11 @@ export const filterModelConfig: IFilterConfig[] = [
 ];
 
 export class ClusterFilterModel {
-  private mostRecentParams: any;
   public asFilterModel: IFilterModel;
 
   constructor() {
     this.asFilterModel = FilterModelService.configureFilterModel(this as any, filterModelConfig);
-    this.bindEvents();
+    FilterModelService.registerSaveAndRestoreRouterHooks(this.asFilterModel, '**.application.insight.clusters');
     this.asFilterModel.activate();
-  }
-
-  private isClusterState(stateName: string): boolean {
-    return (
-      stateName === 'home.applications.application.insight.clusters' ||
-      stateName === 'home.project.application.insight.clusters'
-    );
-  }
-
-  private isClusterStateOrChild(stateName: string): boolean {
-    return this.isClusterState(stateName) || this.isChildState(stateName);
-  }
-
-  private isChildState(stateName: string): boolean {
-    return stateName.includes('clusters.');
-  }
-
-  private movingToClusterState(toState: Ng1StateDeclaration): boolean {
-    return this.isClusterStateOrChild(toState.name);
-  }
-
-  private movingFromClusterState(toState: Ng1StateDeclaration, fromState: Ng1StateDeclaration): boolean {
-    return this.isClusterStateOrChild(fromState.name) && !this.isClusterStateOrChild(toState.name);
-  }
-
-  private fromApplicationListState(fromState: Ng1StateDeclaration): boolean {
-    return fromState.name === 'home.applications';
-  }
-
-  private shouldRouteToSavedState(toParams: StateParams, fromState: Ng1StateDeclaration): boolean {
-    return this.asFilterModel.hasSavedState(toParams) && !this.isClusterStateOrChild(fromState.name);
-  }
-
-  private bindEvents(): void {
-    // WHY??? Because, when the stateChangeStart event fires, the $location.search() will return whatever the query
-    // params are on the route we are going to, so if the user is using the back button, for example, to go to the
-    // Infrastructure page with a search already entered, we'll pick up whatever search was entered there, and if we
-    // come back to this application's clusters view, we'll get whatever that search was.
-    $rootScope.$on('$locationChangeStart', (_event, toUrl: string, fromUrl: string) => {
-      const [oldBase, oldQuery] = fromUrl.split('?'),
-        [newBase, newQuery] = toUrl.split('?');
-
-      if (oldBase === newBase) {
-        this.mostRecentParams = newQuery ? UrlParser.parseQueryString(newQuery) : {};
-      } else {
-        this.mostRecentParams = oldQuery ? UrlParser.parseQueryString(oldQuery) : {};
-      }
-    });
-
-    $rootScope.$on(
-      '$stateChangeStart',
-      (
-        _event,
-        toState: Ng1StateDeclaration,
-        _toParams: StateParams,
-        fromState: Ng1StateDeclaration,
-        fromParams: StateParams,
-      ) => {
-        if (this.movingFromClusterState(toState, fromState)) {
-          this.asFilterModel.saveState(fromState, fromParams, this.mostRecentParams);
-        }
-      },
-    );
-
-    $rootScope.$on(
-      '$stateChangeSuccess',
-      (_event, toState: Ng1StateDeclaration, toParams: StateParams, fromState: Ng1StateDeclaration) => {
-        if (this.movingToClusterState(toState) && this.isClusterStateOrChild(fromState.name)) {
-          this.asFilterModel.applyParamsToUrl();
-          return;
-        }
-        if (this.movingToClusterState(toState)) {
-          if (this.shouldRouteToSavedState(toParams, fromState)) {
-            this.asFilterModel.restoreState(toParams);
-          }
-          if (this.fromApplicationListState(fromState) && !this.asFilterModel.hasSavedState(toParams)) {
-            this.asFilterModel.clearFilters();
-          }
-        }
-      },
-    );
   }
 }

--- a/app/scripts/modules/core/src/cluster/filter/ClusterFilterService.spec.ts
+++ b/app/scripts/modules/core/src/cluster/filter/ClusterFilterService.spec.ts
@@ -1,5 +1,6 @@
 import { mock } from 'angular';
 import * as _ from 'lodash';
+import { REACT_MODULE } from 'core/reactShims';
 import { CLUSTER_SERVICE } from 'core/cluster/cluster.service';
 import { Application } from 'core/application/application.model';
 import { ApplicationModelBuilder } from 'core/application/applicationModel.builder';
@@ -17,7 +18,7 @@ describe('Service: clusterFilterService', function() {
   let application: Application;
 
   beforeEach(function() {
-    mock.module(CLUSTER_SERVICE, require('./mockApplicationData').name, 'ui.router');
+    mock.module(CLUSTER_SERVICE, require('./mockApplicationData').name, 'ui.router', REACT_MODULE);
     mock.inject(function(_applicationJSON_: any, _groupedJSON_: any, _clusterService_: any) {
       clusterService = _clusterService_;
 

--- a/app/scripts/modules/core/src/filterModel/FilterModelService.ts
+++ b/app/scripts/modules/core/src/filterModel/FilterModelService.ts
@@ -1,109 +1,10 @@
-import { StateParams } from '@uirouter/core';
-import { cloneDeep, size, some, isNil, reduce, forOwn, includes, chain, pick } from 'lodash';
-import { $location } from 'ngimport';
+import { cloneDeep, size, some, isNil, reduce, forOwn, includes, pick } from 'lodash';
 
 import { IFilterModel, IFilterConfig, ISortFilter } from './IFilterModel';
 import { ReactInjector } from 'core/reactShims';
 
-export interface IParamConverter {
-  toParam: (filterModel: IFilterModel, property: IFilterConfig) => any;
-  toModel: (filterModel: IFilterModel, property: IFilterConfig) => any;
-}
-
-export class FilterModelServiceConverters {
-  public trueKeyObject: IParamConverter = {
-    toParam: (filterModel: IFilterModel, property: IFilterConfig) => {
-      const obj = filterModel.sortFilter[property.model];
-      return (
-        chain(obj || {})
-          .map(function(val: any, key: string) {
-            if (val) {
-              // replace any commas in the string with their uri-encoded version ('%2c'), since
-              // we use commas as our separator in the URL
-              return key.replace(/,/g, '%2c');
-            }
-            return undefined;
-          })
-          .remove(undefined)
-          .value()
-          .sort()
-          .join(',') || null
-      );
-    },
-    toModel: (_filterModel: IFilterModel, property: IFilterConfig) => {
-      const paramList = this.getParamVal(property);
-      if (paramList) {
-        return reduce(
-          paramList.split(','),
-          function(acc, value: string) {
-            // replace any uri-encoded commas in the string ('%2c') with actual commas, since
-            // we use commas as our separator in the URL
-            acc[value.replace(/%2c/g, ',')] = true;
-            return acc;
-          },
-          {} as { [key: string]: boolean },
-        );
-      } else {
-        return {};
-      }
-    },
-  };
-
-  public string: IParamConverter = {
-    toParam: (filterModel: IFilterModel, property: IFilterConfig) => {
-      const val = filterModel.sortFilter[property.model];
-      return val && val !== property.defaultValue ? val : null;
-    },
-    toModel: (_filterModel: IFilterModel, property: IFilterConfig) => {
-      const val = this.getParamVal(property);
-      return val ? val : '';
-    },
-  };
-
-  public boolean: IParamConverter = {
-    toParam: (filterModel: IFilterModel, property: IFilterConfig) => {
-      const val = filterModel.sortFilter[property.model];
-      return val ? val.toString() : null;
-    },
-    toModel: (_filterModel: IFilterModel, property: IFilterConfig) => {
-      const val = this.getParamVal(property);
-      return Boolean(val);
-    },
-  };
-
-  public 'inverse-boolean': IParamConverter = {
-    toParam: (filterModel: IFilterModel, property: IFilterConfig) => {
-      const val = filterModel.sortFilter[property.model];
-      return val ? null : 'true';
-    },
-    toModel: (_filterModel: IFilterModel, property: IFilterConfig) => {
-      const val = this.getParamVal(property);
-      return !val;
-    },
-  };
-
-  public int: IParamConverter = {
-    toParam: (filterModel: IFilterModel, property: IFilterConfig) => {
-      const val: any = filterModel.sortFilter[property.model];
-      return isNaN(val) ? null : property.defaultValue === val ? null : val;
-    },
-    toModel: (_filterModel: IFilterModel, property: IFilterConfig) => {
-      const val = this.getParamVal(property);
-      return isNaN(val) ? null : Number(val);
-    },
-  };
-
-  private getParamVal(property: IFilterConfig) {
-    return $location.search()[property.param] || property.defaultValue;
-  }
-}
-
 export class FilterModelService {
-  private static converters = new FilterModelServiceConverters();
-
   public static configureFilterModel(filterModel: IFilterModel, filterModelConfig: IFilterConfig[]) {
-    const { converters } = this;
-
     filterModelConfig.forEach(property => (property.param = property.param || property.model));
     filterModel.config = filterModelConfig;
     filterModel.groups = [];
@@ -126,80 +27,34 @@ export class FilterModelService {
       });
     };
 
-    filterModel.activate = () => {
-      filterModelConfig.forEach(function(property) {
-        filterModel.sortFilter[property.model] = converters[property.type].toModel(filterModel, property);
-      });
-    };
+    // TODO: remove usages of this, then remove this
+    filterModel.activate = () => {};
 
-    // What is this trying to do?
-
-    // The filter model is stored as keys/values on the `sortFilter` object
-    // When the user modifies the filter, the ng-model binding is updated to the `sortFilter`
-    // After the ng-model binding is updated, this function is called to update the URL.
-
-    // The values in `sortFilter` are sometimes non-primitive nested objects such as `region: { east: true, west: true }`
-    // To represent these values in the URL, they are encoded as strings using a custom ui-router parameter types.
-    // In addition, there is also parameter encode/decode logic in the `converters` registry that predates the ui-router parameter types.
+    // Apply any mutations to the current sortFilter values as ui-router state params
     filterModel.applyParamsToUrl = () => {
-      // Get the current state parameters
-      const params = ReactInjector.$stateParams;
-      const newFilters = Object.keys(params).reduce(
-        // Iterate over each state parameter
-        (acc, paramName) => {
-          // Find the filter model config for that parameter
-          // If there is a model config:
-          // - Try to convert the param's object model into a query parameter string
-          // - If the string is nil, set the accumulator to null
-          // - Otherwise, copy the sortfilter value for that param to the accumulator
-          // If there isn't a model config:
-          // - clone the current state parameter value and store on the accumulator
-          const modelConfig = filterModelConfig.find(c => c.param === paramName);
-          if (modelConfig) {
-            const converted = converters[modelConfig.type].toParam(filterModel, modelConfig);
-            if (converted === null || converted === undefined) {
-              acc[paramName] = null;
-            } else {
-              acc[paramName] = cloneDeep(filterModel.sortFilter[modelConfig.model]);
-            }
-          } else {
-            acc[paramName] = cloneDeep(ReactInjector.$stateParams[paramName]);
-          }
-          return acc;
-        },
-        {} as StateParams,
+      const { sortFilter } = filterModel;
+      const toParams = filterModel.config.reduce(
+        (acc, filter) => ({ ...acc, [filter.param]: sortFilter[filter.model] }),
+        {},
       );
-
-      // Finally, apply the accumulator as the new state parameters
-      const promise = ReactInjector.$state.go('.', newFilters, { inherit: false });
-      const handleResult = () => {
-        if (promise.transition.success) {
-          console.log(
-            'applyParamsToUrl transition was successful and changed the following params: ',
-            JSON.stringify(promise.transition.paramsChanged()),
-          );
-        } else {
-          console.log('applyParamsToUrl had no effect');
-        }
-      };
-      promise.then(handleResult, handleResult);
+      ReactInjector.$state.go('.', toParams);
     };
 
     return filterModel;
   }
 
-  public static registerSaveAndRestoreRouterHooks(filterModel: IFilterModel, stateGlob: string) {
+  public static registerRouterHooks(filterModel: IFilterModel, stateGlob: string) {
     const { transitionService } = ReactInjector.$uiRouter;
     const filterParams = filterModel.config.map(cfg => cfg.param);
     let savedParamsForScreen: any = {};
 
-    // When exiting the screen, save the filters for that screen
+    // When exiting the screen but staying in the app, save the filters for that screen
     transitionService.onSuccess({ exiting: stateGlob, retained: '**.application' }, trans => {
       const fromParams = trans.params('from');
       savedParamsForScreen = pick(fromParams, filterParams);
     });
 
-    // When entering the screen, restore the filters for that screen
+    // When entering the screen and staying in the app, restore the filters for that screen
     transitionService.onBefore({ entering: stateGlob, retained: '**.application' }, trans => {
       const toParams = trans.params();
       const hasFilters = filterParams.some(key => !isNil(toParams[key]));
@@ -215,6 +70,34 @@ export class FilterModelService {
     // When switching apps, clear the saved state
     transitionService.onStart({ exiting: '**.application' }, () => {
       savedParamsForScreen = {};
+    });
+
+    // Copy the param values to the sortModel for before each transition, applying default values if the param isn't set
+    // In the future, we should remove  the AngularJS code that watches for mutations on the sortFilter object
+    transitionService.onBefore({ to: stateGlob }, trans => {
+      const toParams = trans.params();
+
+      const getValueIfNill = (filterType: string) => {
+        switch (filterType) {
+          case 'trueKeyObject':
+            return {};
+          case 'string':
+            return '';
+          case 'boolean':
+            return false;
+          case 'inverse-boolean':
+            return true;
+        }
+        return undefined;
+      };
+
+      filterModel.config.forEach(filter => {
+        const valueIfNil = getValueIfNill(filter.type);
+        const rawValue = toParams[filter.param];
+        const paramValue = isNil(rawValue) ? valueIfNil : rawValue;
+        // Clone deep so angularjs mutations happen on a different object reference
+        filterModel.sortFilter[filter.model] = cloneDeep(paramValue);
+      });
     });
   }
 

--- a/app/scripts/modules/core/src/filterModel/IFilterModel.ts
+++ b/app/scripts/modules/core/src/filterModel/IFilterModel.ts
@@ -47,15 +47,12 @@ export interface ISortFilter {
 }
 
 export interface IFilterModel {
+  config: IFilterConfig[];
   groups: any[];
   tags: any[];
   displayOptions: any;
-  savedState: any;
   sortFilter: ISortFilter;
   addTags: () => void;
-  saveState: (state: Ng1StateDeclaration, params: StateParams, filters: any) => void;
-  restoreState: (toParams: StateParams) => void;
-  hasSavedState: (toParams: StateParams) => boolean;
   clearFilters: () => void;
   activate: () => void;
   applyParamsToUrl: () => void;

--- a/app/scripts/modules/core/src/filterModel/IFilterModel.ts
+++ b/app/scripts/modules/core/src/filterModel/IFilterModel.ts
@@ -1,11 +1,8 @@
-import { Ng1StateDeclaration, StateParams } from '@uirouter/angularjs';
-import { FilterModelServiceConverters } from 'core/filterModel';
-
 export interface IFilterConfig {
   model: keyof ISortFilter;
   param?: string;
   clearValue?: any;
-  type?: keyof FilterModelServiceConverters;
+  type?: string;
   filterLabel?: string;
   filterTranslator?: { [key: string]: string };
   displayOption?: boolean;

--- a/app/scripts/modules/core/src/loadBalancer/filter/LoadBalancerFilterModel.ts
+++ b/app/scripts/modules/core/src/loadBalancer/filter/LoadBalancerFilterModel.ts
@@ -28,7 +28,7 @@ export class LoadBalancerFilterModel {
 
   constructor() {
     this.asFilterModel = FilterModelService.configureFilterModel(this as any, filterModelConfig);
-    FilterModelService.registerSaveAndRestoreRouterHooks(this.asFilterModel, '**.application.insight.loadBalancers');
+    FilterModelService.registerRouterHooks(this.asFilterModel, '**.application.insight.loadBalancers');
     this.asFilterModel.activate();
   }
 }

--- a/app/scripts/modules/core/src/loadBalancer/filter/LoadBalancerFilterModel.ts
+++ b/app/scripts/modules/core/src/loadBalancer/filter/LoadBalancerFilterModel.ts
@@ -1,10 +1,6 @@
-import { Ng1StateDeclaration, StateParams } from '@uirouter/angularjs';
-import { $rootScope } from 'ngimport';
-
 import { ILoadBalancerGroup } from 'core/domain';
 import { IFilterConfig, IFilterModel } from 'core/filterModel/IFilterModel';
 import { FilterModelService } from 'core/filterModel';
-import { UrlParser } from 'core/navigation/urlParser';
 
 export const filterModelConfig: IFilterConfig[] = [
   { model: 'account', param: 'acct', type: 'trueKeyObject' },
@@ -28,94 +24,11 @@ export interface ILoadBalancerFilterModel extends IFilterModel {
 }
 
 export class LoadBalancerFilterModel {
-  private mostRecentParams: any;
   public asFilterModel: ILoadBalancerFilterModel;
 
   constructor() {
     this.asFilterModel = FilterModelService.configureFilterModel(this as any, filterModelConfig);
-    this.bindEvents();
+    FilterModelService.registerSaveAndRestoreRouterHooks(this.asFilterModel, '**.application.insight.loadBalancers');
     this.asFilterModel.activate();
-  }
-
-  private isLoadBalancerState(stateName: string) {
-    return stateName === 'home.applications.application.insight.loadBalancers';
-  }
-
-  private isLoadBalancerStateOrChild(stateName: string) {
-    return this.isLoadBalancerState(stateName) || this.isChildState(stateName);
-  }
-
-  private isChildState(stateName: string) {
-    return stateName.includes('loadBalancers.');
-  }
-
-  private movingToLoadBalancerState(toState: Ng1StateDeclaration) {
-    return this.isLoadBalancerStateOrChild(toState.name);
-  }
-
-  private movingFromLoadBalancerState(toState: Ng1StateDeclaration, fromState: Ng1StateDeclaration) {
-    return this.isLoadBalancerStateOrChild(fromState.name) && !this.isLoadBalancerStateOrChild(toState.name);
-  }
-
-  private shouldRouteToSavedState(toParams: StateParams, fromState: Ng1StateDeclaration) {
-    return this.asFilterModel.hasSavedState(toParams) && !this.isLoadBalancerStateOrChild(fromState.name);
-  }
-
-  private fromLoadBalancersState(fromState: Ng1StateDeclaration) {
-    return (
-      fromState.name.indexOf('home.applications.application.insight') === 0 &&
-      !fromState.name.includes('home.applications.application.insight.loadBalancers')
-    );
-  }
-
-  private bindEvents(): void {
-    // WHY??? Because, when the stateChangeStart event fires, the $location.search() will return whatever the query
-    // params are on the route we are going to, so if the user is using the back button, for example, to go to the
-    // Infrastructure page with a search already entered, we'll pick up whatever search was entered there, and if we
-    // come back to this application, we'll get whatever that search was.
-    $rootScope.$on('$locationChangeStart', (_event, toUrl: string, fromUrl: string) => {
-      const [oldBase, oldQuery] = fromUrl.split('?'),
-        [newBase, newQuery] = toUrl.split('?');
-
-      if (oldBase === newBase) {
-        this.mostRecentParams = newQuery ? UrlParser.parseQueryString(newQuery) : {};
-      } else {
-        this.mostRecentParams = oldQuery ? UrlParser.parseQueryString(oldQuery) : {};
-      }
-    });
-
-    $rootScope.$on(
-      '$stateChangeStart',
-      (
-        _event,
-        toState: Ng1StateDeclaration,
-        _toParams: StateParams,
-        fromState: Ng1StateDeclaration,
-        fromParams: StateParams,
-      ) => {
-        if (this.movingFromLoadBalancerState(toState, fromState)) {
-          this.asFilterModel.saveState(fromState, fromParams, this.mostRecentParams);
-        }
-      },
-    );
-
-    $rootScope.$on(
-      '$stateChangeSuccess',
-      (_event, toState: Ng1StateDeclaration, toParams: StateParams, fromState: Ng1StateDeclaration) => {
-        if (this.isLoadBalancerStateOrChild(toState.name) && this.isLoadBalancerStateOrChild(fromState.name)) {
-          this.asFilterModel.applyParamsToUrl();
-          return;
-        }
-        if (this.movingToLoadBalancerState(toState)) {
-          if (this.shouldRouteToSavedState(toParams, fromState)) {
-            this.asFilterModel.restoreState(toParams);
-          }
-
-          if (this.fromLoadBalancersState(fromState) && !this.asFilterModel.hasSavedState(toParams)) {
-            this.asFilterModel.clearFilters();
-          }
-        }
-      },
-    );
   }
 }

--- a/app/scripts/modules/core/src/navigation/state.provider.ts
+++ b/app/scripts/modules/core/src/navigation/state.provider.ts
@@ -12,7 +12,7 @@ import { STATE_HELPER, StateHelper } from './stateHelper.provider';
 import { IFilterConfig } from '../filterModel/IFilterModel';
 
 import './navigation.less';
-import { ReactViewDeclaration } from '@uirouter/react';
+import { ReactViewDeclaration, ParamTypeDefinition } from '@uirouter/react';
 
 // Typescript kludge to widen interfaces so INestedState can support both react and angular views
 export interface IReactHybridIntermediate extends Ng1StateDeclaration {
@@ -94,7 +94,7 @@ export class StateConfigProvider implements IServiceProvider {
   }
 }
 
-export const trueKeyObjectParamType = {
+export const trueKeyObjectParamType: ParamTypeDefinition = {
   decode: (val: string) => {
     if (val) {
       const r: any = {};
@@ -122,7 +122,7 @@ export const trueKeyObjectParamType = {
   is: (val: any) => isPlainObject(val),
 };
 
-export const inverseBooleanParamType = {
+export const inverseBooleanParamType: ParamTypeDefinition = {
   decode: (val: string) => {
     if (val) {
       return val !== 'true';
@@ -136,7 +136,7 @@ export const inverseBooleanParamType = {
   is: () => true,
 };
 
-export const booleanParamType = {
+export const booleanParamType: ParamTypeDefinition = {
   // as a string instead of a bit
   decode: (val: string) => {
     if (val) {
@@ -151,7 +151,7 @@ export const booleanParamType = {
   is: () => true,
 };
 
-export const sortKeyParamType = {
+export const sortKeyParamType: ParamTypeDefinition = {
   decode: (val: string) => {
     return { key: val };
   },

--- a/app/scripts/modules/core/src/pipeline/filter/ExecutionFilterModel.ts
+++ b/app/scripts/modules/core/src/pipeline/filter/ExecutionFilterModel.ts
@@ -43,7 +43,7 @@ export class ExecutionFilterModel {
     });
 
     this.asFilterModel = FilterModelService.configureFilterModel(this as any, filterModelConfig);
-    FilterModelService.registerSaveAndRestoreRouterHooks(this.asFilterModel, '**.application.pipelines.executions');
+    FilterModelService.registerRouterHooks(this.asFilterModel, '**.application.pipelines.executions');
     this.asFilterModel.activate();
 
     transitionService.onBefore({ entering: '**.application.pipelines.executions' }, trans => {

--- a/app/scripts/modules/core/src/pipeline/filter/ExecutionFilterModel.ts
+++ b/app/scripts/modules/core/src/pipeline/filter/ExecutionFilterModel.ts
@@ -6,7 +6,7 @@ import { ICache, ViewStateCache } from 'core/cache';
 import { IExecutionGroup } from 'core/domain';
 import { IFilterConfig, IFilterModel } from 'core/filterModel/IFilterModel';
 import { FilterModelService } from 'core/filterModel';
-import { ReactInjector } from '../../reactShims';
+import { ReactInjector } from 'core/reactShims';
 
 export const filterModelConfig: IFilterConfig[] = [
   { model: 'filter', param: 'q', clearValue: '', type: 'string', filterLabel: 'search' },

--- a/app/scripts/modules/core/src/pipeline/filter/ExecutionFilterModel.ts
+++ b/app/scripts/modules/core/src/pipeline/filter/ExecutionFilterModel.ts
@@ -1,15 +1,12 @@
-import { Ng1StateDeclaration, StateParams } from '@uirouter/angularjs';
-import { ExecutionFilterService } from 'core/pipeline/filter/executionFilter.service';
 import { extend } from 'lodash';
 import { Subject } from 'rxjs';
-import { $rootScope } from 'ngimport';
 
 import { SETTINGS } from 'core/config/settings';
 import { ICache, ViewStateCache } from 'core/cache';
 import { IExecutionGroup } from 'core/domain';
 import { IFilterConfig, IFilterModel } from 'core/filterModel/IFilterModel';
 import { FilterModelService } from 'core/filterModel';
-import { UrlParser } from 'core/navigation/urlParser';
+import { ReactInjector } from '../../reactShims';
 
 export const filterModelConfig: IFilterConfig[] = [
   { model: 'filter', param: 'q', clearValue: '', type: 'string', filterLabel: 'search' },
@@ -38,75 +35,21 @@ export class ExecutionFilterModel {
   public expandSubject: Subject<boolean> = new Subject<boolean>();
 
   constructor() {
+    const { transitionService } = ReactInjector.$uiRouter;
+
     this.configViewStateCache = ViewStateCache.createCache('executionFilters', {
       version: 2,
       maxAge: SETTINGS.maxPipelineAgeDays * 24 * 60 * 60 * 1000,
     });
 
     this.asFilterModel = FilterModelService.configureFilterModel(this as any, filterModelConfig);
+    FilterModelService.registerSaveAndRestoreRouterHooks(this.asFilterModel, '**.application.pipelines.executions');
+    this.asFilterModel.activate();
 
-    let mostRecentParams: any = null;
-    // WHY??? Because, when the stateChangeStart event fires, the $location.search() will return whatever the query
-    // params are on the route we are going to, so if the user is using the back button, for example, to go to the
-    // Infrastructure page with a search already entered, we'll pick up whatever search was entered there, and if we
-    // come back to this application's clusters view, we'll get whatever that search was.
-    $rootScope.$on('$locationChangeStart', (_event, toUrl: string, fromUrl: string) => {
-      const [oldBase, oldQuery] = fromUrl.split('?'),
-        [newBase, newQuery] = toUrl.split('?');
-
-      if (oldBase === newBase) {
-        mostRecentParams = newQuery ? UrlParser.parseQueryString(newQuery) : {};
-      } else {
-        mostRecentParams = oldQuery ? UrlParser.parseQueryString(oldQuery) : {};
-      }
+    transitionService.onBefore({ entering: '**.application.pipelines.executions' }, trans => {
+      this.mostRecentApplication = trans.params().application;
+      this.assignViewStateFromCache();
     });
-
-    $rootScope.$on(
-      '$stateChangeStart',
-      (
-        _event,
-        toState: Ng1StateDeclaration,
-        _toParams: StateParams,
-        fromState: Ng1StateDeclaration,
-        fromParams: StateParams,
-      ) => {
-        if (this.movingFromExecutionsState(toState, fromState)) {
-          this.asFilterModel.saveState(fromState, fromParams, mostRecentParams);
-        }
-      },
-    );
-
-    $rootScope.$on(
-      '$stateChangeSuccess',
-      (
-        _event,
-        toState: Ng1StateDeclaration,
-        toParams: StateParams,
-        fromState: Ng1StateDeclaration,
-        fromParams: StateParams,
-      ) => {
-        if (!this.movingToExecutionsState(toState)) {
-          return;
-        }
-        if (
-          !this.isExecutionStateOrChild(fromState.name) ||
-          !this.groupCount ||
-          toParams.application !== fromParams.application
-        ) {
-          this.mostRecentApplication = toParams.application;
-          this.asFilterModel.activate();
-          this.assignViewStateFromCache();
-          ExecutionFilterService.updateExecutionGroups();
-          return;
-        }
-        if (this.shouldRouteToSavedState(toParams, fromState)) {
-          this.asFilterModel.restoreState(toParams);
-        }
-        if (this.fromApplicationListState(fromState) && !this.asFilterModel.hasSavedState(toParams)) {
-          this.asFilterModel.clearFilters();
-        }
-      },
-    );
 
     // A nice way to avoid watches is to define a property on an object
     Object.defineProperty(this.asFilterModel.sortFilter, 'count', {
@@ -174,36 +117,5 @@ export class ExecutionFilterModel {
       globalCacheData.showDurations = this.showDurations;
       this.configViewStateCache.put(GLOBAL_CACHE_KEY, globalCacheData);
     }
-  }
-
-  private isExecutionState(stateName: string): boolean {
-    return (
-      stateName === 'home.applications.application.pipelines.executions' ||
-      stateName === 'home.project.application.pipelines.executions'
-    );
-  }
-
-  private isChildState(stateName: string): boolean {
-    return stateName.includes('executions.execution');
-  }
-
-  private isExecutionStateOrChild(stateName: string): boolean {
-    return this.isExecutionState(stateName) || this.isChildState(stateName);
-  }
-
-  private movingToExecutionsState(toState: Ng1StateDeclaration): boolean {
-    return this.isExecutionStateOrChild(toState.name);
-  }
-
-  private movingFromExecutionsState(toState: Ng1StateDeclaration, fromState: Ng1StateDeclaration): boolean {
-    return this.isExecutionStateOrChild(fromState.name) && !this.isExecutionStateOrChild(toState.name);
-  }
-
-  private fromApplicationListState(fromState: Ng1StateDeclaration): boolean {
-    return fromState.name === 'home.applications';
-  }
-
-  private shouldRouteToSavedState(toParams: StateParams, fromState: Ng1StateDeclaration): boolean {
-    return this.asFilterModel.hasSavedState(toParams) && !this.isExecutionStateOrChild(fromState.name);
   }
 }

--- a/app/scripts/modules/core/src/securityGroup/filter/SecurityGroupFilterModel.ts
+++ b/app/scripts/modules/core/src/securityGroup/filter/SecurityGroupFilterModel.ts
@@ -1,9 +1,6 @@
-import { IAngularEvent, module } from 'angular';
-import { Ng1StateDeclaration, StateParams } from '@uirouter/angularjs';
-import { $rootScope } from 'ngimport';
+import { module } from 'angular';
 
 import { IFilterConfig, IFilterModel } from 'core/filterModel/IFilterModel';
-import { UrlParser } from 'core/navigation/urlParser';
 import { FilterModelService } from 'core/filterModel';
 
 export const SECURITY_GROUP_FILTER_MODEL = 'spinnaker.core.securityGroup.filter.model';
@@ -19,95 +16,12 @@ export const filterModelConfig: IFilterConfig[] = [
 ];
 
 export class SecurityGroupFilterModel {
-  private mostRecentParams: any;
   public asFilterModel: IFilterModel;
 
   constructor() {
     this.asFilterModel = FilterModelService.configureFilterModel(this as any, filterModelConfig);
-    this.bindEvents();
+    FilterModelService.registerSaveAndRestoreRouterHooks(this.asFilterModel, '**.application.insight.firewalls');
     this.asFilterModel.activate();
-  }
-
-  private isSecurityGroupState(stateName: string) {
-    return stateName === 'home.applications.application.insight.securityGroups';
-  }
-
-  private isSecurityGroupStateOrChild(stateName: string) {
-    return this.isSecurityGroupState(stateName) || this.isChildState(stateName);
-  }
-
-  private isChildState(stateName: string) {
-    return stateName.includes('securityGroups.');
-  }
-
-  private movingToSecurityGroupState(toState: Ng1StateDeclaration) {
-    return this.isSecurityGroupStateOrChild(toState.name);
-  }
-
-  private movingFromSecurityGroupState(toState: Ng1StateDeclaration, fromState: Ng1StateDeclaration) {
-    return this.isSecurityGroupStateOrChild(fromState.name) && !this.isSecurityGroupStateOrChild(toState.name);
-  }
-
-  private shouldRouteToSavedState(toParams: StateParams, fromState: Ng1StateDeclaration) {
-    return this.asFilterModel.hasSavedState(toParams) && !this.isSecurityGroupStateOrChild(fromState.name);
-  }
-
-  private fromSecurityGroupsState(fromState: Ng1StateDeclaration) {
-    return (
-      fromState.name.indexOf('home.applications.application.insight') === 0 &&
-      !fromState.name.includes('home.applications.application.insight.securityGroups')
-    );
-  }
-
-  private bindEvents(): void {
-    // WHY??? Because, when the stateChangeStart event fires, the $location.search() will return whatever the query
-    // params are on the route we are going to, so if the user is using the back button, for example, to go to the
-    // Infrastructure page with a search already entered, we'll pick up whatever search was entered there, and if we
-    // come back to this application, we'll get whatever that search was.
-    $rootScope.$on('$locationChangeStart', (_event: IAngularEvent, toUrl: string, fromUrl: string) => {
-      const [oldBase, oldQuery] = fromUrl.split('?'),
-        [newBase, newQuery] = toUrl.split('?');
-
-      if (oldBase === newBase) {
-        this.mostRecentParams = newQuery ? UrlParser.parseQueryString(newQuery) : {};
-      } else {
-        this.mostRecentParams = oldQuery ? UrlParser.parseQueryString(oldQuery) : {};
-      }
-    });
-
-    $rootScope.$on(
-      '$stateChangeStart',
-      (
-        _event: IAngularEvent,
-        toState: Ng1StateDeclaration,
-        _toParams: StateParams,
-        fromState: Ng1StateDeclaration,
-        fromParams: StateParams,
-      ) => {
-        if (this.movingFromSecurityGroupState(toState, fromState)) {
-          this.asFilterModel.saveState(fromState, fromParams, this.mostRecentParams);
-        }
-      },
-    );
-
-    $rootScope.$on(
-      '$stateChangeSuccess',
-      (_event: IAngularEvent, toState: Ng1StateDeclaration, toParams: StateParams, fromState: Ng1StateDeclaration) => {
-        if (this.isSecurityGroupStateOrChild(toState.name) && this.isSecurityGroupStateOrChild(fromState.name)) {
-          this.asFilterModel.applyParamsToUrl();
-          return;
-        }
-        if (this.movingToSecurityGroupState(toState)) {
-          if (this.shouldRouteToSavedState(toParams, fromState)) {
-            this.asFilterModel.restoreState(toParams);
-          }
-
-          if (this.fromSecurityGroupsState(fromState) && !this.asFilterModel.hasSavedState(toParams)) {
-            this.asFilterModel.clearFilters();
-          }
-        }
-      },
-    );
   }
 }
 

--- a/app/scripts/modules/core/src/securityGroup/filter/SecurityGroupFilterModel.ts
+++ b/app/scripts/modules/core/src/securityGroup/filter/SecurityGroupFilterModel.ts
@@ -20,7 +20,7 @@ export class SecurityGroupFilterModel {
 
   constructor() {
     this.asFilterModel = FilterModelService.configureFilterModel(this as any, filterModelConfig);
-    FilterModelService.registerSaveAndRestoreRouterHooks(this.asFilterModel, '**.application.insight.firewalls');
+    FilterModelService.registerRouterHooks(this.asFilterModel, '**.application.insight.firewalls');
     this.asFilterModel.activate();
   }
 }


### PR DESCRIPTION
This refactor tries to simply the logic that handles saving and restoring of filters when switching between the tabs of an app.    It does away with most of the manual reading and writing of the URL's query parameters in favor of some router hooks.  I believe the URL manipulation was responsible for most of the "crazy celery" bugs we have witnessed so far, although I think we've addressed most of those bugs separately.

There is more than can be done to simply further (such as avoiding statefulness in FilterModel altogether, and reducing collaborators that try to manually drive the FilterModel lifecycle), but we are currently held back by the AngularJS code that mutates objects and responds to object mutations.

Additionally, there is more work to be done regarding saving and restoring "display options" (Executions grouping, # of executions per pipeline, etc).  They currently have some special cases that aren't necessary any more.  In the future I'd like to save these as global preferences, and remove all special cases.

