### PR TITLE
fix(core/managed): fix check for row expandability on history table

### DIFF
--- a/app/scripts/modules/core/src/managed/ManagedResourceHistoryModal.tsx
+++ b/app/scripts/modules/core/src/managed/ManagedResourceHistoryModal.tsx
@@ -216,7 +216,8 @@ export const ManagedResourceHistoryModal = ({ resourceSummary, dismissModal }: I
                 layout={tableLayout}
                 columns={['Where', 'What', 'When']}
                 expandable={historyEvents.some(
-                  ({ delta, tasks, message, reason }) => delta || tasks || message || reason,
+                  ({ delta, tasks, message, reason, exceptionMessage }) =>
+                    delta || tasks || message || reason || exceptionMessage,
                 )}
               >
                 {historyEvents


### PR DESCRIPTION
There are a whole bunch of different field names on history event objects which need to be checked in order to find out whether an event has something to provide for display. I recently found out about `exceptionMessage` in addition to the others, but missed a spot when adding it. That meant `ResourceCheckError` events weren't expandable, even if they had a message.