### PR TITLE
fix(kubernetes/serverGroup): Remove unused controller file for 'kubernetesServerGroupLoadBalancersController'

### DIFF
--- a/app/scripts/modules/kubernetes/src/v1/serverGroup/configure/configure.kubernetes.module.js
+++ b/app/scripts/modules/kubernetes/src/v1/serverGroup/configure/configure.kubernetes.module.js
@@ -8,7 +8,6 @@ module.exports = angular.module('spinnaker.serverGroup.configure.kubernetes', [
   require('./wizard/BasicSettings.controller').name,
   require('./wizard/advancedSettings.controller').name,
   require('./wizard/Clone.controller').name,
-  require('./wizard/loadBalancers.controller').name,
   require('./wizard/volumes.controller').name,
   require('./wizard/deployment.controller').name,
 ]);

--- a/app/scripts/modules/kubernetes/src/v1/serverGroup/configure/wizard/loadBalancers.controller.js
+++ b/app/scripts/modules/kubernetes/src/v1/serverGroup/configure/wizard/loadBalancers.controller.js
@@ -1,9 +1,0 @@
-'use strict';
-
-const angular = require('angular');
-
-module.exports = angular
-  .module('spinnaker.kubernetes.serverGroup.configure.loadBalancers.controller', [
-    require('../configuration.service').name,
-  ])
-  .controller('kubernetesServerGroupLoadBalancersController', ['kubernetesServerGroupConfigurationService', '$scope']);


### PR DESCRIPTION
Please check if `kubernetesServerGroupLoadBalancersController` is something that should exist, because it currently does not.