### PR TITLE
chore(package): amazon@0.0.277 core@0.0.525 ecs@0.0.270 titus@0.0.152

### DIFF
--- a/app/scripts/modules/amazon/package.json
+++ b/app/scripts/modules/amazon/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/amazon",
   "license": "Apache-2.0",
-  "version": "0.0.276",
+  "version": "0.0.277",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/core/package.json
+++ b/app/scripts/modules/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/core",
   "license": "Apache-2.0",
-  "version": "0.0.524",
+  "version": "0.0.525",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/ecs/package.json
+++ b/app/scripts/modules/ecs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/ecs",
   "license": "Apache-2.0",
-  "version": "0.0.269",
+  "version": "0.0.270",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/app/scripts/modules/titus/package.json
+++ b/app/scripts/modules/titus/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/titus",
   "license": "Apache-2.0",
-  "version": "0.0.151",
+  "version": "0.0.152",
   "main": "lib/lib.js",
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
## amazon@0.0.277

deab22f34fe0cd82fc797a553732a148b72405b8 refactor(aws/titus): Reactify instance insights (#8698)

## core@0.0.525

ade00f79934e011f6a4c5afe3897e1dc19bb340c fix(core): Remove less override after react refactor (#8695)
deab22f34fe0cd82fc797a553732a148b72405b8 refactor(aws/titus): Reactify instance insights (#8698)
62b81bf027ea6fc6c3bb250abe79f2ec64004d71 fix(core/clusterFilter): Use filterModel object to retrieve filter values (#8693)
4a4f47218b21e79fca92217999e89e5f2a185a9c fix(core/cronTrigger): Fix regex for weekly cron triggers (#8690)

## ecs@0.0.270

10b17b965cd2611b98c0bd069eed8218128bc867 Rename networking module to ECS Networking React
5283f9f926af94d4cc88d7f2be09e674a45f10e1 feat(ecs): migrate networking server group wizard to react

## titus@0.0.152

deab22f34fe0cd82fc797a553732a148b72405b8 refactor(aws/titus): Reactify instance insights (#8698)

PR created via `modules/publish.js`