### PR TITLE
Fast package bumps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,30 +11,28 @@ env:
   NODE_VERSION: 10.15.1
 
 jobs:
-  purebump:
-    name: Ensure package bumps are pure
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Ensure package bumps are pure
-        run: app/scripts/modules/assert_package_bumps_standalone.sh
-
   test:
     name: Unit tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 
+      - name: Ensure package bumps are pure
+        id: purebump
+        run: app/scripts/modules/assert_package_bumps_standalone.sh
+
       - uses: actions/setup-node@v1
+        if: steps.purebump.outputs.ispurebump != 'true'
         with:
           node-version: ${{ env.NODE_VERSION  }}
 
       - name: Get yarn cache
+        if: steps.purebump.outputs.ispurebump != 'true'
         id: yarn-cache
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
       - uses: actions/cache@v1
+        if: steps.purebump.outputs.ispurebump != 'true'
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
@@ -42,9 +40,11 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Install Dependencies
+        if: steps.purebump.outputs.ispurebump != 'true'
         run: yarn --frozen-lockfile
 
       - name: Unit Tests
+        if: steps.purebump.outputs.ispurebump != 'true'
         run: yarn test --single-run
 
   build:
@@ -53,15 +53,22 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Ensure package bumps are pure
+        id: purebump
+        run: app/scripts/modules/assert_package_bumps_standalone.sh
+
       - uses: actions/setup-node@v1
+        if: steps.purebump.outputs.ispurebump != 'true'
         with:
           node-version: ${{ env.NODE_VERSION  }}
 
       - name: Get yarn cache
+        if: steps.purebump.outputs.ispurebump != 'true'
         id: yarn-cache
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
       - uses: actions/cache@v1
+        if: steps.purebump.outputs.ispurebump != 'true'
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
@@ -69,14 +76,17 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Install Dependencies
+        if: steps.purebump.outputs.ispurebump != 'true'
         run: yarn --frozen-lockfile
 
       - name: Yarn Build
+        if: steps.purebump.outputs.ispurebump != 'true'
         run: yarn build
 
   packages:
     name: Build Packages
     runs-on: ubuntu-latest
+
     strategy:
       matrix:
         packages:
@@ -85,15 +95,22 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Ensure package bumps are pure
+        id: purebump
+        run: app/scripts/modules/assert_package_bumps_standalone.sh
+
       - uses: actions/setup-node@v1
+        if: steps.purebump.outputs.ispurebump != 'true'
         with:
           node-version: ${{ env.NODE_VERSION  }}
 
       - name: Get yarn cache
+        if: steps.purebump.outputs.ispurebump != 'true'
         id: yarn-cache
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
       - uses: actions/cache@v1
+        if: steps.purebump.outputs.ispurebump != 'true'
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
@@ -101,7 +118,9 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Install Dependencies
+        if: steps.purebump.outputs.ispurebump != 'true'
         run: yarn --frozen-lockfile
 
       - name: Build NPM Packages
