### PR TITLE
feat(core/managed): add managed resource history modal

### DIFF
--- a/app/scripts/modules/core/src/domain/IManagedEntity.ts
+++ b/app/scripts/modules/core/src/domain/IManagedEntity.ts
@@ -34,3 +34,56 @@ export interface IManagedResource {
   managedResourceSummary?: IManagedResourceSummary;
   isManaged?: boolean;
 }
+
+export enum ManagedResourceEventType {
+  ResourceCreated = 'ResourceCreated',
+  ResourceUpdated = 'ResourceUpdated',
+  ResourceDeleted = 'ResourceDeleted',
+  ResourceMissing = 'ResourceMissing',
+  ResourceValid = 'ResourceValid',
+  ResourceDeltaDetected = 'ResourceDeltaDetected',
+  ResourceDeltaResolved = 'ResourceDeltaResolved',
+  ResourceActuationLaunched = 'ResourceActuationLaunched',
+  ResourceCheckError = 'ResourceCheckError',
+  ResourceCheckUnresolvable = 'ResourceCheckUnresolvable',
+  ResourceActuationPaused = 'ResourceActuationPaused',
+  ResourceActuationResumed = 'ResourceActuationResumed',
+}
+
+export interface IManagedResourceDiff {
+  [fieldName: string]: {
+    key: string;
+    diffType: 'CHANGED' | 'ADDED' | 'REMOVED';
+    desired?: string;
+    actual?: string;
+    fields: IManagedResourceDiff;
+  };
+}
+
+export interface IManagedResourceEvent {
+  type: ManagedResourceEventType;
+  apiVersion: string;
+  kind: string;
+  id: string;
+  application: string;
+  timestamp: string;
+  plugin?: string;
+  tasks?: Array<{ id: string; name: string }>;
+  delta?: IManagedResourceDiff;
+  message?: string;
+  reason?: string;
+}
+
+export type IManagedResourceEventHistory = IManagedResourceEvent[];
+
+export type IManagedResourceEventHistoryResponse = Array<
+  Omit<IManagedResourceEvent, 'delta'> & {
+    delta?: {
+      [key: string]: {
+        state: 'CHANGED' | 'ADDED' | 'REMOVED';
+        desired: string;
+        current: string;
+      };
+    };
+  }
+>;

--- a/app/scripts/modules/core/src/managed/ManagedResourceDetailsIndicator.tsx
+++ b/app/scripts/modules/core/src/managed/ManagedResourceDetailsIndicator.tsx
@@ -3,15 +3,16 @@ import ReactGA from 'react-ga';
 import { Dropdown, MenuItem } from 'react-bootstrap';
 
 import { SETTINGS } from 'core/config/settings';
-import { HoverablePopover } from 'core/presentation';
-
-import { IManagedResourceSummary } from 'core/domain';
+import { HoverablePopover, Modal } from 'core/presentation';
+import { HelpField } from 'core/help';
 import { Application } from 'core/application';
+import { IManagedResourceSummary } from 'core/domain';
 import { ReactInjector } from 'core/reactShims';
 
-import './ManagedResourceDetailsIndicator.css';
 import { toggleResourcePause } from './toggleResourceManagement';
