### PR TITLE
feat(core/utils): Add `traverseObject` which deeply walks object properties

### DIFF
--- a/app/scripts/modules/core/src/utils/index.ts
+++ b/app/scripts/modules/core/src/utils/index.ts
@@ -3,6 +3,7 @@
 export * from './clipboard/CopyToClipboard';
 export * from './debug';
 export * from './json/JsonUtils';
+export * from './json/traverseObject';
 export * from './noop';
 export * from './q';
 export * from './renderIfFeature.component';

--- a/app/scripts/modules/core/src/utils/json/traverseObject.spec.ts
+++ b/app/scripts/modules/core/src/utils/json/traverseObject.spec.ts
@@ -1,44 +1,82 @@
 import { traverseObject } from './traverseObject';
 
 describe('traverseObject', () => {
-  let keysWalked: string[];
-  let valsWalked: any[];
+  let keyValuePairsWalked: Array<[string, any]>;
+  let i: number;
 
   function defaultCallback(key: string, val: any) {
-    keysWalked.push(key);
-    valsWalked.push(val);
+    keyValuePairsWalked.push([key, val]);
   }
 
   beforeEach(() => {
-    keysWalked = [];
-    valsWalked = [];
+    i = 0;
+    keyValuePairsWalked = [];
   });
 
   it('walks simple properties of an object', () => {
     const object = { foo: 1, bar: 2 };
     traverseObject(object, defaultCallback);
-    expect(keysWalked).toEqual(['foo', 'bar']);
-    expect(valsWalked).toEqual([1, 2]);
+    expect(keyValuePairsWalked.length).toEqual(2);
+    expect(keyValuePairsWalked[i++]).toEqual(['foo', 1]);
+    expect(keyValuePairsWalked[i++]).toEqual(['bar', 2]);
   });
 
   it('walks nested properties of an object', () => {
-    const object = { foo: 1, bar: { prop1: 1, prop2: 2, prop3: 3 } };
+    const object = { foo: 1, bar: { prop1: 1, prop2: 2 } };
     traverseObject(object, defaultCallback);
-    expect(keysWalked).toEqual(['foo', 'bar.prop1', 'bar.prop2', 'bar.prop3']);
-    expect(valsWalked).toEqual([1, 1, 2, 3]);
+    expect(keyValuePairsWalked.length).toEqual(4);
+    expect(keyValuePairsWalked[i++]).toEqual(['foo', 1]);
+    expect(keyValuePairsWalked[i++]).toEqual(['bar', { prop1: 1, prop2: 2 }]);
+    expect(keyValuePairsWalked[i++]).toEqual(['bar.prop1', 1]);
+    expect(keyValuePairsWalked[i++]).toEqual(['bar.prop2', 2]);
+  });
+
+  it('only walks simple leaf nodes an object when traverseLeafNodesOnly is true', () => {
+    const object = { foo: 1, bar: { prop1: 1, prop2: 2 } };
+    traverseObject(object, defaultCallback, true);
+    expect(keyValuePairsWalked.length).toEqual(3);
+    expect(keyValuePairsWalked[i++]).toEqual(['foo', 1]);
+    expect(keyValuePairsWalked[i++]).toEqual(['bar.prop1', 1]);
+    expect(keyValuePairsWalked[i++]).toEqual(['bar.prop2', 2]);
   });
 
   it('walks array properties of an object', () => {
-    const object = { foo: 1, bar: [1, 2, 3] };
+    const object = { foo: 1, bar: [1, 2] };
     traverseObject(object, defaultCallback);
-    expect(keysWalked).toEqual(['foo', 'bar[0]', 'bar[1]', 'bar[2]']);
-    expect(valsWalked).toEqual([1, 1, 2, 3]);
+    expect(keyValuePairsWalked.length).toEqual(4);
+    expect(keyValuePairsWalked[i++]).toEqual(['foo', 1]);
+    expect(keyValuePairsWalked[i++]).toEqual(['bar', [1, 2]]);
+    expect(keyValuePairsWalked[i++]).toEqual(['bar[0]', 1]);
+    expect(keyValuePairsWalked[i++]).toEqual(['bar[1]', 2]);
+  });
+
+  it('walks only leaf array elements when traverseLeafNodesOnly is true', () => {
+    const object = { foo: 1, bar: [1, 2] };
+    traverseObject(object, defaultCallback, true);
+    expect(keyValuePairsWalked.length).toEqual(3);
+    expect(keyValuePairsWalked[i++]).toEqual(['foo', 1]);
+    expect(keyValuePairsWalked[i++]).toEqual(['bar[0]', 1]);
+    expect(keyValuePairsWalked[i++]).toEqual(['bar[1]', 2]);
   });
 
   it('walks nested objects inside array properties of an object', () => {
-    const object = { foo: 1, bar: [{ name: 'abc' }, { name: 'def' }, { name: 'ghi' }] };
+    const object = { foo: 1, bar: [{ name: 'abc' }, { name: 'def' }] };
     traverseObject(object, defaultCallback);
-    expect(keysWalked).toEqual(['foo', 'bar[0].name', 'bar[1].name', 'bar[2].name']);
-    expect(valsWalked).toEqual([1, 'abc', 'def', 'ghi']);
+    expect(keyValuePairsWalked.length).toEqual(6);
+    expect(keyValuePairsWalked[i++]).toEqual(['foo', 1]);
+    expect(keyValuePairsWalked[i++]).toEqual(['bar', [{ name: 'abc' }, { name: 'def' }]]);
+    expect(keyValuePairsWalked[i++]).toEqual(['bar[0]', { name: 'abc' }]);
+    expect(keyValuePairsWalked[i++]).toEqual(['bar[0].name', 'abc']);
+    expect(keyValuePairsWalked[i++]).toEqual(['bar[1]', { name: 'def' }]);
+    expect(keyValuePairsWalked[i++]).toEqual(['bar[1].name', 'def']);
+  });
+
+  it('walks only leaf nodes nested objects inside array properties of an object when traverseLeafNodesOnly is true', () => {
+    const object = { foo: 1, bar: [{ name: 'abc' }, { name: 'def' }] };
+    traverseObject(object, defaultCallback, true);
+    expect(keyValuePairsWalked.length).toEqual(3);
+    expect(keyValuePairsWalked[i++]).toEqual(['foo', 1]);
+    expect(keyValuePairsWalked[i++]).toEqual(['bar[0].name', 'abc']);
+    expect(keyValuePairsWalked[i++]).toEqual(['bar[1].name', 'def']);
   });
 });

