### PR TITLE
feat(core/managed): add resource breakdown to artifact details

### DIFF
--- a/app/scripts/modules/core/src/managed/ArtifactDetail.tsx
+++ b/app/scripts/modules/core/src/managed/ArtifactDetail.tsx
@@ -1,19 +1,31 @@
 import React from 'react';
 
-import { IManagedArtifactVersion } from '../domain';
+import { IManagedArtifactVersion, IManagedResourceSummary } from '../domain';
 import { useEventListener } from '../presentation';
 
 import { ArtifactDetailHeader } from './ArtifactDetailHeader';
+import { ManagedResourceObject } from './ManagedResourceObject';
 
 import './ArtifactDetail.less';
+
+function shouldDisplayResource(resource: IManagedResourceSummary) {
+  //TODO: naively filter on presence of moniker but how should we really decide what to display?
+  return !!resource.moniker;
+}
 
 export interface IArtifactDetailProps {
   name: string;
   version: IManagedArtifactVersion;
+  resourcesByEnvironment: { [environment: string]: IManagedResourceSummary[] };
   onRequestClose: () => any;
 }
 
-export const ArtifactDetail = ({ name, version, onRequestClose }: IArtifactDetailProps) => {
+export const ArtifactDetail = ({
+  name,
+  version: { version, environments },
+  resourcesByEnvironment,
+  onRequestClose,
+}: IArtifactDetailProps) => {
   const keydownCallback = ({ keyCode }: KeyboardEvent) => {
     if (keyCode === 27 /* esc */) {
       onRequestClose();
@@ -23,13 +35,21 @@ export const ArtifactDetail = ({ name, version, onRequestClose }: IArtifactDetai
 
   return (
     <>
-      <ArtifactDetailHeader name={name} version={version.version} onRequestClose={onRequestClose} />
+      <ArtifactDetailHeader name={name} version={version} onRequestClose={onRequestClose} />
 
       <div className="ArtifactDetail">
         <div className="flex-container-h">
           {/* a short summary with actions/buttons will live here */}
           <div className="detail-section-right">{/* artifact metadata will live here */}</div>
         </div>
+        {environments.map(({ name }) => (
+          <div key={name}>
+            <h3>{name.toUpperCase()}</h3>
+            {resourcesByEnvironment[name].filter(shouldDisplayResource).map(resource => (
+              <ManagedResourceObject key={resource.id} resource={resource} />
+            ))}
+          </div>
+        ))}
       </div>
     </>
   );

--- a/app/scripts/modules/core/src/managed/ArtifactDetailHeader.tsx
+++ b/app/scripts/modules/core/src/managed/ArtifactDetailHeader.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { Icon } from '../presentation';
+
 import { parseName } from './Frigga';
 
 import './ArtifactDetailHeader.less';
@@ -16,62 +18,14 @@ export const ArtifactDetailHeader = ({ name, version, onRequestClose }: IArtifac
   return (
     <div className="ArtifactDetailHeader flex-container-h space-between middle text-bold">
       <div className="header-section-left flex-container-h middle">
-        {/* embed SVG direclty here until we get either a new SVG impl
-            for icons (in the works) or move these into the icon font */}
-        <svg
-          version="1.1"
-          xmlns="http://www.w3.org/2000/svg"
-          xmlnsXlink="http://www.w3.org/1999/xlink"
-          x="0px"
-          y="0px"
-          viewBox="0 0 24 24"
-          xmlSpace="preserve"
-          fill="white"
-          width="40px"
-        >
-          <g>
-            <path
-              d="M1.5,24C0.673,24,0,23.327,0,22.5V7.82c0-0.165,0.029-0.331,0.085-0.494C0.088,7.318,0.095,7.3,0.099,7.293
-		c0.04-0.115,0.104-0.237,0.18-0.345l4.514-6.32C5.074,0.235,5.53,0,6.014,0h11.971c0.485,0,0.941,0.235,1.222,0.628l4.514,6.32
-		c0.077,0.107,0.14,0.23,0.189,0.365C23.971,7.488,24,7.655,24,7.82V22.5c0,0.827-0.673,1.5-1.5,1.5H1.5z M1,22.5
-		C1,22.776,1.224,23,1.5,23h21c0.276,0,0.5-0.224,0.5-0.5V8H1V22.5z M22.529,7l-4.135-5.791C18.3,1.078,18.147,1,17.986,1H12.5v6
-		H22.529z M11.5,7V1H6.014C5.853,1,5.701,1.078,5.607,1.209L1.471,7H11.5z"
-            />
-            <path
-              d="M13.001,21c-0.552,0-1-0.448-1-1v-2c0-0.552,0.448-1,1-1h7c0.552,0,1,0.448,1,1v2c0,0.552-0.448,1-1,1H13.001z M13.001,20
-		h7v-2h-7L13.001,20z"
-            />
-          </g>
-        </svg>
+        <Icon name="artifact" appearance="light" size="extraLarge" />
         <span className="header-version-pill">{buildNumber ? `#${buildNumber}` : packageVersion || version}</span>
       </div>
 
       <div className="header-section-center">{name}</div>
 
       <div className="header-close flex-container-h center middle" onClick={() => onRequestClose()}>
-        {/* embed SVG direclty here until we get either a new SVG impl
-            for icons (in the works) or move these into the icon font */}
-        <svg
-          version="1.1"
-          xmlns="http://www.w3.org/2000/svg"
-          xmlnsXlink="http://www.w3.org/1999/xlink"
-          x="0px"
-          y="0px"
-          viewBox="0 0 24 24"
-          xmlSpace="preserve"
-          fill="white"
-          width="24px"
-        >
-          <g>
-            <path
-              d="M23.5,23.999c-0.134,0-0.259-0.052-0.354-0.146L12,12.706L0.854,23.853c-0.094,0.094-0.22,0.146-0.354,0.146
-		s-0.259-0.052-0.354-0.146c-0.195-0.195-0.195-0.512,0-0.707l11.146-11.146L0.147,0.853c-0.195-0.195-0.195-0.512,0-0.707
-		C0.241,0.051,0.367-0.001,0.5-0.001s0.259,0.052,0.354,0.146L12,11.292L23.147,0.146c0.094-0.094,0.22-0.146,0.354-0.146
-		s0.259,0.052,0.354,0.146c0.195,0.195,0.195,0.512,0,0.707L12.707,11.999l11.146,11.146c0.195,0.195,0.195,0.512,0,0.707
-		C23.759,23.947,23.634,23.999,23.5,23.999z"
-            />
-          </g>
-        </svg>
+        <Icon name="close" appearance="light" size="medium" />
       </div>
     </div>
   );

--- a/app/scripts/modules/core/src/managed/EnvironmentsList.tsx
+++ b/app/scripts/modules/core/src/managed/EnvironmentsList.tsx
@@ -1,18 +1,9 @@
 import React from 'react';
-import { keyBy } from 'lodash';
 
-import { IManagedEnviromentSummary, IManagedResourceSummary, IManagedArtifactSummary } from '../domain/IManagedEntity';
-import { getKindName } from './ManagedReader';
+import { IManagedEnviromentSummary, IManagedResourceSummary, IManagedArtifactSummary } from '../domain';
+
 import { NoticeCard } from './NoticeCard';
-import { ObjectRow } from './ObjectRow';
-
-const kindIconMap: { [key: string]: string } = {
-  cluster: 'cluster',
-};
-
-function getIconTypeFromKind(kind: string): string {
-  return kindIconMap[getKindName(kind)] ?? 'cluster';
-}
+import { ManagedResourceObject } from './ManagedResourceObject';
 
 function shouldDisplayResource(resource: IManagedResourceSummary) {
   //TODO: naively filter on presence of moniker but how should we really decide what to display?
@@ -21,20 +12,18 @@ function shouldDisplayResource(resource: IManagedResourceSummary) {
 
 interface IEnvironmentsListProps {
   environments: IManagedEnviromentSummary[];
-  resources: IManagedResourceSummary[];
+  resourcesById: { [id: string]: IManagedResourceSummary };
   artifacts: IManagedArtifactSummary[];
 }
 
-export function EnvironmentsList({ environments, resources, artifacts }: IEnvironmentsListProps) {
-  const resourcesMap = keyBy(resources, 'id');
-
+export function EnvironmentsList({ environments, resourcesById, artifacts }: IEnvironmentsListProps) {
   return (
     <div>
       <NoticeCard
         icon="search"
         text={undefined}
-        title={`${artifacts.length} artifacts ${
-          artifacts.length === 1 ? 'is' : 'are'
+        title={`${artifacts.length} ${
+          artifacts.length === 1 ? 'artifact is' : 'artifacts are'
         } deployed in 2 environments with no issues detected.`}
         isActive={true}
         noticeType={'ok'}
@@ -43,15 +32,10 @@ export function EnvironmentsList({ environments, resources, artifacts }: IEnviro
         <div key={name}>
           <h3>{name.toUpperCase()}</h3>
           {resources
-            .map(resourceId => resourcesMap[resourceId])
+            .map(resourceId => resourcesById[resourceId])
             .filter(shouldDisplayResource)
-            .map(({ id, kind, artifact, moniker: { app, stack, detail } }: IManagedResourceSummary) => (
-              <ObjectRow
-                key={id}
-                icon={getIconTypeFromKind(kind)}
-                title={`${[app, stack, detail].filter(Boolean).join('-')} ${artifact?.versions?.current ||
-                  'unknown version'}`}
-              />
+            .map(resource => (
+              <ManagedResourceObject key={resource.id} resource={resource} />
             ))}
         </div>
       ))}

--- a/app/scripts/modules/core/src/managed/ManagedResourceObject.tsx
+++ b/app/scripts/modules/core/src/managed/ManagedResourceObject.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+import { IManagedResourceSummary } from '../domain/IManagedEntity';
+
+import { getKindName } from './ManagedReader';
+import { ObjectRow } from './ObjectRow';
+
+export interface IManagedResourceObjectProps {
+  resource: IManagedResourceSummary;
+}
+
+const kindIconMap: { [key: string]: string } = {
+  cluster: 'cluster',
+};
+
+function getIconTypeFromKind(kind: string): string {
+  return kindIconMap[getKindName(kind)] ?? 'cluster';
+}
+
+export const ManagedResourceObject = ({
+  resource: {
+    kind,
+    artifact,
+    moniker: { app, stack, detail },
+  },
+}: IManagedResourceObjectProps) => (
+  <ObjectRow
+    icon={getIconTypeFromKind(kind)}
+    title={[app, stack, detail].filter(Boolean).join('-')}
+    metadata={artifact?.versions?.current || 'unknown version'}
+  />
+);

--- a/app/scripts/modules/core/src/managed/ObjectRow.tsx
+++ b/app/scripts/modules/core/src/managed/ObjectRow.tsx
@@ -5,9 +5,10 @@ import styles from './ObjectRow.module.css';
 interface IObjectRowProps {
   icon: string;
   title: string;
+  metadata?: JSX.Element;
 }
 
-export const ObjectRow = ({ icon, title }: IObjectRowProps) => {
+export const ObjectRow = ({ icon, title, metadata }: IObjectRowProps) => {
   const depth = 0;
   return (
     <div className={styles.ObjectRow} style={getStylesFromDepth(depth)}>
@@ -16,7 +17,7 @@ export const ObjectRow = ({ icon, title }: IObjectRowProps) => {
         <span className={styles.rowTitle}>{title}</span>
       </div>
       <div className={styles.centerCol} style={{ flex: `0 0 ${200 + depth * 16}px` }}>
-        {'unknown version'}
+        {metadata}
       </div>
     </div>
   );


### PR DESCRIPTION
~~**Depends on https://github.com/spinnaker/deck/pull/8060, diff will be bloated and CI will fail until merged**~~

This does a very light refactoring pass to pull out our existing use of `ObjectRow` into a shared spot, adds some data massaging for getting a breakdown of environments + resources for a particular artifact version, and then shows that on the detail view:

<img width="1302" alt="Screen Shot 2020-03-19 at 5 26 22 PM" src="https://user-images.githubusercontent.com/1850998/77126627-03d7a180-6a07-11ea-9422-e0e00c56fd0c.png">

Right now only environments that reference the artifact are displayed, **but** within those environments all resources are shown. Right now on the Keel side proper resource <--> artifact linkage is in the works and when that drops we'll filter down to just the compute resources that use that artifact.
