### PR TITLE
feat(pager): Allow providing pager duty subject/details in URL

### DIFF
--- a/app/scripts/modules/core/src/pagerDuty/PageModal.tsx
+++ b/app/scripts/modules/core/src/pagerDuty/PageModal.tsx
@@ -4,7 +4,7 @@ import { get } from 'lodash';
 
 import { Application, ApplicationModelBuilder } from 'core/application';
 import { IPagerDutyService, PagerDutyWriter } from 'core/pagerDuty';
-import { NgReact } from 'core/reactShims';
+import { NgReact, ReactInjector } from 'core/reactShims';
 import { SETTINGS } from 'core/config';
 import { SubmitButton } from 'core/modal';
 import { TaskMonitor } from 'core/task';
@@ -40,8 +40,13 @@ export class PageModal extends React.Component<IPageModalProps, IPageModalState>
   }
 
   private getDefaultState(props: IPageModalProps): IPageModalState {
-    const defaultSubject = get(SETTINGS, 'pagerDuty.defaultSubject', 'Urgent Issue');
-    const defaultDetails = get(SETTINGS, 'pagerDuty.defaultDetails', '');
+    const {
+      $state: {
+        params: { subject, details },
+      },
+    } = ReactInjector;
+    const defaultSubject = subject || get(SETTINGS, 'pagerDuty.defaultSubject', 'Urgent Issue');
+    const defaultDetails = details || get(SETTINGS, 'pagerDuty.defaultDetails', '');
 
     return {
       accountName: (SETTINGS.pagerDuty && SETTINGS.pagerDuty.accountName) || '',
@@ -61,11 +66,13 @@ export class PageModal extends React.Component<IPageModalProps, IPageModalState>
 
   private handleSubjectChanged = (event: any): void => {
     const value = event.target.value;
+    ReactInjector.$state.go('.', { subject: value });
     this.setState({ subject: value });
   };
 
   private handleDetailsChanged = (event: any): void => {
     const value = event.target.value;
+    ReactInjector.$state.go('.', { details: value });
     this.setState({ details: value });
   };
 

--- a/app/scripts/modules/core/src/pagerDuty/PageModal.tsx
+++ b/app/scripts/modules/core/src/pagerDuty/PageModal.tsx
@@ -41,8 +41,10 @@ export class PageModal extends React.Component<IPageModalProps, IPageModalState>
 
   private getDefaultState(props: IPageModalProps): IPageModalState {
     const {
-      $state: {
-        params: { subject, details },
+      $uiRouter: {
+        globals: {
+          params: { subject, details },
+        },
       },
     } = ReactInjector;
     const defaultSubject = subject || get(SETTINGS, 'pagerDuty.defaultSubject', 'Urgent Issue');
@@ -66,13 +68,13 @@ export class PageModal extends React.Component<IPageModalProps, IPageModalState>
 
   private handleSubjectChanged = (event: any): void => {
     const value = event.target.value;
-    ReactInjector.$state.go('.', { subject: value });
+    ReactInjector.$state.go('.', { subject: value }, { location: 'replace' });
     this.setState({ subject: value });
   };
 
   private handleDetailsChanged = (event: any): void => {
     const value = event.target.value;
-    ReactInjector.$state.go('.', { details: value });
+    ReactInjector.$state.go('.', { details: value }, { location: 'replace' });
     this.setState({ details: value });
   };
 

--- a/app/scripts/modules/core/src/pagerDuty/pager.states.ts
+++ b/app/scripts/modules/core/src/pagerDuty/pager.states.ts
@@ -10,7 +10,7 @@ module(PAGER_STATES, [STATE_CONFIG_PROVIDER]).config([
   'stateConfigProvider',
   (stateConfigProvider: StateConfigProvider) => {
     const pageState: INestedState = {
-      url: '/page?app&q&keys&by&direction&hideNoApps',
+      url: '/page?app&q&keys&by&direction&hideNoApps&subject&&details',
       name: 'page',
       views: {
         'main@': { component: Pager, $type: 'react' },
@@ -23,6 +23,18 @@ module(PAGER_STATES, [STATE_CONFIG_PROVIDER]).config([
           squash: true,
         },
         q: {
+          dynamic: true,
+          type: 'string',
+          value: '',
+          squash: true,
+        },
+        subject: {
+          dynamic: true,
+          type: 'string',
+          value: '',
+          squash: true,
+        },
+        details: {
           dynamic: true,
           type: 'string',
           value: '',


### PR DESCRIPTION
This change allows more than just a single default subject/details combination to pre-populate the Send Page modal.

I'm not loving the URL reading/syncing but still settled on this approach because it is the most frictionless for users.