### PR TITLE
fix(ecs): Remove dummy metrics values from cluster detail pane

### DIFF
--- a/app/scripts/modules/ecs/src/serverGroup/details/serverGroupDetails.html
+++ b/app/scripts/modules/ecs/src/serverGroup/details/serverGroupDetails.html
@@ -193,27 +193,6 @@
         <dd ng-if="ctrl.serverGroup.metricAlarms.length <= 0"><i>There are no scaling policies assigned.</i></dd>
       </dl>
     </collapsible-section>
-    <collapsible-section heading="Metrics" expanded="false">
-      <i>Example values below</i>
-
-      <dl class="horizontal-when-filters-collapsed">
-        <dt>Average CPU Utilization last 15 minutes</dt>
-        <dd>90%</dd>
-        <!-- TODO - Make the values reflect the current state of the server group -->
-
-        <dt>Average CPU Utilization last 24 hours</dt>
-        <dd>30%</dd>
-        <!-- TODO - Make the values reflect the current state of the server group -->
-
-        <dt>Average memory Utilization last 15 minutes</dt>
-        <dd>40%</dd>
-        <!-- TODO - Make the values reflect the current state of the server group -->
-
-        <dt>Average memory Utilization last 24 hours</dt>
-        <dd>45%</dd>
-        <!-- TODO - Make the values reflect the current state of the server group -->
-      </dl>
-    </collapsible-section>
     <collapsible-section heading="Build data" ng-if="ctrl.serverGroup.buildInfo && ctrl.serverGroup.buildInfo.jenkins">
       <dl class="horizontal-when-filters-collapsed">
         <dt>Job</dt>


### PR DESCRIPTION
The server group detail pane currently contains a metrics section with hard-coded, dummy values. Removing this to avoid confusion until real metrics are added (see https://github.com/spinnaker/spinnaker/issues/5605).

### testing
screen shot of pane w/o metrics section:
<img width="490" alt="fix_screenshot" src="https://user-images.githubusercontent.com/34254888/78702824-0d458280-78be-11ea-9617-e9ccddfecfdc.PNG">

