### PR TITLE
fix(triggers): fix a few minor issues with manual execution triggers

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/triggers/Trigger.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/Trigger.tsx
@@ -158,7 +158,7 @@ function TriggerForm(triggerFormProps: ITriggerProps & { formik: FormikProps<ITr
           <FormikFormField
             name="expectedArtifactIds"
             label="Artifact Constraints"
-            help={<HelpField id="pipeline.config.expectedArtifacts" />}
+            help={<HelpField id="pipeline.config.expectedArtifact" />}
             input={props => <ReactSelectInput {...props} multi={true} options={expectedArtifactOptions} />}
           />
         )}

--- a/app/scripts/modules/core/src/pipeline/manualExecution/ManualPipelineExecutionModal.tsx
+++ b/app/scripts/modules/core/src/pipeline/manualExecution/ManualPipelineExecutionModal.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { Formik, Form } from 'formik';
 import { Modal } from 'react-bootstrap';
 import { Observable, Subject } from 'rxjs';
-import { assign, clone, compact, extend, get, head, uniq, isArray, isEmpty, pickBy } from 'lodash';
+import { assign, clone, compact, extend, get, head, uniq, isArray, isEmpty, isEqual, pickBy } from 'lodash';
 
 import { SubmitButton, ModalClose } from 'core/modal';
 import { Application } from 'core/application';
@@ -289,7 +289,7 @@ export class ManualExecutionModal extends React.Component<IManualExecutionModalP
     const triggers = this.formatTriggers(pipeline && pipeline.triggers ? pipeline.triggers : []);
     let trigger: ITrigger;
     if (this.props.trigger) {
-      // Certain fields like correlationId will cause unexepcted behavior if used to trigger
+      // Certain fields like correlationId will cause unexepected behavior if used to trigger
       // a different execution, others are just left unused. Let's exclude them.
       trigger = pickBy(this.props.trigger, (_, key) => !TRIGGER_FIELDS_TO_EXCLUDE.includes(key));
 
@@ -300,10 +300,10 @@ export class ManualExecutionModal extends React.Component<IManualExecutionModalP
       const matchingTrigger = (pipeline.triggers || []).find(t =>
         Object.keys(t)
           .filter(k => k !== 'description')
-          .every(k => get(t, k) === get(this.props.trigger, k)),
+          .every(k => isEqual(get(t, k), get(trigger, k))),
       );
       // If we found a match, rehydrate it with everything from trigger, otherwise just default back to setting it to trigger
-      trigger = matchingTrigger ? assign(trigger, matchingTrigger) : trigger;
+      trigger = matchingTrigger ? assign(matchingTrigger, trigger) : trigger;
 
       if (Registry.pipeline.hasManualExecutionComponentForTriggerType(trigger.type)) {
         // If the trigger has a manual component, we don't want to also explicitly


### PR DESCRIPTION
While investigating a bug with manual re-runs of pipelines triggered on Docker images (that turned out to be an [Echo issue](https://github.com/spinnaker/echo/pull/669)), I also found a few small regressions in Deck:

- Point "Artifact Constraints" field at correct help text

- When attempting to match a pipeline trigger to an execution trigger, use deep equality to compare properties (currently, there will never be a match because the pipeline trigger's `expectedArtifactIds`, a list, will never triple-equal the execution trigger's `expectedArtifactIds`). Also, only compare the pipeline trigger to the modified execution trigger, which if a manual trigger, has had its type changed from `manual` (which will never match the type of a pipeline trigger).
- When hydrating the matched pipeline trigger with properties from the execution trigger, the matched pipeline trigger should be the target and the execution trigger the source, not vice-versa. I think this logic was accidentally reversed in the conversion to React (see line 124 of `manualPipelineExecution.controller.js` before [this PR](https://github.com/spinnaker/deck/pull/7075/files)).