### PR TITLE
fix(stage): Remove extraneous $ character from Import Delivery Config details

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/managed/ImportDeliveryConfigExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/managed/ImportDeliveryConfigExecutionDetails.tsx
@@ -38,7 +38,7 @@ export function ImportDeliveryConfigExecutionDetails(props: IExecutionDetailsSec
         <div>
           <div className="alert alert-danger">
             Something went wrong during import:
-            <pre>${stage.context.error}</pre>
+            <pre>{stage.context.error}</pre>
           </div>
         </div>
       )}


### PR DESCRIPTION
What the title says... Silly mistake.