### PR TITLE
fix(core): display task monitor above page navigator chrome

### DIFF
--- a/app/scripts/modules/core/src/modal/modals.less
+++ b/app/scripts/modules/core/src/modal/modals.less
@@ -285,7 +285,7 @@ html .select2-container-multi {
   bottom: 0;
   left: 0;
   right: 0;
-  z-index: 2;
+  z-index: 6;
 
   .overlay-modal-status {
     padding: 0 30px;


### PR DESCRIPTION
When I refactored this four weeks ago, I changed the z-index from `2` to `6` because I didn't see any reason for it to be `6`.

It's come to our attention that there was, in fact, a reason it was `6` and not `2`.

## `z-index: 6`
<img width="897" alt="Screen Shot 2020-01-13 at 12 46 16 PM" src="https://user-images.githubusercontent.com/73450/72290720-b738aa00-3602-11ea-86d4-10199d03690b.png">

## `z-index: 2`
<img width="895" alt="Screen Shot 2020-01-13 at 12 46 03 PM" src="https://user-images.githubusercontent.com/73450/72290739-c3246c00-3602-11ea-8cb0-f7507f08c8a9.png">
