### PR TITLE
fix(amazon/firewall): Ensure we use a valid default vpc instead of none

### DIFF
--- a/app/scripts/modules/amazon/src/securityGroup/configure/CreateSecurityGroup.controller.spec.js
+++ b/app/scripts/modules/amazon/src/securityGroup/configure/CreateSecurityGroup.controller.spec.js
@@ -113,8 +113,8 @@ describe('Controller: CreateSecurityGroup', function() {
       this.$scope.securityGroup.regions = ['us-east-1'];
       this.ctrl.accountUpdated();
       this.$scope.$digest();
-      expect(this.$scope.availableSecurityGroups.length).toBe(2);
-      expect(this.$scope.existingSecurityGroupNames).toEqual(['group1', 'group2']);
+      expect(this.$scope.availableSecurityGroups.length).toBe(1);
+      expect(this.$scope.existingSecurityGroupNames).toEqual(['group3']);
     });
 
     it('filters existing names based on join of groups from all regions', function() {
@@ -136,7 +136,7 @@ describe('Controller: CreateSecurityGroup', function() {
       this.$scope.securityGroup.vpcId = 'vpc1-tw';
       this.ctrl.accountUpdated();
       this.$scope.$digest();
-      expect(this.$scope.availableSecurityGroups.length).toBe(1);
+      expect(this.$scope.availableSecurityGroups.length).toBe(0);
     });
 
     it('filters VPCs based on account + region', function() {
@@ -178,10 +178,13 @@ describe('Controller: CreateSecurityGroup', function() {
 
       it('removes rules that are not available when account changes', function() {
         let securityGroup = this.$scope.securityGroup;
+        securityGroup.credentials = 'test';
+        this.ctrl.accountUpdated();
+        this.$scope.$digest();
         this.$scope.availableSecurityGroups.forEach(group => securityGroup.securityGroupIngress.push({ name: group }));
         expect(securityGroup.securityGroupIngress.length).toBe(2);
 
-        securityGroup.credentials = 'test';
+        securityGroup.credentials = 'prod';
         this.ctrl.accountUpdated();
         this.$scope.$digest();
         expect(this.$scope.state.removedRules.length).toBe(1);
@@ -190,13 +193,16 @@ describe('Controller: CreateSecurityGroup', function() {
 
       it('does not repeatedly add removed rule warnings when multiple rules for the same group are removed', function() {
         let securityGroup = this.$scope.securityGroup;
+        securityGroup.credentials = 'test';
+        this.ctrl.accountUpdated();
+        this.$scope.$digest();
         this.$scope.availableSecurityGroups.forEach(group => {
           securityGroup.securityGroupIngress.push({ name: group, startPort: 7001, endPort: 7001, protocol: 'HTTPS' });
           securityGroup.securityGroupIngress.push({ name: group, startPort: 7000, endPort: 7000, protocol: 'HTTP' });
         });
         expect(securityGroup.securityGroupIngress.length).toBe(4);
 
-        securityGroup.credentials = 'test';
+        securityGroup.credentials = 'prod';
         this.ctrl.accountUpdated();
         this.$scope.$digest();
         expect(this.$scope.state.removedRules).toEqual(['group2']);

--- a/app/scripts/modules/amazon/src/securityGroup/configure/configSecurityGroup.mixin.controller.js
+++ b/app/scripts/modules/amazon/src/securityGroup/configure/configSecurityGroup.mixin.controller.js
@@ -187,7 +187,8 @@ module(AMAZON_SECURITYGROUP_CONFIGURE_CONFIGSECURITYGROUP_MIXIN_CONTROLLER, [
       // We matched the vpc ids from one account to another but they are never the same. In order to ensure that users still retain their VPC choice, irrespective of the account, we switched to using vpc names instead of vpc ids
       const selectedVpc = $scope.allVpcs.find(vpc => vpc.id === $scope.securityGroup.vpcId);
       const match = (available || []).find(vpc => selectedVpc && selectedVpc.label === vpc.label);
-      const defaultVpc = (available || []).find(vpc => AWSProviderSettings.defaults.vpc === vpc.label);
+      const defaultVpc =
+        (available || []).find(vpc => AWSProviderSettings.defaults.vpc === vpc.label) || ($scope.activeVpcs || [])[0];
       $scope.securityGroup.vpcId = (match && match.ids[0]) || (defaultVpc && defaultVpc.ids[0]);
       this.vpcUpdated();
     };


### PR DESCRIPTION
For certain accounts, `vpc0` is not a valid VPC but the defaults provided in `AWSProviderSettings.defaults.vpc` points to `vpc0` resulting in no default vpc being selected. When the application has a creation date of earlier than `AWSProviderSettings.classicLaunchLockout`, we end up defaulting to `none` which points to ec2 classic resulting in undesired behavior.

In this PR, I'm attempting to default to the first available vpc for the account if all of the earlier default attempts have failed.