### PR TITLE
feat(tencentcloud): add disableServerGroup, enableServerGroup, tagIma…

### DIFF
--- a/app/scripts/modules/tencentcloud/src/pipeline/stages/disableServerGroup/DisableSGConfig.tsx
+++ b/app/scripts/modules/tencentcloud/src/pipeline/stages/disableServerGroup/DisableSGConfig.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { cloneDeep } from 'lodash';
+
+import { FormikStageConfig, IStageConfigProps } from '@spinnaker/core';
+import { DisableSGStageForm } from './DisableSGStageForm';
+
+export function DisableSGConfig({ application, pipeline, stage, updateStage }: IStageConfigProps) {
+  const stageWithDefaults = React.useMemo(() => {
+    return {
+      cloudProvider: 'tencentcloud',
+      regions: stage.regions || [],
+      ...cloneDeep(stage),
+    };
+  }, []);
+
+  return (
+    <FormikStageConfig
+      application={application}
+      onChange={updateStage}
+      pipeline={pipeline}
+      stage={stageWithDefaults}
+      render={props => <DisableSGStageForm {...props} />}
+    />
+  );
+}

--- a/app/scripts/modules/tencentcloud/src/pipeline/stages/disableServerGroup/DisableSGStageForm.tsx
+++ b/app/scripts/modules/tencentcloud/src/pipeline/stages/disableServerGroup/DisableSGStageForm.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+const { useEffect, useState } = React;
+import {
+  AccountService,
+  NgReact,
+  StageConfigField,
+  StageConstants,
+  IAccount,
+  IFormikStageConfigInjectedProps,
+} from '@spinnaker/core';
+const { AccountRegionClusterSelector, TargetSelect } = NgReact;
+
+export function DisableSGStageForm({ application, formik, pipeline }: IFormikStageConfigInjectedProps) {
+  const stage = formik.values;
+  const { setFieldValue } = formik;
+  const [accounts, setAccounts] = useState([]);
+  const [targets] = useState(StageConstants.TARGET_LIST);
+
+  useEffect(() => {
+    AccountService.listAccounts('tencentcloud').then((accounts: IAccount[]) => {
+      setAccounts(accounts);
+    });
+
+    if (
+      stage.isNew &&
+      application?.attributes?.platformHealthOnlyShowOverride &&
+      application?.attributes?.platformHealthOnly
+    ) {
+      setFieldValue('interestingHealthProviderNames', ['Tencentcloud']);
+    }
+
+    if (!stage.credentials && application?.defaultCredentials?.tencentcloud) {
+      setFieldValue('credentials', application?.defaultCredentials?.tencentcloud);
+    }
+
+    if (!stage?.regions?.length && application?.defaultRegions?.tencentcloud) {
+      setFieldValue('regions', [...stage.regions, application?.defaultRegions?.tencentcloud]);
+    }
+
+    if (!stage.target) {
+      setFieldValue('target', targets[0].val);
+    }
+  }, []);
+
+  const targetUpdated = (target: string) => {
+    setFieldValue('target', target);
+  };
+
+  return (
+    <div className="form-horizontal">
+      {!pipeline.strategy && (
+        <AccountRegionClusterSelector
+          application={application}
+          clusterField={'cluster'}
+          component={stage}
+          accounts={accounts}
+        />
+      )}
+      <StageConfigField label="Target">
+        <TargetSelect model={{ target: stage.target }} options={targets} onChange={targetUpdated} />
+      </StageConfigField>
+    </div>
+  );
+}

--- a/app/scripts/modules/tencentcloud/src/pipeline/stages/disableServerGroup/disableSGStage.ts
+++ b/app/scripts/modules/tencentcloud/src/pipeline/stages/disableServerGroup/disableSGStage.ts
@@ -1,0 +1,11 @@
+import { validate } from './disableSGValidators';
+import { Registry } from '@spinnaker/core';
+import { DisableSGConfig } from './DisableSGConfig';
+
+Registry.pipeline.registerStage({
+  provides: 'disableServerGroup',
+  key: 'disableServerGroup',
+  cloudProvider: 'tencentcloud',
+  component: DisableSGConfig,
+  validateFn: validate,
+});

