### PR TITLE
feat(core/managed): add RESUMED resource status

### DIFF
--- a/app/scripts/modules/core/src/managed/ManagedReader.ts
+++ b/app/scripts/modules/core/src/managed/ManagedReader.ts
@@ -10,6 +10,7 @@ export enum ManagedResourceStatus {
   ERROR = 'ERROR',
   HAPPY = 'HAPPY',
   PAUSED = 'PAUSED',
+  RESUMED = 'RESUMED',
   UNHAPPY = 'UNHAPPY',
   UNKNOWN = 'UNKNOWN',
 }

--- a/app/scripts/modules/core/src/managed/ManagedResourceStatusIndicator.tsx
+++ b/app/scripts/modules/core/src/managed/ManagedResourceStatusIndicator.tsx
@@ -116,7 +116,7 @@ const viewConfigurationByStatus = {
         </p>
         <p>
           Management was resumed after being temporarily paused. If Spinnaker detects that a drift from the declarative
-          configuration occured while paused, it will take automatic action to resolve the drift.
+          configuration occurred while paused, it will take automatic action to resolve the drift.
         </p>
         <p>
           You can pause and resume management on the{' '}

--- a/app/scripts/modules/core/src/managed/ManagedResourceStatusIndicator.tsx
+++ b/app/scripts/modules/core/src/managed/ManagedResourceStatusIndicator.tsx
@@ -106,6 +106,29 @@ const viewConfigurationByStatus = {
       </>
     ),
   },
+  RESUMED: {
+    iconClass: 'icon-md',
+    colorClass: 'info',
+    popoverContents: (id: string) => (
+      <>
+        <p>
+          <b>Continuous management was just resumed.</b>
+        </p>
+        <p>
+          Management was resumed after being temporarily paused. If Spinnaker detects that a drift from the declarative
+          configuration occured while paused, it will take automatic action to resolve the drift.
+        </p>
+        <p>
+          You can pause and resume management on the{' '}
+          <UISref to="home.applications.application.config" params={{ section: 'managed-resources' }}>
+            <a>config view</a>
+          </UISref>
+          .
+        </p>
+        <LearnMoreLink id={id} status={ManagedResourceStatus.RESUMED} />
+      </>
+    ),
+  },
   UNHAPPY: {
     iconClass: 'icon-md-flapping',
     colorClass: 'error',

--- a/app/scripts/modules/core/src/managed/ManagedResourceStatusIndicator.tsx
+++ b/app/scripts/modules/core/src/managed/ManagedResourceStatusIndicator.tsx
@@ -107,7 +107,7 @@ const viewConfigurationByStatus = {
     ),
   },
   RESUMED: {
-    iconClass: 'icon-md',
+    iconClass: 'icon-md-resumed',
     colorClass: 'info',
     popoverContents: (id: string) => (
       <>


### PR DESCRIPTION
Depends on https://github.com/spinnaker/spinnaker.github.io/pull/1585 and https://github.com/spinnaker/deck/pull/7610.

Support for the newly-added `RESUMED` status — feedback on wording / etc is welcome. Until #7610 gets merged there will be an extra commit at the beginning, this PR is only one commit.