### PR TITLE
feat(core/managed): Add resource dropdown with links to history + source JSON

### DIFF
--- a/app/scripts/modules/core/src/managed/ManagedResourceDetailsIndicator.less
+++ b/app/scripts/modules/core/src/managed/ManagedResourceDetailsIndicator.less
@@ -1,4 +1,13 @@
-.ManagedResourceDetailsIndicator > .icon {
+// Selector specificity is the worst
+.band.band-info.ManagedResourceDetailsIndicator {
+  padding: 8px 10px 10px;
+}
+
+.ManagedResourceDetailsIndicator .rainbow-icon {
   text-shadow: 0px 1px 4px rgba(0, 0, 0, 0.5);
   padding-right: 5px;
+}
+
+.ManagedResourceDetailsIndicator .summary-message {
+  cursor: help;
 }

--- a/app/scripts/modules/core/src/managed/ManagedResourceDetailsIndicator.tsx
+++ b/app/scripts/modules/core/src/managed/ManagedResourceDetailsIndicator.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react';
-import { get } from 'lodash';
+import * as ReactGA from 'react-ga';
+import { get, flatMap } from 'lodash';
+import { Dropdown } from 'react-bootstrap';
 
+import { SETTINGS } from 'core/config/settings';
 import { IEntityTags } from 'core/domain';
 import { HoverablePopover } from 'core/presentation';
 
@@ -12,14 +15,25 @@ export interface IManagedResourceDetailsIndicatorProps {
   entityTags: IEntityTags[];
 }
 
-export const ManagedResourceDetailsIndicator = ({ entityTags }: IManagedResourceDetailsIndicatorProps) => {
-  const isManaged =
-    get(entityTags, 'length') &&
-    entityTags.some(({ tags }) => tags.some(({ name }) => name === MANAGED_BY_SPINNAKER_TAG_NAME));
+const logClick = (label: string, resourceId: string) =>
+  ReactGA.event({
+    category: 'Managed Resource Menu',
+    action: `${label} clicked`,
+    label: resourceId,
+  });
 
-  if (!isManaged) {
+export const ManagedResourceDetailsIndicator = ({ entityTags }: IManagedResourceDetailsIndicatorProps) => {
+  const managedTag =
+    get(entityTags, 'length') &&
+    flatMap(entityTags, ({ tags }) => tags).find(({ name }) => name === MANAGED_BY_SPINNAKER_TAG_NAME);
+
+  if (!managedTag) {
     return null;
   }
+
+  const {
+    value: { keelResourceId },
+  } = managedTag;
 
   const helpText = (
     <>
@@ -28,7 +42,11 @@ export const ManagedResourceDetailsIndicator = ({ entityTags }: IManagedResource
       </p>
       <p>
         Changes made in the UI will be stomped in favor of the existing declarative configuration.{' '}
-        <a href="https://www.spinnaker.io/reference/managed-delivery" target="_blank">
+        <a
+          target="_blank"
+          onClick={() => logClick('Learn More', keelResourceId)}
+          href="https://www.spinnaker.io/reference/managed-delivery"
+        >
           Learn More
         </a>
       </p>
@@ -36,11 +54,36 @@ export const ManagedResourceDetailsIndicator = ({ entityTags }: IManagedResource
   );
 
   return (
-    <HoverablePopover template={helpText} placement="left">
-      <div className="band band-info ManagedResourceDetailsIndicator">
-        <span className="icon">🌈</span>
-        Managed by Spinnaker
-      </div>
-    </HoverablePopover>
+    <div className="vertical middle center band band-info ManagedResourceDetailsIndicator">
+      <HoverablePopover template={helpText} placement="left">
+        <span className="summary-message horizontal sp-margin-s-bottom">
+          <span className="rainbow-icon">🌈</span>
+          Managed by Spinnaker
+        </span>
+      </HoverablePopover>
+      <Dropdown className="dropdown" id="server-group-managed-resource-dropdown" pullRight={true}>
+        <Dropdown.Toggle className="btn btn-sm btn-default dropdown-toggle">Resource Actions</Dropdown.Toggle>
+        <Dropdown.Menu className="dropdown-menu">
+          <li>
+            <a
+              target="_blank"
+              onClick={() => logClick('History', keelResourceId)}
+              href={`${SETTINGS.gateUrl}/history/${keelResourceId}`}
+            >
+              History
+            </a>
+          </li>
+          <li>
+            <a
+              target="_blank"
+              onClick={() => logClick('Raw Source', keelResourceId)}
+              href={`${SETTINGS.gateUrl}/managed/resources/${keelResourceId}`}
+            >
+              Raw Source
+            </a>
+          </li>
+        </Dropdown.Menu>
+      </Dropdown>
+    </div>
   );
 };


### PR DESCRIPTION
There's a couple bits of data about a resource we expect folks to care about early on: the event history of a resource, and the underlying config/definition for the resource that Keel has on file. This adds a dropdown to managed resources in the infrastructure views that lets folks see both, as new tabs with the raw JSON payload (opting for JSON instead of YAML to start, as we already do that across spinnaker and JSON is easy to use with the API ad-hoc). Design is quick and dirty for now, as we're not sure what we'll need in the coming months.

<img width="430" alt="Screen Shot 2019-09-04 at 10 37 45 AM" src="https://user-images.githubusercontent.com/1850998/64279279-87b2bc00-cf03-11e9-84ce-2a2ded0cfe1d.png">

<img width="442" alt="Screen Shot 2019-09-04 at 10 38 23 AM" src="https://user-images.githubusercontent.com/1850998/64279315-a1540380-cf03-11e9-94a1-a99bdc40dc2d.png">
