### PR TITLE
fix(amazon): Ensure successful security group decompression

### DIFF
--- a/app/scripts/modules/amazon/src/serverGroup/details/securityGroup/editSecurityGroups.modal.controller.js
+++ b/app/scripts/modules/amazon/src/serverGroup/details/securityGroup/editSecurityGroups.modal.controller.js
@@ -29,7 +29,7 @@ module(AMAZON_SERVERGROUP_DETAILS_SECURITYGROUP_EDITSECURITYGROUPS_MODAL_CONTROL
     securityGroups,
   ) {
     this.command = {
-      securityGroups: securityGroups.slice(0).sort((a, b) => a.name.localeCompare(b.name)),
+      securityGroups: (securityGroups || []).slice(0).sort((a, b) => a.name.localeCompare(b.name)),
     };
 
     this.state = {

--- a/app/scripts/modules/core/src/securityGroup/securityGroupReader.service.ts
+++ b/app/scripts/modules/core/src/securityGroup/securityGroupReader.service.ts
@@ -344,7 +344,11 @@ export class SecurityGroupReader {
           const service: any = this.providerServiceDelegate.getDelegate(provider, 'securityGroup.transformer');
           if (service && service.supportsCompression) {
             Object.keys(data[account][provider]).forEach(region => {
-              data[account][provider][region] = service.decompress(data[account][provider][region]);
+              // Sometimes the data from the cache is already partially decompressed even if the conditionals are met
+              // The isFlattened check avoids a decompression error
+              const decompressData = data[account][provider][region];
+              const isFlattened = Array.isArray(decompressData);
+              data[account][provider][region] = isFlattened ? decompressData : service.decompress(decompressData);
             });
           }
         }


### PR DESCRIPTION
Sometimes security groups from the cache are already partially decompressed. This caused an error in the decompression methods. 

The cached groups start off looking like this: 
```js
{ account: { provider: { region: { vpcId:  Array[] } } } }
```

But sometimes are returned from the cache like this: 
```js
{ account: { provider: { region: Array[]  } } }
```

In the latter case, the security groups are already partially decompressed and this error prevents the user from being able to open the edit modal.

<img width="258" alt="Screen Shot 2020-07-29 at 1 59 34 PM" src="https://user-images.githubusercontent.com/26560152/88852883-c13b8800-d1a3-11ea-9d5b-8fbb0f287ae2.png">

