### PR TITLE
fix(managed-delivery): Minor cosmetic fixes in import delivery config stage

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/managed/ImportDeliveryConfigExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/managed/ImportDeliveryConfigExecutionDetails.tsx
@@ -33,9 +33,9 @@ const CustomErrorMessage = ({ summary, debugDetails }: { summary: string; debugD
   return (
     <div>
       <div className="alert alert-danger">
-        <b>There was an error parsing your delivery config file.</b>
+        <b>There was an error importing your delivery config file.</b>
         <br />
-        <Markdown message={summary} style={{ wordBreak: 'break-all' }} />
+        <Markdown message={summary} style={{ wordBreak: 'break-word' }} />
         <br />
         {debugDetails && (
           <CollapsibleSection heading={({ chevron }) => <span>{chevron} Debug Details</span>}>


### PR DESCRIPTION
Tiny changes to break error details on words, not characters, and to change the wording in the error box label.