### PR TITLE
Revert "fix(aws/titus): Server group names should be lower case"

### DIFF
--- a/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/ServerGroupBasicSettings.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/wizard/pages/ServerGroupBasicSettings.tsx
@@ -166,8 +166,8 @@ export class ServerGroupBasicSettings
 
   private stackChanged = (stack: string) => {
     const { setFieldValue, values } = this.props.formik;
-    values.stack = stack.toLowerCase(); // have to do it here to make sure it's done before calling values.clusterChanged
-    setFieldValue('stack', stack.toLowerCase());
+    values.stack = stack; // have to do it here to make sure it's done before calling values.clusterChanged
+    setFieldValue('stack', stack);
     values.clusterChanged(values);
   };
 

--- a/app/scripts/modules/core/src/serverGroup/configure/common/wizard/fields/ServerGroupDetailsField.tsx
+++ b/app/scripts/modules/core/src/serverGroup/configure/common/wizard/fields/ServerGroupDetailsField.tsx
@@ -12,8 +12,8 @@ export interface DetailsFieldProps<T extends IServerGroupCommand> {
 export class ServerGroupDetailsField<T extends IServerGroupCommand> extends React.Component<DetailsFieldProps<T>> {
   private freeFormDetailsChanged = (freeFormDetails: string) => {
     const { setFieldValue, values } = this.props.formik;
-    values.freeFormDetails = freeFormDetails.toLowerCase(); // have to do it here to make sure it's done before calling values.clusterChanged
-    setFieldValue('freeFormDetails', freeFormDetails.toLowerCase());
+    values.freeFormDetails = freeFormDetails; // have to do it here to make sure it's done before calling values.clusterChanged
+    setFieldValue('freeFormDetails', freeFormDetails);
     values.clusterChanged(values);
   };
 

--- a/app/scripts/modules/titus/src/serverGroup/configure/wizard/pages/ServerGroupBasicSettings.tsx
+++ b/app/scripts/modules/titus/src/serverGroup/configure/wizard/pages/ServerGroupBasicSettings.tsx
@@ -146,7 +146,7 @@ export class ServerGroupBasicSettings
 
   private stackChanged = (stack: string) => {
     const { formik } = this.props;
-    formik.setFieldValue('stack', stack.toLowerCase());
+    formik.setFieldValue('stack', stack);
     formik.values.clusterChanged(formik.values);
   };
 


### PR DESCRIPTION
Reverts spinnaker/deck#8332. We would like to take a different approach. Instead of normalizing server groups to be lowercase (which could have some downstream effects) we would like to ensure that the db/caching is also case sensitive.