### PR TITLE
fix(amazon/alb): Update rule condition validation for edge case

### DIFF
--- a/app/scripts/modules/amazon/src/loadBalancer/configure/application/ALBListeners.tsx
+++ b/app/scripts/modules/amazon/src/loadBalancer/configure/application/ALBListeners.tsx
@@ -133,7 +133,13 @@ export class ALBListeners extends React.Component<IALBListenersProps, IALBListen
         const missingAuth = !!rule.actions.find(
           a => a.type === 'authenticate-oidc' && !a.authenticateOidcConfig.clientId,
         );
-        const missingValue = !!rule.conditions.find(c => c.values.includes(''));
+        const missingValue = !!rule.conditions.find(c => {
+          if (c.field === 'http-request-method') {
+            return !c.values.length;
+          }
+          return c.values.includes('');
+        });
+
         return missingTargets || missingAuth || missingValue;
       });
       return defaultActionsHaveMissingTarget || rulesHaveMissingFields;
@@ -320,6 +326,11 @@ export class ALBListeners extends React.Component<IALBListenersProps, IALBListen
     newField: ListenerRuleConditionField,
   ): void => {
     condition.field = newField;
+
+    if (newField === 'http-request-method') {
+      condition.values = [];
+    }
+
     this.updateListeners();
   };
 


### PR DESCRIPTION
Http-request-method conditions have a different modal for values. It is either an empty array or an array of REST methods. Currently, the validator only checks for an empty string within the values array, so this edge case needs to be accounted for.