### PR TITLE
chore(licenses): add license metadata to npm packages

### DIFF
--- a/app/scripts/modules/amazon/package.json
+++ b/app/scripts/modules/amazon/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@spinnaker/amazon",
+  "license": "Apache-2.0",
   "version": "0.0.262",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",

--- a/app/scripts/modules/appengine/package.json
+++ b/app/scripts/modules/appengine/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@spinnaker/appengine",
+  "license": "Apache-2.0",
   "version": "0.0.14",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",

--- a/app/scripts/modules/azure/package.json
+++ b/app/scripts/modules/azure/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@spinnaker/azure",
+  "license": "Apache-2.0",
   "version": "0.0.252",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",

--- a/app/scripts/modules/cloudfoundry/package.json
+++ b/app/scripts/modules/cloudfoundry/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@spinnaker/cloudfoundry",
+  "license": "Apache-2.0",
   "version": "0.0.96",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",

--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@spinnaker/core",
+  "license": "Apache-2.0",
   "version": "0.0.502",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",

--- a/app/scripts/modules/docker/package.json
+++ b/app/scripts/modules/docker/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@spinnaker/docker",
+  "license": "Apache-2.0",
   "version": "0.0.58",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",

--- a/app/scripts/modules/ecs/package.json
+++ b/app/scripts/modules/ecs/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@spinnaker/ecs",
+  "license": "Apache-2.0",
   "version": "0.0.260",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",

--- a/app/scripts/modules/google/package.json
+++ b/app/scripts/modules/google/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@spinnaker/google",
+  "license": "Apache-2.0",
   "version": "0.0.18",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",

--- a/app/scripts/modules/huaweicloud/package.json
+++ b/app/scripts/modules/huaweicloud/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@spinnaker/huaweicloud",
+  "license": "Apache-2.0",
   "version": "0.0.4",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",

--- a/app/scripts/modules/kubernetes/package.json
+++ b/app/scripts/modules/kubernetes/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@spinnaker/kubernetes",
+  "license": "Apache-2.0",
   "version": "0.0.47",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",

--- a/app/scripts/modules/oracle/package.json
+++ b/app/scripts/modules/oracle/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@spinnaker/oracle",
+  "license": "Apache-2.0",
   "version": "0.0.6",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",

--- a/app/scripts/modules/tencentcloud/package.json
+++ b/app/scripts/modules/tencentcloud/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@spinnaker/tencentcloud",
+  "license": "Apache-2.0",
   "version": "0.0.3",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",

--- a/app/scripts/modules/titus/package.json
+++ b/app/scripts/modules/titus/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@spinnaker/titus",
+  "license": "Apache-2.0",
   "version": "0.0.139",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",


### PR DESCRIPTION
Some organizations need this metadata in order to use Deck's NPM packages.