### PR TITLE
fix(aws): Support security group ip range rule description

### DIFF
--- a/app/scripts/modules/amazon/src/securityGroup/details/securityGroupDetail.controller.js
+++ b/app/scripts/modules/amazon/src/securityGroup/details/securityGroupDetail.controller.js
@@ -116,7 +116,12 @@ angular
         groupedRangeRules[addr].forEach(rule => {
           (rule.portRanges || []).forEach(range => {
             if (rule.protocol === '-1' || (range.startPort !== undefined && range.endPort !== undefined)) {
-              rules.push({ startPort: range.startPort, endPort: range.endPort, protocol: rule.protocol });
+              rules.push({
+                startPort: range.startPort,
+                endPort: range.endPort,
+                protocol: rule.protocol,
+                description: rule.description,
+              });
             }
           });
         });


### PR DESCRIPTION
- Add `description` to IP Range rules , this will be used in the custom component.