### PR TITLE
fix(amazon): Removing unsupported negative lookbehind

### DIFF
--- a/app/scripts/modules/amazon/src/aws.validators.ts
+++ b/app/scripts/modules/amazon/src/aws.validators.ts
@@ -8,10 +8,10 @@ export const iamRoleValidator = (value: string, label: string) => {
 };
 
 export const s3BucketNameValidator = (value: string, label: string) => {
-  const s3BucketName = value.match(/^[0-9A-Za-z\.\-_]*(?<!\.)$/);
+  const s3BucketName = value.match(/^[0-9A-Za-z\.\-_]*[^\.]$/);
   const err = s3BucketName
     ? undefined
-    : `Invalid S3 Bucket name.  ${label} must match regular expression: [0-9A-Za-z\.\-_]*(?<!\.)$`;
+    : `Invalid S3 Bucket name.  ${label} must match regular expression: [0-9A-Za-z\.\-_]*[^\.]$`;
   return err;
 };
 


### PR DESCRIPTION
[Firefox does not support lookbehind assertions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#Browser_compatibility) so the RegExp `^[0-9A-Za-z\.\-_]*(?<!\.)$` causes a syntax error and deck will not load at all in Firefox.

I think all this is trying to do is ensure the string does not end in a `.`, so I replaced with with a compatible expression that I _think_ does the same thing.

@sidmuls FYI in case I inadvertently altered the behavior.