### PR TITLE
Fix date picker parameters in manual execution dialog

### DIFF
--- a/app/scripts/modules/core/src/pipeline/manualExecution/Parameters.tsx
+++ b/app/scripts/modules/core/src/pipeline/manualExecution/Parameters.tsx
@@ -1,12 +1,9 @@
 import * as React from 'react';
 import { FormikProps } from 'formik';
-import DayPickerInput from 'react-day-picker/DayPickerInput';
 
 import { HelpField } from 'core/help';
 import { IParameter, IPipelineCommand } from 'core/domain';
-import { FormikFormField, ReactSelectInput, TextInput } from 'core/presentation';
-
-import 'react-day-picker/lib/style.css';
+import { FormikFormField, ReactSelectInput, TextInput, DayPickerInput } from 'core/presentation';
 
 export interface IParametersProps {
   formik: FormikProps<IPipelineCommand>;
@@ -14,11 +11,6 @@ export interface IParametersProps {
 }
 
 export class Parameters extends React.Component<IParametersProps> {
-  private dateSelected = (date: Date, name: string): void => {
-    /* We need to use bracket notation because parameter names are strings that can have all sorts of characters */
-    this.props.formik.setFieldValue('parameter["' + name + '"]', date.toISOString().slice(0, 10));
-  };
-
   private shouldInclude = (p: IParameter) => {
     const { values } = this.props.formik;
     if (p.conditional) {
@@ -46,6 +38,8 @@ export class Parameters extends React.Component<IParametersProps> {
     const { parameters } = this.props;
     const hasRequiredParameters = parameters.some(p => p.required);
     const visibleParameters = parameters.filter(p => !p.conditional || this.shouldInclude(p));
+    /* We need to use bracket notation because parameter names are strings that can have all sorts of characters */
+    const formikFieldNameForParam = (param: IParameter) => `parameters["${param.name}"]`;
     return (
       <>
         <p className="manual-execution-parameters-description">
@@ -62,20 +56,18 @@ export class Parameters extends React.Component<IParametersProps> {
                 </div>
                 {!parameter.hasOptions && parameter.constraint === 'date' && (
                   <div className="col-md-6">
-                    <DayPickerInput
-                      format={'yyyy-MM-dd'}
-                      onDayChange={(date: Date) => this.dateSelected(date, parameter.name)}
+                    <FormikFormField
+                      name={formikFieldNameForParam(parameter)}
+                      fastField={false}
+                      input={props => <DayPickerInput {...props} format={'yyyy-MM-dd'} />}
+                      required={parameter.required}
                     />
                   </div>
                 )}
                 {!parameter.hasOptions && !parameter.constraint && (
                   <div className="col-md-6">
                     <FormikFormField
-                      name={
-                        'parameters["' +
-                        parameter.name +
-                        '"]' /* We need to use bracket notation because parameter names are strings that can have all sorts of characters */
-                      }
+                      name={formikFieldNameForParam(parameter)}
                       fastField={false}
                       input={props => <TextInput {...props} inputClassName={'form-control input-sm'} />}
                       required={parameter.required}
@@ -85,11 +77,7 @@ export class Parameters extends React.Component<IParametersProps> {
                 {parameter.hasOptions && (
                   <div className="col-md-6">
                     <FormikFormField
-                      name={
-                        'parameters["' +
-                        parameter.name +
-                        '"]' /* We need to use bracket notation because parameter names are strings that can have all sorts of characters */
-                      }
+                      name={formikFieldNameForParam(parameter)}
                       fastField={false}
                       input={props => (
                         <ReactSelectInput

--- a/app/scripts/modules/core/src/presentation/forms/inputs/DayPickerInput.less
+++ b/app/scripts/modules/core/src/presentation/forms/inputs/DayPickerInput.less
@@ -1,0 +1,4 @@
+/* Kludge while we figure out how to add the form-control ng-invalid classes directly to the nested day-picker input */
+.DayPickerInput.ng-invalid > input {
+  border-color: var(--color-danger);
+}

--- a/app/scripts/modules/core/src/presentation/forms/inputs/DayPickerInput.tsx
+++ b/app/scripts/modules/core/src/presentation/forms/inputs/DayPickerInput.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { defaults } from 'lodash';
+
+import { DayPickerInputProps } from 'react-day-picker';
+import DayPicker from 'react-day-picker/DayPickerInput';
+
+import { IFormInputProps } from '../interface';
+import { createFakeReactSyntheticEvent, orEmptyString, validationClassName } from './utils';
+
+import 'react-day-picker/lib/style.css';
+import './DayPickerInput.less';
+
+export function DayPickerInput(props: IFormInputProps & DayPickerInputProps) {
+  const { validation, inputClassName, classNames, onChange, onBlur, name, ...rest } = props;
+  const className = `${orEmptyString(inputClassName)} ${validationClassName(validation)}`;
+
+  React.useEffect(() => onBlur(createFakeReactSyntheticEvent({ name, value: props.value })), []);
+
+  const defaultClassNames = { container: '', overlayWrapper: '', overlay: '' };
+  const managedClassNames = defaults({}, classNames, defaultClassNames);
+  managedClassNames.container = `DayPickerInput ${orEmptyString(managedClassNames.container)} ${className}`;
+
+  return (
+    <DayPicker
+      {...rest}
+      classNames={managedClassNames}
+      onDayChange={(date: Date) => {
+        const newValue = date && date.toISOString().slice(0, 10);
+        props.onChange(createFakeReactSyntheticEvent({ name, value: newValue }));
+      }}
+    />
+  );
+}

--- a/app/scripts/modules/core/src/presentation/forms/inputs/index.ts
+++ b/app/scripts/modules/core/src/presentation/forms/inputs/index.ts
@@ -1,5 +1,6 @@
 export * from './CheckboxInput';
 export * from './ChecklistInput';
+export * from './DayPickerInput';
 export * from './JsonEditor';
 export * from './NumberInput';
 export * from './RadioButtonInput';


### PR DESCRIPTION
This fixes a regression in the date picker for date parameters in the manual execution dialog.  The core bug was a simple typo of `parameter` vs `parameters`.

I also switched to `FormikFormField` and added a `DatePickerInput` compatible with the spinnaker `FormField` system.  This enables surfacing of `required` validation.  There's still some work to do determining how to add classnames to the nested `input` component.  In the meantime, I added a css kludge that looks ugly, but is better than nothing.

I'm going to merge this optimistically, but please review at your leisure.

<img width="601" alt="Screen Shot 2019-08-31 at 9 14 45 PM" src="https://user-images.githubusercontent.com/2053478/64071699-784a1f00-cc34-11e9-962b-912cbc2f2363.png">

<img width="602" alt="Screen Shot 2019-08-31 at 9 15 01 PM" src="https://user-images.githubusercontent.com/2053478/64071700-7a13e280-cc34-11e9-818b-5318d3936b9c.png">
