### PR TITLE
feat(core/managed): add history modal button to status popovers, revise language

### DIFF
--- a/app/scripts/modules/core/src/managed/ManagedResourceStatusIndicator.tsx
+++ b/app/scripts/modules/core/src/managed/ManagedResourceStatusIndicator.tsx
@@ -28,11 +28,8 @@ const viewConfigurationByStatus: { [status in ManagedResourceStatus]: IViewConfi
           <b>Action is being taken to resolve a drift from the declarative configuration.</b>
         </p>
         <p>
-          Check the{' '}
-          <UISref to="home.applications.application.tasks">
-            <a>tasks view</a>
-          </UISref>{' '}
-          to see work that's in progress. <LearnMoreLink resourceSummary={resourceSummary} />
+          Check this resource's History to see details and track the work currently in progress.{' '}
+          <LearnMoreLink resourceSummary={resourceSummary} />
         </p>
       </>
     ),
@@ -62,8 +59,8 @@ const viewConfigurationByStatus: { [status in ManagedResourceStatus]: IViewConfi
           <b>A drift from the declarative configuration was detected.</b>
         </p>
         <p>
-          Spinnaker will automatically take action to bring this resource back to its desired state.{' '}
-          <LearnMoreLink resourceSummary={resourceSummary} />
+          Spinnaker will automatically take action to bring this resource back to its desired state. Check the History
+          to see details and track progress. <LearnMoreLink resourceSummary={resourceSummary} />
         </p>
       </>
     ),
@@ -78,8 +75,8 @@ const viewConfigurationByStatus: { [status in ManagedResourceStatus]: IViewConfi
         </p>
         <p>
           Spinnaker is configured to continuously manage this resource, but something went wrong trying to check its
-          current state. Automatic action can't be taken right now, and manual intervention might be required.{' '}
-          <LearnMoreLink resourceSummary={resourceSummary} />
+          current state. Automatic action can't be taken right now, and manual intervention might be required. Check the
+          History for details. <LearnMoreLink resourceSummary={resourceSummary} />
         </p>
       </>
     ),
@@ -148,7 +145,8 @@ const viewConfigurationByStatus: { [status in ManagedResourceStatus]: IViewConfi
         </p>
         <p>
           Spinnaker has been trying to correct a detected drift, but taking automatic action hasn't helped. Manual
-          intervention might be required. <LearnMoreLink resourceSummary={resourceSummary} />
+          intervention might be required. Check the History for details.{' '}
+          <LearnMoreLink resourceSummary={resourceSummary} />
         </p>
       </>
     ),
