### PR TITLE
feat(*/pipeline): Remove the concept of default stage timeouts, rename option

### DIFF
--- a/app/scripts/modules/amazon/src/pipeline/stages/bake/awsBakeStage.js
+++ b/app/scripts/modules/amazon/src/pipeline/stages/bake/awsBakeStage.js
@@ -23,7 +23,7 @@ module.exports = angular
       extraLabelLines: stage => {
         return stage.masterStage.context.allPreviouslyBaked || stage.masterStage.context.somePreviouslyBaked ? 1 : 0;
       },
-      defaultTimeoutMs: 60 * 60 * 1000, // 60 minutes
+      supportsCustomTimeout: true,
       validators: [
         { type: 'requiredField', fieldName: 'package' },
         { type: 'requiredField', fieldName: 'regions' },

--- a/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/deployCloudFormationStackStage.ts
+++ b/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/deployCloudFormationStackStage.ts
@@ -24,7 +24,7 @@ module(DEPLOY_CLOUDFORMATION_STACK_STAGE, [])
       controllerAs: 'ctrl',
       executionDetailsSections: [ExecutionDetailsTasks],
       producesArtifacts: true,
-      defaultTimeoutMs: 30 * 60 * 1000, // 30 minutes
+      supportsCustomTimeout: true,
       validators: [],
       accountExtractor: (stage: IStage): string[] => (stage.account ? [stage.account] : []),
       configAccountExtractor: (stage: any): string[] => (stage.account ? [stage.account] : []),

--- a/app/scripts/modules/azure/src/pipeline/stages/bake/azureBakeStage.js
+++ b/app/scripts/modules/azure/src/pipeline/stages/bake/azureBakeStage.js
@@ -26,7 +26,7 @@ module.exports = angular
       extraLabelLines: stage => {
         return stage.masterStage.context.allPreviouslyBaked || stage.masterStage.context.somePreviouslyBaked ? 1 : 0;
       },
-      defaultTimeoutMs: 60 * 60 * 1000, // 60 minutes
+      supportsCustomTimeout: true,
       validators: [
         { type: 'requiredField', fieldName: 'package' },
         { type: 'requiredField', fieldName: 'regions' },

--- a/app/scripts/modules/cloudfoundry/src/pipeline/stages/deployService/cloudfoundryDeployServiceStage.module.ts
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/stages/deployService/cloudfoundryDeployServiceStage.module.ts
@@ -101,7 +101,7 @@ Registry.pipeline.registerStage({
   cloudProvider: 'cloudfoundry',
   component: CloudfoundryDeployServiceStageConfig,
   configAccountExtractor: (stage: IStage) => [stage.credentials],
-  defaultTimeoutMs: 30 * 60 * 1000,
+  supportsCustomTimeout: true,
   description: 'Deploys services using Open Service Broker and deploys user-provided services',
   executionDetailsSections: [CloudfoundryServiceExecutionDetails, ExecutionDetailsTasks],
   key: 'deployService',

--- a/app/scripts/modules/cloudfoundry/src/pipeline/stages/destroyService/cloudfoundryDestroyServiceStage.module.ts
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/stages/destroyService/cloudfoundryDestroyServiceStage.module.ts
@@ -7,7 +7,7 @@ Registry.pipeline.registerStage({
   configAccountExtractor: (stage: IStage) => [stage.credentials],
   cloudProvider: 'cloudfoundry',
   component: CloudfoundryDestroyServiceStageConfig,
-  defaultTimeoutMs: 30 * 60 * 1000,
+  supportsCustomTimeout: true,
   executionDetailsSections: [CloudfoundryServiceExecutionDetails, ExecutionDetailsTasks],
   key: 'destroyService',
   provides: 'destroyService',

--- a/app/scripts/modules/cloudfoundry/src/pipeline/stages/runJob/cloudfoundryRunJob.module.ts
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/stages/runJob/cloudfoundryRunJob.module.ts
@@ -11,7 +11,7 @@ Registry.pipeline.registerStage({
   provides: 'runJob',
   restartable: true,
   executionDetailsSections: [ExecutionDetailsTasks, RunJobExecutionDetails],
-  defaultTimeoutMs: 2 * 60 * 60 * 1000, // 2 hours
+  supportsCustomTimeout: true,
   validators: [
     { type: 'requiredField', fieldName: 'credentials' },
     { type: 'requiredField', fieldName: 'region' },

--- a/app/scripts/modules/cloudfoundry/src/pipeline/stages/shareService/cloudfoundryShareServiceStage.module.ts
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/stages/shareService/cloudfoundryShareServiceStage.module.ts
@@ -10,7 +10,7 @@ Registry.pipeline.registerStage({
   cloudProvider: 'cloudfoundry',
   component: CloudfoundryShareServiceStageConfig,
   executionDetailsSections: [CloudfoundryShareServiceExecutionDetails, ExecutionDetailsTasks],
-  defaultTimeoutMs: 30 * 60 * 1000,
+  supportsCustomTimeout: true,
   validators: [
     { type: 'requiredField', fieldName: 'credentials', fieldLabel: 'account' },
     { type: 'requiredField', fieldName: 'region' },

--- a/app/scripts/modules/cloudfoundry/src/pipeline/stages/unshareService/cloudfoundryUnshareServiceStage.module.ts
+++ b/app/scripts/modules/cloudfoundry/src/pipeline/stages/unshareService/cloudfoundryUnshareServiceStage.module.ts
@@ -11,7 +11,7 @@ Registry.pipeline.registerStage({
   component: CloudfoundryUnshareServiceStageConfig,
   controller: 'cfUnshareServiceStageCtrl',
   executionDetailsSections: [CloudfoundryUnshareServiceExecutionDetails, ExecutionDetailsTasks],
-  defaultTimeoutMs: 30 * 60 * 1000,
+  supportsCustomTimeout: true,
   validators: [
     { type: 'requiredField', fieldName: 'credentials', fieldLabel: 'account' },
     { type: 'requiredField', fieldName: 'serviceInstanceName', preventSave: true },

--- a/app/scripts/modules/core/src/domain/IStageTypeConfig.ts
+++ b/app/scripts/modules/core/src/domain/IStageTypeConfig.ts
@@ -16,7 +16,6 @@ export interface IStageTypeConfig extends IStageOrTriggerTypeConfig {
   configAccountExtractor?: (stage: IStage) => string[];
   configuration?: any;
   defaults?: any;
-  defaultTimeoutMs?: number;
   disableNotifications?: boolean;
   executionConfigSections?: string[]; // angular only
   executionDetailsSections?: IExecutionDetailsSection[]; // react only
@@ -33,6 +32,7 @@ export interface IStageTypeConfig extends IStageOrTriggerTypeConfig {
   restartable?: boolean;
   stageFilter?: (stage: IStage) => boolean;
   strategy?: boolean;
+  supportsCustomTimeout?: boolean;
   synthetic?: boolean;
   useBaseProvider?: boolean;
   useCustomTooltip?: boolean;

--- a/app/scripts/modules/core/src/help/help.contents.ts
+++ b/app/scripts/modules/core/src/help/help.contents.ts
@@ -299,8 +299,8 @@ const helpContents: { [key: string]: string } = {
   'pipeline.config.parallel.cancel.queue':
     '<p>If concurrent pipeline execution is disabled, then the pipelines that are in the waiting queue will get canceled when the next execution starts. <br><br>Check this box if you want to keep them in the queue.</p>',
   'pipeline.config.timeout': `
-      <p>Allows you to override the amount of time the stage can run before failing.</p>
-      <p><b>Note:</b> this represents the overall time the stage has to complete (the sum of all the task times).</p>`,
+      <p>Allows you to force the stage to fail if its running time exceeds a specific length.</p>
+      <p><b>Note:</b> by default there is not a time limit on the stage, only the individual tasks it runs. The maximium possible running time for a stage is the sum of each task's timeout.</p>`,
   'pipeline.config.trigger.runAsUser':
     "The current user must have access to the specified service account, and the service account must have access to the current application. Otherwise, you'll receive an 'Access is denied' error.",
   'pipeline.config.script.repoUrl':

--- a/app/scripts/modules/core/src/pipeline/config/stages/createLoadBalancer/createLoadBalancerStage.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/createLoadBalancer/createLoadBalancerStage.js
@@ -19,7 +19,7 @@ module.exports = angular
           ' If a load balancer exists with the same name, then that will be updated.',
         templateUrl: require('./createLoadBalancerStage.html'),
         executionDetailsUrl: require('./createLoadBalancerExecutionDetails.html'),
-        defaultTimeoutMs: 5 * 60 * 1000, // 5 minutes
+        supportsCustomTimeout: true,
         validators: [],
       });
     }

--- a/app/scripts/modules/core/src/pipeline/config/stages/deploy/deployStage.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/deploy/deployStage.js
@@ -24,7 +24,7 @@ module.exports = angular
         executionDetailsUrl: require('./deployExecutionDetails.html'),
         controller: 'DeployStageCtrl',
         controllerAs: 'deployStageCtrl',
-        defaultTimeoutMs: 2 * 60 * 60 * 1000, // 2 hours
+        supportsCustomTimeout: true,
         validators: [
           {
             type: 'stageBeforeType',

--- a/app/scripts/modules/core/src/pipeline/config/stages/jenkins/jenkinsStage.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/jenkins/jenkinsStage.js
@@ -30,7 +30,7 @@ module.exports = angular
         let lines = stage.masterStage.context.buildInfo.number ? 1 : 0;
         return lines + (stage.masterStage.context.buildInfo.testResults || []).length;
       },
-      defaultTimeoutMs: 2 * 60 * 60 * 1000, // 2 hours
+      supportsCustomTimeout: true,
       validators: [{ type: 'requiredField', fieldName: 'job' }],
       strategy: true,
     });

--- a/app/scripts/modules/core/src/pipeline/config/stages/manualJudgment/manualJudgmentStage.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/manualJudgment/manualJudgmentStage.js
@@ -26,7 +26,7 @@ module.exports = angular
       useCustomTooltip: true,
       markerIcon: ManualJudgmentMarkerIcon,
       strategy: true,
-      defaultTimeoutMs: 72 * 60 * 60 * 1000,
+      supportsCustomTimeout: true,
       disableNotifications: true,
     });
   })

--- a/app/scripts/modules/core/src/pipeline/config/stages/overrideTimeout/OverrideTimeout.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/overrideTimeout/OverrideTimeout.tsx
@@ -40,7 +40,7 @@ export const OverrideTimeout = (props: IOverrideTimeoutConfigProps) => {
 
   useEffect(() => {
     stageChanged();
-  }, [!!get(props.stageConfig, 'supportsCustomTimeout'), props.stageTimeoutMs]);
+  }, [props.stageTimeoutMs]);
 
   const stageChanged = () => {
     if (props.stageTimeoutMs !== undefined) {

--- a/app/scripts/modules/core/src/pipeline/config/stages/overrideTimeout/OverrideTimeout.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/overrideTimeout/OverrideTimeout.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { get } from 'lodash';
+import { Duration } from 'luxon';
 
 import { IStage } from 'core/domain';
 import { CheckboxInput, NumberInput } from 'core/presentation';
@@ -21,10 +22,13 @@ const toHoursAndMinutes = (ms: number) => {
   if (!ms) {
     return { hours: 0, minutes: 0 };
   } else {
-    const seconds = ms / 1000;
+    const { hours, minutes } = Duration.fromMillis(ms)
+      .shiftTo('hours', 'minutes')
+      .toObject();
+
     return {
-      hours: Math.floor(seconds / 3600),
-      minutes: Math.floor(seconds / 60) % 60,
+      hours: Math.floor(hours),
+      minutes: Math.floor(minutes),
     };
   }
 };

--- a/app/scripts/modules/core/src/pipeline/config/stages/overrideTimeout/OverrideTimeout.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/overrideTimeout/OverrideTimeout.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { get } from 'lodash';
 
 import { IStage } from 'core/domain';
 import { CheckboxInput, NumberInput } from 'core/presentation';
@@ -13,26 +14,32 @@ export interface IOverrideTimeoutConfigProps {
 }
 
 interface IStageConfig {
-  defaultTimeoutMs: number;
+  supportsCustomTimeout: boolean;
 }
+
+const toHoursAndMinutes = (ms: number) => {
+  if (!ms) {
+    return { hours: 0, minutes: 0 };
+  } else {
+    const seconds = ms / 1000;
+    return {
+      hours: Math.floor(seconds / 3600),
+      minutes: Math.floor(seconds / 60) % 60,
+    };
+  }
+};
 
 export const OverrideTimeout = (props: IOverrideTimeoutConfigProps) => {
   const [hours, setHours] = useState(0);
   const [minutes, setMinutes] = useState(0);
   const [overrideTimeout, setOverrideTimeout] = useState(false);
-  const [configurable, setConfigurable] = useState(false);
-  const [defaults, setDefaults] = useState({ hours: 0, minutes: 0 });
 
   useEffect(() => {
     stageChanged();
-  }, [props.stageConfig, props.stageTimeoutMs]);
+  }, [!!get(props.stageConfig, 'supportsCustomTimeout'), props.stageTimeoutMs]);
 
   const stageChanged = () => {
-    const { stageConfig, stageTimeoutMs } = props;
-    const defaultTimeoutMs = stageConfig && stageConfig.defaultTimeoutMs;
-    setConfigurable(!!defaultTimeoutMs);
-    setDefaults(toHoursAndMinutes(defaultTimeoutMs));
-    if (stageTimeoutMs !== undefined) {
+    if (props.stageTimeoutMs !== undefined) {
       enableTimeout();
     } else {
       clearTimeout();
@@ -56,28 +63,17 @@ export const OverrideTimeout = (props: IOverrideTimeoutConfigProps) => {
   };
 
   const enableTimeout = () => {
-    const stageDefaults = props.stageConfig ? props.stageConfig.defaultTimeoutMs : null;
     setOverrideTimeout(true);
     props.updateStageField({
-      stageTimeoutMs: props.stageTimeoutMs || stageDefaults,
+      stageTimeoutMs: props.stageTimeoutMs || null,
     });
     setHours(toHoursAndMinutes(props.stageTimeoutMs).hours);
     setMinutes(toHoursAndMinutes(props.stageTimeoutMs).minutes);
   };
 
-  function toHoursAndMinutes(ms: number) {
-    if (!ms) {
-      return { hours: 0, minutes: 0 };
-    } else {
-      const seconds = ms / 1000;
-      return {
-        hours: Math.floor(seconds / 3600),
-        minutes: Math.floor(seconds / 60) % 60,
-      };
-    }
-  }
+  const isConfigurable = !!get(props.stageConfig, 'supportsCustomTimeout');
 
-  if (configurable) {
+  if (isConfigurable) {
     return (
       <>
         <div className="form-group">
@@ -86,18 +82,8 @@ export const OverrideTimeout = (props: IOverrideTimeoutConfigProps) => {
               <CheckboxInput
                 text={
                   <>
-                    <strong> Override default timeout</strong> (
-                    {defaults.hours > 0 && (
-                      <span>
-                        {defaults.hours} {defaults.hours > 1 ? 'hours' : 'hour'}{' '}
-                      </span>
-                    )}
-                    {defaults.minutes > 0 && (
-                      <span>
-                        {defaults.minutes} {defaults.minutes > 1 ? 'minutes' : 'minute'}
-                      </span>
-                    )}
-                    ) <HelpField id="pipeline.config.timeout" />
+                    <strong>Fail stage after a specific amount of time</strong>{' '}
+                    <HelpField id="pipeline.config.timeout" />
                   </>
                 }
                 value={overrideTimeout}
@@ -112,7 +98,7 @@ export const OverrideTimeout = (props: IOverrideTimeoutConfigProps) => {
               <div className="col-md-9 col-md-offset-1 checkbox-padding">
                 Fail this stage if it takes longer than
                 <NumberInput
-                  inputClassName={'form-control input-sm inline-number with-space-before'}
+                  inputClassName="form-control input-sm inline-number with-space-before"
                   min={0}
                   onChange={(e: React.ChangeEvent<any>) => {
                     setHours(e.target.value);
@@ -122,7 +108,7 @@ export const OverrideTimeout = (props: IOverrideTimeoutConfigProps) => {
                 />{' '}
                 hours
                 <NumberInput
-                  inputClassName={'form-control input-sm inline-number with-space-before'}
+                  inputClassName="form-control input-sm inline-number with-space-before"
                   min={0}
                   onChange={(e: React.ChangeEvent<any>) => {
                     setMinutes(e.target.value);

--- a/app/scripts/modules/core/src/pipeline/config/stages/pipeline/pipelineStage.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/pipeline/pipelineStage.js
@@ -30,7 +30,7 @@ module.exports = angular
         PipelineParametersExecutionDetails,
         ExecutionDetailsTasks,
       ],
-      defaultTimeoutMs: 12 * 60 * 60 * 1000, // 12 hours
+      supportsCustomTimeout: true,
       validators: [{ type: 'requiredField', fieldName: 'pipeline' }],
     });
   })

--- a/app/scripts/modules/core/src/pipeline/config/stages/savePipelines/savePipelinesStage.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/savePipelines/savePipelinesStage.ts
@@ -13,7 +13,7 @@ if (SETTINGS.feature.versionedProviders) {
     key: 'savePipelinesFromArtifact',
     component: SavePipelinesStageConfig,
     executionDetailsSections: [ExecutionDetailsTasks, ExecutionArtifactTab, SavePipelinesResultsTab],
-    defaultTimeoutMs: 30 * 60 * 1000, // 30 minutes
+    supportsCustomTimeout: true,
     artifactExtractor: ExpectedArtifactService.accumulateArtifacts(['pipelinesArtifactId', 'requiredArtifactIds']),
     artifactRemover: ArtifactReferenceService.removeArtifactFromFields(['pipelinesArtifactId', 'requiredArtifactIds']),
   });

--- a/app/scripts/modules/core/src/pipeline/config/stages/script/scriptStage.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/script/scriptStage.ts
@@ -12,7 +12,7 @@ module(SCRIPT_STAGE, []).config(() => {
   Registry.pipeline.registerStage({
     label: 'Script',
     description: 'Runs a script',
-    defaultTimeoutMs: 1000 * 60 * 60 * 2, // 2 hours
+    supportsCustomTimeout: true,
     key: 'script',
     restartable: true,
     defaults: {

--- a/app/scripts/modules/core/src/pipeline/config/stages/travis/travisStage.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/travis/travisStage.ts
@@ -6,7 +6,6 @@ import { SETTINGS } from 'core/config/settings';
 import { IgorService, BuildServiceType } from 'core/ci/igor.service';
 import { IJobConfig, IParameterDefinitionList, IStage } from 'core/domain';
 import { TravisExecutionLabel } from './TravisExecutionLabel';
-import { Duration } from 'luxon';
 
 export interface ITravisStageViewState {
   mastersLoaded: boolean;
@@ -175,7 +174,7 @@ module(TRAVIS_STAGE, [])
           const lines = stage.masterStage.context.buildInfo.number ? 1 : 0;
           return lines + (stage.masterStage.context.buildInfo.testResults || []).length;
         },
-        defaultTimeoutMs: Duration.fromObject({ hours: 2 }).as('milliseconds'),
+        supportsCustomTimeout: true,
         validators: [{ type: 'requiredField', fieldName: 'job' }],
         strategy: true,
       });

--- a/app/scripts/modules/core/src/pipeline/config/stages/webhook/webhookStage.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/webhook/webhookStage.ts
@@ -162,7 +162,7 @@ module(WEBHOOK_STAGE, [])
       controllerAs: '$ctrl',
       templateUrl: require('./webhookStage.html'),
       executionDetailsUrl: require('./webhookExecutionDetails.html'),
-      defaultTimeoutMs: 60 * 60 * 1000, // 1 hour
+      supportsCustomTimeout: true,
       validators: [{ type: 'requiredField', fieldName: 'url' }, { type: 'requiredField', fieldName: 'method' }],
     });
   })

--- a/app/scripts/modules/core/src/pipeline/config/stages/wercker/werckerStage.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/wercker/werckerStage.ts
@@ -6,7 +6,6 @@ import { IgorService, BuildServiceType } from 'core/ci/igor.service';
 import { IJobConfig, IParameterDefinitionList, IStage } from 'core/domain';
 import { SETTINGS } from 'core/config/settings';
 import { WerckerExecutionLabel } from './WerckerExecutionLabel';
-import { Duration } from 'luxon';
 
 export interface IWerckerStageViewState {
   mastersLoaded: boolean;
@@ -226,7 +225,7 @@ module(WERCKER_STAGE, [])
           const lines = stage.masterStage.context.buildInfo.number ? 1 : 0;
           return lines + (stage.masterStage.context.buildInfo.testResults || []).length;
         },
-        defaultTimeoutMs: Duration.fromObject({ hours: 2 }).as('milliseconds'),
+        supportsCustomTimeout: true,
         validators: [{ type: 'requiredField', fieldName: 'job' }],
         strategy: true,
       });

--- a/app/scripts/modules/core/src/pipeline/config/validation/PipelineConfigValidator.ts
+++ b/app/scripts/modules/core/src/pipeline/config/validation/PipelineConfigValidator.ts
@@ -1,7 +1,7 @@
 import { IPromise } from 'angular';
 import { Subject, Subscription } from 'rxjs';
 import { $log, $q } from 'ngimport';
-import { values, flatten } from 'lodash';
+import { values, flatten, isNumber } from 'lodash';
 import { FormikErrors } from 'formik';
 
 import {
@@ -148,6 +148,13 @@ export class PipelineConfigValidator {
             }
           }),
         );
+      }
+
+      if (stage.stageTimeoutMs !== undefined && !(isNumber(stage.stageTimeoutMs) && stage.stageTimeoutMs > 0)) {
+        stageValidations.set(stage, [
+          ...(stageValidations.get(stage) || []),
+          'Stage is configured to fail after a specific amount of time, but no time is set.',
+        ]);
       }
     });
 

--- a/app/scripts/modules/docker/src/pipeline/stages/bake/dockerBakeStage.js
+++ b/app/scripts/modules/docker/src/pipeline/stages/bake/dockerBakeStage.js
@@ -24,7 +24,7 @@ module.exports = angular
       extraLabelLines: stage => {
         return stage.masterStage.context.allPreviouslyBaked || stage.masterStage.context.somePreviouslyBaked ? 1 : 0;
       },
-      defaultTimeoutMs: 60 * 60 * 1000, // 60 minutes
+      supportsCustomTimeout: true,
       validators: [{ type: 'requiredField', fieldName: 'package' }],
       restartable: true,
     });

--- a/app/scripts/modules/google/src/pipeline/stages/bake/gceBakeStage.js
+++ b/app/scripts/modules/google/src/pipeline/stages/bake/gceBakeStage.js
@@ -29,7 +29,7 @@ module.exports = angular
         return stage.masterStage.context.allPreviouslyBaked || stage.masterStage.context.somePreviouslyBaked ? 1 : 0;
       },
       producesArtifacts: true,
-      defaultTimeoutMs: 60 * 60 * 1000, // 60 minutes
+      supportsCustomTimeout: true,
       validators: [
         {
           type: 'anyFieldRequired',

--- a/app/scripts/modules/google/src/pipeline/stages/resizeAsg/gceResizeAsgStage.js
+++ b/app/scripts/modules/google/src/pipeline/stages/resizeAsg/gceResizeAsgStage.js
@@ -14,7 +14,7 @@ module.exports = angular
       executionStepLabelUrl: require('./resizeAsgStepLabel.html'),
       accountExtractor: stage => [stage.context.credentials],
       configAccountExtractor: stage => [stage.credentials],
-      defaultTimeoutMs: 3 * 60 * 60 * 1000 + 21 * 60 * 1000, // 3h21m
+      supportsCustomTimeout: true,
       validators: [
         {
           type: 'targetImpedance',

--- a/app/scripts/modules/kubernetes/src/pipeline/stages/runJob/runJobStage.js
+++ b/app/scripts/modules/kubernetes/src/pipeline/stages/runJob/runJobStage.js
@@ -26,7 +26,7 @@ module.exports = angular
       templateUrl: require('./runJobStage.html'),
       executionDetailsUrl: require('./runJobExecutionDetails.html'),
       producesArtifacts: true,
-      defaultTimeoutMs: 2 * 60 * 60 * 1000, // 2 hours
+      supportsCustomTimeout: true,
       validators: [{ type: 'requiredField', fieldName: 'account' }, { type: 'requiredField', fieldName: 'namespace' }],
     });
   })

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestStage.ts
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestStage.ts
@@ -22,7 +22,7 @@ if (SETTINGS.feature.versionedProviders) {
     component: DeployManifestStageConfig,
     executionDetailsSections: [DeployStatus, ExecutionDetailsTasks, ExecutionArtifactTab],
     producesArtifacts: true,
-    defaultTimeoutMs: 30 * 60 * 1000, // 30 minutes
+    supportsCustomTimeout: true,
     validators: deployManifestValidators(),
     accountExtractor: (stage: IStage): string[] => (stage.account ? [stage.account] : []),
     configAccountExtractor: (stage: any): string[] => (stage.account ? [stage.account] : []),

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/patchManifest/patchManifestStage.ts
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/patchManifest/patchManifestStage.ts
@@ -25,7 +25,7 @@ if (SETTINGS.feature.versionedProviders) {
     component: PatchManifestStageConfig,
     executionDetailsSections: [PatchStatus, ExecutionDetailsTasks, ExecutionArtifactTab],
     producesArtifacts: true,
-    defaultTimeoutMs: 30 * 60 * 1000, // 30 minutes
+    supportsCustomTimeout: true,
     validators: manifestSelectorValidators(STAGE_NAME),
     artifactExtractor: ExpectedArtifactService.accumulateArtifacts(['manifestArtifactId', 'requiredArtifactIds']),
     artifactRemover: ArtifactReferenceService.removeArtifactFromFields(['manifestArtifactId', 'requiredArtifactIds']),

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/runJob/runJobStage.ts
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/runJob/runJobStage.ts
@@ -26,7 +26,7 @@ module(KUBERNETES_V2_RUN_JOB_STAGE, [])
       cloudProvider: 'kubernetes',
       component: KubernetesV2RunJobStageConfig,
       executionDetailsSections: [ExecutionDetailsTasks, RunJobExecutionDetails],
-      defaultTimeoutMs: 30 * 60 * 1000,
+      supportsCustomTimeout: true,
       producesArtifacts: true,
       validators: [
         {

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/traffic/disableManifest.stage.ts
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/traffic/disableManifest.stage.ts
@@ -16,7 +16,7 @@ module(KUBERNETES_DISABLE_MANIFEST_STAGE, [EXECUTION_ARTIFACT_TAB]).config(() =>
     cloudProvider: 'kubernetes',
     component: ManifestTrafficStageConfig,
     executionDetailsSections: [manifestExecutionDetails(STAGE_KEY), ExecutionDetailsTasks],
-    defaultTimeoutMs: 30 * 60 * 1000, // 30 minutes
+    supportsCustomTimeout: true,
     accountExtractor: (stage: IStage): string[] => (stage.account ? [stage.account] : []),
     configAccountExtractor: (stage: IStage): string[] => (stage.account ? [stage.account] : []),
     validators: manifestSelectorValidators(STAGE_NAME),

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/traffic/enableManifest.stage.ts
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/traffic/enableManifest.stage.ts
@@ -17,7 +17,7 @@ module(KUBERNETES_ENABLE_MANIFEST_STAGE, [EXECUTION_ARTIFACT_TAB]).config(() => 
     cloudProvider: 'kubernetes',
     component: ManifestTrafficStageConfig,
     executionDetailsSections: [manifestExecutionDetails(STAGE_KEY), ExecutionDetailsTasks],
-    defaultTimeoutMs: 30 * 60 * 1000, // 30 minutes
+    supportsCustomTimeout: true,
     accountExtractor: (stage: IStage): string[] => (stage.account ? [stage.account] : []),
     configAccountExtractor: (stage: IStage): string[] => (stage.account ? [stage.account] : []),
     validators: manifestSelectorValidators(STAGE_NAME),

--- a/app/scripts/modules/oracle/src/pipeline/stages/bake/ociBakeStage.js
+++ b/app/scripts/modules/oracle/src/pipeline/stages/bake/ociBakeStage.js
@@ -15,7 +15,7 @@ module.exports = angular
       templateUrl: require('./bakeStage.html'),
       executionDetailsUrl: require('./bakeExecutionDetails.html'),
       executionLabelTemplateUrl: require('core/pipeline/config/stages/bake/BakeExecutionLabel'),
-      defaultTimeoutMs: 60 * 60 * 1000, // 60 minutes
+      supportsCustomTimeout: true,
       validators: [
         { type: 'requiredField', fieldName: 'accountName' },
         { type: 'requiredField', fieldName: 'region' },

--- a/app/scripts/modules/titus/src/pipeline/stages/runJob/titusRunJobStage.ts
+++ b/app/scripts/modules/titus/src/pipeline/stages/runJob/titusRunJobStage.ts
@@ -14,7 +14,7 @@ Registry.pipeline.registerStage({
   executionDetailsSections: [RunJobExecutionDetails, ExecutionDetailsTasks],
   accountExtractor: (stage: IStage) => [stage.context.credentials],
   configAccountExtractor: (stage: IStage) => [stage.credentials],
-  defaultTimeoutMs: 2 * 60 * 60 * 1000, // 2 hours
+  supportsCustomTimeout: true,
   validators: [
     { type: 'requiredField', fieldName: 'cluster.iamProfile' },
     { type: 'requiredField', fieldName: 'cluster.imageId' },


### PR DESCRIPTION
## Why though?
For, well, basically forever we've had the concept of 'default stage timeouts' — the idea that by default, a stage has a maximum amount of time it will run regardless of the tasks it contains.

Turns out that for some pretty significant period of time (maybe since the last orca rewrite?) this isn't even close to true. In reality, stages have no concept of a timeout besides the what we call the 'override timeout' in the UI (`stageTimeoutMs`). _Tasks_ have timeouts, so a stage's maximum running time is actually the sum of all task timeouts in the stage. In some ways this actually makes a lot of sense — if a stage adds or removes synthetic stages/tasks due to the way it's configured (or even some external side-effect) it could theoretically require significantly more time to run.

A good example of why default timeouts are tricky is running pipelines in between steps in a Rolling Red Black strategy — how long should the parent deploy stage take by default? It certainly depends on the strategy you choose, but in the RRB case it also depends on the steps and what the pipeline being run is actually doing.

This gets really confusing for users when they're configuring things, because we _actually do_ show a default timeout for many stages in the UI. This gives people a very misleading impression about the behavior of their stages when run, and (at least at Netflix) has caused various kinds of operational pain as a result.

## Changes
This PR effectively removes the whole concept of a 'default stage timeout' in the UI, and changes the language to 'Fail stage after a specific amount of time'. This means that existing stage timeouts in configs are left totally unchanged, and the actual user flow is identical. The only difference is in how the meaning of the option is communicated.

The biggest switch (and the one that has breakage potential) is a switch in the stage config model/interface from `defaultTimeoutMs` (number) to `supportsCustomTimeout` (boolean). This means that some stages which are loaded in outside of the `deck` repo may need to change the config they register.

**Before:**
![stage-timeouts-before](https://user-images.githubusercontent.com/1850998/62150947-148aaa00-b2b4-11e9-8150-2cdb60ba076c.gif)


**After:**
![stage-timeouts-after](https://user-images.githubusercontent.com/1850998/62150970-1eaca880-b2b4-11e9-96dd-fed2f1214ed9.gif)
