### PR TITLE
feat(executions): Allow rerun on active executions

### DIFF
--- a/app/scripts/modules/core/src/application/config/applicationAttributes.directive.html
+++ b/app/scripts/modules/core/src/application/config/applicationAttributes.directive.html
@@ -33,8 +33,13 @@
   </dd>
   <dt>Instance Port</dt>
   <dd>{{vm.application.attributes.instancePort}}</dd>
-  <dt ng-if="vm.application.attributes.enableRestartRunningExecutions">Pipeline Behavior</dt>
+  <dt
+    ng-if="vm.application.attributes.enableRestartRunningExecutions || vm.application.attributes.enableRerunActiveExecutions"
+  >
+    Pipeline Behavior
+  </dt>
   <dd ng-if="vm.application.attributes.enableRestartRunningExecutions">Allows restarting running pipelines</dd>
+  <dd ng-if="vm.application.attributes.enableRerunActiveExecutions">Allows rerunning active executions</dd>
   <dt ng-if="vm.application.attributes.legacyUdf">User Data Format</dt>
   <dd ng-if="vm.application.attributes.legacyUdf">This application requires legacy user data format.</dd>
   <render-if-feature feature="fiatEnabled" ng-if="vm.permissions">

--- a/app/scripts/modules/core/src/application/config/applicationAttributes.directive.html
+++ b/app/scripts/modules/core/src/application/config/applicationAttributes.directive.html
@@ -39,7 +39,7 @@
     Pipeline Behavior
   </dt>
   <dd ng-if="vm.application.attributes.enableRestartRunningExecutions">Allows restarting running pipelines</dd>
-  <dd ng-if="vm.application.attributes.enableRerunActiveExecutions">Allows rerunning active executions</dd>
+  <dd ng-if="vm.application.attributes.enableRerunActiveExecutions">Allows re-running active executions</dd>
   <dt ng-if="vm.application.attributes.legacyUdf">User Data Format</dt>
   <dd ng-if="vm.application.attributes.legacyUdf">This application requires legacy user data format.</dd>
   <render-if-feature feature="fiatEnabled" ng-if="vm.permissions">

--- a/app/scripts/modules/core/src/application/modal/editApplication.html
+++ b/app/scripts/modules/core/src/application/modal/editApplication.html
@@ -211,6 +211,11 @@
             Enable restarting running pipelines
           </label>
           <help-field key="application.enableRestartRunningExecutions"></help-field>
+          <label>
+            <input type="checkbox" ng-model="editApp.applicationAttributes.enableRerunActiveExecutions" />
+            Enable re-run button on active pipelines
+          </label>
+          <help-field key="application.enableRerunActiveExecutions"></help-field>
         </div>
       </div>
 

--- a/app/scripts/modules/core/src/application/modal/newapplication.html
+++ b/app/scripts/modules/core/src/application/modal/newapplication.html
@@ -230,6 +230,11 @@
             Enable restarting running pipelines
           </label>
           <help-field key="application.enableRestartRunningExecutions"></help-field>
+          <label>
+            <input type="checkbox" ng-model="editApp.applicationAttributes.enableRerunActiveExecutions" />
+            Enable re-run button on active pipelines
+          </label>
+          <help-field key="application.enableRerunActiveExecutions"></help-field>
         </div>
       </div>
 

--- a/app/scripts/modules/core/src/application/modal/upsertApplication.help.ts
+++ b/app/scripts/modules/core/src/application/modal/upsertApplication.help.ts
@@ -19,6 +19,9 @@ const helpContents: { [key: string]: string } = {
   'application.enableRestartRunningExecutions': `
         When this option is enabled, users will be able to restart pipeline stages while a pipeline is still running.
         This behavior can have varying unexpected results and is <b>not recommended</b> to enable.`,
+  'application.enableRerunActiveExecutions': `
+        When this option is enabled, the re-run option also appears on active executions. This is usually not needed
+        but may sometimes be useful for submitting multiple executions with identical parameters.`,
   'application.instance.port': `
      <p>This field is only used to generate links within Spinnaker to a running instance when viewing an
      instance's details.</p> The instance port can be used or overridden for specific links configured for your

--- a/app/scripts/modules/core/src/pipeline/executions/execution/Execution.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/execution/Execution.tsx
@@ -399,21 +399,19 @@ export class Execution extends React.PureComponent<IExecutionProps, IExecutionSt
                 </button>
               </Tooltip>
             )}
+            {(!execution.isActive || application.attributes.enableRerunActiveExecutions) && this.props.onRerun && (
+              <Tooltip value="Re-run execution with same parameters">
+                <button className="link" onClick={this.handleRerunClick}>
+                  <i className="fa fa-redo" />
+                </button>
+              </Tooltip>
+            )}
             {!execution.isActive && (
-              <span>
-                {this.props.onRerun && (
-                  <Tooltip value="Re-run execution with same parameters">
-                    <button className="link" onClick={this.handleRerunClick}>
-                      <i className="fa fa-redo" />
-                    </button>
-                  </Tooltip>
-                )}
-                <Tooltip value="Delete execution">
-                  <button className="link" onClick={this.handleDeleteClick}>
-                    <span className="glyphicon glyphicon-trash" />
-                  </button>
-                </Tooltip>
-              </span>
+              <Tooltip value="Delete execution">
+                <button className="link" onClick={this.handleDeleteClick}>
+                  <span className="glyphicon glyphicon-trash" />
+                </button>
+              </Tooltip>
             )}
             {execution.isActive && (
               <Tooltip value={cancelHelpText}>


### PR DESCRIPTION
Felt like a weird ask but the use-case actually behind this is users just want to resubmit a new execution with the same parameters as an existing one _regardless of whether the existing one is active or not_.

Most of the time this is not necessary and we wouldn't want to globally add clutter by showing the rerun button even on active executions so hiding it behind an application attribute seemed like a good compromise.