### PR TITLE
feat(core/managed): new visual iteration for version sidebar, 'decommissioned' cards

### DIFF
--- a/app/scripts/modules/core/src/managed/ArtifactRow.module.css
+++ b/app/scripts/modules/core/src/managed/ArtifactRow.module.css
@@ -1,15 +1,19 @@
 .ArtifactRow {
-  height: 48px;
+  height: 56px;
   display: block;
+  position: relative;
   cursor: pointer;
+  margin-bottom: 2px;
+  border-radius: 2px;
+  transition: background-color 150ms ease-in-out;
 }
 
 .ArtifactRow:not(.selected):hover {
-  background-color: #f1f4fa;
+  background-color: #e8eaf2;
 }
 
 .selected {
-  background-color: var(--color-white);
+  background-color: #c7def5;
 }
 
 .content {
@@ -17,6 +21,7 @@
   align-items: center;
   height: 100%;
   padding-top: 4px;
+  padding-bottom: 12px;
 }
 .version {
   display: flex;
@@ -29,12 +34,31 @@
   flex: 1 1 auto;
   overflow: hidden;
 }
+.version,
+.text {
+  transition: margin 150ms ease-in-out;
+}
+.ArtifactRow:hover {
+  .version,
+  .text {
+    margin-top: -13px;
+  }
+}
+
 .sha {
   font-size: 14px;
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
 }
