### PR TITLE
feat(core/managed): fill some usage logging gaps in Environments

### DIFF
--- a/app/scripts/modules/core/src/managed/ArtifactDetail.tsx
+++ b/app/scripts/modules/core/src/managed/ArtifactDetail.tsx
@@ -36,6 +36,13 @@ function shouldDisplayResource(reference: string, resource: IManagedResourceSumm
   return isResourceKindSupported(resource.kind) && reference === resource.artifact?.reference;
 }
 
+const logEvent = (label: string, application: string, environment: string, reference: string) =>
+  ReactGA.event({
+    category: 'Environments - version details',
+    action: label,
+    label: `${application}:${environment}:${reference}`,
+  });
+
 const inStyles = {
   opacity: 1,
   transform: 'scale(1.0, 1.0)',
@@ -151,13 +158,7 @@ const EnvironmentCards = memo(
         vetoed={vetoed}
         compareLink={compareLink}
         allVersions={allVersions}
-        logClick={(message) => {
-          ReactGA.event({
-            category: 'Environments - version details',
-            action: message,
-            label: `${application.name}:${environmentName}:${reference}`,
-          });
-        }}
+        logClick={(message) => logEvent(message, application.name, environmentName, reference)}
       />
     );
     const constraintCards = useMemo(
@@ -293,7 +294,12 @@ export const ArtifactDetail = ({
               <VersionMetadataItem
                 label="Pull Request"
                 value={
-                  <a href={git.pullRequest.url} target="_blank" rel="noopener noreferrer">
+                  <a
+                    href={git.pullRequest.url}
+                    onClick={() => logEvent('PR link clicked', application.name, 'none', reference)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
                     #{git.pullRequest.number}
                   </a>
                 }
@@ -304,7 +310,12 @@ export const ArtifactDetail = ({
                 <VersionMetadataItem
                   label="Commit"
                   value={
-                    <a href={git.commitInfo.link} target="_blank" rel="noopener noreferrer">
+                    <a
+                      href={git.commitInfo.link}
+                      onClick={() => logEvent('Commit link clicked', application.name, 'none', reference)}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
                       {git.commitInfo.sha.substring(0, 7)}
                     </a>
                   }

--- a/app/scripts/modules/core/src/managed/MarkArtifactAsBadModal.tsx
+++ b/app/scripts/modules/core/src/managed/MarkArtifactAsBadModal.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback } from 'react';
+import React, { memo, useCallback, useEffect } from 'react';
 import ReactGA from 'react-ga';
 import { Option } from 'react-select';
 
@@ -28,11 +28,11 @@ import { useEnvironmentTypeFromResources } from './useEnvironmentTypeFromResourc
 
 const MARK_BAD_DOCS_URL = 'https://www.spinnaker.io/guides/user/managed-delivery/marking-as-bad/';
 
-const logClick = (label: string, application: string) =>
+const logEvent = (label: string, application: string, environment?: string, reference?: string) =>
   ReactGA.event({
     category: 'Environments - mark version as bad modal',
-    action: `${label} clicked`,
-    label: application,
+    action: label,
+    label: environment ? `${application}:${environment}:${reference}` : application,
   });
 
 type IEnvironmentOptionProps = Option<string> & { disabledReason: string; allResources: IManagedResourceSummary[] };
@@ -62,7 +62,12 @@ export interface IMarkArtifactAsBadModalProps extends IModalComponentProps {
 }
 
 export const showMarkArtifactAsBadModal = (props: IMarkArtifactAsBadModalProps) =>
-  showModal(MarkArtifactAsBadModal, props, { maxWidth: 750 });
+  showModal(MarkArtifactAsBadModal, props, { maxWidth: 750 }).then((result) => {
+    if (status === 'DISMISSED') {
+      logEvent('Modal dismissed', props.application.name);
+    }
+    return result;
+  });
 
 export const MarkArtifactAsBadModal = memo(
   ({
@@ -79,6 +84,8 @@ export const MarkArtifactAsBadModal = memo(
       ),
       [resourcesByEnvironment],
     );
+
+    useEffect(() => logEvent('Modal seen', application.name), []);
 
     return (
       <>
@@ -98,10 +105,14 @@ export const MarkArtifactAsBadModal = memo(
               application: application.name,
               version: version.version,
             })
-              .then(() => closeModal())
+              .then(() => {
+                logEvent('Version marked bad', application.name, environment, reference);
+                closeModal();
+              })
               .catch((error: { data: { error: string; message: string } }) => {
                 setSubmitting(false);
                 setStatus({ error: error.data });
+                logEvent('Error marking version bad', application.name, environment, reference);
               })
           }
           render={({ status, isValid, isSubmitting, submitForm }) => {
@@ -124,7 +135,7 @@ export const MarkArtifactAsBadModal = memo(
                         </p>{' '}
                         <a
                           target="_blank"
-                          onClick={() => logClick('Mark as bad docs link', application.name)}
+                          onClick={() => logEvent('Mark as bad docs link clicked', application.name)}
                           href={MARK_BAD_DOCS_URL}
                         >
                           Check out our documentation

--- a/app/scripts/modules/core/src/managed/MarkArtifactAsBadModal.tsx
+++ b/app/scripts/modules/core/src/managed/MarkArtifactAsBadModal.tsx
@@ -63,7 +63,7 @@ export interface IMarkArtifactAsBadModalProps extends IModalComponentProps {
 
 export const showMarkArtifactAsBadModal = (props: IMarkArtifactAsBadModalProps) =>
   showModal(MarkArtifactAsBadModal, props, { maxWidth: 750 }).then((result) => {
-    if (status === 'DISMISSED') {
+    if (result.status === 'DISMISSED') {
       logEvent('Modal dismissed', props.application.name);
     }
     return result;

--- a/app/scripts/modules/core/src/managed/PinArtifactModal.tsx
+++ b/app/scripts/modules/core/src/managed/PinArtifactModal.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback } from 'react';
+import React, { memo, useCallback, useEffect } from 'react';
 import ReactGA from 'react-ga';
 import { Option } from 'react-select';
 
@@ -28,11 +28,11 @@ import { useEnvironmentTypeFromResources } from './useEnvironmentTypeFromResourc
 
 const PINNING_DOCS_URL = 'https://www.spinnaker.io/guides/user/managed-delivery/pinning';
 
-const logClick = (label: string, application: string) =>
+const logEvent = (label: string, application: string, environment?: string, reference?: string) =>
   ReactGA.event({
     category: 'Environments - pin version modal',
-    action: `${label} clicked`,
-    label: application,
+    action: label,
+    label: environment ? `${application}:${environment}:${reference}` : application,
   });
 
 type IEnvironmentOptionProps = Option<string> & { disabledReason: string; allResources: IManagedResourceSummary[] };
@@ -62,7 +62,12 @@ export interface IPinArtifactModalProps extends IModalComponentProps {
 }
 
 export const showPinArtifactModal = (props: IPinArtifactModalProps) =>
-  showModal(PinArtifactModal, props, { maxWidth: 750 });
+  showModal(PinArtifactModal, props, { maxWidth: 750 }).then((result) => {
+    if (status === 'DISMISSED') {
+      logEvent('Modal dismissed', props.application.name);
+    }
+    return result;
+  });
 
 export const PinArtifactModal = memo(
   ({ application, reference, version, resourcesByEnvironment, dismissModal, closeModal }: IPinArtifactModalProps) => {
@@ -72,6 +77,8 @@ export const PinArtifactModal = memo(
       ),
       [resourcesByEnvironment],
     );
+
+    useEffect(() => logEvent('Modal seen', application.name), []);
 
     return (
       <>
@@ -83,7 +90,7 @@ export const PinArtifactModal = memo(
           initialValues={{
             environment: version.environments.find(({ pinned, state }) => !pinned && state !== 'vetoed').name,
           }}
-          onSubmit={({ environment, comment }, { setSubmitting, setStatus }) =>
+          onSubmit={({ environment, comment }, { setSubmitting, setStatus }) => {
             ManagedWriter.pinArtifactVersion({
               environment,
               reference,
@@ -91,12 +98,16 @@ export const PinArtifactModal = memo(
               application: application.name,
               version: version.version,
             })
-              .then(() => closeModal())
+              .then(() => {
+                logEvent('Version pinned', application.name, environment, reference);
+                closeModal();
+              })
               .catch((error: { data: { error: string; message: string } }) => {
                 setSubmitting(false);
                 setStatus({ error: error.data });
-              })
-          }
+                logEvent('Error pinning version', application.name, environment, reference);
+              });
+          }}
           render={({ status, isValid, isSubmitting, submitForm }) => {
             const errorTitle = status?.error?.error;
             const errorMessage = status?.error?.message;
@@ -117,7 +128,7 @@ export const PinArtifactModal = memo(
                         </p>{' '}
                         <a
                           target="_blank"
-                          onClick={() => logClick('Pinning docs link', application.name)}
+                          onClick={() => logEvent('Pinning docs link clicked', application.name)}
                           href={PINNING_DOCS_URL}
                         >
                           Check out our documentation

--- a/app/scripts/modules/core/src/managed/PinArtifactModal.tsx
+++ b/app/scripts/modules/core/src/managed/PinArtifactModal.tsx
@@ -63,7 +63,7 @@ export interface IPinArtifactModalProps extends IModalComponentProps {
 
 export const showPinArtifactModal = (props: IPinArtifactModalProps) =>
   showModal(PinArtifactModal, props, { maxWidth: 750 }).then((result) => {
-    if (status === 'DISMISSED') {
+    if (result.status === 'DISMISSED') {
       logEvent('Modal dismissed', props.application.name);
     }
     return result;

--- a/app/scripts/modules/core/src/managed/UnpinArtifactModal.tsx
+++ b/app/scripts/modules/core/src/managed/UnpinArtifactModal.tsx
@@ -40,7 +40,7 @@ export interface IUnpinArtifactModalProps extends IModalComponentProps {
 
 export const showUnpinArtifactModal = (props: IUnpinArtifactModalProps) =>
   showModal(UnpinArtifactModal, props, { maxWidth: 628 }).then((result) => {
-    if (status === 'DISMISSED') {
+    if (result.status === 'DISMISSED') {
       logEvent('Modal dismissed', props.application.name);
     }
     return result;

--- a/app/scripts/modules/core/src/managed/UnpinArtifactModal.tsx
+++ b/app/scripts/modules/core/src/managed/UnpinArtifactModal.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useState } from 'react';
+import React, { memo, useEffect, useState } from 'react';
 import ReactGA from 'react-ga';
 
 import {
@@ -23,11 +23,11 @@ import { useEnvironmentTypeFromResources } from './useEnvironmentTypeFromResourc
 
 const PINNING_DOCS_URL = 'https://www.spinnaker.io/guides/user/managed-delivery/pinning';
 
-const logClick = (label: string, application: string) =>
+const logEvent = (label: string, application: string, environment?: string, reference?: string) =>
   ReactGA.event({
     category: 'Environments - unpin version modal',
-    action: `${label} clicked`,
-    label: application,
+    action: label,
+    label: environment ? `${application}:${environment}:${reference}` : application,
   });
 
 export interface IUnpinArtifactModalProps extends IModalComponentProps {
@@ -39,7 +39,12 @@ export interface IUnpinArtifactModalProps extends IModalComponentProps {
 }
 
 export const showUnpinArtifactModal = (props: IUnpinArtifactModalProps) =>
-  showModal(UnpinArtifactModal, props, { maxWidth: 628 });
+  showModal(UnpinArtifactModal, props, { maxWidth: 628 }).then((result) => {
+    if (status === 'DISMISSED') {
+      logEvent('Modal dismissed', props.application.name);
+    }
+    return result;
+  });
 
 export const UnpinArtifactModal = memo(
   ({
@@ -55,6 +60,8 @@ export const UnpinArtifactModal = memo(
     const [submitStatus, setSubmitStatus] = useState<IRequestStatus>('NONE');
     const [error, setError] = useState<{ title: string; message: string }>(null);
 
+    useEffect(() => logEvent('Modal seen', application.name), []);
+
     const submit = () => {
       setSubmitStatus('PENDING');
 
@@ -63,10 +70,14 @@ export const UnpinArtifactModal = memo(
         reference,
         application: application.name,
       })
-        .then(() => closeModal())
+        .then(() => {
+          logEvent('Version unpinned', application.name, environment, reference);
+          closeModal();
+        })
         .catch((error: { data: { error: string; message: string } }) => {
           setSubmitStatus('REJECTED');
           setError({ title: error.data?.error, message: error.data.message });
+          logEvent('Error unpinning version', application.name, environment, reference);
         });
     };
 
@@ -89,7 +100,7 @@ export const UnpinArtifactModal = memo(
                 </p>{' '}
                 <a
                   target="_blank"
-                  onClick={() => logClick('Pinning docs link', application.name)}
+                  onClick={() => logEvent('Pinning docs link clicked', application.name)}
                   href={PINNING_DOCS_URL}
                 >
                   Check out our documentation

--- a/app/scripts/modules/core/src/managed/constraints/ConstraintCard.tsx
+++ b/app/scripts/modules/core/src/managed/constraints/ConstraintCard.tsx
@@ -1,4 +1,5 @@
 import React, { memo, useState } from 'react';
+import ReactGA from 'react-ga';
 import classNames from 'classnames';
 
 import {
@@ -45,6 +46,13 @@ const skippedConstraintCardAppearanceByStatus = {
   [OVERRIDE_PASS]: 'neutral',
   [OVERRIDE_FAIL]: 'neutral',
 } as const;
+
+const logEvent = (label: string, application: string, environment: string, reference: string) =>
+  ReactGA.event({
+    category: 'Environments - version details',
+    action: label,
+    label: `${application}:${environment}:${reference}`,
+  });
 
 const logUnsupportedConstraintError = (type: string) => {
   console.error(
@@ -138,9 +146,23 @@ export const ConstraintCard = memo(
                           version,
                           status: pass ? OVERRIDE_PASS : OVERRIDE_FAIL,
                         })
-                          .then(() => setActionStatus('RESOLVED'))
+                          .then(() => {
+                            setActionStatus('RESOLVED');
+                            logEvent(
+                              `${type} constraint - ${title} action taken`,
+                              application.name,
+                              environment.name,
+                              reference,
+                            );
+                          })
                           .catch(() => {
                             setActionStatus('REJECTED');
+                            logEvent(
+                              `${type} constraint - ${title} action failed`,
+                              application.name,
+                              environment.name,
+                              reference,
+                            );
                           });
                       }}
                     >


### PR DESCRIPTION
Correcting an oversight of mine — I hadn't yet added usage tracking to the meaningful/important behaviors in Environments. Focusing first on the behaviors that are most meaningful to the customer value we seek to provide from MD:

- **Pinning, unpinning, and mark as bad (same events for each flow)**: opening/seeing the modal, dismissing the modal without taking action, taking action successfully (pin/unpin/mark), trying to take action and hitting an error
- **Version metadata**: clicking the link to a version's commit, clicking the link to a version's PR
- **Constraints**: clicking a 'constraint action', which is just what we call the buttons on constraints in the UI like "Approve"/"Reject" for manual judgements. The events we log will include the type of constraint and which action was clicked

The rounds out the tracking we already have on the new "See changes" button to capture most of the value-add behaviors a user could interact with, beyond just viewing the page itself which we already have tracking on.