### PR TITLE
fix(UI): add stage summaries to hydrated graphs

### DIFF
--- a/app/scripts/modules/core/src/pipeline/service/execution.service.ts
+++ b/app/scripts/modules/core/src/pipeline/service/execution.service.ts
@@ -494,6 +494,7 @@ export class ExecutionService {
       });
       unhydrated.hydrated = true;
       unhydrated.graphStatusHash = hydrated.graphStatusHash;
+      unhydrated.stageSummaries = hydrated.stageSummaries;
       return unhydrated;
     });
     unhydrated.hydrator = Promise.resolve(executionHydrator);


### PR DESCRIPTION
When hydrating an execution, we don't add the stage summaries to it. This results in some of the fields not showing, like stage comments.

This PR should fix the problem.