### PR TITLE
fix(titus): Update host account environment

### DIFF
--- a/app/scripts/modules/titus/src/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/titus/src/instance/details/instance.details.controller.js
@@ -123,7 +123,7 @@ module(TITUS_INSTANCE_DETAILS_INSTANCE_DETAILS_CONTROLLER, [
             }
 
             // Network interfaces are needed for any IPv6 addresses.
-            return InstanceReader.getInstanceDetails(accountDetails.awsAccount, region, instanceDetails.agentId);
+            return InstanceReader.getInstanceDetails(accountDetails.environment, region, instanceDetails.agentId);
           })
           .then(instance => {
             if (instance && instance.networkInterfaces) {


### PR DESCRIPTION
Titus instances were using the `awsAccount` field to fetch the host instance network interface information. The best field to use is the `environment` field since this is will always evaluate to a known host account-type (`test` or `prod`), whereas `awsAccount` can evaluate to anything and cause errors (e.g.: `workstation_test` instead of `test`). 