### PR TITLE
Add hooks for observables, data sources

### DIFF
--- a/app/scripts/modules/core/src/presentation/hooks/index.ts
+++ b/app/scripts/modules/core/src/presentation/hooks/index.ts
@@ -1,6 +1,7 @@
 export * from './useContainerClassNames.hook';
 export * from './useData.hook';
 export * from './usePollingData.hook';
+export * from './useDataSource.hook';
 export * from './useDebouncedValue.hook';
 export * from './useDeepObjectDiff.hook';
 export * from './useEventListener.hook';
@@ -9,4 +10,6 @@ export * from './useIsMobile.hook';
 export * from './useIsMountedRef.hook';
 export * from './useLatestCallback.hook';
 export * from './useLatestPromise.hook';
+export * from './useObservable.hook';
+export * from './useObservableValue.hook';
 export * from './usePrevious.hook';

--- a/app/scripts/modules/core/src/presentation/hooks/useDataSource.hook.ts
+++ b/app/scripts/modules/core/src/presentation/hooks/useDataSource.hook.ts
@@ -1,0 +1,32 @@
+import { useObservableValue } from './useObservableValue.hook';
+import { useLatestCallback } from './useLatestCallback.hook';
+
+import { ApplicationDataSource } from '../../application';
+
+export interface IDataSourceResult<T> {
+  data: T;
+  refresh: () => void;
+}
+
+/**
+ * A react hook that returns the current value an ApplicationDataSource
+ * and triggers a re-render when a new value is set. Also provides a function
+ * for refreshing the data source manually.
+ *
+ * @param dataSource the data source to subscribe to
+ * @returns IDataSourceResult<T>
+ */
+export const useDataSource = <T>(dataSource: ApplicationDataSource<T>): IDataSourceResult<T> => {
+  const data = useObservableValue(dataSource.data$, dataSource.data$.value);
+
+  // Memoize to give consumers a stable ref,
+  // but don't return the promise that dataSource.refresh() returns
+  const refresh = useLatestCallback(() => {
+    dataSource.refresh();
+  });
+
+  return {
+    data,
+    refresh,
+  };
+};

--- a/app/scripts/modules/core/src/presentation/hooks/useObservable.hook.ts
+++ b/app/scripts/modules/core/src/presentation/hooks/useObservable.hook.ts
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+import { Observable } from 'rxjs';
+
+/**
+ * A react hook that subscribes to an rxjs observable on mount and calls the provided callback when
+ * a new value is emitted. Unsubscribes on unmount or when the observable parameter changes.
+ *
+ * @param observable the rxjs observable to subscribe to
+ * @param callback the function to call when the observable emits a value.
+ * Passed the new value as its only argument.
+ * @returns void
+ */
+export const useObservable = <T>(observable: Observable<T>, callback: (val: T) => void) => {
+  useEffect(() => {
+    const subscription = observable.subscribe(callback);
+    return () => subscription.unsubscribe();
+  }, [observable]);
+};

--- a/app/scripts/modules/core/src/presentation/hooks/useObservableValue.hook.ts
+++ b/app/scripts/modules/core/src/presentation/hooks/useObservableValue.hook.ts
@@ -1,0 +1,19 @@
+import { useState } from 'react';
+import { Observable } from 'rxjs';
+
+import { useObservable } from './useObservable.hook';
+
+/**
+ * A react hook that returns the current value of an rxjs observable
+ * and triggers a re-render when a new value is emitted.
+ *
+ * @param observable the rxjs observable to subscribe to
+ * @param defaultValue the (optional) value to return before the observable
+ * has emitted a value (for example, when the component is first mounting)
+ * @returns the most recent value of the observable
+ */
+export const useObservableValue = <T>(observable: Observable<T>, defaultValue?: T) => {
+  const [value, setValue] = useState<T>(defaultValue);
+  useObservable(observable, setValue);
+  return value;
+};


### PR DESCRIPTION
This introduces 3 new hooks, each one builds off the former:

**useObservable**
Calls a callback every time an observable emits a value. When you get that value is determined by the observable — if it immediately emits, you'll receive a value then, but if it only emits when something changes you might not get called for a while (or ever)

**useObservableValue**
Delegates to `useObservable` for subscribing to an observable, but returns the value directly from the hook and takes care of triggering a component re-render when the value changes. Also accepts a default value so you can avoid an initial `undefined` value on renders before the first observable value is emitted

**useDataSource**
Delegates to `useObservableValue`. When given a data source, immediately returns an object (`IDataSourceResult`) which first contains the value of `dataSource.data`, and then triggers updates whenever that value changes. The result object returned by the hook also includes a `refresh` function to trigger data source refreshes,  which has a stable reference (even when the data source changes)