### PR TITLE
fix(k8s): fix job log modal overflow

### DIFF
--- a/app/scripts/modules/core/src/manifest/stage/JobManifestPodLogs.tsx
+++ b/app/scripts/modules/core/src/manifest/stage/JobManifestPodLogs.tsx
@@ -85,11 +85,11 @@ export class JobManifestPodLogs extends React.Component<IJobManifestPodLogsProps
           <a onClick={this.onClick} className="clickable">
             {this.props.linkName}
           </a>
-          <Modal show={showModal} onHide={this.close} dialogClassName="modal-lg modal-fullscreen">
+          <Modal show={showModal} onHide={this.close} dialogClassName="modal-lg modal-fullscreen flex-fill">
             <Modal.Header closeButton={true}>
               <Modal.Title>Console Output: {this.podName()} </Modal.Title>
             </Modal.Header>
-            <Modal.Body>
+            <Modal.Body className="flex-fill">
               {containerLogs.length && (
                 <>
                   <ul className="tabs-basic console-output-tabs">
@@ -105,7 +105,7 @@ export class JobManifestPodLogs extends React.Component<IJobManifestPodLogsProps
                       </li>
                     ))}
                   </ul>
-                  <pre className="body-small">{selectedContainerLog.output}</pre>
+                  <pre className="body-small flex-fill">{selectedContainerLog.output}</pre>
                 </>
               )}
               {errorMessage && <pre className="body-small">{errorMessage}</pre>}


### PR DESCRIPTION
adding a couple flex fills to ensure that the model fills the screen
without overflowing. now the log output scrolls when it overflows and
the rest of the modal stays static.