### PR TITLE
fix(functions): change KMSKeyArn to match function cache data model

### DIFF
--- a/app/scripts/modules/amazon/src/domain/IAmazonFunction.ts
+++ b/app/scripts/modules/amazon/src/domain/IAmazonFunction.ts
@@ -23,7 +23,7 @@ export interface IAmazonFunction extends IFunction {
   deadLetterConfig: {
     targetArn: string;
   };
-  KMSKeyArn: string;
+  kmskeyArn: string;
   vpcConfig: {
     securityGroupIds: [];
     subnetIds: [];
@@ -49,7 +49,7 @@ export interface IAmazonFunctionUpsertCommand extends IFunctionUpsertCommand {
   deadLetterConfig: {
     targetArn: string;
   };
-  KMSKeyArn: string;
+  kmskeyArn: string;
   securityGroupIds: string[];
   subnetIds: string[];
   vpcId: string;

--- a/app/scripts/modules/amazon/src/domain/IAmazonFunctionSourceData.ts
+++ b/app/scripts/modules/amazon/src/domain/IAmazonFunctionSourceData.ts
@@ -39,6 +39,6 @@ export interface IAmazonFunctionSourceData extends IFunctionSourceData {
   deadLetterConfig: {
     targetArn: string;
   };
-  KMSKeyArn: string;
+  kmskeyArn: string;
   targetGroups: string[];
 }

--- a/app/scripts/modules/amazon/src/function/configure/FunctionEnvironmentVariables.tsx
+++ b/app/scripts/modules/amazon/src/function/configure/FunctionEnvironmentVariables.tsx
@@ -24,7 +24,7 @@ export class FunctionEnvironmentVariables extends React.Component<IFunctionEnvir
   public validate = (values: IAmazonFunctionUpsertCommand) => {
     const validator = new FormValidator(values);
     validator
-      .field('KMSKeyArn', 'KMS Key ARN')
+      .field('kmskeyArn', 'KMS Key ARN')
       .optional()
       .withValidators(awsArnValidator);
     return validator.validateForm();
@@ -39,7 +39,7 @@ export class FunctionEnvironmentVariables extends React.Component<IFunctionEnvir
           input={props => <MapEditorInput {...props} allowEmptyValues={true} addButtonLabel="Add" />}
         />
         <FormikFormField
-          name="KMSKeyArn"
+          name="kmskeyArn"
           label="Key ARN"
           help={<HelpField id="aws.function.kmsKeyArn" />}
           input={props => <TextInput {...props} />}

--- a/app/scripts/modules/amazon/src/function/function.transformer.ts
+++ b/app/scripts/modules/amazon/src/function/function.transformer.ts
@@ -21,7 +21,7 @@ export class AwsFunctionTransformer {
     deadLetterConfig: {
       targetArn: functionDef.deadLetterConfig ? functionDef.deadLetterConfig.targetArn : '',
     },
-    KMSKeyArn: functionDef.KMSKeyArn ? functionDef.KMSKeyArn : '',
+    KMSKeyArn: functionDef.kmskeyArn ? functionDef.kmskeyArn : '',
     subnetIds: functionDef.vpcConfig ? functionDef.vpcConfig.subnetIds : [],
     securityGroupIds: functionDef.vpcConfig ? functionDef.vpcConfig.securityGroupIds : [],
     vpcId: functionDef.vpcConfig ? functionDef.vpcConfig.vpcId : '',
@@ -56,7 +56,7 @@ export class AwsFunctionTransformer {
       tracingConfig: {
         mode: 'PassThrough',
       },
-      KMSKeyArn: '',
+      kmskeyArn: '',
       vpcId: '',
       subnetIds: [],
       securityGroupIds: [],


### PR DESCRIPTION
KMS Keys used to encrypt environment variables are not displayed in the function form on edit.

Function form expects key `KMSKeyArn` while function cache is providing `kmskeyArn`

_Fix_: Change form to consume the correct cache key `kmskeyArn`