+        if: steps.purebump.outputs.ispurebump != 'true'
         run: app/scripts/modules/build_modules.sh ${{ matrix.packages }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: java
+git:
+  depth: false
 jdk:
   - oraclejdk8
 sudo: required
@@ -18,9 +20,9 @@ jobs:
       name: ensure pull requests with package bumps only contain package bumps
       script: app/scripts/modules/assert_package_bumps_standalone.sh
     - name: run tests for deck
-      script: gradle/buildViaTravis.sh
+      script: app/scripts/modules/assert_package_bumps_standalone.sh | grep -v "This is a pure package bump." || gradle/buildViaTravis.sh
     - name: build the all module libs
-      script: gradle/buildModules.sh
+      script: app/scripts/modules/assert_package_bumps_standalone.sh | grep -v "This is a pure package bump." || gradle/buildModules.sh
 
 before_cache: gradle/prepCaches.sh
 cache:

--- a/app/scripts/modules/assert_package_bumps_standalone.sh
+++ b/app/scripts/modules/assert_package_bumps_standalone.sh
@@ -9,9 +9,10 @@ if [[ $GITHUB_ACTIONS == "true" && ( $GITHUB_BASE_REF != "master" || $GITHUB_REP
   exit 0
 fi
 
-if [[ $GITHUB_ACTIONS == "true" ]] ; then
-  echo "Fetching tags..." && git fetch -q
-  GHA_TARGET=origin/master
+if [[ -n $TRAVIS || -n $GITHUB_ACTIONS ]] ; then
+  echo "git fetch..."
+  git fetch
+  CI_TARGET_BRANCH=origin/master
   cd app/scripts/modules || exit 1;
 else
   cd "$(dirname "$0")" || exit 2;
@@ -19,7 +20,7 @@ fi
 
 # Use the command line argument, origin/master (if running on GHA) or master (in that order)
 TARGET_BRANCH=${1}
-TARGET_BRANCH=${TARGET_BRANCH:-${GHA_TARGET}}
+TARGET_BRANCH=${TARGET_BRANCH:-${CI_TARGET_BRANCH}}
 TARGET_BRANCH=${TARGET_BRANCH:-master}
 echo "TARGET_BRANCH=$TARGET_BRANCH"
 echo ""

--- a/app/scripts/modules/assert_package_bumps_standalone.sh
+++ b/app/scripts/modules/assert_package_bumps_standalone.sh
@@ -1,66 +1,98 @@
 #!/bin/bash
+# Usage: assert_package_bumps_standalone [target branch]
+# Use [target branch] to change the branch the script checks for changes against
+# (default: origin/master if running in a Github Action, master otherwise)
+
 # Reports if package bumps are combined with other changes (not allowed). Package bumps must be standalone.
-cd "$(dirname "$0")" || exit 1;
+if [[ $GITHUB_ACTIONS == "true" && ( $GITHUB_BASE_REF != "master" || $GITHUB_REPOSITORY != 'spinnaker/deck' ) ]] ; then
+  echo "Not a pull request to master -- exiting"
+  exit 0
+fi
 
-PKGJSONCHANGED="Version change detected in package.json"
-ONLYVERSIONCHANGED="Version change must be the only line changed in package.json"
-ONLYPKGJSONCHANGED="package.json (in app/scripts/modules) must be the only files changed in a pull request with version bumps"
+if [[ $GITHUB_ACTIONS == "true" ]] ; then
+  echo "Fetching tags..." && git fetch -q
+  GHA_TARGET=origin/master
+  cd app/scripts/modules || exit 1;
+else
+  cd "$(dirname "$0")" || exit 2;
+fi
 
-TARGET_BRANCH=origin/master
+# Use the command line argument, origin/master (if running on GHA) or master (in that order)
+TARGET_BRANCH=${1}
+TARGET_BRANCH=${TARGET_BRANCH:-${GHA_TARGET}}
+TARGET_BRANCH=${TARGET_BRANCH:-master}
 echo "TARGET_BRANCH=$TARGET_BRANCH"
+echo ""
+
+# Run a git diff against TARGET_BRANCH outside of a pipe so it will exit with any failure code
+git diff "$TARGET_BRANCH" -- . >/dev/null || exit $?
 
 # Tests are run against an ephemeral merge commit so we don't have to merge in $TARGET_BRANCH
 
+HAS_PURE_PKG_BUMP=false
 for PKGJSON in */package.json ; do
   MODULE=$(basename "$(dirname "$PKGJSON")")
-  echo "::group::Checking $MODULE"
 
-  echo "==================================================="
-  echo "Checking $MODULE"
-  echo "==================================================="
-  HAS_PKG_BUMP=$(git diff "$TARGET_BRANCH" -- "$PKGJSON" | grep -c '"version"')
+  HAS_PKG_BUMP=$(git diff "$TARGET_BRANCH" -- "$PKGJSON" | grep -c '"version":')
   if [ "$HAS_PKG_BUMP" -ne 0 ] ; then
-    echo " [ YES  ] $PKGJSONCHANGED"
-
     # Ensuring that the version change is the only change in package.json
     PKG_JSON_OTHER_CHANGES=$(git diff --numstat "$TARGET_BRANCH" -- "$PKGJSON" | cut -f 1)
     if [ "$PKG_JSON_OTHER_CHANGES" -ne 1 ] ; then
-      echo " [ FAIL ] $ONLYVERSIONCHANGED"
+      echo "==================================================="
+      echo "                Impure package bump"
+      echo "==================================================="
       echo ""
-      echo "=========================================="
-      echo "Failure details (git diff of package.json)"
-      echo "=========================================="
+      echo "Version change found in $MODULE/package.json"
+      echo "However, other changes were found in package.json"
       echo ""
-      git diff "$TARGET_BRANCH" -- "$PKGJSON"
+      echo "Version change:"
+      git diff -u "$TARGET_BRANCH" -- "$PKGJSON" | grep '"version"' >&2
       echo ""
+      echo "git diff of package.json:"
       echo "=========================================="
-      exit 2
-    else
-      echo " [ PASS ] $ONLYVERSIONCHANGED"
-      echo "::endgroup::"
+      git diff "$TARGET_BRANCH" -- "$PKGJSON" >&2
+      echo "=========================================="
+      exit 3
     fi
+
 
     # checking that the only files changed are app/scripts/modules/*/package.json
-    OTHER_FILES_CHANGED=$(git diff --name-only "$TARGET_BRANCH" | grep -v -c "app/scripts/modules/.*/package.json")
+    OTHER_FILES_CHANGED=$(git diff --name-only "$TARGET_BRANCH" | grep -c -v "app/scripts/modules/.*/package.json")
     if [ "$OTHER_FILES_CHANGED" -ne 0 ] ; then
-      echo " [ FAIL ] $ONLYPKGJSONCHANGED"
+      echo "==================================================="
+      echo "                Impure package bump"
+      echo "==================================================="
       echo ""
-      echo "==========================================="
-      echo "Failure details (list of all files changed)"
-      echo "==========================================="
+      echo "Version change found in $MODULE/package.json"
+      echo "However, other files were also changed"
       echo ""
-      git diff --name-only "$TARGET_BRANCH"
+      echo "Version change:"
+      git diff -u "$TARGET_BRANCH" -- "$PKGJSON" | grep '"version"' >&2
       echo ""
-      echo "==========================================="
-      exit 1
-    else
-      echo " [ PASS ] $ONLYPKGJSONCHANGED"
+      echo "List of all files changed:"
+      echo "=========================================="
+      git diff --name-only "$TARGET_BRANCH" >&2
+      echo "=========================================="
+      exit 4
     fi
+
+    FROM_VERSION=$(git diff "$TARGET_BRANCH" -- "$PKGJSON" | grep '^-.*"version":' | sed -e 's/^.*version": "//' -e 's/[",]//g')
+    TO_VERSION=$(git diff "$TARGET_BRANCH" -- "$PKGJSON" | grep '^\+.*"version":' | sed -e 's/^.*": "//' -e 's/[",]//g')
+
+
+    HAS_PURE_PKG_BUMP=true
+    echo "$PKGJSON: Pure package bump. $FROM_VERSION -> $TO_VERSION"
   else
-    echo " [  NO  ] $PKGJSONCHANGED"
-    echo " [  N/A ] $ONLYVERSIONCHANGED"
-    echo " [  N/A ] $ONLYPKGJSONCHANGED"
+    echo "$PKGJSON: n/a"
   fi
-  echo ""
 done
 
+echo ""
+echo ""
+
+if [[ $HAS_PURE_PKG_BUMP == "true" ]] ; then
+ [[ "$GITHUB_ACTIONS" == "true" ]] && echo "::set-output name=ispurebump::true"
+ echo "This is a pure package bump."
+else
+ echo "No packages were bumped."
+fi

--- a/app/scripts/modules/build_modules.sh
+++ b/app/scripts/modules/build_modules.sh
@@ -3,7 +3,7 @@
 beginGroup() {
   if [[ -n "$GITHUB_ACTIONS" ]] ; then
     echo "::group::$*"
-  elif [[ -n "$TRAVIS" ]] ; then 
+  elif [[ -n "$TRAVIS" ]] ; then
     echo "travis_fold:start:$*"
     echo "::endgroup::"
   fi
@@ -12,20 +12,19 @@ beginGroup() {
 endGroup() {
   if [[ -n "$GITHUB_ACTIONS" ]] ; then
     echo "::endgroup::"
-  elif [[ -n "$TRAVIS" ]] ; then 
+  elif [[ -n "$TRAVIS" ]] ; then
     echo "travis_fold:end:$*"
   fi
 }
 
-
-
-cd $(dirname $0);
-BUILD_ORDER=$(./build_order.sh $*);
+cd "$(dirname "$0")" || exit $?
+BUILD_ORDER=$(./build_order.sh $*)
+[[ $? -eq 0 ]] || exit $?
 
 for PACKAGE in $BUILD_ORDER ; do
-  beginGroup $PACKAGE
-  pushd $PACKAGE;
-  yarn lib && endGroup $PACKAGE
-  popd;
+  beginGroup "$PACKAGE"
+  pushd "$PACKAGE" || exit $?
+  yarn lib || exit 255
+  endGroup "$PACKAGE"
+  popd || exit $?
 done
-

--- a/app/scripts/modules/build_order.sh
+++ b/app/scripts/modules/build_order.sh
@@ -13,7 +13,7 @@ ModuleDeps () {
       cloudfoundry) echo "core" ;;
       core) echo "core";;
       docker) echo "core" ;;
-      ecs) echo "amazon core" ;;
+      ecs) echo "amazon docker core" ;;
       google) echo "core" ;;
       huaweicloud) echo "core" ;;
       kubernetes) echo "core" ;;

