### PR TITLE
fix(core): allow newlines in CopyToClipboard

### DIFF
--- a/app/scripts/modules/core/src/utils/clipboard/CopyToClipboard.spec.tsx
+++ b/app/scripts/modules/core/src/utils/clipboard/CopyToClipboard.spec.tsx
@@ -9,7 +9,7 @@ describe('<CopyToClipboard />', () => {
 
   it('renders an input with the text value', () => {
     const wrapper = mount(<CopyToClipboard toolTip="Copy Rebel Girl" text="Rebel Girl" />);
-    const input = wrapper.find('input');
+    const input = wrapper.find('textarea');
     expect(input.get(0).props.value).toEqual('Rebel Girl');
   });
 

--- a/app/scripts/modules/core/src/utils/clipboard/CopyToClipboard.tsx
+++ b/app/scripts/modules/core/src/utils/clipboard/CopyToClipboard.tsx
@@ -32,7 +32,7 @@ export class CopyToClipboard extends React.Component<ICopyToClipboardProps, ICop
     displayText: false,
   };
 
-  private inputRef: React.RefObject<HTMLInputElement> = React.createRef();
+  private inputRef: React.RefObject<HTMLTextAreaElement> = React.createRef();
   private mounted = false;
 
   constructor(props: ICopyToClipboardProps) {
@@ -67,7 +67,7 @@ export class CopyToClipboard extends React.Component<ICopyToClipboardProps, ICop
       label: analyticsLabel || text,
     });
 
-    const node: HTMLInputElement = this.inputRef.current;
+    const node: HTMLTextAreaElement = this.inputRef.current;
     node.focus();
     node.select();
 
@@ -116,27 +116,21 @@ export class CopyToClipboard extends React.Component<ICopyToClipboardProps, ICop
   };
 
   public render() {
-    const { buttonInnerNode, toolTip, text = '' } = this.props;
+    const { buttonInnerNode, toolTip, text = '', className = 'btn btn-xs btn-default clipboard-btn' } = this.props;
 
     const copyButton = (
-      <button
-        onClick={this.handleClick}
-        className="btn btn-xs btn-default clipboard-btn"
-        uib-tooltip={toolTip}
-        aria-label="Copy to clipboard"
-      >
+      <button onClick={this.handleClick} className={className} uib-tooltip={toolTip} aria-label="Copy to clipboard">
         {buttonInnerNode ? buttonInnerNode : <span className="glyphicon glyphicon-copy" />}
       </button>
     );
 
     return (
       <>
-        <input
+        <textarea
           onChange={e => e} // no-op to prevent warnings
           ref={this.inputRef}
           value={text}
-          type="text"
-          style={{ zIndex: -1, position: 'fixed', opacity: 0 }}
+          style={{ zIndex: -1, position: 'fixed', opacity: 0, top: 0, left: 0 }}
         />
         {toolTip ? this.renderTooltip(copyButton) : copyButton}
       </>


### PR DESCRIPTION
1. The text input replaces newline characters with single spaces, which is no good with YAML.
2. Explicitly setting the position on the hidden input keeps it from taking up space. I was running into a situation where I had a textarea in a modal and, when I clicked the copy to clipboard button, it put the input next to the textarea, which threw off the layout.
3. Someone added the `className` prop for the button attribute but never wired it up, so I wired it up.