### PR TITLE
feat(core/managed): use displayName for resources in place of moniker

### DIFF
--- a/app/scripts/modules/core/src/domain/IManagedEntity.ts
+++ b/app/scripts/modules/core/src/domain/IManagedEntity.ts
@@ -46,11 +46,12 @@ export interface IManagedResourceSummary {
   kind: string;
   status: ManagedResourceStatus;
   isPaused: boolean;
-  moniker: IMoniker;
+  displayName: string;
   locations: {
     account: string;
     regions: Array<{ name: string }>;
   };
+  moniker?: IMoniker;
   artifact?: {
     name: string;
     type: string;

--- a/app/scripts/modules/core/src/managed/ArtifactDetail.tsx
+++ b/app/scripts/modules/core/src/managed/ArtifactDetail.tsx
@@ -20,12 +20,12 @@ import { showMarkArtifactAsBadModal } from './MarkArtifactAsBadModal';
 
 import { ConstraintCard } from './constraints/ConstraintCard';
 import { isConstraintSupported } from './constraints/constraintRegistry';
+import { isResourceKindSupported } from './resources/resourceRegistry';
 
 import './ArtifactDetail.less';
 
 function shouldDisplayResource(reference: string, resource: IManagedResourceSummary) {
-  //TODO: naively filter on presence of moniker but how should we really decide what to display?
-  return !!resource.moniker && reference === resource.artifact?.reference;
+  return isResourceKindSupported(resource.kind) && reference === resource.artifact?.reference;
 }
 
 const inStyles = {

--- a/app/scripts/modules/core/src/managed/EnvironmentsList.tsx
+++ b/app/scripts/modules/core/src/managed/EnvironmentsList.tsx
@@ -7,9 +7,10 @@ import { IManagedEnviromentSummary, IManagedResourceSummary, IManagedArtifactSum
 import { ManagedResourceObject } from './ManagedResourceObject';
 import { EnvironmentRow } from './EnvironmentRow';
 
+import { isResourceKindSupported } from './resources/resourceRegistry';
+
 function shouldDisplayResource(resource: IManagedResourceSummary) {
-  //TODO: naively filter on presence of moniker but how should we really decide what to display?
-  return !!resource.moniker;
+  return isResourceKindSupported(resource.kind);
 }
 
 interface IEnvironmentsListProps {

--- a/app/scripts/modules/core/src/managed/ManagedResourceHistoryModal.tsx
+++ b/app/scripts/modules/core/src/managed/ManagedResourceHistoryModal.tsx
@@ -23,7 +23,6 @@ import { ManagedReader } from './ManagedReader';
 import { Spinner } from 'core/widgets';
 
 import { ManagedResourceDiffTable } from './ManagedResourceDiffTable';
-import { getResourceName } from './displayNames';
 
 import './ManagedResourceHistoryModal.less';
 
@@ -192,7 +191,6 @@ export const ManagedResourceHistoryModal = ({ resourceSummary, dismissModal }: I
   );
   const previousHistoryEvents: IManagedResourceEvent[] = usePrevious(historyEvents);
 
-  const resourceDisplayName = getResourceName(resourceSummary);
   const isLoading = !historyEvents && ['NONE', 'PENDING'].includes(historyEventStatus);
   const shouldShowExistingData = !isLoading && historyEventStatus !== 'REJECTED';
 
@@ -246,7 +244,7 @@ export const ManagedResourceHistoryModal = ({ resourceSummary, dismissModal }: I
                       >
                         <TableCell>
                           <AccountTag account={account} />{' '}
-                          <span className="sp-margin-s-left">{resourceDisplayName}</span>
+                          <span className="sp-margin-s-left">{resourceSummary.displayName}</span>
                         </TableCell>
                         <TableCell>
                           <i

--- a/app/scripts/modules/core/src/managed/ManagedResourceObject.tsx
+++ b/app/scripts/modules/core/src/managed/ManagedResourceObject.tsx
@@ -9,7 +9,7 @@ import { getKindName } from './ManagedReader';
 import { ObjectRow } from './ObjectRow';
 import { AnimatingPill, Pill } from './Pill';
 import { getResourceIcon } from './resources/resourceRegistry';
-import { getResourceName, getArtifactVersionDisplayName } from './displayNames';
+import { getArtifactVersionDisplayName } from './displayNames';
 import { StatusBubble } from './StatusBubble';
 import { viewConfigurationByStatus } from './managedResourceStatusConfig';
 import { ManagedResourceStatusPopover } from './ManagedResourceStatusPopover';
@@ -30,15 +30,16 @@ const getNativeResourceRoutingInfo = (
 ): { state: string; params: { [key: string]: string } } | null => {
   const {
     kind,
-    moniker: { stack, detail },
+    moniker,
+    displayName,
     locations: { account },
   } = resource;
   const kindName = getKindName(kind);
   const params = {
     acct: account,
-    stack: stack ?? '(none)',
-    detail: detail ?? '(none)',
-    q: getResourceName(resource),
+    stack: moniker?.stack ?? '(none)',
+    detail: moniker?.detail ?? '(none)',
+    q: displayName,
   };
 
   switch (kindName) {
@@ -58,8 +59,7 @@ const getNativeResourceRoutingInfo = (
 
 export const ManagedResourceObject = memo(
   ({ application, resource, artifactVersionsByState, artifactDetails, depth }: IManagedResourceObjectProps) => {
-    const { kind } = resource;
-    const resourceName = getResourceName(resource);
+    const { kind, displayName } = resource;
     const routingInfo = getNativeResourceRoutingInfo(resource) ?? { state: '', params: {} };
     const route = useSref(routingInfo.state, routingInfo.params);
 
@@ -88,7 +88,7 @@ export const ManagedResourceObject = memo(
     return (
       <ObjectRow
         icon={getResourceIcon(kind)}
-        title={route ? <a {...route}>{resourceName}</a> : resourceName}
+        title={route ? <a {...route}>{displayName}</a> : displayName}
         depth={depth}
         content={resourceStatus}
         metadata={

--- a/app/scripts/modules/core/src/managed/displayNames.ts
+++ b/app/scripts/modules/core/src/managed/displayNames.ts
@@ -1,7 +1,4 @@
-import { IManagedResourceSummary, IManagedArtifactVersion } from '../domain';
-
-export const getResourceName = ({ moniker: { app, stack, detail } }: IManagedResourceSummary) =>
-  [app, stack, detail].filter(Boolean).join('-');
+import { IManagedArtifactVersion } from '../domain';
 
 export const getArtifactVersionDisplayName = ({ displayName, build, git }: IManagedArtifactVersion) =>
   build?.id ? `#${build?.id}` : git?.commit || displayName || 'unknown';


### PR DESCRIPTION
Following up #8513, this change switches the way we deal with resource objects to use the [newly added `displayName` field](https://github.com/spinnaker/keel/pull/1456) instead of assuming a resource will have a `moniker` object. That's important for resource plugins/extensions as it doesn't always make sense for a resource to conform to the moniker contract.

I refactored most of this via whack-a-mole-ing the TS compiler errors after making `moniker` optional, so it's possible there's a spot I missed. We'll find out.