### PR TITLE
refactor(amazon/serverGroup): Refactor ServerGroupBasicSettings to use FormikFormField

### DIFF
--- a/app/scripts/modules/amazon/src/serverGroup/configure/AmazonImageSelectInput.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/AmazonImageSelectInput.tsx
@@ -334,7 +334,7 @@ export class AmazonImageSelectInput extends React.Component<IAmazonImageSelector
         : noResultsText;
 
       return (
-        <div className="col-md-9">
+        <div>
           <TetheredSelect
             {...commonReactSelectProps}
             menuRenderer={this.buildImageMenu}
@@ -355,7 +355,7 @@ export class AmazonImageSelectInput extends React.Component<IAmazonImageSelector
     } else if (isPackageImagesLoaded) {
       // User can pick an image from the preloaded 'packageImages' using the typeahead
       return (
-        <div className="col-md-9">
+        <div>
           <TetheredSelect
             {...commonReactSelectProps}
             menuRenderer={this.buildImageMenu}
@@ -375,7 +375,7 @@ export class AmazonImageSelectInput extends React.Component<IAmazonImageSelector
     } else {
       // Show a disabled react-select while waiting for 'packageImages' to load
       return (
-        <div className="col-md-9">
+        <div>
           <TetheredSelect
             {...commonReactSelectProps}
             isLoading={isLoadingPackageImages}

--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/fields/ServerGroupDetailsField.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/fields/ServerGroupDetailsField.tsx
@@ -9,7 +9,7 @@ export interface DetailsFieldProps {
 }
 
 @Overridable('aws.serverGroup.configure.detailsField')
-export default class ServerGroupDetailsField extends React.Component<DetailsFieldProps> {
+export class ServerGroupDetailsField extends React.Component<DetailsFieldProps> {
   private freeFormDetailsChanged = (freeFormDetails: string) => {
     const { setFieldValue, values } = this.props.formik;
     values.freeFormDetails = freeFormDetails; // have to do it here to make sure it's done before calling values.clusterChanged

--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/fields/ServerGroupDetailsField.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/fields/ServerGroupDetailsField.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { FormikProps } from 'formik';
 
-import { HelpField, Overridable } from '@spinnaker/core';
+import { FormikFormField, HelpField, Overridable, TextInput } from '@spinnaker/core';
 import { IAmazonServerGroupCommand } from '../../../serverGroupConfiguration.service';
 
 export interface DetailsFieldProps {
@@ -18,29 +18,16 @@ export default class ServerGroupDetailsField extends React.Component<DetailsFiel
   };
 
   render() {
-    const { errors, values } = this.props.formik;
     return (
       <>
-        <div className="form-group">
-          <div className="col-md-3 sm-label-right">
-            Detail <HelpField id="aws.serverGroup.detail" />
-          </div>
-          <div className="col-md-7">
-            <input
-              type="text"
-              className="form-control input-sm no-spel"
-              value={values.freeFormDetails}
-              onChange={e => this.freeFormDetailsChanged(e.target.value)}
-            />
-          </div>
-        </div>
-        {errors.freeFormDetails && (
-          <div className="form-group row slide-in">
-            <div className="col-sm-9 col-sm-offset-2 error-message">
-              <span>{errors.freeFormDetails}</span>
-            </div>
-          </div>
-        )}
+        <FormikFormField
+          label="Details"
+          name="freeFormDetails"
+          help={<HelpField id="aws.serverGroup.detail" />}
+          input={({ onChange, ...props }) => (
+            <TextInput {...props} onChange={e => this.freeFormDetailsChanged(e.target.value)} />
+          )}
+        />
       </>
     );
   }

--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/notices/ClusterNamePreviewNotice.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/notices/ClusterNamePreviewNotice.tsx
@@ -10,7 +10,7 @@ interface IClusterNamePreviewProps {
   navigateToLatestServerGroup: () => void;
   showPreviewAsWarning: boolean;
 }
-export default function ClusterNamePreview({
+export function ClusterNamePreview({
   createsNewCluster,
   latestServerGroup,
   mode,

--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/notices/ClusterNamePreviewNotice.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/notices/ClusterNamePreviewNotice.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+
+import { IServerGroup } from '@spinnaker/core';
+
+interface IClusterNamePreviewProps {
+  createsNewCluster: boolean;
+  latestServerGroup: IServerGroup;
+  mode: string;
+  namePreview: string;
+  navigateToLatestServerGroup: () => void;
+  showPreviewAsWarning: boolean;
+}
+export default function ClusterNamePreview({
+  createsNewCluster,
+  latestServerGroup,
+  mode,
+  namePreview,
+  navigateToLatestServerGroup,
+  showPreviewAsWarning,
+}: IClusterNamePreviewProps) {
+  return (
+    <div className="form-group">
+      <div className="col-md-12">
+        <div className={`well-compact ${showPreviewAsWarning ? 'alert alert-warning' : 'well'}`}>
+          <h5 className="text-center">
+            <p>Your server group will be in the cluster:</p>
+            <p>
+              <strong>
+                {namePreview}
+                {createsNewCluster && <span> (new cluster)</span>}
+              </strong>
+            </p>
+            {!createsNewCluster && mode === 'create' && latestServerGroup && (
+              <div className="text-left">
+                <p>There is already a server group in this cluster. Do you want to clone it?</p>
+                <p>
+                  Cloning copies the entire configuration from the selected server group, allowing you to modify
+                  whichever fields (e.g. image) you need to change in the new server group.
+                </p>
+                <p>
+                  To clone a server group, select "Clone" from the "Server Group Actions" menu in the details view of
+                  the server group.
+                </p>
+                <p>
+                  <a className="clickable" onClick={navigateToLatestServerGroup}>
+                    Go to details for {latestServerGroup.name}
+                  </a>
+                </p>
+              </div>
+            )}
+          </h5>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/notices/DeployingIntoDeprecatedRegionWarning.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/notices/DeployingIntoDeprecatedRegionWarning.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+import { IAmazonServerGroupCommand } from '../../../serverGroupConfiguration.service';
+import { FormikProps } from 'formik';
+
+interface IDeployingIntoDeprecatedRegionWarningProps {
+  formik: FormikProps<IAmazonServerGroupCommand>;
+}
+
+export default function DeployingIntoDeprecatedRegionWarning({ formik }: IDeployingIntoDeprecatedRegionWarningProps) {
+  const { values } = formik;
+  return values.regionIsDeprecated(values) ? (
+    <div className="form-group row">
+      <div className="col-md-12 error-message">
+        <div className="alert alert-danger">
+          You are deploying into a deprecated region within the {values.credentials} account!
+        </div>
+      </div>
+    </div>
+  ) : null;
+}

--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/notices/DeployingIntoDeprecatedRegionWarning.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/notices/DeployingIntoDeprecatedRegionWarning.tsx
@@ -1,21 +1,17 @@
 import React from 'react';
 
-import { IAmazonServerGroupCommand } from '../../../serverGroupConfiguration.service';
-import { FormikProps } from 'formik';
-
 interface IDeployingIntoDeprecatedRegionWarningProps {
-  formik: FormikProps<IAmazonServerGroupCommand>;
+  credentials: string;
 }
 
-export default function DeployingIntoDeprecatedRegionWarning({ formik }: IDeployingIntoDeprecatedRegionWarningProps) {
-  const { values } = formik;
-  return values.regionIsDeprecated(values) ? (
+export function DeployingIntoDeprecatedRegionWarning({ credentials }: IDeployingIntoDeprecatedRegionWarningProps) {
+  return (
     <div className="form-group row">
       <div className="col-md-12 error-message">
         <div className="alert alert-danger">
-          You are deploying into a deprecated region within the {values.credentials} account!
+          You are deploying into a deprecated region within the {credentials} account!
         </div>
       </div>
     </div>
-  ) : null;
+  );
 }

--- a/app/scripts/modules/core/src/deploymentStrategy/DeploymentStrategySelector.tsx
+++ b/app/scripts/modules/core/src/deploymentStrategy/DeploymentStrategySelector.tsx
@@ -3,7 +3,7 @@ import Select, { Option } from 'react-select';
 import { unset } from 'lodash';
 
 import { HelpField } from 'core/help/HelpField';
-import { Markdown } from 'core/presentation';
+import { Markdown, FormikFormField } from 'core/presentation';
 import { IServerGroupCommand } from 'core/serverGroup';
 
 import {
@@ -18,6 +18,7 @@ export interface IDeploymentStrategySelectorProps {
   onStrategyChange: (command: IServerGroupCommand, strategy: IDeploymentStrategy) => void;
   labelColumns?: string;
   fieldColumns?: string;
+  useSystemLayout?: boolean;
 }
 
 export interface IDeploymentStrategySelectorState {
@@ -84,34 +85,51 @@ export class DeploymentStrategySelector extends React.Component<
   }
 
   public render() {
-    const { command, fieldColumns, labelColumns, onFieldChange } = this.props;
+    const { command, fieldColumns, labelColumns, useSystemLayout, onFieldChange } = this.props;
     const { AdditionalFieldsComponent, currentStrategy, strategies } = this.state;
     const hasAdditionalFields = Boolean(AdditionalFieldsComponent);
+    const selectField = (
+      <Select
+        clearable={false}
+        options={strategies}
+        optionRenderer={this.strategyOptionRenderer}
+        placeholder="None"
+        required={true}
+        value={currentStrategy}
+        valueKey="key"
+        valueRenderer={o => <>{o.label}</>}
+        onChange={this.strategyChanged}
+      />
+    );
+    const label = 'Strategy';
+    const help = <HelpField id="core.serverGroup.strategy" />;
+    const additionalFields = hasAdditionalFields ? (
+      <AdditionalFieldsComponent command={command} onChange={onFieldChange} />
+    ) : null;
+
     if (strategies && strategies.length) {
-      return (
-        <div className="form-group">
-          <div className={`col-md-${labelColumns} sm-label-right`} style={{ paddingLeft: '13px' }}>
-            Strategy
-            <HelpField id="core.serverGroup.strategy" />
-          </div>
-          <div className={`col-md-${fieldColumns}`}>
-            <Select
-              clearable={false}
-              required={true}
-              options={strategies}
-              placeholder="None"
-              valueKey="key"
-              value={currentStrategy}
-              optionRenderer={this.strategyOptionRenderer}
-              valueRenderer={o => <>{o.label}</>}
-              onChange={this.strategyChanged}
-            />
-          </div>
-          {hasAdditionalFields && (
-            <div className="col-md-9 col-md-offset-3" style={{ marginTop: '5px' }}>
-              <AdditionalFieldsComponent command={command} onChange={onFieldChange} />
+      return useSystemLayout ? (
+        <FormikFormField
+          label={label}
+          name="strategy"
+          help={help}
+          input={() => (
+            <div>
+              {selectField}
+              <div style={{ marginTop: '5px' }}>{additionalFields}</div>
             </div>
           )}
+        />
+      ) : (
+        <div className="form-group">
+          <div className={`col-md-${labelColumns} sm-label-right`} style={{ paddingLeft: '13px' }}>
+            {label}
+            {help}
+          </div>
+          <div className={`col-md-${fieldColumns}`}>{selectField}</div>
+          <div className="col-md-9 col-md-offset-3" style={{ marginTop: '5px' }}>
+            {additionalFields}
+          </div>
         </div>
       );
     }

--- a/app/scripts/modules/core/src/deploymentStrategy/DeploymentStrategySelector.tsx
+++ b/app/scripts/modules/core/src/deploymentStrategy/DeploymentStrategySelector.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import Select, { Option } from 'react-select';
+import { Option } from 'react-select';
 import { unset } from 'lodash';
 
 import { HelpField } from 'core/help/HelpField';
-import { Markdown, FormikFormField } from 'core/presentation';
+import { Markdown, FormikFormField, ReactSelectInput } from 'core/presentation';
 import { IServerGroupCommand } from 'core/serverGroup';
 
 import {
@@ -89,7 +89,7 @@ export class DeploymentStrategySelector extends React.Component<
     const { AdditionalFieldsComponent, currentStrategy, strategies } = this.state;
     const hasAdditionalFields = Boolean(AdditionalFieldsComponent);
     const selectField = (
-      <Select
+      <ReactSelectInput
         clearable={false}
         options={strategies}
         optionRenderer={this.strategyOptionRenderer}

--- a/app/scripts/modules/core/src/task/modal/TaskReason.tsx
+++ b/app/scripts/modules/core/src/task/modal/TaskReason.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { FormikFormField } from 'core/presentation';
+import { FormikFormField, TextAreaInput } from 'core/presentation';
 
 export interface ITaskReasonProps {
   onChange: (reason: string) => void;
@@ -11,7 +11,7 @@ export class TaskReason extends React.Component<ITaskReasonProps> {
   public render() {
     const label = 'Reason';
     const field = (
-      <textarea
+      <TextAreaInput
         className="form-control"
         value={this.props.reason}
         onChange={event => this.props.onChange(event.target.value)}

--- a/app/scripts/modules/core/src/task/modal/TaskReason.tsx
+++ b/app/scripts/modules/core/src/task/modal/TaskReason.tsx
@@ -1,25 +1,31 @@
 import React from 'react';
+import { FormikFormField } from 'core/presentation';
 
 export interface ITaskReasonProps {
   onChange: (reason: string) => void;
   reason: string;
+  useSystemLayout?: boolean;
 }
 
 export class TaskReason extends React.Component<ITaskReasonProps> {
   public render() {
-    return (
+    const label = 'Reason';
+    const field = (
+      <textarea
+        className="form-control"
+        value={this.props.reason}
+        onChange={event => this.props.onChange(event.target.value)}
+        ng-model="vm.command.reason"
+        rows={3}
+        placeholder="(Optional) anything that might be helpful to explain the reason for this change; HTML is okay"
+      />
+    );
+    return this.props.useSystemLayout ? (
+      <FormikFormField label={label} name="reason" input={() => field} />
+    ) : (
       <div className="row" style={{ marginTop: '10px', marginBottom: '10px' }}>
-        <div className="col-md-3 sm-label-right">Reason</div>
-        <div className="col-md-7">
-          <textarea
-            className="form-control"
-            value={this.props.reason}
-            onChange={event => this.props.onChange(event.target.value)}
-            ng-model="vm.command.reason"
-            rows={3}
-            placeholder="(Optional) anything that might be helpful to explain the reason for this change; HTML is okay"
-          />
-        </div>
+        <div className="col-md-3 sm-label-right">{label}</div>
+        <div className="col-md-7">{field}</div>
       </div>
     );
   }


### PR DESCRIPTION
`ServerGroupBasicSettings` form now uses `FormikFormField`s only. This PR is split into three commits for easier reviewing.

1. Converted fields in separate modules that are used in `ServerGroupBasicSettings` to use `FormikFormField`. If these fields are used in other areas, then they use `FormikFormField` only when `useStandardLayout` prop is set `true` so that it's existing uses is not affected.

2. Moved notices that are rendered in `ServerGroupBasicSettings` to separate modules for easier maintenance.

3. Converted all fields in `ServerGroupBasicSettings` to use `FormikFormField`.

Before
![before](https://user-images.githubusercontent.com/357832/76886667-5f0a6800-683e-11ea-9547-e34a1e15fea9.png)


After
![after](https://user-images.githubusercontent.com/357832/76886710-67fb3980-683e-11ea-8ebb-c27818697dd0.png)


I tested each field by changing the values and ensured that the backing formik data is updated. For fields that are typically hidden, I explicitly enabled them inline and ensured they rendered correct.

![local-testing](https://user-images.githubusercontent.com/357832/76888077-7f3b2680-6840-11ea-805b-b8d7fc95c0cd.png)
