### PR TITLE
fix(amazon/securityGroup): Initialize accounts while cloning security groups

### DIFF
--- a/app/scripts/modules/amazon/src/securityGroup/clone/cloneSecurityGroup.controller.js
+++ b/app/scripts/modules/amazon/src/securityGroup/clone/cloneSecurityGroup.controller.js
@@ -98,6 +98,6 @@ angular
         vm.mixinUpsert('Clone');
       };
 
-      vm.initializeSecurityGroups();
+      vm.initializeSecurityGroups().then(vm.initializeAccounts);
     },
   ]);


### PR DESCRIPTION
Following what we already do in [`CreateSecurityGroupCtrl`](https://github.com/spinnaker/deck/blob/35fcebbcdd2c6dea2397a90a48db975293096054/app/scripts/modules/amazon/src/securityGroup/configure/CreateSecurityGroupCtrl.js#L45) and [`EditSecurityGroupCtrl`](https://github.com/spinnaker/deck/blob/35fcebbcdd2c6dea2397a90a48db975293096054/app/scripts/modules/amazon/src/securityGroup/configure/EditSecurityGroupCtrl.js#L113) to initialize all the accounts and make them available in the dropdown selector.