### PR TITLE
fix(amazon/pipeline): sort list of available bake regions

### DIFF
--- a/app/scripts/modules/amazon/src/pipeline/stages/bake/awsBakeStage.js
+++ b/app/scripts/modules/amazon/src/pipeline/stages/bake/awsBakeStage.js
@@ -67,7 +67,7 @@ module.exports = angular
           baseLabelOptions: BakeryReader.getBaseLabelOptions(),
           storeTypes: ['ebs', 'docker'],
         }).then(function(results) {
-          $scope.regions = results.regions;
+          $scope.regions = [...results.regions].sort();
           $scope.storeTypes = results.storeTypes;
           if (!$scope.stage.storeType && $scope.storeTypes && $scope.storeTypes.length) {
             $scope.stage.storeType = $scope.storeTypes[0];
@@ -78,10 +78,7 @@ module.exports = angular
             delete $scope.stage.region;
           }
           if (!$scope.stage.regions.length && $scope.application.defaultRegions.aws) {
-            $scope.stage.regions.push($scope.application.defaultRegions.aws);
-          }
-          if (!$scope.stage.regions.length && $scope.application.defaultRegions.aws) {
-            $scope.stage.regions.push($scope.application.defaultRegions.aws);
+            $scope.stage.regions.push(...Object.keys($scope.application.defaultRegions.aws).sort());
           }
           $scope.baseOsOptions = results.baseOsOptions.baseImages;
           $scope.baseLabelOptions = results.baseLabelOptions;


### PR DESCRIPTION
We typically sort the list of available regions in stage configs (e.g. `AccountRegionClusterSelector`), but we don't in the AWS bake stage. This is not only somewhat confusing (we've observed people accidentally select the wrong regions because they were relying on order rather than reading the region name), it also has the side effect of making pipeline JSON 'different' from it's saved state if the API decides to return a different ordering for some reason.

That very thing _seems_ to have happened with some of our internal users, who noticed a prompt to save because the order our `checklist` component used stopped matching the saved JSON ordering, resulting in a diff (even though the same regions were selected).

This PR does two small things:
- Enforce a client side sort
- Change the way we use `application.defaultRegions` from treating it like an array (it's not) to treating it like a map of region strings -> region metadata (which is what it actually is). I guess nobody on AWS actually uses that feature?

