### PR TITLE
feat(core/managed): add artifact detail pane to environments

### DIFF
--- a/app/scripts/modules/core/src/managed/ArtifactDetail.less
+++ b/app/scripts/modules/core/src/managed/ArtifactDetail.less
@@ -1,0 +1,15 @@
+.ArtifactDetail {
+  background-color: var(--color-white);
+  padding: 16px 0 64px 16px;
+
+  .detail-section-left {
+    flex: 0 0 280px;
+    font-style: italic;
+    font-size: 14px;
+    color: var(--color-charcoal);
+  }
+
+  .detail-section-right {
+    flex: 1 1 auto;
+  }
+}

--- a/app/scripts/modules/core/src/managed/ArtifactDetail.tsx
+++ b/app/scripts/modules/core/src/managed/ArtifactDetail.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import { IManagedArtifactVersion } from '../domain';
+import { useEventListener } from '../presentation';
+
+import { ArtifactDetailHeader } from './ArtifactDetailHeader';
+
+import './ArtifactDetail.less';
+
+export interface IArtifactDetailProps {
+  name: string;
+  version: IManagedArtifactVersion;
+  onRequestClose: () => any;
+}
+
+export const ArtifactDetail = ({ name, version, onRequestClose }: IArtifactDetailProps) => {
+  const keydownCallback = ({ keyCode }: KeyboardEvent) => {
+    if (keyCode === 27 /* esc */) {
+      onRequestClose();
+    }
+  };
+  useEventListener(document, 'keydown', keydownCallback);
+
+  return (
+    <>
+      <ArtifactDetailHeader name={name} version={version.version} onRequestClose={onRequestClose} />
+
+      <div className="ArtifactDetail">
+        <div className="flex-container-h">
+          {/* a short summary with actions/buttons will live here */}
+          <div className="detail-section-right">{/* artifact metadata will live here */}</div>
+        </div>
+      </div>
+    </>
+  );
+};

--- a/app/scripts/modules/core/src/managed/ArtifactDetailHeader.less
+++ b/app/scripts/modules/core/src/managed/ArtifactDetailHeader.less
@@ -1,0 +1,41 @@
+.ArtifactDetailHeader {
+  background-color: rgb(100, 140, 175);
+  height: 64px;
+  color: var(--color-white);
+  font-size: 14px;
+  padding: 0 8px 0 16px;
+
+  .header-section-left {
+    flex: 0 0 112px;
+  }
+
+  .header-section-center {
+    flex: 1 1 auto;
+    text-align: center;
+    font-size: 14px;
+  }
+
+  .header-version-pill {
+    margin-left: 16px;
+    background-color: var(--color-white);
+    color: rgb(100, 140, 175);
+    border-radius: 24px;
+    line-height: 24px;
+    height: 24px;
+    font-size: 16px;
+    flex: 0 0 54px;
+    padding: 0 12px 0 10px;
+    text-align: center;
+  }
+
+  .header-close {
+    cursor: pointer;
+    width: 48px;
+    height: 48px;
+    margin-left: 72px;
+  }
+
+  .header-close:hover {
+    background-image: linear-gradient(to bottom, rgba(160, 180, 220, 0.2), rgba(160, 180, 220, 0.2));
+  }
+}

