### PR TITLE
chore(amazon): Bump version to 0.0.224

### DIFF
--- a/app/scripts/modules/amazon/package.json
+++ b/app/scripts/modules/amazon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/amazon",
-  "version": "0.0.223",
+  "version": "0.0.224",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
This has not been published yet.

Instead, trying a new workflow where the package bump(s) are authored first, then the exact commits on master shall be published when they land.

Still working out the kinks for that piece.

Also, no more changeset here because it may not always reflect reality (i.e. of additional commits landed on master)