+
+.ArtifactRow.selected .sha {
+  font-weight: 700;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  color: #2c4b5f;
+}
+
 .name {
   font-size: 12px;
   font-style: italic;
@@ -50,13 +74,24 @@
 
 .stages {
   display: flex;
-  height: 6px;
-  padding-bottom: 2px;
+  position: absolute;
+  height: 8px;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 1;
+  transition: height 150ms ease-in-out;
 }
 
 .stage {
+  display: flex;
   flex: 1 1 auto;
+  font-size: 12px;
+  color: rgba(0, 0, 0, 0.5);
+  border: 1px solid rgba(0, 0, 0, 0.5);
   margin-right: 2px;
+  text-transform: uppercase;
+  transition: background-color 150ms ease-in-out;
 
   &.current {
     background-color: var(--color-status-success);
@@ -70,16 +105,13 @@
     background-color: var(--color-status-progress);
   }
 
-  &.pending {
-    background-color: var(--color-status-inactive);
-  }
-
+  &.pending,
   &.skipped {
-    background-color: var(--color-status-inactive);
+    background-color: var(--color-alabaster);
   }
 
   &.previous {
-    background-color: var(--color-status-neutral);
+    background-color: #dbcec8;
   }
 
   &.vetoed {
@@ -89,4 +121,38 @@
 
 .stage:last-child {
   margin-right: 0;
+}
+
+.stageName {
+  opacity: 0;
+  user-select: none;
+  pointer-events: none;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  transition: opacity 150ms ease-in-out;
+}
+
+.ArtifactRow:not(.selected):hover {
+  .stage.pending,
+  .stage.skipped {
+    background-color: #e8eaf2;
+  }
+}
+
+.ArtifactRow.selected {
+  .stage.pending,
+  .stage.skipped {
+    background-color: #c7def5;
+  }
+}
+
+.ArtifactRow:hover {
+  .stages {
+    height: 21px;
+  }
+
+  .stageName {
+    opacity: 1;
+  }
 }

--- a/app/scripts/modules/core/src/managed/ArtifactsList.tsx
+++ b/app/scripts/modules/core/src/managed/ArtifactsList.tsx
@@ -62,7 +62,7 @@ export const ArtifactRow = ({ isSelected, clickHandler, version: versionInfo, re
       <div className={styles.content}>
         {build?.id && (
           <div className={styles.version}>
-            <Pill text={`#${build.id}`} />
+            <Pill bgColor={isSelected ? '#2c4b5f' : undefined} text={`#${build.id}`} />
           </div>
         )}
         <div className={classNames(styles.text, { 'sp-margin-m-left': !build?.id })}>
@@ -70,14 +70,22 @@ export const ArtifactRow = ({ isSelected, clickHandler, version: versionInfo, re
           {name && <div className={styles.name}>{name}</div>}
         </div>
         <StatusBubbleStack
-          borderColor={isSelected ? 'var(--color-white)' : isHovered ? '#f1f4fa' : 'var(--color-alabaster)'}
+          borderColor={isSelected ? '#c7def5' : isHovered ? '#e8eaf2' : 'var(--color-alabaster)'}
           maxBubbles={3}
           statuses={getArtifactStatuses(versionInfo)}
         />
       </div>
       <div className={styles.stages}>
         {environments
-          .map(({ name, state }) => <span key={name} className={classNames(styles.stage, styles[state])} />)
+          .map(({ name, state }) => (
+            <span
+              key={name}
+              className={classNames(styles.stage, styles[state], 'text-bold flex-container-h center middle')}
+              style={{ width: `${environments.length / 100}%` }}
+            >
+              <span className={styles.stageName}>{name}</span>
+            </span>
+          ))
           .reverse()}
       </div>
     </div>

--- a/app/scripts/modules/core/src/managed/StatusBubble.less
+++ b/app/scripts/modules/core/src/managed/StatusBubble.less
@@ -58,6 +58,10 @@
     background-color: var(--color-status-error);
   }
 
+  .status-archived {
+    background-color: var(--color-status-archived);
+  }
+
   .quantity-pill {
     align-self: flex-end;
     color: var(--color-icon-light);

--- a/app/scripts/modules/core/src/managed/StatusBubble.tsx
+++ b/app/scripts/modules/core/src/managed/StatusBubble.tsx
@@ -10,7 +10,7 @@ const QUANITITY_SIZES = ['small', 'medium', 'large', 'extraLarge'];
 
 export interface IStatusBubbleProps {
   iconName: IconNames;
-  appearance: 'inactive' | 'neutral' | 'info' | 'progress' | 'success' | 'warning' | 'error';
+  appearance: 'inactive' | 'neutral' | 'info' | 'progress' | 'success' | 'warning' | 'error' | 'archived';
   size: 'extraSmall' | 'small' | 'medium' | 'large' | 'extraLarge';
   quantity?: string | number;
 }

--- a/app/scripts/modules/core/src/managed/StatusCard.less
+++ b/app/scripts/modules/core/src/managed/StatusCard.less
@@ -30,4 +30,8 @@
   &.status-card-error {
     background-color: var(--color-status-error-light);
   }
+
+  &.status-card-archived {
+    background-color: var(--color-status-archived-light);
+  }
 }

--- a/app/scripts/modules/core/src/managed/StatusCard.tsx
+++ b/app/scripts/modules/core/src/managed/StatusCard.tsx
@@ -8,7 +8,7 @@ import { StatusBubble } from './StatusBubble';
 import './StatusCard.less';
 
 export interface IStatusCardProps {
-  appearance: 'inactive' | 'neutral' | 'info' | 'progress' | 'success' | 'warning' | 'error';
+  appearance: 'inactive' | 'neutral' | 'info' | 'progress' | 'success' | 'warning' | 'error' | 'archived';
   iconName: IconNames;
   title: React.ReactNode;
   description?: React.ReactNode;

--- a/app/scripts/modules/core/src/managed/VersionStateCard.tsx
+++ b/app/scripts/modules/core/src/managed/VersionStateCard.tsx
@@ -42,7 +42,7 @@ const cardAppearanceByState: { [state: string]: CardAppearance } = {
   },
   previous: {
     icon: 'cloudDecommissioned',
-    appearance: 'neutral',
+    appearance: 'archived',
     title: ({ replacedAtMillis, replacedByVersionName }: CardTitleMetadata) => (
       <span className="sp-group-margin-xs-xaxis">
         <span>Decommissioned {replacedAtMillis && relativeTime(replacedAtMillis)}</span>


### PR DESCRIPTION
We've had some mockups in the pipeline for a long while now based on early customer feedback, this PR is the smallest chunk I could bite off of that larger redesign while still delivering something of value.

Most notable changes are:
1) **Showing environment names when you hover** over a version
2) **Using _way_ more obvious hover + selected state colors** and treatments so it's extremely clear what's selected
3) **Switching to a brown color scheme I'm calling 'archived' for versions that are in a `previous` state** (a.k.a 'decommissioned') across both the version list and the status cards in the detail view — this will hopefully resolve a bunch of the visual ambiguity we've been hearing is painful today

Screenshots:

<details>
<summary>New version sidebar states</summary>

**Initial / steady state view**
<img width="1371" alt="Screen Shot 2020-08-07 at 11 10 26 AM" src="https://user-images.githubusercontent.com/1850998/89678765-a0aab680-d8a4-11ea-8a7c-b9dec960caa3.png">

**Hovering on a version**
<img width="1366" alt="Screen Shot 2020-08-07 at 11 10 40 AM" src="https://user-images.githubusercontent.com/1850998/89678786-a99b8800-d8a4-11ea-83ae-c21dbd3882da.png">

<img width="1361" alt="Screen Shot 2020-08-07 at 11 10 49 AM" src="https://user-images.githubusercontent.com/1850998/89678811-b324f000-d8a4-11ea-8903-573e29a8ad2a.png">

**With a version selected**
<img width="1364" alt="Screen Shot 2020-08-07 at 11 11 17 AM" src="https://user-images.githubusercontent.com/1850998/89678842-bfa94880-d8a4-11ea-8dda-7fb692196e25.png">

**Hovering when there's some status bubbles on the version**
<img width="378" alt="Screen Shot 2020-08-07 at 11 11 42 AM" src="https://user-images.githubusercontent.com/1850998/89678876-cdf76480-d8a4-11ea-9960-52141b7b6966.png">

**When an environment name is too long for the preview**
<img width="367" alt="Screen Shot 2020-08-07 at 11 15 48 AM" src="https://user-images.githubusercontent.com/1850998/89678971-fb441280-d8a4-11ea-8beb-1907dcc86819.png">

</details>

<details>
<summary>Changes to 'decommissioned' cards</summary>

<img width="1365" alt="Screen Shot 2020-08-07 at 11 16 17 AM" src="https://user-images.githubusercontent.com/1850998/89678932-eb2c3300-d8a4-11ea-8bca-009dea8a331d.png">

</details>

<details>
<summary>Hover transition (gif)</summary>

![version-sidebar-hover](https://user-images.githubusercontent.com/1850998/89678998-0bf48880-d8a5-11ea-835f-580dae9aeaae.gif)

</details>

cc @gcomstock 