### PR TITLE
fix(titus/instance): Temporary workaround to get IPv6 for Titus instances

### DIFF
--- a/app/scripts/modules/amazon/src/instance/details/instanceDetails.html
+++ b/app/scripts/modules/amazon/src/instance/details/instanceDetails.html
@@ -209,9 +209,7 @@
         <dd ng-if="instance.permanentIps" ng-repeat="ip in instance.permanentIps">
           <link-with-clipboard url="'http://' + ip + ':' + state.instancePort" text="ip"> </link-with-clipboard>
         </dd>
-        <dt ng-if="instance.publicIpAddress || instance.ipv6Addresses.length">
-          Public IP Address<span ng-if="instance.ipv6Addresses.length > 1">es</span>
-        </dt>
+        <dt ng-if="instance.publicIpAddress">Public IP Address</dt>
         <dd ng-if="instance.publicIpAddress">
           <link-with-clipboard
             url="'http://' + instance.publicIpAddress + ':' + state.instancePort"
@@ -219,6 +217,9 @@
           >
           </link-with-clipboard>
         </dd>
+        <dt ng-if="instance.ipv6Addresses.length">
+          IPv6 Address<span ng-if="instance.ipv6Addresses.length > 1">es</span>
+        </dt>
         <dd ng-if="instance.ipv6Addresses.length" ng-repeat="ip in instance.ipv6Addresses">
           <link-with-clipboard url="'http://[' + ip + ']:' + state.instancePort" text="ip"> </link-with-clipboard>
         </dd>

