### PR TITLE
fix(webpack): use a less race-y way of generating CSS Module TS files

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,12 +1,19 @@
 'use strict';
 
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
+const { TypedCssModulesPlugin } = require('typed-css-modules-webpack-plugin');
+
 const prodWebpackConfig = require('./webpack.config')();
 const webpackConfig = {
   mode: 'development',
   module: prodWebpackConfig.module,
   resolve: prodWebpackConfig.resolve,
-  plugins: [new ForkTsCheckerWebpackPlugin({ checkSyntacticErrors: true, tslint: true })],
+  plugins: [
+    new TypedCssModulesPlugin({
+      globPattern: '**/*.module.css',
+    }),
+    new ForkTsCheckerWebpackPlugin({ checkSyntacticErrors: true, tslint: true }),
+  ],
 };
 
 module.exports = function(config) {

--- a/package.json
+++ b/package.json
@@ -199,7 +199,7 @@
     "tslint-loader": "^3.6.0",
     "tslint-react": "^3.6.0",
     "typed-css-modules": "^0.6.3",
-    "typed-css-modules-loader": "^0.0.18",
+    "typed-css-modules-webpack-plugin": "^0.1.2",
     "typescript": "~3.4.0",
     "url-loader": "1.1.2",
     "wait-on": "^3.2.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,6 +6,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
+const { TypedCssModulesPlugin } = require('typed-css-modules-webpack-plugin');
 
 const CACHE_INVALIDATE = getCacheInvalidateString();
 const NODE_MODULE_PATH = path.join(__dirname, 'node_modules');
@@ -158,7 +159,6 @@ function configure(env, webpackOpts) {
                 localIdentName: '[name]__[local]--[hash:base64:8]',
               },
             },
-            { loader: 'typed-css-modules-loader' },
             { loader: 'postcss-loader' },
           ],
         },
@@ -181,6 +181,9 @@ function configure(env, webpackOpts) {
       ],
     },
     plugins: [
+      new TypedCssModulesPlugin({
+        globPattern: '**/*.module.css',
+      }),
       new ForkTsCheckerWebpackPlugin({ checkSyntacticErrors: true, tslint: true }),
       new CopyWebpackPlugin([
         {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12487,15 +12487,17 @@ type-is@~1.6.15, type-is@~1.6.16:
     media-typer "0.3.0"
     mime-types "~2.1.18"
 
-typed-css-modules-loader@^0.0.18:
-  version "0.0.18"
-  resolved "https://registry.yarnpkg.com/typed-css-modules-loader/-/typed-css-modules-loader-0.0.18.tgz#ee4e9b30f6819e19434b40e37064ae36f7679113"
-  integrity sha512-w7RK5CeycywiqsXIvmWN/vPEs6aSKs39bsfvqJDfRhpbzBbBu+Isat/Qm833S3z5nNHlkhRmVCDiwODQjS/Yxg==
+typed-css-modules-webpack-plugin@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/typed-css-modules-webpack-plugin/-/typed-css-modules-webpack-plugin-0.1.2.tgz#875149d910d5444be8ab24020beab6bebc098c1e"
+  integrity sha512-gJLqsCifgvCW6jjMqk0MNv6/bbfFLf+hYci0jRQDmiWgnz8OUT9gQnaFzbAp+U1oh24ZynLQYaWf75m9mlbYbQ==
   dependencies:
-    loader-utils "^1.1.0"
-    typed-css-modules "^0.6.2"
+    chalk "^2.4.1"
+    css-modules-loader-core "^1.1.0"
+    glob "^7.1.3"
+    typed-css-modules "^0.6.0"
 
-typed-css-modules@^0.6.2, typed-css-modules@^0.6.3:
+typed-css-modules@^0.6.0, typed-css-modules@^0.6.3:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/typed-css-modules/-/typed-css-modules-0.6.3.tgz#c539504d979022432fcea17dff1e264e702528b7"
   integrity sha512-p1JYq628LZLxg6IFZEGwBF+rFbWMwz4AyplAsriyFWKDXdShQNAljrjt4qFO9GvvjmNdsuUMmiQji/MVZHu7JQ==


### PR DESCRIPTION
The loader I had originally added to generate type declarations for CSS Module files seemed like it was working fine, but on Travis has been running into a race where the TS loader tries to lookup defs for the CSS Module files before their declarations are generated on the filesystem. That results in CI builds failing with errors re: not knowing about a module.

This switches to a [different webpack tool](https://github.com/dropbox/typed-css-modules-webpack-plugin) that runs during the plugin phase, before loaders kick in. Tested locally and it seems like it will be less race-y, but need to test on Travis to be sure.