### PR TITLE
feat(plugins): Load plugins and plugin manifest from gate

### DIFF
--- a/app/scripts/modules/core/src/config/settings.ts
+++ b/app/scripts/modules/core/src/config/settings.ts
@@ -1,4 +1,3 @@
-import { IPluginManifest } from 'core/plugins/plugin.registry';
 import { cloneDeep, merge } from 'lodash';
 
 export interface IAdditionalHelpLinks {
@@ -130,7 +129,6 @@ export interface ISpinnakerSettings {
   providers?: {
     [key: string]: IProviderSettings; // allows custom providers not typed in here (good for testing too)
   };
-  plugins: IPluginManifest[];
   pubsubProviders: string[];
   quietPeriod: [string | number, string | number];
   resetProvider: (provider: string) => () => void;
@@ -148,7 +146,6 @@ SETTINGS.analytics = SETTINGS.analytics || {};
 SETTINGS.providers = SETTINGS.providers || {};
 SETTINGS.defaultTimeZone = SETTINGS.defaultTimeZone || 'America/Los_Angeles';
 SETTINGS.dockerInsights = SETTINGS.dockerInsights || { enabled: false, url: '' };
-SETTINGS.plugins = SETTINGS.plugins || [];
 
 // A helper to make resetting settings to steady state after running tests easier
 const originalSettings: ISpinnakerSettings = cloneDeep(SETTINGS);

--- a/app/scripts/modules/core/src/core.module.ts
+++ b/app/scripts/modules/core/src/core.module.ts
@@ -27,7 +27,6 @@ import { RECENT_HISTORY_SERVICE } from 'core/history';
 require('root/app/fonts/spinnaker/icons.css');
 
 import './analytics/GoogleAnalyticsInitializer';
-import { sharedLibraries } from './plugins/sharedLibraries';
 import { ANALYTICS_MODULE } from './analytics/angulartics.module';
 import { APPLICATION_BOOTSTRAP_MODULE } from './bootstrap';
 import { APPLICATION_MODULE } from './application/application.module';
@@ -94,8 +93,6 @@ const templates = require.context('./', true, /\.html$/);
 templates.keys().forEach(function(key) {
   templates(key);
 });
-
-sharedLibraries.exposeSharedLibraries();
 
 export const CORE_MODULE = 'spinnaker.core';
 module(CORE_MODULE, [

--- a/app/scripts/modules/core/src/index.ts
+++ b/app/scripts/modules/core/src/index.ts
@@ -62,6 +62,7 @@ export * from './overrideRegistry';
 export * from './pageTitle';
 export * from './pagerDuty';
 export * from './pipeline';
+export * from './plugins';
 export * from './presentation';
 export * from './projects';
 export * from './pubsub';

--- a/app/scripts/modules/core/src/plugins/index.ts
+++ b/app/scripts/modules/core/src/plugins/index.ts
@@ -1,1 +1,2 @@
 export * from './plugin.module';
+export * from './plugin.registry';

--- a/app/scripts/modules/core/src/plugins/plugin.module.ts
+++ b/app/scripts/modules/core/src/plugins/plugin.module.ts
@@ -1,41 +1,31 @@
 import { module } from 'angular';
 import { UIRouter } from '@uirouter/core';
-import { IPluginManifest, PluginRegistry } from './plugin.registry';
+import { PluginRegistry } from './plugin.registry';
+import { sharedLibraries } from './sharedLibraries';
 
 export const PLUGINS_MODULE = 'netflix.spinnaker.plugins';
-module(PLUGINS_MODULE, ['ui.router']).config([
-  '$uiRouterProvider',
-  async ($uiRouterProvider: UIRouter) => {
-    const pluginRegistry = new PluginRegistry();
-
-    // Tell the router to slow its roll
-    $uiRouterProvider.urlService.deferIntercept();
-
-    // Grab all plugins that are defined in plugin-manifest
-    // The format for plugin-manifest would be:
-    //    const plugins = [{'name':'myPlugin', 'version':'1.2.3', 'devUrl':'/plugins/index.js'}]
-    //    export { plugins }
-    try {
-      const pluginManifestLocation = '/plugin-manifest.js';
-      const pluginModule = await import(/* webpackIgnore: true */ pluginManifestLocation);
-
-      if (!pluginModule || !pluginModule.plugins) {
-        throw new Error(`Expected plugin-manifest.js to contain an export named 'plugins' but it did not.`);
-      } else {
-        pluginModule.plugins.forEach((plugin: IPluginManifest) => pluginRegistry.register(plugin));
+module(PLUGINS_MODULE, ['ui.router'])
+  .config([
+    '$uiRouterProvider',
+    ($uiRouterProvider: UIRouter) => {
+      // Tell the router to slow its roll
+      $uiRouterProvider.urlService.deferIntercept();
+      sharedLibraries.exposeSharedLibraries();
+    },
+  ])
+  .run([
+    '$uiRouter',
+    async ($uiRouter: UIRouter) => {
+      // TODO: find a better home for this registry
+      const pluginRegistry = new PluginRegistry();
+      try {
+        // Load and initialize plugins
+        await Promise.all([pluginRegistry.loadPluginManifestFromDeck(), pluginRegistry.loadPluginManifestFromGate()]);
+        await pluginRegistry.loadPlugins();
+      } finally {
+        // When done, tell the router to initialize
+        $uiRouter.urlService.listen();
+        $uiRouter.urlService.sync();
       }
-    } catch (error) {
-      console.error('Error registering plugin manifests');
-      console.error(error);
-    }
-
-    try {
-      // Load and initialize them
-      await pluginRegistry.loadPlugins();
-    } finally {
-      // When done, tell the router to initialize
-      $uiRouterProvider.urlService.listen();
-      $uiRouterProvider.urlService.sync();
-    }
-  },
-]);
+    },
+  ]);

--- a/app/scripts/modules/core/src/plugins/plugin.registry.spec.ts
+++ b/app/scripts/modules/core/src/plugins/plugin.registry.spec.ts
@@ -1,4 +1,5 @@
 import { IStageTypeConfig } from 'core/domain';
+import { API } from '../api';
 import { IDeckPlugin, IPluginManifest, IPluginMetaData, PluginRegistry } from './plugin.registry';
 import { Registry } from 'core/registry';
 
@@ -31,6 +32,19 @@ describe('PluginRegistry', () => {
       expect(pluginRegistry.getRegisteredPlugins()[0]).toEqual(jasmine.objectContaining(plugin1));
       expect(pluginRegistry.getRegisteredPlugins()[1]).toEqual(jasmine.objectContaining(plugin2));
     });
+  });
+
+  it('loadPluginManifestFromDeck() should import() from /plugin-manifest.js', async () => {
+    loadModuleFromUrlSpy.and.callFake(() => Promise.resolve({ plugins: [] }));
+    await pluginRegistry.loadPluginManifestFromDeck();
+    expect(loadModuleFromUrlSpy).toHaveBeenCalledWith('/plugin-manifest.js');
+  });
+
+  it('loadPluginManifestFromGate() should fetch from gate /plugins/deck/plugin-manifest.json', async () => {
+    const spy = jasmine.createSpy('get', () => Promise.resolve([])).and.callThrough();
+    spyOn(API as any, 'getFn').and.callFake(() => spy);
+    await pluginRegistry.loadPluginManifestFromGate();
+    expect(spy).toHaveBeenCalled();
   });
 
   describe('loadPlugins()', () => {

--- a/app/scripts/modules/core/src/plugins/plugin.registry.spec.ts
+++ b/app/scripts/modules/core/src/plugins/plugin.registry.spec.ts
@@ -1,5 +1,5 @@
 import { IStageTypeConfig } from 'core/domain';
-import { IDeckPlugin, IPluginManifest, PluginRegistry } from 'core/plugins/plugin.registry';
+import { IDeckPlugin, IPluginManifest, IPluginMetaData, PluginRegistry } from './plugin.registry';
 import { Registry } from 'core/registry';
 
 type TestPluginRegistry = PluginRegistry & {
@@ -19,15 +19,17 @@ describe('PluginRegistry', () => {
 
   describe('.register()', () => {
     it('should validate plugin manifests', () => {
-      expect(() => pluginRegistry.register({} as any)).toThrowError(/Invalid plugin manifest/);
+      expect(() => pluginRegistry.registerPluginMetaData({} as any)).toThrowError(/Invalid plugin manifest/);
     });
 
     it('should add plugins manifests to the registry', () => {
-      const plugin1 = { name: 'foo', version: '1.0.0' };
-      const plugin2 = { name: 'bar', version: '1.0.0' };
-      pluginRegistry.register(plugin1);
-      pluginRegistry.register(plugin2);
-      expect(pluginRegistry.getRegisteredPlugins()).toEqual([plugin1, plugin2]);
+      const plugin1 = { id: 'foo', version: '1.0.0' };
+      const plugin2 = { id: 'bar', version: '1.0.0' };
+      pluginRegistry.registerPluginMetaData(plugin1);
+      pluginRegistry.registerPluginMetaData(plugin2);
+      expect(pluginRegistry.getRegisteredPlugins().length).toBe(2);
+      expect(pluginRegistry.getRegisteredPlugins()[0]).toEqual(jasmine.objectContaining(plugin1));
+      expect(pluginRegistry.getRegisteredPlugins()[1]).toEqual(jasmine.objectContaining(plugin2));
     });
   });
 
@@ -36,57 +38,72 @@ describe('PluginRegistry', () => {
     beforeEach(() => {
       pluginModule = {
         plugin: {
-          stages: [({ name: 'mystage' } as any) as IStageTypeConfig],
+          stages: [({ id: 'mystage' } as any) as IStageTypeConfig],
         },
       };
     });
+
     it('should load all registered plugins', () => {
       const loadSpy = spyOn(pluginRegistry, 'load').and.callFake(fakePromise());
-      const plugin1 = { name: 'foo', version: '1.0.0' };
-      const plugin2 = { name: 'bar', version: '1.0.0' };
-      pluginRegistry.register(plugin1);
-      pluginRegistry.register(plugin2);
+      const plugin1 = { id: 'foo', version: '1.0.0' };
+      const plugin2 = { id: 'bar', version: '1.0.0' };
+      pluginRegistry.registerPluginMetaData(plugin1);
+      pluginRegistry.registerPluginMetaData(plugin2);
 
       expect(loadSpy.calls.count()).toBe(0);
 
       pluginRegistry.loadPlugins();
 
       expect(loadSpy.calls.count()).toBe(2);
-      expect(loadSpy.calls.first().args[0]).toBe(plugin1);
-      expect(loadSpy.calls.mostRecent().args[0]).toBe(plugin2);
+      expect(loadSpy.calls.first().args[0]).toEqual(jasmine.objectContaining(plugin1));
+      expect(loadSpy.calls.mostRecent().args[0]).toEqual(jasmine.objectContaining(plugin2));
     });
 
     it('should return a rejected promise if a loaded module doesnt contain an export named plugin', async () => {
       loadModuleFromUrlSpy.and.callFake(fakePromise({}));
       spyOn(console, 'error').and.stub();
-      const plugin1 = { name: 'foo', version: '1.0.0' };
-      pluginRegistry.register(plugin1);
+      const plugin1 = { id: 'foo', version: '1.0.0' };
+      pluginRegistry.registerPluginMetaData(plugin1);
 
       await expectAsync(pluginRegistry.loadPlugins()).toBeRejected();
     });
 
     it('should resolve to all loaded plugin modules', async () => {
       loadModuleFromUrlSpy.and.callFake(fakePromise(pluginModule));
-      const plugin1 = { name: 'foo', version: '1.0.0' };
-      pluginRegistry.register(plugin1);
+      const plugin1 = { id: 'foo', version: '1.0.0' };
+      pluginRegistry.registerPluginMetaData(plugin1);
 
       await expectAsync(pluginRegistry.loadPlugins()).toBeResolvedTo([pluginModule]);
     });
 
-    it('should store the loaded module onto the manifest object', async () => {
+    it('should normalize the metadata object', async () => {
       loadModuleFromUrlSpy.and.callFake(fakePromise(pluginModule));
-      const plugin1 = { name: 'foo', version: '1.0.0' } as IPluginManifest;
-      pluginRegistry.register(plugin1);
+      const plugin1 = { name: 'foo', devUrl: 'abc', version: '1.0.0' } as IPluginMetaData;
+      pluginRegistry.registerPluginMetaData(plugin1);
+      expect(pluginRegistry.getRegisteredPlugins()[0]).toEqual({ id: 'foo', url: 'abc', version: '1.0.0' });
+    });
+
+    it('should return the normalized metadata object', async () => {
+      loadModuleFromUrlSpy.and.callFake(fakePromise(pluginModule));
+      const plugin1 = { id: 'foo', version: '1.0.0' } as IPluginMetaData;
+      const normalized = pluginRegistry.registerPluginMetaData(plugin1);
+      expect(pluginRegistry.getRegisteredPlugins()[0]).toBe(normalized);
+    });
+
+    it('should store the loaded module onto the metadata object', async () => {
+      loadModuleFromUrlSpy.and.callFake(fakePromise(pluginModule));
+      const plugin1 = { id: 'foo', version: '1.0.0' } as IPluginMetaData;
+      const normalized = pluginRegistry.registerPluginMetaData(plugin1);
 
       await pluginRegistry.loadPlugins();
-      expect(plugin1.module).toBe(pluginModule);
+      expect(normalized.module).toBe(pluginModule);
     });
 
     it('should register stages found on the plugin', async () => {
       const registerStageSpy = spyOn(Registry.pipeline, 'registerStage');
       loadModuleFromUrlSpy.and.callFake(fakePromise(pluginModule));
-      const plugin1 = { name: 'foo', version: '1.0.0' };
-      pluginRegistry.register(plugin1);
+      const plugin1 = { id: 'foo', version: '1.0.0' };
+      pluginRegistry.registerPluginMetaData(plugin1);
 
       await pluginRegistry.loadPlugins();
       expect(registerStageSpy).toHaveBeenCalledTimes(1);

--- a/app/scripts/modules/core/src/plugins/plugin.registry.ts
+++ b/app/scripts/modules/core/src/plugins/plugin.registry.ts
@@ -1,8 +1,6 @@
 import { API } from 'core/api';
-import { IUrlBuilder } from 'core/navigation';
 import { Registry } from 'core/registry';
 import { IStageTypeConfig } from 'core/domain';
-import { SearchResultType } from 'core/search';
 
 export interface IDeckPlugin {
   stages?: IStageTypeConfig[];

--- a/app/scripts/modules/core/src/plugins/plugin.registry.ts
+++ b/app/scripts/modules/core/src/plugins/plugin.registry.ts
@@ -1,37 +1,111 @@
+import { API } from 'core/api';
+import { IUrlBuilder } from 'core/navigation';
 import { Registry } from 'core/registry';
-import { IStageTypeConfig } from '../domain';
+import { IStageTypeConfig } from 'core/domain';
+import { SearchResultType } from 'core/search';
 
 export interface IDeckPlugin {
   stages?: IStageTypeConfig[];
 }
 
 export interface IPluginManifest {
-  name: string;
+  plugins: IPluginMetaData[];
+}
+
+export interface IPluginMetaData {
+  id?: string;
+  /** @deprecated use `id` instead */
+  name?: string;
   version: string;
+  url?: string;
+  /** @deprecated if using a plugin-manifest.json baked into a deck instance, use `url` instead */
   devUrl?: string;
   module?: any;
 }
 
 export class PluginRegistry {
-  private pluginManifests: IPluginManifest[] = [];
+  private pluginManifests: IPluginMetaData[] = [];
 
   getRegisteredPlugins() {
     return this.pluginManifests.slice();
   }
 
-  register(pluginManifest: IPluginManifest) {
-    this.validateManifest(pluginManifest);
-    this.pluginManifests.push(pluginManifest);
+  registerPluginMetaData(pluginMetaData: IPluginMetaData): IPluginMetaData {
+    const normalizedMetaData = this.normalize(pluginMetaData);
+    this.validateMetaData(normalizedMetaData);
+    this.pluginManifests.push(normalizedMetaData);
+    return normalizedMetaData;
   }
 
-  validateManifest(pluginManifest: IPluginManifest) {
-    if (!pluginManifest) {
-      throw new Error(`Invalid plugin manifest: received ${pluginManifest} object`);
+  // Temporary backwards compat, remove in 2020 after armory has migrated
+  normalize(pluginMetaData: IPluginMetaData): IPluginMetaData {
+    const { devUrl, url, id, name, ...rest } = pluginMetaData;
+
+    return {
+      id: id ?? name,
+      url: url ?? devUrl,
+      ...rest,
+    };
+  }
+
+  validateMetaData(pluginMetaData: IPluginMetaData) {
+    if (!pluginMetaData) {
+      throw new Error(`Invalid plugin manifest: received ${pluginMetaData} object`);
     }
-    const keys: Array<keyof IPluginManifest> = ['name', 'version'];
-    const missingKeys = keys.filter(key => !pluginManifest[key]);
+    const keys: Array<keyof IPluginMetaData> = ['id', 'version'];
+    const missingKeys = keys.filter(key => !pluginMetaData[key]);
     if (missingKeys.length) {
       throw new Error(`Invalid plugin manifest: Required key is missing: '${missingKeys.join(', ')}'`);
+    }
+  }
+
+  /** Loads plugin manifest file served as a custom deck asset */
+  public loadPluginManifestFromDeck() {
+    const uri = '/plugin-manifest.js';
+    const loadPromise = this.loadModuleFromUrl(uri)
+      .then((pluginManifest: IPluginManifest) => {
+        if (!pluginManifest || !pluginManifest.plugins) {
+          throw new Error(`Expected plugin-manifest.js to contain an export named 'plugins' but it did not.`);
+        }
+        return pluginManifest.plugins;
+      })
+      .catch(error => {
+        console.error(`Failed to load ${uri} from deck`);
+        throw error;
+      });
+
+    return this.loadPluginManifest(uri, loadPromise);
+  }
+
+  /** Loads plugin manifest file served from gate */
+  public loadPluginManifestFromGate() {
+    const uri = '/plugins/deck/plugin-manifest.json';
+    const loadPromise = API.one(uri)
+      .get()
+      .catch((error: any) => {
+        console.error(`Failed to load ${uri} from gate`);
+        throw error;
+      });
+
+    return this.loadPluginManifest(uri, loadPromise);
+  }
+
+  /**
+   * Loads plugin manifests from Gate and from `/plugin-manifest.json` in the deck resources
+   *
+   * plugin-manifest.json should contain an array of IPluginManifest(s) exported as `plugin`, i.e.,
+   * export const plugins = [{ 'name': 'myPlugin', 'version': '1.2.3', 'devUrl': '/plugins/index.js' }]
+   */
+  public async loadPluginManifest(
+    location: string,
+    pluginsMetaDataPromise: Promise<IPluginMetaData[]>,
+  ): Promise<IPluginMetaData[]> {
+    try {
+      const plugins = await pluginsMetaDataPromise;
+      return plugins.map(pluginMetaData => this.registerPluginMetaData(pluginMetaData));
+    } catch (error) {
+      console.error(`Error loading plugin manifest from ${location}`);
+      throw error;
     }
   }
 
@@ -39,24 +113,22 @@ export class PluginRegistry {
     return Promise.all(this.pluginManifests.map(plugin => this.load(plugin)));
   }
 
-  private async load(pluginManifest: IPluginManifest) {
-    this.validateManifest(pluginManifest);
+  private async load(pluginMetaData: IPluginMetaData) {
+    this.validateMetaData(pluginMetaData);
 
-    // Use `url` from the manifest, if it exists.
-    // This will be the case only during local development.
-    const { devUrl } = pluginManifest;
-
-    // This will eventually build the url from name/version and fetch binaries from Gate/Front50
-    // const { name, version } = pluginManifest;
-    // const url = devUrl || `${gateurl}/plugins/${name}/${version}/index.js`;
+    // Use `devUrl` from the manifest, if it exists.
+    // This will be the case during local development.
+    const { devUrl, url } = pluginMetaData;
+    const gateUrl = `${API.baseUrl}/plugins/deck/${pluginMetaData.id}/${pluginMetaData.version}/index.js`;
+    const pluginUrl = url ?? devUrl ?? gateUrl;
 
     try {
-      const module = await this.loadModuleFromUrl(devUrl);
-      Object.assign(pluginManifest, { module });
+      const module = await this.loadModuleFromUrl(pluginUrl);
+      Object.assign(pluginMetaData, { module });
 
       if (!module || !module.plugin) {
         throw new Error(
-          `Successfully loaded plugin module from ${devUrl}, but it doesn't export an object called 'plugin'`,
+          `Successfully loaded plugin module from ${pluginUrl}, but it doesn't export an object called 'plugin'`,
         );
       }
 
@@ -67,7 +139,7 @@ export class PluginRegistry {
 
       return module;
     } catch (error) {
-      console.error(`Failed to load plugin from ${devUrl}`);
+      console.error(`Failed to load plugin code from ${pluginUrl}`);
       throw error;
     }
   }


### PR DESCRIPTION
Load manifest from gate URL: `/plugins/deck/plugin-manifest.json`
Continue to load pre-baked manifest from the local deck asset `/plugin-manifest.js`

*BREAKING CHANGE*: IPluginManifest renamed to IPluginMetaData and shape changed
from: `{ name, version, devUrl }` to: `{ id, version, url }`
*Migrate plugin-manifest.js to use `id` and `url`*

IPluginManifest now describes the shape of plugin-manifest.js

*BREAKING CHANGE*: Plugins are no longer loaded from settings.js or settings-local.js
*Migrate pre-baked plugin metadata to plugin-manifest.js*

