### PR TITLE
fix(core): correct method signature for buildServerGroupCommandFromExisting

### DIFF
--- a/app/scripts/modules/core/src/serverGroup/configure/common/serverGroupCommandBuilder.service.ts
+++ b/app/scripts/modules/core/src/serverGroup/configure/common/serverGroupCommandBuilder.service.ts
@@ -172,7 +172,7 @@ export class ServerGroupCommandBuilderService {
     return this.getDelegate(provider, skin).buildNewServerGroupCommand(application, options);
   }
 
-  public buildServerGroupCommandFromExisting(application: Application, serverGroup: any, mode: string): any {
+  public buildServerGroupCommandFromExisting(application: Application, serverGroup: any, mode?: string): any {
     return this.getDelegate(serverGroup.type).buildServerGroupCommandFromExisting(application, serverGroup, mode);
   }
 


### PR DESCRIPTION
I don't know why I ran into this, and it doesn't matter much (nothing blows up, no compiler errors or warnings), but every place this is implemented provides a default value for `mode`, and it's frequently called with just two arguments, so let's reflect that here.