### PR TITLE
fix(kubernetes): add missing `app` config param for patch manifest st…

### DIFF
--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/patchManifest/PatchManifestStageConfig.tsx
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/patchManifest/PatchManifestStageConfig.tsx
@@ -9,16 +9,15 @@ export class PatchManifestStageConfig extends React.Component<IStageConfigProps>
 
   public constructor(props: IStageConfigProps) {
     super(props);
-    if (props.stage.isNew) {
-      defaults(props.stage, {
-        source: 'text',
-        options: {
-          record: true,
-          mergeStrategy: 'strategic',
-        },
-        cloudProvider: 'kubernetes',
-      });
-    }
+    defaults(props.stage, {
+      app: props.application.name,
+      source: 'text',
+      options: {
+        record: true,
+        mergeStrategy: 'strategic',
+      },
+      cloudProvider: 'kubernetes',
+    });
 
     // There was a bug introduced in Spinnaker 1.15 where we were incorrectly
     // storing the merge strategy on a field called 'strategy' instead of on


### PR DESCRIPTION
…ages

Closes https://github.com/spinnaker/spinnaker/issues/5022

Replaces missing `app` parameter from stage config (and removes `isNew` check, since we should properly default any `undefined` config values). Was previously defaulted in angular controller prior to [this commit](https://github.com/spinnaker/deck/pull/7109/files) which converted the Patch stage config to React to add support for artifacts rewrite.