### PR TITLE
fix(githubactions): switch approve_package_bumps to rebase

### DIFF
--- a/.github/workflows/approve_package_bumps.yml
+++ b/.github/workflows/approve_package_bumps.yml
@@ -48,5 +48,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              labels: ['ready to merge']
+              labels: ['ready to rebase']
             })


### PR DESCRIPTION
Switch from 'ready to merge' to 'ready to rebase' to retain the original commit message with changelog
