### PR TITLE
fix(core/managed): supply references when updating constraints

### DIFF
--- a/app/scripts/modules/core/src/managed/ArtifactDetail.tsx
+++ b/app/scripts/modules/core/src/managed/ArtifactDetail.tsx
@@ -134,6 +134,7 @@ const EnvironmentCards = memo(
               key={constraint.type}
               application={application}
               environment={environmentName}
+              reference={reference}
               version={versionDetails.version}
               constraint={constraint}
             />

--- a/app/scripts/modules/core/src/managed/ManagedWriter.ts
+++ b/app/scripts/modules/core/src/managed/ManagedWriter.ts
@@ -21,6 +21,7 @@ export interface IUpdateConstraintStatusRequest {
   application: string;
   environment: string;
   type: string;
+  reference: string;
   version: string;
   status: StatefulConstraintStatus;
 }
@@ -79,6 +80,7 @@ export class ManagedWriter {
     application,
     environment,
     type,
+    reference,
     version,
     status,
   }: IUpdateConstraintStatusRequest): IPromise<void> {
@@ -88,6 +90,7 @@ export class ManagedWriter {
       .one('constraint')
       .post({
         type,
+        artifactReference: reference,
         artifactVersion: version,
         status,
       });

--- a/app/scripts/modules/core/src/managed/constraints/ConstraintCard.tsx
+++ b/app/scripts/modules/core/src/managed/constraints/ConstraintCard.tsx
@@ -73,67 +73,71 @@ const getCardAppearance = (constraint: IStatefulConstraint | IStatelessConstrain
 export interface IConstraintCardProps {
   application: Application;
   environment: string;
+  reference: string;
   version: string;
   constraint: IStatefulConstraint | IStatelessConstraint;
 }
 
-export const ConstraintCard = memo(({ application, environment, version, constraint }: IConstraintCardProps) => {
-  const { type } = constraint;
+export const ConstraintCard = memo(
+  ({ application, environment, reference, version, constraint }: IConstraintCardProps) => {
+    const { type } = constraint;
 
-  const [actionStatus, setActionStatus] = useState<IRequestStatus>('NONE');
+    const [actionStatus, setActionStatus] = useState<IRequestStatus>('NONE');
 
-  if (!isConstraintSupported(type)) {
-    logUnsupportedConstraintError(type);
-    return null;
-  }
+    if (!isConstraintSupported(type)) {
+      logUnsupportedConstraintError(type);
+      return null;
+    }
 
-  const actions = getConstraintActions(constraint);
+    const actions = getConstraintActions(constraint);
 
-  return (
-    <StatusCard
-      appearance={getCardAppearance(constraint)}
-      iconName={getConstraintIcon(type)}
-      title={getConstraintSummary(constraint)}
-      actions={
-        actions && (
-          <div
-            className={classNames('flex-container-h middle', {
-              'sp-group-margin-s-xaxis': actionStatus !== 'REJECTED',
-            })}
-          >
-            {actionStatus !== 'REJECTED' &&
-              actions.map(({ title, pass }) => {
-                return (
-                  <Button
-                    key={title + pass}
-                    disabled={actionStatus === 'PENDING'}
-                    onClick={() => {
-                      setActionStatus('PENDING');
-                      overrideConstraintStatus(application, {
-                        environment,
-                        type,
-                        version,
-                        status: pass ? OVERRIDE_PASS : OVERRIDE_FAIL,
-                      })
-                        .then(() => setActionStatus('RESOLVED'))
-                        .catch(() => {
-                          setActionStatus('REJECTED');
-                        });
-                    }}
-                  >
-                    {title}
-                  </Button>
-                );
+    return (
+      <StatusCard
+        appearance={getCardAppearance(constraint)}
+        iconName={getConstraintIcon(type)}
+        title={getConstraintSummary(constraint)}
+        actions={
+          actions && (
+            <div
+              className={classNames('flex-container-h middle', {
+                'sp-group-margin-s-xaxis': actionStatus !== 'REJECTED',
               })}
-            {actionStatus === 'REJECTED' && (
-              <>
-                <span className="text-bold action-error-message sp-margin-l-right">Something went wrong</span>
-                <Button onClick={() => setActionStatus('NONE')}>Try again</Button>
-              </>
-            )}
-          </div>
-        )
-      }
-    />
-  );
-});
+            >
+              {actionStatus !== 'REJECTED' &&
+                actions.map(({ title, pass }) => {
+                  return (
+                    <Button
+                      key={title + pass}
+                      disabled={actionStatus === 'PENDING'}
+                      onClick={() => {
+                        setActionStatus('PENDING');
+                        overrideConstraintStatus(application, {
+                          environment,
+                          type,
+                          reference,
+                          version,
+                          status: pass ? OVERRIDE_PASS : OVERRIDE_FAIL,
+                        })
+                          .then(() => setActionStatus('RESOLVED'))
+                          .catch(() => {
+                            setActionStatus('REJECTED');
+                          });
+                      }}
+                    >
+                      {title}
+                    </Button>
+                  );
+                })}
+              {actionStatus === 'REJECTED' && (
+                <>
+                  <span className="text-bold action-error-message sp-margin-l-right">Something went wrong</span>
+                  <Button onClick={() => setActionStatus('NONE')}>Try again</Button>
+                </>
+              )}
+            </div>
+          )
+        }
+      />
+    );
+  },
+);


### PR DESCRIPTION
Related to https://github.com/spinnaker/keel/pull/1417 — this change always includes a reference when updating the status of a constraint so updates can be uniquely mapped to an artifact version. Once this is live we can make the reference field non-nullable on the API.