### PR TITLE
Evaluate variables stage updates

### DIFF
--- a/app/scripts/modules/core/src/domain/IStage.ts
+++ b/app/scripts/modules/core/src/domain/IStage.ts
@@ -1,3 +1,5 @@
+import { IEvaluatedVariable } from 'core/pipeline/config/stages/evaluateVariables/EvaluateVariablesStageConfig';
+
 export interface IStage {
   [k: string]: any;
   alias?: string;
@@ -7,4 +9,5 @@ export interface IStage {
   refId: string | number; // unfortunately, we kept this loose early on, so it's either a string or a number
   requisiteStageRefIds: Array<string | number>;
   type: string;
+  variables?: IEvaluatedVariable[];
 }

--- a/app/scripts/modules/core/src/pipeline/config/stages/evaluateVariables/EvaluateVariablesStageConfig.less
+++ b/app/scripts/modules/core/src/pipeline/config/stages/evaluateVariables/EvaluateVariablesStageConfig.less
@@ -10,4 +10,9 @@
     margin-top: 4px;
     max-height: 150px;
   }
+
+  // Use the entire width when rendering validation preview messages
+  .ValidationMessage.infoMessage .message {
+    width: 100%;
+  }
 }

--- a/app/scripts/modules/core/src/pipeline/config/stages/evaluateVariables/EvaluateVariablesStageConfig.less
+++ b/app/scripts/modules/core/src/pipeline/config/stages/evaluateVariables/EvaluateVariablesStageConfig.less
@@ -1,0 +1,13 @@
+.EvaluateVariablesStageConfig {
+  .StandardFieldLayout_Label {
+    min-width: 200px;
+    font-family: monospace;
+    text-align: left;
+    flex: 0;
+  }
+
+  pre {
+    margin-top: 4px;
+    max-height: 150px;
+  }
+}

--- a/app/scripts/modules/core/src/pipeline/config/stages/evaluateVariables/EvaluateVariablesStageConfig.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/evaluateVariables/EvaluateVariablesStageConfig.tsx
@@ -2,21 +2,27 @@ import * as React from 'react';
 import { countBy } from 'lodash';
 import { FieldArray } from 'formik';
 
+import { IStage } from 'core/domain';
+import { FormikStageConfig, IFormikStageConfigInjectedProps, IStageConfigProps } from 'core/pipeline';
 import {
   FormValidator,
   FormikFormField,
   ILayoutProps,
+  IStageForSpelPreview,
   IValidator,
+  LayoutContext,
   LayoutProvider,
+  Markdown,
   SpelInput,
   StandardFieldLayout,
   TextInput,
   Tooltip,
   ValidationMessage,
   errorMessage,
+  useIsMountedRef,
 } from 'core/presentation';
-import { IStage } from 'core/domain';
-import { FormikStageConfig, IFormikStageConfigInjectedProps, IStageConfigProps } from 'core/pipeline';
+
+import { ExecutionAndStagePicker, IExecutionAndStagePickerProps } from './ExecutionAndStagePicker';
 
 import './EvaluateVariablesStageConfig.less';
 
@@ -26,16 +32,16 @@ export interface IEvaluatedVariable {
 }
 
 const variableNameValidator: IValidator = (val: string, label: string) =>
-  !val.match(/^[a-zA-Z0-9_]+$/) && errorMessage(`${label} should consist only of letters, numbers, or underscore`);
+  !val.match(/^[a-zA-Z_][a-zA-Z0-9_]+$/) && errorMessage(`${label} should consist only of letters, numbers, or underscore`);
 
