### PR TITLE
fix(core/modal): display: flex on body, remove outline on close button

### DIFF
--- a/app/scripts/modules/core/src/presentation/modal/ModalBody.module.css
+++ b/app/scripts/modules/core/src/presentation/modal/ModalBody.module.css
@@ -4,6 +4,7 @@
 @value bodyColor: smoke;
 
 .body {
+  display: flex;
   flex: 1 1 auto;
   overflow: scroll;
   overscroll-behavior: contain;

--- a/app/scripts/modules/core/src/presentation/modal/ModalHeader.module.css
+++ b/app/scripts/modules/core/src/presentation/modal/ModalHeader.module.css
@@ -46,6 +46,7 @@
 .close:hover,
 .close:focus {
   background-color: closeButtonHoverColor;
+  outline: none;
 }
 
 @media belowMobileSize {


### PR DESCRIPTION
Couple small tweaks to the existing `Modal` component family:

- I'm adding `display: flex` to the actual content container for modals (what your view code ends up in). It's been a huge pain trying to get child containers to fill vertical space appropriately (among other frustrations), and making the body a flex container makes things much less gross. I expect at some point some thing we try to put inside here will go against that trend, but we can always adjust later
- The browser-default focus outline on the close button was getting cut off and mangled in weird ways and generally looked strange when you clicked the button. I'm removing it entirely for now, though it might be nice to add a real focus outline of our own