### PR TITLE
feat(core/managed): poll for new history events in modal

### DIFF
--- a/app/scripts/modules/core/src/presentation/hooks/index.ts
+++ b/app/scripts/modules/core/src/presentation/hooks/index.ts
@@ -9,3 +9,4 @@ export * from './useIsMobile.hook';
 export * from './useIsMountedRef.hook';
 export * from './useLatestCallback.hook';
 export * from './useLatestPromise.hook';
+export * from './usePrevious.hook';


### PR DESCRIPTION
**Depends on ~~https://github.com/spinnaker/deck/pull/7984~~ and https://github.com/spinnaker/keel/pull/842**

When folks are looking at the resource history modal and trying to get a sense of what's been happening with their resource, it's valuable to update the view in real time. This change uses the [`usePollingData`](https://github.com/spinnaker/deck/pull/7984) hook to poll for new events every 10 seconds. The bulk of the changes are actually for optimizing rendering, not for wiring up the polling itself.

Rendering the event table itself isn't that much work, but when event rows are expanded the diff tables inside them can have complex component trees which in aggregate consume an unacceptable amount of rendering time. That problem is pretty simple to work around with memoization, it just means we have to do some mildly annoying array slicing and dicing when we receive new requests. In the future we're hoping to add `before` and `after` query parameters to the API this modal calls so that we can effectively have the API do this work for us — i.e. fetch the latest N events, then poll for anything after the newest timestamp in the initial request so we can prepend onto the existing data without even looking at it.