### PR TITLE
fix(kubernetes): whitelist helm artifact types for bake manifest stage

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/helm/BakeHelmConfigForm.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/helm/BakeHelmConfigForm.tsx
@@ -4,7 +4,7 @@ import { StageConfigField } from '../../common/stageConfigField/StageConfigField
 import { CheckboxInput, TextInput } from 'core/presentation';
 import { MapEditor } from 'core/forms';
 import { IArtifact, IExpectedArtifact, IPipeline } from 'core/domain';
-import { StageArtifactSelectorDelegate } from 'core/artifact';
+import { excludeAllTypesExcept, ArtifactTypePatterns, StageArtifactSelectorDelegate } from 'core/artifact';
 import { IFormikStageConfigInjectedProps } from '../../FormikStageConfig';
 
 interface IBakeHelmConfigFormProps {
@@ -12,6 +12,17 @@ interface IBakeHelmConfigFormProps {
 }
 
 export class BakeHelmConfigForm extends React.Component<IBakeHelmConfigFormProps & IFormikStageConfigInjectedProps> {
+  private static readonly excludedArtifactTypes = excludeAllTypesExcept(
+    ArtifactTypePatterns.BITBUCKET_FILE,
+    ArtifactTypePatterns.CUSTOM_OBJECT,
+    ArtifactTypePatterns.GCS_OBJECT,
+    ArtifactTypePatterns.GITHUB_FILE,
+    ArtifactTypePatterns.GITLAB_FILE,
+    ArtifactTypePatterns.S3_OBJECT,
+    ArtifactTypePatterns.HELM_CHART,
+    ArtifactTypePatterns.HTTP_FILE,
+  );
+
   public componentDidMount() {
     const stage = this.props.formik.values;
     if (stage.inputArtifacts && stage.inputArtifacts.length === 0) {
@@ -121,7 +132,7 @@ export class BakeHelmConfigForm extends React.Component<IBakeHelmConfigFormProps
         <h4>Template Artifact</h4>
         <StageArtifactSelectorDelegate
           artifact={this.getInputArtifact(stage, 0).artifact}
-          excludedArtifactTypePatterns={[]}
+          excludedArtifactTypePatterns={BakeHelmConfigForm.excludedArtifactTypes}
           expectedArtifactId={this.getInputArtifact(stage, 0).id}
           helpKey="pipeline.config.bake.manifest.expectedArtifact"
           label="Expected Artifact"

--- a/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/helm/BakeHelmConfigForm.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/helm/BakeHelmConfigForm.tsx
@@ -15,6 +15,7 @@ export class BakeHelmConfigForm extends React.Component<IBakeHelmConfigFormProps
   private static readonly excludedArtifactTypes = excludeAllTypesExcept(
     ArtifactTypePatterns.BITBUCKET_FILE,
     ArtifactTypePatterns.CUSTOM_OBJECT,
+    ArtifactTypePatterns.EMBEDDED_BASE64,
     ArtifactTypePatterns.GCS_OBJECT,
     ArtifactTypePatterns.GITHUB_FILE,
     ArtifactTypePatterns.GITLAB_FILE,


### PR DESCRIPTION
Related to: https://github.com/spinnaker/spinnaker/issues/5589

Previously, we permitted all artifact types as input to Bake (Manifest) stage with the Helm render engine specified. However, this has led to confusion since only certain artifact types are appropriate. For example, the Git Repo artifact type does not yet support Helm (open feature request [here](https://github.com/spinnaker/spinnaker/issues/5249)), but it was available for selection. Let's explicitly whitelist acceptable artifact types for Helm bakes.