### PR TITLE
feat(core/managed): apply consistent sorting to resources

### DIFF
--- a/app/scripts/modules/core/src/managed/ArtifactDetail.tsx
+++ b/app/scripts/modules/core/src/managed/ArtifactDetail.tsx
@@ -326,6 +326,7 @@ export const ArtifactDetail = ({
               <div className="sp-margin-l-top">
                 {resourcesByEnvironment[environmentName]
                   .filter((resource) => shouldDisplayResource(reference, resource))
+                  .sort((a, b) => `${a.kind}${a.displayName}`.localeCompare(`${b.kind}${b.displayName}`))
                   .map((resource) => (
                     <div key={resource.id} className="flex-container-h middle">
                       {state === 'deploying' && (

--- a/app/scripts/modules/core/src/managed/EnvironmentsList.tsx
+++ b/app/scripts/modules/core/src/managed/EnvironmentsList.tsx
@@ -41,6 +41,7 @@ export function EnvironmentsList({
             {resources
               .map((resourceId) => resourcesById[resourceId])
               .filter(shouldDisplayResource)
+              .sort((a, b) => `${a.kind}${a.displayName}`.localeCompare(`${b.kind}${b.displayName}`))
               .map((resource) => {
                 const artifactVersionsByState =
                   resource.artifact &&


### PR DESCRIPTION
Teeny tiny sorting tweak: let's sort resources by their `kind`, and then their `displayName` within that. This means that resources of the same kind will be grouped together, and within each group they'll be sorted alphabetically.

(cc @gcomstock)