### PR TITLE
feat(core/managed): support git compare link on versions

### DIFF
--- a/app/scripts/modules/core/src/domain/IManagedEntity.ts
+++ b/app/scripts/modules/core/src/domain/IManagedEntity.ts
@@ -103,6 +103,7 @@ export interface IManagedArtifactVersion {
     replacedBy?: string;
     statefulConstraints?: IStatefulConstraint[];
     statelessConstraints?: IStatelessConstraint[];
+    compareLink?: string;
   }>;
   build?: {
     id: number; // deprecated, use number

--- a/app/scripts/modules/core/src/managed/ArtifactDetail.tsx
+++ b/app/scripts/modules/core/src/managed/ArtifactDetail.tsx
@@ -1,4 +1,5 @@
 import React, { memo, useMemo } from 'react';
+import ReactGA from 'react-ga';
 import classNames from 'classnames';
 import { useRouter } from '@uirouter/react';
 import { useTransition, animated, UseTransitionProps } from 'react-spring';
@@ -91,6 +92,7 @@ const EnvironmentCards = memo(
       vetoed,
       statefulConstraints,
       statelessConstraints,
+      compareLink,
     } = environment;
     const {
       stateService: { go },
@@ -147,7 +149,15 @@ const EnvironmentCards = memo(
         replacedAt={replacedAt}
         replacedBy={replacedBy}
         vetoed={vetoed}
+        compareLink={compareLink}
         allVersions={allVersions}
+        logClick={(message) => {
+          ReactGA.event({
+            category: 'Environments - version details',
+            action: message,
+            label: `${application.name}:${environmentName}:${reference}`,
+          });
+        }}
       />
     );
     const constraintCards = useMemo(

--- a/app/scripts/modules/core/src/managed/ManagedReader.ts
+++ b/app/scripts/modules/core/src/managed/ManagedReader.ts
@@ -1,4 +1,3 @@
-
 import { get, set, flatMap } from 'lodash';
 
 import { API } from 'core/api';

--- a/app/scripts/modules/core/src/managed/VersionStateCard.tsx
+++ b/app/scripts/modules/core/src/managed/VersionStateCard.tsx
@@ -7,6 +7,7 @@ import { Markdown, IconNames } from '../presentation';
 import { getArtifactVersionDisplayName } from './displayNames';
 import { StatusCard, IStatusCardProps } from './StatusCard';
 import { Pill } from './Pill';
+import { Button } from './Button';
 
 interface CardTitleMetadata {
   deployedAt?: string;
@@ -101,11 +102,20 @@ const cardAppearanceByState: { [state: string]: CardAppearance } = {
 
 export type IVersionStateCardProps = Pick<
   IManagedArtifactVersion['environments'][0],
-  'state' | 'deployedAt' | 'replacedAt' | 'replacedBy' | 'vetoed'
-> & { allVersions: IManagedArtifactVersion[] };
+  'state' | 'deployedAt' | 'replacedAt' | 'replacedBy' | 'vetoed' | 'compareLink'
+> & { allVersions: IManagedArtifactVersion[]; logClick: (message: string) => any };
 
 export const VersionStateCard = memo(
-  ({ state, deployedAt, replacedAt, replacedBy, vetoed, allVersions }: IVersionStateCardProps) => {
+  ({
+    state,
+    deployedAt,
+    replacedAt,
+    replacedBy,
+    vetoed,
+    compareLink,
+    allVersions,
+    logClick,
+  }: IVersionStateCardProps) => {
     const replacedByVersion = useMemo(() => allVersions.find(({ version }) => version === replacedBy), [
       replacedBy,
       allVersions,
@@ -126,6 +136,18 @@ export const VersionStateCard = memo(
         timestamp={cardAppearanceByState[state].timestamp?.(cardMetadata)}
         title={cardAppearanceByState[state].title(cardMetadata)}
         description={cardAppearanceByState[state].description?.(cardMetadata)}
+        actions={
+          compareLink && (
+            <Button
+              onClick={() => {
+                window.open(compareLink, '_blank', 'noopener noreferrer');
+                logClick('See changes clicked');
+              }}
+            >
+              See changes
+            </Button>
+          )
+        }
       />
     );
   },


### PR DESCRIPTION
Once https://github.com/spinnaker/keel/pull/1656 is merged, versions in the `PENDING`, `DEPLOYING`, `PREVIOUS`, or `CURRENT` states in an environment will include a link directly to a git compare view (Bitbucket/Stash at Netflix) that shows the commits between that version and what we believe is the appropriate comparison version. For example, a `DEPLOYING` version would compare against the version it's currently replacing in that environment.

This PR adds support in the Environments UI for showing a `See changes` button on each environment where applicable, that links out to the compare URL in a new tab. Also includes some analytics so we can see if it's popular.

<img width="1091" alt="Screen Shot 2020-11-11 at 5 53 17 PM" src="https://user-images.githubusercontent.com/1850998/98887815-80facf80-244b-11eb-8dcd-e10a9511bbed.png">

cc @gcomstock 