### PR TITLE
fix(kubernetes): specify manifest source as text for ad-hoc applies

### DIFF
--- a/app/scripts/modules/kubernetes/src/v2/manifest/ManifestSource.ts
+++ b/app/scripts/modules/kubernetes/src/v2/manifest/ManifestSource.ts
@@ -1,0 +1,4 @@
+export enum ManifestSource {
+  TEXT = 'text',
+  ARTIFACT = 'artifact',
+}

--- a/app/scripts/modules/kubernetes/src/v2/manifest/manifestCommandBuilder.service.ts
+++ b/app/scripts/modules/kubernetes/src/v2/manifest/manifestCommandBuilder.service.ts
@@ -5,6 +5,8 @@ import { load } from 'js-yaml';
 
 import { AccountService, Application, IMoniker, IArtifactAccount, IAccountDetails } from '@spinnaker/core';
 
+import { ManifestSource } from './ManifestSource';
+
 const LAST_APPLIED_CONFIGURATION = 'kubectl.kubernetes.io/last-applied-configuration';
 
 export interface IKubernetesManifestCommandData {
@@ -21,7 +23,7 @@ export interface IKubernetesManifestCommand {
   moniker: IMoniker;
   manifestArtifactId?: string;
   manifestArtifactAccount?: string;
-  source?: string;
+  source: ManifestSource;
   versioned?: boolean;
 }
 
@@ -50,7 +52,6 @@ export class KubernetesManifestCommandBuilder {
 
   public static copyAndCleanCommand(input: IKubernetesManifestCommand): IKubernetesManifestCommand {
     const command = cloneDeep(input);
-    delete command.source;
     return command;
   }
 
@@ -114,6 +115,7 @@ export class KubernetesManifestCommandBuilder {
             account,
             versioned,
             manifestArtifactAccount,
+            source: ManifestSource.TEXT,
           },
           metadata: {
             backingData,


### PR DESCRIPTION
Closes https://github.com/spinnaker/spinnaker/issues/5596

👩 📈 🐛 😢 (This bug is my fault!)

Prior to this [refactor](https://github.com/spinnaker/orca/pull/3402), Orca assumed Kubernetes manifest operations with an unspecified `source` were `text`-based manifests. However, post-refactor, Orca expects clients to specify whether a manifest operation is `text` or `artifact` based. Stage-based operations already default to `text`, but ad-hoc applies from the Infrastructure view did not specify a `source`. Instead of defaulting to `text` in Orca, let's continue to require clients to specify a valid `source` and update the one client (ad-hoc applies) that left this field unspecified.

This commit is intended for cherry-picking into the 1.19 release branch. However, in a follow-up commit that is not intended for cherry-picking, we will replace the in-stage `source` constants with the enum defined in this PR for consistency.