### PR TITLE
feat(core/amazon/titus): restrict menu items on managed resources

### DIFF
--- a/app/scripts/modules/amazon/src/loadBalancer/details/LoadBalancerActions.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/details/LoadBalancerActions.tsx
@@ -6,6 +6,7 @@ import {
   Application,
   ApplicationReader,
   LoadBalancerWriter,
+  ManagedMenuItem,
   SETTINGS,
   NgReact,
   ReactInjector,
@@ -121,15 +122,13 @@ export class LoadBalancerActions extends React.Component<ILoadBalancerActionsPro
           </Dropdown.Toggle>
           <Dropdown.Menu className="dropdown-menu">
             {application && (
-              <li>
-                <a className="clickable" onClick={this.editLoadBalancer}>
-                  Edit Load Balancer
-                </a>
-              </li>
+              <ManagedMenuItem resource={loadBalancer} application={app} onClick={this.editLoadBalancer}>
+                Edit Load Balancer
+              </ManagedMenuItem>
             )}
             {!application && (
               <li className="disabled">
-                <a className="clickable" onClick={this.editLoadBalancer}>
+                <a>
                   Edit Load Balancer{' '}
                   <HelpField
                     content={`The application <b>${loadBalancerAppName}</b> must be configured before this load balancer can be edited.`}
@@ -138,15 +137,13 @@ export class LoadBalancerActions extends React.Component<ILoadBalancerActionsPro
               </li>
             )}
             {allowDeletion && (
-              <li>
-                <a className="clickable" onClick={this.deleteLoadBalancer}>
-                  Delete Load Balancer
-                </a>
-              </li>
+              <ManagedMenuItem resource={loadBalancer} application={app} onClick={this.deleteLoadBalancer}>
+                Delete Load Balancer
+              </ManagedMenuItem>
             )}
             {!allowDeletion && (
               <li className="disabled">
-                <a className="clickable" onClick={this.deleteLoadBalancer}>
+                <a>
                   Delete Load Balancer{' '}
                   <HelpField content="You must detach all instances before you can delete this load balancer." />
                 </a>

--- a/app/scripts/modules/amazon/src/securityGroup/details/securityGroupDetail.controller.js
+++ b/app/scripts/modules/amazon/src/securityGroup/details/securityGroupDetail.controller.js
@@ -152,8 +152,8 @@ angular
       }
 
       this.editInboundRules = function editInboundRules() {
-        checkManagement()
-          .then(() =>
+        confirmNotManaged($scope.securityGroup, application).then(notManaged => {
+          notManaged &&
             $uibModal.open({
               templateUrl: require('../configure/editSecurityGroup.html'),
               controller: 'awsEditSecurityGroupCtrl as ctrl',
@@ -166,9 +166,8 @@ angular
                   return application;
                 },
               },
-            }),
-          )
-          .catch(noop);
+            });
+        });
       };
 
       this.cloneSecurityGroup = function cloneSecurityGroup() {
@@ -214,18 +213,19 @@ angular
           return SecurityGroupWriter.deleteSecurityGroup(securityGroup, application, params);
         };
 
