### PR TITLE
fix(titus/pipeline): use proper git ssh URL for docker bakes

### DIFF
--- a/app/scripts/modules/titus/src/pipeline/stages/bake/titusBakeStage.js
+++ b/app/scripts/modules/titus/src/pipeline/stages/bake/titusBakeStage.js
@@ -67,7 +67,7 @@ module.exports = angular
             url += '/' + stage.repository.directory;
           }
           if (stage.repository.hash) {
-            url += stage.repository.hash;
+            url += `?${stage.repository.hash}`;
           }
           if (stage.repository.branch) {
             url += '@' + stage.repository.branch;


### PR DESCRIPTION
Most Titus users at Netflix use the option to pull git repository information from the pipeline trigger, which uses expressions to build up a git URL which is passed to our internal bakery.

Turns out that when *not* using that option and specifying a branch/hash/etc. yourself in the stage, we weren't putting the appropriate query string `?` before the hash component of the URL.