### PR TITLE
feat(core): New App Icon with refresher

### DIFF
--- a/app/scripts/modules/core/src/application/ApplicationFreshIcon.tsx
+++ b/app/scripts/modules/core/src/application/ApplicationFreshIcon.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+import { Overridable } from '../overrideRegistry/Overridable';
+
+import { Icon } from '../presentation';
+
+@Overridable('applicationIcon')
+export class ApplicationFreshIcon extends React.Component<{}> {
+  public render() {
+    return <Icon name="spMenuAppInSync" size="small" appearance="light" />;
+  }
+}

--- a/app/scripts/modules/core/src/application/nav/AppRefresher.tsx
+++ b/app/scripts/modules/core/src/application/nav/AppRefresher.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { Observable, Subject } from 'rxjs';
+
+import { Application } from '../application.model';
+import { ApplicationDataSource, IFetchStatus } from '../service/applicationDataSource';
+
+import { AppRefresherIcon } from './AppRefresherIcon';
+
+export interface IAppRefresherProps {
+  app: Application;
+}
+
+export const AppRefresher = ({ app }: IAppRefresherProps) => {
+  const app$ = new Subject<Application>();
+  const destroy$ = new Subject();
+
+  const [isRefreshing, setIsRefreshing] = React.useState(false);
+  const [lastRefresh, setLastRefresh] = React.useState(0);
+
+  const updateStatus = (fetchStatus: IFetchStatus): void => {
+    if (fetchStatus.status === 'FETCHING') {
+      setIsRefreshing(true);
+    } else if (fetchStatus.status === 'FETCHED') {
+      setIsRefreshing(false);
+      setLastRefresh(fetchStatus.lastRefresh);
+    } else {
+      setIsRefreshing(false);
+    }
+  };
+
+  const handleRefresh = (): void => {
+    app.refresh(true);
+  };
+
+  React.useEffect(() => {
+    app$
+      .filter(app => !!app)
+      .distinctUntilChanged()
+      // follow the data source from the active tab
+      .switchMap(app => app.activeDataSource$)
+      .startWith(null)
+      .mergeMap((dataSource: ApplicationDataSource) => {
+        // If there is no active data source (e.g., on config tab), use the application's status.
+        const fetchStatus$: Observable<IFetchStatus> = (dataSource && dataSource.status$) || app.status$;
+        return fetchStatus$.filter(fetchStatus => ['FETCHING', 'FETCHED', 'ERROR'].includes(fetchStatus.status));
+      })
+      .takeUntil(destroy$)
+      .subscribe(fetchStatus => updateStatus(fetchStatus));
+
+    app$.next(app);
+
+    return () => destroy$.next();
+  }, []);
+
+  React.useEffect(() => {
+    app$.next(app);
+  }, [app]);
+
+  return <AppRefresherIcon lastRefresh={lastRefresh} refreshing={isRefreshing} refresh={handleRefresh} />;
+};

--- a/app/scripts/modules/core/src/application/nav/AppRefresher.tsx
+++ b/app/scripts/modules/core/src/application/nav/AppRefresher.tsx
@@ -31,5 +31,7 @@ export const AppRefresher = ({ app }: IAppRefresherProps) => {
     app.refresh(true);
   };
 
-  return <AppRefresherIcon lastRefresh={lastRefresh} refreshing={isRefreshing} refresh={handleRefresh} />;
+  return (
+    <AppRefresherIcon appName={app.name} lastRefresh={lastRefresh} refreshing={isRefreshing} refresh={handleRefresh} />
+  );
 };

--- a/app/scripts/modules/core/src/application/nav/AppRefresherIcon.tsx
+++ b/app/scripts/modules/core/src/application/nav/AppRefresherIcon.tsx
@@ -7,12 +7,13 @@ import { Icon, Tooltip } from 'core/presentation';
 import { relativeTime, timestamp } from 'core/utils/timeFormatters';
 
 export interface IAppRefreshIconProps {
+  appName: string;
   lastRefresh: number;
   refresh: () => void;
   refreshing: boolean;
 }
 
