### PR TITLE
fix(docker/tag): Make help content explicit for tag field by placing it below the field.

### DIFF
--- a/app/scripts/modules/docker/src/image/DockerImageAndTagSelector.tsx
+++ b/app/scripts/modules/docker/src/image/DockerImageAndTagSelector.tsx
@@ -620,9 +620,7 @@ export class DockerImageAndTagSelector extends React.Component<
         specifyTagByRegex ? (
           <div className="sp-formItem">
             <div className="sp-formItem__left">
-              <div className="sp-formLabel">
-                Tag <HelpField id="pipeline.config.docker.trigger.tag" />
-              </div>
+              <div className="sp-formLabel">Tag</div>
             </div>
 
             <div className="sp-formItem__right">
@@ -637,6 +635,7 @@ export class DockerImageAndTagSelector extends React.Component<
                   />
                 </span>
               </div>
+              <HelpField id="pipeline.config.docker.trigger.tag" expand={true} />
             </div>
           </div>
         ) : (


### PR DESCRIPTION
There's been some confusion around how docker registry trigger works when tag is provided. The detailed help content clears up the confusion but since it is hidden beside the label, I'm making it explicit by placing it below the field.

![image](https://user-images.githubusercontent.com/357832/89825687-d13f5a00-db09-11ea-8573-f2277e1c5e75.png)

