### PR TITLE
Introduce new linter rules deprecating API.one()

### DIFF
--- a/packages/eslint-plugin/base.config.js
+++ b/packages/eslint-plugin/base.config.js
@@ -18,6 +18,7 @@ module.exports = {
     '@spinnaker/ng-strictdi': 2,
     '@spinnaker/prefer-promise-like': 1,
     '@spinnaker/react2angular-with-error-boundary.spec.js': 2,
+    '@spinnaker/rest-prefer-static-strings-in-initializer': 2,
     indent: 'off',
     'member-ordering': 'off',
     'no-console': ['error', { allow: ['warn', 'error'] }],

--- a/packages/eslint-plugin/base.config.js
+++ b/packages/eslint-plugin/base.config.js
@@ -5,6 +5,7 @@ module.exports = {
   extends: ['eslint:recommended', 'prettier', 'prettier/@typescript-eslint', 'plugin:@typescript-eslint/recommended'],
   rules: {
     '@spinnaker/api-no-slashes': 2,
+    '@spinnaker/api-no-unused-chaining': 2,
     '@spinnaker/import-from-alias-not-npm': 2,
     '@spinnaker/import-from-npm-not-alias': 2,
     '@spinnaker/import-from-npm-not-relative': 2,

--- a/packages/eslint-plugin/base.config.js
+++ b/packages/eslint-plugin/base.config.js
@@ -4,6 +4,7 @@ module.exports = {
   plugins: ['@typescript-eslint', '@spinnaker/eslint-plugin', 'react-hooks'],
   extends: ['eslint:recommended', 'prettier', 'prettier/@typescript-eslint', 'plugin:@typescript-eslint/recommended'],
   rules: {
+    '@spinnaker/api-deprecation': 2,
     '@spinnaker/api-no-slashes': 2,
     '@spinnaker/api-no-unused-chaining': 2,
     '@spinnaker/import-from-alias-not-npm': 2,

--- a/packages/eslint-plugin/eslint-plugin.js
+++ b/packages/eslint-plugin/eslint-plugin.js
@@ -1,6 +1,7 @@
 module.exports = {
   rules: {
     'api-no-slashes': require('./rules/api-no-slashes'),
+    'api-no-unused-chaining': require('./rules/api-no-unused-chaining'),
     'import-from-alias-not-npm': require('./rules/import-from-alias-not-npm'),
     'import-from-npm-not-alias': require('./rules/import-from-npm-not-alias'),
     'import-from-npm-not-relative': require('./rules/import-from-npm-not-relative'),

--- a/packages/eslint-plugin/eslint-plugin.js
+++ b/packages/eslint-plugin/eslint-plugin.js
@@ -1,5 +1,6 @@
 module.exports = {
   rules: {
+    'api-deprecation': require('./rules/api-deprecation'),
     'api-no-slashes': require('./rules/api-no-slashes'),
     'api-no-unused-chaining': require('./rules/api-no-unused-chaining'),
     'import-from-alias-not-npm': require('./rules/import-from-alias-not-npm'),

--- a/packages/eslint-plugin/eslint-plugin.js
+++ b/packages/eslint-plugin/eslint-plugin.js
@@ -14,6 +14,7 @@ module.exports = {
     'ng-strictdi': require('./rules/ng-strictdi'),
     'prefer-promise-like': require('./rules/prefer-promise-like'),
     'react2angular-with-error-boundary.spec.js': require('./rules/react2angular-with-error-boundary'),
+    'rest-prefer-static-strings-in-initializer': require('./rules/rest-prefer-static-strings-in-initializer'),
   },
   configs: {
     base: require('./base.config.js'),

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -11,6 +11,9 @@
     "lodash": "^4.17.20"
   },
   "devDependencies": {
+    "@types/eslint": "^7.2.5",
+    "@types/estree": "^0.0.45",
+    "@types/lodash": "^4.14.165",
     "jest": "^26.6.3"
   },
   "peerDependencies": {

--- a/packages/eslint-plugin/rules/api-deprecation.js
+++ b/packages/eslint-plugin/rules/api-deprecation.js
@@ -1,0 +1,282 @@
+'use strict';
+
+/**
+ * @typedef {import('estree').CallExpression} CallExpression
+ * @typedef {import('estree').ImportSpecifier} ImportSpecifier
+ */
+const _ = require('lodash/fp');
+const {
+  getProgram,
+  getCallChain,
+  getCallingIdentifier,
+  getVariableInScope,
+  getVariableInitializer,
+} = require('../utils/utils');
+
+/**
+ * @param context {RuleContext}
+ * @param node {CallExpression}
+ */
+function isAPICall(context, node) {
+  // Find the call chain Identifier:
+  // API.one().all().get()
+  // ^^^
+  const callingIdentifier = getCallingIdentifier(node);
+  if (callingIdentifier && callingIdentifier.name === 'API') {
+    return true;
+  }
+
+  // If the calling identifier is a variable reference ...
+  // var foo = API.one(); foo.one().all().get();
+  //                      ^^^
+  // then find the variable initializer: var foo = API.one();
+  //                                               ^^^^^^^^^
+  const variable = getVariableInScope(context, callingIdentifier);
+  const initializer = getVariableInitializer(variable);
+  const initializerIdentifier = getCallingIdentifier(initializer);
+
+  return initializerIdentifier && initializerIdentifier.name === 'API';
+}
+
+const getCallName = _.get('callee.property.name');
+
+/** @param callNames {string} */
+function isCallNamed(...callNames) {
+  /** @param callExpression {CallExpression[]} */
+  return function (callExpression) {
+    const callName = getCallName(callExpression);
+    return callNames.includes(callName);
+  };
+}
+
+/**
+ * Returns a list of deprecated methods that need to be renamed and fixers to do so.
+ * @param callChain {CallExpression[]}
+ */
+function findMethodsToRename(callChain) {
+  const renames = {
+    getList: 'get',
+    withParams: 'query',
+    one: 'path',
+    all: 'path',
+    remove: 'delete',
+  };
+
+  const calls = callChain.map((call) => {
+    const from = getCallName(call);
+    const to = renames[from];
+    /** @param fixer {RuleFixer} */
+    const fix = (fixer) => fixer.replaceText(call.callee.property, to);
+    return { call, fix, from, to };
+  });
+
+  // Only return calls that have a 'to' mapping in the renames object
+  return calls.filter((tuple) => !!tuple.to);
+}
+
+/**
+ * @param context {RuleContext}
+ * @param node {CallExpression}
+ */
+function reportSimpleRenames(context, node, renames) {
+  // Strings for the message
+  const froms = [...new Set(renames.map((tuple) => tuple.from))].join('/');
+  const tos = [...new Set(renames.map((tuple) => tuple.to))].join('/');
+
+  return context.report({
+    node,
+    message: `API.${froms}() is deprecated.  Migrate from ${froms}() to ${tos}()`,
+    fix: (fixer) => renames.map((tuple) => tuple.fix(fixer)),
+  });
+}
+
+/**
+ * @param context {RuleContext}
+ * @param node {CallExpression}
+ * @param callChain {CallExpression[]}
+ */
+function reportDataMethod(context, node, callChain) {
+  // Just the .data() calls
+  const dataCalls = callChain.filter(isCallNamed('data'));
+
+  // Find the corresponding put/post
+  const putOrPost = callChain.find((n) => ['put', 'post'].includes(n.callee.property.name));
+  const message = `API.data() is deprecated.  Migrate from .data({}) to .put({}) or .post({})`;
+
+  // If there is a single .data() and a .put() or .post() in the chain...
+  if (dataCalls.length !== 1 || !putOrPost) {
+    // Can't find a single .data({}) and .post()/.put() to auto-fix, so just report the problem to the user
+    return context.report({ node, message });
+  }
+
+  const call = dataCalls[0];
+  // get the text of the arguments passed to .data(ARGS)
+  const argsText = call.arguments.map((arg) => context.getSourceCode().getText(arg)).join(', ');
+  // find the spot between the parentheses in -> post()
+  const putOrPostRangeEnd = putOrPost.callee.property.range[1] + 1;
+  // Just after ".one()" in `.one().data(value)`
+  const previousCalleeRangeEnd = call.callee.object.range[1];
+  // The end of `.data(value)`
+  const dataRangeEnd = call.range[1];
+  return context.report({
+    node,
+    message,
+    fix: (fixer) => [
+      // Move "value" text from .data(value) into the put/post args, i.e.: .put(value)
+      fixer.replaceTextRange([putOrPostRangeEnd, putOrPostRangeEnd], argsText),
+      // Remove .data(value) entirely
+      fixer.replaceTextRange([previousCalleeRangeEnd, dataRangeEnd], ''),
+    ],
+  });
+}
+/**
+ * @param context {RuleContext}
+ * @param node {CallExpression}
+ * @param getsAndDeletes {CallExpression[]}
+ */
+function reportGetsAndDeletesWithArgs(context, node, getsAndDeletes) {
+  const callNames = [...new Set(getsAndDeletes.map(getCallName))].join('/');
+  const message = `Passing parameters to API.${callNames}() is deprecated.  Migrate from .${callNames}(queryparams) to .query(queryparams).${callNames}()`;
+
+  // Should be only one get/delete, but just in case, report without fixing:
+  if (getsAndDeletes.length > 1) {
+    return context.report({ node, message });
+  }
+
+  /** @type {CallExpression} */
+  const call = getsAndDeletes[0];
+  const type = getCallName(call);
+  const argsText = call.arguments.map((arg) => context.getSourceCode().getText(arg)).join(', ');
+  const getCallStart = call.callee.property.range[0];
+  const getCallEnd = call.range[1];
+  const fix = (fixer) => fixer.replaceTextRange([getCallStart, getCallEnd], `query(${argsText}).${type}()`);
+
+  return context.report({ node, message, fix });
+}
+
+function reportChainedPathAsVarargs(callChain, context, node) {
+  const message = `Prefer API.path('foo', 'bar') over API.path('foo').path('bar')`;
+
+  /** @param fixer {RuleFixer} */
+  const fix = (fixer) => {
+    const [firstPathCall, secondPathCall] = callChain;
+
+    const firstPathLastArg = firstPathCall['arguments'].slice().pop();
+    const secondPathStart = firstPathCall.range[1];
+    const secondPathEnd = secondPathCall.range[1];
+    const secondPathArgsText = secondPathCall['arguments']
+      .map((arg) => context.getSourceCode().getText(arg))
+      .join(', ');
+
+    return [
+      // Move the second .path(...) call's args to first .path() args list
+      fixer.insertTextAfter(firstPathLastArg, `, ${secondPathArgsText}`),
+      // Remove second .path()
+      fixer.removeRange([secondPathStart, secondPathEnd]),
+    ];
+  };
+
+  return context.report({ message, node, fix });
+}
+
+/**
+ * @param context {RuleContext}
+ * @param node {CallExpression}
+ * @param callChain {CallExpression[]}
+ */
+function reportAPIDeprecatedUseREST(node, context, callChain) {
+  // Everything else is migrated, now migrate from API.path() to REST().path()
+  const message = 'API is deprecated, switch to REST()';
+  const API = callChain[0].callee.object;
+  const program = getProgram(node);
+  const allImports = program.body.filter((item) => item.type === 'ImportDeclaration');
+  /** @type {Array<ImportSpecifier>} */
+  const importSpecifiers = allImports.map((decl) => decl.specifiers).reduce((acc, x) => acc.concat(x), []);
+
+  const apiImport = importSpecifiers.find((specifier) => {
+    return specifier.imported && specifier.imported.name === 'API';
+  });
+
+  return context.report({
+    message,
+    node,
+    fix: (fixer) => {
+      if (!apiImport) {
+        // Replace API with REST()
+        return fixer.replaceText(API, 'REST()');
+      }
+
+      return [
+        // Replace API with REST()
+        fixer.replaceText(API, 'REST()'),
+        fixer.replaceText(apiImport, 'REST'),
+      ];
+    },
+  });
+}
+
+/**
+ * @param context {RuleContext}
+ * @param node {CallExpression}
+ */
+
+/** @type {RuleModule} */
+module.exports = {
+  create(context) {
+    return {
+      /**
+       * Look for chains of CallExpressions that are:
+       * - part of an API.xyz() call, e.g.: return API.xyz().get()
+       * - part of an xyz() call chained off a variable, e.g.: var foo = API.xyz(); foo.get()
+       * @param node {CallExpression}
+       */
+      CallExpression(node) {
+        if (node.parent.type === 'MemberExpression' || !isAPICall(context, node)) {
+          return undefined;
+        }
+
+        // an array of CallExpressions, i.e. for API.one().all().get() -> [.one, .all, .get]
+        const callChain = getCallChain(node);
+
+        // Migrate the simple method renames, i.e.: API.one() -> API.path()
+        const renames = findMethodsToRename(callChain);
+        if (renames.length) {
+          return reportSimpleRenames(context, node, renames);
+        }
+
+        // Migrate .data(postdata).post() -> .post(postdata)
+        // Migrate .data(putdata).put() -> .put(putdata)
+        if (callChain.some(isCallNamed('data'))) {
+          return reportDataMethod(context, node, callChain);
+        }
+
+        // Migrate .get(params) -> .query(params).get()
+        // Migrate .delete(params) -> .query(params).delete()
+        const getsAndDeletes = callChain.filter(isCallNamed('get', 'delete'));
+        if (getsAndDeletes.some((x) => x.arguments.length > 0)) {
+          return reportGetsAndDeletesWithArgs(context, node, getsAndDeletes);
+        }
+
+        // Migrate .path('foo').path('bar') -> .path('foo', 'bar')
+        const hasTwoChainedPathCalls = getCallName(callChain[0]) === 'path' && getCallName(callChain[1]) === 'path';
+        if (hasTwoChainedPathCalls) {
+          return reportChainedPathAsVarargs(callChain, context, node);
+        }
+
+        // Migrate from API.xyz() to REST().xyz()
+        const callingIdentifier = getCallingIdentifier(node);
+        if (callingIdentifier && callingIdentifier.name === 'API') {
+          return reportAPIDeprecatedUseREST(node, context, callChain);
+        }
+      },
+    };
+  },
+  meta: {
+    fixable: 'code',
+    type: 'problem',
+    docs: {
+      description: 'Migrate from API.xyz() to REST(path)',
+      recommended: 'error',
+    },
+  },
+};

--- a/packages/eslint-plugin/rules/api-no-unused-chaining.js
+++ b/packages/eslint-plugin/rules/api-no-unused-chaining.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const _ = require('lodash/fp');
+
+const isApiConfigCall = _.overSome([
+  { property: { type: 'Identifier', name: 'one' } },
+  { property: { type: 'Identifier', name: 'all' } },
+  { property: { type: 'Identifier', name: 'useCache' } },
+  { property: { type: 'Identifier', name: 'withParams' } },
+  { property: { type: 'Identifier', name: 'data' } },
+]);
+
+const falsePostitives = _.overSome([
+  { property: { type: 'Identifier', name: 'data' }, object: { type: 'Identifier', name: '$element' } },
+]);
+
+const create = function (context) {
+  return {
+    ExpressionStatement(node) {
+      if (
+        node.expression.type === 'CallExpression' &&
+        isApiConfigCall(node.expression.callee) &&
+        !falsePostitives(node.expression.callee)
+      ) {
+        const text = context.getSourceCode().getText(node);
+        context.report({
+          node,
+          message: `Unused API.xyz() method chaining no longer works. Re-assign the result of: ${text}`,
+        });
+      }
+    },
+  };
+};
+
+module.exports = {
+  create,
+  meta: {
+    docs: {
+      description: 'Check for unused API.xyx() calls',
+      recommended: 'error',
+    },
+  },
+};

--- a/packages/eslint-plugin/rules/rest-prefer-static-strings-in-initializer.js
+++ b/packages/eslint-plugin/rules/rest-prefer-static-strings-in-initializer.js
@@ -1,0 +1,98 @@
+'use strict';
+// @ts-check
+
+/**
+ * Migrate REST().path('foo', 'bar').path('baz').get() to REST('/foo/bar/baz').get()
+ *
+ * @typedef {import('estree').Arg} CallExpression
+ * @typedef {import('estree').Literal} Literal
+ * @typedef {import('estree').ImportSpecifier} ImportSpecifier
+ */
+
+const _ = require('lodash/fp');
+
+const { getNodeType, getCallChain, getCallingIdentifierName } = require('../utils/utils');
+const getCallName = _.get('callee.property.name');
+
+/** @type {RuleModule} */
+module.exports = {
+  create(context) {
+    return {
+      /**
+       * Look for chains of CallExpressions that are part of a REST().path() call
+       * @param node {CallExpression}
+       */
+      CallExpression(node) {
+        const callingIdentifierName = getCallingIdentifierName(node);
+        if (node.parent.type === 'MemberExpression' || callingIdentifierName !== 'REST') {
+          return undefined;
+        }
+
+        // an array of CallExpressions, i.e. for API.one().all().get() -> [.one, .all, .get]
+        const callChain = getCallChain(node);
+
+        // Look for a REST().path().whatever() call
+        if (!callChain[1] || getCallName(callChain[1]) !== 'path') {
+          return;
+        }
+
+        /** @type {CallExpression} */
+        const restCall = callChain[0];
+        /** @type {CallExpression} */
+        const pathCall = callChain[1];
+        /** @type {Literal} */
+        const restArg = restCall.arguments[0];
+        /** @type {Literal} */
+        const firstPathArg = pathCall.arguments[0];
+
+        // Only REST('literal').path('literal', ...)
+        // Ignores: REST(variable) and REST().path(variable)
+        if ((restArg && restArg.type !== 'Literal') || getNodeType(firstPathArg) !== 'Literal') {
+          return undefined;
+        }
+
+        const message = `Prefer REST('/foo/bar') over REST().path('foo', 'bar')`;
+
+        function fix(fixer) {
+          const fixes = [];
+          const restCallEnd = restCall.range[1];
+          if (restArg) {
+            // REST('/foo').path('bar')
+            // Join '/foo' and '/bar' and replace the rest arg
+            // REST('/foo/bar').path('bar');
+            fixes.push(fixer.replaceText(restArg, `'${restArg.value}/${firstPathArg.value}'`));
+          } else {
+            // REST().path('foo')
+            // Insert text between the parentheses
+            // REST('foo').path('foo');
+            fixes.push(fixer.insertTextAfterRange([restCallEnd - 1, restCallEnd - 1], `'/${firstPathArg.value}'`));
+          }
+
+          if (pathCall.arguments.length === 1) {
+            // REST('foo').path('foo');
+            // Remove the entire .path() call
+            // REST('foo');
+            fixes.push(fixer.removeRange([restCallEnd, pathCall.range[1]]));
+          } else {
+            /** @type {Literal} */
+            const secondPathArg = pathCall.arguments[1];
+            // Remove the first .path() call argument
+            fixes.push(fixer.removeRange([firstPathArg.range[0], secondPathArg.range[0]]));
+          }
+
+          return fixes;
+        }
+
+        context.report({ node, message, fix });
+      },
+    };
+  },
+  meta: {
+    fixable: 'code',
+    type: 'problem',
+    docs: {
+      description: 'Migrate from API.xyz() to REST(path)',
+      recommended: 'error',
+    },
+  },
+};

--- a/packages/eslint-plugin/test/api-deprecation.spec.js
+++ b/packages/eslint-plugin/test/api-deprecation.spec.js
@@ -1,0 +1,81 @@
+'use strict';
+
+const ruleTester = require('../utils/ruleTester');
+const rule = require('../rules/api-deprecation');
+
+ruleTester.run('api-deprecation', rule, {
+  valid: [
+    {
+      code: `REST('/path/to/endpoint').path(id).get();`,
+    },
+  ],
+
+  invalid: [
+    // Simple renames: .one(), .all(), .getList(), .withParams(), .remove()
+    {
+      code: `API.one('foo');`,
+      output: `API.path('foo');`,
+      errors: ['API.one() is deprecated.  Migrate from one() to path()'],
+    },
+    {
+      code: `API.all('foo');`,
+      output: `API.path('foo');`,
+      errors: ['API.all() is deprecated.  Migrate from all() to path()'],
+    },
+    {
+      code: `API.path('foo').getList();`,
+      output: `API.path('foo').get();`,
+      errors: ['API.getList() is deprecated.  Migrate from getList() to get()'],
+    },
+    {
+      code: `API.withParams('foo');`,
+      output: `API.params('foo');`,
+      errors: ['API.withParams() is deprecated.  Migrate from withParams() to params()'],
+    },
+    {
+      code: `API.remove('foo');`,
+      output: `API.delete('foo');`,
+      errors: ['API.remove() is deprecated.  Migrate from remove() to delete()'],
+    },
+    // .data(obj).post() -> .post(obj)
+    {
+      code: `API.path('foo').data({ key: 'val' }).post();`,
+      output: `API.path('foo').post({ key: 'val' });`,
+      errors: ['API.data() is deprecated.  Migrate from .data({}) to .put({}) or .post({})'],
+    },
+    // .data(obj).put() -> .put(obj)
+    {
+      code: `API.path('foo').data({ key: 'val' }).put();`,
+      output: `API.path('foo').put({ key: 'val' });`,
+      errors: ['API.data() is deprecated.  Migrate from .data({}) to .put({}) or .post({})'],
+    },
+    // .get() doesn't have queryparams args
+    {
+      code: `API.path('foo').get(queryParams);`,
+      output: `API.path('foo').params(queryParams).get();`,
+      errors: [
+        'Passing parameters to API.get() is deprecated.  Migrate from .get(queryparams) to .params(queryparams).get()',
+      ],
+    },
+    // .delete() doesn't have queryparams args
+    {
+      code: `API.path('foo').delete(queryParams);`,
+      output: `API.path('foo').params(queryParams).delete();`,
+      errors: [
+        'Passing parameters to API.delete() is deprecated.  Migrate from .delete(queryparams) to .params(queryparams).delete()',
+      ],
+    },
+    // .delete() doesn't have queryparams args
+    {
+      code: `API.path('foo').path(id);`,
+      output: `API.path('foo', id);`,
+      errors: ["Prefer API.path('foo', 'bar') over API.path('foo').path('bar')"],
+    },
+    // Migrate from API to REST()
+    {
+      code: `API.path('foo', id).withCache().get()`,
+      output: `REST().path('foo', id).withCache().get()`,
+      errors: ['API is deprecated, switch to REST()'],
+    },
+  ],
+});

--- a/packages/eslint-plugin/test/api-no-unused-chaining.spec.js
+++ b/packages/eslint-plugin/test/api-no-unused-chaining.spec.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const ruleTester = require('../utils/ruleTester');
+const rule = require('../rules/api-no-unused-chaining');
+const errorMessage = (text) => `Unused API.xyz() method chaining no longer works. Re-assign the result of: ${text}`;
+
+ruleTester.run('api-no-slashes', rule, {
+  valid: [
+    { code: `const fooBar = API.one('foo', 'bar');` },
+    { code: `let fooBar = API.one('foo', 'bar'); fooBar = fooBar.useCache()` },
+    { code: `const promise = API.one('foo', 'bar').all('baz').get();` },
+  ],
+
+  invalid: [
+    {
+      code: `API.one('foo/bad');`,
+      errors: [errorMessage(`API.one('foo/bad');`)],
+    },
+    {
+      code: `var foo = API.one('foo/bad'); foo.useCache(true);`,
+      errors: [errorMessage(`foo.useCache(true);`)],
+    },
+    {
+      code: `var foo = API.one('foo/bad'); foo.withParams({});`,
+      errors: [errorMessage(`foo.withParams({});`)],
+    },
+  ],
+});

--- a/packages/eslint-plugin/test/rest-prefer-static-strings-in-initializer.spec.js
+++ b/packages/eslint-plugin/test/rest-prefer-static-strings-in-initializer.spec.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const ruleTester = require('../utils/ruleTester');
+const rule = require('../rules/rest-prefer-static-strings-in-initializer');
+
+ruleTester.run('rest-prefer-static-strings-in-initializer', rule, {
+  valid: [
+    { code: "REST('/foo/bar').path(id).get()" },
+    { code: "REST('/foo/bar').path().get()" },
+    { code: "REST(id).path('foo').get()" },
+  ],
+  invalid: [
+    {
+      code: "REST().path('foo').path('bar')",
+      output: "REST('/foo').path('bar')",
+      errors: ["Prefer REST('/foo/bar') over REST().path('foo', 'bar')"],
+    },
+    {
+      code: "REST('foo').path('bar').get()",
+      output: "REST('foo/bar').get()",
+      errors: ["Prefer REST('/foo/bar') over REST().path('foo', 'bar')"],
+    },
+    {
+      // Process one path arg at a time
+      code: "REST('foo').path('bar', 'baz').get()",
+      output: "REST('foo/bar').path('baz').get()",
+      errors: ["Prefer REST('/foo/bar') over REST().path('foo', 'bar')"],
+    },
+    {
+      // Process one path arg at a time
+      code: "REST('foo').path('bar', 'baz').get()",
+      output: "REST('foo/bar').path('baz').get()",
+      errors: ["Prefer REST('/foo/bar') over REST().path('foo', 'bar')"],
+    },
+  ],
+});

--- a/packages/eslint-plugin/yarn.lock
+++ b/packages/eslint-plugin/yarn.lock
@@ -694,6 +694,19 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
+"@types/eslint@^7.2.5":
+  version "7.2.5"
+  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-7.2.5.tgz#92172ecf490c2fce4b076739693d75f30376d610"
+  integrity sha512-Dc6ar9x16BdaR3NSxSF7T4IjL9gxxViJq8RmFd+2UAyA+K6ck2W+gUwfgpG/y9TPyUuBL35109bbULpEynvltA==
+  dependencies:
+    "@types/estree" "*"
+    "@types/json-schema" "*"
+
+"@types/estree@*", "@types/estree@^0.0.45":
+  version "0.0.45"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.45.tgz#e9387572998e5ecdac221950dab3e8c3b16af884"
+  integrity sha512-jnqIUKDUqJbDIUxm0Uj7bnlMnRm1T/eZ9N+AVMqhPgzrba2GhGG5o/jCTwmdPK709nEZsGoMzXEDUjcXHa3W0g==
+
 "@types/graceful-fs@^4.1.2":
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.4.tgz#4ff9f641a7c6d1a3508ff88bc3141b152772e753"
@@ -719,6 +732,16 @@
   integrity sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==
   dependencies:
     "@types/istanbul-lib-report" "*"
+
+"@types/json-schema@*":
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.6.tgz#f4c7ec43e81b319a9815115031709f26987891f0"
+  integrity sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==
+
+"@types/lodash@^4.14.165":
+  version "4.14.165"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.165.tgz#74d55d947452e2de0742bad65270433b63a8c30f"
+  integrity sha512-tjSSOTHhI5mCHTy/OOXYIhi2Wt1qcbHmuXD1Ha7q70CgI/I71afO4XtLb/cVexki1oVYchpul/TOuu3Arcdxrg==
 
 "@types/node@*":
   version "14.14.7"


### PR DESCRIPTION
This PR introduces three new eslint rules:

- `api-deprecation`: Migrates from `API.one()` to `REST()`
- `api-no-unused-chaining`: Finds `var foo = API.one();  foo.withParams()` chained method calls with unused return values
- `rest-prefer-static-strings-in-initializer`: Migrates from `REST().path('foo', 'bar', id')` to `REST('/foo/bar').path(id)`