### PR TITLE
feat(kubernetes): support rolling restart operation for deployments

### DIFF
--- a/app/scripts/modules/core/src/manifest/ManifestWriter.ts
+++ b/app/scripts/modules/core/src/manifest/ManifestWriter.ts
@@ -75,6 +75,16 @@ export class ManifestWriter {
     });
   }
 
+  public static rollingRestartManifest(command: any, application: Application): IPromise<ITask> {
+    const description = 'Rolling restart of manifest';
+    command.type = 'rollingRestartManifest';
+    return TaskExecutor.executeTask({
+      job: [command],
+      application,
+      description,
+    });
+  }
+
   public static findArtifactsFromResource(command: any, application: Application): IPromise<ITask> {
     const description = 'Find artifacts from a Kubernetes resource';
     command.type = 'findArtifactsFromResource';

--- a/app/scripts/modules/kubernetes/src/v2/kubernetes.v2.module.ts
+++ b/app/scripts/modules/kubernetes/src/v2/kubernetes.v2.module.ts
@@ -36,6 +36,7 @@ import { ManifestWizard } from 'kubernetes/v2/manifest/wizard/ManifestWizard';
 import { KUBERNETES_ENABLE_MANIFEST_STAGE } from 'kubernetes/v2/pipelines/stages/traffic/enableManifest.stage';
 import { KUBERNETES_DISABLE_MANIFEST_STAGE } from 'kubernetes/v2/pipelines/stages/traffic/disableManifest.stage';
 import { KubernetesSecurityGroupReader } from 'kubernetes/shared/securityGroup/securityGroup.reader';
+import { KUBERNETES_ROLLING_RESTART } from 'kubernetes/v2/manifest/rollout/RollingRestart';
 
 import 'kubernetes/shared/validation/applicationName.validator';
 import 'kubernetes/shared/help/kubernetes.help';
@@ -87,6 +88,7 @@ module(KUBERNETES_V2_MODULE, [
   KUBERNETES_ENABLE_MANIFEST_STAGE,
   KUBERNETES_DISABLE_MANIFEST_STAGE,
   STAGE_ARTIFACT_SELECTOR_COMPONENT_REACT,
+  KUBERNETES_ROLLING_RESTART,
 ]).config(() => {
   CloudProviderRegistry.registerProvider('kubernetes', {
     name: 'Kubernetes',

--- a/app/scripts/modules/kubernetes/src/v2/manifest/rollout/RollingRestart.tsx
+++ b/app/scripts/modules/kubernetes/src/v2/manifest/rollout/RollingRestart.tsx
@@ -1,0 +1,55 @@
+import { module } from 'angular';
+
+import * as React from 'react';
+import { react2angular } from 'react2angular';
+
+import { Application, ManifestWriter, ReactInjector } from '@spinnaker/core';
+
+import { IKubernetesServerGroupManager } from 'kubernetes/v2/serverGroupManager';
+
+interface IRollingRestartProps {
+  application: Application;
+  serverGroupManager: IKubernetesServerGroupManager;
+}
+
+interface IRollingRestartParameters {
+  account: string;
+  cloudProvider: string;
+  location: string;
+  manifestName: string;
+}
+
+function RollingRestart({ application, serverGroupManager }: IRollingRestartProps) {
+  function rollingRestart() {
+    const rollingRestartParameters: IRollingRestartParameters = {
+      account: serverGroupManager.account,
+      cloudProvider: 'kubernetes',
+      location: serverGroupManager.namespace,
+      manifestName: serverGroupManager.name,
+    };
+    ReactInjector.confirmationModalService.confirm({
+      account: serverGroupManager.account,
+      askForReason: true,
+      header: `Initiate rolling restart of ${serverGroupManager.name}`,
+      provider: 'kubernetes',
+      submitMethod: () => {
+        return ManifestWriter.rollingRestartManifest(rollingRestartParameters, application);
+      },
+      taskMonitorConfig: {
+        application,
+        title: `Rolling restart of ${serverGroupManager.name}`,
+      },
+    });
+  }
+  return (
+    <li>
+      <a onClick={rollingRestart}>Rolling Restart</a>
+    </li>
+  );
+}
+
+export const KUBERNETES_ROLLING_RESTART = 'spinnaker.kubernetes.v2.rolling.restart';
+module(KUBERNETES_ROLLING_RESTART, []).component(
+  'kubernetesRollingRestart',
+  react2angular(RollingRestart, ['application', 'serverGroupManager']),
+);

--- a/app/scripts/modules/kubernetes/src/v2/serverGroupManager/details/details.html
+++ b/app/scripts/modules/kubernetes/src/v2/serverGroupManager/details/details.html
@@ -63,6 +63,11 @@
               Pause Rollout
             </a>
           </li>
+          <kubernetes-rolling-restart
+            ng-if="!ctrl.manifest.status.paused.state"
+            application="ctrl.app"
+            server-group-manager="ctrl.serverGroupManager"
+          />
           <li role="presentation" class="divider"></li>
           <li>
             <a href ng-click="ctrl.editServerGroupManager()">


### PR DESCRIPTION
Closes spinnaker/spinnaker#4757

As the many comments/emojis on this [Kubernetes feature request](https://github.com/kubernetes/kubernetes/issues/13488) indicate, there are several valid user stories around issuing a rolling restart of a Deployment. The `kubectl rollout restart` command was released with kubectl version 1.15, and we currently use kubectl version 1.16 in Clouddriver. Like the other kubectl rollout commands, it is valid for Deployments, StatefulSets, and DaemonSets. We currently only expose the ad-hoc rollout commands for Deployments in Deck, but could at a later date expose them for StatefulSets and DaemonSets if there is evidence from users that it would be useful.

Related PRs:
Clouddriver: spinnaker/clouddriver#4100
Orca: https://github.com/spinnaker/orca/pull/3233

![863ee1d0-ca4a-4d50-b8ef-870bcfa72908](https://user-images.githubusercontent.com/15936279/67022348-19027a00-f0cf-11e9-89b3-7f928863c5a4.gif)