--- a/app/scripts/modules/tencentcloud/src/pipeline/stages/disableServerGroup/disableSGValidators.ts
+++ b/app/scripts/modules/tencentcloud/src/pipeline/stages/disableServerGroup/disableSGValidators.ts
@@ -1,0 +1,10 @@
+import { FormValidator, IContextualValidator, IStage } from 'core';
+
+export const validate: IContextualValidator = (stage: IStage) => {
+  const formValidator = new FormValidator(stage);
+  formValidator.field('cluster', 'Cluster').required();
+  formValidator.field('target', 'Target').required();
+  formValidator.field('regions', 'Regions').required();
+  formValidator.field('account', 'Account').required();
+  return formValidator.validateForm();
+};

--- a/app/scripts/modules/tencentcloud/src/pipeline/stages/enableServerGroup/EnableSGConfig.tsx
+++ b/app/scripts/modules/tencentcloud/src/pipeline/stages/enableServerGroup/EnableSGConfig.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { cloneDeep } from 'lodash';
+
+import { FormikStageConfig, IStageConfigProps } from '@spinnaker/core';
+import { EnableSGStageForm } from './enableSGStageForm';
+
+export function EnableSGConfig({ application, pipeline, stage, updateStage }: IStageConfigProps) {
+  const stageWithDefaults = React.useMemo(() => {
+    return {
+      cloudProvider: 'tencentcloud',
+      regions: stage.regions || [],
+      ...cloneDeep(stage),
+    };
+  }, []);
+
+  return (
+    <FormikStageConfig
+      application={application}
+      onChange={updateStage}
+      pipeline={pipeline}
+      stage={stageWithDefaults}
+      render={props => <EnableSGStageForm {...props} />}
+    />
+  );
+}

--- a/app/scripts/modules/tencentcloud/src/pipeline/stages/enableServerGroup/enableSGStage.ts
+++ b/app/scripts/modules/tencentcloud/src/pipeline/stages/enableServerGroup/enableSGStage.ts
@@ -1,0 +1,11 @@
+import { validate } from './enableSGValidators';
+import { Registry } from '@spinnaker/core';
+import { EnableSGConfig } from './EnableSGConfig';
+
+Registry.pipeline.registerStage({
+  provides: 'enableServerGroup',
+  key: 'enableServerGroup',
+  cloudProvider: 'tencentcloud',
+  component: EnableSGConfig,
+  validateFn: validate,
+});

--- a/app/scripts/modules/tencentcloud/src/pipeline/stages/enableServerGroup/enableSGStageForm.tsx
+++ b/app/scripts/modules/tencentcloud/src/pipeline/stages/enableServerGroup/enableSGStageForm.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+const { useEffect, useState } = React;
+import {
+  AccountService,
+  NgReact,
+  StageConfigField,
+  StageConstants,
+  IAccount,
+  IFormikStageConfigInjectedProps,
+} from '@spinnaker/core';
+const { AccountRegionClusterSelector, TargetSelect } = NgReact;
+
+export function EnableSGStageForm({ application, formik, pipeline }: IFormikStageConfigInjectedProps) {
+  const stage = formik.values;
+  const { setFieldValue } = formik;
+  const [accounts, setAccounts] = useState([]);
+  const [targets] = useState(StageConstants.TARGET_LIST);
+
+  useEffect(() => {
+    AccountService.listAccounts('tencentcloud').then((accounts: IAccount[]) => {
+      setAccounts(accounts);
+    });
+
+    if (
+      stage.isNew &&
+      application?.attributes?.platformHealthOnlyShowOverride &&
+      application?.attributes?.platformHealthOnly
+    ) {
+      setFieldValue('interestingHealthProviderNames', ['Tencentcloud']);
+    }
+
+    if (!stage.credentials && application?.defaultCredentials?.tencentcloud) {
+      setFieldValue('credentials', application?.defaultCredentials?.tencentcloud);
+    }
+
+    if (!stage?.regions?.length && application?.defaultRegions?.tencentcloud) {
+      setFieldValue('regions', [...stage.regions, application?.defaultRegions?.tencentcloud]);
+    }
+
+    if (!stage.target) {
+      setFieldValue('target', targets[0].val);
+    }
+  }, []);
+
+  const targetUpdated = (target: string) => {
+    setFieldValue('target', target);
+  };
+
+  return (
+    <div className="form-horizontal">
+      {!pipeline.strategy && (
+        <AccountRegionClusterSelector
+          application={application}
+          clusterField={'cluster'}
+          component={stage}
+          accounts={accounts}
+        />
+      )}
+      <StageConfigField label="Target">
+        <TargetSelect model={{ target: stage.target }} options={targets} onChange={targetUpdated} />
+      </StageConfigField>
+    </div>
+  );
+}

