### PR TITLE
feat(managed): allow pausing/resuming managed resources via indicator

### DIFF
--- a/app/scripts/modules/core/src/application/config/managedResources/ManagedResourceConfig.tsx
+++ b/app/scripts/modules/core/src/application/config/managedResources/ManagedResourceConfig.tsx
@@ -69,10 +69,10 @@ const ManagedResourceConfig = ({ application }: IManagedResourceConfigProps) => 
     setPauseFailed(false);
     logClick('Pause Management', application.name);
 
-    ManagedWriter.pauseResourceManagement(application.name)
+    ManagedWriter.pauseApplicationManagement(application.name)
       .then(() => {
         setPaused(true);
-        application.managedResources.refresh();
+        application.managedResources.refresh(true);
       })
       .catch(() => setPauseFailed(true))
       .finally(() => setPausePending(false));
@@ -83,10 +83,10 @@ const ManagedResourceConfig = ({ application }: IManagedResourceConfigProps) => 
     setPauseFailed(false);
     logClick('Resume Management', application.name);
 
-    ManagedWriter.resumeResourceManagement(application.name)
+    ManagedWriter.resumeApplicationManagement(application.name)
       .then(() => {
         setPaused(false);
-        application.managedResources.refresh();
+        application.managedResources.refresh(true);
       })
       .catch(() => setPauseFailed(true))
       .finally(() => setPausePending(false));

--- a/app/scripts/modules/core/src/cluster/ClusterPod.tsx
+++ b/app/scripts/modules/core/src/cluster/ClusterPod.tsx
@@ -98,7 +98,11 @@ export class ClusterPod extends React.Component<IClusterPodProps, IClusterPodSta
           <div>{subgroup.heading}</div>
           <div className={classNames('flex-container-h middle', { 'sp-margin-xs-left': showManagedIndicator })}>
             {showManagedIndicator && (
-              <ManagedResourceStatusIndicator shape="circle" resourceSummary={subgroup.managedResourceSummary} />
+              <ManagedResourceStatusIndicator
+                shape="circle"
+                resourceSummary={subgroup.managedResourceSummary}
+                application={application}
+              />
             )}
             <EntityNotifications
               entity={subgroup}

--- a/app/scripts/modules/core/src/cluster/DefaultClusterPodTitle.tsx
+++ b/app/scripts/modules/core/src/cluster/DefaultClusterPodTitle.tsx
@@ -41,7 +41,11 @@ export class DefaultClusterPodTitle extends React.Component<IClusterPodTitleProp
             />
 
             {grouping.isManaged && (
-              <ManagedResourceStatusIndicator shape="square" resourceSummary={grouping.managedResourceSummary} />
+              <ManagedResourceStatusIndicator
+                shape="square"
+                resourceSummary={grouping.managedResourceSummary}
+                application={application}
+              />
             )}
           </div>
         </div>

--- a/app/scripts/modules/core/src/loadBalancer/LoadBalancer.tsx
+++ b/app/scripts/modules/core/src/loadBalancer/LoadBalancer.tsx
@@ -58,6 +58,7 @@ export class LoadBalancer extends React.Component<ILoadBalancerProps> {
                     <ManagedResourceStatusIndicator
                       shape="circle"
                       resourceSummary={loadBalancer.managedResourceSummary}
+                      application={application}
                     />
                   )}
                   <EntityNotifications

