### PR TITLE
fix(core): fix produces artifacts UI

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/triggers/triggers.module.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/triggers.module.ts
@@ -2,9 +2,10 @@ import { module } from 'angular';
 import { react2angular } from 'react2angular';
 
 import { Triggers } from './Triggers';
+import { ARTIFACT_MODULE } from './artifacts/artifact.module';
 
 export const TRIGGERS = 'spinnaker.core.pipeline.config.trigger.triggersDirective';
-module(TRIGGERS, []).component(
+module(TRIGGERS, [ARTIFACT_MODULE]).component(
   'triggers',
   react2angular(Triggers, ['application', 'pipeline', 'fieldUpdated', 'updatePipelineConfig']),
 );


### PR DESCRIPTION
[This commit](https://github.com/spinnaker/deck/commit/bec54dfa5f0b9c55b7fc8062cf47784f972a0107) removed the artifacts module as an explicit dependency of the triggers module. This manifested as a broken Produces Artifacts UI when artifacts rewrite is disabled, since the Produces Artifact component is still in angular and expects the angular Expected Artifact component to be there.