--- a/app/scripts/modules/tencentcloud/src/pipeline/stages/enableServerGroup/enableSGValidators.ts
+++ b/app/scripts/modules/tencentcloud/src/pipeline/stages/enableServerGroup/enableSGValidators.ts
@@ -1,0 +1,10 @@
+import { FormValidator, IContextualValidator, IStage } from 'core';
+
+export const validate: IContextualValidator = (stage: IStage) => {
+  const formValidator = new FormValidator(stage);
+  formValidator.field('cluster', 'Cluster').required();
+  formValidator.field('target', 'Target').required();
+  formValidator.field('regions', 'Regions').required();
+  formValidator.field('account', 'Account').required();
+  return formValidator.validateForm();
+};

--- a/app/scripts/modules/tencentcloud/src/pipeline/stages/tagImage/TagImageConfig.tsx
+++ b/app/scripts/modules/tencentcloud/src/pipeline/stages/tagImage/TagImageConfig.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { FormikStageConfig, IStageConfigProps } from '@spinnaker/core';
+import { TagImageForm } from './TagImageForm';
+
+export function TagImageConfig({ application, pipeline, stage, updateStage }: IStageConfigProps) {
+  return (
+    <FormikStageConfig
+      application={application}
+      onChange={updateStage}
+      pipeline={pipeline}
+      stage={stage}
+      render={props => <TagImageForm {...props} />}
+    />
+  );
+}

--- a/app/scripts/modules/tencentcloud/src/pipeline/stages/tagImage/TagImageExecutionDetails.tsx
+++ b/app/scripts/modules/tencentcloud/src/pipeline/stages/tagImage/TagImageExecutionDetails.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { IExecutionDetailsSectionProps } from '@spinnaker/core';
+
+TagImageExecutionDetails.title = 'Tag Image Config';
+export function TagImageExecutionDetails(props: IExecutionDetailsSectionProps) {
+  const tags: { [key: string]: string } = props.stage?.context?.tags || {};
+  return (
+    <div className="row">
+      <div className="col-md-12">
+        <dl className="dl-narrow dl-horizontal">
+          <dt>Tags</dt>
+          {Object.keys(tags).map((key: string) => (
+            <dd>
+              {key} = {tags[key]}
+            </dd>
+          ))}
+        </dl>
+      </div>
+    </div>
+  );
+}

