### PR TITLE
chore(typescript): update to @types/angular-ui-bootstrap@1.0.0

### DIFF
--- a/app/scripts/modules/core/src/utils/angular-ui-bootstrap.d.ts
+++ b/app/scripts/modules/core/src/utils/angular-ui-bootstrap.d.ts
@@ -1,4 +1,5 @@
 declare module 'angular-ui-bootstrap' {
+  export default "ui.bootstrap";
   export type IAccordionConfig = angular.ui.bootstrap.IAccordionConfig;
   export type IButtonConfig = angular.ui.bootstrap.IButtonConfig;
   export type IDatepickerConfig = angular.ui.bootstrap.IDatepickerConfig;

--- a/app/scripts/modules/core/src/utils/angular-ui-bootstrap.d.ts
+++ b/app/scripts/modules/core/src/utils/angular-ui-bootstrap.d.ts
@@ -1,0 +1,26 @@
+declare module 'angular-ui-bootstrap' {
+  export type IAccordionConfig = angular.ui.bootstrap.IAccordionConfig;
+  export type IButtonConfig = angular.ui.bootstrap.IButtonConfig;
+  export type IDatepickerConfig = angular.ui.bootstrap.IDatepickerConfig;
+  export type IDatepickerPopupConfig = angular.ui.bootstrap.IDatepickerPopupConfig;
+  export type IDropdownConfig = angular.ui.bootstrap.IDropdownConfig;
+  export type IModalProvider = angular.ui.bootstrap.IModalProvider;
+  export type IModalService = angular.ui.bootstrap.IModalService;
+  export type IModalServiceInstance = angular.ui.bootstrap.IModalServiceInstance;
+  export type IModalInstanceService = angular.ui.bootstrap.IModalInstanceService;
+  export type IModalScope = angular.ui.bootstrap.IModalScope;
+  export type IModalSettings = angular.ui.bootstrap.IModalSettings;
+  export type IModalStackService = angular.ui.bootstrap.IModalStackService;
+  export type IModalStackedMapKeyValuePair = angular.ui.bootstrap.IModalStackedMapKeyValuePair;
+  export type IPaginationConfig = angular.ui.bootstrap.IPaginationConfig;
+  export type IPagerConfig = angular.ui.bootstrap.IPagerConfig;
+  export type IPositionCoordinates = angular.ui.bootstrap.IPositionCoordinates;
+  export type IPositionService = angular.ui.bootstrap.IPositionService;
+  export type IProgressConfig = angular.ui.bootstrap.IProgressConfig;
+  export type IRatingConfig = angular.ui.bootstrap.IRatingConfig;
+  export type ITimepickerConfig = angular.ui.bootstrap.ITimepickerConfig;
+  export type ITooltipOptions = angular.ui.bootstrap.ITooltipOptions;
+  export type ITooltipProvider = angular.ui.bootstrap.ITooltipProvider;
+  export type ITransitionService = angular.ui.bootstrap.ITransitionService;
+  export type ITransitionServiceOptions = angular.ui.bootstrap.ITransitionServiceOptions;
+}

--- a/app/scripts/modules/core/src/utils/index.ts
+++ b/app/scripts/modules/core/src/utils/index.ts
@@ -1,4 +1,5 @@
 ///<reference path="./classnames.d.ts" />
+///<reference path="./angular-ui-bootstrap.d.ts" />
 
 export * from './RenderWhenVisible';
 export * from './clipboard/CopyToClipboard';

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
   "devDependencies": {
     "@types/angular": "1.6.26",
     "@types/angular-mocks": "1.5.10",
-    "@types/angular-ui-bootstrap": "^0.13.41",
+    "@types/angular-ui-bootstrap": "^1.0.0",
     "@types/classnames": "^2.2.0",
     "@types/clipboard": "^1.5.33",
     "@types/commonmark": "^0.27.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -105,10 +105,10 @@
   dependencies:
     "@types/angular" "*"
 
-"@types/angular-ui-bootstrap@^0.13.41":
-  version "0.13.41"
-  resolved "https://registry.yarnpkg.com/@types/angular-ui-bootstrap/-/angular-ui-bootstrap-0.13.41.tgz#dfbe5e6171a8255d7a220bc63baec0f854822d84"
-  integrity sha1-375eYXGoJV16IgvGO67A+FSCLYQ=
+"@types/angular-ui-bootstrap@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/angular-ui-bootstrap/-/angular-ui-bootstrap-1.0.0.tgz#57b2aebacf528f82826c7af7ff328c6da49d1b63"
+  integrity sha512-uqFykayfJIIFmXRrHoa6fPghUZvN+09JoOlHZzgPtm2bp/bVkQtVfef7/H3m//TUWTGCTZlijWtIhavaQNKRsg==
   dependencies:
     "@types/angular" "*"
 


### PR DESCRIPTION
This updated typing file adds the `default export` of the 'ui.bootstrap' string.  In the same version they took away the ability to import the interfaces from `angular-ui-bootstrap` so I added that back with a .d.ts file in Deck codebase.

See: https://github.com/DefinitelyTyped/DefinitelyTyped/commit/f0f7aab46fa08d0ad35bc1208701fc7741a546b0#diff-bc0713cf57d26cdc96a5aaa0966638c4