### PR TITLE
fix(RunJobStage): Add restartability to Kubernetes RunJobStage

### DIFF
--- a/app/scripts/modules/kubernetes/src/pipelines/stages/runJob/runJobStage.ts
+++ b/app/scripts/modules/kubernetes/src/pipelines/stages/runJob/runJobStage.ts
@@ -23,6 +23,7 @@ Registry.pipeline.registerStage({
   executionDetailsSections: [RunJobExecutionDetails, DeployStatus, ExecutionDetailsTasks],
   supportsCustomTimeout: true,
   producesArtifacts: true,
+  restartable: true,
   validators: [
     {
       type: 'custom',


### PR DESCRIPTION
I already submitted this to fix the problem:

https://github.com/spinnaker/deck/pull/8492

But it didn't

It seems there are multiple files for `runJobStage`, but the one I change in this PR is the correct one. I have tested it and it works perfectly.

Apologies for the confusion

@maggieneterval FYI
