### PR TITLE
fix(environments): Allow environments view to render when there are managed artifacts and/or resources

### DIFF
--- a/app/scripts/modules/core/src/managed/Environments.tsx
+++ b/app/scripts/modules/core/src/managed/Environments.tsx
@@ -67,7 +67,7 @@ interface IEnvironmentsProps {
 export function Environments({ app }: IEnvironmentsProps) {
   const dataSource: ApplicationDataSource<IManagedApplicationEnvironmentSummary> = app.getDataSource('environments');
   const {
-    data: { environments, artifacts, resources, hasManagedResources },
+    data: { environments, artifacts, resources },
     status,
     loaded,
   } = useDataSource(dataSource);

--- a/app/scripts/modules/core/src/managed/Environments.tsx
+++ b/app/scripts/modules/core/src/managed/Environments.tsx
@@ -124,7 +124,7 @@ export function Environments({ app }: IEnvironmentsProps) {
     );
   }
 
-  const unmanaged = loaded && !hasManagedResources;
+  const unmanaged = loaded && artifacts.length == 0 && resources.length == 0;
   const gettingStartedLink = SETTINGS.managedDelivery?.gettingStartedUrl || defaultGettingStartedUrl;
   if (unmanaged) {
     return (


### PR DESCRIPTION
Currently the code looks at the `hasManagedResources` flag from the API response to determine if an app is managed, however the app may have a delivery config with just artifacts, which is a valid state, but the page won't render. This PR makes a tiny change such that we look at the sizes of the `resources` and `artifacts` arrays instead of that flag to avoid that problem.