### PR TITLE
fix(core/account): AccountSelectInput pass 'name' in synthetic event

### DIFF
--- a/app/scripts/modules/core/src/account/AccountSelectInput.tsx
+++ b/app/scripts/modules/core/src/account/AccountSelectInput.tsx
@@ -95,7 +95,7 @@ export class AccountSelectInput extends React.Component<IAccountSelectInputProps
   }
 
   private SimpleSelect = () => {
-    const { value, onChange, ...otherProps } = this.props;
+    const { name, value, onChange, ...otherProps } = this.props;
     delete otherProps.renderFilterableSelectThreshold; // not for DOM consumption
     const { primaryAccounts, secondaryAccounts } = this.state;
     const showSeparator = primaryAccounts.length > 0 && secondaryAccounts.length > 0;
@@ -103,7 +103,7 @@ export class AccountSelectInput extends React.Component<IAccountSelectInputProps
     // re-rendered the input, setting its value (the event.target.value) back to the previous value
     // This can go away once we're out of Angular land.
     const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-      onChange(createFakeReactSyntheticEvent({ value: e.target.value }));
+      onChange(createFakeReactSyntheticEvent({ value: e.target.value, name }));
     };
     return (
       <div>
@@ -135,7 +135,7 @@ export class AccountSelectInput extends React.Component<IAccountSelectInputProps
   };
 
   private FilterableSelect = () => {
-    const { value, onChange, ...otherProps } = this.props;
+    const { name, value, onChange, ...otherProps } = this.props;
     delete otherProps.renderFilterableSelectThreshold; // not for DOM consumption
     const { primaryAccounts, secondaryAccounts } = this.state;
     const showSeparator = primaryAccounts.length > 0 && secondaryAccounts.length > 0;
@@ -150,7 +150,7 @@ export class AccountSelectInput extends React.Component<IAccountSelectInputProps
         options={options}
         clearable={false}
         value={value}
-        onChange={(option: Option<string>) => onChange(createFakeReactSyntheticEvent({ value: option.value }))}
+        onChange={(option: Option<string>) => onChange(createFakeReactSyntheticEvent({ value: option.value, name }))}
         required={true}
         {...otherProps}
       />


### PR DESCRIPTION
```
Warning: Formik called `handleChange`, but you forgot to pass an `id` or `name` attribute to your input:

    undefined

    Formik cannot determine which value to update. For more info see https://github.com/jaredpalmer/formik#handlechange-e-reactchangeeventany--void
```