### PR TITLE
chore(karma): Adding spec reporter to find problematic test

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -58,6 +58,7 @@ module.exports = function(config) {
       require('karma-sourcemap-loader'),
       require('karma-super-dots-reporter'),
       require('karma-mocha-reporter'),
+      require('karma-spec-reporter'),
     ],
 
     // list of files / patterns to exclude

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -74,7 +74,7 @@ module.exports = function(config) {
     // possible values: LOG_DISABLE || LOG_ERROR || LOG_WARN || LOG_INFO || LOG_DEBUG
     logLevel: config.DEBUG,
 
-    reporters: ['super-dots', 'mocha'],
+    reporters: ['super-dots', 'mocha', 'spec'],
     mochaReporter: {
       output: 'minimal',
     },

--- a/package.json
+++ b/package.json
@@ -170,6 +170,7 @@
     "karma-junit-reporter": "^1.1.0",
     "karma-mocha-reporter": "^2.2.5",
     "karma-sourcemap-loader": "=0.3.7",
+    "karma-spec-reporter": "^0.0.32",
     "karma-super-dots-reporter": "^0.2.0",
     "karma-webpack": "3.0.5",
     "less": "^2.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3121,6 +3121,11 @@ colors@^1.1.0, colors@~1.1.2:
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
   integrity sha1-FopHAXVran9RoSzgyXv6KMCE7WM=
 
+colors@^1.1.2:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
+  integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
+
 colors@^1.2.1:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.3.3.tgz#39e005d546afe01e01f9c4ca8fa50f686a01205d"
@@ -7556,6 +7561,13 @@ karma-sourcemap-loader@=0.3.7:
   integrity sha1-kTIsd/jxPUb+0GKwQuEAnUxFBdg=
   dependencies:
     graceful-fs "^4.1.2"
+
+karma-spec-reporter@^0.0.32:
+  version "0.0.32"
+  resolved "https://registry.yarnpkg.com/karma-spec-reporter/-/karma-spec-reporter-0.0.32.tgz#2e9c7207ea726771260259f82becb543209e440a"
+  integrity sha1-LpxyB+pyZ3EmAln4K+y1QyCeRAo=
+  dependencies:
+    colors "^1.1.2"
 
 karma-super-dots-reporter@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
Not sure if we want to merge this, but just trying to see if a travis run with this enabled gives us more insight into what is failing in master