### PR TITLE
feat(api): encodeURIComponent in API service

### DIFF
--- a/app/scripts/modules/core/src/api/ApiService.ts
+++ b/app/scripts/modules/core/src/api/ApiService.ts
@@ -60,7 +60,7 @@ export class API {
     return (...urls: string[]) => {
       urls.forEach((url: string) => {
         if (url) {
-          config.url = `${config.url}/${url}`;
+          config.url = `${config.url}/${encodeURIComponent(url)}`;
         }
       });
 
@@ -171,8 +171,9 @@ export class API {
     };
     urls
       .filter((i) => !isNil(i))
-      .forEach((url: string) => (config.url = `${config.url}/${url.toString().replace(/^\/+/, '')}`));
-
+      .map((url: string) => url.toString().replace(/^\/+/, ''))
+      .map((url: string) => encodeURIComponent(url))
+      .forEach((url: string) => (config.url = `${config.url}/${url.toString()}`));
     return this.baseReturn(config);
   }
 

--- a/app/scripts/modules/core/src/pipeline/config/services/PipelineConfigService.ts
+++ b/app/scripts/modules/core/src/pipeline/config/services/PipelineConfigService.ts
@@ -49,7 +49,7 @@ export class PipelineConfigService {
 
   public static deletePipeline(applicationName: string, pipeline: IPipeline, pipelineName: string): IPromise<void> {
     return API.one(pipeline.strategy ? 'strategies' : 'pipelines')
-      .one(applicationName, encodeURIComponent(pipelineName.trim()))
+      .one(applicationName, pipelineName.trim())
       .remove();
   }
 
@@ -106,7 +106,7 @@ export class PipelineConfigService {
     return API.one('pipelines')
       .one('v2')
       .one(applicationName)
-      .one(encodeURIComponent(pipelineName))
+      .one(pipelineName)
       .data(body)
       .post()
       .then((result: ITriggerPipelineResponse) => {

--- a/app/scripts/modules/core/src/pipeline/service/execution.service.ts
+++ b/app/scripts/modules/core/src/pipeline/service/execution.service.ts
@@ -107,7 +107,7 @@ export class ExecutionService {
         execution.hydrated = true;
         this.cleanExecutionForDiffing(execution);
         if (application && name) {
-          return API.one('applications', application, 'pipelineConfigs', encodeURIComponent(name))
+          return API.one('applications', application, 'pipelineConfigs', name)
             .get()
             .then((pipelineConfig: IPipeline) => {
               execution.pipelineConfig = pipelineConfig;


### PR DESCRIPTION
Reimplementation of https://github.com/spinnaker/deck/pull/8586 after having a linter rule for detecting slashes in uri components passed to API methods.

Revert of original PR: https://github.com/spinnaker/deck/pull/8627
No slashes implementation: https://github.com/spinnaker/deck/pull/8631
ES lint rule: https://github.com/spinnaker/deck/pull/8629