### PR TITLE
Louis/modal fixes

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/templates/v2/configurePipelineTemplateModalV2.controller.ts
+++ b/app/scripts/modules/core/src/pipeline/config/templates/v2/configurePipelineTemplateModalV2.controller.ts
@@ -171,12 +171,22 @@ export class ConfigurePipelineTemplateModalV2Controller implements IController {
     return chain(this.variables || [])
       .cloneDeep()
       .map(v => {
-        if (v.type === 'object') {
-          v.value = JSON.parse(v.value);
-        } else if (v.type === 'int') {
-          return [v.name, parseInt(v.value, 10)];
-        } else if (v.type === 'float') {
-          return [v.name, parseFloat(v.value)];
+        switch (v.type) {
+          case 'boolean':
+            v.value = !!v.value;
+            break;
+
+          case 'object':
+            v.value = JSON.parse(v.value);
+            break;
+
+          case 'int':
+            v.value = parseInt(v.value, 10);
+            break;
+
+          case 'float':
+            v.value = parseFloat(v.value);
+            break;
         }
         return [v.name, v.value];
       })

--- a/app/scripts/modules/core/src/pipeline/config/templates/v2/configurePipelineTemplateModalV2.html
+++ b/app/scripts/modules/core/src/pipeline/config/templates/v2/configurePipelineTemplateModalV2.html
@@ -32,7 +32,7 @@
   <div ng-if="ctrl.state.noVariables && !ctrl.state.error" class="alert alert-info">
     <p>This template has no variables to configure.</p>
   </div>
-  <div ng-if="!ctrl.state.error" class="alert alert-info">
+  <div ng-if="!ctrl.state.error && !ctrl.state.loadingError" class="alert alert-info">
     <strong>Inherit the following configuration from the template</strong>
     <p><input type="checkbox" ng-model="ctrl.state.inheritTemplateNotifications" /> Notifications</p>
     <p><input type="checkbox" ng-model="ctrl.state.inheritTemplateParameters" /> Parameters</p>


### PR DESCRIPTION
This fixes the issue where inheritance toggles incorrectly display in the modal when a pipeline template fails to load.

![image](https://user-images.githubusercontent.com/2623242/62161196-9a721980-b2e3-11e9-8a73-925b17e4dd11.png)

And this also fixes an issue where leaving the boolean variable checkbox unchecked in the modal would not save correctly. Now unchecked will save as off.

![image](https://user-images.githubusercontent.com/2623242/62161372-ff2d7400-b2e3-11e9-8518-049a154b0768.png)


https://github.com/spinnaker/spinnaker/issues/4698