### PR TITLE
fix(core): Fix effect in TaskMonitorWrapper

### DIFF
--- a/app/scripts/modules/core/src/task/monitor/TaskMonitorWrapper.tsx
+++ b/app/scripts/modules/core/src/task/monitor/TaskMonitorWrapper.tsx
@@ -18,7 +18,7 @@ export const TaskMonitorWrapper = ({ monitor }: ITaskMonitorProps) => {
   useEffect(() => {
     const subscription = monitor?.statusUpdatedStream.subscribe(() => forceUpdate());
     return () => subscription?.unsubscribe();
-  }, []);
+  }, [monitor]);
 
   if (!monitor || (!monitor.submitting && !monitor.error)) {
     return null;


### PR DESCRIPTION
Without `monitor` in the effect's deps, If `monitor` did not exist on the initial render, the effect would only run once with a null monitor meaning we would never actually subscribe to the `statusUpdatedStream`, rendering a blank screen instead of the task monitor.