### PR TITLE
fix(amazon): Prevent error if target group is undefined

### DIFF
--- a/app/scripts/modules/amazon/src/instance/details/utils.ts
+++ b/app/scripts/modules/amazon/src/instance/details/utils.ts
@@ -16,7 +16,7 @@ export const applyHealthCheckInfoToTargetGroups = (
   healthMetrics.forEach(metric => {
     if (metric.type === 'TargetGroup') {
       metric.targetGroups.forEach((tg: ITargetGroup) => {
-        const group = targetGroups[tg.name];
+        const group = targetGroups[tg.name] || ({} as ITargetGroup);
         const port = group.healthCheckPort && isNumber(group.healthCheckPort) ? group.healthCheckPort : group.port;
         tg.healthCheckProtocol = group.healthCheckProtocol.toLowerCase();
         tg.healthCheckPath = `:${port}${group.healthCheckPath}`;

--- a/app/scripts/modules/amazon/src/instance/details/utils.ts
+++ b/app/scripts/modules/amazon/src/instance/details/utils.ts
@@ -16,7 +16,7 @@ export const applyHealthCheckInfoToTargetGroups = (
   healthMetrics.forEach(metric => {
     if (metric.type === 'TargetGroup') {
       metric.targetGroups.forEach((tg: ITargetGroup) => {
-        const group = targetGroups[tg.name] || ({} as ITargetGroup);
+        const group = targetGroups[tg.name] ?? ({} as ITargetGroup);
         const port = group.healthCheckPort && isNumber(group.healthCheckPort) ? group.healthCheckPort : group.port;
         tg.healthCheckProtocol = group.healthCheckProtocol.toLowerCase();
         tg.healthCheckPath = `:${port}${group.healthCheckPath}`;


### PR DESCRIPTION
The instance details panel was showing "Instance not found" when an instance in application A was attached to a load balancer in application B. Throwing `error: group is undefined`. 

The bug causing the group to be `undefined` was fixed in a prior PR, so this PR adds an extra layer of safety if the `group` is not found.

<img width="842" alt="Screen Shot 2020-01-28 at 12 40 57 PM" src="https://user-images.githubusercontent.com/26560152/73303498-77112400-41cb-11ea-9b74-9482225b192d.png">
