### PR TITLE
feat(core/managed): add resource kind registry as prep for plugins

### DIFF
--- a/app/scripts/modules/core/src/managed/ManagedResourceObject.tsx
+++ b/app/scripts/modules/core/src/managed/ManagedResourceObject.tsx
@@ -2,12 +2,13 @@ import React, { memo } from 'react';
 import { useSref } from '@uirouter/react';
 
 import { Application } from 'core/application';
-import { Icon, IconNames } from '../presentation';
+import { Icon } from '../presentation';
 import { IManagedResourceSummary, IManagedEnviromentSummary, IManagedArtifactSummary } from '../domain/IManagedEntity';
 
 import { getKindName } from './ManagedReader';
 import { ObjectRow } from './ObjectRow';
 import { AnimatingPill, Pill } from './Pill';
+import { getResourceIcon } from './resources/resourceRegistry';
 import { getResourceName, getArtifactVersionDisplayName } from './displayNames';
 import { StatusBubble } from './StatusBubble';
 import { viewConfigurationByStatus } from './managedResourceStatusConfig';
@@ -21,16 +22,10 @@ export interface IManagedResourceObjectProps {
   depth?: number;
 }
 
-const kindIconMap: { [kind: string]: IconNames } = {
-  cluster: 'cluster',
-  'security-group': 'securityGroup',
-  'classic-load-balancer': 'loadBalancer',
-  'application-load-balancer': 'loadBalancer',
-};
-
-const getIconTypeFromKind = (kind: string) => kindIconMap[getKindName(kind)] ?? 'placeholder';
-
-const getResourceRoutingInfo = (
+// We'll add detail drawers for resources soon, but in the meantime let's link
+// to infrastructure views for 'native' Spinnaker resources in a one-off way
+// so the registry doesn't have to know about it.
+const getNativeResourceRoutingInfo = (
   resource: IManagedResourceSummary,
 ): { state: string; params: { [key: string]: string } } | null => {
   const {
@@ -65,7 +60,7 @@ export const ManagedResourceObject = memo(
   ({ application, resource, artifactVersionsByState, artifactDetails, depth }: IManagedResourceObjectProps) => {
     const { kind } = resource;
     const resourceName = getResourceName(resource);
-    const routingInfo = getResourceRoutingInfo(resource) ?? { state: '', params: {} };
+    const routingInfo = getNativeResourceRoutingInfo(resource) ?? { state: '', params: {} };
     const route = useSref(routingInfo.state, routingInfo.params);
 
     const current =
@@ -92,7 +87,7 @@ export const ManagedResourceObject = memo(
 
     return (
       <ObjectRow
-        icon={getIconTypeFromKind(kind)}
+        icon={getResourceIcon(kind)}
         title={route ? <a {...route}>{resourceName}</a> : resourceName}
         depth={depth}
         content={resourceStatus}

--- a/app/scripts/modules/core/src/managed/managed.module.js
+++ b/app/scripts/modules/core/src/managed/managed.module.js
@@ -3,6 +3,9 @@
 import { module } from 'angular';
 
 import { MANAGED_STATES } from './managed.states';
+import { registerNativeResourceKinds } from './resources/registerNativeResourceKinds';
 
 export const CORE_MANAGED_MANAGED_MODULE = 'spinnaker.managed';
-module(CORE_MANAGED_MANAGED_MODULE, [MANAGED_STATES]);
+module(CORE_MANAGED_MANAGED_MODULE, [MANAGED_STATES]).config(() => {
+  registerNativeResourceKinds();
+});

--- a/app/scripts/modules/core/src/managed/resources/registerNativeResourceKinds.ts
+++ b/app/scripts/modules/core/src/managed/resources/registerNativeResourceKinds.ts
@@ -1,0 +1,28 @@
+import { registerResourceKind } from './resourceRegistry';
+
+export const registerNativeResourceKinds = () => {
+  registerResourceKind({
+    kind: 'titus/cluster@v1',
+    iconName: 'cluster',
+  });
+
+  registerResourceKind({
+    kind: 'ec2/cluster@v1',
+    iconName: 'cluster',
+  });
+
+  registerResourceKind({
+    kind: 'ec2/security-group@v1',
+    iconName: 'securityGroup',
+  });
+
+  registerResourceKind({
+    kind: 'ec2/classic-load-balancer@v1',
+    iconName: 'loadBalancer',
+  });
+
+  registerResourceKind({
+    kind: 'ec2/application-load-balancer@v1',
+    iconName: 'loadBalancer',
+  });
+};

--- a/app/scripts/modules/core/src/managed/resources/resourceRegistry.ts
+++ b/app/scripts/modules/core/src/managed/resources/resourceRegistry.ts
@@ -1,0 +1,18 @@
+import { IconNames } from '../../presentation';
+
+const UNKNOWN_RESOURCE_ICON = 'placeholder';
+
+const resourceConfigsByKind: { [kind: string]: IResourceKindConfig } = {};
+
+export interface IResourceKindConfig {
+  kind: string;
+  iconName: IconNames;
+}
+
+export const isResourceKindSupported = (kind: string) => resourceConfigsByKind.hasOwnProperty(kind);
+
+export const registerResourceKind = (config: IResourceKindConfig) => {
+  resourceConfigsByKind[config.kind] = config;
+};
+
+export const getResourceIcon = (kind: string) => resourceConfigsByKind[kind]?.iconName ?? UNKNOWN_RESOURCE_ICON;


### PR DESCRIPTION
We're getting very close to extending our supported resource kinds via plugins, and as prep for that we need to do some UI plumbing. The first step of that is taking hard-coded configuration for the currently supported resource kinds and moving it all behind a registry contract that can later be used for other kinds outside of the core codebase. A couple things still stand in our way:

- We need a way to show a display name when a resource doesn't conform to the moniker contract (@luispollo will be handling this on the API side)
- We need to wire this registry contract up to the externally facing SDK provided to UI plugins, so that it's possible to add kinds outside of the core codebase itself