### PR TITLE
fix(core): override styleguide styles on react-select input

### DIFF
--- a/app/scripts/modules/core/src/presentation/forms/forms.less
+++ b/app/scripts/modules/core/src/presentation/forms/forms.less
@@ -162,6 +162,12 @@
   .Select-input {
     input {
       border: none !important;
+      padding: 8px 0 12px;
+    }
+  }
+  .is-open {
+    .Select-value-label {
+      opacity: 0.6;
     }
   }
 


### PR DESCRIPTION
Currently, using any of the react-select components within a `<FormikStageConfig>` component results in some unpleasant styles when making a selection:

These overrides restore existing styles that are getting overridden by the styleguide.

**Entering the select box, nothing selected**
_current_
<img width="612" alt="Screen Shot 2020-06-03 at 3 36 50 PM" src="https://user-images.githubusercontent.com/73450/83696301-f4e99f80-a5b0-11ea-9a75-a7206f2768a9.png">
_PR_
<img width="581" alt="Screen Shot 2020-06-03 at 3 38 57 PM" src="https://user-images.githubusercontent.com/73450/83696391-3712e100-a5b1-11ea-9f99-7e5a94a00208.png">


**Entering the select box, something already selected**
_current_
<img width="589" alt="Screen Shot 2020-06-03 at 3 37 50 PM" src="https://user-images.githubusercontent.com/73450/83696303-f5823600-a5b0-11ea-91de-c1503f35c058.png">
_PR_
<img width="595" alt="Screen Shot 2020-06-03 at 3 36 14 PM" src="https://user-images.githubusercontent.com/73450/83696442-5c075400-a5b1-11ea-8414-fd2e1b526993.png">

**Entering something in the select box**
_current_
<img width="587" alt="Screen Shot 2020-06-03 at 3 38 13 PM" src="https://user-images.githubusercontent.com/73450/83696304-f61acc80-a5b0-11ea-9337-f62b553de0d2.png">
_PR_
<img width="607" alt="Screen Shot 2020-06-03 at 3 39 05 PM" src="https://user-images.githubusercontent.com/73450/83696470-6c1f3380-a5b1-11ea-89e9-66d8c4438b62.png">

