### PR TITLE
fix(amazon/serverGroup): Do not clone launch template userData

### DIFF
--- a/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupCommandBuilder.service.js
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupCommandBuilder.service.js
@@ -368,9 +368,6 @@ angular
               ),
             });
 
-            if (launchTemplateData.userData) {
-              command.base64UserData = launchTemplateData.userData;
-            }
             command.viewState.imageId = launchTemplateData.imageId;
           }
 


### PR DESCRIPTION
Moving assignment of launch template userData in a cloned serverGroup to the backend. 