@@ -249,6 +247,7 @@ export const ManagedResourceStatusIndicator = ({
   application,
 }: IManagedResourceStatusIndicatorProps) => {
   const { status } = resourceSummary;
+
   const PopoverContents = ({ hidePopover }: IHoverablePopoverContentsProps) => (
     <>
       {viewConfigurationByStatus[status].popoverContents(resourceSummary, application)}

--- a/app/scripts/modules/core/src/managed/ManagedResourceStatusIndicator.tsx
+++ b/app/scripts/modules/core/src/managed/ManagedResourceStatusIndicator.tsx
@@ -3,10 +3,11 @@ import ReactGA from 'react-ga';
 import classNames from 'classnames';
 import { UISref } from '@uirouter/react';
 
-import { HoverablePopover, IHoverablePopoverContentsProps } from 'core/presentation';
+import { HoverablePopover, IHoverablePopoverContentsProps, showModal } from 'core/presentation';
 import { IManagedResourceSummary, ManagedResourceStatus } from 'core/domain';
 import { Application } from 'core/application';
 
+import { ManagedResourceHistoryModal } from './ManagedResourceHistoryModal';
 import { toggleResourcePause } from './toggleResourceManagement';
 
 import './ManagedResourceStatusIndicator.less';
@@ -186,7 +187,7 @@ const LearnMoreLink = ({ resourceSummary }: { resourceSummary: IManagedResourceS
   </a>
 );
 
-const PopoverLinks = ({
+const PopoverActions = ({
   resourceSummary,
   application,
   hidePopover,
@@ -194,31 +195,47 @@ const PopoverLinks = ({
   resourceSummary: IManagedResourceSummary;
   application: Application;
   hidePopover: () => void;
-}) => (
-  <div className="horizontal right">
-    {!resourceSummary.isPaused && (
-      <p className="sp-margin-m-top sp-margin-xs-bottom">
-        <button className="passive" onClick={() => toggleResourcePause(resourceSummary, application, hidePopover)}>
-          <i className="fa fa-pause" /> Pause management of this resource
-        </button>
+}) => {
+  const historyButton = (
+    <button
+      className="passive flex-none"
+      onClick={() => {
+        hidePopover();
+        showModal(ManagedResourceHistoryModal, { resourceSummary });
+      }}
+    >
+      <i className="fa fa-history" /> History
+    </button>
+  );
+  return (
+    <div className="horizontal right">
+      <p className="flex-container-h middle sp-margin-m-top sp-margin-xs-bottom sp-group-margin-s-xaxis">
+        {historyButton}
+        {!resourceSummary.isPaused && (
+          <button
+            className="passive flex-none"
+            onClick={() => toggleResourcePause(resourceSummary, application, hidePopover)}
+          >
+            <i className="fa fa-pause" /> Pause management of this resource
+          </button>
+        )}
+        {resourceSummary.isPaused && !application.isManagementPaused && (
+          <button
+            className="passive flex-none"
+            onClick={() => toggleResourcePause(resourceSummary, application, hidePopover)}
+          >
+            <i className="fa fa-play" /> Resume management of this resource
+          </button>
+        )}
+        {application.isManagementPaused && (
+          <UISref to="home.applications.application.config" params={{ section: 'managed-resources' }}>
+            <a>Resume application management</a>
+          </UISref>
+        )}
       </p>
-    )}
-    {resourceSummary.isPaused && !application.isManagementPaused && (
-      <p className="sp-margin-m-top sp-margin-xs-bottom">
-        <button className="passive" onClick={() => toggleResourcePause(resourceSummary, application, hidePopover)}>
-          <i className="fa fa-play" /> Resume management of this resource
-        </button>
-      </p>
-    )}
-    {application.isManagementPaused && (
-      <p>
-        <UISref to="home.applications.application.config" params={{ section: 'managed-resources' }}>
-          <a>Resume application management</a>
-        </UISref>
-      </p>
-    )}
-  </div>
-);
+    </div>
+  );
+};
 
 export interface IManagedResourceStatusIndicatorProps {
   shape: 'square' | 'circle';
@@ -235,7 +252,7 @@ export const ManagedResourceStatusIndicator = ({
   const PopoverContents = ({ hidePopover }: IHoverablePopoverContentsProps) => (
     <>
       {viewConfigurationByStatus[status].popoverContents(resourceSummary, application)}
-      <PopoverLinks resourceSummary={resourceSummary} application={application} hidePopover={hidePopover} />
+      <PopoverActions resourceSummary={resourceSummary} application={application} hidePopover={hidePopover} />
     </>
   );
   return (

--- a/app/scripts/modules/core/src/managed/ManagedResourceStatusIndicator.tsx
+++ b/app/scripts/modules/core/src/managed/ManagedResourceStatusIndicator.tsx
@@ -179,7 +179,7 @@ const LearnMoreLink = ({ resourceSummary }: { resourceSummary: IManagedResourceS
   <a
     target="_blank"
     onClick={() => logClick('Status docs link', resourceSummary.id, resourceSummary.status)}
-    href={`https://www.spinnaker.io/reference/managed-delivery/resource-status/#${resourceSummary.status.toLowerCase()}`}
+    href={`https://www.spinnaker.io/guides/user/managed-delivery/resource-status/#${resourceSummary.status.toLowerCase()}`}
   >
     Learn more
   </a>


### PR DESCRIPTION
**Depends on #7987 and #7988**

Now that we have a way of viewing historical resource events in the UI, it makes sense to offer a quick way to jump into that view when learning about a resource's current status in the infrastructure view. This PR adds a "History" button to all status popovers that looks like this:

<img width="477" alt="Screen Shot 2020-03-03 at 8 25 43 AM" src="https://user-images.githubusercontent.com/1850998/75801896-b681e180-5d30-11ea-856c-77cd18e40566.png">

In addition, I've tweaked the language on a few of the statuses to offer guidance around when it makes sense to check the History (e.g. `DIFF`, `ACTUATING`, `ERROR`, etc.).

As a bonus, I fixed the deep-linking to the docs which broke when they moved from Reference to Guides. I'll be opening up a separate PR to modify the spinnaker.io doc page with updated screenshots for each status as well.

(cc @gcomstock)