### PR TITLE
Bump package core to 0.0.392 and kubernetes to 0.0.26 and google to 0.0.8 and amazon to 0.0.204 and titus to 0.0.105

### DIFF
--- a/app/scripts/modules/amazon/package.json
+++ b/app/scripts/modules/amazon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/amazon",
-  "version": "0.0.203",
+  "version": "0.0.204",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/core",
-  "version": "0.0.391",
+  "version": "0.0.392",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/google/package.json
+++ b/app/scripts/modules/google/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/google",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/kubernetes/package.json
+++ b/app/scripts/modules/kubernetes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/kubernetes",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/titus/package.json
+++ b/app/scripts/modules/titus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/titus",
-  "version": "0.0.104",
+  "version": "0.0.105",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
### chore(core): Bump version to 0.0.392

2dbc696243b4d4a068b182f9bee64256e4d0db25 test(core/filterModel): Add tests for restoring filters on router transitions, remove tests for removed functionality
f6dbdf5150fc6f5b62546248cd151fd083182370 refactor(core/filterModel): Simplify the AngularJS compatibility code which syncs the 'sortFilter' object and the router params - Removed the FilterModelServiceConverters code which duplicates the router param types code
d39ab96f71ac1a023a9aa17ff75eeeb182ced293 refactor(core/filterModel): Use router hooks to save/restore filters
39a27e6cd4332c11c7a93b662711364b35bbc319 fix(core/reactShims): Fix the state.go wrapper such that it correctly exposes the `transition` (it's been inconsequentially broken a long time and nobody noticed)
ac2f61c3a182823d445c9f6e047358504d04e801 fix(core/pipeline): Trigger pipeline validation when a trigger is updated
4a8b341f8a0bae23ea507d04e75d15763e185751 fix(core/pipeline): Fix initial trigger type state
a4ebd0aa6b0358d451e77869beff677f5f736319 refactor(core): refactored the trigger to react
67314e054d8723cef149bb63448588266274fd8d fix(core): Render template triggers, notif, params for manual execution (#7223)
8275ba6df49006a2d6037f190975ea81cce6fb06 feat(core): Allow filtering PAUSED executions

### chore(kubernetes): Bump version to 0.0.26

7671a5e6914f58c6804287a397e314a34c25be61 feat(kubernetes): allow multi-manifest for rollout strategies (#7219)

### chore(google): Bump version to 0.0.8

ad483a092fbd1798c1f896ed0c8d18b7d54155dd fix(google): replace stateful MIG image input with dropdown (#7210)
97db30b93ab9d9ae82290832056383393c88252a perf(google): improve performance of GCE image selection (#7208)
f340b0268c1c85aae96c54acee77aa39ef9770d6 feat(google): support stateful MIG operations (#7196)
ecb2dd17aea1958e78089ed58f18a19ed502998f feat(gce): Support new artifact model for deploy SG (#7178)

### chore(amazon): Bump version to 0.0.204

b2c0cf0314c2843691b301f4bc9be919934ebc75 fix(amazon): Update default internalPort for CLBs to 80 (#7220)

### chore(titus): Bump version to 0.0.105

0e5e66a3fae50abddb98cb2d97036a32907ea811 feat(titus): Adding support for service job processes (#7186)


