### PR TITLE
fix(core/pipelines): typo with PIPELINE_CONFIG_ACTIONS

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/actions/pipelineConfigActions.module.ts
+++ b/app/scripts/modules/core/src/pipeline/config/actions/pipelineConfigActions.module.ts
@@ -1,7 +1,7 @@
 import { module } from 'angular';
 import { react2angular } from 'react2angular';
 import { PipelineConfigActions } from './PipelineConfigActions';
-export const PIPELINE_CONFIG_ACTIONS = 'pinnaker.core.pipeline.config.actions';
+export const PIPELINE_CONFIG_ACTIONS = 'spinnaker.core.pipeline.config.actions';
 module(PIPELINE_CONFIG_ACTIONS, []).component(
   'pipelineConfigActions',
   react2angular(PipelineConfigActions, [


### PR DESCRIPTION
Pretty self explanatory lol.

Luckily `pinnaker.core.pipeline.config.actions` and `spinnaker.core.pipeline.config.actions` isn't used directly, the common usage is `PIPELINE_CONFIG_ACTIONS` constant.