### PR TITLE
feat(core): rerun child pipelines with artifacts

### DIFF
--- a/app/scripts/modules/core/src/domain/IExecutionTrigger.ts
+++ b/app/scripts/modules/core/src/domain/IExecutionTrigger.ts
@@ -10,6 +10,7 @@ export interface IExecutionTrigger extends ITrigger {
   parentExecution?: IExecution;
   parentPipelineApplication?: string;
   parentPipelineId?: string;
+  parentPipelineStageId?: string;
   parentPipelineName?: string;
   type: string;
   user: string;


### PR DESCRIPTION
Closes https://github.com/spinnaker/spinnaker/issues/4410

- As a user configuring pipeline B to run as a stage of pipeline A, I expect artifacts from pipeline A to be included when retrying an execution of pipeline B. In other words, I expect the retry logic to be the same as if I had configured pipeline B to be triggered by pipeline A.
- This change shims a pipeline trigger for a pipeline when it has run as a stage of a parent pipeline, so that the pipeline trigger manual execution component will render.
- While testing this, I realized that we were rendering the `ArtifactList` component even when the list of artifacts were empty, so I also fixed that.

<details><summary>[Existing Functionality] Pipeline A triggers Pipeline B</summary>
<p>

![JWrOVH6RBy6](https://user-images.githubusercontent.com/15936279/65459505-12f5e200-de1e-11e9-93c5-8f10295a5d2c.png)

</p>
</details>

<details><summary>[Before] Pipeline B runs as a stage of Pipeline A</summary>
<p>

![Va8t7LUF1OF](https://user-images.githubusercontent.com/15936279/65460092-2a819a80-de1f-11e9-9117-7849e431b571.png)

![itgY0N45Lp0](https://user-images.githubusercontent.com/15936279/65460135-41c08800-de1f-11e9-8bd6-441bbc4e3266.png)


</p>
</details>

<details><summary>[After] Pipeline B runs as a stage of Pipeline A</summary>
<p>

![twO3HJUhN92](https://user-images.githubusercontent.com/15936279/65459999-fc03bf80-de1e-11e9-8308-7430cd3a068b.png)


</p>
</details>