### PR TITLE
wip(*): surface individual resource export

### DIFF
--- a/app/scripts/modules/amazon/src/loadBalancer/details/LoadBalancerActions.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/details/LoadBalancerActions.tsx
@@ -6,6 +6,7 @@ import {
   Application,
   ApplicationReader,
   ConfirmationModalService,
+  ExportResourceMenuItem,
   LoadBalancerWriter,
   ManagedMenuItem,
   SETTINGS,
@@ -149,6 +150,14 @@ export class LoadBalancerActions extends React.Component<ILoadBalancerActionsPro
                 </a>
               </li>
             )}
+            <ExportResourceMenuItem
+              cloudProvider={loadBalancer.cloudProvider}
+              account={loadBalancer.account}
+              type={`${loadBalancer.loadBalancerType}-load-balancer`}
+              name={loadBalancer.name}
+              application={app}
+              isManaged={!!loadBalancer.managedResourceSummary}
+            />
             {SETTINGS && SETTINGS.feature.entityTags && (
               <AddEntityTagLinks
                 component={loadBalancer}

--- a/app/scripts/modules/amazon/src/securityGroup/details/securityGroupDetail.controller.js
+++ b/app/scripts/modules/amazon/src/securityGroup/details/securityGroupDetail.controller.js
@@ -12,7 +12,7 @@ import {
   SecurityGroupWriter,
   FirewallLabels,
   MANAGED_RESOURCE_DETAILS_INDICATOR,
-  noop,
+  EXPORT_RESOURCE_MENU_ITEM,
 } from '@spinnaker/core';
 
 import { VpcReader } from '../../vpc/VpcReader';
@@ -28,6 +28,7 @@ angular
     SECURITY_GROUP_READER,
     AMAZON_SECURITYGROUP_CLONE_CLONESECURITYGROUP_CONTROLLER,
     MANAGED_RESOURCE_DETAILS_INDICATOR,
+    EXPORT_RESOURCE_MENU_ITEM,
   ])
   .controller('awsSecurityGroupDetailsCtrl', [
     '$scope',

--- a/app/scripts/modules/amazon/src/securityGroup/details/securityGroupDetail.html
+++ b/app/scripts/modules/amazon/src/securityGroup/details/securityGroupDetail.html
@@ -42,6 +42,14 @@
           <li>
             <a href ng-click="ctrl.cloneSecurityGroup()">Clone <firewall-label label="Firewall"></firewall-label></a>
           </li>
+          <export-resource-menu-item
+            cloud-provider="'aws'"
+            account="securityGroup.account"
+            type="'security-group'"
+            name="securityGroup.name"
+            is-managed="!!securityGroup.managedResourceSummary"
+            application="ctrl.application"
+          ></export-resource-menu-item>
           <render-if-feature feature="entityTags">
             <add-entity-tag-links
               component="securityGroup"

--- a/app/scripts/modules/amazon/src/serverGroup/details/AmazonServerGroupActions.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/details/AmazonServerGroupActions.tsx
@@ -5,6 +5,7 @@ import { filter, find, get, orderBy } from 'lodash';
 import {
   ClusterTargetBuilder,
   ConfirmationModalService,
+  ExportResourceMenuItem,
   IOwnerOption,
   IServerGroupActionsProps,
   IServerGroupJob,
@@ -324,6 +325,14 @@ export class AmazonServerGroupActions extends React.Component<IAmazonServerGroup
               Clone
             </a>
           </li>
+          <ExportResourceMenuItem
+            cloudProvider={serverGroup.cloudProvider}
+            account={serverGroup.account}
+            type="cluster"
+            name={serverGroup.cluster}
+            application={app}
+            isManaged={!!serverGroup.managedResourceSummary}
+          />
           {showEntityTags && (
             <AddEntityTagLinks
               component={serverGroup}

--- a/app/scripts/modules/core/src/managed/ManagedReader.ts
+++ b/app/scripts/modules/core/src/managed/ManagedReader.ts
@@ -14,7 +14,27 @@ export const getResourceKindForLoadBalancerType = (type: string) => {
   }
 };
 
+export interface IResourceExportArguments {
+  cloudProvider: string;
+  account: string;
+  type: string;
+  name: string;
+  serviceAccount: string;
+}
+
 export class ManagedReader {
+  public static getResourceExportUrl({
+    cloudProvider,
+    account,
+    type,
+    name,
+    serviceAccount,
+  }: IResourceExportArguments): string {
+    return `managed/resources/export/${cloudProvider}/${account}/${type}/${name}?serviceAccount=${serviceAccount}`;
+  }
+  public static getResourceExport(params: IResourceExportArguments): IPromise<string> {
+    return API.one(ManagedReader.getResourceExportUrl(params)).get();
+  }
   public static getApplicationSummary(app: string): IPromise<IManagedApplicationSummary> {
     return API.one('managed')
       .one('application', app)

--- a/app/scripts/modules/core/src/managed/export/ExportResourceMenuItem.tsx
+++ b/app/scripts/modules/core/src/managed/export/ExportResourceMenuItem.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+import { module } from 'angular';
+import { react2angular } from 'react2angular';
+
+import { Application } from 'core/application';
+import { ExportResourceModal } from './ExportResourceModal';
+
+export interface IExportResourceMenuItemProps {
+  cloudProvider: string;
+  account: string;
+  type: string;
+  name: string;
+  isManaged: boolean;
+  application: Application;
+}
+
+export const ExportResourceMenuItem = (props: IExportResourceMenuItemProps) => {
+  const [modalIsOpen, setModalIsOpen] = React.useState(false);
+
+  return (
+    <>
+      <li className="divider" />
+      <li>
+        <a onClick={() => setModalIsOpen(true)}>Export Resource Definition</a>
+        {modalIsOpen && (
+          <ExportResourceModal
+            {...props}
+            onRequestClose={() => setModalIsOpen(false)}
+            serviceAccount={props.application.attributes.email}
+          />
+        )}
+      </li>
+    </>
+  );
+};
+
+export const EXPORT_RESOURCE_MENU_ITEM = 'spinnaker.core.managed.export.menu.item';
+module(EXPORT_RESOURCE_MENU_ITEM, []).component(
+  'exportResourceMenuItem',
+  react2angular(ExportResourceMenuItem, ['cloudProvider', 'account', 'type', 'name', 'isManaged', 'application']),
+);

--- a/app/scripts/modules/core/src/managed/export/ExportResourceModal.tsx
+++ b/app/scripts/modules/core/src/managed/export/ExportResourceModal.tsx
@@ -1,0 +1,179 @@
+import React from 'react';
+
+import AceEditor, { AceEditorProps } from 'react-ace';
+import { safeLoad } from 'js-yaml';
+import { $log } from 'ngimport';
+
+import { Modal, ModalHeader, ModalBody, ModalFooter } from 'core/presentation/modal';
+import { useLatestPromise } from 'core/presentation';
+import { Spinner } from 'core/widgets';
+import { CopyToClipboard } from 'core/utils';
+import { SETTINGS } from 'core/config/settings';
+import { AccountTag } from 'core/account';
+
+import { ManagedReader } from '../ManagedReader';
+
+export interface IExportResourceModalProps {
+  cloudProvider: string;
+  account: string;
+  type: string;
+  name: string;
+  isManaged: boolean;
+  serviceAccount: string;
+  onRequestClose: () => void;
+}
+
+const PrimaryActions = ({ text, name, url }: { text: string; name: string; url: string }) => {
+  return (
+    <>
+      <a className="button passive sp-margin-l-right" href={`${SETTINGS.gateUrl}/${url}`}>
+        <i className="fas fa-file-download" /> Download {name}.yml
+      </a>
+      <CopyToClipboard
+        className="primary"
+        buttonInnerNode={
+          <div>
+            <i className="fas fa-copy" /> Copy to Clipboard
+          </div>
+        }
+        text={text}
+      />
+    </>
+  );
+};
+
+const RequestIsPending = () => <Spinner size="medium" message="Generating resource definition..." />;
+
+const RequestWasRejected = () => (
+  <div className="alert alert-danger">
+    <div className="text-center">
+      <h2>🥺</h2>
+      <div>There was a problem generating the resource definition. Try again later.</div>
+    </div>
+  </div>
+);
+
+// Open question whether this info is worth displaying - or should even be included in the export
+// @ts-ignore
+const Metadata = ({ content }: { content: string }) => {
+  if (!content) {
+    return null;
+  }
+  try {
+    const parsed = safeLoad(content);
+    if (!parsed?.spec?.locations) {
+      return null;
+    }
+    return (
+      <>
+        <p>
+          <b>Account:</b> <AccountTag account={parsed.spec.locations.account} />
+        </p>
+        <p>
+          <b>Regions:</b> {parsed.spec.locations.regions.map((r: any) => r.name).join(', ')}
+        </p>
+      </>
+    );
+  } catch (e) {
+    $log.error(`Error parsing YAML from managed resource export:\n${content}`);
+  }
+  return null;
+};
+
+const YamlView = ({ content, showAll }: { content: string; showAll: boolean }) => {
+  // All the height horror is because https://github.com/securingsincity/react-ace/issues/224
+  const lineHeight = 14;
+  let heightProps: Partial<AceEditorProps> = { height: `${lineHeight * 12}px` };
+  if (showAll) {
+    const lines = content.split('\n').length + 1;
+    heightProps = {
+      minLines: lines,
+      maxLines: lines,
+    };
+  }
+  return (
+    <>
+      <style
+        dangerouslySetInnerHTML={{
+          __html: `
+      .ace_gutter-cell, .ace_line { height: 14px; min-height: 14px; line-height: 14px; max-height: 14px; }
+      `,
+        }}
+      />
+      <AceEditor
+        {...heightProps}
+        mode="yaml"
+        theme="textmate"
+        width="auto"
+        name="yaml-editor"
+        readOnly={true}
+        showGutter={true}
+        cursorStart={0}
+        showPrintMargin={false}
+        value={content}
+        setOptions={{
+          firstLineNumber: 1,
+          tabSize: 2,
+          showLineNumbers: true,
+          showFoldWidgets: false,
+          highlightGutterLine: false,
+          highlightActiveLine: false,
+          wrapBehavioursEnabled: true,
+        }}
+        editorProps={{ $blockScrolling: Infinity }}
+        className="ace-editor"
+      />
+    </>
+  );
+};
+
+export const ExportResourceModal = (props: IExportResourceModalProps) => {
+  const fetchResource = useLatestPromise<string>(() => ManagedReader.getResourceExport(props), []);
+  const [showAll, setShowAll] = React.useState(false);
+  const content = fetchResource.result;
+  const totalLines = content?.split('\n').length ?? 0;
+  return (
+    <Modal onRequestClose={props.onRequestClose} isOpen={true}>
+      <ModalHeader>Export Resource: {props.name}</ModalHeader>
+      <ModalBody>
+        <div className="sp-margin-l-yaxis">
+          {fetchResource.status === 'PENDING' && <RequestIsPending />}
+          {fetchResource.status === 'REJECTED' && <RequestWasRejected />}
+          {fetchResource.status === 'RESOLVED' && (
+            <>
+              <h3>Psst! Managed Delivery is in pre-alpha!</h3>
+              <p>
+                This resource definition can be added in the environment of a delivery config. More information is
+                available in the{' '}
+                <a target="_blank" href="https://www.spinnaker.io/reference/managed-delivery/getting-started/">
+                  getting started guide
+                </a>
+                .
+              </p>
+              {/*<Metadata content={content} />*/}
+              <div style={{ border: '1px solid var(--color-silver)' }}>
+                <YamlView content={content} showAll={showAll} />
+              </div>
+              {!showAll && (
+                <button onClick={() => setShowAll(true)} className="passive sp-margin-s-top">
+                  <i className="fa fa-plus" /> Show all {totalLines} lines
+                </button>
+              )}
+            </>
+          )}
+        </div>
+      </ModalBody>
+      {fetchResource.status === 'RESOLVED' && (
+        <ModalFooter
+          primaryActions={
+            <PrimaryActions
+              text={fetchResource.result}
+              url={ManagedReader.getResourceExportUrl(props)}
+              name={props.name}
+            />
+          }
+        />
+      )}
+    </Modal>
+  );
+};

--- a/app/scripts/modules/core/src/managed/index.ts
+++ b/app/scripts/modules/core/src/managed/index.ts
@@ -1,4 +1,5 @@
 export * from './DeployingIntoManagedClusterWarning';
+export * from './export/ExportResourceMenuItem';
 export * from './ManagedReader';
 export * from './ManagedWriter';
 export * from './ManagedResourceDetailsIndicator';

--- a/app/scripts/modules/titus/src/serverGroup/details/serverGroupDetails.html
+++ b/app/scripts/modules/titus/src/serverGroup/details/serverGroupDetails.html
@@ -47,6 +47,14 @@
             <li><a href ng-if="serverGroup.isDisabled" ng-click="ctrl.enableServerGroup()">Enable</a></li>
             <li><a href ng-click="ctrl.destroyServerGroup()">Destroy</a></li>
             <li><a href ng-click="ctrl.cloneServerGroup()">Clone</a></li>
+            <export-resource-menu-item
+              cloud-provider="'titus'"
+              account="serverGroup.account"
+              type="'cluster'"
+              name="serverGroup.cluster"
+              is-managed="!!serverGroup.managedResourceSummary"
+              application="ctrl.application"
+            ></export-resource-menu-item>
             <add-entity-tag-links
               component="serverGroup"
               application="ctrl.application"


### PR DESCRIPTION
Adds a menu item to expose the Managed Delivery export endpoint for relevant resources.

This is still rough and subject to change based on what we do with `locations`. And we need to figure out how we want to feature flag this on/off. Mostly getting this out in case I need to take take off suddenly.

<img width="1006" alt="Screen Shot 2020-01-22 at 10 50 03 AM" src="https://user-images.githubusercontent.com/73450/72935654-9ebf4280-3d1a-11ea-90c1-c4312f149920.png">
