### PR TITLE
chore(core): convert colors to stylesheet variables

### DIFF
--- a/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/chart/LineChartHack.css
+++ b/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/chart/LineChartHack.css
@@ -75,7 +75,7 @@
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  background-color: white;
+  background-color: var(--color-white);
   z-index: 100;
   box-shadow: 1px 1px 2px rgba(61, 61, 61, 0.5);
   padding: 5px 10px;

--- a/app/scripts/modules/core/src/presentation/modal/ModalFooter.module.css
+++ b/app/scripts/modules/core/src/presentation/modal/ModalFooter.module.css
@@ -3,8 +3,8 @@
 
 .footer {
   flex: 0 0 64px;
-  background-color: white;
-  color: white;
+  background-color: var(--color-white);
+  color: var(--color-white);
   display: flex;
   justify-content: center;
   align-items: center;

--- a/app/scripts/modules/core/src/presentation/modal/ModalHeader.module.css
+++ b/app/scripts/modules/core/src/presentation/modal/ModalHeader.module.css
@@ -9,7 +9,7 @@
 .header {
   flex: 1 0 auto;
   background-color: headerColor;
-  color: white;
+  color: var(--color-white);
   justify-content: center;
   display: flex;
   align-items: center;

--- a/app/scripts/modules/core/src/search/widgets/search.less
+++ b/app/scripts/modules/core/src/search/widgets/search.less
@@ -55,11 +55,9 @@
     }
 
     &.search__input--focus {
-      @color: @input-border-focus;
-      @color-rgba: rgba(red(@color), green(@color), blue(@color), 0.6);
-      border-color: @color;
+      border-color: var(--color-accent);
       outline: 0;
-      .box-shadow(~'inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px @{color-rgba}');
+      .box-shadow(~'inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px -2px var(--color-accent)');
     }
 
     &.search__input--blur {


### PR DESCRIPTION
These red warnings have been driving me a little crazy when I run deck locally:
<img width="795" alt="Screen Shot 2020-01-15 at 10 26 43 AM" src="https://user-images.githubusercontent.com/73450/72460397-9054b200-3781-11ea-922c-807756d2e93f.png">

This change gets rid of those warnings.

The only thing that changes visually is the border/shadow on the v2 search input when it's focused:

_Current_
<img width="434" alt="Screen Shot 2020-01-15 at 10 20 58 AM" src="https://user-images.githubusercontent.com/73450/72460474-b8dcac00-3781-11ea-9b78-bbdbd7e1fb81.png">

_This PR_
<img width="432" alt="Screen Shot 2020-01-15 at 10 20 48 AM" src="https://user-images.githubusercontent.com/73450/72460491-c09c5080-3781-11ea-97d4-69fe592312ad.png">

The CSS for the box-shadow is kind of kludgy. I set the `spread-radius` to a negative value to emulate a faded color. Realistically, our users are not going to notice this change, and it's all going to be rewritten in year so these styles will go away.