### PR TITLE
fix(core): Remove conditional for master UI View

### DIFF
--- a/app/scripts/modules/core/src/insight/InsightLayout.tsx
+++ b/app/scripts/modules/core/src/insight/InsightLayout.tsx
@@ -40,11 +40,9 @@ export const InsightLayout = ({ app }: IInsightLayoutProps) => {
           <UIView name="nav" className="nav ng-scope" />
         </div>
       )}
-      {appIsReady && (
-        <div>
-          <UIView name="master" className="nav-content ng-scope" data-scroll-id="nav-content" />
-        </div>
-      )}
+      <div>
+        <UIView name="master" className="nav-content ng-scope" data-scroll-id="nav-content" />
+      </div>
       {appIsReady && (
         <div>
           <UIView name="detail" className="detail-content" />


### PR DESCRIPTION
Improper use of `appIsReady` flag for the master view. The angular version of this component did not have this conditional, and it is causing render errors when loading large apps. 