--- a/app/scripts/modules/titus/src/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/titus/src/instance/details/instance.details.controller.js
@@ -109,6 +109,8 @@ module(TITUS_INSTANCE_DETAILS_INSTANCE_DETAILS_CONTROLLER, [
             AccountService.getAccountDetails(account),
           ])
           .then(([instanceDetails, accountDetails]) => {
+            // eslint-disable-next-line
+            console.log(instanceDetails);
             $scope.state.loading = false;
             extractHealthMetrics(instanceSummary, instanceDetails);
             $scope.instance = defaults(instanceDetails, instanceSummary);
@@ -120,7 +122,7 @@ module(TITUS_INSTANCE_DETAILS_INSTANCE_DETAILS_CONTROLLER, [
             $scope.instance.externalIpAddress = $scope.instance.placement.host;
             getBastionAddressForAccount(accountDetails, region);
             $scope.instance.titusUiEndpoint = this.titusUiEndpoint;
-            addIpv6Addresses(accountDetails.awsAccount, region, instance.agentId);
+            addIpv6Addresses(accountDetails.awsAccount, region, instanceDetails.agentId);
             if (overrides.instanceDetailsLoaded) {
               overrides.instanceDetailsLoaded();
             }
@@ -303,12 +305,16 @@ module(TITUS_INSTANCE_DETAILS_INSTANCE_DETAILS_CONTROLLER, [
     };
 
     const addIpv6Addresses = (account, region, instanceId) => {
+      // eslint-disable-next-line
+      console.log(account, region, instanceId);
       InstanceReader.getInstanceDetails(account, region, instanceId).then(instance => {
-        $scope.instance.addIpv6Addresses = flatMap($scope.instance.netWorkInterfaces, i =>
-          i.ipv6Addresses.map(a => a.ipv6Address),
-        );
         // eslint-disable-next-line
-        console.log($scope.instance);
+        console.log(instance);
+        if (instance.networkInterfaces) {
+          $scope.instance.ipv6Addresses = flatMap(instance.networkInterfaces, i =>
+            i.ipv6Addresses.map(a => a.ipv6Address),
+          );
+        }
       });
     };
 

--- a/app/scripts/modules/titus/src/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/titus/src/instance/details/instance.details.controller.js
@@ -85,8 +85,6 @@ module(TITUS_INSTANCE_DETAILS_INSTANCE_DETAILS_CONTROLLER, [
       let instanceSummary, loadBalancers, account, region, vpcId;
       app.serverGroups.data.some(function(serverGroup) {
         return serverGroup.instances.some(function(possibleInstance) {
-          // eslint-disable-next-line
-          // console.log(possibleInstance);
           if (possibleInstance.id === instance.instanceId) {
             $scope.serverGroup = serverGroup;
             instanceSummary = possibleInstance;
@@ -109,8 +107,6 @@ module(TITUS_INSTANCE_DETAILS_INSTANCE_DETAILS_CONTROLLER, [
             AccountService.getAccountDetails(account),
           ])
           .then(([instanceDetails, accountDetails]) => {
-            // eslint-disable-next-line
-            console.log(instanceDetails);
             $scope.state.loading = false;
             extractHealthMetrics(instanceSummary, instanceDetails);
             $scope.instance = defaults(instanceDetails, instanceSummary);
@@ -305,11 +301,7 @@ module(TITUS_INSTANCE_DETAILS_INSTANCE_DETAILS_CONTROLLER, [
     };
 
     const addIpv6Addresses = (account, region, instanceId) => {
-      // eslint-disable-next-line
-      console.log(account, region, instanceId);
       InstanceReader.getInstanceDetails(account, region, instanceId).then(instance => {
-        // eslint-disable-next-line
-        console.log(instance);
         if (instance.networkInterfaces) {
           $scope.instance.ipv6Addresses = flatMap(instance.networkInterfaces, i =>
             i.ipv6Addresses.map(a => a.ipv6Address),

--- a/app/scripts/modules/titus/src/instance/details/instanceDetails.html
+++ b/app/scripts/modules/titus/src/instance/details/instanceDetails.html
@@ -164,12 +164,18 @@
           >
           </copy-to-clipboard>
         </dd>
+        <dt ng-if="instance.ipv6Addresses.length">Container IPv6</dt>
+        <dd ng-if="instance.ipv6Addresses.length" ng-repeat="ip in instance.ipv6Addresses">
+          {{ip}}
+          <copy-to-clipboard
+            class="copy-to-clipboard"
+            text="'http://[' + ip + ']:' + state.instancePort"
+            tool-tip="'Copy container IP clipboard'"
+          >
+          </copy-to-clipboard>
+        </dd>
         <dt>Host IP</dt>
         <dd>{{instance.placement.host}}</dd>
-        <dt ng-if="instance.ipv6Addresses.length">IPv6</dt>
-        <dd ng-if="instance.ipv6Addresses.length" ng-repeat="ip in instance.ipv6Addresses">
-          <link-with-clipboard url="'http://[' + ip + ']:' + state.instancePort" text="ip"> </link-with-clipboard>
-        </dd>
       </dl>
     </collapsible-section>
     <titus-security-groups

--- a/app/scripts/modules/titus/src/instance/details/instanceDetails.html
+++ b/app/scripts/modules/titus/src/instance/details/instanceDetails.html
@@ -166,9 +166,7 @@
         </dd>
         <dt>Host IP</dt>
         <dd>{{instance.placement.host}}</dd>
-        <dt ng-if="instance.ipv6Addresses.length">
-          IPv6 Address<span ng-if="instance.ipv6Addresses.length > 1">es</span>
-        </dt>
+        <dt ng-if="instance.ipv6Addresses.length">IPv6</dt>
         <dd ng-if="instance.ipv6Addresses.length" ng-repeat="ip in instance.ipv6Addresses">
           <link-with-clipboard url="'http://[' + ip + ']:' + state.instancePort" text="ip"> </link-with-clipboard>
         </dd>

--- a/app/scripts/modules/titus/src/instance/details/instanceDetails.html
+++ b/app/scripts/modules/titus/src/instance/details/instanceDetails.html
@@ -166,6 +166,12 @@
         </dd>
         <dt>Host IP</dt>
         <dd>{{instance.placement.host}}</dd>
+        <dt ng-if="instance.ipv6Addresses.length">
+          IPv6 Address<span ng-if="instance.ipv6Addresses.length > 1">es</span>
+        </dt>
+        <dd ng-if="instance.ipv6Addresses.length" ng-repeat="ip in instance.ipv6Addresses">
+          <link-with-clipboard url="'http://[' + ip + ']:' + state.instancePort" text="ip"> </link-with-clipboard>
+        </dd>
       </dl>
     </collapsible-section>
     <titus-security-groups


### PR DESCRIPTION
Currently, Titus instances do not expose IPv6 addresses. As a temporary workaround to unlock other IPv6 work, we will leverage the `agentId` and `awsAccount` to make a secondary call for this information. In the future we will remove the `addIpv6Addresses` function, since the instance will natively have an `ipv6Addresses` attribute.

Also, I have separated DNS headers for Public v4 addreses and Ipv6 Addresses (which are all public) based on some feedback.