### PR TITLE
fix(core/pipeline): Fix revert button regression for templated pipelines

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/pipelineConfigurer.js
+++ b/app/scripts/modules/core/src/pipeline/config/pipelineConfigurer.js
@@ -431,7 +431,6 @@ module.exports = angular
         $scope.$applyAsync(() => {
           const original = getOriginal();
           $scope.pipeline = _.clone(original);
-          $scope.renderablePipeline = $scope.pipeline;
 
           if ($scope.isTemplatedPipeline) {
             const originalRenderablePipeline = getOriginalRenderablePipeline();


### PR DESCRIPTION
When pressing the revert button for a templated pipeline, the original pipeline got merged with the rendered pipeline, resulting in a strange frankenstein pipeline that you couldn't save.