-const getDuplicateKeyValidator = (variables: IEvaluatedVariable[]) => {
+const duplicateKeyValidatorFactory = (variables: IEvaluatedVariable[] = []) => {
   const keyCounts = countBy(variables.map(x => x.key), x => x);
   return (key: string) => keyCounts[key] > 1 && `Duplicate key '${key}'`;
 };
 
 export function validateEvaluateVariablesStage(stage: IStage) {
   const formValidator = new FormValidator(stage);
-  const duplicateKeyValidator = getDuplicateKeyValidator(stage.variables);
+  const duplicateKeyValidator = duplicateKeyValidatorFactory(stage.variables);
   formValidator.field('variables').withValidators(
     formValidator.arrayForEach(item => {
       item
@@ -48,8 +54,32 @@ export function validateEvaluateVariablesStage(stage: IStage) {
   return formValidator.validateForm();
 }
 
+function PreviewConfiguration(props: IExecutionAndStagePickerProps) {
+  return (
+    <div style={{ marginLeft: '16px', marginRight: '16px' }}>
+      <ValidationMessage
+        type={'info'}
+        message={
+          <>
+            <p className="bold">Variable Previews</p>
+
+            <ExecutionAndStagePicker {...props} />
+          </>
+        }
+      />
+    </div>
+  );
+}
+
 export function EvaluateVariablesStageConfig(props: IStageConfigProps) {
   const { application, stage, pipeline, updateStage } = props;
+  const [chosenStage, setChosenStage] = React.useState({} as IStageForSpelPreview);
+
+  const helpMessage =
+    'Define one or more variables by assigning a **name** _(string)_ and a **value** ' +
+    '_([SpEL Expression](https://www.spinnaker.io/guides/user/pipeline/expressions/))_. ' +
+    'The evaluated variables can be used in downstream stages, referencing them by name.';
+
   return (
     <FormikStageConfig
       application={application}
@@ -60,7 +90,11 @@ export function EvaluateVariablesStageConfig(props: IStageConfigProps) {
       render={renderProps => {
         return (
           <LayoutProvider value={StandardFieldLayout}>
-            <EvaluateVariablesStageForm {...renderProps} />
+            <div className="flex-container-v margin-between-lg">
+              <Markdown message={helpMessage} />
+              <PreviewConfiguration pipeline={pipeline} pipelineStage={stage} onChange={setChosenStage} />
+              <EvaluateVariablesStageForm {...renderProps} chosenStage={chosenStage} />
+            </div>
           </LayoutProvider>
         );
       }}
@@ -68,14 +102,27 @@ export function EvaluateVariablesStageConfig(props: IStageConfigProps) {
   );
 }
 
-function EvaluateVariablesStageForm(props: IFormikStageConfigInjectedProps) {
-  const { formik } = props;
+interface IEvaluateVariablesStageFormProps extends IFormikStageConfigInjectedProps {
+  chosenStage: IStageForSpelPreview;
+}
+
+function EvaluateVariablesStageForm(props: IEvaluateVariablesStageFormProps) {
+  const { formik, chosenStage } = props;
+  const stage = props.formik.values;
+  const { variables = [] } = stage;
+  const isMountedRef = useIsMountedRef();
 
   React.useEffect(() => {
-    const { variables = [] } = props.formik.values;
-    const initialTouched = variables.map(() => ({ key: true, value: true }));
-    formik.setTouched({ variables: initialTouched } as any);
+    if (variables.length === 0) {
+      // This setTimeout is necessary because the interaction between pipelineConfigurer.js and stage.module.js
+      // causes this component to get mounted multiple times.  The second time it gets mounted, the initial
+      // variable is already added to the array, and then gets auto-touched by SpinFormik.tsx.
+      // The end effect is that the red validation warnings are shown immediately when the Evaluate Variables stage is added.
+      setTimeout(() => isMountedRef.current && formik.setFieldValue('variables', [{ key: null, value: null }]), 100);
+    }
   }, []);
+
+  const FieldLayoutComponent = React.useContext(LayoutContext);
 
   const [deleteCount, setDeleteCount] = React.useState(0);
 
@@ -85,12 +132,26 @@ function EvaluateVariablesStageForm(props: IFormikStageConfigInjectedProps) {
       name="variables"
       render={arrayHelpers => (
         <div className="EvaluateVariablesStageConfig form-horizontal">
-          {formik.values.variables.map((_, index) => {
+          <FieldLayoutComponent
+            label={<h4>Variable Name</h4>}
+            input={<h4>Variable Value</h4>}
+            validation={{ hidden: true } as any}
+          />
+
+          {variables.map((_, index) => {
             const onDeleteClicked = () => {
               setDeleteCount(count => count + 1);
               arrayHelpers.handleRemove(index)();
             };
-            return <FormikVariable key={`${deleteCount}-${index}`} index={index} onDeleteClicked={onDeleteClicked} />;
+
+            return (
+              <FormikVariable
+                key={`${deleteCount}-${index}`}
+                index={index}
+                previewStage={chosenStage}
+                onDeleteClicked={onDeleteClicked}
+              />
+            );
           })}
 
           <button
@@ -110,33 +171,49 @@ function EvaluateVariablesStageForm(props: IFormikStageConfigInjectedProps) {
 interface IFormikVariableProps {
   index: number;
   onDeleteClicked(): void;
+  previewStage: IStageForSpelPreview;
 }
 
-function FormikVariable({ index, onDeleteClicked }: IFormikVariableProps) {
+function FormikVariable({ index, onDeleteClicked, previewStage }: IFormikVariableProps) {
+  const [touchedOverride, setTouchedOverride] = React.useState(undefined);
+
+  const variableNameInputAsLabel = (
+    <FormikFormField
+      name={`variables[${index}].key`}
+      required={true}
+      input={inputProps => <TextInput {...inputProps} placeholder="Variable name" />}
+      layout={VariableNameFormLayout}
+    />
+  );
+
+  const actions = (
+    <Tooltip value="Remove variable">
+      <button className="btn btn-sm btn-default" onClick={onDeleteClicked}>
+        <span className="glyphicon glyphicon-trash" />
+      </button>
+    </Tooltip>
+  );
+
+  const fieldName = `variables[${index}].value`;
+
   return (
     <FormikFormField
-      name={`variables[${index}].value`}
-      actions={
-        <Tooltip value="Remove variable">
-          <button className="btn btn-sm btn-default" onClick={onDeleteClicked}>
-            <span className="glyphicon glyphicon-trash" />
-          </button>
-        </Tooltip>
-      }
-      label={
-        <FormikFormField
-          name={`variables[${index}].key`}
-          required={true}
-          input={inputProps => <TextInput {...inputProps} placeholder="Variable name" />}
-          layout={VariableNameFormLayout}
-        />
-      }
+      name={fieldName}
+      onChange={value => {
+        // When the user has entered anything, mark the field as touched so warnings are shown
+        if (value && !touchedOverride) {
+          setTouchedOverride(true);
+        }
+      }}
+      touched={touchedOverride}
+      label={variableNameInputAsLabel}
+      actions={actions}
+      fastField={false}
       input={inputProps => (
         <SpelInput
           {...inputProps}
-          placeholder="Variable value, e.g. ${trigger.properties.myproperty}"
-          executionId={null}
-          stageId={null}
+          placeholder="Variable value, e.g. ${trigger.buildInfo.number}"
+          previewStage={previewStage}
         />
       )}
     />

--- a/app/scripts/modules/core/src/pipeline/config/stages/evaluateVariables/EvaluateVariablesStageConfig.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/evaluateVariables/EvaluateVariablesStageConfig.tsx
@@ -1,48 +1,155 @@
 import * as React from 'react';
-import { map } from 'lodash';
+import { countBy } from 'lodash';
+import { FieldArray } from 'formik';
 
-import { IStageConfigProps, StageConfigField } from 'core/pipeline';
-import { MapEditor } from 'core/forms';
+import {
+  FormValidator,
+  FormikFormField,
+  ILayoutProps,
+  IValidator,
+  LayoutProvider,
+  SpelInput,
+  StandardFieldLayout,
+  TextInput,
+  Tooltip,
+  ValidationMessage,
+  errorMessage,
+} from 'core/presentation';
+import { IStage } from 'core/domain';
+import { FormikStageConfig, IFormikStageConfigInjectedProps, IStageConfigProps } from 'core/pipeline';
+
+import './EvaluateVariablesStageConfig.less';
 
 export interface IEvaluatedVariable {
   key: string;
   value: string;
 }
 
-export class EvaluateVariablesStageConfig extends React.Component<IStageConfigProps> {
-  private expand(variables: { [key: string]: string }): IEvaluatedVariable[] {
-    return map(variables, (value, key): IEvaluatedVariable => ({ key, value }));
-  }
+const variableNameValidator: IValidator = (val: string, label: string) =>
+  !val.match(/^[a-zA-Z0-9_]+$/) && errorMessage(`${label} should consist only of letters, numbers, or underscore`);
 
-  private mapChanged = (key: string, values: { [key: string]: string }) => {
-    this.props.updateStageField({ [key]: this.expand(values) });
-  };
+const getDuplicateKeyValidator = (variables: IEvaluatedVariable[]) => {
+  const keyCounts = countBy(variables.map(x => x.key), x => x);
+  return (key: string) => keyCounts[key] > 1 && `Duplicate key '${key}'`;
+};
 
-  public render() {
-    const {
-      stage: { variables = [] },
-      pipeline,
-    } = this.props;
+export function validateEvaluateVariablesStage(stage: IStage) {
+  const formValidator = new FormValidator(stage);
+  const duplicateKeyValidator = getDuplicateKeyValidator(stage.variables);
+  formValidator.field('variables').withValidators(
+    formValidator.arrayForEach(item => {
+      item
+        .field('key', 'Variable Name')
+        .required()
+        .withValidators(variableNameValidator, duplicateKeyValidator);
+      item.field('value', 'Expression').required();
+    }),
+  );
+  return formValidator.validateForm();
+}
 
-    // Flattens an array of objects {key, value} into a single object with the respective keys/values
-    const variablesObject = variables.reduce(
-      // tslint:disable-next-line:prefer-object-spread
-      (acc: any, { key, value }: IEvaluatedVariable) => Object.assign(acc, { [key]: value }),
-      {},
-    );
+export function EvaluateVariablesStageConfig(props: IStageConfigProps) {
+  const { application, stage, pipeline, updateStage } = props;
+  return (
+    <FormikStageConfig
+      application={application}
+      stage={stage}
+      pipeline={pipeline}
+      validate={validateEvaluateVariablesStage}
+      onChange={updateStage}
+      render={renderProps => {
+        return (
+          <LayoutProvider value={StandardFieldLayout}>
+            <EvaluateVariablesStageForm {...renderProps} />
+          </LayoutProvider>
+        );
+      }}
+    />
+  );
+}
 
-    return (
-      <div className="form-horizontal">
-        <StageConfigField label="Variables to evaluate">
-          <MapEditor
-            model={variablesObject}
-            allowEmpty={true}
-            onChange={(v: any) => this.mapChanged('variables', v)}
-            pipeline={pipeline}
-            valueCanContainSpel={true}
-          />
-        </StageConfigField>
-      </div>
-    );
-  }
+function EvaluateVariablesStageForm(props: IFormikStageConfigInjectedProps) {
+  const { formik } = props;
+
+  React.useEffect(() => {
+    const { variables = [] } = props.formik.values;
+    const initialTouched = variables.map(() => ({ key: true, value: true }));
+    formik.setTouched({ variables: initialTouched } as any);
+  }, []);
+
+  const [deleteCount, setDeleteCount] = React.useState(0);
+
+  return (
+    <FieldArray
+      key={deleteCount}
+      name="variables"
+      render={arrayHelpers => (
+        <div className="EvaluateVariablesStageConfig form-horizontal">
+          {formik.values.variables.map((_, index) => {
+            const onDeleteClicked = () => {
+              setDeleteCount(count => count + 1);
+              arrayHelpers.handleRemove(index)();
+            };
+            return <FormikVariable key={`${deleteCount}-${index}`} index={index} onDeleteClicked={onDeleteClicked} />;
+          })}
+
+          <button
+            type="button"
+            className="btn btn-block btn-sm add-new"
+            onClick={arrayHelpers.handlePush({ key: null, value: null })}
+          >
+            <span className="glyphicon glyphicon-plus-sign" />
+            Add Variable
+          </button>
+        </div>
+      )}
+    />
+  );
+}
+
+interface IFormikVariableProps {
+  index: number;
+  onDeleteClicked(): void;
+}
+
+function FormikVariable({ index, onDeleteClicked }: IFormikVariableProps) {
+  return (
+    <FormikFormField
+      name={`variables[${index}].value`}
+      actions={
+        <Tooltip value="Remove variable">
+          <button className="btn btn-sm btn-default" onClick={onDeleteClicked}>
+            <span className="glyphicon glyphicon-trash" />
+          </button>
+        </Tooltip>
+      }
+      label={
+        <FormikFormField
+          name={`variables[${index}].key`}
+          required={true}
+          input={inputProps => <TextInput {...inputProps} placeholder="Variable name" />}
+          layout={VariableNameFormLayout}
+        />
+      }
+      input={inputProps => (
+        <SpelInput
+          {...inputProps}
+          placeholder="Variable value, e.g. ${trigger.properties.myproperty}"
+          executionId={null}
+          stageId={null}
+        />
+      )}
+    />
+  );
+}
+
+function VariableNameFormLayout(props: ILayoutProps) {
+  const { input, validation } = props;
+  const { messageNode, category, hidden } = validation;
+  return (
+    <div className="flex-container-v margin-between-md">
+      {input}
+      {!hidden && <ValidationMessage message={messageNode} type={category} />}
+    </div>
+  );
 }

--- a/app/scripts/modules/core/src/pipeline/config/stages/evaluateVariables/ExecutionAndStagePicker.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/evaluateVariables/ExecutionAndStagePicker.tsx
@@ -48,6 +48,15 @@ export function ExecutionAndStagePicker(props: IExecutionAndStagePickerProps) {
   const stageOptions: Option[] = stages ? stages.map(x => ({ label: x.name, value: x.id })) : [];
   const executionOptions: Array<Option<IExecution>> = executions ? executions.map(value => ({ value })) : [];
 
+  if (fetchExecutions.status === 'RESOLVED' && !executions.length) {
+    return (
+      <p>
+        This pipeline has never been executed. If you run this pipeline at least once, Spinnaker will show previews of
+        the variables on this screen.
+      </p>
+    );
+  }
+
   return (
     <>
       <p>

--- a/app/scripts/modules/core/src/pipeline/config/stages/evaluateVariables/ExecutionAndStagePicker.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/evaluateVariables/ExecutionAndStagePicker.tsx
@@ -1,0 +1,144 @@
+import * as React from 'react';
+import { keyBy, isEqual } from 'lodash';
+import { Option } from 'react-select';
+
+import { IExecution, IPipeline, IStage } from 'core/domain';
+import { FormField, IStageForSpelPreview, ReactSelectInput, useData } from 'core/presentation';
+import { ReactInjector } from 'core/reactShims';
+import { timestamp, relativeTime } from 'core/utils';
+import { ExecutionStatus } from 'core/pipeline/status/ExecutionStatus';
+
+export interface IExecutionAndStagePickerProps {
+  pipeline: IPipeline;
+  pipelineStage: IStage;
+  onChange(chosenExecutionAndStage: IStageForSpelPreview): void;
+}
+
+export function ExecutionAndStagePicker(props: IExecutionAndStagePickerProps) {
+  const { pipeline, pipelineStage, onChange } = props;
+  const { executionService } = ReactInjector;
+  const [execution, setExecution] = React.useState<IExecution>(null);
+  const [stageId, setStageId] = React.useState<string>(null);
+  const [showStageSelector, setShowStageSelector] = React.useState(false);
+
+  const fetchExecutions = useData(
+    () => executionService.getExecutionsForConfigIds([pipeline.id], { limit: 100 }),
+    [],
+    [],
+  );
+  const executions = fetchExecutions.result;
+  const stages = execution && execution.stages;
+
+  // When executions load, select the first one.
+  React.useEffect(() => executions && setExecution(executions[0]), [executions]);
+
+  // When an execution is chosen or the current pipeline or pipeline stage changes,
+  // find the matching stage from the execution
+  React.useEffect(() => {
+    const exactStage = findExactStageFromExecution(pipeline, execution, pipelineStage);
+    setShowStageSelector(!!exactStage);
+    setStageId(exactStage || findCloseStageFromExecution(pipeline, execution, pipelineStage));
+  }, [pipeline, pipelineStage, execution]);
+
+  // When the chosen execution or stage changes, notify the parent
+  React.useEffect(() => {
+    onChange({ executionLabel: executionLabel(execution), executionId: execution && execution.id, stageId });
+  }, [execution, stageId]);
+
+  const stageOptions: Option[] = stages ? stages.map(x => ({ label: x.name, value: x.id })) : [];
+  const executionOptions: Array<Option<IExecution>> = executions ? executions.map(value => ({ value })) : [];
+
+  return (
+    <>
+      <p>
+        Select a previous execution of this pipeline. Spinnaker will then evaluate each variable as if it had been part
+        of that execution, and generate a preview for you to debug against.
+      </p>
+
+      <FormField
+        label="Execution"
+        value={execution}
+        onChange={e => setExecution(e.target.value)}
+        input={inputProps => (
+          <ReactSelectInput<IExecution>
+            {...inputProps}
+            options={executionOptions as any}
+            clearable={false}
+            isLoading={fetchExecutions.status === 'PENDING'}
+            optionRenderer={option => (
+              <ExecutionStatus
+                execution={(option.value as any) as IExecution}
+                showingDetails={true}
+                standalone={true}
+              />
+            )}
+            valueRenderer={value => <span>{executionLabel(value as any)}</span>}
+          />
+        )}
+      />
+
+      {!showStageSelector && (
+        <>
+          <p className="sp-margin-m-top">
+            Spinnaker could not find this exact same Evaluate Variables stage in the previous execution. Select a stage
+            from the previous execution to use as a stand-in.
+          </p>
+          <FormField
+            label="Stage"
+            value={stageId}
+            onChange={e => setStageId(e.target.value)}
+            input={inputProps => (
+              <ReactSelectInput {...inputProps} options={stageOptions} clearable={false} isLoading={!stages} />
+            )}
+          />
+        </>
+      )}
+    </>
+  );
+}
+
+function executionLabel(execution: IExecution) {
+  if (!execution) {
+    return null;
+  }
+  const time = execution.buildTime || execution.startTime;
+  return `${timestamp(time)} (${relativeTime(time)})`;
+}
+
+function findExactStageFromExecution(pipeline: IPipeline, execution: IExecution, editStage: IStage): string {
+  if (!pipeline || !execution || !editStage) {
+    return null;
+  }
+
+  const pipelineStagesById = keyBy(pipeline.stages, 'refId');
+  const executionStagesById = keyBy(execution.stages, 'refId');
+
+  const exactMatch = execution.stages.find(s => s.refId === editStage.refId && s.type === editStage.type);
+
+  const pipelineRequisiteGraph = stageRequisiteStageGraph(editStage, pipelineStagesById);
+  const executionRequisiteGraph = stageRequisiteStageGraph(editStage, executionStagesById);
+  const exactGraphMatch = isEqual(pipelineRequisiteGraph, executionRequisiteGraph);
+
+  return exactMatch && exactGraphMatch ? exactMatch.id : null;
+}
+
+function findCloseStageFromExecution(pipeline: IPipeline, execution: IExecution, editStage: IStage): string {
+  if (!pipeline || !execution || !editStage) {
+    return null;
+  }
+  const pipelineStagesById = keyBy(pipeline.stages, 'refId');
+  const pipelineRequisiteGraph = stageRequisiteStageGraph(editStage, pipelineStagesById);
+
+  const upstreamStages = Object.keys(pipelineRequisiteGraph).map(id => pipelineStagesById[id]);
+  return upstreamStages.map(stage => findExactStageFromExecution(pipeline, execution, stage)).find(x => !!x);
+}
+
+function stageRequisiteStageGraph(stage: IStage, allStages: { [key: string]: IStage }): { [key: string]: any } {
+  return stage.requisiteStageRefIds.reduce((acc, requisiteStageId) => {
+    const requisiteStage = allStages[requisiteStageId];
+    if (!requisiteStage) {
+      return acc;
+    }
+    return { ...acc, [requisiteStageId]: stageRequisiteStageGraph(requisiteStage, allStages) };
+  }, {});
+}

--- a/app/scripts/modules/core/src/pipeline/config/stages/evaluateVariables/evaluateVariablesStage.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/evaluateVariables/evaluateVariablesStage.ts
@@ -6,8 +6,7 @@ import { EvaluateVariablesStageConfig, validateEvaluateVariablesStage } from './
 
 Registry.pipeline.registerStage({
   label: 'Evaluate Variables',
-  description:
-    'Evaluates variables for use in SpEL expressions in downstream stages. Variables can be accessed by their key.',
+  description: 'Evaluates variables for use in downstream stages.',
   key: 'evaluateVariables',
   defaults: {
     failOnFailedExpressions: true,

--- a/app/scripts/modules/core/src/pipeline/config/stages/evaluateVariables/evaluateVariablesStage.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/evaluateVariables/evaluateVariablesStage.ts
@@ -2,7 +2,7 @@ import { Registry } from 'core/registry';
 
 import { ExecutionDetailsTasks } from '../common';
 import { EvaluateVariablesExecutionDetails } from './EvaluateVariablesExecutionDetails';
-import { EvaluateVariablesStageConfig } from './EvaluateVariablesStageConfig';
+import { EvaluateVariablesStageConfig, validateEvaluateVariablesStage } from './EvaluateVariablesStageConfig';
 
 Registry.pipeline.registerStage({
   label: 'Evaluate Variables',
@@ -15,5 +15,5 @@ Registry.pipeline.registerStage({
   component: EvaluateVariablesStageConfig,
   executionDetailsSections: [EvaluateVariablesExecutionDetails, ExecutionDetailsTasks],
   strategy: true,
-  validators: [{ type: 'requiredField', fieldName: 'variables' }],
+  validateFn: validateEvaluateVariablesStage,
 });


### PR DESCRIPTION
Everyone, meet the new Evaluate Variables stage:

![Nov-08-2019 16-12-32](https://user-images.githubusercontent.com/2053478/68519103-e4a05a80-0243-11ea-8021-8d468cb4a76f.gif)

Lots of changes here, this is a full rewrite:
- Swap out MapEditor in favor of FormikFormFields.  Note how the `label` prop is a nested `FormikFormField` 🤷‍♂ 
- Added Variable Preview and Validation via `SpelInput`
- Better field validation via Formik
- Added a Preview Execution/Stage picker.  This enables us to evaluate the previews against a previous execution and at the right spot in that execution.
- Prepopulate new stages with a blank row

Future work:

- Rewire autocomplete feature

- There are some backend changes coming from @marchello2000 (SpEL v4) that will cause these variables to get evaluated in order, enabling us to provide clear variable dependency rules.  For example, `host` variable is `myapp.${parameters.region}.${parameters.account}.netflix.net` and `delete_endpoint` is `https://${host}/delete`.  We will need to update this stage and SpelInput to preview all the variables in one shot instead of separate API calls.

Future thoughts around SpEL:
- I'd like push users to put all spel into Evaluate Variables stage
- We should only surface the fancy new spel preview UI in the Evaluate Variables stage, as a 🥕 
- We should have a UI for all stage config fields that allow you to pick a variable from a dropdown list
- We should have a clippy mascot that says "It looks like you have inline SpEL in your stage config! Would you like to move them to an Evaluate Variables stage?"
- FormikFormField and FormField components should be responsible for autodetecting SpEL expressions in values and rendering a SpelInput.  This would enable spel support globally.
- FormikFormField and FormField components should render a simple toggle that allows users to switch from (for example) a SelectInput to a VariablePicker input (which doesn't exist yet)

There are some mockups regarding these future thoughts done by @gcomstock available here: https://gallery.io/projects/MCHbtQVoQ2HCZcM1NWkzJjWA/files/MCEvKPS5RTlTG6LlhmLflRIS