### PR TITLE
feat(core/managed): put constraints in a 'skipped' state on skipped versions

### DIFF
--- a/app/scripts/modules/core/src/domain/IManagedEntity.ts
+++ b/app/scripts/modules/core/src/domain/IManagedEntity.ts
@@ -136,6 +136,8 @@ export interface IManagedArtifactVersion {
   };
 }
 
+export type IManagedArtifactVersionEnvironment = IManagedArtifactSummary['versions'][0]['environments'][0];
+
 export interface IManagedArtifactSummary {
   name: string;
   type: string;

--- a/app/scripts/modules/core/src/managed/ArtifactDetail.tsx
+++ b/app/scripts/modules/core/src/managed/ArtifactDetail.tsx
@@ -9,6 +9,7 @@ import {
   IManagedArtifactVersion,
   IManagedEnvironmentSummary,
   IManagedResourceSummary,
+  IManagedArtifactVersionEnvironment,
 } from '../domain';
 import { Application } from '../application';
 import { useEventListener, Markdown } from '../presentation';
@@ -66,14 +67,21 @@ type IEnvironmentCardsProps = Pick<
   IArtifactDetailProps,
   'application' | 'reference' | 'version' | 'allVersions' | 'resourcesByEnvironment'
 > & {
-  environment: IManagedArtifactSummary['versions'][0]['environments'][0];
+  environment: IManagedArtifactVersionEnvironment;
   pinnedVersion: string;
 };
 
 const EnvironmentCards = memo(
   ({
     application,
-    environment: {
+    environment,
+    reference,
+    version: versionDetails,
+    allVersions,
+    pinnedVersion,
+    resourcesByEnvironment,
+  }: IEnvironmentCardsProps) => {
+    const {
       name: environmentName,
       state,
       deployedAt,
@@ -83,13 +91,7 @@ const EnvironmentCards = memo(
       vetoed,
       statefulConstraints,
       statelessConstraints,
-    },
-    reference,
-    version: versionDetails,
-    allVersions,
-    pinnedVersion,
-    resourcesByEnvironment,
-  }: IEnvironmentCardsProps) => {
+    } = environment;
     const {
       stateService: { go },
     } = useRouter();
@@ -156,7 +158,7 @@ const EnvironmentCards = memo(
             <ConstraintCard
               key={constraint.type}
               application={application}
-              environment={environmentName}
+              environment={environment}
               reference={reference}
               version={versionDetails.version}
               constraint={constraint}

--- a/app/scripts/modules/core/src/managed/ArtifactsList.tsx
+++ b/app/scripts/modules/core/src/managed/ArtifactsList.tsx
@@ -8,7 +8,7 @@ import {
   IStatefulConstraint,
   StatefulConstraintStatus,
 } from '../domain/IManagedEntity';
-import { Icon } from '../presentation';
+import { Icon, IconNames } from '../presentation';
 
 import { isConstraintSupported, getConstraintIcon } from './constraints/constraintRegistry';
 
@@ -140,28 +140,35 @@ function getArtifactStatuses({ environments }: IManagedArtifactVersion): Artifac
   // NOTE: The order in which entries are added to `statuses` is important. The highest priority
   // item must be inserted first.
 
-  const pendingConstraintTypes = new Set<string>();
-  const failedConstraintTypes = new Set<string>();
+  const pendingConstraintIcons = new Set<IconNames>();
+  const failedConstraintIcons = new Set<IconNames>();
 
-  environments.forEach((environment) =>
-    environment.statefulConstraints?.forEach(({ type, status }: IStatefulConstraint) => {
-      if (!isConstraintSupported(type)) {
+  environments.forEach((environment) => {
+    if (environment.state === 'skipped') {
+      return;
+    }
+
+    environment.statefulConstraints?.forEach((constraint: IStatefulConstraint) => {
+      if (!isConstraintSupported(constraint.type)) {
         return;
       }
 
-      if (status === StatefulConstraintStatus.PENDING) {
-        pendingConstraintTypes.add(type);
-      } else if (status === StatefulConstraintStatus.FAIL || status === StatefulConstraintStatus.OVERRIDE_FAIL) {
-        failedConstraintTypes.add(type);
+      if (constraint.status === StatefulConstraintStatus.PENDING) {
+        pendingConstraintIcons.add(getConstraintIcon(constraint));
+      } else if (
+        constraint.status === StatefulConstraintStatus.FAIL ||
+        constraint.status === StatefulConstraintStatus.OVERRIDE_FAIL
+      ) {
+        failedConstraintIcons.add(getConstraintIcon(constraint));
       }
-    }),
-  );
-
-  pendingConstraintTypes.forEach((type) => {
-    statuses.push({ appearance: 'progress', iconName: getConstraintIcon(type) });
+    });
   });
-  failedConstraintTypes.forEach((type) => {
-    statuses.push({ appearance: 'error', iconName: getConstraintIcon(type) });
+
+  pendingConstraintIcons.forEach((iconName) => {
+    statuses.push({ appearance: 'progress', iconName });
+  });
+  failedConstraintIcons.forEach((iconName) => {
+    statuses.push({ appearance: 'error', iconName });
   });
 
   const isPinned = environments.some(({ pinned }) => pinned);

--- a/app/scripts/modules/core/src/managed/StatusBubble.less
+++ b/app/scripts/modules/core/src/managed/StatusBubble.less
@@ -31,7 +31,7 @@
     justify-content: center;
   }
 
-  .status-inactive {
+  .status-future {
     border: 1px dotted var(--color-icon-neutral);
   }
 

--- a/app/scripts/modules/core/src/managed/StatusBubble.tsx
+++ b/app/scripts/modules/core/src/managed/StatusBubble.tsx
@@ -10,7 +10,7 @@ const QUANITITY_SIZES = ['small', 'medium', 'large', 'extraLarge'];
 
 export interface IStatusBubbleProps {
   iconName: IconNames;
-  appearance: 'inactive' | 'neutral' | 'info' | 'progress' | 'success' | 'warning' | 'error' | 'archived';
+  appearance: 'future' | 'neutral' | 'info' | 'progress' | 'success' | 'warning' | 'error' | 'archived';
   size: 'extraSmall' | 'small' | 'medium' | 'large' | 'extraLarge';
   quantity?: string | number;
 }
@@ -24,7 +24,7 @@ const paddingBySize = {
 } as const;
 
 const iconColorByAppearance = {
-  inactive: 'neutral',
+  future: 'neutral',
   neutral: 'neutral',
   info: 'neutral',
   progress: 'neutral',
@@ -74,9 +74,9 @@ export const StatusBubble = memo(({ appearance, iconName, size, quantity }: ISta
         <animated.div className="status-bubble-content" key={key} style={props}>
           <div
             className={classNames(['icon-wrapper', `status-${appearance}`, { 'with-quantity': !!quantityPill }])}
-            // The 'inactive' status includes a 1px border, which throws off the size of the bubble.
+            // The 'future' status includes a 1px border, which throws off the size of the bubble.
             // We need to compensate by taking a pixel off the padding.
-            style={{ padding: appearance === 'inactive' ? paddingBySize[size] - 1 : paddingBySize[size] }}
+            style={{ padding: appearance === 'future' ? paddingBySize[size] - 1 : paddingBySize[size] }}
           >
             <div className="icon-container">
               <Icon appearance={iconColorByAppearance[appearance]} name={item} size={size} />

--- a/app/scripts/modules/core/src/managed/StatusCard.less
+++ b/app/scripts/modules/core/src/managed/StatusCard.less
@@ -1,9 +1,14 @@
 .StatusCard {
   font-size: 13px;
-  color: var(--color-charcoal);
+  color: var(--color-icon-neutral);
   border-bottom: 1px dashed rgba(0, 0, 0, 0.2);
 
-  &.status-card-inactive {
+  &.active {
+    color: var(--color-charcoal);
+  }
+
+  // Need to override this, because the 'future' status should always appear inactive
+  &.status-card-future.active {
     color: var(--color-icon-neutral);
   }
 

--- a/app/scripts/modules/core/src/managed/StatusCard.tsx
+++ b/app/scripts/modules/core/src/managed/StatusCard.tsx
@@ -10,8 +10,9 @@ import { RelativeTimestamp } from './RelativeTimestamp';
 import './StatusCard.less';
 
 export interface IStatusCardProps {
-  appearance: 'inactive' | 'neutral' | 'info' | 'progress' | 'success' | 'warning' | 'error' | 'archived';
+  appearance: 'future' | 'neutral' | 'info' | 'progress' | 'success' | 'warning' | 'error' | 'archived';
   background?: boolean;
+  active?: boolean;
   iconName: IconNames;
   title: React.ReactNode;
   timestamp?: DateTime;
@@ -22,6 +23,7 @@ export interface IStatusCardProps {
 export const StatusCard = ({
   appearance,
   background,
+  active,
   iconName,
   title,
   timestamp,
@@ -32,7 +34,7 @@ export const StatusCard = ({
     className={classNames(
       'StatusCard flex-container-h space-between middle wrap sp-padding-s-yaxis sp-padding-l-xaxis',
       `status-card-${appearance}`,
-      { 'with-background': !!background },
+      { 'with-background': !!background, active: active ?? true },
     )}
   >
     <div className="flex-container-h middle">

--- a/app/scripts/modules/core/src/managed/VersionStateCard.tsx
+++ b/app/scripts/modules/core/src/managed/VersionStateCard.tsx
@@ -26,12 +26,12 @@ interface CardAppearance {
 const cardAppearanceByState: { [state: string]: CardAppearance } = {
   pending: {
     icon: 'artifactPending',
-    appearance: 'inactive',
+    appearance: 'future',
     title: (_: CardTitleMetadata) => 'Not deployed yet',
   },
   skipped: {
     icon: 'artifactSkipped',
-    appearance: 'inactive',
+    appearance: 'future',
     title: ({ replacedByVersionName }: CardTitleMetadata) => (
       <span className="sp-group-margin-xs-xaxis">
         <span>Skipped</span> <span className="text-regular">—</span>{' '}


### PR DESCRIPTION
When a version becomes `skipped` in an environment, constraints are no longer evaluated and version is mostly forgotten, never to be heard from again. The exception would be if you manipulate the normal flow of versions via pinning/marking as bad, which would forcefully switch their state to something else.

Despite this relative irrelevance, constraints on skipped versions continue to appear very meaningful and important because they don't actually change state in any way. [We've discussed adding a `SKIPPED` status on the backend](https://github.com/spinnaker/keel/issues/1267), but there are some pretty big, pretty urgent fish to fry in keel that should get attention first. This change makes a low-effort attempt to patch over the lack of a `SKIPPED` status by checking for the `skipped` state on environments in client side code.

I've elected to make a few design decisions that may or may not be good:
- If a version is skipped in an environment, I'm not considering _any_ pending or failed constraints as worthy of showing up in the sidebar. I think failed constraints are the one I'm unsure about here — do people want to see a big red bubble on the sidebar for something that's skipped?
- When stateful constraints are PENDING or NOT_EVALUATED, I'm switching them to a new skipped state that says something like "manual judgement skipped" and doesn't have buttons/a timestamp. If they are FAIL or PASS, though, I'm retaining that data as I think it's useful, but visually greying it out so it's relative importance is accurately portrayed
- For stateless constraints, I'm adding a `skipped` handler that can check whether the constraint is passing. On the depends-on constraint I'm still showing the 'already deployed to...' message if it's passing, because again I think that's useful information


<details>
<summary>Sidebar</summary>

**Before**
<img width="395" alt="Screen Shot 2020-10-02 at 5 53 38 PM" src="https://user-images.githubusercontent.com/1850998/94979954-cd610000-04da-11eb-8220-4028c3b3bb77.png">

**After**
<img width="421" alt="Screen Shot 2020-10-02 at 5 53 13 PM" src="https://user-images.githubusercontent.com/1850998/94979955-d0f48700-04da-11eb-87b1-5f1881ed2320.png">

</details>

<details>
<summary>Pending stateful constraint</summary>

**Before**
<img width="524" alt="Screen Shot 2020-10-02 at 5 53 48 PM" src="https://user-images.githubusercontent.com/1850998/94979915-8ffc7280-04da-11eb-9ffc-345ec89fc9a5.png">

**After**
<img width="512" alt="Screen Shot 2020-10-02 at 5 57 15 PM" src="https://user-images.githubusercontent.com/1850998/94979918-938ff980-04da-11eb-96e3-3ce888db4954.png">

</details>

<details>
<summary>Pass/fail stateful constraint</summary>

**Before**
<img width="497" alt="Screen Shot 2020-10-02 at 6 09 23 PM" src="https://user-images.githubusercontent.com/1850998/94979922-9a1e7100-04da-11eb-8301-463fb1a9be4f.png">

**After**
<img width="495" alt="Screen Shot 2020-10-02 at 5 52 12 PM" src="https://user-images.githubusercontent.com/1850998/94979928-a0ace880-04da-11eb-9787-1c6367d27db7.png">

</details>


@gcomstock I would love your input on any/all of these choices