### PR TITLE
chore(eslint): eslint --fix api-no-slashes

### DIFF
--- a/app/scripts/modules/amazon/src/image/image.reader.ts
+++ b/app/scripts/modules/amazon/src/image/image.reader.ts
@@ -27,7 +27,7 @@ export class AwsImageReader {
       return $q.when([{ message: 'Please enter at least 3 characters...', disabled: true }]) as any;
     }
 
-    return API.one('images/find')
+    return API.one('images', 'find')
       .withParams(params)
       .get()
       .catch(() => [] as IAmazonImage[]);

--- a/app/scripts/modules/azure/src/image/image.reader.js
+++ b/app/scripts/modules/azure/src/image/image.reader.js
@@ -6,15 +6,15 @@ import { API } from '@spinnaker/core';
 
 export const AZURE_IMAGE_IMAGE_READER = 'spinnaker.azure.image.reader';
 export const name = AZURE_IMAGE_IMAGE_READER; // for backwards compatibility
-module(AZURE_IMAGE_IMAGE_READER, []).factory('azureImageReader', function() {
+module(AZURE_IMAGE_IMAGE_READER, []).factory('azureImageReader', function () {
   function findImages(params) {
-    return API.one('images/find')
+    return API.one('images', 'find')
       .get(params)
       .then(
-        function(results) {
+        function (results) {
           return results;
         },
-        function() {
+        function () {
           return [];
         },
       );
@@ -28,10 +28,10 @@ module(AZURE_IMAGE_IMAGE_READER, []).factory('azureImageReader', function() {
       .withParams({ provider: 'azure' })
       .get()
       .then(
-        function(results) {
+        function (results) {
           return results && results.length ? results[0] : null;
         },
-        function() {
+        function () {
           return null;
         },
       );

--- a/app/scripts/modules/cloudfoundry/src/image/image.reader.cf.ts
+++ b/app/scripts/modules/cloudfoundry/src/image/image.reader.cf.ts
@@ -6,13 +6,13 @@ import { ICloudFoundryCluster } from 'cloudfoundry/domain';
 
 export class CloudFoundryImageReader {
   public static findImages(account: string): IPromise<ICloudFoundryCluster[]> {
-    return API.one('images/find')
+    return API.one('images', 'find')
       .withParams({
         account,
         provider: 'cloudfoundry',
       })
       .get()
-      .then(function(results: any) {
+      .then(function (results: any) {
         return results;
       })
       .catch((): any[] => []);

--- a/app/scripts/modules/core/src/pagerDuty/pagerDuty.read.service.ts
+++ b/app/scripts/modules/core/src/pagerDuty/pagerDuty.read.service.ts
@@ -24,10 +24,10 @@ export interface IOnCall {
 
 export class PagerDutyReader {
   public static listServices(): Observable<IPagerDutyService[]> {
-    return Observable.fromPromise(API.one('pagerDuty/services').getList());
+    return Observable.fromPromise(API.one('pagerDuty', 'services').getList());
   }
 
   public static listOnCalls(): Observable<{ [id: string]: IOnCall[] }> {
-    return Observable.fromPromise(API.one('pagerDuty/oncalls').getList());
+    return Observable.fromPromise(API.one('pagerDuty', 'oncalls').getList());
   }
 }

--- a/app/scripts/modules/core/src/pipeline/config/stages/gremlin/GremlinStageConfig.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/stages/gremlin/GremlinStageConfig.tsx
@@ -43,7 +43,7 @@ export class GremlinStageConfig extends React.Component<IStageConfigProps> {
 
   private fetchCommands = (apiKey: string) => {
     return Observable.fromPromise(
-      API.one('integrations/gremlin/templates/command')
+      API.one('integrations', 'gremlin', 'templates', 'command')
         .post({
           apiKey,
         })
@@ -61,7 +61,7 @@ export class GremlinStageConfig extends React.Component<IStageConfigProps> {
 
   private fetchTargets = (apiKey: string) => {
     return Observable.fromPromise(
-      API.one('integrations/gremlin/templates/target')
+      API.one('integrations', 'gremlin', 'templates', 'target')
         .post({
           apiKey,
         })
@@ -88,7 +88,7 @@ export class GremlinStageConfig extends React.Component<IStageConfigProps> {
     });
 
     // Get the data from all the necessary sources before rendering
-    Observable.forkJoin(this.fetchCommands(gremlinApiKey), this.fetchTargets(gremlinApiKey)).subscribe(results => {
+    Observable.forkJoin(this.fetchCommands(gremlinApiKey), this.fetchTargets(gremlinApiKey)).subscribe((results) => {
       const newState: IState = {
         isFetchingData: false,
       };
@@ -125,11 +125,11 @@ export class GremlinStageConfig extends React.Component<IStageConfigProps> {
     // Provides access to meta information for summary box
     const selectedCommandTemplateMeta =
       commands.length && stage.gremlinCommandTemplateId
-        ? commands.find(command => command.guid === stage.gremlinCommandTemplateId)
+        ? commands.find((command) => command.guid === stage.gremlinCommandTemplateId)
         : {};
     const selectedTargetTemplateMeta =
       targets.length && stage.gremlinTargetTemplateId
-        ? targets.find(target => target.guid === stage.gremlinTargetTemplateId)
+        ? targets.find((target) => target.guid === stage.gremlinTargetTemplateId)
         : {};
 
     return (
@@ -141,7 +141,7 @@ export class GremlinStageConfig extends React.Component<IStageConfigProps> {
               className="form-control input"
               type="text"
               value={stage.gremlinApiKey || ''}
-              onChange={e => this.onChange(e.target.name, e.target.value)}
+              onChange={(e) => this.onChange(e.target.name, e.target.value)}
             />
             <div className="form-control-static" style={{ paddingBottom: 0 }}>
               <div className="flex-container-h middle margin-between-md">
@@ -177,7 +177,7 @@ export class GremlinStageConfig extends React.Component<IStageConfigProps> {
             ) : (
               <Select
                 name="gremlinTargetTemplateId"
-                options={targets.map(target => ({
+                options={targets.map((target) => ({
                   label: target.name,
                   value: target.guid,
                 }))}
@@ -197,7 +197,7 @@ export class GremlinStageConfig extends React.Component<IStageConfigProps> {
             ) : (
               <Select
                 name="gremlinCommandTemplateId"
-                options={commands.map(command => ({
+                options={commands.map((command) => ({
                   label: command.name,
                   value: command.guid,
                 }))}

--- a/app/scripts/modules/core/src/plugins/plugin.registry.ts
+++ b/app/scripts/modules/core/src/plugins/plugin.registry.ts
@@ -33,7 +33,7 @@ export class PluginRegistry {
 
   registerPluginMetaData(source: ISource, pluginMetaData: IPluginMetaData): INormalizedPluginMetaData | undefined {
     const metaData = this.normalize(source, pluginMetaData);
-    const duplicateMetaData = this.pluginManifests.find(x => x.id === metaData.id);
+    const duplicateMetaData = this.pluginManifests.find((x) => x.id === metaData.id);
 
     // Handle duplicate plugin ids
     if (duplicateMetaData) {
@@ -45,7 +45,7 @@ export class PluginRegistry {
         // eslint-disable-next-line no-console
         console.log(`Attempted to load plugin ${pluginMetaData.id} from gate and deck.   Using plugin from deck.`);
         if (source === 'deck') {
-          this.pluginManifests = this.pluginManifests.filter(x => x !== duplicateMetaData);
+          this.pluginManifests = this.pluginManifests.filter((x) => x !== duplicateMetaData);
         } else if (source === 'gate') {
           return undefined;
         }
@@ -74,7 +74,7 @@ export class PluginRegistry {
       throw new Error(`Invalid plugin manifest: received ${pluginMetaData} object`);
     }
     const keys: Array<keyof IPluginMetaData> = ['id', 'version'];
-    const missingKeys = keys.filter(key => !pluginMetaData[key]);
+    const missingKeys = keys.filter((key) => !pluginMetaData[key]);
     if (missingKeys.length) {
       throw new Error(`Invalid plugin manifest: Required key is missing: '${missingKeys.join(', ')}'`);
     }
@@ -85,7 +85,7 @@ export class PluginRegistry {
     const source = 'deck';
     const uri = '/plugin-manifest.json';
     const loadPromise = Promise.resolve($http.get<IPluginMetaData[]>(uri))
-      .then(response => response.data)
+      .then((response) => response.data)
       .catch((error: any) => {
         console.error(`Failed to load ${uri} from ${source}`);
         throw error;
@@ -97,8 +97,8 @@ export class PluginRegistry {
   /** Loads plugin manifest file served from gate */
   public loadPluginManifestFromGate() {
     const source = 'gate';
-    const uri = '/plugins/deck/plugin-manifest.json';
-    const loadPromise = API.one(uri)
+    const uri = 'plugins/deck/plugin-manifest.json';
+    const loadPromise = API.one(...uri.split('/'))
       .get()
       .catch((error: any) => {
         console.error(`Failed to load ${uri} from ${source}`);
@@ -126,7 +126,7 @@ export class PluginRegistry {
   ): Promise<IPluginMetaData[]> {
     try {
       const plugins = await pluginsMetaDataPromise;
-      return plugins.map(pluginMetaData => this.registerPluginMetaData(source, pluginMetaData));
+      return plugins.map((pluginMetaData) => this.registerPluginMetaData(source, pluginMetaData));
     } catch (error) {
       console.error(`Error loading plugin manifest from ${location}`);
       throw error;
@@ -134,7 +134,7 @@ export class PluginRegistry {
   }
 
   public loadPlugins(): Promise<any[]> {
-    return Promise.all(this.pluginManifests.map(plugin => this.load(plugin)));
+    return Promise.all(this.pluginManifests.map((plugin) => this.load(plugin)));
   }
 
   private async load(pluginMetaData: IPluginMetaData) {

--- a/app/scripts/modules/core/src/slack/SlackReader.spec.ts
+++ b/app/scripts/modules/core/src/slack/SlackReader.spec.ts
@@ -32,7 +32,7 @@ describe('SlackReader', () => {
     await SlackReader.getChannels().then((channels: ISlackChannel[]) => {
       expect(SlackReader.getChannels).toHaveBeenCalled();
       expect(channels.length).toEqual(2);
-      expect(API.one).toHaveBeenCalledWith('slack/channels');
+      expect(API.one).toHaveBeenCalledWith('slack', 'channels');
     });
   });
 });

--- a/app/scripts/modules/core/src/slack/SlackReader.ts
+++ b/app/scripts/modules/core/src/slack/SlackReader.ts
@@ -13,7 +13,7 @@ export interface ISlackChannel {
 
 export class SlackReader {
   public static getChannels(): IPromise<ISlackChannel[]> {
-    return API.one('slack/channels')
+    return API.one('slack', 'channels')
       .getList()
       .catch(() => [] as ISlackChannel[]);
   }

--- a/app/scripts/modules/dcos/image/image.reader.js
+++ b/app/scripts/modules/dcos/image/image.reader.js
@@ -6,15 +6,15 @@ import { module } from 'angular';
 
 export const DCOS_IMAGE_IMAGE_READER = 'spinnaker.dcos.image.reader';
 export const name = DCOS_IMAGE_IMAGE_READER; // for backwards compatibility
-module(DCOS_IMAGE_IMAGE_READER, []).factory('dcosImageReader', function() {
+module(DCOS_IMAGE_IMAGE_READER, []).factory('dcosImageReader', function () {
   function findImages(params) {
-    return API.all('images/find')
+    return API.all('images', 'find')
       .getList(params)
       .then(
-        function(results) {
+        function (results) {
           return results;
         },
-        function() {
+        function () {
           return [];
         },
       );

--- a/app/scripts/modules/docker/src/image/DockerImageReader.ts
+++ b/app/scripts/modules/docker/src/image/DockerImageReader.ts
@@ -23,7 +23,7 @@ export class DockerImageReader {
 
   public static findImages(params: IFindImageParams): IPromise<IDockerImage[]> {
     return RetryService.buildRetrySequence<IDockerImage[]>(
-      () => API.all('images/find').getList(params),
+      () => API.all('images', 'find').getList(params),
       (results: IDockerImage[]) => results.length > 0,
       10,
       1000,
@@ -34,7 +34,7 @@ export class DockerImageReader {
 
   public static findTags(params: IFindTagsParams): IPromise<string[]> {
     return RetryService.buildRetrySequence<string[]>(
-      () => API.all('images/tags').getList(params),
+      () => API.all('images', 'tags').getList(params),
       (results: string[]) => results.length > 0,
       10,
       1000,

--- a/app/scripts/modules/google/src/image/image.reader.ts
+++ b/app/scripts/modules/google/src/image/image.reader.ts
@@ -8,7 +8,7 @@ export interface IGceImage {
 
 export class GceImageReader {
   public static findImages(params: { account?: string; provider?: string; q?: string }): IPromise<IGceImage[]> {
-    return API.one('images/find')
+    return API.one('images', 'find')
       .withParams(params)
       .get()
       .catch(() => [] as IGceImage[]);

--- a/app/scripts/modules/oracle/src/image/image.reader.js
+++ b/app/scripts/modules/oracle/src/image/image.reader.js
@@ -6,12 +6,12 @@ import { API } from '@spinnaker/core';
 
 export const ORACLE_IMAGE_IMAGE_READER = 'spinnaker.oracle.image.reader';
 export const name = ORACLE_IMAGE_IMAGE_READER; // for backwards compatibility
-module(ORACLE_IMAGE_IMAGE_READER, []).factory('oracleImageReader', function() {
+module(ORACLE_IMAGE_IMAGE_READER, []).factory('oracleImageReader', function () {
   function findImages(params) {
-    return API.one('images/find')
+    return API.one('images', 'find')
       .withParams(params)
       .get()
-      .catch(function() {
+      .catch(function () {
         return [];
       });
   }
@@ -24,10 +24,10 @@ module(ORACLE_IMAGE_IMAGE_READER, []).factory('oracleImageReader', function() {
       .withParams({ provider: 'oracle' })
       .get()
       .then(
-        function(results) {
+        function (results) {
           return results && results.length ? results[0] : null;
         },
-        function() {
+        function () {
           return null;
         },
       );

--- a/app/scripts/modules/tencentcloud/src/image/image.reader.ts
+++ b/app/scripts/modules/tencentcloud/src/image/image.reader.ts
@@ -37,7 +37,7 @@ export class TencentcloudImageReader {
       return $q.when([{ message: 'Please enter at least 3 characters...', disabled: true }]) as any;
     }
 
-    return API.one('images/find')
+    return API.one('images', 'find')
       .withParams({ ...params, provider: 'tencentcloud' })
       .get()
       .catch(() => [] as ITencentcloudImage[]);


### PR DESCRIPTION
Applies the auto-fixes for new `api-no-slashes` eslint rule from #8629

Duplicates work originally done in #8586

via:
```eslint --fix```