### PR TITLE
feat(core/presentation): add four new hooks + tests

### DIFF
--- a/app/scripts/modules/core/src/presentation/hooks/useContainerClassNames.hook.spec.tsx
+++ b/app/scripts/modules/core/src/presentation/hooks/useContainerClassNames.hook.spec.tsx
@@ -1,0 +1,75 @@
+import * as React from 'react';
+import { mount } from 'enzyme';
+import { useContainerClassNames } from './useContainerClassNames.hook';
+
+const TestComponent = ({ classNames }: { classNames: string[] }) => {
+  useContainerClassNames(classNames);
+  return null as JSX.Element;
+};
+
+const containerClassName = 'spinnaker-container';
+const testClassNames = ['testClass1', 'testClass2'];
+
+describe('useContainerClassNames', () => {
+  let containerElement: HTMLDivElement;
+
+  beforeEach(() => {
+    containerElement = document.createElement('div');
+    containerElement.classList.add(containerClassName);
+  });
+
+  it('should add class names to the container element when mounted', () => {
+    spyOn(document, 'querySelector').and.returnValue(containerElement);
+
+    mount(<TestComponent classNames={testClassNames} />);
+
+    expect(containerElement.classList.contains(testClassNames[0])).toBe(true);
+    expect(containerElement.classList.contains(testClassNames[1])).toBe(true);
+  });
+
+  it('should remove class names from the container element when unmounted', () => {
+    spyOn(document, 'querySelector').and.returnValue(containerElement);
+
+    const component = mount(<TestComponent classNames={testClassNames} />);
+
+    component.render();
+    component.unmount();
+
+    expect(containerElement.classList.contains(testClassNames[0])).toBe(false);
+    expect(containerElement.classList.contains(testClassNames[1])).toBe(false);
+  });
+
+  it('should add and remove class names when the elements in "classNames" change', () => {
+    spyOn(document, 'querySelector').and.returnValue(containerElement);
+
+    const component = mount(<TestComponent classNames={testClassNames} />);
+
+    expect(containerElement.classList.contains(testClassNames[0])).toBe(true);
+    expect(containerElement.classList.contains(testClassNames[1])).toBe(true);
+
+    component.setProps({ classNames: testClassNames.concat('additionalClass') });
+    component.render();
+
+    expect(containerElement.classList.contains(testClassNames[0])).toBe(true);
+    expect(containerElement.classList.contains(testClassNames[1])).toBe(true);
+    expect(containerElement.classList.contains('additionalClass')).toBe(true);
+
+    component.setProps({ classNames: [testClassNames[0]] });
+    component.render();
+
+    expect(containerElement.classList.contains(testClassNames[0])).toBe(true);
+    expect(containerElement.classList.contains(testClassNames[1])).toBe(false);
+    expect(containerElement.classList.contains('additionalClass')).toBe(false);
+
+    component.setProps({ classNames: [] });
+    component.render();
+
+    expect(containerElement.classList.contains(testClassNames[0])).toBe(false);
+  });
+
+  it('should silently do nothing when the container element does not exist', () => {
+    spyOn(document, 'querySelector').and.returnValue(null);
+
+    expect(() => mount(<TestComponent classNames={testClassNames} />)).not.toThrow();
+  });
+});

