### PR TITLE
feat(core/managed): show failed, pending bubbles for any constraint type

### DIFF
--- a/app/scripts/modules/core/src/managed/ColumnHeader.less
+++ b/app/scripts/modules/core/src/managed/ColumnHeader.less
@@ -10,6 +10,7 @@
   font-size: 14px;
   margin-bottom: 16px;
   border-radius: 2px;
+  z-index: var(--layer-low);
 
   .column-header-icon {
     flex: 0 0 24px;


### PR DESCRIPTION
We've had some code for a while that will look for `manual-judgement` constraints in a `PENDING` status and throw them into status bubbles on the version sidebar. This change expands that logic in two ways:

1. We'll now surface _any_ constraint types, not just `manual-judgement`
2. We'll now show constraints with a `FAIL` or `OVERRIDE_FAIL` status using an error-colored bubble

As a bonus, I also threw in a one-liner to fix the z-index issue that made for an awkward scrolling experience (before and after below)

**Failed & rejected constraints**
<img width="428" alt="Screen Shot 2020-10-01 at 9 45 52 AM" src="https://user-images.githubusercontent.com/1850998/94839350-bb446c00-03cb-11eb-942d-a1140cc5671e.png">

**Scrolling (before and after)**
<img width="439" alt="Screen Shot 2020-10-01 at 9 45 10 AM" src="https://user-images.githubusercontent.com/1850998/94839274-9a7c1680-03cb-11eb-8156-91b23a7f7c17.png">
<img width="444" alt="Screen Shot 2020-10-01 at 9 44 30 AM" src="https://user-images.githubusercontent.com/1850998/94839282-9e0f9d80-03cb-11eb-9dec-d509468eeb2a.png">

cc @gcomstock 