### PR TITLE
fix(deck): use label for parameters in manual execution if supplied

### DIFF
--- a/app/scripts/modules/core/src/pipeline/manualExecution/Parameters.tsx
+++ b/app/scripts/modules/core/src/pipeline/manualExecution/Parameters.tsx
@@ -49,7 +49,7 @@ export class Parameters extends React.Component<IParametersProps> {
           visibleParameters.map((parameter, i) => {
             const fieldProps = {
               name: formikFieldNameForParam(parameter),
-              label: parameter.name,
+              label: parameter.label || parameter.name,
               help: parameter.description && <HelpField content={parameter.description} />,
               fastField: false,
               required: parameter.required,

--- a/test/functional/tests/core/manual_execution_smoke_test.spec.ts.mountebank_fixture.json
+++ b/test/functional/tests/core/manual_execution_smoke_test.spec.ts.mountebank_fixture.json
@@ -1607,7 +1607,7 @@
               "Date": "Tue, 26 Feb 2019 18:29:46 GMT",
               "Connection": "close"
             },
-            "body": "[{\"application\":\"compute\",\"id\":\"d6e7e0bc-83f5-461f-a95c-568080b49b6e\",\"index\":0,\"keepWaitingPipelines\":false,\"lastModifiedBy\":\"anonymous\",\"limitConcurrent\":true,\"name\":\"Simple Wait Pipeline\",\"stages\":[{\"name\":\"Wait\",\"refId\":\"1\",\"requisiteStageRefIds\":[],\"type\":\"wait\",\"waitTime\":2}],\"triggers\":[],\"updateTs\":\"1551204837863\"}]",
+            "body": "[{\"application\":\"compute\",\"id\":\"d6e7e0bc-83f5-461f-a95c-568080b49b6e\",\"index\":0,\"parameterConfig\":[{\"default\":\"123\",\"description\":\"param1\",\"hasOptions\":false,\"label\":\"labeled param1\",\"name\":\"param1\",\"options\":[{\"value\":\"\"}],\"pinned\":true,\"required\":true},{\"default\":\"abc\",\"description\":\"param2\",\"hasOptions\":false,\"label\":\"\",\"name\":\"param2\",\"options\":[{\"value\":\"\"}],\"pinned\":true,\"required\":true}],\"keepWaitingPipelines\":false,\"lastModifiedBy\":\"anonymous\",\"limitConcurrent\":true,\"name\":\"Simple Wait Pipeline\",\"stages\":[{\"name\":\"Wait\",\"refId\":\"1\",\"requisiteStageRefIds\":[],\"type\":\"wait\",\"waitTime\":2}],\"triggers\":[],\"updateTs\":\"1551204837863\"}]",
             "_mode": "text"
           }
         }

--- a/test/functional/tests/core/pages/ManualExecutionModalPage.ts
+++ b/test/functional/tests/core/pages/ManualExecutionModalPage.ts
@@ -6,6 +6,15 @@ export class ManualExecutionModalPage extends Page {
     runButton:
       '//div[contains(@class, "modal-content")]//button[contains(@class, "btn-primary") and contains(., "Run")]',
 
+    paramWithLabel:
+      '//div[contains(@class, "modal-content")]//div[contains(@class, "form-group")]//label[text()="labeled param1"]',
+    paramWithoutLabel:
+      '//div[contains(@class, "modal-content")]//div[contains(@class, "form-group")]//label[text()="param2"]',
+    notificationsLabel:
+      '//div[contains(@class, "modal-content")]//div[contains(@class, "form-group")]//label[text()="Notifications"]',
+    notificationsValue:
+      '//div[contains(@class, "modal-content")]//div[contains(@class, "form-group")]//input[@type="checkbox" and @name="notificationEnabled"]',
+
     factories: {
       pipelineWithName: (name: string) => `//*[contains(@class, 'Select-menu')]//div[contains(text(), '${name}')]`,
     },
@@ -14,6 +23,10 @@ export class ManualExecutionModalPage extends Page {
   runPipeline = (name: string) => {
     this.click(ManualExecutionModalPage.locators.pipelineSelectArrow);
     this.click(ManualExecutionModalPage.locators.factories.pipelineWithName(name));
+    this.awaitLocator(ManualExecutionModalPage.locators.notificationsLabel);
+    this.awaitLocator(ManualExecutionModalPage.locators.notificationsValue);
+    this.awaitLocator(ManualExecutionModalPage.locators.paramWithLabel);
+    this.awaitLocator(ManualExecutionModalPage.locators.paramWithoutLabel);
     this.click(ManualExecutionModalPage.locators.runButton);
   };
 }


### PR DESCRIPTION
@maggieneterval @ethanfrogers 

fixes the lost functionality mentioned in https://github.com/spinnaker/spinnaker/issues/4890 during angular -> react migration by displaying supplied labels on the manual execution gui.

@maggieneterval I was tracking down how to get the labels to display in the execution details and tracked it down to https://github.com/spinnaker/gate/blob/master/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ApplicationController.groovy#L124 . The problem is, it looks like this is returning a list of linkedhashmaps and the parameters themselves are just a map of name->values for the parameters. Do you have any thoughts on how we could easily get the labels returned as well? Would it be good to push this to a later PR?

Lastly, I updated ManualExecutionModalPage and related fixtures to include some test for the parameters with and without labels. I'm not entirely sure if how I handled the fixture update and if its the best place for those checks, but let me know and I can update if needed.