--- a/app/scripts/modules/oracle/src/pipeline/stages/bake/ociBakeStage.js
+++ b/app/scripts/modules/oracle/src/pipeline/stages/bake/ociBakeStage.js
@@ -2,7 +2,14 @@
 
 import { module } from 'angular';
 
-import { AccountService, AuthenticationService, BakeryReader, Registry, PipelineTemplates } from '@spinnaker/core';
+import {
+  AccountService,
+  AuthenticationService,
+  BakeryReader,
+  BakeExecutionLabel,
+  Registry,
+  PipelineTemplates,
+} from '@spinnaker/core';
 import { ORACLE_PIPELINE_STAGES_BAKE_BAKEEXECUTIONDETAILS_CONTROLLER } from './bakeExecutionDetails.controller';
 
 export const ORACLE_PIPELINE_STAGES_BAKE_OCIBAKESTAGE = 'spinnaker.oracle.pipeline.stage.bakeStage';
@@ -16,7 +23,7 @@ module(ORACLE_PIPELINE_STAGES_BAKE_OCIBAKESTAGE, [ORACLE_PIPELINE_STAGES_BAKE_BA
       description: 'Bakes an image',
       templateUrl: require('./bakeStage.html'),
       executionDetailsUrl: require('./bakeExecutionDetails.html'),
-      executionLabelTemplateUrl: require('core/pipeline/config/stages/bake/BakeExecutionLabel'),
+      executionLabelComponent: BakeExecutionLabel,
       supportsCustomTimeout: true,
       validators: [
         { type: 'requiredField', fieldName: 'accountName' },

--- a/app/scripts/modules/oracle/webpack.config.js
+++ b/app/scripts/modules/oracle/webpack.config.js
@@ -1,0 +1,126 @@
+'use strict';
+
+const path = require('path');
+const basePath = path.join(__dirname, '..', '..', '..', '..');
+const NODE_MODULE_PATH = path.join(basePath, 'node_modules');
+const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
+const nodeExternals = require('webpack-node-externals');
+const TerserPlugin = require('terser-webpack-plugin');
+const exclusionPattern = /(node_modules|\.\.\/deck)/;
+const WEBPACK_THREADS = Math.max(require('physical-cpu-count') - 1, 1);
+
+const WATCH = process.env.WATCH === 'true';
+const WEBPACK_MODE = WATCH ? 'development' : 'production';
+const IS_PRODUCTION = WEBPACK_MODE === 'production';
+
+module.exports = {
+  context: basePath,
+  mode: WEBPACK_MODE,
+  stats: 'minimal',
+  watch: WATCH,
+  entry: {
+    lib: path.join(__dirname, 'src', 'index.ts'),
+  },
+  output: {
+    path: path.join(__dirname, 'lib'),
+    filename: '[name].js',
+    library: '@spinnaker/oracle',
+    libraryTarget: 'umd',
+    umdNamedDefine: true,
+  },
+  devtool: 'source-map',
+  optimization: {
+    minimizer: IS_PRODUCTION
+      ? [
+          new TerserPlugin({
+            cache: true,
+            parallel: true,
+            sourceMap: true,
+            terserOptions: {
+              ecma: 6,
+              mangle: false,
+              output: {
+                comments: false,
+              },
+            },
+          }),
+        ]
+      : [], // disable minification in development mode
+  },
+  resolve: {
+    extensions: ['.json', '.js', '.jsx', '.ts', '.tsx', '.css', '.less', '.html'],
+    modules: [NODE_MODULE_PATH, path.resolve('.')],
+    alias: {
+      '@spinnaker/core': path.resolve(basePath, 'app', 'scripts', 'modules', 'core', 'src'),
+      coreImports: path.resolve(
+        basePath,
+        'app',
+        'scripts',
+        'modules',
+        'core',
+        'src',
+        'presentation',
+        'less',
+        'imports',
+        'commonImports.less',
+      ),
+      oracle: path.join(__dirname, 'src'),
+    },
+  },
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        use: [
+          { loader: 'cache-loader' },
+          { loader: 'thread-loader', options: { workers: WEBPACK_THREADS } },
+          { loader: 'babel-loader' },
+          { loader: 'envify-loader' },
+          { loader: 'eslint-loader' },
+        ],
+        exclude: exclusionPattern,
+      },
+      {
+        test: /\.tsx?$/,
+        use: [
+          { loader: 'cache-loader' },
+          { loader: 'thread-loader', options: { workers: WEBPACK_THREADS } },
+          { loader: 'ts-loader', options: { happyPackMode: true } },
+          { loader: 'eslint-loader' },
+        ],
+        exclude: exclusionPattern,
+      },
+      {
+        test: /\.less$/,
+        use: [
+          { loader: 'style-loader' },
+          { loader: 'css-loader' },
+          { loader: 'postcss-loader' },
+          { loader: 'less-loader' },
+        ],
+      },
+      {
+        test: /\.css$/,
+        use: [{ loader: 'style-loader' }, { loader: 'css-loader' }, { loader: 'postcss-loader' }],
+      },
+      {
+        test: /\.html$/,
+        exclude: exclusionPattern,
+        use: [
+          { loader: 'ngtemplate-loader?relativeTo=' + path.resolve(__dirname) + '&prefix=ecs' },
+          { loader: 'html-loader' },
+        ],
+      },
+      {
+        test: /\.(woff|woff2|otf|ttf|eot|png|gif|ico|svg)$/,
+        use: [{ loader: 'file-loader', options: { name: '[name].[hash:5].[ext]' } }],
+      },
+      {
+        test: require.resolve('jquery'),
+        use: [{ loader: 'expose-loader?$' }, { loader: 'expose-loader?jQuery' }],
+      },
+    ],
+  },
+  plugins: [new ForkTsCheckerWebpackPlugin({ checkSyntacticErrors: true })],
+  externals: ['@spinnaker/core', nodeExternals({ modulesDir: '../../../../node_modules' })],
+};


### PR DESCRIPTION
this change to the github actions workflow bypasses unit tests and builds if all that changed was package bumps.
I removed the separate "Ensure package bumps are pure" job in favor of running this check before each check.  This is because I couldn't find a way to make the other jobs conditional on the purebump job.  This adds a lot of extra boilerplate (an if block on every step).  Hopefully in the future we'll have other options.