### PR TITLE
fix(aws/loadBalancers): Add validator for multiple listeners on same …

### DIFF
--- a/app/scripts/modules/amazon/src/loadBalancer/configure/application/ALBListeners.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/application/ALBListeners.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { $q } from 'ngimport';
 import { SortableContainer, SortableElement, SortableHandle, arrayMove, SortEnd } from 'react-sortable-hoc';
-import { difference, flatten, get, some, uniq } from 'lodash';
+import { difference, flatten, get, some, uniq, uniqBy } from 'lodash';
 import { FormikErrors, FormikProps } from 'formik';
 
 import {
@@ -113,6 +113,11 @@ export class ALBListeners extends React.Component<IALBListenersProps, IALBListen
       errors.listeners = `Target group ${unusedTargetGroupNames[0]} is unused.`;
     } else if (unusedTargetGroupNames.length > 1) {
       errors.listeners = `Target groups ${unusedTargetGroupNames.join(', ')} are unused.`;
+    }
+
+    const { listeners } = values;
+    if (uniqBy(listeners, 'port').length < listeners.length) {
+      errors.listenerPorts = 'Multiple listeners cannot use the same port.';
     }
 
     const missingRuleFields = values.listeners.find(l => {
@@ -578,6 +583,11 @@ export class ALBListeners extends React.Component<IALBListenersProps, IALBListen
                 </div>
               </div>
             ))}
+            {errors.listenerPorts && (
+              <div className="wizard-pod-row-errors">
+                <ValidationMessage type="error" message={errors.listenerPorts} />
+              </div>
+            )}
             {errors.listeners && (
               <div className="wizard-pod-row-errors">
                 <ValidationMessage type="error" message={errors.listeners} />

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/network/NLBListeners.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/network/NLBListeners.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { difference, flatten, uniq } from 'lodash';
+import { difference, flatten, uniq, uniqBy } from 'lodash';
 
 import { ValidationMessage, IWizardPageComponent } from '@spinnaker/core';
 
@@ -32,6 +32,11 @@ export class NLBListeners extends React.Component<INLBListenersProps>
       errors.listeners = `Target group ${unusedTargetGroupNames[0]} is unused.`;
     } else if (unusedTargetGroupNames.length > 1) {
       errors.listeners = `Target groups ${unusedTargetGroupNames.join(', ')} are unused.`;
+    }
+
+    const { listeners } = values;
+    if (uniqBy(listeners, 'port').length < listeners.length) {
+      errors.listenerPorts = 'Multiple listeners cannot use the same port.';
     }
 
     return errors;
@@ -170,6 +175,11 @@ export class NLBListeners extends React.Component<INLBListenersProps>
                 </div>
               </div>
             ))}
+            {errors.listenerPorts && (
+              <div className="wizard-pod-row-errors">
+                <ValidationMessage type="error" message={errors.listenerPorts} />
+              </div>
+            )}
             {errors.listeners && (
               <div className="wizard-pod-row-errors">
                 <ValidationMessage type="error" message={errors.listeners} />


### PR DESCRIPTION
AWS does not allow multiple listeners on the same port. Spinnaker does not support this currently,  so now Deck shows a validation error when two or more listeners have the same port.