### PR TITLE
fix(core): fix NPE in getBaseOsDescription

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/bake/bakeStageChooseOs.component.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/bake/bakeStageChooseOs.component.ts
@@ -1,5 +1,4 @@
 import { IController, IComponentOptions, module } from 'angular';
-import { isEmpty } from 'lodash';
 
 export interface IBaseOsOption {
   id: string;
@@ -21,8 +20,11 @@ export class BakeStageChooseOSController implements IController {
   }
 
   public getBaseOsDescription(baseOsOption: IBaseOsOption): string {
-    const baseOsName = isEmpty(baseOsOption.displayName) ? baseOsOption.id : baseOsOption.displayName;
-    return baseOsName + (baseOsOption.shortDescription ? ' (' + baseOsOption.shortDescription + ')' : '');
+    const baseOsName = baseOsOption?.displayName || baseOsOption?.id || '';
+    if (baseOsOption?.shortDescription) {
+      return `${baseOsName} (${baseOsOption.shortDescription})`;
+    }
+    return baseOsName;
   }
   public getBaseOsDetailedDescription(baseOsOption: IBaseOsOption): string {
     return baseOsOption.detailedDescription + (baseOsOption.isImageFamily ? ' (family)' : '');


### PR DESCRIPTION
When adding a new VM `Bake` stage, I noticed a bunch of console errors (`TypeError: Cannot read property 'displayName' of undefined`), because `baseOsOption` will be `undefined` for the first n render cycles. Let's read off it more safely and default the description to an empty string.