### PR TITLE
feat(pipeline): Custom alert for start manual execution dialog

### DIFF
--- a/app/scripts/modules/core/src/domain/IPipeline.ts
+++ b/app/scripts/modules/core/src/domain/IPipeline.ts
@@ -15,6 +15,7 @@ export interface IPipeline {
   lastModifiedBy?: string;
   locked?: IPipelineLock;
   limitConcurrent: boolean;
+  manualStartAlert?: IPipelineManualStartAlert;
   name: string;
   notifications?: INotification[];
   respectQuietPeriod?: boolean;
@@ -32,6 +33,11 @@ export interface IPipeline {
   };
   type?: string;
   updateTs?: number;
+}
+
+export interface IPipelineManualStartAlert {
+  type: 'danger' | 'warning' | 'info';
+  message: string;
 }
 
 export interface IPipelineLock {

--- a/app/scripts/modules/core/src/pipeline/manualExecution/ManualPipelineExecutionModal.tsx
+++ b/app/scripts/modules/core/src/pipeline/manualExecution/ManualPipelineExecutionModal.tsx
@@ -8,7 +8,7 @@ import { assign, clone, compact, extend, get, head, uniq, isArray, pickBy } from
 import { SubmitButton, ModalClose } from 'core/modal';
 import { Application } from 'core/application';
 import { AuthenticationService } from 'core/authentication';
-import { buildValidators, IModalComponentProps, ReactModal, SpinFormik } from 'core/presentation';
+import { buildValidators, IModalComponentProps, ReactModal, SpinFormik, Markdown } from 'core/presentation';
 import {
   IExecution,
   IExecutionTrigger,
@@ -325,6 +325,7 @@ export class ManualExecutionModal extends React.Component<IManualExecutionModalP
       triggerComponent,
       triggers,
     } = this.state;
+    const { manualStartAlert } = pipeline;
     const notifications = applicationNotifications.concat(pipelineNotifications);
     const pipelineCommand = this.generateInitialValues(pipeline);
     return (
@@ -364,6 +365,14 @@ export class ManualExecutionModal extends React.Component<IManualExecutionModalP
                 )}
                 {currentPipelineExecutions.length > 0 && (
                   <CurrentlyRunningExecutions currentlyRunningExecutions={currentPipelineExecutions} />
+                )}
+                {manualStartAlert && (
+                  <Markdown
+                    className={`alert alert-${
+                      ['danger', 'warning', 'info'].includes(manualStartAlert.type) ? manualStartAlert.type : 'warning'
+                    }`}
+                    message={manualStartAlert.message}
+                  />
                 )}
                 {triggers && triggers.length > 0 && (
                   <Triggers


### PR DESCRIPTION
Allows pipelines to provide extra information/context to users manually triggering the pipeline.
![Screenshot 2019-09-13 at 4 12 14 PM](https://user-images.githubusercontent.com/1633736/64899642-46c45100-d641-11e9-99d5-ef45fa646f1b.png)

Can also be injected when we're programatically opening the start manual execution modal.