-        checkManagement().then(() =>
-          confirmationModalService.confirm({
-            header: 'Really delete ' + securityGroup.name + '?',
-            buttonText: 'Delete ' + securityGroup.name,
-            account: securityGroup.accountId,
-            taskMonitorConfig: taskMonitor,
-            submitMethod: submitMethod,
-            retryBody: `<div><p>Retry deleting the ${FirewallLabels.get(
-              'firewall',
-            )} and revoke any dependent ingress rules?</p><p>Any instance or load balancer associations will have to removed manually.</p></div>`,
-          }),
-        );
+        confirmNotManaged($scope.securityGroup, application).then(notManaged => {
+          notManaged &&
+            confirmationModalService.confirm({
+              header: 'Really delete ' + securityGroup.name + '?',
+              buttonText: 'Delete ' + securityGroup.name,
+              account: securityGroup.accountId,
+              taskMonitorConfig: taskMonitor,
+              submitMethod: submitMethod,
+              retryBody: `<div><p>Retry deleting the ${FirewallLabels.get(
+                'firewall',
+              )} and revoke any dependent ingress rules?</p><p>Any instance or load balancer associations will have to removed manually.</p></div>`,
+            });
+        });
       };
 
       if (app.isStandalone) {

--- a/app/scripts/modules/amazon/src/serverGroup/details/AmazonServerGroupActions.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/details/AmazonServerGroupActions.tsx
@@ -1,18 +1,19 @@
 import React from 'react';
 import { Dropdown, Tooltip } from 'react-bootstrap';
-import { get, find, filter, orderBy } from 'lodash';
+import { filter, find, get, orderBy } from 'lodash';
 
 import {
   ClusterTargetBuilder,
   IOwnerOption,
   IServerGroupActionsProps,
   IServerGroupJob,
+  ManagedMenuItem,
   ModalInjector,
   NgReact,
+  Overridable,
   ReactInjector,
   ServerGroupWarningMessageService,
   SETTINGS,
-  Overridable,
 } from '@spinnaker/core';
 
 import { IAmazonServerGroup, IAmazonServerGroupView } from 'amazon/domain';
@@ -36,11 +37,13 @@ export class AmazonServerGroupActionsResize extends React.Component<IAmazonResiz
 
   public render(): JSX.Element {
     return (
-      <li>
-        <a className="clickable" onClick={this.resizeServerGroup}>
-          Resize
-        </a>
-      </li>
+      <ManagedMenuItem
+        resource={this.props.serverGroup}
+        application={this.props.application}
+        onClick={this.resizeServerGroup}
+      >
+        Resize
+      </ManagedMenuItem>
     );
   }
 }
@@ -296,27 +299,21 @@ export class AmazonServerGroupActions extends React.Component<IAmazonServerGroup
         <Dropdown.Toggle className="btn btn-sm btn-primary dropdown-toggle">Server Group Actions</Dropdown.Toggle>
         <Dropdown.Menu className="dropdown-menu">
           {this.isRollbackEnabled() && (
-            <li>
-              <a className="clickable" onClick={this.rollbackServerGroup}>
-                Rollback
-              </a>
-            </li>
+            <ManagedMenuItem resource={serverGroup} application={app} onClick={this.rollbackServerGroup}>
+              Rollback
+            </ManagedMenuItem>
           )}
           {this.isRollbackEnabled() && <li role="presentation" className="divider" />}
           <AmazonServerGroupActionsResize application={app} serverGroup={serverGroup} />
           {!serverGroup.isDisabled && (
-            <li>
-              <a className="clickable" onClick={this.disableServerGroup}>
-                Disable
-              </a>
-            </li>
+            <ManagedMenuItem resource={serverGroup} application={app} onClick={this.disableServerGroup}>
+              Disable
+            </ManagedMenuItem>
           )}
           {this.hasDisabledInstances() && !this.isEnableLocked() && (
-            <li>
-              <a className="clickable" onClick={this.enableServerGroup}>
-                Enable
-              </a>
-            </li>
+            <ManagedMenuItem resource={serverGroup} application={app} onClick={this.enableServerGroup}>
+              Enable
+            </ManagedMenuItem>
           )}
           {this.isEnableLocked() && (
             <li className="disabled">
@@ -327,11 +324,9 @@ export class AmazonServerGroupActions extends React.Component<IAmazonServerGroup
               </Tooltip>
             </li>
           )}
-          <li>
-            <a className="clickable" onClick={this.destroyServerGroup}>
-              Destroy
-            </a>
-          </li>
+          <ManagedMenuItem resource={serverGroup} application={app} onClick={this.destroyServerGroup}>
+            Destroy
+          </ManagedMenuItem>
           <li>
             <a className="clickable" onClick={this.cloneServerGroup}>
               Clone

--- a/app/scripts/modules/amazon/src/serverGroup/details/AmazonServerGroupActions.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/details/AmazonServerGroupActions.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Dropdown, Tooltip } from 'react-bootstrap';
+import { Dropdown, MenuItem, Tooltip } from 'react-bootstrap';
 import { filter, find, get, orderBy } from 'lodash';
 
 import {
@@ -36,15 +36,7 @@ export class AmazonServerGroupActionsResize extends React.Component<IAmazonResiz
   };
 
   public render(): JSX.Element {
-    return (
-      <ManagedMenuItem
-        resource={this.props.serverGroup}
-        application={this.props.application}
-        onClick={this.resizeServerGroup}
-      >
-        Resize
-      </ManagedMenuItem>
-    );
+    return <MenuItem onClick={this.resizeServerGroup}>Resize</MenuItem>;
   }
 }
 

