### PR TITLE
fix(core/pipeline): Fix execution details chevron for grouped stages

### DIFF
--- a/app/scripts/modules/core/src/pipeline/executions/execution/Execution.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/execution/Execution.tsx
@@ -264,9 +264,9 @@ export class Execution extends React.PureComponent<IExecutionProps, IExecutionSt
     ReactGA.event({ category: 'Pipeline', action: 'Execution source clicked' });
   };
 
-  private handleToggleDetails = (): void => {
+  private handleToggleDetails = (showingDetails: boolean): void => {
     ReactGA.event({ category: 'Pipeline', action: 'Execution details toggled (Details link)' });
-    this.toggleDetails();
+    showingDetails ? this.toggleDetails() : this.toggleDetails(0, 0);
   };
 
   private scrollIntoView = (forceScroll = false) => {
@@ -435,7 +435,7 @@ export class Execution extends React.PureComponent<IExecutionProps, IExecutionSt
 
           {!standalone && (
             <div className="execution-details-button">
-              <a className="clickable" onClick={this.handleToggleDetails}>
+              <a className="clickable" onClick={() => this.handleToggleDetails(showingDetails)}>
                 <span
                   className={`small glyphicon ${showingDetails ? 'glyphicon-chevron-down' : 'glyphicon-chevron-right'}`}
                 />


### PR DESCRIPTION
The Execution Details link in the pipeline view doesn't work if the first stage in the pipeline is a group. I think this was by design, but it has been a major cause of confusion for our users, so I think it makes sense to just expand the first stage with the first substage selected.
![image](https://user-images.githubusercontent.com/155558/65428429-a7f3dd80-de14-11e9-9126-88e4cd68d47b.png)
