### PR TITLE
feat(amazon/sharding): Enable server group sharding in deck

### DIFF
--- a/app/scripts/modules/amazon/src/help/amazon.help.ts
+++ b/app/scripts/modules/amazon/src/help/amazon.help.ts
@@ -57,6 +57,8 @@ const helpContents: { [key: string]: string } = {
     '(Optional) <b>Stack</b> is one of the core naming components of a cluster, used to create vertical stacks of dependent services for integration testing.',
   'aws.serverGroup.detail':
     '(Optional) <b>Detail</b> is a string of free-form alphanumeric characters and hyphens to describe any other variables.',
+  'aws.serverGroup.shard':
+    '(Optional) <b>Shard</b> is a string of alphanumeric characters to create another dimension for a cluster in addition to stack and detail',
   'aws.serverGroup.imageName':
     '(Required) <b>Image</b> is the deployable Amazon Machine Image. Images are restricted to the account and region selected.',
   'aws.serverGroup.legacyUdf': `<p>(Optional) <b>User Data Format</b> allows overriding of the format used when generating user data during deployment. The default format used is configured

--- a/app/scripts/modules/amazon/src/serverGroup/configure/ServerGroupShardingUtils.spec.ts
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/ServerGroupShardingUtils.spec.ts
@@ -1,0 +1,143 @@
+import { parse, toFreeformDetails } from './ServerGroupShardingUtils';
+
+describe('parse', () => {
+  it('should return empty shards for empty string', () => {
+    expect(parse('', 3)).toEqual({
+      shards: { x1: '', x2: '', x3: '' },
+      other: '',
+    });
+  });
+
+  it('should return empty shards for strings without shard info', () => {
+    expect(parse('foo-bar-baz', 3)).toEqual({
+      shards: { x1: '', x2: '', x3: '' },
+      other: 'foo-bar-baz',
+    });
+  });
+
+  it('should return empty shards for strings not starting with x\\d', () => {
+    expect(parse('foo-x1bar-baz', 3)).toEqual({
+      shards: { x1: '', x2: '', x3: '' },
+      other: 'foo-x1bar-baz',
+    });
+  });
+
+  it('should return empty shards for shard identifiers with hyphens', () => {
+    expect(parse('x1foo-bar-x2baz-other', 3)).toEqual({
+      shards: { x1: '', x2: '', x3: '' },
+      other: 'x1foo-bar-x2baz-other',
+    });
+  });
+
+  it('should return shards for string only with shards and no other details', () => {
+    expect(parse('x1foo-x2bar-x3baz', 3)).toEqual({
+      shards: { x1: 'foo', x2: 'bar', x3: 'baz' },
+      other: '',
+    });
+  });
+
+  it('should return shards for string that begin with a hyphen', () => {
+    expect(parse('-x1foo-x2bar-x3baz', 3)).toEqual({
+      shards: { x1: 'foo', x2: 'bar', x3: 'baz' },
+      other: '',
+    });
+  });
+
+  it('should return shards and other details by ignoring shards with identifier x0', () => {
+    expect(parse('x1foo-x0bar', 3)).toEqual({
+      shards: { x1: 'foo', x2: '', x3: '' },
+      other: 'x0bar',
+    });
+  });
+
+  it('should return shards and other details by ignoring shards with identifier x0 and prepend to other', () => {
+    expect(parse('x0foo-x1bar-x2baz-other', 3)).toEqual({
+      shards: { x1: 'bar', x2: 'baz', x3: '' },
+      other: 'x0foo-other',
+    });
+  });
+
+  it('should return shards and other details for string with shards and hyphenated other details', () => {
+    expect(parse('x1foo-bar-baz', 3)).toEqual({
+      shards: { x1: 'foo', x2: '', x3: '' },
+      other: 'bar-baz',
+    });
+  });
+
+  it('should return shards and other details for shards specified in different order', () => {
+    expect(parse('x2bar-x1foo-x3baz-other', 3)).toEqual({
+      shards: { x1: 'foo', x2: 'bar', x3: 'baz' },
+      other: 'other',
+    });
+  });
+
+  it('should return shards and other details for shards with optional identifiers', () => {
+    expect(parse('x1foo-x3baz-long-other', 3)).toEqual({
+      shards: { x1: 'foo', x2: '', x3: 'baz' },
+      other: 'long-other',
+    });
+  });
+
+  it('should return shards and other details for shards that exceed the specified dimensions', () => {
+    expect(parse('x1foo-x2bar-x3baz-x4qux-long-other', 3)).toEqual({
+      shards: { x1: 'foo', x2: 'bar', x3: 'baz' },
+      other: 'x4qux-long-other',
+    });
+  });
+});
+
+describe('toFreeformDetails', () => {
+  it('should return empty string', () => {
+    expect(
+      toFreeformDetails({
+        shards: {},
+        other: '',
+      }),
+    ).toBe('');
+  });
+
+  it('should return other details when no shards are present', () => {
+    expect(
+      toFreeformDetails({
+        shards: {},
+        other: 'foo-bar',
+      }),
+    ).toBe('foo-bar');
+  });
+
+  it('should join shards and ignore other details when not present', () => {
+    expect(
+      toFreeformDetails({
+        shards: {
+          x1: 'foo',
+          x2: 'bar',
+        },
+        other: '',
+      }),
+    ).toBe('x1foo-x2bar');
+  });
+
+  it('should join the only available shard and other details', () => {
+    expect(
+      toFreeformDetails({
+        shards: {
+          x1: '',
+          x2: 'bar',
+        },
+        other: 'other',
+      }),
+    ).toBe('x2bar-other');
+  });
+
+  it('should join shards and other details', () => {
+    expect(
+      toFreeformDetails({
+        shards: {
+          x1: 'foo',
+          x2: 'bar',
+        },
+        other: 'other',
+      }),
+    ).toBe('x1foo-x2bar-other');
+  });
+});

--- a/app/scripts/modules/amazon/src/serverGroup/configure/ServerGroupShardingUtils.ts
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/ServerGroupShardingUtils.ts
@@ -1,0 +1,110 @@
+import { chain, isEmpty, partition, sortBy, times, toPairs } from 'lodash';
+
+export interface ParsedShards {
+  shards: { [shardIndex: string]: string };
+  other: string;
+}
+
+function createEmpty(dimensions: number, other = ''): ParsedShards {
+  const result: ParsedShards = { shards: {}, other };
+  times(dimensions).forEach(index => (result.shards[`x${index + 1}`] = ''));
+
+  return result;
+}
+
+/**
+ * Given a free form details string, this function parses, validates and returns the shards along with remaining
+ * detail string. This function also accepts a `dimension` param that restricts the number of accepted shard
+ * identifiers.
+ *
+ * freeFormDetails = 'x1Shard1-x2Shard2-x3Shard3-Other', dimensions = 3
+ * Returns: {shards: {x1: 'Shard1', x2: 'Shard2', x3: 'Shard3'}, other: 'Other'}
+ *
+ * freeFormDetails = 'x2Shard2-x1Shard1-x3Shard3-Other', dimensions = 2
+ * Returns: {shards: {x1: 'Shard1', x2: 'Shard2'}, other: 'x3Shard3-Other'}
+ */
+export function parse(freeFormDetails: string, dimensions = 2): ParsedShards {
+  // Valid shard strings must begin with x\d or -x\d.
+  if (!freeFormDetails.match(/^-?x\d/)) {
+    return createEmpty(dimensions, freeFormDetails);
+  }
+
+  // Prepend with a '-' and split it so that potentialShards look like the following
+  // [ "" or "-", "1", "Shard1", "2", "Shard2", "3", "Shard3-Other"].
+  const potentialShards = `-${freeFormDetails}`.split(/-x(\d)/);
+
+  // Remove the empty first entry.
+  potentialShards.shift();
+
+  let shards: Array<[number, string]> = [];
+  let other = '';
+  let i = 0;
+
+  // By the end of this loop, we're trying to group the pairs of shard index and shard identifier so that `shards`
+  // looks like [[1, 'Shard1'], [2, 'Shard2'], [3, 'Shard3']] and `other` looks like 'Other'.
+  while (i < potentialShards.length) {
+    // NOTE: Due to how the regular expression is set up, we are guaranteed to have an even number of entries
+    // in potentialShards.
+
+    if (i === potentialShards.length - 2 && potentialShards[i + 1].match(/-/)) {
+      // The last shard entry can potentially contain 'other' details separated by a hyphen. If that is the case, then
+      // they need to be split.
+      const splitIndex = potentialShards[i + 1].indexOf('-');
+      shards.push([parseInt(potentialShards[i]), potentialShards[i + 1].substring(0, splitIndex)]);
+      other = potentialShards[i + 1].substring(splitIndex + 1);
+    } else if (potentialShards[i + 1].indexOf('-') > -1) {
+      // If there are hyphens within a shard identifier, then it is an invalid format and stop processing further.
+      return createEmpty(3, freeFormDetails);
+    } else {
+      shards.push([parseInt(potentialShards[i]), potentialShards[i + 1]]);
+    }
+    i = i + 2;
+  }
+
+  // It is possible for the shards to be not listed in order, so sort them here.
+  shards = sortBy(shards, entry => entry[0]);
+
+  // In the following lines, we are restricting the number of shards to the dimensions param and finally constructing
+  // the output in the desired format.
+  return partition(
+    shards,
+    // Partition the list such that shard indices lesser than the `dimensions` value are included in the
+    // first partition and rest in the second.
+    // NOTE: 0 isn't an accepted shard index, so we're filtering out that as well.
+    entry => entry[0] !== 0 && entry[0] <= dimensions,
+  ).reduce((acc: ParsedShards, entries: Array<[number, string]>, index: number) => {
+    if (index === 0) {
+      // These are the shard entries within the accepted dimensions, so add them to `shards` property.
+      entries.forEach(entry => {
+        acc.shards[`x${entry[0]}`] = entry[1];
+      });
+    } else {
+      // These are the shard entries that go beyond the accepted dimensions, so combine them and set in `other`
+      // property.
+      const other = !isEmpty(entries)
+        ? chain(entries)
+            .map(entry => `x${entry[0]}${entry[1]}`)
+            .flatMap()
+            .join('-')
+        : null;
+
+      if (other) {
+        acc.other = !isEmpty(acc.other) ? `${other}-${acc.other}` : `${other}`;
+      }
+    }
+    return acc;
+  }, createEmpty(dimensions, other));
+}
+
+export function toFreeformDetails(shardObj: ParsedShards): string {
+  const shardString = toPairs(shardObj.shards)
+    .filter(([_, identifier]) => !isEmpty(identifier))
+    .map(([index, identifier]) => `${index}${identifier}`)
+    .join('-');
+
+  return isEmpty(shardString)
+    ? shardObj.other
+    : isEmpty(shardObj.other)
+    ? shardString
+    : `${shardString}-${shardObj.other}`;
+}

--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/ServerGroupBasicSettings.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/ServerGroupBasicSettings.tsx
@@ -21,6 +21,7 @@ import { SubnetSelectField } from 'amazon/subnet';
 
 import { AmazonImageSelectInput } from '../../AmazonImageSelectInput';
 import { IAmazonServerGroupCommand } from '../../serverGroupConfiguration.service';
+import ServerGroupDetailsField from './fields/ServerGroupDetailsField';
 
 const isExpressionLanguage = (field: string) => field && field.includes('${');
 const isStackPattern = (stack: string) =>
@@ -170,13 +171,6 @@ export class ServerGroupBasicSettings
     values.clusterChanged(values);
   };
 
-  private freeFormDetailsChanged = (freeFormDetails: string) => {
-    const { setFieldValue, values } = this.props.formik;
-    values.freeFormDetails = freeFormDetails; // have to do it here to make sure it's done before calling values.clusterChanged
-    setFieldValue('freeFormDetails', freeFormDetails);
-    values.clusterChanged(values);
-  };
-
   public componentWillReceiveProps(nextProps: IServerGroupBasicSettingsProps) {
     this.setState(this.getStateFromProps(nextProps));
   }
@@ -266,26 +260,7 @@ export class ServerGroupBasicSettings
             </div>
           </div>
         )}
-        <div className="form-group">
-          <div className="col-md-3 sm-label-right">
-            Detail <HelpField id="aws.serverGroup.detail" />
-          </div>
-          <div className="col-md-7">
-            <input
-              type="text"
-              className="form-control input-sm no-spel"
-              value={values.freeFormDetails}
-              onChange={e => this.freeFormDetailsChanged(e.target.value)}
-            />
-          </div>
-        </div>
-        {errors.freeFormDetails && (
-          <div className="form-group row slide-in">
-            <div className="col-sm-9 col-sm-offset-2 error-message">
-              <span>{errors.freeFormDetails}</span>
-            </div>
-          </div>
-        )}
+        <ServerGroupDetailsField formik={formik} />
         {values.viewState.imageSourceText && (
           <div className="form-group">
             <div className="col-md-3 sm-label-right">Image Source</div>

--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/fields/ServerGroupDetailsField.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/fields/ServerGroupDetailsField.tsx
@@ -1,0 +1,229 @@
+import React, { SyntheticEvent, useState, useCallback } from 'react';
+import { FormikProps } from 'formik';
+import { times } from 'lodash';
+
+import { HelpField, SETTINGS } from '@spinnaker/core';
+import { IAmazonServerGroupCommand } from '../../../serverGroupConfiguration.service';
+import { ParsedShards, parse, toFreeformDetails } from '../../../ServerGroupShardingUtils';
+
+const SUPPORTED_SHARD_DIMENSION_COUNT = SETTINGS.feature.shards ? 2 : 0;
+
+const removeSPELExpressions = (field: string) => field.split(/\$\{.*\}/).join('');
+
+const validateShard = (shard: string) =>
+  /^[a-zA-Z0-9]*$/.test(removeSPELExpressions(shard))
+    ? null
+    : 'Only alpha-numeric characters are allowed in the Shard field.';
+
+const validateOtherDetails = (detail: string) => {
+  const detailWithoutSPEL = removeSPELExpressions(detail);
+
+  if (!/^([a-zA-Z0-9._-])*$/.test(detailWithoutSPEL)) {
+    return 'Only dot(.), underscore(_), and dash(-) special characters are allowed in the Detail field.';
+  }
+
+  if (/-x\d/.test(`-${detailWithoutSPEL}`)) {
+    return 'Tokens of the form `-x\\d` cannot be used in the Detail field.';
+  }
+
+  return null;
+};
+
+interface LocalError {
+  error: string | null;
+  value: string | null;
+}
+/**
+ * This react hook is expected to listen to value changes and validate them. If there are no errors, then
+ * it will call the `successHandler`. If not, it will store error & value locally and expose it to the
+ * component without calling the `successHandler`. This is needed in components that merely render values that are
+ * completely controlled by their parent but wishes not to update the parent when there is an error.
+ *
+ * @param validator - A function that accepts the new value and returns a string if there is an error.
+ * @param successHandler - A function that is called by the hook when a new valid value is available.
+ * @param errorHandler - A function that is called by the hook when a new invalid value is available.
+ *
+ * Why keep track of a local error state?
+ *
+ * Values for `shards` and `other` are not stored as individual fields in the server group. Instead they are embedded
+ * into `freeformDetails` field along with other details. See `serverGroupShardingUtils` for more details on the
+ * format of the data.
+ *
+ * When the user is editing the value of this field, it is possible to introduce incorrect values such as hyphens,
+ * spaces, dots etc. These incorrect values will get combined to form the consolidated value for `freeformDetails`
+ * field. This consolidated value will be parsed again when `ServerGroupDetailsField` is re-rendered, but the parsing
+ * will fail this time since the consolidated value does not conform to the expected format. This will result in a
+ * state where the error cannot be shown to the user and won't be provided a way to fix it.
+ *
+ * Keeping a local error state allows us to bail out from informing the parent about the change and provide the user
+ * a way to fix the error.
+ */
+function useLocalError(
+  validator: (value: string) => string | null,
+  successHandler: (value: string) => void,
+  errorHandler: (error: string) => void,
+): [LocalError | null, (value: string) => void] {
+  const [localError, setLocalError] = useState<LocalError>(null);
+  const changeHandler = useCallback(
+    (value: string) => {
+      const error = validator(value);
+      if (!error) {
+        successHandler(value);
+        setLocalError(null);
+      } else {
+        setLocalError({ error, value });
+        errorHandler(error);
+      }
+    },
+    [validator, successHandler],
+  );
+
+  return [localError, changeHandler];
+}
+
+interface ShardFieldProps {
+  shardIndex: number;
+  value: string;
+  onChange: (shardIndex: number, value: string) => void;
+  onError: (error: string) => void;
+}
+function ShardField({ shardIndex, value, onChange, onError }: ShardFieldProps) {
+  const [localError, changeHandler] = useLocalError(
+    validateShard,
+    (value: string) => {
+      onChange(shardIndex, value);
+    },
+    onError,
+  );
+
+  const onValueChange = useCallback(
+    (e: SyntheticEvent) => {
+      changeHandler((e.target as HTMLInputElement).value);
+    },
+    [changeHandler],
+  );
+
+  return (
+    <>
+      <div className="form-group">
+        <div className="col-md-3 sm-label-right">
+          Shard {shardIndex} <HelpField id="aws.serverGroup.shard" />
+        </div>
+        <div className="col-md-7">
+          <input
+            type="text"
+            className="form-control input-sm no-spel"
+            // When there is an error, the parent wasn't informed of the change, so use the value from local error
+            // state.
+            value={localError ? localError.value : value}
+            onChange={onValueChange}
+          />
+        </div>
+      </div>
+      {localError && (
+        <div className="form-group row slide-in">
+          <div className="col-md-7 col-md-offset-3 error-message">
+            <span>{localError.error}</span>
+          </div>
+          <span></span>
+        </div>
+      )}
+    </>
+  );
+}
+
+export interface OtherDetailsFieldProps {
+  value: string;
+  onChange: (value: string) => void;
+  onError: (error: string) => void;
+}
+function OtherDetailsField({ value, onChange, onError }: OtherDetailsFieldProps) {
+  const [localError, changeHandler] = useLocalError(
+    validateOtherDetails,
+    (value: string) => {
+      onChange(value);
+    },
+    onError,
+  );
+
+  const onValueChange = useCallback(
+    (e: SyntheticEvent) => {
+      changeHandler((e.target as HTMLInputElement).value);
+    },
+    [changeHandler],
+  );
+
+  return (
+    <>
+      <div className="form-group">
+        <div className="col-md-3 sm-label-right">
+          Detail <HelpField id="aws.serverGroup.detail" />
+        </div>
+        <div className="col-md-7">
+          <input
+            className="form-control input-sm no-spel"
+            type="text"
+            // When there is an error, the parent wasn't informed of the change, so use the value from local error
+            // state.
+            value={localError ? localError.value : value}
+            onChange={onValueChange}
+          />
+        </div>
+      </div>
+      {localError && (
+        <div className="form-group row slide-in">
+          <div className="col-md-7 col-md-offset-3 error-message">
+            <span>{localError.error}</span>
+          </div>
+          <span></span>
+        </div>
+      )}
+    </>
+  );
+}
+
+export interface DetailsFieldProps {
+  formik: FormikProps<IAmazonServerGroupCommand>;
+}
+export default function ServerGroupDetailsField({ formik }: DetailsFieldProps) {
+  const { values, setFieldValue, setFieldError } = formik;
+  const parsed = parse(values.freeFormDetails, SUPPORTED_SHARD_DIMENSION_COUNT);
+
+  const updateFreeformDetails = (shardsObj: ParsedShards) => {
+    // have to do it here to make sure it's done before calling values.clusterChanged
+    values.freeFormDetails = toFreeformDetails(shardsObj);
+    setFieldValue('freeFormDetails', values.freeFormDetails);
+    values.clusterChanged(values);
+  };
+
+  const errorHandler = (error: string) => setFieldError('freeFormDetails', error);
+  const detailsChange = (other: string) =>
+    updateFreeformDetails({
+      ...parsed,
+      other,
+    });
+
+  const shardValueChange = (shardIndex: number, value: string) =>
+    updateFreeformDetails({
+      ...parsed,
+      shards: {
+        ...parsed.shards,
+        [`x${shardIndex}`]: value,
+      },
+    });
+
+  return (
+    <>
+      <OtherDetailsField value={parsed.other} onChange={detailsChange} onError={errorHandler} />
+      {times(SUPPORTED_SHARD_DIMENSION_COUNT).map(index => (
+        <ShardField
+          shardIndex={index + 1}
+          key={index}
+          value={parsed.shards?.[`x${index + 1}`] ?? ''}
+          onChange={shardValueChange}
+          onError={errorHandler}
+        />
+      ))}
+    </>
+  );
+}

--- a/app/scripts/modules/core/src/config/settings.ts
+++ b/app/scripts/modules/core/src/config/settings.ts
@@ -46,6 +46,7 @@ export interface IFeatures {
   pipelineTemplates?: boolean;
   quietPeriod?: boolean;
   roscoMode?: boolean;
+  shards?: boolean;
   slack?: boolean;
   snapshots?: boolean;
   travis?: boolean;

--- a/app/scripts/modules/core/src/serverGroup/configure/common/serverGroupCommandBuilder.service.ts
+++ b/app/scripts/modules/core/src/serverGroup/configure/common/serverGroupCommandBuilder.service.ts
@@ -116,6 +116,9 @@ export interface IServerGroupCommand {
   resourceSummary?: IManagedResourceSummary;
   securityGroups: string[];
   selectedProvider: string;
+  shards: {
+    [shardIndex: string]: string;
+  };
   source?: {
     asgName: string;
   };

--- a/settings.js
+++ b/settings.js
@@ -31,6 +31,7 @@ var managedServiceAccountsEnabled = process.env.MANAGED_SERVICE_ACCOUNTS_ENABLED
 var managedResourcesEnabled = process.env.MANAGED_RESOURCES_ENABLED === 'true';
 var onDemandClusterThreshold = process.env.ON_DEMAND_CLUSTER_THRESHOLD || '350';
 var reduxLoggerEnabled = process.env.REDUX_LOGGER === 'true';
+var shardsEnabled = process.env.SHARDS_ENABLED === 'true';
 var templatesEnabled = process.env.TEMPLATES_ENABLED === 'true';
 var useClassicFirewallLabels = process.env.USE_CLASSIC_FIREWALL_LABELS === 'true';
 var functionsEnabled = process.env.FUNCTIONS_ENABLED === 'true' ? true : false;
@@ -95,6 +96,7 @@ window.spinnakerSettings = {
     pipelines: true,
     quietPeriod: false,
     roscoMode: false,
+    shard: shardsEnabled,
     slack: false,
     snapshots: false,
     travis: false,


### PR DESCRIPTION
### What is the sharding feature?

Spinnaker currently provides a way to create clusters via `stack` and `details` fields. The sharding feature allows us to potentially create more dimensions for clusters.

### How is it implemented?

This feature re-uses the `freeformDetails` field and introduces a new format to specify the sharding identifiers. The format is `x1shard1-x2shard2-other`. In this example `shard1` and `shard2` are the new shard identifiers and `other` will continue to be used as how `details` was used earlier. At the moment we are limiting the additional number of shards to 2. However this could be easily changed in future to include additional ones. This format is completely hidden away from the user as deck will show two new shard fields in pipeline configuration flow and server group clone flow.

The PR is split into 2 commits and it would be easier to review them separately. The first commit includes a new utils module that helps for parsing and forming the `freeformDetails` string. The second commit includes new form fields that accept shard identifiers.