### PR TITLE
Bump package core to 0.0.395 and kubernetes to 0.0.27 and amazon to 0.0.205

### DIFF
--- a/app/scripts/modules/amazon/package.json
+++ b/app/scripts/modules/amazon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/amazon",
-  "version": "0.0.204",
+  "version": "0.0.205",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/core",
-  "version": "0.0.394",
+  "version": "0.0.395",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/kubernetes/package.json
+++ b/app/scripts/modules/kubernetes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/kubernetes",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
### chore(core): Bump version to 0.0.395

f38580f3c4d04bb554d25dbdad2b3e573d84c046 fix(core): save and validate trigger type in pipeline config (#7241)
f37ccf05a02e5248849a2d8d2459a1c6535d60b2 feat(pager): Allow providing pager duty subject/details in URL (#7242)

### chore(kubernetes): Bump version to 0.0.27

af4a1ad9d2bc66922ddd0127c05725670893e29a fix(k8s/runJob): null property file if value none (#7243)
70ea40b2781333b0591ba822cfb8a631ed8781ee fix(kubernetes): fix radio button alignment in deploy manifest stage (#7240)

### chore(amazon): Bump version to 0.0.205

d3249c9e2173cfd3652f6fb8a95c2fb5f2367984 feat(aws): Support new artifact model for deploy cloudformation (#7180)


