### PR TITLE
feat(manualjudgment): Select roles that can execute manual judgement …

### DIFF
--- a/app/scripts/modules/core/src/application/service/ApplicationReader.ts
+++ b/app/scripts/modules/core/src/application/service/ApplicationReader.ts
@@ -41,6 +41,17 @@ export class ApplicationReader {
       });
   }
 
+  public static getApplicationPermissions(applicationName: string): IPromise < any > {
+        return API.one('applications', applicationName)
+            .withParams({
+                expand: false
+            })
+            .get()
+            .then((fromServer: Application) => {
+                return fromServer.attributes.permissions;
+            });
+    }
+
   public static getApplication(name: string, expand = true): IPromise<Application> {
     return API.one('applications', name)
       .withParams({ expand: expand })

--- a/app/scripts/modules/core/src/pipeline/config/stages/stage.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/stage.html
@@ -64,6 +64,26 @@
           </ui-select-choices>
         </ui-select>
       </stage-config-field>
+      <stage-config-field label="Authorized Groups" help-key="pipeline.config.trigger.runAsUser" ng-if="stage.type === 'manualJudgment'" style="margin-bottom: 10px">
+        <ui-select
+          ng-model="stage.selectedStageRoles"
+          multiple
+          class="form-control input-sm"
+          on-select="updateAvailableStageRoles()"
+          on-remove="updateAvailableStageRoles()"
+        >
+          <ui-select-match>{{$item.name}}</ui-select-match>
+          <ui-select-choices
+            repeat="option.roleId as option in options.stageRoles | anyFieldFilter: {name: $select.search}"
+            ui-disable-choice="!option.available"
+          >
+            <span
+              ng-if="!stage.selectedStageRoles.includes(option.roleId)"
+              ng-bind-html="option.name | highlight: $select.search"
+            ></span>
+          </ui-select-choices>
+        </ui-select>
+      </stage-config-field>
     </div>
     <div class="col-md-2 text-right">
       <button


### PR DESCRIPTION
…#4792

Added ability to add roles to manual judgment stage.
This is part of: spinnaker/spinnaker#4792.

Enhanced stage.html to

Get the roles of the application.
Display the roles of the application as a list only if the stage is Manual Judgment.
Enhanced stage.module.js to

Fetch the permissions of the application from the gate application url.
populate the list with only the roles of the application with no duplicates.
Enhanced ApplicationReader.ts to

Fetch the permissions of the application from the gate application url.
Enhanced ManualJudgmentApproval.tsx to

Fetch the roles of the application, stage and the user during the execution.
Iterate through each of the user role to check if the role exists in the stage and application.
If yes/no, enable/disable the continue button.
Display the instruction that User does not have permissions to continue