### PR TITLE
fix(core/presentation): Avoid excessive RadioButton remounts by moving the component outside the render function

### DIFF
--- a/app/scripts/modules/core/src/presentation/forms/inputs/RadioButtonInput.tsx
+++ b/app/scripts/modules/core/src/presentation/forms/inputs/RadioButtonInput.tsx
@@ -21,36 +21,34 @@ interface IRadioButtonOptions extends Option {
 }
 
 export const RadioButtonInput = (props: IRadioButtonInputProps) => {
-  const { inline, value: selectedValue, validation, inputClassName, options, stringOptions, ...otherProps } = props;
-  const radioOptions = isStringArray(stringOptions) ? stringOptions.map(value => ({ value, label: value })) : options;
+  const { inline, validation, value, inputClassName, options, stringOptions, ...otherProps } = props;
+  const radioOptions: IRadioButtonOptions[] = isStringArray(stringOptions)
+    ? stringOptions.map(opt => ({ value: opt, label: opt }))
+    : options;
 
   const userClassName = orEmptyString(inputClassName);
   const validClassName = validationClassName(validation);
-  const elementClassName = `RadioButtonInput radio ${userClassName} ${validClassName}`;
+  const verticalClassName = inline ? '' : 'vertical left';
+  const elementClassName = `RadioButtonInput radio ${userClassName} ${validClassName} ${verticalClassName}`;
 
-  const RadioButton = ({ option }: { option: IRadioButtonOptions }) => (
-    <label key={option.label} className={inline ? 'radio-inline clickable' : 'inline clickable'}>
-      <input type="radio" {...otherProps} value={option.value as any} checked={option.value === selectedValue} />
-      <Markdown message={option.label} style={option.help && { display: 'inline-block' }} />
-      {option.help && <> {option.help}</>}
-    </label>
-  );
-
-  const VerticalRadioButtons = ({ opts }: { opts: IRadioButtonOptions[] }) => (
-    <div className={`${elementClassName} vertical left`}>
-      {opts.map(option => (
-        <RadioButton key={option.label} option={option} />
-      ))}
-    </div>
-  );
-
-  const InlineRadioButtons = ({ opts }: { opts: IRadioButtonOptions[] }) => (
+  return (
     <div className={elementClassName}>
-      {opts.map(option => (
-        <RadioButton key={option.label} option={option} />
+      {radioOptions.map(option => (
+        <RadioButton inline={inline} key={option.label} value={value} option={option} {...otherProps} />
       ))}
     </div>
   );
-
-  return inline ? <InlineRadioButtons opts={radioOptions} /> : <VerticalRadioButtons opts={radioOptions} />;
 };
+
+interface IRadioButtonProps {
+  option: IRadioButtonOptions;
+  inline: boolean;
+  value: any;
+}
+const RadioButton = ({ option, inline, value, ...otherProps }: IRadioButtonProps) => (
+  <label className={inline ? 'radio-inline clickable' : 'inline clickable'}>
+    <input type="radio" {...otherProps} value={option.value as any} checked={option.value === value} />
+    <Markdown message={option.label} style={option.help && { display: 'inline-block' }} />
+    {option.help && <> {option.help}</>}
+  </label>
+);


### PR DESCRIPTION
Previously, we were rendering components defined inside the render function.  Since they get a new reference each time, the buttons were getting unmounted/remounted.  This also caused the radio buttons to be unfocusable, so keyboard navigation was impossible.

Now, the radiobutton component is defined as a separate component at the top level.

before: (pressing tab)

![before](https://user-images.githubusercontent.com/2053478/78949710-41b56c00-7a81-11ea-97a0-1e0e89c39c36.gif)


after: (pressing tab and selecting with spacebar)

![after](https://user-images.githubusercontent.com/2053478/78949714-44b05c80-7a81-11ea-9a60-5e362d13ae33.gif)
