### PR TITLE
refactor(*): Remove exports-loader from n3-chart import

### DIFF
--- a/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/chart/metricAlarmChart.component.js
+++ b/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/chart/metricAlarmChart.component.js
@@ -8,16 +8,12 @@ import 'd3';
 
 import { CloudMetricsReader } from '@spinnaker/core';
 
-// TODO: Remove LineChartHack, replace require with commented out one once
-// https://github.com/n3-charts/line-chart/issues/512 is resolved
-// require('style!n3-charts/build/LineChart.css');
+import 'n3-charts/build/LineChart';
 import './LineChartHack.css';
 import './metricAlarmChart.component.less';
 
 module.exports = angular
-  .module('spinnaker.amazon.serverGroup.details.scalingPolicy.metricAlarmChart.component', [
-    require('exports-loader?"n3-line-chart"!n3-charts/build/LineChart'),
-  ])
+  .module('spinnaker.amazon.serverGroup.details.scalingPolicy.metricAlarmChart.component', ['n3-line-chart'])
   .component('metricAlarmChart', {
     bindings: {
       alarm: '=',

--- a/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/upsert/upsertScalingPolicy.controller.js
+++ b/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/upsert/upsertScalingPolicy.controller.js
@@ -2,6 +2,7 @@
 
 const angular = require('angular');
 
+import 'n3-charts/build/LineChart';
 import { TaskMonitor } from '@spinnaker/core';
 
 import { STEP_POLICY_ACTION } from './step/stepPolicyAction.component';
@@ -11,7 +12,7 @@ import './upsertScalingPolicy.modal.less';
 
 module.exports = angular
   .module('spinnaker.amazon.serverGroup.details.scalingPolicy.upsertScalingPolicy.controller', [
-    require('exports-loader?"n3-line-chart"!n3-charts/build/LineChart'),
+    'n3-line-chart',
     require('./simple/simplePolicyAction.component').name,
     STEP_POLICY_ACTION,
     require('./alarm/alarmConfigurer.component').name,

--- a/app/scripts/modules/amazon/webpack.config.js
+++ b/app/scripts/modules/amazon/webpack.config.js
@@ -122,9 +122,5 @@ module.exports = {
     ],
   },
   plugins: [new ForkTsCheckerWebpackPlugin({ checkSyntacticErrors: true })],
-  externals: [
-    '@spinnaker/core',
-    'exports-loader?"n3-line-chart"!n3-charts/build/LineChart.js',
-    nodeExternals({ modulesDir: '../../../../node_modules' }),
-  ],
+  externals: ['@spinnaker/core', nodeExternals({ modulesDir: '../../../../node_modules' })],
 };

--- a/app/scripts/modules/appengine/webpack.config.js
+++ b/app/scripts/modules/appengine/webpack.config.js
@@ -122,9 +122,5 @@ module.exports = {
     ],
   },
   plugins: [new ForkTsCheckerWebpackPlugin({ checkSyntacticErrors: true })],
-  externals: [
-    '@spinnaker/core',
-    'exports-loader?"n3-line-chart"!n3-charts/build/LineChart.js',
-    nodeExternals({ modulesDir: '../../../../node_modules' }),
-  ],
+  externals: ['@spinnaker/core', nodeExternals({ modulesDir: '../../../../node_modules' })],
 };

--- a/app/scripts/modules/azure/webpack.config.js
+++ b/app/scripts/modules/azure/webpack.config.js
@@ -122,9 +122,5 @@ module.exports = {
     ],
   },
   plugins: [new ForkTsCheckerWebpackPlugin({ checkSyntacticErrors: true })],
-  externals: [
-    '@spinnaker/core',
-    'exports-loader?"n3-line-chart"!n3-charts/build/LineChart.js',
-    nodeExternals({ modulesDir: '../../../../node_modules' }),
-  ],
+  externals: ['@spinnaker/core', nodeExternals({ modulesDir: '../../../../node_modules' })],
 };

