### PR TITLE
chore(package): amazon@0.0.275 appengine@0.0.22 azure@0.0.260 cloudfoundry@0.0.106 core@0.0.523 docker@0.0.65 ecs@0.0.268 google@0.0.26 kubernetes@0.0.54 oracle@0.0.15 tencentcloud@0.0.11 titus@0.0.150

### DIFF
--- a/app/scripts/modules/amazon/package.json
+++ b/app/scripts/modules/amazon/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/amazon",
   "license": "Apache-2.0",
-  "version": "0.0.274",
+  "version": "0.0.275",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/appengine/package.json
+++ b/app/scripts/modules/appengine/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/appengine",
   "license": "Apache-2.0",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/azure/package.json
+++ b/app/scripts/modules/azure/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/azure",
   "license": "Apache-2.0",
-  "version": "0.0.259",
+  "version": "0.0.260",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/cloudfoundry/package.json
+++ b/app/scripts/modules/cloudfoundry/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/cloudfoundry",
   "license": "Apache-2.0",
-  "version": "0.0.105",
+  "version": "0.0.106",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/core",
   "license": "Apache-2.0",
-  "version": "0.0.522",
+  "version": "0.0.523",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/docker/package.json
+++ b/app/scripts/modules/docker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/docker",
   "license": "Apache-2.0",
-  "version": "0.0.64",
+  "version": "0.0.65",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/ecs/package.json
+++ b/app/scripts/modules/ecs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/ecs",
   "license": "Apache-2.0",
-  "version": "0.0.267",
+  "version": "0.0.268",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/google/package.json
+++ b/app/scripts/modules/google/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/google",
   "license": "Apache-2.0",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/kubernetes/package.json
+++ b/app/scripts/modules/kubernetes/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/kubernetes",
   "license": "Apache-2.0",
-  "version": "0.0.53",
+  "version": "0.0.54",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/oracle/package.json
+++ b/app/scripts/modules/oracle/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/oracle",
   "license": "Apache-2.0",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/tencentcloud/package.json
+++ b/app/scripts/modules/tencentcloud/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/tencentcloud",
   "license": "Apache-2.0",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/titus/package.json
+++ b/app/scripts/modules/titus/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/titus",
   "license": "Apache-2.0",
-  "version": "0.0.149",
+  "version": "0.0.150",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
## amazon@0.0.275

1df3daa88209e885abb3d528edae4a942a060afb chore(promiselike): Migrate more code away from angularjs IPromise to PromiseLike (#8687)
d15ca2d56ef4bf924b089c73bb612d302b10fdd2 refactor(aws/instance): Reactify instance tags and security groups (#8686)
ab6cc5edf7c0563d5a32c8a54d8a614f09ed315c chore(titus/serverGroup): Migrate from $q.all({}) to $q.all([])
894caf73e1131d3cd8dfae45a6551ff5bbb14475 chore(titus/serverGroup): Migrate from $q.all({}) to $q.all([])
96df008b5d2b5f187d07c002aa5e9b6a0c90e73c chore(amazon/serverGroup): Migrate from $q.all({}) to $q.all([])

## appengine@0.0.22

1df3daa88209e885abb3d528edae4a942a060afb chore(promiselike): Migrate more code away from angularjs IPromise to PromiseLike (#8687)

## azure@0.0.260

7cc752b3c63745f06aba45ef142424344ad6fda2 chore(azure/pipeline): Migrate from $q.all({}) to $q.all([])
8ab8a0bafc3b51806bfa52a491daf5bce00b3092 chore(azure/serverGroup): Migrate from $q.all({}) to $q.all([])
cadfff2415caccf0ce3fe613aa10c2ec071f5d2f chore(azure/serverGroup): Migrate from $q.all({}) to $q.all([])
87ef51c43670b0988c446bccdbf00a6205385124 chore(google/pipeline): Migrate from $q.all({}) to $q.all([])

## cloudfoundry@0.0.106

1df3daa88209e885abb3d528edae4a942a060afb chore(promiselike): Migrate more code away from angularjs IPromise to PromiseLike (#8687)

## core@0.0.523

6da861a12aaeda744b253491cb67e2b141fe7362 feat(core/clusterFilter): Sort cluster filter values alphabetically (#8689)
1df3daa88209e885abb3d528edae4a942a060afb chore(promiselike): Migrate more code away from angularjs IPromise to PromiseLike (#8687)
947cee14d35f9137d96bc874a5169693470b5252 refactor(storybook/forms): Rewrite stories for SpinFormik (#8660)
d15ca2d56ef4bf924b089c73bb612d302b10fdd2 refactor(aws/instance): Reactify instance tags and security groups (#8686)
9b8795dc07e188afd5bcf9b537e4b56f6926e71d feat(core/managed): add DIFF_NOT_ACTIONABLE resource status (#8681)
2c8b8566e467ce2cf24437a1acd5209f57c66175 chore(eslint): pre-fix linter violations from upcoming eslint-plugin release (#8684)
9de2547deb22111fb94ea33dde4ac1859c0767c0 chore(oracle/serverGroup): Migrate from $q.all({}) to $q.all([])

## docker@0.0.65

d38ff76bc2b54e04ca992ede3436bde5ae45a9c5 chore(docker/pipeline): Migrate from $q.all({}) to $q.all([])

## ecs@0.0.268

1df3daa88209e885abb3d528edae4a942a060afb chore(promiselike): Migrate more code away from angularjs IPromise to PromiseLike (#8687)
27583e5d3d66277eaeb98d4fa85103a140985c08 chore(ecs/serverGroup): Migrate from $q.all({}) to $q.all([])

## google@0.0.26

1df3daa88209e885abb3d528edae4a942a060afb chore(promiselike): Migrate more code away from angularjs IPromise to PromiseLike (#8687)
ec9a5316b133696aad7b535e777586bbb3ccffe8 chore(google/serverGroup): Migrate from $q.all({}) to $q.all([])
9886b795b57d76a96e831ae3f815775459575c76 chore(google/pipeline): Migrate from $q.all({}) to $q.all([])
00d946c7b9bee99ec9c6a492b3d5a456973de142 chore(google/serverGroup): Migrate from $q.all({}) to $q.all([])

## kubernetes@0.0.54

1df3daa88209e885abb3d528edae4a942a060afb chore(promiselike): Migrate more code away from angularjs IPromise to PromiseLike (#8687)

## oracle@0.0.15

1df3daa88209e885abb3d528edae4a942a060afb chore(promiselike): Migrate more code away from angularjs IPromise to PromiseLike (#8687)
5c0713ab8103491d71614a23f2163c6c9f61640f chore(oracle/serverGroup): Migrate from $q.all({}) to $q.all([])
c6208823ab8a49643f132a08515261ef79449d5d chore(oracle/serverGroup): Migrate from $q.all({}) to $q.all([])

## tencentcloud@0.0.11

1df3daa88209e885abb3d528edae4a942a060afb chore(promiselike): Migrate more code away from angularjs IPromise to PromiseLike (#8687)

## titus@0.0.150

1df3daa88209e885abb3d528edae4a942a060afb chore(promiselike): Migrate more code away from angularjs IPromise to PromiseLike (#8687)
f8b38de539c2023e994fb34cd0f67c3fea163e69 chore(amazon/serverGroup): Fix typing bug
37ff2df776e761dbb286fde994259e288cf0add3 chore(amazon/serverGroup): Migrate from $q.all({}) to $q.all([])
70d8d7aa05f26f0a14939c4e375a75ceece1dcf8 chore(titus/serverGroup): Migrate from $q.all({}) to $q.all([])

PR created via `modules/publish.js`