### PR TITLE
fix(core): Rename nav item class to prevent FOUC

### DIFF
--- a/app/scripts/modules/core/src/application/nav/NavItem.tsx
+++ b/app/scripts/modules/core/src/application/nav/NavItem.tsx
@@ -31,7 +31,7 @@ export const NavItem = ({ app, dataSource, isActive }: INavItemProps) => {
   return (
     <div className="nav-category flex-container-h middle sp-padding-s-yaxis">
       <div className={badgeClassNames}>{runningCount > 0 ? runningCount : ''}</div>
-      <div className="nav-item">
+      <div className="nav-row-item">
         {iconName &&
           (!isExpanded ? (
             <Tooltip value={dataSource.label} placement="right">
@@ -43,7 +43,7 @@ export const NavItem = ({ app, dataSource, isActive }: INavItemProps) => {
             <Icon className="nav-icon" name={iconName} size="medium" color={isActive ? 'primary' : 'accent'} />
           ))}
       </div>
-      <div className="nav-item nav-name">{' ' + dataSource.label}</div>
+      <div className="nav-row-item nav-name">{' ' + dataSource.label}</div>
       <DataSourceNotifications tags={tags} application={app} tabName={label} />
     </div>
   );

--- a/app/scripts/modules/core/src/application/nav/verticalNav.less
+++ b/app/scripts/modules/core/src/application/nav/verticalNav.less
@@ -73,7 +73,7 @@
         }
       }
 
-      .nav-item {
+      .nav-row-item {
         min-width: 16px;
         margin-right: 8px;
         line-height: 10px;
@@ -110,7 +110,7 @@
       padding-left: 62px;
       margin-top: -4px;
 
-      .nav-item {
+      .nav-row-item {
         min-width: 16px;
         line-height: 10px;
         padding: 0;


### PR DESCRIPTION
This PR renames a class on the vertical navbar. 

This prevents a FOUC from a custom datasource. The custom datasource has the same class and renders its own CSS before it pulls in `verticalNav.less`. The datasource uses this class in many places, so it is more efficient to change the name in one place in @spinnaker/core.