### PR TITLE
feat(deck): show expression in check precondition execution details

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/checkPreconditions/CheckPreconditionsExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/checkPreconditions/CheckPreconditionsExecutionDetails.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { get } from 'lodash';
+import { get, isBoolean, isString } from 'lodash';
 
 import { StageFailureMessage } from 'core/pipeline';
 
@@ -21,7 +21,9 @@ export function CheckPreconditionsExecutionDetails(props: IExecutionDetailsSecti
               .map(key => (
                 <div key={key}>
                   <dt>{robotToHuman(key)}</dt>
-                  <dd>{JSON.stringify(context[key])}</dd>
+                  <dd>
+                    {isString(context[key]) || isBoolean(context[key]) ? context[key] : JSON.stringify(context[key])}
+                  </dd>
                 </div>
               ))}
             <div>

--- a/app/scripts/modules/core/src/pipeline/config/stages/checkPreconditions/CheckPreconditionsExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/checkPreconditions/CheckPreconditionsExecutionDetails.tsx
@@ -17,7 +17,7 @@ export function CheckPreconditionsExecutionDetails(props: IExecutionDetailsSecti
         <div className="col-md-12">
           <dl className="dl-horizontal">
             {Object.keys(context)
-              .filter(key => !['expression', 'failureMessage'].includes(key) && context[key] !== null)
+              .filter(key => !['failureMessage'].includes(key) && context[key] !== null)
               .map(key => (
                 <div key={key}>
                   <dt>{robotToHuman(key)}</dt>


### PR DESCRIPTION
@maggieneterval @ethanfrogers this PR closes https://github.com/spinnaker/spinnaker/issues/5097 by showing the expression in the check precondition stage execution details .

When doing this I also noticed the expression itself was being escaped when displayed (eg parameters["not"] != "hello" -> parameters[\\"not\\"] != \\"hello\\"). This looks to be due to using JSON.stringify and the values being strings not objects. I didn't see any reason this would be needed otherwise, so I removed it. Let me know if you think it should stay and I can drop that commit. 