### PR TITLE
fix(cf): Deploy stage config template import missing routes

### DIFF
--- a/app/scripts/modules/cloudfoundry/src/serverGroup/configure/serverGroupCommandBuilder.service.cf.ts
+++ b/app/scripts/modules/cloudfoundry/src/serverGroup/configure/serverGroupCommandBuilder.service.cf.ts
@@ -66,7 +66,7 @@ export class CloudFoundryServerGroupCommandBuilder {
             ? serverGroup.droplet.buildpacks.map(item => item.name)
             : [],
         instances: serverGroup.instances ? serverGroup.instances.length : 1,
-        routes: serverGroup.loadBalancers,
+        routes: serverGroup.loadBalancers || [],
         environment: CloudFoundryServerGroupCommandBuilder.envVarsFromObject(serverGroup.env),
         services: (serverGroup.serviceInstances || []).map(serviceInstance => serviceInstance.name),
         healthCheckType: 'port',


### PR DESCRIPTION
When the imported server group had no routes, the routes property would be undefined where it should have been an empty array. spinnaker/spinnaker#4711