### PR TITLE
fix(core): do not log all help contents to the console

### DIFF
--- a/app/scripts/modules/core/src/help/HelpField.tsx
+++ b/app/scripts/modules/core/src/help/HelpField.tsx
@@ -21,7 +21,6 @@ function HelpFieldContents(props: Pick<IHelpFieldProps, 'id' | 'fallback' | 'con
   if (id && !contentString) {
     contentString = HelpContentsRegistry.getHelpField(id) || fallback;
   }
-  console.warn(contentString);
 
   const config = { ADD_ATTR: ['target'] }; // allow: target="_blank"
   return <Markdown message={contentString} options={config} trim={true} />;


### PR DESCRIPTION
I don't think we need to git blame this, let's just all agree it's a good change to make and move on.