### PR TITLE
feat(core/managed): add StatusBubble, StatusCard components

### DIFF
--- a/app/scripts/modules/core/src/managed/StatusBubble.less
+++ b/app/scripts/modules/core/src/managed/StatusBubble.less
@@ -1,0 +1,39 @@
+.StatusBubble {
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: 1fr;
+  border-radius: 50%;
+
+  .status-bubble-icon-container {
+    grid-column: 1;
+    grid-row: 1;
+  }
+
+  &.status-bubble-inactive {
+    background-color: var(--color-status-inactive);
+  }
+
+  &.status-bubble-neutral {
+    background-color: var(--color-status-neutral);
+  }
+
+  &.status-bubble-info {
+    background-color: var(--color-status-info);
+  }
+
+  &.status-bubble-progress {
+    background-color: var(--color-status-progress);
+  }
+
+  &.status-bubble-success {
+    background-color: var(--color-status-success);
+  }
+
+  &.status-bubble-warning {
+    background-color: var(--color-status-warning);
+  }
+
+  &.status-bubble-error {
+    background-color: var(--color-status-error);
+  }
+}

--- a/app/scripts/modules/core/src/managed/StatusBubble.tsx
+++ b/app/scripts/modules/core/src/managed/StatusBubble.tsx
@@ -1,0 +1,51 @@
+import React, { memo } from 'react';
+import { useTransition, animated } from 'react-spring';
+
+import { Icon, IconNames } from '../presentation';
+
+import './StatusBubble.less';
+
+export interface IStatusBubbleProps {
+  iconName: IconNames;
+  appearance: 'inactive' | 'neutral' | 'info' | 'progress' | 'success' | 'warning' | 'error';
+  size: 'extraSmall' | 'small' | 'medium' | 'large' | 'extraLarge';
+}
+
+const paddingBySize = {
+  extraSmall: 'xs',
+  small: 's',
+  medium: 's',
+  large: 's',
+  extraLarge: 'm',
+} as const;
+
+const inStyles = {
+  opacity: 1,
+  transform: 'scale(1.0, 1.0)',
+};
+
+const outStyles = {
+  opacity: 0,
+  transform: 'scale(0.8, 0.8)',
+};
+
+const transitionConfig = {
+  from: outStyles,
+  enter: inStyles,
+  leave: outStyles,
+  config: { mass: 1, tension: 400, friction: 30 },
+};
+
+export const StatusBubble = memo(({ iconName, appearance, size }: IStatusBubbleProps) => {
+  const transitions = useTransition(iconName, null, transitionConfig);
+
+  return (
+    <div className={`StatusBubble status-bubble-${appearance} sp-padding-${paddingBySize[size]}`}>
+      {transitions.map(({ item, key, props }) => (
+        <animated.div key={key} className="status-bubble-icon-container flex-container-h center middle" style={props}>
+          <Icon name={item} appearance="light" size={size} />
+        </animated.div>
+      ))}
+    </div>
+  );
+});

--- a/app/scripts/modules/core/src/managed/StatusCard.less
+++ b/app/scripts/modules/core/src/managed/StatusCard.less
@@ -1,0 +1,33 @@
+.StatusCard {
+  border-radius: 3px;
+  font-size: 13px;
+  color: var(--color-charcoal);
+
+  &.status-card-inactive {
+    color: #666;
+  }
+
+  &.status-card-neutral {
+    background-color: var(--color-status-neutral-light);
+  }
+
+  &.status-card-info {
+    background-color: var(--color-status-info-light);
+  }
+
+  &.status-card-progress {
+    background-color: var(--color-status-progress-light);
+  }
+
+  &.status-card-success {
+    background-color: var(--color-status-success-light);
+  }
+
+  &.status-card-warning {
+    background-color: var(--color-status-warning-light);
+  }
+
+  &.status-card-error {
+    background-color: var(--color-status-error-light);
+  }
+}

--- a/app/scripts/modules/core/src/managed/StatusCard.tsx
+++ b/app/scripts/modules/core/src/managed/StatusCard.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import classNames from 'classnames';
+
+import { IconNames } from '../presentation';
+
+import { StatusBubble } from './StatusBubble';
+
+import './StatusCard.less';
+
+export interface IStatusCardProps {
+  appearance: 'inactive' | 'neutral' | 'info' | 'progress' | 'success' | 'warning' | 'error';
+  iconName: IconNames;
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  actions?: React.ReactNode;
+}
+
+export const StatusCard = ({ appearance, iconName, title, description, actions }: IStatusCardProps) => (
+  <div
+    className={classNames(
+      'StatusCard flex-container-h space-between middle wrap sp-padding-s-yaxis sp-padding-l-xaxis',
+      `status-card-${appearance}`,
+    )}
+  >
+    <div className="flex-container-h middle">
+      <div className="flex-container-h center middle sp-margin-l-right">
+        <StatusBubble iconName={iconName} appearance={appearance} size="medium" />
+      </div>
+      <div className="flex-container-v sp-margin-m-yaxis">
+        <div className="text-bold">{title}</div>
+        {description && <div className="text-regular">{description}</div>}
+      </div>
+    </div>
+    {actions && <div className="flex-container-h right middle flex-grow sp-margin-s-left">{actions}</div>}
+  </div>
+);


### PR DESCRIPTION
This change introduces two new components for displaying 'status', which in our new design system is a first class concept. We expect we'll be using both of these a lot, so while it's in `core/managed` for experimentation right now I'm actively working toward graduating them into `core/presentation` sooner rather than later (hence the level of polish). 

- `StatusBubble` is an icon with a colored circle behind it which can take on a predefined set of status colors/appearances. This "bubble" is ubiquitous in @gcomstock's designs therefore supports the same size portfolio as `Icon`. There's also a spiffy transition for icons entering/leaving, which helps visually call out changing statuses in lists of bubbles/cards
- `StatusCard` is the successor to our early-stage `NoticeCard`, and will replace it fully in my next PR. It uses a `StatusBubble` along with a complimentary background color, and supports the same set of status options. Now that things have stabilized a little I've taken the time to cleanup the styles, get font weights and alignment tightened up, etc. etc

Real-life examples (icon + circle inside each card is a `medium` `StatusBubble`):

`inactive`, `progress`/`info`, `success`:
<img width="942" alt="Screen Shot 2020-04-10 at 5 26 12 PM" src="https://user-images.githubusercontent.com/1850998/79030974-aab7e500-7b50-11ea-8b79-4ac4af7f546d.png">

`warning`, `success`:
<img width="953" alt="Screen Shot 2020-04-10 at 5 30 34 PM" src="https://user-images.githubusercontent.com/1850998/79031042-14d08a00-7b51-11ea-9690-17992c85a619.png">

`error`, `success`:
<img width="945" alt="Screen Shot 2020-04-10 at 5 26 43 PM" src="https://user-images.githubusercontent.com/1850998/79030986-bf947880-7b50-11ea-8753-1de0d10112b5.png">

`neutral`:
<img width="945" alt="Screen Shot 2020-04-10 at 5 27 20 PM" src="https://user-images.githubusercontent.com/1850998/79030991-c4f1c300-7b50-11ea-9c92-7c83959725b2.png">
