### PR TITLE
feat(core): Include SUCCEEDED status in ITaskStatus

### DIFF
--- a/packages/mocks/src/mockTask.ts
+++ b/packages/mocks/src/mockTask.ts
@@ -21,7 +21,7 @@ export const mockOrchestratedItem: IOrchestratedItem = {
   runningTimeInMs: 40000,
 };
 
-type ITaskStatus = 'TERMINAL' | 'NOT_STARTED' | 'CANCELED' | 'RUNNING';
+type ITaskStatus = 'TERMINAL' | 'NOT_STARTED' | 'CANCELED' | 'RUNNING' | 'SUCCEEDED';
 export const createMockOrchestratedItem = (status: ITaskStatus): IOrchestratedItem => {
   if (status === 'TERMINAL') {
     return {


### PR DESCRIPTION
Added `SUCCEEDED` status since that should also be included in the enum.