### PR TITLE
feat(amazon/alb): Support for http-request-method rule conditions on ALBs

### DIFF
--- a/app/scripts/modules/amazon/src/domain/IAmazonLoadBalancer.ts
+++ b/app/scripts/modules/amazon/src/domain/IAmazonLoadBalancer.ts
@@ -115,10 +115,13 @@ export interface IListenerRule {
   priority: number | 'default';
 }
 
-export type ListenerRuleConditionField = 'path-pattern' | 'host-header';
+export type ListenerRuleConditionField = 'path-pattern' | 'host-header' | 'http-request-method';
 
 export interface IListenerRuleCondition {
   field: ListenerRuleConditionField;
+  httpRequestMethodConfig?: {
+    values: string[];
+  };
   values: string[];
 }
 

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/application/ALBListeners.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/application/ALBListeners.tsx
@@ -657,18 +657,34 @@ const Rule = SortableElement((props: IRuleProps) => (
             {(props.rule.conditions.length === 1 || condition.field === 'path-pattern') && (
               <option value="path-pattern">Path</option>
             )}
+            {(props.rule.conditions.length === 1 || condition.field === 'http-request-method') && (
+              <option value="http-request-method">Method(s)</option>
+            )}
           </select>
           {condition.field === 'path-pattern' && <HelpField id="aws.loadBalancer.ruleCondition.path" />}
           {condition.field === 'host-header' && <HelpField id="aws.loadBalancer.ruleCondition.host" />}
-          <input
-            className="form-control input-sm"
-            type="text"
-            value={condition.values[0]}
-            onChange={event => props.handleConditionValueChanged(condition, event.target.value)}
-            maxLength={128}
-            required={true}
-            style={{ width: '63%' }}
-          />
+          {condition.field !== 'http-request-method' && (
+            <input
+              className="form-control input-sm"
+              type="text"
+              value={condition.values[0]}
+              onChange={event => props.handleConditionValueChanged(condition, event.target.value)}
+              maxLength={128}
+              required={true}
+              style={{ width: '63%' }}
+            />
+          )}
+          {condition.field === 'http-request-method' && (
+            <input
+              className="form-control input-sm"
+              type="text"
+              value={condition.httpRequestMethodConfig.values[0]}
+              onChange={event => props.handleConditionValueChanged(condition, event.target.value)}
+              maxLength={128}
+              required={true}
+              style={{ width: '63%' }}
+            />
+          )}
           <span className="remove-condition">
             {cIndex === 1 && (
               <a

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/application/ALBListeners.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/application/ALBListeners.tsx
@@ -133,13 +133,7 @@ export class ALBListeners extends React.Component<IALBListenersProps, IALBListen
         const missingAuth = !!rule.actions.find(
           a => a.type === 'authenticate-oidc' && !a.authenticateOidcConfig.clientId,
         );
-        const missingValue = !!rule.conditions.find(c => {
-          if (c.field !== 'http-request-method') {
-            return c.values.includes('');
-          }
-
-          return c.httpRequestMethodConfig && c.httpRequestMethodConfig.values.includes('');
-        });
+        const missingValue = !!rule.conditions.find(c => c.values.includes(''));
         return missingTargets || missingAuth || missingValue;
       });
       return defaultActionsHaveMissingTarget || rulesHaveMissingFields;
@@ -339,7 +333,7 @@ export class ALBListeners extends React.Component<IALBListenersProps, IALBListen
     newValue: string,
     selected: boolean,
   ): void => {
-    let newValues = condition.httpRequestMethodConfig ? condition.httpRequestMethodConfig.values : [];
+    let newValues = condition.values || [];
 
     if (selected) {
       newValues.push(newValue);
@@ -347,13 +341,10 @@ export class ALBListeners extends React.Component<IALBListenersProps, IALBListen
       newValues = newValues.filter(v => v !== newValue);
     }
 
+    condition.values = newValues;
     condition.httpRequestMethodConfig = {
       values: newValues,
     };
-
-    /** Http-request-method does not have the values attribute, but we default this to an empty array when a new condition is created */
-    delete condition.values;
-
     this.updateListeners();
   };
 
@@ -710,10 +701,7 @@ const Rule = SortableElement((props: IRuleProps) => (
                 <label key={`${httpMethod}-checkbox`}>
                   <input
                     type="checkbox"
-                    checked={
-                      Boolean(condition.httpRequestMethodConfig) &&
-                      condition.httpRequestMethodConfig.values.includes(httpMethod)
-                    }
+                    checked={condition.values.includes(httpMethod)}
                     onChange={event =>
                       props.handleHttpRequestMethodChanged(condition, httpMethod, event.target.checked)
                     }

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/application/ALBListeners.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/application/ALBListeners.tsx
@@ -341,6 +341,11 @@ export class ALBListeners extends React.Component<IALBListenersProps, IALBListen
       newValues = newValues.filter(v => v !== newValue);
     }
 
+    /**
+     * The `http-request-method` conditions have a differnt model.
+     * AWS uses `httpRequestMethodConfig` as the source of truth, while deck uses `values`.
+     * Both are updated for consistency.
+     */
     condition.values = newValues;
     condition.httpRequestMethodConfig = {
       values: newValues,
@@ -977,7 +982,7 @@ const Rules = SortableContainer((props: IRulesProps) => (
           configureOidcClient={props.configureOidcClient}
           configureRedirect={props.configureRedirect}
         />
-    ))}
+      ))}
     <tr className="not-sortable">
       <td colSpan={5}>
         <button type="button" className="add-new col-md-12" onClick={() => props.addRule(props.listener)}>

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/application/ALBListeners.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/application/ALBListeners.tsx
@@ -140,8 +140,6 @@ export class ALBListeners extends React.Component<IALBListenersProps, IALBListen
 
           return c.httpRequestMethodConfig && c.httpRequestMethodConfig.values.includes('');
         });
