### PR TITLE
fix(provider/cf): fix env variables section

### DIFF
--- a/app/scripts/modules/cloudfoundry/src/serverGroup/details/sections/EvironmentVariablesSection.tsx
+++ b/app/scripts/modules/cloudfoundry/src/serverGroup/details/sections/EvironmentVariablesSection.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
-
-import { isEmpty, map } from 'lodash';
+import { isEmpty } from 'lodash';
 
 import { CollapsibleSection } from '@spinnaker/core';
-
-import { ICloudFoundryEnvVar } from 'cloudfoundry/domain';
 import { ICloudFoundryServerGroupDetailsSectionProps } from './ICloudFoundryServerGroupDetailsSectionProps';
 
 export class EvironmentVariablesSection extends React.Component<ICloudFoundryServerGroupDetailsSectionProps> {
@@ -19,11 +16,11 @@ export class EvironmentVariablesSection extends React.Component<ICloudFoundrySer
         {!isEmpty(serverGroup.env) && (
           <CollapsibleSection heading="Environment Variables" defaultExpanded={true}>
             <dl className="dl-horizontal dl-flex">
-              {map(serverGroup.env, (obj: ICloudFoundryEnvVar, index: number) => {
+              {Object.entries(serverGroup.env).map(([k, v], index) => {
                 return (
                   <div key={index}>
-                    <dt>{obj.key}</dt>
-                    <dd>{obj.value}</dd>
+                    <dt>{k}</dt>
+                    <dd>{v}</dd>
                   </div>
                 );
               })}


### PR DESCRIPTION
Small fix for enviornment variables within cloudfoundry. The map function was incorrect for the type so this fix ensures they are displayed correctly. 
<img width="424" alt="Screen Shot 2020-09-08 at 10 29 53 AM" src="https://user-images.githubusercontent.com/33258732/92510600-f8e51900-f1c0-11ea-875e-4ab95854faaf.png">
