### PR TITLE
feat(core): refactor insight menu from dropdown to buttons

### DIFF
--- a/app/scripts/modules/core/src/insight/InsightMenu.spec.tsx
+++ b/app/scripts/modules/core/src/insight/InsightMenu.spec.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { mock } from 'angular';
+import { ReactWrapper, mount } from 'enzyme';
+import { IInsightMenuProps, IInsightMenuState, InsightMenu } from './InsightMenu';
+import { IModalService } from 'angular-ui-bootstrap';
+import { OverrideRegistry } from '../overrideRegistry/override.registry';
+import { CacheInitializerService } from '../cache/cacheInitializer.service';
+import { Button } from 'react-bootstrap';
+
+beforeEach(() => {
+  mock.module(($provide: any) => {
+    $provide.value('$uibModal', {} as IModalService);
+    $provide.value('overrideRegistry', {} as OverrideRegistry);
+    $provide.value('cacheInitializer', {} as CacheInitializerService);
+  });
+});
+
+describe('<InsightMenu />', () => {
+  let component: ReactWrapper<IInsightMenuProps, IInsightMenuState>;
+
+  function getNewMenu(params: object): ReactWrapper<IInsightMenuProps, any> {
+    // Set defaults to zero so we only need to pass in the prop we want rendered
+    const mergedParams = { ...{ createApp: false, createProject: false, refreshCaches: false }, ...params };
+    return mount(
+      <InsightMenu
+        createApp={mergedParams.createApp}
+        createProject={mergedParams.createProject}
+        refreshCaches={mergedParams.refreshCaches}
+      />,
+    );
+  }
+
+  it('should only render create application button when initialized', () => {
+    component = getNewMenu({ createApp: true });
+    const btn = component.find(Button);
+
+    expect(btn.length).toBe(1);
+    expect(btn.text()).toEqual('Create Application');
+    // Button should always be primary for create application
+    // FIXME: when this project moves to v1+ of react-bootstrap this prop will need to change.
+    expect(btn.prop('bsStyle')).toEqual('primary');
+  });
+
+  it('should only render create project button when initialized', () => {
+    component = getNewMenu({ createProject: true });
+
+    const btn = component.find(Button);
+
+    expect(btn.length).toBe(1);
+    expect(btn.text()).toEqual('Create Project');
+    // If project is the only button rendered, it should be primary.
+    // FIXME: when this project moves to v1+ of react-bootstrap this prop will need to change.
+    expect(btn.prop('bsStyle')).toEqual('primary');
+  });
+
+  it('should only render refresh cache button when initialized', () => {
+    // note: this test doesn't validate the state changes that could occur w/
+    //       the refresh button in particular.
+    component = getNewMenu({ refreshCaches: true });
+
+    const btn = component.find(Button);
+
+    expect(btn.length).toBe(1);
+    expect(btn.text()).toMatch('Refresh');
+  });
+
+  it('should only render create application as primary when multiple buttons are rendered', () => {
+    component = getNewMenu({ createApp: true, createProject: true });
+
+    const btns = component.find(Button);
+    const proj = btns.at(0);
+    const app = btns.at(1);
+
+    expect(btns.length).toBe(2);
+    // Project button should be first
+    expect(proj.text()).toEqual('Create Project');
+    // FIXME: when this project moves to v1+ of react-bootstrap this prop will need to change.
+    expect(proj.prop('bsStyle')).toEqual('default');
+    // Application button should be second, so that it renders furthest to the right
+    expect(app.text()).toEqual('Create Application');
+    // FIXME: when this project moves to v1+ of react-bootstrap this prop will need to change.
+    expect(app.prop('bsStyle')).toEqual('primary');
+  });
+});

--- a/app/scripts/modules/core/src/insight/InsightMenu.tsx
+++ b/app/scripts/modules/core/src/insight/InsightMenu.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { IScope } from 'angular';
-import { DropdownButton, MenuItem } from 'react-bootstrap';
+import { Button } from 'react-bootstrap';
 import { StateService } from '@uirouter/core';
 import { IModalService } from 'angular-ui-bootstrap';
 
