### PR TITLE
feat(tasks): Adding redirect for task by id without application

### DIFF
--- a/app/scripts/modules/core/src/domain/ITask.ts
+++ b/app/scripts/modules/core/src/domain/ITask.ts
@@ -3,6 +3,7 @@ import { IOrchestratedItem } from './IOrchestratedItem';
 import { ITaskStep } from './ITaskStep';
 
 export interface ITask extends IOrchestratedItem {
+  application: string;
   id: string;
   name?: string;
   steps?: ITaskStep[];

--- a/app/scripts/modules/core/src/notfound/NotFound.tsx
+++ b/app/scripts/modules/core/src/notfound/NotFound.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+
+interface INotFoundProps {
+  type: string;
+  entityId: string;
+}
+
+export function NotFound(props: INotFoundProps) {
+  return (
+    <div className="application">
+      <div>
+        <h2 className="text-center">{props.type} Not Found</h2>
+        <p className="text-center" style={{ marginBottom: '20px' }}>
+          Please check your URL - we can't find any data for <em>{props.entityId}</em>.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/app/scripts/modules/core/src/pipeline/pipeline.states.ts
+++ b/app/scripts/modules/core/src/pipeline/pipeline.states.ts
@@ -110,8 +110,7 @@ module(PIPELINE_STATES, [APPLICATION_STATE_PROVIDER]).config([
           return undefined;
         }
 
-        return Promise.resolve()
-          .then(() => executionService.getExecution(executionId))
+        return Promise.resolve(executionService.getExecution(executionId))
           .then(execution =>
             transition.router.stateService.target(
               'home.applications.application.pipelines.executionDetails.execution',

--- a/app/scripts/modules/core/src/task/TaskNotFound.tsx
+++ b/app/scripts/modules/core/src/task/TaskNotFound.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { ReactInjector } from 'core/reactShims';
 import { NotFound } from 'core/notfound/NotFound';
 
-export function ExecutionNotFound() {
+export function TaskNotFound() {
   const { params } = ReactInjector.$state;
-  return <NotFound type="Execution" entityId={params.executionId} />;
+  return <NotFound type="Task" entityId={params.taskId} />;
 }

--- a/app/scripts/modules/core/src/task/task.states.ts
+++ b/app/scripts/modules/core/src/task/task.states.ts
@@ -1,12 +1,15 @@
 import { module } from 'angular';
 
-import { INestedState } from 'core/navigation/state.provider';
+import { INestedState, StateConfigProvider } from 'core/navigation/state.provider';
 import { APPLICATION_STATE_PROVIDER, ApplicationStateProvider } from 'core/application/application.state.provider';
+import { TaskReader } from './task.read.service';
+import { TaskNotFound } from './TaskNotFound';
 
 export const TASK_STATES = 'spinnaker.core.task.states';
 module(TASK_STATES, [APPLICATION_STATE_PROVIDER]).config([
   'applicationStateProvider',
-  (applicationStateProvider: ApplicationStateProvider) => {
+  'stateConfigProvider',
+  (applicationStateProvider: ApplicationStateProvider, stateConfigProvider: StateConfigProvider) => {
     const taskDetails: INestedState = {
       name: 'taskDetails',
       url: '/:taskId',
@@ -40,6 +43,36 @@ module(TASK_STATES, [APPLICATION_STATE_PROVIDER]).config([
       children: [taskDetails],
     };
 
+    const taskLookup: INestedState = {
+      name: 'taskLookup',
+      url: '/tasks/:taskId',
+      params: {
+        taskId: { dynamic: true },
+      },
+      redirectTo: transition => {
+        const { taskId } = transition.params();
+
+        if (!taskId) {
+          return undefined;
+        }
+
+        return Promise.resolve()
+          .then(() => TaskReader.getTask(taskId))
+          .then(task =>
+            transition.router.stateService.target('home.applications.application.tasks.taskDetails', {
+              application: task.application,
+              taskId,
+            }),
+          )
+          .catch(() => {});
+      },
+      views: {
+        'main@': { component: TaskNotFound, $type: 'react' },
+      },
+    };
+
     applicationStateProvider.addChildState(tasks);
+
+    stateConfigProvider.addToRootState(taskLookup);
   },
 ]);

--- a/app/scripts/modules/core/src/task/task.states.ts
+++ b/app/scripts/modules/core/src/task/task.states.ts
@@ -56,8 +56,7 @@ module(TASK_STATES, [APPLICATION_STATE_PROVIDER]).config([
           return undefined;
         }
 
-        return Promise.resolve()
-          .then(() => TaskReader.getTask(taskId))
+        return Promise.resolve(TaskReader.getTask(taskId))
           .then(task =>
             transition.router.stateService.target('home.applications.application.tasks.taskDetails', {
               application: task.application,


### PR DESCRIPTION
Similar to #7076 

Redirects from `/#/tasks/8675309` to `/#/applications/sandgnat/tasks/8675309`