### PR TITLE
feat(core/presentation): add Table components, multiple table layouts

### DIFF
--- a/app/scripts/modules/core/src/presentation/index.ts
+++ b/app/scripts/modules/core/src/presentation/index.ts
@@ -20,6 +20,7 @@ export * from './sortToggle';
 export * from './SpanDropdownTrigger';
 export * from './spel';
 export * from './TabBoundary';
+export * from './tables';
 export * from './TetheredCreatable';
 export * from './TetheredSelect';
 export * from './text';

--- a/app/scripts/modules/core/src/presentation/tables/Table.tsx
+++ b/app/scripts/modules/core/src/presentation/tables/Table.tsx
@@ -1,0 +1,71 @@
+import * as React from 'react';
+
+import { useIsMobile, useDeepObjectDiff } from 'core/presentation';
+
+import { ITableRowLayoutProps } from './TableRow';
+import { ITableCellLayoutProps } from './TableCell';
+import { TableContext } from './TableContext';
+
+const { useState, useMemo } = React;
+
+export interface ITableColumn {
+  name: string;
+  sortDirection?: 'ascending' | 'descending';
+  onSort?: () => any;
+}
+
+export type ITableColumns = Readonly<Array<string | ITableColumn>>;
+
+export interface ITableLayoutProps {
+  columns: ITableColumn[];
+  isMobile: boolean;
+  expandable?: boolean;
+  expandAll: () => any;
+  children?: React.ReactNode;
+}
+
+export interface ITableLayout {
+  TableLayout: React.ComponentType<ITableLayoutProps>;
+  TableRowLayout: React.ComponentType<ITableRowLayoutProps>;
+  TableCellLayout: React.ComponentType<ITableCellLayoutProps>;
+}
+
+export interface ITableProps {
+  layout: ITableLayout;
+  columns: ITableColumns;
+  expandable?: boolean;
+  children?: React.ReactNode;
+}
+
+export const Table = (props: ITableProps) => {
+  const isMobile = useIsMobile();
+  const [allExpanded, setAllExpanded] = useState(false);
+
+  const { layout, ...propsWithoutLayout } = props;
+
+  const normalizedColumns = props.columns.map(column => (typeof column === 'string' ? { name: column } : column));
+  const tableContext = useMemo(
+    () => ({
+      layout,
+      isMobile,
+      allExpanded,
+      setAllExpanded: () => setAllExpanded(false),
+      expandable: props.expandable,
+      columns: normalizedColumns,
+    }),
+    [layout, isMobile, props.expandable, allExpanded, useDeepObjectDiff(props.columns)],
+  );
+
+  const { TableLayout } = layout;
+
+  return (
+    <TableContext.Provider value={tableContext}>
+      <TableLayout
+        {...propsWithoutLayout}
+        isMobile={isMobile}
+        columns={normalizedColumns}
+        expandAll={() => setAllExpanded(true)}
+      />
+    </TableContext.Provider>
+  );
+};

--- a/app/scripts/modules/core/src/presentation/tables/TableCell.tsx
+++ b/app/scripts/modules/core/src/presentation/tables/TableCell.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+
+import { ITableContext, TableContext } from './TableContext';
+
+const { useContext } = React;
+
+export interface ITableCellProps {
+  indent?: number;
+  children?: React.ReactNode;
+}
+
+export interface ITableCellPropsWithInternalFields extends ITableCellProps {
+  index: number;
+}
+
+export type ITableCellLayoutProps = ITableCellPropsWithInternalFields &
+  Pick<ITableContext, 'expandable' | 'isMobile' | 'columns'>;
+
+export const TableCell = (props: ITableCellProps) => {
+  const { layout, expandable, isMobile, columns } = useContext(TableContext);
+
+  const { TableCellLayout } = layout;
+
+  return (
+    <TableCellLayout
+      // While the public TableCell API is ITableCellProps,
+      // in reality the parent TableRow will hydrate things
+      // and pass us ITableCellPropsWithInternalFields
+      {...(props as ITableCellPropsWithInternalFields)}
+      expandable={expandable}
+      isMobile={isMobile}
+      columns={columns}
+    />
+  );
+};

