### PR TITLE
feat(manualjudgment): Select roles that can execute manual judgement …

### DIFF
--- a/app/scripts/modules/core/src/application/service/ApplicationReader.ts
+++ b/app/scripts/modules/core/src/application/service/ApplicationReader.ts
@@ -41,6 +41,17 @@ export class ApplicationReader {
       });
   }
 
+  public static getApplicationPermissions(applicationName: string): IPromise < any > {
+        return API.one('applications', applicationName)
+            .withParams({
+                expand: false
+            })
+            .get()
+            .then((fromServer: Application) => {
+                return fromServer.attributes.permissions;
+            });
+    }
+
   public static getApplication(name: string, expand = true): IPromise<Application> {
     return API.one('applications', name)
       .withParams({ expand: expand })

--- a/app/scripts/modules/core/src/pipeline/config/stages/manualJudgment/ManualJudgmentApproval.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/manualJudgment/ManualJudgmentApproval.tsx
@@ -5,6 +5,8 @@ import { IExecution, IExecutionStage } from 'core/domain';
 import { Application } from 'core/application/application.model';
 import { Markdown } from 'core/presentation/Markdown';
 import { NgReact, ReactInjector } from 'core/reactShims';
+import { ApplicationReader } from 'core/application/service/ApplicationReader';
+import { AuthenticationService } from 'core/authentication';
 
 export interface IManualJudgmentApprovalProps {
   execution: IExecution;
@@ -16,6 +18,10 @@ export interface IManualJudgmentApprovalState {
   submitting: boolean;
   judgmentDecision: string;
   judgmentInput: { value?: string };
+  applicationRoles: {};
+  appRoles: string[];
+  runOnce: boolean;
+  userRoles: string[];
   error: boolean;
 }
 
@@ -29,8 +35,33 @@ export class ManualJudgmentApproval extends React.Component<
       submitting: false,
       judgmentDecision: null,
       judgmentInput: {},
+      applicationRoles: {},
+      appRoles: [],
+      runOnce: true,
+      userRoles: [],
       error: false,
     };
+  }
+
+  componentDidMount() {
+      if (this.state.runOnce) {
+          const applicationName = this.props.execution.application;
+          ApplicationReader.getApplicationPermissions(applicationName)
+              .then(result => {
+                  this.setState({
+                      applicationRoles: result,
+                      runOnce: false,
+                  })
+                  this.populateApplicationRoles();
+                  this.isStageAuthorized();
+              })
+              .catch(error => this.setState({
+                  error,
+              }));
+          this.setState({
+              userRoles: AuthenticationService.getAuthenticatedUser().roles
+          });
+      }
   }
 
   private provideJudgment(judgmentDecision: string): void {
@@ -45,6 +76,37 @@ export class ManualJudgmentApproval extends React.Component<
       this.props.stage.context.judgmentStatus === decision ||
       (this.state.submitting && this.state.judgmentDecision === decision)
     );
+  }
+
+  private populateApplicationRoles(): void {
+      const constAppRoles = this.state.applicationRoles;
+      const readArray = constAppRoles.READ || [];
+      const writeArray = constAppRoles.WRITE || [];
+      const executeArray = constAppRoles.EXECUTE || [];
+      const roles = readArray.concat(writeArray, executeArray);
+      this.setState({
+          appRoles: Array.from(new Set(roles))
+      });
+  }
+
+  private isStageAuthorized(): boolean {
+
+      let disableBtn = true;
+      let usrRole;
+      const stageRoles = this.props.stage.context.selectedStageRoles || [];
+      const appRoles = this.state.appRoles;
+      const usrRoles = this.state.userRoles;
+      if (appRoles.length === 0 || stageRoles.length === 0) {
+          disableBtn = false;
+          return disableBtn;
+      }
+      for (usrRole of usrRoles) {
+          if ((stageRoles.indexOf(usrRole) > -1) && (appRoles.indexOf(usrRole) > -1)) {
+              disableBtn = false;
+              break;
+          }
+      }
+      return disableBtn;
   }
 
   private handleJudgementChanged = (option: Option): void => {
@@ -103,7 +165,7 @@ export class ManualJudgmentApproval extends React.Component<
                 className="btn btn-danger"
                 onClick={this.handleStopClick}
                 disabled={
-                  this.state.submitting ||
+                  this.isStageAuthorized() || this.state.submitting ||
                   stage.context.judgmentStatus ||
                   (options.length && !this.state.judgmentInput.value)
                 }
@@ -114,7 +176,7 @@ export class ManualJudgmentApproval extends React.Component<
               <button
                 className="btn btn-primary"
                 disabled={
-                  this.state.submitting ||
+                  this.isStageAuthorized() || this.state.submitting ||
                   stage.context.judgmentStatus ||
                   (options.length && !this.state.judgmentInput.value)
                 }

--- a/app/scripts/modules/core/src/pipeline/config/stages/stage.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/stage.html
@@ -64,6 +64,26 @@
           </ui-select-choices>
         </ui-select>
       </stage-config-field>
+      <stage-config-field label="Authorized Groups" help-key="pipeline.config.trigger.runAsUser" ng-if="stage.type === 'manualJudgment'" style="margin-bottom: 10px">
+        <ui-select
+          ng-model="stage.selectedStageRoles"
+          multiple
+          class="form-control input-sm"
+          on-select="updateAvailableStageRoles()"
+          on-remove="updateAvailableStageRoles()"
+        >
+          <ui-select-match>{{$item.name}}</ui-select-match>
+          <ui-select-choices
+            repeat="option.roleId as option in options.stageRoles | anyFieldFilter: {name: $select.search}"
+            ui-disable-choice="!option.available"
+          >
+            <span
+              ng-if="!stage.selectedStageRoles.includes(option.roleId)"
+              ng-bind-html="option.name | highlight: $select.search"
+            ></span>
+          </ui-select-choices>
+        </ui-select>
+      </stage-config-field>
     </div>
     <div class="col-md-2 text-right">
       <button


### PR DESCRIPTION
…#4792

Added ability to add roles to manual judgment stage.
This is part of: spinnaker/spinnaker#4792.

Enhanced stage.html to

Get the roles of the application.
Display the roles of the application as a list only if the stage is Manual Judgment.
Enhanced stage.module.js to

Fetch the permissions of the application from the gate application url.
populate the list with only the roles of the application with no duplicates.
Enhanced ApplicationReader.ts to

Fetch the permissions of the application from the gate application url.
Enhanced ManualJudgmentApproval.tsx to

Fetch the roles of the application, stage and the user during the execution.
Iterate through each of the user role to check if the role exists in the stage and application.
If yes/no, enable/disable the continue button.
Display the instruction that User does not have permissions to continue.