### PR TITLE
test(core/presentation): Re-add removed isInitialValid logic

### DIFF
--- a/app/scripts/modules/core/src/presentation/forms/SpinFormik.tsx
+++ b/app/scripts/modules/core/src/presentation/forms/SpinFormik.tsx
@@ -14,6 +14,8 @@ function SpinFormikImpl<Values extends {}>(props: FormikConfig<Values>, ref?: Re
   const [refSaved, setRefSaved] = React.useState(false);
   const [ready, setReady] = React.useState(false);
 
+  const defaultIsInitialValid = () => formikRef.current && Object.keys(formikRef.current.state.errors).length === 0;
+
   // When a form is reloaded with existing data, we usually want to show validation errors immediately.
   // When the form is first rendered, mark all fields in initialValues as "touched".
   // Then run initial validation.
@@ -40,6 +42,7 @@ function SpinFormikImpl<Values extends {}>(props: FormikConfig<Values>, ref?: Re
     <Formik<Values>
       ref={saveRef}
       {...props}
+      isInitialValid={props.isInitialValid || defaultIsInitialValid}
       render={renderProps => ready && props.render && props.render(renderProps)}
     />
   );


### PR DESCRIPTION
Turns out this wasn't as unnecessary as I thought.
isInitialValid is _always_ used if the form when `formik.dirty === false`
It doesn't matter if you have validated the form once or twice or a million times.
