### PR TITLE
chore(titus): bump package to 0.0.126

### DIFF
--- a/app/scripts/modules/titus/package.json
+++ b/app/scripts/modules/titus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/titus",
-  "version": "0.0.125",
+  "version": "0.0.126",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
fix(titus/serverGroup): use correct prop name for managed resource banner (#7820)
refactor(titus): Removing container migration as it is no longer used (#7807)