### PR TITLE
fix(titus): Solidify mapping of titus to awsAccount

### DIFF
--- a/app/scripts/modules/titus/src/securityGroup/securityGroup.read.service.js
+++ b/app/scripts/modules/titus/src/securityGroup/securityGroup.read.service.js
@@ -6,15 +6,7 @@ export const TITUS_SECURITYGROUP_SECURITYGROUP_READ_SERVICE = 'spinnaker.titus.s
 export const name = TITUS_SECURITYGROUP_SECURITYGROUP_READ_SERVICE; // for backwards compatibility
 module(TITUS_SECURITYGROUP_SECURITYGROUP_READ_SERVICE, []).factory('titusSecurityGroupReader', function() {
   function resolveIndexedSecurityGroup(indexedSecurityGroups, container, securityGroupId) {
-    // TODO: this is bad, but this method is not async and making it async is going to be non-trivial
-    const account = container.account
-      .replace('titus', '')
-      .replace('vpc', '')
-      .replace('dev', 'test')
-      .replace('prodmce', 'mceprod')
-      .replace('mcestaging', 'mcetest')
-      .replace('testmce', 'mcetest');
-    return indexedSecurityGroups[account][container.region][securityGroupId];
+    return indexedSecurityGroups[container.awsAccount][container.region][securityGroupId];
   }
 
   return {

--- a/app/scripts/modules/titus/src/serverGroup/serverGroup.transformer.js
+++ b/app/scripts/modules/titus/src/serverGroup/serverGroup.transformer.js
@@ -4,13 +4,20 @@ import _ from 'lodash';
 
 import { module } from 'angular';
 
+import { AccountService } from '@spinnaker/core';
+
 export const TITUS_SERVERGROUP_SERVERGROUP_TRANSFORMER = 'spinnaker.titus.serverGroup.transformer';
 export const name = TITUS_SERVERGROUP_SERVERGROUP_TRANSFORMER; // for backwards compatibility
 module(TITUS_SERVERGROUP_SERVERGROUP_TRANSFORMER, []).factory('titusServerGroupTransformer', [
   '$q',
   function($q) {
     function normalizeServerGroup(serverGroup) {
-      return $q.when(serverGroup); // no-op
+      return AccountService.getCredentialsKeyedByAccount('titus').then(credentialsKeyedByAccount => {
+        if (serverGroup.account && credentialsKeyedByAccount[serverGroup.account]) {
+          serverGroup.awsAccount = credentialsKeyedByAccount[serverGroup.account].awsAccount;
+        }
+        return serverGroup;
+      });
     }
 
     function convertServerGroupCommandToDeployConfiguration(base) {


### PR DESCRIPTION
By adding an `awsAccount` attribute onto the Titus server group, we can get rid of the dirty `String.replace()` logic that was trying to derive the AWS account name from the Titus account name, which doesn't work perfectly if accounts are not created following strict convention.

More specifically, this addresses cases where the string logic failed and we basically fail resolving the security group because we were looking up the wrong account, or rather, we constructed an account string that didn't even exist.