### PR TITLE
chore(docker): bump package to 0.0.50

### DIFF
--- a/app/scripts/modules/docker/package.json
+++ b/app/scripts/modules/docker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/docker",
-  "version": "0.0.49",
+  "version": "0.0.50",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
6291f858cb111d9c65affeb82ddd840f05c57b65 chore(core): upgrade to latest prettier (#7713)
90aa47754bc8815eb1bdfcceb4d05c9e1cdf325f refactor(eslint): Fix all 'prefer-const' eslint rule violations
174870161a5a09ab7f15c74cb84d0f3e196cd7cb refactor(eslint): Fix all 'no-var' eslint rule violations
9400826bcb119cf7681e1ce37092b9fdd8b76b1b chore(eslint): remove tslint
88b8f4ae0b9e96ac8d8dbdeff592f3787f0617cb refactor(angularjs): use ES6 to import angular - migrate from `const angular = require('angular')` to `import * as angular from 'angular'` - Where possible, migrate from `import angular from 'angular'; angular.module('asdf')`   to `import { module } from 'angular'; module('asdf')`
a076dc1280b56affcd30cdbea68a84fb7d5ba3f1 refactor(angularjs): use ES6 imports for angularjs module deps - migrate from `require('@uirouter/angularjs').default` to import UIROUTER_ANGULARJS from '@uirouter/angularjs' - migrate from `require('angular-ui-bootstrap')` to import ANGULAR_UI_BOOTSTRAP from 'angular-ui-bootstrap'
ac1c86ebbc72e6d2d83eb57d6710c6ae2651ecc0 refactor(angularjs): Import angularjs module dependencies by name - Migrate angularjs module dependencies to import the exported string identifier, not via require('module').name
784d64b66a6410e622803b4b0519f7050e9c5f82 refactor(angularjs): Always export the ng module name, not the module itself
b6aabe18a2c71f194087c01fd15ec369460f5e70 (origin/master) chore(typescript): Migrate most wildcard imports to javascript style imports - Migrate from "import * as foo from 'foo'" to "import foo from 'foo'"
7ef58b6c122f9ce91eab95d5f444622a710ff968 feat(typescript): enable allowJs and allowSyntheticDefaultImports
c1c4d423a0af57c6a8faf135a7a7ee3eb76d5466 chore(tsconfig): standardize all tsconfig.json files to es2017 (#7656)