### PR TITLE
feat(core/managed): make Environments tab visible on config screen

### DIFF
--- a/app/scripts/modules/core/src/managed/managed.dataSource.ts
+++ b/app/scripts/modules/core/src/managed/managed.dataSource.ts
@@ -60,9 +60,10 @@ module(MANAGED_RESOURCES_DATA_SOURCE, []).run([
       category: DELIVERY_KEY,
       optional: true,
       optIn: true,
-      hidden: true,
+      label: 'Environments',
       icon: 'fa fa-fw fa-xs fa-code-branch',
       iconName: 'spCIBranch',
+      description: '[beta] Artifacts and environments managed by Spinnaker',
       loader: loadEnvironments,
       onLoad: addEnvironments,
       defaultData: {


### PR DESCRIPTION
Managed Delivery is officially in beta — let's make Environments available to opt in for anyone who tries it!