### PR TITLE
feat(core/managed): remove non-deploying state indicators

### DIFF
--- a/app/scripts/modules/core/src/managed/ArtifactDetail.less
+++ b/app/scripts/modules/core/src/managed/ArtifactDetail.less
@@ -18,33 +18,12 @@
     height: 16px;
     border-radius: 16px;
     border-radius: 50%;
-
-    &.current {
-      background-color: #00b237;
-    }
-
-    &.approved {
-      border: 1px solid var(--color-status-info);
-    }
+    // Negative margin, boooo. But we need it to keep the icons
+    // for each resource aligned with other, non-deploying ones.
+    margin-left: -8px;
 
     &.deploying {
       background-color: var(--color-status-info);
-    }
-
-    &.pending {
-      border: 1px solid rgba(0, 0, 0, 0.5);
-    }
-
-    &.previous {
-      background-color: var(--color-nobel);
-    }
-
-    &.vetoed {
-      background-color: var(--color-status-error);
-    }
-
-    i.fa {
-      color: var(--color-white);
     }
   }
 }

--- a/app/scripts/modules/core/src/managed/ArtifactDetail.tsx
+++ b/app/scripts/modules/core/src/managed/ArtifactDetail.tsx
@@ -135,10 +135,16 @@ export const ArtifactDetail = ({
                 .filter(resource => shouldDisplayResource(name, type, resource))
                 .map(resource => (
                   <div key={resource.id} className="flex-container-h middle">
-                    <div
-                      className={classNames('resource-badge flex-container-h center middle sp-margin-s-right', state)}
-                    ></div>
-                    <ManagedResourceObject key={resource.id} resource={resource} />
+                    {state === 'deploying' && (
+                      <div
+                        className={classNames('resource-badge flex-container-h center middle sp-margin-s-right', state)}
+                      />
+                    )}
+                    <ManagedResourceObject
+                      key={resource.id}
+                      resource={resource}
+                      depth={state === 'deploying' ? 0 : 1}
+                    />
                   </div>
                 ))}
             </EnvironmentRow>

--- a/app/scripts/modules/core/src/managed/ManagedResourceObject.tsx
+++ b/app/scripts/modules/core/src/managed/ManagedResourceObject.tsx
@@ -11,6 +11,7 @@ import { parseName } from './Frigga';
 export interface IManagedResourceObjectProps {
   resource: IManagedResourceSummary;
   artifact?: IManagedEnviromentSummary['artifacts'][0];
+  depth?: number;
 }
 
 const kindIconMap: { [kind: string]: IconNames } = {
@@ -30,12 +31,14 @@ export const ManagedResourceObject = ({
     moniker: { app, stack, detail },
   },
   artifact,
+  depth,
 }: IManagedResourceObjectProps) => {
   const { version: currentVersion, buildNumber: currentBuild } = parseName(artifact?.versions.current || '') || {};
   return (
     <ObjectRow
       icon={getIconTypeFromKind(kind)}
       title={[app, stack, detail].filter(Boolean).join('-')}
+      depth={depth}
       metadata={
         artifact?.versions.current && (
           <Pill text={currentBuild ? `#${currentBuild}` : currentVersion || artifact.versions.current || 'unknown'} />


### PR DESCRIPTION
After looking at them in the wild we decided we don't really like having indicators on the left side of every resource for every artifact state. It gets pretty busy:

<img width="926" alt="Screen Shot 2020-03-27 at 9 02 35 AM" src="https://user-images.githubusercontent.com/1850998/77775410-bd3b0600-7009-11ea-82f7-9d94bb033aad.png">

Instead we're now removing them entirely for all states except `deploying`. Right now we can't show deployment progress at the resource level, so these indicators are kind of silly and static, but once we get there we'll treat them as pie chart progress indicators and some fanciness will ensue.

I also took the liberty of making the remaining indicator line up better with its surroundings, so the resource + notice card icons are back in proper alignment and the left edge of the indicator lines up with the left edge of environment rows:

<img width="947" alt="Screen Shot 2020-03-27 at 9 00 35 AM" src="https://user-images.githubusercontent.com/1850998/77775697-24f15100-700a-11ea-996f-725b72900e8b.png">

(cc @gcomstock )