### PR TITLE
fix(core/pipeline): standardize manual execution field layouts

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/bake/ManualExecutionBake.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/bake/ManualExecutionBake.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { get } from 'lodash';
 
+import { FormField, CheckboxInput } from 'core/presentation';
 import { HelpField } from 'core/help/HelpField';
 import { ITriggerTemplateComponentProps } from 'core/pipeline/manualExecution/TriggerTemplate';
 
@@ -16,17 +17,13 @@ export class ManualExecutionBake extends React.Component<ITriggerTemplateCompone
     const force = get(this.props.command, 'trigger.rebake', false);
 
     return (
-      <div className="form-group">
-        <label className="col-md-4 sm-label-right">
-          Rebake <HelpField id="execution.forceRebake" />
-        </label>
-        <div className="checkbox col-md-6">
-          <label>
-            <input type="checkbox" checked={force} onChange={this.handleChange} />
-            Force Rebake
-          </label>
-        </div>
-      </div>
+      <FormField
+        label="Rebake"
+        onChange={this.handleChange}
+        value={force}
+        help={<HelpField id="execution.forceRebake" />}
+        input={props => <CheckboxInput {...props} text="Force Rebake" />}
+      />
     );
   }
 }

--- a/app/scripts/modules/core/src/pipeline/config/stages/bake/ManualExecutionBake.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/bake/ManualExecutionBake.tsx
@@ -17,13 +17,14 @@ export class ManualExecutionBake extends React.Component<ITriggerTemplateCompone
 
     return (
       <div className="form-group">
-        <label className="col-md-4 sm-label-right">Rebake</label>
+        <label className="col-md-4 sm-label-right">
+          Rebake <HelpField id="execution.forceRebake" />
+        </label>
         <div className="checkbox col-md-6">
           <label>
             <input type="checkbox" checked={force} onChange={this.handleChange} />
             Force Rebake
-          </label>{' '}
-          <HelpField id="execution.forceRebake" />
+          </label>
         </div>
       </div>
     );

--- a/app/scripts/modules/core/src/pipeline/manualExecution/DryRun.tsx
+++ b/app/scripts/modules/core/src/pipeline/manualExecution/DryRun.tsx
@@ -2,16 +2,17 @@ import * as React from 'react';
 import { CheckboxInput, FormikFormField } from 'core/presentation';
 import { HelpField } from 'core/help';
 
-export class DryRun extends React.Component {
-  public render() {
-    return (
+export const DryRun = () => (
+  <div className="form-group">
+    <label className="col-md-4 sm-label-right">
+      Dry run <HelpField id="execution.dryRun" />
+    </label>
+    <div className="col-md-6">
       <FormikFormField
         name="dryRun"
-        label={'Dry run'}
         fastField={false}
-        help={<HelpField id={'execution.dryRun'} />}
-        input={props => <CheckboxInput {...props} text={'Run a test execution'} />}
+        input={props => <CheckboxInput {...props} text="Run a test execution" />}
       />
-    );
-  }
-}
+    </div>
+  </div>
+);

--- a/app/scripts/modules/core/src/pipeline/manualExecution/DryRun.tsx
+++ b/app/scripts/modules/core/src/pipeline/manualExecution/DryRun.tsx
@@ -3,16 +3,11 @@ import { CheckboxInput, FormikFormField } from 'core/presentation';
 import { HelpField } from 'core/help';
 
 export const DryRun = () => (
-  <div className="form-group">
-    <label className="col-md-4 sm-label-right">
-      Dry run <HelpField id="execution.dryRun" />
-    </label>
-    <div className="col-md-6">
-      <FormikFormField
-        name="dryRun"
-        fastField={false}
-        input={props => <CheckboxInput {...props} text="Run a test execution" />}
-      />
-    </div>
-  </div>
+  <FormikFormField
+    name="dryRun"
+    label="Dry run"
+    fastField={false}
+    help={<HelpField id="execution.dryRun" />}
+    input={props => <CheckboxInput {...props} text="Run a test execution" />}
+  />
 );

--- a/app/scripts/modules/core/src/pipeline/manualExecution/ManualPipelineExecutionModal.tsx
+++ b/app/scripts/modules/core/src/pipeline/manualExecution/ManualPipelineExecutionModal.tsx
@@ -8,7 +8,14 @@ import { assign, clone, compact, extend, get, head, uniq, isArray, pickBy } from
 import { SubmitButton, ModalClose } from 'core/modal';
 import { Application } from 'core/application';
 import { AuthenticationService } from 'core/authentication';
