### PR TITLE
fix(core/managed): use smaller icon size for expand/collapse arrows

### DIFF
--- a/app/scripts/modules/core/src/managed/EnvironmentRow.tsx
+++ b/app/scripts/modules/core/src/managed/EnvironmentRow.tsx
@@ -35,8 +35,8 @@ export function EnvironmentRow({ name, resources = [], children }: IEnvironmentR
           <span className={envLabelClasses}>{name}</span>
         </span>
         <div className="expand" onClick={() => setIsCollapsed(!isCollapsed)}>
-          {isCollapsed && <Icon name="accordionExpand" size="medium" />}
-          {!isCollapsed && <Icon name="accordionCollapse" size="medium" />}
+          {isCollapsed && <Icon name="accordionExpand" size="extraSmall" />}
+          {!isCollapsed && <Icon name="accordionCollapse" size="extraSmall" />}
         </div>
         {/* <div className="select">
             <i className={`ico icon-checkbox-unchecked`}/>


### PR DESCRIPTION
itty bitty icon tweak now that Greg has changed the size of the paths for expand/collapse arrows to fill more of their svg canvas.

 i would include screenshots, but in an exciting turn of events switching to the `extraSmall` icon size actually look **_identical_** to the way that things looked before the SVG path itself was changed (back when we were using the `medium` size). The paths did switch to rounded ends, but it's not really that visible at that size. Props to Greg for working his designer magic! 🧙‍♂️ 

cc @gcomstock 