### PR TITLE
feat(core): allow yaml responses from ApiService

### DIFF
--- a/app/scripts/modules/core/src/api/ApiService.spec.ts
+++ b/app/scripts/modules/core/src/api/ApiService.spec.ts
@@ -86,6 +86,22 @@ describe('API Service', function() {
       expect(rejected).toBe(false);
     });
 
+    it('application/x-yaml;charset=utf-8 is fine, too', () => {
+      spyOn(AuthenticationInitializer, 'reauthenticateUser').and.callFake(noop);
+      $httpBackend
+        .expectGET(`${baseUrl}/yaml`)
+        .respond(200, '---\nfoo: bar', { 'content-type': 'application/x-yaml;charset=utf-8' });
+
+      let rejected = false;
+      API.one('yaml')
+        .get()
+        .then(noop, () => (rejected = true));
+
+      $httpBackend.flush();
+      expect((AuthenticationInitializer.reauthenticateUser as Spy).calls.count()).toBe(0);
+      expect(rejected).toBe(false);
+    });
+
     it('string responses starting with <html should trigger a reauthentication request and reject', function() {
       spyOn(AuthenticationInitializer, 'reauthenticateUser').and.callFake(noop);
       $httpBackend.expectGET(`${baseUrl}/fine`).respond(200, 'this is fine');

--- a/app/scripts/modules/core/src/api/ApiService.ts
+++ b/app/scripts/modules/core/src/api/ApiService.ts
@@ -42,9 +42,11 @@ export class API {
       const contentType = result.headers('content-type');
       if (contentType) {
         const isJson = contentType.match(/application\/(.+\+)?json/); // e.g application/json, application/hal+json
+        // e.g. application/yaml, application/x-yaml; it's regex, let's not get too fancy
+        const isYaml = contentType.match(/application\/(.+-)?yaml/);
         const isZeroLengthHtml = contentType.includes('text/html') && result.data === '';
         const isZeroLengthText = contentType.includes('text/plain') && result.data === '';
-        if (!(isJson || isZeroLengthHtml || isZeroLengthText)) {
+        if (!(isJson || isYaml || isZeroLengthHtml || isZeroLengthText)) {
           AuthenticationInitializer.reauthenticateUser();
           reject(new InvalidAPIResponse(API.invalidContentMessage, result));
         }


### PR DESCRIPTION
Managed Delivery export returns `application/x-yaml;charset=utf-8` as its `content-type` header, so let's allow that.