### PR TITLE
feat(core/managed): show relevant resources on version details

### DIFF
--- a/app/scripts/modules/core/src/domain/IManagedEntity.ts
+++ b/app/scripts/modules/core/src/domain/IManagedEntity.ts
@@ -17,11 +17,14 @@ export interface IManagedResourceSummary {
   kind: string;
   status: ManagedResourceStatus;
   isPaused: boolean;
-  artifact?: any;
   moniker: IMoniker;
   locations: {
     account: string;
     regions: Array<{ name: string }>;
+  };
+  artifact?: {
+    name: string;
+    type: string;
   };
 }
 

--- a/app/scripts/modules/core/src/managed/ArtifactsList.tsx
+++ b/app/scripts/modules/core/src/managed/ArtifactsList.tsx
@@ -17,16 +17,20 @@ interface IArtifactsListProps {
 export function ArtifactsList({ artifacts, selectedArtifact, artifactSelected }: IArtifactsListProps) {
   return (
     <div>
-      {artifacts.map(({ versions, name }) =>
+      {artifacts.map(({ versions, name, type }) =>
         versions.map((version, i) => (
           <ArtifactRow
             key={`${name}-${version.version}-${i}`} // appending index until name-version is guaranteed to be unique
             isSelected={
-              selectedArtifact && selectedArtifact.name === name && selectedArtifact.version === version.version
+              selectedArtifact &&
+              selectedArtifact.name === name &&
+              selectedArtifact.type === type &&
+              selectedArtifact.version === version.version
             }
             clickHandler={artifactSelected}
             version={version}
             name={name}
+            type={type}
           />
         )),
       )}
@@ -39,15 +43,16 @@ interface IArtifactRowProps {
   clickHandler: (artifact: ISelectedArtifact) => void;
   version: IManagedArtifactVersion;
   name: string;
+  type: string;
 }
 
-export function ArtifactRow({ isSelected, clickHandler, version, name }: IArtifactRowProps) {
+export function ArtifactRow({ isSelected, clickHandler, version, name, type }: IArtifactRowProps) {
   const versionString = version.version;
   const { packageName, version: packageVersion, buildNumber, commit } = parseName(versionString);
   return (
     <div
       className={classNames(styles.ArtifactRow, { [styles.selected]: isSelected })}
-      onClick={() => clickHandler({ name, version: versionString })}
+      onClick={() => clickHandler({ name, type, version: versionString })}
     >
       <div className={styles.content}>
         <div className={styles.version}>

--- a/app/scripts/modules/core/src/managed/Environments.tsx
+++ b/app/scripts/modules/core/src/managed/Environments.tsx
@@ -16,6 +16,7 @@ const CONTENT_WIDTH = 1200;
 
 export interface ISelectedArtifact {
   name: string;
+  type: string;
   version: string;
 }
 
@@ -83,6 +84,7 @@ export function Environments({ app }: IEnvironmentsProps) {
             {selectedArtifact && (
               <ArtifactDetail
                 name={selectedArtifact.name}
+                type={selectedArtifact.type}
                 version={selectedArtifactDetails}
                 resourcesByEnvironment={resourcesByEnvironment}
                 onRequestClose={() => setSelectedArtifact(null)}

--- a/app/scripts/modules/core/src/managed/EnvironmentsList.tsx
+++ b/app/scripts/modules/core/src/managed/EnvironmentsList.tsx
@@ -17,26 +17,29 @@ interface IEnvironmentsListProps {
   artifacts: IManagedArtifactSummary[];
 }
 
-export function EnvironmentsList({ environments, resourcesById, artifacts }: IEnvironmentsListProps) {
+export function EnvironmentsList({ environments, resourcesById, artifacts: allArtifacts }: IEnvironmentsListProps) {
   return (
     <div>
       <NoticeCard
         icon="search"
         text={undefined}
-        title={`${artifacts.length} ${
-          artifacts.length === 1 ? 'artifact is' : 'artifacts are'
+        title={`${allArtifacts.length} ${
+          allArtifacts.length === 1 ? 'artifact is' : 'artifacts are'
         } deployed in 2 environments with no issues detected.`}
         isActive={true}
         noticeType="success"
       />
-      {environments.map(({ name, resources }) => (
+      {environments.map(({ name, resources, artifacts }) => (
         <EnvironmentRow key={name} name={name} isProd={true}>
           {resources
             .map(resourceId => resourcesById[resourceId])
             .filter(shouldDisplayResource)
-            .map(resource => (
-              <ManagedResourceObject key={resource.id} resource={resource} />
-            ))}
+            .map(resource => {
+              const artifact =
+                resource.artifact &&
+                artifacts.find(({ name, type }) => name === resource.artifact.name && type === resource.artifact.type);
+              return <ManagedResourceObject key={resource.id} resource={resource} artifact={artifact} />;
+            })}
         </EnvironmentRow>
       ))}
     </div>

--- a/app/scripts/modules/core/src/managed/ManagedResourceObject.tsx
+++ b/app/scripts/modules/core/src/managed/ManagedResourceObject.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
 
-import { IManagedResourceSummary } from '../domain/IManagedEntity';
+import { IManagedResourceSummary, IManagedEnviromentSummary } from '../domain/IManagedEntity';
 
 import { getKindName } from './ManagedReader';
 import { ObjectRow } from './ObjectRow';
+import { Pill } from './Pill';
+import { parseName } from './Frigga';
 
 export interface IManagedResourceObjectProps {
   resource: IManagedResourceSummary;
+  artifact?: IManagedEnviromentSummary['artifacts'][0];
 }
 
 const kindIconMap: { [key: string]: string } = {
@@ -20,13 +23,20 @@ function getIconTypeFromKind(kind: string): string {
 export const ManagedResourceObject = ({
   resource: {
     kind,
-    artifact,
     moniker: { app, stack, detail },
   },
-}: IManagedResourceObjectProps) => (
-  <ObjectRow
-    icon={getIconTypeFromKind(kind)}
-    title={[app, stack, detail].filter(Boolean).join('-')}
-    metadata={artifact?.versions?.current || 'unknown version'}
-  />
-);
+  artifact,
+}: IManagedResourceObjectProps) => {
+  const { version: currentVersion, buildNumber: currentBuild } = parseName(artifact?.versions.current || '') || {};
+  return (
+    <ObjectRow
+      icon={getIconTypeFromKind(kind)}
+      title={[app, stack, detail].filter(Boolean).join('-')}
+      metadata={
+        artifact?.versions.current && (
+          <Pill text={currentBuild ? `#${currentBuild}` : currentVersion || artifact.versions.current || 'unknown'} />
+        )
+      }
+    />
+  );
+};


### PR DESCRIPTION
Up until today we did not have the ability to tell whether a resource referenced a given artifact. [Now we do](https://github.com/spinnaker/keel/pull/905), so this change filters out all the non-referenced resources when looking at a particular version's journey. For example, here we only see one cluster resource per environment even though each environment actually contains many other resources (security groups, LBs):

<img width="1264" alt="Screen Shot 2020-03-23 at 10 10 54 PM" src="https://user-images.githubusercontent.com/1850998/77390560-98b60400-6d53-11ea-9248-3a1be3c2a2d1.png">

Later I will likely add some sort of treatment that clarifies why you're only seeing those instead of every resource (e.g. a "4 other resources exist in this environment" link that goes to the overview of that environment).

Because the modeling for a resource's `artifact` field changed I also had to mess with resource rows on `EnvironmentList`, so I stuck a pill in for the current version. Doesn't handle when there's a `deploying` version and probably missing all kinds of other stuff: 

<img width="1241" alt="Screen Shot 2020-03-23 at 10 11 03 PM" src="https://user-images.githubusercontent.com/1850998/77390972-bfc10580-6d54-11ea-83e8-186be53c48c7.png">
