### PR TITLE
feat(artifacts): replace legacy-only Find Artifacts UI with Produces A…

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/findArtifactFromExecution/findArtifactFromExecution.controller.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/findArtifactFromExecution/findArtifactFromExecution.controller.ts
@@ -1,13 +1,6 @@
 import { IController, IScope } from 'angular';
 
-import {
-  ApplicationReader,
-  ExpectedArtifactService,
-  IExpectedArtifact,
-  IPipeline,
-  IStage,
-  PipelineConfigService,
-} from 'core';
+import { ApplicationReader, ExpectedArtifactService, IExpectedArtifact, IPipeline, PipelineConfigService } from 'core';
 
 export interface IFindArtifactFromExecutionStage {
   application: string;
@@ -84,12 +77,4 @@ export class FindArtifactFromExecutionCtrl implements IController {
   public onApplicationSelect() {
     this.loadPipelines();
   }
-
-  public addExpectedArtifact = () => {
-    ExpectedArtifactService.addNewArtifactTo(this.stage);
-  };
-
-  public removeExpectedArtifact = (stage: IStage, expectedArtifact: IExpectedArtifact) => {
-    stage.expectedArtifacts = stage.expectedArtifacts.filter((a: IExpectedArtifact) => a.id !== expectedArtifact.id);
-  };
 }

--- a/app/scripts/modules/core/src/pipeline/config/stages/findArtifactFromExecution/findArtifactFromExecutionConfig.html
+++ b/app/scripts/modules/core/src/pipeline/config/stages/findArtifactFromExecution/findArtifactFromExecutionConfig.html
@@ -41,18 +41,4 @@
       <label> <input type="checkbox" ng-model="ctrl.stage.executionOptions.running" /> that are still running </label>
     </div>
   </div>
-  <h4>Match Artifacts</h4>
-  <expected-artifact
-    ng-repeat="artifact in ctrl.stage.expectedArtifacts"
-    context="ctrl.stage"
-    expected-artifact="artifact"
-    remove-expected-artifact="ctrl.removeExpectedArtifact"
-  />
-  <div class="row">
-    <div class="col-md-12">
-      <button class="btn btn-block btn-add-trigger add-new" ng-click="ctrl.addExpectedArtifact()">
-        <span class="glyphicon glyphicon-plus-sign"></span> Add Artifact
-      </button>
-    </div>
-  </div>
 </div>

--- a/app/scripts/modules/core/src/pipeline/config/stages/findArtifactFromExecution/findArtifactFromExecutionStage.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/findArtifactFromExecution/findArtifactFromExecutionStage.ts
@@ -29,6 +29,7 @@ module(FIND_ARTIFACT_FROM_EXECUTION_STAGE, [])
           { type: 'requiredField', fieldName: 'pipeline', fieldLabel: 'Pipeline' },
           { type: 'requiredField', fieldName: 'application', fieldLabel: 'Application' },
         ],
+        producesArtifacts: true,
       });
     }
   })


### PR DESCRIPTION
…rtifacts

Previously, the Find Artifacts from Execution stage rendered its own one-off list of artifacts in the style of the Legacy artifacts UI. Let's replace this with the standard Produces Artifacts UI, for which logic already exists to handle rendering the Legacy vs. Standard artifacts UI. This brings the Find Artifacts from Execution stage to visual parity with the Find Artifact from Resource stage, which also uses the Produces Artifacts section to define a list of expected artifacts for the stage.