### PR TITLE
fix(core/pipeline): Fix stage duration in UI after restarting a stage

### DIFF
--- a/app/scripts/modules/core/src/pipeline/service/ExecutionsTransformer.ts
+++ b/app/scripts/modules/core/src/pipeline/service/ExecutionsTransformer.ts
@@ -88,7 +88,7 @@ export class ExecutionsTransformer {
   // TODO: remove if we ever figure out why quickPatchAsgStage never has a startTime
   private static setMasterStageStartTime(stages: IExecutionStage[], stage: IExecutionStageSummary): void {
     const allStartTimes = stages.filter(child => child.startTime).map(child => child.startTime);
-    if (allStartTimes.length) {
+    if (!stage.startTime && allStartTimes.length) {
       stage.startTime = Math.min(...allStartTimes);
     }
   }


### PR DESCRIPTION
We transform executions in Deck to improve UX.  One of these transforms
combines multiple stages into one (for UI purposes only), and applies
the earliest start-time of all the combined stages to the "master" stage.
This changes the latter logic so it only applies the computed startTime
if the stage doesn't already have a startTime.

This fixes a case where two stages were combined into one in the UI,
the user restarted the stage (it restarts the *second* stage), but the
elapsed time in Deck was incorretly computed using the first stage's startTime.
