### PR TITLE
fix(ecs): ECS Service Discovery container not valid error #5859

### DIFF
--- a/app/scripts/modules/ecs/src/serverGroup/configure/serverGroupConfiguration.service.ts
+++ b/app/scripts/modules/ecs/src/serverGroup/configure/serverGroupConfiguration.service.ts
@@ -111,6 +111,7 @@ export interface IEcsTargetGroupMapping {
 export interface IEcsServiceDiscoveryRegistryAssociation {
   registry: IServiceDiscoveryRegistryDescriptor;
   containerPort: number;
+  containerName: string;
 }
 
 export interface IEcsServerGroupCommand extends IServerGroupCommand {
@@ -130,6 +131,7 @@ export interface IEcsServerGroupCommand extends IServerGroupCommand {
   loadBalancedContainer: string;
   targetGroupMappings: IEcsTargetGroupMapping[];
   serviceDiscoveryAssociations: IEcsServiceDiscoveryRegistryAssociation[];
+  useTaskDefinitionArtifact: boolean;
 
   subnetTypeChanged: (command: IEcsServerGroupCommand) => IServerGroupCommandResult;
   placementStrategyNameChanged: (command: IEcsServerGroupCommand) => IServerGroupCommandResult;

--- a/app/scripts/modules/ecs/src/serverGroup/configure/wizard/serverGroupWizard.html
+++ b/app/scripts/modules/ecs/src/serverGroup/configure/wizard/serverGroupWizard.html
@@ -29,8 +29,9 @@
           <ng-include src="pages.logging"></ng-include>
         </v2-wizard-page>
       </div>
-      <v2-wizard-page key="serviceDiscovery" label="Service Discovery" done="true">
-        <ng-include src="pages.serviceDiscovery"></ng-include>
+      <v2-wizard-page key="serviceDiscovery" label="Service Discovery"  done="true">
+        <ng-include  ng-if="!command.useTaskDefinitionArtifact" src="pages.serviceDiscovery" ></ng-include>
+        <ng-include  ng-if="command.useTaskDefinitionArtifact" src="pages.serviceDiscovery" ></ng-include>
       </v2-wizard-page>
       <v2-wizard-page key="advanced" label="Advanced Settings" mark-complete-on-view="false" done="true">
         <ng-include src="pages.advancedSettings"></ng-include>


### PR DESCRIPTION
Relates to issue: [spinnaker/spinnaker/issues/5859](https://github.com/spinnaker/spinnaker/issues/5859)

Issue Summary:
Turning on ECS Service Discovery integration on the deploy step fails when using an Artifact to pull the task definition
Pulling the task definition from GitHub as an artifact, then enabling the Service Discovery feature on the deployment. When you run the pipeline you get an error like this:
The container v060 is not valid. The value for 'containerName' must already be specified in the task definition. Registry: arn:aws:servicediscovery:us-east-

This PR fix the above issue by providing an input space to add the containerName in the Service Discovery Section

![5859](https://user-images.githubusercontent.com/18301288/91108566-26f92380-e62d-11ea-9647-959bcd7fa575.png)

closes #8517 