### PR TITLE
chore(package): cloudfoundry@0.0.100 core@0.0.515 titus@0.0.146

### DIFF
--- a/app/scripts/modules/cloudfoundry/package.json
+++ b/app/scripts/modules/cloudfoundry/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/cloudfoundry",
   "license": "Apache-2.0",
-  "version": "0.0.99",
+  "version": "0.0.100",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/core",
   "license": "Apache-2.0",
-  "version": "0.0.514",
+  "version": "0.0.515",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/titus/package.json
+++ b/app/scripts/modules/titus/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/titus",
   "license": "Apache-2.0",
-  "version": "0.0.145",
+  "version": "0.0.146",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
## cloudfoundry@0.0.100

2c4a272f65a52ff35ae45a72a3618b682debb713 fix(cf): naming typo in EnvironmentVariables (#8613)

## core@0.0.515

d38e7c54e8aed27a52c1282ed55128bd445f859d fix(Oracle): Fixed Oracle object storage selection (#8588)

## titus@0.0.146

7400d6fcc94e0dc1234122e1837ab96571c113cd fix(titus): Do not check for autoscaling feature flag, always enable autoscaling (#8615)

PR created via `modules/publish.js`