### PR TITLE
fix(amazon): Fix compatibility when cloudProviders missing

### DIFF
--- a/app/scripts/modules/amazon/src/loadBalancer/configure/AmazonLoadBalancerChoiceModal.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/AmazonLoadBalancerChoiceModal.tsx
@@ -84,7 +84,7 @@ export class AmazonLoadBalancerChoiceModal extends React.Component<
     }
 
     // If the list of cloud providers is empty, assume it is compatible by default
-    return true;
+    return false;
   }
 
   public render() {


### PR DESCRIPTION
Refactored this method a couple times and accidentally ended up with the wrong boolean.

As the comment states, when cloudProviders is missing (as in an empty array), we want to assume it is compatible. This means `isIncompatibleWithAllProviders` should be `false`. Accidentally left it as `true` from when this method was "is compatible" instead of "is incompatible".