### PR TITLE
fix(k8s/runJob): Allowing only v1 accounts for v1 runJob

### DIFF
--- a/app/scripts/modules/kubernetes/src/pipeline/stages/runJob/configureJob.controller.js
+++ b/app/scripts/modules/kubernetes/src/pipeline/stages/runJob/configureJob.controller.js
@@ -36,7 +36,7 @@ module.exports = angular
         this.namespaces = namespaces;
       });
 
-      AccountService.listAccounts('kubernetes').then(accounts => {
+      AccountService.listAccounts('kubernetes', 'v1').then(accounts => {
         this.accounts = accounts;
       });
 


### PR DESCRIPTION
Using a v2 account would have `com.netflix.spinnaker.clouddriver.kubernetes.v2.op.job.KubernetesRunJobOperation` be called and throw an NPE at line 70, because there's no manifest.
