### PR TITLE
fix(artifacts): Fix find artifacts from execution stage

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/base64/base64.artifact.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/base64/base64.artifact.ts
@@ -6,6 +6,12 @@ import { Registry } from 'core/registry';
 
 import './base64.artifact.less';
 
+controllerFn.$inject = ['artifact'];
+function controllerFn(artifact: IArtifact) {
+  this.artifact = artifact;
+  this.artifact.type = 'embedded/base64';
+}
+
 export const BASE64_ARTIFACT = 'spinnaker.core.pipeline.trigger.artifact.base64';
 module(BASE64_ARTIFACT, []).config(() => {
   Registry.pipeline.mergeArtifactKind({
@@ -16,10 +22,7 @@ module(BASE64_ARTIFACT, []).config(() => {
     key: 'base64',
     isDefault: false,
     isMatch: true,
-    controller: function(artifact: IArtifact) {
-      this.artifact = artifact;
-      this.artifact.type = 'embedded/base64';
-    },
+    controller: controllerFn,
     controllerAs: 'ctrl',
     template: `
 <div class="col-md-12">

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/bitbucket/bitbucket.artifact.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/bitbucket/bitbucket.artifact.ts
@@ -4,6 +4,12 @@ import { ArtifactTypePatterns } from 'core/artifact';
 import { IArtifact } from 'core/domain/IArtifact';
 import { Registry } from 'core/registry';
 
+controllerFn.$inject = ['artifact'];
+function controllerFn(artifact: IArtifact) {
+  this.artifact = artifact;
+  this.artifact.type = 'bitbucket/file';
+}
+
 export const BITBUCKET_ARTIFACT = 'spinnaker.core.pipeline.trigger.bitbucket.artifact';
 module(BITBUCKET_ARTIFACT, []).config(() => {
   Registry.pipeline.mergeArtifactKind({
@@ -14,10 +20,7 @@ module(BITBUCKET_ARTIFACT, []).config(() => {
     key: 'bitbucket',
     isDefault: false,
     isMatch: true,
-    controller: function(artifact: IArtifact) {
-      this.artifact = artifact;
-      this.artifact.type = 'bitbucket/file';
-    },
+    controller: controllerFn,
     controllerAs: 'ctrl',
     template: `
 <div class="col-md-12">

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/bitbucket/defaultBitbucket.artifact.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/bitbucket/defaultBitbucket.artifact.ts
@@ -4,6 +4,20 @@ import { ArtifactTypePatterns } from 'core/artifact';
 import { IArtifact } from 'core/domain/IArtifact';
 import { Registry } from 'core/registry';
 
+controllerFn.$inject = ['artifact'];
+function controllerFn(artifact: IArtifact) {
+  this.artifact = artifact;
+  this.artifact.type = 'bitbucket/file';
+  const pathRegex = new RegExp('/1.0/repositories/[^/]*/[^/]*/raw/[^/]*/(.*)$');
+
+  this.onReferenceChange = () => {
+    const results = pathRegex.exec(this.artifact.reference);
+    if (results !== null) {
+      this.artifact.name = decodeURIComponent(results[1]);
+    }
+  };
+}
+
 export const DEFAULT_BITBUCKET_ARTIFACT = 'spinnaker.core.pipeline.trigger.artifact.defaultBitbucket';
 module(DEFAULT_BITBUCKET_ARTIFACT, []).config(() => {
   Registry.pipeline.mergeArtifactKind({
@@ -14,18 +28,7 @@ module(DEFAULT_BITBUCKET_ARTIFACT, []).config(() => {
     key: 'default.bitbucket',
     isDefault: true,
     isMatch: false,
-    controller: function(artifact: IArtifact) {
-      this.artifact = artifact;
-      this.artifact.type = 'bitbucket/file';
-      const pathRegex = new RegExp('/1.0/repositories/[^/]*/[^/]*/raw/[^/]*/(.*)$');
-
-      this.onReferenceChange = () => {
-        const results = pathRegex.exec(this.artifact.reference);
-        if (results !== null) {
-          this.artifact.name = decodeURIComponent(results[1]);
-        }
-      };
-    },
+    controller: controllerFn,
     controllerAs: 'ctrl',
     template: `
 <div class="col-md-12">

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/custom/custom.artifact.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/custom/custom.artifact.ts
@@ -8,6 +8,11 @@ class CustomArtifactController implements IController {
   constructor(public artifact: IArtifact) {}
 }
 
+controllerFn.$inject = ['artifact'];
+function controllerFn(artifact: IArtifact) {
+  this.artifact = artifact;
+}
+
 export const CUSTOM_ARTIFACT = 'spinnaker.core.pipeline.trigger.custom.artifact';
 module(CUSTOM_ARTIFACT, [])
   .config(() => {
@@ -18,9 +23,7 @@ module(CUSTOM_ARTIFACT, [])
       customKind: true,
       isDefault: true,
       isMatch: true,
-      controller: function(artifact: IArtifact) {
-        this.artifact = artifact;
-      },
+      controller: controllerFn,
       controllerAs: 'ctrl',
       typePattern: /UNMATCHABLE/,
       template: `

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/docker/defaultDocker.artifact.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/docker/defaultDocker.artifact.ts
@@ -26,6 +26,16 @@ export const setNameAndVersionFromReference = (artifact: IArtifact) => {
   }
 };
 
+controllerFn.$inject = ['artifact'];
+function controllerFn(artifact: IArtifact) {
+  this.artifact = artifact;
+  this.artifact.type = 'docker/image';
+
+  this.onReferenceChange = () => {
+    setNameAndVersionFromReference(this.artifact);
+  };
+}
+
 export const DEFAULT_DOCKER_ARTIFACT = 'spinnaker.core.pipeline.trigger.artifact.defaultDocker';
 module(DEFAULT_DOCKER_ARTIFACT, []).config(() => {
   Registry.pipeline.mergeArtifactKind({
@@ -36,14 +46,7 @@ module(DEFAULT_DOCKER_ARTIFACT, []).config(() => {
     isMatch: false,
     description: 'A Docker image to be deployed.',
     key: 'default.docker',
-    controller: function(artifact: IArtifact) {
-      this.artifact = artifact;
-      this.artifact.type = 'docker/image';
-
-      this.onReferenceChange = () => {
-        setNameAndVersionFromReference(this.artifact);
-      };
-    },
+    controller: controllerFn,
     controllerAs: 'ctrl',
     template: `
 <div class="col-md-12">

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/docker/docker.artifact.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/docker/docker.artifact.ts
@@ -4,6 +4,12 @@ import { ArtifactTypePatterns } from 'core/artifact';
 import { IArtifact } from 'core/domain/IArtifact';
 import { Registry } from 'core/registry';
 
+controllerFn.$inject = ['artifact'];
+function controllerFn(artifact: IArtifact) {
+  this.artifact = artifact;
+  this.artifact.type = 'docker/image';
+}
+
 export const DOCKER_ARTIFACT = 'spinnaker.core.pipeline.trigger.artifact.docker';
 module(DOCKER_ARTIFACT, []).config(() => {
   Registry.pipeline.mergeArtifactKind({
@@ -14,10 +20,7 @@ module(DOCKER_ARTIFACT, []).config(() => {
     isMatch: true,
     description: 'A Docker image to be deployed.',
     key: 'docker',
-    controller: function(artifact: IArtifact) {
-      this.artifact = artifact;
-      this.artifact.type = 'docker/image';
-    },
+    controller: controllerFn,
     controllerAs: 'ctrl',
     template: `
 <div class="col-md-12">

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/gcs/defaultGcs.artifact.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/gcs/defaultGcs.artifact.ts
@@ -5,6 +5,27 @@ import { ArtifactTypePatterns } from 'core/artifact';
 import { IArtifact } from 'core/domain/IArtifact';
 import { Registry } from 'core/registry';
 
+controllerFn.$inject = ['artifact'];
+function controllerFn(artifact: IArtifact) {
+  this.artifact = artifact;
+  this.artifact.type = 'gcs/object';
+
+  this.onReferenceChange = () => {
+    const ref = this.artifact.reference;
+    if (isNil(ref)) {
+      return;
+    }
+
+    if (ref.indexOf('#') >= 0) {
+      const split = ref.split('#');
+      this.artifact.name = split[0];
+      this.artifact.version = split[1];
+    } else {
+      this.artifact.name = ref;
+    }
+  };
+}
+
 export const DEFAULT_GCS_ARTIFACT = 'spinnaker.core.pipeline.trigger.artifact.defaultGcs';
 module(DEFAULT_GCS_ARTIFACT, []).config(() => {
   Registry.pipeline.mergeArtifactKind({
@@ -15,25 +36,7 @@ module(DEFAULT_GCS_ARTIFACT, []).config(() => {
     key: 'default.gcs',
     isDefault: true,
     isMatch: false,
-    controller: function(artifact: IArtifact) {
-      this.artifact = artifact;
-      this.artifact.type = 'gcs/object';
-
-      this.onReferenceChange = () => {
-        const ref = this.artifact.reference;
-        if (isNil(ref)) {
-          return;
-        }
-
-        if (ref.indexOf('#') >= 0) {
-          const split = ref.split('#');
-          this.artifact.name = split[0];
-          this.artifact.version = split[1];
-        } else {
-          this.artifact.name = ref;
-        }
-      };
-    },
+    controller: controllerFn,
     controllerAs: 'ctrl',
     template: `
 <div class="col-md-12">

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/gcs/gcs.artifact.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/gcs/gcs.artifact.ts
@@ -4,6 +4,12 @@ import { ArtifactTypePatterns } from 'core/artifact';
 import { IArtifact } from 'core/domain/IArtifact';
 import { Registry } from 'core/registry';
 
+controllerFn.$inject = ['artifact'];
+function controllerFn(artifact: IArtifact) {
+  this.artifact = artifact;
+  this.artifact.type = 'gcs/object';
+}
+
 export const GCS_ARTIFACT = 'spinnaker.core.pipeline.trigger.gcs.artifact';
 module(GCS_ARTIFACT, []).config(() => {
   Registry.pipeline.mergeArtifactKind({
@@ -14,10 +20,7 @@ module(GCS_ARTIFACT, []).config(() => {
     key: 'gcs',
     isDefault: false,
     isMatch: true,
-    controller: function(artifact: IArtifact) {
-      this.artifact = artifact;
-      this.artifact.type = 'gcs/object';
-    },
+    controller: controllerFn,
     controllerAs: 'ctrl',
     template: `
 <div class="col-md-12">

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/github/defaultGithub.artifact.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/github/defaultGithub.artifact.ts
@@ -4,6 +4,20 @@ import { ArtifactTypePatterns } from 'core/artifact';
 import { IArtifact } from 'core/domain/IArtifact';
 import { Registry } from 'core/registry';
 
+controllerFn.$inject = ['artifact'];
+function controllerFn(artifact: IArtifact) {
+  this.artifact = artifact;
+  this.artifact.type = 'github/file';
+  const pathRegex = new RegExp('/repos/[^/]*/[^/]*/contents/(.*)$');
+
+  this.onReferenceChange = () => {
+    const results = pathRegex.exec(this.artifact.reference);
+    if (results !== null) {
+      this.artifact.name = results[1];
+    }
+  };
+}
+
 export const DEFAULT_GITHUB_ARTIFACT = 'spinnaker.core.pipeline.trigger.artifact.defaultGithub';
 module(DEFAULT_GITHUB_ARTIFACT, []).config(() => {
   Registry.pipeline.mergeArtifactKind({
@@ -14,18 +28,7 @@ module(DEFAULT_GITHUB_ARTIFACT, []).config(() => {
     key: 'default.github',
     isDefault: true,
     isMatch: false,
-    controller: function(artifact: IArtifact) {
-      this.artifact = artifact;
-      this.artifact.type = 'github/file';
-      const pathRegex = new RegExp('/repos/[^/]*/[^/]*/contents/(.*)$');
-
-      this.onReferenceChange = () => {
-        const results = pathRegex.exec(this.artifact.reference);
-        if (results !== null) {
-          this.artifact.name = results[1];
-        }
-      };
-    },
+    controller: controllerFn,
     controllerAs: 'ctrl',
     template: `
 <div class="col-md-12">

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/github/github.artifact.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/github/github.artifact.ts
@@ -4,6 +4,12 @@ import { ArtifactTypePatterns } from 'core/artifact';
 import { IArtifact } from 'core/domain/IArtifact';
 import { Registry } from 'core/registry';
 
+controllerFn.$inject = ['artifact'];
+function controllerFn(artifact: IArtifact) {
+  this.artifact = artifact;
+  this.artifact.type = 'github/file';
+}
+
 export const GITHUB_ARTIFACT = 'spinnaker.core.pipeline.trigger.github.artifact';
 module(GITHUB_ARTIFACT, []).config(() => {
   Registry.pipeline.mergeArtifactKind({
@@ -14,10 +20,7 @@ module(GITHUB_ARTIFACT, []).config(() => {
     type: 'github/file',
     isDefault: false,
     isMatch: true,
-    controller: function(artifact: IArtifact) {
-      this.artifact = artifact;
-      this.artifact.type = 'github/file';
-    },
+    controller: controllerFn,
     controllerAs: 'ctrl',
     template: `
 <div class="col-md-12">

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/gitlab/defaultGitlab.artifact.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/gitlab/defaultGitlab.artifact.ts
@@ -4,6 +4,20 @@ import { ArtifactTypePatterns } from 'core/artifact';
 import { IArtifact } from 'core/domain/IArtifact';
 import { Registry } from 'core/registry';
 
+controllerFn.$inject = ['artifact'];
+function controllerFn(artifact: IArtifact) {
+  this.artifact = artifact;
+  this.artifact.type = 'gitlab/file';
+  const pathRegex = new RegExp('/api/v4/projects/[^/]*/[^/]*/repository/files/(.*)$');
+
+  this.onReferenceChange = () => {
+    const results = pathRegex.exec(this.artifact.reference);
+    if (results !== null) {
+      this.artifact.name = decodeURIComponent(results[1]);
+    }
+  };
+}
+
 export const DEFAULT_GITLAB_ARTIFACT = 'spinnaker.core.pipeline.trigger.artifact.defaultGitlab';
 module(DEFAULT_GITLAB_ARTIFACT, []).config(() => {
   Registry.pipeline.mergeArtifactKind({
@@ -14,18 +28,7 @@ module(DEFAULT_GITLAB_ARTIFACT, []).config(() => {
     key: 'default.gitlab',
     isDefault: true,
     isMatch: false,
-    controller: function(artifact: IArtifact) {
-      this.artifact = artifact;
-      this.artifact.type = 'gitlab/file';
-      const pathRegex = new RegExp('/api/v4/projects/[^/]*/[^/]*/repository/files/(.*)$');
-
-      this.onReferenceChange = () => {
-        const results = pathRegex.exec(this.artifact.reference);
-        if (results !== null) {
-          this.artifact.name = decodeURIComponent(results[1]);
-        }
-      };
-    },
+    controller: controllerFn,
     controllerAs: 'ctrl',
     template: `
 <div class="col-md-12">

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/gitlab/gitlab.artifact.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/gitlab/gitlab.artifact.ts
@@ -4,6 +4,12 @@ import { ArtifactTypePatterns } from 'core/artifact';
 import { IArtifact } from 'core/domain/IArtifact';
 import { Registry } from 'core/registry';
 
+controllerFn.$inject = ['artifact'];
+function controllerFn(artifact: IArtifact) {
+  this.artifact = artifact;
+  this.artifact.type = 'gitlab/file';
+}
+
 export const GITLAB_ARTIFACT = 'spinnaker.core.pipeline.trigger.gitlab.artifact';
 module(GITLAB_ARTIFACT, []).config(() => {
   Registry.pipeline.mergeArtifactKind({
@@ -14,10 +20,7 @@ module(GITLAB_ARTIFACT, []).config(() => {
     key: 'gitlab',
     isDefault: false,
     isMatch: true,
-    controller: function(artifact: IArtifact) {
-      this.artifact = artifact;
-      this.artifact.type = 'gitlab/file';
-    },
+    controller: controllerFn,
     controllerAs: 'ctrl',
     template: `
 <div class="col-md-12">

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/http/defaultHttp.artifact.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/http/defaultHttp.artifact.ts
@@ -4,6 +4,15 @@ import { ArtifactTypePatterns } from 'core/artifact';
 import { IArtifact } from 'core/domain/IArtifact';
 import { Registry } from 'core/registry';
 
+controllerFn.$inject = ['artifact'];
+function controllerFn(artifact: IArtifact) {
+  this.artifact = artifact;
+  this.artifact.type = 'http/file';
+  if (this.artifact.name && !this.artifact.reference) {
+    this.artifact.reference = this.artifact.name;
+  }
+}
+
 export const DEFAULT_HTTP_ARTIFACT = 'spinnaker.core.pipeline.trigger.defaultHttp.artifact';
 module(DEFAULT_HTTP_ARTIFACT, []).config(() => {
   Registry.pipeline.mergeArtifactKind({
@@ -14,13 +23,7 @@ module(DEFAULT_HTTP_ARTIFACT, []).config(() => {
     key: 'default.http',
     isDefault: true,
     isMatch: false,
-    controller: function(artifact: IArtifact) {
-      this.artifact = artifact;
-      this.artifact.type = 'http/file';
-      if (this.artifact.name && !this.artifact.reference) {
-        this.artifact.reference = this.artifact.name;
-      }
-    },
+    controller: controllerFn,
     controllerAs: 'ctrl',
     template: `
 <div class="col-md-12">

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/http/http.artifact.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/http/http.artifact.ts
@@ -9,6 +9,15 @@ class HttpArtifactController implements IController {
   constructor(public artifact: IArtifact) {}
 }
 
+controllerFn.$inject = ['artifact'];
+function controllerFn(artifact: IArtifact) {
+  this.artifact = artifact;
+  this.artifact.type = 'http/file';
+  if (this.artifact.name && !this.artifact.reference) {
+    this.artifact.reference = this.artifact.name;
+  }
+}
+
 export const HTTP_ARTIFACT = 'spinnaker.core.pipeline.trigger.http.artifact';
 module(HTTP_ARTIFACT, [])
   .config(() => {
@@ -20,13 +29,7 @@ module(HTTP_ARTIFACT, [])
       key: 'http',
       isDefault: false,
       isMatch: true,
-      controller: function(artifact: IArtifact) {
-        this.artifact = artifact;
-        this.artifact.type = 'http/file';
-        if (this.artifact.name && !this.artifact.reference) {
-          this.artifact.reference = this.artifact.name;
-        }
-      },
+      controller: controllerFn,
       controllerAs: 'ctrl',
       template: `
 <div class="col-md-12">

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/ivy/ivy.artifact.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/ivy/ivy.artifact.ts
@@ -9,6 +9,12 @@ class IvyArtifactController implements IController {
   constructor(public artifact: IArtifact) {}
 }
 
+controllerFn.$inject = ['artifact'];
+function controllerFn(artifact: IArtifact) {
+  this.artifact = artifact;
+  this.artifact.type = 'ivy/file';
+}
+
 export const IVY_ARTIFACT = 'spinnaker.core.pipeline.trigger.ivy.artifact';
 module(IVY_ARTIFACT, [])
   .config(() => {
@@ -20,10 +26,7 @@ module(IVY_ARTIFACT, [])
       key: 'ivy',
       isDefault: false,
       isMatch: true,
-      controller: function(artifact: IArtifact) {
-        this.artifact = artifact;
-        this.artifact.type = 'ivy/file';
-      },
+      controller: controllerFn,
       controllerAs: 'ctrl',
       template: `
 <div class="col-md-12">

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/jenkins/jenkins.artifact.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/jenkins/jenkins.artifact.ts
@@ -4,6 +4,12 @@ import { ArtifactTypePatterns } from 'core/artifact';
 import { IArtifact } from 'core/domain/IArtifact';
 import { Registry } from 'core/registry';
 
+controllerFn.$inject = ['artifact'];
+function controllerFn(artifact: IArtifact) {
+  this.artifact = artifact;
+  this.artifact.type = 'ivy/file';
+}
+
 export const JENKINS_ARTIFACT = 'spinnaker.core.pipeline.trigger.jenkins.artifact';
 module(JENKINS_ARTIFACT, []).config(() => {
   Registry.pipeline.mergeArtifactKind({
@@ -14,10 +20,7 @@ module(JENKINS_ARTIFACT, []).config(() => {
     key: 'jenkins',
     isDefault: false,
     isMatch: true,
-    controller: function(artifact: IArtifact) {
-      this.artifact = artifact;
-      this.artifact.type = 'ivy/file';
-    },
+    controller: controllerFn,
     controllerAs: 'ctrl',
     template: `
 <div class="col-md-12">

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/maven/maven.artifact.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/maven/maven.artifact.ts
@@ -9,6 +9,12 @@ class MavenArtifactController implements IController {
   constructor(public artifact: IArtifact) {}
 }
 
+controllerFn.$inject = ['artifact'];
+function controllerFn(artifact: IArtifact) {
+  this.artifact = artifact;
+  this.artifact.type = 'maven/file';
+}
+
 export const MAVEN_ARTIFACT = 'spinnaker.core.pipeline.trigger.maven.artifact';
 module(MAVEN_ARTIFACT, [])
   .config(() => {
@@ -20,10 +26,7 @@ module(MAVEN_ARTIFACT, [])
       key: 'maven',
       isDefault: false,
       isMatch: true,
-      controller: function(artifact: IArtifact) {
-        this.artifact = artifact;
-        this.artifact.type = 'maven/file';
-      },
+      controller: controllerFn,
       controllerAs: 'ctrl',
       template: `
 <div class="col-md-12">

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/s3/defaultS3.artifact.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/s3/defaultS3.artifact.ts
@@ -5,6 +5,27 @@ import { ArtifactTypePatterns } from 'core/artifact';
 import { IArtifact } from 'core/domain/IArtifact';
 import { Registry } from 'core/registry';
 
+controllerFn.$inject = ['artifact'];
+function controllerFn(artifact: IArtifact) {
+  this.artifact = artifact;
+  this.artifact.type = 's3/object';
+
+  this.onReferenceChange = () => {
+    const ref = this.artifact.reference;
+    if (isNil(ref)) {
+      return;
+    }
+
+    if (ref.indexOf('#') >= 0) {
+      const split = ref.split('#');
+      this.artifact.name = split[0];
+      this.artifact.version = split[1];
+    } else {
+      this.artifact.name = ref;
+    }
+  };
+}
+
 export const DEFAULT_S3_ARTIFACT = 'spinnaker.core.pipeline.trigger.artifact.defaultS3';
 module(DEFAULT_S3_ARTIFACT, []).config(() => {
   Registry.pipeline.registerArtifactKind({
@@ -15,25 +36,7 @@ module(DEFAULT_S3_ARTIFACT, []).config(() => {
     key: 'default.s3',
     isDefault: true,
     isMatch: false,
-    controller: function(artifact: IArtifact) {
-      this.artifact = artifact;
-      this.artifact.type = 's3/object';
-
-      this.onReferenceChange = () => {
-        const ref = this.artifact.reference;
-        if (isNil(ref)) {
-          return;
-        }
-
-        if (ref.indexOf('#') >= 0) {
-          const split = ref.split('#');
-          this.artifact.name = split[0];
-          this.artifact.version = split[1];
-        } else {
-          this.artifact.name = ref;
-        }
-      };
-    },
+    controller: controllerFn,
     controllerAs: 'ctrl',
     template: `
 <div class="col-md-12">

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/s3/s3.artifact.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/s3/s3.artifact.ts
@@ -4,6 +4,12 @@ import { ArtifactTypePatterns } from 'core/artifact';
 import { IArtifact } from 'core/domain/IArtifact';
 import { Registry } from 'core/registry';
 
+controllerFn.$inject = ['artifact'];
+function controllerFn(artifact: IArtifact) {
+  this.artifact = artifact;
+  this.artifact.type = 's3/object';
+}
+
 export const S3_ARTIFACT = 'spinnaker.core.pipeline.trigger.s3.artifact';
 module(S3_ARTIFACT, []).config(() => {
   Registry.pipeline.mergeArtifactKind({
@@ -14,10 +20,7 @@ module(S3_ARTIFACT, []).config(() => {
     key: 's3',
     isDefault: false,
     isMatch: true,
-    controller: function(artifact: IArtifact) {
-      this.artifact = artifact;
-      this.artifact.type = 's3/object';
-    },
+    controller: controllerFn,
     controllerAs: 'ctrl',
     template: `
 <div class="col-md-12">


### PR DESCRIPTION
The find artifacts from execution stage is not able to load the widget for each artifact type; creating the controller is broken because the constructors are not annotated with dependency injection information and we are running in strict-di mode.

Fix this by extracting the anonymous controller for each artifact type into a function and annotating it with injection information. (I'm not aware of a way to annotate an anonymous function, except
by doing Object.assign(function() {}, { $inject: 'abc' }) which
seemed less readable.)