### PR TITLE
fix(appconfig): Fix error thrown when slack object is not defined

### DIFF
--- a/app/scripts/modules/core/src/application/config/applicationAttributes.directive.js
+++ b/app/scripts/modules/core/src/application/config/applicationAttributes.directive.js
@@ -111,6 +111,6 @@ module(CORE_APPLICATION_CONFIG_APPLICATIONATTRIBUTES_DIRECTIVE, [
           .catch(() => {});
       };
 
-      this.slackBaseUrl = SETTINGS.slack.baseUrl;
+      this.slackBaseUrl = get(SETTINGS, 'slack.baseUrl', '');
     },
   ]);


### PR DESCRIPTION
Fixes https://github.com/spinnaker/spinnaker/issues/5306

Needs to be cherry picked for 1.18