### PR TITLE
refactor(core/managed): switch from ApplicationVeto to pause API

### DIFF
--- a/app/scripts/modules/core/src/application/config/managedResources/ManagedResourceConfig.tsx
+++ b/app/scripts/modules/core/src/application/config/managedResources/ManagedResourceConfig.tsx
@@ -6,9 +6,8 @@ import classNames from 'classnames';
 
 import { NgReact } from 'core/reactShims';
 import { Application } from 'core/application';
-import { useData, ValidationMessage } from 'core/presentation';
-import { Spinner } from 'core/widgets';
-import { ManagedReader, ManagedWriter } from 'core/managed';
+import { ValidationMessage, useLatestCallback } from 'core/presentation';
+import { ManagedWriter } from 'core/managed';
 
 import './ManagedResourceConfig.less';
 
@@ -58,13 +57,12 @@ const getManagementStatus = (paused: boolean) => {
 const ManagedResourceConfig = ({ application }: IManagedResourceConfigProps) => {
   const [pausePending, setPausePending] = useState(false);
   const [pauseFailed, setPauseFailed] = useState(false);
-  const [paused, setPaused] = useState(false);
-  const { status: vetoStatus, result: vetos, refresh } = useData(() => ManagedReader.getApplicationVetos(), [], []);
+  const [paused, setPaused] = useState(application.managedResources.data.applicationPaused);
 
-  const isRejected = vetos && vetos.includes(application.name);
-  useEffect(() => {
-    setPaused(isRejected);
-  }, [isRejected]);
+  const onRefresh = useLatestCallback(() => {
+    setPaused(application.managedResources.data.applicationPaused);
+  });
+  useEffect(() => application.managedResources.onRefresh(null, onRefresh), [application]);
 
   const pauseManagement = () => {
     setPausePending(true);
@@ -72,7 +70,10 @@ const ManagedResourceConfig = ({ application }: IManagedResourceConfigProps) => 
     logClick('Pause Management', application.name);
 
     ManagedWriter.pauseResourceManagement(application.name)
-      .then(() => setPaused(true))
+      .then(() => {
+        setPaused(true);
+        application.managedResources.refresh();
+      })
       .catch(() => setPauseFailed(true))
       .finally(() => setPausePending(false));
   };
@@ -83,23 +84,13 @@ const ManagedResourceConfig = ({ application }: IManagedResourceConfigProps) => 
     logClick('Resume Management', application.name);
 
     ManagedWriter.resumeResourceManagement(application.name)
-      .then(() => setPaused(false))
+      .then(() => {
+        setPaused(false);
+        application.managedResources.refresh();
+      })
       .catch(() => setPauseFailed(true))
       .finally(() => setPausePending(false));
   };
-
-  if (['NONE', 'PENDING'].includes(vetoStatus)) {
-    return <Spinner size="medium" />;
-  } else if (vetoStatus === 'REJECTED') {
-    return (
-      <div className="alert alert-danger">
-        Something went wrong.{' '}
-        <button className="btn btn-link" onClick={refresh}>
-          Try again
-        </button>
-      </div>
-    );
-  }
 
   const iconClass = paused ? 'fa-play' : 'fa-pause';
 

--- a/app/scripts/modules/core/src/domain/IManagedEntity.ts
+++ b/app/scripts/modules/core/src/domain/IManagedEntity.ts
@@ -24,6 +24,7 @@ export interface IManagedResourceSummary {
 }
 
 export interface IManagedApplicationSummary {
+  applicationPaused: boolean;
   hasManagedResources: boolean;
   resources: IManagedResourceSummary[];
 }

--- a/app/scripts/modules/core/src/managed/ManagedWriter.ts
+++ b/app/scripts/modules/core/src/managed/ManagedWriter.ts
@@ -5,17 +5,15 @@ import { API } from 'core/api';
 export class ManagedWriter {
   public static pauseResourceManagement(application: string): IPromise<void> {
     return API.one('managed')
-      .all('vetos')
-      .one('ApplicationVeto')
-      .data({ application, optedOut: true })
+      .one('application', application)
+      .one('pause')
       .post();
   }
 
   public static resumeResourceManagement(application: string): IPromise<void> {
     return API.one('managed')
-      .all('vetos')
-      .one('ApplicationVeto')
-      .data({ application, optedOut: false })
-      .post();
+      .one('application', application)
+      .one('pause')
+      .remove();
   }
 }

--- a/app/scripts/modules/core/src/managed/managed.dataSource.ts
+++ b/app/scripts/modules/core/src/managed/managed.dataSource.ts
@@ -39,7 +39,7 @@ module(MANAGED_RESOURCES_DATA_SOURCE, []).run([
       loader: loadManagedResources,
       onLoad: addManagedResources,
       afterLoad: addManagedMetadataToResources,
-      defaultData: { hasManagedResources: false, resources: [] },
+      defaultData: { applicationPaused: false, hasManagedResources: false, resources: [] },
     });
   },
 ]);


### PR DESCRIPTION
Couple changes:

- Switch to using the new pause APIs added via https://github.com/spinnaker/keel/pull/644 and https://github.com/spinnaker/gate/pull/983
- Little bit of "fun" data-munging where we add a `PAUSED` status to every resource in an app if the app is paused. I did this for now because we want to swap over to the new APIs as soon as possible and I didn't want to go threading state (specifically data source updates) into the stateless components that currently render statuses. I suspect we'll change either the API or the client soon to where that munging doesn't happen