### PR TITLE
feat(keel): set defaults for managed delivery config

### DIFF
--- a/app/scripts/modules/core/src/config/settings.ts
+++ b/app/scripts/modules/core/src/config/settings.ts
@@ -136,6 +136,10 @@ SETTINGS.analytics = SETTINGS.analytics || {};
 SETTINGS.providers = SETTINGS.providers || {};
 SETTINGS.defaultTimeZone = SETTINGS.defaultTimeZone || 'America/Los_Angeles';
 SETTINGS.dockerInsights = SETTINGS.dockerInsights || { enabled: false, url: '' };
+SETTINGS.managedDelivery = SETTINGS.managedDelivery || {
+  defaultManifest: 'spinnaker.yml',
+  manifestBasePath: '.spinnaker',
+};
 
 // A helper to make resetting settings to steady state after running tests easier
 const originalSettings: ISpinnakerSettings = cloneDeep(SETTINGS);


### PR DESCRIPTION
setting defaults for `defaultManifest` name and `manifestBasePath` for managed delivery in the code