### PR TITLE
Validation refactor

### DIFF
--- a/app/scripts/modules/core/src/notification/modal/EditNotificationModal.tsx
+++ b/app/scripts/modules/core/src/notification/modal/EditNotificationModal.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { Formik, Form } from 'formik';
 import { Modal } from 'react-bootstrap';
-import { buildValidators, IModalComponentProps, ReactModal, SpinFormik } from 'core/presentation';
+import { FormValidator, IModalComponentProps, ReactModal, SpinFormik } from 'core/presentation';
 import { INotification } from 'core/domain';
 import { SubmitButton, ModalClose } from 'core/modal';
 
@@ -27,11 +27,12 @@ export class EditNotificationModal extends React.Component<IEditNotificationModa
   }
 
   private validate = (values: INotification): any => {
-    const validation = buildValidators(values);
-    validation
+    const formValidator = new FormValidator(values);
+    formValidator
       .field('when', 'Notify when')
-      .required([(value: any[]) => !value.length && 'Please select when the notification should execute']);
-    return validation.result();
+      .required()
+      .withValidators((value: any[]) => !value.length && 'Please select when the notification should execute');
+    return formValidator.validateForm();
   };
 
   public render(): React.ReactElement<EditNotificationModal> {

--- a/app/scripts/modules/core/src/pipeline/config/stages/googleCloudBuild/googleCloudBuildValidators.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/googleCloudBuild/googleCloudBuildValidators.ts
@@ -1,7 +1,7 @@
-import { buildValidators, IContextualValidator, IStage } from '@spinnaker/core';
+import { FormValidator, IContextualValidator, IStage } from '@spinnaker/core';
 
 export const validate: IContextualValidator = (stage: IStage) => {
-  const validation = buildValidators(stage);
-  validation.field('account', 'Account').required();
-  return validation.result();
+  const formValidator = new FormValidator(stage);
+  formValidator.field('account', 'Account').required();
+  return formValidator.validateForm();
 };

--- a/app/scripts/modules/core/src/pipeline/config/stages/script/ScriptStageConfig.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/script/ScriptStageConfig.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { IStageConfigProps, FormikStageConfig, IContextualValidator } from 'core/pipeline';
-import { FormikFormField, TextInput, TextAreaInput, CheckboxInput, buildValidators } from 'core/presentation';
+import { FormikFormField, TextInput, TextAreaInput, CheckboxInput, FormValidator } from 'core/presentation';
 import { HelpField } from 'core/help';
 
 export const ScriptStageConfig: React.SFC<IStageConfigProps> = stageConfigProps => (
@@ -82,8 +82,8 @@ export const ScriptStageConfig: React.SFC<IStageConfigProps> = stageConfigProps 
 );
 
 export const validate: IContextualValidator = stage => {
-  const validation = buildValidators(stage);
-  validation.field('command', 'Command').required();
-  validation.field('scriptPath', 'Script Path').required();
-  return validation.result();
+  const formValidator = new FormValidator(stage);
+  formValidator.field('command', 'Command').required();
+  formValidator.field('scriptPath', 'Script Path').required();
+  return formValidator.validateForm();
 };

--- a/app/scripts/modules/core/src/pipeline/manualExecution/ManualPipelineExecutionModal.tsx
+++ b/app/scripts/modules/core/src/pipeline/manualExecution/ManualPipelineExecutionModal.tsx
@@ -9,7 +9,7 @@ import { SubmitButton, ModalClose } from 'core/modal';
 import { Application } from 'core/application';
 import { AuthenticationService } from 'core/authentication';
 import {
-  buildValidators,
+  FormValidator,
   IModalComponentProps,
   ReactModal,
   SpinFormik,
@@ -339,8 +339,8 @@ export class ManualExecutionModal extends React.Component<IManualExecutionModalP
   };
 
   private validate = (values: IPipelineCommand): any => {
-    const validation = buildValidators(values);
-    return validation.result();
+    const formValidator = new FormValidator(values);
+    return formValidator.validateForm();
   };
 
   public render(): React.ReactElement<ManualExecutionModal> {

--- a/app/scripts/modules/core/src/presentation/forms/README.md
+++ b/app/scripts/modules/core/src/presentation/forms/README.md
@@ -61,15 +61,18 @@ In addition to the `validate` prop, the field can also be validated at the form 
 This example shows validation of a formik field using the `Formik` component's `validate` prop.
 
 ```js
-import { buildValidators } from 'core/presentation';
+import { FormValidator } from 'core/presentation';
 
 <Formik
   initialValues={{ email: '' }}
   validate={values => {
     const emailRegexp = /[^@]+@[^@]+/;
-    const validator = buildValidators(values);
-    validator.field('email').required([value => (emailRegexp.exec(value) ? null : 'Please enter a valid email')]);
-    return validator.result();
+    const formValidator = new FormValidator(values);
+    formValidator
+      .field('email')
+      .required()
+      .withValidators(value => (emailRegexp.exec(value) ? null : 'Please enter a valid email'));
+    return formValidator.result();
   }}
   render={formik => {
     return (

--- a/app/scripts/modules/core/src/presentation/forms/validation/validation.ts
+++ b/app/scripts/modules/core/src/presentation/forms/validation/validation.ts
@@ -1,4 +1,5 @@
-import { get, set } from 'lodash';
+import { get, isBoolean, set, startCase } from 'lodash';
+import { Validators } from './validators';
 
 // Use Formik's Field.validate() api https://jaredpalmer.com/formik/docs/api/field#validate
 export type IValidatorResult = undefined | string;
@@ -11,23 +12,50 @@ export type IArrayItemValidator = (
   arrayLabel: string,
 ) => void;
 
-export interface IValidationBuilder {
+export interface IFormValidator {
+  /**
+   * Defines a new form field to validate
+   *
+   * @param name the name of the field in the Formik Form
+   * @param label (optional) the label of this field.
+   */
   field: (name: string, label: string) => IValidatableField;
-  result: () => any;
+
+  /**
+   * Runs validation on all the ValidatableField(s) in this FormValidator.
+   *
+   * This function aggregate all the field validation errors into an object compatible with Formik Errors.
+   * Each field error is stored in the resulting object using the field's 'name' as a path.
+   */
+  validateForm: () => any;
   arrayForEach: (iteratee: IArrayItemValidator) => IValidator;
 }
+
+interface IValidatableField {
+  /** Causes the field to fail validation if the value is undefined, null, or empty string. */
+  required(message?: string): ValidatableField;
+
+  /**
+   * Causes the field to pass validation if the value is undefined, null, or empty string.
+   * Fields are default by default.
+   */
+  optional(): ValidatableField;
+
+  /** Causes the field to pass validation if the value contains SpEL */
+  spelAware(isSpelAware?: boolean): ValidatableField;
+
+  /** Adds additional validators */
+  withValidators(...validators: IValidator[]): ValidatableField;
+}
+
+export const FORM_VALIDATION_VALIDATABLE_FIELD_IS_VALID_SHORT_CIRCUIT = '__FIELD_IS_VALID_SHORT_CIRCUIT__';
 
 interface INamedValidatorResult {
   name: string;
   error: string;
 }
 
-interface IValidatableField {
-  required: (validators?: IValidator[]) => undefined;
-  optional: (validators?: IValidator[]) => undefined;
-}
-
-interface IArrayItemValidationBuilder extends IValidationBuilder {
+interface IArrayItemValidationBuilder extends IFormValidator {
   item: (label: string) => IValidatableField;
 }
 
@@ -38,6 +66,7 @@ const runValidators = (validators: IValidator[], value: any, label: string) => {
   );
 };
 
+/** Transforms a list of INamedValidatorResults into a Formik-compatible errors object */
 const expandErrors = (errors: INamedValidatorResult[], isArray: boolean) => {
   return errors.reduce((acc, curr) => set(acc, curr.name, curr.error), isArray ? [] : {});
 };
@@ -45,6 +74,8 @@ const expandErrors = (errors: INamedValidatorResult[], isArray: boolean) => {
 // This allows the error aggregation to ignore nested non-errors (i.e. [] or {})
 const isError = (maybeError: any): boolean => {
   if (!maybeError) {
+    return false;
+  } else if (maybeError === FORM_VALIDATION_VALIDATABLE_FIELD_IS_VALID_SHORT_CIRCUIT) {
     return false;
   } else if (typeof maybeError === 'string') {
     return true;
@@ -56,7 +87,7 @@ const isError = (maybeError: any): boolean => {
   return !!maybeError;
 };
 
-const createItemBuilder = (arrayBuilder: IValidationBuilder, index: number): IArrayItemValidationBuilder => {
+const createItemBuilder = (arrayBuilder: IFormValidator, index: number): IArrayItemValidationBuilder => {
   return {
     item(itemLabel) {
       return arrayBuilder.field(`[${index}]`, itemLabel);
@@ -64,13 +95,13 @@ const createItemBuilder = (arrayBuilder: IValidationBuilder, index: number): IAr
     field(name, itemLabel) {
       return arrayBuilder.field(`[${index}].${name}`, itemLabel);
     },
-    result: arrayBuilder.result,
+    validateForm: arrayBuilder.validateForm,
     arrayForEach: arrayBuilder.arrayForEach,
   };
 };
 
 // Utility to provide a builder for array items. The provided iteratee will be invoked for every array item.
-const arrayForEach = (builder: (values: any) => IValidationBuilder, iteratee: IArrayItemValidator) => {
+const arrayForEach = (builder: (values: any) => IFormValidator, iteratee: IArrayItemValidator) => {
   return (array: any[], arrayLabel?: string) => {
     // Silently ignore non-arrays (usually undefined). If strict type checking is desired, it should be done by a previous validator.
     if (!Array.isArray(array)) {
@@ -81,44 +112,141 @@ const arrayForEach = (builder: (values: any) => IValidationBuilder, iteratee: IA
       const itemBuilder = createItemBuilder(arrayBuilder, index);
       iteratee && iteratee(itemBuilder, item, index, array, arrayLabel);
     });
-    return arrayBuilder.result();
+    return arrayBuilder.validateForm();
   };
 };
 
-export const buildValidators = (values: any): IValidationBuilder => {
-  const isArray = Array.isArray(values);
-  const errors: INamedValidatorResult[] = [];
-  return {
-    field(name: string, label: string): IValidatableField {
-      const value = get(values, name);
-      return {
-        required(validators = [], message?: string): undefined {
-          if (value === undefined || value === null || value === '') {
-            message = message || `${label} is required.`;
-            errors.push({ name, error: message });
-            return undefined;
-          }
-          return this.optional(validators);
-        },
-        optional(validators: IValidator[]): undefined {
-          if (value === undefined || value === null || value === '') {
-            // Don't run validation on an undefined/null/empty
-            return undefined;
-          }
-          const error = runValidators(validators, value, label);
-          errors.push(isError(error) && { name, error });
-          return undefined;
-        },
-      };
-    },
-    result(): any {
-      return expandErrors(errors.filter(x => !!x), isArray);
-    },
-    arrayForEach(iteratee: IArrayItemValidator) {
-      return arrayForEach(buildValidators, iteratee);
-    },
+export class FormValidator implements IFormValidator {
+  constructor(private values: any) {}
+  private fields: ValidatableField[] = [];
+  private isSpelAwareDefault = false;
+
+  /**
+   * Defines a new form field to validate
+   *
+   * @param name the name of the field in the Formik Form
+   * @param label (optional) the label of this field.
+   * If no label is provided, it will be inferred based on the name.
+   */
+  public field(name: string, label?: string): IValidatableField {
+    label = label || startCase(name);
+
+    const field = new ValidatableField(name, label);
+    this.fields.push(field);
+    return field;
+  }
+
+  /**
+   * Makes this FormValidator default to being spel-aware or not
+   *
+   * When true, all fields in this FormValidator will default to allowing spel values to pass validation.
+   * Individual fields may override this default by calling field().spelAware()
+   */
+  public spelAware(isSpelAware = true): FormValidator {
+    this.isSpelAwareDefault = isSpelAware;
+    return this;
+  }
+
+  private getFieldValidators(field: ValidatableField, isSpelAwareDefault: boolean): IValidator[] {
+    const isSpelAware = isBoolean(field.isSpelAware) ? field.isSpelAware : isSpelAwareDefault;
+
+    const requiredValidator = field.isRequired ? Validators.isRequired(field.isRequiredMessage) : null;
+    const optionalValidator = !field.isRequired ? isOptionalValidator() : null;
+    const spelValidator = isSpelAware ? spelAwareValidator() : null;
+
+    return [requiredValidator, optionalValidator, spelValidator, ...field.validators].filter(x => !!x);
+  }
+
+  /**
+   * This runs validation on all the ValidatableField(s) in this FormValidator.
+   *
+   * It aggregate all the field validation errors into an object compatible with Formik Errors.
+   * Each field error is stored in the resulting object using the field's 'name' as a path.
+   */
+  public validateForm(): any {
+    const results: INamedValidatorResult[] = this.fields.map(field => {
+      const { name, label } = field;
+
+      const value = get(this.values, name);
+      const fieldValidators = this.getFieldValidators(field, this.isSpelAwareDefault);
+      const error = runValidators(fieldValidators, value, label);
+
+      return { name, error };
+    });
+
+    const errors = results.filter(fieldResult => isError(fieldResult.error));
+
+    return expandErrors(errors, Array.isArray(this.values));
+  }
+
+  public arrayForEach(iteratee: IArrayItemValidator): any {
+    return arrayForEach(values => new FormValidator(values), iteratee);
+  }
+}
+
+/**
+ * Encapsulates a form field and the validation rules defined for that field.
+ *
+ * By default a ValidatableField is optional.
+ */
+class ValidatableField implements IValidatableField {
+  constructor(public name: string, public label: string) {}
+  public isSpelAware: boolean;
+  public isRequired: boolean;
+  public isRequiredMessage: string;
+  public validators: IValidator[] = [];
+
+  /** Causes the field to fail validation if the value is undefined, null, or empty string. */
+  public required(message?: string): ValidatableField {
+    this.isRequired = true;
+    this.isRequiredMessage = message;
+    return this;
+  }
+
+  /**
+   * Causes the field to pass validation if the value is undefined, null, or empty string.
+   * Fields are default by default.
+   */
+  public optional(): ValidatableField {
+    this.isRequired = false;
+    this.isRequiredMessage = undefined;
+    return this;
+  }
+
+  /** Causes the field to pass validation if the value contains SpEL */
+  public spelAware(isSpelAware = true): ValidatableField {
+    this.isSpelAware = isSpelAware;
+    return this;
+  }
+
+  /** Adds additional validators */
+  public withValidators(...validators: IValidator[]): ValidatableField {
+    this.validators = this.validators.concat(validators);
+    return this;
+  }
+}
+
+/**
+ * Not exported because it uses.short circuiting, so it only works inside of a FormValidator
+ * Use via ValidatableField.optional().
+ */
+function isOptionalValidator(): IValidator {
+  return value => {
+    const isValueMissing = value === undefined || value === null || value === '';
+    return isValueMissing ? FORM_VALIDATION_VALIDATABLE_FIELD_IS_VALID_SHORT_CIRCUIT : null;
   };
-};
+}
+
+/**
+ * Not exported because it uses.short circuiting, so it only works inside of a FormValidator
+ * Use via ValidatableField.spelAware().
+ */
+function spelAwareValidator(): IValidator {
+  return value => {
+    const isSpelContent = typeof value === 'string' && value.includes('${');
+    return isSpelContent ? FORM_VALIDATION_VALIDATABLE_FIELD_IS_VALID_SHORT_CIRCUIT : null;
+  };
+}
 
 export const composeValidators = (validators: IValidator[]): IValidator => {
   const validatorList = validators.filter(x => !!x);

--- a/app/scripts/modules/core/src/presentation/forms/validation/validators.ts
+++ b/app/scripts/modules/core/src/presentation/forms/validation/validators.ts
@@ -1,4 +1,5 @@
 import { IValidator } from './validation';
+import { isNumber } from 'lodash';
 
 const THIS_FIELD = 'This field';
 
@@ -18,16 +19,25 @@ const isRequired = (message?: string): IValidator => {
 
 const minValue = (min: number, message?: string): IValidator => {
   return (val: number, label = THIS_FIELD) => {
-    const text = min === 0 ? 'cannot be negative' : `cannot be less than ${min}`;
-    message = message || `${label} ${text}`;
-    return val < min && message;
+    if (!isNumber(val)) {
+      return message || `${label} must be a number`;
+    } else if (val < min) {
+      const minText = min === 0 ? 'cannot be negative' : `cannot be less than ${min}`;
+      return message || `${label} ${minText}`;
+    }
+    return null;
   };
 };
 
 const maxValue = (max: number, message?: string): IValidator => {
   return (val: number, label = THIS_FIELD) => {
-    message = message || `${label} cannot be greater than ${max}`;
-    return val > max && message;
+    if (!isNumber(val)) {
+      return message || `${label} must be a number`;
+    } else if (val > max) {
+      const maxText = `cannot be greater than ${max}`;
+      return message || `${label} ${maxText}`;
+    }
+    return null;
   };
 };
 


### PR DESCRIPTION
This is an iteration on the form validation API.  The primary changes are:

- Migrate from `buildValidators(values)` to `new FormValidator(values)`
- Make fields optional by default
- Migrate from `.required([validator1, validator2], 'field is required')`
  to `.required('field is required').withValidators(validator1, validator2)`
- Add `spelAware()` to ValidatableField which allows validation to pass
  when the value contains a SpEL expression, even if other validators
  would fail the validation.
- Add a magic string that can be used to short circuit validation of a field
  - Used to implement optional() and spelAware()