### PR TITLE
fix(appengine): remove extraneous "f" from assertion

### DIFF
--- a/app/scripts/modules/appengine/src/serverGroup/configure/wizard/configFileArtifactList.spec.tsx
+++ b/app/scripts/modules/appengine/src/serverGroup/configure/wizard/configFileArtifactList.spec.tsx
@@ -65,7 +65,7 @@ describe('<ConfigFileArtifactList/>', () => {
     $http.flush();
   });
 
-  fit('renders 1 children of StageArtifactSelector when 1 expectedArtifacts are passed in', () => {
+  it('renders 1 children of StageArtifactSelector when 1 expectedArtifacts are passed in', () => {
     const body: IArtifactAccount[] = [
       {
         name: 'http-acc',


### PR DESCRIPTION
This was causing 1626 tests to be skipped since [this PR](https://github.com/spinnaker/deck/pull/8516) was merged (but not fail, which is why CI didn't catch it.)

![aG2yRNanJ7ZfjQN](https://user-images.githubusercontent.com/15936279/93379360-b60fea80-f82b-11ea-8d37-b1ab73f29fec.png)

