### PR TITLE
fix(core/application): add error state to application models, log exceptions

### DIFF
--- a/app/scripts/modules/core/src/application/ApplicationComponent.tsx
+++ b/app/scripts/modules/core/src/application/ApplicationComponent.tsx
@@ -28,7 +28,7 @@ export class ApplicationComponent extends React.Component<IApplicationComponentP
   }
 
   private mountApplication(app: Application) {
-    if (app.notFound) {
+    if (app.notFound || app.hasError) {
       RecentHistoryService.removeLastItem('applications');
       return;
     }
@@ -38,7 +38,7 @@ export class ApplicationComponent extends React.Component<IApplicationComponentP
   }
 
   private unmountApplication(app: Application) {
-    if (app.notFound) {
+    if (app.notFound || app.hasError) {
       return;
     }
     DebugWindow.application = undefined;
@@ -49,12 +49,20 @@ export class ApplicationComponent extends React.Component<IApplicationComponentP
     const { app } = this.props;
     return (
       <div className="application">
-        {!app.notFound && <ApplicationHeader app={app} />}
+        {!app.notFound && !app.hasError && <ApplicationHeader app={app} />}
         {app.notFound && (
           <div>
             <h2 className="text-center">Application Not Found</h2>
             <p className="text-center" style={{ marginBottom: '20px' }}>
               Please check your URL - we can't find any data for <em>{app.name}</em>.
+            </p>
+          </div>
+        )}
+        {app.hasError && (
+          <div>
+            <h2 className="text-center">Something went wrong</h2>
+            <p className="text-center" style={{ marginBottom: '20px' }}>
+              There was a problem loading <em>{app.name}</em>. Try checking your browser console for errors.
             </p>
           </div>
         )}

--- a/app/scripts/modules/core/src/application/application.model.ts
+++ b/app/scripts/modules/core/src/application/application.model.ts
@@ -70,6 +70,13 @@ export class Application {
   public notFound = false;
 
   /**
+   * Indicates that there was an exception while trying to load or create
+   * the application model.
+   * @type {boolean}
+   */
+  public hasError = false;
+
+  /**
    * Indicates that the application does not exist and is used as a stub
    * @type {boolean}
    */

--- a/app/scripts/modules/core/src/application/application.state.provider.ts
+++ b/app/scripts/modules/core/src/application/application.state.provider.ts
@@ -88,7 +88,15 @@ export class ApplicationStateProvider implements IServiceProvider {
                   return app || ApplicationModelBuilder.createNotFoundApplication($stateParams.application);
                 },
               )
-              .catch(() => ApplicationModelBuilder.createNotFoundApplication($stateParams.application));
+              .catch(error => {
+                if (error.status && error.status === 404) {
+                  return ApplicationModelBuilder.createNotFoundApplication($stateParams.application);
+                } else {
+                  // tslint:disable-next-line:no-console
+                  console.error(error);
+                  return ApplicationModelBuilder.createApplicationWithError($stateParams.application);
+                }
+              });
           },
         ],
       },

--- a/app/scripts/modules/core/src/application/applicationModel.builder.ts
+++ b/app/scripts/modules/core/src/application/applicationModel.builder.ts
@@ -22,4 +22,11 @@ export class ApplicationModelBuilder {
     application.notFound = true;
     return application;
   }
+
+  public static createApplicationWithError(name: string): Application {
+    const config: IDataSourceConfig<IServerGroup[]> = { key: 'serverGroups', lazy: true, defaultData: [] };
+    const application = new Application(name, SchedulerFactory.createScheduler(), [config]);
+    application.hasError = true;
+    return application;
+  }
 }

--- a/app/scripts/modules/core/src/application/config/DeleteApplicationSection.tsx
+++ b/app/scripts/modules/core/src/application/config/DeleteApplicationSection.tsx
@@ -35,6 +35,14 @@ export function DeleteApplicationSection(props: IDeleteApplicationSection) {
         <p>Application not found.</p>
       </>
     );
