### PR TITLE
feat(managed-delivery): Improve errors displayed from unparseable delivery configs

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/managed/ImportDeliveryConfigExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/managed/ImportDeliveryConfigExecutionDetails.tsx
@@ -43,14 +43,16 @@ function buildCustomErrorMessage(error: IDeliveryConfigImportError) {
     return CustomErrorMessage(error.message);
   }
 
+  const pathExpression = error.details.pathExpression.replace('.', '/');
+  /* eslint-disable */
   const errorMessage =
     {
-      missing_property: `The following property is missing: \`${error.details.pathExpression}\``,
-      invalid_type: `The type of property \`${error.details.pathExpression}\` is invalid.`,
-      invalid_format: `The format of property \`${error.details.pathExpression}\` is invalid.`,
-      invalid_value: `The value of property \`${error.details.pathExpression}\` is invalid.`,
+      missing_property: `The following property is missing: \`${pathExpression}\``,
+      invalid_type: `The type of property \`${pathExpression}\` is invalid.`,
+      invalid_format: `The format of property \`${pathExpression}\` is invalid.`,
+      invalid_value: `The value of property \`${pathExpression}\` is invalid.`,
     }[error.details.error] || 'Unknown error';
-
+  /* eslint-enable */
   return CustomErrorMessage(errorMessage, error.details.message);
 }
 