--- a/app/scripts/modules/amazon/src/serverGroup/details/resize/AmazonResizeServerGroupModal.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/details/resize/AmazonResizeServerGroupModal.tsx
@@ -70,9 +70,9 @@ export class AmazonResizeServerGroupModal extends React.Component<
   public static show(props: IAmazonResizeServerGroupModalProps) {
     const modalProps = {};
     const { serverGroup, application } = props;
-    return confirmNotManaged(serverGroup, application)
-      .then(() => ReactModal.show(AmazonResizeServerGroupModal, props, modalProps))
-      .catch(noop);
+    return confirmNotManaged(serverGroup, application).then(notManaged => {
+      notManaged && ReactModal.show(AmazonResizeServerGroupModal, props, modalProps);
+    });
   }
 
   constructor(props: IAmazonResizeServerGroupModalProps) {

--- a/app/scripts/modules/amazon/src/serverGroup/details/sections/AdvancedSettingsDetailsSection.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/details/sections/AdvancedSettingsDetailsSection.tsx
@@ -1,14 +1,15 @@
 import React from 'react';
 
-import { CollapsibleSection, ModalInjector, confirmNotManaged, noop } from '@spinnaker/core';
+import { CollapsibleSection, ModalInjector, confirmNotManaged } from '@spinnaker/core';
 
 import { IAmazonServerGroupDetailsSectionProps } from './IAmazonServerGroupDetailsSectionProps';
 
 export class AdvancedSettingsDetailsSection extends React.Component<IAmazonServerGroupDetailsSectionProps> {
   private editAdvancedSettings = (): void => {
     const { app, serverGroup } = this.props;
-    confirmNotManaged(serverGroup, app)
-      .then(() =>
+    confirmNotManaged(serverGroup, app).then(
+      notManaged =>
+        notManaged &&
         ModalInjector.modalService.open({
           templateUrl: require('../advancedSettings/editAsgAdvancedSettings.modal.html'),
           controller: 'EditAsgAdvancedSettingsCtrl as ctrl',
@@ -17,8 +18,7 @@ export class AdvancedSettingsDetailsSection extends React.Component<IAmazonServe
             serverGroup: () => serverGroup,
           },
         }),
-      )
-      .catch(noop);
+    );
   };
 
   public render(): JSX.Element {

--- a/app/scripts/modules/amazon/src/serverGroup/details/sections/ScalingProcessesDetailsSection.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/details/sections/ScalingProcessesDetailsSection.tsx
@@ -1,14 +1,6 @@
 import React from 'react';
 import { IScalingProcess } from 'amazon/domain';
-import {
-  CollapsibleSection,
-  confirmNotManaged,
-  HelpField,
-  ModalInjector,
-  noop,
-  timestamp,
-  Tooltip,
-} from '@spinnaker/core';
+import { CollapsibleSection, confirmNotManaged, HelpField, ModalInjector, timestamp, Tooltip } from '@spinnaker/core';
 import { AutoScalingProcessService } from '../scalingProcesses/AutoScalingProcessService';
 import { IAmazonServerGroupDetailsSectionProps } from './IAmazonServerGroupDetailsSectionProps';
 
@@ -30,8 +22,9 @@ export class ScalingProcessesDetailsSection extends React.Component<
 
   private toggleScalingProcesses = (): void => {
     const { app, serverGroup } = this.props;
-    confirmNotManaged(serverGroup, app)
-      .then(() =>
+    confirmNotManaged(serverGroup, app).then(
+      isNotManaged =>
+        isNotManaged &&
         ModalInjector.modalService.open({
           templateUrl: require('../scalingProcesses/modifyScalingProcesses.html'),
           controller: 'ModifyScalingProcessesCtrl as ctrl',
@@ -41,8 +34,7 @@ export class ScalingProcessesDetailsSection extends React.Component<
             processes: () => this.state.autoScalingProcesses,
           },
         }),
-      )
-      .catch(noop);
+    );
   };
 
   private getState(props: IAmazonServerGroupDetailsSectionProps): IScalingProcessesDetailsSectionState {

--- a/app/scripts/modules/amazon/src/serverGroup/details/sections/SecurityGroupsDetailsSection.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/details/sections/SecurityGroupsDetailsSection.tsx
@@ -2,14 +2,7 @@ import React from 'react';
 import { chain, find, sortBy } from 'lodash';
 import { UISref } from '@uirouter/react';
 
-import {
-  CollapsibleSection,
-  confirmNotManaged,
-  ISecurityGroup,
-  ModalInjector,
-  FirewallLabels,
-  noop,
-} from '@spinnaker/core';
+import { CollapsibleSection, confirmNotManaged, ISecurityGroup, ModalInjector, FirewallLabels } from '@spinnaker/core';
 
 import { IAmazonServerGroupDetailsSectionProps } from './IAmazonServerGroupDetailsSectionProps';
 
@@ -47,8 +40,9 @@ export class SecurityGroupsDetailsSection extends React.Component<
 
   private updateSecurityGroups = (): void => {
     const { app, serverGroup } = this.props;
-    confirmNotManaged(serverGroup, app)
-      .then(() =>
+    confirmNotManaged(serverGroup, app).then(
+      notManaged =>
+        notManaged &&
         ModalInjector.modalService.open({
           templateUrl: require('../securityGroup/editSecurityGroups.modal.html'),
           controller: 'EditSecurityGroupsCtrl as $ctrl',
@@ -58,8 +52,7 @@ export class SecurityGroupsDetailsSection extends React.Component<
             securityGroups: () => this.state.securityGroups,
           },
         }),
-      )
-      .catch(noop);
+    );
   };
 
   public componentWillReceiveProps(nextProps: IAmazonServerGroupDetailsSectionProps): void {

--- a/app/scripts/modules/core/src/confirmationModal/ConfirmModal.tsx
+++ b/app/scripts/modules/core/src/confirmationModal/ConfirmModal.tsx
@@ -64,10 +64,10 @@ export const ConfirmModal = (props: IConfirmModalProps) => {
         });
       });
     } else if (submitJustWithReason) {
-      submitMethod({ reason }).then(dismissModal);
+      submitMethod({ reason }).then(closeModal);
     } else {
       if (submitMethod) {
-        submitMethod().then(dismissModal, showError);
+        submitMethod().then(closeModal, showError);
       } else {
         closeModal();
       }

--- a/app/scripts/modules/core/src/confirmationModal/confirmationModal.service.ts
+++ b/app/scripts/modules/core/src/confirmationModal/confirmationModal.service.ts
@@ -52,12 +52,7 @@ export class ConfirmationModalService {
       extendedParams.taskMonitors = taskMonitorConfigs.map(m => new TaskMonitor(m));
     }
 
-    const modalProps = { closeModal: deferred.resolve, dismissModal: deferred.reject };
-    const props = { ...extendedParams, ...modalProps };
-    ReactModal.show(ConfirmModal, props);
-
-    // modal was closed
-    deferred.promise.catch(() => {});
+    ReactModal.show(ConfirmModal, extendedParams).then(deferred.resolve, deferred.reject);
 
     return deferred.promise;
   }

