### PR TITLE
fix(plugins): Default plugins to empty list to prevent NPE

### DIFF
--- a/app/scripts/modules/core/src/config/settings.ts
+++ b/app/scripts/modules/core/src/config/settings.ts
@@ -144,6 +144,7 @@ SETTINGS.analytics = SETTINGS.analytics || {};
 SETTINGS.providers = SETTINGS.providers || {};
 SETTINGS.defaultTimeZone = SETTINGS.defaultTimeZone || 'America/Los_Angeles';
 SETTINGS.dockerInsights = SETTINGS.dockerInsights || { enabled: false, url: '' };
+SETTINGS.plugins = SETTINGS.plugins || [];
 
 // A helper to make resetting settings to steady state after running tests easier
 const originalSettings: ISpinnakerSettings = cloneDeep(SETTINGS);


### PR DESCRIPTION
While the default configs (halyard and non-halyard) were updated to set plugins to an empty array, users who have a custom config will get an NPE unless we add this defaulting here.