### PR TITLE
refactor(core): default SETTINGS.feature.roscoMode to true

### DIFF
--- a/app/scripts/modules/core/src/config/settings.ts
+++ b/app/scripts/modules/core/src/config/settings.ts
@@ -136,6 +136,7 @@ export const SETTINGS: ISpinnakerSettings = (window as any).spinnakerSettings;
 
 // Make sure to set up some reasonable default settings fields so we do not have to keep checking if they exist everywhere
 SETTINGS.feature = SETTINGS.feature || {};
+SETTINGS.feature.roscoMode = SETTINGS.feature.roscoMode || true;
 SETTINGS.analytics = SETTINGS.analytics || {};
 SETTINGS.providers = SETTINGS.providers || {};
 SETTINGS.defaultTimeZone = SETTINGS.defaultTimeZone || 'America/Los_Angeles';


### PR DESCRIPTION
Rosco is the only bakery that ships with OSS Spinnaker, and is [enabled by default in Orca](https://github.com/spinnaker/orca/blob/master/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/config/BakeryConfigurationProperties.java#L28). Currently, Halyard defaults `SETTINGS.feature.roscoMode` to enabled in Deck. To avoid needing to even expose `roscoMode` to OSS end-users in a post-Halyard world, let's default it to true in Deck as well.