### PR TITLE
fix(core/notification): stop infinite-looping on custom notification input

### DIFF
--- a/app/scripts/modules/core/src/notification/modal/WhenChecklistInput.tsx
+++ b/app/scripts/modules/core/src/notification/modal/WhenChecklistInput.tsx
@@ -8,22 +8,56 @@ import {
   validationClassName,
 } from 'core/presentation';
 
-const { useEffect, useState } = React;
+const { useEffect } = React;
 
 interface IWhenChecklistInputProps
   extends IFormInputProps,
     OmitControlledInputPropsFrom<React.InputHTMLAttributes<any>> {
-  options?: IWehnChecklistInputOption[];
+  options?: IWhenChecklistInputOption[];
 }
 
-export interface IWehnChecklistInputOption {
+interface IWhenChecklistInputOption {
   label: string;
   value: string;
   additionalFields?: React.ReactNode;
 }
 
+interface ICheckBoxProps {
+  option: IWhenChecklistInputOption;
+  selected: string[];
+  onChange: (event: React.ChangeEvent<string[]>) => any;
+  inputClassName: string;
+  inputProps: any;
+}
+
+function CheckBox({ option, selected, onChange, inputClassName, inputProps }: ICheckBoxProps) {
+  function handleChange({ target }: React.ChangeEvent<HTMLInputElement>) {
+    const newValue = !selected.includes(target.value)
+      ? selected.concat(target.value)
+      : selected.filter((v: string) => v !== target.value);
+    onChange(createFakeReactSyntheticEvent({ value: newValue, name: target.name }));
+  }
+
+  return (
+    <>
+      <label className="clickable" key={option.value}>
+        <input
+          className={inputClassName}
+          type="checkbox"
+          value={option.value}
+          onChange={handleChange}
+          checked={selected.includes(option.value)}
+          {...inputProps}
+        />
+        {option.label}
+      </label>
+      {selected.includes(option.value) && option.additionalFields}
+    </>
+  );
+}
+
 export function WhenChecklistInput(props: IWhenChecklistInputProps) {
-  const { value, validation, inputClassName, options, onChange, ...otherProps } = props;
+  const { value, validation, inputClassName, options, onChange, ...inputProps } = props;
 
   // Naively call the the field's onBlur handler
   // This is what Formik uses to mark the field as touched
@@ -32,47 +66,20 @@ export function WhenChecklistInput(props: IWhenChecklistInputProps) {
   }
   useEffect(touchField, []);
 
-  const className = `${orEmptyString(inputClassName)} ${validationClassName(validation)}`;
-
-  const selectedValues = value || [];
-  const isChecked = (checkboxValue: any) => selectedValues.includes(checkboxValue);
-
-  function CheckBox(checkboxProps: { option: IWehnChecklistInputOption }) {
-    const [checked, setChecked] = useState(isChecked(checkboxProps.option.value));
-    const { option } = checkboxProps;
-
-    function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
-      const selected = e.target.value;
-      const alreadyHasValue = isChecked(selected);
-      const newValue = !alreadyHasValue ? selectedValues.concat(selected) : value.filter((v: string) => v !== selected);
-      onChange(createFakeReactSyntheticEvent({ value: newValue, name: e.target.name }));
-      setChecked(isChecked(selected));
-    }
-
-    return (
-      <>
-        <label className="clickable" key={option.value}>
-          <input
-            className={className}
-            type="checkbox"
-            value={option.value}
-            onChange={handleChange}
-            checked={checked}
-            {...otherProps}
-          />
-          {option.label}
-        </label>
-        {checked && option.additionalFields}
-      </>
-    );
-  }
+  const selectedValues: string[] = value || [];
 
   return (
     <div className="checkbox">
       <ul className="checklist">
-        {options.map((option: IWehnChecklistInputOption) => (
+        {options.map((option: IWhenChecklistInputOption) => (
           <li key={option.label}>
-            <CheckBox option={option} />
+            <CheckBox
+              option={option}
+              selected={selectedValues}
+              inputClassName={`${orEmptyString(inputClassName)} ${validationClassName(validation)}`}
+              inputProps={inputProps}
+              onChange={onChange}
+            />
           </li>
         ))}
       </ul>


### PR DESCRIPTION
This was somewhat of a perfect storm of small bugs that led to the page locking up in an infinite loop and eventually crashing whenever we showed the edit experience for a custom notification message:

<img width="640" alt="Screen Shot 2020-05-07 at 1 06 42 PM" src="https://user-images.githubusercontent.com/1850998/81339904-c2a55a80-9063-11ea-951d-24206f403ebf.png">

The initial culprit was an extremely common, straightforward bug that I see come up frequently with form inputs (but it can occur with any kind of component) — defining a component function in another component, and then rendering it. The reason that's bad is because React uses a referential equality check (i.e. `oldFunction === newFunction`) when rendering a component to tell whether that component is the same one, or a different one that happened to get rendered into the same spot in the virtual DOM tree. When it sees the reference change, it assumes the component has changed and it needs to _unmount the existing component and re-mount the new one_. Because of this 'bail out' behavior, when you do something like this it means that _every single render will cause ChildComponent to unmount and remount in both the virtual and real DOM:_
```tsx
function ParentComponent(props) {
  // every single time ParentComponent is rendered, this function is re-defined
  // and has a totally different reference identity
  function ChildComponent(props) {
    return <div>{props.name}</div>;
  }

  return <ChildComponent name="Carole Baskin" />;
}
```

This on its own is super annoying because it means 1) unnecessary mounting which can cause state thrashing and performance problems 2) inputs like form fields that rely on focus/blur events lose focus _every single time you type in the field_. In this case though, the remounting also triggered an unlikely side effect: [this code inside `FormikFormField`](https://github.com/spinnaker/deck/blob/master/app/scripts/modules/core/src/presentation/forms/fields/FormikFormField.tsx#L82-L83) relies on a stable reference to the `internalValidators` array it stores in a `useState` hook, and because the `FormikFormField` was getting unmounted on every render `internalValidators` was always a new array and _every single render triggered the effect callback_. Guess what happens when the effect callback calls that `revalidate()` function? it re-renders the form! That re-render starts the whole process over again, which results in an effectively infinite loop and later a hung/crashed Chrome process.

I didn't want to focus on refactoring the code itself for quality because it seemed low-leverage to spend time on it, but while i was in here i did clean up some typos, unnecessary component local state inside the `CheckBox` component, and otherwise just make things a little less roundabout in the way they worked. still fundamentally the same component and code organization though.