### PR TITLE
feat(core): enable the "Override Helm chart artifact" checkbox in man…

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/ManualExecutionBakeManifest.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/ManualExecutionBakeManifest.tsx
@@ -9,7 +9,7 @@ import { BAKE_MANIFEST_STAGE_KEY } from './bakeManifestStage';
 const HelmEditor = HelmMatch.editCmp;
 
 export function ManualExecutionBakeManifest(props: ITriggerTemplateComponentProps) {
-  const [overrideArtifact, setOverrideArtifact] = React.useState(false);
+  const [overrideArtifact, setOverrideArtifact] = React.useState(true);
 
   const updateHelmArtifact = (artifact: IArtifact) => {
     const updatedArtifacts = (props.command.extraFields.artifacts || []).filter(


### PR DESCRIPTION
…ual execution by default

Since this is manual execution, it seems like a safe assumption that people want to
specify the helm chart to use.  Leaving it unchecked either leads to pipeline failure, or
to using an artifact from a prior execution (if enabled), both of which are surprising.

before:
<img width="352" alt="helm_chart_override_unchecked" src="https://user-images.githubusercontent.com/1521148/73299411-fe5a9980-41c3-11ea-9cab-2fb92ead3736.png">

after:
<img width="486" alt="helm_chart_override_checked" src="https://user-images.githubusercontent.com/1521148/73299441-0b778880-41c4-11ea-8b70-f11435620ea1.png">