--- a/app/scripts/modules/core/src/presentation/tables/TableContext.tsx
+++ b/app/scripts/modules/core/src/presentation/tables/TableContext.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+
+import { ITableLayout, ITableColumn } from './Table';
+
+export interface ITableContext {
+  layout: ITableLayout;
+  isMobile: boolean;
+  expandable: boolean;
+  allExpanded: boolean;
+  setAllExpanded: (allExpanded: boolean) => any;
+  columns: ITableColumn[];
+}
+
+export const TableContext = React.createContext<ITableContext>(null);

--- a/app/scripts/modules/core/src/presentation/tables/TableRow.tsx
+++ b/app/scripts/modules/core/src/presentation/tables/TableRow.tsx
@@ -1,0 +1,81 @@
+import * as React from 'react';
+
+import { ITableCellPropsWithInternalFields } from './TableCell';
+import { ITableContext, TableContext } from './TableContext';
+
+const { useState, useContext, useEffect } = React;
+
+export interface ITableRowProps {
+  defaultExpanded?: boolean;
+  renderExpandedContent?: () => React.ReactNode;
+  children?: React.ReactNode;
+}
+export type ITableRowLayoutProps = ITableRowProps &
+  Pick<ITableContext, 'isMobile' | 'columns'> &
+  Pick<ITableRowProps, 'renderExpandedContent'> & {
+    tableExpandable: boolean;
+    rowExpandable: boolean;
+    expanded: boolean;
+    setExpanded: (expanded: boolean) => any;
+  };
+
+const logDefaultExpandedError = () => {
+  console.error(
+    new Error(
+      `You used the defaultExpanded prop on a row inside a <Table/> that's not expandable.
+       Either remove the defaultExpanded prop or make the <Table/> expandable.`,
+    ),
+  );
+};
+
+const throwCellColumnError = () => {
+  throw new Error(
+    `A <TableCell/> was added that didn't match any of the columns defined on its parent <Table/>.
+     Check if there are an equal number of <TableCell/> elements to the number of columns provided to the <Table/>.
+    `,
+  );
+};
+
+export const TableRow = ({ defaultExpanded, renderExpandedContent, children }: ITableRowProps) => {
+  const { layout, expandable, allExpanded, setAllExpanded, isMobile, columns } = useContext(TableContext);
+  const [expanded, setExpanded] = useState(defaultExpanded || false);
+
+  // Expand individual rows when the table expands all its rows at once
+  useEffect(() => {
+    allExpanded && renderExpandedContent && setExpanded(true);
+  }, [allExpanded]);
+
+  if (!expandable && defaultExpanded != null) {
+    logDefaultExpandedError();
+  }
+
+  const childrenWithIndex = React.Children.map(children, (cell, index) => {
+    return React.cloneElement(cell as React.ReactElement<ITableCellPropsWithInternalFields>, { index });
+  });
+
+  if (childrenWithIndex.length > columns.length) {
+    throwCellColumnError();
+  }
+
+  const { TableRowLayout } = layout;
+
+  return (
+    <TableRowLayout
+      tableExpandable={expandable}
+      rowExpandable={expandable && !!renderExpandedContent}
+      expanded={expanded}
+      setExpanded={expand => {
+        setExpanded(expand);
+        // When all rows were previously expanded, clear away that state
+        // the first time an individual row is collapsed
+        if (allExpanded && !expand) {
+          setAllExpanded(false);
+        }
+      }}
+      renderExpandedContent={renderExpandedContent}
+      isMobile={isMobile}
+      columns={columns}
+      children={childrenWithIndex}
+    />
+  );
+};

--- a/app/scripts/modules/core/src/presentation/tables/index.ts
+++ b/app/scripts/modules/core/src/presentation/tables/index.ts
@@ -1,0 +1,3 @@
+export * from './Table';
+export * from './TableRow';
+export * from './TableCell';

--- a/app/scripts/modules/core/src/presentation/tables/index.ts
+++ b/app/scripts/modules/core/src/presentation/tables/index.ts
@@ -2,3 +2,4 @@ export * from './Table';
 export * from './TableRow';
 export * from './TableCell';
 export * from './minimalNativeTableLayout';
+export * from './standardGridTableLayout';

--- a/app/scripts/modules/core/src/presentation/tables/index.ts
+++ b/app/scripts/modules/core/src/presentation/tables/index.ts
@@ -1,3 +1,4 @@
 export * from './Table';
 export * from './TableRow';
 export * from './TableCell';
+export * from './minimalNativeTableLayout';

