### PR TITLE
chore(builds): Adds GHActions as CI job (PRs, master, release branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,75 @@
+name: Deck CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - release-*
+
+env:
+  NODE_VERSION: 10.15.1
+
+jobs:
+  purebump:
+    name: Ensure package bumps are pure
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Ensure package bumps are pure
+        run: app/scripts/modules/assert_package_bumps_standalone.sh
+
+  test:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ env.NODE_VERSION  }}
+
+      - name: Get yarn cache
+        id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v1
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install Dependencies
+        run: yarn --frozen-lockfile
+
+      - name: Unit Tests
+        run: yarn test --single-run
+
+  build:
+    name: Production Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ env.NODE_VERSION  }}
+
+      - name: Get yarn cache
+        id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v1
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install Dependencies
+        run: yarn --frozen-lockfile
+
+      - name: Yarn Build
+        run: yarn build

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -40,8 +40,8 @@ module.exports = function(config) {
     },
 
     customLaunchers: {
-      Chrome_travis_ci: {
-        base: 'Chrome',
+      ChromeCI: {
+        base: 'ChromeHeadless',
         flags: ['--no-sandbox'],
       },
       ChromeActive: {
@@ -66,7 +66,7 @@ module.exports = function(config) {
     // web server port
     port: 8081,
 
-    browsers: [process.env.TRAVIS ? 'Chrome_travis_ci' : 'ChromeActive'],
+    browsers: [process.env.TRAVIS || process.env.GITHUB_ACTIONS ? 'ChromeCI' : 'ChromeActive'],
 
     colors: true,
 


### PR DESCRIPTION
In the process of doing this, I added a dependency on [Puppeteer](https://github.com/puppeteer/puppeteer), which is the Chrome Dev Tools team-maintained version that pulls in everything needed to run Chrome in CI (see https://github.com/karma-runner/karma-chrome-launcher#headless-chromium-with-puppeteer).