### PR TITLE
fix(bakeManifest): fix bake manifest UI rendering

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/BakeManifestStageForm.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/BakeManifestStageForm.tsx
@@ -27,7 +27,7 @@ export class BakeManifestStageForm extends React.Component<
 
   private shouldRenderHelm(): boolean {
     const stage = this.props.formik.values;
-    return stage.templateRenderer === this.HELM_RENDERER || !SETTINGS.feature.kustomizeEnabled;
+    return stage.templateRenderer === this.HELM_RENDERER;
   }
 
   public render() {


### PR DESCRIPTION
rendering was messed up when kustomize was disables via settings.
previously it would render both forms when no rendering option was
selected.