### PR TITLE
fix(artifacts/bitbucket) Allow updates to the artifact text input even when the regex pattern does not match

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/bitbucket/BitbucketArtifactEditor.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/bitbucket/BitbucketArtifactEditor.tsx
@@ -42,14 +42,22 @@ export const BitbucketDefault: IArtifactKindConfig = {
     }
 
     private onReferenceChanged = (reference: string) => {
-      const pathRegex = new RegExp('/1.0/repositories/[^/]*/[^/]*/raw/[^/]*/(.*)$');
-      const results = pathRegex.exec(reference);
-      if (results !== null) {
-        const clonedArtifact = cloneDeep(this.props.artifact);
-        clonedArtifact.name = decodeURIComponent(results[1]);
-        clonedArtifact.reference = reference;
-        this.props.onChange(clonedArtifact);
+      const bitbucketCloudRegex = new RegExp('/1.0/repositories/[^/]*/[^/]*/raw/[^/]*/(.*)$');
+      const bitbucketServerRegex = new RegExp('/projects/[^/]*/repos/[^/]*/raw/([^?]*)');
+
+      const clonedArtifact = cloneDeep(this.props.artifact);
+      clonedArtifact.reference = reference;
+
+      let results;
+      results = bitbucketCloudRegex.exec(reference);
+      if (results === null) {
+        results = bitbucketServerRegex.exec(reference);
       }
+
+      if (results !== null) {
+        clonedArtifact.name = decodeURIComponent(results[1]);
+      }
+      this.props.onChange(clonedArtifact);
     };
 
     public render() {


### PR DESCRIPTION
Fixes https://github.com/spinnaker/spinnaker/issues/4958

Updated regex to include the bitbucket server regex pattern, allows updates to the text input box (value) even when the regex does not match to allow natural user input versus forcing copying and pasting the full URL.
