### PR TITLE
fix(artifacts): only remove deleted expected artifacts from stages on…

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/triggers/TriggersPageContent.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/TriggersPageContent.tsx
@@ -87,8 +87,8 @@ export function TriggersPageContent(props: ITriggersPageContentProps) {
           findIndex(newExpectedArtifacts, e => e.id === expectedArtifact.id),
           1,
         );
+        ArtifactReferenceService.removeReferenceFromStages(expectedArtifact.id, pipelineParam.stages);
       }
-      ArtifactReferenceService.removeReferenceFromStages(expectedArtifact.id, pipelineParam.stages);
     });
     updateExpectedArtifacts(newExpectedArtifacts);
   }


### PR DESCRIPTION
… trigger update

Closes https://github.com/spinnaker/spinnaker/issues/5573

With the `artifactsRewrite` flag on, upon updating a trigger, all associated artifacts references are being removed from any downstream stages. This change makes it so only _deleted_ artifacts' references are removed from downstream stages.

This commit is intended to be cherry-picked to 1.19, 1.18, and 1.17. This change does not resolve a separate (but less destructive) bug where deleted artifact references are _not_ removed from stages when the trigger that owns them is removed. That bug will be fixed as part of an upcoming more invasive refactor that will not be cherry-picked.