### PR TITLE
feat(managed): add resource status to infrastructure views

### DIFF
--- a/app/scripts/modules/core/src/cluster/ClusterPod.tsx
+++ b/app/scripts/modules/core/src/cluster/ClusterPod.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as classNames from 'classnames';
 import { orderBy, partition, groupBy, map } from 'lodash';
 
 import { ClusterState } from 'core/state';
@@ -11,6 +12,7 @@ import { IClusterSubgroup, IServerGroupSubgroup } from './filter/ClusterFilterSe
 import { ISortFilter } from 'core/filterModel';
 import { ClusterPodTitleWrapper } from 'core/cluster/ClusterPodTitleWrapper';
 import { ServerGroupManager } from 'core/serverGroupManager/ServerGroupManager';
+import { ManagedResourceStatusIndicator } from 'core/managed';
 
 export interface IClusterPodProps {
   grouping: IClusterSubgroup;
@@ -89,20 +91,25 @@ export class ClusterPod extends React.Component<IClusterPodProps, IClusterPodSta
       group => group.serverGroupManagers && group.serverGroupManagers.length,
     );
     const serverGroupManagers = groupBy(managedServerGroups, serverGroup => serverGroup.serverGroupManagers[0].name);
-
+    const showManagedIndicator = !grouping.isManaged && subgroup.isManaged;
     return (
       <div className="pod-subgroup" key={subgroup.key}>
         <h6 className="sticky-header-2 subgroup-title horizontal middle">
           <div>{subgroup.heading}</div>
-          <EntityNotifications
-            entity={subgroup}
-            application={application}
-            placement="top"
-            hOffsetPercent="20%"
-            entityType="cluster"
-            pageLocation="pod"
-            onUpdate={() => application.serverGroups.refresh()}
-          />
+          <div className={classNames('flex-container-h middle', { 'sp-margin-xs-left': showManagedIndicator })}>
+            {showManagedIndicator && (
+              <ManagedResourceStatusIndicator shape="circle" resourceSummary={subgroup.managedResourceSummary} />
+            )}
+            <EntityNotifications
+              entity={subgroup}
+              application={application}
+              placement="top"
+              hOffsetPercent="20%"
+              entityType="cluster"
+              pageLocation="pod"
+              onUpdate={() => application.serverGroups.refresh()}
+            />
+          </div>
         </h6>
 
         {map(serverGroupManagers, (serverGroups, manager) => (

--- a/app/scripts/modules/core/src/cluster/DefaultClusterPodTitle.tsx
+++ b/app/scripts/modules/core/src/cluster/DefaultClusterPodTitle.tsx
@@ -1,8 +1,11 @@
 import * as React from 'react';
+import * as classNames from 'classnames';
 
 import { AccountTag } from 'core/account';
 import { EntityNotifications } from 'core/entityTag/notifications/EntityNotifications';
 import { HealthCounts } from 'core/healthCounts';
+import { ManagedResourceStatusIndicator } from 'core/managed';
+
 import { IClusterPodTitleProps } from './ClusterPodTitleWrapper';
 
 export class DefaultClusterPodTitle extends React.Component<IClusterPodTitleProps> {
@@ -15,22 +18,32 @@ export class DefaultClusterPodTitle extends React.Component<IClusterPodTitleProp
           <AccountTag account={parentHeading} />
         </div>
 
-        <div className="pod-center horizontal space-between center flex-1">
+        <div
+          className={classNames('pod-center horizontal space-between flex-1', {
+            'no-right-padding': grouping.isManaged,
+          })}
+        >
           <div>
             <span className="glyphicon glyphicon-th" />
             {' ' + grouping.heading}
           </div>
 
-          <EntityNotifications
-            entity={grouping}
-            application={application}
-            placement="top"
-            hOffsetPercent="90%"
-            entityType="cluster"
-            pageLocation="pod"
-            className="inverse"
-            onUpdate={() => application.serverGroups.refresh()}
-          />
+          <div className="flex-container-h margin-between-md">
+            <EntityNotifications
+              entity={grouping}
+              application={application}
+              placement="top"
+              hOffsetPercent="90%"
+              entityType="cluster"
+              pageLocation="pod"
+              className="inverse"
+              onUpdate={() => application.serverGroups.refresh()}
+            />
+
+            {grouping.isManaged && (
+              <ManagedResourceStatusIndicator shape="square" resourceSummary={grouping.managedResourceSummary} />
+            )}
+          </div>
         </div>
 
         <HealthCounts container={grouping.cluster.instanceCounts} />

--- a/app/scripts/modules/core/src/cluster/filter/ClusterFilterService.ts
+++ b/app/scripts/modules/core/src/cluster/filter/ClusterFilterService.ts
@@ -9,6 +9,7 @@ import { ClusterState } from 'core/state';
 import { FilterModelService, ISortFilter } from 'core/filterModel';
 import { ReactInjector } from 'core/reactShims';
 import { ILabelFilter, trueKeyObjectToLabelFilters } from 'core/cluster/filter/labelFilterUtils';
+import { IManagedResourceSummary } from 'core/managed';
 
 export interface IParentGrouping {
   subgroups: IClusterSubgroup[] | IServerGroupSubgroup[];
@@ -30,6 +31,8 @@ export interface IClusterSubgroup extends IParentGrouping {
   hasDiscovery?: boolean;
   hasLoadBalancers?: boolean;
   entityTags: IEntityTags;
+  isManaged: boolean;
+  managedResourceSummary?: IManagedResourceSummary;
 }
 
 export interface IServerGroupSubgroup {
@@ -38,6 +41,8 @@ export interface IServerGroupSubgroup {
   category: string;
   serverGroups: IServerGroup[];
   entityTags: IEntityTags;
+  isManaged: boolean;
+  managedResourceSummary?: IManagedResourceSummary;
 }
 
 export type Grouping = IClusterGroup | IClusterSubgroup | IServerGroupSubgroup;
@@ -83,6 +88,8 @@ export class ClusterFilterService {
               serverGroups: regionGroup,
               key: `${region}:${category}`,
               entityTags: (regionGroup[0].clusterEntityTags || []).find(t => t.entityRef['region'] === region),
+              isManaged: !!regionGroup[0].isManaged,
+              managedResourceSummary: regionGroup[0].managedResourceSummary,
             });
           });
 
@@ -91,6 +98,7 @@ export class ClusterFilterService {
           );
 
           if (appCluster) {
+            const isEntireClusterManaged = regionGroups.every(({ isManaged }) => isManaged);
             clusterGroups.push({
               heading: cluster,
               category,
@@ -100,6 +108,8 @@ export class ClusterFilterService {
               entityTags: (clusterGroup[0].clusterEntityTags || []).find(
                 t => t.entityRef['region'] === '*' || t.entityRef['region'] === undefined,
               ),
+              isManaged: isEntireClusterManaged,
+              managedResourceSummary: isEntireClusterManaged ? regionGroups[0].managedResourceSummary : undefined,
             });
           }
         });

--- a/app/scripts/modules/core/src/cluster/filter/mockApplicationData.js
+++ b/app/scripts/modules/core/src/cluster/filter/mockApplicationData.js
@@ -57,12 +57,16 @@ module.exports = angular
           hasDiscovery: false,
           hasLoadBalancers: false,
           entityTags: undefined,
+          isManaged: false,
+          managedResourceSummary: undefined,
           subgroups: [
             {
               heading: 'eu-east-2',
               category: 'serverGroup',
               key: 'eu-east-2:serverGroup',
               entityTags: undefined,
+              isManaged: false,
+              managedResourceSummary: undefined,
               serverGroups: [
                 {
                   cluster: 'in-eu-east-2-only',
@@ -105,12 +109,16 @@ module.exports = angular
           hasDiscovery: false,
           hasLoadBalancers: false,
           entityTags: undefined,
+          isManaged: false,
+          managedResourceSummary: undefined,
           subgroups: [
             {
               heading: 'us-west-1',
               category: 'serverGroup',
               key: 'us-west-1:serverGroup',
               entityTags: undefined,
+              isManaged: false,
+              managedResourceSummary: undefined,
               serverGroups: [
                 {
                   cluster: 'in-us-west-1-only',

--- a/app/scripts/modules/core/src/cluster/rollups.less
+++ b/app/scripts/modules/core/src/cluster/rollups.less
@@ -5,6 +5,7 @@
     font-size: 200%;
     margin: 0;
   }
+
   .server-group-title {
     input {
       margin: 0 5px 3px 0;
@@ -19,10 +20,12 @@
     background-color: var(--color-alabaster);
     margin: 0;
     padding: 10px 0;
+
     &.heading-sticky {
       box-shadow: 0 8px 6px -6px var(--color-concrete);
     }
   }
+
   .heading-sticky {
     > h4 {
       box-shadow: 0 8px 6px -6px var(--color-concrete);
@@ -41,6 +44,7 @@
   &.disabled {
     opacity: 0.4;
     border: 1px dashed var(--color-titanium);
+
     &:hover,
     &.active {
       opacity: 0.75;
@@ -69,6 +73,7 @@
 table.instances {
   table-layout: fixed;
   display: table;
+
   td {
     word-break: break-all;
   }
@@ -79,16 +84,20 @@ table.instances {
   line-height: 10px;
   border-radius: 2px;
   padding-bottom: 5px;
+
   td:first-child,
   th:first-child {
     padding-left: 0;
   }
+
   .instance-group-Starting {
     .pulsing(1);
+
     &:hover {
       animation: none;
     }
   }
+
   a.instance {
     margin: 0;
     display: inline-block;
@@ -101,10 +110,12 @@ table.instances {
     &.health-status-Up {
       background-color: var(--color-success-light);
     }
+
     &.health-status-Down,
     &.health-status-Failed {
       background-color: var(--color-danger);
     }
+
     &.health-status-OutOfService {
       background-color: var(--color-concrete);
     }
@@ -129,10 +140,12 @@ table.instances {
       &.health-status-Up {
         background-color: var(--color-success);
       }
+
       &.health-status-Down,
       &.health-status-Failed {
         background-color: var(--color-danger);
       }
+
       &.health-status-OutOfService {
         background-color: var(--color-dovegray);
         border-color: var(--color-mineshaft);
@@ -158,29 +171,35 @@ table.instances {
     padding: 0 5px;
     margin-left: 2px;
     text-align: center;
+
     button {
       margin-right: 0;
     }
+
     background-color: var(--color-accent-g2);
   }
 
   .tooltip {
     text-transform: none;
   }
+
   button {
     padding: 0;
     display: inline-block;
     margin-right: 5px;
     line-height: 1;
+
     &.active,
     &:focus {
       outline: 0;
       box-shadow: none;
     }
+
     .icon {
       position: relative;
       font-size: 120%;
     }
+
     .icon-spinner {
       font-size: 20px;
     }
@@ -195,6 +214,7 @@ table.instances {
   line-height: 36px;
   font-size: 16px;
   color: var(--color-primary);
+
   .pod-center {
     min-width: 0;
     background-color: var(--color-accent-g2);
@@ -202,26 +222,35 @@ table.instances {
     border-right: 1px solid var(--color-alabaster);
     border-left: 1px solid var(--color-alabaster);
     font-weight: 600;
+
     > div {
       white-space: nowrap;
       overflow-x: hidden;
       text-overflow: ellipsis;
     }
+
+    &.no-right-padding {
+      padding-right: 0;
+    }
   }
+
   .health-counts {
     flex: 0 0 auto;
     background-color: var(--color-cirrus);
     padding: 0 10px;
     border-left: 1px solid var(--color-alabaster);
   }
+
   &:active,
   &:hover,
   &:focus {
     text-decoration: none;
   }
+
   @media (min-width: 768px) and (max-width: 992px) {
     font-size: 85%;
   }
+
   .instance-health-counts {
     padding-right: 10px;
   }
@@ -231,6 +260,7 @@ running-tasks-tag {
   position: relative;
   top: 2px;
   right: 5px;
+
   .icon-spinner {
     color: var(--color-accent);
   }
@@ -267,6 +297,7 @@ running-tasks-tag {
     color: var(--color-cirrus);
     background-color: var(--color-dovegray);
   }
+
   .menu-load-balancers-header,
   a {
     text-transform: none;
@@ -274,6 +305,7 @@ running-tasks-tag {
     padding: 5px 10px;
     display: block;
   }
+
   a {
     cursor: pointer;
     display: flex;
@@ -283,6 +315,7 @@ running-tasks-tag {
 
     .health-counts {
       margin-left: 5px;
+
       .instance-health-counts {
         float: none !important;
       }
@@ -291,11 +324,13 @@ running-tasks-tag {
     &:last-child {
       border-bottom-width: 0;
     }
+
     &:hover,
     &:focus {
       background-color: var(--color-cirrus);
       text-decoration: none;
     }
+
     &:focus {
       padding-left: 15px;
       padding-right: 5px;
@@ -308,6 +343,7 @@ running-tasks-tag {
   &.overflowing {
     position: relative;
   }
+
   .btn-load-balancer button,
   .btn-multiple-load-balancers {
     margin-top: -5px;
@@ -319,16 +355,20 @@ running-tasks-tag {
 
   text-align: right;
   margin-right: 3px;
+
   &:hover {
     text-decoration: none;
   }
+
   .icon {
     width: 30px;
   }
+
   .icon-sitemap {
     height: 14px;
     width: 14px;
   }
+
   .badge-counter {
     color: var(--color-text-link);
     background-color: var(--color-white);
@@ -338,6 +378,7 @@ running-tasks-tag {
     padding: 1px 4px;
     border-radius: 4px;
   }
+
   span {
     position: relative;
   }
@@ -347,6 +388,7 @@ running-tasks-tag {
   .badge-counter {
     margin-top: -5px;
     height: 19px;
+
     .fa-server {
       padding: 1px 0;
     }
@@ -359,6 +401,7 @@ running-tasks-tag {
 
   .section-title {
     margin-bottom: 3px;
+
     span {
       font-size: 13px;
     }
@@ -370,10 +413,12 @@ running-tasks-tag {
     margin: 5px 15px 3px;
     position: relative;
     z-index: 1;
+
     &.active {
       border-color: var(--color-accent-g1);
       background-color: var(--color-accent-g3);
     }
+
     &:hover {
       border-color: var(--color-accent-g1);
       box-shadow: 0 0 4px 2px var(--color-accent-g1);
@@ -385,9 +430,11 @@ running-tasks-tag {
       border-style: dashed;
     }
   }
+
   .permalinks {
     font-size: 80%;
   }
+
   .pod-subgroup {
     h6 {
       text-transform: uppercase;
@@ -395,52 +442,65 @@ running-tasks-tag {
       padding: 10px 10px 5px;
       background-color: var(--color-alabaster);
     }
+
     .heading-sticky {
       > h6 {
         background-color: var(--color-alabaster);
       }
     }
+
     .rollup-pod-server-group {
       .server-group-title {
         background-color: rgba(255, 255, 255, 0.9);
       }
+
       &.running {
         background-color: var(--color-alabaster);
         .pulsing(1);
+
         .server-group-title {
           background-color: var(--color-alabaster);
         }
       }
+
       &.failed {
         background-color: var(--color-cirrus);
+
         .server-group-title {
           background-color: var(--color-cirrus);
         }
       }
+
       &.succeeded {
         background-color: var(--color-accent-g3);
+
         .server-group-title {
           background-color: var(--color-accent-g3);
         }
       }
+
       &.active {
         border-color: var(--color-accent-g1);
         background-color: var(--color-accent-g3);
+
         .server-group-title {
           background-color: var(--color-accent-g3);
         }
       }
     }
+
     .table {
       margin-top: -5px;
       margin-bottom: 10px;
       font-size: 90%;
+
       th,
       td {
         padding: 5px 1px;
       }
     }
   }
+
   h5,
   h6 {
     font-weight: 600;
@@ -458,9 +518,11 @@ running-tasks-tag {
   .rollup-details-section {
     border-right: 1px solid var(--color-silver);
     padding: 10px;
+
     &:last-child {
       border-right-width: 0;
     }
+
     .rollup-row {
       padding: 0;
     }
@@ -468,6 +530,7 @@ running-tasks-tag {
 
   .rollup-row {
     padding: 10px;
+
     &:first-child {
       border-top-width: 0;
     }
@@ -475,15 +538,18 @@ running-tasks-tag {
 
   .disabled {
     opacity: 1;
+
     .section-title,
     .health-counts,
     .load-balancers-tag .badge,
     .instances {
       opacity: 0.4;
     }
+
     .icon-server-group {
       color: var(--color-dovegray);
     }
+
     &:hover {
       .section-title,
       .health-counts,
@@ -520,18 +586,22 @@ running-tasks-tag {
       box-shadow: none;
     }
   }
+
   .server-group-sequence {
     text-transform: uppercase;
     font-weight: 600;
     margin-left: 2px;
   }
+
   .build-link {
     margin-left: 3px;
   }
+
   .server-group-title,
   .subgroup-title {
     padding: 5px 10px 2px;
     border-bottom-width: 0;
+
     &.clickable {
       &:hover,
       &.active {
@@ -539,6 +609,7 @@ running-tasks-tag {
       }
     }
   }
+
   .heading-sticky {
     box-shadow: 0 8px 6px -6px var(--color-concrete);
   }

--- a/app/scripts/modules/core/src/domain/ILoadBalancer.ts
+++ b/app/scripts/modules/core/src/domain/ILoadBalancer.ts
@@ -43,4 +43,6 @@ export interface ILoadBalancerGroup {
   serverGroups?: IServerGroup[];
   subgroups?: ILoadBalancerGroup[];
   searchField?: string;
+  isManaged?: boolean;
+  managedResourceSummary?: IManagedResourceSummary;
 }

--- a/app/scripts/modules/core/src/domain/ISecurityGroup.ts
+++ b/app/scripts/modules/core/src/domain/ISecurityGroup.ts
@@ -49,10 +49,12 @@ export interface ISecurityGroup {
 
 export interface ISecurityGroupGroup {
   heading: string;
+  isManaged?: boolean;
+  loadBalancers?: ILoadBalancer[];
+  managedResourceSummary?: IManagedResourceSummary;
+  searchField?: string;
   securityGroup?: ISecurityGroup;
   serverGroups?: IServerGroup[];
-  loadBalancers?: ILoadBalancer[];
   subgroups?: ISecurityGroupGroup[];
-  searchField?: string;
   vpcName?: string;
 }

--- a/app/scripts/modules/core/src/loadBalancer/LoadBalancer.tsx
+++ b/app/scripts/modules/core/src/loadBalancer/LoadBalancer.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react';
 import { UISref, UISrefActive } from '@uirouter/react';
+import * as classNames from 'classnames';
 
 import { Application } from 'core/application/application.model';
 import { CloudProviderRegistry } from 'core/cloudProvider';
-import { ILoadBalancer, IServerGroup } from 'core/domain';
+import { ILoadBalancer, IServerGroup, ILoadBalancerGroup } from 'core/domain';
+import { ManagedResourceStatusIndicator } from 'core/managed';
 
 import { HealthCounts } from 'core/healthCounts/HealthCounts';
 import { LoadBalancerClusterContainer } from './LoadBalancerClusterContainer';
@@ -11,6 +13,7 @@ import { EntityNotifications } from 'core/entityTag/notifications/EntityNotifica
 
 export interface ILoadBalancerProps {
   application: Application;
+  grouping: ILoadBalancerGroup;
   loadBalancer: ILoadBalancer;
   serverGroups: IServerGroup[];
   showServerGroups?: boolean;
@@ -24,9 +27,10 @@ export class LoadBalancer extends React.Component<ILoadBalancerProps> {
   };
 
   public render(): React.ReactElement<LoadBalancer> {
-    const { application, loadBalancer, serverGroups, showInstances, showServerGroups } = this.props;
+    const { application, grouping, loadBalancer, serverGroups, showInstances, showServerGroups } = this.props;
     const config = CloudProviderRegistry.getValue(loadBalancer.provider || loadBalancer.cloudProvider, 'loadBalancer');
     const ClusterContainer = config.ClusterContainer || LoadBalancerClusterContainer;
+    const showManagedIndicator = !grouping.isManaged && loadBalancer.isManaged;
 
     const params = {
       application: application.name,
@@ -45,7 +49,17 @@ export class LoadBalancer extends React.Component<ILoadBalancerProps> {
               <h6 className="clickable clickable-row horizontal middle">
                 <i className="fa icon-sitemap" />
                 &nbsp; {(loadBalancer.region || '').toUpperCase()}
-                <div className="flex-1">
+                <div
+                  className={classNames('flex-container-h middle flex-1', {
+                    'sp-margin-s-left': showManagedIndicator,
+                  })}
+                >
+                  {showManagedIndicator && (
+                    <ManagedResourceStatusIndicator
+                      shape="circle"
+                      resourceSummary={loadBalancer.managedResourceSummary}
+                    />
+                  )}
                   <EntityNotifications
                     entity={loadBalancer}
                     application={application}

--- a/app/scripts/modules/core/src/loadBalancer/LoadBalancerPod.tsx
+++ b/app/scripts/modules/core/src/loadBalancer/LoadBalancerPod.tsx
@@ -3,6 +3,8 @@ import * as React from 'react';
 import { AccountTag } from 'core/account';
 import { Application } from 'core/application/application.model';
 import { ILoadBalancerGroup } from 'core/domain';
+import { ManagedResourceStatusIndicator } from 'core/managed';
+
 import { LoadBalancer } from './LoadBalancer';
 
 import './loadBalancerPod.less';
@@ -22,6 +24,7 @@ export class LoadBalancerPod extends React.Component<ILoadBalancerPodProps> {
       <LoadBalancer
         key={subgroup.heading}
         application={application}
+        grouping={grouping}
         loadBalancer={subgroup.loadBalancer}
         serverGroups={subgroup.serverGroups}
         showServerGroups={showServerGroups}
@@ -36,8 +39,11 @@ export class LoadBalancerPod extends React.Component<ILoadBalancerPodProps> {
             <div className="heading-tag">
               <AccountTag account={parentHeading} />
             </div>
-            <div className="pod-center horizontal space-between center flex-1">
+            <div className="pod-center horizontal space-between flex-1 no-right-padding">
               <div>{grouping.heading}</div>
+              {grouping.isManaged && (
+                <ManagedResourceStatusIndicator shape="square" resourceSummary={grouping.managedResourceSummary} />
+              )}
             </div>
           </div>
         </div>

--- a/app/scripts/modules/core/src/loadBalancer/filter/LoadBalancerFilterService.spec.ts
+++ b/app/scripts/modules/core/src/loadBalancer/filter/LoadBalancerFilterService.spec.ts
@@ -2,6 +2,7 @@ import { Application } from 'core/application/application.model';
 import { ApplicationModelBuilder } from 'core/application/applicationModel.builder';
 import { ILoadBalancer, IServerGroup, ILoadBalancerGroup } from 'core/domain';
 import { LoadBalancerState } from 'core/state';
+import { IManagedResourceSummary } from 'core/managed';
 
 // Most of this logic has been moved to filter.model.service.js, so these act more as integration tests
 describe('Service: loadBalancerFilterService', function() {
@@ -50,9 +51,27 @@ describe('Service: loadBalancerFilterService', function() {
     ];
 
     resultJson = [
-      { heading: 'us-east-1', loadBalancer: app.loadBalancers.data[0], serverGroups: [] },
-      { heading: 'us-west-1', loadBalancer: app.loadBalancers.data[1], serverGroups: [] },
-      { heading: 'us-east-1', loadBalancer: app.loadBalancers.data[2], serverGroups: [] },
+      {
+        heading: 'us-east-1',
+        loadBalancer: app.loadBalancers.data[0],
+        serverGroups: [],
+        isManaged: false,
+        managedResourceSummary: undefined,
+      },
+      {
+        heading: 'us-west-1',
+        loadBalancer: app.loadBalancers.data[1],
+        serverGroups: [],
+        isManaged: false,
+        managedResourceSummary: undefined,
+      },
+      {
+        heading: 'us-east-1',
+        loadBalancer: app.loadBalancers.data[2],
+        serverGroups: [],
+        isManaged: false,
+        managedResourceSummary: undefined,
+      },
     ];
     LoadBalancerState.filterModel.asFilterModel.clearFilters();
   });
@@ -62,11 +81,25 @@ describe('Service: loadBalancerFilterService', function() {
       const expected = [
         {
           heading: 'prod',
-          subgroups: [{ heading: 'elb-2', subgroups: [resultJson[2]] }],
+          subgroups: [
+            {
+              heading: 'elb-2',
+              subgroups: [resultJson[2]],
+              isManaged: false,
+              managedResourceSummary: undefined as IManagedResourceSummary,
+            },
+          ],
         },
         {
           heading: 'test',
-          subgroups: [{ heading: 'elb-1', subgroups: [resultJson[0], resultJson[1]] }],
+          subgroups: [
+            {
+              heading: 'elb-1',
+              subgroups: [resultJson[0], resultJson[1]],
+              isManaged: false,
+              managedResourceSummary: undefined,
+            },
+          ],
         },
       ];
       LoadBalancerState.filterService.updateLoadBalancerGroups(app);
@@ -104,7 +137,9 @@ describe('Service: loadBalancerFilterService', function() {
           expect(LoadBalancerState.filterModel.asFilterModel.groups).toEqual([
             {
               heading: 'test',
-              subgroups: [{ heading: 'elb-1', subgroups: [resultJson[1]] }],
+              subgroups: [
+                { heading: 'elb-1', subgroups: [resultJson[1]], isManaged: false, managedResourceSummary: undefined },
+              ],
             },
           ]);
           done();
@@ -130,7 +165,9 @@ describe('Service: loadBalancerFilterService', function() {
           expect(LoadBalancerState.filterModel.asFilterModel.groups).toEqual([
             {
               heading: 'prod',
-              subgroups: [{ heading: 'elb-2', subgroups: [resultJson[2]] }],
+              subgroups: [
+                { heading: 'elb-2', subgroups: [resultJson[2]], isManaged: false, managedResourceSummary: undefined },
+              ],
             },
           ]);
           done();
@@ -145,11 +182,20 @@ describe('Service: loadBalancerFilterService', function() {
           expect(LoadBalancerState.filterModel.asFilterModel.groups).toEqual([
             {
               heading: 'prod',
-              subgroups: [{ heading: 'elb-2', subgroups: [resultJson[2]] }],
+              subgroups: [
+                { heading: 'elb-2', subgroups: [resultJson[2]], isManaged: false, managedResourceSummary: undefined },
+              ],
             },
             {
               heading: 'test',
-              subgroups: [{ heading: 'elb-1', subgroups: [resultJson[0], resultJson[1]] }],
+              subgroups: [
+                {
+                  heading: 'elb-1',
+                  subgroups: [resultJson[0], resultJson[1]],
+                  isManaged: false,
+                  managedResourceSummary: undefined,
+                },
+              ],
             },
           ]);
           done();
@@ -167,11 +213,15 @@ describe('Service: loadBalancerFilterService', function() {
         expect(LoadBalancerState.filterModel.asFilterModel.groups).toEqual([
           {
             heading: 'prod',
-            subgroups: [{ heading: 'elb-2', subgroups: [resultJson[2]] }],
+            subgroups: [
+              { heading: 'elb-2', subgroups: [resultJson[2]], isManaged: false, managedResourceSummary: undefined },
+            ],
           },
           {
             heading: 'test',
-            subgroups: [{ heading: 'elb-1', subgroups: [resultJson[0]] }],
+            subgroups: [
+              { heading: 'elb-1', subgroups: [resultJson[0]], isManaged: false, managedResourceSummary: undefined },
+            ],
           },
         ]);
         done();
@@ -186,11 +236,20 @@ describe('Service: loadBalancerFilterService', function() {
         expect(LoadBalancerState.filterModel.asFilterModel.groups).toEqual([
           {
             heading: 'prod',
-            subgroups: [{ heading: 'elb-2', subgroups: [resultJson[2]] }],
+            subgroups: [
+              { heading: 'elb-2', subgroups: [resultJson[2]], isManaged: false, managedResourceSummary: undefined },
+            ],
           },
           {
             heading: 'test',
-            subgroups: [{ heading: 'elb-1', subgroups: [resultJson[0], resultJson[1]] }],
+            subgroups: [
+              {
+                heading: 'elb-1',
+                subgroups: [resultJson[0], resultJson[1]],
+                isManaged: false,
+                managedResourceSummary: undefined,
+              },
+            ],
           },
         ]);
         done();
@@ -212,11 +271,15 @@ describe('Service: loadBalancerFilterService', function() {
         expect(LoadBalancerState.filterModel.asFilterModel.groups).toEqual([
           {
             heading: 'prod',
-            subgroups: [{ heading: 'elb-2', subgroups: [resultJson[2]] }],
+            subgroups: [
+              { heading: 'elb-2', subgroups: [resultJson[2]], isManaged: false, managedResourceSummary: undefined },
+            ],
           },
           {
             heading: 'test',
-            subgroups: [{ heading: 'elb-1', subgroups: [resultJson[1]] }],
+            subgroups: [
+              { heading: 'elb-1', subgroups: [resultJson[1]], isManaged: false, managedResourceSummary: undefined },
+            ],
           },
         ]);
         done();
@@ -237,7 +300,9 @@ describe('Service: loadBalancerFilterService', function() {
         expect(LoadBalancerState.filterModel.asFilterModel.groups).toEqual([
           {
             heading: 'test',
-            subgroups: [{ heading: 'elb-1', subgroups: [resultJson[0]] }],
+            subgroups: [
+              { heading: 'elb-1', subgroups: [resultJson[0]], isManaged: false, managedResourceSummary: undefined },
+            ],
           },
         ]);
         done();
@@ -258,7 +323,9 @@ describe('Service: loadBalancerFilterService', function() {
         expect(LoadBalancerState.filterModel.asFilterModel.groups).toEqual([
           {
             heading: 'test',
-            subgroups: [{ heading: 'elb-1', subgroups: [resultJson[0]] }],
+            subgroups: [
+              { heading: 'elb-1', subgroups: [resultJson[0]], isManaged: false, managedResourceSummary: undefined },
+            ],
           },
         ]);
         done();
@@ -280,11 +347,15 @@ describe('Service: loadBalancerFilterService', function() {
         expect(LoadBalancerState.filterModel.asFilterModel.groups).toEqual([
           {
             heading: 'prod',
-            subgroups: [{ heading: 'elb-2', subgroups: [resultJson[2]] }],
+            subgroups: [
+              { heading: 'elb-2', subgroups: [resultJson[2]], isManaged: false, managedResourceSummary: undefined },
+            ],
           },
           {
             heading: 'test',
-            subgroups: [{ heading: 'elb-1', subgroups: [resultJson[0]] }],
+            subgroups: [
+              { heading: 'elb-1', subgroups: [resultJson[0]], isManaged: false, managedResourceSummary: undefined },
+            ],
           },
         ]);
         done();
@@ -299,11 +370,20 @@ describe('Service: loadBalancerFilterService', function() {
         expect(LoadBalancerState.filterModel.asFilterModel.groups).toEqual([
           {
             heading: 'prod',
-            subgroups: [{ heading: 'elb-2', subgroups: [resultJson[2]] }],
+            subgroups: [
+              { heading: 'elb-2', subgroups: [resultJson[2]], isManaged: false, managedResourceSummary: undefined },
+            ],
           },
           {
             heading: 'test',
-            subgroups: [{ heading: 'elb-1', subgroups: [resultJson[0], resultJson[1]] }],
+            subgroups: [
+              {
+                heading: 'elb-1',
+                subgroups: [resultJson[0], resultJson[1]],
+                isManaged: false,
+                managedResourceSummary: undefined,
+              },
+            ],
           },
         ]);
         done();
@@ -318,11 +398,20 @@ describe('Service: loadBalancerFilterService', function() {
         expect(LoadBalancerState.filterModel.asFilterModel.groups).toEqual([
           {
             heading: 'prod',
-            subgroups: [{ heading: 'elb-2', subgroups: [resultJson[2]] }],
+            subgroups: [
+              { heading: 'elb-2', subgroups: [resultJson[2]], isManaged: false, managedResourceSummary: undefined },
+            ],
           },
           {
             heading: 'test',
-            subgroups: [{ heading: 'elb-1', subgroups: [resultJson[0], resultJson[1]] }],
+            subgroups: [
+              {
+                heading: 'elb-1',
+                subgroups: [resultJson[0], resultJson[1]],
+                isManaged: false,
+                managedResourceSummary: undefined,
+              },
+            ],
           },
         ]);
         done();
@@ -337,11 +426,20 @@ describe('Service: loadBalancerFilterService', function() {
       LoadBalancerState.filterModel.asFilterModel.groups = [
         {
           heading: 'prod',
-          subgroups: [{ heading: 'elb-2', subgroups: [resultJson[2]] }],
+          subgroups: [
+            { heading: 'elb-2', subgroups: [resultJson[2]], isManaged: false, managedResourceSummary: undefined },
+          ],
         },
         {
           heading: 'test',
-          subgroups: [{ heading: 'elb-1', subgroups: [resultJson[0], resultJson[1]] }],
+          subgroups: [
+            {
+              heading: 'elb-1',
+              subgroups: [resultJson[0], resultJson[1]],
+              isManaged: false,
+              managedResourceSummary: undefined,
+            },
+          ],
         },
       ];
     });
@@ -360,8 +458,16 @@ describe('Service: loadBalancerFilterService', function() {
           {
             heading: 'elb-1',
             subgroups: [
-              { heading: 'us-east-1', loadBalancer: app.loadBalancers.data[3], serverGroups: [] as IServerGroup[] },
+              {
+                heading: 'us-east-1',
+                loadBalancer: app.loadBalancers.data[3],
+                serverGroups: [] as IServerGroup[],
+                isManaged: false,
+                managedResourceSummary: undefined as IManagedResourceSummary,
+              },
             ],
+            isManaged: false,
+            managedResourceSummary: undefined as IManagedResourceSummary,
           },
         ],
       };
@@ -372,11 +478,20 @@ describe('Service: loadBalancerFilterService', function() {
           newGroup,
           {
             heading: 'prod',
-            subgroups: [{ heading: 'elb-2', subgroups: [resultJson[2]] }],
+            subgroups: [
+              { heading: 'elb-2', subgroups: [resultJson[2]], isManaged: false, managedResourceSummary: undefined },
+            ],
           },
           {
             heading: 'test',
-            subgroups: [{ heading: 'elb-1', subgroups: [resultJson[0], resultJson[1]] }],
+            subgroups: [
+              {
+                heading: 'elb-1',
+                subgroups: [resultJson[0], resultJson[1]],
+                isManaged: false,
+                managedResourceSummary: undefined,
+              },
+            ],
           },
         ]);
         done();
@@ -394,8 +509,16 @@ describe('Service: loadBalancerFilterService', function() {
       const newSubGroup = {
         heading: 'elb-3',
         subgroups: [
-          { heading: 'eu-west-1', loadBalancer: app.loadBalancers.data[3], serverGroups: [] as IServerGroup[] },
+          {
+            heading: 'eu-west-1',
+            loadBalancer: app.loadBalancers.data[3],
+            serverGroups: [] as IServerGroup[],
+            isManaged: false,
+            managedResourceSummary: undefined as IManagedResourceSummary,
+          },
         ],
+        isManaged: false,
+        managedResourceSummary: undefined as IManagedResourceSummary,
       };
       LoadBalancerState.filterService.updateLoadBalancerGroups(app);
 
@@ -403,11 +526,21 @@ describe('Service: loadBalancerFilterService', function() {
         expect(LoadBalancerState.filterModel.asFilterModel.groups).toEqual([
           {
             heading: 'prod',
-            subgroups: [{ heading: 'elb-2', subgroups: [resultJson[2]] }, newSubGroup],
+            subgroups: [
+              { heading: 'elb-2', subgroups: [resultJson[2]], isManaged: false, managedResourceSummary: undefined },
+              newSubGroup,
+            ],
           },
           {
             heading: 'test',
-            subgroups: [{ heading: 'elb-1', subgroups: [resultJson[0], resultJson[1]] }],
+            subgroups: [
+              {
+                heading: 'elb-1',
+                subgroups: [resultJson[0], resultJson[1]],
+                isManaged: false,
+                managedResourceSummary: undefined,
+              },
+            ],
           },
         ]);
         done();
@@ -426,6 +559,8 @@ describe('Service: loadBalancerFilterService', function() {
         heading: 'eu-west-1',
         loadBalancer: app.loadBalancers.data[3],
         serverGroups: [] as IServerGroup[],
+        isManaged: false,
+        managedResourceSummary: undefined as IManagedResourceSummary,
       };
       LoadBalancerState.filterService.updateLoadBalancerGroups(app);
 
@@ -433,13 +568,25 @@ describe('Service: loadBalancerFilterService', function() {
         expect(LoadBalancerState.filterModel.asFilterModel.groups).toEqual([
           {
             heading: 'prod',
-            subgroups: [{ heading: 'elb-2', subgroups: [resultJson[2]] }],
+            subgroups: [
+              {
+                heading: 'elb-2',
+                subgroups: [resultJson[2]],
+                isManaged: false,
+                managedResourceSummary: undefined,
+              },
+            ],
           },
           {
             heading: 'test',
             subgroups: [
-              { heading: 'elb-1', subgroups: [resultJson[0], resultJson[1]] },
-              { heading: 'elb-2', subgroups: [newSubsubGroup] },
+              {
+                heading: 'elb-1',
+                subgroups: [resultJson[0], resultJson[1]],
+                isManaged: false,
+                managedResourceSummary: undefined,
+              },
+              { heading: 'elb-2', subgroups: [newSubsubGroup], isManaged: false, managedResourceSummary: undefined },
             ],
           },
         ]);

--- a/app/scripts/modules/core/src/loadBalancer/filter/LoadBalancerFilterService.ts
+++ b/app/scripts/modules/core/src/loadBalancer/filter/LoadBalancerFilterService.ts
@@ -235,13 +235,18 @@ export class LoadBalancerFilterService {
             heading: loadBalancer.region,
             loadBalancer,
             serverGroups: this.filterServerGroups(loadBalancer),
+            isManaged: !!loadBalancer.isManaged,
+            managedResourceSummary: loadBalancer.managedResourceSummary,
           });
         });
 
         const heading = `${name}${crossTypeLoadBalancerNames[name] && type ? ` (${type})` : ''}`;
+        const allRegionsManaged = subSubGroups.every(({ isManaged }) => isManaged);
         subGroups.push({
           heading,
           subgroups: sortBy(subSubGroups, 'heading'),
+          isManaged: allRegionsManaged,
+          managedResourceSummary: allRegionsManaged ? subSubGroups[0].managedResourceSummary : undefined,
         });
       });
 

--- a/app/scripts/modules/core/src/managed/ManagedReader.ts
+++ b/app/scripts/modules/core/src/managed/ManagedReader.ts
@@ -5,10 +5,13 @@ import { IMoniker } from 'core/naming';
 
 export enum ManagedResourceStatus {
   ACTUATING = 'ACTUATING',
+  CREATED = 'CREATED',
   DIFF = 'DIFF',
   ERROR = 'ERROR',
   HAPPY = 'HAPPY',
+  PAUSED = 'PAUSED',
   UNHAPPY = 'UNHAPPY',
+  UNKNOWN = 'UNKNOWN',
 }
 
 export interface IManagedResourceSummary {

--- a/app/scripts/modules/core/src/managed/ManagedResourceStatusIndicator.less
+++ b/app/scripts/modules/core/src/managed/ManagedResourceStatusIndicator.less
@@ -1,0 +1,28 @@
+.ManagedResourceStatusIndicator {
+  &.info {
+    background-color: var(--color-status-info);
+  }
+
+  &.warning {
+    background-color: var(--color-status-warning);
+  }
+
+  &.error {
+    background-color: var(--color-status-error);
+  }
+
+  &.square {
+    padding: 0 8px;
+    font-size: 20px;
+  }
+
+  &.circle {
+    padding: 4px;
+    font-size: 14px;
+    border-radius: 50%;
+  }
+
+  > i {
+    color: var(--color-white);
+  }
+}

--- a/app/scripts/modules/core/src/managed/ManagedResourceStatusIndicator.tsx
+++ b/app/scripts/modules/core/src/managed/ManagedResourceStatusIndicator.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import * as classNames from 'classnames';
+
+import { IManagedResourceSummary } from 'core/managed';
+
+import './ManagedResourceStatusIndicator.less';
+
+const resourceStatusToClassNames = {
+  ACTUATING: {
+    iconClass: 'icon-md-actuating',
+    colorClass: 'info',
+  },
+  CREATED: {
+    iconClass: 'icon-md-created',
+    colorClass: 'info',
+  },
+  DIFF: {
+    iconClass: 'icon-md-diff',
+    colorClass: 'info',
+  },
+  ERROR: {
+    iconClass: 'icon-md-error',
+    colorClass: 'error',
+  },
+  HAPPY: {
+    iconClass: 'icon-md',
+    colorClass: 'info',
+  },
+  PAUSED: {
+    iconClass: 'icon-md-paused',
+    colorClass: 'warning',
+  },
+  UNHAPPY: {
+    iconClass: 'icon-md-flapping',
+    colorClass: 'error',
+  },
+  UNKNOWN: {
+    iconClass: 'icon-md-unknown',
+    colorClass: 'warning',
+  },
+};
+
+export interface IManagedResourceStatusIndicatorProps {
+  shape: 'square' | 'circle';
+  resourceSummary: IManagedResourceSummary;
+}
+
+export const ManagedResourceStatusIndicator = ({
+  shape,
+  resourceSummary: { status },
+}: IManagedResourceStatusIndicatorProps) => {
+  return (
+    <div
+      className={classNames(
+        'flex-container-h middle ManagedResourceStatusIndicator',
+        shape,
+        resourceStatusToClassNames[status].colorClass,
+      )}
+    >
+      <i className={classNames('fa', resourceStatusToClassNames[status].iconClass)} />
+    </div>
+  );
+};

--- a/app/scripts/modules/core/src/managed/ManagedResourceStatusIndicator.tsx
+++ b/app/scripts/modules/core/src/managed/ManagedResourceStatusIndicator.tsx
@@ -1,44 +1,167 @@
 import * as React from 'react';
+import * as ReactGA from 'react-ga';
 import * as classNames from 'classnames';
+import { UISref } from '@uirouter/react';
 
+import { HoverablePopover } from 'core/presentation';
 import { IManagedResourceSummary } from 'core/managed';
 
 import './ManagedResourceStatusIndicator.less';
 
-const resourceStatusToClassNames = {
+const viewConfigurationByStatus = {
   ACTUATING: {
     iconClass: 'icon-md-actuating',
     colorClass: 'info',
+    popoverContents: (id: string) => (
+      <>
+        <p>
+          <b>Action is being taken to resolve a drift from the declarative configuration.</b>
+        </p>
+        <p>
+          Check the{' '}
+          <UISref to="home.applications.application.tasks">
+            <a>tasks view</a>
+          </UISref>{' '}
+          to see work that's in progress. <LearnMoreLink id={id} />
+        </p>
+      </>
+    ),
   },
   CREATED: {
     iconClass: 'icon-md-created',
     colorClass: 'info',
+    popoverContents: (id: string) => (
+      <>
+        <p>
+          <b>Spinnaker has started continuously managing this resource.</b>
+        </p>
+        <p>
+          If its actual configuration drifts from the declarative configuration, Spinnaker will automatically correct
+          it. Changes made in the UI will be stomped in favor of the declarative configuration.{' '}
+          <LearnMoreLink id={id} />
+        </p>
+      </>
+    ),
   },
   DIFF: {
     iconClass: 'icon-md-diff',
     colorClass: 'info',
+    popoverContents: (id: string) => (
+      <>
+        <p>
+          <b>A drift from the declarative configuration was detected.</b>
+        </p>
+        <p>
+          Spinnaker will automatically take action to bring this resource back to its desired state.{' '}
+          <LearnMoreLink id={id} />
+        </p>
+      </>
+    ),
   },
   ERROR: {
     iconClass: 'icon-md-error',
     colorClass: 'error',
+    popoverContents: (id: string) => (
+      <>
+        <p>
+          <b>Something went wrong.</b>
+        </p>
+        <p>
+          Spinnaker is configured to continuously manage this resource, but something went wrong trying to check its
+          current state. Automatic action can't be taken right now, and manual intervention might be required.{' '}
+          <LearnMoreLink id={id} />
+        </p>
+      </>
+    ),
   },
   HAPPY: {
     iconClass: 'icon-md',
     colorClass: 'info',
+    popoverContents: (id: string) => (
+      <>
+        <p>
+          <b>Spinnaker is continuously managing this resource.</b>
+        </p>
+        <p>
+          Changes made in the UI will be stomped in favor of the declarative configuration. <LearnMoreLink id={id} />
+        </p>
+      </>
+    ),
   },
   PAUSED: {
     iconClass: 'icon-md-paused',
     colorClass: 'warning',
+    popoverContents: (id: string) => (
+      <>
+        <p>
+          <b>Continuous management is paused.</b>
+        </p>
+        <p>
+          Spinnaker is configured to continuously manage this resource, but management is temporarily paused. You can
+          resume management on the{' '}
+          <UISref to="home.applications.application.config" params={{ section: 'managed-resources' }}>
+            <a>config view</a>
+          </UISref>
+          . <LearnMoreLink id={id} />
+        </p>
+      </>
+    ),
   },
   UNHAPPY: {
     iconClass: 'icon-md-flapping',
     colorClass: 'error',
+    popoverContents: (id: string) => (
+      <>
+        <p>
+          <b>A drift from the declarative configuration was detected, but Spinnaker hasn't been able to correct it.</b>
+        </p>
+        <p>
+          Spinnaker has been trying to correct a detected drift, but taking automatic action hasn't helped. Manual
+          intervention might be required.
+        </p>
+        <p>
+          You can temporarily pause management on the{' '}
+          <UISref to="home.applications.application.config" params={{ section: 'managed-resources' }}>
+            <a>config view</a>
+          </UISref>{' '}
+          to troubleshoot or make manual changes. <LearnMoreLink id={id} />
+        </p>
+      </>
+    ),
   },
   UNKNOWN: {
     iconClass: 'icon-md-unknown',
     colorClass: 'warning',
+    popoverContents: (id: string) => (
+      <>
+        <p>
+          <b>Unable to determine resource status.</b>
+        </p>
+        <p>
+          Spinnaker is configured to continuously manage this resource, but its current status can't be calculated right
+          now. <LearnMoreLink id={id} />
+        </p>
+      </>
+    ),
   },
 };
+
+const logClick = (label: string, resourceId: string) =>
+  ReactGA.event({
+    category: 'Managed Resource Status Indicator',
+    action: `${label} clicked`,
+    label: resourceId,
+  });
+
+const LearnMoreLink = ({ id }: { id: string }) => (
+  <a
+    target="_blank"
+    onClick={() => logClick('Learn More', id)}
+    href="https://www.spinnaker.io/reference/managed-delivery"
+  >
+    Learn More
+  </a>
+);
 
 export interface IManagedResourceStatusIndicatorProps {
   shape: 'square' | 'circle';
@@ -47,17 +170,20 @@ export interface IManagedResourceStatusIndicatorProps {
 
 export const ManagedResourceStatusIndicator = ({
   shape,
-  resourceSummary: { status },
+  resourceSummary: { id, status },
 }: IManagedResourceStatusIndicatorProps) => {
   return (
-    <div
-      className={classNames(
+    <HoverablePopover
+      template={viewConfigurationByStatus[status].popoverContents(id)}
+      placement="left"
+      style={{ display: 'flex' }}
+      wrapperClassName={classNames(
         'flex-container-h middle ManagedResourceStatusIndicator',
         shape,
-        resourceStatusToClassNames[status].colorClass,
+        viewConfigurationByStatus[status].colorClass,
       )}
     >
-      <i className={classNames('fa', resourceStatusToClassNames[status].iconClass)} />
-    </div>
+      <i className={classNames('fa', viewConfigurationByStatus[status].iconClass)} />
+    </HoverablePopover>
   );
 };

--- a/app/scripts/modules/core/src/managed/index.ts
+++ b/app/scripts/modules/core/src/managed/index.ts
@@ -2,5 +2,6 @@ export * from './ManagedReader';
 export * from './ManagedWriter';
 export * from './ManagedResourceDetailsIndicator';
 export * from './managedResourceDetailsIndicator.component';
+export * from './ManagedResourceStatusIndicator';
 export * from './managed.dataSource';
 export * from './managedResourceDecorators';

--- a/app/scripts/modules/core/src/managed/index.ts
+++ b/app/scripts/modules/core/src/managed/index.ts
@@ -2,6 +2,7 @@ export * from './ManagedReader';
 export * from './ManagedWriter';
 export * from './ManagedResourceDetailsIndicator';
 export * from './managedResourceDetailsIndicator.component';
+export * from './managedResourceStatusIndicator.component';
 export * from './ManagedResourceStatusIndicator';
 export * from './managed.dataSource';
 export * from './managedResourceDecorators';

--- a/app/scripts/modules/core/src/managed/managedResourceStatusIndicator.component.ts
+++ b/app/scripts/modules/core/src/managed/managedResourceStatusIndicator.component.ts
@@ -1,0 +1,10 @@
+import { module } from 'angular';
+import { react2angular } from 'react2angular';
+
+import { ManagedResourceStatusIndicator } from './ManagedResourceStatusIndicator';
+
+export const MANAGED_RESOURCE_STATUS_INDICATOR = 'spinnaker.core.managed.resourceStatusIndicator.component';
+module(MANAGED_RESOURCE_STATUS_INDICATOR, []).component(
+  'managedResourceStatusIndicator',
+  react2angular(ManagedResourceStatusIndicator, ['shape', 'resourceSummary']),
+);

--- a/app/scripts/modules/core/src/presentation/HoverablePopover.tsx
+++ b/app/scripts/modules/core/src/presentation/HoverablePopover.tsx
@@ -28,7 +28,10 @@ export interface IHoverablePopoverProps extends React.HTMLProps<any> {
   hOffsetPercent?: string;
   /** class to put on the popover content */
   className?: string;
-
+  /** class to put on the outermost element */
+  wrapperClassName?: string;
+  /** custom style attributes */
+  style?: React.CSSProperties;
   /** Rendered on the top of the popover content */
   title?: string;
   id?: string;
@@ -146,7 +149,18 @@ export class HoverablePopover extends React.Component<IHoverablePopoverProps, IH
   };
 
   public render() {
-    const { Component, template, placement, container, hOffsetPercent, id, title, className } = this.props;
+    const {
+      Component,
+      template,
+      placement,
+      container,
+      hOffsetPercent,
+      id,
+      title,
+      className,
+      wrapperClassName,
+      style,
+    } = this.props;
     const { popoverIsOpen, animation, placementOverride } = this.state;
     const { Wrapper } = this;
 
@@ -157,7 +171,12 @@ export class HoverablePopover extends React.Component<IHoverablePopoverProps, IH
     );
 
     return (
-      <Wrapper style={{ display: 'inline' }} onMouseEnter={this.handleMouseEvent} onMouseLeave={this.handleMouseEvent}>
+      <Wrapper
+        className={wrapperClassName}
+        style={{ display: 'inline', ...style }}
+        onMouseEnter={this.handleMouseEvent}
+        onMouseLeave={this.handleMouseEvent}
+      >
         {this.props.children}
         <Overlay
           show={popoverIsOpen}

--- a/app/scripts/modules/core/src/securityGroup/AllSecurityGroupsCtrl.js
+++ b/app/scripts/modules/core/src/securityGroup/AllSecurityGroupsCtrl.js
@@ -9,11 +9,16 @@ import { SETTINGS } from 'core/config/settings';
 import { FirewallLabels } from './label/FirewallLabels';
 import { SecurityGroupState } from 'core/state';
 import { noop } from 'core/utils';
+import { MANAGED_RESOURCE_STATUS_INDICATOR } from 'core/managed';
 
 const angular = require('angular');
 
 module.exports = angular
-  .module('spinnaker.core.securityGroup.all.controller', [SKIN_SELECTION_SERVICE, require('angular-ui-bootstrap')])
+  .module('spinnaker.core.securityGroup.all.controller', [
+    SKIN_SELECTION_SERVICE,
+    require('angular-ui-bootstrap'),
+    MANAGED_RESOURCE_STATUS_INDICATOR,
+  ])
   .controller('AllSecurityGroupsCtrl', [
     '$scope',
     'app',
@@ -69,7 +74,11 @@ module.exports = angular
 
       function createSecurityGroupProviderFilterFn(application, account, provider) {
         const sgConfig = provider.securityGroup;
-        return sgConfig && (sgConfig.CreateSecurityGroupModal || (sgConfig.createSecurityGroupTemplateUrl && sgConfig.createSecurityGroupController));
+        return (
+          sgConfig &&
+          (sgConfig.CreateSecurityGroupModal ||
+            (sgConfig.createSecurityGroupTemplateUrl && sgConfig.createSecurityGroupController))
+        );
       }
 
       this.createSecurityGroup = function createSecurityGroup() {

--- a/app/scripts/modules/core/src/securityGroup/filter/SecurityGroupFilterService.spec.js
+++ b/app/scripts/modules/core/src/securityGroup/filter/SecurityGroupFilterService.spec.js
@@ -20,9 +20,27 @@ describe('Service: securityGroupFilterService', function() {
       },
     };
     resultJson = [
-      { heading: 'us-east-1', vpcName: '', securityGroup: app.securityGroups.data[0] },
-      { heading: 'us-west-1 (main)', vpcName: 'main', securityGroup: app.securityGroups.data[1] },
-      { heading: 'us-east-1', vpcName: '', securityGroup: app.securityGroups.data[2] },
+      {
+        heading: 'us-east-1',
+        vpcName: '',
+        securityGroup: app.securityGroups.data[0],
+        isManaged: false,
+        managedResourceSummary: undefined,
+      },
+      {
+        heading: 'us-west-1 (main)',
+        vpcName: 'main',
+        securityGroup: app.securityGroups.data[1],
+        isManaged: false,
+        managedResourceSummary: undefined,
+      },
+      {
+        heading: 'us-east-1',
+        vpcName: '',
+        securityGroup: app.securityGroups.data[2],
+        isManaged: false,
+        managedResourceSummary: undefined,
+      },
     ];
     State.SecurityGroupState.filterModel.asFilterModel.clearFilters();
   });
@@ -32,11 +50,20 @@ describe('Service: securityGroupFilterService', function() {
       var expected = [
         {
           heading: 'prod',
-          subgroups: [{ heading: 'sg-2', subgroups: [resultJson[2]] }],
+          subgroups: [
+            { heading: 'sg-2', subgroups: [resultJson[2]], isManaged: false, managedResourceSummary: undefined },
+          ],
         },
         {
           heading: 'test',
-          subgroups: [{ heading: 'sg-1', subgroups: [resultJson[0], resultJson[1]] }],
+          subgroups: [
+            {
+              heading: 'sg-1',
+              subgroups: [resultJson[0], resultJson[1]],
+              isManaged: false,
+              managedResourceSummary: undefined,
+            },
+          ],
         },
       ];
       State.SecurityGroupState.filterService.updateSecurityGroups(app);
@@ -64,7 +91,9 @@ describe('Service: securityGroupFilterService', function() {
         expect(State.SecurityGroupState.filterModel.asFilterModel.groups).toEqual([
           {
             heading: 'test',
-            subgroups: [{ heading: 'sg-1', subgroups: [resultJson[1]] }],
+            subgroups: [
+              { heading: 'sg-1', subgroups: [resultJson[1]], isManaged: false, managedResourceSummary: undefined },
+            ],
           },
         ]);
       });
@@ -83,7 +112,9 @@ describe('Service: securityGroupFilterService', function() {
         expect(State.SecurityGroupState.filterModel.asFilterModel.groups).toEqual([
           {
             heading: 'prod',
-            subgroups: [{ heading: 'sg-2', subgroups: [resultJson[2]] }],
+            subgroups: [
+              { heading: 'sg-2', subgroups: [resultJson[2]], isManaged: false, managedResourceSummary: undefined },
+            ],
           },
         ]);
       });
@@ -94,11 +125,20 @@ describe('Service: securityGroupFilterService', function() {
         expect(State.SecurityGroupState.filterModel.asFilterModel.groups).toEqual([
           {
             heading: 'prod',
-            subgroups: [{ heading: 'sg-2', subgroups: [resultJson[2]] }],
+            subgroups: [
+              { heading: 'sg-2', subgroups: [resultJson[2]], isManaged: false, managedResourceSummary: undefined },
+            ],
           },
           {
             heading: 'test',
-            subgroups: [{ heading: 'sg-1', subgroups: [resultJson[0], resultJson[1]] }],
+            subgroups: [
+              {
+                heading: 'sg-1',
+                subgroups: [resultJson[0], resultJson[1]],
+                isManaged: false,
+                managedResourceSummary: undefined,
+              },
+            ],
           },
         ]);
       });
@@ -113,11 +153,15 @@ describe('Service: securityGroupFilterService', function() {
       expect(State.SecurityGroupState.filterModel.asFilterModel.groups).toEqual([
         {
           heading: 'prod',
-          subgroups: [{ heading: 'sg-2', subgroups: [resultJson[2]] }],
+          subgroups: [
+            { heading: 'sg-2', subgroups: [resultJson[2]], isManaged: false, managedResourceSummary: undefined },
+          ],
         },
         {
           heading: 'test',
-          subgroups: [{ heading: 'sg-1', subgroups: [resultJson[0]] }],
+          subgroups: [
+            { heading: 'sg-1', subgroups: [resultJson[0]], isManaged: false, managedResourceSummary: undefined },
+          ],
         },
       ]);
     });
@@ -129,11 +173,20 @@ describe('Service: securityGroupFilterService', function() {
       expect(State.SecurityGroupState.filterModel.asFilterModel.groups).toEqual([
         {
           heading: 'prod',
-          subgroups: [{ heading: 'sg-2', subgroups: [resultJson[2]] }],
+          subgroups: [
+            { heading: 'sg-2', subgroups: [resultJson[2]], isManaged: false, managedResourceSummary: undefined },
+          ],
         },
         {
           heading: 'test',
-          subgroups: [{ heading: 'sg-1', subgroups: [resultJson[0], resultJson[1]] }],
+          subgroups: [
+            {
+              heading: 'sg-1',
+              subgroups: [resultJson[0], resultJson[1]],
+              isManaged: false,
+              managedResourceSummary: undefined,
+            },
+          ],
         },
       ]);
     });
@@ -151,11 +204,15 @@ describe('Service: securityGroupFilterService', function() {
       expect(State.SecurityGroupState.filterModel.asFilterModel.groups).toEqual([
         {
           heading: 'prod',
-          subgroups: [{ heading: 'sg-2', subgroups: [resultJson[2]] }],
+          subgroups: [
+            { heading: 'sg-2', subgroups: [resultJson[2]], isManaged: false, managedResourceSummary: undefined },
+          ],
         },
         {
           heading: 'test',
-          subgroups: [{ heading: 'sg-1', subgroups: [resultJson[0]] }],
+          subgroups: [
+            { heading: 'sg-1', subgroups: [resultJson[0]], isManaged: false, managedResourceSummary: undefined },
+          ],
         },
       ]);
     });
@@ -166,11 +223,20 @@ describe('Service: securityGroupFilterService', function() {
       expect(State.SecurityGroupState.filterModel.asFilterModel.groups).toEqual([
         {
           heading: 'prod',
-          subgroups: [{ heading: 'sg-2', subgroups: [resultJson[2]] }],
+          subgroups: [
+            { heading: 'sg-2', subgroups: [resultJson[2]], isManaged: false, managedResourceSummary: undefined },
+          ],
         },
         {
           heading: 'test',
-          subgroups: [{ heading: 'sg-1', subgroups: [resultJson[0], resultJson[1]] }],
+          subgroups: [
+            {
+              heading: 'sg-1',
+              subgroups: [resultJson[0], resultJson[1]],
+              isManaged: false,
+              managedResourceSummary: undefined,
+            },
+          ],
         },
       ]);
     });
@@ -181,11 +247,20 @@ describe('Service: securityGroupFilterService', function() {
       expect(State.SecurityGroupState.filterModel.asFilterModel.groups).toEqual([
         {
           heading: 'prod',
-          subgroups: [{ heading: 'sg-2', subgroups: [resultJson[2]] }],
+          subgroups: [
+            { heading: 'sg-2', subgroups: [resultJson[2]], isManaged: false, managedResourceSummary: undefined },
+          ],
         },
         {
           heading: 'test',
-          subgroups: [{ heading: 'sg-1', subgroups: [resultJson[0], resultJson[1]] }],
+          subgroups: [
+            {
+              heading: 'sg-1',
+              subgroups: [resultJson[0], resultJson[1]],
+              isManaged: false,
+              managedResourceSummary: undefined,
+            },
+          ],
         },
       ]);
     });
@@ -198,11 +273,20 @@ describe('Service: securityGroupFilterService', function() {
       State.SecurityGroupState.filterModel.asFilterModel.groups = [
         {
           heading: 'prod',
-          subgroups: [{ heading: 'sg-2', subgroups: [resultJson[2]] }],
+          subgroups: [
+            { heading: 'sg-2', subgroups: [resultJson[2]], isManaged: false, managedResourceSummary: undefined },
+          ],
         },
         {
           heading: 'test',
-          subgroups: [{ heading: 'sg-1', subgroups: [resultJson[0], resultJson[1]] }],
+          subgroups: [
+            {
+              heading: 'sg-1',
+              subgroups: [resultJson[0], resultJson[1]],
+              isManaged: false,
+              managedResourceSummary: undefined,
+            },
+          ],
         },
       ];
     });
@@ -219,7 +303,17 @@ describe('Service: securityGroupFilterService', function() {
         subgroups: [
           {
             heading: 'sg-1',
-            subgroups: [{ heading: 'us-east-1', vpcName: '', securityGroup: app.securityGroups.data[3] }],
+            subgroups: [
+              {
+                heading: 'us-east-1',
+                vpcName: '',
+                securityGroup: app.securityGroups.data[3],
+                isManaged: false,
+                managedResourceSummary: undefined,
+              },
+            ],
+            isManaged: false,
+            managedResourceSummary: undefined,
           },
         ],
       };
@@ -228,11 +322,20 @@ describe('Service: securityGroupFilterService', function() {
         newGroup,
         {
           heading: 'prod',
-          subgroups: [{ heading: 'sg-2', subgroups: [resultJson[2]] }],
+          subgroups: [
+            { heading: 'sg-2', subgroups: [resultJson[2]], isManaged: false, managedResourceSummary: undefined },
+          ],
         },
         {
           heading: 'test',
-          subgroups: [{ heading: 'sg-1', subgroups: [resultJson[0], resultJson[1]] }],
+          subgroups: [
+            {
+              heading: 'sg-1',
+              subgroups: [resultJson[0], resultJson[1]],
+              isManaged: false,
+              managedResourceSummary: undefined,
+            },
+          ],
         },
       ]);
     });
@@ -246,17 +349,37 @@ describe('Service: securityGroupFilterService', function() {
       });
       var newSubGroup = {
         heading: 'sg-3',
-        subgroups: [{ heading: 'eu-west-1', vpcName: '', securityGroup: app.securityGroups.data[3] }],
+        subgroups: [
+          {
+            heading: 'eu-west-1',
+            vpcName: '',
+            securityGroup: app.securityGroups.data[3],
+            isManaged: false,
+            managedResourceSummary: undefined,
+          },
+        ],
+        isManaged: false,
+        managedResourceSummary: undefined,
       };
       State.SecurityGroupState.filterService.updateSecurityGroups(app);
       expect(State.SecurityGroupState.filterModel.asFilterModel.groups).toEqual([
         {
           heading: 'prod',
-          subgroups: [{ heading: 'sg-2', subgroups: [resultJson[2]] }, newSubGroup],
+          subgroups: [
+            { heading: 'sg-2', subgroups: [resultJson[2]], isManaged: false, managedResourceSummary: undefined },
+            newSubGroup,
+          ],
         },
         {
           heading: 'test',
-          subgroups: [{ heading: 'sg-1', subgroups: [resultJson[0], resultJson[1]] }],
+          subgroups: [
+            {
+              heading: 'sg-1',
+              subgroups: [resultJson[0], resultJson[1]],
+              isManaged: false,
+              managedResourceSummary: undefined,
+            },
+          ],
         },
       ]);
     });
@@ -268,18 +391,31 @@ describe('Service: securityGroupFilterService', function() {
         region: 'eu-west-1',
         vpcName: '',
       });
-      var newSubsubGroup = { heading: 'eu-west-1', vpcName: '', securityGroup: app.securityGroups.data[3] };
+      var newSubsubGroup = {
+        heading: 'eu-west-1',
+        vpcName: '',
+        securityGroup: app.securityGroups.data[3],
+        isManaged: false,
+        managedResourceSummary: undefined,
+      };
       State.SecurityGroupState.filterService.updateSecurityGroups(app);
       expect(State.SecurityGroupState.filterModel.asFilterModel.groups).toEqual([
         {
           heading: 'prod',
-          subgroups: [{ heading: 'sg-2', subgroups: [resultJson[2]] }],
+          subgroups: [
+            { heading: 'sg-2', subgroups: [resultJson[2]], isManaged: false, managedResourceSummary: undefined },
+          ],
         },
         {
           heading: 'test',
           subgroups: [
-            { heading: 'sg-1', subgroups: [resultJson[0], resultJson[1]] },
-            { heading: 'sg-2', subgroups: [newSubsubGroup] },
+            {
+              heading: 'sg-1',
+              subgroups: [resultJson[0], resultJson[1]],
+              isManaged: false,
+              managedResourceSummary: undefined,
+            },
+            { heading: 'sg-2', subgroups: [newSubsubGroup], isManaged: false, managedResourceSummary: undefined },
           ],
         },
       ]);

--- a/app/scripts/modules/core/src/securityGroup/filter/SecurityGroupFilterService.ts
+++ b/app/scripts/modules/core/src/securityGroup/filter/SecurityGroupFilterService.ts
@@ -131,11 +131,17 @@ export class SecurityGroupFilterService {
             heading,
             vpcName: securityGroup.vpcName,
             securityGroup,
+            isManaged: !!securityGroup.isManaged,
+            managedResourceSummary: securityGroup.managedResourceSummary,
           });
         });
+
+        const allRegionsManaged = subSubGroups.every(({ isManaged }) => isManaged);
         subGroups.push({
           heading: subKey,
           subgroups: sortBy(subSubGroups, ['heading', 'vpcName']),
+          isManaged: allRegionsManaged,
+          managedResourceSummary: allRegionsManaged ? subSubGroups[0].managedResourceSummary : undefined,
         });
       });
 

--- a/app/scripts/modules/core/src/securityGroup/securityGroup.directive.js
+++ b/app/scripts/modules/core/src/securityGroup/securityGroup.directive.js
@@ -14,12 +14,14 @@ module.exports = angular.module('spinnaker.core.securityGroup.directive', []).di
       scope: {
         application: '=',
         securityGroup: '=',
+        parentGrouping: '=',
         sortFilter: '=',
         heading: '=',
       },
       link: function(scope) {
         scope.sortFilter = SecurityGroupState.filterModel.asFilterModel.sortFilter;
         scope.$state = $rootScope.$state;
+        scope.showManagedIndicator = !scope.parentGrouping.isManaged && scope.securityGroup.isManaged;
 
         const securityGroup = scope.securityGroup;
         scope.srefParams = {

--- a/app/scripts/modules/core/src/securityGroup/securityGroup.html
+++ b/app/scripts/modules/core/src/securityGroup/securityGroup.html
@@ -7,6 +7,12 @@
     <span class="glyphicon glyphicon-transfer"></span>&nbsp;
     <div className="flex-1">{{heading | uppercase}}</div>
 
+    <managed-resource-status-indicator
+      class="sp-margin-s-left"
+      ng-if="showManagedIndicator"
+      shape="'circle'"
+      resource-summary="securityGroup.managedResourceSummary"
+    ></managed-resource-status-indicator>
     <entity-notifications
       entity="securityGroup"
       application="application"

--- a/app/scripts/modules/core/src/securityGroup/securityGroupPod.html
+++ b/app/scripts/modules/core/src/securityGroup/securityGroupPod.html
@@ -4,11 +4,17 @@
       <div class="heading-tag">
         <account-tag account="parentHeading"></account-tag>
       </div>
-      <div class="pod-center horizontal space-between center flex-1">
+      <div class="pod-center horizontal space-between flex-1 no-right-padding">
         <div>
           <span class="glyphicon glyphicon-transfer"></span>
           {{grouping.heading}}
         </div>
+        <managed-resource-status-indicator
+          class="flex-container-h"
+          ng-if="grouping.isManaged"
+          shape="'square'"
+          resource-summary="grouping.managedResourceSummary"
+        ></managed-resource-status-indicator>
       </div>
     </div>
   </div>
@@ -17,6 +23,7 @@
       <security-group
         application="application"
         security-group="subgroup.securityGroup"
+        parent-grouping="grouping"
         heading="subgroup.heading"
         sort-filter="sortFilter"
       ></security-group>


### PR DESCRIPTION
We recently [added the ability to calculate a summarized "status"](https://github.com/spinnaker/keel/pull/433) for every declaratively managed resource. This status can indicate a variety of different states from the keel perspective, and provide valuable transparency into what's going on during normal operations and especially when something is wrong / abnormal. This PR adds iconography and explanatory text to Clusters, Load Balancers, and Firewalls with roughly similar visual style (screenshots below).

The PR itself is split into pretty atomic commits, I recommend going through them in order as a lot of the code is similar for each type of infrastructure and you can pattern match after the first couple of commits.

**Example of what this looks like when _all regions_ for a particular account + name grouping is managed:**
<details>
<summary>Cluster (all regions)</summary>
<img width="735" alt="Screen Shot 2019-10-31 at 5 34 14 PM" src="https://user-images.githubusercontent.com/1850998/67994881-e004f200-fc04-11e9-99f7-3684a24b445e.png">
</details>
<details>
<summary>Load Balancer (all regions)</summary>
<img width="739" alt="Screen Shot 2019-10-31 at 5 35 16 PM" src="https://user-images.githubusercontent.com/1850998/67994885-e5fad300-fc04-11e9-96db-32ba1fe2f49e.png">
</details>
<details>
<summary>Firewall (all regions)</summary>
<img width="742" alt="Screen Shot 2019-10-31 at 5 35 26 PM" src="https://user-images.githubusercontent.com/1850998/67994890-eeeba480-fc04-11e9-81ec-a389dee4c912.png">
</details>

**And examples of when _only some_ regions are managed:**
<details>
<summary>Cluster (some regions)</summary>
<img width="741" alt="Screen Shot 2019-10-31 at 5 38 39 PM" src="https://user-images.githubusercontent.com/1850998/67995064-b8faf000-fc05-11e9-8ee6-31abe9f52022.png">
</details>
<details>
<summary>Load Balancer (some regions)</summary>
<img width="738" alt="Screen Shot 2019-10-31 at 5 39 42 PM" src="https://user-images.githubusercontent.com/1850998/67995020-910b8c80-fc05-11e9-8b3e-ccc281faf1e3.png">
</details>
<details>
<summary>Firewall (some regions)</summary>
<img width="744" alt="Screen Shot 2019-10-31 at 5 40 25 PM" src="https://user-images.githubusercontent.com/1850998/67995069-c1532b00-fc05-11e9-9e2e-cbe5214aaca7.png">
</details>

**And finally, examples of the iconography and microcopy for each status a resource can be in:**
<details>
<summary>HAPPY</summary>
<img width="467" alt="status-happy" src="https://user-images.githubusercontent.com/1850998/67995105-04ad9980-fc06-11e9-9456-687e0f37b1e6.png">
</details>
<details>
<summary>CREATED</summary>
<img width="472" alt="status-created" src="https://user-images.githubusercontent.com/1850998/67995111-0e370180-fc06-11e9-85e0-d20772a3a7f8.png">
</details>
<details>
<summary>DIFF</summary>
<img width="480" alt="status-diff" src="https://user-images.githubusercontent.com/1850998/67995119-12fbb580-fc06-11e9-96d9-a5d422face1e.png">
</details>
<details>
<summary>ACTUATING</summary>
<img width="494" alt="status-actuating" src="https://user-images.githubusercontent.com/1850998/67995126-198a2d00-fc06-11e9-8b1a-2c8bf3287c25.png">
</details>
<details>
<summary>PAUSED</summary>
<img width="463" alt="status-paused" src="https://user-images.githubusercontent.com/1850998/67995148-33c40b00-fc06-11e9-8cb4-cd41356b3d74.png">
</details>
<details>
<summary>UNKNOWN</summary>
<img width="462" alt="status-unknown" src="https://user-images.githubusercontent.com/1850998/67995150-37579200-fc06-11e9-93e4-15b55916b5ac.png">
</details>
<details>
<summary>ERROR</summary>
<img width="488" alt="status-error" src="https://user-images.githubusercontent.com/1850998/67995156-3e7ea000-fc06-11e9-99b9-f7b9cfc603cc.png">
</details>
<details>
<summary>UNHAPPY</summary>
<img width="473" alt="status-unhappy" src="https://user-images.githubusercontent.com/1850998/67995159-42122700-fc06-11e9-9431-6133a1611e8d.png">
</details>

There's a lot of copy and whatnot in this PR, so your help and feedback is appreciated around things like typos, wording, clarity, etc. (cc @gcomstock)