### PR TITLE
fix(core): Filter flashes on non-on-demand apps

### DIFF
--- a/app/scripts/modules/core/src/cluster/allClusters.controller.js
+++ b/app/scripts/modules/core/src/cluster/allClusters.controller.js
@@ -32,7 +32,6 @@ module(CORE_CLUSTER_ALLCLUSTERS_CONTROLLER, [
   'serverGroupCommandBuilder',
   function($scope, app, $uibModal, $timeout, insightFilterStateModel, serverGroupCommandBuilder) {
     this.$onInit = () => {
-      insightFilterStateModel.filtersHidden = true; // hidden to prevent filter flashing for on-demand apps
       const groupsUpdatedSubscription = ClusterState.filterService.groupsUpdatedStream.subscribe(() =>
         clusterGroupsUpdated(),
       );
@@ -51,7 +50,7 @@ module(CORE_CLUSTER_ALLCLUSTERS_CONTROLLER, [
         .ready()
         .then(
           () => {
-            insightFilterStateModel.filtersHidden = false;
+            insightFilterStateModel.filtersHidden = Boolean(this.dataSource.fetchOnDemand);
             updateClusterGroups();
           },
           () => this.clustersLoadError(),


### PR DESCRIPTION
There is a fix to prevent the filter bar flash for on-demand apps. With the upcoming `InsightLayout` changes, this fix is now causing a flash for non-on-demand apps.

The fix initializes the `filtersHidden` property to `false` if `fetchOnDemand = false` and `true` if `fetchOnDemand = true` in an attempt to prevent a flash altogether.  