### PR TITLE
fix(core): do not render the server group warning message in <pre>

### DIFF
--- a/app/scripts/modules/appengine/src/loadBalancer/details/details.controller.ts
+++ b/app/scripts/modules/appengine/src/loadBalancer/details/details.controller.ts
@@ -117,8 +117,7 @@ class AppengineLoadBalancerDetailsController implements IController {
     if (hasAny) {
       if (hasMoreThanOne) {
         const listOfServerGroupNames = serverGroupNames.map(name => `<li>${name}</li>`).join('');
-        return `
-          <div class="alert alert-warning">
+        return `<div class="alert alert-warning">
             <p>
               Deleting <b>${this.loadBalancer.name}</b> will destroy the following server groups:
               <ul>
@@ -128,8 +127,7 @@ class AppengineLoadBalancerDetailsController implements IController {
           </div>
         `;
       } else {
-        return `
-          <div class="alert alert-warning">
+        return `<div class="alert alert-warning">
             <p>
               Deleting <b>${this.loadBalancer.name}</b> will destroy <b>${serverGroupNames[0]}</b>.
             </p>

--- a/app/scripts/modules/appengine/src/serverGroup/details/details.controller.ts
+++ b/app/scripts/modules/appengine/src/serverGroup/details/details.controller.ts
@@ -170,8 +170,7 @@ class AppengineServerGroupDetailsController implements IController {
     const submitMethod = (params: any) =>
       this.serverGroupWriter.enableServerGroup(this.serverGroup, this.app, { ...params });
 
-    const modalBody = `
-      <div class="well well-sm">
+    const modalBody = `<div class="well well-sm">
         <p>
           Enabling <b>${this.serverGroup.name}</b> will set its traffic allocation for
           <b>${this.serverGroup.loadBalancers[0]}</b> to 100%.
@@ -213,8 +212,7 @@ class AppengineServerGroupDetailsController implements IController {
       this.serverGroupWriter.disableServerGroup(this.serverGroup, this.app.name, params);
 
     const expectedAllocations = this.expectedAllocationsAfterDisableOperation(this.serverGroup, this.app);
-    const modalBody = `
-      <div class="well well-sm">
+    const modalBody = `<div class="well well-sm">
         <p>
           For App Engine, a disable operation sets this server group's allocation
           to 0% and sets the other enabled server groups' allocations to their relative proportions
@@ -262,8 +260,7 @@ class AppengineServerGroupDetailsController implements IController {
 
     let modalBody: string;
     if (!this.serverGroup.disabled) {
-      modalBody = `
-        <div class="alert alert-danger">
+      modalBody = `<div class="alert alert-danger">
           <p>Stopping this server group will scale it down to zero instances.</p>
           <p>
             This server group is currently serving traffic from <b>${this.serverGroup.loadBalancers[0]}</b>.

--- a/app/scripts/modules/core/src/pipeline/details/stageSummary.component.ts
+++ b/app/scripts/modules/core/src/pipeline/details/stageSummary.component.ts
@@ -108,8 +108,7 @@ export class StageSummaryController implements IController {
       buttonText: 'Skip',
       askForReason: true,
       submitJustWithReason: true,
-      body: `
-        <div class="alert alert-warning">
+      body: `<div class="alert alert-warning">
           <b>Warning:</b> Skipping this stage may have unpredictable results.
           <ul>
             <li>Mutating changes initiated by this stage will continue and will need to be cleaned up manually.</li>

--- a/app/scripts/modules/core/src/serverGroup/details/serverGroupWarningMessage.service.ts
+++ b/app/scripts/modules/core/src/serverGroup/details/serverGroupWarningMessage.service.ts
@@ -12,15 +12,12 @@ export class ServerGroupWarningMessageService {
   ): void {
     const remainingServerGroups: IServerGroup[] = this.getOtherServerGroupsInCluster(application, serverGroup);
     if (!remainingServerGroups.length) {
-      params.body = `
-        <h4 class="error-message">You are destroying the last Server Group in the Cluster.</h4>
+      params.body = `<h4 class="error-message">You are destroying the last Server Group in the Cluster.</h4>
         <dl class="dl-horizontal dl-narrow">
           <dt>Account: </dt>
           <dd>${serverGroup.account}</dd>
-
           <dt>Region: </dt>
           <dd>${serverGroup.region}</dd>
-
           <dt>Cluster: </dt>
           <dd>${serverGroup.cluster}</dd>
         </dl>`;
@@ -50,8 +47,7 @@ export class ServerGroupWarningMessageService {
       const activeInstancesAfterDisable = totalActiveInstances - serverGroup.instanceCounts.up;
       const activePercentRemaining = Math.round((activeInstancesAfterDisable / totalActiveInstances) * 100);
 
-      params.body = `
-        <h4>You are disabling <b>${serverGroup.instanceCounts.up}</b>
+      params.body = `<h4>You are disabling <b>${serverGroup.instanceCounts.up}</b>
             instance${serverGroup.instanceCounts.up === 1 ? '' : 's'}.</h4>
         <p>This will reduce the cluster to <b>${activePercentRemaining}</b> percent of its current capacity,
            leaving <b>${activeInstancesAfterDisable}</b> instance${activeInstancesAfterDisable === 1 ? '' : 's'} taking


### PR DESCRIPTION
The body is now run through the markdown compiler, which treats 3+ leading spaces as a preformatted text block, which is not what we want.