### PR TITLE
fix(eslint): dcos import must conform to new eslint rules

### DIFF
--- a/app/scripts/app.ts
+++ b/app/scripts/app.ts
@@ -16,6 +16,7 @@ import { ECS_MODULE } from '@spinnaker/ecs';
 import '@spinnaker/cloudfoundry';
 import { AZURE_MODULE } from '@spinnaker/azure';
 import { HUAWEICLOUD_MODULE } from '@spinnaker/huaweicloud';
+import { DCOS_DCOS_MODULE } from './modules/dcos/dcos.module';
 
 module('netflix.spinnaker', [
   CORE_MODULE,
@@ -26,7 +27,7 @@ module('netflix.spinnaker', [
   KUBERNETES_V1_MODULE,
   DOCKER_MODULE,
   ORACLE_MODULE,
-  require('./modules/dcos/dcos.module').name,
+  DCOS_DCOS_MODULE,
   APPENGINE_MODULE,
   CANARY_MODULE,
   KUBERNETES_V2_MODULE,


### PR DESCRIPTION
I think [CI is upset](https://travis-ci.org/spinnaker/deck/jobs/624469904?utm_medium=notification&utm_source=github_status) about this `require`? Happy Friday! :taco: 