### PR TITLE
configure apache to log to stdout/stderr

### DIFF
--- a/docker/run-apache2.sh
+++ b/docker/run-apache2.sh
@@ -44,6 +44,10 @@ mv spinnaker.conf  /etc/apache2/sites-available
 
 a2ensite spinnaker
 
+# Disable default site
+
+a2dissite 000-default
+
 # Update ports.conf to reflect desired deck host
 
 cp docker/ports.conf.gen ports.conf

--- a/docker/setup-apache2.sh
+++ b/docker/setup-apache2.sh
@@ -1,5 +1,7 @@
 apt-get update
 apt-get install apache2 -y
+rm -rf /var/lib/apt/lists/* 
+
 service apache2 stop
 a2enmod proxy proxy_ajp proxy_http rewrite deflate headers proxy_balancer proxy_connect proxy_html xml2enc
 chown -R www-data:www-data /etc/apache2

--- a/docker/spinnaker.conf.gen
+++ b/docker/spinnaker.conf.gen
@@ -4,6 +4,8 @@
   ProxyPass "/gate" "{%API_HOST%}" retry=0
   ProxyPassReverse "/gate" "{%API_HOST%}"
   ProxyPreserveHost On
+  ErrorLog /dev/stderr
+  TransferLog /dev/stdout
 
   <Directory "/opt/deck/html/">
     Require all granted

--- a/docker/spinnaker.conf.ssl
+++ b/docker/spinnaker.conf.ssl
@@ -8,6 +8,9 @@
   ProxyPass "/gate" "{%API_HOST%}" retry=0
   ProxyPassReverse "/gate" "{%API_HOST%}"
 
+  ErrorLog /dev/stderr
+  TransferLog /dev/stdout
+
   <Directory "/opt/deck/html/">
     Require all granted
   </Directory>


### PR DESCRIPTION
Apache is configured by default to log to `/var/log...` which fills up real quick with logs from kubernetes health checks and regular traffic, eventually the pod runs out of space.  This modifies the config to log to stdout/stderr instead inline with docker/kubernetes best practices and should help protect the filesystem of the containers/pods.

Signed-off-by: Paul Czarkowski <username.taken@gmail.com>


