### PR TITLE
fix(core/cluster): Prevent cluster filter from submitting when enter key is pressed

### DIFF
--- a/app/scripts/modules/core/src/cluster/filter/FilterSearch.tsx
+++ b/app/scripts/modules/core/src/cluster/filter/FilterSearch.tsx
@@ -12,7 +12,7 @@ export interface IFilterSearchProps {
 
 export const FilterSearch = ({ helpKey, onBlur, onSearchChange, value }: IFilterSearchProps) => (
   <div className="FilterSearch sp-margin-s-right">
-    <form className="horizontal middle" role="form">
+    <form className="horizontal middle" role="form" onSubmit={e => e.preventDefault()}>
       <div className="form-group nav-search">
         <input
           type="search"


### PR DESCRIPTION
The cluster filter already filters by responding to key changes and hitting enter refreshes the whole page. Preventing the form submit so that whole page doesn't get refreshed.