### PR TITLE
feat(serviceAccounts): supply application when populating run as user dropdown

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/triggers/RunAsUser.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/RunAsUser.tsx
@@ -3,8 +3,15 @@ import React from 'react';
 import { IFormInputProps, ReactSelectInput, useLatestPromise } from 'core/presentation';
 import { ServiceAccountReader } from 'core/serviceAccount';
 
-export function RunAsUserInput(props: IFormInputProps) {
-  const fetchServiceAccounts = useLatestPromise(() => ServiceAccountReader.getServiceAccounts(), []);
+export interface IRunAsUserInputProps extends IFormInputProps {
+  application: string;
+}
+
+export function RunAsUserInput(props: IRunAsUserInputProps) {
+  const fetchServiceAccounts = useLatestPromise(
+    () => ServiceAccountReader.getServiceAccountsForApplication(props.application),
+    [],
+  );
   const isLoading = fetchServiceAccounts.status === 'PENDING';
 
   return (

--- a/app/scripts/modules/core/src/pipeline/config/triggers/Trigger.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/Trigger.tsx
@@ -153,7 +153,7 @@ function TriggerForm(triggerFormProps: ITriggerProps & { formik: FormikProps<ITr
             name="runAsUser"
             label="Run As User"
             help={<HelpField id="pipeline.config.trigger.runAsUser" />}
-            input={props => <RunAsUserInput {...props} />}
+            input={props => <RunAsUserInput {...props} application={triggerFormProps.application.name} />}
           />
         )}
 

--- a/app/scripts/modules/core/src/serviceAccount/ServiceAccountReader.ts
+++ b/app/scripts/modules/core/src/serviceAccount/ServiceAccountReader.ts
@@ -16,4 +16,16 @@ export class ServiceAccountReader {
         .get();
     }
   }
+
+  public static getServiceAccountsForApplication(application: string): IPromise<string[]> {
+    if (!SETTINGS.feature.fiatEnabled) {
+      return $q.resolve([]);
+    } else {
+      return API.one('auth')
+        .one('user')
+        .one('serviceAccounts')
+        .withParams({ application: application })
+        .get();
+    }
+  }
 }


### PR DESCRIPTION
Allows for filtering service accounts to include only those relevant to the specific application.

This is implemented server-side in spinnaker/gate#1130 and spinnaker/fiat#629 however the gate
PR is not blocking as this will just fall back to the current behavior if the new endpoint
has not yet been deployed.