### PR TITLE
chore(package): amazon@0.0.265 appengine@0.0.16 cloudfoundry@0.0.98 core@0.0.506 ecs@0.0.262 titus@0.0.142

### DIFF
--- a/app/scripts/modules/amazon/package.json
+++ b/app/scripts/modules/amazon/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/amazon",
   "license": "Apache-2.0",
-  "version": "0.0.264",
+  "version": "0.0.265",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/appengine/package.json
+++ b/app/scripts/modules/appengine/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/appengine",
   "license": "Apache-2.0",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/cloudfoundry/package.json
+++ b/app/scripts/modules/cloudfoundry/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/cloudfoundry",
   "license": "Apache-2.0",
-  "version": "0.0.97",
+  "version": "0.0.98",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/core",
   "license": "Apache-2.0",
-  "version": "0.0.505",
+  "version": "0.0.506",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/ecs/package.json
+++ b/app/scripts/modules/ecs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/ecs",
   "license": "Apache-2.0",
-  "version": "0.0.261",
+  "version": "0.0.262",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/titus/package.json
+++ b/app/scripts/modules/titus/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/titus",
   "license": "Apache-2.0",
-  "version": "0.0.141",
+  "version": "0.0.142",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
## amazon@0.0.265

03367a08eacb947314e13e07ee9dcbd081db2f51 fix(amazon/serverGroup): Do not clone launch template userData (#8562)
fa8fa7f7449a46f9e9243012ed61ec77f4203eb0 fix(aws/serverGroup): Optimize cloning logic (#8560)
469a2d0169752cb8801dd742e3de2b744b346ca1 fix(amazon/alb): Update rule condition validation for edge case (#8544)

## appengine@0.0.16

1a20a4a4ec7d9c6bf291366dbab59752f270a66f fix(appengine): fix rendering of StageArtifactSelector when artifacts are created (#8516)

## cloudfoundry@0.0.98

680906fe30ccd083d5c67359179b63a262f28602 fix(provider/cf): fix env variables section (#8549)
040b0717b7fb7f18f078d1aa61ec6348c9ecf53d feat(provider/cf): add bake cf manifest stage (#8529)

## core@0.0.506

25e1c5f55894fccd8510ab987c21683310db3cfc fix(aws): Get imageId and imageName from server group info (#8548)
08419c1dff7768aa0a7c26009622cce80f0cf6b8 fix(core/managed): give StatusBubbleStack its own z-index context (#8558)
6c632a99bdd132004f98b7786038985837315e05 feat(core/managed): wording + terminology tweaks for resources (#8552)
2395fa9dd8d515912b09f5c01676f040cc3348ad feat(core/managed): let resource plugins define their own links (#8550)
c32bb9750fc6a22f5fa5055a104d5b65d56d9c3d chore(typescript): Upgrade typescript to v4
aad914f5fbdbf12d27a21fd96386d3a4dc34117e feat(core): Move colorful icons to illustrations (#8551)
040b0717b7fb7f18f078d1aa61ec6348c9ecf53d feat(provider/cf): add bake cf manifest stage (#8529)

## ecs@0.0.262

c32bb9750fc6a22f5fa5055a104d5b65d56d9c3d chore(typescript): Upgrade typescript to v4
7c064c740d242c5411ec1ac4607d77984530561f fix(ecs): add container name for service discovery in server group (#8518)

## titus@0.0.142

c32bb9750fc6a22f5fa5055a104d5b65d56d9c3d chore(typescript): Upgrade typescript to v4

PR created via `modules/publish.js`