### PR TITLE
fix(deck): Bugfix 6112: provide default settings for oracle provider in deck microservice to remove Halyard dependency.

### DIFF
--- a/app/scripts/modules/core/src/region/RegionSelectInput.tsx
+++ b/app/scripts/modules/core/src/region/RegionSelectInput.tsx
@@ -18,7 +18,9 @@ export function RegionSelectInput(props: IRegionSelectInputProps) {
     return <p className="form-control-static">{props.value}</p>;
   }
 
-  const options: Array<Option<string>> = regions.map((region) => ({
+  const allRegions: IRegion[] = regions ? regions : [];
+
+  const options: Array<Option<string>> = allRegions.map((region) => ({
     value: region.name,
     label: `${region.name}${region.deprecated ? " (deprecated in the '" + account + "' account)" : ''}`,
   }));

--- a/app/scripts/modules/oracle/src/loadBalancer/loadBalancer.transformer.ts
+++ b/app/scripts/modules/oracle/src/loadBalancer/loadBalancer.transformer.ts
@@ -1,6 +1,7 @@
 import { module, IPromise } from 'angular';
 
 import { OracleProviderSettings } from 'oracle/oracle.settings';
+import { OracleDefaultProviderSettings } from 'oracle/oracle.settings';
 import { Application } from '@spinnaker/core';
 
 import {
@@ -72,8 +73,16 @@ export class OracleLoadBalancerTransformer {
   }
 
   public constructNewLoadBalancerTemplate(application: Application): IOracleLoadBalancerUpsertCommand {
-    const defaultCredentials = application.defaultCredentials.oracle || OracleProviderSettings.defaults.account;
-    const defaultRegion = application.defaultRegions.oracle || OracleProviderSettings.defaults.region;
+    const defaultCredentials =
+      application.defaultCredentials.oracle ||
+      (OracleProviderSettings.defaults
+        ? OracleProviderSettings.defaults.account
+        : OracleDefaultProviderSettings.defaults.account);
+    const defaultRegion =
+      application.defaultRegions.oracle ||
+      (OracleProviderSettings.defaults
+        ? OracleProviderSettings.defaults.region
+        : OracleDefaultProviderSettings.defaults.region);
     return {
       name: undefined,
       cloudProvider: 'oracle',

--- a/app/scripts/modules/oracle/src/oracle.settings.ts
+++ b/app/scripts/modules/oracle/src/oracle.settings.ts
@@ -12,3 +12,7 @@ export const OracleProviderSettings: IOracleProviderSettings = (SETTINGS.provide
 if (OracleProviderSettings) {
   OracleProviderSettings.resetToOriginal = SETTINGS.resetProvider('oracle');
 }
+
+export const OracleDefaultProviderSettings = {
+  defaults: { account: 'DEFAULT', bakeryRegions: 'us-phoenix-1', region: 'us-phoenix-1' },
+};

--- a/halconfig/settings.js
+++ b/halconfig/settings.js
@@ -37,6 +37,13 @@ var appengine = {
     account: '{%appengine.default.account%}',
   },
 };
+var oracle = {
+  defaults: {
+    account: '{%oracle.default.account%}',
+    bakeryRegions: '{%oracle.default.bakeryRegions%}',
+    region: '{%oracle.default.region%}',
+  },
+};
 var aws = {
   defaults: {
     account: '{%aws.default.account%}',
@@ -140,7 +147,7 @@ window.spinnakerSettings = {
     gce: gce,
     huaweicloud: huaweicloud,
     kubernetes: {},
-    oracle: {},
+    oracle: oracle,
     tencentcloud: tencentcloud,
   },
   version: version,


### PR DESCRIPTION
fix(deck): settings.js doesn't have Oracle default settings
Since the Halyard is planned to sunset, as suggested by @maggieneterval we are moving the config defaults into the microservices themselves rather than have Halyard supply them.