### PR TITLE
fix(execution): Parameter names should be treated as strings

### DIFF
--- a/app/scripts/modules/core/src/pipeline/manualExecution/Parameters.tsx
+++ b/app/scripts/modules/core/src/pipeline/manualExecution/Parameters.tsx
@@ -15,6 +15,7 @@ export interface IParametersProps {
 
 export class Parameters extends React.Component<IParametersProps> {
   private dateSelected = (date: Date, name: string): void => {
+    /* We need to use bracket notation because parameter names are strings that can have all sorts of characters */
     this.props.formik.setFieldValue('parameter["' + name + '"]', date.toISOString().slice(0, 10));
   };
 
@@ -70,7 +71,11 @@ export class Parameters extends React.Component<IParametersProps> {
                 {!parameter.hasOptions && !parameter.constraint && (
                   <div className="col-md-6">
                     <FormikFormField
-                      name={'parameters["' + parameter.name + '"]'}
+                      name={
+                        'parameters["' +
+                        parameter.name +
+                        '"]' /* We need to use bracket notation because parameter names are strings that can have all sorts of characters */
+                      }
                       fastField={false}
                       input={props => <TextInput {...props} inputClassName={'form-control input-sm'} />}
                       required={parameter.required}
@@ -80,7 +85,11 @@ export class Parameters extends React.Component<IParametersProps> {
                 {parameter.hasOptions && (
                   <div className="col-md-6">
                     <FormikFormField
-                      name={'parameters["' + parameter.name + '"]'}
+                      name={
+                        'parameters["' +
+                        parameter.name +
+                        '"]' /* We need to use bracket notation because parameter names are strings that can have all sorts of characters */
+                      }
                       fastField={false}
                       input={props => (
                         <ReactSelectInput

--- a/app/scripts/modules/core/src/pipeline/manualExecution/Parameters.tsx
+++ b/app/scripts/modules/core/src/pipeline/manualExecution/Parameters.tsx
@@ -15,7 +15,7 @@ export interface IParametersProps {
 
 export class Parameters extends React.Component<IParametersProps> {
   private dateSelected = (date: Date, name: string): void => {
-    this.props.formik.setFieldValue('parameter.' + name, date.toISOString().slice(0, 10));
+    this.props.formik.setFieldValue('parameter["' + name + '"]', date.toISOString().slice(0, 10));
   };
 
   private shouldInclude = (p: IParameter) => {
@@ -70,7 +70,7 @@ export class Parameters extends React.Component<IParametersProps> {
                 {!parameter.hasOptions && !parameter.constraint && (
                   <div className="col-md-6">
                     <FormikFormField
-                      name={'parameters.' + parameter.name}
+                      name={'parameters["' + parameter.name + '"]'}
                       fastField={false}
                       input={props => <TextInput {...props} inputClassName={'form-control input-sm'} />}
                       required={parameter.required}
@@ -80,7 +80,7 @@ export class Parameters extends React.Component<IParametersProps> {
                 {parameter.hasOptions && (
                   <div className="col-md-6">
                     <FormikFormField
-                      name={'parameters.' + parameter.name}
+                      name={'parameters["' + parameter.name + '"]'}
                       fastField={false}
                       input={props => (
                         <ReactSelectInput


### PR DESCRIPTION
Otherwise we'll get unexpected behavior on crazy pipelines that have things like `foo.bar.baz` as the name.