### PR TITLE
fix(gitRepoArtifact): move subpath value to location field.

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/gitrepo/GitRepoArtifactEditor.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/gitrepo/GitRepoArtifactEditor.tsx
@@ -1,4 +1,4 @@
-import { cloneDeep, get } from 'lodash';
+import { cloneDeep } from 'lodash';
 import React from 'react';
 
 import { ArtifactTypePatterns } from 'core/artifact';

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/gitrepo/GitRepoArtifactEditor.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/gitrepo/GitRepoArtifactEditor.tsx
@@ -17,10 +17,8 @@ class GitRepoArtifactEditor extends React.Component<IArtifactEditorProps, IGitRe
   public constructor(props: IArtifactEditorProps) {
     super(props);
     const { artifact } = this.props;
-    const location = get(artifact, 'location', '');
-    const metadataSubpath = get(artifact, 'metadata.subPath', '');
     this.state = {
-      includesSubPath: location !== '' || metadataSubpath !== '',
+      includesSubPath: (artifact.location ?? artifact.metadata?.subPath) !== undefined,
     };
   }
 
@@ -76,11 +74,7 @@ class GitRepoArtifactEditor extends React.Component<IArtifactEditorProps, IGitRe
           <StageConfigField label="Subpath" helpKey="pipeline.config.expectedArtifact.gitrepo.subpath">
             <SpelText
               placeholder="path/to/subdirectory"
-              value={
-                get(artifact, 'location', '') !== ''
-                  ? get(artifact, 'location', '')
-                  : get(artifact, 'metadata.subPath', '')
-              }
+              value={artifact.location ?? artifact.metadata?.subPath}
               onChange={this.onSubPathChanged}
               pipeline={this.props.pipeline}
               docLink={true}

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/gitrepo/GitRepoArtifactEditor.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/gitrepo/GitRepoArtifactEditor.tsx
@@ -17,8 +17,10 @@ class GitRepoArtifactEditor extends React.Component<IArtifactEditorProps, IGitRe
   public constructor(props: IArtifactEditorProps) {
     super(props);
     const { artifact } = this.props;
+    const location = get(artifact, 'location', '');
+    const metadataSubpath = get(artifact, 'metadata.subPath', '');
     this.state = {
-      includesSubPath: get(artifact, 'metadata.subPath', '') !== '',
+      includesSubPath: location !== '' || metadataSubpath !== '',
     };
   }
 
@@ -40,9 +42,7 @@ class GitRepoArtifactEditor extends React.Component<IArtifactEditorProps, IGitRe
 
   private onSubPathChanged = (subPath: string) => {
     const clonedArtifact = cloneDeep(this.props.artifact);
-    const metadata = get(clonedArtifact, 'metadata', {}) as any;
-    metadata.subPath = subPath;
-    clonedArtifact.metadata = metadata;
+    clonedArtifact.location = subPath;
     this.props.onChange(clonedArtifact);
   };
 
@@ -76,7 +76,11 @@ class GitRepoArtifactEditor extends React.Component<IArtifactEditorProps, IGitRe
           <StageConfigField label="Subpath" helpKey="pipeline.config.expectedArtifact.gitrepo.subpath">
             <SpelText
               placeholder="path/to/subdirectory"
-              value={get(artifact, 'metadata.subPath', '')}
+              value={
+                get(artifact, 'location', '') !== ''
+                  ? get(artifact, 'location', '')
+                  : get(artifact, 'metadata.subPath', '')
+              }
               onChange={this.onSubPathChanged}
               pipeline={this.props.pipeline}
               docLink={true}


### PR DESCRIPTION
Currently, there are some issues with the `git/repo` artifact because we store `subpath` as metadata, for users that define artifacts with the same URL and branch but different subpath, Orca is not able to match artifacts correctly.

This PR is about move the subpath value of a `git/repo` artifact to be saved in the `location` field.

It will look at `location` field first, then if it is missing will look at `metadata.subPath`
