### PR TITLE
feat(md): Types and new data source for environments

### DIFF
--- a/app/scripts/modules/core/src/domain/IManagedEntity.ts
+++ b/app/scripts/modules/core/src/domain/IManagedEntity.ts
@@ -59,11 +59,6 @@ export interface IManagedArtifactSummary {
   versions: IManagedArtifactVersion[];
 }
 
-export interface IManagedApplicationEnvironmentsSummary extends IManagedApplicationSummary {
-  environments: IManagedEnviromentSummary[];
-  artifacts: IManagedArtifactSummary[];
-}
-
 export interface IManagedApplicationEntities {
   resources: IManagedResourceSummary[];
   environments: IManagedEnviromentSummary[];

--- a/app/scripts/modules/core/src/domain/IManagedEntity.ts
+++ b/app/scripts/modules/core/src/domain/IManagedEntity.ts
@@ -24,11 +24,59 @@ export interface IManagedResourceSummary {
   };
 }
 
-export interface IManagedApplicationSummary {
+export interface IManagedEnviromentSummary {
+  name: string;
+  resources: string[];
+  artifacts: Array<{
+    name: string;
+    type: string;
+    statuses: string[];
+    versions: {
+      current?: string;
+      deploying?: string;
+      pending: string[];
+      approved: string[];
+      previous: string[];
+      vetoed: string[];
+    };
+  }>;
+}
+
+export interface IManagedArtifactVersion {
+  version: string;
+  environments: Array<{
+    name: string;
+    state: string;
+    deployedAt?: string;
+    replacedAt?: string;
+    replacedBy?: string;
+  }>;
+}
+
+export interface IManagedArtifactSummary {
+  name: string;
+  type: string;
+  versions: IManagedArtifactVersion[];
+}
+
+export interface IManagedApplicationEnvironmentsSummary extends IManagedApplicationSummary {
+  environments: IManagedEnviromentSummary[];
+  artifacts: IManagedArtifactSummary[];
+}
+
+export interface IManagedApplicationEntities {
+  resources: IManagedResourceSummary[];
+  environments: IManagedEnviromentSummary[];
+  artifacts: IManagedArtifactSummary[];
+}
+
+export type IManagedApplicationSummary<T extends keyof IManagedApplicationEntities = 'resources'> = Pick<
+  IManagedApplicationEntities,
+  T
+> & {
   applicationPaused: boolean;
   hasManagedResources: boolean;
-  resources: IManagedResourceSummary[];
-}
+};
 
 export interface IManagedResource {
   managedResourceSummary?: IManagedResourceSummary;

--- a/app/scripts/modules/core/src/domain/IManagedEntity.ts
+++ b/app/scripts/modules/core/src/domain/IManagedEntity.ts
@@ -59,7 +59,7 @@ export interface IManagedArtifactSummary {
   versions: IManagedArtifactVersion[];
 }
 
-export interface IManagedApplicationEntities {
+interface IManagedApplicationEntities {
   resources: IManagedResourceSummary[];
   environments: IManagedEnviromentSummary[];
   artifacts: IManagedArtifactSummary[];

--- a/app/scripts/modules/core/src/managed/ManagedReader.ts
+++ b/app/scripts/modules/core/src/managed/ManagedReader.ts
@@ -84,7 +84,7 @@ export class ManagedReader {
   public static getApplicationSummary(app: string): IPromise<IManagedApplicationSummary<'resources'>> {
     return API.one('managed')
       .one('application', app)
-      .withParams({ includeDetails: true, entities: 'resources' })
+      .withParams({ entities: 'resources' })
       .get()
       .then(this.decorateResources);
   }
@@ -94,7 +94,7 @@ export class ManagedReader {
   ): IPromise<IManagedApplicationSummary<'resources' | 'artifacts' | 'environments'>> {
     return API.one('managed')
       .one('application', app)
-      .withParams({ includeDetails: true, entities: ['resources', 'artifacts', 'environments'] })
+      .withParams({ entities: ['resources', 'artifacts', 'environments'] })
       .get()
       .then(this.decorateResources);
   }

--- a/app/scripts/modules/core/src/managed/ManagedReader.ts
+++ b/app/scripts/modules/core/src/managed/ManagedReader.ts
@@ -69,22 +69,34 @@ const transformManagedResourceDiff = (diff: IManagedResourceEventHistoryResponse
   }, {} as IManagedResourceDiff);
 
 export class ManagedReader {
-  public static getApplicationSummary(app: string): IPromise<IManagedApplicationSummary> {
+  private static decorateResources(response: IManagedApplicationSummary) {
+    // Individual resources don't update their status when an application is paused/resumed,
+    // so for now let's swap to a PAUSED status and keep things simpler in downstream components.
+    if (response.applicationPaused) {
+      response.resources.forEach(resource => (resource.status = ManagedResourceStatus.PAUSED));
+    }
+
+    response.resources.forEach(resource => (resource.isPaused = resource.status === ManagedResourceStatus.PAUSED));
+
+    return response;
+  }
+
+  public static getApplicationSummary(app: string): IPromise<IManagedApplicationSummary<'resources'>> {
     return API.one('managed')
       .one('application', app)
-      .withParams({ includeDetails: true })
+      .withParams({ includeDetails: true, entities: 'resources' })
       .get()
-      .then((response: IManagedApplicationSummary) => {
-        // Individual resources don't update their status when an application is paused/resumed,
-        // so for now let's swap to a PAUSED status and keep things simpler in downstream components.
-        if (response.applicationPaused) {
-          response.resources.forEach(resource => (resource.status = ManagedResourceStatus.PAUSED));
-        }
+      .then(this.decorateResources);
+  }
 
-        response.resources.forEach(resource => (resource.isPaused = resource.status === ManagedResourceStatus.PAUSED));
-
-        return response;
-      });
+  public static getEnvironmentsSummary(
+    app: string,
+  ): IPromise<IManagedApplicationSummary<'resources' | 'artifacts' | 'environments'>> {
+    return API.one('managed')
+      .one('application', app)
+      .withParams({ includeDetails: true, entities: ['resources', 'artifacts', 'environments'] })
+      .get()
+      .then(this.decorateResources);
   }
 
   public static getResourceHistory(resourceId: string): IPromise<IManagedResourceEventHistory> {

--- a/app/scripts/modules/core/src/managed/managed.dataSource.ts
+++ b/app/scripts/modules/core/src/managed/managed.dataSource.ts
@@ -3,7 +3,7 @@ import { IQService, module } from 'angular';
 import { noop } from 'core/utils';
 import { SETTINGS } from 'core/config/settings';
 import { ApplicationDataSourceRegistry } from 'core/application/service/ApplicationDataSourceRegistry';
-import { Application } from 'core/application';
+import { Application, DELIVERY_KEY } from 'core/application';
 import { IManagedApplicationSummary } from 'core/domain';
 import { ManagedReader } from './ManagedReader';
 import {
@@ -34,6 +34,14 @@ module(MANAGED_RESOURCES_DATA_SOURCE, []).run([
       application.securityGroups.ready().then(() => addManagedResourceMetadataToSecurityGroups(application), noop);
     };
 
+    const loadEnvironments = (application: Application) => {
+      return ManagedReader.getEnvironmentsSummary(application.name);
+    };
+
+    const addEnvironments = (_application: Application, data: IManagedApplicationSummary) => {
+      return $q.when(data);
+    };
+
     ApplicationDataSourceRegistry.registerDataSource({
       key: 'managedResources',
       visible: false,
@@ -41,6 +49,25 @@ module(MANAGED_RESOURCES_DATA_SOURCE, []).run([
       onLoad: addManagedResources,
       afterLoad: addManagedMetadataToResources,
       defaultData: { applicationPaused: false, hasManagedResources: false, resources: [] },
+    });
+
+    ApplicationDataSourceRegistry.registerDataSource({
+      key: 'environments',
+      sref: '.environments',
+      category: DELIVERY_KEY,
+      optional: true,
+      optIn: true,
+      hidden: true,
+      icon: 'fa fa-fw fa-xs fa-code-branch',
+      loader: loadEnvironments,
+      onLoad: addEnvironments,
+      defaultData: {
+        applicationPaused: false,
+        hasManagedResources: false,
+        environments: [],
+        artifacts: [],
+        resources: [],
+      },
     });
   },
 ]);

--- a/app/scripts/modules/core/src/managed/managed.dataSource.ts
+++ b/app/scripts/modules/core/src/managed/managed.dataSource.ts
@@ -38,7 +38,10 @@ module(MANAGED_RESOURCES_DATA_SOURCE, []).run([
       return ManagedReader.getEnvironmentsSummary(application.name);
     };
 
-    const addEnvironments = (_application: Application, data: IManagedApplicationSummary) => {
+    const addEnvironments = (
+      _application: Application,
+      data: IManagedApplicationSummary<'resources' | 'artifacts' | 'environments'>,
+    ) => {
       return $q.when(data);
     };
 


### PR DESCRIPTION
Opening a new PR for #8020 which got unintentionally merged (then reverted).

Depends on https://github.com/spinnaker/keel/pull/848

The types are probably the most interesting thing in this PR. There's a fair amount of duplication in different views of an entity, for example:

 * `environments` vs `artifact.version.environments`
    * `environments`: a light summary of all resources and all artifacts related to those resources
    * `artifact.version.environments`: a view of each environment as it relates to the artifact's specific version (i.e. time that version was deployed in that specific environment)
* `artifacts` vs `environment.artifacts` vs `resource.artifact`
    * `artifacts`: summary of all artifacts and all versions also including a join between a specific version and it's environment
    * `environment.artifacts`: a view of each artifact that is in a given environment (i.e. approved, vetoed)
    * `resource.artifact`: (not yet present) a view of a specific artifact as it relates to the resource (i.e. deploying, pending)

The shapes or mostly different, so I'm not sure if it's even useful to have common attributes between the types. I also don't know if there's a sane way to name them.

`optional` and `optIn` mean this datasource is only enabled if explicitly enabled.

`hidden` means this (for now) is not yet exposed in the application config UI.