### PR TITLE
fix(core): keep health counts on one line in server group title

### DIFF
--- a/app/scripts/modules/core/src/cluster/rollups.less
+++ b/app/scripts/modules/core/src/cluster/rollups.less
@@ -246,9 +246,7 @@ table.instances {
 }
 
 running-tasks-tag {
-  position: relative;
-  top: 2px;
-  right: 5px;
+  margin-right: 10px;
 
   .icon-spinner {
     color: var(--color-accent);

--- a/app/scripts/modules/core/src/healthCounts/HealthCounts.tsx
+++ b/app/scripts/modules/core/src/healthCounts/HealthCounts.tsx
@@ -188,7 +188,7 @@ export class HealthCounts extends React.Component<IHealthCountsProps, IHealthCou
 
     if (percentLabel !== 'n/a') {
       return (
-        <div className={`health-counts ${className}`}>
+        <span className={`health-counts ${className}`}>
           <Tooltip template={legend} placement={this.props.legendPlacement}>
             <span className="counter instance-health-counts">
               {counts}
@@ -200,11 +200,11 @@ export class HealthCounts extends React.Component<IHealthCountsProps, IHealthCou
               )}
             </span>
           </Tooltip>
-        </div>
+        </span>
       );
     } else if (container.outOfService) {
       return (
-        <div className={`health-counts ${className}`}>
+        <span className={`health-counts ${className}`}>
           <Tooltip template={legend}>
             <span className="counter instance-health-counts">
               <span>
@@ -212,7 +212,7 @@ export class HealthCounts extends React.Component<IHealthCountsProps, IHealthCou
               </span>
             </span>
           </Tooltip>
-        </div>
+        </span>
       );
     } else {
       return null;

--- a/app/scripts/modules/core/src/healthCounts/healthCounts.less
+++ b/app/scripts/modules/core/src/healthCounts/healthCounts.less
@@ -15,24 +15,9 @@
 
 health-counts {
   display: inherit; // Since health-counts wraps a react component with a .health-counts class that does all the layout now, make this component not have layout
-  &.no-float {
-    .instance-health-counts {
-      float: none;
-    }
-  }
 }
 
 .health-counts {
-  display: inline;
-  .instance-health-counts {
-    float: right;
-    padding-left: 5px;
-  }
-  &.no-float {
-    .instance-health-counts {
-      float: none;
-    }
-  }
   .instance-health-counts {
     .glyphicon {
       top: 0;

--- a/app/scripts/modules/core/src/pipeline/config/stages/deploy/deployExecutionDetails.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/deploy/deployExecutionDetails.html
@@ -57,7 +57,7 @@
         </span>
         <span ng-if="stage.context.lastCapacityCheck.total !== 0">
           ( current status:
-          <health-counts container="stage.context.lastCapacityCheck" class="no-float"></health-counts>)
+          <health-counts container="stage.context.lastCapacityCheck"></health-counts>)
         </span>
       </p>
       <div ng-if="waitingForUpInstances && customStuckDeployGuide" ng-bind-html="customStuckDeployGuide"></div>

--- a/app/scripts/modules/core/src/serverGroup/ServerGroupHeader.tsx
+++ b/app/scripts/modules/core/src/serverGroup/ServerGroupHeader.tsx
@@ -188,7 +188,7 @@ export class Alerts extends React.Component<IServerGroupHeaderProps> {
 export class Health extends React.Component<IServerGroupHeaderProps> {
   public render() {
     const { serverGroup } = this.props;
-    return <HealthCounts className="no-float" container={serverGroup.instanceCounts} />;
+    return <HealthCounts container={serverGroup.instanceCounts} />;
   }
 }
 
@@ -216,15 +216,15 @@ export class ServerGroupHeader extends React.Component<IServerGroupHeaderProps> 
     const props = this.props;
 
     return (
-      <div className={`flex-container-h baseline server-group-title sticky-header-3`}>
-        <div className="flex-container-h baseline section-title">
+      <div className="horizontal top server-group-title sticky-header-3">
+        <div className="horizontal section-title flex-1">
           <MultiSelectCheckbox {...props} />
           <CloudProviderIcon {...props} />
           <SequenceAndBuildAndImages {...props} />
           <Alerts {...props} />
         </div>
 
-        <div className="flex-container-h baseline flex-pull-right">
+        <div className="horizontal center flex-none">
           <RunningTasks {...props} />
           <LoadBalancers {...props} />
           <Health {...props} />


### PR DESCRIPTION
This is bad (and what it looks like right now):
<img width="695" alt="Screen Shot 2020-01-09 at 12 45 30 PM" src="https://user-images.githubusercontent.com/73450/72103464-213d1080-32de-11ea-947c-3722b9d6b885.png">

It would be nice if it looked like this (i.e. this PR):
<img width="695" alt="Screen Shot 2020-01-09 at 12 46 33 PM" src="https://user-images.githubusercontent.com/73450/72103497-2ef29600-32de-11ea-9c15-e0331866d3f7.png">

Also, when there is a running task, and some load balancers, right now it looks like this:
<img width="659" alt="Screen Shot 2020-01-09 at 11 40 26 AM" src="https://user-images.githubusercontent.com/73450/72103525-3ca81b80-32de-11ea-94b5-963ed164f578.png">

And it would be better like this:
<img width="687" alt="Screen Shot 2020-01-09 at 11 40 39 AM" src="https://user-images.githubusercontent.com/73450/72103554-46318380-32de-11ea-84ef-f0cd4ca841aa.png">