--- a/app/scripts/modules/core/src/managed/ArtifactDetailHeader.tsx
+++ b/app/scripts/modules/core/src/managed/ArtifactDetailHeader.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+
+import { parseName } from './Frigga';
+
+import './ArtifactDetailHeader.less';
+
+export interface IArtifactDetailHeaderProps {
+  name: string;
+  version: string;
+  onRequestClose: () => any;
+}
+
+export const ArtifactDetailHeader = ({ name, version, onRequestClose }: IArtifactDetailHeaderProps) => {
+  const { version: packageVersion, buildNumber } = parseName(version);
+
+  return (
+    <div className="ArtifactDetailHeader flex-container-h space-between middle text-bold">
+      <div className="header-section-left flex-container-h middle">
+        {/* embed SVG direclty here until we get either a new SVG impl
+            for icons (in the works) or move these into the icon font */}
+        <svg
+          version="1.1"
+          xmlns="http://www.w3.org/2000/svg"
+          xmlnsXlink="http://www.w3.org/1999/xlink"
+          x="0px"
+          y="0px"
+          viewBox="0 0 24 24"
+          xmlSpace="preserve"
+          fill="white"
+          width="40px"
+        >
+          <g>
+            <path
+              d="M1.5,24C0.673,24,0,23.327,0,22.5V7.82c0-0.165,0.029-0.331,0.085-0.494C0.088,7.318,0.095,7.3,0.099,7.293
+		c0.04-0.115,0.104-0.237,0.18-0.345l4.514-6.32C5.074,0.235,5.53,0,6.014,0h11.971c0.485,0,0.941,0.235,1.222,0.628l4.514,6.32
+		c0.077,0.107,0.14,0.23,0.189,0.365C23.971,7.488,24,7.655,24,7.82V22.5c0,0.827-0.673,1.5-1.5,1.5H1.5z M1,22.5
+		C1,22.776,1.224,23,1.5,23h21c0.276,0,0.5-0.224,0.5-0.5V8H1V22.5z M22.529,7l-4.135-5.791C18.3,1.078,18.147,1,17.986,1H12.5v6
+		H22.529z M11.5,7V1H6.014C5.853,1,5.701,1.078,5.607,1.209L1.471,7H11.5z"
+            />
+            <path
+              d="M13.001,21c-0.552,0-1-0.448-1-1v-2c0-0.552,0.448-1,1-1h7c0.552,0,1,0.448,1,1v2c0,0.552-0.448,1-1,1H13.001z M13.001,20
+		h7v-2h-7L13.001,20z"
+            />
+          </g>
+        </svg>
+        <span className="header-version-pill">{buildNumber ? `#${buildNumber}` : packageVersion || version}</span>
+      </div>
+
+      <div className="header-section-center">{name}</div>
+
+      <div className="header-close flex-container-h center middle" onClick={() => onRequestClose()}>
+        {/* embed SVG direclty here until we get either a new SVG impl
+            for icons (in the works) or move these into the icon font */}
+        <svg
+          version="1.1"
+          xmlns="http://www.w3.org/2000/svg"
+          xmlnsXlink="http://www.w3.org/1999/xlink"
+          x="0px"
+          y="0px"
+          viewBox="0 0 24 24"
+          xmlSpace="preserve"
+          fill="white"
+          width="24px"
+        >
+          <g>
+            <path
+              d="M23.5,23.999c-0.134,0-0.259-0.052-0.354-0.146L12,12.706L0.854,23.853c-0.094,0.094-0.22,0.146-0.354,0.146
+		s-0.259-0.052-0.354-0.146c-0.195-0.195-0.195-0.512,0-0.707l11.146-11.146L0.147,0.853c-0.195-0.195-0.195-0.512,0-0.707
+		C0.241,0.051,0.367-0.001,0.5-0.001s0.259,0.052,0.354,0.146L12,11.292L23.147,0.146c0.094-0.094,0.22-0.146,0.354-0.146
+		s0.259,0.052,0.354,0.146c0.195,0.195,0.195,0.512,0,0.707L12.707,11.999l11.146,11.146c0.195,0.195,0.195,0.512,0,0.707
+		C23.759,23.947,23.634,23.999,23.5,23.999z"
+            />
+          </g>
+        </svg>
+      </div>
+    </div>
+  );
+};

