### PR TITLE
feat(core/managed): point to resource spec in YAML format instead of JSON

### DIFF
--- a/app/scripts/modules/core/src/managed/ManagedResourceDetailsIndicator.tsx
+++ b/app/scripts/modules/core/src/managed/ManagedResourceDetailsIndicator.tsx
@@ -114,7 +114,7 @@ export const ManagedResourceDetailsIndicator = ({
               <a
                 target="_blank"
                 onClick={() => logClick('Raw Source', id)}
-                href={`${SETTINGS.gateUrl}/managed/resources/${id}`}
+                href={`${SETTINGS.gateUrl}/managed/resources/${id}.yml`}
               >
                 Raw Source
               </a>


### PR DESCRIPTION
Following up on https://github.com/spinnaker/gate/pull/1342, this sets up deck to point to the YAML-formatted spec. I'll be coming back around to do the same thing for delivery configs once we throw a link to them into Environments.