### PR TITLE
refactor(hooks): Pulling out useData

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/triggers/concourse/ConcourseTrigger.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/concourse/ConcourseTrigger.tsx
@@ -34,14 +34,15 @@ export function ConcourseTrigger({ formik, trigger }: IConcourseTriggerConfigPro
     formik.setFieldValue('jobName', jobName);
   };
 
-  const fetchMasters = useData(() => IgorService.listMasters(BuildServiceType.Concourse), []);
-  const fetchTeams = useData(() => ConcourseService.listTeamsForMaster(master), [master]);
-  const fetchPipelines = useData(() => ConcourseService.listPipelinesForTeam(master, team), [master, team]);
+  const fetchMasters = useData(() => IgorService.listMasters(BuildServiceType.Concourse), [], []);
+  const fetchTeams = useData(() => ConcourseService.listTeamsForMaster(master), [], [master]);
+  const fetchPipelines = useData(() => ConcourseService.listPipelinesForTeam(master, team), [], [master, team]);
   const fetchJobs = useData(
     () =>
       ConcourseService.listJobsForPipeline(master, team, pipeline).then(jobs =>
         jobs.map(job => `${team}/${pipeline}/${job}`),
       ),
+    [],
     [master, team, pipeline],
   );
 

--- a/app/scripts/modules/core/src/pipeline/config/triggers/concourse/ConcourseTrigger.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/concourse/ConcourseTrigger.tsx
@@ -1,12 +1,10 @@
 import * as React from 'react';
-import { IPromise } from 'angular';
 import { FormikProps } from 'formik';
-import { $q } from 'ngimport';
 import { Option } from 'react-select';
 
 import { BuildServiceType, IgorService } from 'core/ci';
 import { IConcourseTrigger } from 'core/domain';
-import { FormikFormField, ReactSelectInput, useLatestPromise } from 'core/presentation';
+import { FormikFormField, ReactSelectInput, useData } from 'core/presentation';
 
 import { ConcourseService } from './concourse.service';
 
@@ -35,14 +33,6 @@ export function ConcourseTrigger({ formik, trigger }: IConcourseTriggerConfigPro
     const jobName = job && job.split('/').pop();
     formik.setFieldValue('jobName', jobName);
   };
-
-  // Fetches data when anything in the dependencies list changes
-  // Returns an empty array if any dependencies are falsey
-  function useData<T>(callback: () => IPromise<T>, deps: any[]) {
-    const anyDepsMissing = deps.some(dep => !dep);
-    const defaultValueCallback = () => $q.resolve(([] as any) as T);
-    return useLatestPromise(anyDepsMissing ? defaultValueCallback : callback, deps);
-  }
 
   const fetchMasters = useData(() => IgorService.listMasters(BuildServiceType.Concourse), []);
   const fetchTeams = useData(() => ConcourseService.listTeamsForMaster(master), [master]);

--- a/app/scripts/modules/core/src/presentation/hooks/index.ts
+++ b/app/scripts/modules/core/src/presentation/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from './useLatestPromise';
+export * from './useData';

--- a/app/scripts/modules/core/src/presentation/hooks/useData.ts
+++ b/app/scripts/modules/core/src/presentation/hooks/useData.ts
@@ -11,7 +11,7 @@ import { useLatestPromise, IUseLatestPromiseResult } from './useLatestPromise';
  * This behavior is similar to RxJS switchMap.
  *
  * @param callback the callback to be invoked whenever dependencies change
- * @param defaultValue the default value to return when any dependencies are falsey
+ * @param defaultValue the default value to return when any dependencies are null or undefined
  * @param deps array of dependencies, which (when changed) cause the callback to be invoked again
  * @returns an object with the result and current status of the promise
  */

