### PR TITLE
chore(package): use node_modules/.bin/* in module scripts, add 'build' script (the old 'lib' script)

### DIFF
--- a/app/scripts/modules/amazon/package.json
+++ b/app/scripts/modules/amazon/package.json
@@ -5,8 +5,9 @@
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {
-    "clean": "../../../../node_modules/rimraf/bin.js lib",
-    "lib": "npm run clean && ../../../../node_modules/typescript/bin/tsc && node ../../../../node_modules/webpack/bin/webpack.js",
-    "prepublishOnly": "npm run lib"
+    "clean": "../../../../node_modules/.bin/rimraf lib",
+    "lib": "npm run build",
+    "prepublishOnly": "npm run lib",
+    "build": "npm run clean && ../../../../node_modules/.bin/tsc && node ../../../../node_modules/.bin/webpack"
   }
 }

--- a/app/scripts/modules/appengine/package.json
+++ b/app/scripts/modules/appengine/package.json
@@ -5,8 +5,9 @@
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {
-    "clean": "../../../../node_modules/rimraf/bin.js lib",
-    "lib": "npm run clean && ../../../../node_modules/typescript/bin/tsc && node ../../../../node_modules/webpack/bin/webpack.js",
-    "prepublishOnly": "npm run lib"
+    "clean": "../../../../node_modules/.bin/rimraf lib",
+    "lib": "npm run build",
+    "prepublishOnly": "npm run lib",
+    "build": "npm run clean && ../../../../node_modules/.bin/tsc && node ../../../../node_modules/.bin/webpack"
   }
 }

--- a/app/scripts/modules/azure/package.json
+++ b/app/scripts/modules/azure/package.json
@@ -5,8 +5,9 @@
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {
-    "clean": "../../../../node_modules/rimraf/bin.js lib",
-    "lib": "npm run clean && ../../../../node_modules/typescript/bin/tsc && node ../../../../node_modules/webpack/bin/webpack.js",
-    "prepublishOnly": "npm run lib"
+    "clean": "../../../../node_modules/.bin/rimraf lib",
+    "lib": "npm run build",
+    "prepublishOnly": "npm run lib",
+    "build": "npm run clean && ../../../../node_modules/.bin/tsc && node ../../../../node_modules/.bin/webpack"
   }
 }

--- a/app/scripts/modules/cloudfoundry/package.json
+++ b/app/scripts/modules/cloudfoundry/package.json
@@ -5,8 +5,9 @@
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {
-    "clean": "../../../../node_modules/rimraf/bin.js lib",
-    "lib": "npm run clean && ../../../../node_modules/typescript/bin/tsc && node ../../../../node_modules/webpack/bin/webpack.js",
-    "prepublishOnly": "npm run lib"
+    "clean": "../../../../node_modules/.bin/rimraf lib",
+    "lib": "npm run build",
+    "prepublishOnly": "npm run lib",
+    "build": "npm run clean && ../../../../node_modules/.bin/tsc && node ../../../../node_modules/.bin/webpack"
   }
 }

--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -5,8 +5,9 @@
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {
-    "clean": "../../../../node_modules/rimraf/bin.js lib",
-    "lib": "npm run clean && ../../../../node_modules/typescript/bin/tsc && node ../../../../node_modules/webpack/bin/webpack.js",
-    "prepublishOnly": "npm run lib"
+    "clean": "../../../../node_modules/.bin/rimraf lib",
+    "lib": "npm run build",
+    "prepublishOnly": "npm run lib",
+    "build": "npm run clean && ../../../../node_modules/.bin/tsc && node ../../../../node_modules/.bin/webpack"
   }
 }

--- a/app/scripts/modules/docker/package.json
+++ b/app/scripts/modules/docker/package.json
@@ -5,8 +5,9 @@
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {
-    "clean": "../../../../node_modules/rimraf/bin.js lib",
-    "lib": "npm run clean && ../../../../node_modules/typescript/bin/tsc && node ../../../../node_modules/webpack/bin/webpack.js",
-    "prepublishOnly": "npm run lib"
+    "clean": "../../../../node_modules/.bin/rimraf lib",
+    "lib": "npm run build",
+    "prepublishOnly": "npm run lib",
+    "build": "npm run clean && ../../../../node_modules/.bin/tsc && node ../../../../node_modules/.bin/webpack"
   }
 }

--- a/app/scripts/modules/ecs/package.json
+++ b/app/scripts/modules/ecs/package.json
@@ -5,8 +5,9 @@
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {
-    "clean": "../../../../node_modules/rimraf/bin.js lib",
-    "lib": "npm run clean && ../../../../node_modules/typescript/bin/tsc && node ../../../../node_modules/webpack/bin/webpack.js",
-    "prepublishOnly": "npm run lib"
+    "clean": "../../../../node_modules/.bin/rimraf lib",
+    "lib": "npm run build",
+    "prepublishOnly": "npm run lib",
+    "build": "npm run clean && ../../../../node_modules/.bin/tsc && node ../../../../node_modules/.bin/webpack"
   }
 }

--- a/app/scripts/modules/google/package.json
+++ b/app/scripts/modules/google/package.json
@@ -5,8 +5,9 @@
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {
-    "clean": "../../../../node_modules/rimraf/bin.js lib",
-    "lib": "npm run clean && ../../../../node_modules/typescript/bin/tsc && node ../../../../node_modules/webpack/bin/webpack.js",
-    "prepublishOnly": "npm run lib"
+    "clean": "../../../../node_modules/.bin/rimraf lib",
+    "lib": "npm run build",
+    "prepublishOnly": "npm run lib",
+    "build": "npm run clean && ../../../../node_modules/.bin/tsc && node ../../../../node_modules/.bin/webpack"
   }
 }

--- a/app/scripts/modules/huaweicloud/package.json
+++ b/app/scripts/modules/huaweicloud/package.json
@@ -5,8 +5,9 @@
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {
-    "clean": "../../../../node_modules/rimraf/bin.js lib",
-    "lib": "npm run clean && ../../../../node_modules/typescript/bin/tsc && node ../../../../node_modules/webpack/bin/webpack.js",
-    "prepublishOnly": "npm run lib"
+    "clean": "../../../../node_modules/.bin/rimraf lib",
+    "lib": "npm run build",
+    "prepublishOnly": "npm run lib",
+    "build": "npm run clean && ../../../../node_modules/.bin/tsc && node ../../../../node_modules/.bin/webpack"
   }
 }

--- a/app/scripts/modules/kubernetes/package.json
+++ b/app/scripts/modules/kubernetes/package.json
@@ -5,8 +5,9 @@
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {
-    "clean": "../../../../node_modules/rimraf/bin.js lib",
-    "lib": "npm run clean && ../../../../node_modules/typescript/bin/tsc && node ../../../../node_modules/webpack/bin/webpack.js",
-    "prepublishOnly": "npm run lib"
+    "clean": "../../../../node_modules/.bin/rimraf lib",
+    "lib": "npm run build",
+    "prepublishOnly": "npm run lib",
+    "build": "npm run clean && ../../../../node_modules/.bin/tsc && node ../../../../node_modules/.bin/webpack"
   }
 }

--- a/app/scripts/modules/oracle/package.json
+++ b/app/scripts/modules/oracle/package.json
@@ -5,8 +5,9 @@
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {
-    "clean": "../../../../node_modules/rimraf/bin.js lib",
-    "lib": "npm run clean && ../../../../node_modules/typescript/bin/tsc && node ../../../../node_modules/webpack/bin/webpack.js",
-    "prepublishOnly": "npm run lib"
+    "clean": "../../../../node_modules/.bin/rimraf lib",
+    "lib": "npm run build",
+    "prepublishOnly": "npm run lib",
+    "build": "npm run clean && ../../../../node_modules/.bin/tsc && node ../../../../node_modules/.bin/webpack"
   }
 }

--- a/app/scripts/modules/tencentcloud/package.json
+++ b/app/scripts/modules/tencentcloud/package.json
@@ -5,8 +5,9 @@
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {
-    "clean": "../../../../node_modules/rimraf/bin.js lib",
-    "lib": "npm run clean && ../../../../node_modules/typescript/bin/tsc && node ../../../../node_modules/webpack/bin/webpack.js",
-    "prepublishOnly": "npm run lib"
+    "clean": "../../../../node_modules/.bin/rimraf lib",
+    "lib": "npm run build",
+    "prepublishOnly": "npm run lib",
+    "build": "npm run clean && ../../../../node_modules/.bin/tsc && node ../../../../node_modules/.bin/webpack"
   }
 }

--- a/app/scripts/modules/titus/package.json
+++ b/app/scripts/modules/titus/package.json
@@ -5,8 +5,9 @@
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {
-    "clean": "../../../../node_modules/rimraf/bin.js lib",
-    "lib": "npm run clean && ../../../../node_modules/typescript/bin/tsc && node ../../../../node_modules/webpack/bin/webpack.js",
-    "prepublishOnly": "npm run lib"
+    "clean": "../../../../node_modules/.bin/rimraf lib",
+    "lib": "npm run build",
+    "prepublishOnly": "npm run lib",
+    "build": "npm run clean && ../../../../node_modules/.bin/tsc && node ../../../../node_modules/.bin/webpack"
   }
 }


### PR DESCRIPTION
Running scripts from `node_modules/.bin/foo` is more idiomatic than `node_modules/foo/path/to/script`