--- a/app/scripts/modules/core/src/presentation/hooks/useContainerClassNames.hook.ts
+++ b/app/scripts/modules/core/src/presentation/hooks/useContainerClassNames.hook.ts
@@ -1,0 +1,43 @@
+import * as React from 'react';
+
+import { usePrevious } from './usePrevious.hook';
+
+const { useEffect, useRef } = React;
+
+const getContainerElement = () => document.querySelector('.spinnaker-container');
+
+export const useContainerClassNames = (classNames: string[]) => {
+  const previousClassNames = usePrevious(classNames);
+
+  useEffect(() => {
+    const containerElement = getContainerElement();
+    if (!containerElement) {
+      return undefined;
+    }
+
+    // If any of the classes in a previous `classNames` array are no longer present,
+    // let's make sure they get cleaned up on the DOM
+    if (previousClassNames) {
+      const removedClassNames = previousClassNames.filter(className => !classNames.includes(className));
+      containerElement.classList.remove(...removedClassNames);
+    }
+
+    containerElement.classList.add(...classNames);
+  }, [classNames.sort().join()]);
+
+  // Take all the most recent classNames off at unmount. It'd be nice to do this in a function
+  // returned from the other useEffect, but then we'd be thrashing class names off
+  // and back onto the element every time the list of classes changes.
+  const classNamesRef = useRef(classNames);
+  classNamesRef.current = classNames;
+  useEffect(() => {
+    return () => {
+      const containerElement = getContainerElement();
+      if (!containerElement) {
+        return undefined;
+      }
+
+      containerElement.classList.remove(...classNamesRef.current);
+    };
+  }, []);
+};

