### PR TITLE
refactor(core/presentation): in renderContent helper, always render Component as JSX, not as a bare function call.

### DIFF
--- a/app/scripts/modules/core/src/presentation/forms/fields/renderContent.tsx
+++ b/app/scripts/modules/core/src/presentation/forms/fields/renderContent.tsx
@@ -6,19 +6,13 @@ import * as React from 'react';
  * Supports:
  *
  * - React Class
- * - Arrow Function
- * - Render Function
+ * - Functional component
  * - JSX.Element or string
  */
 export function renderContent<T>(Content: string | JSX.Element | React.ComponentType<T>, props: T): React.ReactNode {
-  const prototype = typeof Content === 'function' && Content.prototype;
-
-  if (prototype && (prototype.isReactComponent || typeof prototype.render === 'function')) {
-    const ClassComponent = Content as React.ComponentType<T>;
-    return <ClassComponent {...props} />;
-  } else if (typeof Content === 'function') {
-    const arrowOrSFC = Content as (props: T) => JSX.Element;
-    return arrowOrSFC(props);
+  if (typeof Content === 'function') {
+    const Component = Content as React.ComponentType<T>;
+    return <Component {...props} />;
   } else {
     return Content;
   }


### PR DESCRIPTION
This helper function is used in `FormField` and `FormikFormField` to render the render props (`input`, `label`, etc).  If a functional component is provided, it should be rendered as JSX (`<Component {...props} />`), not simply as a function call (`Component(props)`).  This is especially apparent as we have now introduced components with react hooks into the codebase.

I tried to recall why this code originally differentiated between Class components and Functional components in #5844.  My current assumption is that they should both be rendered in the same way, using JSX.  I believe this change will not cause any regressions in behavior, but we should keep a close eye on newly reported problems in deck forms.