### PR TITLE
chore(core): remove versionedProviders flag

### DIFF
--- a/app/scripts/modules/core/src/cloudProvider/skin.service.ts
+++ b/app/scripts/modules/core/src/cloudProvider/skin.service.ts
@@ -1,8 +1,7 @@
 import { IPromise } from 'angular';
 import { map } from 'lodash';
-import { $log, $q } from 'ngimport';
+import { $log } from 'ngimport';
 
-import { SETTINGS } from 'core/config/settings';
 import { AccountService, IAccountDetails } from 'core/account';
 import { CloudProviderRegistry } from './CloudProviderRegistry';
 import { ILoadBalancer, IServerGroup } from 'core/domain';
@@ -109,10 +108,6 @@ export class SkinService {
   }
 
   public static getAccounts(): IPromise<IAccountDetails[]> {
-    if (!SETTINGS.feature.versionedProviders) {
-      return $q.resolve([]);
-    }
-
     return AccountService.getCredentialsKeyedByAccount()
       .then(aggregatedAccounts => map(aggregatedAccounts))
       .catch(e => {

--- a/app/scripts/modules/core/src/config/settings.ts
+++ b/app/scripts/modules/core/src/config/settings.ts
@@ -49,7 +49,6 @@ export interface IFeatures {
   slack?: boolean;
   snapshots?: boolean;
   travis?: boolean;
-  versionedProviders?: boolean;
   wercker?: boolean;
   savePipelinesStageEnabled?: boolean;
   kustomizeEnabled?: boolean;

--- a/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/bakeManifestStage.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/bakeManifestStage.ts
@@ -5,7 +5,6 @@ import { ExecutionDetailsTasks } from '../common';
 import { IArtifact, IStage, IPipeline, IStageOrTriggerTypeConfig } from 'core/domain';
 
 import { Registry } from 'core/registry';
-import { SETTINGS } from 'core/config';
 
 import { BakeManifestConfig } from './BakeManifestConfig';
 import { BakeManifestDetailsTab } from './BakeManifestDetailsTab';
@@ -14,43 +13,41 @@ import { ICustomValidator } from '../../validation/PipelineConfigValidator';
 import { RequiredFieldValidator, IRequiredFieldValidationConfig } from '../../validation/requiredField.validator';
 
 export const BAKE_MANIFEST_STAGE_KEY = 'bakeManifest';
-if (SETTINGS.feature.versionedProviders) {
-  const requiredField = (
-    _pipeline: IPipeline,
-    stage: IStage,
-    _validator: IValidatorConfig,
-    _config: IStageOrTriggerTypeConfig,
-  ): string => {
-    if (stage.templateRenderer !== 'HELM2' && stage.templateRenderer !== 'HELM3') {
-      return '';
-    }
+const requiredField = (
+  _pipeline: IPipeline,
+  stage: IStage,
+  _validator: IValidatorConfig,
+  _config: IStageOrTriggerTypeConfig,
+): string => {
+  if (stage.templateRenderer !== 'HELM2' && stage.templateRenderer !== 'HELM3') {
+    return '';
+  }
 
-    return new RequiredFieldValidator().validate(
-      _pipeline,
-      stage,
-      { fieldLabel: 'Name', fieldName: 'outputName' } as IRequiredFieldValidationConfig,
-      _config,
-    );
-  };
+  return new RequiredFieldValidator().validate(
+    _pipeline,
+    stage,
+    { fieldLabel: 'Name', fieldName: 'outputName' } as IRequiredFieldValidationConfig,
+    _config,
+  );
+};
 
-  Registry.pipeline.registerStage({
-    label: 'Bake (Manifest)',
-    description: 'Bake a manifest (or multi-doc manifest set) using a template renderer such as Helm.',
-    key: BAKE_MANIFEST_STAGE_KEY,
-    component: BakeManifestConfig,
-    producesArtifacts: true,
-    cloudProvider: 'kubernetes',
-    executionDetailsSections: [BakeManifestDetailsTab, ExecutionDetailsTasks, ExecutionArtifactTab],
-    artifactExtractor: (fields: string[]) =>
-      ExpectedArtifactService.accumulateArtifacts<IArtifact>(['inputArtifacts'])(fields).map((a: IArtifact) => a.id),
-    artifactRemover: (stage: IStage, artifactId: string) => {
-      ArtifactReferenceService.removeArtifactFromFields(['expectedArtifactId'])(stage, artifactId);
+Registry.pipeline.registerStage({
+  label: 'Bake (Manifest)',
+  description: 'Bake a manifest (or multi-doc manifest set) using a template renderer such as Helm.',
+  key: BAKE_MANIFEST_STAGE_KEY,
+  component: BakeManifestConfig,
+  producesArtifacts: true,
+  cloudProvider: 'kubernetes',
+  executionDetailsSections: [BakeManifestDetailsTab, ExecutionDetailsTasks, ExecutionArtifactTab],
+  artifactExtractor: (fields: string[]) =>
+    ExpectedArtifactService.accumulateArtifacts<IArtifact>(['inputArtifacts'])(fields).map((a: IArtifact) => a.id),
+  artifactRemover: (stage: IStage, artifactId: string) => {
+    ArtifactReferenceService.removeArtifactFromFields(['expectedArtifactId'])(stage, artifactId);
 
-      const artifactDoesNotMatch = (artifact: IArtifact) => artifact.id !== artifactId;
-      stage.expectedArtifacts = (stage.expectedArtifacts ?? []).filter(artifactDoesNotMatch);
-      stage.inputArtifacts = (stage.inputArtifacts ?? []).filter(artifactDoesNotMatch);
-    },
-    validators: [{ type: 'custom', validate: requiredField } as ICustomValidator],
-    manualExecutionComponent: ManualExecutionBakeManifest,
-  });
-}
+    const artifactDoesNotMatch = (artifact: IArtifact) => artifact.id !== artifactId;
+    stage.expectedArtifacts = (stage.expectedArtifacts ?? []).filter(artifactDoesNotMatch);
+    stage.inputArtifacts = (stage.inputArtifacts ?? []).filter(artifactDoesNotMatch);
+  },
+  validators: [{ type: 'custom', validate: requiredField } as ICustomValidator],
+  manualExecutionComponent: ManualExecutionBakeManifest,
+});

--- a/app/scripts/modules/core/src/pipeline/config/stages/savePipelines/savePipelinesStage.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/savePipelines/savePipelinesStage.ts
@@ -1,20 +1,17 @@
 import { ArtifactReferenceService, ExpectedArtifactService } from 'core/artifact';
 import { ExecutionArtifactTab } from 'core/artifact/react/ExecutionArtifactTab';
-import { SETTINGS } from 'core/config/settings';
 import { Registry } from 'core/registry';
 import { SavePipelinesResultsTab } from './SavePipelinesResultsTab';
 import { ExecutionDetailsTasks } from '../common/ExecutionDetailsTasks';
 import { SavePipelinesStageConfig } from './SavePipelinesStageConfig';
 
-if (SETTINGS.feature.versionedProviders) {
-  Registry.pipeline.registerStage({
-    label: 'Save Pipelines',
-    description: 'Saves pipelines defined in an artifact.',
-    key: 'savePipelinesFromArtifact',
-    component: SavePipelinesStageConfig,
-    executionDetailsSections: [ExecutionDetailsTasks, ExecutionArtifactTab, SavePipelinesResultsTab],
-    supportsCustomTimeout: true,
-    artifactExtractor: ExpectedArtifactService.accumulateArtifacts(['pipelinesArtifactId', 'requiredArtifactIds']),
-    artifactRemover: ArtifactReferenceService.removeArtifactFromFields(['pipelinesArtifactId', 'requiredArtifactIds']),
-  });
-}
+Registry.pipeline.registerStage({
+  label: 'Save Pipelines',
+  description: 'Saves pipelines defined in an artifact.',
+  key: 'savePipelinesFromArtifact',
+  component: SavePipelinesStageConfig,
+  executionDetailsSections: [ExecutionDetailsTasks, ExecutionArtifactTab, SavePipelinesResultsTab],
+  supportsCustomTimeout: true,
+  artifactExtractor: ExpectedArtifactService.accumulateArtifacts(['pipelinesArtifactId', 'requiredArtifactIds']),
+  artifactRemover: ArtifactReferenceService.removeArtifactFromFields(['pipelinesArtifactId', 'requiredArtifactIds']),
+});

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestStage.ts
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/deployManifest/deployManifestStage.ts
@@ -5,28 +5,24 @@ import {
   ExpectedArtifactService,
   IStage,
   Registry,
-  SETTINGS,
 } from '@spinnaker/core';
 
 import { DeployStatus } from './manifestStatus/DeployStatus';
 import { DeployManifestStageConfig } from './DeployManifestStageConfig';
 import { deployManifestValidators } from './deployManifest.validator';
 
-// Todo: replace feature flag with proper versioned provider mechanism once available.
-if (SETTINGS.feature.versionedProviders) {
-  Registry.pipeline.registerStage({
-    label: 'Deploy (Manifest)',
-    description: 'Deploy a Kubernetes manifest yaml/json file.',
-    key: 'deployManifest',
-    cloudProvider: 'kubernetes',
-    component: DeployManifestStageConfig,
-    executionDetailsSections: [DeployStatus, ExecutionDetailsTasks, ExecutionArtifactTab],
-    producesArtifacts: true,
-    supportsCustomTimeout: true,
-    validators: deployManifestValidators(),
-    accountExtractor: (stage: IStage): string[] => (stage.account ? [stage.account] : []),
-    configAccountExtractor: (stage: any): string[] => (stage.account ? [stage.account] : []),
-    artifactExtractor: ExpectedArtifactService.accumulateArtifacts(['manifestArtifactId', 'requiredArtifactIds']),
-    artifactRemover: ArtifactReferenceService.removeArtifactFromFields(['manifestArtifactId', 'requiredArtifactIds']),
-  });
-}
+Registry.pipeline.registerStage({
+  label: 'Deploy (Manifest)',
+  description: 'Deploy a Kubernetes manifest yaml/json file.',
+  key: 'deployManifest',
+  cloudProvider: 'kubernetes',
+  component: DeployManifestStageConfig,
+  executionDetailsSections: [DeployStatus, ExecutionDetailsTasks, ExecutionArtifactTab],
+  producesArtifacts: true,
+  supportsCustomTimeout: true,
+  validators: deployManifestValidators(),
+  accountExtractor: (stage: IStage): string[] => (stage.account ? [stage.account] : []),
+  configAccountExtractor: (stage: any): string[] => (stage.account ? [stage.account] : []),
+  artifactExtractor: ExpectedArtifactService.accumulateArtifacts(['manifestArtifactId', 'requiredArtifactIds']),
+  artifactRemover: ArtifactReferenceService.removeArtifactFromFields(['manifestArtifactId', 'requiredArtifactIds']),
+});

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/patchManifest/patchManifestStage.ts
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/patchManifest/patchManifestStage.ts
@@ -4,7 +4,6 @@ import {
   ExecutionDetailsTasks,
   ExpectedArtifactService,
   Registry,
-  SETTINGS,
 } from '@spinnaker/core';
 
 import { DeployStatus } from '../deployManifest/manifestStatus/DeployStatus';
@@ -16,18 +15,16 @@ export class PatchStatus extends DeployStatus {
 }
 
 const STAGE_NAME = 'Patch (Manifest)';
-if (SETTINGS.feature.versionedProviders) {
-  Registry.pipeline.registerStage({
-    label: STAGE_NAME,
-    description: 'Patch a Kubernetes object in place.',
-    key: 'patchManifest',
-    cloudProvider: 'kubernetes',
-    component: PatchManifestStageConfig,
-    executionDetailsSections: [PatchStatus, ExecutionDetailsTasks, ExecutionArtifactTab],
-    producesArtifacts: true,
-    supportsCustomTimeout: true,
-    validators: manifestSelectorValidators(STAGE_NAME),
-    artifactExtractor: ExpectedArtifactService.accumulateArtifacts(['manifestArtifactId', 'requiredArtifactIds']),
-    artifactRemover: ArtifactReferenceService.removeArtifactFromFields(['manifestArtifactId', 'requiredArtifactIds']),
-  });
-}
+Registry.pipeline.registerStage({
+  label: STAGE_NAME,
+  description: 'Patch a Kubernetes object in place.',
+  key: 'patchManifest',
+  cloudProvider: 'kubernetes',
+  component: PatchManifestStageConfig,
+  executionDetailsSections: [PatchStatus, ExecutionDetailsTasks, ExecutionArtifactTab],
+  producesArtifacts: true,
+  supportsCustomTimeout: true,
+  validators: manifestSelectorValidators(STAGE_NAME),
+  artifactExtractor: ExpectedArtifactService.accumulateArtifacts(['manifestArtifactId', 'requiredArtifactIds']),
+  artifactRemover: ArtifactReferenceService.removeArtifactFromFields(['manifestArtifactId', 'requiredArtifactIds']),
+});

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/scaleManifest/scaleManifestStage.ts
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/scaleManifest/scaleManifestStage.ts
@@ -1,6 +1,6 @@
 import { module } from 'angular';
 
-import { Registry, SETTINGS, IStage, ExecutionDetailsTasks } from '@spinnaker/core';
+import { Registry, IStage, ExecutionDetailsTasks } from '@spinnaker/core';
 import { KubernetesV2ScaleManifestConfigCtrl } from './scaleManifestConfig.controller';
 import { KUBERNETES_SCALE_MANIFEST_SETTINGS_FORM } from 'kubernetes/v2/manifest/scale/scaleSettingsForm.component';
 import { manifestExecutionDetails } from '../ManifestExecutionDetails';
@@ -10,25 +10,22 @@ const STAGE_KEY = 'scaleManifest';
 
 module(KUBERNETES_SCALE_MANIFEST_STAGE, [KUBERNETES_SCALE_MANIFEST_SETTINGS_FORM])
   .config(() => {
-    // Todo: replace feature flag with proper versioned provider mechanism once available.
-    if (SETTINGS.feature.versionedProviders) {
-      Registry.pipeline.registerStage({
-        label: 'Scale (Manifest)',
-        description: 'Scale a Kubernetes object created from a manifest.',
-        key: STAGE_KEY,
-        cloudProvider: 'kubernetes',
-        templateUrl: require('./scaleManifestConfig.html'),
-        controller: 'KubernetesV2ScaleManifestConfigCtrl',
-        controllerAs: 'ctrl',
-        executionDetailsSections: [manifestExecutionDetails(STAGE_KEY), ExecutionDetailsTasks],
-        accountExtractor: (stage: IStage): string[] => (stage.account ? [stage.account] : []),
-        configAccountExtractor: (stage: any): string[] => (stage.account ? [stage.account] : []),
-        validators: [
-          { type: 'requiredField', fieldName: 'location', fieldLabel: 'Namespace' },
-          { type: 'requiredField', fieldName: 'account', fieldLabel: 'Account' },
-          { type: 'requiredField', fieldName: 'replicas', fieldLabel: 'Replicas' },
-        ],
-      });
-    }
+    Registry.pipeline.registerStage({
+      label: 'Scale (Manifest)',
+      description: 'Scale a Kubernetes object created from a manifest.',
+      key: STAGE_KEY,
+      cloudProvider: 'kubernetes',
+      templateUrl: require('./scaleManifestConfig.html'),
+      controller: 'KubernetesV2ScaleManifestConfigCtrl',
+      controllerAs: 'ctrl',
+      executionDetailsSections: [manifestExecutionDetails(STAGE_KEY), ExecutionDetailsTasks],
+      accountExtractor: (stage: IStage): string[] => (stage.account ? [stage.account] : []),
+      configAccountExtractor: (stage: any): string[] => (stage.account ? [stage.account] : []),
+      validators: [
+        { type: 'requiredField', fieldName: 'location', fieldLabel: 'Namespace' },
+        { type: 'requiredField', fieldName: 'account', fieldLabel: 'Account' },
+        { type: 'requiredField', fieldName: 'replicas', fieldLabel: 'Replicas' },
+      ],
+    });
   })
   .controller('KubernetesV2ScaleManifestConfigCtrl', KubernetesV2ScaleManifestConfigCtrl);

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/undoRolloutManifest/undoRolloutManifestStage.ts
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/undoRolloutManifest/undoRolloutManifestStage.ts
@@ -1,31 +1,28 @@
 import { module } from 'angular';
 
-import { Registry, SETTINGS, IStage } from '@spinnaker/core';
+import { Registry, IStage } from '@spinnaker/core';
 import { KubernetesV2UndoRolloutManifestConfigCtrl } from './undoRolloutManifestConfig.controller';
 
 export const KUBERNETES_UNDO_ROLLOUT_MANIFEST_STAGE = 'spinnaker.kubernetes.v2.pipeline.stage.undoRolloutManifestStage';
 
 module(KUBERNETES_UNDO_ROLLOUT_MANIFEST_STAGE, [])
   .config(() => {
-    // Todo: replace feature flag with proper versioned provider mechanism once available.
-    if (SETTINGS.feature.versionedProviders) {
-      Registry.pipeline.registerStage({
-        label: 'Undo Rollout (Manifest)',
-        description: 'Rollback a manifest a target number of revisions.',
-        key: 'undoRolloutManifest',
-        cloudProvider: 'kubernetes',
-        templateUrl: require('./undoRolloutManifestConfig.html'),
-        controller: 'KubernetesV2UndoRolloutManifestConfigCtrl',
-        controllerAs: 'ctrl',
-        accountExtractor: (stage: IStage): string[] => (stage.account ? [stage.account] : []),
-        configAccountExtractor: (stage: any): string[] => (stage.account ? [stage.account] : []),
-        validators: [
-          { type: 'requiredField', fieldName: 'location', fieldLabel: 'Namespace' },
-          { type: 'requiredField', fieldName: 'account', fieldLabel: 'Account' },
-          { type: 'requiredField', fieldName: 'numRevisionsBack', fieldLabel: 'Number of Revisions' },
-          { type: 'manifestSelector' },
-        ],
-      });
-    }
+    Registry.pipeline.registerStage({
+      label: 'Undo Rollout (Manifest)',
+      description: 'Rollback a manifest a target number of revisions.',
+      key: 'undoRolloutManifest',
+      cloudProvider: 'kubernetes',
+      templateUrl: require('./undoRolloutManifestConfig.html'),
+      controller: 'KubernetesV2UndoRolloutManifestConfigCtrl',
+      controllerAs: 'ctrl',
+      accountExtractor: (stage: IStage): string[] => (stage.account ? [stage.account] : []),
+      configAccountExtractor: (stage: any): string[] => (stage.account ? [stage.account] : []),
+      validators: [
+        { type: 'requiredField', fieldName: 'location', fieldLabel: 'Namespace' },
+        { type: 'requiredField', fieldName: 'account', fieldLabel: 'Account' },
+        { type: 'requiredField', fieldName: 'numRevisionsBack', fieldLabel: 'Number of Revisions' },
+        { type: 'manifestSelector' },
+      ],
+    });
   })
   .controller('KubernetesV2UndoRolloutManifestConfigCtrl', KubernetesV2UndoRolloutManifestConfigCtrl);

--- a/halconfig/settings.js
+++ b/halconfig/settings.js
@@ -178,7 +178,6 @@ window.spinnakerSettings = {
     slack: false,
     snapshots: false,
     travis: travisEnabled,
-    versionedProviders: true,
     wercker: werckerEnabled,
     functions: functionsEnabled,
   },

--- a/settings.js
+++ b/settings.js
@@ -98,7 +98,6 @@ window.spinnakerSettings = {
     slack: false,
     snapshots: false,
     travis: false,
-    versionedProviders: true,
     wercker: false,
     functions: functionsEnabled,
   },


### PR DESCRIPTION
Since we already support `unsupportedStageTypes` to differentiate between Kubernetes V1 and V2 stages (and we will be removing V1 for release 1.21 anyway), I do not think there is a need for a `versionedProviders` feature flag to gate V2-specific stages. It is not configurable in Halyard, so this should be the only change necessary to remove the feature flag.