### PR TITLE
feat(core/managed): use real data for version progress in Environments

### DIFF
--- a/app/scripts/modules/core/src/domain/IManagedEntity.ts
+++ b/app/scripts/modules/core/src/domain/IManagedEntity.ts
@@ -47,7 +47,7 @@ export interface IManagedArtifactVersion {
   version: string;
   environments: Array<{
     name: string;
-    state: string;
+    state: 'current' | 'deploying' | 'approved' | 'pending' | 'previous' | 'vetoed';
     deployedAt?: string;
     replacedAt?: string;
     replacedBy?: string;

--- a/app/scripts/modules/core/src/managed/ArtifactRow.module.css
+++ b/app/scripts/modules/core/src/managed/ArtifactRow.module.css
@@ -50,11 +50,36 @@
   height: 6px;
   padding-bottom: 2px;
 }
+
 .stage {
-  background-color: #00b237;
   flex: 1 1 auto;
   margin-right: 2px;
+
+  &.current {
+    background-color: #00b237;
+  }
+
+  &.approved {
+    background-color: #4bafff;
+  }
+
+  &.deploying {
+    background-color: #4bafff;
+  }
+
+  &.pending {
+    background-color: var(--color-porcelain);
+  }
+
+  &.previous {
+    background-color: var(--color-nobel);
+  }
+
+  &.vetoed {
+    background-color: #be0000;
+  }
 }
+
 .stage:last-child {
   margin-right: 0;
 }

--- a/app/scripts/modules/core/src/managed/ArtifactsList.tsx
+++ b/app/scripts/modules/core/src/managed/ArtifactsList.tsx
@@ -27,7 +27,6 @@ export function ArtifactsList({ artifacts, selectedArtifact, artifactSelected }:
             clickHandler={artifactSelected}
             version={version}
             name={name}
-            stages={[4, 3, 0]}
           />
         )),
       )}
@@ -40,10 +39,9 @@ interface IArtifactRowProps {
   clickHandler: (artifact: ISelectedArtifact) => void;
   version: IManagedArtifactVersion;
   name: string;
-  stages: any[];
 }
 
-export function ArtifactRow({ isSelected, clickHandler, version, name, stages }: IArtifactRowProps) {
+export function ArtifactRow({ isSelected, clickHandler, version, name }: IArtifactRowProps) {
   const versionString = version.version;
   const { packageName, version: packageVersion, buildNumber, commit } = parseName(versionString);
   return (
@@ -62,8 +60,8 @@ export function ArtifactRow({ isSelected, clickHandler, version, name, stages }:
         {/* Holding spot for status bubbles */}
       </div>
       <div className={styles.stages}>
-        {stages.map((_stage, i) => (
-          <span key={i} className={styles.stage} />
+        {version.environments.map(({ name, state }) => (
+          <span key={name} className={classNames(styles.stage, styles[state])} />
         ))}
       </div>
     </div>


### PR DESCRIPTION
We were hard-coding all these progress bar steps as green because the API couldn't tell us what to show yet, but now it can!

<img width="307" alt="Screen Shot 2020-03-18 at 11 11 08 PM" src="https://user-images.githubusercontent.com/1850998/77037095-c4a94200-696d-11ea-9152-aedc3746308d.png">
