### PR TITLE
Bump package core to 0.0.421 and amazon to 0.0.216  

### DIFF
--- a/app/scripts/modules/amazon/package.json
+++ b/app/scripts/modules/amazon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/amazon",
-  "version": "0.0.215",
+  "version": "0.0.216",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/core",
-  "version": "0.0.420",
+  "version": "0.0.421",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
### chore(core): Bump version to 0.0.421

c1a28fef4097b5b5bd3f1c7c45f4140d82f65f1e fix(core/presentation): Do not use a regexp with /test/s because it's not supported in firefox (#7518)

### chore(amazon): Bump version to 0.0.216

74e829d0d3d0de32fd2d9e624a5ee88dbbe96e28 feat(provider/aws): Add roleARN to the deploy cloudformation stage (#7492)