@@ -87,23 +87,35 @@ export class InsightMenu extends React.Component<IInsightMenuProps, IInsightMenu
     );
 
     return (
-      <DropdownButton pullRight={true} title="Actions" id="insight-menu">
-        {createApp && (
-          <MenuItem href="javascript:void(0)" onClick={this.createApplication}>
-            Create Application
-          </MenuItem>
-        )}
+      <div id="insight-menu">
         {createProject && (
-          <MenuItem href="javascript:void(0)" onClick={this.createProject}>
+          <Button
+            bsStyle={createApp ? 'default' : 'primary'}
+            href="javascript:void(0)"
+            onClick={this.createProject}
+            style={{ marginRight: createApp ? '5px' : '' }}
+          >
             Create Project
-          </MenuItem>
+          </Button>
         )}
+
+        {createApp && (
+          <Button
+            bsStyle="primary"
+            href="javascript:void(0)"
+            onClick={this.createApplication}
+            style={{ marginRight: refreshCaches ? '5px' : '' }}
+          >
+            Create Application
+          </Button>
+        )}
+
         {refreshCaches && (
-          <MenuItem href="javascript:void(0)" onClick={this.refreshAllCaches}>
+          <Button href="javascript:void(0)" onClick={this.refreshAllCaches}>
             {refreshMarkup}
-          </MenuItem>
+          </Button>
         )}
-      </DropdownButton>
+      </div>
     );
   }
 }

--- a/app/scripts/modules/core/src/projects/projects.controller.js
+++ b/app/scripts/modules/core/src/projects/projects.controller.js
@@ -1,6 +1,8 @@
 'use strict';
 import { module } from 'angular';
 
+import { react2angular } from 'react2angular';
+
 import { ANY_FIELD_FILTER } from '../presentation/anyFieldFilter/anyField.filter';
 import { INSIGHT_MENU_DIRECTIVE } from '../insight/insightmenu.directive';
 import { ViewStateCache } from 'core/cache';
@@ -10,6 +12,8 @@ import { ProjectReader } from './service/ProjectReader';
 import { CORE_PRESENTATION_SORTTOGGLE_SORTTOGGLE_DIRECTIVE } from '../presentation/sortToggle/sorttoggle.directive';
 import UIROUTER_ANGULARJS from '@uirouter/angularjs';
 
