### PR TITLE
fix(ecs): return promise from normalizeLoadBalancer

### DIFF
--- a/app/scripts/modules/ecs/src/loadBalancer/loadBalancer.transformer.ts
+++ b/app/scripts/modules/ecs/src/loadBalancer/loadBalancer.transformer.ts
@@ -1,7 +1,11 @@
+import { IQService, IPromise } from 'angular';
 import { IEcsLoadBalancerSourceData, IEcsLoadBalancer, IEcsTargetGroup } from '../domain/IEcsLoadBalancer';
 
 export class EcsLoadBalancerTransformer {
-  public normalizeLoadBalancer(loadBalancer: IEcsLoadBalancerSourceData): IEcsLoadBalancer {
+  public static $inject = ['$q'];
+  constructor(private $q: IQService) {}
+
+  public normalizeLoadBalancer(loadBalancer: IEcsLoadBalancerSourceData): IPromise<IEcsLoadBalancer> {
     loadBalancer.targetGroups.forEach((tg: IEcsTargetGroup) => {
       tg.region = loadBalancer.region;
       tg.account = loadBalancer.account;
@@ -11,6 +15,6 @@ export class EcsLoadBalancerTransformer {
         tg.serverGroups = tgServiceMap[tg.targetGroupArn];
       }
     });
-    return loadBalancer;
+    return this.$q.resolve(loadBalancer);
   }
 }


### PR DESCRIPTION
Addresses part of https://github.com/spinnaker/spinnaker/issues/5800

Specifically: [this part](https://github.com/spinnaker/spinnaker/issues/5800#issuecomment-637008783).


### Testing

After returning an `IPromise`, load balancer and firewall infa pages now show up. 
* NOTE: still seems to be something off/missing from the top of the search/filter panel?

<img width="621" alt="lb_change" src="https://user-images.githubusercontent.com/34254888/83568031-69501000-a4d7-11ea-901f-b4dd6e90d493.PNG">