-import { HelpField } from 'core/help';
+import { ManagedResourceHistoryModal } from './ManagedResourceHistoryModal';
+
+import './ManagedResourceDetailsIndicator.css';
 
 export interface IManagedResourceDetailsIndicatorProps {
   resourceSummary: IManagedResourceSummary;
@@ -29,6 +30,8 @@ export const ManagedResourceDetailsIndicator = ({
   resourceSummary,
   application,
 }: IManagedResourceDetailsIndicatorProps) => {
+  const [showHistoryModal, setShowHistoryModal] = React.useState(false);
+
   if (!resourceSummary) {
     return null;
   }
@@ -99,7 +102,12 @@ export const ManagedResourceDetailsIndicator = ({
               </MenuItem>
             )}
             <li>
-              <a target="_blank" onClick={() => logClick('History', id)} href={`${SETTINGS.gateUrl}/history/${id}`}>
+              <a
+                onClick={() => {
+                  setShowHistoryModal(true);
+                  logClick('History', id);
+                }}
+              >
                 History
               </a>
             </li>
@@ -114,6 +122,9 @@ export const ManagedResourceDetailsIndicator = ({
             </li>
           </Dropdown.Menu>
         </Dropdown>
+        <Modal isOpen={showHistoryModal} onRequestClose={() => setShowHistoryModal(false)}>
+          <ManagedResourceHistoryModal resourceSummary={resourceSummary} />
+        </Modal>
       </div>
     </div>
   );

--- a/app/scripts/modules/core/src/managed/ManagedResourceDiffTable.tsx
+++ b/app/scripts/modules/core/src/managed/ManagedResourceDiffTable.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+
+import { Table, TableRow, TableCell, minimalNativeTableLayout, BreakString, SingleLineString } from 'core/presentation';
+import { IManagedResourceDiff } from 'core/domain';
+
+const { memo } = React;
+
+export interface IManagedResourceDiffTableProps {
+  diff: IManagedResourceDiff;
+}
+
+interface DiffRow {
+  key: string;
+  name: string;
+  depth: number;
+  isLeafNode: boolean;
+  type: 'CHANGED' | 'ADDED' | 'REMOVED';
+  actual?: string;
+  desired?: string;
+}
+
+const traverseDiffFields = (diff: IManagedResourceDiff, depth: number, rows: DiffRow[]) => {
+  Object.keys(diff)
+    .sort((a, b) => a.localeCompare(b))
+    .forEach(name => {
+      const { key, diffType, actual, desired, fields } = diff[name];
+      rows.push({
+        key,
+        name,
+        depth,
+        actual,
+        desired,
+        type: diffType,
+        isLeafNode: !fields,
+      });
+
+      if (fields) {
+        traverseDiffFields(fields, depth + 1, rows);
+      }
+    });
+
+  return rows;
+};
+
+const tableRowsFromDiff = (diff: IManagedResourceDiff): DiffRow[] => traverseDiffFields(diff, 0, []);
+
+export const ManagedResourceDiffTable = memo(({ diff }: IManagedResourceDiffTableProps) => {
+  const diffRows = tableRowsFromDiff(diff);
+
+  return (
+    <Table layout={minimalNativeTableLayout} columns={['configuration', 'change', 'actual', 'desired']}>
+      {diffRows.map(({ key, name, depth, isLeafNode, type, actual, desired }) => (
+        <TableRow key={key}>
+          <TableCell indent={depth}>
+            <SingleLineString>{name}</SingleLineString>
+          </TableCell>
+          <TableCell>
+            {isLeafNode && <SingleLineString className="text-italic">{type.toLowerCase()}</SingleLineString>}
+          </TableCell>
+          <TableCell>
+            <BreakString>{actual}</BreakString>
+          </TableCell>
+          <TableCell>
+            <BreakString>{desired}</BreakString>
+          </TableCell>
+        </TableRow>
+      ))}
+    </Table>
+  );
+});

--- a/app/scripts/modules/core/src/managed/ManagedResourceHistoryModal.less
+++ b/app/scripts/modules/core/src/managed/ManagedResourceHistoryModal.less
@@ -1,0 +1,34 @@
+.ManagedResourceHistoryModal {
+  width: 100%;
+
+  .event-type,
+  .event-type-icon {
+    color: var(--color-charcoal);
+  }
+
+  .event-type-icon {
+    font-size: 24px;
+  }
+
+  .where-column-arrow {
+    display: inline-block;
+    width: 4px;
+    height: 6px;
+    margin: 0 8px;
+    border-style: solid;
+    border-width: 4px 0 4px 6px;
+    border-color: transparent transparent transparent var(--color-nobel);
+  }
+
+  .event-warning-message {
+    color: var(--color-alert);
+  }
+
+  .event-error-message {
+    color: var(--color-danger);
+  }
+
+  .loading-error-message {
+    color: var(--color-danger);
+  }
+}

--- a/app/scripts/modules/core/src/managed/ManagedResourceHistoryModal.tsx
+++ b/app/scripts/modules/core/src/managed/ManagedResourceHistoryModal.tsx
@@ -1,0 +1,227 @@
+import React from 'react';
+import classNames from 'classnames';
+import { DateTime } from 'luxon';
+import { UISref } from '@uirouter/react';
+
+import {
+  ModalHeader,
+  ModalBody,
+  Table,
+  TableRow,
+  TableCell,
+  standardGridTableLayout,
+  useData,
+} from 'core/presentation';
+
+import { relativeTime, timestamp } from 'core/utils';
+import { IManagedResourceSummary, IManagedResourceDiff } from 'core/domain';
+import { AccountTag } from 'core/account';
+import { ManagedReader } from 'core/managed';
+import { Spinner } from 'core/widgets';
+
+import { ManagedResourceDiffTable } from './ManagedResourceDiffTable';
+
+import './ManagedResourceHistoryModal.less';
+
+export interface IManagedResourceHistoryModalProps {
+  resourceSummary: IManagedResourceSummary;
+}
+
+const { useMemo } = React;
+
+const viewConfigurationByEventType = {
+  ResourceCreated: {
+    displayName: 'Created',
+    iconClass: 'icon-md-created',
+    level: 'info',
+  },
+  ResourceUpdated: {
+    displayName: 'Config updated',
+    // Needs it's own icon
+    iconClass: 'icon-md-created',
+    level: 'info',
+  },
+  ResourceDeleted: {
+    displayName: 'Deleted',
+    // Needs it's own icon
+    iconClass: 'icon-md-missing-resource',
+    level: 'info',
+  },
+  ResourceMissing: {
+    displayName: 'Missing',
+    iconClass: 'icon-md-missing-resource',
+    level: 'info',
+  },
+  ResourceValid: {
+    displayName: 'Valid',
+    // Needs it's own icon
+    iconClass: 'icon-md-delta-resolved',
+    level: 'info',
+  },
+  ResourceDeltaDetected: {
+    displayName: 'Drift detected',
+    iconClass: 'icon-md-delta-detected',
+    level: 'info',
+  },
+  ResourceDeltaResolved: {
+    displayName: 'Drift resolved',
+    iconClass: 'icon-md-delta-resolved',
+    level: 'info',
+  },
+  ResourceActuationLaunched: {
+    displayName: 'Task launched',
+    iconClass: 'icon-md-actuation-launched',
+    level: 'info',
+  },
+  ResourceCheckError: {
+    displayName: 'Error',
+    // Needs it's own icon
+    iconClass: 'icon-md-error',
+    level: 'error',
+  },
+  ResourceCheckUnresolvable: {
+    displayName: 'Error',
+    // Needs it's own icon, but could likely be same as ResourceCheckError
+    iconClass: 'icon-md-error',
+    level: 'error',
+  },
+  ResourceActuationPaused: {
+    displayName: 'Management paused',
+    // Needs it's own icon
+    iconClass: 'icon-md-paused',
+    level: 'warning',
+  },
+  ResourceActuationResumed: {
+    displayName: 'Management resumed',
+    // Needs it's own icon
+    iconClass: 'icon-md-resumed',
+    level: 'info',
+  },
+} as const;
+
+const renderExpandedRowContent = (
+  level: 'info' | 'warning' | 'error',
+  diff: IManagedResourceDiff,
+  tasks: Array<{ id: string; name: string }>,
+  message: string,
+) => {
+  return (
+    <div className="flex-container-v left">
+      {message && (
+        <div
+          className={classNames('sp-padding-xs-yaxis', {
+            'event-warning-message': level === 'warning',
+            'event-error-message': level === 'error',
+          })}
+        >
+          {message}
+        </div>
+      )}
+      {tasks && (
+        <div className="flex-container-v">
+          {tasks.map(({ id, name }) => (
+            <UISref key={id} to="home.applications.application.tasks.taskDetails" params={{ taskId: id }}>
+              <a className="sp-padding-xs-yaxis">{name}</a>
+            </UISref>
+          ))}
+        </div>
+      )}
+      {diff && <ManagedResourceDiffTable diff={diff} />}
+    </div>
+  );
+};
+
+export const ManagedResourceHistoryModal = ({ resourceSummary }: IManagedResourceHistoryModalProps) => {
+  const {
+    id,
+    moniker: { app, stack, detail },
+    locations: { account },
+  } = resourceSummary;
+
+  const tableLayout = useMemo(() => standardGridTableLayout([4, 2, 2.6]), []);
+  const { status: historyEventStatus, result: historyEvents, refresh } = useData(
+    () => ManagedReader.getResourceHistory(id),
+    [],
+    [],
+  );
+
+  const resourceDisplayName = [app, stack, detail].filter(Boolean).join('-');
+  const isLoading = ['NONE', 'PENDING'].includes(historyEventStatus);
+
+  return (
+    <>
+      <ModalHeader>Resource History</ModalHeader>
+      <ModalBody>
+        <div
+          className={classNames('ManagedResourceHistoryModal', {
+            'flex-container-h middle center flex-grow': isLoading || historyEventStatus === 'REJECTED',
+          })}
+        >
+          {isLoading && <Spinner size="medium" />}
+          {historyEventStatus === 'REJECTED' && (
+            <div className="flex-container-v middle center">
+              <div className="loading-error-message text-semibold sp-margin-m-bottom">Something went wrong.</div>
+              <button className="btn btn-default" onClick={refresh}>
+                <i className="fa fa-xs fa-sync-alt sp-margin-xs-right" /> Try again
+              </button>
+            </div>
+          )}
+          {historyEventStatus === 'RESOLVED' && (
+            <div className="sp-margin-xl-bottom">
+              <Table
+                layout={tableLayout}
+                columns={['Where', 'What', 'When']}
+                expandable={historyEvents.some(
+                  ({ delta, tasks, message, reason }) => delta || tasks || message || reason,
+                )}
+              >
+                {historyEvents
+                  .filter(({ type }) => viewConfigurationByEventType[type])
+                  .map(({ type, timestamp: eventTimestamp, delta, tasks, message, reason }) => {
+                    const eventTimestampMillis = DateTime.fromISO(eventTimestamp).toMillis();
+                    const hasDetails = delta || tasks || message || reason;
+                    return (
+                      <TableRow
+                        key={type + eventTimestamp}
+                        renderExpandedContent={
+                          hasDetails &&
+                          (() =>
+                            renderExpandedRowContent(
+                              viewConfigurationByEventType[type].level,
+                              delta,
+                              tasks,
+                              message || reason,
+                            ))
+                        }
+                      >
+                        <TableCell>
+                          <AccountTag account={account} /> <span className="where-column-arrow" /> {resourceDisplayName}
+                        </TableCell>
+                        <TableCell>
+                          <i
+                            className={classNames(
+                              'event-type-icon ico ico--withLabel sp-margin-s-right',
+                              viewConfigurationByEventType[type].iconClass,
+                            )}
+                          />{' '}
+                          <span className="text-semibold event-type">
+                            {viewConfigurationByEventType[type].displayName}
+                          </span>
+                        </TableCell>
+                        <TableCell>
+                          <div className="flex-container-h middle wrap">
+                            <span className="sp-margin-s-right">{timestamp(eventTimestampMillis)}</span>{' '}
+                            <span className="text-italic">{relativeTime(eventTimestampMillis)}</span>
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+              </Table>
+            </div>
+          )}
+        </div>
+      </ModalBody>
+    </>
+  );
+};


### PR DESCRIPTION
**Depends on #7936 and #7937, don't merge yet.**

We've had a nifty API for a while that lets you see an event history of all the things that have happened to a managed resource over time — changes in desired/actual state, tasks being launched, etc. Now it's time to make all that available to folks directly in deck while they're looking at a resource. As a fun bonus, this is also one of the first views in deck that has full (for some definition of "full") mobile/small screen support. Here's what it looks like:


<details>
<summary>Smaller screen</summary>
 
<img width="390" alt="Screen Shot 2020-02-24 at 9 28 46 AM" src="https://user-images.githubusercontent.com/1850998/75175963-23212e80-56e8-11ea-8bcd-51be9bc6d6b8.png">
<img width="391" alt="Screen Shot 2020-02-24 at 9 29 04 AM" src="https://user-images.githubusercontent.com/1850998/75175973-261c1f00-56e8-11ea-87de-46e3867343d3.png">
</details>

<details>
<summary>Larger screen</summary>
 
<img width="1350" alt="Screen Shot 2020-02-24 at 9 26 51 AM" src="https://user-images.githubusercontent.com/1850998/75175859-f4a35380-56e7-11ea-8e43-d2d669a0d9c3.png">
<img width="1350" alt="Screen Shot 2020-02-24 at 9 27 01 AM" src="https://user-images.githubusercontent.com/1850998/75175865-f79e4400-56e7-11ea-90f0-59ae0c494c1b.png">
</details>

<details>
<summary>Interactions on small screens</summary>
 
![history-modal-mobile](https://user-images.githubusercontent.com/1850998/75175501-49929a00-56e7-11ea-8426-b4f580582e8b.gif)
</details>

<details>
<summary>Interactions on larger screens</summary>
 
![history-modal-desktop](https://user-images.githubusercontent.com/1850998/75175623-8f4f6280-56e7-11ea-80da-e70df5bf27ff.gif)
</details>

<details>
<summary>Expanding all events at once (larger screens only)</summary>
 
![history-modal-desktop-expandall](https://user-images.githubusercontent.com/1850998/75175714-b9a12000-56e7-11ea-9ec1-37504b118de2.gif)
</details>

<details>
<summary>When we can't get events from the API</summary>
 
<img width="903" alt="Screen Shot 2020-02-23 at 1 30 09 PM" src="https://user-images.githubusercontent.com/1850998/75176291-bbb7ae80-56e8-11ea-9b39-9e685c6384d2.png">
</details>

Some things I didn't do in this PR, but will probably add shortly:
 - Polling every N seconds for updated events (and displaying them at the top)
 - Help text for each event type (similar to how we have help text for each resource status
 - Maybe a banner that appears at the top of the modal when the resource is paused, with a link to unpause?

Feedback is, as always, very welcome on all aspects.

cc @gcomstock @emjburns @luispollo @gal-yardeni @asher @robfletcher @lorin