### PR TITLE
fix(core): Re-exporting types from ExecutionMarkerIcon to make it available outside core

### DIFF
--- a/app/scripts/modules/core/src/index.ts
+++ b/app/scripts/modules/core/src/index.ts
@@ -18,6 +18,7 @@ export * from './deploymentStrategy';
 export * from './domain';
 
 export * from './entityTag';
+export * from './pipeline/config/stages/common/ExecutionMarkerIcon';
 // TODO: try pushing this export back down; for some unknown reason, it causes grief with the library (the export
 // is found by the TS compiler, but not at runtime)
 export * from './entityTag/notifications/EntityNotifications';


### PR DESCRIPTION
[Recent changes](https://github.com/spinnaker/deck/commit/b51dce46be3df14070f06e06de874108dcf23569#diff-1edca6440bc3b35b161749f95923b0cc) introduced a type error. The types from `ExecutionMarkerIcon` were not made available outside `core`.  Re-exporting types from this module to make them available outside `core`.