### PR TITLE
fix(core/presentation): Memoize defaultResult in useData.hook.ts

### DIFF
--- a/app/scripts/modules/core/src/presentation/hooks/useData.hook.ts
+++ b/app/scripts/modules/core/src/presentation/hooks/useData.hook.ts
@@ -1,5 +1,5 @@
 import { isNil } from 'lodash';
-import { useRef } from 'react';
+import { useMemo, useRef } from 'react';
 
 import { useLatestPromise, IUseLatestPromiseResult } from './useLatestPromise.hook';
 
@@ -15,15 +15,17 @@ import { useLatestPromise, IUseLatestPromiseResult } from './useLatestPromise.ho
  *
  * @param callback the callback to be invoked whenever dependencies change
  * @param defaultResult the default result returned before the first promise resolves
+ *                      this value will be memoized on the first render
  * @param deps array of dependencies, which (when changed) cause the callback to be invoked again
  * @returns an object with the result and current status of the promise
  */
 export function useData<T>(callback: () => PromiseLike<T>, defaultResult: T, deps: any[]): IUseLatestPromiseResult<T> {
+  const memoizedDefaultResult = useMemo(() => defaultResult, []);
   const anyDepsMissing = deps.some(dep => isNil(dep));
   const result = useLatestPromise<T>(anyDepsMissing ? () => null : callback, deps);
   const hasResolvedAtLeastOnceRef = useRef(false);
   if (result.status === 'RESOLVED') {
     hasResolvedAtLeastOnceRef.current = true;
   }
-  return hasResolvedAtLeastOnceRef.current ? result : { ...result, result: defaultResult };
+  return hasResolvedAtLeastOnceRef.current ? result : { ...result, result: memoizedDefaultResult };
 }


### PR DESCRIPTION
One nice thing about useData is that the `result` reference is stable and can be used as a dependency for other hooks.  For example, one could transform the data later in a `useMemo`.

```
const { result } = useData(() => fetch(), [], []);
const transformed = useMemo(() => transform(result),  [result]);
```

For example:

https://github.com/spinnaker/deck/blob/cc7001d9739a5fd42c5a0f3b2f83360e904e3abb/app/scripts/modules/core/src/widgets/ApplicationsPickerInput.tsx#L20-L22

However, the `useData` default value is probably *not* stable, because the default is generally passed as a literal to useData and gets re-created each render if it's an empty array or object.  

I considered having the caller memoize the default value before calling useData, but I couldn't think of a case where the default value should legitimately be changed.  I think it's 99% typical that the caller expects the default value to be stable.

This change should stop infinite re-renders I found in ApplicationsPickerInput while the apps are loading.  This was caused by `useInternalValidator` being passed `apps` as a dependency, and revalidating the form every time the `app` reference changed (every render).

https://github.com/spinnaker/deck/blob/cc7001d9739a5fd42c5a0f3b2f83360e904e3abb/app/scripts/modules/core/src/widgets/ApplicationsPickerInput.tsx#L34