### PR TITLE
fix(core/pipeline): Fix github trigger manual execution missing 'hash' property

### DIFF
--- a/app/scripts/modules/core/src/pipeline/manualExecution/ManualPipelineExecutionModal.tsx
+++ b/app/scripts/modules/core/src/pipeline/manualExecution/ManualPipelineExecutionModal.tsx
@@ -137,7 +137,7 @@ export class ManualExecutionModal extends React.Component<IManualExecutionModalP
   }
 
   private submit = (values: IPipelineCommand): void => {
-    const selectedTrigger: { [key: string]: any } = values.trigger || {};
+    const selectedTrigger: { [key: string]: any } = clone(values.trigger || {});
     const command: { [key: string]: any } = {
       trigger: selectedTrigger,
     };

--- a/app/scripts/modules/core/src/pipeline/manualExecution/Triggers.tsx
+++ b/app/scripts/modules/core/src/pipeline/manualExecution/Triggers.tsx
@@ -43,7 +43,7 @@ export class Triggers extends React.Component<ITriggersProps> {
           const newTrigger = clone(trigger);
           newTrigger.description = label;
           this.props.formik.setFieldValue('trigger', newTrigger);
-          this.props.triggerChanged(trigger);
+          this.props.triggerChanged(newTrigger);
         });
     } else {
       this.props.triggerChanged(trigger);


### PR DESCRIPTION
Adding `key={trigger.description}` to `Triggers.tsx` in a recent PR had an unexpected side effect of remounting the component when this submit method deletes the trigger 'description' field.
Clone the trigger before mutating to stop this.

Also pass the correct trigger object reference to `triggerChanged` invoke in `Triggers.tsx`
