### PR TITLE
package bump chris thielen amazon 0.0.264 appengine 0.0.16 core 0.0.505

### DIFF
--- a/app/scripts/modules/amazon/package.json
+++ b/app/scripts/modules/amazon/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/amazon",
   "license": "Apache-2.0",
-  "version": "0.0.263",
+  "version": "0.0.264",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/appengine/package.json
+++ b/app/scripts/modules/appengine/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/appengine",
   "license": "Apache-2.0",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/core",
   "license": "Apache-2.0",
-  "version": "0.0.504",
+  "version": "0.0.505",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
- chore(amazon): publish @spinnaker/amazon 0.0.264 0de610ed199168375752481199b15e345dc8d3d6 fix(amazon/firewall): Ensure we use a valid default vpc instead of none (#8524)
- chore(appengine): publish @spinnaker/appengine 0.0.16 1a20a4a4ec7d9c6bf291366dbab59752f270a66f fix(appengine): fix rendering of StageArtifactSelector when artifacts are created (#8516)
- chore(core): publish @spinnaker/core 0.0.505 fbe0e54b29c452797a43aaea9f2fab0d7c0fe8d8 feat(core/notifier): Make notifier service work with react components (#8521) 21db6572f9b355696012a459d7878edb963e7709 fix(core/securityGroup): Add job type while updating security groups via infrastructure view (#8522)
