### PR TITLE
fix(core/managed): remove arrow visual treatment on history modal

### DIFF
--- a/app/scripts/modules/core/src/managed/ManagedResourceHistoryModal.less
+++ b/app/scripts/modules/core/src/managed/ManagedResourceHistoryModal.less
@@ -10,16 +10,6 @@
     font-size: 24px;
   }
 
-  .where-column-arrow {
-    display: inline-block;
-    width: 4px;
-    height: 6px;
-    margin: 0 8px;
-    border-style: solid;
-    border-width: 4px 0 4px 6px;
-    border-color: transparent transparent transparent var(--color-nobel);
-  }
-
   .event-warning-message {
     color: var(--color-alert);
   }

--- a/app/scripts/modules/core/src/managed/ManagedResourceHistoryModal.tsx
+++ b/app/scripts/modules/core/src/managed/ManagedResourceHistoryModal.tsx
@@ -195,7 +195,8 @@ export const ManagedResourceHistoryModal = ({ resourceSummary }: IManagedResourc
                         }
                       >
                         <TableCell>
-                          <AccountTag account={account} /> <span className="where-column-arrow" /> {resourceDisplayName}
+                          <AccountTag account={account} />{' '}
+                          <span className="sp-margin-s-left">{resourceDisplayName}</span>
                         </TableCell>
                         <TableCell>
                           <i


### PR DESCRIPTION
We've consistently gotten feedback that the grey arrow on each resource in the `Where` column is confusing because it _looks_ like an expand/collapse arrow, but it isn't. That combined with folks needing to re-learn that expand/collapse controls are on the right has been leading to a bit of awkwardness. Since for now there's really only two sections to the hierarchy in the `Where` column (account + resource name) I'm just removing it. We can figure out what visual treatment works better to communicate hierarchy better separately.

Before: 

<img width="1470" alt="Screen Shot 2020-02-26 at 1 58 50 PM" src="https://user-images.githubusercontent.com/1850998/75392094-3119af80-58a0-11ea-8646-14eabcb68f17.png">

After:

<img width="1452" alt="Screen Shot 2020-02-26 at 1 55 06 PM" src="https://user-images.githubusercontent.com/1850998/75392105-35de6380-58a0-11ea-8650-fec97044ee7e.png">