### PR TITLE
feat(docker): clarify searchability of docker tags on manual execution

### DIFF
--- a/app/scripts/modules/docker/src/pipeline/trigger/DockerTriggerTemplate.tsx
+++ b/app/scripts/modules/docker/src/pipeline/trigger/DockerTriggerTemplate.tsx
@@ -113,10 +113,10 @@ export class DockerTriggerTemplate extends React.Component<
     const { command } = this.props;
     const trigger = command.trigger as IDockerTrigger;
     const newState = {} as IDockerTriggerTemplateState;
-    newState.tags = tags;
-    if (newState.tags.length) {
-      // default to what is supplied by the trigger if possible; otherwise, use the latest
-      const defaultSelection = newState.tags.find(t => t === trigger.tag) || newState.tags[0];
+    newState.tags = tags || [];
+    // default to what is supplied by the trigger if possible
+    const defaultSelection = newState.tags.find(t => t === trigger.tag);
+    if (defaultSelection) {
       newState.selectedTag = defaultSelection;
       this.updateSelectedTag(defaultSelection);
     }
@@ -223,6 +223,7 @@ export class DockerTriggerTemplate extends React.Component<
                       </span>
                     )}
                     onChange={(o: Option<string>) => this.updateSelectedTag(o.value)}
+                    placeholder="Search tags..."
                   />
                 )}
               </div>


### PR DESCRIPTION
As discussed in the #clouddriver-perf Slack channel, many users enable Clouddriver's `--sort-tags-by-date` flag so that they don't have to sift through potentially thousands of tags in Deck when doing a manual execution. At least a couple of these users were not aware that this input was searchable; this is because the UI always selects by default the first tag in the list (which will not even be the newest if you don't have the flag enabled). Let's remove that default and add placeholder text to clarify this (since the default placeholder text is `Select...`, I added ellipsis to the new text as well 🤷‍♀).

![PYrOENxfsbq](https://user-images.githubusercontent.com/15936279/78834543-ba9ec000-79bc-11ea-838b-e05a24038159.png)
