### PR TITLE
fix(core/pipeline): When a trigger is updated, replace the entire object

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/triggers/TriggersPageContent.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/TriggersPageContent.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { extend, findIndex } from 'lodash';
+import { findIndex } from 'lodash';
 
 import { Application } from 'core/application';
 import { ArtifactReferenceService } from 'core/artifact/ArtifactReferenceService';
@@ -51,9 +51,9 @@ export function TriggersPageContent(props: ITriggersPageContentProps) {
     updatePipelineConfig({ triggers: newTriggers });
   }
 
-  function updateTrigger(index: number, changes: Partial<ITrigger>) {
+  function updateTrigger(index: number, updatedTrigger: ITrigger) {
     const updatedTriggers = triggers.slice(0);
-    extend(updatedTriggers[index], changes);
+    updatedTriggers[index] = updatedTrigger;
     PipelineConfigValidator.validatePipeline(pipeline);
     updatePipelineConfig({ triggers: updatedTriggers });
     if (SETTINGS.feature['artifactsRewrite']) {


### PR DESCRIPTION
Previously, triggers would all send partial updates (i.e., one field has changed)and the handler code would mutate the object, updating the fields.

Now, however, all triggers are written in React (and mostly in formik).  We no longer need to support object mutation for angularjs.  This changes the update handler to replace the entire object reference with the updated trigger.