### PR TITLE
Deprecate API.one('foo').all('bar').get() in favor of REST('/foo/bar').get()

### DIFF
--- a/app/scripts/modules/core/src/api/ApiService.spec.ts
+++ b/app/scripts/modules/core/src/api/ApiService.spec.ts
@@ -1,9 +1,9 @@
-import { IHttpClientBackend } from './ApiService';
+import { IHttpClientImplementation } from './ApiService';
 import { SETTINGS } from '../config/settings';
 import { makeRequestBuilderConfig, RequestBuilder } from './ApiService';
 
 describe('RequestBuilder backend', () => {
-  const createBackend = (): IHttpClientBackend => jasmine.createSpyObj(['get', 'post', 'put', 'delete']);
+  const createBackend = (): IHttpClientImplementation => jasmine.createSpyObj(['get', 'post', 'put', 'delete']);
 
   it('receives a url prefixed with the baseUrl', () => {
     const backend = createBackend();

--- a/app/scripts/modules/core/src/api/ApiService.spec.ts
+++ b/app/scripts/modules/core/src/api/ApiService.spec.ts
@@ -1,456 +1,133 @@
-import Spy = jasmine.Spy;
-import { mock, noop } from 'angular';
-import { AuthenticationInitializer } from '../authentication/AuthenticationInitializer';
-import { ICache } from '../cache';
-import { API, InvalidAPIResponse } from './ApiService';
-import { SETTINGS } from 'core/config/settings';
+import { IHttpClientBackend } from './ApiService';
+import { SETTINGS } from '../config/settings';
+import { makeRequestBuilderConfig, RequestBuilder } from './ApiService';
 
-describe('API Service', function () {
-  let $httpBackend: ng.IHttpBackendService;
-  let baseUrl: string;
+describe('RequestBuilder backend', () => {
+  const createBackend = (): IHttpClientBackend => jasmine.createSpyObj(['get', 'post', 'put', 'delete']);
 
-  beforeEach(
-    mock.inject(function (_$httpBackend_: ng.IHttpBackendService) {
-      $httpBackend = _$httpBackend_;
-      baseUrl = API.baseUrl;
-    }),
-  );
-
-  afterEach(function () {
-    SETTINGS.resetToOriginal();
-    $httpBackend.verifyNoOutstandingExpectation();
-    $httpBackend.verifyNoOutstandingRequest();
+  it('receives a url prefixed with the baseUrl', () => {
+    const backend = createBackend();
+    new RequestBuilder(undefined, backend, 'thebaseurl').get();
+    expect(backend.get).toHaveBeenCalledWith(jasmine.objectContaining({ url: 'thebaseurl' }));
   });
 
-  describe('ensure api requests generate normalized urls', function () {
-    let expected: ng.IRequestConfig;
-    beforeEach(() => {
-      expected = {
-        method: '',
-        url: '',
-      };
-    });
-
-    it('trims leading slashes from urls', function () {
-      const result = API.one('/foo');
-      expected.url = `${baseUrl}/foo`;
-      expect(result.config).toEqual(expected);
-    });
-
-    it('trims repeated leading slashes from urls', function () {
-      const result = API.one('/////foo');
-      expected.url = `${baseUrl}/foo`;
-      expect(result.config).toEqual(expected);
-    });
-
-    it('trims trailing slashes from baseUrl', function () {
-      SETTINGS.gateUrl = 'http://localhost/';
-      expect(API.baseUrl).toEqual('http://localhost');
-    });
-
-    it('trims repeated trailing slashes from baseUrl', function () {
-      SETTINGS.gateUrl = 'http://localhost/////';
-      expect(API.baseUrl).toEqual('http://localhost');
-    });
+  it('url prefix defaults to the gate url', () => {
+    const backend = createBackend();
+    new RequestBuilder(undefined, backend).get();
+    expect(backend.get).toHaveBeenCalledWith(jasmine.objectContaining({ url: SETTINGS.gateUrl }));
   });
 
-  describe('validate response content-type header', function () {
-    it('responses with non-"application/json" content types should trigger a reauthentication request and reject', function () {
-      spyOn(AuthenticationInitializer, 'reauthenticateUser').and.callFake(noop);
-      $httpBackend
-        .expectGET(`${baseUrl}/bad`)
-        .respond(200, '<html>this is the authentication page</html>', { 'content-type': 'text/html' });
+  it('receives the url prefixed with the gate url (when no baseUrl specified)', () => {
+    const backend = createBackend();
+    new RequestBuilder(undefined, backend).get();
+    expect(backend.get).toHaveBeenCalledWith(jasmine.objectContaining({ url: SETTINGS.gateUrl }));
+  });
 
-      let rejected = false;
-      API.one('bad')
-        .get()
-        .then(noop, () => (rejected = true));
+  it('accepts a different base url', function () {
+    const backend = createBackend();
+    new RequestBuilder(undefined, backend, 'http://different').get();
+    expect(backend.get).toHaveBeenCalledWith(jasmine.objectContaining({ url: 'http://different' }));
+  });
 
-      $httpBackend.flush();
-      expect((AuthenticationInitializer.reauthenticateUser as Spy).calls.count()).toBe(1);
-      expect(rejected).toBe(true);
+  it('trims trailing slashes from base url', function () {
+    const backend = createBackend();
+    new RequestBuilder(undefined, backend, 'http://different//////').get();
+    expect(backend.get).toHaveBeenCalledWith(jasmine.objectContaining({ url: 'http://different' }));
+  });
+
+  it('trims trailing slashes from base urls with embedded paths', function () {
+    const backend = createBackend();
+    new RequestBuilder(undefined, backend, 'http://different/path/////').get();
+    expect(backend.get).toHaveBeenCalledWith(jasmine.objectContaining({ url: 'http://different/path' }));
+  });
+
+  it('trims all leading and trailing slashes', function () {
+    const backend = createBackend();
+    new RequestBuilder(undefined, backend, '///http://different/path/////').path('////foo///').get();
+    expect(backend.get).toHaveBeenCalledWith(jasmine.objectContaining({ url: 'http://different/path/foo' }));
+  });
+});
+
+describe('REST Service', function () {
+  const builder = () => new RequestBuilder(makeRequestBuilderConfig());
+  afterEach(() => SETTINGS.resetToOriginal());
+
+  describe('RequestBuilder.path()', function () {
+    it('joins a path to the current url using a /', function () {
+      const result = builder().path('foo');
+      expect(result['config'].url).toEqual(`foo`);
     });
 
-    it('application/foo+json is fine', () => {
-      spyOn(AuthenticationInitializer, 'reauthenticateUser').and.callFake(noop);
-      $httpBackend
-        .expectGET(`${baseUrl}/bad`)
-        .respond(200, '{"good":"job"}', { 'content-type': 'application/foo+json' });
-
-      let rejected = false;
-      API.one('bad')
-        .get()
-        .then(noop, () => (rejected = true));
-
-      $httpBackend.flush();
-      expect((AuthenticationInitializer.reauthenticateUser as Spy).calls.count()).toBe(0);
-      expect(rejected).toBe(false);
+    it('joins multiple path to the current url using a /', function () {
+      const result = builder().path('foo', 'bar');
+      expect(result['config'].url).toEqual(`foo/bar`);
     });
 
-    it('application/x-yaml;charset=utf-8 is fine, too', () => {
-      spyOn(AuthenticationInitializer, 'reauthenticateUser').and.callFake(noop);
-      $httpBackend
-        .expectGET(`${baseUrl}/yaml`)
-        .respond(200, '---\nfoo: bar', { 'content-type': 'application/x-yaml;charset=utf-8' });
-
-      let rejected = false;
-      API.one('yaml')
-        .get()
-        .then(noop, () => (rejected = true));
-
-      $httpBackend.flush();
-      expect((AuthenticationInitializer.reauthenticateUser as Spy).calls.count()).toBe(0);
-      expect(rejected).toBe(false);
+    it('can be chained', () => {
+      const result = builder().path('foo').path('bar');
+      expect(result['config'].url).toEqual(`foo/bar`);
     });
 
-    it('string responses starting with <html should trigger a reauthentication request and reject', function () {
-      spyOn(AuthenticationInitializer, 'reauthenticateUser').and.callFake(noop);
-      $httpBackend.expectGET(`${baseUrl}/fine`).respond(200, 'this is fine');
-
-      let rejected = false;
-      let succeeded = false;
-      API.one('fine')
-        .get()
-        .then(
-          () => (succeeded = true),
-          () => (rejected = true),
-        );
-
-      $httpBackend.flush();
-      expect((AuthenticationInitializer.reauthenticateUser as Spy).calls.count()).toBe(0);
-      expect(rejected).toBe(false);
-      expect(succeeded).toBe(true);
+    it('does not modify the parent builder config', () => {
+      const parent = builder().path('foo');
+      const child = parent.path('bar');
+      expect(parent['config'].url).toEqual(`foo`);
+      expect(child['config'].url).toEqual(`foo/bar`);
     });
 
-    it('object and array responses should pass through', function () {
-      spyOn(AuthenticationInitializer, 'reauthenticateUser').and.callFake(noop);
-
-      let rejected = false;
-      let succeeded = false;
-      $httpBackend.expectGET(`${baseUrl}/some-array`).respond(200, []);
-      API.one('some-array')
-        .get()
-        .then(
-          () => (succeeded = true),
-          () => (rejected = true),
-        );
-      $httpBackend.flush();
-
-      expect((AuthenticationInitializer.reauthenticateUser as Spy).calls.count()).toBe(0);
-      expect(rejected).toBe(false);
-      expect(succeeded).toBe(true);
-
-      // verify object responses
-      rejected = false;
-      succeeded = false;
-      $httpBackend.expectGET(`${baseUrl}/some-object`).respond(200, {});
-      API.one('some-object')
-        .get()
-        .then(
-          () => (succeeded = true),
-          () => (rejected = true),
-        );
-      $httpBackend.flush();
-
-      expect((AuthenticationInitializer.reauthenticateUser as Spy).calls.count()).toBe(0);
-      expect(rejected).toBe(false);
-      expect(succeeded).toBe(true);
+    it('trims leading slashes in paths', function () {
+      const result = builder().path('/foo');
+      expect(result['config'].url).toEqual(`foo`);
     });
 
-    it('rejects the request promise with an error when content mismatch occurs', () => {
-      spyOn(AuthenticationInitializer, 'reauthenticateUser').and.callFake(noop);
-      $httpBackend
-        .expectGET(`${baseUrl}/bad`)
-        .respond(200, '<html>this is the authentication page</html>', { 'content-type': 'text/html' });
-
-      let err: any;
-      API.one('bad')
-        .get()
-        .catch((e: any) => (err = e));
-
-      $httpBackend.flush();
-      expect(err instanceof InvalidAPIResponse).toBeTruthy();
+    it('trims trailing slashes in paths', function () {
+      const result = builder().path('foo/');
+      expect(result['config'].url).toEqual(`foo`);
     });
 
-    it('returns a string error message in the format expected by UI components when content mismatch occurs', () => {
-      spyOn(AuthenticationInitializer, 'reauthenticateUser').and.callFake(noop);
-      $httpBackend
-        .expectGET(`${baseUrl}/bad`)
-        .respond(200, '<html>this is the authentication page</html>', { 'content-type': 'text/html' });
-
-      let message = '';
-      API.one('bad')
-        .get()
-        .catch((err: any) => (message = err.data.message));
-
-      $httpBackend.flush();
-      expect(message).toBe(API.invalidContentMessage);
+    it('trims repeated leading and trailing slashes from urls', function () {
+      const result = builder().path('///foo///');
+      expect(result['config'].url).toEqual(`foo`);
     });
 
-    it('returns a copy of the original response when content mismatch occurs', () => {
-      spyOn(AuthenticationInitializer, 'reauthenticateUser').and.callFake(noop);
-      const serverResult = { foo: 'bar' };
-      $httpBackend.expectGET(`${baseUrl}/bad`).respond(200, serverResult, { 'content-type': 'foobar/json' });
+    // coming soon:
+    // it('uriencodes path parameters', () => {
+    //   const result = builder().path('foo/bar');
+    //   expect(result['config'].url).toEqual(`${BASEURL}/foo%2fbar`);
+    // });
+  });
 
-      let receivedResult = null;
-      API.one('bad')
-        .get()
-        .catch((err: any) => (receivedResult = err.originalResult.data));
+  describe('RequestBuilder.query()', function () {
+    it('stores query params in the config', () => {
+      const result = builder().query({ foo: 'foo' });
+      expect(result['config'].params).toEqual({ foo: 'foo' });
+    });
 
-      $httpBackend.flush();
-      expect(receivedResult).toEqual(serverResult);
+    it('merges new params with any already in the config', () => {
+      const result = builder().query({ foo: 'foo' }).query({ bar: 'bar' });
+      expect(result['config'].params).toEqual({ foo: 'foo', bar: 'bar' });
+    });
+
+    it('prefers newer params when keys are the same as those already in the config', () => {
+      const result = builder().query({ foo: 'bar' }).query({ foo: 'foo' });
+      expect(result['config'].params).toEqual({ foo: 'foo' });
     });
   });
 
-  describe('creating the config and testing the chaining functions without parameters', () => {
-    let expected: ng.IRequestConfig;
-    beforeEach(() => {
-      expected = {
-        method: '',
-        url: '',
-      };
+  describe('RequestBuilder.useCache()', function () {
+    it('should set cache to "true" if called with no args', function () {
+      const result = builder().useCache();
+      expect(result['config'].cache).toBe(true);
     });
 
-    describe('creating the config with "one" function', function () {
-      it('missing url should create a default config with the base url', function () {
-        const result = API.one();
-        expected.url = baseUrl;
-        expect(result.config).toEqual(expected);
-      });
-
-      it('single url should create a default config with the base url', function () {
-        const result = API.one('foo');
-        expected.url = `${baseUrl}/foo`;
-        expect(result.config).toEqual(expected);
-      });
-
-      it('multiple calls to "one" should create a default config with the base url and build out the url', function () {
-        const result = API.one('foo').one('bar');
-        expected.url = `${baseUrl}/foo/bar`;
-        expect(result.config).toEqual(expected);
-      });
-
-      it('should allow for multiple urls to be added to the url', function () {
-        const result = API.one('foo', 'bar');
-        expected.url = `${baseUrl}/foo/bar`;
-        expect(result.config).toEqual(expected);
-      });
+    it('should set cache to "true" if called with "true"', function () {
+      const result = builder().useCache(true);
+      expect(result['config'].cache).toBe(true);
     });
 
-    describe('creating the  config with "all" function', function () {
-      it('missing url should create a default config with the base url', function () {
-        const result = API.all();
-        expected.url = baseUrl;
-        expect(result.config).toEqual(expected);
-      });
-
-      it('single url should create a default config with the base url', function () {
-        const result = API.all('foo');
-        expected.url = `${baseUrl}/foo`;
-        expect(result.config).toEqual(expected);
-      });
-
-      it('multiple calls to "all" should create a default config with the base url and build out the url', function () {
-        const result = API.all('foo').all('bar');
-        expected.url = `${baseUrl}/foo/bar`;
-        expect(result.config).toEqual(expected);
-      });
-
-      it('should allow for multiple urls to be added to the url', function () {
-        const result = API.all('foo', 'bar');
-        expected.url = `${baseUrl}/foo/bar`;
-        expect(result.config).toEqual(expected);
-      });
-    });
-
-    describe('creating the  config with mix of "one" and "all" function', function () {
-      it('single url should create a default config with the base url', function () {
-        const result = API.all('foo').one('bar');
-        expected.url = `${baseUrl}/foo/bar`;
-        expect(result.config).toEqual(expected);
-      });
-
-      it('multiple calls to "all" should create a default config with the base url and build out the url', function () {
-        const result = API.one('foo').all('bar');
-        expected.url = `${baseUrl}/foo/bar`;
-        expect(result.config).toEqual(expected);
-      });
-
-      it('should allow for multiple urls to be added to the url', function () {
-        const result = API.all('foo', 'bar').one('baz');
-        expected.url = `${baseUrl}/foo/bar/baz`;
-        expect(result.config).toEqual(expected);
-      });
-    });
-
-    describe('creating multiple endpoints', function () {
-      it('should not stomp on each other', function () {
-        const first = API.one('bar');
-        const second = API.one('foo');
-
-        expect(first.config).toEqual({ method: '', url: `${baseUrl}/bar` });
-        expect(second.config).toEqual({ method: '', url: `${baseUrl}/foo` });
-      });
-    });
-
-    describe('create config with data', function () {
-      it('should add data to the config if data object passed', function () {
-        const data = { bar: 'baz' };
-        const result = API.one('foo').data(data);
-        expected.url = `${baseUrl}/foo`;
-        expected.data = data;
-        expect(result.config).toEqual(expected);
-      });
-    });
-  });
-
-  describe('create a config with params', function () {
-    it('when params are provided', function () {
-      const result = API.one('foo').withParams({ one: 1 });
-      expect(result.config).toEqual({ method: '', url: `${baseUrl}/foo`, params: { one: 1 } });
-    });
-  });
-
-  describe('useCache()', function () {
-    it('should set cache to "true" if no params set', function () {
-      const result = API.one('foo').useCache();
-      expect(result.config.cache).toBe(true);
-    });
-
-    it('should set cache to "false" if explicitly  set', function () {
-      const result = API.one('foo').useCache(false);
-      expect(result.config.cache).toBe(false);
-    });
-
-    it('should set cache to cache object if explicitly set', function () {
-      const cacheObj = ({ count: 1 } as unknown) as ICache;
-      const result = API.one('foo').useCache(cacheObj);
-      expect(result.config.cache).toBe(cacheObj);
-    });
-  });
-
-  describe('get(): create a url with a "GET" method', function () {
-    it('should create the url and issue a get request with the "one" function', function () {
-      $httpBackend.expectGET(`${baseUrl}/foo`).respond(200);
-
-      API.one('foo').get();
-
-      $httpBackend.flush();
-    });
-
-    it('should create the url and issue a get request with the "all" function', function () {
-      $httpBackend.expectGET(`${baseUrl}/foo/bar`).respond(200);
-
-      API.all('foo', 'bar').get();
-
-      $httpBackend.flush();
-    });
-
-    it('should take a param object with one param', function () {
-      $httpBackend.expectGET(`${baseUrl}/foo/bar?param1=2`).respond(200);
-
-      API.one('foo', 'bar').get({ param1: 2 });
-
-      $httpBackend.flush();
-    });
-
-    it('should take a param object with multiple params', function () {
-      $httpBackend.expectGET(`${baseUrl}/foo/bar?param1=2&param2=foo`).respond(200);
-
-      API.one('foo', 'bar').get({ param1: 2, param2: 'foo' });
-
-      $httpBackend.flush();
-    });
-  });
-
-  describe('getList(): create a url with a "GET" method', function () {
-    it('should create the url and issue a get request with the "one" function', function () {
-      $httpBackend.expectGET(`${baseUrl}/foo`).respond(200);
-
-      API.one('foo').getList();
-
-      $httpBackend.flush();
-    });
-
-    it('should create the url and issue a get request with the "all" function', function () {
-      $httpBackend.expectGET(`${baseUrl}/foo/bar`).respond(200);
-
-      API.all('foo', 'bar').getList();
-
-      $httpBackend.flush();
-    });
-
-    it('should take a param object with one param', function () {
-      $httpBackend.expectGET(`${baseUrl}/foo/bar?param1=2`).respond(200);
-
-      API.one('foo', 'bar').getList({ param1: 2 });
-
-      $httpBackend.flush();
-    });
-
-    it('should take a param object with multiple params', function () {
-      $httpBackend.expectGET(`${baseUrl}/foo/bar?param1=2&param2=foo`).respond(200);
-
-      API.one('foo', 'bar').getList({ param1: 2, param2: 'foo' });
-
-      $httpBackend.flush();
-    });
-  });
-
-  describe('post(): create a url with a "POST" method', function () {
-    it('should create the url and make a POST call', function () {
-      $httpBackend.expectPOST(`${baseUrl}/foo`).respond(200);
-
-      API.one('foo').post();
-
-      $httpBackend.flush();
-    });
-
-    it('should create the url and POST with data', function () {
-      const data = { bar: 7 };
-      $httpBackend.expectPOST(`${baseUrl}/foo`, data).respond(200);
-
-      API.one('foo').post(data);
-
-      $httpBackend.flush();
-    });
-  });
-
-  describe('put(): create a url with a "PUT" method', function () {
-    it('should create the url and make a POST call', function () {
-      $httpBackend.expectPUT(`${baseUrl}/foo`).respond(200);
-
-      API.one('foo').put();
-
-      $httpBackend.flush();
-    });
-
-    it('should create the url and PUT with data', function () {
-      const data = { bar: 7 };
-      $httpBackend.expectPUT(`${baseUrl}/foo`, data).respond(200);
-
-      API.one('foo').put(data);
-
-      $httpBackend.flush();
-    });
-  });
-
-  describe('remove(): create a url with a "DELETE" method', function () {
-    it('should create the url and make a DELETE call', function () {
-      $httpBackend.expectDELETE(`${baseUrl}/foo`).respond(200);
-
-      API.one('foo').remove();
-
-      $httpBackend.flush();
-    });
-
-    it('should create the url with params and  make a DELETE call', function () {
-      const params = { bar: 7 };
-      $httpBackend.expectDELETE(`${baseUrl}/foo?bar=7`).respond(200);
-
-      API.one('foo').remove(params);
-
-      $httpBackend.flush();
+    it('should set cache to "false" if called with "false"', function () {
+      const result = builder().useCache(false);
+      expect(result['config'].cache).toBe(false);
     });
   });
 });

--- a/app/scripts/modules/core/src/api/ApiService.ts
+++ b/app/scripts/modules/core/src/api/ApiService.ts
@@ -1,193 +1,254 @@
-import { IRequestConfig } from 'angular';
-import { $q, $http } from 'ngimport';
-import { AuthenticationInitializer } from '../authentication/AuthenticationInitializer';
-import { SETTINGS } from 'core/config/settings';
-import { ICache } from 'core/cache';
 import { isNil } from 'lodash';
+import { $http } from 'ngimport';
+import { ICache } from '../cache/deckCacheFactory';
+import { SETTINGS } from '../config/settings';
+import { AuthenticationInitializer } from '../authentication/AuthenticationInitializer';
 
 type IPrimitive = string | boolean | number;
 type IParams = Record<string, IPrimitive | IPrimitive[]>;
 
+/**
+ * A Builder API for making requests to Gate backend service
+ */
 export interface IRequestBuilder {
-  config?: IRequestConfig;
-  one?: (...urls: string[]) => IRequestBuilder;
-  all?: (...urls: string[]) => IRequestBuilder;
-  useCache?: (useCache?: boolean | ICache) => IRequestBuilder;
-  withParams?: (params: IParams) => IRequestBuilder;
-  data?: (data: any) => IRequestBuilder;
-  get?: <T = any>(params?: IParams) => PromiseLike<T>;
-  getList?: <T = any>(params?: IParams) => PromiseLike<T>;
-  post?: <T = any>(data?: any) => PromiseLike<T>;
-  remove?: <T = any>(params?: IParams) => PromiseLike<T>;
-  put?: <T = any>(data?: any) => PromiseLike<T>;
+  /**
+   * Appends one or more path segments to the URL, separated by slashes.
+   * Each path segment is uri encoded.
+   */
+  path(...pathSegments: IPrimitive[]): this;
+
+  /** Adds query parameters to the URL */
+  query(queryParams: IParams): this;
+
+  /** Enables or disables caching of the response */
+  useCache(useCache?: boolean): this;
+
+  /** issues a GET request */
+  get<T = any>(): PromiseLike<T>;
+  /** issues a POST request */
+  post<T = any, P = any>(data?: P): PromiseLike<T>;
+  /** issues a PUT request */
+  put<T = any, P = any>(data?: P): PromiseLike<T>;
+  /** issues a DELETE request */
+  delete<T = any>(): PromiseLike<T>;
+}
+
+/**
+ * Internal interface to encapsulate a request
+ * Passed to IHttpClientBackend
+ */
+interface IRequestBuilderConfig {
+  url: string;
+  timeout?: number;
+  headers?: { [headerName: string]: string };
+  /** @deprecated used for AngularJS backwards compat */
+  data?: any;
+  params?: object;
+  cache?: boolean;
+}
+
+/**
+ * The old API interface
+ */
+export interface IDeprecatedRequestBuilder extends IRequestBuilder {
+  useCache(): this;
+  useCache(useCache: boolean): this;
+  useCache(useCache: ICache): this;
+  withParams(queryParams: IParams): this;
+
+  /** @deprecated do not use this config object */
+  config: IRequestBuilderConfig;
+  /** @deprecated use SETTINGS.gateUrl */
+  baseUrl: string;
+  /** @deprecated use path() instead (this is a passthrough to path) */
+  one(...urls: string[]): this;
+  /** @deprecated use one() instead (this is a passthrough to one) */
+  all(...urls: string[]): this;
+  /** @deprecated use put(data) or post(data) instead */
+  data(data: any): this;
+  // Add overload with params
+  get<T = any>(params?: IParams): PromiseLike<T>;
+  /** @deprecated use delete() instead (this is a passthrough to delete) */
+  remove(params?: IParams): PromiseLike<any>;
+  /** @deprecated use get() instead (this is a passthrough to get) */
+  getList<T = any>(params?: IParams): PromiseLike<T>;
+}
+
+/**
+ * An interface to support pluggable http clients
+ * In the future, we should have a TestingHttpBackend and a FetchHttpBackend (or whatever http client we go with)
+ */
+export interface IHttpClientBackend {
+  get<T = any>(config: IRequestBuilderConfig): PromiseLike<T>;
+  post<T = any>(config: IRequestBuilderConfig): PromiseLike<T>;
+  put<T = any>(config: IRequestBuilderConfig): PromiseLike<T>;
+  delete<T = any>(config: IRequestBuilderConfig): PromiseLike<T>;
 }
 
 export class InvalidAPIResponse extends Error {
   public data: { message: string };
+
   constructor(message: string, public originalResult: any) {
     super(message);
     this.data = { message };
   }
 }
 
-export class API {
-  private static defaultParams = {
-    timeout: (SETTINGS.pollSchedule || 30000) * 2 + 5000,
-    headers: {
-      'X-RateLimit-App': 'deck',
-    },
-  };
+/**
+ * An HTTP client that uses the AngularJS $http service
+ * This client also handles non-data responses from Gate which is used to indicate the user is not authenticated
+ * TODO: Can the re-authentication logic be moved somewhere else?
+ */
+class AngularJSHttpBackend implements IHttpClientBackend {
+  delete = <T = any>(requestConfig: IRequestBuilderConfig) => this.request<T>('DELETE', requestConfig);
+  get = <T = any>(requestConfig: IRequestBuilderConfig) => this.request<T>('GET', requestConfig);
+  post = <T = any>(requestConfig: IRequestBuilderConfig) => this.request<T>('POST', requestConfig);
+  put = <T = any>(requestConfig: IRequestBuilderConfig) => this.request<T>('PUT', requestConfig);
 
-  public static readonly invalidContentMessage = 'API response was neither JSON nor zero-length html or text';
+  private request<T>(method: 'GET' | 'POST' | 'PUT' | 'DELETE', requestConfig: IRequestBuilderConfig): PromiseLike<T> {
+    return $http<T>({ ...requestConfig, method }).then((response) => {
+      const contentType = response.headers('content-type');
 
-  private static getData(result: any): PromiseLike<any> {
-    return $q((resolve, reject) => {
-      const contentType = result.headers('content-type');
       if (contentType) {
-        const isJson = contentType.match(/application\/(.+\+)?json/); // e.g application/json, application/hal+json
+        // e.g application/json, application/hal+json
+        const isJson = contentType.match(/application\/(.+\+)?json/);
         // e.g. application/yaml, application/x-yaml; it's regex, let's not get too fancy
         const isYaml = contentType.match(/application\/(.+-)?yaml/);
-        const isZeroLengthHtml = contentType.includes('text/html') && result.data === '';
-        const isZeroLengthText = contentType.includes('text/plain') && result.data === '';
+        const isZeroLengthHtml = contentType.includes('text/html') && (response as any).data === '';
+        const isZeroLengthText = contentType.includes('text/plain') && (response as any).data === '';
         if (!(isJson || isYaml || isZeroLengthHtml || isZeroLengthText)) {
           AuthenticationInitializer.reauthenticateUser();
-          reject(new InvalidAPIResponse(API.invalidContentMessage, result));
+          throw new InvalidAPIResponse(invalidContentMessage, response);
         }
       }
 
-      return resolve(result.data);
+      return response.data;
     });
   }
+}
 
-  private static internalOne(config: IRequestConfig): (...urls: string[]) => IRequestBuilder {
-    return (...urls: string[]) => {
-      urls.forEach((url: string) => {
-        if (url) {
-          config.url = `${config.url}/${url}`;
-        }
-      });
+function joinPaths(...paths: IPrimitive[]) {
+  // coerce paths toString() in case somebody sends in a url object
+  // according to https://github.com/spinnaker/deck/pull/6927
+  return paths
+    .filter((path) => !isNil(path) && path !== '')
+    .map((path) => path.toString())
+    .map((path) => path.replace(/^\/+/, '')) // strip leading slashes
+    .map((path) => path.replace(/\/+$/, '')) // strip trailing slashes
+    .join('/');
+}
 
-      return this.baseReturn(config);
-    };
+/** The base request builder implementation */
+export class RequestBuilder implements IRequestBuilder {
+  static defaultBackend = new AngularJSHttpBackend();
+
+  public constructor(
+    protected config: IRequestBuilderConfig = makeRequestBuilderConfig(),
+    protected _backend?: IHttpClientBackend,
+    protected _baseUrl?: string,
+  ) {}
+
+  // Factory function to create a child builder of the appropriate type
+  protected builder(newRequest: IRequestBuilderConfig): this {
+    return new RequestBuilder(newRequest, this.backend, this._baseUrl) as this;
   }
 
-  private static useCacheFn(config: IRequestConfig): (useCache: boolean | ICache) => IRequestBuilder {
-    return (useCache = true) => {
-      config.cache = useCache;
-      return this.baseReturn(config);
-    };
+  protected get backend(): IHttpClientBackend {
+    return this._backend ?? RequestBuilder.defaultBackend;
   }
 
-  private static withParamsFn(config: IRequestConfig): (params: any) => IRequestBuilder {
-    return (params: any) => {
-      if (params) {
-        config.params = params;
-      }
-
-      return this.baseReturn(config);
-    };
+  protected get baseUrl(): string {
+    return (this._baseUrl ?? SETTINGS.gateUrl).replace(/\/+$/, '');
   }
 
-  // sets the data for PUT and POST operations
-  private static dataFn(config: IRequestConfig): (data: any) => IRequestBuilder {
-    return (data: any) => {
-      if (data) {
-        config.data = data;
-      }
-
-      return this.baseReturn(config);
-    };
+  path(...paths: IPrimitive[]) {
+    const url = joinPaths(this.config.url, ...paths);
+    return this.builder({ ...this.config, url });
   }
 
-  // HTTP GET operation
-  private static getFn(config: IRequestConfig): (params: any) => PromiseLike<any> {
-    return (params: any) => {
-      config.method = 'get';
-      Object.assign(config, this.defaultParams);
-      if (params) {
-        config.params = params;
-      }
-
-      return $http(config).then((result: any) => this.getData(result));
-    };
+  // queryParams argument for backwards compat
+  get<T>(queryParams: object = {}) {
+    // Merge with existing params
+    const params = { ...this.config.params, ...queryParams };
+    const url = joinPaths(this.baseUrl, this.config.url);
+    return this.backend.get<T>({ ...this.config, url, params });
   }
 
-  // HTTP POST operation
-  private static postFn(config: IRequestConfig): (data: any) => PromiseLike<any> {
-    return (data: any) => {
-      config.method = 'post';
-      if (data) {
-        config.data = data;
-      }
-      Object.assign(config, this.defaultParams);
-
-      return $http(config).then((result: any) => this.getData(result));
-    };
+  post<T>(postData?: any) {
+    // Check this.config.data for backwards compat
+    const data = postData ?? this.config.data;
+    const url = joinPaths(this.baseUrl, this.config.url);
+    return this.backend.post<T>({ ...this.config, url, data });
   }
 
-  // HTTP DELETE operation
-  private static removeFn(config: IRequestConfig): (params: any) => PromiseLike<any> {
-    return (params: any) => {
-      config.method = 'delete';
-      if (params) {
-        config.params = params;
-      }
-      Object.assign(config, this.defaultParams);
-
-      return $http(config).then((result: any) => this.getData(result));
-    };
+  put<T>(putData?: any) {
+    // Check this.config.data for backwards compat
+    const data = putData ?? this.config.data;
+    const url = joinPaths(this.baseUrl, this.config.url);
+    return this.backend.put<T>({ ...this.config, url, data });
   }
 
-  // HTTP PUT operation
-  private static putFn(config: IRequestConfig): (data: any) => PromiseLike<any> {
-    return (data: any) => {
-      config.method = 'put';
-      if (data) {
-        config.data = data;
-      }
-      Object.assign(config, this.defaultParams);
-
-      return $http(config).then((result: any) => this.getData(result));
-    };
+  // queryParams argument for backwards compat
+  delete<T>(queryParams: object = {}) {
+    const params = { ...this.config.params, ...queryParams };
+    const url = joinPaths(this.baseUrl, this.config.url);
+    return this.backend.delete<T>({ ...this.config, url, params });
   }
 
-  private static baseReturn(config: IRequestConfig): IRequestBuilder {
-    return {
-      config,
-      one: this.internalOne(config),
-      all: this.internalOne(config),
-      useCache: this.useCacheFn(config),
-      withParams: this.withParamsFn(config),
-      data: this.dataFn(config),
-      get: this.getFn(config),
-      getList: this.getFn(config),
-      post: this.postFn(config),
-      remove: this.removeFn(config),
-      put: this.putFn(config),
-    };
+  useCache(cache = true) {
+    return this.builder({ ...this.config, cache: cache as boolean });
   }
 
-  private static init(urls: string[]) {
-    const config: IRequestConfig = {
-      method: '',
-      url: this.baseUrl,
-    };
-    urls
-      .filter((i) => !isNil(i))
-      .forEach((url: string) => (config.url = `${config.url}/${url.toString().replace(/^\/+/, '')}`));
-
-    return this.baseReturn(config);
-  }
-
-  public static one(...urls: string[]): IRequestBuilder {
-    return this.init(urls);
-  }
-
-  public static all(...urls: string[]): IRequestBuilder {
-    return this.init(urls);
-  }
-
-  public static get baseUrl(): string {
-    return SETTINGS.gateUrl.replace(/\/+$/, '');
+  query(queryParams: IParams) {
+    const params = { ...this.config.params, ...queryParams };
+    return this.builder({ ...this.config, params });
   }
 }
+
+/**
+ * This class extends RequestBuilder and re-implements the deprecated API for backwards compat
+ * @deprecated
+ */
+export class DeprecatedRequestBuilder extends RequestBuilder implements IDeprecatedRequestBuilder {
+  protected builder = (newRequest: IRequestBuilderConfig): this => {
+    return new DeprecatedRequestBuilder(newRequest, this._backend, this._baseUrl) as this;
+  };
+  public config: IRequestBuilderConfig;
+
+  ////////  deprecated apis
+  get baseUrl() {
+    return super.baseUrl;
+  }
+  getList = this.get.bind(this);
+  one = this.path.bind(this);
+  all = this.path.bind(this);
+  remove = this.delete.bind(this).bind(this);
+  data = (data: any) => this.builder({ ...this.config, data });
+  withParams = this.query.bind(this);
+  useCache = (cache: boolean | ICache = true) => this.builder({ ...this.config, cache: cache as boolean });
+}
+
+export const invalidContentMessage = 'API response was neither JSON nor zero-length html or text';
+
+export function makeRequestBuilderConfig(pathPrefix?: string): IRequestBuilderConfig {
+  return {
+    url: joinPaths(pathPrefix),
+    cache: false,
+    data: undefined,
+    params: {},
+    timeout: (SETTINGS.pollSchedule || 3000) * 2 + 5000,
+    headers: { 'X-RateLimit-App': 'deck' },
+  };
+}
+
+/** @deprecated use REST('/path/to/gate/endpoint') */
+export const API: IDeprecatedRequestBuilder = new DeprecatedRequestBuilder(makeRequestBuilderConfig());
+
+/**
+ * A REST client used to access Gate endpoints
+ * @param staticPathPrefix a static string, i.e., '/proxies/foo/endpoint' --
+ *        avoid dynamic strings like `/entity/${id}`, use .path('entity', id) instead
+ */
+export const REST = (staticPathPrefix?: string): IRequestBuilder => {
+  return new RequestBuilder(makeRequestBuilderConfig(staticPathPrefix));
+};

--- a/app/scripts/modules/core/src/api/ApiServiceDeprecated.spec.ts
+++ b/app/scripts/modules/core/src/api/ApiServiceDeprecated.spec.ts
@@ -1,0 +1,454 @@
+import Spy = jasmine.Spy;
+import { mock, noop } from 'angular';
+import { AuthenticationInitializer } from '../authentication/AuthenticationInitializer';
+import { ICache } from '../cache';
+import { API, InvalidAPIResponse, invalidContentMessage } from './ApiService';
+import { SETTINGS } from 'core/config/settings';
+
+describe('API Service', function () {
+  let $httpBackend: ng.IHttpBackendService;
+  let baseUrl: string;
+
+  beforeEach(
+    mock.inject(function (_$httpBackend_: ng.IHttpBackendService) {
+      $httpBackend = _$httpBackend_;
+      baseUrl = API.baseUrl;
+    }),
+  );
+
+  afterEach(function () {
+    SETTINGS.resetToOriginal();
+    $httpBackend.verifyNoOutstandingExpectation();
+    $httpBackend.verifyNoOutstandingRequest();
+  });
+
+  describe('ensure api requests generate normalized urls', function () {
+    let expected: any;
+    beforeEach(() => {
+      expected = {
+        url: '',
+      };
+    });
+
+    it('trims leading slashes from urls', function () {
+      const result = API.one('/foo');
+      expected.url = `foo`;
+      expect(result.config).toEqual(jasmine.objectContaining(expected));
+    });
+
+    it('trims repeated leading slashes from urls', function () {
+      const result = API.one('/////foo');
+      expected.url = `foo`;
+      expect(result.config).toEqual(jasmine.objectContaining(expected));
+    });
+
+    it('trims trailing slashes from baseUrl', function () {
+      SETTINGS.gateUrl = 'http://localhost/';
+      expect(API.baseUrl).toEqual('http://localhost');
+    });
+
+    it('trims repeated trailing slashes from baseUrl', function () {
+      SETTINGS.gateUrl = 'http://localhost/////';
+      expect(API.baseUrl).toEqual('http://localhost');
+    });
+  });
+
+  describe('validate response content-type header', function () {
+    it('responses with non-"application/json" content types should trigger a reauthentication request and reject', function () {
+      spyOn(AuthenticationInitializer, 'reauthenticateUser').and.callFake(noop);
+      $httpBackend
+        .expectGET(`${baseUrl}/bad`)
+        .respond(200, '<html>this is the authentication page</html>', { 'content-type': 'text/html' });
+
+      let rejected = false;
+      API.one('bad')
+        .get()
+        .then(noop, () => (rejected = true));
+
+      $httpBackend.flush();
+      expect((AuthenticationInitializer.reauthenticateUser as Spy).calls.count()).toBe(1);
+      expect(rejected).toBe(true);
+    });
+
+    it('application/foo+json is fine', () => {
+      spyOn(AuthenticationInitializer, 'reauthenticateUser').and.callFake(noop);
+      $httpBackend
+        .expectGET(`${baseUrl}/bad`)
+        .respond(200, '{"good":"job"}', { 'content-type': 'application/foo+json' });
+
+      let rejected = false;
+      API.one('bad')
+        .get()
+        .then(noop, () => (rejected = true));
+
+      $httpBackend.flush();
+      expect((AuthenticationInitializer.reauthenticateUser as Spy).calls.count()).toBe(0);
+      expect(rejected).toBe(false);
+    });
+
+    it('application/x-yaml;charset=utf-8 is fine, too', () => {
+      spyOn(AuthenticationInitializer, 'reauthenticateUser').and.callFake(noop);
+      $httpBackend
+        .expectGET(`${baseUrl}/yaml`)
+        .respond(200, '---\nfoo: bar', { 'content-type': 'application/x-yaml;charset=utf-8' });
+
+      let rejected = false;
+      API.one('yaml')
+        .get()
+        .then(noop, () => (rejected = true));
+
+      $httpBackend.flush();
+      expect((AuthenticationInitializer.reauthenticateUser as Spy).calls.count()).toBe(0);
+      expect(rejected).toBe(false);
+    });
+
+    it('string responses starting with <html should trigger a reauthentication request and reject', function () {
+      spyOn(AuthenticationInitializer, 'reauthenticateUser').and.callFake(noop);
+      $httpBackend.expectGET(`${baseUrl}/fine`).respond(200, 'this is fine');
+
+      let rejected = false;
+      let succeeded = false;
+      API.one('fine')
+        .get()
+        .then(
+          () => (succeeded = true),
+          () => (rejected = true),
+        );
+
+      $httpBackend.flush();
+      expect((AuthenticationInitializer.reauthenticateUser as Spy).calls.count()).toBe(0);
+      expect(rejected).toBe(false);
+      expect(succeeded).toBe(true);
+    });
+
+    it('object and array responses should pass through', function () {
+      spyOn(AuthenticationInitializer, 'reauthenticateUser').and.callFake(noop);
+
+      let rejected = false;
+      let succeeded = false;
+      $httpBackend.expectGET(`${baseUrl}/some-array`).respond(200, []);
+      API.one('some-array')
+        .get()
+        .then(
+          () => (succeeded = true),
+          () => (rejected = true),
+        );
+      $httpBackend.flush();
+
+      expect((AuthenticationInitializer.reauthenticateUser as Spy).calls.count()).toBe(0);
+      expect(rejected).toBe(false);
+      expect(succeeded).toBe(true);
+
+      // verify object responses
+      rejected = false;
+      succeeded = false;
+      $httpBackend.expectGET(`${baseUrl}/some-object`).respond(200, {});
+      API.one('some-object')
+        .get()
+        .then(
+          () => (succeeded = true),
+          () => (rejected = true),
+        );
+      $httpBackend.flush();
+
+      expect((AuthenticationInitializer.reauthenticateUser as Spy).calls.count()).toBe(0);
+      expect(rejected).toBe(false);
+      expect(succeeded).toBe(true);
+    });
+
+    it('rejects the request promise with an error when content mismatch occurs', () => {
+      spyOn(AuthenticationInitializer, 'reauthenticateUser').and.callFake(noop);
+      $httpBackend
+        .expectGET(`${baseUrl}/bad`)
+        .respond(200, '<html>this is the authentication page</html>', { 'content-type': 'text/html' });
+
+      let err: any;
+      API.one('bad')
+        .get()
+        .catch((e: any) => (err = e));
+
+      $httpBackend.flush();
+      expect(err instanceof InvalidAPIResponse).toBeTruthy();
+    });
+
+    it('returns a string error message in the format expected by UI components when content mismatch occurs', () => {
+      spyOn(AuthenticationInitializer, 'reauthenticateUser').and.callFake(noop);
+      $httpBackend
+        .expectGET(`${baseUrl}/bad`)
+        .respond(200, '<html>this is the authentication page</html>', { 'content-type': 'text/html' });
+
+      let message = '';
+      API.one('bad')
+        .get()
+        .catch((err: any) => (message = err.data.message));
+
+      $httpBackend.flush();
+      expect(message).toBe(invalidContentMessage);
+    });
+
+    it('returns a copy of the original response when content mismatch occurs', () => {
+      spyOn(AuthenticationInitializer, 'reauthenticateUser').and.callFake(noop);
+      const serverResult = { foo: 'bar' };
+      $httpBackend.expectGET(`${baseUrl}/bad`).respond(200, serverResult, { 'content-type': 'foobar/json' });
+
+      let receivedResult = null;
+      API.one('bad')
+        .get()
+        .catch((err: any) => (receivedResult = err.originalResult.data));
+
+      $httpBackend.flush();
+      expect(receivedResult).toEqual(serverResult);
+    });
+  });
+
+  describe('creating the config and testing the chaining functions without parameters', () => {
+    let expected: any;
+    beforeEach(() => {
+      expected = {
+        url: '',
+      };
+    });
+
+    describe('creating the config with "one" function', function () {
+      // it('missing url should create a default config with the base url', function () {
+      //   const result = API.one();
+      //   expected.url = baseUrl;
+      //   expect(result.config).toEqual(jasmine.objectContaining(expected));
+      // });
+
+      it('single url should create a default config with the base url', function () {
+        const result = API.one('foo');
+        expected.url = `foo`;
+        expect(result.config).toEqual(jasmine.objectContaining(expected));
+      });
+
+      it('multiple calls to "one" should create a default config with the base url and build out the url', function () {
+        const result = API.one('foo').one('bar');
+        expected.url = `foo/bar`;
+        expect(result.config).toEqual(jasmine.objectContaining(expected));
+      });
+
+      it('should allow for multiple urls to be added to the url', function () {
+        const result = API.one('foo', 'bar');
+        expected.url = `foo/bar`;
+        expect(result.config).toEqual(jasmine.objectContaining(expected));
+      });
+    });
+
+    describe('creating the  config with "all" function', function () {
+      // it('missing url should create a default config with the base url', function () {
+      //   const result = API.all();
+      //   expected.url = '';
+      //   expect(result.config).toEqual(jasmine.objectContaining(expected));
+      // });
+
+      it('single url should create a default config with the base url', function () {
+        const result = API.all('foo');
+        expected.url = `foo`;
+        expect(result.config).toEqual(jasmine.objectContaining(expected));
+      });
+
+      it('multiple calls to "all" should create a default config with the base url and build out the url', function () {
+        const result = API.all('foo').all('bar');
+        expected.url = `foo/bar`;
+        expect(result.config).toEqual(jasmine.objectContaining(expected));
+      });
+
+      it('should allow for multiple urls to be added to the url', function () {
+        const result = API.all('foo', 'bar');
+        expected.url = `foo/bar`;
+        expect(result.config).toEqual(jasmine.objectContaining(expected));
+      });
+    });
+
+    describe('creating the  config with mix of "one" and "all" function', function () {
+      it('single url should create a default config with the base url', function () {
+        const result = API.all('foo').one('bar');
+        expected.url = `foo/bar`;
+        expect(result.config).toEqual(jasmine.objectContaining(expected));
+      });
+
+      it('multiple calls to "all" should create a default config with the base url and build out the url', function () {
+        const result = API.one('foo').all('bar');
+        expected.url = `foo/bar`;
+        expect(result.config).toEqual(jasmine.objectContaining(expected));
+      });
+
+      it('should allow for multiple urls to be added to the url', function () {
+        const result = API.all('foo', 'bar').one('baz');
+        expected.url = `foo/bar/baz`;
+        expect(result.config).toEqual(jasmine.objectContaining(expected));
+      });
+    });
+
+    describe('creating multiple endpoints', function () {
+      it('should not stomp on each other', function () {
+        const first = API.one('bar');
+        const second = API.one('foo');
+
+        expect(first.config).toEqual(jasmine.objectContaining({ url: `bar` }));
+        expect(second.config).toEqual(jasmine.objectContaining({ url: `foo` }));
+      });
+    });
+
+    describe('create config with data', function () {
+      it('should add data to the config if data object passed', function () {
+        const data = { bar: 'baz' };
+        const result = API.one('foo').data(data);
+        expected.url = `foo`;
+        expected.data = data;
+        expect(result.config).toEqual(jasmine.objectContaining(expected));
+      });
+    });
+  });
+
+  describe('create a config with params', function () {
+    it('when params are provided', function () {
+      const result = API.one('foo').withParams({ one: 1 });
+      expect(result.config).toEqual(jasmine.objectContaining({ url: `foo`, params: { one: 1 } }));
+    });
+  });
+
+  describe('useCache()', function () {
+    it('should set cache to "true" if no params set', function () {
+      const result = API.one('foo').useCache();
+      expect(result.config.cache).toBe(true);
+    });
+
+    it('should set cache to "false" if explicitly  set', function () {
+      const result = API.one('foo').useCache(false);
+      expect(result.config.cache).toBe(false);
+    });
+
+    it('should set cache to cache object if explicitly set', function () {
+      const cacheObj = ({ count: 1 } as unknown) as ICache;
+      const result = API.one('foo').useCache(cacheObj);
+      expect(result.config.cache).toBe(cacheObj as any);
+    });
+  });
+
+  describe('get(): create a url with a "GET" method', function () {
+    it('should create the url and issue a get request with the "one" function', function () {
+      $httpBackend.expectGET(`${baseUrl}/foo`).respond(200);
+
+      API.one('foo').get();
+
+      $httpBackend.flush();
+    });
+
+    it('should create the url and issue a get request with the "all" function', function () {
+      $httpBackend.expectGET(`${baseUrl}/foo/bar`).respond(200);
+
+      API.all('foo', 'bar').get();
+
+      $httpBackend.flush();
+    });
+
+    it('should take a param object with one param', function () {
+      $httpBackend.expectGET(`${baseUrl}/foo/bar?param1=2`).respond(200);
+
+      API.one('foo', 'bar').get({ param1: 2 });
+
+      $httpBackend.flush();
+    });
+
+    it('should take a param object with multiple params', function () {
+      $httpBackend.expectGET(`${baseUrl}/foo/bar?param1=2&param2=foo`).respond(200);
+
+      API.one('foo', 'bar').get({ param1: 2, param2: 'foo' });
+
+      $httpBackend.flush();
+    });
+  });
+
+  describe('getList(): create a url with a "GET" method', function () {
+    it('should create the url and issue a get request with the "one" function', function () {
+      $httpBackend.expectGET(`${baseUrl}/foo`).respond(200);
+
+      API.one('foo').getList();
+
+      $httpBackend.flush();
+    });
+
+    it('should create the url and issue a get request with the "all" function', function () {
+      $httpBackend.expectGET(`${baseUrl}/foo/bar`).respond(200);
+
+      API.all('foo', 'bar').getList();
+
+      $httpBackend.flush();
+    });
+
+    it('should take a param object with one param', function () {
+      $httpBackend.expectGET(`${baseUrl}/foo/bar?param1=2`).respond(200);
+
+      API.one('foo', 'bar').getList({ param1: 2 });
+
+      $httpBackend.flush();
+    });
+
+    it('should take a param object with multiple params', function () {
+      $httpBackend.expectGET(`${baseUrl}/foo/bar?param1=2&param2=foo`).respond(200);
+
+      API.one('foo', 'bar').getList({ param1: 2, param2: 'foo' });
+
+      $httpBackend.flush();
+    });
+  });
+
+  describe('post(): create a url with a "POST" method', function () {
+    it('should create the url and make a POST call', function () {
+      $httpBackend.expectPOST(`${baseUrl}/foo`).respond(200);
+
+      API.one('foo').post();
+
+      $httpBackend.flush();
+    });
+
+    it('should create the url and POST with data', function () {
+      const data = { bar: 7 };
+      $httpBackend.expectPOST(`${baseUrl}/foo`, data).respond(200);
+
+      API.one('foo').post(data);
+
+      $httpBackend.flush();
+    });
+  });
+
+  describe('put(): create a url with a "PUT" method', function () {
+    it('should create the url and make a POST call', function () {
+      $httpBackend.expectPUT(`${baseUrl}/foo`).respond(200);
+
+      API.one('foo').put();
+
+      $httpBackend.flush();
+    });
+
+    it('should create the url and PUT with data', function () {
+      const data = { bar: 7 };
+      $httpBackend.expectPUT(`${baseUrl}/foo`, data).respond(200);
+
+      API.one('foo').put(data);
+
+      $httpBackend.flush();
+    });
+  });
+
+  describe('remove(): create a url with a "DELETE" method', function () {
+    it('should create the url and make a DELETE call', function () {
+      $httpBackend.expectDELETE(`${baseUrl}/foo`).respond(200);
+
+      API.one('foo').remove();
+
+      $httpBackend.flush();
+    });
+
+    it('should create the url with params and  make a DELETE call', function () {
+      const params = { bar: 7 };
+      $httpBackend.expectDELETE(`${baseUrl}/foo?bar=7`).respond(200);
+
+      API.one('foo').remove(params);
+
+      $httpBackend.flush();
+    });
+  });
+});

--- a/app/scripts/modules/core/src/cluster/cluster.service.ts
+++ b/app/scripts/modules/core/src/cluster/cluster.service.ts
@@ -35,11 +35,11 @@ export class ClusterService {
   public loadServerGroups(application: Application): PromiseLike<IServerGroup[]> {
     return this.getClusters(application.name).then((clusters: IClusterSummary[]) => {
       const dataSource = application.getDataSource('serverGroups');
-      const serverGroupLoader = API.one('applications').one(application.name).all('serverGroups');
+      let serverGroupLoader = API.one('applications').one(application.name).all('serverGroups');
       dataSource.fetchOnDemand = clusters.length > SETTINGS.onDemandClusterThreshold;
       if (dataSource.fetchOnDemand) {
         dataSource.clusters = clusters;
-        serverGroupLoader.withParams({
+        serverGroupLoader = serverGroupLoader.withParams({
           clusters: FilterModelService.getCheckValues(
             ClusterState.filterModel.asFilterModel.sortFilter.clusters,
           ).join(),

--- a/app/scripts/modules/core/src/plugins/plugin.registry.spec.ts
+++ b/app/scripts/modules/core/src/plugins/plugin.registry.spec.ts
@@ -1,6 +1,6 @@
 import { IStageTypeConfig } from 'core/domain';
 import { IDeckPlugin } from './deck.plugin';
-import { API } from '../api';
+import { RequestBuilder } from '../api';
 import { IPluginMetaData, PluginRegistry } from './plugin.registry';
 import { Registry } from 'core/registry';
 import { mock } from 'angular';
@@ -42,8 +42,7 @@ describe('PluginRegistry', () => {
   );
 
   it('loadPluginManifestFromGate() should fetch from gate /plugins/deck/plugin-manifest.json', async () => {
-    const spy = jasmine.createSpy('get', () => Promise.resolve([])).and.callThrough();
-    spyOn(API as any, 'getFn').and.callFake(() => spy);
+    const spy = spyOn(RequestBuilder.defaultBackend, 'get').and.callFake(() => Promise.resolve([]));
     await pluginRegistry.loadPluginManifestFromGate();
     expect(spy).toHaveBeenCalled();
   });

--- a/app/scripts/modules/core/src/plugins/plugin.registry.spec.ts
+++ b/app/scripts/modules/core/src/plugins/plugin.registry.spec.ts
@@ -42,7 +42,7 @@ describe('PluginRegistry', () => {
   );
 
   it('loadPluginManifestFromGate() should fetch from gate /plugins/deck/plugin-manifest.json', async () => {
-    const spy = spyOn(RequestBuilder.defaultBackend, 'get').and.callFake(() => Promise.resolve([]));
+    const spy = spyOn(RequestBuilder.defaultHttpClient, 'get').and.callFake(() => Promise.resolve([]));
     await pluginRegistry.loadPluginManifestFromGate();
     expect(spy).toHaveBeenCalled();
   });

--- a/app/scripts/modules/core/src/plugins/plugin.registry.ts
+++ b/app/scripts/modules/core/src/plugins/plugin.registry.ts
@@ -1,5 +1,6 @@
 import { $http } from 'ngimport';
-import { API } from 'core/api';
+import { SETTINGS } from '../config/settings';
+import { API } from '../api/ApiService';
 import { registerPluginExtensions, IDeckPlugin } from './deck.plugin';
 
 /** The shape of plugin metadata objects in plugin-manifest.json */
@@ -142,7 +143,7 @@ export class PluginRegistry {
 
     // Use `url` from the manifest, if it exists. This will be the case during local development.
     const { devUrl, url } = pluginMetaData;
-    const gateUrl = `${API.baseUrl}/plugins/deck/${pluginMetaData.id}/${pluginMetaData.version}/index.js`;
+    const gateUrl = `${SETTINGS.gateUrl}/plugins/deck/${pluginMetaData.id}/${pluginMetaData.version}/index.js`;
     const pluginUrl = url ?? devUrl ?? gateUrl;
 
     try {

--- a/app/scripts/modules/core/src/presentation/spel/SpelService.spec.ts
+++ b/app/scripts/modules/core/src/presentation/spel/SpelService.spec.ts
@@ -3,7 +3,7 @@ import { SpelService } from './SpelService';
 
 describe('SpelService', () => {
   it('extracts "result" from the payload', async (done) => {
-    const spy = spyOn(RequestBuilder.defaultBackend, 'get').and.callFake(() => Promise.resolve({ result: 'data' }));
+    const spy = spyOn(RequestBuilder.defaultHttpClient, 'get').and.callFake(() => Promise.resolve({ result: 'data' }));
     const result = await SpelService.evaluateExpression('expression', null, null);
     expect(spy).toHaveBeenCalledTimes(1);
     expect(result).toBe('data');
@@ -30,7 +30,7 @@ describe('SpelService', () => {
     const errorDetail = serverExpressionEvaluationFailure.detail['bad expression'][0];
 
     // If expressions fail to evaluate, the server still returns 200 OK
-    const spy = spyOn(RequestBuilder.defaultBackend, 'get').and.callFake(() => {
+    const spy = spyOn(RequestBuilder.defaultHttpClient, 'get').and.callFake(() => {
       return Promise.resolve(serverExpressionEvaluationFailure);
     });
 

--- a/app/scripts/modules/core/src/presentation/spel/SpelService.spec.ts
+++ b/app/scripts/modules/core/src/presentation/spel/SpelService.spec.ts
@@ -1,11 +1,9 @@
-import { API } from 'core/api';
+import { RequestBuilder } from 'core/api';
 import { SpelService } from './SpelService';
 
 describe('SpelService', () => {
   it('extracts "result" from the payload', async (done) => {
-    const spy = jasmine.createSpy('get', () => new Promise((resolve) => resolve({ result: 'data' }))).and.callThrough();
-    spyOn(API as any, 'getFn').and.callFake(() => spy);
-
+    const spy = spyOn(RequestBuilder.defaultBackend, 'get').and.callFake(() => Promise.resolve({ result: 'data' }));
     const result = await SpelService.evaluateExpression('expression', null, null);
     expect(spy).toHaveBeenCalledTimes(1);
     expect(result).toBe('data');
@@ -32,11 +30,9 @@ describe('SpelService', () => {
     const errorDetail = serverExpressionEvaluationFailure.detail['bad expression'][0];
 
     // If expressions fail to evaluate, the server still returns 200 OK
-    const spy = jasmine
-      .createSpy('get', () => new Promise((resolve) => resolve(serverExpressionEvaluationFailure)))
-      .and.callThrough();
-
-    spyOn(API as any, 'getFn').and.callFake(() => spy);
+    const spy = spyOn(RequestBuilder.defaultBackend, 'get').and.callFake(() => {
+      return Promise.resolve(serverExpressionEvaluationFailure);
+    });
 
     let rejection = null;
     try {

--- a/app/scripts/modules/core/src/search/search.service.ts
+++ b/app/scripts/modules/core/src/search/search.service.ts
@@ -49,10 +49,10 @@ export class SearchService {
 
     const params = { ...searchParams, ...defaultParams };
 
-    const requestBuilder = API.one('search').withParams(params);
+    let requestBuilder = API.one('search').withParams(params);
 
     if (cache) {
-      requestBuilder.useCache(cache);
+      requestBuilder = requestBuilder.useCache(cache);
     }
 
     return requestBuilder

--- a/app/scripts/modules/core/src/task/task.read.service.ts
+++ b/app/scripts/modules/core/src/task/task.read.service.ts
@@ -35,7 +35,7 @@ export class TaskReader {
         }
         return task;
       })
-      .catch((error: any) => {
+      .catch((error: any): undefined => {
         $log.warn('There was an issue retrieving taskId: ', taskId, error);
         return undefined;
       });

--- a/app/scripts/modules/core/src/utils/consoleDebug.ts
+++ b/app/scripts/modules/core/src/utils/consoleDebug.ts
@@ -2,7 +2,7 @@ import { module } from 'angular';
 import IInjectorService = angular.auto.IInjectorService;
 
 import { Application } from 'core/application';
-import { API } from '../api';
+import { REST } from '../api';
 
 declare global {
   // tslint:disable-next-line
@@ -16,7 +16,7 @@ const injectables: string[] = [];
 export class ConsoleDebugWindow {
   public application: Application;
   public $injector: IInjectorService;
-  public api = API;
+  public api = REST;
   public plugins = {
     sharedLibraries: {} as { [libraryName: string]: any },
   };


### PR DESCRIPTION
I've been doing some thinking about our `API` rest builders and how it could be improved.

Things I don't like:

1) `.one()` vs `.all()`
  What do these mean?  They are borrowed from the Restangular API but don't actually do anything different.
2) `.get()` vs `.getList()`
  Again, borrowed from Restangular, but they do the same thing.
3) `.data(obj).post()` vs `.post(obj)` ...  `.data(obj).put()` vs `.put(obj)`
  Whats the difference?
4) `.withParams({ param: value }).get()` vs `.get({ param: value })`
  Whats the difference?
5) encodeUriComponent in .one() and .all()
  this PR https://github.com/spinnaker/deck/pull/8646 aims to encode path parameters, such as 'appname'  in `.one('applications', appname)`.  However, this makes it less convenient to append a string like `/proxies/pandora/api/v1`.

With all this in mind, this PR refactors the API to a smaller surface area:

```ts
/**
 * A Builder API for making requests to Gate backend service
 */
export interface IRequestBuilder {
  /**
   * Appends one or more path segments to the URL, separated by slashes.
   * Each path segment is uri encoded.
   */
  path(...pathSegments: IPrimitive[]): this;

  /** Adds query parameters to the URL */
  query(queryParams: IParams): this;

  /** Enables or disables caching of the response */
  useCache(useCache?: boolean): this;

  /** issues a GET request */
  get<T = any>(): PromiseLike<T>;
  /** issues a POST request */
  post<T = any, P = any>(data?: P): PromiseLike<T>;
  /** issues a PUT request */
  put<T = any, P = any>(data?: P): PromiseLike<T>;
  /** issues a DELETE request */
  delete<T = any>(): PromiseLike<T>;
}
```

example:

```
REST('/path/to/resourcetype').path(id).query({ expand: true }).get();
```


---

### Backwards compat:

This refactor introduces a builder factory exported as `REST`.  The previous `API` builder factory still exists and can be used with only minor changes -- this refactor is mostly backwards compatible with the `API` implementation.  One exception is that the old builder impl mutated the http config object, so code like this will no longer work with:

```

let getUsers = API.one('users').one(user);

// OLD WAY
if (expand) {
  // Return value is not used, but getUsers is mutated
  getUsers.withParams({ expand: true });  
}

return getUsers.get();
```

This code should be migrated to:


```
let getUsers = API.one('users').one(user);

// NEW WAY
if (expand) {
  getUsers = getUsers.withParams({ expand: true });  // re-assign the return value
}

return getUsers.get();
```

A linter rule (in a separate PR) should help find and migrate code like this.

---

### HttpClient Implementations

This refactor introduces a simple interface to provide different HTTP clients:

```ts
/**
 * An interface to support pluggable http clients
 * In the future, we should have a TestingHttpBackend and a FetchHttpBackend (or whatever http client we go with)
 */
export interface IHttpClientImplementation {
  get<T = any>(config: IRequestBuilderConfig): PromiseLike<T>;
  post<T = any>(config: IRequestBuilderConfig): PromiseLike<T>;
  put<T = any>(config: IRequestBuilderConfig): PromiseLike<T>;
  delete<T = any>(config: IRequestBuilderConfig): PromiseLike<T>;
}
```

Currently, the AngularJS `$http` client is the only implementation, but we should be able to write a `fetch()` based backend (or whatever) as we migrate away from AngularJS.  We should also be able to leverage this "backend" mechanism to implement a test friendly mock http client backend to replace the AngularJS `$httpBackend` `expectGET()` and similar.