### PR TITLE
refactor(titus): Making service job processes human friendly

### DIFF
--- a/app/scripts/modules/titus/src/serverGroup/configure/wizard/pages/ServerGroupParameters.tsx
+++ b/app/scripts/modules/titus/src/serverGroup/configure/wizard/pages/ServerGroupParameters.tsx
@@ -10,6 +10,7 @@ import {
   PlatformHealthOverride,
   Application,
   ChecklistInput,
+  robotToHuman,
 } from '@spinnaker/core';
 
 import { ITitusServerGroupCommand } from '../../../configure/serverGroupConfiguration.service';
@@ -125,7 +126,10 @@ export class ServerGroupParameters extends React.Component<IServerGroupParameter
           <div className="col-md-4">
             <ChecklistInput
               value={enabledProcesses(values.serviceJobProcesses)}
-              stringOptions={union(processesList, Object.keys(values.serviceJobProcesses))}
+              options={union(processesList, Object.keys(values.serviceJobProcesses)).map((value: string) => ({
+                value,
+                label: robotToHuman(value),
+              }))}
               onChange={(e: React.ChangeEvent<any>) =>
                 setFieldValue(
                   'serviceJobProcesses',

--- a/app/scripts/modules/titus/src/serverGroup/details/serverGroupDetails.html
+++ b/app/scripts/modules/titus/src/serverGroup/details/serverGroupDetails.html
@@ -142,7 +142,7 @@
       style="display: block"
     ></titus-security-groups>
 
-    <collapsible-section heading="Service Job Policies">
+    <collapsible-section heading="Service Job Processes">
       <titus-service-job-processes-section
         app="ctrl.application"
         server-group="serverGroup"

--- a/app/scripts/modules/titus/src/serverGroup/details/serviceJobProcesses/ServiceJobProcessesSection.tsx
+++ b/app/scripts/modules/titus/src/serverGroup/details/serviceJobProcesses/ServiceJobProcessesSection.tsx
@@ -10,6 +10,7 @@ import {
   TextAreaInput,
   TaskMonitorModal,
   Application,
+  robotToHuman,
 } from '@spinnaker/core';
 
 import { ITitusServerGroupDetailsSectionProps } from '../sections/ITitusServerGroupDetailsSectionProps';
@@ -43,7 +44,15 @@ const EditTitusServiceJobProcessesModal: React.SFC<IEditTitusServiceJobProcesses
           <FormikFormField
             label="Service Job Processes"
             name="serviceJobProcesses"
-            input={props => <ChecklistInput {...props} stringOptions={Object.keys(serverGroup.serviceJobProcesses)} />}
+            input={props => (
+              <ChecklistInput
+                {...props}
+                options={Object.keys(serverGroup.serviceJobProcesses).map((value: string) => ({
+                  value,
+                  label: robotToHuman(value),
+                }))}
+              />
+            )}
           />
 
           <FormikFormField
@@ -107,7 +116,7 @@ export class ServiceJobProcessesSection extends React.Component<ITitusServerGrou
                 style={{ visibility: serviceJobProcesses[process] ? 'visible' : 'hidden' }}
                 className="fa fa-check small"
               />
-              <span className={!serviceJobProcesses[process] ? 'text-disabled' : ''}>{process} </span>
+              <span className={!serviceJobProcesses[process] ? 'text-disabled' : ''}>{robotToHuman(process)} </span>
             </li>
           ))}
         </ul>


### PR DESCRIPTION
Just running the service job processes through `robotToHuman` so they're not just raw camelCase.

Also correcting the section title from Service Job `Policies` to Service Job `Processes`. Whoops!