### PR TITLE
feat(gcb): Ability to invoke existing GCB triggers

### DIFF
--- a/app/scripts/modules/core/src/ci/igor.service.ts
+++ b/app/scripts/modules/core/src/ci/igor.service.ts
@@ -2,7 +2,7 @@ import { IPromise } from 'angular';
 import { $q } from 'ngimport';
 
 import { API } from 'core/api/ApiService';
-import { IBuild, IJobConfig } from 'core/domain';
+import { IBuild, IJobConfig, IGcbTrigger } from 'core/domain';
 
 export enum BuildServiceType {
   Jenkins = 'jenkins',
@@ -61,6 +61,13 @@ export class IgorService {
   public static getGcbAccounts(): IPromise<string[]> {
     return API.one('gcb')
       .one('accounts')
+      .get();
+  }
+
+  public static getGcbTriggers(account: string): IPromise<IGcbTrigger[]> {
+    return API.one('gcb')
+      .one('triggers')
+      .one(account)
       .get();
   }
 }

--- a/app/scripts/modules/core/src/domain/IGcbTrigger.ts
+++ b/app/scripts/modules/core/src/domain/IGcbTrigger.ts
@@ -1,0 +1,5 @@
+export interface IGcbTrigger {
+  id: string;
+  name: string;
+  description: string;
+}

--- a/app/scripts/modules/core/src/domain/index.ts
+++ b/app/scripts/modules/core/src/domain/index.ts
@@ -8,8 +8,6 @@ export * from './IBuild';
 export * from './IBuildDiffInfo';
 export * from './IBuildInfo';
 
-export * from './IGcbTrigger';
-
 export * from './ICloudMetric';
 export * from './ICluster';
 export * from './ICredentials';
@@ -22,6 +20,9 @@ export * from './IExecutionStage';
 export * from './IExecutionTrigger';
 export * from './IExpectedArtifact';
 export * from './IFunction';
+
+export * from './IGcbTrigger';
+
 export * from './IHealth';
 
 export * from './IInstance';

--- a/app/scripts/modules/core/src/domain/index.ts
+++ b/app/scripts/modules/core/src/domain/index.ts
@@ -8,6 +8,8 @@ export * from './IBuild';
 export * from './IBuildDiffInfo';
 export * from './IBuildInfo';
 
+export * from './IGcbTrigger';
+
 export * from './ICloudMetric';
 export * from './ICluster';
 export * from './ICredentials';

--- a/app/scripts/modules/core/src/pipeline/config/stages/googleCloudBuild/GoogleCloudBuildStageConfig.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/googleCloudBuild/GoogleCloudBuildStageConfig.tsx
@@ -2,11 +2,10 @@ import * as React from 'react';
 import { Observable, Subject } from 'rxjs';
 import { cloneDeep } from 'lodash';
 
-import { FormikStageConfig, IgorService, IStage, IStageConfigProps } from '@spinnaker/core';
+import { FormikStageConfig, IgorService, IStage, IStageConfigProps, IGcbTrigger } from '@spinnaker/core';
 
-import { GoogleCloudBuildStageForm, buildDefinitionSources } from './GoogleCloudBuildStageForm';
+import { GoogleCloudBuildStageForm, buildDefinitionSources, triggerType } from './GoogleCloudBuildStageForm';
 import { validate } from './googleCloudBuildValidators';
-import { IGcbTrigger } from 'core/domain';
 
 interface IGoogleCloudBuildStageConfigState {
   googleCloudBuildAccounts: string[];
@@ -30,6 +29,9 @@ export class GoogleCloudBuildStageConfig extends React.Component<IStageConfigPro
     }
     if (!stage.buildDefinitionSource) {
       stage.buildDefinitionSource = buildDefinitionSources.TEXT;
+    }
+    if (!stage.triggerType) {
+      stage.triggerType = triggerType.BRANCH;
     }
     // Intentionally initializing the stage config only once in the constructor
     // The stage config is then completely owned within FormikStageConfig's Formik state

--- a/app/scripts/modules/core/src/pipeline/config/stages/googleCloudBuild/GoogleCloudBuildStageConfig.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/googleCloudBuild/GoogleCloudBuildStageConfig.tsx
@@ -6,9 +6,11 @@ import { FormikStageConfig, IgorService, IStage, IStageConfigProps } from '@spin
 
 import { GoogleCloudBuildStageForm, buildDefinitionSources } from './GoogleCloudBuildStageForm';
 import { validate } from './googleCloudBuildValidators';
+import { IGcbTrigger } from 'core/domain';
 
 interface IGoogleCloudBuildStageConfigState {
   googleCloudBuildAccounts: string[];
+  gcbTriggers: IGcbTrigger[];
 }
 
 export class GoogleCloudBuildStageConfig extends React.Component<IStageConfigProps, IGoogleCloudBuildStageConfigState> {
@@ -19,6 +21,7 @@ export class GoogleCloudBuildStageConfig extends React.Component<IStageConfigPro
     super(props);
     this.state = {
       googleCloudBuildAccounts: [],
+      gcbTriggers: [],
     };
     const { stage: initialStageConfig } = props;
     const stage = cloneDeep(initialStageConfig);
@@ -35,6 +38,9 @@ export class GoogleCloudBuildStageConfig extends React.Component<IStageConfigPro
 
   public componentDidMount = (): void => {
     this.fetchGoogleCloudBuildAccounts();
+    if (this.stage.account) {
+      this.fetchGcbTriggers(this.stage.account);
+    }
   };
 
   private fetchGoogleCloudBuildAccounts = (): void => {
@@ -49,6 +55,14 @@ export class GoogleCloudBuildStageConfig extends React.Component<IStageConfigPro
     this.destroy$.next();
   }
 
+  private fetchGcbTriggers: (account: string) => void = account => {
+    Observable.fromPromise(IgorService.getGcbTriggers(account))
+      .takeUntil(this.destroy$)
+      .subscribe((gcbTriggers: IGcbTrigger[]) => {
+        this.setState({ gcbTriggers });
+      });
+  };
+
   public render() {
     return (
       <FormikStageConfig
@@ -60,7 +74,9 @@ export class GoogleCloudBuildStageConfig extends React.Component<IStageConfigPro
           <GoogleCloudBuildStageForm
             {...props}
             googleCloudBuildAccounts={this.state.googleCloudBuildAccounts}
+            gcbTriggers={this.state.gcbTriggers}
             updatePipeline={this.props.updatePipeline}
+            fetchGcbTriggers={this.fetchGcbTriggers}
           />
         )}
       />

--- a/app/scripts/modules/core/src/pipeline/config/stages/googleCloudBuild/googleCloudBuildValidators.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/googleCloudBuild/googleCloudBuildValidators.ts
@@ -1,7 +1,14 @@
 import { FormValidator, IContextualValidator, IStage } from '@spinnaker/core';
+import { buildDefinitionSources } from './GoogleCloudBuildStageForm';
 
 export const validate: IContextualValidator = (stage: IStage) => {
   const formValidator = new FormValidator(stage);
   formValidator.field('account', 'Account').required();
+  if (stage.buildDefinitionSource === buildDefinitionSources.TRIGGER) {
+    formValidator.field('triggerId', 'Trigger Name').required();
+    formValidator.field('triggerType', 'Trigger Type').required();
+    const triggerType = stage.triggerType;
+    formValidator.field(`repoSource.${triggerType}`, 'Value').required();
+  }
   return formValidator.validateForm();
 };


### PR DESCRIPTION
Added ability to call existing GCB triggers.
This is part of: spinnaker/spinnaker#5076

Added a new `Build Definition Source` to the `GoogleCloudBuild` stage.


When this type is selected, new set of fields are shown:

- Trigger Name: A list of triggers populated when `GoogleCloudBuild` account changes.
- Trigger Type: It has to be one of `commitSHA`, `tagName` or `branchName`. Opted for a dropdown list because google api will fail if we send more than one trigger type.
- Value: The value for the trigger type.

<kbd>![](https://user-images.githubusercontent.com/3589427/68738919-b05ddd00-063b-11ea-859f-6b4e13e85a2b.png)</kbd>
