### PR TITLE
fix(core/managed): prevent expand/collapse from selecting text

### DIFF
--- a/app/scripts/modules/core/src/managed/EnvironmentRow.less
+++ b/app/scripts/modules/core/src/managed/EnvironmentRow.less
@@ -42,6 +42,7 @@
     align-items: center;
     width: 44px;
     height: 100%;
+    user-select: none;
   }
 
   //   .clickableArea:hover,


### PR DESCRIPTION
I was getting pretty annoyed using the expand/collapse toggle on environments because whenever i clicked it just _slightly_ too fast it seemed to select all the text in the object rows below it. Turns out if you turn off `user-select` on the element being clicked, it will also prevent that selection from bubbling out to other elements (TIL).