### PR TITLE
fix(core/presentation): properly contain sticky row headers on scroll

### DIFF
--- a/app/scripts/modules/core/src/presentation/tables/standardGridTableLayout.less
+++ b/app/scripts/modules/core/src/presentation/tables/standardGridTableLayout.less
@@ -129,7 +129,6 @@
     grid-column: 1 / -1;
     background-color: var(--color-white);
     padding: 16px;
-    margin-bottom: 16px;
     overflow-x: scroll;
   }
 
@@ -144,16 +143,18 @@
   }
 
   @media screen and (max-width: 1024px) {
+    .standard-grid-table-row-container {
+      &:first-child {
+        margin-top: 16px;
+      }
+    }
+
     .standard-grid-table-row {
       display: flex;
       flex-wrap: wrap;
       padding: 0 8px 16px;
       margin: 0 0 16px;
       border-bottom: 1px solid var(--color-porcelain);
-
-      &:first-child {
-        margin-top: 16px;
-      }
 
       &.expanded {
         position: static;
@@ -171,7 +172,6 @@
 
     .expanded-row-content {
       border-left: 2px solid var(--color-regal);
-      margin-bottom: 16px;
     }
 
     .standard-grid-table-cell {

--- a/app/scripts/modules/core/src/presentation/tables/standardGridTableLayout.tsx
+++ b/app/scripts/modules/core/src/presentation/tables/standardGridTableLayout.tsx
@@ -103,7 +103,11 @@ const TableRowLayout = ({
   const gridTemplateColumns = getGridColumnsStyle(sizes, tableExpandable, isMobile);
 
   return (
-    <>
+    <div
+      className={classNames('flex-container-v standard-grid-table-row-container', {
+        'sp-margin-l-bottom': rowExpandable && expanded,
+      })}
+    >
       <div
         className={classNames('standard-grid-table-row', { expandable: rowExpandable, expanded })}
         style={{ gridTemplateColumns }}
@@ -119,7 +123,7 @@ const TableRowLayout = ({
         )}
       </div>
       {rowExpandable && expanded && <div className="expanded-row-content">{renderExpandedContent()}</div>}
-    </>
+    </div>
   );
 };
 


### PR DESCRIPTION
`standardGridTableLayout` makes rows sticky when expanded, so they're still visible when looking at large amounts of expanded content. Previously the header and its expanded content were siblings without a container which led to some jankiness on scroll (the GIF makes the colors a bit hard to differentiate, but watch the "Drift detected" header stay on top of subsequent rows):

<details>
<summary>Before</summary>

![table-header-scroll-before](https://user-images.githubusercontent.com/1850998/75614236-9c0af680-5aeb-11ea-87d1-ba75058caec8.gif)
</details>

This change sticks both those elements in a container and moves some margins around so that the header is kept where it belongs:

<details>
<summary>After</summary>

![table-header-scroll-after](https://user-images.githubusercontent.com/1850998/75614267-d6749380-5aeb-11ea-9572-09f58dfaed57.gif)
</details>