### PR TITLE
fix(core/presentation): properly handle vertical grow/shrink on Modal

### DIFF
--- a/app/scripts/modules/core/src/presentation/modal/Modal.module.css
+++ b/app/scripts/modules/core/src/presentation/modal/Modal.module.css
@@ -122,33 +122,36 @@
 
 .dialogSizer {
   display: grid;
+  grid-template-rows: 1fr;
+  max-height: calc(100vh - 64px);
+  min-height: 320px;
   margin: 0 64px;
 }
 
-.dialog {
-  position: relative;
-  border-radius: 8px;
-  box-shadow: 0 19px 38px rgba(0, 0, 0, 0.3), 0 15px 12px rgba(0, 0, 0, 0.22);
-  overflow: hidden;
-  display: flex;
-  flex-direction: column;
-  max-height: calc(100% - 64px);
-  min-height: 320px;
-  will-change: transform, opacity;
-}
-
 @media belowMobileSize {
-  .dialog {
-    max-height: calc(100% - 32px);
+  .dialogSizer {
+    max-height: calc(100vh - 32px);
     margin: 0 24px;
   }
 }
 
 /* for large screens, place an eventual cap on the height of a modal */
 @media screen and (min-height: 1164px) {
-  .dialog {
+  .dialogSizer {
     max-height: 1100px;
   }
+}
+
+.dialog {
+  display: flex;
+  position: relative;
+  grid-column: 1;
+  grid-row: 1;
+  flex-direction: column;
+  overflow: hidden;
+  border-radius: 8px;
+  box-shadow: 0 19px 38px rgba(0, 0, 0, 0.3), 0 15px 12px rgba(0, 0, 0, 0.22);
+  will-change: transform, opacity;
 }
 
 .dialogWrapper.enter {


### PR DESCRIPTION
Turns out I made a bit of an oopsie on https://github.com/spinnaker/deck/pull/8237 by not moving the _height_ rules out to the new wrapper element when I moved the width rules. That resulted in the height of modals basically always regressing to min-content on smaller height screens (which I didn't notice on my new ginormous monitor). This does some rejiggering to get things back to the right state, mostly by tweaking the height layout to use the same grid mechanics (though not using `minmax()`). There should be effectively zero changes from the behavior we had before https://github.com/spinnaker/deck/pull/8237.

I'd add screenshots for this, but it's really nuanced and has to do with flexing vertically so really multiple before/after videos would be required which seems like a lot of extra work for the scope of this fix 😆 