### PR TITLE
fix(aws): Icmp port range should default to a port in range

### DIFF
--- a/app/scripts/modules/amazon/src/securityGroup/configure/configSecurityGroup.mixin.controller.js
+++ b/app/scripts/modules/amazon/src/securityGroup/configure/configSecurityGroup.mixin.controller.js
@@ -337,6 +337,15 @@ module(AMAZON_SECURITYGROUP_CONFIGURE_CONFIGSECURITYGROUP_MIXIN_CONTROLLER, [
       ruleset.splice(index, 1);
     };
 
+    ctrl.updateRuleType = function(type, ruleset, index) {
+      const rule = ruleset[index];
+      rule.type = type;
+      if (type === 'icmp') {
+        rule.startPort = 0;
+        rule.endPort = 0;
+      }
+    };
+
     ctrl.dismissRemovedRules = function() {
       $scope.state.removedRules = [];
       ModalWizard.markClean('Ingress');

--- a/app/scripts/modules/amazon/src/securityGroup/configure/configSecurityGroup.mixin.controller.js
+++ b/app/scripts/modules/amazon/src/securityGroup/configure/configSecurityGroup.mixin.controller.js
@@ -339,7 +339,6 @@ module(AMAZON_SECURITYGROUP_CONFIGURE_CONFIGSECURITYGROUP_MIXIN_CONTROLLER, [
 
     ctrl.updateRuleType = function(type, ruleset, index) {
       const rule = ruleset[index];
-      rule.type = type;
       if (type === 'icmp') {
         rule.startPort = 0;
         rule.endPort = 0;

--- a/app/scripts/modules/amazon/src/securityGroup/configure/createSecurityGroupIngress.html
+++ b/app/scripts/modules/amazon/src/securityGroup/configure/createSecurityGroupIngress.html
@@ -55,6 +55,7 @@
                   class="form-control input-sm"
                   ng-model="rule.type"
                   ng-options="protocol as protocol.toUpperCase() for protocol in ['tcp', 'udp', 'icmp']"
+                  ng-change="ctrl.updateRuleType(rule.type, securityGroup.securityGroupIngress, $index)"
                   required
                 ></select>
               </td>


### PR DESCRIPTION
When adding a new security group ingress rule, selecting ICMP protocol defaults to port 7001. This is out of range for ICMP. Users recommended defaulting the start and end port to 0.

<img width="589" alt="Screen Shot 2020-01-15 at 12 25 47 PM" src="https://user-images.githubusercontent.com/26560152/72468511-314b6900-3792-11ea-8b7a-6a4e28511c52.png">
