### PR TITLE
feat(core/managed): Deep link resources to their infrastructure view

### DIFF
--- a/app/scripts/modules/core/src/managed/ObjectRow.module.css
+++ b/app/scripts/modules/core/src/managed/ObjectRow.module.css
@@ -30,8 +30,6 @@
   background-image: linear-gradient(to bottom, rgba(160, 180, 220, 0.15), rgba(160, 180, 220, 0.15));
 }
 
-/* "pointer-events: none;" is added to children so the data-key attached to ObjectRow is always captured */
-
 .leftCol {
   flex: 5 0 1px;
   display: flex;
@@ -40,8 +38,6 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   margin-right: 16px;
-
-  pointer-events: none;
   /* background-color: rgba(255, 0, 0, 0.1); */
 }
 

--- a/app/scripts/modules/core/src/managed/ObjectRow.tsx
+++ b/app/scripts/modules/core/src/managed/ObjectRow.tsx
@@ -6,7 +6,7 @@ import styles from './ObjectRow.module.css';
 
 interface IObjectRowProps {
   icon: IconNames;
-  title: string;
+  title: JSX.Element | string;
   metadata?: JSX.Element;
   depth?: number;
 }


### PR DESCRIPTION
Adding the ability to deep-link resources to their infrastructure view by applying the filters such as `q=name`, `stack`, `detail`. This is done via parsing `kind` and `id` from `resource` object.

[edit: adding screenshots]

![image](https://user-images.githubusercontent.com/357832/78076094-9b6bb700-735a-11ea-984f-a3c48f6a2552.png)
