### PR TITLE
perf(kubernetes): Load manifest and instance details in parallel

### DIFF
--- a/app/scripts/modules/kubernetes/src/instance/details/details.controller.ts
+++ b/app/scripts/modules/kubernetes/src/instance/details/details.controller.ts
@@ -118,34 +118,32 @@ class KubernetesInstanceDetailsController implements IController {
     ]);
 
     const instanceManager = dataSources.find(instanceLocatorPredicate);
-    if (instanceManager) {
-      const recentHistoryExtraData: { [key: string]: string } = {
-        region: instanceManager.region,
-        account: instanceManager.account,
-      };
-
-      if (instanceManager.category === 'serverGroup') {
-        recentHistoryExtraData.serverGroup = instanceManager.name;
-      }
-
-      const instance = instanceManager.instances.find(i => i.id === instanceFromState.instanceId);
-
-      if (!instance) {
-        return this.$q.reject();
-      }
-
-      RecentHistoryService.addExtraDataToLatest('instances', recentHistoryExtraData);
-      return InstanceReader.getInstanceDetails(instanceManager.account, instanceManager.region, instance.name).then(
-        (instanceDetails: IKubernetesInstance) => {
-          instanceDetails.id = instance.id;
-          instanceDetails.name = instance.name;
-          instanceDetails.provider = 'kubernetes';
-          return instanceDetails;
-        },
-      );
-    } else {
+    if (!instanceManager) {
       return this.$q.reject();
     }
+    const recentHistoryExtraData: { [key: string]: string } = {
+      region: instanceManager.region,
+      account: instanceManager.account,
+    };
+
+    if (instanceManager.category === 'serverGroup') {
+      recentHistoryExtraData.serverGroup = instanceManager.name;
+    }
+
+    const instance = instanceManager.instances.find(i => i.id === instanceFromState.instanceId);
+    if (!instance) {
+      return this.$q.reject();
+    }
+
+    RecentHistoryService.addExtraDataToLatest('instances', recentHistoryExtraData);
+    return InstanceReader.getInstanceDetails(instanceManager.account, instanceManager.region, instance.name).then(
+      (instanceDetails: IKubernetesInstance) => {
+        instanceDetails.id = instance.id;
+        instanceDetails.name = instance.name;
+        instanceDetails.provider = 'kubernetes';
+        return instanceDetails;
+      },
+    );
   }
 
   private autoClose(): void {

--- a/app/scripts/modules/kubernetes/src/instance/details/details.controller.ts
+++ b/app/scripts/modules/kubernetes/src/instance/details/details.controller.ts
@@ -35,6 +35,13 @@ interface IConsoleOutputInstance {
   provider: string;
 }
 
+interface InstanceIdentifier {
+  account: string;
+  id: string;
+  name: string;
+  namespace: string;
+}
+
 class KubernetesInstanceDetailsController implements IController {
   public state = { loading: true };
   public instance: IKubernetesInstance;
@@ -88,25 +95,44 @@ class KubernetesInstanceDetailsController implements IController {
   }
 
   private extractInstance(instanceFromState: InstanceFromStateParams): void {
-    this.retrieveInstance(instanceFromState).then((instance: IKubernetesInstance) => {
-      if (!instance) {
-        return this.autoClose();
-      }
-      ManifestReader.getManifest(instance.account, instance.namespace, instance.name).then((manifest: IManifest) => {
-        this.instance = instance;
-        this.manifest = manifest;
-        this.consoleOutputInstance = {
-          account: this.instance.account,
-          region: this.instance.zone,
-          id: this.instance.humanReadableName,
-          provider: this.instance.provider,
-        };
+    const instanceId = this.retrieveInstance(instanceFromState);
+    if (!instanceId) {
+      return this.autoClose();
+    }
+    this.$q
+      .all([
+        this.fetchInstance(instanceId).then((instance: IKubernetesInstance) => {
+          this.instance = instance;
+          this.consoleOutputInstance = {
+            account: instance.account,
+            region: instance.zone,
+            id: instance.humanReadableName,
+            provider: instance.provider,
+          };
+        }),
+        ManifestReader.getManifest(instanceId.account, instanceId.namespace, instanceId.name).then(
+          (manifest: IManifest) => {
+            this.manifest = manifest;
+          },
+        ),
+      ])
+      .then(() => {
         this.state.loading = false;
       });
-    });
   }
 
-  private retrieveInstance(instanceFromState: InstanceFromStateParams): IPromise<IKubernetesInstance> {
+  private fetchInstance(instance: InstanceIdentifier): IPromise<IKubernetesInstance> {
+    return InstanceReader.getInstanceDetails(instance.account, instance.namespace, instance.name).then(
+      (instanceDetails: IKubernetesInstance) => {
+        instanceDetails.id = instance.id;
+        instanceDetails.name = instance.name;
+        instanceDetails.provider = 'kubernetes';
+        return instanceDetails;
+      },
+    );
+  }
+
+  private retrieveInstance(instanceFromState: InstanceFromStateParams): InstanceIdentifier {
     const instanceLocatorPredicate = (dataSource: InstanceManager) => {
       return dataSource.instances.some(possibleMatch => possibleMatch.id === instanceFromState.instanceId);
     };
@@ -119,7 +145,7 @@ class KubernetesInstanceDetailsController implements IController {
 
     const instanceManager = dataSources.find(instanceLocatorPredicate);
     if (!instanceManager) {
-      return this.$q.reject();
+      return null;
     }
     const recentHistoryExtraData: { [key: string]: string } = {
       region: instanceManager.region,
@@ -132,18 +158,17 @@ class KubernetesInstanceDetailsController implements IController {
 
     const instance = instanceManager.instances.find(i => i.id === instanceFromState.instanceId);
     if (!instance) {
-      return this.$q.reject();
+      return null;
     }
 
     RecentHistoryService.addExtraDataToLatest('instances', recentHistoryExtraData);
-    return InstanceReader.getInstanceDetails(instanceManager.account, instanceManager.region, instance.name).then(
-      (instanceDetails: IKubernetesInstance) => {
-        instanceDetails.id = instance.id;
-        instanceDetails.name = instance.name;
-        instanceDetails.provider = 'kubernetes';
-        return instanceDetails;
-      },
-    );
+
+    return {
+      id: instance.id,
+      name: instance.name,
+      namespace: instanceManager.region,
+      account: instanceManager.account,
+    };
   }
 
   private autoClose(): void {


### PR DESCRIPTION
* refactor(kubernetes): Flip an if condition

  retrieveInstance has a really long if block that would be clearer if we just returned null immediately if the data is missing (rather than have the usual path in a long block). Make that change separately to make the next diff smaller.

* perf(kubernetes): Load manifest and instance details in parallel

  When opening an instance tab, we currently wait for the reqeust to
  /instances to finish before starting the request to /manifests even though we have the required information for both.

  This PR updates the Kubernetes instance provider to send both requests immediately, reducing the amount of time the user needs to wait for the instance tab to load.