### PR TITLE
Npm packlist fix

### DIFF
--- a/packages/pluginsdk/package.json
+++ b/packages/pluginsdk/package.json
@@ -6,7 +6,7 @@
   "typings": "dist/index.d.ts",
   "license": "Apache-2.0",
   "scripts": {
-    "clean": "shx rm -rf dist",
+    "clean": "npx shx rm -rf dist",
     "build": "rollup -c",
     "watch": "rollup -c -w",
     "postinstall": "./scripts/syncPeerDependencies.js",

--- a/packages/pluginsdk/package.json
+++ b/packages/pluginsdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/pluginsdk",
   "description": "Provides blessed opinions (rollup, code format, lint) and packages (react, etc) to plugin developers",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "module": "dist/index.js",
   "typings": "dist/index.d.ts",
   "license": "Apache-2.0",

--- a/packages/pluginsdk/scaffold/package.json
+++ b/packages/pluginsdk/scaffold/package.json
@@ -9,9 +9,6 @@
     "watch": "rollup -c -w",
     "postinstall": "check-plugin && check-peer-dependencies"
   },
-  "files": [
-    "build/dist"
-  ],
   "dependencies": {
     "@spinnaker/pluginsdk": "latest"
   },

--- a/packages/pluginsdk/scripts/check-plugin/linters/lint.package.json.js
+++ b/packages/pluginsdk/scripts/check-plugin/linters/lint.package.json.js
@@ -26,7 +26,7 @@ function checkPackageJson(report) {
   checkPackageJsonField('scripts.clean', 'npx shx rm -rf build');
   checkPackageJsonField('scripts.build', 'rollup -c');
   checkPackageJsonField('scripts.watch', 'rollup -c -w');
-  checkPackageJsonField('scripts.postinstall', 'lint-plugin && check-peer-dependencies');
+  checkPackageJsonField('scripts.postinstall', 'check-plugin && check-peer-dependencies');
 
   const bundlesFiles = pkgJson.files && pkgJson.files.includes('build/dist');
   const bundlesFilesFixer = () => {

--- a/packages/pluginsdk/scripts/scaffold.js
+++ b/packages/pluginsdk/scripts/scaffold.js
@@ -48,6 +48,7 @@ function updatePackageJson(pkgJsonPath, scaffoldPath) {
   const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath).toString());
   pkgJson.name = path.basename(scaffoldPath);
   pkgJson.dependencies['@spinnaker/pluginsdk'] = pluginSdkVersion;
+  pkgJson.files = ['build/dist'];
   fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2));
 }
 

--- a/packages/pluginsdk/tsconfig.json
+++ b/packages/pluginsdk/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../tsconfig.base",
-  "exclude": ["scaffold"],
+  "exclude": ["scaffold", "dist"],
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "src",


### PR DESCRIPTION
npm v6.x under the hood uses `npm-packlist` to generate a tarball of the package contents via `npm pack`.  In `npm-packlist` version 1.x, it parses the nested `scaffold/package.json` and processes the `files: ["build/dist"]` entry.  This caused the scaffolding contents to be ignored (because they don't match the `files` list).

This fix changes the scaffold command so it adds the `files: ["build/dist"]` entry to the scaffolded `package.json` in a post-process.

When `npm` updates to `npm-packlist` v2.x (perhaps in npm v7.x?) we can remove this workaround.