### PR TITLE
fix(core/presentation): Fix controlled/uncontrolled warning for number input

### DIFF
--- a/app/scripts/modules/core/src/presentation/forms/inputs/NumberInput.tsx
+++ b/app/scripts/modules/core/src/presentation/forms/inputs/NumberInput.tsx
@@ -26,5 +26,5 @@ export function NumberInput(props: INumberInputProps) {
   useInternalValidator(validation, minMaxValidator);
 
   const className = `NumberInput form-control ${orEmptyString(inputClassName)} ${validationClassName(validation)}`;
-  return <input className={className} type="number" value={value} {...otherProps} />;
+  return <input className={className} type="number" value={orEmptyString(value)} {...otherProps} />;
 }

--- a/app/scripts/modules/core/src/presentation/forms/inputs/utils.ts
+++ b/app/scripts/modules/core/src/presentation/forms/inputs/utils.ts
@@ -1,11 +1,11 @@
 import classNames from 'classnames';
-import { isString } from 'lodash';
+import { isString, isNil } from 'lodash';
 
 import { noop } from 'core/utils';
 
 import { IFormInputValidation } from './interface';
 
-export const orEmptyString = (val: any) => val || '';
+export const orEmptyString = (val: any) => (isNil(val) ? '' : val);
 
 export const validationClassName = (validation = {} as IFormInputValidation) => {
   return classNames({


### PR DESCRIPTION
This reverts https://github.com/spinnaker/deck/pull/7881 and fixes it in the `orEmptyString` helper method
