### PR TITLE
fix(core/securityGroup): Add job type while updating security groups via infrastructure view

### DIFF
--- a/app/scripts/modules/core/src/serverGroup/serverGroupWriter.service.ts
+++ b/app/scripts/modules/core/src/serverGroup/serverGroupWriter.service.ts
@@ -204,6 +204,7 @@ export class ServerGroupWriter {
       region: serverGroup.region,
       securityGroups: securityGroups.map((group: ISecurityGroup) => group.id),
       serverGroupName: serverGroup.name,
+      type: 'updateSecurityGroupsForServerGroup',
     };
 
     if (hasLaunchTemplate) {


### PR DESCRIPTION
This [commit](https://github.com/spinnaker/deck/commit/62e6878756def592f1faad0c5db1b6aa62c3e20e#diff-d55ad7e7e519cd7a0cbad31b2eba3ab1L206) accidentally removed the `type` when submitting the job.