### PR TITLE
feat(core/managed): add git metadata to version details pane

### DIFF
--- a/app/scripts/modules/core/src/domain/IManagedEntity.ts
+++ b/app/scripts/modules/core/src/domain/IManagedEntity.ts
@@ -103,10 +103,35 @@ export interface IManagedArtifactVersion {
     statelessConstraints?: IStatelessConstraint[];
   }>;
   build?: {
-    id: number;
+    id: number; // deprecated, use number
+    number: string;
+    uid: string;
+    job: {
+      link: string;
+      name: string;
+    };
+    startedAt: string;
+    completedAt?: string;
+    status: 'SUCCESS' | 'UNSTABLE' | 'BUILDING' | 'ABORTED' | 'FAILURE' | 'NOT_BUILT';
   };
   git?: {
-    commit: string;
+    commit: string; // deprecated, use commitInfo
+    author: string;
+    project: string;
+    branch: string;
+    repo: {
+      name: string;
+      link: string;
+    };
+    pullRequest?: {
+      number: string;
+      url: string;
+    };
+    commitInfo: {
+      sha: string;
+      link: string;
+      message: string;
+    };
   };
 }
 

--- a/app/scripts/modules/core/src/managed/ArtifactDetail.less
+++ b/app/scripts/modules/core/src/managed/ArtifactDetail.less
@@ -10,7 +10,13 @@
   }
 
   .detail-section-right {
-    flex: 1 1 auto;
+    max-width: 650px;
+    color: var(--color-charcoal);
+
+    .metadata-label {
+      width: 100px;
+      color: var(--color-black);
+    }
   }
 
   .resource-badge {

--- a/app/scripts/modules/core/src/managed/ArtifactDetail.tsx
+++ b/app/scripts/modules/core/src/managed/ArtifactDetail.tsx
@@ -164,6 +164,12 @@ const EnvironmentCards = memo(
   },
 );
 
+const VersionMetadataItem = ({ label, value }: { label: string; value: JSX.Element | string }) => (
+  <div className="flex-container-h sp-margin-xs-bottom">
+    <div className="metadata-label text-bold text-right sp-margin-l-right flex-none">{label}</div> <span>{value}</span>
+  </div>
+);
+
 export interface IArtifactDetailProps {
   application: Application;
   name: string;
@@ -183,7 +189,7 @@ export const ArtifactDetail = ({
   resourcesByEnvironment,
   onRequestClose,
 }: IArtifactDetailProps) => {
-  const { environments } = versionDetails;
+  const { environments, git } = versionDetails;
 
   const keydownCallback = ({ keyCode }: KeyboardEvent) => {
     if (keyCode === 27 /* esc */) {
@@ -200,8 +206,8 @@ export const ArtifactDetail = ({
       <ArtifactDetailHeader name={name} version={versionDetails} onRequestClose={onRequestClose} />
 
       <div className="ArtifactDetail">
-        <div className="flex-container-h sp-margin-xl-bottom">
-          <div className="flex-container-h sp-group-margin-s-xaxis">
+        <div className="flex-container-h top sp-margin-xl-bottom">
+          <div className="flex-container-h sp-group-margin-s-xaxis flex-none">
             <Button
               iconName="pin"
               appearance="primary"
@@ -230,7 +236,34 @@ export const ArtifactDetail = ({
               Mark as bad...
             </Button>
           </div>
-          <div className="detail-section-right">{/* artifact metadata will live here */}</div>
+          <div className="detail-section-right flex-container-v flex-pull-right sp-margin-l-right">
+            {git?.author && <VersionMetadataItem label="Author" value={git.author} />}
+            {git?.pullRequest?.number && git?.pullRequest?.url && (
+              <VersionMetadataItem
+                label="Pull Request"
+                value={
+                  <a href={git.pullRequest.url} target="_blank" rel="noopener noreferrer">
+                    #{git.pullRequest.number}
+                  </a>
+                }
+              />
+            )}
+            {git?.commitInfo && (
+              <>
+                <VersionMetadataItem
+                  label="Commit"
+                  value={
+                    <a href={git.commitInfo.link} target="_blank" rel="noopener noreferrer">
+                      {git.commitInfo.sha.substring(0, 7)}
+                    </a>
+                  }
+                />
+                <VersionMetadataItem label="Message" value={git.commitInfo.message} />
+              </>
+            )}
+            {git?.branch && <VersionMetadataItem label="Branch" value={git.branch} />}
+            {git?.repo && <VersionMetadataItem label="Repository" value={`${git.project}/${git.repo.name}`} />}
+          </div>
         </div>
         {environments.map(environment => {
           const { name: environmentName, state } = environment;


### PR DESCRIPTION
Quick, low-effort follow up to the work recently done on keel to expose git + build metadata for artifact versions. This only adds data about git, because I need to do a little more work on the build data to tie it together with Netflix's internal build UI. I'll be following this up with more thorough/higher effort work around getting a visually rich treatment done for the version sidebar on the left.

I settled on a way of representing "Author" that is consistent with the mockups (having it's own line item), but I also tried out listing it as part of the commit like we do in our internal builds UI. I'm not sure I love that option, but figured I'd show it:

**Current PR (author on its own line):**
<img width="899" alt="Screen Shot 2020-09-17 at 8 52 15 PM" src="https://user-images.githubusercontent.com/1850998/93555795-ea6ad000-f92b-11ea-962c-18118a58c9b9.png">

**Alternative (author consolidated into commit):**
<img width="900" alt="Screen Shot 2020-09-17 at 8 52 44 PM" src="https://user-images.githubusercontent.com/1850998/93555801-f2c30b00-f92b-11ea-8bef-5ab82e0e3895.png">


fyi @gcomstock 