### PR TITLE
fix(core): fix jumping cursor in trigger inputs

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/pipelineConfigurer.js
+++ b/app/scripts/modules/core/src/pipeline/config/pipelineConfigurer.js
@@ -537,23 +537,20 @@ module.exports = angular
 
       //update pipeline through a callback for React
       this.updatePipelineConfig = changes => {
-        $scope.$applyAsync(() => {
-          $scope.pipeline = Object.assign(
-            {},
-            $scope.pipeline,
-            $scope.isV2TemplatedPipeline
-              ? PipelineTemplateV2Service.filterInheritedConfig(Object.assign({}, changes))
-              : changes,
-          );
+        $scope.pipeline = Object.assign(
+          $scope.pipeline,
+          $scope.isV2TemplatedPipeline
+            ? PipelineTemplateV2Service.filterInheritedConfig(Object.assign({}, changes))
+            : changes,
+        );
 
-          if ($scope.isV2TemplatedPipeline) {
-            $scope.renderablePipeline = Object.assign({}, $scope.renderablePipeline, changes);
-          } else if (!$scope.isTemplatedPipeline) {
-            $scope.renderablePipeline = $scope.pipeline;
-          }
+        if ($scope.isV2TemplatedPipeline) {
+          $scope.renderablePipeline = Object.assign($scope.renderablePipeline, changes);
+        } else if (!$scope.isTemplatedPipeline) {
+          $scope.renderablePipeline = $scope.pipeline;
+        }
 
-          markDirty();
-        });
+        markDirty();
       };
     },
   ]);

--- a/app/scripts/modules/core/src/pipeline/config/triggers/TriggersWrapper.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/TriggersWrapper.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+
+import { IPipeline } from 'core/domain';
+import { ITriggersProps, Triggers } from 'core/pipeline';
+
+export class TriggersWrapper extends React.Component<ITriggersProps> {
+  private updatePipelineConfig = (changes: Partial<IPipeline>): void => {
+    this.props.updatePipelineConfig(changes);
+    this.forceUpdate();
+  };
+
+  public render() {
+    return <Triggers {...this.props} updatePipelineConfig={this.updatePipelineConfig} />;
+  }
+}

--- a/app/scripts/modules/core/src/pipeline/config/triggers/triggers.module.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/triggers.module.ts
@@ -1,11 +1,11 @@
 import { module } from 'angular';
 import { react2angular } from 'react2angular';
 
-import { Triggers } from './Triggers';
+import { TriggersWrapper } from './TriggersWrapper';
 import { ARTIFACT_MODULE } from './artifacts/artifact.module';
 
 export const TRIGGERS = 'spinnaker.core.pipeline.config.trigger.triggersDirective';
 module(TRIGGERS, [ARTIFACT_MODULE]).component(
   'triggers',
-  react2angular(Triggers, ['application', 'pipeline', 'fieldUpdated', 'updatePipelineConfig', 'viewState']),
+  react2angular(TriggersWrapper, ['application', 'pipeline', 'fieldUpdated', 'updatePipelineConfig', 'viewState']),
 );

--- a/app/scripts/modules/core/src/pipeline/index.ts
+++ b/app/scripts/modules/core/src/pipeline/index.ts
@@ -10,6 +10,7 @@ export * from './config/stages/templates';
 export * from './config/templates';
 export * from './config/triggers/baseBuild/BaseBuildTriggerTemplate';
 export * from './config/triggers/RunAsUser';
+export * from './config/triggers/Triggers';
 export * from './config/validation/PipelineConfigValidator';
 export * from './create';
 export * from './details';

--- a/app/scripts/modules/core/src/pipeline/manualExecution/ManualPipelineExecutionModal.tsx
+++ b/app/scripts/modules/core/src/pipeline/manualExecution/ManualPipelineExecutionModal.tsx
@@ -289,7 +289,7 @@ export class ManualExecutionModal extends React.Component<IManualExecutionModalP
     const triggers = this.formatTriggers(pipeline && pipeline.triggers ? pipeline.triggers : []);
     let trigger: ITrigger;
     if (this.props.trigger) {
-      // Certain fields like correlationId will cause unexepected behavior if used to trigger
+      // Certain fields like correlationId will cause unexpected behavior if used to trigger
       // a different execution, others are just left unused. Let's exclude them.
       trigger = pickBy(this.props.trigger, (_, key) => !TRIGGER_FIELDS_TO_EXCLUDE.includes(key));
 


### PR DESCRIPTION
As reported by @battlecow in [this PR](https://github.com/spinnaker/deck/pull/7483), controlled inputs such as `SpelText` in the pipeline config view have cursors that will jump to the end of the input whenever the input is edited.

I _think_ this is because we were updating the angular model with `$scope.$applyAsync`, and controlled React inputs are expecting their `onChange` handlers to be synchronous. I fixed this by implementing a wrapper component, similar to the one @alanmquach built for [stage configs](https://github.com/spinnaker/deck/blob/master/app/scripts/modules/core/src/pipeline/config/stages/StageConfigWrapper.tsx), that updates the angular model synchronously and then calls `forceUpdate` on the React component.


<details><summary>Before</summary>
<p>

![48da1454-b2cd-4920-b8b1-4dd9af25215b](https://user-images.githubusercontent.com/15936279/66163810-27e12b00-e5ff-11e9-8f6f-bfff21541cb0.gif)

</p>
</details>

<details><summary>After</summary>
<p>

![e0243a3c-3618-4322-9e68-35ac0b6fec40](https://user-images.githubusercontent.com/15936279/66164117-f026b300-e5ff-11e9-852d-6fa45979fc82.gif)

</p>
</details>


