### PR TITLE
fix(core/pipeline): Revision history is vertically challenged in Safari

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/actions/history/showHistory.less
+++ b/app/scripts/modules/core/src/pipeline/config/actions/history/showHistory.less
@@ -12,6 +12,8 @@
   max-height: calc(~'100vh - 220px');
   .form-control {
     border: 0;
+    height: 100%;
+    padding-left: 15px;
   }
   .form-group {
     margin: 0 -15px;


### PR DESCRIPTION
Safari renders the viewport of the revision history with a height of 34px, which leaves a lot of whitespace unused, and also makes it hard to review the revision history as only two lines can be displayed at once.

![image](https://user-images.githubusercontent.com/155558/65765820-8868f780-e129-11e9-9cf6-a46333b71d0c.png)

The `padding-left` override also makes the revision history stop cropping the pluses and minuses (in all browsers).

![image](https://user-images.githubusercontent.com/155558/65765825-8c951500-e129-11e9-86e9-20635db5bb8e.png)