### PR TITLE
fix(stages/evaluateVariables): Display failures conditionally

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/checkPreconditions/CheckPreconditionsExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/checkPreconditions/CheckPreconditionsExecutionDetails.tsx
@@ -33,7 +33,7 @@ export function CheckPreconditionsExecutionDetails(props: IExecutionDetailsSecti
           </dl>
         </div>
       </div>
-      <StageFailureMessage stage={props.stage} message={stageFailureMessage} />
+      {props.stage.status !== 'SUCCEEDED' && <StageFailureMessage stage={props.stage} message={stageFailureMessage} />}
     </ExecutionDetailsSection>
   );
 }


### PR DESCRIPTION
Checks the status before displaying a `<StageFailureMessage>` in the execution details pane of a Check Preconditions stage. If the status is `SUCCEEDED`, as opposed to `STOPPED` or some other condition, the execution details pane no longer displays a failure warning message.

### Example JSON snippet

```json
    {
      "id": "01EAX3ZRRC5T5XSFJJ8B3F8ERC",
      "refId": "2",
      "type": "checkPreconditions",
      "name": "Check Preconditions - SUCCEED",
      "startTime": 1592262648660,
      "endTime": 1592262648779,
      "status": "SUCCEEDED",
      "context": {
        "preconditions": [
          {
            "context": {
              "expression": true,
              "failureMessage": "This message should NOT appear since the expression is TRUE."
            },
            "failPipeline": false,
            "type": "expression"
          }
        ]
      },
      "outputs": {},
      "tasks": [],
      "requisiteStageRefIds": []
    }
```

### Before: Successful Check Preconditions, failure message shown

<img width="900" alt="Check Preconditions - Failure Message shown" src="https://user-images.githubusercontent.com/56670/85339834-c9fcb800-b499-11ea-98ed-5c916192d1da.png">

### After: Successful Check Preconditions, no failure message shown

<img width="903" alt="Check Preconditions - Failure message suppressed" src="https://user-images.githubusercontent.com/56670/85339847-cff29900-b499-11ea-87b8-3d3eeceb00e5.png">
