### PR TITLE
fix(kubernetes): do not self-close element in angular template

### DIFF
--- a/app/scripts/modules/kubernetes/src/serverGroupManager/details/details.html
+++ b/app/scripts/modules/kubernetes/src/serverGroupManager/details/details.html
@@ -67,7 +67,7 @@
             ng-if="!ctrl.manifest.status.paused.state"
             application="ctrl.app"
             server-group-manager="ctrl.serverGroupManager"
-          />
+          ></kubernetes-rolling-restart>
           <li role="presentation" class="divider"></li>
           <li>
             <a href ng-click="ctrl.editServerGroupManager()">


### PR DESCRIPTION
Closes: https://github.com/spinnaker/spinnaker/issues/5962

Oddly, the `kubernetes-rolling-restart` component was rendering as expected, but each of the remaining elements in the list of actions (Edit and Delete) were not. Self-closing tags are not allowed in Angular templates, so I likely broke this when I added support for rolling restarts.