### PR TITLE
feat(bake): Mark the bake stage as an artifact producer

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/bake/bakeStage.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/bake/bakeStage.js
@@ -16,6 +16,7 @@ module(CORE_PIPELINE_CONFIG_STAGES_BAKE_BAKESTAGE, [CORE_PIPELINE_CONFIG_STAGES_
       description: 'Bakes an image',
       key: 'bake',
       restartable: true,
+      producesArtifacts: true,
       manualExecutionComponent: ManualExecutionBake,
     });
   })


### PR DESCRIPTION
This Just Works™ because the bake stage in orca already puts artifacts in the context and has a `bindProducedArtifacts` task.