### PR TITLE
chore(package): amazon@0.0.274 appengine@0.0.21 azure@0.0.259 cloudfoundry@0.0.105 core@0.0.522 docker@0.0.64 ecs@0.0.267 google@0.0.25 huaweicloud@0.0.7 kubernetes@0.0.53 oracle@0.0.14 tencentcloud@0.0.10 titus@0.0.149

### DIFF
--- a/app/scripts/modules/amazon/package.json
+++ b/app/scripts/modules/amazon/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/amazon",
   "license": "Apache-2.0",
-  "version": "0.0.273",
+  "version": "0.0.274",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/appengine/package.json
+++ b/app/scripts/modules/appengine/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/appengine",
   "license": "Apache-2.0",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/azure/package.json
+++ b/app/scripts/modules/azure/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/azure",
   "license": "Apache-2.0",
-  "version": "0.0.258",
+  "version": "0.0.259",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/cloudfoundry/package.json
+++ b/app/scripts/modules/cloudfoundry/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/cloudfoundry",
   "license": "Apache-2.0",
-  "version": "0.0.104",
+  "version": "0.0.105",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/core",
   "license": "Apache-2.0",
-  "version": "0.0.521",
+  "version": "0.0.522",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/docker/package.json
+++ b/app/scripts/modules/docker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/docker",
   "license": "Apache-2.0",
-  "version": "0.0.63",
+  "version": "0.0.64",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/ecs/package.json
+++ b/app/scripts/modules/ecs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/ecs",
   "license": "Apache-2.0",
-  "version": "0.0.266",
+  "version": "0.0.267",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/google/package.json
+++ b/app/scripts/modules/google/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/google",
   "license": "Apache-2.0",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/huaweicloud/package.json
+++ b/app/scripts/modules/huaweicloud/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/huaweicloud",
   "license": "Apache-2.0",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/kubernetes/package.json
+++ b/app/scripts/modules/kubernetes/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/kubernetes",
   "license": "Apache-2.0",
-  "version": "0.0.52",
+  "version": "0.0.53",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/oracle/package.json
+++ b/app/scripts/modules/oracle/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/oracle",
   "license": "Apache-2.0",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/tencentcloud/package.json
+++ b/app/scripts/modules/tencentcloud/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/tencentcloud",
   "license": "Apache-2.0",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/titus/package.json
+++ b/app/scripts/modules/titus/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/titus",
   "license": "Apache-2.0",
-  "version": "0.0.148",
+  "version": "0.0.149",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
## amazon@0.0.274

