### PR TITLE
fix(pubsub): prevent NPE when retrying a pipeline execution with

### DIFF
--- a/app/scripts/modules/core/src/pipeline/manualExecution/Triggers.tsx
+++ b/app/scripts/modules/core/src/pipeline/manualExecution/Triggers.tsx
@@ -34,7 +34,7 @@ export class Triggers extends React.Component<ITriggersProps> {
   };
 
   private updateTriggerDescription = (trigger: ITrigger) => {
-    if (trigger && !trigger.description) {
+    if (trigger && !trigger.description && Registry.pipeline.hasManualExecutionComponentForTriggerType(trigger.type)) {
       Observable.fromPromise(
         (Registry.pipeline.getManualExecutionComponentForTriggerType(trigger.type) as any).formatLabel(trigger),
       )


### PR DESCRIPTION
a pubsub trigger

Retrying a pipeline with a pubsub trigger + any other trigger doesn't work because the pubsub trigger type doesn't implement a `manualExecutionComponent`. Wrote out a larger description of the problem here: https://github.com/spinnaker/spinnaker/issues/5682

This PR "solves" the problem by preventing the retry modal from blowing up, but eventually would love to see the attached issue solved.
