### PR TITLE
feat(md): Generate fallback artifact info using Frigga

### DIFF
--- a/app/scripts/modules/core/src/managed/ArtifactsList.tsx
+++ b/app/scripts/modules/core/src/managed/ArtifactsList.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { IManagedArtifactSummary } from '../domain/IManagedEntity';
+import { IManagedArtifactSummary, IManagedArtifactVersion } from '../domain/IManagedEntity';
 import { ISelectedArtifact } from './Environments';
 import { Pill } from './Pill';
 import { parseName } from './Frigga';
@@ -17,13 +17,12 @@ export function ArtifactsList({ artifacts, artifactSelected }: IArtifactsListPro
   return (
     <div>
       {artifacts.map(({ versions, name }) =>
-        versions.map(({ version }, i) => (
+        versions.map((version, i) => (
           <ArtifactRow
-            key={`${name}-${version}-${i}`} // appending index until name-version is guaranteed to be unique
+            key={`${name}-${version.version}-${i}`} // appending index until name-version is guaranteed to be unique
             clickHandler={artifactSelected}
             version={version}
             name={name}
-            sha=""
             stages={[4, 3, 0]}
           />
         )),
@@ -34,22 +33,22 @@ export function ArtifactsList({ artifacts, artifactSelected }: IArtifactsListPro
 
 interface IArtifactRowProps {
   clickHandler: (artifact: ISelectedArtifact) => void;
-  version: string;
+  version: IManagedArtifactVersion;
   name: string;
-  sha: string;
   stages: any[];
 }
 
-export function ArtifactRow({ clickHandler, version: versionString, name, sha, stages }: IArtifactRowProps) {
-  const { packageName, version, buildNumber, commit } = parseName(versionString);
+export function ArtifactRow({ clickHandler, version, name, stages }: IArtifactRowProps) {
+  const versionString = version.version;
+  const { packageName, version: packageVersion, buildNumber, commit } = parseName(versionString);
   return (
-    <div className={styles.ArtifactRow} onClick={() => clickHandler({ name, version })}>
+    <div className={styles.ArtifactRow} onClick={() => clickHandler({ name, version: versionString })}>
       <div className={styles.content}>
         <div className={styles.version}>
-          <Pill text={`#${buildNumber}`} />
+          <Pill text={buildNumber ? `#${buildNumber}` : packageVersion || versionString} />
         </div>
         <div className={styles.text}>
-          <div className={styles.sha}>{sha || commit}</div>
+          <div className={styles.sha}>{commit}</div>
           <div className={styles.name}>{name || packageName}</div>
         </div>
         {/* Holding spot for status bubbles */}

--- a/app/scripts/modules/core/src/managed/ArtifactsList.tsx
+++ b/app/scripts/modules/core/src/managed/ArtifactsList.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { IManagedArtifactSummary } from '../domain/IManagedEntity';
 import { ISelectedArtifact } from './Environments';
 import { Pill } from './Pill';
+import { parseName } from './Frigga';
 
 import styles from './ArtifactRow.module.css';
 
@@ -22,7 +23,7 @@ export function ArtifactsList({ artifacts, artifactSelected }: IArtifactsListPro
             clickHandler={artifactSelected}
             version={version}
             name={name}
-            sha="abc123"
+            sha=""
             stages={[4, 3, 0]}
           />
         )),
@@ -39,16 +40,17 @@ interface IArtifactRowProps {
   stages: any[];
 }
 
-export function ArtifactRow({ clickHandler, version, name, sha, stages }: IArtifactRowProps) {
+export function ArtifactRow({ clickHandler, version: versionString, name, sha, stages }: IArtifactRowProps) {
+  const { packageName, version, buildNumber, commit } = parseName(versionString);
   return (
     <div className={styles.ArtifactRow} onClick={() => clickHandler({ name, version })}>
       <div className={styles.content}>
         <div className={styles.version}>
-          <Pill text={version} />
+          <Pill text={`#${buildNumber}`} />
         </div>
         <div className={styles.text}>
-          <div className={styles.sha}>{sha}</div>
-          <div className={styles.name}>{name}</div>
+          <div className={styles.sha}>{sha || commit}</div>
+          <div className={styles.name}>{name || packageName}</div>
         </div>
         {/* Holding spot for status bubbles */}
       </div>

--- a/app/scripts/modules/core/src/managed/Frigga.ts
+++ b/app/scripts/modules/core/src/managed/Frigga.ts
@@ -1,0 +1,28 @@
+export interface IParsedVersionComponents {
+  packageName: string;
+  version: string;
+  buildNumber: string;
+  commit: string;
+}
+
+// Lifted from Netflix/frigga
+// https://github.com/Netflix/frigga/blob/master/src/main/java/com/netflix/frigga/ami/AppVersion.java
+// https://github.com/Netflix/frigga/blob/master/src/main/java/com/netflix/frigga/NameConstants.java
+export function parseName(amiName: string): IParsedVersionComponents {
+  const NAME_CHARS = 'a-zA-Z0-9._';
+  const EXTENDED_NAME_CHARS = NAME_CHARS + '~\\^';
+  const NAME_HYPHEN_CHARS = '-' + EXTENDED_NAME_CHARS;
+  const regex =
+    '([' +
+    NAME_HYPHEN_CHARS +
+    ']+)-([0-9.a-zA-Z~]+)-(\\w+)(?:[.](\\w+))?(?:\\/([' +
+    NAME_HYPHEN_CHARS +
+    ']+)\\/([0-9]+))?';
+  const match = amiName.match(regex);
+  if (match) {
+    const [, packageName, version, buildString, commit] = match;
+    const buildNumber = buildString?.substring(1);
+    return { packageName, version, buildNumber, commit };
+  }
+  return null;
+}


### PR DESCRIPTION
This is temporary.

The following pieces of information is much more meaningful to users of the environments UI than the currently available raw artifact version string:

* A meaningful artifact version number (usually the CI build number)
* Commit hash

Until keel builds proper support for returning rich artifact metadata, Queen of Asgard will parse that information out from the artifact version string for some artifact types.

Before
![keeldemo_·_Environments](https://user-images.githubusercontent.com/1633736/76673289-ea46dd80-6560-11ea-8b5b-804bf9998ea3.png)

After
![keeldemo_·_Environments](https://user-images.githubusercontent.com/1633736/76673336-3c87fe80-6561-11ea-8f95-32aec6ce9f3c.png)
