### PR TITLE
rerrefactor(kubernetes): replace duplicated manifest source constants with enum

### DIFF
--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/DeployManifestStageConfig.tsx
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/DeployManifestStageConfig.tsx
@@ -6,6 +6,7 @@ import { AccountService, FormikStageConfig, IAccountDetails, IStage, IStageConfi
 
 import { DeployManifestStageForm } from './DeployManifestStageForm';
 import { defaultTrafficManagementConfig } from './ManifestDeploymentOptions';
+import { ManifestSource } from '../../../manifest/ManifestSource';
 
 interface IDeployManifestStageConfigState {
   accounts: IAccountDetails[];
@@ -23,7 +24,7 @@ export class DeployManifestStageConfig extends React.Component<IStageConfigProps
     const { stage: initialStageConfig } = props;
     const stage = cloneDeep(initialStageConfig);
     if (!stage.source) {
-      stage.source = 'text';
+      stage.source = ManifestSource.TEXT;
     }
     if (!stage.skipExpressionEvaluation) {
       stage.skipExpressionEvaluation = false;

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/DeployManifestStageForm.tsx
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/DeployManifestStageForm.tsx
@@ -24,6 +24,7 @@ import { IManifestBindArtifact } from './ManifestBindArtifactsSelector';
 import { ManifestDeploymentOptions } from './ManifestDeploymentOptions';
 import { ManifestBindArtifactsSelectorDelegate } from './ManifestBindArtifactsSelectorDelegate';
 import { NamespaceSelector } from './NamespaceSelector';
+import { ManifestSource } from '../../../manifest/ManifestSource';
 
 interface IDeployManifestStageConfigFormProps {
   accounts: IAccountDetails[];
@@ -39,8 +40,6 @@ export class DeployManifestStageForm extends React.Component<
   IDeployManifestStageConfigFormProps & IFormikStageConfigInjectedProps,
   IDeployManifestStageConfigFormState
 > {
-  public readonly textSource = 'text';
-  public readonly artifactSource = 'artifact';
   private readonly excludedManifestArtifactTypes = [
     ArtifactTypePatterns.DOCKER_IMAGE,
     ArtifactTypePatterns.KUBERNETES,
@@ -52,7 +51,7 @@ export class DeployManifestStageForm extends React.Component<
     super(props);
     const stage = this.props.formik.values;
     const manifests: any[] = get(props.formik.values, 'manifests');
-    const isTextManifest: boolean = get(props.formik.values, 'source') === this.textSource;
+    const isTextManifest: boolean = get(props.formik.values, 'source') === ManifestSource.TEXT;
     this.state = {
       rawManifest: !isEmpty(manifests) && isTextManifest ? yamlDocumentsToString(manifests) : '',
       overrideNamespace: get(stage, 'namespaceOverride', '') !== '',
@@ -60,7 +59,7 @@ export class DeployManifestStageForm extends React.Component<
   }
 
   private getSourceOptions = (): Array<Option<string>> => {
-    return map([this.textSource, this.artifactSource], option => ({
+    return map([ManifestSource.TEXT, ManifestSource.ARTIFACT], option => ({
       label: capitalize(option),
       value: option,
     }));
@@ -155,13 +154,13 @@ export class DeployManifestStageForm extends React.Component<
             value={stage.source}
           />
         </StageConfigField>
-        {stage.source === this.textSource && (
+        {stage.source === ManifestSource.TEXT && (
           <StageConfigField label="Manifest">
             <CopyFromTemplateButton application={this.props.application} handleCopy={this.handleCopy} />
             <YamlEditor onChange={this.handleRawManifestChange} value={this.state.rawManifest} />
           </StageConfigField>
         )}
-        {stage.source === this.artifactSource && (
+        {stage.source === ManifestSource.ARTIFACT && (
           <>
             <StageArtifactSelectorDelegate
               artifact={stage.manifestArtifact}

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifest.validator.ts
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifest.validator.ts
@@ -3,6 +3,7 @@ import { get, isEmpty } from 'lodash';
 import { IPipeline, IStage, IValidatorConfig, ICustomValidator } from '@spinnaker/core';
 
 import { strategyRedBlack } from 'kubernetes/v2/rolloutStrategy/redblack.strategy';
+import { ManifestSource } from '../../../manifest/ManifestSource';
 
 const MAX_VERSION_HISTORY_ANNOTATION = 'strategy.spinnaker.io/max-version-history';
 
@@ -18,7 +19,7 @@ export const deployManifestValidators = (): IValidatorConfig[] => {
         if (enabled && isEmpty(services)) {
           return `Select at least one <strong>Service</strong> to enable Spinnaker-managed rollout strategy options.`;
         }
-        if (enabled && stage.source === 'text') {
+        if (enabled && stage.source === ManifestSource.TEXT) {
           const manifests = get(stage, 'manifests', []);
           const replicaSetManifests = manifests.filter(m => m.kind === 'ReplicaSet');
           const strategy = get(stage, 'trafficManagement.options.strategy');

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/patchManifest/PatchManifestStageConfig.tsx
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/patchManifest/PatchManifestStageConfig.tsx
@@ -3,6 +3,7 @@ import { defaults } from 'lodash';
 
 import { FormikStageConfig, IStage, IStageConfigProps } from '@spinnaker/core';
 import { PatchManifestStageForm } from './PatchManifestStageForm';
+import { ManifestSource } from '../../../manifest/ManifestSource';
 
 export class PatchManifestStageConfig extends React.Component<IStageConfigProps> {
   private readonly stage: IStage;
@@ -11,7 +12,7 @@ export class PatchManifestStageConfig extends React.Component<IStageConfigProps>
     super(props);
     defaults(props.stage, {
       app: props.application.name,
-      source: 'text',
+      source: ManifestSource.TEXT,
       options: {
         record: true,
         mergeStrategy: 'strategic',

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/patchManifest/PatchManifestStageForm.tsx
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/patchManifest/PatchManifestStageForm.tsx
@@ -20,6 +20,7 @@ import { IManifestBindArtifact } from '../deployManifest/ManifestBindArtifactsSe
 import { ManifestSelector } from 'kubernetes/v2/manifest/selector/ManifestSelector';
 import { SelectorMode } from 'kubernetes/v2/manifest/selector/IManifestSelector';
 import { PatchManifestOptionsForm } from './PatchManifestOptionsForm';
+import { ManifestSource } from '../../../manifest/ManifestSource';
 
 interface IPatchManifestStageConfigFormProps {
   stageFieldUpdated: () => void;
@@ -34,8 +35,6 @@ export class PatchManifestStageForm extends React.Component<
   IPatchManifestStageConfigFormProps & IFormikStageConfigInjectedProps,
   IPatchManifestStageConfigFormState
 > {
-  public readonly textSource = 'text';
-  public readonly artifactSource = 'artifact';
   private readonly excludedManifestArtifactTypes = [
     ArtifactTypePatterns.DOCKER_IMAGE,
     ArtifactTypePatterns.KUBERNETES,
@@ -47,7 +46,7 @@ export class PatchManifestStageForm extends React.Component<
   public constructor(props: IPatchManifestStageConfigFormProps & IFormikStageConfigInjectedProps) {
     super(props);
     const patchBody: any[] = get(props.formik.values, 'patchBody');
-    const isTextManifest: boolean = get(props.formik.values, 'source') === this.textSource;
+    const isTextManifest: boolean = get(props.formik.values, 'source') === ManifestSource.TEXT;
     this.state = {
       rawManifest: !isEmpty(patchBody) && isTextManifest ? yamlDocumentsToString(patchBody) : '',
     };
@@ -97,7 +96,7 @@ export class PatchManifestStageForm extends React.Component<
   };
 
   private getSourceOptions = (): Array<Option<string>> => {
-    return map([this.textSource, this.artifactSource], option => ({
+    return map([ManifestSource.TEXT, ManifestSource.ARTIFACT], option => ({
       label: capitalize(option),
       value: option,
     }));
@@ -123,12 +122,12 @@ export class PatchManifestStageForm extends React.Component<
             value={stage.source}
           />
         </StageConfigField>
-        {stage.source === this.textSource && (
+        {stage.source === ManifestSource.TEXT && (
           <StageConfigField label="Manifest">
             <YamlEditor onChange={this.handleRawManifestChange} value={this.state.rawManifest} />
           </StageConfigField>
         )}
-        {stage.source === this.artifactSource && (
+        {stage.source === ManifestSource.ARTIFACT && (
           <>
             <StageArtifactSelectorDelegate
               artifact={stage.manifestArtifact}

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/runJob/KubernetesV2RunJobStageConfig.tsx
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/runJob/KubernetesV2RunJobStageConfig.tsx
@@ -22,6 +22,7 @@ import {
 import { ManifestBasicSettings } from 'kubernetes/v2/manifest/wizard/BasicSettings';
 import { ManifestBindArtifactsSelectorDelegate } from '../deployManifest/ManifestBindArtifactsSelectorDelegate';
 import { IManifestBindArtifact } from '../deployManifest/ManifestBindArtifactsSelector';
+import { ManifestSource } from '../../../manifest/ManifestSource';
 
 export interface IKubernetesRunJobStageConfigState {
   credentials: IAccount[];
@@ -29,8 +30,6 @@ export interface IKubernetesRunJobStageConfigState {
 }
 
 export class KubernetesV2RunJobStageConfig extends React.Component<IStageConfigProps> {
-  public readonly textSource = 'text';
-  public readonly artifactSource = 'artifact';
   public state: IKubernetesRunJobStageConfigState = {
     credentials: [],
   };
@@ -49,7 +48,7 @@ export class KubernetesV2RunJobStageConfig extends React.Component<IStageConfigP
       stage.application = application.name;
     }
     if (!stage.source) {
-      stage.source = this.textSource;
+      stage.source = ManifestSource.TEXT;
     }
   }
 
@@ -189,7 +188,7 @@ export class KubernetesV2RunJobStageConfig extends React.Component<IStageConfigP
   }
 
   private getSourceOptions = (): Array<Option<string>> => {
-    return map([this.textSource, this.artifactSource], option => ({
+    return map([ManifestSource.TEXT, ManifestSource.ARTIFACT], option => ({
       label: capitalize(option),
       value: option,
     }));
@@ -235,10 +234,10 @@ export class KubernetesV2RunJobStageConfig extends React.Component<IStageConfigP
             value={stage.source}
           />
         </StageConfigField>
-        {stage.source === this.textSource && (
+        {stage.source === ManifestSource.TEXT && (
           <YamlEditor value={this.state.rawManifest} onChange={this.handleRawManifestChange} />
         )}
-        {stage.source === this.artifactSource && (
+        {stage.source === ManifestSource.ARTIFACT && (
           <>
             <StageArtifactSelectorDelegate
               artifact={stage.manifestArtifact}


### PR DESCRIPTION
Let's replace all Kubernetes stage-specific manifest source constants with the enum added as part of this change: https://github.com/spinnaker/deck/pull/8065