--- a/app/scripts/modules/core/src/presentation/hooks/useEventListener.hook.spec.tsx
+++ b/app/scripts/modules/core/src/presentation/hooks/useEventListener.hook.spec.tsx
@@ -1,0 +1,176 @@
+import * as React from 'react';
+import { mount } from 'enzyme';
+import { useEventListener } from './useEventListener.hook';
+
+const TestComponent = ({
+  element,
+  eventName,
+  listener,
+  options,
+}: {
+  element: Element;
+  eventName: string;
+  listener?: (e: Event) => any;
+  options: AddEventListenerOptions;
+}) => {
+  useEventListener(element, eventName, listener, options);
+  return null as JSX.Element;
+};
+
+const eventListenerOptions = { capture: true };
+
+describe('useEventListener', () => {
+  let eventTarget: HTMLDivElement;
+  let addEventListenerSpy: jasmine.Spy;
+  let removeEventListenerSpy: jasmine.Spy;
+
+  beforeEach(() => {
+    eventTarget = document.createElement('div');
+    addEventListenerSpy = spyOn(eventTarget, 'addEventListener').and.returnValue(undefined);
+    removeEventListenerSpy = spyOn(eventTarget, 'removeEventListener').and.returnValue(undefined);
+  });
+
+  it('should call addEventListener on the target element when mounted', () => {
+    mount(
+      <TestComponent element={eventTarget} eventName="keydown" listener={() => null} options={eventListenerOptions} />,
+    );
+
+    expect(addEventListenerSpy).toHaveBeenCalledTimes(1);
+    expect(removeEventListenerSpy).toHaveBeenCalledTimes(0);
+
+    expect(addEventListenerSpy.calls.argsFor(0)[0]).toBe('keydown');
+    expect(addEventListenerSpy.calls.argsFor(0)[2]).toBe(eventListenerOptions);
+  });
+
+  it('should not do anything when mounted if there is no listener prop', () => {
+    mount(<TestComponent element={eventTarget} eventName="keydown" options={eventListenerOptions} />);
+
+    expect(addEventListenerSpy).toHaveBeenCalledTimes(0);
+    expect(removeEventListenerSpy).toHaveBeenCalledTimes(0);
+  });
+
+  it('should call removeEventListener on the target element when unmounted', () => {
+    const component = mount(
+      <TestComponent element={eventTarget} eventName="keydown" listener={() => null} options={eventListenerOptions} />,
+    );
+
+    expect(addEventListenerSpy).toHaveBeenCalledTimes(1);
+    expect(removeEventListenerSpy).toHaveBeenCalledTimes(0);
+
+    component.unmount();
+
+    expect(addEventListenerSpy).toHaveBeenCalledTimes(1);
+    expect(removeEventListenerSpy).toHaveBeenCalledTimes(1);
+
+    expect(removeEventListenerSpy.calls.argsFor(0)[0]).toBe('keydown');
+    expect(removeEventListenerSpy.calls.argsFor(0)[2]).toBe(eventListenerOptions);
+  });
+
+  it('should call removeEventListener with the same event listener function reference', () => {
+    let addedListener: any;
+    let removedListener: any;
+    addEventListenerSpy.and.callFake((_: string, eventListener: () => any) => (addedListener = eventListener));
+    removeEventListenerSpy.and.callFake((_: string, eventListener: () => any) => (removedListener = eventListener));
+
+    const component = mount(
+      <TestComponent element={eventTarget} eventName="keydown" listener={() => null} options={eventListenerOptions} />,
+    );
+
+    component.unmount();
+
+    expect(addEventListenerSpy).toHaveBeenCalledTimes(1);
+    expect(removeEventListenerSpy).toHaveBeenCalledTimes(1);
+
+    expect(addedListener).toBe(removedListener);
+  });
+
+  it('should call the latest listener prop', () => {
+    let addedListener: any;
+    addEventListenerSpy.and.callFake((_: string, eventListener: () => any) => (addedListener = eventListener));
+
+    const initialListener = jasmine.createSpy('initialListener', () => 'initial');
+
+    const component = mount(
+      <TestComponent
+        element={eventTarget}
+        eventName="keydown"
+        listener={initialListener}
+        options={eventListenerOptions}
+      />,
+    );
+
+    addedListener();
+    expect(initialListener).toHaveBeenCalledTimes(1);
+
+    const updatedListener = jasmine.createSpy('updatedListener', () => 'updated');
+    component.setProps({ listener: updatedListener });
+
+    addedListener();
+    expect(initialListener).toHaveBeenCalledTimes(1);
+    expect(updatedListener).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call removeEventListener with the same event listener function reference after updating the listener prop', () => {
+    let addedListener: any;
+    let removedListener: any;
+    addEventListenerSpy.and.callFake((_: string, eventListener: () => any) => (addedListener = eventListener));
+    removeEventListenerSpy.and.callFake((_: string, eventListener: () => any) => (removedListener = eventListener));
+
+    const component = mount(
+      <TestComponent
+        element={eventTarget}
+        eventName="keydown"
+        listener={() => 'initial'}
+        options={eventListenerOptions}
+      />,
+    );
+
+    component.setProps({ listener: () => 'updated' });
+
+    component.unmount();
+
+    expect(addEventListenerSpy).toHaveBeenCalledTimes(1);
+    expect(removeEventListenerSpy).toHaveBeenCalledTimes(1);
+
+    expect(addedListener).toBe(removedListener);
+  });
+
+  it('should add and remove the same listener reference when the listener prop is added/removed', () => {
+    let addedListener: any;
+    let removedListener: any;
+    addEventListenerSpy.and.callFake((_: string, eventListener: () => any) => (addedListener = eventListener));
+    removeEventListenerSpy.and.callFake((_: string, eventListener: () => any) => (removedListener = eventListener));
+
+    const component = mount(
+      <TestComponent
+        element={eventTarget}
+        eventName="keydown"
+        listener={() => 'first'}
+        options={eventListenerOptions}
+      />,
+    );
+
+    expect(addEventListenerSpy).toHaveBeenCalledTimes(1);
+    expect(removeEventListenerSpy).toHaveBeenCalledTimes(0);
+    component.setProps({ listener: null });
+
+    expect(addEventListenerSpy).toHaveBeenCalledTimes(1);
+    expect(removeEventListenerSpy).toHaveBeenCalledTimes(1);
+
+    expect(addedListener).toBe(removedListener);
+
+    component.setProps({ listener: () => 'second' });
+
+    expect(addEventListenerSpy).toHaveBeenCalledTimes(2);
+    expect(removeEventListenerSpy).toHaveBeenCalledTimes(1);
+
+    expect(addedListener).toBe(removedListener);
+
+    component.setProps({ listener: null });
+
+    expect(addEventListenerSpy).toHaveBeenCalledTimes(2);
+    expect(removeEventListenerSpy).toHaveBeenCalledTimes(2);
+
+    expect(addedListener).toBe(removedListener);
+  });
+});

