### PR TITLE
fix(halyard): Bugfix 6112: settings.js doesn't have Oracle default settings

### DIFF
--- a/halconfig/settings.js
+++ b/halconfig/settings.js
@@ -37,6 +37,13 @@ var appengine = {
     account: '{%appengine.default.account%}',
   },
 };
+var oracle = {
+  defaults: {
+    account: '{%oracle.default.account%}',
+    bakeryRegions: '{%oracle.default.bakeryRegions%}',
+    region: '{%oracle.default.region%}',
+  },
+};
 var aws = {
   defaults: {
     account: '{%aws.default.account%}',
@@ -140,7 +147,7 @@ window.spinnakerSettings = {
     gce: gce,
     huaweicloud: huaweicloud,
     kubernetes: {},
-    oracle: {},
+    oracle: oracle,
     tencentcloud: tencentcloud,
   },
   version: version,


### PR DESCRIPTION
fix(halyard): settings.js doesn't have Oracle default settings 
This settings.js is being used as template by halyard and gets hydrated with default settings. Without these settings, oracle default settings were not getting populated, causing at least one know failure while creating OCI load balancer template.