### PR TITLE
fix(core): prevent tabbing into CopyToClipboard hidden input

### DIFF
--- a/app/scripts/modules/core/src/utils/clipboard/CopyToClipboard.tsx
+++ b/app/scripts/modules/core/src/utils/clipboard/CopyToClipboard.tsx
@@ -134,6 +134,7 @@ export class CopyToClipboard extends React.Component<ICopyToClipboardProps, ICop
           onChange={e => e} // no-op to prevent warnings
           ref={this.inputRef}
           value={text}
+          tabIndex={-1}
           style={{ zIndex: -1, position: 'fixed', opacity: 0, top: 0, left: 0 }}
         />
         {this.renderTooltip(copyButton)}


### PR DESCRIPTION
If you're out there tabbing around on the screen, you can end up with your cursor hidden away in a textarea and you can't see why. It's no good.