### PR TITLE
fix(core): Temporarily allow disabling refresh cycle

### DIFF
--- a/app/scripts/modules/core/src/application/ApplicationComponent.tsx
+++ b/app/scripts/modules/core/src/application/ApplicationComponent.tsx
@@ -34,7 +34,7 @@ export class ApplicationComponent extends React.Component<IApplicationComponentP
     }
 
     DebugWindow.application = app;
-    app.enableAutoRefresh();
+    // !(app.attributes?.disableAutoRefresh) && app.enableAutoRefresh();
   }
 
   private unmountApplication(app: Application) {

--- a/app/scripts/modules/core/src/application/ApplicationComponent.tsx
+++ b/app/scripts/modules/core/src/application/ApplicationComponent.tsx
@@ -34,7 +34,8 @@ export class ApplicationComponent extends React.Component<IApplicationComponentP
     }
 
     DebugWindow.application = app;
-    // !(app.attributes?.disableAutoRefresh) && app.enableAutoRefresh();
+    // KLUDGE: warning, do not use, this is temporarily and will be removed very soon.
+    !app.attributes?.disableAutoRefresh && app.enableAutoRefresh();
   }
 
   private unmountApplication(app: Application) {


### PR DESCRIPTION
... on a per app basis based on application attributes.

⚠️  KLUDGE ALERT: this is temporary until performance improvements land ⚠️ 

The global default application refresh cycle could be too low for applications with large footprints, that is, applications where the refresh payloads are large enough that `( request time + parse time + transform time )` ends up taking a non-trivial chunk of the interval.

In many cases, for applications with footprint larger than `insert arbitrary threshold here` (aka more than `x` number of `y` resources), most of that refresh/parse/transform time is likely wasted because a user cannot meaningfully make use of all that data.

These cases may be better served by a filtered experience where users need to specify what subset of the data they're actually interested in, and the views only refresh and process that subset.

# Very short term
Temporarily allow disabling the refresh cycle by application

# Near term
TBD modifications to reduce the cost of the application refresh cycle for large footprint applications (could be perf improvements in deck, could be server side filtering, maybe both, not too sure yet)

# Longer term
New views that are more targeted (search centric?) to exactly what a user is interested in and requests only include that slice of data rather than asking for the whole world