### PR TITLE
Preconfigured job stage

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/PipelineRegistry.spec.ts
+++ b/app/scripts/modules/core/src/pipeline/config/PipelineRegistry.spec.ts
@@ -7,7 +7,7 @@ import { IRegion } from 'core/account/AccountService';
 import { Registry } from 'core/registry';
 import { ITriggerTemplateComponentProps } from '../manualExecution/TriggerTemplate';
 import { PipelineRegistry } from './PipelineRegistry';
-import { IPreconfiguredJob, PreconfiguredJobReader } from './stages/preconfiguredJob';
+import { IPreconfiguredJob, makePreconfiguredJobStage, PreconfiguredJobReader } from './stages/preconfiguredJob';
 
 const mockProviderAccount = {
   accountId: 'abc',
@@ -186,8 +186,7 @@ describe('PipelineRegistry: API', function() {
   describe('preconfigured stage', function() {
     beforeEach(mock.inject());
 
-    const makeStage = () => ({ key: 'job', alias: 'preconfiguredJob' } as IStageTypeConfig);
-
+    // Gate response
     const makeJobMetadata = () => {
       return {
         type: 'job',
@@ -202,7 +201,7 @@ describe('PipelineRegistry: API', function() {
 
     it('registration returns a promise', async () => {
       spyOnReader();
-      const result = Registry.pipeline.registerPreconfiguredJobStage(makeStage());
+      const result = Registry.pipeline.registerPreconfiguredJobStage(makePreconfiguredJobStage('job'));
       expect(typeof result.then).toBe('function');
       await result;
     });
@@ -210,19 +209,19 @@ describe('PipelineRegistry: API', function() {
     it('registers a stage', async () => {
       spyOnReader();
       expect(Registry.pipeline.getStageTypes().length).toBe(0);
-      await Registry.pipeline.registerPreconfiguredJobStage(makeStage());
+      await Registry.pipeline.registerPreconfiguredJobStage(makePreconfiguredJobStage('job'));
       expect(Registry.pipeline.getStageTypes().length).toBe(1);
     });
 
     it('fetches fresh preconfigured jobs metadata from gate', async () => {
       const spy = spyOnReader();
-      await Registry.pipeline.registerPreconfiguredJobStage(makeStage());
+      await Registry.pipeline.registerPreconfiguredJobStage(makePreconfiguredJobStage('job'));
       expect(spy).toHaveBeenCalledTimes(1);
     });
 
     it('applies default job parameters to the stage config', async () => {
       spyOnReader();
-      await Registry.pipeline.registerPreconfiguredJobStage(makeStage());
+      await Registry.pipeline.registerPreconfiguredJobStage(makePreconfiguredJobStage('job'));
       const stageType = Registry.pipeline.getStageTypes()[0];
       expect(stageType.defaults.parameters).toEqual({ param: 'abc' });
     });

--- a/app/scripts/modules/core/src/pipeline/config/stages/preconfiguredJob/index.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/preconfiguredJob/index.ts
@@ -1,0 +1,2 @@
+export * from './preconfiguredJobStage';
+export * from './preconfiguredJob.reader';

--- a/app/scripts/modules/core/src/pipeline/config/stages/preconfiguredJob/preconfiguredJobStage.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/preconfiguredJob/preconfiguredJobStage.ts
@@ -1,39 +1,43 @@
 import { module } from 'angular';
-import { fromPairs } from 'lodash';
+import { IStageTypeConfig } from 'core/domain';
 import { Registry } from 'core/registry';
 import { ExecutionDetailsTasks } from '../common';
+import { IPreconfiguredJob, PreconfiguredJobReader } from './preconfiguredJob.reader';
 import { PreconfiguredJobExecutionDetails } from './PreconfiguredJobExecutionDetails';
 import { PreconfiguredJobStageConfig } from './PreconfiguredJobStageConfig';
-import { PreconfiguredJobReader } from './preconfiguredJob.reader';
+
+export function buildPreconfiguredJobStage(job: IPreconfiguredJob): IStageTypeConfig {
+  const { label, description, type, waitForCompletion, parameters, producesArtifacts } = job;
+
+  return {
+    label,
+    description,
+    key: type,
+    alias: 'preconfiguredJob',
+    addAliasToConfig: true,
+    restartable: true,
+    // Overriden when the
+    defaults: { parameters: {} },
+    component: PreconfiguredJobStageConfig,
+    executionDetailsSections: [PreconfiguredJobExecutionDetails, ExecutionDetailsTasks],
+    configuration: {
+      waitForCompletion,
+      parameters,
+    },
+    producesArtifacts,
+  };
+}
 
 export const PRECONFIGUREDJOB_STAGE = 'spinnaker.core.pipeline.stage.preconfiguredJobStage';
 
 module(PRECONFIGUREDJOB_STAGE, []).run(() => {
   PreconfiguredJobReader.list().then(preconfiguredJobs => {
-    preconfiguredJobs
-      .filter(job => job.uiType !== 'CUSTOM')
-      .forEach(preconfiguredJob => {
-        const { label, description, type, waitForCompletion, parameters, producesArtifacts } = preconfiguredJob;
-        const paramDefaults = fromPairs(parameters.filter(p => p.defaultValue).map(p => [p.name, p.defaultValue]));
-
-        Registry.pipeline.registerStage({
-          label,
-          description,
-          key: type,
-          alias: 'preconfiguredJob',
-          addAliasToConfig: true,
-          restartable: true,
-          defaults: {
-            parameters: paramDefaults,
-          },
-          component: PreconfiguredJobStageConfig,
-          executionDetailsSections: [PreconfiguredJobExecutionDetails, ExecutionDetailsTasks],
-          configuration: {
-            waitForCompletion,
-            parameters,
-          },
-          producesArtifacts,
-        });
-      });
+    const basicPreconfiguredJobs = preconfiguredJobs.filter(job => job.uiType !== 'CUSTOM');
+    return Promise.all(
+      basicPreconfiguredJobs.map(job => {
+        const stageConfig = buildPreconfiguredJobStage(job);
+        return Registry.pipeline.registerPreconfiguredJobStage(stageConfig);
+      }),
+    );
   });
 });

--- a/app/scripts/modules/core/src/pipeline/index.ts
+++ b/app/scripts/modules/core/src/pipeline/index.ts
@@ -7,7 +7,7 @@ export * from './config/stages/bake/BakeExecutionLabel';
 export * from './config/stages/bake/BakeryReader';
 export * from './config/stages/common';
 export * from './config/stages/pipeline/PipelineStageExecutionDetails';
-export * from './config/stages/preconfiguredJob/preconfiguredJob.reader';
+export * from './config/stages/preconfiguredJob';
 export * from './config/stages/stageConstants';
 export * from './config/stages/templates';
 export * from './config/templates';

--- a/app/scripts/modules/core/src/plugins/plugin.registry.ts
+++ b/app/scripts/modules/core/src/plugins/plugin.registry.ts
@@ -5,6 +5,7 @@ import { $http } from 'ngimport';
 
 export interface IDeckPlugin {
   stages?: IStageTypeConfig[];
+  preconfiguredJobStages?: IStageTypeConfig[];
   initialize?(): void;
 }
 
@@ -168,6 +169,7 @@ export class PluginRegistry {
 
       // Register extensions with deck.
       plugin.stages?.forEach(stage => Registry.pipeline.registerStage(stage));
+      plugin.preconfiguredJobStages?.forEach(stage => Registry.pipeline.registerPreconfiguredJobStage(stage));
 
       // Run code that currently does not have an extension point
       plugin.initialize?.();


### PR DESCRIPTION
This allows registration of a preconfigured job stage UI. The parameter configuration for the stage is fetched from gate.  

This PR also enables plugins to export preconfiguredJob stages