+  } else if (application.hasError) {
+    return (
+      <>
+        <p>
+          Something went wrong loading <em>{application.name}</em>.
+        </p>
+      </>
+    );
   } else {
     return Boolean(application.serverGroups.data.length) ? (
       <>

--- a/app/scripts/modules/core/src/application/config/applicationConfig.controller.js
+++ b/app/scripts/modules/core/src/application/config/applicationConfig.controller.js
@@ -29,7 +29,7 @@ module.exports = angular
       this.application = app;
       this.isDataSourceEnabled = key => app.dataSources.some(ds => ds.key === key && ds.disabled === false);
       this.feature = SETTINGS.feature;
-      if (app.notFound) {
+      if (app.notFound || app.hasError) {
         $state.go('home.infrastructure', null, { location: 'replace' });
       } else {
         this.application.attributes.instancePort =

--- a/app/scripts/modules/core/src/application/config/applicationSnapshotSection.component.js
+++ b/app/scripts/modules/core/src/application/config/applicationSnapshotSection.component.js
@@ -20,7 +20,7 @@ module.exports = angular
       '$state',
       'confirmationModalService',
       function($state, confirmationModalService) {
-        if (this.application.notFound) {
+        if (this.application.notFound || this.application.hasError) {
           return;
         }
 

--- a/app/scripts/modules/core/src/application/config/dataSources/applicationDataSourceEditor.component.ts
+++ b/app/scripts/modules/core/src/application/config/dataSources/applicationDataSourceEditor.component.ts
@@ -21,7 +21,7 @@ export class DataSourceEditorController implements IController {
   public dataSources: ApplicationDataSource[];
 
   public $onInit() {
-    if (this.application.notFound) {
+    if (this.application.notFound || this.application.hasError) {
       return;
     }
     if (!this.application.attributes) {

--- a/app/scripts/modules/core/src/application/config/links/applicationLinks.component.js
+++ b/app/scripts/modules/core/src/application/config/links/applicationLinks.component.js
@@ -23,7 +23,7 @@ module.exports = angular
       '$uibModal',
       function($uibModal) {
         let initialize = () => {
-          if (this.application.notFound) {
+          if (this.application.notFound || this.application.hasError) {
             return;
           }
 

--- a/app/scripts/modules/core/src/application/config/trafficGuard/trafficGuardConfig.component.ts
+++ b/app/scripts/modules/core/src/application/config/trafficGuard/trafficGuardConfig.component.ts
@@ -31,7 +31,7 @@ export class TrafficGuardConfigController {
   public constructor(private $log: ILogService) {}
 
   public $onInit(): void {
-    if (this.application.notFound) {
+    if (this.application.notFound || this.application.hasError) {
       return;
     }
     this.config = this.application.attributes.trafficGuards || [];

--- a/app/scripts/modules/core/src/application/nav/ApplicationHeader.tsx
+++ b/app/scripts/modules/core/src/application/nav/ApplicationHeader.tsx
@@ -164,7 +164,7 @@ export class ApplicationHeader extends React.Component<IApplicationHeaderProps, 
             </div>
           </div>
         </div>
-        {app && !app.notFound && <ThirdLevelNavigation category={activeCategory} application={app} />}
+        {app && !app.notFound && !app.hasError && <ThirdLevelNavigation category={activeCategory} application={app} />}
       </div>
     );
   }

--- a/app/scripts/modules/core/src/application/nav/ApplicationNavSection.tsx
+++ b/app/scripts/modules/core/src/application/nav/ApplicationNavSection.tsx
@@ -12,7 +12,7 @@ export interface IApplicationNavProps {
 }
 
 export const ApplicationNavSection = ({ application, categories, activeCategory }: IApplicationNavProps) => {
-  if (application.notFound) {
+  if (application.notFound || application.hasError) {
     return null;
   }
   return (

--- a/app/scripts/modules/core/src/application/service/applicationDataSource.ts
+++ b/app/scripts/modules/core/src/application/service/applicationDataSource.ts
@@ -344,7 +344,7 @@ export class ApplicationDataSource<T = any> implements IDataSourceConfig<T> {
     Object.assign(this, config);
 
     if (!config.hasOwnProperty('defaultData')) {
-      console.error(
+      throw new Error(
         'The defaultData field is required when registering a data source.\n\n' +
           'defaultData accepts the initial default value that will be used before data has been fetched.\n' +
           'For example, if your data source holds an array of objects, you should set defaultData to an empty array.',

--- a/app/scripts/modules/core/src/chaosMonkey/chaosMonkeyConfig.component.ts
+++ b/app/scripts/modules/core/src/chaosMonkey/chaosMonkeyConfig.component.ts
@@ -48,7 +48,7 @@ export class ChaosMonkeyConfigController implements IController {
   };
 
   public $onInit(): void {
-    if (this.application.notFound) {
+    if (this.application.notFound || this.application.hasError) {
       return;
     }
     this.config = new ChaosMonkeyConfig(this.application.attributes.chaosMonkey || {});

--- a/app/scripts/modules/core/src/insight/insightLayout.component.html
+++ b/app/scripts/modules/core/src/insight/insightLayout.component.html
@@ -1,6 +1,6 @@
 <div
   class="insight"
-  ng-if="!$ctrl.app.notFound"
+  ng-if="!$ctrl.app.notFound && !$ctrl.app.hasError"
   ng-class="$ctrl.insightFilterStateModel.filtersExpanded ? 'filters-expanded' : 'filters-collapsed'"
 >
   <div ui-view="nav" ng-if="!$ctrl.insightFilterStateModel.filtersHidden" class="nav"></div>

--- a/app/scripts/modules/core/src/pipeline/config/pipelineConfig.controller.js
+++ b/app/scripts/modules/core/src/pipeline/config/pipelineConfig.controller.js
@@ -75,7 +75,7 @@ module.exports = angular
         }
       };
 
-      if (!app.notFound) {
+      if (!app.notFound && !app.hasError) {
         app.pipelineConfigs.activate();
         app.pipelineConfigs
           .ready()

--- a/app/scripts/modules/core/src/pipeline/config/pipelineConfig.html
+++ b/app/scripts/modules/core/src/pipeline/config/pipelineConfig.html
@@ -12,11 +12,16 @@
         has-dynamic-source="vm.hasDynamicSource"
         application="vm.application"
         template-error="vm.templateError"
-      ></pipeline-configurer>
+      >
+      </pipeline-configurer>
     </div>
   </div>
 </div>
-<div class="row" ng-if="!vm.application.notFound && !vm.state.pipelinesLoaded" style="min-height: 300px">
+<div
+  class="row"
+  ng-if="!vm.application.notFound && !vm.application.hasError && !vm.state.pipelinesLoaded"
+  style="min-height: 300px"
+>
   <div class="horizontal center middle spinner-container">
     <loading-spinner size="'small'"></loading-spinner>
   </div>

--- a/app/scripts/modules/core/src/pipeline/details/SingleExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/details/SingleExecutionDetails.tsx
@@ -61,7 +61,7 @@ export class SingleExecutionDetails extends React.Component<
     const { executionService, $state } = ReactInjector;
     const { app } = this.props;
 
-    if (!app || app.notFound) {
+    if (!app || app.notFound || app.hasError) {
       return;
     }
 

--- a/app/scripts/modules/core/src/pipeline/executions/Executions.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/Executions.tsx
@@ -181,7 +181,7 @@ export class Executions extends React.Component<IExecutionsProps, IExecutionsSta
       ExecutionState.filterModel.mostRecentApplication = app.name;
     }
 
-    if (app.notFound) {
+    if (app.notFound || app.hasError) {
       return;
     }
     app.setActiveState(app.executions);
@@ -276,7 +276,7 @@ export class Executions extends React.Component<IExecutionsProps, IExecutionsSta
 
     const hasPipelines = !!(get(app, 'executions.data', []).length || get(app, 'pipelineConfigs.data', []).length);
 
-    if (!app.notFound) {
+    if (!app.notFound && !app.hasError) {
       if (!hasPipelines && !loading) {
         return (
           <div className="text-center full-width">

--- a/app/scripts/modules/core/src/task/tasks.controller.js
+++ b/app/scripts/modules/core/src/task/tasks.controller.js
@@ -25,7 +25,7 @@ module.exports = angular
     'app',
     'confirmationModalService',
     function($scope, $state, $stateParams, $q, app, confirmationModalService) {
-      if (app.notFound) {
+      if (app.notFound || app.hasError) {
         return;
       }
 


### PR DESCRIPTION
Historically if _anything_ threw while an application model was being created in the main "we need to load a view" code path, we'd silently catch the error, toss it out, and then show the 'Application not found' message. This makes it very hard to debug when something goes wrong in between fetching the application from Front50 and having a fully hydrated application model with data sources, etc. — that model setup process is really quite a lot of work/steps and there are tons of opportunities for exceptions that are hard to pinpoint. It's also misleading because it claims we couldn't find an app, even though there's really something _wrong_.

This does a few things:
- Log out the caught exception (including the original stack trace before it got caught in a promise handler)
-  Add an additional `hasError` field onto the application model to compliment the existing `notFound` flag, and wire it up through the consumers of `notFound` in a generally similar way
- Use that flag to show a 'Something went wrong' state:
<img width="1444" alt="Screen Shot 2019-11-05 at 10 40 57 PM" src="https://user-images.githubusercontent.com/1850998/68275229-e984c480-001f-11ea-9258-978140e57ad9.png">