-export const AppRefresherIcon = ({ lastRefresh, refresh, refreshing }: IAppRefreshIconProps) => {
+export const AppRefresherIcon = ({ appName, lastRefresh, refresh, refreshing }: IAppRefreshIconProps) => {
   const activeRefresher = SchedulerFactory.createScheduler(2000);
   const [timeSinceRefresh, setTimeSinceRefresh] = React.useState(relativeTime(lastRefresh));
   const [iconPulsing, setIconPulsing] = React.useState(false);
@@ -39,22 +40,14 @@ export const AppRefresherIcon = ({ lastRefresh, refresh, refreshing }: IAppRefre
 
   const RefresherTooltip = (
     <span>
-      {refreshing && (
-        <p>
-          Application is <strong>refreshing</strong>.
-        </p>
-      )}
-      {!refreshing && (
-        <p>
-          (click <span className="fa fa-sync-alt" /> to refresh)
-        </p>
-      )}
       <p>
-        Last refresh: {timestamp(lastRefresh)} <br /> ({timeSinceRefresh})
+        <strong>{appName}</strong>
       </p>
-      <p className="small">
-        <strong>Note:</strong> Due to caching, data may be delayed up to 2 minutes
+      <p>{`app data is ${refreshing ? 'refreshing' : 'up to date (click to refresh)'}`}</p>
+      <p>
+        Last refresh: {timestamp(lastRefresh)} <br /> {timeSinceRefresh}
       </p>
+      <p>Note: Due to caching, data may be delayed up to 2 minutes</p>
     </span>
   );
   const isRefreshing = iconPulsing || refreshing;

--- a/app/scripts/modules/core/src/application/nav/AppRefresherIcon.tsx
+++ b/app/scripts/modules/core/src/application/nav/AppRefresherIcon.tsx
@@ -57,12 +57,13 @@ export const AppRefresherIcon = ({ lastRefresh, refresh, refreshing }: IAppRefre
       </p>
     </span>
   );
+  const isRefreshing = iconPulsing || refreshing;
 
   return (
     <Tooltip template={RefresherTooltip} placement={$window.innerWidth < 1100 ? 'bottom' : 'right'}>
-      <div className={`application-header-icon${iconPulsing ? ' header-icon-pulsing' : ''}`} onClick={refreshApp}>
-        {!isStale && !iconPulsing && <ApplicationFreshIcon />}
-        {(isStale || iconPulsing) && <Icon name="spMenuAppUnsynced" size="small" appearance="light" />}
+      <div className={`application-header-icon${isRefreshing ? ' header-icon-pulsing' : ''}`} onClick={refreshApp}>
+        {!isStale && !isRefreshing && <ApplicationFreshIcon />}
+        {(isStale || isRefreshing) && <Icon name="spMenuAppUnsynced" size="small" appearance="light" />}
       </div>
     </Tooltip>
   );

--- a/app/scripts/modules/core/src/application/nav/AppRefresherIcon.tsx
+++ b/app/scripts/modules/core/src/application/nav/AppRefresherIcon.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { $window } from 'ngimport';
+
+import { ApplicationFreshIcon } from '../ApplicationFreshIcon';
+import { SchedulerFactory } from 'core/scheduler';
+import { Icon, Tooltip } from 'core/presentation';
+import { relativeTime, timestamp } from 'core/utils/timeFormatters';
+
+export interface IAppRefreshIconProps {
+  lastRefresh: number;
+  refresh: () => void;
+  refreshing: boolean;
+}
+
+export const AppRefresherIcon = ({ lastRefresh, refresh, refreshing }: IAppRefreshIconProps) => {
+  const activeRefresher = SchedulerFactory.createScheduler(2000);
+  const [timeSinceRefresh, setTimeSinceRefresh] = React.useState(relativeTime(lastRefresh));
+  const [iconPulsing, setIconPulsing] = React.useState(false);
+
+  React.useEffect(() => {
+    activeRefresher.subscribe(() => {
+      setTimeSinceRefresh(relativeTime(lastRefresh));
+    });
+
+    return () => activeRefresher.unsubscribe();
+  }, [lastRefresh]);
+
+  const oldAge = 2 * 60 * 1000; // 2 minutes;
+  const age = new Date().getTime() - lastRefresh;
+  const isStale = age > oldAge;
+
+  const refreshApp = () => {
+    setIconPulsing(true);
+    setTimeout(() => {
+      setIconPulsing(false);
+    }, 3000);
+    refresh();
+  };
+
+  const RefresherTooltip = (
+    <span>
+      {refreshing && (
+        <p>
+          Application is <strong>refreshing</strong>.
+        </p>
+      )}
+      {!refreshing && (
+        <p>
+          (click <span className="fa fa-sync-alt" /> to refresh)
+        </p>
+      )}
+      <p>
+        Last refresh: {timestamp(lastRefresh)} <br /> ({timeSinceRefresh})
+      </p>
+      <p className="small">
+        <strong>Note:</strong> Due to caching, data may be delayed up to 2 minutes
+      </p>
+    </span>
+  );
+
+  return (
+    <Tooltip template={RefresherTooltip} placement={$window.innerWidth < 1100 ? 'bottom' : 'right'}>
+      <div className={`application-header-icon${iconPulsing ? ' header-icon-pulsing' : ''}`} onClick={refreshApp}>
+        {!isStale && !iconPulsing && <ApplicationFreshIcon />}
+        {(isStale || iconPulsing) && <Icon name="spMenuAppUnsynced" size="small" appearance="light" />}
+      </div>
+    </Tooltip>
+  );
+};

--- a/app/scripts/modules/core/src/application/nav/verticalNav.less
+++ b/app/scripts/modules/core/src/application/nav/verticalNav.less
@@ -1,3 +1,5 @@
+@import (reference) '~core/presentation/less/imports/commonImports.less';
+
 .vertical-navigation {
   width: 240px;
   height: 100%;
@@ -13,10 +15,14 @@
       border: 2px solid var(--color-white);
       color: var(--color-white);
       text-align: center;
-      width: 30px;
-      height: 30px;
-      line-height: 28px;
+      width: 32px;
+      height: 32px;
+      line-height: 32px;
       font-size: 15px;
+    }
+
+    .header-icon-pulsing {
+      .pulsing(4);
     }
 
     .refresher {

--- a/app/scripts/modules/core/src/presentation/icons/iconsByName.ts
+++ b/app/scripts/modules/core/src/presentation/icons/iconsByName.ts
@@ -58,6 +58,8 @@ import { ReactComponent as spCIMerged } from './vectors/spCIMerged.svg';
 import { ReactComponent as spCIPullRequest } from './vectors/spCIPullRequest.svg';
 import { ReactComponent as spCIPullRequestClosed } from './vectors/spCIPullRequestClosed.svg';
 import { ReactComponent as spEnvironments } from './vectors/spEnvironments.svg';
+import { ReactComponent as spMenuAppInSync } from './vectors/spMenuAppInSync.svg';
+import { ReactComponent as spMenuAppUnsynced } from './vectors/spMenuAppUnsynced.svg';
 import { ReactComponent as spMenuCanaryConfig } from './vectors/spMenuCanaryConfig.svg';
 import { ReactComponent as spMenuCanaryReport } from './vectors/spMenuCanaryReport.svg';
 import { ReactComponent as spMenuClusters } from './vectors/spMenuClusters.svg';
@@ -202,6 +204,8 @@ export const iconsByName = {
   spCIPullRequest,
   spCIPullRequestClosed,
   spEnvironments,
+  spMenuAppInSync,
+  spMenuAppUnsynced,
   spMenuCanaryConfig,
   spMenuCanaryReport,
   spMenuClusters,

--- a/app/scripts/modules/core/src/presentation/main.less
+++ b/app/scripts/modules/core/src/presentation/main.less
@@ -533,6 +533,8 @@ dl {
 
 .tooltip-inner {
   overflow-wrap: break-word;
+  max-width: 350px;
+  text-align: left;
   p:last-child {
     margin-bottom: 0;
   }
@@ -1328,7 +1330,7 @@ body > .select2-container.open {
   z-index: 10003;
 }
 
-.tooltip,
+app,
 .popover {
   font-family: 'Source Sans Pro', sans-serif;
   z-index: 10004;

--- a/app/scripts/modules/core/src/presentation/main.less
+++ b/app/scripts/modules/core/src/presentation/main.less
@@ -1330,7 +1330,7 @@ body > .select2-container.open {
   z-index: 10003;
 }
 
-app,
+.tooltip,
 .popover {
   font-family: 'Source Sans Pro', sans-serif;
   z-index: 10004;


### PR DESCRIPTION
This will replace `ApplicationRefresher`, `ApplicationIcon` and `Refresher` once the new navigation rolls out. 

The icon will toggle between `ApplicationFreshIcon` (or overridden Icon) and the stale icon. When it clicks it will refresh the page.

Fresh (not overridden):
<img width="44" alt="Screen Shot 2020-06-25 at 4 18 12 PM" src="https://user-images.githubusercontent.com/26560152/85805059-27923e00-b700-11ea-8baf-2d1f21f065cc.png">
Stale w/ Tooltip:
<img width="323" alt="Screen Shot 2020-06-25 at 4 18 35 PM" src="https://user-images.githubusercontent.com/26560152/85805074-2e20b580-b700-11ea-9562-7bbf2dd0b3c9.png">


