### PR TITLE
fix(ecs): Fix creation of new ECS server group from existing

### DIFF
--- a/app/scripts/modules/ecs/src/serverGroup/configure/wizard/CloneServerGroup.ecs.controller.js
+++ b/app/scripts/modules/ecs/src/serverGroup/configure/wizard/CloneServerGroup.ecs.controller.js
@@ -102,14 +102,8 @@ module.exports = angular
       };
 
       this.templateSelectionText = {
-        copied: [
-          'account, region, subnet, cluster name (stack, details)',
-          'load balancers',
-          'all fields on the Advanced Settings page',
-        ],
-        notCopied: ['the following suspended scaling processes: Launch, Terminate, AddToLoadBalancer'],
-        additionalCopyText:
-          'If a server group exists in this cluster at the time of deployment, its scaling policies will be copied over to the new server group.',
+        copied: ['account, region, ecs cluster, stack', 'capacity'],
+        notCopied: ['launch type, target group, network mode'],
       };
       if (!$scope.command.viewState.disableStrategySelection) {
         this.templateSelectionText.notCopied.push(


### PR DESCRIPTION
Fixes https://github.com/spinnaker/spinnaker/issues/4585

In general, there's more to work to done here re: making templated ECS server group creation useful. Example: right now we're limited to copying over fields provided by [IServerGroup](https://github.com/spinnaker/deck/blob/master/app/scripts/modules/core/src/domain/IServerGroup.ts), which omits many ECS-specific values.

However, this change DOES copy over what we can at the time `buildServerGroupCommandFromExisting` is called, vs. not working at all (current state).

## screenshots

### new template selection text
![newTemplateText](https://user-images.githubusercontent.com/34254888/63198829-d53cb700-c030-11e9-815d-d5493a6503ab.PNG)

### copied over fields in new server group
![copiedFields](https://user-images.githubusercontent.com/34254888/63198838-de2d8880-c030-11e9-9f08-e8fd26356638.PNG)
