### PR TITLE
feat(titus): Additional fields for Run Job and Deploy stage

### DIFF
--- a/app/scripts/modules/titus/src/domain/ITitusServerGroup.ts
+++ b/app/scripts/modules/titus/src/domain/ITitusServerGroup.ts
@@ -16,6 +16,7 @@ export interface ITitusServerGroup extends IServerGroup {
   capacityGroup?: string;
   disruptionBudget?: IJobDisruptionBudget;
   entryPoint: string;
+  cmd?: string;
   iamProfile: string;
   id?: string;
   image?: ITitusImage;

--- a/app/scripts/modules/titus/src/pipeline/stages/runJob/TitusRunJobStageConfig.tsx
+++ b/app/scripts/modules/titus/src/pipeline/stages/runJob/TitusRunJobStageConfig.tsx
@@ -20,6 +20,14 @@ import { ITitusResources } from 'titus/domain';
 
 import { TitusSecurityGroupPicker } from './TitusSecurityGroupPicker';
 import { TitusProviderSettings } from '../../../titus.settings';
+import Select, { Option } from 'react-select';
+import { string } from 'prop-types';
+
+const mountPermOptions = [
+  { label: 'Read and Write', value: 'RW' },
+  { label: 'Read Only', value: 'RO' },
+  { label: 'Write Only', value: 'WO' },
+];
 
 export interface ITitusRunJobStageConfigState {
   credentials: string[];
@@ -30,6 +38,8 @@ export interface ITitusRunJobStageConfigState {
 interface IClusterDefaults {
   application: string;
   containerAttributes: object;
+  constraints: object;
+  efs: object;
   env: object;
   labels: object;
   resources: ITitusResources;
@@ -77,6 +87,16 @@ export class TitusRunJobStageConfig extends React.Component<IStageConfigProps, I
     const clusterDefaults: IClusterDefaults = {
       application: application.name,
       containerAttributes: {},
+      constraints: {
+        soft: {},
+        hard: {},
+      },
+      efs: {
+        efsId: string,
+        mountPoint: string,
+        mountPerm: string,
+        efsRelativeMountPoint: string,
+      },
       env: {},
       labels: {},
       resources: {
@@ -218,7 +238,69 @@ export class TitusRunJobStageConfig extends React.Component<IStageConfigProps, I
           onChange={this.dockerChanged}
           deferInitialization={stage.deferredInitialization}
         />
-
+        <h4>
+          <b>
+            Elastic File System Options <HelpField id="titus.deploy.efs" />
+          </b>
+        </h4>
+        <div className="form-group">
+          <div className="col-md-3 sm-label-right">
+            <b>Mount Permission </b>
+            <HelpField id="titus.deploy.mountPermissions" />
+          </div>
+          <div className="col-md-8">
+            <Select
+              value={stage.cluster.efs.mountPerm}
+              clearable={false}
+              options={mountPermOptions}
+              onChange={(option: Option) => this.stageFieldChanged('cluster.efs.mountPerm', option.value)}
+            />
+          </div>
+        </div>
+        <div className="form-group">
+          <div className="col-md-3 sm-label-right">
+            <b>Mount Point </b>
+            <HelpField id="titus.deploy.mountPoint" />
+          </div>
+          <div className="col-md-8">
+            <input
+              type="text"
+              className="form-control input-sm no-spel"
+              value={stage.cluster.efs.mountPoint}
+              onChange={e => this.stageFieldChanged('cluster.efs.mountPoint', e.target.value)}
+            />
+          </div>
+        </div>
+        <div className="form-group">
+          <div className="col-md-3 sm-label-right">
+            <b>EFS ID </b>
+            <HelpField id="titus.deploy.efsId" />
+          </div>
+          <div className="col-md-8">
+            <input
+              type="text"
+              className="form-control input-sm no-spel"
+              value={stage.cluster.efs.efsId}
+              onChange={e => this.stageFieldChanged('cluster.efs.efsId', e.target.value)}
+            />
+          </div>
+          <div className="col-md-offset-3 col-md-8" />
+        </div>
+        <div className="form-group">
+          <div className="col-md-3 sm-label-right">
+            <b>EFS Relative Mount Point </b>
+            <HelpField id="titus.deploy.efsRelativeMountPoint" />
+          </div>
+          <div className="col-md-8">
+            <input
+              type="text"
+              className="form-control input-sm no-spel"
+              value={stage.cluster.efs.efsRelativeMountPoint}
+              onChange={e => this.stageFieldChanged('cluster.efs.efsRelativeMountPoint', e.target.value)}
+            />
+          </div>
+        </div>
+        <hr />
         <StageConfigField label="CPU(s)">
           <input
             type="number"
@@ -275,6 +357,15 @@ export class TitusRunJobStageConfig extends React.Component<IStageConfigProps, I
             className="form-control input-sm"
             value={stage.cluster.entryPoint}
             onChange={e => this.stageFieldChanged('cluster.entryPoint', e.target.value)}
+          />
+        </StageConfigField>
+
+        <StageConfigField label="Command">
+          <input
+            type="text"
+            className="form-control input-sm"
+            value={stage.cluster.cmd}
+            onChange={e => this.stageFieldChanged('cluster.cmd', e.target.value)}
           />
         </StageConfigField>
 
@@ -397,6 +488,20 @@ export class TitusRunJobStageConfig extends React.Component<IStageConfigProps, I
               model={stage.cluster.env}
               allowEmpty={true}
               onChange={(v: any) => this.mapChanged('cluster.env', v)}
+            />
+          </StageConfigField>
+          <StageConfigField label="Soft Constraints (optional)">
+            <MapEditor
+              model={stage.cluster.constraints.soft}
+              allowEmpty={true}
+              onChange={(v: any) => this.mapChanged('cluster.constraints.soft', v)}
+            />
+          </StageConfigField>
+          <StageConfigField label="Hard Constraints (optional)">
+            <MapEditor
+              model={stage.cluster.constraints.hard}
+              allowEmpty={true}
+              onChange={(v: any) => this.mapChanged('cluster.constraints.hard', v)}
             />
           </StageConfigField>
         </div>

--- a/app/scripts/modules/titus/src/serverGroup/configure/ServerGroupCommandBuilder.js
+++ b/app/scripts/modules/titus/src/serverGroup/configure/ServerGroupCommandBuilder.js
@@ -100,6 +100,7 @@ angular.module(TITUS_SERVERGROUP_CONFIGURE_SERVERGROUPCOMMANDBUILDER, []).factor
         labels: serverGroup.labels,
         containerAttributes: serverGroup.containerAttributes,
         entryPoint: serverGroup.entryPoint,
+        cmd: serverGroup.cmd,
         iamProfile: serverGroup.iamProfile || application.name + 'InstanceProfile',
         capacityGroup: serverGroup.capacityGroup,
         migrationPolicy: serverGroup.migrationPolicy ? serverGroup.migrationPolicy : { type: 'systemDefault' },

--- a/app/scripts/modules/titus/src/serverGroup/configure/wizard/pages/ServerGroupBasicSettings.tsx
+++ b/app/scripts/modules/titus/src/serverGroup/configure/wizard/pages/ServerGroupBasicSettings.tsx
@@ -261,6 +261,15 @@ export class ServerGroupBasicSettings
 
         <div className="form-group">
           <div className="col-md-3 sm-label-right">
+            <b>Command</b>
+          </div>
+          <div className="col-md-7">
+            <Field type="text" className="form-control input-sm no-spel" name="cmd" />
+          </div>
+        </div>
+
+        <div className="form-group">
+          <div className="col-md-3 sm-label-right">
             Traffic <HelpField id="titus.serverGroup.traffic" />
           </div>
           <div className="col-md-7">

--- a/app/scripts/modules/titus/src/serverGroup/details/TitusLaunchConfigSection.tsx
+++ b/app/scripts/modules/titus/src/serverGroup/details/TitusLaunchConfigSection.tsx
@@ -14,7 +14,7 @@ export class TitusLaunchConfigSection extends React.Component<ILaunchConfigSecti
     }
 
     const {
-      serverGroup: { image, entryPoint, iamProfile, resources },
+      serverGroup: { image, entryPoint, cmd, iamProfile, resources },
     } = this.props;
 
     return (
@@ -22,6 +22,7 @@ export class TitusLaunchConfigSection extends React.Component<ILaunchConfigSecti
         {image.dockerImageName && <LabeledValue label="Image Name" value={image.dockerImageName} />}
         {image.dockerImageVersion && <LabeledValue label="Image Version" value={image.dockerImageVersion} />}
         {entryPoint && <LabeledValue label="Entrypoint" value={entryPoint} />}
+        {cmd && <LabeledValue label="Command" value={cmd} />}
         {iamProfile && <LabeledValue label="IAM Profile" value={iamProfile} />}
         <LabeledValue label="CPU(s)" value={resources.cpu} />
         <LabeledValue label="Memory" value={`${resources.memory} MB`} />


### PR DESCRIPTION
- Adding `EFS` , `Command` , `Constraint` fields to make run job on par with deploy
- Also adding `Command` field in titus deploy stage

`EFS`  Mount
![Screen Shot 2020-05-19 at 12 07 24 PM](https://user-images.githubusercontent.com/21320508/82368690-b48ffc00-99ca-11ea-9566-2aaa62a55dde.png)


`Constraints` under advance section
<img width="1126" alt="Screen Shot 2020-05-19 at 12 06 31 PM" src="https://user-images.githubusercontent.com/21320508/82368796-d8534200-99ca-11ea-839d-2b48d5f3c6ff.png">


river PR to support `Command` : https://github.com/spinnaker/clouddriver/pull/4609/files

