### PR TITLE
chore(package): amazon@0.0.266 core@0.0.507

### DIFF
--- a/app/scripts/modules/amazon/package.json
+++ b/app/scripts/modules/amazon/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/amazon",
   "license": "Apache-2.0",
-  "version": "0.0.265",
+  "version": "0.0.266",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/core",
   "license": "Apache-2.0",
-  "version": "0.0.506",
+  "version": "0.0.507",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
## amazon@0.0.266

1e6da6357891803443043c22bfafb5b18cf8dc33 fix(functions): change KMSKeyArn to match function cache data model (#8566)
efee5f229206efad189e57cc9adf3303160c6d9a fix(aws): expose baseLabel to Rosco-powered bake stages (#8559)
547780c92df0f29ee3f766c281d07634ee003f55 fix(amazon/serverGroup): Enable launch templates for rolling push (#8563)

## core@0.0.507

09439726a3abfb1d8f4843d654b8253f90213a8a chore(core): remove CSS module code + build/test scaffolding (#8567)

PR created via `modules/publish.js`