### PR TITLE
feat(core/application): sort Environments first for users with it enabled

### DIFF
--- a/app/scripts/modules/core/src/application/service/ApplicationDataSourceRegistry.ts
+++ b/app/scripts/modules/core/src/application/service/ApplicationDataSourceRegistry.ts
@@ -4,6 +4,7 @@ import { IDataSourceConfig } from './applicationDataSource';
 
 export class ApplicationDataSourceRegistry {
   private static defaultDataSourceOrder: string[] = [
+    'environments',
     'executions',
     'serverGroups',
     'loadBalancers',
@@ -24,7 +25,7 @@ export class ApplicationDataSourceRegistry {
     if (this.dataSourceOrder.length) {
       order = this.dataSourceOrder;
     }
-    this.dataSources.forEach(ds => {
+    this.dataSources.forEach((ds) => {
       if (!order.includes(ds.key)) {
         order.push(ds.key);
       }


### PR DESCRIPTION
We've gotten some feedback that when Environments is turned on, having it sorted higher than pipelines is useful because typically that's the more common landing point for those users.

(fyi @gcomstock)