### PR TITLE
fix(ecs): disable terminate instance

### DIFF
--- a/app/scripts/modules/ecs/src/instance/details/instanceDetails.html
+++ b/app/scripts/modules/ecs/src/instance/details/instanceDetails.html
@@ -73,9 +73,6 @@
               >
             </li>
             <!--<li role="presentation" class="divider" ng-if="instance.health.length > 0"></li>-->
-            <li><a href ng-click="ctrl.terminateInstance()">Terminate</a></li>
-            <!--<li><a href ng-click="ctrl.terminateInstanceAndShrinkServerGroup()">Terminate and Shrink Server Group</a></li>-->
-            <!-- TODO(Bruno Carrier): This is currently not working, and needs to be investiged -->
           </ul>
         </div>
         <div class="dropdown" ng-if="instance.insightActions.length > 0" uib-dropdown dropdown-append-to-body>


### PR DESCRIPTION
Currently terminating tasks fails as it tries to use the instance id to terminate the task. As discussed in this [issue](https://github.com/spinnaker/spinnaker/issues/5383), removing the terminate instance button as it doesn't currently work. 