### PR TITLE
fix(amazon/instance): Show health status failure reason for load balancers

### DIFF
--- a/app/scripts/modules/core/src/instance/loadBalancer/InstanceLoadBalancerHealth.tsx
+++ b/app/scripts/modules/core/src/instance/loadBalancer/InstanceLoadBalancerHealth.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { OverlayTrigger, Tooltip } from 'react-bootstrap';
 
 export interface InstanceLoadBalancer {
   healthState?: string; // (usually present but) optional because there's a fallback
@@ -24,7 +23,6 @@ export class InstanceLoadBalancerHealth extends React.Component<IInstanceLoadBal
     } = this.props;
 
     const health = healthState || (state === 'InService' ? 'Up' : 'OutOfService');
-    const displayName = name || loadBalancerName;
 
     let icon = null;
     if (health === 'Up') {
@@ -35,49 +33,28 @@ export class InstanceLoadBalancerHealth extends React.Component<IInstanceLoadBal
       icon = <span className="glyphicon glyphicon-Starting-triangle" />;
     }
 
-    // We need to continue injecting spaces so that angular and react components align
-    // until everything in a particular view is react and we can move them all to margins
-    const artificialSpaceBetweenSpans = icon ? ' ' : null;
+    const displayName = <span>{name || loadBalancerName}</span>;
 
-    const healthDiv = (
-      <div style={{ display: 'inline-block' }}>
-        {icon}
-        {artificialSpaceBetweenSpans}
-        <span>{displayName}</span>
-      </div>
+    const downReason =
+      healthState !== 'Up' && !!description ? (
+        <span style={{ color: 'var(--color-danger)' }}>{description}</span>
+      ) : null;
+
+    const healthCheckLink = (
+      <a target="_blank" href={`${healthCheckProtocol}://${ipAddress}${healthCheckPath}`}>
+        Health Check
+      </a>
     );
-
-    const healthCheckLinkSpan = (
-      <span className="pad-left small">
-        <a
-          ng-if="targetGroup.healthCheckPath"
-          target="_blank"
-          href={`${healthCheckProtocol}://${ipAddress}${healthCheckPath}`}
-        >
-          Health Check
-        </a>
-      </span>
-    );
-
-    // Only wrap with tooltip if we have text for a tooltip
-    const tooltipText = healthState !== 'Up' ? description : '';
-    if (tooltipText) {
-      const tooltip = <Tooltip id={name}>{tooltipText}</Tooltip>;
-      return (
-        <OverlayTrigger placement="left" overlay={tooltip}>
-          <>
-            {healthDiv}
-            {ipAddress && healthCheckPath && healthCheckLinkSpan}
-          </>
-        </OverlayTrigger>
-      );
-    }
 
     return (
-      <>
-        {healthDiv}
-        {ipAddress && healthCheckPath && healthCheckLinkSpan}
-      </>
+      <div className="flex-container-h">
+        <div style={{ width: '20px' }}>{icon}</div>
+        <div className="flex-container-v">
+          {displayName}
+          {downReason}
+          {ipAddress && healthCheckPath && healthCheckLink}
+        </div>
+      </div>
     );
   }
 }

--- a/app/scripts/modules/core/src/instance/loadBalancer/InstanceLoadBalancerHealth.tsx
+++ b/app/scripts/modules/core/src/instance/loadBalancer/InstanceLoadBalancerHealth.tsx
@@ -48,7 +48,7 @@ export class InstanceLoadBalancerHealth extends React.Component<IInstanceLoadBal
 
     return (
       <div className="flex-container-h">
-        <div style={{ width: '20px' }}>{icon}</div>
+        <div style={{ flex: 'none', width: '16px' }}>{icon}</div>
         <div className="flex-container-v">
           {displayName}
           {downReason}


### PR DESCRIPTION
The health failure reason used to be a popover, but the functionality was lost during a refactor.
Instead of restoring the popover functionality, always surface error reasons below a target group.

Also change the layout to flexbox to avoid weird line wrapping issues.

# Before

<img width="373" alt="Screen Shot 2020-03-12 at 7 56 49 PM" src="https://user-images.githubusercontent.com/2053478/76585471-b2c22d80-649b-11ea-844f-99a477a42f97.png">

<img width="343" alt="Screen Shot 2020-03-12 at 7 56 56 PM" src="https://user-images.githubusercontent.com/2053478/76585491-c2417680-649b-11ea-8825-1f7efd7f09de.png">

# After

<img width="469" alt="Screen Shot 2020-03-12 at 8 06 21 PM" src="https://user-images.githubusercontent.com/2053478/76586077-084b0a00-649d-11ea-9206-fa86d33ca1c3.png">

<img width="365" alt="Screen Shot 2020-03-12 at 8 06 14 PM" src="https://user-images.githubusercontent.com/2053478/76586083-0c772780-649d-11ea-8c2d-8bb3af34655d.png">
