### PR TITLE
fix(packages): fix show_changelog.sh to work when a package bump is reverted

### DIFF
--- a/app/scripts/modules/show_changelog.sh
+++ b/app/scripts/modules/show_changelog.sh
@@ -48,12 +48,12 @@ ENDSHA=HEAD
 if [[ -z $STARTVERSION ]] ; then
   STARTSHA=$($SCRIPTDIR/show_package_bumps.js "$PACKAGEJSON" | head -n 1 | awk '{ print $1; }')
 else
-  STARTSHA=$($SCRIPTDIR/show_package_bumps.js "$PACKAGEJSON" | grep "${STARTVERSION}" | awk '{ print $1; }')
+  STARTSHA=$($SCRIPTDIR/show_package_bumps.js "$PACKAGEJSON" | grep " ${STARTVERSION}$" | tail -n 1 | awk '{ print $1; }')
 fi
 
 # Find the ending SHA
 if [[ ! -z $ENDVERSION ]] ; then
-  ENDSHA=$($SCRIPTDIR/show_package_bumps.js "$PACKAGEJSON" | grep "${ENDVERSION}" | awk '{ print $1; }')
+  ENDSHA=$($SCRIPTDIR/show_package_bumps.js "$PACKAGEJSON" | grep " ${ENDVERSION}$" | head -n 1 | awk '{ print $1; }')
 fi
 
 if [[ -z "$STARTSHA" || -z "$ENDSHA" ]] ; then


### PR DESCRIPTION
fix 1) picks one version when multiple commits have package bump (startsha: earliest, endsha: latest)
fix 2) fix grep wildcards (0.0.3 also matches 0.0.330)

In a220af588e194762757be534cce2d7ae9dc508d5 a package bump was reverted due to github actions automation failures.
After re-applying the package bumps, the changelog generator was broken because there were two commit shas that matched each package bump's version number.

This fix just picks the earliest commit for the startsha and the latest commit for the endsha when computing the change log.