### PR TITLE
fix(core): do not try to render task monitor if monitor is missing

### DIFF
--- a/app/scripts/modules/core/src/task/monitor/TaskMonitorWrapper.tsx
+++ b/app/scripts/modules/core/src/task/monitor/TaskMonitorWrapper.tsx
@@ -12,6 +12,10 @@ export interface ITaskMonitorProps {
 }
 
 export const TaskMonitorWrapper = ({ monitor }: ITaskMonitorProps) => {
+  if (!monitor) {
+    return null;
+  }
+
   const forceUpdate = useForceUpdate();
 
   useEffect(() => {


### PR DESCRIPTION
There are a few places (or at least one: entity tag editor) where the task monitor is not configured yet on initial render, so we should guard against that.