### PR TITLE
fix(ssl/apache2): Port conflict in ports.conf.gen

### DIFF
--- a/docker/ports.conf.gen
+++ b/docker/ports.conf.gen
@@ -2,9 +2,4 @@ Listen {%DECK_HOST%}:{%DECK_PORT%}
 
 <IfModule ssl_module>
         SSLPassPhraseDialog exec:/etc/apache2/passphrase
-        Listen {%DECK_PORT%}
-</IfModule>
-
-<IfModule mod_gnutls.c>
-        Listen {%DECK_PORT%}
 </IfModule>


### PR DESCRIPTION
The Deck pod was failing to start after a recent apache2 version bump in the image(2.4.25 to 2.4.38): `(98)Address already in use: AH00072: make_sock: could not bind to address 0.0.0.0:9000`
Happening only when SSL was enabled.
Starting from apache2 2.4.28, having multiple `Listen` directive listening to the same socket is forbidden:
- https://svn.apache.org/repos/asf/httpd/httpd/branches/2.4.x/CHANGES
- https://httpd.apache.org/docs/2.4/mod/mpm_common.html#listen

In this case, no need for multiple Listen directive as we always listen on one socket whether SSL is enabled or not.