### PR TITLE
fix(core): catch/handle confirmation modal dismissal

### DIFF
--- a/app/scripts/modules/core/src/confirmationModal/confirmationModal.service.ts
+++ b/app/scripts/modules/core/src/confirmationModal/confirmationModal.service.ts
@@ -54,6 +54,9 @@ export class ConfirmationModalService {
 
     ReactModal.show(ConfirmModal, extendedParams).then(deferred.resolve, deferred.reject);
 
+    // modal was dismissed
+    deferred.promise.catch(() => {});
+
     return deferred.promise;
   }
 }


### PR DESCRIPTION
I removed this yesterday, thinking we didn't want it, but, uh, we do. Without this, every call to `confirmationModal.confirm` needs to add a `catch` block to handle the rejection, or Angular will complain and log an error to the console.

With it, they can still catch the rejection! They just don't need to.

*Edit*: It's a pain to catch the rejection with this change. You need to `.then` the result of the `.confirm` call and catch that. I don't see any cases in code where that matters, since we are not catching calls to `.confirm` anywhere (I looked at all 109 calls)