### PR TITLE
Eslint rule import relatively within subpackage

### DIFF
--- a/app/scripts/modules/amazon/src/domain/IAmazonHealth.ts
+++ b/app/scripts/modules/amazon/src/domain/IAmazonHealth.ts
@@ -1,6 +1,6 @@
 import { IHealth } from '@spinnaker/core';
 
-import { ITargetGroup } from 'amazon/domain';
+import { ITargetGroup } from './IAmazonLoadBalancer';
 
 export interface IAmazonHealth extends IHealth {
   targetGroups: ITargetGroup[];

--- a/app/scripts/modules/amazon/src/domain/IAmazonLoadBalancerSourceData.ts
+++ b/app/scripts/modules/amazon/src/domain/IAmazonLoadBalancerSourceData.ts
@@ -1,6 +1,6 @@
 import { ILoadBalancerSourceData } from '@spinnaker/core';
 
-import { IListenerAction, NLBListenerProtocol } from 'amazon/domain';
+import { IListenerAction, NLBListenerProtocol } from './IAmazonLoadBalancer';
 
 import { IListenerRule } from './IAmazonLoadBalancer';
 

--- a/app/scripts/modules/amazon/src/domain/IAmazonServerGroup.ts
+++ b/app/scripts/modules/amazon/src/domain/IAmazonServerGroup.ts
@@ -1,6 +1,7 @@
 import { IAccountDetails, IServerGroup, IAsg } from '@spinnaker/core';
 
-import { ISuspendedProcess, IScalingPolicyView } from 'amazon/domain';
+import { IScalingPolicyView } from './IAmazonScalingPolicy';
+import { ISuspendedProcess } from './IScalingProcess';
 
 import { IScalingPolicy } from './IScalingPolicy';
 

--- a/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/targetTracking/upsertTargetTracking.controller.ts
+++ b/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/targetTracking/upsertTargetTracking.controller.ts
@@ -7,7 +7,7 @@ import { IModalServiceInstance } from 'angular-ui-bootstrap';
 import { Application, IServerGroup, TaskMonitor } from '@spinnaker/core';
 
 import { ITargetTrackingConfiguration, ITargetTrackingPolicy } from 'amazon/domain';
-import { IUpsertScalingPolicyCommand, ScalingPolicyWriter } from 'amazon/serverGroup';
+import { IUpsertScalingPolicyCommand, ScalingPolicyWriter } from '../ScalingPolicyWriter';
 
 export type MetricType = 'custom' | 'predefined';
 

--- a/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/upsert/alarm/metricSelector.component.ts
+++ b/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/upsert/alarm/metricSelector.component.ts
@@ -5,7 +5,7 @@ import { Subject } from 'rxjs';
 
 import { CloudMetricsReader, ICloudMetricDescriptor, IServerGroup, IMetricAlarmDimension } from '@spinnaker/core';
 
-import { IConfigurableMetric } from 'amazon/serverGroup';
+import { IConfigurableMetric } from '../../ScalingPolicyWriter';
 import { AWSProviderSettings } from 'amazon/aws.settings';
 import { NAMESPACES } from './namespaces';
 

--- a/app/scripts/modules/cloudfoundry/src/domain/ICloudFoundryAccount.ts
+++ b/app/scripts/modules/cloudfoundry/src/domain/ICloudFoundryAccount.ts
@@ -1,6 +1,7 @@
 import { IAccountDetails } from '@spinnaker/core';
 
-import { ICloudFoundryDomain, ICloudFoundrySpace } from 'cloudfoundry/domain';
+import { ICloudFoundryDomain } from './ICloudFoundryLoadBalancer';
+import { ICloudFoundrySpace } from './ICloudFoundrySpace';
 
 export interface ICloudFoundryAccount extends IAccountDetails {
   domains?: ICloudFoundryDomain[];

--- a/app/scripts/modules/cloudfoundry/src/domain/ICloudFoundryCluster.ts
+++ b/app/scripts/modules/cloudfoundry/src/domain/ICloudFoundryCluster.ts
@@ -1,4 +1,4 @@
-import { ICloudFoundryServerGroup } from 'cloudfoundry/domain';
+import { ICloudFoundryServerGroup } from './ICloudFoundryServerGroup';
 
 export interface ICloudFoundryCluster {
   name: string;

--- a/app/scripts/modules/cloudfoundry/src/domain/ICloudFoundryDroplet.ts
+++ b/app/scripts/modules/cloudfoundry/src/domain/ICloudFoundryDroplet.ts
@@ -1,4 +1,4 @@
-import { ICloudFoundrySpace } from 'cloudfoundry/domain';
+import { ICloudFoundrySpace } from './ICloudFoundrySpace';
 
 export interface ICloudFoundryDroplet {
   id: string;

--- a/app/scripts/modules/cloudfoundry/src/domain/ICloudFoundryLoadBalancer.ts
+++ b/app/scripts/modules/cloudfoundry/src/domain/ICloudFoundryLoadBalancer.ts
@@ -1,6 +1,7 @@
 import { ILoadBalancer, ILoadBalancerUpsertCommand } from '@spinnaker/core';
 
-import { ICloudFoundryOrganization, ICloudFoundrySpace, ICloudFoundryServerGroup } from 'cloudfoundry/domain';
+import { ICloudFoundryOrganization, ICloudFoundrySpace } from './ICloudFoundrySpace';
+import { ICloudFoundryServerGroup } from './ICloudFoundryServerGroup';
 
 export interface ICloudFoundryDomain {
   id: string;

--- a/app/scripts/modules/cloudfoundry/src/domain/ICloudFoundryServerGroup.ts
+++ b/app/scripts/modules/cloudfoundry/src/domain/ICloudFoundryServerGroup.ts
@@ -1,6 +1,7 @@
 import { IServerGroup } from '@spinnaker/core';
 
-import { ICloudFoundrySpace, ICloudFoundryDroplet } from 'cloudfoundry/domain';
+import { ICloudFoundrySpace } from './ICloudFoundrySpace';
+import { ICloudFoundryDroplet } from './ICloudFoundryDroplet';
 import { ICloudFoundryInstance } from './ICloudFoundryInstance';
 
 export interface ICloudFoundryServerGroup extends IServerGroup {

--- a/app/scripts/modules/cloudfoundry/src/presentation/pipeline/stages/CloudfoundryAsgStageConfig.tsx
+++ b/app/scripts/modules/cloudfoundry/src/presentation/pipeline/stages/CloudfoundryAsgStageConfig.tsx
@@ -11,7 +11,7 @@ import {
   StageConfigField,
 } from '@spinnaker/core';
 
-import { AccountRegionClusterSelector } from 'cloudfoundry/presentation';
+import { AccountRegionClusterSelector } from '../../widgets/accountRegionClusterSelector';
 
 export interface ICloudfoundryAsgStageConfigState {
   accounts: IAccount[];

--- a/app/scripts/modules/cloudfoundry/src/presentation/pipeline/stages/CloudfoundryLoadBalancersStageConfig.tsx
+++ b/app/scripts/modules/cloudfoundry/src/presentation/pipeline/stages/CloudfoundryLoadBalancersStageConfig.tsx
@@ -14,7 +14,8 @@ import {
   StageConstants,
 } from '@spinnaker/core';
 
-import { AccountRegionClusterSelector, Routes } from 'cloudfoundry/presentation';
+import { AccountRegionClusterSelector } from '../../widgets/accountRegionClusterSelector';
+import { Routes } from '../../forms/serverGroup';
 import { Formik } from 'formik';
 
 interface ICloudfoundryLoadBalancerStageConfigProps extends IStageConfigProps {

--- a/app/scripts/modules/core/src/application/ApplicationComponent.tsx
+++ b/app/scripts/modules/core/src/application/ApplicationComponent.tsx
@@ -2,7 +2,7 @@ import { ApplicationHeader } from './nav/ApplicationHeader';
 import React from 'react';
 import { UIView } from '@uirouter/react';
 
-import { Application } from 'core/application';
+import { Application } from './application.model';
 import { RecentHistoryService } from 'core/history';
 import { DebugWindow } from 'core/utils/consoleDebug';
 

--- a/app/scripts/modules/core/src/application/ApplicationIcon.tsx
+++ b/app/scripts/modules/core/src/application/ApplicationIcon.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Application } from 'core/application';
+import { Application } from './application.model';
 
 import { Overridable, IOverridableProps } from '../overrideRegistry/Overridable';
 

--- a/app/scripts/modules/core/src/application/config/DeleteApplicationSection.tsx
+++ b/app/scripts/modules/core/src/application/config/DeleteApplicationSection.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
-import { Application, ApplicationWriter } from 'core/application';
+import { Application } from '../application.model';
+import { ApplicationWriter } from '../service/ApplicationWriter';
 import { ConfirmationModalService } from 'core/confirmationModal';
 import { ReactInjector } from 'core/reactShims';
 import { FirewallLabel } from 'core/securityGroup/label';

--- a/app/scripts/modules/core/src/application/config/managedResources/ManagedResourceConfig.tsx
+++ b/app/scripts/modules/core/src/application/config/managedResources/ManagedResourceConfig.tsx
@@ -5,7 +5,7 @@ import ReactGA from 'react-ga';
 import classNames from 'classnames';
 
 import { NgReact } from 'core/reactShims';
-import { Application } from 'core/application';
+import { Application } from '../../application.model';
 import { ValidationMessage, useLatestCallback } from 'core/presentation';
 import { ManagedWriter } from 'core/managed';
 

--- a/app/scripts/modules/core/src/application/config/trafficGuard/trafficGuardConfig.component.ts
+++ b/app/scripts/modules/core/src/application/config/trafficGuard/trafficGuardConfig.component.ts
@@ -2,7 +2,8 @@ import { ILogService, module, toJson } from 'angular';
 import { cloneDeep, uniq } from 'lodash';
 
 import { AccountService, IAccountDetails, IAggregatedAccounts, IRegion } from 'core/account/AccountService';
-import { Application, IConfigSectionFooterViewState } from 'core/application';
+import { IConfigSectionFooterViewState } from '../footer/configSectionFooter.component';
+import { Application } from '../../application.model';
 import { CLUSTER_MATCHES_COMPONENT, IClusterMatch } from 'core/widgets/cluster/clusterMatches.component';
 import './trafficGuardConfig.help';
 import { ClusterMatcher, IClusterMatchRule } from 'core/cluster/ClusterRuleMatcher';

--- a/app/scripts/modules/core/src/application/nav/ApplicationHeader.tsx
+++ b/app/scripts/modules/core/src/application/nav/ApplicationHeader.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Application } from 'core/application';
+import { Application } from '../application.model';
 import { ApplicationRefresher } from './ApplicationRefresher';
 import { INavigationCategory, navigationCategoryRegistry } from './navigationCategory.registry';
 import { PagerDutyButton } from './PagerDutyButton';

--- a/app/scripts/modules/core/src/application/nav/ApplicationNavSection.tsx
+++ b/app/scripts/modules/core/src/application/nav/ApplicationNavSection.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Application } from 'core/application';
+import { Application } from '../application.model';
 import { CategoryDropdown } from './CategoryDropdown';
 import { IDataSourceCategory } from './ApplicationHeader';
 

--- a/app/scripts/modules/core/src/application/nav/ApplicationRefresher.tsx
+++ b/app/scripts/modules/core/src/application/nav/ApplicationRefresher.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { Observable, Subject } from 'rxjs';
 
-import { Application, ApplicationDataSource, IFetchStatus } from 'core/application';
+import { Application } from '../application.model';
+import { ApplicationDataSource, IFetchStatus } from '../service/applicationDataSource';
 import { Refresher } from 'core/presentation/refresher/Refresher';
 
 export interface IApplicationRefresherProps {

--- a/app/scripts/modules/core/src/application/nav/CategoryDropdown.tsx
+++ b/app/scripts/modules/core/src/application/nav/CategoryDropdown.tsx
@@ -6,7 +6,8 @@ import { Subscription } from 'rxjs';
 import { Dropdown } from 'react-bootstrap';
 import { merge } from 'rxjs/observable/merge';
 
-import { Application, ApplicationDataSource } from 'core/application';
+import { Application } from '../application.model';
+import { ApplicationDataSource } from '../service/applicationDataSource';
 import { IEntityTags } from 'core/domain';
 import { noop } from 'core/utils';
 import { DataSourceNotifications } from 'core/entityTag/notifications/DataSourceNotifications';

--- a/app/scripts/modules/core/src/application/nav/DataSourceEntry.tsx
+++ b/app/scripts/modules/core/src/application/nav/DataSourceEntry.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { Subscription } from 'rxjs';
 
-import { Application, ApplicationDataSource } from 'core/application';
+import { Application } from '../application.model';
+import { ApplicationDataSource } from '../service/applicationDataSource';
 import { IEntityTags } from 'core/domain';
 import { DataSourceNotifications } from 'core/entityTag/notifications/DataSourceNotifications';
 

--- a/app/scripts/modules/core/src/application/nav/MenuTitle.tsx
+++ b/app/scripts/modules/core/src/application/nav/MenuTitle.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { UISref } from '@uirouter/react';
 
-import { Application } from 'core/application';
+import { Application } from '../application.model';
 import { IEntityTags } from 'core/domain';
 import { DataSourceNotifications } from 'core/entityTag/notifications/DataSourceNotifications';
 

--- a/app/scripts/modules/core/src/application/nav/PagerDutyButton.tsx
+++ b/app/scripts/modules/core/src/application/nav/PagerDutyButton.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Application } from 'core/application';
+import { Application } from '../application.model';
 import { PagerDutyWriter } from 'core/pagerDuty';
 import { Tooltip } from 'core/presentation';
 

--- a/app/scripts/modules/core/src/application/nav/ThirdLevelNavigation.tsx
+++ b/app/scripts/modules/core/src/application/nav/ThirdLevelNavigation.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { UIRouterContext } from '@uirouter/react-hybrid';
 import { UISref, UISrefActive } from '@uirouter/react';
 
-import { Application } from 'core/application';
+import { Application } from '../application.model';
 import { IDataSourceCategory } from './ApplicationHeader';
 import { DataSourceEntry } from './DataSourceEntry';
 

--- a/app/scripts/modules/core/src/application/search/Applications.tsx
+++ b/app/scripts/modules/core/src/application/search/Applications.tsx
@@ -5,7 +5,7 @@ import { BehaviorSubject, Observable, Subject } from 'rxjs';
 
 import { IAccount } from 'core/account';
 import { ICache, ViewStateCache } from 'core/cache';
-import { ApplicationReader, IApplicationSummary } from 'core/application';
+import { ApplicationReader, IApplicationSummary } from '../service/ApplicationReader';
 import { ApplicationTable } from './ApplicationsTable';
 import { PaginationControls } from './PaginationControls';
 import { InsightMenu } from 'core/insight/InsightMenu';

--- a/app/scripts/modules/core/src/application/search/ApplicationsTable.tsx
+++ b/app/scripts/modules/core/src/application/search/ApplicationsTable.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { UISref } from '@uirouter/react';
 
 import { timestamp } from 'core/utils';
-import { IApplicationSummary } from 'core/application';
+import { IApplicationSummary } from '../service/ApplicationReader';
 import { SortToggle } from 'core/presentation';
 
 export interface IApplicationTableProps {

--- a/app/scripts/modules/core/src/artifact/NgAppEngineDeployArtifactDelegate.ts
+++ b/app/scripts/modules/core/src/artifact/NgAppEngineDeployArtifactDelegate.ts
@@ -2,7 +2,8 @@ import { IScope } from 'angular';
 
 import { IExpectedArtifact, IArtifactKindConfig, IArtifactSource, IStage, IPipeline } from 'core/domain';
 import { Registry } from 'core/registry';
-import { ExpectedArtifactService, IExpectedArtifactSelectorViewControllerDelegate } from 'core/artifact';
+import { ExpectedArtifactService } from './expectedArtifact.service';
+import { IExpectedArtifactSelectorViewControllerDelegate } from './ExpectedArtifactSelectorViewController';
 import { IArtifactAccount } from 'core/account';
 
 import { ExpectedArtifactSelectorViewControllerAngularDelegate } from './ExpectedArtifactSelectorViewControllerAngularDelegate';

--- a/app/scripts/modules/core/src/artifact/NgAppengineConfigArtifactDelegate.ts
+++ b/app/scripts/modules/core/src/artifact/NgAppengineConfigArtifactDelegate.ts
@@ -2,7 +2,8 @@ import { IScope } from 'angular';
 
 import { Registry } from 'core/registry';
 import { IExpectedArtifact, IArtifactSource, IStage, IPipeline } from 'core/domain';
-import { ExpectedArtifactService, IExpectedArtifactSelectorViewControllerDelegate } from 'core/artifact';
+import { ExpectedArtifactService } from './expectedArtifact.service';
+import { IExpectedArtifactSelectorViewControllerDelegate } from './ExpectedArtifactSelectorViewController';
 import { IArtifactAccount } from 'core/account';
 
 import { ExpectedArtifactSelectorViewControllerAngularDelegate } from './ExpectedArtifactSelectorViewControllerAngularDelegate';

--- a/app/scripts/modules/core/src/artifact/NgBakeManifestArtifactDelegate.ts
+++ b/app/scripts/modules/core/src/artifact/NgBakeManifestArtifactDelegate.ts
@@ -1,7 +1,8 @@
 import { IScope } from 'angular';
 
 import { IExpectedArtifact, IArtifactSource, IStage, IPipeline } from 'core/domain';
-import { ExpectedArtifactService, IExpectedArtifactSelectorViewControllerDelegate } from 'core/artifact';
+import { IExpectedArtifactSelectorViewControllerDelegate } from './ExpectedArtifactSelectorViewController';
+import { ExpectedArtifactService } from './expectedArtifact.service';
 import { Registry } from 'core/registry';
 import { IArtifactAccount } from 'core/account';
 

--- a/app/scripts/modules/core/src/artifact/NgGCEImageArtifactDelegate.ts
+++ b/app/scripts/modules/core/src/artifact/NgGCEImageArtifactDelegate.ts
@@ -1,7 +1,8 @@
 import { IScope } from 'angular';
 
 import { IArtifactKindConfig, IExpectedArtifact, IArtifactSource, IStage, IPipeline } from 'core/domain';
-import { ExpectedArtifactService, IExpectedArtifactSelectorViewControllerDelegate } from 'core/artifact';
+import { IExpectedArtifactSelectorViewControllerDelegate } from './ExpectedArtifactSelectorViewController';
+import { ExpectedArtifactService } from './expectedArtifact.service';
 import { Registry } from 'core/registry';
 import { IArtifactAccount } from 'core/account';
 

--- a/app/scripts/modules/core/src/artifact/NgGenericArtifactDelegate.ts
+++ b/app/scripts/modules/core/src/artifact/NgGenericArtifactDelegate.ts
@@ -1,7 +1,8 @@
 import { IScope } from 'angular';
 
 import { IArtifactKindConfig, IExpectedArtifact, IArtifactSource, IStage, IPipeline } from 'core/domain';
-import { ExpectedArtifactService, IExpectedArtifactSelectorViewControllerDelegate } from 'core/artifact';
+import { IExpectedArtifactSelectorViewControllerDelegate } from './ExpectedArtifactSelectorViewController';
+import { ExpectedArtifactService } from './expectedArtifact.service';
 import { Registry } from 'core/registry';
 import { IArtifactAccount } from 'core/account';
 

--- a/app/scripts/modules/core/src/artifact/react/ArtifactEditor.tsx
+++ b/app/scripts/modules/core/src/artifact/react/ArtifactEditor.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { cloneDeep, head } from 'lodash';
 import { IArtifactAccount } from 'core/account';
-import { ArtifactAccountSelector } from 'core/artifact';
+import { ArtifactAccountSelector } from './ArtifactAccountSelector';
 import { IArtifact, IPipeline } from 'core/domain';
 import { TYPE as CUSTOM_TYPE, CUSTOM_ARTIFACT_ACCOUNT } from 'core/pipeline/config/triggers/artifacts/custom';
 import { StageConfigField } from 'core/pipeline/config/stages/common';

--- a/app/scripts/modules/core/src/artifact/react/ArtifactIconList.tsx
+++ b/app/scripts/modules/core/src/artifact/react/ArtifactIconList.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { isString } from 'lodash';
 import { IArtifact } from 'core/domain';
-import { ArtifactIconService, ArtifactTypePatterns } from 'core/artifact';
+import { ArtifactTypePatterns } from '../ArtifactTypes';
+import { ArtifactIconService } from '../ArtifactIconService';
 
 export interface IArtifactIconListProps {
   artifacts: IArtifact[];

--- a/app/scripts/modules/core/src/artifact/react/ExpectedArtifactModal.tsx
+++ b/app/scripts/modules/core/src/artifact/react/ExpectedArtifactModal.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { AccountService, IArtifactAccount } from 'core/account';
-import { ExpectedArtifactService } from 'core/artifact';
+import { ExpectedArtifactService } from '../expectedArtifact.service';
 import { IArtifact, IExpectedArtifact, IPipeline } from 'core/domain';
 import { HelpField } from 'core/help';
 import { WizardModal, WizardPage } from 'core/modal/wizard';

--- a/app/scripts/modules/core/src/artifact/react/StageArtifactSelector.tsx
+++ b/app/scripts/modules/core/src/artifact/react/StageArtifactSelector.tsx
@@ -5,7 +5,8 @@ import { react2angular } from 'react2angular';
 import { Observable, Subject } from 'rxjs';
 
 import { IArtifact, IExpectedArtifact, IPipeline, IStage } from 'core/domain';
-import { ArtifactIcon, ExpectedArtifactService } from 'core/artifact';
+import { ExpectedArtifactService } from '../expectedArtifact.service';
+import { ArtifactIcon } from './ArtifactIcon';
 import { AccountService, IArtifactAccount } from 'core/account';
 import { ArtifactEditor } from './ArtifactEditor';
 

--- a/app/scripts/modules/core/src/bootstrap/transitionTrace.toggle.ts
+++ b/app/scripts/modules/core/src/bootstrap/transitionTrace.toggle.ts
@@ -1,7 +1,7 @@
 import { UIRouter, Category } from '@uirouter/core';
 
 import { bootstrapModule } from './bootstrap.module';
-import { paramChangedHelper } from 'core/bootstrap';
+import { paramChangedHelper } from './paramChangedHelper';
 
 /** Changes UI-Router console tracing based on the query parameter `trace` */
 bootstrapModule.run([

--- a/app/scripts/modules/core/src/cloudProvider/CloudProviderLabel.tsx
+++ b/app/scripts/modules/core/src/cloudProvider/CloudProviderLabel.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { CloudProviderRegistry } from 'core/cloudProvider';
+import { CloudProviderRegistry } from './CloudProviderRegistry';
 
 export interface ICloudProviderLabelProps {
   provider: string;

--- a/app/scripts/modules/core/src/cloudProvider/CloudProviderLogo.tsx
+++ b/app/scripts/modules/core/src/cloudProvider/CloudProviderLogo.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Tooltip } from 'core/presentation/Tooltip';
-import { CloudProviderRegistry } from 'core/cloudProvider';
+import { CloudProviderRegistry } from './CloudProviderRegistry';
 
 import './cloudProviderLogo.less';
 

--- a/app/scripts/modules/core/src/cloudProvider/cloudProviderLabel.directive.js
+++ b/app/scripts/modules/core/src/cloudProvider/cloudProviderLabel.directive.js
@@ -2,7 +2,7 @@
 
 import { module } from 'angular';
 
-import { CloudProviderRegistry } from 'core/cloudProvider';
+import { CloudProviderRegistry } from './CloudProviderRegistry';
 
 import './cloudProviderLogo.less';
 

--- a/app/scripts/modules/core/src/cloudProvider/providerSelection/ProviderSelectionModal.tsx
+++ b/app/scripts/modules/core/src/cloudProvider/providerSelection/ProviderSelectionModal.tsx
@@ -1,5 +1,5 @@
-import { CloudProviderRegistry } from 'core/cloudProvider';
 import React from 'react';
+import { CloudProviderRegistry } from '../CloudProviderRegistry';
 import { Modal } from 'react-bootstrap';
 import { IModalComponentProps, ReactModal } from 'core/presentation';
 import { ModalClose } from 'core/modal';

--- a/app/scripts/modules/core/src/cloudProvider/providerSelection/providerSelector.directive.js
+++ b/app/scripts/modules/core/src/cloudProvider/providerSelection/providerSelector.directive.js
@@ -3,7 +3,7 @@
 import { module } from 'angular';
 
 import { AccountService } from 'core/account/AccountService';
-import { CloudProviderRegistry } from 'core/cloudProvider';
+import { CloudProviderRegistry } from '../CloudProviderRegistry';
 
 export const CORE_CLOUDPROVIDER_PROVIDERSELECTION_PROVIDERSELECTOR_DIRECTIVE = 'spinnaker.providerSelection.directive';
 export const name = CORE_CLOUDPROVIDER_PROVIDERSELECTION_PROVIDERSELECTOR_DIRECTIVE; // for backwards compatibility

--- a/app/scripts/modules/core/src/cloudProvider/skin.service.ts
+++ b/app/scripts/modules/core/src/cloudProvider/skin.service.ts
@@ -4,7 +4,7 @@ import { $log, $q } from 'ngimport';
 
 import { SETTINGS } from 'core/config/settings';
 import { AccountService, IAccountDetails } from 'core/account';
-import { CloudProviderRegistry } from 'core/cloudProvider';
+import { CloudProviderRegistry } from './CloudProviderRegistry';
 import { ILoadBalancer, IServerGroup } from 'core/domain';
 import { IMoniker } from 'core/naming';
 import { Application } from 'core/application';

--- a/app/scripts/modules/core/src/cloudProvider/skinSelection/skinSelection.service.ts
+++ b/app/scripts/modules/core/src/cloudProvider/skinSelection/skinSelection.service.ts
@@ -3,7 +3,7 @@ import { IPromise, module } from 'angular';
 import { isNil, uniq } from 'lodash';
 
 import { AccountService } from 'core/account/AccountService';
-import { CloudProviderRegistry } from 'core/cloudProvider';
+import { CloudProviderRegistry } from '../CloudProviderRegistry';
 
 export class SkinSelectionService {
   public static $inject = ['$uibModal'];

--- a/app/scripts/modules/core/src/domain/IArtifactEditorProps.ts
+++ b/app/scripts/modules/core/src/domain/IArtifactEditorProps.ts
@@ -1,4 +1,5 @@
-import { IArtifact, IPipeline } from 'core/domain';
+import { IArtifact } from './IArtifact';
+import { IPipeline } from './IPipeline';
 import { IArtifactAccount } from 'core/account';
 
 export interface IArtifactEditorProps {

--- a/app/scripts/modules/core/src/domain/IArtifactExtractor.ts
+++ b/app/scripts/modules/core/src/domain/IArtifactExtractor.ts
@@ -1,4 +1,4 @@
-import { ICluster } from 'core/domain';
+import { ICluster } from './ICluster';
 
 export interface IArtifactExtractor {
   extractArtifacts: (cluster: ICluster) => string[];

--- a/app/scripts/modules/core/src/domain/IArtifactKindConfig.ts
+++ b/app/scripts/modules/core/src/domain/IArtifactKindConfig.ts
@@ -1,5 +1,6 @@
 import { ComponentType, SFC } from 'react';
-import { IArtifactEditorProps, IArtifact } from 'core/domain';
+import { IArtifact } from './IArtifact';
+import { IArtifactEditorProps } from './IArtifactEditorProps';
 
 export interface IArtifactKindConfig {
   label: string;

--- a/app/scripts/modules/core/src/domain/IManifest.ts
+++ b/app/scripts/modules/core/src/domain/IManifest.ts
@@ -1,5 +1,5 @@
 import { IMoniker } from 'core/naming/IMoniker';
-import { IArtifact } from 'core/domain';
+import { IArtifact } from './IArtifact';
 
 export interface IManifest {
   name: string;

--- a/app/scripts/modules/core/src/domain/IPipelineTemplateConfigV2.ts
+++ b/app/scripts/modules/core/src/domain/IPipelineTemplateConfigV2.ts
@@ -1,4 +1,4 @@
-import { IPipeline } from 'core/domain';
+import { IPipeline } from './IPipeline';
 
 export interface IPipelineTemplateConfigV2 extends Partial<IPipeline> {
   exclude?: string[];

--- a/app/scripts/modules/core/src/domain/IPipelineTemplateV2.ts
+++ b/app/scripts/modules/core/src/domain/IPipelineTemplateV2.ts
@@ -1,4 +1,4 @@
-import { IPipeline } from 'core/domain';
+import { IPipeline } from './IPipeline';
 import { VariableType } from 'core/pipeline/config/templates/PipelineTemplateReader';
 
 export interface IPipelineTemplateV2 {

--- a/app/scripts/modules/core/src/domain/IServerGroupManager.ts
+++ b/app/scripts/modules/core/src/domain/IServerGroupManager.ts
@@ -1,5 +1,5 @@
 import { IMoniker } from 'core/naming';
-import { IEntityTags } from 'core/domain';
+import { IEntityTags } from './IEntityTags';
 
 export interface IServerGroupManager {
   account: string;

--- a/app/scripts/modules/core/src/domain/ITrigger.ts
+++ b/app/scripts/modules/core/src/domain/ITrigger.ts
@@ -1,4 +1,6 @@
-import { IArtifact, IExecution, ITemplateInheritable } from 'core/domain';
+import { IArtifact } from './IArtifact';
+import { IExecution } from './IExecution';
+import { ITemplateInheritable } from './IPipeline';
 
 export interface ITrigger extends ITemplateInheritable {
   artifacts?: IArtifact[];

--- a/app/scripts/modules/core/src/entityTag/AddEntityTagLinks.tsx
+++ b/app/scripts/modules/core/src/entityTag/AddEntityTagLinks.tsx
@@ -1,5 +1,5 @@
 import { Application } from 'core/application';
-import { IOwnerOption } from 'core/entityTag';
+import { IOwnerOption } from './EntityTagEditor';
 
 export interface IAddEntityTagLinksProps {
   application: Application;

--- a/app/scripts/modules/core/src/entityTag/notifications/NotificationsPopover.tsx
+++ b/app/scripts/modules/core/src/entityTag/notifications/NotificationsPopover.tsx
@@ -4,13 +4,10 @@ import { uniq, pick } from 'lodash';
 
 import { Application } from 'core/application';
 import { IEntityTags, IEntityTag } from 'core/domain';
-import {
-  EntityTagEditor,
-  EntityTagWriter,
-  GroupedNotificationList,
-  IEntityTagEditorProps,
-  NotificationList,
-} from 'core/entityTag';
+import { EntityTagEditor, IEntityTagEditorProps } from '../EntityTagEditor';
+import { EntityTagWriter } from '../entityTags.write.service';
+import { GroupedNotificationList } from './GroupedNotificationList';
+import { NotificationList } from './NotificationList';
 import { Placement, HoverablePopover, IHoverablePopoverContentsProps } from 'core/presentation';
 import { ConfirmationModalService } from 'core/confirmationModal';
 import { noop } from 'core/utils';

--- a/app/scripts/modules/core/src/filterModel/dependentFilter/DependentFilterService.ts
+++ b/app/scripts/modules/core/src/filterModel/dependentFilter/DependentFilterService.ts
@@ -1,6 +1,6 @@
 import { chain, identity, pickBy } from 'lodash';
 
-import { ISortFilter } from 'core/filterModel';
+import { ISortFilter } from '../IFilterModel';
 
 function generateIterator(sortFilter: ISortFilter & { [key: string]: any }) {
   return function iterator(acc: { headings: any; pool: any }, headingType: string) {

--- a/app/scripts/modules/core/src/function/CreateFunctionButton.tsx
+++ b/app/scripts/modules/core/src/function/CreateFunctionButton.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Application } from 'core/application';
 import { CloudProviderRegistry, ProviderSelectionService } from 'core/cloudProvider';
 import { IFunction } from 'core/domain';
-import { IFunctionUpsertCommand } from 'core/function';
+import { IFunctionUpsertCommand } from './function.write.service';
 import { ReactInjector } from 'core/reactShims';
 import { IModalComponentProps, Tooltip } from 'core/presentation';
 

--- a/app/scripts/modules/core/src/help/HelpField.tsx
+++ b/app/scripts/modules/core/src/help/HelpField.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import ReactGA from 'react-ga';
 import { isUndefined } from 'lodash';
 
-import { HelpContentsRegistry, HelpTextExpandedContext } from 'core/help';
+import { HelpContentsRegistry } from './helpContents.registry';
+import { HelpTextExpandedContext } from './HelpTextExpandedContext';
 import { HoverablePopover, Markdown, Placement } from 'core/presentation';
 
 export interface IHelpFieldProps {

--- a/app/scripts/modules/core/src/loadBalancer/CreateLoadBalancerButton.tsx
+++ b/app/scripts/modules/core/src/loadBalancer/CreateLoadBalancerButton.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Application } from 'core/application';
 import { CloudProviderRegistry, ProviderSelectionService } from 'core/cloudProvider';
 import { ILoadBalancer } from 'core/domain';
-import { ILoadBalancerUpsertCommand } from 'core/loadBalancer';
+import { ILoadBalancerUpsertCommand } from './loadBalancer.write.service';
 import { ModalInjector, ReactInjector } from 'core/reactShims';
 import { IModalComponentProps, Tooltip } from 'core/presentation';
 

--- a/app/scripts/modules/core/src/managed/ManagedResourceHistoryModal.tsx
+++ b/app/scripts/modules/core/src/managed/ManagedResourceHistoryModal.tsx
@@ -18,7 +18,7 @@ import {
 import { relativeTime, timestamp } from 'core/utils';
 import { IManagedResourceSummary, IManagedResourceDiff, IManagedResourceEvent } from 'core/domain';
 import { AccountTag } from 'core/account';
-import { ManagedReader } from 'core/managed';
+import { ManagedReader } from './ManagedReader';
 import { Spinner } from 'core/widgets';
 
 import { ManagedResourceDiffTable } from './ManagedResourceDiffTable';

--- a/app/scripts/modules/core/src/manifest/stage/JobStageExecutionLogs.tsx
+++ b/app/scripts/modules/core/src/manifest/stage/JobStageExecutionLogs.tsx
@@ -6,7 +6,7 @@ import { JobManifestPodLogs } from './JobManifestPodLogs';
 import { IManifest } from 'core/domain/IManifest';
 import { Application } from 'core/application';
 import { IPodNameProvider } from '../PodNameProvider';
-import { ManifestReader } from 'core/manifest';
+import { ManifestReader } from '../ManifestReader';
 
 interface IJobStageExecutionLogsProps {
   deployedName: string;

--- a/app/scripts/modules/core/src/notification/modal/NotificationDetails.tsx
+++ b/app/scripts/modules/core/src/notification/modal/NotificationDetails.tsx
@@ -5,7 +5,7 @@ import { Option } from 'react-select';
 import { INotification, INotificationTypeConfig } from 'core/domain';
 import { Registry } from 'core/registry';
 import { FormikFormField, TextAreaInput } from 'core/presentation';
-import { NotificationSelector } from 'core/notification';
+import { NotificationSelector } from '../selector/NotificationSelector';
 import { NotificationTransformer } from '../notification.transformer';
 import { WhenChecklistInput } from './WhenChecklistInput';
 import { MANUAL_JUDGEMENT_WHEN_OPTIONS, PIPELINE_WHEN_OPTIONS, STAGE_WHEN_OPTIONS } from './whenOptions';

--- a/app/scripts/modules/core/src/overrideRegistry/Overrides.tsx
+++ b/app/scripts/modules/core/src/overrideRegistry/Overrides.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { CloudProviderRegistry } from 'core/cloudProvider';
-import { OverrideRegistry } from 'core/overrideRegistry';
+import { OverrideRegistry } from './override.registry';
 
 /**
  * This queues OverrideComponent registration until the registries are ready.

--- a/app/scripts/modules/core/src/pagerDuty/PageButton.tsx
+++ b/app/scripts/modules/core/src/pagerDuty/PageButton.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Application } from 'core/application';
-import { IPagerDutyService } from 'core/pagerDuty';
+import { IPagerDutyService } from './pagerDuty.read.service';
 
 import { PageModal } from './PageModal';
 

--- a/app/scripts/modules/core/src/pagerDuty/PageModal.tsx
+++ b/app/scripts/modules/core/src/pagerDuty/PageModal.tsx
@@ -3,7 +3,8 @@ import { Button, Modal } from 'react-bootstrap';
 import { get } from 'lodash';
 
 import { Application, ApplicationModelBuilder } from 'core/application';
-import { IPagerDutyService, PagerDutyWriter } from 'core/pagerDuty';
+import { IPagerDutyService } from './pagerDuty.read.service';
+import { PagerDutyWriter } from './pagerDuty.write.service';
 import { NgReact, ReactInjector } from 'core/reactShims';
 import { SETTINGS } from 'core/config';
 import { SubmitButton } from 'core/modal';

--- a/app/scripts/modules/core/src/pipeline/config/actions/delete/DeletePipelineModal.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/actions/delete/DeletePipelineModal.tsx
@@ -8,7 +8,7 @@ import { IPipeline } from 'core/domain';
 import { ModalClose } from 'core/modal';
 import { IModalComponentProps } from 'core/presentation';
 import { ReactInjector } from 'core/reactShims';
-import { PipelineConfigService } from 'core/pipeline';
+import { PipelineConfigService } from '../../services/PipelineConfigService';
 
 export interface IDeletePipelineModalProps extends IModalComponentProps {
   application: Application;

--- a/app/scripts/modules/core/src/pipeline/config/actions/disable/DisablePipelineModal.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/actions/disable/DisablePipelineModal.tsx
@@ -4,7 +4,7 @@ import { Modal } from 'react-bootstrap';
 import { IPipeline } from 'core/domain';
 import { ModalClose } from 'core/modal';
 import { IModalComponentProps } from 'core/presentation';
-import { PipelineConfigService } from 'core/pipeline';
+import { PipelineConfigService } from '../../services/PipelineConfigService';
 
 export interface IDisablePipelineModalProps extends IModalComponentProps {
   pipeline: IPipeline;

--- a/app/scripts/modules/core/src/pipeline/config/actions/enable/EnablePipelineModal.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/actions/enable/EnablePipelineModal.tsx
@@ -4,7 +4,7 @@ import { Modal } from 'react-bootstrap';
 import { IPipeline } from 'core/domain';
 import { ModalClose } from 'core/modal';
 import { IModalComponentProps } from 'core/presentation';
-import { PipelineConfigService } from 'core/pipeline';
+import { PipelineConfigService } from '../../services/PipelineConfigService';
 
 export interface IEnablePipelineModalProps extends IModalComponentProps {
   pipeline: IPipeline;

--- a/app/scripts/modules/core/src/pipeline/config/actions/history/ShowPipelineHistoryModal.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/actions/history/ShowPipelineHistoryModal.tsx
@@ -4,7 +4,7 @@ import { isEmpty } from 'lodash';
 
 import { IPipeline } from 'core/domain';
 import { ModalClose } from 'core/modal';
-import { PipelineConfigService } from 'core/pipeline';
+import { PipelineConfigService } from '../../services/PipelineConfigService';
 import { FormField, IModalComponentProps, ReactSelectInput } from 'core/presentation';
 import { Spinner } from 'core/widgets';
 import { IJsonDiff, JsonUtils, timestamp } from 'core/utils';

--- a/app/scripts/modules/core/src/pipeline/config/actions/lock/LockPipelineModal.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/actions/lock/LockPipelineModal.tsx
@@ -5,7 +5,7 @@ import { IPipeline, IPipelineLock } from 'core/domain';
 import { ModalClose } from 'core/modal';
 import { CheckboxInput, FormField, IModalComponentProps, TextInput } from 'core/presentation';
 import { HelpField } from 'core/help';
-import { PipelineConfigService } from 'core/pipeline';
+import { PipelineConfigService } from '../../services/PipelineConfigService';
 
 export interface ILockPipelineModalProps extends IModalComponentProps {
   pipeline: IPipeline;

--- a/app/scripts/modules/core/src/pipeline/config/actions/rename/RenamePipelineModal.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/actions/rename/RenamePipelineModal.tsx
@@ -6,7 +6,7 @@ import { Form } from 'formik';
 import { Application } from 'core/application';
 import { IPipeline } from 'core/domain';
 import { ModalClose } from 'core/modal';
-import { PipelineConfigService } from 'core/pipeline';
+import { PipelineConfigService } from '../../services/PipelineConfigService';
 import {
   FormikFormField,
   IModalComponentProps,

--- a/app/scripts/modules/core/src/pipeline/config/actions/unlock/UnlockPipelineModal.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/actions/unlock/UnlockPipelineModal.tsx
@@ -5,7 +5,7 @@ import { unset } from 'lodash';
 import { IPipeline } from 'core/domain';
 import { ModalClose } from 'core/modal';
 import { IModalComponentProps } from 'core/presentation';
-import { PipelineConfigService } from 'core/pipeline';
+import { PipelineConfigService } from '../../services/PipelineConfigService';
 
 export interface IUnlockPipelineModalProps extends IModalComponentProps {
   pipeline: IPipeline;

--- a/app/scripts/modules/core/src/pipeline/config/parameters/Parameter.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/parameters/Parameter.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import { IParameter } from 'core/domain';
 import { HelpField } from 'core/help';
 import { Tooltip } from 'core/presentation';
-import { StageConfigField } from 'core/pipeline';
+import { StageConfigField } from '../stages/common';
 import { SortableHandle } from 'react-sortable-hoc';
 
 export interface IParameterOption {

--- a/app/scripts/modules/core/src/pipeline/config/pipelineConfig.controller.js
+++ b/app/scripts/modules/core/src/pipeline/config/pipelineConfig.controller.js
@@ -4,7 +4,7 @@ import _ from 'lodash';
 import { hri as HumanReadableIds } from 'human-readable-ids';
 
 import { PipelineTemplateReader } from './templates/PipelineTemplateReader';
-import { PipelineTemplateV2Service } from 'core/pipeline';
+import { PipelineTemplateV2Service } from './templates/v2/pipelineTemplateV2.service';
 import UIROUTER_ANGULARJS from '@uirouter/angularjs';
 
 import { module } from 'angular';

--- a/app/scripts/modules/core/src/pipeline/config/pipelineConfigurer.js
+++ b/app/scripts/modules/core/src/pipeline/config/pipelineConfigurer.js
@@ -24,7 +24,7 @@ import { UnlockPipelineModal } from './actions/unlock/UnlockPipelineModal';
 import { RenamePipelineModal } from './actions/rename/RenamePipelineModal';
 import { ShowPipelineHistoryModal } from './actions/history/ShowPipelineHistoryModal';
 import { ShowPipelineTemplateJsonModal } from './actions/templateJson/ShowPipelineTemplateJsonModal';
-import { PipelineTemplateV2Service } from 'core/pipeline';
+import { PipelineTemplateV2Service } from './templates/v2/pipelineTemplateV2.service';
 import { PipelineTemplateWriter } from './templates/PipelineTemplateWriter';
 
 export const CORE_PIPELINE_CONFIG_PIPELINECONFIGURER = 'spinnaker.core.pipeline.config.pipelineConfigurer';

--- a/app/scripts/modules/core/src/pipeline/config/services/PipelineConfigService.ts
+++ b/app/scripts/modules/core/src/pipeline/config/services/PipelineConfigService.ts
@@ -4,7 +4,7 @@ import { $q } from 'ngimport';
 
 import { API } from 'core/api/ApiService';
 import { AuthenticationService } from 'core/authentication/AuthenticationService';
-import { PipelineTemplateV2Service } from 'core/pipeline';
+import { PipelineTemplateV2Service } from '../templates/v2/pipelineTemplateV2.service';
 import { ViewStateCache } from 'core/cache';
 import { IStage } from 'core/domain/IStage';
 import { IPipeline } from 'core/domain/IPipeline';

--- a/app/scripts/modules/core/src/pipeline/config/stages/StageConfigWrapper.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/StageConfigWrapper.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { IStageConfigProps } from 'core/pipeline';
+import { IStageConfigProps } from './common/IStageConfigProps';
 
 export interface IStageConfigWrapperProps extends IStageConfigProps {
   component: React.ComponentType<any>;

--- a/app/scripts/modules/core/src/pipeline/config/stages/applySourceServerGroupCapacity/ApplySourceServerGroupCapacityDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/applySourceServerGroupCapacity/ApplySourceServerGroupCapacityDetails.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { find, get } from 'lodash';
 
-import { StageFailureMessage } from 'core/pipeline';
+import { StageFailureMessage } from '../../../details/StageFailureMessage';
 import { IStage } from 'core/domain';
 import { IExecutionDetailsSectionProps } from '../common';
 import { ExecutionDetailsSection } from '../common/ExecutionDetailsSection';

--- a/app/scripts/modules/core/src/pipeline/config/stages/awsCodeBuild/AwsCodeBuildExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/awsCodeBuild/AwsCodeBuildExecutionDetails.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { get } from 'lodash';
 
-import { IExecutionDetailsSectionProps, ExecutionDetailsSection, StageFailureMessage } from 'core/pipeline';
+import { ExecutionDetailsSection, IExecutionDetailsSectionProps } from '../common';
+import { StageFailureMessage } from '../../../details';
 
 export class AwsCodeBuildExecutionDetails extends React.Component<IExecutionDetailsSectionProps> {
   public static title = 'awsCodeBuildStatus';

--- a/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/BakeManifestConfig.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/BakeManifestConfig.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { defaults } from 'lodash';
 
 import { IStage } from 'core/domain';
-import { FormikStageConfig, IStageConfigProps } from 'core/pipeline';
+import { FormikStageConfig } from '../FormikStageConfig';
+import { IStageConfigProps } from '../common';
 import { BakeManifestStageForm } from './BakeManifestStageForm';
 
 export class BakeManifestConfig extends React.Component<IStageConfigProps> {

--- a/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/BakeManifestStageForm.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/BakeManifestStageForm.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
 import { IPipeline } from 'core/domain';
-import { IFormikStageConfigInjectedProps, StageConfigField } from 'core/pipeline';
+import { StageConfigField } from '../common';
+import { IFormikStageConfigInjectedProps } from '../FormikStageConfig';
 import { BakeKustomizeConfigForm } from './kustomize/BakeKustomizeConfigForm';
 import { BakeHelmConfigForm } from './helm/BakeHelmConfigForm';
 import { ReactSelectInput } from 'core/presentation';

--- a/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/bakeManifestStage.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/bakeManifestStage.ts
@@ -1,5 +1,6 @@
 import { ArtifactReferenceService, ExecutionArtifactTab, ExpectedArtifactService } from 'core/artifact';
-import { ExecutionDetailsTasks, IValidatorConfig } from 'core/pipeline';
+import { IValidatorConfig } from '../../validation/PipelineConfigValidator';
+import { ExecutionDetailsTasks } from '../common';
 
 import { IArtifact, IStage, IPipeline, IStageOrTriggerTypeConfig } from 'core/domain';
 

--- a/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/helm/BakeHelmConfigForm.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/helm/BakeHelmConfigForm.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { StageConfigField } from 'core/pipeline';
+import { StageConfigField } from '../../common/stageConfigField/StageConfigField';
 import { CheckboxInput, TextInput } from 'core/presentation';
 import { MapEditor } from 'core/forms';
 import { IArtifact, IExpectedArtifact, IPipeline } from 'core/domain';

--- a/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/kustomize/BakeKustomizeConfigForm.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/kustomize/BakeKustomizeConfigForm.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
-import { IFormikStageConfigInjectedProps, StageConfigField } from 'core/pipeline';
+import { StageConfigField } from '../../common/stageConfigField/StageConfigField';
+import { IFormikStageConfigInjectedProps } from '../../FormikStageConfig';
 import { StageArtifactSelectorDelegate, ArtifactTypePatterns, excludeAllTypesExcept } from 'core/artifact';
 import { IArtifact, IPipeline } from 'core/domain';
 import { TextInput } from 'core/presentation';

--- a/app/scripts/modules/core/src/pipeline/config/stages/checkPreconditions/CheckPreconditionsExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/checkPreconditions/CheckPreconditionsExecutionDetails.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { get, isBoolean, isString } from 'lodash';
 
-import { StageFailureMessage } from 'core/pipeline';
+import { StageFailureMessage } from '../../../details';
 
 import { ExecutionDetailsSection, IExecutionDetailsSectionProps } from '../common';
 import { robotToHuman } from 'core/presentation/robotToHumanFilter/robotToHuman.filter';

--- a/app/scripts/modules/core/src/pipeline/config/stages/checkPreconditions/checkPreconditionsStage.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/checkPreconditions/checkPreconditionsStage.ts
@@ -1,7 +1,7 @@
 import { IScope, module } from 'angular';
 
 import { Registry } from 'core/registry';
-import { PipelineConfigService } from 'core/pipeline';
+import { PipelineConfigService } from '../../services/PipelineConfigService';
 
 import { CheckPreconditionsExecutionDetails } from './CheckPreconditionsExecutionDetails';
 import { ExecutionDetailsTasks } from '../common/ExecutionDetailsTasks';

--- a/app/scripts/modules/core/src/pipeline/config/stages/cloneServerGroup/CloneServerGroupExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/cloneServerGroup/CloneServerGroupExecutionDetails.tsx
@@ -4,7 +4,7 @@ import { find, get } from 'lodash';
 import { AccountTag } from 'core/account';
 import { ReactInjector } from 'core/reactShims';
 import { ExecutionDetailsSection, IExecutionDetailsSectionProps } from '../common';
-import { StageFailureMessage } from 'core/pipeline';
+import { StageFailureMessage } from '../../../details';
 import { ClusterState } from 'core/state';
 import { UrlBuilder } from 'core/navigation';
 

--- a/app/scripts/modules/core/src/pipeline/config/stages/common/AsgActionExecutionDetailsSection.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/common/AsgActionExecutionDetailsSection.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { StageExecutionLogs, StageFailureMessage } from 'core/pipeline';
+import { StageFailureMessage, StageExecutionLogs } from '../../../details';
 import { ExecutionDetailsSection, IExecutionDetailsSectionProps } from './';
 import { AccountTag } from 'core/account';
 

--- a/app/scripts/modules/core/src/pipeline/config/stages/concourse/ConcourseExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/concourse/ConcourseExecutionDetails.tsx
@@ -1,11 +1,7 @@
 import React from 'react';
 
-import {
-  IExecutionDetailsSectionProps,
-  ExecutionDetailsSection,
-  StageExecutionLogs,
-  StageFailureMessage,
-} from 'core/pipeline';
+import { ExecutionDetailsSection, IExecutionDetailsSectionProps } from '../common';
+import { StageFailureMessage, StageExecutionLogs } from '../../../details';
 
 export function ConcourseExecutionDetails(props: IExecutionDetailsSectionProps) {
   const {

--- a/app/scripts/modules/core/src/pipeline/config/stages/concourse/ConcourseStageConfig.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/concourse/ConcourseStageConfig.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Select, { Option } from 'react-select';
 import { BuildServiceType, IgorService } from 'core/ci';
-import { IStageConfigProps, StageConfigField } from 'core/pipeline';
+import { StageConfigField, IStageConfigProps } from '../common';
 import { ConcourseService } from '../../triggers/concourse/concourse.service';
 
 export interface IConcourseStageConfigState {

--- a/app/scripts/modules/core/src/pipeline/config/stages/deployService/DeployServiceExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/deployService/DeployServiceExecutionDetails.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
-import { ExecutionDetailsSection, IExecutionDetailsSectionProps, StageFailureMessage } from 'core/pipeline';
+import { ExecutionDetailsSection, IExecutionDetailsSectionProps } from '../common';
+import { StageFailureMessage } from '../../../details';
 import { AccountTag } from 'core/account';
 
 export function DeployServiceExecutionDetails(props: IExecutionDetailsSectionProps) {

--- a/app/scripts/modules/core/src/pipeline/config/stages/destroyService/DestroyServiceExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/destroyService/DestroyServiceExecutionDetails.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
-import { ExecutionDetailsSection, IExecutionDetailsSectionProps, StageFailureMessage } from 'core/pipeline';
+import { ExecutionDetailsSection, IExecutionDetailsSectionProps } from '../common';
+import { StageFailureMessage } from '../../../details';
 import { AccountTag } from 'core/account';
 
 export function DestroyServiceExecutionDetails(props: IExecutionDetailsSectionProps) {

--- a/app/scripts/modules/core/src/pipeline/config/stages/disableCluster/DisableClusterExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/disableCluster/DisableClusterExecutionDetails.tsx
@@ -1,11 +1,7 @@
 import React from 'react';
 
-import {
-  ExecutionDetailsSection,
-  IExecutionDetailsSectionProps,
-  StageExecutionLogs,
-  StageFailureMessage,
-} from 'core/pipeline';
+import { IExecutionDetailsSectionProps, ExecutionDetailsSection } from '../common';
+import { StageExecutionLogs, StageFailureMessage } from '../../../details';
 import { AccountTag } from 'core/account';
 import { ServerGroupStageContext } from '../common/ServerGroupStageContext';
 

--- a/app/scripts/modules/core/src/pipeline/config/stages/entityTags/ApplyEntityTagsExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/entityTags/ApplyEntityTagsExecutionDetails.tsx
@@ -1,11 +1,7 @@
 import React from 'react';
 
-import {
-  IExecutionDetailsSectionProps,
-  ExecutionDetailsSection,
-  StageExecutionLogs,
-  StageFailureMessage,
-} from 'core/pipeline';
+import { IExecutionDetailsSectionProps, ExecutionDetailsSection } from '../common';
+import { StageExecutionLogs, StageFailureMessage } from '../../../details';
 export function ApplyEntityTagsExecutionDetails(props: IExecutionDetailsSectionProps) {
   const { current, name, stage } = props;
 

--- a/app/scripts/modules/core/src/pipeline/config/stages/entityTags/ApplyEntityTagsStageConfig.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/entityTags/ApplyEntityTagsStageConfig.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { SETTINGS } from 'core/config';
 import { IEntityRef, IEntityTag, IStage } from 'core/domain';
-import { IStageConfigProps, StageConfigField } from 'core/pipeline';
+import { StageConfigField, IStageConfigProps } from '../common';
 import { FormField, ReactSelectInput, TextInput } from 'core/presentation';
 
 import { TagEditor } from './TagEditor';

--- a/app/scripts/modules/core/src/pipeline/config/stages/evaluateVariables/EvaluateVariablesExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/evaluateVariables/EvaluateVariablesExecutionDetails.tsx
@@ -1,11 +1,7 @@
 import React from 'react';
 
-import {
-  IExecutionDetailsSectionProps,
-  ExecutionDetailsSection,
-  StageExecutionLogs,
-  StageFailureMessage,
-} from 'core/pipeline';
+import { ExecutionDetailsSection, IExecutionDetailsSectionProps } from '../common';
+import { StageFailureMessage, StageExecutionLogs } from '../../../details';
 import { Markdown } from '../../../../presentation';
 
 import { IEvaluatedVariable } from './EvaluateVariablesStageConfig';

--- a/app/scripts/modules/core/src/pipeline/config/stages/evaluateVariables/EvaluateVariablesStageConfig.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/evaluateVariables/EvaluateVariablesStageConfig.tsx
@@ -3,7 +3,8 @@ import { countBy } from 'lodash';
 import { FieldArray } from 'formik';
 
 import { IStage } from 'core/domain';
-import { FormikStageConfig, IFormikStageConfigInjectedProps, IStageConfigProps } from 'core/pipeline';
+import { FormikStageConfig, IFormikStageConfigInjectedProps } from '../FormikStageConfig';
+import { IStageConfigProps } from '../common';
 import {
   FormValidator,
   FormikFormField,

--- a/app/scripts/modules/core/src/pipeline/config/stages/executionWindows/ExecutionWindowExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/executionWindows/ExecutionWindowExecutionDetails.tsx
@@ -1,11 +1,7 @@
 import React from 'react';
 
-import {
-  ExecutionDetailsSection,
-  IExecutionDetailsSectionProps,
-  StageExecutionLogs,
-  StageFailureMessage,
-} from 'core/pipeline';
+import { IExecutionDetailsSectionProps, ExecutionDetailsSection } from '../common';
+import { StageFailureMessage, StageExecutionLogs } from '../../../details';
 import { ExecutionWindowActions } from './ExecutionWindowActions';
 
 export function ExecutionWindowExecutionDetails(props: IExecutionDetailsSectionProps) {

--- a/app/scripts/modules/core/src/pipeline/config/stages/executionWindows/executionWindows.transformer.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/executionWindows/executionWindows.transformer.ts
@@ -1,4 +1,4 @@
-import { ITransformer } from 'core/pipeline';
+import { ITransformer } from '../../PipelineRegistry';
 import { Application } from 'core/application';
 import { IExecution } from 'core/domain';
 

--- a/app/scripts/modules/core/src/pipeline/config/stages/findAmi/FindAmiExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/findAmi/FindAmiExecutionDetails.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
-import { ExecutionDetailsSection, IExecutionDetailsSectionProps, StageFailureMessage } from 'core/pipeline';
+import { IExecutionDetailsSectionProps, ExecutionDetailsSection } from '../common';
+import { StageFailureMessage } from '../../../details';
 import { AccountTag } from 'core/account';
 
 import { IFindAmiStageContext } from './findAmiStage';

--- a/app/scripts/modules/core/src/pipeline/config/stages/findArtifactFromExecution/FindArtifactFromExecutionExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/findArtifactFromExecution/FindArtifactFromExecutionExecutionDetails.tsx
@@ -1,11 +1,7 @@
 import React from 'react';
 
-import {
-  ExecutionDetailsSection,
-  IExecutionDetailsSectionProps,
-  StageExecutionLogs,
-  StageFailureMessage,
-} from 'core/pipeline';
+import { ExecutionDetailsSection, IExecutionDetailsSectionProps } from '../common';
+import { StageExecutionLogs, StageFailureMessage } from '../../../details';
 import { JsonUtils } from 'core/utils';
 
 export class FindArtifactFromExecutionExecutionDetails extends React.Component<IExecutionDetailsSectionProps> {

--- a/app/scripts/modules/core/src/pipeline/config/stages/googleCloudBuild/GoogleCloudBuildExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/googleCloudBuild/GoogleCloudBuildExecutionDetails.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { capitalize, get } from 'lodash';
 
-import { IExecutionDetailsSectionProps, ExecutionDetailsSection } from 'core/pipeline';
+import { IExecutionDetailsSectionProps, ExecutionDetailsSection } from '../common';
 
 export class GoogleCloudBuildExecutionDetails extends React.Component<IExecutionDetailsSectionProps> {
   public static title = 'googleCloudBuildStatus';

--- a/app/scripts/modules/core/src/pipeline/config/stages/gremlin/GremlinExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/gremlin/GremlinExecutionDetails.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
-import { ExecutionDetailsSection, IExecutionDetailsSectionProps, StageFailureMessage } from 'core/pipeline';
+import { ExecutionDetailsSection, IExecutionDetailsSectionProps } from '../common';
+import { StageFailureMessage } from '../../../details';
 
 export function GremlinExecutionDetails(props: IExecutionDetailsSectionProps) {
   const { stage } = props;

--- a/app/scripts/modules/core/src/pipeline/config/stages/gremlin/GremlinStageConfig.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/gremlin/GremlinStageConfig.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { API } from 'core/api/ApiService';
-import { IStageConfigProps, StageConfigField } from 'core/pipeline';
+import { IStageConfigProps, StageConfigField } from '../common';
 import { Observable } from 'rxjs';
 import Select from 'react-select';
 

--- a/app/scripts/modules/core/src/pipeline/config/stages/managed/ImportDeliveryConfigExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/managed/ImportDeliveryConfigExecutionDetails.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
-import { ExecutionDetailsSection, IExecutionDetailsSectionProps, StageFailureMessage } from 'core/pipeline';
+import { ExecutionDetailsSection, IExecutionDetailsSectionProps } from '../common';
+import { StageFailureMessage } from '../../../details';
 import { IGitTrigger } from 'core/domain';
 import { CollapsibleSection, Markdown } from 'core/presentation';
 import { SETTINGS } from 'core/config';

--- a/app/scripts/modules/core/src/pipeline/config/stages/managed/ImportDeliveryConfigStageConfig.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/managed/ImportDeliveryConfigStageConfig.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
 import { SETTINGS } from 'core/config/settings';
-import { IStageConfigProps, FormikStageConfig } from 'core/pipeline';
+import { FormikStageConfig } from '../FormikStageConfig';
+import { IStageConfigProps } from '../common';
 import { FormikFormField, TextInput } from 'core/presentation';
 import { HelpField } from 'core/help';
 

--- a/app/scripts/modules/core/src/pipeline/config/stages/managed/importDeliveryConfigStage.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/managed/importDeliveryConfigStage.ts
@@ -1,5 +1,5 @@
 import { Registry } from 'core/registry';
-import { ExecutionDetailsTasks } from 'core/pipeline';
+import { ExecutionDetailsTasks } from '../common';
 
 import { ImportDeliveryConfigStageConfig } from './ImportDeliveryConfigStageConfig';
 import { ImportDeliveryConfigExecutionDetails } from './ImportDeliveryConfigExecutionDetails';

--- a/app/scripts/modules/core/src/pipeline/config/stages/manualJudgment/ManualJudgmentExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/manualJudgment/ManualJudgmentExecutionDetails.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
-import { IExecutionDetailsSectionProps, StageFailureMessage } from 'core/pipeline';
+import { StageFailureMessage } from '../../../details';
+import { IExecutionDetailsSectionProps } from '../common';
 import { IStage } from 'core/domain';
 import { robotToHuman } from 'core/presentation/robotToHumanFilter/robotToHuman.filter';
 import { timestamp } from 'core/utils/timeFormatters';

--- a/app/scripts/modules/core/src/pipeline/config/stages/monitoreddeploy/DeploymentMonitorExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/monitoreddeploy/DeploymentMonitorExecutionDetails.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { get, isEmpty } from 'lodash';
 
-import { StageFailureMessage, IExecutionDetailsSectionProps, ExecutionDetailsSection } from 'core/pipeline';
+import { IExecutionDetailsSectionProps, ExecutionDetailsSection } from '../common';
+import { StageFailureMessage } from '../../../details';
 import { IExecutionStage } from 'core/domain';
 import { DeploymentMonitorReader, IDeploymentMonitorDefinition } from './DeploymentMonitorReader';
 

--- a/app/scripts/modules/core/src/pipeline/config/stages/overrideFailure/OverrideFailure.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/overrideFailure/OverrideFailure.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { IStage } from 'core/domain';
 import { HelpField } from 'core/help';
 import { RadioButtonInput } from 'core/presentation';
-import { StageConfigField } from 'core/pipeline';
+import { StageConfigField } from '../common';
 
 import './overrideFailure.less';
 

--- a/app/scripts/modules/core/src/pipeline/config/stages/pipeline/PipelineParametersExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/pipeline/PipelineParametersExecutionDetails.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { IExecutionDetailsSectionProps, ExecutionDetailsSection } from 'core/pipeline';
+import { IExecutionDetailsSectionProps, ExecutionDetailsSection } from '../common';
 
 export function PipelineParametersExecutionDetails(props: IExecutionDetailsSectionProps) {
   const {

--- a/app/scripts/modules/core/src/pipeline/config/stages/pipeline/PipelineStageExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/pipeline/PipelineStageExecutionDetails.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { UISref } from '@uirouter/react';
 
-import { IExecutionDetailsSectionProps, ExecutionDetailsSection, StageFailureMessage } from 'core/pipeline';
+import { IExecutionDetailsSectionProps, ExecutionDetailsSection } from '../common';
+import { StageFailureMessage } from '../../../details';
 import { IPipeline } from 'core/domain';
 import { useLatestPromise } from 'core/presentation/hooks/useLatestPromise.hook';
 

--- a/app/scripts/modules/core/src/pipeline/config/stages/pipeline/pipelineStage.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/pipeline/pipelineStage.js
@@ -10,7 +10,7 @@ import { Registry } from 'core/registry';
 import { ExecutionDetailsTasks } from '../common';
 import { PipelineStageExecutionDetails } from './PipelineStageExecutionDetails';
 import { PipelineParametersExecutionDetails } from './PipelineParametersExecutionDetails';
-import { PipelineTemplateReader, PipelineTemplateV2Service } from 'core/pipeline';
+import { PipelineTemplateReader, PipelineTemplateV2Service } from '../../templates';
 
 export const CORE_PIPELINE_CONFIG_STAGES_PIPELINE_PIPELINESTAGE = 'spinnaker.core.pipeline.stage.pipelineStage';
 export const name = CORE_PIPELINE_CONFIG_STAGES_PIPELINE_PIPELINESTAGE; // for backwards compatibility

--- a/app/scripts/modules/core/src/pipeline/config/stages/preconfiguredJob/PreconfiguredJobExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/preconfiguredJob/PreconfiguredJobExecutionDetails.tsx
@@ -1,12 +1,8 @@
 import React from 'react';
 import { get, sortBy, last } from 'lodash';
 
-import {
-  IExecutionDetailsSectionProps,
-  ExecutionDetailsSection,
-  StageExecutionLogs,
-  StageFailureMessage,
-} from 'core/pipeline';
+import { IExecutionDetailsSectionProps, ExecutionDetailsSection } from '../common';
+import { StageExecutionLogs, StageFailureMessage } from '../../../details';
 import { IPreconfiguredJobParameter } from './preconfiguredJob.reader';
 import { JobStageExecutionLogs } from 'core/manifest/stage/JobStageExecutionLogs';
 import { IStage, IJobOwnedPodStatus } from 'core/domain';

--- a/app/scripts/modules/core/src/pipeline/config/stages/preconfiguredJob/PreconfiguredJobStageConfig.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/preconfiguredJob/PreconfiguredJobStageConfig.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { set } from 'lodash';
 
-import { IStageConfigProps, StageConfigField } from 'core/pipeline';
+import { IStageConfigProps, StageConfigField } from '../common';
 import { IPreconfiguredJobParameter } from './preconfiguredJob.reader';
 
 export class PreconfiguredJobStageConfig extends React.Component<IStageConfigProps> {

--- a/app/scripts/modules/core/src/pipeline/config/stages/rollbackCluster/RollbackClusterExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/rollbackCluster/RollbackClusterExecutionDetails.tsx
@@ -1,11 +1,7 @@
 import React from 'react';
 
-import {
-  ExecutionDetailsSection,
-  IExecutionDetailsSectionProps,
-  StageExecutionLogs,
-  StageFailureMessage,
-} from 'core/pipeline';
+import { ExecutionDetailsSection, IExecutionDetailsSectionProps } from '../common';
+import { StageExecutionLogs, StageFailureMessage } from '../../../details';
 import { HelpField } from 'core/help/HelpField';
 import { AccountTag } from 'core/account';
 

--- a/app/scripts/modules/core/src/pipeline/config/stages/savePipelines/SavePipelinesResultsTab.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/savePipelines/SavePipelinesResultsTab.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { get } from 'lodash';
 
-import { IExecutionDetailsSectionProps, ExecutionDetailsSection } from 'core/pipeline';
+import { IExecutionDetailsSectionProps, ExecutionDetailsSection } from '../common';
 import { PipelineRefList } from './PipleineRefList';
 
 export class SavePipelinesResultsTab extends React.Component<IExecutionDetailsSectionProps> {

--- a/app/scripts/modules/core/src/pipeline/config/stages/savePipelines/SavePipelinesStageConfig.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/savePipelines/SavePipelinesStageConfig.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { IStageConfigProps, StageConfigField } from 'core/pipeline';
+import { IStageConfigProps, StageConfigField } from '../common';
 import { IArtifact, IExpectedArtifact, StageArtifactSelector } from 'core';
 
 export const SavePipelinesStageConfig: React.SFC<IStageConfigProps> = props => {

--- a/app/scripts/modules/core/src/pipeline/config/stages/scaleDownCluster/ScaleDownClusterExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/scaleDownCluster/ScaleDownClusterExecutionDetails.tsx
@@ -1,11 +1,7 @@
 import React from 'react';
 
-import {
-  ExecutionDetailsSection,
-  IExecutionDetailsSectionProps,
-  StageExecutionLogs,
-  StageFailureMessage,
-} from 'core/pipeline';
+import { ExecutionDetailsSection, IExecutionDetailsSectionProps } from '../common';
+import { StageExecutionLogs, StageFailureMessage } from '../../../details';
 import { AccountTag } from 'core/account';
 import { ServerGroupStageContext } from '../common/ServerGroupStageContext';
 

--- a/app/scripts/modules/core/src/pipeline/config/stages/script/ScriptExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/script/ScriptExecutionDetails.tsx
@@ -2,7 +2,8 @@ import { RenderOutputFile } from 'core/presentation/RenderOutputFile';
 import React from 'react';
 import { get } from 'lodash';
 
-import { ExecutionDetailsSection, IExecutionDetailsSectionProps, StageFailureMessage } from 'core/pipeline';
+import { ExecutionDetailsSection, IExecutionDetailsSectionProps } from '../common';
+import { StageFailureMessage } from '../../../details';
 
 export function ScriptExecutionDetails(props: IExecutionDetailsSectionProps) {
   const { stage } = props;

--- a/app/scripts/modules/core/src/pipeline/config/stages/script/ScriptStageConfig.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/script/ScriptStageConfig.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
-import { IStageConfigProps, FormikStageConfig, IContextualValidator } from 'core/pipeline';
+import { IStageConfigProps } from '../common/IStageConfigProps';
+import { FormikStageConfig, IContextualValidator } from '../FormikStageConfig';
 import { FormikFormField, TextInput, TextAreaInput, CheckboxInput, FormValidator } from 'core/presentation';
 import { HelpField } from 'core/help';
 

--- a/app/scripts/modules/core/src/pipeline/config/stages/script/scriptStage.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/script/scriptStage.ts
@@ -2,7 +2,7 @@ import { module } from 'angular';
 
 import { Registry } from 'core/registry';
 import { AuthenticationService } from 'core/authentication';
-import { ExecutionDetailsTasks } from 'core/pipeline';
+import { ExecutionDetailsTasks } from '../common';
 
 import { ScriptStageConfig, validate } from './ScriptStageConfig';
 import { ScriptExecutionDetails } from './ScriptExecutionDetails';

--- a/app/scripts/modules/core/src/pipeline/config/stages/shareService/ShareServiceExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/shareService/ShareServiceExecutionDetails.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
-import { ExecutionDetailsSection, IExecutionDetailsSectionProps, StageFailureMessage } from 'core/pipeline';
+import { ExecutionDetailsSection, IExecutionDetailsSectionProps } from '../common';
+import { StageFailureMessage } from '../../../details';
 import { AccountTag } from 'core/account';
 
 export function ShareServiceExecutionDetails(props: IExecutionDetailsSectionProps) {

--- a/app/scripts/modules/core/src/pipeline/config/stages/shrinkCluster/ShrinkClusterExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/shrinkCluster/ShrinkClusterExecutionDetails.tsx
@@ -1,11 +1,7 @@
 import React from 'react';
 
-import {
-  ExecutionDetailsSection,
-  IExecutionDetailsSectionProps,
-  StageExecutionLogs,
-  StageFailureMessage,
-} from 'core/pipeline';
+import { ExecutionDetailsSection, IExecutionDetailsSectionProps } from '../common';
+import { StageExecutionLogs, StageFailureMessage } from '../../../details';
 import { AccountTag } from 'core/account';
 import { ServerGroupStageContext } from '../common/ServerGroupStageContext';
 

--- a/app/scripts/modules/core/src/pipeline/config/stages/unshareService/UnshareServiceExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/unshareService/UnshareServiceExecutionDetails.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
-import { ExecutionDetailsSection, IExecutionDetailsSectionProps, StageFailureMessage } from 'core/pipeline';
+import { ExecutionDetailsSection, IExecutionDetailsSectionProps } from '../common';
+import { StageFailureMessage } from '../../../details';
 import { AccountTag } from 'core/account';
 
 export function UnshareServiceExecutionDetails(props: IExecutionDetailsSectionProps) {

--- a/app/scripts/modules/core/src/pipeline/config/stages/wait/WaitExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/wait/WaitExecutionDetails.tsx
@@ -1,11 +1,7 @@
 import React from 'react';
 
-import {
-  ExecutionDetailsSection,
-  IExecutionDetailsSectionProps,
-  StageExecutionLogs,
-  StageFailureMessage,
-} from 'core/pipeline';
+import { ExecutionDetailsSection, IExecutionDetailsSectionProps } from '../common';
+import { StageExecutionLogs, StageFailureMessage } from '../../../details';
 import { SkipWait } from './SkipWait';
 
 export function WaitExecutionDetails(props: IExecutionDetailsSectionProps) {

--- a/app/scripts/modules/core/src/pipeline/config/stages/wait/WaitStageConfig.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/wait/WaitStageConfig.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { IStageConfigProps } from 'core/pipeline';
+import { IStageConfigProps } from '../common';
 import { SpelNumberInput } from 'core/widgets';
 import { IStage } from 'core/domain';
 import { StageConfigField } from '../common/stageConfigField/StageConfigField';

--- a/app/scripts/modules/core/src/pipeline/config/stages/waitForCondition/WaitForConditionExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/waitForCondition/WaitForConditionExecutionDetails.tsx
@@ -1,11 +1,7 @@
 import React from 'react';
 
-import {
-  ExecutionDetailsSection,
-  IExecutionDetailsSectionProps,
-  StageExecutionLogs,
-  StageFailureMessage,
-} from 'core/pipeline';
+import { ExecutionDetailsSection, IExecutionDetailsSectionProps } from '../common';
+import { StageExecutionLogs, StageFailureMessage } from '../../../details';
 import { SkipConditionWait } from './SkipConditionWait';
 
 export function WaitForConditionExecutionDetails(props: IExecutionDetailsSectionProps) {

--- a/app/scripts/modules/core/src/pipeline/config/stages/waitForCondition/waitForCondition.transformer.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/waitForCondition/waitForCondition.transformer.ts
@@ -1,4 +1,4 @@
-import { ITransformer } from 'core/pipeline';
+import { ITransformer } from '../../PipelineRegistry';
 import { Application } from 'core/application';
 import { IExecution } from 'core/domain';
 

--- a/app/scripts/modules/core/src/pipeline/config/templates/PipelineTemplateReader.ts
+++ b/app/scripts/modules/core/src/pipeline/config/templates/PipelineTemplateReader.ts
@@ -5,7 +5,7 @@ import { API } from 'core/api/ApiService';
 import { IPipeline } from 'core/domain/IPipeline';
 import { IPipelineTemplateV2Collections } from 'core/domain/IPipelineTemplateV2';
 import { IPipelineTemplateConfigV2 } from 'core/domain';
-import { PipelineTemplateV2Service } from 'core/pipeline';
+import { PipelineTemplateV2Service } from './v2/pipelineTemplateV2.service';
 
 export interface IPipelineTemplate {
   id: string;

--- a/app/scripts/modules/core/src/pipeline/config/templates/v2/configurePipelineTemplateModalV2.controller.ts
+++ b/app/scripts/modules/core/src/pipeline/config/templates/v2/configurePipelineTemplateModalV2.controller.ts
@@ -4,7 +4,7 @@ import { without, chain, has } from 'lodash';
 
 import { Application } from 'core/application/application.model';
 import { IPipelineTemplateConfigV2 } from 'core/domain';
-import { PipelineTemplateV2Service } from 'core/pipeline';
+import { PipelineTemplateV2Service } from './pipelineTemplateV2.service';
 import { VariableValidatorService } from '../validators/variableValidator.service';
 
 import {

--- a/app/scripts/modules/core/src/pipeline/config/templates/v2/createPipelineFromTemplate/CreatePipelineFromTemplate.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/templates/v2/createPipelineFromTemplate/CreatePipelineFromTemplate.tsx
@@ -5,7 +5,7 @@ import { Observable, Subject } from 'rxjs';
 
 import { Application, ApplicationReader, IApplicationSummary } from 'core/application';
 import ApplicationSelector from '../ApplicationSelector';
-import { CreatePipelineModal } from 'core/pipeline';
+import { CreatePipelineModal } from '../../../../create';
 import { IPipelineTemplateV2 } from 'core/domain/IPipelineTemplateV2';
 import { ReactInjector } from 'core/reactShims';
 import { Spinner } from 'core/widgets/spinners/Spinner';

--- a/app/scripts/modules/core/src/pipeline/config/triggers/TriggersPageContent.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/TriggersPageContent.tsx
@@ -6,7 +6,7 @@ import { Application } from 'core/application';
 import { ArtifactReferenceService } from 'core/artifact/ArtifactReferenceService';
 import { IExpectedArtifact, IPipeline, ITrigger } from 'core/domain';
 import { HelpField } from 'core/help';
-import { PipelineConfigValidator } from 'core/pipeline';
+import { PipelineConfigValidator } from '../validation/PipelineConfigValidator';
 import { CheckboxInput, FormField } from 'core/presentation';
 import { Registry } from 'core/registry';
 import { SETTINGS } from 'core/config/settings';

--- a/app/scripts/modules/core/src/pipeline/config/triggers/TriggersWrapper.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/TriggersWrapper.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { IPipeline } from 'core/domain';
-import { ITriggersProps, Triggers } from 'core/pipeline';
+import { ITriggersProps, Triggers } from './Triggers';
 
 export class TriggersWrapper extends React.Component<ITriggersProps> {
   private updatePipelineConfig = (changes: Partial<IPipeline>): void => {

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/base64/Base64ArtifactEditor.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/base64/Base64ArtifactEditor.tsx
@@ -3,7 +3,7 @@ import { has, cloneDeep } from 'lodash';
 
 import { ArtifactTypePatterns } from 'core/artifact';
 import { IArtifactEditorProps, IArtifactKindConfig } from 'core/domain';
-import { StageConfigField } from 'core/pipeline';
+import { StageConfigField } from '../../../stages/common';
 import { CopyToClipboard } from 'core/utils';
 import { SpelText } from 'core/widgets';
 

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/bitbucket/BitbucketArtifactEditor.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/bitbucket/BitbucketArtifactEditor.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import { ArtifactTypePatterns } from 'core/artifact';
 import { IArtifactEditorProps, IArtifactKindConfig } from 'core/domain';
-import { StageConfigField } from 'core/pipeline';
+import { StageConfigField } from '../../../stages/common';
 import { SpelText } from 'core/widgets';
 
 import { singleFieldArtifactEditor } from '../singleFieldArtifactEditor';

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/custom/CustomArtifactEditor.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/custom/CustomArtifactEditor.tsx
@@ -3,7 +3,7 @@ import { cloneDeep, extend } from 'lodash';
 
 import { ArtifactTypePatterns } from 'core/artifact';
 import { IArtifactEditorProps, IArtifactKindConfig } from 'core/domain';
-import { StageConfigField } from 'core/pipeline';
+import { StageConfigField } from '../../../stages/common';
 import { SpelText } from 'core/widgets';
 
 import { ArtifactEditor } from '../ArtifactEditor';

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/docker/DockerArtifactEditor.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/docker/DockerArtifactEditor.tsx
@@ -3,7 +3,7 @@ import { cloneDeep, isNil } from 'lodash';
 
 import { ArtifactTypePatterns } from 'core/artifact';
 import { IArtifact, IArtifactEditorProps, IArtifactKindConfig } from 'core/domain';
-import { StageConfigField } from 'core/pipeline';
+import { StageConfigField } from '../../../stages/common';
 import { SpelText } from 'core/widgets';
 
 import { singleFieldArtifactEditor } from '../singleFieldArtifactEditor';

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/gcs/GcsArtifactEditor.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/gcs/GcsArtifactEditor.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import { ArtifactTypePatterns } from 'core/artifact';
 import { IArtifactEditorProps, IArtifactKindConfig } from 'core/domain';
-import { StageConfigField } from 'core/pipeline';
+import { StageConfigField } from '../../../stages/common';
 import { SpelText } from 'core/widgets';
 
 import { singleFieldArtifactEditor } from '../singleFieldArtifactEditor';

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/github/GithubArtifactEditor.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/github/GithubArtifactEditor.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import { ArtifactTypePatterns } from 'core/artifact';
 import { IArtifactEditorProps, IArtifactKindConfig } from 'core/domain';
-import { StageConfigField } from 'core/pipeline';
+import { StageConfigField } from '../../../stages/common';
 import { SpelText } from 'core/widgets';
 
 import { singleFieldArtifactEditor } from '../singleFieldArtifactEditor';

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/gitlab/GitlabArtifactEditor.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/gitlab/GitlabArtifactEditor.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import { ArtifactTypePatterns } from 'core/artifact';
 import { IArtifactEditorProps, IArtifactKindConfig } from 'core/domain';
-import { StageConfigField } from 'core/pipeline';
+import { StageConfigField } from '../../../stages/common';
 import { SpelText } from 'core/widgets';
 
 import { singleFieldArtifactEditor } from '../singleFieldArtifactEditor';

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/gitrepo/GitRepoArtifactEditor.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/gitrepo/GitRepoArtifactEditor.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import { ArtifactTypePatterns } from 'core/artifact';
 import { IArtifactEditorProps, IArtifactKindConfig } from 'core/domain';
-import { StageConfigField } from 'core/pipeline';
+import { StageConfigField } from '../../../stages/common';
 import { SpelText } from 'core/widgets';
 import { CheckboxInput } from 'core/presentation';
 

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/helm/HelmArtifactEditor.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/helm/HelmArtifactEditor.tsx
@@ -4,7 +4,7 @@ import { cloneDeep } from 'lodash';
 
 import { ArtifactTypePatterns } from 'core/artifact';
 import { IArtifact, IArtifactEditorProps, IArtifactKindConfig } from 'core/domain';
-import { StageConfigField } from 'core/pipeline';
+import { StageConfigField } from '../../../stages/common';
 import { TetheredSelect, TetheredCreatable } from 'core/presentation';
 import { ArtifactService } from '../ArtifactService';
 import { Spinner } from 'core/widgets';

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/jenkins/JenkinsArtifactEditor.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/jenkins/JenkinsArtifactEditor.tsx
@@ -6,7 +6,7 @@ import { Option } from 'react-select';
 import { IArtifactEditorProps, IArtifactKindConfig, IBuild } from 'core/domain';
 import { ArtifactTypePatterns } from 'core/artifact';
 import { IgorService } from 'core/ci';
-import { StageConfigField } from 'core/pipeline';
+import { StageConfigField } from '../../../stages/common';
 import { TetheredSelect } from 'core/presentation';
 import { SpelText } from 'core/widgets';
 

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/kubernetes/KubernetesArtifactEditor.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/kubernetes/KubernetesArtifactEditor.tsx
@@ -4,7 +4,7 @@ import Select, { Option } from 'react-select';
 
 import { ArtifactTypePatterns } from 'core/artifact';
 import { IArtifactEditorProps, IArtifactKindConfig } from 'core/domain';
-import { StageConfigField } from 'core/pipeline';
+import { StageConfigField } from '../../../stages/common';
 import { SpelText } from 'core/widgets';
 
 import { ArtifactEditor } from '../ArtifactEditor';

--- a/app/scripts/modules/core/src/pipeline/config/triggers/pipeline/PipelineTrigger.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/pipeline/PipelineTrigger.tsx
@@ -3,7 +3,7 @@ import { FormikProps } from 'formik';
 
 import { ApplicationReader } from 'core/application';
 import { IPipelineTrigger } from 'core/domain';
-import { PipelineConfigService } from 'core/pipeline';
+import { PipelineConfigService } from '../../services/PipelineConfigService';
 import { ChecklistInput, FormikFormField, ReactSelectInput, useLatestPromise } from 'core/presentation';
 
 export interface IPipelineTriggerConfigProps {

--- a/app/scripts/modules/core/src/pipeline/create/CreatePipelineModal.tsx
+++ b/app/scripts/modules/core/src/pipeline/create/CreatePipelineModal.tsx
@@ -20,7 +20,7 @@ import {
 import { Spinner } from 'core/widgets/spinners/Spinner';
 import { IPipelineTemplateV2 } from 'core/domain/IPipelineTemplateV2';
 import { PipelineConfigService } from '../config/services/PipelineConfigService';
-import { PipelineTemplateV2Service } from 'core/pipeline';
+import { PipelineTemplateV2Service } from '../config/templates/v2/pipelineTemplateV2.service';
 
 import { TemplateDescription } from './TemplateDescription';
 import { ManagedTemplateSelector } from './ManagedTemplateSelector';
@@ -390,7 +390,10 @@ export class CreatePipelineModal extends React.Component<ICreatePipelineModalPro
                     </div>
                     <div className="col-md-7">
                       <Select
-                        options={[{ label: 'Pipeline', value: false }, { label: 'Strategy', value: true }]}
+                        options={[
+                          { label: 'Pipeline', value: false },
+                          { label: 'Strategy', value: true },
+                        ]}
                         clearable={false}
                         value={this.state.command.strategy ? { label: 'Strategy' } : { label: 'Pipeline' }}
                         onChange={this.handleTypeChange}

--- a/app/scripts/modules/core/src/pipeline/details/SingleExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/details/SingleExecutionDetails.tsx
@@ -7,7 +7,7 @@ import { Application } from 'core/application/application.model';
 import { IExecution, IPipeline } from 'core/domain';
 import { Execution } from '../executions/execution/Execution';
 import { IScheduler, SchedulerFactory } from 'core/scheduler';
-import { ManualExecutionModal } from 'core/pipeline';
+import { ManualExecutionModal } from '../manualExecution';
 import { ReactInjector, IStateChange } from 'core/reactShims';
 import { Tooltip } from 'core/presentation';
 import { ISortFilter } from 'core/filterModel';

--- a/app/scripts/modules/core/src/pipeline/details/stageSummary.component.ts
+++ b/app/scripts/modules/core/src/pipeline/details/stageSummary.component.ts
@@ -6,7 +6,7 @@ import { Application } from 'core/application';
 import { IExecution, IExecutionStage, IExecutionStageSummary, IStage } from 'core/domain';
 import { Registry } from 'core/registry';
 import { ConfirmationModalService } from 'core/confirmationModal';
-import { ExecutionService } from 'core/pipeline';
+import { ExecutionService } from '../service/execution.service';
 
 export class StageSummaryController implements IController {
   public application: Application;

--- a/app/scripts/modules/core/src/pipeline/executions/Executions.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/Executions.tsx
@@ -10,7 +10,7 @@ import { Subscription } from 'rxjs';
 import { Application } from 'core/application';
 import { IPipeline, IPipelineCommand, IExecution } from 'core/domain';
 import { ReactInjector } from 'core/reactShims';
-import { ManualExecutionModal } from 'core/pipeline';
+import { ManualExecutionModal } from '../manualExecution';
 import { Tooltip } from 'core/presentation/Tooltip';
 
 import { CreatePipeline } from '../config/CreatePipeline';

--- a/app/scripts/modules/core/src/pipeline/executions/executionGroup/ExecutionGroup.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/executionGroup/ExecutionGroup.tsx
@@ -26,7 +26,8 @@ import { RenderWhenVisible } from 'core/utils/RenderWhenVisible';
 import { TriggersTag } from '../../triggers/TriggersTag';
 import { AccountTag } from 'core/account';
 import { ReactInjector } from 'core/reactShims';
-import { ManualExecutionModal, PipelineTemplateReader, PipelineTemplateV2Service } from 'core/pipeline';
+import { ManualExecutionModal } from '../../manualExecution';
+import { PipelineTemplateReader, PipelineTemplateV2Service } from '../../config/templates';
 import { Spinner } from 'core/widgets/spinners/Spinner';
 
 import './executionGroup.less';

--- a/app/scripts/modules/core/src/pipeline/manualExecution/ManualPipelineExecutionModal.tsx
+++ b/app/scripts/modules/core/src/pipeline/manualExecution/ManualPipelineExecutionModal.tsx
@@ -28,7 +28,9 @@ import {
   ITrigger,
 } from 'core/domain';
 import { AppNotificationsService } from 'core/notification/AppNotificationsService';
-import { ArtifactList, IPipelineTemplateConfig, ITriggerTemplateComponentProps } from 'core/pipeline';
+import { ArtifactList } from '../status/ArtifactList';
+import { IPipelineTemplateConfig } from '../config/templates';
+import { ITriggerTemplateComponentProps } from './TriggerTemplate';
 import { Registry } from 'core/registry';
 import { SETTINGS } from 'core/config/settings';
 import { UrlParser } from 'core/navigation/urlParser';

--- a/app/scripts/modules/core/src/pipeline/manualExecution/PipelineOptions.tsx
+++ b/app/scripts/modules/core/src/pipeline/manualExecution/PipelineOptions.tsx
@@ -5,7 +5,7 @@ import { FormikProps } from 'formik';
 import { head } from 'lodash';
 
 import { IParameter, IPipeline, IPipelineCommand, ITrigger } from 'core/domain';
-import { IPipelineTemplateConfig, PipelineTemplateReader, PipelineTemplateV2Service } from 'core/pipeline';
+import { IPipelineTemplateConfig, PipelineTemplateReader, PipelineTemplateV2Service } from '../config/templates';
 import { FormField, TetheredSelect } from 'core/presentation';
 
 export interface IPipelineOptionsProps {

--- a/app/scripts/modules/core/src/presentation/FormElements.tsx
+++ b/app/scripts/modules/core/src/presentation/FormElements.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Tooltip } from 'core/presentation';
+import { Tooltip } from './Tooltip';
 
 export const SpInput = (
   props: React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> & {

--- a/app/scripts/modules/core/src/presentation/HoverablePopover.tsx
+++ b/app/scripts/modules/core/src/presentation/HoverablePopover.tsx
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 import { Overlay, Popover, PopoverProps } from 'react-bootstrap';
 import { Observable, Subject } from 'rxjs';
 
-import { Placement } from 'core/presentation';
+import { Placement } from './Placement';
 import { UUIDGenerator } from 'core/utils';
 
 import './HoverablePopover.css';

--- a/app/scripts/modules/core/src/presentation/Popover.tsx
+++ b/app/scripts/modules/core/src/presentation/Popover.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { OverlayTrigger, Popover as BSPopover } from 'react-bootstrap';
 
-import { Placement, Markdown } from 'core/presentation';
+import { Markdown } from './Markdown';
+import { Placement } from './Placement';
 
 export interface IPopoverProps {
   value?: string;

--- a/app/scripts/modules/core/src/presentation/forms/fields/FormikExpressionRegexField.tsx
+++ b/app/scripts/modules/core/src/presentation/forms/fields/FormikExpressionRegexField.tsx
@@ -1,16 +1,13 @@
 import React from 'react';
 import { getIn } from 'formik';
 
-import {
-  CollapsibleSection,
-  errorMessage,
-  ExpressionError,
-  FormikForm,
-  FormikFormField,
-  ILayoutProps,
-  messageMessage,
-  TextInput,
-} from 'core/presentation';
+import { CollapsibleSection } from '../../collapsibleSection/CollapsibleSection';
+import { ExpressionError } from '../inputs/expression/ExpressionError';
+import { FormikForm } from '../FormikForm';
+import { FormikFormField } from './FormikFormField';
+import { ILayoutProps } from '../layouts';
+import { errorMessage, messageMessage } from '../validation/categories';
+import { TextInput } from '../inputs/TextInput';
 
 import { ExpressionInput, ExpressionPreview, ISpelError } from '../inputs';
 import { IFormikExpressionFieldProps } from './FormikExpressionField';

--- a/app/scripts/modules/core/src/presentation/forms/inputs/NumberInput.tsx
+++ b/app/scripts/modules/core/src/presentation/forms/inputs/NumberInput.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useInternalValidator } from 'core/presentation';
+import { useInternalValidator } from './hooks/useInternalValidator.hook';
 import { composeValidators, IValidator, Validators } from '../validation';
 import { IFormInputProps, OmitControlledInputPropsFrom } from './interface';
 

--- a/app/scripts/modules/core/src/presentation/forms/inputs/RadioButtonInput.tsx
+++ b/app/scripts/modules/core/src/presentation/forms/inputs/RadioButtonInput.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { Option } from 'react-select';
 
-import { Markdown, OmitControlledInputPropsFrom } from 'core/presentation';
+import { Markdown } from '../../Markdown';
+import { OmitControlledInputPropsFrom } from './interface';
 
 import { isStringArray, orEmptyString, validationClassName } from './utils';
 import { IFormInputProps } from './interface';

--- a/app/scripts/modules/core/src/presentation/forms/inputs/expression/ExpressionInput.tsx
+++ b/app/scripts/modules/core/src/presentation/forms/inputs/expression/ExpressionInput.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { isEqual } from 'lodash';
 
-import { IFormInputProps, TextInput } from 'core/presentation';
+import { TextInput } from '../TextInput';
+import { IFormInputProps } from '../interface';
 
 import { IExpressionChange, evaluateExpression } from './evaluateExpression';
 

--- a/app/scripts/modules/core/src/presentation/forms/inputs/expression/ExpressionPreview.tsx
+++ b/app/scripts/modules/core/src/presentation/forms/inputs/expression/ExpressionPreview.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Markdown } from 'core/presentation';
+import { Markdown } from '../../../Markdown';
 
 export interface IExpressionPreviewProps {
   spelPreview: string;

--- a/app/scripts/modules/core/src/presentation/forms/inputs/hooks/useInternalValidator.hook.ts
+++ b/app/scripts/modules/core/src/presentation/forms/inputs/hooks/useInternalValidator.hook.ts
@@ -1,5 +1,5 @@
-import { useIsMountedRef } from 'core/presentation';
 import React from 'react';
+import { useIsMountedRef } from '../../../hooks/useIsMountedRef.hook';
 import { IValidator } from '../../validation';
 import { IFormInputValidation } from '../interface';
 

--- a/app/scripts/modules/core/src/presentation/modal/Modal.tsx
+++ b/app/scripts/modules/core/src/presentation/modal/Modal.tsx
@@ -4,7 +4,8 @@ import { CSSTransition } from 'react-transition-group';
 
 const { useMemo } = React;
 
-import { useEventListener, useContainerClassNames, useLatestCallback, TabBoundary } from 'core/presentation';
+import { useLatestCallback, useContainerClassNames, useEventListener } from '../hooks';
+import { TabBoundary } from '../TabBoundary';
 
 import { ModalContext } from './ModalContext';
 import styles from './Modal.module.css';

--- a/app/scripts/modules/core/src/presentation/refresher/Refresher.tsx
+++ b/app/scripts/modules/core/src/presentation/refresher/Refresher.tsx
@@ -3,7 +3,7 @@ import { $window } from 'ngimport';
 
 import { IScheduler } from 'core/scheduler/SchedulerFactory';
 import { SchedulerFactory } from 'core/scheduler';
-import { Tooltip } from 'core/presentation';
+import { Tooltip } from '../Tooltip';
 import { relativeTime, timestamp } from 'core/utils/timeFormatters';
 
 import './refresher.less';

--- a/app/scripts/modules/core/src/presentation/spel/SpelInput.tsx
+++ b/app/scripts/modules/core/src/presentation/spel/SpelInput.tsx
@@ -1,17 +1,10 @@
 import React from 'react';
 import { SpelService } from './SpelService';
 
-import {
-  ITextInputProps,
-  TextAreaInput,
-  asyncMessage,
-  messageMessage,
-  useDebouncedValue,
-  useInternalValidator,
-  useIsMountedRef,
-  useData,
-  warningMessage,
-} from 'core/presentation';
+import { useDebouncedValue, useIsMountedRef, useData } from '../hooks';
+import { ITextInputProps, TextAreaInput } from '../forms/inputs';
+import { asyncMessage, messageMessage, warningMessage } from '../forms/validation';
+import { useInternalValidator } from '../forms/inputs/hooks';
 
 import './SpelInput.less';
 

--- a/app/scripts/modules/core/src/presentation/spel/SpelService.ts
+++ b/app/scripts/modules/core/src/presentation/spel/SpelService.ts
@@ -1,7 +1,7 @@
 import { isString } from 'lodash';
 
 import { API } from 'core/api';
-import { parseSpelExpressions } from 'core/presentation';
+import { parseSpelExpressions } from '../forms/inputs/expression';
 
 interface IEvaluationException {
   description: string;

--- a/app/scripts/modules/core/src/presentation/spel/SpelToggle.tsx
+++ b/app/scripts/modules/core/src/presentation/spel/SpelToggle.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as classNames from 'classnames';
 
-import { Tooltip } from 'core/presentation';
+import { Tooltip } from '../Tooltip';
 
 interface ISpelToggleProps {
   inputMode: SpelAwareInputMode;

--- a/app/scripts/modules/core/src/presentation/tables/Table.tsx
+++ b/app/scripts/modules/core/src/presentation/tables/Table.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { useIsMobile, useDeepObjectDiff } from 'core/presentation';
+import { useIsMobile, useDeepObjectDiff } from '../hooks';
 
 import { ITableRowLayoutProps } from './TableRow';
 import { ITableCellLayoutProps } from './TableCell';

--- a/app/scripts/modules/core/src/projects/ProjectHeader.tsx
+++ b/app/scripts/modules/core/src/projects/ProjectHeader.tsx
@@ -9,7 +9,7 @@ import { Subject } from 'rxjs';
 import { ReactInjector } from 'core/reactShims';
 import { IProject } from 'core/domain';
 import { SpanDropdownTrigger } from 'core/presentation';
-import { ConfigureProjectModal } from 'core/projects';
+import { ConfigureProjectModal } from './configure/ConfigureProjectModal';
 
 import './project.less';
 

--- a/app/scripts/modules/core/src/search/infrastructure/SearchResultPods.tsx
+++ b/app/scripts/modules/core/src/search/infrastructure/SearchResultPods.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { get } from 'lodash';
 
 import { IRecentHistoryEntry } from 'core/history';
-import { SearchResultType } from 'core/search';
+import { SearchResultType } from '../searchResult/searchResultType';
 
 import { SearchResultPod } from './SearchResultPod';
 import { ProjectSummaryPod } from './ProjectSummaryPod';

--- a/app/scripts/modules/core/src/serverGroup/configure/common/DeployInitializer.tsx
+++ b/app/scripts/modules/core/src/serverGroup/configure/common/DeployInitializer.tsx
@@ -8,7 +8,7 @@ import { AccountTag } from 'core/account';
 import { Application } from 'core/application';
 import { IServerGroup } from 'core/domain';
 import { ReactInjector } from 'core/reactShims';
-import { ServerGroupReader } from 'core/serverGroup';
+import { ServerGroupReader } from '../../serverGroupReader.service';
 import { ModalClose } from 'core/modal';
 import { TetheredSelect } from 'core/presentation/TetheredSelect';
 

--- a/app/scripts/modules/core/src/serverGroup/configure/common/deployInitializer.component.ts
+++ b/app/scripts/modules/core/src/serverGroup/configure/common/deployInitializer.component.ts
@@ -5,7 +5,7 @@ import { groupBy, sortBy } from 'lodash';
 import { IServerGroup } from 'core/domain';
 import { Application } from 'core/application';
 import { PROVIDER_SERVICE_DELEGATE, ProviderServiceDelegate } from 'core/cloudProvider/providerService.delegate';
-import { ServerGroupReader } from 'core/serverGroup';
+import { ServerGroupReader } from '../../serverGroupReader.service';
 
 export interface IDeployTemplate {
   key?: string;

--- a/app/scripts/modules/core/src/serverGroupManager/ServerGroupManagerTag.tsx
+++ b/app/scripts/modules/core/src/serverGroupManager/ServerGroupManagerTag.tsx
@@ -4,7 +4,7 @@ import { Application } from 'core/application';
 import { IServerGroupManager, IServerGroup } from 'core/domain';
 import { ReactInjector } from 'core/reactShims';
 import { Tooltip } from 'core/presentation/Tooltip';
-import { IServerGroupManagerStateParams } from 'core/serverGroupManager';
+import { IServerGroupManagerStateParams } from './serverGroupManager.states';
 
 export interface IServerGroupManagerTagProps {
   application: Application;

--- a/app/scripts/modules/core/src/task/monitor/TaskMonitorWrapper.tsx
+++ b/app/scripts/modules/core/src/task/monitor/TaskMonitorWrapper.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import { CSSTransition } from 'react-transition-group';
 import { Modal } from 'react-bootstrap';
 
-import { TaskMonitor } from 'core/task';
+import { TaskMonitor } from './TaskMonitor';
 import { useForceUpdate } from 'core/presentation/hooks';
 
 import { TaskMonitorStatus } from './TaskMonitorStatus';

--- a/app/scripts/modules/core/src/widgets/notifier/Notifier.tsx
+++ b/app/scripts/modules/core/src/widgets/notifier/Notifier.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Subscription } from 'rxjs';
 
-import { INotifier, NotifierService } from 'core/widgets';
+import { INotifier, NotifierService } from './notifier.service';
 import { Markdown } from 'core/presentation';
 
 export interface INotifierState {

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/eslint-plugin",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "main": "eslint-plugin.js",
   "license": "Apache-2.0",
   "scripts": {

--- a/packages/eslint-plugin/test.eslintrc
+++ b/packages/eslint-plugin/test.eslintrc
@@ -1,4 +1,5 @@
 {
+  parser: '@typescript-eslint/parser',
   "rules": {
   },
   "parserOptions": {

--- a/packages/eslint-plugin/test/import-relative-within-subpackage.spec.js
+++ b/packages/eslint-plugin/test/import-relative-within-subpackage.spec.js
@@ -18,10 +18,6 @@ ruleTester.run('import-relative-within-subpackage', rule, {
       code: `import { Anything } from '../subpackage/foo';`,
     },
     {
-      filename: '/root/spinnaker/deck/app/scripts/modules/core/subpackage/nest/core_source_file.ts',
-      code: `import { Anything } from 'core/subpackage';`,
-    },
-    {
       // kubernetes subpackages are nested under v1 or v2 directory so treat them differently
       filename:
         '/Users/cthielen/netflix/spinnaker/deck/app/scripts/modules/kubernetes/src/v1/pipeline/stages/runJob/configureJob.controller.js',
@@ -50,6 +46,13 @@ ruleTester.run('import-relative-within-subpackage', rule, {
       filename: '/root/spinnaker/deck/app/scripts/modules/core/subpackage/nest/core_source_file.ts',
       code: `import { Anything } from 'core/subpackage/foo/bar';`,
       output: `import { Anything } from '../foo/bar';`,
+      errors: [
+        'Do not use an alias to import from core/subpackage from code inside core/subpackage. Instead, use a relative import',
+      ],
+    },
+    {
+      filename: '/root/spinnaker/deck/app/scripts/modules/core/subpackage/nest/core_source_file.ts',
+      code: `import { Anything } from 'core/subpackage';`,
       errors: [
         'Do not use an alias to import from core/subpackage from code inside core/subpackage. Instead, use a relative import',
       ],

--- a/packages/eslint-plugin/test_rule_against_deck_source.sh
+++ b/packages/eslint-plugin/test_rule_against_deck_source.sh
@@ -5,6 +5,6 @@ if [[ -z "$1" ]] ; then
 else
   RULE={\"$1\":2}
   shift;
-  echo "node ${NODE_OPTS} ../../node_modules/.bin/eslint --no-eslintrc -c test.eslintrc --rulesdir rules --rule $RULE ../../app $*"
-  node ${NODE_OPTS} ../../node_modules/.bin/eslint --no-eslintrc -c test.eslintrc --rulesdir rules --rule $RULE ../../app $*
+  echo "node ${NODE_OPTS} ../../node_modules/.bin/eslint --ext js,ts,jsx,tsx --no-eslintrc -c test.eslintrc --rulesdir rules --rule $RULE ../../app $*"
+  node ${NODE_OPTS} ../../node_modules/.bin/eslint --ext js,ts,jsx,tsx --no-eslintrc -c test.eslintrc --rulesdir rules --rule $RULE ../../app $*
 fi


### PR DESCRIPTION
I have run into cases where circular dependencies (caused by importing from a subpackage barrel from the subpackage itself) has caused imports to be undefined.

This change widens the scope of the `import-relative-within-subpackage` rule to complain about direct subpackage imports.

If code within `core/presentation` imports other symbols directly from `core/presentation`, this rule flags this as an error.  It will not offer a fix, because it's difficult to determine the deeper import. 

I updated the violating imports using webstorm's "modify import" action (yes, I did this almost 200 times, manually).

Please review this PR commit by commit, but only skim the second commit.