### PR TITLE
Fix new resource versions not showing up in environment view

### DIFF
--- a/app/scripts/modules/core/src/managed/resources/registerNativeResourceKinds.ts
+++ b/app/scripts/modules/core/src/managed/resources/registerNativeResourceKinds.ts
@@ -12,6 +12,11 @@ export const registerNativeResourceKinds = () => {
   });
 
   registerResourceKind({
+    kind: 'ec2/cluster@v1.1',
+    iconName: 'cluster',
+  });
+
+  registerResourceKind({
     kind: 'ec2/security-group@v1',
     iconName: 'securityGroup',
   });
@@ -23,6 +28,11 @@ export const registerNativeResourceKinds = () => {
 
   registerResourceKind({
     kind: 'ec2/application-load-balancer@v1',
+    iconName: 'loadBalancer',
+  });
+
+  registerResourceKind({
+    kind: 'ec2/application-load-balancer@v1.1',
     iconName: 'loadBalancer',
   });
 };


### PR DESCRIPTION
We added v1.1 of ALBs (ages ago), and clusters (recently) and they currently do not show up as managed resources in the environments view. This was missed in main because nobody has updated their delivery config to these new versions. However, today I made a query fix (https://github.com/spinnaker/keel/pull/1635) that means the resources will be migrated on-the-fly by the query that backs the API endpoint the environment view uses.