### PR TITLE
fix(core): default and validate Bake (Manifest) produced artifacts

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/BakeManifestConfig.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/BakeManifestConfig.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 import { cloneDeep } from 'lodash';
 import { FormikErrors } from 'formik';
 
-import { IStage } from 'core/domain';
+import { IExpectedArtifact, IStage } from 'core/domain';
 import { FormValidator } from 'core/presentation';
 
 import { FormikStageConfig } from '../FormikStageConfig';
 import { IStageConfigProps } from '../common';
-import { BakeManifestStageForm } from './BakeManifestStageForm';
+import { BakeManifestStageForm, validateProducedArtifacts } from './BakeManifestStageForm';
 import { HELM_RENDERERS } from './ManifestRenderers';
 
 export function BakeManifestConfig({ application, pipeline, stage, updatePipeline, updateStage }: IStageConfigProps) {
@@ -33,6 +33,16 @@ export function BakeManifestConfig({ application, pipeline, stage, updatePipelin
 
 export function validateBakeManifestStage(stage: IStage): FormikErrors<IStage> {
   const formValidator = new FormValidator(stage);
+
+  formValidator
+    .field('expectedArtifacts', 'Produced artifacts')
+    .required()
+    .withValidators((artifacts: IExpectedArtifact[]) => {
+      if (validateProducedArtifacts(artifacts)) {
+        return undefined;
+      }
+      return 'Exactly one expected artifact of type embedded/base64 must be configured in the Produces Artifacts section';
+    });
 
   if (HELM_RENDERERS.includes(stage.templateRenderer)) {
     formValidator.field('outputName', 'Name').required();

--- a/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/BakeManifestConfig.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/BakeManifestConfig.tsx
@@ -1,37 +1,42 @@
 import React from 'react';
-import { defaults } from 'lodash';
+import { cloneDeep } from 'lodash';
+import { FormikErrors } from 'formik';
 
 import { IStage } from 'core/domain';
+import { FormValidator } from 'core/presentation';
+
 import { FormikStageConfig } from '../FormikStageConfig';
 import { IStageConfigProps } from '../common';
 import { BakeManifestStageForm } from './BakeManifestStageForm';
+import { HELM_RENDERERS } from './ManifestRenderers';
 
-export class BakeManifestConfig extends React.Component<IStageConfigProps> {
-  private readonly stage: IStage;
-
-  public constructor(props: IStageConfigProps) {
-    super(props);
-
-    // Intentionally initializing the stage config only once in the constructor
-    // The stage config is then completely owned within FormikStageConfig's Formik state
-    this.stage = props.stage;
-  }
-
-  public componentDidMount() {
-    defaults(this.stage, {
+export function BakeManifestConfig({ application, pipeline, stage, updatePipeline, updateStage }: IStageConfigProps) {
+  const stageWithDefaults = React.useMemo(() => {
+    return {
       inputArtifacts: [],
       overrides: {},
-    });
+      ...cloneDeep(stage),
+    };
+  }, []);
+
+  return (
+    <FormikStageConfig
+      application={application}
+      onChange={updateStage}
+      pipeline={pipeline}
+      stage={stageWithDefaults}
+      validate={validateBakeManifestStage}
+      render={props => <BakeManifestStageForm {...props} updatePipeline={updatePipeline} />}
+    />
+  );
+}
+
+export function validateBakeManifestStage(stage: IStage): FormikErrors<IStage> {
+  const formValidator = new FormValidator(stage);
+
+  if (HELM_RENDERERS.includes(stage.templateRenderer)) {
+    formValidator.field('outputName', 'Name').required();
   }
 
-  public render() {
-    return (
-      <FormikStageConfig
-        {...this.props}
-        stage={this.stage}
-        onChange={this.props.updateStage}
-        render={props => <BakeManifestStageForm {...props} updatePipeline={this.props.updatePipeline} />}
-      />
-    );
-  }
+  return formValidator.validateForm();
 }

--- a/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/BakeManifestStageForm.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/BakeManifestStageForm.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
+import { ExpectedArtifactService } from 'core/artifact';
 import { SETTINGS } from 'core/config';
-import { IPipeline } from 'core/domain';
+import { IExpectedArtifact, IPipeline } from 'core/domain';
 import { ReactSelectInput } from 'core/presentation';
 
 import { StageConfigField } from '../common';
@@ -9,6 +10,7 @@ import { IFormikStageConfigInjectedProps } from '../FormikStageConfig';
 import { BakeKustomizeConfigForm } from './kustomize/BakeKustomizeConfigForm';
 import { BakeHelmConfigForm } from './helm/BakeHelmConfigForm';
 import { ManifestRenderers, HELM_RENDERERS } from './ManifestRenderers';
+import { BASE_64_ARTIFACT_ACCOUNT, BASE_64_ARTIFACT_TYPE } from '../../triggers/artifacts/base64/base64.artifact';
 
 interface IBakeManifestStageFormProps {
   updatePipeline: (pipeline: IPipeline) => void;
@@ -21,6 +23,16 @@ export function BakeManifestStageForm({
   updatePipeline,
 }: IBakeManifestStageFormProps & IFormikStageConfigInjectedProps) {
   const stage = formik.values;
+
+  React.useEffect(() => {
+    if (!validateProducedArtifacts(stage.expectedArtifacts)) {
+      const defaultProducedArtifact = ExpectedArtifactService.createEmptyArtifact();
+      defaultProducedArtifact.matchArtifact.type = BASE_64_ARTIFACT_TYPE;
+      defaultProducedArtifact.matchArtifact.artifactAccount = BASE_64_ARTIFACT_ACCOUNT;
+      defaultProducedArtifact.matchArtifact.customKind = false;
+      formik.setFieldValue('expectedArtifacts', [defaultProducedArtifact]);
+    }
+  }, []);
 
   const templateRenderers = React.useMemo(() => {
     const renderers = [...HELM_RENDERERS];
@@ -67,4 +79,8 @@ export function BakeManifestStageForm({
       </div>
     </div>
   );
+}
+
+export function validateProducedArtifacts(artifacts: IExpectedArtifact[]): boolean {
+  return artifacts?.length === 1 && artifacts[0]?.matchArtifact?.type === BASE_64_ARTIFACT_TYPE;
 }

--- a/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/ManifestRenderers.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/ManifestRenderers.ts
@@ -1,0 +1,7 @@
+export enum ManifestRenderers {
+  HELM2 = 'HELM2',
+  HELM3 = 'HELM3',
+  KUSTOMIZE = 'KUSTOMIZE',
+}
+
+export const HELM_RENDERERS: Readonly<ManifestRenderers[]> = [ManifestRenderers.HELM2, ManifestRenderers.HELM3];

--- a/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/ManualExecutionBakeManifest.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/ManualExecutionBakeManifest.tsx
@@ -5,11 +5,13 @@ import { ITriggerTemplateComponentProps } from '../../../manualExecution/Trigger
 import { IArtifact, IExpectedArtifact } from 'core/domain';
 import { HelmMatch } from '../../triggers/artifacts/helm/HelmArtifactEditor';
 import { BAKE_MANIFEST_STAGE_KEY } from './bakeManifestStage';
+import { HELM_RENDERERS } from './ManifestRenderers';
 
 const HelmEditor = HelmMatch.editCmp;
 
 export function ManualExecutionBakeManifest(props: ITriggerTemplateComponentProps) {
   const [overrideArtifact, setOverrideArtifact] = React.useState(true);
+  let defaultArtifact: IArtifact = null;
 
   const updateHelmArtifact = (artifact: IArtifact) => {
     const updatedArtifacts = (props.command.extraFields.artifacts || []).filter(
@@ -29,7 +31,7 @@ export function ManualExecutionBakeManifest(props: ITriggerTemplateComponentProp
   React.useEffect(() => {
     if (overrideArtifact === false) {
       removeHelmArtifact();
-    } else {
+    } else if (defaultArtifact !== null) {
       updateHelmArtifact(defaultArtifact);
     }
   }, [overrideArtifact]);
@@ -39,10 +41,7 @@ export function ManualExecutionBakeManifest(props: ITriggerTemplateComponentProp
   Bake (Manifest) stage and exactly one artifact of type `helm/chart`.
    */
   const bakeManifestStages = props.command.pipeline.stages.filter(stage => stage.type === BAKE_MANIFEST_STAGE_KEY);
-  if (
-    bakeManifestStages.length !== 1 ||
-    (bakeManifestStages[0].templateRenderer !== 'HELM2' && bakeManifestStages[0].templateRenderer !== 'HELM3')
-  ) {
+  if (bakeManifestStages.length !== 1 || !HELM_RENDERERS.includes(bakeManifestStages[0].templateRenderer)) {
     return null;
   }
   const expectedArtifacts = props.command.pipeline.expectedArtifacts || [];
@@ -54,7 +53,7 @@ export function ManualExecutionBakeManifest(props: ITriggerTemplateComponentProp
   }
 
   const helmArtifact = (props.command.extraFields.artifacts || []).find((a: IArtifact) => a.type === HelmMatch.type);
-  const defaultArtifact: IArtifact = {
+  defaultArtifact = {
     ...expectedHelmArtifacts[0].matchArtifact,
     version: null,
   };

--- a/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/ManualExecutionBakeManifest.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/ManualExecutionBakeManifest.tsx
@@ -4,14 +4,34 @@ import { CheckboxInput } from 'core/presentation';
 import { ITriggerTemplateComponentProps } from '../../../manualExecution/TriggerTemplate';
 import { IArtifact, IExpectedArtifact } from 'core/domain';
 import { HelmMatch } from '../../triggers/artifacts/helm/HelmArtifactEditor';
-import { BAKE_MANIFEST_STAGE_KEY } from './bakeManifestStage';
-import { HELM_RENDERERS } from './ManifestRenderers';
 
 const HelmEditor = HelmMatch.editCmp;
 
 export function ManualExecutionBakeManifest(props: ITriggerTemplateComponentProps) {
   const [overrideArtifact, setOverrideArtifact] = React.useState(true);
-  let defaultArtifact: IArtifact = null;
+
+  const defaultArtifact: IArtifact = React.useMemo(() => {
+    const expectedHelmArtifacts = (props.command.pipeline.expectedArtifacts || []).filter(
+      (artifact: IExpectedArtifact) => artifact.matchArtifact.type === HelmMatch.type,
+    );
+    if (expectedHelmArtifacts.length === 0) {
+      return null;
+    }
+    return {
+      ...expectedHelmArtifacts[0].matchArtifact,
+      version: null,
+    };
+  }, []);
+
+  React.useEffect(() => {
+    if (overrideArtifact === false) {
+      removeHelmArtifact();
+    } else if (defaultArtifact) {
+      updateHelmArtifact(defaultArtifact);
+    }
+  }, [defaultArtifact, overrideArtifact]);
+
+  const helmArtifact = (props.command.extraFields.artifacts || []).find((a: IArtifact) => a.type === HelmMatch.type);
 
   const updateHelmArtifact = (artifact: IArtifact) => {
     const updatedArtifacts = (props.command.extraFields.artifacts || []).filter(
@@ -28,35 +48,9 @@ export function ManualExecutionBakeManifest(props: ITriggerTemplateComponentProp
     props.updateCommand('extraFields.artifacts', updatedArtifacts);
   };
 
-  React.useEffect(() => {
-    if (overrideArtifact === false) {
-      removeHelmArtifact();
-    } else if (defaultArtifact !== null) {
-      updateHelmArtifact(defaultArtifact);
-    }
-  }, [overrideArtifact]);
-
-  /*
-  Only allow manual override of a helm chart artifact when there is exactly one Helm
-  Bake (Manifest) stage and exactly one artifact of type `helm/chart`.
-   */
-  const bakeManifestStages = props.command.pipeline.stages.filter(stage => stage.type === BAKE_MANIFEST_STAGE_KEY);
-  if (bakeManifestStages.length !== 1 || !HELM_RENDERERS.includes(bakeManifestStages[0].templateRenderer)) {
+  if (!defaultArtifact) {
     return null;
   }
-  const expectedArtifacts = props.command.pipeline.expectedArtifacts || [];
-  const expectedHelmArtifacts = expectedArtifacts.filter(
-    (artifact: IExpectedArtifact) => artifact.matchArtifact.type === HelmMatch.type,
-  );
-  if (expectedHelmArtifacts.length !== 1) {
-    return null;
-  }
-
-  const helmArtifact = (props.command.extraFields.artifacts || []).find((a: IArtifact) => a.type === HelmMatch.type);
-  defaultArtifact = {
-    ...expectedHelmArtifacts[0].matchArtifact,
-    version: null,
-  };
 
   return (
     <>
@@ -75,7 +69,7 @@ export function ManualExecutionBakeManifest(props: ITriggerTemplateComponentProp
           <div className="col-md-2" />
           <div className="col-md-10">
             <HelmEditor
-              account={{ name: expectedHelmArtifacts[0].matchArtifact.artifactAccount, types: [HelmMatch.type] }}
+              account={{ name: defaultArtifact.artifactAccount, types: [HelmMatch.type] }}
               artifact={helmArtifact || defaultArtifact}
               pipeline={props.command.pipeline}
               onChange={updateHelmArtifact}

--- a/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/bakeManifestStage.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/bakeManifestStage.ts
@@ -1,35 +1,13 @@
 import { ArtifactReferenceService, ExecutionArtifactTab, ExpectedArtifactService } from 'core/artifact';
-import { IValidatorConfig } from '../../validation/PipelineConfigValidator';
-import { ExecutionDetailsTasks } from '../common';
-
-import { IArtifact, IStage, IPipeline, IStageOrTriggerTypeConfig } from 'core/domain';
-
+import { IArtifact, IStage } from 'core/domain';
 import { Registry } from 'core/registry';
 
-import { BakeManifestConfig } from './BakeManifestConfig';
+import { BakeManifestConfig, validateBakeManifestStage } from './BakeManifestConfig';
 import { BakeManifestDetailsTab } from './BakeManifestDetailsTab';
 import { ManualExecutionBakeManifest } from './ManualExecutionBakeManifest';
-import { ICustomValidator } from '../../validation/PipelineConfigValidator';
-import { RequiredFieldValidator, IRequiredFieldValidationConfig } from '../../validation/requiredField.validator';
+import { ExecutionDetailsTasks } from '../common';
 
 export const BAKE_MANIFEST_STAGE_KEY = 'bakeManifest';
-const requiredField = (
-  _pipeline: IPipeline,
-  stage: IStage,
-  _validator: IValidatorConfig,
-  _config: IStageOrTriggerTypeConfig,
-): string => {
-  if (stage.templateRenderer !== 'HELM2' && stage.templateRenderer !== 'HELM3') {
-    return '';
-  }
-
-  return new RequiredFieldValidator().validate(
-    _pipeline,
-    stage,
-    { fieldLabel: 'Name', fieldName: 'outputName' } as IRequiredFieldValidationConfig,
-    _config,
-  );
-};
 
 Registry.pipeline.registerStage({
   label: 'Bake (Manifest)',
@@ -48,6 +26,6 @@ Registry.pipeline.registerStage({
     stage.expectedArtifacts = (stage.expectedArtifacts ?? []).filter(artifactDoesNotMatch);
     stage.inputArtifacts = (stage.inputArtifacts ?? []).filter(artifactDoesNotMatch);
   },
-  validators: [{ type: 'custom', validate: requiredField } as ICustomValidator],
+  validateFn: validateBakeManifestStage,
   manualExecutionComponent: ManualExecutionBakeManifest,
 });

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/base64/base64.artifact.ts
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/base64/base64.artifact.ts
@@ -6,10 +6,13 @@ import { Registry } from 'core/registry';
 
 import './base64.artifact.less';
 
+export const BASE_64_ARTIFACT_TYPE = 'embedded/base64';
+export const BASE_64_ARTIFACT_ACCOUNT = 'embedded-artifact';
+
 controllerFn.$inject = ['artifact'];
 function controllerFn(artifact: IArtifact) {
   this.artifact = artifact;
-  this.artifact.type = 'embedded/base64';
+  this.artifact.type = BASE_64_ARTIFACT_TYPE;
 }
 
 export const BASE64_ARTIFACT = 'spinnaker.core.pipeline.trigger.artifact.base64';
@@ -17,7 +20,7 @@ module(BASE64_ARTIFACT, []).config(() => {
   Registry.pipeline.mergeArtifactKind({
     label: 'Base64',
     typePattern: ArtifactTypePatterns.EMBEDDED_BASE64,
-    type: 'embedded/base64',
+    type: BASE_64_ARTIFACT_TYPE,
     description: 'An artifact that includes its referenced resource as part of its payload.',
     key: 'base64',
     isDefault: false,


### PR DESCRIPTION
Closes https://github.com/spinnaker/spinnaker/issues/5624

* refactor(core): clean up Bake (Manifest) stage 

  Before resolving a long-standing regression, let's give the Bake (Manifest) code some TLC. This commit cleans up import statements per convention, abstracts the manifest renderer constants into an enum, refactors stage validation per new Formik conventions, and simplifies components that are unnecessarily class components into functional components.

* fix(core): default and validate Bake (Manifest) produced artifacts 

  [This PR](https://github.com/spinnaker/deck/pull/7138) unintentionally removed the functionality that added a default base64 expected artifact to Bake (Manifest) pipelines. Let's re-add that functionality, and add an additional validator to ensure that users catch this issue prior to Orca reporting the [error](https://github.com/spinnaker/orca/blob/master/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/manifests/CreateBakeManifestTask.java#L113).
