### PR TITLE
feat(amazon): Expose addresses for IPv6 instances

### DIFF
--- a/app/scripts/modules/amazon/src/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/amazon/src/instance/details/instance.details.controller.js
@@ -197,8 +197,9 @@ module(AMAZON_INSTANCE_DETAILS_INSTANCE_DETAILS_CONTROLLER, [
           $scope.instance.loadBalancers = loadBalancers;
           $scope.instance.targetGroups = targetGroups;
           if ($scope.instance.networkInterfaces) {
-            const allIpv6Addresses = _.flatten($scope.instance.networkInterfaces.map(i => i.ipv6Addresses));
-            $scope.instance.ipv6Addresses = allIpv6Addresses.map(address => address.ipv6Address);
+            $scope.instance.ipv6Addresses = _.flatMap($scope.instance.networkInterfaces, i =>
+              i.ipv6Addresses.map(a => a.ipv6Address),
+            );
 
             const permanentNetworkInterfaces = $scope.instance.networkInterfaces.filter(
               f => f.attachment.deleteOnTermination === false,

--- a/app/scripts/modules/amazon/src/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/amazon/src/instance/details/instance.details.controller.js
@@ -197,6 +197,9 @@ module(AMAZON_INSTANCE_DETAILS_INSTANCE_DETAILS_CONTROLLER, [
           $scope.instance.loadBalancers = loadBalancers;
           $scope.instance.targetGroups = targetGroups;
           if ($scope.instance.networkInterfaces) {
+            const allIpv6Addresses = _.flatten($scope.instance.networkInterfaces.map(i => i.ipv6Addresses));
+            $scope.instance.ipv6Addresses = allIpv6Addresses.map(address => address.ipv6Address);
+
             const permanentNetworkInterfaces = $scope.instance.networkInterfaces.filter(
               f => f.attachment.deleteOnTermination === false,
             );

--- a/app/scripts/modules/amazon/src/instance/details/instanceDetails.html
+++ b/app/scripts/modules/amazon/src/instance/details/instanceDetails.html
@@ -223,7 +223,9 @@
           <copy-to-clipboard class="copy-to-clipboard copy-to-clipboard-sm" text="ip" tool-tip="'Copy to clipboard'">
           </copy-to-clipboard>
         </dd>
-        <dt ng-if="instance.publicIpAddress">Public IP Address</dt>
+        <dt ng-if="instance.publicIpAddress || instance.ipv6Addresses.length">
+          Public IP Address<span ng-if="instance.ipv6Addresses.length > 1">es</span>
+        </dt>
         <dd ng-if="instance.publicIpAddress">
           <a href="http://{{instance.publicIpAddress}}:{{state.instancePort}}" target="_blank"
             >{{instance.publicIpAddress}}</a
@@ -233,6 +235,11 @@
             text="instance.publicIpAddress"
             tool-tip="'Copy to clipboard'"
           >
+          </copy-to-clipboard>
+        </dd>
+        <dd ng-if="instance.ipv6Addresses.length" ng-repeat="ip in instance.ipv6Addresses">
+          <a href="http://{{ip}}:{{state.instancePort}}" target="_blank">{{ip}}</a>
+          <copy-to-clipboard class="copy-to-clipboard copy-to-clipboard-sm" text="ip" tool-tip="'Copy to clipboard'">
           </copy-to-clipboard>
         </dd>
       </dl>


### PR DESCRIPTION
Amazon supports instances with IPv6 addresses, so Spinnaker should expose those addresses in the instance details section. 

IP addresses from the v6 family are all public. Also, multiple interfaces can be attached to a v6 instance, so each may have N number of IPv6 addresses. Here are some possible scenarios for an aws instance:
1. One Private IPv4 with one public IPv4 (currently supported)
2. One Private IPv4 with one or more IPv6
3. Only IPv6 addresses, maximum one per network interface
4. One private IPv4, one public IPv4, and one or more IPv6 address (rare edge case)

This PR enables support for the last 3 scenarios.