### PR TITLE
fix(core/pipeline): handle missing trigger fields in importDeliveryConfig stage

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/managed/ImportDeliveryConfigExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/managed/ImportDeliveryConfigExecutionDetails.tsx
@@ -4,6 +4,8 @@ import { ExecutionDetailsSection, IExecutionDetailsSectionProps, StageFailureMes
 import { IGitTrigger } from 'core/domain';
 import { SETTINGS } from 'core/config';
 
+const NOT_FOUND = 'Not found';
+
 export function ImportDeliveryConfigExecutionDetails(props: IExecutionDetailsSectionProps) {
   const { stage } = props;
   const trigger = props.execution.trigger as IGitTrigger;
@@ -18,17 +20,17 @@ export function ImportDeliveryConfigExecutionDetails(props: IExecutionDetailsSec
         <div className="col-md-12">
           <dl className="dl-narrow dl-horizontal">
             <dt>SCM</dt>
-            <dd>{trigger.source}</dd>
+            <dd>{trigger.source ?? NOT_FOUND}</dd>
             <dt>Project</dt>
-            <dd>{trigger.project}</dd>
+            <dd>{trigger.project ?? NOT_FOUND}</dd>
             <dt>Repository</dt>
-            <dd>{trigger.slug}</dd>
+            <dd>{trigger.slug ?? NOT_FOUND}</dd>
             <dt>Manifest Path</dt>
-            <dd>{manifestPath}</dd>
+            <dd>{manifestPath ?? NOT_FOUND}</dd>
             <dt>Branch</dt>
-            <dd>{trigger.branch}</dd>
+            <dd>{trigger.branch ?? NOT_FOUND}</dd>
             <dt>Commit</dt>
-            <dd>{trigger.hash.substring(0, 7)}</dd>
+            <dd>{trigger.hash?.substring(0, 7) ?? NOT_FOUND}</dd>
           </dl>
         </div>
       </div>


### PR DESCRIPTION
Currently when there's an issue with the trigger used for the `importDeliveryConfig` stage and some fields are missing, we throw trying to call `substring()` on the `hash` field and the entire executions view goes blank (along with permanently busting the entire UI until a full page reload).

This change uses a `Not found` fallback for all the trigger-related fields we surface, so things render and the page continues to work. Looks like this:

<img width="951" alt="Screen Shot 2020-02-21 at 1 21 00 PM" src="https://user-images.githubusercontent.com/1850998/75080088-d0652e00-54bf-11ea-8c51-25b18dad5f02.png">
