### PR TITLE
feat(codebuild): List project names

### DIFF
--- a/app/scripts/modules/core/src/ci/igor.service.ts
+++ b/app/scripts/modules/core/src/ci/igor.service.ts
@@ -76,4 +76,11 @@ export class IgorService {
       .one('accounts')
       .get();
   }
+
+  public static getCodeBuildProjects(account: string): IPromise<string[]> {
+    return API.one('codebuild')
+      .one('projects')
+      .one(account)
+      .get();
+  }
 }

--- a/app/scripts/modules/core/src/pipeline/config/stages/awsCodeBuild/AwsCodeBuildStageForm.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/awsCodeBuild/AwsCodeBuildStageForm.tsx
@@ -33,6 +33,12 @@ export function AwsCodeBuildStageForm(props: IAwsCodeBuildStageFormProps & IForm
     [],
   );
 
+  const { result: fetchProjectsResult, status: fetchProjectsStatus } = useData(
+    () => IgorService.getCodeBuildProjects(stage.account),
+    [],
+    [stage.account],
+  );
+
   const onFieldChange = (fieldName: string, fieldValue: any): void => {
     props.formik.setFieldValue(fieldName, fieldValue);
   };
@@ -53,12 +59,18 @@ export function AwsCodeBuildStageForm(props: IAwsCodeBuildStageFormProps & IForm
           />
         )}
       />
-      {/* TODO: Select project from a drop-down list. Behind the scene, gate calls igor to fetch projects list */}
       <FormikFormField
         fastField={false}
         label="Project Name"
         name="projectName"
-        input={(inputProps: IFormInputProps) => <TextInput {...inputProps} />}
+        input={(inputProps: IFormInputProps) => (
+          <ReactSelectInput
+            {...inputProps}
+            clearable={false}
+            isLoading={fetchProjectsStatus === 'PENDING'}
+            stringOptions={fetchProjectsResult}
+          />
+        )}
       />
       <h4>Source Configuration</h4>
       <FormikFormField
@@ -69,7 +81,7 @@ export function AwsCodeBuildStageForm(props: IAwsCodeBuildStageFormProps & IForm
           <CheckboxInput {...inputProps} text="Override source to Spinnaker artifact" />
         )}
       />
-      {stage.source.sourceOverride === true && (
+      {get(stage, 'source.sourceOverride') === true && (
         <FormikFormField
           fastField={false}
           label="SourceType"
@@ -79,7 +91,7 @@ export function AwsCodeBuildStageForm(props: IAwsCodeBuildStageFormProps & IForm
           )}
         />
       )}
-      {stage.source.sourceOverride === true && (
+      {get(stage, 'source.sourceOverride') === true && (
         <FormikFormField
           fastField={false}
           label="Source Artifact Override"


### PR DESCRIPTION
Change text input field to select input field for project name
so that user could select project name from a dropdown list
instead of manually type in the name.

Fix a null pointer issue when creating a new CodeBuild stage.

![Screen Shot 2020-02-20 at 2 05 44 PM](https://user-images.githubusercontent.com/37637696/74983034-1cde3a00-53ea-11ea-9261-1c0176e851ca.png)
