### PR TITLE
fix(kubernetes): add nullable createdTime to base resource interface

### DIFF
--- a/app/scripts/modules/kubernetes/src/interfaces/infrastructure.types.ts
+++ b/app/scripts/modules/kubernetes/src/interfaces/infrastructure.types.ts
@@ -9,6 +9,7 @@ import {
 
 export interface IKubernetesResource {
   apiVersion: string;
+  createdTime?: number;
   displayName: string;
   kind: string;
   namespace: string;


### PR DESCRIPTION
Each resource template tries to read this field.

Requires: https://github.com/spinnaker/clouddriver/pull/4791