### PR TITLE
feat(dataSources): log runtime error when defaultData isn't provided

### DIFF
--- a/app/scripts/modules/core/src/application/service/applicationDataSource.ts
+++ b/app/scripts/modules/core/src/application/service/applicationDataSource.ts
@@ -343,6 +343,14 @@ export class ApplicationDataSource<T = any> implements IDataSourceConfig<T> {
   constructor(config: IDataSourceConfig<T>, private application: Application) {
     Object.assign(this, config);
 
+    if (!config.hasOwnProperty('defaultData')) {
+      console.error(
+        'The defaultData field is required when registering a data source.\n\n' +
+          'defaultData accepts the initial default value that will be used before data has been fetched.\n' +
+          'For example, if your data source holds an array of objects, you should set defaultData to an empty array.',
+      );
+    }
+
     this.data = this.data || this.defaultData;
     this.label = FirewallLabels.get(config.label || robotToHuman(config.key));
 


### PR DESCRIPTION
Since this is a new required field and might unexpectedly mess up someone's custom data source in a non-obvious way, let's log an error with some context to make the resolution more obvious.

I originally wanted to just throw a full-on `Error`, but those always get swallowed and end up making the application fail to load without showing up in the console.