### PR TITLE
fix(core): sort application names in ApplicationsPickerInput

### DIFF
--- a/app/scripts/modules/core/src/widgets/ApplicationsPickerInput.tsx
+++ b/app/scripts/modules/core/src/widgets/ApplicationsPickerInput.tsx
@@ -17,7 +17,7 @@ interface IApplicationsPickerInputProps extends IFormInputProps {
 
 /** This input supports single or multiple selection of applications */
 export function ApplicationsPickerInput(props: IApplicationsPickerInputProps) {
-  const getAppNames = () => ApplicationReader.listApplications().then(apps => apps.map(app => app.name));
+  const getAppNames = () => ApplicationReader.listApplications().then(apps => apps.map(app => app.name).sort());
   const { result: apps, status } = useData(getAppNames, [], []);
   const options = useMemo(() => apps.map(app => ({ label: app, value: app })), [apps]);
 


### PR DESCRIPTION
The applications are not sorted on the backend, and we aren't sorting them on the frontend right now, so the list of applications is in a random order.