### PR TITLE
fix(amazon/instance): fix npe when applying health to instances

### DIFF
--- a/app/scripts/modules/amazon/src/instance/details/utils.ts
+++ b/app/scripts/modules/amazon/src/instance/details/utils.ts
@@ -19,7 +19,7 @@ export const applyHealthCheckInfoToTargetGroups = (
         const group = targetGroups[tg.name] ?? ({} as ITargetGroup);
         const useTrafficPort = group.healthCheckPort === 'traffic-port' || isNil(group.healthCheckPort);
         const port = useTrafficPort ? group.port : group.healthCheckPort;
-        tg.healthCheckProtocol = group.healthCheckProtocol.toLowerCase();
+        tg.healthCheckProtocol = group.healthCheckProtocol?.toLowerCase();
         tg.healthCheckPath = `:${port}${group.healthCheckPath}`;
       });
     }


### PR DESCRIPTION
null check when a servergroup is reported to have a target group (but that target group doesn't actually exist)