### PR TITLE
chore(amazon): Remove unused AmazonTemplates

### DIFF
--- a/app/scripts/modules/amazon/src/index.ts
+++ b/app/scripts/modules/amazon/src/index.ts
@@ -9,6 +9,5 @@ export * from './loadBalancer';
 export * from './function';
 export * from './reactShims';
 export * from './serverGroup';
-export * from './templates';
 export * from './vpc';
 export * from './instance';

--- a/app/scripts/modules/amazon/src/templates.ts
+++ b/app/scripts/modules/amazon/src/templates.ts
@@ -1,3 +1,0 @@
-export const AmazonTemplates = {
-  upsertScalingPolicyModal: require('amazon/serverGroup/details/scalingPolicy/upsert/upsertScalingPolicy.modal.html'),
-};


### PR DESCRIPTION
Looks like this was used at netflix for a month or two to customize scaling policies, but it's no longer needed.