### PR TITLE
Update eslint-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "webpack-dev-middleware": "^3.7.2"
   },
   "devDependencies": {
-    "@spinnaker/eslint-plugin": "./packages/eslint-plugin",
+    "@spinnaker/eslint-plugin": "latest",
     "@types/angular": "1.6.26",
     "@types/angular-mocks": "1.5.10",
     "@types/angular-ui-bootstrap": "^0.13.41",

--- a/packages/eslint-plugin/base.config.js
+++ b/packages/eslint-plugin/base.config.js
@@ -21,6 +21,8 @@ module.exports = {
     'one-var': ['error', { initialized: 'never' }],
     'prefer-rest-params': 'off',
     'prefer-spread': 'off',
+    // turn back on if https://github.com/eslint/eslint/issues/11899 fixes false positives
+    'require-atomic-updates': 'off',
     '@typescript-eslint/array-type': ['error', { default: 'array-simple' }],
     '@typescript-eslint/ban-ts-ignore': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',

--- a/packages/eslint-plugin/eslint-plugin.js
+++ b/packages/eslint-plugin/eslint-plugin.js
@@ -12,5 +12,6 @@ module.exports = {
   },
   configs: {
     base: require('./base.config.js'),
+    none: require('./none.config.js'),
   },
 };

--- a/packages/eslint-plugin/none.config.js
+++ b/packages/eslint-plugin/none.config.js
@@ -1,0 +1,18 @@
+module.exports = {
+  parser: '@typescript-eslint/parser',
+  parserOptions: { sourceType: 'module' },
+  plugins: ['@typescript-eslint', '@spinnaker/eslint-plugin'],
+  extends: [],
+  rules: {},
+  env: {
+    browser: true,
+    node: true,
+    es6: true,
+    jasmine: true,
+  },
+  globals: {
+    angular: true,
+    $: true,
+    _: true,
+  },
+};

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/eslint-plugin",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "main": "eslint-plugin.js",
   "license": "Apache-2.0",
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -319,8 +319,10 @@
   dependencies:
     tinyqueue "^1.1.0"
 
-"@spinnaker/eslint-plugin@./packages/eslint-plugin":
-  version "1.0.2"
+"@spinnaker/eslint-plugin@latest":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@spinnaker/eslint-plugin/-/eslint-plugin-1.0.3.tgz#566285eb055532637a416fb1f45fb5f20509c22a"
+  integrity sha512-nzC6xkXwnU6rRWFui+IEt/fn1d6jusYAR9NsW3LRU0jCsLVkz4FzCAfF0qcoYjxJppYMZnCnqmhEFIwHOz1JjA==
   dependencies:
     jest "^24.9.0"
     lodash "^4.17.15"


### PR DESCRIPTION
This eslint-plugin is a set of eslint rules that we use use in deck.  We will also be using these rules in the pluginsdk (when it becomes a thing).  We're also about to be using these rules in netflix's internal customization of deck.

- Update eslint-plugin with a blank config.  
  - this can be used to apply parser opinions (`parser: '@typescript-eslint/parser',  parserOptions: { sourceType: 'module' }`) but test or run individual rules on the command line `--rule "{'prefer-const':2}"`
- publish package version 1.0.3 to npm
- use the npm package in deck