### PR TITLE
fix(plugins): allow one of the plugin metadata sources to fail withou…

### DIFF
--- a/app/scripts/modules/core/src/plugins/plugin.registry.spec.ts
+++ b/app/scripts/modules/core/src/plugins/plugin.registry.spec.ts
@@ -51,6 +51,17 @@ describe('PluginRegistry', () => {
     expect(spy).toHaveBeenCalled();
   });
 
+  it('loadPluginManifest() should not throw if passed a metadata promise that will be rejected', async () => {
+    const promise = Promise.reject(new Error('Could not load metadata from Gate'));
+    let result;
+    try {
+      result = await pluginRegistry.loadPluginManifest('gate', '/plugins/deck/plugin-manifest.json', promise);
+    } catch (e) {
+      expect(e).not.toBeDefined();
+    }
+    expect(result).toEqual([]);
+  });
+
   describe('loadPlugins()', () => {
     let pluginModule: { plugin: IDeckPlugin };
     beforeEach(() => {

--- a/app/scripts/modules/core/src/plugins/plugin.registry.ts
+++ b/app/scripts/modules/core/src/plugins/plugin.registry.ts
@@ -139,7 +139,7 @@ export class PluginRegistry {
       return plugins.map(pluginMetaData => this.registerPluginMetaData(source, pluginMetaData));
     } catch (error) {
       console.error(`Error loading plugin manifest from ${location}`);
-      throw error;
+      return [];
     }
   }
 


### PR DESCRIPTION
…t breaking the other.

If the Deck server doesn't have a `/plugins-manifest.json`, then Deck should still be able to ask Gate for its plugins manifest.
