### PR TITLE
fix(core/managed): give StatusBubbleStack its own z-index context

### DIFF
--- a/app/scripts/modules/core/src/managed/StatusBubbleStack.less
+++ b/app/scripts/modules/core/src/managed/StatusBubbleStack.less
@@ -1,3 +1,10 @@
+.StatusBubbleStack {
+  // We want to create a new stacking context so that all
+  // the bubbles go in front/behind other elements as a unit
+  // vs. each individual bubble having its own stacking.
+  transform: translate(0px, 0px);
+}
+
 .StatusBubbleContainer {
   background-color: var(--color-alabaster);
   border-radius: 50%;

--- a/app/scripts/modules/core/src/managed/StatusBubbleStack.tsx
+++ b/app/scripts/modules/core/src/managed/StatusBubbleStack.tsx
@@ -18,7 +18,7 @@ export const StatusBubbleStack = ({ borderColor, maxBubbles, statuses }: IStatus
   const hiddenStatusBubbleCount = statuses.length - statusBubblesToRender.length;
 
   return (
-    <div className="flex-container-h middle sp-margin-s-right">
+    <div className="StatusBubbleStack flex-container-h middle sp-margin-s-right">
       {statusBubblesToRender.map((status, index) => (
         <div
           className="StatusBubbleContainer"


### PR DESCRIPTION
I noticed that when certain status bubbles stack in Environments, they move backward/forward in the z-index stack independently of their other status bubbles. Turns out there's a `transform` CSS rule on the ones that move forward which is letting them bust out of their container's stacking context and into their own:

<img width="440" alt="Screen Shot 2020-09-10 at 8 50 04 AM" src="https://user-images.githubusercontent.com/1850998/92758674-d16a8980-f343-11ea-8720-19124a864d40.png">

This change adds a no-op `transform: translate(0px, 0px)` to force the entire StatusBubbleStack component onto its own stacking context, so that when elements create their own there is no risk of moving out of the container in the process:

<img width="440" alt="Screen Shot 2020-09-10 at 8 46 09 AM" src="https://user-images.githubusercontent.com/1850998/92758805-f232df00-f343-11ea-92c6-8aeb80d4e91f.png">
