### PR TITLE
fix(core): derive firewalls view options from filterModel

### DIFF
--- a/app/scripts/modules/core/src/securityGroup/SecurityGroup.tsx
+++ b/app/scripts/modules/core/src/securityGroup/SecurityGroup.tsx
@@ -8,6 +8,7 @@ import { ManagedResourceStatusIndicator } from 'core/managed';
 import { EntityNotifications } from 'core/entityTag/notifications/EntityNotifications';
 import { CloudProviderLogo } from 'core/cloudProvider';
 import { ReactInjector } from 'core/reactShims';
+import { SecurityGroupState } from 'core/state';
 
 import './securityGroup.less';
 
@@ -68,8 +69,7 @@ const ServerGroup = ({ serverGroup }: { serverGroup: IServerGroupUsage }) => (
 );
 
 const ServerGroups = ({ serverGroups }: { serverGroups: IServerGroupUsage[] }) => {
-  // super confusing inverse-boolean here
-  if (!ReactInjector.$stateParams.hideServerGroups) {
+  if (!SecurityGroupState.filterModel.asFilterModel.sortFilter.showServerGroups) {
     return null;
   }
   return (
@@ -112,8 +112,7 @@ const LoadBalancer = ({
 );
 
 const LoadBalancers = ({ securityGroup }: { securityGroup: ISecurityGroup }) => {
-  // super confusing inverse-boolean here
-  if (!ReactInjector.$stateParams.hideLoadBalancers) {
+  if (!SecurityGroupState.filterModel.asFilterModel.sortFilter.showLoadBalancers) {
     return null;
   }
   return (

--- a/app/scripts/modules/core/src/securityGroup/SecurityGroups.tsx
+++ b/app/scripts/modules/core/src/securityGroup/SecurityGroups.tsx
@@ -5,7 +5,6 @@ import { FilterTags, IFilterTag } from 'core/filterModel/FilterTags';
 import { ISecurityGroupGroup } from 'core/domain';
 import { SecurityGroupState } from 'core/state';
 import { Spinner } from 'core/widgets/spinners/Spinner';
-import { ReactInjector } from 'core/reactShims';
 import { ISortFilter } from 'core/filterModel';
 import { SETTINGS } from 'core/config';
 
@@ -48,6 +47,7 @@ const Groupings = ({ groups, app }: { groups: ISecurityGroupGroup[]; app: Applic
 );
 
 const Filters = () => {
+  const { showServerGroups, showLoadBalancers } = SecurityGroupState.filterModel.asFilterModel.sortFilter;
   const toggleParam = (event: any): void => {
     const { checked } = event.target;
     const name: keyof ISortFilter = event.target.name;
@@ -55,7 +55,6 @@ const Filters = () => {
     SecurityGroupState.filterModel.asFilterModel.applyParamsToUrl();
   };
 
-  // The way these "hideX" stateParams work is extra confusing and we should never do this inverse-boolean thing again
   return (
     <div className="col-lg-8 col-md-10">
       <div className="form-inline clearfix filters">
@@ -63,24 +62,14 @@ const Filters = () => {
           <label className="checkbox"> Show </label>
           <div className="checkbox">
             <label>
-              <input
-                type="checkbox"
-                name="showServerGroups"
-                checked={ReactInjector.$stateParams.hideServerGroups === true}
-                onChange={toggleParam}
-              />{' '}
-              Server Groups
+              <input type="checkbox" name="showServerGroups" checked={showServerGroups} onChange={toggleParam} /> Server
+              Groups
             </label>
           </div>
           <div className="checkbox">
             <label>
-              <input
-                type="checkbox"
-                name="showLoadBalancers"
-                checked={ReactInjector.$stateParams.hideLoadBalancers === true}
-                onChange={toggleParam}
-              />{' '}
-              Load Balancers
+              <input type="checkbox" name="showLoadBalancers" checked={showLoadBalancers} onChange={toggleParam} /> Load
+              Balancers
             </label>
           </div>
         </div>


### PR DESCRIPTION
When I refactored this, I only tested loading the firewalls view from the firewalls view. If you come into the firewalls view from some other tab, the server groups and load balancers are hidden until the next refresh cycle. 

This whole thing where we derive state from a model that is set by state transitions, which is sometimes driven by URL changes, but not necessarily...it's not great. But it's also outside the scope of this change. This change...just fixes the view in all use cases I can find.