0b1e29778521da03673dc2aff083e490164ce616 chore(modules): Reformat package.json with prettier (#8679)
a220af588e194762757be534cce2d7ae9dc508d5 Revert "chore(package): amazon@0.0.274 appengine@0.0.21 azure@0.0.259 cloudfoundry@0.0.105 core@0.0.522 docker@0.0.64 ecs@0.0.267 google@0.0.25 huaweicloud@0.0.7 kubernetes@0.0.53 oracle@0.0.14 tencentcloud@0.0.10 titus@0.0.149" (#8678)
602021de4ebffc04a406d0ccd23290b548b9a9bb chore(amazon): publish amazon@0.0.274
d5ae512d5025f16a99236307c2e8fb7c019c796d chore(PromiseLike): Migrate code from IPromise types to PromiseLike
553be66f1c2757e0bb5ecfd595986697f245c041 chore(PromiseLike): Migrate code from IPromise types to PromiseLike
e622a5348f614ee8615fab13082ac5f2fdd95960 feat(typescript): Add a new `app/types` typeRoot to all the tsconfig.json files providing `PromiseLike` and *.svg imports
8b3c134d1ab82610611a194917cf5958047e1cc3 chore(package): In packages, do not use webpack to typecheck (#8670)
231f7818895e7e2a12bb3591a2112559e07ee01d chore(package): use node_modules/.bin/* in module scripts, add 'build' script (the old 'lib' script) (#8668)

## appengine@0.0.21

0b1e29778521da03673dc2aff083e490164ce616 chore(modules): Reformat package.json with prettier (#8679)
a220af588e194762757be534cce2d7ae9dc508d5 Revert "chore(package): amazon@0.0.274 appengine@0.0.21 azure@0.0.259 cloudfoundry@0.0.105 core@0.0.522 docker@0.0.64 ecs@0.0.267 google@0.0.25 huaweicloud@0.0.7 kubernetes@0.0.53 oracle@0.0.14 tencentcloud@0.0.10 titus@0.0.149" (#8678)
dad138da83c4aa7881f5dfcd26be1ebc67e2b5a8 chore(appengine): publish appengine@0.0.21
d5ae512d5025f16a99236307c2e8fb7c019c796d chore(PromiseLike): Migrate code from IPromise types to PromiseLike
e622a5348f614ee8615fab13082ac5f2fdd95960 feat(typescript): Add a new `app/types` typeRoot to all the tsconfig.json files providing `PromiseLike` and *.svg imports
8b3c134d1ab82610611a194917cf5958047e1cc3 chore(package): In packages, do not use webpack to typecheck (#8670)
231f7818895e7e2a12bb3591a2112559e07ee01d chore(package): use node_modules/.bin/* in module scripts, add 'build' script (the old 'lib' script) (#8668)

## azure@0.0.259

0b1e29778521da03673dc2aff083e490164ce616 chore(modules): Reformat package.json with prettier (#8679)
a220af588e194762757be534cce2d7ae9dc508d5 Revert "chore(package): amazon@0.0.274 appengine@0.0.21 azure@0.0.259 cloudfoundry@0.0.105 core@0.0.522 docker@0.0.64 ecs@0.0.267 google@0.0.25 huaweicloud@0.0.7 kubernetes@0.0.53 oracle@0.0.14 tencentcloud@0.0.10 titus@0.0.149" (#8678)
7852568ddb76c0d430eb6e4eabff37bc315fb0cf chore(azure): publish azure@0.0.259
e622a5348f614ee8615fab13082ac5f2fdd95960 feat(typescript): Add a new `app/types` typeRoot to all the tsconfig.json files providing `PromiseLike` and *.svg imports
8b3c134d1ab82610611a194917cf5958047e1cc3 chore(package): In packages, do not use webpack to typecheck (#8670)
231f7818895e7e2a12bb3591a2112559e07ee01d chore(package): use node_modules/.bin/* in module scripts, add 'build' script (the old 'lib' script) (#8668)

## cloudfoundry@0.0.105

0b1e29778521da03673dc2aff083e490164ce616 chore(modules): Reformat package.json with prettier (#8679)
a220af588e194762757be534cce2d7ae9dc508d5 Revert "chore(package): amazon@0.0.274 appengine@0.0.21 azure@0.0.259 cloudfoundry@0.0.105 core@0.0.522 docker@0.0.64 ecs@0.0.267 google@0.0.25 huaweicloud@0.0.7 kubernetes@0.0.53 oracle@0.0.14 tencentcloud@0.0.10 titus@0.0.149" (#8678)
6d4e22c7ac49060d201cb98d3ff66a55f8144c3b chore(cloudfoundry): publish cloudfoundry@0.0.105
d5ae512d5025f16a99236307c2e8fb7c019c796d chore(PromiseLike): Migrate code from IPromise types to PromiseLike
e622a5348f614ee8615fab13082ac5f2fdd95960 feat(typescript): Add a new `app/types` typeRoot to all the tsconfig.json files providing `PromiseLike` and *.svg imports
8b3c134d1ab82610611a194917cf5958047e1cc3 chore(package): In packages, do not use webpack to typecheck (#8670)
231f7818895e7e2a12bb3591a2112559e07ee01d chore(package): use node_modules/.bin/* in module scripts, add 'build' script (the old 'lib' script) (#8668)

## core@0.0.522

0b1e29778521da03673dc2aff083e490164ce616 chore(modules): Reformat package.json with prettier (#8679)
a220af588e194762757be534cce2d7ae9dc508d5 Revert "chore(package): amazon@0.0.274 appengine@0.0.21 azure@0.0.259 cloudfoundry@0.0.105 core@0.0.522 docker@0.0.64 ecs@0.0.267 google@0.0.25 huaweicloud@0.0.7 kubernetes@0.0.53 oracle@0.0.14 tencentcloud@0.0.10 titus@0.0.149" (#8678)
343296b1a0404c142a2c6cf23f30d66a527a375a chore(core): publish core@0.0.522
1e2032bb39d6b524a3dfae3df9c4bd6862c40057 chore(PromiseLike): Migrate code from IPromise types to PromiseLike
553be66f1c2757e0bb5ecfd595986697f245c041 chore(PromiseLike): Migrate code from IPromise types to PromiseLike
e622a5348f614ee8615fab13082ac5f2fdd95960 feat(typescript): Add a new `app/types` typeRoot to all the tsconfig.json files providing `PromiseLike` and *.svg imports
c9c0b4dc0d071e737090745f450fef0e84b08c74 feat($q): Adds PromiseLike compatibility to $q and $q promises
8b3c134d1ab82610611a194917cf5958047e1cc3 chore(package): In packages, do not use webpack to typecheck (#8670)
231f7818895e7e2a12bb3591a2112559e07ee01d chore(package): use node_modules/.bin/* in module scripts, add 'build' script (the old 'lib' script) (#8668)
f3e1d6e5f78b9149c5a89f5a84992357c289a1f0 fix(core): Check if manifest event is null from k8s. (#8666)
6022821f895597e7bf8b9d62d02d7ba5c92ab70f fix(deck): Bugfix 6112: provide default settings for oracle provider in deck microservice to remove Halyard dependency. (#8665)
926b1bd8943144648d503c011d2c0a68a6f0c17b feat(core/managed): run commit messages through Markdown (#8664)

## docker@0.0.64

0b1e29778521da03673dc2aff083e490164ce616 chore(modules): Reformat package.json with prettier (#8679)
a220af588e194762757be534cce2d7ae9dc508d5 Revert "chore(package): amazon@0.0.274 appengine@0.0.21 azure@0.0.259 cloudfoundry@0.0.105 core@0.0.522 docker@0.0.64 ecs@0.0.267 google@0.0.25 huaweicloud@0.0.7 kubernetes@0.0.53 oracle@0.0.14 tencentcloud@0.0.10 titus@0.0.149" (#8678)
3207ad00ba4699aed8555ae74967dd2912098d90 chore(docker): publish docker@0.0.64
553be66f1c2757e0bb5ecfd595986697f245c041 chore(PromiseLike): Migrate code from IPromise types to PromiseLike
e622a5348f614ee8615fab13082ac5f2fdd95960 feat(typescript): Add a new `app/types` typeRoot to all the tsconfig.json files providing `PromiseLike` and *.svg imports
8b3c134d1ab82610611a194917cf5958047e1cc3 chore(package): In packages, do not use webpack to typecheck (#8670)
231f7818895e7e2a12bb3591a2112559e07ee01d chore(package): use node_modules/.bin/* in module scripts, add 'build' script (the old 'lib' script) (#8668)

## ecs@0.0.267

0b1e29778521da03673dc2aff083e490164ce616 chore(modules): Reformat package.json with prettier (#8679)
a220af588e194762757be534cce2d7ae9dc508d5 Revert "chore(package): amazon@0.0.274 appengine@0.0.21 azure@0.0.259 cloudfoundry@0.0.105 core@0.0.522 docker@0.0.64 ecs@0.0.267 google@0.0.25 huaweicloud@0.0.7 kubernetes@0.0.53 oracle@0.0.14 tencentcloud@0.0.10 titus@0.0.149" (#8678)
a7dc7e5d574559a5b6aea7631fe3245d14f1cbac chore(ecs): publish ecs@0.0.267
e622a5348f614ee8615fab13082ac5f2fdd95960 feat(typescript): Add a new `app/types` typeRoot to all the tsconfig.json files providing `PromiseLike` and *.svg imports
8b3c134d1ab82610611a194917cf5958047e1cc3 chore(package): In packages, do not use webpack to typecheck (#8670)
231f7818895e7e2a12bb3591a2112559e07ee01d chore(package): use node_modules/.bin/* in module scripts, add 'build' script (the old 'lib' script) (#8668)

## google@0.0.25

0b1e29778521da03673dc2aff083e490164ce616 chore(modules): Reformat package.json with prettier (#8679)
a220af588e194762757be534cce2d7ae9dc508d5 Revert "chore(package): amazon@0.0.274 appengine@0.0.21 azure@0.0.259 cloudfoundry@0.0.105 core@0.0.522 docker@0.0.64 ecs@0.0.267 google@0.0.25 huaweicloud@0.0.7 kubernetes@0.0.53 oracle@0.0.14 tencentcloud@0.0.10 titus@0.0.149" (#8678)
6ccd3bdb593e4b75c1c79c5fc27bbb60a657199c chore(google): publish google@0.0.25
1e2032bb39d6b524a3dfae3df9c4bd6862c40057 chore(PromiseLike): Migrate code from IPromise types to PromiseLike
e622a5348f614ee8615fab13082ac5f2fdd95960 feat(typescript): Add a new `app/types` typeRoot to all the tsconfig.json files providing `PromiseLike` and *.svg imports
8b3c134d1ab82610611a194917cf5958047e1cc3 chore(package): In packages, do not use webpack to typecheck (#8670)
231f7818895e7e2a12bb3591a2112559e07ee01d chore(package): use node_modules/.bin/* in module scripts, add 'build' script (the old 'lib' script) (#8668)

## huaweicloud@0.0.7

0b1e29778521da03673dc2aff083e490164ce616 chore(modules): Reformat package.json with prettier (#8679)
a220af588e194762757be534cce2d7ae9dc508d5 Revert "chore(package): amazon@0.0.274 appengine@0.0.21 azure@0.0.259 cloudfoundry@0.0.105 core@0.0.522 docker@0.0.64 ecs@0.0.267 google@0.0.25 huaweicloud@0.0.7 kubernetes@0.0.53 oracle@0.0.14 tencentcloud@0.0.10 titus@0.0.149" (#8678)
c7279a2787598106b2baef38df1c1971e506b268 chore(huaweicloud): publish huaweicloud@0.0.7
e622a5348f614ee8615fab13082ac5f2fdd95960 feat(typescript): Add a new `app/types` typeRoot to all the tsconfig.json files providing `PromiseLike` and *.svg imports
8b3c134d1ab82610611a194917cf5958047e1cc3 chore(package): In packages, do not use webpack to typecheck (#8670)
231f7818895e7e2a12bb3591a2112559e07ee01d chore(package): use node_modules/.bin/* in module scripts, add 'build' script (the old 'lib' script) (#8668)

## kubernetes@0.0.53

0b1e29778521da03673dc2aff083e490164ce616 chore(modules): Reformat package.json with prettier (#8679)
a220af588e194762757be534cce2d7ae9dc508d5 Revert "chore(package): amazon@0.0.274 appengine@0.0.21 azure@0.0.259 cloudfoundry@0.0.105 core@0.0.522 docker@0.0.64 ecs@0.0.267 google@0.0.25 huaweicloud@0.0.7 kubernetes@0.0.53 oracle@0.0.14 tencentcloud@0.0.10 titus@0.0.149" (#8678)
450e7cb71c60ca8d4de1caf904b0ac5c3c03cbce chore(kubernetes): publish kubernetes@0.0.53
553be66f1c2757e0bb5ecfd595986697f245c041 chore(PromiseLike): Migrate code from IPromise types to PromiseLike
e622a5348f614ee8615fab13082ac5f2fdd95960 feat(typescript): Add a new `app/types` typeRoot to all the tsconfig.json files providing `PromiseLike` and *.svg imports
8b3c134d1ab82610611a194917cf5958047e1cc3 chore(package): In packages, do not use webpack to typecheck (#8670)
231f7818895e7e2a12bb3591a2112559e07ee01d chore(package): use node_modules/.bin/* in module scripts, add 'build' script (the old 'lib' script) (#8668)
67c0d3d195bdc89545b4e923081658499b7fed4e  fix(kubernetes): remove unneeded application validation warning  (#8662)

## oracle@0.0.14

0b1e29778521da03673dc2aff083e490164ce616 chore(modules): Reformat package.json with prettier (#8679)
a220af588e194762757be534cce2d7ae9dc508d5 Revert "chore(package): amazon@0.0.274 appengine@0.0.21 azure@0.0.259 cloudfoundry@0.0.105 core@0.0.522 docker@0.0.64 ecs@0.0.267 google@0.0.25 huaweicloud@0.0.7 kubernetes@0.0.53 oracle@0.0.14 tencentcloud@0.0.10 titus@0.0.149" (#8678)
e083d752135993bf2fe2441a8d76f4fe8247be04 chore(oracle): publish oracle@0.0.14
e622a5348f614ee8615fab13082ac5f2fdd95960 feat(typescript): Add a new `app/types` typeRoot to all the tsconfig.json files providing `PromiseLike` and *.svg imports
8b3c134d1ab82610611a194917cf5958047e1cc3 chore(package): In packages, do not use webpack to typecheck (#8670)
231f7818895e7e2a12bb3591a2112559e07ee01d chore(package): use node_modules/.bin/* in module scripts, add 'build' script (the old 'lib' script) (#8668)
6022821f895597e7bf8b9d62d02d7ba5c92ab70f fix(deck): Bugfix 6112: provide default settings for oracle provider in deck microservice to remove Halyard dependency. (#8665)

## tencentcloud@0.0.10

0b1e29778521da03673dc2aff083e490164ce616 chore(modules): Reformat package.json with prettier (#8679)
a220af588e194762757be534cce2d7ae9dc508d5 Revert "chore(package): amazon@0.0.274 appengine@0.0.21 azure@0.0.259 cloudfoundry@0.0.105 core@0.0.522 docker@0.0.64 ecs@0.0.267 google@0.0.25 huaweicloud@0.0.7 kubernetes@0.0.53 oracle@0.0.14 tencentcloud@0.0.10 titus@0.0.149" (#8678)
10b8d8644e2877cc069e8efcbce3fc4336c4ceb2 chore(tencentcloud): publish tencentcloud@0.0.10
e622a5348f614ee8615fab13082ac5f2fdd95960 feat(typescript): Add a new `app/types` typeRoot to all the tsconfig.json files providing `PromiseLike` and *.svg imports
8b3c134d1ab82610611a194917cf5958047e1cc3 chore(package): In packages, do not use webpack to typecheck (#8670)
231f7818895e7e2a12bb3591a2112559e07ee01d chore(package): use node_modules/.bin/* in module scripts, add 'build' script (the old 'lib' script) (#8668)

## titus@0.0.149

0b1e29778521da03673dc2aff083e490164ce616 chore(modules): Reformat package.json with prettier (#8679)
a220af588e194762757be534cce2d7ae9dc508d5 Revert "chore(package): amazon@0.0.274 appengine@0.0.21 azure@0.0.259 cloudfoundry@0.0.105 core@0.0.522 docker@0.0.64 ecs@0.0.267 google@0.0.25 huaweicloud@0.0.7 kubernetes@0.0.53 oracle@0.0.14 tencentcloud@0.0.10 titus@0.0.149" (#8678)
f41283f0f9d32bb88f7857c8f189e665b6fe8a72 chore(titus): publish titus@0.0.149
e622a5348f614ee8615fab13082ac5f2fdd95960 feat(typescript): Add a new `app/types` typeRoot to all the tsconfig.json files providing `PromiseLike` and *.svg imports
8b3c134d1ab82610611a194917cf5958047e1cc3 chore(package): In packages, do not use webpack to typecheck (#8670)
231f7818895e7e2a12bb3591a2112559e07ee01d chore(package): use node_modules/.bin/* in module scripts, add 'build' script (the old 'lib' script) (#8668)

PR created via `modules/publish.js`