### PR TITLE
feat(codebuild): Add support for multiple sources

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/awsCodeBuild/AwsCodeBuildSourceList.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/awsCodeBuild/AwsCodeBuildSourceList.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { Subject } from 'rxjs';
+import classNames from 'classnames';
+
+import { EditAwsCodeBuildSourceModal } from './EditAwsCodeBuildSourceModal';
+import { IAwsCodeBuildSource } from './IAwsCodeBuildSource';
+import { IPipeline, IStage } from 'core/domain';
+import { ArtifactIcon } from 'core/artifact';
+
+export interface IAwsCodeBuildSourceListProps {
+  stage: IStage;
+  pipeline: IPipeline;
+  sources: IAwsCodeBuildSource[];
+  updateSources: (notifications: IAwsCodeBuildSource[]) => void;
+}
+
+export class AwsCodeBuildSourceList extends React.Component<IAwsCodeBuildSourceListProps> {
+  private destroy$ = new Subject();
+
+  constructor(props: IAwsCodeBuildSourceListProps) {
+    super(props);
+  }
+
+  public componentWillUnmount() {
+    this.destroy$.next();
+  }
+
+  private addSource = () => {
+    this.editSource();
+  };
+
+  private editSource = (source?: IAwsCodeBuildSource, index?: number) => {
+    const { sources, updateSources, stage, pipeline } = this.props;
+    EditAwsCodeBuildSourceModal.show({
+      source: source || {},
+      stage,
+      pipeline,
+    })
+      .then(newSource => {
+        const sourceCopy = sources || [];
+        if (!source) {
+          updateSources(sourceCopy.concat(newSource));
+        } else {
+          const update = [...sourceCopy];
+          update[index] = newSource;
+          updateSources(update);
+        }
+      })
+      .catch(() => {});
+  };
+
+  private removeSource = (index: number) => {
+    const sources = [...this.props.sources];
+    sources.splice(index, 1);
+    this.props.updateSources(sources);
+  };
+
+  public render() {
+    const { sources } = this.props;
+    return (
+      <div className="row">
+        <div className={'col-md-12'}>
+          <table className="table table-condensed">
+            <thead>
+              <tr>
+                <th>Artifact</th>
+                <th>Type</th>
+                <th>Source Version</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sources &&
+                sources.map((source, i) => {
+                  return (
+                    <tr key={i} className={classNames({ 'templated-pipeline-item': false })}>
+                      <td>
+                        <ArtifactIcon type={source.sourceArtifact.artifactType} width="16" height="16" />
+                        {source.sourceArtifact.artifactDisplayName}
+                      </td>
+                      <td>{source.type}</td>
+                      <td>{source.sourceVersion}</td>
+                      <td>
+                        <button className="btn btn-xs btn-link" onClick={() => this.editSource(source, i)}>
+                          Edit
+                        </button>
+                        <button className="btn btn-xs btn-link" onClick={() => this.removeSource(i)}>
+                          Remove
+                        </button>
+                      </td>
+                    </tr>
+                  );
+                })}
+            </tbody>
+            <tfoot>
+              <tr>
+                <td colSpan={7}>
+                  <button className="btn btn-block add-new" onClick={() => this.addSource()}>
+                    <span className="glyphicon glyphicon-plus-sign" /> Add Secondary Source
+                  </button>
+                </td>
+              </tr>
+            </tfoot>
+          </table>
+        </div>
+      </div>
+    );
+  }
+}

--- a/app/scripts/modules/core/src/pipeline/config/stages/awsCodeBuild/AwsCodeBuildStageForm.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/awsCodeBuild/AwsCodeBuildStageForm.tsx
@@ -33,22 +33,8 @@ export function AwsCodeBuildStageForm(props: IAwsCodeBuildStageFormProps & IForm
     [],
   );
 
