### PR TITLE
fix(core): Executions css causing overflow

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/graph/pipelineGraph.less
+++ b/app/scripts/modules/core/src/pipeline/config/graph/pipelineGraph.less
@@ -175,5 +175,4 @@ svg.pipeline-graph {
   background-color: var(--color-cirrus);
   border: 1px solid var(--color-alto);
   border-top: none;
-  max-width: 72vw;
 }

--- a/app/scripts/modules/core/src/pipeline/executions/executions.less
+++ b/app/scripts/modules/core/src/pipeline/executions/executions.less
@@ -5,7 +5,7 @@
 }
 .executions-section {
   display: flex;
-  flex: 1 1 auto;
+  width: 100%;
   margin-top: 6px;
 
   .insight {
@@ -13,6 +13,7 @@
     margin-top: 6px;
     display: flex;
     flex-direction: row;
+    width: 100%;
 
     .nav {
       flex-shrink: 0;
@@ -21,8 +22,7 @@
 
     .nav-content {
       margin-left: 12px;
-      // override
-      max-width: unset;
+      max-width: 80%;
 
       .execution-groups-header {
         margin-left: -8px;
@@ -62,6 +62,9 @@
   .insight.filters-collapsed {
     .execution-groups-header {
       margin-left: 84px;
+    }
+    .nav-content {
+      max-width: 100%;
     }
   }
 


### PR DESCRIPTION
The executions view is different than the other views. In order to support a variable width pipeline graph with a scrolling out container, more strict `max-widths` need to be enforced on the broader parent containers. 