### PR TITLE
chore(kubernetes): Bump version to 0.0.30

### DIFF
--- a/app/scripts/modules/kubernetes/package.json
+++ b/app/scripts/modules/kubernetes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/kubernetes",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
- d2838d80c refactor(core): remove unused parameter options from confirmation modal (#7716)
- 6291f858c chore(core): upgrade to latest prettier (#7713)
- 90aa47754 refactor(eslint): Fix all 'prefer-const' eslint rule violations
- d070bd45f refactor(eslint): Fix all 'one-var' eslint rule violations
- 174870161 refactor(eslint): Fix all 'no-var' eslint rule violations
- 9400826bc chore(eslint): remove tslint
- 88b8f4ae0 refactor(angularjs): use ES6 to import angular - migrate from `const angular = require('angular')` to `import * as angular from 'angular'` - Where possible, migrate from `import angular from 'angular'; angular.module('asdf')`   to `import { module } from 'angular'; module('asdf')`
- a076dc128 refactor(angularjs): use ES6 imports for angularjs module deps - migrate from `require('@uirouter/angularjs').default` to import UIROUTER_ANGULARJS from '@uirouter/angularjs' - migrate from `require('angular-ui-bootstrap')` to import ANGULAR_UI_BOOTSTRAP from 'angular-ui-bootstrap'
- ac1c86ebb refactor(angularjs): Import angularjs module dependencies by name - Migrate angularjs module dependencies to import the exported string identifier, not via require('module').name
- 784d64b66 refactor(angularjs): Always export the ng module name, not the module itself
- b6aabe18a chore(typescript): Migrate most wildcard imports to javascript style imports - Migrate from "import * as foo from 'foo'" to "import foo from 'foo'"
- 7ef58b6c1 feat(typescript): enable allowJs and allowSyntheticDefaultImports
- 145f540d8 chore(typescript): update to typescript 3.7.x (#7668)
- f0613c1b1 refactor(*): Remove exports-loader from n3-chart import
- 9e4e898b8 fix(kubernetes/serverGroup): Remove unused controller file for 'kubernetesServerGroupLoadBalancersController' (#7663)
- c233af0e4 fix(angularJS): Fix all remaining non-strict angularJS DI code via @spinnaker/strictdi linter rule
- baf5e3116 fix(kubernetes): fix patchBody input in Patch (Manifest) stage (#7600)
- 4ed015a07 feat(dataSources): widen + parameterize types, add default values
- 2c100b6b1 feat(kubernetes): permit multiple ReplicaSets to be deployed with a single rollout strategy config (#7574)
- 03cb78cb3 fix(runJob): fix artifact output creation (#7579)
- a71f76d1a fix: credentails typo (#7541)
- 17be6af0c feat(kubernetes): support rolling restart operation for deployments (#7538)
- be258cd34 fix(kubernetes): add missing `app` config param for patch manifest stages (#7521)
- 479e9d6ed fix(kubernetes): Fix merge strategy field (#7455)
- 3b880c76d refactor(kubernetes): remove unnecessary angular and non-typescript deps (#7454)
- e667bdf51 refactor(kubernetes): isolate v1 code (#7451)
- 1083a7098 fix(kubernetes): remove former 24-char limit on services names (#7389)
- 8bdca8907  fix(core): fix vertical alignment of radio buttons (#7344)
- 413a3debb feat(kubernetes): permit creatable options for service and namespace in rollout strategy config (#7320)
- 0b1ce1e75 feat(provider/k8s): support artifacts in run job (#7309)