### PR TITLE
fix(webhook): Show 'Progress' as Info instead of Warning in webhookExecutionDetails

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/webhook/webhookExecutionDetails.controller.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/webhook/webhookExecutionDetails.controller.ts
@@ -39,8 +39,15 @@ export class WebhookExecutionDetailsCtrl implements IController {
 
   private getProgressMessage(): string {
     const context = this.stage.context || {};
+    const webhook = context.webhook || {};
+    const monitor = webhook.monitor || {};
     const buildInfo = context.buildInfo || {};
-    return buildInfo.progressMessage;
+
+    if (monitor.progressMessage) {
+      return monitor.progressMessage;
+    } else {
+      return buildInfo.progressMessage;
+    }
   }
 
   private getFailureMessage(): string {
@@ -52,8 +59,6 @@ export class WebhookExecutionDetailsCtrl implements IController {
 
     if (error) {
       failureMessage = `Webhook failed: ${error}`;
-    } else if (monitor.progressMessage) {
-      failureMessage = `Webhook failed. Last known progress message: ${monitor.progressMessage}`;
     }
 
     return failureMessage;

--- a/app/scripts/modules/core/src/pipeline/config/stages/webhook/webhookExecutionDetails.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/webhook/webhookExecutionDetails.html
@@ -38,13 +38,15 @@
       is-failed="ctrl.stage.isFailed"
       message="ctrl.getException(stage) || ctrl.failureMessage"
     ></stage-failure-message>
-    <div class="well alert-info" ng-if="ctrl.stage.context.progressMessage || ctrl.stage.status">
+    <div class="well alert-info" ng-if="ctrl.progressMessage || ctrl.stage.status">
       <h4>Results</h4>
       <dl class="dl-narrow dl-horizontal ng-scope">
         <dt>Status</dt>
         <dd class="ng-binding">{{ctrl.stage.status}}</dd>
         <dt>Info</dt>
-        <dd class="ng-binding"><p ng-bind-html="ctrl.stage.context.progressMessage | linky:'_blank'"></p></dd>
+        <dd class="ng-binding">
+          <p ng-bind-html="ctrl.progressMessage | linky:'_blank'" style="white-space: pre-line;"></p>
+        </dd>
         <dt>Code</dt>
         <dd class="ng-binding">
           {{ctrl.stage.context.webhook.monitor.statusCodeValue || ctrl.stage.context.webhook.statusCodeValue}}


### PR DESCRIPTION
This change addresses how the "Wait for completion" Webhook feature displays progress. https://github.com/spinnaker/spinnaker/issues/4639

Progress is defined as so in the Webhook stage config UI:

> JSON path to a descriptive message about the progress in the webhook's response JSON.

However, when actually returned by a webhook, the progress is seemingly always displayed as a "Warning" with the text "Webhook failed". This is clearly not always the case. In the following screenshot, the webhook ended up returning SUCCESS and Orca passed the stage and kept going. Deck is making up the "failed" aspect:

<kbd><img width="532" alt="Screen Shot 2020-03-25 at 3 36 52 PM" src="https://user-images.githubusercontent.com/40628/77554594-928c6880-6eb6-11ea-83d2-71f08964ef57.png"></kbd>

This PR changes the component to treat progress messages as 'Info' instead of 'Warning', and also linkifies and respects newlines in the message:

<kbd><img width="532" alt="Screen Shot 2020-03-25 at 3 37 10 PM" src="https://user-images.githubusercontent.com/40628/77554621-991ae000-6eb6-11ea-8a66-92234975fa4d.png"></kbd>

The UX of this stage is still not perfect, but it's no longer misleading 😄 

Here's a Webhook stage JSON which uses a public endpoint to reproduce the issue:

```json
{
  "canceledStatuses": "CANCELED",
  "method": "GET",
  "name": "Webhook",
  "progressJsonPath": "$.progress",
  "statusJsonPath": "$.status",
  "statusUrlResolution": "getMethod",
  "successStatuses": "SUCCESS",
  "terminalStatuses": "TERMINAL",
  "type": "webhook",
  "url": "https://enkyic4ruf4nrmo.m.pipedream.net",
  "waitForCompletion": true
}
```