### PR TITLE
Bump package core to 0.0.411 and titus to 0.0.112

### DIFF
--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/core",
-  "version": "0.0.410",
+  "version": "0.0.411",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/titus/package.json
+++ b/app/scripts/modules/titus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/titus",
-  "version": "0.0.111",
+  "version": "0.0.112",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
## Core
5d2e469 feat(core/pipeline): Add timestamp for failed executions (#7419)
3cfb3f1 feat(core/pipeline): Make custom artifacts more readable (#7418)
0034fa8 fix(core/pipeline): Add space before Source-link for failed executions (#7420)
bce3ac5 fix(core/pipeline): standardize manual execution field layouts (#7413)
9c0a994 fix(artifacts): Support custom artifacts with custom type (#7415)

## Titus
97c85d9 chore(titus): Deprecating pipeline migration strategy (#7414)