### PR TITLE
fix(core): Validation for max luxon duration

### DIFF
--- a/app/scripts/modules/core/src/utils/timeFormatters.ts
+++ b/app/scripts/modules/core/src/utils/timeFormatters.ts
@@ -7,7 +7,9 @@ import { SETTINGS } from 'core/config/settings';
 
 import { SystemTimezone } from './SystemTimezone';
 
-const isInputValid = (input: any) => !(!input || isNaN(input) || input < 0);
+// Luxon supports up to 100 million days after epoch start
+const MAX_VALID_INPUT = 8640000000000000;
+const isInputValid = (input: any) => !(!input || isNaN(input) || input < 0 || input > MAX_VALID_INPUT);
 
 export function duration(input: any) {
   if (!isInputValid(input)) {


### PR DESCRIPTION
Upon investigation, the module we use to calculate stage duration has a maximum value that we do not currently impose. It only honors up to 100 million days after epoch start, or 8.64x10^15. 

Fix: Add max value to the validator so a large value does not impact rendering. 