### PR TITLE
fix(bakeManifest/helm): rawOverrides option

### DIFF
--- a/app/scripts/modules/core/src/help/help.contents.ts
+++ b/app/scripts/modules/core/src/help/help.contents.ts
@@ -256,6 +256,8 @@ const helpContents: { [key: string]: string } = {
   'pipeline.config.bake.manifest.expectedArtifact': '<p>This is the template you want to render.</p>',
   'pipeline.config.bake.manifest.overrideExpressionEvaluation':
     '<p>Explicitly evaluate SpEL expressions in overrides just prior to manifest baking. Can be paired with the "Skip SpEL evaluation" option in the Deploy Manifest stage when baking a third-party manifest artifact with expressions not meant for Spinnaker to evaluate as SpEL.</p>',
+  'pipeline.config.bake.manifest.helm.rawOverrides':
+    'Use <i>--set</i> instead of <i>--set-string</i> when injecting override values. Values injected using <i>--set</i> will be converted to primitive types by Helm.',
   'pipeline.config.haltPipelineOnFailure':
     'Immediately halts execution of all running stages and fails the entire execution.',
   'pipeline.config.haltBranchOnFailure':

--- a/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/BakeManifestStageForm.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/BakeManifestStageForm.tsx
@@ -47,6 +47,7 @@ export class BakeManifestStageForm extends React.Component<
                 this.props.formik.setFieldValue('templateRenderer', o.target.value);
               }}
               value={stage.templateRenderer}
+              validation={{}}
               stringOptions={this.templateRenderers()}
             />
           </StageConfigField>

--- a/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/helm/BakeHelmConfigForm.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/helm/BakeHelmConfigForm.tsx
@@ -195,6 +195,17 @@ export class BakeHelmConfigForm extends React.Component<IBakeHelmConfigFormProps
         </StageConfigField>
         <StageConfigField
           fieldColumns={6}
+          helpKey={'pipeline.config.bake.manifest.helm.rawOverrides'}
+          label="Raw Overrides"
+        >
+          <CheckboxInput
+            value={stage.rawOverrides}
+            text={''}
+            onChange={() => this.props.formik.setFieldValue('rawOverrides', !stage.rawOverrides)}
+          />
+        </StageConfigField>
+        <StageConfigField
+          fieldColumns={6}
           helpKey={'pipeline.config.bake.manifest.overrideExpressionEvaluation'}
           label="Expression Evaluation"
         >


### PR DESCRIPTION
adds an option for rawOverrides. this will trigger the use of `--set` in
the bake manifest stage.