### PR TITLE
fix(core): Stop propagation of task monitor close event

### DIFF
--- a/app/scripts/modules/core/src/task/monitor/TaskMonitor.ts
+++ b/app/scripts/modules/core/src/task/monitor/TaskMonitor.ts
@@ -80,8 +80,9 @@ export class TaskMonitor {
     }
   }
 
-  public closeModal = (): void => {
+  public closeModal = (evt?: React.MouseEvent<any>): void => {
     try {
+      evt && evt.stopPropagation();
       this.modalInstance.dismiss();
     } catch (ignored) {
       // modal was already closed


### PR DESCRIPTION
This seemed to have been propagating and trigger other `onClick` handlers.