### PR TITLE
fix(eslint-plugin): Cast a wider net in api-no-slashes.js

### DIFF
--- a/packages/eslint-plugin/rules/api-no-slashes.js
+++ b/packages/eslint-plugin/rules/api-no-slashes.js
@@ -31,7 +31,7 @@ const rule = function (context) {
       // Get the source code (think .toString()) of the AST node and find a slash
       // This isn't 100% accurate, but it's good enough.
       function sourceCodeHasSlash(node) {
-        const text = context.getSourceCode().getText(node);
+        const text = node ? context.getSourceCode().getText(node) : '';
         return !!(text && text.includes('/'));
       }
 

--- a/packages/eslint-plugin/test/api-no-slashes.spec.js
+++ b/packages/eslint-plugin/test/api-no-slashes.spec.js
@@ -61,5 +61,15 @@ ruleTester.run('api-no-slashes', rule, {
       output: `const foo = "foo/bad"; API.all('api').one(...foo.split('/')).one('ok', 'bar', 'baz');`,
       errors: [errorMessage, errorMessage], // two errors
     },
+    // Detectable but unfixable
+    {
+      code: 'API.one(`foo/${cantfix}`);',
+      errors: [errorMessage], // two errors
+    },
+    // Detectable but unfixable
+    {
+      code: 'API.one("foo/" + cantfix);',
+      errors: [errorMessage], // two errors
+    },
   ],
 });

--- a/packages/eslint-plugin/test/api-no-slashes.spec.js
+++ b/packages/eslint-plugin/test/api-no-slashes.spec.js
@@ -16,30 +16,50 @@ ruleTester.run('api-no-slashes', rule, {
   invalid: [
     {
       code: `API.one('foo/bad');`,
-      errors: [errorMessage],
       output: `API.one('foo', 'bad');`,
+      errors: [errorMessage],
     },
+    // Fixes slashes in chained .one().all().one() calls
     {
       code: `API.one('ok').one('ok').all('ok').one('foo/bad');`,
-      errors: [errorMessage],
       output: `API.one('ok').one('ok').all('ok').one('foo', 'bad');`,
+      errors: [errorMessage],
     },
+    // Fixes slashes in varargs arguments
     {
       code: `API.one('ok').one('ok', 'foo/bad');`,
       output: `API.one('ok').one('ok', 'foo', 'bad');`,
       errors: [errorMessage],
     },
-    // Variables which are initialized to a string literal with a slash
+    // Variables which are initialized to a string literal with a slash transform to split+spread
     {
       code: `let foo = "foo/bad"; API.one(foo);`,
-      errors: [errorMessage],
       output: `let foo = "foo/bad"; API.one(...foo.split('/'));`,
+      errors: [errorMessage],
     },
-    // Mix of everything
+    // Variables whose initializer contains a slash
+    {
+      code: 'let foo = `foo/${variable}`; API.one(foo);',
+      output: "let foo = `foo/${variable}`; API.one(...foo.split('/'));",
+      errors: [errorMessage],
+    },
+    // Variables whose initializer contains a slash (anywhere)
+    {
+      code: 'let foo = "foo/bad" + variable; API.one(foo);',
+      output: `let foo = "foo/bad" + variable; API.one(...foo.split('/'));`,
+      errors: [errorMessage],
+    },
+    // Variables whose initializer contains a slash (mix of everything, still can be detected)
+    {
+      code: 'let foo = variable + `foo/${expr}` + "/bad/" + variable; API.one(foo);',
+      output: 'let foo = variable + `foo/${expr}` + "/bad/" + variable; API.one(...foo.split(\'/\'));',
+      errors: [errorMessage],
+    },
+    // Multiple errors, mix of styles
     {
       code: `const foo = "foo/bad"; API.all('api').one(foo).one('ok', 'bar/baz');`,
-      errors: [errorMessage, errorMessage], // two errors
       output: `const foo = "foo/bad"; API.all('api').one(...foo.split('/')).one('ok', 'bar', 'baz');`,
+      errors: [errorMessage, errorMessage], // two errors
     },
   ],
 });

--- a/packages/eslint-plugin/utils/utils.js
+++ b/packages/eslint-plugin/utils/utils.js
@@ -17,8 +17,10 @@ function getCallingIdentifier(calleeObject) {
 
 /** given an identifier, finds its Variable in the enclosing scope */
 function getVariableInScope(context, identifier) {
-  const { variables } = context.getScope();
-  return variables.find((v) => v.name === identifier.name);
+  if (identifier.type === 'Identifier') {
+    const { variables } = context.getScope();
+    return variables.find((v) => v.name === identifier.name);
+  }
 }
 
 function getProgram(node) {


### PR DESCRIPTION
Simplified the detection logic for slashes.

Now detects slashes in the following new cases:


some arg is template string or string concatenation with a slash
```
var prefix = 'proxies/foo/v1';
API.one(`${prefix}/endpoint`);
API.one(prefix + "/endpoint"`);
```

some arg is reference to a template string or concatenated string with a slash
```
var prefix = 'proxies/foo/v1';
var url = prefix + "/endpoint";
var url = `${prefix}/endpoint`;
API.one(url);
```
