### PR TITLE
fix(core/account): use relative import for IFormInputProps interface

### DIFF
--- a/app/scripts/modules/core/src/account/AccountSelectInput.tsx
+++ b/app/scripts/modules/core/src/account/AccountSelectInput.tsx
@@ -4,10 +4,10 @@ import { flatten, isEqual, map, uniq, xor } from 'lodash';
 import { Option } from 'react-select';
 
 import { createFakeReactSyntheticEvent } from 'core/presentation/forms/inputs/utils';
-import { IFormInputProps } from 'core/presentation/forms/inputs';
 import { ReactSelectInput } from 'core/presentation/forms/inputs/ReactSelectInput';
 import { SelectInput } from 'core/presentation/forms/inputs/SelectInput';
 
+import { IFormInputProps } from '../presentation/forms/inputs';
 import { AccountService, IAccount } from './AccountService';
 
 export interface IAccountSelectInputProps extends IFormInputProps {


### PR DESCRIPTION
We got bit again by the issue with extending interfaces that were imported using one of our package aliases (`core`, `amazon`, etc.). This just moves to using a relative import to get around it. The interface in question only extends one other interface which is defined in the same file.