### PR TITLE
fix(aws): Fix to set right state while cloning security group

### DIFF
--- a/app/scripts/modules/amazon/src/securityGroup/clone/cloneSecurityGroup.controller.js
+++ b/app/scripts/modules/amazon/src/securityGroup/clone/cloneSecurityGroup.controller.js
@@ -41,7 +41,7 @@ angular
           securityGroup: securityGroup,
         }),
       );
-
+      $scope.state.isNew = true;
       // We want to let people clone as a means to copy security groups across
       // regions so don't block them because the names already exist.
       $scope.allowDuplicateNames = true;


### PR DESCRIPTION
- Setting `state.isNew` to `true` during clone which is used in the overridden component 