### PR TITLE
fix(core/pipeline): Pass Trigger validateFn to the trigger's Formik

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/triggers/Trigger.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/Trigger.tsx
@@ -35,13 +35,22 @@ export interface ITriggerProps {
   updateTrigger: (index: number, changes: { [key: string]: any }) => void;
 }
 
-export const Trigger = (props: ITriggerProps) => (
-  <SpinFormik
-    onSubmit={() => null}
-    initialValues={props.trigger}
-    render={formik => <TriggerForm {...props} formik={formik} />}
-  />
-);
+export const Trigger = (props: ITriggerProps) => {
+  function getValidateFn() {
+    const triggerType = Registry.pipeline.getTriggerTypes().find(type => type.key === props.trigger.type);
+    const validateWithContext = (values: ITrigger) => triggerType.validateFn(values, { pipeline: props.pipeline });
+    return triggerType && triggerType.validateFn ? validateWithContext : undefined;
+  }
+
+  return (
+    <SpinFormik<ITrigger>
+      onSubmit={() => null}
+      initialValues={props.trigger}
+      validate={getValidateFn()}
+      render={formik => <TriggerForm {...props} formik={formik} />}
+    />
+  );
+};
 
 const commonTriggerFields: Array<keyof ITrigger> = [
   'enabled',


### PR DESCRIPTION
A trigger type can register a 'validateFn'.
This validateFn is run against its trigger data by the PipelineConfigValidator.
If any errors are found, the little triangle shows up next to the save pipeline button.

However, those same trigger validation errors didn't show up on the form fields themselves.
This PR wires the validateFn into the Trigger's Formik validate prop.
Validation is run twice (once by formik, once by PipelineConfigValidator).
Not ideal, but acceptable.


Before:

![broken](https://user-images.githubusercontent.com/2053478/66536357-7ac05400-ead1-11e9-82af-a22c5f81a245.gif)


After:

![fixed](https://user-images.githubusercontent.com/2053478/66536362-7e53db00-ead1-11e9-8ec1-5a5f36a3c8d6.gif)
