### PR TITLE
fix(google): add default gce instance type disk constants to front end

### DIFF
--- a/app/scripts/modules/google/src/instance/gceInstanceType.service.js
+++ b/app/scripts/modules/google/src/instance/gceInstanceType.service.js
@@ -5,6 +5,8 @@ import _ from 'lodash';
 
 import { AccountService, SETTINGS } from '@spinnaker/core';
 
+import { GCE_INSTANCE_TYPE_DISK_DEFAULTS } from './gceInstanceTypeDisks';
+
 module.exports = angular.module('spinnaker.gce.instanceType.service', []).factory('gceInstanceTypeService', [
   '$http',
   '$q',
@@ -237,7 +239,10 @@ module.exports = angular.module('spinnaker.gce.instanceType.service', []).factor
       const initializedCategories = _.cloneDeep(categories);
       return AccountService.getAllAccountDetailsForProvider('gce').then(accountDetails => {
         // All GCE accounts have the same instance type disk defaults, so we can pick the first one.
-        const instanceTypeDisks = _.get(accountDetails, '[0].instanceTypeDisks');
+        let instanceTypeDisks = _.get(accountDetails, '[0].instanceTypeDisks');
+        if (_.isEmpty(instanceTypeDisks)) {
+          instanceTypeDisks = GCE_INSTANCE_TYPE_DISK_DEFAULTS;
+        }
         if (instanceTypeDisks) {
           const families = _.flatten(initializedCategories.map(category => category.families));
           families.forEach(family => {

--- a/app/scripts/modules/google/src/instance/gceInstanceTypeDisks.ts
+++ b/app/scripts/modules/google/src/instance/gceInstanceTypeDisks.ts
@@ -1,0 +1,177 @@
+// Duplicated from https://github.com/spinnaker/clouddriver/blob/master/clouddriver-web/config/clouddriver.yml
+// TODO(mneterval): remove after resolution of https://github.com/spinnaker/spinnaker/issues/4859
+export const GCE_INSTANCE_TYPE_DISK_DEFAULTS = Object.freeze([
+  {
+    instanceType: 'n1-standard-1',
+    disks: [
+      {
+        type: 'pd-ssd',
+        sizeGb: 10,
+      },
+    ],
+  },
+  {
+    instanceType: 'n1-standard-2',
+    disks: [
+      {
+        type: 'pd-ssd',
+        sizeGb: 10,
+      },
+    ],
+  },
+  {
+    instanceType: 'n1-standard-4',
+    disks: [
+      {
+        type: 'pd-ssd',
+        sizeGb: 10,
+      },
+    ],
+  },
+  {
+    instanceType: 'n1-standard-8',
+    disks: [
+      {
+        type: 'pd-ssd',
+        sizeGb: 10,
+      },
+    ],
+  },
+  {
+    instanceType: 'n1-standard-16',
+    disks: [
+      {
+        type: 'pd-ssd',
+        sizeGb: 10,
+      },
+    ],
+  },
+  {
+    instanceType: 'n1-standard-32',
+    disks: [
+      {
+        type: 'pd-ssd',
+        sizeGb: 10,
+      },
+    ],
+  },
+  {
+    instanceType: 'f1-micro',
+    supportsLocalSSD: false,
+    disks: [
+      {
+        type: 'pd-standard',
+        sizeGb: 10,
+      },
+    ],
+  },
+  {
+    instanceType: 'g1-small',
+    supportsLocalSSD: false,
+    disks: [
+      {
+        type: 'pd-standard',
+        sizeGb: 10,
+      },
+    ],
+  },
+  {
+    instanceType: 'n1-highmem-2',
+    disks: [
+      {
+        type: 'pd-ssd',
+        sizeGb: 10,
+      },
+    ],
+  },
+  {
+    instanceType: 'n1-highmem-4',
+    disks: [
+      {
+        type: 'pd-ssd',
+        sizeGb: 10,
+      },
+    ],
+  },
+  {
+    instanceType: 'n1-highmem-8',
+    disks: [
+      {
+        type: 'pd-ssd',
+        sizeGb: 10,
+      },
+    ],
+  },
+  {
+    instanceType: 'n1-highmem-16',
+    disks: [
+      {
+        type: 'pd-ssd',
+        sizeGb: 10,
+      },
+    ],
+  },
+  {
+    instanceType: 'n1-highmem-32',
+    disks: [
+      {
+        type: 'pd-ssd',
+        sizeGb: 10,
+      },
+    ],
+  },
+  {
+    instanceType: 'n1-highcpu-2',
+    disks: [
+      {
+        type: 'pd-ssd',
+        sizeGb: 10,
+      },
+    ],
+  },
+  {
+    instanceType: 'n1-highcpu-4',
+    disks: [
+      {
+        type: 'pd-ssd',
+        sizeGb: 10,
+      },
+    ],
+  },
+  {
+    instanceType: 'n1-highcpu-8',
+    disks: [
+      {
+        type: 'pd-ssd',
+        sizeGb: 10,
+      },
+    ],
+  },
+  {
+    instanceType: 'n1-highcpu-16',
+    disks: [
+      {
+        type: 'pd-ssd',
+        sizeGb: 10,
+      },
+    ],
+  },
+  {
+    instanceType: 'n1-highcpu-32',
+    disks: [
+      {
+        type: 'pd-ssd',
+        sizeGb: 10,
+      },
+    ],
+  },
+  {
+    instanceType: 'default',
+    disks: [
+      {
+        type: 'pd-ssd',
+        sizeGb: 10,
+      },
+    ],
+  },
+]);


### PR DESCRIPTION
Band-aid for https://github.com/spinnaker/spinnaker/issues/4859.
Should be reverted pending investigation of root cause.