### PR TITLE
 fix(kubernetes): remove unneeded application validation warning 

### DIFF
--- a/app/scripts/modules/kubernetes/src/validation/applicationName.validator.spec.ts
+++ b/app/scripts/modules/kubernetes/src/validation/applicationName.validator.spec.ts
@@ -7,10 +7,9 @@ describe('ApplicationNameValidator', () => {
       expect(validator.validate('myapp123').errors.length).toEqual(0);
       expect(validator.validate('myapp123').warnings.length).toEqual(0);
     });
-    // TODO(mneterval): Warning is no longer necessary since removal of the legacy (V1) provider
-    it('Returns a warning for names that contain dashes', () => {
+    it('Returns no warnings or errors for names that contain only alphanumeric characters and dashes', () => {
       expect(validator.validate('my-app-123').errors.length).toEqual(0);
-      expect(validator.validate('my-app-123').warnings.length).toEqual(1);
+      expect(validator.validate('my-app-123').warnings.length).toEqual(0);
     });
     it('Returns an error for names that contain other non-alphanumeric characters', () => {
       expect(validator.validate('my-app-123$').errors.length).toEqual(1);

--- a/app/scripts/modules/kubernetes/src/validation/applicationName.validator.spec.ts
+++ b/app/scripts/modules/kubernetes/src/validation/applicationName.validator.spec.ts
@@ -1,0 +1,20 @@
+import { KubernetesApplicationNameValidator } from './applicationName.validator';
+
+describe('ApplicationNameValidator', () => {
+  const validator = new KubernetesApplicationNameValidator();
+  describe('validateSpecialCharacters', () => {
+    it('Returns no warnings or errors for names that contain only alphanumeric characters', () => {
+      expect(validator.validate('myapp123').errors.length).toEqual(0);
+      expect(validator.validate('myapp123').warnings.length).toEqual(0);
+    });
+    // TODO(mneterval): Warning is no longer necessary since removal of the legacy (V1) provider
+    it('Returns a warning for names that contain dashes', () => {
+      expect(validator.validate('my-app-123').errors.length).toEqual(0);
+      expect(validator.validate('my-app-123').warnings.length).toEqual(1);
+    });
+    it('Returns an error for names that contain other non-alphanumeric characters', () => {
+      expect(validator.validate('my-app-123$').errors.length).toEqual(1);
+      expect(validator.validate('my-app-123$').warnings.length).toEqual(0);
+    });
+  });
+});

--- a/app/scripts/modules/kubernetes/src/validation/applicationName.validator.ts
+++ b/app/scripts/modules/kubernetes/src/validation/applicationName.validator.ts
@@ -1,6 +1,6 @@
 import { ApplicationNameValidator } from '@spinnaker/core';
 
-class KubernetesApplicationNameValidator {
+export class KubernetesApplicationNameValidator {
   // general k8s resource restriction: 253 characters - https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
   // safe bet is 63 characters - (see also RFC 1035 or RFC 1123 - both setting DNS label maximum to 63 chars)
   // for service names: - https://github.com/kubernetes/kubernetes/pull/29523 (until K8s 1.4.0 it was 24 characters https://github.com/kubernetes/kubernetes/issues/12463)

--- a/app/scripts/modules/kubernetes/src/validation/applicationName.validator.ts
+++ b/app/scripts/modules/kubernetes/src/validation/applicationName.validator.ts
@@ -7,18 +7,13 @@ export class KubernetesApplicationNameValidator {
   // or annotations:    - https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set
   private static MAX_RESOURCE_NAME_LENGTH = 63;
 
-  private static validateSpecialCharacters(name: string, warnings: string[], errors: string[]): void {
-    const alphanumPattern = /^([a-zA-Z][a-zA-Z0-9]*)?$/;
-    if (!alphanumPattern.test(name)) {
-      const alphanumWithDashPattern = /^([a-zA-Z][a-zA-Z0-9-]*)?$/;
-      if (alphanumWithDashPattern.test(name)) {
-        warnings.push('Dashes should only be used in application names when using the Kubernetes v2 provider.');
-      } else {
-        errors.push(
-          'The application name must begin with a letter and must contain only letters or digits. ' +
-            'No special characters are allowed.',
-        );
-      }
+  private static validateSpecialCharacters(name: string, errors: string[]): void {
+    const alphanumWithDashPattern = /^([a-zA-Z][a-zA-Z0-9-]*)?$/;
+    if (!alphanumWithDashPattern.test(name)) {
+      errors.push(
+        'The application name must begin with a letter and must contain only letters, digits, or dashes. ' +
+          'No special characters are allowed.',
+      );
     }
   }
 
@@ -35,7 +30,7 @@ export class KubernetesApplicationNameValidator {
     const errors: string[] = [];
 
     if (name && name.length) {
-      KubernetesApplicationNameValidator.validateSpecialCharacters(name, warnings, errors);
+      KubernetesApplicationNameValidator.validateSpecialCharacters(name, errors);
       KubernetesApplicationNameValidator.validateLength(name, errors);
     }
 


### PR DESCRIPTION
Related to: https://github.com/spinnaker/spinnaker/issues/6082

* test(kubernetes): add test for KubernetesApplicationNameValidator.validate 

  Demonstrates existence of unnecessary warning for dash-containing application names, which are now always valid since the removal of the legacy (V1) Kubernetes provider.

* fix(kubernetes): remove unneeded application validation warning 
