### PR TITLE
fix(core/managed): surface artifact reference on details pane

### DIFF
--- a/app/scripts/modules/core/src/managed/ArtifactDetail.tsx
+++ b/app/scripts/modules/core/src/managed/ArtifactDetail.tsx
@@ -204,17 +204,18 @@ export interface IArtifactDetailProps {
   version: IManagedArtifactVersion;
   allVersions: IManagedArtifactSummary['versions'];
   allEnvironments: IManagedEnvironmentSummary[];
+  showReferenceNames: boolean;
   resourcesByEnvironment: { [environment: string]: IManagedResourceSummary[] };
   onRequestClose: () => any;
 }
 
 export const ArtifactDetail = ({
   application,
-  name,
   reference,
   version: versionDetails,
   allVersions,
   allEnvironments,
+  showReferenceNames,
   resourcesByEnvironment,
   onRequestClose,
 }: IArtifactDetailProps) => {
@@ -233,7 +234,11 @@ export const ArtifactDetail = ({
 
   return (
     <>
-      <ArtifactDetailHeader name={name} version={versionDetails} onRequestClose={onRequestClose} />
+      <ArtifactDetailHeader
+        reference={showReferenceNames ? reference : null}
+        version={versionDetails}
+        onRequestClose={onRequestClose}
+      />
 
       <div className="ArtifactDetail flex-grow">
         <div className="flex-container-h top sp-margin-xl-bottom">

--- a/app/scripts/modules/core/src/managed/ArtifactDetailHeader.less
+++ b/app/scripts/modules/core/src/managed/ArtifactDetailHeader.less
@@ -13,12 +13,6 @@
     flex: 0 0 112px;
   }
 
-  .header-section-center {
-    flex: 1 1 auto;
-    text-align: center;
-    font-size: 14px;
-  }
-
   .header-version-pill {
     margin-left: 16px;
     background-color: var(--color-white);
@@ -30,6 +24,7 @@
     flex: 0 0 54px;
     padding: 0 12px 0 10px;
     text-align: center;
+    white-space: nowrap;
   }
 
   .header-close {

--- a/app/scripts/modules/core/src/managed/ArtifactDetailHeader.tsx
+++ b/app/scripts/modules/core/src/managed/ArtifactDetailHeader.tsx
@@ -8,19 +8,19 @@ import { getArtifactVersionDisplayName } from './displayNames';
 import './ArtifactDetailHeader.less';
 
 export interface IArtifactDetailHeaderProps {
-  name: string;
+  reference: string;
   version: IManagedArtifactVersion;
   onRequestClose: () => any;
 }
 
-export const ArtifactDetailHeader = ({ name, version, onRequestClose }: IArtifactDetailHeaderProps) => (
+export const ArtifactDetailHeader = ({ reference, version, onRequestClose }: IArtifactDetailHeaderProps) => (
   <div className="ArtifactDetailHeader flex-container-h space-between middle text-bold">
     <div className="header-section-left flex-container-h middle">
       <Icon name="artifact" appearance="light" size="extraLarge" />
-      <span className="header-version-pill">{getArtifactVersionDisplayName(version)}</span>
+      <span className="header-version-pill">{`${getArtifactVersionDisplayName(version)}${
+        reference ? ' ' + reference : ''
+      }`}</span>
     </div>
-
-    <div className="header-section-center">{name}</div>
 
     <div className="header-close flex-container-h center middle" onClick={() => onRequestClose()}>
       <Icon name="close" appearance="light" size="medium" />

--- a/app/scripts/modules/core/src/managed/Environments.tsx
+++ b/app/scripts/modules/core/src/managed/Environments.tsx
@@ -190,6 +190,7 @@ export function Environments({ app }: IEnvironmentsProps) {
                   version={item.selectedVersionDetails}
                   allVersions={item.selectedArtifactDetails.versions}
                   allEnvironments={environments}
+                  showReferenceNames={artifacts.length > 1}
                   resourcesByEnvironment={resourcesByEnvironment}
                   onRequestClose={() => go('^')}
                 />


### PR DESCRIPTION
We have a pretty nice new way of showing artifact reference names inside version pills, which we've added in both the sidebar and the environments overview. Recently it was noticed that the header for the version details pane still uses the _name_ of the artifact, which isn't unique and can cause confusion (e.g. you could have the same artifact name configured to pull from PR builds and master builds). This change switches to using the reference, and modifies the visual treatment to look the exact same as the other version pills (reference if there are > 1 artifacts and you need them, no reference if you only have 1 artifact).

Before:
<img width="1104" alt="Screen Shot 2020-10-14 at 3 23 08 PM" src="https://user-images.githubusercontent.com/1850998/96052015-86a3cc00-0e31-11eb-8ebe-d3d0b84da03b.png">

After:
<img width="1108" alt="Screen Shot 2020-10-14 at 3 22 53 PM" src="https://user-images.githubusercontent.com/1850998/96052028-8d324380-0e31-11eb-8b19-9bf3b769b986.png">


fyi @gcomstock 