### PR TITLE
fix(artifacts): enable inline editing of base64 artifacts

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/base64/Base64ArtifactEditor.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/base64/Base64ArtifactEditor.tsx
@@ -63,7 +63,10 @@ class DefaultBase64ArtifactEditor extends React.Component<IArtifactEditorProps, 
       artifact.reference = encoded;
       this.props.onChange(artifact);
     }
-    this.setState({ encodeDecodeError: encodeDecodeError });
+    this.setState({
+      decoded: event.target.value,
+      encodeDecodeError: encodeDecodeError,
+    });
   };
 
   public render() {


### PR DESCRIPTION
Closes https://github.com/spinnaker/spinnaker/issues/5102

The [artifacts rewrite commit](https://github.com/spinnaker/deck/pull/6634) added support for a React base64 artifact editor. In the [Angular implementation](https://github.com/spinnaker/deck/blob/master/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/base64/defaultBase64.artifact.ts#L83), the textarea value is bound to the value of the decoded base64, so does not need to be updated manually. In the React implementation, we are storing the value of the decoded base64 on state and need to manually update it in the textarea change handler.

![143e2bc6-47bc-45eb-9d84-6f1346c306b0](https://user-images.githubusercontent.com/15936279/68406725-467f9800-0150-11ea-80f4-d3ab2b431ef2.gif)
