### PR TITLE
fix(core/forms): revert legacy MapEditor adapter to old component

### DIFF
--- a/app/scripts/modules/core/src/forms/mapEditor/MapEditor.tsx
+++ b/app/scripts/modules/core/src/forms/mapEditor/MapEditor.tsx
@@ -1,10 +1,7 @@
 import * as React from 'react';
-import { isString, isFunction } from 'lodash';
-
 import { IPipeline } from 'core/domain';
-import { IValidationProps, IValidator } from 'core/presentation';
-
-import { MapEditorInput, IMapEditorModel } from './MapEditorInput';
+import { isString } from 'lodash';
+import { IMapPair, MapPair } from './MapPair';
 
 export interface IMapEditorProps {
   addButtonLabel?: string;
@@ -13,52 +10,160 @@ export interface IMapEditorProps {
   keyLabel?: string;
   label?: string;
   labelsLeft?: boolean;
-  model: string | IMapEditorModel;
+  model: string | { [key: string]: string };
   valueLabel?: string;
-  onChange: (model: string | IMapEditorModel, error: boolean) => void;
+  onChange: (model: string | { [key: string]: string }, duplicateKeys: boolean) => void;
   valueCanContainSpel?: boolean;
   pipeline?: IPipeline;
 }
-function doValidation(validator: IValidator, value: string | IMapEditorModel): IMapEditorModel {
-  if (isString(value)) {
-    return null;
-  }
 
-  const newErrors = isFunction(validator) ? validator(value) : null;
-  return (newErrors as any) as IMapEditorModel;
+export interface IMapEditorState {
+  backingModel: IMapPair[];
 }
 
-// A component that adapts the MapEditorInput (a controlled component) to the previous API of MapEditor
-// Handles validation and feeds it back into the MapEditorInput
-export function MapEditor(mapEditorProps: IMapEditorProps) {
-  const { onChange, model: initialModel, ...props } = mapEditorProps;
-  const [model, setModel] = React.useState<string | IMapEditorModel>(initialModel);
-  const [validator, setValidator] = React.useState<IValidator>();
-  const [errors, setErrors] = React.useState<IMapEditorModel>();
-
-  React.useEffect(() => {
-    const newErrors = doValidation(validator, model);
-    const hasError = !!Object.keys(newErrors || {}).length;
-    setErrors(newErrors);
-    onChange(model, hasError);
-  }, [validator, model]);
-
-  const validation: IValidationProps = {
-    touched: true,
-    // Use setValidator(oldstate => newstate) overload
-    // Otherwise, react calls the validator function internally and stores the returned errors object
-    // https://reactjs.org/docs/hooks-reference.html#functional-updates
-    addValidator: newValidator => setValidator(() => newValidator),
-    removeValidator: () => setValidator(null),
+export class MapEditor extends React.Component<IMapEditorProps, IMapEditorState> {
+  public static defaultProps: Partial<IMapEditorProps> = {
+    addButtonLabel: 'Add Field',
+    allowEmpty: false,
+    hiddenKeys: [],
+    keyLabel: 'Key',
+    labelsLeft: false,
+    valueLabel: 'Value',
+    valueCanContainSpel: false,
   };
 
-  return (
-    <MapEditorInput
-      {...props}
-      errors={errors}
-      value={model}
-      onChange={e => setModel(e.target.value)}
-      validation={validation}
-    />
-  );
+  constructor(props: IMapEditorProps) {
+    super(props);
+    const isParameterized = isString(props.model);
+
+    this.state = {
+      backingModel: !isParameterized ? this.mapModel(props.model as { [key: string]: string }) : null,
+    };
+  }
+
+  private mapModel(model: { [key: string]: string }): IMapPair[] {
+    return Object.keys(model).map(key => ({ key: key, value: model[key] }));
+  }
+
+  private reduceModel(backingModel: IMapPair[]): { [key: string]: string } {
+    return backingModel.reduce(
+      (acc, pair) => {
+        if (this.props.allowEmpty || pair.value) {
+          acc[pair.key] = pair.value;
+        }
+        return acc;
+      },
+      {} as any,
+    );
+  }
+
+  private validateUnique(model: IMapPair[]): boolean {
+    let error = false;
+
+    const usedKeys = new Set();
+
+    model.forEach(p => {
+      if (usedKeys.has(p.key)) {
+        p.error = 'Duplicate key';
+        error = true;
+      } else {
+        delete p.error;
+      }
+      usedKeys.add(p.key);
+    });
+
+    return error;
+  }
+
+  private handleChanged() {
+    const error = this.validateUnique(this.state.backingModel);
+    const newModel = this.reduceModel(this.state.backingModel);
+    this.props.onChange(newModel, error);
+  }
+
+  private onChange = (newPair: IMapPair, index: number) => {
+    this.state.backingModel[index] = newPair;
+    this.handleChanged();
+  };
+
+  private onDelete = (index: number) => {
+    this.state.backingModel.splice(index, 1);
+    this.handleChanged();
+  };
+
+  private onAdd = () => {
+    this.state.backingModel.push({ key: '', value: '' });
+    this.handleChanged();
+  };
+
+  public render() {
+    const {
+      addButtonLabel,
+      hiddenKeys,
+      keyLabel,
+      label,
+      labelsLeft,
+      model,
+      valueLabel,
+      valueCanContainSpel,
+      pipeline,
+    } = this.props;
+    const { backingModel } = this.state;
+
+    const rowProps = { keyLabel, valueLabel, labelsLeft };
+
+    const columnCount = this.props.labelsLeft ? 5 : 3;
+    const tableClass = this.props.label ? '' : 'no-border-top';
+    const isParameterized = isString(this.props.model);
+
+    return (
+      <div>
+        {label && (
+          <div className="sm-label-left">
+            <b>{label}</b>
+          </div>
+        )}
+
+        {isParameterized && <input className="form-control input-sm" value={model as string} />}
+        {!isParameterized && (
+          <table className={`table table-condensed packed tags ${tableClass}`}>
+            <thead>
+              {!labelsLeft && (
+                <tr>
+                  <th>{keyLabel}</th>
+                  <th>{valueLabel}</th>
+                  <th />
+                </tr>
+              )}
+            </thead>
+            <tbody>
+              {backingModel
+                .filter(p => !hiddenKeys.includes(p.key))
+                .map((pair, index) => (
+                  <MapPair
+                    key={index}
+                    {...rowProps}
+                    onChange={value => this.onChange(value, index)}
+                    onDelete={() => this.onDelete(index)}
+                    pair={pair}
+                    valueCanContainSpel={valueCanContainSpel}
+                    pipeline={pipeline}
+                  />
+                ))}
+            </tbody>
+            <tfoot>
+              <tr>
+                <td colSpan={columnCount}>
+                  <button type="button" className="btn btn-block btn-sm add-new" onClick={this.onAdd}>
+                    <span className="glyphicon glyphicon-plus-sign" />
+                    {addButtonLabel}
+                  </button>
+                </td>
+              </tr>
+            </tfoot>
+          </table>
+        )}
+      </div>
+    );
+  }
 }


### PR DESCRIPTION
This effectively reverts the changes to `MapEditor` made in https://github.com/spinnaker/deck/pull/7299, while retaining the new `MapEditorInput` as-is.

We observed an issue with the `TitusRunJobStageConfig` component where `DockerImageAndTagSelector` was failing to properly fetch and display image org/name autocomplete data, which we eventually tracked back to a change in behavior (`onChange` gets called immediately on mounting) between the legacy `MapEditor` and the new, hook-based adapter that took `MapEditorInput` and made it appear to work like `MapEditor`.

After looking at the usage of the legacy `MapEditor` and the way in which the behavior change broke things, we feel it's appropriate to do two things:
1) Fix the immediate-term regression we know about — and guard against regressions we may not know about — by moving back to an implementation of `MapEditor` we know to be safe and predictable.
2) Separately, because we think the issues with this behavior will only manifest in non-Formik stage configs, move the remaining few of those which use `MapEditor` over to Formik + `MapEditorInput` so we can confidently move toward getting rid of the legacy `MapEditor` entirely.