### PR TITLE
feat(ecs): support selecting multiple subnet types

### DIFF
--- a/app/scripts/modules/ecs/src/ecs.help.ts
+++ b/app/scripts/modules/ecs/src/ecs.help.ts
@@ -44,7 +44,8 @@ const helpContents: { [key: string]: string } = {
   'ecs.publicip': '<p>Assign a public IP address to each task.</p>',
   'ecs.networkMode':
     '<p>awsvpc is the only networking mode that allows you to use Elastic Network Interfaces (ENI).  The default value converts to Bridge on Linux, and NAT on Windows.</p>',
-  'ecs.subnet': '<p>The subnet group on which your server group will be deployed.</p>',
+  'ecs.subnet':
+    '<p>The subnet group(s) on which your server group will be deployed. All subnet groups selected must exist within the same VPC.</p>',
   'ecs.securityGroups': '<p>The security group(s) name(s) your containers are deployed with.</p>',
   'ecs.dockerLabels':
     '<p>Additional labels applied to your Docker container.  This metadata can be used to identify your containers, or in conjunction with logging options.  Maps directly to the <a href="https://docs.docker.com/engine/reference/commandline/run/#set-metadata-on-container--l---label---label-file"><b>--label</b> Docker flag</a>.</p> <p>Spinnaker will automatically add the spinnaker.servergroup, spinnaker.stack, spinnaker.detail labels for non-null values.</p>',

--- a/app/scripts/modules/ecs/src/serverGroup/configure/wizard/networking/Networking.tsx
+++ b/app/scripts/modules/ecs/src/serverGroup/configure/wizard/networking/Networking.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { module } from 'angular';
+import { uniqWith, isEqual } from 'lodash';
 import { react2angular } from 'react2angular';
 import { IEcsServerGroupCommand } from '../../serverGroupConfiguration.service';
-import { HelpField, TetheredSelect, withErrorBoundary } from '@spinnaker/core';
+import { HelpField, ISubnet, TetheredSelect, withErrorBoundary } from '@spinnaker/core';
 import { Alert } from 'react-bootstrap';
 import { Option } from 'react-select';
 
@@ -18,14 +19,26 @@ interface IEcsNetworkingState {
   networkModesAvailable: string[];
   securityGroups: string[];
   securityGroupsAvailable: string[];
-  subnetType: string;
-  subnetTypesAvailable: string[];
+  subnetTypes: string[];
+  subnetTypesAvailable: ISubnet[];
 }
 
 export class EcsNetworking extends React.Component<IEcsNetworkingProps, IEcsNetworkingState> {
   constructor(props: IEcsNetworkingProps) {
     super(props);
     const cmd = this.props.command;
+
+    let defaultSubnetTypes: string[] = [];
+    if (cmd.subnetTypes && cmd.subnetTypes.length > 0) {
+      defaultSubnetTypes = cmd.subnetTypes;
+    }
+
+    if (cmd.subnetType && cmd.subnetType.length > 0) {
+      defaultSubnetTypes.push(cmd.subnetType);
+      cmd.subnetType = '';
+    }
+
+    cmd.subnetTypes = uniqWith(defaultSubnetTypes, isEqual);
 
     this.state = {
       associatePublicIpAddress: cmd.associatePublicIpAddress,
@@ -36,7 +49,7 @@ export class EcsNetworking extends React.Component<IEcsNetworkingProps, IEcsNetw
         cmd.backingData && cmd.backingData.filtered && cmd.backingData.filtered.securityGroupNames
           ? cmd.backingData.filtered.securityGroupNames
           : [],
-      subnetType: cmd.subnetType,
+      subnetTypes: cmd.subnetTypes,
       subnetTypesAvailable:
         cmd.backingData && cmd.backingData.filtered && cmd.backingData.filtered.subnetTypes
           ? cmd.backingData.filtered.subnetTypes
@@ -76,10 +89,12 @@ export class EcsNetworking extends React.Component<IEcsNetworkingProps, IEcsNetw
     this.setState({ securityGroups: updatedSecurityGroups });
   };
 
-  private updateSubnetType = (newSubnetType: Option<string>) => {
-    const updatedSubnetType = newSubnetType.value;
-    this.props.notifyAngular('subnetType', updatedSubnetType);
-    this.setState({ subnetType: updatedSubnetType });
+  private updateSubnetTypes = (newSubnetTypes: Option<string>) => {
+    const updatedSubnetTypes = Array.isArray(newSubnetTypes)
+      ? newSubnetTypes.map((subnetType) => subnetType.value)
+      : [];
+    this.props.notifyAngular('subnetTypes', updatedSubnetTypes);
+    this.setState({ subnetTypes: updatedSubnetTypes });
   };
 
   private updateAssociatePublicIpAddress = (usePublicIp: boolean) => {
@@ -91,7 +106,7 @@ export class EcsNetworking extends React.Component<IEcsNetworkingProps, IEcsNetw
     const updateAssociatePublicIpAddress = this.updateAssociatePublicIpAddress;
     const updateNetworkMode = this.updateNetworkMode;
     const updateSecurityGroups = this.updateSecurityGroups;
-    const updateSubnetType = this.updateSubnetType;
+    const updateSubnetTypes = this.updateSubnetTypes;
 
     const networkModesAvailable = this.state.networkModesAvailable.map(function (networkMode) {
       return { label: `${networkMode}`, value: networkMode };
@@ -102,15 +117,16 @@ export class EcsNetworking extends React.Component<IEcsNetworkingProps, IEcsNetw
     });
 
     const subnetTypesAvailable = this.state.subnetTypesAvailable.map(function (subnetType) {
-      return { label: `${subnetType}`, value: subnetType };
+      return { label: `${subnetType.purpose} (${subnetType.vpcId})`, value: subnetType.purpose };
     });
 
     const subnetTypeOptions = this.state.subnetTypesAvailable.length ? (
       <TetheredSelect
+        multi={true}
         options={subnetTypesAvailable}
-        value={this.state.subnetType}
+        value={this.state.subnetTypes}
         onChange={(e: Option) => {
-          updateSubnetType(e as Option<string>);
+          updateSubnetTypes(e as Option<string>);
         }}
       />
     ) : (


### PR DESCRIPTION
Add support for multiple subnet types in the ECS Provider. 

This change is dependent on https://github.com/spinnaker/clouddriver/pull/5087 being merged in first!

Closes: https://github.com/spinnaker/spinnaker/issues/6097

![Screen Shot 2020-12-15 at 4 57 17 PM](https://user-images.githubusercontent.com/44981951/102277694-a53c4700-3ef6-11eb-82af-f88eb5f9d4a1.png)

![Screen Shot 2020-12-15 at 5 55 17 PM](https://user-images.githubusercontent.com/44981951/102282530-bf7a2300-3efe-11eb-8a7e-fd8f02f47d1d.png)

![Screen Shot 2020-12-15 at 4 59 24 PM](https://user-images.githubusercontent.com/44981951/102277903-ea607900-3ef6-11eb-9512-5ab289a642f8.png)

![Screen Shot 2020-12-15 at 4 59 29 PM](https://user-images.githubusercontent.com/44981951/102277930-f3514a80-3ef6-11eb-8790-c57e1d1e0dad.png)
