### PR TITLE
feat(core/amazon/titus): do not allow create/clone in managed clusters

### DIFF
--- a/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupConfiguration.service.spec.ts
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupConfiguration.service.spec.ts
@@ -404,4 +404,79 @@ describe('Service: awsServerGroupConfiguration', function() {
       expect(result.dirty.amiName).toBe(true);
     });
   });
+
+  describe('managedResources', () => {
+    beforeEach(() => {
+      this.command = {
+        viewState: {},
+        backingData: {
+          filtered: {},
+          credentialsKeyedByAccount: {
+            prod: {
+              regions: [
+                { name: 'us-east-1', availabilityZones: [] },
+                { name: 'us-west-1', availabilityZones: [] },
+              ],
+            },
+            test: {
+              regions: [
+                { name: 'us-east-1', availabilityZones: [] },
+                { name: 'us-west-1', availabilityZones: [] },
+              ],
+            },
+          },
+          managedResources: [
+            {
+              kind: 'cluster',
+              locations: {
+                account: 'prod',
+                regions: [{ name: 'us-east-1' }],
+              },
+              moniker: {
+                stack: 'foo',
+                detail: 'bar',
+              },
+            },
+          ],
+          securityGroups: {},
+          preferredZones: {},
+        },
+        credentials: 'test',
+        region: 'us-west-1',
+        stack: '',
+        freeFormDetails: '',
+      };
+      service.attachEventHandlers(this.command);
+    });
+
+    it('does not add managedResource on initial load if not matched', () => {
+      expect(this.command.viewState.resourceSummary).toBeFalsy();
+    });
+
+    it('adds managedResource when all fields match a non-paused resource', () => {
+      const { command } = this;
+      const managedResource = command.backingData.managedResources[0];
+      expect(command.resourceSummary).toBeFalsy();
+
+      command.credentials = managedResource.locations.account;
+      command.credentialsChanged(command);
+      expect(command.resourceSummary).toBeFalsy();
+
+      command.region = managedResource.locations.regions[0].name;
+      command.regionChanged(command);
+      expect(command.resourceSummary).toBeFalsy();
+
+      command.stack = managedResource.moniker.stack;
+      command.clusterChanged(command);
+      expect(command.resourceSummary).toBeFalsy();
+
+      command.freeFormDetails = managedResource.moniker.detail;
+      command.clusterChanged(command);
+      expect(command.resourceSummary).toBe(managedResource);
+
+      managedResource.isPaused = true;
+      command.clusterChanged(command);
+      expect(command.resourceSummary).toBeFalsy();
+    });
+  });
 });

--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/ServerGroupBasicSettings.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/ServerGroupBasicSettings.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Field, FormikProps } from 'formik';
+import { Field, FormikErrors, FormikProps } from 'formik';
 
 import {
   AccountSelectInput,
@@ -12,6 +12,7 @@ import {
   IServerGroup,
   IWizardPageComponent,
   Markdown,
+  DeployingIntoManagedClusterWarning,
   TaskReason,
 } from '@spinnaker/core';
 
@@ -111,8 +112,8 @@ export class ServerGroupBasicSettings
     setFieldValue('subnetType', values.subnetType);
   };
 
