### PR TITLE
fix(titus): Fix resetting region when updated account is not in region

### DIFF
--- a/app/scripts/modules/titus/src/serverGroup/configure/serverGroupConfiguration.service.ts
+++ b/app/scripts/modules/titus/src/serverGroup/configure/serverGroupConfiguration.service.ts
@@ -220,7 +220,7 @@ export class TitusServerGroupConfigurationService {
 
   private configureSecurityGroupOptions(command: ITitusServerGroupCommand): void {
     const currentOptions = command.backingData.filtered.securityGroups;
-    if (command.credentials.includes('${') || command.region.includes('${')) {
+    if (command.credentials.includes('${') || (command.region && command.region.includes('${'))) {
       // If any of our dependencies are expressions, the only thing we can do is preserve current values
       command.backingData.filtered.securityGroups = command.securityGroups.map(group => ({ name: group, id: group }));
     } else {
@@ -309,7 +309,7 @@ export class TitusServerGroupConfigurationService {
 
   public configureLoadBalancerOptions(command: ITitusServerGroupCommand) {
     const currentTargetGroups = command.targetGroups || [];
-    if (command.credentials.includes('${') || command.region.includes('${')) {
+    if (command.credentials.includes('${') || (command.region && command.region.includes('${'))) {
       // If any of our dependencies are expressions, the only thing we can do is preserve current values
       command.targetGroups = currentTargetGroups;
       (command.backingData.filtered as any).targetGroups = currentTargetGroups;


### PR DESCRIPTION
This case never worked correctly for Titus because we would set `command.region = null` then try to do `command.region.includes('${')` which would always blow up.

Protecting it against null allows it to actually reset the region when the new account is not in that region.