### PR TITLE
fix(core/pipeline): Pipeline param execution details should handle Ob…

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/pipeline/PipelineParametersExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/pipeline/PipelineParametersExecutionDetails.tsx
@@ -10,13 +10,7 @@ export function PipelineParametersExecutionDetails(props: IExecutionDetailsSecti
   } = props;
 
   const { pipelineParameters: parameters = {} } = context;
-  // eslint-disable-next-line
-  console.log(
-    Object.keys(parameters),
-    Object.keys(parameters)
-      .sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()))
-      .map(key => parameters[key]),
-  );
+
   return (
     <ExecutionDetailsSection name={name} current={current}>
       <div className="row">

--- a/app/scripts/modules/core/src/pipeline/config/stages/pipeline/PipelineParametersExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/pipeline/PipelineParametersExecutionDetails.tsx
@@ -10,7 +10,13 @@ export function PipelineParametersExecutionDetails(props: IExecutionDetailsSecti
   } = props;
 
   const { pipelineParameters: parameters = {} } = context;
-
+  // eslint-disable-next-line
+  console.log(
+    Object.keys(parameters),
+    Object.keys(parameters)
+      .sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()))
+      .map(key => parameters[key]),
+  );
   return (
     <ExecutionDetailsSection name={name} current={current}>
       <div className="row">
@@ -22,7 +28,7 @@ export function PipelineParametersExecutionDetails(props: IExecutionDetailsSecti
               .map(key => (
                 <React.Fragment key={key}>
                   <dt>{key}</dt>
-                  <dd>{parameters[key]}</dd>
+                  <dd>{parameters[key].toString()}</dd>
                 </React.Fragment>
               ))}
           </dl>


### PR DESCRIPTION
Many pipelines depend on params that are not strings. Deck crashes if the param is an object, so let's make it handle that better. 