### PR TITLE
fix(artifacts): set the artifacts on trigger before the pipeline to s…

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/triggers/Trigger.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/Trigger.tsx
@@ -103,8 +103,8 @@ function TriggerForm(triggerFormProps: ITriggerProps & { formik: FormikProps<ITr
       triggerExpectedArtifactIds.push(expectedArtifact.id);
     }
 
-    updateExpectedArtifacts(pipelineExpectedArtifacts);
     updateTriggerFields({ expectedArtifactIds: triggerExpectedArtifactIds });
+    updateExpectedArtifacts(pipelineExpectedArtifacts);
   };
 
   const showRunAsUser = SETTINGS.feature.fiatEnabled && !SETTINGS.feature.managedServiceAccounts;


### PR DESCRIPTION
Timing issue with Angular and React which requires the expected artifacts to be set on the trigger first before adding a new artifact to the pipeline.