--- a/app/scripts/modules/tencentcloud/src/pipeline/stages/tagImage/TagImageForm.tsx
+++ b/app/scripts/modules/tencentcloud/src/pipeline/stages/tagImage/TagImageForm.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { IFormikStageConfigInjectedProps, StageConfigField, TextInput } from '@spinnaker/core';
+import './style.less';
+
+export function TagImageForm({ formik }: IFormikStageConfigInjectedProps) {
+  const stage = formik.values;
+  const { setFieldValue } = formik;
+  const tags = stage?.tags || {};
+
+  return (
+    <div className="form-horizontal">
+      <StageConfigField label="Tags">
+        <>
+          <div className={'tag-image-label'}>
+            <div>Key</div>
+            <div>Values</div>
+          </div>
+          <div>
+            {Object.keys(tags).map((key: string, index: number) => (
+              <div key={index} className={'input-group-row'}>
+                <TextInput
+                  value={key}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                    const tagsBak = { ...tags };
+                    const val = (tagsBak as any)[key];
+                    delete (tagsBak as any)[key];
+                    (tagsBak as any)[e.target.value] = val;
+                    setFieldValue('tags', tagsBak);
+                  }}
+                />
+                <TextInput
+                  value={(tags as any)[key]}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                    const tagsBak = { ...tags };
+                    (tagsBak as any)[key] = e.target.value;
+                    setFieldValue('tags', tagsBak);
+                  }}
+                />
+                <button
+                  style={{ display: 'inline-block', marginLeft: '10px' }}
+                  className="btn btn-sm btn-default"
+                  onClick={() => {
+                    const tagBak = { ...tags };
+                    delete (tagBak as any)[key];
+                    setFieldValue('tags', tagBak);
+                  }}
+                >
+                  <span className="glyphicon glyphicon-trash" />
+                </button>
+              </div>
+            ))}
+            <button
+              className="btn btn-block btn-add-trigger add-new"
+              onClick={() => {
+                setFieldValue('tags', { ...tags, '': '' });
+              }}
+            >
+              <span className="glyphicon glyphicon-plus-sign" />
+              Add Field
+            </button>
+          </div>
+        </>
+      </StageConfigField>
+    </div>
+  );
+}

--- a/app/scripts/modules/tencentcloud/src/pipeline/stages/tagImage/style.less
+++ b/app/scripts/modules/tencentcloud/src/pipeline/stages/tagImage/style.less
@@ -1,0 +1,24 @@
+.tag-image-label {
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  margin: 5px 0;
+  & > div {
+    font-weight: bold;
+    flex: 1;
+  }
+}
+
+.input-group-row {
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  & > * {
+    &:first-child {
+      margin-right: 5px;
+    }
+    margin: 3px 0;
+  }
+}

--- a/app/scripts/modules/tencentcloud/src/pipeline/stages/tagImage/tagImageStage.ts
+++ b/app/scripts/modules/tencentcloud/src/pipeline/stages/tagImage/tagImageStage.ts
@@ -1,0 +1,12 @@
+import { Registry, ExecutionDetailsTasks } from '@spinnaker/core';
+import { TagImageConfig } from './TagImageConfig';
+import { TagImageExecutionDetails } from './TagImageExecutionDetails';
+
+Registry.pipeline.registerStage({
+  provides: 'upsertImageTags',
+  key: 'upsertImageTags',
+  cloudProvider: 'tencentcloud',
+  component: TagImageConfig,
+  executionDetailsSections: [TagImageExecutionDetails, ExecutionDetailsTasks],
+  executionConfigSections: ['tagImageConfig', 'taskStatus'],
+});

--- a/app/scripts/modules/tencentcloud/src/tencentcloud.module.ts
+++ b/app/scripts/modules/tencentcloud/src/tencentcloud.module.ts
@@ -14,6 +14,9 @@ import './pipeline/stages/disableCluster/disableClusterStage';
 import './pipeline/stages/rollbackCluster/rollbackClusterStage';
 import './pipeline/stages/scaleDownCluster/scaleDownClusterStage';
 import './pipeline/stages/shrinkCluster/shrinkClusterStage';
+import './pipeline/stages/disableServerGroup/disableSGStage';
+import './pipeline/stages/enableServerGroup/enableSGStage';
+import './pipeline/stages/tagImage/tagImageStage';
 // load all templates into the $templateCache
 const templates = require.context('./', true, /\.html$/);
 templates.keys().forEach(function(key) {


### PR DESCRIPTION
This PR aims to add 3 pipelines for tencentcloud includes Tag image, Enable Server Group, Disable Server Group The proposal is spinnaker/governance#79

The preview is as follows：
![image](https://user-images.githubusercontent.com/15920861/91419954-97e74800-e886-11ea-9b42-293ff9240217.png)
![image](https://user-images.githubusercontent.com/15920861/91419963-9ae23880-e886-11ea-9bb6-c470b300c28c.png)
![image](https://user-images.githubusercontent.com/15920861/91419967-9cabfc00-e886-11ea-9a1a-bb71c391a3c3.png)
