### PR TITLE
fix(azure,gce): Fix typo breaking bake stage

### DIFF
--- a/app/scripts/modules/azure/src/pipeline/stages/bake/azureBakeStage.js
+++ b/app/scripts/modules/azure/src/pipeline/stages/bake/azureBakeStage.js
@@ -93,7 +93,7 @@ module.exports = angular
             $scope.stage.baseLabel = $scope.baseLabelOptions[0];
           }
           $scope.viewState.roscoMode =
-            SETTINGS.feature.roscoModeSETTINGS.feature.roscoMode ||
+            SETTINGS.feature.roscoMode ||
             (typeof SETTINGS.feature.roscoSelector === 'function' && SETTINGS.feature.roscoSelector($scope.stage));
           $scope.viewState.loading = false;
         });

--- a/app/scripts/modules/google/src/pipeline/stages/bake/gceBakeStage.js
+++ b/app/scripts/modules/google/src/pipeline/stages/bake/gceBakeStage.js
@@ -85,7 +85,7 @@ module.exports = angular
             $scope.stage.baseLabel = $scope.baseLabelOptions[0];
           }
           $scope.viewState.roscoMode =
-            SETTINGS.feature.roscoModeSETTINGS.feature.roscoMode ||
+            SETTINGS.feature.roscoMode ||
             (typeof SETTINGS.feature.roscoSelector === 'function' && SETTINGS.feature.roscoSelector($scope.stage));
           $scope.showAdvancedOptions = showAdvanced();
           $scope.viewState.loading = false;


### PR DESCRIPTION
Somehow ended up with the string `SETTINGS.feature.roscoMode` duplicated, probably while copy/pasting #7564 to other providers resulting in 
```
SETTINGS.feature.roscoModeSETTINGS.feature.roscoMode
```
Which causes a javascript exception trying to access the second `feature` because `SETTINGS.feature.roscoModeSETTINGS` is likely never defined.