### PR TITLE
fix(titus): Remove default metricName

### DIFF
--- a/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/upsert/alarm/metricSelector.component.ts
+++ b/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/upsert/alarm/metricSelector.component.ts
@@ -96,7 +96,7 @@ export class MetricSelectorController implements IController {
         if (selected) {
           this.state.selectedMetric = selected;
         } else {
-          // If metricName is blank (new policy), auto-select the first metric instead of sitting on the blank invalid option
+          // If metricName is blank (new policy), try to find a CPU metric or select the first option instead of sitting on the invalid blank option
           if (alarm.metricName === '' && this.state.metrics.length > 0) {
             this.state.selectedMetric =
               this.state.metrics.find(metric => metric.name.match('CPUUtilization')) || this.state.metrics[0];

--- a/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/upsert/alarm/metricSelector.component.ts
+++ b/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/upsert/alarm/metricSelector.component.ts
@@ -97,7 +97,7 @@ export class MetricSelectorController implements IController {
           this.state.selectedMetric = selected;
         } else {
           // If metricName is blank (new policy), try to find a CPU metric or select the first option instead of sitting on the invalid blank option
-          if (alarm.metricName === '' && this.state.metrics.length > 0) {
+          if (!alarm.metricName && this.state.metrics.length) {
             this.state.selectedMetric =
               this.state.metrics.find(metric => metric.name.match('CPUUtilization')) || this.state.metrics[0];
           }

--- a/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/upsert/alarm/metricSelector.component.ts
+++ b/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/upsert/alarm/metricSelector.component.ts
@@ -98,7 +98,8 @@ export class MetricSelectorController implements IController {
         } else {
           // If metricName is blank (new policy), auto-select the first metric instead of sitting on the blank invalid option
           if (alarm.metricName === '' && this.state.metrics.length > 0) {
-            this.state.selectedMetric = this.state.metrics[0];
+            this.state.selectedMetric =
+              this.state.metrics.find(metric => metric.name.match('CPUUtilization')) || this.state.metrics[0];
           }
         }
         this.metricChanged();

--- a/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/upsert/alarm/metricSelector.component.ts
+++ b/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/upsert/alarm/metricSelector.component.ts
@@ -95,6 +95,11 @@ export class MetricSelectorController implements IController {
         }
         if (selected) {
           this.state.selectedMetric = selected;
+        } else {
+          // If metricName is blank (new policy), auto-select the first metric instead of sitting on the blank invalid option
+          if (alarm.metricName === '' && this.state.metrics.length > 0) {
+            this.state.selectedMetric = this.state.metrics[0];
+          }
         }
         this.metricChanged();
       })

--- a/app/scripts/modules/titus/src/serverGroup/serverGroup.transformer.js
+++ b/app/scripts/modules/titus/src/serverGroup/serverGroup.transformer.js
@@ -34,7 +34,7 @@ module.exports = angular.module('spinnaker.titus.serverGroup.transformer', []).f
         alarms: [
           {
             namespace: 'NFLX/EPIC',
-            metricName: 'CPUUtilization',
+            metricName: '',
             threshold: 50,
             statistic: 'Average',
             comparisonOperator: 'GreaterThanThreshold',
@@ -62,7 +62,7 @@ module.exports = angular.module('spinnaker.titus.serverGroup.transformer', []).f
           disableScaleIn: false,
           customizedMetricSpecification: {
             namespace: 'NFLX/EPIC',
-            metricName: 'CPUUtilization',
+            metricName: '',
             dimensions: [{ name: 'AutoScalingGroupName', value: serverGroup.name }],
           },
           scaleInCooldown: 300,


### PR DESCRIPTION
When we can't find any CloudWatch metrics, we automatically throw the user into advanced mode. 

However, the presence of a default metricName gives the user a false impression that maybe the can set up that autoscaling policy of the default metricName was the metric they wanted to track against anyways.

This is FALSE. If there are no metrics in CloudWatch, autoscaling will not happen.

I've changed the default metricName to be blank instead of `CPUUtilization` (which is anyways wrong), so that the user does not get this false impression and hope that they see the text that has been there all along to tell them that they need to make metrics available in CloudWatch.

Also added a tweak so that if metrics are available and we are creating a new policy, we try to auto-select a metric like `CPUUtilization` otherwise we auto-select the first option. Both of these seem better than auto-selecting the invalid empty option.