--- a/app/scripts/modules/core/src/loadBalancer/LoadBalancerPod.tsx
+++ b/app/scripts/modules/core/src/loadBalancer/LoadBalancerPod.tsx
@@ -42,7 +42,11 @@ export class LoadBalancerPod extends React.Component<ILoadBalancerPodProps> {
             <div className="pod-center horizontal space-between flex-1 no-right-padding">
               <div>{grouping.heading}</div>
               {grouping.isManaged && (
-                <ManagedResourceStatusIndicator shape="square" resourceSummary={grouping.managedResourceSummary} />
+                <ManagedResourceStatusIndicator
+                  shape="square"
+                  resourceSummary={grouping.managedResourceSummary}
+                  application={application}
+                />
               )}
             </div>
           </div>

--- a/app/scripts/modules/core/src/managed/ManagedResourceStatusIndicator.tsx
+++ b/app/scripts/modules/core/src/managed/ManagedResourceStatusIndicator.tsx
@@ -3,16 +3,25 @@ import ReactGA from 'react-ga';
 import classNames from 'classnames';
 import { UISref } from '@uirouter/react';
 
-import { HoverablePopover } from 'core/presentation';
+import { HoverablePopover, IHoverablePopoverContentsProps } from 'core/presentation';
 import { IManagedResourceSummary, ManagedResourceStatus } from 'core/domain';
+import { Application } from 'core/application';
+
+import { toggleResourcePause } from './toggleResourceManagement';
 
 import './ManagedResourceStatusIndicator.less';
 
-const viewConfigurationByStatus = {
+interface IViewConfiguration {
+  iconClass: string;
+  colorClass: string;
+  popoverContents: (resourceSummary: IManagedResourceSummary, application?: Application) => JSX.Element;
+}
+
+const viewConfigurationByStatus: { [status in ManagedResourceStatus]: IViewConfiguration } = {
   ACTUATING: {
     iconClass: 'icon-md-actuating',
     colorClass: 'info',
-    popoverContents: (id: string) => (
+    popoverContents: (resourceSummary: IManagedResourceSummary) => (
       <>
         <p>
           <b>Action is being taken to resolve a drift from the declarative configuration.</b>
@@ -22,149 +31,139 @@ const viewConfigurationByStatus = {
           <UISref to="home.applications.application.tasks">
             <a>tasks view</a>
           </UISref>{' '}
-          to see work that's in progress.
+          to see work that's in progress. <LearnMoreLink resourceSummary={resourceSummary} />
         </p>
-        <LearnMoreLink id={id} status={ManagedResourceStatus.ACTUATING} />
       </>
     ),
   },
   CREATED: {
     iconClass: 'icon-md-created',
     colorClass: 'info',
-    popoverContents: (id: string) => (
+    popoverContents: (resourceSummary: IManagedResourceSummary) => (
       <>
         <p>
           <b>Spinnaker has started continuously managing this resource.</b>
         </p>
         <p>
           If its actual configuration drifts from the declarative configuration, Spinnaker will automatically correct
-          it. Changes made in the UI will be stomped in favor of the declarative configuration.
+          it. Changes made in the UI will be stomped in favor of the declarative configuration.{' '}
+          <LearnMoreLink resourceSummary={resourceSummary} />
         </p>
-        <LearnMoreLink id={id} status={ManagedResourceStatus.CREATED} />
       </>
     ),
   },
   DIFF: {
     iconClass: 'icon-md-diff',
     colorClass: 'info',
-    popoverContents: (id: string) => (
+    popoverContents: (resourceSummary: IManagedResourceSummary) => (
       <>
         <p>
           <b>A drift from the declarative configuration was detected.</b>
         </p>
-        <p>Spinnaker will automatically take action to bring this resource back to its desired state.</p>
-        <LearnMoreLink id={id} status={ManagedResourceStatus.DIFF} />
+        <p>
+          Spinnaker will automatically take action to bring this resource back to its desired state.{' '}
+          <LearnMoreLink resourceSummary={resourceSummary} />
+        </p>
       </>
     ),
   },
   ERROR: {
     iconClass: 'icon-md-error',
     colorClass: 'error',
-    popoverContents: (id: string) => (
+    popoverContents: (resourceSummary: IManagedResourceSummary) => (
       <>
         <p>
           <b>Something went wrong.</b>
         </p>
         <p>
           Spinnaker is configured to continuously manage this resource, but something went wrong trying to check its
-          current state. Automatic action can't be taken right now, and manual intervention might be required.
+          current state. Automatic action can't be taken right now, and manual intervention might be required.{' '}
+          <LearnMoreLink resourceSummary={resourceSummary} />
         </p>
-        <LearnMoreLink id={id} status={ManagedResourceStatus.ERROR} />
       </>
     ),
   },
   HAPPY: {
     iconClass: 'icon-md',
     colorClass: 'info',
-    popoverContents: (id: string) => (
+    popoverContents: (resourceSummary: IManagedResourceSummary) => (
       <>
         <p>
           <b>Spinnaker is continuously managing this resource.</b>
         </p>
-        <p>Changes made in the UI will be stomped in favor of the declarative configuration.</p>
-        <LearnMoreLink id={id} status={ManagedResourceStatus.HAPPY} />
+        <p>
+          Changes made in the UI will be stomped in favor of the declarative configuration.{' '}
+          <LearnMoreLink resourceSummary={resourceSummary} />
+        </p>
       </>
     ),
   },
   PAUSED: {
     iconClass: 'icon-md-paused',
     colorClass: 'warning',
-    popoverContents: (id: string) => (
+    popoverContents: (resourceSummary: IManagedResourceSummary, application: Application) => (
       <>
         <p>
           <b>Continuous management is paused.</b>
         </p>
-        <p>
-          Spinnaker is configured to continuously manage this resource, but management is temporarily paused. You can
-          resume management on the{' '}
-          <UISref to="home.applications.application.config" params={{ section: 'managed-resources' }}>
-            <a>config view</a>
-          </UISref>
-          .
-        </p>
-        <LearnMoreLink id={id} status={ManagedResourceStatus.PAUSED} />
+        {application.isManagementPaused && (
+          <p>
+            Spinnaker is configured to continuously manage this resource, but management for the entire application is
+            temporarily paused. <LearnMoreLink resourceSummary={resourceSummary} />
+          </p>
+        )}
+        {!application.isManagementPaused && (
+          <p>
+            Spinnaker is configured to continuously manage this resource, but management has been temporarily paused.{' '}
+            <LearnMoreLink resourceSummary={resourceSummary} />
+          </p>
+        )}
       </>
     ),
   },
   RESUMED: {
     iconClass: 'icon-md-resumed',
     colorClass: 'info',
-    popoverContents: (id: string) => (
+    popoverContents: (resourceSummary: IManagedResourceSummary) => (
       <>
         <p>
           <b>Continuous management was just resumed.</b>
         </p>
         <p>
           Management was resumed after being temporarily paused. If Spinnaker detects that a drift from the declarative
-          configuration occurred while paused, it will take automatic action to resolve the drift.
+          configuration occurred while paused, it will take automatic action to resolve the drift.{' '}
+          <LearnMoreLink resourceSummary={resourceSummary} />
         </p>
-        <p>
-          You can pause and resume management on the{' '}
-          <UISref to="home.applications.application.config" params={{ section: 'managed-resources' }}>
-            <a>config view</a>
-          </UISref>
-          .
-        </p>
-        <LearnMoreLink id={id} status={ManagedResourceStatus.RESUMED} />
       </>
     ),
   },
   UNHAPPY: {
     iconClass: 'icon-md-flapping',
     colorClass: 'error',
-    popoverContents: (id: string) => (
+    popoverContents: (resourceSummary: IManagedResourceSummary) => (
       <>
         <p>
           <b>A drift from the declarative configuration was detected, but Spinnaker hasn't been able to correct it.</b>
         </p>
         <p>
           Spinnaker has been trying to correct a detected drift, but taking automatic action hasn't helped. Manual
-          intervention might be required.
+          intervention might be required. <LearnMoreLink resourceSummary={resourceSummary} />
         </p>
-        <p>
-          You can temporarily pause management on the{' '}
-          <UISref to="home.applications.application.config" params={{ section: 'managed-resources' }}>
-            <a>config view</a>
-          </UISref>{' '}
-          to troubleshoot or make manual changes.
-        </p>
-        <LearnMoreLink id={id} status={ManagedResourceStatus.UNHAPPY} />
       </>
     ),
   },
   UNKNOWN: {
     iconClass: 'icon-md-unknown',
     colorClass: 'warning',
-    popoverContents: (id: string) => (
+    popoverContents: (resourceSummary: IManagedResourceSummary) => (
       <>
         <p>
           <b>Unable to determine resource status.</b>
         </p>
         <p>
           Spinnaker is configured to continuously manage this resource, but its current status can't be calculated right
-          now.
+          now. <LearnMoreLink resourceSummary={resourceSummary} />
         </p>
-        <LearnMoreLink id={id} status={ManagedResourceStatus.UNKNOWN} />
       </>
     ),
   },
@@ -177,30 +176,71 @@ const logClick = (label: string, resourceId: string, status: ManagedResourceStat
     label: `${resourceId},${status}`,
   });
 
-const LearnMoreLink = ({ id, status }: { id: string; status: ManagedResourceStatus }) => (
-  <p className="sp-margin-m-top sp-margin-xs-bottom">
-    <a
-      target="_blank"
-      onClick={() => logClick('Status docs link', id, status)}
-      href={`https://www.spinnaker.io/reference/managed-delivery/resource-status/#${status.toLowerCase()}`}
-    >
-      Learn more about this
-    </a>
-  </p>
+const LearnMoreLink = ({ resourceSummary }: { resourceSummary: IManagedResourceSummary }) => (
+  <a
+    target="_blank"
+    onClick={() => logClick('Status docs link', resourceSummary.id, resourceSummary.status)}
+    href={`https://www.spinnaker.io/reference/managed-delivery/resource-status/#${resourceSummary.status.toLowerCase()}`}
+  >
+    Learn more
+  </a>
+);
+
+const PopoverLinks = ({
+  resourceSummary,
+  application,
+  hidePopover,
+}: {
+  resourceSummary: IManagedResourceSummary;
+  application: Application;
+  hidePopover: () => void;
+}) => (
+  <div className="horizontal right">
+    {!resourceSummary.isPaused && (
+      <p className="sp-margin-m-top sp-margin-xs-bottom">
+        <button className="passive" onClick={() => toggleResourcePause(resourceSummary, application, hidePopover)}>
+          <i className="fa fa-pause" /> Pause management of this resource
+        </button>
+      </p>
+    )}
+    {resourceSummary.isPaused && !application.isManagementPaused && (
+      <p className="sp-margin-m-top sp-margin-xs-bottom">
+        <button className="passive" onClick={() => toggleResourcePause(resourceSummary, application, hidePopover)}>
+          <i className="fa fa-play" /> Resume management of this resource
+        </button>
+      </p>
+    )}
+    {application.isManagementPaused && (
+      <p>
+        <UISref to="home.applications.application.config" params={{ section: 'managed-resources' }}>
+          <a>Resume application management</a>
+        </UISref>
+      </p>
+    )}
+  </div>
 );
 
 export interface IManagedResourceStatusIndicatorProps {
   shape: 'square' | 'circle';
   resourceSummary: IManagedResourceSummary;
+  application: Application;
 }
 
 export const ManagedResourceStatusIndicator = ({
   shape,
-  resourceSummary: { id, status },
+  resourceSummary,
+  application,
 }: IManagedResourceStatusIndicatorProps) => {
+  const { status } = resourceSummary;
+  const PopoverContents = ({ hidePopover }: IHoverablePopoverContentsProps) => (
+    <>
+      {viewConfigurationByStatus[status].popoverContents(resourceSummary, application)}
+      <PopoverLinks resourceSummary={resourceSummary} application={application} hidePopover={hidePopover} />
+    </>
+  );
   return (
     <div className="flex-container-h stretch ManagedResourceStatusIndicator">
-      <HoverablePopover template={viewConfigurationByStatus[status].popoverContents(id)} placement="left">
+      <HoverablePopover Component={PopoverContents} placement="left">
         <div className={classNames('flex-container-h middle', shape, viewConfigurationByStatus[status].colorClass)}>
           <i className={classNames('fa', viewConfigurationByStatus[status].iconClass)} />
         </div>

--- a/app/scripts/modules/core/src/managed/ManagedWriter.ts
+++ b/app/scripts/modules/core/src/managed/ManagedWriter.ts
@@ -3,16 +3,30 @@ import { IPromise } from 'angular';
 import { API } from 'core/api';
 
 export class ManagedWriter {
-  public static pauseResourceManagement(application: string): IPromise<void> {
+  public static pauseApplicationManagement(applicationName: string): IPromise<void> {
     return API.one('managed')
-      .one('application', application)
+      .one('application', applicationName)
       .one('pause')
       .post();
   }
 
-  public static resumeResourceManagement(application: string): IPromise<void> {
+  public static resumeApplicationManagement(applicationName: string): IPromise<void> {
     return API.one('managed')
-      .one('application', application)
+      .one('application', applicationName)
+      .one('pause')
+      .remove();
+  }
+
+  public static pauseResourceManagement(resourceId: string): IPromise<void> {
+    return API.one('managed')
+      .one('resources', resourceId)
+      .one('pause')
+      .post();
+  }
+
+  public static resumeResourceManagement(resourceId: string): IPromise<void> {
+    return API.one('managed')
+      .one('resources', resourceId)
       .one('pause')
       .remove();
   }

--- a/app/scripts/modules/core/src/managed/managedResourceDecorators.ts
+++ b/app/scripts/modules/core/src/managed/managedResourceDecorators.ts
@@ -31,6 +31,7 @@ export const addManagedResourceMetadataToServerGroups = (application: Applicatio
     serverGroup.isManaged = !!matchingResource;
     serverGroup.managedResourceSummary = matchingResource;
   });
+  application.serverGroups.dataUpdated();
 };
 
 export const addManagedResourceMetadataToLoadBalancers = (application: Application) => {
@@ -53,6 +54,7 @@ export const addManagedResourceMetadataToLoadBalancers = (application: Applicati
     loadBalancer.isManaged = !!matchingResource;
     loadBalancer.managedResourceSummary = matchingResource;
   });
+  application.loadBalancers.dataUpdated();
 };
 
 export const addManagedResourceMetadataToSecurityGroups = (application: Application) => {
@@ -74,4 +76,5 @@ export const addManagedResourceMetadataToSecurityGroups = (application: Applicat
     securityGroup.isManaged = !!matchingResource;
     securityGroup.managedResourceSummary = matchingResource;
   });
+  application.securityGroups.dataUpdated();
 };

--- a/app/scripts/modules/core/src/managed/toggleResourceManagement.ts
+++ b/app/scripts/modules/core/src/managed/toggleResourceManagement.ts
@@ -1,0 +1,76 @@
+import { IManagedResourceSummary, ManagedResourceStatus } from 'core/domain';
+import { Application } from 'core/application';
+
+import { ManagedWriter } from './ManagedWriter';
+
+import './ManagedResourceStatusIndicator.less';
+import { ReactInjector } from 'core/reactShims';
+
+interface IToggleConfiguration {
+  popoverPauseWarning?: string;
+}
+
+const viewConfigurationByStatus: { [status in ManagedResourceStatus]?: IToggleConfiguration } = {
+  ACTUATING: {
+    popoverPauseWarning: `<p>
+          <div class="horizontal top sp-padding-m alert alert-warning">
+            <i class="fa fa-exclamation-triangle sp-margin-m-right sp-margin-xs-top"></i>
+            <span>Pausing management will not interrupt the action Spinnaker is currently performing to resolve the
+            drift in configuration.</span>
+          </div>
+        </p>`,
+  },
+};
+
+export const toggleResourcePause = (
+  resourceSummary: IManagedResourceSummary,
+  application: Application,
+  hidePopover: () => void,
+) => {
+  hidePopover();
+  const { id, isPaused } = resourceSummary;
+  const toggle = () =>
+    isPaused ? ManagedWriter.resumeResourceManagement(id) : ManagedWriter.pauseResourceManagement(id);
+
+  const submitMethod = () => toggle().then(() => application.managedResources.refresh(true));
+
+  return ReactInjector.confirmationModalService.confirm({
+    header: `Really ${isPaused ? 'resume' : 'pause'} resource management?`,
+    body: getPopoverToggleBodyText(resourceSummary),
+    account: resourceSummary.locations.account,
+    buttonText: `${isPaused ? 'Resume' : 'Pause'} management`,
+    submitMethod,
+  });
+};
+
+const getPopoverToggleBodyText = (resourceSummary: IManagedResourceSummary) => {
+  const { isPaused, locations, status } = resourceSummary;
+  const regions = locations.regions.map(r => r.name).sort();
+  let body = '';
+  if (!isPaused) {
+    body += `
+        <p>
+          While a resource is paused, Spinnaker will not take action to resolve drift from the declarative configuration.
+        </p>`;
+    body += viewConfigurationByStatus[status]?.popoverPauseWarning ?? '';
+  } else {
+    body += `
+        <p>
+          Spinnaker will resume taking action to resolve drift from the declarative configuration.
+        </p>
+      `;
+  }
+  if (regions.length > 1) {
+    body += `
+        <p>
+          <div class="horizontal top sp-padding-m alert alert-warning">
+            <i class="fa fa-exclamation-triangle sp-margin-m-right sp-margin-xs-top"></i>
+            <span>${
+              isPaused ? 'Resuming' : 'Pausing'
+            } management of this resource will affect the following regions: <b>${regions.join(', ')}</b>.
+            </span>
+          </div>
+        </p>`;
+  }
+  return body;
+};

--- a/app/scripts/modules/core/src/securityGroup/SecurityGroup.tsx
+++ b/app/scripts/modules/core/src/securityGroup/SecurityGroup.tsx
@@ -26,7 +26,11 @@ const Heading = ({ application, parentGrouping, securityGroup, heading }: ISecur
       <div className="flex-1">{(heading || '').toUpperCase()}</div>
 
       {!parentGrouping.isManaged && securityGroup.isManaged && (
-        <ManagedResourceStatusIndicator shape="circle" resourceSummary={securityGroup.managedResourceSummary} />
+        <ManagedResourceStatusIndicator
+          shape="circle"
+          resourceSummary={securityGroup.managedResourceSummary}
+          application={application}
+        />
       )}
       <EntityNotifications
         entity={securityGroup}

--- a/app/scripts/modules/core/src/securityGroup/SecurityGroupPod.tsx
+++ b/app/scripts/modules/core/src/securityGroup/SecurityGroupPod.tsx
@@ -24,7 +24,11 @@ export const SecurityGroupPod = ({ grouping, application, parentHeading }: ISecu
             {grouping.heading}
           </div>
           {grouping.isManaged && (
-            <ManagedResourceStatusIndicator shape="square" resourceSummary={grouping.managedResourceSummary} />
+            <ManagedResourceStatusIndicator
+              shape="square"
+              resourceSummary={grouping.managedResourceSummary}
+              application={application}
+            />
           )}
         </div>
       </div>


### PR DESCRIPTION
We now have the ability to pause individual resources 😺via the REST API. This adds the ability to pause/unpause resources from the popover badge on the various components:

![md-pause-popover](https://user-images.githubusercontent.com/73450/71021899-1f53a900-20b4-11ea-965c-b6d5ac96d3e3.gif)

If the resource is in multiple regions, we'll warn the user of that. If the resource is being actuated, we'll warn the user that the current actuation will continue.

If we find it useful to add more context to the modal when the resource is in other states, we can do that pretty easily.

Most of the file changes here are to add the application to the status indicator (so we can refresh the `managedResources` data source).

I don't love putting all this text into strings, but the confirmation modal is Angular and only deals with strings for the body text. I'm working on making a React option that would take a component, but it's WIP.

Leaving the "Resume application management" action as a link is an intentional decision:
<img width="447" alt="Screen Shot 2019-12-17 at 10 12 46 AM" src="https://user-images.githubusercontent.com/73450/71022668-e0265780-20b5-11ea-826f-2c72a504baf4.png">
We want to be really sure the user understands that they're opening the floodgates for the entire app, not just this single resource, so we send them to the config page. We may want to make this even *more* explicit in the future.