### PR TITLE
fix(core/forms): MapEditorInput: Add validation for empty keys and empty values.

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/triggers/pubsub/PubsubTrigger.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/pubsub/PubsubTrigger.tsx
@@ -57,26 +57,14 @@ export function PubsubTrigger(pubsubTriggerProps: IPubsubTriggerProps) {
           name="payloadConstraints"
           label="Payload Constraints"
           help={<HelpField id="pipeline.config.trigger.pubsub.payloadConstraints" />}
-          input={props => (
-            <MapEditorInput
-              {...props}
-              errors={formik.errors.payloadConstraints}
-              addButtonLabel="Add payload constraint"
-            />
-          )}
+          input={props => <MapEditorInput {...props} addButtonLabel="Add payload constraint" />}
         />
 
         <FormikFormField
           name="attributeConstraints"
           label="Attribute Constraints "
           help={<HelpField id="pipeline.config.trigger.pubsub.attributeConstraints" />}
-          input={props => (
-            <MapEditorInput
-              {...props}
-              errors={formik.errors.attributeConstraints}
-              addButtonLabel="Add attribute constraint"
-            />
-          )}
+          input={props => <MapEditorInput {...props} addButtonLabel="Add attribute constraint" />}
         />
       </>
     );

--- a/app/scripts/modules/core/src/pipeline/config/triggers/webhook/WebhookTrigger.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/webhook/WebhookTrigger.tsx
@@ -34,13 +34,7 @@ export function WebhookTrigger(webhookTriggerProps: IWebhookTriggerProps) {
         name="payloadConstraints"
         label="Payload Constraints"
         help={<HelpField id="pipeline.config.trigger.webhook.payloadConstraints" />}
-        input={props => (
-          <MapEditorInput
-            {...props}
-            errors={formik.errors.payloadConstraints}
-            addButtonLabel="Add payload constraint"
-          />
-        )}
+        input={props => <MapEditorInput {...props} addButtonLabel="Add payload constraint" />}
       />
     </>
   );


### PR DESCRIPTION
```js
            <FormField
              label="Map Editor"
              value={mapEditorData}
              onChange={(e: any) => setMapEditorData(e.target.value)}
              input={props => <MapEditorInput {...props} allowEmptyValues={false} />}
            /
```

![Screen Shot 2019-09-23 at 4 00 49 PM](https://user-images.githubusercontent.com/2053478/65469216-729ebe00-de1b-11e9-8ceb-102bd26df68c.png)
