### PR TITLE
fix(pipeline): Fix NPE in stage requisiteStageRefIds

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/services/PipelineConfigService.ts
+++ b/app/scripts/modules/core/src/pipeline/config/services/PipelineConfigService.ts
@@ -139,6 +139,7 @@ export class PipelineConfigService {
         stage !== stageToTest &&
         stageToTest.requisiteStageRefIds &&
         !downstreamIds.includes(stageToTest.refId) &&
+        stage.requisiteStageRefIds &&
         !stage.requisiteStageRefIds.includes(stageToTest.refId)
       );
     });


### PR DESCRIPTION
Some pipelines that where generated in some older version of deck (or maybe someone what carving them manually), if the `requisiteStageRefIds` in a stage object does not exist it will throw a NPE in the console and fail to render the pipeline.
Evaluating if the variable is defined before calling a function on it fixes the issue.