### PR TITLE
fix(rosco): Re-evaluate roscoSelector on stage updates

### DIFF
--- a/app/scripts/modules/amazon/src/pipeline/stages/bake/awsBakeStage.js
+++ b/app/scripts/modules/amazon/src/pipeline/stages/bake/awsBakeStage.js
@@ -109,6 +109,14 @@ module.exports = angular
         });
       }
 
+      function stageUpdated() {
+        deleteEmptyProperties();
+        // Since the selector computes using stage as an input, it needs to be able to recompute roscoMode on updates
+        if (typeof SETTINGS.feature.roscoSelector === 'function') {
+          $scope.viewState.roscoMode = SETTINGS.feature.roscoSelector($scope.stage);
+        }
+      }
+
       function deleteEmptyProperties() {
         _.forOwn($scope.stage, function(val, key) {
           if (val === '') {
@@ -195,7 +203,7 @@ module.exports = angular
         }
       };
 
-      $scope.$watch('stage', deleteEmptyProperties, true);
+      $scope.$watch('stage', stageUpdated, true);
 
       initialize();
     },

--- a/app/scripts/modules/azure/src/pipeline/stages/bake/azureBakeStage.js
+++ b/app/scripts/modules/azure/src/pipeline/stages/bake/azureBakeStage.js
@@ -104,6 +104,14 @@ module.exports = angular
         $scope.stage.osType = selectedOption.osType;
       };
 
+      function stageUpdated() {
+        deleteEmptyProperties();
+        // Since the selector computes using stage as an input, it needs to be able to recompute roscoMode on updates
+        if (typeof SETTINGS.feature.roscoSelector === 'function') {
+          $scope.viewState.roscoMode = SETTINGS.feature.roscoSelector($scope.stage);
+        }
+      }
+
       function deleteEmptyProperties() {
         _.forOwn($scope.stage, function(val, key) {
           if (val === '') {
@@ -154,7 +162,7 @@ module.exports = angular
         return $scope.viewState.roscoMode || $scope.stage.varFileName;
       };
 
-      $scope.$watch('stage', deleteEmptyProperties, true);
+      $scope.$watch('stage', stageUpdated, true);
 
       initialize();
     },

--- a/app/scripts/modules/google/src/pipeline/stages/bake/gceBakeStage.js
+++ b/app/scripts/modules/google/src/pipeline/stages/bake/gceBakeStage.js
@@ -103,6 +103,14 @@ module.exports = angular
         );
       }
 
+      function stageUpdated() {
+        deleteEmptyProperties();
+        // Since the selector computes using stage as an input, it needs to be able to recompute roscoMode on updates
+        if (typeof SETTINGS.feature.roscoSelector === 'function') {
+          $scope.viewState.roscoMode = SETTINGS.feature.roscoSelector($scope.stage);
+        }
+      }
+
       function deleteEmptyProperties() {
         _.forOwn($scope.stage, function(val, key) {
           if (val === '') {
@@ -157,7 +165,7 @@ module.exports = angular
         return $scope.viewState.roscoMode || $scope.stage.varFileName;
       };
 
-      $scope.$watch('stage', deleteEmptyProperties, true);
+      $scope.$watch('stage', stageUpdated, true);
 
       initialize();
     },


### PR DESCRIPTION
Minor fix, `roscoMode` only got evaluated once, but if `roscoSelector` is used, we should really evaluate every time the stage is updated so that changes that cause the result to flip between `true` and `false` appropriately flip `roscoMode` and the bake stage config is updated appropriately (rosco fields toggled).