### PR TITLE
fix(core/pipeline): Don't break templated pipelines when updating config

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/pipelineConfigurer.js
+++ b/app/scripts/modules/core/src/pipeline/config/pipelineConfigurer.js
@@ -537,7 +537,6 @@ module.exports = angular
         $scope.$applyAsync(() => {
           $scope.pipeline = _.cloneDeep($scope.pipeline);
           _.extend($scope.pipeline, changes);
-          $scope.renderablePipeline = $scope.pipeline;
           markDirty();
         });
       };


### PR DESCRIPTION
When updatePipelineConfig is called on a templated pipeline, it breaks the UI rendering of the pipeline (since it is based on `$scope.plan`, not `$scope.pipeline`). This happens when you open the pipeline config screen for some pipelines (for instance if you have expected artifacts defined in the old format without artifact account).
Removing the line in this PR solves the problem, while it seems like the functionality still works (because angular watches `$scope.pipeline` and calls `updatePipeline()` when it changes).