### PR TITLE
Bump package docker to 0.0.49 and amazon to 0.0.221 and titus to 0.0.117

### DIFF
--- a/app/scripts/modules/amazon/package.json
+++ b/app/scripts/modules/amazon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/amazon",
-  "version": "0.0.220",
+  "version": "0.0.221",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/docker/package.json
+++ b/app/scripts/modules/docker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/docker",
-  "version": "0.0.48",
+  "version": "0.0.49",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/titus/package.json
+++ b/app/scripts/modules/titus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/titus",
-  "version": "0.0.116",
+  "version": "0.0.117",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
### chore(docker): Bump version to 0.0.49

dae00c87adc5e69ac232a2145d35e73072cf5766 feat(rosco): Allow optional roscoDetailUrl for roscoMode bakes (#7575)

### chore(amazon): Bump version to 0.0.221

d620e057e1c0d85984caa9a8ff0639d17ea9309c fix(rosco): Re-evaluate roscoSelector on stage updates (#7577)
dae00c87adc5e69ac232a2145d35e73072cf5766 feat(rosco): Allow optional roscoDetailUrl for roscoMode bakes (#7575)

### chore(titus): Bump version to 0.0.117

dae00c87adc5e69ac232a2145d35e73072cf5766 feat(rosco): Allow optional roscoDetailUrl for roscoMode bakes (#7575)


