### PR TITLE
fix(core/application): ensure disable cluster tab waits for task to finish

### DIFF
--- a/app/scripts/modules/core/src/application/config/dataSources/applicationDataSourceEditor.component.spec.ts
+++ b/app/scripts/modules/core/src/application/config/dataSources/applicationDataSourceEditor.component.spec.ts
@@ -4,6 +4,7 @@ import { Application } from 'core/application/application.model';
 import { ApplicationModelBuilder } from 'core/application/applicationModel.builder';
 import { APPLICATION_DATA_SOURCE_EDITOR, DataSourceEditorController } from './applicationDataSourceEditor.component';
 import { ApplicationWriter } from 'core/application/service/ApplicationWriter';
+import { TaskReader } from 'core';
 
 describe('Component: Application Data Source Editor', () => {
   let application: Application,
@@ -127,6 +128,7 @@ describe('Component: Application Data Source Editor', () => {
   describe('save', () => {
     it('sets state flags, saves, then updates existing data sources and refreshes application', () => {
       spyOn(ApplicationWriter, 'updateApplication').and.returnValue($q.when());
+      spyOn(TaskReader, 'waitUntilTaskCompletes').and.returnValue($q.when());
       spyOn(application, 'refresh').and.returnValue(null);
       initialize();
       expect(ctrl.saving).toBe(false);

--- a/app/scripts/modules/core/src/application/config/dataSources/applicationDataSourceEditor.component.ts
+++ b/app/scripts/modules/core/src/application/config/dataSources/applicationDataSourceEditor.component.ts
@@ -4,6 +4,7 @@ import { Application } from '../../application.model';
 import { ApplicationDataSource } from '../../service/applicationDataSource';
 import { ApplicationWriter } from '../../service/ApplicationWriter';
 import { ApplicationReader } from '../../service/ApplicationReader';
+import { TaskReader } from 'core';
 
 import './applicationDataSourceEditor.component.less';
 
@@ -66,20 +67,24 @@ export class DataSourceEditorController implements IController {
       name: this.application.name,
       accounts: this.application.attributes.accounts,
       dataSources: newDataSources,
-    }).then(
-      () => {
-        this.application.attributes.dataSources = newDataSources;
-        ApplicationReader.setDisabledDataSources(this.application);
-        this.application.refresh(true);
-        this.saving = false;
-        this.isDirty = false;
-        this.$onInit();
-      },
-      () => {
-        this.saving = false;
-        this.saveError = true;
-      },
-    );
+    })
+      .then(task => {
+        return TaskReader.waitUntilTaskCompletes(task);
+      })
+      .then(
+        () => {
+          this.application.attributes.dataSources = newDataSources;
+          ApplicationReader.setDisabledDataSources(this.application);
+          this.application.refresh(true);
+          this.saving = false;
+          this.isDirty = false;
+          this.$onInit();
+        },
+        () => {
+          this.saving = false;
+          this.saveError = true;
+        },
+      );
   }
 }
 


### PR DESCRIPTION
In application configuration, the cluster option would allow an unauthorized user the ability to enable/disable clusters without waiting for the task to finish. In reality, it should only enable/disable the clusters tab if the task successfully finishes. Even if the task ends up being rejected because the user doesn't have write access, there would still be a window that would allow the user to see the cluster tab under infrastructure. This fix ensures that the task would only show the clusters tab once the task has successfully finished. Otherwise, it will remain its current state. The inverse is also true here which will now not allow an unauthorized user the ability disable the clusters tab momentarily. 