### PR TITLE
Pipeline stage tweaks

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/PipelineRegistry.spec.ts
+++ b/app/scripts/modules/core/src/pipeline/config/PipelineRegistry.spec.ts
@@ -177,7 +177,7 @@ describe('PipelineRegistry: API', function() {
         Registry.pipeline.registerStage(config);
         expect(Registry.pipeline.getStageConfig({ type: 'a' } as IStage)).toEqual(config);
         expect(Registry.pipeline.getStageConfig({ type: 'a1' } as IStage)).toEqual(config);
-        expect(Registry.pipeline.getStageConfig({ type: 'b' } as IStage)).toBe(null);
+        expect(Registry.pipeline.getStageConfig({ type: 'b' } as IStage)).toBeFalsy();
       }),
     );
   });
@@ -234,7 +234,7 @@ describe('PipelineRegistry: API', function() {
       const pipelineRegistry = new PipelineRegistry();
       slimmaker.filter(stage => stage !== unmatchedStage).forEach(stage => pipelineRegistry.registerStage(stage));
 
-      expect(pipelineRegistry.getStageConfig({ type: 'x' } as IStage)).toEqual(null);
+      expect(pipelineRegistry.getStageConfig({ type: 'x' } as IStage)).toBeFalsy();
     });
 
     it('matches renamed stage with both stageType.key or (legacy) stageType.alias', function() {

--- a/app/scripts/modules/core/src/pipeline/config/PipelineRegistry.ts
+++ b/app/scripts/modules/core/src/pipeline/config/PipelineRegistry.ts
@@ -288,7 +288,7 @@ export class PipelineRegistry {
         // - to have stages that actually run as their 'alias' in orca (addAliasToConfig) because their 'key' doesn't actually exist
         const aliasMatch = this.checkAliasedStageTypes(stage) || this.checkAliasFallback(stage);
         const unmatchedStageType = this.getStageTypes().find(s => s.key === 'unmatched');
-        return aliasMatch ?? unmatchedStageType ?? null;
+        return aliasMatch ?? unmatchedStageType;
       }
       case 1:
         return matches[0];
@@ -298,8 +298,7 @@ export class PipelineRegistry {
         const provider = PipelineRegistry.resolveCloudProvider(stage);
         const matchesThisCloudProvider = matches.find(stageType => stageType.cloudProvider === provider);
         const matchesAnyCloudProvider = matches.find(stageType => !!stageType.cloudProvider);
-        // ct: I'm not sure why we fall back to null instead of matches[0]
-        return matchesThisCloudProvider ?? matchesAnyCloudProvider ?? null;
+        return matchesThisCloudProvider ?? matchesAnyCloudProvider ?? matches[0];
       }
     }
   }


### PR DESCRIPTION
- refactor(core/pipeline): Simplify logic finding matching stage types
  this is a pure refactor

- fix(core/pipeline): fall back to 'unmatched' stage (JSON editor) instead of null
  this changes fallback behavior
