### PR TITLE
refactor(core): move managed entity fields to separate interface

### DIFF
--- a/app/scripts/modules/core/src/cluster/filter/ClusterFilterService.ts
+++ b/app/scripts/modules/core/src/cluster/filter/ClusterFilterService.ts
@@ -4,12 +4,11 @@ import { $log } from 'ngimport';
 import { Subject } from 'rxjs';
 
 import { Application } from 'core/application/application.model';
-import { ICluster, IEntityTags, IInstance, IServerGroup } from 'core/domain';
+import { ICluster, IEntityTags, IInstance, IManagedResourceSummary, IServerGroup } from 'core/domain';
 import { ClusterState } from 'core/state';
 import { FilterModelService, ISortFilter } from 'core/filterModel';
 import { ReactInjector } from 'core/reactShims';
 import { ILabelFilter, trueKeyObjectToLabelFilters } from 'core/cluster/filter/labelFilterUtils';
-import { IManagedResourceSummary } from 'core/managed';
 
 export interface IParentGrouping {
   subgroups: IClusterSubgroup[] | IServerGroupSubgroup[];

--- a/app/scripts/modules/core/src/domain/ILoadBalancer.ts
+++ b/app/scripts/modules/core/src/domain/ILoadBalancer.ts
@@ -1,8 +1,8 @@
 import { IMoniker } from 'core/naming';
-import { IManagedResourceSummary } from 'core/managed';
 
 import { IInstance } from './IInstance';
 import { IInstanceCounts } from './IInstanceCounts';
+import { IManagedResource } from './IManagedEntity';
 import { IServerGroup } from './IServerGroup';
 import { ITaggedEntity } from './ITaggedEntity';
 
@@ -13,17 +13,15 @@ export interface ILoadBalancerSourceData {
   type?: string;
 }
 
-export interface ILoadBalancer extends ITaggedEntity {
+export interface ILoadBalancer extends ITaggedEntity, IManagedResource {
   account?: string;
   cloudProvider?: string;
   detail?: string;
   healthState?: string;
   instanceCounts?: IInstanceCounts;
   instances?: IInstance[];
-  isManaged?: boolean;
   listenerDescriptions?: any[];
   loadBalancerType?: string;
-  managedResourceSummary?: IManagedResourceSummary;
   moniker?: IMoniker;
   name?: string;
   provider?: string;
@@ -37,12 +35,10 @@ export interface ILoadBalancer extends ITaggedEntity {
   vpcName?: string;
 }
 
-export interface ILoadBalancerGroup {
+export interface ILoadBalancerGroup extends IManagedResource {
   heading: string;
   loadBalancer?: ILoadBalancer;
   serverGroups?: IServerGroup[];
   subgroups?: ILoadBalancerGroup[];
   searchField?: string;
-  isManaged?: boolean;
-  managedResourceSummary?: IManagedResourceSummary;
 }

--- a/app/scripts/modules/core/src/domain/IManagedEntity.ts
+++ b/app/scripts/modules/core/src/domain/IManagedEntity.ts
@@ -1,0 +1,34 @@
+import { IMoniker } from 'core/naming';
+
+export enum ManagedResourceStatus {
+  ACTUATING = 'ACTUATING',
+  CREATED = 'CREATED',
+  DIFF = 'DIFF',
+  ERROR = 'ERROR',
+  HAPPY = 'HAPPY',
+  PAUSED = 'PAUSED',
+  RESUMED = 'RESUMED',
+  UNHAPPY = 'UNHAPPY',
+  UNKNOWN = 'UNKNOWN',
+}
+
+export interface IManagedResourceSummary {
+  id: string;
+  kind: string;
+  status: ManagedResourceStatus;
+  moniker: IMoniker;
+  locations: {
+    account: string;
+    regions: Array<{ name: string }>;
+  };
+}
+
+export interface IManagedApplicationSummary {
+  hasManagedResources: boolean;
+  resources: IManagedResourceSummary[];
+}
+
+export interface IManagedResource {
+  managedResourceSummary?: IManagedResourceSummary;
+  isManaged?: boolean;
+}

--- a/app/scripts/modules/core/src/domain/ISecurityGroup.ts
+++ b/app/scripts/modules/core/src/domain/ISecurityGroup.ts
@@ -1,9 +1,8 @@
-import { ILoadBalancer } from 'core/domain/ILoadBalancer';
-import { IServerGroup } from 'core/domain/IServerGroup';
-import { IMoniker } from 'core/naming';
-import { IManagedResourceSummary } from 'core/managed';
-
 import { IEntityTags } from './IEntityTags';
+import { ILoadBalancer } from './ILoadBalancer';
+import { IServerGroup } from './IServerGroup';
+import { IManagedResource } from './IManagedEntity';
+import { IMoniker } from 'core/naming';
 
 export interface ILoadBalancerUsage {
   name: string;
@@ -22,7 +21,7 @@ export interface IUsages {
   serverGroups: IServerGroupUsage[];
 }
 
-export interface ISecurityGroup {
+export interface ISecurityGroup extends IManagedResource {
   account?: string;
   accountId?: string;
   accountName?: string;
@@ -33,9 +32,7 @@ export interface ISecurityGroup {
   entityTags?: IEntityTags;
   id?: string;
   inferredName?: boolean;
-  isManaged?: boolean;
   moniker?: IMoniker;
-  managedResourceSummary?: IManagedResourceSummary;
   name?: string;
   provider?: string;
   region?: string;
@@ -47,11 +44,9 @@ export interface ISecurityGroup {
   vpcName?: string;
 }
 
-export interface ISecurityGroupGroup {
+export interface ISecurityGroupGroup extends IManagedResource {
   heading: string;
-  isManaged?: boolean;
   loadBalancers?: ILoadBalancer[];
-  managedResourceSummary?: IManagedResourceSummary;
   searchField?: string;
   securityGroup?: ISecurityGroup;
   serverGroups?: IServerGroup[];

--- a/app/scripts/modules/core/src/domain/IServerGroup.ts
+++ b/app/scripts/modules/core/src/domain/IServerGroup.ts
@@ -2,10 +2,10 @@ import { IEntityTags } from './IEntityTags';
 import { IExecution } from './IExecution';
 import { IInstance } from './IInstance';
 import { IInstanceCounts } from './IInstanceCounts';
+import { IManagedResource } from './IManagedEntity';
 import { ITask } from './ITask';
 import { IMoniker } from 'core/naming';
 import { ICapacity } from 'core/serverGroup';
-import { IManagedResourceSummary } from 'core/managed';
 
 // remnant from legacy code
 export interface IAsg {
@@ -15,7 +15,7 @@ export interface IAsg {
   tags?: any[];
 }
 
-export interface IServerGroup {
+export interface IServerGroup extends IManagedResource {
   account: string;
   app?: string;
   asg?: IAsg;
@@ -35,11 +35,9 @@ export interface IServerGroup {
   instances: IInstance[];
   instanceType?: string;
   isDisabled?: boolean;
-  isManaged?: boolean;
   labels?: { [key: string]: string };
   launchConfig?: any;
   loadBalancers?: string[];
-  managedResourceSummary?: IManagedResourceSummary;
   moniker?: IMoniker;
   name: string;
   namespace?: string;

--- a/app/scripts/modules/core/src/domain/index.ts
+++ b/app/scripts/modules/core/src/domain/index.ts
@@ -36,6 +36,7 @@ export * from '../widgets/Keys';
 export * from './ILoadBalancer';
 export * from './ILoadBalancerIncompatibility';
 
+export * from './IManagedEntity';
 export * from './IManifest';
 
 export * from './INotification';

--- a/app/scripts/modules/core/src/loadBalancer/filter/LoadBalancerFilterService.spec.ts
+++ b/app/scripts/modules/core/src/loadBalancer/filter/LoadBalancerFilterService.spec.ts
@@ -1,8 +1,7 @@
 import { Application } from 'core/application/application.model';
 import { ApplicationModelBuilder } from 'core/application/applicationModel.builder';
-import { ILoadBalancer, IServerGroup, ILoadBalancerGroup } from 'core/domain';
+import { ILoadBalancer, IServerGroup, ILoadBalancerGroup, IManagedResourceSummary } from 'core/domain';
 import { LoadBalancerState } from 'core/state';
-import { IManagedResourceSummary } from 'core/managed';
 
 // Most of this logic has been moved to filter.model.service.js, so these act more as integration tests
 describe('Service: loadBalancerFilterService', function() {

--- a/app/scripts/modules/core/src/managed/ManagedReader.ts
+++ b/app/scripts/modules/core/src/managed/ManagedReader.ts
@@ -1,35 +1,7 @@
 import { IPromise } from 'angular';
 
 import { API } from 'core/api';
-import { IMoniker } from 'core/naming';
-
-export enum ManagedResourceStatus {
-  ACTUATING = 'ACTUATING',
-  CREATED = 'CREATED',
-  DIFF = 'DIFF',
-  ERROR = 'ERROR',
-  HAPPY = 'HAPPY',
-  PAUSED = 'PAUSED',
-  RESUMED = 'RESUMED',
-  UNHAPPY = 'UNHAPPY',
-  UNKNOWN = 'UNKNOWN',
-}
-
-export interface IManagedResourceSummary {
-  id: string;
-  kind: string;
-  status: ManagedResourceStatus;
-  moniker: IMoniker;
-  locations: {
-    account: string;
-    regions: Array<{ name: string }>;
-  };
-}
-
-export interface IManagedApplicationSummary {
-  hasManagedResources: boolean;
-  resources: IManagedResourceSummary[];
-}
+import { IManagedApplicationSummary } from 'core/domain';
 
 export const getResourceKindForLoadBalancerType = (type: string) => {
   switch (type) {

--- a/app/scripts/modules/core/src/managed/ManagedResourceDetailsIndicator.tsx
+++ b/app/scripts/modules/core/src/managed/ManagedResourceDetailsIndicator.tsx
@@ -5,7 +5,7 @@ import { Dropdown } from 'react-bootstrap';
 import { SETTINGS } from 'core/config/settings';
 import { HoverablePopover } from 'core/presentation';
 
-import { IManagedResourceSummary } from './ManagedReader';
+import { IManagedResourceSummary } from 'core/domain';
 
 import './ManagedResourceDetailsIndicator.css';
 

--- a/app/scripts/modules/core/src/managed/ManagedResourceStatusIndicator.tsx
+++ b/app/scripts/modules/core/src/managed/ManagedResourceStatusIndicator.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import { UISref } from '@uirouter/react';
 
 import { HoverablePopover } from 'core/presentation';
-import { IManagedResourceSummary, ManagedResourceStatus } from 'core/managed';
+import { IManagedResourceSummary, ManagedResourceStatus } from 'core/domain';
 
 import './ManagedResourceStatusIndicator.less';
 

--- a/app/scripts/modules/core/src/managed/managed.dataSource.ts
+++ b/app/scripts/modules/core/src/managed/managed.dataSource.ts
@@ -4,7 +4,8 @@ import { noop } from 'core/utils';
 import { SETTINGS } from 'core/config/settings';
 import { ApplicationDataSourceRegistry } from 'core/application/service/ApplicationDataSourceRegistry';
 import { Application } from 'core/application';
-import { ManagedReader, IManagedApplicationSummary } from './ManagedReader';
+import { IManagedApplicationSummary } from 'core/domain';
+import { ManagedReader } from './ManagedReader';
 import {
   addManagedResourceMetadataToServerGroups,
   addManagedResourceMetadataToLoadBalancers,

--- a/app/scripts/modules/core/src/managed/managedResourceDecorators.ts
+++ b/app/scripts/modules/core/src/managed/managedResourceDecorators.ts
@@ -1,9 +1,9 @@
 import { Application } from 'core/application';
 import { SETTINGS } from 'core/config';
-import { IServerGroup, ILoadBalancer, ISecurityGroup } from 'core/domain';
+import { IServerGroup, ILoadBalancer, IManagedResourceSummary, ISecurityGroup } from 'core/domain';
 import { IMoniker } from 'core/naming';
 
-import { IManagedResourceSummary, getResourceKindForLoadBalancerType } from './ManagedReader';
+import { getResourceKindForLoadBalancerType } from './ManagedReader';
 
 const isMonikerEqual = (a: IMoniker, b: IMoniker) => a.app === b.app && a.stack === b.stack && a.detail === b.detail;
 


### PR DESCRIPTION
It's getting to the end of the year and I'm concerned about my GH stats, so I wanted to get those numbers up and this seemed like an easy way to do it.

Just kidding! When we start adding pause/resume behavior at the resource level, and a resource gets paused, we'll need an indicator of where the pausing comes from: either the resource itself, or the application. If the resource is explicitly paused, we'll provide a way for the user to resume actuation. If it's at the application level, we'll tell the user that the entire application is paused, and they can resume actuation from the config view.

Not sure what the API is going to return to indicate that (cc @emjburns), but when it does, we'll just need to update the one interface, instead of all three domain classes.