### PR TITLE
feat(core/presentation): add useDeepObjectDiff hook for easier memoization of objects

### DIFF
--- a/app/scripts/modules/core/src/presentation/hooks/index.ts
+++ b/app/scripts/modules/core/src/presentation/hooks/index.ts
@@ -1,6 +1,7 @@
 export * from './useContainerClassNames.hook';
 export * from './useData.hook';
 export * from './useDebouncedValue.hook';
+export * from './useDeepObjectDiff.hook';
 export * from './useEventListener.hook';
 export * from './useForceUpdate.hook';
 export * from './useIsMobile.hook';

--- a/app/scripts/modules/core/src/presentation/hooks/useDeepObjectDiff.hook.spec.tsx
+++ b/app/scripts/modules/core/src/presentation/hooks/useDeepObjectDiff.hook.spec.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { useDeepObjectDiff } from './useDeepObjectDiff.hook';
+
+const { useEffect } = React;
+
+describe('useDeepObjectDiff', () => {
+  it('changes its return value when the object has changed between renders', () => {
+    const spy = jasmine.createSpy('useEffect callback');
+    function TestComponent(props: any) {
+      useEffect(spy, [useDeepObjectDiff(props)]);
+      return null as JSX.Element;
+    }
+
+    const wrapper = mount(<TestComponent prop={123} />);
+    wrapper.setProps({ prop: 123 });
+    wrapper.setProps({ prop: 123 });
+    wrapper.setProps({ prop: 123 });
+    wrapper.setProps({ prop: 123 });
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    wrapper.setProps({ prop: 456 });
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/app/scripts/modules/core/src/presentation/hooks/useDeepObjectDiff.hook.ts
+++ b/app/scripts/modules/core/src/presentation/hooks/useDeepObjectDiff.hook.ts
@@ -1,0 +1,15 @@
+import React from 'react';
+import { isEqual } from 'lodash';
+
+const { useRef } = React;
+
+export function useDeepObjectDiff(obj: object): number {
+  const ref = useRef(obj);
+  const version = useRef(1);
+  const deepEqual = obj === ref.current || isEqual(obj, ref.current);
+  ref.current = obj;
+  if (!deepEqual) {
+    version.current++;
+  }
+  return version.current;
+}


### PR DESCRIPTION
Useful when you want to do a deep equals on an object that's used as a dependency in a hook. Test has a small usage example.

Both the hook itself and the test are basically lifted right out of UI Router as a result of [this comment](https://github.com/spinnaker/deck/pull/7903#discussion_r380361946)