### PR TITLE
fix(amazon): Copy capacity from current server group does not persist

### DIFF
--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/capacity/CapacitySelector.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/capacity/CapacitySelector.tsx
@@ -34,7 +34,6 @@ export class CapacitySelector extends React.Component<ICapacitySelectorProps> {
       ...command.viewState,
       useSimpleCapacity: simpleCapacity,
     };
-    // command.viewState.useSimpleCapacity = simpleCapacity;
     this.props.setFieldValue('useSourceCapacity', false);
     this.props.setFieldValue('viewState', newViewState);
     this.setMinMax(command.capacity.desired);

--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/capacity/CapacitySelector.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/capacity/CapacitySelector.tsx
@@ -30,8 +30,13 @@ export class CapacitySelector extends React.Component<ICapacitySelectorProps> {
 
   private setSimpleCapacity(simpleCapacity: boolean) {
     const { command } = this.props;
-    command.viewState.useSimpleCapacity = simpleCapacity;
+    const newViewState = {
+      ...command.viewState,
+      useSimpleCapacity: simpleCapacity,
+    };
+    // command.viewState.useSimpleCapacity = simpleCapacity;
     this.props.setFieldValue('useSourceCapacity', false);
+    this.props.setFieldValue('viewState', newViewState);
     this.setMinMax(command.capacity.desired);
     this.setState({});
   }
@@ -67,7 +72,7 @@ export class CapacitySelector extends React.Component<ICapacitySelectorProps> {
 
     const readOnlyFields = command.viewState.readOnlyFields || {};
 
-    if (!command.viewState.useSimpleCapacity) {
+    if (!command.viewState.useSimpleCapacity || command.useSourceCapacity) {
       return (
         <div>
           <div className="form-group">


### PR DESCRIPTION
When editing a Titus deploy stage and setting the capacity to "Copy the capacity form the current server group" in advanced mode, the state does not persist after saving + reloading. This PR fixes this so that the situation below does not happen. 

Example: 
<img width="680" alt="Screen Shot 2019-10-28 at 12 34 50 PM" src="https://user-images.githubusercontent.com/26560152/69194768-db827980-0ade-11ea-862e-0b41f599407b.png">
<img width="672" alt="Screen Shot 2019-10-28 at 12 35 05 PM" src="https://user-images.githubusercontent.com/26560152/69194770-dd4c3d00-0ade-11ea-8fad-07287be51543.png">



