### PR TITLE
fix(core): Protect rendering when deploymentMonitor is null

### DIFF
--- a/app/scripts/modules/core/src/deploymentStrategy/strategies/monitored/AdditionalFields.tsx
+++ b/app/scripts/modules/core/src/deploymentStrategy/strategies/monitored/AdditionalFields.tsx
@@ -107,11 +107,11 @@ export class AdditionalFields extends React.Component<
               clearable={false}
               required={true}
               options={this.state.deploymentMonitors.map(deploymentMonitor => ({
-                label: deploymentMonitor.name,
-                value: deploymentMonitor.id,
+                label: deploymentMonitor?.name || '',
+                value: deploymentMonitor?.id || '',
               }))}
               placeholder="select deployment monitor"
-              value={command.deploymentMonitor.id || ''}
+              value={command.deploymentMonitor?.id || ''}
               onChange={this.handleDeploymentMonitorChange}
             />
           </div>


### PR DESCRIPTION
This protects failure in rendering the Edit Deploy Stage modal. It is an edge case, but if the `deploymentMonitor` is `undefined` then the modal will not open - this could happen if using the API.