### PR TITLE
fix(notifications): Fixing custom message text shape

### DIFF
--- a/app/scripts/modules/core/src/notification/modal/NotificationDetails.tsx
+++ b/app/scripts/modules/core/src/notification/modal/NotificationDetails.tsx
@@ -57,7 +57,7 @@ export class NotificationDetails extends React.Component<INotificationDetailsPro
     if (whenOption !== 'manualJudgment' && ['email', 'slack', 'googlechat'].includes(type)) {
       return (
         <FormikFormField
-          name={'message["' + whenOption + '"].text'}
+          name={`message["${whenOption}"].text`}
           input={props => <TextAreaInput {...props} placeholder="enter a custom notification message (optional)" />}
         />
       );

--- a/app/scripts/modules/core/src/notification/modal/NotificationDetails.tsx
+++ b/app/scripts/modules/core/src/notification/modal/NotificationDetails.tsx
@@ -57,7 +57,7 @@ export class NotificationDetails extends React.Component<INotificationDetailsPro
     if (whenOption !== 'manualJudgment' && ['email', 'slack', 'googlechat'].includes(type)) {
       return (
         <FormikFormField
-          name={'message.' + whenOption + '.text'}
+          name={'message["' + whenOption + '"].text'}
           input={props => <TextAreaInput {...props} placeholder="enter a custom notification message (optional)" />}
         />
       );


### PR DESCRIPTION
Echo expects the custom message structure to be:
```
message: {
  "pipeline.starting": {
    text: 'foo'
  }
}
```
So we have to set the path to be `message["pipeline.starting"].text` instead of `message.pipeline.starting.text`, which would result in:
```
message: {
  pipeline: {
    starting: {
      text: 'foo'
    }
  }
}
```