### PR TITLE
fix(google): do not display zones for regional mig unless selected ex…

### DIFF
--- a/app/scripts/modules/google/src/serverGroup/configure/wizard/zones/zoneSelector.directive.html
+++ b/app/scripts/modules/google/src/serverGroup/configure/wizard/zones/zoneSelector.directive.html
@@ -12,19 +12,9 @@
   </div>
 </div>
 
-<div class="form-group" ng-if="vm.command.regional">
+<div class="form-group" ng-if="vm.command.regional && vm.command.selectZones">
   <div class="col-md-3 sm-label-right">Zones</div>
-  <div class="col-md-7" ng-if="!vm.command.selectZones">
-    <p>
-      Server group will be available in:
-    </p>
-    <ul>
-      <li ng-repeat="zone in vm.command.backingData.filtered.truncatedZones">
-        {{zone}}
-      </li>
-    </ul>
-  </div>
-  <div class="col-md-7" ng-if="vm.command.selectZones">
+  <div class="col-md-7">
     <ui-select multiple ng-model="vm.command.distributionPolicy.zones" class="form-control input-sm">
       <ui-select-match>{{ $item }}</ui-select-match>
       <ui-select-choices repeat="zone as zone in vm.command.backingData.filtered.zones">


### PR DESCRIPTION
…plicitly

According to the GCE MIG team, there is no API for determining in which zones a regional MIG will be distributed, so we should not be displaying this information in the UI (even though it is, for now, incidentally correct).

![ebb685e8-78ce-4fe3-a4e5-419012f4512f](https://user-images.githubusercontent.com/15936279/66838118-1e768d80-ef32-11e9-8a8f-55bfae2227dd.gif)
