### PR TITLE
fix(ecs): Update tooltip for using previous server group capacity

### DIFF
--- a/app/scripts/modules/ecs/src/ecs.help.ts
+++ b/app/scripts/modules/ecs/src/ecs.help.ts
@@ -12,7 +12,7 @@ const helpContents: { [key: string]: string } = {
   'ecs.serverGroup.detail':
     '<p>An environment variable available within your container, and on which you should base your application configuration at runtime.</p>  <p>Typical values for this parameter are <i>app</i>, <i>worker</i>, <i>migrator</i>, etc.  Keep this parameter short!</p>',
   'ecs.capacity.overwrite':
-    "<p>Checking this box will have the previous server group's capacity overwrite the new <i>desired containers</i> parameter if a previous server group exists.</p>",
+    "<p>Checking this box will have the previous server group's capacity overwrite the new <i>min</i>, <i>max</i> and <i>desired capacity</i> parameters if a previous server group exists.</p>",
   'ecs.capacity.desired': '<p>The starting number of containers, before any autoscaling happens.</p>',
   'ecs.capacity.minimum':
     '<p>The minimum number of containers you can reach as a result of autoscaling.</p> <p>Typically, this represents the bare minimum you can afford to run without impacting your capacity to meet your SLA (Service Level Agreement) objectives</p>',


### PR DESCRIPTION
Fixes https://github.com/spinnaker/spinnaker/issues/5541


Screen shot:
<img width="406" alt="screengrab" src="https://user-images.githubusercontent.com/34254888/76798662-3d04dd00-678d-11ea-8966-756b139e2be8.PNG">
