### PR TITLE
fix(pipeline): Not 'Use default' should be empty string

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/pipeline/pipelineStage.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/pipeline/pipelineStage.js
@@ -155,7 +155,7 @@ module(CORE_PIPELINE_CONFIG_STAGES_PIPELINE_PIPELINESTAGE, [])
           delete $scope.userSuppliedParameters[parameter];
           delete $scope.stage.pipelineParameters[parameter];
         } else if ($scope.userSuppliedParameters[parameter]) {
-          $scope.stage.pipelineParameters[parameter] = $scope.userSuppliedParameters[parameter];
+          $scope.stage.pipelineParameters[parameter] = $scope.userSuppliedParameters[parameter] || '';
         }
       };
 


### PR DESCRIPTION
The stage config for a pipeline stage starts off with all parameters having `Use default` checked.

In addition to this, we also render the default parameter value (if any) in a disabled text box.

When unchecking `Use default`, we clear out the text box, making the user think that this is now set to something (say an empty string).

Regardless of what the user thinks happened, the fact we cleared out the default value would communicate that when the stage executes, the child pipeline will NOT be executed with the default value.

This is not the case because we did not default to an empty string and we do not set a value for that parameter until something is typed into the text box.

This change makes it so that as soon as `Use default` is unchecked, the parameter is set to an empty string.