### PR TITLE
fix(amazon/instance): don't blow up on standalone instances

### DIFF
--- a/app/scripts/modules/amazon/src/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/amazon/src/instance/details/instance.details.controller.js
@@ -72,9 +72,11 @@ module.exports = angular
           return metric.type !== 'Amazon' || metric.state !== 'Unknown';
         });
 
-        // augment with target group healthcheck data
-        const targetGroups = getAllTargetGroups(app.loadBalancers.data);
-        applyHealthCheckInfoToTargetGroups(displayableMetrics, targetGroups);
+        if (!app.isStandalone) {
+          // augment with target group healthcheck data
+          const targetGroups = getAllTargetGroups(app.loadBalancers.data);
+          applyHealthCheckInfoToTargetGroups(displayableMetrics, targetGroups);
+        }
 
         // backfill details where applicable
         if (latest.health) {


### PR DESCRIPTION
Turns out the reference to `app.loadBalancers.data` we added is an NPE when an instance isn't attached to an ASG ("standalone"). Most of this file already dances around not touching any of the data sources when the app model is in standalone mode, so just doing the same thing to fix.