### PR TITLE
feat(core): make artifacts account selector searchable by name

### DIFF
--- a/app/scripts/modules/core/src/artifact/react/ArtifactAccountSelector.tsx
+++ b/app/scripts/modules/core/src/artifact/react/ArtifactAccountSelector.tsx
@@ -38,6 +38,7 @@ export class ArtifactAccountSelector extends React.Component<IArtifactAccountSel
         optionRenderer={this.renderOption}
         valueRenderer={this.renderOption}
         clearable={false}
+        valueKey="name"
       />
     );
   }


### PR DESCRIPTION
Adds `valueKey` of `name` so that the `ArtifactAccountSelector` dropdown is filterable by account name.