### PR TITLE
fix(titus): Disable edits of step scaling dimensions

### DIFF
--- a/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/upsert/alarm/dimensionsEditor.component.html
+++ b/app/scripts/modules/amazon/src/serverGroup/details/scalingPolicy/upsert/alarm/dimensionsEditor.component.html
@@ -19,6 +19,7 @@
       ng-model-options="{ updateOn: 'default blur', debounce: { 'default': 300, 'blur': 0 } }"
       ng-model="dimension.name"
       placeholder="name"
+      ng-disabled="$ctrl.alarm.disableEditingDimensions"
     />
   </div>
   <div class="col-md-6" style="padding-left: 10px">
@@ -31,15 +32,16 @@
       ng-change="$ctrl.updateAvailableMetrics()"
       ng-model="dimension.value"
       placeholder="value"
+      ng-disabled="$ctrl.alarm.disableEditingDimensions"
     />
   </div>
-  <div class="col-md-2">
+  <div ng-show="!$ctrl.alarm.disableEditingDimensions" class="col-md-2">
     <a class="form-control-static" href ng-click="$ctrl.removeDimension($index)">
       <span class="glyphicon glyphicon-trash" uib-tooltip="Remove dimension"></span>
     </a>
   </div>
 </div>
-<div class="row">
+<div ng-show="!$ctrl.alarm.disableEditingDimensions" class="row">
   <div class="col-md-10">
     <button class="btn btn-block btn-xs add-new" ng-click="$ctrl.alarm.dimensions.push({})">
       <span class="glyphicon glyphicon-plus-sign"></span>

--- a/app/scripts/modules/titus/src/serverGroup/details/scalingPolicy/upsert/upsertScalingPolicy.controller.js
+++ b/app/scripts/modules/titus/src/serverGroup/details/scalingPolicy/upsert/upsertScalingPolicy.controller.js
@@ -47,6 +47,7 @@ module(TITUS_SERVERGROUP_DETAILS_SCALINGPOLICY_UPSERT_UPSERTSCALINGPOLICY_CONTRO
           region: serverGroup.region,
           comparisonOperator: alarm.comparisonOperator,
           dimensions: alarm.dimensions,
+          disableEditingDimensions: alarm.disableEditingDimensions,
           evaluationPeriods: alarm.evaluationPeriods,
           period: alarm.period,
           threshold: alarm.threshold,

--- a/app/scripts/modules/titus/src/serverGroup/details/serverGroupDetails.titus.controller.js
+++ b/app/scripts/modules/titus/src/serverGroup/details/serverGroupDetails.titus.controller.js
@@ -139,7 +139,10 @@ angular
               const alarm = stepPolicyDescriptor.alarmConfig;
               alarm.period = alarm.periodSec;
               alarm.namespace = alarm.metricNamespace;
+              alarm.disableEditingDimensions = true;
               if (alarm.metricNamespace === 'NFLX/EPIC' && !alarm.dimensions) {
+                // NOTE: Titus creates the step scaling policy with these dimensions
+                // TODO: Remove this once Titus supports configuring dimensions
                 alarm.dimensions = [{ name: 'AutoScalingGroupName', value: serverGroup.name }];
               }
               if (!alarm.dimensions) {

--- a/app/scripts/modules/titus/src/serverGroup/serverGroup.transformer.js
+++ b/app/scripts/modules/titus/src/serverGroup/serverGroup.transformer.js
@@ -48,6 +48,7 @@ module(TITUS_SERVERGROUP_SERVERGROUP_TRANSFORMER, []).factory('titusServerGroupT
             statistic: 'Average',
             comparisonOperator: 'GreaterThanThreshold',
             evaluationPeriods: 1,
+            disableEditingDimensions: true,
             dimensions: [{ name: 'AutoScalingGroupName', value: serverGroup.name }],
             period: 60,
           },


### PR DESCRIPTION
Not the cleanest, but the least invasive way to temporarily disable editing of dimensions in step scaling policies for Titus.