### PR TITLE
fix(amazon): Update load balancer validations to match user expectations

### DIFF
--- a/app/scripts/modules/amazon/src/domain/IAmazonLoadBalancer.ts
+++ b/app/scripts/modules/amazon/src/domain/IAmazonLoadBalancer.ts
@@ -167,7 +167,7 @@ export interface IListenerDescription {
 
 export interface IALBTargetGroupDescription {
   name: string;
-  protocol: 'HTTP' | 'HTTPS';
+  protocol: 'HTTP' | 'HTTPS' | 'TCP' | 'TLS';
   port: number;
   targetType: 'instance' | 'ip' | 'lambda';
   attributes: {
@@ -187,7 +187,7 @@ export interface IALBTargetGroupDescription {
   healthCheckMatcher?: string;
   healthCheckPath: string;
   healthCheckPort: string;
-  healthCheckProtocol: 'HTTP' | 'HTTPS';
+  healthCheckProtocol: 'HTTP' | 'HTTPS' | 'TCP';
   // Defaults to 10
   healthyThreshold?: number;
   // Defaults to 5

--- a/app/scripts/modules/amazon/src/help/amazon.help.ts
+++ b/app/scripts/modules/amazon/src/help/amazon.help.ts
@@ -110,6 +110,9 @@ const helpContents: { [key: string]: string } = {
     'The time period, in seconds, during which requests from a client should be routed to the same target. After this time period expires, the load balancer-generated cookie is considered stale. The range is 1 second to 1 week (604800 seconds). The default value is 1 day (86400 seconds).',
   'aws.targetGroup.attributes.healthCheckPort.trafficPort':
     'The port the load balancer uses when performing health checks on targets. The default is <b>traffic-port</b>, which is the port on which each target receives traffic from the load balancer.',
+  'aws.targetGroup.healthCheckProtocol': 'TCP health checks only support 10s and 30s intervals',
+  'aws.targetGroup.healthCheckTimeout':
+    'Target groups with TCP or TLS protocol must have a 6s timeout for HTTP health checks or a 10s timeout for HTTPS/TLS health checks.',
   'aws.serverGroup.capacityConstraint': `
       <p>Ensures that the capacity of this server group has not changed in the background (i.e. due to autoscaling activity).</p>
       <p>If the capacity has changed, this resize operation will be rejected.</p>`,

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/application/TargetGroups.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/application/TargetGroups.tsx
@@ -13,8 +13,6 @@ import {
   spelNumberCheck,
   FormValidator,
 } from '@spinnaker/core';
-
-import { IAmazonApplicationLoadBalancer, IAmazonApplicationLoadBalancerUpsertCommand } from 'amazon/domain';
 import {
   isNameLong,
   isNameInUse,
@@ -24,6 +22,8 @@ import {
   isValidHealthCheckProtocol,
   spelNumber,
 } from '../common/targetGroupValidators';
+
+import { IAmazonApplicationLoadBalancer, IAmazonApplicationLoadBalancerUpsertCommand } from 'amazon/domain';
 
 export interface ITargetGroupsProps {
   app: Application;
@@ -93,13 +93,13 @@ export class TargetGroups extends React.Component<ITargetGroupsProps, ITargetGro
           .spelAware()
           .withValidators(spelNumber, checkBetween('unhealthyThreshold', 2, 10));
         builder.field('protocol', 'Protocol').required();
-        builder.field('healthCheckPath', 'HealthCheck Path').required();
+        builder.field('healthCheckPath', 'Health Check Path').required();
         builder
-          .field('healthCheckPort', 'HealthCheck Port')
+          .field('healthCheckPort', 'Health Check Port')
           .required()
           .spelAware()
           .withValidators(value => (value === 'traffic-port' ? null : spelNumberCheck(value)));
-        builder.field('healthCheckProtocol', 'HealthCheck Protocol').required();
+        builder.field('healthCheckProtocol', 'Health Check Protocol').required();
         builder
           .field('healthCheckTimeout', 'Timeout')
           .withValidators(isValidTimeout(item), checkBetween('healthCheckTimeout', 2, 120));

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/application/TargetGroups.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/application/TargetGroups.tsx
@@ -46,10 +46,12 @@ export class TargetGroups extends React.Component<ITargetGroupsProps, ITargetGro
 
   private checkBetween(errors: any, object: any, fieldName: string, min: number, max: number) {
     const field = object[fieldName];
-    if (!Number.isNaN(field)) {
+    const sanitizedField = Number.parseInt(field, 10);
+
+    if (!Number.isNaN(sanitizedField)) {
       const error =
-        Validators.minValue(min)(field, robotToHuman(fieldName)) ||
-        Validators.maxValue(max)(field, robotToHuman(fieldName));
+        Validators.minValue(min)(sanitizedField, robotToHuman(fieldName)) ||
+        Validators.maxValue(max)(sanitizedField, robotToHuman(fieldName));
       if (error) {
         errors[fieldName] = error;
       }
@@ -94,6 +96,20 @@ export class TargetGroups extends React.Component<ITargetGroupsProps, ITargetGro
           }
         });
       }
+      ['port', 'healthCheckInterval', 'healthyThreshold', 'unhealthyThreshold'].forEach(key => {
+        const err = spelNumberCheck(targetGroup[key]);
+        if (err) {
+          tgErrors[key] = err;
+        }
+      });
+
+      if (targetGroup.healthCheckProtocol === 'TCP') {
+        const field = Number.parseInt(targetGroup.healthCheckInterval, 10);
+        if (field !== 10 && field !== 30) {
+          tgErrors.healthCheckInterval = 'TCP health checks only support 10s and 30s intervals.';
+        }
+      }
+
       this.checkBetween(tgErrors, targetGroup, 'healthCheckTimeout', 2, 60);
       this.checkBetween(tgErrors, targetGroup, 'healthCheckInterval', 5, 300);
       this.checkBetween(tgErrors, targetGroup, 'healthyThreshold', 2, 10);

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/application/TargetGroups.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/application/TargetGroups.tsx
@@ -110,7 +110,20 @@ export class TargetGroups extends React.Component<ITargetGroupsProps, ITargetGro
         }
       }
 
-      this.checkBetween(tgErrors, targetGroup, 'healthCheckTimeout', 2, 60);
+      if (targetGroup.protocol === 'TCP' || targetGroup.protocol === 'TLS') {
+        if (targetGroup.healthCheckProtocol === 'HTTP' && Number.parseInt(targetGroup.healthCheckInterval, 10) !== 6) {
+          tgErrors.healthCheckTimeout = 'HTTP health check timeouts for TCP/TLS target groups must be 6s';
+        }
+
+        if (
+          (targetGroup.healthCheckProtocol === 'HTTPS' || targetGroup.healthCheckProtocol === 'TLS') &&
+          Number.parseInt(targetGroup.healthCheckInterval, 10) !== 10
+        ) {
+          tgErrors.healthCheckTimeout = 'HTTPS/TLS health check timeouts for TCP/TLS target groups must be 10s';
+        }
+      }
+
+      this.checkBetween(tgErrors, targetGroup, 'healthCheckTimeout', 2, 120);
       this.checkBetween(tgErrors, targetGroup, 'healthCheckInterval', 5, 300);
       this.checkBetween(tgErrors, targetGroup, 'healthyThreshold', 2, 10);
       this.checkBetween(tgErrors, targetGroup, 'unhealthyThreshold', 2, 10);

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/application/TargetGroups.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/application/TargetGroups.tsx
@@ -19,7 +19,7 @@ import {
   isDuplicateName,
   isValidTimeout,
   checkBetween,
-  isValidHealthCheckProtocol,
+  isValidHealthCheckInterval,
   spelNumber,
 } from '../common/targetGroupValidators';
 
@@ -81,7 +81,7 @@ export class TargetGroups extends React.Component<ITargetGroupsProps, ITargetGro
         builder
           .field('healthCheckInterval', 'Health Check Interval')
           .required()
-          .withValidators(isValidHealthCheckProtocol(item), checkBetween('healthCheckProtocol', 5, 300), spelNumber);
+          .withValidators(isValidHealthCheckInterval(item), checkBetween('healthCheckProtocol', 5, 300), spelNumber);
         builder
           .field('healthyThreshold', 'Healthy Threshold')
           .required()
@@ -235,7 +235,6 @@ export class TargetGroups extends React.Component<ITargetGroupsProps, ITargetGro
 
     const ProtocolOptions = this.protocols.map(p => <option key={p}>{p}</option>);
     const TargetTypeOptions = this.targetTypes.map(p => <option key={p}>{p}</option>);
-
     return (
       <div className="container-fluid form-horizontal">
         <div className="form-group">

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/application/TargetGroups.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/application/TargetGroups.tsx
@@ -242,6 +242,13 @@ export class TargetGroups extends React.Component<ITargetGroupsProps, ITargetGro
           <div className="col-md-12">
             {values.targetGroups.map((targetGroup, index) => {
               const tgErrors = (errors.targetGroups && errors.targetGroups[index]) || {};
+              const has6sTimeout =
+                (targetGroup.protocol === 'TCP' || targetGroup.protocol === 'TLS') &&
+                targetGroup.healthCheckProtocol === 'HTTP';
+              const has10sTimeout =
+                (targetGroup.protocol === 'TCP' || targetGroup.protocol === 'TLS') &&
+                targetGroup.healthCheckProtocol === 'HTTPS';
+
               return (
                 <div key={index} className="wizard-pod">
                   <div>
@@ -374,6 +381,53 @@ export class TargetGroups extends React.Component<ITargetGroupsProps, ITargetGro
                             </span>
                           )}
                           <span className="wizard-pod-content">
+                            <label>Protocol </label>
+                            {targetGroup.healthCheckProtocol === 'TCP' && (
+                              <HelpField id="aws.targetGroup.healthCheckProtocol" />
+                            )}{' '}
+                            <select
+                              className="form-control input-sm inline-number"
+                              value={targetGroup.healthCheckProtocol}
+                              onChange={event =>
+                                this.targetGroupFieldChanged(index, 'healthCheckProtocol', event.target.value)
+                              }
+                            >
+                              {ProtocolOptions}
+                            </select>
+                          </span>
+                          <span className="wizard-pod-content">
+                            <label>Port </label>
+                            <HelpField id="aws.targetGroup.attributes.healthCheckPort.trafficPort" />{' '}
+                            <select
+                              className="form-control input-sm inline-number"
+                              style={{ width: '90px' }}
+                              value={targetGroup.healthCheckPort === 'traffic-port' ? 'traffic-port' : 'manual'}
+                              onChange={event =>
+                                this.targetGroupFieldChanged(
+                                  index,
+                                  'healthCheckPort',
+                                  event.target.value === 'traffic-port' ? 'traffic-port' : '',
+                                )
+                              }
+                            >
+                              <option value="traffic-port">Traffic Port</option>
+                              <option value="manual">Manual</option>
+                            </select>{' '}
+                            <SpInput
+                              className="form-control input-sm inline-number"
+                              error={tgErrors.healthCheckPort}
+                              style={{
+                                visibility: targetGroup.healthCheckPort === 'traffic-port' ? 'hidden' : 'inherit',
+                              }}
+                              name="healthCheckPort"
+                              required={true}
+                              value={targetGroup.healthCheckPort}
+                              onChange={event =>
+                                this.targetGroupFieldChanged(index, 'healthCheckPort', event.target.value)
+                              }
+                            />
+                          </span>
+                          <span className="wizard-pod-content">
                             <label>Path </label>
                             <SpInput
                               // error={tgErrors.healthCheckPath}
@@ -387,16 +441,31 @@ export class TargetGroups extends React.Component<ITargetGroupsProps, ITargetGro
                           </span>
                           <span className="wizard-pod-content">
                             <label>Timeout </label>
-                            <SpelNumberInput
-                              error={tgErrors.healthCheckTimeout}
-                              required={true}
-                              value={targetGroup.healthCheckTimeout}
-                              min={2}
-                              max={120}
-                              onChange={(value: string) =>
-                                this.targetGroupFieldChanged(index, 'healthCheckTimeout', value)
-                              }
-                            />
+                            {(has6sTimeout || has10sTimeout) && <HelpField id="aws.targetGroup.healthCheckTimeout" />}
+                            {has6sTimeout || has10sTimeout ? (
+                              <SpInput
+                                disabled={true}
+                                className="form-control input-sm inline-number"
+                                error={tgErrors.healthCheckTimeout}
+                                name="healthCheckTimeout"
+                                required={true}
+                                value={has6sTimeout ? 6 : 10}
+                                onChange={event =>
+                                  this.targetGroupFieldChanged(index, 'healthCheckTimeout', event.target.value)
+                                }
+                              />
+                            ) : (
+                              <SpelNumberInput
+                                error={tgErrors.healthCheckTimeout}
+                                required={true}
+                                value={targetGroup.healthCheckTimeout}
+                                min={2}
+                                max={120}
+                                onChange={(value: string) =>
+                                  this.targetGroupFieldChanged(index, 'healthCheckTimeout', value)
+                                }
+                              />
+                            )}
                           </span>
                           <span className="wizard-pod-content">
                             <label>Interval </label>

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/application/TargetGroups.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/application/TargetGroups.tsx
@@ -12,6 +12,7 @@ import {
   ValidationMessage,
   FormValidator,
   Validators,
+  spelNumberCheck,
 } from '@spinnaker/core';
 import { isNameLong, isNameInUse, isValidTimeout, isValidHealthCheckInterval } from '../common/targetGroupValidators';
 
@@ -69,11 +70,7 @@ export class TargetGroups extends React.Component<ITargetGroupsProps, ITargetGro
           );
         builder
           .field('healthCheckInterval', 'Health Check Interval')
-          .withValidators(
-            isValidHealthCheckInterval(item),
-            Validators.checkBetween('healthCheckProtocol', 5, 300),
-            Validators.isNum(),
-          );
+          .withValidators(isValidHealthCheckInterval(item), Validators.checkBetween('healthCheckInterval', 5, 300));
         builder
           .field('healthyThreshold', 'Healthy Threshold')
           .withValidators(Validators.checkBetween('healthyThreshold', 2, 10));
@@ -94,37 +91,37 @@ export class TargetGroups extends React.Component<ITargetGroupsProps, ITargetGro
             .field('healthyThreshold', 'Healthy Threshold')
             .required()
             .spelAware()
-            .withValidators(Validators.isNum());
+            .withValidators(value => spelNumberCheck(value));
           builder
             .field('unhealthyThreshold', 'Unhealthy Threshold')
             .required()
             .spelAware()
-            .withValidators(Validators.isNum());
+            .withValidators(value => spelNumberCheck(value));
           builder
             .field('healthCheckInterval', 'Health Check Interval')
             .required()
             .spelAware()
-            .withValidators(Validators.isNum());
+            .withValidators(value => spelNumberCheck(value));
           builder
             .field('healthCheckPort', 'Health Check Port')
             .required()
             .spelAware()
-            .withValidators(value => (value === 'traffic-port' ? null : Validators.isNum()(value)));
+            .withValidators(value => (value === 'traffic-port' ? null : spelNumberCheck(value)));
           builder
             .field('port', 'Port')
             .required()
             .spelAware()
-            .withValidators(Validators.isNum());
+            .withValidators(value => spelNumberCheck(value));
           builder
             .field('healthyThreshold', 'Healthy Threshold')
             .required()
             .spelAware()
-            .withValidators(Validators.isNum(), Validators.checkBetween('healthyThreshold', 2, 10));
+            .withValidators(value => spelNumberCheck(value), Validators.checkBetween('healthyThreshold', 2, 10));
           builder
             .field('unhealthyThreshold', 'Unhealthy Threshold')
             .required()
             .spelAware()
-            .withValidators(Validators.isNum(), Validators.checkBetween('unhealthyThreshold', 2, 10));
+            .withValidators(value => spelNumberCheck(value), Validators.checkBetween('unhealthyThreshold', 2, 10));
         }
       }),
     );

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/common/configure.less
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/common/configure.less
@@ -59,6 +59,8 @@
         }
         .wizard-pod-content {
           padding: 0 10px 5px 0;
+          display: flex;
+          align-items: center;
         }
         .group-name-prefix {
           flex-grow: 2;

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/common/targetGroupValidators.spec.ts
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/common/targetGroupValidators.spec.ts
@@ -1,0 +1,162 @@
+import * as Validators from './targetGroupValidators';
+
+const mockTargetGroup = {
+  attributes: {
+    deregistrationDelay: 600,
+    stickinessDuration: 8400,
+    stickinessEnabled: false,
+    stickinessType: 'lb_cookie',
+  },
+  healthCheckInterval: 10,
+  healthCheckPath: '/healthcheck',
+  healthCheckPort: 7001,
+  healthCheckProtocol: 'HTTP',
+  healthCheckTimeout: 5,
+  healthyThreshold: 10,
+  name: 'targetgroup',
+  port: 7001,
+  protocol: 'HTTP',
+  targetType: 'ip',
+  unhealthyThreshold: 2,
+  account: 'test',
+  cloudProvider: 'aws',
+  healthTimeout: 1000,
+  healthInterval: 10,
+  loadBalancerNames: ['loadbalancer1', 'loadbalancer2'],
+  region: 'us-east-1',
+  type: '',
+};
+
+describe('Target Group validators', () => {
+  describe('of used names', () => {
+    it('returns an error if the name exists already', () => {
+      const existingGroups = {
+        test: {
+          'us-east-1': ['targetgroup'],
+        },
+      };
+      const actual = Validators.isNameInUse(existingGroups, 'test', 'us-east-1')(mockTargetGroup.name);
+      const expected = 'There is already a target group in test:us-east-1 with that name.';
+      expect(actual).toEqual(expected);
+    });
+
+    it('returns an null if it does not exist', () => {
+      const existingGroups = {
+        test: {
+          'us-east-1': ['targetgroup2'],
+        },
+      };
+      const actual = Validators.isNameInUse(existingGroups, 'test', 'us-east-1')(mockTargetGroup.name);
+      expect(actual).toEqual(null);
+    });
+  });
+
+  describe('of name length', () => {
+    it('returns error if the name is >32 additional characters', () => {
+      const actual = Validators.isNameLong(12)(`${mockTargetGroup.name}areallylongname`);
+      const expected =
+        'Target group name is automatically prefixed with the application name and cannot exceed 32 characters in length.';
+      expect(actual).toEqual(expected);
+    });
+
+    it('returns null if the name is < 32', () => {
+      const actual = Validators.isNameLong(12)(mockTargetGroup.name);
+      expect(actual).toEqual(null);
+    });
+  });
+
+  describe('of duplicate names across the load balancer', () => {
+    it('returns an error if the name exists', () => {
+      const actual = Validators.isDuplicateName(['targetgroup'])(mockTargetGroup.name);
+      const expected = 'Duplicate target group name in this load balancer.';
+      expect(actual).toEqual(expected);
+    });
+
+    it('returns null if the name is new', () => {
+      const actual = Validators.isDuplicateName(['targetGroup2'])(mockTargetGroup.name);
+      expect(actual).toEqual(null);
+    });
+  });
+
+  describe('of health check timeout constraints', () => {
+    const tg = {
+      ...mockTargetGroup,
+      protocol: 'TCP',
+      healthCheckProtocol: 'HTTP',
+    };
+
+    it('should have a 6s timeout', () => {
+      const actual = Validators.isValidTimeout(tg)('8');
+      const expected = 'HTTP health check timeouts for TCP/TLS target groups must be 6s';
+      expect(actual).toEqual(expected);
+    });
+
+    it('should be 6s and is valid', () => {
+      const actual = Validators.isValidTimeout(tg)('6');
+      expect(actual).toEqual(null);
+    });
+
+    it('should have a 10s timeout', () => {
+      const actual = Validators.isValidTimeout({ ...tg, healthCheckProtocol: 'HTTPS' })('9');
+      const expected = 'HTTPS/TLS health check timeouts for TCP/TLS target groups must be 10s';
+      expect(actual).toEqual(expected);
+    });
+
+    it('should be 10s and is valid', () => {
+      const actual = Validators.isValidTimeout({ ...tg, healthCheckProtocol: 'HTTPS' })('10');
+      expect(actual).toEqual(null);
+    });
+
+    it('should not have a timeout constraint', () => {
+      const actual = Validators.isValidTimeout(mockTargetGroup)('10');
+      expect(actual).toEqual(null);
+    });
+  });
+
+  describe('of health check interval', () => {
+    const tg = {
+      ...mockTargetGroup,
+      healthCheckProtocol: 'TCP',
+    };
+
+    it('TCPs can have a 10s interval', () => {
+      const actual = Validators.isValidHealthCheckInterval(tg)('10');
+      expect(actual).toEqual(null);
+    });
+
+    it('TCPs can have a 30s interval', () => {
+      const actual = Validators.isValidHealthCheckInterval(tg)('30');
+      expect(actual).toEqual(null);
+    });
+
+    it('returns an error when it fails TCP rules', () => {
+      const actual = Validators.isValidHealthCheckInterval(tg)('20');
+      const expected = 'TCP health checks only support 10s and 30s intervals';
+      expect(actual).toEqual(expected);
+    });
+
+    it('is not a TCP protocol target group', () => {
+      const actual = Validators.isValidHealthCheckInterval(mockTargetGroup)('20');
+      expect(actual).toEqual(null);
+    });
+  });
+
+  describe('of max/min limits', () => {
+    it('returns an error when less than min', () => {
+      const actual = Validators.checkBetween('field', 10, 100)('8');
+      const expected = ' Field cannot be less than 10';
+      expect(actual).toEqual(expected);
+    });
+
+    it('returns an error when greater than max', () => {
+      const actual = Validators.checkBetween('field', 10, 100)('125');
+      const expected = ' Field cannot be greater than 100';
+      expect(actual).toEqual(expected);
+    });
+
+    it('returns null when within limits', () => {
+      const actual = Validators.checkBetween('field', 10, 100)('50');
+      expect(actual).toEqual(null);
+    });
+  });
+});

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/common/targetGroupValidators.spec.ts
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/common/targetGroupValidators.spec.ts
@@ -27,17 +27,33 @@ const mockTargetGroup = {
   type: '',
 };
 
+const httpTargetGroup = {
+  ...mockTargetGroup,
+  protocol: 'TCP',
+  healthCheckProtocol: 'HTTP',
+};
+
+const httpsTargetGroup = {
+  ...mockTargetGroup,
+  protocol: 'TCP',
+  healthCheckProtocol: 'HTTPS',
+};
+
+const tcpTargetGroup = {
+  ...mockTargetGroup,
+  healthCheckProtocol: 'TCP',
+};
+
 describe('Target Group validators', () => {
   describe('of used names', () => {
     it('returns an error if the name exists already', () => {
       const existingGroups = {
         test: {
-          'us-east-1': ['targetgroup'],
+          'us-east-1': [mockTargetGroup.name],
         },
       };
       const actual = Validators.isNameInUse(existingGroups, 'test', 'us-east-1')(mockTargetGroup.name);
-      const expected = 'There is already a target group in test:us-east-1 with that name.';
-      expect(actual).toEqual(expected);
+      expect(actual).toBeTruthy();
     });
 
     it('returns an null if it does not exist', () => {
@@ -52,58 +68,35 @@ describe('Target Group validators', () => {
   });
 
   describe('of name length', () => {
-    it('returns error if the name is >32 additional characters', () => {
-      const actual = Validators.isNameLong(12)(`${mockTargetGroup.name}areallylongname`);
-      const expected =
-        'Target group name is automatically prefixed with the application name and cannot exceed 32 characters in length.';
-      expect(actual).toEqual(expected);
+    it('returns an error if the inputted name >32 additional characters (this is prepended to the application name)', () => {
+      const actual = Validators.isNameLong('application'.length)(`applicationwithareallylongname`);
+      expect(actual).toBeTruthy();
     });
 
     it('returns null if the name is < 32', () => {
-      const actual = Validators.isNameLong(12)(mockTargetGroup.name);
-      expect(actual).toEqual(null);
-    });
-  });
-
-  describe('of duplicate names across the load balancer', () => {
-    it('returns an error if the name exists', () => {
-      const actual = Validators.isDuplicateName(['targetgroup'])(mockTargetGroup.name);
-      const expected = 'Duplicate target group name in this load balancer.';
-      expect(actual).toEqual(expected);
-    });
-
-    it('returns null if the name is new', () => {
-      const actual = Validators.isDuplicateName(['targetGroup2'])(mockTargetGroup.name);
+      const actual = Validators.isNameLong('app'.length)('appwithshortname');
       expect(actual).toEqual(null);
     });
   });
 
   describe('of health check timeout constraints', () => {
-    const tg = {
-      ...mockTargetGroup,
-      protocol: 'TCP',
-      healthCheckProtocol: 'HTTP',
-    };
-
     it('should have a 6s timeout', () => {
-      const actual = Validators.isValidTimeout(tg)('8');
-      const expected = 'HTTP health check timeouts for TCP/TLS target groups must be 6s';
-      expect(actual).toEqual(expected);
+      const actual = Validators.isValidTimeout(httpTargetGroup)('8');
+      expect(actual).toBeTruthy();
     });
 
     it('should be 6s and is valid', () => {
-      const actual = Validators.isValidTimeout(tg)('6');
+      const actual = Validators.isValidTimeout(httpTargetGroup)('6');
       expect(actual).toEqual(null);
     });
 
     it('should have a 10s timeout', () => {
-      const actual = Validators.isValidTimeout({ ...tg, healthCheckProtocol: 'HTTPS' })('9');
-      const expected = 'HTTPS/TLS health check timeouts for TCP/TLS target groups must be 10s';
-      expect(actual).toEqual(expected);
+      const actual = Validators.isValidTimeout(httpsTargetGroup)('9');
+      expect(actual).toBeTruthy();
     });
 
     it('should be 10s and is valid', () => {
-      const actual = Validators.isValidTimeout({ ...tg, healthCheckProtocol: 'HTTPS' })('10');
+      const actual = Validators.isValidTimeout(httpsTargetGroup)('10');
       expect(actual).toEqual(null);
     });
 
@@ -114,48 +107,23 @@ describe('Target Group validators', () => {
   });
 
   describe('of health check interval', () => {
-    const tg = {
-      ...mockTargetGroup,
-      healthCheckProtocol: 'TCP',
-    };
-
     it('TCPs can have a 10s interval', () => {
-      const actual = Validators.isValidHealthCheckInterval(tg)('10');
+      const actual = Validators.isValidHealthCheckInterval(tcpTargetGroup)('10');
       expect(actual).toEqual(null);
     });
 
     it('TCPs can have a 30s interval', () => {
-      const actual = Validators.isValidHealthCheckInterval(tg)('30');
+      const actual = Validators.isValidHealthCheckInterval(tcpTargetGroup)('30');
       expect(actual).toEqual(null);
     });
 
     it('returns an error when it fails TCP rules', () => {
-      const actual = Validators.isValidHealthCheckInterval(tg)('20');
-      const expected = 'TCP health checks only support 10s and 30s intervals';
-      expect(actual).toEqual(expected);
+      const actual = Validators.isValidHealthCheckInterval(tcpTargetGroup)('20');
+      expect(actual).toBeTruthy();
     });
 
     it('is not a TCP protocol target group', () => {
       const actual = Validators.isValidHealthCheckInterval(mockTargetGroup)('20');
-      expect(actual).toEqual(null);
-    });
-  });
-
-  describe('of max/min limits', () => {
-    it('returns an error when less than min', () => {
-      const actual = Validators.checkBetween('field', 10, 100)('8');
-      const expected = ' Field cannot be less than 10';
-      expect(actual).toEqual(expected);
-    });
-
-    it('returns an error when greater than max', () => {
-      const actual = Validators.checkBetween('field', 10, 100)('125');
-      const expected = ' Field cannot be greater than 100';
-      expect(actual).toEqual(expected);
-    });
-
-    it('returns null when within limits', () => {
-      const actual = Validators.checkBetween('field', 10, 100)('50');
       expect(actual).toEqual(null);
     });
   });

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/common/targetGroupValidators.ts
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/common/targetGroupValidators.ts
@@ -35,10 +35,12 @@ export const isValidTimeout = (targetGroup: ITargetGroup) => (value: string) => 
   return null;
 };
 
-export const isValidHealthCheckProtocol = (targetGroup: ITargetGroup) => (value: string) =>
-  targetGroup.healthCheckProtocol === 'TCP' && (Number.parseInt(value, 10) !== 10 || Number.parseInt(value, 10) !== 30)
-    ? 'TCP health checks only support 10s and 30s intervals'
-    : null;
+export const isValidHealthCheckInterval = (targetGroup: ITargetGroup) => (value: string) =>
+  targetGroup.healthCheckProtocol !== 'TCP' ||
+  (targetGroup.healthCheckProtocol === 'TCP' &&
+    (Number.parseInt(value, 10) === 10 || Number.parseInt(value, 10) === 30))
+    ? null
+    : 'TCP health checks only support 10s and 30s intervals';
 
 export const checkBetween = (fieldName: string, min: number, max: number) => (value: string) => {
   const sanitizedField = Number.parseInt(value, 10);

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/common/targetGroupValidators.ts
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/common/targetGroupValidators.ts
@@ -1,26 +1,23 @@
-import { get } from 'lodash';
-import { Validators, robotToHuman, spelNumberCheck } from '@spinnaker/core';
+import { get, isNumber } from 'lodash';
+import { IValidator } from '@spinnaker/core';
 import { ITargetGroup } from 'amazon/domain';
 
 export const isNameInUse = (
   existingNames: { [account: string]: { [region: string]: string[] } },
   credentials: string,
   region: string,
-) => (name: string) =>
+): IValidator => (name: string) =>
   get(existingNames, [credentials, region], []).includes(name.toLowerCase())
     ? `There is already a target group in ${credentials}:${region} with that name.`
     : null;
 
-export const isNameLong = (appNameLength: number) => (name: string) =>
+export const isNameLong = (appNameLength: number): IValidator => (name: string) =>
   name.length < 32 - appNameLength
     ? null
-    : 'Target group name is automatically prefixed with the application name and cannot exceed 32 characters in length.';
+    : 'Target group names are automatically prefixed with their application name and cannot exceed 32 characters in length.';
 
-export const isDuplicateName = (duplicateGroups: string[]) => (name: string) =>
-  !duplicateGroups.includes(name) ? null : 'Duplicate target group name in this load balancer.';
-
-export const isValidTimeout = (targetGroup: ITargetGroup) => (value: string) => {
-  const num = Number.parseInt(value, 10);
+export const isValidTimeout = (targetGroup: ITargetGroup): IValidator => (value: number | string) => {
+  const num = isNumber(value) ? value : Number.parseInt(value, 10);
   const { protocol, healthCheckProtocol } = targetGroup;
 
   if (protocol === 'TCP' || protocol === 'TLS') {
@@ -35,24 +32,9 @@ export const isValidTimeout = (targetGroup: ITargetGroup) => (value: string) => 
   return null;
 };
 
-export const isValidHealthCheckInterval = (targetGroup: ITargetGroup) => (value: string) =>
+export const isValidHealthCheckInterval = (targetGroup: ITargetGroup): IValidator => (value: string) =>
   targetGroup.healthCheckProtocol !== 'TCP' ||
   (targetGroup.healthCheckProtocol === 'TCP' &&
     (Number.parseInt(value, 10) === 10 || Number.parseInt(value, 10) === 30))
     ? null
     : 'TCP health checks only support 10s and 30s intervals';
-
-export const checkBetween = (fieldName: string, min: number, max: number) => (value: string) => {
-  const sanitizedField = Number.parseInt(value, 10);
-
-  if (!Number.isNaN(sanitizedField)) {
-    const error =
-      Validators.minValue(min)(sanitizedField, robotToHuman(fieldName)) ||
-      Validators.maxValue(max)(sanitizedField, robotToHuman(fieldName));
-
-    return error;
-  }
-  return null;
-};
-
-export const spelNumber = (value: number | string) => spelNumberCheck(value);

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/common/targetGroupValidators.ts
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/common/targetGroupValidators.ts
@@ -1,0 +1,56 @@
+import { get } from 'lodash';
+import { Validators, robotToHuman, spelNumberCheck } from '@spinnaker/core';
+import { ITargetGroup } from 'amazon/domain';
+
+export const isNameInUse = (
+  existingNames: { [account: string]: { [region: string]: string[] } },
+  credentials: string,
+  region: string,
+) => (name: string) =>
+  get(existingNames, [credentials, region], []).includes(name.toLowerCase())
+    ? `There is already a target group in ${credentials}:${region} with that name.`
+    : null;
+
+export const isNameLong = (appNameLength: number) => (name: string) =>
+  name.length < 32 - appNameLength
+    ? null
+    : 'Target group name is automatically prefixed with the application name and cannot exceed 32 characters in length.';
+
+export const isDuplicateName = (duplicateGroups: string[]) => (name: string) =>
+  !duplicateGroups.includes(name) ? null : 'Duplicate target group name in this load balancer.';
+
+export const isValidTimeout = (targetGroup: ITargetGroup) => (value: string) => {
+  const num = Number.parseInt(value, 10);
+  const { protocol, healthCheckProtocol } = targetGroup;
+
+  if (protocol === 'TCP' || protocol === 'TLS') {
+    if (healthCheckProtocol === 'HTTP' && num !== 6) {
+      return 'HTTP health check timeouts for TCP/TLS target groups must be 6s';
+    }
+
+    if ((healthCheckProtocol === 'HTTPS' || healthCheckProtocol === 'TLS') && num !== 10) {
+      return 'HTTPS/TLS health check timeouts for TCP/TLS target groups must be 10s';
+    }
+  }
+  return null;
+};
+
+export const isValidHealthCheckProtocol = (targetGroup: ITargetGroup) => (value: string) =>
+  targetGroup.healthCheckProtocol === 'TCP' && (Number.parseInt(value, 10) !== 10 || Number.parseInt(value, 10) !== 30)
+    ? 'TCP health checks only support 10s and 30s intervals'
+    : null;
+
+export const checkBetween = (fieldName: string, min: number, max: number) => (value: string) => {
+  const sanitizedField = Number.parseInt(value, 10);
+
+  if (!Number.isNaN(sanitizedField)) {
+    const error =
+      Validators.minValue(min)(sanitizedField, robotToHuman(fieldName)) ||
+      Validators.maxValue(max)(sanitizedField, robotToHuman(fieldName));
+
+    return error;
+  }
+  return null;
+};
+
+export const spelNumber = (value: number | string) => spelNumberCheck(value);

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/network/TargetGroups.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/network/TargetGroups.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { filter, flatten, get, groupBy, set, uniq } from 'lodash';
+import { filter, flatten, groupBy, set, uniq } from 'lodash';
 import { FormikErrors, FormikProps } from 'formik';
 import { Observable, Subject } from 'rxjs';
 
@@ -9,8 +9,11 @@ import {
   IWizardPageComponent,
   spelNumberCheck,
   SpInput,
+  SpelNumberInput,
   ValidationMessage,
+  FormValidator,
 } from '@spinnaker/core';
+import { isNameLong, isNameInUse, isDuplicateName, spelNumber } from '../common/targetGroupValidators';
 
 import { IAmazonApplicationLoadBalancer, IAmazonNetworkLoadBalancerUpsertCommand } from 'amazon/domain';
 
@@ -46,72 +49,52 @@ export class TargetGroups extends React.Component<ITargetGroupsProps, ITargetGro
   public validate(
     values: IAmazonNetworkLoadBalancerUpsertCommand,
   ): FormikErrors<IAmazonNetworkLoadBalancerUpsertCommand> {
-    const errors = {} as any;
-
-    let hasErrors = false;
     const duplicateTargetGroups = uniq(
       flatten(filter(groupBy(values.targetGroups, 'name'), count => count.length > 1)).map(tg => tg.name),
     );
-    const targetGroupsErrors = values.targetGroups.map((targetGroup: any) => {
-      const tgErrors: { [key: string]: string } = {};
+    const formValidator = new FormValidator(values);
+    const { arrayForEach } = formValidator;
 
-      if (
-        targetGroup.name &&
-        get(this.state.existingTargetGroupNames, [values.credentials, values.region], []).includes(
-          targetGroup.name.toLowerCase(),
-        )
-      ) {
-        tgErrors.name = `There is already a target group in ${values.credentials}:${values.region} with that name.`;
-      }
-
-      if (targetGroup.name && targetGroup.name.length > 32 - this.props.app.name.length) {
-        tgErrors.name =
-          'Target group name is automatically prefixed with the application name and cannot exceed 32 characters in length.';
-      }
-
-      if (duplicateTargetGroups.includes(targetGroup.name)) {
-        tgErrors.name = 'Duplicate target group name in this load balancer.';
-      }
-
-      ['port', 'healthCheckInterval', 'healthyThreshold', 'unhealthyThreshold'].forEach(key => {
-        const err = spelNumberCheck(targetGroup[key]);
-        if (err) {
-          tgErrors[key] = err;
-        }
-      });
-
-      if (targetGroup.healthCheckPort !== 'traffic-port') {
-        const err = spelNumberCheck(targetGroup.healthCheckPort);
-        if (err) {
-          tgErrors.healthCheckPort = err;
-        }
-      }
-
-      [
-        'name',
-        'protocol',
-        'port',
-        'healthCheckInterval',
-        'healthCheckPort',
-        'healthCheckProtocol',
-        'healthyThreshold',
-        'unhealthyThreshold',
-      ].forEach(key => {
-        if (!targetGroup[key]) {
-          tgErrors[key] = 'Required';
-        }
-      });
-
-      if (Object.keys(tgErrors).length > 0) {
-        hasErrors = true;
-      }
-      return tgErrors;
-    });
-
-    if (hasErrors) {
-      errors.targetGroups = targetGroupsErrors;
-    }
-    return errors;
+    formValidator.field('targetGroups').withValidators(
+      arrayForEach(builder => {
+        builder
+          .field('name', 'Name')
+          .required()
+          .withValidators(
+            isNameInUse(this.state.existingTargetGroupNames, values.credentials, values.region),
+            isNameLong(this.props.app.name.length),
+            isDuplicateName(duplicateTargetGroups),
+          );
+        builder
+          .field('port', 'Port')
+          .required()
+          .spelAware()
+          .withValidators(spelNumber);
+        builder
+          .field('healthCheckInterval', 'Health Check Interval')
+          .required()
+          .spelAware()
+          .withValidators(spelNumber);
+        builder
+          .field('healthyThreshold', 'Healthy Threshold')
+          .required()
+          .spelAware()
+          .withValidators(spelNumber);
+        builder
+          .field('unhealthyThreshold', 'Unhealthy Threshold')
+          .required()
+          .spelAware()
+          .withValidators(spelNumber);
+        builder
+          .field('healthCheckPort', 'Health Check Port')
+          .required()
+          .spelAware()
+          .withValidators(value => (value === 'traffic-port' ? null : spelNumberCheck(value)));
+        builder.field('protocol', 'Protocol').required();
+        builder.field('healthCheckProtocol', 'Health Check Protocol').required();
+      }),
+    );
+    return formValidator.validateForm();
   }
 
   private removeAppName(name: string): string {
@@ -335,27 +318,23 @@ export class TargetGroups extends React.Component<ITargetGroupsProps, ITargetGro
                           )}
                           <span className="wizard-pod-content">
                             <label>Timeout </label>
-                            <SpInput
-                              className="form-control input-sm inline-number"
+                            <SpelNumberInput
                               error={tgErrors.healthCheckTimeout}
-                              name="healthCheckTimeout"
                               required={true}
                               value={targetGroup.healthCheckTimeout}
-                              onChange={event =>
-                                this.targetGroupFieldChanged(index, 'healthCheckTimeout', event.target.value)
+                              onChange={(value: string) =>
+                                this.targetGroupFieldChanged(index, 'healthCheckTimeout', value)
                               }
                             />
                           </span>
                           <span className="wizard-pod-content">
                             <label>Interval </label>
-                            <SpInput
-                              className="form-control input-sm inline-number"
+                            <SpelNumberInput
                               error={tgErrors.healthCheckInterval}
-                              name="healthCheckInterval"
                               required={true}
                               value={targetGroup.healthCheckInterval}
-                              onChange={event =>
-                                this.targetGroupFieldChanged(index, 'healthCheckInterval', event.target.value)
+                              onChange={(value: string) =>
+                                this.targetGroupFieldChanged(index, 'healthCheckInterval', value)
                               }
                             />
                           </span>
@@ -367,14 +346,11 @@ export class TargetGroups extends React.Component<ITargetGroupsProps, ITargetGro
                       <div className="wizard-pod-row-contents">
                         <div className="wizard-pod-row-data">
                           <span className="wizard-pod-content">
-                            <SpInput
-                              className="form-control input-sm inline-number"
+                            <SpelNumberInput
                               error={tgErrors.healthyThreshold}
-                              name="healthyThreshold"
-                              type="text"
                               value={targetGroup.healthyThreshold}
-                              onChange={event =>
-                                this.targetGroupFieldChanged(index, 'healthyThreshold', event.target.value)
+                              onChange={(value: string) =>
+                                this.targetGroupFieldChanged(index, 'healthyThreshold', value)
                               }
                             />
                           </span>

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/network/TargetGroups.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/network/TargetGroups.tsx
@@ -12,8 +12,9 @@ import {
   SpelNumberInput,
   ValidationMessage,
   FormValidator,
+  Validators,
 } from '@spinnaker/core';
-import { isNameLong, isNameInUse, isDuplicateName, spelNumber } from '../common/targetGroupValidators';
+import { isNameLong, isNameInUse } from '../common/targetGroupValidators';
 
 import { IAmazonApplicationLoadBalancer, IAmazonNetworkLoadBalancerUpsertCommand } from 'amazon/domain';
 
@@ -63,28 +64,31 @@ export class TargetGroups extends React.Component<ITargetGroupsProps, ITargetGro
           .withValidators(
             isNameInUse(this.state.existingTargetGroupNames, values.credentials, values.region),
             isNameLong(this.props.app.name.length),
-            isDuplicateName(duplicateTargetGroups),
+            Validators.valueUnique(
+              duplicateTargetGroups,
+              'There is already a target group in this load balancer with the same name.',
+            ),
           );
         builder
           .field('port', 'Port')
           .required()
           .spelAware()
-          .withValidators(spelNumber);
+          .withValidators(Validators.isNum());
         builder
           .field('healthCheckInterval', 'Health Check Interval')
           .required()
           .spelAware()
-          .withValidators(spelNumber);
+          .withValidators(Validators.isNum());
         builder
           .field('healthyThreshold', 'Healthy Threshold')
           .required()
           .spelAware()
-          .withValidators(spelNumber);
+          .withValidators(Validators.isNum());
         builder
           .field('unhealthyThreshold', 'Unhealthy Threshold')
           .required()
           .spelAware()
-          .withValidators(spelNumber);
+          .withValidators(Validators.isNum());
         builder
           .field('healthCheckPort', 'Health Check Port')
           .required()

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/network/TargetGroups.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/network/TargetGroups.tsx
@@ -73,22 +73,22 @@ export class TargetGroups extends React.Component<ITargetGroupsProps, ITargetGro
           .field('port', 'Port')
           .required()
           .spelAware()
-          .withValidators(Validators.isNum());
+          .withValidators(value => spelNumberCheck(value));
         builder
           .field('healthCheckInterval', 'Health Check Interval')
           .required()
           .spelAware()
-          .withValidators(Validators.isNum());
+          .withValidators(value => spelNumberCheck(value));
         builder
           .field('healthyThreshold', 'Healthy Threshold')
           .required()
           .spelAware()
-          .withValidators(Validators.isNum());
+          .withValidators(value => spelNumberCheck(value));
         builder
           .field('unhealthyThreshold', 'Unhealthy Threshold')
           .required()
           .spelAware()
-          .withValidators(Validators.isNum());
+          .withValidators(value => spelNumberCheck(value));
         builder
           .field('healthCheckPort', 'Health Check Port')
           .required()

--- a/app/scripts/modules/core/src/presentation/forms/validation/validators.spec.ts
+++ b/app/scripts/modules/core/src/presentation/forms/validation/validators.spec.ts
@@ -1,0 +1,37 @@
+import { Validators } from './validators';
+
+describe('Target Group validators', () => {
+  describe('is a number', () => {
+    it('returns an error if a string is inputted', () => {
+      const actual = Validators.isNum('Should be a number')('hello');
+      expect(actual).toBeTruthy();
+    });
+
+    it('returns null if a number is inputted', () => {
+      const actual = Validators.isNum()(5);
+      expect(actual).toEqual(null);
+    });
+
+    it('Will return a default error message', () => {
+      const actual = Validators.isNum()('hello');
+      expect(actual).toBeTruthy();
+    });
+  });
+
+  describe('of max/min limits', () => {
+    it('returns an error when less than min', () => {
+      const actual = Validators.checkBetween('field', 10, 100)('8');
+      expect(actual).toBeTruthy();
+    });
+
+    it('returns an error when greater than max', () => {
+      const actual = Validators.checkBetween('field', 10, 100)('125');
+      expect(actual).toBeTruthy();
+    });
+
+    it('returns null when within limits', () => {
+      const actual = Validators.checkBetween('field', 10, 100)('50');
+      expect(actual).toEqual(null);
+    });
+  });
+});

--- a/app/scripts/modules/core/src/presentation/forms/validation/validators.ts
+++ b/app/scripts/modules/core/src/presentation/forms/validation/validators.ts
@@ -1,5 +1,6 @@
 import { IValidator } from './validation';
 import { isNumber } from 'lodash';
+import { robotToHuman } from '@spinnaker/core';
 
 const THIS_FIELD = 'This field';
 
@@ -16,6 +17,8 @@ const isRequired = (message?: string): IValidator => {
     return (val === undefined || val === null || val === '') && message;
   };
 };
+
+const isNum = (message?: string) => (value: any) => (isNumber(value) ? null : message || 'Must be a number');
 
 const minValue = (min: number, message?: string): IValidator => {
   return (val: number, label = THIS_FIELD) => {
@@ -39,6 +42,19 @@ const maxValue = (max: number, message?: string): IValidator => {
     }
     return null;
   };
+};
+
+const checkBetween = (fieldName: string, min: number, max: number): IValidator => (value: string) => {
+  const sanitizedField = Number.parseInt(value, 10);
+
+  if (!Number.isNaN(sanitizedField)) {
+    const error =
+      Validators.minValue(min)(sanitizedField, robotToHuman(fieldName)) ||
+      Validators.maxValue(max)(sanitizedField, robotToHuman(fieldName));
+
+    return error;
+  }
+  return null;
 };
 
 const oneOf = (list: any[], message?: string): IValidator => {
@@ -81,8 +97,10 @@ export const Validators = {
   arrayNotEmpty,
   emailValue,
   isRequired,
+  isNum,
   maxValue,
   minValue,
+  checkBetween,
   oneOf,
   skipIfUndefined,
   valueUnique,

--- a/app/scripts/modules/core/src/widgets/spelText/SpelNumberInput.tsx
+++ b/app/scripts/modules/core/src/widgets/spelText/SpelNumberInput.tsx
@@ -8,6 +8,7 @@ export interface INumberInputProps {
   min?: number;
   max?: number;
   required?: boolean;
+  error?: string;
 }
 
 export interface INumberInputState {
@@ -46,49 +47,51 @@ export class SpelNumberInput extends React.Component<INumberInputProps, INumberI
 
   public render() {
     const { expressionActive, glowing } = this.state;
-    const { value, min, max, required = false } = this.props;
+    const { value, min, max, required = false, error } = this.props;
     return (
-      <div className="navbar-form" style={{ padding: 0, margin: 0 }}>
-        <div className={`button-input ${expressionActive ? 'text' : 'number'}${glowing ? ' focus' : ''}`}>
-          <span className="btn-group btn-group-xs" role="group">
-            <button
-              type="button"
-              className={`btn btn-default ${expressionActive ? '' : 'active'}`}
-              onClick={() => this.setExpressionActive(false)}
+      <div className="navbar-form" style={{ padding: 0, margin: 0, display: 'inline-block' }}>
+        <Tooltip value={error} placement="right">
+          <div className={`button-input${glowing && !error ? ' focus' : ''}${error ? ' invalid' : ''}`}>
+            <span className="btn-group btn-group-xs" role="group">
+              <button
+                type="button"
+                className={`btn btn-default ${expressionActive ? '' : 'active'}`}
+                onClick={() => this.setExpressionActive(false)}
+                onFocus={() => this.setGlow(true)}
+                onBlur={() => this.setGlow(false)}
+              >
+                <Tooltip value="Toggle to enter number">
+                  <span>Num</span>
+                </Tooltip>
+              </button>
+              <button
+                type="button"
+                className={`btn btn-default ${expressionActive ? 'active' : ''}`}
+                onClick={() => this.setExpressionActive(true)}
+                onFocus={() => this.setGlow(true)}
+                onBlur={() => this.setGlow(false)}
+              >
+                <Tooltip value="Toggle to enter expression">
+                  <span>
+                    {'${'}
+                    &hellip;}
+                  </span>
+                </Tooltip>
+              </button>
+            </span>
+            <input
+              type={expressionActive ? 'text' : 'number'}
+              className={`form-control borderless inline-${expressionActive ? 'text' : 'number'}`}
+              value={value}
+              min={min}
+              max={max}
+              onChange={this.valueChanged}
               onFocus={() => this.setGlow(true)}
               onBlur={() => this.setGlow(false)}
-            >
-              <Tooltip value="Toggle to enter number">
-                <span>Num</span>
-              </Tooltip>
-            </button>
-            <button
-              type="button"
-              className={`btn btn-default ${expressionActive ? 'active' : ''}`}
-              onClick={() => this.setExpressionActive(true)}
-              onFocus={() => this.setGlow(true)}
-              onBlur={() => this.setGlow(false)}
-            >
-              <Tooltip value="Toggle to enter expression">
-                <span>
-                  {'${'}
-                  &hellip;}
-                </span>
-              </Tooltip>
-            </button>
-          </span>
-          <input
-            type={expressionActive ? 'text' : 'number'}
-            className="form-control borderless"
-            value={value}
-            min={min}
-            max={max}
-            onChange={this.valueChanged}
-            onFocus={() => this.setGlow(true)}
-            onBlur={() => this.setGlow(false)}
-            required={required}
-          />
-        </div>
+              required={required}
+            />
+          </div>
+        </Tooltip>
       </div>
     );
   }

--- a/app/scripts/modules/core/src/widgets/spelText/SpelNumberInput.tsx
+++ b/app/scripts/modules/core/src/widgets/spelText/SpelNumberInput.tsx
@@ -9,6 +9,7 @@ export interface INumberInputProps {
   max?: number;
   required?: boolean;
   error?: string;
+  disabled?: boolean;
 }
 
 export interface INumberInputState {
@@ -47,7 +48,7 @@ export class SpelNumberInput extends React.Component<INumberInputProps, INumberI
 
   public render() {
     const { expressionActive, glowing } = this.state;
-    const { value, min, max, required = false, error } = this.props;
+    const { value, min, max, required = false, error, disabled } = this.props;
     return (
       <div className="navbar-form" style={{ padding: 0, margin: 0, display: 'inline-block' }}>
         <Tooltip value={error} placement="right">
@@ -55,6 +56,7 @@ export class SpelNumberInput extends React.Component<INumberInputProps, INumberI
             <span className="btn-group btn-group-xs" role="group">
               <button
                 type="button"
+                disabled={disabled}
                 className={`btn btn-default ${expressionActive ? '' : 'active'}`}
                 onClick={() => this.setExpressionActive(false)}
                 onFocus={() => this.setGlow(true)}
@@ -66,6 +68,7 @@ export class SpelNumberInput extends React.Component<INumberInputProps, INumberI
               </button>
               <button
                 type="button"
+                disabled={disabled}
                 className={`btn btn-default ${expressionActive ? 'active' : ''}`}
                 onClick={() => this.setExpressionActive(true)}
                 onFocus={() => this.setGlow(true)}
@@ -81,6 +84,7 @@ export class SpelNumberInput extends React.Component<INumberInputProps, INumberI
             </span>
             <input
               type={expressionActive ? 'text' : 'number'}
+              disabled={disabled}
               className={`form-control borderless inline-${expressionActive ? 'text' : 'number'}`}
               value={value}
               min={min}

--- a/app/scripts/modules/core/src/widgets/spelText/spel.less
+++ b/app/scripts/modules/core/src/widgets/spelText/spel.less
@@ -44,6 +44,13 @@ input.borderless,
   flex-grow: 1;
 }
 
+.button-input.invalid {
+  border-color: var(--color-danger);
+  outline: 0;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px var(--color-danger-light);
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px var(--color-danger-light);
+}
+
 .button-input.focus {
   border-color: var(--color-accent);
   outline: 0;


### PR DESCRIPTION
Addressing validation issues on the create/edit load balancer user flow: 

1. Form validation for health check values was invoked on the user string, causing the validation to fail. ("Must be a number")
2. Inconsistent with [AWS](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html) rules. The summary is below, but more details can be found in the doc I linked. 

**HealthCheckTimeoutSeconds**
For target groups with TCP/TLS protocols - it must be 6 seconds for HTTP healthchecks and 10 seconds for TCP/HTTPS healthchecks.

For target groups with HTTP/HTTPS protocols, the range of values 2-120 should be acceptable.

**HealthCheckIntervalSeconds**
For TCP healthchecks, the interval must be 10 or 30 seconds.