### PR TITLE
feat(provider/k8s): support artifacts in run job

### DIFF
--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/runJob/RunJobExecutionDetails.tsx
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/runJob/RunJobExecutionDetails.tsx
@@ -8,6 +8,7 @@ import {
   JobStageExecutionLogs,
   DefaultPodNameProvider,
   IJobOwnedPodStatus,
+  StageFailureMessage,
 } from '@spinnaker/core';
 
 export class RunJobExecutionDetails extends React.Component<IExecutionDetailsSectionProps> {
@@ -31,6 +32,7 @@ export class RunJobExecutionDetails extends React.Component<IExecutionDetailsSec
 
     return (
       <ExecutionDetailsSection name={name} current={current}>
+        <StageFailureMessage stage={stage} message={stage.failureMessage} />
         <div className="row">
           <div className="col-md-9">
             <dl className="dl-narrow dl-horizontal">

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/runJob/runJobStage.ts
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/runJob/runJobStage.ts
@@ -25,7 +25,7 @@ module(KUBERNETES_V2_RUN_JOB_STAGE, [])
       addAliasToConfig: true,
       cloudProvider: 'kubernetes',
       component: KubernetesV2RunJobStageConfig,
-      executionDetailsSections: [ExecutionDetailsTasks, RunJobExecutionDetails],
+      executionDetailsSections: [RunJobExecutionDetails, ExecutionDetailsTasks],
       supportsCustomTimeout: true,
       producesArtifacts: true,
       validators: [


### PR DESCRIPTION
adds support for artifacts in the v2 run job stage. very similar to
deploy manifest.