### PR TITLE
fix(titus): Blank IAM profile unclickable

### DIFF
--- a/app/scripts/modules/titus/src/pipeline/stages/runJob/TitusRunJobStageConfig.tsx
+++ b/app/scripts/modules/titus/src/pipeline/stages/runJob/TitusRunJobStageConfig.tsx
@@ -338,21 +338,18 @@ export class TitusRunJobStageConfig extends React.Component<IStageConfigProps, I
                 required={true}
                 onChange={e => this.stageFieldChanged('cluster.iamProfile', e.target.value)}
               />
+              {!stage.isNew && !stage.cluster.iamProfile && (
+                <a
+                  className="small clickable"
+                  onClick={() => this.stageFieldChanged('cluster.iamProfile', this.defaultIamProfile)}
+                >
+                  Use suggested default
+                </a>
+              )}
             </div>
             <div className="col-md-1 small" style={{ whiteSpace: 'nowrap', paddingLeft: '0px', paddingTop: '7px' }}>
               in <AccountTag account={awsAccount} />
             </div>
-            {!stage.isNew && !stage.cluster.iamProfile && (
-              <div className="checkbox">
-                <label>
-                  <input
-                    type="checkbox"
-                    onChange={() => this.stageFieldChanged('cluster.iamProfile', this.defaultIamProfile)}
-                  />
-                  Use default
-                </label>
-              </div>
-            )}
           </div>
 
           <StageConfigField label="Capacity Group" fieldColumns={4} helpKey="titus.job.capacityGroup">


### PR DESCRIPTION
Believe it or not, the `Use default` (IAM profile) checkbox covered the text field basically rendering it unclickable:
<img width="898" alt="aquachpy_·_pipeline_config" src="https://user-images.githubusercontent.com/1633736/72309777-c46e8c80-3634-11ea-9efa-bb16cf2facc6.png">

The checkbox interaction also feels awkward so instead I switched to a clickable link below the check box instead:
<img width="616" alt="aquachpy_·_pipeline_config" src="https://user-images.githubusercontent.com/1633736/72309863-08619180-3635-11ea-8725-458b799642e9.png">

Et voila, problems solved.