### PR TITLE
fix(pluginsdk): Fix sourcemaps in typescript config

### DIFF
--- a/packages/pluginsdk/pluginconfig/tsconfig.json
+++ b/packages/pluginsdk/pluginconfig/tsconfig.json
@@ -3,6 +3,8 @@
     "allowSyntheticDefaultImports": true,
     "declaration": true,
     "declarationMap": true,
+    "inlineSources": true,
+    "inlineSourceMap": true,
     "esModuleInterop": true,
     "experimentalDecorators": true,
     "jsx": "react",


### PR DESCRIPTION
This embed the typescript sources into the sourcemap files (index.js.map)