### PR TITLE
chore(tsconfig): standardize all tsconfig.json files to es2017

### DIFF
--- a/app/scripts/modules/amazon/tsconfig.json
+++ b/app/scripts/modules/amazon/tsconfig.json
@@ -9,7 +9,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "jsx": "react",
-    "lib": ["es2016", "dom"],
+    "lib": ["es2017", "dom"],
     "moduleResolution": "node",
     "module": "esnext",
     "noEmitHelpers": false,

--- a/app/scripts/modules/appengine/tsconfig.json
+++ b/app/scripts/modules/appengine/tsconfig.json
@@ -9,7 +9,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "jsx": "react",
-    "lib": ["es2016", "dom"],
+    "lib": ["es2017", "dom"],
     "moduleResolution": "node",
     "module": "esnext",
     "noEmitHelpers": false,

--- a/app/scripts/modules/azure/tsconfig.json
+++ b/app/scripts/modules/azure/tsconfig.json
@@ -9,7 +9,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "jsx": "react",
-    "lib": ["es2016", "dom", "es2017.object"],
+    "lib": ["es2017", "dom"],
     "moduleResolution": "node",
     "module": "esnext",
     "noEmitHelpers": false,

--- a/app/scripts/modules/cloudfoundry/tsconfig.json
+++ b/app/scripts/modules/cloudfoundry/tsconfig.json
@@ -9,7 +9,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "jsx": "react",
-    "lib": ["es2016", "dom"],
+    "lib": ["es2017", "dom"],
     "moduleResolution": "node",
     "module": "esnext",
     "noEmitHelpers": false,

--- a/app/scripts/modules/core/tsconfig.json
+++ b/app/scripts/modules/core/tsconfig.json
@@ -9,7 +9,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "jsx": "react",
-    "lib": ["es2016", "dom"],
+    "lib": ["es2017", "dom"],
     "moduleResolution": "node",
     "module": "esnext",
     "noEmitHelpers": false,

--- a/app/scripts/modules/docker/tsconfig.json
+++ b/app/scripts/modules/docker/tsconfig.json
@@ -9,7 +9,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "jsx": "react",
-    "lib": ["es2016", "dom"],
+    "lib": ["es2017", "dom"],
     "moduleResolution": "node",
     "module": "esnext",
     "noEmitHelpers": false,

--- a/app/scripts/modules/ecs/tsconfig.json
+++ b/app/scripts/modules/ecs/tsconfig.json
@@ -9,7 +9,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "jsx": "react",
-    "lib": ["es2016", "dom"],
+    "lib": ["es2017", "dom"],
     "moduleResolution": "node",
     "module": "esnext",
     "noEmitHelpers": false,

--- a/app/scripts/modules/google/tsconfig.json
+++ b/app/scripts/modules/google/tsconfig.json
@@ -9,7 +9,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "jsx": "react",
-    "lib": ["es2016", "dom"],
+    "lib": ["es2017", "dom"],
     "moduleResolution": "node",
     "module": "esnext",
     "noEmitHelpers": false,

--- a/app/scripts/modules/huaweicloud/tsconfig.json
+++ b/app/scripts/modules/huaweicloud/tsconfig.json
@@ -9,7 +9,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "jsx": "react",
-    "lib": ["es2016", "dom"],
+    "lib": ["es2017", "dom"],
     "moduleResolution": "node",
     "module": "esnext",
     "noEmitHelpers": false,

--- a/app/scripts/modules/oracle/tsconfig.json
+++ b/app/scripts/modules/oracle/tsconfig.json
@@ -9,7 +9,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "jsx": "react",
-    "lib": ["es2016", "dom"],
+    "lib": ["es2017", "dom"],
     "moduleResolution": "node",
     "module": "esnext",
     "noEmitHelpers": false,

--- a/app/scripts/modules/titus/tsconfig.json
+++ b/app/scripts/modules/titus/tsconfig.json
@@ -9,7 +9,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "jsx": "react",
-    "lib": ["es2016", "dom"],
+    "lib": ["es2017", "dom"],
     "moduleResolution": "node",
     "module": "esnext",
     "noEmitHelpers": false,


### PR DESCRIPTION
On another feature branch I was using `Object.values` and ran into a TS error — turns out while our root `tsconfig.json` was on `es2017` most of them are on `es2016`. This just standardizes all of the configs on `es2017`, which should theoretically be harmless 🤷‍♂ 