### PR TITLE
fix(amazon/serverGroup): Enable launch templates for rolling push

### DIFF
--- a/app/scripts/modules/amazon/src/aws.settings.ts
+++ b/app/scripts/modules/amazon/src/aws.settings.ts
@@ -42,6 +42,7 @@ export interface IAWSProviderSettings extends IProviderSettings {
   };
   minRootVolumeSize?: number;
   serverGroups?: {
+    enableLaunchTemplates?: boolean;
     enableIPv6?: boolean;
     enableIMDSv2?: boolean;
     defaultIMDSv2AppAgeLimit?: number;

--- a/app/scripts/modules/amazon/src/deploymentStrategy/AdditionalFields.tsx
+++ b/app/scripts/modules/amazon/src/deploymentStrategy/AdditionalFields.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { IDeploymentStrategyAdditionalFieldsProps, HelpField } from '@spinnaker/core';
+import { AWSProviderSettings } from '../aws.settings';
 import { IRollingPushCommand } from './rollingPush.strategy';
 
 export interface IRollingPushStrategyAdditionalFieldsProps extends IDeploymentStrategyAdditionalFieldsProps {
@@ -18,8 +19,11 @@ export class AdditionalFields extends React.Component<IRollingPushStrategyAdditi
     return (
       <div className="form-group" style={{ marginTop: '20px' }}>
         <div className="well-compact alert alert-warning">
-          <strong>Note:</strong> a rolling push only updates the <em>launch configuration</em> for the auto scaling
-          group.
+          <strong>Note:</strong> a rolling push only updates the{' '}
+          <em>
+            launch {Boolean(AWSProviderSettings.serverGroups?.enableLaunchTemplates) ? 'template' : 'configuration'}
+          </em>{' '}
+          for the auto scaling group.
           <br /> Changes to the following fields will be ignored:
           <ul>
             <li>Account, Region, Subnet Type</li>

--- a/app/scripts/modules/amazon/src/deploymentStrategy/rollingPush.strategy.ts
+++ b/app/scripts/modules/amazon/src/deploymentStrategy/rollingPush.strategy.ts
@@ -1,5 +1,5 @@
 import { DeploymentStrategyRegistry, IServerGroupCommand } from '@spinnaker/core';
-
+import { AWSProviderSettings } from '../aws.settings';
 import { AdditionalFields } from './AdditionalFields';
 
 export interface IRollingPushTermination {
@@ -16,7 +16,9 @@ export interface IRollingPushCommand extends IServerGroupCommand {
 
 DeploymentStrategyRegistry.registerStrategy({
   label: 'Rolling Push (not recommended)',
-  description: `Updates the launch configuration for this server group, then terminates instances incrementally,
+  description: `Updates the launch ${
+    AWSProviderSettings.serverGroups?.enableLaunchTemplates ? 'template' : 'configuration'
+  } for this server group, then terminates instances incrementally,
     replacing them with instances launched with the updated configuration. This is not a best practice - it goes against
     the principles of immutable infrastructure - but may be necessary in some cases.`,
   key: 'rollingpush',

--- a/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupConfiguration.service.ts
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupConfiguration.service.ts
@@ -167,7 +167,7 @@ export class AwsServerGroupConfigurationService {
       command.suspendedProcesses.includes(process);
 
     cmd.onStrategyChange = (command: IAmazonServerGroupCommand, strategy: IDeploymentStrategy): void => {
-      if (AWSProviderSettings.serverGroups.enableLaunchTemplates) {
+      if (AWSProviderSettings.serverGroups?.enableLaunchTemplates) {
         command.setLaunchTemplate = strategy.key === 'rollingpush' ? true : undefined;
       }
 

--- a/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupConfiguration.service.ts
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupConfiguration.service.ts
@@ -166,6 +166,8 @@ export class AwsServerGroupConfigurationService {
       command.suspendedProcesses.includes(process);
 
     cmd.onStrategyChange = (command: IAmazonServerGroupCommand, strategy: IDeploymentStrategy): void => {
+      command.setLaunchTemplate = strategy.key === 'rollingpush' ? true : undefined;
+
       // Any strategy other than None or Custom should force traffic to be enabled
       if (strategy.key !== '' && strategy.key !== 'custom') {
         command.suspendedProcesses = (command.suspendedProcesses || []).filter(p => p !== 'AddToLoadBalancer');

--- a/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupConfiguration.service.ts
+++ b/app/scripts/modules/amazon/src/serverGroup/configure/serverGroupConfiguration.service.ts
@@ -52,6 +52,7 @@ import {
 import { KeyPairsReader } from 'amazon/keyPairs';
 import { AutoScalingProcessService } from '../details/scalingProcesses/AutoScalingProcessService';
 import { AMAZON_INSTANCE_AWSINSTANCETYPE_SERVICE } from 'amazon/instance/awsInstanceType.service';
+import { AWSProviderSettings } from 'amazon/aws.settings';
 
 export type IBlockDeviceMappingSource = 'source' | 'ami' | 'default';
 
@@ -166,7 +167,9 @@ export class AwsServerGroupConfigurationService {
       command.suspendedProcesses.includes(process);
 
     cmd.onStrategyChange = (command: IAmazonServerGroupCommand, strategy: IDeploymentStrategy): void => {
-      command.setLaunchTemplate = strategy.key === 'rollingpush' ? true : undefined;
+      if (AWSProviderSettings.serverGroups.enableLaunchTemplates) {
+        command.setLaunchTemplate = strategy.key === 'rollingpush' ? true : undefined;
+      }
 
       // Any strategy other than None or Custom should force traffic to be enabled
       if (strategy.key !== '' && strategy.key !== 'custom') {

--- a/settings.js
+++ b/settings.js
@@ -148,6 +148,7 @@ window.spinnakerSettings = {
         inferInternalFlagFromSubnet: false,
       },
       serverGroups: {
+        enableLaunchTemplates: false,
         enableIPv6: false,
         enableIMDSv2: false,
       },


### PR DESCRIPTION
- specifies `setLaunchTemplate` when rolling push strategy is selected by user
- adds a settings to conditionally use `launch templates` in help text depending on whether or not launch templates or launch configurations are activated. 