### PR TITLE
feat(core/managed): add proper support for skipped, approved artifact states

### DIFF
--- a/app/scripts/modules/core/src/domain/IManagedEntity.ts
+++ b/app/scripts/modules/core/src/domain/IManagedEntity.ts
@@ -69,6 +69,7 @@ export interface IManagedEnviromentSummary {
       approved: string[];
       previous: string[];
       vetoed: string[];
+      skipped: string[];
     };
   }>;
 }
@@ -77,7 +78,7 @@ export interface IManagedArtifactVersion {
   version: string;
   environments: Array<{
     name: string;
-    state: 'current' | 'deploying' | 'approved' | 'pending' | 'previous' | 'vetoed';
+    state: 'current' | 'deploying' | 'approved' | 'pending' | 'previous' | 'vetoed' | 'skipped';
     deployedAt?: string;
     replacedAt?: string;
     replacedBy?: string;

--- a/app/scripts/modules/core/src/managed/ArtifactDetail.tsx
+++ b/app/scripts/modules/core/src/managed/ArtifactDetail.tsx
@@ -156,7 +156,46 @@ export const ArtifactDetail = ({
                     className="sp-margin-l-right"
                     icon="placeholder"
                     text={undefined}
-                    title="Never deployed here"
+                    title="Not deployed here yet"
+                    isActive={true}
+                    noticeType="neutral"
+                  />
+                )}
+                {state === 'approved' && (
+                  <NoticeCard
+                    className="sp-margin-l-right"
+                    icon="checkBadge"
+                    text={undefined}
+                    title={
+                      <span className="sp-group-margin-xs-xaxis">
+                        <span>Approved</span> <span className="text-regular">—</span>{' '}
+                        <span className="text-regular">deployment is about to begin</span>
+                      </span>
+                    }
+                    isActive={true}
+                    noticeType="info"
+                  />
+                )}
+                {state === 'skipped' && (
+                  <NoticeCard
+                    className="sp-margin-l-right"
+                    icon="placeholder"
+                    text={undefined}
+                    title={
+                      <span className="sp-group-margin-xs-xaxis">
+                        <span>Skipped</span> <span className="text-regular">—</span>{' '}
+                        {replacedBy && (
+                          <Pill
+                            text={
+                              replacedByBuildNumber
+                                ? `#${replacedByBuildNumber}`
+                                : replacedByPackageVersion || replacedBy
+                            }
+                          />
+                        )}{' '}
+                        <span className="text-regular">{!replacedBy && 'a later version '}became available</span>
+                      </span>
+                    }
                     isActive={true}
                     noticeType="neutral"
                   />

--- a/app/scripts/modules/core/src/managed/ArtifactRow.module.css
+++ b/app/scripts/modules/core/src/managed/ArtifactRow.module.css
@@ -71,6 +71,10 @@
     background-color: var(--color-porcelain);
   }
 
+  &.skipped {
+    background-color: var(--color-porcelain);
+  }
+
   &.previous {
     background-color: var(--color-nobel);
   }


### PR DESCRIPTION
We recently came to the realization that the `approved` and `pending` states an artifact can have in a particular environment were a bit conceptually overloaded, because they both contained versions that had been skipped over due to later versions becoming available. This meant it was very challenging to explain what `approved` and `pending` meant in the UI because a version could _either_ be in a state of approved-ness / pending-ness, or it could've been skipped and have no chance of ever being deployed.

[We've now split out a totally new state](https://github.com/spinnaker/keel/pull/959) — `skipped` — to help clarify the semantics of the other two states, freeing up `approved` to mean "this version is about to start deploying" and `pending` to mean "this version is actively under consideration for deployment, but hasn't been chosen yet". This change adds full-fledged support to all three of these statuses, as the inherent confusion had prevented us from adding useful UI treatments until this point. Looks like this:

**Pending:**
<img width="899" alt="Screen Shot 2020-04-07 at 7 58 05 PM" src="https://user-images.githubusercontent.com/1850998/78739929-368c0000-790a-11ea-9458-1ffdd4367c1d.png">

**Approved:**
<img width="900" alt="Screen Shot 2020-04-07 at 7 41 52 PM" src="https://user-images.githubusercontent.com/1850998/78739940-3c81e100-790a-11ea-99a8-b67b67b6dc01.png">

**Skipped (version info available):**
<img width="894" alt="Screen Shot 2020-04-07 at 7 29 53 PM" src="https://user-images.githubusercontent.com/1850998/78739956-44da1c00-790a-11ea-88f0-c51398a3f20b.png">

**Skipped (no version info available):**
<img width="900" alt="Screen Shot 2020-04-07 at 7 37 56 PM" src="https://user-images.githubusercontent.com/1850998/78739968-4acffd00-790a-11ea-9563-2a8c12aad845.png">

Icons are coming soon (the `approved` one is also temporary), but wanted to get this out in advance of having iconography.

(cc @gcomstock)