### PR TITLE
fix(core/pipeline): Refresh jenkins jobs component when manual execution trigger is changed

### DIFF
--- a/app/scripts/modules/core/src/pipeline/manualExecution/Triggers.tsx
+++ b/app/scripts/modules/core/src/pipeline/manualExecution/Triggers.tsx
@@ -89,7 +89,12 @@ export class Triggers extends React.Component<ITriggersProps> {
 
         {triggerComponent && (
           <div className={'trigger-template'}>
-            <TriggerTemplate updateCommand={this.updateCommand} component={triggerComponent} command={formik.values} />
+            <TriggerTemplate
+              key={formik.values.trigger.description}
+              updateCommand={this.updateCommand}
+              component={triggerComponent}
+              command={formik.values}
+            />
           </div>
         )}
       </div>


### PR DESCRIPTION
In Manual Execution dialog, we have a dropdown where a user selects the desired trigger.
When they change the selected trigger, we now force the trigger's custom component to remount.
This is a kludge and some day we should remove it.
Instead, all the trigger type components should properly respond to changes in the props passed to it.
