### PR TITLE
feat(core/managed): new visual treatment for environment badges

### DIFF
--- a/app/scripts/modules/core/src/managed/EnvironmentBadge.less
+++ b/app/scripts/modules/core/src/managed/EnvironmentBadge.less
@@ -2,11 +2,8 @@
   border-radius: 2px;
   text-transform: uppercase;
   color: var(--color-white);
-  background-color: #666666;
-
-  &.critical {
-    background-color: #be0000;
-  }
+  background-color: #53809f;
+  line-height: normal;
 
   &.small,
   &.extraSmall {
@@ -15,5 +12,9 @@
 
   &.medium {
     font-size: 14px;
+  }
+
+  .critical-symbol {
+    vertical-align: middle;
   }
 }

--- a/app/scripts/modules/core/src/managed/EnvironmentBadge.tsx
+++ b/app/scripts/modules/core/src/managed/EnvironmentBadge.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import classNames from 'classnames';
 
+import { Tooltip } from '../presentation';
+
+import { ReactComponent as Star } from './icons/star.svg';
+
 import './EnvironmentBadge.less';
 
 export interface IEnvironmentBadgeProps {
@@ -16,9 +20,20 @@ export const EnvironmentBadge = ({ name, critical, size = DEFAULT_SIZE }: IEnvir
     className={classNames('EnvironmentBadge sp-padding-s-xaxis text-bold', size, {
       'sp-padding-xs-yaxis': size !== 'extraSmall',
       'sp-padding-2xs-yaxis': size === 'extraSmall',
-      critical,
     })}
   >
+    {critical && (
+      <Tooltip value="This is a production environment">
+        <span
+          className={classNames('critical-symbol', {
+            'sp-margin-s-right': size !== 'extraSmall',
+            'sp-margin-xs-right': size === 'extraSmall',
+          })}
+        >
+          <Star style={{ width: size === 'extraSmall' ? '12px' : '16px', fill: 'var(--color-white)' }} />
+        </span>
+      </Tooltip>
+    )}
     {name}
   </span>
 );

--- a/app/scripts/modules/core/src/managed/EnvironmentRow.less
+++ b/app/scripts/modules/core/src/managed/EnvironmentRow.less
@@ -4,17 +4,13 @@
   .srow {
     display: flex;
     align-items: center;
-    box-shadow: inset 0 -1px 0 0 #cccccc;
+    box-shadow: inset 0 -1px 0 0 #53809f;
     height: 44px;
     font-size: 14px;
   }
 
   .srow:hover .select {
     visibility: visible;
-  }
-
-  .rowProd {
-    box-shadow: inset 0 -1px 0 0 #be0000;
   }
 
   .clickableArea {

--- a/app/scripts/modules/core/src/managed/EnvironmentRow.tsx
+++ b/app/scripts/modules/core/src/managed/EnvironmentRow.tsx
@@ -24,7 +24,6 @@ export function EnvironmentRow({ name, resources = [], hasPinnedVersions, childr
 
   const envRowClasses = classNames({
     srow: true,
-    rowProd: isCritical,
   });
 
   return (

--- a/app/scripts/modules/core/src/managed/icons/star.svg
+++ b/app/scripts/modules/core/src/managed/icons/star.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <title>Artboard 1</title>
+  <polygon points="12 0 14.833 9.167 24 9.167 16.584 14.833 19.416 24 12 18.334 4.584 24 7.416 14.833 0 9.167 9.167 9.167 12 0"/>
+</svg>


### PR DESCRIPTION
We've had many discussions about how to visually re-treat the environment badges we currently have to move away from 'production red' — this PR implements the initial attempt we settled on.

Note that I chose to directly use the SVG star symbol vs. adding it via `<Icon/>` — this is because we need it at an extremely small size which doesn't match any of the available icon sizes. After talking with @gcomstock it became clear that this is a slightly different kind of graphic (we've been calling it a 'symbol' vs an icon) which may later get it's own kind of component (e.g. `<Symbol/>`). For now we're trying it out inline and will re-evaulate if we discover further places for this treatment.

Screenshots:

<img width="1252" alt="Screen Shot 2020-08-07 at 3 19 17 PM" src="https://user-images.githubusercontent.com/1850998/89693341-1cb3f700-d8c3-11ea-9e0f-1cf683723b4e.png">
<img width="1251" alt="Screen Shot 2020-08-07 at 3 19 32 PM" src="https://user-images.githubusercontent.com/1850998/89693343-1f165100-d8c3-11ea-8def-bbab3a080581.png">
<img width="790" alt="Screen Shot 2020-08-07 at 3 36 50 PM 1" src="https://user-images.githubusercontent.com/1850998/89693613-d612cc80-d8c3-11ea-9a93-174ea1c77e72.png">
