### PR TITLE
fix(kubernetes): remove former 24-char limit on services names

### DIFF
--- a/app/scripts/modules/kubernetes/src/loadBalancer/configure/wizard/basicSettings.html
+++ b/app/scripts/modules/kubernetes/src/loadBalancer/configure/wizard/basicSettings.html
@@ -14,7 +14,7 @@
         <input
           type="text"
           style="display: none"
-          ng-maxlength="24"
+          ng-maxlength="63"
           class="form-control input-sm"
           ng-model="loadBalancer.name"
           validate-unique="existingLoadBalancerNames"
@@ -83,7 +83,7 @@
       </div>
       <div class="form-group">
         <div class="col-md-9 col-md-offset-3" ng-if="form.loadBalancerName.$error.maxlength">
-          <validation-error message="Load Balancer name can only be 24 characters."></validation-error>
+          <validation-error message="Load Balancer name can only be 63 characters."></validation-error>
         </div>
       </div>
     </div>

--- a/app/scripts/modules/kubernetes/src/validation/applicationName.validator.js
+++ b/app/scripts/modules/kubernetes/src/validation/applicationName.validator.js
@@ -23,31 +23,16 @@ module.exports = angular
     }
 
     function validateLength(name, warnings, errors) {
-      // Kubernetes resource names must match [a-z]([-a-z0-9]*[a-z0-9])?
+      // general k8s resource restriction: 253 characters - https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+      // safe bet is 63 characters - (see also RFC 1035 or RFC 1123 - both setting DNS label maximum to 63 chars)
+      // for service names: - https://github.com/kubernetes/kubernetes/pull/29523 (until K8s 1.4.0 it was 24 characters https://github.com/kubernetes/kubernetes/issues/12463)
+      // or annotations:    - https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set
+
       let maxResourceNameLength = 63;
 
-      let maxServiceNameLength = 24;
-
       if (name.length > maxResourceNameLength) {
-        errors.push('The maximum length for an application in Kubernetes is 63 characters.');
+        errors.push('The maximum length for an application in Kubernetes is ${maxResourceNameLength} characters.');
         return;
-      }
-
-      if (name.length > maxServiceNameLength) {
-        if (name.length > maxServiceNameLength) {
-          warnings.push(`You will not be able to create a Kubernetes load balancer for this application if the
-            application's name is longer than ${maxServiceNameLength} characters (currently: ${name.length}
-          characters).`);
-        } else if (name.length >= maxServiceNameLength - 2) {
-          warnings.push(
-            'With separators ("-"), you will not be able to include a stack and detail field for ' +
-              'Kubernetes load balancers.',
-          );
-        } else {
-          let remaining = maxServiceNameLength - 2 - name.length;
-          warnings.push(`If you plan to include a stack or detail field for Kubernetes load balancers, you will only
-            have ~${remaining} characters to do so.`);
-        }
       }
     }
 

--- a/app/scripts/modules/kubernetes/src/validation/applicationName.validator.js
+++ b/app/scripts/modules/kubernetes/src/validation/applicationName.validator.js
@@ -28,7 +28,7 @@ module.exports = angular
       // for service names: - https://github.com/kubernetes/kubernetes/pull/29523 (until K8s 1.4.0 it was 24 characters https://github.com/kubernetes/kubernetes/issues/12463)
       // or annotations:    - https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set
 
-      let maxResourceNameLength = 63;
+      const maxResourceNameLength = 63;
 
       if (name.length > maxResourceNameLength) {
         errors.push('The maximum length for an application in Kubernetes is ${maxResourceNameLength} characters.');


### PR DESCRIPTION
This PR removes the 24 character limitation on application name length for Kubernetes providers that got into deck with PR #2102 
According to various ressource (some of them mentioned in the code) that limitation is not in place since May 2016 or k8s > 1.4.0.

This change has been discussed in Slack prior to it being opened.