-  public validate(values: IAmazonServerGroupCommand): { [key: string]: string } {
-    const errors: { [key: string]: string } = {};
+  public validate(values: IAmazonServerGroupCommand): FormikErrors<IAmazonServerGroupCommand> {
+    const errors: FormikErrors<IAmazonServerGroupCommand> = {};
 
     if (!isStackPattern(values.stack)) {
       errors.stack = 'Only dot(.) and underscore(_) special characters are allowed in the Stack field.';
@@ -125,6 +126,12 @@ export class ServerGroupBasicSettings
 
     if (!values.viewState.disableImageSelection && !values.amiName) {
       errors.amiName = 'Image required.';
+    }
+
+    // this error is added exclusively to disable the "create/clone" button - it is not visible aside from the warning
+    // rendered by the DeployingIntoManagedClusterWarning component
+    if (values.resourceSummary) {
+      errors.resourceSummary = { id: 'Cluster is managed' };
     }
 
     return errors;
@@ -206,6 +213,7 @@ export class ServerGroupBasicSettings
             </div>
           </div>
         )}
+        <DeployingIntoManagedClusterWarning app={app} formik={formik} />
         <div className="form-group">
           <div className="col-md-3 sm-label-right">Account</div>
           <div className="col-md-7">

--- a/app/scripts/modules/core/src/managed/DeployingIntoManagedClusterWarning.tsx
+++ b/app/scripts/modules/core/src/managed/DeployingIntoManagedClusterWarning.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { IServerGroupCommand } from 'core/serverGroup';
+import { FormikProps } from 'formik';
+import { Application } from 'core/application';
+import { toggleResourcePause } from './toggleResourceManagement';
+
+export interface IDeployingIntoManagedClusterWarningProps {
+  app: Application;
+  formik: FormikProps<IServerGroupCommand>;
+}
+
+export const DeployingIntoManagedClusterWarning = ({ app, formik }: IDeployingIntoManagedClusterWarningProps) => {
+  const [userPaused, setUserPaused] = React.useState(false);
+
+  const command = formik.values;
+  const pauseResource = React.useCallback(() => {
+    const { resourceSummary, backingData } = formik.values;
+    toggleResourcePause(resourceSummary, app).then(() => {
+      backingData.managedResources = app.getDataSource('managedResources')?.data?.resources;
+      setUserPaused(true);
+      formik.setFieldValue('resourceSummary', null);
+    });
+  }, [app, formik]);
+
+  if (!command.resourceSummary && !userPaused) {
+    return null;
+  }
+
+  if (userPaused) {
+    return (
+      <div className="alert alert-info">
+        <div className="horizontal top">
+          <div>
+            <i className="fa fa-check-circle" />
+          </div>
+          <div className="sp-margin-m-left">Resource management has been paused.</div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="alert alert-danger">
+      <p>
+        <b>🌈 Spinnaker is continuously managing this resource.</b>
+      </p>
+      <p>Any changes you make to this cluster will be stomped in favor of the declarative configuration.</p>
+      <p>If you need to manually deploy a new version of this server group, you should pause management.</p>
+      <div className="sp-margin-m-top">
+        <button className="passive" onClick={pauseResource}>
+          <i className="fa fa-pause" /> Pause management
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/app/scripts/modules/core/src/managed/index.ts
+++ b/app/scripts/modules/core/src/managed/index.ts
@@ -1,3 +1,4 @@
+export * from './DeployingIntoManagedClusterWarning';
 export * from './ManagedReader';
 export * from './ManagedWriter';
 export * from './ManagedResourceDetailsIndicator';

--- a/app/scripts/modules/titus/src/serverGroup/configure/serverGroupConfiguration.service.ts
+++ b/app/scripts/modules/titus/src/serverGroup/configure/serverGroupConfiguration.service.ts
@@ -20,6 +20,8 @@ import {
   SecurityGroupReader,
   IVpc,
   ISecurityGroup,
+  NameUtils,
+  setMatchingResourceSummary,
 } from '@spinnaker/core';
 import {
   IAmazonApplicationLoadBalancer,
@@ -135,13 +137,20 @@ export class TitusServerGroupConfigurationService {
       command.viewState.dirty = { ...(command.viewState.dirty || {}), ...result.dirty };
       this.configureLoadBalancerOptions(command);
       this.configureSecurityGroupOptions(command);
+      setMatchingResourceSummary(command);
       return result;
     };
 
     cmd.regionChanged = (command: ITitusServerGroupCommand) => {
       this.configureLoadBalancerOptions(command);
       this.configureSecurityGroupOptions(command);
+      setMatchingResourceSummary(command);
       return {};
+    };
+
+    cmd.clusterChanged = (command: ITitusServerGroupCommand): void => {
+      command.moniker = NameUtils.getMoniker(command.application, command.stack, command.freeFormDetails);
+      setMatchingResourceSummary(command);
     };
   }
 

--- a/app/scripts/modules/titus/src/serverGroup/configure/wizard/pages/ServerGroupBasicSettings.tsx
+++ b/app/scripts/modules/titus/src/serverGroup/configure/wizard/pages/ServerGroupBasicSettings.tsx
@@ -3,6 +3,7 @@ import { Field, FormikErrors, FormikProps } from 'formik';
 
 import {
   DeploymentStrategySelector,
+  DeployingIntoManagedClusterWarning,
   HelpField,
   NameUtils,
   RegionSelectField,
@@ -114,6 +115,12 @@ export class ServerGroupBasicSettings
       }
     }
 
+    // this error is added exclusively to disable the "create/clone" button - it is not visible aside from the warning
+    // rendered by the DeployingIntoManagedClusterWarning component
+    if (values.resourceSummary) {
+      errors.resourceSummary = { id: 'Cluster is managed' };
+    }
+
     return errors;
   }
 
@@ -137,11 +144,15 @@ export class ServerGroupBasicSettings
   };
 
   private stackChanged = (stack: string) => {
-    this.props.formik.setFieldValue('stack', stack);
+    const { formik } = this.props;
+    formik.setFieldValue('stack', stack);
+    formik.values.clusterChanged(formik.values);
   };
 
   private freeFormDetailsChanged = (freeFormDetails: string) => {
-    this.props.formik.setFieldValue('freeFormDetails', freeFormDetails);
+    const { formik } = this.props;
+    formik.setFieldValue('freeFormDetails', freeFormDetails);
+    formik.values.clusterChanged(formik.values);
   };
 
   public componentWillReceiveProps(nextProps: IServerGroupBasicSettingsProps) {
@@ -164,7 +175,8 @@ export class ServerGroupBasicSettings
   };
 
   public render() {
-    const { errors, setFieldValue, values } = this.props.formik;
+    const { app, formik } = this.props;
+    const { errors, setFieldValue, values } = formik;
     const { createsNewCluster, latestServerGroup, namePreview, showPreviewAsWarning } = this.state;
 
     const accounts = values.backingData.accounts;
@@ -172,6 +184,7 @@ export class ServerGroupBasicSettings
 
     return (
       <div className="container-fluid form-horizontal">
+        <DeployingIntoManagedClusterWarning app={app} formik={formik} />
         <div className="form-group">
           <div className="col-md-3 sm-label-right">Account</div>
           <div className="col-md-7">


### PR DESCRIPTION
In the UI, we're doing a pretty good job preventing users from performing actions that will just get stomped. The create/clone server group flow is a little tricky: we want to let them select "Clone" on a managed server group: they might want to use it as a base to create a different (non-managed) cluster. And we can't disable the "Create server group" button.

This PR adds an alert that invalidates the command whenever they have configured the new server group to be in a managed cluster.

When the user clicks the button to pause management, there's that modal-over-a-modal experience, which I don't like, but it's important to really confirm that the user wants to pause management.

(forgive the deprecated region warning also being here, I am having trouble with my sandbox environment so using some other one)
![hey-pauso](https://user-images.githubusercontent.com/73450/72037920-9237e600-3254-11ea-86e8-795f05a3b9c9.gif)
