### PR TITLE
fix(artifacts): fix artifact account default logic

### DIFF
--- a/app/scripts/modules/core/src/artifact/react/ArtifactEditor.tsx
+++ b/app/scripts/modules/core/src/artifact/react/ArtifactEditor.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { cloneDeep } from 'lodash';
+import { cloneDeep, head } from 'lodash';
 import { IArtifactAccount } from 'core/account';
 import { ArtifactAccountSelector } from 'core/artifact';
 import { IArtifact, IPipeline } from 'core/domain';
@@ -35,7 +35,9 @@ export class ArtifactEditor extends React.Component<IArtifactEditorProps> {
   private defaultArtifactAccountIfNecessary(): void {
     const { artifact, artifactAccounts } = this.props;
     if (!artifact.artifactAccount && artifactAccounts.length > 0) {
-      this.onArtifactAccountChanged(artifactAccounts[0]);
+      this.onArtifactAccountChanged(
+        head(artifactAccounts.filter(a => a.types.includes(artifact.type))) || head(artifactAccounts),
+      );
     }
   }
 

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/ExpectedArtifact.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/ExpectedArtifact.tsx
@@ -44,14 +44,14 @@ export function ExpectedArtifact(props: IExpectedArtifactProps) {
               Match against
               <HelpField id="pipeline.config.expectedArtifact.matchArtifact" />
             </div>
-            <div className="col-md-1 col-md-offset-8">
+            <div className="col-md-2 col-md-offset-7">
               <Tooltip value="Remove expected artifact">
                 <button
                   className="btn btn-sm btn-default"
                   onClick={() => removeExpectedArtifact(pipeline, expectedArtifact)}
                 >
                   <span className="glyphicon glyphicon-trash" />
-                  <span className="visible-xl-inline">Remove artifact</span>
+                  <span>Remove artifact</span>
                 </button>
               </Tooltip>
             </div>


### PR DESCRIPTION
Fixes the logic to default an artifact account to the correct type. The previous logic always set the first one from the list.