### PR TITLE
Pluginsdk 0.0.10

### DIFF
--- a/packages/pluginsdk/package.json
+++ b/packages/pluginsdk/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "check-peer-dependencies": "^2.0.1",
+    "lodash": "^4.17.15",
     "readline-sync": "^1.4.10",
     "strip-json-comments": "^3.1.0",
     "yargs": "^15.3.1"

--- a/packages/pluginsdk/package.json
+++ b/packages/pluginsdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/pluginsdk",
   "description": "Provides blessed opinions (rollup, code format, lint) and packages (react, etc) to plugin developers",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "module": "dist/index.js",
   "typings": "dist/index.d.ts",
   "license": "Apache-2.0",

--- a/packages/pluginsdk/scaffold/package.json
+++ b/packages/pluginsdk/scaffold/package.json
@@ -7,7 +7,7 @@
     "clean": "npx shx rm -rf build",
     "build": "rollup -c",
     "watch": "rollup -c -w",
-    "postinstall": "check-plugin && check-peer-dependencies"
+    "postinstall": "check-plugin && check-peer-dependencies || true"
   },
   "dependencies": {
     "@spinnaker/pluginsdk": "latest"

--- a/packages/pluginsdk/scripts/check-plugin/asserters/assertJsonFile.js
+++ b/packages/pluginsdk/scripts/check-plugin/asserters/assertJsonFile.js
@@ -1,23 +1,15 @@
 const { readJson, writeJson } = require('../util/readWriteJson');
-
-const get = (path, obj) => {
-  return path.split('.').reduce((acc, key) => {
-    return acc === undefined ? undefined : key ? acc[key] : acc;
-  }, obj);
-};
+const { get, set } = require('lodash');
 
 const writeJsonField = (filename, field, val) => {
   const json = readJson(filename);
-  const segments = field.split('.');
-  const tail = segments.pop();
-  const parent = get(segments.join('.'), json);
-  parent[tail] = val;
+  set(json, field, val);
   writeJson(filename, json);
 };
 
 const assertJsonFile = (report, filename, json) => {
   return function assertJsonFile(field, expectedValue) {
-    const currentValue = get(field, json);
+    const currentValue = get(json, field);
     const resolution = `--fix: change ${field} in ${filename} from "${currentValue}" to "${expectedValue}"`;
     const fixer = () => {
       writeJsonField(filename, field, expectedValue);

--- a/packages/pluginsdk/scripts/check-plugin/linters/lint.package.json.js
+++ b/packages/pluginsdk/scripts/check-plugin/linters/lint.package.json.js
@@ -26,7 +26,7 @@ function checkPackageJson(report) {
   checkPackageJsonField('scripts.clean', 'npx shx rm -rf build');
   checkPackageJsonField('scripts.build', 'rollup -c');
   checkPackageJsonField('scripts.watch', 'rollup -c -w');
-  checkPackageJsonField('scripts.postinstall', 'check-plugin && check-peer-dependencies');
+  checkPackageJsonField('scripts.postinstall', 'check-plugin && check-peer-dependencies || true');
 
   const bundlesFiles = pkgJson.files && pkgJson.files.includes('build/dist');
   const bundlesFilesFixer = () => {


### PR DESCRIPTION
Tweaks the scaffold `postinstall` script a bit so it doesn't exit with a failure code.   
Use lodash `set` to deeply set configuration values