### PR TITLE
fix(core): Do not add security group multiple times

### DIFF
--- a/app/scripts/modules/core/src/securityGroup/securityGroupReader.service.ts
+++ b/app/scripts/modules/core/src/securityGroup/securityGroupReader.service.ts
@@ -185,7 +185,7 @@ export class SecurityGroupReader {
 
   private addServerGroupSecurityGroups(application: Application): ISecurityGroupProcessorResult {
     let notFoundCaught = false;
-    const securityGroups: ISecurityGroup[] = [];
+    const sgSet: Set<ISecurityGroup> = new Set();
     application.getDataSource('serverGroups').data.forEach((serverGroup: IServerGroup) => {
       if (serverGroup.securityGroups) {
         serverGroup.securityGroups.forEach((securityGroupId: string) => {
@@ -200,7 +200,7 @@ export class SecurityGroupReader {
               const { account, isDisabled, name, cloudProvider, region } = serverGroup;
               securityGroup.usages.serverGroups.push({ account, isDisabled, name, cloudProvider, region });
             }
-            securityGroups.push(securityGroup);
+            sgSet.add(securityGroup);
           } catch (e) {
             this.$log.warn('could not attach firewall to server group:', serverGroup.name, securityGroupId);
             notFoundCaught = true;
@@ -208,6 +208,7 @@ export class SecurityGroupReader {
         });
       }
     });
+    const securityGroups: ISecurityGroup[] = Array.from(sgSet);
     securityGroups.forEach(SecurityGroupReader.sortUsages);
 
     return { notFoundCaught, securityGroups };


### PR DESCRIPTION
By using a local `Set` to prevent duplicates (but still returning an `Array`).

We were redundantly adding the same security group into the `securityGroups` array multiple times when it is used by multiple server groups. This is not necessary and results in performing operations redundantly:

https://github.com/spinnaker/deck/blob/35fcebbcdd2c6dea2397a90a48db975293096054/app/scripts/modules/core/src/securityGroup/securityGroupReader.service.ts#L211

...which is not expensive in and of itself, but becomes expensive as the number of `serverGroups` increases as we were pushing duplicate securityGroup objects on every iteration of a `serverGroup`.

We basically had ( `number of security groups` x `number of server groups` ) in the array, which is now reduced to only `number of security groups`.