### PR TITLE
fix(RunJobStage): Make RunJobStage restartable

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/runJob/runJobStage.js
+++ b/app/scripts/modules/core/src/pipeline/config/stages/runJob/runJobStage.js
@@ -12,5 +12,6 @@ module(CORE_PIPELINE_CONFIG_STAGES_RUNJOB_RUNJOBSTAGE, []).config(function() {
     key: 'runJob',
     label: 'Run Job',
     description: 'Runs a container',
+    restartable: true,
   });
 });


### PR DESCRIPTION
This is supposed to fix this issue:
https://github.com/spinnaker/spinnaker/issues/5461

Is there a reason why the RunJobStage doesn't have the `restartable` property on it?