### PR TITLE
fix(config): replace kubernetes and oracle keys to halconfig/settings…

### DIFF
--- a/halconfig/settings.js
+++ b/halconfig/settings.js
@@ -136,6 +136,8 @@ window.spinnakerSettings = {
     ecs: ecs,
     gce: gce,
     huaweicloud: huaweicloud,
+    kubernetes: {},
+    oracle: {},
     tencentcloud: tencentcloud,
   },
   version: version,

--- a/settings.js
+++ b/settings.js
@@ -198,6 +198,7 @@ window.spinnakerSettings = {
         region: 'cn-north-1',
       },
     },
+    kubernetes: {},
     oracle: {
       defaults: {
         account: 'DEFAULT',


### PR DESCRIPTION
….js providers map

Partially reverts [this commit](https://github.com/spinnaker/deck/commit/7bb785c1b523e6ac420abe2292b7ce95d47e7e39), in which unread defaults were removed from SETTINGS.providers. Although these defaults are unused, we do rely on the presence of each provider key in the CloudProviderRegistry, so replace an empty object for kubernetes and oracle.