### PR TITLE
fix(kubernetes): remove accidental static from resolveIndexedSecurity…

### DIFF
--- a/app/scripts/modules/kubernetes/src/shared/securityGroup/securityGroup.reader.ts
+++ b/app/scripts/modules/kubernetes/src/shared/securityGroup/securityGroup.reader.ts
@@ -1,7 +1,7 @@
 import { ISecurityGroupsByAccount, ISecurityGroup } from '@spinnaker/core';
 
 export class KubernetesSecurityGroupReader {
-  public static resolveIndexedSecurityGroup(
+  public resolveIndexedSecurityGroup(
     indexedSecurityGroups: ISecurityGroupsByAccount,
     container: ISecurityGroup,
     securityGroupId: string,


### PR DESCRIPTION
…Groups

Partially addresses https://github.com/spinnaker/spinnaker/issues/5068

I added a bad `static`!  Unfortunately, removing it does not resolve https://github.com/spinnaker/spinnaker/issues/5068 because we are still unable to resolve `KubernetesSecurityGroupReader` [here](https://github.com/spinnaker/deck/blob/master/app/scripts/modules/core/src/securityGroup/securityGroupReader.service.ts#L132), because we are not attaching `kubernetes` on each security group under any of the permitted keys (`provider`, `cloudProvider`, `type`). I tried running Deck at its 1.12.14 commit, when this was known to work, to ensure that it was in fact Clouddriver's responsibility to pass one of those fields along. Corresponding Clouddriver PR coming soon...