### PR TITLE
refactor(kubernetes/pipelines): clean up ManifestStatus and DeployStatus components.

### DIFF
--- a/app/scripts/modules/kubernetes/src/manifest/manifest.service.ts
+++ b/app/scripts/modules/kubernetes/src/manifest/manifest.service.ts
@@ -38,4 +38,52 @@ export class KubernetesManifestService {
     // effect elsewhere
     return `${namespace} ${kind} ${apiVersion} ${name}`;
   }
+
+  public static stageManifestToManifestParams(manifest: IStageManifest, account: string): IManifestParams {
+    return {
+      account,
+      name: KubernetesManifestService.scopedKind(manifest) + ' ' + manifest.metadata.name,
+      location: manifest.metadata.namespace == null ? '_' : manifest.metadata.namespace,
+    };
+  }
+
+  private static apiGroup(manifest: IStageManifest): string {
+    const parts = (manifest.apiVersion || '_').split('/');
+    if (parts.length < 2) {
+      return '';
+    }
+    return parts[0];
+  }
+
+  private static isCRDGroup(manifest: IStageManifest): boolean {
+    return !KubernetesManifestService.BUILT_IN_GROUPS.includes(KubernetesManifestService.apiGroup(manifest));
+  }
+
+  private static scopedKind(manifest: IStageManifest): string {
+    if (KubernetesManifestService.isCRDGroup(manifest)) {
+      return manifest.kind + '.' + KubernetesManifestService.apiGroup(manifest);
+    }
+
+    return manifest.kind;
+  }
+
+  // from https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.12/
+  private static readonly BUILT_IN_GROUPS = [
+    '',
+    'core',
+    'batch',
+    'apps',
+    'extensions',
+    'storage.k8s.io',
+    'apiextensions.k8s.io',
+    'apiregistration.k8s.io',
+    'policy',
+    'scheduling.k8s.io',
+    'settings.k8s.io',
+    'authorization.k8s.io',
+    'authentication.k8s.io',
+    'rbac.authorization.k8s.io',
+    'certifcates.k8s.io',
+    'networking.k8s.io',
+  ];
 }

