### PR TITLE
fix(kustomize): fix artifact selector

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/helm/BakeHelmConfigForm.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/helm/BakeHelmConfigForm.tsx
@@ -27,6 +27,7 @@ export class BakeHelmConfigForm extends React.Component<IBakeHelmConfigFormProps
   private onTemplateArtifactEdited = (artifact: IArtifact, index: number) => {
     this.props.formik.setFieldValue(`inputArtifacts[${index}].id`, null);
     this.props.formik.setFieldValue(`inputArtifacts[${index}].artifact`, artifact);
+    this.props.formik.setFieldValue(`inputArtifacts[${index}].account`, artifact.artifactAccount);
   };
 
   private onTemplateArtifactSelected = (id: string, index: number) => {

--- a/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/kustomize/BakeKustomizeConfigForm.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/kustomize/BakeKustomizeConfigForm.tsx
@@ -42,6 +42,7 @@ export class BakeKustomizeConfigForm extends React.Component<
             onArtifactEdited={(artifact: IArtifact) => {
               this.props.formik.setFieldValue('inputArtifact.id', null);
               this.props.formik.setFieldValue('inputArtifact.artifact', artifact);
+              this.props.formik.setFieldValue('inputArtifact.account', artifact.artifactAccount);
             }}
             onExpectedArtifactSelected={(artifact: IArtifact) => {
               this.props.formik.setFieldValue('inputArtifact.id', artifact.id);


### PR DESCRIPTION
when `artifactsRewrite` is enabled the `setArtifactAccount` method on
the delegate isn't fired. so we need to set the artifact account
manually.