### PR TITLE
fix(core/pipeline): ExecutionAndStagePicker Fix auto selection of stage

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/evaluateVariables/ExecutionAndStagePicker.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/evaluateVariables/ExecutionAndStagePicker.tsx
@@ -143,11 +143,13 @@ function findCloseStageFromExecution(pipeline: IPipeline, execution: IExecution,
 }
 
 function stageRequisiteStageGraph(stage: IStage, allStages: { [key: string]: IStage }): { [key: string]: any } {
-  return stage.requisiteStageRefIds.reduce((acc, requisiteStageId) => {
-    const requisiteStage = allStages[requisiteStageId];
-    if (!requisiteStage) {
-      return acc;
-    }
-    return { ...acc, [requisiteStageId]: stageRequisiteStageGraph(requisiteStage, allStages) };
-  }, {});
+  return stage.requisiteStageRefIds
+    .filter(ref => /^[0-9]+$/.exec(ref.toString()))
+    .reduce((acc, requisiteStageId) => {
+      const requisiteStage = allStages[requisiteStageId];
+      if (!requisiteStage) {
+        return acc;
+      }
+      return { ...acc, [requisiteStageId]: stageRequisiteStageGraph(requisiteStage, allStages) };
+    }, {});
 }


### PR DESCRIPTION
This fixes auto-selection of a execution/stage in the evaluate expressions stage.  

This code looks for a matching stage between the pipeline source stages and the executed stages found in the selected previous execution.  This filters out any non-numeric stage ref ids, i.e. "waitForAuthorizationContext".  


Before:
<img width="748" alt="Screen Shot 2019-11-16 at 9 58 18 AM" src="https://user-images.githubusercontent.com/2053478/68997108-a4e6fd80-0857-11ea-82d8-da0589a012ac.png">
