### PR TITLE
feat(helm): allow manual execution overrides for helm charts

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/ManualExecutionBakeManifest.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/ManualExecutionBakeManifest.tsx
@@ -1,0 +1,86 @@
+import * as React from 'react';
+
+import { CheckboxInput } from 'core/presentation';
+import { ITriggerTemplateComponentProps } from 'core/pipeline/manualExecution/TriggerTemplate';
+import { IArtifact, IExpectedArtifact } from 'core/domain';
+import { HelmMatch } from 'core/pipeline/config/triggers/artifacts/helm/HelmArtifactEditor';
+import { BAKE_MANIFEST_STAGE_KEY } from 'core/pipeline/config/stages/bakeManifest/bakeManifestStage';
+
+const HelmEditor = HelmMatch.editCmp;
+
+export function ManualExecutionBakeManifest(props: ITriggerTemplateComponentProps) {
+  const [overrideArtifact, setOverrideArtifact] = React.useState(false);
+
+  const updateHelmArtifact = (artifact: IArtifact) => {
+    const updatedArtifacts = (props.command.extraFields.artifacts || []).filter(
+      (a: IArtifact) => a.type !== HelmMatch.type,
+    );
+    updatedArtifacts.push(artifact);
+    props.updateCommand('extraFields.artifacts', updatedArtifacts);
+  };
+
+  const removeHelmArtifact = () => {
+    const updatedArtifacts = (props.command.extraFields.artifacts || []).filter(
+      (a: IArtifact) => a.type !== HelmMatch.type,
+    );
+    props.updateCommand('extraFields.artifacts', updatedArtifacts);
+  };
+
+  /*
+  Only allow manual override of a helm chart artifact when there is exactly one Helm
+  Bake (Manifest) stage and exactly one artifact of type `helm/chart`.
+   */
+  const bakeManifestStages = props.command.pipeline.stages.filter(stage => stage.type === BAKE_MANIFEST_STAGE_KEY);
+  if (bakeManifestStages.length !== 1 || bakeManifestStages[0].templateRenderer !== 'HELM2') {
+    return null;
+  }
+  const expectedArtifacts = props.command.pipeline.expectedArtifacts || [];
+  const expectedHelmArtifacts = expectedArtifacts.filter(
+    (artifact: IExpectedArtifact) => artifact.matchArtifact.type === HelmMatch.type,
+  );
+  if (expectedHelmArtifacts.length !== 1) {
+    return null;
+  }
+
+  const helmArtifact = (props.command.extraFields.artifacts || []).find((a: IArtifact) => a.type === HelmMatch.type);
+  const defaultArtifact: IArtifact = {
+    ...expectedHelmArtifacts[0].matchArtifact,
+    version: null,
+  };
+
+  React.useEffect(() => {
+    if (overrideArtifact === false) {
+      removeHelmArtifact();
+    } else {
+      updateHelmArtifact(defaultArtifact);
+    }
+  }, [overrideArtifact]);
+
+  return (
+    <>
+      <div className="form-group">
+        <div className="sm-label-right col-md-4">Helm override</div>
+        <div className="col-md-8">
+          <CheckboxInput
+            checked={overrideArtifact}
+            onChange={(e: any) => setOverrideArtifact(e.target.checked)}
+            text="Override Helm chart artifact"
+          />
+        </div>
+      </div>
+      {overrideArtifact && (
+        <div className="form-group">
+          <div className="col-md-2" />
+          <div className="col-md-10">
+            <HelmEditor
+              account={{ name: expectedHelmArtifacts[0].matchArtifact.artifactAccount, types: [HelmMatch.type] }}
+              artifact={helmArtifact || defaultArtifact}
+              pipeline={props.command.pipeline}
+              onChange={updateHelmArtifact}
+            />
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/bakeManifestStage.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/bakeManifestStage.ts
@@ -8,12 +8,14 @@ import { SETTINGS } from 'core/config';
 
 import { BakeManifestConfig } from './BakeManifestConfig';
 import { BakeManifestDetailsTab } from './BakeManifestDetailsTab';
+import { ManualExecutionBakeManifest } from './ManualExecutionBakeManifest';
 
+export const BAKE_MANIFEST_STAGE_KEY = 'bakeManifest';
 if (SETTINGS.feature.versionedProviders) {
   Registry.pipeline.registerStage({
     label: 'Bake (Manifest)',
     description: 'Bake a manifest (or multi-doc manifest set) using a template renderer such as Helm.',
-    key: 'bakeManifest',
+    key: BAKE_MANIFEST_STAGE_KEY,
     component: BakeManifestConfig,
     producesArtifacts: true,
     cloudProvider: 'kubernetes',
@@ -28,5 +30,6 @@ if (SETTINGS.feature.versionedProviders) {
       stage.inputArtifacts = get(stage, 'inputArtifacts', []).filter(a => !artifactMatches(a));
     },
     validators: [{ type: 'requiredField', fieldName: 'outputName', fieldLabel: 'Name' }],
+    manualExecutionComponent: ManualExecutionBakeManifest,
   });
 }


### PR DESCRIPTION
Closes https://github.com/spinnaker/spinnaker/issues/4628

Allows helm chart artifact names and version to be overridden during manual execution under the following conditions:
- The pipeline has exactly one Bake (Manifest) stage
- The pipeline has exactly one expected artifact of type `helm/chart`

The specific type of workflow this unblocks is users setting either the helm chart Match Artifact name and/or version as a regular expression (for example, `.*` to match all versions) who want to manually test and select a certain name and/or version at pipeline run time. I only tested this with artifacts rewrite _off_ but since it's supposed to be backwards compatible this should work with it on as well.

![20c65c8f-b13d-4e3b-9efe-1137529c452b](https://user-images.githubusercontent.com/15936279/62728770-984a4200-b9ea-11e9-8908-76347fa7d68b.gif)
