### PR TITLE
feat(dataSources): widen + parameterize types, add 'managed' data source

### DIFF
--- a/app/scripts/modules/amazon/src/instance/details/instance.details.controller.spec.js
+++ b/app/scripts/modules/amazon/src/instance/details/instance.details.controller.spec.js
@@ -26,8 +26,8 @@ describe('Controller: awsInstanceDetailsCtrl', function() {
 
       application = ApplicationModelBuilder.createApplicationForTests(
         'app',
-        { key: 'loadBalancers', lazy: true },
-        { key: 'serverGroups', lazy: true },
+        { key: 'loadBalancers', lazy: true, defaultData: [] },
+        { key: 'serverGroups', lazy: true, defaultData: [] },
       );
     }),
   );

--- a/app/scripts/modules/amazon/src/loadBalancer/amazonLoadBalancerDataUtils.ts
+++ b/app/scripts/modules/amazon/src/loadBalancer/amazonLoadBalancerDataUtils.ts
@@ -48,11 +48,10 @@ export class AmazonLoadBalancerDataUtils {
       .all([AccountService.getAccountDetails(serverGroup.account), application.getDataSource('loadBalancers').ready()])
       .then(data => {
         const awsAccount = (data[0] && data[0].awsAccount) || serverGroup.account;
-        const loadBalancers: IAmazonApplicationLoadBalancer[] = application
-          .getDataSource('loadBalancers')
-          .data.filter(
-            lb => lb.loadBalancerType === 'application' || lb.loadBalancerType === 'network',
-          ) as IAmazonApplicationLoadBalancer[];
+        const loadBalancers: IAmazonApplicationLoadBalancer[] = (application.loadBalancers
+          .data as ILoadBalancer[]).filter(
+          lb => lb.loadBalancerType === 'application' || lb.loadBalancerType === 'network',
+        ) as IAmazonApplicationLoadBalancer[];
         const targetGroups = serverGroup.targetGroups
           .map((targetGroupName: string) => {
             const allTargetGroups = flatten(loadBalancers.map(lb => lb.targetGroups || []));

--- a/app/scripts/modules/amazon/src/loadBalancer/details/loadBalancerDetails.controller.spec.ts
+++ b/app/scripts/modules/amazon/src/loadBalancer/details/loadBalancerDetails.controller.spec.ts
@@ -23,7 +23,11 @@ describe('Controller: LoadBalancerDetailsCtrl', function() {
     mock.inject(($controller: IControllerService, $rootScope: IRootScopeService, _$state_: StateService) => {
       $scope = $rootScope.$new();
       $state = _$state_;
-      const app = ApplicationModelBuilder.createApplicationForTests('app', { key: 'loadBalancers', lazy: true });
+      const app = ApplicationModelBuilder.createApplicationForTests('app', {
+        key: 'loadBalancers',
+        lazy: true,
+        defaultData: [],
+      });
       app.loadBalancers.data.push(loadBalancer);
       controller = $controller(AwsLoadBalancerDetailsController, {
         $scope,

--- a/app/scripts/modules/amazon/src/loadBalancer/details/loadBalancerDetails.html
+++ b/app/scripts/modules/amazon/src/loadBalancer/details/loadBalancerDetails.html
@@ -59,8 +59,8 @@
     </div>
   </div>
   <managed-resource-details-indicator
-    ng-if="!ctrl.state.loading && ctrl.loadBalancer.entityTags"
-    entity-tags="[ctrl.loadBalancer.entityTags]"
+    ng-if="!ctrl.state.loading && ctrl.loadBalancer.isManaged"
+    resource-summary="ctrl.loadBalancer.managedResourceSummary"
   >
   </managed-resource-details-indicator>
   <div ng-if="!ctrl.state.loading" class="content">

--- a/app/scripts/modules/amazon/src/loadBalancer/details/targetGroupDetails.html
+++ b/app/scripts/modules/amazon/src/loadBalancer/details/targetGroupDetails.html
@@ -24,8 +24,8 @@
     </div>
   </div>
   <managed-resource-details-indicator
-    ng-if="!ctrl.state.loading && ctrl.loadBalancer.entityTags"
-    entity-tags="[ctrl.loadBalancer.entityTags]"
+    ng-if="!ctrl.state.loading && ctrl.loadBalancer.isManaged"
+    resource-summary="ctrl.loadBalancer.managedResourceSummary"
   >
   </managed-resource-details-indicator>
   <div ng-if="!ctrl.state.loading" class="content">

--- a/app/scripts/modules/amazon/src/securityGroup/details/securityGroupDetail.html
+++ b/app/scripts/modules/amazon/src/securityGroup/details/securityGroupDetail.html
@@ -55,8 +55,8 @@
     </div>
   </div>
   <managed-resource-details-indicator
-    ng-if="!state.loading && securityGroup.entityTags"
-    entity-tags="[securityGroup.entityTags]"
+    ng-if="!state.loading && securityGroup.isManaged"
+    resource-summary="securityGroup.managedResourceSummary"
   >
   </managed-resource-details-indicator>
   <div class="content" ng-if="!state.loading">

--- a/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupConfiguration.service.spec.ts
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupConfiguration.service.spec.ts
@@ -104,7 +104,11 @@ describe('Service: awsServerGroupConfiguration', function() {
       } as any;
 
       service.configureCommand(
-        ApplicationModelBuilder.createApplicationForTests('name', { key: 'loadBalancers', lazy: true }),
+        ApplicationModelBuilder.createApplicationForTests('name', {
+          key: 'loadBalancers',
+          lazy: true,
+          defaultData: [],
+        }),
         command,
       );
       $scope.$digest();

--- a/app/scripts/modules/appengine/src/instance/details/details.controller.ts
+++ b/app/scripts/modules/appengine/src/instance/details/details.controller.ts
@@ -9,6 +9,7 @@ import {
   InstanceReader,
   InstanceWriter,
   RecentHistoryService,
+  ILoadBalancer,
 } from '@spinnaker/core';
 
 import { IAppengineInstance } from 'appengine/domain';
@@ -91,7 +92,7 @@ class AppengineInstanceDetailsController implements IController {
     const dataSources: InstanceManager[] = flattenDeep([
       this.app.getDataSource('serverGroups').data,
       this.app.getDataSource('loadBalancers').data,
-      this.app.getDataSource('loadBalancers').data.map(loadBalancer => loadBalancer.serverGroups),
+      this.app.getDataSource('loadBalancers').data.map((loadBalancer: ILoadBalancer) => loadBalancer.serverGroups),
     ]);
 
     const instanceManager = dataSources.find(instanceLocatorPredicate);

--- a/app/scripts/modules/appengine/src/pipeline/stages/editLoadBalancer/loadBalancerChoice.modal.controller.ts
+++ b/app/scripts/modules/appengine/src/pipeline/stages/editLoadBalancer/loadBalancerChoice.modal.controller.ts
@@ -44,9 +44,9 @@ class AppengineLoadBalancerChoiceModalCtrl implements IController {
       .getDataSource('loadBalancers')
       .ready()
       .then(() => {
-        this.loadBalancers = this.application
-          .getDataSource('loadBalancers')
-          .data.filter(candidate => candidate.cloudProvider === 'appengine');
+        this.loadBalancers = (this.application.loadBalancers.data as ILoadBalancer[]).filter(
+          candidate => candidate.cloudProvider === 'appengine',
+        );
 
         if (this.loadBalancers.length) {
           this.selectedLoadBalancer = this.loadBalancers[0];

--- a/app/scripts/modules/appengine/src/serverGroup/details/details.controller.ts
+++ b/app/scripts/modules/appengine/src/serverGroup/details/details.controller.ts
@@ -13,6 +13,7 @@ import {
   ServerGroupReader,
   ServerGroupWarningMessageService,
   ServerGroupWriter,
+  ILoadBalancer,
 } from '@spinnaker/core';
 
 import { AppengineHealth } from 'appengine/common/appengineHealth';
@@ -441,7 +442,7 @@ class AppengineServerGroupDetailsController implements IController {
       });
 
       if (!fromApp) {
-        this.app.getDataSource('loadBalancers').data.some(loadBalancer => {
+        this.app.getDataSource('loadBalancers').data.some((loadBalancer: ILoadBalancer) => {
           if (loadBalancer.account === fromParams.accountId) {
             return loadBalancer.serverGroups.some((toCheck: IServerGroup) => {
               let result = false;
@@ -451,6 +452,8 @@ class AppengineServerGroupDetailsController implements IController {
               }
               return result;
             });
+          } else {
+            return false;
           }
         });
       }

--- a/app/scripts/modules/azure/src/instance/details/instance.details.controller.spec.js
+++ b/app/scripts/modules/azure/src/instance/details/instance.details.controller.spec.js
@@ -15,8 +15,8 @@ describe('Controller: azureInstanceDetailsCtrl', function() {
 
       application = ApplicationModelBuilder.createApplicationForTests(
         'app',
-        { key: 'loadBalancers', lazy: true },
-        { key: 'serverGroups', lazy: true },
+        { key: 'loadBalancers', lazy: true, defaultData: [] },
+        { key: 'serverGroups', lazy: true, defaultData: [] },
       );
 
       this.createController = function(application, instance) {

--- a/app/scripts/modules/azure/src/loadBalancer/configure/createLoadBalancer.controller.spec.js
+++ b/app/scripts/modules/azure/src/loadBalancer/configure/createLoadBalancer.controller.spec.js
@@ -11,7 +11,11 @@ describe('Controller: azureCreateLoadBalancerCtrl', function() {
   // Initialize the controller and a mock scope
   beforeEach(
     window.inject(function($controller, $rootScope) {
-      const app = ApplicationModelBuilder.createApplicationForTests('app', { key: 'loadBalancers', lazy: true });
+      const app = ApplicationModelBuilder.createApplicationForTests('app', {
+        key: 'loadBalancers',
+        lazy: true,
+        defaultData: [],
+      });
       this.$scope = $rootScope.$new();
       this.ctrl = $controller('azureCreateLoadBalancerCtrl', {
         $scope: this.$scope,

--- a/app/scripts/modules/azure/src/loadBalancer/details/loadBalancerDetail.controller.spec.js
+++ b/app/scripts/modules/azure/src/loadBalancer/details/loadBalancerDetail.controller.spec.js
@@ -18,7 +18,11 @@ describe('Controller: azureLoadBalancerDetailsCtrl', function() {
     window.inject(function($controller, $rootScope, _$state_) {
       $scope = $rootScope.$new();
       $state = _$state_;
-      let app = ApplicationModelBuilder.createApplicationForTests('app', { key: 'loadBalancers', lazy: true });
+      let app = ApplicationModelBuilder.createApplicationForTests('app', {
+        key: 'loadBalancers',
+        lazy: true,
+        defaultData: [],
+      });
       app.loadBalancers.data.push(loadBalancer);
       controller = $controller('azureLoadBalancerDetailsCtrl', {
         $scope: $scope,

--- a/app/scripts/modules/cloudfoundry/src/instance/details/CloudFoundryInstanceDetails.tsx
+++ b/app/scripts/modules/cloudfoundry/src/instance/details/CloudFoundryInstanceDetails.tsx
@@ -9,6 +9,7 @@ import {
   InstanceWriter,
   RecentHistoryService,
   Spinner,
+  ILoadBalancer,
 } from '@spinnaker/core';
 
 import { ICloudFoundryInstance } from 'cloudfoundry/domain';
@@ -68,7 +69,9 @@ export class CloudFoundryInstanceDetails extends React.Component<
     const dataSources: InstanceManager[] = flattenDeep([
       this.props.app.getDataSource('serverGroups').data,
       this.props.app.getDataSource('loadBalancers').data,
-      this.props.app.getDataSource('loadBalancers').data.map(loadBalancer => loadBalancer.serverGroups),
+      this.props.app
+        .getDataSource('loadBalancers')
+        .data.map((loadBalancer: ILoadBalancer) => loadBalancer.serverGroups),
     ]);
 
     const instanceManager = dataSources.find(instanceLocatorPredicate);

--- a/app/scripts/modules/cloudfoundry/src/presentation/widgets/accountRegionClusterSelector/AccountRegionClusterSelector.spec.tsx
+++ b/app/scripts/modules/cloudfoundry/src/presentation/widgets/accountRegionClusterSelector/AccountRegionClusterSelector.spec.tsx
@@ -45,7 +45,8 @@ describe('<AccountRegionClusterSelector />', () => {
           createServerGroup('account-name-one', 'app-stack-detailFour', 'app', 'region-three'),
           createServerGroup('account-name-one', 'app-stack-detailFive', 'app', 'region-two'),
         ],
-      } as ApplicationDataSource);
+        defaultData: [] as IServerGroup[],
+      } as ApplicationDataSource<IServerGroup[]>);
     }),
   );
 

--- a/app/scripts/modules/cloudfoundry/src/serverGroup/details/cloudFoundryServerGroupActions.tsx
+++ b/app/scripts/modules/cloudfoundry/src/serverGroup/details/cloudFoundryServerGroupActions.tsx
@@ -210,12 +210,9 @@ export class CloudFoundryServerGroupActions extends React.Component<ICloudFoundr
 
     let serverGroup: ICloudFoundryServerGroup = this.props.serverGroup;
     let previousServerGroup: ICloudFoundryServerGroup;
-    let allServerGroups = app
-      .getDataSource('serverGroups')
-      .data.filter(
-        (g: ICloudFoundryServerGroup) =>
-          g.cluster === serverGroup.cluster && g.region === serverGroup.region && g.account === serverGroup.account,
-      );
+    let allServerGroups = (app.serverGroups.data as ICloudFoundryServerGroup[]).filter(
+      g => g.cluster === serverGroup.cluster && g.region === serverGroup.region && g.account === serverGroup.account,
+    );
 
     if (serverGroup.isDisabled) {
       // if the selected server group is disabled, it represents the server group that should be _rolled back to_
@@ -234,7 +231,7 @@ export class CloudFoundryServerGroupActions extends React.Component<ICloudFoundr
     }
 
     // the set of all server groups should not include the server group selected for rollback
-    allServerGroups = allServerGroups.filter((g: ICloudFoundryServerGroup) => g.name !== serverGroup.name);
+    allServerGroups = allServerGroups.filter(g => g.name !== serverGroup.name);
 
     if (allServerGroups.length === 1 && !previousServerGroup) {
       // if there is only one other server group, default to it being the rollback target

--- a/app/scripts/modules/core/src/application/application.model.spec.ts
+++ b/app/scripts/modules/core/src/application/application.model.spec.ts
@@ -64,6 +64,7 @@ describe('Application Model', function() {
       ApplicationDataSourceRegistry.registerDataSource({
         key: 'lazySource',
         lazy: true,
+        defaultData: [],
         loader: () => $q.resolve(['a']),
         onLoad: (_app, data) => $q.resolve(data),
       });

--- a/app/scripts/modules/core/src/application/application.model.ts
+++ b/app/scripts/modules/core/src/application/application.model.ts
@@ -93,7 +93,11 @@ export class Application {
 
   private dataLoader: Subscription;
 
-  constructor(private applicationName: string, private scheduler: any, dataSourceConfigs: IDataSourceConfig[]) {
+  constructor(
+    private applicationName: string,
+    private scheduler: any,
+    dataSourceConfigs: Array<IDataSourceConfig<any>>,
+  ) {
     dataSourceConfigs.forEach(config => this.addDataSource(config));
     this.status$ = Observable.combineLatest(this.dataSources.map(ds => ds.status$)).map(statuses =>
       this.getDerivedApplicationStatus(statuses),
@@ -118,7 +122,7 @@ export class Application {
     };
   }
 
-  private addDataSource(config: IDataSourceConfig) {
+  private addDataSource<T>(config: IDataSourceConfig<T>) {
     const dataSource = new ApplicationDataSource(config, this);
     this.dataSources.push(dataSource);
     this[config.key] = dataSource;
@@ -222,21 +226,27 @@ export class Application {
   private setApplicationAccounts(): void {
     let accounts = this.accounts.concat(this.attributes.accounts || []);
     this.dataSources
-      .filter(ds => ds.credentialsField !== undefined)
-      .forEach(ds => (accounts = accounts.concat(ds.data.map(d => d[ds.credentialsField]))));
+      .filter(ds => Array.isArray(ds.data) && ds.credentialsField !== undefined)
+      .forEach(
+        (ds: ApplicationDataSource<any[]>) => (accounts = accounts.concat(ds.data.map(d => d[ds.credentialsField]))),
+      );
 
     this.accounts = uniq(accounts);
   }
 
   private extractProviderDefault(field: string): Map<string, string> {
     const results = new Map<string, string>();
-    const sources = this.dataSources.filter(d => d[field] !== undefined);
+    const sources: Array<ApplicationDataSource<any[]>> = this.dataSources.filter(
+      ds => ds[field] !== undefined && Array.isArray(ds.data) && ds.providerField !== undefined,
+    );
     const providers = sources.map(ds => ds.data.map(d => d[ds.providerField])).filter(p => p.length > 0);
     let allProviders: any; // typescript made me do it this way
     allProviders = union<string[]>(...providers);
     allProviders.forEach((provider: string) => {
       const vals = sources
-        .map(ds => map(ds.data.filter(d => d[ds.providerField] === provider), ds[field]))
+        .map(ds =>
+          map(ds.data.filter((d: any) => typeof d === 'object' && d[ds.providerField] === provider), ds[field]),
+        )
         .filter(v => v.length > 0);
       const allValues = union(...vals);
       if (allValues.length === 1) {

--- a/app/scripts/modules/core/src/application/applicationModel.builder.ts
+++ b/app/scripts/modules/core/src/application/applicationModel.builder.ts
@@ -1,11 +1,12 @@
 import { SchedulerFactory } from 'core/scheduler/SchedulerFactory';
-import { Application } from './application.model';
+import { IServerGroup } from 'core/domain';
 
+import { Application } from './application.model';
 import { IDataSourceConfig } from './service/applicationDataSource';
 
 export class ApplicationModelBuilder {
   /** This is mostly used in tests */
-  public static createApplicationForTests(name: string, ...dataSources: IDataSourceConfig[]): Application {
+  public static createApplicationForTests(name: string, ...dataSources: Array<IDataSourceConfig<any>>): Application {
     return new Application(name, SchedulerFactory.createScheduler(), dataSources);
   }
 
@@ -16,7 +17,7 @@ export class ApplicationModelBuilder {
   }
 
   public static createNotFoundApplication(name: string): Application {
-    const config: IDataSourceConfig = { key: 'serverGroups', lazy: true };
+    const config: IDataSourceConfig<IServerGroup[]> = { key: 'serverGroups', lazy: true, defaultData: [] };
     const application = new Application(name, SchedulerFactory.createScheduler(), [config]);
     application.notFound = true;
     return application;

--- a/app/scripts/modules/core/src/application/config/appConfig.dataSource.js
+++ b/app/scripts/modules/core/src/application/config/appConfig.dataSource.js
@@ -9,5 +9,6 @@ module.exports = angular.module('spinnaker.core.application.config.dataSource', 
     label: 'Config',
     sref: '.config',
     active: '**.config.**',
+    defaultData: [],
   });
 });

--- a/app/scripts/modules/core/src/application/config/applicationConfig.controller.js
+++ b/app/scripts/modules/core/src/application/config/applicationConfig.controller.js
@@ -5,7 +5,6 @@ import { CHAOS_MONKEY_CONFIG_COMPONENT } from 'core/chaosMonkey/chaosMonkeyConfi
 import { TRAFFIC_GUARD_CONFIG_COMPONENT } from './trafficGuard/trafficGuardConfig.component';
 import { SETTINGS } from 'core/config/settings';
 import { ApplicationWriter } from 'core/application/service/ApplicationWriter';
-import { ManagedReader } from 'core/managed';
 import { DELETE_APPLICATION_SECTION } from './deleteApplicationSection.module';
 
 const angular = require('angular');
@@ -69,11 +68,14 @@ module.exports = angular
 
       if (this.feature.managedResources) {
         this.hasManagedResources = false;
-        ManagedReader.getApplicationSummary(this.application.name).then(({ hasManagedResources }) => {
-          $scope.$applyAsync(() => {
-            this.hasManagedResources = hasManagedResources;
+        this.application
+          .getDataSource('managedResources')
+          .ready()
+          .then(({ hasManagedResources }) => {
+            $scope.$applyAsync(() => {
+              this.hasManagedResources = hasManagedResources;
+            });
           });
-        });
       }
     },
   ]);

--- a/app/scripts/modules/core/src/application/config/dataSources/applicationDataSourceEditor.component.spec.ts
+++ b/app/scripts/modules/core/src/application/config/dataSources/applicationDataSourceEditor.component.spec.ts
@@ -44,20 +44,24 @@ describe('Component: Application Data Source Editor', () => {
         key: 'optionalSource',
         optional: true,
         visible: true,
+        defaultData: [],
       },
       {
         key: 'invisibleSource',
         visible: false,
+        defaultData: [],
       },
       {
         key: 'requiredSource',
         visible: true,
+        defaultData: [],
       },
       {
         key: 'optInSource',
         optional: true,
         visible: true,
         optIn: true,
+        defaultData: [],
       },
     );
     application.getDataSource('optInSource').disabled = true;

--- a/app/scripts/modules/core/src/application/listExtractor/AppListExtractor.spec.ts
+++ b/app/scripts/modules/core/src/application/listExtractor/AppListExtractor.spec.ts
@@ -9,6 +9,7 @@ describe('AppListExtractor', function() {
     const application: Application = ApplicationModelBuilder.createApplicationForTests('app', {
       key: 'serverGroups',
       lazy: true,
+      defaultData: [],
     });
     application.getDataSource('serverGroups').data = serverGroups;
     return application;

--- a/app/scripts/modules/core/src/application/nav/CategoryDropdown.tsx
+++ b/app/scripts/modules/core/src/application/nav/CategoryDropdown.tsx
@@ -55,7 +55,7 @@ export class CategoryDropdown extends React.Component<ICategoryDropdownProps, IC
     const withBadges = category.dataSources.filter(ds => ds.badge).map(ds => application.getDataSource(ds.badge));
     this.runningCountSubscription = merge(...withBadges.map(ds => ds.refresh$)).subscribe(() => {
       this.setState({
-        runningCount: withBadges.reduce((acc: number, ds: ApplicationDataSource) => acc + ds.data.length, 0),
+        runningCount: withBadges.reduce((acc: number, ds: ApplicationDataSource<any[]>) => acc + ds.data.length, 0),
       });
     });
     if (category.key === 'delivery') {

--- a/app/scripts/modules/core/src/application/service/ApplicationDataSourceRegistry.ts
+++ b/app/scripts/modules/core/src/application/service/ApplicationDataSourceRegistry.ts
@@ -11,7 +11,7 @@ export class ApplicationDataSourceRegistry {
     'tasks',
     'config',
   ];
-  private static dataSources: IDataSourceConfig[] = [];
+  private static dataSources: Array<IDataSourceConfig<any>> = [];
   private static dataSourceOrder: string[] = [];
 
   public static setDataSourceOrder(keys: string[]): void {
@@ -32,12 +32,12 @@ export class ApplicationDataSourceRegistry {
     this.dataSources.sort((a, b) => order.indexOf(a.key) - order.indexOf(b.key));
   }
 
-  public static registerDataSource(config: IDataSourceConfig): void {
+  public static registerDataSource(config: IDataSourceConfig<any>): void {
     this.dataSources.push(config);
     this.sortDataSources();
   }
 
-  public static getDataSources(): IDataSourceConfig[] {
+  public static getDataSources(): Array<IDataSourceConfig<any>> {
     return cloneDeep(this.dataSources);
   }
 

--- a/app/scripts/modules/core/src/application/service/ApplicationReader.spec.ts
+++ b/app/scripts/modules/core/src/application/service/ApplicationReader.spec.ts
@@ -112,6 +112,7 @@ describe('ApplicationReader', function() {
           visible: true,
           optional: true,
           optIn: true,
+          defaultData: [],
         });
       });
 

--- a/app/scripts/modules/core/src/application/service/ApplicationReader.ts
+++ b/app/scripts/modules/core/src/application/service/ApplicationReader.ts
@@ -3,7 +3,7 @@ import { IPromise } from 'angular';
 import { API } from 'core/api';
 import { SchedulerFactory } from 'core/scheduler';
 import { Application } from '../application.model';
-import { ApplicationDataSource, IDataSourceConfig } from '../service/applicationDataSource';
+import { ApplicationDataSource } from '../service/applicationDataSource';
 import { ApplicationDataSourceRegistry } from './ApplicationDataSourceRegistry';
 import { InferredApplicationWarningService } from './InferredApplicationWarningService';
 
@@ -46,7 +46,7 @@ export class ApplicationReader {
       .withParams({ expand: expand })
       .get()
       .then((fromServer: Application) => {
-        const configs: IDataSourceConfig[] = ApplicationDataSourceRegistry.getDataSources();
+        const configs = ApplicationDataSourceRegistry.getDataSources();
         const application: Application = new Application(fromServer.name, SchedulerFactory.createScheduler(), configs);
         application.attributes = fromServer.attributes;
         this.splitAttributes(application.attributes, ['accounts', 'cloudProviders']);
@@ -69,7 +69,7 @@ export class ApplicationReader {
   }
 
   public static setDisabledDataSources(application: Application) {
-    const allDataSources: ApplicationDataSource[] = application.dataSources;
+    const allDataSources = application.dataSources;
     const appDataSources: IApplicationDataSourceAttribute = application.attributes.dataSources;
 
     if (!appDataSources) {

--- a/app/scripts/modules/core/src/chaosMonkey/chaosMonkeyExceptions.component.spec.ts
+++ b/app/scripts/modules/core/src/chaosMonkey/chaosMonkeyExceptions.component.spec.ts
@@ -45,6 +45,7 @@ describe('Controller: ChaosMonkeyExceptions', () => {
         key: 'serverGroups',
         loader: () => $q.resolve([]),
         onLoad: (_app, data) => $q.resolve(data),
+        defaultData: [],
       });
       $ctrl.application.serverGroups.refresh();
       $scope.$digest();

--- a/app/scripts/modules/core/src/cloudProvider/skin.service.spec.ts
+++ b/app/scripts/modules/core/src/cloudProvider/skin.service.spec.ts
@@ -54,9 +54,11 @@ describe('Service: SkinService', () => {
               },
             ]),
           onLoad: (_app, data) => $q.resolve(data),
+          defaultData: [],
         },
         {
           key: 'loadBalancers',
+          defaultData: [],
         },
       );
 
@@ -82,9 +84,11 @@ describe('Service: SkinService', () => {
               },
             ]),
           onLoad: (_app, data) => $q.resolve(data),
+          defaultData: [],
         },
         {
           key: 'serverGroups',
+          defaultData: [],
         },
       );
 
@@ -116,9 +120,11 @@ describe('Service: SkinService', () => {
               },
             ]),
           onLoad: (_app, data) => $q.resolve(data),
+          defaultData: [],
         },
         {
           key: 'serverGroups',
+          defaultData: [],
         },
       );
 

--- a/app/scripts/modules/core/src/cluster/cluster.service.spec.ts
+++ b/app/scripts/modules/core/src/cluster/cluster.service.spec.ts
@@ -36,9 +36,9 @@ describe('Service: Cluster', function() {
 
       application = ApplicationModelBuilder.createApplicationForTests(
         'app',
-        { key: 'serverGroups' },
-        { key: 'runningExecutions' },
-        { key: 'runningTasks' },
+        { key: 'serverGroups', defaultData: [] },
+        { key: 'runningExecutions', defaultData: [] },
+        { key: 'runningTasks', defaultData: [] },
       );
       application.getDataSource('serverGroups').data = [
         { name: 'the-target', account: 'not-the-target', region: 'us-east-1' },

--- a/app/scripts/modules/core/src/cluster/filter/ClusterFilterService.spec.ts
+++ b/app/scripts/modules/core/src/cluster/filter/ClusterFilterService.spec.ts
@@ -29,7 +29,11 @@ describe('Service: clusterFilterService', function() {
     });
 
     this.buildApplication = (json: any) => {
-      const app = ApplicationModelBuilder.createApplicationForTests('app', { key: 'serverGroups', lazy: true });
+      const app = ApplicationModelBuilder.createApplicationForTests('app', {
+        key: 'serverGroups',
+        lazy: true,
+        defaultData: [],
+      });
       if (json.serverGroups) {
         app.getDataSource('serverGroups').data = _.cloneDeep(json.serverGroups.data);
       }

--- a/app/scripts/modules/core/src/core.module.ts
+++ b/app/scripts/modules/core/src/core.module.ts
@@ -46,7 +46,9 @@ import { INSIGHT_MODULE } from './insight/insight.module';
 import { INTERCEPTOR_MODULE } from './interceptor/interceptor.module';
 import { LOAD_BALANCER_MODULE } from './loadBalancer/loadBalancer.module';
 import { MANAGED_RESOURCE_CONFIG } from './application/config/managedResources/ManagedResourceConfig';
+import { MANAGED_RESOURCES_DATA_SOURCE } from './managed';
 import { FUNCTION_MODULE } from './function/function.module';
+
 import { NETWORK_INTERCEPTOR } from './api/network.interceptor';
 
 import { PAGE_TITLE_MODULE } from './pageTitle/pageTitle.module';
@@ -116,6 +118,7 @@ module(CORE_MODULE, [
   LOAD_BALANCER_MODULE,
   FUNCTION_MODULE,
   MANAGED_RESOURCE_CONFIG,
+  MANAGED_RESOURCES_DATA_SOURCE,
   require('./modal/modal.module').name,
 
   NETWORK_INTERCEPTOR,

--- a/app/scripts/modules/core/src/domain/ILoadBalancer.ts
+++ b/app/scripts/modules/core/src/domain/ILoadBalancer.ts
@@ -1,8 +1,10 @@
+import { IMoniker } from 'core/naming';
+import { IManagedResourceSummary } from 'core/managed';
+
 import { IInstance } from './IInstance';
 import { IInstanceCounts } from './IInstanceCounts';
 import { IServerGroup } from './IServerGroup';
 import { ITaggedEntity } from './ITaggedEntity';
-import { IMoniker } from 'core/naming/IMoniker';
 
 export interface ILoadBalancerSourceData {
   cloudProvider?: string;
@@ -18,10 +20,12 @@ export interface ILoadBalancer extends ITaggedEntity {
   healthState?: string;
   instanceCounts?: IInstanceCounts;
   instances?: IInstance[];
+  isManaged?: boolean;
   listenerDescriptions?: any[];
   loadBalancerType?: string;
-  name?: string;
+  managedResourceSummary?: IManagedResourceSummary;
   moniker?: IMoniker;
+  name?: string;
   provider?: string;
   region?: string;
   searchField?: string;

--- a/app/scripts/modules/core/src/domain/ISecurityGroup.ts
+++ b/app/scripts/modules/core/src/domain/ISecurityGroup.ts
@@ -1,5 +1,8 @@
 import { ILoadBalancer } from 'core/domain/ILoadBalancer';
 import { IServerGroup } from 'core/domain/IServerGroup';
+import { IMoniker } from 'core/naming';
+import { IManagedResourceSummary } from 'core/managed';
+
 import { IEntityTags } from './IEntityTags';
 
 export interface ILoadBalancerUsage {
@@ -30,6 +33,9 @@ export interface ISecurityGroup {
   entityTags?: IEntityTags;
   id?: string;
   inferredName?: boolean;
+  isManaged?: boolean;
+  moniker?: IMoniker;
+  managedResourceSummary?: IManagedResourceSummary;
   name?: string;
   provider?: string;
   region?: string;

--- a/app/scripts/modules/core/src/domain/IServerGroup.ts
+++ b/app/scripts/modules/core/src/domain/IServerGroup.ts
@@ -3,8 +3,9 @@ import { IExecution } from './IExecution';
 import { IInstance } from './IInstance';
 import { IInstanceCounts } from './IInstanceCounts';
 import { ITask } from './ITask';
-import { IMoniker } from 'core/naming/IMoniker';
+import { IMoniker } from 'core/naming';
 import { ICapacity } from 'core/serverGroup';
+import { IManagedResourceSummary } from 'core/managed';
 
 // remnant from legacy code
 export interface IAsg {
@@ -19,8 +20,8 @@ export interface IServerGroup {
   app?: string;
   asg?: IAsg;
   buildInfo?: any;
-  category?: string;
   capacity?: ICapacity;
+  category?: string;
   cloudProvider: string;
   cluster: string;
   clusterEntityTags?: IEntityTags[];
@@ -34,12 +35,14 @@ export interface IServerGroup {
   instances: IInstance[];
   instanceType?: string;
   isDisabled?: boolean;
+  isManaged?: boolean;
   labels?: { [key: string]: string };
   launchConfig?: any;
   loadBalancers?: string[];
+  managedResourceSummary?: IManagedResourceSummary;
+  moniker?: IMoniker;
   name: string;
   namespace?: string;
-  moniker?: IMoniker;
   provider?: string;
   providerMetadata?: any;
   region: string;

--- a/app/scripts/modules/core/src/entityTag/EntityTagsReader.ts
+++ b/app/scripts/modules/core/src/entityTag/EntityTagsReader.ts
@@ -28,21 +28,23 @@ export class EntityTagsReader {
     if (!SETTINGS.feature.entityTags) {
       return;
     }
-    const allTags = application.getDataSource('entityTags').data;
-    const serverGroupTags: IEntityTags[] = allTags.filter(t => t.entityRef.entityType === 'servergroup');
-    const clusterTags: IEntityTags[] = allTags.filter(t => t.entityRef.entityType === 'cluster');
-    application.getDataSource('serverGroups').data.forEach((serverGroup: IServerGroup) => {
+    const allTags: IEntityTags[] = application.entityTags.data;
+    const serverGroupTags = allTags.filter(({ entityRef }) => entityRef.entityType === 'servergroup');
+    const clusterTags = allTags.filter(({ entityRef }) => entityRef.entityType === 'cluster');
+    const serverGroups: IServerGroup[] = application.serverGroups.data;
+
+    serverGroups.forEach(serverGroup => {
       serverGroup.entityTags = serverGroupTags.find(
-        t =>
-          t.entityRef.entityId === serverGroup.name &&
-          t.entityRef.account === serverGroup.account &&
-          t.entityRef.region === serverGroup.region,
+        ({ entityRef }) =>
+          entityRef.entityId === serverGroup.name &&
+          entityRef.account === serverGroup.account &&
+          entityRef.region === serverGroup.region,
       );
       serverGroup.clusterEntityTags = clusterTags.filter(
-        t =>
-          t.entityRef.entityId === serverGroup.cluster &&
-          (t.entityRef.account === '*' || t.entityRef.account === serverGroup.account) &&
-          (t.entityRef.region === '*' || t.entityRef.region === serverGroup.region),
+        ({ entityRef }) =>
+          entityRef.entityId === serverGroup.cluster &&
+          (entityRef.account === '*' || entityRef.account === serverGroup.account) &&
+          (entityRef.region === '*' || entityRef.region === serverGroup.region),
       );
     });
   }
@@ -51,14 +53,16 @@ export class EntityTagsReader {
     if (!SETTINGS.feature.entityTags) {
       return;
     }
-    const allTags = application.getDataSource('entityTags').data;
-    const serverGroupManagerTags: IEntityTags[] = allTags.filter(t => t.entityRef.entityType === 'servergroupmanager');
-    application.getDataSource('serverGroupManagers').data.forEach((serverGroupManager: IServerGroupManager) => {
+    const allTags: IEntityTags[] = application.entityTags.data;
+    const serverGroupManagerTags = allTags.filter(({ entityRef }) => entityRef.entityType === 'servergroupmanager');
+    const serverGroupManagers: IServerGroupManager[] = application.serverGroupManagers.data;
+
+    serverGroupManagers.forEach(serverGroupManager => {
       serverGroupManager.entityTags = serverGroupManagerTags.find(
-        t =>
-          t.entityRef.entityId === serverGroupManager.name &&
-          t.entityRef.account === serverGroupManager.account &&
-          t.entityRef.region === serverGroupManager.region,
+        ({ entityRef }) =>
+          entityRef.entityId === serverGroupManager.name &&
+          entityRef.account === serverGroupManager.account &&
+          entityRef.region === serverGroupManager.region,
       );
     });
   }
@@ -67,14 +71,16 @@ export class EntityTagsReader {
     if (!SETTINGS.feature.entityTags) {
       return;
     }
-    const allTags = application.getDataSource('entityTags').data;
-    const loadBalancerTags: IEntityTags[] = allTags.filter(t => t.entityRef.entityType === 'loadbalancer');
-    application.getDataSource('loadBalancers').data.forEach((loadBalancer: ILoadBalancer) => {
+    const allTags: IEntityTags[] = application.entityTags.data;
+    const loadBalancerTags = allTags.filter(({ entityRef }) => entityRef.entityType === 'loadbalancer');
+    const loadBalancers: ILoadBalancer[] = application.loadBalancers.data;
+
+    loadBalancers.forEach(loadBalancer => {
       loadBalancer.entityTags = loadBalancerTags.find(
-        t =>
-          t.entityRef.entityId === loadBalancer.name &&
-          t.entityRef.account === loadBalancer.account &&
-          t.entityRef.region === loadBalancer.region,
+        ({ entityRef }) =>
+          entityRef.entityId === loadBalancer.name &&
+          entityRef.account === loadBalancer.account &&
+          entityRef.region === loadBalancer.region,
       );
     });
   }
@@ -83,14 +89,14 @@ export class EntityTagsReader {
     if (!SETTINGS.feature.entityTags || !SETTINGS.feature.functions) {
       return;
     }
-    const allTags = application.getDataSource('entityTags').data;
-    const functionTags: IEntityTags[] = allTags.filter(t => t.entityRef.entityType === 'function');
-    application.getDataSource('functions').data.forEach((fn: IFunction) => {
+    const allTags: IEntityTags[] = application.entityTags.data;
+    const functionTags = allTags.filter(({ entityRef }) => entityRef.entityType === 'function');
+    const functions: IFunction[] = application.functions.data;
+
+    functions.forEach(fn => {
       fn.entityTags = functionTags.find(
-        t =>
-          t.entityRef.entityId === fn.functionName &&
-          t.entityRef.account === fn.account &&
-          t.entityRef.region === fn.region,
+        ({ entityRef }) =>
+          entityRef.entityId === fn.functionName && entityRef.account === fn.account && entityRef.region === fn.region,
       );
     });
   }
@@ -98,14 +104,16 @@ export class EntityTagsReader {
     if (!SETTINGS.feature.entityTags) {
       return;
     }
-    const allTags = application.getDataSource('entityTags').data;
-    const securityGroupTags: IEntityTags[] = allTags.filter(t => t.entityRef.entityType === 'securitygroup');
-    application.getDataSource('securityGroups').data.forEach((securityGroup: ISecurityGroup) => {
+    const allTags: IEntityTags[] = application.entityTags.data;
+    const securityGroupTags = allTags.filter(({ entityRef }) => entityRef.entityType === 'securitygroup');
+    const securityGroups: ISecurityGroup[] = application.securityGroups.data;
+
+    securityGroups.forEach(securityGroup => {
       securityGroup.entityTags = securityGroupTags.find(
-        t =>
-          t.entityRef.entityId === securityGroup.name &&
-          t.entityRef.account === securityGroup.account &&
-          t.entityRef.region === securityGroup.region,
+        ({ entityRef }) =>
+          entityRef.entityId === securityGroup.name &&
+          entityRef.account === securityGroup.account &&
+          entityRef.region === securityGroup.region,
       );
     });
   }
@@ -114,10 +122,12 @@ export class EntityTagsReader {
     if (!SETTINGS.feature.entityTags) {
       return;
     }
-    const allTags = application.getDataSource('entityTags').data;
-    const executionTags: IEntityTags[] = allTags.filter(t => t.entityRef.entityType === 'execution');
-    application.getDataSource('executions').data.forEach((execution: IExecution) => {
-      execution.entityTags = executionTags.find(t => t.entityRef.entityId === execution.id);
+    const allTags: IEntityTags[] = application.entityTags.data;
+    const executionTags = allTags.filter(({ entityRef }) => entityRef.entityType === 'execution');
+    const executions: IExecution[] = application.executions.data;
+
+    executions.forEach(execution => {
+      execution.entityTags = executionTags.find(({ entityRef }) => entityRef.entityId === execution.id);
     });
   }
 
@@ -125,10 +135,12 @@ export class EntityTagsReader {
     if (!SETTINGS.feature.entityTags) {
       return;
     }
-    const allTags = application.getDataSource('entityTags').data;
-    const pipelineTags: IEntityTags[] = allTags.filter(t => t.entityRef.entityType === 'pipeline');
-    application.getDataSource('pipelineConfigs').data.forEach((pipeline: IPipeline) => {
-      pipeline.entityTags = pipelineTags.find(t => t.entityRef.entityId === pipeline.id);
+    const allTags: IEntityTags[] = application.entityTags.data;
+    const pipelineTags = allTags.filter(({ entityRef }) => entityRef.entityType === 'pipeline');
+    const pipelineConfigs: IPipeline[] = application.pipelineConfigs.data;
+
+    pipelineConfigs.forEach(pipeline => {
+      pipeline.entityTags = pipelineTags.find(({ entityRef }) => entityRef.entityId === pipeline.id);
     });
   }
 

--- a/app/scripts/modules/core/src/entityTag/entityTags.dataSource.ts
+++ b/app/scripts/modules/core/src/entityTag/entityTags.dataSource.ts
@@ -1,6 +1,6 @@
 import { module, IQService } from 'angular';
 
-import { ApplicationDataSourceRegistry } from 'core/application/service/ApplicationDataSourceRegistry';
+import { ApplicationDataSourceRegistry } from 'core/application';
 import { Application } from 'core/application/application.model';
 import { EntityTagsReader } from './EntityTagsReader';
 import { IEntityTags } from 'core/domain/IEntityTags';
@@ -56,6 +56,7 @@ module(ENTITY_TAGS_DATA_SOURCE, [LOAD_BALANCER_READ_SERVICE]).run([
       loader: loadEntityTags,
       onLoad: addEntityTags,
       afterLoad: addTagsToEntities,
+      defaultData: [],
     });
   },
 ]);

--- a/app/scripts/modules/core/src/function/filter/FunctionFilterService.spec.ts
+++ b/app/scripts/modules/core/src/function/filter/FunctionFilterService.spec.ts
@@ -14,7 +14,7 @@ describe('Service: functionFilterService', function() {
   });
 
   beforeEach(function() {
-    app = ApplicationModelBuilder.createApplicationForTests('app', { key: 'functions', lazy: true });
+    app = ApplicationModelBuilder.createApplicationForTests('app', { key: 'functions', lazy: true, defaultData: [] });
     app.getDataSource('functions').data = [
       {
         functionName: 'function1',

--- a/app/scripts/modules/core/src/function/function.dataSource.ts
+++ b/app/scripts/modules/core/src/function/function.dataSource.ts
@@ -42,6 +42,7 @@ module(FUNCTION_DATA_SOURCE, [FUNCTION_READ_SERVICE]).run([
       credentialsField: 'account',
       regionField: 'region',
       description: 'Serverless Compute Service.',
+      defaultData: [],
     });
   },
 ]);

--- a/app/scripts/modules/core/src/instance/details/multipleInstances.controller.spec.js
+++ b/app/scripts/modules/core/src/instance/details/multipleInstances.controller.spec.js
@@ -14,7 +14,11 @@ describe('Controller: MultipleInstances', function() {
       scope = $rootScope.$new();
 
       this.createController = function(serverGroups) {
-        let application = ApplicationModelBuilder.createApplicationForTests('app', { key: 'serverGroups', lazy: true });
+        let application = ApplicationModelBuilder.createApplicationForTests('app', {
+          key: 'serverGroups',
+          lazy: true,
+          defaultData: [],
+        });
         application.serverGroups.data = serverGroups;
         application.serverGroups.loaded = true;
         this.application = application;

--- a/app/scripts/modules/core/src/instance/instance.write.service.spec.ts
+++ b/app/scripts/modules/core/src/instance/instance.write.service.spec.ts
@@ -46,6 +46,7 @@ describe('Service: instance writer', function() {
       const application: Application = ApplicationModelBuilder.createApplicationForTests('app', {
         key: 'serverGroups',
         lazy: true,
+        defaultData: [],
       });
       let executedTask: IJob = null;
 

--- a/app/scripts/modules/core/src/loadBalancer/LoadBalancersTag.spec.tsx
+++ b/app/scripts/modules/core/src/loadBalancer/LoadBalancersTag.spec.tsx
@@ -23,6 +23,7 @@ describe('<LoadBalancersTag />', () => {
         key: 'loadBalancers',
         loader: () => $q.resolve(application.loadBalancers.data),
         onLoad: (_app, data) => $q.resolve(data),
+        defaultData: [],
       });
       application.loadBalancers.refresh();
       $scope.$digest();

--- a/app/scripts/modules/core/src/loadBalancer/filter/LoadBalancerFilterService.spec.ts
+++ b/app/scripts/modules/core/src/loadBalancer/filter/LoadBalancerFilterService.spec.ts
@@ -14,7 +14,11 @@ describe('Service: loadBalancerFilterService', function() {
   });
 
   beforeEach(function() {
-    app = ApplicationModelBuilder.createApplicationForTests('app', { key: 'loadBalancers', lazy: true });
+    app = ApplicationModelBuilder.createApplicationForTests('app', {
+      key: 'loadBalancers',
+      lazy: true,
+      defaultData: [],
+    });
     app.getDataSource('loadBalancers').data = [
       {
         name: 'elb-1',

--- a/app/scripts/modules/core/src/loadBalancer/loadBalancer.dataSource.ts
+++ b/app/scripts/modules/core/src/loadBalancer/loadBalancer.dataSource.ts
@@ -6,6 +6,7 @@ import { Application } from 'core/application/application.model';
 import { EntityTagsReader } from 'core/entityTag/EntityTagsReader';
 import { ILoadBalancer } from 'core/domain';
 import { LOAD_BALANCER_READ_SERVICE, LoadBalancerReader } from 'core/loadBalancer/loadBalancer.read.service';
+import { addManagedResourceMetadataToLoadBalancers } from 'core/managed';
 
 export const LOAD_BALANCER_DATA_SOURCE = 'spinnaker.core.loadBalancer.dataSource';
 module(LOAD_BALANCER_DATA_SOURCE, [LOAD_BALANCER_READ_SERVICE]).run([
@@ -22,6 +23,7 @@ module(LOAD_BALANCER_DATA_SOURCE, [LOAD_BALANCER_READ_SERVICE]).run([
 
     const addTags = (application: Application) => {
       EntityTagsReader.addTagsToLoadBalancers(application);
+      addManagedResourceMetadataToLoadBalancers(application);
     };
 
     ApplicationDataSourceRegistry.registerDataSource({

--- a/app/scripts/modules/core/src/loadBalancer/loadBalancer.dataSource.ts
+++ b/app/scripts/modules/core/src/loadBalancer/loadBalancer.dataSource.ts
@@ -37,6 +37,7 @@ module(LOAD_BALANCER_DATA_SOURCE, [LOAD_BALANCER_READ_SERVICE]).run([
       credentialsField: 'account',
       regionField: 'region',
       description: 'Traffic distribution management between servers',
+      defaultData: [],
     });
   },
 ]);

--- a/app/scripts/modules/core/src/managed/ManagedReader.ts
+++ b/app/scripts/modules/core/src/managed/ManagedReader.ts
@@ -1,15 +1,37 @@
 import { IPromise } from 'angular';
 
 import { API } from 'core/api';
+import { IMoniker } from 'core/naming';
+
+export enum ManagedResourceStatus {
+  ACTUATING = 'ACTUATING',
+  DIFF = 'DIFF',
+  ERROR = 'ERROR',
+  HAPPY = 'HAPPY',
+  UNHAPPY = 'UNHAPPY',
+}
+
+export interface IManagedResourceSummary {
+  id: string;
+  kind: string;
+  status: ManagedResourceStatus;
+  moniker: IMoniker;
+  locations: {
+    accountName: string;
+    regions: string[];
+  };
+}
 
 export interface IManagedApplicationSummary {
   hasManagedResources: boolean;
+  resources: IManagedResourceSummary[];
 }
 
 export class ManagedReader {
   public static getApplicationSummary(app: string): IPromise<IManagedApplicationSummary> {
     return API.one('managed')
       .one('application', app)
+      .withParams({ includeDetails: true })
       .get();
   }
 

--- a/app/scripts/modules/core/src/managed/ManagedReader.ts
+++ b/app/scripts/modules/core/src/managed/ManagedReader.ts
@@ -17,8 +17,8 @@ export interface IManagedResourceSummary {
   status: ManagedResourceStatus;
   moniker: IMoniker;
   locations: {
-    accountName: string;
-    regions: string[];
+    account: string;
+    regions: Array<{ name: string }>;
   };
 }
 
@@ -26,6 +26,17 @@ export interface IManagedApplicationSummary {
   hasManagedResources: boolean;
   resources: IManagedResourceSummary[];
 }
+
+export const getResourceKindForLoadBalancerType = (type: string) => {
+  switch (type) {
+    case 'classic':
+      return 'classic-load-balancer';
+    case 'application':
+      return 'application-load-balancer';
+    default:
+      return null;
+  }
+};
 
 export class ManagedReader {
   public static getApplicationSummary(app: string): IPromise<IManagedApplicationSummary> {

--- a/app/scripts/modules/core/src/managed/ManagedResourceDetailsIndicator.tsx
+++ b/app/scripts/modules/core/src/managed/ManagedResourceDetailsIndicator.tsx
@@ -1,18 +1,16 @@
 import * as React from 'react';
 import * as ReactGA from 'react-ga';
-import { get, flatMap } from 'lodash';
 import { Dropdown } from 'react-bootstrap';
 
 import { SETTINGS } from 'core/config/settings';
-import { IEntityTags } from 'core/domain';
 import { HoverablePopover } from 'core/presentation';
+
+import { IManagedResourceSummary } from './ManagedReader';
 
 import './ManagedResourceDetailsIndicator.less';
 
-export const MANAGED_BY_SPINNAKER_TAG_NAME = 'spinnaker_ui_notice:managed_by_spinnaker';
-
 export interface IManagedResourceDetailsIndicatorProps {
-  entityTags: IEntityTags[];
+  resourceSummary: IManagedResourceSummary;
 }
 
 const logClick = (label: string, resourceId: string) =>
@@ -22,18 +20,12 @@ const logClick = (label: string, resourceId: string) =>
     label: resourceId,
   });
 
-export const ManagedResourceDetailsIndicator = ({ entityTags }: IManagedResourceDetailsIndicatorProps) => {
-  const managedTag =
-    get(entityTags, 'length') &&
-    flatMap(entityTags, ({ tags }) => tags).find(({ name }) => name === MANAGED_BY_SPINNAKER_TAG_NAME);
-
-  if (!managedTag) {
+export const ManagedResourceDetailsIndicator = ({ resourceSummary }: IManagedResourceDetailsIndicatorProps) => {
+  if (!resourceSummary) {
     return null;
   }
 
-  const {
-    value: { keelResourceId },
-  } = managedTag;
+  const { id } = resourceSummary;
 
   const helpText = (
     <>
@@ -44,7 +36,7 @@ export const ManagedResourceDetailsIndicator = ({ entityTags }: IManagedResource
         Changes made in the UI will be stomped in favor of the existing declarative configuration.{' '}
         <a
           target="_blank"
-          onClick={() => logClick('Learn More', keelResourceId)}
+          onClick={() => logClick('Learn More', id)}
           href="https://www.spinnaker.io/reference/managed-delivery"
         >
           Learn More
@@ -65,19 +57,15 @@ export const ManagedResourceDetailsIndicator = ({ entityTags }: IManagedResource
         <Dropdown.Toggle className="btn btn-sm btn-default dropdown-toggle">Resource Actions</Dropdown.Toggle>
         <Dropdown.Menu className="dropdown-menu">
           <li>
-            <a
-              target="_blank"
-              onClick={() => logClick('History', keelResourceId)}
-              href={`${SETTINGS.gateUrl}/history/${keelResourceId}`}
-            >
+            <a target="_blank" onClick={() => logClick('History', id)} href={`${SETTINGS.gateUrl}/history/${id}`}>
               History
             </a>
           </li>
           <li>
             <a
               target="_blank"
-              onClick={() => logClick('Raw Source', keelResourceId)}
-              href={`${SETTINGS.gateUrl}/managed/resources/${keelResourceId}`}
+              onClick={() => logClick('Raw Source', id)}
+              href={`${SETTINGS.gateUrl}/managed/resources/${id}`}
             >
               Raw Source
             </a>

--- a/app/scripts/modules/core/src/managed/index.ts
+++ b/app/scripts/modules/core/src/managed/index.ts
@@ -3,3 +3,4 @@ export * from './ManagedWriter';
 export * from './ManagedResourceDetailsIndicator';
 export * from './managedResourceDetailsIndicator.component';
 export * from './managed.dataSource';
+export * from './managedResourceDecorators';

--- a/app/scripts/modules/core/src/managed/index.ts
+++ b/app/scripts/modules/core/src/managed/index.ts
@@ -2,3 +2,4 @@ export * from './ManagedReader';
 export * from './ManagedWriter';
 export * from './ManagedResourceDetailsIndicator';
 export * from './managedResourceDetailsIndicator.component';
+export * from './managed.dataSource';

--- a/app/scripts/modules/core/src/managed/managed.dataSource.ts
+++ b/app/scripts/modules/core/src/managed/managed.dataSource.ts
@@ -1,0 +1,31 @@
+import { module, IQService } from 'angular';
+
+import { SETTINGS } from 'core/config/settings';
+import { ApplicationDataSourceRegistry } from 'core/application/service/ApplicationDataSourceRegistry';
+import { Application } from 'core/application';
+import { ManagedReader, IManagedApplicationSummary } from './ManagedReader';
+
+export const MANAGED_RESOURCES_DATA_SOURCE = 'spinnaker.core.managed.dataSource';
+module(MANAGED_RESOURCES_DATA_SOURCE, []).run([
+  '$q',
+  ($q: IQService) => {
+    if (!SETTINGS.feature.managedResources) {
+      return;
+    }
+    const loadManagedResources = (application: Application) => {
+      return ManagedReader.getApplicationSummary(application.name);
+    };
+
+    const addManagedResources = (_application: Application, data: IManagedApplicationSummary) => {
+      return $q.when(data);
+    };
+
+    ApplicationDataSourceRegistry.registerDataSource({
+      key: 'managedResources',
+      visible: false,
+      loader: loadManagedResources,
+      onLoad: addManagedResources,
+      defaultData: { hasManagedResources: false, resources: [] },
+    });
+  },
+]);

--- a/app/scripts/modules/core/src/managed/managed.dataSource.ts
+++ b/app/scripts/modules/core/src/managed/managed.dataSource.ts
@@ -1,9 +1,15 @@
 import { module, IQService } from 'angular';
 
+import { noop } from 'core/utils';
 import { SETTINGS } from 'core/config/settings';
 import { ApplicationDataSourceRegistry } from 'core/application/service/ApplicationDataSourceRegistry';
 import { Application } from 'core/application';
 import { ManagedReader, IManagedApplicationSummary } from './ManagedReader';
+import {
+  addManagedResourceMetadataToServerGroups,
+  addManagedResourceMetadataToLoadBalancers,
+  addManagedResourceMetadataToSecurityGroups,
+} from './managedResourceDecorators';
 
 export const MANAGED_RESOURCES_DATA_SOURCE = 'spinnaker.core.managed.dataSource';
 module(MANAGED_RESOURCES_DATA_SOURCE, []).run([
@@ -20,11 +26,18 @@ module(MANAGED_RESOURCES_DATA_SOURCE, []).run([
       return $q.when(data);
     };
 
+    const addManagedMetadataToResources = (application: Application) => {
+      application.serverGroups.ready().then(() => addManagedResourceMetadataToServerGroups(application), noop);
+      application.loadBalancers.ready().then(() => addManagedResourceMetadataToLoadBalancers(application), noop);
+      application.securityGroups.ready().then(() => addManagedResourceMetadataToSecurityGroups(application), noop);
+    };
+
     ApplicationDataSourceRegistry.registerDataSource({
       key: 'managedResources',
       visible: false,
       loader: loadManagedResources,
       onLoad: addManagedResources,
+      afterLoad: addManagedMetadataToResources,
       defaultData: { hasManagedResources: false, resources: [] },
     });
   },

--- a/app/scripts/modules/core/src/managed/managedResourceDecorators.ts
+++ b/app/scripts/modules/core/src/managed/managedResourceDecorators.ts
@@ -1,0 +1,77 @@
+import { Application } from 'core/application';
+import { SETTINGS } from 'core/config';
+import { IServerGroup, ILoadBalancer, ISecurityGroup } from 'core/domain';
+import { IMoniker } from 'core/naming';
+
+import { IManagedResourceSummary, getResourceKindForLoadBalancerType } from './ManagedReader';
+
+const isMonikerEqual = (a: IMoniker, b: IMoniker) => a.app === b.app && a.stack === b.stack && a.detail === b.detail;
+
+const getResourcesOfKind = (application: Application, kinds: string[]) => {
+  const resources: IManagedResourceSummary[] = application.managedResources.data.resources;
+  return resources.filter(({ kind }) => kinds.includes(kind));
+};
+
+export const addManagedResourceMetadataToServerGroups = (application: Application) => {
+  if (!SETTINGS.feature.managedResources) {
+    return;
+  }
+
+  const clusterResources = getResourcesOfKind(application, ['cluster']);
+  const serverGroups: IServerGroup[] = application.serverGroups.data;
+
+  serverGroups.forEach(serverGroup => {
+    const matchingResource = clusterResources.find(
+      ({ moniker, locations: { account, regions } }) =>
+        isMonikerEqual(moniker, serverGroup.moniker) &&
+        account === serverGroup.account &&
+        regions.some(({ name }) => name === serverGroup.region),
+    );
+
+    serverGroup.isManaged = !!matchingResource;
+    serverGroup.managedResourceSummary = matchingResource;
+  });
+};
+
+export const addManagedResourceMetadataToLoadBalancers = (application: Application) => {
+  if (!SETTINGS.feature.managedResources) {
+    return;
+  }
+
+  const loadBalancerResources = getResourcesOfKind(application, ['classic-load-balancer', 'application-load-balancer']);
+  const loadBalancers: ILoadBalancer[] = application.loadBalancers.data;
+
+  loadBalancers.forEach(loadBalancer => {
+    const matchingResource = loadBalancerResources.find(
+      ({ kind, moniker, locations: { account, regions } }) =>
+        kind === getResourceKindForLoadBalancerType(loadBalancer.loadBalancerType) &&
+        isMonikerEqual(moniker, loadBalancer.moniker) &&
+        account === loadBalancer.account &&
+        regions.some(({ name }) => name === loadBalancer.region),
+    );
+
+    loadBalancer.isManaged = !!matchingResource;
+    loadBalancer.managedResourceSummary = matchingResource;
+  });
+};
+
+export const addManagedResourceMetadataToSecurityGroups = (application: Application) => {
+  if (!SETTINGS.feature.managedResources) {
+    return;
+  }
+
+  const securityGroupResources = getResourcesOfKind(application, ['security-group']);
+  const securityGroups: ISecurityGroup[] = application.securityGroups.data;
+
+  securityGroups.forEach(securityGroup => {
+    const matchingResource = securityGroupResources.find(
+      ({ moniker, locations: { account, regions } }) =>
+        isMonikerEqual(moniker, securityGroup.moniker) &&
+        account === securityGroup.account &&
+        regions.some(({ name }) => name === securityGroup.region),
+    );
+
+    securityGroup.isManaged = !!matchingResource;
+    securityGroup.managedResourceSummary = matchingResource;
+  });
+};

--- a/app/scripts/modules/core/src/managed/managedResourceDetailsIndicator.component.ts
+++ b/app/scripts/modules/core/src/managed/managedResourceDetailsIndicator.component.ts
@@ -6,5 +6,5 @@ import { ManagedResourceDetailsIndicator } from './ManagedResourceDetailsIndicat
 export const MANAGED_RESOURCE_DETAILS_INDICATOR = 'spinnaker.core.managed.resourceDetailsIndicator.component';
 module(MANAGED_RESOURCE_DETAILS_INDICATOR, []).component(
   'managedResourceDetailsIndicator',
-  react2angular(ManagedResourceDetailsIndicator, ['entityTags']),
+  react2angular(ManagedResourceDetailsIndicator, ['resourceSummary']),
 );

--- a/app/scripts/modules/core/src/naming/nameUtils.ts
+++ b/app/scripts/modules/core/src/naming/nameUtils.ts
@@ -1,4 +1,4 @@
-import { padStart, isNil } from 'lodash';
+import { padStart, isNil, pickBy } from 'lodash';
 import { IMoniker } from './IMoniker';
 
 export interface IComponentName {
@@ -102,6 +102,6 @@ export class NameUtils {
   }
 
   public static getMoniker(app: string, stack: string, detail: string): IMoniker {
-    return { app, stack, detail };
+    return pickBy({ app, stack, detail });
   }
 }

--- a/app/scripts/modules/core/src/pipeline/config/pipelineConfig.controller.spec.js
+++ b/app/scripts/modules/core/src/pipeline/config/pipelineConfig.controller.spec.js
@@ -17,6 +17,7 @@ describe('Controller: PipelineConfigCtrl', function() {
     const application = ApplicationModelBuilder.createApplicationForTests('app', {
       key: 'pipelineConfigs',
       lazy: true,
+      defaultData: [],
     });
     application.pipelineConfigs.data = [{ id: 'a' }];
     application.pipelineConfigs.loaded = true;
@@ -36,6 +37,7 @@ describe('Controller: PipelineConfigCtrl', function() {
     const application = ApplicationModelBuilder.createApplicationForTests('app', {
       key: 'pipelineConfigs',
       lazy: true,
+      defaultData: [],
     });
     spyOn(application.pipelineConfigs, 'activate').and.callFake(angular.noop);
     let vm = controller('PipelineConfigCtrl', {

--- a/app/scripts/modules/core/src/pipeline/config/pipelineConfigurer.controller.spec.ts
+++ b/app/scripts/modules/core/src/pipeline/config/pipelineConfigurer.controller.spec.ts
@@ -127,6 +127,7 @@ describe('Controller: pipelineConfigurer', function() {
       $scope.application = ApplicationModelBuilder.createApplicationForTests('app', {
         key: 'pipelineConfigs',
         lazy: true,
+        defaultData: [],
       });
       $scope.plan = plan;
       $scope.isTemplatedPipeline = true;

--- a/app/scripts/modules/core/src/pipeline/create/CreatePipelineModal.spec.tsx
+++ b/app/scripts/modules/core/src/pipeline/create/CreatePipelineModal.spec.tsx
@@ -31,12 +31,14 @@ xdescribe('CreatePipelineModal', () => {
             lazy: true,
             loader: () => $q.resolve(application.pipelineConfigs.data),
             onLoad: (_app, data) => $q.resolve(data),
+            defaultData: [],
           },
           {
             key: 'strategyConfigs',
             lazy: true,
             loader: () => $q.resolve(application.strategyConfigs.data),
             onLoad: (_app, data) => $q.resolve(data),
+            defaultData: [],
           },
         );
         application.pipelineConfigs.data = configs;

--- a/app/scripts/modules/core/src/pipeline/create/CreatePipelineModal.tsx
+++ b/app/scripts/modules/core/src/pipeline/create/CreatePipelineModal.tsx
@@ -182,27 +182,25 @@ export class CreatePipelineModal extends React.Component<ICreatePipelineModalPro
 
   private onSaveSuccess(config: Partial<IPipeline>): void {
     const application = this.props.application;
-    application
-      .getDataSource('pipelineConfigs')
-      .refresh(true)
-      .then(() => {
-        const newPipeline = (config.strategy
-          ? (application.strategyConfigs.data as IPipeline[])
-          : application.getDataSource('pipelineConfigs').data
-        ).find(_config => _config.name === config.name);
-        if (!newPipeline) {
-          $log.warn('Could not find new pipeline after save succeeded.');
-          this.setState({
-            saveError: true,
-            saveErrorMessage: 'Sorry, there was an error retrieving your new pipeline. Please refresh the browser.',
-            submitting: false,
-          });
-        } else {
-          newPipeline.isNew = true;
-          this.setState(this.getDefaultState());
-          this.props.pipelineSavedCallback(newPipeline.id);
-        }
-      });
+    application.pipelineConfigs.refresh(true).then(() => {
+      const configs: IPipeline[] = config.strategy
+        ? application.strategyConfigs.data
+        : application.pipelineConfigs.data;
+      const newPipeline = configs.find(_config => _config.name === config.name);
+
+      if (!newPipeline) {
+        $log.warn('Could not find new pipeline after save succeeded.');
+        this.setState({
+          saveError: true,
+          saveErrorMessage: 'Sorry, there was an error retrieving your new pipeline. Please refresh the browser.',
+          submitting: false,
+        });
+      } else {
+        newPipeline.isNew = true;
+        this.setState(this.getDefaultState());
+        this.props.pipelineSavedCallback(newPipeline.id);
+      }
+    });
   }
 
   private onSaveFailure = (response: IHttpPromiseCallbackArg<{ message: string }>): void => {

--- a/app/scripts/modules/core/src/pipeline/executions/Executions.spec.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/Executions.spec.tsx
@@ -38,8 +38,8 @@ describe('<Executions/>', () => {
       scope = $rootScope.$new();
       application = ApplicationModelBuilder.createApplicationForTests(
         'app',
-        { key: 'executions', lazy: true },
-        { key: 'pipelineConfigs', lazy: true },
+        { key: 'executions', lazy: true, defaultData: [] },
+        { key: 'pipelineConfigs', lazy: true, defaultData: [] },
       );
     }),
   );

--- a/app/scripts/modules/core/src/pipeline/executions/Executions.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/Executions.tsx
@@ -8,7 +8,7 @@ import { $q } from 'ngimport';
 import { Subscription } from 'rxjs';
 
 import { Application } from 'core/application';
-import { IPipeline, IPipelineCommand } from 'core/domain';
+import { IPipeline, IPipelineCommand, IExecution } from 'core/domain';
 import { ReactInjector } from 'core/reactShims';
 import { ManualExecutionModal } from 'core/pipeline';
 import { Tooltip } from 'core/presentation/Tooltip';
@@ -202,7 +202,8 @@ export class Executions extends React.Component<IExecutionsProps, IExecutionsSta
         // if an execution was selected but is no longer present, navigate up
         const { $state } = ReactInjector;
         if ($state.params.executionId) {
-          if (app.getDataSource('executions').data.every(e => e.id !== $state.params.executionId)) {
+          const executions: IExecution[] = app.executions.data;
+          if (executions.every(e => e.id !== $state.params.executionId)) {
             $state.go('.^');
           }
         }

--- a/app/scripts/modules/core/src/pipeline/pipeline.dataSource.js
+++ b/app/scripts/modules/core/src/pipeline/pipeline.dataSource.js
@@ -77,6 +77,7 @@ module.exports = angular.module('spinnaker.core.pipeline.dataSource', [EXECUTION
         lazy: true,
         badge: 'runningExecutions',
         description: 'Orchestrated deployment management',
+        defaultData: [],
       });
 
       ApplicationDataSourceRegistry.registerDataSource({
@@ -86,6 +87,7 @@ module.exports = angular.module('spinnaker.core.pipeline.dataSource', [EXECUTION
         afterLoad: addPipelineTags,
         lazy: true,
         visible: false,
+        defaultData: [],
       });
 
       ApplicationDataSourceRegistry.registerDataSource({
@@ -94,6 +96,7 @@ module.exports = angular.module('spinnaker.core.pipeline.dataSource', [EXECUTION
         loader: loadRunningExecutions,
         onLoad: addRunningExecutions,
         afterLoad: runningExecutionsLoaded,
+        defaultData: [],
       });
     }
   },

--- a/app/scripts/modules/core/src/pipeline/pipeline.dataSource.spec.ts
+++ b/app/scripts/modules/core/src/pipeline/pipeline.dataSource.spec.ts
@@ -29,7 +29,7 @@ describe('Pipeline Data Source', function() {
   );
 
   function configureApplication() {
-    ApplicationDataSourceRegistry.registerDataSource({ key: 'serverGroups' });
+    ApplicationDataSourceRegistry.registerDataSource({ key: 'serverGroups', defaultData: [] });
     application = ApplicationModelBuilder.createApplicationForTests(
       'app',
       ...ApplicationDataSourceRegistry.getDataSources(),

--- a/app/scripts/modules/core/src/pipeline/service/execution.service.ts
+++ b/app/scripts/modules/core/src/pipeline/service/execution.service.ts
@@ -436,10 +436,10 @@ export class ExecutionService {
   public updateExecution(
     application: Application,
     updatedExecution: IExecution,
-    dataSource: ApplicationDataSource = application.executions,
+    dataSource: ApplicationDataSource<IExecution[]> = application.executions,
   ): void {
     if (dataSource.data && dataSource.data.length) {
-      dataSource.data.forEach((currentExecution: IExecution, idx: number) => {
+      dataSource.data.forEach((currentExecution, idx) => {
         if (updatedExecution.id === currentExecution.id) {
           updatedExecution.stringVal = this.stringifyExecution(updatedExecution);
           if (

--- a/app/scripts/modules/core/src/securityGroup/securityGroup.dataSource.ts
+++ b/app/scripts/modules/core/src/securityGroup/securityGroup.dataSource.ts
@@ -37,6 +37,7 @@ module(SECURITY_GROUP_DATA_SOURCE, [SECURITY_GROUP_READER]).run([
       credentialsField: 'accountName',
       regionField: 'region',
       description: 'Network traffic access management',
+      defaultData: [],
     });
   },
 ]);

--- a/app/scripts/modules/core/src/securityGroup/securityGroup.dataSource.ts
+++ b/app/scripts/modules/core/src/securityGroup/securityGroup.dataSource.ts
@@ -6,6 +6,7 @@ import { Application } from 'core/application/application.model';
 import { SECURITY_GROUP_READER, SecurityGroupReader } from 'core/securityGroup/securityGroupReader.service';
 import { EntityTagsReader } from 'core/entityTag/EntityTagsReader';
 import { ISecurityGroup } from 'core/domain';
+import { addManagedResourceMetadataToSecurityGroups } from 'core/managed';
 
 export const SECURITY_GROUP_DATA_SOURCE = 'spinnaker.core.securityGroup.dataSource';
 module(SECURITY_GROUP_DATA_SOURCE, [SECURITY_GROUP_READER]).run([
@@ -20,7 +21,8 @@ module(SECURITY_GROUP_DATA_SOURCE, [SECURITY_GROUP_READER]).run([
     };
 
     const addTags = (application: Application) => {
-      return EntityTagsReader.addTagsToSecurityGroups(application);
+      EntityTagsReader.addTagsToSecurityGroups(application);
+      addManagedResourceMetadataToSecurityGroups(application);
     };
 
     ApplicationDataSourceRegistry.registerDataSource({

--- a/app/scripts/modules/core/src/securityGroup/securityGroupReader.service.spec.ts
+++ b/app/scripts/modules/core/src/securityGroup/securityGroupReader.service.spec.ts
@@ -55,11 +55,13 @@ describe('Service: securityGroupReader', function() {
         key: 'securityGroups',
         loader: () => $q.resolve([]),
         onLoad: (_app, _data) => $q.resolve(_data),
+        defaultData: [],
       },
       {
         key: 'serverGroups',
         loader: () => $q.resolve([]),
         onLoad: (_app, _data) => $q.resolve(_data),
+        defaultData: [],
       },
       {
         key: 'loadBalancers',
@@ -73,6 +75,7 @@ describe('Service: securityGroupReader', function() {
             },
           ]),
         onLoad: (_app, _data) => $q.resolve(_data),
+        defaultData: [],
       },
     );
 
@@ -132,11 +135,13 @@ describe('Service: securityGroupReader', function() {
       'app',
       {
         key: 'securityGroups',
+        defaultData: [],
       },
       {
         key: 'serverGroups',
         loader: () => $q.resolve([]),
         onLoad: (_app, _data) => $q.resolve(_data),
+        defaultData: [],
       },
       {
         key: 'loadBalancers',
@@ -150,6 +155,7 @@ describe('Service: securityGroupReader', function() {
             },
           ]),
         onLoad: (_app, _data) => $q.resolve(_data),
+        defaultData: [],
       },
     );
 

--- a/app/scripts/modules/core/src/securityGroup/securityGroupReader.service.ts
+++ b/app/scripts/modules/core/src/securityGroup/securityGroupReader.service.ts
@@ -216,6 +216,7 @@ export class SecurityGroupReader {
     const nameParts: IComponentName = NameUtils.parseSecurityGroupName(securityGroup.name);
     securityGroup.stack = nameParts.stack;
     securityGroup.detail = nameParts.freeFormDetails;
+    securityGroup.moniker = NameUtils.getMoniker(nameParts.application, nameParts.stack, nameParts.freeFormDetails);
   }
 
   private attachSecurityGroups(

--- a/app/scripts/modules/core/src/serverGroup/configure/common/deployInitializer.component.spec.ts
+++ b/app/scripts/modules/core/src/serverGroup/configure/common/deployInitializer.component.spec.ts
@@ -27,7 +27,11 @@ describe('Component: deployInitializer', () => {
 
   describe('template initialization', () => {
     it('creates separate template options for each account and region of a cluster', () => {
-      application = ApplicationModelBuilder.createApplicationForTests('app', { key: 'serverGroups', lazy: true });
+      application = ApplicationModelBuilder.createApplicationForTests('app', {
+        key: 'serverGroups',
+        lazy: true,
+        defaultData: [],
+      });
       application.getDataSource('serverGroups').data = [
         {
           name: 'sg1',

--- a/app/scripts/modules/core/src/serverGroup/details/ServerGroupDetails.tsx
+++ b/app/scripts/modules/core/src/serverGroup/details/ServerGroupDetails.tsx
@@ -122,7 +122,9 @@ export class ServerGroupDetails extends React.Component<IServerGroupDetailsProps
         {serverGroup && serverGroup.isDisabled && (
           <div className="band band-info">Disabled {timestamp(serverGroup.disabledDate)}</div>
         )}
-        {!loading && <ManagedResourceDetailsIndicator entityTags={serverGroup.clusterEntityTags} />}
+        {!loading && serverGroup.isManaged && (
+          <ManagedResourceDetailsIndicator resourceSummary={serverGroup.managedResourceSummary} />
+        )}
         {!loading && (
           <div className="content">
             <RunningTasks serverGroup={serverGroup} application={app} />

--- a/app/scripts/modules/core/src/serverGroup/details/multipleServerGroups.controller.spec.js
+++ b/app/scripts/modules/core/src/serverGroup/details/multipleServerGroups.controller.spec.js
@@ -16,7 +16,11 @@ describe('Controller: MultipleServerGroups', function() {
       ClusterState.filterModel.sortFilter.multiselect = true;
 
       this.createController = function(serverGroups) {
-        let application = ApplicationModelBuilder.createApplicationForTests('app', { key: 'serverGroups', lazy: true });
+        let application = ApplicationModelBuilder.createApplicationForTests('app', {
+          key: 'serverGroups',
+          lazy: true,
+          defaultData: [],
+        });
         application.serverGroups.data = serverGroups;
         application.serverGroups.loaded = true;
         this.application = application;

--- a/app/scripts/modules/core/src/serverGroup/serverGroup.dataSource.ts
+++ b/app/scripts/modules/core/src/serverGroup/serverGroup.dataSource.ts
@@ -6,6 +6,7 @@ import { CLUSTER_SERVICE, ClusterService } from 'core/cluster/cluster.service';
 import { JsonUtils } from 'core/utils';
 import { Application } from 'core/application/application.model';
 import { IServerGroup } from 'core/domain';
+import { addManagedResourceMetadataToServerGroups } from 'core/managed';
 
 export const SERVER_GROUP_DATA_SOURCE = 'spinnaker.core.serverGroup.dataSource';
 
@@ -34,6 +35,7 @@ module(SERVER_GROUP_DATA_SOURCE, [CLUSTER_SERVICE]).run([
 
     const addTags = (application: Application) => {
       EntityTagsReader.addTagsToServerGroups(application);
+      addManagedResourceMetadataToServerGroups(application);
     };
 
     ApplicationDataSourceRegistry.registerDataSource({

--- a/app/scripts/modules/core/src/serverGroup/serverGroup.dataSource.ts
+++ b/app/scripts/modules/core/src/serverGroup/serverGroup.dataSource.ts
@@ -51,6 +51,7 @@ module(SERVER_GROUP_DATA_SOURCE, [CLUSTER_SERVICE]).run([
       credentialsField: 'account',
       regionField: 'region',
       description: 'Collections of server groups or jobs',
+      defaultData: [],
     });
   },
 ]);

--- a/app/scripts/modules/core/src/serverGroupManager/serverGroupManager.dataSource.ts
+++ b/app/scripts/modules/core/src/serverGroupManager/serverGroupManager.dataSource.ts
@@ -25,6 +25,7 @@ module(SERVER_GROUP_MANAGER_DATA_SOURCE, []).run([
       loader,
       onLoad,
       afterLoad: addTags,
+      defaultData: [],
     });
   },
 ]);

--- a/app/scripts/modules/core/src/task/monitor/taskMonitor.spec.ts
+++ b/app/scripts/modules/core/src/task/monitor/taskMonitor.spec.ts
@@ -27,7 +27,11 @@ describe('TaskMonitor', () => {
 
       const operation = () => $q.when(task);
       const monitor = new TaskMonitor({
-        application: ApplicationModelBuilder.createApplicationForTests('app', { key: 'runningTasks', lazy: true }),
+        application: ApplicationModelBuilder.createApplicationForTests('app', {
+          key: 'runningTasks',
+          lazy: true,
+          defaultData: [],
+        }),
         title: 'some task',
         modalInstance: { result: $q.defer().promise } as IModalServiceInstance,
         onTaskComplete: () => (completeCalled = true),
@@ -60,7 +64,11 @@ describe('TaskMonitor', () => {
       const task = { failureMessage: 'it failed' };
       const operation = () => $q.reject(task);
       const monitor = new TaskMonitor({
-        application: ApplicationModelBuilder.createApplicationForTests('app', { key: 'runningTasks', lazy: true }),
+        application: ApplicationModelBuilder.createApplicationForTests('app', {
+          key: 'runningTasks',
+          lazy: true,
+          defaultData: [],
+        }),
         title: 'a task',
         modalInstance: { result: $q.defer().promise } as IModalServiceInstance,
         onTaskComplete: () => (completeCalled = true),
@@ -84,7 +92,11 @@ describe('TaskMonitor', () => {
 
       const operation = () => $q.when(task);
       const monitor = new TaskMonitor({
-        application: ApplicationModelBuilder.createApplicationForTests('app', { key: 'runningTasks', lazy: true }),
+        application: ApplicationModelBuilder.createApplicationForTests('app', {
+          key: 'runningTasks',
+          lazy: true,
+          defaultData: [],
+        }),
         title: 'a task',
         modalInstance: { result: $q.defer().promise } as IModalServiceInstance,
         onTaskComplete: () => (completeCalled = true),

--- a/app/scripts/modules/core/src/task/task.dataSource.js
+++ b/app/scripts/modules/core/src/task/task.dataSource.js
@@ -40,6 +40,7 @@ module.exports = angular.module('spinnaker.core.task.dataSource', [CLUSTER_SERVI
       lazy: true,
       primary: true,
       icon: 'fa fa-sm fa-fw fa-check-square',
+      defaultData: [],
     });
 
     ApplicationDataSourceRegistry.registerDataSource({
@@ -47,6 +48,7 @@ module.exports = angular.module('spinnaker.core.task.dataSource', [CLUSTER_SERVI
       visible: false,
       loader: loadRunningTasks,
       onLoad: addRunningTasks,
+      defaultData: [],
     });
   },
 ]);

--- a/app/scripts/modules/core/src/task/task.dataSource.spec.ts
+++ b/app/scripts/modules/core/src/task/task.dataSource.spec.ts
@@ -20,7 +20,7 @@ describe('Task Data Source', function() {
   );
 
   function configureApplication() {
-    ApplicationDataSourceRegistry.registerDataSource({ key: 'serverGroups' });
+    ApplicationDataSourceRegistry.registerDataSource({ key: 'serverGroups', defaultData: [] });
     application = ApplicationModelBuilder.createApplicationForTests(
       'app',
       ...ApplicationDataSourceRegistry.getDataSources(),

--- a/app/scripts/modules/core/src/task/tasks.controller.spec.js
+++ b/app/scripts/modules/core/src/task/tasks.controller.spec.js
@@ -13,7 +13,11 @@ describe('Controller: tasks', function() {
       $q = _$q_;
 
       this.initializeController = tasks => {
-        let application = ApplicationModelBuilder.createApplicationForTests('app', { key: 'tasks', lazy: true });
+        let application = ApplicationModelBuilder.createApplicationForTests('app', {
+          key: 'tasks',
+          lazy: true,
+          defaultData: [],
+        });
         application.tasks.activate = angular.noop;
         application.tasks.data = tasks || [];
         application.tasks.loaded = true;

--- a/app/scripts/modules/ecs/src/securityGroup/details/securityGroupDetail.html
+++ b/app/scripts/modules/ecs/src/securityGroup/details/securityGroupDetail.html
@@ -30,11 +30,6 @@
       </h3>
     </div>
   </div>
-  <managed-resource-details-indicator
-    ng-if="!state.loading && securityGroup.entityTags"
-    entity-tags="[securityGroup.entityTags]"
-  >
-  </managed-resource-details-indicator>
   <div class="content" ng-if="!state.loading">
     <collapsible-section heading="{{ctrl.firewallLabel}} Details" expanded="true">
       <dl class="dl-horizontal dl-medium">

--- a/app/scripts/modules/google/src/loadBalancer/configure/network/createLoadBalancer.controller.spec.js
+++ b/app/scripts/modules/google/src/loadBalancer/configure/network/createLoadBalancer.controller.spec.js
@@ -14,7 +14,11 @@ describe('Controller: gceCreateLoadBalancerCtrl', function() {
   beforeEach(
     window.inject(function($controller, $rootScope) {
       this.$scope = $rootScope.$new();
-      const app = ApplicationModelBuilder.createApplicationForTests('app', { key: 'loadBalancers', lazy: true });
+      const app = ApplicationModelBuilder.createApplicationForTests('app', {
+        key: 'loadBalancers',
+        lazy: true,
+        defaultData: [],
+      });
       this.ctrl = $controller('gceCreateLoadBalancerCtrl', {
         $scope: this.$scope,
         $uibModalInstance: { dismiss: angular.noop, result: { then: angular.noop } },

--- a/app/scripts/modules/google/src/loadBalancer/details/loadBalancerDetail.controller.spec.js
+++ b/app/scripts/modules/google/src/loadBalancer/details/loadBalancerDetail.controller.spec.js
@@ -20,7 +20,11 @@ describe('Controller: LoadBalancerDetailsCtrl', function() {
     window.inject(function($controller, $rootScope, _$state_) {
       $scope = $rootScope.$new();
       $state = _$state_;
-      const app = ApplicationModelBuilder.createApplicationForTests('app', { key: 'loadBalancers', lazy: true });
+      const app = ApplicationModelBuilder.createApplicationForTests('app', {
+        key: 'loadBalancers',
+        lazy: true,
+        defaultData: [],
+      });
       app.loadBalancers.data.push(loadBalancer);
       controller = $controller('gceLoadBalancerDetailsCtrl', {
         $scope: $scope,

--- a/app/scripts/modules/kubernetes/src/v2/instance/details/details.controller.ts
+++ b/app/scripts/modules/kubernetes/src/v2/instance/details/details.controller.ts
@@ -8,6 +8,7 @@ import {
   InstanceReader,
   RecentHistoryService,
   IManifest,
+  ILoadBalancer,
 } from '@spinnaker/core';
 
 import { IKubernetesInstance } from './IKubernetesInstance';
@@ -115,7 +116,7 @@ class KubernetesInstanceDetailsController implements IController {
     const dataSources: InstanceManager[] = flattenDeep([
       this.app.getDataSource('serverGroups').data,
       this.app.getDataSource('loadBalancers').data,
-      this.app.getDataSource('loadBalancers').data.map(loadBalancer => loadBalancer.serverGroups),
+      this.app.getDataSource('loadBalancers').data.map((loadBalancer: ILoadBalancer) => loadBalancer.serverGroups),
     ]);
 
     const instanceManager = dataSources.find(instanceLocatorPredicate);

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/ManifestCopier.spec.ts
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/ManifestCopier.spec.ts
@@ -46,6 +46,7 @@ describe('<ManifestCopier />', () => {
               },
             ]),
           onLoad: (_app: Application, data: any) => $q.resolve(data),
+          defaultData: [],
         },
         {
           key: 'serverGroupManagers',
@@ -59,16 +60,19 @@ describe('<ManifestCopier />', () => {
               },
             ]),
           onLoad: (_app: Application, data: any) => $q.resolve(data),
+          defaultData: [],
         },
         {
           key: 'securityGroups',
           loader: () => $q.resolve([]),
           onLoad: (_app: Application, data: any) => $q.resolve(data),
+          defaultData: [],
         },
         {
           key: 'loadBalancers',
           loader: () => $q.resolve([]),
           onLoad: (_app: Application, data: any) => $q.resolve(data),
+          defaultData: [],
         },
       );
       application.refresh();

--- a/app/scripts/modules/oracle/src/loadBalancer/configure/createLoadBalancer.controller.spec.ts
+++ b/app/scripts/modules/oracle/src/loadBalancer/configure/createLoadBalancer.controller.spec.ts
@@ -28,6 +28,7 @@ describe('Controller: oracleCreateLoadBalancerCtrl', function() {
       const application = ApplicationModelBuilder.createApplicationForTests('app', {
         key: 'loadBalancers',
         lazy: true,
+        defaultData: [],
       });
 
       const isNew = true;

--- a/app/scripts/modules/oracle/src/loadBalancer/configure/createLoadBalancer.controller.ts
+++ b/app/scripts/modules/oracle/src/loadBalancer/configure/createLoadBalancer.controller.ts
@@ -16,6 +16,7 @@ import {
   IRegion,
   ISubnet,
   SubnetReader,
+  ILoadBalancer,
 } from '@spinnaker/core';
 
 import {
@@ -174,7 +175,8 @@ export class OracleLoadBalancerController implements IController {
       .getDataSource('loadBalancers')
       .refresh(true)
       .then(() => {
-        this.application.getDataSource('loadBalancers').data.forEach(loadBalancer => {
+        const loadBalancers: ILoadBalancer[] = this.application.loadBalancers.data;
+        loadBalancers.forEach(loadBalancer => {
           if (loadBalancer.account === account) {
             accountLoadBalancerNamesByRegion[loadBalancer.region] =
               accountLoadBalancerNamesByRegion[loadBalancer.region] || [];

--- a/app/scripts/modules/oracle/src/loadBalancer/details/loadBalancerDetail.controller.spec.ts
+++ b/app/scripts/modules/oracle/src/loadBalancer/details/loadBalancerDetail.controller.spec.ts
@@ -51,7 +51,11 @@ describe('Controller: oracleLoadBalancerDetailCtrl', function() {
       ) => {
         $scope = $rootScope.$new();
         $state = _$state_;
-        const app = ApplicationModelBuilder.createApplicationForTests('app', { key: 'loadBalancers', lazy: true });
+        const app = ApplicationModelBuilder.createApplicationForTests('app', {
+          key: 'loadBalancers',
+          lazy: true,
+          defaultData: [],
+        });
         app.loadBalancers.data.push(loadBalancer);
         securityGroupReader = _securityGroupReader_;
         confirmationModalService = _confirmationModalService_;


### PR DESCRIPTION
While working on Managed Delivery, we wanted to stop using entity tags for indicating Keel-managed things in the UI and add a new data source that could hold a 'summary' of Keel's view of an app — managed resources, some additional metadata that will be tacked on later like the status of various policies/vetos, and surely things we don't know we need yet. I quickly discovered that the existing data source implementation is highly coupled to the idea that _everything_ a data source holds is typed as `any[]`, and we have assumptions baked into the code that further narrow the typing down to "an array of objects that usually have certain properties available".

Thinking about it, I came to a couple conclusions:
- **It doesn't make sense anymore to require that data sources hold arrays of objects**, because the real value in data sources is providing a unified orchestrator for polling and data aggregation/joins/transformation.
- **We should do _something_ to unlock the ability to gradually add more static typing to data sources over time**, without boiling the ocean. As of right now the types for data sources are hard-coded into the class (`any[]`), and it's basically impossible to assert anything about types beyond that as a result.

So here we are, with this big PR. What I've chosen to try out/propose is conceptually not too complicated, but in practice touches a lot of code across providers and should be reviewed with a skeptical eye. I'm proposing we:
- **Widen out the _possible_ types a data source could wrap from `any[]` to `any`.** This means that if you get handed a data source you know nothing about, you'll need to confirm its type via runtime checks before doing anything to it like calling `.length` or built in array methods.
- **Add a single, required type parameter to the data source and its config object**, which represents the type of data it actually wraps. This parameter is used to express the relationship between what you'll get inside the `data` field, what you should return inside the `onLoad` callback, etc., so if you say that a data source wraps a particular type of data you'll get a small amount of oversight from TS.
- **Require that code which registers a new data source provides an explicit default value of the same type as the declared data type**, rather than implicitly defaulting it to `[]`. This one means that there are tons of different places defaults needed adding, but on the flip side it was easier to refactor because today the correct default is universally `[]`. While potentially controversial, I feel this is a good choice because when a data source can wrap any type of data, it makes some sense for the owner of the data source to decide what a reasonable default looks like and declare that for other consumers to see and understand.

If this goes well, I'd like to attempt to make it possible to get type information automatically when you dereference a data source off of an application model (e.g. `application.loadBalancers.data`). I ran into some trouble doing that this time, but setting up a real type system for data sources means we can leverage it later to accomplish more fun stuff.

I also decided to go ahead and add the new `managedResources` data source in the same PR. While this makes the size slightly larger, I felt it was very important to _actually use_ a data source with a new and different type as I was refactoring to make sure things really worked the way I wanted them to. The first commit contains all the data source refactoring and a very small amount of new data source code for Managed Delivery, which I think serves as a nice usage example of this new type scheme.

**Please give feedback if you have it**, this is potentially disruptive and the size/scope means things will probably break in unexpected places. I want to make sure folks like the direction before pulling the trigger.