### PR TITLE
style(appengine): Fix typo in Server Group settings

### DIFF
--- a/app/scripts/modules/appengine/src/serverGroup/configure/wizard/advancedSettings.html
+++ b/app/scripts/modules/appengine/src/serverGroup/configure/wizard/advancedSettings.html
@@ -25,7 +25,7 @@
 
   <div class="form-group">
     <div class="col-md-4 sm-label-right">
-      Supress Version String
+      Suppress Version String
       <help-field key="appengine.serverGroup.suppress-version-string"></help-field>
     </div>
     <div class="col-md-7">


### PR DESCRIPTION
- Fix a typo in the Server Group advanced settings for Appengine.