### PR TITLE
fix(test/functional): fix functional tests by increasing the timeout to 60 seconds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Functional Tests
         if: steps.purebump.outputs.ispurebump != 'true'
-        run: node test/functional/run.js --replay-fixtures --serve-deck --imposter-port=8084 --browser=chrome --headless
+        run: yarn functional
 
   build:
     name: Production Build

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "int": "protractor protractor.conf.js",
     "modules": "./gradle/buildModules.sh",
     "prettier": "prettier --write 'app/**/*.{js,jsx,ts,tsx,html,css,less}'",
-    "functional": "test/functional/run.js --serve-deck --replay-fixtures --browser chrome --headless"
+    "functional": "test/functional/run.js --replay-fixtures --serve-deck --imposter-port=8084 --browser=chrome --headless"
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.4.1",

--- a/test/functional/tests/core/pages/Page.ts
+++ b/test/functional/tests/core/pages/Page.ts
@@ -2,7 +2,7 @@ import '@wdio/sync';
 import { defaultsDeep } from 'lodash';
 
 const DEFAULT_OPTIONS = {
-  awaitExistsTime: 10000,
+  awaitExistsTime: 60000,
 };
 
 export class Page {


### PR DESCRIPTION
Looks like we can "fix" the functional tests by bumping up the timeout.  I'd like to merge this before the migration to cypress lands.