### PR TITLE
feat(core/notifier): Make notifier service work with react components

### DIFF
--- a/app/scripts/modules/core/src/application/service/InferredApplicationWarningService.tsx
+++ b/app/scripts/modules/core/src/application/service/InferredApplicationWarningService.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import { Application } from '../application.model';
 import { NotifierService } from 'core/widgets/notifier/notifier.service';
 
@@ -30,7 +32,11 @@ export class InferredApplicationWarningService {
     NotifierService.publish({
       key: 'inferredApplicationWarning',
       action: 'create',
-      body: `The application <b>${appName}</b> has not been <a href="#/applications/${appName}/config">configured</a>.`,
+      content: (
+        <div>
+          The application <b>{appName}</b> has not been <a href={`#/applications/${appName}/config`}>configured</a>.
+        </div>
+      ),
     });
   }
 }

--- a/app/scripts/modules/core/src/config/VersionChecker.tsx
+++ b/app/scripts/modules/core/src/config/VersionChecker.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { $http, $log } from 'ngimport';
 
 import { NotifierService } from 'core/widgets/notifier/notifier.service';
@@ -39,8 +40,14 @@ export class VersionChecker {
         NotifierService.publish({
           key: 'newVersion',
           action: 'create',
-          body: `A new version of Spinnaker is available
-              <a role="button" class="action" onclick="document.location.reload(true)">Refresh</a>`,
+          content: (
+            <div>
+              A new version of Spinnaker is available{' '}
+              <a role="button" className="action" onClick={() => document.location.reload(true)}>
+                Refresh
+              </a>
+            </div>
+          ),
         });
         this.scheduler.unsubscribe();
       }

--- a/app/scripts/modules/core/src/widgets/notifier/Notifier.tsx
+++ b/app/scripts/modules/core/src/widgets/notifier/Notifier.tsx
@@ -44,7 +44,11 @@ export class Notifier extends React.Component<{}, INotifierState> {
 
   private makeNotification = (message: INotifier) => (
     <div key={message.key} className="user-notification horizontal space-around">
-      <Markdown className="message" message={message.body} options={{ ADD_ATTR: ['onclick'] }} />
+      {message.content ? (
+        <div className="message">{message.content}</div>
+      ) : (
+        <Markdown className="message" message={message.body} options={{ ADD_ATTR: ['onclick'] }} />
+      )}
       <button className="btn btn-link close-notification" role="button" onClick={() => this.dismiss(message.key)}>
         <span className="fa fa-times" />
       </button>

--- a/app/scripts/modules/core/src/widgets/notifier/notifier.service.ts
+++ b/app/scripts/modules/core/src/widgets/notifier/notifier.service.ts
@@ -1,9 +1,11 @@
+import React from 'react';
 import { Subject } from 'rxjs';
 
 export interface INotifier {
   key: string;
   action: 'remove' | 'create';
-  body?: string;
+  body?: string /* Deprecated in favor of `content` */;
+  content?: React.ReactNode;
 }
 
 export class NotifierService {


### PR DESCRIPTION
`notifier.service.ts` currently only accepts string inputs to render as messages. There's a request to open application configuration modal for non-configured applications via the notifications message and it can't be done without making `notifier.service.ts` accept a react component as content. This PR includes this change and updates the existing usages of this service in spinnaker.

NOTE that I'm not removing the old prop `body` from `notifier.service.ts` as I'm not sure if it is used in other customized spinnaker implementations.