--- a/app/scripts/modules/core/src/presentation/hooks/useData.ts
+++ b/app/scripts/modules/core/src/presentation/hooks/useData.ts
@@ -6,7 +6,7 @@ import { useLatestPromise, IUseLatestPromiseResult } from './useLatestPromise';
 
 /**
  * A react hook which invokes a promise returning callback whenever any of its dependencies changes.
- * Returns the provided default value whenever any dependency is falsey
+ * Returns the provided default value whenever any dependency is null or undefined
  *
  * This can be useful when fetching data based on a users keyboard input, for example.
  * This behavior is similar to RxJS switchMap.

--- a/app/scripts/modules/core/src/presentation/hooks/useData.ts
+++ b/app/scripts/modules/core/src/presentation/hooks/useData.ts
@@ -15,7 +15,7 @@ import { useLatestPromise, IUseLatestPromiseResult } from './useLatestPromise';
  * @param deps array of dependencies, which (when changed) cause the callback to be invoked again
  * @returns an object with the result and current status of the promise
  */
-function useData<T>(callback: () => IPromise<T>, defaultValue: T, deps: any[]): IUseLatestPromiseResult<T> {
+export function useData<T>(callback: () => IPromise<T>, defaultValue: T, deps: any[]): IUseLatestPromiseResult<T> {
   const anyDepsMissing = deps.some(dep => !dep);
   const defaultValueCallback = () => $q.resolve(defaultValue);
   return useLatestPromise(anyDepsMissing ? defaultValueCallback : callback, deps);

--- a/app/scripts/modules/core/src/presentation/hooks/useData.ts
+++ b/app/scripts/modules/core/src/presentation/hooks/useData.ts
@@ -1,5 +1,6 @@
 import { IPromise } from 'angular';
 import { $q } from 'ngimport';
+import { isNil } from 'lodash';
 
 import { useLatestPromise, IUseLatestPromiseResult } from './useLatestPromise';
 

--- a/app/scripts/modules/core/src/presentation/hooks/useData.ts
+++ b/app/scripts/modules/core/src/presentation/hooks/useData.ts
@@ -1,0 +1,22 @@
+import { IPromise } from 'angular';
+import { $q } from 'ngimport';
+
+import { useLatestPromise, IUseLatestPromiseResult } from './useLatestPromise';
+
+/**
+ * A react hook which invokes a promise returning callback whenever any of its dependencies changes.
+ * Returns the provided default value whenever any dependency is falsey
+ *
+ * This can be useful when fetching data based on a users keyboard input, for example.
+ * This behavior is similar to RxJS switchMap.
+ *
+ * @param callback the callback to be invoked whenever dependencies change
+ * @param defaultValue the default value to return when any dependencies are falsey
+ * @param deps array of dependencies, which (when changed) cause the callback to be invoked again
+ * @returns an object with the result and current status of the promise
+ */
+function useData<T>(callback: () => IPromise<T>, defaultValue: T, deps: any[]): IUseLatestPromiseResult<T> {
+  const anyDepsMissing = deps.some(dep => !dep);
+  const defaultValueCallback = () => $q.resolve(defaultValue);
+  return useLatestPromise(anyDepsMissing ? defaultValueCallback : callback, deps);
+}

--- a/app/scripts/modules/core/src/presentation/hooks/useData.ts
+++ b/app/scripts/modules/core/src/presentation/hooks/useData.ts
@@ -16,7 +16,7 @@ import { useLatestPromise, IUseLatestPromiseResult } from './useLatestPromise';
  * @returns an object with the result and current status of the promise
  */
 export function useData<T>(callback: () => IPromise<T>, defaultValue: T, deps: any[]): IUseLatestPromiseResult<T> {
-  const anyDepsMissing = deps.some(dep => !dep);
+  const anyDepsMissing = deps.some(dep => isNil(dep));
   const defaultValueCallback = () => $q.resolve(defaultValue);
   return useLatestPromise(anyDepsMissing ? defaultValueCallback : callback, deps);
 }


### PR DESCRIPTION
Pulling `useData` out so it can be reused in all the places.

Credit to @christopherthielen who actually wrote this.

Me? I just move bits back and forth to pad my commit count.