### PR TITLE
fix(core/managed): make snake case enum values link properly to dashed URLs

### DIFF
--- a/app/scripts/modules/core/src/managed/ManagedResourceStatusIndicator.tsx
+++ b/app/scripts/modules/core/src/managed/ManagedResourceStatusIndicator.tsx
@@ -196,7 +196,9 @@ const LearnMoreLink = ({ resourceSummary }: { resourceSummary: IManagedResourceS
   <a
     target="_blank"
     onClick={() => logClick('Status docs link', resourceSummary.id, resourceSummary.status)}
-    href={`https://www.spinnaker.io/guides/user/managed-delivery/resource-status/#${resourceSummary.status.toLowerCase()}`}
+    href={`https://www.spinnaker.io/guides/user/managed-delivery/resource-status/#${resourceSummary.status
+      .toLowerCase()
+      .replace('_', '-')}`}
   >
     Learn more
   </a>


### PR DESCRIPTION
we deep-link to slugs in the docs that are dashed, but until now all the enum values for these statuses have been single words. [Now that we have `CURRENTLY_UNRESOLVABLE`](https://github.com/spinnaker/deck/pull/8189) we need to map to the right casing to make the link work.