### PR TITLE
chore(eslint-plugin): publish 1.0.9

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/eslint-plugin",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "main": "eslint-plugin.js",
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
fix(pluginsdk-peerdeps): Move eslint peer deps to plugin-eslint package ([64d57086](https://github.com/spinnaker/deck/commit/64d57086d31a5599c64a7fd9e302186327981c39))
chore(eslint-plugin): bump jest and lodash ([96b2b869](https://github.com/spinnaker/deck/commit/96b2b86925c20910f6a839b55b8895fc980dc988))
feat(eslint-plugin): Add a new rule prefer-promise-like to help migrate off of ng.IPromise [#8673](https://github.com/spinnaker/deck/pull/8673) ([3dc0309d](https://github.com/spinnaker/deck/commit/3dc0309d795946edebef5ebc80836d14b12df0d1))
feat(eslint-plugin): Auto-fix arbitrary expressions with slashes in api-no-slashes lint rule ([28e95ee0](https://github.com/spinnaker/deck/commit/28e95ee003c194b429448f980e6fe501e6b797e9))
fix(eslint-plugin): Allow .split('/') in API.one() calls in api-no-slashes lint rule ([e5473895](https://github.com/spinnaker/deck/commit/e54738955e58d7bd6b9e1898d4a3c58050f52f80))
fix(eslint-plugin): Cast a wider net in api-no-slashes.js [#8649](https://github.com/spinnaker/deck/pull/8649) ([cf5ab832](https://github.com/spinnaker/deck/commit/cf5ab83211fc10ce0576c2f4d17906f384cd1d11))
feat(eslint-plugin): Write a new rule react2angular-with-error-boundary All react2angular components should be wrapped in an error boundary ([bd9858d3](https://github.com/spinnaker/deck/commit/bd9858d34e2bca351e17083ba8e62fcde92bba9d))
refactor(eslint-plugin): move angular-rule utils to a separate directory ([873bec32](https://github.com/spinnaker/deck/commit/873bec32e1d346d6ffedc54d64a2e20d6baf95c2))
feat(eslint-plugin): Add a new rule api-no-slashes that forbids using string literals with slashes to API.one()  [#8629](https://github.com/spinnaker/deck/pull/8629) ([75a054ef](https://github.com/spinnaker/deck/commit/75a054efd9cf544aee7f11678459e4c7b8818180))
feat(eslint-plugin): Add a README.md with instructions on creating eslint rules [#8628](https://github.com/spinnaker/deck/pull/8628) ([6cab9e61](https://github.com/spinnaker/deck/commit/6cab9e6111cffb3f6824f0d295652687525d8de9))
