### PR TITLE
fix(titus): Fallback dimensions for target tracking policy

### DIFF
--- a/app/scripts/modules/titus/src/serverGroup/details/serverGroupDetails.titus.controller.js
+++ b/app/scripts/modules/titus/src/serverGroup/details/serverGroupDetails.titus.controller.js
@@ -133,7 +133,7 @@ angular
         serverGroup.scalingPolicies = (serverGroup.scalingPolicies || [])
           .map((p) => {
             const { policy } = p;
-            const { stepPolicyDescriptor } = policy;
+            const { stepPolicyDescriptor, targetPolicyDescriptor } = policy;
             const policyType = stepPolicyDescriptor ? 'StepScaling' : 'TargetTrackingScaling';
             if (stepPolicyDescriptor) {
               const alarm = stepPolicyDescriptor.alarmConfig;
@@ -167,6 +167,10 @@ angular
               }
               return policy;
             } else {
+              const { customizedMetricSpecification } = targetPolicyDescriptor;
+              if (customizedMetricSpecification.dimensions === undefined) {
+                customizedMetricSpecification.dimensions = [];
+              }
               policy.id = p.id;
               policy.targetTrackingConfiguration = policy.targetPolicyDescriptor;
               policy.targetTrackingConfiguration.scaleOutCooldown =


### PR DESCRIPTION
Just making `dimensions` an empty array if it's undefined to prevent this reduce from throwing:
https://github.com/spinnaker/deck/blob/976e958b25d44086b59108367ab038199ffcdc7e/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/chart/metricAlarmChart.component.js#L42