### PR TITLE
fix(core/infrastructure): Fix deep links with filters

### DIFF
--- a/app/scripts/modules/core/src/cluster/filter/ClusterFilterModel.ts
+++ b/app/scripts/modules/core/src/cluster/filter/ClusterFilterModel.ts
@@ -30,7 +30,7 @@ export class ClusterFilterModel {
 
   constructor() {
     this.asFilterModel = FilterModelService.configureFilterModel(this as any, filterModelConfig);
-    FilterModelService.registerRouterHooks(this.asFilterModel, '**.application.insight.clusters');
+    FilterModelService.registerRouterHooks(this.asFilterModel, '**.application.insight.clusters.**');
     this.asFilterModel.activate();
   }
 }

--- a/app/scripts/modules/core/src/loadBalancer/filter/LoadBalancerFilterModel.ts
+++ b/app/scripts/modules/core/src/loadBalancer/filter/LoadBalancerFilterModel.ts
@@ -28,7 +28,7 @@ export class LoadBalancerFilterModel {
 
   constructor() {
     this.asFilterModel = FilterModelService.configureFilterModel(this as any, filterModelConfig);
-    FilterModelService.registerRouterHooks(this.asFilterModel, '**.application.insight.loadBalancers');
+    FilterModelService.registerRouterHooks(this.asFilterModel, '**.application.insight.loadBalancers.**');
     this.asFilterModel.activate();
   }
 }

--- a/app/scripts/modules/core/src/pipeline/filter/ExecutionFilterModel.ts
+++ b/app/scripts/modules/core/src/pipeline/filter/ExecutionFilterModel.ts
@@ -43,7 +43,7 @@ export class ExecutionFilterModel {
     });
 
     this.asFilterModel = FilterModelService.configureFilterModel(this as any, filterModelConfig);
-    FilterModelService.registerRouterHooks(this.asFilterModel, '**.application.pipelines.executions');
+    FilterModelService.registerRouterHooks(this.asFilterModel, '**.application.pipelines.executions.**');
     this.asFilterModel.activate();
 
     transitionService.onBefore({ entering: '**.application.pipelines.executions' }, trans => {

--- a/app/scripts/modules/core/src/securityGroup/filter/SecurityGroupFilterModel.ts
+++ b/app/scripts/modules/core/src/securityGroup/filter/SecurityGroupFilterModel.ts
@@ -20,7 +20,7 @@ export class SecurityGroupFilterModel {
 
   constructor() {
     this.asFilterModel = FilterModelService.configureFilterModel(this as any, filterModelConfig);
-    FilterModelService.registerRouterHooks(this.asFilterModel, '**.application.insight.firewalls');
+    FilterModelService.registerRouterHooks(this.asFilterModel, '**.application.insight.firewalls.**');
     this.asFilterModel.activate();
   }
 }


### PR DESCRIPTION
This fixes a problem where deep links to infrastructure items (such as an instance chiclet) where filters are applied will lose the filters when the deep link is activated.  This was due to a but introduced when refactoring the filter save/restore code a few months back.  We started using router hooks to manage saving/restoring the filters.  However, the case where a user was navigating deeply was not accounted for in the router trigger criteria.  It only took effect when the top level view was activated.

This change switches to triggering the router hook on a wildcard glob on the beginning and end of the state names.
This causes the AngularJS compatibility code to be run whether you're activating the clusters tab, or deep linking to an instance _within_ the clusters tab.
