### PR TITLE
feat(core/managed): switch to abbreviated timestamp format, add version timestamps

### DIFF
--- a/app/scripts/modules/core/src/domain/IManagedEntity.ts
+++ b/app/scripts/modules/core/src/domain/IManagedEntity.ts
@@ -83,6 +83,7 @@ export interface IManagedEnvironmentSummary {
 export interface IManagedArtifactVersion {
   version: string;
   displayName: string;
+  createdAt?: string;
   environments: Array<{
     name: string;
     state: 'current' | 'deploying' | 'approved' | 'pending' | 'previous' | 'vetoed' | 'skipped';

--- a/app/scripts/modules/core/src/managed/AbsoluteTimestamp.tsx
+++ b/app/scripts/modules/core/src/managed/AbsoluteTimestamp.tsx
@@ -1,0 +1,33 @@
+import React, { memo } from 'react';
+import { DateTime } from 'luxon';
+
+import { SETTINGS } from '../config';
+import { CopyToClipboard } from '../utils';
+
+export interface IAbsoluteTimestampProps {
+  timestamp: DateTime;
+  clickToCopy?: boolean;
+}
+
+const TIMEZONE = SETTINGS.feature.displayTimestampsInUserLocalTime ? undefined : SETTINGS.defaultTimeZone;
+
+export const AbsoluteTimestamp = memo(
+  ({ timestamp: timestampInOriginalZone, clickToCopy }: IAbsoluteTimestampProps) => {
+    const timestamp = timestampInOriginalZone.setZone(TIMEZONE);
+
+    const fullTimestamp = timestamp.toFormat('yyyy-MM-dd HH:mm:ss ZZZZ');
+    const formattedTimestamp = timestamp.toFormat('MMM d, y HH:mm');
+    const timestampElement = <span>{formattedTimestamp}</span>;
+
+    if (clickToCopy) {
+      return (
+        <span>
+          {timestampElement}
+          <CopyToClipboard text={fullTimestamp} toolTip={`${fullTimestamp} (click to copy)`} />
+        </span>
+      );
+    } else {
+      return timestampElement;
+    }
+  },
+);

--- a/app/scripts/modules/core/src/managed/ArtifactDetail.tsx
+++ b/app/scripts/modules/core/src/managed/ArtifactDetail.tsx
@@ -4,7 +4,6 @@ import { useRouter } from '@uirouter/react';
 import { useTransition, animated, UseTransitionProps } from 'react-spring';
 import { DateTime } from 'luxon';
 
-import { CopyToClipboard, timestamp } from '../utils';
 import {
   IManagedArtifactSummary,
   IManagedArtifactVersion,
@@ -14,6 +13,7 @@ import {
 import { Application } from '../application';
 import { useEventListener, Markdown } from '../presentation';
 
+import { AbsoluteTimestamp } from './AbsoluteTimestamp';
 import { ArtifactDetailHeader } from './ArtifactDetailHeader';
 import { ManagedResourceObject } from './ManagedResourceObject';
 import { EnvironmentRow } from './EnvironmentRow';
@@ -227,7 +227,7 @@ export const ArtifactDetail = ({
 
   const isPinnedEverywhere = environments.every(({ pinned }) => pinned);
   const isBadEverywhere = environments.every(({ state }) => state === 'vetoed');
-  const createdAtMillis = createdAt && DateTime.fromISO(createdAt).toMillis();
+  const createdAtTimestamp = useMemo(() => createdAt && DateTime.fromISO(createdAt), [createdAt]);
 
   return (
     <>
@@ -265,15 +265,10 @@ export const ArtifactDetail = ({
             </Button>
           </div>
           <div className="detail-section-right flex-container-v flex-pull-right sp-margin-l-right">
-            {createdAtMillis && (
+            {createdAtTimestamp && (
               <VersionMetadataItem
                 label="Created"
-                value={
-                  <>
-                    {timestamp(createdAtMillis)}{' '}
-                    <CopyToClipboard text={timestamp(createdAtMillis)} toolTip="Copy timestamp" />
-                  </>
-                }
+                value={<AbsoluteTimestamp timestamp={createdAtTimestamp} clickToCopy={true} />}
               />
             )}
             {git?.author && <VersionMetadataItem label="Author" value={git.author} />}

--- a/app/scripts/modules/core/src/managed/ArtifactDetail.tsx
+++ b/app/scripts/modules/core/src/managed/ArtifactDetail.tsx
@@ -4,7 +4,7 @@ import { useRouter } from '@uirouter/react';
 import { useTransition, animated, UseTransitionProps } from 'react-spring';
 import { DateTime } from 'luxon';
 
-import { relativeTime, timestamp } from '../utils';
+import { timestamp } from '../utils';
 import {
   IManagedArtifactSummary,
   IManagedArtifactVersion,
@@ -94,8 +94,6 @@ const EnvironmentCards = memo(
       stateService: { go },
     } = useRouter();
 
-    const pinnedAtMillis = pinned?.at ? DateTime.fromISO(pinned.at).toMillis() : null;
-
     const differentVersionPinnedCard = pinnedVersion &&
       pinnedVersion !== versionDetails.version &&
       !['vetoed', 'skipped'].includes(state) && (
@@ -113,11 +111,11 @@ const EnvironmentCards = memo(
         iconName="pin"
         appearance="warning"
         background={true}
+        timestamp={pinned?.at ? DateTime.fromISO(pinned.at) : null}
         title={
           <span className="sp-group-margin-xs-xaxis">
-            Pinned here {relativeTime(pinnedAtMillis)}{' '}
-            <span className="text-italic text-regular sp-margin-xs-left">({timestamp(pinnedAtMillis)})</span>{' '}
-            <span className="text-regular">—</span> <span className="text-regular">by {pinned.by}</span>
+            <span>Pinned</span> <span className="text-regular">—</span>{' '}
+            <span className="text-regular">by {pinned.by}</span>
           </span>
         }
         description={pinned.comment && <Markdown message={pinned.comment} tag="span" />}

--- a/app/scripts/modules/core/src/managed/ArtifactDetail.tsx
+++ b/app/scripts/modules/core/src/managed/ArtifactDetail.tsx
@@ -218,7 +218,7 @@ export const ArtifactDetail = ({
   resourcesByEnvironment,
   onRequestClose,
 }: IArtifactDetailProps) => {
-  const { environments, git } = versionDetails;
+  const { environments, git, createdAt } = versionDetails;
 
   const keydownCallback = ({ keyCode }: KeyboardEvent) => {
     if (keyCode === 27 /* esc */) {
@@ -229,6 +229,7 @@ export const ArtifactDetail = ({
 
   const isPinnedEverywhere = environments.every(({ pinned }) => pinned);
   const isBadEverywhere = environments.every(({ state }) => state === 'vetoed');
+  const createdAtMillis = createdAt && DateTime.fromISO(createdAt).toMillis();
 
   return (
     <>
@@ -266,6 +267,7 @@ export const ArtifactDetail = ({
             </Button>
           </div>
           <div className="detail-section-right flex-container-v flex-pull-right sp-margin-l-right">
+            {createdAtMillis && <VersionMetadataItem label="Created" value={timestamp(createdAtMillis)} />}
             {git?.author && <VersionMetadataItem label="Author" value={git.author} />}
             {git?.pullRequest?.number && git?.pullRequest?.url && (
               <VersionMetadataItem

--- a/app/scripts/modules/core/src/managed/ArtifactDetail.tsx
+++ b/app/scripts/modules/core/src/managed/ArtifactDetail.tsx
@@ -4,7 +4,7 @@ import { useRouter } from '@uirouter/react';
 import { useTransition, animated, UseTransitionProps } from 'react-spring';
 import { DateTime } from 'luxon';
 
-import { timestamp } from '../utils';
+import { CopyToClipboard, timestamp } from '../utils';
 import {
   IManagedArtifactSummary,
   IManagedArtifactVersion,
@@ -265,7 +265,17 @@ export const ArtifactDetail = ({
             </Button>
           </div>
           <div className="detail-section-right flex-container-v flex-pull-right sp-margin-l-right">
-            {createdAtMillis && <VersionMetadataItem label="Created" value={timestamp(createdAtMillis)} />}
+            {createdAtMillis && (
+              <VersionMetadataItem
+                label="Created"
+                value={
+                  <>
+                    {timestamp(createdAtMillis)}{' '}
+                    <CopyToClipboard text={timestamp(createdAtMillis)} toolTip="Copy timestamp" />
+                  </>
+                }
+              />
+            )}
             {git?.author && <VersionMetadataItem label="Author" value={git.author} />}
             {git?.pullRequest?.number && git?.pullRequest?.url && (
               <VersionMetadataItem

--- a/app/scripts/modules/core/src/managed/ArtifactsList.tsx
+++ b/app/scripts/modules/core/src/managed/ArtifactsList.tsx
@@ -1,5 +1,6 @@
+import React, { useMemo, useState } from 'react';
 import classNames from 'classnames';
-import React, { useState } from 'react';
+import { DateTime } from 'luxon';
 
 import {
   IManagedArtifactSummary,
@@ -11,6 +12,7 @@ import { Icon } from '../presentation';
 
 import { ISelectedArtifactVersion } from './Environments';
 import { Pill } from './Pill';
+import { RelativeTimestamp } from './RelativeTimestamp';
 import { IStatusBubbleStackProps, StatusBubbleStack } from './StatusBubbleStack';
 
 import './ArtifactRow.less';
@@ -71,11 +73,12 @@ interface IArtifactRowProps {
 }
 
 export const ArtifactRow = ({ isSelected, clickHandler, version: versionInfo, reference, name }: IArtifactRowProps) => {
-  const { version, displayName, environments, build, git } = versionInfo;
+  const { version, displayName, createdAt, environments, build, git } = versionInfo;
   const [isHovered, setIsHovered] = useState(false);
 
   const versionIcon = getVersionIcon(versionInfo);
   const secondarySummary = getVersionSecondarySummary(versionInfo);
+  const timestamp = useMemo(() => createdAt && DateTime.fromISO(createdAt), [createdAt]);
 
   return (
     <div
@@ -86,8 +89,9 @@ export const ArtifactRow = ({ isSelected, clickHandler, version: versionInfo, re
     >
       <div className="row-content flex-container-v left sp-padding-m-top sp-padding-l-bottom sp-padding-s-xaxis">
         {(build?.number || build?.id) && (
-          <div className="flex-container-h sp-margin-s-bottom">
+          <div className="row-middle-section flex-container-h space-between middle sp-margin-s-bottom">
             <Pill bgColor={isSelected ? '#2e4b5f' : undefined} text={`#${build.number || build.id} ${name || ''}`} />
+            {timestamp && <RelativeTimestamp timestamp={timestamp} />}
           </div>
         )}
         <div className="row-middle-section flex-container-h space-between">

--- a/app/scripts/modules/core/src/managed/RelativeTimestamp.tsx
+++ b/app/scripts/modules/core/src/managed/RelativeTimestamp.tsx
@@ -1,0 +1,75 @@
+import React, { memo, useEffect, useState } from 'react';
+import { DateTime, Duration } from 'luxon';
+
+import { SETTINGS } from '../config';
+import { CopyToClipboard } from '../utils';
+import { useInterval, Tooltip } from '../presentation';
+
+export interface IRelativeTimestampProps {
+  timestamp: DateTime;
+  clickToCopy?: boolean;
+}
+
+const TIMEZONE = SETTINGS.feature.displayTimestampsInUserLocalTime ? undefined : SETTINGS.defaultTimeZone;
+
+const formatTimestamp = (timestamp: DateTime, distance: Duration) => {
+  if (distance.years || distance.months) {
+    if (timestamp.year === DateTime.local().setZone(TIMEZONE).year) {
+      return timestamp.toFormat('MMM d');
+    } else {
+      return timestamp.toFormat('MMM d, y');
+    }
+  } else if (distance.days) {
+    return distance.toFormat('d') + 'd';
+  } else if (distance.hours) {
+    return distance.toFormat('h') + 'h';
+  } else if (distance.minutes) {
+    return distance.toFormat('m') + 'm';
+  } else if (distance.seconds) {
+    return distance.toFormat('s') + 's';
+  } else {
+    return null;
+  }
+};
+
+const getDistanceFromNow = (timestamp: DateTime) =>
+  timestamp.diffNow().negate().shiftTo('years', 'months', 'days', 'hours', 'minutes', 'seconds');
+
+export const RelativeTimestamp = memo(
+  ({ timestamp: timestampInOriginalZone, clickToCopy }: IRelativeTimestampProps) => {
+    const timestamp = timestampInOriginalZone.setZone(TIMEZONE);
+    const [formattedTimestamp, setFormattedTimestamp] = useState(
+      formatTimestamp(timestamp, getDistanceFromNow(timestamp)),
+    );
+
+    const updateTimestamp = () => {
+      setFormattedTimestamp(formatTimestamp(timestamp, getDistanceFromNow(timestamp)));
+    };
+
+    useInterval(updateTimestamp, 1000);
+    useEffect(updateTimestamp, [timestamp]);
+
+    if (!formattedTimestamp) {
+      return null;
+    }
+
+    const absoluteTimestamp = timestamp.toFormat('yyyy-MM-dd HH:mm:ss ZZZZ');
+    const relativeTimestamp = (
+      <span className="text-regular text-italic" style={{ fontSize: 13, lineHeight: 1 }}>
+        {formattedTimestamp}
+      </span>
+    );
+
+    if (clickToCopy) {
+      return (
+        <CopyToClipboard
+          buttonInnerNode={relativeTimestamp}
+          text={absoluteTimestamp}
+          toolTip={`${absoluteTimestamp} (click to copy)`}
+        />
+      );
+    } else {
+      return <Tooltip value={absoluteTimestamp}>{relativeTimestamp}</Tooltip>;
+    }
+  },
+);

--- a/app/scripts/modules/core/src/managed/StatusCard.tsx
+++ b/app/scripts/modules/core/src/managed/StatusCard.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import classNames from 'classnames';
+import { DateTime } from 'luxon';
 
 import { IconNames } from '../presentation';
 
 import { StatusBubble } from './StatusBubble';
+import { RelativeTimestamp } from './RelativeTimestamp';
 
 import './StatusCard.less';
 
@@ -12,11 +14,20 @@ export interface IStatusCardProps {
   background?: boolean;
   iconName: IconNames;
   title: React.ReactNode;
+  timestamp?: DateTime;
   description?: React.ReactNode;
   actions?: React.ReactNode;
 }
 
-export const StatusCard = ({ appearance, background, iconName, title, description, actions }: IStatusCardProps) => (
+export const StatusCard = ({
+  appearance,
+  background,
+  iconName,
+  title,
+  timestamp,
+  description,
+  actions,
+}: IStatusCardProps) => (
   <div
     className={classNames(
       'StatusCard flex-container-h space-between middle wrap sp-padding-s-yaxis sp-padding-l-xaxis',
@@ -27,6 +38,9 @@ export const StatusCard = ({ appearance, background, iconName, title, descriptio
     <div className="flex-container-h middle">
       <div className="flex-container-h center middle sp-margin-l-right">
         <StatusBubble iconName={iconName} appearance={appearance} size="medium" />
+      </div>
+      <div className="sp-margin-m-right" style={{ minWidth: 24 }}>
+        {timestamp && <RelativeTimestamp timestamp={timestamp} clickToCopy={true} />}
       </div>
       <div className="flex-container-v sp-margin-xs-yaxis">
         <div className="text-bold">{title}</div>

--- a/app/scripts/modules/core/src/managed/constraints/ConstraintCard.tsx
+++ b/app/scripts/modules/core/src/managed/constraints/ConstraintCard.tsx
@@ -18,6 +18,7 @@ import {
   isConstraintSupported,
   isConstraintStateful,
   getConstraintIcon,
+  getConstraintTimestamp,
   getConstraintSummary,
   getConstraintActions,
 } from './constraintRegistry';
@@ -95,6 +96,7 @@ export const ConstraintCard = memo(
       <StatusCard
         appearance={getCardAppearance(constraint)}
         iconName={getConstraintIcon(type)}
+        timestamp={getConstraintTimestamp(constraint)}
         title={getConstraintSummary(constraint)}
         actions={
           actions && (


### PR DESCRIPTION
Couple of tightly related updates:
- We've been playing around with making time formatting less noisy and easier to scan. Today cards for constraints and deployment states include _a lot_ of text describing times, which are useful if you're very interested in the timing of that specific thing but tough to scan and process at a glance. What we're trying out first is a new relative timestamp which looks a lot like social media platforms (Twitter, Instagram, etc.) — things like `25s`, `1hr`, `3d`. When it gets beyond a month we switch to `Jan 28`, and when it moves into a different year we add `Jan 28, 2019`. The 'full' timestamp that is traditionally used across Spinnaker is available on hover, and in most places you can click on the abbreviated timestamp to copy the full one to your clipboard.

- We now have a `createdAt` date on artifact versions. This update surfaces that timestamp in the new abbreviated format on the sidebar, along with a longer format in the details pane. Soon we'll also start sorting versions for approval/deployment via this timestamp.

<details>
<summary>Version sidebar</summary>

**New `createdAt` timestamps**
<img width="437" alt="Screen Shot 2020-09-30 at 5 59 24 PM" src="https://user-images.githubusercontent.com/1850998/94754904-84c50d80-0347-11eb-8def-f77189cbe40c.png">

**On hover**
<img width="489" alt="Screen Shot 2020-09-30 at 5 59 43 PM" src="https://user-images.githubusercontent.com/1850998/94754912-8e4e7580-0347-11eb-9094-cd7ced236c9c.png">

**When more than 1 month in the past**
<img width="429" alt="Screen Shot 2020-09-30 at 6 02 56 PM" src="https://user-images.githubusercontent.com/1850998/94754919-98707400-0347-11eb-88b3-633e769f9d8e.png">

**When in a different year from the current one**
<img width="425" alt="Screen Shot 2020-09-30 at 6 03 30 PM" src="https://user-images.githubusercontent.com/1850998/94754932-a4f4cc80-0347-11eb-99da-b695b597089f.png">

</details>

<details>
<summary>Version details</summary>

**New timestamp treatment for environment/constraint cards, new "Created" timestamp**
<img width="1173" alt="Screen Shot 2020-09-30 at 6 00 04 PM" src="https://user-images.githubusercontent.com/1850998/94754978-c2299b00-0347-11eb-9194-6395c6ebb841.png">

**On hover (click to copy for all timestamps)**
<img width="1173" alt="Screen Shot 2020-09-30 at 6 00 16 PM" src="https://user-images.githubusercontent.com/1850998/94755001-d40b3e00-0347-11eb-8a1e-6f79dc49b0c2.png">

<img width="1174" alt="Screen Shot 2020-09-30 at 6 00 26 PM" src="https://user-images.githubusercontent.com/1850998/94755005-d7062e80-0347-11eb-9a8f-380e7cfd4593.png">


</details>

cc @gcomstock 