### PR TITLE
refactor(core): Remove componentWillUpdate and componentWillMount methods

### DIFF
--- a/app/scripts/modules/amazon/src/function/details/FunctionActions.tsx
+++ b/app/scripts/modules/amazon/src/function/details/FunctionActions.tsx
@@ -30,7 +30,7 @@ export class FunctionActions extends React.Component<IFunctionActionsProps, IFun
     super(props);
   }
 
-  public componentWillMount(): void {
+  public componentDidMount(): void {
     const { app, functionDef } = this.props;
     let application: Application;
 

--- a/app/scripts/modules/core/src/pagerDuty/Pager.tsx
+++ b/app/scripts/modules/core/src/pagerDuty/Pager.tsx
@@ -239,18 +239,18 @@ export class Pager extends React.Component<IPagerProps, IPagerState> {
     });
   }
 
-  public componentWillUpdate(_nextProps: IPagerProps, nextState: IPagerState): void {
-    if (nextState.filterString !== this.state.filterString || nextState.hideNoApps !== this.state.hideNoApps) {
+  public componentDidUpdate(_prevProps: IPagerProps, prevState: IPagerState): void {
+    if (prevState.filterString !== this.state.filterString || prevState.hideNoApps !== this.state.hideNoApps) {
       this.runFilter(
-        nextState.app,
-        nextState.initialKeys,
-        nextState.filterString,
-        nextState.sortBy,
-        nextState.sortDirection,
-        nextState.hideNoApps,
+        this.state.app,
+        this.state.initialKeys,
+        this.state.filterString,
+        this.state.sortBy,
+        this.state.sortDirection,
+        this.state.hideNoApps,
       );
     } else {
-      this.sort({ sortBy: nextState.sortBy, sortDirection: nextState.sortDirection });
+      this.sort({ sortBy: this.state.sortBy, sortDirection: this.state.sortDirection });
     }
   }
 

--- a/app/scripts/modules/core/src/pipeline/create/CreatePipelineModal.tsx
+++ b/app/scripts/modules/core/src/pipeline/create/CreatePipelineModal.tsx
@@ -75,8 +75,8 @@ export class CreatePipelineModal extends React.Component<ICreatePipelineModalPro
     preselectedTemplate: null,
   };
 
-  public componentWillUpdate(nextProps: ICreatePipelineModalProps): void {
-    if (nextProps.show && !this.props.show && !this.state.loading) {
+  public componentDidUpdate(prevProps: ICreatePipelineModalProps): void {
+    if (!prevProps.show && this.props.show && !this.state.loading) {
       this.loadPipelineTemplates();
     }
   }


### PR DESCRIPTION
React 17 upgrade [requires removing](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) `componentWillUpdate`, `componentWillMount` and `componentWillReceiveProps` lifecycle methods. In this PR, I'm removing `componentWillUpdate`, `componentWillMount` methods from `deck`.

`componentWillReceiveProps` is used in around 70 different files and requires a broader migration effort.