### PR TITLE
fix(amazon): Add a warning when no oidc conifgs are found

### DIFF
--- a/app/scripts/modules/amazon/src/loadBalancer/configure/application/ALBListeners.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/application/ALBListeners.tsx
@@ -772,12 +772,11 @@ const Action = (props: {
         props.oidcConfigs.length > 0 &&
         (!clientId || props.oidcConfigs.find(c => c.clientId === clientId)));
 
-    const oidcOptions =
-      props.oidcConfigs && props.oidcConfigs.length ? (
-        (props.oidcConfigs || []).map(config => <option key={config.clientId}>{config.clientId}</option>)
-      ) : (
-        <option disabled>No {CustomLabels.get('OIDC client')} config found</option>
-      );
+    const oidcOptions = props.oidcConfigs?.length ? (
+      props.oidcConfigs.map(config => <option key={config.clientId}>{config.clientId}</option>)
+    ) : (
+      <option disabled>No {CustomLabels.get('OIDC client')} config found</option>
+    );
 
     return (
       <div className="horizontal middle" style={{ height: '30px' }}>

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/application/ALBListeners.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/application/ALBListeners.tsx
@@ -771,6 +771,14 @@ const Action = (props: {
       (props.oidcConfigs &&
         props.oidcConfigs.length > 0 &&
         (!clientId || props.oidcConfigs.find(c => c.clientId === clientId)));
+
+    const oidcOptions =
+      props.oidcConfigs && props.oidcConfigs.length ? (
+        (props.oidcConfigs || []).map(config => <option key={config.clientId}>{config.clientId}</option>)
+      ) : (
+        <option disabled>No {CustomLabels.get('OIDC client')} config found</option>
+      );
+
     return (
       <div className="horizontal middle" style={{ height: '30px' }}>
         <span style={{ whiteSpace: 'pre' }}>auth with {CustomLabels.get('OIDC client')} </span>
@@ -783,9 +791,7 @@ const Action = (props: {
             required={true}
           >
             <option value="" />
-            {(props.oidcConfigs || []).map(config => (
-              <option key={config.clientId}>{config.clientId}</option>
-            ))}
+            {oidcOptions}
           </select>
         )}
         {!showOidcConfigs && (


### PR DESCRIPTION
When authenticating an ALB listener rule, the select field is empty if there are no configs found. This is due to configuration being nonexistent or being configured improperly for the application. This PR adds a warning in the dropdown (in addition to the help field), so it does not look like an error rendering the options.
<img width="618" alt="Screen Shot 2020-02-12 at 11 05 23 AM" src="https://user-images.githubusercontent.com/26560152/74367994-a2793e80-4d87-11ea-86d1-e9c86e05f16f.png">
