### PR TITLE
refactor(google): refactor GCB stage to use new FormikFormFields and …

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/googleCloudBuild/GoogleCloudBuildStageConfig.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/googleCloudBuild/GoogleCloudBuildStageConfig.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { cloneDeep, defaults } from 'lodash';
+import { cloneDeep } from 'lodash';
 
 import { FormikStageConfig, IFormikStageConfigInjectedProps, IStageConfigProps } from '@spinnaker/core';
 
@@ -15,10 +15,11 @@ export function GoogleCloudBuildStageConfig({
   updateStage,
 }: IStageConfigProps) {
   const stageWithDefaults: IGoogleCloudBuildStage = React.useMemo(() => {
-    return defaults(cloneDeep(stage), {
+    return {
       application: application.name,
       buildDefinitionSource: BuildDefinitionSource.TEXT,
-    });
+      ...cloneDeep(stage),
+    };
   }, []);
 
   return (

--- a/app/scripts/modules/core/src/pipeline/config/stages/googleCloudBuild/GoogleCloudBuildStageConfig.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/googleCloudBuild/GoogleCloudBuildStageConfig.tsx
@@ -1,87 +1,36 @@
 import React from 'react';
-import { Observable, Subject } from 'rxjs';
-import { cloneDeep } from 'lodash';
+import { cloneDeep, defaults } from 'lodash';
 
-import { FormikStageConfig, IgorService, IStage, IStageConfigProps, IGcbTrigger } from '@spinnaker/core';
+import { FormikStageConfig, IFormikStageConfigInjectedProps, IStageConfigProps } from '@spinnaker/core';
 
-import { GoogleCloudBuildStageForm, buildDefinitionSources, triggerType } from './GoogleCloudBuildStageForm';
+import { GoogleCloudBuildStageForm } from './GoogleCloudBuildStageForm';
 import { validate } from './googleCloudBuildValidators';
+import { BuildDefinitionSource, IGoogleCloudBuildStage } from './IGoogleCloudBuildStage';
 
-interface IGoogleCloudBuildStageConfigState {
-  googleCloudBuildAccounts: string[];
-  gcbTriggers: IGcbTrigger[];
-}
+export function GoogleCloudBuildStageConfig({
+  application,
+  pipeline,
+  stage,
+  updatePipeline,
+  updateStage,
+}: IStageConfigProps) {
+  const stageWithDefaults: IGoogleCloudBuildStage = React.useMemo(() => {
+    return defaults(cloneDeep(stage), {
+      application: application.name,
+      buildDefinitionSource: BuildDefinitionSource.TEXT,
+    });
+  }, []);
 
-export class GoogleCloudBuildStageConfig extends React.Component<IStageConfigProps, IGoogleCloudBuildStageConfigState> {
-  private stage: IStage;
-  private destroy$ = new Subject();
-
-  public constructor(props: IStageConfigProps) {
-    super(props);
-    this.state = {
-      googleCloudBuildAccounts: [],
-      gcbTriggers: [],
-    };
-    const { stage: initialStageConfig } = props;
-    const stage = cloneDeep(initialStageConfig);
-    if (!stage.application) {
-      stage.application = props.application.name;
-    }
-    if (!stage.buildDefinitionSource) {
-      stage.buildDefinitionSource = buildDefinitionSources.TEXT;
-    }
-    if (!stage.triggerType) {
-      stage.triggerType = triggerType.BRANCH;
-    }
-    // Intentionally initializing the stage config only once in the constructor
-    // The stage config is then completely owned within FormikStageConfig's Formik state
-    this.stage = stage;
-  }
-
-  public componentDidMount = (): void => {
-    this.fetchGoogleCloudBuildAccounts();
-    if (this.stage.account) {
-      this.fetchGcbTriggers(this.stage.account);
-    }
-  };
-
-  private fetchGoogleCloudBuildAccounts = (): void => {
-    Observable.fromPromise(IgorService.getGcbAccounts())
-      .takeUntil(this.destroy$)
-      .subscribe((googleCloudBuildAccounts: string[]) => {
-        this.setState({ googleCloudBuildAccounts });
-      });
-  };
-
-  public componentWillUnmount(): void {
-    this.destroy$.next();
-  }
-
-  private fetchGcbTriggers: (account: string) => void = account => {
-    Observable.fromPromise(IgorService.getGcbTriggers(account))
-      .takeUntil(this.destroy$)
-      .subscribe((gcbTriggers: IGcbTrigger[]) => {
-        this.setState({ gcbTriggers });
-      });
-  };
-
-  public render() {
-    return (
-      <FormikStageConfig
-        {...this.props}
-        stage={this.stage}
-        onChange={this.props.updateStage}
-        validate={validate}
-        render={props => (
-          <GoogleCloudBuildStageForm
-            {...props}
-            googleCloudBuildAccounts={this.state.googleCloudBuildAccounts}
-            gcbTriggers={this.state.gcbTriggers}
-            updatePipeline={this.props.updatePipeline}
-            fetchGcbTriggers={this.fetchGcbTriggers}
-          />
-        )}
-      />
-    );
-  }
+  return (
+    <FormikStageConfig
+      application={application}
+      onChange={updateStage}
+      pipeline={pipeline}
+      stage={stageWithDefaults}
+      validate={validate}
+      render={(props: IFormikStageConfigInjectedProps) => (
+        <GoogleCloudBuildStageForm {...props} updatePipeline={updatePipeline} />
+      )}
+    />
+  );
 }

--- a/app/scripts/modules/core/src/pipeline/config/stages/googleCloudBuild/GoogleCloudBuildStageForm.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/googleCloudBuild/GoogleCloudBuildStageForm.tsx
@@ -52,7 +52,7 @@ const EXCLUDED_ARTIFACT_TYPES: RegExp[] = excludeAllTypesExcept(
 export function GoogleCloudBuildStageForm(props: IGoogleCloudBuildStageFormProps & IFormikStageConfigInjectedProps) {
   const stage = props.formik.values;
 
-  const [rawBuildDefinitionYaml, setRawBuildDefinitionYaml] = React.useState(
+  const [rawBuildDefinitionYaml, setRawBuildDefinitionYaml] = React.useState(() =>
     stage.buildDefinition ? yamlDocumentsToString([stage.buildDefinition]) : '',
   );
 

--- a/app/scripts/modules/core/src/pipeline/config/stages/googleCloudBuild/IGoogleCloudBuildStage.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/googleCloudBuild/IGoogleCloudBuildStage.ts
@@ -1,0 +1,30 @@
+import { IArtifact, IStage } from '@spinnaker/core';
+
+export interface IGoogleCloudBuildStage extends IStage {
+  account?: string;
+  application?: string;
+  buildDefinition?: string;
+  buildDefinitionArtifact?: {
+    artifact?: IArtifact;
+    artifactAccount?: string;
+    artifactId?: string;
+  };
+  buildDefinitionSource?: BuildDefinitionSource;
+  repoSource?: {
+    [t in TriggerType]?: string;
+  };
+  triggerId?: string;
+  triggerType?: TriggerType;
+}
+
+export enum BuildDefinitionSource {
+  ARTIFACT = 'artifact',
+  TEXT = 'text',
+  TRIGGER = 'trigger',
+}
+
+export enum TriggerType {
+  BRANCH = 'branchName',
+  TAG = 'tagName',
+  COMMIT = 'commitSha',
+}

--- a/app/scripts/modules/core/src/pipeline/config/stages/googleCloudBuild/googleCloudBuildValidators.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/googleCloudBuild/googleCloudBuildValidators.ts
@@ -1,14 +1,18 @@
 import { FormValidator, IContextualValidator, IStage } from '@spinnaker/core';
-import { buildDefinitionSources } from './GoogleCloudBuildStageForm';
+import { BuildDefinitionSource } from './IGoogleCloudBuildStage';
 
 export const validate: IContextualValidator = (stage: IStage) => {
   const formValidator = new FormValidator(stage);
   formValidator.field('account', 'Account').required();
-  if (stage.buildDefinitionSource === buildDefinitionSources.TRIGGER) {
+  if (stage.buildDefinitionSource === BuildDefinitionSource.TEXT) {
+    formValidator.field('buildDefinition', 'Build Definition').required();
+  }
+  if (stage.buildDefinitionSource === BuildDefinitionSource.TRIGGER) {
     formValidator.field('triggerId', 'Trigger Name').required();
     formValidator.field('triggerType', 'Trigger Type').required();
     const triggerType = stage.triggerType;
     formValidator.field(`repoSource.${triggerType}`, 'Value').required();
   }
+  // todo(mneterval): add reusable validator for stage artifacts
   return formValidator.validateForm();
 };


### PR DESCRIPTION
…hooks APIs

The goal of this PR is to refactor the Google Cloud Build stage to use Deck's new best-practice patterns for wiring up a stage config form with FormikFormFields and handling data fetching and other side effects with hooks.

User experience improvements:
- Clear loading states for inputs with data dependent on pending requests
- Inline validation for missing required inputs
- Inputs that are dependent on missing prior inputs are disabled

Developer experience improvements:
- The declarative style of hooks makes it much easier to understand the implicit dependency graph in this component: we fetch all accounts once, we fetch available account triggers when the selected account changes, we clear no-longer-relevant fields when upstream form inputs change, etc.

Future work:
- Encapsulate pre- and post-artifact-rewrite stage config Formik setters and validators so we don't have to duplicate these across each Kubernetes stage that accepts artifacts.
- Encapsulate YAML editor state management and Formik setters so we don't have to duplicate these across each Kubernetes stage that accepts YAML.
- Add SpEL-aware FormikFormFields and enable experimentally in this stage only.

