### PR TITLE
chore(package): amazon@0.0.276 appengine@0.0.23 azure@0.0.261 cloudfoundry@0.0.107 core@0.0.524 docker@0.0.66 ecs@0.0.269 google@0.0.27 huaweicloud@0.0.8 kubernetes@0.0.55 oracle@0.0.16 tencentcloud@0.0.12 titus@0.0.151

### DIFF
--- a/app/scripts/modules/amazon/package.json
+++ b/app/scripts/modules/amazon/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/amazon",
   "license": "Apache-2.0",
-  "version": "0.0.275",
+  "version": "0.0.276",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/appengine/package.json
+++ b/app/scripts/modules/appengine/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/appengine",
   "license": "Apache-2.0",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/azure/package.json
+++ b/app/scripts/modules/azure/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/azure",
   "license": "Apache-2.0",
-  "version": "0.0.260",
+  "version": "0.0.261",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/cloudfoundry/package.json
+++ b/app/scripts/modules/cloudfoundry/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/cloudfoundry",
   "license": "Apache-2.0",
-  "version": "0.0.106",
+  "version": "0.0.107",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/core",
   "license": "Apache-2.0",
-  "version": "0.0.523",
+  "version": "0.0.524",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/docker/package.json
+++ b/app/scripts/modules/docker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/docker",
   "license": "Apache-2.0",
-  "version": "0.0.65",
+  "version": "0.0.66",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/ecs/package.json
+++ b/app/scripts/modules/ecs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/ecs",
   "license": "Apache-2.0",
-  "version": "0.0.268",
+  "version": "0.0.269",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/google/package.json
+++ b/app/scripts/modules/google/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/google",
   "license": "Apache-2.0",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/huaweicloud/package.json
+++ b/app/scripts/modules/huaweicloud/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/huaweicloud",
   "license": "Apache-2.0",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/kubernetes/package.json
+++ b/app/scripts/modules/kubernetes/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/kubernetes",
   "license": "Apache-2.0",
-  "version": "0.0.54",
+  "version": "0.0.55",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/oracle/package.json
+++ b/app/scripts/modules/oracle/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/oracle",
   "license": "Apache-2.0",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/tencentcloud/package.json
+++ b/app/scripts/modules/tencentcloud/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/tencentcloud",
   "license": "Apache-2.0",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/titus/package.json
+++ b/app/scripts/modules/titus/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/titus",
   "license": "Apache-2.0",
-  "version": "0.0.150",
+  "version": "0.0.151",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
## amazon@0.0.276

a929d3fa4db978aaf7b6d8ada12abc5b03403821 fix(promiselike): Revert typeRoots tsconfig change, move types to src/types and add KLUDGE to expose them in the @spinnaker/core bundle
2c0d0f6814689d93820eab4e97e5d89f98a61cc5 chore(PromiseLike): Migrate remaining IPromise typings to PromiseLike
d40cc6d0fe5a3ca9b441f379105c229388a1f7b3 feat(aws): Display CPU credit specification in Launch Template section (#8654)

## appengine@0.0.23

a929d3fa4db978aaf7b6d8ada12abc5b03403821 fix(promiselike): Revert typeRoots tsconfig change, move types to src/types and add KLUDGE to expose them in the @spinnaker/core bundle
2c0d0f6814689d93820eab4e97e5d89f98a61cc5 chore(PromiseLike): Migrate remaining IPromise typings to PromiseLike

## azure@0.0.261

a929d3fa4db978aaf7b6d8ada12abc5b03403821 fix(promiselike): Revert typeRoots tsconfig change, move types to src/types and add KLUDGE to expose them in the @spinnaker/core bundle

## cloudfoundry@0.0.107

a929d3fa4db978aaf7b6d8ada12abc5b03403821 fix(promiselike): Revert typeRoots tsconfig change, move types to src/types and add KLUDGE to expose them in the @spinnaker/core bundle

## core@0.0.524

a929d3fa4db978aaf7b6d8ada12abc5b03403821 fix(promiselike): Revert typeRoots tsconfig change, move types to src/types and add KLUDGE to expose them in the @spinnaker/core bundle
2c0d0f6814689d93820eab4e97e5d89f98a61cc5 chore(PromiseLike): Migrate remaining IPromise typings to PromiseLike

## docker@0.0.66

a929d3fa4db978aaf7b6d8ada12abc5b03403821 fix(promiselike): Revert typeRoots tsconfig change, move types to src/types and add KLUDGE to expose them in the @spinnaker/core bundle
2c0d0f6814689d93820eab4e97e5d89f98a61cc5 chore(PromiseLike): Migrate remaining IPromise typings to PromiseLike

## ecs@0.0.269

a929d3fa4db978aaf7b6d8ada12abc5b03403821 fix(promiselike): Revert typeRoots tsconfig change, move types to src/types and add KLUDGE to expose them in the @spinnaker/core bundle
2c0d0f6814689d93820eab4e97e5d89f98a61cc5 chore(PromiseLike): Migrate remaining IPromise typings to PromiseLike

## google@0.0.27

a929d3fa4db978aaf7b6d8ada12abc5b03403821 fix(promiselike): Revert typeRoots tsconfig change, move types to src/types and add KLUDGE to expose them in the @spinnaker/core bundle
2c0d0f6814689d93820eab4e97e5d89f98a61cc5 chore(PromiseLike): Migrate remaining IPromise typings to PromiseLike

## huaweicloud@0.0.8

a929d3fa4db978aaf7b6d8ada12abc5b03403821 fix(promiselike): Revert typeRoots tsconfig change, move types to src/types and add KLUDGE to expose them in the @spinnaker/core bundle

## kubernetes@0.0.55

a929d3fa4db978aaf7b6d8ada12abc5b03403821 fix(promiselike): Revert typeRoots tsconfig change, move types to src/types and add KLUDGE to expose them in the @spinnaker/core bundle
2c0d0f6814689d93820eab4e97e5d89f98a61cc5 chore(PromiseLike): Migrate remaining IPromise typings to PromiseLike

## oracle@0.0.16

a929d3fa4db978aaf7b6d8ada12abc5b03403821 fix(promiselike): Revert typeRoots tsconfig change, move types to src/types and add KLUDGE to expose them in the @spinnaker/core bundle
2c0d0f6814689d93820eab4e97e5d89f98a61cc5 chore(PromiseLike): Migrate remaining IPromise typings to PromiseLike

## tencentcloud@0.0.12

a929d3fa4db978aaf7b6d8ada12abc5b03403821 fix(promiselike): Revert typeRoots tsconfig change, move types to src/types and add KLUDGE to expose them in the @spinnaker/core bundle

## titus@0.0.151

a929d3fa4db978aaf7b6d8ada12abc5b03403821 fix(promiselike): Revert typeRoots tsconfig change, move types to src/types and add KLUDGE to expose them in the @spinnaker/core bundle

PR created via `modules/publish.js`