### PR TITLE
chore(gradle): upgrade spinnaker gradle plugin

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-spinnakerGradleVersion=8.3.0
+spinnakerGradleVersion=8.4.0


### PR DESCRIPTION
All the java project required some changes for this to work, so I killed
the autobump job. I forgot there would be two where it could have gone
through without a hitch. Oh well.