### PR TITLE
fix(kubernetes): Fix merge strategy field (#7455)

### DIFF
--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/patchManifest/PatchManifestStageForm.tsx
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/patchManifest/PatchManifestStageForm.tsx
@@ -22,6 +22,7 @@ import { SelectorMode } from 'kubernetes/v2/manifest/selector/IManifestSelector'
 import { PatchManifestOptionsForm } from './PatchManifestOptionsForm';
 
 interface IPatchManifestStageConfigFormProps {
+  stageFieldUpdated: () => void;
   updatePipeline: (pipeline: IPipeline) => void;
 }
 
@@ -88,7 +89,9 @@ export class PatchManifestStageForm extends React.Component<
     this.props.formik.setFieldValue('patchBody', manifests[0]);
   };
 
-  private onManifestSelectorChange = (): void => {};
+  private onManifestSelectorChange = (): void => {
+    this.props.stageFieldUpdated();
+  };
 
   private getSourceOptions = (): Array<Option<string>> => {
     return map([this.textSource, this.artifactSource], option => ({
@@ -114,8 +117,8 @@ export class PatchManifestStageForm extends React.Component<
           <RadioButtonInput
             options={this.getSourceOptions()}
             onChange={(e: any) => this.props.formik.setFieldValue('source', e.target.value)}
-            value={stage.source || 'text'}
             inline={true}
+            value={stage.source}
           />
         </StageConfigField>
         {stage.source === this.textSource && (
@@ -155,8 +158,8 @@ export class PatchManifestStageForm extends React.Component<
         <hr />
         <h4>Patch Options</h4>
         <PatchManifestOptionsForm
-          strategy={!!stage.options && stage.options.strategy}
-          onStrategyChange={(strategy: string) => this.props.formik.setFieldValue('options.strategy', strategy)}
+          strategy={!!stage.options && stage.options.mergeStrategy}
+          onStrategyChange={(strategy: string) => this.props.formik.setFieldValue('options.mergeStrategy', strategy)}
           record={!!stage.options && stage.options.record}
           onRecordChange={(record: boolean) => this.props.formik.setFieldValue('options.record', record)}
         />


### PR DESCRIPTION
Manual cherry pick of #7455 to 1.15.  The only conflict was that #7344 removed `inline={true}` on a line adjacent to a changed line; manually resolved this.

* fix(kubernetes): Properly dirty patch stage on resource update

We're not currently not marking the stage dirty upon chaning the
resource to be selected, which makes it impossible to save (without
making some other change or waiting for a digest cycle to happen
for another reason).

* fix(kubernetes): Fix manifest source defaulting in patch manifest

When creating a new patch manifest stage, we default the 'Manifest
Source' selector to 'Text' but the 'Manifest' text box is not visible;
the user needs to choose 'Artifact' then 'Text' again to make the
text box visible.

* fix(kubernetes): Fix merge strategy field

We've been incorrectly setting the merge strategy on options.strategy
instead of options.mergeStrategy since 1.15. Start writing to the
correct field, and handle updating any stages affected by the bug by
deleting the value of 'strategy' and copying it over to mergeStrategy.

* fix(kubernetes): Fix defaulting of strategy field

The prior commit was incorrect; delete does not return the deleted
value.

* fix(kubernetes): Fix display of strategy field