### PR TITLE
fix(core): Update functional tests with new modal heading el

### DIFF
--- a/test/functional/tests/google/pages/CreateServerGroupModalPage.ts
+++ b/test/functional/tests/google/pages/CreateServerGroupModalPage.ts
@@ -2,7 +2,7 @@ import { Page } from '../../core/pages/Page';
 
 export class CreateServerGroupModalPage extends Page {
   public static locators = {
-    createServerGroupHeading: `//h3[contains(., 'Create New Server Group')]`,
+    createServerGroupHeading: `//h4[contains(., 'Create New Server Group')]`,
     acceleratorSectionHeading: `//*[contains(@class, 'sm-label-left') and contains(., 'Accelerators')]`,
     addAcceleratorButton: `//button[contains(., 'Add Accelerator')]`,
     acceleratorTypeSelect: `//gce-accelerator-configurer//div[contains(@class, 'Select')]`,


### PR DESCRIPTION
Modal elements were standardized on `<h4>` in https://github.com/spinnaker/deck/pull/7743. This updates a breaking a functional test to look for that el.
