### PR TITLE
fix(core/managed): respect line breaks in commit messages

### DIFF
--- a/app/scripts/modules/core/src/managed/ArtifactDetail.tsx
+++ b/app/scripts/modules/core/src/managed/ArtifactDetail.tsx
@@ -294,7 +294,12 @@ export const ArtifactDetail = ({
                     </a>
                   }
                 />
-                <VersionMetadataItem label="Message" value={git.commitInfo.message} />
+                <VersionMetadataItem
+                  label="Message"
+                  value={
+                    <span style={{ wordBreak: 'break-word', whiteSpace: 'pre-wrap' }}>{git.commitInfo.message}</span>
+                  }
+                />
               </>
             )}
             {git?.branch && <VersionMetadataItem label="Branch" value={git.branch} />}


### PR DESCRIPTION
The commit message in the version details pane currently doesn't respect newlines/carriage returns in the message, so it all gets garbled together in a big wrapping line. This just sets the right combination of magical incantations to properly handle those breaks while still wrapping when a single line overflows.