### PR TITLE
feat(core): link to specific version changelog

### DIFF
--- a/app/scripts/modules/core/src/help/HelpMenu.tsx
+++ b/app/scripts/modules/core/src/help/HelpMenu.tsx
@@ -34,6 +34,21 @@ const AdditionalHelpLinks = () =>
     </>
   ) : null;
 
+const Version = () => {
+  if (!SETTINGS.version) {
+    return null;
+  }
+
+  const CHANGELOG_PATH = `${SETTINGS.version.replace(/\./g, '-')}-changelog`;
+  const CHANGELOG_URL = `${VERSIONS_URL}${CHANGELOG_PATH}`;
+
+  return (
+    <MenuItem href={CHANGELOG_URL} target="_blank">
+      Spinnaker {SETTINGS.version}
+    </MenuItem>
+  );
+};
+
 export const HelpMenu = () => {
   return (
     <li className="help-menu">
@@ -51,11 +66,7 @@ export const HelpMenu = () => {
           <MenuItem href={COMMUNITY_URL} target="_blank">
             Community Resources
           </MenuItem>
-          {SETTINGS.version && (
-            <MenuItem href={VERSIONS_URL} target="_blank">
-              Spinnaker {SETTINGS.version}
-            </MenuItem>
-          )}
+          <Version />
           {SETTINGS.feature.pagerDuty && (
             <li role="presentation">
               <UISref to="home.page">
@@ -81,11 +92,7 @@ export const HelpMenu = () => {
           <MenuItem href={COMMUNITY_URL} target="_blank">
             Community Resources
           </MenuItem>
-          {SETTINGS.version && (
-            <MenuItem href={VERSIONS_URL} target="_blank">
-              Spinnaker {SETTINGS.version}
-            </MenuItem>
-          )}
+          <Version />
           {SETTINGS.feature.pagerDuty && (
             <li role="presentation">
               <UISref to="home.page">


### PR DESCRIPTION
Since [this change](https://github.com/spinnaker/buildtool/pull/48) to spinnaker/buildtool, the OSS release changelog gists have been published with one top-level gist per minor release and individual files for each patch release. Since we can now stably link to each patch release changelog on spinnaker.io, let's point the Help --> Version link there rather than the general Releases page, which just links out ot each individual changelog anyway.