### PR TITLE
fix(core): CSS for details panel

### DIFF
--- a/app/scripts/modules/core/src/presentation/details.less
+++ b/app/scripts/modules/core/src/presentation/details.less
@@ -59,7 +59,7 @@
   background-color: var(--color-white);
   box-shadow: -2px 2px 3px 1px var(--color-alto);
   margin-left: var(--xs-spacing);
-  padding-bottom: 36px;
+  padding-bottom: 12px;
 
   .actions {
     display: flex;

--- a/app/scripts/modules/core/src/presentation/main.less
+++ b/app/scripts/modules/core/src/presentation/main.less
@@ -286,12 +286,11 @@ html {
 
   .detail-content {
     z-index: var(--layer-high);
-    position: fixed;
+    position: absolute;
     margin-top: -20px;
     right: 0;
-    height: 98%;
+    height: 100%;
     width: 390px;
-    padding-bottom: 28px;
 
     @media (max-width: 390px) {
       width: 100%;

--- a/app/scripts/modules/core/src/presentation/main.less
+++ b/app/scripts/modules/core/src/presentation/main.less
@@ -289,9 +289,9 @@ html {
     position: fixed;
     margin-top: -20px;
     right: 0;
-    height: 100%;
+    height: 98%;
     width: 390px;
-    padding-bottom: 24px;
+    padding-bottom: 28px;
 
     @media (max-width: 390px) {
       width: 100%;

--- a/app/scripts/modules/core/src/projects/project.less
+++ b/app/scripts/modules/core/src/projects/project.less
@@ -8,6 +8,7 @@
 
   .container {
     margin-left: 47px;
+    width: 100%;
   }
 
   h2 {

--- a/app/scripts/modules/core/src/projects/project.less
+++ b/app/scripts/modules/core/src/projects/project.less
@@ -58,6 +58,12 @@
       margin-top: -10px;
     }
   }
+
+  .insight {
+    .detail-content {
+      height: calc(~'100% - 54px');
+    }
+  }
 }
 
 .table-search-results-project {


### PR DESCRIPTION
Two css fixes: 
1. The project header being full-width was being overwritten by custom styles. This moves the `width: 100%` to a more specific set of classes to ensure there are no issues.
2. Tweaking the height of the details panel so there are no scrolling issues. 