### PR TITLE
fix(core/pipeline): fix side menu rendering for trigger config

### DIFF
--- a/app/scripts/modules/core/src/presentation/navigation/PageNavigator.tsx
+++ b/app/scripts/modules/core/src/presentation/navigation/PageNavigator.tsx
@@ -50,7 +50,7 @@ export class PageNavigator extends React.Component<IPageNavigatorProps, IPageNav
     }
 
     const pages = React.Children.map(children, (child: any) => {
-      if (child.type && child.type.name === 'PageSection') {
+      if (child.props.pageKey && child.props.label) {
         return {
           key: child.props.pageKey,
           label: child.props.label,


### PR DESCRIPTION
Shouldn't rely on `child.type.name` when adding the menu items because the nightly build does not contain the name `PageSection` but `PageSection_ PageSection` instead.