### PR TITLE
When using $q.all(), pass arrays of promises, not an object

### DIFF
--- a/app/scripts/modules/amazon/src/pipeline/stages/bake/awsBakeStage.js
+++ b/app/scripts/modules/amazon/src/pipeline/stages/bake/awsBakeStage.js
@@ -65,14 +65,14 @@ module(AMAZON_PIPELINE_STAGES_BAKE_AWSBAKESTAGE, [AMAZON_PIPELINE_STAGES_BAKE_BA
       };
 
       function initialize() {
-        $q.all({
-          regions: BakeryReader.getRegions('aws'),
-          baseOsOptions: BakeryReader.getBaseOsOptions('aws'),
-          baseLabelOptions: BakeryReader.getBaseLabelOptions(),
-          storeTypes: ['ebs', 'docker'],
-        }).then(function (results) {
-          $scope.regions = [...results.regions].sort();
-          $scope.storeTypes = results.storeTypes;
+        $q.all([
+          BakeryReader.getRegions('aws'),
+          BakeryReader.getBaseOsOptions('aws'),
+          BakeryReader.getBaseLabelOptions(),
+          ['ebs', 'docker'],
+        ]).then(function ([regions, baseOsOptions, baseLabelOptions, storeTypes]) {
+          $scope.regions = [...regions].sort();
+          $scope.storeTypes = storeTypes;
           if (!$scope.stage.storeType && $scope.storeTypes && $scope.storeTypes.length) {
             $scope.stage.storeType = $scope.storeTypes[0];
           }
@@ -84,8 +84,8 @@ module(AMAZON_PIPELINE_STAGES_BAKE_AWSBAKESTAGE, [AMAZON_PIPELINE_STAGES_BAKE_BA
           if (!$scope.stage.regions.length && $scope.application.defaultRegions.aws) {
             $scope.stage.regions.push(...Object.keys($scope.application.defaultRegions.aws).sort());
           }
-          $scope.baseOsOptions = results.baseOsOptions.baseImages;
-          $scope.baseLabelOptions = results.baseLabelOptions;
+          $scope.baseOsOptions = baseOsOptions.baseImages;
+          $scope.baseLabelOptions = baseLabelOptions;
 
           if (!$scope.stage.baseOs && $scope.baseOsOptions && $scope.baseOsOptions.length) {
             $scope.stage.baseOs = $scope.baseOsOptions[0].id;

--- a/app/scripts/modules/azure/src/pipeline/stages/bake/azureBakeStage.js
+++ b/app/scripts/modules/azure/src/pipeline/stages/bake/azureBakeStage.js
@@ -63,12 +63,12 @@ module(AZURE_PIPELINE_STAGES_BAKE_AZUREBAKESTAGE, [AZURE_PIPELINE_STAGES_BAKE_BA
       };
 
       function initialize() {
-        $q.all({
-          regions: BakeryReader.getRegions('azure'),
-          baseOsOptions: BakeryReader.getBaseOsOptions('azure'),
-          baseLabelOptions: BakeryReader.getBaseLabelOptions(),
-        }).then(function (results) {
-          $scope.regions = results.regions;
+        $q.all([
+          BakeryReader.getRegions('azure'),
+          BakeryReader.getBaseOsOptions('azure'),
+          BakeryReader.getBaseLabelOptions(),
+        ]).then(function ([regions, baseOsOptions, baseLabelOptions]) {
+          $scope.regions = regions;
           if ($scope.regions.length === 1) {
             $scope.stage.region = $scope.regions[0];
           } else if (!$scope.regions.includes($scope.stage.region)) {
@@ -80,12 +80,12 @@ module(AZURE_PIPELINE_STAGES_BAKE_AZUREBAKESTAGE, [AZURE_PIPELINE_STAGES_BAKE_BA
           if (!$scope.stage.regions.length && $scope.application.defaultRegions.azure) {
             $scope.stage.regions.push($scope.application.defaultRegions.azure);
           }
-          $scope.baseOsOptions = results.baseOsOptions.baseImages;
+          $scope.baseOsOptions = baseOsOptions.baseImages;
           if ($scope.baseOsOptions.length) {
-            $scope.stage.osType = results.baseOsOptions.baseImages[0].osType;
+            $scope.stage.osType = baseOsOptions.baseImages[0].osType;
           }
 
-          $scope.baseLabelOptions = results.baseLabelOptions;
+          $scope.baseLabelOptions = baseLabelOptions;
 
           if (!$scope.stage.baseOs && $scope.baseOsOptions && $scope.baseOsOptions.length) {
             $scope.stage.baseOs = $scope.baseOsOptions[0].id;

--- a/app/scripts/modules/azure/src/serverGroup/configure/serverGroupCommandBuilder.service.js
+++ b/app/scripts/modules/azure/src/serverGroup/configure/serverGroupCommandBuilder.service.js
@@ -23,47 +23,41 @@ angular
       function buildNewServerGroupCommand(application, defaults) {
         defaults = defaults || {};
 
-        const imageLoader = azureImageReader.findImages({ provider: 'azure' });
-
         const defaultCredentials = defaults.account || application.defaultCredentials.azure;
         const defaultRegion = defaults.region || application.defaultRegions.azure;
 
-        return $q
-          .all({
-            images: imageLoader,
-          })
-          .then(function (backingData) {
-            return {
-              application: application.name,
-              credentials: defaultCredentials,
-              region: defaultRegion,
-              images: backingData.images,
-              loadBalancers: [],
-              selectedVnetSubnets: [],
-              strategy: '',
-              sku: {
-                capacity: 1,
-              },
-              zonesEnabled: false,
-              zones: [],
-              instanceTags: {},
-              dataDisks: [],
-              selectedProvider: 'azure',
-              viewState: {
-                instanceProfile: 'custom',
-                allImageSelection: null,
-                useAllImageSelection: false,
-                useSimpleCapacity: true,
-                usePreferredZones: true,
-                mode: defaults.mode || 'create',
-                disableStrategySelection: true,
-                loadBalancersConfigured: false,
-                networkSettingsConfigured: false,
-                securityGroupsConfigured: false,
-              },
-              enableInboundNAT: false,
-            };
-          });
+        return azureImageReader.findImages({ provider: 'azure' }).then(function (images) {
+          return {
+            application: application.name,
+            credentials: defaultCredentials,
+            region: defaultRegion,
+            images,
+            loadBalancers: [],
+            selectedVnetSubnets: [],
+            strategy: '',
+            sku: {
+              capacity: 1,
+            },
+            zonesEnabled: false,
+            zones: [],
+            instanceTags: {},
+            dataDisks: [],
+            selectedProvider: 'azure',
+            viewState: {
+              instanceProfile: 'custom',
+              allImageSelection: null,
+              useAllImageSelection: false,
+              useSimpleCapacity: true,
+              usePreferredZones: true,
+              mode: defaults.mode || 'create',
+              disableStrategySelection: true,
+              loadBalancersConfigured: false,
+              networkSettingsConfigured: false,
+              securityGroupsConfigured: false,
+            },
+            enableInboundNAT: false,
+          };
+        });
       }
 
       // Only used to prepare view requiring template selecting

--- a/app/scripts/modules/azure/src/serverGroup/configure/serverGroupCommandBuilder.service.js
+++ b/app/scripts/modules/azure/src/serverGroup/configure/serverGroupCommandBuilder.service.js
@@ -142,14 +142,9 @@ angular
       function buildServerGroupCommandFromPipeline(application, originalCluster) {
         const pipelineCluster = _.cloneDeep(originalCluster);
         const region = pipelineCluster.region;
+
         const commandOptions = { account: pipelineCluster.account, region: region };
-        const asyncLoader = $q.all({
-          command: buildNewServerGroupCommand(application, commandOptions),
-        });
-
-        return asyncLoader.then(function (asyncData) {
-          const command = asyncData.command;
-
+        return buildNewServerGroupCommand(application, commandOptions).then(function (command) {
           const viewState = {
             disableImageSelection: true,
             useSimpleCapacity: true,

--- a/app/scripts/modules/azure/src/serverGroup/configure/serverGroupConfiguration.service.js
+++ b/app/scripts/modules/azure/src/serverGroup/configure/serverGroupConfiguration.service.js
@@ -59,17 +59,21 @@ angular
 
       function configureCommand(application, command) {
         return $q
-          .all({
-            credentialsKeyedByAccount: AccountService.getCredentialsKeyedByAccount('azure'),
-            securityGroups: securityGroupReader.loadSecurityGroups(),
-            loadBalancers: loadBalancerReader.loadLoadBalancers(application.name),
-            dataDiskTypes: $q.when(angular.copy(dataDiskTypes)),
-            dataDiskCachingTypes: $q.when(angular.copy(dataDiskCachingTypes)),
-          })
-          .then(function (backingData) {
-            backingData.accounts = _.keys(backingData.credentialsKeyedByAccount);
-            backingData.filtered = {};
-            command.backingData = backingData;
+          .all([
+            AccountService.getCredentialsKeyedByAccount('azure'),
+            securityGroupReader.loadSecurityGroups(),
+            loadBalancerReader.loadLoadBalancers(application.name),
+          ])
+          .then(function ([credentialsKeyedByAccount, securityGroups, loadBalancers]) {
+            command.backingData = {
+              credentialsKeyedByAccount,
+              securityGroups,
+              loadBalancers,
+              dataDiskTypes: angular.copy(dataDiskTypes),
+              dataDiskCachingTypes: angular.copy(dataDiskCachingTypes),
+              accounts: _.keys(credentialsKeyedByAccount),
+              filtered: {},
+            };
             attachEventHandlers(command);
           });
       }

--- a/app/scripts/modules/core/src/pipeline/pipeline.dataSource.js
+++ b/app/scripts/modules/core/src/pipeline/pipeline.dataSource.js
@@ -27,7 +27,9 @@ module(CORE_PIPELINE_PIPELINE_DATASOURCE, [EXECUTION_SERVICE, CLUSTER_SERVICE]).
     const loadPipelineConfigs = (application) => {
       const pipelineLoader = PipelineConfigService.getPipelinesForApplication(application.name);
       const strategyLoader = PipelineConfigService.getStrategiesForApplication(application.name);
-      return $q.all({ pipelineConfigs: pipelineLoader, strategyConfigs: strategyLoader });
+      return $q
+        .all([pipelineLoader, strategyLoader])
+        .then(([pipelineConfigs, strategyConfigs]) => ({ pipelineConfigs, strategyConfigs }));
     };
 
     const addPipelineConfigs = (application, data) => {

--- a/app/scripts/modules/dcos/pipeline/stages/runJob/runJobStage.js
+++ b/app/scripts/modules/dcos/pipeline/stages/runJob/runJobStage.js
@@ -118,14 +118,14 @@ module(DCOS_PIPELINE_STAGES_RUNJOB_RUNJOBSTAGE, [
         }
       }
 
-      $q.all({
-        credentialsKeyedByAccount: AccountService.getCredentialsKeyedByAccount('dcos'),
-      }).then((backingData) => {
-        backingData.accounts = Object.keys(backingData.credentialsKeyedByAccount);
-        $scope.backingData = backingData;
+      AccountService.getCredentialsKeyedByAccount('dcos').then((credentialsKeyedByAccount) => {
+        $scope.backingData = {
+          credentialsKeyedByAccount,
+          accounts: Object.keys(credentialsKeyedByAccount),
+        };
 
         if (!stage.account) {
-          attemptToSetValidAccount(backingData.credentialsKeyedByAccount, stage);
+          attemptToSetValidAccount(credentialsKeyedByAccount, stage);
         }
 
         setRegistry();

--- a/app/scripts/modules/dcos/serverGroup/configure/CommandBuilder.js
+++ b/app/scripts/modules/dcos/serverGroup/configure/CommandBuilder.js
@@ -231,11 +231,7 @@ angular.module(DCOS_SERVERGROUP_CONFIGURE_COMMANDBUILDER, []).factory('dcosServe
       const pipelineCluster = _.cloneDeep(originalCluster);
 
       const commandOptions = { account: pipelineCluster.account, region: pipelineCluster.region };
-      const asyncLoader = $q.all({ command: buildNewServerGroupCommand(application, commandOptions) });
-
-      return asyncLoader.then(function (asyncData) {
-        const command = asyncData.command;
-
+      return buildNewServerGroupCommand(application, commandOptions).then(function (command) {
         let contextImages = findUpstreamImages(current, pipeline.stages) || [];
         contextImages = contextImages.concat(findTriggerImages(pipeline.triggers));
 

--- a/app/scripts/modules/docker/src/pipeline/stages/bake/dockerBakeStage.js
+++ b/app/scripts/modules/docker/src/pipeline/stages/bake/dockerBakeStage.js
@@ -49,12 +49,12 @@ module(DOCKER_PIPELINE_STAGES_BAKE_DOCKERBAKESTAGE, [DOCKER_PIPELINE_STAGES_BAKE
 
       function initialize() {
         $scope.viewState.providerSelected = true;
-        $q.all({
-          baseOsOptions: BakeryReader.getBaseOsOptions('docker'),
-          baseLabelOptions: BakeryReader.getBaseLabelOptions(),
-        }).then(function (results) {
-          $scope.baseOsOptions = results.baseOsOptions.baseImages;
-          $scope.baseLabelOptions = results.baseLabelOptions;
+        $q.all([BakeryReader.getBaseOsOptions('docker'), BakeryReader.getBaseLabelOptions()]).then(function ([
+          baseOsOptions,
+          baseLabelOptions,
+        ]) {
+          $scope.baseOsOptions = baseOsOptions.baseImages;
+          $scope.baseLabelOptions = baseLabelOptions;
 
           if (!$scope.stage.baseOs && $scope.baseOsOptions && $scope.baseOsOptions.length) {
             $scope.stage.baseOs = $scope.baseOsOptions[0].id;

--- a/app/scripts/modules/ecs/src/serverGroup/configure/serverGroupCommandBuilder.service.js
+++ b/app/scripts/modules/ecs/src/serverGroup/configure/serverGroupCommandBuilder.service.js
@@ -177,11 +177,9 @@ angular
         const pipelineCluster = _.cloneDeep(originalCluster);
         const region = Object.keys(pipelineCluster.availabilityZones)[0];
         // var instanceTypeCategoryLoader = instanceTypeService.getCategoryForInstanceType('ecs', pipelineCluster.instanceType);
-        const commandOptions = { account: pipelineCluster.account, region: region };
-        const asyncLoader = $q.all({ command: buildNewServerGroupCommand(application, commandOptions) });
 
-        return asyncLoader.then(function (asyncData) {
-          const command = asyncData.command;
+        const commandOptions = { account: pipelineCluster.account, region: region };
+        return buildNewServerGroupCommand(application, commandOptions).then(function (command) {
           const zones = pipelineCluster.availabilityZones[region];
           const usePreferredZones = zones.join(',') === command.availabilityZones.join(',');
 
@@ -193,7 +191,7 @@ angular
           }
 
           const viewState = {
-            instanceProfile: asyncData.instanceProfile,
+            instanceProfile: undefined,
             disableImageSelection: true,
             useSimpleCapacity:
               pipelineCluster.capacity.min === pipelineCluster.capacity.max &&
@@ -255,14 +253,10 @@ angular
       }
 
       function buildServerGroupCommandFromExisting(application, serverGroup, mode = 'clone') {
-        const commandOptions = { account: serverGroup.account, region: serverGroup.region };
-        const asyncLoader = $q.all({ command: buildNewServerGroupCommand(application, commandOptions) });
-
         // do NOT copy: deployment strategy. DO copy: account, region, cluster name, stack
         // TODO: query for & pull in ECS-specific data that would be useful, e.g, network mode, launch type
-        return asyncLoader.then(function (asyncData) {
-          const command = asyncData.command;
-
+        const commandOptions = { account: serverGroup.account, region: serverGroup.region };
+        return buildNewServerGroupCommand(application, commandOptions).then(function (command) {
           command.credentials = serverGroup.account;
           command.app = serverGroup.moniker.app;
           command.stack = serverGroup.moniker.stack;

--- a/app/scripts/modules/google/src/pipeline/stages/bake/gceBakeStage.js
+++ b/app/scripts/modules/google/src/pipeline/stages/bake/gceBakeStage.js
@@ -68,17 +68,14 @@ module(GOOGLE_PIPELINE_STAGES_BAKE_GCEBAKESTAGE, [GOOGLE_PIPELINE_STAGES_BAKE_BA
 
       function initialize() {
         $scope.viewState.providerSelected = true;
-        $q.all({
-          baseOsOptions: BakeryReader.getBaseOsOptions('gce'),
-          baseLabelOptions: BakeryReader.getBaseLabelOptions(),
-          expectedArtifacts: ExpectedArtifactService.getExpectedArtifactsAvailableToStage(
-            $scope.stage,
-            $scope.pipeline,
-          ),
-        }).then(function (results) {
-          $scope.baseOsOptions = results.baseOsOptions.baseImages;
-          $scope.baseLabelOptions = results.baseLabelOptions;
-          $scope.viewState.expectedArtifacts = results.expectedArtifacts;
+        $q.all([
+          BakeryReader.getBaseOsOptions('gce'),
+          BakeryReader.getBaseLabelOptions(),
+          ExpectedArtifactService.getExpectedArtifactsAvailableToStage($scope.stage, $scope.pipeline),
+        ]).then(function ([baseOsOptions, baseLabelOptions, expectedArtifacts]) {
+          $scope.baseOsOptions = baseOsOptions.baseImages;
+          $scope.baseLabelOptions = baseLabelOptions;
+          $scope.viewState.expectedArtifacts = expectedArtifacts;
 
           if (!$scope.stage.baseOs && $scope.baseOsOptions && $scope.baseOsOptions.length) {
             $scope.stage.baseOs = $scope.baseOsOptions[0].id;

--- a/app/scripts/modules/google/src/serverGroup/configure/serverGroupConfiguration.service.js
+++ b/app/scripts/modules/google/src/serverGroup/configure/serverGroupConfiguration.service.js
@@ -90,20 +90,45 @@ angular
 
       function configureCommand(application, command) {
         return $q
-          .all({
-            credentialsKeyedByAccount: AccountService.getCredentialsKeyedByAccount('gce'),
-            securityGroups: securityGroupReader.getAllSecurityGroups(),
-            networks: NetworkReader.listNetworksByProvider('gce'),
-            subnets: SubnetReader.listSubnetsByProvider('gce'),
-            loadBalancers: loadBalancerReader.listLoadBalancers('gce'),
-            allImages: loadAllImages(command.credentials),
-            instanceTypes: gceInstanceTypeService.getAllTypesByRegion(),
-            persistentDiskTypes: $q.when(angular.copy(persistentDiskTypes)),
-            authScopes: $q.when(angular.copy(authScopes)),
-            healthChecks: gceHealthCheckReader.listHealthChecks(),
-            accounts: AccountService.listAccounts('gce'),
-          })
-          .then(function (backingData) {
+          .all([
+            AccountService.getCredentialsKeyedByAccount('gce'),
+            securityGroupReader.getAllSecurityGroups(),
+            NetworkReader.listNetworksByProvider('gce'),
+            SubnetReader.listSubnetsByProvider('gce'),
+            loadBalancerReader.listLoadBalancers('gce'),
+            loadAllImages(command.credentials),
+            gceInstanceTypeService.getAllTypesByRegion(),
+            $q.when(angular.copy(persistentDiskTypes)),
+            $q.when(angular.copy(authScopes)),
+            gceHealthCheckReader.listHealthChecks(),
+            AccountService.listAccounts('gce'),
+          ])
+          .then(function ([
+            credentialsKeyedByAccount,
+            securityGroups,
+            networks,
+            subnets,
+            loadBalancers,
+            allImages,
+            instanceTypes,
+            persistentDiskTypes,
+            authScopes,
+            healthChecks,
+            accounts,
+          ]) {
+            const backingData = {
+              credentialsKeyedByAccount,
+              securityGroups,
+              networks,
+              subnets,
+              loadBalancers,
+              allImages,
+              instanceTypes,
+              persistentDiskTypes,
+              authScopes,
+              healthChecks,
+              accounts,
+            };
             let securityGroupReloader = $q.when(null);
             let networkReloader = $q.when(null);
             let healthCheckReloader = $q.when(null);

--- a/app/scripts/modules/oracle/src/pipeline/stages/bake/ociBakeStage.js
+++ b/app/scripts/modules/oracle/src/pipeline/stages/bake/ociBakeStage.js
@@ -60,36 +60,35 @@ module(ORACLE_PIPELINE_STAGES_BAKE_OCIBAKESTAGE, [ORACLE_PIPELINE_STAGES_BAKE_BA
       function initialize() {
         $scope.viewState.providerSelected = true;
 
-        $q.all({
-          baseOsOptions: BakeryReader.getBaseOsOptions(provider),
-          accounts: AccountService.listAccounts(provider),
-        }).then((results) => {
-          if (results.baseOsOptions.baseImages.length > 0) {
-            $scope.baseOsOptions = results.baseOsOptions;
-          }
-          if (!$scope.stage.user) {
-            $scope.stage.user = AuthenticationService.getAuthenticatedUser().name;
-          }
-          if (!$scope.stage.baseOs) {
-            $scope.stage.baseOs = $scope.baseOsOptions.baseImages[0].id;
-          }
-          if (!$scope.stage.upgrade) {
-            $scope.stage.upgrade = true;
-          }
+        $q.all([BakeryReader.getBaseOsOptions(provider), AccountService.listAccounts(provider)]).then(
+          ([baseOsOptions, accounts]) => {
+            if (baseOsOptions.baseImages.length > 0) {
+              $scope.baseOsOptions = baseOsOptions;
+            }
+            if (!$scope.stage.user) {
+              $scope.stage.user = AuthenticationService.getAuthenticatedUser().name;
+            }
+            if (!$scope.stage.baseOs) {
+              $scope.stage.baseOs = $scope.baseOsOptions.baseImages[0].id;
+            }
+            if (!$scope.stage.upgrade) {
+              $scope.stage.upgrade = true;
+            }
 
-          $scope.accounts = results.accounts;
+            $scope.accounts = accounts;
 
-          if ($scope.stage.accountName) {
-            AccountService.getRegionsForAccount($scope.stage.accountName).then(function (regions) {
-              if (Array.isArray(regions) && regions.length != 0) {
-                // there is exactly one region per account
-                $scope.stage.region = regions[0].name;
-              }
-            });
-          }
+            if ($scope.stage.accountName) {
+              AccountService.getRegionsForAccount($scope.stage.accountName).then(function (regions) {
+                if (Array.isArray(regions) && regions.length != 0) {
+                  // there is exactly one region per account
+                  $scope.stage.region = regions[0].name;
+                }
+              });
+            }
 
-          $scope.viewState.loading = false;
-        });
+            $scope.viewState.loading = false;
+          },
+        );
       }
 
       this.getBaseOsDescription = function (baseOsOption) {

--- a/app/scripts/modules/oracle/src/serverGroup/configure/serverGroupConfiguration.service.js
+++ b/app/scripts/modules/oracle/src/serverGroup/configure/serverGroupConfiguration.service.js
@@ -75,19 +75,24 @@ module(ORACLE_SERVERGROUP_CONFIGURE_SERVERGROUPCONFIGURATION_SERVICE, [SECURITY_
           defaults.region || application.defaultRegions.oracle || OracleProviderSettings.defaults.region;
 
         return $q
-          .all({
-            credentialsKeyedByAccount: AccountService.getCredentialsKeyedByAccount(oracle),
-            networks: NetworkReader.listNetworksByProvider(oracle),
-            subnets: SubnetReader.listSubnetsByProvider(oracle),
-            securityGroups: securityGroupReader.getAllSecurityGroups(),
-            images: loadImages(),
-            availDomains: AccountService.getAvailabilityZonesForAccountAndRegion(
-              oracle,
-              defaultCredentials,
-              defaultRegion,
-            ),
-          })
-          .then(function (backingData) {
+          .all([
+            AccountService.getCredentialsKeyedByAccount(oracle),
+            NetworkReader.listNetworksByProvider(oracle),
+            SubnetReader.listSubnetsByProvider(oracle),
+            securityGroupReader.getAllSecurityGroups(),
+            loadImages(),
+            AccountService.getAvailabilityZonesForAccountAndRegion(oracle, defaultCredentials, defaultRegion),
+          ])
+          .then(function ([credentialsKeyedByAccount, networks, subnets, securityGroups, images, availDomains]) {
+            const backingData = {
+              credentialsKeyedByAccount,
+              networks,
+              subnets,
+              securityGroups,
+              images,
+              availDomains,
+            };
+
             backingData.accounts = _.keys(backingData.credentialsKeyedByAccount);
             backingData.filtered = {};
             loadAndSelectRegions(command, backingData);

--- a/app/scripts/modules/titus/src/serverGroup/configure/ServerGroupCommandBuilder.js
+++ b/app/scripts/modules/titus/src/serverGroup/configure/ServerGroupCommandBuilder.js
@@ -178,11 +178,8 @@ angular.module(TITUS_SERVERGROUP_CONFIGURE_SERVERGROUPCOMMANDBUILDER, []).factor
         imageId: pipelineCluster.imageId,
         region: pipelineCluster.region,
       };
-      const asyncLoader = $q.all({ command: buildNewServerGroupCommand(application, commandOptions) });
 
-      return asyncLoader.then(function (asyncData) {
-        const command = asyncData.command;
-
+      return buildNewServerGroupCommand(application, commandOptions).then(function (command) {
         command.constraints = {
           hard:
             (originalCluster.constraints && originalCluster.constraints.hard) ||

--- a/app/scripts/modules/titus/src/serverGroup/configure/serverGroupConfiguration.service.ts
+++ b/app/scripts/modules/titus/src/serverGroup/configure/serverGroupConfiguration.service.ts
@@ -187,7 +187,7 @@ export class TitusServerGroupConfigurationService {
           // If our dependency is an expression, the only thing we can really do is to just preserve current selections
           backingData.filtered.regions = [{ name: cmd.region }];
         } else {
-          backingData.filtered.regions = (credentialsKeyedByAccount[cmd.credentials] || []).regions || [];
+          backingData.filtered.regions = credentialsKeyedByAccount[cmd.credentials]?.regions ?? [];
         }
         backingData.filtered.securityGroups = this.getRegionalSecurityGroups(cmd);
         cmd.backingData = backingData;


### PR DESCRIPTION
angularjs's `$q.all()` supports passing in objects with promises as properties, such as:
```
$q.all({
  foo: fetch('/foo'),
  bar: fetch('/bar'),
});
```

But no feature exists in native promises.  This PR migrates all uses of `$q.all({})` to array style.