### PR TITLE
feat(core/presentation): Add a 'defaultValue' prop to SelectInput and RadioButtonInput to apply a default value

### DIFF
--- a/app/scripts/modules/core/src/presentation/forms/inputs/RadioButtonInput.spec.tsx
+++ b/app/scripts/modules/core/src/presentation/forms/inputs/RadioButtonInput.spec.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { RadioButtonInput } from './RadioButtonInput';
+
+const noop = () => {};
+
+describe('<RadioButtonInput />', () => {
+  it('renders radio button inputs', () => {
+    const value = 'b';
+    const options = ['a', 'b', 'c', 'd'];
+    const wrapper = mount(<RadioButtonInput value={value} stringOptions={options} onChange={noop} />);
+    expect(wrapper.find('.RadioButtonInput').length).toBe(1);
+    expect(wrapper.find('input[type="radio"]').length).toBe(4);
+  });
+
+  it('updates the selected item using the value prop', () => {
+    const value = 'b';
+    const options = ['a', 'b', 'c', 'd'];
+    const wrapper = mount(<RadioButtonInput value={value} stringOptions={options} onChange={noop} />);
+    expect(wrapper.find('input[type="radio"][checked=true]').getDOMNode<any>().value).toBe('b');
+    wrapper.setProps({ value: 'c' });
+    expect(wrapper.find('input[type="radio"][checked=true]').getDOMNode<any>().value).toBe('c');
+  });
+
+  it('wires the onChange handler to the radios', () => {
+    const value = 'b';
+    const options = ['a', 'b', 'c', 'd'];
+    const spy = jasmine.createSpy('onChange');
+    const wrapper = mount(<RadioButtonInput value={value} stringOptions={options} onChange={spy} />);
+    wrapper.find('input[type="radio"][value="c"]').simulate('change', { target: { value: 'c' } });
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  describe('defaultValue prop', () => {
+    it('causes the onChange handler to be called with a default value when no value is set', () => {
+      const value = undefined as string;
+      const options = ['a', 'b', 'c', 'd'];
+      const spy = jasmine.createSpy('onChange');
+      mount(<RadioButtonInput value={value} defaultValue={options[0]} stringOptions={options} onChange={spy} />);
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy.calls.mostRecent().args[0].target.value).toBe('a');
+    });
+
+    it('causes the onChange handler to be called with a default value when an invalid value is set', () => {
+      const value = 'x';
+      const options = ['a', 'b', 'c', 'd'];
+      const spy = jasmine.createSpy('onChange');
+      mount(<RadioButtonInput value={value} defaultValue={options[0]} stringOptions={options} onChange={spy} />);
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy.calls.mostRecent().args[0].target.value).toBe('a');
+    });
+
+    it('does not call the onChange handler if no defaultValue is provided', () => {
+      const value = 'x';
+      const options = ['a', 'b', 'c', 'd'];
+      const spy = jasmine.createSpy('onChange');
+      mount(<RadioButtonInput value={value} stringOptions={options} onChange={spy} />);
+      expect(spy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/app/scripts/modules/core/src/presentation/forms/inputs/RadioButtonInput.tsx
+++ b/app/scripts/modules/core/src/presentation/forms/inputs/RadioButtonInput.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { Option } from 'react-select';
+import { isNil } from 'lodash';
 
 import { Markdown } from '../../Markdown';
 import { OmitControlledInputPropsFrom } from './interface';
 
-import { isStringArray, orEmptyString, validationClassName } from './utils';
+import { createFakeReactSyntheticEvent, isStringArray, orEmptyString, validationClassName } from './utils';
 import { IFormInputProps } from './interface';
 
 interface IRadioButtonInputProps
@@ -13,7 +14,15 @@ interface IRadioButtonInputProps
   stringOptions?: string[];
   options?: IRadioButtonOptions[];
   inputClassName?: string;
+  /** When true, will render the radio buttons horizontally */
   inline?: boolean;
+  /**
+   * If the value prop does not match any of the options, this value will be used.
+   * This can be used to ensures that a valid option is always selected (for initial state, for example).
+   * This mechanism calls onChange with the defaultValue.
+   * If this is used, the options prop provided should be stable (useMemo)
+   */
+  defaultValue?: string;
 }
 
 interface IRadioButtonOptions extends Option {
@@ -21,10 +30,17 @@ interface IRadioButtonOptions extends Option {
 }
 
 export const RadioButtonInput = (props: IRadioButtonInputProps) => {
-  const { inline, validation, value, inputClassName, options, stringOptions, ...otherProps } = props;
-  const radioOptions: IRadioButtonOptions[] = isStringArray(stringOptions)
-    ? stringOptions.map(opt => ({ value: opt, label: opt }))
-    : options;
+  const { inline, validation, value, defaultValue, inputClassName, options, stringOptions, ...otherProps } = props;
+  const radioOptions: IRadioButtonOptions[] = useMemo(
+    () => (isStringArray(stringOptions) ? stringOptions.map(opt => ({ value: opt, label: opt })) : options),
+    [options],
+  );
+
+  useEffect(() => {
+    if (!isNil(defaultValue) && !radioOptions.map(opt => opt.value).includes(value)) {
+      props.onChange(createFakeReactSyntheticEvent({ name: props.name, value: defaultValue }));
+    }
+  }, [value, defaultValue, radioOptions]);
 
   const userClassName = orEmptyString(inputClassName);
   const validClassName = validationClassName(validation);

--- a/app/scripts/modules/core/src/presentation/forms/inputs/SelectInput.spec.tsx
+++ b/app/scripts/modules/core/src/presentation/forms/inputs/SelectInput.spec.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { SelectInput } from './SelectInput';
+
+const noop = () => {};
+
+describe('<SelectInput />', () => {
+  it('renders a select with options', () => {
+    const value = 'b';
+    const options = ['a', 'b', 'c', 'd'];
+    const wrapper = mount(<SelectInput value={value} options={options} onChange={noop} />);
+    expect(wrapper.find('.SelectInput').length).toBe(1);
+    expect(wrapper.find('select').length).toBe(1);
+    expect(wrapper.find('option').length).toBe(4);
+  });
+
+  it('updates the selected item using the value prop', () => {
+    const value = 'b';
+    const options = ['a', 'b', 'c', 'd'];
+    const wrapper = mount(<SelectInput value={value} options={options} onChange={noop} />);
+    expect(wrapper.find('select').getDOMNode<HTMLSelectElement>().value).toBe('b');
+    wrapper.setProps({ value: 'c' });
+    expect(wrapper.find('select').getDOMNode<HTMLSelectElement>().value).toBe('c');
+  });
+
+  it('wires the onChange handler to the selected item', () => {
+    const value = 'b';
+    const options = ['a', 'b', 'c', 'd'];
+    const spy = jasmine.createSpy('onChange');
+    const component = mount(<SelectInput value={value} options={options} onChange={spy} />);
+    component.find('select').simulate('change', { target: { value: 'c' } });
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.calls.mostRecent().args[0].target.value).toBe('c');
+  });
+
+  describe('defaultValue prop', () => {
+    it('causes the onChange handler to be called with a default value when no value is set', () => {
+      const value = undefined as string;
+      const options = ['a', 'b', 'c', 'd'];
+      const spy = jasmine.createSpy('onChange');
+      mount(<SelectInput value={value} defaultValue={options[0]} options={options} onChange={spy} />);
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy.calls.mostRecent().args[0].target.value).toBe('a');
+    });
+
+    it('causes the onChange handler to be called with a default value when an invalid value is set', () => {
+      const value = 'x';
+      const options = ['a', 'b', 'c', 'd'];
+      const spy = jasmine.createSpy('onChange');
+      mount(<SelectInput value={value} defaultValue={options[0]} options={options} onChange={spy} />);
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy.calls.mostRecent().args[0].target.value).toBe('a');
+    });
+
+    it('does not call the onChange handler if no defaultValue is provided', () => {
+      const value = 'x';
+      const options = ['a', 'b', 'c', 'd'];
+      const spy = jasmine.createSpy('onChange');
+      mount(<SelectInput value={value} options={options} onChange={spy} />);
+      expect(spy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "int": "protractor protractor.conf.js",
     "modules": "./gradle/buildModules.sh",
     "prettier": "prettier --write 'app/**/*.{js,jsx,ts,tsx,html,css,less}'",
-    "functional": "npm run build && cd test/functional && yarn && npm run test"
+    "functional": "npm run build && cd test/functional && yarn && npm run test",
+    "functional:debug": "npm run build && cd test/functional && yarn && npm run open"
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.4.1",


### PR DESCRIPTION
Applies the default value using 'onChange' when the current value is undefined, or is not an actual value in the options array


The motivation for this new prop is to keep the radio button/select in a valid state.  I'm working on a form where depending on form state, the list of options might change.  If the previous `value` is no longer valid, I want to be able to easily provide a new (valid) value.

Another option is to manage these defaults externally, via state management.  However, as I was writing code like that, it seemed bespoke and not very re-usable.  

```jsx
<SelectInput value={value} defaultValue={options[0]} options={options} />
```