### PR TITLE
fix(core/pipeline): Reformat fixed footer

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/pipelineConfigurer.html
+++ b/app/scripts/modules/core/src/pipeline/config/pipelineConfigurer.html
@@ -134,8 +134,8 @@
       view-state="viewState"
     ></pipeline-config-view>
 
-    <div class="row main-footer fixed-footer">
-      <div class="col-md-3">
+    <div class="row main-footer fixed-footer horizontal">
+      <div class="fixed-footer-button">
         <button
           is-visible="!pipeline.locked && viewState.isDirty && !viewState.saving"
           class="btn btn-default"
@@ -147,7 +147,7 @@
           <span class="glyphicon glyphicon-flash"></span> Revert
         </button>
       </div>
-      <div class="col-md-9 text-right">
+      <div class="text-right">
         <button
           class="btn btn-link"
           ng-if="pipelineConfigurerCtrl.validations.hasWarnings"

--- a/app/scripts/modules/core/src/presentation/main.less
+++ b/app/scripts/modules/core/src/presentation/main.less
@@ -1481,8 +1481,8 @@ div.modal-header.has-sticky-headers {
   background-color: var(--color-white);
   margin: 0;
   border-top: 1px solid var(--color-alto);
-  .col-md-9,
-  .col-md-3 {
+  .fixed-footer-button {
     padding: 0;
+    margin-left: auto;
   }
 }


### PR DESCRIPTION
The fixed footer for pipelines is now partially hidden by the new nav, preventing some buttons from being used. This PR reformats the footer so that the buttons are all on the right side of the footer. 
![Screen Shot 2020-07-24 at 3 34 31 PM](https://user-images.githubusercontent.com/26560152/88440575-3b929380-cdc3-11ea-821e-5aa6c2992378.png)
