### PR TITLE
refactor(*): do not use angular to register cloud providers

### DIFF
--- a/app/scripts/app.ts
+++ b/app/scripts/app.ts
@@ -15,7 +15,7 @@ import { TITUS_MODULE } from '@spinnaker/titus';
 import { ECS_MODULE } from '@spinnaker/ecs';
 import '@spinnaker/cloudfoundry';
 import { AZURE_MODULE } from '@spinnaker/azure';
-import { HUAWEICLOUD_MODULE } from '@spinnaker/huaweicloud';
+import '@spinnaker/huaweicloud';
 import { DCOS_DCOS_MODULE } from './modules/dcos/dcos.module';
 
 module('netflix.spinnaker', [
@@ -33,5 +33,4 @@ module('netflix.spinnaker', [
   KUBERNETES_V2_MODULE,
   KAYENTA_MODULE,
   TITUS_MODULE,
-  HUAWEICLOUD_MODULE,
 ]);

--- a/app/scripts/modules/amazon/src/aws.module.ts
+++ b/app/scripts/modules/amazon/src/aws.module.ts
@@ -105,76 +105,76 @@ module(AMAZON_MODULE, [
   CLOUDFORMATION_TEMPLATE_ENTRY,
   CLOUD_FORMATION_CHANGE_SET_INFO,
   AWS_EVALUATE_CLOUD_FORMATION_CHANGE_SET_EXECUTION_SERVICE,
-]).config(() => {
-  CloudProviderRegistry.registerProvider('aws', {
-    name: 'Amazon',
-    logo: {
-      path: require('./logo/amazon.logo.svg'),
-    },
-    image: {
-      reader: AwsImageReader,
-    },
-    serverGroup: {
-      transformer: 'awsServerGroupTransformer',
-      detailsActions: AmazonServerGroupActions,
-      detailsGetter: amazonServerGroupDetailsGetter,
-      detailsSections: [
-        AmazonInfoDetailsSection,
-        AmazonCapacityDetailsSection,
-        HealthDetailsSection,
-        LaunchConfigDetailsSection,
-        SecurityGroupsDetailsSection,
-        ScalingProcessesDetailsSection,
-        ScalingPoliciesDetailsSection,
-        ScheduledActionsDetailsSection,
-        TagsDetailsSection,
-        PackageDetailsSection,
-        AdvancedSettingsDetailsSection,
-        LogsDetailsSection,
-      ],
-      CloneServerGroupModal: AmazonCloneServerGroupModal,
-      commandBuilder: 'awsServerGroupCommandBuilder',
-      configurationService: 'awsServerGroupConfigurationService',
-      scalingActivitiesEnabled: true,
-    },
-    instance: {
-      instanceTypeService: 'awsInstanceTypeService',
-      detailsTemplateUrl: require('./instance/details/instanceDetails.html'),
-      detailsController: 'awsInstanceDetailsCtrl',
-    },
-    loadBalancer: {
-      transformer: AwsLoadBalancerTransformer,
-      detailsTemplateUrl: require('./loadBalancer/details/loadBalancerDetails.html'),
-      detailsController: 'awsLoadBalancerDetailsCtrl',
-      CreateLoadBalancerModal: AmazonLoadBalancerChoiceModal,
-      targetGroupDetailsTemplateUrl: require('./loadBalancer/details/targetGroupDetails.html'),
-      targetGroupDetailsController: 'awsTargetGroupDetailsCtrl',
-      ClusterContainer: AmazonLoadBalancerClusterContainer,
-      LoadBalancersTag: AmazonLoadBalancersTag,
-    },
-    function: {
-      details: AmazonFunctionDetails,
-      CreateFunctionModal: CreateLambdaFunction,
-      transformer: AwsFunctionTransformer,
-    },
-    securityGroup: {
-      transformer: 'awsSecurityGroupTransformer',
-      reader: 'awsSecurityGroupReader',
-      detailsTemplateUrl: require('./securityGroup/details/securityGroupDetail.html'),
-      detailsController: 'awsSecurityGroupDetailsCtrl',
-      createSecurityGroupTemplateUrl: require('./securityGroup/configure/createSecurityGroup.html'),
-      createSecurityGroupController: 'awsCreateSecurityGroupCtrl',
-    },
-    subnet: {
-      renderer: 'awsSubnetRenderer',
-    },
-    search: {
-      resultFormatter: 'awsSearchResultFormatter',
-    },
-    applicationProviderFields: {
-      templateUrl: require('./applicationProviderFields/awsFields.html'),
-    },
-  });
+]);
+
+CloudProviderRegistry.registerProvider('aws', {
+  name: 'Amazon',
+  logo: {
+    path: require('./logo/amazon.logo.svg'),
+  },
+  image: {
+    reader: AwsImageReader,
+  },
+  serverGroup: {
+    transformer: 'awsServerGroupTransformer',
+    detailsActions: AmazonServerGroupActions,
+    detailsGetter: amazonServerGroupDetailsGetter,
+    detailsSections: [
+      AmazonInfoDetailsSection,
+      AmazonCapacityDetailsSection,
+      HealthDetailsSection,
+      LaunchConfigDetailsSection,
+      SecurityGroupsDetailsSection,
+      ScalingProcessesDetailsSection,
+      ScalingPoliciesDetailsSection,
+      ScheduledActionsDetailsSection,
+      TagsDetailsSection,
+      PackageDetailsSection,
+      AdvancedSettingsDetailsSection,
+      LogsDetailsSection,
+    ],
+    CloneServerGroupModal: AmazonCloneServerGroupModal,
+    commandBuilder: 'awsServerGroupCommandBuilder',
+    configurationService: 'awsServerGroupConfigurationService',
+    scalingActivitiesEnabled: true,
+  },
+  instance: {
+    instanceTypeService: 'awsInstanceTypeService',
+    detailsTemplateUrl: require('./instance/details/instanceDetails.html'),
+    detailsController: 'awsInstanceDetailsCtrl',
+  },
+  loadBalancer: {
+    transformer: AwsLoadBalancerTransformer,
+    detailsTemplateUrl: require('./loadBalancer/details/loadBalancerDetails.html'),
+    detailsController: 'awsLoadBalancerDetailsCtrl',
+    CreateLoadBalancerModal: AmazonLoadBalancerChoiceModal,
+    targetGroupDetailsTemplateUrl: require('./loadBalancer/details/targetGroupDetails.html'),
+    targetGroupDetailsController: 'awsTargetGroupDetailsCtrl',
+    ClusterContainer: AmazonLoadBalancerClusterContainer,
+    LoadBalancersTag: AmazonLoadBalancersTag,
+  },
+  function: {
+    details: AmazonFunctionDetails,
+    CreateFunctionModal: CreateLambdaFunction,
+    transformer: AwsFunctionTransformer,
+  },
+  securityGroup: {
+    transformer: 'awsSecurityGroupTransformer',
+    reader: 'awsSecurityGroupReader',
+    detailsTemplateUrl: require('./securityGroup/details/securityGroupDetail.html'),
+    detailsController: 'awsSecurityGroupDetailsCtrl',
+    createSecurityGroupTemplateUrl: require('./securityGroup/configure/createSecurityGroup.html'),
+    createSecurityGroupController: 'awsCreateSecurityGroupCtrl',
+  },
+  subnet: {
+    renderer: 'awsSubnetRenderer',
+  },
+  search: {
+    resultFormatter: 'awsSearchResultFormatter',
+  },
+  applicationProviderFields: {
+    templateUrl: require('./applicationProviderFields/awsFields.html'),
+  },
 });
 
 DeploymentStrategyRegistry.registerProvider('aws', [

--- a/app/scripts/modules/amazon/src/function/details/AmazonFunctionDetails.tsx
+++ b/app/scripts/modules/amazon/src/function/details/AmazonFunctionDetails.tsx
@@ -15,6 +15,8 @@ import { isEmpty } from 'lodash';
 import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
 
+import 'amazon/aws.module';
+
 export interface IFunctionFromStateParams {
   account: string;
   region: string;

--- a/app/scripts/modules/appengine/src/appengine.module.ts
+++ b/app/scripts/modules/appengine/src/appengine.module.ts
@@ -41,33 +41,33 @@ module(APPENGINE_MODULE, [
   APPENGINE_SERVER_GROUP_TRANSFORMER,
   APPENGINE_SERVER_GROUP_WRITER,
   CONFIG_FILE_ARTIFACT_LIST,
-]).config(() => {
-  CloudProviderRegistry.registerProvider('appengine', {
-    name: 'App Engine',
-    instance: {
-      detailsTemplateUrl: require('./instance/details/details.html'),
-      detailsController: 'appengineInstanceDetailsCtrl',
-    },
-    serverGroup: {
-      transformer: 'appengineServerGroupTransformer',
-      detailsController: 'appengineServerGroupDetailsCtrl',
-      detailsTemplateUrl: require('./serverGroup/details/details.html'),
-      commandBuilder: 'appengineServerGroupCommandBuilder',
-      cloneServerGroupController: 'appengineCloneServerGroupCtrl',
-      cloneServerGroupTemplateUrl: require('./serverGroup/configure/wizard/serverGroupWizard.html'),
-      skipUpstreamStageCheck: true,
-    },
-    loadBalancer: {
-      transformer: 'appengineLoadBalancerTransformer',
-      createLoadBalancerTemplateUrl: require('./loadBalancer/configure/wizard/wizard.html'),
-      createLoadBalancerController: 'appengineLoadBalancerWizardCtrl',
-      detailsTemplateUrl: require('./loadBalancer/details/details.html'),
-      detailsController: 'appengineLoadBalancerDetailsCtrl',
-    },
-    logo: {
-      path: require('./logo/appengine.logo.svg'),
-    },
-  });
+]);
+
+CloudProviderRegistry.registerProvider('appengine', {
+  name: 'App Engine',
+  instance: {
+    detailsTemplateUrl: require('./instance/details/details.html'),
+    detailsController: 'appengineInstanceDetailsCtrl',
+  },
+  serverGroup: {
+    transformer: 'appengineServerGroupTransformer',
+    detailsController: 'appengineServerGroupDetailsCtrl',
+    detailsTemplateUrl: require('./serverGroup/details/details.html'),
+    commandBuilder: 'appengineServerGroupCommandBuilder',
+    cloneServerGroupController: 'appengineCloneServerGroupCtrl',
+    cloneServerGroupTemplateUrl: require('./serverGroup/configure/wizard/serverGroupWizard.html'),
+    skipUpstreamStageCheck: true,
+  },
+  loadBalancer: {
+    transformer: 'appengineLoadBalancerTransformer',
+    createLoadBalancerTemplateUrl: require('./loadBalancer/configure/wizard/wizard.html'),
+    createLoadBalancerController: 'appengineLoadBalancerWizardCtrl',
+    detailsTemplateUrl: require('./loadBalancer/details/details.html'),
+    detailsController: 'appengineLoadBalancerDetailsCtrl',
+  },
+  logo: {
+    path: require('./logo/appengine.logo.svg'),
+  },
 });
 
 DeploymentStrategyRegistry.registerProvider('appengine', ['custom']);

--- a/app/scripts/modules/azure/src/azure.module.ts
+++ b/app/scripts/modules/azure/src/azure.module.ts
@@ -53,47 +53,47 @@ module(AZURE_MODULE, [
   AZURE_SECURITYGROUP_SECURITYGROUP_READER,
   AZURE_IMAGE_IMAGE_READER,
   AZURE_VALIDATION_APPLICATIONNAME_VALIDATOR,
-]).config(function() {
-  CloudProviderRegistry.registerProvider('azure', {
-    name: 'Azure',
-    logo: {
-      path: require('./logo/logo_azure.png'),
-    },
-    image: {
-      reader: 'azureImageReader',
-    },
-    serverGroup: {
-      transformer: 'azureServerGroupTransformer',
-      detailsTemplateUrl: require('./serverGroup/details/serverGroupDetails.html'),
-      detailsController: 'azureServerGroupDetailsCtrl',
-      cloneServerGroupTemplateUrl: require('./serverGroup/configure/wizard/serverGroupWizard.html'),
-      cloneServerGroupController: 'azureCloneServerGroupCtrl',
-      commandBuilder: 'azureServerGroupCommandBuilder',
-      configurationService: 'azureServerGroupConfigurationService',
-    },
-    instance: {
-      instanceTypeService: 'azureInstanceTypeService',
-      detailsTemplateUrl: require('./instance/details/instanceDetails.html'),
-      detailsController: 'azureInstanceDetailsCtrl',
-    },
-    loadBalancer: {
-      transformer: 'azureLoadBalancerTransformer',
-      detailsTemplateUrl: require('./loadBalancer/details/loadBalancerDetail.html'),
-      detailsController: 'azureLoadBalancerDetailsCtrl',
-      createLoadBalancerTemplateUrl: require('./loadBalancer/configure/createLoadBalancer.html'),
-      createLoadBalancerController: 'azureCreateLoadBalancerCtrl',
-      CreateLoadBalancerModal: require('./loadBalancer/configure/AzureLoadBalancerChoiceModal')
-        .AzureLoadBalancerChoiceModal,
-    },
-    securityGroup: {
-      transformer: 'azureSecurityGroupTransformer',
-      reader: 'azureSecurityGroupReader',
-      detailsTemplateUrl: require('./securityGroup/details/securityGroupDetail.html'),
-      detailsController: 'azureSecurityGroupDetailsCtrl',
-      createSecurityGroupTemplateUrl: require('./securityGroup/configure/createSecurityGroup.html'),
-      createSecurityGroupController: 'azureCreateSecurityGroupCtrl',
-    },
-  });
+]);
+
+CloudProviderRegistry.registerProvider('azure', {
+  name: 'Azure',
+  logo: {
+    path: require('./logo/logo_azure.png'),
+  },
+  image: {
+    reader: 'azureImageReader',
+  },
+  serverGroup: {
+    transformer: 'azureServerGroupTransformer',
+    detailsTemplateUrl: require('./serverGroup/details/serverGroupDetails.html'),
+    detailsController: 'azureServerGroupDetailsCtrl',
+    cloneServerGroupTemplateUrl: require('./serverGroup/configure/wizard/serverGroupWizard.html'),
+    cloneServerGroupController: 'azureCloneServerGroupCtrl',
+    commandBuilder: 'azureServerGroupCommandBuilder',
+    configurationService: 'azureServerGroupConfigurationService',
+  },
+  instance: {
+    instanceTypeService: 'azureInstanceTypeService',
+    detailsTemplateUrl: require('./instance/details/instanceDetails.html'),
+    detailsController: 'azureInstanceDetailsCtrl',
+  },
+  loadBalancer: {
+    transformer: 'azureLoadBalancerTransformer',
+    detailsTemplateUrl: require('./loadBalancer/details/loadBalancerDetail.html'),
+    detailsController: 'azureLoadBalancerDetailsCtrl',
+    createLoadBalancerTemplateUrl: require('./loadBalancer/configure/createLoadBalancer.html'),
+    createLoadBalancerController: 'azureCreateLoadBalancerCtrl',
+    CreateLoadBalancerModal: require('./loadBalancer/configure/AzureLoadBalancerChoiceModal')
+      .AzureLoadBalancerChoiceModal,
+  },
+  securityGroup: {
+    transformer: 'azureSecurityGroupTransformer',
+    reader: 'azureSecurityGroupReader',
+    detailsTemplateUrl: require('./securityGroup/details/securityGroupDetail.html'),
+    detailsController: 'azureSecurityGroupDetailsCtrl',
+    createSecurityGroupTemplateUrl: require('./securityGroup/configure/createSecurityGroup.html'),
+    createSecurityGroupController: 'azureCreateSecurityGroupCtrl',
+  },
 });
 
 DeploymentStrategyRegistry.registerProvider('azure', ['redblack']);

--- a/app/scripts/modules/core/src/cloudProvider/CloudProviderRegistry.spec.ts
+++ b/app/scripts/modules/core/src/cloudProvider/CloudProviderRegistry.spec.ts
@@ -1,16 +1,21 @@
 import { mock } from 'angular';
 
 import { CloudProviderRegistry } from './CloudProviderRegistry';
+import { SETTINGS } from 'core/config';
 
 describe('CloudProviderRegistry: API', function() {
+  beforeEach(() => {
+    SETTINGS.providers.aws2 = { defaults: {} };
+  });
+  afterEach(SETTINGS.resetToOriginal);
   describe('registration', function() {
     it(
       'registers providers',
       mock.inject(function() {
-        expect(CloudProviderRegistry.getProvider('aws')).toBeNull();
+        expect(CloudProviderRegistry.getProvider('aws2')).toBeNull();
         const config = { name: 'a', key: 'a' };
-        CloudProviderRegistry.registerProvider('aws', config);
-        expect(CloudProviderRegistry.getProvider('aws')).toEqual(config);
+        CloudProviderRegistry.registerProvider('aws2', config);
+        expect(CloudProviderRegistry.getProvider('aws2')).toEqual(config);
       }),
     );
   });
@@ -29,42 +34,42 @@ describe('CloudProviderRegistry: API', function() {
     });
 
     it('returns simple or nested properties', function() {
-      CloudProviderRegistry.registerProvider('aws', this.config);
-      expect(CloudProviderRegistry.getValue('aws', 'key')).toEqual('a');
-      expect(CloudProviderRegistry.getValue('aws', 'nested')).toEqual(this.config.nested);
-      expect(CloudProviderRegistry.getValue('aws', 'nested.good')).toEqual('nice');
+      CloudProviderRegistry.registerProvider('aws2', this.config);
+      expect(CloudProviderRegistry.getValue('aws2', 'key')).toEqual('a');
+      expect(CloudProviderRegistry.getValue('aws2', 'nested')).toEqual(this.config.nested);
+      expect(CloudProviderRegistry.getValue('aws2', 'nested.good')).toEqual('nice');
     });
 
     it('returns a copy of properties, not actual registered values', function() {
-      CloudProviderRegistry.registerProvider('aws', this.config);
+      CloudProviderRegistry.registerProvider('aws2', this.config);
 
-      expect(CloudProviderRegistry.getValue('aws', 'nested')).not.toBe(this.config.nested);
-      expect(CloudProviderRegistry.getValue('aws', 'nested')).toEqual(this.config.nested);
+      expect(CloudProviderRegistry.getValue('aws2', 'nested')).not.toBe(this.config.nested);
+      expect(CloudProviderRegistry.getValue('aws2', 'nested')).toEqual(this.config.nested);
 
       // the above tests should be sufficient, but just to really drive home the point
-      const nested = CloudProviderRegistry.getValue('aws', 'nested');
+      const nested = CloudProviderRegistry.getValue('aws2', 'nested');
       expect(nested.good).toBe('nice');
       nested.good = 'mean';
-      expect(CloudProviderRegistry.getValue('aws', 'nested').good).toBe('nice');
+      expect(CloudProviderRegistry.getValue('aws2', 'nested').good).toBe('nice');
     });
 
     it(
       'returns falsy values',
       mock.inject(function() {
-        CloudProviderRegistry.registerProvider('aws', this.config);
-        expect(CloudProviderRegistry.getValue('aws', 'nested.falsy')).toBe(false);
-        expect(CloudProviderRegistry.getValue('aws', 'nested.nully')).toBe(null);
-        expect(CloudProviderRegistry.getValue('aws', 'nested.zero')).toBe(0);
+        CloudProviderRegistry.registerProvider('aws2', this.config);
+        expect(CloudProviderRegistry.getValue('aws2', 'nested.falsy')).toBe(false);
+        expect(CloudProviderRegistry.getValue('aws2', 'nested.nully')).toBe(null);
+        expect(CloudProviderRegistry.getValue('aws2', 'nested.zero')).toBe(0);
       }),
     );
 
     it(
       'returns null when provider or property is not found',
       mock.inject(function() {
-        CloudProviderRegistry.registerProvider('aws', this.config);
+        CloudProviderRegistry.registerProvider('aws2', this.config);
         expect(CloudProviderRegistry.getValue('gce', 'a')).toBe(null);
-        expect(CloudProviderRegistry.getValue('aws', 'b')).toBe(null);
-        expect(CloudProviderRegistry.getValue('aws', 'a.b')).toBe(null);
+        expect(CloudProviderRegistry.getValue('aws2', 'b')).toBe(null);
+        expect(CloudProviderRegistry.getValue('aws2', 'a.b')).toBe(null);
       }),
     );
   });
@@ -83,19 +88,19 @@ describe('CloudProviderRegistry: API', function() {
     });
 
     it('returns true on simple or nested properties', function() {
-      CloudProviderRegistry.registerProvider('aws', this.config);
-      expect(CloudProviderRegistry.hasValue('aws', 'key')).toBe(true);
-      expect(CloudProviderRegistry.hasValue('aws', 'nested')).toBe(true);
-      expect(CloudProviderRegistry.hasValue('aws', 'nested.good')).toBe(true);
-      expect(CloudProviderRegistry.hasValue('aws', 'nested.falsy')).toBe(true);
-      expect(CloudProviderRegistry.hasValue('aws', 'nested.zero')).toBe(true);
+      CloudProviderRegistry.registerProvider('aws2', this.config);
+      expect(CloudProviderRegistry.hasValue('aws2', 'key')).toBe(true);
+      expect(CloudProviderRegistry.hasValue('aws2', 'nested')).toBe(true);
+      expect(CloudProviderRegistry.hasValue('aws2', 'nested.good')).toBe(true);
+      expect(CloudProviderRegistry.hasValue('aws2', 'nested.falsy')).toBe(true);
+      expect(CloudProviderRegistry.hasValue('aws2', 'nested.zero')).toBe(true);
     });
 
     it('returns false on null properties, non-existent properties or non-existent providers', function() {
-      CloudProviderRegistry.registerProvider('aws', this.config);
-      expect(CloudProviderRegistry.hasValue('aws', 'nested.nully')).toBe(false);
-      expect(CloudProviderRegistry.hasValue('aws', 'nonexistent')).toBe(false);
-      expect(CloudProviderRegistry.hasValue('aws', 'definitely.nonexistent')).toBe(false);
+      CloudProviderRegistry.registerProvider('aws2', this.config);
+      expect(CloudProviderRegistry.hasValue('aws2', 'nested.nully')).toBe(false);
+      expect(CloudProviderRegistry.hasValue('aws2', 'nonexistent')).toBe(false);
+      expect(CloudProviderRegistry.hasValue('aws2', 'definitely.nonexistent')).toBe(false);
       expect(CloudProviderRegistry.hasValue('boo', 'bar')).toBe(false);
       expect(CloudProviderRegistry.hasValue('boo', 'bar.baz')).toBe(false);
     });

--- a/app/scripts/modules/dcos/dcos.module.js
+++ b/app/scripts/modules/dcos/dcos.module.js
@@ -56,35 +56,35 @@ module(DCOS_DCOS_MODULE, [
   DCOS_SERVERGROUP_TRANSFORMER,
   DCOS_VALIDATION_APPLICATIONNAME_VALIDATOR,
   DCOS_COMMON_SELECTFIELD_DIRECTIVE,
-]).config(function() {
-  CloudProviderRegistry.registerProvider('dcos', {
-    name: 'DC/OS',
-    logo: {
-      path: require('./logo/dcos.logo.png'),
-    },
-    instance: {
-      detailsTemplateUrl: require('./instance/details/details.html'),
-      detailsController: 'dcosInstanceDetailsController',
-    },
-    loadBalancer: {
-      transformer: 'dcosLoadBalancerTransformer',
-      detailsTemplateUrl: require('./loadBalancer/details/details.html'),
-      detailsController: 'dcosLoadBalancerDetailsController',
-      createLoadBalancerTemplateUrl: require('./loadBalancer/configure/wizard/createWizard.html'),
-      createLoadBalancerController: 'dcosUpsertLoadBalancerController',
-    },
-    image: {
-      reader: 'dcosImageReader',
-    },
-    serverGroup: {
-      skipUpstreamStageCheck: true,
-      transformer: 'dcosServerGroupTransformer',
-      detailsTemplateUrl: require('./serverGroup/details/details.html'),
-      detailsController: 'dcosServerGroupDetailsController',
-      cloneServerGroupController: 'dcosCloneServerGroupController',
-      cloneServerGroupTemplateUrl: require('./serverGroup/configure/wizard/wizard.html'),
-      commandBuilder: 'dcosServerGroupCommandBuilder',
-      configurationService: 'dcosServerGroupConfigurationService',
-    },
-  });
+]);
+
+CloudProviderRegistry.registerProvider('dcos', {
+  name: 'DC/OS',
+  logo: {
+    path: require('./logo/dcos.logo.png'),
+  },
+  instance: {
+    detailsTemplateUrl: require('./instance/details/details.html'),
+    detailsController: 'dcosInstanceDetailsController',
+  },
+  loadBalancer: {
+    transformer: 'dcosLoadBalancerTransformer',
+    detailsTemplateUrl: require('./loadBalancer/details/details.html'),
+    detailsController: 'dcosLoadBalancerDetailsController',
+    createLoadBalancerTemplateUrl: require('./loadBalancer/configure/wizard/createWizard.html'),
+    createLoadBalancerController: 'dcosUpsertLoadBalancerController',
+  },
+  image: {
+    reader: 'dcosImageReader',
+  },
+  serverGroup: {
+    skipUpstreamStageCheck: true,
+    transformer: 'dcosServerGroupTransformer',
+    detailsTemplateUrl: require('./serverGroup/details/details.html'),
+    detailsController: 'dcosServerGroupDetailsController',
+    cloneServerGroupController: 'dcosCloneServerGroupController',
+    cloneServerGroupTemplateUrl: require('./serverGroup/configure/wizard/wizard.html'),
+    commandBuilder: 'dcosServerGroupCommandBuilder',
+    configurationService: 'dcosServerGroupConfigurationService',
+  },
 });

--- a/app/scripts/modules/ecs/src/ecs.module.ts
+++ b/app/scripts/modules/ecs/src/ecs.module.ts
@@ -77,31 +77,31 @@ module(ECS_MODULE, [
   ECS_PIPELINE_STAGES_SHRINKCLUSTER_ECSSHRINKCLUSTERSTAGE,
   ECS_SECURITY_GROUP_MODULE,
   ECS_SERVERGROUP_MODULE,
-]).config(function() {
-  CloudProviderRegistry.registerProvider('ecs', {
-    name: 'EC2 Container Service',
-    logo: { path: require('./logo/ecs.logo.svg') },
-    serverGroup: {
-      transformer: 'ecsServerGroupTransformer',
-      detailsTemplateUrl: require('./serverGroup/details/serverGroupDetails.html'),
-      detailsController: 'ecsServerGroupDetailsCtrl',
-      cloneServerGroupTemplateUrl: require('./serverGroup/configure/wizard/serverGroupWizard.html'),
-      cloneServerGroupController: 'ecsCloneServerGroupCtrl',
-      commandBuilder: 'ecsServerGroupCommandBuilder',
-      // configurationService: 'ecsServerGroupConfigurationService',
-      scalingActivitiesEnabled: false,
-    },
-    instance: {
-      detailsTemplateUrl: require('./instance/details/instanceDetails.html'),
-      detailsController: 'ecsInstanceDetailsCtrl',
-    },
-    securityGroup: {
-      transformer: 'ecsSecurityGroupTransformer',
-      reader: 'ecsSecurityGroupReader',
-      detailsTemplateUrl: require('./securityGroup/details/securityGroupDetail.html'),
-      detailsController: 'ecsSecurityGroupDetailsCtrl',
-    },
-  });
+]);
+
+CloudProviderRegistry.registerProvider('ecs', {
+  name: 'EC2 Container Service',
+  logo: { path: require('./logo/ecs.logo.svg') },
+  serverGroup: {
+    transformer: 'ecsServerGroupTransformer',
+    detailsTemplateUrl: require('./serverGroup/details/serverGroupDetails.html'),
+    detailsController: 'ecsServerGroupDetailsCtrl',
+    cloneServerGroupTemplateUrl: require('./serverGroup/configure/wizard/serverGroupWizard.html'),
+    cloneServerGroupController: 'ecsCloneServerGroupCtrl',
+    commandBuilder: 'ecsServerGroupCommandBuilder',
+    // configurationService: 'ecsServerGroupConfigurationService',
+    scalingActivitiesEnabled: false,
+  },
+  instance: {
+    detailsTemplateUrl: require('./instance/details/instanceDetails.html'),
+    detailsController: 'ecsInstanceDetailsCtrl',
+  },
+  securityGroup: {
+    transformer: 'ecsSecurityGroupTransformer',
+    reader: 'ecsSecurityGroupReader',
+    detailsTemplateUrl: require('./securityGroup/details/securityGroupDetail.html'),
+    detailsController: 'ecsSecurityGroupDetailsCtrl',
+  },
 });
 
 DeploymentStrategyRegistry.registerProvider('ecs', ['redblack']);

--- a/app/scripts/modules/google/src/gce.module.ts
+++ b/app/scripts/modules/google/src/gce.module.ts
@@ -99,58 +99,58 @@ module(GOOGLE_MODULE, [
   GOOGLE_VALIDATION_APPLICATIONNAME_VALIDATOR,
   GOOGLE_CACHE_CACHECONFIGURER_SERVICE,
   GOOGLE_COMMON_XPNNAMING_GCE_SERVICE,
-]).config(() => {
-  CloudProviderRegistry.registerProvider('gce', {
-    name: 'Google',
-    logo: {
-      path: require('./logo/gce.logo.png'),
-    },
-    cache: {
-      configurer: 'gceCacheConfigurer',
-    },
-    image: {
-      reader: GceImageReader,
-    },
-    serverGroup: {
-      transformer: 'gceServerGroupTransformer',
-      detailsTemplateUrl: require('./serverGroup/details/serverGroupDetails.html'),
-      detailsController: 'gceServerGroupDetailsCtrl',
-      cloneServerGroupTemplateUrl: require('./serverGroup/configure/wizard/serverGroupWizard.html'),
-      cloneServerGroupController: 'gceCloneServerGroupCtrl',
-      commandBuilder: 'gceServerGroupCommandBuilder',
-      configurationService: 'gceServerGroupConfigurationService',
-    },
-    instance: {
-      instanceTypeService: 'gceInstanceTypeService',
-      detailsTemplateUrl: require('./instance/details/instanceDetails.html'),
-      detailsController: 'gceInstanceDetailsCtrl',
-      multiInstanceTaskTransformer: 'gceMultiInstanceTaskTransformer',
-      customInstanceBuilderTemplateUrl: require('./serverGroup/configure/wizard/customInstance/customInstanceBuilder.html'),
-    },
-    loadBalancer: {
-      transformer: 'gceLoadBalancerTransformer',
-      setTransformer: 'gceLoadBalancerSetTransformer',
-      detailsTemplateUrl: require('./loadBalancer/details/loadBalancerDetails.html'),
-      detailsController: 'gceLoadBalancerDetailsCtrl',
-      createLoadBalancerTemplateUrl: require('./loadBalancer/configure/choice/gceLoadBalancerChoice.modal.html'),
-      createLoadBalancerController: 'gceLoadBalancerChoiceCtrl',
-    },
-    securityGroup: {
-      transformer: 'gceSecurityGroupTransformer',
-      reader: 'gceSecurityGroupReader',
-      detailsTemplateUrl: require('./securityGroup/details/securityGroupDetail.html'),
-      detailsController: 'gceSecurityGroupDetailsCtrl',
-      createSecurityGroupTemplateUrl: require('./securityGroup/configure/createSecurityGroup.html'),
-      createSecurityGroupController: 'gceCreateSecurityGroupCtrl',
-    },
-    subnet: {
-      renderer: 'gceSubnetRenderer',
-    },
-    snapshotsEnabled: true,
-    applicationProviderFields: {
-      templateUrl: require('./applicationProviderFields/gceFields.html'),
-    },
-  });
+]);
+
+CloudProviderRegistry.registerProvider('gce', {
+  name: 'Google',
+  logo: {
+    path: require('./logo/gce.logo.png'),
+  },
+  cache: {
+    configurer: 'gceCacheConfigurer',
+  },
+  image: {
+    reader: GceImageReader,
+  },
+  serverGroup: {
+    transformer: 'gceServerGroupTransformer',
+    detailsTemplateUrl: require('./serverGroup/details/serverGroupDetails.html'),
+    detailsController: 'gceServerGroupDetailsCtrl',
+    cloneServerGroupTemplateUrl: require('./serverGroup/configure/wizard/serverGroupWizard.html'),
+    cloneServerGroupController: 'gceCloneServerGroupCtrl',
+    commandBuilder: 'gceServerGroupCommandBuilder',
+    configurationService: 'gceServerGroupConfigurationService',
+  },
+  instance: {
+    instanceTypeService: 'gceInstanceTypeService',
+    detailsTemplateUrl: require('./instance/details/instanceDetails.html'),
+    detailsController: 'gceInstanceDetailsCtrl',
+    multiInstanceTaskTransformer: 'gceMultiInstanceTaskTransformer',
+    customInstanceBuilderTemplateUrl: require('./serverGroup/configure/wizard/customInstance/customInstanceBuilder.html'),
+  },
+  loadBalancer: {
+    transformer: 'gceLoadBalancerTransformer',
+    setTransformer: 'gceLoadBalancerSetTransformer',
+    detailsTemplateUrl: require('./loadBalancer/details/loadBalancerDetails.html'),
+    detailsController: 'gceLoadBalancerDetailsCtrl',
+    createLoadBalancerTemplateUrl: require('./loadBalancer/configure/choice/gceLoadBalancerChoice.modal.html'),
+    createLoadBalancerController: 'gceLoadBalancerChoiceCtrl',
+  },
+  securityGroup: {
+    transformer: 'gceSecurityGroupTransformer',
+    reader: 'gceSecurityGroupReader',
+    detailsTemplateUrl: require('./securityGroup/details/securityGroupDetail.html'),
+    detailsController: 'gceSecurityGroupDetailsCtrl',
+    createSecurityGroupTemplateUrl: require('./securityGroup/configure/createSecurityGroup.html'),
+    createSecurityGroupController: 'gceCreateSecurityGroupCtrl',
+  },
+  subnet: {
+    renderer: 'gceSubnetRenderer',
+  },
+  snapshotsEnabled: true,
+  applicationProviderFields: {
+    templateUrl: require('./applicationProviderFields/gceFields.html'),
+  },
 });
 
 DeploymentStrategyRegistry.registerProvider('gce', ['custom', 'redblack']);

--- a/app/scripts/modules/huaweicloud/src/huaweicloud.module.ts
+++ b/app/scripts/modules/huaweicloud/src/huaweicloud.module.ts
@@ -1,20 +1,7 @@
-'use strict';
-
-import { module } from 'angular';
-
 import { CloudProviderRegistry, DeploymentStrategyRegistry } from '@spinnaker/core';
 
-// load all templates into the $templateCache
-const templates = require.context('./', true, /\.html$/);
-templates.keys().forEach(function(key) {
-  templates(key);
-});
-
-export const HUAWEICLOUD_MODULE = 'spinnaker.huaweicloud';
-module(HUAWEICLOUD_MODULE, []).config(() => {
-  CloudProviderRegistry.registerProvider('huaweicloud', {
-    name: 'huaweicloud',
-  });
+CloudProviderRegistry.registerProvider('huaweicloud', {
+  name: 'huaweicloud',
 });
 
 DeploymentStrategyRegistry.registerProvider('huaweicloud', ['redblack']);

--- a/app/scripts/modules/huaweicloud/src/index.ts
+++ b/app/scripts/modules/huaweicloud/src/index.ts
@@ -1,1 +1,1 @@
-export { HUAWEICLOUD_MODULE } from './huaweicloud.module';
+export * from './huaweicloud.module';

--- a/app/scripts/modules/kubernetes/src/v1/kubernetes.v1.module.ts
+++ b/app/scripts/modules/kubernetes/src/v1/kubernetes.v1.module.ts
@@ -85,61 +85,61 @@ module(KUBERNETES_V1_MODULE, [
   KUBERNETES_V1_SERVERGROUP_PARAMSMIXIN,
   KUBERNETES_V1_SERVERGROUP_TRANSFORMER,
   KUBERNETES_TOLERATIONS,
-]).config(() => {
-  CloudProviderRegistry.registerProvider('kubernetes', {
-    name: 'Kubernetes',
-    skin: 'v1',
-    defaultSkin: true,
-    search: {
-      resultFormatter: 'kubernetesSearchResultFormatter',
-    },
-    logo: {
-      path: require('../shared/logo/kubernetes.logo.svg'),
-    },
-    image: {
-      reader: 'kubernetesImageReader',
-    },
-    instance: {
-      detailsTemplateUrl: require('./instance/details/details.html'),
-      detailsController: 'kubernetesInstanceDetailsController',
-    },
-    loadBalancer: {
-      transformer: 'kubernetesLoadBalancerTransformer',
-      detailsTemplateUrl: require('./loadBalancer/details/details.html'),
-      detailsController: 'kubernetesLoadBalancerDetailsController',
-      createLoadBalancerTemplateUrl: require('./loadBalancer/configure/wizard/createWizard.html'),
-      createLoadBalancerController: 'kubernetesUpsertLoadBalancerController',
-    },
-    securityGroup: {
-      reader: KubernetesSecurityGroupReader,
-      transformer: 'kubernetesSecurityGroupTransformer',
-      detailsTemplateUrl: require('./securityGroup/details/details.html'),
-      detailsController: 'kubernetesSecurityGroupDetailsController',
-      createSecurityGroupTemplateUrl: require('./securityGroup/configure/wizard/createWizard.html'),
-      createSecurityGroupController: 'kubernetesUpsertSecurityGroupController',
-    },
-    serverGroup: {
-      artifactExtractor: 'kubernetesServerGroupArtifactExtractor',
-      skipUpstreamStageCheck: true,
-      transformer: 'kubernetesServerGroupTransformer',
-      detailsTemplateUrl: require('./serverGroup/details/details.html'),
-      detailsController: 'kubernetesServerGroupDetailsController',
-      cloneServerGroupController: 'kubernetesCloneServerGroupController',
-      cloneServerGroupTemplateUrl: require('./serverGroup/configure/wizard/wizard.html'),
-      commandBuilder: 'kubernetesServerGroupCommandBuilder',
-      configurationService: 'kubernetesServerGroupConfigurationService',
-      paramsMixin: 'kubernetesServerGroupParamsMixin',
-    },
-    unsupportedStageTypes: [
-      'scaleManifest',
-      'deployManifest',
-      'deleteManifest',
-      'undoRolloutManifest',
-      'findArtifactsFromResource',
-      'bakeManifest',
-      'patchManifest',
-    ],
-  });
+]);
+
+CloudProviderRegistry.registerProvider('kubernetes', {
+  name: 'Kubernetes',
+  skin: 'v1',
+  defaultSkin: true,
+  search: {
+    resultFormatter: 'kubernetesSearchResultFormatter',
+  },
+  logo: {
+    path: require('../shared/logo/kubernetes.logo.svg'),
+  },
+  image: {
+    reader: 'kubernetesImageReader',
+  },
+  instance: {
+    detailsTemplateUrl: require('./instance/details/details.html'),
+    detailsController: 'kubernetesInstanceDetailsController',
+  },
+  loadBalancer: {
+    transformer: 'kubernetesLoadBalancerTransformer',
+    detailsTemplateUrl: require('./loadBalancer/details/details.html'),
+    detailsController: 'kubernetesLoadBalancerDetailsController',
+    createLoadBalancerTemplateUrl: require('./loadBalancer/configure/wizard/createWizard.html'),
+    createLoadBalancerController: 'kubernetesUpsertLoadBalancerController',
+  },
+  securityGroup: {
+    reader: KubernetesSecurityGroupReader,
+    transformer: 'kubernetesSecurityGroupTransformer',
+    detailsTemplateUrl: require('./securityGroup/details/details.html'),
+    detailsController: 'kubernetesSecurityGroupDetailsController',
+    createSecurityGroupTemplateUrl: require('./securityGroup/configure/wizard/createWizard.html'),
+    createSecurityGroupController: 'kubernetesUpsertSecurityGroupController',
+  },
+  serverGroup: {
+    artifactExtractor: 'kubernetesServerGroupArtifactExtractor',
+    skipUpstreamStageCheck: true,
+    transformer: 'kubernetesServerGroupTransformer',
+    detailsTemplateUrl: require('./serverGroup/details/details.html'),
+    detailsController: 'kubernetesServerGroupDetailsController',
+    cloneServerGroupController: 'kubernetesCloneServerGroupController',
+    cloneServerGroupTemplateUrl: require('./serverGroup/configure/wizard/wizard.html'),
+    commandBuilder: 'kubernetesServerGroupCommandBuilder',
+    configurationService: 'kubernetesServerGroupConfigurationService',
+    paramsMixin: 'kubernetesServerGroupParamsMixin',
+  },
+  unsupportedStageTypes: [
+    'scaleManifest',
+    'deployManifest',
+    'deleteManifest',
+    'undoRolloutManifest',
+    'findArtifactsFromResource',
+    'bakeManifest',
+    'patchManifest',
+  ],
 });
 
 const strategies = ['custom', 'redblack'];

--- a/app/scripts/modules/kubernetes/src/v2/kubernetes.v2.module.ts
+++ b/app/scripts/modules/kubernetes/src/v2/kubernetes.v2.module.ts
@@ -89,54 +89,54 @@ module(KUBERNETES_V2_MODULE, [
   KUBERNETES_DISABLE_MANIFEST_STAGE,
   STAGE_ARTIFACT_SELECTOR_COMPONENT_REACT,
   KUBERNETES_ROLLING_RESTART,
-]).config(() => {
-  CloudProviderRegistry.registerProvider('kubernetes', {
-    name: 'Kubernetes',
-    skin: 'v2',
-    logo: {
-      path: require('../shared/logo/kubernetes.icon.svg'),
-    },
-    serverGroup: {
-      CloneServerGroupModal: ManifestWizard,
-      commandBuilder: 'kubernetesV2ServerGroupCommandBuilder',
-      detailsController: 'kubernetesV2ServerGroupDetailsCtrl',
-      detailsTemplateUrl: require('./serverGroup/details/details.html'),
-      transformer: 'kubernetesV2ServerGroupTransformer',
-    },
-    serverGroupManager: {
-      detailsTemplateUrl: require('./serverGroupManager/details/details.html'),
-      detailsController: 'kubernetesV2ServerGroupManagerDetailsCtrl',
-    },
-    loadBalancer: {
-      CreateLoadBalancerModal: ManifestWizard,
-      detailsController: 'kubernetesV2LoadBalancerDetailsCtrl',
-      detailsTemplateUrl: require('./loadBalancer/details/details.html'),
-      transformer: 'kubernetesV2LoadBalancerTransformer',
-    },
-    securityGroup: {
-      reader: KubernetesSecurityGroupReader,
-      CreateSecurityGroupModal: ManifestWizard,
-      detailsController: 'kubernetesV2SecurityGroupDetailsCtrl',
-      detailsTemplateUrl: require('./securityGroup/details/details.html'),
-      transformer: 'kubernetesV2SecurityGroupTransformer',
-    },
-    instance: {
-      detailsController: 'kubernetesV2InstanceDetailsCtrl',
-      detailsTemplateUrl: require('./instance/details/details.html'),
-    },
-    unsupportedStageTypes: [
-      'deploy',
-      'destroyServerGroup',
-      'disableCluster',
-      'disableServerGroup',
-      'enableServerGroup',
-      'findImage',
-      'resizeServerGroup',
-      'rollbackCluster',
-      'runJob',
-      'scaleDown',
-      'scaleDownCluster',
-      'shrinkCluster',
-    ],
-  });
+]);
+
+CloudProviderRegistry.registerProvider('kubernetes', {
+  name: 'Kubernetes',
+  skin: 'v2',
+  logo: {
+    path: require('../shared/logo/kubernetes.icon.svg'),
+  },
+  serverGroup: {
+    CloneServerGroupModal: ManifestWizard,
+    commandBuilder: 'kubernetesV2ServerGroupCommandBuilder',
+    detailsController: 'kubernetesV2ServerGroupDetailsCtrl',
+    detailsTemplateUrl: require('./serverGroup/details/details.html'),
+    transformer: 'kubernetesV2ServerGroupTransformer',
+  },
+  serverGroupManager: {
+    detailsTemplateUrl: require('./serverGroupManager/details/details.html'),
+    detailsController: 'kubernetesV2ServerGroupManagerDetailsCtrl',
+  },
+  loadBalancer: {
+    CreateLoadBalancerModal: ManifestWizard,
+    detailsController: 'kubernetesV2LoadBalancerDetailsCtrl',
+    detailsTemplateUrl: require('./loadBalancer/details/details.html'),
+    transformer: 'kubernetesV2LoadBalancerTransformer',
+  },
+  securityGroup: {
+    reader: KubernetesSecurityGroupReader,
+    CreateSecurityGroupModal: ManifestWizard,
+    detailsController: 'kubernetesV2SecurityGroupDetailsCtrl',
+    detailsTemplateUrl: require('./securityGroup/details/details.html'),
+    transformer: 'kubernetesV2SecurityGroupTransformer',
+  },
+  instance: {
+    detailsController: 'kubernetesV2InstanceDetailsCtrl',
+    detailsTemplateUrl: require('./instance/details/details.html'),
+  },
+  unsupportedStageTypes: [
+    'deploy',
+    'destroyServerGroup',
+    'disableCluster',
+    'disableServerGroup',
+    'enableServerGroup',
+    'findImage',
+    'resizeServerGroup',
+    'rollbackCluster',
+    'runJob',
+    'scaleDown',
+    'scaleDownCluster',
+    'shrinkCluster',
+  ],
 });

--- a/app/scripts/modules/oracle/src/oracle.module.ts
+++ b/app/scripts/modules/oracle/src/oracle.module.ts
@@ -61,39 +61,39 @@ module(ORACLE_MODULE, [
   ORACLE_SECURITYGROUP_SECURITYGROUP_READER,
   ORACLE_SECURITYGROUP_SECURITYGROUP_TRANSFORMER,
   ORACLE_SECURITYGROUP_CONFIGURE_CREATESECURITYGROUP_CONTROLLER,
-]).config(function() {
-  CloudProviderRegistry.registerProvider('oracle', {
-    name: 'Oracle',
-    image: {
-      reader: 'oracleImageReader',
-    },
-    loadBalancer: {
-      transformer: 'oracleLoadBalancerTransformer',
-      detailsTemplateUrl: require('./loadBalancer/details/loadBalancerDetail.html'),
-      detailsController: 'oracleLoadBalancerDetailCtrl',
-      createLoadBalancerTemplateUrl: require('./loadBalancer/configure/createLoadBalancer.html'),
-      createLoadBalancerController: 'oracleCreateLoadBalancerCtrl',
-    },
-    serverGroup: {
-      transformer: 'oracleServerGroupTransformer',
-      detailsTemplateUrl: require('./serverGroup/details/serverGroupDetails.html'),
-      detailsController: 'oracleServerGroupDetailsCtrl',
-      commandBuilder: 'oracleServerGroupCommandBuilder',
-      cloneServerGroupController: 'oracleCloneServerGroupCtrl',
-      cloneServerGroupTemplateUrl: require('./serverGroup/configure/wizard/serverGroupWizard.html'),
-      configurationService: 'oracleServerGroupConfigurationService',
-    },
-    instance: {
-      detailsController: 'oracleInstanceDetailsCtrl',
-      detailsTemplateUrl: require('./instance/details/instanceDetails.html'),
-    },
-    securityGroup: {
-      reader: 'oracleSecurityGroupReader',
-      transformer: 'oracleSecurityGroupTransformer',
-      createSecurityGroupTemplateUrl: require('./securityGroup/configure/createSecurityGroup.html'),
-      createSecurityGroupController: 'oracleCreateSecurityGroupCtrl',
-    },
-  });
+]);
+
+CloudProviderRegistry.registerProvider('oracle', {
+  name: 'Oracle',
+  image: {
+    reader: 'oracleImageReader',
+  },
+  loadBalancer: {
+    transformer: 'oracleLoadBalancerTransformer',
+    detailsTemplateUrl: require('./loadBalancer/details/loadBalancerDetail.html'),
+    detailsController: 'oracleLoadBalancerDetailCtrl',
+    createLoadBalancerTemplateUrl: require('./loadBalancer/configure/createLoadBalancer.html'),
+    createLoadBalancerController: 'oracleCreateLoadBalancerCtrl',
+  },
+  serverGroup: {
+    transformer: 'oracleServerGroupTransformer',
+    detailsTemplateUrl: require('./serverGroup/details/serverGroupDetails.html'),
+    detailsController: 'oracleServerGroupDetailsCtrl',
+    commandBuilder: 'oracleServerGroupCommandBuilder',
+    cloneServerGroupController: 'oracleCloneServerGroupCtrl',
+    cloneServerGroupTemplateUrl: require('./serverGroup/configure/wizard/serverGroupWizard.html'),
+    configurationService: 'oracleServerGroupConfigurationService',
+  },
+  instance: {
+    detailsController: 'oracleInstanceDetailsCtrl',
+    detailsTemplateUrl: require('./instance/details/instanceDetails.html'),
+  },
+  securityGroup: {
+    reader: 'oracleSecurityGroupReader',
+    transformer: 'oracleSecurityGroupTransformer',
+    createSecurityGroupTemplateUrl: require('./securityGroup/configure/createSecurityGroup.html'),
+    createSecurityGroupController: 'oracleCreateSecurityGroupCtrl',
+  },
 });
 
 DeploymentStrategyRegistry.registerProvider('oracle', []);

--- a/app/scripts/modules/titus/src/titus.module.ts
+++ b/app/scripts/modules/titus/src/titus.module.ts
@@ -59,40 +59,40 @@ module(TITUS_MODULE, [
   TITUS_SERVERGROUP_DETAILS_CAPACITYDETAILSSECTION,
   TITUS_SERVERGROUP_DETAILS_LAUNCHCONFIGSECTION,
   TITUS_MIGRATION_CONFIG_COMPONENT,
-]).config(() => {
-  CloudProviderRegistry.registerProvider('titus', {
-    name: 'Titus',
-    logo: {
-      path: require('./logo/titus.logo.png'),
-    },
-    serverGroup: {
-      transformer: 'titusServerGroupTransformer',
-      detailsTemplateUrl: require('./serverGroup/details/serverGroupDetails.html'),
-      detailsController: 'titusServerGroupDetailsCtrl',
-      CloneServerGroupModal: TitusCloneServerGroupModal,
-      commandBuilder: 'titusServerGroupCommandBuilder',
-      configurationService: 'titusServerGroupConfigurationService',
-      skipUpstreamStageCheck: true,
-    },
-    securityGroup: {
-      reader: 'titusSecurityGroupReader',
-      useProvider: 'aws',
-    },
-    loadBalancer: {
-      LoadBalancersTag: AmazonLoadBalancersTag,
-      incompatibleLoadBalancerTypes: [
-        {
-          type: 'classic',
-          reason: 'Classic Load Balancers cannot be used with Titus as they do not have IP based target groups.',
-        },
-      ],
-      useProvider: 'aws',
-    },
-    instance: {
-      detailsTemplateUrl: require('./instance/details/instanceDetails.html'),
-      detailsController: 'titusInstanceDetailsCtrl',
-    },
-  });
+]);
+
+CloudProviderRegistry.registerProvider('titus', {
+  name: 'Titus',
+  logo: {
+    path: require('./logo/titus.logo.png'),
+  },
+  serverGroup: {
+    transformer: 'titusServerGroupTransformer',
+    detailsTemplateUrl: require('./serverGroup/details/serverGroupDetails.html'),
+    detailsController: 'titusServerGroupDetailsCtrl',
+    CloneServerGroupModal: TitusCloneServerGroupModal,
+    commandBuilder: 'titusServerGroupCommandBuilder',
+    configurationService: 'titusServerGroupConfigurationService',
+    skipUpstreamStageCheck: true,
+  },
+  securityGroup: {
+    reader: 'titusSecurityGroupReader',
+    useProvider: 'aws',
+  },
+  loadBalancer: {
+    LoadBalancersTag: AmazonLoadBalancersTag,
+    incompatibleLoadBalancerTypes: [
+      {
+        type: 'classic',
+        reason: 'Classic Load Balancers cannot be used with Titus as they do not have IP based target groups.',
+      },
+    ],
+    useProvider: 'aws',
+  },
+  instance: {
+    detailsTemplateUrl: require('./instance/details/instanceDetails.html'),
+    detailsController: 'titusInstanceDetailsCtrl',
+  },
 });
 
 DeploymentStrategyRegistry.registerProvider('titus', ['custom', 'redblack']);


### PR DESCRIPTION
**Reviewers:** this is almost entirely a whitespace change. **Use [this link](https://github.com/spinnaker/deck/pull/7796/files?w=1) to review**

The registration of the providers via config blocks isn't necessary.

This gets rid of the following warning in the console when running tests:
```
WARN: 'Cannot override "function.details" for provider "aws" (provider not registered)'
```