### PR TITLE
feat(plugins): copies over plugin-manifest from a halyard deploy

### DIFF
--- a/app/scripts/modules/core/src/plugins/plugin.registry.spec.ts
+++ b/app/scripts/modules/core/src/plugins/plugin.registry.spec.ts
@@ -53,6 +53,7 @@ describe('PluginRegistry', () => {
       pluginModule = {
         plugin: {
           stages: [({ id: 'mystage' } as any) as IStageTypeConfig],
+          undefinedExtensions: () => {},
         },
       };
     });

--- a/app/scripts/modules/core/src/plugins/plugin.registry.ts
+++ b/app/scripts/modules/core/src/plugins/plugin.registry.ts
@@ -4,6 +4,7 @@ import { IStageTypeConfig } from 'core/domain';
 
 export interface IDeckPlugin {
   stages?: IStageTypeConfig[];
+  undefinedExtensions?(): void;
 }
 
 export interface IPluginManifest {
@@ -134,6 +135,9 @@ export class PluginRegistry {
 
       // Register extensions with deck.
       plugin.stages?.forEach(stage => Registry.pipeline.registerStage(stage));
+
+      // Run code that currently does not have an extension point
+      plugin.undefinedExtensions && plugin.undefinedExtensions();
 
       return module;
     } catch (error) {

--- a/docker/run-apache2.sh
+++ b/docker/run-apache2.sh
@@ -80,4 +80,9 @@ then
 	cp /opt/spinnaker/config/settings-local.js /opt/deck/html/settings-local.js
 fi
 
+if [ -e /opt/spinnaker/config/plugin-manifest.js ];
+then 
+	cp /opt/spinnaker/config/plugin-manifest.js /opt/deck/html/plugin-manifest.js
+fi
+
 apache2ctl -D FOREGROUND 


### PR DESCRIPTION
When using Halyard to deploy to Kubernetes, copy over the `plugin-manifest.js` as well
