### PR TITLE
fix(amazon/availabilityZone): Simplify state management for availability zone selection

### DIFF
--- a/app/scripts/modules/amazon/src/serverGroup/AvailabilityZoneSelector.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/AvailabilityZoneSelector.tsx
@@ -1,108 +1,41 @@
 import React from 'react';
 
-import { AccountService, ChecklistInput } from '@spinnaker/core';
+import { ChecklistInput } from '@spinnaker/core';
 
 export interface IAvailabilityZoneSelectorProps {
-  region: string;
-  credentials: string;
-  onChange: (zones: string[]) => void;
   allZones: string[];
-  usePreferredZones?: boolean;
+  credentials: string;
+  region: string;
   selectedZones: string[];
+  onChange: (zones: string[]) => void;
+  onPreferredZonesSelect?: () => void;
 }
 
-export interface IAvailabilityZoneSelectorState {
-  defaultZones: string[];
-  usePreferredZones: boolean;
-}
-
-export class AvailabilityZoneSelector extends React.Component<
-  IAvailabilityZoneSelectorProps,
-  IAvailabilityZoneSelectorState
-> {
-  constructor(props: IAvailabilityZoneSelectorProps) {
-    super(props);
-    this.state = {
-      defaultZones: [],
-      usePreferredZones: props.usePreferredZones || !props.selectedZones || props.selectedZones.length === 0,
-    };
-
-    this.setDefaultZones(props);
-  }
-
-  public componentWillReceiveProps(nextProps: IAvailabilityZoneSelectorProps): void {
-    if (nextProps.region !== this.props.region || nextProps.credentials !== this.props.credentials) {
-      this.setDefaultZones(nextProps);
-    }
-  }
-
-  private setDefaultZones(props: IAvailabilityZoneSelectorProps) {
-    const { credentials, onChange, region } = props;
-    const { usePreferredZones } = this.state;
-
-    AccountService.getAvailabilityZonesForAccountAndRegion('aws', credentials, region).then(preferredZones => {
-      this.setState({ defaultZones: preferredZones });
-      if (usePreferredZones && preferredZones) {
-        onChange(preferredZones.slice());
-      }
-    });
-  }
-
-  private handleUsePreferredZonesChanged = (event: React.ChangeEvent<HTMLSelectElement>): void => {
-    const usePreferredZones = event.target.value === 'true';
-    this.setState({ usePreferredZones });
-
-    if (usePreferredZones) {
-      this.setDefaultZones(this.props);
-    }
-  };
-
-  private handleSelectedZonesChanged = (zones: Set<string>): void => {
-    this.props.onChange([...zones]);
-  };
-
-  public render(): React.ReactElement<AvailabilityZoneSelector> {
-    const { region, allZones, selectedZones } = this.props;
-    const { defaultZones, usePreferredZones } = this.state;
-
-    return (
-      <div className="form-group">
-        <div className="col-md-3 sm-label-right">Availability Zones</div>
-        {region && (
-          <div className="col-md-7">
-            <p className="form-control-static">Automatic Availability Zone Balancing:</p>
-            <select
-              className="form-control input-sm"
-              value={usePreferredZones ? 'true' : 'false'}
-              onChange={this.handleUsePreferredZonesChanged}
-            >
-              <option value="true">Enabled</option>
-              <option value="false">Manual</option>
-            </select>
-            <br />
-            {usePreferredZones && (
-              <div>
-                <p className="form-control-static">Server group will be available in:</p>
-                <ul>
-                  {defaultZones.map(zone => (
-                    <li key={zone}>{zone}</li>
-                  ))}
-                </ul>
-              </div>
-            )}
-            {!usePreferredZones && (
-              <div>
-                Restrict server group instances to:
-                <ChecklistInput
-                  stringOptions={allZones}
-                  value={selectedZones}
-                  onChange={(e: React.ChangeEvent<any>) => this.handleSelectedZonesChanged(e.target.value)}
-                />
-              </div>
-            )}
-          </div>
-        )}
+export const AvailabilityZoneSelector = ({
+  allZones,
+  selectedZones,
+  onChange,
+  onPreferredZonesSelect,
+}: IAvailabilityZoneSelectorProps) => {
+  const handleSelectedZonesChanged = React.useCallback(zones => onChange([...zones]), []);
+  return (
+    <div className="form-group">
+      <div className="col-md-3 sm-label-right">Availability Zones</div>
+      <div className="col-md-7">
+        <p className="form-control-static">Choose Your Zones:</p>
+        <div>
+          <ChecklistInput
+            stringOptions={allZones}
+            value={selectedZones}
+            onChange={(e: React.ChangeEvent<any>) => handleSelectedZonesChanged(e.target.value)}
+          />
+          {onPreferredZonesSelect ? (
+            <a style={{ cursor: 'pointer' }} onClick={onPreferredZonesSelect}>
+              Reset to preferred zones
+            </a>
+          ) : null}
+        </div>
       </div>
-    );
-  }
-}
+    </div>
+  );
+};

--- a/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupCommandBuilder.aws.service.spec.js
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupCommandBuilder.aws.service.spec.js
@@ -59,25 +59,6 @@ describe('Service: awsServerGroup', function() {
       expect(command.credentials).toBe('prod');
       expect(command.region).toBe('us-west-1');
     });
