### PR TITLE
fix(core): manual cherry-pick of MapEditor fixes

### DIFF
--- a/app/scripts/modules/core/src/forms/mapEditor/MapPair.css
+++ b/app/scripts/modules/core/src/forms/mapEditor/MapPair.css
@@ -1,0 +1,5 @@
+table tbody tr.MapPair_error td {
+  border-top: 0;
+  padding-top: 0;
+  margin-top: 0;
+}

--- a/app/scripts/modules/core/src/forms/mapEditor/MapPair.tsx
+++ b/app/scripts/modules/core/src/forms/mapEditor/MapPair.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
+import { ValidationMessage } from 'core/presentation';
 import { IPipeline } from '../../domain';
 import { SpelText } from '../../widgets';
+import './MapPair.css';
 
 export interface IMapPair {
   key: string;
@@ -21,51 +23,59 @@ export const MapPair = (props: {
   const { keyLabel, labelsLeft, pair, onChange, onDelete, valueLabel, valueCanContainSpel, pipeline } = props;
 
   return (
-    <tr>
-      {labelsLeft && (
-        <td className="table-label">
-          <b>{keyLabel}</b>
-        </td>
-      )}
-      <td>
-        <input
-          className="form-control input input-sm"
-          type="text"
-          value={pair.key}
-          onChange={e => onChange({ key: e.target.value, value: pair.value })}
-        />
-        {pair.error && <div className="error-message">{pair.error}</div>}
-      </td>
-      {labelsLeft && (
-        <td className="table-label">
-          <b>{valueLabel}</b>
-        </td>
-      )}
-      <td>
-        {valueCanContainSpel ? (
-          <SpelText
-            value={pair.value}
-            pipeline={pipeline}
-            docLink={true}
-            onChange={value => onChange({ key: pair.key, value: value })}
-          />
-        ) : (
+    <>
+      <tr>
+        {labelsLeft && (
+          <td className="table-label">
+            <b>{keyLabel}</b>
+          </td>
+        )}
+        <td>
           <input
             className="form-control input input-sm"
             type="text"
-            value={pair.value}
-            onChange={e => onChange({ key: pair.key, value: e.target.value })}
+            value={pair.key}
+            onChange={e => onChange({ key: e.target.value, value: pair.value })}
           />
+        </td>
+        {labelsLeft && (
+          <td className="table-label">
+            <b>{valueLabel}</b>
+          </td>
         )}
-      </td>
-      <td>
-        <div className="form-control-static">
-          <a className="clickable" onClick={onDelete}>
-            <span className="glyphicon glyphicon-trash" />
-            <span className="sr-only">Remove field</span>
-          </a>
-        </div>
-      </td>
-    </tr>
+        <td>
+          {valueCanContainSpel ? (
+            <SpelText
+              value={pair.value}
+              pipeline={pipeline}
+              docLink={true}
+              onChange={value => onChange({ key: pair.key, value: value })}
+            />
+          ) : (
+            <input
+              className="form-control input input-sm"
+              type="text"
+              value={pair.value}
+              onChange={e => onChange({ key: pair.key, value: e.target.value })}
+            />
+          )}
+        </td>
+        <td>
+          <div className="form-control-static">
+            <a className="clickable" onClick={onDelete}>
+              <span className="glyphicon glyphicon-trash" />
+              <span className="sr-only">Remove field</span>
+            </a>
+          </div>
+        </td>
+      </tr>
+      {pair.error && (
+        <tr className="MapPair_error">
+          <td colSpan={3}>
+            <ValidationMessage message={pair.error} type={'error'} />
+          </td>
+        </tr>
+      )}
+    </>
   );
 };

--- a/app/scripts/modules/core/src/presentation/forms/fields/FormikFormField.tsx
+++ b/app/scripts/modules/core/src/presentation/forms/fields/FormikFormField.tsx
@@ -53,7 +53,12 @@ function FormikFormFieldImpl<T = any>(props: IFormikFormFieldImplProps<T>) {
   const [internalValidators, setInternalValidators] = useState([]);
   const addValidator = useCallback((v: IValidator) => setInternalValidators(list => list.concat(v)), []);
   const removeValidator = useCallback((v: IValidator) => setInternalValidators(list => list.filter(x => x !== v)), []);
-  const revalidate = () => formik.validate(formik.values);
+
+  function revalidate() {
+    formik.validateForm();
+  }
+
+  React.useEffect(() => revalidate(), [internalValidators]);
 
   const validation: IFormInputValidation = {
     touched,

--- a/app/scripts/modules/core/src/presentation/forms/validation/useValidationData.spec.tsx
+++ b/app/scripts/modules/core/src/presentation/forms/validation/useValidationData.spec.tsx
@@ -50,11 +50,20 @@ describe('useValidationData hook', () => {
     expect(data.category).toBe('error');
   });
 
-  it('should pass non-string ReactNodes through (such as JSX.Element) with no validation category', () => {
+  it('should pass JSX.Element nodes through, with category: null and hidden: false', () => {
     const element = <div />;
     const data = runUseValidationDataHook(element);
     expect(data.messageNode).toBe(element);
     expect(data.category).toBeNull();
+    expect(data.hidden).toBe(false);
+  });
+
+  it('should pass non-JSX.Element/non-string nodes through, with category: null and hidden: true', () => {
+    const element = { foo: 'bar', baz: [1] };
+    const data = runUseValidationDataHook(element);
+    expect(data.messageNode).toBe(element);
+    expect(data.category).toBeNull();
+    expect(data.hidden).toBe(true);
   });
 
   it('should return async category when asyncMessage is provided', () => {

--- a/app/scripts/modules/core/src/presentation/forms/validation/useValidationData.ts
+++ b/app/scripts/modules/core/src/presentation/forms/validation/useValidationData.ts
@@ -22,15 +22,17 @@ export function useValidationData(validationMessage: React.ReactNode, touched: b
       return { category: null, messageNode: null, hidden: true };
     }
 
-    if (!isString(validationMessage)) {
+    if (React.isValidElement(validationMessage)) {
       return { category: null, messageNode: validationMessage, hidden: false };
+    } else if (isString(validationMessage)) {
+      const [category, messageNode] = categorizeValidationMessage(validationMessage as string);
+
+      const isErrorOrWarning = category === 'error' || category === 'warning';
+      const hidden = !touched && isErrorOrWarning;
+
+      return { category, messageNode, hidden };
     }
 
-    const [category, messageNode] = categorizeValidationMessage(validationMessage);
-
-    const isErrorOrWarning = category === 'error' || category === 'warning';
-    const hidden = !touched && isErrorOrWarning;
-
-    return { category, messageNode, hidden };
+    return { category: null, messageNode: validationMessage, hidden: true };
   }, [validationMessage, touched]);
 }


### PR DESCRIPTION
Closes https://github.com/spinnaker/spinnaker/issues/5279

Manual cherry-pick of each of the three commits from [this PR](https://github.com/spinnaker/deck/pull/7601) into the 1.17 release branch.

- fix(core/presentation): MapEditor: Make errors fill the entire row width.
- fix(core/presentation): FormikFormField: call revalidate whenever internal validators change
- fix(core/presentation): pass objects through in useValidationData