### PR TITLE
fix(executions): Fixing execution marker ordering

### DIFF
--- a/app/scripts/modules/core/src/pipeline/service/ExecutionsTransformer.ts
+++ b/app/scripts/modules/core/src/pipeline/service/ExecutionsTransformer.ts
@@ -195,10 +195,9 @@ export class ExecutionsTransformer {
         }
       }
     });
+    execution.stages = sortBy(stages, 'phase', 'refId');
     if (!allPhasesResolved) {
       this.applyPhasesAndLink(execution, stageMap);
-    } else {
-      execution.stages = sortBy(stages, 'phase', 'refId');
     }
   }
 


### PR DESCRIPTION
Oh boy, this was a fun one.

Reverting a tiny piece of https://github.com/spinnaker/deck/pull/7217/ which regressed the ordering of the execution markers due to incorrect calculation of the phases.

Basically, sorting stages unconditionally before each recursive called guaranteed that in subsequent recursions, parents are iterated over before their children. This is important because otherwise, in the terminal condition (`allPhasesResolved`), we could get a buggy not-so-corner-case where:
1. Child is iterated over before its parent
2. Child's phase is set to its parent + 1 (lets say parent=2 so child is now 3)
3. Parent's phase is incremented (parent is now 3)
4. Child's phase doesn't get updated to 4 (parent + 1) and could get sorted before it's parent because when `phase` is identical, we string sort on `refId` and `11` comes before `9`

Ideally we should instead just build out the graph in a single pass then traverse and set the phases in a second pass, but it's late so I'll save that fun for another day.