### PR TITLE
fix (amazon/target group): Remove duplicate form fields for target group health

### DIFF
--- a/app/scripts/modules/amazon/src/loadBalancer/configure/application/TargetGroups.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/application/TargetGroups.tsx
@@ -320,6 +320,9 @@ export class TargetGroups extends React.Component<ITargetGroupsProps, ITargetGro
                           {targetGroup.targetType !== 'lambda' && (
                             <span className="wizard-pod-content">
                               <label>Protocol </label>
+                              {targetGroup.healthCheckProtocol === 'TCP' && (
+                                <HelpField id="aws.targetGroup.healthCheckProtocol" />
+                              )}{' '}
                               <select
                                 className="form-control input-sm inline-number"
                                 value={targetGroup.healthCheckProtocol}
@@ -365,53 +368,6 @@ export class TargetGroups extends React.Component<ITargetGroupsProps, ITargetGro
                               />
                             </span>
                           )}
-                          <span className="wizard-pod-content">
-                            <label>Protocol </label>
-                            {targetGroup.healthCheckProtocol === 'TCP' && (
-                              <HelpField id="aws.targetGroup.healthCheckProtocol" />
-                            )}{' '}
-                            <select
-                              className="form-control input-sm inline-number"
-                              value={targetGroup.healthCheckProtocol}
-                              onChange={event =>
-                                this.targetGroupFieldChanged(index, 'healthCheckProtocol', event.target.value)
-                              }
-                            >
-                              {ProtocolOptions}
-                            </select>
-                          </span>
-                          <span className="wizard-pod-content">
-                            <label>Port </label>
-                            <HelpField id="aws.targetGroup.attributes.healthCheckPort.trafficPort" />{' '}
-                            <select
-                              className="form-control input-sm inline-number"
-                              style={{ width: '90px' }}
-                              value={targetGroup.healthCheckPort === 'traffic-port' ? 'traffic-port' : 'manual'}
-                              onChange={event =>
-                                this.targetGroupFieldChanged(
-                                  index,
-                                  'healthCheckPort',
-                                  event.target.value === 'traffic-port' ? 'traffic-port' : '',
-                                )
-                              }
-                            >
-                              <option value="traffic-port">Traffic Port</option>
-                              <option value="manual">Manual</option>
-                            </select>{' '}
-                            <SpInput
-                              className="form-control input-sm inline-number"
-                              error={tgErrors.healthCheckPort}
-                              style={{
-                                visibility: targetGroup.healthCheckPort === 'traffic-port' ? 'hidden' : 'inherit',
-                              }}
-                              name="healthCheckPort"
-                              required={true}
-                              value={targetGroup.healthCheckPort}
-                              onChange={event =>
-                                this.targetGroupFieldChanged(index, 'healthCheckPort', event.target.value)
-                              }
-                            />
-                          </span>
                           <span className="wizard-pod-content">
                             <label>Path </label>
                             <SpInput

--- a/app/scripts/modules/core/src/authentication/AuthenticationInitializer.ts
+++ b/app/scripts/modules/core/src/authentication/AuthenticationInitializer.ts
@@ -52,8 +52,6 @@ export class AuthenticationInitializer {
 
   public static loginRedirect(): void {
     const callback: string = encodeURIComponent($location.absUrl());
-    // eslint-disable-next-line
-    console.log(callback);
     window.location.href = `${SETTINGS.gateUrl}/auth/redirect?to=${callback}`;
   }
 

--- a/app/scripts/modules/core/src/authentication/AuthenticationInitializer.ts
+++ b/app/scripts/modules/core/src/authentication/AuthenticationInitializer.ts
@@ -52,6 +52,8 @@ export class AuthenticationInitializer {
 
   public static loginRedirect(): void {
     const callback: string = encodeURIComponent($location.absUrl());
+    // eslint-disable-next-line
+    console.log(callback);
     window.location.href = `${SETTINGS.gateUrl}/auth/redirect?to=${callback}`;
   }
 


### PR DESCRIPTION
The `port` and `protocol` fields were duplicated in the target group health check section of the modal. This PR removes the extra fields so that there is only one. 