--- a/app/scripts/modules/core/src/utils/json/traverseObject.spec.ts
+++ b/app/scripts/modules/core/src/utils/json/traverseObject.spec.ts
@@ -1,0 +1,44 @@
+import { traverseObject } from './traverseObject';
+
+describe('traverseObject', () => {
+  let keysWalked: string[];
+  let valsWalked: any[];
+
+  function defaultCallback(key: string, val: any) {
+    keysWalked.push(key);
+    valsWalked.push(val);
+  }
+
+  beforeEach(() => {
+    keysWalked = [];
+    valsWalked = [];
+  });
+
+  it('walks simple properties of an object', () => {
+    const object = { foo: 1, bar: 2 };
+    traverseObject(object, defaultCallback);
+    expect(keysWalked).toEqual(['foo', 'bar']);
+    expect(valsWalked).toEqual([1, 2]);
+  });
+
+  it('walks nested properties of an object', () => {
+    const object = { foo: 1, bar: { prop1: 1, prop2: 2, prop3: 3 } };
+    traverseObject(object, defaultCallback);
+    expect(keysWalked).toEqual(['foo', 'bar.prop1', 'bar.prop2', 'bar.prop3']);
+    expect(valsWalked).toEqual([1, 1, 2, 3]);
+  });
+
+  it('walks array properties of an object', () => {
+    const object = { foo: 1, bar: [1, 2, 3] };
+    traverseObject(object, defaultCallback);
+    expect(keysWalked).toEqual(['foo', 'bar[0]', 'bar[1]', 'bar[2]']);
+    expect(valsWalked).toEqual([1, 1, 2, 3]);
+  });
+
+  it('walks nested objects inside array properties of an object', () => {
+    const object = { foo: 1, bar: [{ name: 'abc' }, { name: 'def' }, { name: 'ghi' }] };
+    traverseObject(object, defaultCallback);
+    expect(keysWalked).toEqual(['foo', 'bar[0].name', 'bar[1].name', 'bar[2].name']);
+    expect(valsWalked).toEqual([1, 'abc', 'def', 'ghi']);
+  });
+});

