### PR TITLE
fix(deck): Evaluate Variables Stage: Update checkbox behavior so 'unchecked' saves correctly

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/failOnFailedExpressions/failOnFailedExpressions.directive.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/failOnFailedExpressions/failOnFailedExpressions.directive.html
@@ -3,7 +3,7 @@
     <div class="col-md-8 col-md-offset-1">
       <div class="checkbox pull-left">
         <label>
-          <input type="checkbox" ng-false-value="undefined" ng-model="$ctrl.stage.failOnFailedExpressions" />
+          <input type="checkbox" ng-false-value="false" ng-model="$ctrl.stage.failOnFailedExpressions" />
           <strong
             >Fail stage on failed
             <a href="http://spinnaker.github.io/guides/user/pipeline-expressions" target="_blank">expressions</a>


### PR DESCRIPTION
In the "Evaluate variables" stage, if you uncheck "Fail stage on failed expressions", rather than saving the field `failOnFailedExpressions` to false, it removes it.

So if you then exit the pipeline editor and re-open it, it shows up as checked again.

This PR changes the behavior so that when the checkbox is unchecked, it is set to `false`.

Old behavior:

![Failed Expression checkbox before change](https://user-images.githubusercontent.com/4943268/78075106-ea711680-7371-11ea-8263-ec7b6781fa2b.gif)

New behavior:

![Failed Expression checkbox after change](https://user-images.githubusercontent.com/4943268/78075154-01b00400-7372-11ea-9552-7b0f73caea12.gif)
