### PR TITLE
Bump package core to 0.0.409 and amazon to 0.0.212 and titus to 0.0.111

### DIFF
--- a/app/scripts/modules/amazon/package.json
+++ b/app/scripts/modules/amazon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/amazon",
-  "version": "0.0.211",
+  "version": "0.0.212",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/core",
-  "version": "0.0.408",
+  "version": "0.0.409",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/titus/package.json
+++ b/app/scripts/modules/titus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/titus",
-  "version": "0.0.110",
+  "version": "0.0.111",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
### chore(core): Bump version to 0.0.409

b396658cc8a0f400bb2dadd474bb3e355573284c fix(core): fix manual execution (#7408)
476ad6255f4e871d8d6d7de3672f42b683533eaf feat(pipeline): Custom alert for start manual execution dialog (#7406)
ec1d32f27ce1ca9d04a4c6bde0c44227a9eb74fd fix(help): reflect reality in rollingredblack help text bubble-things (#7405)
23540b61003d8eb08c73ee9e53d6ff15e69c5ecd fix(nexus): nexus trigger selectable in UI (#7381)

### chore(amazon): Bump version to 0.0.212

2821438ce34f1676620bad6f66b13feec7b95f07 fix(amazon): Fix compatibility when cloudProviders missing (#7410)

### chore(titus): Bump version to 0.0.111

f491ac69f3ed00b3afed738d4ffba0e5f34b8259 feat(titus): direct link to stdout and stderr (#7400)


