### PR TITLE
feat(rosco): Allow roscoMode per stage/execution

### DIFF
--- a/app/scripts/modules/amazon/src/pipeline/stages/bake/awsBakeStage.js
+++ b/app/scripts/modules/amazon/src/pipeline/stages/bake/awsBakeStage.js
@@ -55,7 +55,9 @@ module.exports = angular
 
       $scope.viewState = {
         loading: true,
-        roscoMode: SETTINGS.feature.roscoMode,
+        roscoMode:
+          SETTINGS.feature.roscoMode ||
+          (typeof SETTINGS.feature.roscoSelector === 'function' && SETTINGS.feature.roscoSelector($scope.stage)),
         minRootVolumeSize: AWSProviderSettings.minRootVolumeSize,
         showVmTypeSelector: true,
       };

--- a/app/scripts/modules/amazon/src/pipeline/stages/bake/awsBakeStage.js
+++ b/app/scripts/modules/amazon/src/pipeline/stages/bake/awsBakeStage.js
@@ -85,6 +85,15 @@ module.exports = angular
 
           if (!$scope.stage.baseOs && $scope.baseOsOptions && $scope.baseOsOptions.length) {
             $scope.stage.baseOs = $scope.baseOsOptions[0].id;
+          } else if (
+            $scope.stage.baseOs &&
+            !($scope.baseOsOptions || []).find(baseOs => baseOs.id === $scope.stage.baseOs)
+          ) {
+            $scope.baseOsOptions.push({
+              id: $scope.stage.baseOs,
+              detailedDescription: 'Custom',
+              vmTypes: ['hvm', 'pv'],
+            });
           }
           if (!$scope.stage.baseLabel && $scope.baseLabelOptions && $scope.baseLabelOptions.length) {
             $scope.stage.baseLabel = $scope.baseLabelOptions[0];

--- a/app/scripts/modules/amazon/src/pipeline/stages/bake/bakeExecutionDetails.controller.js
+++ b/app/scripts/modules/amazon/src/pipeline/stages/bake/bakeExecutionDetails.controller.js
@@ -18,7 +18,10 @@ module.exports = angular
       let initialized = () => {
         $scope.detailsSection = $stateParams.details;
         $scope.provider = $scope.stage.context.cloudProviderType || 'aws';
-        $scope.roscoMode = SETTINGS.feature.roscoMode;
+        $scope.roscoMode =
+          SETTINGS.feature.roscoMode ||
+          (typeof SETTINGS.feature.roscoSelector === 'function' &&
+            SETTINGS.feature.roscoSelector($scope.stage.context));
         $scope.bakeryDetailUrl = $interpolate(SETTINGS.bakeryDetailUrl);
         $scope.bakeFailedNoError =
           get($scope.stage, 'context.status.result') === 'FAILURE' && !$scope.stage.failureMessage;

--- a/app/scripts/modules/azure/src/pipeline/stages/bake/azureBakeStage.js
+++ b/app/scripts/modules/azure/src/pipeline/stages/bake/azureBakeStage.js
@@ -92,7 +92,9 @@ module.exports = angular
           if (!$scope.stage.baseLabel && $scope.baseLabelOptions && $scope.baseLabelOptions.length) {
             $scope.stage.baseLabel = $scope.baseLabelOptions[0];
           }
-          $scope.viewState.roscoMode = SETTINGS.feature.roscoMode;
+          $scope.viewState.roscoMode =
+            SETTINGS.feature.roscoModeSETTINGS.feature.roscoMode ||
+            (typeof SETTINGS.feature.roscoSelector === 'function' && SETTINGS.feature.roscoSelector($scope.stage));
           $scope.viewState.loading = false;
         });
       }

--- a/app/scripts/modules/azure/src/pipeline/stages/bake/bakeExecutionDetails.controller.js
+++ b/app/scripts/modules/azure/src/pipeline/stages/bake/bakeExecutionDetails.controller.js
@@ -17,7 +17,10 @@ module.exports = angular
       let initialized = () => {
         $scope.detailsSection = $stateParams.details;
         $scope.provider = $scope.stage.context.cloudProviderType || 'azure';
-        $scope.roscoMode = SETTINGS.feature.roscoMode;
+        $scope.roscoMode =
+          SETTINGS.feature.roscoMode ||
+          (typeof SETTINGS.feature.roscoSelector === 'function' &&
+            SETTINGS.feature.roscoSelector($scope.stage.context));
         $scope.bakeryDetailUrl = $interpolate(SETTINGS.bakeryDetailUrl);
       };
 

--- a/app/scripts/modules/google/src/pipeline/stages/bake/bakeExecutionDetails.controller.js
+++ b/app/scripts/modules/google/src/pipeline/stages/bake/bakeExecutionDetails.controller.js
@@ -17,7 +17,10 @@ module.exports = angular
       const initialized = () => {
         $scope.detailsSection = $stateParams.details;
         $scope.provider = $scope.stage.context.cloudProviderType || 'gce';
-        $scope.roscoMode = SETTINGS.feature.roscoMode;
+        $scope.roscoMode =
+          SETTINGS.feature.roscoMode ||
+          (typeof SETTINGS.feature.roscoSelector === 'function' &&
+            SETTINGS.feature.roscoSelector($scope.stage.context));
         $scope.bakeryDetailUrl = $interpolate(SETTINGS.bakeryDetailUrl);
       };
 

--- a/app/scripts/modules/google/src/pipeline/stages/bake/gceBakeStage.js
+++ b/app/scripts/modules/google/src/pipeline/stages/bake/gceBakeStage.js
@@ -84,7 +84,9 @@ module.exports = angular
           if (!$scope.stage.baseLabel && $scope.baseLabelOptions && $scope.baseLabelOptions.length) {
             $scope.stage.baseLabel = $scope.baseLabelOptions[0];
           }
-          $scope.viewState.roscoMode = SETTINGS.feature.roscoMode;
+          $scope.viewState.roscoMode =
+            SETTINGS.feature.roscoModeSETTINGS.feature.roscoMode ||
+            (typeof SETTINGS.feature.roscoSelector === 'function' && SETTINGS.feature.roscoSelector($scope.stage));
           $scope.showAdvancedOptions = showAdvanced();
           $scope.viewState.loading = false;
         });


### PR DESCRIPTION
This allows deck to be configured to compute `roscoMode` on a per stage/execution basis via an optional `roscoSelector` in settings:

```
roscoMode: false,
roscoSelector: (stage) => stage && stage.roscoMode,
snapshots: false,
```
