### PR TITLE
fix(core): Order executions by startTime not endTime

### DIFF
--- a/app/scripts/modules/core/src/pipeline/filter/executionFilter.service.ts
+++ b/app/scripts/modules/core/src/pipeline/filter/executionFilter.service.ts
@@ -373,7 +373,7 @@ export class ExecutionFilterService {
     if (!b.endTime) {
       return 1;
     }
-    return b.endTime - a.endTime;
+    return b.startTime - a.startTime;
   }
 
   public static clearFilters(): void {


### PR DESCRIPTION
While there could be an argument to be made that it's nice to see more recently running things, overall sorting by anything other than `startTime` is mostly unexpected and confusing to the user.

Because the executions endpoint returns a limited number of things ordered by `startTime` not `endTime`, ordering by`endTime` is only more confusing because requesting newer items could get sandwiched between existing items, which is just plain weird.