### PR TITLE
feat(core/presentation): Perf optimization to avoid unnecessary re-renders

### DIFF
--- a/app/scripts/modules/core/src/presentation/forms/fields/FormikFormField.tsx
+++ b/app/scripts/modules/core/src/presentation/forms/fields/FormikFormField.tsx
@@ -10,6 +10,7 @@ import { ICommonFormFieldProps, renderContent } from './index';
 import { IFormInputValidation } from '../inputs';
 import { ILayoutProps, LayoutContext } from '../layouts';
 import { FormikSpelContext, SimpleSpelInput, SpelAwareInputMode, SpelService, SpelToggle } from '../../spel';
+import { useIsFirstRender } from '../../hooks/useIsFirstRender.hook';
 
 export interface IFormikFieldProps<T> {
   /**
@@ -40,6 +41,18 @@ type IFormikFormFieldImplProps<T> = IFormikFormFieldProps<T> & { formik: FormikC
 
 const { useCallback, useContext, useState } = React;
 
+const revalidateMap = new Map();
+// If many formfields request a revalidate at the same time, coalesce the requests and revalidate once on the next tick
+function coalescedRevalidate(formik: FormikContext<any>) {
+  if (!revalidateMap.has(formik)) {
+    revalidateMap.set(formik, true);
+    setTimeout(() => {
+      revalidateMap.delete(formik);
+      return formik.validateForm();
+    });
+  }
+}
+
 function FormikFormFieldImpl<T = any>(props: IFormikFormFieldImplProps<T>) {
   const { formik } = props;
   const { name, onChange, fastField: fastFieldProp } = props;
@@ -60,11 +73,14 @@ function FormikFormFieldImpl<T = any>(props: IFormikFormFieldImplProps<T>) {
   const addValidator = useCallback((v: IValidator) => setInternalValidators(list => list.concat(v)), []);
   const removeValidator = useCallback((v: IValidator) => setInternalValidators(list => list.filter(x => x !== v)), []);
 
-  function revalidate() {
-    formik.validateForm();
-  }
-
-  React.useEffect(() => revalidate(), [internalValidators]);
+  const revalidate = () => coalescedRevalidate(formik);
+  const isFirstRender = useIsFirstRender();
+  React.useEffect(() => {
+    if (isFirstRender && internalValidators.length === 0) {
+      return;
+    }
+    revalidate();
+  }, [internalValidators]);
 
   const validation: IFormInputValidation = {
     touched,

--- a/app/scripts/modules/core/src/presentation/hooks/useIsFirstRender.hook.spec.tsx
+++ b/app/scripts/modules/core/src/presentation/hooks/useIsFirstRender.hook.spec.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { useIsFirstRender } from './useIsFirstRender.hook';
+
+describe('useIsFirstRender', () => {
+  const TestComponent = ({ callback }: { callback: (isFirst: boolean) => void }) => {
+    const isFirstRender = useIsFirstRender();
+    callback(isFirstRender);
+    return <i />;
+  };
+
+  it('should rerender when the mutation stream changes', () => {
+    let isFirstRender: boolean;
+    const mounted = mount(<TestComponent callback={isFirst => (isFirstRender = isFirst)} />);
+
+    expect(isFirstRender).toBe(true);
+    mounted.setProps({});
+    expect(isFirstRender).toBe(false);
+    mounted.setProps({});
+    expect(isFirstRender).toBe(false);
+  });
+});

--- a/app/scripts/modules/core/src/presentation/hooks/useIsFirstRender.hook.ts
+++ b/app/scripts/modules/core/src/presentation/hooks/useIsFirstRender.hook.ts
@@ -1,0 +1,9 @@
+import { useEffect, useRef } from 'react';
+
+export const useIsFirstRender = () => {
+  const isFirstRender = useRef(true);
+  useEffect(() => {
+    isFirstRender.current = false;
+  }, []);
+  return isFirstRender.current;
+};


### PR DESCRIPTION
Problem:
When a FormikFormField mounted, it was always forcing a `validateForm` call.
Each field in a form would make this same call, and each revalidate would cause a full re-render.
These revalidate/rerenders stack up and cause a noticeable delay to initially loading the form.

Forcing revalidation of the form is only necessary if the formfield added new validations.

This PR does two things:
1) It avoids revalidating on the first render if there are no actual `internalValidators`
2) It coalesces revalidate calls from multiple form fields within the same form into a single call.
   It waits for the next tick, then invokes `validateForm` once.