### PR TITLE
feat(cloudformation): Make the template editor more lenient

### DIFF
--- a/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/cloudFormationTemplateEntry.component.ts
+++ b/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/cloudFormationTemplateEntry.component.ts
@@ -1,4 +1,5 @@
 import { IComponentOptions, IController, IScope, module } from 'angular';
+import { yamlDocumentsToString } from '@spinnaker/core';
 
 class CloudFormationTemplateController implements IController {
   public command: any;
@@ -10,12 +11,16 @@ class CloudFormationTemplateController implements IController {
   }
 
   public $onInit = (): void => {
-    this.rawTemplateBody = JSON.stringify(this.command.templateBody, null, 2);
+    if (typeof this.command.templateBody === 'string') {
+      this.rawTemplateBody = this.command.templateBody;
+    } else {
+      this.rawTemplateBody = yamlDocumentsToString(this.command.templateBody);
+    }
   };
 
   public handleChange = (rawTemplateBody: string, templateBody: any): void => {
-    this.command.templateBody = templateBody;
-    this.templateBody = templateBody;
+    this.command.templateBody = templateBody || rawTemplateBody;
+    this.templateBody = templateBody || rawTemplateBody;
     this.rawTemplateBody = rawTemplateBody;
     this.$scope.$applyAsync();
   };
@@ -26,10 +31,10 @@ class CloudFormationTemplateEntryComponent implements IComponentOptions {
   public controller = CloudFormationTemplateController;
   public controllerAs = 'ctrl';
   public template = `
-    <json-editor
+    <yaml-editor
       value="ctrl.rawTemplateBody"
       on-change="ctrl.handleChange"
-    ></json-editor>`;
+    ></yaml-editor>`;
 }
 
 export const CLOUDFORMATION_TEMPLATE_ENTRY = 'spinnaker.amazon.cloudformation.entry.component';


### PR DESCRIPTION
When paired with the changes in https://github.com/spinnaker/orca/pull/3024 and https://github.com/spinnaker/clouddriver/pull/3849, this makes it possible to use Yaml instead of Json in the editor, and it will also accept CloudFormation specific functions like `!Ref` and `!Join`. Since Json is a subset of Yaml, Json will still be accepted and parsed correctly.

Cloudformation specific YAML:
![image](https://user-images.githubusercontent.com/155558/62278486-74b25500-b448-11e9-8524-3e5e70a6473d.png)

This will be parsed as a string because of the `!Join`:
![image](https://user-images.githubusercontent.com/155558/62278819-1fc30e80-b449-11e9-9b58-7e0097b5cd76.png)

"Valid" Json and Yaml will be parsed into a map/list as before.
![image](https://user-images.githubusercontent.com/155558/62278784-0b7f1180-b449-11e9-82b2-e36804c0676b.png)
