### PR TITLE
feat(readme): add UI SIG link to README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -59,3 +59,8 @@ For now, you can look at the https://github.com/spinnaker/deck/tree/master/app/s
 get an idea how we are customizing Deck internally. Expect a lot of this to change, though, as we figure out better, cleaner
 hooks and integration points. And we're happy to provide new integration points (or accept pull requests) following
 those existing conventions if you need an integration point that doesn't already exist.
+
+== Join Us
+
+Interested in sharing feedback on Spinnaker's UI or contributing to Deck?
+Please join us at the https://github.com/spinnaker/governance/tree/master/sig-ui-ux[Spinnaker UI SIG]!


### PR DESCRIPTION
Per discussion at the UI SIG, let's add information about the UI SIG to Deck's README. Let's simply reference the governance page instead of duplicating the meeting details here.

I also [updated the governance README](https://github.com/spinnaker/governance/pull/99) to include the meeting link, so hopefully there will be less confusion there.