### PR TITLE
feat(aws/cfn): Cloudformation ChangeSet execution

### DIFF
--- a/app/scripts/modules/amazon/src/aws.module.ts
+++ b/app/scripts/modules/amazon/src/aws.module.ts
@@ -45,6 +45,7 @@ import {
 
 import { DEPLOY_CLOUDFORMATION_STACK_STAGE } from './pipeline/stages/deployCloudFormation/deployCloudFormationStackStage';
 import { CLOUDFORMATION_TEMPLATE_ENTRY } from './pipeline/stages/deployCloudFormation/cloudFormationTemplateEntry.component';
+import { CLOUD_FORMATION_CHANGE_SET_INFO } from './pipeline/stages/deployCloudFormation/CloudFormationChangeSetInfo';
 import { CreateLambdaFunction } from './function/CreateLambdaFunction';
 import { AmazonFunctionDetails } from './function';
 import { AMAZON_PIPELINE_STAGES_BAKE_AWSBAKESTAGE } from './pipeline/stages/bake/awsBakeStage';
@@ -102,6 +103,7 @@ module(AMAZON_MODULE, [
   AMAZON_SEARCH_SEARCHRESULTFORMATTER,
   DEPLOY_CLOUDFORMATION_STACK_STAGE,
   CLOUDFORMATION_TEMPLATE_ENTRY,
+  CLOUD_FORMATION_CHANGE_SET_INFO,
   AWS_EVALUATE_CLOUD_FORMATION_CHANGE_SET_EXECUTION_SERVICE,
 ]).config(() => {
   CloudProviderRegistry.registerProvider('aws', {

--- a/app/scripts/modules/amazon/src/aws.module.ts
+++ b/app/scripts/modules/amazon/src/aws.module.ts
@@ -64,6 +64,7 @@ import { AMAZON_PIPELINE_STAGES_TAGIMAGE_AWSTAGIMAGESTAGE } from './pipeline/sta
 import { AMAZON_INSTANCE_AWSINSTANCETYPE_SERVICE } from './instance/awsInstanceType.service';
 import { AMAZON_INSTANCE_DETAILS_INSTANCE_DETAILS_CONTROLLER } from './instance/details/instance.details.controller';
 import { AMAZON_SEARCH_SEARCHRESULTFORMATTER } from './search/searchResultFormatter';
+import { AWS_EVALUATE_CLOUD_FORMATION_CHANGE_SET_EXECUTION_SERVICE } from './pipeline/stages/deployCloudFormation/evaluateCloudFormationChangeSetExecution.service';
 
 // load all templates into the $templateCache
 const templates = require.context('./', true, /\.html$/);
@@ -101,6 +102,7 @@ module(AMAZON_MODULE, [
   AMAZON_SEARCH_SEARCHRESULTFORMATTER,
   DEPLOY_CLOUDFORMATION_STACK_STAGE,
   CLOUDFORMATION_TEMPLATE_ENTRY,
+  AWS_EVALUATE_CLOUD_FORMATION_CHANGE_SET_EXECUTION_SERVICE,
 ]).config(() => {
   CloudProviderRegistry.registerProvider('aws', {
     name: 'Amazon',

--- a/app/scripts/modules/amazon/src/help/amazon.help.ts
+++ b/app/scripts/modules/amazon/src/help/amazon.help.ts
@@ -159,6 +159,19 @@ const helpContents: { [key: string]: string } = {
   'aws.function.deadletterqueue': `A dead letter queue configuration that specifies the queue or topic where Lambda sends asynchronous events when they fail processing. (SNS or SQS)`,
   'aws.function.tracingConfig.mode': `The function's AWS X-Ray tracing configuration.`,
   'aws.function.kmsKeyArn': `The ARN of the AWS Key Management Service (AWS KMS) key that's used to encrypt your function's environment variables. If it's not provided, AWS Lambda uses a default service key.`,
+  'aws.cloudformation.changeSet.options': `<p>Action to take when the created ChangeSet contains a replacement.</p>
+        <p>
+          <b>ask:</b> Execution will be put on hold asking for user feedback.
+        </p>
+        <p>
+          <b>skip it:</b> ChangeSet will not be executed and stage will continue.
+        </p>
+        <p>
+          <b>execute it</b> ChangeSet will be executed.
+        </p>
+        <p>
+          <b>fail stage</b> ChangeSet will not be executed and the stage will fail.
+        </p>`,
 };
 
 Object.keys(helpContents).forEach(key => HelpContentsRegistry.register(key, helpContents[key]));

--- a/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/CloudFormationChangeSetInfo.tsx
+++ b/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/CloudFormationChangeSetInfo.tsx
@@ -1,0 +1,88 @@
+import React, { useState } from 'react';
+import { module } from 'angular';
+import { react2angular } from 'react2angular';
+
+import {
+  StageConfigField,
+  TextInput,
+  CheckboxInput,
+  ReactSelectInput,
+  IStage,
+  IStageConfigProps,
+} from '@spinnaker/core';
+
+export interface ICloudFormationChangeSetInfoProps {
+  stage: IStage[];
+  stageconfig: IStageConfigProps;
+}
+
+export const CloudFormationChangeSetInfo = (props: ICloudFormationChangeSetInfoProps) => {
+  const randomString = Math.random()
+    .toString(36)
+    .substring(2, 10)
+    .toUpperCase();
+
+  const { stage, stageconfig } = props;
+  const [changeSetName, setChangeSetName] = useState(
+    stage.changeSetName ? stage.changeSetName : 'ChangeSet-' + randomString,
+  );
+  const [executeChangeSet, setExecuteChangeSet] = useState(stage.executeChangeSet);
+  const [actionOnReplacement, setActionOnReplacement] = useState(stage.actionOnReplacement);
+
+  const modifyChangeSetName = (value: string) => {
+    setChangeSetName(value);
+    stageconfig.updateStageField({ changeSetName: value });
+  };
+
+  const toggleExecuteChangeSet = (checked: boolean) => {
+    setExecuteChangeSet(checked);
+    stageconfig.updateStageField({ executeChangeSet: checked });
+  };
+
+  const modifyActionOnReplacement = (value: string) => {
+    setActionOnReplacement(value);
+    stageconfig.updateStageField({ actionOnReplacement: value });
+  };
+
+  const actionOnReplacementOptions = [
+    { value: 'ask', label: 'ask' },
+    { value: 'skip', label: 'skip it' },
+    { value: 'execute', label: 'execute it' },
+    { value: 'fail', label: 'fail stage' },
+  ];
+
+  return (
+    <div>
+      <hr />
+      <h4>ChangeSet Configuration</h4>
+      <StageConfigField label="ChangeSet Name" helpkey="someone">
+        <TextInput
+          className="form-control"
+          type="text"
+          value={changeSetName}
+          onChange={e => modifyChangeSetName(e.target.value)}
+        />
+      </StageConfigField>
+      <StageConfigField label="Execute ChangeSet">
+        <CheckboxInput checked={executeChangeSet} onChange={e => toggleExecuteChangeSet(e.target.checked)} />
+      </StageConfigField>
+      {executeChangeSet && (
+        <StageConfigField label="If ChangeSet contains a replacement" help-key="aws.cloudformation.changeSet.options">
+          <ReactSelectInput
+            clearable={false}
+            value={actionOnReplacement}
+            options={actionOnReplacementOptions}
+            onChange={e => modifyActionOnReplacement(e.target.value)}
+          />
+        </StageConfigField>
+      )}
+    </div>
+  );
+};
+
+export const CLOUD_FORMATION_CHANGE_SET_INFO = 'spinnaker.amazon.cloudformation.changetset.info.component';
+
+module(CLOUD_FORMATION_CHANGE_SET_INFO, []).component(
+  'cloudFormationChangeSetInfo',
+  react2angular(CloudFormationChangeSetInfo, ['stage', 'stageconfig']),
+);

--- a/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/CloudFormationChangeSetInfo.tsx
+++ b/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/CloudFormationChangeSetInfo.tsx
@@ -55,7 +55,7 @@ export const CloudFormationChangeSetInfo = (props: ICloudFormationChangeSetInfoP
     <div>
       <hr />
       <h4>ChangeSet Configuration</h4>
-      <StageConfigField label="ChangeSet Name" helpkey="someone">
+      <StageConfigField label="ChangeSet Name">
         <TextInput
           className="form-control"
           type="text"

--- a/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/CloudFormationChangeSetInfo.tsx
+++ b/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/CloudFormationChangeSetInfo.tsx
@@ -24,10 +24,10 @@ export const CloudFormationChangeSetInfo = (props: ICloudFormationChangeSetInfoP
 
   const { stage, stageconfig } = props;
   const [changeSetName, setChangeSetName] = useState(
-    stage.changeSetName ? stage.changeSetName : 'ChangeSet-' + randomString,
+    (stage as any).changeSetName ? (stage as any).changeSetName : 'ChangeSet-' + randomString,
   );
-  const [executeChangeSet, setExecuteChangeSet] = useState(stage.executeChangeSet);
-  const [actionOnReplacement, setActionOnReplacement] = useState(stage.actionOnReplacement);
+  const [executeChangeSet, setExecuteChangeSet] = useState((stage as any).executeChangeSet);
+  const [actionOnReplacement, setActionOnReplacement] = useState((stage as any).actionOnReplacement);
 
   const modifyChangeSetName = (value: string) => {
     setChangeSetName(value);

--- a/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/CloudFormationChangeSetInfo.tsx
+++ b/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/CloudFormationChangeSetInfo.tsx
@@ -17,14 +17,9 @@ export interface ICloudFormationChangeSetInfoProps {
 }
 
 export const CloudFormationChangeSetInfo = (props: ICloudFormationChangeSetInfoProps) => {
-  const randomString = Math.random()
-    .toString(36)
-    .substring(2, 10)
-    .toUpperCase();
-
   const { stage, stageconfig } = props;
   const [changeSetName, setChangeSetName] = useState(
-    (stage as any).changeSetName ? (stage as any).changeSetName : 'ChangeSet-' + randomString,
+    (stage as any).changeSetName ? (stage as any).changeSetName : "ChangeSet-${ execution['id']}",
   );
   const [executeChangeSet, setExecuteChangeSet] = useState((stage as any).executeChangeSet);
   const [actionOnReplacement, setActionOnReplacement] = useState((stage as any).actionOnReplacement);

--- a/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/deployCloudFormationStackConfig.controller.ts
+++ b/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/deployCloudFormationStackConfig.controller.ts
@@ -53,14 +53,6 @@ export class DeployCloudFormationStackConfigController implements IController {
     );
   }
 
-  public isChangeSet() {
-    return this.$scope.stage.isChangeSet;
-  }
-
-  public executeChangeSet() {
-    return this.$scope.stage.executeChangeSet;
-  }
-
   public toggleChangeSet() {
     this.$scope.stage.isChangeSet = !this.$scope.stage.isChangeSet;
   }

--- a/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/deployCloudFormationStackConfig.controller.ts
+++ b/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/deployCloudFormationStackConfig.controller.ts
@@ -57,8 +57,16 @@ export class DeployCloudFormationStackConfigController implements IController {
     return this.$scope.stage.isChangeSet;
   }
 
+  public executeChangeSet() {
+    return this.$scope.stage.executeChangeSet;
+  }
+
   public toggleChangeSet() {
     this.$scope.stage.isChangeSet = !this.$scope.stage.isChangeSet;
+  }
+
+  public toggleExecuteChangeSet() {
+    this.$scope.stage.executeChangeSet = !this.$scope.stage.executeChangeSet;
   }
 
   public onStackArtifactEdited = (artifact: IArtifact) => {

--- a/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/deployCloudFormationStackConfig.controller.ts
+++ b/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/deployCloudFormationStackConfig.controller.ts
@@ -57,10 +57,6 @@ export class DeployCloudFormationStackConfigController implements IController {
     this.$scope.stage.isChangeSet = !this.$scope.stage.isChangeSet;
   }
 
-  public toggleExecuteChangeSet() {
-    this.$scope.stage.executeChangeSet = !this.$scope.stage.executeChangeSet;
-  }
-
   public onStackArtifactEdited = (artifact: IArtifact) => {
     this.$scope.$applyAsync(() => {
       this.$scope.stage.stackArtifactId = null;

--- a/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/deployCloudFormationStackConfig.html
+++ b/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/deployCloudFormationStackConfig.html
@@ -22,13 +22,7 @@
           <strong>Create CloudFormation ChangeSet</strong>
         </label>
       </stage-config-field>
-      <div ng-if="ctrl.isChangeSet()">
-        <stage-config-field label="ChangeSet name">
-          <label class="sm-label-right">
-            <input type="text" class="form-control input-sm" ng-model="stage.changeSetName" />
-          </label>
-        </stage-config-field>
-      </div>
+
       <stage-config-field label="IAM role ARN">
         <label class="sm-label-right">
           <input type="text" class="form-control input-sm" ng-model="stage.roleARN" />
@@ -71,6 +65,38 @@
       update-pipeline="ctrl.updatePipeline"
     >
     </stage-artifact-selector-delegate>
+    <div ng-if="ctrl.isChangeSet()">
+      <hr />
+      <h4>ChangeSet Configuration</h4>
+      <stage-config-field label="ChangeSet name">
+        <label class="sm-label-right">
+          <input type="text" class="form-control input-sm" ng-model="stage.changeSetName" />
+        </label>
+      </stage-config-field>
+      <stage-config-field label="" field-colums="6">
+        <label>
+          <input type="checkbox" ng-checked="ctrl.executeChangeSet()" ng-click="ctrl.toggleExecuteChangeSet()" />
+        </label>
+        <strong>Execute CloudFormation ChangeSet</strong>
+      </stage-config-field>
+      <div ng-if="ctrl.isChangeSet()">
+        <div ng-if="ctrl.executeChangeSet()">
+          <stage-config-field
+            label="If ChangeSet contains a replacement"
+            help-key="aws.cloudformation.changeSet.options"
+          >
+            <label>
+              <select class="form-control input-sm" ng-model="stage.actionOnReplacement" required>
+                <option value="ask">ask</option>
+                <option value="skip">skip it</option>
+                <option value="execute">execute it</option>
+                <option value="fail">fail stage</option>
+              </select>
+            </label>
+          </stage-config-field>
+        </div>
+      </div>
+    </div>
     <hr />
     <stage-config-field label="Parameters" field-columns="6">
       <map-editor model="ctrl.$scope.stage.parameters" add-button-label="Add parameter"></map-editor>

--- a/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/deployCloudFormationStackConfig.html
+++ b/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/deployCloudFormationStackConfig.html
@@ -18,7 +18,7 @@
         </label>
         <br />
         <label>
-          <input type="checkbox" ng-checked="ctrl.isChangeSet()" ng-click="ctrl.toggleChangeSet()" />
+          <input type="checkbox" ng-checked="stage.isChangeSet" ng-click="ctrl.toggleChangeSet()" />
           <strong>Create CloudFormation ChangeSet</strong>
         </label>
       </stage-config-field>
@@ -65,7 +65,7 @@
       update-pipeline="ctrl.updatePipeline"
     >
     </stage-artifact-selector-delegate>
-    <div ng-if="ctrl.isChangeSet()">
+    <div ng-if="stage.isChangeSet">
       <hr />
       <h4>ChangeSet Configuration</h4>
       <stage-config-field label="ChangeSet name">
@@ -75,12 +75,12 @@
       </stage-config-field>
       <stage-config-field label="" field-colums="6">
         <label>
-          <input type="checkbox" ng-checked="ctrl.executeChangeSet()" ng-click="ctrl.toggleExecuteChangeSet()" />
+          <input type="checkbox" ng-checked="stage.executeChangeSet" ng-click="ctrl.toggleExecuteChangeSet()" />
         </label>
         <strong>Execute CloudFormation ChangeSet</strong>
       </stage-config-field>
-      <div ng-if="ctrl.isChangeSet()">
-        <div ng-if="ctrl.executeChangeSet()">
+      <div ng-if="stage.isChangeSet">
+        <div ng-if="stage.executeChangeSet">
           <stage-config-field
             label="If ChangeSet contains a replacement"
             help-key="aws.cloudformation.changeSet.options"

--- a/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/deployCloudFormationStackConfig.html
+++ b/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/deployCloudFormationStackConfig.html
@@ -66,36 +66,7 @@
     >
     </stage-artifact-selector-delegate>
     <div ng-if="stage.isChangeSet">
-      <hr />
-      <h4>ChangeSet Configuration</h4>
-      <stage-config-field label="ChangeSet name">
-        <label class="sm-label-right">
-          <input type="text" class="form-control input-sm" ng-model="stage.changeSetName" />
-        </label>
-      </stage-config-field>
-      <stage-config-field label="" field-colums="6">
-        <label>
-          <input type="checkbox" ng-checked="stage.executeChangeSet" ng-click="ctrl.toggleExecuteChangeSet()" />
-        </label>
-        <strong>Execute CloudFormation ChangeSet</strong>
-      </stage-config-field>
-      <div ng-if="stage.isChangeSet">
-        <div ng-if="stage.executeChangeSet">
-          <stage-config-field
-            label="If ChangeSet contains a replacement"
-            help-key="aws.cloudformation.changeSet.options"
-          >
-            <label>
-              <select class="form-control input-sm" ng-model="stage.actionOnReplacement" required>
-                <option value="ask">ask</option>
-                <option value="skip">skip it</option>
-                <option value="execute">execute it</option>
-                <option value="fail">fail stage</option>
-              </select>
-            </label>
-          </stage-config-field>
-        </div>
-      </div>
+      <cloud-formation-change-set-info stage="stage" stageconfig="stageConfigCtrl"> </cloud-formation-change-set-info>
     </div>
     <hr />
     <stage-config-field label="Parameters" field-columns="6">

--- a/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/deployCloudFormationStackStage.ts
+++ b/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/deployCloudFormationStackStage.ts
@@ -8,6 +8,10 @@ import {
   Registry,
 } from '@spinnaker/core';
 
+import { EvaluateCloudFormationChangeSetExecutionMarkerIcon } from './evaluateCloudFormationChangeSetExecutionMarkerIcon';
+import { EvaluateCloudFormationChangeSetExecutionLabel } from './evaluateCloudFormationChangeSetExecutionLabel';
+import { EvaluateCloudFormationChangeSetExecutionDetails } from './evaluateCloudFormationChangeSetExecutionDetails';
+
 import { DeployCloudFormationStackConfigController } from './deployCloudFormationStackConfig.controller';
 
 export const DEPLOY_CLOUDFORMATION_STACK_STAGE = 'spinnaker.amazon.pipeline.stages.deployCloudFormationStage';
@@ -22,10 +26,13 @@ module(DEPLOY_CLOUDFORMATION_STACK_STAGE, [])
       templateUrl: require('./deployCloudFormationStackConfig.html'),
       controller: 'DeployCloudFormationStackConfigController',
       controllerAs: 'ctrl',
-      executionDetailsSections: [ExecutionDetailsTasks],
+      useCustomTooltip: true,
+      executionDetailsSections: [ExecutionDetailsTasks, EvaluateCloudFormationChangeSetExecutionDetails],
+      executionLabelComponent: EvaluateCloudFormationChangeSetExecutionLabel,
       producesArtifacts: true,
       supportsCustomTimeout: true,
       validators: [],
+      markerIcon: EvaluateCloudFormationChangeSetExecutionMarkerIcon,
       accountExtractor: (stage: IStage): string[] => (stage.account ? [stage.account] : []),
       configAccountExtractor: (stage: any): string[] => (stage.account ? [stage.account] : []),
       artifactExtractor: ExpectedArtifactService.accumulateArtifacts(['stackArtifactId', 'requiredArtifactIds']),

--- a/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/evaluateCloudFormationChangeSetExecution.service.ts
+++ b/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/evaluateCloudFormationChangeSetExecution.service.ts
@@ -1,0 +1,47 @@
+import { IPromise, module } from 'angular';
+import { EXECUTION_SERVICE, ExecutionService } from '@spinnaker/core';
+import { IExecution, IExecutionStage } from 'core/domain';
+import { Application } from 'core/application';
+
+export class EvaluateCloudFormationChangeSetExecutionService {
+  public static $inject = ['executionService'];
+  constructor(private executionService: ExecutionService) {}
+
+  private clearPipelineColor(): void {
+    if (
+      typeof document.getElementsByClassName(
+        'execution-marker-running stage-type-deploycloudformation stage-type-deploycloudformation-ask',
+      )[0] !== 'undefined'
+    ) {
+      document
+        .getElementsByClassName(
+          'execution-marker-running stage-type-deploycloudformation stage-type-deploycloudformation-ask',
+        )[0]
+        .classList.remove('stage-type-deploycloudformation-ask');
+    }
+  }
+
+  public evaluateExecution(
+    application: Application,
+    execution: IExecution,
+    stage: IExecutionStage,
+    changeSetExecutionChoice: string,
+  ): IPromise<void> {
+    this.clearPipelineColor();
+    const matcher = (result: IExecution) => {
+      const match = result.stages.find((test: { id: any }) => test.id === stage.id);
+      return match && match.status !== 'RUNNING';
+    };
+    return this.executionService
+      .patchExecution(execution.id, stage.id, { changeSetExecutionChoice })
+      .then(() => this.executionService.waitUntilExecutionMatches(execution.id, matcher))
+      .then((updated: any) => this.executionService.updateExecution(application, updated));
+  }
+}
+
+export const AWS_EVALUATE_CLOUD_FORMATION_CHANGE_SET_EXECUTION_SERVICE =
+  'spinnaker.amazon.deployCloudFormation.service';
+module(AWS_EVALUATE_CLOUD_FORMATION_CHANGE_SET_EXECUTION_SERVICE, [EXECUTION_SERVICE]).service(
+  'evaluateCloudFormationChangeSetExecutionService',
+  EvaluateCloudFormationChangeSetExecutionService,
+);

--- a/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/evaluateCloudFormationChangeSetExecution.service.ts
+++ b/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/evaluateCloudFormationChangeSetExecution.service.ts
@@ -7,27 +7,12 @@ export class EvaluateCloudFormationChangeSetExecutionService {
   public static $inject = ['executionService'];
   constructor(private executionService: ExecutionService) {}
 
-  private clearPipelineColor(): void {
-    if (
-      typeof document.getElementsByClassName(
-        'execution-marker-running stage-type-deploycloudformation stage-type-deploycloudformation-ask',
-      )[0] !== 'undefined'
-    ) {
-      document
-        .getElementsByClassName(
-          'execution-marker-running stage-type-deploycloudformation stage-type-deploycloudformation-ask',
-        )[0]
-        .classList.remove('stage-type-deploycloudformation-ask');
-    }
-  }
-
   public evaluateExecution(
     application: Application,
     execution: IExecution,
     stage: IExecutionStage,
     changeSetExecutionChoice: string,
   ): IPromise<void> {
-    this.clearPipelineColor();
     const matcher = (result: IExecution) => {
       const match = result.stages.find((test: { id: any }) => test.id === stage.id);
       return match && match.status !== 'RUNNING';

--- a/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/evaluateCloudFormationChangeSetExecutionApproval.tsx
+++ b/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/evaluateCloudFormationChangeSetExecutionApproval.tsx
@@ -1,0 +1,108 @@
+import * as React from 'react';
+
+import { IExecution, IExecutionStage } from 'core/domain';
+import { Application } from 'core/application/application.model';
+import { NgReact } from '@spinnaker/core';
+import { AwsReactInjector } from 'amazon/reactShims';
+
+export interface IEvaluateCloudFormationChangeSetExecutionApprovalProps {
+  execution: IExecution;
+  stage: IExecutionStage;
+  application: Application;
+}
+
+export interface IEvaluateCloudFormationChangeSetExecutionApprovalState {
+  submitting: boolean;
+  judgmentDecision: string;
+  error: boolean;
+}
+
+export class EvaluateCloudFormationChangeSetExecutionApproval extends React.Component<
+  IEvaluateCloudFormationChangeSetExecutionApprovalProps,
+  IEvaluateCloudFormationChangeSetExecutionApprovalState
+> {
+  constructor(props: IEvaluateCloudFormationChangeSetExecutionApprovalProps) {
+    super(props);
+    this.state = {
+      submitting: false,
+      judgmentDecision: '',
+      error: false,
+    };
+  }
+
+  public provideJudgment(judgmentDecision: string): void {
+    const { application, execution, stage } = this.props;
+    this.setState({ submitting: true, error: false, judgmentDecision });
+    AwsReactInjector.evaluateCloudFormationChangeSetExecutionService.evaluateExecution(
+      application,
+      execution,
+      stage,
+      judgmentDecision,
+    );
+  }
+
+  private isSubmitting(decision: string): boolean {
+    return (
+      this.props.stage.context.judgmentStatus === decision ||
+      (this.state.submitting && this.state.judgmentDecision === decision)
+    );
+  }
+
+  private handleContinueClick = (): void => {
+    this.provideJudgment('skip');
+  };
+
+  private handleFailClick = (): void => {
+    this.provideJudgment('fail');
+  };
+
+  private handleStopClick = (): void => {
+    this.provideJudgment('execute');
+  };
+
+  public render(): React.ReactElement<EvaluateCloudFormationChangeSetExecutionApproval> {
+    const stage: IExecutionStage = this.props.stage;
+    const changeSetIsReplacement = !stage.context.changeSetIsReplacement;
+    const { ButtonBusyIndicator } = NgReact;
+
+    return (
+      <div>
+        <div>
+          <p>
+            This ChangeSet contains a replacement, which means there will be <b>potential data loss</b> when executed.
+          </p>
+          <p>How do you want to proceed?</p>
+          <div className="action-buttons">
+            <button
+              className="btn btn-danger"
+              onClick={this.handleStopClick}
+              disabled={changeSetIsReplacement || this.state.submitting}
+            >
+              {this.isSubmitting('Execute') && <ButtonBusyIndicator />}
+              {stage.context.stopButtonLabel || 'Execute'}
+            </button>
+            <button
+              className="btn btn-primary"
+              disabled={changeSetIsReplacement || this.state.submitting}
+              onClick={this.handleContinueClick}
+            >
+              {this.isSubmitting('Skip') && <ButtonBusyIndicator />}
+              {stage.context.continueButtonLabel || 'Skip'}
+            </button>
+            <button
+              className="btn btn-primary"
+              disabled={changeSetIsReplacement || this.state.submitting}
+              onClick={this.handleFailClick}
+            >
+              {this.isSubmitting('Fail') && <ButtonBusyIndicator />}
+              {stage.context.continueButtonLabel || 'Fail'}
+            </button>
+          </div>
+        </div>
+        {this.state.error && (
+          <div className="error-message">There was an error recording your decision. Please try again.</div>
+        )}
+      </div>
+    );
+  }
+}

--- a/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/evaluateCloudFormationChangeSetExecutionApproval.tsx
+++ b/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/evaluateCloudFormationChangeSetExecutionApproval.tsx
@@ -62,7 +62,7 @@ export class EvaluateCloudFormationChangeSetExecutionApproval extends React.Comp
 
   public render(): React.ReactElement<EvaluateCloudFormationChangeSetExecutionApproval> {
     const stage: IExecutionStage = this.props.stage;
-    const changeSetIsReplacement = !stage.context.changeSetIsReplacement;
+    const changeSetContainsReplacement = !stage.context.changeSetContainsReplacement;
     const { ButtonBusyIndicator } = NgReact;
 
     return (
@@ -76,14 +76,14 @@ export class EvaluateCloudFormationChangeSetExecutionApproval extends React.Comp
             <button
               className="btn btn-danger"
               onClick={this.handleStopClick}
-              disabled={changeSetIsReplacement || this.state.submitting}
+              disabled={changeSetContainsReplacement || this.state.submitting}
             >
               {this.isSubmitting('Execute') && <ButtonBusyIndicator />}
               {stage.context.stopButtonLabel || 'Execute'}
             </button>
             <button
               className="btn btn-primary"
-              disabled={changeSetIsReplacement || this.state.submitting}
+              disabled={changeSetContainsReplacement || this.state.submitting}
               onClick={this.handleContinueClick}
             >
               {this.isSubmitting('Skip') && <ButtonBusyIndicator />}
@@ -91,7 +91,7 @@ export class EvaluateCloudFormationChangeSetExecutionApproval extends React.Comp
             </button>
             <button
               className="btn btn-primary"
-              disabled={changeSetIsReplacement || this.state.submitting}
+              disabled={changeSetContainsReplacement || this.state.submitting}
               onClick={this.handleFailClick}
             >
               {this.isSubmitting('Fail') && <ButtonBusyIndicator />}

--- a/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/evaluateCloudFormationChangeSetExecutionApproval.tsx
+++ b/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/evaluateCloudFormationChangeSetExecutionApproval.tsx
@@ -19,7 +19,6 @@ export interface IEvaluateCloudFormationChangeSetExecutionApprovalState {
 
 export const EvaluateCloudFormationChangeSetExecutionApproval = (
   props: IEvaluateCloudFormationChangeSetExecutionApprovalProps,
-  IEvaluateCloudFormationChangeSetExecutionApprovalState,
 ) => {
   const { execution, stage, application } = props;
   const [submitting, setSubmitting] = useState(false);
@@ -29,6 +28,7 @@ export const EvaluateCloudFormationChangeSetExecutionApproval = (
 
   const provideJudgment = (judgmentDecision: string) => {
     setSubmitting(true);
+    setJudgmentDecision(judgmentDecision);
     setError(false);
     AwsReactInjector.evaluateCloudFormationChangeSetExecutionService.evaluateExecution(
       application,

--- a/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/evaluateCloudFormationChangeSetExecutionDetails.tsx
+++ b/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/evaluateCloudFormationChangeSetExecutionDetails.tsx
@@ -25,6 +25,21 @@ export class EvaluateCloudFormationChangeSetExecutionDetails extends React.Compo
           />
         </ExecutionDetailsSection>
       );
+    } else if (hasReplacement && !stage.isRunning && stage.context.changeSetExecutionChoice) {
+      return (
+        <ExecutionDetailsSection name={name} current={current}>
+          <div>
+            <div>
+              <dl className="no-margin">
+                <dt>Judgment</dt>
+                <dd>{stage.context.changeSetExecutionChoice}</dd>
+                <dt>Judged By</dt>
+                <dd>{stage.context.lastModifiedBy}</dd>
+              </dl>
+            </div>
+          </div>
+        </ExecutionDetailsSection>
+      );
     } else {
       return null;
     }

--- a/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/evaluateCloudFormationChangeSetExecutionDetails.tsx
+++ b/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/evaluateCloudFormationChangeSetExecutionDetails.tsx
@@ -37,7 +37,7 @@ export class EvaluateCloudFormationChangeSetExecutionDetails extends React.Compo
         </ExecutionDetailsSection>
       );
     } else {
-      return <br />;
+      return null;
     }
   }
 }

--- a/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/evaluateCloudFormationChangeSetExecutionDetails.tsx
+++ b/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/evaluateCloudFormationChangeSetExecutionDetails.tsx
@@ -24,7 +24,7 @@ export class EvaluateCloudFormationChangeSetExecutionDetails extends React.Compo
 
   public render() {
     const { application, execution, stage, current, name } = this.props;
-    const hasReplacement = stage.context.changeSetIsReplacement;
+    const hasReplacement = stage.context.changeSetContainsReplacement;
     if (hasReplacement && stage.isRunning && stage.context.actionOnReplacement === 'ask') {
       return (
         <ExecutionDetailsSection name={name} current={current}>

--- a/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/evaluateCloudFormationChangeSetExecutionDetails.tsx
+++ b/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/evaluateCloudFormationChangeSetExecutionDetails.tsx
@@ -1,21 +1,10 @@
 import * as React from 'react';
 
 import { IExecutionDetailsSectionProps } from 'core/pipeline';
-import { IStage } from 'core/domain';
 import { ExecutionDetailsSection } from '@spinnaker/core';
-import {
-  EvaluateCloudFormationChangeSetExecutionApproval,
-  IEvaluateCloudFormationChangeSetExecutionApprovalState,
-} from './evaluateCloudFormationChangeSetExecutionApproval';
+import { EvaluateCloudFormationChangeSetExecutionApproval } from './evaluateCloudFormationChangeSetExecutionApproval';
 
-export interface IEvaluateCloudFormationChangeSetExecutionDetailsState {
-  parentDeployStage: IStage;
-}
-
-export class EvaluateCloudFormationChangeSetExecutionDetails extends React.Component<
-  IExecutionDetailsSectionProps,
-  IEvaluateCloudFormationChangeSetExecutionApprovalState
-> {
+export class EvaluateCloudFormationChangeSetExecutionDetails extends React.Component<IExecutionDetailsSectionProps> {
   public static title = 'Change Set Execution';
 
   constructor(props: IExecutionDetailsSectionProps) {

--- a/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/evaluateCloudFormationChangeSetExecutionDetails.tsx
+++ b/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/evaluateCloudFormationChangeSetExecutionDetails.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+
+import { IExecutionDetailsSectionProps } from 'core/pipeline';
+import { IStage } from 'core/domain';
+import { ExecutionDetailsSection } from '@spinnaker/core';
+import {
+  EvaluateCloudFormationChangeSetExecutionApproval,
+  IEvaluateCloudFormationChangeSetExecutionApprovalState,
+} from './evaluateCloudFormationChangeSetExecutionApproval';
+
+export interface IEvaluateCloudFormationChangeSetExecutionDetailsState {
+  parentDeployStage: IStage;
+}
+
+export class EvaluateCloudFormationChangeSetExecutionDetails extends React.Component<
+  IExecutionDetailsSectionProps,
+  IEvaluateCloudFormationChangeSetExecutionApprovalState
+> {
+  public static title = 'Change Set Execution';
+
+  constructor(props: IExecutionDetailsSectionProps) {
+    super(props);
+  }
+
+  public render() {
+    const { application, execution, stage, current, name } = this.props;
+    const hasReplacement = stage.context.changeSetIsReplacement;
+    if (hasReplacement && stage.isRunning && stage.context.actionOnReplacement === 'ask') {
+      return (
+        <ExecutionDetailsSection name={name} current={current}>
+          <EvaluateCloudFormationChangeSetExecutionApproval
+            key={stage.refId}
+            application={application}
+            execution={execution}
+            stage={stage}
+          />
+        </ExecutionDetailsSection>
+      );
+    } else {
+      return <br />;
+    }
+  }
+}

--- a/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/evaluateCloudFormationChangeSetExecutionDetails.tsx
+++ b/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/evaluateCloudFormationChangeSetExecutionDetails.tsx
@@ -31,6 +31,10 @@ export class EvaluateCloudFormationChangeSetExecutionDetails extends React.Compo
           <div>
             <div>
               <dl className="no-margin">
+                <dt>ChangeSet Name</dt>
+                <dd>{stage.context.changeSetName}</dd>
+                <dt>Replacement</dt>
+                <dd>true</dd>
                 <dt>Judgment</dt>
                 <dd>{stage.context.changeSetExecutionChoice}</dd>
                 <dt>Judged By</dt>
@@ -40,8 +44,34 @@ export class EvaluateCloudFormationChangeSetExecutionDetails extends React.Compo
           </div>
         </ExecutionDetailsSection>
       );
+    } else if (!hasReplacement && !stage.isRunning) {
+      return (
+        <ExecutionDetailsSection name={name} current={current}>
+          <div>
+            <div>
+              <dl className="no-margin">
+                <dt>ChangeSet Name</dt>
+                <dd>{stage.context.changeSetName}</dd>
+                <dt>Replacement</dt>
+                <dd>false</dd>
+              </dl>
+            </div>
+          </div>
+        </ExecutionDetailsSection>
+      );
     } else {
-      return null;
+      return (
+        <ExecutionDetailsSection name={name} current={current}>
+          <div>
+            <div>
+              <dl className="no-margin">
+                <dt>ChangeSet Name</dt>
+                <dd>{stage.context.changeSetName}</dd>
+              </dl>
+            </div>
+          </div>
+        </ExecutionDetailsSection>
+      );
     }
   }
 }

--- a/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/evaluateCloudFormationChangeSetExecutionDetails.tsx
+++ b/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/evaluateCloudFormationChangeSetExecutionDetails.tsx
@@ -14,64 +14,43 @@ export class EvaluateCloudFormationChangeSetExecutionDetails extends React.Compo
   public render() {
     const { application, execution, stage, current, name } = this.props;
     const hasReplacement = stage.context.changeSetContainsReplacement;
-    if (hasReplacement && stage.isRunning && stage.context.actionOnReplacement === 'ask') {
-      return (
-        <ExecutionDetailsSection name={name} current={current}>
+    const askAction = hasReplacement && stage.isRunning && stage.context.actionOnReplacement === 'ask';
+    const isChangeSet = stage.context.isChangeSet;
+
+    return (
+      <ExecutionDetailsSection name={name} current={current}>
+        {askAction ? (
           <EvaluateCloudFormationChangeSetExecutionApproval
             key={stage.refId}
             application={application}
             execution={execution}
             stage={stage}
           />
-        </ExecutionDetailsSection>
-      );
-    } else if (hasReplacement && !stage.isRunning && stage.context.changeSetExecutionChoice) {
-      return (
-        <ExecutionDetailsSection name={name} current={current}>
+        ) : (
           <div>
-            <div>
-              <dl className="no-margin">
-                <dt>ChangeSet Name</dt>
-                <dd>{stage.context.changeSetName}</dd>
-                <dt>Replacement</dt>
-                <dd>true</dd>
-                <dt>Judgment</dt>
-                <dd>{stage.context.changeSetExecutionChoice}</dd>
-                <dt>Judged By</dt>
-                <dd>{stage.context.lastModifiedBy}</dd>
-              </dl>
-            </div>
+            {isChangeSet ? (
+              <div>
+                <dl className="no-margin">
+                  <dt>ChangeSet Name</dt>
+                  <dd>{stage.context.changeSetName}</dd>
+                  <dt>Replacement</dt>
+                  <dd>{String(hasReplacement)}</dd>
+                  {stage.context.changeSetExecutionChoice && (
+                    <div>
+                      <dt>Judgment</dt>
+                      <dd>{stage.context.changeSetExecutionChoice}</dd>
+                      <dt>Judged By</dt>
+                      <dd>{stage.context.lastModifiedBy}</dd>
+                    </div>
+                  )}
+                </dl>
+              </div>
+            ) : (
+              <div>No changeSets found</div>
+            )}
           </div>
-        </ExecutionDetailsSection>
-      );
-    } else if (!hasReplacement && !stage.isRunning) {
-      return (
-        <ExecutionDetailsSection name={name} current={current}>
-          <div>
-            <div>
-              <dl className="no-margin">
-                <dt>ChangeSet Name</dt>
-                <dd>{stage.context.changeSetName}</dd>
-                <dt>Replacement</dt>
-                <dd>false</dd>
-              </dl>
-            </div>
-          </div>
-        </ExecutionDetailsSection>
-      );
-    } else {
-      return (
-        <ExecutionDetailsSection name={name} current={current}>
-          <div>
-            <div>
-              <dl className="no-margin">
-                <dt>ChangeSet Name</dt>
-                <dd>{stage.context.changeSetName}</dd>
-              </dl>
-            </div>
-          </div>
-        </ExecutionDetailsSection>
-      );
-    }
+        )}
+      </ExecutionDetailsSection>
+    );
   }
 }

--- a/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/evaluateCloudFormationChangeSetExecutionDetailsAsk.less
+++ b/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/evaluateCloudFormationChangeSetExecutionDetailsAsk.less
@@ -1,0 +1,9 @@
+.execution-marker {
+  &.execution-marker-running {
+    &.stage-type-deploycloudformation-ask {
+      background-color: var(--color-alert);
+      fill: var(--color-alert);
+      animation: none;
+    }
+  }
+}

--- a/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/evaluateCloudFormationChangeSetExecutionDetailsAsk.less
+++ b/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/evaluateCloudFormationChangeSetExecutionDetailsAsk.less
@@ -1,9 +1,0 @@
-.execution-marker {
-  &.execution-marker-running {
-    &.stage-type-deploycloudformation-ask {
-      background-color: var(--color-alert);
-      fill: var(--color-alert);
-      animation: none;
-    }
-  }
-}

--- a/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/evaluateCloudFormationChangeSetExecutionLabel.tsx
+++ b/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/evaluateCloudFormationChangeSetExecutionLabel.tsx
@@ -23,7 +23,7 @@ export class EvaluateCloudFormationChangeSetExecutionLabel extends React.Compone
     const stage = this.props.stage;
     if (
       stage.isRunning &&
-      stage.stages[0].context.changeSetIsReplacement &&
+      stage.stages[0].context.changeSetContainsReplacement &&
       stage.stages[0].context.actionOnReplacement === 'ask'
     ) {
       const template = (

--- a/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/evaluateCloudFormationChangeSetExecutionLabel.tsx
+++ b/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/evaluateCloudFormationChangeSetExecutionLabel.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+import { OverlayTrigger, Tooltip } from 'react-bootstrap';
+import { IExecutionStageSummary, IExecution } from 'core/domain';
+import { Application } from 'core/application/application.model';
+import { ExecutionBarLabel, HoverablePopover } from '@spinnaker/core';
+import { EvaluateCloudFormationChangeSetExecutionApproval } from './evaluateCloudFormationChangeSetExecutionApproval';
+
+export interface IEvaluateCloudFormationChangeSetExecutionProps {
+  stage: IExecutionStageSummary;
+  execution: IExecution;
+  application: Application;
+  executionMarker: boolean;
+}
+
+export class EvaluateCloudFormationChangeSetExecutionLabel extends React.Component<
+  IEvaluateCloudFormationChangeSetExecutionProps
+> {
+  public render() {
+    if (!this.props.executionMarker) {
+      return <ExecutionBarLabel {...this.props} />;
+    }
+
+    const stage = this.props.stage;
+    if (
+      stage.isRunning &&
+      stage.stages[0].context.changeSetIsReplacement &&
+      stage.stages[0].context.actionOnReplacement === 'ask'
+    ) {
+      const template = (
+        <div>
+          <div>
+            <b>{stage.name}</b>
+          </div>
+
+          <EvaluateCloudFormationChangeSetExecutionApproval
+            stage={stage.masterStage}
+            application={this.props.application}
+            execution={this.props.execution}
+          />
+        </div>
+      );
+      return <HoverablePopover template={template}>{this.props.children}</HoverablePopover>;
+    }
+    const tooltip = <Tooltip id={stage.id}>{stage.name}</Tooltip>;
+    return (
+      <OverlayTrigger placement="top" overlay={tooltip}>
+        <span>{this.props.children}</span>
+      </OverlayTrigger>
+    );
+  }
+}

--- a/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/evaluateCloudFormationChangeSetExecutionLabel.tsx
+++ b/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/evaluateCloudFormationChangeSetExecutionLabel.tsx
@@ -20,7 +20,7 @@ export class EvaluateCloudFormationChangeSetExecutionLabel extends React.Compone
       return <ExecutionBarLabel {...this.props} />;
     }
 
-    const stage = this.props.stage;
+    const { stage } = this.props;
     if (
       stage.isRunning &&
       stage.stages[0].context.changeSetContainsReplacement &&

--- a/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/evaluateCloudFormationChangeSetExecutionMarkerIcon.tsx
+++ b/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/evaluateCloudFormationChangeSetExecutionMarkerIcon.tsx
@@ -9,7 +9,7 @@ export class EvaluateCloudFormationChangeSetExecutionMarkerIcon extends React.Co
   public render() {
     if (
       this.props.stage.isRunning &&
-      this.props.stage.stages[0].context.changeSetIsReplacement &&
+      this.props.stage.stages[0].context.changeSetContainsReplacement &&
       this.props.stage.stages[0].context.actionOnReplacement === 'ask'
     ) {
       require('./evaluateCloudFormationChangeSetExecutionDetailsAsk.less');

--- a/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/evaluateCloudFormationChangeSetExecutionMarkerIcon.tsx
+++ b/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/evaluateCloudFormationChangeSetExecutionMarkerIcon.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { IExecutionMarkerIconProps } from 'core/pipeline/config/stages/common/ExecutionMarkerIcon';
+
+export class EvaluateCloudFormationChangeSetExecutionMarkerIcon extends React.Component<IExecutionMarkerIconProps> {
+  constructor(props: IExecutionMarkerIconProps) {
+    super(props);
+  }
+
+  public render() {
+    if (
+      this.props.stage.isRunning &&
+      this.props.stage.stages[0].context.changeSetIsReplacement &&
+      this.props.stage.stages[0].context.actionOnReplacement === 'ask'
+    ) {
+      require('./evaluateCloudFormationChangeSetExecutionDetailsAsk.less');
+      if (
+        typeof document.getElementsByClassName('execution-marker-running stage-type-deploycloudformation')[0] !==
+        'undefined'
+      ) {
+        document
+          .getElementsByClassName('execution-marker-running stage-type-deploycloudformation')[0]
+          .classList.add('stage-type-deploycloudformation-ask');
+      }
+      return <span className="fa fa-child" />;
+    }
+    return null;
+  }
+}

--- a/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/evaluateCloudFormationChangeSetExecutionMarkerIcon.tsx
+++ b/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/evaluateCloudFormationChangeSetExecutionMarkerIcon.tsx
@@ -1,15 +1,20 @@
 import * as React from 'react';
-import { IExecutionMarkerIconProps } from '@spinnaker/core';
+import { IExecutionMarkerIconProps } from 'core/pipeline/config/stages/common/ExecutionMarkerIcon';
 
-export const EvaluateCloudFormationChangeSetExecutionMarkerIcon = (props: IExecutionMarkerIconProps) => {
-  const { stage } = props;
-  if (
-    stage.isRunning &&
-    stage.stages[0].context.changeSetContainsReplacement &&
-    stage.stages[0].context.actionOnReplacement === 'ask'
-  ) {
-    stage.requiresAttention = true;
-    return <span className="fa fa-child" />;
+export class EvaluateCloudFormationChangeSetExecutionMarkerIcon extends React.Component<IExecutionMarkerIconProps> {
+  constructor(props: IExecutionMarkerIconProps) {
+    super(props);
   }
-  return null;
-};
+
+  public render() {
+    if (
+      this.props.stage.isRunning &&
+      this.props.stage.stages[0].context.changeSetContainsReplacement &&
+      this.props.stage.stages[0].context.actionOnReplacement === 'ask'
+    ) {
+      this.props.stage.requiresAttention = true;
+      return <span className="fa fa-child" />;
+    }
+    return null;
+  }
+}

--- a/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/evaluateCloudFormationChangeSetExecutionMarkerIcon.tsx
+++ b/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/evaluateCloudFormationChangeSetExecutionMarkerIcon.tsx
@@ -1,28 +1,15 @@
 import * as React from 'react';
-import { IExecutionMarkerIconProps } from 'core/pipeline/config/stages/common/ExecutionMarkerIcon';
+import { IExecutionMarkerIconProps } from '@spinnaker/core';
 
-export class EvaluateCloudFormationChangeSetExecutionMarkerIcon extends React.Component<IExecutionMarkerIconProps> {
-  constructor(props: IExecutionMarkerIconProps) {
-    super(props);
+export const EvaluateCloudFormationChangeSetExecutionMarkerIcon = (props: IExecutionMarkerIconProps) => {
+  const { stage } = props;
+  if (
+    stage.isRunning &&
+    stage.stages[0].context.changeSetContainsReplacement &&
+    stage.stages[0].context.actionOnReplacement === 'ask'
+  ) {
+    stage.requiresAttention = true;
+    return <span className="fa fa-child" />;
   }
-
-  public render() {
-    if (
-      this.props.stage.isRunning &&
-      this.props.stage.stages[0].context.changeSetContainsReplacement &&
-      this.props.stage.stages[0].context.actionOnReplacement === 'ask'
-    ) {
-      require('./evaluateCloudFormationChangeSetExecutionDetailsAsk.less');
-      if (
-        typeof document.getElementsByClassName('execution-marker-running stage-type-deploycloudformation')[0] !==
-        'undefined'
-      ) {
-        document
-          .getElementsByClassName('execution-marker-running stage-type-deploycloudformation')[0]
-          .classList.add('stage-type-deploycloudformation-ask');
-      }
-      return <span className="fa fa-child" />;
-    }
-    return null;
-  }
-}
+  return null;
+};

--- a/app/scripts/modules/amazon/src/reactShims/aws.react.injector.ts
+++ b/app/scripts/modules/amazon/src/reactShims/aws.react.injector.ts
@@ -4,6 +4,7 @@ import { ReactInject, FunctionReader } from '@spinnaker/core';
 
 import { AwsServerGroupConfigurationService } from '../serverGroup/configure/serverGroupConfiguration.service';
 import { AwsServerGroupTransformer } from '../serverGroup/serverGroup.transformer';
+import { EvaluateCloudFormationChangeSetExecutionService } from 'amazon/pipeline/stages/deployCloudFormation/evaluateCloudFormationChangeSetExecution.service';
 
 // prettier-ignore
 export class AwsReactInject extends ReactInject {
@@ -11,7 +12,9 @@ export class AwsReactInject extends ReactInject {
   public get awsServerGroupCommandBuilder() { return this.$injector.get('awsServerGroupCommandBuilder') as any; }
   public get awsServerGroupConfigurationService() { return this.$injector.get('awsServerGroupConfigurationService') as AwsServerGroupConfigurationService; }
   public get awsServerGroupTransformer() { return this.$injector.get('awsServerGroupTransformer') as AwsServerGroupTransformer; }
+
   public get functionReader() { return this.$injector.get('functionReader') as FunctionReader; }
+  public get evaluateCloudFormationChangeSetExecutionService() { return this.$injector.get('evaluateCloudFormationChangeSetExecutionService') as EvaluateCloudFormationChangeSetExecutionService; }
   public initialize($injector: IInjectorService) {
     this.$injector = $injector;
   }

--- a/app/scripts/modules/core/src/domain/IExecutionStage.ts
+++ b/app/scripts/modules/core/src/domain/IExecutionStage.ts
@@ -77,4 +77,5 @@ export interface IExecutionStageSummary extends IOrchestratedItem {
   status: string;
   type: string;
   useCustomTooltip?: boolean;
+  requiresAttention?: boolean;
 }

--- a/app/scripts/modules/core/src/pipeline/config/stages/common/index.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/common/index.ts
@@ -1,5 +1,6 @@
 export * from './AsgActionExecutionDetailsSection';
 export * from './ExecutionDetailsSection';
+export * from './ExecutionBarLabel';
 export * from './ExecutionDetailsTasks';
 export * from './IStageConfigProps';
 export * from './stageConfigField/StageConfigField';

--- a/app/scripts/modules/core/src/pipeline/executions/execution/ExecutionMarker.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/execution/ExecutionMarker.tsx
@@ -70,6 +70,7 @@ export class ExecutionMarker extends React.Component<IExecutionMarkerProps, IExe
       active ? 'active' : '',
       previousStageActive ? 'after-active' : '',
       stage.isRunning ? 'glowing' : '',
+      stage.requiresAttention ? 'requires-attention' : '',
     ].join(' ');
 
     const TooltipComponent = stage.useCustomTooltip ? stage.labelComponent : ExecutionBarLabel;

--- a/app/scripts/modules/core/src/pipeline/executions/execution/executionMarker.less
+++ b/app/scripts/modules/core/src/pipeline/executions/execution/executionMarker.less
@@ -32,4 +32,7 @@
   &.glowing {
     .glowing(2.5);
   }
+  &.requires-attention {
+    background-color: var(--color-alert);
+  }
 }


### PR DESCRIPTION
Add components for aws cloudformation change set execution.

* Reorganize and add forms for the ChangeSet Name, default action and execution tick.
![Screenshot 2019-11-27 at 14 18 14](https://user-images.githubusercontent.com/1881230/70053440-c2e18b80-15d5-11ea-9e79-34241da54aaf.png)

* Helper for the default action on replacement.
![Screenshot 2019-11-27 at 14 20 55](https://user-images.githubusercontent.com/1881230/70053465-cffe7a80-15d5-11ea-83ff-264722949fd4.png)

* In case of replacement there is a hold task much like manual judgement stage, asking for user input to continue:
<img width="1086" alt="Screenshot 2019-11-26 at 11 18 14" src="https://user-images.githubusercontent.com/1881230/70053512-e60c3b00-15d5-11ea-9806-37a3fe9b6388.png">

Thing is that we cannot know if a change set has a replacement until it's created, so this will allow the user to choose the behavior in advance or what to do at runtime.

Liked issue:
https://github.com/spinnaker/spinnaker/issues/5091