### PR TITLE
feat(core/managed): scroll to selected version in sidebar, update scroll containers

### DIFF
--- a/app/scripts/modules/core/src/managed/ArtifactDetail.less
+++ b/app/scripts/modules/core/src/managed/ArtifactDetail.less
@@ -1,6 +1,7 @@
 .ArtifactDetail {
   background-color: var(--color-white);
-  padding: 16px 0 64px 16px;
+  padding: 16px 16px 64px 16px;
+  overflow-y: scroll;
 
   .detail-section-left {
     flex: 0 0 280px;

--- a/app/scripts/modules/core/src/managed/ArtifactDetail.tsx
+++ b/app/scripts/modules/core/src/managed/ArtifactDetail.tsx
@@ -233,7 +233,7 @@ export const ArtifactDetail = ({
     <>
       <ArtifactDetailHeader name={name} version={versionDetails} onRequestClose={onRequestClose} />
 
-      <div className="ArtifactDetail">
+      <div className="ArtifactDetail flex-grow">
         <div className="flex-container-h top sp-margin-xl-bottom">
           <div className="flex-container-h sp-group-margin-s-xaxis flex-none">
             <Button

--- a/app/scripts/modules/core/src/managed/ArtifactRow.less
+++ b/app/scripts/modules/core/src/managed/ArtifactRow.less
@@ -7,6 +7,14 @@
   border-radius: 2px;
   transition: background-color 150ms ease-in-out;
 
+  &:first-of-type {
+    margin-top: var(--m-spacing);
+  }
+
+  &:last-of-type {
+    margin-bottom: var(--m-spacing);
+  }
+
   &:not(.selected):hover {
     background-color: #e8eaf2;
   }
@@ -57,8 +65,8 @@
     position: absolute;
     height: 8px;
     bottom: 8px;
-    left: 8px;
-    right: 8px;
+    left: 12px;
+    right: 12px;
     z-index: 1;
     transition: height 150ms ease-in-out;
   }

--- a/app/scripts/modules/core/src/managed/ArtifactsList.tsx
+++ b/app/scripts/modules/core/src/managed/ArtifactsList.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo, useEffect, useRef, useState } from 'react';
 import classNames from 'classnames';
 import { DateTime } from 'luxon';
 
@@ -27,7 +27,7 @@ interface IArtifactsListProps {
 
 export function ArtifactsList({ artifacts, selectedVersion, versionSelected }: IArtifactsListProps) {
   return (
-    <div>
+    <>
       {artifacts.map(({ versions, name, reference }) =>
         versions.map((version) => (
           <ArtifactRow
@@ -42,7 +42,7 @@ export function ArtifactsList({ artifacts, selectedVersion, versionSelected }: I
           />
         )),
       )}
-    </div>
+    </>
   );
 }
 
@@ -77,6 +77,32 @@ interface IArtifactRowProps {
 export const ArtifactRow = ({ isSelected, clickHandler, version: versionInfo, reference, name }: IArtifactRowProps) => {
   const { version, displayName, createdAt, environments, build, git } = versionInfo;
   const [isHovered, setIsHovered] = useState(false);
+  const rowRef = useRef<HTMLDivElement>();
+
+  useEffect(() => {
+    // Why does the call to scrollIntoView() have to be deferred for 100ms? A couple reasons:
+    //
+    // 1. When quickly moving between versions, giving a very short window to cancel the scroll
+    //    makes the experience less janky. Nobody needs their sidebars to dance and shuffle.
+    // 2. For some reason trying to call scrollIntoView in the same event loop just does not
+    //    work at all. The same is true for a setTimeout with no delay. DOM read/write ops are weird
+    //    and there is not a great practical justification for solving that mystery here and now.
+    const timeout = setTimeout(() => {
+      if (isSelected && rowRef.current) {
+        // *** VERY BRITTLE ASSUMPTION WARNING ***
+        // This code assumes that the direct parent element of a row is the scrollable container.
+        // If a wrapper element of any kind is added, this code will need to be modified
+        // to search upward in the tree and find the scrollable container.
+        const { top, bottom } = rowRef.current.getBoundingClientRect();
+        const { top: parentTop, bottom: parentBottom } = rowRef.current.parentElement.getBoundingClientRect();
+        const isInView = top < parentBottom && bottom > parentTop;
+
+        !isInView && rowRef.current.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      }
+    }, 100);
+
+    return () => clearTimeout(timeout);
+  }, [isSelected, rowRef.current]);
 
   const versionIcon = getVersionIcon(versionInfo);
   const secondarySummary = getVersionSecondarySummary(versionInfo);
@@ -84,12 +110,13 @@ export const ArtifactRow = ({ isSelected, clickHandler, version: versionInfo, re
 
   return (
     <div
+      ref={rowRef}
       className={classNames('ArtifactRow', { selected: isSelected })}
       onClick={() => clickHandler({ reference, version })}
       onMouseOver={() => setIsHovered(true)}
       onMouseOut={() => setIsHovered(false)}
     >
-      <div className="row-content flex-container-v left sp-padding-m-top sp-padding-l-bottom sp-padding-s-xaxis">
+      <div className="row-content flex-container-v left sp-padding-m-top sp-padding-l-bottom sp-padding-m-xaxis">
         {(build?.number || build?.id) && (
           <div className="row-middle-section flex-container-h space-between middle sp-margin-s-bottom">
             <Pill bgColor={isSelected ? '#2e4b5f' : undefined} text={`#${build.number || build.id} ${name || ''}`} />

--- a/app/scripts/modules/core/src/managed/ColumnHeader.less
+++ b/app/scripts/modules/core/src/managed/ColumnHeader.less
@@ -1,25 +1,23 @@
 .ColumnHeader {
   background-color: rgb(100, 140, 175);
   display: flex;
-  position: sticky;
-  top: 0;
   height: 32px;
   justify-content: space-between;
   align-items: center;
   color: var(--color-white);
   font-size: 14px;
-  margin-bottom: 16px;
   border-radius: 2px;
   z-index: var(--layer-low);
+  flex: none;
 
   .column-header-icon {
     flex: 0 0 24px;
-    margin-left: 16px;
+    margin-left: 12px;
   }
 
   .column-header-text {
     flex: 1 1 1px;
     text-align: center;
-    margin: 0 16px;
+    margin: 0 12px;
   }
 }

--- a/app/scripts/modules/core/src/managed/Environments.less
+++ b/app/scripts/modules/core/src/managed/Environments.less
@@ -7,6 +7,10 @@
 
   .artifacts-column {
     padding-right: 16px;
+    overflow: hidden;
+  }
+
+  .artifacts-column-scroll-container {
     overflow: scroll;
   }
 

--- a/app/scripts/modules/core/src/managed/Environments.less
+++ b/app/scripts/modules/core/src/managed/Environments.less
@@ -16,12 +16,16 @@
 
   .environments-column {
     display: grid;
+    overflow: hidden;
+  }
+
+  .environments-column-scroll-container {
     overflow: scroll;
   }
 
   .environments-pane {
     grid-column: 1;
     grid-row: 1;
-    overflow: scroll;
+    overflow: hidden;
   }
 }

--- a/app/scripts/modules/core/src/managed/Environments.tsx
+++ b/app/scripts/modules/core/src/managed/Environments.tsx
@@ -140,17 +140,19 @@ export function Environments({ app }: IEnvironmentsProps) {
 
   return (
     <div className="Environments">
-      <div className="artifacts-column">
+      <div className="artifacts-column flex-container-v">
         <ColumnHeader text="Versions" icon="artifact" />
-        <ArtifactsList
-          artifacts={artifacts}
-          selectedVersion={selectedVersion}
-          versionSelected={(clickedVersion) => {
-            if (!isEqual(clickedVersion, selectedVersion)) {
-              go(selectedVersion ? '.' : '.artifactVersion', clickedVersion);
-            }
-          }}
-        />
+        <div className="artifacts-column-scroll-container">
+          <ArtifactsList
+            artifacts={artifacts}
+            selectedVersion={selectedVersion}
+            versionSelected={(clickedVersion) => {
+              if (!isEqual(clickedVersion, selectedVersion)) {
+                go(selectedVersion ? '.' : '.artifactVersion', clickedVersion);
+              }
+            }}
+          />
+        </div>
       </div>
       <div className="environments-column">
         {overviewPaneTransition.map(

--- a/app/scripts/modules/core/src/managed/Environments.tsx
+++ b/app/scripts/modules/core/src/managed/Environments.tsx
@@ -158,16 +158,24 @@ export function Environments({ app }: IEnvironmentsProps) {
         {overviewPaneTransition.map(
           ({ item: show, key, props }) =>
             show && (
-              <animated.div key={key} className="environments-pane" style={props}>
-                <ColumnHeader text="Environments" icon="environment" />
-                <EnvironmentsHeader
-                  app={app}
-                  resourceInfo={{
-                    managed: resources.filter((r) => !r.isPaused).length,
-                    total: resources.length,
-                  }}
-                />
-                <EnvironmentsList application={app} {...{ environments, artifacts, resourcesById }} />
+              <animated.div key={key} className="environments-pane flex-container-v" style={props}>
+                <div className="flex-container-v" style={{ overflow: 'hidden' }}>
+                  <div className="sp-margin-m-right">
+                    <ColumnHeader text="Environments" icon="environment" />
+                  </div>
+                  <div className="environments-column-scroll-container">
+                    <div className="sp-margin-m-yaxis sp-margin-m-right">
+                      <EnvironmentsHeader
+                        app={app}
+                        resourceInfo={{
+                          managed: resources.filter((r) => !r.isPaused).length,
+                          total: resources.length,
+                        }}
+                      />
+                      <EnvironmentsList application={app} {...{ environments, artifacts, resourcesById }} />
+                    </div>
+                  </div>
+                </div>
               </animated.div>
             ),
         )}

--- a/app/scripts/modules/core/src/managed/Environments.tsx
+++ b/app/scripts/modules/core/src/managed/Environments.tsx
@@ -182,7 +182,7 @@ export function Environments({ app }: IEnvironmentsProps) {
         {detailPaneTransition.map(
           ({ item, key, props }) =>
             item.selectedVersion && (
-              <animated.div key={key} className="environments-pane" style={props}>
+              <animated.div key={key} className="environments-pane flex-container-v" style={props}>
                 <ArtifactDetail
                   application={app}
                   name={item.selectedArtifactDetails.name}


### PR DESCRIPTION
Boy was this some "fun". Couple changes:

- Add some pretty 🙄 logic for scrolling to the currently selected version in the sidebar. This is especially helpful when clicking on a link to a version that's not in the most recent ~5-10, or in similar situations like clicking on the new "another version is pinned" warning to jump you to a different version. **I made an explicit decision to go with the lowest-effort approach here because I expect this code to change very quickly and didn't want to invest in optimizations yet**. I have expectations that we'll move to paging + virtualization in the foreseeable future, and at that point leaning on the virtualization library for this will probably make sense
- As part of doing the first thing, I tripped over a thing I've been putting off forever: the scroll containers on the list/detail layout are just terrible and I should be ashamed. This was mostly just causing weird visual behavior when scrollbars were shown up until now, but this change forced some adjustments that made it critical to refactor the scroll containers. I've taken the opportunity to not just adjust the containers functionally, but also tweak the layout slightly to make scrollbars jive aesthetically with the content more as well. Screenshots below.

<details>
<summary>Sidebar</summary>

**Before**
<img width="441" alt="Screen Shot 2020-10-02 at 2 59 58 PM (2)" src="https://user-images.githubusercontent.com/1850998/94973265-0d66b980-04c0-11eb-8d87-c8b110c98a82.png">

**After**
<img width="386" alt="Screen Shot 2020-10-02 at 2 23 52 PM (2)" src="https://user-images.githubusercontent.com/1850998/94973129-c1b41000-04bf-11eb-8d6c-ad46e2948b75.png">

</details>

<details>
<summary>Overview</summary>

**Before**
<img width="1095" alt="Screen Shot 2020-10-02 at 3 02 01 PM (2)" src="https://user-images.githubusercontent.com/1850998/94973342-49018380-04c0-11eb-9e6f-309bea8daaec.png">

**After**
<img width="1038" alt="Screen Shot 2020-10-02 at 2 34 37 PM (2)" src="https://user-images.githubusercontent.com/1850998/94973275-16578b00-04c0-11eb-87b5-6c10817d8951.png">

</details>

<details>
<summary>Version details</summary>

**Before**
<img width="1098" alt="Screen Shot 2020-10-02 at 3 02 45 PM (2)" src="https://user-images.githubusercontent.com/1850998/94973386-67677f00-04c0-11eb-8104-2b5c3be55cda.png">

**After**
<img width="1083" alt="Screen Shot 2020-10-02 at 3 03 36 PM (2)" src="https://user-images.githubusercontent.com/1850998/94973426-89610180-04c0-11eb-95f3-c63effd8af1b.png">

</details>


cc @gcomstock