### PR TITLE
fix(amazon): Export securityGroup interfaces

### DIFF
--- a/app/scripts/modules/amazon/src/index.ts
+++ b/app/scripts/modules/amazon/src/index.ts
@@ -11,3 +11,4 @@ export * from './reactShims';
 export * from './serverGroup';
 export * from './vpc';
 export * from './instance';
+export * from './securityGroup';


### PR DESCRIPTION
- Export securityGroup interfaces , missed updating `index.ts` for @spinnaker/amazon  in the last PR #8001 