### PR TITLE
fix(core): updateStageField should not update reserved fields

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/stage.module.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/stage.module.js
@@ -3,7 +3,7 @@
 import { module } from 'angular';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { defaultsDeep, extend } from 'lodash';
+import { defaultsDeep, extend, omit } from 'lodash';
 
 import { AccountService } from 'core/account/AccountService';
 import { API } from 'core/api';
@@ -225,7 +225,10 @@ module(CORE_PIPELINE_CONFIG_STAGES_STAGE_MODULE, [
               application: $scope.application,
               stageFieldUpdated: $scope.stageFieldUpdated,
               updateStageField: changes => {
-                extend($scope.stage, changes);
+                // Reserved fields should not be mutated from with a StageConfig component
+                const allowedChanges = omit(changes, ['requisiteStageRefIds', 'refId', 'isNew', 'name', 'type']);
+
+                extend($scope.stage, allowedChanges);
                 $scope.stageFieldUpdated();
               },
               // Added to enable inline artifact editing from React stages


### PR DESCRIPTION
Changes to reserved fields (namely the stage name) were getting reverted because updating a field in formik would effectively freeze it's values into formik state.

This is because

1. these fields are **mutated** in Angular land
2. formik's `setIn` util works by merging the new slice into the object a la spread operator `const result = { ...obj, ...res }`

This means Angular was free to update the name and the mutated object made it all the way into formik's initial state, but as soon as `setIn` is called (implicitly via`handleChange` or explicitly via `setFieldValue`), a shallow copy was made and cemented those values in formik's state forever.

This fix is still not great as the stage config would be looking at stale values for name/type/etc. but our current patterns don't really allow for external changes to get **pushed** into formik.