--- a/app/scripts/modules/core/src/presentation/hooks/useEventListener.hook.ts
+++ b/app/scripts/modules/core/src/presentation/hooks/useEventListener.hook.ts
@@ -1,0 +1,33 @@
+import * as React from 'react';
+
+import { useLatestCallback } from './useLatestCallback.hook';
+
+const { useEffect } = React;
+
+export const useEventListener = (
+  element: EventTarget,
+  eventName: string,
+  listener?: (event: Event) => any,
+  options?: AddEventListenerOptions,
+) => {
+  const memoizedListener = useLatestCallback(listener);
+
+  useEffect(() => {
+    if (!listener) {
+      return undefined;
+    }
+
+    element.addEventListener(eventName, memoizedListener, options);
+
+    return () => {
+      element.removeEventListener(eventName, memoizedListener, options);
+    };
+  }, [
+    element,
+    eventName,
+    !!listener,
+    Object.values(options || {})
+      .sort()
+      .join(),
+  ]);
+};

--- a/app/scripts/modules/core/src/presentation/hooks/useLatestCallback.hook.spec.tsx
+++ b/app/scripts/modules/core/src/presentation/hooks/useLatestCallback.hook.spec.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+import { mount } from 'enzyme';
+import { useLatestCallback } from './useLatestCallback.hook';
+
+const TestComponent = ({
+  callback,
+  onCallbackChange,
+}: {
+  callback: (...args: any) => any;
+  onCallbackChange: (callback: Function) => any;
+}) => {
+  const memoizedCallback = useLatestCallback(callback);
+  onCallbackChange(memoizedCallback);
+  return null as JSX.Element;
+};
+
+describe('useLatestCallback', () => {
+  it('should give back a stable function reference when the callback argument changes', () => {
+    const callbacksFromHook: any[] = [];
+    const onCallbackChange = (callback: any) => callbacksFromHook.push(callback);
+
+    const component = mount(<TestComponent callback={() => 'first'} onCallbackChange={onCallbackChange} />);
+
+    component.setProps({ callback: () => 'second' });
+
+    expect(callbacksFromHook.length).toBe(2);
+    expect(callbacksFromHook[0]).toBe(callbacksFromHook[1]);
+
+    component.setProps({ callback: () => 'third' });
+
+    expect(callbacksFromHook.length).toBe(3);
+    expect(callbacksFromHook[1]).toBe(callbacksFromHook[2]);
+  });
+
+  it('should always call the latest callback argument', () => {
+    let callbackFromHook: any;
+    const onCallbackChange = (callback: any) => (callbackFromHook = callback);
+
+    const initialCallback = jasmine.createSpy('initialCallback', () => 'initial');
+
+    const component = mount(<TestComponent callback={initialCallback} onCallbackChange={onCallbackChange} />);
+
+    callbackFromHook();
+    expect(initialCallback).toHaveBeenCalledTimes(1);
+
+    const updatedCallback = jasmine.createSpy('updatedCallback', () => 'updated');
+
+    component.setProps({ callback: updatedCallback });
+
+    callbackFromHook();
+    expect(initialCallback).toHaveBeenCalledTimes(1);
+    expect(updatedCallback).toHaveBeenCalledTimes(1);
+  });
+
+  it('should pass through the arguments/return value of the original callback', () => {
+    let callbackFromHook: any;
+    const onCallbackChange = (callback: any) => (callbackFromHook = callback);
+
+    mount(<TestComponent callback={value => `Hello ${value}`} onCallbackChange={onCallbackChange} />);
+
+    const returnValue = callbackFromHook('World');
+    expect(returnValue).toBe('Hello World');
+  });
+});

