### PR TITLE
fix(core/presentation): Do not render the form input even once ...

### DIFF
--- a/app/scripts/modules/core/src/presentation/forms/fields/FormikFormField.spec.tsx
+++ b/app/scripts/modules/core/src/presentation/forms/fields/FormikFormField.spec.tsx
@@ -138,6 +138,19 @@ describe('<FormikFormField/>', () => {
       expect(component.find(ReactSelectInput).length).toEqual(0);
     });
 
+    it('does not render the input even once if the field value is SpEL and freeform SpEL inputs are enabled', () => {
+      const spy = jasmine.createSpy();
+      const NeverRenderedComponent = () => {
+        spy();
+        return <span />;
+      };
+      const TestField = () => (
+        <FormikFormField name="account" label="Account" input={NeverRenderedComponent} spelAware={true} />
+      );
+      mount(<Test initialValues={{ account: '${spel_account}' }} render={() => <TestField />} />);
+      expect(spy).not.toHaveBeenCalled();
+    });
+
     it('renders the default input if the field value is not SpEL', () => {
       const component = mount(
         <Test initialValues={{ account: 'account' }} render={() => <AccountField propsSpelAware={true} />} />,


### PR DESCRIPTION
... (render the spel input instead) if spel is present and freeform is enabled

This fixes a problem encountered where a SelectInput applied a default value using an `useEffect`.  The form value had spel in it and should have been in freeform input mode.  However, because the SelectInput was rendered once, its useEffect kicked in and applied the default value overriding the spel value.

```js
<FormikFormField name="env" input={props => {
  return <SelectInput defaultValue="test" options={["test", "prod"]} {...props} />
}} />
```

<img width="1027" alt="Screen Shot 2020-08-05 at 8 07 49 PM" src="https://user-images.githubusercontent.com/2053478/89486246-80b9ac80-d757-11ea-8e1b-38194255d8a7.png">
