### PR TITLE
fix(executions): Fix time grouping with never started executions

### DIFF
--- a/app/scripts/modules/core/src/pipeline/filter/executionFilter.service.ts
+++ b/app/scripts/modules/core/src/pipeline/filter/executionFilter.service.ts
@@ -328,7 +328,10 @@ export class ExecutionFilterService {
 
   public static executionGroupSorter(a: IExecutionGroup, b: IExecutionGroup): number {
     if (ExecutionState.filterModel.asFilterModel.sortFilter.groupBy === 'timeBoundary') {
-      return b.executions[0].startTime - a.executions[0].startTime;
+      return (
+        (b.executions[0].startTime || b.executions[0].buildTime) -
+        (a.executions[0].startTime || a.executions[0].buildTime)
+      );
     }
     if (a.config && b.config) {
       if (a.config.strategy === b.config.strategy) {


### PR DESCRIPTION
Executions that never started wrecked havoc on time boundary sorting because we didn't use `buildTime` as a fallback and only sorted by `startTime`:

![greatscott](https://user-images.githubusercontent.com/1633736/62403319-42d0e980-b541-11e9-946c-c5ba28fd7116.png)


No more! With this, we can safely go 88 mph again.