### PR TITLE
fix(artifact/bitbucket): Bitbucket Use Default Artifact fix

### DIFF
--- a/app/scripts/modules/core/src/help/help.contents.ts
+++ b/app/scripts/modules/core/src/help/help.contents.ts
@@ -148,7 +148,7 @@ const helpContents: { [key: string]: string } = {
       <p>The version of chart you want to trigger on changes to</p>`,
   'pipeline.config.expectedArtifact.defaultBitbucket.reference': `
       <p>The Bitbucket API file url the artifact lives under. The domain name may change if you're running your own Bitbucket server. The repository and path to files must be URL encoded.</p>
-      <p>An example is <code>https://api.bitbucket.org/1.0/repositories/$ORG/$REPO/raw/$VERSION/$FILEPATH</code>. See <a href="https://www.spinnaker.io/reference/artifacts/types/bitbucket-file/#fields">our docs</a> for more info.</p>`,
+      <p>An example is <code>https://api.bitbucket.com/rest/api/1.0/$PROJECTS/$PROJECTKEY/repos/$REPONAME/raw/$FILEPATH</code>. See <a href="https://www.spinnaker.io/reference/artifacts/types/bitbucket-file/#fields">our docs</a> for more info.</p>`,
   'pipeline.config.trigger.webhook.source': `
       <p>Determines the target URL required to trigger this pipeline, as well as how the payload can be transformed into artifacts.</p>
   `,

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/bitbucket/BitbucketArtifactEditor.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/bitbucket/BitbucketArtifactEditor.tsx
@@ -42,21 +42,23 @@ export const BitbucketDefault: IArtifactKindConfig = {
     }
 
     private onReferenceChanged = (reference: string) => {
-      const pathRegex = new RegExp('/1.0/repositories/[^/]*/[^/]*/raw/[^/]*/(.*)$');
+      const pathRegex = new RegExp('.*/rest/api/1.0/[^/]*/[^/]*/repos/[^/]*/raw/(.*)$');
       const results = pathRegex.exec(reference);
+      const clonedArtifact = cloneDeep(this.props.artifact);
+      clonedArtifact.reference = reference;
       if (results !== null) {
-        const clonedArtifact = cloneDeep(this.props.artifact);
-        clonedArtifact.name = decodeURIComponent(results[1]);
-        clonedArtifact.reference = reference;
-        this.props.onChange(clonedArtifact);
+        clonedArtifact.name = results[1];
+      } else {
+        clonedArtifact.name = reference;
       }
+      this.props.onChange(clonedArtifact);
     };
 
     public render() {
       return (
         <StageConfigField label="Object path" helpKey="pipeline.config.expectedArtifact.defaultDocker.reference">
           <SpelText
-            placeholder="https://api.bitbucket.com/repos/$ORG/$REPO/contents/$FILEPATH"
+            placeholder="https://api.bitbucket.com/rest/api/1.0/$PROJECTS/$PROJECTKEY/repos/$REPONAME/raw/$FILEPATH"
             value={this.props.artifact.reference}
             onChange={this.onReferenceChanged}
             pipeline={this.props.pipeline}

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/bitbucket/defaultBitbucket.artifact.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/bitbucket/defaultBitbucket.artifact.ts
@@ -17,12 +17,14 @@ module(DEFAULT_BITBUCKET_ARTIFACT, []).config(() => {
     controller: function(artifact: IArtifact) {
       this.artifact = artifact;
       this.artifact.type = 'bitbucket/file';
-      const pathRegex = new RegExp('/1.0/repositories/[^/]*/[^/]*/raw/[^/]*/(.*)$');
+      const pathRegex = new RegExp('.*/rest/api/1.0/[^/]*/[^/]*/repos/[^/]*/raw/(.*)$');
 
       this.onReferenceChange = () => {
         const results = pathRegex.exec(this.artifact.reference);
         if (results !== null) {
-          this.artifact.name = decodeURIComponent(results[1]);
+          this.artifact.name = results[1];
+        } else {
+          this.artifact.name = this.artifact.reference;
         }
       };
     },
@@ -36,7 +38,7 @@ module(DEFAULT_BITBUCKET_ARTIFACT, []).config(() => {
     </label>
     <div class="col-md-8">
       <input type="text"
-             placeholder="https://api.bitbucket.org/1.0/repositories/$ORG/$REPO/raw/$VERSION/$FILEPATH"
+             placeholder="https://api.bitbucket.com/rest/api/1.0/$PROJECTS/$PROJECTKEY/repos/$REPONAME/raw/$FILEPATH"
              class="form-control input-sm"
              ng-change="ctrl.onReferenceChange()"
              ng-model="ctrl.artifact.reference"/>


### PR DESCRIPTION
# Bitbucket Default analysis
## Current behavior
When **Use Default Artifact** option is checked the **Object path** field is NOT editable.

![](https://paper-attachments.dropbox.com/s_275B06AD8FE10A10A61F125AB047125AC92D8FDC115907C318E7B542FF89D962_1570557564944_Screen+Shot+2019-10-08+at+12.58.49.png)

The issue is due the method **onReferenceChanged** the variable **results** is always null
```
private onReferenceChanged = (reference: string) => {
	const pathRegex = new RegExp('/1.0/repositories/[^/]*/[^/]*/raw/[^/]*/(.*)$');
	const results = pathRegex.exec(reference);
	if (results !== null) {
		const clonedArtifact = cloneDeep(this.props.artifact);
		clonedArtifact.name = decodeURIComponent(results[1]);
		clonedArtifact.reference = reference;
		this.props.onChange(clonedArtifact);
	}
};
```
The correct way to do that is pulled out the **clonedAtifact** constant and then check if **results** exists.
```
    private  onReferenceChanged  = (reference:  string) => {
    	const  pathRegex  =  new  RegExp('/1.0/repositories/[^/]*/[^/]*/raw/[^/]*/(.*)$');
    	const  results  =  pathRegex.exec(reference);
    	const  clonedArtifact  =  cloneDeep(this.props.artifact);
    	clonedArtifact.reference  =  reference;
    	if (results  !==  null) {
    		clonedArtifact.name  =  results[1];
    	} else {
    		clonedArtifact.name  =  reference;
    	}
    	this.props.onChange(clonedArtifact);
    };
```
Doing this, the field is editable now.
  
![](https://paper-attachments.dropbox.com/s_275B06AD8FE10A10A61F125AB047125AC92D8FDC115907C318E7B542FF89D962_1570558797141_Screen+Shot+2019-10-08+at+13.17.42.png)

## RegEx Issue
  The RegEx is not matching with the 1.0 api rest format.
**Current:**
`/1.0/repositories/[^/]*/[^/]*/raw/[^/]*/(.*)$`
  **Proposed**
  `.*/rest/api/1.0/[^/]*/[^/]*/repos/[^/]*/raw/(.*)$`

Replacing this regEx then the values for **name** and **reference** are well formed.

![](https://paper-attachments.dropbox.com/s_275B06AD8FE10A10A61F125AB047125AC92D8FDC115907C318E7B542FF89D962_1570558966358_Screen+Shot+2019-10-08+at+13.18.07.png)

## Conclusion
Modify the method and change the RegEx in order to support 1.0 API rest.

  ```
private  onReferenceChanged  = (reference:  string) => {
	const  pathRegex  =  new  RegExp('.*/rest/api/1.0/[^/]*/[^/]*/repos/[^/]*/raw/(.*)$');
	const  results  =  pathRegex.exec(reference);
	const  clonedArtifact  =  cloneDeep(this.props.artifact);
	clonedArtifact.reference  =  reference;
	if (results  !==  null) {
		clonedArtifact.name  =  results[1];
	} else {
		clonedArtifact.name  =  reference;
	}
	this.props.onChange(clonedArtifact);
};
```
