### PR TITLE
feat(core): always show copied tooltip on CopyToClipboard

### DIFF
--- a/app/scripts/modules/core/src/utils/clipboard/CopyToClipboard.spec.tsx
+++ b/app/scripts/modules/core/src/utils/clipboard/CopyToClipboard.spec.tsx
@@ -23,6 +23,20 @@ describe('<CopyToClipboard />', () => {
     expect(overlay.innerText).toEqual('Copy Rebel Girl');
   });
 
+  it('Shows tooltip when button clicked, even if no default tooltip configured', () => {
+    const wrapper = mount(<CopyToClipboard text="No Tooltip" />);
+    const button = wrapper.find('button');
+    button.simulate('mouseOver');
+
+    // Grab the overlay from document by generated ID
+    let overlay = document.getElementById('clipboardValue-No-Tooltip');
+    expect(overlay).toBeFalsy();
+
+    button.simulate('click');
+    overlay = document.getElementById('clipboardValue-No-Tooltip');
+    expect(overlay.innerText).toEqual('Copied!');
+  });
+
   it('fires a GA event on click', () => {
     const wrapper = mount(<CopyToClipboard toolTip="Copy Rebel Girl" text="Rebel Girl" />);
     const button = wrapper.find('button');

--- a/app/scripts/modules/core/src/utils/clipboard/CopyToClipboard.tsx
+++ b/app/scripts/modules/core/src/utils/clipboard/CopyToClipboard.tsx
@@ -98,6 +98,10 @@ export class CopyToClipboard extends React.Component<ICopyToClipboardProps, ICop
       shouldUpdatePosition,
     };
 
+    if (!copy) {
+      return children;
+    }
+
     return (
       <OverlayTrigger
         defaultOverlayShown={persistOverlay}
@@ -116,10 +120,10 @@ export class CopyToClipboard extends React.Component<ICopyToClipboardProps, ICop
   };
 
   public render() {
-    const { buttonInnerNode, toolTip, text = '', className = 'btn btn-xs btn-default clipboard-btn' } = this.props;
+    const { buttonInnerNode, text = '', className = 'btn btn-xs btn-default clipboard-btn' } = this.props;
 
     const copyButton = (
-      <button onClick={this.handleClick} className={className} uib-tooltip={toolTip} aria-label="Copy to clipboard">
+      <button onClick={this.handleClick} className={className} aria-label="Copy to clipboard">
         {buttonInnerNode ? buttonInnerNode : <span className="glyphicon glyphicon-copy" />}
       </button>
     );
@@ -132,7 +136,7 @@ export class CopyToClipboard extends React.Component<ICopyToClipboardProps, ICop
           value={text}
           style={{ zIndex: -1, position: 'fixed', opacity: 0, top: 0, left: 0 }}
         />
-        {toolTip ? this.renderTooltip(copyButton) : copyButton}
+        {this.renderTooltip(copyButton)}
       </>
     );
   }


### PR DESCRIPTION
I think we always want to provide user feedback when clicking a "Copy to Clipboard" button that something was copied — especially since we do it almost every time (except one, and soon another).

This change lets you add a "Copy to Clipboard" button with custom text and still get the "Copied!" tooltip when clicking the button.