### PR TITLE
chore(ci): don't run CI on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
   ci:
     # Meta-job that depends on the other job statuses.  Branch protection then checks this job status.
     name: Deck CI
+    if: startsWith(github.repository, 'spinnaker/')
     needs: [test, build, functional-tests, packages]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This is the [same set up we have on all the Java repositories](https://github.com/spinnaker/clouddriver/blob/10cf7883cb30209492ac660b31fd40c3fc0901ae/.github/workflows/build.yml#L15).