--- a/app/scripts/modules/core/src/presentation/tables/minimalNativeTableLayout.less
+++ b/app/scripts/modules/core/src/presentation/tables/minimalNativeTableLayout.less
@@ -1,0 +1,36 @@
+.MinimalNativeTableLayout {
+  text-align: left;
+  font-size: 13px;
+  overflow: hidden;
+
+  .header-row {
+    height: 24px;
+  }
+
+  .header-cell {
+    color: var(--color-charcoal);
+    font-weight: 400;
+    padding: 0 16px;
+    border-bottom: 1px solid var(--color-porcelain);
+
+    &:first-child {
+      font-weight: 900;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+      color: var(--color-black);
+    }
+  }
+
+  .cell {
+    color: var(--color-charcoal);
+    padding: 6px 16px;
+    vertical-align: top;
+    min-width: 80px;
+
+    &:first-child {
+      font-weight: 600;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+    }
+  }
+}

--- a/app/scripts/modules/core/src/presentation/tables/minimalNativeTableLayout.tsx
+++ b/app/scripts/modules/core/src/presentation/tables/minimalNativeTableLayout.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+
+import { ITableLayoutProps } from './Table';
+import { ITableRowLayoutProps } from './TableRow';
+import { ITableCellLayoutProps } from './TableCell';
+
+import './minimalNativeTableLayout.less';
+
+const GUTTER_SIZE_PX = 16;
+const INDENT_SIZE_PX = 20;
+
+const TableLayout = ({ columns, children }: ITableLayoutProps) => {
+  return (
+    <table className="MinimalNativeTableLayout" cellSpacing="0" cellPadding="0">
+      <thead>
+        <tr className="header-row">
+          {columns.map(({ name }) => (
+            <th key={name} className="header-cell">
+              {name}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>{children}</tbody>
+    </table>
+  );
+};
+
+const TableRowLayout = ({ children }: ITableRowLayoutProps) => {
+  return <tr>{children}</tr>;
+};
+
+const TableCellLayout = ({ children, indent }: ITableCellLayoutProps) => {
+  return (
+    <td
+      className="cell"
+      style={{ paddingLeft: !!indent ? `${GUTTER_SIZE_PX + indent * INDENT_SIZE_PX}px` : undefined }}
+    >
+      {children}
+    </td>
+  );
+};
+
+export const minimalNativeTableLayout = {
+  TableLayout,
+  TableRowLayout,
+  TableCellLayout,
+};

--- a/app/scripts/modules/core/src/presentation/tables/standardGridTableLayout.less
+++ b/app/scripts/modules/core/src/presentation/tables/standardGridTableLayout.less
@@ -1,0 +1,196 @@
+.StandardGridTableLayout {
+  display: grid;
+
+  .standard-grid-table-header {
+    display: grid;
+    position: sticky;
+    top: 0;
+    font-weight: 600;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    color: var(--color-regal);
+    font-size: 13px;
+    z-index: 100;
+    align-items: flex-end;
+    min-height: 48px;
+    grid-column: 1 / -1;
+    background-color: var(--color-smoke);
+    border-bottom: 2px solid var(--color-blumine);
+
+    .standard-grid-table-cell {
+      align-items: flex-end;
+      padding-bottom: 6px;
+
+      &.sortable {
+        border-radius: 16px 16px 0 0;
+        cursor: pointer;
+        height: 32px;
+
+        &:hover {
+          background-color: rgba(160, 180, 220, 0.15);
+        }
+
+        & > .sort-indicator {
+          border-radius: 16px;
+          background-color: var(--color-blumine);
+          width: 16px;
+          height: 16px;
+          margin-left: 6px;
+          margin-bottom: 1px;
+          position: relative;
+
+          &:after {
+            content: '';
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            width: 0;
+            height: 0;
+            margin-left: -4px;
+            border-left: 4px solid transparent;
+            border-right: 4px solid transparent;
+          }
+
+          &.ascending:after {
+            margin-top: -2px;
+            border-bottom: 4px solid var(--color-smoke);
+          }
+
+          &.descending:after {
+            margin-top: -1px;
+            border-top: 4px solid var(--color-smoke);
+          }
+        }
+      }
+
+      &.header-expand-toggle {
+        display: flex;
+        justify-content: center;
+        align-items: flex-end;
+        cursor: pointer;
+        padding-left: 0;
+        border-radius: 16px 16px 0 0;
+        height: 32px;
+
+        &:hover {
+          background-color: rgba(160, 180, 220, 0.15);
+        }
+
+        & > i {
+          font-size: 24px;
+          margin-bottom: -4px;
+        }
+      }
+    }
+  }
+
+  .standard-grid-table-row {
+    display: grid;
+    min-height: 40px;
+    overflow: hidden;
+    align-items: center;
+    font-size: 13px;
+    padding: 8px 0;
+    grid-column: 1 / -1;
+
+    &.expandable {
+      cursor: pointer;
+
+      &:hover {
+        /*
+          Since this becomes a sticky header when rows are expanded
+          and the color we want is semi-transparent, let's use a gradient
+          that grabs the right color but puts a white backdrop behind it
+          so the things scrolling below it don't come through.
+        */
+        background-image: linear-gradient(180deg, rgba(160, 180, 220, 0.15), rgba(160, 180, 220, 0.15));
+      }
+    }
+
+    &.expanded {
+      background-color: var(--color-white);
+      position: sticky;
+      top: 48px;
+    }
+
+    .row-expand-toggle {
+      justify-content: center;
+      padding-left: 0;
+      color: var(--color-nobel);
+
+      & > i {
+        font-size: 24px;
+      }
+    }
+  }
+
+  .expanded-row-content {
+    /* stretch across entire table width */
+    grid-column: 1 / -1;
+    background-color: var(--color-white);
+    padding: 16px;
+    margin-bottom: 16px;
+    overflow-x: scroll;
+  }
+
+  .standard-grid-table-cell,
+  .cell-content {
+    display: flex;
+    align-items: center;
+  }
+
+  .standard-grid-table-cell {
+    padding-left: 16px;
+  }
+
+  @media screen and (max-width: 1024px) {
+    .standard-grid-table-row {
+      display: flex;
+      flex-wrap: wrap;
+      padding: 0 8px 16px;
+      margin: 0 0 16px;
+      border-bottom: 1px solid var(--color-porcelain);
+
+      &:first-child {
+        margin-top: 16px;
+      }
+
+      &.expanded {
+        position: static;
+        margin-bottom: 0;
+        padding-left: 6px;
+        /*for border */
+        border-left: 2px solid var(--color-regal);
+        border-bottom: none;
+      }
+
+      &.expanded:hover {
+        background-color: var(--color-white);
+      }
+    }
+
+    .expanded-row-content {
+      border-left: 2px solid var(--color-regal);
+      margin-bottom: 16px;
+    }
+
+    .standard-grid-table-cell {
+      flex: 0 0 100%;
+      flex-direction: column;
+      align-items: flex-start;
+    }
+
+    .mobile-cell-header {
+      font-weight: 900;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+      color: var(--color-regal);
+      margin-top: 9px;
+    }
+
+    .cell-content {
+      margin-top: 4px;
+      margin-left: 4px;
+    }
+  }
+}

--- a/app/scripts/modules/core/src/presentation/tables/standardGridTableLayout.tsx
+++ b/app/scripts/modules/core/src/presentation/tables/standardGridTableLayout.tsx
@@ -1,0 +1,144 @@
+import * as React from 'react';
+import * as classNames from 'classnames';
+
+import { ITableLayoutProps } from './Table';
+import { ITableRowLayoutProps } from './TableRow';
+import { ITableCellLayoutProps } from './TableCell';
+
+import './standardGridTableLayout.less';
+
+export interface ITableColumnSize {
+  size: number;
+  unit: 'fr' | '%' | 'px' | 'em' | 'rem' | 'vh' | 'vw' | 'vmin' | 'vmax';
+}
+
+export type ITableColumnSizes = Readonly<Array<number | ITableColumnSize | [ITableColumnSize, ITableColumnSize]>>;
+
+// If the table rows are expandable, we'll need a column on the right
+// for the expand/collapse indicators
+const EXPAND_COLLAPSE_COLUMN_SIZE = '48px';
+
+const GUTTER_SIZE_PX = 16;
+const INDENT_SIZE_PX = 20;
+
+const throwSizingError = (invalidSizing: any) => {
+  throw new Error(
+    `Invalid table sizing configuration.
+     Expected either a sizing object with 'size' and 'unit' fields or an array of two sizing objects.
+     Actual value was ${JSON.stringify(invalidSizing)}`,
+  );
+};
+
+export const getGridColumnsStyle = (sizes: ITableColumnSizes, expandable: boolean, isMobile: boolean) => {
+  if (isMobile) {
+    return undefined;
+  }
+
+  const gridColumns = sizes.map(sizing => {
+    if (typeof sizing === 'number') {
+      return `${sizing}fr`;
+    } else if (Array.isArray(sizing) && sizing.length === 2) {
+      const [min, max] = sizing;
+      return `minmax(${min.size + min.unit}, ${max.size + max.unit})`;
+    } else if (!Array.isArray(sizing) && sizing.size && sizing.unit) {
+      return `${sizing.size}${sizing.unit}`;
+    } else {
+      return throwSizingError(sizing);
+    }
+  });
+
+  if (expandable) {
+    gridColumns.push(EXPAND_COLLAPSE_COLUMN_SIZE);
+  }
+
+  return gridColumns.join(' ');
+};
+
+const TableLayout = ({
+  columns,
+  expandable,
+  expandAll,
+  isMobile,
+  children,
+  sizes,
+}: ITableLayoutProps & { sizes: ITableColumnSizes }) => {
+  const gridTemplateColumns = getGridColumnsStyle(sizes, expandable, isMobile);
+
+  return (
+    <div className="StandardGridTableLayout">
+      {!isMobile && (
+        <div className="standard-grid-table-header" style={{ gridTemplateColumns }}>
+          {columns.map(({ name, sortDirection, onSort }) => (
+            <div
+              key={name}
+              className={classNames('standard-grid-table-cell', { sortable: !!onSort })}
+              onClick={onSort || null}
+            >
+              {name}
+              {sortDirection ? <span className={classNames('sort-indicator', sortDirection)} /> : null}
+            </div>
+          ))}
+          {expandable && (
+            <div className="standard-grid-table-cell header-expand-toggle" onClick={expandAll}>
+              <i className="ico icon-arrow-toggle-all" />
+            </div>
+          )}
+        </div>
+      )}
+      {children}
+    </div>
+  );
+};
+
+const TableRowLayout = ({
+  tableExpandable,
+  rowExpandable,
+  expanded,
+  setExpanded,
+  isMobile,
+  sizes,
+  children,
+  renderExpandedContent,
+}: ITableRowLayoutProps & { sizes: ITableColumnSizes }) => {
+  const gridTemplateColumns = getGridColumnsStyle(sizes, tableExpandable, isMobile);
+
+  return (
+    <>
+      <div
+        className={classNames('standard-grid-table-row', { expandable: rowExpandable, expanded })}
+        style={{ gridTemplateColumns }}
+        onClick={rowExpandable ? () => setExpanded(!expanded) : null}
+      >
+        {children}
+        {tableExpandable && !isMobile && (
+          <div className="standard-grid-table-cell row-expand-toggle">
+            {rowExpandable && (
+              <i
+                className={classNames('ico', { 'icon-arrow-collapsed': !expanded, 'icon-arrow-expanded': expanded })}
+              />
+            )}
+          </div>
+        )}
+      </div>
+      {rowExpandable && expanded && <div className="expanded-row-content">{renderExpandedContent()}</div>}
+    </>
+  );
+};
+
+const TableCellLayout = ({ children, indent, index, columns, isMobile }: ITableCellLayoutProps) => {
+  const columnName = columns[index].name;
+  const indentPx = !!indent && isMobile ? `${GUTTER_SIZE_PX + indent * INDENT_SIZE_PX}px` : undefined;
+
+  return (
+    <div className="standard-grid-table-cell" style={{ paddingLeft: indentPx }}>
+      {isMobile && <div className="mobile-cell-header">{columnName}</div>}
+      <div className="cell-content">{children}</div>
+    </div>
+  );
+};
+
+export const standardGridTableLayout = (sizes: ITableColumnSizes) => ({
+  TableLayout: (props: ITableLayoutProps) => <TableLayout {...props} sizes={sizes} />,
+  TableRowLayout: (props: ITableRowLayoutProps) => <TableRowLayout {...props} sizes={sizes} />,
+  TableCellLayout: (props: ITableCellLayoutProps) => <TableCellLayout {...props} />,
+});


### PR DESCRIPTION
Don't merge, depends on #7899 and #7901. CI will likely fail until those are merged.

This is another chapter of adding some re-usable components to match @gcomstock's new design work, in support of a Managed Delivery view. My goal was to provide a high-level component API for creating tables which — similar to previous work on form fields — could serve as a generic scaffold with pluggable points for different kinds of table layouts. I'm starting with two (very different) layout implementations because that's what my current work calls for, but the idea is that adding or iterating on layouts themselves should be pretty isolated from actual usage (vs. requiring refactors of all consuming code).

To start, here's some example screenshots of the end result:

<details>
<summary>"Mobile" display size</summary>
<img width="755" alt="Screen Shot 2020-02-14 at 7 56 50 PM" src="https://user-images.githubusercontent.com/1850998/74608023-a3b1b080-5092-11ea-9a0e-4fe4794c8900.png">
</details>

<details>
<summary>Larger width display size</summary>
<img width="1520" alt="Screen Shot 2020-02-14 at 7 56 43 PM" src="https://user-images.githubusercontent.com/1850998/74608229-49b1ea80-5094-11ea-9197-ff55d1376197.png">
</details>

As shown, I've started with two layout examples: one is a 'minimal' visual style that leverages native tables to get an auto-arranged layout without much fuss or complexity. The other is what I'm calling a 'standard' visual style (this is the style we're expecting will be most commonly used) laid out using CSS grids, with some fancy features added in (expanding rows, responsive + mobile layout, sorting, etc.). Both these layouts plug into the same layout contract used by some higher level components: `Table`, `TableRow`, and `TableCell`.

The responsibilities of those externally-facing components are primarily:
- Give a common, consistent component structure and API to all tables regardless of layout
- Handle frequently used, often stateful table patterns like row expandability or row indenting that consumers and individual layouts can leverage
- Do runtime validation for things like required/dependent prop combinations so layouts can focus on their own needs (and any layout-specific validation)

For a simple example, here's what the `minimalNativeTableLayout` looks like in use:
<details>
<summary>Minimal layout</summary>

```jsx
<Table layout={minimalNativeTableLayout} columns={['configuration', 'change', 'current', 'desired']}>
  <TableRow>
    // indent is useful for tables where rows have hierarchical relationships
    <TableCell indent={2}>
      <SingleLineString>keeldemo</SingleLineString>
    </TableCell>
    <TableCell>
      <SingleLineString className="text-italic">removed</SingleLineString>
    </TableCell>
    <TableCell>
      <BreakString>keeldemo</BreakString>
    </TableCell>
    <TableCell>
      <BreakString>null</BreakString>
    </TableCell>
  </TableRow>
</Table>
```

</details>

And as a more involved example, here's what it looks like to use a `standardGridTableLayout` with sorting and expandable rows:
<details>
<summary>Standard layout</summary>

```jsx
// First we setup some state for sorting and create column definitions.
// While the simple example used an array of strings for the column names,
// this one shows how column definitions can add additional behavior.
const [sortColumn, setSortColumn] = React.useState('When');
const [sortDirection, setSortDirection] = React.useState<'ascending' | 'descending'>('descending');
const mainTableColumns = React.useMemo(
  () =>
    ['Where', 'What', 'When'].map(name => ({
      name,
      // works like a controlled input — add a `sortDirection` to indicate a sort,
      // react to changes via `onSort` 
      sortDirection: name === sortColumn ? sortDirection : undefined,
      onSort: () => {
        const newDirection = sortDirection === 'ascending' ? 'descending' : 'ascending';
        console.log(`sorting ${name} column to direction: ${newDirection}`);

        setSortColumn(name);
        setSortDirection(newDirection);
      },
    })),
  [sortColumn, sortDirection],
);

// This layout accepts some of its own configuration parameters
// to control how large each column is relative to the others (among some other options)
<Table layout={standardGridTableLayout([4, 2, 2.6])} columns={mainTableColumns} expandable={true}>
  <TableRow
    // Works like an uncontrolled input — if `defaultExpanded` is set
    // that will be the initial expanded state after mount until a user interacts with it.
    defaultExpanded={true}
    renderExpandedContent={() => (
      // Render whatever you want,
      // in the example case we stick a minimal native table here
    )}
  >
    <TableCell>TEST > keeldemo-prestaging</TableCell>
    <TableCell>
      Drift Detected
    </TableCell>
    <TableCell>
      2018-10-17 15:51:00 PDT 30 minutes ago
    </TableCell>
  </TableRow>
</Table>
```

</details>

While the diff is a little larger, each commit is pretty tightly scoped and I recommend going one-by-one. Because this is still in the process of getting its first real usage, I'm deferring investing more time in documenting the available configuration options for the Table components and specific layouts until this PR is reviewed/iterated and the API settles slightly more. If you have feedback about API design or overall approach, now is the time!