### PR TITLE
fix(buildStatus): Change Deck CI to Branch Build to align with the re…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Deck CI
+name: Branch Build
 
 on:
   pull_request:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Spinnaker UI
 
-![Deck CI](https://github.com/spinnaker/deck/workflows/Deck%20CI/badge.svg)
+![Branch Build](https://github.com/spinnaker/deck/workflows/Branch%20Build/badge.svg)
 
 ## Prerequisites
 


### PR DESCRIPTION
…st of the repos

It appears these GHActions are much more integrated, and it's unclear which reference _Actions_ named "Deck CI" and which reference _Jobs_ named "Deck CI". I *think* most of them reference _job names_, but I'm not 100% certain.

This change goes along with https://github.com/spinnaker/spinnaker.github.io/pull/1823 