### PR TITLE
fix(amazon/sg): Default security group ingress to an empty array

### DIFF
--- a/app/scripts/modules/amazon/src/securityGroup/configure/configSecurityGroup.mixin.controller.js
+++ b/app/scripts/modules/amazon/src/securityGroup/configure/configSecurityGroup.mixin.controller.js
@@ -128,10 +128,7 @@ module(AMAZON_SECURITYGROUP_CONFIGURE_CONFIGSECURITYGROUP_MIXIN_CONTROLLER, [
       const account = getAccount();
       const regions = $scope.securityGroup.regions || [];
       VpcReader.listVpcs().then(function(vpcs) {
-        const vpcsByName = _.groupBy(
-          vpcs.filter(vpc => vpc.account === account),
-          'label',
-        );
+        const vpcsByName = _.groupBy((vpcs || []).filter(vpc => vpc.account === account), 'label');
         $scope.allVpcs = vpcs;
         const available = [];
         _.forOwn(vpcsByName, function(vpcsToTest, label) {
@@ -326,6 +323,7 @@ module(AMAZON_SECURITYGROUP_CONFIGURE_CONFIGSECURITYGROUP_MIXIN_CONTROLLER, [
     };
 
     ctrl.addRule = function(ruleset) {
+      ruleset = ruleset || [];
       ruleset.push({
         type: 'tcp',
         startPort: 7001,


### PR DESCRIPTION
Creating a security group was throwing errors and sometimes failing when attempting to add a security group rule. This does not happen locally, but seen in production. 
![Screen Shot 2019-12-17 at 1 49 10 PM](https://user-images.githubusercontent.com/26560152/71211653-6d0f1380-2264-11ea-8474-fc32920df91e.png)
