### PR TITLE
feat(core): add overridable decorator to BakeKustomizeConfigForm

### DIFF
--- a/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/kustomize/BakeKustomizeConfigForm.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/bakeManifest/kustomize/BakeKustomizeConfigForm.tsx
@@ -3,9 +3,11 @@ import React from 'react';
 import { StageConfigField } from '../../common/stageConfigField/StageConfigField';
 import { IFormikStageConfigInjectedProps } from '../../FormikStageConfig';
 import { StageArtifactSelectorDelegate, ArtifactTypePatterns, excludeAllTypesExcept } from 'core/artifact';
+import { Overridable } from 'core/overrideRegistry';
 import { IArtifact } from 'core/domain';
 import { TextInput } from 'core/presentation';
 
+@Overridable('bakeKustomizeConfigForm')
 export class BakeKustomizeConfigForm extends React.Component<IFormikStageConfigInjectedProps> {
   private getInputArtifact = () => {
     const stage = this.props.formik.values;


### PR DESCRIPTION
I'm exploring what it would look like to add additional artifact sources
for Kustomize bakes to an existing extension project. Rather than build
a plugin or fork Deck, I'd rather do this in an existing extension
project so I can tweak things in Rosco at the same time as I'm making
changes to Deck!