### PR TITLE
fix(google): do not self-close react2Angular-created elements

### DIFF
--- a/app/scripts/modules/google/src/serverGroup/configure/wizard/advancedSettings/advancedSettings.directive.html
+++ b/app/scripts/modules/google/src/serverGroup/configure/wizard/advancedSettings/advancedSettings.directive.html
@@ -27,7 +27,7 @@
   set-accelerator-configs="vm.setAcceleratorConfigs"
   zone="vm.command.zone"
   available-accelerators="vm.command.viewState.acceleratorTypes"
-/>
+></gce-accelerator-configurer>
 
 <div class="form-group">
   <div class="sm-label-left" style="margin-bottom: 5px;">

--- a/app/scripts/modules/google/src/serverGroup/configure/wizard/advancedSettings/diskConfigurer.component.ts
+++ b/app/scripts/modules/google/src/serverGroup/configure/wizard/advancedSettings/diskConfigurer.component.ts
@@ -167,7 +167,7 @@ const gceDiskConfigurer: IComponentOptions = {
                   selected-image="disk.sourceImage"
                   select-image="$ctrl.handleImageChange"
                   target="disk"
-                />
+                ></gce-image-select>
               </td>
               <td ng-if="$index > 0">
                 <a class="btn btn-link sm-label" style="margin-top: 0;" ng-click="$ctrl.removePersistentDisk($index)">

--- a/app/scripts/modules/google/src/serverGroup/configure/wizard/location/basicSettings.html
+++ b/app/scripts/modules/google/src/serverGroup/configure/wizard/location/basicSettings.html
@@ -114,7 +114,7 @@
           available-images="command.backingData.allImages"
           selected-image="command.image"
           select-image="basicSettingsCtrl.selectImage"
-        />
+        ></gce-image-select>
       </div>
     </div>
     <div class="form-group">

--- a/app/scripts/modules/google/src/serverGroup/details/serverGroupDetails.html
+++ b/app/scripts/modules/google/src/serverGroup/details/serverGroupDetails.html
@@ -155,7 +155,8 @@
         <dd>{{ctrl.serverGroup.launchConfig.instanceType | customInstanceFilter }}</dd>
         <dt>Minimum CPU Platform</dt>
         <dd>{{ctrl.serverGroup.launchConfig.minCpuPlatform || '(Automatic)'}}</dd>
-        <gce-server-group-disk-descriptions application="ctrl.application" server-group="ctrl.serverGroup" />
+        <gce-server-group-disk-descriptions application="ctrl.application" server-group="ctrl.serverGroup">
+        </gce-server-group-disk-descriptions>
         <dt ng-if="ctrl.serverGroup.serviceAccountEmail">Service Account</dt>
         <dd ng-if="ctrl.serverGroup.serviceAccountEmail">{{ctrl.serverGroup.serviceAccountEmail}}</dd>
         <dt ng-if="ctrl.serverGroup.authScopes">Auth Scopes</dt>


### PR DESCRIPTION
As [reported in Slack](https://spinnakerteam.slack.com/archives/CGXLE1BGW/p1597182222006500), several components of the GCE deploy modal disappeared for users upon upgrading from 1.20.x to 1.21.x. It appears that any subsequent siblings of self-closing `react2Angular`-generated elements are no longer rendered, and this seems to be a known issue when [upgrading](https://jquery.com/upgrade-guide/3.5/) from jquery 3.4.x to 3.5.x, which [Deck did](https://github.com/spinnaker/deck/pull/8222) between the 1.20.x and 1.21.x releases.