--- a/app/scripts/modules/kubernetes/src/pipelines/stages/deployManifest/manifestStatus/DeployStatus.tsx
+++ b/app/scripts/modules/kubernetes/src/pipelines/stages/deployManifest/manifestStatus/DeployStatus.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { get, upperFirst } from 'lodash';
+import { get } from 'lodash';
 import {
   IExecutionDetailsSectionProps,
   ExecutionDetailsSection,
@@ -110,10 +110,10 @@ export class DeployStatus extends React.Component<IExecutionDetailsSectionProps,
 
   private scopedKind(manifest: IStageManifest): string {
     if (this.isCRDGroup(manifest)) {
-      return upperFirst(manifest.kind) + '.' + this.apiGroup(manifest);
+      return manifest.kind + '.' + this.apiGroup(manifest);
     }
 
-    return upperFirst(manifest.kind);
+    return manifest.kind;
   }
 
   private stageManifestToIManifest(manifest: IStageManifest, account: string): IManifest {

--- a/app/scripts/modules/kubernetes/src/pipelines/stages/deployManifest/manifestStatus/DeployStatus.tsx
+++ b/app/scripts/modules/kubernetes/src/pipelines/stages/deployManifest/manifestStatus/DeployStatus.tsx
@@ -143,7 +143,7 @@ export class DeployStatus extends React.Component<IExecutionDetailsSectionProps,
                 {manifests.map(manifest => {
                   const uid =
                     manifest.manifest.metadata.uid || KubernetesManifestService.manifestIdentifier(manifest.manifest);
-                  return <ManifestStatus key={uid} manifest={manifest} stage={stage} />;
+                  return <ManifestStatus key={uid} manifest={manifest} account={stage.context.account} />;
                 })}
               </div>
             </div>

--- a/app/scripts/modules/kubernetes/src/pipelines/stages/deployManifest/manifestStatus/ManifestStatus.tsx
+++ b/app/scripts/modules/kubernetes/src/pipelines/stages/deployManifest/manifestStatus/ManifestStatus.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { dump } from 'js-yaml';
 
-import { CopyToClipboard, IManifest, ManifestYaml, Overridable } from '@spinnaker/core';
+import { CopyToClipboard, IManifest, ManifestYaml } from '@spinnaker/core';
 
 import { DeployManifestStatusPills } from './DeployStatusPills';
 import { ManifestDetailsLink } from './ManifestDetailsLink';
@@ -14,11 +14,9 @@ export interface IManifestStatusProps {
   manifest: IManifest;
 }
 
-@Overridable('kubernetes.v2.pipeline.stages.deployManifest.manifestStatus')
-export class ManifestStatus extends React.Component<IManifestStatusProps> {
-  public render() {
-    const { account, manifest } = this.props;
-    return [
+export function ManifestStatus({ account, manifest }: IManifestStatusProps) {
+  return (
+    <>
       <dl className="manifest-status" key="manifest-status">
         <dt>{manifest.manifest.kind}</dt>
         <dd>
@@ -30,7 +28,7 @@ export class ManifestStatus extends React.Component<IManifestStatusProps> {
           &nbsp;
           <DeployManifestStatusPills manifest={manifest} />
         </dd>
-      </dl>,
+      </dl>
       <div className="manifest-support-links" key="manifest-support-links">
         <ManifestYaml
           linkName="YAML"
@@ -38,10 +36,10 @@ export class ManifestStatus extends React.Component<IManifestStatusProps> {
           modalTitle={manifest.manifest.metadata.name}
         />
         <ManifestDetailsLink linkName="Details" manifest={manifest} accountId={account} />
-      </div>,
+      </div>
       <div className="manifest-events pad-left" key="manifest-events">
         <ManifestEvents manifest={manifest} />
-      </div>,
-    ];
-  }
+      </div>
+    </>
+  );
 }

--- a/app/scripts/modules/kubernetes/src/pipelines/stages/deployManifest/manifestStatus/ManifestStatus.tsx
+++ b/app/scripts/modules/kubernetes/src/pipelines/stages/deployManifest/manifestStatus/ManifestStatus.tsx
@@ -10,15 +10,14 @@ import { ManifestEvents } from './ManifestEvents';
 import './ManifestStatus.less';
 
 export interface IManifestStatusProps {
+  account: string;
   manifest: IManifest;
-  stage: any;
 }
 
 @Overridable('kubernetes.v2.pipeline.stages.deployManifest.manifestStatus')
 export class ManifestStatus extends React.Component<IManifestStatusProps> {
   public render() {
-    const { manifest, stage } = this.props;
-    const { account } = stage.context;
+    const { account, manifest } = this.props;
     return [
       <dl className="manifest-status" key="manifest-status">
         <dt>{manifest.manifest.kind}</dt>


### PR DESCRIPTION
Preparation for: https://github.com/spinnaker/spinnaker/issues/5909

* refactor(kubernetes/pipelines): make ManifestStatus props more specific 

  ManifestStatus component does not require the entire stage, only the account name to pass to one of its children; update the contract accordingly.

* refactor(kubernetes/pipelines): make ManifestStatus functional component 

  This component does not rely on any React lifecycle hooks, and we are encouraging all new contributions to prefer functional components. The @Overridable annotation only works on class components, and we are not sure if their were ever any custom extensions relying on it, so remove this for now. (Any custom extensions are unlikely to still work as expected anyway after the upcoming refactor in which data fetching is pushed down into each per-Manifest ManifestStatus component, so we can revisit appropriate extension points if anyone lets us know that this broke their custom overrides.)

* refactor(kubernetes/pipelines): remove unnecessary capitalization of Kubernetes kinds 

  The kind as specified on the manifest already has the correct casing.

* refactor(kubernetes/pipelines): move translation from stage manifest to manifest params out of DeployStatus 

  Deck currently gets the full manifests it receives from Orca in the execution context, parses some details from those full manifests to create a new request to Clouddriver's /manifests endpoint. Much of this logic was added to disambiguate CRDs of the same kind but different API group. Ideally, Deck would have no knowledge of build-in Kubernetes groups and simply receive all the information it needs to construct a valid request. We'll revisit this later, but for now, let's at least move all the logic into private methods on the KubernetesManifestService rather than having them live on the DeployStatus component. This is also important because in a future commit, we will push the logic that sets up subscriptions against the /manifest endpoint further down the tree so that each ManifestStatus component is responsible for fetching its own data.
