### PR TITLE
feat(core): make Environments the default route if enabled

### DIFF
--- a/app/scripts/modules/core/src/application/application.state.provider.ts
+++ b/app/scripts/modules/core/src/application/application.state.provider.ts
@@ -33,19 +33,6 @@ export class ApplicationStateProvider implements IServiceProvider {
     this.childStates.push(this.insightState);
   }
 
-  private static getDefaultState(app: Application) {
-    const environments = app.getDataSource('environments');
-    const serverGroups = app.getDataSource('serverGroups');
-
-    if (environments && !environments.disabled) {
-      return '.environments';
-    } else if (serverGroups && !serverGroups.disabled) {
-      return '.insight.clusters';
-    } else {
-      return app.dataSources.find((ds) => ds.sref && !ds.disabled).sref;
-    }
-  }
-
   /**
    * Adds a direct child to the application that does not use the Insight (i.e. inspector) views, e.g. tasks
    * @param state
@@ -97,12 +84,13 @@ export class ApplicationStateProvider implements IServiceProvider {
           .injector()
           .getAsync('app')
           .then((app: Application) => {
-            const defaultState = ApplicationStateProvider.getDefaultState(app);
+            const defaultDataSource = app.dataSources.find((ds) => ds.sref && !ds.disabled)?.sref;
 
             const params = transition.params();
-            const options = { relative: transition.to().name };
+            // If there's no data source to route to, we need to use the absolute href 'home.search'
+            const options = { relative: defaultDataSource ? transition.to().name : undefined };
 
-            return transition.router.stateService.target(defaultState, params, options);
+            return transition.router.stateService.target(defaultDataSource || 'home.search', params, options);
           });
       },
       resolve: {

--- a/app/scripts/modules/core/src/application/application.state.provider.ts
+++ b/app/scripts/modules/core/src/application/application.state.provider.ts
@@ -33,6 +33,19 @@ export class ApplicationStateProvider implements IServiceProvider {
     this.childStates.push(this.insightState);
   }
 
+  private static getDefaultState(app: Application) {
+    const environments = app.getDataSource('environments');
+    const serverGroups = app.getDataSource('serverGroups');
+
+    if (environments && !environments.disabled) {
+      return '.environments';
+    } else if (serverGroups && !serverGroups.disabled) {
+      return '.insight.clusters';
+    } else {
+      return app.dataSources.find((ds) => ds.sref && !ds.disabled).sref;
+    }
+  }
+
   /**
    * Adds a direct child to the application that does not use the Insight (i.e. inspector) views, e.g. tasks
    * @param state
@@ -84,8 +97,7 @@ export class ApplicationStateProvider implements IServiceProvider {
           .injector()
           .getAsync('app')
           .then((app: Application) => {
-            const environments = app.getDataSource('environments');
-            const defaultState = environments && !environments.disabled ? '.environments' : '.insight.clusters';
+            const defaultState = ApplicationStateProvider.getDefaultState(app);
 
             const params = transition.params();
             const options = { relative: transition.to().name };

--- a/app/scripts/modules/core/src/application/applications.state.provider.ts
+++ b/app/scripts/modules/core/src/application/applications.state.provider.ts
@@ -28,6 +28,5 @@ module(APPLICATIONS_STATE_PROVIDER, [STATE_CONFIG_PROVIDER, APPLICATION_STATE_PR
 
     applicationStateProvider.addParentState(applicationsState, 'main@');
     stateConfigProvider.addToRootState(applicationsState);
-    stateConfigProvider.addRewriteRule('/applications/{application}', '/applications/{application}/clusters');
   },
 ]);

--- a/app/scripts/modules/core/src/application/modal/createApplication.modal.controller.js
+++ b/app/scripts/modules/core/src/application/modal/createApplication.modal.controller.js
@@ -30,15 +30,15 @@ module(CORE_APPLICATION_MODAL_CREATEAPPLICATION_MODAL_CONTROLLER, [
   '$state',
   '$uibModalInstance',
   '$timeout',
-  function($scope, $q, $log, $state, $uibModalInstance, $timeout) {
+  function ($scope, $q, $log, $state, $uibModalInstance, $timeout) {
     const applicationLoader = ApplicationReader.listApplications();
-    applicationLoader.then(applications => (this.data.appNameList = _.map(applications, 'name')));
+    applicationLoader.then((applications) => (this.data.appNameList = _.map(applications, 'name')));
 
     const providerLoader = AccountService.listProviders();
-    providerLoader.then(providers => (this.data.cloudProviders = providers));
+    providerLoader.then((providers) => (this.data.cloudProviders = providers));
 
     $q.all([applicationLoader, providerLoader])
-      .catch(error => {
+      .catch((error) => {
         this.state.initializeFailed = true;
         throw error;
       })
@@ -72,7 +72,7 @@ module(CORE_APPLICATION_MODAL_CREATEAPPLICATION_MODAL_CONTROLLER, [
 
     const routeToApplication = () => {
       navigateTimeout = $timeout(() => {
-        $state.go('home.applications.application.insight.clusters', {
+        $state.go('home.applications.application', {
           application: this.application.name,
         });
       }, 1000);
@@ -80,7 +80,7 @@ module(CORE_APPLICATION_MODAL_CREATEAPPLICATION_MODAL_CONTROLLER, [
 
     $scope.$on('$destroy', () => $timeout.cancel(navigateTimeout));
 
-    const waitUntilApplicationIsCreated = task => {
+    const waitUntilApplicationIsCreated = (task) => {
       return TaskReader.waitUntilTaskCompletes(task).then(routeToApplication, () => {
         this.state.errorMessages.push('Could not create application: ' + task.failureMessage);
         goIdle();
@@ -118,7 +118,7 @@ module(CORE_APPLICATION_MODAL_CREATEAPPLICATION_MODAL_CONTROLLER, [
       return true;
     }
 
-    this.handlePermissionsChange = permissions => {
+    this.handlePermissionsChange = (permissions) => {
       this.state.permissionsInvalid = !permissionsAreValid(permissions);
       this.application.permissions = permissions;
       $scope.$digest();

--- a/app/scripts/modules/core/src/application/search/ApplicationsTable.tsx
+++ b/app/scripts/modules/core/src/application/search/ApplicationsTable.tsx
@@ -35,14 +35,14 @@ export const ApplicationTable = ({ currentSort, toggleSort, applications }: IApp
     </thead>
 
     <tbody>
-      {applications.map(app => {
+      {applications.map((app) => {
         const appName = app.name.toLowerCase();
 
         return (
-          <UISref key={appName} to=".application.insight.clusters" params={{ application: appName }}>
+          <UISref key={appName} to=".application" params={{ application: appName }}>
             <tr className="clickable">
               <td>
-                <UISref to=".application.insight.clusters" params={{ application: appName }}>
+                <UISref to=".application" params={{ application: appName }}>
                   <a>{appName}</a>
                 </UISref>
               </td>

--- a/app/scripts/modules/core/src/application/service/ApplicationDataSourceRegistry.ts
+++ b/app/scripts/modules/core/src/application/service/ApplicationDataSourceRegistry.ts
@@ -5,8 +5,8 @@ import { IDataSourceConfig } from './applicationDataSource';
 export class ApplicationDataSourceRegistry {
   private static defaultDataSourceOrder: string[] = [
     'environments',
-    'executions',
     'serverGroups',
+    'executions',
     'loadBalancers',
     'securityGroups',
     'tasks',

--- a/app/scripts/modules/core/src/insight/InsightMenu.tsx
+++ b/app/scripts/modules/core/src/insight/InsightMenu.tsx
@@ -41,7 +41,7 @@ export class InsightMenu extends React.Component<IInsightMenuProps, IInsightMenu
 
   private createProject = () =>
     ConfigureProjectModal.show()
-      .then(result => {
+      .then((result) => {
         this.$state.go('home.project.dashboard', { project: result.name });
       })
       .catch(() => {});
@@ -62,7 +62,7 @@ export class InsightMenu extends React.Component<IInsightMenuProps, IInsightMenu
   };
 
   private routeToApplication = (app: Application) => {
-    this.$state.go('home.applications.application.insight.clusters', { application: app.name });
+    this.$state.go('home.applications.application', { application: app.name });
   };
 
   private refreshAllCaches = () => {

--- a/app/scripts/modules/core/src/navigation/UrlBuilder.ts
+++ b/app/scripts/modules/core/src/navigation/UrlBuilder.ts
@@ -103,13 +103,13 @@ class ApplicationsUrlBuilder implements IUrlBuilder {
     let result: string;
     if (input.project) {
       result = $state.href(
-        'home.project.application.insight.clusters',
+        'home.project.application',
         { application: input.application, project: input.project },
         { inherit: false },
       );
     } else {
       result = $state.href(
-        'home.applications.application.insight.clusters',
+        'home.applications.application',
         {
           application: input.application,
         },

--- a/app/scripts/modules/core/src/pagerDuty/Pager.tsx
+++ b/app/scripts/modules/core/src/pagerDuty/Pager.tsx
@@ -172,7 +172,7 @@ export class Pager extends React.Component<IPagerProps, IPagerState> {
   }
 
   private findServiceByApplicationName(applicationName: string): IOnCallsByService {
-    return this.allData.find(data => data.applications.some(application => application.name === applicationName));
+    return this.allData.find((data) => data.applications.some((application) => application.name === applicationName));
   }
 
   @Debounce(25)
@@ -189,7 +189,7 @@ export class Pager extends React.Component<IPagerProps, IPagerState> {
       const foundServices: IOnCallsByService[] = [];
       const notFoundApps: string[] = [];
 
-      app.split(',').forEach(applicationName => {
+      app.split(',').forEach((applicationName) => {
         const service = this.findServiceByApplicationName(applicationName);
         if (service) {
           foundServices.push(service);
@@ -199,7 +199,7 @@ export class Pager extends React.Component<IPagerProps, IPagerState> {
       });
 
       if (foundServices.length > 0) {
-        foundServices.forEach(foundService =>
+        foundServices.forEach((foundService) =>
           selectedKeys.set(foundService.service.integration_key, foundService.service),
         );
         this.setState({ sortedData: foundServices, selectedKeys, notFoundApps });
@@ -213,8 +213,8 @@ export class Pager extends React.Component<IPagerProps, IPagerState> {
     }
 
     if (keys && keys.length > 0) {
-      const selectedServices = this.allData.filter(data => keys.includes(data.service.integration_key));
-      selectedServices.forEach(s => selectedKeys.set(s.service.integration_key, s.service));
+      const selectedServices = this.allData.filter((data) => keys.includes(data.service.integration_key));
+      selectedServices.forEach((s) => selectedKeys.set(s.service.integration_key, s.service));
       this.setState({ selectedKeys });
     }
 
@@ -228,9 +228,9 @@ export class Pager extends React.Component<IPagerProps, IPagerState> {
     });
 
     this.searchApi.search(filterString).then((results: string[]) => {
-      let data = results.map(serviceId => this.allData.find(service => service.service.id === serviceId));
+      let data = results.map((serviceId) => this.allData.find((service) => service.service.id === serviceId));
       if (hideNoApps) {
-        data = data.filter(s => s.applications.length);
+        data = data.filter((s) => s.applications.length);
       }
       this.sortList(data, sortBy, sortDirection);
       this.cache.clearAll();
@@ -261,8 +261,8 @@ export class Pager extends React.Component<IPagerProps, IPagerState> {
   ): IOnCallsByService[] {
     const appsByApiKey = groupBy(applications, 'pdApiKey');
     return services
-      .filter(a => a.integration_key) // filter out services without an integration_key
-      .map(service => {
+      .filter((a) => a.integration_key) // filter out services without an integration_key
+      .map((service) => {
         // connect the users attached to the service by way of escalation policy
         let users: IUserList;
         const searchTokens: string[] = [service.name];
@@ -270,21 +270,21 @@ export class Pager extends React.Component<IPagerProps, IPagerState> {
         if (levels) {
           users = groupBy(
             levels
-              .map(level => {
+              .map((level) => {
                 return level.user
                   ? { name: level.user.summary, url: level.user.html_url, level: level.escalation_level }
                   : undefined;
               })
-              .filter(a => a),
+              .filter((a) => a),
             'level',
           );
-          searchTokens.push(...levels.map(level => (level.user ? level.user.summary : undefined)).filter(n => n));
+          searchTokens.push(...levels.map((level) => (level.user ? level.user.summary : undefined)).filter((n) => n));
         }
 
         // Get applications associated with the service key
         const apiKey = service.integration_key;
         const associatedApplications = appsByApiKey[apiKey] ?? [];
-        searchTokens.push(...associatedApplications.map(app => `${app.name},${app.aliases || ''}`));
+        searchTokens.push(...associatedApplications.map((app) => `${app.name},${app.aliases || ''}`));
 
         const onCallsByService = {
           users,
@@ -337,7 +337,7 @@ export class Pager extends React.Component<IPagerProps, IPagerState> {
 
   private applicationRenderer = (data: TableCellProps): React.ReactNode => {
     const apps: IApplicationSummary[] = data.cellData;
-    const appList = apps.map(app => {
+    const appList = apps.map((app) => {
       let displayName = app.name;
       if (app.aliases) {
         displayName = `${displayName} (${app.aliases.replace(/,/g, ', ')})`;
@@ -345,7 +345,7 @@ export class Pager extends React.Component<IPagerProps, IPagerState> {
 
       return (
         <li key={app.name}>
-          <UISref to="home.applications.application.insight.clusters" params={{ application: app.name }}>
+          <UISref to="home.applications.application" params={{ application: app.name }}>
             <a>
               <Markdown message={this.highlight(displayName)} tag="span" />
             </a>
@@ -390,13 +390,13 @@ export class Pager extends React.Component<IPagerProps, IPagerState> {
       >
         <div style={paddingStyle}>
           {onCalls
-            ? Object.keys(onCalls).map(level => {
+            ? Object.keys(onCalls).map((level) => {
                 return (
                   <div key={level} className="users">
                     <div className="user-level">{level}</div>
                     <div className="user-names">
                       {onCalls[Number(level)]
-                        .filter(user => !user.name.includes('ExcludeFromAudit'))
+                        .filter((user) => !user.name.includes('ExcludeFromAudit'))
                         .map((user, index) => (
                           <a key={index} target="_blank" href={user.url}>
                             <Markdown tag="span" message={this.highlight(user.name)} />
@@ -517,10 +517,7 @@ export class Pager extends React.Component<IPagerProps, IPagerState> {
                 PagerDuty Services were not found for the following applications:{' '}
                 {notFoundApps.map((applicationName, i) => (
                   <>
-                    <UISref
-                      to="home.applications.application.insight.clusters"
-                      params={{ application: applicationName }}
-                    >
+                    <UISref to="home.applications.application" params={{ application: applicationName }}>
                       <a className="clickable">{applicationName}</a>
                     </UISref>
                     {i + 1 < notFoundApps.length && ', '}
@@ -614,7 +611,7 @@ export class Pager extends React.Component<IPagerProps, IPagerState> {
               {selectedKeys.size} {selectedKeys.size === 1 ? 'policy' : 'policies'} selected{' '}
             </span>
             <div className="selected-pills">
-              {Array.from(selectedKeys.values()).map(service => (
+              {Array.from(selectedKeys.values()).map((service) => (
                 <ServicePill key={service.integration_key} service={service} changeCallback={this.selectedChanged} />
               ))}
             </div>

--- a/app/scripts/modules/core/src/projects/ProjectHeader.tsx
+++ b/app/scripts/modules/core/src/projects/ProjectHeader.tsx
@@ -30,7 +30,7 @@ export class ProjectHeader extends React.Component<IProjectHeaderProps, IProject
 
   public componentDidMount() {
     const { success$ } = this.props.transition.router.globals;
-    success$.takeUntil(this.destroy$).subscribe(success => {
+    success$.takeUntil(this.destroy$).subscribe((success) => {
       const state = success.to().name;
       const application = success.params().application;
       this.setState({ state, application });
@@ -48,7 +48,7 @@ export class ProjectHeader extends React.Component<IProjectHeaderProps, IProject
     const { $state } = ReactInjector;
     const title = 'Configure project';
 
-    ConfigureProjectModal.show({ title, projectConfiguration }).then(result => {
+    ConfigureProjectModal.show({ title, projectConfiguration }).then((result) => {
       if (result.action === 'delete') {
         $state.go('home.infrastructure');
       } else if (result.action === 'upsert') {
@@ -112,8 +112,8 @@ export class ProjectHeader extends React.Component<IProjectHeaderProps, IProject
                     </UISref>
                     <MenuItem divider={true} />
                     {config.applications &&
-                      config.applications.sort().map(app => (
-                        <UISref key={app} to=".application.insight.clusters" params={{ application: app }}>
+                      config.applications.sort().map((app) => (
+                        <UISref key={app} to=".application" params={{ application: app }}>
                           <MenuItem onClick={closeDropdown}> {app} </MenuItem>
                         </UISref>
                       ))}

--- a/app/scripts/modules/core/src/projects/projects.states.ts
+++ b/app/scripts/modules/core/src/projects/projects.states.ts
@@ -100,9 +100,5 @@ module(PROJECTS_STATES_CONFIG, [
     applicationStateProvider.addParentState(project, 'detail', '/applications');
 
     stateConfigProvider.addRewriteRule('/projects/{project}', '/projects/{project}/dashboard');
-    stateConfigProvider.addRewriteRule(
-      '/projects/{project}/applications/{application}',
-      '/projects/{project}/applications/{application}/clusters',
-    );
   },
 ]);

--- a/app/scripts/modules/core/src/search/infrastructure/infrastructure.controller.js
+++ b/app/scripts/modules/core/src/search/infrastructure/infrastructure.controller.js
@@ -147,7 +147,7 @@ angular
       };
 
       function routeToApplication(app) {
-        $state.go('home.applications.application.insight.clusters', {
+        $state.go('home.applications.application', {
           application: app.name,
         });
       }

--- a/app/scripts/modules/core/src/serverGroup/serverGroup.states.ts
+++ b/app/scripts/modules/core/src/serverGroup/serverGroup.states.ts
@@ -25,13 +25,13 @@ module(SERVER_GROUP_STATES, [APPLICATION_STATE_PROVIDER, STATE_CONFIG_PROVIDER])
           controllerAs: 'ctrl',
         },
       },
-      redirectTo: transition => {
+      redirectTo: (transition) => {
         return transition
           .injector()
           .getAsync('app')
           .then((app: Application) => {
             if (app.serverGroups.disabled) {
-              const relativeSref = app.dataSources.find(ds => ds.sref && !ds.disabled).sref;
+              const relativeSref = app.dataSources.find((ds) => ds.sref && !ds.disabled).sref;
               const params = transition.params();
               // Target the state relative to the `clusters` state
               const options = { relative: transition.to().name };
@@ -101,7 +101,5 @@ module(SERVER_GROUP_STATES, [APPLICATION_STATE_PROVIDER, STATE_CONFIG_PROVIDER])
     applicationStateProvider.addInsightState(clusters);
     applicationStateProvider.addInsightDetailState(serverGroupDetails);
     applicationStateProvider.addInsightDetailState(multipleServerGroups);
-
-    stateConfigProvider.addRewriteRule('/applications/{application}', '/applications/{application}/clusters');
   },
 ]);

--- a/app/scripts/modules/core/src/serverGroup/serverGroup.states.ts
+++ b/app/scripts/modules/core/src/serverGroup/serverGroup.states.ts
@@ -3,7 +3,6 @@ import { module } from 'angular';
 import { StateParams } from '@uirouter/angularjs';
 import { STATE_CONFIG_PROVIDER, INestedState, StateConfigProvider } from 'core/navigation/state.provider';
 import { APPLICATION_STATE_PROVIDER, ApplicationStateProvider } from 'core/application/application.state.provider';
-import { Application } from 'core/application/application.model';
 import { filterModelConfig } from 'core/cluster/filter/ClusterFilterModel';
 import { ClusterFilters } from 'core/cluster/filter/ClusterFilters';
 
@@ -24,22 +23,6 @@ module(SERVER_GROUP_STATES, [APPLICATION_STATE_PROVIDER, STATE_CONFIG_PROVIDER])
           controller: 'AllClustersCtrl',
           controllerAs: 'ctrl',
         },
-      },
-      redirectTo: (transition) => {
-        return transition
-          .injector()
-          .getAsync('app')
-          .then((app: Application) => {
-            if (app.serverGroups.disabled) {
-              const relativeSref = app.dataSources.find((ds) => ds.sref && !ds.disabled).sref;
-              const params = transition.params();
-              // Target the state relative to the `clusters` state
-              const options = { relative: transition.to().name };
-              // Up two state levels first
-              return transition.router.stateService.target('^.^' + relativeSref, params, options);
-            }
-            return null;
-          });
       },
       params: stateConfigProvider.buildDynamicParams(filterModelConfig),
       data: {


### PR DESCRIPTION
When users migrate to Managed Delivery, we turn on the Environments route for them. Our internal customers have given us feedback that once they migrate it's much more useful to route directly to Environments when hitting `/application/{application}` vs. the standard default (clusters). As a result @gcomstock and I are looking to try out changing the default route _only for apps with Environments enabled_ — any other apps ought to continue to behave the way they already do.

Based on my limited knowledge of UI Router I've taken a stab at doing this, PLEASE give any feedback you may have as I'm more than happy to take a different approach — my primary concern is just getting the end result this PR achieves.

Today we use the static `addRewriteRule` method to redirect to `/clusters`, but now we need to consult the enabled data sources for the chosen app before deciding where to go. I've taken the approach of making the `application` state non-abstract, and adding a `redirectTo` handler for it which grabs the app model already being fetched for the route and checks it to decide where to redirect. AFAICT this is behaviorally equivalent outside of apps with Environments enabled and doesn't cause jank/noticeable changes in loading performance (which I assume is because we were already blocking on fetching the app model to show the route).

In order to make all the existing links in deck work with this new dynamic default (search results, applications list, etc.), I've gone through to all the places which were routing to the `insight.clusters` state as a means to go to the app's default screen and changed them to point to the newly routable `.application`. Any overridden/customized code that's still pointing directly to `insight.clusters` should theoretically continue to work as it always has. I've also tested it with apps that belong to a project and the nested states continue to work as expected.