--- a/app/scripts/modules/core/src/managed/ManagedMenuItem.tsx
+++ b/app/scripts/modules/core/src/managed/ManagedMenuItem.tsx
@@ -21,9 +21,12 @@ export const ManagedMenuItem = ({ resource, application, onClick, children }: IM
   const resourceIsPaused = resource.isManaged && resource.managedResourceSummary.isPaused;
   const appIsPaused = application.isManagementPaused;
   const showInterstitial = resource.isManaged && !resourceIsPaused && !appIsPaused;
-  const interstitial: () => IPromise<void> = () =>
-    showInterstitial ? confirmNotManaged(resource, application) : $q.when();
-  const handleClick: () => void = () => interstitial().then(onClick);
+  const interstitial: () => IPromise<boolean> = () =>
+    showInterstitial ? confirmNotManaged(resource, application) : $q.when(true);
+  const handleClick: () => void = () =>
+    interstitial().then(isNotManaged => {
+      isNotManaged && onClick();
+    });
 
   return <MenuItem onClick={handleClick}>{children}</MenuItem>;
 };

--- a/app/scripts/modules/core/src/managed/ManagedMenuItem.tsx
+++ b/app/scripts/modules/core/src/managed/ManagedMenuItem.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { MenuItem } from 'react-bootstrap';
+import { $q } from 'ngimport';
+import { IPromise } from 'angular';
+
+import { Application } from 'core/application';
+import { IManagedResource } from 'core/domain';
+import { confirmNotManaged } from './toggleResourceManagement';
+
+interface IManagedMenuItemProps {
+  resource: IManagedResource;
+  application: Application;
+  onClick?: () => void;
+  children: React.ReactNode;
+}
+
+export const ManagedMenuItem = ({ resource, application, onClick, children }: IManagedMenuItemProps) => {
+  if (!resource) {
+    return null;
+  }
+  const resourceIsPaused = resource.isManaged && resource.managedResourceSummary.isPaused;
+  const appIsPaused = application.isManagementPaused;
+  const showInterstitial = resource.isManaged && !resourceIsPaused && !appIsPaused;
+  const interstitial: () => IPromise<void> = () =>
+    showInterstitial ? confirmNotManaged(resource, application) : $q.when();
+  const handleClick: () => void = () => interstitial().then(onClick);
+
+  return <MenuItem onClick={handleClick}>{children}</MenuItem>;
+};

