### PR TITLE
refactor(core): custom -> styleguide colors for icons, artifact status bars

### DIFF
--- a/app/scripts/modules/core/src/managed/ArtifactRow.module.css
+++ b/app/scripts/modules/core/src/managed/ArtifactRow.module.css
@@ -58,7 +58,7 @@
   margin-right: 2px;
 
   &.current {
-    background-color: #00b237;
+    background-color: var(--color-status-success);
   }
 
   &.approved {
@@ -66,19 +66,19 @@
   }
 
   &.deploying {
-    background-color: var(--color-status-info);
+    background-color: var(--color-status-progress);
   }
 
   &.pending {
-    background-color: var(--color-porcelain);
+    background-color: var(--color-status-inactive);
   }
 
   &.skipped {
-    background-color: var(--color-porcelain);
+    background-color: var(--color-status-inactive);
   }
 
   &.previous {
-    background-color: var(--color-nobel);
+    background-color: var(--color-status-neutral);
   }
 
   &.vetoed {

--- a/app/scripts/modules/core/src/presentation/icons/Icon.tsx
+++ b/app/scripts/modules/core/src/presentation/icons/Icon.tsx
@@ -23,12 +23,6 @@ const pxDimensionsBySize: { [size: string]: string } = {
   extraLarge: '40px',
 };
 
-const colorsByAppearance = {
-  light: 'var(--color-white)',
-  neutral: 'rgba(0, 0, 0, 0.5)',
-  dark: 'var(--color-black)',
-};
-
 const throwInvalidIconError = (name: string) => {
   throw new Error(`No icon with the name ${name} exists`);
 };
@@ -41,7 +35,7 @@ export const Icon = memo(({ name, appearance, size, color, className }: IIconPro
   }
 
   const width = pxDimensionsBySize[size] || size || pxDimensionsBySize[DEFAULT_SIZE];
-  const fill = color ? `var(--color-${color})` : colorsByAppearance[appearance || DEFAULT_APPEARANCE];
+  const fill = color ? `var(--color-${color})` : `var(--color-icon-${appearance || DEFAULT_APPEARANCE})`;
 
   return <Component className={className} style={{ width, fill }} />;
 });


### PR DESCRIPTION
Just moving from colors that were hard-coded to the same colors (with the exception of `--color-status-success`) exposed via `@spinanker/styleguide`.