### PR TITLE
feat(ecs): Implement load balancer views

### DIFF
--- a/app/scripts/modules/ecs/src/domain/IEcsLoadBalancer.ts
+++ b/app/scripts/modules/ecs/src/domain/IEcsLoadBalancer.ts
@@ -14,7 +14,7 @@ export interface IEcsLoadBalancer extends ILoadBalancer {
   cloudProvider: string;
   createdTime: number;
   dnsname: string;
-  listeners: IALBListener[];
+  listeners: IEcsListener[];
   targetGroups: IEcsTargetGroup[];
   ipAddressType?: string; // returned from clouddriver
   deletionProtection: boolean;
@@ -55,23 +55,24 @@ export interface IEcsTargetGroup {
   region: string;
   serverGroups?: string[];
   targetType?: string;
-  type: string; // returned from clouddriver
+  type: string;
   vpcId?: string;
   vpcName?: string;
 }
 
-export interface IALBListener {
-  certificates: any[];
+export interface IEcsListener {
+  certificates?: any[];
   defaultActions: IListenerAction[];
   port: number;
   protocol: string;
-  rules: any[]; // TODO: use & define IListenerRule
+  rules?: any[]; // TODO: use & define IListenerRule
   sslPolicy?: string;
 }
 
 // see https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_Action.html
 export interface IListenerAction {
   authenticateOidcConfig?: IAuthenticateOidcActionConfig;
+  authenticateCognitoActionConfig?: IAuthenticateCognitoActionConfig;
   order?: number;
   forwardConfig?: IForwardConfig;
   fixedResponseConfig?: IFixedResponseConfig;
@@ -87,15 +88,29 @@ export interface IAuthenticateOidcActionConfig {
   clientSecret?: string;
   idpLogoutUrl?: string;
   issuer: string;
-  scope: string;
-  sessionCookieName: string;
+  onUnauthenticatedRequest?: 'deny' | 'allow' | 'authenticate';
+  scope?: string;
+  sessionCookieName?: string;
   sessionTimeout?: number;
   tokenEndpoint: string;
   userInfoEndpoint: string;
+  useExistingClientSecret?: boolean;
+}
+
+export interface IAuthenticateCognitoActionConfig {
+  authenticationRequestExtraParams?: { [key: string]: string };
+  onUnauthenticatedRequest?: 'deny' | 'allow' | 'authenticate';
+  scope?: string;
+  sessionCookieName?: string;
+  sessionTimeout?: number;
+  userPoolArn: string;
+  userPoolClientId: string;
+  userPoolDomain: string;
 }
 
 export interface IForwardConfig {
   targetGroups?: { targetGroupArn: string; weight: number }[];
+  targetGroupStickinessConfig?: any;
 }
 
 export interface IFixedResponseConfig {

--- a/app/scripts/modules/ecs/src/domain/IEcsLoadBalancer.ts
+++ b/app/scripts/modules/ecs/src/domain/IEcsLoadBalancer.ts
@@ -1,0 +1,114 @@
+import { ILoadBalancer, IInstance, IInstanceCounts } from '@spinnaker/core';
+
+export type IListenerActionType =
+  | 'forward'
+  | 'authenticate-oidc'
+  | 'redirect'
+  | 'authenticate-cognito'
+  | 'fixed-response';
+
+export interface IEcsLoadBalancer extends ILoadBalancer {
+  name: string;
+  account: string;
+  availabilityZones: string[];
+  cloudProvider: string;
+  createdTime: number;
+  dnsname: string;
+  listeners: IALBListener[];
+  targetGroups: IEcsTargetGroup[];
+  ipAddressType?: string; // returned from clouddriver
+  deletionProtection: boolean;
+  idleTimeout: number;
+  loadBalancerType: string;
+  securityGroups: string[];
+  subnets?: string[];
+  region: string;
+  vpcId: string;
+}
+
+export interface IEcsLoadBalancerSourceData extends IEcsLoadBalancer {
+  targetGroupServices: { [key: string]: string[] };
+}
+
+export interface IEcsTargetGroup {
+  account: string;
+  attributes?: any;
+  cloudProvider: string;
+  createdTime: number;
+  detachedInstances?: IInstance[];
+  healthCheckProtocol: string;
+  healthCheckPort: number | 'traffic-port';
+  healthCheckPath: string;
+  healthCheckTimeoutSeconds: number;
+  healthCheckIntervalSeconds: number;
+  healthyThresholdCount: number;
+  unhealthyThresholdCount: number;
+  instanceCounts?: IInstanceCounts;
+  instances?: IInstance[];
+  loadBalancerNames: string[];
+  matcher: any;
+  targetGroupArn: string;
+  targetGroupName: string;
+  port: number;
+  protocol: string;
+  provider?: string;
+  region: string;
+  serverGroups?: string[];
+  targetType?: string;
+  type: string; // returned from clouddriver
+  vpcId?: string;
+  vpcName?: string;
+}
+
+export interface IALBListener {
+  certificates: any[];
+  defaultActions: IListenerAction[];
+  port: number;
+  protocol: string;
+  rules: any[]; // TODO: use & define IListenerRule
+  sslPolicy?: string;
+}
+
+// see https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_Action.html
+export interface IListenerAction {
+  authenticateOidcConfig?: IAuthenticateOidcActionConfig;
+  order?: number;
+  forwardConfig?: IForwardConfig;
+  fixedResponseConfig?: IFixedResponseConfig;
+  redirectConfig?: IRedirectActionConfig;
+  targetGroupArn?: string;
+  type: IListenerActionType;
+}
+
+export interface IAuthenticateOidcActionConfig {
+  authorizationEndpoint: string;
+  authenticationRequestExtraParams?: any;
+  clientId: string;
+  clientSecret?: string;
+  idpLogoutUrl?: string;
+  issuer: string;
+  scope: string;
+  sessionCookieName: string;
+  sessionTimeout?: number;
+  tokenEndpoint: string;
+  userInfoEndpoint: string;
+}
+
+export interface IForwardConfig {
+  targetGroups?: { targetGroupArn: string; weight: number }[];
+}
+
+export interface IFixedResponseConfig {
+  statusCode: string;
+  messageBody?: string;
+  contentType?: string;
+}
+
+export interface IRedirectActionConfig {
+  host?: string;
+  path?: string;
+  port?: string;
+  protocol?: 'HTTP' | 'HTTPS' | '#{protocol}';
+  query?: string;
+  statusCode: 'HTTP_301' | 'HTTP_302';
+}

--- a/app/scripts/modules/ecs/src/ecs.module.ts
+++ b/app/scripts/modules/ecs/src/ecs.module.ts
@@ -39,6 +39,12 @@ import { ECS_PIPELINE_STAGES_RESIZEASG_ECSRESIZEASGSTAGE } from './pipeline/stag
 import { ECS_PIPELINE_STAGES_SCALEDOWNCLUSTER_ECSSCALEDOWNCLUSTERSTAGE } from './pipeline/stages/scaleDownCluster/ecsScaleDownClusterStage';
 import { ECS_PIPELINE_STAGES_SHRINKCLUSTER_ECSSHRINKCLUSTERSTAGE } from './pipeline/stages/shrinkCluster/ecsShrinkClusterStage';
 
+import { ECS_TARGET_GROUP_STATES } from './loadBalancer/targetGroup.states';
+import { EcsLoadBalancerDetails } from './loadBalancer/details/loadBalancerDetails';
+import { EcsLoadBalancerTransformer } from './loadBalancer/loadBalancer.transformer';
+import { EcsLoadBalancerClusterContainer } from './loadBalancer/EcsLoadBalancerClusterContainer';
+import { EcsTargetGroupDetails } from './loadBalancer/details/targetGroupDetails';
+
 require('./ecs.settings');
 
 // load all templates into the $templateCache
@@ -79,6 +85,7 @@ module(ECS_MODULE, [
   ECS_PIPELINE_STAGES_SHRINKCLUSTER_ECSSHRINKCLUSTERSTAGE,
   ECS_SECURITY_GROUP_MODULE,
   ECS_SERVERGROUP_MODULE,
+  ECS_TARGET_GROUP_STATES,
 ]).config(function() {
   CloudProviderRegistry.registerProvider('ecs', {
     name: 'EC2 Container Service',
@@ -92,6 +99,12 @@ module(ECS_MODULE, [
       commandBuilder: 'ecsServerGroupCommandBuilder',
       // configurationService: 'ecsServerGroupConfigurationService',
       scalingActivitiesEnabled: false,
+    },
+    loadBalancer: {
+      transformer: EcsLoadBalancerTransformer,
+      ClusterContainer: EcsLoadBalancerClusterContainer,
+      targetGroupDetails: EcsTargetGroupDetails,
+      details: EcsLoadBalancerDetails,
     },
     instance: {
       detailsTemplateUrl: require('./instance/details/instanceDetails.html'),

--- a/app/scripts/modules/ecs/src/loadBalancer/EcsLoadBalancerClusterContainer.tsx
+++ b/app/scripts/modules/ecs/src/loadBalancer/EcsLoadBalancerClusterContainer.tsx
@@ -29,9 +29,9 @@ export class EcsLoadBalancerClusterContainer extends React.Component<ILoadBalanc
 
   public render(): React.ReactElement<EcsLoadBalancerClusterContainer> {
     const { loadBalancer, showInstances, showServerGroups } = this.props;
-    const alb = loadBalancer as IEcsLoadBalancer;
+    const lb = loadBalancer as IEcsLoadBalancer;
 
-    const TargetGroups = alb.targetGroups.map(targetGroup => {
+    const TargetGroups = lb.targetGroups.map(targetGroup => {
       return (
         <EcsTargetGroup
           key={targetGroup.targetGroupName}

--- a/app/scripts/modules/ecs/src/loadBalancer/EcsLoadBalancerClusterContainer.tsx
+++ b/app/scripts/modules/ecs/src/loadBalancer/EcsLoadBalancerClusterContainer.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { isEqual } from 'lodash';
+
+import { ILoadBalancerClusterContainerProps } from '@spinnaker/core';
+
+import { IEcsLoadBalancer } from '../domain/IEcsLoadBalancer';
+import { EcsTargetGroup } from './TargetGroup';
+
+export class EcsLoadBalancerClusterContainer extends React.Component<ILoadBalancerClusterContainerProps> {
+  public shouldComponentUpdate(nextProps: ILoadBalancerClusterContainerProps) {
+    const serverGroupsDiffer = () =>
+      !isEqual(
+        (nextProps.serverGroups || []).map(g => g.name),
+        (this.props.serverGroups || []).map(g => g.name),
+      );
+    const targetGroupsDiffer = () =>
+      !isEqual(
+        ((nextProps.loadBalancer as IEcsLoadBalancer).targetGroups || []).map(t => t.targetGroupName),
+        ((this.props.loadBalancer as IEcsLoadBalancer).targetGroups || []).map(t => t.targetGroupName),
+      );
+    return (
+      nextProps.showInstances !== this.props.showInstances ||
+      nextProps.showServerGroups !== this.props.showServerGroups ||
+      nextProps.loadBalancer !== this.props.loadBalancer ||
+      serverGroupsDiffer() ||
+      targetGroupsDiffer()
+    );
+  }
+
+  public render(): React.ReactElement<EcsLoadBalancerClusterContainer> {
+    const { loadBalancer, showInstances, showServerGroups } = this.props;
+    const alb = loadBalancer as IEcsLoadBalancer;
+
+    const TargetGroups = alb.targetGroups.map(targetGroup => {
+      return (
+        <EcsTargetGroup
+          key={targetGroup.targetGroupName}
+          loadBalancer={loadBalancer as IEcsLoadBalancer}
+          targetGroup={targetGroup}
+          showInstances={showInstances}
+          showServerGroups={showServerGroups}
+        />
+      );
+    });
+
+    return <div className="cluster-container">{TargetGroups}</div>;
+  }
+}

--- a/app/scripts/modules/ecs/src/loadBalancer/TargetGroup.tsx
+++ b/app/scripts/modules/ecs/src/loadBalancer/TargetGroup.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { UISref, UISrefActive } from '@uirouter/react';
+import { LoadBalancerServerGroup, IInstanceCounts } from '@spinnaker/core';
+
+import { IEcsLoadBalancer, IEcsTargetGroup } from '../domain/IEcsLoadBalancer';
+
+export interface IEcsTargetGroupProps {
+  loadBalancer: IEcsLoadBalancer;
+  targetGroup: IEcsTargetGroup;
+  showServerGroups: boolean;
+  showInstances: boolean;
+}
+
+export class EcsTargetGroup extends React.Component<IEcsTargetGroupProps> {
+  public render(): React.ReactElement<EcsTargetGroup> {
+    const { targetGroup, loadBalancer, showServerGroups } = this.props;
+
+    const params = {
+      loadBalancerName: loadBalancer.name,
+      region: targetGroup.region,
+      accountId: targetGroup.account,
+      name: targetGroup.targetGroupName,
+      vpcId: targetGroup.vpcId,
+      provider: targetGroup.cloudProvider,
+    };
+
+    // info not yet available; HealthCounts component requires it,
+    // but will not render if no values are defined.
+    const emptyInstanceCounts: IInstanceCounts = {
+      up: undefined,
+      down: undefined,
+      starting: undefined,
+      succeeded: undefined,
+      failed: undefined,
+      unknown: undefined,
+      outOfService: undefined,
+    };
+
+    return (
+      <div className="target-group-container container-fluid no-padding">
+        <UISrefActive class="active">
+          <UISref to=".ecsTargetGroupDetails" params={params}>
+            <div className={`clickable clickable-row row no-margin-y target-group-header`}>
+              <div className="col-md-8 target-group-title">{targetGroup.targetGroupName}</div>
+            </div>
+          </UISref>
+        </UISrefActive>
+        {showServerGroups &&
+          targetGroup.serverGroups.map(sgName => {
+            return (
+              <LoadBalancerServerGroup
+                key={sgName}
+                account={targetGroup.account}
+                region={targetGroup.region}
+                serverGroup={{
+                  account: targetGroup.account,
+                  cloudProvider: targetGroup.cloudProvider,
+                  cluster: sgName,
+                  instanceCounts: emptyInstanceCounts,
+                  instances: targetGroup.instances,
+                  name: sgName,
+                  type: targetGroup.type,
+                  region: targetGroup.region,
+                }}
+                showInstances={false} // TODO: use prop when instanceCounts available
+              />
+            );
+          })}
+      </div>
+    );
+  }
+}

--- a/app/scripts/modules/ecs/src/loadBalancer/details/loadBalancerDetails.tsx
+++ b/app/scripts/modules/ecs/src/loadBalancer/details/loadBalancerDetails.tsx
@@ -186,21 +186,29 @@ export class EcsLoadBalancerDetails extends React.Component<
           <span>Select a target group to check the instance health status from the view of its server groups.</span>
         </CollapsibleSection>
         <CollapsibleSection heading="Listeners" defaultExpanded={false}>
-          {loadBalancer.listeners.map((listener, index) => {
-            return (
-              <div key={index}>
-                <span>
-                  <EcsListener listener={listener}></EcsListener>
-                </span>
-              </div>
-            );
-          })}
+          {loadBalancer.listeners ? (
+            loadBalancer.listeners.map((listener, index) => {
+              return (
+                <div key={index}>
+                  <span>
+                    <EcsListener listener={listener}></EcsListener>
+                  </span>
+                </div>
+              );
+            })
+          ) : (
+            <li>No listeners provided.</li>
+          )}
         </CollapsibleSection>
         <CollapsibleSection heading="Firewalls" defaultExpanded={false}>
           <ul>
-            {loadBalancer.securityGroups.map(sg => {
-              return <li key={sg}>{sg}</li>;
-            })}
+            {loadBalancer.securityGroups ? (
+              loadBalancer.securityGroups.map(sg => {
+                return <li key={sg}>{sg}</li>;
+              })
+            ) : (
+              <li>No security groups provided.</li>
+            )}
           </ul>
         </CollapsibleSection>
         <CollapsibleSection heading="Subnets" defaultExpanded={false}>

--- a/app/scripts/modules/ecs/src/loadBalancer/details/loadBalancerDetails.tsx
+++ b/app/scripts/modules/ecs/src/loadBalancer/details/loadBalancerDetails.tsx
@@ -1,0 +1,225 @@
+import React from 'react';
+import { UISref, UISrefActive } from '@uirouter/react';
+import { AccountTag, Application, CollapsibleSection, timestamp, Spinner } from '@spinnaker/core';
+
+import { IEcsLoadBalancer } from '../../domain/IEcsLoadBalancer';
+import { EcsListener } from '../listener';
+
+interface IEcsLoadBalancerFromStateParams {
+  accountId: string;
+  region: string;
+  name: string;
+  vpcId: string;
+}
+
+interface IEcsLoadBalancerDetailsState {
+  loadBalancer: IEcsLoadBalancer;
+  loadBalancerNotFound?: string;
+  loading: boolean;
+  refreshListenerUnsubscribe: () => void;
+}
+
+export interface IEcsLoadBalancerDetailsProps {
+  app: Application;
+  accountId: string;
+  loadBalancer: IEcsLoadBalancerFromStateParams;
+}
+
+export class EcsLoadBalancerDetails extends React.Component<
+  IEcsLoadBalancerDetailsProps,
+  IEcsLoadBalancerDetailsState
+> {
+  constructor(props: IEcsLoadBalancerDetailsProps) {
+    super(props);
+    this.state = {
+      loading: true,
+      loadBalancer: undefined,
+      refreshListenerUnsubscribe: () => {},
+    };
+
+    props.app
+      .getDataSource('loadBalancers')
+      .ready()
+      .then(() => this.extractLoadBalancer());
+  }
+
+  public componentWillUnmount(): void {
+    this.state.refreshListenerUnsubscribe();
+  }
+
+  private extractLoadBalancer(): void {
+    const { name, region } = this.props.loadBalancer;
+    const loadBalancer: IEcsLoadBalancer = this.props.app
+      .getDataSource('loadBalancers')
+      .data.find((test: IEcsLoadBalancer) => {
+        return test.name === name && test.account === this.props.loadBalancer.accountId && test.region === region;
+      });
+
+    this.setState({
+      loading: false,
+      loadBalancer,
+    });
+    this.state.refreshListenerUnsubscribe();
+
+    if (loadBalancer) {
+      this.setState({
+        refreshListenerUnsubscribe: this.props.app
+          .getDataSource('loadBalancers')
+          .onRefresh(null, () => this.extractLoadBalancer()),
+      });
+    } else {
+      this.setState({
+        refreshListenerUnsubscribe: () => {},
+      });
+    }
+  }
+
+  public render(): React.ReactElement<EcsLoadBalancerDetails> {
+    const loadBalancerName = this.props.loadBalancer.name;
+    const { loadBalancer, loading } = this.state;
+    const { accountId } = this.props;
+
+    const CloseButton = (
+      <div className="close-button">
+        <UISref to="^">
+          <span className="glyphicon glyphicon-remove" />
+        </UISref>
+      </div>
+    );
+
+    const loadingHeader = () => (
+      <div className="header">
+        {CloseButton}
+        <div className="horizontal center middle">
+          <Spinner size="small" />
+        </div>
+      </div>
+    );
+
+    const notFoundContent = () => (
+      <div className="content">
+        <div className="content-section">
+          <div className="content-body text-center">
+            <h3>Load balancer not found.</h3>
+          </div>
+        </div>
+      </div>
+    );
+
+    const loadBalancerHeader = () => (
+      <div className="header">
+        {CloseButton}
+        <div className="header-text horizontal middle">
+          <i className="fa icon-sitemap" />
+          <h3 className="horizontal middle space-between flex-1">{loadBalancerName}</h3>
+        </div>
+      </div>
+    );
+
+    const loadBalancerContent = () => (
+      <div className="content">
+        <CollapsibleSection heading="Load Balancer Details" defaultExpanded={true}>
+          <dl className="dl-horizontal dl-flex">
+            <dt>Created</dt>
+            <dd>{timestamp(loadBalancer.createdTime)}</dd>
+            <dt>In</dt>
+            <dd>
+              <AccountTag account={accountId} />
+              <br />
+              {loadBalancer.region}
+            </dd>
+            <dt>VPC</dt>
+            <dd>{loadBalancer.vpcId}</dd>
+            <dt>Type</dt>
+            <dd>{loadBalancer.loadBalancerType}</dd>
+            <dt>IP Type</dt>
+            <dd>{loadBalancer.ipAddressType}</dd>
+          </dl>
+          <dl className="horizontal-when-filters-collapsed">
+            <dt>Availability Zones</dt>
+            <dd>
+              <ul>
+                {loadBalancer.availabilityZones.map(az => {
+                  return <li key={az}>{az}</li>;
+                })}
+              </ul>
+            </dd>
+          </dl>
+          <dl className="horizontal-when-filters-collapsed">
+            <dt>Target Groups</dt>
+            <dd>
+              <ul>
+                {loadBalancer.targetGroups.map(tg => {
+                  return (
+                    <li key={tg.targetGroupName}>
+                      <UISrefActive class="active">
+                        <UISref
+                          to="^.ecsTargetGroupDetails"
+                          params={{
+                            loadBalancerName: loadBalancer.name,
+                            region: loadBalancer.region,
+                            accountId: loadBalancer.account,
+                            name: tg.targetGroupName,
+                            vpcId: tg.vpcId,
+                            provider: loadBalancer.cloudProvider,
+                          }}
+                        >
+                          <a>{tg.targetGroupName}</a>
+                        </UISref>
+                      </UISrefActive>
+                    </li>
+                  );
+                })}
+              </ul>
+            </dd>
+          </dl>
+          <dl className="horizontal-when-filters-collapsed">
+            <dt>DNS Name</dt>
+            <dd>
+              <a target="_blank" href={'http://' + loadBalancer.dnsname}>
+                {loadBalancer.dnsname}
+              </a>
+            </dd>
+          </dl>
+        </CollapsibleSection>
+        <CollapsibleSection heading="Status" defaultExpanded={false}>
+          <span>Select a target group to check the instance health status from the view of its server groups.</span>
+        </CollapsibleSection>
+        <CollapsibleSection heading="Listeners" defaultExpanded={false}>
+          {loadBalancer.listeners.map((listener, index) => {
+            return (
+              <div key={index}>
+                <span>
+                  <EcsListener listener={listener}></EcsListener>
+                </span>
+              </div>
+            );
+          })}
+        </CollapsibleSection>
+        <CollapsibleSection heading="Firewalls" defaultExpanded={false}>
+          <ul>
+            {loadBalancer.securityGroups.map(sg => {
+              return <li key={sg}>{sg}</li>;
+            })}
+          </ul>
+        </CollapsibleSection>
+        <CollapsibleSection heading="Subnets" defaultExpanded={false}>
+          <ul>
+            {loadBalancer.subnets.map(subnet => {
+              return <li key={subnet}>{subnet}</li>;
+            })}
+          </ul>
+        </CollapsibleSection>
+      </div>
+    );
+
+    return (
+      <div className="details-panel">
+        {loading && loadingHeader()}
+        {!loading && loadBalancerHeader()}
+        {!loading && !loadBalancer && notFoundContent()}
+        {!loading && loadBalancer && loadBalancerContent()}
+      </div>
+    );
+  }
+}

--- a/app/scripts/modules/ecs/src/loadBalancer/details/targetGroupDetails.tsx
+++ b/app/scripts/modules/ecs/src/loadBalancer/details/targetGroupDetails.tsx
@@ -1,0 +1,243 @@
+import React from 'react';
+import { UISref, UISrefActive } from '@uirouter/react';
+import { AccountTag, Application, CollapsibleSection, Spinner } from '@spinnaker/core';
+
+import { IEcsTargetGroup, IEcsLoadBalancer } from '../../domain/IEcsLoadBalancer';
+
+interface IEcsTargetGroupFromStateParams {
+  loadBalancerName: string;
+  targetGroupName: string;
+  region: string;
+  vpcId: string;
+}
+
+interface IEcsTargetGroupDetailsState {
+  loadBalancer: IEcsLoadBalancer;
+  targetGroup: IEcsTargetGroup;
+  targetGroupNotFound?: string;
+  loading: boolean;
+  refreshListenerUnsubscribe: () => void;
+}
+
+export interface IEcsTargetGroupProps {
+  app: Application;
+  accountId: string;
+  name: string;
+  targetGroup: IEcsTargetGroupFromStateParams;
+  provider: string;
+}
+
+export class EcsTargetGroupDetails extends React.Component<IEcsTargetGroupProps, IEcsTargetGroupDetailsState> {
+  constructor(props: IEcsTargetGroupProps) {
+    super(props);
+    this.state = {
+      loading: true,
+      targetGroup: undefined,
+      loadBalancer: undefined,
+      refreshListenerUnsubscribe: () => {},
+    };
+
+    props.app
+      .getDataSource('loadBalancers')
+      .ready()
+      .then(() => this.extractTargetGroup());
+  }
+
+  public componentWillUnmount(): void {
+    this.state.refreshListenerUnsubscribe();
+  }
+
+  private extractTargetGroup(): void {
+    const { loadBalancerName, region, targetGroupName } = this.props.targetGroup;
+    const loadBalancer: IEcsLoadBalancer = this.props.app
+      .getDataSource('loadBalancers')
+      .data.find((test: IEcsLoadBalancer) => {
+        return test.name === loadBalancerName && test.account === this.props.accountId && test.region === region;
+      });
+
+    this.setState({
+      loadBalancer,
+    });
+    this.state.refreshListenerUnsubscribe();
+
+    if (!loadBalancer) {
+      this.setState({
+        loading: false,
+        targetGroup: null,
+      });
+    } else {
+      const targetGroup: IEcsTargetGroup = loadBalancer.targetGroups.find(tg => tg.targetGroupName === targetGroupName);
+      if (!targetGroup) {
+        this.setState({
+          loading: false,
+          targetGroup: null,
+        });
+      }
+
+      if (targetGroup) {
+        this.setState({
+          loading: false,
+          targetGroup,
+        });
+
+        if (targetGroup) {
+          this.setState({
+            refreshListenerUnsubscribe: this.props.app
+              .getDataSource('loadBalancers')
+              .onRefresh(null, () => this.extractTargetGroup()),
+          });
+        } else {
+          this.setState({
+            refreshListenerUnsubscribe: () => {},
+          });
+        }
+      }
+    }
+  }
+
+  public render(): React.ReactElement<EcsTargetGroupDetails> {
+    const { name, accountId } = this.props;
+    const region = this.props.targetGroup.region;
+    const { targetGroup, loadBalancer, loading } = this.state;
+
+    const CloseButton = (
+      <div className="close-button">
+        <UISref to="^">
+          <span className="glyphicon glyphicon-remove" />
+        </UISref>
+      </div>
+    );
+
+    const loadingHeader = () => (
+      <div className="header">
+        {CloseButton}
+        <div className="horizontal center middle">
+          <Spinner size="small" />
+        </div>
+      </div>
+    );
+
+    const notFoundContent = () => (
+      <div className="content">
+        <div className="content-section">
+          <div className="content-body text-center">
+            <h3>Target group not found.</h3>
+          </div>
+        </div>
+      </div>
+    );
+
+    const targetGroupHeader = () => (
+      <div className="header">
+        <div className="header-text horizontal middle">
+          <i className="fa fa-crosshairs icon" aria-hidden="true"></i>
+          <h3 className="horizontal middle space-between flex-1">{name}</h3>
+        </div>
+      </div>
+    );
+
+    const targetGroupContent = () => (
+      <div className="content">
+        <CollapsibleSection heading="Target Group Details" defaultExpanded={true}>
+          <dl className="dl-horizontal dl-flex">
+            <dt>In</dt>
+            <dd>
+              <AccountTag account={accountId}></AccountTag>
+              <br />
+              {targetGroup.region}
+            </dd>
+            <dt>VPC</dt>
+            <dd>{targetGroup.vpcId}</dd>
+            <dt>Protocol</dt>
+            <dd>{targetGroup.protocol}</dd>
+            <dt>Port</dt>
+            <dd>{targetGroup.port}</dd>
+            <dt>Target Type</dt>
+            <dd>{targetGroup.targetType.toUpperCase()}</dd>
+          </dl>
+          <dl className="horizontal-when-filters-collapsed">
+            <dt>Load Balancers</dt>
+            <dd>
+              {/* TODO: use UISref to display/highlight LBs in this app. See core/.../LoadBalancer.tsx */}
+              <ul className="collapse-margin-on-filter-collapse">
+                {targetGroup.loadBalancerNames.map((lb, i) => {
+                  return <li key={i}>{lb}</li>;
+                })}
+              </ul>
+            </dd>
+          </dl>
+          <dl className="horizontal-when-filters-collapsed">
+            <dt>Load Balancer DNS Name</dt>
+            <dd>
+              <a target="_blank" href={'http://' + loadBalancer.dnsname}>
+                {loadBalancer.dnsname}
+              </a>
+            </dd>
+          </dl>
+          <dl className="horizontal-when-filters-collapsed">
+            <dt>Server Groups</dt>
+            <dd>
+              <ul className="collapse-margin-on-filter-collapse">
+                {targetGroup.serverGroups.map((sg, i) => {
+                  return (
+                    <li key={i}>
+                      <UISrefActive class="active">
+                        <UISref
+                          to="^.serverGroup"
+                          params={{
+                            region: region,
+                            accountId: accountId,
+                            serverGroup: sg,
+                            provider: 'ecs',
+                          }}
+                        >
+                          <a>{sg}</a>
+                        </UISref>
+                      </UISrefActive>
+                    </li>
+                  );
+                })}
+              </ul>
+            </dd>
+          </dl>
+        </CollapsibleSection>
+        <CollapsibleSection heading="Health Checks" defaultExpanded={false}>
+          <dl className="horizontal-when-filters-collapsed">
+            <dt>Target</dt>
+            <dd>
+              {targetGroup.healthCheckProtocol}:{targetGroup.healthCheckPort}
+              {targetGroup.healthCheckPath}
+            </dd>
+            <dt>Timeout</dt>
+            <dd>{targetGroup.healthCheckTimeoutSeconds} seconds</dd>
+            <dt>Interval</dt>
+            <dd>{targetGroup.healthCheckIntervalSeconds} seconds</dd>
+            <dt>Healthy Threshold</dt>
+            <dd>{targetGroup.healthyThresholdCount}</dd>
+            <dt>Unhealthy Threshold</dt>
+            <dd>{targetGroup.unhealthyThresholdCount}</dd>
+            <dt>Matcher</dt>
+            <dd>HTTP Code(s): {targetGroup.matcher.httpCode}</dd>
+          </dl>
+        </CollapsibleSection>
+        <CollapsibleSection heading="Attributes" defaultExpanded={false}>
+          <dl>
+            <dt>Deregistration Delay Timeout</dt>
+            <dd>{targetGroup.attributes['deregistration_delay.timeout_seconds']} seconds</dd>
+            <dt>Stickiness Enabled</dt>
+            <dd>{targetGroup.attributes['stickiness.enabled']}</dd>
+          </dl>
+        </CollapsibleSection>
+      </div>
+    );
+
+    return (
+      <div className="details-panel">
+        {loading && loadingHeader()}
+        {!loading && targetGroupHeader()}
+        {!loading && !targetGroup && notFoundContent()}
+        {!loading && targetGroup && targetGroupContent()}
+      </div>
+    );
+  }
+}

--- a/app/scripts/modules/ecs/src/loadBalancer/details/targetGroupDetails.tsx
+++ b/app/scripts/modules/ecs/src/loadBalancer/details/targetGroupDetails.tsx
@@ -160,9 +160,13 @@ export class EcsTargetGroupDetails extends React.Component<IEcsTargetGroupProps,
             <dd>
               {/* TODO: use UISref to display/highlight LBs in this app. See core/.../LoadBalancer.tsx */}
               <ul className="collapse-margin-on-filter-collapse">
-                {targetGroup.loadBalancerNames.map((lb, i) => {
-                  return <li key={i}>{lb}</li>;
-                })}
+                {targetGroup.loadBalancerNames ? (
+                  targetGroup.loadBalancerNames.map((lb, i) => {
+                    return <li key={i}>{lb}</li>;
+                  })
+                ) : (
+                  <li>No load balncers provided.</li>
+                )}
               </ul>
             </dd>
           </dl>
@@ -217,15 +221,15 @@ export class EcsTargetGroupDetails extends React.Component<IEcsTargetGroupProps,
             <dt>Unhealthy Threshold</dt>
             <dd>{targetGroup.unhealthyThresholdCount}</dd>
             <dt>Matcher</dt>
-            <dd>HTTP Code(s): {targetGroup.matcher.httpCode}</dd>
+            <dd>HTTP Code(s): {targetGroup && targetGroup.matcher ? targetGroup.matcher.httpCode : 'None'}</dd>
           </dl>
         </CollapsibleSection>
         <CollapsibleSection heading="Attributes" defaultExpanded={false}>
           <dl>
             <dt>Deregistration Delay Timeout</dt>
-            <dd>{targetGroup.attributes['deregistration_delay.timeout_seconds']} seconds</dd>
+            <dd>{targetGroup.attributes['deregistration_delay.timeout_seconds'] || 0} seconds</dd>
             <dt>Stickiness Enabled</dt>
-            <dd>{targetGroup.attributes['stickiness.enabled']}</dd>
+            <dd>{targetGroup.attributes['stickiness.enabled'] || 'N/A'}</dd>
           </dl>
         </CollapsibleSection>
       </div>

--- a/app/scripts/modules/ecs/src/loadBalancer/listener.tsx
+++ b/app/scripts/modules/ecs/src/loadBalancer/listener.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+
+import { IALBListener } from '../domain/IEcsLoadBalancer';
+
+export interface IEcsListenerProps {
+  listener: IALBListener;
+}
+
+export class EcsListener extends React.Component<IEcsListenerProps> {
+  constructor(props: IEcsListenerProps) {
+    super(props);
+  }
+
+  private getTargetGroupNameFromArn(arn: string): string {
+    const parts = arn.split('/');
+    if (parts.length < 0) {
+      return arn;
+    }
+    return parts[1];
+  }
+
+  public render(): React.ReactElement<EcsListener> {
+    const { port, protocol, defaultActions } = this.props.listener;
+
+    // TODO: retrieve and display 'rules' in addition to default actions
+    return (
+      <div>
+        <h4>
+          {protocol}:{port}
+        </h4>
+        <div style={{ paddingLeft: 10 }}>
+          <i>default actions</i>
+          <ul>
+            {defaultActions.map((action, i) => {
+              if (action.type == 'forward') {
+                return (
+                  <li key={i}>
+                    &rarr;
+                    <i className="fa fa-fw fa-crosshairs icon" aria-hidden="true"></i>
+                    <span>
+                      {action.targetGroupArn ||
+                        action.forwardConfig.targetGroups.map(tg => {
+                          return this.getTargetGroupNameFromArn(tg.targetGroupArn);
+                        })}
+                    </span>
+                  </li>
+                );
+              } else {
+                return (
+                  <li key={i}>
+                    {action.type}:{' '}
+                    {action.redirectConfig.statusCode ||
+                      action.fixedResponseConfig.statusCode ||
+                      action.authenticateOidcConfig.clientId}
+                  </li>
+                );
+              }
+            })}
+          </ul>
+        </div>
+      </div>
+    );
+  }
+}

--- a/app/scripts/modules/ecs/src/loadBalancer/listener.tsx
+++ b/app/scripts/modules/ecs/src/loadBalancer/listener.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
-import { IALBListener } from '../domain/IEcsLoadBalancer';
+import { IEcsListener } from '../domain/IEcsLoadBalancer';
 
 export interface IEcsListenerProps {
-  listener: IALBListener;
+  listener: IEcsListener;
 }
 
 export class EcsListener extends React.Component<IEcsListenerProps> {
@@ -51,7 +51,8 @@ export class EcsListener extends React.Component<IEcsListenerProps> {
                     {action.type}:{' '}
                     {action.redirectConfig.statusCode ||
                       action.fixedResponseConfig.statusCode ||
-                      action.authenticateOidcConfig.clientId}
+                      action.authenticateOidcConfig.clientId ||
+                      action.authenticateCognitoActionConfig.userPoolDomain}
                   </li>
                 );
               }

--- a/app/scripts/modules/ecs/src/loadBalancer/loadBalancer.transformer.ts
+++ b/app/scripts/modules/ecs/src/loadBalancer/loadBalancer.transformer.ts
@@ -1,0 +1,16 @@
+import { IEcsLoadBalancerSourceData, IEcsLoadBalancer, IEcsTargetGroup } from '../domain/IEcsLoadBalancer';
+
+export class EcsLoadBalancerTransformer {
+  public normalizeLoadBalancer(loadBalancer: IEcsLoadBalancerSourceData): IEcsLoadBalancer {
+    loadBalancer.targetGroups.forEach((tg: IEcsTargetGroup) => {
+      tg.region = loadBalancer.region;
+      tg.account = loadBalancer.account;
+      tg.cloudProvider = loadBalancer.cloudProvider;
+      if (loadBalancer.targetGroupServices) {
+        const tgServiceMap = loadBalancer.targetGroupServices;
+        tg.serverGroups = tgServiceMap[tg.targetGroupArn];
+      }
+    });
+    return loadBalancer;
+  }
+}

--- a/app/scripts/modules/ecs/src/loadBalancer/targetGroup.states.ts
+++ b/app/scripts/modules/ecs/src/loadBalancer/targetGroup.states.ts
@@ -1,0 +1,58 @@
+import { module } from 'angular';
+import { StateParams } from '@uirouter/angularjs';
+
+import { APPLICATION_STATE_PROVIDER, ApplicationStateProvider, INestedState } from '@spinnaker/core';
+
+import { EcsTargetGroupDetails } from '../loadBalancer/details/targetGroupDetails';
+//import { IEcsTargetGroup } from '../domain/IEcsLoadBalancer';
+
+export const ECS_TARGET_GROUP_STATES = 'spinnaker.ecs.loadBalancer.targetGroup.states';
+module(ECS_TARGET_GROUP_STATES, [APPLICATION_STATE_PROVIDER]).config([
+  'applicationStateProvider',
+  (applicationStateProvider: ApplicationStateProvider) => {
+    const ecsTargetGroupDetails: INestedState = {
+      name: 'ecsTargetGroupDetails',
+      url: '/ecsTargetGroupDetails/:provider/:accountId/:region/:vpcId/:loadBalancerName/:name',
+      params: {
+        vpcId: {
+          value: null,
+          squash: true,
+        },
+      },
+      views: {
+        'detail@../insight': {
+          component: EcsTargetGroupDetails,
+          $type: 'react',
+        },
+      },
+      resolve: {
+        accountId: ['$stateParams', ($stateParams: StateParams) => $stateParams.accountId],
+        name: ['$stateParams', ($stateParams: StateParams) => $stateParams.name],
+        provider: ['$stateParams', ($stateParams: StateParams) => $stateParams.provider],
+        // resolve flat params into an IEcsTargetGroup
+        targetGroup: [
+          '$stateParams',
+          ($stateParams: StateParams) => {
+            return {
+              loadBalancerName: $stateParams.loadBalancerName,
+              targetGroupName: $stateParams.name,
+              accountId: $stateParams.accountId,
+              region: $stateParams.region,
+              vpcId: $stateParams.vpcId,
+            };
+          },
+        ],
+      },
+      data: {
+        pageTitleDetails: {
+          title: 'Target Group Details',
+          nameParam: 'name',
+          accountParam: 'accountId',
+          regionParam: 'region',
+        },
+      },
+    };
+
+    applicationStateProvider.addInsightDetailState(ecsTargetGroupDetails);
+  },
+]);


### PR DESCRIPTION
Implements https://github.com/spinnaker/spinnaker/issues/4797

Depends on: https://github.com/spinnaker/clouddriver/pull/4526

Adds basic ECS load balancer and target group views to deck.

### screenshots

* ECS load balancers on */loadBalaners* page
<img width="478" alt="ecs_lbs" src="https://user-images.githubusercontent.com/34254888/79517123-24911800-8002-11ea-995b-5c08be060144.PNG">

* ECS load balancers detail pane
<img width="501" alt="ecs_lb_details" src="https://user-images.githubusercontent.com/34254888/79517114-193dec80-8002-11ea-8d27-4399ccecd080.PNG">


* ECS target group detail pane
<img width="514" alt="ecs_tg_details" src="https://user-images.githubusercontent.com/34254888/79517134-2eb31680-8002-11ea-9c38-802f8d5afdb3.PNG">

* ECS load balanced server group display (SG pane unchanged, notice center highlight)
<img width="440" alt="ecs_lb_serverGroups_single_tg" src="https://user-images.githubusercontent.com/34254888/79517143-34a8f780-8002-11ea-9821-df71989dbf22.PNG">

* ECS load balanced server group display for service with multiple target groups (SG pane unchanged, notice center highlight)
<img width="434" alt="ecs_lb_serverGroups_multi_tgs" src="https://user-images.githubusercontent.com/34254888/79517150-3a9ed880-8002-11ea-83c3-0ca518f6b48c.PNG">


