### PR TITLE
fix(ui): Type field missing for CLB detail view

### DIFF
--- a/app/scripts/modules/amazon/src/loadBalancer/details/loadBalancerDetails.html
+++ b/app/scripts/modules/amazon/src/loadBalancer/details/loadBalancerDetails.html
@@ -78,8 +78,8 @@
         </dd>
         <dt>Subnet</dt>
         <dd>{{ctrl.getFirstSubnetPurpose(ctrl.loadBalancer.subnetDetails)}}</dd>
-        <dt ng-if="ctrl.ipAddressTypeDescription">Type</dt>
-        <dd ng-if="ctrl.ipAddressTypeDescription">{{ctrl.loadBalancer.loadBalancerType}}</dd>
+        <dt ng-if="ctrl.loadBalancer.loadBalancerType">Type</dt>
+        <dd ng-if="ctrl.loadBalancer.loadBalancerType">{{ctrl.loadBalancer.loadBalancerType}}</dd>
         <dt ng-if="ctrl.ipAddressTypeDescription">IP Type</dt>
         <dd ng-if="ctrl.ipAddressTypeDescription">{{ctrl.ipAddressTypeDescription}}</dd>
       </dl>


### PR DESCRIPTION
The "type" field is missing in the loadbalancer details view for CLBs. 

Before: 
![Screen Shot 2019-10-09 at 12 24 51 PM](https://user-images.githubusercontent.com/26560152/66513787-b4249f80-ea90-11e9-8588-790f147a0fd3.png)

After:
![Screen Shot 2019-10-09 at 12 25 49 PM](https://user-images.githubusercontent.com/26560152/66513795-b850bd00-ea90-11e9-91ea-533441f57697.png)
