### PR TITLE
fix(titus/serverGroup): use correct prop name for managed resource banner

### DIFF
--- a/app/scripts/modules/titus/src/serverGroup/details/serverGroupDetails.html
+++ b/app/scripts/modules/titus/src/serverGroup/details/serverGroupDetails.html
@@ -81,8 +81,9 @@
       Job is Disabled
     </div>
     <managed-resource-details-indicator
+      ng-if="!state.loading && serverGroup.isManaged"
       resource-summary="serverGroup.managedResourceSummary"
-      app="ctrl.application"
+      application="ctrl.application"
     ></managed-resource-details-indicator>
     <server-group-running-tasks-details
       server-group="serverGroup"


### PR DESCRIPTION
Sometimes the bugs Angular templates manage to silently hide all the way into production are truly awe-inspiring.