### PR TITLE
fix(core): Letting angular know when the promises resolve

### DIFF
--- a/app/scripts/modules/core/src/plugins/plugin.module.ts
+++ b/app/scripts/modules/core/src/plugins/plugin.module.ts
@@ -1,4 +1,4 @@
-import { module } from 'angular';
+import { module, IRootScopeService } from 'angular';
 import { UIRouter } from '@uirouter/core';
 import { PluginRegistry } from './plugin.registry';
 import { sharedLibraries } from './sharedLibraries';
@@ -14,8 +14,9 @@ module(PLUGINS_MODULE, ['ui.router'])
     },
   ])
   .run([
+    '$rootScope',
     '$uiRouter',
-    async ($uiRouter: UIRouter) => {
+    async ($rootScope: IRootScopeService, $uiRouter: UIRouter) => {
       // TODO: find a better home for this registry
       const pluginRegistry = new PluginRegistry();
       try {
@@ -24,8 +25,10 @@ module(PLUGINS_MODULE, ['ui.router'])
         await pluginRegistry.loadPlugins();
       } finally {
         // When done, tell the router to initialize
-        $uiRouter.urlService.listen();
-        $uiRouter.urlService.sync();
+        $rootScope.$applyAsync(() => {
+          $uiRouter.urlService.listen();
+          $uiRouter.urlService.sync();
+        });
       }
     },
   ]);


### PR DESCRIPTION
Otherwise deck will not go to the default route until the next digest cycle (kicked by the version checker).