### PR TITLE
refactor(core): Introduce  -> PromiseLike kludge, start refactoring code to use PromiseLike

### DIFF
--- a/app/scripts/modules/core/src/api/ApiService.ts
+++ b/app/scripts/modules/core/src/api/ApiService.ts
@@ -1,4 +1,4 @@
-import { IPromise, IRequestConfig } from 'angular';
+import { IRequestConfig } from 'angular';
 import { $q, $http } from 'ngimport';
 import { AuthenticationInitializer } from '../authentication/AuthenticationInitializer';
 import { SETTINGS } from 'core/config/settings';
@@ -12,11 +12,11 @@ export interface IRequestBuilder {
   useCache?: (useCache: boolean | ICache) => IRequestBuilder;
   withParams?: (data: any) => IRequestBuilder;
   data?: (data: any) => IRequestBuilder;
-  get?: (data?: any) => IPromise<any>;
-  getList?: (data?: any) => IPromise<any>;
-  post?: (data: any) => IPromise<any>;
-  remove?: (data: any) => IPromise<any>;
-  put?: (data: any) => IPromise<any>;
+  get?: (data?: any) => PromiseLike<any>;
+  getList?: (data?: any) => PromiseLike<any>;
+  post?: (data: any) => PromiseLike<any>;
+  remove?: (data: any) => PromiseLike<any>;
+  put?: (data: any) => PromiseLike<any>;
 }
 
 export class InvalidAPIResponse extends Error {
@@ -37,7 +37,7 @@ export class API {
 
   public static readonly invalidContentMessage = 'API response was neither JSON nor zero-length html or text';
 
-  private static getData(result: any): IPromise<any> {
+  private static getData(result: any): PromiseLike<any> {
     return $q((resolve, reject) => {
       const contentType = result.headers('content-type');
       if (contentType) {
@@ -97,7 +97,7 @@ export class API {
   }
 
   // HTTP GET operation
-  private static getFn(config: IRequestConfig): (data: any) => IPromise<any> {
+  private static getFn(config: IRequestConfig): (data: any) => PromiseLike<any> {
     return (params: any) => {
       config.method = 'get';
       Object.assign(config, this.defaultParams);
@@ -110,7 +110,7 @@ export class API {
   }
 
   // HTTP POST operation
-  private static postFn(config: IRequestConfig): (data: any) => IPromise<any> {
+  private static postFn(config: IRequestConfig): (data: any) => PromiseLike<any> {
     return (data: any) => {
       config.method = 'post';
       if (data) {
@@ -123,7 +123,7 @@ export class API {
   }
 
   // HTTP DELETE operation
-  private static removeFn(config: IRequestConfig): (data: any) => IPromise<any> {
+  private static removeFn(config: IRequestConfig): (data: any) => PromiseLike<any> {
     return (params: any) => {
       config.method = 'delete';
       if (params) {
@@ -136,7 +136,7 @@ export class API {
   }
 
   // HTTP PUT operation
-  private static putFn(config: IRequestConfig): (data: any) => IPromise<any> {
+  private static putFn(config: IRequestConfig): (data: any) => PromiseLike<any> {
     return (data: any) => {
       config.method = 'put';
       if (data) {

--- a/app/scripts/modules/core/src/task/monitor/TaskMonitor.ts
+++ b/app/scripts/modules/core/src/task/monitor/TaskMonitor.ts
@@ -1,4 +1,4 @@
-import { IPromise, IDeferred } from 'angular';
+import { IDeferred } from 'angular';
 import { IModalServiceInstance } from 'angular-ui-bootstrap';
 import { $timeout, $q } from 'ngimport';
 import { Subject } from 'rxjs';
@@ -14,7 +14,7 @@ export interface ITaskMonitorConfig {
   onTaskComplete?: () => any;
   onTaskRetry?: () => void;
   monitorInterval?: number;
-  submitMethod?: () => IPromise<ITask>;
+  submitMethod?: () => PromiseLike<ITask>;
 }
 
 export interface IModalServiceInstanceEmulation<T = any> extends IModalServiceInstance {
@@ -28,7 +28,7 @@ export class TaskMonitor {
   public errorMessage: string;
   public title: string;
   public application: Application;
-  public submitMethod: (params?: any) => IPromise<ITask>;
+  public submitMethod: (params?: any) => PromiseLike<ITask>;
   public modalInstance: IModalServiceInstance;
   private monitorInterval: number;
   private onTaskComplete: () => any;
@@ -134,7 +134,7 @@ export class TaskMonitor {
     this.statusUpdatedStream.next();
   };
 
-  public submit = (submitMethod?: () => IPromise<ITask>) => {
+  public submit = (submitMethod?: () => PromiseLike<ITask>) => {
     this.startSubmit();
     (submitMethod || this.submitMethod)()
       .then((task: ITask) => this.handleTaskSuccess(task))

--- a/app/scripts/modules/core/src/task/taskExecutor.ts
+++ b/app/scripts/modules/core/src/task/taskExecutor.ts
@@ -1,4 +1,4 @@
-import { IHttpPromiseCallbackArg, IPromise } from 'angular';
+import { IHttpPromiseCallbackArg } from 'angular';
 
 import { ITask } from 'core/domain';
 import { TaskReader } from './task.read.service';
@@ -25,7 +25,7 @@ export interface ITaskCommand {
 }
 
 export class TaskExecutor {
-  public static executeTask(taskCommand: ITaskCommand): IPromise<ITask> {
+  public static executeTask(taskCommand: ITaskCommand): PromiseLike<ITask> {
     const owner: any = taskCommand.application || taskCommand.project || { name: 'ad-hoc' };
     if (taskCommand.application && taskCommand.application.name) {
       taskCommand.application = taskCommand.application.name;

--- a/app/scripts/modules/core/src/utils/q.d.ts
+++ b/app/scripts/modules/core/src/utils/q.d.ts
@@ -7,3 +7,18 @@ declare module '@types/angular' {
     resolve<T>(promise: Promise<T>): IPromise<T>;
   }
 }
+
+
+declare global {
+  // This allows an angular $q promise to be returned as a PromiseLike<T>
+  interface PromiseLike<T> {
+    /**
+     * Attaches a callback for only the rejection of the Promise.
+     * @param onrejected The callback to execute when the Promise is rejected.
+     * @returns A Promise for the completion of the callback.
+     */
+    catch<TResult = never>(
+      onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null,
+    ): PromiseLike<T | TResult>;
+  }
+}


### PR DESCRIPTION
This is a step towards eliminating our dependence on the `$q` http client and `IPromise` littered everywhere in our codebase.

`PromiseLike` has `.then()` (from `lib.es5` typedefs) and `.catch()` methods (from the `q.d.ts` kludge).

Both `$q` promises and native ES6 `Promise`s can be typed as a `PromiseLike` allowing for easier migration of APIs to be agnostic to the `$q` promise implementation.

```
let promiselike1: PromiseLike<any> = $q.when('$q promise');
let promiselike2: PromiseLike<any> = Promise.resolve('$q promise');
```
