### PR TITLE
fix(core/pipeline): use fresh trigger + stage list for upstream flag validation

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/validation/upstreamHasFlagValidator.builder.ts
+++ b/app/scripts/modules/core/src/pipeline/config/validation/upstreamHasFlagValidator.builder.ts
@@ -15,10 +15,6 @@ export interface IUpstreamFlagProvidedValidationConfig extends IValidatorConfig 
 }
 
 export const buildUpstreamHasFlagValidator = (flag: keyof IStageOrTriggerTypeConfig, name: string) => {
-  const providingStages = Registry.pipeline.getStageTypes().filter(x => x[flag]);
-  const providingTriggers = Registry.pipeline.getTriggerTypes().filter(x => x[flag]);
-  const defaultProviders = providingStages.concat(providingTriggers);
-
   PipelineConfigValidator.registerValidator(name, {
     validate: (
       pipeline: IPipeline,
@@ -26,6 +22,10 @@ export const buildUpstreamHasFlagValidator = (flag: keyof IStageOrTriggerTypeCon
       validator: IUpstreamFlagProvidedValidationConfig,
       _config: IStageOrTriggerTypeConfig,
     ) => {
+      const providingStages = Registry.pipeline.getStageTypes().filter(x => x[flag]);
+      const providingTriggers = Registry.pipeline.getTriggerTypes().filter(x => x[flag]);
+      const defaultProviders = providingStages.concat(providingTriggers);
+
       const genericUpstreamValidator = new StageOrTriggerBeforeTypeValidator();
       const repositoryProviders = validator.getProviders ? validator.getProviders() : defaultProviders;
       const stageTypes: string[] = uniq(map(repositoryProviders, 'key'));


### PR DESCRIPTION
turns out when you register triggers/stages outside the point where normal triggers in `core` et al are registered (like in our internal-only modules at Netflix), this validator never sees them today because it has a stale list of triggers/stages from the registry. Instead, let's just deref the registry on every validator run.