### PR TITLE
test(core): Fix intermittent Executions test

### DIFF
--- a/app/scripts/modules/core/src/pipeline/executions/Executions.spec.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/Executions.spec.tsx
@@ -40,6 +40,7 @@ describe('<Executions/>', () => {
         'app',
         { key: 'executions', lazy: true, defaultData: [] },
         { key: 'pipelineConfigs', lazy: true, defaultData: [] },
+        { key: 'runningExecutions', lazy: true, defaultData: [] },
       );
     }),
   );


### PR DESCRIPTION
Looks like this test is intermittently blowing up on master because `app.getDataSource('runningExecutions')` is undefined and blowing up:
```
    this.activeRefresher.subscribe(() => {
      app.getDataSource('runningExecutions').refresh();
    });
```