### PR TITLE
fix(monitored deploy): fix the rollback config to match what orca expects

### DIFF
--- a/app/scripts/modules/core/src/deploymentStrategy/strategies/monitored/monitored.strategy.ts
+++ b/app/scripts/modules/core/src/deploymentStrategy/strategies/monitored/monitored.strategy.ts
@@ -1,7 +1,7 @@
 import { isEmpty, defaultsDeep } from 'lodash';
 import { DeploymentStrategyRegistry } from 'core/deploymentStrategy/deploymentStrategy.registry';
 
-import { AdditionalFields } from './AdditionalFields';
+import { AdditionalFields, RollbackType } from './AdditionalFields';
 
 DeploymentStrategyRegistry.registerStrategy({
   label: 'Monitored Deploy',
@@ -12,7 +12,10 @@ DeploymentStrategyRegistry.registerStrategy({
   AdditionalFieldsComponent: AdditionalFields,
   initializationMethod: command => {
     defaultsDeep(command, {
-      rollback: { onFailure: true },
+      failureActions: {
+        destroyInstances: false,
+        rollback: RollbackType.Automatic,
+      },
       deploymentMonitor: { id: '' },
       maxRemainingAsgs: 2,
     });

--- a/app/scripts/modules/core/src/help/help.contents.ts
+++ b/app/scripts/modules/core/src/help/help.contents.ts
@@ -367,6 +367,8 @@ const helpContents: { [key: string]: string } = {
     '<p>Monitored Deploy will scale up the new server group as specified by these per cent steps. After each step, the health of the new server group will be evaluated by the specified deployment monitor.</p>',
   'strategy.monitored.rollback':
     '<p>If deploy fails, disable the new server group and ensure that the previous server group is active and restored to its original capacity.</p>',
+  'strategy.monitored.destroyFailedAsg':
+    '<p>If deploy fails and rollback succeeds destroys the server group that failed the deploy instead of just disabling it.</p>',
   'loadBalancers.filter.serverGroups': `
       <p>Displays all server groups configured to use the load balancer.</p>
       <p>If the server group is configured to <em>not</em> add new instances to the load balancer, it will be grayed out.</p>`,


### PR DESCRIPTION
Note: `Manual` type is not yet implemented in orca, hence it's not used in deck, other then the enum definition