--- a/app/scripts/modules/core/src/pipeline/config/stages/managed/ImportDeliveryConfigExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/managed/ImportDeliveryConfigExecutionDetails.tsx
@@ -24,11 +24,11 @@ const CustomErrorMessage = (message: string, debugDetails?: string) => {
       <div className="alert alert-danger">
         <b>There was an error parsing your delivery config file.</b>
         <br />
-        <Markdown message={message} />
+        <Markdown message={message} style={{ wordBreak: 'break-all' }} />
         <br />
         {debugDetails && (
           <CollapsibleSection heading={({ chevron }) => <span>{chevron} Debug Details</span>}>
-            <pre>{debugDetails}</pre>
+            <pre style={{ whiteSpace: 'pre-wrap' }}>{debugDetails}</pre>
           </CollapsibleSection>
         )}
       </div>
@@ -45,14 +45,16 @@ function buildCustomErrorMessage(error: IDeliveryConfigImportError) {
     return CustomErrorMessage(error.message);
   }
 
-  const pathExpression = error.details.pathExpression.replace('.', '/');
-  /* eslint-disable */
+  // Replace dots with slashes for paths because it feels more familiar. Also ditch the very first slash/dot as it just adds noise.
+  const pathExpression = error.details.pathExpression.substring(1).replace(/\./g, '/');
+  // Turn off linter for the block below because it wants CamelCase property names.
+  /* eslint-disable @typescript-eslint/camelcase */
   const errorMessage =
     {
-      missing_property: `The following property is missing: \`${pathExpression}\``,
-      invalid_type: `The type of property \`${pathExpression}\` is invalid.`,
-      invalid_format: `The format of property \`${pathExpression}\` is invalid.`,
-      invalid_value: `The value of property \`${pathExpression}\` is invalid.`,
+      missing_property: `The following property is missing: <br/> \`${pathExpression}\``,
+      invalid_type: `The type of the following property is invalid: <br/> \`${pathExpression}\``,
+      invalid_format: `The format of the following property is invalid: <br/> \`${pathExpression}\``,
+      invalid_value: `The value of the following property is invalid: <br/> \`${pathExpression}\``,
     }[error.details.error] || 'Unknown error';
   /* eslint-enable */
   return CustomErrorMessage(errorMessage, error.details.message);

--- a/app/scripts/modules/core/src/pipeline/config/stages/managed/ImportDeliveryConfigExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/managed/ImportDeliveryConfigExecutionDetails.tsx
@@ -6,41 +6,41 @@ import { SETTINGS } from 'core/config';
 
 const NOT_FOUND = 'Not found';
 
-export class DeliveryConfigImportErrorDetails {
+interface IDeliveryConfigImportErrorDetails {
   error: string;
   message: string;
   pathExpression: string;
-
-  getErrorMessage() {
-    let errorMessage = 'Error parsing delivery config: <br/>';
-    switch (this.error) {
-      case 'missing_property':
-        errorMessage += 'The following property is missing: ' + this.pathExpression;
-        break;
-
-      case 'invalid_type':
-        errorMessage += 'The type of property `' + this.pathExpression + '` is invalid.';
-        break;
-
-      case 'invalid_format':
-        errorMessage += 'The format of property `' + this.pathExpression + '` is invalid.';
-        break;
-
-      case 'invalid_value':
-        errorMessage += 'The value of property `' + this.pathExpression + '` is invalid.';
-        break;
-
-      default:
-        errorMessage += this.message;
-        break;
-    }
-    return errorMessage;
-  }
 }
 
-export interface IDeliveryConfigImportError {
+interface IDeliveryConfigImportError {
   message: string;
-  details?: DeliveryConfigImportErrorDetails;
+  details?: IDeliveryConfigImportErrorDetails;
+}
+
+function extractErrorMessage(props: IDeliveryConfigImportErrorDetails) {
+  let errorMessage = 'There was an error parsing your delivery config file.<br/>';
+  switch (props.error) {
+    case 'missing_property':
+      errorMessage += 'The following property is missing: `' + props.pathExpression + '`';
+      break;
+
+    case 'invalid_type':
+      errorMessage += 'The type of property `' + props.pathExpression + '` is invalid.';
+      break;
+
+    case 'invalid_format':
+      errorMessage += 'The format of property `' + props.pathExpression + '` is invalid.';
+      break;
+
+    case 'invalid_value':
+      errorMessage += 'The value of property `' + props.pathExpression + '` is invalid.';
+      break;
+
+    default:
+      break;
+  }
+  errorMessage += '<br/><br/>Debug details: ' + props.message;
+  return errorMessage;
 }
 
 export function ImportDeliveryConfigExecutionDetails(props: IExecutionDetailsSectionProps) {
@@ -52,9 +52,9 @@ export function ImportDeliveryConfigExecutionDetails(props: IExecutionDetailsSec
     (stage.context.manifest ?? SETTINGS.managedDelivery?.defaultManifest);
 
   let errorMessage;
-  if (stage.context.error instanceof Map) {
+  if (stage.context.error instanceof Object) {
     const importError = stage.context.error as IDeliveryConfigImportError;
-    errorMessage = importError.details ? importError.details.getErrorMessage() : importError.message;
+    errorMessage = importError.details ? extractErrorMessage(importError.details) : importError.message;
   } else {
     errorMessage = stage.context.error;
   }

--- a/app/scripts/modules/core/src/pipeline/config/stages/managed/ImportDeliveryConfigExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/managed/ImportDeliveryConfigExecutionDetails.tsx
@@ -28,13 +28,13 @@ interface IDeliveryConfigImportError {
   details?: IDeliveryConfigImportErrorDetails;
 }
 
-const CustomErrorMessage = ({ message, debugDetails }: { message: string; debugDetails?: string }) => {
+const CustomErrorMessage = ({ summary, debugDetails }: { summary: string; debugDetails?: string }) => {
   return (
     <div>
       <div className="alert alert-danger">
         <b>There was an error parsing your delivery config file.</b>
         <br />
-        <Markdown message={message} style={{ wordBreak: 'break-all' }} />
+        <Markdown message={summary} style={{ wordBreak: 'break-all' }} />
         <br />
         {debugDetails && (
           <CollapsibleSection heading={({ chevron }) => <span>{chevron} Debug Details</span>}>
@@ -46,7 +46,7 @@ const CustomErrorMessage = ({ message, debugDetails }: { message: string; debugD
   );
 };
 
-function extractErrorMessage(error: IDeliveryConfigImportError): { summary: string; debugDetails?: string } {
+function extractCustomError(error: IDeliveryConfigImportError): { summary: string; debugDetails?: string } {
   if (!error) {
     return null;
   }
@@ -73,7 +73,7 @@ export function ImportDeliveryConfigExecutionDetails(props: IExecutionDetailsSec
     '/' +
     (stage.context.manifest ?? SETTINGS.managedDelivery?.defaultManifest);
 
-  const errorMessage = extractErrorMessage(stage.context.error as IDeliveryConfigImportError);
+  const customError = extractCustomError(stage.context.error as IDeliveryConfigImportError);
 
   return (
     <ExecutionDetailsSection name={props.name} current={props.current}>
@@ -96,8 +96,8 @@ export function ImportDeliveryConfigExecutionDetails(props: IExecutionDetailsSec
         </div>
       </div>
 
-      {errorMessage ? (
-        <CustomErrorMessage message={errorMessage.summary} debugDetails={errorMessage.debugDetails} />
+      {customError ? (
+        <CustomErrorMessage summary={customError.summary} debugDetails={customError.debugDetails} />
       ) : (
         <StageFailureMessage stage={stage} />
       )}

--- a/app/scripts/modules/core/src/pipeline/config/stages/managed/ImportDeliveryConfigExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/managed/ImportDeliveryConfigExecutionDetails.tsx
@@ -9,7 +9,7 @@ const NOT_FOUND = 'Not found';
 
 // Turn off linter for the block below because it wants CamelCase property names.
 /* eslint-disable @typescript-eslint/camelcase */
-const ERROR_MESSAGE_MAP = {
+const ERROR_MESSAGE_MAP: any = {
   missing_property: 'The following property is missing:',
   invalid_type: 'The type of the following property is invalid:',
   invalid_format: 'The format of the following property is invalid:',

--- a/app/scripts/modules/core/src/pipeline/config/stages/managed/ImportDeliveryConfigExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/managed/ImportDeliveryConfigExecutionDetails.tsx
@@ -49,14 +49,14 @@ function buildCustomErrorMessage(error: IDeliveryConfigImportError) {
   const pathExpression = error.details.pathExpression.substring(1).replace(/\./g, '/');
   // Turn off linter for the block below because it wants CamelCase property names.
   /* eslint-disable @typescript-eslint/camelcase */
-  const errorMessage =
-    {
-      missing_property: `The following property is missing: <br/> \`${pathExpression}\``,
-      invalid_type: `The type of the following property is invalid: <br/> \`${pathExpression}\``,
-      invalid_format: `The format of the following property is invalid: <br/> \`${pathExpression}\``,
-      invalid_value: `The value of the following property is invalid: <br/> \`${pathExpression}\``,
-    }[error.details.error] || 'Unknown error';
+  const errorMessageMap = {
+    missing_property: `The following property is missing: <br/> \`${pathExpression}\``,
+    invalid_type: `The type of the following property is invalid: <br/> \`${pathExpression}\``,
+    invalid_format: `The format of the following property is invalid: <br/> \`${pathExpression}\``,
+    invalid_value: `The value of the following property is invalid: <br/> \`${pathExpression}\``,
+  };
   /* eslint-enable */
+  const errorMessage = errorMessageMap[error.details.error] || 'Unknown error';
   return CustomErrorMessage(errorMessage, error.details.message);
 }
 

--- a/app/scripts/modules/core/src/pipeline/config/stages/managed/ImportDeliveryConfigExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/managed/ImportDeliveryConfigExecutionDetails.tsx
@@ -26,9 +26,11 @@ const CustomErrorMessage = (message: string, debugDetails?: string) => {
         <br />
         <Markdown message={message} />
         <br />
-        <CollapsibleSection heading={({ chevron }) => <span>{chevron} Debug Details</span>}>
-          <pre>{debugDetails}</pre>
-        </CollapsibleSection>
+        {debugDetails && (
+          <CollapsibleSection heading={({ chevron }) => <span>{chevron} Debug Details</span>}>
+            <pre>{debugDetails}</pre>
+          </CollapsibleSection>
+        )}
       </div>
     </div>
   );

--- a/app/scripts/modules/core/src/pipeline/config/stages/managed/ImportDeliveryConfigExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/managed/ImportDeliveryConfigExecutionDetails.tsx
@@ -9,7 +9,7 @@ const NOT_FOUND = 'Not found';
 
 // Turn off linter for the block below because it wants CamelCase property names.
 /* eslint-disable @typescript-eslint/camelcase */
-const ERROR_MESSAGE_MAP: any = {
+const ERROR_MESSAGE_MAP = {
   missing_property: 'The following property is missing:',
   invalid_type: 'The type of the following property is invalid:',
   invalid_format: 'The format of the following property is invalid:',
@@ -18,7 +18,7 @@ const ERROR_MESSAGE_MAP: any = {
 /* eslint-enable */
 
 interface IDeliveryConfigImportErrorDetails {
-  error: string;
+  error: 'missing_property' | 'invalid_type' | 'invalid_format' | 'invalid_value';
   message: string;
   pathExpression: string;
 }

--- a/app/scripts/modules/core/src/pipeline/config/stages/managed/ImportDeliveryConfigExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/managed/ImportDeliveryConfigExecutionDetails.tsx
@@ -7,6 +7,16 @@ import { SETTINGS } from 'core/config';
 
 const NOT_FOUND = 'Not found';
 
+// Turn off linter for the block below because it wants CamelCase property names.
+/* eslint-disable @typescript-eslint/camelcase */
+const ERROR_MESSAGE_MAP = {
+  missing_property: 'The following property is missing:',
+  invalid_type: 'The type of the following property is invalid:',
+  invalid_format: 'The format of the following property is invalid:',
+  invalid_value: 'The value of the following property is invalid:',
+};
+/* eslint-enable */
+
 interface IDeliveryConfigImportErrorDetails {
   error: string;
   message: string;
@@ -47,16 +57,11 @@ function buildCustomErrorMessage(error: IDeliveryConfigImportError) {
 
   // Replace dots with slashes for paths because it feels more familiar. Also ditch the very first slash/dot as it just adds noise.
   const pathExpression = error.details.pathExpression.substring(1).replace(/\./g, '/');
-  // Turn off linter for the block below because it wants CamelCase property names.
-  /* eslint-disable @typescript-eslint/camelcase */
-  const errorMessageMap = {
-    missing_property: `The following property is missing: <br/> \`${pathExpression}\``,
-    invalid_type: `The type of the following property is invalid: <br/> \`${pathExpression}\``,
-    invalid_format: `The format of the following property is invalid: <br/> \`${pathExpression}\``,
-    invalid_value: `The value of the following property is invalid: <br/> \`${pathExpression}\``,
-  };
-  /* eslint-enable */
-  const errorMessage = errorMessageMap[error.details.error] || 'Unknown error';
+
+  const errorMessage = ERROR_MESSAGE_MAP[error.details.error]
+    ? ERROR_MESSAGE_MAP[error.details.error] + `<br/>\`${pathExpression}\``
+    : 'Unknown error';
+
   return CustomErrorMessage(errorMessage, error.details.message);
 }
 


### PR DESCRIPTION
Adds a bit more logic to the Import Delivery Config stage's execution details component so it displays more user-friendly error messages when the error is in parsing a delivery config.

Closes https://github.com/spinnaker/keel/issues/818