### PR TITLE
Bump package core to 0.0.428 and amazon to 0.0.222 and titus to 0.0.118

### DIFF
--- a/app/scripts/modules/amazon/package.json
+++ b/app/scripts/modules/amazon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/amazon",
-  "version": "0.0.221",
+  "version": "0.0.222",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/core",
-  "version": "0.0.427",
+  "version": "0.0.428",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/titus/package.json
+++ b/app/scripts/modules/titus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/titus",
-  "version": "0.0.117",
+  "version": "0.0.118",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
### chore(core): Bump version to 0.0.428

34a3b00beea0287a68a05014862351c0f5904afa feat(managed): Update resource indicators to use new data source
7b33d2b490987a070febbd3478e902dd37c6b7b7 feat(managed): Join managed data to infra data, add moniker to Security Groups
d4c89ceffd2f14eca7660a930d1d675a737da150 feat(managed): Use new data source for 'Managed Resources' config section
efcceb34a541ad71d887f0957fe43741a4ed1de4 feat(managed): add 'managedResources' data source
4ed015a07c028eb58807601a0b0fb9783b02b0d9 feat(dataSources): widen + parameterize types, add default values
8c29cbae0278695316ba493a9f0cb7ae52b51d10 Reactify titus launch configuration (#7581)
5d89a04465f911d49bf171ef47b9d88aa2b8c4a9 feat(google): add gce scale-down controls (#7570)
f88254455238b566936fcca02e0a9e7f0a647958 feat(git/repo): add git/repo artifact support in kustomize bake manifest (#7572)

### chore(amazon): Bump version to 0.0.222

34a3b00beea0287a68a05014862351c0f5904afa feat(managed): Update resource indicators to use new data source
4ed015a07c028eb58807601a0b0fb9783b02b0d9 feat(dataSources): widen + parameterize types, add default values
57c7d6d0f9df0a4d10d9fbbeb350c130de283830 fix(core): Ensure default port used for target group healthcheck link (#7576)

### chore(titus): Bump version to 0.0.118

8c29cbae0278695316ba493a9f0cb7ae52b51d10 Reactify titus launch configuration (#7581)


