### PR TITLE
fix(core): bump up width on numerical form fields

### DIFF
--- a/app/scripts/modules/core/src/presentation/main.less
+++ b/app/scripts/modules/core/src/presentation/main.less
@@ -652,7 +652,7 @@ body > .container {
 
 .form-control {
   &.inline-number {
-    width: 60px;
+    width: 100px;
     display: inline-block;
   }
   &.inline-text {


### PR DESCRIPTION
This addresses a Netflix customer concern that the width on the pipeline wait stage > wait time form field was too narrow. I took a look and saw the 60px style is used throughout deck, but I don't think it's necessary. I think a placeholder value or tooltips go further to instruct a user on the expected input vs the width of the form field. I wanted to get feedback from folks more familiar with the codebase than me though, so I'm just nudging up the width as a safe first step/conversation starter.

Here's a screen shot of the new width

![Screen Shot 2020-03-31 at 12 49 44 PM](https://user-images.githubusercontent.com/3046463/78069412-ebdd1780-734e-11ea-8fb2-95606f2ca428.png)
