### PR TITLE
chore(core): Bump version to 0.0.400

### DIFF
--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/core",
-  "version": "0.0.399",
+  "version": "0.0.400",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
6d53fafe17d993233884ca6e8767be4c8882ca4a fix(core/pipeline): Fix github trigger manual execution missing 'hash' property Adding `key={trigger.description}` to `Triggers.tsx` in a recent PR had an unexpected side effect of remounting the component when this submit method deletes the trigger 'description' field. Clone the trigger before mutating to stop this.
a67226c10c5994a0210e826024d9026c39a8c54c feat(tasks): Adding redirect for task by id without application (#7307)
