### PR TITLE
fix(amazon): Instance details is not displayed

### DIFF
--- a/app/scripts/modules/amazon/src/instance/details/instance.details.controller.js
+++ b/app/scripts/modules/amazon/src/instance/details/instance.details.controller.js
@@ -64,7 +64,9 @@ module(AMAZON_INSTANCE_DETAILS_INSTANCE_DETAILS_CONTROLLER, [
 
       if (!app.isStandalone) {
         // augment with target group healthcheck data
-        const targetGroups = getAllTargetGroups(app.loadBalancers.data);
+        const targetGroups = getAllTargetGroups(app.loadBalancers.data.filter(function(loadBalancer) {
+          return loadBalancer.cloudProvider === 'aws';
+        }));
         applyHealthCheckInfoToTargetGroups(displayableMetrics, targetGroups, instance.account);
       }
 


### PR DESCRIPTION
We have a Spinnaker application where we deploy both in AWS and Kubernetes. When I try to display the details of an AWS instance, I get "Instance not found." in the UI and this error in the console:
```
TypeError: "g is undefined"
    _a utils.ts:20
    applyHealthCheckInfoToTargetGroups utils.ts:20
    applyHealthCheckInfoToTargetGroups utils.ts:19
    applyHealthCheckInfoToTargetGroups utils.ts:17
    retrieveInstance instance.details.controller.js:68
    retrieveInstance instance.details.controller.js:192
    Angular 7
 Possibly unhandled rejection: {} angular.js:14961:40
```

While investigating, I found out that get the variable `app.loadBalancers.data` contains data coming from both of the providers and led to store `undefined` in `allTargetGroups` [array](https://github.com/spinnaker/deck/blob/master/app/scripts/modules/amazon/src/instance/details/utils.ts#L7) because the Kubernetes loadbalancer object does not have the property `targetGroups`. Then when we iterate over the target groups in `applyHealthCheckInfoToTargetGroups`, it tries to access properties on `undefined` and fails with the error above.

The solution I suggest is to ensure that `getAllTargetGroups` is called only with AWS objects.