### PR TITLE
fix(core/projects): fix layout for projects view

### DIFF
--- a/app/scripts/modules/core/src/projects/ProjectHeader.tsx
+++ b/app/scripts/modules/core/src/projects/ProjectHeader.tsx
@@ -96,7 +96,7 @@ export class ProjectHeader extends React.Component<IProjectHeaderProps, IProject
     );
 
     return (
-      <div className="flex-fill">
+      <div className="flex-fill application">
         <div className="project-header">
           <div className="container">
             <h2>


### PR DESCRIPTION
this fixes a problem viewing a pipeline execution in the context of a project where the details content width was 30,000px wide
