### PR TITLE
 fix(core): fix vertical alignment of radio buttons

### DIFF
--- a/app/scripts/modules/core/src/presentation/forms/inputs/RadioButtonInput.tsx
+++ b/app/scripts/modules/core/src/presentation/forms/inputs/RadioButtonInput.tsx
@@ -36,12 +36,10 @@ export const RadioButtonInput = (props: IRadioButtonInputProps) => {
   );
 
   const VerticalRadioButtons = ({ opts }: { opts: IRadioButtonOptions[] }) => (
-    <div className="vertical left">
-      <div className={elementClassName}>
-        {opts.map(option => (
-          <RadioButton key={option.label} option={option} />
-        ))}
-      </div>
+    <div className={`${elementClassName} vertical left`}>
+      {opts.map(option => (
+        <RadioButton key={option.label} option={option} />
+      ))}
     </div>
   );
 

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/DeployManifestStageForm.tsx
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/DeployManifestStageForm.tsx
@@ -148,7 +148,6 @@ export class DeployManifestStageForm extends React.Component<
         <h4>Manifest Configuration</h4>
         <StageConfigField label="Manifest Source" helpKey="kubernetes.manifest.source">
           <RadioButtonInput
-            inline={true}
             options={this.getSourceOptions()}
             onChange={(e: any) => this.props.formik.setFieldValue('source', e.target.value)}
             value={stage.source}

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/patchManifest/PatchManifestStageForm.tsx
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/patchManifest/PatchManifestStageForm.tsx
@@ -115,7 +115,6 @@ export class PatchManifestStageForm extends React.Component<
             options={this.getSourceOptions()}
             onChange={(e: any) => this.props.formik.setFieldValue('source', e.target.value)}
             value={stage.source || 'text'}
-            inline={true}
           />
         </StageConfigField>
         {stage.source === this.textSource && (

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/runJob/KubernetesV2RunJobStageConfig.tsx
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/runJob/KubernetesV2RunJobStageConfig.tsx
@@ -230,7 +230,6 @@ export class KubernetesV2RunJobStageConfig extends React.Component<IStageConfigP
         <h4>Manifest Configuration</h4>
         <StageConfigField label="Manifest Source" helpKey="kubernetes.manifest.source">
           <RadioButtonInput
-            inline={true}
             options={this.getSourceOptions()}
             onChange={(e: any) => this.props.updateStageField({ source: e.target.value })}
             value={stage.source}


### PR DESCRIPTION
fix(core): fix vertical alignment of radio buttons
- Previously, even if the `inline` prop to `RadioButtonInput` was falsy, the radio buttons would not display vertically. Moves the relevant classes to directly wrap the input to resolve this.
![kAETmUzGehi](https://user-images.githubusercontent.com/15936279/63293254-a5421d80-c295-11e9-9488-e3bbdc23b880.png)

fix(kubernetes): make all kubernetes v2 stages use vertically aligned
- For visual consistency, makes all horizontal radio buttons in Kubernetes V2 stages vertical.
![PdLRj04YB8Z](https://user-images.githubusercontent.com/15936279/63293348-ef2b0380-c295-11e9-99d3-2f17a28ae1bb.png)