--- a/app/scripts/modules/core/src/managed/index.ts
+++ b/app/scripts/modules/core/src/managed/index.ts
@@ -5,4 +5,5 @@ export * from './managedResourceDetailsIndicator.component';
 export * from './ManagedResourceStatusIndicator';
 export * from './managed.dataSource';
 export * from './managedResourceDecorators';
+export * from './ManagedMenuItem';
 export * from './toggleResourceManagement';

--- a/app/scripts/modules/titus/src/serverGroup/details/TitusCapacityDetailsSection.tsx
+++ b/app/scripts/modules/titus/src/serverGroup/details/TitusCapacityDetailsSection.tsx
@@ -25,11 +25,10 @@ export class TitusCapacityDetailsSection extends React.Component<ICapacityDetail
     const simpleMode = capacity.min === capacity.max;
 
     const resizeServerGroup = () =>
-      confirmNotManaged(serverGroup, application)
-        .then(() => {
+      confirmNotManaged(serverGroup, application).then(notManaged => {
+        notManaged &&
           ReactModal.show<ITitusResizeServerGroupModalProps>(TitusResizeServerGroupModal, { serverGroup, application });
-        })
-        .catch(() => {});
+      });
 
     return (
       <>

--- a/app/scripts/modules/titus/src/serverGroup/details/TitusCapacityDetailsSection.tsx
+++ b/app/scripts/modules/titus/src/serverGroup/details/TitusCapacityDetailsSection.tsx
@@ -1,6 +1,13 @@
 import React from 'react';
 
-import { CurrentCapacity, DesiredCapacity, ReactModal, Application, Overridable } from '@spinnaker/core';
+import {
+  confirmNotManaged,
+  CurrentCapacity,
+  DesiredCapacity,
+  ReactModal,
+  Application,
+  Overridable,
+} from '@spinnaker/core';
 import { ITitusServerGroup } from 'titus/domain';
 import { ITitusResizeServerGroupModalProps, TitusResizeServerGroupModal } from './resize/TitusResizeServerGroupModal';
 
@@ -18,7 +25,11 @@ export class TitusCapacityDetailsSection extends React.Component<ICapacityDetail
     const simpleMode = capacity.min === capacity.max;
 
     const resizeServerGroup = () =>
-      ReactModal.show<ITitusResizeServerGroupModalProps>(TitusResizeServerGroupModal, { serverGroup, application });
+      confirmNotManaged(serverGroup, application)
+        .then(() => {
+          ReactModal.show<ITitusResizeServerGroupModalProps>(TitusResizeServerGroupModal, { serverGroup, application });
+        })
+        .catch(() => {});
 
     return (
       <>

--- a/app/scripts/modules/titus/src/serverGroup/details/serverGroupDetails.titus.controller.js
+++ b/app/scripts/modules/titus/src/serverGroup/details/serverGroupDetails.titus.controller.js
@@ -261,9 +261,9 @@ angular
 
         ServerGroupWarningMessageService.addDestroyWarningMessage(app, serverGroup, confirmationModalParams);
 
-        confirmNotManaged(serverGroup, app)
-          .then(() => confirmationModalService.confirm(confirmationModalParams))
-          .catch(() => {});
+        confirmNotManaged(serverGroup, app).then(
+          notManaged => notManaged && confirmationModalService.confirm(confirmationModalParams),
+        );
       };
 
       this.disableServerGroup = function disableServerGroup() {
@@ -295,46 +295,45 @@ angular
 
         ServerGroupWarningMessageService.addDisableWarningMessage(app, serverGroup, confirmationModalParams);
 
-        confirmNotManaged(serverGroup, app)
-          .then(() => confirmationModalService.confirm(confirmationModalParams))
-          .catch(() => {});
+        confirmNotManaged(serverGroup, app).then(
+          notManaged => notManaged && confirmationModalService.confirm(confirmationModalParams),
+        );
       };
 
       this.enableServerGroup = () => {
-        confirmNotManaged(serverGroup, app)
-          .then(() => {
-            if (!this.isRollbackEnabled()) {
-              this.showEnableServerGroupModal();
-              return;
-            }
+        confirmNotManaged(serverGroup, app).then(notManaged => {
+          if (!notManaged) {
+            return;
+          }
+          if (!this.isRollbackEnabled()) {
+            this.showEnableServerGroupModal();
+            return;
+          }
 
-            const confirmationModalParams = {
-              header: 'Rolling back?',
-              body: `Spinnaker provides an orchestrated rollback feature to carefully restore a different version of this
+          const confirmationModalParams = {
+            header: 'Rolling back?',
+            body: `Spinnaker provides an orchestrated rollback feature to carefully restore a different version of this
                  server group. Do you want to use the orchestrated rollback?`,
-              buttonText: `Yes, take me to the rollback settings modal`,
-              cancelButtonText: 'No, I just want to enable the server group',
-            };
+            buttonText: `Yes, take me to the rollback settings modal`,
+            cancelButtonText: 'No, I just want to enable the server group',
+          };
 
-            confirmationModalService
-              .confirm(confirmationModalParams)
-              .then(() => this.rollbackServerGroup())
-              .catch(({ source }) => {
-                // don't show the enable modal if the user cancels with the header button
-                if (source === 'footer') {
-                  this.showEnableServerGroupModal();
-                }
-              });
-          })
-          .catch(() => {});
+          confirmationModalService
+            .confirm(confirmationModalParams)
+            .then(() => this.rollbackServerGroup())
+            .catch(({ source }) => {
+              // don't show the enable modal if the user cancels with the header button
+              if (source === 'footer') {
+                this.showEnableServerGroupModal();
+              }
+            });
+        });
       };
 
       this.resizeServerGroup = () => {
-        confirmNotManaged(serverGroup, app)
-          .then(() => {
-            ReactModal.show(TitusResizeServerGroupModal, { serverGroup: $scope.serverGroup, application });
-          })
-          .catch(() => {});
+        confirmNotManaged(serverGroup, app).then(notManaged => {
+          notManaged && ReactModal.show(TitusResizeServerGroupModal, { serverGroup: $scope.serverGroup, application });
+        });
       };
 
       this.showEnableServerGroupModal = () => {
@@ -430,8 +429,8 @@ angular
           previousServerGroup = allServerGroups[0];
         }
 
-        confirmNotManaged(serverGroup, app)
-          .then(() => {
+        confirmNotManaged(serverGroup, app).then(notManaged => {
+          notManaged &&
             $uibModal.open({
               templateUrl: require('./rollback/rollbackServerGroup.html'),
               controller: 'titusRollbackServerGroupCtrl as ctrl',
@@ -449,8 +448,7 @@ angular
                 application: () => application,
               },
             });
-          })
-          .catch(() => {});
+        });
       };
     },
   ]);


### PR DESCRIPTION
This adds a pretty simple component to prevent menu item actions on managed resources. If the user clicks an action, they'll get an interstitial modal asking them to pause management.

I started to make a similar component for the angular world, but...the bootstrap CSS for the dropdown menu includes a bunch of immediate child selectors so it didn't really work, and...we want to convert this stuff to React at some point, anyway, so for now, we're just handling that functionality manually.