### PR TITLE
feat(core): Add svg name to dataSource

### DIFF
--- a/app/scripts/modules/core/src/application/config/appConfig.dataSource.js
+++ b/app/scripts/modules/core/src/application/config/appConfig.dataSource.js
@@ -12,5 +12,6 @@ module(CORE_APPLICATION_CONFIG_APPCONFIG_DATASOURCE, [APP_CONFIG_STATES]).run(fu
     sref: '.config',
     active: '**.config.**',
     defaultData: [],
+    iconSvg: 'spMenuConfig',
   });
 });

--- a/app/scripts/modules/core/src/application/config/appConfig.dataSource.js
+++ b/app/scripts/modules/core/src/application/config/appConfig.dataSource.js
@@ -12,6 +12,6 @@ module(CORE_APPLICATION_CONFIG_APPCONFIG_DATASOURCE, [APP_CONFIG_STATES]).run(fu
     sref: '.config',
     active: '**.config.**',
     defaultData: [],
-    iconSvg: 'spMenuConfig',
+    iconName: 'spMenuConfig',
   });
 });

--- a/app/scripts/modules/core/src/application/nav/navigationCategory.registry.ts
+++ b/app/scripts/modules/core/src/application/nav/navigationCategory.registry.ts
@@ -1,10 +1,11 @@
 import { cloneDeep } from 'lodash';
+import { IconNames } from 'core/presentation';
 
 export interface INavigationCategory {
   key: string;
   label: string;
   icon?: string;
-  iconSvg?: string;
+  iconName?: IconNames;
   primary: boolean;
   order: number;
 }

--- a/app/scripts/modules/core/src/application/nav/navigationCategory.registry.ts
+++ b/app/scripts/modules/core/src/application/nav/navigationCategory.registry.ts
@@ -4,6 +4,7 @@ export interface INavigationCategory {
   key: string;
   label: string;
   icon?: string;
+  iconSvg?: string;
   primary: boolean;
   order: number;
 }

--- a/app/scripts/modules/core/src/application/service/applicationDataSource.ts
+++ b/app/scripts/modules/core/src/application/service/applicationDataSource.ts
@@ -3,7 +3,7 @@ import { $log, $q } from 'ngimport';
 import { BehaviorSubject, Observable, Subject } from 'rxjs';
 
 import { IEntityTags } from 'core/domain';
-import { robotToHuman } from 'core/presentation';
+import { robotToHuman, IconNames } from 'core/presentation';
 import { ReactInjector } from 'core/reactShims';
 import { FirewallLabels } from 'core/securityGroup';
 import { toIPromise } from 'core/utils';