-  const onYamlChange = (buildspec: string, _: any): void => {
-    props.formik.setFieldValue('source.buildspec', buildspec);
-  };
-
-  const setArtifactId = (artifactId: string): void => {
-    props.formik.setFieldValue('source.sourceArtifact.artifactId', artifactId);
-    props.formik.setFieldValue('source.sourceArtifact.artifact', null);
-  };
-
-  const setArtifact = (artifact: IArtifact): void => {
-    props.formik.setFieldValue('source.sourceArtifact.artifact', artifact);
-    props.formik.setFieldValue('source.sourceArtifact.artifactId', null);
-  };
-
-  const updateSources = (sources: IAwsCodeBuildSource[]): void => {
-    props.formik.setFieldValue('secondarySources', sources);
+  const onFieldChange = (fieldName: string, fieldValue: any): void => {
+    props.formik.setFieldValue(fieldName, fieldValue);
   };
 
   return (
@@ -104,8 +90,14 @@ export function AwsCodeBuildStageForm(props: IAwsCodeBuildStageFormProps & IForm
               artifact={get(stage, 'source.sourceArtifact.artifact')}
               excludedArtifactTypePatterns={EXCLUDED_ARTIFACT_TYPES}
               expectedArtifactId={get(stage, 'source.sourceArtifact.artifactId')}
-              onArtifactEdited={setArtifact}
-              onExpectedArtifactSelected={(artifact: IExpectedArtifact) => setArtifactId(artifact.id)}
+              onArtifactEdited={(artifact: IArtifact) => {
+                onFieldChange('source.sourceArtifact.artifact', artifact);
+                onFieldChange('source.sourceArtifact.artifactId', null);
+              }}
+              onExpectedArtifactSelected={(artifact: IExpectedArtifact) => {
+                onFieldChange('source.sourceArtifact.artifact', null);
+                onFieldChange('source.sourceArtifact.artifactId', artifact.id);
+              }}
               pipeline={props.pipeline}
               stage={stage}
             />
@@ -123,7 +115,11 @@ export function AwsCodeBuildStageForm(props: IAwsCodeBuildStageFormProps & IForm
         label="Buildspec"
         name="source.buildspec"
         input={(inputProps: IFormInputProps) => (
-          <YamlEditor {...inputProps} value={get(stage, 'source.buildspec')} onChange={onYamlChange} />
+          <YamlEditor
+            {...inputProps}
+            value={get(stage, 'source.buildspec')}
+            onChange={(buildspec: string, _: any) => onFieldChange('source.buildspec', buildspec)}
+          />
         )}
       />
       <FormikFormField
@@ -134,7 +130,7 @@ export function AwsCodeBuildStageForm(props: IAwsCodeBuildStageFormProps & IForm
           <AwsCodeBuildSourceList
             {...inputProps}
             sources={get(stage, 'secondarySources')}
-            updateSources={updateSources}
+            updateSources={(sources: IAwsCodeBuildSource[]) => onFieldChange('secondarySources', sources)}
             stage={stage}
             pipeline={props.pipeline}
           />

--- a/app/scripts/modules/core/src/pipeline/config/stages/awsCodeBuild/EditAwsCodeBuildSourceModal.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/awsCodeBuild/EditAwsCodeBuildSourceModal.tsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import { get } from 'lodash';
+
+import { Formik, FormikProps, Form } from 'formik';
+import { Modal } from 'react-bootstrap';
+import {
+  FormikFormField,
+  FormValidator,
+  IArtifact,
+  IExpectedArtifact,
+  IFormInputProps,
+  IPipeline,
+  IStage,
+  IModalComponentProps,
+  ReactModal,
+  ReactSelectInput,
+  SpinFormik,
+  StageArtifactSelector,
+  TextInput,
+} from 'core';
+import { SubmitButton, ModalClose } from 'core/modal';
+import { EXCLUDED_ARTIFACT_TYPES, IAwsCodeBuildSource, SOURCE_TYPES } from './IAwsCodeBuildSource';
+
+export interface IEditAwsCodeBuildSourceModalProps extends IModalComponentProps {
+  source: IAwsCodeBuildSource;
+  stage: IStage;
+  pipeline: IPipeline;
+}
+
+export class EditAwsCodeBuildSourceModal extends React.Component<IEditAwsCodeBuildSourceModalProps> {
+  private formikRef = React.createRef<Formik<any>>();
+
+  private submit = (values: IAwsCodeBuildSource): void => {
+    this.props.closeModal(values);
+  };
+
+  public static show(props: any): Promise<IAwsCodeBuildSource> {
+    const modalProps = { dialogClassName: 'modal-md' };
+    return ReactModal.show(EditAwsCodeBuildSourceModal, props, modalProps);
+  }
+
+  private onExpectedArtifactSelected = (
+    formik: FormikProps<IAwsCodeBuildSource>,
+    artifact: IExpectedArtifact,
+  ): void => {
+    formik.setFieldValue('sourceArtifact.artifactId', artifact.id);
+    formik.setFieldValue('sourceArtifact.artifactDisplayName', artifact.displayName);
+    formik.setFieldValue(
+      'sourceArtifact.artifactType',
+      (artifact.matchArtifact && artifact.matchArtifact.type) ||
+        (artifact.defaultArtifact && artifact.defaultArtifact.type),
+    );
+    formik.setFieldValue('sourceArtifact.artifact', null);
+  };
+
+  private onArtifactEdited = (formik: FormikProps<IAwsCodeBuildSource>, artifact: IArtifact): void => {
+    formik.setFieldValue('sourceArtifact.artifact', artifact);
+    formik.setFieldValue('sourceArtifact.artifactDisplayName', artifact.reference);
+    formik.setFieldValue('sourceArtifact.artifactType', artifact.type);
+    formik.setFieldValue('sourceArtifact.artifactId', null);
+  };
+
+  private validate = (values: IAwsCodeBuildSource): any => {
+    const formValidator = new FormValidator(values);
+    formValidator
+      .field('sourceArtifact', 'Source Artifact') // display name should exist no matter if it's artifact or id
+      .required()
+      .withValidators((value: any[]) => !value && 'Artifact is required');
+    return formValidator.validateForm();
+  };
+
+  public render(): React.ReactElement<EditAwsCodeBuildSourceModal> {
+    const { dismissModal, source, stage, pipeline } = this.props;
+    return (
+      <SpinFormik<IAwsCodeBuildSource>
+        ref={this.formikRef}
+        initialValues={source}
+        onSubmit={this.submit}
+        validate={this.validate}
+        render={formik => (
+          <Form className={`form-horizontal`}>
+            <ModalClose dismiss={dismissModal} />
+            <Modal.Header>
+              <Modal.Title>Edit Source</Modal.Title>
+            </Modal.Header>
+            <Modal.Body>
+              <div className="form-group">
+                <div className="col-md-3 sm-label-right">Source Artifact</div>
+                <div className="col-md-9 sm-control-field">
+                  <StageArtifactSelector
+                    artifact={get(formik, 'values.sourceArtifact.artifact')}
+                    excludedArtifactTypePatterns={EXCLUDED_ARTIFACT_TYPES}
+                    expectedArtifactId={get(formik, 'values.sourceArtifact.artifactId')}
+                    onArtifactEdited={(artifact: IArtifact) => this.onArtifactEdited(formik, artifact)}
+                    onExpectedArtifactSelected={(artifact: IExpectedArtifact) =>
+                      this.onExpectedArtifactSelected(formik, artifact)
+                    }
+                    pipeline={pipeline}
+                    stage={stage}
+                  />
+                </div>
+              </div>
+              <FormikFormField
+                fastField={false}
+                label="Source Type"
+                name="type"
+                input={(inputProps: IFormInputProps) => (
+                  <ReactSelectInput {...inputProps} clearable={true} stringOptions={SOURCE_TYPES} />
+                )}
+              />
+              <FormikFormField
+                fastField={false}
+                label="Source Version"
+                name="sourceVersion"
+                input={(inputProps: IFormInputProps) => <TextInput {...inputProps} />}
+              />
+            </Modal.Body>
+            <Modal.Footer>
+              <button className="btn btn-default" onClick={dismissModal} type="button">
+                Cancel
+              </button>
+              <SubmitButton isDisabled={!formik.isValid} isFormSubmit={true} submitting={false} label={'Update'} />
+            </Modal.Footer>
+          </Form>
+        )}
+      />
+    );
+  }
+}

--- a/app/scripts/modules/core/src/pipeline/config/stages/awsCodeBuild/IAwsCodeBuildSource.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/awsCodeBuild/IAwsCodeBuildSource.tsx
@@ -1,0 +1,21 @@
+import { ArtifactTypePatterns, excludeAllTypesExcept, IArtifact } from 'core';
+
+export interface IAwsCodeBuildSource {
+  type?: string;
+  sourceArtifact: IAwsCodeBuildSourceArtifact;
+  sourceVersion?: string;
+}
+
+interface IAwsCodeBuildSourceArtifact {
+  artifactId?: string;
+  artifactDisplayName?: string;
+  artifactType?: string;
+  artifact?: IArtifact;
+}
+
+export const SOURCE_TYPES: string[] = ['BITBUCKET', 'CODECOMMIT', 'GITHUB', 'GITHUB_ENTERPRISE', 'S3'];
+
+export const EXCLUDED_ARTIFACT_TYPES: RegExp[] = excludeAllTypesExcept(
+  ArtifactTypePatterns.S3_OBJECT,
+  ArtifactTypePatterns.GIT_REPO,
+);


### PR DESCRIPTION
Refactor the stage definition so that all source related fields go into one single structure.
This is helpful when it comes to multiple sources because of the reusability that the single
structure provides. For primary source, artifact is not required. Users can override source
version without touching source artifact. However, in secondary sources, users must specify
an artifact. Otherwise, there's no way to link a secondary source version to a secondary source
defined in the project configuration.

![Screen Shot 2020-02-18 at 2 28 00 PM](https://user-images.githubusercontent.com/37637696/74783662-ff2e9a80-525a-11ea-81d2-0f2f275211df.png)

![Screen Shot 2020-02-18 at 2 28 35 PM](https://user-images.githubusercontent.com/37637696/74783668-02298b00-525b-11ea-88e3-d3251602ab50.png)
