### PR TITLE
feat(core/presentation): Expose status in useDataSource hook

### DIFF
--- a/app/scripts/modules/core/src/application/application.model.ts
+++ b/app/scripts/modules/core/src/application/application.model.ts
@@ -126,10 +126,12 @@ export class Application {
 
     const noneLeftToFetch = statuses.every(({ status }) => ['FETCHED', 'NOT_INITIALIZED'].includes(status));
     const lastFetch = statuses.reduce((latest, status) => Math.max(latest, status.lastRefresh || 0), 0);
+    const allLoaded = statuses.every(({ loaded }) => loaded);
 
     return {
       status: rolledUpStatus,
       lastRefresh: noneLeftToFetch ? lastFetch : this.lastRefresh,
+      loaded: allLoaded,
       data: undefined,
     };
   }

--- a/app/scripts/modules/core/src/application/service/applicationDataSource.ts
+++ b/app/scripts/modules/core/src/application/service/applicationDataSource.ts
@@ -12,6 +12,7 @@ import { Application } from '../application.model';
 
 export interface IFetchStatus {
   status: 'NOT_INITIALIZED' | 'FETCHING' | 'FETCHED' | 'ERROR';
+  loaded: boolean;
   error?: any;
   lastRefresh: number;
   data: any;
@@ -316,6 +317,8 @@ export class ApplicationDataSource<T = any> implements IDataSourceConfig<T> {
   public dataUpdated(data?: T): void {
     if (this.loaded) {
       this.updateData(data !== undefined ? data : this.data);
+      const updatedStatus = { data: this.data, ...this.status$.value };
+      this.status$.next(updatedStatus);
     }
   }
 
@@ -364,6 +367,7 @@ export class ApplicationDataSource<T = any> implements IDataSourceConfig<T> {
 
     this.status$ = new BehaviorSubject({
       status: 'NOT_INITIALIZED',
+      loaded: this.loaded,
       lastRefresh: 0,
       error: null,
       data: this.data,
@@ -397,6 +401,7 @@ export class ApplicationDataSource<T = any> implements IDataSourceConfig<T> {
     fetchStream$.withLatestFrom(nextTick$).subscribe(([fetchStatus, _void]) => {
       // Update mutable flags
       this.statusUpdated(fetchStatus);
+      fetchStatus.loaded = this.loaded;
 
       if (fetchStatus.status === 'FETCHED') {
         this.updateData(fetchStatus.data);

--- a/app/scripts/modules/core/src/presentation/hooks/useDataSource.hook.ts
+++ b/app/scripts/modules/core/src/presentation/hooks/useDataSource.hook.ts
@@ -3,12 +3,8 @@ import { useLatestCallback } from './useLatestCallback.hook';
 
 import { ApplicationDataSource, IFetchStatus } from '../../application';
 
-export interface IDataSourceResult<T> {
+export interface IDataSourceResult<T> extends IFetchStatus {
   data: T;
-  status: IFetchStatus;
-  loaded: boolean;
-  loading: boolean;
-  loadFailure: boolean;
   refresh: () => void;
 }
 
@@ -21,9 +17,7 @@ export interface IDataSourceResult<T> {
  * @returns IDataSourceResult<T>
  */
 export const useDataSource = <T>(dataSource: ApplicationDataSource<T>): IDataSourceResult<T> => {
-  const data = useObservableValue(dataSource.data$, dataSource.data$.value);
   const status = useObservableValue(dataSource.status$, dataSource.status$.value);
-  const { loaded, loading, loadFailure } = dataSource;
 
   // Memoize to give consumers a stable ref,
   // but don't return the promise that dataSource.refresh() returns
@@ -32,11 +26,7 @@ export const useDataSource = <T>(dataSource: ApplicationDataSource<T>): IDataSou
   });
 
   return {
-    data,
-    status,
-    loaded,
-    loading,
-    loadFailure,
+    ...status,
     refresh,
   };
 };

--- a/app/scripts/modules/core/src/presentation/hooks/useDataSource.hook.ts
+++ b/app/scripts/modules/core/src/presentation/hooks/useDataSource.hook.ts
@@ -1,10 +1,14 @@
 import { useObservableValue } from './useObservableValue.hook';
 import { useLatestCallback } from './useLatestCallback.hook';
 
-import { ApplicationDataSource } from '../../application';
+import { ApplicationDataSource, IFetchStatus } from '../../application';
 
 export interface IDataSourceResult<T> {
   data: T;
+  status: IFetchStatus;
+  loaded: boolean;
+  loading: boolean;
+  loadFailure: boolean;
   refresh: () => void;
 }
 
@@ -18,6 +22,8 @@ export interface IDataSourceResult<T> {
  */
 export const useDataSource = <T>(dataSource: ApplicationDataSource<T>): IDataSourceResult<T> => {
   const data = useObservableValue(dataSource.data$, dataSource.data$.value);
+  const status = useObservableValue(dataSource.status$, dataSource.status$.value);
+  const { loaded, loading, loadFailure } = dataSource;
 
   // Memoize to give consumers a stable ref,
   // but don't return the promise that dataSource.refresh() returns
@@ -27,6 +33,10 @@ export const useDataSource = <T>(dataSource: ApplicationDataSource<T>): IDataSou
 
   return {
     data,
+    status,
+    loaded,
+    loading,
+    loadFailure,
     refresh,
   };
 };


### PR DESCRIPTION
Without tapping into the status stream in the hook, we actually can't handle error or loading states.

This change basically just exposes the `loaded`, `loading`, `loadFailure` convenience properties of the `dataSource`. Tapping into the `status$` allows the hook to run whenever the status changes.

Example of how these are leveraged is in https://github.com/spinnaker/deck/pull/8119