### PR TITLE
feat(core/managed): surface git metadata on version list

### DIFF
--- a/app/scripts/modules/core/src/managed/ArtifactRow.less
+++ b/app/scripts/modules/core/src/managed/ArtifactRow.less
@@ -1,5 +1,5 @@
 .ArtifactRow {
-  height: 56px;
+  height: 94px;
   display: block;
   position: relative;
   cursor: pointer;
@@ -16,68 +16,49 @@
   }
 
   .row-content {
-    display: flex;
-    align-items: center;
     height: 100%;
-    padding-top: 4px;
-    padding-bottom: 12px;
   }
 
-  .version-identifier {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    flex: 0 0 48px;
-    margin: 0 8px 0 4px;
+  .row-middle-section {
+    width: 100%;
   }
 
   .version-title {
-    flex: 1 1 auto;
+    max-width: 100%;
     overflow: hidden;
-  }
-
-  .version-identifier,
-  .version-title {
-    transition: margin 150ms ease-in-out;
-  }
-
-  &:hover {
-    .version-identifier,
-    .version-title {
-      margin-top: -13px;
-    }
   }
 
   .version-name {
-    font-size: 14px;
+    font-size: 13px;
+    color: var(--color-icon-neutral);
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;
   }
 
-  &.selected .version-name {
-    font-weight: 700;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    color: #2c4b5f;
-  }
-
-  .artifact-name {
-    font-size: 12px;
+  .version-secondary-summary {
+    font-size: 13px;
     font-style: italic;
-    color: var(--color-nobel);
+    color: var(--color-icon-neutral);
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;
+    margin-left: 20px;
+    opacity: 1;
+    transition: opacity 150ms ease-in-out;
+  }
+
+  &:hover .version-secondary-summary {
+    opacity: 0;
   }
 
   .environment-stages {
     display: flex;
     position: absolute;
     height: 8px;
-    bottom: 0;
-    left: 0;
-    right: 0;
+    bottom: 8px;
+    left: 8px;
+    right: 8px;
     z-index: 1;
     transition: height 150ms ease-in-out;
   }

--- a/app/scripts/modules/core/src/managed/StatusBubbleStack.tsx
+++ b/app/scripts/modules/core/src/managed/StatusBubbleStack.tsx
@@ -18,7 +18,7 @@ export const StatusBubbleStack = ({ borderColor, maxBubbles, statuses }: IStatus
   const hiddenStatusBubbleCount = statuses.length - statusBubblesToRender.length;
 
   return (
-    <div className="StatusBubbleStack flex-container-h middle sp-margin-s-right">
+    <div className="StatusBubbleStack flex-container-h middle">
       {statusBubblesToRender.map((status, index) => (
         <div
           className="StatusBubbleContainer"


### PR DESCRIPTION
Now that we've got git metadata, let's show it off at a glance in the list of versions! We'll now be able to show commit messages, branches, pull requests, and authors without even a single click. Screenshots:

<img width="672" alt="Screen Shot 2020-09-18 at 4 15 35 PM" src="https://user-images.githubusercontent.com/1850998/93652679-c27e7980-f9ca-11ea-9fda-fb7a75a433a2.png">
<img width="682" alt="Screen Shot 2020-09-18 at 4 15 47 PM" src="https://user-images.githubusercontent.com/1850998/93652681-c4483d00-f9ca-11ea-8d7f-3a6646deb519.png">
<img width="673" alt="Screen Shot 2020-09-18 at 4 16 15 PM" src="https://user-images.githubusercontent.com/1850998/93652683-c5796a00-f9ca-11ea-813e-24072c21978c.png">


Only thing that's a bit gross is the experience of _not_ having git metadata for a version — it's a bit of a step down in layout/UX right now. I feel strongly we should optimize for making the git metadata case great, so I'm shipping this now and will polish the other case next. I've swapped out the relatively meaningless commit sha we were lifting from versions to instead use the `displayName`. Here's what it looks like:

<img width="670" alt="Screen Shot 2020-09-18 at 4 19 54 PM" src="https://user-images.githubusercontent.com/1850998/93652703-d4f8b300-f9ca-11ea-9652-e95d608932c7.png">


cc @gcomstock 