### PR TITLE
fix(tasks): (re)-enable durations on canceled tasks

### DIFF
--- a/app/scripts/modules/core/src/task/tasks.html
+++ b/app/scripts/modules/core/src/task/tasks.html
@@ -16,19 +16,19 @@
             <a href>All</a>
           </label>
           <label class="btn btn-sm btn-default" ng-model="viewState.taskStateFilter" uib-btn-radio="'NOT_STARTED'">
-            <a href><status-glyph item="{hasNotStarted: true}"></status-glyph> Not Started</a>
+            <a href> <status-glyph item="{hasNotStarted: true}"></status-glyph> Not Started </a>
           </label>
           <label class="btn btn-sm btn-default" ng-model="viewState.taskStateFilter" uib-btn-radio="'RUNNING'">
-            <a href><status-glyph item="{isRunning: true}"></status-glyph> Running</a>
+            <a href> <status-glyph item="{isRunning: true}"></status-glyph> Running </a>
           </label>
           <label class="btn btn-sm btn-default" ng-model="viewState.taskStateFilter" uib-btn-radio="'SUCCEEDED'">
-            <a href><status-glyph item="{isCompleted: true}"></status-glyph> Succeeded</a>
+            <a href> <status-glyph item="{isCompleted: true}"></status-glyph> Succeeded </a>
           </label>
           <label class="btn btn-sm btn-default" ng-model="viewState.taskStateFilter" uib-btn-radio="'TERMINAL'">
-            <a href><status-glyph item="{isFailed: true}"></status-glyph> Terminal</a>
+            <a href> <status-glyph item="{isFailed: true}"></status-glyph> Terminal </a>
           </label>
           <label class="btn btn-sm btn-default" ng-model="viewState.taskStateFilter" uib-btn-radio="'CANCELED'">
-            <a href><status-glyph item="{isCanceled: true}"></status-glyph> Canceled</a>
+            <a href> <status-glyph item="{isCanceled: true}"></status-glyph> Canceled </a>
           </label>
         </div>
       </div>
@@ -139,10 +139,10 @@
                 {{ task.endTime | timestamp }}
               </td>
               <td>
-                <span ng-if="!task.isCanceled">
+                <span ng-if="task.runningTimeInMs">
                   {{ task.runningTimeInMs | duration }}
                 </span>
-                <span ng-if="task.isCanceled">
+                <span ng-if="!task.runningTimeInMs">
                   -
                 </span>
               </td>


### PR DESCRIPTION
long, long ago (it was 2015), [a change was made to hide the duration of canceled tasks](https://github.com/spinnaker/deck/pull/844/files#diff-09a97886cae0dcb44dcb7c22fe7641cfR78-R84). I don't know why, and nobody else seems to know either. It seems useful to have a duration even on things you've canceled, so let's try turning it on 🤷‍♂

before:
<img width="1321" alt="Screen Shot 2019-09-24 at 10 48 06 AM" src="https://user-images.githubusercontent.com/1850998/65537496-2ce50280-deba-11e9-91df-6fd30f4733af.png">

after:
<img width="1346" alt="Screen Shot 2019-09-24 at 10 47 48 AM" src="https://user-images.githubusercontent.com/1850998/65537507-32424d00-deba-11e9-8896-4fd8c68dce7c.png">

