### PR TITLE
fix(core/managed): properly diff/patch mutable infra groupings

### DIFF
--- a/app/scripts/modules/core/src/cluster/filter/ClusterFilterService.ts
+++ b/app/scripts/modules/core/src/cluster/filter/ClusterFilterService.ts
@@ -473,6 +473,12 @@ export class ClusterFilterService {
         if (oldGroup.entityTags || newGroup.entityTags) {
           oldGroup.entityTags = newGroup.entityTags;
         }
+        if (oldGroup.hasOwnProperty('isManaged') || newGroup.hasOwnProperty('isManaged')) {
+          const oldSubGroup = oldGroup as IClusterSubgroup | IServerGroupSubgroup;
+          const newSubGroup = newGroup as IClusterSubgroup | IServerGroupSubgroup;
+          oldSubGroup.isManaged = newSubGroup.isManaged;
+          oldSubGroup.managedResourceSummary = newSubGroup.managedResourceSummary;
+        }
       }
     });
     groupsToRemove.reverse().forEach((idx: number) => {

--- a/app/scripts/modules/core/src/loadBalancer/filter/LoadBalancerFilterService.ts
+++ b/app/scripts/modules/core/src/loadBalancer/filter/LoadBalancerFilterService.ts
@@ -106,6 +106,10 @@ export class LoadBalancerFilterService {
         if (newGroup.subgroups) {
           this.diffSubgroups(oldGroup.subgroups, newGroup.subgroups);
         }
+        if (oldGroup.hasOwnProperty('isManaged') || newGroup.hasOwnProperty('isManaged')) {
+          oldGroup.isManaged = newGroup.isManaged;
+          oldGroup.managedResourceSummary = newGroup.managedResourceSummary;
+        }
       }
     });
     groupsToRemove.reverse().forEach(idx => {

--- a/app/scripts/modules/core/src/securityGroup/filter/SecurityGroupFilterService.ts
+++ b/app/scripts/modules/core/src/securityGroup/filter/SecurityGroupFilterService.ts
@@ -91,6 +91,10 @@ export class SecurityGroupFilterService {
         if (newGroup.subgroups) {
           this.diffSubgroups(oldGroup.subgroups, newGroup.subgroups);
         }
+        if (oldGroup.hasOwnProperty('isManaged') || newGroup.hasOwnProperty('isManaged')) {
+          oldGroup.isManaged = newGroup.isManaged;
+          oldGroup.managedResourceSummary = newGroup.managedResourceSummary;
+        }
       }
     });
     groupsToRemove.reverse().forEach(idx => {


### PR DESCRIPTION
tl;dr I mistakenly thought that these filter services generated new grouping data and then pushed that out to consumers, but in reality the new data gets generated and then is used to diff + patch the original objects from the first time the grouping was created. Because I didn't implement this logic in previous PRs, changes to the `isManaged` and `managedResourceSummary` fields were not being picked up until a full reload.

Normally I would say this is a horrible kludge, but I suppose it's just the (gross) way of things while there's still some angular floating around since we need stable object references for those directives/components to behave correctly.