### PR TITLE
fix(core/pipeline): make revision dropdown usable, layout tweaks

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/actions/history/ShowPipelineHistoryModal.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/actions/history/ShowPipelineHistoryModal.tsx
@@ -119,7 +119,7 @@ export function ShowPipelineHistoryModal(props: IShowHistoryModalProps) {
           {!loading && history.length > 1 && (
             <>
               <div className="history-header row horizontal">
-                <div className="revision-section col-md-4">
+                <div className="col-md-4">
                   <FormField
                     label="Revision"
                     layout={({ label, input }) => (

--- a/app/scripts/modules/core/src/pipeline/config/actions/history/ShowPipelineHistoryModal.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/actions/history/ShowPipelineHistoryModal.tsx
@@ -122,6 +122,12 @@ export function ShowPipelineHistoryModal(props: IShowHistoryModalProps) {
                 <div className="revision-section col-md-4">
                   <FormField
                     label="Revision"
+                    layout={({ label, input }) => (
+                      <div className="flex-container-h baseline margin-between-lg">
+                        <div className="bold">{label}</div>
+                        <div className="flex-grow">{input}</div>
+                      </div>
+                    )}
                     input={inputProps => (
                       <ReactSelectInput
                         clearable={false}

--- a/app/scripts/modules/core/src/pipeline/config/actions/history/ShowPipelineHistoryModal.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/actions/history/ShowPipelineHistoryModal.tsx
@@ -118,8 +118,8 @@ export function ShowPipelineHistoryModal(props: IShowHistoryModalProps) {
           )}
           {!loading && history.length > 1 && (
             <>
-              <div className="history-header row">
-                <div className="col-md-4">
+              <div className="history-header row horizontal">
+                <div className="revision-section col-md-4">
                   <FormField
                     label="Revision"
                     input={inputProps => (
@@ -133,7 +133,7 @@ export function ShowPipelineHistoryModal(props: IShowHistoryModalProps) {
                     value={version}
                   />
                 </div>
-                <div className="col-md-4">
+                <div className="diff-section col-md-4 horizontal middle">
                   <DiffSummary summary={diff.summary} />
                   {version > 0 && (
                     <button className="btn btn-sm btn-primary" onClick={restoreVersion}>

--- a/app/scripts/modules/core/src/pipeline/config/actions/history/showHistory.less
+++ b/app/scripts/modules/core/src/pipeline/config/actions/history/showHistory.less
@@ -3,6 +3,7 @@
 
 .history-header {
   padding-bottom: 10px;
+  align-items: stretch;
 }
 
 .show-history {
@@ -10,26 +11,32 @@
   overflow-y: auto;
   clear: both;
   max-height: calc(~'100vh - 220px');
-  .form-control {
-    border: 0;
-    height: 100%;
-    padding-left: 15px;
-  }
+
   .form-group {
     margin: 0 -15px;
   }
 }
 
+.revision-section .StandardFieldLayout_Label {
+  min-width: 0px;
+}
+
+.diff-section {
+  padding-left: 0;
+}
+
 .diff-summary {
   vertical-align: middle;
   display: inline-block;
-  margin: 0 20px;
+  margin-right: 20px;
   font-size: 120%;
   font-weight: 600;
   letter-spacing: -1px;
+
   .footer-additions {
     color: var(--color-success);
   }
+
   .footer-removals {
     color: var(--color-danger);
     display: inline-block;
@@ -39,23 +46,28 @@
 
 .diff-view {
   display: block;
+
   .diff {
     color: var(--color-black);
     font-size: 80%;
     overflow-x: visible;
     margin: 0;
     padding-bottom: 0;
+
     .match,
     .add,
     .remove {
       font-family: @font-family-monospace;
+
       &::before {
         position: relative;
         left: 0;
       }
     }
+
     .match {
       color: var(--color-dovegray);
+
       &::before {
         content: ' ';
       }
@@ -63,6 +75,7 @@
 
     .add {
       background-color: var(--color-github-history-add); // copied from GitHub
+
       &::before {
         content: '+';
       }
@@ -70,17 +83,21 @@
 
     .remove {
       background-color: var(--color-github-history-remove); // also copied from GitHub
+
       &::before {
         content: '-';
       }
     }
+
     .form-group {
       margin-bottom: 0;
     }
+
     &::-webkit-scrollbar {
       height: 8px;
     }
   }
+
   .summary-nav {
     cursor: pointer;
     z-index: 2;
@@ -89,13 +106,16 @@
     top: 0;
     right: -7px;
     height: calc(~'100% - 8px');
+
     .delta {
       width: 100%;
       position: absolute;
       min-height: 3px;
+
       &.add {
         background: var(--color-success);
       }
+
       &.remove {
         background: var(--color-danger);
       }

--- a/app/scripts/modules/core/src/pipeline/config/actions/history/showHistory.less
+++ b/app/scripts/modules/core/src/pipeline/config/actions/history/showHistory.less
@@ -17,10 +17,6 @@
   }
 }
 
-.revision-section .StandardFieldLayout_Label {
-  min-width: 0px;
-}
-
 .diff-section {
   padding-left: 0;
 }


### PR DESCRIPTION
When the pipeline revision history dropdown got moved to react, we started using `StandardFieldLayout` which has a pesky min width on its label. That caused some "fun" usability challenges with the width of the dropdown itself, which this fixes. I've also taken the liberty of improving some other layout nits, as the diff summary was both vertical misaligned and had a bunch of excess padding/margin that made it look a little funky.

**Before:**
<img width="918" alt="Screen Shot 2019-10-25 at 6 34 02 PM" src="https://user-images.githubusercontent.com/1850998/67612321-9163dd80-f756-11e9-8cc1-3d71c9ece7db.png">
<img width="252" alt="Screen Shot 2019-10-25 at 6 34 11 PM" src="https://user-images.githubusercontent.com/1850998/67612324-988aeb80-f756-11e9-805b-3900afc605e9.png">

**After:**
<img width="945" alt="Screen Shot 2019-10-25 at 6 33 05 PM" src="https://user-images.githubusercontent.com/1850998/67612335-a8a2cb00-f756-11e9-8bca-c4d7469c31d6.png">
<img width="293" alt="Screen Shot 2019-10-25 at 6 34 19 PM" src="https://user-images.githubusercontent.com/1850998/67612339-b2c4c980-f756-11e9-8573-43bc760ba941.png">
