### PR TITLE
fix(core/presentation): remove style + wrapperClassName from HoverablePopover

### DIFF
--- a/app/scripts/modules/core/src/managed/ManagedResourceStatusIndicator.less
+++ b/app/scripts/modules/core/src/managed/ManagedResourceStatusIndicator.less
@@ -1,28 +1,32 @@
 .ManagedResourceStatusIndicator {
-  &.info {
+  .HoverablePopover {
+    display: flex;
+  }
+
+  .info {
     background-color: var(--color-status-info);
   }
 
-  &.warning {
+  .warning {
     background-color: var(--color-status-warning);
   }
 
-  &.error {
+  .error {
     background-color: var(--color-status-error);
   }
 
-  &.square {
+  .square {
     padding: 0 8px;
     font-size: 20px;
   }
 
-  &.circle {
+  .circle {
     padding: 4px;
     font-size: 14px;
     border-radius: 50%;
   }
 
-  > i {
+  i {
     color: var(--color-white);
   }
 }

--- a/app/scripts/modules/core/src/managed/ManagedResourceStatusIndicator.tsx
+++ b/app/scripts/modules/core/src/managed/ManagedResourceStatusIndicator.tsx
@@ -173,17 +173,12 @@ export const ManagedResourceStatusIndicator = ({
   resourceSummary: { id, status },
 }: IManagedResourceStatusIndicatorProps) => {
   return (
-    <HoverablePopover
-      template={viewConfigurationByStatus[status].popoverContents(id)}
-      placement="left"
-      style={{ display: 'flex' }}
-      wrapperClassName={classNames(
-        'flex-container-h middle ManagedResourceStatusIndicator',
-        shape,
-        viewConfigurationByStatus[status].colorClass,
-      )}
-    >
-      <i className={classNames('fa', viewConfigurationByStatus[status].iconClass)} />
-    </HoverablePopover>
+    <div className="flex-container-h stretch ManagedResourceStatusIndicator">
+      <HoverablePopover template={viewConfigurationByStatus[status].popoverContents(id)} placement="left">
+        <div className={classNames('flex-container-h middle', shape, viewConfigurationByStatus[status].colorClass)}>
+          <i className={classNames('fa', viewConfigurationByStatus[status].iconClass)} />
+        </div>
+      </HoverablePopover>
+    </div>
   );
 };

--- a/app/scripts/modules/core/src/presentation/HoverablePopover.css
+++ b/app/scripts/modules/core/src/presentation/HoverablePopover.css
@@ -1,0 +1,3 @@
+.HoverablePopover {
+  display: inline;
+}

--- a/app/scripts/modules/core/src/presentation/HoverablePopover.tsx
+++ b/app/scripts/modules/core/src/presentation/HoverablePopover.tsx
@@ -6,6 +6,8 @@ import { Observable, Subject } from 'rxjs';
 import { Placement } from 'core/presentation';
 import { UUIDGenerator } from 'core/utils';
 
+import './HoverablePopover.css';
+
 export interface IHoverablePopoverContentsProps extends IHoverablePopoverProps {
   // The popover contents can forcibly hide the popover by calling this function
   hidePopover: () => void;
@@ -28,10 +30,6 @@ export interface IHoverablePopoverProps extends React.HTMLProps<any> {
   hOffsetPercent?: string;
   /** class to put on the popover content */
   className?: string;
-  /** class to put on the outermost element */
-  wrapperClassName?: string;
-  /** custom style attributes */
-  style?: React.CSSProperties;
   /** Rendered on the top of the popover content */
   title?: string;
   id?: string;
@@ -149,18 +147,7 @@ export class HoverablePopover extends React.Component<IHoverablePopoverProps, IH
   };
 
   public render() {
-    const {
-      Component,
-      template,
-      placement,
-      container,
-      hOffsetPercent,
-      id,
-      title,
-      className,
-      wrapperClassName,
-      style,
-    } = this.props;
+    const { Component, template, placement, container, hOffsetPercent, id, title, className } = this.props;
     const { popoverIsOpen, animation, placementOverride } = this.state;
     const { Wrapper } = this;
 
@@ -171,12 +158,7 @@ export class HoverablePopover extends React.Component<IHoverablePopoverProps, IH
     );
 
     return (
-      <Wrapper
-        className={wrapperClassName}
-        style={{ display: 'inline', ...style }}
-        onMouseEnter={this.handleMouseEvent}
-        onMouseLeave={this.handleMouseEvent}
-      >
+      <Wrapper className="HoverablePopover" onMouseEnter={this.handleMouseEvent} onMouseLeave={this.handleMouseEvent}>
         {this.props.children}
         <Overlay
           show={popoverIsOpen}


### PR DESCRIPTION
[As previously discussed](https://github.com/spinnaker/deck/pull/7590#discussion_r341455641) in the PR that added them, expanding the HoverablePopover API to include `style` and `wrapperClassName` felt like bloat and I was hoping to find a way to avoid that expansion before they caught on and became popular 😄 

The approach is to take a small specificity risk in moving from inline -> class styles for the popover target wrapper, and then do overrides in the consuming component. I'm guessing there will be one or two places that eventually pop up with slightly weird styling because of specificity silliness, but didn't see anything alarming with a brief trip around the main views / some forms / etc.