-
-    it('sets usePreferredZones', function() {
-      var command = null;
-      this.service.buildServerGroupCommandFromPipeline({}, this.cluster).then(function(result) {
-        command = result;
-      });
-
-      this.$scope.$digest();
-      expect(command.viewState.usePreferredZones).toBe(true);
-
-      // remove an availability zone, should be false
-      this.cluster.availabilityZones['us-west-1'].pop();
-      this.service.buildServerGroupCommandFromPipeline({}, this.cluster).then(function(result) {
-        command = result;
-      });
-
-      this.$scope.$digest();
-      expect(command.viewState.usePreferredZones).toBe(false);
-    });
   });
 
   describe('buildServerGroupCommandFromExisting', function() {

--- a/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupCommandBuilder.spec.js
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupCommandBuilder.spec.js
@@ -29,7 +29,7 @@ describe('awsServerGroupCommandBuilder', function() {
   afterEach(AWSProviderSettings.resetToOriginal);
 
   describe('buildNewServerGroupCommand', function() {
-    it('initializes to default values, setting usePreferredZone flag to true', function() {
+    it('initializes to default values', function() {
       var command = null;
       AWSProviderSettings.defaults.iamRole = '{{application}}IAMRole';
       this.awsServerGroupCommandBuilder
@@ -40,14 +40,13 @@ describe('awsServerGroupCommandBuilder', function() {
 
       this.$scope.$digest();
 
-      expect(command.viewState.usePreferredZones).toBe(true);
       expect(command.availabilityZones).toEqual(['a', 'b', 'c']);
       expect(command.iamRole).toBe('appoIAMRole');
     });
   });
 
   describe('buildServerGroupCommandFromExisting', function() {
-    it('sets usePreferredZones flag based on initial value', function() {
+    it('sets availabilityZones based on initial value', function() {
       spyOn(this.instanceTypeService, 'getCategoryForInstanceType').and.returnValue(this.$q.when('custom'));
       var baseServerGroup = {
         account: 'prod',
@@ -67,7 +66,6 @@ describe('awsServerGroupCommandBuilder', function() {
 
       this.$scope.$digest();
 
-      expect(command.viewState.usePreferredZones).toBe(true);
       expect(command.availabilityZones).toEqual(['g', 'h', 'i']);
 
       baseServerGroup.asg.availabilityZones = ['g'];
@@ -80,7 +78,6 @@ describe('awsServerGroupCommandBuilder', function() {
 
       this.$scope.$digest();
 
-      expect(command.viewState.usePreferredZones).toBe(false);
       expect(command.availabilityZones).toEqual(['g']);
     });
 

--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/ServerGroupZones.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/ServerGroupZones.tsx
@@ -21,9 +21,14 @@ export class ServerGroupZones extends React.Component<IServerGroupZonesProps>
   }
 
   private handleAvailabilityZonesChanged = (zones: string[]): void => {
+    this.props.formik.setFieldValue('availabilityZones', zones);
+  };
+
+  private handlePreferredZonesSelected = (): void => {
     const { values, setFieldValue } = this.props.formik;
-    values.usePreferredZonesChanged(values);
-    setFieldValue('availabilityZones', zones);
+    const preferredZones = values.backingData.preferredZones[values.credentials]?.[values.region]?.slice() || [];
+
+    setFieldValue('availabilityZones', preferredZones);
   };
 
   private rebalanceToggled = () => {
@@ -35,15 +40,18 @@ export class ServerGroupZones extends React.Component<IServerGroupZonesProps>
 
   public render() {
     const { values } = this.props.formik;
+    const currentAvailabilityZones = values.availabilityZones;
+    const preferredZones = values.backingData.preferredZones[values.credentials]?.[values.region] || [];
+    const isUsingPreferredZones = currentAvailabilityZones.sort().join() === preferredZones.sort().join();
     return (
       <div className="container-fluid form-horizontal">
         <AvailabilityZoneSelector
           credentials={values.credentials}
           region={values.region}
           onChange={this.handleAvailabilityZonesChanged}
+          onPreferredZonesSelect={isUsingPreferredZones ? undefined : this.handlePreferredZonesSelected}
           selectedZones={values.availabilityZones}
           allZones={values.backingData.filtered.availabilityZones}
-          usePreferredZones={values.viewState.usePreferredZones}
         />
         <div className="form-group">
           <div className="col-md-3 sm-label-right">

--- a/app/scripts/modules/core/src/serverGroup/configure/common/serverGroupCommandBuilder.service.ts
+++ b/app/scripts/modules/core/src/serverGroup/configure/common/serverGroupCommandBuilder.service.ts
@@ -52,7 +52,6 @@ export interface IServerGroupCommandViewState {
   showImageSourceSelector: true;
   useAllImageSelection: boolean;
   useSimpleCapacity: boolean;
-  usePreferredZones: boolean;
   mode: string;
   pipeline?: IPipeline;
   stage?: IStage;


### PR DESCRIPTION
The primary purpose of this PR is to remove the use of dropdown selector to select between manual and automatic selection of availability zones. We do not have a flag to determine manual vs automatic selection, instead we use the selected availability zones and the pre-configured preferred zones to determine that. This confuses users when they see automatic selected even though they chose manual (but ended up selecting preferred zones).

The new UI treatment looks the following way.

![availbilityzones](https://user-images.githubusercontent.com/357832/74266187-b9049480-4cb8-11ea-9af8-214c0e31e956.png)

I also used this opportunity to fix a few bad patterns that might have crept in due to angular to react migration. The state management for availability zone selection is spread across `AvailabilityZoneSelector.tsx`, `ServerGroupZones.tsx`, `serverGroupConfiguration.service.ts` and `serverGroupCommandBuilder.service.js` and I've made the following changes.

1. Removed local component state (required by `AvailabilityZoneSelector.tsx`)  from formik.
2. Removed preferred zones loading and computation from `AvailabilityZoneSelector.tsx` and made it a stateless component.
3. Removed unused code from `LoadBalancerLocation.tsx`. This component only allows selection of availability zones computed from subnets and the removed code wasn't actually affecting anything in the UI.
4. Retained form level state management at `serverGroupConfiguration.service.ts`