### PR TITLE
fix(core): Fix security group load performance

### DIFF
--- a/app/scripts/modules/core/src/securityGroup/securityGroupReader.service.ts
+++ b/app/scripts/modules/core/src/securityGroup/securityGroupReader.service.ts
@@ -156,8 +156,8 @@ export class SecurityGroupReader {
           }
         });
       }
-      securityGroups.forEach(SecurityGroupReader.sortUsages);
     });
+    securityGroups.forEach(SecurityGroupReader.sortUsages);
 
     return { notFoundCaught, securityGroups };
   }
@@ -206,8 +206,8 @@ export class SecurityGroupReader {
           }
         });
       }
-      securityGroups.forEach(SecurityGroupReader.sortUsages);
     });
+    securityGroups.forEach(SecurityGroupReader.sortUsages);
 
     return { notFoundCaught, securityGroups };
   }


### PR DESCRIPTION
I think maybe the `forEach(sortUsages)` was meant to be run after `forEach`ing through the serverGroups and building up the `securityGroups` array and not during?

Doing it during runs it (1 + 2 + 3 + 4 .. + n) times with everything but the last pass being redundant, I think?