--- a/app/scripts/modules/core/src/presentation/hooks/useLatestCallback.hook.ts
+++ b/app/scripts/modules/core/src/presentation/hooks/useLatestCallback.hook.ts
@@ -1,0 +1,17 @@
+import * as React from 'react';
+
+const { useRef, useCallback } = React;
+
+/**
+ * Returns a stable function reference that delegates to the latest version
+ * of the unstable function argument. Allows the latest version of the unstable
+ * function to access the latest version of its closure.
+ */
+export const useLatestCallback = <T extends (...args: any) => any>(callback: T) => {
+  const callbackRef = useRef(callback);
+  callbackRef.current = callback;
+
+  return useCallback((...args: Parameters<T>) => {
+    return callbackRef.current && (callbackRef.current.apply(null, args) as ReturnType<T>);
+  }, []);
+};

--- a/app/scripts/modules/core/src/presentation/hooks/usePrevious.hook.spec.tsx
+++ b/app/scripts/modules/core/src/presentation/hooks/usePrevious.hook.spec.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { mount } from 'enzyme';
+import { usePrevious } from './usePrevious.hook';
+
+const TestComponent = ({ value, valueCallback }: { value: any; valueCallback: (value: any) => any }) => {
+  const previousValue = usePrevious(value);
+  valueCallback(previousValue);
+  return null as JSX.Element;
+};
+
+describe('usePrevious', () => {
+  it('should give back undefined on initial mount', () => {
+    let valueFromHook: any;
+    const valueCallback = (value: any) => (valueFromHook = value);
+    mount(<TestComponent value={'first value'} valueCallback={valueCallback} />);
+
+    expect(valueFromHook).toBe(undefined);
+  });
+
+  it('should give back the value before the most recent render', () => {
+    let valueFromHook: any;
+    const valueCallback = (value: any) => (valueFromHook = value);
+    const component = mount(<TestComponent value={'first value'} valueCallback={valueCallback} />);
+
+    component.setProps({ value: 'second value' });
+
+    expect(valueFromHook).toBe('first value');
+
+    component.setProps({ value: 'third value' });
+
+    expect(valueFromHook).toBe('second value');
+  });
+});

--- a/app/scripts/modules/core/src/presentation/hooks/usePrevious.hook.ts
+++ b/app/scripts/modules/core/src/presentation/hooks/usePrevious.hook.ts
@@ -1,0 +1,11 @@
+import * as React from 'react';
+
+const { useEffect, useRef } = React;
+
+export const usePrevious = <T>(value: T): T => {
+  const ref = useRef<T>();
+  useEffect(() => {
+    ref.current = value;
+  });
+  return ref.current;
+};


### PR DESCRIPTION
I'm currently working on building out a `Modal` component that will be part of our slowly growing design system/component library and hopefully replace our use of `Modal` from `react-bootstrap`. In doing that, I ended up wanting three new hooks to accomplish some underlying behavior and are relatively generic/reusable:

- **usePrevious**: This is a hook that [the react docs actually gives an example for](https://reactjs.org/docs/hooks-faq.html#how-to-get-the-previous-props-or-state), and says they might bring into the core library later. I wanted it for one of the other two hooks in this PR. It's basically a way to get the value from the _last render_ for any value you care about

- **useContainerClassNames**: This one is interesting and specific to our app/presentation needs. I had a need to add a class onto the `.spinnaker-container` div that holds all of the nav/content (specifically to blur the content behind a modal when open), and toggle that class on/off depending on some state. Right now I've structured it as a hook that knows what element to look for so that individual components don't need to reference the DOM element itself, but if we see more need for this sort of thing in the future it might make sense to have this hook delegate to a generic `useClassNames` hook that accepts any DOM element

- **useEventListener**: We sometimes end up needing to add/remove event listeners from real-life DOM elements for various reasons. In my case I needed to attach some keyboard handlers to the modal I'm working on, but this need pops up in lots of places. `useEventListener` accepts any DOM element, any event name, and registers a stable listener reference that will call whatever the latest callback you pass into the hook is. It also handles registering / deregistering the listener when you add and remove the listener callback prop so you can toggle it based on state