### PR TITLE
fix(core/managed): fixup some details from new layout

### DIFF
--- a/app/scripts/modules/core/src/managed/StatusBubble.tsx
+++ b/app/scripts/modules/core/src/managed/StatusBubble.tsx
@@ -16,11 +16,11 @@ export interface IStatusBubbleProps {
 }
 
 const paddingBySize = {
-  extraSmall: '4px',
-  small: '6px',
-  medium: '8px',
-  large: '8px',
-  extraLarge: '12px',
+  extraSmall: 4,
+  small: 6,
+  medium: 8,
+  large: 8,
+  extraLarge: 12,
 } as const;
 
 const iconColorByAppearance = {
@@ -74,7 +74,9 @@ export const StatusBubble = memo(({ appearance, iconName, size, quantity }: ISta
         <animated.div className="status-bubble-content" key={key} style={props}>
           <div
             className={classNames(['icon-wrapper', `status-${appearance}`, { 'with-quantity': !!quantityPill }])}
-            style={{ padding: paddingBySize[size] }}
+            // The 'inactive' status includes a 1px border, which throws off the size of the bubble.
+            // We need to compensate by taking a pixel off the padding.
+            style={{ padding: appearance === 'inactive' ? paddingBySize[size] - 1 : paddingBySize[size] }}
           >
             <div className="icon-container">
               <Icon appearance={iconColorByAppearance[appearance]} name={item} size={size} />

--- a/app/scripts/modules/core/src/managed/StatusCard.tsx
+++ b/app/scripts/modules/core/src/managed/StatusCard.tsx
@@ -39,7 +39,7 @@ export const StatusCard = ({
       <div className="flex-container-h center middle sp-margin-l-right">
         <StatusBubble iconName={iconName} appearance={appearance} size="medium" />
       </div>
-      <div className="sp-margin-m-right" style={{ minWidth: 24 }}>
+      <div className="sp-margin-m-right" style={{ minWidth: 33 }}>
         {timestamp && <RelativeTimestamp timestamp={timestamp} clickToCopy={true} />}
       </div>
       <div className="flex-container-v sp-margin-xs-yaxis">


### PR DESCRIPTION
Cleaning up a couple one-line messes I made with some previous PRs:

- There's a 1px border on the 'inactive' status bubble now, which was making it 2px bigger in diameter than other bubbles and causing some layout jank when switching between versions. Removed a pixel of padding to compensate
- When relative timestamps grow to three characters (e.g. `21d`) they're busting out of the minimum width of the timestamp column on status cards, which leads to text misalignment. I explicitly chose to be ok with that for timestamps that cross into the longer format (e.g. `Jan 28`) for now, but I'm bumping the minimum width so that any abbreviated timestamps retain the standard column size

cc @gcomstock 