### PR TITLE
fix(core): UIView insertBefore error

### DIFF
--- a/app/scripts/modules/core/src/insight/InsightLayout.tsx
+++ b/app/scripts/modules/core/src/insight/InsightLayout.tsx
@@ -35,13 +35,21 @@ export const InsightLayout = ({ app }: IInsightLayoutProps) => {
           <FilterCollapse />
         </div>
       )}
-      {!filtersHidden && <UIView name="nav" className="nav ng-scope" />}
+      {!filtersHidden && (
+        <div>
+          <UIView name="nav" className="nav ng-scope" />
+        </div>
+      )}
       {appIsReady && (
         <div>
           <UIView name="master" className="nav-content ng-scope" data-scroll-id="nav-content" />
         </div>
       )}
-      {appIsReady && <UIView name="detail" className="detail-content" />}
+      {appIsReady && (
+        <div>
+          <UIView name="detail" className="detail-content" />
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
`@uirouter/react-hybrid` inserts a component `<react-ui-view-adapter>` between the `UIView` and the component that is being rendered. In certain situations, a nested `UIView` triggers an error:

```
Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.
```

I presume this occurs when the UI Router inserts the adapter. It happens when one UI view is a direct child of another. The fix (unclear why) is to wrap the `UIView` in a div. 