### PR TITLE
fix(core/presentation): Default FormField 'name' prop to '', not noop

### DIFF
--- a/app/scripts/modules/core/src/presentation/forms/FormField.tsx
+++ b/app/scripts/modules/core/src/presentation/forms/FormField.tsx
@@ -78,7 +78,7 @@ export function FormField(props: IFormFieldProps) {
 
   const controlledInputProps: IControlledInputProps = {
     value: props.value,
-    name: props.name || noop,
+    name: props.name || '',
     onChange: props.onChange || noop,
     onBlur: (e: React.FocusEvent) => {
       setHasBlurred(true);

--- a/app/scripts/modules/core/src/presentation/forms/interface.ts
+++ b/app/scripts/modules/core/src/presentation/forms/interface.ts
@@ -19,11 +19,11 @@ export interface IFieldLayoutProps extends IFieldLayoutPropsWithoutInput {
 
 /**
  * These props are used by controlled components, such as <input> or Input components like TextInput
- * The typings reference the typings supplied by formik FieldProps
+ * Some of the typings reference the typings supplied by formik FieldProps
  */
 export interface IControlledInputProps {
   value: FieldProps['field']['value'];
-  onChange: FieldProps['field']['onChange'];
+  onChange(e: React.ChangeEvent<any>): void;
   onBlur: FieldProps['field']['onBlur'];
   name: FieldProps['field']['name'];
 }


### PR DESCRIPTION
This fixes a bug which blocked usage of the `FormField` component without a name prop. 

```js
<FormField
  input={TheInput}
  // no name specified
/>
```

Also fixes the typing for onChange handler allowing (formik provides two overloads, and the correct one cannot be inferred)

Previously, `e` had implicity `any` type
```js
<FormField onChange={e => handleEvent(e)} />
```