### PR TITLE
fix(core): Exporting DiffView component

### DIFF
--- a/app/scripts/modules/core/src/pipeline/index.ts
+++ b/app/scripts/modules/core/src/pipeline/index.ts
@@ -1,4 +1,5 @@
 export * from './config/PipelineRegistry';
+export * from './config/actions/history/DiffView';
 export * from './config/services/PipelineConfigService';
 export * from './config/stages/bake/BakeExecutionLabel';
 export * from './config/stages/bake/BakeryReader';


### PR DESCRIPTION
Since the angular one was removed, exporting the react one so it can be imported from `@spinnaker/core`