-import { buildValidators, IModalComponentProps, ReactModal, SpinFormik, Markdown } from 'core/presentation';
+import {
+  buildValidators,
+  IModalComponentProps,
+  ReactModal,
+  SpinFormik,
+  Markdown,
+  LayoutProvider,
+} from 'core/presentation';
 import {
   IExecution,
   IExecutionTrigger,
@@ -25,6 +32,7 @@ import { Registry } from 'core/registry';
 import { SETTINGS } from 'core/config/settings';
 import { UrlParser } from 'core/navigation/urlParser';
 
+import { ManualExecutionFieldLayout } from './layout/ManualExecutionFieldLayout';
 import { PipelineOptions } from './PipelineOptions';
 import { CurrentlyRunningExecutions } from './CurrentlyRunningExecutions';
 import { StageManualComponents } from './StageManualComponents';
@@ -340,74 +348,76 @@ export class ManualExecutionModal extends React.Component<IManualExecutionModalP
               <Modal.Title>{modalHeader}</Modal.Title>
             </Modal.Header>
             <Modal.Body>
-              <div className="container-fluid modal-body-content">
-                {pipelineOptions.length > 0 && (
-                  <PipelineOptions
-                    formik={formik}
-                    formatPipeline={this.formatPipeline}
-                    formatTriggers={this.formatTriggers}
-                    formatParameterConfig={this.formatParameterConfig}
-                    pipelineOptions={pipelineOptions}
-                    pipelineChanged={this.pipelineChanged}
-                    triggerChanged={this.triggerChanged}
-                    updateTriggerOptions={this.updateTriggerOptions}
-                  />
-                )}
-                {formik.values.pipeline && (
-                  <div className="form-group">
-                    <div className="col-md-10">
-                      <p>
-                        This will start a new run of <strong>{formik.values.pipeline.name}</strong>.
-                      </p>
-                    </div>
-                  </div>
-                )}
-                {currentPipelineExecutions.length > 0 && (
-                  <CurrentlyRunningExecutions currentlyRunningExecutions={currentPipelineExecutions} />
-                )}
-                {pipeline && pipeline.manualStartAlert && (
-                  <Markdown
-                    className={`alert alert-${
-                      ['danger', 'warning', 'info'].includes(pipeline.manualStartAlert.type)
-                        ? pipeline.manualStartAlert.type
-                        : 'warning'
-                    }`}
-                    message={pipeline.manualStartAlert.message}
-                  />
-                )}
-                {triggers && triggers.length > 0 && (
-                  <Triggers
-                    formik={formik}
-                    triggers={triggers}
-                    triggerChanged={this.triggerChanged}
-                    triggerComponent={triggerComponent}
-                  />
-                )}
-                {formik.values.pipeline &&
-                  formik.values.pipeline.parameterConfig &&
-                  formik.values.pipeline.parameterConfig.length > 0 && (
-                    <Parameters formik={formik} parameters={formik.values.pipeline.parameterConfig} />
+              <LayoutProvider value={ManualExecutionFieldLayout}>
+                <div className="container-fluid modal-body-content">
+                  {pipelineOptions.length > 0 && (
+                    <PipelineOptions
+                      formik={formik}
+                      formatPipeline={this.formatPipeline}
+                      formatTriggers={this.formatTriggers}
+                      formatParameterConfig={this.formatParameterConfig}
+                      pipelineOptions={pipelineOptions}
+                      pipelineChanged={this.pipelineChanged}
+                      triggerChanged={this.triggerChanged}
+                      updateTriggerOptions={this.updateTriggerOptions}
+                    />
                   )}
-                {stageComponents.length > 0 && (
-                  <StageManualComponents
-                    command={formik.values}
-                    components={stageComponents}
-                    updateCommand={(path: string, value: any) => {
-                      formik.setFieldValue(path, value);
-                    }}
-                  />
-                )}
-                {formik.values.trigger && formik.values.trigger.artifacts && (
-                  <div className="form-group">
-                    <label className="col-md-4 sm-label-right">Artifacts</label>
-                    <div className="col-md-8">
-                      <ArtifactList artifacts={formik.values.trigger.artifacts} />
+                  {formik.values.pipeline && (
+                    <div className="form-group">
+                      <div className="col-md-6 col-md-offset-4">
+                        <p>
+                          This will start a new run of <strong>{formik.values.pipeline.name}</strong>.
+                        </p>
+                      </div>
                     </div>
-                  </div>
-                )}
-                {dryRunEnabled && <DryRun />}
-                <NotificationDetails formik={formik} notifications={notifications} />
-              </div>
+                  )}
+                  {currentPipelineExecutions.length > 0 && (
+                    <CurrentlyRunningExecutions currentlyRunningExecutions={currentPipelineExecutions} />
+                  )}
+                  {pipeline && pipeline.manualStartAlert && (
+                    <Markdown
+                      className={`alert alert-${
+                        ['danger', 'warning', 'info'].includes(pipeline.manualStartAlert.type)
+                          ? pipeline.manualStartAlert.type
+                          : 'warning'
+                      }`}
+                      message={pipeline.manualStartAlert.message}
+                    />
+                  )}
+                  {triggers && triggers.length > 0 && (
+                    <Triggers
+                      formik={formik}
+                      triggers={triggers}
+                      triggerChanged={this.triggerChanged}
+                      triggerComponent={triggerComponent}
+                    />
+                  )}
+                  {formik.values.pipeline &&
+                    formik.values.pipeline.parameterConfig &&
+                    formik.values.pipeline.parameterConfig.length > 0 && (
+                      <Parameters formik={formik} parameters={formik.values.pipeline.parameterConfig} />
+                    )}
+                  {stageComponents.length > 0 && (
+                    <StageManualComponents
+                      command={formik.values}
+                      components={stageComponents}
+                      updateCommand={(path: string, value: any) => {
+                        formik.setFieldValue(path, value);
+                      }}
+                    />
+                  )}
+                  {formik.values.trigger && formik.values.trigger.artifacts && (
+                    <div className="form-group">
+                      <label className="col-md-4 sm-label-right">Artifacts</label>
+                      <div className="col-md-8">
+                        <ArtifactList artifacts={formik.values.trigger.artifacts} />
+                      </div>
+                    </div>
+                  )}
+                  {dryRunEnabled && <DryRun />}
+                  <NotificationDetails formik={formik} notifications={notifications} />
+                </div>
+              </LayoutProvider>
             </Modal.Body>
             <Modal.Footer>
               <button className="btn btn-default" onClick={dismissModal} type="button">

--- a/app/scripts/modules/core/src/pipeline/manualExecution/NotificationDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/manualExecution/NotificationDetails.tsx
@@ -3,11 +3,9 @@ import { FormikProps } from 'formik';
 import { Option } from 'react-select';
 
 import { INotification, INotificationTypeConfig, IPipelineCommand } from 'core/domain';
-import { CheckboxInput, FormikFormField, HoverablePopover, LayoutProvider } from 'core/presentation';
+import { CheckboxInput, FormikFormField, HoverablePopover } from 'core/presentation';
 import { Registry } from 'core/registry';
 import { NotificationSelector, NotificationTransformer } from 'core/notification';
-
-import { ManualExecutionFieldLayout } from './layout/ManualExecutionFieldLayout';
 
 export interface INotificationDetailsProps {
   formik: FormikProps<IPipelineCommand>;
@@ -65,16 +63,12 @@ export class NotificationDetails extends React.Component<INotificationDetailsPro
     const { values } = formik;
     return (
       <>
-        <div className={'form-group'}>
-          <label className={'col-md-4 sm-label-right'}>Notifications</label>
-          <div className="col-md-6">
-            <FormikFormField
-              name="notificationEnabled"
-              fastField={false}
-              input={props => <CheckboxInput {...props} text={'Notify me when the pipeline completes'} />}
-            />
-          </div>
-        </div>
+        <FormikFormField
+          name="notificationEnabled"
+          label="Notifications"
+          fastField={false}
+          input={props => <CheckboxInput {...props} text={'Notify me when the pipeline completes'} />}
+        />
         <div className="form-group">
           {notifications.length === 1 && (
             <div className="col-md-offset-4 col-md-6">
@@ -96,13 +90,11 @@ export class NotificationDetails extends React.Component<INotificationDetailsPro
           )}
         </div>
         {values.notificationEnabled && (
-          <LayoutProvider value={ManualExecutionFieldLayout}>
-            <NotificationSelector
-              onNotificationTypeChange={onNotificationTypeChange}
-              fieldName={'notification'}
-              type={values.notification.type}
-            />
-          </LayoutProvider>
+          <NotificationSelector
+            onNotificationTypeChange={onNotificationTypeChange}
+            fieldName={'notification'}
+            type={values.notification.type}
+          />
         )}
       </>
     );

--- a/app/scripts/modules/core/src/pipeline/manualExecution/PipelineOptions.tsx
+++ b/app/scripts/modules/core/src/pipeline/manualExecution/PipelineOptions.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import { Observable, Subject } from 'rxjs';
-import Select, { Option } from 'react-select';
+import { Option } from 'react-select';
 import { FormikProps } from 'formik';
 import { head } from 'lodash';
 
 import { IParameter, IPipeline, IPipelineCommand, ITrigger } from 'core/domain';
 import { IPipelineTemplateConfig, PipelineTemplateReader, PipelineTemplateV2Service } from 'core/pipeline';
-import { FormField } from 'core/presentation';
+import { FormField, TetheredSelect } from 'core/presentation';
 
 export interface IPipelineOptionsProps {
   formatParameterConfig: (p: IParameter[]) => { [key: string]: any };
@@ -106,14 +106,14 @@ export class PipelineOptions extends React.Component<IPipelineOptionsProps, IPip
       return (
         <div className="form-group row">
           <FormField
-            label={'Pipeline'}
+            label="Pipeline"
             onChange={this.pipelineSelected}
             value={formik.values.pipeline ? formik.values.pipeline.id : ''}
             input={props => (
-              <Select
+              <TetheredSelect
                 {...props}
                 clearable={false}
-                className={'pipeline-select'}
+                className="pipeline-select"
                 options={pipelineOptions.map(p => ({
                   label: p.name,
                   value: p.id,

--- a/app/scripts/modules/core/src/pipeline/manualExecution/Triggers.tsx
+++ b/app/scripts/modules/core/src/pipeline/manualExecution/Triggers.tsx
@@ -63,29 +63,27 @@ export class Triggers extends React.Component<ITriggersProps> {
     const { formik, triggerComponent, triggers } = this.props;
     return (
       <div className="form-group row">
-        <div className={'form-group'}>
-          <label className={'col-md-4 sm-label-right'}>Trigger</label>
-          <div className="col-md-6">
-            {triggers.length > 1 && (
-              <FormField
-                onChange={this.triggerSelected}
-                value={formik.values.trigger ? formik.values.trigger.description : ''}
-                input={props => (
-                  <Select
-                    {...props}
-                    className={'trigger-select'}
-                    clearable={false}
-                    options={triggers.map(t => ({
-                      label: t.description,
-                      value: t.description,
-                    }))}
-                  />
-                )}
-              />
-            )}
-            {triggers.length === 1 && <p className="form-control-static">{head(triggers).description}</p>}
-          </div>
-        </div>
+        <FormField
+          label="Trigger"
+          onChange={this.triggerSelected}
+          value={formik.values.trigger ? formik.values.trigger.description : ''}
+          input={props => (
+            <>
+              {triggers.length > 1 && (
+                <Select
+                  {...props}
+                  className="trigger-select"
+                  clearable={false}
+                  options={triggers.map(t => ({
+                    label: t.description,
+                    value: t.description,
+                  }))}
+                />
+              )}
+              {triggers.length === 1 && <p className="form-control-static">{head(triggers).description}</p>}
+            </>
+          )}
+        />
 
         {triggerComponent && (
           <div className={'trigger-template'}>


### PR DESCRIPTION
Most of the fields that end up inside a manual execution modal are currently either:
- A vanilla bootstrap layout + input with hand-rolled logic for everything
- A `FormField`/`FormikFormField` that sets up the input + state management, but doesn't have a label and uses vanilla bootstrap grids to add labels and layout.

When the modal itself got moved to react, one of the sub-components that got migrated was the dry run option, which got moved to a full-on `FormikFormField` with a `StandardFieldLayout`. Turns out that layout really does not play nicely with the existing standard bootstrap columns for the modal in a variety of ways — widths are off, flex layouts don't match, and snapping things to a stacked layout at small widths isn't consistent.

To get this fixed cosmetically for now, I'm moving the dry run field to use a pattern consistent with the other fields in this modal. I'd suggest that we should do two things, though I don't think they're super high priority:
1. Move all the vanilla inputs over to `FormField`/`FormikFormField` but keep the vanilla bootstrap layouts
2. Once ☝️is done, move all the bootstrap column layouts over to `StandardFieldLayout` so things change all at once rather than trying to interop between the two in weird ways

Just for funsies, I also made the help field on `Rebake` sit next to the label to be consistent with how we're trying to lay out help fields now.

**before:**
<img width="627" alt="Screen Shot 2019-09-19 at 8 25 00 AM" src="https://user-images.githubusercontent.com/1850998/65266972-faf22b80-dac8-11e9-96cd-b1019ffc9cbd.png">

**after:**
<img width="626" alt="Screen Shot 2019-09-19 at 9 24 52 AM" src="https://user-images.githubusercontent.com/1850998/65266986-03e2fd00-dac9-11e9-8eed-9dff71ddd4c4.png">
