### PR TITLE
Bump package core to 0.0.406 and amazon to 0.0.209

### DIFF
--- a/app/scripts/modules/amazon/package.json
+++ b/app/scripts/modules/amazon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/amazon",
-  "version": "0.0.208",
+  "version": "0.0.209",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/core",
-  "version": "0.0.405",
+  "version": "0.0.406",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
### chore(core): Bump version to 0.0.406

d8f1a51e910e5f1ff6008ba14f78c56e9df80d77 fix(triggers): Protecting from undefined triggers (#7377)
ad4c1447c6134b8c823d9b92f12364754a11168a feat(core/managed): Add resource dropdown with links to history + source JSON (#7376)
3665d3ec9387764573162a62c20f938e94002073 fix(typos): fix a few typos in help messages (#7373)

### chore(amazon): Bump version to 0.0.209

373f581e0689a0e1d3873c7b4cc6948fafadcf8e fix(titus): Removing NLB as it is not compatible with Titus (#7317)


