### PR TITLE
fix(core/pipeline): Fix revert button for non-templated pipelines

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/pipelineConfigurer.js
+++ b/app/scripts/modules/core/src/pipeline/config/pipelineConfigurer.js
@@ -440,6 +440,8 @@ module.exports = angular
                 delete $scope.renderablePipeline[key];
               }
             });
+          } else {
+            $scope.renderablePipeline = $scope.pipeline;
           }
 
           // if we were looking at a stage that no longer exists, move to the last stage


### PR DESCRIPTION
I accidentally broke this in #7427. Adding the removed line back, but only for non-templated pipelines.