### PR TITLE
fix(core/pipeline): Fixes UX of saving non-templated pipelines

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/pipelineConfigurer.js
+++ b/app/scripts/modules/core/src/pipeline/config/pipelineConfigurer.js
@@ -536,6 +536,9 @@ module.exports = angular
         $scope.$applyAsync(() => {
           $scope.pipeline = _.cloneDeep($scope.pipeline);
           _.extend($scope.pipeline, changes);
+          if (!$scope.isTemplatedPipeline) {
+            $scope.renderablePipeline = $scope.pipeline;
+          }
           markDirty();
         });
       };


### PR DESCRIPTION
Previously, a fix for saving Templated pipelines was applied which removed the assigment of the updated pipeline to 'renderablePipeline'.  This fix re-applies the assignment of the 'renderablepipeline' variable but only if the pipeline is non-templated.
