### PR TITLE
feat(gce): remove the scale-in control feature flag

### DIFF
--- a/app/scripts/modules/core/src/config/settings.ts
+++ b/app/scripts/modules/core/src/config/settings.ts
@@ -31,7 +31,6 @@ export interface IFeatures {
   entityTags?: boolean;
   executionMarkerInformationModal?: boolean;
   fiatEnabled?: boolean;
-  gceScaleDownControlsEnabled?: boolean;
   gceStatefulMigsEnabled?: boolean;
   iapRefresherEnabled?: boolean;
   managedDelivery?: boolean;

--- a/app/scripts/modules/google/src/autoscalingPolicy/components/basicSettings/basicSettings.component.html
+++ b/app/scripts/modules/google/src/autoscalingPolicy/components/basicSettings/basicSettings.component.html
@@ -71,5 +71,5 @@
       </select>
     </div>
   </div>
-  <gce-scale-down-controls policy="$ctrl.policy" update-policy="$ctrl.updatePolicy"> </gce-scale-down-controls>
+  <gce-scale-in-controls policy="$ctrl.policy" update-policy="$ctrl.updatePolicy"> </gce-scale-in-controls>
 </ng-form>

--- a/app/scripts/modules/google/src/gce.module.ts
+++ b/app/scripts/modules/google/src/gce.module.ts
@@ -9,7 +9,7 @@ import { GCE_TCP_LOAD_BALANCER_CTRL } from './loadBalancer/configure/tcp/gceCrea
 import { IAP_INTERCEPTOR } from 'google/interceptors/iap.interceptor';
 import { LOAD_BALANCER_SET_TRANSFORMER } from './loadBalancer/loadBalancer.setTransformer';
 import { GCE_SERVER_GROUP_DISK_DESCRIPTIONS } from './serverGroup/details/ServerGroupDiskDescriptions';
-import { GCE_SCALE_DOWN_CONTROLS } from './serverGroup/details/autoscalingPolicy/modal/GceScaleDownControls';
+import { GCE_SCALE_IN_CONTROLS } from './serverGroup/details/autoscalingPolicy/modal/GceScaleInControls';
 import { GceImageReader } from './image';
 import './help/gce.help';
 
@@ -64,7 +64,7 @@ module(GOOGLE_MODULE, [
   GCE_TCP_LOAD_BALANCER_CTRL,
   IAP_INTERCEPTOR,
   GCE_SERVER_GROUP_DISK_DESCRIPTIONS,
-  GCE_SCALE_DOWN_CONTROLS,
+  GCE_SCALE_IN_CONTROLS,
   GOOGLE_SERVERGROUP_DETAILS_SERVERGROUP_DETAILS_GCE_MODULE,
   GOOGLE_SERVERGROUP_CONFIGURE_SERVERGROUPCOMMANDBUILDER_SERVICE,
   GOOGLE_SERVERGROUP_CONFIGURE_WIZARD_CLONESERVERGROUP_GCE_CONTROLLER,

--- a/app/scripts/modules/google/src/serverGroup/details/autoscalingPolicy/autoscalingPolicy.directive.html
+++ b/app/scripts/modules/google/src/serverGroup/details/autoscalingPolicy/autoscalingPolicy.directive.html
@@ -26,18 +26,18 @@
     <help-field key="gce.serverGroup.autoscaling.mode"></help-field>
   </dt>
   <dd>{{$ctrl.policy.mode}}</dd>
-  <dt ng-if="$ctrl.scaleDownControlsEnabled">
-    Scale-down Controls
+  <dt ng-if="$ctrl.scaleInControlsEnabled">
+    Scale-in Controls
   </dt>
-  <dd ng-if="$ctrl.scaleDownControlsEnabled">{{$ctrl.scaleDownControlsConfigured ? 'Enabled' : 'Disabled'}}</dd>
-  <dt ng-if="$ctrl.scaleDownControlsConfigured">
-    Max Scaled-down Replicas
+  <dd ng-if="$ctrl.scaleInControlsEnabled">{{$ctrl.scaleInControlsConfigured ? 'Enabled' : 'Disabled'}}</dd>
+  <dt ng-if="$ctrl.scaleInControlsConfigured">
+    Max Scaled-in Replicas
   </dt>
-  <dd ng-if="$ctrl.scaleDownControlsConfigured">{{$ctrl.maxScaledDownReplicasMessage}}</dd>
-  <dt ng-if="$ctrl.scaleDownControlsConfigured">
-    Scale-down Time Window
+  <dd ng-if="$ctrl.scaleInControlsConfigured">{{$ctrl.maxScaledInReplicasMessage}}</dd>
+  <dt ng-if="$ctrl.scaleInControlsConfigured">
+    Scale-in Time Window
   </dt>
-  <dd ng-if="$ctrl.scaleDownControlsConfigured">{{$ctrl.timeWindowSecMessage}}</dd>
+  <dd ng-if="$ctrl.scaleDownInConfigured">{{$ctrl.timeWindowSecMessage}}</dd>
   <dt ng-if="$ctrl.serverGroup.autoscalingMessages">Messages</dt>
   <dd ng-if="$ctrl.serverGroup.autoscalingMessages" ng-repeat="message in $ctrl.serverGroup.autoscalingMessages">
     {{message}}

--- a/app/scripts/modules/google/src/serverGroup/details/autoscalingPolicy/autoscalingPolicy.directive.js
+++ b/app/scripts/modules/google/src/serverGroup/details/autoscalingPolicy/autoscalingPolicy.directive.js
@@ -79,20 +79,18 @@ module(GOOGLE_SERVERGROUP_DETAILS_AUTOSCALINGPOLICY_AUTOSCALINGPOLICY_DIRECTIVE,
         policy.bases.push(basis);
       }
 
-      this.scaleDownControlsEnabled = SETTINGS.feature.gceScaleDownControlsEnabled;
-      this.scaleDownControlsConfigured =
-        this.scaleDownControlsEnabled &&
-        policy.scaleDownControl &&
-        policy.scaleDownControl.timeWindowSec &&
-        policy.scaleDownControl.maxScaledDownReplicas &&
-        (policy.scaleDownControl.maxScaledDownReplicas.percent || policy.scaleDownControl.maxScaledDownReplicas.fixed);
+      this.scaleInControlsConfigured =
+        policy.scaleInControl &&
+        policy.scaleInControl.timeWindowSec &&
+        policy.scaleInControl.maxScaledInReplicas &&
+        (policy.scaleInControl.maxScaledInReplicas.percent || policy.scaleInControl.maxScaledInReplicas.fixed);
 
-      if (this.scaleDownControlsConfigured) {
-        this.maxScaledDownReplicasMessage = policy.scaleDownControl.maxScaledDownReplicas.percent
-          ? `${policy.scaleDownControl.maxScaledDownReplicas.percent}%`
-          : `${policy.scaleDownControl.maxScaledDownReplicas.fixed}`;
+      if (this.scaleInControlsConfigured) {
+        this.maxScaledInReplicasMessage = policy.scaleInControl.maxScaledInReplicas.percent
+          ? `${policy.scaleInControl.maxScaledInReplicas.percent}%`
+          : `${policy.scaleInControl.maxScaledInReplicas.fixed}`;
 
-        this.timeWindowSecMessage = `${policy.scaleDownControl.timeWindowSec} seconds`;
+        this.timeWindowSecMessage = `${policy.scaleInControl.timeWindowSec} seconds`;
       }
 
       this.editPolicy = () => {

--- a/app/scripts/modules/google/src/serverGroup/details/autoscalingPolicy/modal/GceAutoScalingFieldLayout.tsx
+++ b/app/scripts/modules/google/src/serverGroup/details/autoscalingPolicy/modal/GceAutoScalingFieldLayout.tsx
@@ -3,7 +3,7 @@ import { isEmpty } from 'lodash';
 
 import { ILayoutProps } from '@spinnaker/core';
 
-import './gceScaleDownControls.less';
+import './gceScaleInControls.less';
 
 // todo(mneterval): remove when GCE Autoscaling Controls are entirely converted to React & Formik
 export function GceAutoScalingFieldLayout(props: ILayoutProps) {
@@ -13,7 +13,7 @@ export function GceAutoScalingFieldLayout(props: ILayoutProps) {
   const { hidden, messageNode } = validation;
 
   return (
-    <div className="gce-scale-down-controls">
+    <div className="gce-scale-in-controls">
       {showLabel && (
         <label className="col-md-3 sm-label-right">
           {label}

--- a/app/scripts/modules/google/src/serverGroup/details/autoscalingPolicy/modal/GceScaleInControls.tsx
+++ b/app/scripts/modules/google/src/serverGroup/details/autoscalingPolicy/modal/GceScaleInControls.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { react2angular } from 'react2angular';
 import { isEmpty } from 'lodash';
 
-import { CheckboxInput, FormField, LayoutProvider, NumberInput, ReactSelectInput, SETTINGS } from '@spinnaker/core';
+import { CheckboxInput, FormField, LayoutProvider, NumberInput, ReactSelectInput } from '@spinnaker/core';
 
 import { GceAutoScalingFieldLayout } from './GceAutoScalingFieldLayout';
 
@@ -13,8 +13,8 @@ enum maxReplicasUnit {
   percent = 'percent',
 }
 
-interface IGceScaleDownControl {
-  maxScaledDownReplicas?: {
+interface IGceScaleInControl {
+  maxScaledInReplicas?: {
     fixed?: number;
     percent?: number;
   };
@@ -22,36 +22,32 @@ interface IGceScaleDownControl {
 }
 
 interface IGceAutoscalingPolicy {
-  scaleDownControl: IGceScaleDownControl;
+  scaleInControl: IGceScaleInControl;
 }
 
-interface IGceScaleDownControlsProps {
+interface IGceScaleInControlsProps {
   policy: IGceAutoscalingPolicy;
   updatePolicy: (policy: IGceAutoscalingPolicy) => void;
 }
 
-const defaultScaleDownControl: IGceScaleDownControl = {
-  maxScaledDownReplicas: {
+const defaultScaleInControl: IGceScaleInControl = {
+  maxScaledInReplicas: {
     fixed: null,
     percent: 0,
   },
   timeWindowSec: 60,
 };
 
-function GceScaleDownControls({ policy, updatePolicy }: IGceScaleDownControlsProps) {
-  if (!SETTINGS.feature.gceScaleDownControlsEnabled) {
-    return null;
-  }
-
-  function updateScaleDownControl(scaleDownControl: IGceScaleDownControl) {
+function GceScaleInControls({ policy, updatePolicy }: IGceScaleInControlsProps) {
+  function updateScaleInControl(scaleInControl: IGceScaleInControl) {
     updatePolicy({
       ...policy,
-      scaleDownControl,
+      scaleInControl,
     });
   }
 
   function getMaxReplicasUnit(): maxReplicasUnit {
-    if (Number.isInteger(policy.scaleDownControl.maxScaledDownReplicas.percent)) {
+    if (Number.isInteger(policy.scaleInControl.maxScaledInReplicas.percent)) {
       return maxReplicasUnit.percent;
     }
     return maxReplicasUnit.fixed;
@@ -62,14 +58,14 @@ function GceScaleDownControls({ policy, updatePolicy }: IGceScaleDownControlsPro
       <div className="row">
         <FormField
           input={inputProps => <CheckboxInput {...inputProps} />}
-          label="Enable scale-down controls"
+          label="Enable scale-in controls"
           onChange={(e: React.ChangeEvent<any>) => {
-            updateScaleDownControl(e.target.checked ? defaultScaleDownControl : {});
+            updateScaleInControl(e.target.checked ? defaultScaleInControl : {});
           }}
-          value={!isEmpty(policy.scaleDownControl)}
+          value={!isEmpty(policy.scaleInControl)}
         />
       </div>
-      {!isEmpty(policy.scaleDownControl) && (
+      {!isEmpty(policy.scaleInControl) && (
         <>
           <div className="row">
             <FormField
@@ -80,16 +76,16 @@ function GceScaleDownControls({ policy, updatePolicy }: IGceScaleDownControlsPro
                   max={getMaxReplicasUnit() === maxReplicasUnit.percent ? 100 : null}
                 />
               )}
-              label="Max scaled-down replicas"
+              label="Max scaled-in replicas"
               onChange={(e: React.ChangeEvent<any>) => {
-                updateScaleDownControl({
-                  ...policy.scaleDownControl,
-                  maxScaledDownReplicas: {
+                updateScaleInControl({
+                  ...policy.scaleInControl,
+                  maxScaledInReplicas: {
                     [getMaxReplicasUnit()]: parseInt(e.target.value, 10),
                   },
                 });
               }}
-              value={policy.scaleDownControl.maxScaledDownReplicas[getMaxReplicasUnit()]}
+              value={policy.scaleInControl.maxScaledInReplicas[getMaxReplicasUnit()]}
             />
             <FormField
               input={inputProps => (
@@ -101,10 +97,10 @@ function GceScaleDownControls({ policy, updatePolicy }: IGceScaleDownControlsPro
               )}
               label=""
               onChange={(e: React.ChangeEvent<any>) => {
-                updateScaleDownControl({
-                  ...policy.scaleDownControl,
-                  maxScaledDownReplicas: {
-                    [e.target.value]: policy.scaleDownControl.maxScaledDownReplicas[getMaxReplicasUnit()],
+                updateScaleInControl({
+                  ...policy.scaleInControl,
+                  maxScaledInReplicas: {
+                    [e.target.value]: policy.scaleInControl.maxScaledInReplicas[getMaxReplicasUnit()],
                   },
                 });
               }}
@@ -116,12 +112,12 @@ function GceScaleDownControls({ policy, updatePolicy }: IGceScaleDownControlsPro
               input={inputProps => <NumberInput {...inputProps} min={60} max={3600} />}
               label="Time window (seconds)"
               onChange={(e: React.ChangeEvent<any>) => {
-                updateScaleDownControl({
-                  ...policy.scaleDownControl,
+                updateScaleInControl({
+                  ...policy.scaleInControl,
                   timeWindowSec: parseInt(e.target.value, 10),
                 });
               }}
-              value={policy.scaleDownControl.timeWindowSec}
+              value={policy.scaleInControl.timeWindowSec}
             />
           </div>
         </>
@@ -130,8 +126,8 @@ function GceScaleDownControls({ policy, updatePolicy }: IGceScaleDownControlsPro
   );
 }
 
-export const GCE_SCALE_DOWN_CONTROLS = 'spinnaker.gce.scaleDownControls';
-module(GCE_SCALE_DOWN_CONTROLS, []).component(
-  'gceScaleDownControls',
-  react2angular(GceScaleDownControls, ['policy', 'updatePolicy']),
+export const GCE_SCALE_IN_CONTROLS = 'spinnaker.gce.scaleInControls';
+module(GCE_SCALE_IN_CONTROLS, []).component(
+  'gceScaleInControls',
+  react2angular(GceScaleInControls, ['policy', 'updatePolicy']),
 );

--- a/app/scripts/modules/google/src/serverGroup/details/autoscalingPolicy/modal/gceScaleInControls.less
+++ b/app/scripts/modules/google/src/serverGroup/details/autoscalingPolicy/modal/gceScaleInControls.less
@@ -1,5 +1,5 @@
 // todo(mneterval): remove when GCE Autoscaling Controls are entirely converted to React & Formik
-.gce-scale-down-controls {
+.gce-scale-in-controls {
   .checkbox {
     margin-left: 5px;
     margin-top: 7px;

--- a/settings.js
+++ b/settings.js
@@ -19,7 +19,6 @@ var displayTimestampsInUserLocalTime = process.env.DISPLAY_TIMESTAMPS_IN_USER_LO
 var dryRunEnabled = process.env.DRYRUN_ENABLED === 'true' ? true : false;
 var entityTagsEnabled = process.env.ENTITY_TAGS_ENABLED === 'true' ? true : false;
 var fiatEnabled = process.env.FIAT_ENABLED === 'true' ? true : false;
-var gceScaleDownControlsEnabled = process.env.GCE_SCALE_DOWN_CONTROLS_ENABLED === 'true' ? true : false;
 var gceStatefulMigsEnabled = process.env.GCE_STATEFUL_MIGS_ENABLED === 'true' ? true : false;
 var iapRefresherEnabled = process.env.IAP_REFRESHER_ENABLED === 'true' ? true : false;
 var managedDeliveryEnabled = process.env.MANAGED_DELIVERY_ENABLED === 'true';
@@ -76,7 +75,6 @@ window.spinnakerSettings = {
     entityTags: entityTagsEnabled,
     executionMarkerInformationModal: false,
     fiatEnabled: fiatEnabled,
-    gceScaleDownControlsEnabled: gceScaleDownControlsEnabled,
     gceStatefulMigsEnabled: gceStatefulMigsEnabled,
     iapRefresherEnabled: iapRefresherEnabled,
     managedDelivery: managedDeliveryEnabled,


### PR DESCRIPTION
This is now on prod, so I think it's okay to remove this flag.

I also updated methods, variables, filenames, etc. to use the new terminology and the updated clouddriver API for this feature.

See spinnaker/clouddriver#4705