### PR TITLE
feat(aws): Add IPv6 and IMDSv2 to aws settings

### DIFF
--- a/app/scripts/modules/amazon/src/aws.settings.ts
+++ b/app/scripts/modules/amazon/src/aws.settings.ts
@@ -41,6 +41,10 @@ export interface IAWSProviderSettings extends IProviderSettings {
     customNamespaces?: string[];
   };
   minRootVolumeSize?: number;
+  serverGroups?: {
+    enableIPv6?: boolean;
+    enableIMDSv2?: boolean;
+  };
   useAmiBlockDeviceMappings?: boolean;
 }
 


### PR DESCRIPTION
With the upcoming launch template support, server groups will be able to opt instances into IPv6 and/or IMDSv2. If enabled in `aws.settings`, these options will be available in the server group configuration `Advanced Settings` modal.