### PR TITLE
feat(core): Filter out providers that don't support creating load bal…

### DIFF
--- a/app/scripts/modules/core/src/loadBalancer/CreateLoadBalancerButton.tsx
+++ b/app/scripts/modules/core/src/loadBalancer/CreateLoadBalancerButton.tsx
@@ -28,7 +28,11 @@ export class CreateLoadBalancerButton extends React.Component<ICreateLoadBalance
     super(props);
   }
 
-  private createLoadBalancerProviderFilterFn = ({}, {}, provider: ICloudProviderConfig): boolean => {
+  private createLoadBalancerProviderFilterFn = (
+    _app: Application,
+    _acc: IAccountDetails,
+    provider: ICloudProviderConfig,
+  ): boolean => {
     const lbConfig = provider.loadBalancer;
     return (
       lbConfig &&

--- a/app/scripts/modules/core/src/loadBalancer/CreateLoadBalancerButton.tsx
+++ b/app/scripts/modules/core/src/loadBalancer/CreateLoadBalancerButton.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
 import { Application } from 'core/application';
-import { CloudProviderRegistry, ProviderSelectionService } from 'core/cloudProvider';
+import { IAccountDetails } from 'core/account';
+import { CloudProviderRegistry, ProviderSelectionService, ICloudProviderConfig } from 'core/cloudProvider';
 import { ILoadBalancer } from 'core/domain';
 import { ILoadBalancerUpsertCommand } from './loadBalancer.write.service';
 import { ModalInjector, ReactInjector } from 'core/reactShims';
@@ -27,39 +28,54 @@ export class CreateLoadBalancerButton extends React.Component<ICreateLoadBalance
     super(props);
   }
 
+  private createLoadBalancerProviderFilterFn = (
+    app: Application,
+    account: IAccountDetails,
+    provider: ICloudProviderConfig,
+  ): boolean => {
+    const lbConfig = provider.loadBalancer;
+    return (
+      lbConfig &&
+      (lbConfig.CreateLoadBalancerModal ||
+        (lbConfig.createLoadBalancerTemplateUrl && lbConfig.createLoadBalancerController))
+    );
+  };
+
   private createLoadBalancer = (): void => {
     const { skinSelectionService } = ReactInjector;
     const { app } = this.props;
-    ProviderSelectionService.selectProvider(app, 'loadBalancer').then(selectedProvider => {
-      skinSelectionService.selectSkin(selectedProvider).then(selectedSkin => {
-        const provider = CloudProviderRegistry.getValue(selectedProvider, 'loadBalancer', selectedSkin);
+    ProviderSelectionService.selectProvider(app, 'loadBalancer', this.createLoadBalancerProviderFilterFn).then(
+      selectedProvider => {
+        skinSelectionService.selectSkin(selectedProvider).then(selectedSkin => {
+          const provider = CloudProviderRegistry.getValue(selectedProvider, 'loadBalancer', selectedSkin);
 
-        if (provider.CreateLoadBalancerModal) {
-          provider.CreateLoadBalancerModal.show({
-            app: app,
-            application: app,
-            forPipelineConfig: false,
-            loadBalancer: null,
-            isNew: true,
-          });
-        } else {
-          // angular
-          ModalInjector.modalService
-            .open({
-              templateUrl: provider.createLoadBalancerTemplateUrl,
-              controller: `${provider.createLoadBalancerController} as ctrl`,
-              size: 'lg',
-              resolve: {
-                application: () => this.props.app,
-                loadBalancer: (): ILoadBalancer => null,
-                isNew: () => true,
-                forPipelineConfig: () => false,
-              },
-            })
-            .result.catch(() => {});
-        }
-      });
-    });
+          if (provider.CreateLoadBalancerModal) {
+            provider.CreateLoadBalancerModal.show({
+              app: app,
+              application: app,
+              forPipelineConfig: false,
+              loadBalancer: null,
+              isNew: true,
+            });
+          } else {
+            // angular
+            ModalInjector.modalService
+              .open({
+                templateUrl: provider.createLoadBalancerTemplateUrl,
+                controller: `${provider.createLoadBalancerController} as ctrl`,
+                size: 'lg',
+                resolve: {
+                  application: () => this.props.app,
+                  loadBalancer: (): ILoadBalancer => null,
+                  isNew: () => true,
+                  forPipelineConfig: () => false,
+                },
+              })
+              .result.catch(() => {});
+          }
+        });
+      },
+    );
   };
 
   public render() {

--- a/app/scripts/modules/core/src/loadBalancer/CreateLoadBalancerButton.tsx
+++ b/app/scripts/modules/core/src/loadBalancer/CreateLoadBalancerButton.tsx
@@ -28,11 +28,7 @@ export class CreateLoadBalancerButton extends React.Component<ICreateLoadBalance
     super(props);
   }
 
-  private createLoadBalancerProviderFilterFn = (
-    app: Application,
-    account: IAccountDetails,
-    provider: ICloudProviderConfig,
-  ): boolean => {
+  private createLoadBalancerProviderFilterFn = ({}, {}, provider: ICloudProviderConfig): boolean => {
     const lbConfig = provider.loadBalancer;
     return (
       lbConfig &&


### PR DESCRIPTION
…ancers

While working to address https://github.com/spinnaker/spinnaker/issues/4797, discovered that adding ECS load balancer components results in a broken experience for the `Create Load Balancer` button/modal because no provider-specific `CreateLoadBalancerModal` is defined.

This change allows some providers' load balancer support to be "read only", where viewing existing load balancers is possible but new ones cannot be created through Spinnaker. Builds on precedence set by https://github.com/spinnaker/deck/pull/7370 .

I believe this currently only effects the ECS provider, where load balancers/target groups can be created through the associated AWS account and AWS provider "create load balancer" Ul.

### Testing
Spinnaker with AWS + ECS enabled, `Create Load Balancer` goes straight to AWS LB choice modal (no provider selection)
<img width="540" alt="lb_create_aws" src="https://user-images.githubusercontent.com/34254888/79279594-35efee00-7e63-11ea-8ef0-24d9d33baf8e.PNG">


Existing LB page: only AWS LBs shown
<img width="500" alt="lb_view_no_ecs" src="https://user-images.githubusercontent.com/34254888/79279630-4acc8180-7e63-11ea-9ef8-5f457958148c.PNG">


W/ ECS LB components implemented (PR pending): AWS and ECS LBs shown
<img width="510" alt="lb_view_with_ecs" src="https://user-images.githubusercontent.com/34254888/79279636-4ef89f00-7e63-11ea-826c-3a8338ae5aac.PNG">
