### PR TITLE
feat(core/managed): add scrolling grid layout, detail pane transition

### DIFF
--- a/app/scripts/modules/core/src/managed/ArtifactDetailHeader.less
+++ b/app/scripts/modules/core/src/managed/ArtifactDetailHeader.less
@@ -1,6 +1,9 @@
 .ArtifactDetailHeader {
-  background-color: rgb(100, 140, 175);
+  position: sticky;
+  top: 0;
   height: 64px;
+  z-index: 1;
+  background-color: rgb(100, 140, 175);
   color: var(--color-white);
   font-size: 14px;
   padding: 0 8px 0 16px;

--- a/app/scripts/modules/core/src/managed/ColumnHeader.module.css
+++ b/app/scripts/modules/core/src/managed/ColumnHeader.module.css
@@ -1,6 +1,8 @@
 .ColumnHeader {
   background-color: rgb(100, 140, 175);
   display: flex;
+  position: sticky;
+  top: 0;
   height: 32px;
   justify-content: space-between;
   align-items: center;

--- a/app/scripts/modules/core/src/managed/EnvironmentRow.less
+++ b/app/scripts/modules/core/src/managed/EnvironmentRow.less
@@ -2,12 +2,10 @@
   max-width: 100%;
 
   .srow {
-    position: relative;
     display: flex;
     align-items: center;
     box-shadow: inset 0 -1px 0 0 #cccccc;
     height: 40px;
-    position: relative;
     font-size: 14px;
   }
 

--- a/app/scripts/modules/core/src/managed/Environments.module.css
+++ b/app/scripts/modules/core/src/managed/Environments.module.css
@@ -27,16 +27,27 @@
 }
 
 .mainContent {
-  display: flex;
-  margin-top: 24px;
+  display: grid;
+  grid-template-columns: minmax(300px, 3fr) 8fr;
+  grid-template-rows: auto;
+  width: 100%;
+  overflow: hidden;
 }
 
 .artifactsColumn {
-  flex: 0 1 280px;
-  overflow: hidden;
-  margin-right: 16px;
+  padding-right: 16px;
+  overflow: scroll;
 }
 
 .environmentsColumn {
-  flex: 1 1 400px;
+  display: grid;
+  grid-column-template: 1fr;
+  grid-row-template: auto;
+  overflow: scroll;
+}
+
+.environmentsPane {
+  grid-column: 1;
+  grid-row: 1;
+  overflow: scroll;
 }

--- a/app/scripts/modules/core/src/managed/ObjectRow.module.css
+++ b/app/scripts/modules/core/src/managed/ObjectRow.module.css
@@ -6,11 +6,8 @@
   display: flex;
   align-items: center;
   flex: auto;
-
   box-shadow: inset 0 -1px 0 0 #cccccc;
   height: 40px;
-
-  position: relative;
   font-size: 14px;
 }
 

--- a/app/scripts/modules/core/src/managed/ObjectRow.tsx
+++ b/app/scripts/modules/core/src/managed/ObjectRow.tsx
@@ -30,8 +30,5 @@ export const ObjectRow = ({ icon, title, metadata, depth = 1 }: IObjectRowProps)
 const getStylesFromDepth = (depth: number): React.CSSProperties => {
   return {
     marginLeft: 16 * depth,
-    position: 'sticky',
-    top: 104 + 40 * depth,
-    zIndex: 500 - depth,
   };
 };


### PR DESCRIPTION
A couple _very_ related changes:

**First,** the overall layout for the two-column Environments view is a mix of some prototype flexbox markup/styles, some ad-hoc 'make it work' layout code from porting over the prototype, and then some layering on top of stuff we did to accommodate a particular feature/component. I'd like to simplify that markup, prepare it to become something more re-usable (i.e. some kind of standard list/detail layout we can use elsewhere), and fix the sizing/scroll overflow wonkiness we've deferred polishing. As part of this first chunk of changes I've:

- Swapped out the flexbox rules which implicitly depended on each other's size in favor of a two-column grid layout, which has the pleasant side effect of filling the available space in the route container
- Tweaked the size relationship between the list and detail panes to give more breathing room to the list pane when there's sufficient horizontal space
- Made each column handle overflow properly so you can independently scroll
- Made all the headers sticky so the new scroll behavior doesn't allow them to scroll away
- Fixed the position and stickiness issues with `EnvironmentRow` and `ObjectRow` to fix the wonkiness that was happening on scroll (I intend to add back proper stickiness later)

**Second,** I've added enter/leave transitions for swapping between the overview pane and the detail pane for a specific version. After getting early feedback we decided this should be upgraded from nice-to-have to must-have, as the lack of a context-setting transition made it very unclear what was going on when you clicked on a version. For now it's done in a sort of annoying way (I'll comment on the lines I'm talking about) because I want to experiment with the transition and confirm that folks are feeling good about it, but my plan is to extract a nice layout component like `<ListDetailLayout />` that will do all the transition stuff internally, and expose a render prop for rendering the detail pane so we can avoid the stuff I had to do here.

While this PR (amazingly!) doesn't depend on https://github.com/spinnaker/deck/pull/8158, the usage examples are from locally running both https://github.com/spinnaker/deck/pull/8158 _and_ this change together. I chose to do that because https://github.com/spinnaker/deck/pull/8158 has related visual and motion changes, and their interplay is useful in evaluating these changes.

<details>
<summary>Before</summary>

<img width="1354" alt="Screen Shot 2020-04-10 at 6 39 45 PM" src="https://user-images.githubusercontent.com/1850998/79032390-d4760980-7b5a-11ea-921f-23f89da39638.png">

<img width="1355" alt="Screen Shot 2020-04-10 at 6 39 58 PM" src="https://user-images.githubusercontent.com/1850998/79032391-da6bea80-7b5a-11ea-965c-f4c43d932cd9.png">

</details>

<details>
<summary>After</summary>

<img width="1369" alt="Screen Shot 2020-04-10 at 6 34 46 PM" src="https://user-images.githubusercontent.com/1850998/79032396-e8217000-7b5a-11ea-93b5-40d717442014.png">

<img width="1361" alt="Screen Shot 2020-04-10 at 6 35 09 PM" src="https://user-images.githubusercontent.com/1850998/79032397-eeafe780-7b5a-11ea-8846-24a6b7d7fc48.png">

[Video of properly scrolling columns and detail pane transitions](https://slack-files.com/T091CRSGH-F011N2QGKPD-0f21d9a110). I recommend making it fullscreen so you can see the smaller components.

</details>