--- a/app/scripts/modules/cloudfoundry/webpack.config.js
+++ b/app/scripts/modules/cloudfoundry/webpack.config.js
@@ -123,9 +123,5 @@ module.exports = {
     ],
   },
   plugins: [new ForkTsCheckerWebpackPlugin({ checkSyntacticErrors: true })],
-  externals: [
-    '@spinnaker/core',
-    'exports-loader?"n3-line-chart"!n3-charts/build/LineChart.js',
-    nodeExternals({ modulesDir: '../../../../node_modules' }),
-  ],
+  externals: ['@spinnaker/core', nodeExternals({ modulesDir: '../../../../node_modules' })],
 };

--- a/app/scripts/modules/ecs/webpack.config.js
+++ b/app/scripts/modules/ecs/webpack.config.js
@@ -126,7 +126,6 @@ module.exports = {
     '@spinnaker/core',
     '@spinnaker/amazon',
     '@spinnaker/docker',
-    'exports-loader?"n3-line-chart"!n3-charts/build/LineChart.js',
     nodeExternals({ modulesDir: '../../../../node_modules' }),
   ],
 };

--- a/app/scripts/modules/kubernetes/webpack.config.js
+++ b/app/scripts/modules/kubernetes/webpack.config.js
@@ -122,9 +122,5 @@ module.exports = {
     ],
   },
   plugins: [new ForkTsCheckerWebpackPlugin({ checkSyntacticErrors: true })],
-  externals: [
-    '@spinnaker/core',
-    'exports-loader?"n3-line-chart"!n3-charts/build/LineChart.js',
-    nodeExternals({ modulesDir: '../../../../node_modules' }),
-  ],
+  externals: ['@spinnaker/core', nodeExternals({ modulesDir: '../../../../node_modules' })],
 };

--- a/app/scripts/modules/titus/webpack.config.js
+++ b/app/scripts/modules/titus/webpack.config.js
@@ -126,7 +126,6 @@ module.exports = {
     '@spinnaker/core',
     '@spinnaker/amazon',
     '@spinnaker/docker',
-    'exports-loader?"n3-line-chart"!n3-charts/build/LineChart.js',
     nodeExternals({ modulesDir: '../../../../node_modules' }),
   ],
 };

--- a/package.json
+++ b/package.json
@@ -151,7 +151,6 @@
     "eslint": "^5.13.0",
     "eslint-config-prettier": "^4.0.0",
     "eslint-loader": "^2.1.2",
-    "exports-loader": "^0.7.0",
     "expose-loader": "^0.7.5",
     "file-loader": "3.0.1",
     "fork-ts-checker-webpack-plugin": "0.5.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5106,14 +5106,6 @@ expand-tilde@^2.0.0, expand-tilde@^2.0.2:
   dependencies:
     homedir-polyfill "^1.0.1"
 
-exports-loader@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/exports-loader/-/exports-loader-0.7.0.tgz#84881c784dea6036b8e1cd1dac3da9b6409e21a5"
-  integrity sha512-RKwCrO4A6IiKm0pG3c9V46JxIHcDplwwGJn6+JJ1RcVnh/WSGJa0xkmk5cRVtgOPzCAtTMGj2F7nluh9L0vpSA==
-  dependencies:
-    loader-utils "^1.1.0"
-    source-map "0.5.0"
-
 expose-loader@^0.7.5:
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/expose-loader/-/expose-loader-0.7.5.tgz#e29ea2d9aeeed3254a3faa1b35f502db9f9c3f6f"
@@ -11577,11 +11569,6 @@ source-map-url@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
   integrity sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=
-
-source-map@0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.0.tgz#0fe96503ac86a5adb5de63f4e412ae4872cdbe86"
-  integrity sha1-D+llA6yGpa213mP05BKuSHLNvoY=
 
 source-map@0.5.x, source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.0, source-map@~0.5.1:
   version "0.5.7"


### PR DESCRIPTION
We were using `exports-loader` so we could `require()` and resolve to a string.  but y tho?  I just put the string inline.

Also I removed `exports-loader` dep because it's no longer used.