### PR TITLE
fix(kubernetes): disable project cluster filtration by stack/detail

### DIFF
--- a/app/scripts/modules/core/src/help/help.contents.ts
+++ b/app/scripts/modules/core/src/help/help.contents.ts
@@ -385,9 +385,9 @@ const helpContents: { [key: string]: string } = {
       <p>Filters the list of load balancers and server groups (if enabled)
       to only show load balancers with instances failing the health check for the load balancer.</p>`,
   'project.cluster.stack':
-    '<p>(Optional field)</p><p>Filters displayed clusters by stack.</p><p>Enter <samp>*</samp> to include all stacks; leave blank to omit any clusters with a stack.</p>',
+    '<p>(Optional field)</p><p>Filters displayed clusters by stack.</p><p>Enter <samp>*</samp> to include all stacks; leave blank to omit any clusters with a stack.</p><p>Only <samp>*</samp> is valid for Kubernetes V2 accounts.</p>',
   'project.cluster.detail':
-    '<p>(Optional field)</p><p>Filters displayed clusters by detail.</p><p>Enter <samp>*</samp> to include all details; leave blank to omit any clusters with a detail.</p>',
+    '<p>(Optional field)</p><p>Filters displayed clusters by detail.</p><p>Enter <samp>*</samp> to include all details; leave blank to omit any clusters with a detail.</p><p>Only <samp>*</samp> is valid for Kubernetes V2 accounts.</p>',
   'instanceType.storageOverridden':
     '<p>These storage settings have been cloned from the base server group and differ from the default settings for this instance type.</p>',
   'instanceType.unavailable': '<p>This instance type is not available for the selected configuration.</p>',

--- a/app/scripts/modules/core/src/projects/configure/Clusters.tsx
+++ b/app/scripts/modules/core/src/projects/configure/Clusters.tsx
@@ -50,6 +50,11 @@ export class Clusters extends React.Component<IClustersProps> implements IWizard
     formik.setFieldValue(path, isChecked ? [] : null);
   }
 
+  private areStackAndDetailDisabled(cluster: IProjectCluster): boolean {
+    const account = this.props.accounts.find(({ name }) => name === cluster.account);
+    return account.type === 'kubernetes' && account.providerVersion === 'v2';
+  }
+
   public render() {
     const { HelpField } = NgReact;
     const { accounts } = this.props;
@@ -87,6 +92,7 @@ export class Clusters extends React.Component<IClustersProps> implements IWizard
                   {clusters.map((cluster, idx) => {
                     const clusterPath = `config.clusters[${idx}]`;
                     const applicationsPath = `${clusterPath}.applications`;
+                    const areStackAndDetailDisabled = this.areStackAndDetailDisabled(cluster);
 
                     return (
                       <tr key={idx}>
@@ -118,14 +124,26 @@ export class Clusters extends React.Component<IClustersProps> implements IWizard
                         <td>
                           <FormikFormField
                             name={`${clusterPath}.stack`}
-                            input={props => <TextInput {...props} inputClassName="sp-padding-xs-xaxis" />}
+                            input={props => (
+                              <TextInput
+                                {...props}
+                                disabled={areStackAndDetailDisabled}
+                                inputClassName="sp-padding-xs-xaxis"
+                              />
+                            )}
                           />
                         </td>
 
                         <td>
                           <FormikFormField
                             name={`${clusterPath}.detail`}
-                            input={props => <TextInput {...props} inputClassName="sp-padding-xs-xaxis" />}
+                            input={props => (
+                              <TextInput
+                                {...props}
+                                disabled={areStackAndDetailDisabled}
+                                inputClassName="sp-padding-xs-xaxis"
+                              />
+                            )}
                           />
                         </td>
 


### PR DESCRIPTION
Closes https://github.com/spinnaker/spinnaker/issues/4880, https://github.com/spinnaker/spinnaker/issues/3490

When configuring a Spinnaker project with Kubernetes V2 accounts, only filtering by `*` for stack and detail will return any clusters. This is because unlike with the VM-based providers, an application cluster itself is not associated with a single stack/detail, and each of its workloads can be associated with different stacks/details depending on the moniker annotations added to each manifest. This violates some assumptions in the Clouddriver logic shared by all providers and would be non-trivial to fix. We brought this issues to the SIG and there was not a ton of interest in further investment in the Projects view at this time, so this fix is a bandaid so at least the limitations of configuring projects with Kubernetes V2 accounts is clear at configuration time.

![kqGgZddefqB](https://user-images.githubusercontent.com/15936279/67525623-1a104a00-f681-11e9-8621-3ff94762bda5.png)
