### PR TITLE
fix(project dashboard) columns not overlapping

### DIFF
--- a/app/scripts/modules/core/src/projects/dashboard/dashboard.html
+++ b/app/scripts/modules/core/src/projects/dashboard/dashboard.html
@@ -1,6 +1,6 @@
 <div ng-if="!vm.project.notFound" class="project-dashboard container">
   <div class="row">
-    <div class="col-md-7">
+    <div class="col-md-7 project-column">
       <h3>
         Application Status
         <component-refresher
@@ -17,7 +17,7 @@
       <h4 ng-if="!vm.project.config.clusters.length">No clusters configured</h4>
       <h4 ng-if="vm.state.clusters.error">There was a problem loading the clusters for this project.</h4>
     </div>
-    <div class="col-md-5">
+    <div class="col-md-5 project-column">
       <h3>
         Pipeline Status
         <component-refresher

--- a/app/scripts/modules/core/src/projects/dashboard/dashboard.less
+++ b/app/scripts/modules/core/src/projects/dashboard/dashboard.less
@@ -3,4 +3,8 @@
   h3 {
     font-weight: 600;
   }
+
+  .project-column {
+    overflow-x: scroll;
+  }
 }


### PR DESCRIPTION
When adding clusters to the project dashboard, it often ends up overlapping on the application pipelines side as discussed here:  https://github.com/spinnaker/spinnaker/issues/4925

Added a subclass to make the columns on the project dashboard scrollable.