### PR TITLE
chore(build): change Dockerfile.compile base to openjdk:11-slim

### DIFF
--- a/Dockerfile.compile
+++ b/Dockerfile.compile
@@ -1,8 +1,8 @@
-FROM alpine:3.11
-RUN apk add --update \
-    openjdk11 \
-    git \
-    && rm -rf /var/cache/apk
+FROM openjdk:11-slim
+
+RUN apt-get update && apt-get install -y \
+  git
+
 LABEL maintainer="sig-platform@spinnaker.io"
 ENV GRADLE_USER_HOME /workspace/.gradle
 ENV GRADLE_OPTS -Xmx2048m


### PR DESCRIPTION
The move to `alpine` caused build failures when attempting to use the
`node` binary provided by the `nebula.node` Gradle plugin. The binary
was built assuming the presence of `glibc` while Alpine is based on
`musl`, so the build would always fail.

Moving to openjdk:11-slim appears to get us around these build issues,
we'll see in the final build in gcloud if that's correct!