### PR TITLE
fix(kubernetes): Don't overwrite namespace on instance

### DIFF
--- a/app/scripts/modules/kubernetes/src/instance/details/details.controller.ts
+++ b/app/scripts/modules/kubernetes/src/instance/details/details.controller.ts
@@ -97,7 +97,7 @@ class KubernetesInstanceDetailsController implements IController {
         this.manifest = manifest;
         this.consoleOutputInstance = {
           account: this.instance.account,
-          region: this.instance.region,
+          region: this.instance.zone,
           id: this.instance.humanReadableName,
           provider: this.instance.provider,
         };
@@ -137,7 +137,6 @@ class KubernetesInstanceDetailsController implements IController {
       RecentHistoryService.addExtraDataToLatest('instances', recentHistoryExtraData);
       return InstanceReader.getInstanceDetails(instanceManager.account, instanceManager.region, instance.name).then(
         (instanceDetails: IKubernetesInstance) => {
-          instanceDetails.namespace = instanceDetails.region;
           instanceDetails.id = instance.id;
           instanceDetails.name = instance.name;
           instanceDetails.provider = 'kubernetes';

--- a/app/scripts/modules/kubernetes/src/serverGroup/details/details.html
+++ b/app/scripts/modules/kubernetes/src/serverGroup/details/details.html
@@ -93,7 +93,7 @@
         <dt>Created</dt>
         <dd>{{ctrl.serverGroup.createdTime | timestamp}}</dd>
         <dt>Account</dt>
-        <dd><account-tag account="ctrl.serverGroup.accountName"></account-tag></dd>
+        <dd><account-tag account="ctrl.serverGroup.account"></account-tag></dd>
         <dt>Namespace</dt>
         <dd>{{ctrl.serverGroup.namespace}}</dd>
         <dt>Kind</dt>

--- a/app/scripts/modules/kubernetes/src/serverGroupManager/details/details.html
+++ b/app/scripts/modules/kubernetes/src/serverGroupManager/details/details.html
@@ -99,7 +99,7 @@
         <dt>Created</dt>
         <dd>{{ctrl.serverGroupManager.createdTime | timestamp}}</dd>
         <dt>Account</dt>
-        <dd><account-tag account="ctrl.serverGroupManager.accountName"></account-tag></dd>
+        <dd><account-tag account="ctrl.serverGroupManager.account"></account-tag></dd>
         <dt>Namespace</dt>
         <dd>{{ctrl.serverGroupManager.namespace}}</dd>
         <dt>Kind</dt>


### PR DESCRIPTION
* fix(kubernetes): Don't overwrite namespace on instance

  The namespace is already set on the instance details object; as we're about to remove region from the instance view (in favor of zone, which is the correct field for an instance) leaving this code will cause the namespace to be cleared.

* fix(kubernetes): Use account instead of accountName in details view

  Only security groups set accountName; the convention for all others is to only set account. To prepare for removing accountName from these two objects, read account instead.