@@ -67,7 +67,7 @@ export interface IDataSourceConfig<T> {
   /**
    * Represents the name of the svg to be used with the svg loader (Icon.tsx)
    */
-  iconSvg?: string;
+  iconName?: IconNames;
 
   /**
    * unique value for this data source; the data source will be available on the Application directly via this key,
@@ -200,7 +200,7 @@ export class ApplicationDataSource<T = any> implements IDataSourceConfig<T> {
   public credentialsField: string;
   public description: string;
   public icon: string;
-  public iconSvg: string;
+  public iconName: IconNames;
   public key: string;
   public label: string;
   public category: string;

--- a/app/scripts/modules/core/src/application/service/applicationDataSource.ts
+++ b/app/scripts/modules/core/src/application/service/applicationDataSource.ts
@@ -65,6 +65,11 @@ export interface IDataSourceConfig<T> {
   icon?: string;
 
   /**
+   * Represents the name of the svg to be used with the svg loader (Icon.tsx)
+   */
+  iconSvg?: string;
+
+  /**
    * unique value for this data source; the data source will be available on the Application directly via this key,
    * e.g. if the key is "serverGroups", you can access the data source via application.serverGroups
    */
@@ -195,6 +200,7 @@ export class ApplicationDataSource<T = any> implements IDataSourceConfig<T> {
   public credentialsField: string;
   public description: string;
   public icon: string;
+  public iconSvg: string;
   public key: string;
   public label: string;
   public category: string;

--- a/app/scripts/modules/core/src/loadBalancer/loadBalancer.dataSource.ts
+++ b/app/scripts/modules/core/src/loadBalancer/loadBalancer.dataSource.ts
@@ -32,6 +32,7 @@ module(LOAD_BALANCER_DATA_SOURCE, [LOAD_BALANCER_READ_SERVICE]).run([
       category: INFRASTRUCTURE_KEY,
       optional: true,
       icon: 'fa fa-xs fa-fw icon-sitemap',
+      iconSvg: 'spMenuLoadBalancers',
       loader: loadLoadBalancers,
       onLoad: addLoadBalancers,
       afterLoad: addTags,

--- a/app/scripts/modules/core/src/loadBalancer/loadBalancer.dataSource.ts
+++ b/app/scripts/modules/core/src/loadBalancer/loadBalancer.dataSource.ts
@@ -32,7 +32,7 @@ module(LOAD_BALANCER_DATA_SOURCE, [LOAD_BALANCER_READ_SERVICE]).run([
       category: INFRASTRUCTURE_KEY,
       optional: true,
       icon: 'fa fa-xs fa-fw icon-sitemap',
-      iconSvg: 'spMenuLoadBalancers',
+      iconName: 'spMenuLoadBalancers',
       loader: loadLoadBalancers,
       onLoad: addLoadBalancers,
       afterLoad: addTags,

--- a/app/scripts/modules/core/src/managed/managed.dataSource.ts
+++ b/app/scripts/modules/core/src/managed/managed.dataSource.ts
@@ -62,7 +62,7 @@ module(MANAGED_RESOURCES_DATA_SOURCE, []).run([
       optIn: true,
       hidden: true,
       icon: 'fa fa-fw fa-xs fa-code-branch',
-      iconSvg: 'spCIBranch',
+      iconName: 'spCIBranch',
       loader: loadEnvironments,
       onLoad: addEnvironments,
       defaultData: {

--- a/app/scripts/modules/core/src/managed/managed.dataSource.ts
+++ b/app/scripts/modules/core/src/managed/managed.dataSource.ts
@@ -62,6 +62,7 @@ module(MANAGED_RESOURCES_DATA_SOURCE, []).run([
       optIn: true,
       hidden: true,
       icon: 'fa fa-fw fa-xs fa-code-branch',
+      iconSvg: 'spCIBranch',
       loader: loadEnvironments,
       onLoad: addEnvironments,
       defaultData: {

--- a/app/scripts/modules/core/src/pipeline/pipeline.dataSource.js
+++ b/app/scripts/modules/core/src/pipeline/pipeline.dataSource.js
@@ -68,7 +68,7 @@ module(CORE_PIPELINE_PIPELINE_DATASOURCE, [EXECUTION_SERVICE, CLUSTER_SERVICE]).
         optional: true,
         primary: true,
         icon: 'fa fa-xs fa-fw fa-list',
-        iconSvg: 'spMenuPipelines',
+        iconName: 'spMenuPipelines',
         key: 'executions',
         label: 'Pipelines',
         category: DELIVERY_KEY,

--- a/app/scripts/modules/core/src/pipeline/pipeline.dataSource.js
+++ b/app/scripts/modules/core/src/pipeline/pipeline.dataSource.js
@@ -68,6 +68,7 @@ module(CORE_PIPELINE_PIPELINE_DATASOURCE, [EXECUTION_SERVICE, CLUSTER_SERVICE]).
         optional: true,
         primary: true,
         icon: 'fa fa-xs fa-fw fa-list',
+        iconSvg: 'spMenuPipelines',
         key: 'executions',
         label: 'Pipelines',
         category: DELIVERY_KEY,

--- a/app/scripts/modules/core/src/securityGroup/securityGroup.dataSource.ts
+++ b/app/scripts/modules/core/src/securityGroup/securityGroup.dataSource.ts
@@ -32,6 +32,7 @@ module(SECURITY_GROUP_DATA_SOURCE, [SECURITY_GROUP_READER]).run([
       sref: '.insight.firewalls',
       optional: true,
       icon: 'fa fa-xs fa-fw fa-lock',
+      iconSvg: 'spMenuSecurityGroups',
       loader: loadSecurityGroups,
       onLoad: addSecurityGroups,
       afterLoad: addTags,

--- a/app/scripts/modules/core/src/securityGroup/securityGroup.dataSource.ts
+++ b/app/scripts/modules/core/src/securityGroup/securityGroup.dataSource.ts
@@ -32,7 +32,7 @@ module(SECURITY_GROUP_DATA_SOURCE, [SECURITY_GROUP_READER]).run([
       sref: '.insight.firewalls',
       optional: true,
       icon: 'fa fa-xs fa-fw fa-lock',
-      iconSvg: 'spMenuSecurityGroups',
+      iconName: 'spMenuSecurityGroups',
       loader: loadSecurityGroups,
       onLoad: addSecurityGroups,
       afterLoad: addTags,

--- a/app/scripts/modules/core/src/serverGroup/serverGroup.dataSource.ts
+++ b/app/scripts/modules/core/src/serverGroup/serverGroup.dataSource.ts
@@ -46,6 +46,7 @@ module(SERVER_GROUP_DATA_SOURCE, [CLUSTER_SERVICE]).run([
       optional: true,
       primary: true,
       icon: 'fas fa-xs fa-fw fa-th-large',
+      iconSvg: 'spMenuClusters',
       loader: loadServerGroups,
       onLoad: addServerGroups,
       afterLoad: addTags,

--- a/app/scripts/modules/core/src/serverGroup/serverGroup.dataSource.ts
+++ b/app/scripts/modules/core/src/serverGroup/serverGroup.dataSource.ts
@@ -46,7 +46,7 @@ module(SERVER_GROUP_DATA_SOURCE, [CLUSTER_SERVICE]).run([
       optional: true,
       primary: true,
       icon: 'fas fa-xs fa-fw fa-th-large',
-      iconSvg: 'spMenuClusters',
+      iconName: 'spMenuClusters',
       loader: loadServerGroups,
       onLoad: addServerGroups,
       afterLoad: addTags,

--- a/app/scripts/modules/core/src/task/task.dataSource.js
+++ b/app/scripts/modules/core/src/task/task.dataSource.js
@@ -42,6 +42,7 @@ angular.module(CORE_TASK_TASK_DATASOURCE, [CLUSTER_SERVICE]).run([
       lazy: true,
       primary: true,
       icon: 'fa fa-sm fa-fw fa-check-square',
+      iconSvg: 'spMenuTasks',
       defaultData: [],
     });
 

--- a/app/scripts/modules/core/src/task/task.dataSource.js
+++ b/app/scripts/modules/core/src/task/task.dataSource.js
@@ -42,7 +42,7 @@ angular.module(CORE_TASK_TASK_DATASOURCE, [CLUSTER_SERVICE]).run([
       lazy: true,
       primary: true,
       icon: 'fa fa-sm fa-fw fa-check-square',
-      iconSvg: 'spMenuTasks',
+      iconName: 'spMenuTasks',
       defaultData: [],
     });
 


### PR DESCRIPTION
Given the svg icon loader (https://github.com/spinnaker/deck/pull/8056) and the upcoming Nav restructure, it is a good time to migrate the nav bar icons to svgs.

In order to do this, the `ApplicationDataSource` type now has an `iconSvg` attribute. Once this change propagates to all data sources in `deck` and `deck-kayenta`, a follow-up PR will update the `NavIcon` component to utilize `dataSource.iconSvg` instead of the current `dataSource.icon`, which points to the font awesome icon. 