+import { InsightMenu as ProjectInsightMenu } from 'core/insight/InsightMenu';
+
 export const CORE_PROJECTS_PROJECTS_CONTROLLER = 'spinnaker.projects.controller';
 export const name = CORE_PROJECTS_PROJECTS_CONTROLLER; // for backwards compatibility
 module(CORE_PROJECTS_PROJECTS_CONTROLLER, [
@@ -17,84 +21,86 @@ module(CORE_PROJECTS_PROJECTS_CONTROLLER, [
   ANY_FIELD_FILTER,
   CORE_PRESENTATION_SORTTOGGLE_SORTTOGGLE_DIRECTIVE,
   INSIGHT_MENU_DIRECTIVE,
-]).controller('ProjectsCtrl', [
-  '$scope',
-  '$uibModal',
-  '$log',
-  '$filter',
-  function($scope, $uibModal, $log, $filter) {
-    const projectsViewStateCache =
-      ViewStateCache.get('projects') || ViewStateCache.createCache('projects', { version: 1 });
+])
+  .component('projectInsightMenu', react2angular(ProjectInsightMenu, ['createApp', 'createProject', 'refreshCaches']))
+  .controller('ProjectsCtrl', [
+    '$scope',
+    '$uibModal',
+    '$log',
+    '$filter',
+    function($scope, $uibModal, $log, $filter) {
+      const projectsViewStateCache =
+        ViewStateCache.get('projects') || ViewStateCache.createCache('projects', { version: 1 });
 
-    function cacheViewState() {
-      projectsViewStateCache.put('#global', $scope.viewState);
-    }
+      function cacheViewState() {
+        projectsViewStateCache.put('#global', $scope.viewState);
+      }
 
-    function initializeViewState() {
-      $scope.viewState = projectsViewStateCache.get('#global') || {
-        sortModel: { key: 'name' },
-        projectFilter: '',
-      };
-    }
+      function initializeViewState() {
+        $scope.viewState = projectsViewStateCache.get('#global') || {
+          sortModel: { key: 'name' },
+          projectFilter: '',
+        };
+      }
 
-    $scope.projectsLoaded = false;
+      $scope.projectsLoaded = false;
 
-    $scope.projectFilter = '';
+      $scope.projectFilter = '';
 
-    $scope.menuActions = [
-      {
-        displayName: 'Create Project',
-        action: function() {
-          ConfigureProjectModal.show().catch(() => {});
+      $scope.menuActions = [
+        {
+          displayName: 'Create Project',
+          action: function() {
+            ConfigureProjectModal.show().catch(() => {});
+          },
         },
-      },
-    ];
+      ];
 
-    this.filterProjects = function filterProjects() {
-      const filtered = $filter('anyFieldFilter')($scope.projects, {
-        name: $scope.viewState.projectFilter,
-        email: $scope.viewState.projectFilter,
-      });
-      const sorted = $filter('orderBy')(filtered, $scope.viewState.sortModel.key);
-      $scope.filteredProjects = sorted;
-      this.resetPaginator();
-    };
-
-    this.resultPage = function resultPage() {
-      const pagination = $scope.pagination;
-      const allFiltered = $scope.filteredProjects;
-      const start = (pagination.currentPage - 1) * pagination.itemsPerPage;
-      const end = pagination.currentPage * pagination.itemsPerPage;
-      if (!allFiltered || !allFiltered.length) {
-        return [];
-      }
-      if (allFiltered.length < pagination.itemsPerPage) {
-        return allFiltered;
-      }
-      if (allFiltered.length < end) {
-        return allFiltered.slice(start);
-      }
-      return allFiltered.slice(start, end);
-    };
-
-    this.resetPaginator = function resetPaginator() {
-      $scope.pagination = {
-        currentPage: 1,
-        itemsPerPage: 12,
-        maxSize: 12,
+      this.filterProjects = function filterProjects() {
+        const filtered = $filter('anyFieldFilter')($scope.projects, {
+          name: $scope.viewState.projectFilter,
+          email: $scope.viewState.projectFilter,
+        });
+        const sorted = $filter('orderBy')(filtered, $scope.viewState.sortModel.key);
+        $scope.filteredProjects = sorted;
+        this.resetPaginator();
       };
-    };
 
-    const ctrl = this;
+      this.resultPage = function resultPage() {
+        const pagination = $scope.pagination;
+        const allFiltered = $scope.filteredProjects;
+        const start = (pagination.currentPage - 1) * pagination.itemsPerPage;
+        const end = pagination.currentPage * pagination.itemsPerPage;
+        if (!allFiltered || !allFiltered.length) {
+          return [];
+        }
+        if (allFiltered.length < pagination.itemsPerPage) {
+          return allFiltered;
+        }
+        if (allFiltered.length < end) {
+          return allFiltered.slice(start);
+        }
+        return allFiltered.slice(start, end);
+      };
 
-    ProjectReader.listProjects().then(function(projects) {
-      $scope.projects = projects;
-      ctrl.filterProjects();
-      $scope.projectsLoaded = true;
-    });
+      this.resetPaginator = function resetPaginator() {
+        $scope.pagination = {
+          currentPage: 1,
+          itemsPerPage: 12,
+          maxSize: 12,
+        };
+      };
 
-    $scope.$watch('viewState', cacheViewState, true);
+      const ctrl = this;
 
-    initializeViewState();
-  },
-]);
+      ProjectReader.listProjects().then(function(projects) {
+        $scope.projects = projects;
+        ctrl.filterProjects();
+        $scope.projectsLoaded = true;
+      });
+
+      $scope.$watch('viewState', cacheViewState, true);
+
+      initializeViewState();
+    },
+  ]);

--- a/app/scripts/modules/core/src/projects/projects.html
+++ b/app/scripts/modules/core/src/projects/projects.html
@@ -13,7 +13,7 @@
         />
       </h2>
       <div class="header-actions">
-        <insight-menu data-purpose="projects-menu" actions="menuActions" right-align="true"> </insight-menu>
+        <project-insight-menu create-app="false" create-project="true" refresh-caches="false" />
       </div>
     </div>
   </div>

--- a/app/scripts/modules/core/src/search/infrastructure/infrastructure.controller.js
+++ b/app/scripts/modules/core/src/search/infrastructure/infrastructure.controller.js
@@ -4,6 +4,8 @@ import _ from 'lodash';
 
 import * as angular from 'angular';
 
+import { react2angular } from 'react2angular';
+
 import { FirewallLabels } from 'core/securityGroup/label';
 import { SEARCH_RANK_FILTER } from '../searchRank.filter';
 import { OVERRIDE_REGISTRY } from 'core/overrideRegistry/override.registry';
@@ -17,6 +19,7 @@ import { ClusterState } from 'core/state';
 
 import { SearchService } from '../search.service';
 import { ConfigureProjectModal } from 'core/projects';
+import { InsightMenu as SearchInsightMenu } from 'core/insight/InsightMenu';
 
 export const CORE_SEARCH_INFRASTRUCTURE_INFRASTRUCTURE_CONTROLLER = 'spinnaker.search.infrastructure.controller';
 export const name = CORE_SEARCH_INFRASTRUCTURE_INFRASTRUCTURE_CONTROLLER; // for backwards compatibility
@@ -31,6 +34,7 @@ angular
     RECENTLY_VIEWED_ITEMS_COMPONENT,
     SPINNER_COMPONENT,
   ])
