### PR TITLE
fix(artifacts): Support custom artifacts with custom type

### DIFF
--- a/app/scripts/modules/core/src/artifact/react/ArtifactEditor.tsx
+++ b/app/scripts/modules/core/src/artifact/react/ArtifactEditor.tsx
@@ -3,6 +3,7 @@ import { cloneDeep, head } from 'lodash';
 import { IArtifactAccount } from 'core/account';
 import { ArtifactAccountSelector } from 'core/artifact';
 import { IArtifact, IPipeline } from 'core/domain';
+import { TYPE as CUSTOM_TYPE, CUSTOM_ARTIFACT_ACCOUNT } from 'core/pipeline/config/triggers/artifacts/custom';
 import { StageConfigField } from 'core/pipeline/config/stages/common';
 import { Registry } from 'core/registry';
 import { UUIDGenerator } from 'core/utils';
@@ -23,12 +24,19 @@ export class ArtifactEditor extends React.Component<IArtifactEditorProps> {
   private onArtifactAccountChanged = (artifactAccount: IArtifactAccount) => {
     // reset artifact fields if the account type has changed, so we don't leave dangling properties
     // that are not modifiable using the new artifact account type's form.
+
     const artifact: IArtifact =
-      this.props.artifact && (!this.props.artifact.type || artifactAccount.types.includes(this.props.artifact.type))
+      this.props.artifact &&
+      (!this.props.artifact.type ||
+        artifactAccount.types.includes(this.props.artifact.type) ||
+        (artifactAccount.name === CUSTOM_ARTIFACT_ACCOUNT &&
+          this.props.artifact.artifactAccount === artifactAccount.name))
         ? cloneDeep(this.props.artifact)
         : { id: UUIDGenerator.generateUuid() };
     artifact.artifactAccount = artifactAccount.name;
-    artifact.type = artifactAccount.types && artifactAccount.types.length > 0 ? artifactAccount.types[0] : '';
+    if (!artifact.type || artifactAccount.name !== CUSTOM_ARTIFACT_ACCOUNT) {
+      artifact.type = artifactAccount.types && artifactAccount.types.length > 0 ? artifactAccount.types[0] : '';
+    }
     this.props.onArtifactEdit(artifact);
   };
 
@@ -36,7 +44,9 @@ export class ArtifactEditor extends React.Component<IArtifactEditorProps> {
     const { artifact, artifactAccounts } = this.props;
     if (!artifact.artifactAccount && artifactAccounts.length > 0) {
       this.onArtifactAccountChanged(
-        head(artifactAccounts.filter(a => a.types.includes(artifact.type))) || head(artifactAccounts),
+        head(artifactAccounts.filter(a => a.types.includes(artifact.type))) ||
+          head(artifactAccounts.filter(a => a.types.includes(CUSTOM_TYPE))) ||
+          head(artifactAccounts),
       );
     }
   }

--- a/app/scripts/modules/core/src/artifact/react/ArtifactEditor.tsx
+++ b/app/scripts/modules/core/src/artifact/react/ArtifactEditor.tsx
@@ -29,8 +29,7 @@ export class ArtifactEditor extends React.Component<IArtifactEditorProps> {
       this.props.artifact &&
       (!this.props.artifact.type ||
         artifactAccount.types.includes(this.props.artifact.type) ||
-        (artifactAccount.name === CUSTOM_ARTIFACT_ACCOUNT &&
-          this.props.artifact.artifactAccount === artifactAccount.name))
+        artifactAccount.name === CUSTOM_ARTIFACT_ACCOUNT)
         ? cloneDeep(this.props.artifact)
         : { id: UUIDGenerator.generateUuid() };
     artifact.artifactAccount = artifactAccount.name;

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/ArtifactEditor.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/ArtifactEditor.ts
@@ -5,7 +5,7 @@ import { cloneDeep } from 'lodash';
 export class ArtifactEditor extends React.Component<IArtifactEditorProps, IArtifactEditorState> {
   protected constructor(props: IArtifactEditorProps, type: string) {
     super(props);
-    if (props.artifact.type !== type) {
+    if (props.artifact.type !== type && props.artifact.artifactAccount !== 'custom-artifact') {
       const clonedArtifact = cloneDeep(props.artifact);
       clonedArtifact.type = type;
       clonedArtifact.customKind = false;

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/custom/CustomArtifactEditor.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/custom/CustomArtifactEditor.tsx
@@ -7,9 +7,93 @@ import { StageConfigField } from 'core/pipeline';
 import { SpelText } from 'core/widgets';
 
 import { ArtifactEditor } from '../ArtifactEditor';
-import { singleFieldArtifactEditor } from '../singleFieldArtifactEditor';
 
-const TYPE = 'custom/object';
+export const TYPE = 'custom/object';
+export const CUSTOM_ARTIFACT_ACCOUNT = 'custom-artifact';
+
+export class CustomArtifactEditor extends ArtifactEditor {
+  constructor(props: IArtifactEditorProps) {
+    super(props, TYPE);
+  }
+
+  private onTypeChanged = (type: string) => {
+    this.updateArtifact({ type });
+  };
+
+  private onNameChanged = (name: string) => {
+    this.updateArtifact({ name });
+  };
+
+  private onVersionChanged = (version: string) => {
+    this.updateArtifact({ version });
+  };
+
+  private onLocationChanged = (location: string) => {
+    this.updateArtifact({ location });
+  };
+
+  private onReferenceChanged = (reference: string) => {
+    this.updateArtifact({ reference });
+  };
+
+  private updateArtifact = (changes: any) => {
+    const clonedArtifact = cloneDeep(this.props.artifact);
+    extend(clonedArtifact, changes);
+    this.props.onChange(clonedArtifact);
+  };
+
+  public render() {
+    return (
+      <>
+        <StageConfigField label="Type">
+          <SpelText
+            placeholder=""
+            value={this.props.artifact.type}
+            onChange={this.onTypeChanged}
+            pipeline={this.props.pipeline}
+            docLink={true}
+          />
+        </StageConfigField>
+        <StageConfigField label="Name">
+          <SpelText
+            placeholder=""
+            value={this.props.artifact.name}
+            onChange={this.onNameChanged}
+            pipeline={this.props.pipeline}
+            docLink={true}
+          />
+        </StageConfigField>
+        <StageConfigField label="Version">
+          <SpelText
+            placeholder=""
+            value={this.props.artifact.version}
+            onChange={this.onVersionChanged}
+            pipeline={this.props.pipeline}
+            docLink={true}
+          />
+        </StageConfigField>
+        <StageConfigField label="Location">
+          <SpelText
+            placeholder=""
+            value={this.props.artifact.location}
+            onChange={this.onLocationChanged}
+            pipeline={this.props.pipeline}
+            docLink={true}
+          />
+        </StageConfigField>
+        <StageConfigField label="Reference">
+          <SpelText
+            placeholder=""
+            value={this.props.artifact.reference}
+            onChange={this.onReferenceChanged}
+            pipeline={this.props.pipeline}
+            docLink={true}
+          />
+        </StageConfigField>
+      </>
+    );
+  }
+}
 
 export const CustomMatch: IArtifactKindConfig = {
   label: 'Custom',
@@ -19,7 +103,7 @@ export const CustomMatch: IArtifactKindConfig = {
   key: 'custom',
   isDefault: false,
   isMatch: true,
-  editCmp: singleFieldArtifactEditor('name', TYPE, 'Reference', '', ''),
+  editCmp: CustomArtifactEditor,
 };
 
 export const CustomDefault: IArtifactKindConfig = {
@@ -30,87 +114,5 @@ export const CustomDefault: IArtifactKindConfig = {
   key: 'default.custom',
   isDefault: true,
   isMatch: false,
-  editCmp: class extends ArtifactEditor {
-    constructor(props: IArtifactEditorProps) {
-      super(props, TYPE);
-    }
-
-    private onTypeChanged = (type: string) => {
-      this.updateArtifact({ type });
-    };
-
-    private onNameChanged = (name: string) => {
-      this.updateArtifact({ name });
-    };
-
-    private onVersionChanged = (version: string) => {
-      this.updateArtifact({ version });
-    };
-
-    private onLocationChanged = (location: string) => {
-      this.updateArtifact({ location });
-    };
-
-    private onReferenceChanged = (reference: string) => {
-      this.updateArtifact({ reference });
-    };
-
-    private updateArtifact = (changes: any) => {
-      const clonedArtifact = cloneDeep(this.props.artifact);
-      extend(clonedArtifact, changes);
-      this.props.onChange(clonedArtifact);
-    };
-
-    public render() {
-      return (
-        <>
-          <StageConfigField label="Type">
-            <SpelText
-              placeholder=""
-              value={this.props.artifact.type}
-              onChange={this.onTypeChanged}
-              pipeline={this.props.pipeline}
-              docLink={true}
-            />
-          </StageConfigField>
-          <StageConfigField label="Name">
-            <SpelText
-              placeholder=""
-              value={this.props.artifact.name}
-              onChange={this.onNameChanged}
-              pipeline={this.props.pipeline}
-              docLink={true}
-            />
-          </StageConfigField>
-          <StageConfigField label="Version">
-            <SpelText
-              placeholder=""
-              value={this.props.artifact.version}
-              onChange={this.onVersionChanged}
-              pipeline={this.props.pipeline}
-              docLink={true}
-            />
-          </StageConfigField>
-          <StageConfigField label="Location">
-            <SpelText
-              placeholder=""
-              value={this.props.artifact.location}
-              onChange={this.onLocationChanged}
-              pipeline={this.props.pipeline}
-              docLink={true}
-            />
-          </StageConfigField>
-          <StageConfigField label="Reference">
-            <SpelText
-              placeholder=""
-              value={this.props.artifact.reference}
-              onChange={this.onReferenceChanged}
-              pipeline={this.props.pipeline}
-              docLink={true}
-            />
-          </StageConfigField>
-        </>
-      );
-    }
-  },
+  editCmp: CustomArtifactEditor,
 };

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/custom/index.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/custom/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2019 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from './CustomArtifactEditor';


### PR DESCRIPTION
Some recent changes to the Expected Artifacts feature has severely broken backwards compatibility with artifacts that have a custom type (for instance Igor can create artifacts with type `deb` or `rpm`). This commit will make Deck be more lenient when it encounters legacy artifacts that does not strictly adhere to the new standard. It will also add back the UI fields `type`, `name`, `version` and `location` for custom artifacts.