### PR TITLE
chore(package): appengine@0.0.17 core@0.0.508 ecs@0.0.263 kubernetes@0.0.49 titus@0.0.143

### DIFF
--- a/app/scripts/modules/appengine/package.json
+++ b/app/scripts/modules/appengine/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/appengine",
   "license": "Apache-2.0",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/core",
   "license": "Apache-2.0",
-  "version": "0.0.507",
+  "version": "0.0.508",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/ecs/package.json
+++ b/app/scripts/modules/ecs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/ecs",
   "license": "Apache-2.0",
-  "version": "0.0.262",
+  "version": "0.0.263",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/kubernetes/package.json
+++ b/app/scripts/modules/kubernetes/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/kubernetes",
   "license": "Apache-2.0",
-  "version": "0.0.48",
+  "version": "0.0.49",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/titus/package.json
+++ b/app/scripts/modules/titus/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/titus",
   "license": "Apache-2.0",
-  "version": "0.0.142",
+  "version": "0.0.143",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
## appengine@0.0.17

6d0bfc6ad63e5fe548fab96a8e2593aedaaad8d3 fix(appengine): remove extraneous "f" from assertion (#8571)

## core@0.0.508

edc190cae0ee468ac31701547a0f63f4e5eb5706 feat(core/managed): add git metadata to version details pane (#8576)
439617d2bed5a215a007d8660a19ea3ad02a6d54 feat(core): add overridable decorator to BakeKustomizeConfigForm (#8575)
57771e64f3e6e6ce37300235e9721844cd0eb25b refactor(hint): Change incorrect grammar for hint (#8568)

## ecs@0.0.263

249aa8e0a16ae3fad7421dec654901f278c4cd4e fix(ecs): set container name to empty when using container inputs #8527 (#8527)

## kubernetes@0.0.49

02085ce1ced2ac8bba846bb853545ec04b293b61 fix(kubernetes/serverGroup): use the actual server group manager's kind in name (#8570)

## titus@0.0.143

30da1a5b82f04d30e86ba0db5ac0c8d38e88c892 fix(titus/instance): Construct discovery health info in controller (#8572)

PR created via `modules/publish.js`