### PR TITLE
feat(core/managed): add support for overriding constraints via Environments

### DIFF
--- a/app/scripts/modules/core/src/managed/ArtifactDetail.tsx
+++ b/app/scripts/modules/core/src/managed/ArtifactDetail.tsx
@@ -4,6 +4,7 @@ import { DateTime } from 'luxon';
 
 import { relativeTime, timestamp } from '../utils';
 import { IManagedArtifactVersion, IManagedResourceSummary } from '../domain';
+import { Application } from '../application';
 import { useEventListener } from '../presentation';
 
 import { ArtifactDetailHeader } from './ArtifactDetailHeader';
@@ -23,6 +24,7 @@ function shouldDisplayResource(name: string, type: string, resource: IManagedRes
 }
 
 export interface IArtifactDetailProps {
+  application: Application;
   name: string;
   type: string;
   version: IManagedArtifactVersion;
@@ -31,6 +33,7 @@ export interface IArtifactDetailProps {
 }
 
 export const ArtifactDetail = ({
+  application,
   name,
   type,
   version: { version, environments },
@@ -66,7 +69,14 @@ export const ArtifactDetail = ({
                   statefulConstraints
                     .filter(({ type }) => isConstraintSupported(type))
                     .map(constraint => (
-                      <ConstraintCard key={constraint.type} className="sp-margin-l-right" constraint={constraint} />
+                      <ConstraintCard
+                        key={constraint.type}
+                        className="sp-margin-l-right"
+                        application={application}
+                        environment={environmentName}
+                        version={version}
+                        constraint={constraint}
+                      />
                     ))}
                 {state === 'deploying' && (
                   <NoticeCard

--- a/app/scripts/modules/core/src/managed/Environments.tsx
+++ b/app/scripts/modules/core/src/managed/Environments.tsx
@@ -120,6 +120,7 @@ export function Environments({ app }: IEnvironmentsProps) {
             )}
             {selectedArtifact && (
               <ArtifactDetail
+                application={app}
                 name={selectedArtifact.name}
                 type={selectedArtifact.type}
                 version={selectedArtifactDetails}

--- a/app/scripts/modules/core/src/managed/ManagedWriter.ts
+++ b/app/scripts/modules/core/src/managed/ManagedWriter.ts
@@ -1,8 +1,35 @@
 import { IPromise } from 'angular';
 
 import { API } from 'core/api';
+import { StatefulConstraintStatus } from 'core/domain';
+
+export interface IUpdateConstraintStatusRequest {
+  application: string;
+  environment: string;
+  type: string;
+  version: string;
+  status: StatefulConstraintStatus;
+}
 
 export class ManagedWriter {
+  public static updateConstraintStatus({
+    application,
+    environment,
+    type,
+    version,
+    status,
+  }: IUpdateConstraintStatusRequest): IPromise<void> {
+    return API.one('managed')
+      .one('application', application)
+      .one('environment', environment)
+      .one('constraint')
+      .post({
+        type,
+        artifactVersion: version,
+        status,
+      });
+  }
+
   public static pauseApplicationManagement(applicationName: string): IPromise<void> {
     return API.one('managed')
       .one('application', applicationName)

--- a/app/scripts/modules/core/src/managed/NoticeCard.module.css
+++ b/app/scripts/modules/core/src/managed/NoticeCard.module.css
@@ -44,7 +44,13 @@
   font-weight: bold;
   flex: 1 1 1px;
   min-height: 24px;
-  margin-top: 12px;
+  display: flex;
+  align-items: center;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
 }
 
 .text {

--- a/app/scripts/modules/core/src/managed/NoticeCard.tsx
+++ b/app/scripts/modules/core/src/managed/NoticeCard.tsx
@@ -6,15 +6,16 @@ import { Icon, IconNames } from '../presentation';
 import styles from './NoticeCard.module.css';
 
 interface INoticeCardProps {
-  title: JSX.Element | string;
-  text: JSX.Element | string;
+  title: React.ReactNode;
+  actions?: React.ReactNode;
+  text?: React.ReactNode;
   icon: IconNames;
   noticeType: 'success' | 'neutral' | 'info' | 'error';
   isActive: boolean;
   className?: string;
 }
 
-export function NoticeCard({ title, text, icon, noticeType, isActive, className }: INoticeCardProps) {
+export function NoticeCard({ title, actions, text, icon, noticeType, isActive, className }: INoticeCardProps) {
   const NoticeCardClasses = classNames({
     [styles.NoticeCard]: true,
     [styles[noticeType]]: noticeType,
@@ -33,6 +34,7 @@ export function NoticeCard({ title, text, icon, noticeType, isActive, className 
         </div>
       )}
       {title && <div className={styles.title}>{title}</div>}
+      {actions && <div className={styles.actions}>{actions}</div>}
       {text && <div className={styles.text}>{text}</div>}
     </div>
   );

--- a/app/scripts/modules/core/src/managed/constraints/ConstraintCard.less
+++ b/app/scripts/modules/core/src/managed/constraints/ConstraintCard.less
@@ -1,0 +1,51 @@
+.ConstraintCard {
+  // TODO (erik): this is a bunch of custom styles for a button.
+  // really it should be a real button component we put somewhere central.
+  // for now it's entirely experimental and might totally go away
+  // or be replaced.
+
+  .constraint-override-action {
+    color: rgb(90, 95, 180);
+    background-color: transparent;
+    font-size: 16px;
+    border: 1px solid rgb(90, 95, 180);
+    border-radius: 2px;
+    padding: 4px 20px;
+    min-width: 120px;
+    transition: all 90ms ease-in;
+  }
+
+  .constraint-override-action:not([disabled]) {
+    cursor: pointer;
+  }
+
+  .constraint-override-action[disabled] {
+    cursor: not-allowed;
+    opacity: 0.66;
+  }
+
+  .constraint-override-action:not([disabled]):hover {
+    transform: scale(1.03);
+    background-color: rgba(90, 95, 180, 0.15);
+  }
+
+  .constraint-override-action:not([disabled]):focus,
+  .constraint-override-action:not([disabled]):active {
+    outline: none;
+    transform: scale(1.04);
+  }
+
+  .constraint-override-action:not([disabled]):focus {
+    box-shadow: 2px 2px 0px rgba(90, 95, 180, 0.66);
+  }
+
+  .constraint-override-action:not([disabled]):active {
+    box-shadow: none !important;
+    background-color: rgba(90, 95, 180, 0.66);
+    color: var(--color-white);
+  }
+
+  .action-error-message {
+    color: #be0000;
+  }
+}

--- a/app/scripts/modules/core/src/managed/constraints/constraintRegistry.tsx
+++ b/app/scripts/modules/core/src/managed/constraints/constraintRegistry.tsx
@@ -13,13 +13,21 @@ const throwUnhandledStatusError = (status: string) => {
 
 const { NOT_EVALUATED, PENDING, FAIL, OVERRIDE_PASS, OVERRIDE_FAIL } = StatefulConstraintStatus;
 
+export interface IConstraintOverrideAction {
+  title: string;
+  pass: boolean;
+}
+
 interface IStatefulConstraintConfig {
   iconName: IconNames;
-  shortSummary: (constraint: IStatefulConstraint) => JSX.Element | string;
+  shortSummary: (constraint: IStatefulConstraint) => React.ReactNode;
+  overrideActions: { [status in StatefulConstraintStatus]?: IConstraintOverrideAction[] };
 }
 
 export const isConstraintSupported = (type: string) => statefulConstraintOptionsByType.hasOwnProperty(type);
 export const getStatefulConstraintConfig = (type: string) => statefulConstraintOptionsByType[type];
+export const getStatefulConstraintActions = ({ type, status }: IStatefulConstraint) =>
+  statefulConstraintOptionsByType[type]?.overrideActions?.[status] ?? null;
 
 // Later, this will become a "proper" registry so we can separate configs
 // into their own files and extend them dynamically at runtime.
@@ -61,5 +69,17 @@ export const statefulConstraintOptionsByType: { [type: string]: IStatefulConstra
           return throwUnhandledStatusError(status);
       }
     },
+    overrideActions: {
+      [PENDING]: [
+        {
+          title: 'Reject',
+          pass: false,
+        },
+        {
+          title: 'Approve',
+          pass: true,
+        },
+      ],
+    },
   },
-} as const;
+};


### PR DESCRIPTION
Today is the day! This is a pretty rough first pass at interactively approving/rejecting manual judgements via the UI 🌈 

<img width="923" alt="Screen Shot 2020-04-01 at 5 52 42 PM" src="https://user-images.githubusercontent.com/1850998/78200497-b403cc00-7443-11ea-90cf-a87d5ee9d1df.png">

I would show you a nice gif of actually doing a judgement, but sadly Netflix isn't running the version of Gate with the appropriate endpoint yet and I didn't want to go through the hassle of running it locally today. In the case of the endpoint failing we show a pretty lame (but hopefully soon to be improved!) error state with an option to go back and try again:

<img width="935" alt="Screen Shot 2020-04-01 at 5 52 58 PM" src="https://user-images.githubusercontent.com/1850998/78200568-f200f000-7443-11ea-8e25-6bf82c07a24f.png">

There were some choices I made that are either temporary or require a little additional context, for those not already commented I'll add some PR comments.