### PR TITLE
fix(core/api): Fix type safety for API.one() builder

### DIFF
--- a/app/scripts/modules/core/src/api/ApiService.spec.ts
+++ b/app/scripts/modules/core/src/api/ApiService.spec.ts
@@ -1,6 +1,7 @@
 import Spy = jasmine.Spy;
 import { mock, noop } from 'angular';
 import { AuthenticationInitializer } from '../authentication/AuthenticationInitializer';
+import { ICache } from '../cache';
 import { API, InvalidAPIResponse } from './ApiService';
 import { SETTINGS } from 'core/config/settings';
 
@@ -293,12 +294,6 @@ describe('API Service', function () {
     });
 
     describe('create config with data', function () {
-      it('should not alter the config if no data object passed', function () {
-        const result = API.one('foo').data();
-        expected.url = `${baseUrl}/foo`;
-        expect(result.config).toEqual(expected);
-      });
-
       it('should add data to the config if data object passed', function () {
         const data = { bar: 'baz' };
         const result = API.one('foo').data(data);
@@ -310,11 +305,6 @@ describe('API Service', function () {
   });
 
   describe('create a config with params', function () {
-    it('when no params are provided do not alter config', function () {
-      const result = API.one('foo').withParams();
-      expect(result.config).toEqual({ method: '', url: `${baseUrl}/foo` });
-    });
-
     it('when params are provided', function () {
       const result = API.one('foo').withParams({ one: 1 });
       expect(result.config).toEqual({ method: '', url: `${baseUrl}/foo`, params: { one: 1 } });
@@ -333,7 +323,7 @@ describe('API Service', function () {
     });
 
     it('should set cache to cache object if explicitly set', function () {
-      const cacheObj = { count: 1 };
+      const cacheObj = ({ count: 1 } as unknown) as ICache;
       const result = API.one('foo').useCache(cacheObj);
       expect(result.config.cache).toBe(cacheObj);
     });

--- a/app/scripts/modules/core/src/api/ApiService.ts
+++ b/app/scripts/modules/core/src/api/ApiService.ts
@@ -5,18 +5,21 @@ import { SETTINGS } from 'core/config/settings';
 import { ICache } from 'core/cache';
 import { isNil } from 'lodash';
 
+type toStringable = { toString(): string };
+type IParams = Record<string, toStringable | toStringable[]>;
+
 export interface IRequestBuilder {
   config?: IRequestConfig;
   one?: (...urls: string[]) => IRequestBuilder;
   all?: (...urls: string[]) => IRequestBuilder;
-  useCache?: (useCache: boolean | ICache) => IRequestBuilder;
-  withParams?: (data: any) => IRequestBuilder;
+  useCache?: (useCache?: boolean | ICache) => IRequestBuilder;
+  withParams?: (params: IParams) => IRequestBuilder;
   data?: (data: any) => IRequestBuilder;
-  get?: (data?: any) => PromiseLike<any>;
-  getList?: (data?: any) => PromiseLike<any>;
-  post?: (data: any) => PromiseLike<any>;
-  remove?: (data: any) => PromiseLike<any>;
-  put?: (data: any) => PromiseLike<any>;
+  get?: <T = any>(params?: IParams) => PromiseLike<T>;
+  getList?: <T = any>(params?: IParams) => PromiseLike<T>;
+  post?: <T = any>(data?: any) => PromiseLike<T>;
+  remove?: <T = any>(params?: IParams) => PromiseLike<T>;
+  put?: <T = any>(data?: any) => PromiseLike<T>;
 }
 
 export class InvalidAPIResponse extends Error {
@@ -97,7 +100,7 @@ export class API {
   }
 
   // HTTP GET operation
-  private static getFn(config: IRequestConfig): (data: any) => PromiseLike<any> {
+  private static getFn(config: IRequestConfig): (params: any) => PromiseLike<any> {
     return (params: any) => {
       config.method = 'get';
       Object.assign(config, this.defaultParams);
@@ -123,7 +126,7 @@ export class API {
   }
 
   // HTTP DELETE operation
-  private static removeFn(config: IRequestConfig): (data: any) => PromiseLike<any> {
+  private static removeFn(config: IRequestConfig): (params: any) => PromiseLike<any> {
     return (params: any) => {
       config.method = 'delete';
       if (params) {
@@ -176,11 +179,11 @@ export class API {
     return this.baseReturn(config);
   }
 
-  public static one(...urls: string[]): any {
+  public static one(...urls: string[]): IRequestBuilder {
     return this.init(urls);
   }
 
-  public static all(...urls: string[]): any {
+  public static all(...urls: string[]): IRequestBuilder {
     return this.init(urls);
   }
 

--- a/app/scripts/modules/core/src/api/ApiService.ts
+++ b/app/scripts/modules/core/src/api/ApiService.ts
@@ -5,8 +5,8 @@ import { SETTINGS } from 'core/config/settings';
 import { ICache } from 'core/cache';
 import { isNil } from 'lodash';
 
-type toStringable = { toString(): string };
-type IParams = Record<string, toStringable | toStringable[]>;
+type IPrimitive = string | boolean | number;
+type IParams = Record<string, IPrimitive | IPrimitive[]>;
 
 export interface IRequestBuilder {
   config?: IRequestConfig;

--- a/app/scripts/modules/core/src/image/image.reader.ts
+++ b/app/scripts/modules/core/src/image/image.reader.ts
@@ -2,19 +2,19 @@ import { module } from 'angular';
 
 import { ProviderServiceDelegate, PROVIDER_SERVICE_DELEGATE } from 'core/cloudProvider/providerService.delegate';
 
-export interface IFindImageParams {
+export type IFindImageParams = {
   provider: string;
   q?: string;
   region?: string;
   account?: string;
   count?: number;
-}
+};
 
-export interface IFindTagsParams {
+export type IFindTagsParams = {
   provider: string;
   account: string;
   repository: string;
-}
+};
 
 // marker interface
 export interface IImage {}

--- a/app/scripts/modules/core/src/managed/ManagedReader.ts
+++ b/app/scripts/modules/core/src/managed/ManagedReader.ts
@@ -8,7 +8,6 @@ import {
   IManagedResourceEventHistory,
   IManagedResourceDiff,
   IManagedResourceEvent,
-  IManagedApplicationEnvironmentSummary,
 } from 'core/domain';
 
 const KIND_NAME_MATCHER = /.*\/(.*?)@/i;
@@ -89,7 +88,7 @@ export class ManagedReader {
       .then(this.decorateResources);
   }
 
-  public static getEnvironmentsSummary(app: string): PromiseLike<IManagedApplicationEnvironmentSummary> {
+  public static getEnvironmentsSummary(app: string): PromiseLike<IManagedApplicationSummary> {
     return API.one('managed')
       .one('application', app)
       .withParams({ entities: ['resources', 'artifacts', 'environments'], maxArtifactVersions: 30 })

--- a/app/scripts/modules/core/src/network/NetworkReader.ts
+++ b/app/scripts/modules/core/src/network/NetworkReader.ts
@@ -10,7 +10,7 @@ export interface INetwork {
 }
 
 export class NetworkReader {
-  public static listNetworks(): INetwork[] {
+  public static listNetworks(): PromiseLike<INetwork[]> {
     return API.one('networks').getList();
   }
 

--- a/app/scripts/modules/core/src/notification/NotificationService.ts
+++ b/app/scripts/modules/core/src/notification/NotificationService.ts
@@ -15,7 +15,7 @@ export interface INotificationTypeMetadata {
 }
 
 export class NotificationService {
-  public static getNotificationTypeMetadata(): Promise<INotificationTypeMetadata[]> {
+  public static getNotificationTypeMetadata(): PromiseLike<INotificationTypeMetadata[]> {
     return API.one('notifications').all('metadata').useCache().getList();
   }
 }

--- a/app/scripts/modules/core/src/plugins/plugin.registry.ts
+++ b/app/scripts/modules/core/src/plugins/plugin.registry.ts
@@ -98,7 +98,7 @@ export class PluginRegistry {
   public loadPluginManifestFromGate() {
     const source = 'gate';
     const uri = 'plugins/deck/plugin-manifest.json';
-    const loadPromise = API.one(...uri.split('/'))
+    const loadPromise: PromiseLike<IPluginMetaData[]> = API.one(...uri.split('/'))
       .get()
       .catch((error: any) => {
         console.error(`Failed to load ${uri} from ${source}`);
@@ -122,7 +122,7 @@ export class PluginRegistry {
   public async loadPluginManifest(
     source: ISource,
     location: string,
-    pluginsMetaDataPromise: Promise<IPluginMetaData[]>,
+    pluginsMetaDataPromise: PromiseLike<IPluginMetaData[]>,
   ): Promise<IPluginMetaData[]> {
     try {
       const plugins = await pluginsMetaDataPromise;

--- a/app/scripts/modules/core/src/search/search.service.ts
+++ b/app/scripts/modules/core/src/search/search.service.ts
@@ -30,7 +30,7 @@ export interface ISearchResult {
   type: string;
 }
 
-export const getFallbackResults = (): ISearchResults<ISearchResult> => {
+const getFallbackResults = <T extends ISearchResult>(): ISearchResults<T> => {
   return { results: [] };
 };
 
@@ -58,7 +58,7 @@ export class SearchService {
     return requestBuilder
       .get()
       .then((response: Array<ISearchResults<T>>) => {
-        return response[0] || getFallbackResults();
+        return response[0] || getFallbackResults<T>();
       })
       .catch((response: IHttpPromiseCallbackArg<any>) => {
         $log.error(response.data, response);

--- a/app/scripts/modules/core/src/task/task.read.service.ts
+++ b/app/scripts/modules/core/src/task/task.read.service.ts
@@ -1,4 +1,3 @@
-
 import { $log, $q, $timeout } from 'ngimport';
 import { Subject } from 'rxjs';
 
@@ -36,7 +35,10 @@ export class TaskReader {
         }
         return task;
       })
-      .catch((error: any) => $log.warn('There was an issue retrieving taskId: ', taskId, error));
+      .catch((error: any) => {
+        $log.warn('There was an issue retrieving taskId: ', taskId, error);
+        return undefined;
+      });
   }
 
   public static waitUntilTaskMatches(

--- a/app/scripts/modules/core/src/task/task.write.service.ts
+++ b/app/scripts/modules/core/src/task/task.write.service.ts
@@ -1,6 +1,5 @@
-
-
 import { API } from 'core/api/ApiService';
+import { ITask } from '../domain';
 import { TaskReader } from './task.read.service';
 import { ITaskCommand } from './taskExecutor';
 import { DebugWindow } from 'core/utils/consoleDebug';
@@ -14,7 +13,7 @@ export class TaskWriter {
     return API.all('tasks').post(taskCommand);
   }
 
-  public static cancelTask(taskId: string): PromiseLike<void> {
+  public static cancelTask(taskId: string): PromiseLike<ITask> {
     return API.all('tasks')
       .one(taskId, 'cancel')
       .put()


### PR DESCRIPTION
Previously, `API.one()` returned `any` so all type safety and auto-complete was lost.  Now, those methods return `IRequestBuilder` interface.


- I've cleaned up the calling code whereever it was relying on `any` type being returned
- I added generic parameter to `.get<ReturnType>()` (and `.post`/`.put`/etc)
