### PR TITLE
fix(k8s/runJob): External logs URL support manifest with implicit default namespace

### DIFF
--- a/app/scripts/modules/core/src/manifest/stage/JobStageExecutionLogs.tsx
+++ b/app/scripts/modules/core/src/manifest/stage/JobStageExecutionLogs.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { template, isEmpty } from 'lodash';
 import { Observable, Subject } from 'rxjs';
 
-import { IStageManifest } from '../ManifestService';
 import { JobManifestPodLogs } from './JobManifestPodLogs';
 import { IManifest } from 'core/domain/IManifest';
 import { Application } from 'core/application';
@@ -10,7 +9,6 @@ import { IPodNameProvider } from '../PodNameProvider';
 import { ManifestReader } from 'core/manifest';
 
 interface IJobStageExecutionLogsProps {
-  manifest: IStageManifest;
   deployedName: string;
   account: string;
   application: Application;

--- a/app/scripts/modules/core/src/pipeline/config/stages/preconfiguredJob/PreconfiguredJobExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/preconfiguredJob/PreconfiguredJobExecutionDetails.tsx
@@ -75,7 +75,6 @@ export class PreconfiguredJobExecutionDetails extends React.Component<IExecution
     const { stage } = this.props;
 
     if (cloudProvider === 'kubernetes') {
-      const manifest = get(stage, ['context', 'manifest'], null);
       const namespace = get<string>(stage, ['context', 'jobStatus', 'location']);
       const deployedJobs = get(this.props.stage, ['context', 'deploy.jobs']);
       const deployedName = get(deployedJobs, namespace, [])[0] || '';
@@ -85,7 +84,6 @@ export class PreconfiguredJobExecutionDetails extends React.Component<IExecution
       return (
         <div className="well">
           <JobStageExecutionLogs
-            manifest={manifest}
             deployedName={deployedName}
             account={this.props.stage.context.account}
             application={this.props.application}


### PR DESCRIPTION
When the manifest had no namespace explicitly provided, the external logs URL couldn't be prepared.
Now sourcing the namespace from `context.jobStatus.location`, reusing the existing variable.
Also removed the `manifest` property from `JobStageExecutionLogs` because unused.