### PR TITLE
fix(ecs): use preferSourceCapacity instead of useSourceCapacity when configuring a serverGroup

### DIFF
--- a/app/scripts/modules/ecs/src/serverGroup/configure/serverGroupCommandBuilder.service.js
+++ b/app/scripts/modules/ecs/src/serverGroup/configure/serverGroupCommandBuilder.service.js
@@ -149,6 +149,7 @@ angular
               ecsClusterName: '',
               targetGroup: '',
               copySourceScalingPoliciesAndActions: true,
+              preferSourceCapacity: true,
               useSourceCapacity: true,
               viewState: {
                 useAllImageSelection: false,

--- a/app/scripts/modules/ecs/src/serverGroup/configure/wizard/horizontalScaling/horizontalScaling.component.html
+++ b/app/scripts/modules/ecs/src/serverGroup/configure/wizard/horizontalScaling/horizontalScaling.component.html
@@ -52,7 +52,11 @@
   <div class="form-group">
     <div class="col-md-12 checkbox">
       <label>
-        <input type="checkbox" ng-model="$ctrl.command.useSourceCapacity" />
+        <input
+          type="checkbox"
+          ng-model="$ctrl.command.useSourceCapacity"
+          ng-change="$ctrl.command.preferSourceCapacity=$ctrl.command.useSourceCapacity"
+        />
         <b>If available, use the previous server group's capacity</b>
       </label>
       <help-field key="ecs.capacity.overwrite"></help-field>


### PR DESCRIPTION
Use preferSourceCapacity instead of useSourceCapacity when configuring a serverGroup to use the previous server groups capacity.

Fixes: https://github.com/spinnaker/spinnaker/issues/4690

![Screen Shot 2020-02-24 at 3 37 45 PM](https://user-images.githubusercontent.com/44981951/75201018-31893d80-571c-11ea-8ee4-1ba955c41131.png)

![Screen Shot 2020-02-24 at 3 38 42 PM](https://user-images.githubusercontent.com/44981951/75201020-3221d400-571c-11ea-967b-39e31ba76f5a.png)

