### PR TITLE
chore(core): clean up import warnings

### DIFF
--- a/app/scripts/modules/core/src/modal/index.ts
+++ b/app/scripts/modules/core/src/modal/index.ts
@@ -2,4 +2,3 @@ export * from './buttons/ModalClose';
 export * from './buttons/SubmitButton';
 export * from './wizard';
 export { V2_MODAL_WIZARD_COMPONENT, V2ModalWizard } from './wizard/v2modalWizard.component';
-export { IWizardPage, ModalWizard, IWizardPageState } from './wizard/ModalWizard';

--- a/app/scripts/modules/core/src/modal/wizard/ModalWizard.ts
+++ b/app/scripts/modules/core/src/modal/wizard/ModalWizard.ts
@@ -1,6 +1,6 @@
 import { ScrollToService } from 'core/utils/scrollTo/scrollTo.service';
 
-export interface IWizardPageState {
+export interface IModalWizardPageState {
   done: boolean;
   blocked: boolean;
   rendered: boolean;
@@ -11,23 +11,23 @@ export interface IWizardPageState {
   required: boolean;
 }
 
-export interface IWizardPage {
-  state: IWizardPageState;
+export interface IModalWizardPage {
+  state: IModalWizardPageState;
   key: string;
   label: string;
 }
 
 export class ModalWizard {
-  public static renderedPages: IWizardPage[] = [];
-  public static pageRegistry: IWizardPage[] = [];
-  public static currentPage: IWizardPage;
+  public static renderedPages: IModalWizardPage[] = [];
+  public static pageRegistry: IModalWizardPage[] = [];
+  public static currentPage: IModalWizardPage;
   public static heading: string;
 
   public static setHeading(heading: string): void {
     this.heading = heading;
   }
 
-  public static getPage(key: string): IWizardPage {
+  public static getPage(key: string): IModalWizardPage {
     return this.pageRegistry.find(p => p.key === key);
   }
 
@@ -47,7 +47,7 @@ export class ModalWizard {
     this.getPage(key).state.done = false;
   }
 
-  public static setCurrentPage(page: IWizardPage, skipScroll?: boolean): void {
+  public static setCurrentPage(page: IModalWizardPage, skipScroll?: boolean): void {
     this.pageRegistry.forEach(test => (test.state.current = test === page));
     this.currentPage = page;
 
@@ -64,7 +64,7 @@ export class ModalWizard {
     }
   }
 
-  public static registerPage(key: string, label: string, state?: IWizardPageState): void {
+  public static registerPage(key: string, label: string, state?: IModalWizardPageState): void {
     state = state || {
       done: false,
       blocked: true,
@@ -80,7 +80,7 @@ export class ModalWizard {
   }
 
   public static renderPages(): void {
-    const renderedPages: IWizardPage[] = this.pageRegistry.filter(page => page.state.rendered);
+    const renderedPages: IModalWizardPage[] = this.pageRegistry.filter(page => page.state.rendered);
     this.renderedPages = renderedPages;
     if (renderedPages.length === 1) {
       this.setCurrentPage(renderedPages[0]);

--- a/app/scripts/modules/core/src/modal/wizard/WizardPage.tsx
+++ b/app/scripts/modules/core/src/modal/wizard/WizardPage.tsx
@@ -22,7 +22,7 @@ export interface IWizardPageProps {
   wizard: IWizardModalApi;
 }
 
-export interface IWizardPageState {
+interface IWizardPageState {
   errors: object;
   order: number;
   isLoading: boolean;

--- a/app/scripts/modules/core/src/modal/wizard/index.ts
+++ b/app/scripts/modules/core/src/modal/wizard/index.ts
@@ -1,3 +1,4 @@
+export * from './ModalWizard';
 export * from './WizardModal';
 export * from './WizardPage';
 export * from './WizardStepLabel';

--- a/app/scripts/modules/core/src/modal/wizard/v2wizardPage.component.ts
+++ b/app/scripts/modules/core/src/modal/wizard/v2wizardPage.component.ts
@@ -1,6 +1,6 @@
 import { IController, module } from 'angular';
 
-import { ModalWizard, IWizardPageState } from './ModalWizard';
+import { ModalWizard, IModalWizardPageState } from './ModalWizard';
 /**
  * Wizard page directive
  * possible attributes:
@@ -67,7 +67,7 @@ export class WizardPageController implements IController {
   /**
    * Internal state of the page, initialized based on other public fields
    */
-  public state: IWizardPageState;
+  public state: IModalWizardPageState;
 
   public static $inject = ['$scope'];
   public constructor(private $scope: ng.IScope) {}

--- a/app/scripts/modules/core/src/pagerDuty/Pager.tsx
+++ b/app/scripts/modules/core/src/pagerDuty/Pager.tsx
@@ -12,11 +12,13 @@ import {
   Column,
   RowMouseEventHandlerParams,
   SortDirection,
-  SortDirectionType,
   Table,
   TableCellProps,
   TableHeaderProps,
 } from 'react-virtualized';
+
+// defined in react-virtualized but TS complains about not finding it so we duplicate it here
+type SortDirectionType = 'ASC' | 'DESC';
 
 import { ApplicationReader, IApplicationSummary } from 'core/application';
 import { relativeTime } from 'core/utils/timeFormatters';


### PR DESCRIPTION
This cleans up the last of the console noise when running tests:
```
WARNING in ./app/scripts/modules/core/src/modal/index.ts 5:0-82
"export 'IWizardPage' was not found in './wizard/ModalWizard'

WARNING in ./app/scripts/modules/core/src/modal/index.ts 5:0-82
"export 'IWizardPageState' was not found in './wizard/ModalWizard'

WARNING in ./app/scripts/modules/core/src/pagerDuty/Pager.tsx 369:88-105
"export 'SortDirectionType' was not found in 'react-virtualized'

WARNING in ./app/scripts/modules/core/src/pagerDuty/Pager.tsx 369:125-142
"export 'SortDirectionType' was not found in 'react-virtualized'
```

The `ModalWizard` ones are (I think) related to duplicate interface names found in `WizardPage`.

I don't know why TS is having trouble with `SortDirectionType`. As far as I can tell, it's only defined in one place in the exported react-virtualized type definitions. I'd rather duplicate it here and get rid of the noise when running tests. That's my just my opinion — I'm happy to discuss if others feel differently!