### PR TITLE
fix(core): Custom banner pushes details panel off screen

### DIFF
--- a/app/scripts/modules/core/src/presentation/main.less
+++ b/app/scripts/modules/core/src/presentation/main.less
@@ -291,6 +291,7 @@ html {
     right: 0;
     height: 100%;
     width: 390px;
+    padding-bottom: 24px;
 
     @media (max-width: 390px) {
       width: 100%;


### PR DESCRIPTION
Add padding to counteract custom banners pushing the detail content down. This also aligns the content with the bottom of the filters and main panels.