### PR TITLE
fix(page): Do not auto-close modal on success

### DIFF
--- a/app/scripts/modules/core/src/pagerDuty/PageModal.tsx
+++ b/app/scripts/modules/core/src/pagerDuty/PageModal.tsx
@@ -7,7 +7,7 @@ import { IPagerDutyService, PagerDutyWriter } from 'core/pagerDuty';
 import { NgReact, ReactInjector } from 'core/reactShims';
 import { SETTINGS } from 'core/config';
 import { SubmitButton } from 'core/modal';
-import { TaskMonitor, TaskExecutor } from 'core/task';
+import { TaskMonitor } from 'core/task';
 
 import { IPageButtonProps } from './PageButton';
 

--- a/app/scripts/modules/core/src/pagerDuty/PageModal.tsx
+++ b/app/scripts/modules/core/src/pagerDuty/PageModal.tsx
@@ -7,7 +7,7 @@ import { IPagerDutyService, PagerDutyWriter } from 'core/pagerDuty';
 import { NgReact, ReactInjector } from 'core/reactShims';
 import { SETTINGS } from 'core/config';
 import { SubmitButton } from 'core/modal';
-import { TaskMonitor } from 'core/task';
+import { TaskMonitor, TaskExecutor } from 'core/task';
 
 import { IPageButtonProps } from './PageButton';
 
@@ -87,7 +87,6 @@ export class PageModal extends React.Component<IPageModalProps, IPageModalState>
       application: ownerApp,
       title: `Sending page to ${this.state.pageCount} policies`,
       modalInstance: TaskMonitor.modalInstanceEmulation(() => this.close()),
-      onTaskComplete: () => this.props.closeCallback(true),
     });
 
     const submitMethod = () => {


### PR DESCRIPTION
Because this can complete so fast that users don't even see the task monitor, auto-closing causes users to not know whether their page even went through successfully.