### PR TITLE
chore(pluginsdk-peerdeps): Publish 0.0.4

### DIFF
--- a/packages/pluginsdk-peerdeps/package.json
+++ b/packages/pluginsdk-peerdeps/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spinnaker/pluginsdk-peerdeps",
   "description": "Provides package dependencies to plugin developers",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "license": "Apache-2.0",
   "scripts": {
     "usage": "cat USAGE.txt",
@@ -14,7 +14,7 @@
     "@rollup/plugin-commonjs": "16.0.0",
     "@rollup/plugin-node-resolve": "10.0.0",
     "@rollup/plugin-typescript": "6.1.0",
-    "@spinnaker/core": "0.0.526",
+    "@spinnaker/core": "0.0.534",
     "@spinnaker/eslint-plugin": "1.0.9",
     "@spinnaker/pluginsdk": "*",
     "@types/react": "16.8.25",


### PR DESCRIPTION
Bumping to use some newly exported core components in a plugin. 