### PR TITLE
fix(artifacts/k8s): fix rewrite k8s artifact edit

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/kubernetes/KubernetesArtifactEditor.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/kubernetes/KubernetesArtifactEditor.tsx
@@ -7,8 +7,54 @@ import { IArtifactEditorProps, IArtifactKindConfig } from 'core/domain';
 import { StageConfigField } from 'core/pipeline';
 import { SpelText } from 'core/widgets';
 
-import { singleFieldArtifactEditor } from '../singleFieldArtifactEditor';
 import { ArtifactEditor } from '../ArtifactEditor';
+
+class KubernetesArtifactEditor extends ArtifactEditor {
+  constructor(props: IArtifactEditorProps) {
+    super(props, props.artifact.type || 'kubernetes/configMap');
+  }
+
+  private onReferenceChange = (reference: string) => {
+    const clonedArtifact = cloneDeep(this.props.artifact);
+    clonedArtifact.reference = reference;
+    this.props.onChange(clonedArtifact);
+  };
+
+  private onTypeChange = (option: Option<string>) => {
+    const clonedArtifact = cloneDeep(this.props.artifact);
+    clonedArtifact.type = option.value;
+    this.props.onChange(clonedArtifact);
+  };
+
+  public render() {
+    return (
+      <>
+        <StageConfigField label="Resource Type">
+          <Select
+            options={[
+              { label: 'ConfigMap', value: 'kubernetes/configMap' },
+              { label: 'Deployment', value: 'kubernetes/deployment' },
+              { label: 'ReplicaSet', value: 'kubernetes/replicaSet' },
+              { label: 'Secret', value: 'kubernetes/secret' },
+            ]}
+            clearable={false}
+            value={this.props.artifact.type}
+            onChange={this.onTypeChange}
+          />
+        </StageConfigField>
+        <StageConfigField label="Reference">
+          <SpelText
+            placeholder=""
+            value={this.props.artifact.reference}
+            onChange={this.onReferenceChange}
+            pipeline={this.props.pipeline}
+            docLink={true}
+          />
+        </StageConfigField>
+      </>
+    );
+  }
+}
 
 export const KubernetesMatch: IArtifactKindConfig = {
   label: 'Kubernetes',
@@ -18,7 +64,7 @@ export const KubernetesMatch: IArtifactKindConfig = {
   key: 'kubernetes',
   isDefault: false,
   isMatch: true,
-  editCmp: singleFieldArtifactEditor('reference', 'kubernetes/RESOURCE', 'Resource', '', ''),
+  editCmp: KubernetesArtifactEditor,
 };
 
 export const KubernetesDefault: IArtifactKindConfig = {
@@ -29,50 +75,5 @@ export const KubernetesDefault: IArtifactKindConfig = {
   key: 'default.kubernetes',
   isDefault: true,
   isMatch: false,
-  editCmp: class extends ArtifactEditor {
-    constructor(props: IArtifactEditorProps) {
-      super(props, props.artifact.type || 'kubernetes/configMap');
-    }
-
-    private onReferenceChange = (reference: string) => {
-      const clonedArtifact = cloneDeep(this.props.artifact);
-      clonedArtifact.reference = reference;
-      this.props.onChange(clonedArtifact);
-    };
-
-    private onTypeChange = (option: Option<string>) => {
-      const clonedArtifact = cloneDeep(this.props.artifact);
-      clonedArtifact.type = option.value;
-      this.props.onChange(clonedArtifact);
-    };
-
-    public render() {
-      return (
-        <>
-          <StageConfigField label="Resource Type">
-            <Select
-              options={[
-                { label: 'ConfigMap', value: 'kubernetes/configMap' },
-                { label: 'Deployment', value: 'kubernetes/deployment' },
-                { label: 'ReplicaSet', value: 'kubernetes/replicaSet' },
-                { label: 'Secret', value: 'kubernetes/secret' },
-              ]}
-              clearable={false}
-              value={this.props.artifact.type}
-              onChange={this.onTypeChange}
-            />
-          </StageConfigField>
-          <StageConfigField label="Reference">
-            <SpelText
-              placeholder=""
-              value={this.props.artifact.reference}
-              onChange={this.onReferenceChange}
-              pipeline={this.props.pipeline}
-              docLink={true}
-            />
-          </StageConfigField>
-        </>
-      );
-    }
-  },
+  editCmp: KubernetesArtifactEditor,
 };


### PR DESCRIPTION
the match artifact editor used for kubernetes match artifacts wasn't
working right. previously, you were only presented with a single
reference field which didn't capture all of the data we needed to match
on artifacts. instead of something like `kubernetes/configMap` the
default artifact type was `kubernetes/REFERENCE` which is not a valid
type but there was no way to change it.