### PR TITLE
feat(core): Add Registry object to DebugWindow for easier debugging

### DIFF
--- a/app/scripts/modules/core/src/registry/Registry.ts
+++ b/app/scripts/modules/core/src/registry/Registry.ts
@@ -1,5 +1,6 @@
 import { PipelineRegistry } from 'core/pipeline/config/PipelineRegistry';
 import { UrlBuilderRegistry } from 'core/navigation/UrlBuilderRegistry';
+import { DebugWindow } from 'core/utils/consoleDebug';
 
 export class Registry {
   public static pipeline: PipelineRegistry = new PipelineRegistry();
@@ -10,3 +11,5 @@ export class Registry {
     Registry.urlBuilder = new UrlBuilderRegistry();
   };
 }
+
+DebugWindow.Registry = Registry;


### PR DESCRIPTION
I often find myself adding `pipelineRegistry` to `window` while debugging something in my machine, so I thought it would be helpful to make it available in `DebugWindow`. 