-        // eslint-disable-next-line
-        console.log(missingValue);
         return missingTargets || missingAuth || missingValue;
       });
       return defaultActionsHaveMissingTarget || rulesHaveMissingFields;
@@ -341,8 +339,6 @@ export class ALBListeners extends React.Component<IALBListenersProps, IALBListen
     newValue: string,
     selected: boolean,
   ): void => {
-    // eslint-disable-next-line
-    console.log(newValue, selected);
     let newValues = condition.httpRequestMethodConfig ? condition.httpRequestMethodConfig.values : [];
 
     if (selected) {
@@ -350,14 +346,14 @@ export class ALBListeners extends React.Component<IALBListenersProps, IALBListen
     } else {
       newValues = newValues.filter(v => v !== newValue);
     }
-    // eslint-disable-next-line
-    console.log(newValues);
 
     condition.httpRequestMethodConfig = {
       values: newValues,
     };
 
-    // condition.httpRequestMethodConfig.values = newValues;
+    /** Http-request-method does not have the values attribute, but we default this to an empty array when a new condition is created */
+    delete condition.values;
+
     this.updateListeners();
   };
 
@@ -491,8 +487,6 @@ export class ALBListeners extends React.Component<IALBListenersProps, IALBListen
   public render() {
     const { errors, values } = this.props.formik;
     const { certificates, certificateTypes, oidcConfigs } = this.state;
-    // eslint-disable-next-line
-    console.log(values.listeners);
     return (
       <div className="container-fluid form-horizontal">
         <div className="form-group">
@@ -693,8 +687,9 @@ const Rule = SortableElement((props: IRuleProps) => (
             {(props.rule.conditions.length === 1 || condition.field === 'path-pattern') && (
               <option value="path-pattern">Path</option>
             )}
-            {((props.rule.conditions.length === 1 && props.listener.protocol === 'HTTP') ||
-              condition.field === 'http-request-method') && <option value="http-request-method">Method(s)</option>}
+            {(props.rule.conditions.length === 1 || condition.field === 'http-request-method') && (
+              <option value="http-request-method">Method(s)</option>
+            )}
           </select>
           {condition.field === 'path-pattern' && <HelpField id="aws.loadBalancer.ruleCondition.path" />}
           {condition.field === 'host-header' && <HelpField id="aws.loadBalancer.ruleCondition.host" />}

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/application/CreateApplicationLoadBalancer.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/application/CreateApplicationLoadBalancer.tsx
@@ -154,7 +154,7 @@ export class CreateApplicationLoadBalancer extends React.Component<
             return condition.values[0].length > 0;
           }
 
-          return condition.httpRequestMethodConfig && condition.httpRequestMethodConfig.values.length > 0;
+          return condition.values.length > 0;
         });
       });
     });

--- a/app/scripts/modules/amazon/src/loadBalancer/configure/application/CreateApplicationLoadBalancer.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/application/CreateApplicationLoadBalancer.tsx
@@ -149,7 +149,13 @@ export class CreateApplicationLoadBalancer extends React.Component<
         // Set the priority in array order, starting with 1
         rule.priority = index + 1;
         // Remove conditions that have no value
-        rule.conditions = rule.conditions.filter(condition => condition.values[0].length > 0);
+        rule.conditions = rule.conditions.filter(condition => {
+          if (condition.field !== 'http-request-method') {
+            return condition.values[0].length > 0;
+          }
+
+          return condition.httpRequestMethodConfig && condition.httpRequestMethodConfig.values.length > 0;
+        });
       });
     });
   }

--- a/app/scripts/modules/amazon/src/loadBalancer/loadBalancer.transformer.ts
+++ b/app/scripts/modules/amazon/src/loadBalancer/loadBalancer.transformer.ts
@@ -332,6 +332,11 @@ export class AwsLoadBalancerTransformer {
               }
               action.redirectActionConfig = action.redirectConfig;
             });
+            (rule.conditions || []).forEach(condition => {
+              if (condition.field === 'http-request-method') {
+                condition.values = condition.httpRequestMethodConfig.values;
+              }
+            });
             rule.conditions = rule.conditions || [];
           });
 

--- a/app/scripts/modules/core/src/task/monitor/TaskMonitor.ts
+++ b/app/scripts/modules/core/src/task/monitor/TaskMonitor.ts
@@ -99,8 +99,6 @@ export class TaskMonitor {
   }
 
   public setError(task?: ITask): void {
-    // eslint-disable-next-line
-    console.log(task);
     if (task) {
       this.task = task;
       this.errorMessage = task.failureMessage || 'There was an unknown server error.';

--- a/app/scripts/modules/core/src/task/monitor/TaskMonitor.ts
+++ b/app/scripts/modules/core/src/task/monitor/TaskMonitor.ts
@@ -99,6 +99,8 @@ export class TaskMonitor {
   }
 
   public setError(task?: ITask): void {
+    // eslint-disable-next-line
+    console.log(task);
     if (task) {
       this.task = task;
       this.errorMessage = task.failureMessage || 'There was an unknown server error.';


### PR DESCRIPTION
Enable support for listener rules that have conditions of type `http-request-method`. 

These conditions have a different model than `path-pattern` or `host-header` conditions. Prior to this PR, these conditions could only be created in the aws console, and would fail to render when editing an ALB.

<img width="649" alt="Screen Shot 2020-08-03 at 10 24 43 AM" src="https://user-images.githubusercontent.com/26560152/89235727-9dad7e80-d5a3-11ea-932e-cd6e9065d40c.png">



