### PR TITLE
chore(titus): Deprecating pipeline container migration strategy

### DIFF
--- a/app/scripts/modules/titus/src/migration/titusMigrationConfigurer.component.html
+++ b/app/scripts/modules/titus/src/migration/titusMigrationConfigurer.component.html
@@ -3,7 +3,7 @@
     <select
       class="form-control input-sm"
       ng-model="$ctrl.config.type"
-      ng-options="strategy as (strategy | robotToHuman) for strategy in $ctrl.migrationOptions"
+      ng-options="strategy as (strategy | robotToHuman) disable when strategy === 'pipeline' for strategy in $ctrl.migrationOptions"
       ng-change="$ctrl.updateType()"
     ></select>
   </div>


### PR DESCRIPTION
This will eventually be removed, but for now the ask is to make it not configurable.