### PR TITLE
feat(core/managed): limit artifact versions to 30

### DIFF
--- a/app/scripts/modules/core/src/managed/ManagedReader.ts
+++ b/app/scripts/modules/core/src/managed/ManagedReader.ts
@@ -36,7 +36,7 @@ export const getResourceKindForLoadBalancerType = (type: string) => {
 const transformManagedResourceDiff = (diff: IManagedResourceEventHistoryResponse[0]['delta']): IManagedResourceDiff =>
   Object.keys(diff).reduce((transformed, key) => {
     const diffNode = diff[key];
-    const fieldKeys = flatMap<string, string>(key.split('/').filter(Boolean), fieldKey => {
+    const fieldKeys = flatMap<string, string>(key.split('/').filter(Boolean), (fieldKey) => {
       // Region keys currently come wrapped in {}, which is distracting and not useful. Let's trim those off.
       if (fieldKey.startsWith('{') && fieldKey.endsWith('}')) {
         return fieldKey.substring(1, fieldKey.length - 1);
@@ -74,10 +74,10 @@ export class ManagedReader {
     // Individual resources don't update their status when an application is paused/resumed,
     // so for now let's swap to a PAUSED status and keep things simpler in downstream components.
     if (response.applicationPaused) {
-      response.resources.forEach(resource => (resource.status = ManagedResourceStatus.PAUSED));
+      response.resources.forEach((resource) => (resource.status = ManagedResourceStatus.PAUSED));
     }
 
-    response.resources.forEach(resource => (resource.isPaused = resource.status === ManagedResourceStatus.PAUSED));
+    response.resources.forEach((resource) => (resource.isPaused = resource.status === ManagedResourceStatus.PAUSED));
 
     return response;
   }
@@ -93,7 +93,7 @@ export class ManagedReader {
   public static getEnvironmentsSummary(app: string): IPromise<IManagedApplicationEnvironmentSummary> {
     return API.one('managed')
       .one('application', app)
-      .withParams({ entities: ['resources', 'artifacts', 'environments'] })
+      .withParams({ entities: ['resources', 'artifacts', 'environments'], maxArtifactVersions: 30 })
       .get()
       .then(this.decorateResources);
   }
@@ -103,7 +103,7 @@ export class ManagedReader {
       .withParams({ limit: 100 })
       .get()
       .then((response: IManagedResourceEventHistoryResponse) => {
-        response.forEach(event => {
+        response.forEach((event) => {
           if (event.delta) {
             ((event as unknown) as IManagedResourceEvent).delta = transformManagedResourceDiff(event.delta);
           }


### PR DESCRIPTION
As part of trying to do some short-term tweaks to improve Environments performance, this change caps the maximum number of artifact versions we fetch to 30. Above 30 I begin to see increased variability in latency that I'm not super comfortable with (i.e. getting >3s latency on a percentage of calls).