### PR TITLE
feat(core/presentation): Put margin between StandardFieldLayout's input and validation

### DIFF
--- a/app/scripts/modules/core/src/presentation/flex-layout.less
+++ b/app/scripts/modules/core/src/presentation/flex-layout.less
@@ -81,6 +81,24 @@
   &.space-between {
     justify-content: space-between;
   }
+
+  &.margin-between-sm {
+    > * + * {
+      margin-top: 4px;
+    }
+  }
+
+  &.margin-between-md {
+    > * + * {
+      margin-top: 8px;
+    }
+  }
+
+  &.margin-between-lg {
+    > * + * {
+      margin-top: 12px;
+    }
+  }
 }
 
 // TODO(archana): Fix !important by removing the nowrap from the flex-container-h and v and testing to

--- a/app/scripts/modules/core/src/presentation/forms/layouts/StandardFieldLayout.tsx
+++ b/app/scripts/modules/core/src/presentation/forms/layouts/StandardFieldLayout.tsx
@@ -28,12 +28,12 @@ export class StandardFieldLayout extends React.Component<IFieldLayoutProps> {
         )}
 
         <div className="flex-grow">
-          <div className="flex-container-v">
+          <div className="flex-container-v margin-between-md">
             <div className="flex-container-h baseline margin-between-lg StandardFieldLayout_Contents">
               {input} {actions}
             </div>
 
-            <div className="StandardFieldLayout_Validation">{validation}</div>
+            {validation && <div className="StandardFieldLayout_Validation">{validation}</div>}
           </div>
         </div>
       </div>


### PR DESCRIPTION
![Screen Shot 2019-10-02 at 10 50 37 AM](https://user-images.githubusercontent.com/2053478/66068543-a2785080-e502-11e9-9d38-f87514eefd01.png)

Adding margin in prep for switching to the newer form field validation styles