--- a/app/scripts/modules/core/src/utils/json/traverseObject.ts
+++ b/app/scripts/modules/core/src/utils/json/traverseObject.ts
@@ -1,26 +1,44 @@
 import { forIn, isPlainObject } from 'lodash';
 
 /**
- * Deeply walks an object tree and invokes `callback` for every simple property leaf node
- * (i.e., a property that is neither a nested object, nor an array)
+ * Deeply walks an object tree and invokes `callback` for each node
  *
  * @param object the object to walk
  * @param callback the callback to invoke on each simple leaf nodes.
  *        This callback receives the `path` and `value`.
  *        The `path` is a string representing the path into the object, which is compatible with lodash _.get(key).
  *        The `value` is the value of the simple leaf node.
+ * @param traverseLeafNodesOnly When true, only walks simple leaf nodes,
+ *        i.e., properties that are neither a nested object, nor an array.
  */
-export const traverseObject = (object: object, callback: ITraverseCallback) => {
-  return _traverseObject(null, object, callback);
+export const traverseObject = (object: object, callback: ITraverseCallback, traverseLeafNodesOnly = false) => {
+  return _traverseObject(null, object, callback, traverseLeafNodesOnly);
 };
 
 type ITraverseCallback = (path: string, obj: object) => void;
-const _traverseObject = (contextPath: string, obj: object, callback: ITraverseCallback) => {
+
+const _traverseObject = (
+  contextPath: string,
+  obj: object,
+  callback: ITraverseCallback,
+  traverseLeafNodesOnly: boolean,
+) => {
+  function maybeInvokeCallback(isLeafNode: boolean) {
+    if (contextPath !== null && (isLeafNode || !traverseLeafNodesOnly)) {
+      callback(contextPath, obj);
+    }
+  }
+
   if (isPlainObject(obj)) {
-    forIn(obj, (val, key) => _traverseObject(`${contextPath ? contextPath + '.' : ''}${key}`, val, callback));
+    maybeInvokeCallback(false);
+    forIn(obj, (val, key) => {
+      const path = contextPath ? contextPath + '.' : '';
+      return _traverseObject(`${path}${key}`, val, callback, traverseLeafNodesOnly);
+    });
   } else if (Array.isArray(obj)) {
-    obj.forEach((val, idx) => _traverseObject(`${contextPath}[${idx}]`, val, callback));
+    maybeInvokeCallback(false);
+    obj.forEach((val, idx) => _traverseObject(`${contextPath}[${idx}]`, val, callback, traverseLeafNodesOnly));
   } else {
-    callback(contextPath, obj);
+    maybeInvokeCallback(true);
   }
 };

--- a/app/scripts/modules/core/src/utils/json/traverseObject.ts
+++ b/app/scripts/modules/core/src/utils/json/traverseObject.ts
@@ -1,0 +1,26 @@
+import { forIn, isPlainObject } from 'lodash';
+
+/**
+ * Deeply walks an object tree and invokes `callback` for every simple property leaf node
+ * (i.e., a property that is neither a nested object, nor an array)
+ *
+ * @param object the object to walk
+ * @param callback the callback to invoke on each simple leaf nodes.
+ *        This callback receives the `path` and `value`.
+ *        The `path` is a string representing the path into the object, which is compatible with lodash _.get(key).
+ *        The `value` is the value of the simple leaf node.
+ */
+export const traverseObject = (object: object, callback: ITraverseCallback) => {
+  return _traverseObject(null, object, callback);
+};
+
+type ITraverseCallback = (path: string, obj: object) => void;
+const _traverseObject = (contextPath: string, obj: object, callback: ITraverseCallback) => {
+  if (isPlainObject(obj)) {
+    forIn(obj, (val, key) => _traverseObject(`${contextPath ? contextPath + '.' : ''}${key}`, val, callback));
+  } else if (Array.isArray(obj)) {
+    obj.forEach((val, idx) => _traverseObject(`${contextPath}[${idx}]`, val, callback));
+  } else {
+    callback(contextPath, obj);
+  }
+};


### PR DESCRIPTION
A utility function I intend to use when adding some form validation enhancements.


```js
  it('walks nested objects inside array properties of an object', () => {
    const object = { foo: 1, bar: [{ name: 'abc' }, { name: 'def' }, { name: 'ghi' }] };
    traverseObject(object, defaultCallback);
    expect(keysWalked).toEqual(['foo', 'bar[0].name', 'bar[1].name', 'bar[2].name']);
    expect(valsWalked).toEqual([1, 'abc', 'def', 'ghi']);
  });
```