### PR TITLE
feat(mocks): Add Launch Template data mocks

### DIFF
--- a/packages/mocks/package.json
+++ b/packages/mocks/package.json
@@ -8,6 +8,7 @@
     "prepublishOnly": "tsc"
   },
   "devDependencies": {
+    "@spinnaker/amazon": "latest",
     "@spinnaker/core": "latest",
     "@spinnaker/eslint-plugin": "latest",
     "typescript": "~3.8.2"

--- a/packages/mocks/src/amazon/index.ts
+++ b/packages/mocks/src/amazon/index.ts
@@ -1,0 +1,2 @@
+export * from './mockAmazonBlockDeviceMapping';
+export * from './mockAmazonLaunchTemplate';

--- a/packages/mocks/src/amazon/mockAmazonBlockDeviceMapping.ts
+++ b/packages/mocks/src/amazon/mockAmazonBlockDeviceMapping.ts
@@ -1,0 +1,13 @@
+import { IEbsBlockDevice, IBlockDeviceMapping } from '@spinnaker/amazon';
+
+export const createMockEbsBlockDevice = (size?: number, type?: string): IEbsBlockDevice => ({
+  deleteOnTermination: false,
+  encrypted: true,
+  volumeSize: size || 40,
+  volumeType: type || 'standard',
+});
+
+export const createMockBlockDeviceMapping = (customEbs?: IEbsBlockDevice) => ({
+  deviceName: '/dev/sdb',
+  ebs: customEbs || createMockEbsBlockDevice(),
+});

--- a/packages/mocks/src/amazon/mockAmazonBlockDeviceMapping.ts
+++ b/packages/mocks/src/amazon/mockAmazonBlockDeviceMapping.ts
@@ -1,10 +1,10 @@
 import { IEbsBlockDevice, IBlockDeviceMapping } from '@spinnaker/amazon';
 
-export const createMockEbsBlockDevice = (size?: number, type?: string): IEbsBlockDevice => ({
+export const createMockEbsBlockDevice = (options?: { size?: number; type?: string }): IEbsBlockDevice => ({
   deleteOnTermination: false,
   encrypted: true,
-  volumeSize: size || 40,
-  volumeType: type || 'standard',
+  volumeSize: options?.size || 40,
+  volumeType: options?.type || 'standard',
 });
 
 export const createMockBlockDeviceMapping = (customEbs?: IEbsBlockDevice) => ({

--- a/packages/mocks/src/amazon/mockAmazonLaunchTemplate.ts
+++ b/packages/mocks/src/amazon/mockAmazonLaunchTemplate.ts
@@ -1,0 +1,49 @@
+import { IAmazonLaunchTemplate, IIamInstanceProfile, IMetadataOptions, ILaunchTemplateData } from '@spinnaker/amazon';
+import { createMockBlockDeviceMapping } from './mockAmazonBlockDeviceMapping';
+
+export const mockIamInstanceProfile: IIamInstanceProfile = {
+  name: 'testapplicationInstanceProfile',
+};
+
+export const mockMetadataOptions: IMetadataOptions = {
+  httpEndpoint: 'enabled',
+  httpsTokens: 'required',
+};
+
+export const mockLaunchTemplateData: ILaunchTemplateData = {
+  ebsOptimized: true,
+  iamInstanceProfile: mockIamInstanceProfile,
+  imageId: 'ami-0123456789',
+  instanceType: 'm5.large',
+  keyName: 'test',
+  metadataOptions: mockMetadataOptions,
+  monitoring: {
+    enabled: false,
+  },
+  networkInterfaces: [],
+  blockDeviceMappings: [createMockBlockDeviceMapping()],
+  securityGroupIds: ['sg-1', 'sg-2'],
+  securityGroups: [],
+  tagSpecifications: [],
+  userData: 'thisisfakeuserdata',
+};
+
+export const mockLaunchTemplate: IAmazonLaunchTemplate = {
+  createdBy: 'testuser@test.com',
+  createdTime: 1588787656527,
+  defaultVersion: true,
+  launchTemplateData: mockLaunchTemplateData,
+  launchTemplateId: '123456',
+  launchTemplateName: 'testLaunchTemplatev001',
+  versionDescription: 'Test purposes',
+  versionNumber: 1,
+};
+
+export const createCustomMockLaunchTemplate = (name: string, data: ILaunchTemplateData): IAmazonLaunchTemplate => ({
+  ...mockLaunchTemplate,
+  launchTemplateName: name,
+  launchTemplateData: {
+    ...mockLaunchTemplateData,
+    ...data,
+  },
+});

--- a/packages/mocks/yarn.lock
+++ b/packages/mocks/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@spinnaker/amazon@latest":
+  version "0.0.252"
+  resolved "https://registry.yarnpkg.com/@spinnaker/amazon/-/amazon-0.0.252.tgz#36c74bd4a2622b30cc4f81ddd0a1942280fb2212"
+  integrity sha512-qwv9VsBrBm5p7Y5TyytJHqmM57gC8fxfR0Wag262VPQQJgKED5OiLvYTQgUFLddz3PLu8HFitOrDtQ1BHtOwnw==
+
 "@spinnaker/core@latest":
   version "0.0.450"
   resolved "https://registry.yarnpkg.com/@spinnaker/core/-/core-0.0.450.tgz#db3e2d1bd2423e9da737fcc532493edd493ed8ba"


### PR DESCRIPTION
Introduce base and customizable mock data. This will be used in test fixtures through development of the launch template feature.
