### PR TITLE
feat(amazon/serverGroup): add AmazonMQ CloudWatch namespace

### DIFF
--- a/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/upsert/alarm/namespaces.ts
+++ b/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/upsert/alarm/namespaces.ts
@@ -1,6 +1,7 @@
 export const NAMESPACES = [
   'AWS/ApplicationELB',
   'AWS/AutoScaling',
+  'AWS/AmazonMQ',
   'AWS/Billing',
   'AWS/CloudFront',
   'AWS/CloudSearch',


### PR DESCRIPTION
We whitelist the CloudWatch namespaces you can pick from when setting up a custom scaling policy metric, and recently got asked to include an additional one. We pass these on untouched through orca/clouddriver and on to AWS, so no additional work needed on the backend.