### PR TITLE
fix(aws): expose baseLabel to Rosco-powered bake stages

### DIFF
--- a/app/scripts/modules/amazon/src/pipeline/stages/bake/bakeStage.html
+++ b/app/scripts/modules/amazon/src/pipeline/stages/bake/bakeStage.html
@@ -39,7 +39,7 @@
         {{storeType | uppercase}}
       </label>
     </stage-config-field>
-    <stage-config-field label="Base Label" ng-if="!viewState.roscoMode">
+    <stage-config-field label="Base Label">
       <label class="radio-inline" ng-repeat="baseLabel in baseLabelOptions">
         <input type="radio" ng-model="stage.baseLabel" ng-value="baseLabel" />
         {{baseLabel}}


### PR DESCRIPTION
The `baseLabel` field was hidden from Rosco-enabled bake stages in #2727 but is valid as Rosco does support the `baseLabel` concept (and it can even be added/modified in the stage JSON).

This will be required for Netflix internal adoption of Rosco. (Internal JIRA SPIN-5625)