--- a/app/scripts/modules/core/src/managed/ArtifactRow.module.css
+++ b/app/scripts/modules/core/src/managed/ArtifactRow.module.css
@@ -1,10 +1,14 @@
 .ArtifactRow {
   height: 48px;
   display: block;
-}
-.ArtifactRow:hover {
   cursor: pointer;
+}
+.ArtifactRow:not(.selected):hover {
   background-image: linear-gradient(to bottom, rgba(160, 180, 220, 0.15), rgba(160, 180, 220, 0.15));
+}
+
+.selected {
+  background-color: var(--color-white);
 }
 
 .content {
@@ -24,6 +28,9 @@
 }
 .sha {
   font-size: 14px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
 }
 .name {
   font-size: 12px;

--- a/app/scripts/modules/core/src/managed/ArtifactsList.tsx
+++ b/app/scripts/modules/core/src/managed/ArtifactsList.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import classNames from 'classnames';
 
 import { IManagedArtifactSummary, IManagedArtifactVersion } from '../domain/IManagedEntity';
 import { ISelectedArtifact } from './Environments';
@@ -13,13 +14,16 @@ interface IArtifactsListProps {
   selectedArtifact: ISelectedArtifact;
 }
 
-export function ArtifactsList({ artifacts, artifactSelected }: IArtifactsListProps) {
+export function ArtifactsList({ artifacts, selectedArtifact, artifactSelected }: IArtifactsListProps) {
   return (
     <div>
       {artifacts.map(({ versions, name }) =>
         versions.map((version, i) => (
           <ArtifactRow
             key={`${name}-${version.version}-${i}`} // appending index until name-version is guaranteed to be unique
+            isSelected={
+              selectedArtifact && selectedArtifact.name === name && selectedArtifact.version === version.version
+            }
             clickHandler={artifactSelected}
             version={version}
             name={name}
@@ -32,17 +36,21 @@ export function ArtifactsList({ artifacts, artifactSelected }: IArtifactsListPro
 }
 
 interface IArtifactRowProps {
+  isSelected: boolean;
   clickHandler: (artifact: ISelectedArtifact) => void;
   version: IManagedArtifactVersion;
   name: string;
   stages: any[];
 }
 
-export function ArtifactRow({ clickHandler, version, name, stages }: IArtifactRowProps) {
+export function ArtifactRow({ isSelected, clickHandler, version, name, stages }: IArtifactRowProps) {
   const versionString = version.version;
   const { packageName, version: packageVersion, buildNumber, commit } = parseName(versionString);
   return (
-    <div className={styles.ArtifactRow} onClick={() => clickHandler({ name, version: versionString })}>
+    <div
+      className={classNames(styles.ArtifactRow, { [styles.selected]: isSelected })}
+      onClick={() => clickHandler({ name, version: versionString })}
+    >
       <div className={styles.content}>
         <div className={styles.version}>
           <Pill text={buildNumber ? `#${buildNumber}` : packageVersion || versionString} />

--- a/app/scripts/modules/core/src/managed/Environments.tsx
+++ b/app/scripts/modules/core/src/managed/Environments.tsx
@@ -7,6 +7,7 @@ import { IManagedApplicationEnvironmentSummary } from '../domain/IManagedEntity'
 import { ColumnHeader } from './ColumnHeader';
 import { ArtifactsList } from './ArtifactsList';
 import { EnvironmentsList } from './EnvironmentsList';
+import { ArtifactDetail } from './ArtifactDetail';
 
 import styles from './Environments.module.css';
 
@@ -30,6 +31,12 @@ export function Environments(props: IEnvironmentsProps) {
 
   const totalContentWidth = isFiltersOpen ? CONTENT_WIDTH + 248 + 'px' : CONTENT_WIDTH + 'px';
 
+  const selectedArtifactDetails =
+    selectedArtifact &&
+    environments.artifacts
+      .find(({ name }) => name === selectedArtifact.name)
+      ?.versions.find(({ version }) => version === selectedArtifact.version);
+
   return (
     <div style={{ width: '100%' }}>
       <span>For there shall be no greater pursuit than that towards desired state.</span>
@@ -41,14 +48,29 @@ export function Environments(props: IEnvironmentsProps) {
             <ArtifactsList
               {...environments}
               selectedArtifact={selectedArtifact}
-              artifactSelected={clickedArtifact =>
-                setSelectedArtifact(isEqual(clickedArtifact, selectedArtifact) ? null : clickedArtifact)
-              }
+              artifactSelected={clickedArtifact => {
+                if (!isEqual(clickedArtifact, selectedArtifact)) {
+                  setSelectedArtifact(clickedArtifact);
+                }
+              }}
             />
           </div>
           <div className={styles.environmentsColumn}>
-            <ColumnHeader text="Environments" icon="search" />
-            <EnvironmentsList {...environments} selectedArtifact={selectedArtifact} />
+            {/* This view switcheroo will be handled via the router soon,
+                but for now let's do it in component local state.  */}
+            {!selectedArtifact && (
+              <>
+                <ColumnHeader text="Environments" icon="search" />
+                <EnvironmentsList {...environments} />
+              </>
+            )}
+            {selectedArtifact && (
+              <ArtifactDetail
+                name={selectedArtifact.name}
+                version={selectedArtifactDetails}
+                onRequestClose={() => setSelectedArtifact(null)}
+              />
+            )}
           </div>
         </div>
       </div>

--- a/app/scripts/modules/core/src/managed/EnvironmentsList.tsx
+++ b/app/scripts/modules/core/src/managed/EnvironmentsList.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { keyBy } from 'lodash';
 
 import { IManagedEnviromentSummary, IManagedResourceSummary, IManagedArtifactSummary } from '../domain/IManagedEntity';
-import { ISelectedArtifact } from './Environments';
 import { getKindName } from './ManagedReader';
 import { NoticeCard } from './NoticeCard';
 import { ObjectRow } from './ObjectRow';
@@ -24,10 +23,9 @@ interface IEnvironmentsListProps {
   environments: IManagedEnviromentSummary[];
   resources: IManagedResourceSummary[];
   artifacts: IManagedArtifactSummary[];
-  selectedArtifact: ISelectedArtifact;
 }
 
-export function EnvironmentsList({ environments, resources, artifacts, selectedArtifact }: IEnvironmentsListProps) {
+export function EnvironmentsList({ environments, resources, artifacts }: IEnvironmentsListProps) {
   const resourcesMap = keyBy(resources, 'id');
 
   return (
@@ -35,11 +33,9 @@ export function EnvironmentsList({ environments, resources, artifacts, selectedA
       <NoticeCard
         icon="search"
         text={undefined}
-        title={
-          selectedArtifact
-            ? `Showing ${selectedArtifact.name} ${selectedArtifact.version}`
-            : `${artifacts.length} artifacts is deployed in 2 environments with no issues detected.`
-        }
+        title={`${artifacts.length} artifacts ${
+          artifacts.length === 1 ? 'is' : 'are'
+        } deployed in 2 environments with no issues detected.`}
         isActive={true}
         noticeType={'ok'}
       />


### PR DESCRIPTION
Most of the changes here are for adding a detail pane to the right column of Environments when a specific artifact version is selected:

<img width="1287" alt="Screen Shot 2020-03-13 at 9 12 12 PM" src="https://user-images.githubusercontent.com/1850998/76674744-d656a800-656f-11ea-805e-71aa843f3708.png">

There are some other tweaks I'll call out in comments given they're pretty contextual.