### PR TITLE
refactor(core): add pause status flags to managed resources

### DIFF
--- a/app/scripts/modules/core/src/application/application.model.ts
+++ b/app/scripts/modules/core/src/application/application.model.ts
@@ -83,6 +83,11 @@ export class Application {
   public isStandalone = false;
 
   /**
+   * If managed delivery is enabled, indicates whether an entire application is in an explicit paused state
+   */
+  public isManagementPaused = false;
+
+  /**
    * Which data source is the active state
    * @type {ApplicationDataSource}
    */

--- a/app/scripts/modules/core/src/application/config/managedResources/ManagedResourceConfig.tsx
+++ b/app/scripts/modules/core/src/application/config/managedResources/ManagedResourceConfig.tsx
@@ -57,10 +57,10 @@ const getManagementStatus = (paused: boolean) => {
 const ManagedResourceConfig = ({ application }: IManagedResourceConfigProps) => {
   const [pausePending, setPausePending] = useState(false);
   const [pauseFailed, setPauseFailed] = useState(false);
-  const [paused, setPaused] = useState(application.managedResources.data.applicationPaused);
+  const [paused, setPaused] = useState(application.isManagementPaused);
 
   const onRefresh = useLatestCallback(() => {
-    setPaused(application.managedResources.data.applicationPaused);
+    setPaused(application.isManagementPaused);
   });
   useEffect(() => application.managedResources.onRefresh(null, onRefresh), [application]);
 

--- a/app/scripts/modules/core/src/domain/IManagedEntity.ts
+++ b/app/scripts/modules/core/src/domain/IManagedEntity.ts
@@ -16,6 +16,7 @@ export interface IManagedResourceSummary {
   id: string;
   kind: string;
   status: ManagedResourceStatus;
+  isPaused: boolean;
   moniker: IMoniker;
   locations: {
     account: string;

--- a/app/scripts/modules/core/src/managed/ManagedReader.ts
+++ b/app/scripts/modules/core/src/managed/ManagedReader.ts
@@ -24,10 +24,10 @@ export class ManagedReader {
         // Individual resources don't update their status when an application is paused/resumed,
         // so for now let's swap to a PAUSED status and keep things simpler in downstream components.
         if (!response.applicationPaused) {
-          return response;
+          response.resources.forEach(resource => (resource.status = ManagedResourceStatus.PAUSED));
         }
 
-        response.resources.forEach(resource => (resource.status = ManagedResourceStatus.PAUSED));
+        response.resources.forEach(resource => (resource.isPaused = resource.status === ManagedResourceStatus.PAUSED));
 
         return response;
       });

--- a/app/scripts/modules/core/src/managed/managed.dataSource.ts
+++ b/app/scripts/modules/core/src/managed/managed.dataSource.ts
@@ -1,4 +1,4 @@
-import { module, IQService } from 'angular';
+import { IQService, module } from 'angular';
 
 import { noop } from 'core/utils';
 import { SETTINGS } from 'core/config/settings';
@@ -23,7 +23,8 @@ module(MANAGED_RESOURCES_DATA_SOURCE, []).run([
       return ManagedReader.getApplicationSummary(application.name);
     };
 
-    const addManagedResources = (_application: Application, data: IManagedApplicationSummary) => {
+    const addManagedResources = (application: Application, data: IManagedApplicationSummary) => {
+      application.isManagementPaused = data.applicationPaused;
       return $q.when(data);
     };
 


### PR DESCRIPTION
Nothing big here, just adding some shorthand fields: `isPaused` to managed resource summaries, and `isManagementPaused` to the application. I'm going to use those flags pretty heavily in some subsequent PRs, and it's a lot easier to read:
 `resource.isPaused` 
than 
`resource.status === ManagedResourceStatus.PAUSED`

and
`application.isManagementPaused`
than
`application.managedResources.data.applicationPaused`

The latter is also a little safer, as we're not getting type checks on data source references on the application. I kept typing `application.managedResource.data.applicationPaused` and then getting a JS error at runtime since Typescript wasn't able to catch it.