### PR TITLE
chore(build): Update cloudbuild.yaml file

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,10 +4,10 @@ steps:
     entrypoint: 'bash'
     args: ['-c', './gradlew build -PskipTests']
   - name: gcr.io/cloud-builders/docker
-    args: ['build', '-t', 'gcr.io/$PROJECT_ID/$REPO_NAME:$TAG_NAME', '-f', 'Dockerfile.slim', '.']
+    args: ['build', '-t', 'gcr.io/$PROJECT_ID/deck:$TAG_NAME', '-f', 'Dockerfile.slim', '.']
     env: ['GRADLE_USER_HOME=/gradle_cache/.gradle']
 images:
-  - gcr.io/$PROJECT_ID/$REPO_NAME:$TAG_NAME
+  - gcr.io/$PROJECT_ID/deck:$TAG_NAME
 timeout: 3600s
 options:
   machineType: N1_HIGHCPU_8


### PR DESCRIPTION
Remove the $REPO_NAME variable from the cloudbuild.yaml file; this is being used to decide the name of the image to push which will not always correspond to the image name. In particular, if we start publishing both alpine and ubuntu images we'll want the image name to have a suffix reflecting that.