### PR TITLE
fix(core/managed): support new group/name@version syntax for kind field

### DIFF
--- a/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupConfiguration.service.spec.ts
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupConfiguration.service.spec.ts
@@ -427,7 +427,7 @@ describe('Service: awsServerGroupConfiguration', function() {
           },
           managedResources: [
             {
-              kind: 'cluster',
+              kind: 'ec2/cluster@v1',
               locations: {
                 account: 'prod',
                 regions: [{ name: 'us-east-1' }],

--- a/app/scripts/modules/core/src/domain/IManagedEntity.ts
+++ b/app/scripts/modules/core/src/domain/IManagedEntity.ts
@@ -62,7 +62,6 @@ export interface IManagedResourceDiff {
 
 export interface IManagedResourceEvent {
   type: ManagedResourceEventType;
-  apiVersion: string;
   kind: string;
   id: string;
   application: string;

--- a/app/scripts/modules/core/src/managed/ManagedReader.ts
+++ b/app/scripts/modules/core/src/managed/ManagedReader.ts
@@ -11,7 +11,15 @@ import {
   IManagedResourceEvent,
 } from 'core/domain';
 
+const KIND_NAME_MATCHER = /.*\/(.*?)@/i;
 const RESOURCE_DIFF_LIST_MATCHER = /^(.*)\[(.*)\]$/i;
+
+export const getKindName = (kind: string) => {
+  const match = kind.match(KIND_NAME_MATCHER);
+  const extractedKind = match && match[1];
+
+  return extractedKind || kind;
+};
 
 export const getResourceKindForLoadBalancerType = (type: string) => {
   switch (type) {

--- a/app/scripts/modules/core/src/managed/managedResourceDecorators.ts
+++ b/app/scripts/modules/core/src/managed/managedResourceDecorators.ts
@@ -3,13 +3,13 @@ import { SETTINGS } from 'core/config';
 import { IServerGroup, ILoadBalancer, IManagedResourceSummary, ISecurityGroup } from 'core/domain';
 import { IMoniker } from 'core/naming';
 
-import { getResourceKindForLoadBalancerType } from './ManagedReader';
+import { getKindName, getResourceKindForLoadBalancerType } from './ManagedReader';
 
 const isMonikerEqual = (a: IMoniker, b: IMoniker) => a.app === b.app && a.stack === b.stack && a.detail === b.detail;
 
 const getResourcesOfKind = (application: Application, kinds: string[]) => {
   const resources: IManagedResourceSummary[] = application.managedResources.data.resources;
-  return resources.filter(({ kind }) => kinds.includes(kind));
+  return resources.filter(({ kind }) => kinds.includes(getKindName(kind)));
 };
 
 export const addManagedResourceMetadataToServerGroups = (application: Application) => {
@@ -45,7 +45,7 @@ export const addManagedResourceMetadataToLoadBalancers = (application: Applicati
   loadBalancers.forEach(loadBalancer => {
     const matchingResource = loadBalancerResources.find(
       ({ kind, moniker, locations: { account, regions } }) =>
-        kind === getResourceKindForLoadBalancerType(loadBalancer.loadBalancerType) &&
+        getKindName(kind) === getResourceKindForLoadBalancerType(loadBalancer.loadBalancerType) &&
         isMonikerEqual(moniker, loadBalancer.moniker) &&
         account === loadBalancer.account &&
         regions.some(({ name }) => name === loadBalancer.region),

--- a/app/scripts/modules/core/src/serverGroup/configure/common/serverGroupCommandBuilder.service.ts
+++ b/app/scripts/modules/core/src/serverGroup/configure/common/serverGroupCommandBuilder.service.ts
@@ -9,6 +9,7 @@ import { ISecurityGroupsByAccountSourceData } from 'core/securityGroup/securityG
 import { IRegion, IAggregatedAccounts } from 'core/account/AccountService';
 import { PROVIDER_SERVICE_DELEGATE, ProviderServiceDelegate } from 'core/cloudProvider';
 import { IPreferredInstanceType } from 'core/instance';
+import { getKindName } from 'core/managed';
 
 export interface IServerGroupCommandBuilderOptions {
   account: string;
@@ -147,7 +148,7 @@ export const setMatchingResourceSummary = (command: IServerGroupCommand) => {
   command.resourceSummary = (command.backingData.managedResources ?? []).find(
     resource =>
       !resource.isPaused &&
-      resource.kind === 'cluster' &&
+      getKindName(resource.kind) === 'cluster' &&
       resource.locations.regions.some(r => r.name === command.region) &&
       (resource.moniker.stack ?? '') === command.stack &&
       (resource.moniker.detail ?? '') === command.freeFormDetails &&


### PR DESCRIPTION
As part of trying to auto-generate OpenAPI schemas for resources, we're moving from a `kind` like `cluster` or `security-group` to a compound `kind` that includes both the concept of a 'group' and a version (so basically merging `apiVersion` and `kind`). This means kinds now look like `ec2/cluster@v1` or `ec2/security-group@v1`. We rely on `kind` in various places for matching infrastructure with a resource definition, so this PR attempts to get us ready for that change in a backwards-compatible way to avoid any temporary downtime/bad behavior.

In short, I'm adding a `getKindName()` function that tries to regex its way into returning what we were operating on before (the "name" part of the compound string). This means we can keep most of our code the same for now and only worry about the "group" and "version" parts of the string later when or if we care. Tested with the current API _and_ by hacking the reader to return stuff with the new kind format, seems to work fine.