### PR TITLE
feat(core/managed): switch 'Artifacts' header to 'Versions'

### DIFF
--- a/app/scripts/modules/core/src/managed/Environments.tsx
+++ b/app/scripts/modules/core/src/managed/Environments.tsx
@@ -140,7 +140,7 @@ export function Environments({ app }: IEnvironmentsProps) {
   return (
     <div className={styles.mainContent}>
       <div className={styles.artifactsColumn}>
-        <ColumnHeader text="Artifacts" icon="artifact" />
+        <ColumnHeader text="Versions" icon="artifact" />
         <ArtifactsList
           artifacts={artifacts}
           selectedVersion={selectedVersion}


### PR DESCRIPTION
I've heard a couple different forms of feedback that seemed to come from a bit of ambiguity around what "Artifacts" means in the sidebar. In your app's delivery manifest you define an `artifacts` list that specifies the artifact you care about (oftentimes just a single image/deb), I'm sort of wondering if the name being the same here for something that's a list of lots of versions causes a little bit of a mismatch.

Thoughts? I'm honestly a bit torn but figured it was worth trying out and considering. Looks like this:

<img width="1376" alt="Screen Shot 2020-05-19 at 9 31 30 PM" src="https://user-images.githubusercontent.com/1850998/82406173-c4373100-9a1a-11ea-8710-17d7f96928f8.png">

fyi @gcomstock 