### PR TITLE
fix(core/presentation): Make all DOMPurify'd links open in a new window

### DIFF
--- a/app/scripts/modules/core/src/presentation/domPurifyOpenLinksInNewWindow.ts
+++ b/app/scripts/modules/core/src/presentation/domPurifyOpenLinksInNewWindow.ts
@@ -1,0 +1,19 @@
+import * as DOMPurify from 'dompurify';
+
+export function domPurifyOpenLinksInNewWindow() {
+  // Add a hook to make all DOMPurify'd links open a new window
+  // See: https://github.com/cure53/DOMPurify/tree/master/demos#hook-to-open-all-links-in-a-new-window-link
+  DOMPurify.addHook('afterSanitizeAttributes', function(node: any) {
+    // set all elements owning target to target=_blank
+    if ('target' in node) {
+      node.setAttribute('target', '_blank');
+      // prevent https://www.owasp.org/index.php/Reverse_Tabnabbing
+      node.setAttribute('rel', 'noopener noreferrer');
+    }
+    // set non-HTML/MathML links to xlink:show=new
+    if (!node.hasAttribute('target') && (node.hasAttribute('xlink:href') || node.hasAttribute('href'))) {
+      node.setAttribute('xlink:show', 'new');
+    }
+    return node;
+  });
+}

--- a/app/scripts/modules/core/src/presentation/presentation.module.js
+++ b/app/scripts/modules/core/src/presentation/presentation.module.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import * as DOMPurify from 'dompurify';
+
 const angular = require('angular');
 
 import { AUTO_SCROLL_DIRECTIVE } from 'core/presentation/autoScroll/autoScroll.directive';
@@ -14,15 +16,33 @@ import './details.less';
 import './main.less';
 import './navPopover.less';
 
-module.exports = angular.module('spinnaker.core.presentation', [
-  ANY_FIELD_FILTER,
-  AUTO_SCROLL_DIRECTIVE,
-  PAGE_NAVIGATOR_COMPONENT,
-  PAGE_SECTION_COMPONENT,
-  require('./collapsibleSection/collapsibleSection.directive').name,
-  require('./isVisible/isVisible.directive').name,
-  ROBOT_TO_HUMAN_FILTER,
-  require('./sortToggle/sorttoggle.directive').name,
-  require('./percent.filter').name,
-  REPLACE_FILTER,
-]);
+module.exports = angular
+  .module('spinnaker.core.presentation', [
+    ANY_FIELD_FILTER,
+    AUTO_SCROLL_DIRECTIVE,
+    PAGE_NAVIGATOR_COMPONENT,
+    PAGE_SECTION_COMPONENT,
+    require('./collapsibleSection/collapsibleSection.directive').name,
+    require('./isVisible/isVisible.directive').name,
+    ROBOT_TO_HUMAN_FILTER,
+    require('./sortToggle/sorttoggle.directive').name,
+    require('./percent.filter').name,
+    REPLACE_FILTER,
+  ])
+  .run(() => {
+    // Add a hook to make all DOMPurify'd links open a new window
+    // See: https://github.com/cure53/DOMPurify/tree/master/demos#hook-to-open-all-links-in-a-new-window-link
+    DOMPurify.addHook('afterSanitizeAttributes', function(node) {
+      // set all elements owning target to target=_blank
+      if ('target' in node) {
+        node.setAttribute('target', '_blank');
+        // prevent https://www.owasp.org/index.php/Reverse_Tabnabbing
+        node.setAttribute('rel', 'noopener noreferrer');
+      }
+      // set non-HTML/MathML links to xlink:show=new
+      if (!node.hasAttribute('target') && (node.hasAttribute('xlink:href') || node.hasAttribute('href'))) {
+        node.setAttribute('xlink:show', 'new');
+      }
+      return node;
+    });
+  });

--- a/app/scripts/modules/core/src/presentation/presentation.module.js
+++ b/app/scripts/modules/core/src/presentation/presentation.module.js
@@ -1,7 +1,5 @@
 'use strict';
 
-import * as DOMPurify from 'dompurify';
-
 const angular = require('angular');
 
 import { AUTO_SCROLL_DIRECTIVE } from 'core/presentation/autoScroll/autoScroll.directive';
@@ -10,6 +8,7 @@ import { PAGE_NAVIGATOR_COMPONENT } from './navigation/pageNavigator.component';
 import { PAGE_SECTION_COMPONENT } from './navigation/pageSection.component';
 import { REPLACE_FILTER } from './replace.filter';
 import { ROBOT_TO_HUMAN_FILTER } from './robotToHumanFilter/robotToHuman.filter';
+import { domPurifyOpenLinksInNewWindow } from './domPurifyOpenLinksInNewWindow';
 
 import './flex-layout.less';
 import './details.less';
@@ -29,20 +28,4 @@ module.exports = angular
     require('./percent.filter').name,
     REPLACE_FILTER,
   ])
-  .run(() => {
-    // Add a hook to make all DOMPurify'd links open a new window
-    // See: https://github.com/cure53/DOMPurify/tree/master/demos#hook-to-open-all-links-in-a-new-window-link
-    DOMPurify.addHook('afterSanitizeAttributes', function(node) {
-      // set all elements owning target to target=_blank
-      if ('target' in node) {
-        node.setAttribute('target', '_blank');
-        // prevent https://www.owasp.org/index.php/Reverse_Tabnabbing
-        node.setAttribute('rel', 'noopener noreferrer');
-      }
-      // set non-HTML/MathML links to xlink:show=new
-      if (!node.hasAttribute('target') && (node.hasAttribute('xlink:href') || node.hasAttribute('href'))) {
-        node.setAttribute('xlink:show', 'new');
-      }
-      return node;
-    });
-  });
+  .run(domPurifyOpenLinksInNewWindow);


### PR DESCRIPTION
https://github.com/cure53/DOMPurify/tree/master/demos#hook-to-open-all-links-in-a-new-window-link

This makes it so `DOMPurify.purify(html)` will add `target="_blank"` to all links.  

The assumption here is that whenever we use DOMPurify, we're likely rendering user-provided content, and that any links provided should not blow away the spinnaker session.
