### PR TITLE
fix(core): Reduce FilterCollapse z-index

### DIFF
--- a/app/scripts/modules/core/src/filterModel/FilterCollapse.tsx
+++ b/app/scripts/modules/core/src/filterModel/FilterCollapse.tsx
@@ -14,7 +14,7 @@ export class FilterCollapse extends React.Component<{}> {
 
   public render() {
     return (
-      <div className="filters-toggle layer-high sp-margin-s-xaxis">
+      <div className="filters-toggle layer-medium sp-margin-s-xaxis">
         <h3 className="filters-placeholder">
           <Tooltip value="Show filters">
             <button


### PR DESCRIPTION
Reduce the z-index to `layer-medium` so that the modal backdrop will dim the `FilterCollapse` button. 

Creating a separate PR for this since the layout v1 PR is dependent on a couple react refactors now. 

Fixes this problem: 
<img width="1627" alt="Screen Shot 2020-05-12 at 11 26 00 AM" src="https://user-images.githubusercontent.com/26560152/81731153-69627000-9443-11ea-8380-fc761d42b81c.png">


