### PR TITLE
feat(core/jenkins): Refer to Jenkins controller instead of master

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/concourse/ConcourseExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/concourse/ConcourseExecutionDetails.tsx
@@ -18,7 +18,7 @@ export function ConcourseExecutionDetails(props: IExecutionDetailsSectionProps) 
   return (
     <ExecutionDetailsSection name={name} current={current}>
       <dl className="dl-narrow dl-horizontal">
-        <dt>Master</dt>
+        <dt>Build Service</dt>
         <dd>{context.master}</dd>
         <dt>Team</dt>
         <dd>{context.teamName}</dd>

--- a/app/scripts/modules/core/src/pipeline/config/stages/concourse/ConcourseStageConfig.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/concourse/ConcourseStageConfig.tsx
@@ -46,17 +46,17 @@ export class ConcourseStageConfig extends React.Component<IStageConfigProps, ICo
 
     return (
       <>
-        <StageConfigField label="Master">
+        <StageConfigField label="Build Service">
           <Select
             value={master}
-            placeholder="Select a master..."
+            placeholder="Select a build service..."
             onChange={this.onMasterChanged}
             options={masters.map((name: string) => ({ label: name, value: name }))}
             clearable={false}
           />
         </StageConfigField>
         <StageConfigField label="Team">
-          {!master && <p className="form-control-static">(Select a master)</p>}
+          {!master && <p className="form-control-static">(Select a build service)</p>}
           {master && (
             <Select
               value={teamName}
@@ -68,7 +68,7 @@ export class ConcourseStageConfig extends React.Component<IStageConfigProps, ICo
           )}
         </StageConfigField>
         <StageConfigField label="Pipeline">
-          {!teamName && <p className="form-control-static">(Select a master and team)</p>}
+          {!teamName && <p className="form-control-static">(Select a build service and team)</p>}
           {teamName && (
             <Select
               value={pipelineName}
@@ -80,7 +80,7 @@ export class ConcourseStageConfig extends React.Component<IStageConfigProps, ICo
           )}
         </StageConfigField>
         <StageConfigField label="Resource Name">
-          {!pipelineName && <p className="form-control-static">(Select a master, team, and pipeline)</p>}
+          {!pipelineName && <p className="form-control-static">(Select a build service, team, and pipeline)</p>}
           {pipelineName && (
             <Select
               value={resourceName}

--- a/app/scripts/modules/core/src/pipeline/config/stages/jenkins/jenkinsExecutionDetails.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/jenkins/jenkinsExecutionDetails.html
@@ -5,7 +5,7 @@
       <div class="col-md-{{stage.context.buildInfo.testResults ? 6 : 12}}">
         <h5>Jenkins Stage Configuration</h5>
         <dl class="dl-narrow dl-horizontal">
-          <dt>Master</dt>
+          <dt>Controller</dt>
           <dd>{{stage.context.master}}</dd>
           <dt>Job</dt>
           <dd>{{stage.context.job}}</dd>

--- a/app/scripts/modules/core/src/pipeline/config/stages/jenkins/jenkinsStage.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/jenkins/jenkinsStage.html
@@ -1,10 +1,10 @@
 <div class="form-horizontal">
   <div class="form-group">
-    <label class="col-md-2 col-md-offset-1 sm-label-right">Master</label>
+    <label class="col-md-2 col-md-offset-1 sm-label-right">Controller</label>
     <div class="col-md-6">
       <p class="form-control-static" ng-if="viewState.masterIsParameterized">{{stage.master}}</p>
       <ui-select class="form-control input-sm" ng-if="!viewState.masterIsParameterized" ng-model="stage.master">
-        <ui-select-match placeholder="Select a master...">{{$select.selected}}</ui-select-match>
+        <ui-select-match placeholder="Select a controller...">{{$select.selected}}</ui-select-match>
         <ui-select-choices repeat="master in masters | filter: $select.search">
           <span ng-bind-html="master | highlight: $select.search"></span>
         </ui-select-choices>
@@ -24,7 +24,7 @@
   <div class="form-group">
     <label class="col-md-2 col-md-offset-1 sm-label-right">Job</label>
     <div class="col-md-6">
-      <p class="form-control-static" ng-if="!stage.master">(Select a master)</p>
+      <p class="form-control-static" ng-if="!stage.master">(Select a controller)</p>
       <p class="form-control-static" ng-if="viewState.masterIsParameterized || viewState.jobIsParameterized">
         {{stage.job}}
       </p>

--- a/app/scripts/modules/core/src/pipeline/config/stages/travis/travisExecutionDetails.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/travis/travisExecutionDetails.html
@@ -5,7 +5,7 @@
       <div class="col-md-{{ctrl.stage.context.buildInfo.testResults ? 6 : 12}}">
         <h5>Travis Stage Configuration</h5>
         <dl class="dl-narrow dl-horizontal">
-          <dt>Master</dt>
+          <dt>Build Service</dt>
           <dd>{{ctrl.stage.context.master}}</dd>
           <dt>Job</dt>
           <dd>{{ctrl.stage.context.job}}</dd>

--- a/app/scripts/modules/core/src/pipeline/config/stages/travis/travisStage.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/travis/travisStage.html
@@ -1,6 +1,6 @@
 <div class="form-horizontal">
   <div class="form-group">
-    <label class="col-md-2 col-md-offset-1 sm-label-right">Master</label>
+    <label class="col-md-2 col-md-offset-1 sm-label-right">Build Service</label>
     <div class="col-md-6">
       <p class="form-control-static" ng-if="$ctrl.viewState.masterIsParameterized">{{$ctrl.stage.master}}</p>
       <ui-select
@@ -8,7 +8,7 @@
         ng-if="!$ctrl.viewState.masterIsParameterized"
         ng-model="$ctrl.stage.master"
       >
-        <ui-select-match placeholder="Select a master...">{{$select.selected}}</ui-select-match>
+        <ui-select-match placeholder="Select a build service...">{{$select.selected}}</ui-select-match>
         <ui-select-choices repeat="master in $ctrl.masters | filter: $select.search">
           <span ng-bind-html="master | highlight: $select.search"></span>
         </ui-select-choices>
@@ -30,7 +30,7 @@
       >Job<help-field key="pipeline.config.travis.job.isFiltered" ng-if="$ctrl.shouldFilter()"></help-field
     ></label>
     <div class="col-md-6">
-      <p class="form-control-static" ng-if="!$ctrl.stage.master">(Select a master)</p>
+      <p class="form-control-static" ng-if="!$ctrl.stage.master">(Select a build service)</p>
       <p
         class="form-control-static"
         ng-if="$ctrl.viewState.masterIsParameterized || $ctrl.viewState.jobIsParameterized"

--- a/app/scripts/modules/core/src/pipeline/config/stages/wercker/werckerExecutionDetails.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/wercker/werckerExecutionDetails.html
@@ -5,7 +5,7 @@
       <div class="col-md-{{stage.context.buildInfo.testResults ? 6 : 12}}">
         <h5>Wercker Stage Configuration</h5>
         <dl class="dl-narrow dl-horizontal">
-          <dt>Master</dt>
+          <dt>Build Service</dt>
           <dd>{{stage.context.master}}</dd>
           <dt>Job</dt>
           <dd>{{stage.context.job}}</dd>

--- a/app/scripts/modules/core/src/pipeline/config/stages/wercker/werckerStage.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/wercker/werckerStage.html
@@ -29,7 +29,7 @@
   <div class="form-group">
     <label class="col-md-2 col-md-offset-1 sm-label-right">Application</label>
     <div class="col-md-6">
-      <p class="form-control-static" ng-if="!$ctrl.stage.master">(Select a master)</p>
+      <p class="form-control-static" ng-if="!$ctrl.stage.master">(Select a build service)</p>
       <p
         class="form-control-static"
         ng-if="$ctrl.viewState.masterIsParameterized || $ctrl.viewState.appIsParameterized"

--- a/app/scripts/modules/core/src/pipeline/config/stages/wercker/werckerStage.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/wercker/werckerStage.html
@@ -1,6 +1,6 @@
 <div class="form-horizontal">
   <div class="form-group">
-    <label class="col-md-2 col-md-offset-1 sm-label-right">Master</label>
+    <label class="col-md-2 col-md-offset-1 sm-label-right">Build Service</label>
     <div class="col-md-6">
       <p class="form-control-static" ng-if="$ctrl.viewState.masterIsParameterized">{{$ctrl.stage.master}}</p>
       <ui-select
@@ -8,7 +8,7 @@
         ng-if="!$ctrl.viewState.masterIsParameterized"
         ng-model="$ctrl.stage.master"
       >
-        <ui-select-match placeholder="Select a Wercker Master...">{{$select.selected}}</ui-select-match>
+        <ui-select-match placeholder="Select a Wercker build service...">{{$select.selected}}</ui-select-match>
         <ui-select-choices repeat="master in $ctrl.masters | filter: $select.search">
           <span ng-bind-html="master | highlight: $select.search"></span>
         </ui-select-choices>

--- a/app/scripts/modules/core/src/pipeline/config/triggers/baseBuild/BaseBuildTrigger.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/baseBuild/BaseBuildTrigger.tsx
@@ -34,11 +34,13 @@ export function BaseBuildTrigger(buildTriggerProps: IBaseBuildTriggerConfigProps
     }
   }, [fetchJobs.result]);
 
+  const label = buildTriggerType === 'jenkins' ? 'Controller' : 'Master';
+
   return (
     <>
       <FormikFormField
         name="master"
-        label="Master"
+        label={label}
         fastField={false}
         input={props => (
           <RefreshableReactSelectInput
@@ -48,7 +50,7 @@ export function BaseBuildTrigger(buildTriggerProps: IBaseBuildTriggerConfigProps
             isLoading={fetchMasters.status === 'PENDING'}
             onRefreshClicked={() => fetchMasters.refresh()}
             refreshButtonTooltipText={fetchMasters.status === 'PENDING' ? 'Masters refreshing' : 'Refresh masters list'}
-            placeholder="Select a master..."
+            placeholder={`Select a ${label.toLowerCase()}`}
           />
         )}
       />

--- a/app/scripts/modules/core/src/pipeline/config/triggers/baseBuild/BaseBuildTrigger.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/baseBuild/BaseBuildTrigger.tsx
@@ -34,7 +34,7 @@ export function BaseBuildTrigger(buildTriggerProps: IBaseBuildTriggerConfigProps
     }
   }, [fetchJobs.result]);
 
-  const label = buildTriggerType === 'jenkins' ? 'Controller' : 'Master';
+  const label = buildTriggerType === 'jenkins' ? 'Controller' : 'Build Service';
 
   return (
     <>

--- a/app/scripts/modules/core/src/pipeline/config/triggers/concourse/ConcourseTrigger.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/concourse/ConcourseTrigger.tsx
@@ -52,7 +52,7 @@ export function ConcourseTrigger({ formik, trigger }: IConcourseTriggerConfigPro
     <>
       <FormikFormField
         name="master"
-        label="Master"
+        label="Build Service"
         fastField={false}
         input={props => (
           <ReactSelectInput
@@ -61,7 +61,7 @@ export function ConcourseTrigger({ formik, trigger }: IConcourseTriggerConfigPro
             disabled={fetchMasters.status === 'PENDING'}
             isLoading={fetchMasters.status === 'PENDING'}
             stringOptions={fetchMasters.result}
-            placeholder="Select a master..."
+            placeholder="Select a build service..."
           />
         )}
       />

--- a/app/scripts/modules/core/src/pipeline/config/triggers/wercker/WerckerTrigger.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/wercker/WerckerTrigger.tsx
@@ -75,13 +75,13 @@ export function WerckerTrigger(werckerTriggerProps: IWerckerTriggerConfigProps) 
     <>
       <FormikFormField
         name="master"
-        label="Master"
+        label="Build Service"
         fastField={false}
         input={props => (
           <RefreshableReactSelectInput
             {...props}
             stringOptions={fetchMasters.result}
-            placeholder={'Select a master...'}
+            placeholder={'Select a build service...'}
             disabled={!mastersLoaded}
             isLoading={mastersLoading}
             onRefreshClicked={() => fetchMasters.refresh()}


### PR DESCRIPTION
Currently we reference the Jenkins controller as 'master' in the config for both a Jenkins stage and trigger. This terminology has been deprecated by Jenkins and we need to reference the updated terminology of 'controller'.