### PR TITLE
fix(ecs): Fixes AmazonLoadBalancerChoiceModal for ecs

### DIFF
--- a/app/scripts/modules/amazon/src/loadBalancer/configure/AmazonLoadBalancerChoiceModal.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/AmazonLoadBalancerChoiceModal.tsx
@@ -67,7 +67,7 @@ export class AmazonLoadBalancerChoiceModal extends React.Component<
   };
 
   private getIncompatibility(choice: IAmazonLoadBalancerConfig, cloudProvider: string): ILoadBalancerIncompatibility {
-    const { loadBalancer } = CloudProviderRegistry.getProvider(cloudProvider);
+    const { loadBalancer = {} } = CloudProviderRegistry.getProvider(cloudProvider);
     const {
       incompatibleLoadBalancerTypes = [],
     }: { incompatibleLoadBalancerTypes: ILoadBalancerIncompatibility[] } = loadBalancer;


### PR DESCRIPTION
Fixes https://github.com/spinnaker/spinnaker/issues/5271

I'm not sure why the `ecs` module doesn't register/need a `loadBalancer` block, but now protecting this code from providers without a `loadBalancer` balancer attribute since it was originally written with the (incorrect) assumption that ALL providers have that attribute.