### PR TITLE
feat(core/clusterFilter): Sort cluster filter values alphabetically

### DIFF
--- a/app/scripts/modules/core/src/cluster/filter/ClusterFilters.tsx
+++ b/app/scripts/modules/core/src/cluster/filter/ClusterFilters.tsx
@@ -244,7 +244,7 @@ export const ClusterFilters = ({ app }: IClusterFiltersProps) => {
           <FilterSection key="filter-status" heading="Status" expanded={true}>
             <div className="form">
               {['Up', 'Down', 'Disabled', 'Starting', 'OutOfService', 'Unknown'].map((status) => (
-                <div className="checkbox">
+                <div className="checkbox" key={status}>
                   <label>
                     <input
                       key={status}

--- a/app/scripts/modules/core/src/filterModel/dependentFilter/DependentFilterService.spec.ts
+++ b/app/scripts/modules/core/src/filterModel/dependentFilter/DependentFilterService.spec.ts
@@ -141,8 +141,8 @@ describe('Service: dependentFilterService', function () {
           dependencyOrder,
         });
 
-        expect(region).toEqual(['us-central1', 'asia-east1']);
-        expect(availabilityZone).toEqual(['us-central1-f', 'asia-east1-c', 'asia-east1-b']);
+        expect(region).toEqual(['asia-east1', 'us-central1']);
+        expect(availabilityZone).toEqual(['asia-east1-b', 'asia-east1-c', 'us-central1-f']);
         expect(instanceType).toEqual(['f1-micro']);
       });
 
@@ -157,7 +157,7 @@ describe('Service: dependentFilterService', function () {
         const { region, availabilityZone } = digestDependentFilters({ sortFilter, pool, dependencyOrder });
 
         expect(region.length).toEqual(3);
-        expect(availabilityZone).toEqual(['asia-east1-c', 'asia-east1-b']);
+        expect(availabilityZone).toEqual(['asia-east1-b', 'asia-east1-c']);
       });
 
       it(`should return us-west-2a, us-west-2b, and Amazon regions
@@ -211,8 +211,8 @@ describe('Service: dependentFilterService', function () {
         } as any;
         const { region, availabilityZone } = digestDependentFilters({ sortFilter, pool, dependencyOrder });
 
-        expect(region).toEqual(['us-central1', 'asia-east1']);
-        expect(availabilityZone).toEqual(['us-central1-f', 'asia-east1-c', 'asia-east1-b']);
+        expect(region).toEqual(['asia-east1', 'us-central1']);
+        expect(availabilityZone).toEqual(['asia-east1-b', 'asia-east1-c', 'us-central1-f']);
         expect(sortFilter.region['us-west-2']).not.toBeDefined();
       });
 
@@ -225,8 +225,8 @@ describe('Service: dependentFilterService', function () {
         } as any;
         const { region, availabilityZone } = digestDependentFilters({ sortFilter, pool, dependencyOrder });
 
-        expect(region).toEqual(['us-central1', 'asia-east1']);
-        expect(availabilityZone).toEqual(['us-central1-f', 'asia-east1-c', 'asia-east1-b']);
+        expect(region).toEqual(['asia-east1', 'us-central1']);
+        expect(availabilityZone).toEqual(['asia-east1-b', 'asia-east1-c', 'us-central1-f']);
         expect(sortFilter.availabilityZone['us-west-2a']).not.toBeDefined();
       });
 
@@ -243,8 +243,8 @@ describe('Service: dependentFilterService', function () {
           dependencyOrder,
         });
 
-        expect(region).toEqual(['us-central1', 'asia-east1']);
-        expect(availabilityZone).toEqual(['us-central1-f', 'asia-east1-c', 'asia-east1-b']);
+        expect(region).toEqual(['asia-east1', 'us-central1']);
+        expect(availabilityZone).toEqual(['asia-east1-b', 'asia-east1-c', 'us-central1-f']);
         expect(instanceType).toEqual(['f1-micro']);
         expect(sortFilter.availabilityZone['us-west-2a']).not.toBeDefined();
         expect(sortFilter.region['us-west-2']).not.toBeDefined();
@@ -263,7 +263,7 @@ describe('Service: dependentFilterService', function () {
         });
 
         expect(region.length).toEqual(3);
-        expect(availabilityZone).toEqual(['asia-east1-c', 'asia-east1-b']);
+        expect(availabilityZone).toEqual(['asia-east1-b', 'asia-east1-c']);
         expect(instanceType).toEqual(['f1-micro']);
         expect(sortFilter.availabilityZone['us-central1-f']).not.toBeDefined();
       });

--- a/app/scripts/modules/core/src/filterModel/dependentFilter/DependentFilterService.ts
+++ b/app/scripts/modules/core/src/filterModel/dependentFilter/DependentFilterService.ts
@@ -5,7 +5,7 @@ import { ISortFilter } from '../IFilterModel';
 function generateIterator(sortFilter: ISortFilter & { [key: string]: any }) {
   return function iterator(acc: { headings: any; pool: any }, headingType: string) {
     const { headings, pool } = acc;
-    headings[headingType] = chain(pool).map(headingType).uniq().compact().value();
+    headings[headingType] = chain(pool).map(headingType).uniq().compact().value().sort();
     unselectUnavailableHeadings(headings[headingType], sortFilter[headingType]);
     acc.pool = filterPoolBySelectedHeadings(pool, headingType, sortFilter);
     return acc;


### PR DESCRIPTION
- Filter values like `detail`, `stack` are [alphabetically sorted](https://github.com/spinnaker/deck/blob/95e43d430b434157e00f7f462768ecae4bde5173/app/scripts/modules/core/src/cluster/filter/ClusterFilters.tsx#L51), so making the other ones alphabetically sorted as well in this PR. 

- Fixed the annoying react warning about missing keys in `ClusterFilters`