### PR TITLE
fix(travis): Fixing typos in package bump checks

### DIFF
--- a/app/scripts/modules/assert_package_bumps_standalone.sh
+++ b/app/scripts/modules/assert_package_bumps_standalone.sh
@@ -4,7 +4,7 @@
 
 PKGJSONCHANGED="Version change detected in package.json"
 ONLYVERSIONCHANGED="Version change must be the only line changed in package.json"
-ONLYPKGJSONCHANGED="package.json (in apps/scripts/modules) must be the only files changed in a pull request with version bumps"
+ONLYPKGJSONCHANGED="package.json (in app/scripts/modules) must be the only files changed in a pull request with version bumps"
 
 echo "TRAVIS_BRANCH=$TRAVIS_BRANCH"
 TARGET_BRANCH=${TRAVIS_BRANCH:-master}
@@ -38,8 +38,8 @@ for PKGJSON in `ls app/scripts/modules/*/package.json` ; do
       echo " [ PASS ] $ONLYVERSIONCHANGED"
     fi
 
-    # checking that the only files changed are apps/scripts/modules/*/package.json
-    OTHER_FILES_CHANGED=`git diff --name-only $TARGET_BRANCH | grep -v "apps/scripts/modules/*/package.json" | wc -l`
+    # checking that the only files changed are app/scripts/modules/*/package.json
+    OTHER_FILES_CHANGED=`git diff --name-only $TARGET_BRANCH | grep -v "app/scripts/modules/.*/package.json" | wc -l`
     if [ $OTHER_FILES_CHANGED -ne 0 ] ; then
       echo " [ FAIL ] $ONLYPKGJSONCHANGED"
       echo ""


### PR DESCRIPTION
Neat!

In #7646 the new checks _almost_ worked:
```
===================================================
Checking amazon
===================================================
 [ YES  ] Version change detected in package.json
 [ PASS ] Version change must be the only line changed in package.json
 [ FAIL ] package.json (in apps/scripts/modules) must be the only files changed in a pull request with version bumps
===========================================
Failure details (list of all files changed)
===========================================
app/scripts/modules/amazon/package.json
===========================================
```

Except for a few typos that caused the last check to fail incorrectly.