### PR TITLE
fix(core): Filters should not re-render multiples times after loading

### DIFF
--- a/app/scripts/modules/core/src/cluster/filter/ClusterFilters.tsx
+++ b/app/scripts/modules/core/src/cluster/filter/ClusterFilters.tsx
@@ -160,8 +160,10 @@ export const ClusterFilters = ({ app }: IClusterFiltersProps) => {
   };
 
   React.useEffect(() => {
-    updateClusterGroups();
-  }, [serverGroupData.length, tags.length]);
+    if (clustersLoaded) {
+      updateClusterGroups();
+    }
+  }, [clustersLoaded, tags.length]);
 
   return (
     <div className="insight-filter-content">

--- a/app/scripts/modules/core/src/securityGroup/filter/SecurityGroupFilters.tsx
+++ b/app/scripts/modules/core/src/securityGroup/filter/SecurityGroupFilters.tsx
@@ -130,8 +130,10 @@ export const SecurityGroupFilters = ({ app }: ISecurityGroupFiltersProps) => {
   };
 
   React.useEffect(() => {
-    updateSecurityGroups();
-  }, [securityGroupData.length, tags.length]);
+    if (securityGroupsLoaded) {
+      updateSecurityGroups();
+    }
+  }, [securityGroupsLoaded, tags.length]);
 
   return (
     <div className="insight-filter-content">


### PR DESCRIPTION
Filters were being reset from a custom url because they were rendering too many times before the datasource was finished loading. The `useEffect` was updated to prevent this. 