### PR TITLE
fix(core/managed): mitigate layout jank on ObjectRow + EnvironmentRow

### DIFF
--- a/app/scripts/modules/core/src/managed/EnvironmentRow.less
+++ b/app/scripts/modules/core/src/managed/EnvironmentRow.less
@@ -21,13 +21,13 @@
     flex: 1 1 auto;
     height: 100%;
     display: flex;
+    justify-content: space-between;
     align-items: center;
     padding-left: 8px;
   }
 
-  .environment-row-status {
-    margin-right: 40px;
-    max-width: 320px;
+  .titleColumn {
+    flex-basis: 50%;
   }
 
   .select {

--- a/app/scripts/modules/core/src/managed/EnvironmentRow.tsx
+++ b/app/scripts/modules/core/src/managed/EnvironmentRow.tsx
@@ -31,15 +31,17 @@ export function EnvironmentRow({ name, resources = [], hasPinnedVersions, childr
     <div className="EnvironmentRow">
       <div className={envRowClasses}>
         <span className="clickableArea">
-          <EnvironmentBadge name={name} critical={isCritical} />
-          <div className="environment-row-status flex-container-h flex-grow flex-pull-right">
+          <div className="titleColumn flex-container-h left middle sp-margin-s-right">
+            <EnvironmentBadge name={name} critical={isCritical} />
+          </div>
+          <div className="flex-container-h flex-grow flex-pull-right">
             {hasPinnedVersions && <StatusBubble iconName="pin" appearance="warning" size="small" />}
           </div>
+          <div className="expand" onClick={() => setIsCollapsed(!isCollapsed)}>
+            {isCollapsed && <Icon name="accordionExpand" size="extraSmall" />}
+            {!isCollapsed && <Icon name="accordionCollapse" size="extraSmall" />}
+          </div>
         </span>
-        <div className="expand" onClick={() => setIsCollapsed(!isCollapsed)}>
-          {isCollapsed && <Icon name="accordionExpand" size="extraSmall" />}
-          {!isCollapsed && <Icon name="accordionCollapse" size="extraSmall" />}
-        </div>
         {/* <div className="select">
             <i className={`ico icon-checkbox-unchecked`}/>
           </div> */}

--- a/app/scripts/modules/core/src/managed/ObjectRow.module.css
+++ b/app/scripts/modules/core/src/managed/ObjectRow.module.css
@@ -41,11 +41,6 @@
   white-space: nowrap;
 }
 
-.metaDataCol {
-  flex-basis: 110px;
-  justify-content: flex-end;
-}
-
 .rowTitle {
   overflow: hidden;
   text-overflow: ellipsis;

--- a/app/scripts/modules/core/src/managed/ObjectRow.tsx
+++ b/app/scripts/modules/core/src/managed/ObjectRow.tsx
@@ -21,8 +21,10 @@ export const ObjectRow = ({ content, icon, title, metadata, depth = 1 }: IObject
           <Icon name={icon} size="medium" appearance="dark" className="sp-margin-s-right" />
           <span className={styles.rowTitle}>{title}</span>
         </div>
-        <div className={styles.col}>{content}</div>
-        <div className={classNames([styles.col, styles.metaDataCol])}>{metadata}</div>
+        <div className={classNames(styles.col, 'flex-grow')}>
+          {content}
+          {metadata && <div className="flex-pull-right">{metadata}</div>}
+        </div>
       </span>
     </div>
   );


### PR DESCRIPTION
We're starting to see the use of flexbox on ObjectRow/EnvironmentRow break down a bit as things get more complicated. We just added some new code to show a StatusBubble on both kinds of rows, and the fact that each section is sized differently depending on its content was making it to where the bubbles were looking... not so great when they happened to show up together:

<img width="1003" alt="Screen Shot 2020-05-04 at 2 36 24 PM" src="https://user-images.githubusercontent.com/1850998/81019163-ede93900-8e1a-11ea-84f1-97e38cfaf0d2.png">

For now I do not have the time nor the mental capacity to try to iron things out in a holistic, long-term viable way. This PR really just band-aids the situation with some changes to the DOM + flex rules to get things to line up a little better. While it does look _better_, it's still not great, as the indent of StatusBubbles on parent/child rows isn't exactly the same as the rows themselves, nor does it make the bubbles line up with each other (I'm not sure which we'd prefer):

<img width="998" alt="Screen Shot 2020-05-04 at 3 15 21 PM" src="https://user-images.githubusercontent.com/1850998/81019294-399be280-8e1b-11ea-8c96-a9bd22b929e7.png">

Longer term, I really think we need to move over to using a grid layout for these rows and make the grid layout resilient to things like the expand/collapse button being there or not, having lots of bubbles vs. only a few, etc. etc. Flexbox is lovely for stacking things on an axis, but it really can't handle layout concerns like this in a way that remains consistent between rows.

(cc @gcomstock)