### PR TITLE
feat(rosco): Allow optional roscoDetailUrl for roscoMode bakes

### DIFF
--- a/app/scripts/modules/amazon/src/pipeline/stages/bake/bakeExecutionDetails.controller.js
+++ b/app/scripts/modules/amazon/src/pipeline/stages/bake/bakeExecutionDetails.controller.js
@@ -22,7 +22,9 @@ module.exports = angular
           SETTINGS.feature.roscoMode ||
           (typeof SETTINGS.feature.roscoSelector === 'function' &&
             SETTINGS.feature.roscoSelector($scope.stage.context));
-        $scope.bakeryDetailUrl = $interpolate(SETTINGS.bakeryDetailUrl);
+        $scope.bakeryDetailUrl = $interpolate(
+          $scope.roscoMode && SETTINGS.roscoDetailUrl ? SETTINGS.roscoDetailUrl : SETTINGS.bakeryDetailUrl,
+        );
         $scope.bakeFailedNoError =
           get($scope.stage, 'context.status.result') === 'FAILURE' && !$scope.stage.failureMessage;
       };

--- a/app/scripts/modules/azure/src/pipeline/stages/bake/bakeExecutionDetails.controller.js
+++ b/app/scripts/modules/azure/src/pipeline/stages/bake/bakeExecutionDetails.controller.js
@@ -21,7 +21,9 @@ module.exports = angular
           SETTINGS.feature.roscoMode ||
           (typeof SETTINGS.feature.roscoSelector === 'function' &&
             SETTINGS.feature.roscoSelector($scope.stage.context));
-        $scope.bakeryDetailUrl = $interpolate(SETTINGS.bakeryDetailUrl);
+        $scope.bakeryDetailUrl = $interpolate(
+          $scope.roscoMode && SETTINGS.roscoDetailUrl ? SETTINGS.roscoDetailUrl : SETTINGS.bakeryDetailUrl,
+        );
       };
 
       let initialize = () => executionDetailsSectionService.synchronizeSection($scope.configSections, initialized);

--- a/app/scripts/modules/docker/src/pipeline/stages/bake/bakeExecutionDetails.controller.js
+++ b/app/scripts/modules/docker/src/pipeline/stages/bake/bakeExecutionDetails.controller.js
@@ -17,7 +17,9 @@ module.exports = angular
       let initialized = () => {
         $scope.detailsSection = $stateParams.details;
         $scope.provider = $scope.stage.context.cloudProviderType || 'docker';
-        $scope.bakeryDetailUrl = $interpolate(SETTINGS.bakeryDetailUrl);
+        $scope.bakeryDetailUrl = $interpolate(
+          $scope.roscoMode && SETTINGS.roscoDetailUrl ? SETTINGS.roscoDetailUrl : SETTINGS.bakeryDetailUrl,
+        );
       };
 
       let initialize = () => executionDetailsSectionService.synchronizeSection($scope.configSections, initialized);

--- a/app/scripts/modules/google/src/pipeline/stages/bake/bakeExecutionDetails.controller.js
+++ b/app/scripts/modules/google/src/pipeline/stages/bake/bakeExecutionDetails.controller.js
@@ -21,7 +21,9 @@ module.exports = angular
           SETTINGS.feature.roscoMode ||
           (typeof SETTINGS.feature.roscoSelector === 'function' &&
             SETTINGS.feature.roscoSelector($scope.stage.context));
-        $scope.bakeryDetailUrl = $interpolate(SETTINGS.bakeryDetailUrl);
+        $scope.bakeryDetailUrl = $interpolate(
+          $scope.roscoMode && SETTINGS.roscoDetailUrl ? SETTINGS.roscoDetailUrl : SETTINGS.bakeryDetailUrl,
+        );
       };
 
       const initialize = () => executionDetailsSectionService.synchronizeSection($scope.configSections, initialized);

--- a/app/scripts/modules/oracle/src/pipeline/stages/bake/bakeExecutionDetails.controller.js
+++ b/app/scripts/modules/oracle/src/pipeline/stages/bake/bakeExecutionDetails.controller.js
@@ -22,7 +22,9 @@ module.exports = angular
         $scope.detailsSection = $stateParams.details;
         $scope.provider = $scope.stage.context.cloudProviderType || 'oracle';
         $scope.roscoMode = SETTINGS.feature.roscoMode;
-        $scope.bakeryDetailUrl = $interpolate(SETTINGS.bakeryDetailUrl);
+        $scope.bakeryDetailUrl = $interpolate(
+          $scope.roscoMode && SETTINGS.roscoDetailUrl ? SETTINGS.roscoDetailUrl : SETTINGS.bakeryDetailUrl,
+        );
       };
 
       let initialize = () => executionDetailsSectionService.synchronizeSection($scope.configSections, initialized);

--- a/app/scripts/modules/titus/src/pipeline/stages/bake/bakeExecutionDetails.controller.js
+++ b/app/scripts/modules/titus/src/pipeline/stages/bake/bakeExecutionDetails.controller.js
@@ -17,7 +17,9 @@ module.exports = angular
       let initialized = () => {
         $scope.detailsSection = $stateParams.details;
         $scope.provider = $scope.stage.context.cloudProviderType || 'titus';
-        $scope.bakeryDetailUrl = $interpolate(SETTINGS.bakeryDetailUrl);
+        $scope.bakeryDetailUrl = $interpolate(
+          $scope.roscoMode && SETTINGS.roscoDetailUrl ? SETTINGS.roscoDetailUrl : SETTINGS.bakeryDetailUrl,
+        );
       };
 
       let initialize = () => executionDetailsSectionService.synchronizeSection($scope.configSections, initialized);


### PR DESCRIPTION
And of course will fail back to just using bakeryDetailUrl if `roscoDetailUrl` is not defined.