+  .component('searchInsightMenu', react2angular(SearchInsightMenu, ['createApp', 'createProject', 'refreshCaches']))
   .controller('InfrastructureCtrl', [
     '$scope',
     'infrastructureSearchService',
@@ -142,12 +146,12 @@ angular
 
       this.menuActions = [
         {
-          displayName: 'Create Application',
-          action: this.createApplicationForTests,
-        },
-        {
           displayName: 'Create Project',
           action: this.createProject,
+        },
+        {
+          displayName: 'Create Application',
+          action: this.createApplicationForTests,
         },
       ];
 

--- a/app/scripts/modules/core/src/search/infrastructure/infrastructure.html
+++ b/app/scripts/modules/core/src/search/infrastructure/infrastructure.html
@@ -19,27 +19,7 @@
         </div>
       </h2>
       <div class="header-actions">
-        <div class="dropdown" uib-dropdown dropdown-append-to-body>
-          <button type="button" class="btn btn-default dropdown-toggle" uib-dropdown-toggle>
-            Actions <span class="caret"></span>
-          </button>
-          <ul uib-dropdown-menu class="uib-dropdown-menu">
-            <li ng-repeat="action in ctrl.menuActions">
-              <a
-                href
-                ng-if="action.disableAutoClose"
-                ng-click="action.action(status)"
-                ng-bind-html="action.displayName"
-              ></a>
-              <a
-                href
-                ng-if="!action.disableAutoClose"
-                ng-click="action.action(); status.isOpen = false"
-                ng-bind-html="action.displayName"
-              ></a>
-            </li>
-          </ul>
-        </div>
+        <search-insight-menu create-app="true" createProject="true" refresh-caches="false" />
       </div>
     </div>
   </div>

--- a/test/functional/cypress/integration/core/create_application.js
+++ b/test/functional/cypress/integration/core/create_application.js
@@ -4,7 +4,6 @@ describe('core: Create Application', () => {
   beforeEach(() => registerDefaultFixtures());
   it(`shows a config screen with required fields preventing creation until they're populated`, () => {
     cy.visit('#/applications');
-    cy.get('button:contains("Actions")').click();
     cy.get('a:contains("Create Application")').click();
 
     cy.get('button:contains("Create")').should('be.disabled');
@@ -20,7 +19,6 @@ describe('core: Create Application', () => {
     cy.route('/applications/testapp1?expand=false', 'fixture:core/create_application/testapp1.json');
 
     cy.visit('#/applications');
-    cy.get('button:contains("Actions")').click();
     cy.get('a:contains("Create Application")').click();
 
     cy.get('input[name=name]').type('testapp1');


### PR DESCRIPTION
The motivation for this change is to better surface an action for the user to
take when they are on the search, project, and application pages. The current
UX obscures the next appropriate action behind a drop down menu that visually
blends into the page, making it difficult for users to know what to do next.

The proposed change is to replace the drop down menu with buttons rendered
appropriately for each page. When on the search page, both create project and
application buttons are rendered, with a call to action for create application.
When on project or application pages, only render those buttons. Finally, if a
cache refresh is needed, render this on all pages when appropriate.

At a technical level, this unifies the three dropdowns which currently depend
on 2 separate angular controllers and a react component. The component has been
used in favor of the angular implementations on both search and project pages.

The only thing I'm not really sure of is if I've done the `react2angular` thing correctly 🤷 I'm sure someone will this out in the PR :)

Here are a few screenshots of how this looks:
<kbd>![](https://p-qKFvWn.b3.n0.cdn.getcloudapp.com/items/xQuDyjOQ/Screen%20Shot%202020-07-22%20at%201.32.18%20PM.png?v=a60dc42a8c6e87c82479f74e10b36d3b)</kbd>
<kbd>![](https://p-qKFvWn.b3.n0.cdn.getcloudapp.com/items/qGuKkRqj/Screen%20Shot%202020-07-22%20at%201.32.23%20PM.png?v=a5a511c01523c482bffd26e3b06d14aa)</kbd>
<kbd>![](https://p-qKFvWn.b3.n0.cdn.getcloudapp.com/items/RBuq8Jw9/Screen%20Shot%202020-07-22%20at%204.12.31%20PM.png?v=003c5a2e07a747832123885d38bed5ea)</kbd>