### PR TITLE
feat(core/*): Deck layout optimizations

### DIFF
--- a/app/scripts/modules/amazon/src/function/details/AmazonFunctionDetails.tsx
+++ b/app/scripts/modules/amazon/src/function/details/AmazonFunctionDetails.tsx
@@ -98,7 +98,7 @@ export class AmazonFunctionDetails extends React.Component<IAmazonFunctionDetail
     }
 
     const functionDetails = (
-      <dl className="horizontal-when-filters-collapsed dl-horizontal dl-flex">
+      <dl className="horizontal-when-filters-collapsed dl-horizontal dl-narrow">
         <dt>Last Modified </dt>
         <dd>{functionDef.lastModified}</dd>
         <dt>In</dt>

--- a/app/scripts/modules/amazon/src/loadBalancer/details/loadBalancerDetails.html
+++ b/app/scripts/modules/amazon/src/loadBalancer/details/loadBalancerDetails.html
@@ -66,7 +66,7 @@
   </managed-resource-details-indicator>
   <div ng-if="!ctrl.state.loading" class="content">
     <collapsible-section heading="Load Balancer Details" expanded="true">
-      <dl class="dl-horizontal dl-flex">
+      <dl class="dl-horizontal dl-narrow">
         <dt>Created</dt>
         <dd>{{ctrl.loadBalancer.elb.createdTime | timestamp}}</dd>
         <dt>In</dt>
@@ -243,7 +243,7 @@
       </div>
       <div ng-repeat="subnet in ctrl.loadBalancer.subnetDetails" ng-class="{'bottom-border': !$last}">
         <h5><strong>{{subnet.id}}</strong></h5>
-        <dl class="dl-horizontal dl-flex">
+        <dl class="dl-horizontal dl-narrow">
           <dt>Purpose</dt>
           <dd>{{subnet.purpose}}</dd>
 

--- a/app/scripts/modules/amazon/src/loadBalancer/details/targetGroupDetails.html
+++ b/app/scripts/modules/amazon/src/loadBalancer/details/targetGroupDetails.html
@@ -31,7 +31,7 @@
   </managed-resource-details-indicator>
   <div ng-if="!ctrl.state.loading" class="content">
     <collapsible-section heading="Target Group Details" expanded="true">
-      <dl class="dl-horizontal dl-flex">
+      <dl class="dl-horizontal dl-narrow">
         <dt>In</dt>
         <dd><account-tag account="ctrl.targetGroup.account" pad="right"></account-tag> {{ctrl.targetGroup.region}}</dd>
         <dt>VPC</dt>

--- a/app/scripts/modules/amazon/src/serverGroup/details/sections/AmazonInfoDetailsSection.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/details/sections/AmazonInfoDetailsSection.tsx
@@ -58,7 +58,7 @@ export class AmazonInfoDetailsSection extends React.Component<
 
     return (
       <CollapsibleSection heading="Server Group Information" defaultExpanded={true}>
-        <dl className="dl-horizontal dl-flex">
+        <dl className="dl-horizontal dl-narrow">
           <dt>Created</dt>
           <dd>{timestamp(serverGroup.createdTime)}</dd>
           {showEntityTags && <EntitySource metadata={entityTags.creationMetadata} />}

--- a/app/scripts/modules/amazon/src/serverGroup/details/sections/HealthDetailsSection.tsx
+++ b/app/scripts/modules/amazon/src/serverGroup/details/sections/HealthDetailsSection.tsx
@@ -11,7 +11,7 @@ export class HealthDetailsSection extends React.Component<IAmazonServerGroupDeta
     if (serverGroup.instanceCounts.total > 0) {
       return (
         <CollapsibleSection heading="Health" defaultExpanded={true}>
-          <dl className="dl-horizontal dl-flex">
+          <dl className="dl-horizontal dl-narrow">
             <dt>Instances</dt>
             <dd>
               <HealthCounts container={serverGroup.instanceCounts} className="pull-left" />

--- a/app/scripts/modules/appengine/src/serverGroup/details/details.html
+++ b/app/scripts/modules/appengine/src/serverGroup/details/details.html
@@ -89,7 +89,7 @@
       application="ctrl.app"
     ></server-group-running-tasks-details>
     <collapsible-section heading="Server Group Information" expanded="true">
-      <dl class="dl-horizontal dl-flex">
+      <dl class="dl-horizontal dl-narrow">
         <dt>Created</dt>
         <dd>{{ctrl.serverGroup.createdTime | timestamp}}</dd>
         <dt>In</dt>
@@ -105,13 +105,13 @@
       </dl>
     </collapsible-section>
     <collapsible-section heading="Size" expanded="true">
-      <dl class="dl-horizontal dl-flex" ng-if="ctrl.serverGroup.capacity.min === ctrl.serverGroup.capacity.max">
+      <dl class="dl-horizontal dl-narrow" ng-if="ctrl.serverGroup.capacity.min === ctrl.serverGroup.capacity.max">
         <dt>Min/Max</dt>
         <dd>{{ctrl.serverGroup.capacity.min}}</dd>
         <dt>Current</dt>
         <dd>{{ctrl.serverGroup.instances.length}}</dd>
       </dl>
-      <dl class="dl-horizontal dl-flex" ng-if="ctrl.serverGroup.capacity.min !== ctrl.serverGroup.capacity.max">
+      <dl class="dl-horizontal dl-narrow" ng-if="ctrl.serverGroup.capacity.min !== ctrl.serverGroup.capacity.max">
         <dt>Min</dt>
         <dd>{{ctrl.serverGroup.capacity.min}}</dd>
         <dt>Max</dt>
@@ -121,7 +121,7 @@
       </dl>
     </collapsible-section>
     <collapsible-section heading="Health" expanded="true">
-      <dl class="dl-horizontal dl-flex" ng-if="ctrl.serverGroup">
+      <dl class="dl-horizontal dl-narrow" ng-if="ctrl.serverGroup">
         <dt>Instances</dt>
         <dd>
           <health-counts container="ctrl.serverGroup.instanceCounts" class="pull-left"></health-counts>

--- a/app/scripts/modules/azure/src/instance/details/instanceDetails.html
+++ b/app/scripts/modules/azure/src/instance/details/instanceDetails.html
@@ -25,7 +25,7 @@
   </div>
   <div class="content" ng-if="!state.loading && instance">
     <collapsible-section heading="Instance Information" expanded="true">
-      <dl class="dl-horizontal dl-flex">
+      <dl class="dl-horizontal dl-narrow">
         <dt>Launched</dt>
         <dd ng-if="instance.launchTime">{{instance.launchTime | timestamp}}</dd>
         <dd ng-if="!instance.launchTime">(Unknown)</dd>

--- a/app/scripts/modules/azure/src/loadBalancer/details/loadBalancerDetail.html
+++ b/app/scripts/modules/azure/src/loadBalancer/details/loadBalancerDetail.html
@@ -47,7 +47,7 @@
   </div>
   <div ng-if="!state.loading" class="content">
     <collapsible-section heading="Load Balancer Details" expanded="true">
-      <dl class="dl-horizontal dl-flex">
+      <dl class="dl-horizontal dl-narrow">
         <dt>Type</dt>
         <dd>{{loadBalancer.loadBalancerType}}</dd>
         <dt>Created</dt>

--- a/app/scripts/modules/azure/src/serverGroup/details/serverGroupDetails.html
+++ b/app/scripts/modules/azure/src/serverGroup/details/serverGroupDetails.html
@@ -59,7 +59,7 @@
     ></server-group-running-tasks-details>
 
     <collapsible-section heading="Server Group Information" expanded="true">
-      <dl class="dl-horizontal dl-flex">
+      <dl class="dl-horizontal dl-narrow">
         <dt>Created</dt>
         <dd>{{serverGroup.createdTime | timestamp}}</dd>
         <dt>Region</dt>
@@ -75,14 +75,14 @@
     </collapsible-section>
 
     <collapsible-section heading="Size" expanded="true">
-      <dl class="dl-horizontal dl-flex">
+      <dl class="dl-horizontal dl-narrow">
         <dt>Current</dt>
         <dd>{{serverGroup.instances.length}}</dd>
       </dl>
     </collapsible-section>
 
     <collapsible-section heading="Health" expanded="true">
-      <dl class="dl-horizontal dl-flex" ng-if="serverGroup">
+      <dl class="dl-horizontal dl-narrow" ng-if="serverGroup">
         <dt>Instances</dt>
         <dd>
           <health-counts container="serverGroup.instanceCounts" class="pull-left"></health-counts>
@@ -91,7 +91,7 @@
     </collapsible-section>
 
     <collapsible-section heading="{{firewallsLabel}}">
-      <dl class="dl-horizontal dl-flex">
+      <dl class="dl-horizontal dl-narrow">
         <dt>Name</dt>
         <dd>{{serverGroup.securityGroupName}}</dd>
       </dl>

--- a/app/scripts/modules/cloudfoundry/src/serverGroup/details/sections/BoundServicesSection.tsx
+++ b/app/scripts/modules/cloudfoundry/src/serverGroup/details/sections/BoundServicesSection.tsx
@@ -18,7 +18,7 @@ export class BoundServicesSection extends React.Component<ICloudFoundryServerGro
       <>
         {!isEmpty(serverGroup.serviceInstances) && (
           <CollapsibleSection heading="Bound Services" defaultExpanded={true}>
-            <dl className="dl-horizontal dl-flex">
+            <dl className="dl-horizontal dl-narrow">
               {serverGroup.serviceInstances.map(function(service: ICloudFoundryServiceInstance, index: number) {
                 return (
                   <div key={index}>

--- a/app/scripts/modules/cloudfoundry/src/serverGroup/details/sections/BuildSection.tsx
+++ b/app/scripts/modules/cloudfoundry/src/serverGroup/details/sections/BuildSection.tsx
@@ -13,7 +13,7 @@ export class BuildSection extends React.Component<ICloudFoundryServerGroupDetail
     const { serverGroup } = this.props;
     return (
       <CollapsibleSection heading="Build" defaultExpanded={true}>
-        <dl className="dl-horizontal dl-flex">
+        <dl className="dl-horizontal dl-narrow">
           {serverGroup.ciBuild && serverGroup.ciBuild.jobName && (
             <div>
               <dt>Job Name</dt>

--- a/app/scripts/modules/cloudfoundry/src/serverGroup/details/sections/EvironmentVariablesSection.tsx
+++ b/app/scripts/modules/cloudfoundry/src/serverGroup/details/sections/EvironmentVariablesSection.tsx
@@ -15,7 +15,7 @@ export class EvironmentVariablesSection extends React.Component<ICloudFoundrySer
       <>
         {!isEmpty(serverGroup.env) && (
           <CollapsibleSection heading="Environment Variables" defaultExpanded={true}>
-            <dl className="dl-horizontal dl-narrowxs">
+            <dl className="dl-horizontal dl-narrow">
               {Object.entries(serverGroup.env).map(([k, v], index) => {
                 return (
                   <div key={index}>

--- a/app/scripts/modules/cloudfoundry/src/serverGroup/details/sections/EvironmentVariablesSection.tsx
+++ b/app/scripts/modules/cloudfoundry/src/serverGroup/details/sections/EvironmentVariablesSection.tsx
@@ -15,7 +15,7 @@ export class EvironmentVariablesSection extends React.Component<ICloudFoundrySer
       <>
         {!isEmpty(serverGroup.env) && (
           <CollapsibleSection heading="Environment Variables" defaultExpanded={true}>
-            <dl className="dl-horizontal dl-flex">
+            <dl className="dl-horizontal dl-narrowxs">
               {Object.entries(serverGroup.env).map(([k, v], index) => {
                 return (
                   <div key={index}>

--- a/app/scripts/modules/cloudfoundry/src/serverGroup/details/sections/HealthCheckSection.tsx
+++ b/app/scripts/modules/cloudfoundry/src/serverGroup/details/sections/HealthCheckSection.tsx
@@ -12,7 +12,7 @@ export class HealthCheckSection extends React.Component<ICloudFoundryServerGroup
     const { serverGroup } = this.props;
     return (
       <CollapsibleSection heading="Health Check" defaultExpanded={true}>
-        <dl className="dl-horizontal dl-flex">
+        <dl className="dl-horizontal dl-narrow">
           <dt>Type</dt>
           <dd>{serverGroup.healthCheckType === undefined ? 'port' : serverGroup.healthCheckType}</dd>
           {serverGroup.healthCheckType === 'http' && (

--- a/app/scripts/modules/cloudfoundry/src/serverGroup/details/sections/PackageSection.tsx
+++ b/app/scripts/modules/cloudfoundry/src/serverGroup/details/sections/PackageSection.tsx
@@ -15,7 +15,7 @@ export class PackageSection extends React.Component<ICloudFoundryServerGroupDeta
       <>
         {serverGroup.droplet && serverGroup.droplet.sourcePackage && (
           <CollapsibleSection heading="Package" defaultExpanded={true}>
-            <dl className="dl-horizontal dl-flex">
+            <dl className="dl-horizontal dl-narrow">
               <dt>Checksum</dt>
               <dd>{serverGroup.droplet.sourcePackage.checksum}</dd>
             </dl>

--- a/app/scripts/modules/cloudfoundry/src/serverGroup/details/sections/ServerGroupInformationSection.tsx
+++ b/app/scripts/modules/cloudfoundry/src/serverGroup/details/sections/ServerGroupInformationSection.tsx
@@ -14,7 +14,7 @@ export class ServerGroupInformationSection extends React.Component<ICloudFoundry
     const { serverGroup } = this.props;
     return (
       <CollapsibleSection heading="Server Group Information" defaultExpanded={true}>
-        <dl className="dl-horizontal dl-flex">
+        <dl className="dl-horizontal dl-narrow">
           <dt>Created</dt>
           {serverGroup.pipelineId ? (
             <dd>

--- a/app/scripts/modules/cloudfoundry/src/serverGroup/details/sections/ServerGroupSizingSection.tsx
+++ b/app/scripts/modules/cloudfoundry/src/serverGroup/details/sections/ServerGroupSizingSection.tsx
@@ -13,7 +13,7 @@ export class ServerGroupSizingSection extends React.Component<ICloudFoundryServe
     const { serverGroup } = this.props;
     return (
       <CollapsibleSection heading="Server Group Sizing" defaultExpanded={true}>
-        <dl className="dl-horizontal dl-flex">
+        <dl className="dl-horizontal dl-narrow">
           <dt>Instances</dt>
           <dd>{serverGroup.instances.length}</dd>
           <dt>Disk (MB)</dt>

--- a/app/scripts/modules/core/src/account/accountTag.less
+++ b/app/scripts/modules/core/src/account/accountTag.less
@@ -21,14 +21,14 @@
 .heading-tag-overflow-group {
   display: flex;
   .account-tag {
-    font-size: 100%;
+    font-size: 14px;
     font-weight: 400;
     display: flex;
     min-height: 36px;
     line-height: 16px;
     align-items: center;
     flex: 0 0 auto;
-    padding: 0 15px;
+    padding: 0 12px;
     margin-right: 0;
     border-right: 1px solid var(--color-alabaster);
     .glyphicon {

--- a/app/scripts/modules/core/src/application/ApplicationFreshIcon.tsx
+++ b/app/scripts/modules/core/src/application/ApplicationFreshIcon.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 
 import { Overridable } from '../overrideRegistry/Overridable';
 
-import { Icon } from '../presentation';
+import { Illustration } from '../presentation';
 
 @Overridable('applicationIcon')
 export class ApplicationFreshIcon extends React.Component<{}> {
   public render() {
-    return <Icon name="spMenuAppInSync" size="small" appearance="light" />;
+    return <Illustration className="app-fresh-icon horizontal middle" name="appSynced" />;
   }
 }

--- a/app/scripts/modules/core/src/application/nav/AppRefresherIcon.tsx
+++ b/app/scripts/modules/core/src/application/nav/AppRefresherIcon.tsx
@@ -3,7 +3,7 @@ import { $window } from 'ngimport';
 
 import { ApplicationFreshIcon } from '../ApplicationFreshIcon';
 import { SchedulerFactory } from 'core/scheduler';
-import { Icon, Tooltip } from 'core/presentation';
+import { Illustration, Tooltip } from 'core/presentation';
 import { relativeTime, timestamp } from 'core/utils/timeFormatters';
 
 export interface IAppRefreshIconProps {
@@ -56,7 +56,7 @@ export const AppRefresherIcon = ({ appName, lastRefresh, refresh, refreshing }: 
     <Tooltip template={RefresherTooltip} placement={$window.innerWidth < 1100 ? 'bottom' : 'right'}>
       <div className={`application-header-icon${isRefreshing ? ' header-icon-pulsing' : ''}`} onClick={refreshApp}>
         {!isStale && !isRefreshing && <ApplicationFreshIcon />}
-        {(isStale || isRefreshing) && <Icon name="spMenuAppUnsynced" size="small" appearance="light" />}
+        {(isStale || isRefreshing) && <Illustration className="app-fresh-icon horizontal middle" name="appUnsynced" />}
       </div>
     </Tooltip>
   );

--- a/app/scripts/modules/core/src/application/nav/ApplicationNavigation.tsx
+++ b/app/scripts/modules/core/src/application/nav/ApplicationNavigation.tsx
@@ -64,7 +64,7 @@ export const ApplicationNavigation = ({ app }: IApplicationNavigationProps) => {
 
   return (
     <div className={`vertical-navigation flex-fill layer-high${!isExpanded ? ' vertical-nav-collapsed' : ''}`}>
-      <h3 className="heading-2 horizontal middle nav-header sp-margin-l-xaxis sp-margin-l-top">
+      <h3 className="heading-2 horizontal middle nav-header sp-margin-m-xaxis sp-margin-l-top">
         <AppRefresher app={app} />
         <span className="application-name text-semibold heading-2 sp-margin-m-left">{app.name}</span>
       </h3>

--- a/app/scripts/modules/core/src/application/nav/NavItem.tsx
+++ b/app/scripts/modules/core/src/application/nav/NavItem.tsx
@@ -26,11 +26,9 @@ export const NavItem = ({ app, dataSource, isActive }: INavItemProps) => {
   useDataSource(dataSource);
   const tags: IEntityTags[] = alerts || [];
 
-  const badgeClassNames = runningCount ? 'badge-running-count' : 'badge-none';
-
   return (
     <div className="nav-category flex-container-h middle sp-padding-s-yaxis">
-      <div className={badgeClassNames}>{runningCount > 0 ? runningCount : ''}</div>
+      <div className={runningCount ? 'badge-running-count' : ''}>{runningCount > 0 ? runningCount : ''}</div>
       <div className="nav-row-item">
         {iconName &&
           (!isExpanded ? (
@@ -40,7 +38,12 @@ export const NavItem = ({ app, dataSource, isActive }: INavItemProps) => {
               </div>
             </Tooltip>
           ) : (
-            <Icon className="nav-icon" name={iconName} size="medium" color={isActive ? 'primary' : 'accent'} />
+            <Icon
+              className="nav-icon"
+              name={iconName || 'config'}
+              size="medium"
+              color={isActive ? 'primary' : 'accent'}
+            />
           ))}
       </div>
       <div className="nav-row-item nav-name">{' ' + dataSource.label}</div>

--- a/app/scripts/modules/core/src/application/nav/NavItem.tsx
+++ b/app/scripts/modules/core/src/application/nav/NavItem.tsx
@@ -26,9 +26,11 @@ export const NavItem = ({ app, dataSource, isActive }: INavItemProps) => {
   useDataSource(dataSource);
   const tags: IEntityTags[] = alerts || [];
 
+  const badgeClassNames = runningCount ? 'badge-running-count' : 'badge-none';
+
   return (
     <div className="nav-category flex-container-h middle sp-padding-s-yaxis">
-      <div className={runningCount ? 'badge-running-count' : ''}>{runningCount > 0 ? runningCount : ''}</div>
+      <div className={badgeClassNames}>{runningCount > 0 ? runningCount : ''}</div>
       <div className="nav-row-item">
         {iconName &&
           (!isExpanded ? (

--- a/app/scripts/modules/core/src/application/nav/verticalNav.less
+++ b/app/scripts/modules/core/src/application/nav/verticalNav.less
@@ -4,8 +4,8 @@
   height: 100%;
   background-color: var(--color-accent-g2);
   box-shadow: 2px 0 3px 1px var(--color-alto);
-  min-width: 254px;
-  max-width: 330px;
+  min-width: 226px;
+  max-width: 300px;
 
   .nav-header {
     color: var(--color-primary);
@@ -40,26 +40,21 @@
 
     .nav-category {
       color: var(--color-accent);
-      padding-left: 34px;
+      padding-left: 22px;
       align-items: center;
 
-      .badge-none {
-        min-width: 18px;
-        margin-right: 8px;
-      }
-
       .badge-running-count {
-        min-width: 18px;
-        margin-right: 8px;
+        min-width: 16px;
+        height: 16px;
+        margin-right: -12px;
+        margin-top: 18px;
         border-radius: 3px;
         color: var(--color-white);
-        background-color: var(--color-black);
-        padding: 2px;
-        line-height: 14px;
+        background-color: var(--color-primary);
+        line-height: 16px;
         text-align: center;
-        @media (max-width: 1400px) {
-          font-size: 10px;
-        }
+        font-size: 12px;
+        z-index: 100;
       }
 
       .nav-row-item {
@@ -96,7 +91,7 @@
 
     .page-category {
       color: var(--color-accent);
-      padding-left: 62px;
+      padding-left: 22px;
       margin-top: -4px;
 
       .nav-row-item {
@@ -130,9 +125,7 @@
   .nav-section {
     .nav-category,
     .page-category {
-      padding-left: 16px;
-      .badge-none,
-      .badge-running-count,
+      padding-left: 20px;
       .nav-name,
       .HoverablePopover {
         display: none;

--- a/app/scripts/modules/core/src/application/nav/verticalNav.less
+++ b/app/scripts/modules/core/src/application/nav/verticalNav.less
@@ -7,6 +7,10 @@
   min-width: 226px;
   max-width: 300px;
 
+  @media (max-width: 1640px) {
+    max-width: 226px;
+  }
+
   .nav-header {
     color: var(--color-primary);
     // override
@@ -17,13 +21,16 @@
       justify-content: center;
       border-radius: 50%;
       background-color: var(--color-primary);
-      border: 2px solid var(--color-white);
       color: var(--color-white);
       text-align: center;
       width: 36px;
       height: 36px;
       font-size: 15px;
       cursor: pointer;
+    }
+
+    .app-fresh-icon {
+      width: 20px;
     }
 
     .header-icon-pulsing {
@@ -40,7 +47,7 @@
 
     .nav-category {
       color: var(--color-accent);
-      padding-left: 22px;
+      padding-left: 12px;
       align-items: center;
 
       .badge-running-count {
@@ -55,6 +62,12 @@
         text-align: center;
         font-size: 12px;
         z-index: 100;
+      }
+
+      .badge-none {
+        min-width: 16px;
+        margin-right: -12px;
+        margin-top: 18px;
       }
 
       .nav-row-item {
@@ -91,7 +104,7 @@
 
     .page-category {
       color: var(--color-accent);
-      padding-left: 22px;
+      padding-left: 16px;
       margin-top: -4px;
 
       .nav-row-item {
@@ -125,7 +138,6 @@
   .nav-section {
     .nav-category,
     .page-category {
-      padding-left: 20px;
       .nav-name,
       .HoverablePopover {
         display: none;

--- a/app/scripts/modules/core/src/header/SpinnakerHeader.css
+++ b/app/scripts/modules/core/src/header/SpinnakerHeader.css
@@ -13,6 +13,14 @@
 .spinnaker-header .navbar-menu-icon {
   min-width: 24px;
   cursor: pointer;
+  color: var(--color-primary);
+  width: 60px;
+  height: 40px;
+  cursor: pointer;
+}
+
+.spinnaker-header .app-view-menu {
+  background-color: var(--color-accent-g2);
 }
 
 .spinnaker-header a {

--- a/app/scripts/modules/core/src/header/SpinnakerHeader.css
+++ b/app/scripts/modules/core/src/header/SpinnakerHeader.css
@@ -10,12 +10,11 @@
   margin-left: auto;
 }
 
-.spinnaker-header .navbar-menu-icon {
+.spinnaker-header .navbar-header .navbar-menu-icon {
   min-width: 24px;
   cursor: pointer;
-  color: var(--color-primary);
   width: 60px;
-  height: 40px;
+  height: 40px !important;
   cursor: pointer;
 }
 

--- a/app/scripts/modules/core/src/header/SpinnakerHeader.tsx
+++ b/app/scripts/modules/core/src/header/SpinnakerHeader.tsx
@@ -60,7 +60,9 @@ export const SpinnakerHeaderContent = () => {
             isApplicationView ? 'app-view-menu' : ''
           }`}
         >
-          {isApplicationView && <Icon name={verticalNavExpanded ? 'menuClose' : 'menu'} size="medium" color="white" />}
+          {isApplicationView && (
+            <Icon name={verticalNavExpanded ? 'menuClose' : 'menu'} size="medium" color="primary" />
+          )}
         </div>
         <a className="navbar-brand flex-1" href="#">
           SPINNAKER

--- a/app/scripts/modules/core/src/header/SpinnakerHeader.tsx
+++ b/app/scripts/modules/core/src/header/SpinnakerHeader.tsx
@@ -76,10 +76,10 @@ export const SpinnakerHeaderContent = () => {
             <li key="navPipelineTemplates">
               <a {...templatesSref}>Pipeline Templates</a>
             </li>
+            <GlobalSearch />
           </ul>
           <ul className="nav nav-items">
             <UserMenu />
-            <GlobalSearch />
             <HelpMenu />
           </ul>
         </div>

--- a/app/scripts/modules/core/src/header/SpinnakerHeader.tsx
+++ b/app/scripts/modules/core/src/header/SpinnakerHeader.tsx
@@ -54,7 +54,12 @@ export const SpinnakerHeaderContent = () => {
   return (
     <nav className="container spinnaker-header" role="navigation" aria-label="Main Menu">
       <div className="navbar-header horizontal middle">
-        <div onClick={toggleNav} className="sp-margin-xl-right navbar-menu-icon">
+        <div
+          onClick={toggleNav}
+          className={`nav-container navbar-menu-icon horizontal middle center sp-margin-xl-right ${
+            isApplicationView ? 'app-view-menu' : ''
+          }`}
+        >
           {isApplicationView && <Icon name={verticalNavExpanded ? 'menuClose' : 'menu'} size="medium" color="white" />}
         </div>
         <a className="navbar-brand flex-1" href="#">

--- a/app/scripts/modules/core/src/insight/InsightLayout.tsx
+++ b/app/scripts/modules/core/src/insight/InsightLayout.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { UIView, useCurrentStateAndParams } from '@uirouter/react';
+import { useRecoilValue } from 'recoil';
 
 import { ReactInjector } from 'core/reactShims';
 import { FilterCollapse } from 'core/filterModel/FilterCollapse';
 import { Application } from 'core/application';
+import { verticalNavExpandedAtom } from 'core/application/nav/navAtoms';
 
 export interface IInsightLayoutProps {
   app: Application;
@@ -19,15 +21,18 @@ export const InsightLayout = ({ app }: IInsightLayoutProps) => {
     setExpandFilters(!expandFilters);
   };
 
+  const navClass = useRecoilValue(verticalNavExpandedAtom) ? 'nav-expanded' : 'nav-collapsed';
+
   const { state: currentState } = useCurrentStateAndParams();
   const showDetailsView = Boolean(Object.keys(currentState.views).find(v => v.indexOf('detail@') !== -1));
+  const detailsClass = showDetailsView ? 'details-open' : 'details-closed';
 
   if (app.notFound || app.hasError) {
     return null;
   }
 
   return (
-    <div className={`insight ${filterClass}`}>
+    <div className={`insight ${filterClass} ${navClass} ${detailsClass}`}>
       {!filtersHidden && (
         <div onClick={toggleFilters}>
           <FilterCollapse />

--- a/app/scripts/modules/core/src/pipeline/executions/executionGroup/executionGroup.less
+++ b/app/scripts/modules/core/src/pipeline/executions/executionGroup/executionGroup.less
@@ -14,7 +14,7 @@
     line-height: 20px;
     min-width: 50px;
     font-size: 14px;
-    padding: 0 10px;
+    padding: 0 12px;
     margin-right: 5px;
   }
 }

--- a/app/scripts/modules/core/src/presentation/details.less
+++ b/app/scripts/modules/core/src/presentation/details.less
@@ -57,7 +57,7 @@
   display: flex;
   flex-direction: column;
   background-color: var(--color-white);
-  box-shadow: -2px 2px 3px 1px var(--color-alto);
+  box-shadow: -2px 2px 6px -1px var(--color-alto);
   margin-left: var(--xs-spacing);
   padding-bottom: 12px;
 

--- a/app/scripts/modules/core/src/presentation/illustrations/Illustration.tsx
+++ b/app/scripts/modules/core/src/presentation/illustrations/Illustration.tsx
@@ -6,13 +6,14 @@ export type IllustrationName = keyof typeof illustrationsByName;
 
 export interface IIllustrationProps {
   name: IllustrationName;
+  className?: string;
 }
 
 const throwInvalidIllustrationError = (name: string) => {
   throw new Error(`No illustration with the name ${name} exists`);
 };
 
-export const Illustration = memo(({ name }: IIllustrationProps) => {
+export const Illustration = memo(({ name, className }: IIllustrationProps) => {
   const Component = illustrationsByName[name];
 
   if (!Component) {
@@ -20,7 +21,7 @@ export const Illustration = memo(({ name }: IIllustrationProps) => {
   }
 
   return (
-    <div style={{ display: 'grid', gridTemplateColumns: '1fr', gridTemplateRows: '1fr' }}>
+    <div className={className} style={{ display: 'grid', gridTemplateColumns: '1fr', gridTemplateRows: '1fr' }}>
       <Component style={{ gridColumn: 1, gridRow: 1 }} />
     </div>
   );

--- a/app/scripts/modules/core/src/presentation/main.less
+++ b/app/scripts/modules/core/src/presentation/main.less
@@ -305,12 +305,50 @@ html {
   }
   .nav-content {
     margin-right: 25px;
-    max-width: calc(~'100% - 390px');
+  }
 
-    @media (max-width: 1740px) {
+  &.details-closed {
+    .nav-content {
       max-width: 100%;
     }
   }
+
+  &.details-open.filters-collapsed.nav-collapsed {
+    .nav-content {
+      max-width: calc(~'100% - 390px');
+      @media (max-width: 1170px) {
+        max-width: 100%;
+      }
+    }
+  }
+
+  &.details-open.filters-expanded.nav-collapsed {
+    .nav-content {
+      max-width: calc(~'100% - 390px');
+      @media (max-width: 1340px) {
+        max-width: 100%;
+      }
+    }
+  }
+
+  &.details-open.filters-collapsed.nav-expanded {
+    .nav-content {
+      max-width: calc(~'100% - 390px');
+      @media (max-width: 1410px) {
+        max-width: 100%;
+      }
+    }
+  }
+
+  &.details-open.filters-expanded.nav-expanded {
+    .nav-content {
+      max-width: calc(~'100% - 390px');
+      @media (max-width: 1580px) {
+        max-width: 100%;
+      }
+    }
+  }
+
   .full-content {
     margin: 0 25px;
     flex-direction: column;
@@ -1218,6 +1256,8 @@ html {
       display: flex;
       overflow-y: hidden;
       padding-top: 20px;
+      padding-left: 15px;
+
       > div {
         display: flex;
         flex: 1 1 auto;

--- a/app/scripts/modules/core/src/presentation/main.less
+++ b/app/scripts/modules/core/src/presentation/main.less
@@ -291,10 +291,8 @@ html {
     height: 100%;
     width: 390px;
     box-shadow: 2px 2px 6px -1px var(--color-alto);
-
-    @media (max-width: 1700px) {
-      right: 0;
-    }
+    right: 0;
+    overflow-y: hidden;
 
     @media (max-width: 390px) {
       width: 100%;
@@ -307,11 +305,10 @@ html {
   }
   .nav-content {
     margin-right: 25px;
-    max-width: 1000px;
+    max-width: calc(~'100% - 390px');
 
-    @media (max-width: 1440px) {
-      min-width: 640px;
-      max-width: 800px;
+    @media (max-width: 1740px) {
+      max-width: 100%;
     }
   }
   .full-content {

--- a/app/scripts/modules/core/src/presentation/main.less
+++ b/app/scripts/modules/core/src/presentation/main.less
@@ -288,9 +288,13 @@ html {
     z-index: var(--layer-high);
     position: absolute;
     margin-top: -20px;
-    right: 0;
     height: 100%;
     width: 390px;
+    box-shadow: 2px 2px 6px -1px var(--color-alto);
+
+    @media (max-width: 1700px) {
+      right: 0;
+    }
 
     @media (max-width: 390px) {
       width: 100%;
@@ -304,6 +308,11 @@ html {
   .nav-content {
     margin-right: 25px;
     max-width: 1000px;
+
+    @media (max-width: 1440px) {
+      min-width: 640px;
+      max-width: 800px;
+    }
   }
   .full-content {
     margin: 0 25px;
@@ -514,6 +523,10 @@ body > .container {
 .navbar-inverse {
   background-color: var(--color-primary);
   border: none;
+
+  .container {
+    padding: 0;
+  }
 
   .navbar-brand {
     color: var(--color-white);
@@ -1175,7 +1188,7 @@ html {
   @media (min-width: 768px) and (max-width: 1200px) {
     .container {
       width: 100%;
-      padding: 0 10px;
+      padding: 0;
     }
   }
   width: 100%;

--- a/app/scripts/modules/core/src/serverGroup/details/capacity/CapacityDetailsSection.tsx
+++ b/app/scripts/modules/core/src/serverGroup/details/capacity/CapacityDetailsSection.tsx
@@ -13,7 +13,7 @@ export function CapacityDetailsSection(props: ICapacityDetailsSectionProps) {
   const { capacity, current } = props;
   const simpleMode = capacity.min === capacity.max;
   return (
-    <dl className="dl-horizontal dl-flex">
+    <dl className="dl-horizontal dl-narrow">
       <DesiredCapacity capacity={capacity} simpleMode={simpleMode} />
       <CurrentCapacity currentCapacity={current} />
     </dl>

--- a/app/scripts/modules/dcos/instance/details/details.html
+++ b/app/scripts/modules/dcos/instance/details/details.html
@@ -63,7 +63,7 @@
   </div>
   <div class="content" ng-if="!state.loading">
     <collapsible-section heading="Instance Information" expanded="true">
-      <dl class="dl-horizontal dl-flex">
+      <dl class="dl-horizontal dl-narrow">
         <dt>Launched</dt>
         <dd ng-if="instance.launchTime">{{instance.launchTime | timestamp}}</dd>
         <dd ng-if="!instance.launchTime">(Unknown)</dd>

--- a/app/scripts/modules/dcos/loadBalancer/details/details.html
+++ b/app/scripts/modules/dcos/loadBalancer/details/details.html
@@ -47,7 +47,7 @@
   </div>
   <div ng-if="!state.loading" class="content">
     <collapsible-section heading="Load Balancer Details" expanded="true">
-      <dl class="dl-horizontal dl-flex">
+      <dl class="dl-horizontal dl-narrow">
         <dt>Created</dt>
         <dd>{{loadBalancer.createdTime | timestamp}}</dd>
         <dt>In</dt>

--- a/app/scripts/modules/dcos/serverGroup/details/details.html
+++ b/app/scripts/modules/dcos/serverGroup/details/details.html
@@ -50,7 +50,7 @@
   <div class="content" ng-if="!state.loading">
     <server-group-running-tasks-details server-group="serverGroup"></server-group-running-tasks-details>
     <collapsible-section heading="Server Group Information" expanded="true">
-      <dl class="dl-horizontal dl-flex">
+      <dl class="dl-horizontal dl-narrow">
         <dt>Created</dt>
         <dd>{{serverGroup.createdTime | timestamp }}</dd>
         <dt>In</dt>
@@ -74,7 +74,7 @@
       </dl>
     </collapsible-section>
     <collapsible-section heading="Capacity" expanded="true">
-      <dl class="dl-horizontal dl-flex">
+      <dl class="dl-horizontal dl-narrow">
         <dt>Current</dt>
         <dd>{{serverGroup.capacity.desired}}</dd>
       </dl>
@@ -83,7 +83,7 @@
       </div>
     </collapsible-section>
     <collapsible-section heading="Status" expanded="true">
-      <dl class="dl-horizontal dl-flex" ng-if="serverGroup">
+      <dl class="dl-horizontal dl-narrow" ng-if="serverGroup">
         <dt>Tasks</dt>
         <dd>
           <health-counts container="serverGroup.instanceCounts" class="pull-left"></health-counts>
@@ -91,7 +91,7 @@
       </dl>
     </collapsible-section>
     <collapsible-section heading="Resources" expanded="true">
-      <dl class="dl-horizontal dl-flex" ng-if="serverGroup">
+      <dl class="dl-horizontal dl-narrow" ng-if="serverGroup">
         <dt>CPU</dt>
         <dd>{{serverGroup.cpus}}</dd>
         <dt>GPU</dt>
@@ -103,12 +103,12 @@
       </dl>
     </collapsible-section>
     <collapsible-section heading="Environment" ng-if="serverGroup.env">
-      <dl class="dl-horizontal dl-flex">
+      <dl class="dl-horizontal dl-narrow">
         <dcos-key-value-details map="serverGroup.env"> </dcos-key-value-details>
       </dl>
     </collapsible-section>
     <collapsible-section heading="Labels" ng-if="serverGroup.labels">
-      <dl class="dl-horizontal dl-flex">
+      <dl class="dl-horizontal dl-narrow">
         <dcos-key-value-details map="serverGroup.labels"> </dcos-key-value-details>
       </dl>
     </collapsible-section>

--- a/app/scripts/modules/ecs/src/instance/details/instanceDetails.html
+++ b/app/scripts/modules/ecs/src/instance/details/instanceDetails.html
@@ -90,7 +90,7 @@
   </div>
   <div class="content" ng-if="!state.loading && instance">
     <collapsible-section heading="Instance Information" expanded="true">
-      <dl class="dl-horizontal dl-flex">
+      <dl class="dl-horizontal dl-narrow">
         <dt>Launched</dt>
         <dd ng-if="instance.launchTime">{{instance.launchTime | timestamp}}</dd>
         <dd ng-if="!instance.launchTime">(Unknown)</dd>

--- a/app/scripts/modules/ecs/src/loadBalancer/details/loadBalancerDetails.tsx
+++ b/app/scripts/modules/ecs/src/loadBalancer/details/loadBalancerDetails.tsx
@@ -119,7 +119,7 @@ export class EcsLoadBalancerDetails extends React.Component<
     const loadBalancerContent = () => (
       <div className="content">
         <CollapsibleSection heading="Load Balancer Details" defaultExpanded={true}>
-          <dl className="dl-horizontal dl-flex">
+          <dl className="dl-horizontal dl-narrow">
             <dt>Created</dt>
             <dd>{timestamp(loadBalancer.createdTime)}</dd>
             <dt>In</dt>

--- a/app/scripts/modules/ecs/src/loadBalancer/details/targetGroupDetails.tsx
+++ b/app/scripts/modules/ecs/src/loadBalancer/details/targetGroupDetails.tsx
@@ -139,7 +139,7 @@ export class EcsTargetGroupDetails extends React.Component<IEcsTargetGroupProps,
     const targetGroupContent = () => (
       <div className="content">
         <CollapsibleSection heading="Target Group Details" defaultExpanded={true}>
-          <dl className="dl-horizontal dl-flex">
+          <dl className="dl-horizontal dl-narrow">
             <dt>In</dt>
             <dd>
               <AccountTag account={accountId}></AccountTag>

--- a/app/scripts/modules/ecs/src/serverGroup/details/serverGroupDetails.html
+++ b/app/scripts/modules/ecs/src/serverGroup/details/serverGroupDetails.html
@@ -93,7 +93,7 @@
       application="ctrl.application"
     ></server-group-running-tasks-details>
     <collapsible-section heading="General" expanded="true">
-      <dl class="dl-horizontal dl-flex">
+      <dl class="dl-horizontal dl-narrow">
         <dt>Created</dt>
         <dd>{{ctrl.serverGroup.createdTime | timestamp}}</dd>
         <render-if-feature feature="entityTags">
@@ -153,7 +153,7 @@
       </dl>
     </collapsible-section>
     <collapsible-section heading="Health" expanded="true" ng-if="ctrl.serverGroup.instanceCounts.total > 0">
-      <dl class="dl-horizontal dl-flex" ng-if="ctrl.serverGroup">
+      <dl class="dl-horizontal dl-narrow" ng-if="ctrl.serverGroup">
         <dt>Instances</dt>
         <dd>
           <health-counts container="ctrl.serverGroup.instanceCounts" class="pull-left"></health-counts>
@@ -168,7 +168,7 @@
       </ul>
     </collapsible-section>
     <collapsible-section heading="Capacity" expanded="false">
-      <dl class="dl-horizontal dl-flex">
+      <dl class="dl-horizontal dl-narrow">
         <dt>Current</dt>
         <dd>{{ctrl.serverGroup.instances.length}}</dd>
 

--- a/app/scripts/modules/google/src/instance/details/instanceDetails.html
+++ b/app/scripts/modules/google/src/instance/details/instanceDetails.html
@@ -86,7 +86,7 @@
   </div>
   <div class="content" ng-if="!state.loading && instance">
     <collapsible-section heading="Instance Information" expanded="true">
-      <dl class="dl-horizontal dl-flex">
+      <dl class="dl-horizontal dl-narrow">
         <dt>Launched</dt>
         <dd ng-if="instance.launchTime">{{instance.launchTime | timestamp}}</dd>
         <dd ng-if="!instance.launchTime">(Unknown)</dd>

--- a/app/scripts/modules/google/src/loadBalancer/details/loadBalancerDetails.html
+++ b/app/scripts/modules/google/src/loadBalancer/details/loadBalancerDetails.html
@@ -66,7 +66,7 @@
   </div>
   <div ng-if="!state.loading" class="content">
     <collapsible-section heading="Load Balancer Details" expanded="true">
-      <dl class="dl-horizontal dl-flex">
+      <dl class="dl-horizontal dl-narrow">
         <dt>Created</dt>
         <dd>{{loadBalancer.elb.createdTime | timestamp}}</dd>
         <dt>In</dt>

--- a/app/scripts/modules/google/src/serverGroup/details/serverGroupDetails.html
+++ b/app/scripts/modules/google/src/serverGroup/details/serverGroupDetails.html
@@ -85,7 +85,7 @@
       application="ctrl.application"
     ></server-group-running-tasks-details>
     <collapsible-section heading="Server Group Information" expanded="true">
-      <dl class="dl-horizontal dl-flex">
+      <dl class="dl-horizontal dl-narrow">
         <dt>Created</dt>
         <dd>{{ctrl.serverGroup.launchConfig.createdTime | timestamp}}</dd>
         <render-if-feature feature="entityTags">
@@ -113,13 +113,13 @@
       </dl>
     </collapsible-section>
     <collapsible-section heading="Size" expanded="true">
-      <dl class="dl-horizontal dl-flex" ng-if="ctrl.serverGroup.asg.minSize === ctrl.serverGroup.asg.maxSize">
+      <dl class="dl-horizontal dl-narrow" ng-if="ctrl.serverGroup.asg.minSize === ctrl.serverGroup.asg.maxSize">
         <dt>Min/Max</dt>
         <dd>{{ctrl.serverGroup.asg.desiredCapacity}}</dd>
         <dt>Current</dt>
         <dd>{{ctrl.serverGroup.instances.length}}</dd>
       </dl>
-      <dl class="dl-horizontal dl-flex" ng-if="ctrl.serverGroup.asg.minSize !== ctrl.serverGroup.asg.maxSize">
+      <dl class="dl-horizontal dl-narrow" ng-if="ctrl.serverGroup.asg.minSize !== ctrl.serverGroup.asg.maxSize">
         <dt>Min</dt>
         <dd>{{ctrl.serverGroup.asg.minSize}}</dd>
         <dt>Desired</dt>
@@ -132,13 +132,13 @@
       <a href ng-click="ctrl.resizeServerGroup()">Resize Server Group</a>
     </collapsible-section>
     <collapsible-section heading="Current Actions" ng-if="ctrl.serverGroup.currentActionsSummary">
-      <dl class="dl-horizontal dl-flex">
+      <dl class="dl-horizontal dl-narrow">
         <dt ng-repeat-start="currentAction in ctrl.serverGroup.currentActionsSummary">{{currentAction.action}}</dt>
         <dd ng-repeat-end>{{currentAction.count}}</dd>
       </dl>
     </collapsible-section>
     <collapsible-section heading="Health" expanded="true">
-      <dl class="dl-horizontal dl-flex" ng-if="ctrl.serverGroup">
+      <dl class="dl-horizontal dl-narrow" ng-if="ctrl.serverGroup">
         <dt>Instances</dt>
         <dd>
           <health-counts container="ctrl.serverGroup.instanceCounts" class="pull-left"></health-counts>

--- a/app/scripts/modules/kubernetes/src/resources/ResourceDetails.tsx
+++ b/app/scripts/modules/kubernetes/src/resources/ResourceDetails.tsx
@@ -83,7 +83,7 @@ export class KubernetesResourceDetails extends React.Component<
         {!this.state.loading && (
           <div className="content">
             <CollapsibleSection heading="Information">
-              <dl className="dl-horizontal dl-flex">
+              <dl className="dl-horizontal dl-narrow">
                 <dt>Created</dt>
                 <dd>{timestamp(creationUnixMs)}</dd>
                 <dt>Account</dt>

--- a/app/scripts/modules/kubernetes/src/serverGroup/details/details.html
+++ b/app/scripts/modules/kubernetes/src/serverGroup/details/details.html
@@ -89,7 +89,7 @@
       application="ctrl.app"
     ></server-group-running-tasks-details>
     <collapsible-section heading="Information" expanded="true">
-      <dl class="dl-horizontal dl-flex">
+      <dl class="dl-horizontal dl-narrow">
         <dt>Created</dt>
         <dd>{{ctrl.serverGroup.createdTime | timestamp}}</dd>
         <dt>Account</dt>
@@ -129,12 +129,12 @@
       <kubernetes-manifest-labels manifest="ctrl.manifest.manifest"></kubernetes-manifest-labels>
     </collapsible-section>
     <collapsible-section heading="Size" expanded="true">
-      <dl class="dl-horizontal dl-flex" ng-if="ctrl.serverGroup.capacity.min == null">
+      <dl class="dl-horizontal dl-narrow" ng-if="ctrl.serverGroup.capacity.min == null">
         <dt>Current</dt>
         <dd>{{ctrl.serverGroup.instances.length}}</dd>
       </dl>
       <dl
-        class="dl-horizontal dl-flex"
+        class="dl-horizontal dl-narrow"
         ng-if="ctrl.serverGroup.capacity.min != null && ctrl.serverGroup.capacity.min === ctrl.serverGroup.capacity.max"
       >
         <dt>Min/Max</dt>
@@ -142,7 +142,7 @@
         <dt>Current</dt>
         <dd>{{ctrl.serverGroup.instances.length}}</dd>
       </dl>
-      <dl class="dl-horizontal dl-flex" ng-if="ctrl.serverGroup.capacity.min !== ctrl.serverGroup.capacity.max">
+      <dl class="dl-horizontal dl-narrow" ng-if="ctrl.serverGroup.capacity.min !== ctrl.serverGroup.capacity.max">
         <dt>Min</dt>
         <dd>{{ctrl.serverGroup.capacity.min}}</dd>
         <dt>Max</dt>
@@ -152,7 +152,7 @@
       </dl>
     </collapsible-section>
     <collapsible-section heading="Health" expanded="true">
-      <dl class="dl-horizontal dl-flex" ng-if="ctrl.serverGroup">
+      <dl class="dl-horizontal dl-narrow" ng-if="ctrl.serverGroup">
         <dt>Instances</dt>
         <dd>
           <health-counts container="ctrl.serverGroup.instanceCounts" class="pull-left"></health-counts>

--- a/app/scripts/modules/kubernetes/src/serverGroupManager/details/details.html
+++ b/app/scripts/modules/kubernetes/src/serverGroupManager/details/details.html
@@ -95,7 +95,7 @@
   <div class="content" ng-if="!ctrl.state.loading">
     <kubernetes-manifest-status status="ctrl.manifest.status"></kubernetes-manifest-status>
     <collapsible-section heading="Information" expanded="true">
-      <dl class="dl-horizontal dl-flex">
+      <dl class="dl-horizontal dl-narrow">
         <dt>Created</dt>
         <dd>{{ctrl.serverGroupManager.createdTime | timestamp}}</dd>
         <dt>Account</dt>

--- a/app/scripts/modules/oracle/src/instance/details/instanceDetails.html
+++ b/app/scripts/modules/oracle/src/instance/details/instanceDetails.html
@@ -23,7 +23,7 @@
     </div>
     <div class="content" ng-if="!state.loading">
       <collapsible-section heading="Instance Information" expanded="true">
-        <dl class="dl-horizontal dl-flex">
+        <dl class="dl-horizontal dl-narrow">
           <dt>Launched</dt>
           <dd ng-if="instance.launchTime">{{instance.launchTime | timestamp}}</dd>
           <dd ng-if="!instance.launchTime">(Unknown)</dd>

--- a/app/scripts/modules/oracle/src/loadBalancer/details/loadBalancerDetail.html
+++ b/app/scripts/modules/oracle/src/loadBalancer/details/loadBalancerDetail.html
@@ -47,7 +47,7 @@
   </div>
   <div ng-if="!state.loading" class="content">
     <collapsible-section heading="Load Balancer Details" expanded="true">
-      <dl class="dl-horizontal dl-flex">
+      <dl class="dl-horizontal dl-narrow">
         <dt>Created</dt>
         <dd>{{loadBalancer.timeCreated}}</dd>
         <dt>In</dt>

--- a/app/scripts/modules/oracle/src/serverGroup/details/serverGroupDetails.html
+++ b/app/scripts/modules/oracle/src/serverGroup/details/serverGroupDetails.html
@@ -52,7 +52,7 @@
     <h4 class="text-center" ng-if="ctrl.serverGroup.isDisabled">[SERVER GROUP IS DISABLED]</h4>
     <server-group-running-tasks-details server-group="ctrl.serverGroup"></server-group-running-tasks-details>
     <collapsible-section heading="Server Group Information" expanded="true">
-      <dl class="dl-horizontal dl-flex">
+      <dl class="dl-horizontal dl-narrow">
         <dt>Created</dt>
         <dd>{{ctrl.serverGroup.createdTime | timestamp}}</dd>
         <dt>In</dt>
@@ -69,7 +69,7 @@
       </dl>
     </collapsible-section>
     <collapsible-section heading="Size" expanded="true">
-      <dl class="dl-horizontal dl-flex">
+      <dl class="dl-horizontal dl-narrow">
         <dt>Desired</dt>
         <dd>{{ctrl.serverGroup.capacity.desired}}</dd>
         <dt>Current</dt>
@@ -77,7 +77,7 @@
       </dl>
     </collapsible-section>
     <collapsible-section heading="Launch Configuration">
-      <dl class="dl-horizontal dl-flex">
+      <dl class="dl-horizontal dl-narrow">
         <dt>Name</dt>
         <dd>{{ctrl.serverGroup.name}}</dd>
         <dt>Image</dt>

--- a/app/scripts/modules/titus/src/instance/details/instanceDetails.html
+++ b/app/scripts/modules/titus/src/instance/details/instanceDetails.html
@@ -90,7 +90,7 @@
     >
     </instance-status>
     <collapsible-section heading="DNS">
-      <dl class="dl-horizontal dl-flex">
+      <dl class="dl-horizontal dl-narrow">
         <dt ng-if="instance.placement.containerIp">Container IP</dt>
         <dd ng-if="instance.placement.containerIp">
           {{instance.placement.containerIp}}
@@ -122,7 +122,7 @@
       style="display: block"
     ></titus-security-groups>
     <!--<collapsible-section heading="Resources">
-      <dl class="dl-horizontal dl-flex">
+      <dl class="dl-horizontal dl-narrow">
         <dt>CPU(s)</dt>
         <dd>{{instance.resources.cpu}}</dd>
         <dt>Memory</dt>

--- a/app/scripts/modules/titus/src/serverGroup/details/TitusCapacityDetailsSection.tsx
+++ b/app/scripts/modules/titus/src/serverGroup/details/TitusCapacityDetailsSection.tsx
@@ -32,7 +32,7 @@ export class TitusCapacityDetailsSection extends React.Component<ICapacityDetail
 
     return (
       <>
-        <dl className="dl-horizontal dl-flex">
+        <dl className="dl-horizontal dl-narrow">
           <DesiredCapacity capacity={capacity} simpleMode={simpleMode} />
           <CurrentCapacity currentCapacity={current} />
           {serverGroup.capacityGroup && (

--- a/app/scripts/modules/titus/src/serverGroup/details/serverGroupDetails.html
+++ b/app/scripts/modules/titus/src/serverGroup/details/serverGroupDetails.html
@@ -90,7 +90,7 @@
       application="ctrl.application"
     ></server-group-running-tasks-details>
     <collapsible-section heading="Server Group Information" expanded="true">
-      <dl class="dl-horizontal dl-flex">
+      <dl class="dl-horizontal dl-narrow">
         <dt>Created</dt>
         <dd>{{serverGroup.createdTime | timestamp}}</dd>
         <dt>In</dt>
@@ -110,7 +110,7 @@
       ></titus-capacity-details-section>
     </collapsible-section>
     <collapsible-section heading="Health" expanded="true" ng-if="serverGroup.instanceCounts.total > 0">
-      <dl class="dl-horizontal dl-flex" ng-if="serverGroup">
+      <dl class="dl-horizontal dl-narrow" ng-if="serverGroup">
         <dt>Tasks</dt>
         <dd>
           <health-counts container="serverGroup.instanceCounts" class="pull-left"></health-counts>


### PR DESCRIPTION
Implementing some user feedback after the new deck layout was released:

- Introducing new app sync/unsynced icons
- Move running executions so that it is visible when the navbar is collapsed
- Make the details drawer friendly for widescreen monitors by ensuring it does not block any information. Make content width responsive for infrastructure routes.
- Updating the layout of details sections (you will see a lot of changes to `dl-narrow` class), and other various tweaks to sizing/layout

Before and after
<img width="244" alt="Screen Shot 2020-09-09 at 12 28 48 PM" src="https://user-images.githubusercontent.com/26560152/92644353-0e794200-f298-11ea-971f-ea949a2b21d9.png">
<img width="307" alt="Screen Shot 2020-09-09 at 12 24 39 PM" src="https://user-images.githubusercontent.com/26560152/92644119-b2aeb900-f297-11ea-893e-64f35818861f.png">

