### PR TITLE
fix(core/instance): use fragment on non-UP health code path

### DIFF
--- a/app/scripts/modules/core/src/instance/loadBalancer/InstanceLoadBalancerHealth.tsx
+++ b/app/scripts/modules/core/src/instance/loadBalancer/InstanceLoadBalancerHealth.tsx
@@ -65,8 +65,10 @@ export class InstanceLoadBalancerHealth extends React.Component<IInstanceLoadBal
       const tooltip = <Tooltip id={name}>{tooltipText}</Tooltip>;
       return (
         <OverlayTrigger placement="left" overlay={tooltip}>
-          {healthDiv}
-          {ipAddress && healthCheckPath && healthCheckLinkSpan}
+          <>
+            {healthDiv}
+            {ipAddress && healthCheckPath && healthCheckLinkSpan}
+          </>
         </OverlayTrigger>
       );
     }


### PR DESCRIPTION
Turns out that the `<OverlayTrigger>` component needs whatever you give it as children to be a single node. With the change introduced in #7520, the code path that runs when the health status is `UP` works fine, but any non-UP status hits the `<OverlayTrigger>` path and blows up/fails to render because there's two root nodes. This just wraps those two nodes in a fragment.