### PR TITLE
fix(core): Initialize cache for executions permalink

### DIFF
--- a/app/scripts/modules/core/src/pipeline/filter/ExecutionFilterModel.ts
+++ b/app/scripts/modules/core/src/pipeline/filter/ExecutionFilterModel.ts
@@ -46,10 +46,19 @@ export class ExecutionFilterModel {
     FilterModelService.registerRouterHooks(this.asFilterModel, '**.application.pipelines.executions.**');
     this.asFilterModel.activate();
 
-    transitionService.onBefore({ entering: '**.application.pipelines.executions' }, (trans) => {
-      this.mostRecentApplication = trans.params().application;
-      this.assignViewStateFromCache();
-    });
+    transitionService.onBefore(
+      {
+        entering: (state) =>
+          !!(
+            state.self.name.match('.application.pipelines.executions$') ||
+            state.self.name.match('.application.pipelines.executionDetails.execution$')
+          ),
+      },
+      (trans) => {
+        this.mostRecentApplication = trans.params().application;
+        this.assignViewStateFromCache();
+      },
+    );
 
     // A nice way to avoid watches is to define a property on an object
     Object.defineProperty(this.asFilterModel.sortFilter, 'count', {


### PR DESCRIPTION
The router hook registered against `entering: '**.application.pipelines.executions'` does not get run when someone opens a single execution permalink, so the shared code doesn't get to used values stored in the cache.

Not sure if there is a better way register against both states.