### PR TITLE
fix(titus): Temporarily disabling previous image rollbacks for Titus

### DIFF
--- a/app/scripts/modules/titus/src/serverGroup/details/rollback/rollbackServerGroup.controller.js
+++ b/app/scripts/modules/titus/src/serverGroup/details/rollback/rollbackServerGroup.controller.js
@@ -89,7 +89,9 @@ module.exports = angular
 
         if (rollbackType === 'PREVIOUS_IMAGE') {
           // no need to validate when using an explicit image
-          return true;
+          // return true;
+          // KLUDGE: temporarily disabling previous image rollbacks for titus because they do not work properly
+          return false;
         }
 
         return command.rollbackContext.restoreServerGroupName !== undefined;

--- a/app/scripts/modules/titus/src/serverGroup/details/rollback/rollbackServerGroup.html
+++ b/app/scripts/modules/titus/src/serverGroup/details/rollback/rollbackServerGroup.html
@@ -128,6 +128,16 @@
             This rollback will affect server groups in {{ serverGroup.account }} ({{ serverGroup.region }}).
           </p>
         </div>
+        <div class="col-sm-12">
+          <div class="alert alert-warning">
+            Rolling back to a server group that is no longer deployed is currently not available for Titus. <br />
+            Please clone the server group with the previous image instead. <br />
+            <span class="small">
+              <strong>Image</strong>: {{ previousServerGroup.imageName}}
+              <span ng-if="previousServerGroup.imageId">({{ previousServerGroup.imageId }})</span><br />
+            </span>
+          </div>
+        </div>
       </div>
     </div>
     <aws-footer


### PR DESCRIPTION
`PREVIOUS_IMAGE` rollbacks for Titus were incompletely implemented making them dangerous to allow at this point.

Temporarily disabling them from being performed in the UI until they are addressed.