### PR TITLE
fix(travis): Refresh travis build information on each render

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/travis/travisExecutionDetails.controller.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/travis/travisExecutionDetails.controller.ts
@@ -21,6 +21,7 @@ export class TravisExecutionDetailsCtrl implements IController {
     this.stage = this.$scope.stage;
     this.initialize();
     this.$scope.$on('$stateChangeSuccess', () => this.initialize());
+    this.$scope.$watch('stage.refId', () => (this.stage = $scope.stage));
   }
 
   public initialized(): void {


### PR DESCRIPTION
Probably this could be handled better... the issue is that Travis build info is set in the controller constructor, so any pipeline with more than one travis stage. It only shows execution details for the stage fetched at load time for all the stages.

Just added a refresh method that is called on each render of the execution details.

https://github.com/spinnaker/spinnaker/issues/5601