### PR TITLE
feat(core): enable standard artifacts UI by default

### DIFF
--- a/app/scripts/modules/core/src/artifact/ArtifactsModeService.ts
+++ b/app/scripts/modules/core/src/artifact/ArtifactsModeService.ts
@@ -21,7 +21,6 @@ import { SETTINGS } from 'core/config';
  */
 
 export enum ArtifactsMode {
-  DISABLED,
   LEGACY,
   STANDARD,
 }
@@ -30,12 +29,9 @@ export class ArtifactsModeService {
   public static readonly artifactsMode = ArtifactsModeService.getArtifactsMode();
 
   private static getArtifactsMode(): ArtifactsMode {
-    if (SETTINGS.feature.artifactsRewrite === true) {
-      return ArtifactsMode.STANDARD;
-    }
-    if (SETTINGS.feature.artifacts === true) {
+    if (SETTINGS.feature.legacyArtifactsEnabled === true) {
       return ArtifactsMode.LEGACY;
     }
-    return ArtifactsMode.DISABLED;
+    return ArtifactsMode.STANDARD;
   }
 }

--- a/app/scripts/modules/core/src/artifact/expectedArtifactMultiSelector.component.ts
+++ b/app/scripts/modules/core/src/artifact/expectedArtifactMultiSelector.component.ts
@@ -1,7 +1,6 @@
 import { IComponentOptions, IController, module } from 'angular';
 import { IExpectedArtifact } from 'core/domain';
 import { ArtifactIconService } from './ArtifactIconService';
-import { ArtifactsMode, ArtifactsModeService } from './ArtifactsModeService';
 
 import './artifactSelector.less';
 
@@ -12,7 +11,6 @@ class ExpectedArtifactMultiSelectorCtrl implements IController {
   public expectedArtifacts: IExpectedArtifact[];
   public helpFieldKey: string;
   public showIcons: boolean;
-  public artifactsEnabled = ArtifactsModeService.artifactsMode !== ArtifactsMode.DISABLED;
 
   public iconPath(expected: IExpectedArtifact): string {
     const artifact = expected && (expected.matchArtifact || expected.defaultArtifact);
@@ -35,7 +33,7 @@ const expectedArtifactMultiSelectorComponent: IComponentOptions = {
   controller: ExpectedArtifactMultiSelectorCtrl,
   controllerAs: 'ctrl',
   template: `
-      <ng-form name="artifacts" ng-if="ctrl.artifactsEnabled">
+      <ng-form name="artifacts">
         <stage-config-field label="{{ctrl.artifactLabel}}" help-key="{{ctrl.helpFieldKey}}">
           <ui-select multiple
                      ng-model="ctrl.command[ctrl.idsField]"

--- a/app/scripts/modules/core/src/artifact/imageSourceSelector.component.ts
+++ b/app/scripts/modules/core/src/artifact/imageSourceSelector.component.ts
@@ -7,7 +7,6 @@ const imageSourceSelectorComponent: IComponentOptions = {
     helpFieldKey: '@',
     idField: '@',
     imageSourceText: '<',
-    artifactsEnabled: '<',
   },
   controllerAs: 'ctrl',
   template: `
@@ -19,7 +18,7 @@ const imageSourceSelectorComponent: IComponentOptions = {
         <span ng-bind-html="ctrl.imageSourceText"></span>
       </div>
     </div>
-    <div class="form-group" ng-if="!ctrl.imageSourceText && ctrl.artifactsEnabled">
+    <div class="form-group" ng-if="!ctrl.imageSourceText">
       <div class="col-md-3 sm-label-right">
         Image Source
         <help-field key="{{ ctrl.helpFieldKey }}"></help-field>

--- a/app/scripts/modules/core/src/config/settings.ts
+++ b/app/scripts/modules/core/src/config/settings.ts
@@ -24,8 +24,6 @@ export interface INotificationSettings {
 
 export interface IFeatures {
   [key: string]: any;
-  artifacts?: boolean;
-  artifactsRewrite?: boolean;
   canary?: boolean;
   chaosMonkey?: boolean;
   displayTimestampsInUserLocalTime?: boolean;
@@ -37,6 +35,8 @@ export interface IFeatures {
   iapRefresherEnabled?: boolean;
   // whether stages affecting infrastructure (like "Create Load Balancer") should be enabled or not
   infrastructureStages?: boolean;
+  // todo(mneterval): remove prior to release 1.21
+  legacyArtifactsEnabled?: boolean;
   managedDelivery?: boolean;
   managedServiceAccounts?: boolean;
   managedResources?: boolean;

--- a/app/scripts/modules/core/src/pipeline/config/stages/findArtifactFromExecution/findArtifactFromExecutionStage.ts
+++ b/app/scripts/modules/core/src/pipeline/config/stages/findArtifactFromExecution/findArtifactFromExecutionStage.ts
@@ -1,6 +1,5 @@
 import { module } from 'angular';
 
-import { ArtifactsMode, ArtifactsModeService } from 'core/artifact';
 import { Registry } from 'core/registry';
 
 import { ExecutionDetailsTasks } from '../common';
@@ -12,25 +11,23 @@ export const FIND_ARTIFACT_FROM_EXECUTION_STAGE = 'spinnaker.core.pipeline.stage
 
 module(FIND_ARTIFACT_FROM_EXECUTION_STAGE, [])
   .config(() => {
-    if (ArtifactsModeService.artifactsMode !== ArtifactsMode.DISABLED) {
-      Registry.pipeline.registerStage({
-        label: 'Find Artifacts From Execution',
-        description: 'Find and bind artifacts from another execution',
-        key: 'findArtifactFromExecution',
-        templateUrl: require('./findArtifactFromExecutionConfig.html'),
-        controller: 'findArtifactFromExecutionCtrl',
-        controllerAs: 'ctrl',
-        executionDetailsSections: [
-          FindArtifactFromExecutionExecutionDetails,
-          ExecutionDetailsTasks,
-          ExecutionArtifactTab,
-        ],
-        validators: [
-          { type: 'requiredField', fieldName: 'pipeline', fieldLabel: 'Pipeline' },
-          { type: 'requiredField', fieldName: 'application', fieldLabel: 'Application' },
-        ],
-        producesArtifacts: true,
-      });
-    }
+    Registry.pipeline.registerStage({
+      label: 'Find Artifacts From Execution',
+      description: 'Find and bind artifacts from another execution',
+      key: 'findArtifactFromExecution',
+      templateUrl: require('./findArtifactFromExecutionConfig.html'),
+      controller: 'findArtifactFromExecutionCtrl',
+      controllerAs: 'ctrl',
+      executionDetailsSections: [
+        FindArtifactFromExecutionExecutionDetails,
+        ExecutionDetailsTasks,
+        ExecutionArtifactTab,
+      ],
+      validators: [
+        { type: 'requiredField', fieldName: 'pipeline', fieldLabel: 'Pipeline' },
+        { type: 'requiredField', fieldName: 'application', fieldLabel: 'Application' },
+      ],
+      producesArtifacts: true,
+    });
   })
   .controller('findArtifactFromExecutionCtrl', FindArtifactFromExecutionCtrl);

--- a/app/scripts/modules/core/src/pipeline/status/ParametersAndArtifacts.tsx
+++ b/app/scripts/modules/core/src/pipeline/status/ParametersAndArtifacts.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { keyBy, truncate } from 'lodash';
 import memoizeOne from 'memoize-one';
 
-import { ArtifactsMode, ArtifactsModeService } from 'core/artifact';
 import { IExecution, IPipeline } from 'core/domain';
 
 import { ExecutionParameters, IDisplayableParameter } from './ExecutionParameters';
@@ -131,14 +130,11 @@ export class ParametersAndArtifacts extends React.Component<
           displayableParameters={displayableParameters}
           pinnedDisplayableParameters={pinnedDisplayableParameters}
         />
-
-        {ArtifactsModeService.artifactsMode !== ArtifactsMode.DISABLED && (
-          <ResolvedArtifactList
-            artifacts={artifacts}
-            resolvedExpectedArtifacts={resolvedExpectedArtifacts}
-            showingExpandedArtifacts={showingParams}
-          />
-        )}
+        <ResolvedArtifactList
+          artifacts={artifacts}
+          resolvedExpectedArtifacts={resolvedExpectedArtifacts}
+          showingExpandedArtifacts={showingParams}
+        />
       </>
     );
   }

--- a/app/scripts/modules/google/src/serverGroup/configure/wizard/location/basicSettings.controller.js
+++ b/app/scripts/modules/google/src/serverGroup/configure/wizard/location/basicSettings.controller.js
@@ -5,8 +5,6 @@ import { Observable, Subject } from 'rxjs';
 import { extend } from 'lodash';
 
 import {
-  ArtifactsMode,
-  ArtifactsModeService,
   ArtifactTypePatterns,
   ExpectedArtifactSelectorViewController,
   excludeAllTypesExcept,
@@ -143,7 +141,5 @@ angular
         delegate: gceImageDelegate,
         controller: new ExpectedArtifactSelectorViewController(gceImageDelegate),
       };
-
-      this.artifactsEnabled = ArtifactsModeService.artifactsMode !== ArtifactsMode.DISABLED;
     },
   ]);

--- a/app/scripts/modules/google/src/serverGroup/configure/wizard/location/basicSettings.html
+++ b/app/scripts/modules/google/src/serverGroup/configure/wizard/location/basicSettings.html
@@ -87,7 +87,6 @@
         image-sources="basicSettingsCtrl.imageSources"
         image-source-text="command.viewState.imageSourceText"
         help-field-key="gce.image.source"
-        artifacts-enabled="basicSettingsCtrl.artifactsEnabled"
       >
       </image-source-selector>
       <stage-artifact-selector-delegate

--- a/app/scripts/modules/kubernetes/src/v2/pipelines/stages/findArtifactsFromResource/findArtifactsFromResourceStage.ts
+++ b/app/scripts/modules/kubernetes/src/v2/pipelines/stages/findArtifactsFromResource/findArtifactsFromResourceStage.ts
@@ -1,12 +1,6 @@
 import { module } from 'angular';
 
-import {
-  ArtifactsMode,
-  ArtifactsModeService,
-  Registry,
-  ExecutionDetailsTasks,
-  ExecutionArtifactTab,
-} from '@spinnaker/core';
+import { Registry, ExecutionDetailsTasks, ExecutionArtifactTab } from '@spinnaker/core';
 
 import { KubernetesV2FindArtifactsFromResourceConfigCtrl } from './findArtifactsFromResourceConfig.controller';
 import { KUBERNETES_MANIFEST_SELECTOR } from '../../../manifest/selector/selector.component';
@@ -18,19 +12,17 @@ export const KUBERNETES_FIND_ARTIFACTS_FROM_RESOURCE_STAGE =
 const STAGE_NAME = 'Find Artifacts From Resource (Manifest)';
 module(KUBERNETES_FIND_ARTIFACTS_FROM_RESOURCE_STAGE, [KUBERNETES_MANIFEST_SELECTOR])
   .config(() => {
-    if (ArtifactsModeService.artifactsMode !== ArtifactsMode.DISABLED) {
-      Registry.pipeline.registerStage({
-        label: STAGE_NAME,
-        description: 'Finds artifacts from a Kubernetes resource.',
-        key: 'findArtifactsFromResource',
-        cloudProvider: 'kubernetes',
-        templateUrl: require('./findArtifactsFromResourceConfig.html'),
-        controller: 'KubernetesV2FindArtifactsFromResourceConfigCtrl',
-        controllerAs: 'ctrl',
-        executionDetailsSections: [ExecutionDetailsTasks, ExecutionArtifactTab],
-        producesArtifacts: true,
-        validators: manifestSelectorValidators(STAGE_NAME),
-      });
-    }
+    Registry.pipeline.registerStage({
+      label: STAGE_NAME,
+      description: 'Finds artifacts from a Kubernetes resource.',
+      key: 'findArtifactsFromResource',
+      cloudProvider: 'kubernetes',
+      templateUrl: require('./findArtifactsFromResourceConfig.html'),
+      controller: 'KubernetesV2FindArtifactsFromResourceConfigCtrl',
+      controllerAs: 'ctrl',
+      executionDetailsSections: [ExecutionDetailsTasks, ExecutionArtifactTab],
+      producesArtifacts: true,
+      validators: manifestSelectorValidators(STAGE_NAME),
+    });
   })
   .controller('KubernetesV2FindArtifactsFromResourceConfigCtrl', KubernetesV2FindArtifactsFromResourceConfigCtrl);

--- a/halconfig/settings.js
+++ b/halconfig/settings.js
@@ -1,8 +1,6 @@
 'use strict';
 
 var gateHost = '{%gate.baseUrl%}';
-var artifactsEnabled = '{%features.artifacts%}' === 'true';
-var artifactsRewriteEnabled = '{%features.artifactsRewrite%}' === 'true';
 var atlasWebComponentsUrl = '{%canary.atlasWebComponentsUrl%}';
 var authEnabled = '{%features.auth%}' === 'true';
 var authEndpoint = gateHost + '/auth/user';
@@ -158,8 +156,6 @@ window.spinnakerSettings = {
   ],
   defaultTimeZone: timezone, // see http://momentjs.com/timezone/docs/#/data-utilities/
   feature: {
-    artifacts: artifactsEnabled,
-    artifactsRewrite: artifactsRewriteEnabled,
     canary: mineCanaryEnabled,
     chaosMonkey: chaosEnabled,
     displayTimestampsInUserLocalTime: displayTimestampsInUserLocalTime,

--- a/settings.js
+++ b/settings.js
@@ -3,8 +3,6 @@
 // Use environment variables when developing locally via 'yarn start', i.e.:
 // API_HOST=https://gate.spinnaker.mycompany.com yarn start
 var apiHost = process.env.API_HOST || 'http://localhost:8084';
-var artifactsEnabled = process.env.ARTIFACTS_ENABLED === 'true';
-var artifactsRewriteEnabled = process.env.ARTIFACTS_REWRITE_ENABLED === 'true';
 var atlasWebComponentsUrl = process.env.ATLAS_WEB_COMPONENTS_URL;
 var authEndpoint = process.env.AUTH_ENDPOINT || apiHost + '/auth/user';
 var authEnabled = process.env.AUTH_ENABLED === 'false' ? false : true;
@@ -72,8 +70,6 @@ window.spinnakerSettings = {
     maxResults: 5000,
   },
   feature: {
-    artifacts: artifactsEnabled,
-    artifactsRewrite: artifactsRewriteEnabled,
     canary: canaryEnabled,
     chaosMonkey: chaosEnabled,
     displayTimestampsInUserLocalTime: displayTimestampsInUserLocalTime,


### PR DESCRIPTION
Related to: https://github.com/spinnaker/governance/blob/master/rfc/legacy_artifacts_ui_removal.md 

This change removes `artifacts` and `artifactsRewrite` feature flags in preparation for release 1.20, in which the standard artifacts UI will be enabled by default. Provides a temporary flag that can be enabled in order to revert to the legacy UI, which will be removed in release 1.21.

Corresponding Halyard and Docs changes coming soon!