### PR TITLE
fix(k8s/runJob): null property file if value none

### DIFF
--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/runJob/KubernetesV2RunJobStageConfig.tsx
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/runJob/KubernetesV2RunJobStageConfig.tsx
@@ -72,6 +72,9 @@ export class KubernetesV2RunJobStageConfig extends React.Component<IStageConfigP
 
   private sourceChanged = (event: any) => {
     this.props.updateStageField({ consumeArtifactSource: event.value });
+    if (event.value === 'none') {
+      this.props.updateStageField({ propertyFile: null });
+    }
   };
 
   private updateArtifactId(artifactId: string) {


### PR DESCRIPTION
if the logs capture selector changes to `none` we should null out the
`propertyFile` field. the `consumeArtifactSource` field is used as a
flag for deck to determine which option is selected but it isn't taken
into account in orca. so, if `propertyFile` is non-null, orca will still
try to find properties even if we have `consumeArtifactSource = none`.

Fixes spinnaker/spinnaker#4642