### PR TITLE
fix(artifacts): set the reference attribute for helm artifact

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/helm/HelmArtifactEditor.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/helm/HelmArtifactEditor.tsx
@@ -80,6 +80,7 @@ class HelmEditor extends React.Component<IArtifactEditorProps, IHelmArtifactEdit
               value={artifact.name || ''}
               onChange={(e: Option) => {
                 this.onChange(e, 'name');
+                this.onChange(e, 'reference');
                 this.getChartVersionOptions(e.value.toString());
               }}
               clearable={false}


### PR DESCRIPTION
spinnaker/spinnaker#4777

It appears the initial refactor of the helm artifact did not set the `reference` property.  This should rectify the issue and set the reference when the account changes as indicated by the previous implementation.

https://github.com/spinnaker/deck/blob/81386a3c55608dd1c31a30eff1d46f7c39627f30/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/helm/helm.artifact.ts#L27