### PR TITLE
fix(core/presentation): protect against width overflow on Modal + StandardGridTableLayout

### DIFF
--- a/app/scripts/modules/core/src/managed/ManagedResourceHistoryModal.tsx
+++ b/app/scripts/modules/core/src/managed/ManagedResourceHistoryModal.tsx
@@ -146,7 +146,7 @@ const renderExpandedRowContent = (
   dismissModal: () => any,
 ) => {
   return (
-    <div className="flex-container-v left" style={{ maxWidth: '90vw' }}>
+    <div className="flex-container-v left">
       {message && (
         <div
           className={classNames('sp-padding-xs-yaxis', {

--- a/app/scripts/modules/core/src/presentation/modal/Modal.module.css
+++ b/app/scripts/modules/core/src/presentation/modal/Modal.module.css
@@ -122,15 +122,18 @@
 
 .dialogSizer {
   display: grid;
+  grid-template-columns: 1fr;
   grid-template-rows: 1fr;
   max-height: calc(100vh - 64px);
   min-height: 320px;
+  width: calc(100vw - 128px);
   margin: 0 64px;
 }
 
 @media belowMobileSize {
   .dialogSizer {
     max-height: calc(100vh - 32px);
+    width: calc(100vw - 48px);
     margin: 0 24px;
   }
 }
@@ -145,8 +148,8 @@
 .dialog {
   display: flex;
   position: relative;
-  grid-column: 1;
-  grid-row: 1;
+  grid-column: 1 / -1;
+  grid-row: 1 / -1;
   flex-direction: column;
   overflow: hidden;
   border-radius: 8px;

--- a/app/scripts/modules/core/src/presentation/modal/Modal.tsx
+++ b/app/scripts/modules/core/src/presentation/modal/Modal.tsx
@@ -51,8 +51,7 @@ export const Modal = ({ isOpen, maxWidth, onRequestClose, onAfterClose, children
               <div
                 className={styles.dialogSizer}
                 style={{
-                  gridTemplateColumns: `minmax(min-content, ${(isNumber(maxWidth) ? `${maxWidth}px` : maxWidth) ??
-                    DEFAULT_MAX_WIDTH})`,
+                  maxWidth: (isNumber(maxWidth) ? `${maxWidth}px` : maxWidth) ?? DEFAULT_MAX_WIDTH,
                 }}
               >
                 <div className={styles.dialog}>{children}</div>

--- a/app/scripts/modules/core/src/presentation/tables/standardGridTableLayout.less
+++ b/app/scripts/modules/core/src/presentation/tables/standardGridTableLayout.less
@@ -84,6 +84,10 @@
     }
   }
 
+  .standard-grid-table-row-container {
+    display: grid;
+  }
+
   .standard-grid-table-row {
     display: grid;
     min-height: 40px;
@@ -92,6 +96,7 @@
     font-size: 13px;
     padding: 8px 0;
     grid-column: 1 / -1;
+    grid-row: 1;
 
     &.expandable {
       cursor: pointer;
@@ -127,6 +132,7 @@
   .expanded-row-content {
     /* stretch across entire table width */
     grid-column: 1 / -1;
+    grid-row: 2;
     background-color: var(--color-white);
     padding: 16px;
     overflow-x: scroll;

--- a/app/scripts/modules/core/src/presentation/tables/standardGridTableLayout.tsx
+++ b/app/scripts/modules/core/src/presentation/tables/standardGridTableLayout.tsx
@@ -104,7 +104,7 @@ const TableRowLayout = ({
 
   return (
     <div
-      className={classNames('flex-container-v standard-grid-table-row-container', {
+      className={classNames('standard-grid-table-row-container', {
         'sp-margin-l-bottom': rowExpandable && expanded,
       })}
     >


### PR DESCRIPTION
Recently an issue was exposed with how both `Modal` and `StandardGridTableLayout` handle content that overflows their intended width ([temporary hotfix PR](https://github.com/spinnaker/deck/pull/8378)). This PR attempts to protect against content overflow on both components, so that regardless of what's being displayed inside a table or modal overflowing works as one would expect:

1. Unclear to me whether it's always been this way vs. it being a regression from [my recent changes](https://github.com/spinnaker/deck/pull/8237), but as of this moment `Modal` will grow beyond both the viewport width and its own intended max width if something inside the modal gets greedy and forces itself to be a larger width. While the grid layout stuff I added in #8237 generally works, it turns out the downside is an inability to forcefully cap the width while retaining flexibility in the way we were aiming for. I took the approach here of moving back to a combination of `width` and `max-width` while keeping the rest of #8237 which gets us the behavior we want: modal content that is too wide for the modal's available width becomes horizontally scrollable without affecting the parent container, and the modal itself will flex up to the maximum available space until it hits the user defined (or default) max width.
2. The other discovery was that expanded row content in `StandardGridTableLayout` is not currently confined to whatever space is available to the table — if row content (in this case the diff tables in the history UI) decides it has to be a particular width, it is free to force the entire table to grow in width. With `Modal` fixed we at least get a graceful handling of that problem (you can scroll around within a properly sized modal to look at the now-giant table), but it's still a problem. Turns out it was easy enough to retain flexibility by taking the flex layout that housed the row and its expanded content and turning it into a grid, which combined with the already existing `overflow-x: scroll` gives us the right behavior.

In addition to getting sensible overflow handling for anything using either of these components in the future, the immediate-term result of 1 + 2 is that the history UI shows a properly sized modal, with a properly sized table, and a big horizontally scrollable diff table nested in the right spot:

![horizontal-table-scroll](https://user-images.githubusercontent.com/1850998/86295708-120f8f00-bbac-11ea-979d-e53cb74e3e3e.gif)