### PR TITLE
fix(amazon): Preserve policyNames in CLB descriptions

### DIFF
--- a/app/scripts/modules/amazon/src/domain/IAmazonLoadBalancer.ts
+++ b/app/scripts/modules/amazon/src/domain/IAmazonLoadBalancer.ts
@@ -239,6 +239,7 @@ export interface IAmazonLoadBalancerDeleteCommand extends ILoadBalancerDeleteCom
 export interface IClassicListenerDescription extends IClassicListener {
   sslCertificateId?: string;
   sslCertificateName?: string;
+  policyNames?: string[];
 }
 
 export interface IAmazonClassicLoadBalancerUpsertCommand extends IAmazonLoadBalancerUpsertCommand {

--- a/app/scripts/modules/amazon/src/loadBalancer/loadBalancer.transformer.ts
+++ b/app/scripts/modules/amazon/src/loadBalancer/loadBalancer.transformer.ts
@@ -238,6 +238,7 @@ export class AwsLoadBalancerTransformer {
               sslCertificateId: listener.sslcertificateId,
               sslCertificateName: listener.sslcertificateId,
               sslCertificateType: listener.sslCertificateType,
+              policyNames: description.policyNames,
             };
           },
         );


### PR DESCRIPTION
Otherwise existing policies get dropped on edit operations