### PR TITLE
feat(core/managed): run commit messages through Markdown

### DIFF
--- a/app/scripts/modules/core/src/managed/ArtifactDetail.tsx
+++ b/app/scripts/modules/core/src/managed/ArtifactDetail.tsx
@@ -302,7 +302,9 @@ export const ArtifactDetail = ({
                 <VersionMetadataItem
                   label="Message"
                   value={
-                    <span style={{ wordBreak: 'break-word', whiteSpace: 'pre-wrap' }}>{git.commitInfo.message}</span>
+                    <span style={{ wordBreak: 'break-word', whiteSpace: 'pre-wrap' }}>
+                      <Markdown message={git.commitInfo.message} tag="span" />
+                    </span>
                   }
                 />
               </>


### PR DESCRIPTION
We're experimenting a bit with commit messages and how they're displayed, since this is new territory for us/our customers. Some tooling and automation likes to put links in commit messages — we have our own stuff that does this internally and the pattern is fairly common. We're interested in enabling this use case to be a bit more convenient by supporting markdown parsing in messages so you can get actual real links, which Slack will do with the notifications we send by default.

This runs commits through the markdown parser and retains the same whitespace/newline rules, we'll see how it goes. Markdown can often be a bit fickle and unpredictable, so we'll want to keep an eye on whether it's inadvertently mangling commit messages in a way that's not useful.