### PR TITLE
feat(core/managed): tighten up layout on environments header

### DIFF
--- a/app/scripts/modules/core/src/managed/EnvironmentsHeader.tsx
+++ b/app/scripts/modules/core/src/managed/EnvironmentsHeader.tsx
@@ -44,15 +44,17 @@ export const EnvironmentsHeader = ({ app, resourceInfo: { managed, total } }: IE
 
   return (
     <div className="EnvironmentsHeader">
-      <div className="flex-container-h sp-padding-l">
-        <div style={{ width: 145 }}>
+      <div className="flex-container-h sp-padding-m sp-padding-l-left">
+        <div style={{ width: 115, marginTop: -6 }}>
           <Illustration name={icon} />
         </div>
-        <div className="flex-container-v sp-padding-xl-top sp-margin-m-left sp-margin-m-top">
-          <div className="heading-3 bold">{title(managed === total ? `${total}` : `${managed}/${total}`)}</div>
+        <div className="flex-container-v middle sp-margin-xl-left">
+          <div className="heading-3 text-bold">{title(managed === total ? `${total}` : `${managed}/${total}`)}</div>
           {description && <div className="sp-margin-s-top">{description}</div>}
           <Dropdown id="application-actions" className="sp-margin-l-top">
-            <Dropdown.Toggle className="dropdown-toggle-btn">Application Actions</Dropdown.Toggle>
+            <Dropdown.Toggle className="dropdown-toggle-btn">
+              <span className="text-bold">Application Actions</span>
+            </Dropdown.Toggle>
             <Dropdown.Menu className="dropdown-menu">
               <ToggleManagedResourceAction app={app} />
             </Dropdown.Menu>


### PR DESCRIPTION
The masthead/summary thing at the top of the environments overview is a little bloated right now in terms of padding and illustration size, I'm just quickly tightening it up to match the mocks (including tweaks to the drop shadow + text weight) while I'm already in there working on #8600.

**Before**
<img width="933" alt="Screen Shot 2020-09-25 at 4 18 23 PM" src="https://user-images.githubusercontent.com/1850998/94323900-582a8380-ff4c-11ea-85a9-0615311f3c60.png">


**After**
<img width="941" alt="Screen Shot 2020-09-25 at 4 18 04 PM" src="https://user-images.githubusercontent.com/1850998/94323906-5c56a100-ff4c-11ea-9c69-fb8e2e39d950.png">


cc @gcomstock 