### PR TITLE
feat(deck): Add execution error details to Task Status in Cloud Formation Stage

### DIFF
--- a/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/deployCloudFormationExecutionDetails.tsx
+++ b/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/deployCloudFormationExecutionDetails.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+
+import {
+  IExecutionDetailsSectionProps,
+  ExecutionDetailsSection,
+  ExecutionStepDetails,
+  StageFailureMessage,
+} from '@spinnaker/core';
+
+export class DeployExecutionDetails extends React.Component<IExecutionDetailsSectionProps> {
+  public static title = 'Task Status';
+
+  constructor(props: IExecutionDetailsSectionProps) {
+    super(props);
+  }
+
+  public render() {
+    const { stage, current, name } = this.props;
+
+    return (
+      <ExecutionDetailsSection name={name} current={current}>
+        <ExecutionStepDetails item={stage} />
+        <StageFailureMessage stage={stage} message={stage.failureMessage} />
+      </ExecutionDetailsSection>
+    );
+  }
+}

--- a/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/deployCloudFormationStackStage.ts
+++ b/app/scripts/modules/amazon/src/pipeline/stages/deployCloudFormation/deployCloudFormationStackStage.ts
@@ -1,12 +1,8 @@
 import { module } from 'angular';
 
-import {
-  ArtifactReferenceService,
-  ExecutionDetailsTasks,
-  ExpectedArtifactService,
-  IStage,
-  Registry,
-} from '@spinnaker/core';
+import { ArtifactReferenceService, ExpectedArtifactService, IStage, Registry } from '@spinnaker/core';
+
+import { DeployExecutionDetails } from './deployCloudFormationExecutionDetails';
 
 import { EvaluateCloudFormationChangeSetExecutionMarkerIcon } from './evaluateCloudFormationChangeSetExecutionMarkerIcon';
 import { EvaluateCloudFormationChangeSetExecutionLabel } from './evaluateCloudFormationChangeSetExecutionLabel';
@@ -27,7 +23,7 @@ module(DEPLOY_CLOUDFORMATION_STACK_STAGE, [])
       controller: 'DeployCloudFormationStackConfigController',
       controllerAs: 'ctrl',
       useCustomTooltip: true,
-      executionDetailsSections: [ExecutionDetailsTasks, EvaluateCloudFormationChangeSetExecutionDetails],
+      executionDetailsSections: [DeployExecutionDetails, EvaluateCloudFormationChangeSetExecutionDetails],
       executionLabelComponent: EvaluateCloudFormationChangeSetExecutionLabel,
       producesArtifacts: true,
       supportsCustomTimeout: true,

--- a/app/scripts/modules/core/src/pipeline/config/stages/common/index.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/common/index.ts
@@ -5,3 +5,4 @@ export * from './ExecutionDetailsTasks';
 export * from './IStageConfigProps';
 export * from './stageConfigField/StageConfigField';
 export * from './applySuspendedStatuses';
+export * from './ExecutionStepDetails';


### PR DESCRIPTION
The CFN Stage is not showing the error when failing. With this feature the error is shown.

Before:
![image](https://user-images.githubusercontent.com/45596882/73169162-cbe56980-40fb-11ea-972f-8aebd1c32804.png)

After:
![image](https://user-images.githubusercontent.com/45596882/73169342-28e11f80-40fc-11ea-9782-215eb8e6e4f2.png)

