### PR TITLE
feat(core/presentation): Add refresh() api to useLatestPromise react hook

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/triggers/RunAsUser.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/RunAsUser.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react';
 
-import { IFormInputProps, ReactSelectInput } from 'core/presentation';
-import { useLatestPromise } from 'core/presentation/forms/useLatestPromise';
+import { IFormInputProps, ReactSelectInput, useLatestPromise } from 'core/presentation';
 import { ServiceAccountReader } from 'core/serviceAccount';
 
 export function RunAsUserInput(props: IFormInputProps) {
-  const [serviceAccounts, status] = useLatestPromise(() => ServiceAccountReader.getServiceAccounts(), []);
+  const { result: serviceAccounts, status } = useLatestPromise(() => ServiceAccountReader.getServiceAccounts(), []);
   const isLoading = status === 'PENDING';
 
   return (

--- a/app/scripts/modules/core/src/presentation/forms/FormField.tsx
+++ b/app/scripts/modules/core/src/presentation/forms/FormField.tsx
@@ -3,9 +3,9 @@ import { isNil } from 'lodash';
 import { IPromise } from 'angular';
 import { $q } from 'ngimport';
 
-import { noop } from '../../utils';
+import { noop } from 'core/utils';
 import { LayoutContext } from './layouts';
-import { useLatestPromise } from './useLatestPromise';
+import { useLatestPromise } from '../hooks';
 import { createFieldValidator } from './FormikFormField';
 import { renderContent } from './fields/renderContent';
 import { IValidator, IValidatorResultRaw } from './validation';
@@ -55,7 +55,7 @@ export function FormField(props: IFormFieldProps) {
     [label, required, validate],
   );
 
-  const [errorMessage] = useLatestPromise(
+  const { result: errorMessage } = useLatestPromise(
     // TODO: remove the following cast when we remove async validation from our API
     () => $q.resolve((fieldValidator(value) as any) as IPromise<IValidatorResultRaw>),
     [fieldValidator, value],

--- a/app/scripts/modules/core/src/presentation/hooks/index.ts
+++ b/app/scripts/modules/core/src/presentation/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useLatestPromise';

--- a/app/scripts/modules/core/src/presentation/index.ts
+++ b/app/scripts/modules/core/src/presentation/index.ts
@@ -14,6 +14,7 @@ export * from './WatchValue';
 export * from './collapsibleSection/CollapsibleSection';
 export * from './details/Details';
 export * from './forms';
+export * from './hooks';
 export * from './robotToHumanFilter/robotToHuman.filter';
 export * from './sortToggle';
 export * from './navigation';


### PR DESCRIPTION
This PR does two things to the `useLatestPromise` react hook:

- Adds `refresh()` api

```js
const fetchStuff = useLatestPromise(() => fetch('http://stuff.com').then(res => res.json())), []);

return (
  <>
    <pre>{JSON.stringify(fetchStuff.result, null, 2)}</pre>
    <button onClick={fetchStuff.refresh()}>Refresh</button>
  </>
```

- Changes the return value from an Array of tuples to an object with properties

before: 
```js
const [thingData, status, error, requestId] = useLatestPromise(() => getThings(), [])
```

after:
```js
const { result, status, error, requestId } = useLatestPromise(() => getThings(), [])
```
