### PR TITLE
fix(core/managed): add stack + detail filtering on resource links

### DIFF
--- a/app/scripts/modules/core/src/managed/ManagedResourceObject.tsx
+++ b/app/scripts/modules/core/src/managed/ManagedResourceObject.tsx
@@ -32,11 +32,14 @@ const getResourceRoutingInfo = (
 ): { state: string; params: { [key: string]: string } } | null => {
   const {
     kind,
+    moniker: { stack, detail },
     locations: { account },
   } = resource;
   const kindName = getKindName(kind);
   const params = {
     acct: account,
+    stack: stack ?? '(none)',
+    detail: detail ?? '(none)',
     q: getResourceName(resource),
   };
 


### PR DESCRIPTION
Turns out that [I was wrong](https://github.com/spinnaker/deck/pull/8115#discussion_r401156580) when I suggested @vigneshm could leave out stack + detail filters when linking to managed resources in #8113. 

The reason this is necessary is because filtering by name may include other stacks or details depending on the name itself — e.g. if have 3 cluster resources:

- `keel`
- `keel-test`
- `keel-test-b`

If I click on the link for `keel`, the substring search query for `keel` will return all three clusters. If I click on `keel-test`, I'll get `keel-test` and `keel-test-b`. Filtering on stack + detail _and/or their absence_ is the only way to get just the single resource that's relevant.