### PR TITLE
feat(kubernetes) Add host rules to the ingress information

### DIFF
--- a/app/scripts/modules/kubernetes/src/loadBalancer/details/details.html
+++ b/app/scripts/modules/kubernetes/src/loadBalancer/details/details.html
@@ -135,6 +135,21 @@
           </dd>
         </div>
       </dl>
+      <dl ng-if="ctrl.loadBalancer.manifest.spec.rules.length">
+        <dt>Host Rules</dt>
+        <dd ng-repeat="ingressRule in ctrl.loadBalancer.manifest.spec.rules">
+          <a ng-if="ingressRule.host" target="_blank" href="//{{ingressRule.host}}">
+            {{ingressRule.host}}
+          </a>
+          <copy-to-clipboard
+            ng-if="ingressRule.host"
+            class="copy-to-clipboard copy-to-clipboard-sm"
+            text="ingressRule.host"
+            tool-tip="'Copy ingress rule host to clipboard'"
+          >
+          </copy-to-clipboard>
+        </dd>
+      </dl>
       <dl ng-if="ctrl.loadBalancer.manifest.status.loadBalancer.ingress.length">
         <dt>Ingress</dt>
         <dd ng-repeat="ingress in ctrl.loadBalancer.manifest.status.loadBalancer.ingress">


### PR DESCRIPTION
This should close https://github.com/spinnaker/spinnaker/issues/4271

It will add a list of hostname rules that will look like this:

![image](https://user-images.githubusercontent.com/725020/85222024-cd6c4280-b3b8-11ea-8877-e7ada7cb97c3.png)

Reading from an ingress spec that could look like this:
```
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  annotations:
(...)
spec:
  rules:
    - host: service.spinnaker.io
      http:
        paths:
          - backend:
              serviceName: myservice
              servicePort: 80
            path: /
    - host: service.namespace.cluster.spinnaker.io
      http:
        paths:
          - backend:
              serviceName: myservice
              servicePort: 80
            path: /
status:
  loadBalancer:
    ingress:
(...)

```