### PR TITLE
feat(kubernetes): remove readonly application input

### DIFF
--- a/app/scripts/modules/kubernetes/src/shared/help/kubernetes.help.ts
+++ b/app/scripts/modules/kubernetes/src/shared/help/kubernetes.help.ts
@@ -173,9 +173,6 @@ const helpContents: { [key: string]: string } = {
   'kubernetes.manifest.account': `
       <p>A Spinnaker account corresponds to a physical Kubernetes cluster. If you are unsure which account to use, talk to your Spinnaker admin.</p>
   `,
-  'kubernetes.manifest.application': `
-      <p>This is the Spinnaker application that your manifest will be deployed to. An application is generally used to group resources that belong to a single service.</p>
-  `,
   'kubernetes.manifest.cluster': `
       <p>A cluster is a grouping of resources (often across multiple versions of a resource) within an application.</p>
   `,

--- a/app/scripts/modules/kubernetes/src/v2/manifest/wizard/BasicSettings.tsx
+++ b/app/scripts/modules/kubernetes/src/v2/manifest/wizard/BasicSettings.tsx
@@ -1,23 +1,17 @@
 import React from 'react';
 import { FormikProps } from 'formik';
 
-import { AccountSelectInput, Application, HelpField, IAccount } from '@spinnaker/core';
+import { AccountSelectInput, HelpField, IAccount } from '@spinnaker/core';
 
 import { IKubernetesManifestCommandData } from '../manifestCommandBuilder.service';
 
 export interface IManifestBasicSettingsProps {
-  app: Application;
   accounts: IAccount[];
   onAccountSelect: (account: string) => void;
   selectedAccount: string;
 }
 
-export function ManifestBasicSettings({
-  app,
-  accounts,
-  onAccountSelect,
-  selectedAccount,
-}: IManifestBasicSettingsProps) {
+export function ManifestBasicSettings({ accounts, onAccountSelect, selectedAccount }: IManifestBasicSettingsProps) {
   return (
     <div className="form-horizontal">
       <div className="form-group">
@@ -34,20 +28,11 @@ export function ManifestBasicSettings({
           />
         </div>
       </div>
-      <div className="form-group">
-        <div className="col-md-3 sm-label-right">
-          Application <HelpField id="kubernetes.manifest.application" />
-        </div>
-        <div className="col-md-7">
-          <input type="text" className="form-control input-sm no-spel" readOnly={true} value={app.name} />
-        </div>
-      </div>
     </div>
   );
 }
 
 export interface IWizardManifestBasicSettingsProps {
-  app: Application;
   formik: FormikProps<IKubernetesManifestCommandData>;
 }
 
@@ -59,10 +44,9 @@ export class WizardManifestBasicSettings extends React.Component<IWizardManifest
   };
 
   public render() {
-    const { formik, app } = this.props;
+    const { formik } = this.props;
     return (
       <ManifestBasicSettings
-        app={app}
         accounts={formik.values.metadata.backingData.accounts}
         onAccountSelect={this.accountUpdated}
         selectedAccount={formik.values.command.account}

--- a/app/scripts/modules/kubernetes/src/v2/manifest/wizard/ManifestWizard.tsx
+++ b/app/scripts/modules/kubernetes/src/v2/manifest/wizard/ManifestWizard.tsx
@@ -84,9 +84,7 @@ export class ManifestWizard extends React.Component<IKubernetesManifestModalProp
               label="Basic Settings"
               wizard={wizard}
               order={nextIdx()}
-              render={({ innerRef }) => (
-                <WizardManifestBasicSettings ref={innerRef} formik={formik} app={application} />
-              )}
+              render={({ innerRef }) => <WizardManifestBasicSettings ref={innerRef} formik={formik} />}
             />
 
             <WizardPage

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/DeployManifestStageForm.tsx
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/DeployManifestStageForm.tsx
@@ -125,7 +125,6 @@ export class DeployManifestStageForm extends React.Component<
       <div className="form-horizontal">
         <h4>Basic Settings</h4>
         <ManifestBasicSettings
-          app={this.props.application}
           accounts={this.props.accounts}
           onAccountSelect={accountName => this.props.formik.setFieldValue('account', accountName)}
           selectedAccount={stage.account}

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/runJob/KubernetesV2RunJobStageConfig.tsx
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/runJob/KubernetesV2RunJobStageConfig.tsx
@@ -210,7 +210,7 @@ export class KubernetesV2RunJobStageConfig extends React.Component<IStageConfigP
   };
 
   public render() {
-    const { application, stage } = this.props;
+    const { stage } = this.props;
 
     let outputSource = <div />;
     if (stage.consumeArtifactSource === 'propertyFile') {
@@ -223,7 +223,6 @@ export class KubernetesV2RunJobStageConfig extends React.Component<IStageConfigP
       <div className="container-fluid form-horizontal">
         <h4>Basic Settings</h4>
         <ManifestBasicSettings
-          app={application}
           selectedAccount={stage.account || ''}
           accounts={this.state.credentials}
           onAccountSelect={(selectedAccount: string) => this.accountChanged(selectedAccount)}


### PR DESCRIPTION
There is currently a readonly input field displaying the name of the application in Deploy (Manifest) and Run Job (Manifest) stages, and in the ad-hoc Deploy wizard. Since we already display the name of the application prominently in the nav bar and define a Spinnaker application in our documentation, let's remove this unnecessary input.

<details><summary>Before</summary>
<p>

![8FpKEZDdfsw](https://user-images.githubusercontent.com/15936279/76997596-ebde2000-6929-11ea-9164-581505e5fc61.png)


</p>
</details>

<details><summary>After</summary>
<p>

![GAzSu2qdJJi](https://user-images.githubusercontent.com/15936279/76997633-fbf5ff80-6929-11ea-9358-4d7bc66894d6.png)



</p>
</details>